### PR TITLE
research(arithmetic-series-oq-02-oq-04-oq-01-oq-01): multiset-coefficient identity C(n+k-1,k)·k! = ∏(n+i)

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ04.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ04.lean
@@ -50,7 +50,7 @@ theorem simplicial_factorial (k n : ℕ) :
 /-- The ascending factorial as an explicit product:
     ascFactorial(n, k) = n * (n+1) * ... * (n+k-1) = prod i in range k, (n + i). -/
 theorem ascFactorial_eq_prod (n k : ℕ) :
-    Nat.ascFactorial n k = ∏ i in range k, (n + i) := by
+    Nat.ascFactorial n k = ∏ i ∈ range k, (n + i) := by
   induction k with
   | zero => simp
   | succ k ih =>
@@ -60,7 +60,7 @@ theorem ascFactorial_eq_prod (n k : ℕ) :
 /-- **Explicit Product Formula**: S_k(n) * k! = prod i in range k, (n + 1 + i).
     This makes explicit that the identity is (n+1)(n+2)...(n+k). -/
 theorem simplicial_product (k n : ℕ) :
-    simplicial k n * k.factorial = ∏ i in range k, (n + 1 + i) := by
+    simplicial k n * k.factorial = ∏ i ∈ range k, (n + 1 + i) := by
   rw [simplicial_factorial, ascFactorial_eq_prod]
 
 -- ============================================================
@@ -82,7 +82,7 @@ theorem simplicial_full_factorial (k n : ℕ) :
     is always a natural number. -/
 theorem factorial_dvd_ascFactorial (n k : ℕ) :
     k.factorial ∣ Nat.ascFactorial (n + 1) k :=
-  ⟨simplicial k n, (simplicial_factorial k n).symm⟩
+  ⟨simplicial k n, by rw [Nat.mul_comm, simplicial_factorial]⟩
 
 -- ============================================================
 -- Part IV: Low-Dimensional Specializations
@@ -90,35 +90,33 @@ theorem factorial_dvd_ascFactorial (n k : ℕ) :
 
 /-- k=1: S_1(n) * 1! = n + 1. -/
 theorem simplicial_factorial_one (n : ℕ) :
-    simplicial 1 n * 1.factorial = n + 1 := by
-  rw [simplicial_product, Finset.prod_range_one]; omega
+    simplicial 1 n * Nat.factorial 1 = n + 1 := by
+  rw [simplicial_product, Finset.prod_range_one]
 
 /-- k=2: S_2(n) * 2! = (n+1)(n+2). Matches `simplicial_two_formula`. -/
 theorem simplicial_factorial_two (n : ℕ) :
-    simplicial 2 n * 2.factorial = (n + 1) * (n + 2) := by
+    simplicial 2 n * Nat.factorial 2 = (n + 1) * (n + 2) := by
   rw [simplicial_product]
   simp only [Finset.prod_range_succ, Finset.prod_range_zero, one_mul, Nat.add_zero]
-  ring
 
 /-- k=3: S_3(n) * 3! = (n+1)(n+2)(n+3). Matches `simplicial_three_formula`. -/
 theorem simplicial_factorial_three (n : ℕ) :
-    simplicial 3 n * 3.factorial = (n + 1) * (n + 2) * (n + 3) := by
+    simplicial 3 n * Nat.factorial 3 = (n + 1) * (n + 2) * (n + 3) := by
   rw [simplicial_product]
   simp only [Finset.prod_range_succ, Finset.prod_range_zero, one_mul, Nat.add_zero]
-  ring
 
 -- ============================================================
 -- Part V: Concrete Verification
 -- ============================================================
 
 /-- S_4(3) * 4! = 4*5*6*7 = 840. C(7,4) = 35, 35 * 24 = 840. -/
-theorem check_k4_n3 : simplicial 4 3 * 4.factorial = 840 := by native_decide
+theorem check_k4_n3 : simplicial 4 3 * Nat.factorial 4 = 840 := by decide
 
 /-- S_5(2) * 5! = 3*4*5*6*7 = 2520. C(7,5) = 21, 21 * 120 = 2520. -/
-theorem check_k5_n2 : simplicial 5 2 * 5.factorial = 2520 := by native_decide
+theorem check_k5_n2 : simplicial 5 2 * Nat.factorial 5 = 2520 := by decide
 
 /-- The product formula agrees: prod i in range 4, (4 + i) = 4*5*6*7 = 840. -/
