### PR TITLE
research(prime-gap-bounds-oq-03): connect exponential prime bound to Chebyshev θ and ψ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3167,6 +3167,7 @@ import Proofs.PowerMeanLimitOQ
 import Proofs.PowerMeanMonotoneOQ
 import Proofs.PrimeGapBounds
 import Proofs.PrimeGapBoundsOQ01
+import Proofs.PrimeGapBoundsOQ03
 import Proofs.PrimeNumberTheorem
 import Proofs.PrimeNumberTheoremOQ01
 import Proofs.PrimeNumberTheoremOQ01OQ01

--- a/proofs/Proofs/PrimeGapBoundsOQ03.lean
+++ b/proofs/Proofs/PrimeGapBoundsOQ03.lean
@@ -1,0 +1,152 @@
+/-
+  Connecting the exponential prime bound to the Chebyshev functions θ and ψ
+  =========================================================================
+
+  Open question (prime-gap-bounds, OQ #3):
+    "Connect the exponential bound p_n ≤ 2^(n+1) to the Chebyshev functions
+     θ(x) and ψ(x)."
+
+  The parent entry `PrimeGapBounds` proves, by elementary induction from
+  Bertrand's postulate, the exponential bound on the n-th prime
+
+      PrimeGapBounds.nth_prime_le_two_pow_succ : nth Prime n ≤ 2 ^ (n + 1).
+
+  Mathlib v4.26.0's `Mathlib.NumberTheory.Chebyshev` develops the two Chebyshev
+  prime-power summatory functions
+
+      ψ(x) = ∑_{p^k ≤ x} log p,        θ(x) = ∑_{p ≤ x} log p
+
+  together with the elementary upper bounds θ(x) ≤ x·log 4 and
+  ψ(x) ≤ (log 4 + 4)·x, and the identity θ(x) = log (primorial ⌊x⌋₊).
+
+  This file plugs the parent's exponential prime bound into that machinery to
+  obtain *two-sided* control of θ, ψ, and the primorial **evaluated at the
+  n-th prime**:
+
+    • θ(p_n) ≤ (log 4)·2^(n+1)                          [Chebyshev upper bound]
+    • (n+1)·log 2 ≤ θ(p_n)                              [counting lower bound]
+    • ψ(p_n) ≤ (log 4 + 4)·2^(n+1)                       [Chebyshev upper bound]
+    • θ(p_n) ≤ ψ(p_n)                                    [θ ≤ ψ]
+    • 2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1))             [doubly-exponential]
+
+  The lower bounds rest on the exact prime count
+      #{ p ≤ p_n : p prime } = n + 1,
+  which we read off from `Nat.primeCounting'_nth_eq` and `Nat.count_succ`.
+
+  Everything is fully verified: 0 sorries, 0 `axiom` declarations, no
+  `native_decide`.  `#print axioms` reports only the foundational
+  [propext, Classical.choice, Quot.sound].
+-/
+import Mathlib
+import Proofs.PrimeGapBounds
+
+open Nat Chebyshev Finset
+
+namespace PrimeGapBoundsOQ03
+
+/-- The exponential bound on the n-th prime, cast to the reals. -/
+theorem nth_prime_le_two_pow_succ_real (n : ℕ) :
+    (Nat.nth Nat.Prime n : ℝ) ≤ 2 ^ (n + 1) := by
+  exact_mod_cast PrimeGapBounds.nth_prime_le_two_pow_succ n
+
+/-! ### θ at the n-th prime -/
+
+/-- **Chebyshev upper bound at the n-th prime.**  Combining θ-monotonicity with
+the exponential prime bound `p_n ≤ 2^(n+1)` and Mathlib's `θ(x) ≤ x·log 4`. -/
+theorem theta_nth_prime_le (n : ℕ) :
+    θ (Nat.nth Nat.Prime n) ≤ Real.log 4 * 2 ^ (n + 1) := by
+  calc θ (Nat.nth Nat.Prime n)
+      ≤ θ ((2 : ℝ) ^ (n + 1)) := theta_mono (nth_prime_le_two_pow_succ_real n)
+    _ ≤ Real.log 4 * 2 ^ (n + 1) := theta_le_log4_mul_x (by positivity)
+
+/-! ### The exact prime count below `p_n` and the primorial sandwich -/
+
+/-- There are exactly `n + 1` primes `≤ p_n` (the primes `p_0, …, p_n`).  This is
+the combinatorial input for both the primorial lower bound and the θ lower bound. -/
+theorem prime_count_nth_prime (n : ℕ) :
+    ((Finset.range (Nat.nth Nat.Prime n + 1)).filter (fun p => Nat.Prime p)).card
+      = n + 1 := by
+  rw [← Nat.count_eq_card_filter_range, Nat.count_succ,
+      if_pos (Nat.prime_nth_prime n)]
+  have hc : Nat.count Nat.Prime (Nat.nth Nat.Prime n) = n :=
+    Nat.primeCounting'_nth_eq n
+  omega
+
+/-- **Lower bound on the primorial.**  The product of the `n + 1` primes `≤ p_n`
+is at least `2^(n+1)`, since each prime is `≥ 2`. -/
+theorem two_pow_le_primorial (n : ℕ) :
+    2 ^ (n + 1) ≤ primorial (Nat.nth Nat.Prime n) := by
+  have hge := Finset.pow_card_le_prod
+      ((Finset.range (Nat.nth Nat.Prime n + 1)).filter (fun p => Nat.Prime p))
+      (fun p => p) 2
+      (fun p hp => (Finset.mem_filter.mp hp).2.two_le)
+  calc 2 ^ (n + 1)
+      = 2 ^ ((Finset.range (Nat.nth Nat.Prime n + 1)).filter
+              (fun p => Nat.Prime p)).card := by rw [prime_count_nth_prime]
+    _ ≤ primorial (Nat.nth Nat.Prime n) := by unfold primorial; exact hge
+
+/-- **Upper bound on the primorial.**  Mathlib's `primorial_le_4_pow` together
+with the exponential prime bound gives the doubly-exponential bound
+`primorial p_n ≤ 4^(2^(n+1))`. -/
+theorem primorial_nth_prime_le (n : ℕ) :
+    primorial (Nat.nth Nat.Prime n) ≤ 4 ^ (2 ^ (n + 1)) := by
+  calc primorial (Nat.nth Nat.Prime n)
+      ≤ 4 ^ (Nat.nth Nat.Prime n) := primorial_le_4_pow _
+    _ ≤ 4 ^ (2 ^ (n + 1)) :=
+        Nat.pow_le_pow_right (by norm_num)
+          (PrimeGapBounds.nth_prime_le_two_pow_succ n)
+
+/-- The two-sided doubly-exponential bound on the primorial of the n-th prime. -/
+theorem primorial_nth_prime_bounds (n : ℕ) :
+    2 ^ (n + 1) ≤ primorial (Nat.nth Nat.Prime n) ∧
+      primorial (Nat.nth Nat.Prime n) ≤ 4 ^ (2 ^ (n + 1)) :=
+  ⟨two_pow_le_primorial n, primorial_nth_prime_le n⟩
+
+/-- **Lower bound on θ at the n-th prime.**  Via `θ(p_n) = log (primorial p_n)`
+and the primorial lower bound `2^(n+1) ≤ primorial p_n`. -/
+theorem theta_nth_prime_ge (n : ℕ) :
+    (n + 1 : ℝ) * Real.log 2 ≤ θ (Nat.nth Nat.Prime n) := by
+  rw [theta_eq_log_primorial, Nat.floor_natCast]
+  have h2 : ((2 : ℝ) ^ (n + 1)) ≤ (primorial (Nat.nth Nat.Prime n) : ℝ) := by
+    exact_mod_cast two_pow_le_primorial n
+  calc (n + 1 : ℝ) * Real.log 2
+      = Real.log (2 ^ (n + 1)) := by rw [Real.log_pow]; push_cast; ring
+    _ ≤ Real.log (primorial (Nat.nth Nat.Prime n)) :=
+        Real.log_le_log (by positivity) h2
+
+/-- The two-sided Chebyshev bound on θ at the n-th prime:
+`(n+1)·log 2 ≤ θ(p_n) ≤ (log 4)·2^(n+1)`. -/
+theorem theta_nth_prime_bounds (n : ℕ) :
+    (n + 1 : ℝ) * Real.log 2 ≤ θ (Nat.nth Nat.Prime n) ∧
+      θ (Nat.nth Nat.Prime n) ≤ Real.log 4 * 2 ^ (n + 1) :=
+  ⟨theta_nth_prime_ge n, theta_nth_prime_le n⟩
+
+/-! ### ψ at the n-th prime -/
+
+/-- **Chebyshev upper bound on ψ at the n-th prime.**  From Mathlib's
+`ψ(x) ≤ (log 4 + 4)·x` and the exponential prime bound. -/
+theorem psi_nth_prime_le (n : ℕ) :
+    ψ (Nat.nth Nat.Prime n) ≤ (Real.log 4 + 4) * 2 ^ (n + 1) := by
+  have h4 : (0 : ℝ) ≤ Real.log 4 + 4 := by
+    have := Real.log_nonneg (show (1 : ℝ) ≤ 4 by norm_num); linarith
+  calc ψ (Nat.nth Nat.Prime n)
+      ≤ (Real.log 4 + 4) * (Nat.nth Nat.Prime n) :=
+        psi_le_const_mul_self (by positivity)
+    _ ≤ (Real.log 4 + 4) * 2 ^ (n + 1) :=
+        mul_le_mul_of_nonneg_left (nth_prime_le_two_pow_succ_real n) h4
+
+/-- `θ(p_n) ≤ ψ(p_n)`: the prime-power sum dominates the prime sum. -/
+theorem theta_le_psi_nth_prime (n : ℕ) :
+    θ (Nat.nth Nat.Prime n) ≤ ψ (Nat.nth Nat.Prime n) :=
+  theta_le_psi _
+
+/-- **The full chain at the n-th prime**, exhibiting both Chebyshev functions
+sandwiched against the exponential bound:
+`(n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1)`. -/
+theorem chebyshev_nth_prime_chain (n : ℕ) :
+    (n + 1 : ℝ) * Real.log 2 ≤ θ (Nat.nth Nat.Prime n) ∧
+      θ (Nat.nth Nat.Prime n) ≤ ψ (Nat.nth Nat.Prime n) ∧
+        ψ (Nat.nth Nat.Prime n) ≤ (Real.log 4 + 4) * 2 ^ (n + 1) :=
+  ⟨theta_nth_prime_ge n, theta_le_psi_nth_prime n, psi_nth_prime_le n⟩
+
+end PrimeGapBoundsOQ03

