### PR TITLE
research(basel-problem-oq-03): multiple zeta values and relations among single zeta values

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -251,6 +251,7 @@ import Proofs.BaselProblemOQ01OQ03
 import Proofs.BaselProblemOQ01OQ05
 import Proofs.BaselProblemOQ02
 import Proofs.BaselProblemOQ02Aristotle
+import Proofs.BaselProblemOQ03
 import Proofs.BaselProblemOQ04
 import Proofs.BaselProblemOQ04OQ03
 import Proofs.BaselProblemOQ05

--- a/proofs/Proofs/BaselProblemOQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ03.lean
@@ -1,0 +1,177 @@
+import Mathlib.NumberTheory.ZetaValues
+import Mathlib.NumberTheory.Bernoulli
+import Mathlib.Tactic
+
+/-
+# Basel Problem (OQ-03): Multiple Zeta Values — Relationship to Single Zeta Values
+
+Open Question (OQ-03 from the Basel Problem ∑ 1/n² = π²/6):
+What is the relationship between multiple zeta values and single zeta values?
+
+## Background
+
+The Basel problem evaluates the single zeta value ζ(2) = ∑_{n≥1} 1/n² = π²/6.
+Euler's general formula extends this to every even argument:
+
+  ζ(2k) = (-1)^{k+1} · 2^{2k-1} · π^{2k} · B_{2k} / (2k)!
+
+so each even zeta value is a *rational multiple of π^{2k}* (`Mathlib`'s
+`hasSum_zeta_nat`). A striking structural consequence is that the even zeta
+values are **algebraically degenerate**: any product of them collapses back to a
+single even zeta value times a rational. These "product-reduction" identities are
+the single-variable shadow of the *stuffle* (harmonic) product of multiple zeta
+values (MZVs).
+
+## This File
+
+We derive the closed forms ζ(2), ζ(4), ζ(6), ζ(8) from Euler's formula (the
+last two require the Bernoulli numbers B₆ = 1/42 and B₈ = -1/30, which are not in
+Mathlib and are computed here from the defining recursion), and prove the
+product-reduction relations among the *actual* zeta series:
+
+* `zeta_two_sq`        : ζ(2)² = (5/2)·ζ(4)
+* `zeta_two_mul_four`  : ζ(2)·ζ(4) = (7/4)·ζ(6)
+* `zeta_two_cubed`     : ζ(2)³ = (35/8)·ζ(6)
+* `zeta_four_sq`       : ζ(4)² = (7/6)·ζ(8)
+* `zeta_two_mul_six`   : ζ(2)·ζ(6) = (5/3)·ζ(8)
+
+and record the simplest genuine MZV value forced by the stuffle relation
+ζ(2)² = ζ(4) + 2·ζ(2,2):
+
+* `mzv_two_two_value`  : (ζ(2)² − ζ(4))/2 = π⁴/120   (i.e. ζ(2,2) = π⁴/120)
+
+## Status
+
+Verified. Axioms: 0 (no `native_decide`). Sorries: 0.
+-/
+
+namespace BaselProblemOQ03
+
+open scoped Real
+open Nat Finset
+
+/-! ## Bernoulli numbers B₆ and B₈
+
+Mathlib stocks `bernoulli'_two`, `bernoulli'_three`, `bernoulli'_four` but stops
+there.  We compute the next two even Bernoulli numbers from the defining
+recursion `bernoulli'_def`, using that the odd ones (B₅, B₇) vanish. -/
+
+theorem bernoulli'_five : bernoulli' 5 = 0 :=
+  bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+
+theorem bernoulli'_seven : bernoulli' 7 = 0 :=
+  bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+
+theorem bernoulli'_six : bernoulli' 6 = 1 / 42 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_two, bernoulli'_three, bernoulli'_four, bernoulli'_five, Nat.choose]
+
+theorem bernoulli'_eight : bernoulli' 8 = -1 / 30 := by
+  rw [bernoulli'_def]
+  norm_num [sum_range_succ, sum_range_zero, bernoulli'_zero, bernoulli'_one,
+    bernoulli'_two, bernoulli'_three, bernoulli'_four, bernoulli'_five,
+    bernoulli'_six, bernoulli'_seven, Nat.choose]
+
+theorem bernoulli_six : bernoulli 6 = 1 / 42 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_six]
+
+theorem bernoulli_eight : bernoulli 8 = -1 / 30 := by
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide), bernoulli'_eight]
+
+/-! ## Closed forms for even zeta values
+
+`hasSum_zeta_two` and `hasSum_zeta_four` are in Mathlib; we add ζ(6) and ζ(8). -/
+
+theorem hasSum_zeta_six :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 6) (π ^ 6 / 945) := by
+  have h := hasSum_zeta_nat (k := 3) (by norm_num)
+  simp only [(by norm_num : (2 * 3 : ℕ) = 6), (by norm_num : (2 * 3 - 1 : ℕ) = 5)] at h
+  rw [bernoulli_six] at h
+  convert h using 1
+  rw [show (6 : ℕ)! = 720 from by norm_num]
+  push_cast
+  ring
+
+theorem hasSum_zeta_eight :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8) (π ^ 8 / 9450) := by
+  have h := hasSum_zeta_nat (k := 4) (by norm_num)
+  simp only [(by norm_num : (2 * 4 : ℕ) = 8), (by norm_num : (2 * 4 - 1 : ℕ) = 7)] at h
+  rw [bernoulli_eight] at h
+  convert h using 1
+  rw [show (8 : ℕ)! = 40320 from by norm_num]
+  push_cast
+  ring
+
+/-! ## The single even zeta values as `tsum`s -/
+
+theorem tsum_zeta_two : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2 = π ^ 2 / 6 :=
+  hasSum_zeta_two.tsum_eq
+
+theorem tsum_zeta_four : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4 = π ^ 4 / 90 :=
+  hasSum_zeta_four.tsum_eq
+
+theorem tsum_zeta_six : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6 = π ^ 6 / 945 :=
+  hasSum_zeta_six.tsum_eq
+
+theorem tsum_zeta_eight : ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8 = π ^ 8 / 9450 :=
+  hasSum_zeta_eight.tsum_eq
+
+/-! ## Product-reduction relations among single zeta values
+
+Each product of even zeta values is a rational multiple of a single even zeta
+value of the summed weight.  These are exact identities between the genuine
+infinite series (not just the π-expressions). -/
+
+/-- ζ(2)² = (5/2)·ζ(4). The classical Euler relation; also the stuffle product
+of ζ(2) with itself, modulo the diagonal term. -/
+theorem zeta_two_sq :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 2
+      = (5 / 2) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4 := by
+  rw [tsum_zeta_two, tsum_zeta_four]; ring
+
+/-- ζ(2)·ζ(4) = (7/4)·ζ(6). -/
+theorem zeta_two_mul_four :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4)
+      = (7 / 4) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6 := by
+  rw [tsum_zeta_two, tsum_zeta_four, tsum_zeta_six]; ring
+
+/-- ζ(2)³ = (35/8)·ζ(6). -/
+theorem zeta_two_cubed :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 3
+      = (35 / 8) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6 := by
+  rw [tsum_zeta_two, tsum_zeta_six]; ring
+
+/-- ζ(4)² = (7/6)·ζ(8). -/
+theorem zeta_four_sq :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) ^ 2
+      = (7 / 6) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8 := by
+  rw [tsum_zeta_four, tsum_zeta_eight]; ring
+
+/-- ζ(2)·ζ(6) = (5/3)·ζ(8). -/
+theorem zeta_two_mul_six :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) * (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 6)
+      = (5 / 3) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8 := by
+  rw [tsum_zeta_two, tsum_zeta_six, tsum_zeta_eight]; ring
+
+/-! ## The double zeta value ζ(2,2)
+
+The harmonic (stuffle) product gives ζ(2)·ζ(2) = ζ(4) + 2·ζ(2,2), where
+ζ(2,2) = ∑_{m>n≥1} 1/(m²n²) is the simplest genuine multiple zeta value.
+Solving for ζ(2,2) and substituting the closed forms above yields its exact
+value — a single rational multiple of π⁴, the canonical example of MZV ↔ single
+zeta value reduction. -/
+
+/-- ζ(2,2) = (ζ(2)² − ζ(4))/2 = π⁴/120. -/
+theorem mzv_two_two_value :
+    ((∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 2 - ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) / 2
+      = π ^ 4 / 120 := by
+  rw [tsum_zeta_two, tsum_zeta_four]; ring
+
+/-- Equivalently, ζ(2,2) is the weight-4 MZV equal to (3/4)·ζ(4). -/
+theorem mzv_two_two_eq_three_quarter_zeta_four :
+    ((∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 2 - ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4) / 2
+      = (3 / 4) * ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 4 := by
+  rw [tsum_zeta_two, tsum_zeta_four]; ring
+
+end BaselProblemOQ03

--- a/src/data/proofs/basel-problem-oq-03/annotations.json
+++ b/src/data/proofs/basel-problem-oq-03/annotations.json
@@ -1,0 +1,107 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "basel-problem-oq-03",
+    "range": {
+      "startLine": 5,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "From Single Zeta Values to Multiple Zeta Values",
+    "content": "The Basel problem evaluates the single zeta value ζ(2) = π²/6. Euler's general formula makes every even zeta value a rational multiple of π^{2k}, which forces a web of polynomial relations among them — the single-variable shadow of the stuffle product on multiple zeta values (MZVs). This file derives ζ(6) and ζ(8), proves the product-reduction relations between the actual series, and records the simplest MZV value ζ(2,2) = π⁴/120. All 0 axioms / 0 sorries.",
+    "mathContext": "ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!; MZV ζ(2,2) = ∑_{m>n≥1} 1/(m²n²).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Riemann zeta function",
+      "multiple zeta values",
+      "Bernoulli numbers",
+      "stuffle product"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6",
+      "Euler's even-zeta formula"
+    ]
+  },
+  {
+    "id": "ann-bernoulli",
+    "proofId": "basel-problem-oq-03",
+    "range": {
+      "startLine": 53,
+      "endLine": 80
+    },
+    "type": "lemma",
+    "title": "Bernoulli Numbers B₆ and B₈",
+    "content": "Euler's formula needs the Bernoulli numbers, but Mathlib stocks only B₂, B₃, B₄. We compute B₆ = 1/42 and B₈ = -1/30 from the defining recursion bernoulli'_def, using that the odd Bernoulli numbers B₅, B₇ vanish (bernoulli'_eq_zero_of_odd), then convert to the 'bernoulli' convention via bernoulli_eq_bernoulli'_of_ne_one.",
+    "mathContext": "bernoulli' n = 1 - ∑_{k<n} C(n,k)/(n-k+1)·bernoulli' k.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bernoulli numbers",
+      "recursive definition"
+    ],
+    "prerequisites": [
+      "Bernoulli number recursion"
+    ]
+  },
+  {
+    "id": "ann-closed-forms",
+    "proofId": "basel-problem-oq-03",
+    "range": {
+      "startLine": 82,
+      "endLine": 118
+    },
+    "type": "theorem",
+    "title": "Closed Forms ζ(6) = π⁶/945 and ζ(8) = π⁸/9450",
+    "content": "Instantiating Euler's hasSum_zeta_nat at k=3 and k=4, with B₆ and B₈ substituted, gives ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 after a push_cast/ring normalization of the constant. Together with Mathlib's ζ(2) and ζ(4), all four even values are packaged as tsums so the relations below are stated between genuine infinite series.",
+    "mathContext": "ζ(6): (-1)⁴·2⁵·π⁶·(1/42)/720 = π⁶/945; ζ(8): (-1)⁵·2⁷·π⁸·(-1/30)/40320 = π⁸/9450.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's even-zeta formula",
+      "Riemann zeta function"
+    ],
+    "prerequisites": [
+      "Bernoulli numbers B₆, B₈"
+    ]
+  },
+  {
+    "id": "ann-product-relations",
+    "proofId": "basel-problem-oq-03",
+    "range": {
+      "startLine": 120,
+      "endLine": 155
+    },
+    "type": "theorem",
+    "title": "Product-Reduction Relations",
+    "content": "Five exact identities among the infinite series: ζ(2)² = (5/2)ζ(4), ζ(2)·ζ(4) = (7/4)ζ(6), ζ(2)³ = (35/8)ζ(6), ζ(4)² = (7/6)ζ(8), and ζ(2)·ζ(6) = (5/3)ζ(8). Each holds because both sides are rational multiples of the same power of π; the proof rewrites the tsum closed forms and finishes with one ring step. ζ(2)² = (5/2)ζ(4) is the classical Euler relation and the stuffle square of ζ(2).",
+    "mathContext": "Products of even zeta values reduce to a single even zeta value of the summed weight.",
+    "significance": "key",
+    "relatedConcepts": [
+      "stuffle product",
+      "algebraic relations among zeta values"
+    ],
+    "prerequisites": [
+      "closed forms for ζ(2), ζ(4), ζ(6), ζ(8)"
+    ]
+  },
+  {
+    "id": "ann-double-zeta",
+    "proofId": "basel-problem-oq-03",
+    "range": {
+      "startLine": 157,
+      "endLine": 177
+    },
+    "type": "theorem",
+    "title": "The Double Zeta Value ζ(2,2) = π⁴/120",
+    "content": "The harmonic (stuffle) product gives ζ(2)·ζ(2) = ζ(4) + 2·ζ(2,2), where ζ(2,2) = ∑_{m>n≥1} 1/(m²n²) is the simplest genuine multiple zeta value. Solving and substituting the closed forms yields ζ(2,2) = (ζ(2)²−ζ(4))/2 = π⁴/120 = (3/4)ζ(4) — the canonical example of a multiple zeta value expressed through single zeta values.",
+    "mathContext": "(π⁴/36 − π⁴/90)/2 = π⁴/120; equivalently (3/4)·π⁴/90.",
+    "significance": "key",
+    "relatedConcepts": [
+      "multiple zeta values",
+      "double zeta value",
+      "stuffle relation"
+    ],
+    "prerequisites": [
+      "product-reduction relations",
+      "stuffle product ζ(2)² = ζ(4) + 2ζ(2,2)"
+    ]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-03/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "basel-problem-oq-03",
+  "title": "Multiple Zeta Values: Relationship to Single Zeta Values",
+  "slug": "basel-problem-oq-03",
+  "description": "Extends the Basel problem (ζ(2) = π²/6) along Euler's even-zeta formula. Derives the closed forms ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 (computing the Bernoulli numbers B₆ = 1/42 and B₈ = -1/30, which Mathlib does not stock, from the defining recursion), then proves the product-reduction relations ζ(2)² = (5/2)ζ(4), ζ(2)·ζ(4) = (7/4)ζ(6), ζ(2)³ = (35/8)ζ(6), ζ(4)² = (7/6)ζ(8), ζ(2)·ζ(6) = (5/3)ζ(8) directly between the infinite series. Records the simplest genuine multiple zeta value ζ(2,2) = π⁴/120 = (3/4)ζ(4) forced by the stuffle relation ζ(2)² = ζ(4) + 2ζ(2,2). 0 axioms.",
+  "meta": {
+    "author": "Leonhard Euler (even-zeta formula); product relations / MZV reduction",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
+    "date": "1740",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaselProblemOQ03.lean",
+    "tags": [
+      "number-theory",
+      "zeta-function",
+      "multiple-zeta-values",
+      "bernoulli-numbers",
+      "series",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "Euler's formula ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!; instantiated at k=3,4 to get ζ(6) and ζ(8)",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "ζ(2) = ∑ 1/n² = π²/6, the Basel identity",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_four",
+        "description": "ζ(4) = ∑ 1/n⁴ = π⁴/90",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "bernoulli'_def",
+        "description": "The defining recursion bernoulli' n = 1 - ∑_{k<n} C(n,k)/(n-k+1)·bernoulli' k; unfolded to evaluate B₆ and B₈",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "Odd Bernoulli numbers above 1 vanish; supplies B₅ = B₇ = 0 inside the recursion",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli_eq_bernoulli'_of_ne_one",
+        "description": "bernoulli n = bernoulli' n for n ≠ 1; bridges the two Bernoulli conventions for the even arguments used by hasSum_zeta_nat",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "HasSum.tsum_eq",
+        "description": "Turns the HasSum closed forms into the value of the corresponding tsum, so the relations are stated between the actual series",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Closed forms ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 derived from Euler's hasSum_zeta_nat, including the Bernoulli numbers B₆ = 1/42 and B₈ = -1/30 computed from the defining recursion (Mathlib only stocks B₂, B₃, B₄)",
+      "Product-reduction relations proved directly between the infinite series: ζ(2)² = (5/2)ζ(4), ζ(2)·ζ(4) = (7/4)ζ(6), ζ(2)³ = (35/8)ζ(6), ζ(4)² = (7/6)ζ(8), ζ(2)·ζ(6) = (5/3)ζ(8) — the single-variable shadow of the stuffle (harmonic) product of multiple zeta values",
+      "The double zeta value ζ(2,2) = π⁴/120 = (3/4)ζ(4), the value forced by the stuffle relation ζ(2)² = ζ(4) + 2ζ(2,2), recorded as the canonical example of an MZV reducing to single zeta values",
+      "0 axioms (only propext / Classical.choice / Quot.sound), 0 sorries, no native_decide"
+    ],
+    "axiomCount": 0,
+    "lineCount": 177,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The double zeta value ζ(2,2) is recorded via its stuffle-relation value (ζ(2)² − ζ(4))/2; the underlying stuffle identity ζ(2)² = ζ(4) + 2ζ(2,2) is stated as the motivation rather than proved from the double sum.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 13,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler solved the Basel problem in 1734 (ζ(2) = π²/6) and by 1740 had the general formula ζ(2k) = (-1)^{k+1}·2^{2k-1}·B_{2k}·π^{2k}/(2k)!, showing every even zeta value is a rational multiple of π^{2k}. The theory of multiple zeta values (MZVs) ζ(s₁,…,s_r) = ∑_{n₁>…>n_r≥1} ∏ n_i^{-s_i}, revived by Zagier and others in the 1990s, studies the rich algebra of relations these satisfy; the shuffle and stuffle products express products of MZVs as integer combinations of MZVs.",
+    "problemStatement": "What is the relationship between multiple zeta values and the single zeta values ζ(2k)? Concretely: are products of even zeta values themselves expressible through single zeta values, and what value does the simplest double zeta value ζ(2,2) take?",
+    "text": "Closed forms for ζ(6), ζ(8) and the product-reduction relations among even single zeta values, with the double zeta value ζ(2,2) = π⁴/120 as the simplest MZV reduction.",
+    "proofStrategy": "Compute B₆ and B₈ from bernoulli'_def (using that the odd Bernoulli numbers B₅, B₇ vanish), convert to the bernoulli convention, and instantiate hasSum_zeta_nat at k=3,4 to obtain ζ(6)=π⁶/945 and ζ(8)=π⁸/9450. Convert all four HasSum statements to tsum values. Because each ζ(2k) is a rational multiple of π^{2k}, every product of even zeta values is — by matching π-powers — a rational multiple of a single ζ of the summed weight; each relation is then closed by rewriting the tsum closed forms and a single ring step. The double zeta value ζ(2,2) is obtained as (ζ(2)²−ζ(4))/2, the quantity the stuffle relation ζ(2)² = ζ(4) + 2ζ(2,2) forces.",
+    "keyInsights": [
+      "Euler's formula makes every even zeta value a rational multiple of π^{2k}, so the ring they generate is highly degenerate: products collapse to single values",
+      "ζ(2)² = (5/2)ζ(4) is both the classical Euler relation and the stuffle square of ζ(2) modulo its diagonal term",
+      "Mathlib stops at B₄; B₆ = 1/42 and B₈ = -1/30 are recovered from the defining recursion with the odd-index vanishing lemma",
+      "The double zeta value ζ(2,2) = π⁴/120 = (3/4)ζ(4) is the smallest genuine MZV and the canonical witness of MZV ↔ single-zeta reduction",
+      "Stating the relations between tsums (not just π-expressions) keeps them honest identities about the infinite series themselves"
+    ],
+    "prerequisites": [
+      "Basel problem ζ(2) = π²/6 (parent entry)",
+      "Bernoulli numbers and Euler's even-zeta formula",
+      "Convergent infinite series (tsum)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "bernoulli",
+      "title": "Bernoulli Numbers B₆ and B₈",
+      "startLine": 53,
+      "endLine": 80,
+      "summary": "Computes B₆ = 1/42 and B₈ = -1/30 from the defining recursion bernoulli'_def, using bernoulli'_eq_zero_of_odd for B₅ = B₇ = 0, then converts to the bernoulli convention needed by Euler's formula.",
+      "mathContext": "Mathlib stocks only B₂, B₃, B₄; these are the next two even Bernoulli numbers."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Closed Forms for ζ(6) and ζ(8)",
+      "startLine": 82,
+      "endLine": 118,
+      "summary": "Instantiates Euler's hasSum_zeta_nat at k=3,4 to obtain ζ(6) = π⁶/945 and ζ(8) = π⁸/9450, and packages ζ(2),ζ(4),ζ(6),ζ(8) as tsum values.",
+      "mathContext": "ζ(2k) = (-1)^{k+1}·2^{2k-1}·π^{2k}·B_{2k}/(2k)!."
+    },
+    {
+      "id": "product-relations",
+      "title": "Product-Reduction Relations",
+      "startLine": 120,
+      "endLine": 155,
+      "summary": "Five exact identities between the infinite series: ζ(2)²=(5/2)ζ(4), ζ(2)·ζ(4)=(7/4)ζ(6), ζ(2)³=(35/8)ζ(6), ζ(4)²=(7/6)ζ(8), ζ(2)·ζ(6)=(5/3)ζ(8).",
+      "mathContext": "The single-variable shadow of the stuffle product on multiple zeta values."
+    },
+    {
+      "id": "double-zeta",
+      "title": "The Double Zeta Value ζ(2,2)",
+      "startLine": 157,
+      "endLine": 177,
+      "summary": "Records ζ(2,2) = (ζ(2)²−ζ(4))/2 = π⁴/120 = (3/4)ζ(4), the value the stuffle relation ζ(2)² = ζ(4) + 2ζ(2,2) forces — the simplest MZV expressed through single zeta values.",
+      "mathContext": "ζ(2,2) = ∑_{m>n≥1} 1/(m²n²), the simplest genuine multiple zeta value."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) closed forms for ζ(6) and ζ(8), the product-reduction relations among even single zeta values, and the double zeta value ζ(2,2) = π⁴/120, exhibiting the relationship between multiple and single zeta values.",
+    "implications": "Because each even zeta value is a rational multiple of π^{2k}, the even zeta values are algebraically degenerate and products of them reduce to single values; the double zeta value ζ(2,2) shows the same reduction one level up in the MZV hierarchy. These are the elementary instances of the shuffle/stuffle relations that organize the whole algebra of multiple zeta values.",
+    "openQuestions": [
+      "Prove the stuffle relation ζ(2)² = ζ(4) + 2ζ(2,2) directly from the double sum ∑_{m>n} 1/(m²n²) via a Fubini/diagonal split, upgrading ζ(2,2) = π⁴/120 from 'value forced by stuffle' to a fully derived theorem.",
+      "Formalize Euler's reflection ζ(2,1) = ζ(3), the first MZV relation expressing a weight-3 double value through a single odd zeta value.",
+      "State the general even-weight reduction: every monomial ∏ ζ(2k_i) is a rational multiple of π^{2∑k_i}, hence of the single value ζ(2∑k_i)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "basel-problem",
+      "relationship": "parent",
+      "description": "Parent entry establishing ζ(2) = π²/6; this entry extends to ζ(6), ζ(8) and the relations among even zeta values and the double zeta value ζ(2,2)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.ZetaValues",
+      "Mathlib.NumberTheory.Bernoulli",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "BaselProblemOQ03",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the Basel-problem open question **OQ-03: Multiple Zeta Values — Relationship to Single Zeta Values** (tier A, significance 7).

Euler's formula makes every even zeta value a rational multiple of π^{2k}, so products of even zeta values collapse back to single values. This entry derives ζ(6), ζ(8) and proves that web of relations directly between the infinite series.

## Contributions

- **Bernoulli numbers B₆ = 1/42, B₈ = -1/30** computed from the defining recursion `bernoulli'_def` (Mathlib only stocks B₂, B₃, B₄), using `bernoulli'_eq_zero_of_odd` for B₅ = B₇ = 0.
- **Closed forms** ζ(6) = π⁶/945 and ζ(8) = π⁸/9450 from `hasSum_zeta_nat`.
- **Product-reduction relations** between the actual `tsum` series:
  - ζ(2)² = (5/2)ζ(4)  (classical Euler relation / stuffle square)
  - ζ(2)·ζ(4) = (7/4)ζ(6)
  - ζ(2)³ = (35/8)ζ(6)
  - ζ(4)² = (7/6)ζ(8)
  - ζ(2)·ζ(6) = (5/3)ζ(8)
- **Double zeta value** ζ(2,2) = π⁴/120 = (3/4)ζ(4), the value forced by the stuffle relation ζ(2)² = ζ(4) + 2ζ(2,2) — the simplest MZV reducing to single zeta values.

## Verification

- 13 theorems, 0 definitions, 177 lines.
- **0 axioms** (`#print axioms` shows only `propext` / `Classical.choice` / `Quot.sound`), **0 sorries**, **no `native_decide`**.
- Builds under Lean/Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ03`.

## Scope note

ζ(2,2) is recorded via its stuffle-relation value (ζ(2)²−ζ(4))/2; the underlying stuffle identity ζ(2)² = ζ(4) + 2ζ(2,2) is stated as motivation rather than derived from the double sum (flagged as a follow-up open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)