### PR TITLE
research(combinations-formula-oq-07-oq-03): the weighted sum of squares 2·∑ k·C(n,k)² = n·C(2n,n)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -709,6 +709,7 @@ import Proofs.CombinationsFormulaOQ06
 import Proofs.CombinationsFormulaOQ07
 import Proofs.CombinationsFormulaOQ07OQ01
 import Proofs.CombinationsFormulaOQ07OQ02
+import Proofs.CombinationsFormulaOQ07OQ03
 import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09
 import Proofs.CompactnessFiniteSubcover

--- a/proofs/Proofs/CombinationsFormulaOQ07OQ03.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ03.lean
@@ -1,0 +1,137 @@
+import Mathlib
+import Proofs.CombinationsFormulaOQ07
+
+/-
+# The Weighted Sum of Squares of Binomial Coefficients
+
+## Open Question OQ-07-OQ-03
+
+The central identity of OQ-07 sums the *squares* of a Pascal row:
+
+  C(2n, n) = ∑_{k=0}^{n} C(n, k)² .
+
+This file weights that sum by `k`.  The result is the elegant closed form
+
+  2 · ∑_{k=0}^{n} k · C(n, k)² = n · C(2n, n),                     (★)
+
+equivalently, for `n ≥ 1`,
+
+  ∑_{k=0}^{n} k · C(n, k)² = n · C(2n − 1, n − 1).
+
+Mathlib provides the unweighted row sum (`Nat.sum_range_choose`), the
+alternating row sum (`Nat.alternating_sum_range_choose`), and Vandermonde's
+convolution (`Nat.add_choose_eq`), but **not** this first-moment identity.
+
+## The reflection proof
+
+The proof of (★) needs no induction, no generating functions, and no
+factorial bookkeeping — only the reflection symmetry `k ↦ n − k`.  Writing
+`S = ∑_{k} k · C(n, k)²`, the substitution `k ↦ n − k` together with the
+symmetry `C(n, n − k) = C(n, k)` gives
+
+  S = ∑_{k} (n − k) · C(n, k)² .
+
+Adding the two expressions for `S` collapses the weight to a constant:
+
+  2S = ∑_{k} (k + (n − k)) · C(n, k)² = n · ∑_{k} C(n, k)² = n · C(2n, n),
+
+the last step being exactly the parent identity `central_binom_eq_sum_sq`.
+
+## Mathematical Context
+
+Reading `C(n, k)² / C(2n, n)` as a probability distribution on `{0, …, n}`
+(the hypergeometric distribution arising from the Vandermonde split of a
+`2n`-set into two halves), identity (★) says its **mean is `n / 2`** — the
+distribution is symmetric about its centre.  The same reflection argument that
+proves (★) is the combinatorial reason for that symmetry.
+
+## Results
+
+1. `sum_weighted_sq_reflect` — the reflection symmetry
+   `∑ k · C(n, k)² = ∑ (n − k) · C(n, k)²`, the conceptual core.
+2. `two_mul_sum_weighted_sq` — the closed form `2 · ∑ k · C(n,k)² = n · C(2n, n)`.
+3. `central_binom_two_mul_pred` — the halving `C(2n, n) = 2 · C(2n−1, n−1)`
+   (for `n ≥ 1`), the bridge to the classical statement.
+4. `sum_weighted_sq` — the classical form `∑ k · C(n,k)² = n · C(2n−1, n−1)`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ03
+
+open Finset
+
+/-- **Reflection symmetry.** Substituting `k ↦ n − k` and using
+    `C(n, n − k) = C(n, k)` shows the `k`-weighted and `(n−k)`-weighted sums of
+    squares agree. This is the heart of the closed form below. -/
+theorem sum_weighted_sq_reflect (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * (n.choose k) ^ 2
+      = ∑ k ∈ range (n + 1), (n - k) * (n.choose k) ^ 2 := by
+  rw [← Finset.sum_range_reflect (fun k => (n - k) * (n.choose k) ^ 2) (n + 1)]
+  refine Finset.sum_congr rfl (fun i hi => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hi
+  have h1 : n + 1 - 1 - i = n - i := by omega
+  rw [h1, Nat.choose_symm hi]
+  congr 1
+  omega
+
+/-- **Weighted central binomial sum of squares.**
+    `2 · ∑_{k=0}^{n} k · C(n, k)² = n · C(2n, n)`.
+    The factor of `2` packages the reflection symmetry and keeps the statement
+    free of natural-number subtraction. -/
+theorem two_mul_sum_weighted_sq (n : ℕ) :
+    2 * ∑ k ∈ range (n + 1), k * (n.choose k) ^ 2 = n * (2 * n).choose n := by
+  have key : ∀ k ∈ range (n + 1),
+      k * (n.choose k) ^ 2 + (n - k) * (n.choose k) ^ 2 = n * (n.choose k) ^ 2 := by
+    intro k hk
+    rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+    rw [← Nat.add_mul]
+    congr 1
+    omega
+  calc 2 * ∑ k ∈ range (n + 1), k * (n.choose k) ^ 2
+      = (∑ k ∈ range (n + 1), k * (n.choose k) ^ 2)
+          + ∑ k ∈ range (n + 1), k * (n.choose k) ^ 2 := by rw [two_mul]
+    _ = (∑ k ∈ range (n + 1), k * (n.choose k) ^ 2)
+          + ∑ k ∈ range (n + 1), (n - k) * (n.choose k) ^ 2 := by
+          rw [← sum_weighted_sq_reflect]
+    _ = ∑ k ∈ range (n + 1),
+          (k * (n.choose k) ^ 2 + (n - k) * (n.choose k) ^ 2) := by
+          rw [← Finset.sum_add_distrib]
+    _ = ∑ k ∈ range (n + 1), n * (n.choose k) ^ 2 := Finset.sum_congr rfl key
+    _ = n * ∑ k ∈ range (n + 1), (n.choose k) ^ 2 := by rw [Finset.mul_sum]
+    _ = n * (2 * n).choose n := by
+          rw [← CombinationsFormulaOQ07.central_binom_eq_sum_sq]
+
+/-- **Halving the central binomial coefficient.** For `n ≥ 1`,
+    `C(2n, n) = 2 · C(2n − 1, n − 1)`, since Pascal's rule splits `C(2n, n)`
+    into two symmetric halves `C(2n−1, n−1) = C(2n−1, n)`. -/
+theorem central_binom_two_mul_pred (n : ℕ) (hn : 1 ≤ n) :
+    (2 * n).choose n = 2 * (2 * n - 1).choose (n - 1) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  have e1 : 2 * (m + 1) = (2 * m + 1) + 1 := by ring
+  have e2 : 2 * (m + 1) - 1 = 2 * m + 1 := by omega
+  have e3 : m + 1 - 1 = m := by omega
+  have hsymm : (2 * m + 1).choose (m + 1) = (2 * m + 1).choose m := by
+    have h := Nat.choose_symm (show m ≤ 2 * m + 1 by omega)
+    rwa [show 2 * m + 1 - m = m + 1 by omega] at h
+  rw [e2, e3, e1, Nat.choose_succ_succ, hsymm]
+  ring
+
+/-- **Weighted sum of squares (classical form).** For `n ≥ 1`,
+    `∑_{k=0}^{n} k · C(n, k)² = n · C(2n − 1, n − 1)`. -/
+theorem sum_weighted_sq (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ range (n + 1), k * (n.choose k) ^ 2 = n * (2 * n - 1).choose (n - 1) := by
+  have h2 := two_mul_sum_weighted_sq n
+  rw [central_binom_two_mul_pred n hn] at h2
+  have h3 : 2 * (∑ k ∈ range (n + 1), k * (n.choose k) ^ 2)
+      = 2 * (n * (2 * n - 1).choose (n - 1)) := by rw [h2]; ring
+  exact Nat.eq_of_mul_eq_mul_left (by norm_num) h3
+
+/-- Sanity check: `∑_{k=0}^{3} k·C(3,k)² = 0 + 9 + 18 + 3 = 30 = 3·C(5,2) = 3·10`. -/
+example : ∑ k ∈ range 4, k * ((3 : ℕ).choose k) ^ 2 = 30 := by decide
+
+/-- Sanity check of the closed form at `n = 3`: `30 = 3 · C(5, 2)`. -/
+example : ∑ k ∈ range 4, k * ((3 : ℕ).choose k) ^ 2 = 3 * (2 * 3 - 1).choose (3 - 1) := by
+  decide
+
+end CombinationsFormulaOQ07OQ03

--- a/src/data/proofs/combinations-formula-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "weighted-context",
+    "proofId": "combinations-formula-oq-07-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 58
+    },
+    "type": "concept",
+    "title": "Weighting the Sum of Squares: A First Moment",
+    "content": "The parent entry proves the central sum of squares C(2n,n) = ∑_{k=0}^{n} C(n,k)². This follow-up weights each term by its index k. The result, 2·∑ k·C(n,k)² = n·C(2n,n) (equivalently ∑ k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1), is a first-moment identity: reading p_k = C(n,k)²/C(2n,n) as the hypergeometric distribution on {0,…,n}, the weighted sum is its mean, and the identity says that mean is n/2. The proof needs nothing beyond the parent identity and a reflection.",
+    "mathContext": "$2\\sum_{k=0}^{n} k\\binom{n}{k}^2 = n\\binom{2n}{n}$. Probabilistically, with $p_k = \\binom{n}{k}^2/\\binom{2n}{n}$ the hypergeometric law, $\\sum_k k\\,p_k = n/2$ — the mean sits at the centre of a distribution symmetric under $k \\mapsto n-k$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares of binomial coefficients",
+      "first moment / weighted sum",
+      "hypergeometric distribution",
+      "reflection symmetry",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "binomial symmetry C(n,k) = C(n,n-k)",
+      "the parent identity C(2n,n) = ∑ C(n,k)²"
+    ]
+  },
+  {
+    "id": "reflection-thm",
+    "proofId": "combinations-formula-oq-07-oq-03",
+    "range": {
+      "startLine": 67,
+      "endLine": 76
+    },
+    "type": "theorem",
+    "title": "The Reflection Symmetry",
+    "content": "sum_weighted_sq_reflect establishes ∑_{k=0}^{n} k·C(n,k)² = ∑_{k=0}^{n} (n−k)·C(n,k)². The substitution k ↦ n−k is performed by Finset.sum_range_reflect (which rewrites a sum over range (n+1) by sending the index j to n−j), and Nat.choose_symm turns the resulting C(n,n−k) back into C(n,k). This single symmetry is the entire engine of the closed form: it gives a second expression for the same sum in which the weight is n−k instead of k.",
+    "mathContext": "Substituting $k \\mapsto n-k$ and using $\\binom{n}{n-k} = \\binom{n}{k}$: $\\sum_k k\\binom{n}{k}^2 = \\sum_k (n-k)\\binom{n}{k}^2$. The two weights $k$ and $n-k$ are mirror images about $n/2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_range_reflect",
+      "Nat.choose_symm",
+      "reflection / mirror substitution",
+      "symmetry of binomial coefficients"
+    ],
+    "prerequisites": [
+      "summation over Finset.range",
+      "reindexing a finite sum",
+      "binomial symmetry"
+    ]
+  },
+  {
+    "id": "closed-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-03",
+    "range": {
+      "startLine": 82,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "The Weighted Closed Form",
+    "content": "two_mul_sum_weighted_sq proves 2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n). Adding the original sum to its reflection (Finset.sum_add_distrib) gives a single sum with summand (k + (n−k))·C(n,k)²; since k ≤ n on the range, the weight collapses to the constant n (verified by omega). Pulling n out (Finset.mul_sum) leaves n·∑ C(n,k)², which the parent identity central_binom_eq_sum_sq turns into n·C(2n,n). The factor of 2 keeps the statement free of natural-number subtraction and valid for every n.",
+    "mathContext": "$2S = \\sum_k\\big(k+(n-k)\\big)\\binom{n}{k}^2 = n\\sum_k \\binom{n}{k}^2 = n\\binom{2n}{n}$, using $\\sum_k\\binom{n}{k}^2 = \\binom{2n}{n}$ from the parent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "Finset.mul_sum",
+      "central_binom_eq_sum_sq (parent)",
+      "averaging a sum with its reflection"
+    ],
+    "prerequisites": [
+      "linearity of finite sums",
+      "the reflection symmetry above",
+      "the parent sum of squares identity"
+    ]
+  },
+  {
+    "id": "classical-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-03",
+    "range": {
+      "startLine": 108,
+      "endLine": 135
+    },
+    "type": "theorem",
+    "title": "Halving and the Classical Form",
+    "content": "central_binom_two_mul_pred proves C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1: Pascal's rule splits C(2n,n) = C(2n−1,n−1) + C(2n−1,n), and binomial symmetry identifies C(2n−1,n) = C(2n−1,n−1), the point where the n ≥ 1 hypothesis is needed (the relation fails at n=0 under truncated subtraction). Substituting into the factor-of-2 form and cancelling the 2 yields the classical statement sum_weighted_sq: ∑_{k=0}^{n} k·C(n,k)² = n·C(2n−1,n−1). The numeric check confirms ∑_{k=0}^{3} k·C(3,k)² = 30 = 3·C(5,2).",
+    "mathContext": "$\\binom{2n}{n} = \\binom{2n-1}{n-1} + \\binom{2n-1}{n} = 2\\binom{2n-1}{n-1}$, hence $\\sum_k k\\binom{n}{k}^2 = n\\binom{2n-1}{n-1}$ for $n \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.choose_succ_succ (Pascal's rule)",
+      "Nat.choose_symm",
+      "Nat.eq_of_mul_eq_mul_left",
+      "central binomial halving"
+    ],
+    "prerequisites": [
+      "Pascal's rule",
+      "binomial symmetry",
+      "cancellation in ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-03/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-03/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "combinations-formula-oq-07-oq-03",
+  "title": "The Weighted Sum of Squares of Binomial Coefficients",
+  "slug": "combinations-formula-oq-07-oq-03",
+  "description": "Weights the parent's central sum of squares C(2n,n) = ∑ C(n,k)² by the index k, yielding the first-moment identity 2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n), equivalently ∑ k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1. The proof is a pure reflection argument: substituting k ↦ n−k and using C(n,n−k) = C(n,k) shows ∑ k·C(n,k)² = ∑ (n−k)·C(n,k)²; adding the two collapses the weight k+(n−k) to the constant n, and the parent identity finishes. No induction, no generating functions, no factorial bookkeeping. Reading C(n,k)²/C(2n,n) as a hypergeometric distribution, the identity says its mean is n/2.",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ03.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 137,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. The closed form 2·∑ k·C(n,k)² = n·C(2n,n) holds for all n and is fully machine-checked; the classical form ∑ k·C(n,k)² = n·C(2n−1,n−1) and the halving C(2n,n) = 2·C(2n−1,n−1) are stated for n ≥ 1. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "sum-of-squares",
+      "weighted-sum",
+      "first-moment",
+      "reflection",
+      "central-binomial",
+      "double-counting"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "two_mul_sum_weighted_sq: the weighted central binomial sum of squares 2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n), a first-moment companion to the parent's unweighted C(2n,n) = ∑ C(n,k)², absent from Mathlib",
+      "sum_weighted_sq_reflect: the reflection symmetry ∑ k·C(n,k)² = ∑ (n−k)·C(n,k)², the conceptual core that makes the closed form a one-line consequence",
+      "central_binom_two_mul_pred: the halving C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1 via Pascal's rule and binomial symmetry, the bridge between the subtraction-free and classical forms",
+      "sum_weighted_sq: the classical closed form ∑_{k=0}^{n} k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1",
+      "Worked check ∑_{k=0}^{3} k·C(3,k)² = 0 + 9 + 18 + 3 = 30 = 3·C(5,2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑_{j ∈ range n} f(n−1−j) = ∑_{j ∈ range n} f(j). Applied to f(k) = (n−k)·C(n,k)² over range (n+1) to perform the substitution k ↦ n−k that drives the reflection symmetry.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "C(n, n−k) = C(n, k) for k ≤ n. Turns the reflected coefficient C(n, n−k) back into C(n, k) so the (n−k)-weighted sum has exactly the parent's squared summands.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule C(n+1, k+1) = C(n, k) + C(n, k+1). Splits C(2n, n) into C(2n−1, n−1) + C(2n−1, n), the two halves used to prove C(2n,n) = 2·C(2n−1,n−1).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07.central_binom_eq_sum_sq",
+        "description": "The parent identity C(2n, n) = ∑_{k=0}^{n} C(n, k)². Supplies the right-hand side once the weight has been collapsed to the constant n; the entire weighted result rests on it.",
+        "module": "Proofs.CombinationsFormulaOQ07"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "∑ (f + g) = ∑ f + ∑ g. Combines the k-weighted and (n−k)-weighted sums into a single sum whose summand is (k + (n−k))·C(n,k)² before the weight collapses to n.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ03.lean",
+    "namespace": "CombinationsFormulaOQ07OQ03",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 137,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The sum of squares of a Pascal row, ∑_{k} C(n,k)² = C(2n,n), is the most quoted special case of Vandermonde's convolution and the subject of the parent entry. Weighting the terms by k turns a counting identity into a moment computation. If one reads p_k = C(n,k)²/C(2n,n) as a probability distribution on {0,…,n} — the hypergeometric law for the number of items drawn from the first half when n of 2n items are chosen — then ∑ k·p_k is its mean. The identity 2·∑ k·C(n,k)² = n·C(2n,n) says that mean equals n/2, an instance of the symmetry of the hypergeometric distribution about its centre. Such weighted binomial sums are catalogued in Gould's Combinatorial Identities (1972) and underlie the absorption identity ∑ k·C(n,k) = n·2^{n−1}; Mathlib carries the unweighted row sum and the alternating row sum but none of the squared-coefficient moments.",
+    "problemStatement": "Open Question OQ-07-OQ-03: the parent entry combinations-formula-oq-07 proves C(2n,n) = ∑_{k=0}^{n} C(n,k)². What happens when the terms are weighted by their index k? Formalize the first-moment identity 2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n) and its classical form ∑ k·C(n,k)² = n·C(2n−1,n−1), and identify the structural reason — the reflection symmetry k ↦ n−k — behind the clean closed form.",
+    "proofStrategy": "Write S = ∑_{k=0}^{n} k·C(n,k)². Apply Finset.sum_range_reflect to substitute k ↦ n−k; combined with Nat.choose_symm (C(n,n−k) = C(n,k)) this gives the reflection symmetry S = ∑_{k=0}^{n} (n−k)·C(n,k)² (sum_weighted_sq_reflect). Adding the original and reflected sums termwise, the weights combine as k + (n−k) = n (valid since k ≤ n on the summation range, discharged by omega), so 2S = ∑_{k} n·C(n,k)² = n·∑_{k} C(n,k)² = n·C(2n,n) by the parent's central_binom_eq_sum_sq (two_mul_sum_weighted_sq). The classical form follows by halving: C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1 (central_binom_two_mul_pred), proved from Pascal's rule C(2n,n) = C(2n−1,n−1) + C(2n−1,n) and the symmetry C(2n−1,n) = C(2n−1,n−1); cancelling the factor 2 then gives sum_weighted_sq. Keeping the headline identity in the factor-of-2 form avoids all natural-number subtraction.",
+    "keyInsights": [
+      "Weighting the parent's sum of squares by k is exactly a first-moment computation: it asks for the mean of the hypergeometric distribution C(n,k)²/C(2n,n), and the answer n/2 is the distribution's symmetry made arithmetic.",
+      "The reflection k ↦ n−k is the whole proof: it produces a second expression ∑ (n−k)·C(n,k)² for the same sum, and averaging the two replaces the variable weight k by the constant n.",
+      "Stating the result as 2·∑ k·C(n,k)² = n·C(2n,n) keeps it subtraction-free and valid for all n including n=0; the classical n·C(2n−1,n−1) form is recovered only after the n≥1 halving C(2n,n) = 2·C(2n−1,n−1).",
+      "The halving C(2n,n) = 2·C(2n−1,n−1) is itself a one-line Pascal-plus-symmetry fact and is the precise point where the n≥1 hypothesis enters (it fails at n=0 under truncated subtraction).",
+      "The entire development reuses the parent identity as a black box — no re-derivation of the sum of squares — illustrating how a moment identity bootstraps off its zeroth-moment parent."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 58,
+      "summary": "Header stating OQ-07-OQ-03: weighting the parent's central sum of squares by k, the reflection proof of 2·∑ k·C(n,k)² = n·C(2n,n), and the hypergeometric-mean interpretation (mean = n/2)."
+    },
+    {
+      "id": "reflection",
+      "title": "The Reflection Symmetry",
+      "startLine": 64,
+      "endLine": 76,
+      "summary": "sum_weighted_sq_reflect: ∑ k·C(n,k)² = ∑ (n−k)·C(n,k)², proved by Finset.sum_range_reflect (substituting k ↦ n−k) and Nat.choose_symm. This is the conceptual core that makes the closed form immediate."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Weighted Closed Form",
+      "startLine": 78,
+      "endLine": 103,
+      "summary": "two_mul_sum_weighted_sq: 2·∑ k·C(n,k)² = n·C(2n,n). Adds the k-weighted and (n−k)-weighted sums (Finset.sum_add_distrib), collapses the weight k+(n−k) = n (omega), and applies the parent's central_binom_eq_sum_sq."
+    },
+    {
+      "id": "classical-form",
+      "title": "Halving and the Classical Form",
+      "startLine": 105,
+      "endLine": 135,
+      "summary": "central_binom_two_mul_pred: C(2n,n) = 2·C(2n−1,n−1) for n ≥ 1 via Pascal's rule and symmetry; sum_weighted_sq: ∑ k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1 by cancelling the factor 2; with the numeric check ∑_{k=0}^{3} k·C(3,k)² = 30 = 3·C(5,2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. The first-moment identity 2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n) weights the parent's central sum of squares by k, and reduces to the classical ∑ k·C(n,k)² = n·C(2n−1,n−1) for n ≥ 1. The entire proof is the reflection symmetry k ↦ n−k against the parent identity — no induction or generating functions.",
+    "implications": "Adds a squared-coefficient moment identity that Mathlib lacks, built on its reflection lemma and the parent's sum of squares. The reflection-and-average technique — produce a second expression for a weighted sum by k ↦ n−k, then average to constantise the weight — is a reusable route to first moments of symmetric binomial sums, and the C(n,k)²/C(2n,n) hypergeometric reading connects the identity to its probabilistic meaning (mean n/2).",
+    "openQuestions": [
+      "What is the second moment ∑_{k=0}^{n} k²·C(n,k)²? The reflection symmetry gives ∑ k²·C(n,k)² = ∑ (n−k)²·C(n,k)², but constantising now leaves a residual ∑ k·C(n,k)² term — does the closed form involve C(2n,n) and C(2n−2,n−1) (the hypergeometric variance n²/(4(2n−1)))?",
+      "Does the weighted identity admit a signed analogue ∑_{k} (−1)^k k·C(n,k)², and how does it relate to the alternating central coefficient?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "parent — proves the unweighted C(2n,n) = ∑ C(n,k)²; this entry weights that sum by k to obtain its first moment, reusing the parent identity directly"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-02",
+      "relationship": "sibling — develops the off-diagonal Vandermonde convolution (sliding the second factor); this entry instead weights the diagonal sum of squares by the index"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "sibling — the multiplicative subset-of-a-subset companion, whose absorption identity k·C(n,k) = n·C(n−1,k−1) is the multiplicative analogue of the index-weighting studied here"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Self-generated follow-up (OQ-07-OQ-03) on the solved parent **combinations-formula-oq-07**, which proves the central sum of squares `C(2n,n) = ∑_{k=0}^{n} C(n,k)²`. This entry **weights that sum by the index k**, giving the first-moment identity

  **2·∑_{k=0}^{n} k·C(n,k)² = n·C(2n,n)**,  equivalently  **∑ k·C(n,k)² = n·C(2n−1,n−1)** for n ≥ 1.

Not in Mathlib (which carries the unweighted row sum, the alternating row sum, and Vandermonde, but no squared-coefficient moments).

## The reflection proof

No induction, no generating functions, no factorial bookkeeping. Writing `S = ∑ k·C(n,k)²`, the substitution `k ↦ n−k` (`Finset.sum_range_reflect`) plus `C(n,n−k) = C(n,k)` (`Nat.choose_symm`) gives `S = ∑ (n−k)·C(n,k)²`. Averaging the two collapses the weight `k+(n−k)` to the constant `n`, and the parent identity finishes:
`2S = ∑ n·C(n,k)² = n·∑ C(n,k)² = n·C(2n,n)`.

Reading `C(n,k)²/C(2n,n)` as a hypergeometric distribution, the identity says its **mean is n/2** — the distribution's symmetry made arithmetic.

## Results (4 theorems, 0 sorries, 0 axioms)

- `sum_weighted_sq_reflect` — the reflection symmetry `∑ k·C(n,k)² = ∑ (n−k)·C(n,k)²` (conceptual core)
- `two_mul_sum_weighted_sq` — `2·∑ k·C(n,k)² = n·C(2n,n)` (subtraction-free, all n)
- `central_binom_two_mul_pred` — the halving `C(2n,n) = 2·C(2n−1,n−1)` for n ≥ 1 (Pascal + symmetry)
- `sum_weighted_sq` — classical form `∑ k·C(n,k)² = n·C(2n−1,n−1)` for n ≥ 1

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CombinationsFormulaOQ07OQ03` ✔ (built first try)
- 0 sorries, 0 `axiom` declarations, no `native_decide` (numeric checks use kernel `decide`)
- Foundational axioms only (`propext`, `Classical.choice`, `Quot.sound`)
- Gallery `meta.json` + `annotations.json` added; annotations resolve cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)