### PR TITLE
research(tangent-addition-formula-oq-01-oq-01): three-argument tangent addition law

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3445,6 +3445,7 @@ import Proofs.SzemerediRegularityOQ02
 import Proofs.SzemerediTheorem
 import Proofs.SzemerediTheoremOQ01
 import Proofs.TangentAdditionFormula
+import Proofs.TangentAdditionFormulaOQ01
 import Proofs.TaxicabNumberOQ01
 import Proofs.TaylorSinCosConvergence
 import Proofs.TaylorSinCosConvergenceOQ01

--- a/proofs/Proofs/TangentAdditionFormulaOQ01.lean
+++ b/proofs/Proofs/TangentAdditionFormulaOQ01.lean
@@ -1,0 +1,108 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
+import Mathlib.Analysis.Complex.Trigonometric
+import Mathlib.Tactic
+
+/-
+# The Three-Argument Tangent Addition Law
+
+## What This Proves
+
+The parent entry `TangentAdditionFormula` establishes the two-argument tangent
+law `tan (x + y) = (tan x + tan y)/(1 - tan x · tan y)`, the triangle tangent
+identity for `A + B + C = π`, and a Machin-style numeric application. This
+follow-up proves the genuinely more general **three-argument** law and its
+diagonal corollary, neither of which is in Mathlib nor in the parent.
+
+* **Three-argument addition law.** For angles with `cos x, cos y, cos z ≠ 0`
+  and `cos (x + y + z) ≠ 0`,
+  `tan (x + y + z) = (e₁ - e₃) / (1 - e₂)`,
+  where `e₁ = tan x + tan y + tan z`, `e₂ = tan x·tan y + tan y·tan z + tan z·tan x`,
+  and `e₃ = tan x·tan y·tan z` are the elementary symmetric polynomials in the
+  three tangents. This is the tangent analogue of the symmetric-function shape
+  of `sin`/`cos` of a triple sum.
+
+* **Triple-angle formula.** The diagonal `x = y = z` gives the classical
+  `tan (3x) = (3 tan x - tan³ x)/(1 - 3 tan² x)`.
+
+* **Unification.** The parent's triangle identity `tan A + tan B + tan C =
+  tan A · tan B · tan C` (for `A + B + C = π`) is recovered as the special case
+  `tan (A + B + C) = tan π = 0`: the numerator `e₁ - e₃` must vanish.
+
+## Method
+
+We avoid the fragile nested-fraction route. Writing everything over the common
+denominator `cos x · cos y · cos z`, the numerator and denominator of the claimed
+formula are exactly the expansions of `sin (x + y + z)` and `cos (x + y + z)`
+(via `sin_add`/`cos_add`). The law then collapses to the cancellation
+`(N/c)/(D/c) = N/D` (`div_div_div_cancel_right₀`). The triple-angle formula is a
+one-line `ring` specialization, and the triangle identity follows from
+`div_eq_zero_iff` once the denominator is shown nonzero.
+-/
+
+open Real
+
+variable {x y z A B C : ℝ}
+
+/-- **Three-argument tangent addition law.** With the directly checkable
+side-conditions `cos x, cos y, cos z ≠ 0` and `cos (x + y + z) ≠ 0`,
+`tan (x + y + z)` equals `(e₁ - e₃)/(1 - e₂)` in the elementary symmetric
+polynomials of `tan x, tan y, tan z`. Not in Mathlib. -/
+theorem tan_add_three (hx : cos x ≠ 0) (hy : cos y ≠ 0) (hz : cos z ≠ 0)
+    (hxyz : cos (x + y + z) ≠ 0) :
+    tan (x + y + z)
+      = (tan x + tan y + tan z - tan x * tan y * tan z)
+          / (1 - (tan x * tan y + tan y * tan z + tan z * tan x)) := by
+  have hcc : cos x * cos y * cos z ≠ 0 := mul_ne_zero (mul_ne_zero hx hy) hz
+  have hs : sin (x + y + z)
+      = sin x * cos y * cos z + cos x * sin y * cos z + cos x * cos y * sin z
+          - sin x * sin y * sin z := by
+    rw [show x + y + z = (x + y) + z from by ring, sin_add, sin_add, cos_add]; ring
+  have hc : cos (x + y + z)
+      = cos x * cos y * cos z - sin x * sin y * cos z - sin x * cos y * sin z
+          - cos x * sin y * sin z := by
+    rw [show x + y + z = (x + y) + z from by ring, cos_add, sin_add, cos_add]; ring
+  have hnum : tan x + tan y + tan z - tan x * tan y * tan z
+      = (sin x * cos y * cos z + cos x * sin y * cos z + cos x * cos y * sin z
+          - sin x * sin y * sin z) / (cos x * cos y * cos z) := by
+    rw [tan_eq_sin_div_cos, tan_eq_sin_div_cos, tan_eq_sin_div_cos]; field_simp <;> ring
+  have hden : 1 - (tan x * tan y + tan y * tan z + tan z * tan x)
+      = (cos x * cos y * cos z - sin x * sin y * cos z - sin x * cos y * sin z
+          - cos x * sin y * sin z) / (cos x * cos y * cos z) := by
+    rw [tan_eq_sin_div_cos, tan_eq_sin_div_cos, tan_eq_sin_div_cos]; field_simp <;> ring
+  rw [tan_eq_sin_div_cos, hs, hc, hnum, hden, div_div_div_cancel_right₀ hcc]
+
+/-- **Triple-angle tangent formula.** The `x = y = z` diagonal of the
+three-argument law: `tan (3x) = (3 tan x - tan³ x)/(1 - 3 tan² x)`, for
+`cos x ≠ 0` and `cos (3x) ≠ 0`. -/
+theorem tan_three_mul (hx : cos x ≠ 0) (h3x : cos (3 * x) ≠ 0) :
+    tan (3 * x) = (3 * tan x - tan x ^ 3) / (1 - 3 * tan x ^ 2) := by
+  have hxyz : cos (x + x + x) ≠ 0 := by rw [show x + x + x = 3 * x from by ring]; exact h3x
+  rw [show 3 * x = x + x + x from by ring, tan_add_three hx hx hx hxyz]
+  ring
+
+/-- **Triangle tangent identity, recovered from the general law.** For
+`A + B + C = π` with no angle a right angle, the parent's
+`tan A + tan B + tan C = tan A · tan B · tan C` is exactly the statement that the
+numerator `e₁ - e₃` of `tan (A + B + C) = tan π = 0` vanishes. -/
+theorem tan_sum_eq_tan_prod_of_three (h : A + B + C = π)
+    (hA : cos A ≠ 0) (hB : cos B ≠ 0) (hC : cos C ≠ 0) :
+    tan A + tan B + tan C = tan A * tan B * tan C := by
+  have hABC : cos (A + B + C) ≠ 0 := by rw [h, cos_pi]; norm_num
+  have hcc : cos A * cos B * cos C ≠ 0 := mul_ne_zero (mul_ne_zero hA hB) hC
+  -- the denominator `1 - e₂` is nonzero because `cos (A+B+C) = (cos A cos B cos C)·(1 - e₂)`
+  have hden_ne : (1 : ℝ) - (tan A * tan B + tan B * tan C + tan C * tan A) ≠ 0 := by
+    have hexp : cos (A + B + C)
+        = cos A * cos B * cos C
+            * (1 - (tan A * tan B + tan B * tan C + tan C * tan A)) := by
+      rw [tan_eq_sin_div_cos, tan_eq_sin_div_cos, tan_eq_sin_div_cos,
+        show A + B + C = (A + B) + C from by ring, cos_add, sin_add, cos_add]
+      field_simp <;> ring
+    intro hzero
+    exact hABC (by rw [hexp, hzero, mul_zero])
+  have key := tan_add_three hA hB hC hABC
+  rw [h, tan_pi] at key
+  rw [eq_comm, div_eq_zero_iff] at key
+  rcases key with hnum | hbad
+  · linarith
+  · exact absurd hbad hden_ne
+

--- a/src/data/proofs/tangent-addition-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01-oq-01/annotations.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "tangent-addition-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "From Two Angles to Three",
+    "content": "The parent entry proves the two-argument tangent law and the triangle identity for A+B+C=π. This file takes the genuinely more general step: tan(x+y+z) expressed in the elementary symmetric polynomials of tan x, tan y, tan z. The triple-angle formula and the triangle identity both fall out as corollaries — all 0 axioms / 0 sorries.",
+    "mathContext": "e₁ = Σ tan, e₂ = Σ tan·tan, e₃ = ∏ tan; the law is tan(x+y+z) = (e₁ - e₃)/(1 - e₂).",
+    "significance": "key",
+    "relatedConcepts": [
+      "tangent addition law",
+      "elementary symmetric polynomials",
+      "multiple-angle formulas"
+    ],
+    "prerequisites": [
+      "tangent addition law",
+      "sine and cosine angle-sum identities"
+    ]
+  },
+  {
+    "id": "ann-three-arg",
+    "proofId": "tangent-addition-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 72
+    },
+    "type": "theorem",
+    "title": "Three-Argument Tangent Addition Law",
+    "content": "tan(x+y+z) = (tan x + tan y + tan z - tan x tan y tan z)/(1 - (tan x tan y + tan y tan z + tan z tan x)). The proof writes both sides over cos x·cos y·cos z: the numerator is then exactly the sin_add/cos_add expansion of sin(x+y+z), the denominator that of cos(x+y+z), and the law collapses to (N/c)/(D/c) = N/D via div_div_div_cancel_right₀. This avoids the brittle nested-fraction route of substituting tan(x+y) into a second tan_add.",
+    "mathContext": "Side-conditions cos x, cos y, cos z ≠ 0 and cos(x+y+z) ≠ 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "angle-sum identities",
+      "common denominator method"
+    ],
+    "prerequisites": [
+      "Real.sin_add",
+      "Real.cos_add",
+      "Real.tan_eq_sin_div_cos"
+    ]
+  },
+  {
+    "id": "ann-triple-angle",
+    "proofId": "tangent-addition-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Triple-Angle Formula",
+    "content": "tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x), obtained by specializing the three-argument law to x=y=z and finishing with ring. The classical multiple-angle formula for the tangent.",
+    "mathContext": "Diagonal x=y=z of the symmetric law; needs cos x ≠ 0 and cos(3x) ≠ 0.",
+    "significance": "important",
+    "relatedConcepts": [
+      "multiple-angle formulas",
+      "Chebyshev-like recurrences"
+    ],
+    "prerequisites": [
+      "three-argument tangent law"
+    ]
+  },
+  {
+    "id": "ann-triangle",
+    "proofId": "tangent-addition-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 108
+    },
+    "type": "theorem",
+    "title": "Triangle Identity from the General Law",
+    "content": "For A+B+C = π, tan(A+B+C) = tan π = 0, so the numerator e₁ - e₃ of the three-argument law must vanish: tan A + tan B + tan C = tan A·tan B·tan C. The denominator 1 - e₂ is shown nonzero from cos(A+B+C) = cos A cos B cos C·(1 - e₂), and div_eq_zero_iff finishes. This recovers the parent's triangle identity as a special case of the general law.",
+    "mathContext": "A+B+C = π and cos A, cos B, cos C ≠ 0.",
+    "significance": "important",
+    "relatedConcepts": [
+      "triangle tangent identity",
+      "unification"
+    ],
+    "prerequisites": [
+      "three-argument tangent law",
+      "div_eq_zero_iff"
+    ]
+  }
+]

--- a/src/data/proofs/tangent-addition-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tangent-addition-formula-oq-01-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "tangent-addition-formula-oq-01-oq-01",
+  "title": "The Three-Argument Tangent Addition Law",
+  "slug": "tangent-addition-formula-oq-01-oq-01",
+  "description": "Extends the parent tangent addition entry from two angles to three: proves tan(x+y+z) = (e₁ - e₃)/(1 - e₂) in the elementary symmetric polynomials of tan x, tan y, tan z, derives the triple-angle formula tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x) as the diagonal, and recovers the parent's triangle identity tan A + tan B + tan C = tan A·tan B·tan C (for A+B+C=π) as the vanishing of the numerator of tan(π)=0. 0 axioms.",
+  "meta": {
+    "author": "classical (symmetric-function form)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/List_of_trigonometric_identities#Angle_sum_and_difference_identities",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TangentAdditionFormulaOQ01.lean",
+    "tags": [
+      "trigonometry",
+      "tangent",
+      "addition-formula",
+      "symmetric-polynomials",
+      "triple-angle",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.sin_add",
+        "description": "sin(a+b) = sin a cos b + cos a sin b; expands sin(x+y+z) into the symmetric numerator",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.cos_add",
+        "description": "cos(a+b) = cos a cos b - sin a sin b; expands cos(x+y+z) into the symmetric denominator",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.tan_eq_sin_div_cos",
+        "description": "tan θ = sin θ / cos θ; the bridge that puts numerator and denominator over the common product cos x·cos y·cos z",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "div_div_div_cancel_right₀",
+        "description": "(a/c)/(b/c) = a/b for c ≠ 0; collapses the common-denominator form to the symmetric quotient",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Basic"
+      },
+      {
+        "theorem": "div_eq_zero_iff",
+        "description": "a/b = 0 ↔ a = 0 ∨ b = 0; extracts the triangle identity from tan(π) = 0",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Three-argument tangent addition law tan(x+y+z) = (e₁ - e₃)/(1 - e₂) stated in the elementary symmetric polynomials of the three tangents, with directly checkable cos≠0 side-conditions — not in Mathlib and not in the parent entry",
+      "Robust common-denominator proof: the claimed numerator and denominator are exactly the sin/cos expansions of sin(x+y+z) and cos(x+y+z), so the law collapses to the field cancellation (N/c)/(D/c) = N/D, avoiding fragile nested fractions",
+      "Triple-angle tangent formula tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x) obtained as the x=y=z diagonal in one ring step",
+      "Unification: the parent's triangle identity tan A + tan B + tan C = tan A·tan B·tan C (A+B+C=π) recovered as the statement that the numerator e₁-e₃ of tan(A+B+C) = tan π = 0 vanishes"
+    ],
+    "axiomCount": 0,
+    "lineCount": 108,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The law carries the standard side-conditions cos x, cos y, cos z ≠ 0 and cos(x+y+z) ≠ 0 (the angles and their sum are not odd multiples of π/2), which are hypotheses of the theorem, not assumptions about the ambient logic.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The tangent addition law tan(x+y) = (tan x + tan y)/(1 - tan x tan y) is among the oldest trigonometric identities; its three-angle form is the natural next step and exposes the elementary symmetric polynomials e₁ = Σ tan, e₂ = Σ tan·tan, e₃ = ∏ tan. The numerator e₁ - e₃ and denominator 1 - e₂ are the tangent analogue of the symmetric shape of sin and cos of a triple sum, and they specialize to the triple-angle formula and to the classical triangle identity tan A + tan B + tan C = tan A tan B tan C.",
+    "problemStatement": "Going beyond the parent's two-argument tangent law, derive the three-argument addition formula tan(x+y+z) in terms of the tangents of the summands, and obtain the triple-angle formula and the triangle identity as corollaries.",
+    "text": "The three-argument tangent addition law in elementary symmetric form, with the triple-angle formula and the triangle identity as corollaries.",
+    "proofStrategy": "Write everything over the common denominator cos x·cos y·cos z. The numerator e₁ - e₃ then equals sin x cos y cos z + cos x sin y cos z + cos x cos y sin z - sin x sin y sin z, which is the sin_add/cos_add expansion of sin(x+y+z); the denominator 1 - e₂ equals the expansion of cos(x+y+z). The law is therefore (N/c)/(D/c) = N/D, closed by div_div_div_cancel_right₀ with c = cos x cos y cos z ≠ 0. The triple-angle formula is the x=y=z diagonal (one ring step), and the triangle identity follows from tan(A+B+C) = tan π = 0 via div_eq_zero_iff once the denominator is shown nonzero (using cos(A+B+C) = cos A cos B cos C·(1-e₂)).",
+    "keyInsights": [
+      "The numerator e₁-e₃ and denominator 1-e₂ of the tangent triple-sum are literally the sin/cos expansions of sin(x+y+z) and cos(x+y+z) divided by cos x cos y cos z",
+      "Casting the identity as (N/c)/(D/c)=N/D sidesteps the brittle nested-fraction form (tan(x+y) substituted into another tan_add) and its many denominator side-conditions",
+      "Setting x=y=z collapses the symmetric polynomials to (3t - t³)/(1 - 3t²): the classical triple-angle tangent formula",
+      "The triangle identity is the special case x+y+z = π, where tan = 0 forces the numerator e₁ - e₃ to vanish, i.e. Σ tan = ∏ tan",
+      "cos(x+y+z) = cos x cos y cos z·(1 - e₂) gives both the nonzero denominator and the geometric meaning of the side-condition"
+    ],
+    "prerequisites": [
+      "Tangent addition law (parent entry)",
+      "Angle-sum identities for sine and cosine",
+      "Elementary symmetric polynomials"
+    ]
+  },
+  "sections": [
+    {
+      "id": "three-arg-law",
+      "title": "The Three-Argument Tangent Addition Law",
+      "startLine": 46,
+      "endLine": 72,
+      "summary": "Proves tan(x+y+z) = (e₁ - e₃)/(1 - e₂) by recognizing the symmetric numerator/denominator as the sin/cos expansions of sin(x+y+z) and cos(x+y+z) over cos x cos y cos z, then cancelling via div_div_div_cancel_right₀.",
+      "mathContext": "e₁ = tan x+tan y+tan z, e₂ = Σ tan·tan, e₃ = tan x tan y tan z."
+    },
+    {
+      "id": "triple-angle",
+      "title": "Triple-Angle Formula",
+      "startLine": 74,
+      "endLine": 81,
+      "summary": "The x=y=z diagonal: tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x), one ring specialization of the three-argument law.",
+      "mathContext": "Classical multiple-angle formula for the tangent."
+    },
+    {
+      "id": "triangle-identity",
+      "title": "Triangle Identity Recovered",
+      "startLine": 83,
+      "endLine": 108,
+      "summary": "For A+B+C = π, tan(A+B+C) = tan π = 0, so the numerator e₁ - e₃ vanishes: tan A + tan B + tan C = tan A·tan B·tan C, recovering the parent's identity from the general law.",
+      "mathContext": "Denominator 1-e₂ shown nonzero via cos(A+B+C) = cos A cos B cos C·(1-e₂)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) three-argument tangent addition law in elementary symmetric form, with the triple-angle formula and the parent's triangle identity recovered as corollaries.",
+    "implications": "The symmetric-polynomial shape (e₁-e₃)/(1-e₂) unifies the tangent multiple-angle and triangle identities: the triple-angle formula is its diagonal and the triangle identity is its value at angle-sum π. The same common-denominator method extends to n angles, with numerator and denominator the odd- and even-degree elementary symmetric polynomials of the tangents.",
+    "openQuestions": [
+      "State the general n-argument tangent law tan(x₁+…+xₙ) = (e₁ - e₃ + e₅ - …)/(e₀ - e₂ + e₄ - …) with eₖ the elementary symmetric polynomials of the tangents.",
+      "Derive the cotangent triple-sum and triple-angle formulas by the same common-denominator method.",
+      "Use the triple-angle formula to give a tangent-side proof of a Machin-like π identity (cf. the MachinFromAddition gallery entry)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "tangent-addition-formula-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry establishing the two-argument tangent law, the triangle identity, and the arctan(1/2)+arctan(1/3)=π/4 application; this entry generalizes to three arguments and re-derives the triangle identity from the general law"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan",
+      "Mathlib.Analysis.Complex.Trigonometric",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "",
+    "lineCount": 108,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/TangentAdditionFormulaOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The parent gallery entry **tangent-addition-formula-oq-01** (`TangentAdditionFormula.lean`) already proves the literal open question: the two-argument tangent law, the triangle tangent/cotangent identities, and the Machin-style `arctan(1/2)+arctan(1/3)=π/4`. This PR ships the genuine **follow-up** as a new entry `tangent-addition-formula-oq-01-oq-01`.

### New results (`Proofs/TangentAdditionFormulaOQ01.lean`, 3 theorems, 108 lines)

1. **`tan_add_three`** — the three-argument tangent addition law in elementary symmetric form:
   `tan(x+y+z) = (e₁ - e₃) / (1 - e₂)` where `e₁ = Σ tan`, `e₂ = Σ tan·tan`, `e₃ = ∏ tan`,
   under `cos x, cos y, cos z ≠ 0` and `cos(x+y+z) ≠ 0`. Not in Mathlib, not in the parent.
2. **`tan_three_mul`** — triple-angle formula `tan(3x) = (3 tan x - tan³x)/(1 - 3 tan²x)`, the `x=y=z` diagonal.
3. **`tan_sum_eq_tan_prod_of_three`** — recovers the parent's triangle identity `tan A + tan B + tan C = tan A·tan B·tan C` (for `A+B+C=π`) as the vanishing of the numerator of `tan(π)=0`.

### Method

Rather than the brittle nested-fraction route, both sides are placed over the common denominator `cos x·cos y·cos z`. The numerator `e₁-e₃` is then exactly the `sin_add`/`cos_add` expansion of `sin(x+y+z)` and the denominator `1-e₂` that of `cos(x+y+z)`, so the law collapses to `(N/c)/(D/c) = N/D` via `div_div_div_cancel_right₀`.

### Verification

- Builds against Mathlib 4.26.0 (`docker-build.sh Proofs.TangentAdditionFormulaOQ01`).
- `#print axioms` on all three: `[propext, Classical.choice, Quot.sound]` only — **0 axioms**, no `Lean.ofReduceBool`, no `native_decide`, 0 sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)