### PR TITLE
research(combinations-formula-oq-07-oq-05): the alternating sum of squares ∑ (-1)^k·C(n,k)² = if 2∣n then (-1)^{n/2}·C(n,n/2) else 0

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -710,6 +710,7 @@ import Proofs.CombinationsFormulaOQ07
 import Proofs.CombinationsFormulaOQ07OQ01
 import Proofs.CombinationsFormulaOQ07OQ02
 import Proofs.CombinationsFormulaOQ07OQ03
+import Proofs.CombinationsFormulaOQ07OQ05
 import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09
 import Proofs.CompactnessFiniteSubcover

--- a/proofs/Proofs/CombinationsFormulaOQ07OQ05.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ05.lean
@@ -1,0 +1,173 @@
+import Mathlib
+import Proofs.CombinationsFormulaOQ07
+
+/-
+# The Alternating Sum of Squares of Binomial Coefficients
+
+## Open Question OQ-07 → OQ-05
+
+The parent problem `combinations-formula-oq-07` proves the **central binomial
+sum-of-squares**, the diagonal of Vandermonde's convolution:
+
+  ∑_{k=0}^{n} C(n, k)² = C(2n, n).
+
+This file treats its **signed companion**, the alternating sum of squares
+
+  S(n) := ∑_{k=0}^{n} (-1)^k · C(n, k)²,
+
+which is *not* available in Mathlib (Mathlib has only the linear alternating sum
+`Int.alternating_sum_range_choose`, i.e. ∑ (-1)^k C(n,k) = [n = 0]).
+
+The signed sum exhibits a sharp **even/odd dichotomy**:
+
+  S(n) = 0                       if n is odd,
+  S(2m) = (-1)^m · C(2m, m)      if n = 2m is even.
+
+Equivalently, in one closed form,
+
+  S(n) = if 2 ∣ n then (-1)^{n/2} · C(n, n/2) else 0.
+
+## Two independent proofs
+
+* **Generating function (`alt_sum_sq`).**  The whole dichotomy falls out of one
+  coefficient comparison.  Over ℤ[X],
+        (1 - X)^n · (1 + X)^n = (1 - X²)^n.
+  Reading off the coefficient of `X^n`:
+    - the left side, expanded by `coeff_mul` and the binomial coefficients of
+      `(1 ± X)^n`, collapses (via `C(n, n-k) = C(n, k)`) to exactly `S(n)`;
+    - the right side is a polynomial in `X²`, so its `X^n` coefficient is
+      detected by `Polynomial.coeff_expand`: it vanishes unless `2 ∣ n`, in
+      which case it equals `(-1)^{n/2} C(n, n/2)`.
+
+* **Reflection / antisymmetry (`alt_sum_sq_odd_reflect`).**  For the odd case
+  there is a one-line conceptual reason: substituting `k ↦ n - k` and using
+  `C(n, n-k) = C(n, k)` together with `(-1)^{n-k} = -(-1)^k` (valid because `n`
+  is odd) shows `S(n) = -S(n)`, hence `S(n) = 0`.  This is the signed analogue
+  of the fact that the rows of Pascal's triangle are symmetric.
+
+## Mathematical context
+
+`S(n)` is the coefficient of `X^n` in `(1 - X²)^n`; the dichotomy is the
+statement that the "central" coefficient of a polynomial in `X²` only survives
+in even degree.  The even value `(-1)^m C(2m, m)` is, up to sign, the central
+binomial coefficient — the same quantity the *unsigned* sum produces — so the
+alternation precisely sieves out a single signed central term.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ05
+
+open Finset Polynomial
+
+/-- **Coefficients of `(1 - X)^n`.**  `((1 - X)^n).coeff k = (-1)^k · C(n, k)`.
+    Derived from `coeff_X_add_C_pow` after writing `1 - X = -(X + C (-1))`. -/
+theorem coeff_one_sub_X_pow (n k : ℕ) :
+    ((1 - X : ℤ[X]) ^ n).coeff k = (-1) ^ k * (n.choose k : ℤ) := by
+  have h1 : (1 - X : ℤ[X]) = -(X + C (-1 : ℤ)) := by
+    rw [map_neg, map_one]; ring
+  rw [h1, neg_pow,
+      show (-1 : ℤ[X]) ^ n = C ((-1 : ℤ) ^ n) by rw [map_pow, map_neg, map_one],
+      coeff_C_mul, coeff_X_add_C_pow]
+  rcases le_or_gt k n with hkn | hkn
+  · rw [← mul_assoc, ← pow_add, show n + (n - k) = 2 * (n - k) + k from by omega,
+        pow_add, pow_mul, neg_one_sq, one_pow, one_mul]
+  · rw [Nat.choose_eq_zero_of_lt hkn]; simp
+
+/-- **The alternating sum of squares is the `X^n`-coefficient of `(1 - X²)^n`.**
+    Uses the factorization `(1 - X²)^n = (1 - X)^n · (1 + X)^n`, `coeff_mul`,
+    and the symmetry `C(n, n-k) = C(n, k)`. -/
+theorem alt_sum_sq_eq_coeff (n : ℕ) :
+    (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2)
+      = ((1 - X ^ 2 : ℤ[X]) ^ n).coeff n := by
+  have hfac : (1 - X ^ 2 : ℤ[X]) ^ n = (1 - X) ^ n * (1 + X) ^ n := by
+    rw [← mul_pow]; congr 1; ring
+  rw [hfac, coeff_mul,
+      Finset.Nat.sum_antidiagonal_eq_sum_range_succ
+        (fun i j => ((1 - X : ℤ[X]) ^ n).coeff i * ((1 + X : ℤ[X]) ^ n).coeff j) n]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  rw [coeff_one_sub_X_pow, coeff_one_add_X_pow ℤ, Nat.choose_symm hk]
+  ring
+
+/-- **The diagonal coefficient of `(1 - X²)^n`.**  Since `(1 - X²)^n` is a
+    polynomial in `X²`, namely `expand ℤ 2 ((1 - X)^n)`, its `X^n` coefficient is
+    nonzero only in even degree, where `coeff_expand` reads it off. -/
+theorem coeff_one_sub_X_sq_pow_diag (n : ℕ) :
+    ((1 - X ^ 2 : ℤ[X]) ^ n).coeff n
+      = if 2 ∣ n then (-1) ^ (n / 2) * (n.choose (n / 2) : ℤ) else 0 := by
+  have hbase : (1 - X ^ 2 : ℤ[X]) = expand ℤ 2 (1 - X) := by
+    rw [map_sub, map_one, expand_X]
+  have hexp : (1 - X ^ 2 : ℤ[X]) ^ n = expand ℤ 2 ((1 - X) ^ n) := by
+    rw [map_pow, ← hbase]
+  rw [hexp, coeff_expand (by norm_num : (0 : ℕ) < 2)]
+  split_ifs with h
+  · rw [coeff_one_sub_X_pow]
+  · rfl
+
+/-- **Main theorem (generating-function proof).**  The closed form for the
+    alternating sum of squares of binomial coefficients:
+        ∑_{k=0}^{n} (-1)^k C(n,k)² = if 2 ∣ n then (-1)^{n/2} C(n, n/2) else 0. -/
+theorem alt_sum_sq (n : ℕ) :
+    (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2)
+      = if 2 ∣ n then (-1) ^ (n / 2) * (n.choose (n / 2) : ℤ) else 0 := by
+  rw [alt_sum_sq_eq_coeff, coeff_one_sub_X_sq_pow_diag]
+
+/-- **Odd case (corollary).**  For odd `n`, the alternating sum of squares
+    vanishes. -/
+theorem alt_sum_sq_odd {n : ℕ} (hn : Odd n) :
+    (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) = 0 := by
+  have h2 : ¬ (2 ∣ n) := by
+    obtain ⟨j, hj⟩ := hn; rw [hj]; omega
+  rw [alt_sum_sq, if_neg h2]
+
+/-- **Even case (corollary).**  For `n = 2m`, the alternating sum of squares
+    equals the signed central binomial coefficient `(-1)^m C(2m, m)`. -/
+theorem alt_sum_sq_even (m : ℕ) :
+    (∑ k ∈ range (2 * m + 1), (-1 : ℤ) ^ k * ((2 * m).choose k : ℤ) ^ 2)
+      = (-1) ^ m * ((2 * m).choose m : ℤ) := by
+  rw [alt_sum_sq (2 * m), if_pos (dvd_mul_right 2 m),
+      Nat.mul_div_cancel_left m (by norm_num : 0 < 2)]
+
+/-- **Odd case, second proof (reflection / antisymmetry).**  Independent of the
+    polynomial machinery: substituting `k ↦ n - k` (`Finset.sum_range_reflect`)
+    together with `C(n, n-k) = C(n, k)` and `(-1)^{n-k} = -(-1)^k` for odd `n`
+    shows the sum equals its own negation. -/
+theorem alt_sum_sq_odd_reflect {n : ℕ} (hn : Odd n) :
+    (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) = 0 := by
+  have hsum : (∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2)
+      = ∑ k ∈ range (n + 1), -((-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) := by
+    rw [← Finset.sum_range_reflect
+          (fun k => (-1 : ℤ) ^ k * (n.choose k : ℤ) ^ 2) (n + 1)]
+    refine Finset.sum_congr rfl (fun k hk => ?_)
+    rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+    have hidx : n + 1 - 1 - k = n - k := by omega
+    have hsign : (-1 : ℤ) ^ (n - k) = -((-1) ^ k) := by
+      have ha : (-1 : ℤ) ^ (n - k) * (-1) ^ k = -1 := by
+        rw [← pow_add, Nat.sub_add_cancel hk, hn.neg_one_pow]
+      have hb : ((-1 : ℤ) ^ k) * (-1) ^ k = 1 := by
+        rw [← pow_add, ← two_mul]; exact Even.neg_one_pow ⟨k, two_mul k⟩
+      calc (-1 : ℤ) ^ (n - k)
+            = (-1) ^ (n - k) * ((-1) ^ k * (-1) ^ k) := by rw [hb, mul_one]
+        _ = ((-1) ^ (n - k) * (-1) ^ k) * (-1) ^ k := by ring
+        _ = (-1) * (-1) ^ k := by rw [ha]
+        _ = -((-1) ^ k) := by ring
+    show (-1 : ℤ) ^ (n + 1 - 1 - k) * (n.choose (n + 1 - 1 - k) : ℤ) ^ 2
+        = -((-1) ^ k * (n.choose k : ℤ) ^ 2)
+    rw [hidx, Nat.choose_symm hk, hsign]; ring
+  rw [Finset.sum_neg_distrib] at hsum
+  linarith
+
+/-- Sanity check: `n = 2` gives `1 - 4 + 1 = -2 = (-1)^1 · C(2, 1)`. -/
+example : (∑ k ∈ Finset.range (2 * 1 + 1), (-1 : ℤ) ^ k * ((2 * 1).choose k : ℤ) ^ 2) = -2 := by
+  rw [alt_sum_sq_even 1]; decide
+
+/-- Sanity check: `n = 4` gives `1 - 16 + 36 - 16 + 1 = 6 = (-1)^2 · C(4, 2)`. -/
+example : (∑ k ∈ Finset.range (2 * 2 + 1), (-1 : ℤ) ^ k * ((2 * 2).choose k : ℤ) ^ 2) = 6 := by
+  rw [alt_sum_sq_even 2]; decide
+
+/-- Sanity check: `n = 3` (odd) gives `1 - 9 + 9 - 1 = 0`. -/
+example : (∑ k ∈ Finset.range (3 + 1), (-1 : ℤ) ^ k * ((3).choose k : ℤ) ^ 2) = 0 :=
+  alt_sum_sq_odd (by decide)
+
+end CombinationsFormulaOQ07OQ05

--- a/src/data/proofs/combinations-formula-oq-07-oq-05/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-05/annotations.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "signed-context",
+    "proofId": "combinations-formula-oq-07-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Signing the Sum of Squares: A Parity Dichotomy",
+    "content": "The parent entry proves the central sum of squares C(2n,n) = ∑_{k=0}^{n} C(n,k)². This follow-up inserts the alternating sign (-1)^k. The signed sum S(n) = ∑ (-1)^k·C(n,k)² is the coefficient of X^n in (1−X²)^n = (1−X)^n(1+X)^n; because (1−X²)^n is a polynomial in X², that coefficient survives only in even degree. The result is a sharp dichotomy: S(n) = 0 for odd n and S(2m) = (-1)^m·C(2m,m) for even n. Mathlib has the unsigned row sum, the unsigned sum of squares (the parent), and the linear alternating sum, but not this signed sum of squares.",
+    "mathContext": "$\\sum_{k=0}^{n} (-1)^k \\binom{n}{k}^2 = [X^n]\\,(1-X^2)^n = \\begin{cases} (-1)^{n/2}\\binom{n}{n/2} & n \\text{ even}\\\\ 0 & n \\text{ odd}\\end{cases}$. The alternation sieves the full Pascal row down to a single signed central coefficient.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares of binomial coefficients",
+      "alternating / signed sum",
+      "generating functions",
+      "polynomial coefficient extraction",
+      "central binomial coefficient",
+      "parity dichotomy"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "binomial symmetry C(n,k) = C(n,n-k)",
+      "polynomial coefficients and the product rule coeff_mul",
+      "the parent identity C(2n,n) = ∑ C(n,k)²"
+    ]
+  },
+  {
+    "id": "coeff-one-sub-x-thm",
+    "proofId": "combinations-formula-oq-07-oq-05",
+    "range": {
+      "startLine": 65,
+      "endLine": 78
+    },
+    "type": "theorem",
+    "title": "Coefficients of (1 − X)^n",
+    "content": "coeff_one_sub_X_pow establishes ((1−X)^n).coeff k = (-1)^k·C(n,k). Rather than a fresh induction, it reduces to Mathlib's coeff_X_add_C_pow by writing 1 − X = −(X + C(−1)), so (1−X)^n = (-1)^n·(X + C(−1))^n; the latter's coefficient is (-1)^{n−k}·C(n,k), and the parity identity (-1)^n·(-1)^{n−k} = (-1)^k (via neg_one_sq) finishes. The k > n branch is closed by Nat.choose_eq_zero_of_lt.",
+    "mathContext": "$[X^k]\\,(1-X)^n = (-1)^k\\binom{n}{k}$, the binomial theorem with one sign.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binomial theorem",
+      "polynomial coefficients",
+      "sign parity"
+    ],
+    "prerequisites": [
+      "Polynomial.coeff_X_add_C_pow",
+      "Polynomial.coeff_C_mul"
+    ]
+  },
+  {
+    "id": "sum-as-coeff-thm",
+    "proofId": "combinations-formula-oq-07-oq-05",
+    "range": {
+      "startLine": 80,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "The Alternating Sum as a Polynomial Coefficient",
+    "content": "alt_sum_sq_eq_coeff identifies ∑ (-1)^k·C(n,k)² with the coefficient of X^n in (1−X²)^n. The factorization (1−X²)^n = (1−X)^n·(1+X)^n lets coeff_mul expand the X^n coefficient over the antidiagonal as ∑_k ((1−X)^n).coeff k · ((1+X)^n).coeff (n−k) = ∑_k (-1)^k C(n,k)·C(n,n−k); Nat.choose_symm turns C(n,n−k) into C(n,k), assembling the square.",
+    "mathContext": "$\\sum_{k=0}^{n} (-1)^k \\binom{n}{k}^2 = [X^n]\\big((1-X)^n(1+X)^n\\big)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy product of polynomials",
+      "Vandermonde convolution",
+      "binomial symmetry"
+    ],
+    "prerequisites": [
+      "Polynomial.coeff_mul",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ",
+      "Nat.choose_symm"
+    ]
+  },
+  {
+    "id": "diagonal-coeff-thm",
+    "proofId": "combinations-formula-oq-07-oq-05",
+    "range": {
+      "startLine": 96,
+      "endLine": 109
+    },
+    "type": "theorem",
+    "title": "The Diagonal Coefficient via Polynomial.expand",
+    "content": "coeff_one_sub_X_sq_pow_diag computes the X^n coefficient of (1−X²)^n as (-1)^{n/2}·C(n,n/2) when 2∣n and 0 otherwise. The key observation is that (1−X²)^n = expand ℤ 2 ((1−X)^n) — a polynomial in X² — so Polynomial.coeff_expand reads off the diagonal coefficient: it is the (n/2)-th coefficient of (1−X)^n exactly when 2 divides n, which by coeff_one_sub_X_pow is (-1)^{n/2}·C(n,n/2).",
+    "mathContext": "$[X^n]\\,(1-X^2)^n = [X^n]\\,\\mathrm{expand}_2\\big((1-X)^n\\big) = \\mathbf{1}_{2\\mid n}\\,(-1)^{n/2}\\binom{n}{n/2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Polynomial.expand (substitution X ↦ X^p)",
+      "coefficient extraction",
+      "parity / divisibility"
+    ],
+    "prerequisites": [
+      "Polynomial.coeff_expand",
+      "Polynomial.expand_X",
+      "coeff_one_sub_X_pow"
+    ]
+  },
+  {
+    "id": "closed-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-05",
+    "range": {
+      "startLine": 111,
+      "endLine": 134
+    },
+    "type": "theorem",
+    "title": "The Closed Form and Even/Odd Corollaries",
+    "content": "alt_sum_sq combines the two coefficient lemmas into the unified closed form ∑ (-1)^k·C(n,k)² = if 2∣n then (-1)^{n/2}·C(n,n/2) else 0. The corollaries specialize the branch: alt_sum_sq_odd uses if_neg (an odd n is not divisible by 2) to give 0, and alt_sum_sq_even uses if_pos with 2m/2 = m to give the signed central binomial coefficient (-1)^m·C(2m,m).",
+    "mathContext": "$\\sum_{k=0}^{2m} (-1)^k \\binom{2m}{k}^2 = (-1)^m \\binom{2m}{m}$, and $\\sum_{k=0}^{n}(-1)^k\\binom{n}{k}^2 = 0$ for odd $n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "case split on parity",
+      "closed-form evaluation"
+    ],
+    "prerequisites": [
+      "alt_sum_sq_eq_coeff",
+      "coeff_one_sub_X_sq_pow_diag"
+    ]
+  },
+  {
+    "id": "reflection-thm",
+    "proofId": "combinations-formula-oq-07-oq-05",
+    "range": {
+      "startLine": 136,
+      "endLine": 159
+    },
+    "type": "theorem",
+    "title": "Odd Case via Reflection (Antisymmetry)",
+    "content": "alt_sum_sq_odd_reflect reproves the vanishing of the odd-n sum without any generating-function machinery. Finset.sum_range_reflect substitutes k ↦ n−k; Nat.choose_symm restores C(n,k)², and for odd n the sign flips via (-1)^{n−k} = −(-1)^k (a consequence of Odd.neg_one_pow). Thus each reflected term is the negative of the original, the sum equals −itself, and so it is 0 — the signed analogue of Pascal-row symmetry.",
+    "mathContext": "For odd $n$: $S(n) = \\sum_k (-1)^{n-k}\\binom{n}{n-k}^2 = -\\sum_k (-1)^k \\binom{n}{k}^2 = -S(n)$, hence $S(n)=0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflection symmetry",
+      "antisymmetry / sign reversal",
+      "alternative proof"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_reflect",
+      "Nat.choose_symm",
+      "Odd.neg_one_pow"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-05/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-05/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "combinations-formula-oq-07-oq-05",
+  "title": "The Alternating Sum of Squares of Binomial Coefficients",
+  "slug": "combinations-formula-oq-07-oq-05",
+  "description": "The signed companion to the parent's central sum of squares C(2n,n) = ∑ C(n,k)²: the alternating sum S(n) = ∑_{k=0}^{n} (-1)^k·C(n,k)², which Mathlib lacks (it carries only the linear alternating sum ∑ (-1)^k C(n,k) = [n=0]). The sum exhibits a sharp even/odd dichotomy — S(n) = 0 for odd n, and S(2m) = (-1)^m·C(2m,m) for even n — packaged as the single closed form S(n) = if 2∣n then (-1)^{n/2}·C(n,n/2) else 0. Two independent proofs are given: a generating-function argument reading the X^n coefficient of (1−X)^n·(1+X)^n = (1−X²)^n (the X²-structure, detected by Polynomial.coeff_expand, kills odd degrees), and a reflection/antisymmetry argument that for odd n substitutes k ↦ n−k to show S(n) = −S(n).",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ05.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 173,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. All results hold for the stated n (the closed form for all n, the odd corollary for odd n, the even corollary for n = 2m) and are fully machine-checked. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "sum-of-squares",
+      "alternating-sum",
+      "central-binomial",
+      "generating-functions",
+      "polynomial-coefficients",
+      "reflection",
+      "parity"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "alt_sum_sq: the closed form ∑_{k=0}^{n} (-1)^k·C(n,k)² = if 2∣n then (-1)^{n/2}·C(n,n/2) else 0, the signed companion to the parent's unsigned C(2n,n) = ∑ C(n,k)², absent from Mathlib",
+      "alt_sum_sq_eq_coeff: the identification ∑ (-1)^k·C(n,k)² = coefficient of X^n in (1−X²)^n, via the factorization (1−X²)^n = (1−X)^n·(1+X)^n, coeff_mul, and C(n,n−k) = C(n,k)",
+      "coeff_one_sub_X_pow: the coefficients of (1−X)^n, namely ((1−X)^n).coeff k = (-1)^k·C(n,k), derived from coeff_X_add_C_pow",
+      "coeff_one_sub_X_sq_pow_diag: the X^n coefficient of (1−X²)^n is (-1)^{n/2}·C(n,n/2) for even n and 0 for odd n, via Polynomial.expand and coeff_expand",
+      "alt_sum_sq_odd / alt_sum_sq_even: the even/odd dichotomy as corollaries — vanishing for odd n, and the signed central binomial coefficient (-1)^m·C(2m,m) for n = 2m",
+      "alt_sum_sq_odd_reflect: an independent reflection proof of the odd case, showing S(n) = −S(n) by k ↦ n−k for odd n",
+      "Worked checks: ∑ (-1)^k C(2,k)² = -2 = (-1)·C(2,1), ∑ (-1)^k C(4,k)² = 6 = C(4,2), ∑ (-1)^k C(3,k)² = 0"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.coeff_expand",
+        "description": "(expand R p f).coeff n = if p ∣ n then f.coeff (n/p) else 0. With p = 2 and f = (1−X)^n this reads off the X^n coefficient of (1−X²)^n = expand ℤ 2 ((1−X)^n), producing the even/odd dichotomy.",
+        "module": "Mathlib.Algebra.Polynomial.Expand"
+      },
+      {
+        "theorem": "Polynomial.coeff_X_add_C_pow",
+        "description": "((X + C r)^n).coeff k = r^(n−k)·C(n,k). Applied with r = −1 (after writing 1 − X = −(X + C(−1))) to compute the coefficients of (1−X)^n.",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Polynomial.coeff_one_add_X_pow",
+        "description": "((1 + X)^n).coeff k = C(n,k). Supplies the coefficients of the (1+X)^n factor in the coeff_mul expansion.",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Polynomial.coeff_mul",
+        "description": "coeff (p·q) n = ∑ over the antidiagonal of coeff p i · coeff q j. Expands the X^n coefficient of (1−X)^n·(1+X)^n into the convolution that collapses to ∑ (-1)^k C(n,k)².",
+        "module": "Mathlib.Algebra.Polynomial.Coeff"
+      },
+      {
+        "theorem": "Nat.choose_symm",
+        "description": "C(n, n−k) = C(n, k) for k ≤ n. Turns the (1+X)^n factor's coefficient C(n, n−k) into C(n, k), producing the square C(n,k)², and also drives the reflection proof.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑_{j ∈ range n} f(n−1−j) = ∑_{j ∈ range n} f(j). The substitution k ↦ n−k behind the independent reflection proof of the odd case.",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Odd.neg_one_pow",
+        "description": "(-1)^n = -1 for odd n. The sign fact that makes (-1)^{n−k} = −(-1)^k for odd n, so the reflected sum equals the negation of the original.",
+        "module": "Mathlib.Algebra.Ring.Parity"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ05.lean",
+    "namespace": "CombinationsFormulaOQ07OQ05",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 173,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The unsigned sum of squares of a Pascal row, ∑_k C(n,k)² = C(2n,n), is the most quoted special case of Vandermonde's convolution and the subject of the parent entry. Inserting the sign (-1)^k changes its character completely: the alternating sum is the coefficient of X^n in (1−X²)^n = (1−X)^n(1+X)^n, a polynomial in X², so half its coefficients vanish identically. The surviving even-degree value is, up to sign, the same central binomial coefficient the unsigned sum produces — the alternation acts as a sieve selecting a single signed central term. This identity is classical (it appears in Riordan and in Gould's Combinatorial Identities) and is the n-even half of the q=−1 evaluation of the Gaussian binomial; Mathlib carries the unsigned row sum (sum_range_choose), the unsigned sum of squares (the parent), and the linear alternating sum (Int.alternating_sum_range_choose), but not the alternating sum of squares.",
+    "problemStatement": "Open Question OQ-07-OQ-05: the parent entry combinations-formula-oq-07 proves C(2n,n) = ∑_{k=0}^{n} C(n,k)². What is the signed analogue ∑_{k=0}^{n} (-1)^k·C(n,k)²? Formalize the closed form — vanishing for odd n and (-1)^{n/2}·C(n,n/2) for even n — identify the generating-function reason (the X^n coefficient of (1−X²)^n), and give the conceptual one-line reason the odd case vanishes (reflection antisymmetry).",
+    "proofStrategy": "Two routes. (1) Generating function: factor (1−X²)^n = (1−X)^n·(1+X)^n. Expanding the X^n coefficient by Polynomial.coeff_mul and substituting the binomial coefficients of (1±X)^n — ((1−X)^n).coeff k = (-1)^k C(n,k) (coeff_one_sub_X_pow, from coeff_X_add_C_pow) and ((1+X)^n).coeff (n−k) = C(n,n−k) = C(n,k) (coeff_one_add_X_pow, Nat.choose_symm) — collapses it to exactly ∑ (-1)^k C(n,k)² (alt_sum_sq_eq_coeff). Separately, (1−X²)^n = expand ℤ 2 ((1−X)^n) is a polynomial in X², so Polynomial.coeff_expand gives its X^n coefficient as (-1)^{n/2} C(n,n/2) when 2∣n and 0 otherwise (coeff_one_sub_X_sq_pow_diag). Equating the two yields the closed form alt_sum_sq, with the corollaries alt_sum_sq_odd (if_neg) and alt_sum_sq_even (if_pos, 2m/2 = m). (2) Reflection: for odd n, Finset.sum_range_reflect substitutes k ↦ n−k; with Nat.choose_symm and (-1)^{n−k} = −(-1)^k (from Odd.neg_one_pow) the sum equals its own negation, hence is 0 (alt_sum_sq_odd_reflect).",
+    "keyInsights": [
+      "Inserting (-1)^k turns the sum of squares into the X^n coefficient of (1−X²)^n; because this is a polynomial in X², the coefficient is detected only in even total degree, which is the entire source of the even/odd dichotomy.",
+      "Polynomial.expand is the clean device: (1−X²)^n = expand ℤ 2 ((1−X)^n) makes the X²-structure explicit, and coeff_expand reads off the diagonal coefficient as a single binomial term with no case-by-case index juggling.",
+      "The even value (-1)^m·C(2m,m) is the signed central binomial coefficient — the same magnitude the unsigned parent sum gives — so alternation sieves the full Pascal row down to one signed central entry.",
+      "The odd case has a sign-symmetry explanation independent of generating functions: k ↦ n−k sends (-1)^k C(n,k)² to (-1)^{n−k} C(n,k)² = −(-1)^k C(n,k)² for odd n, so the sum is antisymmetric and must vanish.",
+      "The coefficients of (1−X)^n need no new induction: writing 1 − X = −(X + C(−1)) reduces them to Mathlib's coeff_X_add_C_pow, with the sign (-1)^n·(-1)^{n−k} = (-1)^k handled by parity arithmetic."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Header stating OQ-07-OQ-05: the signed companion ∑ (-1)^k C(n,k)² of the parent's central sum of squares, the even/odd dichotomy, the two proof routes (generating function via coeff_expand, reflection antisymmetry), and the central-binomial interpretation."
+    },
+    {
+      "id": "coeff-one-sub-x",
+      "title": "Coefficients of (1 − X)^n",
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "coeff_one_sub_X_pow: ((1−X)^n).coeff k = (-1)^k·C(n,k). Writes 1 − X = −(X + C(−1)) and applies coeff_X_add_C_pow, with the parity identity (-1)^n·(-1)^{n−k} = (-1)^k discharged by neg_one_sq and arithmetic."
+    },
+    {
+      "id": "sum-as-coeff",
+      "title": "The Alternating Sum as a Polynomial Coefficient",
+      "startLine": 80,
+      "endLine": 94,
+      "summary": "alt_sum_sq_eq_coeff: ∑ (-1)^k C(n,k)² equals the X^n coefficient of (1−X²)^n. Uses the factorization (1−X²)^n = (1−X)^n·(1+X)^n, coeff_mul over the antidiagonal, and Nat.choose_symm to assemble the squares."
+    },
+    {
+      "id": "diagonal-coeff",
+      "title": "The Diagonal Coefficient of (1 − X²)^n",
+      "startLine": 96,
+      "endLine": 109,
+      "summary": "coeff_one_sub_X_sq_pow_diag: the X^n coefficient of (1−X²)^n is (-1)^{n/2}·C(n,n/2) for even n and 0 for odd n. Recognizes (1−X²)^n = expand ℤ 2 ((1−X)^n) and applies Polynomial.coeff_expand."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Form and Its Corollaries",
+      "startLine": 111,
+      "endLine": 134,
+      "summary": "alt_sum_sq: the unified closed form ∑ (-1)^k C(n,k)² = if 2∣n then (-1)^{n/2} C(n,n/2) else 0, combining the two coefficient lemmas; alt_sum_sq_odd (vanishing for odd n) and alt_sum_sq_even (the signed central value (-1)^m C(2m,m)) follow as if_neg/if_pos corollaries."
+    },
+    {
+      "id": "reflection",
+      "title": "Odd Case via Reflection",
+      "startLine": 136,
+      "endLine": 159,
+      "summary": "alt_sum_sq_odd_reflect: an independent proof that the odd-n sum vanishes. Finset.sum_range_reflect substitutes k ↦ n−k; with Nat.choose_symm and (-1)^{n−k} = −(-1)^k (Odd.neg_one_pow) the sum equals its negation, so it is 0."
+    },
+    {
+      "id": "checks",
+      "title": "Numeric Checks",
+      "startLine": 161,
+      "endLine": 173,
+      "summary": "Worked sanity checks: ∑ (-1)^k C(2,k)² = 1 − 4 + 1 = -2 = (-1)·C(2,1); ∑ (-1)^k C(4,k)² = 1 − 16 + 36 − 16 + 1 = 6 = C(4,2); ∑ (-1)^k C(3,k)² = 1 − 9 + 9 − 1 = 0 (odd)."
+    }
+  ],
+  "conclusion": {
+    "summary": "7 theorems, 0 sorries, 0 axioms. The alternating sum of squares ∑_{k=0}^{n} (-1)^k·C(n,k)² = if 2∣n then (-1)^{n/2}·C(n,n/2) else 0 — the signed companion to the parent's unsigned C(2n,n) = ∑ C(n,k)² — is proved two ways: a generating-function coefficient comparison on (1−X²)^n = (1−X)^n(1+X)^n, and an independent reflection argument for the vanishing odd case.",
+    "implications": "Adds a signed squared-coefficient identity Mathlib lacks, complementing its unsigned row sum, unsigned sum of squares (the parent), and linear alternating sum. The technique — recognize an alternating coefficient sum as the diagonal coefficient of a product of polynomials, then expose hidden X^p structure with Polynomial.expand to read it off via coeff_expand — is a reusable route to parity dichotomies in binomial sums. The reflection proof records the conceptual reason odd-degree alternating squares vanish: sign-antisymmetry under k ↦ n−k.",
+    "openQuestions": [
+      "What is the alternating weighted sum ∑_{k=0}^{n} (-1)^k·k·C(n,k)² — the signed first moment combining this entry's sign with sibling oq-03's index weight? Reflection should again give an antisymmetry, but the surviving even-n value is no longer a single central term.",
+      "Does the q-analogue hold: is ∑_{k} (-1)^k q^{k²} \\binom{n}{k}_q² (or the simpler ∑ (-1)^k \\binom{n}{k}_q²) governed by the same even/odd vanishing, recovering this identity at q = 1?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "parent — proves the unsigned C(2n,n) = ∑ C(n,k)²; this entry inserts the sign (-1)^k, turning the central binomial value into a parity-dependent signed central coefficient"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-03",
+      "relationship": "sibling — weights the parent sum by the index k (first moment) and also turns on the reflection k ↦ n−k; this entry instead inserts the sign (-1)^k, and its open question on a signed weighted sum is the common refinement of the two"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-02",
+      "relationship": "sibling — the off-diagonal (unsigned) Vandermonde convolution; this entry stays on the diagonal but signs the terms, replacing convolution reindexing with coefficient extraction"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "sibling — the multiplicative subset-of-a-subset companion; both supplement the parent with binomial identities Mathlib does not carry"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

The **signed companion** to the parent `combinations-formula-oq-07` (which proves the unsigned central sum of squares $C(2n,n) = \sum_k C(n,k)^2$). This entry evaluates the **alternating** sum

$$S(n) = \sum_{k=0}^{n} (-1)^k \binom{n}{k}^2 = \begin{cases}(-1)^{n/2}\binom{n}{n/2} & n \text{ even}\\ 0 & n \text{ odd}\end{cases}$$

packaged as the single closed form `if 2∣n then (-1)^(n/2)·C(n,n/2) else 0`. This identity is **not in Mathlib** — it carries only the *linear* alternating sum `Int.alternating_sum_range_choose` ($\sum (-1)^k C(n,k) = [n=0]$).

## Two independent proofs

1. **Generating function (`alt_sum_sq`).** $S(n)$ is the coefficient of $X^n$ in $(1-X)^n(1+X)^n = (1-X^2)^n$. The left factorization, expanded by `coeff_mul` + `Nat.choose_symm`, collapses to $S(n)$; the right side is a polynomial in $X^2$ (recognized as `expand ℤ 2 ((1-X)^n)`), so `Polynomial.coeff_expand` forces the even/odd dichotomy.
2. **Reflection (`alt_sum_sq_odd_reflect`).** For odd $n$, the substitution $k \mapsto n-k$ (via `Finset.sum_range_reflect`) plus $(-1)^{n-k} = -(-1)^k$ shows $S(n) = -S(n)$, hence $0$.

## Verification

- **7 theorems, 0 sorries, 0 `axiom` declarations, 0 definitions**
- **No `native_decide`** — numeric checks use kernel `decide`; only foundational axioms (propext, Classical.choice, Quot.sound)
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.CombinationsFormulaOQ07OQ05` (no warnings)
- Gallery data: `meta.json` + `annotations.json` (6 annotations, startLines on theorem keywords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)