### PR TITLE
Research: combinations-formula-oq-07-oq-04 — second moment ∑ k²·C(n,k)² = n²·C(2n−2,n−1) (0-axiom verified)

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ07OQ04.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ04.lean
@@ -1,0 +1,119 @@
+import Mathlib
+import Proofs.CombinationsFormulaOQ07
+
+/-
+# The Second Moment of the Sum of Squares of Binomial Coefficients
+
+## Open Question OQ-07-OQ-04
+
+The central identity of OQ-07 sums the *squares* of a Pascal row:
+
+  C(2n, n) = ∑_{k=0}^{n} C(n, k)² .
+
+Its sibling OQ-07-OQ-03 weights that sum by `k` (the *first moment*):
+
+  2 · ∑_{k=0}^{n} k · C(n, k)² = n · C(2n, n).
+
+This file weights it by `k²` (the *second moment*).  The result is again a
+single central binomial coefficient — now of the predecessor row:
+
+  ∑_{k=0}^{n} k² · C(n, k)² = n² · C(2n − 2, n − 1)        (n ≥ 1).      (★)
+
+Mathlib provides the unweighted row sum (`Nat.sum_range_choose`), Vandermonde's
+convolution (`Nat.add_choose_eq`) and the absorption identity
+`(k+1)·C(n+1,k+1) = (n+1)·C(n,k)` (`Nat.add_one_mul_choose_eq`), but **not**
+this second-moment identity.
+
+## The absorption proof
+
+Unlike the first moment, no reflection is needed: a single application of
+absorption collapses each term.  From `k · C(n, k) = n · C(n−1, k−1)` we get
+
+  k² · C(n, k)² = (k · C(n, k))² = (n · C(n−1, k−1))² = n² · C(n−1, k−1)² .
+
+The `k = 0` term vanishes, so reindexing `k = j + 1` and pulling out the
+constant `n²` leaves exactly the parent sum of squares over the row `n − 1`:
+
+  ∑_{k=0}^{n} k² · C(n, k)² = n² · ∑_{j=0}^{n−1} C(n−1, j)² = n² · C(2n−2, n−1),
+
+the last step being `central_binom_eq_sum_sq` (OQ-07) applied to `n − 1`.
+
+## Mathematical Context
+
+Read `C(n, k)² / C(2n, n)` as a probability distribution on `{0, …, n}` — the
+hypergeometric distribution from splitting a `2n`-set into two halves of size
+`n`.  OQ-07-OQ-03 gives its **mean** `n / 2`; identity (★) gives its **second
+moment**
+
+  E[k²] = n² · C(2n−2, n−1) / C(2n, n) = n³ / (2(2n−1)),
+
+using `C(2n−2,n−1) / C(2n,n) = n² / (2n(2n−1))`.  Combining the two yields the
+clean closed form for the **variance**
+
+  Var[k] = E[k²] − (n/2)² = n² / (4(2n−1)),
+
+the textbook variance of this hypergeometric law.  The absorption identity that
+proves (★) is the algebraic engine behind that formula.
+
+## Results
+
+1. `sum_sq_weighted_sq_succ` — the subtraction-free form
+   `∑_{k=0}^{m+1} k² · C(m+1, k)² = (m+1)² · C(2m, m)`, valid for every `m`.
+2. `sum_sq_weighted_sq` — the classical form (★), `n ≥ 1`.
+3. `sum_sq_weighted_centralBinom` — (1) packaged with `Nat.centralBinom`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ04
+
+open Finset
+
+/-- **Second moment (subtraction-free form).** For every `m`,
+    `∑_{k=0}^{m+1} k² · C(m+1, k)² = (m+1)² · C(2m, m)`.
+
+    The factor `(m+1)²` is what survives the absorption
+    `(j+1)·C(m+1,j+1) = (m+1)·C(m,j)`; writing `n = m+1` keeps the statement
+    free of natural-number subtraction. -/
+theorem sum_sq_weighted_sq_succ (m : ℕ) :
+    ∑ k ∈ range (m + 2), k ^ 2 * ((m + 1).choose k) ^ 2
+      = (m + 1) ^ 2 * (2 * m).choose m := by
+  -- Absorption applied term-by-term to the reindexed (`k = j + 1`) summand.
+  have term : ∀ j ∈ range (m + 1),
+      (j + 1) ^ 2 * ((m + 1).choose (j + 1)) ^ 2 = (m + 1) ^ 2 * (m.choose j) ^ 2 := by
+    intro j _
+    have hkey : (j + 1) * (m + 1).choose (j + 1) = (m + 1) * m.choose j := by
+      rw [Nat.add_one_mul_choose_eq]; ring
+    calc (j + 1) ^ 2 * ((m + 1).choose (j + 1)) ^ 2
+        = ((j + 1) * (m + 1).choose (j + 1)) ^ 2 := by rw [mul_pow]
+      _ = ((m + 1) * m.choose j) ^ 2 := by rw [hkey]
+      _ = (m + 1) ^ 2 * (m.choose j) ^ 2 := by rw [mul_pow]
+  rw [Finset.sum_range_succ', Finset.sum_congr rfl term, ← Finset.mul_sum,
+      ← CombinationsFormulaOQ07.central_binom_eq_sum_sq]
+  simp
+
+/-- **Second moment of the central sum of squares (classical form).**
+    For `n ≥ 1`, `∑_{k=0}^{n} k² · C(n, k)² = n² · C(2n − 2, n − 1)`. -/
+theorem sum_sq_weighted_sq (n : ℕ) (hn : 1 ≤ n) :
+    ∑ k ∈ range (n + 1), k ^ 2 * (n.choose k) ^ 2 = n ^ 2 * (2 * n - 2).choose (n - 1) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  rw [show 2 * (m + 1) - 2 = 2 * m from by omega, show m + 1 - 1 = m from by omega,
+      show m + 1 + 1 = m + 2 from by omega]
+  exact sum_sq_weighted_sq_succ m
+
+/-- **Second moment via `Nat.centralBinom`.** Packages `sum_sq_weighted_sq_succ`
+    using Mathlib's central binomial coefficient: the second moment of row
+    `m + 1` is `(m+1)²` times the central binomial coefficient of row `m`. -/
+theorem sum_sq_weighted_centralBinom (m : ℕ) :
+    ∑ k ∈ range (m + 2), k ^ 2 * ((m + 1).choose k) ^ 2
+      = (m + 1) ^ 2 * Nat.centralBinom m := by
+  rw [sum_sq_weighted_sq_succ, Nat.centralBinom]
+
+/-- Sanity check: `∑_{k=0}^{3} k²·C(3,k)² = 0 + 9 + 4·9 + 9·1 = 54 = 9·C(4,2) = 9·6`. -/
+example : ∑ k ∈ range 4, k ^ 2 * ((3 : ℕ).choose k) ^ 2 = 54 := by decide
+
+/-- Sanity check of the closed form at `n = 3`: `54 = 3² · C(4, 2)`. -/
+example : ∑ k ∈ range 4, k ^ 2 * ((3 : ℕ).choose k) ^ 2
+    = 3 ^ 2 * (2 * 3 - 2).choose (3 - 1) := by decide
+
+end CombinationsFormulaOQ07OQ04

