### PR TITLE
research(combinations-formula-oq-07-oq-06): the third moment 2·∑ k³·C(n,k)² = n²(n+1)·C(2n−2,n−1)

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ07OQ06.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ07OQ06.lean
@@ -1,0 +1,145 @@
+import Mathlib
+import Proofs.CombinationsFormulaOQ07
+import Proofs.CombinationsFormulaOQ07OQ01
+import Proofs.CombinationsFormulaOQ07OQ03
+
+/-
+# The Cubically Weighted Sum of Squares of Binomial Coefficients
+
+## Open Question OQ-07-OQ-06
+
+The OQ-07 lineage studies the moments of the symmetric distribution
+`C(n, k)² / C(2n, n)` on `{0, …, n}`:
+
+  * zeroth moment (parent OQ-07):   `∑_{k} C(n, k)²       = C(2n, n)`,
+  * first  moment (OQ-07-OQ-03):    `2 · ∑_{k} k · C(n,k)² = n · C(2n, n)`,
+  * second moment (OQ-07-OQ-04):    `∑_{k} k² · C(n,k)²    = n² · C(2n−2, n−1)`.
+
+This file computes the **third moment**:
+
+  2 · ∑_{k=0}^{n} k³ · C(n, k)² = n² · (n + 1) · C(2n − 2, n − 1),         (★)
+
+equivalently in subtraction-free form, writing `n = m + 1`,
+
+  2 · ∑_{k=0}^{m+1} k³ · C(m+1, k)² = (m+1)² · (m+2) · C(2m, m).
+
+Mathlib provides the zeroth-moment row sum (`Nat.sum_range_choose`) but **none**
+of the squared-coefficient moments, so (★) is a genuine gap.
+
+## The proof — absorption then first-moment reduction
+
+The engine is the absorption identity (OQ-07-OQ-01, `mul_choose_eq`)
+
+  k · C(n, k) = n · C(n − 1, k − 1).
+
+Squaring it turns a `k²`-weighted square of `C(n, ·)` into an *unweighted* square
+of `C(n−1, ·)` one order down; the leftover factor of `k` becomes a `(k+1)` after
+the index shift `k ↦ k+1` (which also discards the vanishing `k = 0` term):
+
+  ∑_{k} k³ C(n,k)² = n² ∑_{j} (j+1) C(n−1, j)²
+                   = n² ( ∑_{j} j·C(n−1,j)²  +  ∑_{j} C(n−1,j)² ).
+
+The two surviving sums are exactly the **first moment** (OQ-07-OQ-03) and the
+**zeroth moment** (parent OQ-07) at level `n − 1`:
+
+  2 ∑_{j} j·C(n−1,j)² = (n−1)·C(2n−2, n−1),     ∑_{j} C(n−1,j)² = C(2n−2, n−1).
+
+Substituting and clearing the `2` gives `(n−1 + 2)·C(2n−2,n−1) = (n+1)·C(2n−2,n−1)`
+inside the `n²` factor, which is (★).  No induction or generating functions are
+needed — only one absorption step and the two lower moments already in the gallery.
+
+## Mathematical context
+
+Reading `C(n,k)² / C(2n,n)` as the hypergeometric distribution, (★) records its
+third raw moment.  Combined with `C(2n,n) = (2(2n−1)/n)·C(2n−2,n−1)`, it yields the
+closed form `E[k³] = n³(n+1) / (4(2n−1))` (e.g. `n = 2` gives `E[k³] = 2`).
+
+## Results
+
+1. `sum_cube_weighted_sq_reduce` — the absorption + index-shift step
+   `∑_{k} k³ C(m+1,k)² = (m+1)² · ∑_{j} (j+1) C(m,j)²`.
+2. `two_mul_sum_cube_weighted_sq` — the closed form (subtraction-free `m`-form)
+   `2 · ∑_{k} k³ C(m+1,k)² = (m+1)² · (m+2) · C(2m, m)`.
+3. `two_mul_sum_cube_weighted_sq'` — the classical `n ≥ 1` form
+   `2 · ∑_{k} k³ C(n,k)² = n² · (n+1) · C(2n−2, n−1)`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ07OQ06
+
+open Finset
+
+/-- **Absorption + index-shift reduction.** Squaring the absorption identity
+    `k · C(m+1, k) = (m+1) · C(m, k−1)` demotes the cubically-weighted square of
+    `C(m+1, ·)` to a *linearly*-weighted square of `C(m, ·)` one order down.  The
+    `k = 0` term vanishes, and the shift `k ↦ k+1` turns the residual weight `k`
+    into `k + 1`. -/
+theorem sum_cube_weighted_sq_reduce (m : ℕ) :
+    ∑ k ∈ range (m + 2), k ^ 3 * ((m + 1).choose k) ^ 2
+      = (m + 1) ^ 2 * ∑ j ∈ range (m + 1), (j + 1) * (m.choose j) ^ 2 := by
+  rw [Finset.sum_range_succ' (fun k => k ^ 3 * ((m + 1).choose k) ^ 2) (m + 1)]
+  -- the peeled `k = 0` term is `0 ^ 3 * _ = 0`
+  simp only [pow_succ, Nat.mul_zero, Nat.zero_mul, add_zero]
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun k hk => ?_)
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  -- absorption with the index already shifted: (k+1)·C(m+1,k+1) = (m+1)·C(m,k)
+  have hab : (k + 1) * ((m + 1).choose (k + 1)) = (m + 1) * (m.choose k) := by
+    have h := CombinationsFormulaOQ07OQ01.mul_choose_eq
+      (n := m + 1) (k := k + 1) (by omega) (by omega)
+    simpa using h
+  -- square it to demote the coefficient
+  have hsq : (k + 1) ^ 2 * ((m + 1).choose (k + 1)) ^ 2
+      = (m + 1) ^ 2 * (m.choose k) ^ 2 := by
+    have h2 : ((k + 1) * ((m + 1).choose (k + 1))) ^ 2
+        = ((m + 1) * (m.choose k)) ^ 2 := by rw [hab]
+    rw [mul_pow, mul_pow] at h2
+    exact h2
+  calc (k + 1) ^ 3 * ((m + 1).choose (k + 1)) ^ 2
+      = (k + 1) * ((k + 1) ^ 2 * ((m + 1).choose (k + 1)) ^ 2) := by ring
+    _ = (k + 1) * ((m + 1) ^ 2 * (m.choose k) ^ 2) := by rw [hsq]
+    _ = (m + 1) ^ 2 * ((k + 1) * (m.choose k) ^ 2) := by ring
+
+/-- **Cubically weighted central binomial sum of squares** (subtraction-free form).
+    `2 · ∑_{k=0}^{m+1} k³ · C(m+1, k)² = (m+1)² · (m+2) · C(2m, m)`.
+    The factor of `2` absorbs the first-moment doubling and keeps the statement
+    free of natural-number subtraction. -/
+theorem two_mul_sum_cube_weighted_sq (m : ℕ) :
+    2 * ∑ k ∈ range (m + 2), k ^ 3 * ((m + 1).choose k) ^ 2
+      = (m + 1) ^ 2 * (m + 2) * (2 * m).choose m := by
+  -- split the linearly-weighted sum into first + zeroth moment at level `m`
+  have hsplit : ∑ j ∈ range (m + 1), (j + 1) * (m.choose j) ^ 2
+      = (∑ j ∈ range (m + 1), j * (m.choose j) ^ 2)
+          + ∑ j ∈ range (m + 1), (m.choose j) ^ 2 := by
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl (fun j _ => by ring)
+  -- `2 · S₃` rewritten in terms of the two lower moments
+  have hR : 2 * ∑ k ∈ range (m + 2), k ^ 3 * ((m + 1).choose k) ^ 2
+      = (m + 1) ^ 2 * (2 * (∑ j ∈ range (m + 1), j * (m.choose j) ^ 2)
+          + 2 * ∑ j ∈ range (m + 1), (m.choose j) ^ 2) := by
+    rw [sum_cube_weighted_sq_reduce, hsplit]; ring
+  -- first moment (OQ-07-OQ-03) and zeroth moment (parent OQ-07) at level `m`
+  have hF := CombinationsFormulaOQ07OQ03.two_mul_sum_weighted_sq m
+  have hP := (CombinationsFormulaOQ07.central_binom_eq_sum_sq m).symm
+  rw [hR, hF, hP]; ring
+
+/-- **Third moment (classical form).** For `n ≥ 1`,
+    `2 · ∑_{k=0}^{n} k³ · C(n, k)² = n² · (n + 1) · C(2n − 2, n − 1)`. -/
+theorem two_mul_sum_cube_weighted_sq' (n : ℕ) (hn : 1 ≤ n) :
+    2 * ∑ k ∈ range (n + 1), k ^ 3 * (n.choose k) ^ 2
+      = n ^ 2 * (n + 1) * (2 * n - 2).choose (n - 1) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  have e1 : 2 * (m + 1) - 2 = 2 * m := by omega
+  have e2 : m + 1 - 1 = m := by omega
+  rw [e1, e2, two_mul_sum_cube_weighted_sq m]
+
+/-- Sanity check: `∑_{k=0}^{3} k³·C(3,k)² = 0 + 9 + 72 + 27 = 108`, and
+    `2·108 = 216 = 3²·4·C(4,2) = 9·4·6`. -/
+example : ∑ k ∈ range 4, k ^ 3 * ((3 : ℕ).choose k) ^ 2 = 108 := by decide
+
+/-- Sanity check of the closed form at `n = 3`: `2·108 = 3²·4·C(4,2)`. -/
+example : 2 * ∑ k ∈ range 4, k ^ 3 * ((3 : ℕ).choose k) ^ 2
+    = 3 ^ 2 * (3 + 1) * (2 * 3 - 2).choose (3 - 1) := by decide
+
+end CombinationsFormulaOQ07OQ06