-theorem check_product : ∏ i in range 4, (3 + 1 + i) = 840 := by native_decide
+theorem check_product : ∏ i ∈ range 4, (3 + 1 + i) = 840 := by decide
 
 /-
   Summary

--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean
@@ -8,34 +8,32 @@
     C(n+k-1, k) * k! = n*(n+1)*...*(n+k-1) = ascFactorial(n, k) = ∏ i in range k, (n+i).
 
   This is the rising-factorial analogue indexed so the product STARTS at n:
-    - parent  OQ01 gives the descending form  C(n,k)   * k! = ∏ (n - i)
-    - grandpa OQ04 gives the ascending  form  C(n+k,k) * k! = ascFactorial(n+1,k) = ∏ (n+1+i)
+    - parent  OQ01 gives the descending form  C(n,   k) * k! = ∏ (n - i)
+    - grandpa OQ04 gives the ascending  form  C(n+k, k) * k! = ascFactorial(n+1,k) = ∏ (n+1+i)
   Here the product starts at n itself, which is exactly the multiset coefficient
   C(n+k-1, k) = (number of size-k multisets drawn from n symbols).
 
-  Combinatorial content: C(n+k-1, k) counts unordered k-multisets from n symbols;
-  multiplying by k! recovers the rising factorial n*(n+1)*...*(n+k-1). This is the
-  multiset / "stars and bars" dual of the parent's descending (falling) factorial.
+  Combinatorial content: C(n+k-1, k) counts unordered k-multisets from n symbols
+  ("stars and bars"); multiplying by k! recovers the rising factorial
+  n*(n+1)*...*(n+k-1). This is the multiset dual of the parent's descending
+  (falling) factorial C(n,k)*k! = n*(n-1)*...*(n-k+1).
 
-  Proof strategy (reduces entirely to build-checked lemmas):
-    - n = 0 is degenerate: for k ≥ 1 both sides vanish (C(k-1,k) = 0 and the
-      product contains the i = 0 factor 0); k = 0 gives 1 = 1.
-    - n = m+1 is the grandparent's identity shifted by one:
-        C(m+k, k) * k! = ascFactorial(m+1, k) = ∏ i in range k, (m+1+i)
-      via `Nat.ascFactorial_eq_factorial_mul_choose` (Mathlib) and
-      `ArithmeticSeriesOQ02OQ04.ascFactorial_eq_prod`.
+  Proof: the identity is `Nat.ascFactorial_eq_factorial_mul_choose'`
+    (n.ascFactorial k = k! * (n+k-1).choose k)
+  composed with `Nat.ascFactorial_eq_prod_range`
+    (n.ascFactorial k = ∏ i in range k, (n+i)).
+  Both hold for all n (including the degenerate n = 0, where both sides vanish
+  for k ≥ 1 and equal 1 for k = 0), so no case split or side condition is needed.
 
-  STATUS: DRAFT — proof written but NOT build-verified (Docker/lake outage
-  2026-06-13; see project memory "Verification blackout 2026-06-13"). It is
-  intentionally NOT yet registered in proofs/Proofs.lean so it cannot affect the
-  whole-library build. To verify: add `import Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01`
-  to Proofs.lean and run
-    ./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01
+  Status: 0 axioms, 0 sorries, no native_decide.
 
   Parent: ArithmeticSeriesOQ02OQ04OQ01.lean (descending factorial)
+  Grandparent: ArithmeticSeriesOQ02OQ04.lean (ascending factorial)
 -/
 
-import Proofs.ArithmeticSeriesOQ02OQ04OQ01
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Data.Nat.Factorial.BigOperators
+import Proofs.ArithmeticSeriesOQ02OQ04
 
 namespace ArithmeticSeriesOQ02OQ04OQ01OQ01
 
@@ -48,71 +46,97 @@ open Finset BigOperators
 /-- **Multiset-Coefficient Identity**: C(n+k-1, k) * k! = ∏ i in range k, (n + i).
 
     The left side is "n multichoose k" times k!; the right side is the rising
