### PR TITLE
research(pythagorean-theorem-oq-03-oq-02): relativistic velocity addition from rapidity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3187,6 +3187,7 @@ import Proofs.PuiseuxTheoremOQ02
 import Proofs.PvsNP
 import Proofs.PythagoreanTheorem
 import Proofs.PythagoreanTheoremOQ03
+import Proofs.PythagoreanTheoremOQ03OQ02
 import Proofs.PythagoreanTheoremOQ05
 import Proofs.PythagoreanTriples
 import Proofs.PythagoreanTriplesOQ01

--- a/proofs/Proofs/PythagoreanTheoremOQ03OQ02.lean
+++ b/proofs/Proofs/PythagoreanTheoremOQ03OQ02.lean
@@ -1,0 +1,190 @@
+/-
+# Relativistic Velocity Addition from Rapidity (Pythagorean OQ-03-OQ-02)
+
+The parent gallery entry **pythagorean-theorem-oq-03** ("Pythagorean Theorem in
+Non-Euclidean Geometry") develops the Minkowski branch τ² = t² − x²: Lorentz
+boosts parameterized by rapidity φ (with β = tanh φ), interval invariance, and
+the *additivity of rapidity* under composition of boosts (φ₁, φ₂ ↦ φ₁ + φ₂).
+Its open questions explicitly ask to
+
+  > formalize the rapidity–velocity relation β = tanh(φ) and derive relativistic
+  > velocity addition.
+
+This file answers that. The velocity associated to rapidity φ is β = tanh φ, and
+the additivity of rapidity becomes the **relativistic velocity-addition law**
+
+    β = (β₁ + β₂) / (1 + β₁ β₂),   i.e.   tanh(φ₁ + φ₂) = velAdd (tanh φ₁) (tanh φ₂).
+
+We prove, with zero axioms (imports Mathlib only):
+
+  * `tanh_lt_one` / `neg_one_lt_tanh` / `abs_tanh_lt_one` — every rapidity gives a
+    strictly subluminal speed |β| < 1;
+  * `tanh_add` — rapidity additivity *is* the velocity-addition formula;
+  * `abs_velAdd_lt_one` — **closure**: composing two subluminal velocities stays
+    subluminal (c is never exceeded), proved algebraically via
+    1 ∓ velAdd = (1 ∓ β₁)(1 ∓ β₂)/(1 + β₁ β₂);
+  * `velAdd_one` — **light-speed invariance**: adding any velocity to c gives c;
+  * `velAdd_sub_sum` — the **Galilean limit**: the correction to β₁ + β₂ is the
+    second-order term −(β₁+β₂)β₁β₂/(1+β₁β₂);
+  * `cosh_sq_eq_inv_one_sub_tanh_sq` — the **Lorentz factor** γ = cosh φ obeys
+    γ² = 1/(1 − β²);
+  * concrete checks: ½c ⊕ ½c = ⅘ c, and ⅗c ⊕ c = c.
+
+Self-contained: the rapidity/velocity facts are derived directly from Mathlib's
+`Real.sinh`/`Real.cosh`/`Real.tanh`, so nothing is imported from the parent.
+-/
+import Mathlib
+
+open Real
+
+namespace PythagoreanTheoremOQ03OQ02
+
+/- ## Speeds from rapidities are subluminal: |tanh φ| < 1 -/
+
+/-- A rapidity never reaches the speed of light from above: `tanh φ < 1`.
+Equivalent to `sinh φ < cosh φ`, i.e. `0 < cosh φ − sinh φ = exp(−φ)`. -/
+theorem tanh_lt_one (x : ℝ) : Real.tanh x < 1 := by
+  rw [Real.tanh_eq_sinh_div_cosh, div_lt_one (Real.cosh_pos x)]
+  have h := Real.cosh_sub_sinh x
+  have := Real.exp_pos (-x)
+  linarith
+
+/-- A rapidity never reaches the speed of light from below: `-1 < tanh φ`.
+Equivalent to `-cosh φ < sinh φ`, i.e. `0 < cosh φ + sinh φ = exp(φ)`. -/
+theorem neg_one_lt_tanh (x : ℝ) : -1 < Real.tanh x := by
+  rw [Real.tanh_eq_sinh_div_cosh, lt_div_iff₀ (Real.cosh_pos x)]
+  have h : Real.cosh x + Real.sinh x = Real.exp x := by
+    have := Real.cosh_sub_sinh (-x)
+    rw [Real.cosh_neg, Real.sinh_neg, neg_neg] at this
+    linarith
+  have := Real.exp_pos x
+  linarith
+
+/-- The speed associated to any rapidity is strictly subluminal: `|tanh φ| < 1`. -/
+theorem abs_tanh_lt_one (x : ℝ) : |Real.tanh x| < 1 :=
+  abs_lt.mpr ⟨neg_one_lt_tanh x, tanh_lt_one x⟩
+
+/- ## Relativistic velocity addition -/
+
+/-- The relativistic velocity-addition operation `β₁ ⊕ β₂ = (β₁+β₂)/(1+β₁β₂)`. -/
+noncomputable def velAdd (β₁ β₂ : ℝ) : ℝ := (β₁ + β₂) / (1 + β₁ * β₂)
+
+/-- The relativistic denominator stays positive for any two subluminal speeds:
+`(1+β₁)(1+β₂) > 0` and `(1-β₁)(1-β₂) > 0` sum to `2(1 + β₁β₂) > 0`. -/
+theorem one_add_mul_pos {β₁ β₂ : ℝ} (h₁ : |β₁| < 1) (h₂ : |β₂| < 1) :
+    0 < 1 + β₁ * β₂ := by
+  rw [abs_lt] at h₁ h₂
+  nlinarith [mul_pos (by linarith : (0:ℝ) < 1 + β₁) (by linarith : (0:ℝ) < 1 + β₂),
+    mul_pos (by linarith : (0:ℝ) < 1 - β₁) (by linarith : (0:ℝ) < 1 - β₂)]
+
+/-- The relativistic denominator `1 + tanh φ₁ tanh φ₂` is positive — immediate from
+`|tanh φ| < 1`. -/
+theorem one_add_tanh_mul_pos (x y : ℝ) : 0 < 1 + Real.tanh x * Real.tanh y :=
+  one_add_mul_pos (abs_tanh_lt_one x) (abs_tanh_lt_one y)
+
+/-- The "cleared" form of velocity addition: multiplying through by the
+denominator. Keeping `sinh(φ₁+φ₂)`/`cosh(φ₁+φ₂)` atomic lets `field_simp` clear the
+(product) denominators `cosh φᵢ`; the addition formulas then close it by `ring`. -/
+theorem tanh_add_mul (x y : ℝ) :
+    Real.tanh (x + y) * (1 + Real.tanh x * Real.tanh y) = Real.tanh x + Real.tanh y := by
+  have hx := (Real.cosh_pos x).ne'
+  have hy := (Real.cosh_pos y).ne'
+  have hxy := (Real.cosh_pos (x + y)).ne'
+  rw [Real.tanh_eq_sinh_div_cosh x, Real.tanh_eq_sinh_div_cosh y,
+    Real.tanh_eq_sinh_div_cosh (x + y)]
+  field_simp
+  rw [Real.sinh_add, Real.cosh_add]
+  ring
+
+/-- **Relativistic velocity addition is rapidity addition.** The velocity of the
+composite boost with rapidity `φ₁ + φ₂` is `velAdd` of the two velocities:
+
+    tanh(φ₁ + φ₂) = (tanh φ₁ + tanh φ₂) / (1 + tanh φ₁ tanh φ₂). -/
+theorem tanh_add (x y : ℝ) :
+    Real.tanh (x + y) = velAdd (Real.tanh x) (Real.tanh y) := by
+  unfold velAdd
+  rw [eq_div_iff (one_add_tanh_mul_pos x y).ne']
+  exact tanh_add_mul x y
+
+/- ## Closure: subluminal ⊕ subluminal = subluminal -/
+
+/-- **The speed of light is never exceeded.** Composing two strictly subluminal
+velocities yields a strictly subluminal velocity: `|velAdd β₁ β₂| < 1`. The proof
+is the algebraic identity `1 ∓ velAdd = (1 ∓ β₁)(1 ∓ β₂)/(1 + β₁ β₂)`. -/
+theorem abs_velAdd_lt_one {β₁ β₂ : ℝ} (h₁ : |β₁| < 1) (h₂ : |β₂| < 1) :
+    |velAdd β₁ β₂| < 1 := by
+  have hd := one_add_mul_pos h₁ h₂
+  rw [abs_lt] at h₁ h₂ ⊢
+  refine ⟨?_, ?_⟩
+  · -- -1 < velAdd β₁ β₂  ⟺  0 < (1+β₁)(1+β₂)
+    unfold velAdd
+    rw [lt_div_iff₀ hd]
+    nlinarith [mul_pos (by linarith : (0:ℝ) < 1 + β₁) (by linarith : (0:ℝ) < 1 + β₂)]
+  · -- velAdd β₁ β₂ < 1  ⟺  0 < (1-β₁)(1-β₂)
+    unfold velAdd
+    rw [div_lt_one hd]
+    nlinarith [mul_pos (by linarith : (0:ℝ) < 1 - β₁) (by linarith : (0:ℝ) < 1 - β₂)]
+
+/-- **Closure for rapidities, stated directly**: any two rapidity-velocities
+compose to a subluminal velocity, equal to the velocity of the summed rapidity. -/
+theorem velAdd_tanh_subluminal (x y : ℝ) :
+    velAdd (Real.tanh x) (Real.tanh y) = Real.tanh (x + y) ∧
+      |velAdd (Real.tanh x) (Real.tanh y)| < 1 :=
+  ⟨(tanh_add x y).symm, by rw [← tanh_add]; exact abs_tanh_lt_one _⟩
+
+/- ## Light-speed invariance -/
+
+/-- **The speed of light is invariant.** Adding any velocity `β ≠ -1` to `c` (the
+speed `1`) returns `c`: `velAdd β 1 = 1`. -/
+theorem velAdd_one (β : ℝ) (hβ : β ≠ -1) : velAdd β 1 = 1 := by
+  unfold velAdd
+  have hne : (1 : ℝ) + β * 1 ≠ 0 := by
+    rw [mul_one]; intro h; exact hβ (by linarith)
+  rw [div_eq_one_iff_eq hne]; ring
+
+/-- Symmetric form: adding `c` to any velocity `β ≠ -1` returns `c`. -/
+theorem one_velAdd (β : ℝ) (hβ : β ≠ -1) : velAdd 1 β = 1 := by
+  unfold velAdd
+  have hne : (1 : ℝ) + 1 * β ≠ 0 := by
+    rw [one_mul]; intro h; exact hβ (by linarith)
+  rw [div_eq_one_iff_eq hne]; ring
+
+/- ## Galilean (non-relativistic) limit -/
+
+/-- **The classical limit.** Velocity addition differs from the Galilean sum
+`β₁ + β₂` only by the second-order term `−(β₁+β₂)β₁β₂/(1+β₁β₂)`, which vanishes
+when `β₁β₂` is negligible — recovering Galilean addition at low speeds. -/
+theorem velAdd_sub_sum (β₁ β₂ : ℝ) (hd : 1 + β₁ * β₂ ≠ 0) :
+    velAdd β₁ β₂ - (β₁ + β₂) = -(β₁ + β₂) * (β₁ * β₂) / (1 + β₁ * β₂) := by
+  unfold velAdd
+  field_simp
+  ring
+
+/- ## The Lorentz factor -/
+
+/-- The identity `1 − tanh²φ = 1/cosh²φ`, from `cosh²φ − sinh²φ = 1`. -/
+theorem one_sub_tanh_sq (x : ℝ) : 1 - Real.tanh x ^ 2 = 1 / Real.cosh x ^ 2 := by
+  rw [Real.tanh_eq_sinh_div_cosh, div_pow]
+  have hc := (Real.cosh_pos x).ne'
+  have h := Real.cosh_sq_sub_sinh_sq x
+  field_simp
+  linarith
+
+/-- **The Lorentz factor** `γ = cosh φ` satisfies the familiar `γ² = 1/(1 − β²)`,
+with `β = tanh φ` the velocity. -/
+theorem cosh_sq_eq_inv_one_sub_tanh_sq (x : ℝ) :
+    Real.cosh x ^ 2 = 1 / (1 - Real.tanh x ^ 2) := by
+  rw [one_sub_tanh_sq, one_div_one_div]
+
+/- ## Concrete instances -/
+
+/-- Half the speed of light added to half the speed of light gives `⅘ c`, not `c`:
+`velAdd (1/2) (1/2) = 4/5`. -/
+theorem velAdd_half_half : velAdd (1 / 2) (1 / 2) = 4 / 5 := by
+  unfold velAdd; norm_num
+
+/-- `⅗ c` added to `c` is `c` — light-speed invariance in a concrete instance. -/
+theorem velAdd_three_fifths_one : velAdd (3 / 5) 1 = 1 := by
+  unfold velAdd; norm_num
+
+end PythagoreanTheoremOQ03OQ02

--- a/src/data/proofs/pythagorean-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-subluminal",
+    "proofId": "pythagorean-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 44,
+      "endLine": 65
+    },
+    "type": "insight",
+    "title": "Why Rapidity-Velocities Are Always Sub-c",
+    "content": "tanh maps all of ℝ onto the open interval (−1, 1), so β = tanh φ is always strictly below the speed of light. The proof is one identity: cosh φ − sinh φ = exp(−φ) > 0 gives sinh φ < cosh φ, i.e. tanh φ < 1; and cosh φ + sinh φ = exp(φ) > 0 gives −1 < tanh φ. There is no finite rapidity for which the speed reaches c — that requires φ → ∞."
+  },
+  {
+    "id": "ann-velocity-addition",
+    "proofId": "pythagorean-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 85,
+      "endLine": 112
+    },
+    "type": "insight",
+    "title": "Einstein's Law Is tanh's Addition Formula",
+    "content": "The parent entry proves that boosts compose by ADDING rapidities (φ₁ + φ₂). Because tanh inherits an addition formula from sinh and cosh, that additivity becomes the relativistic velocity-addition law tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂). The Lean proof goes through the cross-multiplied identity tanh_add_mul; the trick is to keep sinh(φ₁+φ₂)/cosh(φ₁+φ₂) atomic so field_simp only clears the simple denominators cosh φᵢ, after which sinh_add/cosh_add and ring finish. The denominator 1 + β₁β₂ > 0 is free from |tanh| < 1."
+  },
+  {
+    "id": "ann-closure",
+    "proofId": "pythagorean-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 114,
+      "endLine": 133
+    },
+    "type": "concept",
+    "title": "c Is an Unreachable Speed Limit",
+    "content": "Composing two sub-c velocities can never reach or exceed c. The proof is purely algebraic and needs no arctanh: 1 − velAdd β₁ β₂ = (1−β₁)(1−β₂)/(1+β₁β₂) and 1 + velAdd β₁ β₂ = (1+β₁)(1+β₂)/(1+β₁β₂). When |β₁|, |β₂| < 1 both numerators and the denominator are positive, so −1 < velAdd β₁ β₂ < 1. This is the kinematic statement that the speed of light is a closed, unattainable boundary."
+  },
+  {
+    "id": "ann-invariance-limit-gamma",
+    "proofId": "pythagorean-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 142,
+      "endLine": 181
+    },
+    "type": "insight",
+    "title": "Invariance, the Classical Limit, and γ",
+    "content": "Three textbook facts fall out. velAdd β 1 = (β+1)/(1+β) = 1: adding any velocity to c returns c — the second postulate as an algebraic fixed point. velAdd β₁ β₂ − (β₁+β₂) is second-order in the velocities, so Galilean addition β ≈ β₁+β₂ is the low-speed limit. And the Lorentz factor γ = cosh φ satisfies γ² = 1/(1−β²), since 1 − tanh²φ = 1/cosh²φ from cosh²−sinh²=1."
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "pythagorean-theorem-oq-03-oq-02",
+    "range": {
+      "startLine": 182,
+      "endLine": 189
+    },
+    "type": "concept",
+    "title": "Half-c Plus Half-c Is Four-Fifths c",
+    "content": "velAdd_half_half computes (½+½)/(1+¼) = ⅘: combining two half-light-speed velocities yields 0.8c, conspicuously not c — the hallmark of relativistic addition. velAdd_three_fifths_one confirms ⅗c ⊕ c = c. Both are proved by norm_num after unfolding velAdd, with no native_decide, so the file stays fully kernel-checked."
+  }
+]

