### PR TITLE
research(binomial-theorem-oq-03-oq-01-oq-02): the alternating (signed) falling-factorial moment Σ(-1)ᵏ·k^(r)·C(n,k) = (-1)ʳ·n^(r)·[n=r]

### DIFF
--- a/proofs/Proofs/BinomialTheoremOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/BinomialTheoremOQ03OQ01OQ02.lean
@@ -1,0 +1,175 @@
+/-
+# The Alternating (Signed) Falling-Factorial Moment — Finite Differences (OQ-03-OQ-01-OQ-02)
+
+Research Question (follow-up to OQ-03-OQ-01 "Combinatorial Moments of the
+Binomial Coefficients").  The parent computes the *unsigned* moments
+
+    Σ_{k=0}^{n} k·C(n,k)      = n·2ⁿ⁻¹,
+    Σ_{k=0}^{n} k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²,   …
+
+— the values of `(d/dx)^r (1+x)ⁿ` at `x = +1`.  What happens at the *other*
+natural evaluation point `x = -1`, i.e. what are the **signed** moments
+
+    Σ_{k=0}^{n} (-1)ᵏ · k^(r) · C(n,k)            (k^(r) = Nat.descFactorial k r)?
+
+Unlike the unsigned case, where `(1+x)ⁿ⁻ʳ` is still large at `x = 1`, here the
+factor `(1+x)ⁿ⁻ʳ` *vanishes* at `x = -1` for every `r < n`.  This is the
+generating-function shadow of the classical **finite-difference** fact: the
+`n`-th forward difference annihilates every polynomial of degree `< n`.
+
+Answer.  For all `n r : ℕ`,
+
+    Σ_{k=0}^{n} (-1)ᵏ · k^(r) · C(n,k) = (-1)ʳ · n^(r) · [n = r],
+
+a single closed form (`[P]` is the Iverson bracket, `1` if `P` else `0`).  In
+particular the sum **vanishes whenever `n ≠ r`** — for `r < n` because the
+polynomial `k^(r)` has degree `r < n`, and for `r > n` because every term is
+zero — and at the diagonal `r = n` it peaks at
+
+    Σ_{k=0}^{n} (-1)ᵏ · k^(n) · C(n,k) = (-1)ⁿ · n!.
+
+None of these signed moments is in Mathlib (Mathlib has only the zeroth one,
+`Int.alternating_sum_range_choose : Σ (-1)ᵏ C(n,k) = [n = 0]`).
+
+The proof reuses the parent's single *absorption* identity
+`(k+1)·C(m+1,k+1) = (m+1)·C(m,k)`.  Over ℤ it lifts the signed sum to the
+recurrence
+
+    T(m+1, r+1) = -(m+1) · T(m, r),     T(n, 0) = [n = 0],
+
+— identical to the unsigned recurrence `S(m+1,r+1) = (m+1)·S(m,r)` of OQ-01 but
+carrying the extra minus sign produced by reindexing `k ↦ k+1` against `(-1)ᵏ`.
+Iterating it `r` times unfolds `n^(r)` through `descFactorial` and lands the base
+case `T(n-r, 0)`, which is Mathlib's alternating binomial sum.  The whole proof
+is one induction on `r`; everything stays exact over ℤ.
+
+Tags: combinatorics, binomial-coefficients, moments, falling-factorial,
+finite-differences, alternating-sum, absorption, generating-functions
+-/
+
+import Mathlib
+import Proofs.BinomialTheoremOQ03
+
+open Finset BigOperators
+
+namespace BinomialTheoremOQ03OQ01OQ02
+
+/-! ## Part I: The signed absorption step
+
+The engine of the induction.  Reindexing `k ↦ k+1` against the alternating sign
+`(-1)ᵏ` is what turns the parent's positive recurrence into a *signed* one. -/
+
+/-- **Signed falling-factorial absorption step.**  Peeling the vanishing `k = 0`
+term, reindexing `k ↦ k+1`, and applying the single absorption identity
+`(k+1)·C(m+1,k+1) = (m+1)·C(m,k)` term-by-term turns the `(r+1)`-th *signed*
+falling-factorial sum over `range (m+2)` into `-(m+1)` times the `r`-th signed
+falling-factorial sum over `range (m+1)`.  The minus sign comes from the
+`(-1)ᵏ⁺¹ = -(-1)ᵏ` produced by the reindex; everything else is exactly the
+parent's positive step. -/
+theorem signed_step (m r : ℕ) :
+    ∑ k ∈ range (m + 2),
+        (-1 : ℤ) ^ k * (k.descFactorial (r + 1) : ℤ) * ((m + 1).choose k : ℤ)
+      = -(m + 1 : ℤ) *
+          ∑ k ∈ range (m + 1),
+            (-1 : ℤ) ^ k * (k.descFactorial r : ℤ) * (m.choose k : ℤ) := by
+  rw [Finset.sum_range_succ']
+  -- the peeled `k = 0` term is `(-1)⁰ · 0^(r+1) · C(m+1,0) = 0`
+  simp only [Nat.zero_descFactorial_succ, Nat.cast_zero, mul_zero, zero_mul, add_zero]
+  rw [Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k _
+  -- (k+1)^(r+1) = (k+1) · k^(r), and absorption rewrites the choose product
+  rw [Nat.succ_descFactorial_succ]
+  have habZ : ((k : ℤ) + 1) * ((m + 1).choose (k + 1) : ℤ)
+      = ((m : ℤ) + 1) * (m.choose k : ℤ) := by
+    exact_mod_cast BinomialTheoremOQ03.absorption m k
+  push_cast
+  linear_combination (-((-1 : ℤ) ^ k) * (k.descFactorial r : ℤ)) * habZ
+
+/-! ## Part II: The general signed moment (Iverson-bracket closed form) -/
+
+/-- **General signed falling-factorial moment.**  For all `n r : ℕ`,
+
+    Σ_{k=0}^{n} (-1)ᵏ · k^(r) · C(n,k) = (-1)ʳ · n^(r) · [n = r],
+
+where `k^(r) = Nat.descFactorial k r` and `[n = r] = if n = r then 1 else 0`.
+Proved by induction on `r`: the base case `r = 0` is Mathlib's alternating
+binomial sum `Σ (-1)ᵏ C(n,k) = [n = 0]`, and the step is the recurrence
+`signed_step` (`T(m+1,r+1) = -(m+1)·T(m,r)`) together with
+`Nat.succ_descFactorial_succ`.  Holds unconditionally; for `n ≠ r` the right-hand
+side is `0`. -/
+theorem signed_descFactorial_moment (n r : ℕ) :
+    ∑ k ∈ range (n + 1),
+        (-1 : ℤ) ^ k * (k.descFactorial r : ℤ) * (n.choose k : ℤ)
+      = (-1 : ℤ) ^ r * (n.descFactorial r : ℤ) * (if n = r then 1 else 0) := by
+  induction r generalizing n with
+  | zero =>
+    -- `k^(0) = 1`, so this is exactly the alternating binomial sum
+    simpa [Nat.descFactorial_zero] using
+      (Int.alternating_sum_range_choose (n := n))
+  | succ r ih =>
+    cases n with
+    | zero =>
+      -- the only term is `k = 0`, whose `0^(r+1) = 0`; RHS is `[0 = r+1] = 0` too
+      simp
+    | succ m =>
+      rw [signed_step m r, ih m, Nat.succ_descFactorial_succ]
+      rcases eq_or_ne m r with h | h
+      · subst h
+        rw [if_pos rfl, if_pos rfl]
+        push_cast
+        ring
+      · rw [if_neg h, if_neg (show m + 1 ≠ r + 1 by omega)]
+        ring
+
+/-! ## Part III: Vanishing (finite differences) and the diagonal peak -/
+
+/-- **Vanishing off the diagonal.**  Whenever `n ≠ r`,
+
+    Σ_{k=0}^{n} (-1)ᵏ · k^(r) · C(n,k) = 0.
+
+For `r < n` this is the finite-difference annihilation of a degree-`r` polynomial
+by the `n`-th alternating sum; for `r > n` every term already vanishes. -/
+theorem signed_descFactorial_moment_of_ne (n r : ℕ) (h : n ≠ r) :
+    ∑ k ∈ range (n + 1),
+        (-1 : ℤ) ^ k * (k.descFactorial r : ℤ) * (n.choose k : ℤ) = 0 := by
+  rw [signed_descFactorial_moment, if_neg h, mul_zero]
+
+/-- **Diagonal peak.**  At `r = n` the signed falling-factorial moment is the
+nonzero extreme
+
+    Σ_{k=0}^{n} (-1)ᵏ · k^(n) · C(n,k) = (-1)ⁿ · n!.
+
+This is the `n`-th finite difference of the leading monomial `x^(n)`, equal to
+`n!` (up to the alternating sign), and the discrete analogue of `dⁿ/dxⁿ xⁿ = n!`. -/
+theorem signed_descFactorial_moment_diagonal (n : ℕ) :
+    ∑ k ∈ range (n + 1),
+        (-1 : ℤ) ^ k * (k.descFactorial n : ℤ) * (n.choose k : ℤ)
+      = (-1 : ℤ) ^ n * (n.factorial : ℤ) := by
+  rw [signed_descFactorial_moment, if_pos rfl, Nat.descFactorial_self]
+  ring
+
+/-! ## Part IV: Concrete signed power moments (companions to the parent) -/
+
+/-- **Signed first moment.**  `Σ_{k=0}^{n} (-1)ᵏ · k · C(n,k) = 0` for `n ≥ 2`.
+The alternating companion of the parent's `Σ k·C(n,k) = n·2ⁿ⁻¹`: weighting the
+binomial coefficients by `k` and alternating signs sums to zero once `n` exceeds
+the degree `1`.  (At `n = 1` the sum is `-1`, the diagonal peak.) -/
+theorem alternating_sum_id_mul_choose (n : ℕ) (h : 2 ≤ n) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * (k : ℤ) * (n.choose k : ℤ) = 0 := by
+  have hkey := signed_descFactorial_moment_of_ne n 1 (by omega)
+  simpa [Nat.descFactorial_one] using hkey
+
+/-- **Signed second factorial moment.**  `Σ_{k=0}^{n} (-1)ᵏ · k(k-1) · C(n,k) = 0`
+for `n ≥ 3`.  The alternating companion of the parent's
+`Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²`; it vanishes once `n` exceeds the degree `2`. -/
+theorem alternating_sum_descFactorial2_mul_choose (n : ℕ) (h : 3 ≤ n) :
+    ∑ k ∈ range (n + 1), (-1 : ℤ) ^ k * ((k * (k - 1) : ℕ) : ℤ) * (n.choose k : ℤ) = 0 := by
+  have hkey := signed_descFactorial_moment_of_ne n 2 (by omega)
+  have hdf : ∀ k : ℕ, k.descFactorial 2 = k * (k - 1) := fun k => by
+    rw [show (2 : ℕ) = 1 + 1 from rfl, Nat.descFactorial_succ, Nat.descFactorial_one,
+      Nat.mul_comm]
+  simp only [hdf] at hkey
+  exact hkey
+
+end BinomialTheoremOQ03OQ01OQ02

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-02/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "signed-moments-context",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 55 },
+    "type": "concept",
+    "title": "The Other Evaluation Point: x = -1 and Finite Differences",
+    "content": "The parent computes the unsigned moments Σ k^(r)·C(n,k) — the derivatives of (1+x)ⁿ = Σ C(n,k)xᵏ at x = +1, where the factor (1+x)ⁿ⁻ʳ = 2ⁿ⁻ʳ is large. Inserting the alternating sign (-1)ᵏ evaluates the same derivatives at x = -1, where (1+x)ⁿ⁻ʳ vanishes for every r < n. The signed moments therefore collapse to a single Iverson-bracket form Σ (-1)ᵏ·k^(r)·C(n,k) = (-1)ʳ·n^(r)·[n = r]: zero off the diagonal, peaking at (-1)ⁿ·n! when r = n. This is the generating-function shadow of the finite-difference fact that the n-th forward difference kills every polynomial of degree < n.",
+    "mathContext": "$\\sum_{k=0}^{n}(-1)^k k^{\\underline{r}}\\binom{n}{k} = (-1)^r n^{\\underline{r}}[n=r]$, the value of the falling-factorial-weighted derivative of $(1+x)^n$ at $x=-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "finite differences",
+      "alternating binomial sums",
+      "falling factorial Nat.descFactorial",
+      "generating functions at x = -1"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Int.alternating_sum_range_choose",
+      "the binomial theorem"
+    ]
+  },
+  {
+    "id": "signed-recurrence",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 69, "endLine": 88 },
+    "type": "technique",
+    "title": "The Signed Recurrence T(m+1,r+1) = -(m+1)·T(m,r)",
+    "content": "Peeling the vanishing k = 0 term and reindexing k ↦ k+1 turns each summand into (-1)ᵏ⁺¹·(k+1)^(r+1)·C(m+1,k+1). Then Nat.succ_descFactorial_succ splits (k+1)^(r+1) = (k+1)·k^(r) and the grandparent's absorption rewrites (k+1)·C(m+1,k+1) = (m+1)·C(m,k). The sign (-1)ᵏ⁺¹ = -(-1)ᵏ supplies the minus, yielding the parent's positive recurrence with one extra negative factor. Each term closes by `linear_combination` against the cast absorption identity.",
+    "mathContext": "$\\sum_{k\\le m+1}(-1)^k k^{\\underline{r+1}}\\binom{m+1}{k} = -(m+1)\\sum_{k\\le m}(-1)^k k^{\\underline{r}}\\binom{m}{k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absorption identity (k+1)C(m+1,k+1) = (m+1)C(m,k)",
+      "index shift Finset.sum_range_succ'",
+      "sign flip from reindexing"
+    ],
+    "prerequisites": [
+      "BinomialTheoremOQ03.absorption",
+      "Nat.succ_descFactorial_succ",
+      "Finset.sum_range_succ'",
+      "linear_combination"
+    ]
+  },
+  {
+    "id": "general-closed-form",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 124 },
+    "type": "key-step",
+    "title": "One Induction on r Lands the Closed Form",
+    "content": "Induction on r: the base case r = 0 is Mathlib's Int.alternating_sum_range_choose : Σ (-1)ᵏ·C(n,k) = [n = 0]. The step rewrites the sum with signed_step, applies the induction hypothesis, lowers the falling factorial with Nat.succ_descFactorial_succ, and splits on whether m = r to align the Iverson brackets [m = r] and [m+1 = r+1]. The whole closed form (-1)ʳ·n^(r)·[n = r] falls out unconditionally.",
+    "mathContext": "Iterating $T(m+1,r+1) = -(m+1)T(m,r)$ unfolds $n^{\\underline r}$ through the falling factorial and reaches the base case $T(n-r,0) = [n=r]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction on falling-factorial order",
+      "Iverson bracket closed form",
+      "signed binomial moments"
+    ],
+    "prerequisites": [
+      "Int.alternating_sum_range_choose",
+      "signed_step recurrence",
+      "Nat.succ_descFactorial_succ"
+    ]
+  },
+  {
+    "id": "vanishing-peak",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 133, "endLine": 151 },
+    "type": "concept",
+    "title": "Finite-Difference Vanishing and the Diagonal Peak",
+    "content": "For n ≠ r the bracket [n = r] is zero, so the signed moment vanishes — for r < n this is the annihilation of a degree-r polynomial by the n-th alternating sum, and for r > n every term is already zero. At r = n the bracket is one and n^(n) = n! (Nat.descFactorial_self), giving the sharp value (-1)ⁿ·n!, the discrete analogue of dⁿ/dxⁿ xⁿ = n!.",
+    "mathContext": "$\\sum_{k}(-1)^k k^{\\underline r}\\binom{n}{k} = 0$ for $n \\ne r$, and $= (-1)^n n!$ at $r = n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "finite-difference annihilation",
+      "leading term n! ",
+      "discrete derivative"
+    ],
+    "prerequisites": [
+      "signed_descFactorial_moment closed form",
+      "Nat.descFactorial_self"
+    ]
+  },
+  {
+    "id": "concrete-companions",
+    "proofId": "binomial-theorem-oq-03-oq-01-oq-02",
+    "range": { "startLine": 158, "endLine": 175 },
+    "type": "concept",
+    "title": "Concrete Companions of the Parent's Moments",
+    "content": "Specialising r = 1 and r = 2 gives the alternating versions of the parent's first two moments: Σ (-1)ᵏ·k·C(n,k) = 0 for n ≥ 2 (against the parent's Σ k·C(n,k) = n·2ⁿ⁻¹), and Σ (-1)ᵏ·k(k-1)·C(n,k) = 0 for n ≥ 3 (against Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²). Same weights and coefficients as the parent, but summed against alternating signs they vanish once n exceeds the polynomial's degree.",
+    "mathContext": "$\\sum_k(-1)^k k\\binom{n}{k}=0\\ (n\\ge2)$, $\\sum_k(-1)^k k(k-1)\\binom{n}{k}=0\\ (n\\ge3)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "signed first moment",
+      "signed second factorial moment",
+      "degree threshold"
+    ],
+    "prerequisites": [
+      "signed_descFactorial_moment_of_ne",
+      "Nat.descFactorial_one",
+      "Nat.descFactorial_succ"
+    ]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-01-oq-02/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "binomial-theorem-oq-03-oq-01-oq-02",
+  "title": "The Alternating Falling-Factorial Moment — Finite Differences",
+  "slug": "binomial-theorem-oq-03-oq-01-oq-02",
+  "description": "The signed (alternating) moments Σ_{k=0}^{n} (-1)ᵏ·k^(r)·C(n,k) of the binomial coefficients, where k^(r) = Nat.descFactorial k r is the falling factorial. They have the single closed form (-1)ʳ·n^(r)·[n = r]: the sum vanishes whenever n ≠ r and peaks at (-1)ⁿ·n! on the diagonal r = n. This is the generating-function shadow of the classical finite-difference fact that the n-th alternating sum annihilates every polynomial of degree < n. The sibling of the unsigned moments (parent OQ-03-OQ-01, evaluation at x = +1); here the evaluation is at x = -1, where (1+x)ⁿ⁻ʳ vanishes. None of these signed moments is in Mathlib, which has only the zeroth one (Int.alternating_sum_range_choose). The whole result is one induction on r off the parent's absorption identity (k+1)·C(m+1,k+1) = (m+1)·C(m,k).",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ03OQ01OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 175,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "assumptions": "None. Every identity is fully machine-checked over ℤ. The general closed form signed_descFactorial_moment, the off-diagonal vanishing signed_descFactorial_moment_of_ne, and the diagonal peak signed_descFactorial_moment_diagonal all hold unconditionally for the stated quantifiers. The two concrete power-moment corollaries carry the natural degree thresholds (n ≥ 2 for the first moment, n ≥ 3 for the second factorial moment) below which the sum sits on or past its diagonal peak. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; no Lean.ofReduceBool, no native_decide, no sorryAx.",
+    "tags": [
+      "combinatorics",
+      "binomial-coefficients",
+      "moments",
+      "falling-factorial",
+      "finite-differences",
+      "alternating-sum",
+      "absorption",
+      "generating-functions",
+      "mathlib-contribution",
+      "research"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "signed_descFactorial_moment: the general closed form Σ_{k=0}^{n} (-1)ᵏ·k^(r)·C(n,k) = (-1)ʳ·n^(r)·[n = r] for all n, r — the alternating (x = -1) companion of the parent's unsigned (x = +1) falling-factorial moment, absent from Mathlib",
+      "signed_descFactorial_moment_of_ne: the finite-difference vanishing Σ_{k=0}^{n} (-1)ᵏ·k^(r)·C(n,k) = 0 whenever n ≠ r — for r < n the n-th alternating sum annihilates the degree-r polynomial k^(r); for r > n every term vanishes",
+      "signed_descFactorial_moment_diagonal: the diagonal peak Σ_{k=0}^{n} (-1)ᵏ·k^(n)·C(n,k) = (-1)ⁿ·n!, the discrete analogue of dⁿ/dxⁿ xⁿ = n!",
+      "signed_step: the signed absorption recurrence T(m+1, r+1) = -(m+1)·T(m, r) over ℤ — the parent's positive recurrence acquiring a minus sign from reindexing k ↦ k+1 against (-1)ᵏ, the sole engine of the induction",
+      "alternating_sum_id_mul_choose and alternating_sum_descFactorial2_mul_choose: the concrete signed first and second factorial moments Σ (-1)ᵏ·k·C(n,k) = 0 (n ≥ 2) and Σ (-1)ᵏ·k(k-1)·C(n,k) = 0 (n ≥ 3), the alternating companions of the parent's Σ k·C(n,k) = n·2ⁿ⁻¹ and Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.alternating_sum_range_choose",
+        "description": "Σ_{m ∈ range (n+1)} (-1)ᵐ·C(n,m) = if n = 0 then 1 else 0, the zeroth signed moment. This is the only alternating binomial sum Mathlib provides and the base case (r = 0) onto which every signed moment here collapses.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "BinomialTheoremOQ03.absorption",
+        "description": "(k+1)·C(m+1,k+1) = (m+1)·C(m,k), proved in the grandparent. Cast to ℤ it drives the signed recurrence: after reindexing k ↦ k+1 it rewrites each choose product, the (-1)ᵏ⁺¹ = -(-1)ᵏ supplying the sign.",
+        "module": "Proofs.BinomialTheoremOQ03"
+      },
+      {
+        "theorem": "Nat.succ_descFactorial_succ",
+        "description": "(k+1).descFactorial (r+1) = (k+1)·k.descFactorial r. Lowers the falling-factorial order by one in the inductive step, pulling out the leading (k+1) that absorption then converts into the (m+1) coefficient.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.descFactorial_self",
+        "description": "n.descFactorial n = n!. Identifies the diagonal value n^(n) with n!, turning the peak into (-1)ⁿ·n!.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Σ_{i ∈ range (n+1)} f i = (Σ_{i ∈ range n} f (i+1)) + f 0. Peels the vanishing k = 0 term and reindexes k ↦ k+1 so absorption applies term-by-term; the reindex is exactly where the alternating sign flips.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "b · Σ f = Σ (b · f). Pulls the constant -(m+1) out of the recurrence's right-hand side so the induction hypothesis can be applied under a single Finset.sum_congr.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/BinomialTheoremOQ03OQ01OQ02.lean",
+    "namespace": "BinomialTheoremOQ03OQ01OQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 175,
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "overview": [
+    "The parent entry, *Combinatorial Moments of the Binomial Coefficients*, computes the unsigned sums Σ k·C(n,k), Σ k(k-1)·C(n,k), … — the values of the derivatives of the generating function (1+x)ⁿ = Σ C(n,k)xᵏ evaluated at x = +1. This follow-up evaluates the same derivatives at the other natural point, x = -1, by inserting the alternating sign (-1)ᵏ. The question becomes: what are the signed moments Σ_{k=0}^{n} (-1)ᵏ·k^(r)·C(n,k)?",
+    "Where the unsigned case keeps the large factor (1+x)ⁿ⁻ʳ = 2ⁿ⁻ʳ at x = 1, the signed case kills it: (1+x)ⁿ⁻ʳ = 0 at x = -1 for every r < n. This is the generating-function form of the classical finite-difference fact that the n-th forward difference annihilates every polynomial of degree < n. The result is a single Iverson-bracket closed form Σ (-1)ᵏ·k^(r)·C(n,k) = (-1)ʳ·n^(r)·[n = r], vanishing off the diagonal and peaking at (-1)ⁿ·n! when r = n.",
+    "None of these signed moments is in Mathlib, which supplies only the zeroth one, Int.alternating_sum_range_choose : Σ (-1)ᵏ·C(n,k) = [n = 0]. That lemma is exactly the base case of the induction here.",
+    "The proof reuses the grandparent's single absorption identity (k+1)·C(m+1,k+1) = (m+1)·C(m,k). Cast to ℤ and combined with the reindex k ↦ k+1 — which turns (-1)ᵏ⁺¹ into -(-1)ᵏ — it lifts the signed sum to the recurrence T(m+1, r+1) = -(m+1)·T(m, r), the parent's positive recurrence with one extra minus sign. A single induction on r unfolds n^(r) through descFactorial and lands the base case; everything stays exact over ℤ."
+  ],
+  "conclusion": [
+    "The signed falling-factorial moments collapse to one formula, Σ_{k=0}^{n} (-1)ᵏ·k^(r)·C(n,k) = (-1)ʳ·n^(r)·[n = r]. Off the diagonal the sum is identically zero — the finite-difference annihilation of low-degree polynomials — and on the diagonal it attains the sharp value (-1)ⁿ·n!, the discrete shadow of dⁿ/dxⁿ xⁿ = n!.",
+    "Together with the parent's unsigned moments, this entry pins down both natural evaluation points of the binomial generating function's derivatives: x = +1 gives the 2ⁿ⁻ʳ-scaled moments, x = -1 gives the finite differences. A single absorption identity, with or without the alternating sign, produces the whole pair.",
+    "Because these closed forms extend Mathlib's `Nat.Choose.Sum` — which stops at the zeroth signed moment Int.alternating_sum_range_choose — they are natural upstream contributions sitting one induction away from material Mathlib already has."
+  ],
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "File docstring stating the research question (evaluation at x = -1), the Iverson-bracket closed form, and the finite-difference interpretation; `import Mathlib` together with `import Proofs.BinomialTheoremOQ03` to reuse the grandparent's absorption lemma, `open Finset BigOperators`, and the `BinomialTheoremOQ03OQ01OQ02` namespace.",
+      "mathContext": "The grandparent's `absorption` is the only non-Mathlib input; the base case is Mathlib's `Int.alternating_sum_range_choose`."
+    },
+    {
+      "id": "signed-step",
+      "title": "Part I — The Signed Absorption Step",
+      "startLine": 57,
+      "endLine": 88,
+      "summary": "`signed_step` proves the recurrence Σ_{k≤m+1} (-1)ᵏ·k^(r+1)·C(m+1,k) = -(m+1)·Σ_{k≤m} (-1)ᵏ·k^(r)·C(m,k) by peeling the vanishing k = 0 term, reindexing k ↦ k+1, applying `Nat.succ_descFactorial_succ` and the grandparent's absorption term-by-term, and closing each term with `linear_combination` against the cast absorption identity.",
+      "mathContext": "This is the parent's positive recurrence S(m+1,r+1) = (m+1)·S(m,r) carrying the minus sign produced by (-1)ᵏ⁺¹ = -(-1)ᵏ — the sole structural difference between the signed and unsigned moments."
+    },
+    {
+      "id": "general-moment",
+      "title": "Part II — The General Signed Moment",
+      "startLine": 89,
+      "endLine": 124,
+      "summary": "`signed_descFactorial_moment` proves Σ_{k=0}^{n} (-1)ᵏ·k^(r)·C(n,k) = (-1)ʳ·n^(r)·[n = r] for all n, r by induction on r: the base case r = 0 is `Int.alternating_sum_range_choose`, and the step combines `signed_step`, the induction hypothesis, and `Nat.succ_descFactorial_succ`, with an `eq_or_ne m r` split to align the two Iverson brackets.",
+      "mathContext": "The single closed form subsumes every signed moment; iterating the recurrence unfolds n^(r) through descFactorial and lands the base case at n - r."
+    },
+    {
+      "id": "vanishing-and-peak",
+      "title": "Part III — Vanishing and the Diagonal Peak",
+      "startLine": 125,
+      "endLine": 151,
+      "summary": "`signed_descFactorial_moment_of_ne` reads off Σ (-1)ᵏ·k^(r)·C(n,k) = 0 for every n ≠ r (the if-branch is false), and `signed_descFactorial_moment_diagonal` reads off Σ (-1)ᵏ·k^(n)·C(n,k) = (-1)ⁿ·n! at r = n via `Nat.descFactorial_self`.",
+      "mathContext": "Off-diagonal vanishing is the finite-difference annihilation of degree-r polynomials by the n-th alternating sum; the diagonal peak (-1)ⁿ·n! is the discrete analogue of dⁿ/dxⁿ xⁿ = n!."
+    },
+    {
+      "id": "concrete-power-moments",
+      "title": "Part IV — Concrete Signed Power Moments",
+      "startLine": 152,
+      "endLine": 175,
+      "summary": "`alternating_sum_id_mul_choose` gives Σ (-1)ᵏ·k·C(n,k) = 0 for n ≥ 2 (the r = 1 case, via `Nat.descFactorial_one`), and `alternating_sum_descFactorial2_mul_choose` gives Σ (-1)ᵏ·k(k-1)·C(n,k) = 0 for n ≥ 3 (the r = 2 case, with descFactorial 2 rewritten to k(k-1)).",
+      "mathContext": "These are the alternating companions of the parent's Σ k·C(n,k) = n·2ⁿ⁻¹ and Σ k(k-1)·C(n,k) = n(n-1)·2ⁿ⁻²: the same weights, the same coefficients, but summed against alternating signs to zero once n exceeds the degree."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-03-oq-01",
+      "relationship": "parent",
+      "description": "Computes the unsigned moments Σ k·C(n,k) = n·2ⁿ⁻¹, etc. (the generating-function derivatives at x = +1). This entry is the alternating companion, evaluating the same derivatives at x = -1 to obtain the finite differences."
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "ancestor",
+      "description": "Provides the absorption identity (k+1)·C(m+1,k+1) = (m+1)·C(m,k) reused here as the engine of the signed recurrence."
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "ancestor",
+      "description": "The binomial theorem (1+x)ⁿ = Σ C(n,k)xᵏ is the generating function whose derivatives at x = -1 are exactly these signed moments."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to **OQ-03-OQ-01** ("Combinatorial Moments of the Binomial Coefficients"). The parent computes the *unsigned* falling-factorial moments — the values of `(d/dx)^r (1+x)ⁿ` at `x = +1`. This entry evaluates the **signed** moments at the other natural point `x = -1`:

```
Σ_{k=0}^{n} (-1)ᵏ · k^(r) · C(n,k) = (-1)ʳ · n^(r) · [n = r]
```

(`k^(r) = Nat.descFactorial k r`, `[P]` the Iverson bracket). A single closed form: the sum **vanishes whenever `n ≠ r`** — the generating-function shadow of the classical **finite-difference** fact that the `n`-th forward difference annihilates every polynomial of degree `< n` — and at the diagonal `r = n` it peaks at `(-1)ⁿ · n!`, the discrete analogue of `dⁿ/dxⁿ xⁿ = n!`.

## Contents (6 theorems, 0 axioms)

- `signed_step` — the signed absorption recurrence `T(m+1,r+1) = -(m+1)·T(m,r)` (reuses the parent's `absorption` identity; the minus sign comes from reindexing `k ↦ k+1` against `(-1)ᵏ`)
- `signed_descFactorial_moment` — the general closed form, one induction on `r`
- `signed_descFactorial_moment_of_ne` — vanishing off the diagonal (finite differences)
- `signed_descFactorial_moment_diagonal` — the diagonal peak `(-1)ⁿ·n!`
- `alternating_sum_id_mul_choose`, `alternating_sum_descFactorial2_mul_choose` — concrete signed power-moment companions to the parent

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BinomialTheoremOQ03OQ01OQ02` → **Build succeeded**
- 0 sorries, 0 `axiom` declarations, no `native_decide`. Depends only on `propext`, `Classical.choice`, `Quot.sound`.

Not in Mathlib — Mathlib has only the zeroth signed moment (`Int.alternating_sum_range_choose`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)