### PR TITLE
Research: binomial-theorem-oq-03-oq-01 — combinatorial moments of the binomial coefficients (0-axiom verified)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ03OQ01.lean
@@ -1,0 +1,145 @@
+/-
+# Combinatorial Moments of the Binomial Coefficients (OQ-03-OQ-01)
+
+Research Question (follow-up to OQ-03 "Binomial Distribution from the Binomial
+Theorem"): the parent derives the *probabilistic* moments of the binomial
+distribution over ℝ — the mean `E[X] = np` and the variance `np(1-p)` — by
+weighting `C(n,k)` with `pᵏ(1-p)ⁿ⁻ᵏ`.  What are the *unweighted* combinatorial
+moments, i.e. the closed forms of the plain integer sums
+
+    Σ_{k=0}^{n} k · C(n,k),   Σ_{k=0}^{n} k(k-1) · C(n,k),   Σ_{k=0}^{n} k² · C(n,k) ?
+
+These are the `p = 1` / counting analogues of the probabilistic moments, and
+they are NOT in Mathlib (Mathlib has `Nat.sum_range_choose : Σ C(n,k) = 2ⁿ`
+— the zeroth moment — but none of the higher ones).
+
+Answer.  All three have clean closed forms, obtained from the single
+*absorption* identity `(k+1)·C(n+1,k+1) = (n+1)·C(n,k)` (already proved in the
+parent) together with the zeroth-moment `Σ C(n,k) = 2ⁿ`:
+
+    Σ k · C(n,k)      = n · 2ⁿ⁻¹
+    Σ k(k-1) · C(n,k) = n(n-1) · 2ⁿ⁻²
+    Σ k² · C(n,k)     = n(n+1) · 2ⁿ⁻²
+
+The mechanism is exactly the `xⁿ ↦ derivative at x=1` of `(1+x)ⁿ = Σ C(n,k)xᵏ`,
+done purely combinatorially over ℕ (no analysis, no casts).  Subtraction-free
+"successor" forms are proved first to keep everything inside ℕ, then the
+headline forms with `2ⁿ⁻¹` / `2ⁿ⁻²` follow.
+
+Tags: combinatorics, binomial-coefficients, moments, absorption, generating-functions
+-/
+
+import Mathlib
+import Proofs.BinomialTheoremOQ03
+
+open Finset BigOperators
+
+namespace BinomialTheoremOQ03OQ01
+
+/-! ## Part I: First combinatorial moment  Σ k·C(n,k) = n·2ⁿ⁻¹ -/
+
+/-- Subtraction-free form of the first moment.  Summing `k·C(n+1,k)` over the
+full range `0 ≤ k ≤ n+1` gives `(n+1)·2ⁿ`.  Proved by peeling the vanishing
+`k = 0` term, reindexing `k ↦ k+1`, and applying absorption term-by-term to
+collapse the sum to `(n+1)·Σ C(n,k) = (n+1)·2ⁿ`. -/
+theorem sum_id_mul_choose_succ (n : ℕ) :
+    ∑ k ∈ range (n + 2), k * (n + 1).choose k = (n + 1) * 2 ^ n := by
+  rw [Finset.sum_range_succ']
+  simp only [Nat.zero_mul, add_zero]
+  -- goal: Σ x ∈ range (n+1), (x+1) * C(n+1, x+1) = (n+1) * 2^n
+  rw [← Nat.sum_range_choose n, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  -- (k+1) * C(n+1, k+1) = (n+1) * C(n, k)
+  exact BinomialTheoremOQ03.absorption n k
+
+/-- **First combinatorial moment.**  `Σ_{k=0}^{n} k · C(n,k) = n · 2ⁿ⁻¹`.
+This is the counting (`p = 1`) analogue of the binomial mean `E[X] = np`. -/
+theorem sum_id_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * n.choose k = n * 2 ^ (n - 1) := by
+  cases n with
+  | zero => simp
+  | succ m => simpa using sum_id_mul_choose_succ m
+
+/-! ## Part II: Second factorial moment  Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻² -/
+
+/-- Subtraction-free form of the second factorial moment.  Summing
+`k(k-1)·C(n+2,k)` over `0 ≤ k ≤ n+2` gives `(n+2)(n+1)·2ⁿ`.  Two vanishing
+terms (`k = 0, 1`) are peeled, the index is shifted `k ↦ k+2`, and double
+absorption collapses the result to `(n+2)(n+1)·Σ C(n,k)`. -/
+theorem sum_descFactorial_mul_choose_succ (n : ℕ) :
+    ∑ k ∈ range (n + 3), k * (k - 1) * (n + 2).choose k
+      = (n + 2) * (n + 1) * 2 ^ n := by
+  -- peel k = 0 (term is 0·(0-1)·… = 0)
+  rw [Finset.sum_range_succ']
+  simp only [Nat.zero_mul, Nat.zero_sub, Nat.mul_zero, add_zero]
+  -- now Σ x ∈ range (n+2), (x+1)·((x+1)-1)·C(n+2, x+1)
+  rw [show n + 2 = (n + 1) + 1 from rfl, Finset.sum_range_succ']
+  -- peel the new k = 0 (i.e. original k = 1: term is 1·0·… = 0)
+  simp only [Nat.add_sub_cancel, Nat.zero_add,
+    Nat.sub_self, Nat.mul_zero, Nat.zero_mul, add_zero]
+  -- goal: Σ x ∈ range (n+1), (x+2)·(x+1)·C(n+2, x+2) = (n+2)(n+1)·2^n
+  rw [← Nat.sum_range_choose n, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  -- (k+2)(k+1)·C(n+2, k+2) = (n+2)(n+1)·C(n, k)
+  have h := BinomialTheoremOQ03.double_absorption n k
+  -- normalise the literal `+ 1 + 1` shapes produced by reindexing
+  simpa [Nat.add_sub_cancel] using h
+
+/-- **Second factorial moment.**  `Σ_{k=0}^{n} k(k-1) · C(n,k) = n(n-1) · 2ⁿ⁻²`.
+This is the counting analogue of `E[X(X-1)] = n(n-1)p²` from the parent. -/
+theorem sum_descFactorial_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * (k - 1) * n.choose k = n * (n - 1) * 2 ^ (n - 2) := by
+  match n with
+  | 0 => simp
+  | 1 => decide
+  | (m + 2) => simpa using sum_descFactorial_mul_choose_succ m
+
+/-! ## Part III: Second moment  Σ k²·C(n,k) = n(n+1)·2ⁿ⁻² -/
+
+/-- The pointwise splitting `k² = k(k-1) + k`, valid for *all* `k : ℕ`
+(including `k = 0`, where truncated subtraction gives `0·0 + 0 = 0`). -/
+theorem sq_eq_descFactorial_add_id (k : ℕ) : k ^ 2 = k * (k - 1) + k := by
+  cases k with
+  | zero => rfl
+  | succ j => simp only [Nat.add_sub_cancel, pow_two]; ring
+
+/-- Subtraction-free form of the second moment:
+`Σ k²·C(n+2,k) = (n+2)(n+3)·2ⁿ`.  Obtained by splitting `k² = k(k-1) + k` and
+adding the first moment to the second factorial moment. -/
+theorem sum_sq_mul_choose_succ (n : ℕ) :
+    ∑ k ∈ range (n + 3), k ^ 2 * (n + 2).choose k = (n + 2) * (n + 3) * 2 ^ n := by
+  have hsplit : ∑ k ∈ range (n + 3), k ^ 2 * (n + 2).choose k
+      = (∑ k ∈ range (n + 3), k * (k - 1) * (n + 2).choose k)
+        + ∑ k ∈ range (n + 3), k * (n + 2).choose k := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [sq_eq_descFactorial_add_id k, Nat.add_mul]
+  rw [hsplit, sum_descFactorial_mul_choose_succ n]
+  -- the first moment over range (n+3) is `sum_id_mul_choose_succ (n+1)`
+  have hfirst := sum_id_mul_choose_succ (n + 1)
+  rw [show n + 1 + 2 = n + 3 from rfl, show n + 1 + 1 = n + 2 from rfl] at hfirst
+  rw [hfirst]
+  ring
+
+/-- **Second combinatorial moment.**  `Σ_{k=0}^{n} k² · C(n,k) = n(n+1) · 2ⁿ⁻²`
+for `n ≥ 2`.  This is the counting analogue of `E[X²] = n(n-1)p² + np`; the
+variance identity `Var = E[X²] - E[X]²` of the parent corresponds to
+`n(n+1)2ⁿ⁻² - (n·2ⁿ⁻¹)²/2ⁿ`.  The hypothesis `2 ≤ n` is genuinely needed: at
+`n = 1` the left side is `1` but truncated subtraction makes `2¹⁻² = 2⁰ = 1`,
+giving `1·2·1 = 2 ≠ 1` (the same reason the parent's variance requires `n ≥ 2`);
+the subtraction-free `sum_sq_mul_choose_succ` holds for every `n`. -/
+theorem sum_sq_mul_choose (n : ℕ) (hn : 2 ≤ n) :
+    ∑ k ∈ range (n + 1), k ^ 2 * n.choose k = n * (n + 1) * 2 ^ (n - 2) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  simpa using sum_sq_mul_choose_succ m
+
+/-! ## Part IV: Sanity checks -/
+
+example : ∑ k ∈ range 5, k * (4).choose k = 4 * 2 ^ 3 := by decide
+example : ∑ k ∈ range 5, k ^ 2 * (4).choose k = 4 * 5 * 2 ^ 2 := by decide
+example : ∑ k ∈ range 6, k * (k - 1) * (5).choose k = 5 * 4 * 2 ^ 3 := by decide
+
+end BinomialTheoremOQ03OQ01

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01/annotations.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "moments-context",
+    "proofId": "binomial-theorem-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "From Probabilistic to Combinatorial Moments",
+    "content": "The parent derives the binomial distribution's mean and variance by weighting C(n,k) with pᵏ(1-p)ⁿ⁻ᵏ. Setting p = 1 strips away the probability and leaves the bare counting sums Σ k·C(n,k), Σ k(k-1)·C(n,k), Σ k²·C(n,k). These are exactly the derivatives of the generating function (1+x)ⁿ = Σ C(n,k)xᵏ evaluated at x = 1 — but the whole computation is done over ℕ, with no analysis, using one absorption identity. Mathlib stops at the zeroth moment Σ C(n,k) = 2ⁿ; these higher moments are new.",
+    "mathContext": "$\\sum_k k\\binom{n}{k} = n2^{n-1}$, $\\sum_k k(k-1)\\binom{n}{k} = n(n-1)2^{n-2}$, $\\sum_k k^2\\binom{n}{k} = n(n+1)2^{n-2}$ — the values of $\\frac{d}{dx}, \\frac{d^2}{dx^2}, (x\\frac{d}{dx})^2$ applied to $(1+x)^n$ at $x = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial moments",
+      "generating functions",
+      "absorption identity",
+      "binomial distribution mean and variance"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Σ C(n,k) = 2ⁿ (Nat.sum_range_choose)",
+      "the binomial theorem"
+    ]
+  },
+  {
+    "id": "first-moment-absorption",
+    "proofId": "binomial-theorem-oq-03-oq-01",
+    "range": { "startLine": 45, "endLine": 62 },
+    "type": "technique",
+    "title": "First Moment via a Single Absorption Step",
+    "content": "Peeling the k = 0 term (which vanishes) and reindexing k ↦ k+1 turns every summand into (k+1)·C(n+1,k+1), which absorption rewrites as (n+1)·C(n,k). The constant (n+1) factors out and the remaining Σ C(n,k) = 2ⁿ finishes the job. The subtraction-free succ form is proved first; the headline n·2ⁿ⁻¹ follows by splitting on whether n is zero.",
+    "mathContext": "$\\sum_{k=0}^{n+1} k\\binom{n+1}{k} = \\sum_{k=0}^{n}(k+1)\\binom{n+1}{k+1} = (n+1)\\sum_{k=0}^{n}\\binom{n}{k} = (n+1)2^n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absorption identity (k+1)C(n+1,k+1) = (n+1)C(n,k)",
+      "index shift Finset.sum_range_succ'",
+      "first moment / mean"
+    ],
+    "prerequisites": [
+      "BinomialTheoremOQ03.absorption",
+      "Finset.sum_range_succ'",
+      "Finset.mul_sum"
+    ]
+  },
+  {
+    "id": "second-factorial-double-absorption",
+    "proofId": "binomial-theorem-oq-03-oq-01",
+    "range": { "startLine": 70, "endLine": 97 },
+    "type": "technique",
+    "title": "Second Factorial Moment via Double Absorption",
+    "content": "Two low-index terms (k = 0 and k = 1) vanish because of the k(k-1) weight. Peeling both and shifting the index by two turns each summand into (k+2)(k+1)·C(n+2,k+2), which double absorption collapses to (n+2)(n+1)·C(n,k). The descending-factorial weight k(k-1) is what makes both boundary terms drop out cleanly and is the integer counterpart of the second derivative.",
+    "mathContext": "$\\sum_{k} k(k-1)\\binom{n+2}{k} = (n+2)(n+1)\\sum_k \\binom{n}{k} = (n+2)(n+1)2^n$, i.e. $\\sum_k k(k-1)\\binom{n}{k} = n(n-1)2^{n-2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "double absorption",
+      "falling factorial weights",
+      "second factorial moment E[X(X-1)]"
+    ],
+    "prerequisites": [
+      "BinomialTheoremOQ03.double_absorption",
+      "truncated natural subtraction",
+      "Finset.sum_range_succ' applied twice"
+    ]
+  },
+  {
+    "id": "second-moment-splitting",
+    "proofId": "binomial-theorem-oq-03-oq-01",
+    "range": { "startLine": 103, "endLine": 138 },
+    "type": "insight",
+    "title": "k² = k(k-1) + k Assembles the Ordinary Second Moment",
+    "content": "The ordinary second moment is not proved from scratch: the pointwise identity k² = k(k-1) + k — valid for every natural k, including k = 0 under truncated subtraction — lets Σ k²·C(n,k) be split into the second factorial moment plus the first moment, giving n(n-1)2ⁿ⁻² + n·2ⁿ⁻¹ = n(n+1)2ⁿ⁻². The headline form needs n ≥ 2: at n = 1 the truncated exponent 2¹⁻² = 2⁰ = 1 makes the formula give 2 instead of the true value 1 — the same edge case that forces the parent's variance to assume n ≥ 2.",
+    "mathContext": "$k^2 = k(k-1) + k \\Rightarrow \\sum_k k^2\\binom{n}{k} = n(n-1)2^{n-2} + n2^{n-1} = n(n+1)2^{n-2}$ for $n \\ge 2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "factorial-moment to ordinary-moment conversion",
+      "Stirling numbers of the second kind",
+      "variance decomposition E[X²] = E[X(X-1)] + E[X]"
+    ],
+    "prerequisites": [
+      "sum_id_mul_choose_succ",
+      "sum_descFactorial_mul_choose_succ",
+      "Finset.sum_add_distrib"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "binomial-theorem-oq-03-oq-01",
+  "title": "Combinatorial Moments of the Binomial Coefficients",
+  "slug": "binomial-theorem-oq-03-oq-01",
+  "description": "The unweighted (counting) moments of the binomial coefficients: Σ k·C(n,k) = n·2ⁿ⁻¹, Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻², and Σ k²·C(n,k) = n(n+1)·2ⁿ⁻². These are the p = 1 analogues of the parent's probabilistic mean E[X] = np and variance np(1-p), and none of them are in Mathlib (which has only the zeroth moment Σ C(n,k) = 2ⁿ). All three follow purely combinatorially over ℕ from the single absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k).",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ03OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 145,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Every identity is fully machine-checked over ℕ. The subtraction-free 'successor' forms (sum_id_mul_choose_succ, sum_descFactorial_mul_choose_succ, sum_sq_mul_choose_succ) hold for all n. The headline form sum_sq_mul_choose requires n ≥ 2 — exactly like the parent's variance — because at n = 1 truncated natural subtraction makes 2¹⁻² = 2⁰ = 1 rather than 2⁻¹, so n(n+1)2ⁿ⁻² evaluates to 2 instead of the true value 1. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the three numeric sanity checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "moments",
+      "absorption",
+      "first-moment",
+      "second-moment",
+      "generating-functions",
+      "mathlib-contribution",
+      "research"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "sum_id_mul_choose: the first combinatorial moment Σ_{k=0}^{n} k·C(n,k) = n·2ⁿ⁻¹, the counting (p = 1) analogue of the parent's binomial mean E[X] = np, absent from Mathlib",
+      "sum_descFactorial_mul_choose: the second factorial moment Σ_{k=0}^{n} k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻², the counting analogue of E[X(X-1)] = n(n-1)p²",
+      "sum_sq_mul_choose: the second moment Σ_{k=0}^{n} k²·C(n,k) = n(n+1)·2ⁿ⁻² (for n ≥ 2), the counting analogue of E[X²] = n(n-1)p² + np",
+      "Subtraction-free successor forms (…_succ) that hold for every n and isolate the combinatorial mechanism — peel the vanishing low-index terms, shift the index, and collapse via absorption to (constant)·Σ C(n,k) = (constant)·2ⁿ",
+      "sq_eq_descFactorial_add_id: the ℕ-valid pointwise splitting k² = k(k-1) + k (true even at k = 0 under truncated subtraction), which converts the second moment into first-moment + second-factorial-moment"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_range_choose",
+        "description": "Σ_{m ∈ range (n+1)} C(n,m) = 2ⁿ, the zeroth moment. This is the only binomial-sum moment Mathlib provides; every moment here collapses onto it after absorption.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Σ_{i ∈ range (n+1)} f i = (Σ_{i ∈ range n} f (i+1)) + f 0. Peels the vanishing low-index terms (k = 0 for the first moment, k = 0,1 for the second factorial moment) and reindexes k ↦ k+1 so the absorption identity applies term-by-term.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b · Σ f = Σ (b · f). Distributes the constant (n+1) or (n+2)(n+1) across Σ C(n,k) so the result is read off from the zeroth moment.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "BinomialTheoremOQ03.absorption",
+        "description": "(k+1)·C(n+1,k+1) = (n+1)·C(n,k), proved in the parent. The single engine behind the first moment: it is the combinatorial form of differentiating (1+x)ⁿ and evaluating at x = 1.",
+        "module": "Proofs.BinomialTheoremOQ03"
+      },
+      {
+        "theorem": "BinomialTheoremOQ03.double_absorption",
+        "description": "(k+2)(k+1)·C(n+2,k+2) = (n+2)(n+1)·C(n,k), proved in the parent. Drives the second factorial moment, the combinatorial form of differentiating (1+x)ⁿ twice.",
+        "module": "Proofs.BinomialTheoremOQ03"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "Σ (f + g) = Σ f + Σ g. Splits Σ k²·C(n,k) into Σ k(k-1)·C(n,k) + Σ k·C(n,k) after the pointwise identity k² = k(k-1) + k.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ03OQ01.lean",
+    "namespace": "BinomialTheoremOQ03OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 145,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "overview": [
+    "The parent entry, *Binomial Distribution from the Binomial Theorem*, derives the probabilistic moments of the binomial law over ℝ: weighting each coefficient C(n,k) by pᵏ(1-p)ⁿ⁻ᵏ gives the mean E[X] = np and the variance np(1-p). This follow-up asks the purely combinatorial question hiding inside that derivation: what are the *unweighted* sums Σ k·C(n,k), Σ k(k-1)·C(n,k), and Σ k²·C(n,k)?",
+    "These are the p = 1 (counting) analogues of the probabilistic moments, and — unlike the zeroth moment Σ C(n,k) = 2ⁿ, which Mathlib supplies as `Nat.sum_range_choose` — none of them are in Mathlib. The answers are the clean closed forms n·2ⁿ⁻¹, n(n-1)·2ⁿ⁻², and n(n+1)·2ⁿ⁻².",
+    "Every one of them is the value at x = 1 of a derivative of the generating function (1+x)ⁿ = Σ C(n,k)xᵏ: differentiating once gives Σ k·C(n,k)xᵏ⁻¹ = n(1+x)ⁿ⁻¹, and so on. Here that analytic picture is carried out entirely over ℕ, with no analysis and no casts, using the single absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) borrowed from the parent.",
+    "The mechanism is uniform: peel the low-index terms that vanish, shift the summation index so absorption rewrites each term as a constant times a smaller binomial coefficient, pull the constant out, and finish with the zeroth moment Σ C(n,k) = 2ⁿ. Subtraction-free 'successor' forms are proved first to keep everything inside ℕ; the headline forms with 2ⁿ⁻¹ and 2ⁿ⁻² then follow by case analysis."
+  ],
+  "conclusion": [
+    "The three combinatorial moments Σ k·C(n,k) = n·2ⁿ⁻¹, Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻², and Σ k²·C(n,k) = n(n+1)·2ⁿ⁻² are exactly the integer skeletons of the parent's probabilistic mean and variance, recovered without any reference to probability, real numbers, or the analytic notion of a derivative.",
+    "A single absorption step (k+1)·C(n+1,k+1) = (n+1)·C(n,k) is doing all the work; iterating it gives the factorial moments, and the elementary identity k² = k(k-1) + k assembles the ordinary second moment from them. The same scheme produces every higher moment Σ kʳ·C(n,k) as a 2ⁿ⁻ʳ multiple of a polynomial in n (an Eulerian-number expansion), so this entry is the base of an open-ended ladder.",
+    "Because these closed forms fill a genuine gap in Mathlib's `Nat.Choose.Sum` — which stops at the zeroth moment — they are natural upstream contributions sitting one absorption identity away from material Mathlib already has."
+  ],
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "File docstring stating the research question and the three closed forms, `import Mathlib` together with `import Proofs.BinomialTheoremOQ03` to reuse the parent's absorption lemmas, `open Finset BigOperators`, and the `BinomialTheoremOQ03OQ01` namespace.",
+      "mathContext": "The parent's `absorption` and `double_absorption` are the only non-Mathlib inputs; everything else (`Nat.sum_range_choose`, `Finset.sum_range_succ'`, `Finset.mul_sum`) is standard `Finset` and `Nat.Choose` infrastructure."
+    },
+    {
+      "id": "first-moment",
+      "title": "Part I — First Moment Σ k·C(n,k) = n·2ⁿ⁻¹",
+      "startLine": 39,
+      "endLine": 62,
+      "summary": "`sum_id_mul_choose_succ` proves the subtraction-free form Σ_{k≤n+1} k·C(n+1,k) = (n+1)·2ⁿ by peeling the k = 0 term, reindexing, and applying absorption under `Finset.sum_congr`; `sum_id_mul_choose` derives the headline n·2ⁿ⁻¹ by case analysis on n.",
+      "mathContext": "This is the combinatorial form of d/dx (1+x)ⁿ |ₓ₌₁ = n·2ⁿ⁻¹ and the counting analogue of the parent's mean E[X] = np."
+    },
+    {
+      "id": "second-factorial-moment",
+      "title": "Part II — Second Factorial Moment Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²",
+      "startLine": 64,
+      "endLine": 97,
+      "summary": "`sum_descFactorial_mul_choose_succ` peels the two vanishing terms k = 0, 1, shifts the index by two, and collapses via the parent's `double_absorption` to (n+2)(n+1)·2ⁿ; `sum_descFactorial_mul_choose` gives the headline n(n-1)·2ⁿ⁻² (valid for all n, the (n-1) factor absorbing the n = 1 edge case).",
+      "mathContext": "The combinatorial form of the second derivative d²/dx² (1+x)ⁿ |ₓ₌₁ = n(n-1)·2ⁿ⁻², matching the parent's E[X(X-1)] = n(n-1)p²."
+    },
+    {
+      "id": "second-moment",
+      "title": "Part III — Second Moment Σ k²·C(n,k) = n(n+1)·2ⁿ⁻²",
+      "startLine": 99,
+      "endLine": 138,
+      "summary": "`sq_eq_descFactorial_add_id` proves the ℕ-valid splitting k² = k(k-1) + k; `sum_sq_mul_choose_succ` adds the first and second-factorial moments to get (n+2)(n+3)·2ⁿ; `sum_sq_mul_choose` gives the headline n(n+1)·2ⁿ⁻² for n ≥ 2, with the n = 1 anomaly documented.",
+      "mathContext": "Σ k²·C(n,k) = Σ k(k-1)·C(n,k) + Σ k·C(n,k); the parent's variance Var = E[X²] − E[X]² is the probabilistic shadow of this decomposition."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part IV — Numeric Sanity Checks",
+      "startLine": 139,
+      "endLine": 145,
+      "summary": "Three concrete `decide` checks at n = 4 and n = 5 confirming Σ k·C(4,k) = 32, Σ k²·C(4,k) = 80, and Σ k(k-1)·C(5,k) = 160 against the closed forms.",
+      "mathContext": "Kernel `decide` (not `native_decide`) keeps the checks axiom-free; they guard against transcription errors in the closed-form constants."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "parent",
+      "description": "Provides the probabilistic moments E[X] = np and Var = np(1-p) over ℝ, and the absorption / double_absorption lemmas reused here. This entry extracts the underlying integer (p = 1) moments."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "ancestor",
+      "description": "The binomial theorem (1+x)ⁿ = Σ C(n,k)xᵏ is the generating function whose derivatives at x = 1 are exactly these moments."
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-03",
+      "relationship": "related",
+      "description": "A sibling first-moment identity 2·Σ k·C(n,k)² = n·C(2n,n) for the squared (hypergeometric) weights; this entry treats the plain (binomial) weights C(n,k)."
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
@@ -1,27 +1,35 @@
 {
   "slug": "binomial-theorem-oq-03-oq-01",
-  "title": "[Problem Title]",
+  "title": "Combinatorial Moments of the Binomial Coefficients",
   "phase": "COMPLETED",
   "status": "graduated",
   "tier": "A",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{[LaTeX formulation of the theorem/conjecture]}",
-    "plain": "[Explain what we're trying to prove in accessible terms]",
-    "whyMatters": []
+    "formal": "\\sum_{k=0}^{n} k\\binom{n}{k} = n2^{n-1},\\quad \\sum_{k=0}^{n} k(k-1)\\binom{n}{k} = n(n-1)2^{n-2},\\quad \\sum_{k=0}^{n} k^2\\binom{n}{k} = n(n+1)2^{n-2}",
+    "plain": "The parent derives the binomial distribution mean E[X]=np and variance np(1-p) over the reals by weighting C(n,k) with p^k(1-p)^{n-k}. This follow-up computes the unweighted (p=1, counting) moments of the binomial coefficients themselves. Mathlib has only the zeroth moment sum C(n,k)=2^n; the first, second-factorial, and second moments are new.",
+    "whyMatters": [
+      "Fills a real Mathlib gap: Nat.Choose.Sum stops at the zeroth moment.",
+      "Shows the analytic derivative-of-(1+x)^n picture as a purely combinatorial ℕ computation.",
+      "Base case of the Eulerian-number ladder sum k^r C(n,k) = (polynomial in n)·2^{n-r}."
+    ]
   },
   "knownResults": {
-    "proven": [],
+    "proven": [
+      "sum_id_mul_choose: sum k·C(n,k) = n·2^{n-1}",
+      "sum_descFactorial_mul_choose: sum k(k-1)·C(n,k) = n(n-1)·2^{n-2}",
+      "sum_sq_mul_choose: sum k²·C(n,k) = n(n+1)·2^{n-2} for n≥2"
+    ],
     "open": [],
-    "goal": ""
+    "goal": "Closed forms for the unweighted combinatorial moments of the binomial coefficients, verified 0-axiom."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-04-22T14:36:48+02:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Proved all three moment closed forms via absorption; 0-axiom verified; PR opened.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Possible follow-up: general r-th moment via Eulerian/Stirling numbers.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,17 +37,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "COMPLETE: three combinatorial moment identities proved 0-axiom (145L, 7 thm), reusing parent absorption/double_absorption.",
+    "builtItems": [
+      "sum_id_mul_choose_succ / sum_id_mul_choose (BinomialTheoremOQ03OQ01.lean)",
+      "sum_descFactorial_mul_choose_succ / sum_descFactorial_mul_choose",
+      "sq_eq_descFactorial_add_id: k²=k(k-1)+k over ℕ",
+      "sum_sq_mul_choose_succ / sum_sq_mul_choose"
+    ],
+    "insights": [
+      "All three moments collapse onto Nat.sum_range_choose (sum C=2^n) after one or two absorption steps — the combinatorial form of differentiating (1+x)^n at x=1.",
+      "Subtraction-free succ forms avoid ℕ-truncation artifacts; the n²-moment headline genuinely fails at n=1 (2^{1-2}=2^0=1) so needs n≥2, mirroring the parent variance.",
+      "k²=k(k-1)+k holds for ALL ℕ k including 0, so the ordinary second moment is first+second-factorial with no case split in the splitting step."
+    ],
+    "mathlibGaps": [
+      "Mathlib Nat.Choose.Sum has only Σ C(n,k)=2^n (zeroth moment); no Σ k·C(n,k), Σ k(k-1)·C(n,k), or Σ k²·C(n,k)."
+    ],
+    "nextSteps": [
+      "General r-th moment Σ k^r C(n,k) = 2^{n-r}·(Eulerian/Stirling polynomial in n).",
+      "Upstream the three identities to Mathlib (one absorption identity away from existing material)."
+    ],
     "markdown": "# Knowledge Base: binomial-theorem-oq-03-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [
-    "number-theory  # or: algebra, analysis, topology, combinatorics, etc.",
-    "prime-gaps",
-    "sieve-methods"
+    "combinatorics",
+    "binomial-coefficients",
+    "moments",
+    "absorption",
+    "generating-functions"
   ],
   "relatedProofs": [
     "binomial-theorem",
@@ -69,10 +93,10 @@
     "mathlib": []
   },
   "started": "2026-04-14T17:49:44.227Z",
-  "lastUpdate": "2026-04-14T21:25:05.927Z",
-  "completed": "2026-04-14T21:25:05.927Z",
+  "lastUpdate": "2026-06-22T00:00:00Z",
+  "completed": "2026-06-22T00:00:00Z",
   "significance": 7,
-  "tractability": 6,
+  "tractability": 8,
   "leanFiles": [
     {
       "path": "Proofs/BinomialTheorem.lean",
@@ -326,6 +350,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ04.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ01.lean",
+      "filename": "BinomialTheoremOQ03OQ01.lean",
+      "lineCount": 145,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ01.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to **binomial-theorem-oq-03** (*Binomial Distribution from the Binomial Theorem*), which derives the **probabilistic** moments over ℝ — mean `E[X] = np`, variance `np(1-p)` — by weighting `C(n,k)` with `pᵏ(1-p)ⁿ⁻ᵏ`. This entry computes the **unweighted (counting, p = 1) moments** of the binomial coefficients:

| moment | closed form | analogue |
|--------|-------------|----------|
| `Σ k·C(n,k)` | `n·2ⁿ⁻¹` | mean `np` |
| `Σ k(k-1)·C(n,k)` | `n(n-1)·2ⁿ⁻²` | `E[X(X-1)] = n(n-1)p²` |
| `Σ k²·C(n,k)` | `n(n+1)·2ⁿ⁻²` (n ≥ 2) | `E[X²]` |

**Genuine Mathlib gap:** `Nat.Choose.Sum` provides only the *zeroth* moment `Nat.sum_range_choose : Σ C(n,k) = 2ⁿ`. None of the higher combinatorial moments are in Mathlib.

## Approach

Each moment is the value at `x = 1` of a derivative of the generating function `(1+x)ⁿ = Σ C(n,k)xᵏ`, carried out **purely over ℕ** (no analysis, no casts) using the parent's absorption identity `(k+1)·C(n+1,k+1) = (n+1)·C(n,k)`:

1. Peel the low-index terms that vanish (`k=0`; also `k=1` for the factorial moment).
2. Shift the index so absorption / double-absorption rewrites each term as `(const)·C(n,·)`.
3. Factor the constant out and finish with `Σ C(n,k) = 2ⁿ`.

Subtraction-free `…_succ` forms hold for **all n**; the headline forms follow by case analysis. The ordinary second moment is assembled from `k² = k(k-1) + k` (valid for every `k : ℕ` under truncated subtraction).

## Verification

- **145 lines, 7 theorems, 0 definitions**
- **0 axioms, 0 sorries**, no `native_decide` — builds clean under `docker-build.sh Proofs.BinomialTheoremOQ03OQ01`
- The three numeric sanity checks use **kernel `decide`** (axiom-free; no `Lean.ofReduceBool`)
- `status: verified`, `badge: mathlib`

## Honest scope note

The headline `sum_sq_mul_choose` requires `n ≥ 2`: at `n = 1` truncated subtraction makes `2¹⁻² = 2⁰ = 1` instead of `2⁻¹`, so `n(n+1)2ⁿ⁻²` gives `2 ≠ 1` — the same edge case that forces the parent's variance to assume `n ≥ 2`. The subtraction-free `sum_sq_mul_choose_succ` holds for every `n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)