### PR TITLE
research(cauchy-schwarz-integral-oq-02-oq-03): reverse Minkowski inequality from Cauchy-Schwarz

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ02OQ03.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ02OQ03.lean
@@ -1,0 +1,136 @@
+import Mathlib.MeasureTheory.Function.L2Space
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.MeanInequalities
+import Mathlib.Tactic
+
+/-
+# Reverse Minkowski Inequality from Cauchy-Schwarz (cauchy-schwarz-integral-oq-02-oq-03)
+
+## The Open Question (from cauchy-schwarz-integral-oq-02)
+
+> Can the **reverse Minkowski inequality** `‖f+g‖_p ≥ |‖f‖_p − ‖g‖_p|` also be derived
+> from Cauchy-Schwarz?
+
+The parent (`cauchy-schwarz-integral-oq-02`) derives the forward Minkowski inequality
+`‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p` from Cauchy-Schwarz (inner-product form for `p = 2`, Hölder
+for general `p`). This file answers the reverse question.
+
+## The Answer: YES
+
+**Reverse Minkowski (reverse triangle inequality):**
+```
+|‖f‖_p − ‖g‖_p| ≤ ‖f + g‖_p
+```
+
+### Path 1: L² and abstract inner-product spaces — directly from CS
+
+For `p = 2`, just as the *forward* inequality uses the CS *upper* bound
+`⟪f,g⟫ ≤ ‖f‖·‖g‖`, the reverse inequality uses the CS *lower* bound
+`⟪f,g⟫ ≥ −‖f‖·‖g‖`:
+```
+‖f+g‖² = ‖f‖² + 2⟪f,g⟫ + ‖g‖²
+        ≥ ‖f‖² − 2‖f‖·‖g‖ + ‖g‖²    (by CS: ⟪f,g⟫ ≥ −‖f‖·‖g‖)
+        = (‖f‖ − ‖g‖)²
+```
+Taking square roots gives `|‖f‖ − ‖g‖| ≤ ‖f+g‖`.
+
+### Path 2: General Lᵖ — from the forward triangle inequality
+
+For general `p ≥ 1` the reverse inequality follows from the *forward* one
+(which the parent derived from CS/Hölder): writing `f = (f+g) − g`,
+```
+‖f‖ ≤ ‖f+g‖ + ‖g‖   ⟹   ‖f‖ − ‖g‖ ≤ ‖f+g‖,
+```
+and symmetrically `‖g‖ − ‖f‖ ≤ ‖f+g‖`, hence `|‖f‖ − ‖g‖| ≤ ‖f+g‖`.
+
+## Status (0 axioms, 0 sorries)
+-/
+
+noncomputable section
+
+open MeasureTheory
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace ReverseMinkowskiFromCS
+
+/-!
+## Section I: Reverse Minkowski from the CS lower bound (inner-product spaces)
+-/
+
+/-- **Reverse Minkowski for L² via Cauchy-Schwarz.** For `f, g ∈ L²(μ)`,
+    `|‖f‖ − ‖g‖| ≤ ‖f + g‖`, proved from the CS *lower* bound
+    `⟪f,g⟫ ≥ −‖f‖·‖g‖` and the norm-squared identity. -/
+theorem reverse_minkowski_l2_from_CS (f g : Lp ℝ 2 μ) :
+    |‖f‖ - ‖g‖| ≤ ‖f + g‖ := by
+  have h_cs : |@inner ℝ _ _ f g| ≤ ‖f‖ * ‖g‖ := abs_real_inner_le_norm f g
+  have h_ge : -(‖f‖ * ‖g‖) ≤ @inner ℝ _ _ f g := (abs_le.mp h_cs).1
+  have h_sq : (‖f‖ - ‖g‖) ^ 2 ≤ ‖f + g‖ ^ 2 := by
+    rw [norm_add_sq_real]; nlinarith [h_ge]
+  have h_sqrt := Real.sqrt_le_sqrt h_sq
+  rwa [Real.sqrt_sq_eq_abs, Real.sqrt_sq (norm_nonneg _)] at h_sqrt
+
+/-- **Reverse Minkowski in any real inner-product space**, from Cauchy-Schwarz.
+    The abstract version of `reverse_minkowski_l2_from_CS`. -/
+theorem reverse_minkowski_inner_product_space {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace ℝ E] (u v : E) :
+    |‖u‖ - ‖v‖| ≤ ‖u + v‖ := by
+  have h_cs : |@inner ℝ _ _ u v| ≤ ‖u‖ * ‖v‖ := abs_real_inner_le_norm u v
+  have h_ge : -(‖u‖ * ‖v‖) ≤ @inner ℝ _ _ u v := (abs_le.mp h_cs).1
+  have h_sq : (‖u‖ - ‖v‖) ^ 2 ≤ ‖u + v‖ ^ 2 := by
+    rw [norm_add_sq_real]; nlinarith [h_ge]
+  have h_sqrt := Real.sqrt_le_sqrt h_sq
+  rwa [Real.sqrt_sq_eq_abs, Real.sqrt_sq (norm_nonneg _)] at h_sqrt
+
+/-!
+## Section II: Reverse Minkowski for general Lᵖ from the forward triangle inequality
+
+For `p ≠ 2` we use the forward Minkowski inequality (which the parent derived from
+CS/Hölder). This works in *any* normed group, so we prove it there and specialize.
+-/
+
+/-- **Reverse triangle inequality in any normed group.** `|‖u‖ − ‖v‖| ≤ ‖u + v‖`.
+    Derived purely from the forward triangle inequality `norm_sub_le`. -/
+theorem reverse_minkowski_norm {E : Type*} [NormedAddCommGroup E] (u v : E) :
+    |‖u‖ - ‖v‖| ≤ ‖u + v‖ := by
+  rw [abs_sub_le_iff]
+  refine ⟨?_, ?_⟩
+  · have : ‖u‖ ≤ ‖u + v‖ + ‖v‖ := by
+      calc ‖u‖ = ‖(u + v) - v‖ := by rw [add_sub_cancel_right]
+        _ ≤ ‖u + v‖ + ‖v‖ := norm_sub_le _ _
+    linarith
+  · have : ‖v‖ ≤ ‖u + v‖ + ‖u‖ := by
+      calc ‖v‖ = ‖(u + v) - u‖ := by rw [add_sub_cancel_left]
+        _ ≤ ‖u + v‖ + ‖u‖ := norm_sub_le _ _
+    linarith
+
+/-- **Reverse Minkowski for general Lᵖ** (`1 ≤ p`): `|‖f‖_p − ‖g‖_p| ≤ ‖f + g‖_p`.
+    Specialization of `reverse_minkowski_norm` to `Lp ℝ p μ`. -/
+theorem reverse_minkowski_lp (p : ENNReal) [Fact (1 ≤ p)] (f g : Lp ℝ p μ) :
+    |‖f‖ - ‖g‖| ≤ ‖f + g‖ :=
+  reverse_minkowski_norm f g
+
+/-!
+## Section III: One-sided and difference forms
+-/
+
+/-- One-sided reverse Minkowski: `‖f‖_p − ‖g‖_p ≤ ‖f + g‖_p` (no absolute value). -/
+theorem norm_sub_norm_le_norm_add {E : Type*} [NormedAddCommGroup E] (u v : E) :
+    ‖u‖ - ‖v‖ ≤ ‖u + v‖ :=
+  le_trans (le_abs_self _) (reverse_minkowski_norm u v)
+
+/-- The classical reverse triangle inequality in difference form:
+    `|‖f‖_p − ‖g‖_p| ≤ ‖f − g‖_p`. Obtained from `reverse_minkowski_norm` by replacing
+    `v` with `−v`. -/
+theorem reverse_minkowski_sub {E : Type*} [NormedAddCommGroup E] (u v : E) :
+    |‖u‖ - ‖v‖| ≤ ‖u - v‖ := by
+  have h := reverse_minkowski_norm u (-v)
+  rwa [norm_neg, ← sub_eq_add_neg] at h
+
+/-- A lower bound on the Lᵖ norm of a sum: `‖f + g‖_p ≥ ‖f‖_p − ‖g‖_p`. This is the
+    inequality exactly as posed in the open question. -/
+theorem norm_add_ge_norm_sub_norm (p : ENNReal) [Fact (1 ≤ p)] (f g : Lp ℝ p μ) :
+    ‖f‖ - ‖g‖ ≤ ‖f + g‖ :=
+  norm_sub_norm_le_norm_add f g
+
+end ReverseMinkowskiFromCS

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-cs-lower-bound",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
+    "range": { "startLine": 64, "endLine": 72 },
+    "type": "insight",
+    "title": "Reverse Minkowski = Forward Minkowski with the CS Lower Bound",
+    "content": "The forward Minkowski proof (parent) uses ⟪f,g⟫ ≤ ‖f‖·‖g‖ (the CS UPPER bound) in ‖f+g‖² = ‖f‖²+2⟪f,g⟫+‖g‖² to get ‖f+g‖² ≤ (‖f‖+‖g‖)². Here we use the CS LOWER bound: |⟪f,g⟫| ≤ ‖f‖·‖g‖ unpacks (abs_le.mp) to −‖f‖·‖g‖ ≤ ⟪f,g⟫, so ‖f+g‖² ≥ ‖f‖²−2‖f‖·‖g‖+‖g‖² = (‖f‖−‖g‖)². Taking square roots (Real.sqrt_sq_eq_abs on the left, Real.sqrt_sq on the right) gives |‖f‖−‖g‖| ≤ ‖f+g‖. The forward and reverse inequalities are thus the two halves of one Cauchy-Schwarz estimate.",
+    "mathContext": "$$-\\|f\\|\\|g\\| \\le \\langle f,g\\rangle \\implies \\|f+g\\|^2 \\ge (\\|f\\|-\\|g\\|)^2$$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz", "norm_add_sq_real", "abs_le", "Real.sqrt_sq_eq_abs"],
+    "prerequisites": ["inner product norm-squared identity", "square root monotonicity"]
+  },
+  {
+    "id": "ann-general-normed",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
+    "range": { "startLine": 94, "endLine": 107 },
+    "type": "insight",
+    "title": "General Lᵖ Needs No Inner Product — Just the Forward Triangle",
+    "content": "For p ≠ 2 there is no inner product, but the reverse inequality requires no new analysis: it is a formal consequence of the forward triangle inequality, valid in any NormedAddCommGroup. abs_sub_le_iff splits |‖u‖−‖v‖| ≤ ‖u+v‖ into two symmetric one-sided bounds; each follows from writing u = (u+v)−v (add_sub_cancel_right) and applying norm_sub_le: ‖u‖ ≤ ‖u+v‖+‖v‖. reverse_minkowski_lp is then just the specialization to Lp ℝ p μ, whose NormedAddCommGroup instance encodes forward Minkowski (from CS/Hölder in the parent).",
+    "mathContext": "$$\\|u\\| = \\|(u+v)-v\\| \\le \\|u+v\\|+\\|v\\| \\implies \\|u\\|-\\|v\\| \\le \\|u+v\\|$$",
+    "significance": "key",
+    "relatedConcepts": ["norm_sub_le", "abs_sub_le_iff", "NormedAddCommGroup", "Lp spaces"],
+    "prerequisites": ["forward triangle inequality", "normed group structure of Lᵖ"]
+  },
+  {
+    "id": "ann-forms",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03",
+    "range": { "startLine": 118, "endLine": 136 },
+    "type": "insight",
+    "title": "One-Sided and Difference Forms",
+    "content": "norm_sub_norm_le_norm_add gives the one-sided ‖u‖−‖v‖ ≤ ‖u+v‖ (drop the absolute value via le_abs_self). reverse_minkowski_sub gives the classical difference form |‖u‖−‖v‖| ≤ ‖u−v‖ by substituting −v (norm_neg turns ‖−v‖ into ‖v‖, sub_eq_add_neg turns u+(−v) into u−v). norm_add_ge_norm_sub_norm restates the result as the lower bound ‖f+g‖ ≥ ‖f‖−‖g‖ exactly as the open question poses it.",
+    "mathContext": "$$\\big|\\|u\\|-\\|v\\|\\big| \\le \\|u-v\\| \\quad(\\text{reflection } v\\mapsto -v)$$",
+    "significance": "supporting",
+    "relatedConcepts": ["le_abs_self", "norm_neg", "sub_eq_add_neg", "reverse triangle inequality"],
+    "prerequisites": ["absolute value bounds", "norm of negation"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "cauchy-schwarz-integral-oq-02-oq-03",
+  "title": "Reverse Minkowski Inequality from Cauchy-Schwarz",
+  "slug": "cauchy-schwarz-integral-oq-02-oq-03",
+  "description": "Answers open question 3 of the parent (Minkowski Integral Inequality as Corollary of CS): can the reverse Minkowski inequality ‖f+g‖_p ≥ |‖f‖_p − ‖g‖_p| also be derived from Cauchy-Schwarz? Yes. For L² and abstract real inner-product spaces it follows from the CS LOWER bound ⟪f,g⟫ ≥ −‖f‖·‖g‖ via the norm-squared identity (mirroring the parent's forward derivation, which used the CS upper bound). For general Lᵖ it follows from the forward triangle inequality (itself derived from CS/Hölder in the parent). Includes one-sided and difference forms. 7 theorems, 0 axioms, 0 sorries; verified.",
+  "leanFile": {
+    "path": "Proofs/CauchySchwarzIntegralOQ02OQ03.lean",
+    "namespace": "ReverseMinkowskiFromCS",
+    "imports": [
+      "Mathlib.MeasureTheory.Function.L2Space",
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.MeanInequalities",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 136,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "openQuestion": {
+    "id": "cauchy-schwarz-integral-oq-02-oq-03",
+    "parentId": "cauchy-schwarz-integral-oq-02",
+    "question": "Can the reverse Minkowski inequality ‖f+g‖_p ≥ |‖f‖_p − ‖g‖_p| also be derived from Cauchy-Schwarz?",
+    "answer": "Yes. For L² and any real inner-product space, the reverse inequality is the mirror of the forward one: where the forward Minkowski uses the CS upper bound ⟪f,g⟫ ≤ ‖f‖·‖g‖, the reverse uses the CS lower bound ⟪f,g⟫ ≥ −‖f‖·‖g‖, giving ‖f+g‖² ≥ (‖f‖−‖g‖)² and hence |‖f‖−‖g‖| ≤ ‖f+g‖ after taking square roots. For general Lᵖ (p ≥ 1) it follows from the forward triangle inequality (which the parent derived from CS/Hölder): f = (f+g) − g gives ‖f‖ ≤ ‖f+g‖ + ‖g‖, and symmetrically, so |‖f‖−‖g‖| ≤ ‖f+g‖. One-sided (‖f‖−‖g‖ ≤ ‖f+g‖) and difference (|‖f‖−‖g‖| ≤ ‖f−g‖) forms are also given. 0 axioms, 0 sorries."
+  },
+  "highlights": [
+    "Reverse Minkowski |‖f‖−‖g‖| ≤ ‖f+g‖ for L², inner-product spaces, and Lᵖ",
+    "L²/inner-product derivation from the CS LOWER bound ⟪f,g⟫ ≥ −‖f‖·‖g‖",
+    "Mirrors the parent's forward derivation (which used the CS upper bound)",
+    "General Lᵖ via the forward triangle inequality (itself from CS/Hölder)",
+    "One-sided and difference (‖f−g‖) forms of the reverse triangle inequality"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "|‖f‖−‖g‖| ≤ ‖f+g‖ in L² and real inner-product spaces, from the CS lower bound",
+      "type": "theorem"
+    },
+    {
+      "statement": "|‖f‖−‖g‖| ≤ ‖f+g‖ for general Lᵖ (p ≥ 1), from the forward triangle inequality",
+      "type": "theorem"
+    },
+    {
+      "statement": "‖f‖−‖g‖ ≤ ‖f+g‖ (one-sided) and |‖f‖−‖g‖| ≤ ‖f−g‖ (difference form)",
+      "type": "corollary"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Minkowski's inequality is the triangle inequality for Lᵖ norms; its reverse companion |‖f‖−‖g‖| ≤ ‖f+g‖ (the reverse triangle inequality) bounds how far the norm of a sum can fall below the difference of norms. The parent problem derived the FORWARD Minkowski inequality as a corollary of Cauchy-Schwarz — directly via the inner product for p=2, and via Hölder (the generalized CS) for general p — and explicitly asked whether the REVERSE inequality admits the same CS-based derivation. It does, and the symmetry is clean: the forward inequality is exactly the CS upper bound fed through the norm-squared identity, while the reverse inequality is the CS lower bound fed through the same identity.",
+    "problemStatement": "Show ‖f+g‖_p ≥ |‖f‖_p − ‖g‖_p| (1 ≤ p < ∞), deriving the p=2 case from the inner-product Cauchy-Schwarz inequality and the general case from the forward Minkowski (triangle) inequality established in the parent.",
+    "proofStrategy": "For p=2 (and any real inner-product space): from |⟪f,g⟫| ≤ ‖f‖·‖g‖ extract the lower bound ⟪f,g⟫ ≥ −‖f‖·‖g‖ (abs_le.mp), then norm_add_sq_real gives ‖f+g‖² = ‖f‖²+2⟪f,g⟫+‖g‖² ≥ (‖f‖−‖g‖)² (nlinarith); take square roots with Real.sqrt_sq_eq_abs and Real.sqrt_sq. For general normed groups (hence Lᵖ): from f = (f+g)−g and norm_sub_le, ‖f‖ ≤ ‖f+g‖+‖g‖ and symmetrically, so abs_sub_le_iff closes |‖f‖−‖g‖| ≤ ‖f+g‖. The difference form replaces v by −v (norm_neg, sub_eq_add_neg).",
+    "keyInsights": [
+      "Forward and reverse Minkowski are the two halves of one CS estimate: |⟪f,g⟫| ≤ ‖f‖·‖g‖ unpacks to −‖f‖·‖g‖ ≤ ⟪f,g⟫ ≤ ‖f‖·‖g‖; the upper half gives forward Minkowski, the lower half gives reverse Minkowski, both through ‖f+g‖² = ‖f‖²+2⟪f,g⟫+‖g‖².",
+      "For p ≠ 2 there is no inner product, but the reverse inequality needs no new analytic input: it is a formal consequence of the forward triangle inequality, valid in any normed group, so it holds for Lᵖ once forward Minkowski is known.",
+      "abs_sub_le_iff reduces the two-sided reverse inequality to two symmetric one-sided bounds, each a one-line application of norm_sub_le after rewriting f as (f+g)−g.",
+      "The difference form |‖f‖−‖g‖| ≤ ‖f−g‖ is the +/− reflection of the sum form, obtained by substituting −v (norm_neg and sub_eq_add_neg).",
+      "Keeping the inner-product proof separate from the general normed-group proof makes the 'derived from CS' content explicit for p=2, matching the parent's pedagogical split."
+    ],
+    "prerequisites": [
+      "Parent: cauchy-schwarz-integral-oq-02 (forward Minkowski from CS)",
+      "abs_real_inner_le_norm and norm_add_sq_real (inner-product CS and expansion)",
+      "Real.sqrt_sq_eq_abs, Real.sqrt_sq, Real.sqrt_le_sqrt",
+      "norm_sub_le and abs_sub_le_iff for the general normed-group argument",
+      "Lp ℝ p μ NormedAddCommGroup instance (1 ≤ p)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "from-cs",
+      "title": "Reverse Minkowski from the CS Lower Bound",
+      "startLine": 60,
+      "endLine": 88,
+      "summary": "reverse_minkowski_l2_from_CS and reverse_minkowski_inner_product_space: from ⟪f,g⟫ ≥ −‖f‖·‖g‖ (the CS lower bound) and norm_add_sq_real, get (‖f‖−‖g‖)² ≤ ‖f+g‖², then take square roots.",
+      "mathContext": "‖f+g‖² = ‖f‖²+2⟪f,g⟫+‖g‖² ≥ ‖f‖²−2‖f‖‖g‖+‖g‖² = (‖f‖−‖g‖)²."
+    },
+    {
+      "id": "general-lp",
+      "title": "General Lᵖ from the Forward Triangle Inequality",
+      "startLine": 90,
+      "endLine": 116,
+      "summary": "reverse_minkowski_norm proves |‖u‖−‖v‖| ≤ ‖u+v‖ in any normed group from norm_sub_le and abs_sub_le_iff; reverse_minkowski_lp specializes it to Lp ℝ p μ.",
+      "mathContext": "‖u‖ = ‖(u+v)−v‖ ≤ ‖u+v‖+‖v‖, symmetrically for v, so |‖u‖−‖v‖| ≤ ‖u+v‖."
+    },
+    {
+      "id": "forms",
+      "title": "One-Sided and Difference Forms",
+      "startLine": 118,
+      "endLine": 136,
+      "summary": "norm_sub_norm_le_norm_add (one-sided ‖u‖−‖v‖ ≤ ‖u+v‖), reverse_minkowski_sub (difference form |‖u‖−‖v‖| ≤ ‖u−v‖), and norm_add_ge_norm_sub_norm (the Lᵖ inequality exactly as posed).",
+      "mathContext": "Difference form via v ↦ −v (norm_neg, sub_eq_add_neg)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The reverse Minkowski inequality |‖f‖_p − ‖g‖_p| ≤ ‖f+g‖_p is derived from Cauchy-Schwarz: for p=2 and any real inner-product space directly from the CS lower bound ⟪f,g⟫ ≥ −‖f‖·‖g‖, and for general Lᵖ from the forward triangle inequality (itself a CS/Hölder corollary in the parent). One-sided and difference forms are included. 7 theorems, 0 axioms, 0 sorries.",
+    "implications": "This completes the symmetric picture begun in the parent: both the upper (forward Minkowski) and lower (reverse Minkowski) halves of the Lᵖ triangle inequality are corollaries of Cauchy-Schwarz, the two coming from the upper and lower CS bounds respectively. The reverse inequality also gives the standard stability bound on how much a norm can drop under addition.",
+    "openQuestions": [
+      "Establish the equality case of reverse Minkowski (when is |‖f‖−‖g‖| = ‖f+g‖?) — equality forces f and g anti-proportional.",
+      "Derive the complex Lᵖ reverse inequality from the complex inner-product CS (parent OQ-04).",
+      "Quantitative reverse Minkowski: a lower bound on ‖f+g‖_p − |‖f‖_p − ‖g‖_p| in terms of the angle between f and g."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-integral-oq-02",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-02-oq-01",
+      "relationship": "sibling"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-22",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ02OQ03.lean",
+    "tags": [
+      "functional-analysis",
+      "cauchy-schwarz",
+      "minkowski-inequality",
+      "reverse-triangle-inequality",
+      "lp-spaces",
+      "inner-product-spaces"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 136,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "reverse_minkowski_l2_from_CS: reverse Minkowski for L² from the CS lower bound",
+      "reverse_minkowski_inner_product_space: abstract inner-product-space version",
+      "reverse_minkowski_norm: reverse triangle inequality in any normed group",
+      "reverse_minkowski_lp: general Lᵖ reverse Minkowski",
+      "norm_sub_norm_le_norm_add, reverse_minkowski_sub, norm_add_ge_norm_sub_norm: one-sided and difference forms"
+    ],
+    "proofStrategy": "p=2 / inner-product: extract ⟪f,g⟫ ≥ −‖f‖·‖g‖ from CS, expand ‖f+g‖² (norm_add_sq_real), nlinarith to (‖f‖−‖g‖)² ≤ ‖f+g‖², take square roots. General Lᵖ: forward triangle inequality (norm_sub_le) + abs_sub_le_iff in any normed group.",
+    "openQuestions": [
+      "Equality case of reverse Minkowski (anti-proportionality)",
+      "Complex Lᵖ reverse inequality from complex CS",
+      "Quantitative reverse Minkowski via the angle between f and g"
+    ],
+    "sections": [
+      {
+        "title": "Reverse Minkowski from CS Lower Bound",
+        "content": "reverse_minkowski_l2_from_CS, reverse_minkowski_inner_product_space.",
+        "startLine": 60,
+        "endLine": 88,
+        "theorems": ["reverse_minkowski_l2_from_CS", "reverse_minkowski_inner_product_space"]
+      },
+      {
+        "title": "General Lᵖ from Forward Triangle",
+        "content": "reverse_minkowski_norm, reverse_minkowski_lp.",
+        "startLine": 90,
+        "endLine": 116,
+        "theorems": ["reverse_minkowski_norm", "reverse_minkowski_lp"]
+      },
+      {
+        "title": "One-Sided and Difference Forms",
+        "content": "norm_sub_norm_le_norm_add, reverse_minkowski_sub, norm_add_ge_norm_sub_norm.",
+        "startLine": 118,
+        "endLine": 136,
+        "theorems": ["norm_sub_norm_le_norm_add", "reverse_minkowski_sub", "norm_add_ge_norm_sub_norm"]
+      }
+    ],
+    "mathContext": {
+      "field": "Functional Analysis / Inequalities",
+      "keyTheorem": "Reverse Minkowski: |‖f‖_p − ‖g‖_p| ≤ ‖f+g‖_p, from the CS lower bound (p=2) and the forward triangle inequality (general p).",
+      "historicalBackground": "The reverse triangle inequality complements Minkowski's inequality; together they bracket ‖f+g‖_p between |‖f‖_p−‖g‖_p| and ‖f‖_p+‖g‖_p. The parent derived the upper bracket from Cauchy-Schwarz.",
+      "significance": "Completes the CS-based derivation of both halves of the Lᵖ triangle inequality, showing the forward and reverse inequalities arise from the upper and lower Cauchy-Schwarz bounds respectively."
+    }
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-03.json
@@ -1,0 +1,54 @@
+{
+  "id": "cauchy-schwarz-integral-oq-02-oq-03",
+  "slug": "cauchy-schwarz-integral-oq-02-oq-03",
+  "title": "Reverse Minkowski Inequality from Cauchy-Schwarz",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "EMPTY",
+  "tractability": "high",
+  "path": "Proofs/CauchySchwarzIntegralOQ02OQ03.lean",
+  "started": "2026-06-22",
+  "lastUpdate": "2026-06-22",
+  "problemStatement": "Open question 3 of cauchy-schwarz-integral-oq-02: can the reverse Minkowski inequality ‖f+g‖_p ≥ |‖f‖_p − ‖g‖_p| also be derived from Cauchy-Schwarz?",
+  "significance": "Completes the CS-based derivation of both halves of the Lᵖ triangle inequality: the forward (upper) and reverse (lower) inequalities come from the upper and lower Cauchy-Schwarz bounds.",
+  "currentState": "COMPLETED. Reverse Minkowski |‖f‖−‖g‖| ≤ ‖f+g‖ proved for L²/inner-product spaces from the CS lower bound, and for general Lᵖ from the forward triangle inequality. One-sided and difference forms included.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: reverse Minkowski from CS (7 thms, 0 axioms, 0 sorries, verified).",
+    "builtItems": [
+      "CauchySchwarzIntegralOQ02OQ03.lean (7 theorems, 0 axioms, 0 sorries, verified)",
+      "reverse_minkowski_l2_from_CS + reverse_minkowski_inner_product_space: from CS lower bound ⟪f,g⟫≥−‖f‖‖g‖",
+      "reverse_minkowski_norm (any normed group) + reverse_minkowski_lp",
+      "norm_sub_norm_le_norm_add, reverse_minkowski_sub, norm_add_ge_norm_sub_norm"
+    ],
+    "insights": [
+      "Forward/reverse Minkowski are the upper/lower halves of |⟪f,g⟫|≤‖f‖‖g‖ through ‖f+g‖²=‖f‖²+2⟪f,g⟫+‖g‖².",
+      "General Lᵖ reverse needs NO inner product: it is a formal consequence of the forward triangle in any normed group.",
+      "abs_sub_le_iff splits into two symmetric norm_sub_le bounds; difference form via v↦−v (norm_neg, ← sub_eq_add_neg)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Equality case (anti-proportionality of f, g)",
+      "Complex Lᵖ reverse from complex CS (parent OQ-04)",
+      "Quantitative reverse Minkowski via the angle between f and g"
+    ]
+  },
+  "knownResults": [
+    "Parent forward Minkowski from CS/Hölder",
+    "abs_real_inner_le_norm, norm_add_sq_real, norm_sub_le"
+  ],
+  "relatedProofs": [
+    "cauchy-schwarz-integral-oq-02",
+    "cauchy-schwarz-integral-oq-02-oq-01",
+    "cauchy-schwarz-integral"
+  ],
+  "references": [
+    "Parent: cauchy-schwarz-integral-oq-02 (Minkowski from CS)"
+  ],
+  "tags": [
+    "functional-analysis",
+    "cauchy-schwarz",
+    "minkowski-inequality",
+    "reverse-triangle-inequality",
+    "lp-spaces"
+  ]
+}


### PR DESCRIPTION
## Reverse Minkowski Inequality from Cauchy-Schwarz

**Problem:** `cauchy-schwarz-integral-oq-02-oq-03` — open question 3 of the parent *Minkowski Integral Inequality as a Corollary of Cauchy-Schwarz* (`cauchy-schwarz-integral-oq-02`):

> *Can the reverse Minkowski inequality `‖f+g‖_p ≥ |‖f‖_p − ‖g‖_p|` also be derived from Cauchy-Schwarz?*

### Answer: yes — and it's the mirror image of the forward derivation

**Path 1 — L² / inner-product spaces, from the CS *lower* bound.** Where the parent's forward Minkowski uses `⟪f,g⟫ ≤ ‖f‖·‖g‖`, the reverse uses `⟪f,g⟫ ≥ −‖f‖·‖g‖`:
```
‖f+g‖² = ‖f‖² + 2⟪f,g⟫ + ‖g‖² ≥ ‖f‖² − 2‖f‖·‖g‖ + ‖g‖² = (‖f‖−‖g‖)²
```
Square roots give `|‖f‖−‖g‖| ≤ ‖f+g‖`. Forward and reverse Minkowski are the two halves of one Cauchy-Schwarz estimate.

**Path 2 — general Lᵖ, from the forward triangle inequality** (itself CS/Hölder in the parent): `f = (f+g)−g` gives `‖f‖ ≤ ‖f+g‖+‖g‖`, symmetrically for `g`, so `|‖f‖−‖g‖| ≤ ‖f+g‖`. This holds in any normed group.

### Contents (7 theorems, 0 axioms, 0 sorries)
- `reverse_minkowski_l2_from_CS`, `reverse_minkowski_inner_product_space` — from the CS lower bound
- `reverse_minkowski_norm` (any normed group), `reverse_minkowski_lp` — general Lᵖ
- `norm_sub_norm_le_norm_add`, `reverse_minkowski_sub` (`|‖f‖−‖g‖| ≤ ‖f−g‖`), `norm_add_ge_norm_sub_norm` — one-sided and difference forms

### Verification
- Builds via Docker wrapper against Mathlib (Lean 4.26.0)
- `#print axioms` on all results: only `[propext, Classical.choice, Quot.sound]` — 0 `axiom` declarations, 0 sorries, no `native_decide`
- Status `verified` / badge `original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)