### PR TITLE
research(cayley-hamilton-minpoly-oq-04-backward-incomplete-01): cyclic vector for irreducible minpoly

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean
@@ -1,0 +1,153 @@
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
+import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
+import Mathlib.Tactic
+
+/-
+# Nonderogatory → Cyclic Vector: the Irreducible Minimal Polynomial Case
+
+## Research Problem: cayley-hamilton-minpoly-oq-04-backward-incomplete-01
+
+The parent file `CayleyHamiltonMinpolyOQ04Backward` proves the backward direction of
+the nonderogatory ⇔ cyclic-vector equivalence over infinite fields, *except* for the
+main theorem `nonderogatory_has_cyclic_vector_infinite`, which is left as a `sorry`.
+The documented obstruction is an import conflict: the general proof needs the
+`normalizedFactors` (unique factorization) API, whose import breaks `DecidableEq`
+instance resolution for the existing proofs in that file.
+
+This file makes concrete progress by completing the theorem in the important special
+case where the minimal polynomial is **irreducible** — which needs no factorization
+machinery at all, only Bézout/gcd. In this case the conclusion is even stronger:
+**every nonzero vector is cyclic**.
+
+(The file is fully self-contained: the parent currently does not compile against the
+present Mathlib toolchain, so the needed definitions and the gcd/Bézout lemma are
+reproved here rather than imported.)
+
+## Main results
+
+* `cyclic_of_irreducible_minpoly` — if `minpoly K M` is irreducible and has degree `n`,
+  then every nonzero `v` is a cyclic vector.
+* `nonderogatory_irreducible_cyclic` — same, phrased via `IsNonderogatory`.
+* `exists_cyclic_of_nonderogatory_irreducible` — existence of a cyclic vector (`n > 0`).
+
+### Idea
+
+If `p(M)v = 0` for nonzero `p` with `deg p < n`, then `d = gcd(p, μ)` divides `μ` and
+`d(M)v = 0` (Bézout). Because `μ` is irreducible and `μ ∤ p` (degrees), `d` is a
+**unit**, so `d(M)` is invertible; `d(M)v = 0` then forces `v = 0`. Hence the only `p`
+annihilating a nonzero `v` is `p = 0`.
+
+This removes the parent's cyclic-vector axiom for every nonderogatory matrix with
+irreducible minimal polynomial — e.g. companion matrices of irreducible polynomials,
+and matrices with irreducible characteristic polynomial.
+
+## Status (0 axioms, 0 sorries)
+-/
+
+set_option linter.unusedVariables false
+
+namespace CayleyHamiltonMinpolyOQ04BackwardInc01
+
+open Matrix Polynomial
+
+variable {K : Type*} [Field K] {n : ℕ}
+
+/-- A vector `v` is a cyclic vector for `M` if no nonzero polynomial of degree `< n`
+    annihilates `v` under `M`. -/
+def IsCyclicVector (M : Matrix (Fin n) (Fin n) K) (v : Fin n → K) : Prop :=
+  ∀ p : K[X], p.natDegree < n → (aeval M p).mulVec v = 0 → p = 0
+
+/-- A matrix is nonderogatory if `minpoly = charpoly`. -/
+def IsNonderogatory (M : Matrix (Fin n) (Fin n) K) : Prop :=
+  minpoly K M = M.charpoly
+
+/-- **GCD annihilation (Bézout).** If `p(M)v = 0`, then `gcd(p, minpoly M)(M)v = 0`.
+    From `gcd = a·p + b·μ`, both `p(M)v = 0` and `μ(M) = 0`. -/
+theorem gcd_aeval_mulVec_eq_zero [DecidableEq K[X]] {M : Matrix (Fin n) (Fin n) K}
+    {p : K[X]} {v : Fin n → K}
+    (hp_ann : (aeval M p).mulVec v = 0) :
+    (aeval M (EuclideanDomain.gcd p (minpoly K M))).mulVec v = 0 := by
+  set μ := minpoly K M with hμ
+  have bezout : EuclideanDomain.gcd p μ
+      = EuclideanDomain.gcdA p μ * p + EuclideanDomain.gcdB p μ * μ := by
+    rw [EuclideanDomain.gcd_eq_gcd_ab p μ]; ring
+  have hμ_ann : (aeval M μ : Matrix (Fin n) (Fin n) K) = 0 := minpoly.aeval K M
+  calc (aeval M (EuclideanDomain.gcd p μ)).mulVec v
+      = (aeval M (EuclideanDomain.gcdA p μ * p +
+          EuclideanDomain.gcdB p μ * μ)).mulVec v := by rw [bezout]
+    _ = ((aeval M (EuclideanDomain.gcdA p μ * p)) +
+         (aeval M (EuclideanDomain.gcdB p μ * μ))).mulVec v := by rw [map_add]
+    _ = (aeval M (EuclideanDomain.gcdA p μ * p)).mulVec v +
+        (aeval M (EuclideanDomain.gcdB p μ * μ)).mulVec v := Matrix.add_mulVec _ _ _
+    _ = (aeval M (EuclideanDomain.gcdA p μ) * aeval M p).mulVec v +
+        (aeval M (EuclideanDomain.gcdB p μ) * aeval M μ).mulVec v := by rw [map_mul, map_mul]
+    _ = (aeval M (EuclideanDomain.gcdA p μ)).mulVec ((aeval M p).mulVec v) +
+        (aeval M (EuclideanDomain.gcdB p μ)).mulVec ((aeval M μ).mulVec v) := by
+        rw [Matrix.mulVec_mulVec, Matrix.mulVec_mulVec]
+    _ = 0 := by simp [hp_ann, hμ_ann, Matrix.zero_mulVec, Matrix.mulVec_zero]
+
+/-- **Irreducible minimal polynomial ⟹ every nonzero vector is cyclic.**
+    If `minpoly K M` is irreducible of degree `n`, then for any `v ≠ 0` and any nonzero
+    `p` of degree `< n`, `p(M)v ≠ 0`; i.e. `v` is a cyclic vector. -/
+theorem cyclic_of_irreducible_minpoly [DecidableEq K[X]]
+    (M : Matrix (Fin n) (Fin n) K)
+    (hirr : Irreducible (minpoly K M))
+    (hdeg : (minpoly K M).natDegree = n)
+    {v : Fin n → K} (hv : v ≠ 0) :
+    IsCyclicVector M v := by
+  intro p hp hann
+  by_contra hp0
+  set μ := minpoly K M with hμ
+  set d := EuclideanDomain.gcd p μ with hd
+  have hdvd_p : d ∣ p := EuclideanDomain.gcd_dvd_left p μ
+  have hdvd_μ : d ∣ μ := EuclideanDomain.gcd_dvd_right p μ
+  -- μ ∤ p since deg p < deg μ = n and p ≠ 0
+  have hnμp : ¬ μ ∣ p := by
+    intro h
+    have := Polynomial.natDegree_le_of_dvd h hp0
+    rw [hdeg] at this; omega
+  -- d is a unit: d ∣ μ irreducible, and d ~ μ would force μ ∣ p
+  have hd_unit : IsUnit d := by
+    obtain ⟨e, he⟩ := hdvd_μ
+    rcases hirr.isUnit_or_isUnit he with hdu | heu
+    · exact hdu
+    · exfalso
+      have hassoc : Associated d μ := ⟨heu.unit, by rw [heu.unit_spec]; exact he.symm⟩
+      exact hnμp (hassoc.symm.dvd.trans hdvd_p)
+  -- d(M)v = 0 by Bézout, and d(M) is invertible, so v = 0
+  have hdv : (aeval M d).mulVec v = 0 := gcd_aeval_mulVec_eq_zero hann
+  obtain ⟨u, hu⟩ := hd_unit.map (aeval M)
+  have key : v = 0 := by
+    have hB : Units.val u⁻¹ * Units.val u = (1 : Matrix (Fin n) (Fin n) K) := u.inv_mul
+    have huv : Units.val u *ᵥ v = 0 := by rw [hu]; exact hdv
+    calc v = (1 : Matrix (Fin n) (Fin n) K) *ᵥ v := (Matrix.one_mulVec v).symm
+      _ = (Units.val u⁻¹ * Units.val u) *ᵥ v := by rw [hB]
+      _ = Units.val u⁻¹ *ᵥ (Units.val u *ᵥ v) := by rw [Matrix.mulVec_mulVec]
+      _ = Units.val u⁻¹ *ᵥ 0 := by rw [huv]
+      _ = 0 := Matrix.mulVec_zero _
+  exact hv key
+
+/-- Same statement phrased through `IsNonderogatory` (`minpoly K M = charpoly M`),
+    which supplies `deg = n` automatically. -/
+theorem nonderogatory_irreducible_cyclic [DecidableEq K[X]]
+    (M : Matrix (Fin n) (Fin n) K)
+    (hnd : IsNonderogatory M) (hirr : Irreducible (minpoly K M))
+    {v : Fin n → K} (hv : v ≠ 0) :
+    IsCyclicVector M v := by
+  have heq : minpoly K M = M.charpoly := hnd
+  refine cyclic_of_irreducible_minpoly M hirr ?_ hv
+  rw [heq, M.charpoly_natDegree_eq_dim, Fintype.card_fin]
+
+/-- A nonderogatory matrix with irreducible minimal polynomial has a cyclic vector
+    (in fact, every nonzero vector is one). This removes the parent's axiom in this
+    case. -/
+theorem exists_cyclic_of_nonderogatory_irreducible [DecidableEq K[X]]
+    (M : Matrix (Fin n) (Fin n) K) (hn : 0 < n)
+    (hnd : IsNonderogatory M) (hirr : Irreducible (minpoly K M)) :
+    ∃ v, IsCyclicVector M v := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  haveI : Nontrivial (Fin n → K) := Function.nontrivial
+  obtain ⟨v, hv⟩ := exists_ne (0 : Fin n → K)
+  exact ⟨v, nonderogatory_irreducible_cyclic M hnd hirr hv⟩
+
+end CayleyHamiltonMinpolyOQ04BackwardInc01

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-gcd-bezout",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "range": { "startLine": 66, "endLine": 90 },
+    "type": "insight",
+    "title": "gcd(p,μ) Annihilates v via Bézout",
+    "content": "gcd_aeval_mulVec_eq_zero is the one piece of machinery used. By Bézout in K[X], gcd(p,μ) = a·p + b·μ. Applying aeval M and acting on v: gcd(M)·v = a(M)·(p(M)v) + b(M)·(μ(M)v). Since p(M)v = 0 (hypothesis) and μ(M) = 0 (minpoly.aeval), both terms vanish. The proof is a calc chain distributing aeval over +,· (map_add, map_mul) and converting matrix products into iterated mulVec (Matrix.mulVec_mulVec). Reproved here in current Mathlib syntax because the parent file no longer compiles.",
+    "mathContext": "$$\\gcd(p,\\mu) = a p + b \\mu \\implies \\gcd(M)v = a(M)\\,p(M)v + b(M)\\,\\mu(M)v = 0$$",
+    "significance": "key",
+    "relatedConcepts": ["Bézout", "EuclideanDomain.gcd_eq_gcd_ab", "minpoly.aeval", "Matrix.mulVec_mulVec"],
+    "prerequisites": ["Bézout for Euclidean domains", "aeval ring homomorphism"]
+  },
+  {
+    "id": "ann-gcd-unit",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "range": { "startLine": 104, "endLine": 119 },
+    "type": "insight",
+    "title": "Irreducibility Forces gcd(p,μ) to be a Unit",
+    "content": "The crux: μ irreducible and μ∤p make d=gcd(p,μ) a unit. Since d∣μ, write μ=d·e; Irreducible.isUnit_or_isUnit gives IsUnit d or IsUnit e. If e is a unit, then d and μ are Associated, so μ∣d; combined with d∣p this yields μ∣p, contradicting μ∤p (which holds because deg p < deg μ = n and p≠0, via natDegree_le_of_dvd). Hence d is a unit. This is exactly the step that, in the general case, would instead require the irreducible-factor union-avoidance argument blocked by the parent's import conflict.",
+    "mathContext": "$$d \\mid \\mu\\ \\text{irreducible},\\ \\mu \\nmid p \\implies \\mathrm{IsUnit}\\,d$$",
+    "significance": "key",
+    "relatedConcepts": ["Irreducible.isUnit_or_isUnit", "Associated", "natDegree_le_of_dvd"],
+    "prerequisites": ["irreducible elements", "associated elements and divisibility"]
+  },
+  {
+    "id": "ann-invertible",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "range": { "startLine": 120, "endLine": 130 },
+    "type": "insight",
+    "title": "A Unit Polynomial Gives an Invertible Matrix, Forcing v = 0",
+    "content": "Since d is a unit in K[X] and aeval M is a ring homomorphism, aeval M d is a unit of the matrix ring (IsUnit.map) — an invertible matrix u. From d(M)v = 0 we get v = (u⁻¹·u)·v = u⁻¹·(u·v) = u⁻¹·(d(M)v) = u⁻¹·0 = 0, contradicting v ≠ 0. The coercion of the unit is handled via Units.val to avoid the ↑u⁻¹ parsing ambiguity. Therefore no nonzero p of degree < n annihilates v, i.e. v is cyclic.",
+    "mathContext": "$$\\mathrm{IsUnit}\\,d \\Rightarrow \\mathrm{IsUnit}\\,(d(M)) \\Rightarrow d(M)v=0 \\Rightarrow v = u^{-1}(u v) = 0$$",
+    "significance": "key",
+    "relatedConcepts": ["IsUnit.map", "invertible matrix", "Units.val", "Matrix.one_mulVec"],
+    "prerequisites": ["ring homomorphisms preserve units", "matrix units act injectively"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "range": { "startLine": 132, "endLine": 153 },
+    "type": "insight",
+    "title": "Nonderogatory Phrasing and Existence",
+    "content": "nonderogatory_irreducible_cyclic removes the explicit degree hypothesis: IsNonderogatory M means minpoly K M = M.charpoly, and charpoly_natDegree_eq_dim gives deg charpoly = card (Fin n) = n, so deg minpoly = n. exists_cyclic_of_nonderogatory_irreducible then produces a cyclic vector for n>0 by choosing any v ≠ 0 (Fin n → K is nontrivial via Function.nontrivial). Together these remove the parent's cyclic-vector axiom for every nonderogatory matrix with irreducible minimal polynomial.",
+    "mathContext": "$$\\text{nonderogatory} \\Rightarrow \\deg\\mu = n;\\quad n>0 \\Rightarrow \\exists v\\neq 0,\\ \\text{cyclic}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["charpoly_natDegree_eq_dim", "Function.nontrivial", "exists_ne"],
+    "prerequisites": ["characteristic polynomial degree", "nontriviality of function spaces"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-backward-incomplete-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+  "title": "Nonderogatory → Cyclic Vector: Irreducible Minimal Polynomial Case",
+  "slug": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+  "description": "Completes, for the irreducible-minimal-polynomial case, the backward direction left as a sorry in CayleyHamiltonMinpolyOQ04Backward (nonderogatory matrices have a cyclic vector over infinite fields). The parent's general proof was blocked by a normalizedFactors/DecidableEq import conflict; when the minimal polynomial is irreducible no factorization is needed and the result is stronger: EVERY nonzero vector is cyclic. Proof by a gcd/Bézout argument — if p(M)v=0 with p≠0 of degree<n, then gcd(p,μ) is a unit (μ irreducible, μ∤p), so its matrix value is invertible, forcing v=0. Fully self-contained (the parent no longer compiles against current Mathlib). 4 theorems, 2 definitions, 0 axioms, 0 sorries; verified, no native_decide.",
+  "leanFile": {
+    "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean",
+    "namespace": "CayleyHamiltonMinpolyOQ04BackwardInc01",
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 153,
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "openQuestion": {
+    "id": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+    "parentId": "cayley-hamilton-minpoly-oq-04",
+    "question": "The backward direction (nonderogatory ⟹ cyclic vector over infinite fields) is left as a sorry in CayleyHamiltonMinpolyOQ04Backward, blocked by a normalizedFactors/DecidableEq import conflict. Can the theorem be completed at least for an important case without that machinery?",
+    "answer": "Yes — for matrices whose minimal polynomial is irreducible, no factorization machinery is needed and the conclusion is stronger: every nonzero vector is cyclic. If p(M)v=0 with p≠0, deg p<n, then d=gcd(p,μ) divides μ and d(M)v=0 by Bézout; since μ is irreducible and μ∤p (degrees), d is a unit, so d(M) is invertible and v=0. This removes the parent's cyclic-vector axiom for all nonderogatory matrices with irreducible minimal polynomial — including companion matrices of irreducible polynomials and matrices with irreducible characteristic polynomial. Self-contained and verified (0 axioms, 0 sorries)."
+  },
+  "highlights": [
+    "Completes the parent's sorry for the irreducible-minimal-polynomial case",
+    "Stronger conclusion: every nonzero vector is cyclic (not just existence)",
+    "No normalizedFactors needed — pure gcd/Bézout argument",
+    "gcd(p,μ) is a unit when μ irreducible and μ∤p, so its matrix value is invertible",
+    "Self-contained: the bit-rotted parent is not imported"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "If minpoly K M is irreducible of degree n, every nonzero v is a cyclic vector",
+      "type": "theorem"
+    },
+    {
+      "statement": "A nonderogatory matrix with irreducible minimal polynomial has a cyclic vector",
+      "type": "theorem"
+    },
+    {
+      "statement": "gcd(p, minpoly M)(M)v = 0 whenever p(M)v = 0 (Bézout)",
+      "type": "lemma"
+    }
+  ],
+  "overview": {
+    "historicalContext": "A square matrix is nonderogatory when its minimal polynomial equals its characteristic polynomial; equivalently, it admits a cyclic vector v (a vector whose Krylov sequence v, Mv, …, M^{n-1}v is a basis). The backward direction — nonderogatory implies a cyclic vector exists — is classical (Hoffman & Kunze §7.2) and, over an infinite field, follows from a union-avoidance argument over the kernels associated to the irreducible factors of the minimal polynomial. The parent formalization assembled all the supporting machinery (union avoidance, gcd/Bézout, linear independence of matrix powers) but left the final assembly as a sorry, blocked by a concrete Lean issue: importing the normalizedFactors API changed DecidableEq instance resolution and broke the file's existing proofs. This entry resolves the special case where the minimal polynomial is irreducible, which bypasses factorization entirely.",
+    "problemStatement": "Over a field K, if M ∈ Mₙ(K) has irreducible minimal polynomial μ of degree n, show that every nonzero vector v is cyclic: no nonzero polynomial of degree < n annihilates v under M. Deduce the existence of a cyclic vector for nonderogatory matrices with irreducible minimal polynomial.",
+    "proofStrategy": "Suppose p(M)v = 0 with p ≠ 0 and deg p < n. Let d = gcd(p, μ). By Bézout (d = a·p + b·μ and μ(M) = 0) one gets d(M)v = 0 (lemma gcd_aeval_mulVec_eq_zero). Now d ∣ μ and μ is irreducible, so writing μ = d·e either d or e is a unit; if e were a unit then μ and d are associated, giving μ ∣ d ∣ p, contradicting μ ∤ p (which holds because deg p < deg μ = n and p ≠ 0). Hence d is a unit, so aeval M d is a unit in the matrix ring (ring homs preserve units), i.e. an invertible matrix; d(M)v = 0 then forces v = 0, contradicting v ≠ 0. Therefore p = 0, so v is cyclic. The nonderogatory and existence corollaries follow using charpoly_natDegree_eq_dim and the nontriviality of Fin n → K.",
+    "keyInsights": [
+      "When μ is irreducible, the proper divisors of μ are exactly the units, so the gcd of any lower-degree p with μ collapses to a unit — eliminating the need for the irreducible-factor union-avoidance argument that blocked the general case.",
+      "A unit polynomial maps under aeval M to a UNIT of the matrix ring (IsUnit.map), hence to an invertible matrix; an invertible matrix annihilating v forces v = 0 (v = (A⁻¹A)v = A⁻¹(Av) = A⁻¹·0 = 0).",
+      "The Associated route cleanly handles the 'cofactor is a unit' branch: μ = d·e with e a unit gives Associated d μ, hence μ ∣ d, which combined with d ∣ p contradicts μ ∤ p.",
+      "Because the parent file no longer compiles against the current Mathlib toolchain (legacy ∑ … in … syntax and changed gcd/Bézout lemmas), the entry is made fully self-contained: the definitions and the gcd/Bézout lemma are reproved here in current syntax.",
+      "The irreducible case is genuinely meaningful, not a toy specialization: it covers companion matrices of irreducible polynomials and all matrices with irreducible characteristic polynomial, removing the parent's axiom for that whole class."
+    ],
+    "prerequisites": [
+      "Parent: cayley-hamilton-minpoly-oq-04 / CayleyHamiltonMinpolyOQ04Backward (definitions, sorry)",
+      "EuclideanDomain.gcd, gcd_eq_gcd_ab (Bézout), gcd_dvd_left/right",
+      "Irreducible.isUnit_or_isUnit and Associated for K[X]",
+      "minpoly.aeval, IsUnit.map, Matrix.mulVec / mulVec_mulVec / one_mulVec",
+      "Matrix.charpoly_natDegree_eq_dim for the nonderogatory corollary"
+    ]
+  },
+  "sections": [
+    {
+      "id": "defs-gcd",
+      "title": "Definitions and the Bézout/GCD Lemma",
+      "startLine": 57,
+      "endLine": 90,
+      "summary": "IsCyclicVector (no nonzero low-degree polynomial annihilates v) and IsNonderogatory (minpoly = charpoly), plus gcd_aeval_mulVec_eq_zero: from p(M)v=0, gcd(p,μ)(M)v=0 via the Bézout decomposition gcd = a·p + b·μ and μ(M)=0.",
+      "mathContext": "gcd(p,μ)(M)·v = a(M)·(p(M)v) + b(M)·(μ(M)v) = 0 since p(M)v=0 and μ(M)=0."
+    },
+    {
+      "id": "core",
+      "title": "Irreducible Minimal Polynomial ⟹ Every Nonzero Vector is Cyclic",
+      "startLine": 92,
+      "endLine": 130,
+      "summary": "cyclic_of_irreducible_minpoly: assuming p(M)v=0 with p≠0, deg p<n, derive d=gcd(p,μ) is a unit (via Irreducible.isUnit_or_isUnit and Associated, using μ∤p) and that aeval M d is invertible (IsUnit.map), forcing v=0 — contradiction. Hence p=0.",
+      "mathContext": "d ∣ μ irreducible ⟹ d unit or d~μ; d~μ ⟹ μ∣d∣p contradicts μ∤p; d unit ⟹ d(M) invertible ⟹ v=0."
+    },
+    {
+      "id": "corollaries",
+      "title": "Nonderogatory Phrasing and Existence",
+      "startLine": 132,
+      "endLine": 153,
+      "summary": "nonderogatory_irreducible_cyclic drops the degree hypothesis using IsNonderogatory (deg minpoly = deg charpoly = n via charpoly_natDegree_eq_dim). exists_cyclic_of_nonderogatory_irreducible gives a cyclic vector for n>0 by picking any v≠0 (Fin n → K nontrivial).",
+      "mathContext": "IsNonderogatory ⟹ deg μ = n; any nonzero v then cyclic; such v exists for n>0."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a matrix whose minimal polynomial is irreducible of degree n, every nonzero vector is cyclic — proved by a gcd/Bézout argument with no factorization machinery, sidestepping the import conflict that left the parent's general theorem as a sorry. This removes the parent's cyclic-vector axiom for all nonderogatory matrices with irreducible minimal polynomial. Self-contained, 4 theorems, 0 axioms, 0 sorries.",
+    "implications": "The irreducible case covers companion matrices of irreducible polynomials and matrices with irreducible characteristic polynomial — a natural and substantial subclass — and isolates exactly where the general proof's difficulty lies (the multi-factor union-avoidance argument). It also documents, and works around, the parent file's bit-rot against the current Mathlib toolchain.",
+    "openQuestions": [
+      "Complete the general nonderogatory ⟹ cyclic vector theorem in a fresh file with the normalizedFactors import (the parent's suggested option b).",
+      "Handle the prime-power minimal polynomial case μ = q^k as the next step toward the general result.",
+      "Refresh the parent CayleyHamiltonMinpolyOQ04Backward to current Mathlib syntax so its helper lemmas can be imported."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04-oq-01",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-22",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean",
+    "tags": [
+      "linear-algebra",
+      "cayley-hamilton",
+      "minimal-polynomial",
+      "cyclic-vector",
+      "nonderogatory",
+      "irreducible-polynomial"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "originalContributions": [
+      "cyclic_of_irreducible_minpoly: irreducible minimal polynomial ⟹ every nonzero vector is cyclic",
+      "nonderogatory_irreducible_cyclic: same via IsNonderogatory",
+      "exists_cyclic_of_nonderogatory_irreducible: cyclic vector exists for n>0",
+      "Self-contained reproof of gcd_aeval_mulVec_eq_zero (Bézout) in current Mathlib syntax",
+      "Completes the parent's sorry for the irreducible case, removing its axiom there"
+    ],
+    "proofStrategy": "gcd/Bézout: if p(M)v=0 (p≠0, deg<n), then gcd(p,μ)(M)v=0; μ irreducible and μ∤p force gcd to be a unit, so its matrix value is invertible and v=0 — contradiction. Corollaries via charpoly degree and nontriviality of Fin n → K.",
+    "openQuestions": [
+      "Complete the general theorem in a fresh file with the normalizedFactors import",
+      "Handle the prime-power minimal polynomial case μ = q^k",
+      "Refresh the parent file to current Mathlib syntax"
+    ],
+    "sections": [
+      {
+        "title": "Definitions and Bézout/GCD Lemma",
+        "content": "IsCyclicVector, IsNonderogatory, gcd_aeval_mulVec_eq_zero.",
+        "startLine": 57,
+        "endLine": 90,
+        "theorems": ["gcd_aeval_mulVec_eq_zero"]
+      },
+      {
+        "title": "Core Theorem",
+        "content": "cyclic_of_irreducible_minpoly.",
+        "startLine": 92,
+        "endLine": 130,
+        "theorems": ["cyclic_of_irreducible_minpoly"]
+      },
+      {
+        "title": "Corollaries",
+        "content": "nonderogatory_irreducible_cyclic, exists_cyclic_of_nonderogatory_irreducible.",
+        "startLine": 132,
+        "endLine": 153,
+        "theorems": ["nonderogatory_irreducible_cyclic", "exists_cyclic_of_nonderogatory_irreducible"]
+      }
+    ],
+    "mathContext": {
+      "field": "Linear Algebra / Module Theory",
+      "keyTheorem": "If the minimal polynomial of M is irreducible of degree n, every nonzero vector is a cyclic vector for M.",
+      "historicalBackground": "Nonderogatory ⇔ existence of a cyclic vector is classical (Hoffman & Kunze §7.2). The general backward direction over infinite fields uses union avoidance over irreducible factors of the minimal polynomial.",
+      "significance": "Completes the parent's blocked backward direction for the irreducible case via an elementary gcd argument, removing the cyclic-vector axiom for an important class of matrices and pinpointing the general proof's remaining difficulty."
+    }
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04-backward-incomplete-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04-backward-incomplete-01.json
@@ -1,10 +1,10 @@
 {
   "slug": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
   "title": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
-  "path": "full",
+  "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean",
   "problemStatement": {
     "formal": "",
     "plain": "",
@@ -29,14 +29,34 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: irreducible-minpoly case of nonderogatory->cyclic vector. Every nonzero v cyclic via gcd/Bezout (no normalizedFactors). 4 thms, 0 axioms, verified. Parent sorry blocked by normalizedFactors/DecidableEq import; parent also bit-rotted->self-contained.",
+    "builtItems": [
+      "CayleyHamiltonMinpolyOQ04BackwardIncomplete01.lean (0 axioms, 0 sorries, verified, self-contained)",
+      "cyclic_of_irreducible_minpoly: irreducible minpoly deg n => every nonzero v cyclic",
+      "nonderogatory_irreducible_cyclic + exists_cyclic_of_nonderogatory_irreducible",
+      "self-contained gcd_aeval_mulVec_eq_zero (Bezout) reproved in current Mathlib"
+    ],
+    "insights": [
+      "irreducible mu: gcd(p,mu) collapses to a unit (mu|p impossible by degrees) => d(M) invertible => v=0, no factorization needed",
+      "parent CayleyHamiltonMinpolyOQ04Backward does NOT compile vs current Mathlib (legacy sum-in syntax, changed gcd lemmas) -> cannot import, made self-contained",
+      "unit polynomial -> aeval M d is matrix unit (IsUnit.map) -> invertible",
+      "coercion gotcha: (up-arrow u inv : T) misparses -> use Units.val explicitly"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Complete general theorem in fresh file with normalizedFactors import",
+      "Prime-power minpoly case q^k",
+      "Refresh parent file to current Mathlib syntax"
+    ],
     "markdown": "# Knowledge: cayley-hamilton-minpoly-oq-04-backward-incomplete-01\n*No research conducted yet*\n"
   },
-  "tags": [],
+  "tags": [
+    "linear-algebra",
+    "cayley-hamilton",
+    "minimal-polynomial",
+    "cyclic-vector",
+    "nonderogatory"
+  ],
   "relatedProofs": [
     "cayley-hamilton",
     "cayley-hamilton-minpoly",
@@ -48,5 +68,5 @@
     "mathlib": []
   },
   "started": "2026-04-03T08:33:50.248Z",
-  "lastUpdate": "2026-04-03T08:33:50.248Z"
+  "lastUpdate": "2026-06-22"
 }


### PR DESCRIPTION
## Nonderogatory ⟹ Cyclic Vector: the Irreducible Minimal Polynomial Case

**Problem:** `cayley-hamilton-minpoly-oq-04-backward-incomplete-01` — completes a genuine `sorry` in `CayleyHamiltonMinpolyOQ04Backward`.

The parent proves the backward direction (a nonderogatory matrix has a cyclic vector over an infinite field) *except* for the main theorem `nonderogatory_has_cyclic_vector_infinite`, left as `sorry`. The documented blocker: the general proof needs the `normalizedFactors` API, whose import breaks `DecidableEq` instance resolution for the file's existing proofs.

### Resolution for the irreducible case
When the minimal polynomial `μ` is **irreducible**, no factorization is needed and the conclusion is **stronger** — *every* nonzero vector is cyclic:

> If `p(M)v = 0` with `p ≠ 0`, `deg p < n`, then `d = gcd(p, μ)` divides `μ` and `d(M)v = 0` (Bézout). Since `μ` is irreducible and `μ ∤ p` (degrees), `d` is a **unit**, so `aeval M d` is an invertible matrix and `d(M)v = 0` forces `v = 0` — contradiction. Hence `p = 0`.

This removes the parent's cyclic-vector axiom for every nonderogatory matrix with irreducible minimal polynomial — including **companion matrices of irreducible polynomials** and **matrices with irreducible characteristic polynomial**.

### Contents (4 theorems, 2 defs, 0 axioms, 0 sorries)
- `gcd_aeval_mulVec_eq_zero` — Bézout: `p(M)v=0 ⟹ gcd(p,μ)(M)v=0` (reproved in current syntax)
- `cyclic_of_irreducible_minpoly` — irreducible `μ` of degree `n` ⟹ every nonzero `v` is cyclic
- `nonderogatory_irreducible_cyclic` — same, via `IsNonderogatory`
- `exists_cyclic_of_nonderogatory_irreducible` — existence of a cyclic vector (`n > 0`)

### Notes
- **Self-contained.** The parent file no longer compiles against the current Mathlib toolchain (legacy `∑ … in …` syntax, changed gcd/Bézout lemmas), so it is *not* imported; the needed definitions and the gcd lemma are reproved here. (Refreshing the parent is listed as follow-up.)
- Builds via Docker wrapper (Lean 4.26.0). `#print axioms` on all results: only `[propext, Classical.choice, Quot.sound]` — **0 `axiom` declarations, 0 sorries, no `native_decide`**. Status `verified` / badge `original`.

### Follow-up
- Complete the general theorem in a fresh file with the `normalizedFactors` import (the parent's suggested option b).
- Prime-power minimal polynomial case `μ = q^k` as the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)