--- a/src/data/proofs/combinations-formula-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "secondmoment-context",
+    "proofId": "combinations-formula-oq-07-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 66
+    },
+    "type": "concept",
+    "title": "Weighting the Sum of Squares by k²: A Second Moment",
+    "content": "The parent entry proves the central sum of squares C(2n,n) = ∑_{k=0}^{n} C(n,k)², and the sibling oq-07-oq-03 weights it by k to get the first moment. This entry weights by k². The result, ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1, is a second-moment identity: reading p_k = C(n,k)²/C(2n,n) as the hypergeometric distribution on {0,…,n}, the weighted sum is its second moment. Together with the mean n/2 it yields the variance n²/(4(2n−1)). Crucially, unlike the first moment, no reflection is needed — a single squared absorption identity collapses each term.",
+    "mathContext": "$\\sum_{k=0}^{n} k^2\\binom{n}{k}^2 = n^2\\binom{2n-2}{n-1}$. Probabilistically, with $p_k = \\binom{n}{k}^2/\\binom{2n}{n}$, the second moment is $\\sum_k k^2 p_k = n^3/(2(2n-1))$, giving variance $n^2/(4(2n-1))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares of binomial coefficients",
+      "second moment / weighted sum",
+      "hypergeometric distribution and variance",
+      "absorption identity",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "absorption k·C(n,k) = n·C(n-1,k-1)",
+      "the parent identity C(2n,n) = ∑ C(n,k)²"
+    ]
+  },
+  {
+    "id": "succ-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-04",
+    "range": {
+      "startLine": 78,
+      "endLine": 93
+    },
+    "type": "theorem",
+    "title": "The Second Moment (Subtraction-Free Form)",
+    "content": "sum_sq_weighted_sq_succ establishes ∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m). The proof's engine is the term lemma: squaring the absorption identity Nat.add_one_mul_choose_eq, which gives (j+1)·C(m+1,j+1) = (m+1)·C(m,j), turns each summand (j+1)²·C(m+1,j+1)² into (m+1)²·C(m,j)². Finset.sum_range_succ' peels off the vanishing k=0 term and reindexes the rest as k = j+1; Finset.mul_sum extracts the constant (m+1)²; and the parent's central_binom_eq_sum_sq applied to row m evaluates ∑_{j=0}^{m} C(m,j)² = C(2m,m).",
+    "mathContext": "$k^2\\binom{n}{k}^2 = (k\\binom{n}{k})^2 = (n\\binom{n-1}{k-1})^2 = n^2\\binom{n-1}{k-1}^2$, so the sum becomes $n^2\\sum_{j} \\binom{n-1}{j}^2 = n^2\\binom{2n-2}{n-1}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.add_one_mul_choose_eq",
+      "Finset.sum_range_succ'",
+      "Finset.mul_sum",
+      "absorption identity",
+      "squaring an exact identity"
+    ],
+    "prerequisites": [
+      "summation over Finset.range",
+      "reindexing a finite sum",
+      "the absorption identity for binomial coefficients"
+    ]
+  },
+  {
+    "id": "classical-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-04",
+    "range": {
+      "startLine": 97,
+      "endLine": 102
+    },
+    "type": "theorem",
+    "title": "The Classical Form",
+    "content": "sum_sq_weighted_sq states the result in its familiar form: ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1. It is obtained from the subtraction-free form by writing n = m+1 and rewriting 2(m+1)−2 = 2m and (m+1)−1 = m. The n ≥ 1 hypothesis is needed only to make the truncated subtractions 2n−2 and n−1 mean what the mathematics intends; the underlying content is the all-n subtraction-free identity.",
+    "mathContext": "$\\sum_{k=0}^{n} k^2\\binom{n}{k}^2 = n^2\\binom{2n-2}{n-1}$, $n \\geq 1$. This is the closed form posed as an open question by the first-moment sibling.",
+    "significance": "key",
+    "relatedConcepts": [
+      "natural-number subtraction",
+      "central binomial coefficient of the predecessor row",
+      "second moment closed form"
+    ],
+    "prerequisites": [
+      "the subtraction-free form sum_sq_weighted_sq_succ",
+      "arithmetic of truncated subtraction (omega)"
+    ]
+  },
+  {
+    "id": "centralbinom-thm",
+    "proofId": "combinations-formula-oq-07-oq-04",
+    "range": {
+      "startLine": 107,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "Packaging via Nat.centralBinom",
+    "content": "sum_sq_weighted_centralBinom restates the second moment using Mathlib's central binomial coefficient: ∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·centralBinom(m). Since Nat.centralBinom m is definitionally C(2m,m), this connects the new identity to Mathlib's existing API and makes the row-shift explicit — the second moment of row m+1 is (m+1)² times the central binomial coefficient of row m.",
+    "mathContext": "$\\sum_{k=0}^{m+1} k^2\\binom{m+1}{k}^2 = (m+1)^2\\,\\mathrm{centralBinom}(m)$, where $\\mathrm{centralBinom}(m) = \\binom{2m}{m}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.centralBinom",
+      "definitional unfolding",
+      "Mathlib API integration"
+    ],
+    "prerequisites": [
+      "Nat.centralBinom definition",
+      "the subtraction-free form sum_sq_weighted_sq_succ"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-04/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-04/meta.json
@@ -1,0 +1,137 @@
+{
+  "id": "combinations-formula-oq-07-oq-04",
+  "title": "The Second Moment of the Sum of Squares of Binomial Coefficients",
+  "slug": "combinations-formula-oq-07-oq-04",
+  "description": "Weights the parent's central sum of squares C(2n,n) = ∑ C(n,k)² by k², yielding the second-moment identity ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1. This directly answers the open question posed by the first-moment sibling oq-07-oq-03. Unlike the first moment, no reflection is needed: a single absorption k·C(n,k) = n·C(n−1,k−1) gives k²·C(n,k)² = n²·C(n−1,k−1)², so the k=0 term vanishes, reindexing k = j+1 pulls out n², and the parent identity applied to row n−1 finishes. Reading C(n,k)²/C(2n,n) as a hypergeometric distribution, this is its second moment n³/(2(2n−1)); combined with the mean n/2 it gives the variance n²/(4(2n−1)).",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ04.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 119,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. The subtraction-free form ∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m) is fully machine-checked for all m; the classical form ∑ k²·C(n,k)² = n²·C(2n−2,n−1) is stated for n ≥ 1. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "sum-of-squares",
+      "weighted-sum",
+      "second-moment",
+      "absorption",
+      "central-binomial",
+      "hypergeometric"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "sum_sq_weighted_sq_succ: the second-moment identity ∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m) in subtraction-free form, a squared-index companion to the parent's C(2n,n) = ∑ C(n,k)² and the sibling's first moment, absent from Mathlib",
+      "sum_sq_weighted_sq: the classical closed form ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1, directly answering the open question raised by oq-07-oq-03",
+      "sum_sq_weighted_centralBinom: the second moment packaged via Mathlib's Nat.centralBinom, expressing the result as (m+1)²·centralBinom(m)",
+      "The absorption route k²·C(n,k)² = (k·C(n,k))² = (n·C(n−1,k−1))² = n²·C(n−1,k−1)², which needs no reflection and reduces the whole sum to the parent identity on the predecessor row",
+      "Worked check ∑_{k=0}^{3} k²·C(3,k)² = 0 + 9 + 36 + 9 = 54 = 3²·C(4,2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_one_mul_choose_eq",
+        "description": "The absorption identity (n+1)·C(n,k) = C(n+1,k+1)·(k+1). Rearranged to (j+1)·C(m+1,j+1) = (m+1)·C(m,j), it converts each squared term (j+1)²·C(m+1,j+1)² into (m+1)²·C(m,j)², which is the entire engine of the proof.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "∑_{i ∈ range (n+1)} f i = (∑_{i ∈ range n} f (i+1)) + f 0. Peels off the vanishing k=0 term and reindexes the remaining sum as k = j+1, the form on which absorption acts.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b·∑ f = ∑ (b·f). Used in reverse to pull the constant (m+1)² out of the reindexed sum so the parent identity can be applied to what remains.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07.central_binom_eq_sum_sq",
+        "description": "The parent identity C(2n,n) = ∑_{k=0}^{n} C(n,k)². Applied to row m, it evaluates the reindexed sum ∑_{j=0}^{m} C(m,j)² as C(2m,m); the entire weighted result rests on it.",
+        "module": "Proofs.CombinationsFormulaOQ07"
+      },
+      {
+        "theorem": "Nat.centralBinom",
+        "description": "Mathlib's central binomial coefficient centralBinom(n) = C(2n,n). Used to package the second moment as (m+1)²·centralBinom(m), connecting the result to Mathlib's existing API.",
+        "module": "Mathlib.Combinatorics.Choose.Central"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ04.lean",
+    "namespace": "CombinationsFormulaOQ07OQ04",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 119,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The sum of squares of a Pascal row, ∑_{k} C(n,k)² = C(2n,n), is the most quoted special case of Vandermonde's convolution and the subject of the parent entry. Its moments turn this counting identity into a probabilistic statement: reading p_k = C(n,k)²/C(2n,n) as the hypergeometric law for the number of items drawn from the first half when n of 2n items are chosen, ∑ k·p_k is the mean and ∑ k²·p_k is the second moment. The sibling oq-07-oq-03 computed the mean (n/2); this entry computes the second moment, from which the variance follows. Weighted binomial sums of this kind are catalogued in Gould's Combinatorial Identities (1972); the absorption identity k·C(n,k) = n·C(n−1,k−1) used here is the same one that yields ∑ k·C(n,k) = n·2^{n−1}. Mathlib carries the unweighted and alternating row sums and the central binomial coefficient, but none of the squared-coefficient moments.",
+    "problemStatement": "Open Question OQ-07-OQ-04 (raised explicitly by oq-07-oq-03): the parent proves C(2n,n) = ∑_{k=0}^{n} C(n,k)² and the first-moment sibling proves 2·∑ k·C(n,k)² = n·C(2n,n). What is the second moment ∑_{k=0}^{n} k²·C(n,k)²? Find and formalize its closed form, and identify the structural mechanism behind it.",
+    "proofStrategy": "Write n = m+1 to stay subtraction-free. The key is absorption: Nat.add_one_mul_choose_eq gives (j+1)·C(m+1,j+1) = (m+1)·C(m,j), so squaring yields (j+1)²·C(m+1,j+1)² = (m+1)²·C(m,j)² (the term lemma). The k=0 summand vanishes, so Finset.sum_range_succ' rewrites ∑_{k=0}^{m+1} k²·C(m+1,k)² as the reindexed sum ∑_{j=0}^{m} (j+1)²·C(m+1,j+1)²; applying the term lemma turns each summand into (m+1)²·C(m,j)², Finset.mul_sum pulls out the constant (m+1)², and the parent's central_binom_eq_sum_sq on row m evaluates ∑_{j=0}^{m} C(m,j)² = C(2m,m) (sum_sq_weighted_sq_succ). The classical form ∑ k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1 then follows by substituting n = m+1 and rewriting 2(m+1)−2 = 2m, (m+1)−1 = m (sum_sq_weighted_sq). A final packaging expresses C(2m,m) as Nat.centralBinom m (sum_sq_weighted_centralBinom).",
+    "keyInsights": [
+      "Unlike the first moment, the second moment needs no reflection: absorption alone collapses each term, because k²·C(n,k)² = (k·C(n,k))² and k·C(n,k) = n·C(n−1,k−1) is an exact identity that squares cleanly.",
+      "Squaring the absorption identity is the whole proof — it converts a second moment on row n into a constant n² times the zeroth moment (sum of squares) on row n−1, which the parent identity already evaluates.",
+      "The answer is again a single central binomial coefficient, now of the predecessor row: n²·C(2n−2,n−1). The pattern (zeroth moment → C(2n,n), second moment → n²·C(2n−2,n−1)) reflects how each index weight shifts the central coefficient down one row.",
+      "Stating the result subtraction-free as ∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m) makes it valid for all m and avoids the n ≥ 1 hypothesis needed only to write 2n−2 and n−1 under truncated subtraction.",
+      "Probabilistically the second moment is n³/(2(2n−1)) (using C(2n−2,n−1)/C(2n,n) = n²/(2n(2n−1))); combined with the sibling's mean n/2 it gives the clean hypergeometric variance n²/(4(2n−1))."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Header stating OQ-07-OQ-04: weighting the parent's central sum of squares by k², the absorption proof of ∑ k²·C(n,k)² = n²·C(2n−2,n−1), and the hypergeometric second-moment/variance interpretation."
+    },
+    {
+      "id": "succ-form",
+      "title": "The Second Moment (Subtraction-Free Form)",
+      "startLine": 72,
+      "endLine": 93,
+      "summary": "sum_sq_weighted_sq_succ: ∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m). The term lemma squares the absorption identity Nat.add_one_mul_choose_eq; Finset.sum_range_succ' drops the k=0 term and reindexes, Finset.mul_sum extracts (m+1)², and the parent's central_binom_eq_sum_sq finishes."
+    },
+    {
+      "id": "classical-form",
+      "title": "The Classical Form",
+      "startLine": 95,
+      "endLine": 102,
+      "summary": "sum_sq_weighted_sq: ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) for n ≥ 1, obtained from the subtraction-free form by substituting n = m+1 and simplifying 2n−2 = 2m, n−1 = m."
+    },
+    {
+      "id": "central-binom",
+      "title": "Packaging via Nat.centralBinom",
+      "startLine": 104,
+      "endLine": 118,
+      "summary": "sum_sq_weighted_centralBinom: expresses the second moment as (m+1)²·centralBinom(m) using Mathlib's central binomial coefficient; with the numeric check ∑_{k=0}^{3} k²·C(3,k)² = 54 = 3²·C(4,2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "3 theorems, 0 sorries, 0 axioms. The second-moment identity ∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1) (n ≥ 1) weights the parent's central sum of squares by k² and answers the open question left by the first-moment sibling oq-07-oq-03. The proof is a single squared absorption identity against the parent identity — no reflection, induction, or generating functions.",
+    "implications": "Adds a squared-coefficient second-moment identity that Mathlib lacks, built on its absorption lemma and the parent's sum of squares. The technique — square the absorption identity k·C(n,k) = n·C(n−1,k−1) to reduce a second moment on row n to a constant times the zeroth moment on row n−1 — is a reusable route to higher moments of squared binomial sums, and the C(n,k)²/C(2n,n) hypergeometric reading completes the mean/second-moment/variance trio (mean n/2, second moment n³/(2(2n−1)), variance n²/(4(2n−1))).",
+    "openQuestions": [
+      "Do the higher moments ∑_{k=0}^{n} k^r·C(n,k)² for r ≥ 3 admit closed forms as integer combinations of central binomial coefficients C(2n−2j, n−j)? Iterating the squared absorption suggests each weight shifts the row down, but cross terms appear for r ≥ 3.",
+      "Is there a single generating identity ∑_{k} x^k·C(n,k)² = C(2n,n)·(hypergeometric in x) whose r-th derivative at x=1 reproduces these moments, and can it be formalized over ℚ[x]?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07-oq-03",
+      "relationship": "sibling and direct predecessor — computes the first moment 2·∑ k·C(n,k)² = n·C(2n,n) and explicitly poses the second moment as an open question; this entry answers it with ∑ k²·C(n,k)² = n²·C(2n−2,n−1)"
+    },
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "parent — proves the unweighted C(2n,n) = ∑ C(n,k)²; this entry weights that sum by k² and reuses the parent identity on the predecessor row n−1"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "sibling — the multiplicative subset-of-a-subset companion, whose absorption identity k·C(n,k) = n·C(n−1,k−1) is exactly the lemma squared here to drive the second moment"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Weights the parent's central sum of squares `C(2n,n) = ∑ C(n,k)²` by **k²** — the squared-index companion to the first-moment sibling `oq-07-oq-03`, which explicitly posed this second moment as an open question. The closed form is

  **∑_{k=0}^{n} k²·C(n,k)² = n²·C(2n−2,n−1)**  (n ≥ 1),

stated subtraction-free as `∑_{k=0}^{m+1} k²·C(m+1,k)² = (m+1)²·C(2m,m)`. Not in Mathlib.

## The absorption proof

Unlike the first moment, **no reflection** is needed. A single squared application of absorption collapses every term:

  k²·C(n,k)² = (k·C(n,k))² = (n·C(n−1,k−1))² = n²·C(n−1,k−1)².

The `k=0` term vanishes, so reindexing `k = j+1` pulls out the constant `n²` and leaves exactly the parent sum of squares over row `n−1`, evaluated by `central_binom_eq_sum_sq`.

## Probabilistic payoff

Reading `C(n,k)²/C(2n,n)` as the hypergeometric distribution on `{0,…,n}`: this is the second moment `n³/(2(2n−1))`, and with the sibling's mean `n/2` it gives the clean variance **n²/(4(2n−1))** — completing the mean/second-moment/variance trio for the central sum-of-squares law.

## Results (3 theorems, 0 sorries, 0 axioms)

- `sum_sq_weighted_sq_succ` — subtraction-free form, all `m`
- `sum_sq_weighted_sq` — classical form `n²·C(2n−2,n−1)`, `n ≥ 1`
- `sum_sq_weighted_centralBinom` — packaged via `Nat.centralBinom`

Builds against Mathlib via the Docker wrapper. No `native_decide`; numeric checks use kernel `decide`. Foundational axioms only (propext/Classical.choice/Quot.sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)