### PR TITLE
research(quadratic-reciprocity-algorithm-oq-02): the Jacobi symbol on composite moduli

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3248,6 +3248,7 @@ import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticGaussSumSquareOQ02
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
+import Proofs.QuadraticReciprocityAlgorithmOQ02
 import Proofs.QuadraticReciprocityAlgorithmOQ03
 import Proofs.QuadraticReciprocityAlgorithmOQ03FieldBridge
 import Proofs.QuadraticReciprocityAlgorithmOQ03M2

--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ02.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ02.lean
@@ -1,0 +1,194 @@
+import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
+import Mathlib.Tactic
+
+/-
+# The Jacobi Symbol on Composite Moduli: Extending the Legendre Algorithm
+
+## Open Question
+
+The parent entry `quadratic-reciprocity-algorithm-oq-01` implements a verified
+recursive algorithm `jacobiAlgo` for the symbol J(a | b) with an odd modulus b.
+OQ-02 asks: what changes when the modulus b is **composite** — how does the
+Jacobi symbol genuinely extend the Legendre symbol, and what is the precise price
+of that extension?
+
+## What This File Establishes
+
+The Legendre symbol (a | p) over a prime p is a faithful residuosity test:
+(a | p) = 1 ⟺ a is a nonzero square mod p, and (a | p) = −1 ⟺ a is a nonsquare.
+The Jacobi symbol J(a | n) over a composite odd n keeps **one** of these
+directions and loses the other. Concretely:
+
+* **Multiplicativity in the modulus** (`jacobi_mul_right`):
+  J(a | m·n) = J(a | m)·J(a | n). This is the defining feature that turns the
+  prime-modulus Legendre symbol into a function of composite moduli.
+
+* **It extends Legendre** (`jacobi_eq_legendre_of_prime`):
+  for prime p, J(a | p) = legendreSym p a.
+
+* **The surviving direction** (`nonsquare_of_jacobi_eq_neg_one`):
+  J(a | n) = −1 ⟹ a is a nonsquare mod n, for ANY n — a genuine
+  nonresidue certificate that needs no primality hypothesis.
+
+* **The lost direction, made precise** (`jacobi_one_not_isSquare`):
+  J(a | n) = 1 does NOT imply a is a square mod n once n is composite. The
+  canonical witness is a = 2, n = 15: J(2 | 15) = J(2 | 3)·J(2 | 5) =
+  (−1)·(−1) = 1, yet 2 is not a square mod 15 (the squares mod 15 are
+  {0,1,4,6,9,10}). Over a PRIME modulus this never happens
+  (`isSquare_of_jacobi_eq_one_prime`).
+
+* **Why the witness exists** (`jacobi_neg_one_factor`): with n = m·k, a value
+  J(a | n) = 1 can arise from J(a | m) = J(a | k) = −1, so a is a nonsquare
+  modulo each factor while the product symbol cancels to +1.
+
+All numeric Legendre/Jacobi values are evaluated through the residuosity iff
+lemmas (`legendreSym.eq_one_iff`, `legendreSym.eq_neg_one_iff`), which reduce to
+kernel-decidable `IsSquare` statements over the small fields `ZMod p` — so there
+is no `native_decide` anywhere.
+
+## Status: 0 sorries, 0 `axiom`s, no `native_decide`.
+-/
+
+namespace QuadraticReciprocityAlgorithmOQ02
+
+open scoped NumberTheorySymbols
+
+-- ============================================================================
+-- Part 1: The Jacobi symbol extends Legendre and is multiplicative in n
+-- ============================================================================
+
+/-- The Jacobi symbol agrees with the Legendre symbol on a prime modulus. -/
+theorem jacobi_eq_legendre_of_prime (p : ℕ) [Fact p.Prime] (a : ℤ) :
+    J(a | p) = legendreSym p a :=
+  (jacobiSym.legendreSym.to_jacobiSym p a).symm
+
+/-- **Multiplicativity in the modulus.**  J(a | m·n) = J(a | m)·J(a | n).
+    This is what makes the symbol a function of composite moduli at all. -/
+theorem jacobi_mul_right (a : ℤ) (m n : ℕ) [NeZero m] [NeZero n] :
+    J(a | m * n) = J(a | m) * J(a | n) :=
+  jacobiSym.mul_right a m n
+
+/-- Iterated multiplicativity: the Jacobi symbol over a product of three odd
+    moduli factors completely. -/
+theorem jacobi_mul_right₃ (a : ℤ) (m n k : ℕ) [NeZero m] [NeZero n] [NeZero k] :
+    J(a | m * n * k) = J(a | m) * J(a | n) * J(a | k) := by
+  rw [jacobi_mul_right, jacobi_mul_right]
+
+-- ============================================================================
+-- Part 2: The surviving direction — a nonresidue certificate for composite n
+-- ============================================================================
+
+/-- **The certificate that survives compositeness.**  If J(a | n) = −1 then `a`
+    is a nonsquare modulo `n`, with no primality hypothesis on `n`. -/
+theorem nonsquare_of_jacobi_eq_neg_one {a : ℤ} {n : ℕ} (h : J(a | n) = -1) :
+    ¬ IsSquare (a : ZMod n) :=
+  ZMod.nonsquare_of_jacobiSym_eq_neg_one h
+
+/-- Contrapositive form: if `a` is a square mod `n`, the Jacobi symbol is not −1. -/
+theorem jacobi_ne_neg_one_of_isSquare {a : ℤ} {n : ℕ} (h : IsSquare (a : ZMod n)) :
+    J(a | n) ≠ -1 :=
+  fun hj => nonsquare_of_jacobi_eq_neg_one hj h
+
+-- ============================================================================
+-- Part 3: Prime-modulus values via the residuosity iff lemmas
+-- ============================================================================
+
+/-- `J(2 | 3) = −1`: 2 is a nonsquare mod the prime 3. -/
+theorem jacobi_two_three : J(2 | 3) = -1 := by
+  haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+  rw [jacobi_eq_legendre_of_prime, legendreSym.eq_neg_one_iff 3 (a := 2)]
+  decide +revert
+
+/-- `J(2 | 5) = −1`: 2 is a nonsquare mod the prime 5. -/
+theorem jacobi_two_five : J(2 | 5) = -1 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  rw [jacobi_eq_legendre_of_prime, legendreSym.eq_neg_one_iff 5 (a := 2)]
+  decide +revert
+
+/-- `J(2 | 7) = 1`: 2 is a square mod 7 (3² = 9 ≡ 2). -/
+theorem jacobi_two_seven : J(2 | 7) = 1 := by
+  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+  rw [jacobi_eq_legendre_of_prime, legendreSym.eq_one_iff 7 (a := 2) (by decide +revert)]
+  decide +revert
+
+/-- `J(7 | 3) = 1`: 7 ≡ 1 mod 3 is a square. -/
+theorem jacobi_seven_three : J(7 | 3) = 1 := by
+  haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+  rw [jacobi_eq_legendre_of_prime, legendreSym.eq_one_iff 3 (a := 7) (by decide +revert)]
+  decide +revert
+
+/-- `J(7 | 5) = −1`: 7 ≡ 2 mod 5 is a nonsquare. -/
+theorem jacobi_seven_five : J(7 | 5) = -1 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  rw [jacobi_eq_legendre_of_prime, legendreSym.eq_neg_one_iff 5 (a := 7)]
+  decide +revert
+
+-- ============================================================================
+-- Part 4: The lost direction — J = 1 does not certify a square mod composite n
+-- ============================================================================
+
+/-- `J(2 | 15) = 1`, from multiplicativity J(2|15) = J(2|3)·J(2|5) = (−1)·(−1).
+    Two nonresidue contributions cancel. -/
+theorem jacobi_two_fifteen : J(2 | 15) = 1 := by
+  rw [show (15 : ℕ) = 3 * 5 from by norm_num, jacobi_mul_right,
+    jacobi_two_three, jacobi_two_five]
+  norm_num
+
+/-- `2` is not a square modulo `15` (the squares mod 15 are {0,1,4,6,9,10}). -/
+theorem two_not_isSquare_mod_fifteen : ¬ IsSquare (2 : ZMod 15) := by decide
+
+/-- **The asymmetry, witnessed.**  There exist `a` and a composite odd `n` with
+    J(a | n) = 1 yet `a` not a square mod `n`.  The Legendre symbol over a prime
+    never behaves this way (`isSquare_of_jacobi_eq_one_prime`). -/
+theorem jacobi_one_not_isSquare :
+    ∃ (a : ℤ) (n : ℕ), J(a | n) = 1 ∧ ¬ IsSquare (a : ZMod n) :=
+  ⟨2, 15, jacobi_two_fifteen, two_not_isSquare_mod_fifteen⟩
+
+/-- The contrast: over a PRIME modulus, `J(a | p) = 1` does imply `a` is a square.
+    This is exactly the direction that fails for composite `n`. -/
+theorem isSquare_of_jacobi_eq_one_prime {a : ℤ} {p : ℕ} [Fact p.Prime]
+    (h : J(a | p) = 1) : IsSquare (a : ZMod p) :=
+  ZMod.isSquare_of_jacobiSym_eq_one h
+
+-- ============================================================================
+-- Part 5: Why the witness exists — cancellation across the factorization
+-- ============================================================================
+
+/-- The mechanism behind the lost direction: with `n = 3·5`, `J(2 | 15) = 1`
+    arises from `J(2 | 3) = J(2 | 5) = −1`, i.e. `2` is a nonsquare modulo each
+    prime factor while the product symbol is `+1`. -/
+theorem jacobi_neg_one_factor :
+    J(2 | 15) = 1 ∧ ¬ IsSquare (2 : ZMod 3) ∧ ¬ IsSquare (2 : ZMod 5) := by
+  refine ⟨jacobi_two_fifteen, ?_, ?_⟩
+  · exact nonsquare_of_jacobi_eq_neg_one jacobi_two_three
+  · exact nonsquare_of_jacobi_eq_neg_one jacobi_two_five
+
+-- ============================================================================
+-- Part 6: Worked composite-modulus computations and the surviving direction
+-- ============================================================================
+
+/-- `J(7 | 15) = −1` via J(7|3)·J(7|5) = (1)·(−1).  Here the surviving direction
+    applies: `7` is a genuine nonsquare mod 15. -/
+theorem jacobi_seven_fifteen : J(7 | 15) = -1 := by
+  rw [show (15 : ℕ) = 3 * 5 from by norm_num, jacobi_mul_right,
+    jacobi_seven_three, jacobi_seven_five]
+  norm_num
+
+example : ¬ IsSquare (7 : ZMod 15) :=
+  nonsquare_of_jacobi_eq_neg_one jacobi_seven_fifteen
+
+/-- `J(2 | 21) = −1` via J(2|3)·J(2|7) = (−1)·(1), so `2` is a nonsquare mod 21. -/
+theorem jacobi_two_twentyone : J(2 | 21) = -1 := by
+  rw [show (21 : ℕ) = 3 * 7 from by norm_num, jacobi_mul_right,
+    jacobi_two_three, jacobi_two_seven]
+  norm_num
+
+example : ¬ IsSquare (2 : ZMod 21) :=
+  nonsquare_of_jacobi_eq_neg_one jacobi_two_twentyone
+
+#check @jacobi_mul_right
+#check @nonsquare_of_jacobi_eq_neg_one
+#check @jacobi_one_not_isSquare
+#check @isSquare_of_jacobi_eq_one_prime
+
+end QuadraticReciprocityAlgorithmOQ02

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-02/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-02/annotations.json
@@ -1,0 +1,116 @@
+[
+  {
+    "id": "jacobi-composite-context",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Extending Legendre to Composite Moduli: One Direction Survives",
+    "content": "The Legendre symbol (a | p) over a prime p is a faithful quadratic-residuosity test: +1 means a is a nonzero square mod p, −1 means a nonsquare. Jacobi extended it to odd moduli by J(a | n) = ∏ (a | pᵢ) over the factorization of n, which is what lets the reciprocity-based algorithm avoid factoring. But over a composite modulus only one direction of the test survives: J(a | n) = −1 still certifies a nonsquare, while J(a | n) = 1 no longer guarantees a square — an even number of −1 factors can cancel. The smallest example is J(2 | 15) = 1 with 2 a genuine nonsquare mod 15.",
+    "mathContext": "$J(a \\mid n) = \\prod_i \\left(\\tfrac{a}{p_i}\\right)$ for $n = \\prod_i p_i$. Surviving: $J(a\\mid n) = -1 \\Rightarrow a$ a nonsquare. Lost: $J(a\\mid n) = 1 \\not\\Rightarrow a$ a square (e.g. $J(2\\mid 15) = (-1)(-1) = 1$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre symbol",
+      "Jacobi symbol",
+      "quadratic residues",
+      "Solovay–Strassen primality test",
+      "multiplicativity in the modulus"
+    ],
+    "prerequisites": [
+      "quadratic residues mod p",
+      "the Legendre symbol",
+      "prime factorization"
+    ]
+  },
+  {
+    "id": "jacobi-multiplicativity",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02",
+    "range": {
+      "startLine": 67,
+      "endLine": 75
+    },
+    "type": "theorem",
+    "title": "Multiplicativity in the Modulus",
+    "content": "jacobi_mul_right states J(a | m·n) = J(a | m)·J(a | n), and jacobi_mul_right₃ iterates it to a three-factor product. This is the property that turns the prime-only Legendre symbol into a function of composite moduli: the Jacobi symbol of a over a product is the product of the symbols over the factors, which is precisely why the reciprocity algorithm never needs to factor the modulus to compute it.",
+    "mathContext": "$J(a \\mid mn) = J(a \\mid m)\\,J(a \\mid n)$. Iterating, $J(a \\mid mnk) = J(a\\mid m)J(a\\mid n)J(a\\mid k)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "jacobiSym.mul_right",
+      "multiplicative functions",
+      "prime factorization of the modulus"
+    ],
+    "prerequisites": [
+      "Jacobi symbol definition",
+      "the modulus as a product of factors"
+    ]
+  },
+  {
+    "id": "jacobi-surviving",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02",
+    "range": {
+      "startLine": 83,
+      "endLine": 90
+    },
+    "type": "theorem",
+    "title": "The Surviving Direction: a Nonresidue Certificate",
+    "content": "nonsquare_of_jacobi_eq_neg_one shows J(a | n) = −1 ⟹ a is a nonsquare mod n, with NO primality hypothesis on n. This is the half of the residuosity test that survives compositeness: a value of −1 can only come from an odd number of −1 Legendre factors, which is impossible if a were a global square. Its contrapositive (jacobi_ne_neg_one_of_isSquare) says a square never has symbol −1.",
+    "mathContext": "$J(a \\mid n) = -1 \\Rightarrow \\neg\\,\\mathrm{IsSquare}\\,(a : \\mathbb{Z}/n)$, for every $n$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ZMod.nonsquare_of_jacobiSym_eq_neg_one",
+      "nonresidue certificate",
+      "quadratic nonresidue"
+    ],
+    "prerequisites": [
+      "IsSquare in ZMod n",
+      "Jacobi symbol values"
+    ]
+  },
+  {
+    "id": "jacobi-lost-witness",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02",
+    "range": {
+      "startLine": 143,
+      "endLine": 151
+    },
+    "type": "theorem",
+    "title": "The Lost Direction, Witnessed",
+    "content": "jacobi_one_not_isSquare exhibits a = 2, n = 15 with J(2 | 15) = 1 (computed from J(2|3)·J(2|5) = (−1)·(−1) by multiplicativity) yet 2 not a square mod 15. This is the precise failure of the converse over composite moduli, and it is exactly what isSquare_of_jacobi_eq_one_prime shows does NOT happen for a prime modulus, where J(a | p) = 1 forces a to be a square. The asymmetry between these two theorems is the whole content of 'composite' here.",
+    "mathContext": "$\\exists\\,a,n:\\ J(a\\mid n)=1 \\wedge \\neg\\,\\mathrm{IsSquare}\\,(a:\\mathbb{Z}/n)$ — witnessed by $(2,15)$. Contrast: for prime $p$, $J(a\\mid p)=1 \\Rightarrow \\mathrm{IsSquare}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "ZMod.isSquare_of_jacobiSym_eq_one",
+      "Euler liars",
+      "Solovay–Strassen primality test",
+      "converse failure"
+    ],
+    "prerequisites": [
+      "multiplicativity of the Jacobi symbol",
+      "IsSquare in ZMod 15"
+    ]
+  },
+  {
+    "id": "jacobi-mechanism",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02",
+    "range": {
+      "startLine": 160,
+      "endLine": 164
+    },
+    "type": "theorem",
+    "title": "Why the Witness Exists: Cancellation Across Factors",
+    "content": "jacobi_neg_one_factor exposes the mechanism: J(2 | 15) = 1 together with ¬IsSquare (2 : ZMod 3) and ¬IsSquare (2 : ZMod 5). The two −1 contributions from the prime factors 3 and 5 multiply to +1, so the global Jacobi symbol gives no alarm even though 2 is a nonsquare modulo each factor. This is the structural reason the J = 1 direction is lost, and the seed of the Solovay–Strassen 'Euler liar' phenomenon.",
+    "mathContext": "$J(2\\mid 15) = 1$ while $\\neg\\mathrm{IsSquare}(2:\\mathbb{Z}/3)$ and $\\neg\\mathrm{IsSquare}(2:\\mathbb{Z}/5)$: $(-1)\\cdot(-1) = +1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "cancellation of nonresidue factors",
+      "Chinese Remainder structure of squares",
+      "Euler liars"
+    ],
+    "prerequisites": [
+      "multiplicativity in the modulus",
+      "the surviving nonresidue direction"
+    ]
+  }
+]

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-02/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-02/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "quadratic-reciprocity-algorithm-oq-02",
+  "title": "The Jacobi Symbol on Composite Moduli: What Extends and What Breaks",
+  "slug": "quadratic-reciprocity-algorithm-oq-02",
+  "description": "The parent entry implements a verified recursive algorithm jacobiAlgo for J(a | b). This follow-up makes precise how the Jacobi symbol over a COMPOSITE modulus genuinely extends the Legendre symbol and exactly what residuosity information it loses. It establishes multiplicativity in the modulus J(a | m·n) = J(a | m)·J(a | n) (the feature that defines composite-modulus behavior), that J agrees with the Legendre symbol on primes, the surviving direction J(a | n) = −1 ⟹ a is a nonsquare mod n (a nonresidue certificate valid for any n), and the lost direction with its canonical witness: J(2 | 15) = J(2 | 3)·J(2 | 5) = (−1)·(−1) = 1 even though 2 is not a square mod 15 — whereas over a prime J(a | p) = 1 always forces a square. All numeric symbol values are computed through the residuosity iff lemmas (legendreSym.eq_one_iff / eq_neg_one_iff), reducing to kernel-decidable IsSquare facts over small ZMod p, so there is no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticReciprocityAlgorithmOQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 194,
+    "theoremCount": 17,
+    "definitionCount": 0,
+    "assumptions": "None. Every result is fully machine-checked. Numeric Legendre/Jacobi values are discharged via the residuosity iff lemmas, which reduce to kernel `decide` over the finite fields ZMod p (the `+revert` modifier cleans up the local `Fact p.Prime` instance before deciding); there is no `native_decide`, hence no Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; no axiom declaration, no structure-encoded hypothesis, no sorryAx.",
+    "tags": [
+      "number-theory",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "quadratic-residues",
+      "quadratic-reciprocity",
+      "composite-moduli",
+      "multiplicativity",
+      "nonresidue-certificate"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "jacobi_mul_right / jacobi_mul_right₃: multiplicativity of the Jacobi symbol in the modulus, J(a | m·n) = J(a | m)·J(a | n), packaged as the defining composite-modulus property",
+      "jacobi_eq_legendre_of_prime: the Jacobi symbol agrees with the Legendre symbol on prime moduli (the sense in which it extends it)",
+      "nonsquare_of_jacobi_eq_neg_one: the surviving residuosity direction — J(a | n) = −1 certifies a is a nonsquare mod n for ANY modulus n, with no primality hypothesis",
+      "jacobi_one_not_isSquare: the asymmetry witnessed — ∃ a, n with J(a | n) = 1 yet a not a square mod n (a = 2, n = 15), the precise failure of the converse for composite moduli, contrasted with isSquare_of_jacobi_eq_one_prime for primes",
+      "jacobi_neg_one_factor: the mechanism — J(2 | 15) = 1 arises from J(2 | 3) = J(2 | 5) = −1 cancelling, so 2 is a nonsquare modulo each prime factor while the product symbol is +1",
+      "Native-decide-free numeric evaluation of J(2|3), J(2|5), J(2|7), J(7|3), J(7|5), J(2|15), J(7|15), J(2|21) through the IsSquare residuosity criterion"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "jacobiSym.legendreSym.to_jacobiSym",
+        "description": "legendreSym p a = J(a | p) for prime p. Bridges the two symbols, letting prime-modulus Jacobi values be computed through the Legendre residuosity criterion.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.mul_right",
+        "description": "J(a | m·n) = J(a | m)·J(a | n) for nonzero m, n. The multiplicativity of the Jacobi symbol in its modulus, the core of composite-modulus behavior.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "ZMod.nonsquare_of_jacobiSym_eq_neg_one",
+        "description": "J(a | b) = −1 ⟹ a is not a square in ZMod b, for any b. Supplies the surviving residuosity direction that makes the Jacobi symbol a valid nonresidue certificate over composite moduli.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "ZMod.isSquare_of_jacobiSym_eq_one",
+        "description": "For prime p, J(a | p) = 1 ⟹ a is a square mod p. The direction that holds for primes and fails for composite moduli, pinning down the asymmetry.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "legendreSym.eq_one_iff / legendreSym.eq_neg_one_iff",
+        "description": "legendreSym p a = 1 ↔ IsSquare (a : ZMod p) (for a ≠ 0) and = −1 ↔ ¬IsSquare. Reduce each prime-modulus symbol value to a kernel-decidable IsSquare statement over a small finite field, avoiding native_decide.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/QuadraticReciprocityAlgorithmOQ02.lean",
+    "namespace": "QuadraticReciprocityAlgorithmOQ02",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 194,
+    "theoremCount": 17,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The Legendre symbol (a | p), defined for an odd prime p, records whether a is a quadratic residue: +1 for a nonzero square, −1 for a nonsquare, 0 for a multiple of p. Jacobi extended it to all odd moduli by setting J(a | n) = ∏ (a | pᵢ) over the prime factorization n = ∏ pᵢ. The extension is what makes the reciprocity-based GCD-like algorithm (the parent entry's jacobiAlgo) efficient: one never has to factor the modulus. But the extension is not free. For a prime, the Legendre symbol is a faithful test of quadratic residuosity in both directions. For a composite modulus the Jacobi symbol keeps only one direction — a −1 still certifies a nonresidue — while a +1 no longer guarantees a square, because an even number of −1 factors can cancel. This single asymmetry is the reason the Jacobi symbol cannot by itself decide quadratic residuosity mod n, and it is exactly the gap that the Solovay–Strassen probabilistic primality test exploits.",
+    "problemStatement": "Open Question OQ-02 (child of quadratic-reciprocity-algorithm-oq-01): extend the verified Legendre symbol computation to Jacobi symbols for composite moduli. Concretely: state and prove the multiplicativity of the Jacobi symbol in its modulus, the sense in which it extends the Legendre symbol, and — the mathematically substantive part — the precise residuosity information that survives versus is lost when the modulus is composite.",
+    "proofStrategy": "Multiplicativity in the modulus is Mathlib's jacobiSym.mul_right; iterating it gives the three-factor form. Agreement with Legendre on primes is jacobiSym.legendreSym.to_jacobiSym. The surviving direction J(a | n) = −1 ⟹ ¬IsSquare (a : ZMod n) is ZMod.nonsquare_of_jacobiSym_eq_neg_one, which carries no primality hypothesis; its contrapositive gives a residue ⟹ symbol ≠ −1. The lost direction is exhibited by the witness a = 2, n = 15: compute J(2 | 15) = J(2 | 3)·J(2 | 5) by multiplicativity, evaluate J(2 | 3) = J(2 | 5) = −1, so J(2 | 15) = 1, while ¬IsSquare (2 : ZMod 15) is checked by kernel decide; packaged as the existential jacobi_one_not_isSquare and contrasted with ZMod.isSquare_of_jacobiSym_eq_one for primes. Every prime-modulus symbol value is obtained by rewriting J(a | p) to legendreSym p a and then to a decidable IsSquare statement via legendreSym.eq_one_iff / eq_neg_one_iff with the prime and argument supplied explicitly; the residual decide is run with `+revert` so the local Fact p.Prime instance does not leave the goal with a free variable. This keeps the whole development free of native_decide.",
+    "keyInsights": [
+      "The Jacobi symbol is the prime-factorization product of Legendre symbols, so multiplicativity in the modulus is not a theorem to be earned but the very definition extended — and it is what lets the reciprocity algorithm avoid factoring.",
+      "Compositeness breaks the symbol's residuosity test in exactly one direction: J(a | n) = −1 still proves a is a nonsquare (an odd number of nonresidue factors cannot come from a global square), but J(a | n) = 1 proves nothing, since two −1 factors cancel.",
+      "The smallest witness, J(2 | 15) = 1 with 2 a nonsquare mod 15, is not a curiosity but the structural heart of the Solovay–Strassen primality test: composite moduli admit 'Euler liars' precisely because the Jacobi symbol can read +1 on a genuine nonresidue.",
+      "A clean residuosity computation need not use native_decide: routing each prime-modulus value through legendreSym.eq_*_iff turns it into an IsSquare question over a tiny finite field, which the kernel decides — keeping the entry axiom-honest (no Lean.ofReduceBool).",
+      "`decide +revert` is the right tool when a goal like ¬IsSquare (↑2 : ZMod 3) is blocked by a local `Fact p.Prime` instance: reverting it removes the free-variable obstruction before kernel evaluation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Overview",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "States OQ-02: extending the parent's Legendre algorithm to composite moduli, and previews the surviving (J = −1 ⟹ nonsquare) versus lost (J = 1 ⤏ square) residuosity directions, with the J(2|15) witness."
+    },
+    {
+      "id": "extend-multiplicative",
+      "title": "Extending Legendre; Multiplicativity in the Modulus",
+      "startLine": 56,
+      "endLine": 75,
+      "summary": "jacobi_eq_legendre_of_prime (J(a|p) = legendreSym p a) and jacobi_mul_right / jacobi_mul_right₃ (J(a | m·n) = J(a|m)·J(a|n)), the defining composite-modulus property."
+    },
+    {
+      "id": "surviving-direction",
+      "title": "The Surviving Direction: a Nonresidue Certificate",
+      "startLine": 77,
+      "endLine": 90,
+      "summary": "nonsquare_of_jacobi_eq_neg_one: J(a | n) = −1 ⟹ a is a nonsquare mod n for any n, and its contrapositive jacobi_ne_neg_one_of_isSquare."
+    },
+    {
+      "id": "prime-values",
+      "title": "Prime-Modulus Values via Residuosity",
+      "startLine": 92,
+      "endLine": 124,
+      "summary": "J(2|3), J(2|5), J(2|7), J(7|3), J(7|5) computed by rewriting to legendreSym and then to a decidable IsSquare statement (legendreSym.eq_one_iff / eq_neg_one_iff), with `decide +revert`. No native_decide."
+    },
+    {
+      "id": "lost-direction",
+      "title": "The Lost Direction and Its Witness",
+      "startLine": 126,
+      "endLine": 151,
+      "summary": "jacobi_two_fifteen (J(2|15) = 1 by multiplicativity), two_not_isSquare_mod_fifteen, the existential jacobi_one_not_isSquare, and the prime contrast isSquare_of_jacobi_eq_one_prime."
+    },
+    {
+      "id": "mechanism",
+      "title": "Why the Witness Exists",
+      "startLine": 153,
+      "endLine": 164,
+      "summary": "jacobi_neg_one_factor: J(2|15) = 1 arises from J(2|3) = J(2|5) = −1, so 2 is a nonsquare modulo each prime factor while the product cancels to +1."
+    },
+    {
+      "id": "worked",
+      "title": "Worked Composite-Modulus Computations",
+      "startLine": 166,
+      "endLine": 194,
+      "summary": "jacobi_seven_fifteen (J(7|15) = −1, surviving direction gives 7 a nonsquare mod 15) and jacobi_two_twentyone (J(2|21) = −1), each with the nonsquare corollary."
+    }
+  ],
+  "conclusion": {
+    "summary": "17 theorems, 0 sorries, 0 axioms, no native_decide. The Jacobi symbol over a composite modulus is multiplicative in the modulus and agrees with the Legendre symbol on primes, but its residuosity test survives only in one direction: J(a | n) = −1 certifies a nonsquare for any n, while J(a | n) = 1 does not certify a square once n is composite, witnessed by J(2 | 15) = 1 with 2 a nonsquare mod 15.",
+    "implications": "Completes the parent's Legendre/Jacobi algorithm by pinning down exactly what the symbol does and does not decide over composite moduli — the foundation of the Solovay–Strassen primality test. The technique of evaluating Legendre/Jacobi values through the IsSquare residuosity criterion (rather than native_decide) is a reusable, axiom-honest way to compute these symbols on concrete inputs.",
+    "openQuestions": [
+      "Can the Euler-criterion failure be formalized directly as a Solovay–Strassen compositeness witness: if n is odd and J(a | n) ≢ a^((n−1)/2) (mod n) for some a coprime to n, then n is composite?",
+      "What fraction of a ∈ (ZMod n)ˣ are 'Euler liars' (J(a|n) = 1 with a a nonsquare) for a given composite n, and can the ≤ 1/2 bound underlying Solovay–Strassen be proved in Lean?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "quadratic-reciprocity-algorithm-oq-01",
+      "relationship": "parent — implements the verified recursive symbol algorithm jacobiAlgo; this entry characterizes what that symbol decides over composite moduli"
+    },
+    {
+      "targetId": "quadratic-reciprocity-algorithm",
+      "relationship": "ancestor — the law of quadratic reciprocity underlying both the algorithm and the multiplicativity used here"
+    },
+    {
+      "targetId": "quadratic-reciprocity-algorithm-oq-03",
+      "relationship": "sibling — a further development of the quadratic-reciprocity algorithm line"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Open Question

**OQ-02** (child of `quadratic-reciprocity-algorithm-oq-01`): extend the parent's verified recursive Legendre-symbol algorithm to **composite moduli** — characterize how the Jacobi symbol genuinely extends the Legendre symbol and what residuosity information it loses.

## Result

The Jacobi symbol over a composite modulus extends Legendre via multiplicativity but its residuosity test survives in **only one direction**:

- `jacobi_mul_right` — `J(a | m·n) = J(a | m)·J(a | n)` (the defining composite-modulus property)
- `jacobi_eq_legendre_of_prime` — agrees with `legendreSym` on primes
- `nonsquare_of_jacobi_eq_neg_one` — **surviving:** `J(a | n) = -1 ⟹ a` a nonsquare mod `n`, for *any* `n`
- `jacobi_one_not_isSquare` — **lost:** `∃ a n, J(a | n) = 1 ∧ ¬IsSquare (a : ZMod n)`, witnessed by `a = 2, n = 15` (`J(2|15) = (-1)·(-1) = 1`), contrasted with `isSquare_of_jacobi_eq_one_prime` (holds for primes)
- `jacobi_neg_one_factor` — the cancellation mechanism: `J(2|3) = J(2|5) = -1` cancel to `+1`

This asymmetry is the structural seed of the Solovay–Strassen primality test.

## Verification

- 194 lines, 17 theorems, **0 sorries, 0 `axiom`s, no `native_decide`**
- Numeric symbol values are evaluated through `legendreSym.eq_one_iff` / `eq_neg_one_iff`, reducing to kernel-decidable `IsSquare` facts over small `ZMod p` (`decide +revert`) — keeping the entry axiom-honest (no `Lean.ofReduceBool`)
- Depends only on `propext` / `Classical.choice` / `Quot.sound`
- Builds via `./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ02`
- Gallery entry at `src/data/proofs/quadratic-reciprocity-algorithm-oq-02/` (annotations validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)