### PR TITLE
research(amgm-inequality-oq-02-oq-03-oq-03-oq-03): power-mean inequality Mₚ ≤ M_q for 0 < p ≤ q (fills a Mathlib TODO)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ03.lean
@@ -1,0 +1,128 @@
+/-
+# The power-mean inequality `Mₚ ≤ M_q` for `0 < p ≤ q`
+
+## Open Question (`amgm-inequality-oq-02-oq-03-oq-03-oq-03`)
+
+The parent gallery entry *Full Maclaurin Chain* (`amgm-inequality-oq-02-oq-03-oq-03`)
+records the open question:
+
+> Can the Maclaurin chain be generalized to power means (Lᵖ norms), giving the
+> power-mean inequality `M_p ≥ M_q` for `p ≤ q`?
+
+### Answer and a clarification on direction
+
+The power means
+
+  `Mₚ(x) = ( (1/n) · Σᵢ xᵢᵖ )^{1/p}`
+
+are **monotone increasing in the exponent**: for `0 < p ≤ q` one has
+`Mₚ ≤ M_q`, *not* `Mₚ ≥ M_q` as the question literally states.  (For example
+`M₁` is the arithmetic mean and `M₂` the quadratic mean / root-mean-square, and
+`M₁ ≤ M₂` is the classical RMS–AM inequality.)  The decreasing ordering of the
+question belongs to the *Maclaurin means* `Mₖ = (eₖ/C(n,k))^{1/k}`, which are
+indexed by the **symmetric-function degree** `k` and decrease in `k`; that is a
+genuinely different family from the power means, even though both interpolate the
+AM–GM inequality.  So the honest answer to the question is: yes, there is a clean
+power-mean generalization, and its correct form is `Mₚ ≤ M_q` for `p ≤ q`.
+
+### Why this is not already in Mathlib
+
+`Mathlib.Analysis.MeanInequalities` lists, verbatim in its `TODO` section,
+
+  "- generalized mean inequality with any `p ≤ q`, including negative numbers;"
+
+so the unweighted power-mean monotonicity is *not* presently available as a
+theorem.  Mathlib does supply the convexity engine
+`NNReal.rpow_arith_mean_le_arith_mean_rpow`
+(Jensen for `t ↦ tʳ`, `r ≥ 1`, with arbitrary weights summing to `1`).  This file
+specialises it to uniform weights `1/n` to obtain the power-mean inequality for
+positive exponents `0 < p ≤ q`.
+
+## Mechanism (all `0`-axiom, no `sorry`)
+
+Put `r = q/p ≥ 1`, take uniform weights `wᵢ = 1/n`, and apply Jensen to
+`zᵢ = xᵢᵖ`:
+
+  `(Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ (xᵢᵖ)^{q/p} = Σ wᵢ xᵢ^q`,
+
+then raise both sides to the power `1/q` (monotone, `q > 0`):
+
+  `(Σ wᵢ xᵢᵖ)^{1/p} = ((Σ wᵢ xᵢᵖ)^{q/p})^{1/q} ≤ (Σ wᵢ xᵢ^q)^{1/q}`,
+
+which is exactly `Mₚ ≤ M_q`.
+
+The negative-exponent case (`p ≤ q` with `p < 0`, requiring `xᵢ > 0`) remains, as
+in Mathlib, future work.
+-/
+import Mathlib
+
+open Finset NNReal
+open scoped BigOperators
+
+namespace AmgmInequalityOQ02OQ03OQ03OQ03
+
+noncomputable section
+
+variable {ι : Type*}
+
+/-- The (unweighted) **power mean** of order `p` of `x : ι → ℝ≥0` over a finite
+set `s`:  `Mₚ = ( (1/|s|) · Σᵢ (x i)ᵖ )^{1/p}`, written with the uniform weight
+`(|s|)⁻¹` distributed across the sum. -/
+def powerMean (s : Finset ι) (x : ι → ℝ≥0) (p : ℝ) : ℝ≥0 :=
+  (∑ i ∈ s, (s.card : ℝ≥0)⁻¹ * (x i) ^ p) ^ (1 / p)
+
+/-- **Power-mean inequality.** For a nonempty finite index set and positive
+exponents `0 < p ≤ q`, the power means are monotone in the exponent:
+`Mₚ ≤ M_q`.
+
+This is the unweighted "generalized mean inequality with `p ≤ q`" that
+`Mathlib.Analysis.MeanInequalities` lists as a `TODO`.  The proof specialises
+`NNReal.rpow_arith_mean_le_arith_mean_rpow` (Jensen for `t ↦ t^{q/p}`) to the
+uniform weights `1/|s|`. -/
+theorem powerMean_le_powerMean (s : Finset ι) (x : ι → ℝ≥0)
+    (hs : s.Nonempty) {p q : ℝ} (hp : 0 < p) (hpq : p ≤ q) :
+    powerMean s x p ≤ powerMean s x q := by
+  unfold powerMean
+  set n : ℝ≥0 := (s.card : ℝ≥0) with hn
+  have hn0 : n ≠ 0 := by
+    rw [hn]; exact_mod_cast (Finset.card_pos.mpr hs).ne'
+  have hq : (0 : ℝ) < q := lt_of_lt_of_le hp hpq
+  have hr : (1 : ℝ) ≤ q / p := (one_le_div hp).mpr hpq
+  -- The uniform weights sum to one.
+  have hw : ∑ _i ∈ s, n⁻¹ = 1 := by
+    rw [Finset.sum_const, nsmul_eq_mul, ← hn, mul_inv_cancel₀ hn0]
+  -- Jensen for `t ↦ t^{q/p}` with weights `1/n` applied to `zᵢ = (x i)^p`.
+  have key := NNReal.rpow_arith_mean_le_arith_mean_rpow
+    s (fun _ => n⁻¹) (fun i => (x i) ^ p) hw hr
+  -- Simplify the right-hand exponent:  ((x i)^p)^{q/p} = (x i)^q.
+  have hrhs : (∑ i ∈ s, n⁻¹ * ((x i) ^ p) ^ (q / p))
+      = ∑ i ∈ s, n⁻¹ * (x i) ^ q := by
+    refine Finset.sum_congr rfl (fun i _ => ?_)
+    rw [← NNReal.rpow_mul]
+    congr 2
+    field_simp
+  rw [hrhs] at key
+  -- Raise both sides to the power `1/q ≥ 0`.
+  have hmono := NNReal.rpow_le_rpow key (by positivity : (0 : ℝ) ≤ 1 / q)
+  rw [← NNReal.rpow_mul] at hmono
+  -- `(q/p) * (1/q) = 1/p`, so the left side becomes `Mₚ`.
+  have hexp : q / p * (1 / q) = 1 / p := by field_simp
+  rwa [hexp] at hmono
+
+/-- **Root-mean-square ≥ arithmetic mean** (the quadratic mean dominates the
+arithmetic mean), a special case of `powerMean_le_powerMean` with `p = 1`,
+`q = 2`. -/
+theorem arithMean_le_quadraticMean (s : Finset ι) (x : ι → ℝ≥0) (hs : s.Nonempty) :
+    powerMean s x 1 ≤ powerMean s x 2 :=
+  powerMean_le_powerMean s x hs (by norm_num) (by norm_num)
+
+/-- The power mean is monotone across any positive exponent gap; restating
+`powerMean_le_powerMean` with the hypotheses bundled for `0 < p` and `0 < q`. -/
+theorem powerMean_mono (s : Finset ι) (x : ι → ℝ≥0) (hs : s.Nonempty)
+    {p q : ℝ} (hp : 0 < p) (_hq : 0 < q) (hpq : p ≤ q) :
+    powerMean s x p ≤ powerMean s x q :=
+  powerMean_le_powerMean s x hs hp hpq
+
+end
+
+end AmgmInequalityOQ02OQ03OQ03OQ03

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+  "slug": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+  "title": "Power-Mean Inequality: Mₚ ≤ M_q for 0 < p ≤ q",
+  "description": "Proves the unweighted power-mean (generalized mean) inequality Mₚ ≤ M_q for positive exponents 0 < p ≤ q — the case Mathlib's MeanInequalities lists as a TODO. Answers the parent open question on generalizing the Maclaurin chain to Lᵖ means, and corrects its stated direction (power means increase, not decrease, in the exponent). Fully verified (0 axioms, 0 sorries).",
+  "leanFile": {
+    "namespace": "AmgmInequalityOQ02OQ03OQ03OQ03",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/AmgmInequalityOQ02OQ03OQ03OQ03.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "overview": "The power means Mₚ(x) = ((1/n)·Σᵢ xᵢᵖ)^{1/p} are monotone increasing in the exponent: for 0 < p ≤ q one has Mₚ ≤ M_q. The classical instance M₁ ≤ M₂ is the arithmetic-mean ≤ root-mean-square inequality. This file establishes the general positive-exponent case by specializing Mathlib's weighted Jensen inequality NNReal.rpow_arith_mean_le_arith_mean_rpow (convexity of t ↦ t^{q/p} for q/p ≥ 1) to the uniform weights 1/n. With r = q/p and zᵢ = xᵢᵖ, Jensen gives (Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ xᵢ^q; raising both sides to 1/q (monotone since q > 0) yields Mₚ ≤ M_q. The result is exactly the entry 'generalized mean inequality with any p ≤ q' that Mathlib.Analysis.MeanInequalities records in its TODO section, so it is not currently available upstream as a theorem. The negative-exponent case (p < 0, requiring xᵢ > 0) remains future work, mirroring Mathlib's own TODO.",
+  "mainTheorems": [
+    {
+      "name": "powerMean_le_powerMean",
+      "type": "main",
+      "description": "The power-mean inequality: for a nonempty finite index set and 0 < p ≤ q, the power means satisfy Mₚ ≤ M_q. Proved by specializing NNReal.rpow_arith_mean_le_arith_mean_rpow to uniform weights and raising to the 1/q power.",
+      "leanType": "(s : Finset ι) (x : ι → ℝ≥0) (hs : s.Nonempty) {p q : ℝ} (hp : 0 < p) (hpq : p ≤ q) → powerMean s x p ≤ powerMean s x q"
+    },
+    {
+      "name": "arithMean_le_quadraticMean",
+      "type": "corollary",
+      "description": "Arithmetic mean ≤ quadratic mean (root-mean-square), the special case p = 1, q = 2 of the power-mean inequality.",
+      "leanType": "(s : Finset ι) (x : ι → ℝ≥0) (hs : s.Nonempty) → powerMean s x 1 ≤ powerMean s x 2"
+    },
+    {
+      "name": "powerMean_mono",
+      "type": "corollary",
+      "description": "Restatement of the power-mean inequality with both 0 < p and 0 < q hypotheses bundled, for a monotonicity-style API.",
+      "leanType": "(s : Finset ι) (x : ι → ℝ≥0) (hs : s.Nonempty) {p q : ℝ} (hp : 0 < p) (hq : 0 < q) (hpq : p ≤ q) → powerMean s x p ≤ powerMean s x q"
+    }
+  ],
+  "sections": [],
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03OQ03OQ03.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "power-means",
+      "jensen",
+      "convexity"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 128,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "assumptions": "None beyond Mathlib. Fully verified: 0 axioms, 0 sorries. Restricted to positive exponents 0 < p ≤ q; the negative-exponent case (which Mathlib also lists as a TODO) is not covered.",
+    "originalContributions": [
+      "Definition of the unweighted power mean Mₚ over a finite set with NNReal values",
+      "The power-mean inequality Mₚ ≤ M_q for 0 < p ≤ q, an item Mathlib lists in its MeanInequalities TODO",
+      "Clarifies the direction of the parent open question: power means increase in the exponent (Mₚ ≤ M_q), unlike the degree-indexed Maclaurin means",
+      "Root-mean-square ≥ arithmetic-mean corollary as the p=1, q=2 instance"
+    ],
+    "prerequisites": [
+      "Real powers of nonnegative reals (NNReal.rpow) and the identity (a^p)^(q/p) = a^q",
+      "Jensen's inequality for the convex map t ↦ t^r (r ≥ 1) with weights summing to one",
+      "Monotonicity of x ↦ x^z for nonnegative exponent z (NNReal.rpow_le_rpow)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "NNReal.rpow_arith_mean_le_arith_mean_rpow",
+        "description": "Weighted generalized-mean (Jensen) inequality for t ↦ t^p, p ≥ 1, over ℝ≥0-valued functions with weights summing to 1. The convexity engine specialized here to uniform weights.",
+        "module": "Mathlib.Analysis.MeanInequalitiesPow"
+      },
+      {
+        "theorem": "NNReal.rpow_mul",
+        "description": "x^(y*z) = (x^y)^z over ℝ≥0; used to rewrite (xᵢ^p)^{q/p} = xᵢ^q and to collapse the iterated exponent (q/p)·(1/q) = 1/p.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "NNReal.rpow_le_rpow",
+        "description": "Monotonicity of x ↦ x^z for 0 ≤ z over ℝ≥0; used to raise the Jensen inequality to the 1/q power.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.NNReal"
+      },
+      {
+        "theorem": "Finset.sum_const / nsmul_eq_mul / mul_inv_cancel₀",
+        "description": "Establishes that the uniform weights (|s|)⁻¹ sum to one over a nonempty finite set.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Classical reference for the power-mean (generalized mean) inequality and its monotonicity in the exponent."
+    },
+    {
+      "authors": "mathlib4 contributors",
+      "title": "Mathlib.Analysis.MeanInequalities — TODO: generalized mean inequality with any p ≤ q",
+      "year": "2026",
+      "venue": "leanprover-community/mathlib4",
+      "note": "The module's TODO section explicitly lists the generalized mean inequality for arbitrary p ≤ q as unformalized; this entry supplies the positive-exponent case."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "Parent Full Maclaurin Chain entry, whose open question asks for a power-mean generalization; this entry answers it and corrects the stated inequality direction."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question resolving whether the Maclaurin step follows from Newton's identities; both clarify the analytic content underlying Maclaurin/power means."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Base AM-GM inequality; the power means interpolate between AM-GM endpoints, and M₁ ≤ M₂ recovers the AM ≤ RMS instance."
+    }
+  ],
+  "conclusion": "The unweighted power-mean inequality Mₚ ≤ M_q holds for all 0 < p ≤ q, fully verified with no axioms. This fills the positive-exponent case of an inequality Mathlib currently lists only as a TODO, and clarifies that the correct power-mean ordering is increasing in the exponent — distinct from the degree-decreasing Maclaurin means of the parent entry.",
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question in the parent gallery entry `amgm-inequality-oq-02-oq-03-oq-03` (*Full Maclaurin Chain*):

