### PR TITLE
research(euler-totient-oq-01-oq-01): gallery data for Carmichael multiplicativity λ(m·n)=lcm(λ(m),λ(n))

### DIFF
--- a/src/data/proofs/euler-totient-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-ettoq0101-00-header",
+    "proofId": "euler-totient-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Module Overview: Multiplicativity is the Keystone",
+    "content": "Carmichael's function λ(n) is the exponent of the unit group (Z/nZ)*. Its structural characterization 'λ(n) = lcm of cyclic group orders' rests on one keystone step: multiplicativity over coprime factors, λ(m·n) = lcm(λ(m), λ(n)). Iterating over the prime-power factorization n = ∏ p^k then gives λ(n) = lcm_i λ(p_i^{k_i}); with each (Z/p^kZ)* cyclic (odd p), that is the lcm-of-cyclic-orders form. This file proves the keystone, advancing the parent entry's open question.",
+    "mathContext": "λ(n) = Monoid.exponent (Z/nZ)*; goal λ(m·n) = lcm(λ(m), λ(n)) for gcd(m,n)=1.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Carmichael function",
+      "universal exponent",
+      "Chinese Remainder Theorem",
+      "structure of (Z/nZ)*"
+    ],
+    "prerequisites": [
+      "Monoid.exponent",
+      "ZMod.chineseRemainder"
+    ]
+  },
+  {
+    "id": "ann-ettoq0101-01-def",
+    "proofId": "euler-totient-oq-01-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 54
+    },
+    "type": "definition",
+    "title": "Carmichael's Function as a Group Exponent",
+    "content": "carmichael n is defined as Monoid.exponent (ZMod n)ˣ — the smallest e > 0 with a^e = 1 for every unit a, i.e. the least universal exponent of (Z/nZ)*. Defining it locally (rather than importing the parent's identical definition) keeps the file build-independent while remaining definitionally equal to the parent's λ. Casting λ to a group-theoretic exponent is what lets the whole proof run on facts about Monoid.exponent.",
+    "mathContext": "carmichael n := Monoid.exponent (Z/nZ)*.",
+    "significance": "key",
+    "relatedConcepts": [
+      "monoid exponent",
+      "unit group"
+    ],
+    "prerequisites": [
+      "Monoid.exponent"
+    ]
+  },
+  {
+    "id": "ann-ettoq0101-02-crt-units",
+    "proofId": "euler-totient-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 60
+    },
+    "type": "key-step",
+    "title": "Splitting the Unit Group via CRT",
+    "content": "unitsChineseRemainder builds the multiplicative isomorphism (Z/mnZ)* ≃* (Z/mZ)* × (Z/nZ)* for coprime m, n. It transports the Chinese Remainder ring isomorphism ZMod (m*n) ≃+* ZMod m × ZMod n to unit groups with Units.mapEquiv, then splits the units of a product ring with MulEquiv.prodUnits. This isomorphism is the geometric content of coprime multiplicativity — everything else is a property of exponents.",
+    "mathContext": "(Z/mnZ)* ≃* (Z/mZ)* × (Z/nZ)* = Units.mapEquiv (ZMod.chineseRemainder h) followed by MulEquiv.prodUnits.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Chinese Remainder Theorem",
+      "unit group of a product ring",
+      "multiplicative isomorphism"
+    ],
+    "prerequisites": [
+      "ZMod.chineseRemainder",
+      "Units.mapEquiv",
+      "MulEquiv.prodUnits"
+    ]
+  },
+  {
+    "id": "ann-ettoq0101-03-keystone",
+    "proofId": "euler-totient-oq-01-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 69
+    },
+    "type": "key-step",
+    "title": "The Keystone: λ(m·n) = lcm(λ(m), λ(n))",
+    "content": "carmichael_mul_coprime is the headline. After unfolding carmichael, three rewrites finish it: Monoid.exponent_eq_of_mulEquiv (unitsChineseRemainder h) transports the exponent across the CRT isomorphism to the product group; Monoid.exponent_prod rewrites the exponent of a product as the lattice-lcm of the factor exponents; lcm_eq_nat_lcm aligns that with Nat.lcm. The result is exactly λ(m·n) = lcm(λ(m), λ(n)). The proof is a three-line consequence of 'exponent is an isomorphism invariant' and 'exponent of a product is the lcm'.",
+    "mathContext": "λ(m·n) = exp((Z/mnZ)*) = exp((Z/mZ)* × (Z/nZ)*) = lcm(exp(Z/mZ)*, exp(Z/nZ)*) = lcm(λ(m), λ(n)).",
+    "significance": "critical",
+    "relatedConcepts": [
+      "exponent of a product group",
+      "isomorphism invariance",
+      "least common multiple"
+    ],
+    "prerequisites": [
+      "Monoid.exponent_eq_of_mulEquiv",
+      "Monoid.exponent_prod"
+    ]
+  },
+  {
+    "id": "ann-ettoq0101-04-order-dvd",
+    "proofId": "euler-totient-oq-01-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 74
+    },
+    "type": "concept",
+    "title": "The Universal-Exponent Property",
+    "content": "order_dvd_carmichael records that every unit's order divides λ(n) (orderOf a | carmichael n), via Monoid.order_dvd_exponent. This is the defining 'universal exponent' property of λ and, combined with carmichael_mul_coprime, shows λ(n) is a common multiple of all element orders across the coprime factors — the lower-bound half of the lcm characterization.",
+    "mathContext": "orderOf a | λ(n) for every unit a in (Z/nZ)*.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "order of an element",
+      "universal exponent"
+    ],
+    "prerequisites": [
+      "Monoid.order_dvd_exponent"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "euler-totient-oq-01-oq-01",
+  "title": "Carmichael's Function is Multiplicative: λ(m·n) = lcm(λ(m), λ(n))",
+  "slug": "euler-totient-oq-01-oq-01",
+  "description": "Proves the keystone multiplicativity of Carmichael's function: for coprime m and n, λ(m·n) = lcm(λ(m), λ(n)). Via the Chinese Remainder isomorphism on unit groups and the fact that the exponent of a product group is the lcm of exponents, this is the step that reduces λ(n) to the lcm of the cyclic-factor orders of (Z/nZ)*.",
+  "meta": {
+    "author": "researcher-9 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Carmichael_function",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "carmichael-function",
+      "group-theory",
+      "chinese-remainder-theorem",
+      "exponent",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Monoid.exponent_eq_of_mulEquiv",
+        "description": "the exponent is invariant under a multiplicative isomorphism of monoids",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "Monoid.exponent_prod",
+        "description": "the exponent of a product monoid is the lcm of the factor exponents",
+        "module": "Mathlib.GroupTheory.Exponent"
+      },
+      {
+        "theorem": "ZMod.chineseRemainder",
+        "description": "ring isomorphism ZMod (m*n) ≃+* ZMod m × ZMod n for coprime m, n",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Units.mapEquiv",
+        "description": "transports a multiplicative isomorphism of rings to their unit groups",
+        "module": "Mathlib.Algebra.Group.Units.Equiv"
+      },
+      {
+        "theorem": "MulEquiv.prodUnits",
+        "description": "(M × N)ˣ ≃* Mˣ × Nˣ, splitting the unit group of a product",
+        "module": "Mathlib.Algebra.Group.Units.Equiv"
+      },
+      {
+        "theorem": "Monoid.order_dvd_exponent",
+        "description": "every element's order divides the monoid exponent",
+        "module": "Mathlib.GroupTheory.Exponent"
+      }
+    ],
+    "originalContributions": [
+      "carmichael: Carmichael's function as the exponent of (Z/nZ)*, defined self-containedly (build-independent of the parent file)",
+      "unitsChineseRemainder: the multiplicative isomorphism (Z/mnZ)* ≃* (Z/mZ)* × (Z/nZ)* for coprime m, n, built by transporting ZMod.chineseRemainder to units and splitting with MulEquiv.prodUnits",
+      "carmichael_mul_coprime: the keystone λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n",
+      "order_dvd_carmichael: the universal-exponent property orderOf a | λ(n), restated for the Carmichael function"
+    ],
+    "references": [
+      {
+        "authors": "Carmichael, Robert D.",
+        "title": "Note on a new number theory function",
+        "year": "1910",
+        "venue": "Bulletin of the American Mathematical Society",
+        "note": "Introduces the function λ(n) and its multiplicativity over coprime factors"
+      },
+      {
+        "authors": "Hardy, G. H.; Wright, E. M.",
+        "title": "An Introduction to the Theory of Numbers",
+        "year": "2008",
+        "venue": "Oxford University Press",
+        "note": "Structure of (Z/nZ)* and the universal exponent"
+      }
+    ],
+    "prerequisites": [
+      "Carmichael's function λ(n) = exponent of (Z/nZ)* (parent entry euler-totient-oq-01)",
+      "Chinese Remainder Theorem as a ring isomorphism",
+      "Unit groups and the splitting (M × N)ˣ ≃ Mˣ × Nˣ",
+      "Monoid exponent and its lcm behavior on products",
+      "Least common multiple over the naturals"
+    ],
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 76,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 2,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Robert Carmichael introduced the function λ(n) in 1910 as the smallest exponent e for which a^e ≡ 1 (mod n) holds for every a coprime to n — the universal exponent of the group (Z/nZ)*. It divides Euler's totient φ(n) and is often strictly smaller. The parent entry euler-totient-oq-01 formalizes λ(n) as Mathlib's group exponent Monoid.exponent (Z/nZ)* and proves λ(n) | φ(n).\n\nThe structural heart of Carmichael's function is its behaviour on a factorization. Because the Chinese Remainder Theorem splits (Z/mnZ)* into (Z/mZ)* × (Z/nZ)* whenever m and n are coprime, and because the exponent of a direct product is the least common multiple of the factor exponents, λ is determined by its values on prime powers: λ(n) = lcm over the prime powers p^k || n of λ(p^k). Combined with the fact that each (Z/p^kZ)* is cyclic for odd p (and an explicit small product for p = 2), this yields the full classical formula 'λ(n) = lcm of the cyclic group orders'. This entry proves the keystone multiplicativity step on which that whole reduction rests.",
+    "problemStatement": "**Open Question (from parent proof euler-totient-oq-01)**: Strengthen carmichael_dvd_totient toward the full structural characterization λ(n) = lcm of the cyclic-factor orders of (Z/nZ)*.\n\n**Resolution (this step)**: Prove the keystone multiplicativity λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n. Iterating over the prime-power factorization then gives λ(n) = lcm_i λ(p_i^{k_i}), the lcm-of-cyclic-orders form.",
+    "text": "A compact, axiom-free development (2 definitions, 2 theorems, 76 lines). carmichael n is defined as Monoid.exponent (ZMod n)ˣ. The construction unitsChineseRemainder packages the multiplicative isomorphism (Z/mnZ)* ≃* (Z/mZ)* × (Z/nZ)* for coprime m, n by composing Units.mapEquiv applied to ZMod.chineseRemainder with MulEquiv.prodUnits. The keystone theorem carmichael_mul_coprime then reads λ(m·n) = lcm(λ(m), λ(n)) directly off two Mathlib facts: Monoid.exponent_eq_of_mulEquiv (the exponent is an isomorphism invariant) transports λ(m·n) across unitsChineseRemainder, and Monoid.exponent_prod rewrites the exponent of the product as the lcm of the two exponents. order_dvd_carmichael records the universal-exponent property orderOf a | λ(n) via Monoid.order_dvd_exponent.",
+    "proofStrategy": "carmichael_mul_coprime: unfold carmichael, then rw with three lemmas. (1) Monoid.exponent_eq_of_mulEquiv (unitsChineseRemainder h) rewrites the exponent of (Z/mnZ)* as the exponent of the product group (Z/mZ)* × (Z/nZ)*. (2) Monoid.exponent_prod rewrites that as Monoid.exponent (Z/mZ)* ⊔ ... i.e. the lcm of the two factor exponents. (3) lcm_eq_nat_lcm aligns the lattice lcm with Nat.lcm. order_dvd_carmichael: unfold and apply Monoid.order_dvd_exponent.",
+    "keyInsights": [
+      "Carmichael's λ is the group exponent of the unit group, so its arithmetic is governed by group-theoretic facts about exponents, not by direct number theory.",
+      "Coprime multiplicativity is exactly CRT (split the unit group) plus 'exponent of a product = lcm of exponents'.",
+      "The exponent being an isomorphism invariant (Monoid.exponent_eq_of_mulEquiv) is what lets the CRT isomorphism be applied at the level of λ.",
+      "Iterating the keystone over n = ∏ p^k reduces λ(n) to lcm_i λ(p_i^{k_i}); with each prime-power unit group cyclic (odd p), this is the classical 'lcm of cyclic group orders'.",
+      "Defining carmichael locally (rather than importing the parent's) keeps the file build-independent while matching the parent's definition definitionally."
+    ],
+    "prerequisites": [
+      "Group theory (exponent of a finite abelian group, direct products)",
+      "Number theory (Chinese Remainder Theorem, structure of (Z/nZ)*)",
+      "Carmichael's function (parent entry euler-totient-oq-01)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The keystone multiplicativity of Carmichael's function, λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n, is proved from the CRT splitting of unit groups and the lcm behavior of the exponent on product groups. With order_dvd_carmichael recording the universal-exponent property, this is the step that reduces λ(n) to the lcm of its prime-power (cyclic-factor) values. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This advances the parent entry's open question toward the full characterization λ(n) = lcm of cyclic group orders: iterating carmichael_mul_coprime over the prime-power factorization yields λ(n) = lcm_i λ(p_i^{k_i}), and the cyclicity of (Z/p^kZ)* (odd p) identifies each factor exponent with a cyclic group order. It also underpins the RSA-relevant fact that λ, not φ, is the minimal exponent for modular exponentiation.",
+    "openQuestions": [
+      "Complete the induction over the prime-power factorization to state λ(n) = lcm_i λ(p_i^{k_i}) as a single theorem.",
+      "Prove λ(2^k) = 2^{k-2} for k ≥ 3 from the structure (Z/2^kZ)* ≅ Z/2 × Z/2^{k-2}.",
+      "Combine with cyclicity of (Z/p^kZ)* (odd p) to close the full 'lcm of cyclic group orders' characterization."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-01",
+      "relationship": "extends",
+      "description": "Strengthens the parent's carmichael_dvd_totient toward the full structural characterization of λ(n)"
+    },
+    {
+      "targetId": "euler-totient-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry on Carmichael prime-power values λ(2^k) and λ(p^k); this entry supplies the coprime-multiplicativity that combines those values"
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "λ(n) divides Euler's totient φ(n) and shares its multiplicative structure"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ZMod"
+    ],
+    "namespace": "CarmichaelMultiplicative",
+    "lineCount": 76,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/EulerTotientOQ01OQ01.lean"
+  }
+}