-    factorial n*(n+1)*...*(n+k-1). For n ≥ 1 this is the grandparent's
-    `simplicial_factorial` shifted by one; the n = 0 case is degenerate (both
-    sides vanish for k ≥ 1, and equal 1 for k = 0). -/
+    factorial n*(n+1)*...*(n+k-1). Reduces directly to two Mathlib lemmas:
+    `Nat.ascFactorial_eq_factorial_mul_choose'` and
+    `Nat.ascFactorial_eq_prod_range`. -/
 theorem multichoose_factorial (n k : ℕ) :
     Nat.choose (n + k - 1) k * k.factorial = ∏ i ∈ range k, (n + i) := by
-  rcases n with _ | m
-  · -- n = 0
-    rcases k with _ | j
-    · simp
-    · -- k = j + 1 ≥ 1: both sides are 0
-      rw [show 0 + (j + 1) - 1 = j from by omega,
-          Nat.choose_eq_zero_of_lt (Nat.lt_succ_self j), Nat.zero_mul]
-      symm
-      apply Finset.prod_eq_zero (Finset.mem_range.mpr (Nat.succ_pos j))
-      simp
-  · -- n = m + 1: reduce to the ascending factorial identity from OQ04
-    rw [← ArithmeticSeriesOQ02OQ04.ascFactorial_eq_prod,
-        show m + 1 + k - 1 = m + k from by omega,
-        Nat.ascFactorial_eq_factorial_mul_choose]
-    ring
+  rw [Nat.mul_comm, ← Nat.ascFactorial_eq_factorial_mul_choose',
+      Nat.ascFactorial_eq_prod_range]
+
+/-- **Rising Factorial Closed Form**: C(n+k-1, k) * k! = ascFactorial(n, k).
+    The same identity, packaged against Mathlib's `Nat.ascFactorial`. -/
+theorem multichoose_eq_ascFactorial (n k : ℕ) :
+    Nat.choose (n + k - 1) k * k.factorial = n.ascFactorial k := by
+  rw [Nat.mul_comm, ← Nat.ascFactorial_eq_factorial_mul_choose']
 
 -- ============================================================
--- Part II: Low-Dimensional Specializations
+-- Part II: Structural Properties
+-- ============================================================
+
+/-- **k! divides the rising product**: equivalently, the multiset coefficient
+    C(n+k-1, k) = (∏ i in range k, (n+i)) / k! is an integer. -/
+theorem factorial_dvd_rising_product (n k : ℕ) :
+    k.factorial ∣ ∏ i ∈ range k, (n + i) :=
+  ⟨Nat.choose (n + k - 1) k, by rw [← multichoose_factorial]; exact Nat.mul_comm _ _⟩
+
+/-- **Multiset vs. ascending duality**: the multiset form starts its product at n,
+    while the grandparent's ascending (simplicial) form starts at n+1.
+
+    - multiset    : C(n+k-1, k) * k! = ∏ i in range k, (n + i)     = n(n+1)···(n+k-1)
+    - ascending   : C(n+k,   k) * k! = ∏ i in range k, (n + 1 + i) = (n+1)(n+2)···(n+k)
+
+    They are the same ordered-selection count read off two adjacent index origins. -/
+theorem multiset_ascending_duality (n k : ℕ) :
+    Nat.choose (n + k - 1) k * k.factorial = ∏ i ∈ range k, (n + i) ∧
+    ArithmeticSeriesOQ02.simplicial k n * k.factorial = ∏ i ∈ range k, (n + 1 + i) :=
+  ⟨multichoose_factorial n k, ArithmeticSeriesOQ02OQ04.simplicial_product k n⟩
+
+-- ============================================================
+-- Part III: Low-Dimensional Specializations
 -- ============================================================
 
 /-- k = 1: C(n, 1) * 1! = n. -/
 theorem multichoose_factorial_one (n : ℕ) :
-    Nat.choose (n + 1 - 1) 1 * 1.factorial = n := by
+    Nat.choose (n + 1 - 1) 1 * Nat.factorial 1 = n := by
   rw [multichoose_factorial, Finset.prod_range_one, Nat.add_zero]
 
 /-- k = 2: C(n+1, 2) * 2! = n*(n+1). -/
 theorem multichoose_factorial_two (n : ℕ) :
-    Nat.choose (n + 2 - 1) 2 * 2.factorial = n * (n + 1) := by
+    Nat.choose (n + 2 - 1) 2 * Nat.factorial 2 = n * (n + 1) := by
   rw [multichoose_factorial, Finset.prod_range_succ, Finset.prod_range_one]; ring
 
 /-- k = 3: C(n+2, 3) * 3! = n*(n+1)*(n+2). -/
 theorem multichoose_factorial_three (n : ℕ) :
-    Nat.choose (n + 3 - 1) 3 * 3.factorial = n * (n + 1) * (n + 2) := by
+    Nat.choose (n + 3 - 1) 3 * Nat.factorial 3 = n * (n + 1) * (n + 2) := by
   rw [multichoose_factorial, Finset.prod_range_succ, Finset.prod_range_succ,
       Finset.prod_range_one]; ring
 
+/-- n = 1: C(1+k-1, k) * k! = C(k, k) * k! = k!. The product 1·2···k is just k!. -/
+theorem multichoose_factorial_n_one (k : ℕ) :
+    Nat.choose (1 + k - 1) k * k.factorial = k.factorial := by
+  rw [show 1 + k - 1 = k from by omega, Nat.choose_self, Nat.one_mul]
+
 -- ============================================================
--- Part III: Concrete Verification
+-- Part IV: Concrete Verification (decide — no native_decide)
 -- ============================================================
 
 /-- C(4,3) * 3! = 2*3*4 = 24. C(4,3) = 4, 4 * 6 = 24. -/
-theorem check_n2_k3 : Nat.choose (2 + 3 - 1) 3 * 3.factorial = 24 := by native_decide
+theorem check_n2_k3 : Nat.choose (2 + 3 - 1) 3 * Nat.factorial 3 = 24 := by decide
 
 /-- C(4,2) * 2! = 3*4 = 12. C(4,2) = 6, 6 * 2 = 12. -/
-theorem check_n3_k2 : Nat.choose (3 + 2 - 1) 2 * 2.factorial = 12 := by native_decide
+theorem check_n3_k2 : Nat.choose (3 + 2 - 1) 2 * Nat.factorial 2 = 12 := by decide
 
-/-- The product agrees: ∏ i in range 3, (2 + i) = 2*3*4 = 24. -/
-theorem check_product_n2_k3 : ∏ i ∈ range 3, (2 + i) = 24 := by native_decide
+/-- The product side agrees: ∏ i in range 3, (2 + i) = 2*3*4 = 24. -/
+theorem check_product_n2_k3 : ∏ i ∈ range 3, (2 + i) = 24 := by
+  rw [← multichoose_factorial]; decide
 
 /-
   Summary
 
-  This file (DRAFT, awaiting Docker build verification) states the multiset-
-  coefficient generalization of the descending/ascending factorial identities:
+  This file proves the multiset-coefficient generalization of the
+  descending/ascending factorial identities, 0 axioms / 0 sorries / no
+  native_decide:
 
     Part I  - multichoose_factorial:        C(n+k-1, k) * k! = ∏ i in range k, (n + i)
-    Part II - multichoose_factorial_one:    C(n,   1) * 1 = n
-              multichoose_factorial_two:    C(n+1, 2) * 2 = n*(n+1)
-              multichoose_factorial_three:  C(n+2, 3) * 6 = n*(n+1)*(n+2)
-    Part III- concrete native_decide checks
+              multichoose_eq_ascFactorial:   C(n+k-1, k) * k! = ascFactorial(n, k)
+    Part II - factorial_dvd_rising_product:  k! ∣ ∏ i in range k, (n + i)
+              multiset_ascending_duality:    multiset (start n) vs ascending (start n+1)
+    Part III- multichoose_factorial_one:     C(n,   1) * 1 = n
+              multichoose_factorial_two:     C(n+1, 2) * 2 = n*(n+1)
+              multichoose_factorial_three:   C(n+2, 3) * 6 = n*(n+1)*(n+2)
+              multichoose_factorial_n_one:   C(k,   k) * k! = k!
+    Part IV - concrete decide checks
 
   Key insight:
     descending : C(n,    k) * k! = n*(n-1)*...*(n-k+1)   [OQ01]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-asoq0101-main-identity",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 61
+    },
+    "type": "insight",
+    "title": "Main Identity: Multiset Coefficient times k! is the Rising Factorial",
+    "content": "multichoose_factorial proves C(n+k-1, k)·k! = ∏ i ∈ range k, (n+i) by a single rewrite chain: Nat.mul_comm puts the factorial in front, ← Nat.ascFactorial_eq_factorial_mul_choose' folds k!·(n+k-1).choose k into n.ascFactorial k, and Nat.ascFactorial_eq_prod_range expands that into the explicit product. multichoose_eq_ascFactorial stops one step earlier, exposing the closed form against Mathlib's Nat.ascFactorial. Crucially, both Mathlib lemmas hold for every n — including the degenerate n=0, where C(k-1,k)=0 and the product carries the i=0 factor 0 — so no case split or side condition is needed.",
+    "mathContext": "$\\left(\\!\\binom{n}{k}\\!\\right) \\cdot k! = \\binom{n+k-1}{k} \\cdot k! = n^{\\overline{k}} = n(n+1)\\cdots(n+k-1)$, the **rising factorial** (Pochhammer symbol). The multiset coefficient $\\binom{n+k-1}{k}$ counts size-$k$ multisets drawn from $n$ symbols; multiplying by $k!$ recovers the product of $k$ consecutive integers starting at $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.ascFactorial",
+      "Nat.ascFactorial_eq_factorial_mul_choose'",
+      "Nat.ascFactorial_eq_prod_range",
+      "rising factorial",
+      "multiset coefficient",
+      "Pochhammer symbol"
+    ],
+    "prerequisites": [
+      "Nat.choose",
+      "Nat.factorial",
+      "Nat.ascFactorial_eq_factorial_mul_choose'"
+    ]
+  },
+  {
+    "id": "ann-asoq0101-structural",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 86
+    },
+    "type": "concept",
+    "title": "Integrality and the Ascending/Multiset Duality",
+    "content": "factorial_dvd_rising_product shows k! ∣ ∏ i ∈ range k, (n+i) by exhibiting the multiset coefficient as the cofactor — a free corollary of the main identity, with no separate induction. multiset_ascending_duality pairs the multiset form with the grandparent's ascending (simplicial) form: both are products of k consecutive integers, but the multiset product starts at n while the ascending product starts at n+1.",
+    "mathContext": "Integrality: $k! \\mid \\prod_{i=0}^{k-1}(n+i)$, equivalently $\\binom{n+k-1}{k} \\in \\mathbb{N}$. Duality: $\\binom{n+k-1}{k}k! = n(n+1)\\cdots(n+k-1)$ (origin $n$) versus $\\binom{n+k}{k}k! = (n+1)(n+2)\\cdots(n+k)$ (origin $n+1$) — adjacent index origins for the same kind of consecutive-integer product.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "divisibility",
+      "Nat.ascFactorial",
+      "simplicial number",
+      "Pochhammer symbol"
+    ],
+    "prerequisites": [
+      "Dvd",
+      "ArithmeticSeriesOQ02OQ04.simplicial_product"
+    ]
+  },
+  {
+    "id": "ann-asoq0101-specializations",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 109
+    },
+    "type": "concept",
+    "title": "Low-Dimensional Specializations",
+    "content": "multichoose_factorial_one/two/three instantiate k=1,2,3 by rewriting with the main identity and expanding the product via Finset.prod_range_succ + ring, giving C(n,1)·1!=n, C(n+1,2)·2!=n(n+1), C(n+2,3)·6=n(n+1)(n+2). multichoose_factorial_n_one is the dual n=1 instance: C(k,k)·k! = k!, proved directly from Nat.choose_self.",
+    "mathContext": "$k=1$: $\\binom{n}{1}\\cdot 1! = n$. $k=2$: $\\binom{n+1}{2}\\cdot 2! = n(n+1)$. $k=3$: $\\binom{n+2}{3}\\cdot 3! = n(n+1)(n+2)$. $n=1$: $\\binom{k}{k}\\cdot k! = 1\\cdot k! = k!$, the product $1\\cdot 2\\cdots k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.prod_range_succ",
+      "Nat.choose_self"
+    ],
+    "prerequisites": [
+      "Finset.prod_range_one",
+      "Finset.prod_range_succ"
+    ]
+  },
+  {
+    "id": "ann-asoq0101-concrete",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 149
+    },
+    "type": "concept",
+    "title": "Concrete Verification without native_decide",
+    "content": "Three sanity checks confirm the identity numerically using decide (not native_decide), keeping the file Lean.ofReduceBool-free: C(4,3)·3!=24, C(4,2)·2!=12, and the product side ∏ i ∈ range 3, (2+i)=24 (proved by rewriting backwards through the main identity, then decide). This is a deliberate axiom-hygiene choice so the entry can be reported as fully verified with 0 axioms.",
+    "mathContext": "$n=2,k=3$: $\\binom{4}{3}\\cdot 3! = 4\\cdot 6 = 24 = 2\\cdot 3\\cdot 4$. $n=3,k=2$: $\\binom{4}{2}\\cdot 2! = 6\\cdot 2 = 12 = 3\\cdot 4$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide",
+      "native_decide",
+      "Lean.ofReduceBool"
+    ],
+    "prerequisites": [
+      "Decidable equality on ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+  "title": "Multiset-Coefficient (Rising Factorial) Identity: C(n+k-1,k)·k! = n·(n+1)·⋯·(n+k-1)",
+  "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-01",
+  "description": "Answers the open question from the descending-factorial entry: generalize to multiset coefficients. Proves C(n+k-1, k)·k! = ∏ i in range k, (n+i) = ascFactorial(n, k), the rising-factorial form whose product starts at n — exactly the multiset coefficient ('n multichoose k') times k!.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "factorial",
+      "binomial-coefficient",
+      "rising-factorial",
+      "multiset-coefficient",
+      "stars-and-bars",
+      "arithmetic-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 149,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (concrete checks use `decide`, so `#print axioms` lists only the ordinary foundational axioms propext / Classical.choice / Quot.sound, which are not counted). Imports ArithmeticSeriesOQ02OQ04.lean (whose own concrete checks were converted from `native_decide` to `decide` in this change, so the dependency chain is now Lean.ofReduceBool-free).",
+    "originalContributions": [
+      "multichoose_factorial: C(n+k-1, k) * k! = ∏ i in range k, (n+i) — the multiset-coefficient identity (rising factorial starting at n)",
+      "multichoose_eq_ascFactorial: the same identity packaged as C(n+k-1, k) * k! = Nat.ascFactorial(n, k)",
+      "factorial_dvd_rising_product: k! | ∏ i in range k, (n+i) (integrality of the multiset coefficient)",
+      "multiset_ascending_duality: connects the multiset form (product starts at n) to the parent's ascending form (product starts at n+1)",
+      "multichoose_factorial_one/two/three: k=1,2,3 specializations",
+      "multichoose_factorial_n_one: n=1 case, C(k,k)·k! = k!"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The multiset coefficient $\\left(\\!\\binom{n}{k}\\!\\right) = \\binom{n+k-1}{k}$ counts the number of size-$k$ multisets drawn from $n$ symbols — equivalently, the number of ways to place $k$ indistinguishable balls into $n$ distinguishable boxes ('stars and bars'). Multiplying it by $k!$ recovers the rising factorial (Pochhammer symbol) $n^{\\overline{k}} = n(n+1)\\cdots(n+k-1)$, which is fundamental in the theory of hypergeometric functions and special functions.\n\nThis entry completes a three-way family of ordered-selection identities built across the arithmetic-series gallery branch. The grandparent (ArithmeticSeriesOQ02OQ04) proved the ascending form $\\binom{n+k}{k}\\cdot k! = (n+1)(n+2)\\cdots(n+k)$ (product starting at $n+1$); the parent (ArithmeticSeriesOQ02OQ04OQ01) proved the descending form $\\binom{n}{k}\\cdot k! = n(n-1)\\cdots(n-k+1)$. The open question recorded in the parent asked for the multiset generalization, where the product starts at $n$ itself: that is exactly the identity proved here.",
+    "problemStatement": "Prove the multiset-coefficient generalization C(n+k-1, k)·k! = ∏ i in range k, (n+i) = n·(n+1)·⋯·(n+k-1), the rising factorial whose product origin is n.",
+    "proofStrategy": "The headline reduces to two Mathlib lemmas with no case split: `Nat.ascFactorial_eq_factorial_mul_choose'` (n.ascFactorial k = k! · (n+k-1).choose k) rewrites the binomial side into a rising factorial, and `Nat.ascFactorial_eq_prod_range` (n.ascFactorial k = ∏ i in range k, (n+i)) expands it to the explicit product. Both Mathlib lemmas hold for every n (including the degenerate n=0, where both sides vanish for k≥1), so the proof is a single chain of rewrites. Divisibility follows from the identity; the duality theorem pairs the result with the grandparent's ascending form; specializations expand small k by `Finset.prod_range_succ` + `ring`; concrete checks use `decide`.",
+    "keyInsights": [
+      "The three ordered-selection identities are the same count read off three index origins: descending C(n,k)·k! = n(n-1)···(n-k+1) (origin n, going down); ascending C(n+k,k)·k! = (n+1)···(n+k) (origin n+1, going up); multiset C(n+k-1,k)·k! = n(n+1)···(n+k-1) (origin n, going up).",
+      "The multiset coefficient C(n+k-1, k) counts size-k multisets from n symbols (stars and bars); multiplying by k! turns the unordered count into the rising factorial, mirroring how the parent's binomial·k! turns into the falling factorial.",
+      "Mathlib's `Nat.ascFactorial_eq_factorial_mul_choose'` already states the identity in exactly the C(n+k-1,k) form, so the formalization is a near-trivial composition once the right lemma is located — a recurring lesson that good Mathlib naming collapses a textbook derivation to a one-line rewrite.",
+      "No parity/positivity side conditions are needed: the n=0 boundary is handled uniformly by the Mathlib lemmas (C(k-1,k)=0 for k≥1, and the product contains the i=0 factor 0), so the statement holds for all n,k:ℕ.",
+      "k! ∣ ∏ i in range k, (n+i) is the integrality of the multiset coefficient — a free corollary of the main identity, with no separate induction."
+    ],
+    "prerequisites": [
+      "Nat.ascFactorial: rising factorial in Mathlib",
+      "Nat.ascFactorial_eq_factorial_mul_choose': ascFactorial in the C(n+k-1,k) form",
+      "Nat.ascFactorial_eq_prod_range: product expansion of ascFactorial",
+      "simplicial / simplicial_product from ArithmeticSeriesOQ02OQ04: ascending factorial identity (used in the duality theorem)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "main-identity",
+      "title": "Part I: The Main Identity",
+      "summary": "multichoose_factorial: C(n+k-1,k)·k! = ∏ i in range k, (n+i), and multichoose_eq_ascFactorial: the same packaged against Nat.ascFactorial. Reduce to two Mathlib lemmas.",
+      "startLine": 44,
+      "endLine": 61
+    },
+    {
+      "id": "structural",
+      "title": "Part II: Structural Properties",
+      "summary": "factorial_dvd_rising_product (k! divides the rising product = integrality of the multiset coefficient) and multiset_ascending_duality (multiset form starts the product at n; the parent's ascending form starts at n+1).",
+      "startLine": 63,
+      "endLine": 86
+    },
+    {
+      "id": "specializations",
+      "title": "Part III: Low-Dimensional Specializations",
+      "summary": "multichoose_factorial_one (k=1: C(n,1)·1!=n), _two (k=2: C(n+1,2)·2!=n(n+1)), _three (k=3: C(n+2,3)·6=n(n+1)(n+2)), and _n_one (n=1: C(k,k)·k!=k!).",
+      "startLine": 88,
+      "endLine": 109
+    },
+    {
+      "id": "concrete-checks",
+      "title": "Part IV: Concrete Verification",
+      "summary": "Three decide checks (no native_decide): C(4,3)·3!=24, C(4,2)·2!=12, ∏ i in range 3, (2+i)=24. Summary comment lists all 11 theorems.",
+      "startLine": 111,
+      "endLine": 149
+    }
+  ],
+  "conclusion": {
+    "summary": "Proved the multiset-coefficient (rising factorial) identity C(n+k-1,k)·k! = ∏ i in range k, (n+i) and 8 consequences. 149 lines, 11 theorems, 0 sorries, 0 axioms, no native_decide. Completes the descending/ascending/multiset family of ordered-selection identities on the arithmetic-series branch. As part of this change, the grandparent ArithmeticSeriesOQ02OQ04.lean was repaired for Mathlib v4.26.0 (∏-binder syntax, numeric-literal factorial) and its concrete checks moved from native_decide to decide.",
+    "implications": "With the descending (parent) and ascending (grandparent) forms, the multiset form completes the natural triad of consecutive-integer products attached to binomial and multiset coefficients. The rising-factorial form is the bridge to Pochhammer symbols and hypergeometric series.",
+    "openQuestions": [
+      "Formalize the stars-and-bars bijection directly: C(n+k-1,k) = number of size-k multisets from n symbols (e.g. via Mathlib's Sym), and connect it to this product identity.",
+      "Prove the multiset Vandermonde / Chu–Vandermonde identity in rising-factorial form.",
+      "Relate the rising factorial to Mathlib's general ascending Pochhammer (ascPochhammer) over a commutative ring and recover this ℕ identity as a specialization."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Parent: descending factorial identity C(n,k)·k! = n(n-1)···(n-k+1). The open question recorded there asked for this multiset generalization."
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04",
+      "relationship": "related",
+      "description": "Grandparent: ascending factorial identity C(n+k,k)·k! = (n+1)(n+2)···(n+k). The duality theorem pairs the multiset form against this ascending form."
+    },
+    {
+      "targetId": "arithmetic-series-oq-02",
+      "relationship": "related",
+      "description": "Great-grandparent: arithmetic series Σ k = n(n+1)/2 and the simplicial numbers."
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "C(n+k-1,k) is the multiset coefficient; multiplying by k! counts ordered selections with repetition allowed in symbol type."
+    }
+  ],
+  "mathlibDependencies": [
+    {
+      "theorem": "Nat.ascFactorial_eq_factorial_mul_choose'",
+      "description": "Core identity in multiset form: n.ascFactorial k = k! * (n+k-1).choose k — the headline is the commuted form of this",
+      "module": "Mathlib.Data.Nat.Choose.Basic"
+    },
+    {
+      "theorem": "Nat.ascFactorial_eq_prod_range",
+      "description": "Product expansion: n.ascFactorial k = ∏ i in range k, (n + i)",
+      "module": "Mathlib.Data.Nat.Factorial.BigOperators"
+    },
+    {
+      "theorem": "Nat.choose_self",
+      "description": "C(k,k) = 1, used in the n=1 specialization",
+      "module": "Mathlib.Data.Nat.Choose.Basic"
+    }
+  ],
+  "leanFile": {
+    "namespace": "ArithmeticSeriesOQ02OQ04OQ01OQ01",
+    "lineCount": 149,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Basic",
+      "Mathlib.Data.Nat.Factorial.BigOperators",
+      "Proofs.ArithmeticSeriesOQ02OQ04"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question recorded in the descending-factorial entry (`arithmetic-series-oq-02-oq-04-oq-01`): the **multiset-coefficient (rising factorial)** generalization.

```
C(n+k-1, k) · k! = ∏ i in range k, (n+i) = ascFactorial(n, k) = n·(n+1)·⋯·(n+k-1)
```

The multiset coefficient `C(n+k-1, k)` ("n multichoose k", stars-and-bars) times `k!` is the rising factorial whose product **starts at n** — completing the natural triad:

| form | identity | product origin |
|------|----------|----------------|
| descending (parent) | C(n,k)·k! = n(n−1)···(n−k+1) | n, down |
| ascending (grandparent) | C(n+k,k)·k! = (n+1)···(n+k) | n+1, up |
| **multiset (this entry)** | C(n+k−1,k)·k! = n···(n+k−1) | n, up |

## Proof

The headline reduces with **no case split** to two Mathlib lemmas:
- `Nat.ascFactorial_eq_factorial_mul_choose'` : `n.ascFactorial k = k! * (n+k-1).choose k`
- `Nat.ascFactorial_eq_prod_range` : `n.ascFactorial k = ∏ i ∈ range k, (n+i)`

Both hold for **all** n (including the degenerate n=0, where C(k−1,k)=0 and the product carries the i=0 factor 0), so no parity/positivity side condition is needed.

**11 theorems, 0 defs, 0 sorries, 0 axioms, no `native_decide`** (concrete checks use `decide`). Includes the rising-factorial closed form, integrality (k! ∣ ∏), the multiset↔ascending duality, k=1,2,3 and n=1 specializations.

## Dependency repair

The grandparent `Proofs/ArithmeticSeriesOQ02OQ04.lean` had **bit-rotted** under Mathlib v4.26.0 and no longer parsed:
- `∏ i in s` → `∏ i ∈ s` (binder syntax change)
- `1.factorial` numeric literal now lexed as a float → `Nat.factorial 1`
- a `Dvd` witness needed a `mul_comm`
- three `rw`/`simp` chains now close their goals on their own (redundant `omega`/`ring` removed)
- its concrete checks moved from `native_decide` to `decide`, so the whole chain is now `Lean.ofReduceBool`-free

## Verification

```
./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01
=> Build succeeded (3060 jobs)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)