### PR TITLE
research(angle-trisection-oq-01-oq-04): Gauss–Wantzel structural tools — 0-axiom polygon classification beyond n=20

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -102,6 +102,7 @@ import Proofs.AngleTrisectionCos20GalOQ03
 import Proofs.AngleTrisectionCos20GalOQ03OQ01
 import Proofs.AngleTrisectionEmbedding
 import Proofs.AngleTrisectionOQ01
+import Proofs.AngleTrisectionOQ01OQ04
 import Proofs.AngleTrisectionOQ02
 import Proofs.AngleTrisectionOQ02OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01

--- a/proofs/Proofs/AngleTrisectionOQ01OQ04.lean
+++ b/proofs/Proofs/AngleTrisectionOQ01OQ04.lean
@@ -1,0 +1,172 @@
+/-
+  Gauss–Wantzel: Structural Tools for Regular Polygon Constructibility
+  Open Question: angle-trisection-oq-01-oq-04
+
+  The parent AngleTrisectionOQ01.lean classifies the constructible regular
+  n-gons for 3 ≤ n ≤ 20 using the criterion
+
+      RegularNgonConstructible n  ⇔  n ≥ 3 ∧ φ(n) is a power of 2,
+
+  but it discharges every individual case with `native_decide` (which depends
+  on `Lean.ofReduceBool`). Its fourth open question asks to extend the
+  classification beyond n = 20 toward the general Gauss–Wantzel theorem:
+
+      a regular n-gon is constructible  ⇔  n = 2^a · p₁ ⋯ pₘ
+      with the pᵢ distinct Fermat primes.
+
+  This file provides the STRUCTURAL machinery for that extension, proved with
+  0 axioms / 0 sorries (no `native_decide`):
+
+    • `totient_two_pow_isPow`  : φ(2^a) is a power of 2.
+    • `totient_mul_isPow`      : coprime factors with power-of-2 totients
+                                  multiply to a power-of-2 totient
+                                  (the multiplicative engine of Gauss–Wantzel).
+    • `prime_constructible_iff`: for a prime p, the p-gon is constructible iff
+                                  p − 1 is a power of 2 (since φ(p) = p − 1).
+    • `fermatPrime_constructible` : every Fermat prime gives a constructible
+                                  polygon.
+    • `twoPow_constructible`   : every 2^a-gon (a ≥ 2) is constructible.
+
+  Using only these (no per-case `native_decide`), we extend the explicit
+  classification with new constructible n-gons (24, 32, 34, 40, 48, 51, 60,
+  64, 68, 80, 85, 96, …) and new non-constructible ones (21, 28, 36, …).
+
+  Reference: https://en.wikipedia.org/wiki/Constructible_polygon
+-/
+
+import Mathlib
+
+namespace AngleTrisectionGaussWantzel
+
+/-- A regular n-gon is constructible iff n ≥ 3 and φ(n) is a power of 2
+    (the parent's definition, reproduced for self-containment). -/
+def RegularNgonConstructible (n : ℕ) : Prop :=
+  n ≥ 3 ∧ ∃ k : ℕ, Nat.totient n = 2 ^ k
+
+/- ## Part I: Structural tools -/
+
+/-- φ(2^a) is a power of 2 (for a ≥ 1): indeed φ(2^a) = 2^(a-1). -/
+theorem totient_two_pow_isPow (a : ℕ) (ha : 1 ≤ a) :
+    ∃ k : ℕ, Nat.totient (2 ^ a) = 2 ^ k := by
+  refine ⟨a - 1, ?_⟩
+  rw [Nat.totient_prime_pow Nat.prime_two ha]
+  simp
+
+/-- **Multiplicative engine.** If m and n are coprime and each has a power-of-2
+    totient, then so does m·n. This is what lets Gauss–Wantzel build up
+    n = 2^a · (distinct Fermat primes) one coprime factor at a time. -/
+theorem totient_mul_isPow {m n : ℕ} (h : Nat.Coprime m n)
+    (hm : ∃ k : ℕ, Nat.totient m = 2 ^ k) (hn : ∃ j : ℕ, Nat.totient n = 2 ^ j) :
+    ∃ i : ℕ, Nat.totient (m * n) = 2 ^ i := by
+  obtain ⟨k, hk⟩ := hm
+  obtain ⟨j, hj⟩ := hn
+  exact ⟨k + j, by rw [Nat.totient_mul h, hk, hj, pow_add]⟩
+
+/-- A 2^a-gon is constructible for a ≥ 2 (so that 2^a ≥ 4 ≥ 3). -/
+theorem twoPow_constructible (a : ℕ) (ha : 2 ≤ a) :
+    RegularNgonConstructible (2 ^ a) := by
+  refine ⟨?_, totient_two_pow_isPow a (by omega)⟩
+  calc 3 ≤ 2 ^ 2 := by norm_num
+    _ ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) ha
+
+/- ## Part II: Prime and Fermat-prime criteria -/
+
+/-- For a prime p ≥ 3, the regular p-gon is constructible iff p − 1 is a power
+    of 2. (Equality φ(p) = p − 1 turns the totient criterion into this form.) -/
+theorem prime_constructible_iff {p : ℕ} (hp : Nat.Prime p) (hp3 : 3 ≤ p) :
+    RegularNgonConstructible p ↔ ∃ k : ℕ, p - 1 = 2 ^ k := by
+  unfold RegularNgonConstructible
+  rw [Nat.totient_prime hp]
+  exact ⟨fun h => h.2, fun h => ⟨hp3, h⟩⟩
+
+/-- Every Fermat prime p = 2^(2^k) + 1 yields a constructible polygon:
+    φ(p) = p − 1 = 2^(2^k) is a power of 2. -/
+theorem fermatPrime_constructible {p : ℕ} (hp : Nat.Prime p) (k : ℕ)
+    (hpk : p = 2 ^ (2 ^ k) + 1) : RegularNgonConstructible p := by
+  have h2 : 2 ≤ 2 ^ (2 ^ k) :=
+    calc 2 = 2 ^ 1 := by norm_num
+      _ ≤ 2 ^ (2 ^ k) := Nat.pow_le_pow_right (by norm_num) Nat.one_le_two_pow
+  refine ⟨by omega, 2 ^ k, ?_⟩
+  rw [Nat.totient_prime hp, hpk, Nat.add_sub_cancel]
+
+/-- A regular n-gon is NOT constructible if an odd prime divides φ(n). -/
+theorem not_constructible_of_odd_prime_dvd_totient (n p : ℕ) (hp : Nat.Prime p)
+    (hodd : p ≠ 2) (hdvd : p ∣ Nat.totient n) : ¬ RegularNgonConstructible n := by
+  rintro ⟨_, k, hk⟩
+  rw [hk] at hdvd
+  exact hodd ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hdvd))
+
+/- ## Part III: New constructible n-gons (21 ≤ n ≤ 100), all 0-axiom -/
+
+/-- Helper: 2^a · p constructible when p is an odd prime with power-of-2 totient. -/
+private theorem twoPow_mul_constructible (a p : ℕ) (ha : 1 ≤ a) (hge : 3 ≤ 2 ^ a * p)
+    (hcop : Nat.Coprime (2 ^ a) p) (hp : ∃ k, Nat.totient p = 2 ^ k) :
+    RegularNgonConstructible (2 ^ a * p) :=
+  ⟨hge, totient_mul_isPow hcop (totient_two_pow_isPow a ha) hp⟩
+
+theorem constructible_24 : RegularNgonConstructible 24 :=
+  twoPow_mul_constructible 3 3 (by norm_num) (by norm_num) (by decide) ⟨1, by decide⟩
+
+theorem constructible_32 : RegularNgonConstructible 32 := twoPow_constructible 5 (by norm_num)
+
+theorem constructible_34 : RegularNgonConstructible 34 :=
+  twoPow_mul_constructible 1 17 (by norm_num) (by norm_num) (by decide) ⟨4, by decide⟩
+
+theorem constructible_40 : RegularNgonConstructible 40 :=
+  twoPow_mul_constructible 3 5 (by norm_num) (by norm_num) (by decide) ⟨2, by decide⟩
+
+theorem constructible_48 : RegularNgonConstructible 48 :=
+  twoPow_mul_constructible 4 3 (by norm_num) (by norm_num) (by decide) ⟨1, by decide⟩
+
+theorem constructible_64 : RegularNgonConstructible 64 := twoPow_constructible 6 (by norm_num)
+
+theorem constructible_68 : RegularNgonConstructible 68 :=
+  twoPow_mul_constructible 2 17 (by norm_num) (by norm_num) (by decide) ⟨4, by decide⟩
+
+theorem constructible_80 : RegularNgonConstructible 80 :=
+  twoPow_mul_constructible 4 5 (by norm_num) (by norm_num) (by decide) ⟨2, by decide⟩
+
+theorem constructible_96 : RegularNgonConstructible 96 :=
+  twoPow_mul_constructible 5 3 (by norm_num) (by norm_num) (by decide) ⟨1, by decide⟩
+
+/-- 51 = 3 · 17, a product of two distinct Fermat primes. -/
+theorem constructible_51 : RegularNgonConstructible 51 :=
+  ⟨by norm_num, totient_mul_isPow (m := 3) (n := 17) (by decide) ⟨1, by decide⟩ ⟨4, by decide⟩⟩
+
+/-- 85 = 5 · 17, a product of two distinct Fermat primes. -/
+theorem constructible_85 : RegularNgonConstructible 85 :=
+  ⟨by norm_num, totient_mul_isPow (m := 5) (n := 17) (by decide) ⟨2, by decide⟩ ⟨4, by decide⟩⟩
+
+/-- 60 = 4 · 15 = 2² · 3 · 5, the parent's largest entry × 3. -/
+theorem constructible_60 : RegularNgonConstructible 60 :=
+  twoPow_mul_constructible 2 15 (by norm_num) (by norm_num) (by decide)
+    (totient_mul_isPow (m := 3) (n := 5) (by decide) ⟨1, by decide⟩ ⟨2, by decide⟩)
+
+/- ## Part IV: New non-constructible n-gons -/
+
+/-- Helper: a·b is not constructible if an odd prime p divides φ(b)
+    (and a, b are coprime), since then p ∣ φ(a·b). -/
+private theorem not_constructible_mul (a b p : ℕ) (hp : Nat.Prime p) (hodd : p ≠ 2)
+    (hcop : Nat.Coprime a b) (hdvd : p ∣ Nat.totient b) :
+    ¬ RegularNgonConstructible (a * b) := by
+  apply not_constructible_of_odd_prime_dvd_totient (a * b) p hp hodd
+  rw [Nat.totient_mul hcop]
+  exact hdvd.mul_left _
+
+/-- 21 = 3 · 7: φ(7) = 6 is divisible by 3. -/
+theorem not_constructible_21 : ¬ RegularNgonConstructible 21 :=
+  not_constructible_mul 3 7 3 (by decide) (by decide) (by decide) (by decide)
+
+/-- 28 = 4 · 7: φ(7) = 6 is divisible by 3. -/
+theorem not_constructible_28 : ¬ RegularNgonConstructible 28 :=
+  not_constructible_mul 4 7 3 (by decide) (by decide) (by decide) (by decide)
+
+/-- 36 = 4 · 9: φ(9) = 6 is divisible by 3. -/
+theorem not_constructible_36 : ¬ RegularNgonConstructible 36 :=
+  not_constructible_mul 4 9 3 (by decide) (by decide) (by decide) (by decide)
+
+/-- 100 = 4 · 25: φ(25) = 20 is divisible by 5. -/
+theorem not_constructible_100 : ¬ RegularNgonConstructible 100 :=
+  not_constructible_mul 4 25 5 (by decide) (by decide) (by decide) (by decide)
+
+end AngleTrisectionGaussWantzel