--- a/src/data/proofs/prime-gap-bounds-oq-03/annotations.json
+++ b/src/data/proofs/prime-gap-bounds-oq-03/annotations.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "ann-module-header",
+    "proofId": "prime-gap-bounds-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Linking an Elementary Prime Bound to the Chebyshev Functions",
+    "content": "The parent entry proves the exponential bound p_n ≤ 2^(n+1) on the n-th prime, entirely elementarily, from Bertrand's postulate. Mathlib separately develops the Chebyshev prime-power sums ψ(x) and θ(x) with elementary upper bounds. This file fuses the two: it evaluates θ and ψ at the n-th prime, sandwiching them between a counting lower bound and the exponential upper bound — all at 0 axioms / 0 sorries, no native_decide.",
+    "mathContext": "θ(x) = Σ_{p ≤ x} log p, ψ(x) = Σ_{p^k ≤ x} log p; the target is two-sided control at x = p_n.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Chebyshev functions",
+      "exponential prime bound",
+      "primorial"
+    ],
+    "prerequisites": [
+      "Bertrand's postulate",
+      "prime-counting function"
+    ]
+  },
+  {
+    "id": "ann-theta-upper",
+    "proofId": "prime-gap-bounds-oq-03",
+    "range": {
+      "startLine": 54,
+      "endLine": 60
+    },
+    "type": "theorem",
+    "title": "θ Upper Bound at the n-th Prime",
+    "content": "θ(p_n) ≤ (log 4)·2^(n+1). Because θ is monotone (Chebyshev.theta_mono), the parent's bound p_n ≤ 2^(n+1) gives θ(p_n) ≤ θ(2^(n+1)); Mathlib's elementary Chebyshev bound θ(x) ≤ x·log 4 then closes it. No analytic input beyond what Mathlib already packages.",
+    "mathContext": "θ(x) ≤ x·log 4 is the primorial bound primorial m ≤ 4^m in logarithmic form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotonicity of θ",
+      "Chebyshev upper bound"
+    ],
+    "prerequisites": [
+      "θ(x) ≤ x·log 4"
+    ]
+  },
+  {
+    "id": "ann-prime-count",
+    "proofId": "prime-gap-bounds-oq-03",
+    "range": {
+      "startLine": 64,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Exactly n+1 Primes ≤ p_n, and 2^(n+1) ≤ primorial p_n",
+    "content": "The count #{p ≤ p_n : p prime} is exactly n+1: Nat.count_succ peels the prime p_n itself off the count of primes strictly below it, which is π'(p_n) = n by Nat.primeCounting'_nth_eq. Since primorial p_n is the product of those n+1 primes and each is ≥ 2, Finset.pow_card_le_prod yields 2^(n+1) ≤ primorial p_n.",
+    "mathContext": "primorial m = ∏_{p ≤ m, p prime} p; the cardinality of the index filter equals π'(m+1).",
+    "significance": "key",
+    "relatedConcepts": [
+      "prime-counting function",
+      "primorial",
+      "product lower bound"
+    ],
+    "prerequisites": [
+      "π'(p_n) = n",
+      "Nat.count_succ"
+    ]
+  },
+  {
+    "id": "ann-primorial-sandwich",
+    "proofId": "prime-gap-bounds-oq-03",
+    "range": {
+      "startLine": 88,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Doubly-Exponential Primorial Sandwich",
+    "content": "2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1)). The upper bound combines Mathlib's primorial m ≤ 4^m with the exponential prime bound p_n ≤ 2^(n+1): primorial p_n ≤ 4^(p_n) ≤ 4^(2^(n+1)). The lower bound is the previous count argument. Both sides are in ℕ.",
+    "mathContext": "primorial_le_4_pow, then Nat.pow_le_pow_right on the exponent.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "primorial growth",
+      "doubly-exponential bound"
+    ],
+    "prerequisites": [
+      "primorial m ≤ 4^m"
+    ]
+  },
+  {
+    "id": "ann-theta-lower",
+    "proofId": "prime-gap-bounds-oq-03",
+    "range": {
+      "startLine": 105,
+      "endLine": 122
+    },
+    "type": "theorem",
+    "title": "θ Lower Bound via the Primorial",
+    "content": "(n+1)·log 2 ≤ θ(p_n). Mathlib provides no lower bound for θ or ψ, so this is routed through the primorial: θ(p_n) = log(primorial ⌊p_n⌋₊) = log(primorial p_n), and 2^(n+1) ≤ primorial p_n gives log(2^(n+1)) = (n+1)·log 2 ≤ θ(p_n) by monotonicity of log.",
+    "mathContext": "Chebyshev.theta_eq_log_primorial bridges θ and the primorial; Real.log_pow and Real.log_le_log finish.",
+    "significance": "key",
+    "relatedConcepts": [
+      "θ = log primorial",
+      "logarithm monotonicity"
+    ],
+    "prerequisites": [
+      "θ(x) = log(primorial ⌊x⌋₊)",
+      "2^(n+1) ≤ primorial p_n"
+    ]
+  },
+  {
+    "id": "ann-psi-chain",
+    "proofId": "prime-gap-bounds-oq-03",
+    "range": {
+      "startLine": 124,
+      "endLine": 150
+    },
+    "type": "theorem",
+    "title": "ψ Upper Bound and the Full Chain",
+    "content": "ψ(p_n) ≤ (log 4 + 4)·2^(n+1) from Mathlib's explicit-constant bound ψ(x) ≤ (log 4 + 4)·x applied at p_n and the exponential prime bound. With θ(p_n) ≤ ψ(p_n) (Chebyshev.theta_le_psi) the file closes the chain (n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1), linking both Chebyshev functions to the exponential bound.",
+    "mathContext": "ψ dominates θ since it also counts prime powers; the constant bound has a worse main term than Chebyshev.psi_le but is simpler.",
+    "significance": "key",
+    "relatedConcepts": [
+      "ψ ≥ θ",
+      "Chebyshev upper bound"
+    ],
+    "prerequisites": [
+      "ψ(x) ≤ (log 4 + 4)·x",
+      "θ(x) ≤ ψ(x)"
+    ]
+  }
+]

