### PR TITLE
research(intermediate-value-theorem-oq-01-oq-01): sign persistence f(aₙ)·f(bₙ)≤0 of the bisection method

### DIFF
--- a/proofs/Proofs/IntermediateValueTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/IntermediateValueTheoremOQ01OQ01.lean
@@ -1,0 +1,155 @@
+import Proofs.IntermediateValueTheoremOQ01
+import Mathlib
+
+/-
+# Sign Persistence of the Bisection Method (intermediate-value-theorem-oq-01-oq-01)
+
+## Research Problem
+
+The parent entry `intermediate-value-theorem-oq-01` formalizes the bisection
+method — the recursive interval `bisectIter`, its endpoints `bisectLeft` /
+`bisectRight`, and the width-decay law `bisectRight − bisectLeft = (b−a)/2ⁿ`.
+It leaves open its **first** stated question:
+
+  > Prove sign persistence: `f(aₙ) · f(bₙ) ≤ 0` at each step.
+
+This is the *invariant* that makes the bisection method correct: it is precisely
+the hypothesis "`f` changes sign on `[aₙ, bₙ]`" that, via the IVT, certifies a
+root inside every interval the method produces. The parent proves that the
+intervals shrink; this file proves that they never lose the root.
+
+## What This Proves
+
+1. `sign_persist_aux` — the pure sign-algebra lemma: from `p·q ≤ 0` and
+   `0 < p·m` deduce `m·q ≤ 0`. (If the sign is kept on the left half it is
+   immediate; on the right half this lemma transfers it.)
+2. `bisectStep_sign_persist` — one bisection step preserves `f a · f b ≤ 0`.
+3. `bisect_sign_persist` — **the invariant**: `f(aₙ)·f(bₙ) ≤ 0` for all `n`.
+4. `bisect_le` — the bisection intervals stay ordered (`aₙ ≤ bₙ`).
+5. `sign_change_root` — IVT corollary: a continuous sign-changing function has
+   a root in `[a,b]`.
+6. `bisect_interval_contains_root` — combining 3 + 4 + 5: **every** bisection
+   interval contains a genuine root of a continuous `f`.
+7. `bisect_sqrt2_sign_persist` — the invariant holds for `x² − 2` on `[1,2]`.
+-/
+
+namespace BisectionMethod
+
+open Real
+
+-- ============================================================
+-- Part I: The sign-algebra core
+-- ============================================================
+
+/-- **Sign-transfer lemma.** If `p·q ≤ 0` (a sign change between `p` and `q`)
+    and `0 < p·m` (so `m` has the *same* sign as `p`), then `m·q ≤ 0` — the
+    sign change is inherited by the pair `(m, q)`.
+
+    Proof: `(p·m)·(m·q) = (p·q)·m² ≤ 0` while `p·m > 0`, forcing `m·q ≤ 0`. -/
+theorem sign_persist_aux {p m q : ℝ} (hpq : p * q ≤ 0) (hpm : 0 < p * m) :
+    m * q ≤ 0 := by
+  nlinarith [mul_nonpos_of_nonpos_of_nonneg hpq (sq_nonneg m), hpm,
+    sq_nonneg m]
+
+-- ============================================================
+-- Part II: One step preserves the sign change
+-- ============================================================
+
+/-- A single bisection step preserves the sign-change invariant: if
+    `f a · f b ≤ 0` then `f` still changes sign across the chosen sub-interval. -/
+theorem bisectStep_sign_persist {f : ℝ → ℝ} {a b : ℝ} (hsign : f a * f b ≤ 0) :
+    f (bisectStep f a b).1 * f (bisectStep f a b).2 ≤ 0 := by
+  simp only [bisectStep]
+  split_ifs with h
+  · -- left half (a, mid): the chosen condition IS the goal
+    exact h
+  · -- right half (mid, b): transfer the sign via sign_persist_aux
+    push_neg at h
+    exact sign_persist_aux hsign h
+
+-- ============================================================
+-- Part III: The invariant for all n
+-- ============================================================
+
+/-- **Sign persistence.** If `f` changes sign on the initial interval
+    (`f a · f b ≤ 0`), then it changes sign on every bisection interval:
+    `f(aₙ) · f(bₙ) ≤ 0` for all `n`. This is the correctness invariant of the
+    bisection method. -/
+theorem bisect_sign_persist {f : ℝ → ℝ} {a b : ℝ} (hsign : f a * f b ≤ 0) :
+    ∀ n : ℕ, f (bisectLeft f a b n) * f (bisectRight f a b n) ≤ 0 := by
+  intro n
+  induction n with
+  | zero => simpa [bisectLeft, bisectRight, bisectIter] using hsign
+  | succ n ih =>
+      have step := bisectStep_sign_persist (f := f)
+        (a := bisectLeft f a b n) (b := bisectRight f a b n) ih
+      simpa [bisectLeft, bisectRight, bisectIter] using step
+
+-- ============================================================
+-- Part IV: The intervals stay ordered
+-- ============================================================
+
+/-- Every bisection interval is non-degenerate: `aₙ ≤ bₙ`. (Follows from the
+    parent's width law `bisect_width`, since `(b−a)/2ⁿ ≥ 0`.) -/
+theorem bisect_le {f : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b) (n : ℕ) :
+    bisectLeft f a b n ≤ bisectRight f a b n := by
+  have hw := bisect_width f a b hab n
+  have hnn : (0 : ℝ) ≤ (b - a) / 2 ^ n := by
+    have : (0 : ℝ) ≤ b - a := by linarith
+    positivity
+  linarith [hw]
+
+-- ============================================================
+-- Part V: IVT corollary — every interval contains a root
+-- ============================================================
+
+/-- **IVT for sign changes.** A continuous function that changes sign across
+    `[a,b]` (i.e. `f a · f b ≤ 0`) has a root in `[a,b]`. -/
+theorem sign_change_root {f : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
+    (hf : ContinuousOn f (Set.Icc a b)) (hsign : f a * f b ≤ 0) :
+    ∃ c ∈ Set.Icc a b, f c = 0 := by
+  rcases mul_nonpos_iff.mp hsign with ⟨hfa, hfb⟩ | ⟨hfa, hfb⟩
+  · -- 0 ≤ f a and f b ≤ 0 : use the descending IVT
+    have h0 : (0 : ℝ) ∈ Set.Icc (f b) (f a) := ⟨hfb, hfa⟩
+    obtain ⟨c, hc, hfc⟩ := intermediate_value_Icc' hab hf h0
+    exact ⟨c, hc, hfc⟩
+  · -- f a ≤ 0 and 0 ≤ f b : use the ascending IVT
+    have h0 : (0 : ℝ) ∈ Set.Icc (f a) (f b) := ⟨hfa, hfb⟩
+    obtain ⟨c, hc, hfc⟩ := intermediate_value_Icc hab hf h0
+    exact ⟨c, hc, hfc⟩
+
+/-- **The bisection method never loses the root.** For a continuous `f` with an
+    initial sign change, *every* bisection interval `[aₙ, bₙ]` contains a true
+    root of `f`. Together with the parent's width decay (`bisect_width`), this
+    is the full correctness statement: the intervals shrink to zero width while
+    each one is certified to contain a root. -/
+theorem bisect_interval_contains_root {f : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
+    (hf : Continuous f) (hsign : f a * f b ≤ 0) (n : ℕ) :
+    ∃ c ∈ Set.Icc (bisectLeft f a b n) (bisectRight f a b n), f c = 0 :=
+  sign_change_root (bisect_le hab n) (hf.continuousOn) (bisect_sign_persist hsign n)
+
+-- ============================================================
+-- Part VI: Concrete instance — √2
+-- ============================================================
+
+/-- Sign persistence for `f(x) = x² − 2` on `[1,2]` (the √2 search of the
+    parent entry): `f` changes sign on every bisection interval. -/
+theorem bisect_sqrt2_sign_persist (n : ℕ) :
+    (fun x => x ^ 2 - 2) (bisectLeft (fun x => x ^ 2 - 2) 1 2 n) *
+      (fun x => x ^ 2 - 2) (bisectRight (fun x => x ^ 2 - 2) 1 2 n) ≤ 0 := by
+  have h : (fun x => x ^ 2 - 2) (1 : ℝ) * (fun x => x ^ 2 - 2) (2 : ℝ) ≤ 0 := by
+    norm_num
+  exact bisect_sign_persist (f := fun x => x ^ 2 - 2) (a := 1) (b := 2) h n
+
+/-- Consequently every bisection interval of the `x² − 2` search on `[1,2]`
+    contains a genuine root (namely √2). -/
+theorem bisect_sqrt2_contains_root (n : ℕ) :
+    ∃ c ∈ Set.Icc (bisectLeft (fun x => x ^ 2 - 2) 1 2 n)
+        (bisectRight (fun x => x ^ 2 - 2) 1 2 n),
+      c ^ 2 - 2 = 0 := by
+  have hcont : Continuous (fun x : ℝ => x ^ 2 - 2) := by continuity
+  have := bisect_interval_contains_root (f := fun x => x ^ 2 - 2)
+    (a := 1) (b := 2) (by norm_num) hcont (by norm_num) n
+  simpa using this
+
+end BisectionMethod

--- a/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,175 @@
+[
+  {
+    "id": "ann-ivtoq0101-00-header",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "type": "concept",
+    "title": "Module Overview: Why Sign Persistence Matters",
+    "content": "The bisection method works because two facts hold together: the intervals shrink (proved in the parent entry intermediate-value-theorem-oq-01, width = (b-a)/2^n), and the sign change is never lost (proved here). Width decay alone lets the intervals converge to an arbitrary point; the sign-persistence invariant f(a_n)*f(b_n) <= 0 is what forces that limit to be a root, via the intermediate value theorem. This file resolves the FIRST open question left by the parent entry.",
+    "mathContext": "Invariant: f(a_n) * f(b_n) <= 0 for all n, given f(a_0) * f(b_0) <= 0.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "bisection method",
+      "intermediate value theorem",
+      "loop invariant",
+      "constructive root finding"
+    ],
+    "prerequisites": [
+      "intermediate_value_Icc",
+      "BisectionMethod.bisect_width"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-01-sign-algebra",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 52
+    },
+    "type": "key-step",
+    "title": "The Sign-Transfer Lemma",
+    "content": "sign_persist_aux is the algebraic heart of the proof. Given p*q <= 0 (the running sign change between the endpoints) and 0 < p*m (the midpoint m shares the LEFT endpoint's sign), it concludes m*q <= 0 (the sign change has moved to the right pair). The trick is the polynomial identity (p*m)*(m*q) = (p*q)*m^2: the right side is <= 0 (nonpositive times a square), so the left side is <= 0; since p*m > 0, the factor m*q must be <= 0. nlinarith discharges it with the hint mul_nonpos_of_nonpos_of_nonneg hpq (sq_nonneg m).",
+    "mathContext": "(p*m)*(m*q) = (p*q)*m^2 <= 0 and p*m > 0 imply m*q <= 0.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sign analysis",
+      "nlinarith",
+      "nonnegativity of squares"
+    ],
+    "prerequisites": [
+      "mul_nonpos_of_nonpos_of_nonneg",
+      "sq_nonneg"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-02-one-step",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 68
+    },
+    "type": "technique",
+    "title": "One Bisection Step Preserves the Sign Change",
+    "content": "bisectStep_sign_persist case-splits on the bisection step's if-condition (simp only [bisectStep] then split_ifs). In the 'then' branch the algorithm kept the left half precisely because f a * f mid <= 0, which IS the goal — no work needed. In the 'else' branch f a * f mid > 0 (push_neg), meaning the midpoint shares the left endpoint's sign, so sign_persist_aux transfers the sign change to the right pair f mid * f b. Only the 'else' branch requires the lemma.",
+    "mathContext": "if f a * f mid <= 0 then keep (a, mid) [sign change immediate]; else keep (mid, b) [sign change via sign_persist_aux].",
+    "significance": "key",
+    "relatedConcepts": [
+      "case analysis",
+      "split_ifs",
+      "bisection step"
+    ],
+    "prerequisites": [
+      "BisectionMethod.bisectStep"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-03-invariant",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 72,
+      "endLine": 86
+    },
+    "type": "key-step",
+    "title": "Sign Persistence for All n",
+    "content": "bisect_sign_persist is the headline result and the answer to the parent's open question: f(a_n) * f(b_n) <= 0 for every n. The proof is induction on n. The base case n = 0 is the initial hypothesis (the endpoints are a and b). The successor case feeds the inductive hypothesis into bisectStep_sign_persist, since the (n+1)st interval is one bisection step applied to the nth. This is the loop invariant that makes the bisection method correct.",
+    "mathContext": "Base: f(a_0)*f(b_0) = f(a)*f(b) <= 0. Step: bisectStep_sign_persist carries the invariant from n to n+1.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "mathematical induction",
+      "loop invariant",
+      "bisection method correctness"
+    ],
+    "prerequisites": [
+      "BisectionMethod.bisectStep_sign_persist"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-04-ordering",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 100
+    },
+    "type": "technique",
+    "title": "Intervals Stay Ordered",
+    "content": "bisect_le shows a_n <= b_n for every n, needed so that the intervals are genuine (non-empty) closed intervals on which the IVT applies. It reads off the parent entry's width law bisect_width (bisectRight - bisectLeft = (b-a)/2^n): since b - a >= 0 and 2^n > 0, the width is nonnegative, hence bisectLeft <= bisectRight.",
+    "mathContext": "bisectRight - bisectLeft = (b-a)/2^n >= 0, so bisectLeft <= bisectRight.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "interval ordering",
+      "width decay"
+    ],
+    "prerequisites": [
+      "BisectionMethod.bisect_width"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-05-ivt-root",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 124
+    },
+    "type": "key-step",
+    "title": "From Sign Change to Root (IVT)",
+    "content": "sign_change_root packages the intermediate value theorem for root finding: a continuous f with f a * f b <= 0 has a root in [a,b]. mul_nonpos_iff splits the product condition into the two orderings (0 <= f a and f b <= 0, or f a <= 0 and 0 <= f b); each feeds the descending intermediate_value_Icc' or the ascending intermediate_value_Icc respectively, yielding 0 in the image f '' (Icc a b), i.e. a point c with f c = 0.",
+    "mathContext": "f a * f b <= 0 and ContinuousOn f (Icc a b) imply exists c in Icc a b with f c = 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "intermediate value theorem",
+      "mul_nonpos_iff",
+      "image of an interval"
+    ],
+    "prerequisites": [
+      "intermediate_value_Icc",
+      "intermediate_value_Icc'",
+      "mul_nonpos_iff"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-06-contains-root",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 130
+    },
+    "type": "concept",
+    "title": "Every Bisection Interval Contains a Root",
+    "content": "bisect_interval_contains_root is the full correctness statement: for a continuous f with an initial sign change, EVERY bisection interval [a_n, b_n] contains a true root of f. It is a one-line composition of the three pillars — bisect_le (intervals ordered), bisect_sign_persist (sign change kept), and sign_change_root (sign change implies root). Together with the parent's width decay, this certifies that the algorithm's intervals shrink to zero width while each one provably brackets a root.",
+    "mathContext": "Continuous f, f a * f b <= 0 imply for all n, exists c in Icc (a_n) (b_n) with f c = 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "algorithm correctness",
+      "root bracketing"
+    ],
+    "prerequisites": [
+      "BisectionMethod.sign_change_root",
+      "BisectionMethod.bisect_sign_persist",
+      "BisectionMethod.bisect_le"
+    ]
+  },
+  {
+    "id": "ann-ivtoq0101-07-sqrt2",
+    "proofId": "intermediate-value-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 133,
+      "endLine": 152
+    },
+    "type": "concept",
+    "title": "Concrete Instance: the √2 Search",
+    "content": "bisect_sqrt2_sign_persist and bisect_sqrt2_contains_root instantiate the general results for f(x) = x^2 - 2 on [1,2] — the √2 example of the parent entry. Since f(1) = -1 and f(2) = 2, the initial sign change f(1)*f(2) = -2 <= 0 holds (norm_num), so every bisection interval keeps the sign change and, by continuity (continuity tactic), contains a genuine root of x^2 - 2, namely √2.",
+    "mathContext": "f(x) = x^2 - 2 on [1,2]: f(1)*f(2) = -2 <= 0, so √2 is bracketed in every bisection interval.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "square root of 2",
+      "worked example"
+    ],
+    "prerequisites": [
+      "BisectionMethod.bisect_sign_persist",
+      "BisectionMethod.bisect_interval_contains_root"
+    ]
+  }
+]

