### PR TITLE
Research: binomial-theorem-oq-03-oq-01-oq-01 — the general falling-factorial moment of the binomial coefficients (0-axiom verified)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/BinomialTheoremOQ03OQ01OQ01.lean
@@ -1,0 +1,162 @@
+/-
+# The General Falling-Factorial Moment of the Binomial Coefficients (OQ-03-OQ-01-OQ-01)
+
+Research Question (follow-up to OQ-03-OQ-01 "Combinatorial Moments of the
+Binomial Coefficients").  The parent computed the first three *unweighted*
+moments one at a time,
+
+    Σ k·C(n,k)      = n·2ⁿ⁻¹,
+    Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²,
+    Σ k²·C(n,k)     = n(n+1)·2ⁿ⁻²,
+
+each via the absorption identity `(k+1)·C(n+1,k+1) = (n+1)·C(n,k)`.  Is there a
+*single* closed form that subsumes all of the factorial moments at once?
+
+Answer.  Yes.  Writing `k^(r) = k(k-1)⋯(k-r+1) = Nat.descFactorial k r` for the
+falling factorial, the general identity is
+
+    Σ_{k=0}^{n} k^(r) · C(n,k) = n^(r) · 2ⁿ⁻ʳ            (for all n, r : ℕ)
+
+— the **r-th falling-factorial moment** of the binomial coefficients.  It is the
+combinatorial shadow of differentiating `(1+x)ⁿ = Σ C(n,k)xᵏ` exactly `r` times
+and setting `x = 1`: the r-th derivative of `(1+x)ⁿ` is `n^(r)(1+x)ⁿ⁻ʳ`, worth
+`n^(r)·2ⁿ⁻ʳ` at `x = 1`, while term-by-term it produces `Σ k^(r)·C(n,k)·xᵏ⁻ʳ`.
+Specialising `r = 0, 1, 2` recovers `Σ C = 2ⁿ` (Mathlib's `Nat.sum_range_choose`)
+and the parent's first two factorial moments; none of the positive-order cases is
+in Mathlib.
+
+The proof is a clean induction on `r`.  The single absorption step lifts to the
+recurrence
+
+    S(m+1, r+1) = (m+1) · S(m, r),     S(n, 0) = 2ⁿ,
+
+via `Nat.succ_descFactorial_succ : (k+1)^(r+1) = (k+1)·k^(r)` together with the
+parent's `absorption`.  Iterating the recurrence is exactly the unfolding of
+`n^(r) = n·(n-1)⋯` through `descFactorial`, so the falling factorial appears on
+the right with no extra bookkeeping.  Everything stays inside ℕ; the truncated
+subtraction in `2ⁿ⁻ʳ` is harmless because `n^(r) = 0` whenever `r > n`, killing
+the right-hand side exactly where the left-hand side vanishes too.
+
+Tags: combinatorics, binomial-coefficients, moments, falling-factorial,
+absorption, generating-functions
+-/
+
+import Mathlib
+import Proofs.BinomialTheoremOQ03
+
+open Finset BigOperators
+
+namespace BinomialTheoremOQ03OQ01OQ01
+
+/-! ## Part I: The absorption step lifted to falling-factorial sums -/
+
+/-- **Falling-factorial absorption step.**  Peeling the vanishing `k = 0` term,
+reindexing `k ↦ k+1`, and applying the single absorption identity
+`(k+1)·C(m+1,k+1) = (m+1)·C(m,k)` term-by-term turns the `(r+1)`-th
+falling-factorial sum over `range (m+2)` into `(m+1)` times the `r`-th
+falling-factorial sum over `range (m+1)`.  This is the engine of the induction:
+each differentiation of the generating function drops the upper index by one and
+pulls out a leading factor of `m+1`. -/
+theorem sum_descFactorial_mul_choose_step (m r : ℕ) :
+    ∑ k ∈ range (m + 2), k.descFactorial (r + 1) * (m + 1).choose k
+      = (m + 1) * ∑ k ∈ range (m + 1), k.descFactorial r * m.choose k := by
+  rw [Finset.sum_range_succ']
+  -- the peeled `k = 0` term is `0^(r+1) · C(m+1,0) = 0`
+  rw [Nat.zero_descFactorial_succ, Nat.zero_mul, add_zero, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  -- (k+1)^(r+1) · C(m+1, k+1) = (m+1) · (k^(r) · C(m,k))
+  rw [Nat.succ_descFactorial_succ]
+  have h := BinomialTheoremOQ03.absorption m k
+  calc (k + 1) * k.descFactorial r * (m + 1).choose (k + 1)
+      = k.descFactorial r * ((k + 1) * (m + 1).choose (k + 1)) := by ring
+    _ = k.descFactorial r * ((m + 1) * m.choose k) := by rw [h]
+    _ = (m + 1) * (k.descFactorial r * m.choose k) := by ring
+
+/-! ## Part II: The general falling-factorial moment -/
+
+/-- **General falling-factorial moment.**  For every `n r : ℕ`,
+`Σ_{k=0}^{n} k^(r) · C(n,k) = n^(r) · 2ⁿ⁻ʳ`, where `k^(r) = Nat.descFactorial k r`
+is the falling factorial.  Proved by induction on `r`: the base case `r = 0` is
+the zeroth moment `Σ C(n,k) = 2ⁿ`, and the step is the recurrence
+`sum_descFactorial_mul_choose_step` combined with
+`Nat.succ_descFactorial_succ`.  Holds unconditionally — when `r > n` both sides
+are `0`. -/
+theorem sum_descFactorial_mul_choose (n r : ℕ) :
+    ∑ k ∈ range (n + 1), k.descFactorial r * n.choose k
+      = n.descFactorial r * 2 ^ (n - r) := by
+  induction r generalizing n with
+  | zero =>
+    simp only [Nat.descFactorial_zero, one_mul, Nat.sub_zero]
+    exact Nat.sum_range_choose n
+  | succ r ih =>
+    cases n with
+    | zero => simp
+    | succ m =>
+      rw [sum_descFactorial_mul_choose_step m r, ih m,
+        Nat.succ_descFactorial_succ, Nat.succ_sub_succ]
+      ring
+
+/-! ## Part III: The parent's moments as special cases (subsumption) -/
+
+/-- **r = 1 (first moment).**  `Σ_{k=0}^{n} k · C(n,k) = n · 2ⁿ⁻¹`.  The parent's
+`sum_id_mul_choose`, now a one-line specialisation of the general formula at
+`r = 1` (using `Nat.descFactorial_one : k^(1) = k`). -/
+theorem sum_id_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * n.choose k = n * 2 ^ (n - 1) := by
+  have h := sum_descFactorial_mul_choose n 1
+  simpa [Nat.descFactorial_one] using h
+
+/-- `descFactorial k 2 = k·(k-1)` — the order-2 falling factorial written out. -/
+theorem descFactorial_two (k : ℕ) : k.descFactorial 2 = k * (k - 1) := by
+  rw [show (2 : ℕ) = 1 + 1 from rfl, Nat.descFactorial_succ, Nat.descFactorial_one]
+  ring
+
+/-- **r = 2 (second factorial moment).**  `Σ_{k=0}^{n} k(k-1) · C(n,k) =
+n(n-1) · 2ⁿ⁻²`.  The parent's `sum_descFactorial_mul_choose`, recovered from the
+general formula at `r = 2`. -/
+theorem sum_descFactorial2_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * (k - 1) * n.choose k = n * (n - 1) * 2 ^ (n - 2) := by
+  have hgen := sum_descFactorial_mul_choose n 2
+  rw [descFactorial_two n] at hgen
+  rw [← hgen]
+  apply Finset.sum_congr rfl
+  intro k _
+  rw [descFactorial_two k]
+
+/-! ## Part IV: A genuinely new case — the third factorial moment -/
+
+/-- `descFactorial k 3 = k·(k-1)·(k-2)` — the order-3 falling factorial. -/
+theorem descFactorial_three (k : ℕ) : k.descFactorial 3 = k * (k - 1) * (k - 2) := by
+  rw [show (3 : ℕ) = 1 + 1 + 1 from rfl, Nat.descFactorial_succ, Nat.descFactorial_succ,
+    Nat.descFactorial_one]
+  ring
+
+/-- **r = 3 (third factorial moment).**  `Σ_{k=0}^{n} k(k-1)(k-2) · C(n,k) =
+n(n-1)(n-2) · 2ⁿ⁻³`.  This case is **beyond** what the parent proved and is a
+free instance of the general formula at `r = 3`, illustrating that one single
+result delivers every factorial moment at once. -/
+theorem sum_descFactorial3_mul_choose (n : ℕ) :
+    ∑ k ∈ range (n + 1), k * (k - 1) * (k - 2) * n.choose k
+      = n * (n - 1) * (n - 2) * 2 ^ (n - 3) := by
+  have hgen := sum_descFactorial_mul_choose n 3
+  rw [descFactorial_three n] at hgen
+  rw [← hgen]
+  apply Finset.sum_congr rfl
+  intro k _
+  rw [descFactorial_three k]
+
+/-! ## Part V: Sanity checks -/
+
+-- General formula at small parameters (note `descFactorial` is computable).
+example : ∑ k ∈ range 5, k.descFactorial 1 * (4).choose k = (4).descFactorial 1 * 2 ^ 3 := by
+  decide
+example : ∑ k ∈ range 6, k.descFactorial 2 * (5).choose k = (5).descFactorial 2 * 2 ^ 3 := by
+  decide
+example : ∑ k ∈ range 8, k.descFactorial 3 * (7).choose k = (7).descFactorial 3 * 2 ^ 4 := by
+  decide
+-- The `r > n` degenerate case: both sides vanish.
+example : ∑ k ∈ range 4, k.descFactorial 5 * (3).choose k = (3).descFactorial 5 * 2 ^ (3 - 5) := by
+  decide
+
+end BinomialTheoremOQ03OQ01OQ01

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "general-moment-context",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "One Closed Form for Every Factorial Moment",
+    "content": "The parent computed the r = 1 and r = 2 combinatorial moments by two separate peel-and-absorb arguments. This entry replaces them with a single identity Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ holding for every order r, where k^(r) = Nat.descFactorial k r is the falling factorial. It is the integer shadow of differentiating (1+x)ⁿ = Σ C(n,k)xᵏ exactly r times and setting x = 1: the r-th derivative n^(r)(1+x)ⁿ⁻ʳ is worth n^(r)·2ⁿ⁻ʳ there. The falling factorial — not the ordinary power — is the natural carrier of binomial moments, exactly as for repeated differentiation.",
+    "mathContext": "$\\sum_{k=0}^{n} k^{\\underline{r}}\\binom{n}{k} = n^{\\underline{r}}\\,2^{\\,n-r}$, where $k^{\\underline{r}} = k(k-1)\\cdots(k-r+1)$. The value of $\\frac{d^r}{dx^r}(1+x)^n$ at $x = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "falling factorial / descFactorial",
+      "factorial moments",
+      "generating functions",
+      "repeated differentiation"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Nat.descFactorial falling factorial",
+      "Σ C(n,k) = 2ⁿ (Nat.sum_range_choose)"
+    ]
+  },
+  {
+    "id": "absorption-step-lift",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 74 },
+    "type": "technique",
+    "title": "Lifting Order-1 Absorption to the Recurrence S(m+1,r+1) = (m+1)S(m,r)",
+    "content": "The whole induction runs on one step lemma. Peel the vanishing k = 0 term, reindex k ↦ k+1, then split the falling factorial with Nat.succ_descFactorial_succ : (k+1)^(r+1) = (k+1)·k^(r). The leading (k+1) is exactly what the grandparent's absorption (k+1)·C(m+1,k+1) = (m+1)·C(m,k) consumes, leaving k^(r)·(m+1)·C(m,k). Pulling the constant out gives (m+1) times the r-th moment over the shorter range. So a single order-1 identity, applied term-by-term, drives every order.",
+    "mathContext": "$\\sum_{k=0}^{m+1} k^{\\underline{r+1}}\\binom{m+1}{k} = \\sum_{k=0}^{m}(k+1)k^{\\underline{r}}\\binom{m+1}{k+1} = (m+1)\\sum_{k=0}^{m} k^{\\underline{r}}\\binom{m}{k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absorption identity (k+1)C(n+1,k+1) = (n+1)C(n,k)",
+      "Nat.succ_descFactorial_succ",
+      "index shift Finset.sum_range_succ'"
+    ],
+    "prerequisites": [
+      "BinomialTheoremOQ03.absorption",
+      "Nat.succ_descFactorial_succ",
+      "Nat.zero_descFactorial_succ",
+      "Finset.mul_sum"
+    ]
+  },
+  {
+    "id": "induction-on-order",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 98 },
+    "type": "insight",
+    "title": "Induction on r, with n^(r) Building Itself",
+    "content": "The main theorem is a clean induction on the order r. The base r = 0 is the zeroth moment Σ C(n,k) = 2ⁿ. In the step, applying the lemma turns the (r+1)-moment at n = m+1 into (m+1) times the r-moment at m; the induction hypothesis evaluates that as m^(r)·2^(m-r), and Nat.succ_descFactorial_succ folds the leading (m+1) back in as (m+1)^(r+1) = (m+1)·m^(r). The falling factorial on the right is thus assembled by the very same recurrence that drives the sum. No side condition is needed: when r > n both sides are 0, since n^(r) = 0 and every term k^(r) with k ≤ n < r vanishes.",
+    "mathContext": "Base $r=0$: $\\sum_k\\binom{n}{k}=2^n$. Step: $S(m{+}1,r{+}1)=(m{+}1)S(m,r)=(m{+}1)\\,m^{\\underline{r}}2^{m-r}=(m{+}1)^{\\underline{r+1}}2^{(m+1)-(r+1)}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction on the order of a moment",
+      "truncated natural subtraction (r > n vanishing)",
+      "Nat.succ_sub_succ"
+    ],
+    "prerequisites": [
+      "sum_descFactorial_mul_choose_step",
+      "Nat.sum_range_choose",
+      "Nat.succ_descFactorial_succ"
+    ]
+  },
+  {
+    "id": "subsumption-and-new-cases",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 147 },
+    "type": "insight",
+    "title": "Recovering the Parent and Reaching Beyond It",
+    "content": "Specialising the general formula at r = 1 (using descFactorial_one) gives back the parent's first moment Σ k·C(n,k) = n·2ⁿ⁻¹, and at r = 2 (using descFactorial_two : k^(2) = k(k-1)) gives the second factorial moment Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻² — now one-line corollaries rather than separate theorems. At r = 3 the same theorem hands over the third factorial moment Σ k(k-1)(k-2)·C(n,k) = n(n-1)(n-2)·2ⁿ⁻³, a case the parent never reached, for free. The ordinary power moments Σ kʳ·C(n,k) are one Stirling-number change of basis away.",
+    "mathContext": "$\\sum_k k^{\\underline{3}}\\binom{n}{k} = n^{\\underline{3}}2^{n-3} = n(n-1)(n-2)2^{n-3}$; in general $\\sum_k k^r\\binom{n}{k} = \\sum_j S(r,j)\\,n^{\\underline{j}}2^{n-j}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subsumption of the parent's moments",
+      "third factorial moment",
+      "Stirling numbers of the second kind",
+      "Eulerian-number expansion of power moments"
+    ],
+    "prerequisites": [
+      "sum_descFactorial_mul_choose",
+      "Nat.descFactorial_one",
+      "descFactorial_two",
+      "descFactorial_three"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "binomial-theorem-oq-03-oq-01-oq-01",
+  "title": "The General Falling-Factorial Moment of the Binomial Coefficients",
+  "slug": "binomial-theorem-oq-03-oq-01-oq-01",
+  "description": "A single closed form subsuming every factorial moment of the binomial coefficients: Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ, where k^(r) = Nat.descFactorial k r is the falling factorial. The parent computed the r = 1 and r = 2 moments one at a time; this entry proves all orders at once by induction on r, lifting the single absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) to the recurrence S(m+1,r+1) = (m+1)·S(m,r). It holds unconditionally over ℕ (when r > n both sides vanish), recovers the parent's first two moments as one-line corollaries, and supplies new cases such as the third factorial moment Σ k(k-1)(k-2)·C(n,k) = n(n-1)(n-2)·2ⁿ⁻³. None of the positive-order moments is in Mathlib.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ03OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 162,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. The general identity Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ is fully machine-checked over ℕ for all n, r — no side conditions. Truncated natural subtraction in 2ⁿ⁻ʳ is harmless: when r > n the falling factorial n^(r) is 0, so the right-hand side vanishes exactly where the left-hand side does (every term k^(r) with k ≤ n < r is 0). Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the four numeric sanity checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "moments",
+      "falling-factorial",
+      "descFactorial",
+      "absorption",
+      "generating-functions",
+      "induction",
+      "mathlib-contribution",
+      "research"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "sum_descFactorial_mul_choose: the general r-th falling-factorial moment Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ for all n, r : ℕ, where k^(r) = Nat.descFactorial k r. A single theorem subsuming every factorial moment of the binomial coefficients; absent from Mathlib, which provides only the zeroth moment Σ C(n,k) = 2ⁿ.",
+      "sum_descFactorial_mul_choose_step: the falling-factorial absorption step S(m+1,r+1) = (m+1)·S(m,r), which lifts the parent's single absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) to arbitrary order via Nat.succ_descFactorial_succ. This is the engine of the induction — each differentiation of the generating function drops the upper index by one and pulls out a leading factor of (m+1).",
+      "sum_id_mul_choose and sum_descFactorial2_mul_choose: the parent's first moment (n·2ⁿ⁻¹) and second factorial moment (n(n-1)·2ⁿ⁻²) recovered as one-line specialisations of the general formula at r = 1 and r = 2, demonstrating genuine subsumption.",
+      "sum_descFactorial3_mul_choose: the third factorial moment Σ_{k=0}^{n} k(k-1)(k-2)·C(n,k) = n(n-1)(n-2)·2ⁿ⁻³, a case beyond what the parent proved, delivered for free by the general theorem.",
+      "descFactorial_two and descFactorial_three: the order-2 and order-3 falling factorials written in explicit product form k(k-1) and k(k-1)(k-2), bridging Nat.descFactorial to the parent's notation."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_range_choose",
+        "description": "Σ_{m ∈ range (n+1)} C(n,m) = 2ⁿ, the zeroth moment. This is the only binomial-sum moment Mathlib provides; it is the base case r = 0 of the induction, onto which every higher moment collapses.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Nat.succ_descFactorial_succ",
+        "description": "(k+1).descFactorial (r+1) = (k+1) · k.descFactorial r. Peels the leading factor of the falling factorial so that the absorption identity's (k+1) lines up with it, and simultaneously builds n^(r) on the right-hand side as the recurrence unfolds.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.zero_descFactorial_succ",
+        "description": "(0).descFactorial (r+1) = 0. Kills the peeled k = 0 term in the absorption step and the whole sum in the n = 0 base of the inner case analysis.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "BinomialTheoremOQ03.absorption",
+        "description": "(k+1)·C(n+1,k+1) = (n+1)·C(n,k), proved in the grandparent. The single combinatorial engine — the integer form of differentiating (1+x)ⁿ once — here applied term-by-term at every order of the induction.",
+        "module": "Proofs.BinomialTheoremOQ03"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Σ_{i ∈ range (n+1)} f i = (Σ_{i ∈ range n} f (i+1)) + f 0. Peels the vanishing k = 0 term and reindexes k ↦ k+1 so that absorption applies term-by-term inside the step lemma.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b · Σ f = Σ (b · f). Distributes the pulled-out factor (m+1) across the r-th moment so the step lemma matches term-by-term under Finset.sum_congr.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ03OQ01OQ01.lean",
+    "namespace": "BinomialTheoremOQ03OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 162,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "overview": [
+    "The parent entry, *Combinatorial Moments of the Binomial Coefficients*, computed the first three unweighted moments — Σ k·C(n,k) = n·2ⁿ⁻¹, Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻², Σ k²·C(n,k) = n(n+1)·2ⁿ⁻² — each by a bespoke application of the absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k). This follow-up asks the natural structural question: is there one closed form behind all of them?",
+    "There is. Writing k^(r) = k(k-1)⋯(k-r+1) = Nat.descFactorial k r for the falling factorial, the single identity Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ holds for every n and r. It is the combinatorial shadow of differentiating the generating function (1+x)ⁿ = Σ C(n,k)xᵏ exactly r times and evaluating at x = 1: the r-th derivative is n^(r)(1+x)ⁿ⁻ʳ, worth n^(r)·2ⁿ⁻ʳ at x = 1, while term-by-term it produces Σ k^(r)·C(n,k)·xᵏ⁻ʳ.",
+    "The whole proof is one induction on r. The base case r = 0 is the zeroth moment Σ C(n,k) = 2ⁿ (Mathlib's Nat.sum_range_choose). The inductive engine is a single step lemma that lifts the parent's order-1 absorption to arbitrary order: peeling the vanishing k = 0 term, reindexing k ↦ k+1, and applying absorption term-by-term collapses the (r+1)-th moment over range (m+2) into (m+1) times the r-th moment over range (m+1) — the recurrence S(m+1,r+1) = (m+1)·S(m,r). Iterating it is exactly the unfolding of n^(r) = n·(n-1)⋯ through descFactorial, so the falling factorial materialises on the right with no extra bookkeeping.",
+    "Everything stays inside ℕ. The truncated subtraction in 2ⁿ⁻ʳ never causes trouble: when r > n the falling factorial n^(r) is 0, so both sides vanish — the identity needs no side condition at all. The parent's first two moments fall out as one-line corollaries (r = 1, r = 2), and new cases such as the third factorial moment are free instances of the same theorem."
+  ],
+  "conclusion": [
+    "The general falling-factorial moment Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ packages the entire ladder of combinatorial moments into one unconditional ℕ-identity. Where the parent proved three moments by three separate peel-and-absorb arguments, here a single induction on r does all of them — and every higher order — at once.",
+    "The mathematical content is that the order-1 absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) is the only nontrivial ingredient: lifting it through Nat.succ_descFactorial_succ turns it into the recurrence S(m+1,r+1) = (m+1)·S(m,r), whose solution is precisely n^(r)·2ⁿ⁻ʳ. This makes explicit that the falling factorial — not the ordinary power — is the natural carrier of binomial-coefficient moments, exactly as it is for repeated differentiation.",
+    "The ordinary power moments Σ kʳ·C(n,k) are now one Stirling-number change of basis away (kʳ = Σ_j S(r,j)·k^(j) gives Σ kʳ·C(n,k) = Σ_j S(r,j)·n^(j)·2ⁿ⁻ʲ), and the closed form fills a genuine gap in Mathlib's Nat.Choose.Sum, which stops at the zeroth moment. The result sits one absorption identity away from material Mathlib already has, making it a natural upstream contribution."
+  ],
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "File docstring stating the research question, the general closed form Σ k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ, and the generating-function and recurrence picture; `import Mathlib` together with `import Proofs.BinomialTheoremOQ03` to reuse the grandparent's absorption lemma; `open Finset BigOperators`; the `BinomialTheoremOQ03OQ01OQ01` namespace.",
+      "mathContext": "The grandparent's `absorption` is the only non-Mathlib input. The falling factorial is Mathlib's Nat.descFactorial, with the key recurrence Nat.succ_descFactorial_succ : (k+1)^(r+1) = (k+1)·k^(r)."
+    },
+    {
+      "id": "absorption-step",
+      "title": "Part I — The Absorption Step Lifted to Falling-Factorial Sums",
+      "startLine": 51,
+      "endLine": 74,
+      "summary": "`sum_descFactorial_mul_choose_step` proves the recurrence Σ_{k≤m+1} k^(r+1)·C(m+1,k) = (m+1)·Σ_{k≤m} k^(r)·C(m,k): peel the vanishing k = 0 term (Nat.zero_descFactorial_succ), reindex k ↦ k+1, then rewrite k^(r+1) = (k+1)·k^(r) (Nat.succ_descFactorial_succ) and apply the grandparent's absorption (k+1)·C(m+1,k+1) = (m+1)·C(m,k) under Finset.sum_congr.",
+      "mathContext": "This is the integer form of d/dx applied to the generating function: each differentiation lowers the upper binomial index by one and extracts a leading factor m+1. It is the sole engine of the induction."
+    },
+    {
+      "id": "general-moment",
+      "title": "Part II — The General Falling-Factorial Moment",
+      "startLine": 76,
+      "endLine": 98,
+      "summary": "`sum_descFactorial_mul_choose` proves Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ for all n, r by induction on r. Base r = 0 is Nat.sum_range_choose (Σ C(n,k) = 2ⁿ); the successor case splits on n (the n = 0 sub-case is 0 = 0 since 0^(r+1) = 0) and otherwise applies the step lemma, the induction hypothesis at (m, r), Nat.succ_descFactorial_succ, and Nat.succ_sub_succ.",
+      "mathContext": "The r-th derivative of (1+x)ⁿ is n^(r)(1+x)ⁿ⁻ʳ; evaluating at x = 1 gives n^(r)·2ⁿ⁻ʳ. Holds unconditionally — when r > n both sides are 0."
+    },
+    {
+      "id": "subsumption",
+      "title": "Part III — The Parent's Moments as Special Cases",
+      "startLine": 100,
+      "endLine": 125,
+      "summary": "`sum_id_mul_choose` (Σ k·C(n,k) = n·2ⁿ⁻¹) and `sum_descFactorial2_mul_choose` (Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²) recovered from the general formula at r = 1 and r = 2, using Nat.descFactorial_one and the helper `descFactorial_two : k^(2) = k(k-1)`.",
+      "mathContext": "These are exactly the parent's first moment and second factorial moment, now corollaries rather than independent theorems — concrete evidence that the general identity subsumes the earlier work."
+    },
+    {
+      "id": "third-moment",
+      "title": "Part IV — A Genuinely New Case: The Third Factorial Moment",
+      "startLine": 127,
+      "endLine": 147,
+      "summary": "`descFactorial_three : k^(3) = k(k-1)(k-2)` and `sum_descFactorial3_mul_choose : Σ k(k-1)(k-2)·C(n,k) = n(n-1)(n-2)·2ⁿ⁻³`, a moment beyond the parent's reach, obtained as a free instance of the general theorem at r = 3.",
+      "mathContext": "Demonstrates that the single theorem produces every factorial moment; the third is the combinatorial form of the third derivative of (1+x)ⁿ at x = 1."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part V — Numeric Sanity Checks",
+      "startLine": 149,
+      "endLine": 162,
+      "summary": "Four concrete `decide` checks: the general formula at (r,n) = (1,4), (2,5), (3,7), plus the degenerate r > n case (r,n) = (5,3) where both sides are 0, confirming the closed form including its boundary behaviour.",
+      "mathContext": "Kernel `decide` (not `native_decide`) keeps the checks axiom-free; they guard against transcription errors and verify the unconditional r > n vanishing."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "Computes the first three combinatorial moments (r = 1, 2 and the ordinary second moment) one at a time via absorption and double_absorption. This entry generalises them into the single falling-factorial moment for all orders r and recovers the parent's first two as corollaries."
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "ancestor",
+      "description": "Derives the probabilistic mean E[X] = np and variance np(1-p) over ℝ and supplies the absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) that drives the induction here."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "ancestor",
+      "description": "The binomial theorem (1+x)ⁿ = Σ C(n,k)xᵏ is the generating function whose r-th derivative at x = 1 is exactly the r-th falling-factorial moment proved here."
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-01-oq-01.json
@@ -1,0 +1,99 @@
+{
+  "slug": "binomial-theorem-oq-03-oq-01-oq-01",
+  "title": "The General Falling-Factorial Moment of the Binomial Coefficients",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\sum_{k=0}^{n} k^{\\underline{r}}\\binom{n}{k} = n^{\\underline{r}}\\,2^{\\,n-r}",
+    "plain": "The parent entry computed the first three unweighted combinatorial moments of the binomial coefficients (Σ k·C(n,k), Σ k(k-1)·C(n,k), Σ k²·C(n,k)) one at a time. Is there a single closed form behind all of the factorial moments? Yes: writing k^(r) = k(k-1)⋯(k-r+1) for the falling factorial, Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ for every n and r — the r-th falling-factorial moment, the integer shadow of differentiating (1+x)ⁿ exactly r times and setting x = 1.",
+    "whyMatters": [
+      "Subsumes every factorial moment of the binomial coefficients in one identity",
+      "Fills a genuine gap in Mathlib's Nat.Choose.Sum (which stops at the zeroth moment)"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T11:30:00-07:00",
+    "iteration": 1,
+    "focus": "Generalise the parent's three combinatorial moments into a single falling-factorial moment for all orders.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved the general falling-factorial moment Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ for all n,r:ℕ, 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/BinomialTheoremOQ03OQ01OQ01.lean (162L, 7 thm). Induction on r: base r=0 is Nat.sum_range_choose (Σ C=2ⁿ); step lemma sum_descFactorial_mul_choose_step lifts the grandparent's order-1 absorption (k+1)·C(m+1,k+1)=(m+1)·C(m,k) to the recurrence S(m+1,r+1)=(m+1)·S(m,r) via Nat.succ_descFactorial_succ : (k+1)^(r+1)=(k+1)·k^(r). Unconditional — when r>n both sides are 0 (n^(r)=0). Recovers parent's r=1, r=2 moments as one-line corollaries; new r=3 case for free.",
+    "builtItems": [
+      "Proofs/BinomialTheoremOQ03OQ01OQ01.lean: sum_descFactorial_mul_choose (general r-th falling-factorial moment, 0-axiom)",
+      "sum_descFactorial_mul_choose_step (the absorption recurrence S(m+1,r+1)=(m+1)·S(m,r), reusable engine)",
+      "sum_id_mul_choose, sum_descFactorial2_mul_choose (parent's first two moments recovered as r=1, r=2 corollaries)",
+      "sum_descFactorial3_mul_choose (new third factorial moment), descFactorial_two, descFactorial_three",
+      "src/data/proofs/binomial-theorem-oq-03-oq-01-oq-01/ gallery entry"
+    ],
+    "insights": [
+      "The order-1 absorption identity is the ONLY nontrivial ingredient: lifting it through Nat.succ_descFactorial_succ gives the recurrence S(m+1,r+1)=(m+1)·S(m,r), whose solution is exactly n^(r)·2ⁿ⁻ʳ",
+      "The falling factorial (not the ordinary power) is the natural carrier of binomial-coefficient moments — n^(r) builds itself as the recurrence unfolds",
+      "No side condition needed: truncated subtraction in 2ⁿ⁻ʳ is harmless because n^(r)=0 whenever r>n, killing the RHS exactly where every term k^(r) (k≤n<r) on the LHS vanishes",
+      "Ordinary power moments Σ kʳ·C(n,k) follow by Stirling change of basis: kʳ=Σ_j S(r,j)·k^(j) ⟹ Σ kʳ·C = Σ_j S(r,j)·n^(j)·2ⁿ⁻ʲ"
+    ],
+    "mathlibGaps": [
+      "Mathlib's Nat.Choose.Sum has only the zeroth moment Σ C(n,k)=2ⁿ (Nat.sum_range_choose); no positive-order falling-factorial or power moment — the general identity here is a natural upstream contribution"
+    ],
+    "nextSteps": [
+      "Formalise the ordinary power moments Σ kʳ·C(n,k) via Stirling numbers of the second kind (needs Stirling S(r,j) infrastructure in Mathlib)",
+      "Ascending-factorial / generating-function variants and the analogous identities for Σ k^(r)·C(n,k)·xᵏ"
+    ],
+    "markdown": "# Knowledge Base: binomial-theorem-oq-03-oq-01-oq-01\n\n## Problem Understanding\n\nGeneralise the parent's three unweighted combinatorial moments into a single falling-factorial moment Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ for all orders r.\n\n## Insights\n\nThe single order-1 absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) is the only nontrivial ingredient. Lifting it through `Nat.succ_descFactorial_succ` turns it into the recurrence S(m+1,r+1) = (m+1)·S(m,r), whose solution is n^(r)·2ⁿ⁻ʳ. The falling factorial materialises on the right with no extra bookkeeping. The identity is unconditional over ℕ (both sides vanish when r > n).\n\n## Dead Ends\n\nNone — the induction-on-r approach worked on the first attempt.\n"
+  },
+  "tags": [
+    "combinatorics",
+    "binomial-coefficients",
+    "moments",
+    "falling-factorial",
+    "absorption",
+    "generating-functions",
+    "mathlib"
+  ],
+  "relatedProofs": [
+    "binomial-theorem",
+    "binomial-theorem-oq-03",
+    "binomial-theorem-oq-03-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Nat.sum_range_choose",
+      "Nat.succ_descFactorial_succ",
+      "Nat.descFactorial_one"
+    ]
+  },
+  "started": "2026-06-22T11:00:00-07:00",
+  "lastUpdate": "2026-06-22T11:30:00-07:00",
+  "completed": "2026-06-22T11:30:00-07:00",
+  "significance": 7,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ01OQ01.lean",
+      "filename": "BinomialTheoremOQ03OQ01OQ01.lean",
+      "lineCount": 162,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A single closed form subsuming **every** factorial moment of the binomial coefficients:

$$\sum_{k=0}^{n} k^{\underline{r}}\binom{n}{k} = n^{\underline{r}}\,2^{\,n-r}\qquad(\text{for all }n,r:\mathbb{N})$$

where $k^{\underline{r}} = k(k-1)\cdots(k-r+1) = $ `Nat.descFactorial k r` is the falling factorial. This is the **r-th falling-factorial moment** — the combinatorial shadow of differentiating the generating function $(1+x)^n = \sum \binom{n}{k}x^k$ exactly $r$ times and evaluating at $x=1$ (the $r$-th derivative $n^{\underline{r}}(1+x)^{n-r}$ is worth $n^{\underline{r}}2^{n-r}$ there).

**Follow-up to** `binomial-theorem-oq-03-oq-01` (*Combinatorial Moments of the Binomial Coefficients*), which proved the $r=1$, $r=2$ moments and the ordinary second moment one at a time. This entry generalises them into one identity and recovers them as corollaries.

## Why it's new

Mathlib's `Nat.Choose.Sum` provides only the **zeroth** moment $\sum \binom{n}{k} = 2^n$ (`Nat.sum_range_choose`). No positive-order falling-factorial or power moment is in Mathlib — this fills a genuine gap and sits one absorption identity away from existing material.

## Proof idea

One induction on the order $r$:
- **Base** $r=0$: the zeroth moment `Nat.sum_range_choose`.
- **Step** (`sum_descFactorial_mul_choose_step`): peel the vanishing $k=0$ term, reindex $k\mapsto k+1$, split the falling factorial via `Nat.succ_descFactorial_succ : (k+1)^{\underline{r+1}} = (k+1)\cdot k^{\underline{r}}`, and consume the leading $(k+1)$ with the grandparent's absorption $(k+1)\binom{m+1}{k+1} = (m+1)\binom{m}{k}$. This gives the recurrence $S(m{+}1,r{+}1) = (m{+}1)\,S(m,r)$, whose solution is exactly $n^{\underline{r}}2^{n-r}$.

The identity is **unconditional** over $\mathbb{N}$: when $r>n$ both sides are $0$ (since $n^{\underline{r}}=0$ and every term $k^{\underline{r}}$ with $k\le n<r$ vanishes), so truncated subtraction in $2^{n-r}$ is harmless.

## Contents (`Proofs/BinomialTheoremOQ03OQ01OQ01.lean`, 162 lines, 7 theorems)

- `sum_descFactorial_mul_choose` — the general moment (star result)
- `sum_descFactorial_mul_choose_step` — the absorption recurrence engine
- `sum_id_mul_choose`, `sum_descFactorial2_mul_choose` — parent's $r=1,2$ moments recovered as one-line corollaries
- `sum_descFactorial3_mul_choose` — third factorial moment $\sum k(k-1)(k-2)\binom{n}{k} = n(n-1)(n-2)2^{n-3}$ (beyond the parent), for free
- `descFactorial_two`, `descFactorial_three` — explicit product forms

## Verification

- **0 sorries, 0 `axiom` declarations.**
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` only — **no `Lean.ofReduceBool`, no `native_decide`, no `sorryAx`**. Genuinely axiom-free.
- Four numeric sanity checks use kernel `decide` (including the degenerate $r>n$ case).
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ03OQ01OQ01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)