### PR TITLE
research(gcd-algorithm-oq-01-oq-01): Binet's closest-integer formula fib(n) = round(φⁿ/√5)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2688,6 +2688,7 @@ import Proofs.FurstenbergShiftChaos
 import Proofs.FurstenbergShiftTransitive
 import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
+import Proofs.GcdAlgorithmOQ01OQ01
 import Proofs.GCDAlgorithmOQ01OQ03
 import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01

--- a/proofs/Proofs/GcdAlgorithmOQ01OQ01.lean
+++ b/proofs/Proofs/GcdAlgorithmOQ01OQ01.lean
@@ -1,0 +1,74 @@
+/-
+# Binet's closest-integer formula: fib(n) = round(φⁿ/√5) (GCD OQ-01-OQ-01)
+
+The parent entry **gcd-algorithm-oq-01** ("Average-Case Complexity of the
+Euclidean Algorithm") formalizes Lamé's worst-case theorem — the Euclidean
+algorithm on consecutive Fibonacci numbers takes the most steps — and asks, among
+its open questions, to formalize **the golden-ratio identity**
+`fib(n) = ⌊φⁿ/√5 + ½⌋`, the closest-integer form of Binet's formula, which is the
+quantitative engine behind the Lamé step bound (`b ≥ fib(steps+1)`, with
+`fib(n) ≈ φⁿ/√5` growing geometrically).
+
+This file proves it, axiom-free, from Mathlib's `Real.coe_fib_eq`
+(`fib n = (φⁿ − ψⁿ)/√5`) and the bound `|ψ| < 1`:
+
+  * `abs_fib_sub_binet` — `|fib(n) − φⁿ/√5| < ½` for all `n`, since the difference
+    is exactly `−ψⁿ/√5` and `|ψⁿ|/√5 ≤ 1/√5 < ½`;
+  * `fib_eq_round_binet` — hence `round(φⁿ/√5) = fib(n)`: the Fibonacci numbers are
+    exactly the nearest integers to the geometric sequence `φⁿ/√5`;
+  * `fib_lt_goldenRatio_pow_div_add_half` / `goldenRatio_pow_div_sub_half_lt_fib` —
+    the explicit sandwich `φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½`.
+
+This is the precise sense in which the Euclidean worst case grows geometrically:
+`fib(n)` tracks `φⁿ/√5` to within half a unit, so the `n`-step worst case needs
+inputs of size `≈ φⁿ`, i.e. `n ≈ log_φ(√5·b)` steps — the Lamé bound.
+
+Zero axioms; imports only Mathlib.
+-/
+import Mathlib
+
+open scoped goldenRatio
+open Real
+
+namespace GcdAlgorithmOQ01OQ01
+
+/-- `√5 > 2` (since `5 > 4`). -/
+theorem two_lt_sqrt_five : (2 : ℝ) < √5 := by
+  nlinarith [Real.sq_sqrt (show (0 : ℝ) ≤ 5 by norm_num), Real.sqrt_nonneg 5]
+
+/-- The golden conjugate `ψ = (1−√5)/2` has `|ψ| < 1`. -/
+theorem abs_goldenConj_lt_one : |ψ| < 1 := by
+  rw [abs_of_neg goldenConj_neg]; linarith [neg_one_lt_goldenConj]
+
+/-- **The Binet error is less than ½.** For every `n`, `fib(n)` differs from
+`φⁿ/√5` by less than `½`, because the difference is exactly `−ψⁿ/√5` and
+`|ψⁿ|/√5 ≤ 1/√5 < ½`. -/
+theorem abs_fib_sub_binet (n : ℕ) : |(Nat.fib n : ℝ) - φ ^ n / √5| < 1 / 2 := by
+  have h5 : (0 : ℝ) < √5 := by linarith [two_lt_sqrt_five]
+  have heq : (Nat.fib n : ℝ) - φ ^ n / √5 = -ψ ^ n / √5 := by
+    rw [Real.coe_fib_eq n]; field_simp; ring
+  rw [heq, abs_div, abs_neg, abs_pow, abs_of_pos h5, div_lt_iff₀ h5]
+  have hpsi : |ψ| ^ n ≤ 1 := pow_le_one₀ (abs_nonneg _) abs_goldenConj_lt_one.le
+  nlinarith [hpsi, two_lt_sqrt_five]
+
+/-- **Binet's closest-integer formula.** The `n`-th Fibonacci number is the nearest
+integer to `φⁿ/√5`:  `round(φⁿ/√5) = fib(n)`. -/
+theorem fib_eq_round_binet (n : ℕ) : round (φ ^ n / √5) = (Nat.fib n : ℤ) := by
+  have habs := abs_fib_sub_binet n
+  rw [abs_lt] at habs
+  rw [round_eq, Int.floor_eq_iff]
+  refine ⟨?_, ?_⟩
+  · push_cast; linarith [habs.2]
+  · push_cast; linarith [habs.1]
+
+/-- The upper half of the sandwich: `fib(n) < φⁿ/√5 + ½`. -/
+theorem fib_lt_goldenRatio_pow_div_add_half (n : ℕ) :
+    (Nat.fib n : ℝ) < φ ^ n / √5 + 1 / 2 := by
+  have := (abs_lt.mp (abs_fib_sub_binet n)).2; linarith
+
+/-- The lower half of the sandwich: `φⁿ/√5 − ½ < fib(n)`. -/
+theorem goldenRatio_pow_div_sub_half_lt_fib (n : ℕ) :
+    φ ^ n / √5 - 1 / 2 < (Nat.fib n : ℝ) := by
+  have := (abs_lt.mp (abs_fib_sub_binet n)).1; linarith
+
+end GcdAlgorithmOQ01OQ01

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-01/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-bounds",
+    "proofId": "gcd-algorithm-oq-01-oq-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 42
+    },
+    "type": "concept",
+    "title": "Two Scalar Facts",
+    "content": "The whole formula rests on two small bounds: √5 > 2 (so 1/√5 < ½), proved by nlinarith from (√5)² = 5; and |ψ| < 1 for the golden conjugate ψ = (1−√5)/2, since −1 < ψ < 0 gives |ψ| = −ψ < 1. These control the size of the error term ψⁿ/√5 in Binet's formula."
+  },
+  {
+    "id": "ann-error",
+    "proofId": "gcd-algorithm-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 54
+    },
+    "type": "insight",
+    "title": "The Error Term Never Reaches ½",
+    "content": "Binet's formula fib(n) = (φⁿ − ψⁿ)/√5 means fib(n) − φⁿ/√5 = −ψⁿ/√5 exactly — no inequality is lost. Taking absolute values, |fib(n) − φⁿ/√5| = |ψ|ⁿ/√5 ≤ 1/√5 < ½ (using |ψ|ⁿ ≤ 1 and √5 > 2). The ψⁿ term, which makes Binet's closed form an integer despite involving √5, is precisely what stays below half a unit."
+  },
+  {
+    "id": "ann-round",
+    "proofId": "gcd-algorithm-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 73
+    },
+    "type": "insight",
+    "title": "Fibonacci as a Rounded Geometric Sequence",
+    "content": "Because the error is below ½, round(φⁿ/√5) = fib(n): the Fibonacci numbers are exactly the nearest integers to the geometric sequence φⁿ/√5. The proof rewrites round as ⌊· + ½⌋ and applies Int.floor_eq_iff, with both bracketing inequalities following from the <½ error by linarith. The sandwich φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½ then makes the geometric growth explicit — the engine behind the logarithmic Euclidean worst case: n-step worst-case inputs have size ≈ φⁿ."
+  }
+]

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-01/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "gcd-algorithm-oq-01-oq-01",
+  "title": "Binet's Closest-Integer Formula: fib(n) = round(φⁿ/√5)",
+  "slug": "gcd-algorithm-oq-01-oq-01",
+  "description": "The parent entry gcd-algorithm-oq-01 formalizes Lamé's worst-case theorem for the Euclidean algorithm (consecutive Fibonacci numbers are worst) and asks, among its open questions, to formalize the golden-ratio identity fib(n) = ⌊φⁿ/√5 + ½⌋ — the closest-integer form of Binet's formula, the quantitative engine behind the geometric Lamé step bound. This entry proves it axiom-free from Mathlib's Real.coe_fib_eq (fib n = (φⁿ − ψⁿ)/√5) and |ψ| < 1: the Binet error |fib(n) − φⁿ/√5| equals |ψⁿ|/√5 ≤ 1/√5 < ½, so round(φⁿ/√5) = fib(n) exactly, with the explicit sandwich φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½. This is the precise sense in which the Euclidean worst case grows geometrically (n-step worst case needs inputs ≈ φⁿ).",
+  "meta": {
+    "author": "Jacques Binet (1843); A. de Moivre; D. Bernoulli; formalized in Lean 4",
+    "date": "1843",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GcdAlgorithmOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "golden-ratio",
+      "binet-formula",
+      "euclidean-algorithm",
+      "lame-theorem"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 74,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "fib_eq_round_binet: Binet's closest-integer formula round(φⁿ/√5) = fib(n) — the golden-ratio identity the parent's open question asks for, proved axiom-free.",
+      "abs_fib_sub_binet: the Binet error |fib(n) − φⁿ/√5| < ½ for all n, from the exact identity fib(n) − φⁿ/√5 = −ψⁿ/√5 and |ψⁿ|/√5 ≤ 1/√5 < ½.",
+      "fib_lt_goldenRatio_pow_div_add_half / goldenRatio_pow_div_sub_half_lt_fib: the explicit sandwich φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½, the half-unit tracking of fib(n) by the geometric φⁿ/√5.",
+      "two_lt_sqrt_five and abs_goldenConj_lt_one: the supporting bounds √5 > 2 (so 1/√5 < ½) and |ψ| < 1 (so |ψⁿ| ≤ 1)."
+    ],
+    "prerequisites": [
+      "Binet's formula fib(n) = (φⁿ − ψⁿ)/√5 (Mathlib's Real.coe_fib_eq)",
+      "The golden ratio φ and conjugate ψ = (1−√5)/2, with −1 < ψ < 0",
+      "round and ⌊·⌋ (round x = ⌊x + ½⌋)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.coe_fib_eq",
+        "description": "Binet's formula: (fib n : ℝ) = (φⁿ − ψⁿ)/√5.",
+        "module": "Mathlib.NumberTheory.Real.GoldenRatio"
+      },
+      {
+        "theorem": "goldenConj_neg / neg_one_lt_goldenConj",
+        "description": "ψ < 0 and −1 < ψ, giving |ψ| < 1 — so the ψⁿ term in Binet's formula stays below ½/√5·√5.",
+        "module": "Mathlib.NumberTheory.Real.GoldenRatio"
+      },
+      {
+        "theorem": "round_eq / Int.floor_eq_iff",
+        "description": "round x = ⌊x + ½⌋ and the floor characterization — convert the <½ error into round(φⁿ/√5) = fib(n).",
+        "module": "Mathlib.Algebra.Order.Round"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Binet's formula (1843; known earlier to de Moivre and Daniel Bernoulli) expresses the Fibonacci numbers in closed form, fib(n) = (φⁿ − ψⁿ)/√5, where φ = (1+√5)/2 is the golden ratio and ψ = (1−√5)/2 its conjugate. Because |ψ| < 1, the ψⁿ term is always small, and fib(n) is in fact the nearest integer to φⁿ/√5: fib(n) = round(φⁿ/√5). This closest-integer identity is the quantitative heart of the Euclidean algorithm's worst case. The parent entry formalizes Lamé's theorem — that the algorithm on inputs below fib(n+1) takes fewer than n steps, with consecutive Fibonacci numbers achieving the maximum — and lists the golden-ratio identity as the key to turning the Fibonacci bound into a clean logarithmic step count.\n\nThis entry supplies that identity. The difference fib(n) − φⁿ/√5 is exactly −ψⁿ/√5; since |ψ| < 1 gives |ψⁿ| ≤ 1, and √5 > 2 gives 1/√5 < ½, the error is below ½ for every n. Therefore round(φⁿ/√5) = fib(n) on the nose, and fib(n) is sandwiched in (φⁿ/√5 − ½, φⁿ/√5 + ½). Geometrically: the worst-case inputs of n steps have size ≈ φⁿ, so n ≈ log_φ(√5·b) — the Lamé logarithmic bound.",
+    "problemStatement": "**Open Question (parent gcd-algorithm-oq-01)**: formalize the golden-ratio identity fib(n) = ⌊φⁿ/√5 + ½⌋ (closest-integer Binet), the engine behind the Lamé worst-case step bound.\n\n**This entry**: proves round(φⁿ/√5) = fib(n) and the explicit half-unit sandwich, axiom-free, from Mathlib's Binet formula and |ψ| < 1.",
+    "text": "A 74-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. two_lt_sqrt_five and abs_goldenConj_lt_one are the supporting bounds; abs_fib_sub_binet is the <½ error; fib_eq_round_binet is the closest-integer formula; the two sandwich theorems give the explicit bracketing.",
+    "proofStrategy": "abs_fib_sub_binet rewrites fib(n) via Real.coe_fib_eq, simplifies fib(n) − φⁿ/√5 to −ψⁿ/√5 (field_simp + ring), takes absolute values (|−ψⁿ/√5| = |ψ|ⁿ/√5), and bounds |ψ|ⁿ ≤ 1 (pow_le_one₀ from |ψ| < 1) against √5 > 2 (nlinarith). fib_eq_round_binet rewrites round as ⌊· + ½⌋ and applies Int.floor_eq_iff, discharging both bracketing inequalities by linarith from the <½ error (after push_cast). The sandwich theorems read off the two halves of abs_lt.",
+    "keyInsights": [
+      "Binet's exact formula has a small 'error term' ψⁿ/√5: because |ψ| < 1, it never reaches ½, so fib(n) is literally the rounded value of φⁿ/√5.",
+      "The difference fib(n) − φⁿ/√5 is exactly −ψⁿ/√5 — no inequality is lost; the whole content is |ψ| < 1 and √5 > 2.",
+      "round(φⁿ/√5) = fib(n) means the Fibonacci sequence is a geometric sequence (ratio φ) read to the nearest integer — the cleanest statement of its exponential growth.",
+      "This growth rate is exactly what makes the Euclidean worst case logarithmic: n steps require inputs of size ≈ φⁿ, so steps ≈ log_φ(input).",
+      "The proof is a clean reduction to two scalar facts (|ψ| < 1, √5 > 2) once Mathlib's Binet formula is in hand."
+    ]
+  },
+  "sections": [
+    {
+      "id": "bounds",
+      "title": "The Supporting Bounds",
+      "startLine": 34,
+      "endLine": 42,
+      "summary": "two_lt_sqrt_five (√5 > 2, so 1/√5 < ½) and abs_goldenConj_lt_one (|ψ| < 1, so |ψⁿ| ≤ 1).",
+      "mathContext": "The two scalar facts the closest-integer formula rests on."
+    },
+    {
+      "id": "error",
+      "title": "The Binet Error Is < ½",
+      "startLine": 44,
+      "endLine": 54,
+      "summary": "abs_fib_sub_binet: |fib(n) − φⁿ/√5| < ½, since the difference is −ψⁿ/√5 and |ψⁿ|/√5 ≤ 1/√5 < ½.",
+      "mathContext": "The ψⁿ term of Binet's formula never reaches half a unit."
+    },
+    {
+      "id": "round",
+      "title": "The Closest-Integer Formula",
+      "startLine": 56,
+      "endLine": 73,
+      "summary": "fib_eq_round_binet (round(φⁿ/√5) = fib(n)) and the explicit sandwich φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½.",
+      "mathContext": "Fibonacci numbers are the nearest integers to the geometric sequence φⁿ/√5."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves Binet's closest-integer formula round(φⁿ/√5) = fib(n) — the golden-ratio identity the parent's open question asks for — axiom-free, from Mathlib's Binet formula Real.coe_fib_eq and the bounds |ψ| < 1, √5 > 2. The Binet error |fib(n) − φⁿ/√5| = |ψⁿ|/√5 < ½ gives both the rounding identity and the explicit half-unit sandwich φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½.",
+    "implications": "The closest-integer Binet formula makes precise that Fibonacci numbers grow geometrically as φⁿ/√5 to within half a unit. This is the quantitative engine of the Euclidean algorithm's worst case: n-step worst-case inputs have size ≈ φⁿ, so the step count is logarithmic, n ≈ log_φ(√5·b) — the clean form of Lamé's bound the parent entry develops combinatorially.",
+    "openQuestions": [
+      "Use fib_eq_round_binet to extend the parent's 5-digit Lamé bound to arbitrary input sizes (b beyond 10^20), as the open question proposes.",
+      "Derive the precise constant in steps ≈ log_φ(√5·b) and connect it to the worst-case step count euclideanSteps(fib(n+1), fib(n)) = n.",
+      "Formalize the average-case constant (Dixon, ~0.8427 ln N) — the deeper open question requiring continued-fraction ergodic theory."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "gcd-algorithm-oq-01",
+      "relationship": "extends",
+      "description": "Parent: Lamé worst-case theorem for the Euclidean algorithm; asks for the golden-ratio identity fib(n) = ⌊φⁿ/√5 + ½⌋. This entry proves it (closest-integer Binet)."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "related",
+      "description": "Root: the Euclidean GCD algorithm; the Fibonacci/golden-ratio growth underlies its worst-case step count."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "goldenRatio",
+      "Real"
+    ],
+    "namespace": "GcdAlgorithmOQ01OQ01",
+    "lineCount": 74,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "fib_eq_round_binet",
+        "type": "core",
+        "description": "Binet's closest-integer formula: round(φⁿ/√5) = fib(n).",
+        "leanType": "(n : ℕ) → round (φ ^ n / √5) = (Nat.fib n : ℤ)"
+      },
+      {
+        "name": "abs_fib_sub_binet",
+        "type": "key",
+        "description": "The Binet error is below ½: |fib(n) − φⁿ/√5| < ½.",
+        "leanType": "(n : ℕ) → |(Nat.fib n : ℝ) - φ ^ n / √5| < 1 / 2"
+      },
+      {
+        "name": "fib_lt_goldenRatio_pow_div_add_half",
+        "type": "supporting",
+        "description": "Upper half of the sandwich: fib(n) < φⁿ/√5 + ½.",
+        "leanType": "(n : ℕ) → (Nat.fib n : ℝ) < φ ^ n / √5 + 1 / 2"
+      }
+    ],
+    "path": "Proofs/GcdAlgorithmOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "fib_eq_round_binet",
+      "type": "core",
+      "description": "round(φⁿ/√5) = fib(n) — Binet's closest-integer formula.",
+      "leanType": "(n : ℕ) → round (φ ^ n / √5) = (Nat.fib n : ℤ)"
+    },
+    {
+      "name": "abs_fib_sub_binet",
+      "type": "key",
+      "description": "|fib(n) − φⁿ/√5| < ½, the Binet error bound.",
+      "leanType": "(n : ℕ) → |(Nat.fib n : ℝ) - φ ^ n / √5| < 1 / 2"
+    },
+    {
+      "name": "goldenRatio_pow_div_sub_half_lt_fib",
+      "type": "supporting",
+      "description": "Lower half of the sandwich: φⁿ/√5 − ½ < fib(n).",
+      "leanType": "(n : ℕ) → φ ^ n / √5 - 1 / 2 < (Nat.fib n : ℝ)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Binet, Jacques Philippe Marie",
+      "title": "Mémoire sur l'intégration des équations linéaires aux différences finies",
+      "year": "1843",
+      "venue": "Comptes Rendus Acad. Sci. Paris 17",
+      "note": "Closed form for the Fibonacci numbers"
+    },
+    {
+      "authors": "Lamé, Gabriel",
+      "title": "Note sur la limite du nombre des divisions dans la recherche du plus grand commun diviseur",
+      "year": "1844",
+      "venue": "Comptes Rendus Acad. Sci. Paris 19",
+      "note": "Fibonacci worst case of the Euclidean algorithm"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent entry **gcd-algorithm-oq-01** ("Average-Case Complexity of the Euclidean Algorithm") formalizes **Lamé's worst-case theorem** — the Euclidean algorithm on consecutive Fibonacci numbers takes the most steps — and asks, among its open questions, to formalize the **golden-ratio identity** `fib(n) = ⌊φⁿ/√5 + ½⌋`, the closest-integer form of Binet's formula and the quantitative engine behind the geometric Lamé step bound.

This PR proves it, axiom-free, from Mathlib's `Real.coe_fib_eq` (`fib n = (φⁿ − ψⁿ)/√5`) and `|ψ| < 1`:

- **`abs_fib_sub_binet`** — `|fib(n) − φⁿ/√5| < ½` for all `n`. The difference is *exactly* `−ψⁿ/√5`, and `|ψⁿ|/√5 ≤ 1/√5 < ½` (using `|ψ| < 1` and `√5 > 2`).
- **`fib_eq_round_binet`** — hence `round(φⁿ/√5) = fib(n)`: the Fibonacci numbers are exactly the nearest integers to the geometric sequence `φⁿ/√5`.
- **`fib_lt_…` / `…_lt_fib`** — the explicit sandwich `φⁿ/√5 − ½ < fib(n) < φⁿ/√5 + ½`.

This is the precise sense in which the Euclidean worst case grows geometrically: `n`-step worst-case inputs have size `≈ φⁿ`, so the step count is logarithmic, `n ≈ log_φ(√5·b)` — the clean form of Lamé's bound.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.GcdAlgorithmOQ01OQ01` → `✔ Built`, build completed successfully.
- 74 lines, 6 theorems, **0 sorries, 0 axioms, no native_decide** — verified.
- Self-contained: imports Mathlib only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)