--- a/src/data/proofs/pythagorean-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03-oq-02/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "pythagorean-theorem-oq-03-oq-02",
+  "title": "Relativistic Velocity Addition from Rapidity",
+  "slug": "pythagorean-theorem-oq-03-oq-02",
+  "description": "Answers the parent non-Euclidean Pythagorean entry's open question to 'formalize the rapidity–velocity relation β = tanh(φ) and derive relativistic velocity addition'. Building only on Mathlib's hyperbolic functions, it proves: every rapidity gives a strictly subluminal speed |tanh φ| < 1; the additivity of rapidity is exactly the velocity-addition law tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂); closure (composing two subluminal velocities stays subluminal, via 1∓velAdd = (1∓β₁)(1∓β₂)/(1+β₁β₂)); light-speed invariance (velAdd β 1 = 1); the Galilean low-speed limit; the Lorentz factor γ = cosh φ satisfying γ² = 1/(1−β²); and concrete checks ½c⊕½c = ⅘c and ⅗c⊕c = c.",
+  "meta": {
+    "author": "Albert Einstein (1905); Vladimir Varićak / Alfred Robb (rapidity); formalized in Lean 4",
+    "date": "1905",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PythagoreanTheoremOQ03OQ02.lean",
+    "tags": [
+      "special-relativity",
+      "minkowski-spacetime",
+      "rapidity",
+      "velocity-addition",
+      "hyperbolic-functions",
+      "lorentz-factor"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 190,
+    "theoremCount": 16,
+    "definitionCount": 1,
+    "originalContributions": [
+      "tanh_add: the additivity of rapidity IS the relativistic velocity-addition law — tanh(φ₁+φ₂) = velAdd(tanh φ₁, tanh φ₂) = (β₁+β₂)/(1+β₁β₂) — closing the gap left by the parent (which proved rapidity composition φ₁+φ₂ but not the velocity formula).",
+      "abs_tanh_lt_one (+ tanh_lt_one, neg_one_lt_tanh): every rapidity yields a strictly subluminal speed |β| = |tanh φ| < 1, from cosh φ ∓ sinh φ = exp(∓φ) > 0.",
+      "abs_velAdd_lt_one: CLOSURE / the speed of light is never exceeded — composing two subluminal velocities stays subluminal, proved algebraically via 1∓velAdd = (1∓β₁)(1∓β₂)/(1+β₁β₂) with no appeal to arctanh.",
+      "velAdd_one / one_velAdd: light-speed invariance — adding any velocity (≠ -c) to c returns c.",
+      "velAdd_sub_sum: the Galilean limit — velocity addition differs from β₁+β₂ only by the second-order term −(β₁+β₂)β₁β₂/(1+β₁β₂).",
+      "cosh_sq_eq_inv_one_sub_tanh_sq (+ one_sub_tanh_sq): the Lorentz factor γ = cosh φ obeys γ² = 1/(1−β²).",
+      "velAdd_half_half and velAdd_three_fifths_one: ½c ⊕ ½c = ⅘c and ⅗c ⊕ c = c, without native_decide."
+    ],
+    "prerequisites": [
+      "Special relativity: rapidity φ, the velocity relation β = tanh φ, and Lorentz boosts",
+      "Mathlib's Real.sinh / Real.cosh / Real.tanh and the identities cosh²−sinh²=1, sinh/cosh addition formulas",
+      "Elementary real inequalities (nlinarith / linarith)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.tanh_eq_sinh_div_cosh",
+        "description": "tanh x = sinh x / cosh x — the bridge from the velocity β to the rapidity φ.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sinh_add / Real.cosh_add",
+        "description": "The hyperbolic addition formulas, the algebraic core of the velocity-addition law.",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      },
+      {
+        "theorem": "Real.cosh_sub_sinh / Real.cosh_sq_sub_sinh_sq",
+        "description": "cosh x − sinh x = exp(−x) (subluminality) and cosh²−sinh²=1 (the Lorentz factor).",
+        "module": "Mathlib.Analysis.Complex.Trigonometric"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "In Minkowski's geometry of spacetime the natural coordinate along a Lorentz boost is not the velocity β but the rapidity φ, related by β = tanh φ. Rapidity is the hyperbolic analogue of an angle: boosts compose by simply ADDING rapidities, exactly as rotations compose by adding angles. The parent gallery entry ('Pythagorean Theorem in Non-Euclidean Geometry') develops this Minkowski branch — the invariant interval τ² = t² − x², Lorentz boosts parameterized by φ, interval invariance, and the additivity of rapidity under composition — and explicitly leaves open the step of converting that additivity into the velocity language.\n\nThis entry makes that conversion. Because tanh has an addition formula inherited from sinh and cosh, the additive law φ = φ₁ + φ₂ becomes Einstein's velocity-addition formula β = (β₁ + β₂)/(1 + β₁β₂) (1905). Two structural facts fall out for free: velocities from rapidities are always strictly below the speed of light (|tanh φ| < 1), and the set of subluminal velocities is CLOSED under addition — you can never reach or exceed c by composing sub-c speeds. The Galilean rule β ≈ β₁ + β₂ reappears as the low-speed limit, and the Lorentz factor γ = cosh φ satisfies the textbook γ² = 1/(1−β²).",
+    "problemStatement": "**Open Question (parent pythagorean-theorem-oq-03)**: formalize the rapidity–velocity relation β = tanh(φ) and derive relativistic velocity addition.\n\n**This entry**: proves the velocity-addition law tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂), the subluminal bound |tanh φ| < 1, closure of subluminal velocities, light-speed invariance, the Galilean limit, and the Lorentz factor identity — all with zero axioms.",
+    "text": "A 190-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. velAdd is the velocity-addition operation; tanh_add identifies it with rapidity addition; abs_tanh_lt_one and abs_velAdd_lt_one give the subluminal bound and its closure; velAdd_one, velAdd_sub_sum, and cosh_sq_eq_inv_one_sub_tanh_sq give light-speed invariance, the Galilean limit, and the Lorentz factor; two concrete instances illustrate the physics.",
+    "proofStrategy": "Subluminality: tanh φ < 1 ⟺ sinh φ < cosh φ ⟺ 0 < cosh φ − sinh φ = exp(−φ) (Real.cosh_sub_sinh); the lower bound −1 < tanh φ uses cosh φ + sinh φ = exp φ. The velocity-addition law is proved through tanh_add_mul, the cross-multiplied identity tanh(φ₁+φ₂)·(1 + tanh φ₁ tanh φ₂) = tanh φ₁ + tanh φ₂: rewrite each tanh as sinh/cosh KEEPING sinh(φ₁+φ₂)/cosh(φ₁+φ₂) atomic so field_simp clears only the product denominators cosh φᵢ, then expand with sinh_add/cosh_add and close by ring. The denominator 1 + tanh φ₁ tanh φ₂ > 0 is immediate from |tanh| < 1 (one_add_mul_pos). Dividing gives tanh_add, and eq_div_iff finishes. Closure abs_velAdd_lt_one rewrites with lt_div_iff₀ / div_lt_one and reduces to the positivity of (1±β₁)(1±β₂) by nlinarith — the algebraic heart 1∓velAdd = (1∓β₁)(1∓β₂)/(1+β₁β₂). Light-speed invariance is div_eq_one_iff_eq; the Galilean limit is field_simp+ring; the Lorentz factor uses cosh²−sinh²=1.",
+    "keyInsights": [
+      "Rapidity linearizes Lorentz boosts: φ adds, exactly like an angle. The velocity-addition law is just tanh's addition formula in disguise — the non-linearity of β = (β₁+β₂)/(1+β₁β₂) is the non-linearity of tanh.",
+      "Subluminality is automatic: tanh maps all of ℝ into (−1,1), because cosh φ ∓ sinh φ = exp(∓φ) > 0. No velocity built from a finite rapidity reaches c.",
+      "Closure needs no arctanh: 1 ∓ velAdd β₁ β₂ = (1∓β₁)(1∓β₂)/(1+β₁β₂), so if both factors are subluminal the result is too — a purely algebraic proof that c is an unreachable speed limit.",
+      "Light speed is the fixed point: velAdd β 1 = (β+1)/(1+β) = 1 for every β ≠ −1, encoding the second postulate of relativity.",
+      "The Galilean rule is the linearization: velAdd β₁ β₂ − (β₁+β₂) is second order in the velocities, so β ≈ β₁ + β₂ when β₁β₂ ≪ 1.",
+      "The Lorentz factor lives on the same hyperbola: γ = cosh φ and βγ = sinh φ, with γ² − (βγ)² = 1 giving γ² = 1/(1−β²)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "subluminal",
+      "title": "Rapidities Give Subluminal Speeds",
+      "startLine": 42,
+      "endLine": 65,
+      "summary": "tanh_lt_one, neg_one_lt_tanh, abs_tanh_lt_one: |tanh φ| < 1 from cosh φ ∓ sinh φ = exp(∓φ) > 0.",
+      "mathContext": "Every finite rapidity maps to a velocity strictly below the speed of light."
+    },
+    {
+      "id": "velocity-addition",
+      "title": "Velocity Addition = Rapidity Addition",
+      "startLine": 67,
+      "endLine": 112,
+      "summary": "velAdd, one_add_mul_pos, one_add_tanh_mul_pos, tanh_add_mul, tanh_add: tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂).",
+      "mathContext": "The additivity of rapidity is exactly Einstein's velocity-addition law."
+    },
+    {
+      "id": "closure",
+      "title": "Closure: the Speed of Light Is Never Exceeded",
+      "startLine": 114,
+      "endLine": 141,
+      "summary": "abs_velAdd_lt_one and velAdd_tanh_subluminal: subluminal ⊕ subluminal stays subluminal, via 1∓velAdd = (1∓β₁)(1∓β₂)/(1+β₁β₂).",
+      "mathContext": "The interval (−c, c) of physical velocities is closed under composition."
+    },
+    {
+      "id": "invariance-limit-gamma",
+      "title": "Light-Speed Invariance, Galilean Limit, Lorentz Factor",
+      "startLine": 142,
+      "endLine": 181,
+      "summary": "velAdd_one/one_velAdd (c is invariant), velAdd_sub_sum (Galilean limit), one_sub_tanh_sq and cosh_sq_eq_inv_one_sub_tanh_sq (γ² = 1/(1−β²)).",
+      "mathContext": "The second postulate, the classical limit, and the Lorentz factor."
+    },
+    {
+      "id": "concrete",
+      "title": "Concrete Instances",
+      "startLine": 182,
+      "endLine": 189,
+      "summary": "velAdd_half_half (½c ⊕ ½c = ⅘c) and velAdd_three_fifths_one (⅗c ⊕ c = c).",
+      "mathContext": "Adding half-c to half-c gives 0.8c, not c; adding any speed to c gives c."
+    }
+  ],
+  "conclusion": {
+    "summary": "Starting only from Mathlib's hyperbolic functions, this entry derives the relativistic velocity-addition law as the additivity of rapidity (tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂)), proves every rapidity gives a subluminal speed and that subluminal velocities are closed under composition, establishes light-speed invariance and the Galilean limit, and records the Lorentz factor identity γ² = 1/(1−β²) — answering the parent entry's open question with zero axioms.",
+    "implications": "The velocity-addition law and the unreachability of c are now machine-checked consequences of tanh's addition formula and the bound |tanh φ| < 1, complementing the parent's rapidity-composition result. Together they give the full Minkowski kinematics in the velocity language: c is an algebraic fixed point and an unattainable speed limit, with Newtonian addition recovered in the low-speed limit.",
+    "openQuestions": [
+      "Formalize the rapidity-to-velocity map's inverse (arctanh) and prove the velocity-addition group is isomorphic to (ℝ, +) via rapidity.",
+      "Extend velocity addition to non-collinear boosts and derive Thomas–Wigner rotation.",
+      "Connect γ = cosh φ and βγ = sinh φ to the parent's lorentzBoostRapidity matrix and prove the boost is the hyperbolic rotation by φ."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "pythagorean-theorem-oq-03",
+      "relationship": "extends",
+      "description": "Parent: the non-Euclidean / Minkowski Pythagorean entry proves rapidity composition φ₁+φ₂ but leaves the velocity-addition law open. This entry supplies it (β = tanh φ) and the surrounding kinematics."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "PythagoreanTheoremOQ03OQ02",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "tanh_add",
+        "type": "core",
+        "description": "Relativistic velocity addition is rapidity addition: tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂).",
+        "leanType": "(x y : ℝ) → Real.tanh (x + y) = velAdd (Real.tanh x) (Real.tanh y)"
+      },
+      {
+        "name": "abs_velAdd_lt_one",
+        "type": "key",
+        "description": "Closure: composing two subluminal velocities stays subluminal (c is never exceeded).",
+        "leanType": "{β₁ β₂ : ℝ} → |β₁| < 1 → |β₂| < 1 → |velAdd β₁ β₂| < 1"
+      },
+      {
+        "name": "cosh_sq_eq_inv_one_sub_tanh_sq",
+        "type": "key",
+        "description": "The Lorentz factor γ = cosh φ obeys γ² = 1/(1−β²).",
+        "leanType": "(x : ℝ) → Real.cosh x ^ 2 = 1 / (1 - Real.tanh x ^ 2)"
+      }
+    ],
+    "path": "Proofs/PythagoreanTheoremOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "tanh_add",
+      "type": "core",
+      "description": "The velocity-addition law tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂).",
+      "leanType": "(x y : ℝ) → Real.tanh (x + y) = velAdd (Real.tanh x) (Real.tanh y)"
+    },
+    {
+      "name": "abs_velAdd_lt_one",
+      "type": "key",
+      "description": "Subluminal velocities are closed under composition — c is an unreachable speed limit.",
+      "leanType": "{β₁ β₂ : ℝ} → |β₁| < 1 → |β₂| < 1 → |velAdd β₁ β₂| < 1"
+    },
+    {
+      "name": "velAdd_one",
+      "type": "supporting",
+      "description": "Light-speed invariance: velAdd β 1 = 1 for β ≠ −1.",
+      "leanType": "(β : ℝ) → β ≠ -1 → velAdd β 1 = 1"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Einstein, Albert",
+      "title": "Zur Elektrodynamik bewegter Körper",
+      "year": "1905",
+      "venue": "Annalen der Physik 17, 891–921",
+      "note": "Original derivation of the relativistic velocity-addition law"
+    },
+    {
+      "authors": "Varićak, Vladimir",
+      "title": "Anwendung der Lobatschefskijschen Geometrie in der Relativtheorie",
+      "year": "1910",
+      "venue": "Physikalische Zeitschrift 11, 93–96",
+      "note": "Rapidity and the hyperbolic-geometry interpretation of velocity addition"
+    },
+    {
+      "authors": "Robb, Alfred A.",
+      "title": "Optical Geometry of Motion",
+      "year": "1911",
+      "venue": "Heffer, Cambridge",
+      "note": "Introduced 'rapidity' as the additive boost parameter"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent gallery entry **pythagorean-theorem-oq-03** ("Pythagorean Theorem in Non-Euclidean Geometry") develops the Minkowski branch τ² = t² − x²: Lorentz boosts parameterized by rapidity φ (with β = tanh φ), interval invariance, and the **additivity of rapidity** under composition of boosts. Its open questions explicitly ask to

> formalize the rapidity–velocity relation β = tanh(φ) and derive relativistic velocity addition.

This PR answers that. Because tanh has an addition formula inherited from sinh/cosh, the additive law φ = φ₁ + φ₂ becomes **Einstein's velocity-addition formula** β = (β₁ + β₂)/(1 + β₁β₂). Building only on Mathlib's hyperbolic functions, it proves:

- **`abs_tanh_lt_one`** — every rapidity gives a strictly subluminal speed `|tanh φ| < 1`, from `cosh φ ∓ sinh φ = exp(∓φ) > 0`;
- **`tanh_add`** — rapidity additivity *is* the velocity-addition law: `tanh(φ₁+φ₂) = (β₁+β₂)/(1+β₁β₂)`;
- **`abs_velAdd_lt_one`** — **closure**: composing two subluminal velocities stays subluminal (c is never exceeded), proved algebraically via `1 ∓ velAdd = (1∓β₁)(1∓β₂)/(1+β₁β₂)` with no appeal to arctanh;
- **`velAdd_one`** — **light-speed invariance**: adding any velocity (≠ −c) to c returns c;
- **`velAdd_sub_sum`** — the **Galilean limit**: the correction to β₁+β₂ is the second-order term `−(β₁+β₂)β₁β₂/(1+β₁β₂)`;
- **`cosh_sq_eq_inv_one_sub_tanh_sq`** — the **Lorentz factor** γ = cosh φ obeys `γ² = 1/(1−β²)`;
- concrete checks **½c ⊕ ½c = ⅘c** and **⅗c ⊕ c = c** (no `native_decide`).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PythagoreanTheoremOQ03OQ02` → `✔ Built Proofs.PythagoreanTheoremOQ03OQ02`, build completed successfully.
- 190 lines, 16 theorems / 1 definition, **0 sorries, 0 axioms, no native_decide** — verified.
- Self-contained: imports Mathlib only; the rapidity/velocity facts are derived directly from `Real.sinh`/`Real.cosh`/`Real.tanh`, so nothing is imported from the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)