### PR TITLE
research(erdos-1065-incomplete-01): decidable characterization of Form A primes

### DIFF
--- a/proofs/Proofs/Erdos1065Incomplete01.lean
+++ b/proofs/Proofs/Erdos1065Incomplete01.lean
@@ -1,0 +1,181 @@
+import Mathlib.Data.Nat.Factorization.Basic
+import Mathlib.Tactic
+
+/-
+# Erdős #1065: A Structural Characterization of Form A Primes
+
+## Research Problem: erdos-1065-incomplete-01
+
+Erdős Problem #1065 asks whether there are infinitely many primes
+`p = 2^k · q + 1` with `q` prime (call these **Form A** primes). The parent
+formalization (`erdos-1065`) axiomatizes this infinitude conjecture and verifies
+many individual examples and non-examples by hand.
+
+This file supplies the missing **structural characterization** that those
+case-by-case verifications were probing: a single decidable criterion deciding
+Form A membership for every odd prime, expressed through the *odd part* of `p − 1`.
+
+## Main result
+
+Write `p − 1 = 2^a · m` with `m` odd (`m = ordCompl[2] (p−1)` is the odd part).
+Then for an odd prime `p`:
+
+  **`p` is a Form A prime  ⟺  `m = 1`  or  `m` is prime.**
+
+* `m = 1` means `p − 1` is a power of two — i.e. `p` is a Fermat-type prime
+  `2^a + 1`, which is Form A with `q = 2`.
+* `m` prime means `p = 2^a · m + 1` directly, Form A with `q = m`.
+* `m` odd *composite* (e.g. `p = 37`, `36 = 2² · 9`, `m = 9`) means `p` is
+  **not** Form A.
+
+This criterion subsumes the parent's whole family of example / non-example
+verifications: deciding Form A reduces to a single primality test on the odd part
+of `p − 1`.
+
+## Status (0 axioms, 0 sorries)
+
+Fully self-contained and elementary (no number-theoretic conjectures). The
+Form A predicate is redefined locally so this file does not import the parent's
+conjecture axiom.
+
+## References
+- Parent: erdos-1065 (Primes of the Form 2^k · q + 1), Guy's B46
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos1065Char
+
+open Nat
+
+/-- **Form A**: a prime `p` with `p = 2^k · q + 1` for some prime `q` and `k ≥ 0`.
+    (Local copy of the parent's `IsTwoTimePrimePlusOne`, kept axiom-free.) -/
+def IsFormA (p : ℕ) : Prop :=
+  p.Prime ∧ ∃ q k : ℕ, q.Prime ∧ p = 2 ^ k * q + 1
+
+/-- The odd part of `p − 1`: `ordCompl[2] (p−1) = (p−1) / 2^{v₂(p−1)}`. -/
+abbrev oddPart (p : ℕ) : ℕ := ordCompl[2] (p - 1)
+
+/-- The 2-adic valuation of `p − 1`. -/
+abbrev twoVal (p : ℕ) : ℕ := (p - 1).factorization 2
+
+/-- Decomposition: `2^{twoVal p} · oddPart p = p − 1`. Unfolds `ordProj · ordCompl = self`. -/
+theorem sub_one_eq (p : ℕ) : 2 ^ twoVal p * oddPart p = p - 1 :=
+  Nat.ordProj_mul_ordCompl_eq_self (p - 1) 2
+
+/-- **Core computation.** If `p − 1 = 2^a · m` with `m` odd, then the odd part of
+    `p − 1` is exactly `m` (and its 2-adic valuation is `a`). This is the unique
+    factoring of `p − 1` into a power of two times an odd number. -/
+theorem oddPart_eq {p a m : ℕ} (hm : ¬ 2 ∣ m) (h : p - 1 = 2 ^ a * m) :
+    oddPart p = m := by
+  have hm0 : m ≠ 0 := by rintro rfl; exact hm (dvd_zero 2)
+  have hval : twoVal p = a := by
+    rw [twoVal, h, Nat.factorization_mul (pow_ne_zero a two_ne_zero) hm0, Finsupp.add_apply,
+      Nat.factorization_pow_self Nat.prime_two, Nat.factorization_eq_zero_of_not_dvd hm, add_zero]
+  have hdec := sub_one_eq p
+  rw [hval, h] at hdec
+  exact Nat.eq_of_mul_eq_mul_left (by positivity) hdec
+
+-- ============================================================
+-- PART 1: Sufficiency — m = 1 or m prime ⟹ Form A
+-- ============================================================
+
+/-- If the odd part of `p − 1` is itself prime, then `p` is Form A
+    (`q = oddPart p`, `k = twoVal p`). Converse of the parent's `smooth_structure`. -/
+theorem isFormA_of_oddPart_prime {p : ℕ} (hp : p.Prime)
+    (hq : (oddPart p).Prime) : IsFormA p := by
+  refine ⟨hp, oddPart p, twoVal p, hq, ?_⟩
+  have h := sub_one_eq p
+  have hp1 : 1 ≤ p := hp.one_lt.le
+  omega
+
+/-- If `p − 1` is a power of two (odd part `= 1`) and `p` is an odd prime, then `p` is a
+    Fermat-type prime `2^a + 1`, which is Form A with `q = 2`. -/
+theorem isFormA_of_oddPart_one {p : ℕ} (hp : p.Prime) (hodd : Odd p)
+    (h1 : oddPart p = 1) : IsFormA p := by
+  refine ⟨hp, 2, twoVal p - 1, Nat.prime_two, ?_⟩
+  have h := sub_one_eq p
+  rw [h1, mul_one] at h
+  -- h : 2 ^ twoVal p = p - 1
+  have hp3 : 3 ≤ p := by
+    have h2 := hp.two_le
+    have hpar := Nat.odd_iff.mp hodd
+    omega
+  have hval : 1 ≤ twoVal p := by
+    rcases Nat.eq_zero_or_pos (twoVal p) with h0 | h0
+    · rw [h0, pow_zero] at h; omega
+    · exact h0
+  have hpow : 2 ^ twoVal p = 2 ^ (twoVal p - 1) * 2 := by
+    rw [← pow_succ]; congr 1; omega
+  omega
+
+/-- **Sufficiency.** If the odd part of `p − 1` is `1` or prime, then the odd prime
+    `p` is Form A. -/
+theorem isFormA_of_oddPart {p : ℕ} (hp : p.Prime) (hodd : Odd p)
+    (h : oddPart p = 1 ∨ (oddPart p).Prime) : IsFormA p :=
+  h.elim (isFormA_of_oddPart_one hp hodd) (isFormA_of_oddPart_prime hp)
+
+-- ============================================================
+-- PART 2: Necessity — Form A ⟹ m = 1 or m prime
+-- ============================================================
+
+/-- **Necessity.** If `p = 2^k · q + 1` with `q` prime, then the odd part of `p − 1`
+    is `1` (when `q = 2`) or prime (equal to `q`, when `q` is odd). -/
+theorem oddPart_of_isFormA {p : ℕ} (h : IsFormA p) :
+    oddPart p = 1 ∨ (oddPart p).Prime := by
+  obtain ⟨hp, q, k, hq, heq⟩ := h
+  have hsub : p - 1 = 2 ^ k * q := by omega
+  rcases eq_or_ne q 2 with hq2 | hq2
+  · -- q = 2: p − 1 = 2^(k+1) · 1, odd part is 1
+    left
+    have h' : p - 1 = 2 ^ (k + 1) * 1 := by rw [hsub, hq2, pow_succ]; ring
+    exact oddPart_eq (m := 1) (by norm_num) h'
+  · -- q odd prime: odd part = q
+    right
+    have hodd_q : ¬ 2 ∣ q := fun hdvd =>
+      hq2 (((Nat.prime_dvd_prime_iff_eq Nat.prime_two hq).mp hdvd).symm)
+    rw [oddPart_eq hodd_q hsub]
+    exact hq
+
+-- ============================================================
+-- PART 3: The characterization (decidable criterion)
+-- ============================================================
+
+/-- **Main theorem.** For an odd prime `p`, `p` is a Form A prime if and only if the odd
+    part of `p − 1` is `1` (so `p − 1` is a power of two) or is itself prime.
+
+    The right-hand side is decidable, so this turns the parent's case-by-case Form A
+    verifications into a single primality test on the odd part of `p − 1`. -/
+theorem isFormA_iff_oddPart {p : ℕ} (hp : p.Prime) (hodd : Odd p) :
+    IsFormA p ↔ (oddPart p = 1 ∨ (oddPart p).Prime) :=
+  ⟨oddPart_of_isFormA, isFormA_of_oddPart hp hodd⟩
+
+-- ============================================================
+-- PART 4: The criterion subsumes example / non-example verification
+-- ============================================================
+
+/-- `p = 37` is **not** Form A: `36 = 2² · 9`, odd part `9 = 3²` is composite. -/
+theorem not_isFormA_37 : ¬ IsFormA 37 := by
+  rw [isFormA_iff_oddPart (by norm_num) (by norm_num)]
+  rw [oddPart_eq (a := 2) (m := 9) (by norm_num) (by norm_num)]
+  decide
+
+/-- `p = 41` is Form A: `40 = 2³ · 5`, odd part `5` is prime. -/
+theorem isFormA_41 : IsFormA 41 := by
+  rw [isFormA_iff_oddPart (by norm_num) (by norm_num)]
+  rw [oddPart_eq (a := 3) (m := 5) (by norm_num) (by norm_num)]
+  decide
+
+/-- `p = 17` is Form A as a Fermat prime: `16 = 2⁴`, odd part `1`. -/
+theorem isFormA_17 : IsFormA 17 := by
+  rw [isFormA_iff_oddPart (by norm_num) (by norm_num)]
+  rw [oddPart_eq (a := 4) (m := 1) (by norm_num) (by norm_num)]
+  decide
+
+/-- `p = 71` is not Form A: `70 = 2 · 35`, odd part `35 = 5 · 7` composite. -/
+theorem not_isFormA_71 : ¬ IsFormA 71 := by
+  rw [isFormA_iff_oddPart (by norm_num) (by norm_num)]
+  rw [oddPart_eq (a := 1) (m := 35) (by norm_num) (by norm_num)]
+  decide
+
+end Erdos1065Char

--- a/src/data/proofs/erdos-1065-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-1065-incomplete-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-oddpart-eq",
+    "proofId": "erdos-1065-incomplete-01",
+    "range": { "startLine": 69, "endLine": 82 },
+    "type": "insight",
+    "title": "oddPart_eq: the Unique 2-Power × Odd Factoring",
+    "content": "Every prime p>2 has p-1 = 2^a·m with m odd, uniquely. oddPart_eq turns ANY such presentation into the value of the odd part: from p-1 = 2^a·m (m odd), ordCompl[2](p-1) = m. The 2-adic valuation is computed by Nat.factorization_mul + Nat.factorization_pow_self (giving v₂(2^a)=a) + Nat.factorization_eq_zero_of_not_dvd (giving v₂(m)=0 since 2∤m), so twoVal p = a; then Nat.ordProj_mul_ordCompl_eq_self (2^a·oddPart = p-1 = 2^a·m) and Nat.eq_of_mul_eq_mul_left cancel 2^a. This single lemma powers both the necessity proof and every concrete example.",
+    "mathContext": "$$p-1 = 2^a\\cdot m,\\ 2\\nmid m \\implies v_2(p-1)=a,\\ \\mathrm{ordCompl}_2(p-1)=m$$",
+    "significance": "key",
+    "relatedConcepts": ["ordCompl", "Nat.factorization_mul", "2-adic valuation", "unique factorization"],
+    "prerequisites": ["Nat.ordProj_mul_ordCompl_eq_self", "Nat.factorization_pow_self", "Nat.eq_of_mul_eq_mul_left"]
+  },
+  {
+    "id": "ann-sufficiency-fermat",
+    "proofId": "erdos-1065-incomplete-01",
+    "range": { "startLine": 94, "endLine": 112 },
+    "type": "insight",
+    "title": "Fermat Branch: Odd Part 1 ⟹ Form A with q = 2",
+    "content": "When ordCompl[2](p-1) = 1, the decomposition gives p-1 = 2^a (a pure power of two), so p = 2^a + 1 is a Fermat-type prime. This is Form A with q = 2 and k = a-1, since p = 2^(a-1)·2 + 1. The proof needs a ≥ 1, which follows from p being an ODD prime: p ≥ 3, so p-1 ≥ 2, ruling out a = 0 (which would force p-1 = 1, p = 2). This is exactly why the characterization requires Odd p — p = 2 has odd part 1 but is not Form A.",
+    "mathContext": "$$\\mathrm{ordCompl}_2(p-1)=1 \\implies p-1=2^a \\implies p = 2^{a-1}\\cdot 2 + 1$$",
+    "significance": "key",
+    "relatedConcepts": ["Fermat primes", "power of two", "odd prime hypothesis"],
+    "prerequisites": ["Nat.odd_iff", "pow_succ"]
+  },
+  {
+    "id": "ann-necessity-split",
+    "proofId": "erdos-1065-incomplete-01",
+    "range": { "startLine": 124, "endLine": 145 },
+    "type": "insight",
+    "title": "Necessity: the q = 2 vs q-odd Split",
+    "content": "From p-1 = 2^k·q (q prime), the odd part is computed by oddPart_eq in two cases. If q = 2, then p-1 = 2^(k+1)·1, so the odd part is 1 (Fermat case). If q is odd, then 2 ∤ q (via Nat.prime_dvd_prime_iff_eq: 2∣q ⟹ 2=q, contradicting q≠2), so p-1 = 2^k·q with q odd and the odd part is q, which is prime. Either way the odd part is 1 or prime.",
+    "mathContext": "$$q=2: \\mathrm{oddPart}=1;\\quad q\\ \\text{odd prime}: \\mathrm{oddPart}=q$$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.prime_dvd_prime_iff_eq", "case split", "odd part"],
+    "prerequisites": ["primes dividing primes", "oddPart_eq"]
+  },
+  {
+    "id": "ann-characterization",
+    "proofId": "erdos-1065-incomplete-01",
+    "range": { "startLine": 149, "endLine": 156 },
+    "type": "insight",
+    "title": "The Decidable Characterization",
+    "content": "isFormA_iff_oddPart bundles necessity and sufficiency: for an odd prime p, IsFormA p ↔ (oddPart p = 1 ∨ (oddPart p).Prime). The right-hand side is a decidable predicate (equality and primality of a concrete natural number), so Form A membership reduces to a single primality test on the odd part of p-1 — collapsing the parent's infinite family of per-prime verifications into one criterion.",
+    "mathContext": "$$\\text{odd prime } p \\text{ is Form A} \\iff \\mathrm{ordCompl}_2(p-1) \\in \\{1\\}\\cup\\mathbb{P}$$",
+    "significance": "key",
+    "relatedConcepts": ["decidable predicate", "characterization theorem", "Form A primes"],
+    "prerequisites": ["Iff from both directions"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "erdos-1065-incomplete-01",
+    "range": { "startLine": 158, "endLine": 181 },
+    "type": "insight",
+    "title": "Recovering the Parent's Examples via the Criterion",
+    "content": "not_isFormA_37, isFormA_41, isFormA_17, not_isFormA_71 reprove the parent's bespoke (non-)examples uniformly: rewrite by isFormA_iff_oddPart, compute the odd part with oddPart_eq (37→9, 41→5, 17→1, 71→35), then decide the 1-or-prime test. Because Nat.factorization is not decide-reducible, the odd part is evaluated through the structural lemma oddPart_eq rather than by raw computation, keeping the proofs kernel-checked and free of native_decide.",
+    "mathContext": "$$36=2^2\\cdot 9\\,(\\text{composite}),\\ 40=2^3\\cdot 5,\\ 16=2^4,\\ 70=2\\cdot 35\\,(\\text{composite})$$",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "kernel decide", "oddPart_eq instantiation"],
+    "prerequisites": ["decide on small primality", "rewrite by characterization"]
+  }
+]