--- a/src/data/research/problems/euler-totient-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-totient-oq-01-oq-01.json
@@ -1,0 +1,58 @@
+{
+  "slug": "euler-totient-oq-01-oq-01",
+  "title": "Carmichael Multiplicativity: λ(m·n) = lcm(λ(m), λ(n))",
+  "phase": "complete",
+  "status": "completed",
+  "tier": "B",
+  "path": "proofs/Proofs/EulerTotientOQ01OQ01.lean",
+  "problemStatement": "Strengthen carmichael_dvd_totient (parent euler-totient-oq-01) toward the full characterization λ(n) = lcm of cyclic group orders. The keystone is coprime multiplicativity λ(m·n) = lcm(λ(m), λ(n)).",
+  "knownResults": "Mathlib defines the group exponent (Monoid.exponent) with Monoid.exponent_prod (exponent of a product = lcm) and Monoid.exponent_eq_of_mulEquiv (isomorphism invariance). ZMod.chineseRemainder gives the CRT ring iso; Units.mapEquiv and MulEquiv.prodUnits split unit groups.",
+  "currentState": "COMPLETE. Proved the keystone multiplicativity λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n, plus the universal-exponent property orderOf a | λ(n). 2 definitions, 2 theorems, 76 lines, 0 sorries, 0 axioms. Builds via docker-build. Gallery data added (this entry was a complete-but-ungalleried orphan in main).",
+  "knowledge": {
+    "progressSummary": "COMPLETE: Keystone multiplicativity λ(m·n) = lcm(λ(m), λ(n)) for coprime m, n, proved via the CRT unit-group splitting (Z/mnZ)* ≃* (Z/mZ)* × (Z/nZ)* and Monoid.exponent_prod + Monoid.exponent_eq_of_mulEquiv. Plus order_dvd_carmichael (universal exponent). 2 defs, 2 theorems, 76 lines, 0 sorries, 0 axioms. Builds successfully. Added missing gallery data for an orphaned proof.",
+    "builtItems": [
+      "carmichael: λ(n) = Monoid.exponent (Z/nZ)* (self-contained definition)",
+      "unitsChineseRemainder: (Z/mnZ)* ≃* (Z/mZ)* × (Z/nZ)* for coprime m, n",
+      "carmichael_mul_coprime: λ(m·n) = lcm(λ(m), λ(n)) (keystone)",
+      "order_dvd_carmichael: orderOf a | λ(n) (universal-exponent property)"
+    ],
+    "insights": [
+      "Carmichael's λ is the group exponent of the unit group, so its arithmetic follows from exponent facts, not direct number theory.",
+      "Coprime multiplicativity = CRT splitting of the unit group + 'exponent of a product is the lcm of exponents'.",
+      "Monoid.exponent_eq_of_mulEquiv (exponent is an isomorphism invariant) is what allows the CRT isomorphism to be applied at the level of λ.",
+      "Iterating the keystone over n = ∏ p^k reduces λ(n) to lcm_i λ(p_i^{k_i}), the lcm-of-cyclic-orders form once each (Z/p^kZ)* is cyclic (odd p)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the group-exponent machinery but no packaged Carmichael-function multiplicativity statement.",
+      "The full λ(n) = lcm of prime-power values is not stated as a single theorem in Mathlib."
+    ],
+    "nextSteps": [
+      "Complete the induction over the prime-power factorization: λ(n) = lcm_i λ(p_i^{k_i}).",
+      "Prove λ(2^k) = 2^{k-2} for k ≥ 3 from (Z/2^kZ)* ≅ Z/2 × Z/2^{k-2}.",
+      "Combine with cyclicity of (Z/p^kZ)* (odd p) for the full 'lcm of cyclic group orders' characterization."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "carmichael-function",
+    "group-theory",
+    "chinese-remainder-theorem",
+    "research"
+  ],
+  "relatedProofs": [
+    "euler-totient-oq-01",
+    "euler-totient-oq-01-oq-02",
+    "euler-totient"
+  ],
+  "references": [
+    "Carmichael (1910): introduction of λ(n) and its multiplicativity",
+    "Hardy & Wright, An Introduction to the Theory of Numbers: structure of (Z/nZ)*"
+  ],
+  "started": "2026-06-22",
+  "lastUpdate": "2026-06-22",
+  "significance": 7,
+  "tractability": 7,
+  "leanFiles": [
+    "proofs/Proofs/EulerTotientOQ01OQ01.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **missing gallery data** for `euler-totient-oq-01-oq-01`. The Lean proof `proofs/Proofs/EulerTotientOQ01OQ01.lean` already lives in `main` but had no gallery entry (an orphan). This PR contributes `meta.json`, `annotations.json`, and the research-problem record, and marks the problem completed.

## The proof (already in main; 2 defs, 2 theorems, 76 lines, 0 sorries, 0 axioms)

Establishes the keystone multiplicativity of Carmichael's function for coprime `m, n`:

$$\lambda(m\cdot n) = \operatorname{lcm}(\lambda(m), \lambda(n)).$$

- `carmichael n := Monoid.exponent (Z/nZ)ˣ`
- `unitsChineseRemainder` — the iso `(Z/mnZ)ˣ ≃* (Z/mZ)ˣ × (Z/nZ)ˣ` (`Units.mapEquiv ∘ ZMod.chineseRemainder`, then `MulEquiv.prodUnits`)
- `carmichael_mul_coprime` — the keystone, from `Monoid.exponent_eq_of_mulEquiv` + `Monoid.exponent_prod`
- `order_dvd_carmichael` — the universal-exponent property `orderOf a ∣ λ(n)`

Iterating the keystone over `n = ∏ pᵏ` reduces `λ(n)` to `lcm_i λ(p_iᵏ)` — advancing the parent entry `euler-totient-oq-01` toward the full "λ(n) = lcm of cyclic group orders" characterization.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ01OQ01` — builds successfully.
- `#print axioms` on `carmichael_mul_coprime` and `order_dvd_carmichael`: only `[propext, Classical.choice, Quot.sound]`. No `native_decide`, no `sorryAx`. **0-axiom verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)