### PR TITLE
research(banach-fixed-point-oq-01-oq-01): Picard–Lindelöf via contraction mapping — local existence and uniqueness

### DIFF
--- a/proofs/Proofs/PicardLindelofOQ01.lean
+++ b/proofs/Proofs/PicardLindelofOQ01.lean
@@ -1,0 +1,91 @@
+import Mathlib
+
+/-
+# Picard–Lindelöf via the contraction mapping principle: local existence and uniqueness
+
+The Picard–Lindelöf (Cauchy–Lipschitz) theorem is the prototypical application of the
+Banach contraction mapping principle.  To solve the autonomous initial value problem
+
+  `y'(t) = f(y(t))`,  `y(t₀) = x₀`,
+
+one rewrites it as the fixed-point equation `y = P y` for the **Picard integral
+operator** `(P y)(t) = x₀ + ∫_{t₀}^{t} f(y(s)) ds`.  When `f` is Lipschitz, `P` is a
+contraction on a suitable complete space of continuous curves on a short time interval,
+so Banach's theorem produces a unique fixed point — the local solution.
+
+Mathlib carries out exactly this construction internally (`IsPicardLindelof`, the
+`FunSpace` contraction, and `ODE_solution_unique` via Grönwall's inequality).  This file
+packages the two halves of the theorem for the autonomous problem `y' = f(y)` into clean,
+directly usable statements:
+
+* `exists_local_solution` — if `f` is `C¹` near `x₀` then the IVP has a local solution on
+  a genuine open time interval around `t₀` (existence, from the contraction fixed point).
+* `solution_unique` — if `f` is (globally) Lipschitz then any two solutions sharing an
+  initial value coincide on their common interval (uniqueness, from Grönwall).
+* `exists_unique_local_solution` — the two combined: a `C¹`, Lipschitz field admits a
+  local solution that is unique among all solutions on that interval.
+
+Everything is a 0-axiom derivation from Mathlib's ODE library.
+-/
+
+open Set Metric
+
+namespace PicardLindelofOQ01
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- **Picard–Lindelöf, local existence.**
+
+If the vector field `f : E → E` is continuously differentiable near `x₀`, then for any
+initial time `t₀` the autonomous initial value problem `y' = f(y)`, `y(t₀) = x₀` has a
+solution `α` on some genuine open interval `(t₀ - ε, t₀ + ε)` with `α t₀ = x₀`.
+
+This is the existence half of the Cauchy–Lipschitz theorem: the local solution is the
+fixed point of the Picard integral operator, obtained from Banach's contraction principle
+(carried out inside Mathlib's `IsPicardLindelof.of_contDiffAt_one`). -/
+theorem exists_local_solution [CompleteSpace E] {f : E → E} {x₀ : E} (hf : ContDiffAt ℝ 1 f x₀)
+    (t₀ : ℝ) :
+    ∃ ε > (0 : ℝ), ∃ α : ℝ → E, α t₀ = x₀ ∧
+      ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), HasDerivAt α (f (α t)) t := by
+  obtain ⟨r, hr, ε, hε, h⟩ :=
+    hf.exists_forall_mem_closedBall_exists_eq_forall_mem_Ioo_hasDerivAt t₀
+  obtain ⟨α, hα0, hαderiv⟩ := h x₀ (mem_closedBall_self hr.le)
+  exact ⟨ε, hε, α, hα0, hαderiv⟩
+
+/-- **Picard–Lindelöf, local uniqueness.**
+
+If the vector field `f : E → E` is Lipschitz continuous, then any two solutions of the
+autonomous equation `y' = f(y)` on an open interval `(a, b)` that agree at one interior
+point `t₀` agree on the whole interval.
+
+This is the uniqueness half of the Cauchy–Lipschitz theorem, a consequence of Grönwall's
+inequality (`ODE_solution_unique_of_mem_Ioo`); it is what makes the Picard fixed point the
+*unique* local solution. -/
+theorem solution_unique {f : E → E} {K : NNReal} (hf : LipschitzWith K f)
+    {a b t₀ : ℝ} {α β : ℝ → E} (ht₀ : t₀ ∈ Ioo a b)
+    (hα : ∀ t ∈ Ioo a b, HasDerivAt α (f (α t)) t)
+    (hβ : ∀ t ∈ Ioo a b, HasDerivAt β (f (β t)) t) (h0 : α t₀ = β t₀) :
+    EqOn α β (Ioo a b) :=
+  ODE_solution_unique_of_mem_Ioo (v := fun _ => f) (s := fun _ => univ)
+    (fun _ _ => hf.lipschitzOnWith) ht₀
+    (fun t ht => ⟨hα t ht, mem_univ _⟩) (fun t ht => ⟨hβ t ht, mem_univ _⟩) h0
+
+/-- **Picard–Lindelöf (Cauchy–Lipschitz), local existence and uniqueness.**
+
+If the vector field `f : E → E` is both `C¹` near `x₀` and globally Lipschitz, then the
+autonomous initial value problem `y' = f(y)`, `y(t₀) = x₀` has, on a genuine open interval
+around `t₀`, a solution `α` that is unique: any solution `β` on that interval with the same
+initial value `β t₀ = x₀` coincides with `α`. -/
+theorem exists_unique_local_solution [CompleteSpace E] {f : E → E} {x₀ : E} {K : NNReal}
+    (hf : ContDiffAt ℝ 1 f x₀) (hlip : LipschitzWith K f) (t₀ : ℝ) :
+    ∃ ε > (0 : ℝ), ∃ α : ℝ → E, (α t₀ = x₀ ∧
+        ∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), HasDerivAt α (f (α t)) t) ∧
+      ∀ β : ℝ → E, β t₀ = x₀ →
+        (∀ t ∈ Ioo (t₀ - ε) (t₀ + ε), HasDerivAt β (f (β t)) t) →
+          EqOn α β (Ioo (t₀ - ε) (t₀ + ε)) := by
+  obtain ⟨ε, hε, α, hα0, hαderiv⟩ := exists_local_solution hf t₀
+  have ht₀ : t₀ ∈ Ioo (t₀ - ε) (t₀ + ε) := by constructor <;> linarith
+  refine ⟨ε, hε, α, ⟨hα0, hαderiv⟩, fun β hβ0 hβderiv => ?_⟩
+  exact solution_unique hlip ht₀ hαderiv hβderiv (by rw [hα0, hβ0])
+
+end PicardLindelofOQ01

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "banach-fixed-point-oq-01-oq-01",
+  "title": "Picard–Lindelöf via the contraction mapping principle: local existence and uniqueness",
+  "slug": "banach-fixed-point-oq-01-oq-01",
+  "description": "The Picard–Lindelöf (Cauchy–Lipschitz) theorem is the prototypical application of the Banach contraction mapping principle: the initial value problem y' = f(y), y(t₀) = x₀ is recast as the fixed-point equation y = P y for the Picard integral operator (P y)(t) = x₀ + ∫ from t₀ to t of f(y(s)) ds, which is a contraction on a complete space of curves over a short time interval, so Banach's theorem yields a unique local solution. Mathlib carries out this construction internally (IsPicardLindelof, the FunSpace contraction, and ODE_solution_unique via Grönwall's inequality) but does not expose a clean autonomous existence-and-uniqueness statement. This entry packages the two halves for y' = f(y): exists_local_solution (C¹ vector field ⟹ a solution on a genuine open interval around t₀ with α t₀ = x₀, the existence half from the contraction fixed point), solution_unique (Lipschitz vector field ⟹ any two solutions agreeing at an interior point agree on the whole interval, the uniqueness half from Grönwall), and exists_unique_local_solution combining both: a C¹, Lipschitz field admits a local solution unique among all solutions on that interval. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Émile Picard / Ernst Lindelöf (classical); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PicardLindelofOQ01.lean",
+    "tags": [
+      "analysis",
+      "ordinary-differential-equations",
+      "picard-lindelof",
+      "cauchy-lipschitz",
+      "banach-fixed-point",
+      "contraction-mapping",
+      "existence-uniqueness",
+      "initial-value-problem",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ContDiffAt.exists_forall_mem_closedBall_exists_eq_forall_mem_Ioo_hasDerivAt",
+        "description": "For a vector field f continuously differentiable at x₀, there exist radius r and time ε such that every initial point in the closed ball admits an integral curve on the open time interval (t₀-ε, t₀+ε). The existence engine; internally builds IsPicardLindelof via IsPicardLindelof.of_contDiffAt_one and solves it by the FunSpace contraction.",
+        "module": "Mathlib.Analysis.ODE.PicardLindelof"
+      },
+      {
+        "theorem": "ODE_solution_unique_of_mem_Ioo",
+        "description": "Two solutions of y' = v(t, y) on an open interval that agree at one interior point agree on the whole interval, provided v is Lipschitz in y on the relevant set. Specialized to the autonomous, set = univ case it gives the uniqueness half. A consequence of Grönwall's inequality.",
+        "module": "Mathlib.Analysis.ODE.Gronwall"
+      },
+      {
+        "theorem": "LipschitzWith.lipschitzOnWith",
+        "description": "A globally Lipschitz function is Lipschitz on any set; supplies the Lipschitz-on-univ hypothesis of ODE_solution_unique_of_mem_Ioo from a global Lipschitz constant.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ],
+    "originalContributions": [
+      "exists_local_solution: for an autonomous vector field f : E → E that is C¹ near x₀ (E a complete normed space), the IVP y' = f(y), y(t₀) = x₀ has a solution on a genuine open interval (t₀-ε, t₀+ε) — the existence half of Cauchy–Lipschitz, stated cleanly from Mathlib's contraction-based local-flow theorem.",
+      "solution_unique: for a Lipschitz autonomous vector field, any two solutions of y' = f(y) on an open interval (a, b) that agree at one interior point t₀ coincide on (a, b) — the uniqueness half via Grönwall, with the time-independent vector field and set = univ specialization handled.",
+      "exists_unique_local_solution: the combined Cauchy–Lipschitz statement — a C¹ and globally Lipschitz field admits a local solution that is unique among all solutions on that interval with the same initial value. Packages existence and uniqueness into the single theorem the contraction mapping principle is famous for delivering."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas. The statements take the usual mathematical hypotheses of the Picard–Lindelöf theorem (complete normed space, C¹ / Lipschitz vector field) as ordinary hypotheses, not as unproved assumptions.",
+    "lineCount": 91,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Émile Picard's method of successive approximations (1890) and Ernst Lindelöf's refinement (1894) established that an initial value problem with a Lipschitz right-hand side has a unique local solution. The modern proof is the textbook showcase of Stefan Banach's contraction mapping principle (1922): the Picard integral operator P, y ↦ (t ↦ x₀ + ∫ f(y)), is a contraction on a complete space of continuous curves over a short enough time interval, so it has a unique fixed point — the solution. The result is also called the Cauchy–Lipschitz theorem.",
+    "problemStatement": "The Banach fixed-point theorem (the parent entry) guarantees a unique fixed point for a contraction on a complete metric space. Its headline application is local existence and uniqueness for the ODE y' = f(y): can the two halves be stated as clean, directly usable theorems for the autonomous initial value problem?\n\n**Answer:** Yes. Mathlib's contraction-based local-flow theorem gives existence for a C¹ field on a genuine open time interval; Grönwall's inequality gives uniqueness for a Lipschitz field; and the two combine into a single existence-and-uniqueness statement.",
+    "text": "The Picard–Lindelöf theorem for the autonomous IVP y' = f(y) is packaged into clean existence (from the Picard contraction), uniqueness (from Grönwall), and combined existence-and-uniqueness theorems — all with 0 axioms.",
+    "proofStrategy": "1. exists_local_solution: apply Mathlib's ContDiffAt.exists_forall_mem_closedBall_exists_eq_forall_mem_Ioo_hasDerivAt (which builds IsPicardLindelof from the C¹ hypothesis and solves it by the FunSpace contraction), then instantiate the initial point at the centre x₀ (which lies in the closed ball since r > 0).\n2. solution_unique: apply ODE_solution_unique_of_mem_Ioo with the time-independent vector field v t := f and set s t := univ; the Lipschitz-on-univ hypothesis comes from LipschitzWith.lipschitzOnWith and membership in univ is trivial.\n3. exists_unique_local_solution: take the solution from exists_local_solution, note t₀ lies in (t₀-ε, t₀+ε), and feed any competing solution with the same initial value into solution_unique.",
+    "keyInsights": [
+      "**Existence is a fixed point; uniqueness is Grönwall.** The two halves of Cauchy–Lipschitz come from different machinery — the contraction mapping principle produces the solution, while Grönwall's inequality (a comparison estimate for the growth of the gap between two solutions) forces it to be the only one.",
+      "**Autonomous is the clean case.** Writing the vector field as time-independent (v t := f) and the constraint set as univ collapses the general Mathlib uniqueness lemma to exactly the y' = f(y) statement, with all the time-dependence and domain bookkeeping discharged.",
+      "**C¹ for existence, Lipschitz for uniqueness.** C¹ near x₀ is what Mathlib needs to manufacture the Picard–Lindelöf data automatically; global Lipschitz is the natural hypothesis for the Grönwall comparison. The combined theorem simply asks for both.",
+      "**The contraction lives inside Mathlib.** The Banach fixed-point step is carried out in Mathlib's FunSpace construction; this entry exposes the resulting existence/uniqueness facts in the form a user of the theorem actually wants."
+    ],
+    "exampleSections": [
+      {
+        "title": "Linear flow",
+        "mathContext": "For f(y) = A y a bounded linear vector field on a Banach space (C¹ and Lipschitz with constant ‖A‖), exists_unique_local_solution gives the unique local solution y(t) = exp((t-t₀)A) x₀ of y' = A y, y(t₀) = x₀ — the prototype the contraction mapping argument was designed to capture."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Picard, Émile",
+      "title": "Mémoire sur la théorie des équations aux dérivées partielles et la méthode des approximations successives",
+      "year": "1890",
+      "note": "J. Math. Pures Appl. 6, 145–210 — the method of successive approximations."
+    },
+    {
+      "authors": "Lindelöf, Ernst",
+      "title": "Sur l'application de la méthode des approximations successives aux équations différentielles ordinaires du premier ordre",
+      "year": "1894",
+      "note": "C. R. Acad. Sci. Paris 118, 454–457 — the sharpened existence-uniqueness statement."
+    },
+    {
+      "authors": "Banach, Stefan",
+      "title": "Sur les opérations dans les ensembles abstraits et leur application aux équations intégrales",
+      "year": "1922",
+      "note": "Fund. Math. 3, 133–181 — the contraction mapping principle underlying the proof."
+    },
+    {
+      "authors": "Teschl, Gerald",
+      "title": "Ordinary Differential Equations and Dynamical Systems",
+      "year": "2012",
+      "note": "American Mathematical Society — Chapter 2 develops Picard–Lindelöf as an application of the contraction mapping principle."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "banach-fixed-point-oq-01",
+      "reason": "The parent entry: the Banach contraction mapping theorem (existence and uniqueness of a fixed point for a contraction on a complete space), of which Picard–Lindelöf is the canonical application."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Picard–Lindelöf (Cauchy–Lipschitz) theorem for the autonomous initial value problem y' = f(y), y(t₀) = x₀ is packaged into three verified theorems: local existence from a C¹ vector field (exists_local_solution, via Mathlib's contraction-based local flow), local uniqueness from a Lipschitz vector field (solution_unique, via Grönwall's inequality), and their combination (exists_unique_local_solution). All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Exposes the existence and uniqueness halves of the Cauchy–Lipschitz theorem — the headline application of the Banach fixed-point principle — as clean, reusable statements for the autonomous ODE, complementing the parent contraction mapping entry.",
+    "openQuestions": [
+      "State the non-autonomous version y' = F(t, y) with F Lipschitz in y and continuous in t, packaging IsPicardLindelof's full hypothesis set directly.",
+      "Expose the Picard iteration P y = x₀ + ∫ f(y) and its contraction constant explicitly, recovering the solution as an explicit limit of successive approximations rather than an abstract fixed point.",
+      "Quantify the interval of existence ε in terms of the Lipschitz constant and the bound on f, recovering the classical estimate ε ≥ min(a/L, 1/K)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Metric"
+    ],
+    "namespace": "PicardLindelofOQ01",
+    "lineCount": 91,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/PicardLindelofOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **banach-fixed-point-oq-01-oq-01**: packages the headline application of the Banach contraction mapping principle — the **Picard–Lindelöf / Cauchy–Lipschitz** theorem for the autonomous IVP `y' = f(y)`, `y(t₀) = x₀` — into clean, directly usable statements. **0 axioms, 0 sorries, no `native_decide`** — Docker build green (7743 jobs).

The Picard integral operator `(P y)(t) = x₀ + ∫_{t₀}^{t} f(y(s)) ds` is a contraction on a complete space of curves over a short time interval; Banach's theorem gives a unique fixed point — the local solution. Mathlib performs this construction internally (`IsPicardLindelof`, the `FunSpace` contraction, `ODE_solution_unique` via Grönwall) but does not expose a clean autonomous existence-and-uniqueness theorem.

## Theorems (`Proofs/PicardLindelofOQ01.lean`, 91 lines, 3 theorems)

- **`exists_local_solution`** — `f` is `C¹` near `x₀` ⟹ a solution on a genuine open interval `(t₀-ε, t₀+ε)` with `α t₀ = x₀` (existence, from the Picard contraction fixed point).
- **`solution_unique`** — `f` Lipschitz ⟹ any two solutions of `y' = f(y)` agreeing at one interior point agree on the whole open interval (uniqueness, via Grönwall / `ODE_solution_unique_of_mem_Ioo`).
- **`exists_unique_local_solution`** — the combined Cauchy–Lipschitz statement: a `C¹`, globally Lipschitz field admits a local solution unique among all solutions on that interval.

## Verification

```
#print axioms → [propext, Classical.choice, Quot.sound]   -- foundational only
```

No `sorryAx`, no `Lean.ofReduceBool`. `status: verified`, `axiomCount: 0`. Cross-references the parent Banach contraction mapping entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)