--- a/src/data/proofs/prime-gap-bounds-oq-03/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-03/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "prime-gap-bounds-oq-03",
+  "title": "The Exponential Prime Bound Meets the Chebyshev Functions θ and ψ",
+  "slug": "prime-gap-bounds-oq-03",
+  "description": "Connects the parent entry's elementary exponential bound p_n ≤ 2^(n+1) to Mathlib's Chebyshev prime-power summatory functions θ and ψ. Feeding the prime bound into θ-monotonicity and the Chebyshev upper bounds θ(x) ≤ x·log 4, ψ(x) ≤ (log 4 + 4)·x yields two-sided control at the n-th prime: (n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1) and 2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1)). The lower bounds use the exact prime count #{p ≤ p_n} = n+1, read off from Nat.primeCounting'_nth_eq and Nat.count_succ. 0 axioms, no native_decide.",
+  "meta": {
+    "author": "research (Chebyshev connection); θ/ψ machinery: Mathlib.NumberTheory.Chebyshev",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "classical (Chebyshev, 1852)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PrimeGapBoundsOQ03.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "chebyshev-function",
+      "primorial",
+      "prime-counting",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Chebyshev.theta_mono",
+        "description": "θ is monotone; transports the exponential prime bound p_n ≤ 2^(n+1) to θ(p_n) ≤ θ(2^(n+1))",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.theta_le_log4_mul_x",
+        "description": "θ(x) ≤ (log 4)·x, the elementary Chebyshev upper bound; evaluated at 2^(n+1)",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.theta_eq_log_primorial",
+        "description": "θ(x) = log (primorial ⌊x⌋₊); the bridge that turns the primorial lower bound into a θ lower bound",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.psi_le_const_mul_self",
+        "description": "ψ(x) ≤ (log 4 + 4)·x; the explicit-constant Chebyshev bound used at x = p_n",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "Chebyshev.theta_le_psi",
+        "description": "θ(x) ≤ ψ(x): the prime-power sum dominates the prime sum",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "primorial_le_4_pow",
+        "description": "primorial n ≤ 4^n; combined with p_n ≤ 2^(n+1) gives the doubly-exponential bound primorial p_n ≤ 4^(2^(n+1))",
+        "module": "Mathlib.NumberTheory.Primorial"
+      },
+      {
+        "theorem": "Finset.pow_card_le_prod",
+        "description": "a^(s.card) ≤ ∏ x in s, f x when a ≤ f x on s; gives 2^(n+1) ≤ primorial p_n from each prime being ≥ 2",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Nat.primeCounting'_nth_eq",
+        "description": "π'(p_n) = n (there are exactly n primes strictly below the n-th prime); with Nat.count_succ gives #{p ≤ p_n} = n+1",
+        "module": "Mathlib.NumberTheory.PrimeCounting"
+      },
+      {
+        "theorem": "PrimeGapBounds.nth_prime_le_two_pow_succ",
+        "description": "The parent entry's exponential bound p_n ≤ 2^(n+1), proved by elementary induction from Bertrand's postulate",
+        "module": "Proofs.PrimeGapBounds"
+      }
+    ],
+    "originalContributions": [
+      "Connects the parent's purely combinatorial exponential prime bound p_n ≤ 2^(n+1) to the analytic Chebyshev functions θ and ψ, evaluating both at the n-th prime",
+      "Two-sided Chebyshev sandwich at the n-th prime: (n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1), combining a counting lower bound with Mathlib's elementary upper bounds",
+      "Doubly-exponential primorial sandwich 2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1)): the lower bound from each of the n+1 primes ≤ p_n being ≥ 2, the upper from primorial_le_4_pow and the exponential prime bound",
+      "Exact prime count #{p ≤ p_n : p prime} = n+1 derived from Nat.primeCounting'_nth_eq and Nat.count_succ, the combinatorial input feeding both lower bounds",
+      "θ lower bound obtained without any θ/ψ lower bound from Mathlib (which only ships upper bounds): it is routed through the primorial via θ(x) = log(primorial ⌊x⌋₊)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 152,
+    "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. Depends on the parent entry PrimeGapBounds, itself verified at 0 axioms.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev (1852) introduced the prime-power summatory functions ψ(x) = Σ_{p^k ≤ x} log p and θ(x) = Σ_{p ≤ x} log p as the analytic carriers of the distribution of primes; they satisfy ψ(x), θ(x) ≍ x and underlie the Prime Number Theorem. The parent entry instead proves, by entirely elementary means from Bertrand's postulate, the much weaker exponential bound p_n ≤ 2^(n+1) on the n-th prime. This entry ties the two pictures together: it shows precisely what the elementary prime bound says about the Chebyshev functions, and conversely how the prime count pins down their size at the n-th prime.",
+    "problemStatement": "Connect the parent entry's exponential bound p_n ≤ 2^(n+1) to the Chebyshev functions θ(x) and ψ(x).",
+    "text": "A two-sided control of θ, ψ, and the primorial at the n-th prime, obtained by feeding the elementary exponential prime bound into Mathlib's Chebyshev machinery.",
+    "proofStrategy": "Upper bounds: θ is monotone, so p_n ≤ 2^(n+1) gives θ(p_n) ≤ θ(2^(n+1)) ≤ (log 4)·2^(n+1) by Chebyshev.theta_le_log4_mul_x; ψ(p_n) ≤ (log 4 + 4)·p_n ≤ (log 4 + 4)·2^(n+1) by Chebyshev.psi_le_const_mul_self; primorial p_n ≤ 4^(p_n) ≤ 4^(2^(n+1)) by primorial_le_4_pow and monotonicity of k ↦ 4^k. Lower bounds: the primorial of p_n is the product of the n+1 primes ≤ p_n, each ≥ 2, so 2^(n+1) ≤ primorial p_n via Finset.pow_card_le_prod, where the cardinality n+1 is the exact prime count #{p ≤ p_n} obtained from Nat.primeCounting'_nth_eq and Nat.count_succ; applying θ(x) = log(primorial ⌊x⌋₊) and monotonicity of log turns this into (n+1)·log 2 ≤ θ(p_n). Finally θ(p_n) ≤ ψ(p_n) by Chebyshev.theta_le_psi.",
+    "keyInsights": [
+      "The elementary prime bound p_n ≤ 2^(n+1) and θ-monotonicity already give a Chebyshev upper bound at the n-th prime — no analysis needed beyond Mathlib's θ(x) ≤ x·log 4",
+      "Mathlib ships only upper bounds for θ and ψ; the θ lower bound here is obtained for free by routing through the primorial identity θ(x) = log(primorial ⌊x⌋₊) and a product lower bound",
+      "The whole lower-bound story rests on one exact count: there are exactly n+1 primes ≤ p_n, namely p_0, …, p_n, which Nat.count_succ peels off the (n)-prime count π'(p_n) = n",
+      "primorial p_n is squeezed doubly-exponentially: 2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1)), the lower bound from each prime exceeding 2 and the upper from primorial_le_4_pow at the exponential prime bound",
+      "θ(p_n) ≤ ψ(p_n) completes a clean chain (n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1) linking both Chebyshev functions to the exponential bound"
+    ],
+    "prerequisites": [
+      "Exponential prime bound p_n ≤ 2^(n+1) (parent entry)",
+      "Chebyshev functions θ and ψ",
+      "Primorial and the prime-counting function"
+    ]
+  },
+  "sections": [
+    {
+      "id": "theta-upper",
+      "title": "Chebyshev Upper Bound for θ at the n-th Prime",
+      "startLine": 54,
+      "endLine": 60,
+      "summary": "θ(p_n) ≤ (log 4)·2^(n+1), by θ-monotonicity against p_n ≤ 2^(n+1) followed by Chebyshev.theta_le_log4_mul_x.",
+      "mathContext": "θ(x) = Σ_{p ≤ x} log p; Mathlib's elementary bound θ(x) ≤ x·log 4."
+    },
+    {
+      "id": "prime-count",
+      "title": "Exact Prime Count and Primorial Lower Bound",
+      "startLine": 64,
+      "endLine": 86,
+      "summary": "There are exactly n+1 primes ≤ p_n (from Nat.primeCounting'_nth_eq and Nat.count_succ), so 2^(n+1) ≤ primorial p_n via Finset.pow_card_le_prod, each prime being ≥ 2.",
+      "mathContext": "primorial m = ∏_{p ≤ m, p prime} p; π'(p_n) = n."
+    },
+    {
+      "id": "primorial-sandwich",
+      "title": "Doubly-Exponential Primorial Sandwich",
+      "startLine": 88,
+      "endLine": 103,
+      "summary": "2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1)): the upper bound from primorial_le_4_pow and the exponential prime bound, the lower from the previous section.",
+      "mathContext": "primorial_le_4_pow: primorial m ≤ 4^m."
+    },
+    {
+      "id": "theta-lower",
+      "title": "θ Lower Bound via the Primorial",
+      "startLine": 105,
+      "endLine": 122,
+      "summary": "(n+1)·log 2 ≤ θ(p_n), obtained from 2^(n+1) ≤ primorial p_n through the identity θ(x) = log(primorial ⌊x⌋₊) and monotonicity of log — Mathlib has no θ lower bound of its own.",
+      "mathContext": "θ(p_n) = log(primorial p_n) ≥ log(2^(n+1)) = (n+1)·log 2."
+    },
+    {
+      "id": "psi-and-chain",
+      "title": "ψ Upper Bound and the Full Chain",
+      "startLine": 124,
+      "endLine": 150,
+      "summary": "ψ(p_n) ≤ (log 4 + 4)·2^(n+1) by Chebyshev.psi_le_const_mul_self, and θ(p_n) ≤ ψ(p_n) by Chebyshev.theta_le_psi, assembling (n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1).",
+      "mathContext": "ψ(x) = Σ_{p^k ≤ x} log p ≥ θ(x); explicit-constant bound ψ(x) ≤ (log 4 + 4)·x."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 axioms, 0 sorries, no native_decide) connection of the parent's exponential bound p_n ≤ 2^(n+1) to the Chebyshev functions: (n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1) and the doubly-exponential primorial sandwich 2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1)).",
+    "implications": "The elementary prime bound and the analytic Chebyshev functions are made to talk to each other in Lean: the same exponential bound that controls the n-th prime controls θ and ψ at the n-th prime, while the exact prime count π'(p_n) = n supplies matching lower bounds. The gap between the (n+1)·log 2 lower bound and the 2^(n+1)·log 4 upper bound on θ(p_n) is exactly the gap between the trivial and the exponential prime bounds — a quantitative reminder that elementary methods are far from the PNT-sharp θ(p_n) ≍ p_n ≍ n log n.",
+    "openQuestions": [
+      "Sharpen the θ(p_n) lower bound from (n+1)·log 2 toward c·p_n using a Chebyshev-strength ψ lower bound (the single ingredient Mathlib still lacks).",
+      "Derive an explicit lower bound on the prime-counting function π(x) by combining θ(x) ≤ π(x)·log x with the θ lower bound at the n-th prime.",
+      "Replace the exponential bound p_n ≤ 2^(n+1) with a Dusart-type bound p_n ≤ n(log n + log log n) and recompute the Chebyshev sandwich."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prime-gap-bounds",
+      "relationship": "parent",
+      "description": "Parent entry proving the exponential bound p_n ≤ 2^(n+1) from Bertrand's postulate by elementary induction; this entry connects that bound to the Chebyshev functions θ and ψ as requested by its open question #3"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.PrimeGapBounds"
+    ],
+    "opens": [
+      "Nat",
+      "Chebyshev",
+      "Finset"
+    ],
+    "namespace": "PrimeGapBoundsOQ03",
+    "lineCount": 152,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/PrimeGapBoundsOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves open question #3 of the **prime-gap-bounds** entry: *"Connect the exponential bound p_n ≤ 2^(n+1) to the Chebyshev functions θ(x) and ψ(x)."*

The parent proves, elementarily from Bertrand's postulate, the exponential bound `p_n ≤ 2^(n+1)`. Mathlib (`Mathlib.NumberTheory.Chebyshev`) separately develops the prime-power sums θ and ψ with elementary **upper** bounds. This entry fuses the two, evaluating both Chebyshev functions at the n-th prime.

**Two-sided control at the n-th prime** (0 axioms, 0 sorries, no `native_decide`):

- `(n+1)·log 2 ≤ θ(p_n) ≤ ψ(p_n) ≤ (log 4 + 4)·2^(n+1)`
- `2^(n+1) ≤ primorial p_n ≤ 4^(2^(n+1))`  (doubly-exponential)

## Method

- **Upper bounds:** θ-monotonicity against `p_n ≤ 2^(n+1)`, then `Chebyshev.theta_le_log4_mul_x`; `Chebyshev.psi_le_const_mul_self` at `p_n`; `primorial_le_4_pow` + monotonicity of `4^·`.
- **Lower bounds:** the exact prime count `#{p ≤ p_n} = n+1` (from `Nat.primeCounting'_nth_eq` and `Nat.count_succ`) feeds `Finset.pow_card_le_prod` to give `2^(n+1) ≤ primorial p_n`. Since Mathlib ships **no** θ/ψ lower bound, the θ lower bound is routed through `θ(x) = log(primorial ⌊x⌋₊)`.

## Verification

`#print axioms` on the bundled theorems reports only `[propext, Classical.choice, Quot.sound]`. Built green via `./proofs/scripts/docker-build.sh Proofs.PrimeGapBoundsOQ03`.

9 theorems / 0 definitions, 152 lines. Gallery data added under `src/data/proofs/prime-gap-bounds-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)