--- a/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "intermediate-value-theorem-oq-01-oq-01",
+  "title": "Sign Persistence of the Bisection Method",
+  "slug": "intermediate-value-theorem-oq-01-oq-01",
+  "description": "Proves the correctness invariant of the bisection method: if f changes sign on the initial interval (f(a)*f(b) <= 0), then it changes sign on every bisection interval (f(a_n)*f(b_n) <= 0). Combined with the parent entry's width decay and Mathlib's IVT, this shows every bisection interval is certified to contain a genuine root of a continuous f.",
+  "meta": {
+    "author": "researcher-9 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bisection_method",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/IntermediateValueTheoremOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "intermediate-value-theorem",
+      "bisection-method",
+      "root-finding",
+      "constructive",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "intermediate_value_Icc",
+        "description": "a <= b and ContinuousOn f (Icc a b) implies Icc (f a) (f b) is a subset of f '' (Icc a b)",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      },
+      {
+        "theorem": "intermediate_value_Icc'",
+        "description": "descending variant: Icc (f b) (f a) is a subset of f '' (Icc a b)",
+        "module": "Mathlib.Topology.Order.IntermediateValue"
+      },
+      {
+        "theorem": "mul_nonpos_iff",
+        "description": "a*b <= 0 iff (0 <= a and b <= 0) or (a <= 0 and 0 <= b); selects the IVT branch",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "BisectionMethod.bisect_width",
+        "description": "parent entry: bisectRight - bisectLeft = (b-a)/2^n (used to show intervals stay ordered)",
+        "module": "Proofs.IntermediateValueTheoremOQ01"
+      }
+    ],
+    "originalContributions": [
+      "sign_persist_aux: the sign-algebra core — from p*q <= 0 and 0 < p*m deduce m*q <= 0, via (p*m)*(m*q) = (p*q)*m^2 <= 0",
+      "bisectStep_sign_persist: one bisection step preserves the sign-change invariant f(a)*f(b) <= 0",
+      "bisect_sign_persist: THE invariant — f(a_n)*f(b_n) <= 0 for all n, by induction (resolves the parent's first open question)",
+      "bisect_le: every bisection interval stays ordered (a_n <= b_n), from the parent's width law",
+      "sign_change_root: IVT corollary — a continuous sign-changing function has a root in [a,b]",
+      "bisect_interval_contains_root: every bisection interval of a continuous f contains a genuine root",
+      "bisect_sqrt2_sign_persist / bisect_sqrt2_contains_root: the invariant and root containment instantiated for x^2 - 2 on [1,2]"
+    ],
+    "references": [
+      {
+        "authors": "Bolzano, Bernard",
+        "title": "Rein analytischer Beweis des Lehrsatzes ...",
+        "year": "1817",
+        "venue": "",
+        "note": "Early rigorous statement of the intermediate value theorem underlying the bisection method"
+      },
+      {
+        "authors": "Burden, Richard L.; Faires, J. Douglas",
+        "title": "Numerical Analysis",
+        "year": "2010",
+        "venue": "Brooks/Cole",
+        "note": "Standard treatment of the bisection method, its sign-change invariant and convergence rate"
+      }
+    ],
+    "prerequisites": [
+      "Intermediate value theorem for continuous functions on a closed interval",
+      "The bisection method and its interval-halving recursion (parent entry intermediate-value-theorem-oq-01)",
+      "Sign analysis of products of reals (mul_nonpos_iff)",
+      "Induction on the natural numbers"
+    ],
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 153,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The bisection method is the oldest and most robust root-finding algorithm: to solve f(x) = 0 on an interval [a,b] where f changes sign, repeatedly halve the interval, keeping whichever half still exhibits a sign change. Its correctness rests on two facts working together. The parent entry intermediate-value-theorem-oq-01 formalized the first — that the intervals shrink geometrically, with width (b-a)/2^n after n steps. This entry supplies the second, and logically prior, fact: that the sign change is never lost. As long as the algorithm keeps the half on which f(a_n) and f(b_n) have opposite signs, the intermediate value theorem guarantees a root lives inside every interval the method produces. Width decay alone would let the intervals converge to an arbitrary point; sign persistence is what forces that point to be a root.\n\nThe sign-persistence invariant is the discrete shadow of Bolzano's 1817 insight that a continuous function changing sign must vanish in between. In a numerical-analysis course it is usually waved through ('we always keep the half where the sign changes'), but making it precise requires a small piece of sign algebra: when the left half does not change sign, the right half must — because the midpoint's sign is then pinned to match the left endpoint, leaving the right endpoint as the one in opposition.",
+    "problemStatement": "**Open Question (from parent proof intermediate-value-theorem-oq-01)**: Prove sign persistence: f(a_n) * f(b_n) <= 0 at each bisection step (requires continuity or the IVT hypothesis).\n\n**Resolution**: We prove f(a_n) * f(b_n) <= 0 for all n by induction, the inductive step resting on a sign-algebra lemma. We then combine the invariant with the parent's width law and Mathlib's intermediate value theorem to show that every bisection interval of a continuous f is certified to contain a genuine root.",
+    "text": "An eight-theorem, 153-line, axiom-free development resolving the parent entry's first open question. The crux is sign_persist_aux: from p*q <= 0 (the running sign change) and 0 < p*m (the midpoint shares the left endpoint's sign) it deduces m*q <= 0, because (p*m)*(m*q) = (p*q)*m^2 <= 0 while p*m > 0 — a one-line nlinarith. bisectStep_sign_persist applies it: a single bisection step keeps f(a)*f(b) <= 0, with the left-half case being the chosen if-condition itself and the right-half case handled by the lemma. bisect_sign_persist then propagates the invariant to all n by induction. The development closes the loop with the intermediate value theorem: sign_change_root turns a continuous sign change into a root via intermediate_value_Icc / intermediate_value_Icc' (branch chosen by mul_nonpos_iff), and bisect_interval_contains_root combines sign persistence, interval ordering (bisect_le, from the parent's width law), and the IVT to certify a root in every bisection interval. The concrete x^2 - 2 search on [1,2] is verified end to end.",
+    "proofStrategy": "**Sign algebra (sign_persist_aux)**: the polynomial identity (p*m)*(m*q) = (p*q)*m^2 means the product of the kept-half indicator p*m and the candidate m*q equals a nonpositive quantity; since p*m > 0, m*q <= 0. nlinarith closes it with the hint mul_nonpos_of_nonpos_of_nonneg hpq (sq_nonneg m).\n\n**One step (bisectStep_sign_persist)**: simp only [bisectStep] then split_ifs. The 'then' branch's hypothesis is exactly the goal f a * f mid <= 0. The 'else' branch gives 0 < f a * f mid (push_neg), and sign_persist_aux transfers the sign to f mid * f b.\n\n**All n (bisect_sign_persist)**: induction on n; the base case is the hypothesis, the successor case feeds the inductive hypothesis through bisectStep_sign_persist.\n\n**Root certification**: bisect_le shows a_n <= b_n from the parent's bisect_width (since (b-a)/2^n >= 0). sign_change_root case-splits mul_nonpos_iff and applies the ascending/descending IVT. bisect_interval_contains_root composes the three.",
+    "keyInsights": [
+      "Width decay and sign persistence are independent halves of correctness: the parent proves intervals shrink, this entry proves they keep the root.",
+      "The whole invariant reduces to one sign-algebra fact: (p*m)*(m*q) = (p*q)*m^2, so if the sign change is not on the left half it must be on the right.",
+      "Only the 'else' branch of a bisection step needs real work — the 'then' branch keeps the sign change by the very condition that selected it.",
+      "mul_nonpos_iff is the clean bridge from 'f(a)*f(b) <= 0' to the two orderings the intermediate value theorem needs.",
+      "Sign persistence + interval ordering + IVT yields a constructive certificate: a true root lives in every interval the algorithm reports, at every step."
+    ],
+    "prerequisites": [
+      "Real analysis (continuity, intermediate value theorem)",
+      "Numerical analysis (bisection method, root finding)",
+      "Elementary inequality reasoning over the reals"
+    ]
+  },
+  "conclusion": {
+    "summary": "The sign-persistence invariant f(a_n)*f(b_n) <= 0 of the bisection method is proved for all n, resolving the parent entry's first open question. Combined with the parent's width decay and Mathlib's intermediate value theorem, it shows every bisection interval of a continuous sign-changing function contains a genuine root. Fully verified with 0 axioms and 0 sorries.",
+    "implications": "This completes the correctness story for the bisection method begun in intermediate-value-theorem-oq-01: the intervals both shrink to zero width and provably contain a root at every step. The reusable lemma sign_change_root (continuous sign change implies a root) is a packaged, search-friendly form of the IVT for root finding. The remaining parent open questions — connecting bisectIter to Filter.Tendsto for full convergence, and formalizing Newton's method for comparison — are natural follow-ups.",
+    "openQuestions": [
+      "Connect bisectIter to Filter.Tendsto: prove the bisection sequence converges to a specific root using sign persistence + width decay.",
+      "Quantify the certified root's location: the root lies within (b-a)/2^(n+1) of the nth midpoint.",
+      "Formalize Newton's method and contrast its quadratic convergence with bisection's linear rate."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "intermediate-value-theorem-oq-01",
+      "relationship": "resolves",
+      "description": "Answers the parent's first open question: sign persistence f(a_n)*f(b_n) <= 0 at each step"
+    },
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "extends",
+      "description": "Turns the non-constructive IVT into a step-by-step certified root-finding invariant"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.IntermediateValueTheoremOQ01",
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "BisectionMethod",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/IntermediateValueTheoremOQ01OQ01.lean"
+  }
+}

