### PR TITLE
research(binomial-theorem-oq-02-oq-02-oq-02): hockey-stick identity via sum_range_succ + Pascal, and figurate numbers

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -334,6 +334,7 @@ import Proofs.BinomialTheoremOQ02OQ01OQ03
 import Proofs.BinomialTheoremOQ02OQ01OQ04
 import Proofs.BinomialTheoremOQ02OQ02
 import Proofs.BinomialTheoremOQ02OQ02OQ01
+import Proofs.BinomialTheoremOQ02OQ02OQ02
 import Proofs.BinomialTheoremOQ02OQ03
 import Proofs.BinomialTheoremOQ02OQ04
 import Proofs.BinomialTheoremOQ03

--- a/proofs/Proofs/BinomialTheoremOQ02OQ02OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ02OQ02OQ02.lean
@@ -1,0 +1,84 @@
+/-
+  The Hockey-Stick (Zhu Shijie) Identity and Figurate Numbers
+  Open Question: binomial-theorem-oq-02-oq-02-oq-02
+
+  The parent BinomialTheoremOQ02OQ02.lean proves Vandermonde's convolution
+  identity. Its second open question asks:
+
+    "The hockey-stick identity C(r,r) + C(r+1,r) + … + C(n,r) = C(n+1,r+1)
+     follows from Vandermonde by a telescoping argument. Can it be derived
+     from the existing formalization using `Finset.sum_range_succ` directly?"
+
+  This file answers that directly. It gives a fully self-contained,
+  `Finset.sum_range_succ`-based induction proof of the hockey-stick identity
+  (the diagonal-sum form ∑_{i≤n} C(r+i, r) = C(r+n+1, r+1)), relates it to
+  Mathlib's `Nat.sum_Icc_choose`, and derives the classical figurate-number
+  consequences — all with 0 axioms / 0 sorries:
+
+    • `hockeyStick`       : ∑_{i ∈ range (n+1)} C(r+i, r) = C(r+n+1, r+1)
+                            (independent induction via sum_range_succ + Pascal).
+    • `hockeyStick_Icc`   : ∑_{m ∈ Icc r n} C(m, r) = C(n+1, r+1) (Mathlib form).
+    • `sum_Icc_id`        : 1 + 2 + … + n = C(n+1, 2)   (Gauss / triangular).
+    • `gauss_sum`         : 1 + 2 + … + n = n(n+1)/2.
+    • `sum_Icc_triangular`: ∑_{m≤n} C(m, 2) = C(n+1, 3) (tetrahedral numbers).
+
+  Reference: https://en.wikipedia.org/wiki/Hockey-stick_identity
+-/
+
+import Mathlib
+
+namespace BinomialHockeyStick
+
+open Finset
+
+/- ## Part I: The hockey-stick identity, proved by induction -/
+
+/-- **Hockey-stick identity (diagonal form).**
+    ∑_{i=0}^{n} C(r+i, r) = C(r+n+1, r+1).
+
+    Proved directly by induction on n with `Finset.sum_range_succ`, peeling off
+    the top term and closing each step with Pascal's rule
+    `Nat.choose_succ_succ` — the telescoping the parent's OQ#2 describes. -/
+theorem hockeyStick (r n : ℕ) :
+    ∑ i ∈ range (n + 1), Nat.choose (r + i) r = Nat.choose (r + n + 1) (r + 1) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    -- Peel off the top term, apply the IH, then close with Pascal's rule.
+    rw [Finset.sum_range_succ, ih]
+    have e1 : r + (m + 1) = r + m + 1 := by ring
+    rw [e1, Nat.choose_succ_succ (r + m + 1) r, Nat.add_comm]
+
+/- ## Part II: Connection to Mathlib's `Icc` form -/
+
+/-- **Hockey-stick identity (interval form).**
+    ∑_{m=r}^{n} C(m, r) = C(n+1, r+1). This is Mathlib's `Nat.sum_Icc_choose`,
+    restated; together with `hockeyStick` it gives both standard phrasings. -/
+theorem hockeyStick_Icc (n r : ℕ) :
+    ∑ m ∈ Icc r n, Nat.choose m r = Nat.choose (n + 1) (r + 1) :=
+  Nat.sum_Icc_choose n r
+
+/- ## Part III: Figurate-number consequences -/
+
+/-- **Gauss's sum, as a binomial coefficient.** 1 + 2 + … + n = C(n+1, 2).
+    Specialize the hockey-stick to r = 1 and use C(m, 1) = m. -/
+theorem sum_Icc_id (n : ℕ) :
+    ∑ m ∈ Icc 1 n, m = Nat.choose (n + 1) 2 := by
+  rw [← hockeyStick_Icc n 1]
+  exact Finset.sum_congr rfl (fun m _ => (Nat.choose_one_right m).symm)
+
+/-- **Gauss's sum, closed form.** 1 + 2 + … + n = n(n+1)/2. -/
+theorem gauss_sum (n : ℕ) :
+    ∑ m ∈ Icc 1 n, m = n * (n + 1) / 2 := by
+  rw [sum_Icc_id, Nat.choose_two_right, Nat.add_sub_cancel, Nat.mul_comm (n + 1) n]
+
+/-- **Tetrahedral numbers.** ∑_{m=2}^{n} C(m, 2) = C(n+1, 3): the partial sums
+    of the triangular numbers are the tetrahedral numbers. -/
+theorem sum_Icc_triangular (n : ℕ) :
+    ∑ m ∈ Icc 2 n, Nat.choose m 2 = Nat.choose (n + 1) 3 :=
+  Nat.sum_Icc_choose n 2
+
+/-- Sanity check: 1 + 2 + 3 + 4 + 5 = 15 = C(6, 2). -/
+example : ∑ m ∈ Icc 1 5, m = 15 := by decide
+
+end BinomialHockeyStick

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 28
+    },
+    "type": "concept",
+    "title": "The Hockey-Stick Identity (OQ#2)",
+    "content": "The parent proves Vandermonde's identity and asks whether the hockey-stick identity C(r,r)+…+C(n,r) = C(n+1,r+1) can be derived using Finset.sum_range_succ and a telescoping argument. This file does exactly that with an independent induction proof, relates it to Mathlib's interval form, and derives the classical figurate-number sums — all 0 axioms / 0 sorries.",
+    "mathContext": "Summing a diagonal of Pascal's triangle gives the entry just past the diagonal's end.",
+    "significance": "key",
+    "relatedConcepts": [
+      "hockey-stick identity",
+      "Pascal's triangle",
+      "figurate numbers"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Pascal's rule"
+    ]
+  },
+  {
+    "id": "ann-hockey-induction",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 42,
+      "endLine": 50
+    },
+    "type": "theorem",
+    "title": "Hockey-Stick by Induction (diagonal form)",
+    "content": "Proves ∑_{i=0}^{n} C(r+i, r) = C(r+n+1, r+1) by induction on n. Each step peels the top term with `Finset.sum_range_succ`, applies the IH, and closes with Pascal's rule `Nat.choose_succ_succ`: C(r+m+1, r+1) + C(r+m+1, r) = C(r+m+2, r+1). This is the telescoping derivation the parent's OQ#2 requested.",
+    "mathContext": "Base: C(r,r) = C(r+1,r+1) = 1. Step: Pascal absorbs the new term.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "induction",
+      "Pascal's rule",
+      "sum_range_succ"
+    ]
+  },
+  {
+    "id": "ann-icc",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 57,
+      "endLine": 60
+    },
+    "type": "theorem",
+    "title": "Interval Form",
+    "content": "Relates the diagonal form to Mathlib's `Nat.sum_Icc_choose`: ∑_{m∈Icc r n} C(m, r) = C(n+1, r+1), giving both standard phrasings of the identity.",
+    "mathContext": "The interval [r, n] version of the hockey-stick sum.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval sum"
+    ]
+  },
+  {
+    "id": "ann-gauss",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "Gauss's Sum: 1 + 2 + … + n = C(n+1, 2)",
+    "content": "Specializing the hockey-stick to r = 1 with C(m,1) = m gives 1 + 2 + … + n = C(n+1, 2), and `gauss_sum` derives the closed form n(n+1)/2 via C(n+1,2) = (n+1)n/2.",
+    "mathContext": "The triangular numbers are the r=1 diagonal of Pascal's triangle.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gauss sum",
+      "triangular numbers"
+    ]
+  },
+  {
+    "id": "ann-tetrahedral",
+    "proofId": "binomial-theorem-oq-02-oq-02-oq-02",
+    "range": {
+      "startLine": 77,
+      "endLine": 84
+    },
+    "type": "theorem",
+    "title": "Tetrahedral Numbers: ∑ C(m, 2) = C(n+1, 3)",
+    "content": "The r = 2 diagonal: the partial sums of the triangular numbers ∑_{m≤n} C(m,2) are the tetrahedral numbers C(n+1,3). A numeric sanity check confirms 1+2+3+4+5 = 15 = C(6,2).",
+    "mathContext": "Partial sums of triangular numbers are tetrahedral numbers.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "tetrahedral numbers",
+      "figurate numbers"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02-oq-02/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "binomial-theorem-oq-02-oq-02-oq-02",
+  "title": "The Hockey-Stick Identity and Figurate Numbers",
+  "slug": "binomial-theorem-oq-02-oq-02-oq-02",
+  "description": "Answers the parent's second open question with an independent Finset.sum_range_succ-based induction proof of the hockey-stick (Zhu Shijie) identity ∑_{i≤n} C(r+i,r) = C(r+n+1,r+1) via Pascal's rule, relates it to Mathlib's sum_Icc_choose, and derives the classical figurate-number consequences: Gauss's sum 1+…+n = C(n+1,2) = n(n+1)/2 and the tetrahedral numbers ∑ C(m,2) = C(n+1,3). 0 axioms.",
+  "meta": {
+    "author": "Zhu Shijie (1303)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hockey-stick_identity",
+    "date": "1303",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ02OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "hockey-stick",
+      "figurate-numbers",
+      "pascal-rule",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑_{i<n+1} f i = ∑_{i<n} f i + f n; peels off the top term for the induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1); closes each induction step",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.sum_Icc_choose",
+        "description": "Mathlib's hockey-stick: ∑_{m∈Icc k n} C(m,k) = C(n+1,k+1); used for the interval form and figurate sums",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.choose_one_right",
+        "description": "C(m,1) = m; turns the r=1 hockey-stick into Gauss's sum",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "C(m,2) = m(m-1)/2; gives the closed form of Gauss's sum",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Independent induction proof of the hockey-stick identity ∑_{i≤n} C(r+i,r) = C(r+n+1,r+1) using only Finset.sum_range_succ and Pascal's rule — exactly the telescoping derivation the parent's OQ#2 requested",
+      "Related the diagonal form to Mathlib's interval form Nat.sum_Icc_choose, providing both standard phrasings",
+      "Derived Gauss's sum 1+2+…+n = C(n+1,2) (r=1 specialization) and its closed form n(n+1)/2",
+      "Derived the tetrahedral numbers: partial sums of triangular numbers ∑_{m≤n} C(m,2) = C(n+1,3)",
+      "Connected binomial diagonals in Pascal's triangle to classical figurate-number sequences"
+    ],
+    "axiomCount": 0,
+    "lineCount": 84,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide (the single numeric sanity check uses kernel `decide`). The q-analogue (q-Vandermonde) and the Stirling asymptotic of C(2n,n) are the parent's other open questions and remain out of scope.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The hockey-stick identity — that summing a diagonal of Pascal's triangle gives the entry just below the end of the diagonal — appears in Zhu Shijie's 1303 *Jade Mirror of the Four Unknowns* and is named for the shape the summed cells trace. Its specializations are the oldest sums in mathematics: r = 1 gives Gauss's 1+2+…+n = n(n+1)/2, and r = 2 gives the tetrahedral numbers (partial sums of triangular numbers). The identity is equivalent to repeated application of Pascal's rule.",
+    "problemStatement": "Derive the hockey-stick identity C(r,r)+C(r+1,r)+…+C(n,r) = C(n+1,r+1) from the binomial framework using Finset.sum_range_succ and a telescoping (Pascal) argument.",
+    "text": "An independent induction proof of the hockey-stick identity plus its figurate-number consequences.",
+    "proofStrategy": "Induction on n in the diagonal form ∑_{i=0}^{n} C(r+i, r) = C(r+n+1, r+1). The base case is C(r,r) = C(r+1,r+1) = 1. The step peels the top term with Finset.sum_range_succ, applies the induction hypothesis, and closes with Pascal's rule Nat.choose_succ_succ: C(r+m+1, r+1) + C(r+m+1, r) = C(r+m+2, r+1). The interval form is Mathlib's Nat.sum_Icc_choose; specializing it at r = 1 (with C(m,1) = m) yields Gauss's sum, and at r = 2 the tetrahedral numbers.",
+    "keyInsights": [
+      "The hockey-stick identity is exactly Pascal's rule telescoped: each induction step is a single application of C(n+1,k+1) = C(n,k) + C(n,k+1)",
+      "Finset.sum_range_succ is the right engine — peeling the top term reduces the sum to the previous case plus one binomial coefficient that Pascal absorbs",
+      "Gauss's sum 1+2+…+n is the r=1 diagonal of Pascal's triangle: ∑ C(m,1) = C(n+1,2)",
+      "Tetrahedral numbers are the r=2 diagonal: ∑ C(m,2) = C(n+1,3), so partial sums of triangular numbers are tetrahedral",
+      "Index normalization r+(m+1) = r+m+1 (definitional but not syntactic) must be made explicit before Pascal's rule fires"
+    ],
+    "prerequisites": [
+      "Binomial coefficients and Pascal's rule",
+      "Finite sums (Finset.sum_range_succ)",
+      "figurate numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "hockey-induction",
+      "title": "The Hockey-Stick Identity by Induction",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring framing OQ#2. Proves ∑_{i≤n} C(r+i,r) = C(r+n+1,r+1) by induction with Finset.sum_range_succ and Pascal's rule — the telescoping derivation requested.",
+      "mathContext": "Step: C(r+m+1,r+1) + C(r+m+1,r) = C(r+m+2,r+1) by Pascal."
+    },
+    {
+      "id": "icc-form",
+      "title": "Interval Form (Mathlib)",
+      "startLine": 52,
+      "endLine": 60,
+      "summary": "Relates the diagonal form to Mathlib's Nat.sum_Icc_choose: ∑_{m∈Icc r n} C(m,r) = C(n+1,r+1).",
+      "mathContext": "Both standard phrasings of the hockey-stick identity."
+    },
+    {
+      "id": "figurate",
+      "title": "Figurate-Number Consequences",
+      "startLine": 61,
+      "endLine": 84,
+      "summary": "Gauss's sum 1+…+n = C(n+1,2) = n(n+1)/2 (r=1), and tetrahedral numbers ∑ C(m,2) = C(n+1,3) (r=2); plus a numeric sanity check.",
+      "mathContext": "C(m,1) = m gives the triangular sum; C(m,2) summed gives the tetrahedral sequence."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) independent proof of the hockey-stick identity via Finset.sum_range_succ and Pascal's rule, answering the parent's second open question, together with its classical figurate-number consequences (Gauss's sum and tetrahedral numbers).",
+    "implications": "The hockey-stick identity is Pascal's rule telescoped; specializing the summation order r recovers the triangular (r=1) and tetrahedral (r=2) number sequences as binomial coefficients. This grounds elementary figurate-number formulas in Pascal's triangle.",
+    "openQuestions": [
+      "Formalize the q-Vandermonde identity via Mathlib's Gaussian binomial coefficients (parent OQ#1).",
+      "Formalize the Stirling asymptotic C(2n,n) ~ 4^n/√(πn) (parent OQ#3).",
+      "Generalize the figurate consequences to arbitrary r: ∑ C(m,r) = C(n+1,r+1) gives the r-simplex numbers."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02-oq-02",
+      "relationship": "parent",
+      "description": "Parent proving Vandermonde's identity; this entry answers its second open question (derive the hockey-stick identity via sum_range_succ)"
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-02-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling addressing the first open question (q-Vandermonde base cases via Gaussian binomials)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "BinomialHockeyStick",
+    "lineCount": 84,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ02OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent `BinomialTheoremOQ02OQ02.lean` proves Vandermonde's identity. Its **second open question** asks:

> The hockey-stick identity $\binom{r}{r} + \binom{r+1}{r} + \cdots + \binom{n}{r} = \binom{n+1}{r+1}$ follows from Vandermonde by a telescoping argument. Can it be derived using `Finset.sum_range_succ` directly?

This answers it directly, with **0 axioms / 0 sorries**:

- **`hockeyStick`** — $\sum_{i=0}^{n} \binom{r+i}{r} = \binom{r+n+1}{r+1}$, proved by induction on $n$ using `Finset.sum_range_succ` to peel the top term and Pascal's rule `Nat.choose_succ_succ` to close each step — exactly the requested telescoping.
- **`hockeyStick_Icc`** — $\sum_{m \in [r,n]} \binom{m}{r} = \binom{n+1}{r+1}$ (related to Mathlib's `Nat.sum_Icc_choose`).
- **`sum_Icc_id`** — $1 + 2 + \cdots + n = \binom{n+1}{2}$ (Gauss's sum, the $r=1$ diagonal).
- **`gauss_sum`** — closed form $\tfrac{n(n+1)}{2}$.
- **`sum_Icc_triangular`** — $\sum_{m \le n} \binom{m}{2} = \binom{n+1}{3}$ (tetrahedral numbers, the $r=2$ diagonal).

The figurate-number corollaries ground the oldest sums in mathematics in the diagonals of Pascal's triangle.

## Verification

- 5 theorems, 84 lines, self-contained (`import Mathlib`).
- Builds clean under Lean 4.26.0 via `docker-build.sh`.
- **0-axiom**: `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (no `native_decide`).

The q-Vandermonde identity and the Stirling asymptotic of $\binom{2n}{n}$ are the parent's other open questions and remain out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)