--- a/src/data/proofs/combinations-formula-oq-07-oq-06/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-06/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "cube-context",
+    "proofId": "combinations-formula-oq-07-oq-06",
+    "range": {
+      "startLine": 1,
+      "endLine": 67
+    },
+    "type": "concept",
+    "title": "The Third Moment of the Squared-Coefficient Sum",
+    "content": "The parent entry proves the zeroth moment C(2n,n) = ∑_{k} C(n,k)²; siblings OQ-07-OQ-03 and OQ-07-OQ-04 compute the first and second moments ∑ k·C(n,k)² and ∑ k²·C(n,k)². This entry climbs one more rung to the third moment, 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) for n ≥ 1. Reading p_k = C(n,k)²/C(2n,n) as the hypergeometric distribution on {0,…,n}, the weighted sum is its third raw moment; combined with C(2n,n) = (2(2n−1)/n)·C(2n−2,n−1) it gives E[k³] = n³(n+1)/(4(2n−1)).",
+    "mathContext": "$2\\sum_{k=0}^{n} k^3\\binom{n}{k}^2 = n^2(n+1)\\binom{2n-2}{n-1}$. With $p_k = \\binom{n}{k}^2/\\binom{2n}{n}$ the hypergeometric law, $\\sum_k k^3 p_k = n^3(n+1)/(4(2n-1))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares of binomial coefficients",
+      "third moment / weighted sum",
+      "hypergeometric distribution",
+      "absorption identity",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "absorption identity k·C(n,k) = n·C(n-1,k-1)",
+      "the parent identity C(2n,n) = ∑ C(n,k)²",
+      "the first moment 2·∑ k·C(n,k)² = n·C(2n,n)"
+    ]
+  },
+  {
+    "id": "reduce-thm",
+    "proofId": "combinations-formula-oq-07-oq-06",
+    "range": {
+      "startLine": 78,
+      "endLine": 102
+    },
+    "type": "theorem",
+    "title": "Absorption and Index-Shift Reduction",
+    "content": "sum_cube_weighted_sq_reduce establishes ∑_{k=0}^{m+1} k³·C(m+1,k)² = (m+1)²·∑_{j=0}^{m} (j+1)·C(m,j)². Finset.sum_range_succ' shifts the index k ↦ k+1 and discards the vanishing k=0 term. The absorption identity (OQ-07-OQ-01 mul_choose_eq) at the shifted index gives (k+1)·C(m+1,k+1) = (m+1)·C(m,k); squaring it demotes the squared coefficient C(m+1,k+1)² to (m+1)²·C(m,k)² one order down, while the residual factor (k+1) is carried along.",
+    "mathContext": "$(k{+}1)\\binom{m+1}{k+1} = (m{+}1)\\binom{m}{k}$, so $(k{+}1)^3\\binom{m+1}{k+1}^2 = (m{+}1)^2(k{+}1)\\binom{m}{k}^2$. Summing: $\\sum_k k^3\\binom{m+1}{k}^2 = (m{+}1)^2\\sum_j (j{+}1)\\binom{m}{j}^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "absorption / committee-chair identity",
+      "Finset.sum_range_succ'",
+      "index shift",
+      "moment demotion"
+    ],
+    "prerequisites": [
+      "mul_choose_eq: k·C(n,k) = n·C(n-1,k-1)",
+      "Finset.sum_range_succ'",
+      "Finset.mul_sum"
+    ]
+  },
+  {
+    "id": "closed-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-06",
+    "range": {
+      "startLine": 108,
+      "endLine": 125
+    },
+    "type": "theorem",
+    "title": "The Cubically Weighted Closed Form",
+    "content": "two_mul_sum_cube_weighted_sq establishes 2·∑_{k=0}^{m+1} k³·C(m+1,k)² = (m+1)²·(m+2)·C(2m,m). Starting from the reduction, the linearly-weighted summand splits as (j+1)·C(m,j)² = j·C(m,j)² + C(m,j)² (Finset.sum_add_distrib), exposing the first moment and the zeroth moment at level m. Substituting OQ-07-OQ-03 (2·∑ j·C(m,j)² = m·C(2m,m)) and the parent (∑ C(m,j)² = C(2m,m)) gives (m+1)²·(m·C(2m,m) + 2·C(2m,m)) = (m+1)²·(m+2)·C(2m,m).",
+    "mathContext": "$2\\sum_k k^3\\binom{m+1}{k}^2 = (m{+}1)^2\\big(m\\binom{2m}{m} + 2\\binom{2m}{m}\\big) = (m{+}1)^2(m{+}2)\\binom{2m}{m}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "first moment (OQ-07-OQ-03)",
+      "zeroth moment / parent identity",
+      "Finset.sum_add_distrib",
+      "central binomial coefficient"
+    ],
+    "prerequisites": [
+      "sum_cube_weighted_sq_reduce",
+      "two_mul_sum_weighted_sq (first moment)",
+      "central_binom_eq_sum_sq (parent)"
+    ]
+  },
+  {
+    "id": "classical-form-thm",
+    "proofId": "combinations-formula-oq-07-oq-06",
+    "range": {
+      "startLine": 129,
+      "endLine": 143
+    },
+    "type": "theorem",
+    "title": "The Classical Form and Numeric Checks",
+    "content": "two_mul_sum_cube_weighted_sq' restates the closed form for n ≥ 1 as 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1), obtained by substituting n = m+1 into the subtraction-free m-form (so 2n−2 = 2m and n−1 = m carry no truncated subtraction). The numeric checks confirm ∑_{k=0}^{3} k³·C(3,k)² = 0 + 9 + 72 + 27 = 108 and 2·108 = 216 = 3²·4·C(4,2).",
+    "mathContext": "For $n \\ge 1$: $2\\sum_{k=0}^{n} k^3\\binom{n}{k}^2 = n^2(n+1)\\binom{2n-2}{n-1}$. At $n=3$: $2\\cdot 108 = 9\\cdot 4\\cdot 6 = 216$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "subtraction-free vs classical form",
+      "central binomial coefficient C(2n-2,n-1)",
+      "numeric verification"
+    ],
+    "prerequisites": [
+      "two_mul_sum_cube_weighted_sq (m-form)",
+      "Nat.choose evaluation by decide"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-07-oq-06/meta.json
+++ b/src/data/proofs/combinations-formula-oq-07-oq-06/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "combinations-formula-oq-07-oq-06",
+  "title": "The Cubically Weighted Sum of Squares of Binomial Coefficients",
+  "slug": "combinations-formula-oq-07-oq-06",
+  "description": "Computes the third moment of the OQ-07 family of squared-coefficient sums: 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) for n ≥ 1. The proof squares the absorption identity k·C(n,k) = n·C(n−1,k−1) to demote a cubically-weighted square of C(n,·) into a linearly-weighted square of C(n−1,·) one order down; the leftover k becomes a (k+1) under the index shift k ↦ k+1 (which discards the vanishing k=0 term). The residual sums are exactly the first moment (OQ-07-OQ-03) and the zeroth moment (parent OQ-07) at level n−1, giving (n−1+2)·C(2n−2,n−1) = (n+1)·C(2n−2,n−1) inside the n² factor. No induction or generating functions. Reading C(n,k)²/C(2n,n) as the hypergeometric distribution, the identity records its third raw moment, with E[k³] = n³(n+1)/(4(2n−1)).",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ07OQ06.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 145,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "assumptions": "None. The closed form 2·∑ k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) is fully machine-checked; the subtraction-free m-form holds for all m ≥ 0 and the classical form is stated for n ≥ 1 (so that 2n−2 and n−1 carry no truncated subtraction). Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the numeric checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "sum-of-squares",
+      "weighted-sum",
+      "third-moment",
+      "absorption",
+      "central-binomial",
+      "hypergeometric"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "two_mul_sum_cube_weighted_sq': the third-moment identity 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) for n ≥ 1, completing the moment ladder (zeroth → first → second → third) of the OQ-07 squared-coefficient sums, absent from Mathlib",
+      "two_mul_sum_cube_weighted_sq: the subtraction-free m-form 2·∑_{k=0}^{m+1} k³·C(m+1,k)² = (m+1)²·(m+2)·C(2m,m), valid for all m",
+      "sum_cube_weighted_sq_reduce: the absorption-and-shift reduction ∑_{k} k³·C(m+1,k)² = (m+1)²·∑_{j} (j+1)·C(m,j)², which demotes the cubic weight to a linear one at order m by squaring the absorption identity",
+      "Worked check ∑_{k=0}^{3} k³·C(3,k)² = 0 + 9 + 72 + 27 = 108, with 2·108 = 216 = 3²·4·C(4,2)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "CombinationsFormulaOQ07OQ01.mul_choose_eq",
+        "description": "The absorption identity k·C(n,k) = n·C(n−1,k−1) (the m=1 slice of the subset-of-a-subset identity). Squared and applied at the shifted index k+1, it turns (k+1)²·C(m+1,k+1)² into (m+1)²·C(m,k)², demoting the squared coefficient one order down — the engine of the whole reduction.",
+        "module": "Proofs.CombinationsFormulaOQ07OQ01"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07OQ03.two_mul_sum_weighted_sq",
+        "description": "The first-moment identity 2·∑_{k=0}^{m} k·C(m,k)² = m·C(2m,m). Supplies the residual linearly-weighted sum that survives the reduction, contributing the m·C(2m,m) summand.",
+        "module": "Proofs.CombinationsFormulaOQ07OQ03"
+      },
+      {
+        "theorem": "CombinationsFormulaOQ07.central_binom_eq_sum_sq",
+        "description": "The parent (zeroth-moment) identity C(2m,m) = ∑_{j=0}^{m} C(m,j)². Supplies the unweighted residual sum, contributing the 2·C(2m,m) summand after the cubic weight is split as (j+1) = j + 1.",
+        "module": "Proofs.CombinationsFormulaOQ07"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "∑_{i ∈ range (n+1)} f(i) = ∑_{i ∈ range n} f(i+1) + f(0). Performs the index shift k ↦ k+1 that discards the vanishing k=0 term and aligns the absorption identity's k−1 with a clean k.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "∑ (f + g) = ∑ f + ∑ g. Splits the linearly-weighted sum ∑ (j+1)·C(m,j)² into the first-moment sum ∑ j·C(m,j)² plus the zeroth-moment sum ∑ C(m,j)².",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ07OQ06.lean",
+    "namespace": "CombinationsFormulaOQ07OQ06",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 145,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The sum of squares of a Pascal row, ∑_{k} C(n,k)² = C(2n,n), is the diagonal of Vandermonde's convolution and the subject of the parent entry. Weighting the terms by successive powers of k turns the counting identity into a sequence of moment computations for the hypergeometric law p_k = C(n,k)²/C(2n,n). The first moment (mean n/2) and second moment were formalized in the sibling entries OQ-07-OQ-03 and OQ-07-OQ-04. This entry completes the next rung, the third moment. Such weighted binomial sums are catalogued in Gould's Combinatorial Identities (1972); Mathlib carries the unweighted and alternating row sums but none of the squared-coefficient moments, so each rung of the ladder is a genuine gap.",
+    "problemStatement": "Open Question OQ-07-OQ-06: the OQ-07 family computes the moments ∑_{k} k^r·C(n,k)² of the central sum of squares — r=0 (parent), r=1 (OQ-07-OQ-03), r=2 (OQ-07-OQ-04). Continue the ladder to r=3: find and formalize the closed form for ∑_{k=0}^{n} k³·C(n,k)², and identify the structural reduction — squaring the absorption identity — that expresses it through the lower moments.",
+    "proofStrategy": "Work with n = m+1 to stay subtraction-free. By Finset.sum_range_succ' the k=0 term drops and the sum becomes ∑_{k} (k+1)³·C(m+1,k+1)². Square the absorption identity (OQ-07-OQ-01, mul_choose_eq) at the shifted index: (k+1)·C(m+1,k+1) = (m+1)·C(m,k), so (k+1)²·C(m+1,k+1)² = (m+1)²·C(m,k)²; the leftover factor (k+1) is carried along, giving ∑_{k} k³·C(m+1,k)² = (m+1)²·∑_{j} (j+1)·C(m,j)² (sum_cube_weighted_sq_reduce). Split (j+1)·C(m,j)² = j·C(m,j)² + C(m,j)² (Finset.sum_add_distrib) into the first moment and the zeroth moment at level m. Substituting 2·∑ j·C(m,j)² = m·C(2m,m) (OQ-07-OQ-03) and ∑ C(m,j)² = C(2m,m) (parent OQ-07), the doubled sum becomes (m+1)²·(m·C(2m,m) + 2·C(2m,m)) = (m+1)²·(m+2)·C(2m,m) (two_mul_sum_cube_weighted_sq). Re-expressing in n = m+1 gives the classical form 2·∑ k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) for n ≥ 1 (two_mul_sum_cube_weighted_sq').",
+    "keyInsights": [
+      "The cubic weight is tamed by squaring the absorption identity: (k·C(n,k))² = n²·C(n−1,k−1)² converts a squared coefficient at order n into a squared coefficient at order n−1, while the third power of k is split as k = (one factor consumed by absorption) × (a residual linear weight).",
+      "After the index shift k ↦ k+1, the residual weight k becomes k+1, which splits cleanly as (j+1) = j + 1 — turning the third moment into a sum of the first moment and the zeroth moment one order down.",
+      "The moment ladder is self-bootstrapping: the r=3 result is assembled entirely from the r=1 (OQ-07-OQ-03) and r=0 (parent) identities at level n−1, with no fresh combinatorial input beyond the absorption step.",
+      "Keeping the headline in the factor-of-2 form 2·∑ k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) absorbs the intrinsic doubling of the first moment and keeps the m-form free of natural-number subtraction.",
+      "Probabilistically the identity is the third raw moment of the hypergeometric law; combined with C(2n,n) = (2(2n−1)/n)·C(2n−2,n−1) it yields E[k³] = n³(n+1)/(4(2n−1)) (e.g. E[k³] = 2 at n = 2)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Header stating OQ-07-OQ-06: the third moment of the squared-coefficient sums, the moment ladder (r=0,1,2 already formalized), the absorption-and-reduction strategy, and the hypergeometric third-moment interpretation E[k³] = n³(n+1)/(4(2n−1))."
+    },
+    {
+      "id": "reduction",
+      "title": "Absorption and Index-Shift Reduction",
+      "startLine": 78,
+      "endLine": 102,
+      "summary": "sum_cube_weighted_sq_reduce: ∑_{k} k³·C(m+1,k)² = (m+1)²·∑_{j} (j+1)·C(m,j)². Drops the k=0 term (Finset.sum_range_succ'), squares the absorption identity (OQ-07-OQ-01 mul_choose_eq) at the shifted index to demote C(m+1,·)² to C(m,·)², and carries the residual linear weight."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Cubically Weighted Closed Form",
+      "startLine": 108,
+      "endLine": 125,
+      "summary": "two_mul_sum_cube_weighted_sq: 2·∑_{k} k³·C(m+1,k)² = (m+1)²·(m+2)·C(2m,m). Splits (j+1)·C(m,j)² into first- plus zeroth-moment summands (Finset.sum_add_distrib), then substitutes OQ-07-OQ-03 (2·∑ j·C(m,j)² = m·C(2m,m)) and the parent (∑ C(m,j)² = C(2m,m))."
+    },
+    {
+      "id": "classical-form",
+      "title": "The Classical Form and Numeric Checks",
+      "startLine": 129,
+      "endLine": 143,
+      "summary": "two_mul_sum_cube_weighted_sq': 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) for n ≥ 1, obtained by setting n = m+1 in the m-form; with the numeric check ∑_{k=0}^{3} k³·C(3,k)² = 108 and 2·108 = 3²·4·C(4,2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "3 theorems, 0 sorries, 0 axioms. The third-moment identity 2·∑_{k=0}^{n} k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1) (n ≥ 1) completes the moment ladder of the parent's central sum of squares (zeroth → first → second → third). The proof squares the absorption identity to demote the squared coefficient one order down, then assembles the answer from the first moment (OQ-07-OQ-03) and the zeroth moment (parent) at level n−1 — no induction or generating functions.",
+    "implications": "Adds the third squared-coefficient moment, a Mathlib gap, built entirely from sibling and parent identities. The technique — square the absorption identity k·C(n,k) = n·C(n−1,k−1) to demote a weighted square one order down, shift the index to discard the vanishing term, and reduce the residual to lower moments — is a reusable engine for higher moments ∑ k^r·C(n,k)² and mirrors the absorption route used for the second moment (OQ-07-OQ-04). The hypergeometric reading places the result as the distribution's third raw moment, E[k³] = n³(n+1)/(4(2n−1)).",
+    "openQuestions": [
+      "Does the absorption-and-demote engine give a uniform closed form for the general moment ∑_{k=0}^{n} k^r·C(n,k)² as a linear combination of C(2n−j,n−j) for 0 ≤ j ≤ r with Stirling-number coefficients (the r-th moment of the hypergeometric law)?",
+      "Is there a single generating identity ∑_{k} x^k·C(n,k)² with a closed form (a Legendre/Jacobi-polynomial evaluation) from which all the moments r=0,1,2,3,… follow by differentiation at x=1?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-07",
+      "relationship": "parent — proves the unweighted (zeroth-moment) C(2n,n) = ∑ C(n,k)²; this entry computes the third moment of that sum, reusing the parent identity at level n−1"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-03",
+      "relationship": "sibling — the first moment 2·∑ k·C(n,k)² = n·C(2n,n); supplies the residual linearly-weighted sum used here at level n−1"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-04",
+      "relationship": "sibling — the second moment ∑ k²·C(n,k)² = n²·C(2n−2,n−1); this entry extends the same absorption-and-demote technique one power higher"
+    },
+    {
+      "targetId": "combinations-formula-oq-07-oq-01",
+      "relationship": "sibling — supplies the absorption identity k·C(n,k) = n·C(n−1,k−1) (mul_choose_eq) that, squared, drives the entire reduction"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the **moment ladder** of the parent's central sum of squares, climbing one rung above the existing siblings:

| moment | identity | entry |
|--------|----------|-------|
| zeroth | `∑ C(n,k)² = C(2n,n)` | OQ-07 (parent) |
| first  | `2·∑ k·C(n,k)² = n·C(2n,n)` | OQ-07-OQ-03 |
| second | `∑ k²·C(n,k)² = n²·C(2n−2,n−1)` | OQ-07-OQ-04 |
| **third** | **`2·∑ k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1)`** (n ≥ 1) | **this PR** |

This third-moment identity is **not in Mathlib** (Mathlib carries only the unweighted and alternating row sums, no squared-coefficient moments).

## Proof

Engine = **squaring the absorption identity** `k·C(n,k) = n·C(n−1,k−1)` (OQ-07-OQ-01):

1. `sum_cube_weighted_sq_reduce` — shift `k ↦ k+1` (drops the vanishing `k=0` term), square the absorption identity to demote `C(m+1,·)²` to `C(m,·)²` one order down → `∑ k³·C(m+1,k)² = (m+1)²·∑ (j+1)·C(m,j)²`.
2. `two_mul_sum_cube_weighted_sq` — split `(j+1) = j + 1` to expose the **first moment** (OQ-07-OQ-03) and the **zeroth moment** (parent), giving `(m+1)²·(m+2)·C(2m,m)`.
3. `two_mul_sum_cube_weighted_sq'` — restate for `n ≥ 1`: `2·∑ k³·C(n,k)² = n²·(n+1)·C(2n−2,n−1)`.

No induction, no generating functions — assembled entirely from sibling and parent identities at level `n−1`.

## Verification

- **3 theorems, 0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`; numeric checks use kernel `decide`, **no `native_decide`**).
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.CombinationsFormulaOQ07OQ06`.
- Gallery `meta.json` + `annotations.json` added; annotations validate with no errors for this entry.

Probabilistic reading: the third raw moment of the hypergeometric law `C(n,k)²/C(2n,n)`, `E[k³] = n³(n+1)/(4(2n−1))` (e.g. `E[k³] = 2` at `n = 2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)