### PR TITLE
Research: erdos-ko-rado-oq-01 — Katona's cyclic-interval lemma, de-axiomatized (0-axiom verified)

### DIFF
--- a/proofs/Proofs/ErdosKoRadoOQ01.lean
+++ b/proofs/Proofs/ErdosKoRadoOQ01.lean
@@ -1,0 +1,244 @@
+import Mathlib
+
+/-
+# Erdős–Ko–Rado, OQ-01: the cyclic-interval lemma, de-axiomatized
+
+The parent gallery entry `ErdosKoRado` formalizes the Erdős–Ko–Rado theorem via
+Katona's cyclic-permutation argument. Its combinatorial heart — the statement that
+in any cyclic order of `n ≥ 2k` points, **at most `k` of the `n` cyclic intervals
+(arcs) of length `k` can be pairwise intersecting** — was left as an `axiom`:
+
+    axiom at_most_k_intersecting_cyclic_intervals (n k : ℕ) (hn : n ≥ 2 * k) (hk : 0 < k) :
+      ∀ (I : Finset ℕ), (∀ i ∈ I, i < n) →
+        (∀ i j, i ∈ I → j ∈ I → (cyclicInterval n k i ∩ cyclicInterval n k j).Nonempty) →
+        I.card ≤ k
+
+The sibling open question OQ-02 explicitly records that this lemma was "released
+unsolved" because "its modular bookkeeping resisted a Lean formalization", and
+side-stepped it by re-proving EKR through Mathlib's Kruskal–Katona shadow
+inequality. This file answers OQ-01 directly: it **proves that exact statement as
+a theorem, with zero axioms and no `native_decide`**, so the parent's axiom can be
+discharged.
+
+## The proof
+
+The arc starting at position `i` is `A_i = {i, i+1, …, i+k-1} mod n`. The argument
+is Katona's classic collapse-pairing:
+
+* Fix any arc `A_{i₀}` in the family. Every other arc `A_j` in the family intersects
+  it, which forces the circular offset `r(j) := (j - i₀) mod n` to lie in
+  `{0,…,k-1} ∪ {n-k+1,…,n-1}` (lemma `offset_range`).
+* Define `g(j) = r(j)` on the lower block and `g(j) = r(j) - (n-k)` on the upper
+  block, collapsing each pair `{s, s+(n-k)}` to one value in `{0,…,k-1}`.
+* `g` is injective on the family: a lower value `s` and an upper value `s+(n-k)`
+  index two arcs whose starts differ by **exactly** `k`, hence (as `n ≥ 2k`) those
+  arcs are disjoint — impossible in a pairwise-intersecting family
+  (lemma `not_intersect_mixed`). Within a single block, `g` is injective because the
+  offset map is (lemma `offset_inj`).
+* Therefore the family injects into `range k`, so it has at most `k` members.
+
+The definitions `cyclicInterval` is reproduced verbatim from the parent (which is
+`axiomatized`, so we avoid importing it). Self-contained: imports only Mathlib.
+-/
+
+namespace ErdosKoRadoOQ01
+
+open Finset
+
+/-- A cyclic interval starting at position `i` with length `k` in a cyclic order of
+`n` elements: the positions `{i, i+1, …, i+k-1} mod n`. (Verbatim from the parent
+`ErdosKoRado.lean`.) -/
+def cyclicInterval (n k i : ℕ) : Finset (Fin n) :=
+  if h : 0 < n then
+    (Finset.range k).image (fun j => ⟨(i + j) % n, Nat.mod_lt _ h⟩)
+  else ∅
+
+/-- Membership in a cyclic interval: `x` lies in `A_i` iff `x ≡ i + a (mod n)` for
+some offset `a < k`. -/
+lemma mem_cyclicInterval {n k i : ℕ} (hn : 0 < n) (x : Fin n) :
+    x ∈ cyclicInterval n k i ↔ ∃ a < k, (i + a) % n = (x : ℕ) := by
+  unfold cyclicInterval
+  rw [dif_pos hn, Finset.mem_image]
+  constructor
+  · rintro ⟨a, ha, hax⟩
+    refine ⟨a, Finset.mem_range.mp ha, ?_⟩
+    have := congrArg Fin.val hax
+    simpa using this
+  · rintro ⟨a, ha, hax⟩
+    refine ⟨a, Finset.mem_range.mpr ha, ?_⟩
+    apply Fin.ext
+    simpa using hax
+
+/-- Two cyclic intervals meet iff some offsets `a, b < k` give the same point. -/
+lemma inter_nonempty_iff {n k i j : ℕ} (hn : 0 < n) :
+    (cyclicInterval n k i ∩ cyclicInterval n k j).Nonempty ↔
+      ∃ a < k, ∃ b < k, (i + a) % n = (j + b) % n := by
+  constructor
+  · rintro ⟨x, hx⟩
+    rw [Finset.mem_inter] at hx
+    obtain ⟨a, ha, hax⟩ := (mem_cyclicInterval hn x).1 hx.1
+    obtain ⟨b, hb, hbx⟩ := (mem_cyclicInterval hn x).1 hx.2
+    exact ⟨a, ha, b, hb, by rw [hax, hbx]⟩
+  · rintro ⟨a, ha, b, hb, hab⟩
+    refine ⟨⟨(i + a) % n, Nat.mod_lt _ hn⟩, ?_⟩
+    rw [Finset.mem_inter]
+    constructor
+    · exact (mem_cyclicInterval hn _).2 ⟨a, ha, rfl⟩
+    · exact (mem_cyclicInterval hn _).2 ⟨b, hb, by rw [← hab]⟩
+
+/-- **Offset range.** If arc `A_j` meets arc `A_{i₀}`, then the circular offset
+`r(j) = (j + (n - i₀)) mod n` lies in the lower block `[0, k)` or the upper block
+`(n-k, n)`. -/
+lemma offset_range {n k i₀ j : ℕ} (hn : n ≥ 2 * k) (_hk : 0 < k) (hi₀ : i₀ < n)
+    (h : ∃ a < k, ∃ b < k, (i₀ + a) % n = (j + b) % n) :
+    (j + (n - i₀)) % n < k ∨ n - k < (j + (n - i₀)) % n := by
+  obtain ⟨a, ha, b, hb, hab⟩ := h
+  have hn0 : 0 < n := by omega
+  have hrjn : (j + (n - i₀)) % n < n := Nat.mod_lt _ hn0
+  -- `(j + (n-i₀)) + b ≡ a  [MOD n]`
+  have key : ((j + (n - i₀)) + b) % n = a := by
+    have hc : ((j + (n - i₀)) + b + i₀) % n = (a + i₀) % n := by
+      have hsum : j + (n - i₀) + b + i₀ = (j + b) + n := by omega
+      rw [hsum, Nat.add_mod_right, ← hab, Nat.add_comm i₀ a]
+    have hcancel : ((j + (n - i₀)) + b) % n = a % n :=
+      Nat.ModEq.add_right_cancel' i₀
+        (show ((j + (n - i₀)) + b + i₀) ≡ (a + i₀) [MOD n] from hc)
+    rw [hcancel, Nat.mod_eq_of_lt (show a < n by omega)]
+  -- fold the inner `% n`
+  have key2 : ((j + (n - i₀)) % n + b) % n = a := by rwa [Nat.mod_add_mod]
+  rcases Nat.lt_or_ge ((j + (n - i₀)) % n + b) n with hlt | hge
+  · rw [Nat.mod_eq_of_lt hlt] at key2
+    left; omega
+  · have hsub : ((j + (n - i₀)) % n + b) % n = (j + (n - i₀)) % n + b - n := by
+      rw [Nat.mod_eq_sub_mod hge, Nat.mod_eq_of_lt (by omega)]
+    rw [hsub] at key2
+    right; omega
+
+/-- **Offset injectivity.** The map `x ↦ (x + (n - i₀)) mod n` is injective on
+positions `< n`. -/
+lemma offset_inj {n i₀ p q : ℕ} (hp : p < n) (hq : q < n)
+    (h : (p + (n - i₀)) % n = (q + (n - i₀)) % n) : p = q := by
+  have hcancel : p % n = q % n :=
+    Nat.ModEq.add_right_cancel' (n - i₀)
+      (show (p + (n - i₀)) ≡ (q + (n - i₀)) [MOD n] from h)
+  rw [Nat.mod_eq_of_lt hp, Nat.mod_eq_of_lt hq] at hcancel
+  exact hcancel
+
+/-- **Disjointness of a collapsed pair.** If `r(p) = c` (lower block, `c < k`) and
+`r(q) = c + (n - k)` (upper block), the arcs `A_p` and `A_q` have starts differing
+by exactly `k`, so they are disjoint. -/
+lemma not_intersect_mixed {n k i₀ p q c : ℕ} (hn : n ≥ 2 * k) (_hk : 0 < k)
+    (hc : c < k) (hrp : (p + (n - i₀)) % n = c)
+    (hrq : (q + (n - i₀)) % n = c + (n - k)) :
+    ¬ (∃ a < k, ∃ b < k, (p + a) % n = (q + b) % n) := by
+  rintro ⟨a, ha, b, hb, hab⟩
+  -- `p ≡ q + k  [MOD n]`
+  have hpqk : p ≡ q + k [MOD n] := by
+    have step : ((q + (n - i₀)) + k) % n = c := by
+      rw [← Nat.mod_add_mod, hrq, show c + (n - k) + k = c + n by omega,
+          Nat.add_mod_right, Nat.mod_eq_of_lt (show c < n by omega)]
+    have e : (q + k + (n - i₀)) % n = (p + (n - i₀)) % n := by
+      rw [show q + k + (n - i₀) = (q + (n - i₀)) + k by ring, step, hrp]
+    exact (Nat.ModEq.add_right_cancel' (n - i₀)
+      (show (q + k + (n - i₀)) ≡ (p + (n - i₀)) [MOD n] from e)).symm
+  -- combine with the intersection equation
+  have hab' : (p + a) ≡ (q + b) [MOD n] := hab
+  have hcomb : (q + k) + a ≡ q + b [MOD n] := (hpqk.add_right a).symm.trans hab'
+  have hcomb2 : q + (k + a) ≡ q + b [MOD n] := by
+    have h0 : (q + k) + a = q + (k + a) := by ring
+    rwa [h0] at hcomb
+  have hka : (k + a) % n = b % n := Nat.ModEq.add_left_cancel' q hcomb2
+  rw [Nat.mod_eq_of_lt (show k + a < n by omega),
+      Nat.mod_eq_of_lt (show b < n by omega)] at hka
+  omega
+
+/-- The collapse map sending arc starts to their representative in `range k`. -/
+private def gmap (n k i₀ j : ℕ) : ℕ :=
+  if (j + (n - i₀)) % n < k then (j + (n - i₀)) % n else (j + (n - i₀)) % n - (n - k)
+
+/-- **Katona's cyclic-interval lemma (OQ-01).** In any cyclic order of `n ≥ 2k`
+points (`k > 0`), at most `k` of the `n` cyclic intervals of length `k` can be
+pairwise intersecting. This is exactly the parent's axiom
+`at_most_k_intersecting_cyclic_intervals`, now proved. -/
+theorem at_most_k_intersecting_cyclic_intervals (n k : ℕ) (hn : n ≥ 2 * k) (hk : 0 < k) :
+    ∀ (I : Finset ℕ), (∀ i ∈ I, i < n) →
+      (∀ i j, i ∈ I → j ∈ I → (cyclicInterval n k i ∩ cyclicInterval n k j).Nonempty) →
+      I.card ≤ k := by
+  intro I hI hinter
+  have hn0 : 0 < n := by omega
+  rcases I.eq_empty_or_nonempty with hE | hNE
+  · simp [hE]
+  obtain ⟨i₀, hi₀⟩ := hNE
+  have hi₀n : i₀ < n := hI i₀ hi₀
+  -- offset range fact for every member, via intersection with the anchor `i₀`
+  have hrange : ∀ j ∈ I, (j + (n - i₀)) % n < k ∨ n - k < (j + (n - i₀)) % n := by
+    intro j hj
+    have hInt := hinter i₀ j hi₀ hj
+    rw [inter_nonempty_iff hn0] at hInt
+    exact offset_range hn hk hi₀n hInt
+  rw [show k = (Finset.range k).card from (Finset.card_range k).symm]
+  apply Finset.card_le_card_of_injOn (gmap n k i₀)
+  · -- `gmap` lands in `range k`
+    intro j hj
+    rw [Finset.mem_coe] at hj
+    rw [Finset.mem_coe, Finset.mem_range]
+    simp only [gmap]
+    have hjmod : (j + (n - i₀)) % n < n := Nat.mod_lt _ hn0
+    rcases hrange j hj with h | h
+    · rw [if_pos h]; exact h
+    · have hnk : ¬ (j + (n - i₀)) % n < k := by omega
+      rw [if_neg hnk]; omega
+  · -- `gmap` is injective on `I`
+    intro p hp q hq hpq
+    rw [Finset.mem_coe] at hp hq
+    have hpn : p < n := hI p hp
+    have hqn : q < n := hI q hq
+    have hrp := hrange p hp
+    have hrq := hrange q hq
+    simp only [gmap] at hpq
+    by_cases hcp : (p + (n - i₀)) % n < k <;> by_cases hcq : (q + (n - i₀)) % n < k
+    · -- both lower
+      rw [if_pos hcp, if_pos hcq] at hpq
+      exact offset_inj hpn hqn hpq
+    · -- p lower, q upper
+      exfalso
+      rw [if_pos hcp, if_neg hcq] at hpq
+      have hrqval : n - k < (q + (n - i₀)) % n := hrq.resolve_left hcq
+      have hrqeq : (q + (n - i₀)) % n = (p + (n - i₀)) % n + (n - k) := by omega
+      have hInt := hinter p q hp hq
+      rw [inter_nonempty_iff hn0] at hInt
+      exact not_intersect_mixed (c := (p + (n - i₀)) % n) hn hk hcp rfl hrqeq hInt
+    · -- p upper, q lower
+      exfalso
+      rw [if_neg hcp, if_pos hcq] at hpq
+      have hrpval : n - k < (p + (n - i₀)) % n := hrp.resolve_left hcp
+      have hrpeq : (p + (n - i₀)) % n = (q + (n - i₀)) % n + (n - k) := by omega
+      have hInt := hinter q p hq hp
+      rw [inter_nonempty_iff hn0] at hInt
+      exact not_intersect_mixed (c := (q + (n - i₀)) % n) hn hk hcq rfl hrpeq hInt
+    · -- both upper
+      rw [if_neg hcp, if_neg hcq] at hpq
+      have hrpval : n - k < (p + (n - i₀)) % n := hrp.resolve_left hcp
+      have hrqval : n - k < (q + (n - i₀)) % n := hrq.resolve_left hcq
+      have heq : (p + (n - i₀)) % n = (q + (n - i₀)) % n := by omega
+      exact offset_inj hpn hqn heq
+
+/-- The bound is achieved: the `k` arcs anchored at a common point (sharing position
+`0`) form a pairwise-intersecting family of starting positions `{0, n-1, …, n-k+1}`,
+witnessing that `k` cannot be improved. Here we record the simplest instance: a
+single arc is a pairwise-intersecting family, so the bound is nonvacuous. -/
+theorem singleton_family_bound (n k : ℕ) (hn : n ≥ 2 * k) (hk : 0 < k) (i : ℕ) (hi : i < n) :
+    ({i} : Finset ℕ).card ≤ k := by
+  apply at_most_k_intersecting_cyclic_intervals n k hn hk
+  · intro x hx; rw [Finset.mem_singleton] at hx; omega
+  · intro x y hx hy
+    rw [Finset.mem_singleton] at hx hy
+    subst hx; subst hy
+    have hn0 : 0 < n := by omega
+    rw [inter_nonempty_iff hn0]
+    exact ⟨0, hk, 0, hk, rfl⟩
+
+#check @at_most_k_intersecting_cyclic_intervals
+#print axioms at_most_k_intersecting_cyclic_intervals
+
+end ErdosKoRadoOQ01

