### PR TITLE
research(binomial-theorem-oq-03-oq-01-oq-03): the Vandermonde convolution for falling factorials — umbral binomial theorem (0-axiom verified)

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ03OQ01OQ03.lean
+++ b/proofs/Proofs/BinomialTheoremOQ03OQ01OQ03.lean
@@ -1,0 +1,141 @@
+/-
+# The Vandermonde Convolution for Falling Factorials (OQ-03-OQ-01-OQ-03)
+
+Research Question (follow-up to OQ-03-OQ-01 "Combinatorial Moments of the
+Binomial Coefficients" and its sibling OQ-03-OQ-01-OQ-01, the general
+falling-factorial moment).  The moment entries treat the falling factorial
+`k^(r) = k(k-1)⋯(k-r+1) = Nat.descFactorial k r` as the natural weight against
+the binomial coefficients.  The falling factorial has another binomial-flavoured
+property — an *addition law* in its base.  Does the falling factorial obey a
+Vandermonde-type convolution, the umbral analogue of the binomial theorem?
+
+Answer.  Yes.  The falling factorial is a sequence *of binomial type*:
+
+    (x + y)^(n) = Σ_{k=0}^{n} C(n,k) · x^(k) · y^(n-k)        (for all x, y, n : ℕ)
+
+This is the **Vandermonde convolution for falling factorials** (the umbral, or
+"Newton", binomial theorem).  Dividing both sides by `n!` collapses it to the
+ordinary Chu–Vandermonde identity for binomial coefficients
+`C(x+y, n) = Σ_k C(x,k)·C(y,n-k)`; the falling-factorial form is the
+polynomial-level refinement that keeps the factorials uncancelled.  Mathlib has
+the binomial Vandermonde (`Nat.add_choose_eq`, in antidiagonal form) but not its
+falling-factorial lift, nor even the range form of Chu–Vandermonde.
+
+The proof is the reduction just sketched, run in reverse.  Each falling factorial
+is `m^(j) = j!·C(m,j)` (`Nat.descFactorial_eq_factorial_mul_choose`), so a single
+summand carries the factor `C(n,k)·k!·(n-k)! = n!`
+(`Nat.choose_mul_factorial_mul_factorial`, valid because `k ≤ n` throughout the
+range).  Pulling that constant `n!` out of the sum leaves exactly
+`n!·Σ_k C(x,k)·C(y,n-k) = n!·C(x+y,n) = (x+y)^(n)`, where the inner sum is
+Chu–Vandermonde.  Everything stays in ℕ; the truncated subtraction in `n - k` is
+harmless because `k` ranges only up to `n`.
+
+Tags: combinatorics, binomial-coefficients, falling-factorial, Vandermonde,
+Chu-Vandermonde, umbral-calculus, binomial-type, convolution
+-/
+
+import Mathlib
+
+open Finset BigOperators
+
+namespace BinomialTheoremOQ03OQ01OQ03
+
+/-! ## Part I: Chu–Vandermonde in range form
+
+Mathlib proves Vandermonde's identity as `Nat.add_choose_eq`, but only in
+*antidiagonal* form `Σ_{(i,j) ∈ antidiagonal n} C(x,i)·C(y,j)`.  For an honest
+"convolution over `range (n+1)`" we repackage it with
+`Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`, which substitutes the unique
+antidiagonal index `(k, n-k)`.  This range form is the engine of the main result
+and is itself absent from Mathlib. -/
+
+/-- **Chu–Vandermonde, range form.**  `C(x+y, n) = Σ_{k=0}^{n} C(x,k)·C(y,n-k)`.
+The classical convolution of binomial coefficients, written as a sum over
+`range (n+1)` rather than over the antidiagonal. -/
+theorem add_choose_eq_sum_range (x y n : ℕ) :
+    (x + y).choose n = ∑ k ∈ range (n + 1), x.choose k * y.choose (n - k) := by
+  rw [Nat.add_choose_eq, Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk]
+
+/-! ## Part II: The Vandermonde convolution for falling factorials -/
+
+/-- **Vandermonde convolution for falling factorials.**  For all `x y n : ℕ`,
+`(x + y)^(n) = Σ_{k=0}^{n} C(n,k) · x^(k) · y^(n-k)`, where `m^(j) =
+Nat.descFactorial m j` is the falling factorial.  This is the umbral binomial
+theorem: the falling factorial is a sequence of binomial type.
+
+The proof rewrites every falling factorial as `m^(j) = j!·C(m,j)`, so each
+summand acquires the constant factor `C(n,k)·k!·(n-k)! = n!`; pulling it out
+reduces the statement to the binomial Chu–Vandermonde identity
+(`add_choose_eq_sum_range`).  Holds unconditionally over ℕ — the truncated
+subtraction in `n - k` is harmless since `k ≤ n` over the whole range. -/
+theorem add_descFactorial_eq_sum (x y n : ℕ) :
+    (x + y).descFactorial n
+      = ∑ k ∈ range (n + 1), n.choose k * (x.descFactorial k * y.descFactorial (n - k)) := by
+  rw [Nat.descFactorial_eq_factorial_mul_choose, add_choose_eq_sum_range, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [Finset.mem_range, Nat.lt_succ_iff] at hk
+  rw [Nat.descFactorial_eq_factorial_mul_choose, Nat.descFactorial_eq_factorial_mul_choose,
+    ← Nat.choose_mul_factorial_mul_factorial hk]
+  ring
+
+/-! ## Part III: Corollaries -/
+
+/-- **Diagonal case `x = y`.**  `(2x)^(n) = Σ_{k=0}^{n} C(n,k) · x^(k) · x^(n-k)`.
+The self-convolution of the falling factorial — the umbral analogue of the
+duplication `(2x)ⁿ = Σ C(n,k) xᵏ xⁿ⁻ᵏ`. -/
+theorem two_mul_descFactorial_eq_sum (x n : ℕ) :
+    (2 * x).descFactorial n
+      = ∑ k ∈ range (n + 1), n.choose k * (x.descFactorial k * x.descFactorial (n - k)) := by
+  have h := add_descFactorial_eq_sum x x n
+  rwa [two_mul]
+
+/-- **The convolution is symmetric.**  Reindexing `k ↦ n-k` swaps the roles of
+`x` and `y` in the falling-factorial Vandermonde, matching the symmetry
+`(x+y)^(n) = (y+x)^(n)`.  Stated as the equality of the two convolutions. -/
+theorem descFactorial_sum_comm (x y n : ℕ) :
+    ∑ k ∈ range (n + 1), n.choose k * (x.descFactorial k * y.descFactorial (n - k))
+      = ∑ k ∈ range (n + 1), n.choose k * (y.descFactorial k * x.descFactorial (n - k)) := by
+  rw [← add_descFactorial_eq_sum, ← add_descFactorial_eq_sum, Nat.add_comm]
+
+/-- **Recovering the ordinary binomial theorem on the diagonal.**  Specialising
+the binomial coefficient form: the zeroth case `n = 0` is `1`, and the first case
+`n = 1` is the linear addition law `(x+y)^(1) = x + y`. -/
+theorem descFactorial_one_add (x y : ℕ) :
+    (x + y).descFactorial 1 = x.descFactorial 1 + y.descFactorial 1 := by
+  simp
+
+/-! ## Part IV: Sanity checks
+
+Concrete instances verified by kernel `decide` (no `native_decide`, so these add
+no axioms).  `Nat.descFactorial` is computable, so each side reduces to a literal. -/
+
+-- (3+4)^(2) = 7·6 = 42 = Σ_{k=0}^{2} C(2,k)·3^(k)·4^(2-k)
+example :
+    (3 + 4).descFactorial 2
+      = ∑ k ∈ range 3, (2).choose k * ((3 : ℕ).descFactorial k * (4 : ℕ).descFactorial (2 - k)) := by
+  decide
+
+-- order 3, mixed bases
+example :
+    (5 + 2).descFactorial 3
+      = ∑ k ∈ range 4, (3).choose k * ((5 : ℕ).descFactorial k * (2 : ℕ).descFactorial (3 - k)) := by
+  decide
+
+-- diagonal duplication (2·4)^(3) = 8·7·6 = 336
+example :
+    (2 * 4).descFactorial 3
+      = ∑ k ∈ range 4, (3).choose k * ((4 : ℕ).descFactorial k * (4 : ℕ).descFactorial (3 - k)) := by
+  decide
+
+-- a base smaller than the order, exercising truncated subtraction: 1^(3) = 0
+example :
+    (1 + 1).descFactorial 3
+      = ∑ k ∈ range 4, (3).choose k * ((1 : ℕ).descFactorial k * (1 : ℕ).descFactorial (3 - k)) := by
+  decide
+
+-- Chu–Vandermonde range form: C(7,3) = 35
+example : (3 + 4).choose 3 = ∑ k ∈ range 4, (3 : ℕ).choose k * (4 : ℕ).choose (3 - k) := by
+  decide
+
+end BinomialTheoremOQ03OQ01OQ03

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-03/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "umbral-binomial-context",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "The Falling Factorial Is a Sequence of Binomial Type",
+    "content": "The moment entries in this lineage weight the binomial coefficients by a falling factorial. Here the falling factorial plays the opposite role — it is convolved against the binomial coefficients in an addition law. The result is the umbral (Newton) binomial theorem: (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k), where m^(j) = Nat.descFactorial m j. This says the polynomials p_n(x) = x^(n) are a sequence of binomial type, p_n(x+y) = Σ C(n,k)·p_k(x)·p_{n-k}(y), exactly the relation the ordinary powers xⁿ obey. Dividing through by n! collapses it to the classical Chu–Vandermonde identity C(x+y,n) = Σ_k C(x,k)·C(y,n-k).",
+    "mathContext": "$(x+y)^{\\underline{n}} = \\sum_{k=0}^{n}\\binom{n}{k}x^{\\underline{k}}y^{\\underline{n-k}}$, the umbral analogue of $(x+y)^n = \\sum_k \\binom{n}{k}x^k y^{n-k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "falling factorial / descFactorial",
+      "sequences of binomial type",
+      "umbral calculus",
+      "Chu–Vandermonde convolution"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Nat.descFactorial falling factorial",
+      "Vandermonde's identity"
+    ]
+  },
+  {
+    "id": "vandermonde-range-form",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-03",
+    "range": { "startLine": 55, "endLine": 57 },
+    "type": "technique",
+    "title": "Repackaging Antidiagonal Vandermonde into Range Form",
+    "content": "Mathlib proves Vandermonde's identity (Nat.add_choose_eq) as a sum over the antidiagonal of n: Σ_{(i,j) ∈ antidiagonal n} C(x,i)·C(y,j). For an honest convolution over range(n+1) one substitutes the unique antidiagonal index (k, n-k) with Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk, yielding C(x+y,n) = Σ_{k=0}^{n} C(x,k)·C(y,n-k). This range form is itself absent from Mathlib and is the engine of the falling-factorial identity.",
+    "mathContext": "$\\sum_{(i,j)\\in\\text{antidiagonal }n} f(i,j) = \\sum_{k\\in\\text{range}(n+1)} f(k, n-k)$ applied to $f(i,j) = \\binom{x}{i}\\binom{y}{j}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.add_choose_eq (Vandermonde)",
+      "Finset.Nat.antidiagonal",
+      "antidiagonal-to-range conversion"
+    ],
+    "prerequisites": [
+      "Nat.add_choose_eq",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk"
+    ]
+  },
+  {
+    "id": "reduction-to-chu-vandermonde",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-03",
+    "range": { "startLine": 71, "endLine": 80 },
+    "type": "insight",
+    "title": "One Global Constant n! Reduces the Whole Identity to Chu–Vandermonde",
+    "content": "The main proof is a single observation made precise. Rewrite the left side as n!·C(x+y,n) (descFactorial_eq_factorial_mul_choose) and apply the range-form Vandermonde, then distribute n! across the sum (Finset.mul_sum). Term-by-term, rewrite every falling factorial as m^(j) = j!·C(m,j); the coefficients collect into C(n,k)·k!·(n-k)!, which Nat.choose_mul_factorial_mul_factorial equates to n! (legitimate because membership in range(n+1) gives k ≤ n). So the falling-factorial convolution and the binomial convolution differ only by the global constant n!, and ring closes each summand. The seemingly stronger umbral statement is Chu–Vandermonde dressed with factorials.",
+    "mathContext": "$\\binom{n}{k}\\,x^{\\underline{k}}y^{\\underline{n-k}} = \\binom{n}{k}k!(n-k)!\\,\\binom{x}{k}\\binom{y}{n-k} = n!\\,\\binom{x}{k}\\binom{y}{n-k}$, summed.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.descFactorial_eq_factorial_mul_choose",
+      "Nat.choose_mul_factorial_mul_factorial",
+      "Finset.mul_sum",
+      "pulling a constant out of a sum"
+    ],
+    "prerequisites": [
+      "add_choose_eq_sum_range",
+      "Nat.descFactorial_eq_factorial_mul_choose",
+      "Nat.choose_mul_factorial_mul_factorial",
+      "Finset.sum_congr"
+    ]
+  },
+  {
+    "id": "corollaries-binomial-type",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 106 },
+    "type": "insight",
+    "title": "Diagonal, Symmetry, and the Order-1 Addition Law",
+    "content": "Three corollaries record the binomial-type structure. Setting x = y gives the self-convolution (2x)^(n) = Σ C(n,k)·x^(k)·x^(n-k), the umbral analogue of (2x)ⁿ = Σ C(n,k)·xᵏ·xⁿ⁻ᵏ. The symmetry descFactorial_sum_comm follows because both convolutions equal (x+y)^(n) = (y+x)^(n) — the umbral shadow of commutativity. The order-1 case (x+y)^(1) = x^(1) + y^(1) is the linear addition law, the simplest instance of binomial type.",
+    "mathContext": "$(2x)^{\\underline{n}} = \\sum_k\\binom{n}{k}x^{\\underline{k}}x^{\\underline{n-k}}$; $p_n(x+y) = p_n(y+x)$; $(x+y)^{\\underline{1}} = x^{\\underline{1}} + y^{\\underline{1}}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "diagonal / self-convolution",
+      "symmetry of binomial-type sequences",
+      "linear addition law"
+    ],
+    "prerequisites": [
+      "add_descFactorial_eq_sum",
+      "two_mul",
+      "Nat.add_comm"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-03/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "binomial-theorem-oq-03-oq-01-oq-03",
+  "title": "The Vandermonde Convolution for Falling Factorials",
+  "slug": "binomial-theorem-oq-03-oq-01-oq-03",
+  "description": "The falling factorial is a sequence of binomial type: (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k), where m^(j) = Nat.descFactorial m j. This is the umbral (Newton) binomial theorem — the Vandermonde convolution for falling factorials. Dividing by n! collapses it to the ordinary Chu–Vandermonde identity C(x+y,n) = Σ_k C(x,k)·C(y,n-k); the falling-factorial form is the polynomial-level refinement that keeps the factorials uncancelled. The proof rewrites every falling factorial as m^(j) = j!·C(m,j), so each summand carries the constant factor C(n,k)·k!·(n-k)! = n!; pulling it out reduces the statement to Chu–Vandermonde. Mathlib has the binomial Vandermonde only in antidiagonal form (Nat.add_choose_eq) and lacks both the range form and the falling-factorial lift.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ03OQ01OQ03.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "assumptions": "None. The convolution (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k) is fully machine-checked over ℕ for all x, y, n — no side conditions. Truncated natural subtraction in n - k is harmless: k ranges only over range(n+1), so k ≤ n throughout. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; the five numeric sanity checks use kernel `decide` (no Lean.ofReduceBool, no native_decide, no sorryAx).",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "falling-factorial",
+      "descFactorial",
+      "vandermonde",
+      "chu-vandermonde",
+      "umbral-calculus",
+      "binomial-type",
+      "convolution",
+      "mathlib-contribution",
+      "research"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "add_descFactorial_eq_sum: the Vandermonde convolution for falling factorials (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k) for all x, y, n : ℕ, where m^(j) = Nat.descFactorial m j. The umbral binomial theorem, identifying the falling factorial as a sequence of binomial type; absent from Mathlib, which has only the binomial-coefficient Vandermonde.",
+      "add_choose_eq_sum_range: the ordinary Chu–Vandermonde identity C(x+y,n) = Σ_{k=0}^{n} C(x,k)·C(y,n-k) in range form, repackaged from Mathlib's antidiagonal Nat.add_choose_eq via Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk. The range form itself is not in Mathlib and is the engine of the main result.",
+      "two_mul_descFactorial_eq_sum: the diagonal self-convolution (2x)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·x^(n-k), the umbral analogue of the duplication (2x)ⁿ = Σ C(n,k)·xᵏ·xⁿ⁻ᵏ.",
+      "descFactorial_sum_comm: the symmetry of the convolution under x ↔ y (reindexing k ↦ n-k), the umbral shadow of (x+y)^(n) = (y+x)^(n).",
+      "descFactorial_one_add: the order-1 linear addition law (x+y)^(1) = x^(1) + y^(1)."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.add_choose_eq",
+        "description": "Vandermonde's identity (x+y).choose n = Σ_{(i,j) ∈ antidiagonal n} x.choose i * y.choose j, in antidiagonal form. Repackaged into range form here and used as the combinatorial core onto which the falling-factorial identity reduces.",
+        "module": "Mathlib.Data.Nat.Choose.Vandermonde"
+      },
+      {
+        "theorem": "Nat.descFactorial_eq_factorial_mul_choose",
+        "description": "m.descFactorial j = j! * m.choose j. The bridge between falling factorials and binomial coefficients: applying it to all three falling factorials turns each summand's coefficient into C(n,k)·k!·(n-k)!.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "k ≤ n → n.choose k * k! * (n-k)! = n!. Collapses each summand's factor to the global constant n!, which then pulls out of the sum. Valid because k ≤ n throughout range(n+1).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk",
+        "description": "Σ_{ij ∈ antidiagonal n} f ij = Σ_{k ∈ range (n+1)} f (k, n-k). Converts Mathlib's antidiagonal Vandermonde into the honest range form Σ_{k=0}^{n} C(x,k)·C(y,n-k).",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b · Σ f = Σ (b · f). Distributes the pulled-out constant n! across the convolution so the two sums can be matched term-by-term under Finset.sum_congr.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ03OQ01OQ03.lean",
+    "namespace": "BinomialTheoremOQ03OQ01OQ03",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "overview": [
+    "The moment entries in this lineage — the parent *Combinatorial Moments of the Binomial Coefficients* and its sibling *The General Falling-Factorial Moment* — treat the falling factorial k^(r) = k(k-1)⋯(k-r+1) = Nat.descFactorial k r as the natural weight against the binomial coefficients. The falling factorial carries a second binomial-flavoured property: an addition law in its base. This entry asks whether it obeys a Vandermonde-type convolution — the umbral analogue of the binomial theorem.",
+    "It does. For all x, y, n : ℕ, (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k). In the language of umbral calculus, the falling factorial is a sequence *of binomial type*: the polynomials p_n(x) = x^(n) satisfy p_n(x+y) = Σ C(n,k)·p_k(x)·p_{n-k}(y), exactly the relation the ordinary powers xⁿ satisfy. Dividing both sides by n! collapses the identity to the ordinary Chu–Vandermonde convolution for binomial coefficients C(x+y,n) = Σ_k C(x,k)·C(y,n-k).",
+    "The proof runs that reduction in reverse. Each falling factorial is m^(j) = j!·C(m,j) (Nat.descFactorial_eq_factorial_mul_choose), so a single summand carries the factor C(n,k)·k!·(n-k)! = n! (Nat.choose_mul_factorial_mul_factorial, valid because k ≤ n over the whole range). Pulling that constant n! out of the sum leaves n!·Σ_k C(x,k)·C(y,n-k) = n!·C(x+y,n) = (x+y)^(n), where the inner sum is Chu–Vandermonde. To use Mathlib's Vandermonde (Nat.add_choose_eq, stated over the antidiagonal) one first repackages it into range form via Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk — a small but independently useful lemma.",
+    "Everything stays inside ℕ. The truncated subtraction in n - k never causes trouble because k ranges only over range(n+1), so k ≤ n throughout; the identity needs no side condition. Corollaries record the diagonal self-convolution (2x)^(n) = Σ C(n,k)·x^(k)·x^(n-k), the symmetry under x ↔ y, and the order-1 linear addition law."
+  ],
+  "conclusion": [
+    "The Vandermonde convolution for falling factorials (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k) packages the umbral binomial theorem into one unconditional ℕ-identity, lifting Mathlib's binomial-coefficient Vandermonde to the falling factorial and certifying Nat.descFactorial as a sequence of binomial type.",
+    "The mathematical content is the single observation that, summand by summand, the falling-factorial convolution and the binomial convolution differ only by the global constant n!: each falling factorial m^(j) = j!·C(m,j) feeds the factor C(n,k)·k!·(n-k)! = n! into its term. Once that constant is pulled out, the entire identity is exactly Chu–Vandermonde — so the seemingly stronger umbral statement is the same theorem dressed with factorials.",
+    "The result fills a genuine gap: Mathlib carries Vandermonde only in antidiagonal form and lacks both the range form (built here as a byproduct) and the falling-factorial lift. Natural sequels are the rising-factorial Vandermonde through the descending↔ascending bridge Nat.add_descFactorial_eq_ascFactorial, and the lowering recurrence (x+1)^(n) = x^(n) + n·x^(n-1) as the y = 1 specialisation."
+  ],
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "File docstring stating the research question, the umbral binomial theorem (x+y)^(n) = Σ C(n,k)·x^(k)·y^(n-k), and the reduction-to-Chu–Vandermonde strategy; `import Mathlib`; `open Finset BigOperators`; the `BinomialTheoremOQ03OQ01OQ03` namespace.",
+      "mathContext": "The falling factorial is Mathlib's Nat.descFactorial, linked to binomial coefficients by m^(j) = j!·C(m,j). The only combinatorial input is Mathlib's Vandermonde Nat.add_choose_eq."
+    },
+    {
+      "id": "vandermonde-range",
+      "title": "Part I — Chu–Vandermonde in Range Form",
+      "startLine": 43,
+      "endLine": 57,
+      "summary": "`add_choose_eq_sum_range` proves C(x+y,n) = Σ_{k=0}^{n} C(x,k)·C(y,n-k) by rewriting Mathlib's antidiagonal Vandermonde (Nat.add_choose_eq) with Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk, which substitutes the unique antidiagonal index (k, n-k). This range form is absent from Mathlib and is the engine of the main result.",
+      "mathContext": "Vandermonde's convolution $\\binom{x+y}{n} = \\sum_{k=0}^{n}\\binom{x}{k}\\binom{y}{n-k}$, repackaged from $\\sum_{(i,j)\\in\\text{antidiagonal }n}$ to $\\sum_{k\\in\\text{range}(n+1)}$."
+    },
+    {
+      "id": "falling-vandermonde",
+      "title": "Part II — The Vandermonde Convolution for Falling Factorials",
+      "startLine": 59,
+      "endLine": 80,
+      "summary": "`add_descFactorial_eq_sum` proves (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k). Rewrite the left side as n!·C(x+y,n) and apply Part I; distribute n! with Finset.mul_sum; then term-by-term (Finset.sum_congr, with k ≤ n from membership) rewrite the falling factorials as j!·C(m,j) and replace n! by C(n,k)·k!·(n-k)! (Nat.choose_mul_factorial_mul_factorial), closing with ring.",
+      "mathContext": "Each summand's coefficient $\\binom{n}{k}k!(n-k)! = n!$ is the same global constant, so the falling-factorial convolution equals $n!$ times the binomial one — i.e. Chu–Vandermonde."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part III — Corollaries",
+      "startLine": 82,
+      "endLine": 106,
+      "summary": "`two_mul_descFactorial_eq_sum`: the diagonal x = y case (2x)^(n) = Σ C(n,k)·x^(k)·x^(n-k), via two_mul. `descFactorial_sum_comm`: the convolution is symmetric under x ↔ y, since both sides equal (x+y)^(n) = (y+x)^(n). `descFactorial_one_add`: the order-1 linear addition law (x+y)^(1) = x^(1) + y^(1).",
+      "mathContext": "Self-convolution $(2x)^{\\underline{n}} = \\sum_k\\binom{n}{k}x^{\\underline{k}}x^{\\underline{n-k}}$ and the binomial-type symmetry $p_n(x+y) = p_n(y+x)$."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part IV — Numeric Sanity Checks",
+      "startLine": 108,
+      "endLine": 141,
+      "summary": "Five concrete `decide` checks: the convolution at (x,y,n) = (3,4,2) and (5,2,3), the diagonal (2·4)^(3), a base-below-order case 1^(3) = 0 exercising truncated subtraction, and the range-form Chu–Vandermonde C(7,3) = 35.",
+      "mathContext": "Kernel `decide` (not `native_decide`) keeps the checks axiom-free; Nat.descFactorial is computable, so each side reduces to a literal."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-03-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "The general falling-factorial moment Σ_{k=0}^{n} k^(r)·C(n,k) = n^(r)·2ⁿ⁻ʳ. That entry weights the binomial coefficients by a falling factorial; this one convolves falling factorials against the binomial coefficients — the two binomial-flavoured properties of Nat.descFactorial."
+    },
+    {
+      "targetId": "binomial-theorem-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "Computes the first combinatorial moments of the binomial coefficients via absorption, establishing the falling factorial as the natural weight. This entry develops the falling factorial's addition law instead."
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "ancestor",
+      "description": "Derives the binomial mean and variance and supplies the absorption identity (k+1)·C(n+1,k+1) = (n+1)·C(n,k) that organises the moment lineage."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "ancestor",
+      "description": "The binomial theorem (x+y)ⁿ = Σ C(n,k)·xᵏ·yⁿ⁻ᵏ is the prototype: the result here is its umbral counterpart with ordinary powers replaced by falling factorials."
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-01-oq-03.json
@@ -1,0 +1,104 @@
+{
+  "slug": "binomial-theorem-oq-03-oq-01-oq-03",
+  "title": "The Vandermonde Convolution for Falling Factorials",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "(x+y)^{\\underline{n}} = \\sum_{k=0}^{n}\\binom{n}{k}\\,x^{\\underline{k}}\\,y^{\\underline{n-k}}",
+    "plain": "The moment entries in this lineage treat the falling factorial k^(r) = k(k-1)⋯(k-r+1) as the natural weight against the binomial coefficients. The falling factorial has a second binomial-flavoured property: an addition law in its base. Does it obey a Vandermonde-type convolution — the umbral analogue of the binomial theorem? Yes: (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k) for all x,y,n. The falling factorial is a sequence of binomial type. Dividing by n! collapses this to the ordinary Chu–Vandermonde identity C(x+y,n) = Σ_k C(x,k)·C(y,n-k); the falling-factorial form is the polynomial-level refinement.",
+    "whyMatters": [
+      "Lifts Mathlib's binomial Vandermonde (Nat.add_choose_eq) to the falling factorial — the umbral binomial theorem",
+      "Supplies the range form of Chu–Vandermonde, which Mathlib has only in antidiagonal form",
+      "Identifies Nat.descFactorial as a sequence of binomial type"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T13:30:00-07:00",
+    "iteration": 1,
+    "focus": "Prove the falling-factorial Vandermonde convolution by reducing it to the binomial Chu–Vandermonde identity.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved the Vandermonde convolution for falling factorials (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k) for all x,y,n:ℕ, 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/BinomialTheoremOQ03OQ01OQ03.lean (141L, 5 thm). Reduction: rewrite every falling factorial m^(j) = j!·C(m,j) (Nat.descFactorial_eq_factorial_mul_choose), so each summand carries C(n,k)·k!·(n-k)! = n! (Nat.choose_mul_factorial_mul_factorial, valid since k ≤ n on the range); pull out the constant n! to reduce to the binomial Chu–Vandermonde in range form, which is itself repackaged from Mathlib's antidiagonal Nat.add_choose_eq via Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk. Unconditional over ℕ; truncated subtraction in n-k is harmless since k ≤ n.",
+    "builtItems": [
+      "Proofs/BinomialTheoremOQ03OQ01OQ03.lean: add_descFactorial_eq_sum (the falling-factorial Vandermonde convolution, 0-axiom)",
+      "add_choose_eq_sum_range (Chu–Vandermonde in range form, repackaging Mathlib's antidiagonal Nat.add_choose_eq — itself a Mathlib gap)",
+      "two_mul_descFactorial_eq_sum (diagonal self-convolution (2x)^(n) = Σ C(n,k)·x^(k)·x^(n-k))",
+      "descFactorial_sum_comm (symmetry of the convolution under x ↔ y), descFactorial_one_add (order-1 linear addition law)",
+      "src/data/proofs/binomial-theorem-oq-03-oq-01-oq-03/ gallery entry"
+    ],
+    "insights": [
+      "The whole identity is one rewrite away from Chu–Vandermonde: each falling factorial m^(j) = j!·C(m,j) feeds the factor C(n,k)·k!·(n-k)! = n! into every summand, so the binomial sum and the falling-factorial sum differ only by the global constant n!",
+      "Mathlib carries Vandermonde only in antidiagonal form (Nat.add_choose_eq); the honest range form Σ_{k=0}^{n} C(x,k)·C(y,n-k) requires Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk to extract the index (k, n-k)",
+      "The falling factorial is a sequence of binomial type: p_n(x) = x^(n) satisfies p_n(x+y) = Σ C(n,k)·p_k(x)·p_{n-k}(y), the defining umbral-calculus property — the same one the ordinary powers xⁿ satisfy",
+      "No side condition: the truncated natural subtraction n-k never bites because k ranges only over range(n+1), so k ≤ n throughout"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the binomial Vandermonde (Nat.add_choose_eq) only in antidiagonal form, not the range form, and lacks entirely the falling-factorial (umbral) lift proved here — both are natural upstream contributions"
+    ],
+    "nextSteps": [
+      "Ascending-factorial (rising) Vandermonde via the descending↔ascending bridge Nat.add_descFactorial_eq_ascFactorial",
+      "The lowering recurrence (x+1)^(n) = x^(n) + n·x^(n-1) as the y = 1 specialisation",
+      "A unified umbral framework recording which Mathlib sequences (powers, falling/rising factorials) are of binomial type"
+    ],
+    "markdown": "# Knowledge Base: binomial-theorem-oq-03-oq-01-oq-03\n\n## Problem Understanding\n\nProve that the falling factorial obeys a Vandermonde-type convolution (x+y)^(n) = Σ_{k=0}^{n} C(n,k)·x^(k)·y^(n-k) — the umbral binomial theorem, identifying Nat.descFactorial as a sequence of binomial type.\n\n## Insights\n\nWriting every falling factorial as m^(j) = j!·C(m,j) turns each summand's coefficient into C(n,k)·k!·(n-k)! = n!, a global constant. Pulling it out reduces the statement to the ordinary Chu–Vandermonde identity. Mathlib has Chu–Vandermonde only in antidiagonal form, so a range-form repackaging (via sum_antidiagonal_eq_sum_range_succ_mk) is built along the way and is independently useful. The identity is unconditional over ℕ.\n\n## Dead Ends\n\nNone — the reduction-to-Chu–Vandermonde approach worked on the first attempt.\n"
+  },
+  "tags": [
+    "combinatorics",
+    "binomial-coefficients",
+    "falling-factorial",
+    "vandermonde",
+    "chu-vandermonde",
+    "umbral-calculus",
+    "binomial-type",
+    "mathlib"
+  ],
+  "relatedProofs": [
+    "binomial-theorem",
+    "binomial-theorem-oq-03",
+    "binomial-theorem-oq-03-oq-01",
+    "binomial-theorem-oq-03-oq-01-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Nat.add_choose_eq",
+      "Nat.descFactorial_eq_factorial_mul_choose",
+      "Nat.choose_mul_factorial_mul_factorial",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk"
+    ]
+  },
+  "started": "2026-06-22T13:00:00-07:00",
+  "lastUpdate": "2026-06-22T13:30:00-07:00",
+  "completed": "2026-06-22T13:30:00-07:00",
+  "significance": 7,
+  "tractability": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ01OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ01OQ03.lean",
+      "lineCount": 141,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ01OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## The Vandermonde Convolution for Falling Factorials

A self-generated open-question child of the solved `binomial-theorem-oq-03-oq-01` lineage, filling a genuine Mathlib gap.

### Result

The falling factorial is a **sequence of binomial type** — it obeys the umbral (Newton) binomial theorem. For all `x y n : ℕ`,

$$(x+y)^{\underline{n}} = \sum_{k=0}^{n}\binom{n}{k}\,x^{\underline{k}}\,y^{\underline{n-k}},$$

where `m^(j) = Nat.descFactorial m j`. Dividing both sides by `n!` collapses this to the ordinary Chu–Vandermonde identity `C(x+y,n) = Σ_k C(x,k)·C(y,n-k)`; the falling-factorial form is the polynomial-level refinement that keeps the factorials uncancelled.

### Proof

Rewrite every falling factorial as `m^(j) = j!·C(m,j)` (`Nat.descFactorial_eq_factorial_mul_choose`), so each summand carries the constant factor `C(n,k)·k!·(n-k)! = n!` (`Nat.choose_mul_factorial_mul_factorial`, valid because `k ≤ n` over `range (n+1)`). Pulling `n!` out of the sum reduces the statement to Chu–Vandermonde in **range form**, which is itself repackaged from Mathlib's antidiagonal `Nat.add_choose_eq` via `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk`. Unconditional over ℕ — the truncated subtraction `n - k` is harmless since `k ≤ n` throughout.

### Contents (`Proofs/BinomialTheoremOQ03OQ01OQ03.lean`, 141 L, 5 thm, 0 def, 0 sorry)

- `add_descFactorial_eq_sum` — the main falling-factorial Vandermonde convolution
- `add_choose_eq_sum_range` — Chu–Vandermonde in range form (also a Mathlib gap; the engine)
- `two_mul_descFactorial_eq_sum` — diagonal self-convolution `(2x)^(n) = Σ C(n,k)·x^(k)·x^(n-k)`
- `descFactorial_sum_comm` — symmetry of the convolution under `x ↔ y`
- `descFactorial_one_add` — the order-1 linear addition law
- five kernel-`decide` numeric sanity checks (incl. the `k > base` truncation case)

### Verification

- `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ03OQ01OQ03` — builds clean, no warnings
- `#print axioms` on all three main theorems: `[propext, Classical.choice, Quot.sound]` only — **0-axiom verified**, no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`

### Mathlib gap

Mathlib has Vandermonde only in antidiagonal form (`Nat.add_choose_eq`) and lacks both the range form and the falling-factorial (umbral) lift — both are natural upstream contributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)