### PR TITLE
research(bezout-identity-oq-02-oq-01-oq-02-oq-04): Eisenstein's criterion over any integral domain

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -283,6 +283,7 @@ import Proofs.BezoutIdentityOQ02OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ02
+import Proofs.BezoutIdentityOQ02OQ01OQ02OQ04
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02OQ03

--- a/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ04.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ04.lean
@@ -1,0 +1,108 @@
+/-
+# Eisenstein's criterion over an arbitrary integral domain (Bézout OQ-02-01-02-04)
+
+The parent entry **bezout-identity-oq-02-oq-01-oq-02** ("FTA Generalization to
+Euclidean Domains") develops unique factorization in the abstract UFD / Euclidean-
+domain setting, and asks, as its fourth open question:
+
+  > The Eisenstein criterion for irreducibility of polynomials over UFDs is a key
+  > application of the UFD framework. Is it formalized in Mathlib, and can it be
+  > used here?
+
+Yes — and it works far beyond UFDs. Mathlib's `Polynomial.irreducible_of_eisenstein_criterion`
+applies at any prime ideal of any commutative ring. This file packages it into the
+clean headline theorem
+
+    for any **integral domain** `R` and any **prime** `p : R`, and any `n ≥ 1`,
+    `Xⁿ − p` is irreducible over `R[X]`,
+
+via Eisenstein at the prime ideal `(p)`. Specializing the domain shows the
+criterion in genuinely different settings:
+
+  * `R = ℤ`: `Yⁿ − 2` and `Yⁿ − 3` are irreducible over `ℤ[Y]`;
+  * `R = ℚ[X]` (a Euclidean domain, exactly the parent's theme): `Yⁿ − X` is
+    irreducible over `ℚ[X][Y]` — Eisenstein at the prime element `X`.
+
+This is the same Eisenstein argument used for `∛3` (entry cube-root-3-irrational-oq-01)
+but with `ℤ` replaced by an arbitrary integral domain, answering OQ-04 in the full
+generality the UFD/Euclidean-domain framework invites.
+
+Zero axioms; imports only Mathlib.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace BezoutIdentityOQ02OQ01OQ02OQ04
+
+/- ## The general theorem -/
+
+/-- **Eisenstein's criterion for `Xⁿ − p` over any integral domain.** For an
+integral domain `R`, a prime element `p : R`, and `n ≥ 1`, the polynomial
+`Xⁿ − p` is irreducible in `R[X]`. The four Eisenstein hypotheses at the prime
+ideal `(p)`: the leading coefficient `1 ∉ (p)`; every lower coefficient is `0` or
+`−p`, both in `(p)`; the constant `−p ∉ (p)²` (else `p² ∣ p`, impossible for a
+prime); and `Xⁿ − p` is monic, hence primitive. -/
+theorem irreducible_X_pow_sub_C_of_prime {R : Type*} [CommRing R] [IsDomain R]
+    {p : R} (hp : Prime p) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : R[X]) ^ n - C p) := by
+  have hp0 : p ≠ 0 := hp.ne_zero
+  set P : Ideal R := Ideal.span {p} with hP
+  have hPprime : P.IsPrime := (Ideal.span_singleton_prime hp0).mpr hp
+  have hmonic : ((X : R[X]) ^ n - C p).Monic := monic_X_pow_sub_C p hn.ne'
+  have hdeg : ((X : R[X]) ^ n - C p).degree = n := degree_X_pow_sub_C hn p
+  apply irreducible_of_eisenstein_criterion hPprime
+  · -- leading coefficient `1 ∉ P`
+    rw [hmonic.leadingCoeff]
+    intro h1
+    exact hPprime.ne_top (Ideal.eq_top_of_isUnit_mem P h1 isUnit_one)
+  · -- coefficients below the top degree lie in `P`
+    intro m hm
+    have hmn : m < n := by rw [hdeg] at hm; exact_mod_cast hm
+    rw [coeff_sub, coeff_X_pow, coeff_C, if_neg (by omega : ¬ m = n)]
+    split_ifs with h0m
+    · simpa using P.neg_mem (Ideal.mem_span_singleton_self p)
+    · simp
+  · -- positive degree
+    rw [hdeg]; exact_mod_cast hn
+  · -- constant coefficient `−p ∉ P²`
+    have hc : ((X : R[X]) ^ n - C p).coeff 0 = -p := by
+      have hx0 : ((X : R[X]) ^ n).coeff 0 = 0 := by
+        rw [coeff_X_pow]; exact if_neg (by omega)
+      rw [coeff_sub, hx0, coeff_C_zero, zero_sub]
+    rw [hc]
+    intro hmem
+    rw [Ideal.neg_mem_iff, hP, Ideal.span_singleton_pow, Ideal.mem_span_singleton] at hmem
+    have hdvd1 : p ∣ 1 := by
+      have h2 : p * p ∣ p * 1 := by rwa [mul_one, ← sq]
+      exact (mul_dvd_mul_iff_left hp0).mp h2
+    exact hp.not_unit (isUnit_of_dvd_one hdvd1)
+  · -- primitive, because monic
+    exact hmonic.isPrimitive
+
+/- ## The criterion in different domains -/
+
+/-- Over `ℤ`: `Yⁿ − 2` is irreducible — Eisenstein at the prime `2`. -/
+theorem irreducible_Y_pow_sub_two_int {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C 2) :=
+  irreducible_X_pow_sub_C_of_prime Int.prime_two hn
+
+/-- Over `ℤ`: `Yⁿ − 3` is irreducible — Eisenstein at the prime `3`. -/
+theorem irreducible_Y_pow_sub_three_int {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C 3) :=
+  irreducible_X_pow_sub_C_of_prime Int.prime_three hn
+
+/-- **Over the Euclidean domain `ℚ[X]`:** `Yⁿ − X` is irreducible in `ℚ[X][Y]` —
+Eisenstein at the prime element `X`. This is the parent's setting (a Euclidean
+domain that is not `ℤ`), and exhibits an irreducible giving the function-field
+extension `ℚ(X)(X^{1/n})`. -/
+theorem irreducible_Y_pow_sub_X_ratPoly {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : (Polynomial ℚ)[X]) ^ n - C (Polynomial.X)) :=
+  irreducible_X_pow_sub_C_of_prime (Polynomial.prime_X) hn
+
+/-- Specialization to the cubic over `ℚ[X]`: `Y³ − X` is irreducible. -/
+theorem irreducible_Y_cubed_sub_X_ratPoly :
+    Irreducible ((X : (Polynomial ℚ)[X]) ^ 3 - C (Polynomial.X)) :=
+  irreducible_Y_pow_sub_X_ratPoly (by norm_num)
+
+end BezoutIdentityOQ02OQ01OQ02OQ04

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/annotations.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "ann-general",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-04",
+    "range": {
+      "startLine": 46,
+      "endLine": 84
+    },
+    "type": "insight",
+    "title": "Eisenstein at the Right Generality",
+    "content": "irreducible_X_pow_sub_C_of_prime proves Xⁿ − p irreducible over R[X] for ANY integral domain R and prime p. Eisenstein's criterion is usually stated over ℤ, but the argument only ever touches a prime ideal — here (p) — so it works over any domain. The four hypotheses: leading coefficient 1 ∉ (p) (the ideal is proper); lower coefficients 0 or −p, both in (p); constant −p ∉ (p)² because p² ∤ p (cancel one factor: p² ∣ p ⟹ p ∣ 1, impossible for a prime); monic ⟹ primitive. No property of ℤ is used beyond being a domain with a prime element."
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-04",
+    "range": {
+      "startLine": 86,
+      "endLine": 107
+    },
+    "type": "concept",
+    "title": "The Same Criterion in Different Domains",
+    "content": "Supplying different prime elements instantiates the one theorem across settings. Over ℤ: Yⁿ − 2 and Yⁿ − 3 (Eisenstein at 2, 3). Over the Euclidean domain ℚ[X] — exactly the parent entry's framework — Eisenstein at the prime element X gives Yⁿ − X irreducible in ℚ[X][Y]. Its root is an n-th root of the variable, so it generates the function-field extension ℚ(X)(X^{1/n}), the geometric analogue of a radical number-field extension. One Eisenstein argument, two genuinely different domains."
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-04/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "bezout-identity-oq-02-oq-01-oq-02-oq-04",
+  "title": "Eisenstein's Criterion over an Arbitrary Integral Domain",
+  "slug": "bezout-identity-oq-02-oq-01-oq-02-oq-04",
+  "description": "The parent entry (FTA Generalization to Euclidean Domains) asks, as its fourth open question, whether the Eisenstein irreducibility criterion over UFDs is formalized in Mathlib and usable in this framework. It is — and works far beyond UFDs. This entry packages Mathlib's Polynomial.irreducible_of_eisenstein_criterion into the clean headline: for any INTEGRAL DOMAIN R and prime p : R and n ≥ 1, Xⁿ − p is irreducible over R[X], via Eisenstein at the prime ideal (p). Specializing the domain shows the criterion across genuinely different settings: over ℤ (Yⁿ − 2, Yⁿ − 3 irreducible) and over the Euclidean domain ℚ[X] (Yⁿ − X irreducible over ℚ[X][Y], Eisenstein at the prime X — exactly the parent's theme). This is the ∛3 Eisenstein argument with ℤ replaced by an arbitrary domain. Zero axioms, no native_decide.",
+  "meta": {
+    "author": "Gotthold Eisenstein (1850); formalized in Lean 4",
+    "date": "1850",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ04.lean",
+    "tags": [
+      "ring-theory",
+      "eisenstein-criterion",
+      "irreducible-polynomial",
+      "integral-domain",
+      "euclidean-domain",
+      "ufd"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 108,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "irreducible_X_pow_sub_C_of_prime: the GENERAL theorem that Xⁿ − p is irreducible over R[X] for any integral domain R, any prime p : R, and n ≥ 1 — Eisenstein at the prime ideal (p). Answers the parent's OQ-04 in full generality (beyond UFDs).",
+      "irreducible_Y_pow_sub_two_int / _three_int: the ℤ instances Yⁿ − 2 and Yⁿ − 3 (Eisenstein at 2, 3).",
+      "irreducible_Y_pow_sub_X_ratPoly: over the Euclidean domain ℚ[X] — Yⁿ − X is irreducible in ℚ[X][Y], Eisenstein at the prime element X. This is the parent's exact setting (a Euclidean domain that is not ℤ) and exhibits the function-field extension ℚ(X)(X^{1/n}).",
+      "irreducible_Y_cubed_sub_X_ratPoly: the cubic specialization Y³ − X over ℚ[X].",
+      "Demonstrates that Eisenstein's criterion is a property of integral domains with a prime element — the right level of generality for the UFD/Euclidean-domain framework."
+    ],
+    "prerequisites": [
+      "Eisenstein's criterion (Mathlib's Polynomial.irreducible_of_eisenstein_criterion)",
+      "Prime ideals span {p} and primitivity of monic polynomials",
+      "Prime elements in ℤ and in polynomial rings (Int.prime_two, Polynomial.prime_X)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+        "description": "Eisenstein's criterion at a prime ideal P of a commutative ring — applies over any integral domain.",
+        "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Criterion"
+      },
+      {
+        "theorem": "Ideal.span_singleton_prime / Polynomial.Monic.isPrimitive",
+        "description": "span {p} is prime for prime p; a monic polynomial is primitive — the Eisenstein hypotheses.",
+        "module": "Mathlib.RingTheory.Ideal.Maximal / Mathlib.RingTheory.Polynomial.Content"
+      },
+      {
+        "theorem": "Int.prime_two / Int.prime_three / Polynomial.prime_X",
+        "description": "Prime elements giving the concrete instances over ℤ and over ℚ[X].",
+        "module": "Mathlib.Data.Int.Prime / Mathlib.Algebra.Polynomial.RingDivision"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Eisenstein's criterion (1850) is the workhorse for proving polynomials irreducible: if a prime p divides every coefficient of a monic polynomial except the leading one, and p² does not divide the constant term, the polynomial is irreducible. It is usually stated over ℤ, but the argument is purely about a prime ideal, so it holds over any commutative ring with a prime ideal. The parent entry develops unique factorization in the abstract UFD / Euclidean-domain setting and asks whether Eisenstein's criterion is available there.\n\nThis entry answers yes, at the natural level of generality: any integral domain with a prime element. The polynomial Xⁿ − p satisfies Eisenstein at the prime ideal (p) — all lower coefficients are 0 or −p (both in (p)), the leading coefficient is 1 (not in the proper ideal (p)), and the constant −p is not in (p)² because p² ∤ p for a prime. Specializing the domain illustrates the reach: over ℤ one recovers the familiar Yⁿ − 2; over the Euclidean domain ℚ[X], Eisenstein at the prime element X proves Yⁿ − X irreducible — the polynomial whose root is an n-th root of the variable, generating the function-field extension ℚ(X)(X^{1/n}). The same one theorem covers both, and any other domain with a prime.",
+    "problemStatement": "**Open Question (parent bezout-identity-oq-02-oq-01-oq-02, OQ-04)**: is Eisenstein's criterion over UFDs formalized in Mathlib, and can it be used in the Euclidean-domain framework?\n\n**This entry**: yes — the general theorem Xⁿ − p irreducible over R[X] for any integral domain R and prime p, with instances over ℤ and over the Euclidean domain ℚ[X].",
+    "text": "A 108-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. irreducible_X_pow_sub_C_of_prime is the general theorem; the ℤ and ℚ[X] instances follow by supplying the appropriate prime element.",
+    "proofStrategy": "irreducible_X_pow_sub_C_of_prime verifies the four Eisenstein hypotheses at P = span{p}: leading coefficient 1 ∉ P (P proper since prime); each coefficient below degree n is 0 or −p, both in P (coeff_sub/coeff_X_pow/coeff_C + P.neg_mem / mem_span_singleton_self); positive degree; constant coefficient −p ∉ P² = span{p²}, since p² ∣ p would force p ∣ 1 (mul_dvd_mul_iff_left in the cancellative domain), contradicting hp.not_unit; and Xⁿ − p monic, hence primitive (Monic.isPrimitive). The instances apply the theorem with Int.prime_two, Int.prime_three, and Polynomial.prime_X.",
+    "keyInsights": [
+      "Eisenstein's criterion is not special to ℤ — it is a property of an integral domain with a prime element, so Xⁿ − p is irreducible over R[X] uniformly.",
+      "The only arithmetic step is −p ∉ (p²), which reduces to p² ∤ p, i.e. p ∤ 1 — the defining property of a prime, valid in any domain.",
+      "Over ℚ[X], Eisenstein at the prime X proves Yⁿ − X irreducible — a clean example over a Euclidean domain that is not ℤ, directly answering the parent's question.",
+      "Yⁿ − X generating ℚ(X)(X^{1/n}) is the function-field analogue of ⁿ√p generating ℚ(p^{1/n}) — the same Eisenstein argument in a different domain.",
+      "This generalizes the ℤ-only Eisenstein result (entry cube-root-3-irrational-oq-01) to the abstract setting the parent's UFD/Euclidean-domain framework invites."
+    ]
+  },
+  "sections": [
+    {
+      "id": "general",
+      "title": "The General Theorem",
+      "startLine": 42,
+      "endLine": 84,
+      "summary": "irreducible_X_pow_sub_C_of_prime: Xⁿ − p irreducible over R[X] for any integral domain R, prime p, n ≥ 1, via Eisenstein at (p).",
+      "mathContext": "Eisenstein's criterion at the natural level of generality."
+    },
+    {
+      "id": "instances",
+      "title": "Instances over ℤ and ℚ[X]",
+      "startLine": 86,
+      "endLine": 107,
+      "summary": "Yⁿ − 2, Yⁿ − 3 over ℤ; Yⁿ − X and Y³ − X over the Euclidean domain ℚ[X] (Eisenstein at the prime X).",
+      "mathContext": "The criterion in genuinely different domains, including the parent's Euclidean-domain setting."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent's OQ-04 by packaging Mathlib's Eisenstein criterion into the general theorem that Xⁿ − p is irreducible over R[X] for any integral domain R and prime p (n ≥ 1), with concrete instances over ℤ (Yⁿ − 2, Yⁿ − 3) and over the Euclidean domain ℚ[X] (Yⁿ − X, via Eisenstein at the prime X). Zero axioms, no native_decide.",
+    "implications": "Eisenstein's criterion is shown to be a tool of the abstract integral-domain / UFD / Euclidean-domain framework, not just of ℤ. The ℚ[X] instance exhibits irreducibles generating function-field extensions ℚ(X)(X^{1/n}), the geometric analogue of radical number-field extensions, both produced by the identical Eisenstein argument.",
+    "openQuestions": [
+      "Combine with Gauss's lemma over a general UFD to transfer irreducibility from R[X] to (Frac R)[X].",
+      "Formalize the generalized Eisenstein criterion allowing the constant term to be only squarefree-at-some-prime, not a prime itself.",
+      "Use the ℚ[X] instances to formalize the ramification of the function-field extension ℚ(X)(X^{1/n}) at the place X."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent: FTA generalization to Euclidean domains; asks whether Eisenstein's criterion over UFDs is available. This entry supplies it for any integral domain."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-01",
+      "relationship": "related",
+      "description": "Sibling: the same Eisenstein argument specialized to ℤ (for ∛3). This entry generalizes it to arbitrary integral domains."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "BezoutIdentityOQ02OQ01OQ02OQ04",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "irreducible_X_pow_sub_C_of_prime",
+        "type": "core",
+        "description": "Xⁿ − p is irreducible over R[X] for any integral domain R, prime p, n ≥ 1.",
+        "leanType": "{R : Type*} → [CommRing R] → [IsDomain R] → {p : R} → Prime p → {n : ℕ} → 0 < n → Irreducible ((X : R[X]) ^ n - C p)"
+      },
+      {
+        "name": "irreducible_Y_pow_sub_X_ratPoly",
+        "type": "key",
+        "description": "Over the Euclidean domain ℚ[X]: Yⁿ − X is irreducible (Eisenstein at the prime X).",
+        "leanType": "{n : ℕ} → 0 < n → Irreducible ((X : (Polynomial ℚ)[X]) ^ n - C Polynomial.X)"
+      },
+      {
+        "name": "irreducible_Y_pow_sub_two_int",
+        "type": "key",
+        "description": "Over ℤ: Yⁿ − 2 is irreducible.",
+        "leanType": "{n : ℕ} → 0 < n → Irreducible ((X : ℤ[X]) ^ n - C 2)"
+      }
+    ],
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "irreducible_X_pow_sub_C_of_prime",
+      "type": "core",
+      "description": "General Eisenstein: Xⁿ − p irreducible over R[X] for any integral domain R and prime p.",
+      "leanType": "{R : Type*} → [CommRing R] → [IsDomain R] → {p : R} → Prime p → {n : ℕ} → 0 < n → Irreducible ((X : R[X]) ^ n - C p)"
+    },
+    {
+      "name": "irreducible_Y_pow_sub_X_ratPoly",
+      "type": "key",
+      "description": "Yⁿ − X irreducible over the Euclidean domain ℚ[X].",
+      "leanType": "{n : ℕ} → 0 < n → Irreducible ((X : (Polynomial ℚ)[X]) ^ n - C Polynomial.X)"
+    },
+    {
+      "name": "irreducible_Y_cubed_sub_X_ratPoly",
+      "type": "supporting",
+      "description": "Y³ − X irreducible over ℚ[X].",
+      "leanType": "Irreducible ((X : (Polynomial ℚ)[X]) ^ 3 - C Polynomial.X)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Eisenstein, Gotthold",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung...",
+      "year": "1850",
+      "venue": "Journal für die reine und angewandte Mathematik 39, 160–179",
+      "note": "Original irreducibility criterion"
+    },
+    {
+      "authors": "Lang, Serge",
+      "title": "Algebra",
+      "year": "2002",
+      "venue": "Springer, 3rd ed., IV §3",
+      "note": "Eisenstein's criterion over arbitrary integral domains / UFDs"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent entry **bezout-identity-oq-02-oq-01-oq-02** ("FTA Generalization to Euclidean Domains") asks, as its fourth open question:

> The Eisenstein criterion for irreducibility of polynomials over UFDs is a key application of the UFD framework. Is it formalized in Mathlib, and can it be used here?

Yes — and it works far beyond UFDs. Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` applies at any prime ideal of any commutative ring. This PR packages it into the clean headline theorem:

- **`irreducible_X_pow_sub_C_of_prime`** — for any **integral domain** `R`, any **prime** `p : R`, and `n ≥ 1`, `Xⁿ − p` is irreducible over `R[X]`, via Eisenstein at the prime ideal `(p)`.

Specializing the domain shows the criterion in genuinely different settings:

- **over `ℤ`**: `Yⁿ − 2` and `Yⁿ − 3` are irreducible over `ℤ[Y]`;
- **over the Euclidean domain `ℚ[X]`** (exactly the parent's theme): `Yⁿ − X` and `Y³ − X` are irreducible over `ℚ[X][Y]` — Eisenstein at the prime element `X`. Its root is an n-th root of the variable, generating the function-field extension `ℚ(X)(X^{1/n})`.

This is the `∛3` Eisenstein argument (entry **cube-root-3-irrational-oq-01**) with `ℤ` replaced by an arbitrary integral domain — the natural generality the UFD/Euclidean-domain framework invites.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BezoutIdentityOQ02OQ01OQ02OQ04` → `✔ Built`, build completed successfully.
- 108 lines, 5 theorems, **0 sorries, 0 axioms, no native_decide** — verified.
- Self-contained: imports Mathlib only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)