### PR TITLE
research(combinations-formula-oq-07-oq-02): the off-diagonal Vandermonde convolution

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -708,6 +708,7 @@ import Proofs.CombinationsFormulaOQ05
 import Proofs.CombinationsFormulaOQ06
 import Proofs.CombinationsFormulaOQ07
 import Proofs.CombinationsFormulaOQ07OQ01
+import Proofs.CombinationsFormulaOQ07OQ02
 import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09
 import Proofs.CompactnessFiniteSubcover

--- a/proofs/Proofs/CombinationsFormulaOQ07OQ02.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ02.lean
@@ -1,0 +1,118 @@
+import Mathlib
+
+/-
+# The Off-Diagonal Vandermonde Convolution
+
+## Open Question OQ-07-OQ-02
+
+The parent entry `combinations-formula-oq-07` reindexes Mathlib's antidiagonal
+form of Vandermonde's identity (`Nat.add_choose_eq`) into the single-sum
+*range* form
+
+  C(m + n, k) = ∑_{i=0}^{k} C(m, i) · C(n, k - i),
+
+and reads off the celebrated *diagonal* special case
+
+  C(2n, n) = ∑_{i=0}^{n} C(n, i)² .
+
+This follow-up develops the **off-diagonal** companion.  Where the diagonal
+identity pairs each entry of row `n` with itself, the off-diagonal identity
+slides the second factor by a fixed shift `r`:
+
+  C(m + n, n − r) = ∑_{i=0}^{n−r} C(m, i) · C(n, i + r)        (r ≤ n).
+
+The diagonal sum-of-squares is precisely the central case `m = n`, `r = 0`, so
+this identity is a genuine two-parameter generalisation of the parent's
+headline rather than a restatement of it.
+
+## Why the shift is natural
+
+Setting `r = 0` and replacing `C(n, i)` by `C(n, n − i)` (symmetry) turns the
+range form of Vandermonde at `k = n` into the *mixed* product sum
+
+  C(m + n, n) = ∑_{i=0}^{n} C(m, i) · C(n, i) ,
+
+an identity from Gould's combinatorial tables.  Carrying a shift `r` through the
+same computation — and choosing the summation range so that **every** term
+stays inside the symmetry window `i + r ≤ n` — yields the off-diagonal form
+above with no vanishing tail to discard.  This is the cleanest route: it never
+needs to split the sum into nonzero and zero parts.
+
+## Results
+
+* `add_choose_eq_sum_range` — the range form of Vandermonde (re-derived here so
+  the file is self-contained).
+* `sum_choose_mul_choose_shift` — the off-diagonal convolution
+  `C(m + n, n − r) = ∑_{i=0}^{n−r} C(m, i) · C(n, i + r)`.
+* `sum_choose_mul_choose` — the `r = 0` mixed product sum
+  `C(m + n, n) = ∑_{i=0}^{n} C(m, i) · C(n, i)`.
+* `central_sum_sq_shift` — the `m = n` central case
+  `C(2n, n − r) = ∑_{i=0}^{n−r} C(n, i) · C(n, i + r)`.
+* `central_binom_eq_sum_sq` — recovers the parent's diagonal
+  `C(2n, n) = ∑_{i=0}^{n} C(n, i)²` as the `m = n`, `r = 0` corner.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ02
+
+open Finset
+
+/-- **Vandermonde's convolution (range form).**
+    `C(m + n, k) = ∑_{i=0}^{k} C(m, i) · C(n, k - i)`.  This is `Nat.add_choose_eq`
+    pushed through `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`. -/
+theorem add_choose_eq_sum_range (m n k : ℕ) :
+    (m + n).choose k = ∑ i ∈ Finset.range (k + 1), m.choose i * n.choose (k - i) := by
+  rw [Nat.add_choose_eq,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ (fun i j => m.choose i * n.choose j) k]
+
+/-- **Off-diagonal Vandermonde convolution.**
+    For a shift `r ≤ n`,
+        `C(m + n, n − r) = ∑_{i=0}^{n−r} C(m, i) · C(n, i + r)`.
+    The summation range `i ≤ n − r` guarantees `i + r ≤ n`, so the symmetry
+    `C(n, (n−r) − i) = C(n, i + r)` applies to every term. -/
+theorem sum_choose_mul_choose_shift (m n r : ℕ) (hr : r ≤ n) :
+    (m + n).choose (n - r) = ∑ i ∈ Finset.range (n - r + 1), m.choose i * n.choose (i + r) := by
+  rw [add_choose_eq_sum_range]
+  refine Finset.sum_congr rfl (fun i hi => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hi
+  -- `i ≤ n - r` and `r ≤ n` give `i + r ≤ n`, and `(n - r) - i = n - (i + r)`.
+  have hsub : n - r - i = n - (i + r) := by omega
+  rw [hsub, Nat.choose_symm (by omega)]
+
+/-- **Mixed product sum** (`r = 0`).
+    `C(m + n, n) = ∑_{i=0}^{n} C(m, i) · C(n, i)`. -/
+theorem sum_choose_mul_choose (m n : ℕ) :
+    (m + n).choose n = ∑ i ∈ Finset.range (n + 1), m.choose i * n.choose i := by
+  have h := sum_choose_mul_choose_shift m n 0 (Nat.zero_le n)
+  simpa using h
+
+/-- **Central off-diagonal case** (`m = n`).
+    `C(2n, n − r) = ∑_{i=0}^{n−r} C(n, i) · C(n, i + r)` for `r ≤ n`. -/
+theorem central_sum_sq_shift (n r : ℕ) (hr : r ≤ n) :
+    (2 * n).choose (n - r) = ∑ i ∈ Finset.range (n - r + 1), n.choose i * n.choose (i + r) := by
+  rw [two_mul]
+  exact sum_choose_mul_choose_shift n n r hr
+
+/-- **Parent's diagonal identity recovered** (`m = n`, `r = 0`).
+    `C(2n, n) = ∑_{i=0}^{n} C(n, i)²` — the central case of the off-diagonal
+    convolution.  Matches `CombinationsFormulaOQ07.central_binom_eq_sum_sq`. -/
+theorem central_binom_eq_sum_sq (n : ℕ) :
+    (2 * n).choose n = ∑ i ∈ Finset.range (n + 1), (n.choose i) ^ 2 := by
+  have h := central_sum_sq_shift n 0 (Nat.zero_le n)
+  simp only [Nat.sub_zero, Nat.add_zero] at h
+  rw [h]
+  exact Finset.sum_congr rfl (fun i _ => (sq (n.choose i)).symm)
+
+/-- Sanity check: `C(5, 1) = 5` from the shift `r = 1` with `m = 2`, `n = 3`:
+    `∑_{i=0}^{2} C(2,i)·C(3,i+1) = 1·3 + 2·3 + 1·1 = 10`. -/
+example : (2 + 3).choose (3 - 1) = 10 := by
+  rw [sum_choose_mul_choose_shift 2 3 1 (by norm_num)]
+  decide
+
+/-- Sanity check: the diagonal `C(6, 3) = 20 = 1 + 9 + 9 + 1`. -/
+example : (2 * 3).choose 3 = 20 := by
+  rw [central_binom_eq_sum_sq 3]
+  decide
+
+end CombinationsFormulaOQ07OQ02

--- a/src/data/proofs/combinations-formula-oq-07-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-02/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "off-diagonal-context",
+    "proofId": "combinations-formula-oq-07-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "From the Diagonal to the Off-Diagonal of Vandermonde",
+    "content": "The parent entry reads the diagonal corner C(2n,n) = ∑ C(n,i)² off Vandermonde's convolution. This follow-up develops the off-diagonal companion: slide the second factor by a fixed shift r to obtain C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r). Setting r=0 gives the mixed product sum ∑ C(m,i)·C(n,i) = C(m+n,n) from Gould's tables, and setting m=n, r=0 returns the parent's sum of squares. The whole family is built from Mathlib's antidiagonal Vandermonde (Nat.add_choose_eq), which is the only single-sum convolution Mathlib ships.",
+    "mathContext": "$\\binom{m+n}{n-r} = \\sum_{i=0}^{n-r}\\binom{m}{i}\\binom{n}{i+r}$ for $r \\le n$. Combinatorially: to choose $n-r$ items from $m+n$ split into pools of $m$ and $n$, take $i$ from the first pool and the rest from the second; reindexing the second pool by the symmetry $\\binom{n}{(n-r)-i} = \\binom{n}{i+r}$ slides the count into the offset form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vandermonde's identity",
+      "off-diagonal convolution",
+      "sum of squares of binomial coefficients",
+      "Gould's combinatorial identities",
+      "double counting"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Vandermonde's convolution",
+      "binomial symmetry C(n,k) = C(n,n-k)"
+    ]
+  },
+  {
+    "id": "range-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 67
+    },
+    "type": "theorem",
+    "title": "Vandermonde's Convolution in Range Form",
+    "content": "add_choose_eq_sum_range restates Mathlib's antidiagonal Vandermonde Nat.add_choose_eq as the textbook single sum C(m+n,k) = ∑_{i=0}^{k} C(m,i)·C(n,k-i). The reindexing is a single rewrite by Finset.Nat.sum_antidiagonal_eq_sum_range_succ, which evaluates the antidiagonal pair (i,j) as (i, k-i) over i ∈ range (k+1). Re-derived here so the file stands alone.",
+    "mathContext": "Mathlib stores Vandermonde as a sum over $\\{(i,j) : i+j=k\\}$; the range form $\\sum_{i=0}^{k}$ with $j = k-i$ is the version used in generating-function manipulations and combinatorial tables.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.add_choose_eq",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+      "antidiagonal reindexing"
+    ],
+    "prerequisites": [
+      "Finset.antidiagonal",
+      "Vandermonde's convolution"
+    ]
+  },
+  {
+    "id": "off-diagonal-thm",
+    "proofId": "combinations-formula-oq-07-oq-02",
+    "range": {
+      "startLine": 74,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "The Off-Diagonal Convolution with No Vanishing Tail",
+    "content": "sum_choose_mul_choose_shift proves C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r) for r ≤ n. Instantiate the range form at k = n-r: each summand carries C(n, (n-r)-i). The design choice that makes the proof clean is the summation range itself — because 0 ≤ i ≤ n-r and r ≤ n, every index obeys i+r ≤ n, so (n-r)-i = n-(i+r) (omega) and Nat.choose_symm turns C(n, n-(i+r)) into C(n, i+r) for every term. No summand is zero, so unlike the usual textbook proof there is no tail to split off and discard.",
+    "mathContext": "The standard derivation sums over $i \\le n$ and argues the terms with $i+r>n$ vanish. Restricting the range to $i \\le n-r$ instead keeps all $\\binom{n}{i+r}$ nonzero candidates inside the symmetry window $i+r \\le n$, so $\\binom{n}{(n-r)-i} = \\binom{n}{i+r}$ is a pointwise rewrite applied under `Finset.sum_congr`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_symm",
+      "Finset.sum_congr",
+      "natural-number subtraction",
+      "omega"
+    ],
+    "prerequisites": [
+      "range form of Vandermonde",
+      "binomial symmetry C(n, n-k) = C(n, k)"
+    ]
+  },
+  {
+    "id": "corollaries-thm",
+    "proofId": "combinations-formula-oq-07-oq-02",
+    "range": {
+      "startLine": 85,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Mixed Product, Central Shift, and the Parent's Diagonal",
+    "content": "Three specializations. sum_choose_mul_choose (r=0): C(m+n, n) = ∑_{i=0}^{n} C(m,i)·C(n,i), Gould's mixed product sum, obtained by simp collapsing i+0 and n-0. central_sum_sq_shift (m=n): C(2n, n-r) = ∑_{i=0}^{n-r} C(n,i)·C(n,i+r). central_binom_eq_sum_sq (m=n, r=0): C(2n, n) = ∑_{i=0}^{n} C(n,i)², the parent's headline recovered, with sq folding C(n,i)·C(n,i). Numeric checks: C(5,2) = 10 from the shift r=1, and the diagonal C(6,3) = 20.",
+    "mathContext": "The lattice of special cases: shift $r$ and equality $m=n$ are independent knobs. $(m=n,r=0)$ is the diagonal sum of squares; $(r=0)$ alone is the mixed product sum; $(m=n)$ alone is the central shifted sum. Each is one `simp`/`rw` away from the two-parameter master identity.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares of binomial coefficients",
+      "central binomial coefficient",
+      "specialization",
+      "consistency with parent entry"
+    ],
+    "prerequisites": [
+      "off-diagonal convolution",
+      "C(2n,n) central binomial coefficient"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-02/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "combinations-formula-oq-07-oq-02",
+  "title": "The Off-Diagonal Vandermonde Convolution",
+  "slug": "combinations-formula-oq-07-oq-02",
+  "description": "Generalizes the parent's diagonal sum-of-squares C(2n,n) = ∑ C(n,i)² to the two-parameter off-diagonal convolution C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r) for r ≤ n. The summation range i ≤ n-r is chosen so that every term stays inside the symmetry window i+r ≤ n, letting C(n,(n-r)-i) = C(n,i+r) be applied uniformly with no vanishing tail to discard. The parent's diagonal identity, the mixed product sum C(m+n,n) = ∑ C(m,i)·C(n,i), and the central shifted sum all fall out as special cases (m=n and/or r=0).",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. The off-diagonal identity holds for all m, n and all shifts r ≤ n, and is fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "vandermonde",
+      "convolution",
+      "sum-of-squares",
+      "off-diagonal",
+      "double-counting"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "sum_choose_mul_choose_shift: the off-diagonal Vandermonde convolution C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r) for r ≤ n, a two-parameter generalization of the parent's diagonal sum of squares, absent from Mathlib",
+      "sum_choose_mul_choose: the mixed product sum C(m+n, n) = ∑_{i=0}^{n} C(m,i)·C(n,i) (Gould's tables), recovered as the r=0 case",
+      "central_sum_sq_shift: the central off-diagonal case C(2n, n-r) = ∑_{i=0}^{n-r} C(n,i)·C(n,i+r), m=n",
+      "central_binom_eq_sum_sq: the parent's diagonal C(2n,n) = ∑ C(n,i)² recovered as the m=n, r=0 corner, confirming consistency with combinations-formula-oq-07",
+      "add_choose_eq_sum_range: the range form of Vandermonde re-derived self-contained from Nat.add_choose_eq",
+      "Worked checks C(5,2) = 10 = ∑_{i=0}^{2} C(2,i)·C(3,i+1) (shift r=1) and the diagonal C(6,3) = 20"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_choose_eq",
+        "description": "Vandermonde's convolution in antidiagonal form: (m+n).choose k = ∑ p ∈ antidiagonal k, C(m,p.1)·C(n,p.2). The anchor the entire file rests on.",
+        "module": "Mathlib.Data.Nat.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+        "description": "Reindexes a sum over the antidiagonal of k as a sum over range (k+1) evaluating the pair as (i, k-i); turns the antidiagonal Vandermonde into the textbook single-sum range form.",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "C(n, n-i) = C(n, i) for i ≤ n. Applied to each summand: with the range chosen so i ≤ n-r, one has i+r ≤ n, so C(n, (n-r)-i) = C(n, n-(i+r)) = C(n, i+r) holds for every term with no zero tail.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ02.lean",
+    "namespace": "CombinationsFormulaOQ07OQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 118,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Vandermonde's convolution C(m+n,k) = ∑_{i} C(m,i)·C(n,k-i) is the additive backbone of binomial-coefficient combinatorics. Its diagonal corner C(2n,n) = ∑ C(n,i)² — the sum of squares across a row of Pascal's triangle — is the single most quoted special case. Less often stated, but equally elementary, is the off-diagonal family obtained by sliding the second factor: ∑ C(m,i)·C(n,i+r). The r=0 mixed form ∑ C(m,i)·C(n,i) = C(m+n,n) appears in Gould's standard tables of binomial identities (Combinatorial Identities, 1972) and counts intersecting selections from two disjoint pools; the shifted version measures the overlap when one selection is offset by r. None of these single-sum forms are in Mathlib, which provides only the antidiagonal convolution.",
+    "problemStatement": "Open Question OQ-07-OQ-02: the parent entry combinations-formula-oq-07 extracts the diagonal C(2n,n) = ∑ C(n,i)² from Vandermonde's convolution. What is the off-diagonal companion? Formalize the two-parameter identity C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r) for r ≤ n, and recover the parent's diagonal sum of squares as its central, unshifted corner.",
+    "proofStrategy": "Start from the range form of Vandermonde, C(m+n, k) = ∑_{i=0}^{k} C(m,i)·C(n,k-i), obtained from Mathlib's antidiagonal Nat.add_choose_eq via Finset.Nat.sum_antidiagonal_eq_sum_range_succ. Instantiate k = n-r. Each summand carries the factor C(n, (n-r)-i). The crucial design choice is the summation range: because i ranges over 0 ≤ i ≤ n-r and r ≤ n, every index satisfies i+r ≤ n, so the natural-subtraction identity (n-r)-i = n-(i+r) holds and Nat.choose_symm rewrites C(n, n-(i+r)) = C(n, i+r) for every single term — no summand is zero, so the sum needs no splitting. Specializing r=0 gives the mixed product sum; specializing m=n gives the central shifted sum; both together recover the parent's diagonal sum of squares (with sq folding C(n,i)·C(n,i) = C(n,i)²). Natural-subtraction bookkeeping is discharged by omega throughout.",
+    "keyInsights": [
+      "The off-diagonal convolution is a genuine two-parameter generalization of the parent's diagonal identity, not a restatement: the parent is exactly the m=n, r=0 corner.",
+      "Choosing the summation range to be i ≤ n-r (rather than i ≤ n) keeps every term inside the symmetry window i+r ≤ n, so C(n,(n-r)-i) = C(n,i+r) applies uniformly and the proof never has to discard a vanishing tail — the cleanest possible route.",
+      "The single natural-number fact (n-r)-i = n-(i+r), valid because i ≤ n-r and r ≤ n, is what lets the symmetry lemma fire; omega supplies it.",
+      "The mixed product sum ∑ C(m,i)·C(n,i) = C(m+n,n) (Gould) is just the unshifted r=0 slice, exposed by simp collapsing i+0 and n-0.",
+      "Reusing Mathlib's antidiagonal Vandermonde keeps the whole development to a handful of rewrites: no induction, no generating functions, no double sums."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Header stating OQ-07-OQ-02: the off-diagonal Vandermonde convolution as the two-parameter companion of the parent's diagonal sum of squares, with the range-choice insight that avoids any vanishing tail."
+    },
+    {
+      "id": "range-form",
+      "title": "Vandermonde's Convolution (Range Form)",
+      "startLine": 72,
+      "endLine": 78,
+      "summary": "add_choose_eq_sum_range: C(m+n,k) = ∑_{i=0}^{k} C(m,i)·C(n,k-i), re-derived self-contained by pushing Nat.add_choose_eq through Finset.Nat.sum_antidiagonal_eq_sum_range_succ."
+    },
+    {
+      "id": "off-diagonal",
+      "title": "Off-Diagonal Convolution",
+      "startLine": 80,
+      "endLine": 94,
+      "summary": "sum_choose_mul_choose_shift: C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r) for r ≤ n. Instantiates the range form at k=n-r and rewrites each term with Nat.choose_symm, using (n-r)-i = n-(i+r) (omega)."
+    },
+    {
+      "id": "corollaries",
+      "title": "Mixed Product and Central Cases",
+      "startLine": 96,
+      "endLine": 116,
+      "summary": "sum_choose_mul_choose (r=0 mixed sum C(m+n,n) = ∑ C(m,i)·C(n,i)), central_sum_sq_shift (m=n shifted), and central_binom_eq_sum_sq (m=n, r=0 recovers the parent's diagonal C(2n,n) = ∑ C(n,i)²), with numeric checks."
+    }
+  ],
+  "conclusion": {
+    "summary": "5 theorems, 0 sorries, 0 axioms. The off-diagonal Vandermonde convolution C(m+n, n-r) = ∑_{i=0}^{n-r} C(m,i)·C(n,i+r) (r ≤ n) generalizes the parent's diagonal sum of squares to two parameters. The mixed product sum, the central shifted sum, and the parent's C(2n,n) = ∑ C(n,i)² all follow as special cases, confirming consistency with combinations-formula-oq-07.",
+    "implications": "Supplies single-sum convolution forms (range, mixed-product, off-diagonal) that Mathlib lacks, packaged from its antidiagonal Vandermonde. The range-choice technique — summing only over the window where the symmetry lemma applies to every term — is a reusable pattern for binomial convolution identities that sidesteps the usual zero-tail case split.",
+    "openQuestions": [
+      "Does the off-diagonal sum admit a closed form when summed against an alternating sign, ∑ (-1)^i C(m,i)·C(n,i+r), and does it reduce (for m=n) to the signed central coefficient ±C(n, n/2)?",
+      "Can the off-diagonal convolution be lifted to the q-binomial (Gaussian) coefficients, where the q-Vandermonde identity replaces Nat.add_choose_eq?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "parent — extracts the diagonal C(2n,n) = ∑ C(n,i)² from Vandermonde; this entry generalizes that to the off-diagonal family"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "sibling — the multiplicative (subset-of-a-subset) companion of Vandermonde, where this entry develops the additive off-diagonal companion"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **combinations-formula-oq-07** (Vandermonde's convolution and the central sum of squares). The parent extracts the *diagonal* corner `C(2n,n) = ∑ C(n,i)²` from Vandermonde. This entry develops the **off-diagonal** companion — a genuine two-parameter generalization, not a restatement:

```
C(m + n, n − r) = ∑_{i=0}^{n−r} C(m,i)·C(n,i+r)        (r ≤ n)
```

The parent's sum of squares is exactly the `m = n`, `r = 0` corner.

## Key idea

The standard textbook proof sums over `i ≤ n` and argues the terms with `i+r > n` vanish. We instead restrict the range to `i ≤ n−r`, which keeps **every** term inside the symmetry window `i+r ≤ n`. Then `(n−r)−i = n−(i+r)` (omega) and `Nat.choose_symm` rewrites `C(n, (n−r)−i) = C(n, i+r)` pointwise under `Finset.sum_congr` — no zero tail to split off and discard.

## Theorems (5, 0 sorries, 0 axioms)

- `add_choose_eq_sum_range` — range form of Vandermonde, re-derived from `Nat.add_choose_eq`
- `sum_choose_mul_choose_shift` — the off-diagonal convolution (headline)
- `sum_choose_mul_choose` — `r=0` mixed product sum `C(m+n,n) = ∑ C(m,i)·C(n,i)` (Gould)
- `central_sum_sq_shift` — `m=n` central shifted sum
- `central_binom_eq_sum_sq` — `m=n, r=0` recovers the parent's `C(2n,n) = ∑ C(n,i)²`

Builds cleanly via `docker-build.sh Proofs.CombinationsFormulaOQ07OQ02`. Numeric checks use kernel `decide` (no `native_decide`). None of these single-sum convolution forms are in Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)