### PR TITLE
Research: lhopital-oq-04 — L'Hôpital's 0/0 rule via the Taylor / leading-order route (0-axiom verified)

### DIFF
--- a/proofs/Proofs/LHopitalOQ04.lean
+++ b/proofs/Proofs/LHopitalOQ04.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-
+# L'Hôpital's Rule via Taylor / Leading-Order Expansion (OQ-04)
+
+The parent gallery entry `LHopital` proves L'Hôpital's rule for the `0/0` form
+through the Mean Value Theorem (Mathlib's `HasDerivAt.lhopital_zero_right`). The
+open question OQ-04 asks for the *Taylor-series* perspective instead: if `f` and
+`g` both vanish at `a`, then near `a` they behave like their leading (linear)
+Taylor terms, so
+
+    f(x)/g(x) → f'(a)/g'(a).
+
+This file formalizes exactly that derivation, **without** invoking the MVT-based
+rule. The engine is the leading-order coefficient extraction
+
+    f(a) = 0,  f differentiable at a  ⟹  f(x)/(x-a) → f'(a),
+
+which is nothing but the definition of the derivative as the limit of slopes
+(Mathlib's `HasDerivAt.tendsto_slope`). Writing
+
+    f(x)/g(x) = (f(x)/(x-a)) / (g(x)/(x-a))    (for x ≠ a)
+
+and dividing the two leading-order limits gives the rule directly. This is the
+order-1 Taylor statement: the limit is the ratio of the first Taylor coefficients
+`f'(a)/1!` and `g'(a)/1!`.
+
+Self-contained: imports only Mathlib.
+-/
+
+namespace LHopitalOQ04
+
+open Filter Topology
+
+/-- **Leading-order Taylor coefficient.** If `f` vanishes at `a` and is
+differentiable there, then `f(x)/(x-a) → f'(a)` as `x → a` (`x ≠ a`). This is the
+derivative-as-slope statement specialised to `f a = 0`, and the `n = 1` case of the
+Taylor expansion `f(x) = f'(a)(x-a) + o(x-a)`. -/
+theorem tendsto_div_sub_of_hasDerivAt {f : ℝ → ℝ} {a f' : ℝ}
+    (hf : HasDerivAt f f' a) (hfa : f a = 0) :
+    Tendsto (fun x => f x / (x - a)) (𝓝[≠] a) (𝓝 f') := by
+  apply hf.tendsto_slope.congr'
+  filter_upwards [self_mem_nhdsWithin] with x hx
+  simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hx
+  rw [slope_def_field, hfa, sub_zero]
+
+/-- **L'Hôpital's rule for `0/0`, via the Taylor / leading-order route.** For `f, g`
+differentiable at `a` with `f a = g a = 0` and `g'(a) ≠ 0`,
+
+    f(x)/g(x) → f'(a)/g'(a)    as x → a.
+
+The proof divides the two leading-order limits `f(x)/(x-a) → f'(a)` and
+`g(x)/(x-a) → g'(a)`, using `f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a))` for `x ≠ a`.
+No Mean Value Theorem is used. -/
+theorem lhopital_zero_taylor {f g : ℝ → ℝ} {a f' g' : ℝ}
+    (hf : HasDerivAt f f' a) (hg : HasDerivAt g g' a)
+    (hfa : f a = 0) (hga : g a = 0) (hg' : g' ≠ 0) :
+    Tendsto (fun x => f x / g x) (𝓝[≠] a) (𝓝 (f' / g')) := by
+  have hF := tendsto_div_sub_of_hasDerivAt hf hfa
+  have hG := tendsto_div_sub_of_hasDerivAt hg hga
+  have hdiv := hF.div hG hg'
+  apply hdiv.congr'
+  filter_upwards [self_mem_nhdsWithin] with x hx
+  simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hx
+  have hxa : x - a ≠ 0 := sub_ne_zero.mpr hx
+  simp only [Pi.div_apply]
+  rw [div_div_div_cancel_right₀ hxa]
+
+/-- The same statement packaged so the limit is named by the Taylor coefficients
+`f'(a)/1!` and `g'(a)/1!` — making explicit that order-1 L'Hôpital *is* the ratio
+of first Taylor coefficients. -/
+theorem lhopital_zero_taylor_coeff {f g : ℝ → ℝ} {a f' g' : ℝ}
+    (hf : HasDerivAt f f' a) (hg : HasDerivAt g g' a)
+    (hfa : f a = 0) (hga : g a = 0) (hg' : g' ≠ 0) :
+    Tendsto (fun x => f x / g x) (𝓝[≠] a)
+      (𝓝 ((f' / (Nat.factorial 1 : ℝ)) / (g' / (Nat.factorial 1 : ℝ)))) := by
+  have h := lhopital_zero_taylor hf hg hfa hga hg'
+  simpa using h
+
+/-- Worked example: `sin x / x → 1` as `x → 0`. Here `f = sin` (with `f 0 = 0`,
+`f'(0) = cos 0 = 1`) and `g = id` (`g 0 = 0`, `g'(0) = 1`), so the limit is
+`cos 0 / 1 = 1`. -/
+example : Tendsto (fun x => Real.sin x / x) (𝓝[≠] (0 : ℝ)) (𝓝 1) := by
+  have h := lhopital_zero_taylor (Real.hasDerivAt_sin 0) (hasDerivAt_id (0 : ℝ))
+    Real.sin_zero rfl (by norm_num)
+  simpa [Real.cos_zero] using h
+
+/-- Worked example with a vanishing numerator derivative: `(1 - cos x)/x → 0` as
+`x → 0`. Here `f'(0) = sin 0 = 0`, so the leading term vanishes and the limit is
+`0 / 1 = 0`. -/
+example : Tendsto (fun x => (1 - Real.cos x) / x) (𝓝[≠] (0 : ℝ)) (𝓝 0) := by
+  have hf : HasDerivAt (fun x => 1 - Real.cos x) (Real.sin 0) 0 := by
+    simpa using (hasDerivAt_const (0 : ℝ) (1 : ℝ)).sub (Real.hasDerivAt_cos 0)
+  have h := lhopital_zero_taylor hf (hasDerivAt_id (0 : ℝ))
+    (by simp) rfl (by norm_num)
+  simpa using h
+
+#check @lhopital_zero_taylor
+
+end LHopitalOQ04

--- a/src/data/proofs/lhopital-oq-04/annotations.json
+++ b/src/data/proofs/lhopital-oq-04/annotations.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": "ann-leading-order",
+    "proofId": "lhopital-oq-04",
+    "range": {
+      "startLine": 39,
+      "endLine": 53
+    },
+    "type": "insight",
+    "title": "The Engine: f(x)/(x-a) → f'(a)",
+    "content": "tendsto_div_sub_of_hasDerivAt is the whole Taylor story in one line. The derivative of f at a IS the limit of slopes (f x - f a)/(x - a) as x → a (HasDerivAt.tendsto_slope). When f a = 0 this slope is exactly f(x)/(x-a), so f(x)/(x-a) → f'(a). This is the order-1 Taylor coefficient extracted as a limit: f(x) = f'(a)(x-a) + o(x-a), divided by (x-a)."
+  },
+  {
+    "id": "ann-main-rule",
+    "proofId": "lhopital-oq-04",
+    "range": {
+      "startLine": 55,
+      "endLine": 80
+    },
+    "type": "insight",
+    "title": "Dividing Leading Terms — No Mean Value Theorem",
+    "content": "lhopital_zero_taylor takes the two leading-order limits f(x)/(x-a) → f'(a) and g(x)/(x-a) → g'(a) and divides them (Filter.Tendsto.div, valid since g'(a) ≠ 0). The bridge back to f(x)/g(x) is the identity f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) for x ≠ a — the shared (x-a) Taylor factor cancels (div_div_div_cancel_right₀) — transported by Tendsto.congr'. The Cauchy Mean Value Theorem the parent uses never appears; lhopital_zero_taylor_coeff additionally names the value as the ratio of first Taylor coefficients f'(a)/1! and g'(a)/1!."
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "lhopital-oq-04",
+    "range": {
+      "startLine": 83,
+      "endLine": 99
+    },
+    "type": "concept",
+    "title": "sin x / x and a Vanishing Leading Term",
+    "content": "sin x / x → 1 instantiates the rule with f = sin (f'(0) = cos 0 = 1) and g = id (g'(0) = 1), giving cos 0 / 1 = 1. The second example (1 - cos x)/x → 0 shows the f'(a) = 0 case: the numerator's leading Taylor coefficient is sin 0 = 0, so the limit is 0/1 = 0 — the leading-order picture makes this immediate."
+  }
+]

--- a/src/data/proofs/lhopital-oq-04/meta.json
+++ b/src/data/proofs/lhopital-oq-04/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "lhopital-oq-04",
+  "title": "L'Hôpital's Rule via the Taylor / Leading-Order Expansion",
+  "slug": "lhopital-oq-04",
+  "description": "Answers the parent L'Hôpital entry's OQ-04 — give the Taylor-series derivation of L'Hôpital's 0/0 rule rather than the Mean Value Theorem proof. The key is the leading-order coefficient extraction f(a)=0 ⇒ f(x)/(x-a) → f'(a), which is the derivative-as-slope limit (HasDerivAt.tendsto_slope) and the n=1 case of the Taylor expansion. Writing f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) for x≠a and dividing the two leading-order limits gives f(x)/g(x) → f'(a)/g'(a) with no MVT. Verified, zero axioms, no native_decide.",
+  "meta": {
+    "author": "L'Hôpital / Bernoulli (1696); Taylor route formalized in Lean 4",
+    "date": "1696",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LHopitalOQ04.lean",
+    "tags": [
+      "analysis",
+      "calculus",
+      "lhopital",
+      "taylor-series",
+      "limits",
+      "derivatives"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 101,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "originalContributions": [
+      "tendsto_div_sub_of_hasDerivAt: the leading-order Taylor coefficient — if f a = 0 and f is differentiable at a, then f(x)/(x-a) → f'(a). This is the derivative-as-slope limit specialised to f a = 0, and the engine of the whole Taylor derivation.",
+      "lhopital_zero_taylor: L'Hôpital's rule for 0/0 derived WITHOUT the Mean Value Theorem — f(x)/g(x) → f'(a)/g'(a) by dividing the two leading-order limits, using f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) for x ≠ a (div_div_div_cancel_right₀).",
+      "lhopital_zero_taylor_coeff: the same limit named by the first Taylor coefficients (f'(a)/1!)/(g'(a)/1!), making explicit that order-1 L'Hôpital is the ratio of first Taylor coefficients.",
+      "Worked examples sin x / x → 1 (cos 0 / 1) and (1 - cos x)/x → 0 (vanishing leading term, sin 0 / 1), instantiating the rule with no native_decide."
+    ],
+    "prerequisites": [
+      "The derivative as the limit of slopes (HasDerivAt.tendsto_slope)",
+      "The Taylor expansion f(x) = f'(a)(x-a) + o(x-a) at first order",
+      "Limit arithmetic: Filter.Tendsto.div for the quotient of limits",
+      "L'Hôpital's rule for the 0/0 indeterminate form"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "HasDerivAt.tendsto_slope",
+        "description": "HasDerivAt f f' a ↔ the slopes (f x - f a)/(x - a) tend to f' along 𝓝[≠] a. The leading-order limit is this with f a = 0.",
+        "module": "Mathlib.Analysis.Calculus.Deriv.Slope"
+      },
+      {
+        "theorem": "Filter.Tendsto.div",
+        "description": "The limit of a quotient is the quotient of limits when the denominator limit is nonzero — used to divide the two leading-order limits.",
+        "module": "Mathlib.Topology.Algebra.GroupWithZero"
+      },
+      {
+        "theorem": "div_div_div_cancel_right₀",
+        "description": "(a/c)/(b/c) = a/b for c ≠ 0 — the algebraic identity letting f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) for x ≠ a.",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "L'Hôpital's rule (published 1696 by the Marquis de l'Hôpital, due to Johann Bernoulli) evaluates 0/0 and ∞/∞ indeterminate limits by differentiating numerator and denominator. Mathlib's development, and the parent gallery entry, prove the 0/0 case through the Cauchy Mean Value Theorem. But there is a more transparent story for the 0/0 case: if f and g both vanish at a, their Taylor expansions begin at the linear term, f(x) ≈ f'(a)(x-a) and g(x) ≈ g'(a)(x-a), so the ratio tends to f'(a)/g'(a) simply because the leading terms dominate. This entry formalizes that Taylor / leading-order derivation directly, sidestepping the Mean Value Theorem entirely.",
+    "problemStatement": "**Open Question (parent lhopital, OQ-04)**: formalize the connection between L'Hôpital's rule and Taylor series — prove L'Hôpital's 0/0 rule via Taylor expansion (an alternative to the MVT proof), recognising that the limit is governed by the leading Taylor coefficients.\n\n**This entry**: proves f(x)/g(x) → f'(a)/g'(a) (for f a = g a = 0, g'(a) ≠ 0) by the leading-order route, with zero axioms and no MVT.",
+    "text": "A 101-line, fully verified file (0 sorries, 0 axioms, no native_decide) importing only Mathlib. Its core is tendsto_div_sub_of_hasDerivAt: the slope limit (f x - f a)/(x - a) → f'(a), specialised to f a = 0, which is precisely the order-1 Taylor coefficient. lhopital_zero_taylor then divides the f- and g-limits, and lhopital_zero_taylor_coeff renames the value as the ratio of first Taylor coefficients. Two worked examples (sin x/x → 1 and (1 - cos x)/x → 0) instantiate the rule.",
+    "proofStrategy": "tendsto_div_sub_of_hasDerivAt rewrites the slope (slope_def_field) and uses f a = 0 to identify (f x - f a)/(x - a) with f(x)/(x-a), so HasDerivAt.tendsto_slope gives f(x)/(x-a) → f'(a). For the main rule, lhopital_zero_taylor takes the two leading-order limits hF : f(x)/(x-a) → f'(a) and hG : g(x)/(x-a) → g'(a), forms hF.div hG hg' : (f(x)/(x-a))/(g(x)/(x-a)) → f'(a)/g'(a), and transports it along the eventual equality f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) (valid for x ≠ a by div_div_div_cancel_right₀) using Tendsto.congr'. No Mean Value Theorem appears.",
+    "keyInsights": [
+      "The whole rule reduces to one fact, the leading-order limit f(x)/(x-a) → f'(a) — which is just the definition of the derivative as a slope, restated with f a = 0.",
+      "The cancellation f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) for x ≠ a is what turns 'ratio of functions' into 'ratio of slopes'; the shared (x-a) factor is the Taylor leading term divided out of both.",
+      "Order-1 L'Hôpital is literally the ratio of first Taylor coefficients f'(a)/1! and g'(a)/1!, as lhopital_zero_taylor_coeff records.",
+      "This derivation is strictly more elementary than the Cauchy Mean Value Theorem proof: it needs only the derivative-as-slope characterisation and limit arithmetic, no auxiliary point ξ.",
+      "When the leading numerator coefficient vanishes (f'(a) = 0) the limit is 0, as the (1 - cos x)/x → 0 example shows — the leading-order picture makes this transparent."
+    ]
+  },
+  "sections": [
+    {
+      "id": "leading-order",
+      "title": "The Leading-Order Taylor Coefficient",
+      "startLine": 39,
+      "endLine": 53,
+      "summary": "tendsto_div_sub_of_hasDerivAt: f a = 0 and differentiability give f(x)/(x-a) → f'(a), the order-1 Taylor coefficient as a slope limit.",
+      "mathContext": "The derivative as a slope, specialised to a vanishing value."
+    },
+    {
+      "id": "main-rule",
+      "title": "L'Hôpital via Dividing Leading Terms",
+      "startLine": 55,
+      "endLine": 80,
+      "summary": "lhopital_zero_taylor divides the two leading-order limits; lhopital_zero_taylor_coeff names the value as a ratio of first Taylor coefficients.",
+      "mathContext": "f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a)) → f'(a)/g'(a), no MVT."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Examples",
+      "startLine": 83,
+      "endLine": 99,
+      "summary": "sin x/x → 1 (limit cos 0/1) and (1 - cos x)/x → 0 (vanishing leading term, sin 0/1).",
+      "mathContext": "Instantiating the rule, including the f'(a) = 0 case."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry answers the parent L'Hôpital entry's OQ-04 by giving the Taylor / leading-order derivation of the 0/0 rule: the limit f(x)/g(x) → f'(a)/g'(a) follows from the single leading-order fact f(x)/(x-a) → f'(a) (the derivative as a slope) divided across numerator and denominator, with zero axioms and no Mean Value Theorem.",
+    "implications": "The Taylor perspective is more elementary than the MVT proof for the 0/0 form: it isolates exactly why L'Hôpital works — the functions are, to leading order, their linear Taylor terms. The leading-order lemma tendsto_div_sub_of_hasDerivAt is reusable wherever a first Taylor coefficient must be extracted as a limit.",
+    "openQuestions": [
+      "Iterated L'Hôpital: when f^(k)(a) = g^(k)(a) = 0 for k < n, prove the limit equals the ratio of n-th Taylor coefficients f^(n)(a)/g^(n)(a), via f(x)/(x-a)^n → f^(n)(a)/n! from Taylor's theorem with remainder.",
+      "A two-sided (deleted-neighbourhood) version stated for analytic f, g packaging the higher-order Taylor remainder explicitly."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lhopital",
+      "relationship": "extends",
+      "description": "Parent entry: proves L'Hôpital's 0/0 rule via the Mean Value Theorem. This entry gives the alternative Taylor / leading-order derivation requested in OQ-04."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "LHopitalOQ04",
+    "lineCount": 101,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "lhopital_zero_taylor",
+        "type": "core",
+        "description": "L'Hôpital's rule for 0/0 via the Taylor / leading-order route (no MVT): f(x)/g(x) → f'(a)/g'(a) for f a = g a = 0, g'(a) ≠ 0.",
+        "leanType": "{f g : ℝ → ℝ} → {a f' g' : ℝ} → HasDerivAt f f' a → HasDerivAt g g' a → f a = 0 → g a = 0 → g' ≠ 0 → Tendsto (fun x => f x / g x) (𝓝[≠] a) (𝓝 (f' / g'))"
+      },
+      {
+        "name": "tendsto_div_sub_of_hasDerivAt",
+        "type": "key",
+        "description": "The leading-order Taylor coefficient: f a = 0 and differentiability give f(x)/(x-a) → f'(a).",
+        "leanType": "{f : ℝ → ℝ} → {a f' : ℝ} → HasDerivAt f f' a → f a = 0 → Tendsto (fun x => f x / (x - a)) (𝓝[≠] a) (𝓝 f')"
+      }
+    ],
+    "path": "Proofs/LHopitalOQ04.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "lhopital_zero_taylor",
+      "type": "core",
+      "description": "L'Hôpital 0/0 via Taylor / leading-order expansion, no Mean Value Theorem.",
+      "leanType": "{f g : ℝ → ℝ} → {a f' g' : ℝ} → HasDerivAt f f' a → HasDerivAt g g' a → f a = 0 → g a = 0 → g' ≠ 0 → Tendsto (fun x => f x / g x) (𝓝[≠] a) (𝓝 (f' / g'))"
+    },
+    {
+      "name": "tendsto_div_sub_of_hasDerivAt",
+      "type": "key",
+      "description": "Leading-order Taylor coefficient: f(x)/(x-a) → f'(a) when f a = 0.",
+      "leanType": "{f : ℝ → ℝ} → {a f' : ℝ} → HasDerivAt f f' a → f a = 0 → Tendsto (fun x => f x / (x - a)) (𝓝[≠] a) (𝓝 f')"
+    }
+  ],
+  "references": [
+    {
+      "authors": "de l'Hôpital, Guillaume (after Johann Bernoulli)",
+      "title": "Analyse des Infiniment Petits pour l'Intelligence des Lignes Courbes",
+      "year": "1696",
+      "venue": "Paris",
+      "note": "The original publication of the rule"
+    },
+    {
+      "authors": "Rudin, Walter",
+      "title": "Principles of Mathematical Analysis",
+      "year": "1976",
+      "venue": "McGraw-Hill (3rd ed.)",
+      "note": "Standard reference relating L'Hôpital to Taylor expansion for the 0/0 form"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/lhopital-oq-04.json
+++ b/src/data/research/problems/lhopital-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "lhopital-oq-04",
   "title": "L'Hôpital's Rule — Relationship to Taylor Series",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -31,11 +31,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): Answered OQ-04 (LHopital via Taylor) by the leading-order/slope route, NO MVT, 0-axiom verified (propext/Classical.choice/Quot.sound). File Proofs/LHopitalOQ04.lean (101L, 3 thm). Core tendsto_div_sub_of_hasDerivAt: f a=0 + HasDerivAt => f(x)/(x-a) -> f' (order-1 Taylor coeff = HasDerivAt.tendsto_slope with f a=0). Main lhopital_zero_taylor: divide the f and g leading-order limits (Filter.Tendsto.div) then transport along f(x)/g(x)=(f(x)/(x-a))/(g(x)/(x-a)) for x != a (div_div_div_cancel_right0 + Tendsto.congr'). +coeff form (ratio of first Taylor coeffs) and examples sin x/x->1, (1-cos x)/x->0.",
+    "builtItems": [
+      "Proofs/LHopitalOQ04.lean: lhopital_zero_taylor (0-axiom, MVT-free LHopital 0/0)",
+      "tendsto_div_sub_of_hasDerivAt (leading-order Taylor coefficient, reusable)",
+      "lhopital_zero_taylor_coeff + sin x/x and (1-cos x)/x examples",
+      "src/data/proofs/lhopital-oq-04/ gallery entry"
+    ],
+    "insights": [
+      "Whole rule reduces to f(x)/(x-a) -> f' (derivative-as-slope with f a=0)",
+      "f(x)/g(x)=(f(x)/(x-a))/(g(x)/(x-a)) cancels shared Taylor (x-a) factor",
+      "Order-1 LHopital = ratio of first Taylor coefficients"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Iterated LHopital via Taylor remainder: higher derivatives vanish => limit = ratio of n-th Taylor coefficients"
+    ],
     "markdown": "# Knowledge Base: lhopital-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
@@ -55,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.496Z",
-  "lastUpdate": "2026-04-22T13:03:46.532Z",
+  "lastUpdate": "2026-06-22",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Answers the parent `LHopital` entry's **OQ-04**: give the *Taylor-series* derivation of L'Hôpital's `0/0` rule, an alternative to the parent's Mean Value Theorem proof.

The whole rule rests on one fact — the **leading-order Taylor coefficient**:

> `f a = 0` and `f` differentiable at `a` ⟹ `f(x)/(x-a) → f'(a)`,

which is just the derivative-as-slope limit (`HasDerivAt.tendsto_slope`) with `f a = 0`, i.e. the `n = 1` Taylor term. Writing `f(x)/g(x) = (f(x)/(x-a))/(g(x)/(x-a))` for `x ≠ a` and dividing the two leading-order limits gives `f(x)/g(x) → f'(a)/g'(a)` — **no MVT**.

## Theorems
- `tendsto_div_sub_of_hasDerivAt` — the leading-order coefficient `f(x)/(x-a) → f'(a)`.
- `lhopital_zero_taylor` — L'Hôpital's `0/0` rule via the Taylor route.
- `lhopital_zero_taylor_coeff` — names the value as the ratio of first Taylor coefficients `f'(a)/1!`, `g'(a)/1!`.
- Examples: `sin x / x → 1` and `(1 - cos x)/x → 0` (vanishing leading term).

## Files
- `proofs/Proofs/LHopitalOQ04.lean` (101 lines, 3 theorems)
- `src/data/proofs/lhopital-oq-04/{meta.json,annotations.json}`
- `src/data/research/problems/lhopital-oq-04.json`

## Verification
- **0 sorries, 0 `axiom` declarations, no `native_decide`**
- `#print axioms lhopital_zero_taylor` → `[propext, Classical.choice, Quot.sound]`
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.LHopitalOQ04`

## Status
**Outcome**: completed
**Next**: iterated L'Hôpital — when higher derivatives vanish, the limit is the ratio of `n`-th Taylor coefficients via Taylor's remainder.

🤖 Generated by researcher-9