### PR TITLE
research(cube-root-3-irrational-oq-01): ∛3 via Eisenstein's criterion, general prime case

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -724,6 +724,7 @@ import Proofs.CubeRoot2IrrationalOQ01
 import Proofs.CubeRoot2IrrationalOQ03
 import Proofs.CubeRoot2IrrationalOQ05
 import Proofs.CubeRoot3Irrational
+import Proofs.CubeRoot3IrrationalOQ01
 import Proofs.CubeRoot3IrrationalOQ02
 import Proofs.CubeRoot3IrrationalOQ02OQ01
 import Proofs.CubeRoot3IrrationalOQ02OQ02

--- a/proofs/Proofs/CubeRoot3IrrationalOQ01.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ01.lean
@@ -1,0 +1,130 @@
+/-
+# ∛3 via Eisenstein's Criterion — and the general prime case (OQ-01 / OQ-02 of ∛3)
+
+The parent gallery entry **cube-root-3-irrational** proves ∛3 ∉ ℚ by the rational
+root theorem, and its open questions ask:
+
+  > Is there a Lean proof of Eisenstein's irreducibility criterion? Combined with
+  > the rational root theorem, this would give a cleaner algebraic proof of ∛3's
+  > irrationality via the degree argument.
+
+This file answers that with the *general* theorem the rational-root approach does
+not give. Using Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` at the
+prime ideal `(p) ⊆ ℤ`, we prove
+
+    for every prime `p` and every `n ≥ 1`,  Xⁿ − p  is irreducible over ℤ,
+
+and transfer it to ℚ by Gauss's lemma. Specializing `p = 3, n = 3` recovers the
+irreducibility of `X³ − 3` (the minimal polynomial of ∛3) — now via Eisenstein
+rather than an ad-hoc rational-root computation — and the construction works
+uniformly for `X⁵ − 7`, `X² − 5`, and so on. Irreducibility of the degree-`n`
+minimal polynomial is strictly stronger than irrationality: it pins the algebraic
+degree of `p^{1/n}` at exactly `n`.
+
+Verification of the Eisenstein hypotheses for `Xⁿ − p`:
+  * leading coefficient `1 ∉ (p)` — the ideal is proper;
+  * every lower coefficient is `0` or `−p`, both in `(p)`;
+  * the constant coefficient `−p ∉ (p)²` — else `p² ∣ p`, impossible for a prime;
+  * `Xⁿ − p` is monic, hence primitive.
+
+Zero axioms; imports only Mathlib.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace CubeRoot3IrrationalOQ01
+
+/- ## The general Eisenstein irreducibility theorem over ℤ -/
+
+/-- **Eisenstein's criterion applied to `Xⁿ − p`.** For a prime `p` and `n ≥ 1`,
+the polynomial `Xⁿ − p` is irreducible over `ℤ`. -/
+theorem irreducible_X_pow_sub_C_prime_int {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C (p : ℤ)) := by
+  have hpZ : Prime (p : ℤ) := Nat.prime_iff_prime_int.mp hp
+  have hp0 : (p : ℤ) ≠ 0 := hpZ.ne_zero
+  set P : Ideal ℤ := Ideal.span {(p : ℤ)} with hP
+  have hPprime : P.IsPrime := (Ideal.span_singleton_prime hp0).mpr hpZ
+  have hmonic : ((X : ℤ[X]) ^ n - C (p : ℤ)).Monic := monic_X_pow_sub_C (p : ℤ) hn.ne'
+  have hdeg : ((X : ℤ[X]) ^ n - C (p : ℤ)).degree = n := degree_X_pow_sub_C hn (p : ℤ)
+  apply irreducible_of_eisenstein_criterion hPprime
+  · -- leading coefficient `1 ∉ P`
+    rw [hmonic.leadingCoeff]
+    intro h1
+    exact hPprime.ne_top (Ideal.eq_top_of_isUnit_mem P h1 isUnit_one)
+  · -- every coefficient below the top degree lies in `P`
+    intro m hm
+    have hmn : m < n := by rw [hdeg] at hm; exact_mod_cast hm
+    rw [coeff_sub, coeff_X_pow, coeff_C]
+    rw [if_neg (by omega : ¬ m = n)]
+    split_ifs with h0m
+    · -- `m = 0`: the coefficient is `0 − p = −p ∈ P`
+      simpa using P.neg_mem (Ideal.mem_span_singleton_self (p : ℤ))
+    · -- otherwise the coefficient is `0`
+      simp
+  · -- positive degree
+    rw [hdeg]; exact_mod_cast hn
+  · -- constant coefficient `−p ∉ P²`
+    have hc : ((X : ℤ[X]) ^ n - C (p : ℤ)).coeff 0 = -(p : ℤ) := by
+      have hx0 : ((X : ℤ[X]) ^ n).coeff 0 = 0 := by
+        rw [coeff_X_pow]; exact if_neg (by omega)
+      rw [coeff_sub, hx0, coeff_C_zero, zero_sub]
+    rw [hc]
+    intro hmem
+    rw [Ideal.neg_mem_iff, hP, Ideal.span_singleton_pow, Ideal.mem_span_singleton] at hmem
+    -- `hmem : p² ∣ p`; cancel one factor of `p` to get `p ∣ 1`, contradicting primality
+    have hdvd1 : (p : ℤ) ∣ 1 := by
+      have h2 : (p : ℤ) * (p : ℤ) ∣ (p : ℤ) * 1 := by rwa [mul_one, ← sq]
+      exact (mul_dvd_mul_iff_left hp0).mp h2
+    exact hpZ.not_unit (isUnit_of_dvd_one hdvd1)
+  · -- primitive, because monic
+    exact hmonic.isPrimitive
+
+/- ## Transfer to ℚ via Gauss's lemma -/
+
+/-- **`Xⁿ − p` is irreducible over `ℚ`** for prime `p` and `n ≥ 1.** Gauss's lemma
+(`IsPrimitive.Int.irreducible_iff_irreducible_map_cast`) lifts the integer
+irreducibility, after identifying the casted polynomial with `Xⁿ − p` over `ℚ`. -/
+theorem irreducible_X_pow_sub_C_prime_rat {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℚ[X]) ^ n - C (p : ℚ)) := by
+  have hprim : ((X : ℤ[X]) ^ n - C (p : ℤ)).IsPrimitive :=
+    (monic_X_pow_sub_C (p : ℤ) hn.ne').isPrimitive
+  have hmap : ((X : ℤ[X]) ^ n - C (p : ℤ)).map (Int.castRingHom ℚ)
+      = (X : ℚ[X]) ^ n - C (p : ℚ) := by
+    simp [Polynomial.map_sub, Polynomial.map_pow]
+  have hiff := Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast hprim
+  rw [← hmap, ← hiff]
+  exact irreducible_X_pow_sub_C_prime_int hp hn
+
+/- ## Specialization: the minimal polynomial of ∛3 -/
+
+/-- `X³ − 3` is irreducible over `ℤ` — via Eisenstein at `p = 3`. -/
+theorem irreducible_X_cubed_sub_three_int :
+    Irreducible ((X : ℤ[X]) ^ 3 - C (3 : ℤ)) := by
+  have h := irreducible_X_pow_sub_C_prime_int (p := 3) (n := 3) (by norm_num) (by norm_num)
+  simpa using h
+
+/-- `X³ − 3` is irreducible over `ℚ`. This is the minimal polynomial of ∛3, so ∛3
+has degree exactly 3 over ℚ — in particular it is irrational. The proof is now
+Eisenstein's criterion, answering the parent's open question. -/
+theorem irreducible_X_cubed_sub_three_rat :
+    Irreducible ((X : ℚ[X]) ^ 3 - C (3 : ℚ)) := by
+  have h := irreducible_X_pow_sub_C_prime_rat (p := 3) (n := 3) (by norm_num) (by norm_num)
+  simpa using h
+
+/- ## The technique is uniform across primes and exponents -/
+
+/-- `X⁵ − 7` is irreducible over `ℚ` (so `⁵√7` has degree 5). -/
+theorem irreducible_X_fifth_sub_seven_rat :
+    Irreducible ((X : ℚ[X]) ^ 5 - C (7 : ℚ)) := by
+  have h := irreducible_X_pow_sub_C_prime_rat (p := 7) (n := 5) (by norm_num) (by norm_num)
+  simpa using h
+
+/-- `X² − 5` is irreducible over `ℚ` (the Eisenstein proof that `√5` is irrational
+of degree 2). -/
+theorem irreducible_X_sq_sub_five_rat :
+    Irreducible ((X : ℚ[X]) ^ 2 - C (5 : ℚ)) := by
+  have h := irreducible_X_pow_sub_C_prime_rat (p := 5) (n := 2) (by norm_num) (by norm_num)
+  simpa using h
+
+end CubeRoot3IrrationalOQ01

--- a/src/data/proofs/cube-root-3-irrational-oq-01/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-eisenstein-int",
+    "proofId": "cube-root-3-irrational-oq-01",
+    "range": {
+      "startLine": 42,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "The Four Eisenstein Hypotheses for Xⁿ − p",
+    "content": "irreducible_X_pow_sub_C_prime_int verifies Mathlib's Eisenstein criterion at the prime ideal P = span{p}: (1) the leading coefficient is 1, not in the proper ideal P; (2) every lower coefficient of Xⁿ − p is 0 or −p, both in P; (3) the degree n is positive; (4) the constant coefficient −p is NOT in P² = span{p²}, because p² ∣ p would cancel to p ∣ 1, impossible for a prime; (5) the polynomial is monic, hence primitive. No candidate-root case analysis appears anywhere — that is the whole point of Eisenstein over the rational root theorem."
+  },
+  {
+    "id": "ann-gauss-rat",
+    "proofId": "cube-root-3-irrational-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 93
+    },
+    "type": "concept",
+    "title": "Gauss's Lemma: ℤ-Irreducible ⟹ ℚ-Irreducible",
+    "content": "Eisenstein's criterion lives over ℤ (it needs the prime ideal (p)), but minimal polynomials live over ℚ. Gauss's lemma — Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast — bridges them: a primitive integer polynomial is irreducible over ℤ iff its image in ℚ[X] is. Since Xⁿ − p is monic (hence primitive) and its cast is again Xⁿ − p, the ℚ-irreducibility follows immediately."
+  },
+  {
+    "id": "ann-cbrt3",
+    "proofId": "cube-root-3-irrational-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 109
+    },
+    "type": "insight",
+    "title": "∛3 Has Degree Exactly 3",
+    "content": "Specializing p = 3, n = 3 gives the irreducibility of X³ − 3 over ℚ — the minimal polynomial of ∛3. This is exactly the parent entry's requested 'cleaner algebraic proof via the degree argument': irreducibility of a degree-3 polynomial with ∛3 as a root means ∛3 has algebraic degree 3 over ℚ, which is strictly stronger than 'irrational' (degree > 1). The rational-root argument gives only the latter."
+  },
+  {
+    "id": "ann-general",
+    "proofId": "cube-root-3-irrational-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 124
+    },
+    "type": "concept",
+    "title": "One Theorem, Every Radical of a Prime",
+    "content": "Because the proof is uniform in p and n, ⁵√7 (X⁵ − 7, degree 5) and √5 (X² − 5, degree 2) drop out by the same six-line instantiation. Where the rational-root theorem must enumerate divisors afresh for each number, Eisenstein handles the entire family Xⁿ − p in a single argument — the structural advantage the parent's open question was pointing at."
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-01/meta.json
@@ -1,0 +1,194 @@
+{
+  "id": "cube-root-3-irrational-oq-01",
+  "title": "∛3 via Eisenstein's Criterion, and the General Prime Case",
+  "slug": "cube-root-3-irrational-oq-01",
+  "description": "Answers the parent ∛3 entry's open question for a cleaner algebraic proof via Eisenstein's criterion. Using Mathlib's Polynomial.irreducible_of_eisenstein_criterion at the prime ideal (p) ⊆ ℤ, it proves the GENERAL theorem that Xⁿ − p is irreducible over ℤ for every prime p and every n ≥ 1, transfers it to ℚ by Gauss's lemma, and specializes to X³ − 3 (the minimal polynomial of ∛3, so ∛3 has algebraic degree exactly 3) as well as X⁵ − 7 and X² − 5 — showing the technique is uniform where the rational-root argument is ad hoc. Zero axioms, no native_decide.",
+  "meta": {
+    "author": "Gotthold Eisenstein (1850); Carl Friedrich Gauss; formalized in Lean 4",
+    "date": "1850",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CubeRoot3IrrationalOQ01.lean",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "eisenstein-criterion",
+      "irreducible-polynomial",
+      "gauss-lemma",
+      "algebraic-degree"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 130,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "irreducible_X_pow_sub_C_prime_int: the GENERAL theorem that Xⁿ − p is irreducible over ℤ for every prime p and n ≥ 1, proved by verifying the four Eisenstein hypotheses (leading coeff 1 ∉ (p); lower coeffs 0 or −p ∈ (p); constant −p ∉ (p)² since p²∤p; monic ⟹ primitive).",
+      "irreducible_X_pow_sub_C_prime_rat: the same over ℚ, lifted by Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
+      "irreducible_X_cubed_sub_three_int / _rat: X³ − 3 is irreducible over ℤ and ℚ — the minimal polynomial of ∛3 via Eisenstein at p=3, answering the parent's open question and pinning ∛3's algebraic degree at exactly 3 (hence irrational).",
+      "irreducible_X_fifth_sub_seven_rat and irreducible_X_sq_sub_five_rat: the same machinery gives the irreducibility (and degree) of ⁵√7 and √5, demonstrating the technique is uniform across primes and exponents."
+    ],
+    "prerequisites": [
+      "Eisenstein's irreducibility criterion (Mathlib's Polynomial.irreducible_of_eisenstein_criterion)",
+      "Gauss's lemma transferring ℤ-irreducibility of a primitive polynomial to ℚ",
+      "Prime ideals span {p} ⊆ ℤ and elementary divisibility"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+        "description": "Eisenstein's criterion: a primitive polynomial whose non-leading coeffs lie in a prime ideal P, with leading coeff ∉ P and constant coeff ∉ P², is irreducible.",
+        "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion"
+      },
+      {
+        "theorem": "Polynomial.IsPrimitive.Int.irreducible_iff_irreducible_map_cast",
+        "description": "Gauss's lemma: a primitive integer polynomial is irreducible iff its image in ℚ[X] is.",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "Ideal.span_singleton_prime / monic_X_pow_sub_C / degree_X_pow_sub_C",
+        "description": "The prime ideal (p), and that Xⁿ − C a is monic of degree n for n ≥ 1.",
+        "module": "Mathlib.RingTheory.Ideal.Maximal / Mathlib.Algebra.Polynomial"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The parent entry proves ∛3 ∉ ℚ by the rational root theorem: the only candidate rational roots of X³ − 3 are ±1, ±3, none of which work. That argument is elementary but ad hoc — it must be re-run for each number and gives only irrationality, not the algebraic degree. Eisenstein's criterion (1850) is the systematic alternative: for a prime p, the polynomial Xⁿ − p satisfies the criterion at p (all lower coefficients divisible by p, the constant term not divisible by p²), so it is irreducible at one stroke for every n. The parent's open question asks precisely for this cleaner, Eisenstein-based proof.\n\nThis entry supplies it as a general theorem. Over ℤ the criterion applies directly at the prime ideal (p); Gauss's lemma then lifts the irreducibility to ℚ. Because Xⁿ − p is the minimal polynomial of p^{1/n} over ℚ, irreducibility is strictly stronger than irrationality: it pins the algebraic degree of p^{1/n} at exactly n. Specializing p=3, n=3 recovers ∛3 (degree 3, irrational), and the identical proof yields ⁵√7 (degree 5) and √5 (degree 2) with no extra work.",
+    "problemStatement": "**Open Question (parent cube-root-3-irrational)**: is there a Lean proof of Eisenstein's irreducibility criterion that, combined with the rational root theorem, gives a cleaner algebraic proof of ∛3's irrationality via the degree argument?\n\n**This entry**: proves Xⁿ − p irreducible over ℤ and ℚ for every prime p and n ≥ 1 via Eisenstein + Gauss, specializing to X³ − 3 (∛3, degree 3) and to X⁵ − 7, X² − 5.",
+    "text": "A 130-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. irreducible_X_pow_sub_C_prime_int is the general Eisenstein theorem over ℤ; irreducible_X_pow_sub_C_prime_rat transfers it to ℚ by Gauss; the four specializations instantiate ∛3, ⁵√7, and √5.",
+    "proofStrategy": "For Xⁿ − C p over ℤ, the Eisenstein criterion at P = span{p} needs: (1) leadingCoeff = 1 ∉ P, since P is a proper (prime) ideal; (2) every coefficient below degree n lies in P — by coeff_sub/coeff_X_pow/coeff_C each such coefficient is 0 or −p, both in P; (3) 0 < degree = n; (4) the constant coefficient is −p, and −p ∉ P² = span{p²} because p² ∣ p would force p ∣ 1 (cancel one factor via mul_dvd_mul_iff_left), contradicting primality; (5) Xⁿ − C p is monic, hence primitive (Monic.isPrimitive). Gauss's lemma (IsPrimitive.Int.irreducible_iff_irreducible_map_cast) then gives the ℚ version after identifying the casted polynomial with Xⁿ − C p via map_sub/map_pow. The specializations follow by instantiating p and n and normalizing the casts with simpa.",
+    "keyInsights": [
+      "Eisenstein's criterion is the structural reason X³ − 3 is irreducible: the prime 3 divides the constant term once and no other coefficient — no case analysis on candidate roots required.",
+      "The proof is uniform: the same lemma handles every Xⁿ − p, so ∛3, ⁵√7, √5 are one theorem with three instantiations, unlike the rational-root argument which restarts each time.",
+      "Irreducibility ⟹ degree: since Xⁿ − p is the minimal polynomial of p^{1/n}, its irreducibility pins the algebraic degree at exactly n — strictly more than 'irrational' (degree > 1).",
+      "The only genuinely arithmetic step is −p ∉ (p²): it reduces to p² ∤ p, i.e. p ∤ 1, the defining property of a prime.",
+      "Gauss's lemma is what makes the ℤ-level Eisenstein argument yield the ℚ-level (field) irreducibility relevant to minimal polynomials."
+    ]
+  },
+  "sections": [
+    {
+      "id": "eisenstein-int",
+      "title": "Eisenstein's Criterion over ℤ",
+      "startLine": 40,
+      "endLine": 77,
+      "summary": "irreducible_X_pow_sub_C_prime_int: Xⁿ − p irreducible over ℤ for prime p, n ≥ 1, verifying the four Eisenstein hypotheses at P = span{p}.",
+      "mathContext": "The general integer irreducibility, the heart of the entry."
+    },
+    {
+      "id": "gauss-rat",
+      "title": "Transfer to ℚ via Gauss's Lemma",
+      "startLine": 79,
+      "endLine": 93,
+      "summary": "irreducible_X_pow_sub_C_prime_rat lifts the ℤ result to ℚ using IsPrimitive.Int.irreducible_iff_irreducible_map_cast.",
+      "mathContext": "Field-level irreducibility, relevant to minimal polynomials."
+    },
+    {
+      "id": "cbrt3",
+      "title": "The Minimal Polynomial of ∛3",
+      "startLine": 95,
+      "endLine": 109,
+      "summary": "irreducible_X_cubed_sub_three_int / _rat: X³ − 3 irreducible (Eisenstein at p=3), so ∛3 has degree exactly 3 and is irrational.",
+      "mathContext": "Answers the parent's open question; the degree argument."
+    },
+    {
+      "id": "general",
+      "title": "Uniform Across Primes and Exponents",
+      "startLine": 111,
+      "endLine": 129,
+      "summary": "irreducible_X_fifth_sub_seven_rat and irreducible_X_sq_sub_five_rat: ⁵√7 (degree 5) and √5 (degree 2) by the same machinery.",
+      "mathContext": "Demonstrates the technique's generality."
+    }
+  ],
+  "conclusion": {
+    "summary": "Via Mathlib's Eisenstein criterion at the prime ideal (p) and Gauss's lemma, this entry proves the general theorem that Xⁿ − p is irreducible over ℤ and ℚ for every prime p and n ≥ 1, and specializes it to X³ − 3 (the minimal polynomial of ∛3) and to X⁵ − 7, X² − 5 — answering the parent's open question for a cleaner, Eisenstein-based proof of ∛3's irrationality via the degree argument.",
+    "implications": "Eisenstein's criterion replaces the ad-hoc rational-root computation with a uniform structural argument that also yields the algebraic degree: ∛3 (and p^{1/n} for any prime p) has minimal polynomial of degree exactly n, hence is irrational and not contained in any proper subfield of degree < n. The same six-line instantiation pattern covers every radical of a prime.",
+    "openQuestions": [
+      "Conclude irrationality/degree of p^{1/n} as a real number directly from this irreducibility (connect to minpoly ℚ (p^{1/n} : ℝ)).",
+      "Prove ℚ(∛3) has degree 3 and exhibit its ℚ-basis {1, ∛3, ∛9}, linking to the parent's linear-independence open question.",
+      "Generalize the Eisenstein input to Xⁿ − a for any a that is squarefree-at-some-prime, not just a prime."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cube-root-3-irrational",
+      "relationship": "extends",
+      "description": "Parent: proves ∛3 ∉ ℚ by the rational root theorem and asks for an Eisenstein-based proof. This entry supplies it, generally, and pins the algebraic degree."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "Companion thread on the general n-th-root irrationality theorem; this entry adds the irreducibility/degree refinement via Eisenstein."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "CubeRoot3IrrationalOQ01",
+    "lineCount": 130,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "irreducible_X_pow_sub_C_prime_int",
+        "type": "core",
+        "description": "Xⁿ − p is irreducible over ℤ for every prime p and n ≥ 1 (Eisenstein's criterion).",
+        "leanType": "{p : ℕ} → p.Prime → {n : ℕ} → 0 < n → Irreducible ((X : ℤ[X]) ^ n - C (p : ℤ))"
+      },
+      {
+        "name": "irreducible_X_pow_sub_C_prime_rat",
+        "type": "key",
+        "description": "The same over ℚ, by Gauss's lemma.",
+        "leanType": "{p : ℕ} → p.Prime → {n : ℕ} → 0 < n → Irreducible ((X : ℚ[X]) ^ n - C (p : ℚ))"
+      },
+      {
+        "name": "irreducible_X_cubed_sub_three_rat",
+        "type": "key",
+        "description": "X³ − 3 irreducible over ℚ: ∛3 has algebraic degree exactly 3.",
+        "leanType": "Irreducible ((X : ℚ[X]) ^ 3 - C (3 : ℚ))"
+      }
+    ],
+    "path": "Proofs/CubeRoot3IrrationalOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "irreducible_X_pow_sub_C_prime_int",
+      "type": "core",
+      "description": "General Eisenstein irreducibility of Xⁿ − p over ℤ for prime p, n ≥ 1.",
+      "leanType": "{p : ℕ} → p.Prime → {n : ℕ} → 0 < n → Irreducible ((X : ℤ[X]) ^ n - C (p : ℤ))"
+    },
+    {
+      "name": "irreducible_X_cubed_sub_three_rat",
+      "type": "key",
+      "description": "X³ − 3 irreducible over ℚ — the minimal polynomial of ∛3 via Eisenstein.",
+      "leanType": "Irreducible ((X : ℚ[X]) ^ 3 - C (3 : ℚ))"
+    },
+    {
+      "name": "irreducible_X_fifth_sub_seven_rat",
+      "type": "supporting",
+      "description": "X⁵ − 7 irreducible over ℚ — same machinery, ⁵√7 has degree 5.",
+      "leanType": "Irreducible ((X : ℚ[X]) ^ 5 - C (7 : ℚ))"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Eisenstein, Gotthold",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung...",
+      "year": "1850",
+      "venue": "Journal für die reine und angewandte Mathematik 39, 160–179",
+      "note": "Original irreducibility criterion"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley, 3rd ed., §9.4",
+      "note": "Eisenstein's criterion and Gauss's lemma, the textbook route to degree of radicals"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent gallery entry **cube-root-3-irrational** proves ∛3 ∉ ℚ by the **rational root theorem** and asks, in its open questions:

> Is there a Lean proof of Eisenstein's irreducibility criterion? Combined with the rational root theorem, this would give a cleaner algebraic proof of ∛3's irrationality via the degree argument.

This PR answers that with the **general** theorem the rational-root approach does not give. Using Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` at the prime ideal `(p) ⊆ ℤ`:

- **`irreducible_X_pow_sub_C_prime_int`** — `Xⁿ − p` is irreducible over **ℤ** for every prime `p` and `n ≥ 1`. The four Eisenstein hypotheses: leading coeff `1 ∉ (p)`; every lower coeff is `0` or `−p`, both in `(p)`; constant coeff `−p ∉ (p)²` (else `p² ∣ p`, impossible for a prime); monic ⟹ primitive.
- **`irreducible_X_pow_sub_C_prime_rat`** — the same over **ℚ**, lifted by **Gauss's lemma** (`IsPrimitive.Int.irreducible_iff_irreducible_map_cast`).
- **`irreducible_X_cubed_sub_three_int / _rat`** — `X³ − 3` is irreducible, i.e. the **minimal polynomial of ∛3**, pinning its algebraic degree at exactly 3 (strictly stronger than "irrational").
- **`irreducible_X_fifth_sub_seven_rat`, `irreducible_X_sq_sub_five_rat`** — `⁵√7` (degree 5) and `√5` (degree 2) by the identical machinery, demonstrating the technique is **uniform** where the rational-root argument is ad hoc.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ01` → `✔ Built Proofs.CubeRoot3IrrationalOQ01`, build completed successfully.
- 130 lines, 6 theorems / 0 definitions, **0 sorries, 0 axioms, no native_decide** — verified.
- Self-contained: imports Mathlib only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)