--- a/src/data/proofs/erdos-1065-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1065-incomplete-01/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "erdos-1065-incomplete-01",
+  "title": "Erdős #1065: Decidable Characterization of Form A Primes",
+  "slug": "erdos-1065-incomplete-01",
+  "description": "Supplies the structural characterization that the parent erdos-1065's case-by-case verifications were probing. For an odd prime p, writing p-1 = 2^a·m with m odd (m = ordCompl[2](p-1) the odd part), p is a Form A prime (p = 2^k·q+1 with q prime) if and only if m = 1 or m is prime. This decidable criterion subsumes the entire family of example/non-example verifications: deciding Form A reduces to one primality test on the odd part of p-1. Includes the core odd-part computation oddPart_eq, both directions, and reproofs of the parent's 37/41/17/71 (non-)examples via the criterion. 11 theorems, 3 definitions, 0 axioms, 0 sorries; fully verified, no native_decide.",
+  "leanFile": {
+    "path": "Proofs/Erdos1065Incomplete01.lean",
+    "namespace": "Erdos1065Char",
+    "imports": [
+      "Mathlib.Data.Nat.Factorization.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 181,
+    "theoremCount": 11,
+    "definitionCount": 3
+  },
+  "openQuestion": {
+    "id": "erdos-1065-incomplete-01",
+    "parentId": "erdos-1065",
+    "question": "The parent verifies Form A membership (p = 2^k·q+1, q prime) prime-by-prime. Is there a single decidable criterion characterizing exactly which primes are Form A?",
+    "answer": "Yes. Write p-1 = 2^a·m with m odd (m is the odd part ordCompl[2](p-1)). For an odd prime p, p is Form A iff m = 1 or m is prime: m=1 means p-1 is a power of two (Fermat-type prime, q=2), m prime means p = 2^a·m+1 directly (q=m), and m odd composite (e.g. p=37, 36=2²·9) means p is not Form A. The right-hand side is decidable, so Form A membership reduces to one primality test on the odd part of p-1. Proved via a reusable odd-part computation oddPart_eq (uniqueness of the 2-power × odd factoring). 0 axioms, 0 sorries."
+  },
+  "highlights": [
+    "Decidable characterization: odd prime p is Form A ⟺ odd part of p-1 is 1 or prime",
+    "Reusable core: oddPart_eq computes the odd part from p-1 = 2^a·m with m odd",
+    "Sufficiency (both branches) and necessity (q=2 vs q odd) proved separately",
+    "Subsumes the parent's per-prime verification: one primality test on oddPart(p-1)",
+    "Reproofs of 37, 41, 17, 71 (non-)examples through the single criterion"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "For an odd prime p, IsFormA p ↔ (oddPart p = 1 ∨ (oddPart p).Prime)",
+      "type": "theorem"
+    },
+    {
+      "statement": "If the odd part of p-1 is prime, p is Form A (converse of smooth_structure)",
+      "type": "theorem"
+    },
+    {
+      "statement": "Fermat-type primes 2^a+1 are Form A with q = 2",
+      "type": "corollary"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős Problem #1065 (Guy's B46) asks whether there are infinitely many primes p = 2^k·q + 1 with q prime — a class that includes the safe primes (k=1) and the Fermat primes (q=2). The parent formalization axiomatizes the infinitude conjecture and establishes membership for many specific primes by separate, hand-built proofs (example_3, …, not_form_a_37, …). What those verifications implicitly compute is the 2-adic structure of p-1: every prime p>2 has p-1 = 2^a·m with m odd, and whether p is Form A depends entirely on the odd part m. Making this explicit yields a uniform decision procedure and replaces the open-ended list of examples with a theorem.",
+    "problemStatement": "Characterize exactly which odd primes p are Form A (p = 2^k·q+1 with q prime), in terms of the 2-adic decomposition p-1 = 2^a·m (m odd), and verify the characterization is decidable by recovering the parent's example/non-example list from it.",
+    "proofStrategy": "The workhorse is oddPart_eq: if p-1 = 2^a·m with m odd, then ordCompl[2](p-1) = m (the unique factoring of p-1 into a power of two times an odd number), proved from Nat.factorization_mul + Nat.factorization_pow_self + Nat.factorization_eq_zero_of_not_dvd plus Nat.ordProj_mul_ordCompl_eq_self. Sufficiency: if oddPart p is prime, take q = oddPart p, k = twoVal p; if oddPart p = 1, then p-1 is a power of two, so p = 2^(a-1)·2 + 1 with q = 2 (using that an odd prime has p-1 ≥ 2, hence a ≥ 1). Necessity: from p-1 = 2^k·q split on q = 2 (oddPart = 1 via oddPart_eq with m = 1) versus q odd (oddPart = q via oddPart_eq, using 2 ∤ q). The examples instantiate oddPart_eq to compute oddPart(p-1) concretely, then decide the 1-or-prime test.",
+    "keyInsights": [
+      "Every prime p > 2 factors p-1 = 2^a·m with m odd uniquely; Form A membership depends ONLY on the odd part m, collapsing an infinite verification problem to a single primality test.",
+      "oddPart_eq is the reusable bridge: it identifies ordCompl[2](p-1) with the odd cofactor m from any presentation p-1 = 2^a·m (m odd), so both the necessity proof and the concrete examples share one computation.",
+      "The q = 2 (Fermat) branch and the q odd branch are genuinely different: q = 2 forces oddPart = 1 (p-1 a pure power of two), while q odd forces oddPart = q. The characterization unifies them as 'oddPart ∈ {1} ∪ primes'.",
+      "The odd-prime hypothesis is necessary: p = 2 has odd part 1 but is not Form A (2^k·q ≥ 2 can never equal 1), so the criterion is stated for p with Odd p, where p-1 ≥ 2 guarantees a ≥ 1.",
+      "Because Nat.factorization is not directly reducible by decide, the concrete examples evaluate the odd part through oddPart_eq (a structural lemma) rather than by computation, then finish with decide on the small 1-or-prime test — keeping everything kernel-checked and free of native_decide."
+    ],
+    "prerequisites": [
+      "Parent: erdos-1065 (Form A primes p = 2^k·q+1)",
+      "Nat.ordCompl / ordProj and Nat.ordProj_mul_ordCompl_eq_self",
+      "Nat.factorization_mul, Nat.factorization_pow_self, Nat.factorization_eq_zero_of_not_dvd",
+      "Nat.prime_dvd_prime_iff_eq for 2 ∤ q when q is an odd prime"
+    ]
+  },
+  "sections": [
+    {
+      "id": "core",
+      "title": "Definitions and the Odd-Part Computation",
+      "startLine": 53,
+      "endLine": 82,
+      "summary": "IsFormA (local axiom-free copy of the parent predicate), oddPart = ordCompl[2](p-1), twoVal = v₂(p-1), sub_one_eq (2^twoVal·oddPart = p-1), and oddPart_eq: from p-1 = 2^a·m with m odd, oddPart p = m.",
+      "mathContext": "ordProj·ordCompl = self gives p-1 = 2^a·oddPart; oddPart_eq pins oddPart down via the factorization of 2^a·m at the prime 2."
+    },
+    {
+      "id": "sufficiency",
+      "title": "Sufficiency: odd part 1 or prime ⟹ Form A",
+      "startLine": 85,
+      "endLine": 118,
+      "summary": "isFormA_of_oddPart_prime (q = oddPart p), isFormA_of_oddPart_one (Fermat case, q = 2, needs Odd p so that twoVal ≥ 1), and isFormA_of_oddPart combining the two branches.",
+      "mathContext": "oddPart prime ⟹ p = 2^a·m+1; oddPart = 1 ⟹ p-1 = 2^a ⟹ p = 2^(a-1)·2+1."
+    },
+    {
+      "id": "necessity",
+      "title": "Necessity: Form A ⟹ odd part 1 or prime",
+      "startLine": 124,
+      "endLine": 145,
+      "summary": "oddPart_of_isFormA: from p-1 = 2^k·q, split on q = 2 (oddPart = 1) and q odd (oddPart = q, using 2 ∤ q via prime_dvd_prime_iff_eq).",
+      "mathContext": "Both branches reduce to oddPart_eq with the appropriate (a, m)."
+    },
+    {
+      "id": "characterization",
+      "title": "The Characterization and Worked Examples",
+      "startLine": 149,
+      "endLine": 181,
+      "summary": "isFormA_iff_oddPart packages both directions. not_isFormA_37, isFormA_41, isFormA_17, not_isFormA_71 recover the parent's (non-)examples by computing the odd part via oddPart_eq and deciding the 1-or-prime test.",
+      "mathContext": "37: 36=2²·9 (9 composite) → not Form A; 41: 40=2³·5 → Form A; 17: 16=2⁴ (odd part 1) → Form A; 71: 70=2·35 (35 composite) → not Form A."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an odd prime p with p-1 = 2^a·m (m odd), p is a Form A prime iff m = 1 or m is prime. The proof rests on a reusable odd-part computation oddPart_eq and splits cleanly into sufficiency (Fermat and odd-q branches) and necessity. The criterion is decidable and recovers the parent's example/non-example verifications as instances. 0 axioms, 0 sorries; kernel-checked (no native_decide).",
+    "implications": "This replaces the parent's open-ended, per-prime Form A verification with a single decidable criterion, and isolates the conjecture's difficulty precisely: 'infinitely many Form A primes' is equivalent to 'infinitely many primes p whose p-1 has prime (or unit) odd part', a clean restatement in terms of the 2-adic structure of p-1.",
+    "openQuestions": [
+      "Extend the characterization to the parent's Form B (p-1 = 2^k·3^l·q): p is Form B iff the {2,3}-free part of p-1 is 1 or prime.",
+      "Express the infinitude conjecture as a statement purely about the odd part of p-1 and connect it to known sieve heuristics.",
+      "Provide an efficient (norm_num-style) evaluator for ordCompl[2] to make the criterion executable on large primes."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1065",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "erdos-1065-oq-05",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-22",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/Erdos1065Incomplete01.lean",
+    "tags": [
+      "erdos-problems",
+      "number-theory",
+      "prime-numbers",
+      "2-adic-valuation",
+      "decidable-criterion",
+      "fermat-primes"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 181,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "originalContributions": [
+      "isFormA_iff_oddPart: decidable characterization of Form A primes via the odd part of p-1",
+      "oddPart_eq: reusable computation of ordCompl[2](p-1) from any 2^a·m (m odd) presentation",
+      "isFormA_of_oddPart_prime: odd part prime ⟹ Form A (converse of parent's smooth_structure)",
+      "isFormA_of_oddPart_one: Fermat-type characterization (odd part 1 ⟹ Form A with q=2)",
+      "oddPart_of_isFormA: necessity via the q=2 / q-odd split",
+      "Reproofs of 37/41/17/71 (non-)examples through the single criterion"
+    ],
+    "proofStrategy": "Prove the unique 2^a·odd factoring lemma oddPart_eq, then derive sufficiency (two branches) and necessity (q=2 vs q odd) and combine into isFormA_iff_oddPart. Recover the parent's examples by instantiating oddPart_eq and deciding the 1-or-prime test (kernel decide).",
+    "openQuestions": [
+      "Extend to Form B via the {2,3}-free part of p-1",
+      "Restate the infinitude conjecture purely about the odd part of p-1",
+      "Efficient evaluator for ordCompl[2] to run the criterion on large primes"
+    ],
+    "sections": [
+      {
+        "title": "Definitions and Odd-Part Computation",
+        "content": "IsFormA, oddPart, twoVal, sub_one_eq, oddPart_eq.",
+        "startLine": 53,
+        "endLine": 82,
+        "theorems": ["sub_one_eq", "oddPart_eq"]
+      },
+      {
+        "title": "Sufficiency",
+        "content": "isFormA_of_oddPart_prime, isFormA_of_oddPart_one, isFormA_of_oddPart.",
+        "startLine": 85,
+        "endLine": 118,
+        "theorems": ["isFormA_of_oddPart_prime", "isFormA_of_oddPart_one", "isFormA_of_oddPart"]
+      },
+      {
+        "title": "Necessity",
+        "content": "oddPart_of_isFormA (q=2 / q-odd split).",
+        "startLine": 124,
+        "endLine": 145,
+        "theorems": ["oddPart_of_isFormA"]
+      },
+      {
+        "title": "Characterization and Examples",
+        "content": "isFormA_iff_oddPart and the 37/41/17/71 reproofs.",
+        "startLine": 149,
+        "endLine": 181,
+        "theorems": ["isFormA_iff_oddPart", "not_isFormA_37", "isFormA_41", "isFormA_17", "not_isFormA_71"]
+      }
+    ],
+    "mathContext": {
+      "field": "Number Theory / Erdős Problems",
+      "keyTheorem": "Odd prime p is Form A (p=2^k·q+1, q prime) iff the odd part of p-1 is 1 or prime.",
+      "historicalBackground": "Erdős #1065 (Guy's B46) concerns the infinitude of primes p = 2^k·q+1; safe primes (k=1) and Fermat primes (q=2) are special cases. The parent axiomatizes the conjecture and verifies examples individually.",
+      "significance": "Turns Form A membership into a single decidable primality test on the odd part of p-1, subsuming all example verification and restating the conjecture in terms of the 2-adic structure of p-1."
+    }
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-1065-incomplete-01.json
+++ b/src/data/research/problems/erdos-1065-incomplete-01.json
@@ -1,10 +1,10 @@
 {
   "slug": "erdos-1065-incomplete-01",
   "title": "Erdős Problem #1065: Primes of the Form 2^k · q + 1",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
-  "path": "fast",
+  "path": "Proofs/Erdos1065Incomplete01.lean",
   "problemStatement": {
     "formal": "",
     "plain": "",
@@ -13,7 +13,7 @@
   "knownResults": {
     "proven": [],
     "open": [],
-    "goal": ""
+    "goal": "Decidable characterization of Form A primes (p=2^k*q+1) via the odd part of p-1"
   },
   "currentState": {
     "phase": "NEW",
@@ -29,13 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: odd prime p is Form A iff oddPart(p-1)=1 or prime. 11 thms, 3 defs, 0 axioms, 0 sorries, verified (no native_decide). Parent had no real sorries (1 conjecture-axiom each) -> pivoted to new structural result.",
+    "builtItems": [
+      "Erdos1065Incomplete01.lean: decidable characterization (0 axioms, 0 sorries)",
+      "oddPart_eq: ordCompl[2](p-1)=m from p-1=2^a*m (m odd)",
+      "isFormA_iff_oddPart: main characterization",
+      "sufficiency (Fermat + odd-q branches) and necessity (q=2/q-odd split)",
+      "not_isFormA_37/41/17/71 reproofs via the criterion"
+    ],
+    "insights": [
+      "Form A depends only on odd part m of p-1: m=1 (Fermat,q=2) or m prime (q=m); m odd composite => not Form A",
+      "Odd-prime hypothesis necessary: p=2 has odd part 1 but is not Form A",
+      "Nat.factorization not decide-reducible -> evaluate odd part via structural oddPart_eq then decide small 1-or-prime test (kernel, no native_decide)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Extend to Form B via {2,3}-free part of p-1",
+      "Restate infinitude conjecture about odd part of p-1",
+      "Efficient ordCompl[2] evaluator"
+    ]
   },
-  "tags": [],
+  "tags": [
+    "erdos-problems",
+    "number-theory",
+    "prime-numbers",
+    "2-adic-valuation",
+    "decidable-criterion"
+  ],
   "relatedProofs": [
     "erdos-1",
     "erdos-10",
@@ -48,7 +68,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:27:10.205Z",
-  "lastUpdate": "2026-04-03T08:27:10.205Z",
+  "lastUpdate": "2026-06-22",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Erdős #1065: A Decidable Characterization of Form A Primes

**Problem:** `erdos-1065-incomplete-01` — a follow-up to `erdos-1065` (*Primes of the Form 2^k·q+1*, Guy's B46).

The parent verifies Form A membership (`p = 2^k·q+1`, `q` prime) **prime-by-prime** (`example_3`, …, `not_form_a_37`, …) and axiomatizes the infinitude conjecture. This PR supplies the **structural criterion** those verifications were implicitly computing.

> Note: the parent `erdos-1065` and its companions (`BatemanHorn`, `CunninghamChains`) have **0 real sorries** — each carries one conjecture-axiom and is otherwise complete. There was no incomplete work to finish, so this is a **genuine new structural contribution**, not a sorry completion.

### Main theorem
Write `p − 1 = 2^a · m` with `m` odd (`m = ordCompl[2](p−1)`, the odd part). For an **odd prime** `p`:

```
IsFormA p  ↔  (oddPart p = 1  ∨  (oddPart p).Prime)
```

- `m = 1` → `p − 1` is a power of two → Fermat-type prime `2^a+1`, Form A with `q = 2`
- `m` prime → `p = 2^a·m + 1` directly, Form A with `q = m`
- `m` odd **composite** (e.g. `p = 37`, `36 = 2²·9`) → **not** Form A

The right-hand side is **decidable**, so Form A membership reduces to a single primality test on the odd part of `p − 1` — subsuming the parent's entire example/non-example family.

### Contents (11 theorems, 3 defs, 0 axioms, 0 sorries)
- `oddPart_eq` — reusable: from `p−1 = 2^a·m` (`m` odd), `ordCompl[2](p−1) = m`
- `isFormA_of_oddPart_prime` / `isFormA_of_oddPart_one` / `isFormA_of_oddPart` — sufficiency (odd-`q` and Fermat branches)
- `oddPart_of_isFormA` — necessity (`q = 2` vs `q` odd split)
- `isFormA_iff_oddPart` — the characterization
- `not_isFormA_37`, `isFormA_41`, `isFormA_17`, `not_isFormA_71` — parent (non-)examples reproved through the criterion

### Verification
- Builds via Docker wrapper against Mathlib (Lean 4.26.0)
- **0 `axiom` declarations, 0 structure-encoded assumptions, 0 sorries** — fully self-contained (Form A predicate redefined locally to avoid the parent's conjecture axiom)
- `#print axioms`: only `[propext, Classical.choice, Quot.sound]`. Examples use **kernel `decide`, NOT `native_decide`** (no `Lean.ofReduceBool`); since `Nat.factorization` isn't `decide`-reducible, the odd part is evaluated through the structural lemma `oddPart_eq`
- Status `verified` / badge `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)