> Can the Maclaurin chain be generalized to power means (Lᵖ norms), giving the power-mean inequality `M_p ≥ M_q` for `p ≤ q`?

**Answer:** Yes — with a corrected direction. The power means

> `Mₚ(x) = ( (1/n)·Σᵢ xᵢᵖ )^{1/p}`

are monotone **increasing** in the exponent, so the correct statement is `Mₚ ≤ M_q` for `0 < p ≤ q` (e.g. `M₁ ≤ M₂` is arithmetic-mean ≤ root-mean-square), *not* `Mₚ ≥ M_q`. The decreasing ordering of the question belongs to the degree-indexed *Maclaurin means*, a different family.

## Why this isn't already in Mathlib

`Mathlib.Analysis.MeanInequalities` lists, verbatim in its `TODO` section:

> - generalized mean inequality with any `p ≤ q`, including negative numbers;

So the unweighted power-mean monotonicity is **not** currently available upstream as a theorem. Mathlib does supply the convexity engine `NNReal.rpow_arith_mean_le_arith_mean_rpow` (Jensen for `t ↦ tʳ`, `r ≥ 1`); this PR specializes it to uniform weights.

## New file

`proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ03.lean` (128 LOC, 1 def, 3 theorems, **0 axioms, 0 sorries, Docker-verified**):

- `powerMean` — the unweighted NNReal power mean of order `p` over a finite set
- `powerMean_le_powerMean` — `Mₚ ≤ M_q` for `0 < p ≤ q`. Put `r = q/p ≥ 1`, take uniform weights `1/n`, apply Jensen to `zᵢ = xᵢᵖ`: `(Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ xᵢ^q`, then raise to `1/q` ⟹ `Mₚ ≤ M_q`
- `arithMean_le_quadraticMean` — AM ≤ RMS as the `p=1, q=2` instance
- `powerMean_mono` — monotonicity-style restatement

The negative-exponent case (`p < 0`, requiring `xᵢ > 0`) remains future work, as in Mathlib.

Adds gallery `meta.json` (status `verified`, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)