--- a/src/data/proofs/erdos-ko-rado-oq-01/annotations.json
+++ b/src/data/proofs/erdos-ko-rado-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-arc-calculus",
+    "proofId": "erdos-ko-rado-oq-01",
+    "range": {
+      "startLine": 58,
+      "endLine": 90
+    },
+    "type": "concept",
+    "title": "Turning Arcs into Modular Equations",
+    "content": "The parent defines an arc A_i as the image of {0,…,k-1} under j ↦ (i+j) mod n. mem_cyclicInterval rephrases membership as a modular equation: x ∈ A_i iff x ≡ i+a (mod n) for some offset a < k. inter_nonempty_iff then says two arcs meet iff some offsets a,b < k satisfy (i+a) ≡ (j+b) (mod n). This calculus is what makes the rest of the proof a matter of Nat.ModEq bookkeeping rather than reasoning about Finset images directly — and it is precisely the step that was missing when the lemma 'resisted formalization'."
+  },
+  {
+    "id": "ann-offset-range",
+    "proofId": "erdos-ko-rado-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 117
+    },
+    "type": "insight",
+    "title": "Why Intersecting Arcs Cluster Near the Anchor",
+    "content": "Fix one arc A_{i₀} of the family. Any other member A_j meets it, so by inter_nonempty_iff there are offsets a,b < k with (i₀+a) ≡ (j+b) (mod n). Rearranging gives the circular offset r(j) = (j + (n−i₀)) mod n congruent to a−b. Since a,b < k, this offset is squeezed into the lower block [0,k) (when a ≥ b) or the upper block (n−k,n) (when a < b, wrapping around). The proof makes this precise by reducing to whether r(j)+b overflows n, closed by omega. This two-block constraint is exactly what lets the collapse map target a k-element set."
+  },
+  {
+    "id": "ann-disjointness",
+    "proofId": "erdos-ko-rado-oq-01",
+    "range": {
+      "startLine": 119,
+      "endLine": 154
+    },
+    "type": "insight",
+    "title": "The Pairing: Offsets k Apart Are Disjoint",
+    "content": "The k−1 pairs {s, s+(n−k)} (lower offset s, upper offset s+(n−k)) are the crux. not_intersect_mixed shows that two arcs with these paired offsets have starting positions differing by exactly k, so an overlap would force k + a ≡ b (mod n) with a,b < k. But k + a < 2k ≤ n, so the congruence collapses to the literal equation k + a = b — impossible since b < k. Hence the arcs are disjoint, and a pairwise-intersecting family can contain at most one arc from each pair. This is the only place the hypotheses 'pairwise intersecting' and n ≥ 2k are used. offset_inj handles the easy within-block injectivity."
+  },
+  {
+    "id": "ann-main",
+    "proofId": "erdos-ko-rado-oq-01",
+    "range": {
+      "startLine": 163,
+      "endLine": 228
+    },
+    "type": "insight",
+    "title": "Katona's Pairing as an Injection into range k",
+    "content": "The collapse map g(j) = r(j) on the lower block and r(j) − (n−k) on the upper block sends the whole family injectively into {0,…,k−1}. offset_range guarantees it lands in range k; the three-case injectivity argument (lower/lower and upper/upper via offset_inj, lower/upper via not_intersect_mixed) guarantees it is injective. Finset.card_le_card_of_injOn then yields |I| ≤ |range k| = k. This is Katona's textbook pairing argument rendered as an explicit injection — the combinatorial heart of his Erdős–Ko–Rado proof, now machine-checked with zero axioms."
+  }
+]

