### PR TITLE
research(law-of-cosines-oq-03-oq-03): hyperbolic AAA congruence — angles determine the triangle

### DIFF
--- a/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03OQ03.lean
@@ -1,0 +1,267 @@
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp
+import Mathlib.Tactic
+
+/-
+# Hyperbolic AAA Congruence — Angles Determine the Triangle
+
+## Research Problem: law-of-cosines-oq-03-oq-03
+
+A follow-up to the Hyperbolic Law of Cosines (`law-of-cosines-oq-03`) and the
+Hyperbolic Law of Sines (`law-of-cosines-oq-03-oq-02`).
+
+## Open Question
+
+In Euclidean geometry, knowing the three angles A, B, C of a triangle does **not**
+determine its size — there are infinitely many similar triangles. What happens in
+hyperbolic geometry?
+
+## Answer: AAA congruence holds
+
+The **second hyperbolic law of cosines**
+
+  cos C = -cos A · cos B + sin A · sin B · cosh c
+
+can be **inverted** to express each side purely in terms of the three angles:
+
+  cosh c = (cos C + cos A · cos B) / (sin A · sin B)
+
+(and symmetrically for cosh a, cosh b). Since `cosh` is injective on `[0, ∞)`, the
+three angles *determine the three sides*. Two hyperbolic triangles with the same
+angles are congruent — there are **no non-trivial similar triangles** in hyperbolic
+geometry.
+
+Two further consequences are formalized here:
+
+* **Internal consistency.** The angle formula `(cos C + cos A cos B)/(sin A sin B)`
+  exceeds `1` *exactly because* of the angular defect `A + B + C < π`. The defect is
+  what makes the formula yield a valid value `cosh c > 1`. This connects the defect
+  (= area) directly to the existence of the side.
+
+* **Equilateral closed form.** For an equilateral hyperbolic triangle with common
+  angle θ, every side satisfies `cosh(side) = cos θ / (1 - cos θ)`.
+
+## Status (0 sorries; structure-encoded geometric assumptions)
+
+The three second-law-of-cosines relations and the angular defect are encoded as
+structure fields (assumptions about a hyperbolic triangle, exactly as in the parent
+`law-of-cosines-oq-03`). All theorems below are derived from those assumptions with
+no additional axioms and no sorries.
+
+## References
+- Ratcliffe (2006): "Foundations of Hyperbolic Manifolds", Ch. 3 (AAA congruence)
+- Thurston (1997): "Three-Dimensional Geometry and Topology"
+-/
+
+set_option linter.unusedVariables false
+
+namespace HyperbolicAAA
+
+open Real Set
+
+-- ============================================================
+-- A hyperbolic triangle via its angles and the second law of cosines
+-- ============================================================
+
+/-- A hyperbolic triangle, specified by its three side lengths `a, b, c` and the
+    three opposite angles `A, B, C`. The geometric content is encoded in the three
+    **second laws of cosines** (one per angle) together with the angular defect
+    `A + B + C < π`. These are the same kind of structure-encoded assumptions used in
+    the parent `law-of-cosines-oq-03`. -/
+structure HyperbolicTriangle where
+  a : ℝ
+  b : ℝ
+  c : ℝ
+  A : ℝ
+  B : ℝ
+  C : ℝ
+  ha : 0 < a
+  hb : 0 < b
+  hc : 0 < c
+  hA : 0 < A
+  hB : 0 < B
+  hC : 0 < C
+  hA_lt : A < Real.pi
+  hB_lt : B < Real.pi
+  hC_lt : C < Real.pi
+  /-- Angular defect: the hyperbolic angle sum is strictly less than π. -/
+  defect : A + B + C < Real.pi
+  /-- Second law of cosines at vertex A. -/
+  lawA : Real.cos A = -Real.cos B * Real.cos C + Real.sin B * Real.sin C * Real.cosh a
+  /-- Second law of cosines at vertex B. -/
+  lawB : Real.cos B = -Real.cos A * Real.cos C + Real.sin A * Real.sin C * Real.cosh b
+  /-- Second law of cosines at vertex C. -/
+  lawC : Real.cos C = -Real.cos A * Real.cos B + Real.sin A * Real.sin B * Real.cosh c
+
+-- ============================================================
+-- PART 1: Angles are strictly between 0 and π ⟹ sines are positive
+-- ============================================================
+
+theorem sin_A_pos (t : HyperbolicTriangle) : 0 < Real.sin t.A :=
+  Real.sin_pos_of_pos_of_lt_pi t.hA t.hA_lt
+
+theorem sin_B_pos (t : HyperbolicTriangle) : 0 < Real.sin t.B :=
+  Real.sin_pos_of_pos_of_lt_pi t.hB t.hB_lt
+
+theorem sin_C_pos (t : HyperbolicTriangle) : 0 < Real.sin t.C :=
+  Real.sin_pos_of_pos_of_lt_pi t.hC t.hC_lt
+
+-- ============================================================
+-- PART 2: Inverting the second law — each side as a function of the angles
+-- ============================================================
+
+/-- **Side `c` as a function of the angles.** Inverting the second law of cosines:
+
+      cosh c = (cos C + cos A · cos B) / (sin A · sin B).
+
+    The right-hand side depends only on the angles. -/
+theorem cosh_c_eq (t : HyperbolicTriangle) :
+    Real.cosh t.c =
+      (Real.cos t.C + Real.cos t.A * Real.cos t.B) / (Real.sin t.A * Real.sin t.B) := by
+  have hne : Real.sin t.A * Real.sin t.B ≠ 0 :=
+    mul_ne_zero (sin_A_pos t).ne' (sin_B_pos t).ne'
+  rw [eq_div_iff hne]
+  linear_combination -t.lawC
+
+/-- **Side `a` as a function of the angles.** -/
+theorem cosh_a_eq (t : HyperbolicTriangle) :
+    Real.cosh t.a =
+      (Real.cos t.A + Real.cos t.B * Real.cos t.C) / (Real.sin t.B * Real.sin t.C) := by
+  have hne : Real.sin t.B * Real.sin t.C ≠ 0 :=
+    mul_ne_zero (sin_B_pos t).ne' (sin_C_pos t).ne'
+  rw [eq_div_iff hne]
+  linear_combination -t.lawA
+
+/-- **Side `b` as a function of the angles.** -/
+theorem cosh_b_eq (t : HyperbolicTriangle) :
+    Real.cosh t.b =
+      (Real.cos t.B + Real.cos t.A * Real.cos t.C) / (Real.sin t.A * Real.sin t.C) := by
+  have hne : Real.sin t.A * Real.sin t.C ≠ 0 :=
+    mul_ne_zero (sin_A_pos t).ne' (sin_C_pos t).ne'
+  rw [eq_div_iff hne]
+  linear_combination -t.lawB
+
+-- ============================================================
+-- PART 3: Internal consistency — the defect makes cosh > 1
+-- ============================================================
+
+/-- **The angular defect makes the angle formula valid.** Using only the angle bounds
+    and the defect `A + B + C < π` (no reference to the side `c`), the formula for
+    `cosh c` exceeds `1`:
+
+      (cos C + cos A · cos B) / (sin A · sin B) > 1.
+
+    The key step is `cos(A+B) > cos(π - C) = -cos C`, which holds precisely because the
+    defect gives `A + B < π - C`. Thus the angular defect is exactly what guarantees a
+    valid hyperbolic side exists. -/
+theorem angle_formula_gt_one (t : HyperbolicTriangle) :
+    1 < (Real.cos t.C + Real.cos t.A * Real.cos t.B) / (Real.sin t.A * Real.sin t.B) := by
+  have hden : 0 < Real.sin t.A * Real.sin t.B := mul_pos (sin_A_pos t) (sin_B_pos t)
+  rw [lt_div_iff₀ hden, one_mul]
+  -- Goal: sin A · sin B < cos C + cos A · cos B.
+  have hAB_pos : (0 : ℝ) ≤ t.A + t.B := by linarith [t.hA, t.hB]
+  have hpi : Real.pi - t.C ≤ Real.pi := by linarith [t.hC]
+  have hAB_lt : t.A + t.B < Real.pi - t.C := by linarith [t.defect]
+  -- cos is strictly antitone on [0, π]:  A+B < π-C  ⟹  cos(π-C) < cos(A+B).
+  have hlt : Real.cos (Real.pi - t.C) < Real.cos (t.A + t.B) :=
+    Real.cos_lt_cos_of_nonneg_of_le_pi hAB_pos hpi hAB_lt
+  rw [Real.cos_pi_sub, Real.cos_add] at hlt
+  -- hlt : -cos C < cos A · cos B - sin A · sin B
+  linarith
+
+/-- **The hyperbolic side is genuine.** `cosh c > 1`, derived from the angle formula and
+    the defect. (Consistent with `c > 0`, but proved here from the angles alone.) -/
+theorem cosh_c_gt_one (t : HyperbolicTriangle) : 1 < Real.cosh t.c := by
+  rw [cosh_c_eq t]
+  exact angle_formula_gt_one t
+
+-- ============================================================
+-- PART 4: AAA congruence — equal angles force equal sides
+-- ============================================================
+
+/-- Each `cosh`-side is determined by the angles: triangles with equal angles have
+    equal `cosh c`. -/
+theorem cosh_c_determined (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    Real.cosh t₁.c = Real.cosh t₂.c := by
+  rw [cosh_c_eq t₁, cosh_c_eq t₂, hA, hB, hC]
+
+theorem cosh_a_determined (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    Real.cosh t₁.a = Real.cosh t₂.a := by
+  rw [cosh_a_eq t₁, cosh_a_eq t₂, hA, hB, hC]
+
+theorem cosh_b_determined (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    Real.cosh t₁.b = Real.cosh t₂.b := by
+  rw [cosh_b_eq t₁, cosh_b_eq t₂, hA, hB, hC]
+
+/-- The side itself (not just its `cosh`) is determined, since `cosh` is injective on
+    `[0, ∞)` and side lengths are positive. -/
+theorem c_determined (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    t₁.c = t₂.c :=
+  Real.cosh_strictMonoOn.injOn (mem_Ici.mpr t₁.hc.le) (mem_Ici.mpr t₂.hc.le)
+    (cosh_c_determined t₁ t₂ hA hB hC)
+
+theorem a_determined (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    t₁.a = t₂.a :=
+  Real.cosh_strictMonoOn.injOn (mem_Ici.mpr t₁.ha.le) (mem_Ici.mpr t₂.ha.le)
+    (cosh_a_determined t₁ t₂ hA hB hC)
+
+theorem b_determined (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    t₁.b = t₂.b :=
+  Real.cosh_strictMonoOn.injOn (mem_Ici.mpr t₁.hb.le) (mem_Ici.mpr t₂.hb.le)
+    (cosh_b_determined t₁ t₂ hA hB hC)
+
+/-- **Hyperbolic AAA congruence.** Two hyperbolic triangles with the same three angles
+    have the same three sides. Unlike Euclidean geometry, there are no non-trivial
+    similar triangles: angles determine the triangle up to congruence. -/
+theorem aaa_congruence (t₁ t₂ : HyperbolicTriangle)
+    (hA : t₁.A = t₂.A) (hB : t₁.B = t₂.B) (hC : t₁.C = t₂.C) :
+    t₁.a = t₂.a ∧ t₁.b = t₂.b ∧ t₁.c = t₂.c :=
+  ⟨a_determined t₁ t₂ hA hB hC, b_determined t₁ t₂ hA hB hC, c_determined t₁ t₂ hA hB hC⟩
+
+-- ============================================================
+-- PART 5: Equilateral closed form
+-- ============================================================
+
+/-- **Equilateral hyperbolic triangle.** If all three angles are equal to a common
+    value θ (`= C`), then every side satisfies
+
+      cosh(side) = cos θ / (1 - cos θ).
+
+    This is a clean closed form: the side grows without bound as θ → 0 (thin, large
+    triangles) and shrinks to 0 as θ → π/3 (the Euclidean limit, where the angle sum
+    approaches π). -/
+theorem equilateral_cosh (t : HyperbolicTriangle)
+    (hAB : t.A = t.B) (hBC : t.B = t.C) :
+    Real.cosh t.c = Real.cos t.C / (1 - Real.cos t.C) := by
+  have hsC : Real.sin t.C ≠ 0 := (sin_C_pos t).ne'
+  have hsq : Real.sin t.C * Real.sin t.C
+      = (1 - Real.cos t.C) * (1 + Real.cos t.C) := by
+    nlinarith [Real.sin_sq_add_cos_sq t.C]
+  have hcos_ne : 1 - Real.cos t.C ≠ 0 := by
+    intro hh
+    apply hsC
+    have : Real.sin t.C * Real.sin t.C = 0 := by rw [hsq, hh, zero_mul]
+    exact mul_self_eq_zero.mp this
+  rw [cosh_c_eq t, hAB, hBC, div_eq_div_iff (mul_ne_zero hsC hsC) hcos_ne, hsq]
+  ring
+
+-- ============================================================
+-- PART 6: Re-exported geometric facts
+-- ============================================================
+
+/-- The hyperbolic angle sum is strictly less than π. -/
+theorem angle_sum_lt_pi (t : HyperbolicTriangle) : t.A + t.B + t.C < Real.pi :=
+  t.defect
+
+/-- The angular defect (= area) is strictly positive. -/
+theorem area_positive (t : HyperbolicTriangle) :
+    0 < Real.pi - (t.A + t.B + t.C) := by
+  linarith [t.defect]
+
+end HyperbolicAAA

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-structure-axioms",
+    "proofId": "law-of-cosines-oq-03-oq-03",
+    "range": { "startLine": 71, "endLine": 94 },
+    "type": "definition",
+    "title": "HyperbolicTriangle: 7 Structure-Encoded Axioms",
+    "content": "The structure carries side lengths a,b,c, angles A,B,C, side positivity (ha,hb,hc), angle bounds (hA,hB,hC and hA_lt,hB_lt,hC_lt), the angular defect (defect: A+B+C<π), and the three second laws of cosines (lawA,lawB,lawC). Following the CLAUDE.md axiom policy and the sibling law-of-sines entry, the 7 counted mathematical axioms are ha,hb,hc (side positivity — geometric facts about hyperbolic distance), defect, and lawA/lawB/lawC. The angle-range fields are well-formedness constraints. Axiomatizing the second laws of cosines is consistent with the parent LawOfCosinesOQ03.",
+    "mathContext": "$$\\cos C = -\\cos A\\cos B + \\sin A\\sin B\\,\\cosh c \\quad(\\text{second law, no Euclidean analogue})$$",
+    "significance": "key",
+    "relatedConcepts": ["structure-encoded axioms", "second law of cosines", "hyperbolic triangle", "AAA congruence"],
+    "prerequisites": ["Lean 4 structure syntax", "axiom counting policy", "hyperbolic geometry basics"]
+  },
+  {
+    "id": "ann-sin-positivity",
+    "proofId": "law-of-cosines-oq-03-oq-03",
+    "range": { "startLine": 100, "endLine": 107 },
+    "type": "insight",
+    "title": "Sine Positivity Supplies Nonzero Denominators",
+    "content": "sin_A_pos, sin_B_pos, sin_C_pos apply Real.sin_pos_of_pos_of_lt_pi to each angle, which lies strictly in (0,π) by the structure's range fields. The positivity of sin A and sin B makes their product nonzero, which is exactly what eq_div_iff needs to invert the second law of cosines into an explicit side formula.",
+    "mathContext": "$$\\sin x > 0 \\text{ for } x \\in (0,\\pi) \\implies \\sin A\\cdot\\sin B > 0$$",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.sin_pos_of_pos_of_lt_pi", "eq_div_iff", "denominator clearing"],
+    "prerequisites": ["Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"]
+  },
+  {
+    "id": "ann-inversion",
+    "proofId": "law-of-cosines-oq-03-oq-03",
+    "range": { "startLine": 118, "endLine": 124 },
+    "type": "insight",
+    "title": "Inverting the Second Law: One-Line linear_combination",
+    "content": "The second law of cosines is LINEAR in cosh of the opposite side: cos C = -cos A cos B + (sin A sin B)·cosh c. So cosh c = (cos C + cos A cos B)/(sin A sin B). In Lean, eq_div_iff (with the nonzero product of sines) turns the goal into cosh c · (sin A sin B) = cos C + cos A cos B, which is precisely the structure field lawC rearranged — discharged by linear_combination -t.lawC. The right-hand side depends only on the angles, which is the entire content of AAA determinacy.",
+    "mathContext": "$$\\cosh c = \\frac{\\cos C + \\cos A\\cos B}{\\sin A\\sin B}$$",
+    "significance": "key",
+    "relatedConcepts": ["eq_div_iff", "linear_combination", "second law of cosines", "AAA congruence"],
+    "prerequisites": ["linear_combination tactic", "eq_div_iff"]
+  },
+  {
+    "id": "ann-consistency",
+    "proofId": "law-of-cosines-oq-03-oq-03",
+    "range": { "startLine": 157, "endLine": 176 },
+    "type": "insight",
+    "title": "The Angular Defect Is What Makes cosh c > 1",
+    "content": "angle_formula_gt_one proves the angle ratio exceeds 1 using ONLY the angle bounds and the defect — no reference to the side. After lt_div_iff₀ the goal is sin A sin B < cos C + cos A cos B, i.e. 0 < cos C + (cos A cos B - sin A sin B) = cos C + cos(A+B). The defect A+B+C<π gives A+B < π-C; both lie in [0,π], so strict antitonicity of cos (Real.cos_lt_cos_of_nonneg_of_le_pi) yields cos(A+B) > cos(π-C) = -cos C (Real.cos_pi_sub). Hence cos C + cos(A+B) > 0. cosh_c_gt_one then concludes cosh c > 1. Existence of a valid hyperbolic side is equivalent to positive defect.",
+    "mathContext": "$$A+B<\\pi-C \\implies \\cos(A+B) > -\\cos C \\implies \\cos C + \\cos A\\cos B > \\sin A\\sin B$$",
+    "significance": "key",
+    "relatedConcepts": ["angular defect", "Real.cos_lt_cos_of_nonneg_of_le_pi", "Real.cos_pi_sub", "Real.cos_add", "Gauss-Bonnet"],
+    "prerequisites": ["strict antitonicity of cos on [0,π]", "lt_div_iff₀"]
+  },
+  {
+    "id": "ann-aaa-congruence",
+    "proofId": "law-of-cosines-oq-03-oq-03",
+    "range": { "startLine": 201, "endLine": 225 },
+    "type": "insight",
+    "title": "AAA Congruence via cosh Injectivity",
+    "content": "cosh_c_determined rewrites both triangles by the angle formula, so equal angles give equal cosh-sides. c_determined upgrades this to equal sides: cosh is strictly monotone (hence injective) on [0,∞) (Real.cosh_strictMonoOn.injOn), and side lengths are positive (the ha/hb/hc fields place them in the domain). aaa_congruence packages all three side equalities. This is the formal statement that hyperbolic geometry has no non-trivial similar triangles — a sharp contrast with the Euclidean AAA (similarity only).",
+    "mathContext": "$$\\cosh\\text{ injective on }[0,\\infty),\\ c_1,c_2>0,\\ \\cosh c_1=\\cosh c_2 \\implies c_1=c_2$$",
+    "significance": "key",
+    "relatedConcepts": ["Real.cosh_strictMonoOn", "StrictMonoOn.injOn", "AAA congruence", "rigidity"],
+    "prerequisites": ["injectivity from strict monotonicity", "Set.Ici membership"]
+  },
+  {
+    "id": "ann-equilateral",
+    "proofId": "law-of-cosines-oq-03-oq-03",
+    "range": { "startLine": 239, "endLine": 252 },
+    "type": "insight",
+    "title": "Equilateral Closed Form: cos θ/(1 - cos θ)",
+    "content": "With A=B=C=θ, the angle formula becomes (cos θ + cos²θ)/sin²θ. Writing sin²θ = (1-cos θ)(1+cos θ) and cos θ + cos²θ = cos θ(1+cos θ), the (1+cos θ) factors cancel to leave cos θ/(1-cos θ). The Lean proof establishes sin C ≠ 0 and 1-cos C ≠ 0 (from sin C ≠ 0 via the factorization), then closes with div_eq_div_iff and ring. The side grows without bound as θ→0 and shrinks to 0 as θ→π/3, the Euclidean limit where the defect vanishes.",
+    "mathContext": "$$\\cosh(\\text{side}) = \\frac{\\cos\\theta + \\cos^2\\theta}{\\sin^2\\theta} = \\frac{\\cos\\theta(1+\\cos\\theta)}{(1-\\cos\\theta)(1+\\cos\\theta)} = \\frac{\\cos\\theta}{1-\\cos\\theta}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["equilateral triangle", "sin_sq_add_cos_sq", "div_eq_div_iff", "Euclidean limit"],
+    "prerequisites": ["Pythagorean identity", "div_eq_div_iff"]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03-oq-03/meta.json
@@ -1,0 +1,263 @@
+{
+  "id": "law-of-cosines-oq-03-oq-03",
+  "title": "Hyperbolic AAA Congruence",
+  "slug": "law-of-cosines-oq-03-oq-03",
+  "description": "Formalizes hyperbolic AAA congruence: in hyperbolic geometry the three angles determine the triangle, so there are no non-trivial similar triangles. Inverts the second law of cosines to express each side purely in terms of the angles, cosh(c) = (cos C + cos A cos B)/(sin A sin B), then uses injectivity of cosh on [0,∞) to conclude equal angles force equal sides. Also proves an internal-consistency theorem (the angular defect A+B+C<π is exactly what makes the angle formula exceed 1, so cosh c > 1) and a closed form for the equilateral triangle, cosh(side) = cos θ/(1-cos θ). 18 theorems, 1 structure, 7 structure-encoded axioms, 0 sorries.",
+  "leanFile": {
+    "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
+    "namespace": "HyperbolicAAA",
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.DerivHyp",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Set"
+    ],
+    "axiomCount": 7,
+    "sorries": 0,
+    "lineCount": 267,
+    "theoremCount": 18,
+    "definitionCount": 1
+  },
+  "openQuestion": {
+    "id": "law-of-cosines-oq-03-oq-03",
+    "parentId": "law-of-cosines-oq-03",
+    "question": "In hyperbolic geometry, do the three angles of a triangle determine its size, or are there similar (same-angle, different-size) triangles as in Euclidean geometry?",
+    "answer": "AAA congruence holds: the angles determine the triangle. The second hyperbolic law of cosines cos C = -cos A cos B + sin A sin B cosh c inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone (and symmetrically for cosh a, cosh b). Since cosh is injective on [0,∞) and side lengths are positive, equal angles force equal sides. There are no non-trivial similar triangles in hyperbolic geometry. The angular defect A+B+C<π is precisely what makes the angle formula exceed 1 (cos(A+B) > cos(π-C) = -cos C), so a valid side cosh c>1 exists. 7 structure-encoded axioms, 0 sorries."
+  },
+  "highlights": [
+    "Hyperbolic AAA congruence: equal angles ⟹ equal sides (no similar triangles)",
+    "Inversion of the second law: cosh c = (cos C + cos A cos B)/(sin A sin B)",
+    "Internal consistency: the angular defect A+B+C<π makes the angle formula exceed 1",
+    "cosh c > 1 derived from the angles alone, via cos(A+B) > -cos C",
+    "Equilateral closed form: cosh(side) = cos θ/(1-cos θ)"
+  ],
+  "assumptions": [
+    "HyperbolicTriangle.ha: 0 < a (structure field — side length positive)",
+    "HyperbolicTriangle.hb: 0 < b (structure field — side length positive)",
+    "HyperbolicTriangle.hc: 0 < c (structure field — side length positive)",
+    "HyperbolicTriangle.defect: A+B+C < π (structure field — angular defect)",
+    "HyperbolicTriangle.lawA: cos A = -cos B cos C + sin B sin C cosh a (structure field — second law of cosines at A)",
+    "HyperbolicTriangle.lawB: cos B = -cos A cos C + sin A sin C cosh b (structure field — second law of cosines at B)",
+    "HyperbolicTriangle.lawC: cos C = -cos A cos B + sin A sin B cosh c (structure field — second law of cosines at C)",
+    "Angle-range fields (hA, hB, hC, hA_lt, hB_lt, hC_lt: 0 < A,B,C < π) are additional well-formedness constraints (not counted among the 7 mathematical axioms, consistent with the sibling law-of-sines entry)."
+  ],
+  "implications": [
+    {
+      "statement": "Two hyperbolic triangles with equal angles have equal sides (AAA congruence)",
+      "type": "theorem"
+    },
+    {
+      "statement": "cosh c > 1 follows from the angular defect alone",
+      "type": "corollary"
+    },
+    {
+      "statement": "Equilateral triangle with angle θ has cosh(side) = cos θ/(1-cos θ)",
+      "type": "corollary"
+    }
+  ],
+  "overview": {
+    "historicalContext": "In Euclidean geometry the angle-angle-angle (AAA) criterion gives only similarity, not congruence: scaling a triangle preserves its angles, so there are infinitely many similar triangles of every size. Hyperbolic geometry breaks this. The discovery (Lobachevsky, Bolyai, Gauss) that the angle sum of a triangle is strictly less than π — with the defect equal to the area — already shows that angle data carries metric information. The second law of cosines $\\cos C = -\\cos A\\cos B + \\sin A\\sin B\\cosh c$ (which has no Euclidean analogue) makes this precise: it can be solved for the side, so the three angles determine the three sides exactly. Hyperbolic triangles therefore satisfy AAA *congruence*, one of the most striking qualitative differences between hyperbolic and Euclidean geometry, and the reason that hyperbolic structures are rigid.",
+    "problemStatement": "Given a hyperbolic triangle with sides $a,b,c>0$, angles $A,B,C\\in(0,\\pi)$ opposite the respective sides, angular defect $A+B+C<\\pi$, and the three second laws of cosines, prove that the angles determine the sides: $\\cosh c=(\\cos C+\\cos A\\cos B)/(\\sin A\\sin B)$ and, consequently, two triangles with equal angles are congruent. Show further that the defect is exactly the condition making the angle formula yield a valid $\\cosh c>1$.",
+    "proofStrategy": "Each second law of cosines is linear in the corresponding $\\cosh$ of the side, so dividing by $\\sin\\cdot\\sin$ (positive on $(0,\\pi)$ via Real.sin_pos_of_pos_of_lt_pi) gives an explicit formula for $\\cosh a,\\cosh b,\\cosh c$ as functions of the angles (eq_div_iff + linear_combination). The internal-consistency theorem rewrites $\\cos A\\cos B-\\sin A\\sin B=\\cos(A+B)$ and uses strict antitonicity of cos on $[0,\\pi]$ (Real.cos_lt_cos_of_nonneg_of_le_pi) with $A+B<\\pi-C$ to get $\\cos(A+B)>\\cos(\\pi-C)=-\\cos C$, i.e. the formula exceeds 1. AAA congruence follows by injectivity of cosh on $[0,\\infty)$ (Real.cosh_strictMonoOn.injOn). The equilateral closed form substitutes $A=B=C$ and simplifies using $\\sin^2\\theta=(1-\\cos\\theta)(1+\\cos\\theta)$.",
+    "keyInsights": [
+      "The second law of cosines is *linear* in cosh of the opposite side, so it inverts to give cosh(side) as an explicit rational function of the three angles. This is the algebraic heart of AAA congruence — no Euclidean analogue exists because the Euclidean law of cosines relates a side to the other two sides, not purely to angles.",
+      "The angular defect A+B+C<π is not just a curiosity: it is exactly the inequality that makes (cos C + cos A cos B)/(sin A sin B) > 1. Writing the numerator-minus-denominator as cos C + cos(A+B), the defect gives A+B < π−C, and strict antitonicity of cos on [0,π] yields cos(A+B) > −cos C, i.e. cos C + cos(A+B) > 0. Thus existence of a valid hyperbolic side is equivalent to positive defect.",
+      "Injectivity of cosh on [0,∞) (Real.cosh_strictMonoOn.injOn) upgrades 'equal cosh of sides' to 'equal sides', completing the congruence. Side positivity (the ha, hb, hc structure fields) is what places the sides in the domain of injectivity.",
+      "The equilateral case collapses to a memorable closed form cosh(side) = cos θ/(1−cos θ): the (1+cos θ) factors cancel between sin²θ and the numerator cos θ(1+cos θ). The side grows without bound as θ→0 (thin ideal triangles) and shrinks to 0 as θ→π/3 (the Euclidean limit, where the defect vanishes).",
+      "linear_combination -t.lawC discharges the inverted formula in one line: after eq_div_iff the goal is exactly the structure field rearranged, so the certificate is a single signed copy of the law."
+    ],
+    "prerequisites": [
+      "Hyperbolic second law of cosines (parent file LawOfCosinesOQ03.lean)",
+      "Real.sin_pos_of_pos_of_lt_pi: sin x > 0 on (0, π)",
+      "Real.cos_lt_cos_of_nonneg_of_le_pi: cos strictly antitone on [0, π]",
+      "Real.cos_pi_sub and Real.cos_add",
+      "Real.cosh_strictMonoOn: cosh strictly monotone (hence injective) on [0, ∞)",
+      "Angular defect: A+B+C < π for hyperbolic triangles"
+    ]
+  },
+  "sections": [
+    {
+      "id": "structure",
+      "title": "HyperbolicTriangle Structure",
+      "startLine": 66,
+      "endLine": 94,
+      "summary": "Defines HyperbolicTriangle with side lengths a,b,c, angles A,B,C, side positivity (ha,hb,hc), angle range bounds (hA,hB,hC and hA_lt,hB_lt,hC_lt), the angular defect (defect: A+B+C<π), and the three second laws of cosines (lawA, lawB, lawC). The 7 mathematical axioms are ha,hb,hc,defect,lawA,lawB,lawC; angle-range fields are domain constraints.",
+      "mathContext": "The second law of cosines cos C = -cos A cos B + sin A sin B cosh c has no Euclidean analogue and is the source of AAA rigidity. Axiomatizing it as a structure field is consistent with the parent LawOfCosinesOQ03 and the sibling law of sines."
+    },
+    {
+      "id": "sin-positivity",
+      "title": "Sine Positivity on (0, π)",
+      "startLine": 96,
+      "endLine": 107,
+      "summary": "sin_A_pos, sin_B_pos, sin_C_pos: each angle lies in (0,π), so its sine is positive (Real.sin_pos_of_pos_of_lt_pi). These provide the nonzero denominators for inverting the law.",
+      "mathContext": "sin x > 0 for x ∈ (0, π); the product sin A · sin B is therefore positive and the formula is well-defined."
+    },
+    {
+      "id": "inversion",
+      "title": "Inverting the Second Law: Sides from Angles",
+      "startLine": 109,
+      "endLine": 142,
+      "summary": "cosh_c_eq, cosh_a_eq, cosh_b_eq express each cosh-side as the angle ratio (cos opp + cos·cos)/(sin·sin). Each is proved by eq_div_iff (nonzero product of sines) followed by linear_combination of the corresponding law field.",
+      "mathContext": "cosh c = (cos C + cos A cos B)/(sin A sin B). The right-hand side depends only on the angles — the algebraic statement of AAA determinacy."
+    },
+    {
+      "id": "consistency",
+      "title": "The Defect Makes the Formula Valid",
+      "startLine": 144,
+      "endLine": 176,
+      "summary": "angle_formula_gt_one: the angle ratio exceeds 1, using only the angle bounds and defect. After lt_div_iff₀ the goal is sin A sin B < cos C + cos A cos B; rewriting cos A cos B - sin A sin B = cos(A+B) and using cos strictly antitone on [0,π] (A+B < π-C) gives cos(A+B) > cos(π-C) = -cos C. cosh_c_gt_one then concludes cosh c > 1.",
+      "mathContext": "Existence of a valid hyperbolic side (cosh c > 1) is equivalent to positive angular defect. This ties the metric quantity to the area defect A+B+C<π."
+    },
+    {
+      "id": "congruence",
+      "title": "AAA Congruence",
+      "startLine": 178,
+      "endLine": 225,
+      "summary": "cosh_{a,b,c}_determined: equal angles give equal cosh-sides (rewrite by the formula). {a,b,c}_determined: upgrade to equal sides via cosh injectivity on [0,∞) (Real.cosh_strictMonoOn.injOn with side positivity). aaa_congruence packages all three side equalities.",
+      "mathContext": "cosh is injective on [0,∞); side lengths are positive, so cosh t₁.c = cosh t₂.c forces t₁.c = t₂.c. Two hyperbolic triangles with equal angles are congruent."
+    },
+    {
+      "id": "equilateral",
+      "title": "Equilateral Closed Form",
+      "startLine": 227,
+      "endLine": 252,
+      "summary": "equilateral_cosh: with A=B=C, cosh(side) = cos θ/(1-cos θ). Uses sin²θ = (1-cos θ)(1+cos θ) and div_eq_div_iff; the (1+cos θ) factors cancel.",
+      "mathContext": "cosh(side) = cos θ/(1-cos θ) → ∞ as θ→0 and → 1 (side→0) as θ→π/3 (Euclidean limit)."
+    },
+    {
+      "id": "defect-exports",
+      "title": "Angle Sum and Area",
+      "startLine": 254,
+      "endLine": 265,
+      "summary": "angle_sum_lt_pi and area_positive re-export the angular defect and its positivity (the hyperbolic area).",
+      "mathContext": "The defect π-(A+B+C) equals the hyperbolic area (Gauss-Bonnet, curvature -1)."
+    }
+  ],
+  "conclusion": {
+    "summary": "Hyperbolic AAA congruence is formalized by inverting the second law of cosines: cosh c = (cos C + cos A cos B)/(sin A sin B) expresses each side as a function of the angles, and injectivity of cosh on [0,∞) turns equal angles into equal sides. An internal-consistency theorem shows the angular defect A+B+C<π is exactly the condition making the formula exceed 1 (cosh c > 1), and the equilateral case yields the closed form cosh(side) = cos θ/(1-cos θ). 7 structure-encoded axioms, 0 sorries.",
+    "implications": "AAA congruence is the precise sense in which hyperbolic geometry is rigid: there are no similar non-congruent triangles, in sharp contrast to Euclidean geometry. The same inversion underlies the fact that hyperbolic structures on surfaces are determined by their holonomy/angle data, a theme central to Thurston's geometrization. Together with the parent law of cosines and the sibling law of sines, this completes the basic congruence theory of hyperbolic triangles.",
+    "openQuestions": [
+      "Derive the three second laws of cosines from a single first law of cosines (and the metric), reducing the structure-encoded axiom count.",
+      "Formalize SAS and ASA congruence for hyperbolic triangles using the same inversion technique.",
+      "Quantify the size-from-angles map: prove monotonicity of cosh(side) in the opposite angle and recover the area defect as the integral of the side formulas."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines-oq-03",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "law-of-cosines-oq-03-oq-02",
+      "relationship": "sibling"
+    },
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-22",
+    "status": "axiomatized",
+    "badge": "axiom",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ03OQ03.lean",
+    "tags": [
+      "hyperbolic-geometry",
+      "law-of-cosines",
+      "trigonometry",
+      "real-analysis",
+      "aaa-congruence",
+      "rigidity",
+      "open-question"
+    ],
+    "sorries": 0,
+    "axiomCount": 7,
+    "lineCount": 267,
+    "theoremCount": 18,
+    "definitionCount": 1,
+    "originalContributions": [
+      "HyperbolicTriangle structure encoding the three second laws of cosines plus the angular defect",
+      "cosh_c_eq / cosh_a_eq / cosh_b_eq: inversion of the second law giving each side as a function of the angles",
+      "angle_formula_gt_one: the angular defect is exactly what makes the angle formula exceed 1",
+      "cosh_c_gt_one: cosh c > 1 derived from the angles alone",
+      "aaa_congruence: equal angles ⟹ equal sides via cosh injectivity on [0,∞)",
+      "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) for the equilateral triangle"
+    ],
+    "proofStrategy": "Invert each second law of cosines (linear in cosh of the opposite side) via eq_div_iff + linear_combination to get cosh(side) as a ratio of angle functions. Prove the angle ratio exceeds 1 from the defect using cos(A+B) > cos(π-C) = -cos C (strict antitonicity of cos on [0,π]). Conclude AAA congruence by cosh injectivity on [0,∞). Specialize to the equilateral case for a closed form.",
+    "openQuestions": [
+      "Derive the second laws of cosines from a first law to reduce structure-encoded axioms",
+      "Formalize SAS and ASA hyperbolic congruence by the same inversion technique",
+      "Recover the area defect as an integral of the side-from-angle formulas"
+    ],
+    "sections": [
+      {
+        "title": "HyperbolicTriangle Structure",
+        "content": "7 mathematical axioms: ha,hb,hc (side positivity), defect (A+B+C<π), lawA,lawB,lawC (second laws of cosines). Angle-range fields are domain constraints.",
+        "startLine": 66,
+        "endLine": 94,
+        "theorems": []
+      },
+      {
+        "title": "Sine Positivity and Inversion",
+        "content": "sin_A_pos/sin_B_pos/sin_C_pos give nonzero denominators; cosh_c_eq/cosh_a_eq/cosh_b_eq invert the law to express sides from angles.",
+        "startLine": 96,
+        "endLine": 142,
+        "theorems": [
+          "sin_A_pos",
+          "sin_B_pos",
+          "sin_C_pos",
+          "cosh_c_eq",
+          "cosh_a_eq",
+          "cosh_b_eq"
+        ]
+      },
+      {
+        "title": "Internal Consistency from the Defect",
+        "content": "angle_formula_gt_one and cosh_c_gt_one: the angular defect makes the angle formula exceed 1, so a valid hyperbolic side exists.",
+        "startLine": 144,
+        "endLine": 176,
+        "theorems": [
+          "angle_formula_gt_one",
+          "cosh_c_gt_one"
+        ]
+      },
+      {
+        "title": "AAA Congruence",
+        "content": "cosh_{a,b,c}_determined and {a,b,c}_determined combine into aaa_congruence: equal angles force equal sides.",
+        "startLine": 178,
+        "endLine": 225,
+        "theorems": [
+          "cosh_c_determined",
+          "cosh_a_determined",
+          "cosh_b_determined",
+          "c_determined",
+          "a_determined",
+          "b_determined",
+          "aaa_congruence"
+        ]
+      },
+      {
+        "title": "Equilateral Form and Area",
+        "content": "equilateral_cosh (closed form cos θ/(1-cos θ)); angle_sum_lt_pi and area_positive re-export the defect.",
+        "startLine": 227,
+        "endLine": 265,
+        "theorems": [
+          "equilateral_cosh",
+          "angle_sum_lt_pi",
+          "area_positive"
+        ]
+      }
+    ],
+    "mathContext": {
+      "field": "Hyperbolic Geometry / Trigonometry",
+      "keyTheorem": "Hyperbolic AAA congruence: angles determine the triangle, via cosh c = (cos C + cos A cos B)/(sin A sin B); the angular defect A+B+C<π is what makes the formula valid (cosh c > 1).",
+      "historicalBackground": "AAA gives only similarity in Euclidean geometry but congruence in hyperbolic geometry. This rigidity, discovered with hyperbolic geometry itself (Lobachevsky, Bolyai, Gauss), is central to the deformation theory of hyperbolic structures (Thurston).",
+      "significance": "Establishes that there are no non-trivial similar triangles in hyperbolic geometry and exhibits the explicit angle-to-side map, completing the basic congruence theory alongside the laws of cosines and sines."
+    }
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-03-oq-03.json
@@ -1,0 +1,61 @@
+{
+  "id": "law-of-cosines-oq-03-oq-03",
+  "slug": "law-of-cosines-oq-03-oq-03",
+  "title": "Hyperbolic AAA Congruence",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "EMPTY",
+  "tractability": "high",
+  "path": "Proofs/LawOfCosinesOQ03OQ03.lean",
+  "started": "2026-06-22",
+  "lastUpdate": "2026-06-22",
+  "problemStatement": "In hyperbolic geometry, do the three angles of a triangle determine its size (AAA congruence), or are there similar non-congruent triangles as in Euclidean geometry? Invert the second hyperbolic law of cosines and decide.",
+  "significance": "AAA congruence is one of the sharpest qualitative differences between hyperbolic and Euclidean geometry, and underlies the rigidity of hyperbolic structures (Thurston). Completes the basic congruence theory alongside the parent law of cosines and sibling law of sines.",
+  "currentState": "COMPLETED. Proved AAA congruence: the second law of cosines inverts to cosh c = (cos C + cos A cos B)/(sin A sin B), a function of the angles alone; injectivity of cosh on [0,∞) turns equal angles into equal sides. Also proved internal consistency (the defect A+B+C<π is exactly what makes the formula exceed 1) and the equilateral closed form cosh(side)=cos θ/(1-cos θ).",
+  "knowledge": {
+    "progressSummary": "COMPLETE: hyperbolic AAA congruence formalized (18 theorems, 1 structure, 7 structure-encoded axioms, 0 sorries; verified 0-axiom — only propext/Classical/Quot, no native_decide). PR #27561.",
+    "builtItems": [
+      "LawOfCosinesOQ03OQ03.lean: hyperbolic AAA congruence (0 sorries, 7 structure-encoded axioms)",
+      "HyperbolicTriangle: structure with sides a,b,c, angles A,B,C, side positivity, angle bounds, defect, and three second laws of cosines lawA/lawB/lawC",
+      "cosh_c_eq / cosh_a_eq / cosh_b_eq: invert the second law to express each side from the angles (eq_div_iff + linear_combination -t.law*)",
+      "angle_formula_gt_one: angle ratio > 1 from the defect alone, via cos(A+B) > cos(π-C) = -cos C (Real.cos_lt_cos_of_nonneg_of_le_pi + Real.cos_pi_sub + Real.cos_add)",
+      "cosh_c_gt_one: cosh c > 1 derived purely from the angles",
+      "aaa_congruence: equal angles ⟹ equal sides via Real.cosh_strictMonoOn.injOn",
+      "equilateral_cosh: closed form cosh(side) = cos θ/(1-cos θ) using sin²θ=(1-cosθ)(1+cosθ) + div_eq_div_iff"
+    ],
+    "insights": [
+      "The second law of cosines is linear in cosh of the opposite side, so it inverts algebraically — no Euclidean analogue, since the Euclidean law relates a side to the other two sides, not purely to angles.",
+      "The angular defect A+B+C<π is equivalent to the angle formula exceeding 1: numerator-minus-denominator = cos C + cos(A+B), and the defect gives A+B<π-C, so by strict antitonicity of cos on [0,π], cos(A+B)>-cos C. Existence of a valid hyperbolic side ⟺ positive defect.",
+      "cosh injectivity on [0,∞) (Real.cosh_strictMonoOn.injOn) upgrades equal cosh-sides to equal sides; side positivity (ha/hb/hc) places sides in the domain.",
+      "lt_div_iff was renamed to lt_div_iff₀ in current Mathlib (4.26.0).",
+      "Equilateral case collapses to cos θ/(1-cos θ): the (1+cos θ) factors cancel between sin²θ and the numerator cos θ(1+cos θ)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Derive the three second laws of cosines from a single first law to reduce structure-encoded axioms",
+      "Formalize SAS and ASA hyperbolic congruence by the same inversion technique",
+      "Recover the area defect as an integral of the side-from-angle formulas"
+    ]
+  },
+  "knownResults": [
+    "Second hyperbolic law of cosines (parent law-of-cosines-oq-03)",
+    "Real.cosh_strictMonoOn: cosh strictly monotone on [0,∞)",
+    "Real.cos_lt_cos_of_nonneg_of_le_pi: cos strictly antitone on [0,π]"
+  ],
+  "relatedProofs": [
+    "law-of-cosines-oq-03",
+    "law-of-cosines-oq-03-oq-02",
+    "law-of-cosines"
+  ],
+  "references": [
+    "Ratcliffe (2006), Foundations of Hyperbolic Manifolds, Ch. 3",
+    "Thurston (1997), Three-Dimensional Geometry and Topology"
+  ],
+  "tags": [
+    "hyperbolic-geometry",
+    "law-of-cosines",
+    "aaa-congruence",
+    "rigidity",
+    "trigonometry"
+  ]
+}


### PR DESCRIPTION
## Hyperbolic AAA Congruence — Angles Determine the Triangle

**Problem:** `law-of-cosines-oq-03-oq-03` (follow-up to the Hyperbolic Law of Cosines `law-of-cosines-oq-03`, sibling of the Hyperbolic Law of Sines `law-of-cosines-oq-03-oq-02`).

### Open question
In Euclidean geometry the AAA criterion gives only **similarity** — there are infinitely many same-angle triangles of every size. What happens in hyperbolic geometry?

### Answer: AAA congruence holds
The **second hyperbolic law of cosines** `cos C = -cos A·cos B + sin A·sin B·cosh c` is *linear in `cosh c`*, so it inverts to

```
cosh c = (cos C + cos A·cos B) / (sin A·sin B)
```

a function of the **angles alone** (and symmetrically for `cosh a`, `cosh b`). Since `cosh` is injective on `[0, ∞)` and side lengths are positive, equal angles force equal sides: **two hyperbolic triangles with the same angles are congruent.** There are no non-trivial similar triangles in hyperbolic geometry.

### Results (18 theorems, 1 structure, 0 sorries)
- `cosh_c_eq` / `cosh_a_eq` / `cosh_b_eq` — invert the second law: each side as a function of the angles
- `aaa_congruence` — equal angles ⟹ equal sides (via `Real.cosh_strictMonoOn.injOn`)
- `angle_formula_gt_one` / `cosh_c_gt_one` — **internal consistency**: the angular defect `A+B+C<π` is *exactly* what makes the angle formula exceed 1 (`cos(A+B) > cos(π−C) = −cos C`), so a valid side `cosh c > 1` exists. Existence of the side ⟺ positive defect.
- `equilateral_cosh` — closed form `cosh(side) = cos θ/(1 − cos θ)` for the equilateral triangle (→ ∞ as θ→0, → 1 as θ→π/3, the Euclidean limit)

### Verification
- Builds via Docker wrapper against Mathlib (Lean 4.26.0)
- `#print axioms` on `aaa_congruence`, `cosh_c_gt_one`, `equilateral_cosh`: only `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`**
- Status `axiomatized` / badge `axiom`: the three second-laws-of-cosines and side-positivity/defect are **structure-encoded geometric assumptions** (7), consistent with the parent and sibling entries; all theorems are derived from them with no additional axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)