### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-01-oq-02): isoperimetric ratio of the n-ball — equality case & scale invariance

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -139,6 +139,7 @@ import Proofs.AreaOfCircleOQ01OQ02OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ02
+import Proofs.AreaOfCircleOQ01OQ02OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ03
 import Proofs.AreaOfCircleOQ01OQ02OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ02OQ01

--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ02.lean
@@ -1,0 +1,216 @@
+/-
+  The Isoperimetric Ratio of the n-Ball
+  Open Question: area-of-circle-oq-01-oq-02-oq-01-oq-02
+
+  This entry formalizes the second open question of the parent
+  "N-Dimensional Volume from Surface Area Integration":
+
+    "Can the isoperimetric inequality be formalized using these
+     volume/surface area definitions?"
+
+  The classical isoperimetric inequality in dimension n states that for any
+  reasonable body with surface area S and volume V,
+
+        Sⁿ  ≥  (nⁿ · ω_n) · V^(n-1),
+
+  with equality **if and only if** the body is a ball. Here
+  ω_n = π^(n/2)/Γ(n/2+1) is the unit-ball volume and the optimal constant
+  nⁿ·ω_n is the *isoperimetric constant* of n-dimensional space.
+
+  The "≥, with equality iff ball" direction is a deep theorem of geometric
+  measure theory (Brunn–Minkowski / spherical symmetrization) and is well
+  beyond the scope of these elementary monomial definitions. What IS fully
+  formalizable here — and what this file proves with 0 axioms / 0 sorries —
+  is the *equality case* and the *scale invariance* that make the constant
+  meaningful:
+
+    • The n-ball SATURATES the bound:  S_n(r)ⁿ = (nⁿ·ω_n) · V_n(r)^(n-1)
+      for every radius r (the isoperimetric deficit of a ball is 0).
+    • The dimensionless isoperimetric quotient  Q_n(r) = S_n(r)ⁿ / V_n(r)^(n-1)
+      is independent of the radius r and equals the constant nⁿ·ω_n.
+    • The low-dimensional constants recover the textbook inequalities:
+        n=2:  Q₂ = 4π   (the planar  L² ≥ 4π·A),
+        n=3:  Q₃ = 36π  (the spatial A³ ≥ 36π·V²).
+
+  Definitions match the parent file AreaOfCircleOQ01OQ02OQ01.lean and are
+  reproduced here so the file is self-contained:
+      V_n(r) = ω_n · r^n            (n-ball volume)
+      S_n(r) = n · ω_n · r^(n-1)    ((n-1)-sphere surface area)
+
+  Chain: area-of-circle → OQ01 (C = dA/dr) → OQ02 (A = ∫C)
+         → OQ01 (V_n = ∫S_n) → OQ02 (isoperimetric ratio of the n-ball)
+-/
+
+import Mathlib
+
+open Real
+
+noncomputable section
+
+namespace NBallIsoperimetric
+
+/- ## Part I: Volume, Surface Area, and the Isoperimetric Constant -/
+
+/-- The unit ball volume ω_n = π^(n/2) / Γ(n/2 + 1).
+    Self-contained; matches AreaOfCircleOQ01OQ02OQ01.unitBallVolume. -/
+def unitBallVolume (n : ℕ) : ℝ :=
+  π ^ ((n : ℝ) / 2) / Gamma ((n : ℝ) / 2 + 1)
+
+/-- The n-ball volume function V_n(r) = ω_n · r^n. -/
+def nBallVol (n : ℕ) (r : ℝ) : ℝ :=
+  unitBallVolume n * r ^ n
+
+/-- The (n-1)-sphere surface area function S_n(r) = n · ω_n · r^(n-1). -/
+def nSphereArea (n : ℕ) (r : ℝ) : ℝ :=
+  n * unitBallVolume n * r ^ (n - 1)
+
+/-- The isoperimetric constant of n-dimensional space: c_n = nⁿ · ω_n.
+    This is the optimal constant in the inequality Sⁿ ≥ c_n · V^(n-1). -/
+def isoperimetricConst (n : ℕ) : ℝ :=
+  (n : ℝ) ^ n * unitBallVolume n
+
+/-- The dimensionless isoperimetric quotient Q_n(r) = S_n(r)ⁿ / V_n(r)^(n-1). -/
+def isoperimetricQuotient (n : ℕ) (r : ℝ) : ℝ :=
+  nSphereArea n r ^ n / nBallVol n r ^ (n - 1)
+
+/- ## Part II: Positivity -/
+
+/-- ω_n > 0 for all n (positive numerator, positive Gamma value). -/
+theorem unitBallVolume_pos (n : ℕ) : 0 < unitBallVolume n := by
+  unfold unitBallVolume
+  apply div_pos
+  · exact rpow_pos_of_pos pi_pos _
+  · exact Gamma_pos_of_pos (by positivity)
+
+/-- The isoperimetric constant is positive (for n ≥ 1). -/
+theorem isoperimetricConst_pos (n : ℕ) (hn : 1 ≤ n) : 0 < isoperimetricConst n := by
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast (show 0 < n from hn)
+  exact mul_pos (pow_pos hnpos n) (unitBallVolume_pos n)
+
+/-- V_n(r) > 0 for r > 0. -/
+theorem nBallVol_pos (n : ℕ) {r : ℝ} (hr : 0 < r) : 0 < nBallVol n r :=
+  mul_pos (unitBallVolume_pos n) (pow_pos hr n)
+
+/- ## Part III: The n-Ball Saturates the Isoperimetric Inequality -/
+
+/-- **KEY EQUALITY CASE.** The n-ball of radius r achieves equality in the
+    isoperimetric inequality:  S_n(r)ⁿ = (nⁿ · ω_n) · V_n(r)^(n-1).
+
+    The powers of r cancel exactly: S_n(r)ⁿ carries r^((n-1)·n) and
+    V_n(r)^(n-1) carries r^(n·(n-1)). This holds for *every* radius — the
+    defining feature of the optimal isoperimetric constant. -/
+theorem ball_saturates_isoperimetric (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :
+    nSphereArea n r ^ n = isoperimetricConst n * nBallVol n r ^ (n - 1) := by
+  unfold nSphereArea isoperimetricConst nBallVol
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
+  simp only [Nat.succ_sub_one, Nat.succ_eq_add_one]
+  ring
+
+/-- The isoperimetric deficit of an n-ball is identically zero. -/
+theorem ball_isoperimetric_deficit_zero (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :
+    nSphereArea n r ^ n - isoperimetricConst n * nBallVol n r ^ (n - 1) = 0 := by
+  rw [ball_saturates_isoperimetric n hn r]; ring
+
+/-- The n-ball meets the isoperimetric lower bound (trivially, with equality). -/
+theorem ball_meets_isoperimetric_bound (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :
+    isoperimetricConst n * nBallVol n r ^ (n - 1) ≤ nSphereArea n r ^ n :=
+  le_of_eq (ball_saturates_isoperimetric n hn r).symm
+
+/- ## Part IV: Scale Invariance of the Isoperimetric Quotient -/
+
+/-- **SCALE INVARIANCE.** For r > 0 the isoperimetric quotient
+    Q_n(r) = S_n(r)ⁿ / V_n(r)^(n-1) equals the constant nⁿ · ω_n,
+    independent of the radius r. -/
+theorem isoperimetricQuotient_eq_const (n : ℕ) (hn : 1 ≤ n) {r : ℝ} (hr : 0 < r) :
+    isoperimetricQuotient n r = isoperimetricConst n := by
+  unfold isoperimetricQuotient
+  have hV : nBallVol n r ^ (n - 1) ≠ 0 := (pow_pos (nBallVol_pos n hr) _).ne'
+  rw [div_eq_iff hV]
+  exact ball_saturates_isoperimetric n hn r
+
+/-- The isoperimetric quotient takes the same value at any two positive radii:
+    Q_n(r₁) = Q_n(r₂). The ratio is genuinely a dimensionless invariant. -/
+theorem isoperimetricQuotient_scale_invariant (n : ℕ) (hn : 1 ≤ n)
+    {r₁ r₂ : ℝ} (h₁ : 0 < r₁) (h₂ : 0 < r₂) :
+    isoperimetricQuotient n r₁ = isoperimetricQuotient n r₂ := by
+  rw [isoperimetricQuotient_eq_const n hn h₁, isoperimetricQuotient_eq_const n hn h₂]
+
+/- ## Part V: Low-Dimensional Constants — Recovering the Classical Inequalities -/
+
+/-- ω_1 = 2 (the interval [-1,1]). -/
+theorem unitBallVolume_one : unitBallVolume 1 = 2 := by
+  unfold unitBallVolume
+  simp only [Nat.cast_one]
+  rw [show (1 : ℝ)/2 + 1 = 3/2 from by ring]
+  have h32 : Gamma (3/2 : ℝ) = √π / 2 := by
+    have h := Gamma_add_one (show (1/2 : ℝ) ≠ 0 from by norm_num)
+    rw [show (1 : ℝ)/2 + 1 = 3/2 from by ring] at h
+    rw [h, Gamma_one_half_eq]; ring
+  rw [h32, ← Real.sqrt_eq_rpow]
+  have h : (0 : ℝ) < √π := Real.sqrt_pos.mpr Real.pi_pos
+  field_simp [h.ne']
+
+/-- ω_2 = π (area of the unit disk). -/
+theorem unitBallVolume_two : unitBallVolume 2 = π := by
+  unfold unitBallVolume
+  simp only [Nat.cast_ofNat]
+  rw [show (2 : ℝ)/2 + 1 = 2 from by ring, show (2 : ℝ)/2 = 1 from by ring]
+  rw [rpow_one, Gamma_two]
+  simp
+
+/-- ω_3 = 4π/3 (volume of the unit 3-ball). -/
+theorem unitBallVolume_three : unitBallVolume 3 = 4 * π / 3 := by
+  unfold unitBallVolume
+  simp only [Nat.cast_ofNat]
+  have h32 : Gamma (3/2 : ℝ) = √π / 2 := by
+    have h := Gamma_add_one (show (1/2 : ℝ) ≠ 0 from by norm_num)
+    rw [show (1 : ℝ)/2 + 1 = 3/2 from by ring] at h
+    rw [h, Gamma_one_half_eq]; ring
+  have h52 : Gamma (5/2 : ℝ) = 3 * √π / 4 := by
+    have h := Gamma_add_one (show (3/2 : ℝ) ≠ 0 from by norm_num)
+    rw [show (3 : ℝ)/2 + 1 = 5/2 from by ring] at h
+    rw [h, h32]; ring
+  rw [show (3 : ℝ)/2 + 1 = 5/2 from by ring, h52]
+  rw [show (3 : ℝ)/2 = (1 : ℝ) + 1/2 from by ring]
+  rw [rpow_add pi_pos, rpow_one, ← Real.sqrt_eq_rpow]
+  have hpi : (0 : ℝ) < √π := Real.sqrt_pos.mpr Real.pi_pos
+  field_simp [hpi.ne']
+
+/-- The 1-dimensional isoperimetric constant c₁ = 2. -/
+theorem isoperimetricConst_one : isoperimetricConst 1 = 2 := by
+  unfold isoperimetricConst
+  rw [unitBallVolume_one]; norm_num
+
+/-- The **planar** isoperimetric constant c₂ = 4π.
+    This is the optimal constant in the classical inequality L² ≥ 4π·A
+    relating the length L of a closed curve to the enclosed area A. -/
+theorem isoperimetricConst_two : isoperimetricConst 2 = 4 * π := by
+  unfold isoperimetricConst
+  rw [unitBallVolume_two]; norm_num
+
+/-- The **spatial** isoperimetric constant c₃ = 36π.
+    This is the optimal constant in the classical inequality A³ ≥ 36π·V²
+    relating the surface area A of a body to its volume V. -/
+theorem isoperimetricConst_three : isoperimetricConst 3 = 36 * π := by
+  unfold isoperimetricConst
+  rw [unitBallVolume_three]; ring
+
+/- ## Part VI: Worked Equalities in Low Dimensions -/
+
+/-- Planar equality case: for the disk of radius r, (2πr)² = 4π·(πr²),
+    i.e. circumference² = 4π · area. -/
+theorem disk_saturates_planar (r : ℝ) :
+    nSphereArea 2 r ^ 2 = 4 * π * nBallVol 2 r := by
+  have h := ball_saturates_isoperimetric 2 (by norm_num) r
+  rw [isoperimetricConst_two] at h
+  simpa using h
+
+/-- Spatial equality case: for the ball of radius r, (4πr²)³ = 36π·(4πr³/3)²,
+    i.e. surface area³ = 36π · volume². -/
+theorem ball_saturates_spatial (r : ℝ) :
+    nSphereArea 3 r ^ 3 = 36 * π * nBallVol 3 r ^ 2 := by
+  have h := ball_saturates_isoperimetric 3 (by norm_num) r
+  rw [isoperimetricConst_three] at h
+  simpa using h
+
+end NBallIsoperimetric

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Open Question: Formalizing the Isoperimetric Inequality",
+    "content": "This proof addresses the parent's second open question. The full isoperimetric inequality $S^n \\ge (n^n\\omega_n)V^{n-1}$ (equality iff ball) is a deep theorem of geometric measure theory. What is fully formalizable from the monomial definitions is the *equality case* (the ball saturates the bound) and the *scale invariance* of the dimensionless isoperimetric quotient — together these pin the optimal constant $n^n\\omega_n$.",
+    "mathContext": "The optimal constant in $S^n \\ge c_n V^{n-1}$ is $c_n = n^n\\omega_n$, attained exactly on balls. Specializes to $4\\pi$ in the plane ($L^2 \\ge 4\\pi A$) and $36\\pi$ in space ($A^3 \\ge 36\\pi V^2$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "isoperimetric inequality",
+      "n-ball volume",
+      "surface area",
+      "geometric measure theory"
+    ],
+    "prerequisites": [
+      "Gamma function theory",
+      "n-dimensional geometry"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 74
+    },
+    "type": "definition",
+    "title": "Volume, Surface Area, Isoperimetric Constant and Quotient",
+    "content": "Defines $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ (unit ball volume), $V_n(r) = \\omega_n r^n$, $S_n(r) = n\\omega_n r^{n-1}$, the isoperimetric constant $c_n = n^n\\omega_n$, and the dimensionless quotient $Q_n(r) = S_n(r)^n/V_n(r)^{n-1}$. Definitions match the parent file for self-containment.",
+    "mathContext": "$Q_n(r)$ is dimensionless: scaling $r \\mapsto \\lambda r$ multiplies $S_n^n$ and $V_n^{n-1}$ by the same power $\\lambda^{n(n-1)}$, so $Q_n$ is radius-independent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "unit ball volume",
+      "isoperimetric constant",
+      "dimensionless quotient"
+    ]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 79,
+      "endLine": 92
+    },
+    "type": "technique",
+    "title": "Positivity of ω_n, the Constant, and V_n(r)",
+    "content": "Proves $\\omega_n > 0$ (positive numerator $\\pi^{n/2}$ over positive $\\Gamma(n/2+1)$), $c_n > 0$ for $n \\ge 1$, and $V_n(r) > 0$ for $r > 0$. The last is what lets us divide by $V_n(r)^{n-1}$ to form the quotient.",
+    "mathContext": "$\\Gamma(x) > 0$ for $x > 0$ via `Gamma_pos_of_pos`; $\\pi^{n/2} > 0$ via `rpow_pos_of_pos`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity",
+      "Gamma function"
+    ]
+  },
+  {
+    "id": "ann-saturation",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 102,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Main Theorem: The n-Ball Saturates the Isoperimetric Bound",
+    "content": "Proves $S_n(r)^n = (n^n\\omega_n)\\cdot V_n(r)^{n-1}$ for every radius $r$. The proof substitutes $n = m+1$ to clear the natural-number subtraction $n-1$, after which both sides are monomials $n^n\\omega_n^n r^{n(n-1)}$ and close by `ring`.",
+    "mathContext": "$S_n(r)^n = (n\\omega_n r^{n-1})^n = n^n\\omega_n^n r^{n(n-1)}$; $(n^n\\omega_n)V_n(r)^{n-1} = n^n\\omega_n\\cdot\\omega_n^{n-1}r^{n(n-1)}$. The powers of $r$ are identical.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "isoperimetric equality",
+      "ball saturation",
+      "monomial identity"
+    ]
+  },
+  {
+    "id": "ann-deficit-zero",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 110,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "Isoperimetric Deficit of a Ball is Zero",
+    "content": "Immediate corollaries of saturation: the isoperimetric deficit $S_n(r)^n - c_n V_n(r)^{n-1}$ is identically $0$, and the ball meets the lower bound $c_n V_n(r)^{n-1} \\le S_n(r)^n$ with equality.",
+    "mathContext": "The deficit measures how far a body is from being a ball; for the ball itself it vanishes.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "isoperimetric deficit",
+      "extremal body"
+    ]
+  },
+  {
+    "id": "ann-scale-invariance",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 124,
+      "endLine": 136
+    },
+    "type": "theorem",
+    "title": "Scale Invariance of the Isoperimetric Quotient",
+    "content": "Proves $Q_n(r) = n^n\\omega_n$ for $r > 0$ (via `div_eq_iff` and the saturation equality), hence $Q_n(r_1) = Q_n(r_2)$ for any two positive radii. The quotient is a genuine dimensionless invariant of the ball.",
+    "mathContext": "Because $S_n^n$ and $V_n^{n-1}$ scale identically in $r$, the quotient is constant — the structural reason the isoperimetric problem is scale-free.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "scale invariance",
+      "dimensional analysis",
+      "isoperimetric constant"
+    ]
+  },
+  {
+    "id": "ann-low-dim-volumes",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 141,
+      "endLine": 178
+    },
+    "type": "technique",
+    "title": "Evaluating ω_1, ω_2, ω_3 via the Gamma Function",
+    "content": "Computes $\\omega_1 = 2$, $\\omega_2 = \\pi$, $\\omega_3 = 4\\pi/3$ from the Gamma recurrence $\\Gamma(z+1) = z\\Gamma(z)$ and $\\Gamma(1/2) = \\sqrt{\\pi}$. These feed the low-dimensional isoperimetric constants.",
+    "mathContext": "$\\Gamma(3/2) = \\sqrt{\\pi}/2$, $\\Gamma(5/2) = 3\\sqrt{\\pi}/4$, $\\Gamma(2) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gamma function",
+      "half-integer values"
+    ]
+  },
+  {
+    "id": "ann-classical-constants",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 180,
+      "endLine": 196
+    },
+    "type": "theorem",
+    "title": "Recovering the Classical Constants 4π and 36π",
+    "content": "Proves $c_1 = 2$, $c_2 = 4\\pi$, $c_3 = 36\\pi$. The values $4\\pi$ and $36\\pi$ are exactly the optimal constants in the textbook planar inequality $L^2 \\ge 4\\pi A$ and spatial inequality $A^3 \\ge 36\\pi V^2$ — a strong correctness check on the general formula $c_n = n^n\\omega_n$.",
+    "mathContext": "$c_2 = 2^2\\cdot\\pi = 4\\pi$; $c_3 = 3^3\\cdot(4\\pi/3) = 36\\pi$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "planar isoperimetric inequality",
+      "spatial isoperimetric inequality",
+      "optimal constant"
+    ]
+  },
+  {
+    "id": "ann-worked-equalities",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+    "range": {
+      "startLine": 202,
+      "endLine": 216
+    },
+    "type": "theorem",
+    "title": "Worked Equality Cases: Disk and Ball",
+    "content": "Specializes the saturation identity to dimensions 2 and 3: the disk satisfies $(2\\pi r)^2 = 4\\pi(\\pi r^2)$ and the ball satisfies $(4\\pi r^2)^3 = 36\\pi(4\\pi r^3/3)^2$ — the classical isoperimetric equalities for circle and sphere.",
+    "mathContext": "These are circumference² = 4π·area and surface area³ = 36π·volume² for the extremal bodies.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "circle",
+      "sphere",
+      "equality case"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+  "title": "The Isoperimetric Ratio of the n-Ball",
+  "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+  "description": "Formalizes the equality case and scale invariance of the n-dimensional isoperimetric inequality: the n-ball saturates Sⁿ = (nⁿ·ω_n)·V^(n-1), so its dimensionless isoperimetric quotient S_n(r)ⁿ/V_n(r)^(n-1) equals the optimal constant nⁿ·ω_n independent of radius — recovering the classical planar (4π) and spatial (36π) constants.",
+  "meta": {
+    "author": "Classical (isoperimetric inequality)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
+    "date": "1902",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ02.lean",
+    "tags": [
+      "geometry",
+      "analysis",
+      "isoperimetric",
+      "n-dimensional-geometry",
+      "gamma-function",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Gamma_add_one",
+        "description": "Γ(z+1) = z·Γ(z), used to evaluate ω_1, ω_2, ω_3 and hence the low-dimensional isoperimetric constants",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Gamma_one_half_eq",
+        "description": "Γ(1/2) = √π, the base value for half-integer Gamma evaluation",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Gamma_pos_of_pos",
+        "description": "Γ(x) > 0 for x > 0, giving positivity of ω_n and the isoperimetric constant",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "rpow_pos_of_pos",
+        "description": "x^y > 0 for x > 0, used in positivity of ω_n",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "div_eq_iff",
+        "description": "a/b = c ↔ a = c·b for b ≠ 0, converts the saturation equality into the quotient value",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Identified the formalizable content of the n-dimensional isoperimetric inequality given monomial volume/surface definitions: the equality case (ball saturation) and scale invariance, while honestly flagging the optimality direction as deep geometric measure theory",
+      "Main equality: the n-ball saturates the isoperimetric inequality S_n(r)ⁿ = (nⁿ·ω_n)·V_n(r)^(n-1) for every radius r, via exact cancellation of the r-powers r^(n(n-1))",
+      "Scale invariance: the dimensionless isoperimetric quotient Q_n(r) = S_n(r)ⁿ/V_n(r)^(n-1) is independent of r and equals the optimal constant nⁿ·ω_n",
+      "Recovered the textbook isoperimetric constants c₂ = 4π (planar L² ≥ 4πA) and c₃ = 36π (spatial A³ ≥ 36πV²) as low-dimensional specializations",
+      "Worked equality cases: disk (2πr)² = 4π·(πr²) and ball (4πr²)³ = 36π·(4πr³/3)²"
+    ],
+    "axiomCount": 0,
+    "lineCount": 216,
+    "assumptions": "None for the equality case and scale invariance — fully verified from Mathlib with 0 axioms and 0 sorries. The inequality direction (that the ball is the unique minimizer over all bodies of fixed volume) is NOT formalized here; it is a deep theorem of geometric measure theory beyond the scope of these elementary monomial definitions.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 16,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "The isoperimetric problem — among all closed curves of fixed length, which encloses the greatest area? — is among the oldest in mathematics, encoded in the legend of Queen Dido founding Carthage. The planar inequality $L^2 \\ge 4\\pi A$, with equality only for the circle, was given its first rigorous proofs by Weierstrass, Schwarz, and Hurwitz (1902, via Fourier series) in the 19th and early 20th centuries. The n-dimensional generalization $S^n \\ge n^n \\omega_n V^{n-1}$, with the optimal constant $n^n \\omega_n$ attained uniquely by the ball, is a cornerstone of geometric measure theory, provable via the Brunn–Minkowski inequality or spherical symmetrization. The constant $n^n\\omega_n$ specializes to $4\\pi$ in the plane and $36\\pi$ in space.",
+    "problemStatement": "Can the isoperimetric inequality be formalized using the n-ball volume $V_n(r) = \\omega_n r^n$ and surface area $S_n(r) = n\\omega_n r^{n-1}$ definitions?",
+    "text": "Formalizes the equality case and scale invariance of the n-dimensional isoperimetric inequality for the n-ball.",
+    "proofStrategy": "Write $n = m+1$ to remove natural-number subtraction in the exponent $n-1$, then both sides of the saturation identity become $\\pi$-power-free monomials in $\\omega_n$ and $r$: $S_n(r)^n = n^n\\omega_n^n r^{n(n-1)}$ and $(n^n\\omega_n)V_n(r)^{n-1} = n^n\\omega_n^n r^{n(n-1)}$, closed by `ring`. The quotient identity follows from `div_eq_iff` with $V_n(r)^{n-1} \\ne 0$ (from $\\omega_n > 0$ and $r > 0$). Low-dimensional constants reduce to Gamma function evaluations $\\omega_1 = 2$, $\\omega_2 = \\pi$, $\\omega_3 = 4\\pi/3$.",
+    "keyInsights": [
+      "The optimal isoperimetric constant $n^n\\omega_n$ is exactly the value of the dimensionless quotient $S^n/V^{n-1}$ on a ball — the ball is where equality holds, so it pins the constant",
+      "Scale invariance is structural: $S_n(r)^n$ and $V_n(r)^{n-1}$ both carry the factor $r^{n(n-1)}$, which cancels, leaving a radius-independent constant. This is why the isoperimetric problem is dimensionless",
+      "The low-dimensional values $c_2 = 4\\pi$ and $c_3 = 36\\pi$ recover the classical planar inequality $L^2 \\ge 4\\pi A$ and spatial inequality $A^3 \\ge 36\\pi V^2$ — a strong correctness check on the general formula",
+      "The honest scope: equality (ball saturation) and scale invariance are elementary algebra over the monomial definitions; the inequality direction (optimality of the ball) genuinely requires geometric measure theory and is left as the deep open part",
+      "Avoiding natural-number subtraction by substituting $n = m+1$ before `ring` is the key tactic for monomial identities whose exponents involve $n-1$"
+    ],
+    "prerequisites": [
+      "Gamma function theory (functional equation)",
+      "n-dimensional ball volume and surface area formulas",
+      "Real analysis (rpow, field arithmetic)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble-defs",
+      "title": "Definitions: Volume, Surface Area, Isoperimetric Constant and Quotient",
+      "startLine": 1,
+      "endLine": 74,
+      "summary": "Module docstring framing the second open question. Defines ω_n = π^(n/2)/Γ(n/2+1), V_n(r) = ω_n·r^n, S_n(r) = n·ω_n·r^(n-1), the isoperimetric constant c_n = nⁿ·ω_n, and the dimensionless quotient Q_n(r) = S_n(r)ⁿ/V_n(r)^(n-1)."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity",
+      "startLine": 76,
+      "endLine": 92,
+      "summary": "Proves ω_n > 0, the isoperimetric constant c_n > 0 (for n ≥ 1), and V_n(r) > 0 for r > 0 — the nonvanishing facts needed to divide by V_n(r)^(n-1).",
+      "mathContext": "$\\omega_n > 0$ since $\\pi^{n/2} > 0$ and $\\Gamma(n/2+1) > 0$; $c_n = n^n\\omega_n > 0$; $V_n(r) = \\omega_n r^n > 0$."
+    },
+    {
+      "id": "saturation",
+      "title": "The n-Ball Saturates the Isoperimetric Inequality (Main Theorem)",
+      "startLine": 94,
+      "endLine": 117,
+      "summary": "**MAIN THEOREM** `ball_saturates_isoperimetric`: S_n(r)ⁿ = (nⁿ·ω_n)·V_n(r)^(n-1) for all r. Corollaries: the isoperimetric deficit of a ball is identically zero, and the ball meets the lower bound with equality.",
+      "mathContext": "$S_n(r)^n = (n\\omega_n r^{n-1})^n = n^n\\omega_n^n r^{n(n-1)}$ and $(n^n\\omega_n)V_n(r)^{n-1} = n^n\\omega_n\\cdot\\omega_n^{n-1}r^{n(n-1)}$ coincide."
+    },
+    {
+      "id": "scale-invariance",
+      "title": "Scale Invariance of the Isoperimetric Quotient",
+      "startLine": 119,
+      "endLine": 136,
+      "summary": "`isoperimetricQuotient_eq_const`: for r > 0, Q_n(r) = nⁿ·ω_n, independent of r. `isoperimetricQuotient_scale_invariant`: Q_n(r₁) = Q_n(r₂) for any two positive radii.",
+      "mathContext": "The factor $r^{n(n-1)}$ cancels between numerator and denominator, so $Q_n(r)$ is a dimensionless invariant of the ball, equal to the optimal constant."
+    },
+    {
+      "id": "low-dim-constants",
+      "title": "Low-Dimensional Constants: 4π and 36π",
+      "startLine": 138,
+      "endLine": 196,
+      "summary": "Evaluates ω_1 = 2, ω_2 = π, ω_3 = 4π/3 via the Gamma function, then the isoperimetric constants c₁ = 2, c₂ = 4π (planar), c₃ = 36π (spatial).",
+      "mathContext": "$c_2 = 2^2\\cdot\\pi = 4\\pi$ is the constant in $L^2 \\ge 4\\pi A$; $c_3 = 3^3\\cdot(4\\pi/3) = 36\\pi$ is the constant in $A^3 \\ge 36\\pi V^2$."
+    },
+    {
+      "id": "worked-equalities",
+      "title": "Worked Equality Cases",
+      "startLine": 198,
+      "endLine": 216,
+      "summary": "Specializes the saturation identity: the disk satisfies (2πr)² = 4π·(πr²) and the ball satisfies (4πr²)³ = 36π·(4πr³/3)².",
+      "mathContext": "These are the classical isoperimetric equalities for the circle and sphere written in the monomial form $S^n = c_n V^{n-1}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified formalization (0 axioms, 0 sorries) of the equality case and scale invariance of the n-dimensional isoperimetric inequality. The n-ball saturates Sⁿ = (nⁿ·ω_n)·V^(n-1), and its dimensionless isoperimetric quotient equals the optimal constant nⁿ·ω_n independent of radius, recovering the classical 4π (planar) and 36π (spatial) constants.",
+    "implications": "This pins the optimal isoperimetric constant nⁿ·ω_n as the value of the dimensionless quotient on the extremal body. It answers the parent's second open question to the extent the elementary monomial definitions allow: the equality structure and scale invariance are fully formalized.",
+    "openQuestions": [
+      "Can the inequality direction Sⁿ ≥ nⁿ·ω_n·V^(n-1) be formalized for general bodies (not just balls)? This requires the Brunn–Minkowski inequality or spherical symmetrization from geometric measure theory.",
+      "Can uniqueness of the ball as the equality case be characterized within Mathlib's measure-theoretic framework?",
+      "Does the constant nⁿ·ω_n → 0 super-exponentially, mirroring the thin-shell behavior of ω_n?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Parent OQ defining unitBallVolume, nBallVol, nSphereArea and proving V_n(r) = ∫₀ʳ S_n(ρ) dρ; this entry answers its second open question (isoperimetric inequality)"
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling answering the first open question: the recurrence ω_{n+2} = (2π/(n+2))·ω_n"
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling answering the third open question: the thin-shell limit ω_n → 0 as n → ∞"
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "ancestor",
+      "description": "Root proof: A = πr² for the circle, the starting point of this OQ chain"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "NBallIsoperimetric",
+    "lineCount": 216,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 5,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent *N-Dimensional Volume from Surface Area Integration* (`area-of-circle-oq-01-oq-02-oq-01`):

> *"Can the isoperimetric inequality be formalized using these volume/surface area definitions?"*

The full inequality $S^n \ge (n^n\omega_n)V^{n-1}$ (with equality **iff** the body is a ball) is a deep theorem of geometric measure theory — beyond elementary monomial definitions, and honestly flagged as out of scope. What **is** fully formalizable, and proved here with **0 axioms / 0 sorries**, is the *equality case* and *scale invariance* that pin the optimal constant.

## Main results

- **`ball_saturates_isoperimetric`** — the n-ball achieves equality for every radius:
  $$S_n(r)^n = (n^n\omega_n)\cdot V_n(r)^{n-1}.$$
  Proof: substitute $n = m+1$ to clear ℕ-subtraction, then `ring`; the powers $r^{n(n-1)}$ cancel exactly.
- **`isoperimetricQuotient_eq_const` / `_scale_invariant`** — the dimensionless quotient $Q_n(r) = S_n(r)^n/V_n(r)^{n-1}$ is radius-independent and equals the optimal constant $n^n\omega_n$.
- **`isoperimetricConst_two = 4π`, `isoperimetricConst_three = 36π`** — recovering the classical planar ($L^2 \ge 4\pi A$) and spatial ($A^3 \ge 36\pi V^2$) constants as a correctness check.
- Worked equality cases for disk $(2\pi r)^2 = 4\pi(\pi r^2)$ and ball $(4\pi r^2)^3 = 36\pi(4\pi r^3/3)^2$.

## Verification

- 16 theorems / 5 defs, 216 lines, self-contained (`import Mathlib` only).
- Builds clean under Lean 4.26.0 via `docker-build.sh`.
- **0-axiom**, no `native_decide`: `#print axioms` of the main theorems lists only `propext`, `Classical.choice`, `Quot.sound`.

Sibling entries already cover the parent's other two open questions: the recurrence $\omega_{n+2}=(2\pi/(n+2))\omega_n$ (`-oq-01`) and the thin-shell limit $\omega_n\to0$ (`-oq-03`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)