### PR TITLE
research(erdos-1100-incomplete-01): the first consecutive divisor pair is always coprime — τ⊥(n) ≥ 1

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1117,6 +1117,7 @@ import Proofs.Erdos10OQ02Popcount
 import Proofs.Erdos10PrimePlusPowers
 import Proofs.Erdos10Problem
 import Proofs.Erdos10WIP01
+import Proofs.Erdos1100Incomplete01
 import Proofs.Erdos1100OQ01Aristotle
 import Proofs.Erdos1100Problem
 import Proofs.Erdos1100ProblemAristotle

--- a/proofs/Proofs/Erdos1100Incomplete01.lean
+++ b/proofs/Proofs/Erdos1100Incomplete01.lean
@@ -1,0 +1,120 @@
+/-
+  Erdős Problem #1100: The First Consecutive Divisor Pair is Always Coprime
+  Companion to Erdos1100Problem.lean (incomplete-01)
+
+  Erdős #1100 concerns τ⊥(n) = the number of indices i for which the i-th and
+  (i+1)-th divisors of n (in increasing order 1 = d₁ < d₂ < ⋯ < d_τ(n) = n)
+  are coprime. The parent file Erdos1100Problem.lean states the deep results
+  (Erdős–Hall, Erdős–Simonovits) as axioms and ALSO axiomatizes the "trivial"
+  lower bound τ⊥(n) ≥ ω(n), commenting that a formal proof "requires intricate
+  reasoning about sorted divisor positions."
+
+  This self-contained companion proves, with 0 axioms / 0 sorries, the
+  universal weak form of that lower bound that requires only the FIRST divisor:
+
+    • `tauPerp_ge_one` : τ⊥(n) ≥ 1 for every n ≥ 2.
+
+  The key observation is that the smallest divisor is always d₁ = 1, so the
+  first consecutive pair (d₁, d₂) = (1, d₂) is automatically coprime
+  (gcd(1, ·) = 1) — no matter what d₂ is. This gives a coprime pair for free,
+  hence τ⊥(n) ≥ 1. It matches the axiomatized bound τ⊥(n) ≥ ω(n) exactly when
+  ω(n) = 1 (prime powers), where it is tight.
+
+  We also expose the coprimality of the first pair directly (`first_pair_coprime`)
+  and pin the edge case `tauPerp_one = 0` (n = 1 has a single divisor and thus no
+  consecutive pairs).
+
+  Reference: https://erdosproblems.com/1100
+-/
+
+import Mathlib
+
+namespace Erdos1100Coprime
+
+open Finset
+
+/- ## Definitions (matching Erdos1100Problem.lean) -/
+
+/-- The list of divisors of n in increasing order: 1 = d₁ < d₂ < ⋯ < d_τ(n) = n. -/
+noncomputable def divisorList (n : ℕ) : List ℕ :=
+  (Finset.filter (· ∣ n) (Finset.range (n + 1))).sort (· ≤ ·)
+
+/-- τ⊥(n): the number of indices i with gcd(dᵢ, dᵢ₊₁) = 1.
+    (Stated without the parent's `let` binding so the body unfolds cleanly.) -/
+noncomputable def tauPerp (n : ℕ) : ℕ :=
+  ((List.range ((divisorList n).length - 1)).filter
+    (fun i => Nat.gcd ((divisorList n).getD i 0) ((divisorList n).getD (i + 1) 0) = 1)).length
+
+/- ## The divisor set: 1 and n are members -/
+
+private lemma one_mem_divisorFilter (n : ℕ) (hn : 1 ≤ n) :
+    (1 : ℕ) ∈ Finset.filter (· ∣ n) (Finset.range (n + 1)) := by
+  simp only [Finset.mem_filter, Finset.mem_range]
+  exact ⟨by omega, one_dvd n⟩
+
+private lemma self_mem_divisorFilter (n : ℕ) (_hn : 1 ≤ n) :
+    n ∈ Finset.filter (· ∣ n) (Finset.range (n + 1)) := by
+  simp only [Finset.mem_filter, Finset.mem_range]
+  exact ⟨by omega, dvd_refl n⟩
+
+/- ## The first divisor is 1, and there are ≥ 2 divisors when n ≥ 2 -/
+
+/-- The first entry of the (sorted) divisor list is 1, for every n ≥ 1. -/
+private lemma divisorList_getD_zero (n : ℕ) (hn : 1 ≤ n) :
+    (divisorList n).getD 0 0 = 1 := by
+  unfold divisorList
+  have hne : (Finset.filter (· ∣ n) (Finset.range (n + 1))).Nonempty :=
+    ⟨1, one_mem_divisorFilter n hn⟩
+  have hpos : 0 < ((Finset.filter (· ∣ n) (Finset.range (n + 1))).sort (· ≤ ·)).length := by
+    rw [Finset.length_sort]; exact Finset.card_pos.mpr hne
+  rw [List.getD_eq_getElem _ _ hpos, Finset.sorted_zero_eq_min']
+  -- Goal: (filter …).min' _ = 1
+  refine le_antisymm (Finset.min'_le _ 1 (one_mem_divisorFilter n hn)) ?_
+  have hmem := Finset.min'_mem (Finset.filter (· ∣ n) (Finset.range (n + 1))) hne
+  exact Nat.pos_of_dvd_of_pos (Finset.mem_filter.mp hmem).2 (by omega)
+
+/-- A set with n ≥ 2 has at least two divisors (1 and n). -/
+private lemma divisorList_length_ge_two (n : ℕ) (hn : 2 ≤ n) :
+    2 ≤ (divisorList n).length := by
+  unfold divisorList
+  rw [Finset.length_sort]
+  have : 1 < (Finset.filter (· ∣ n) (Finset.range (n + 1))).card :=
+    Finset.one_lt_card.mpr
+      ⟨1, one_mem_divisorFilter n (by omega), n, self_mem_divisorFilter n (by omega), by omega⟩
+  omega
+
+/- ## Main results -/
+
+/-- **The first consecutive divisor pair is always coprime, so τ⊥(n) ≥ 1.**
+    Since d₁ = 1, the pair (d₁, d₂) = (1, d₂) is coprime for free. This proves
+    the universal weak form of the parent's axiomatized τ⊥(n) ≥ ω(n) bound. -/
+theorem tauPerp_ge_one (n : ℕ) (hn : 2 ≤ n) : 1 ≤ tauPerp n := by
+  unfold tauPerp
+  have h0 : (divisorList n).getD 0 0 = 1 := divisorList_getD_zero n (by omega)
+  have hlen : 2 ≤ (divisorList n).length := divisorList_length_ge_two n hn
+  -- index 0 satisfies the coprimality predicate and lies in range (length - 1)
+  have hmem : 0 ∈ (List.range ((divisorList n).length - 1)).filter
+      (fun i => Nat.gcd ((divisorList n).getD i 0) ((divisorList n).getD (i + 1) 0) = 1) := by
+    rw [List.mem_filter]
+    refine ⟨List.mem_range.mpr (by omega), ?_⟩
+    have hp : Nat.gcd ((divisorList n).getD 0 0) ((divisorList n).getD (0 + 1) 0) = 1 := by
+      rw [h0]; exact Nat.gcd_one_left _
+    simpa using hp
+  have := List.length_pos_iff.mpr (List.ne_nil_of_mem hmem)
+  omega
+
+/-- The first consecutive divisor pair, stated directly: gcd(d₁, d₂) = 1. -/
+theorem first_pair_coprime (n : ℕ) (hn : 2 ≤ n) :
+    Nat.gcd ((divisorList n).getD 0 0) ((divisorList n).getD 1 0) = 1 := by
+  rw [divisorList_getD_zero n (by omega), Nat.gcd_one_left]
+
+/-- Edge case: τ⊥(1) = 0 (a single divisor, no consecutive pairs). -/
+theorem tauPerp_one : tauPerp 1 = 0 := by
+  have hfilter : Finset.filter (· ∣ 1) (Finset.range (1 + 1)) = {1} := by decide
+  have hd : divisorList 1 = [1] := by
+    unfold divisorList; rw [hfilter]; simp
+  unfold tauPerp
+  rw [hd]
+  simp
+
+end Erdos1100Coprime

--- a/src/data/proofs/erdos-1100-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-1100-incomplete-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "erdos-1100-incomplete-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 30
+    },
+    "type": "concept",
+    "title": "Erdős #1100 and the Coprime-Consecutive-Divisor Count",
+    "content": "Erdős #1100 studies $\\tau^\\perp(n)$, the number of consecutive divisor pairs $(d_i, d_{i+1})$ of $n$ that are coprime. The parent file states the deep Erdős–Hall / Erdős–Simonovits results as axioms and ALSO axiomatizes the 'trivial' bound $\\tau^\\perp(n) \\ge \\omega(n)$, noting it 'requires intricate reasoning about sorted divisor positions.' This companion proves the universal weak form $\\tau^\\perp(n) \\ge 1$ with 0 axioms / 0 sorries.",
+    "mathContext": "Divisors are listed $1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$; $\\tau^\\perp(n) = |\\{i : \\gcd(d_i, d_{i+1}) = 1\\}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "coprime divisors",
+      "divisor function",
+      "Erdős–Hall"
+    ],
+    "prerequisites": [
+      "divisors",
+      "gcd"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-1100-incomplete-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 46
+    },
+    "type": "definition",
+    "title": "divisorList and τ⊥",
+    "content": "`divisorList n` is the sorted list of divisors of n (filter of `range (n+1)` by divisibility, then `sort`). `tauPerp n` counts indices i with $\\gcd(d_i, d_{i+1}) = 1$. Matches the parent's definitions but uses a `let`-free body so the index argument unfolds cleanly.",
+    "mathContext": "$\\mathrm{divisorList}\\,n = \\mathrm{sort}\\,\\{d \\le n : d \\mid n\\}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sort",
+      "List.filter"
+    ]
+  },
+  {
+    "id": "ann-first-divisor",
+    "proofId": "erdos-1100-incomplete-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "The First Sorted Divisor is 1",
+    "content": "Proves `(divisorList n).getD 0 0 = 1` for n ≥ 1. The 0-th sorted entry is the minimum of the divisor set (`Finset.sorted_zero_eq_min'`); that minimum is $\\le 1$ (since 1 is a divisor) and $\\ge 1$ (the smallest divisor is positive, `Nat.pos_of_dvd_of_pos`), hence equals 1. This is exactly the 'sorted divisor position' reasoning the parent flagged.",
+    "mathContext": "$d_1 = \\min'\\{d : d \\mid n\\} = 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sorted_zero_eq_min'",
+      "minimum divisor"
+    ]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "erdos-1100-incomplete-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "Main: τ⊥(n) ≥ 1 — the First Pair is Coprime",
+    "content": "Proves `tauPerp_ge_one`: τ⊥(n) ≥ 1 for n ≥ 2. Because $d_1 = 1$, the first consecutive pair $(1, d_2)$ has $\\gcd = 1$ ($\\gcd(1,\\cdot) = 1$), so index 0 lies in the filtered index list, which is therefore nonempty. The bound is tight when $\\omega(n) = 1$ (prime powers), matching the axiomatized $\\tau^\\perp(n) \\ge \\omega(n)$ there.",
+    "mathContext": "$\\gcd(d_1, d_2) = \\gcd(1, d_2) = 1 \\Rightarrow \\tau^\\perp(n) \\ge 1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "lower bound",
+      "gcd_one_left",
+      "coprime pair"
+    ]
+  },
+  {
+    "id": "ann-edge",
+    "proofId": "erdos-1100-incomplete-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 119
+    },
+    "type": "theorem",
+    "title": "first_pair_coprime and the Edge Case τ⊥(1) = 0",
+    "content": "`first_pair_coprime` states the coprimality $\\gcd(d_1, d_2) = 1$ directly. `tauPerp_one` pins the edge case: $n = 1$ has the single divisor list $[1]$, so there are no consecutive pairs and $\\tau^\\perp(1) = 0$ (computed via kernel `decide`, not `native_decide`).",
+    "mathContext": "$\\mathrm{divisorList}\\,1 = [1]$, length 1, zero consecutive pairs.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "edge case",
+      "singleton divisor list"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1100-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1100-incomplete-01/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "erdos-1100-incomplete-01",
+  "title": "Erdős #1100: The First Consecutive Divisor Pair is Always Coprime",
+  "slug": "erdos-1100-incomplete-01",
+  "description": "Proves the universal weak form of the parent's axiomatized lower bound for Erdős Problem #1100 (coprime consecutive divisors): since the smallest divisor is always d₁ = 1, the first consecutive pair (1, d₂) is automatically coprime, giving τ⊥(n) ≥ 1 for all n ≥ 2 — tight exactly when ω(n) = 1 (prime powers).",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://erdosproblems.com/1100",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1100Incomplete01.lean",
+    "tags": [
+      "number-theory",
+      "divisors",
+      "coprimality",
+      "erdos",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sorted_zero_eq_min'",
+        "description": "The 0-th entry of a sorted finset equals its minimum; identifies d₁ with min' of the divisor set",
+        "module": "Mathlib.Data.Finset.Sort"
+      },
+      {
+        "theorem": "Finset.min'_le",
+        "description": "min' s ≤ a for a ∈ s; gives min' ≤ 1 since 1 is a divisor",
+        "module": "Mathlib.Order.Finset.Lattice"
+      },
+      {
+        "theorem": "Nat.pos_of_dvd_of_pos",
+        "description": "m ∣ n → 0 < n → 0 < m; the minimal divisor is positive, hence ≥ 1",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Nat.gcd_one_left",
+        "description": "gcd(1, x) = 1; the first pair (1, d₂) is coprime for free",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Finset.one_lt_card",
+        "description": "1 < |s| ↔ two distinct elements exist; gives ≥ 2 divisors (1 and n) when n ≥ 2",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "Proved tauPerp_ge_one: τ⊥(n) ≥ 1 for every n ≥ 2, the universal weak form of the parent's axiomatized τ⊥(n) ≥ ω(n) bound",
+      "Identified the mechanism: d₁ = 1 always, so the first consecutive divisor pair (1, d₂) is coprime regardless of d₂ (gcd(1,·)=1)",
+      "Proved the supporting fact divisorList_getD_zero: the first sorted divisor is 1, via Finset.sorted_zero_eq_min' and positivity of divisors",
+      "Proved divisorList_length_ge_two (n ≥ 2 has at least the two divisors 1 and n) and the edge case tauPerp_one = 0",
+      "Self-contained: reproduces the divisorList / tauPerp definitions and avoids importing the parent's three axioms"
+    ],
+    "axiomCount": 0,
+    "lineCount": 120,
+    "assumptions": "None for the results proved here — fully verified from Mathlib with 0 axioms (only the standard propext / Classical.choice / Quot.sound; tauPerp_one uses kernel `decide`, not `native_decide`, so no Lean.ofReduceBool) and 0 sorries. The DEEP results of Erdős #1100 (Erdős–Hall, Erdős–Simonovits, the full τ⊥(n) ≥ ω(n) bound) remain axiomatized in the parent and are NOT addressed here.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1100 (Erdős–Hall, 1978) studies $\\tau^\\perp(n)$, the number of indices $i$ for which consecutive divisors $d_i, d_{i+1}$ (in the increasing list $1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$) are coprime. The deep questions — whether $\\tau^\\perp(n)/\\omega(n) \\to \\infty$ for almost all $n$, and the growth of $g(k) = \\max_{\\omega(n)=k}\\tau^\\perp(n)$ — remain open, with bounds by Erdős–Hall and Erdős–Simonovits. The basic lower bound $\\tau^\\perp(n) \\ge \\omega(n)$ is described as trivial but its formalization 'requires intricate reasoning about sorted divisor positions'; the parent file axiomatizes it.",
+    "problemStatement": "Prove, without the parent's axioms, that every n ≥ 2 has at least one coprime consecutive divisor pair, i.e. τ⊥(n) ≥ 1.",
+    "text": "Proves τ⊥(n) ≥ 1 for n ≥ 2 from the fact that d₁ = 1, with 0 axioms and 0 sorries.",
+    "proofStrategy": "The smallest divisor in the sorted list is the minimum of the divisor finset, which is 1 (it is a divisor and every divisor is ≥ 1). Hence d₁ = 1, so the first consecutive pair (d₁, d₂) = (1, d₂) has gcd 1 by `Nat.gcd_one_left`. That makes index 0 a member of the filtered index list, so the list is nonempty and τ⊥(n) ≥ 1. The first-divisor fact uses `Finset.sorted_zero_eq_min'` together with `min'_le` (≤ 1 since 1 is a divisor) and `Nat.pos_of_dvd_of_pos` (≥ 1 since the minimal divisor is positive).",
+    "keyInsights": [
+      "The smallest divisor is always $d_1 = 1$, so the first consecutive pair is coprime for free — this gives a uniform lower bound $\\tau^\\perp(n) \\ge 1$ with no case analysis on $n$",
+      "Identifying $d_1$ with $\\min'$ of the divisor set via `sorted_zero_eq_min'` is exactly the 'reasoning about sorted divisor positions' the parent flagged; it is short once the right lemma is used",
+      "The bound is tight precisely when $\\omega(n) = 1$ (prime powers), matching the axiomatized $\\tau^\\perp(n) \\ge \\omega(n)$ in that case",
+      "$\\gcd(1, x) = 1$ makes the value of $d_2$ irrelevant — only the position $d_1 = 1$ matters",
+      "Working with a `let`-free restatement of $\\tau^\\perp$ lets the body unfold cleanly for the index-membership argument"
+    ],
+    "prerequisites": [
+      "Divisors and gcd in ℕ",
+      "Finset sort and min'",
+      "List filter / membership"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Divisor List and τ⊥",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring framing the companion's scope. Reproduces divisorList (the sorted divisors of n) and tauPerp (count of coprime consecutive pairs), matching the parent but with a let-free body."
+    },
+    {
+      "id": "membership",
+      "title": "1 and n are Divisors",
+      "startLine": 48,
+      "endLine": 59,
+      "summary": "Membership lemmas: 1 and n both lie in the divisor filter of range(n+1) (for n ≥ 1).",
+      "mathContext": "$1 \\mid n$ and $n \\mid n$, and both are $< n+1$."
+    },
+    {
+      "id": "first-divisor",
+      "title": "The First Divisor is 1; at Least Two Divisors",
+      "startLine": 60,
+      "endLine": 85,
+      "summary": "Proves the 0-th sorted divisor equals 1 (via sorted_zero_eq_min', min'_le ≤ 1, and positivity ≥ 1) and that n ≥ 2 has at least two divisors.",
+      "mathContext": "$d_1 = \\min'\\{d : d \\mid n\\} = 1$; $|\\{d : d \\mid n\\}| \\ge 2$ for $n \\ge 2$."
+    },
+    {
+      "id": "main",
+      "title": "Main Results",
+      "startLine": 86,
+      "endLine": 120,
+      "summary": "**MAIN THEOREM** tauPerp_ge_one: τ⊥(n) ≥ 1 for n ≥ 2 — index 0 satisfies the coprimality predicate because d₁ = 1. Plus first_pair_coprime (gcd(d₁,d₂) = 1) and the edge case tauPerp_one = 0.",
+      "mathContext": "Since $\\gcd(d_1, d_2) = \\gcd(1, d_2) = 1$, the first index is counted, so $\\tau^\\perp(n) \\ge 1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries) proof that every n ≥ 2 has at least one coprime consecutive divisor pair, τ⊥(n) ≥ 1, because the smallest divisor is always d₁ = 1. This is the universal weak form of the parent's axiomatized τ⊥(n) ≥ ω(n) bound, tight when ω(n) = 1.",
+    "implications": "The 'intricate reasoning about sorted divisor positions' the parent cited reduces, for the first position, to identifying d₁ with the minimum divisor (= 1) via Finset.sorted_zero_eq_min'. The deep Erdős–Hall / Erdős–Simonovits results and the full ω(n) lower bound remain axiomatized in the parent and out of scope here.",
+    "openQuestions": [
+      "Can the full bound τ⊥(n) ≥ ω(n) be de-axiomatized by locating one coprime consecutive pair per prime factor?",
+      "Does τ⊥(n)/ω(n) → ∞ for almost all n? (Erdős Question 1, open)",
+      "What is g(k) = max over squarefree n with ω(n) = k of τ⊥(n)? (Erdős–Simonovits bounds, open)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1100",
+      "relationship": "parent",
+      "description": "Parent formalization stating the deep Erdős–Hall / Erdős–Simonovits results and axiomatizing the τ⊥(n) ≥ ω(n) lower bound this companion partially discharges"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1100Coprime",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1100Incomplete01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Erdős Problem #1100 studies $\tau^\perp(n)$, the number of *coprime consecutive divisor pairs* of $n$ (divisors listed $1 = d_1 < d_2 < \cdots < d_{\tau(n)} = n$). The parent `Erdos1100Problem.lean` states the deep **Erdős–Hall** and **Erdős–Simonovits** results as `axiom`s and *also* axiomatizes the "trivial" lower bound $\tau^\perp(n) \ge \omega(n)$, commenting that a formal proof "requires intricate reasoning about sorted divisor positions."

This self-contained companion proves the **universal weak form** of that bound with **0 axioms / 0 sorries**:

- **`tauPerp_ge_one`** — $\tau^\perp(n) \ge 1$ for every $n \ge 2$.

### Why it's true

The smallest divisor is always $d_1 = 1$, so the first consecutive pair $(d_1, d_2) = (1, d_2)$ is coprime *for free* ($\gcd(1, \cdot) = 1$) — no matter what $d_2$ is. Identifying $d_1$ with $\min'$ of the divisor set via `Finset.sorted_zero_eq_min'` is precisely the "sorted divisor position" reasoning the parent flagged; it is short with the right lemma. The bound is **tight** exactly when $\omega(n) = 1$ (prime powers), matching the axiomatized $\tau^\perp(n) \ge \omega(n)$ there.

Also included: `first_pair_coprime` ($\gcd(d_1, d_2) = 1$) and the edge case `tauPerp_one = 0`.

## Verification

- 3 theorems / 2 defs (+ 4 supporting lemmas), 120 lines, self-contained (`import Mathlib`; reproduces the divisor definitions to avoid importing the parent's 3 axioms).
- Builds clean under Lean 4.26.0 via `docker-build.sh`.
- **0-axiom**: `tauPerp_one` uses kernel `decide` (not `native_decide`), so `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`.

The deep Erdős–Hall / Erdős–Simonovits results and the full $\omega(n)$ lower bound remain axiomatized in the parent and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)