--- a/src/data/research/problems/intermediate-value-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/intermediate-value-theorem-oq-01-oq-01.json
@@ -1,0 +1,61 @@
+{
+  "slug": "intermediate-value-theorem-oq-01-oq-01",
+  "title": "Bisection Method: Sign Persistence f(a_n)·f(b_n) ≤ 0",
+  "phase": "complete",
+  "status": "completed",
+  "tier": "B",
+  "path": "proofs/Proofs/IntermediateValueTheoremOQ01OQ01.lean",
+  "problemStatement": "Prove sign persistence: f(a_n) · f(b_n) ≤ 0 at each bisection step (the first open question of the parent entry intermediate-value-theorem-oq-01).",
+  "knownResults": "The parent entry defines bisectStep, bisectIter, bisectLeft/bisectRight and proves width decay bisectRight - bisectLeft = (b-a)/2^n. Mathlib provides intermediate_value_Icc, intermediate_value_Icc', and mul_nonpos_iff.",
+  "currentState": "COMPLETE. Proved the sign-persistence invariant for all n by induction, plus the IVT root-certification corollary (every bisection interval of a continuous f contains a genuine root) and a concrete x^2-2 instance. 8 theorems, 153 lines, 0 sorries, 0 axioms. Builds via docker-build.",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Sign persistence f(a_n)·f(b_n) ≤ 0 proved for all n by induction (resolves parent OQ #1). Crux is sign_persist_aux: (p*m)*(m*q) = (p*q)*m^2 ≤ 0 with p*m > 0 forces m*q ≤ 0. Combined with the parent's width law and Mathlib's IVT to certify a root in every bisection interval. 8 theorems, 153 lines, 0 sorries, 0 axioms. Builds successfully.",
+    "builtItems": [
+      "sign_persist_aux: from p*q ≤ 0 and 0 < p*m deduce m*q ≤ 0 (the sign-algebra core)",
+      "bisectStep_sign_persist: one bisection step preserves f(a)*f(b) ≤ 0",
+      "bisect_sign_persist: the invariant f(a_n)*f(b_n) ≤ 0 for all n, by induction",
+      "bisect_le: bisection intervals stay ordered (a_n ≤ b_n) from the parent's width law",
+      "sign_change_root: continuous sign change implies a root in [a,b] (IVT corollary)",
+      "bisect_interval_contains_root: every bisection interval of a continuous f contains a genuine root",
+      "bisect_sqrt2_sign_persist / bisect_sqrt2_contains_root: x^2 - 2 on [1,2] instance"
+    ],
+    "insights": [
+      "Width decay (parent) and sign persistence (this entry) are independent halves of bisection correctness; only together do they force convergence to a root.",
+      "The entire invariant reduces to one sign-algebra identity: (p*m)*(m*q) = (p*q)*m^2.",
+      "Only the 'else' branch of a bisection step needs work; the 'then' branch keeps the sign change by its selecting condition.",
+      "mul_nonpos_iff cleanly bridges f(a)*f(b) ≤ 0 to the two orderings the IVT requires.",
+      "Sign persistence + interval ordering + IVT gives a per-step certificate that a true root is bracketed."
+    ],
+    "mathlibGaps": [
+      "Mathlib's IVT (intermediate_value_Icc) is stated as a set inclusion, not as a ready 'sign change implies root' lemma; sign_change_root packages that.",
+      "No Mathlib formalization of the bisection method's sign-persistence invariant."
+    ],
+    "nextSteps": [
+      "Connect bisectIter to Filter.Tendsto to prove full convergence to a root (parent OQ #2).",
+      "Formalize Newton's method and its quadratic convergence (parent OQ #3).",
+      "Bound the certified root's distance from the nth midpoint by (b-a)/2^(n+1)."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "intermediate-value-theorem",
+    "bisection-method",
+    "root-finding",
+    "research"
+  ],
+  "relatedProofs": [
+    "intermediate-value-theorem-oq-01",
+    "intermediate-value-theorem"
+  ],
+  "references": [
+    "Bolzano (1817): rigorous statement of the IVT underlying bisection",
+    "Burden & Faires, Numerical Analysis: bisection sign-change invariant and convergence"
+  ],
+  "started": "2026-06-22",
+  "lastUpdate": "2026-06-22",
+  "significance": 7,
+  "tractability": 7,
+  "leanFiles": [
+    "proofs/Proofs/IntermediateValueTheoremOQ01OQ01.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the **first open question** of the parent entry `intermediate-value-theorem-oq-01` ("Prove sign persistence: `f(aₙ)·f(bₙ) ≤ 0` at each bisection step"). The parent proved the bisection intervals *shrink*; this entry proves they *keep the root*, and combines the two with Mathlib's IVT to certify a genuine root in every interval the method produces.

## Contents (8 theorems, 153 lines, 0 sorries, 0 axioms)

- `sign_persist_aux` — the sign-algebra core: from `p·q ≤ 0` and `0 < p·m`, deduce `m·q ≤ 0`, via `(p·m)·(m·q) = (p·q)·m² ≤ 0` (one `nlinarith`).
- `bisectStep_sign_persist` — one bisection step preserves `f a · f b ≤ 0`.
- `bisect_sign_persist` — **headline**: `f(aₙ)·f(bₙ) ≤ 0` for all `n`, by induction.
- `bisect_le` — intervals stay ordered (`aₙ ≤ bₙ`), from the parent's `bisect_width`.
- `sign_change_root` — IVT corollary: a continuous sign-changing function has a root in `[a,b]`.
- `bisect_interval_contains_root` — **every** bisection interval of a continuous `f` brackets a root.
- `bisect_sqrt2_sign_persist` / `bisect_sqrt2_contains_root` — the `x²−2` on `[1,2]` instance.

The proof imports and builds on the parent module `Proofs.IntermediateValueTheoremOQ01`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.IntermediateValueTheoremOQ01OQ01` — builds successfully.
- `#print axioms` on `bisect_sign_persist`, `bisect_interval_contains_root`, `bisect_sqrt2_contains_root`: only `[propext, Classical.choice, Quot.sound]`. No `native_decide`, no `sorryAx`. **0-axiom verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)