--- a/src/data/proofs/erdos-ko-rado-oq-01/meta.json
+++ b/src/data/proofs/erdos-ko-rado-oq-01/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "erdos-ko-rado-oq-01",
+  "title": "Katona's Cyclic-Interval Lemma, De-Axiomatized",
+  "slug": "erdos-ko-rado-oq-01",
+  "description": "Proves the combinatorial heart of Katona's proof of Erdős–Ko–Rado — that in any cyclic order of n ≥ 2k points, at most k of the n cyclic intervals (arcs) of length k can be pairwise intersecting — which the parent gallery entry leaves as the axiom 'at_most_k_intersecting_cyclic_intervals' and the sibling OQ-02 explicitly recorded as 'released unsolved' because its modular bookkeeping resisted Lean. This entry proves that exact statement with zero axioms and no native_decide, via Katona's collapse-pairing injection: every arc meeting the anchor has circular offset in [0,k) ∪ (n−k,n); collapsing each disjoint pair {s, s+(n−k)} to one representative injects the family into range k, capping it at k.",
+  "meta": {
+    "author": "Katona (1972); formalized in Lean 4",
+    "date": "1972",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosKoRadoOQ01.lean",
+    "tags": [
+      "combinatorics",
+      "erdos",
+      "extremal-set-theory",
+      "intersecting-families",
+      "katona",
+      "cyclic-intervals",
+      "erdos-ko-rado"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 244,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "originalContributions": [
+      "at_most_k_intersecting_cyclic_intervals: the parent's axiomatized cyclic-interval lemma, now a ZERO-axiom theorem — in any cyclic order of n ≥ 2k points (k > 0), at most k of the n length-k arcs are pairwise intersecting. This is the combinatorial core of Katona's proof and the sibling OQ-02 documented it as released unsolved because the modular bookkeeping resisted formalization.",
+      "offset_range: if arc A_j meets the anchor arc A_{i₀}, the circular offset r(j) = (j + (n−i₀)) mod n is forced into the lower block [0,k) or the upper block (n−k,n) — the constraint that makes the collapse map land in range k.",
+      "not_intersect_mixed: the disjointness lemma at the heart of the pairing — if two arcs have offsets r(p)=c (lower) and r(q)=c+(n−k) (upper), their starts differ by exactly k, so (as n ≥ 2k) they are disjoint and cannot both lie in a pairwise-intersecting family.",
+      "offset_inj: the offset map x ↦ (x + (n−i₀)) mod n is injective on positions < n, handling the within-block injectivity of the collapse map.",
+      "mem_cyclicInterval / inter_nonempty_iff: a usable membership and intersection calculus for the parent's bespoke 'cyclicInterval' definition — x ∈ A_i iff x ≡ i+a (mod n) for some a < k, and A_i ∩ A_j ≠ ∅ iff some offsets a,b < k coincide mod n."
+    ],
+    "prerequisites": [
+      "Katona's cyclic-permutation proof of Erdős–Ko–Rado and its key lemma on pairwise-intersecting arcs",
+      "Modular arithmetic on ℕ via Nat.ModEq (cancellation, add_right/left_cancel')",
+      "Finset cardinality bounds through injections (Finset.card_le_card_of_injOn)",
+      "The condition n ≥ 2k: it makes two arcs whose starts differ by exactly k genuinely disjoint"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "If f maps s into t and is injective on s, then |s| ≤ |t| — the engine turning the collapse injection into the cardinality bound |I| ≤ |range k| = k.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Nat.ModEq.add_right_cancel'",
+        "description": "Cancellation a + c ≡ b + c [MOD n] → a ≡ b [MOD n] — used to strip the anchor offset (n−i₀) and to derive the exact-k offset difference between collapsed arcs.",
+        "module": "Mathlib.Data.Nat.ModCast"
+      },
+      {
+        "theorem": "Nat.mod_add_mod",
+        "description": "(a % n + b) % n = (a + b) % n — folds the inner reduction when relating r(j) = (j+(n−i₀)) mod n to the intersection equation.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Katona's 1972 proof of Erdős–Ko–Rado, featured in 'Proofs from THE BOOK', is celebrated for its brevity: arrange the n points on a circle and double-count pairs (S, σ) of a family member S and a cyclic order σ in which S appears as an arc. The whole argument hinges on one finite combinatorial fact — in a single cyclic order, among the n arcs of length k, at most k can pairwise intersect. On paper this is a one-paragraph pairing argument; in Lean it requires careful modular arithmetic on arc starting positions, and the parent gallery entry consequently left it as an axiom. The sibling open question OQ-02, which discharged the EKR upper bound by the unrelated Kruskal–Katona route, explicitly noted that this cyclic-interval lemma had been 'released unsolved' because its modular bookkeeping resisted formalization. This entry supplies that missing proof.",
+    "problemStatement": "**Open Question (parent erdos-ko-rado, OQ-01)**: prove at_most_k_intersecting_cyclic_intervals — in any cyclic order of n ≥ 2k points (k > 0), at most k of the n cyclic intervals of length k can be pairwise intersecting — which the parent entry axiomatizes as the core of Katona's double count.\n\n**This entry**: proves that exact statement (same signature) with zero axioms and no native_decide.",
+    "text": "A 244-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. It reproduces the parent's 'cyclicInterval' definition verbatim (the parent is axiomatized, so importing it would import its nine axioms), builds a membership/intersection calculus for arcs, and proves the lemma by Katona's collapse-pairing injection into range k.",
+    "proofStrategy": "Fix any arc A_{i₀} in the family (the family is nonempty or the bound is trivial). For each member j, intersection with A_{i₀} forces the circular offset r(j) = (j + (n−i₀)) mod n into the lower block [0,k) or the upper block (n−k,n) — this is offset_range, proved by turning the intersection equation (i₀+a) ≡ (j+b) [MOD n] into r(j) ≡ a−b and case-splitting on whether r(j)+b overflows n. Define the collapse map g(j) = r(j) on the lower block and g(j) = r(j) − (n−k) on the upper block, sending the family into range k. Injectivity of g splits into three cases: within a single block it reduces to injectivity of the offset map (offset_inj); across blocks, a lower value c and an upper value c+(n−k) would index two arcs whose starts differ by exactly k, which not_intersect_mixed shows are disjoint (k + a ≡ b [MOD n] with a,b < k and k+a < n ≤ forces k+a = b, impossible) — contradicting the pairwise-intersecting hypothesis. Finset.card_le_card_of_injOn then gives |I| ≤ |range k| = k.",
+    "keyInsights": [
+      "The whole lemma is an injection into a k-element set: collapse each disjoint pair of offsets {s, s+(n−k)} (s = 1,…,k−1) to one representative, leaving the lower block [0,k) as the target.",
+      "'Pairwise intersecting' enters in exactly one place — the across-block case of injectivity — where it rules out two arcs whose starts differ by precisely k. This is the only step that needs n ≥ 2k.",
+      "The modular bookkeeping that 'resisted formalization' is tamed by working with one fixed offset r(j) = (j + (n−i₀)) mod n and reducing every claim to Nat.ModEq cancellation plus an omega case-split on whether a sum overflows n.",
+      "Two arcs with starts differing by k are disjoint because an overlap would give k + a ≡ b (mod n) with offsets a, b < k, yet k + a < 2k ≤ n forces the literal equation k + a = b — contradicting b < k.",
+      "Restating the parent's bespoke 'cyclicInterval' as a clean membership/intersection iff (mem_cyclicInterval, inter_nonempty_iff) is what makes the modular arguments tractable."
+    ]
+  },
+  "sections": [
+    {
+      "id": "arc-calculus",
+      "title": "A Membership Calculus for Arcs",
+      "startLine": 47,
+      "endLine": 90,
+      "summary": "mem_cyclicInterval and inter_nonempty_iff give x ∈ A_i ⇔ x ≡ i+a (mod n) for some a < k, and A_i ∩ A_j ≠ ∅ ⇔ some offsets a,b < k coincide mod n.",
+      "mathContext": "Turning the parent's image-based arc definition into a modular-equation calculus."
+    },
+    {
+      "id": "offset-range",
+      "title": "Offsets of Intersecting Arcs",
+      "startLine": 92,
+      "endLine": 117,
+      "summary": "offset_range: meeting the anchor forces the circular offset r(j) into the lower block [0,k) or upper block (n−k,n).",
+      "mathContext": "The constraint that makes the collapse map land in range k."
+    },
+    {
+      "id": "disjointness",
+      "title": "Collapsed Pairs Are Disjoint",
+      "startLine": 119,
+      "endLine": 154,
+      "summary": "offset_inj (offset map injective) and not_intersect_mixed (arcs with starts differing by exactly k are disjoint) supply the two halves of injectivity.",
+      "mathContext": "Where 'pairwise intersecting' and n ≥ 2k are used."
+    },
+    {
+      "id": "main",
+      "title": "The Collapse-Pairing Injection",
+      "startLine": 156,
+      "endLine": 244,
+      "summary": "at_most_k_intersecting_cyclic_intervals: the collapse map injects the family into range k, so |I| ≤ k; singleton_family_bound records nonvacuousness.",
+      "mathContext": "Katona's pairing as an explicit injection, capping the family at k."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves at_most_k_intersecting_cyclic_intervals — the cyclic-interval lemma at the heart of Katona's proof of Erdős–Ko–Rado, axiomatized in the parent and explicitly 'released unsolved' by the sibling OQ-02 — as a zero-axiom theorem with no native_decide, via Katona's collapse-pairing injection into range k.",
+    "implications": "Together with the sibling OQ-02 (which discharged the EKR upper bound via Kruskal–Katona), the two combinatorial axioms at the core of the parent's Katona formalization are now both proved by independent routes: OQ-01 supplies Katona's own cyclic-interval lemma directly, OQ-02 the resulting bound. The piece that 'resisted formalization' is now machine-checked.",
+    "openQuestions": [
+      "Complete Katona's double count (double_counting_bound) in the parent by combining this cyclic-interval lemma with set-appearance counting, giving a fully native Lean rendering of Katona's argument (rather than routing through Kruskal–Katona as OQ-02 does).",
+      "Characterize the extremal cyclic families: which pairwise-intersecting arc families attain exactly k members (the cyclic analogue of the star)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-ko-rado",
+      "relationship": "extends",
+      "description": "Parent entry: formalizes EKR via Katona's cyclic proof but axiomatizes the cyclic-interval lemma (at_most_k_intersecting_cyclic_intervals). This entry discharges that axiom with zero axioms."
+    },
+    {
+      "targetId": "erdos-ko-rado-oq-02",
+      "relationship": "complements",
+      "description": "Sibling entry: discharged the EKR upper bound (double_counting_bound) via Kruskal–Katona and recorded this cyclic-interval lemma as released unsolved. This entry supplies the missing lemma directly."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosKoRadoOQ01",
+    "lineCount": 244,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "mainTheorems": [
+      {
+        "name": "at_most_k_intersecting_cyclic_intervals",
+        "type": "core",
+        "description": "Katona's cyclic-interval lemma: in any cyclic order of n ≥ 2k points (k > 0), at most k of the n length-k arcs are pairwise intersecting. Zero axioms, no native_decide — the parent's axiom, now proved.",
+        "leanType": "(n k : ℕ) → n ≥ 2 * k → 0 < k → ∀ (I : Finset ℕ), (∀ i ∈ I, i < n) → (∀ i j, i ∈ I → j ∈ I → (cyclicInterval n k i ∩ cyclicInterval n k j).Nonempty) → I.card ≤ k"
+      },
+      {
+        "name": "not_intersect_mixed",
+        "type": "key",
+        "description": "Two arcs whose starting offsets are c (lower block) and c+(n−k) (upper block) have starts differing by exactly k, hence are disjoint when n ≥ 2k.",
+        "leanType": "{n k i₀ p q c : ℕ} → n ≥ 2 * k → 0 < k → c < k → (p + (n - i₀)) % n = c → (q + (n - i₀)) % n = c + (n - k) → ¬ (∃ a < k, ∃ b < k, (p + a) % n = (q + b) % n)"
+      },
+      {
+        "name": "offset_range",
+        "type": "key",
+        "description": "If arc A_j meets the anchor A_{i₀}, its circular offset lies in the lower block [0,k) or the upper block (n−k,n).",
+        "leanType": "{n k i₀ j : ℕ} → n ≥ 2 * k → 0 < k → i₀ < n → (∃ a < k, ∃ b < k, (i₀ + a) % n = (j + b) % n) → (j + (n - i₀)) % n < k ∨ n - k < (j + (n - i₀)) % n"
+      }
+    ],
+    "path": "Proofs/ErdosKoRadoOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "at_most_k_intersecting_cyclic_intervals",
+      "type": "core",
+      "description": "Zero-axiom proof of Katona's cyclic-interval lemma (the parent's axiom): at most k of the n length-k arcs in an n ≥ 2k cycle are pairwise intersecting.",
+      "leanType": "(n k : ℕ) → n ≥ 2 * k → 0 < k → ∀ (I : Finset ℕ), (∀ i ∈ I, i < n) → (∀ i j, i ∈ I → j ∈ I → (cyclicInterval n k i ∩ cyclicInterval n k j).Nonempty) → I.card ≤ k"
+    },
+    {
+      "name": "offset_range",
+      "type": "key",
+      "description": "Meeting the anchor arc forces the circular offset into the lower or upper block.",
+      "leanType": "{n k i₀ j : ℕ} → n ≥ 2 * k → 0 < k → i₀ < n → (∃ a < k, ∃ b < k, (i₀ + a) % n = (j + b) % n) → (j + (n - i₀)) % n < k ∨ n - k < (j + (n - i₀)) % n"
+    },
+    {
+      "name": "not_intersect_mixed",
+      "type": "key",
+      "description": "Arcs whose offsets differ by exactly n−k (starts differing by k) are disjoint when n ≥ 2k.",
+      "leanType": "{n k i₀ p q c : ℕ} → n ≥ 2 * k → 0 < k → c < k → (p + (n - i₀)) % n = c → (q + (n - i₀)) % n = c + (n - k) → ¬ (∃ a < k, ∃ b < k, (p + a) % n = (q + b) % n)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Katona, Gyula O. H.",
+      "title": "A simple proof of the Erdős–Chao Ko–Rado theorem",
+      "year": "1972",
+      "venue": "Journal of Combinatorial Theory, Series B 13(2), 183–184",
+      "note": "The cyclic-permutation proof; this entry formalizes its key cyclic-interval lemma"
+    },
+    {
+      "authors": "Erdős, Paul; Ko, Chao; Rado, Richard",
+      "title": "Intersection theorems for systems of finite sets",
+      "year": "1961",
+      "venue": "Quarterly Journal of Mathematics 12(1), 313–320",
+      "note": "The original Erdős–Ko–Rado theorem"
+    },
+    {
+      "authors": "Aigner, Martin; Ziegler, Günter M.",
+      "title": "Proofs from THE BOOK",
+      "year": "2018",
+      "venue": "Springer (6th ed.)",
+      "note": "Presents Katona's cyclic proof, including the pairing argument formalized here"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/erdos-ko-rado-oq-01.json
+++ b/src/data/research/problems/erdos-ko-rado-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-ko-rado-oq-01",
   "title": "Erdős-Ko-Rado OQ-01: Prove `at_most_k_intersecting_cyclic_intervals` Bound",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -29,11 +29,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): Proved the parent axiom at_most_k_intersecting_cyclic_intervals — Katona key lemma — as a 0-axiom theorem (no native_decide), depends only on propext/Classical.choice/Quot.sound. File Proofs/ErdosKoRadoOQ01.lean (244L, 6 thm, 2 def). Method: collapse-pairing injection into range k. Helpers: mem_cyclicInterval/inter_nonempty_iff (arc membership/intersection as Nat.ModEq); offset_range (intersecting arcs have offset in [0,k)∪(n-k,n)); not_intersect_mixed (arcs with offsets c and c+(n-k) differ by exactly k → disjoint when n≥2k); offset_inj (offset map injective). Finset.card_le_card_of_injOn closes |I|≤|range k|=k. Sibling OQ-02 had recorded this as released-unsolved (modular bookkeeping resisted formalization).",
     "builtItems": [],
     "insights": [],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Complete double_counting_bound in parent natively (combine this lemma with set-appearance counting)",
+      "Characterize extremal cyclic families attaining exactly k"
+    ],
     "markdown": "# Knowledge Base: erdos-ko-rado-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [],
@@ -46,7 +49,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T15:38:25.652Z",
-  "lastUpdate": "2026-04-03T15:38:25.667Z",
+  "lastUpdate": "2026-06-22",
   "leanFiles": [
     {
       "path": "Proofs/ErdosKoRado.lean",


### PR DESCRIPTION
## Summary

Proves the parent `ErdosKoRado` axiom **`at_most_k_intersecting_cyclic_intervals`** — the combinatorial heart of Katona's proof of Erdős–Ko–Rado:

> In any cyclic order of `n ≥ 2k` points (`k > 0`), at most `k` of the `n` cyclic intervals (arcs) of length `k` can be pairwise intersecting.

The sibling OQ-02 (#27531) discharged the EKR *upper bound* via Kruskal–Katona but explicitly recorded this cyclic-interval lemma as **"released unsolved"** because "its modular bookkeeping resisted a Lean formalization." This entry supplies the missing proof directly, matching the parent axiom's exact signature.

## Proof (Katona's collapse-pairing injection)

Fix any arc `A_{i₀}` in the family. Every member's circular offset `r(j) = (j + (n−i₀)) mod n` is forced into the lower block `[0,k)` or upper block `(n−k,n)`. The collapse map `g(j) = r(j)` (lower) / `r(j)−(n−k)` (upper) injects the family into `range k`:

- **`mem_cyclicInterval` / `inter_nonempty_iff`** — arc membership and intersection as `Nat.ModEq` equations over offsets `a,b < k`.
- **`offset_range`** — meeting the anchor forces the offset into the two blocks.
- **`not_intersect_mixed`** — two arcs with offsets `c` and `c+(n−k)` have starts differing by *exactly* `k`, hence are disjoint when `n ≥ 2k` (an overlap would force `k+a = b` with `a,b < k`). This is the only place `pairwise-intersecting` and `n ≥ 2k` are used.
- **`offset_inj`** — the offset map is injective on positions `< n`.
- **`Finset.card_le_card_of_injOn`** closes `|I| ≤ |range k| = k`.

## Files
- `proofs/Proofs/ErdosKoRadoOQ01.lean` (244 lines, 6 theorems, 2 defs)
- `src/data/proofs/erdos-ko-rado-oq-01/{meta.json,annotations.json}`
- `src/data/research/problems/erdos-ko-rado-oq-01.json` (knowledge update)

## Verification
- **0 sorries, 0 `axiom` declarations, no `native_decide`**
- `#print axioms at_most_k_intersecting_cyclic_intervals` → `[propext, Classical.choice, Quot.sound]` (standard foundational axioms only)
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.ErdosKoRadoOQ01`

## Status
**Outcome**: completed (axiom elimination)
**Next**: complete the parent's `double_counting_bound` natively by combining this lemma with set-appearance counting.

🤖 Generated by researcher-9