--- a/src/data/proofs/angle-trisection-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04/annotations.json
@@ -1,0 +1,108 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "angle-trisection-oq-01-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Extending the Gauss–Wantzel Classification (0-axiom)",
+    "content": "The parent classifies constructible regular n-gons for n ≤ 20 using `native_decide` (which depends on `Lean.ofReduceBool`). This file provides the structural machinery to extend that classification toward the general Gauss–Wantzel theorem — a regular n-gon is constructible iff n = 2^a·(distinct Fermat primes) — proved with 0 axioms and NO native_decide.",
+    "mathContext": "Constructibility ⇔ φ(n) is a power of 2, where φ is Euler's totient.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gauss–Wantzel theorem",
+      "Euler totient",
+      "Fermat primes"
+    ],
+    "prerequisites": [
+      "Euler totient",
+      "constructibility"
+    ]
+  },
+  {
+    "id": "ann-totient-tools",
+    "proofId": "angle-trisection-oq-01-oq-04",
+    "range": {
+      "startLine": 49,
+      "endLine": 70
+    },
+    "type": "theorem",
+    "title": "Power-of-2 Totients are Closed Under Coprime Products",
+    "content": "`totient_two_pow_isPow`: φ(2^a) = 2^(a-1) is a power of 2. `totient_mul_isPow`: if m, n are coprime and φ(m), φ(n) are powers of 2, then so is φ(mn) (via Nat.totient_mul and pow_add). This is the multiplicative engine that assembles n = 2^a·(distinct Fermat primes) one coprime factor at a time.",
+    "mathContext": "φ(mn) = φ(m)φ(n) = 2^k·2^j = 2^{k+j} for coprime m, n.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "totient multiplicativity",
+      "coprimality"
+    ]
+  },
+  {
+    "id": "ann-twopow",
+    "proofId": "angle-trisection-oq-01-oq-04",
+    "range": {
+      "startLine": 66,
+      "endLine": 71
+    },
+    "type": "theorem",
+    "title": "Every 2^a-gon is Constructible",
+    "content": "`twoPow_constructible`: for a ≥ 2 the regular 2^a-gon is constructible, since φ(2^a) = 2^(a-1) is a power of 2 and 2^a ≥ 4 ≥ 3.",
+    "mathContext": "The doubling sequence 4, 8, 16, 32, 64, … of constructible polygons.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "powers of two"
+    ]
+  },
+  {
+    "id": "ann-prime-criteria",
+    "proofId": "angle-trisection-oq-01-oq-04",
+    "range": {
+      "startLine": 76,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "Prime and Fermat-Prime Criteria",
+    "content": "`prime_constructible_iff`: for prime p ≥ 3, the p-gon is constructible iff p−1 is a power of 2 (because φ(p) = p−1). `fermatPrime_constructible`: every Fermat prime p = 2^(2^k)+1 gives a constructible polygon, since φ(p) = 2^(2^k).",
+    "mathContext": "φ(p) = p − 1, so constructibility ⇔ p − 1 = 2^m ⇔ p is a Fermat prime.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Fermat primes",
+      "totient of a prime"
+    ]
+  },
+  {
+    "id": "ann-nonconstructible-criterion",
+    "proofId": "angle-trisection-oq-01-oq-04",
+    "range": {
+      "startLine": 93,
+      "endLine": 97
+    },
+    "type": "theorem",
+    "title": "Odd Prime Factor of φ(n) ⇒ Not Constructible",
+    "content": "`not_constructible_of_odd_prime_dvd_totient`: if an odd prime p divides φ(n), the n-gon is not constructible — otherwise p would divide 2^k, forcing p = 2 (Nat.prime_dvd_prime_iff_eq), a contradiction.",
+    "mathContext": "An odd prime cannot divide any power of 2.",
+    "significance": "key",
+    "relatedConcepts": [
+      "non-constructibility",
+      "prime divisibility"
+    ]
+  },
+  {
+    "id": "ann-entries",
+    "proofId": "angle-trisection-oq-01-oq-04",
+    "range": {
+      "startLine": 99,
+      "endLine": 172
+    },
+    "type": "theorem",
+    "title": "New Polygon Entries Beyond n = 20",
+    "content": "Twelve new constructible n-gons (24, 32, 34, 40, 48, 51, 60, 64, 68, 80, 85, 96 — including the two-Fermat-prime products 51 = 3·17 and 85 = 5·17) and four new non-constructible ones (21, 28, 36, 100), all proved 0-axiom via the structural lemmas and kernel `decide` on small component totients — no native_decide.",
+    "mathContext": "e.g. φ(96) = φ(32)φ(3) = 16·2 = 32 = 2^5; φ(100) = 40, divisible by 5.",
+    "significance": "key",
+    "relatedConcepts": [
+      "constructible polygons",
+      "explicit classification"
+    ]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-01-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "angle-trisection-oq-01-oq-04",
+  "title": "Gauss–Wantzel: Structural Tools for Polygon Constructibility",
+  "slug": "angle-trisection-oq-01-oq-04",
+  "description": "Extends the parent's regular-polygon classification (n ≤ 20, proved by native_decide) toward the general Gauss–Wantzel theorem, with 0 axioms (no native_decide): φ(2^a) and coprime-product totients are powers of 2, the p-gon is constructible iff p−1 is a power of 2, Fermat primes give constructible polygons, and new explicit entries (24,32,34,40,48,51,60,64,68,80,85,96 constructible; 21,28,36,100 not).",
+  "meta": {
+    "author": "Carl Friedrich Gauss / Pierre Wantzel",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Constructible_polygon",
+    "date": "1837",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ01OQ04.lean",
+    "tags": [
+      "constructibility",
+      "gauss-wantzel",
+      "euler-totient",
+      "fermat-primes",
+      "number-theory",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_mul",
+        "description": "φ(m·n) = φ(m)·φ(n) for coprime m, n — the multiplicative engine of Gauss–Wantzel",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_prime_pow",
+        "description": "φ(p^n) = p^(n-1)·(p-1); specialized to φ(2^a) = 2^(a-1)",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_prime",
+        "description": "φ(p) = p-1 for prime p; turns the totient criterion into 'p-1 is a power of 2'",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.prime_dvd_prime_iff_eq",
+        "description": "p ∣ q ↔ p = q for primes; gives the contradiction when an odd prime divides 2^k",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_of_dvd_pow",
+        "description": "p ∣ a^n → p ∣ a; reduces p ∣ 2^k to p ∣ 2",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "totient_mul_isPow: coprime factors with power-of-2 totients combine to a power-of-2 totient — the multiplicative core of the Gauss–Wantzel characterization n = 2^a·(distinct Fermat primes)",
+      "totient_two_pow_isPow and twoPow_constructible: every 2^a-gon (a ≥ 2) is constructible, proved structurally (φ(2^a) = 2^(a-1))",
+      "prime_constructible_iff: for prime p, the p-gon is constructible iff p−1 is a power of 2 (φ(p) = p−1)",
+      "fermatPrime_constructible: every Fermat prime 2^(2^k)+1 yields a constructible polygon",
+      "Extended the explicit classification beyond the parent's n ≤ 20 (12 new constructible n-gons up to 96 and 4 new non-constructible ones up to 100), all 0-axiom — replacing the parent's native_decide approach with structural totient lemmas"
+    ],
+    "axiomCount": 0,
+    "lineCount": 172,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries. Crucially, no native_decide is used: small totients are computed with kernel `decide` and the general facts via structural totient lemmas, so this entry does NOT depend on Lean.ofReduceBool (unlike the parent). The full Gauss–Wantzel equivalence (constructible ⇔ n = 2^a·distinct Fermat primes) as a single biconditional, and the parent's 3 geometric axioms, remain out of scope.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 24,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Gauss showed (1796, published in Disquisitiones Arithmeticae 1801) that the regular 17-gon is constructible, and stated that a regular n-gon is constructible exactly when n = 2^a·p₁⋯pₘ with the pᵢ distinct Fermat primes; Pierre Wantzel (1837) supplied the necessity proof. The criterion is equivalent to φ(n) being a power of 2, where φ is Euler's totient. The known Fermat primes are 3, 5, 17, 257, 65537; whether any others exist is a famous open problem. The parent file verifies the n ≤ 20 cases with native_decide; this entry develops the structural machinery to go further without trusting the compiler.",
+    "problemStatement": "Extend the regular-polygon classification beyond n = 20 toward the general Gauss–Wantzel characterization n = 2^a·(distinct Fermat primes).",
+    "text": "Provides the 0-axiom structural tools (totient multiplicativity, prime/Fermat criteria) and new explicit polygon entries.",
+    "proofStrategy": "Everything reduces to 'φ(n) is a power of 2'. φ(2^a) = 2^(a-1) via Nat.totient_prime_pow; coprime products multiply totients (Nat.totient_mul), so power-of-2 totients are closed under coprime products (pow_add). For a prime p, φ(p) = p−1, giving the 'p−1 is a power of 2' criterion and the Fermat-prime corollary. Non-constructibility follows when an odd prime divides φ(n): then it would divide 2^k, contradicting Nat.prime_dvd_prime_iff_eq. Explicit entries combine these lemmas with kernel `decide` on small component totients (≤ 25), avoiding native_decide entirely.",
+    "keyInsights": [
+      "Power-of-2 totients are closed under coprime multiplication — this single lemma (totient_mul_isPow) is the engine that assembles n = 2^a·(distinct Fermat primes)",
+      "φ(p) = p−1 collapses the prime case to a one-line criterion: the p-gon is constructible iff p−1 is a power of 2 (i.e. p is a Fermat prime)",
+      "Replacing native_decide with structural totient lemmas removes the Lean.ofReduceBool dependency, so the extended classification is genuinely axiom-free",
+      "Non-constructibility is detected by a single odd prime factor of φ(n) — an odd prime cannot divide 2^k",
+      "Supplying implicit m, n explicitly to totient_mul_isPow is necessary: the product n = m·n does not determine the factors, so they cannot be inferred"
+    ],
+    "prerequisites": [
+      "Euler's totient function and its multiplicativity",
+      "Fermat primes",
+      "Compass-and-straightedge constructibility"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "The Constructibility Criterion",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring framing OQ#4. Reproduces RegularNgonConstructible n := n ≥ 3 ∧ φ(n) is a power of 2 (the parent's totient criterion)."
+    },
+    {
+      "id": "structural-tools",
+      "title": "Structural Tools",
+      "startLine": 46,
+      "endLine": 71,
+      "summary": "φ(2^a) is a power of 2; coprime factors with power-of-2 totients multiply to a power-of-2 totient (the multiplicative engine); every 2^a-gon (a ≥ 2) is constructible.",
+      "mathContext": "φ(2^a) = 2^(a-1); φ(mn) = φ(m)φ(n) = 2^k·2^j = 2^(k+j) for coprime m, n."
+    },
+    {
+      "id": "prime-criteria",
+      "title": "Prime and Fermat-Prime Criteria",
+      "startLine": 72,
+      "endLine": 98,
+      "summary": "For prime p, the p-gon is constructible iff p−1 is a power of 2 (φ(p) = p−1); every Fermat prime gives a constructible polygon; non-constructibility from an odd prime factor of φ(n).",
+      "mathContext": "φ(p) = p−1, so constructible ⇔ p−1 = 2^k ⇔ p Fermat prime."
+    },
+    {
+      "id": "constructible-entries",
+      "title": "New Constructible n-gons (21 ≤ n ≤ 96)",
+      "startLine": 99,
+      "endLine": 144,
+      "summary": "12 new constructible polygons beyond the parent's n ≤ 20: 24, 32, 34, 40, 48, 51, 60, 64, 68, 80, 85, 96 — including the two-Fermat-prime products 51 = 3·17 and 85 = 5·17.",
+      "mathContext": "Each n = 2^a·(Fermat primes); e.g. φ(96) = φ(32)φ(3) = 16·2 = 32 = 2^5."
+    },
+    {
+      "id": "nonconstructible-entries",
+      "title": "New Non-constructible n-gons",
+      "startLine": 145,
+      "endLine": 172,
+      "summary": "New non-constructible polygons 21, 28, 36, 100, each detected by an odd prime dividing φ(n).",
+      "mathContext": "φ(21) = 12 (3 ∣ 12), φ(100) = 40 (5 ∣ 40), etc."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) structural toolkit for the Gauss–Wantzel classification of constructible regular polygons, extending the parent's n ≤ 20 table with 12 new constructible and 4 new non-constructible entries up to n = 100. The key lemma is that power-of-2 totients are closed under coprime multiplication.",
+    "implications": "These tools assemble the constructible n = 2^a·(distinct Fermat primes) one coprime factor at a time, and reduce the prime case to 'p−1 is a power of 2'. Replacing native_decide with structural lemmas makes the extended classification genuinely axiom-free.",
+    "openQuestions": [
+      "Package the tools into the single Gauss–Wantzel biconditional: constructible ⇔ n = 2^a · (product of distinct Fermat primes).",
+      "Prove that 2^m + 1 prime forces m to be a power of 2 (so 'p−1 a power of 2' ⇔ 'p a Fermat prime' for primes p).",
+      "Are there infinitely many Fermat primes? (Open — bounds the supply of odd prime factors allowed.)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-01",
+      "relationship": "parent",
+      "description": "Parent classifying constructible n-gons for n ≤ 20 via native_decide; this entry answers its fourth open question (extend the classification / general Gauss–Wantzel) with 0-axiom structural tools"
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "ancestor",
+      "description": "Root problem: impossibility of angle trisection by compass and straightedge"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "AngleTrisectionGaussWantzel",
+    "lineCount": 172,
+    "axiomCount": 0,
+    "theoremCount": 24,
+    "definitionCount": 1,
+    "path": "Proofs/AngleTrisectionOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent `AngleTrisectionOQ01.lean` classifies constructible regular $n$-gons for $3 \le n \le 20$ via the criterion **$\phi(n)$ is a power of 2**, but discharges every case with `native_decide` (which depends on `Lean.ofReduceBool`). Its **fourth open question** asks to extend the classification beyond $n = 20$ toward the general Gauss–Wantzel theorem:

> a regular $n$-gon is constructible $\iff n = 2^a \cdot p_1 \cdots p_m$ with the $p_i$ distinct Fermat primes.

This file supplies the **structural machinery** for that extension, with **0 axioms / 0 sorries and no `native_decide`**:

- **`totient_two_pow_isPow`** — $\phi(2^a)$ is a power of 2.
- **`totient_mul_isPow`** — coprime factors with power-of-2 totients multiply to a power-of-2 totient (via `Nat.totient_mul` + `pow_add`). This is the *multiplicative engine* of Gauss–Wantzel.
- **`twoPow_constructible`** — every $2^a$-gon ($a \ge 2$) is constructible.
- **`prime_constructible_iff`** — for prime $p$, the $p$-gon is constructible $\iff p-1$ is a power of 2 (since $\phi(p) = p-1$).
- **`fermatPrime_constructible`** — every Fermat prime $2^{2^k}+1$ gives a constructible polygon.
- **`not_constructible_of_odd_prime_dvd_totient`** — an odd prime dividing $\phi(n)$ rules out constructibility.

Using only these (kernel `decide` on small component totients $\le 25$), the explicit classification is extended with **12 new constructible $n$-gons** (24, 32, 34, 40, 48, **51 = 3·17**, 60, 64, 68, 80, **85 = 5·17**, 96) and **4 new non-constructible ones** (21, 28, 36, 100).

## Verification

- 24 theorems / 1 def, 172 lines, self-contained (`import Mathlib`).
- Builds clean under Lean 4.26.0 via `docker-build.sh`.
- **0-axiom**: `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` — crucially **no `Lean.ofReduceBool`**, unlike the parent's `native_decide` approach.

The full Gauss–Wantzel biconditional as a single statement, and the parent's 3 geometric axioms, remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)