### PR TITLE
research(narcissistic-number-oq-01): gallery data — narcissistic (Armstrong) numbers are finite

### DIFF
--- a/src/data/proofs/narcissistic-number-oq-01/annotations.json
+++ b/src/data/proofs/narcissistic-number-oq-01/annotations.json
@@ -1,0 +1,127 @@
+[
+  {
+    "id": "ann-nnoq01-00-header",
+    "proofId": "narcissistic-number-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "Module Overview: A Race Between Two Growth Rates",
+    "content": "A narcissistic (Armstrong) number equals the sum of its decimal digits each raised to the power of its digit count: 153 = 1^3+5^3+3^3, 9474 = 9^4+4^4+7^4+4^4. Finiteness follows from a race: an n-digit number is at least 10^(n-1), but its digit-power-sum is at most n*9^n. Since 10^(n-1) outgrows n*9^n (crossover at n = 61), no narcissistic number can have 61 or more digits, so all of them lie below 10^61 — a finite range.",
+    "mathContext": "n-digit number ≥ 10^(n-1); digit-power-sum ≤ n*9^n; crossover at n = 61.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "narcissistic number",
+      "Armstrong number",
+      "digit-power-sum",
+      "exponential growth"
+    ],
+    "prerequisites": [
+      "Nat.digits"
+    ]
+  },
+  {
+    "id": "ann-nnoq01-01-defs",
+    "proofId": "narcissistic-number-oq-01",
+    "range": {
+      "startLine": 35,
+      "endLine": 47
+    },
+    "type": "definition",
+    "title": "Digit Count and Narcissistic Numbers",
+    "content": "numDigits m is the length of Nat.digits 10 m. Narcissistic m says m equals the sum over its decimal digits d of d^(numDigits m). digit_le_nine records that every base-10 digit is at most 9 (from Nat.digits_lt_base), the per-term bound the whole argument rests on.",
+    "mathContext": "Narcissistic m ⟺ m = Σ_{d ∈ digits 10 m} d^(numDigits m); each d ≤ 9.",
+    "significance": "key",
+    "relatedConcepts": [
+      "decimal digits",
+      "digit bound"
+    ],
+    "prerequisites": [
+      "Nat.digits_lt_base"
+    ]
+  },
+  {
+    "id": "ann-nnoq01-02-sumbound",
+    "proofId": "narcissistic-number-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 70
+    },
+    "type": "technique",
+    "title": "Bounding the Digit-Power-Sum",
+    "content": "digitPowSum_le bounds the digit-power-sum of m by numDigits m * 9^(numDigits m). Each summand d^n has d ≤ 9, so d^n ≤ 9^n (Nat.pow_le_pow_left); with numDigits m terms, List.sum_le_card_nsmul gives the sum ≤ (length)·9^n = n·9^n. This is the upper half of the race.",
+    "mathContext": "Σ d^n ≤ (number of digits) · 9^n = n · 9^n.",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum bounded by card times max term",
+      "monotonicity of powers"
+    ],
+    "prerequisites": [
+      "List.sum_le_card_nsmul",
+      "Nat.pow_le_pow_left"
+    ]
+  },
+  {
+    "id": "ann-nnoq01-03-crossover",
+    "proofId": "narcissistic-number-oq-01",
+    "range": {
+      "startLine": 72,
+      "endLine": 92
+    },
+    "type": "key-step",
+    "title": "The Crossover Inequality n·9ⁿ < 10ⁿ⁻¹ for n ≥ 61",
+    "content": "crossover is the arithmetic heart: for all n ≥ 61, n*9^n < 10^(n-1), by Nat.le_induction from n = 61. The base case 61*9^61 < 10^60 is closed by norm_num (which evaluates both large numbers exactly — kernel-checked, no native_decide). The step uses 9^(n+1) = 9·9^n and 10^n = 10·10^(n-1) together with 9·(n+1) ≤ 10·n (valid for n ≥ 9): (n+1)·9^(n+1) = 9(n+1)·9^n ≤ 10n·9^n = 10·(n·9^n) < 10·10^(n-1) = 10^n. The factor-10 vs factor-9 gap absorbs the linear digit growth.",
+    "mathContext": "n ≥ 61 ⟹ n·9^n < 10^(n-1); step: 9(n+1) ≤ 10n bridges the powers.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.le_induction",
+      "exponential vs linear growth",
+      "norm_num evaluation"
+    ],
+    "prerequisites": [
+      "Nat.le_induction",
+      "pow_succ"
+    ]
+  },
+  {
+    "id": "ann-nnoq01-04-lowerbound",
+    "proofId": "narcissistic-number-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 103
+    },
+    "type": "technique",
+    "title": "The n-Digit Lower Bound",
+    "content": "pow_pred_length_le gives the lower half of the race: a nonzero m is at least 10^(numDigits m - 1). It starts from Nat.base_pow_length_digits_le (10^(digit length) ≤ 10·m for m ≠ 0) and cancels one factor of 10, using that the digit length is positive.",
+    "mathContext": "m ≠ 0 ⟹ 10^(numDigits m - 1) ≤ m.",
+    "significance": "key",
+    "relatedConcepts": [
+      "digit length lower bound"
+    ],
+    "prerequisites": [
+      "Nat.base_pow_length_digits_le"
+    ]
+  },
+  {
+    "id": "ann-nnoq01-05-finite",
+    "proofId": "narcissistic-number-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 136
+    },
+    "type": "key-step",
+    "title": "Digit Cap and Finiteness",
+    "content": "numDigits_lt_61 combines the three bounds: for a narcissistic m with n = numDigits m ≥ 61, m = digit-power-sum ≤ n*9^n (digitPowSum_le) while m ≥ 10^(n-1) (pow_pred_length_le) and n*9^n < 10^(n-1) (crossover) — an omega contradiction. So every narcissistic number has fewer than 61 digits. narcissistic_finite then exhibits the set as a subset of the finite interval Set.Iio (10^61): m < 10^(numDigits m) ≤ 10^61, and a subset of a finite set is finite.",
+    "mathContext": "narcissistic m ⟹ numDigits m < 61 ⟹ m < 10^61; subset of Iio(10^61) is finite.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "finiteness from a bound",
+      "Set.Finite.subset"
+    ],
+    "prerequisites": [
+      "Set.finite_Iio",
+      "Nat.lt_base_pow_length_digits"
+    ]
+  }
+]

--- a/src/data/proofs/narcissistic-number-oq-01/meta.json
+++ b/src/data/proofs/narcissistic-number-oq-01/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "narcissistic-number-oq-01",
+  "title": "Narcissistic (Armstrong) Numbers Are Finite",
+  "slug": "narcissistic-number-oq-01",
+  "description": "Proves that the set of narcissistic numbers — naturals equal to the sum of their decimal digits each raised to the power of the digit count, e.g. 153 = 1^3 + 5^3 + 3^3 — is finite. The digit-power-sum of an n-digit number is at most n*9^n, which is eventually dwarfed by the n-digit lower bound 10^(n-1); the crossover at n = 61 caps every narcissistic number below 10^61.",
+  "meta": {
+    "author": "researcher-9 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Narcissistic_number",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NarcissisticNumberOQ01.lean",
+    "tags": [
+      "number-theory",
+      "digits",
+      "narcissistic-number",
+      "armstrong-number",
+      "finiteness",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.digits",
+        "description": "the list of base-10 digits of a natural number",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.digits_lt_base",
+        "description": "every base-10 digit is < 10 (hence ≤ 9)",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Nat.base_pow_length_digits_le",
+        "description": "lower bound relating a number to a power of its digit-length",
+        "module": "Mathlib.Data.Nat.Digits"
+      },
+      {
+        "theorem": "Set.Finite.subset",
+        "description": "a subset of a finite set is finite; used with a bounded interval of naturals",
+        "module": "Mathlib.Data.Set.Finite"
+      }
+    ],
+    "originalContributions": [
+      "numDigits / Narcissistic: definitions of the decimal digit count and of a narcissistic number (m equals the sum of its digits each raised to the numDigits m power)",
+      "digit_le_nine: every base-10 digit is at most 9",
+      "digitPowSum_le: the digit-power-sum of m is at most numDigits m * 9^(numDigits m)",
+      "crossover: the arithmetic crossover n*9^n < 10^(n-1) for all n ≥ 61, by induction",
+      "pow_pred_length_le: an n-digit number is at least 10^(n-1)",
+      "numDigits_lt_61: any narcissistic number has fewer than 61 digits",
+      "narcissistic_finite: the set of narcissistic numbers is finite"
+    ],
+    "references": [
+      {
+        "authors": "Armstrong, Michael F.",
+        "title": "Armstrong (narcissistic) numbers",
+        "year": "1966",
+        "venue": "",
+        "note": "Popularized the n-digit base-10 narcissistic numbers (Armstrong numbers)"
+      },
+      {
+        "authors": "Madachy, Joseph S.",
+        "title": "Mathematics on Vacation",
+        "year": "1966",
+        "venue": "Scribner",
+        "note": "Notes that there are exactly 88 base-10 narcissistic numbers, the largest being 115132219018763992565095597973971522401 (39 digits)"
+      }
+    ],
+    "prerequisites": [
+      "Decimal digit representation of natural numbers (Nat.digits)",
+      "Bounding a sum by a bound on each term times the number of terms",
+      "Exponential growth: 10^(n-1) eventually exceeds n*9^n",
+      "A bounded set of naturals is finite"
+    ],
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 136,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "A narcissistic number (or Armstrong number, or pluperfect digital invariant) is a natural number that equals the sum of its own decimal digits each raised to the power of the number of digits: 153 = 1^3 + 5^3 + 3^3, 8208 = 8^4 + 2^4 + 0^4 + 8^4, 9474 = 9^4 + 4^4 + 7^4 + 4^4. They are a recreational-mathematics staple, but the fact that there are only finitely many of them is a genuine (if elementary) theorem, first observed in the mid-20th century. In base 10 there are exactly 88 of them, the largest being a 39-digit number; beyond a certain digit length no narcissistic number can exist at all.\n\nThe reason is a race between two growth rates. An n-digit number is at least 10^(n-1). But the largest its digit-power-sum can be is n * 9^n (n digits, each at most 9, each raised to the n-th power). For small n the digit-power-sum can keep up, but 10^(n-1) grows faster than n * 9^n, and once n is large enough the digit-power-sum can never reach the number itself. The crossover happens at n = 61: for every n ≥ 61, n * 9^n < 10^(n-1). Hence every narcissistic number has at most 60 digits, so they all lie below 10^61 — a finite range.",
+    "problemStatement": "**Open Question (narcissistic-number-oq-01)**: Prove that the set of narcissistic numbers is finite.\n\n**Resolution**: Bound the digit-power-sum of an n-digit number by n*9^n and the number itself below by 10^(n-1). Since n*9^n < 10^(n-1) for n ≥ 61 (proved by induction), no narcissistic number has 61 or more digits, so the set is contained in the finite interval [0, 10^61) and is therefore finite.",
+    "text": "A 136-line, axiom-free development (2 definitions, 6 theorems). numDigits m is the length of Nat.digits 10 m, and Narcissistic m says m equals the sum over its digits d of d^(numDigits m). digit_le_nine bounds each base-10 digit by 9; digitPowSum_le then bounds the digit-power-sum by numDigits m * 9^(numDigits m). The arithmetic heart is crossover: n*9^n < 10^(n-1) for all n ≥ 61, proved by induction from the base case n = 61. pow_pred_length_le gives the matching lower bound 10^(numDigits m - 1) ≤ m. Combining these, numDigits_lt_61 shows a narcissistic number cannot have 61 or more digits (else m ≤ n*9^n < 10^(n-1) ≤ m, a contradiction). Finally narcissistic_finite exhibits the set as a subset of the finite interval below 10^61.",
+    "proofStrategy": "digitPowSum_le: each summand d^n with d ≤ 9 is ≤ 9^n, and there are numDigits m of them, so the sum is ≤ numDigits m * 9^n. crossover: induction on n ≥ 61; the inductive step multiplies the bound through using 9^(n+1) = 9·9^n and 10^n = 10·10^(n-1), with the factor-10 vs factor-9 gap absorbing the linear (n+1)/n growth. numDigits_lt_61: for a narcissistic m, m = digit-power-sum ≤ n*9^n while m ≥ 10^(n-1); if n ≥ 61, crossover gives n*9^n < 10^(n-1) ≤ m ≤ n*9^n, impossible. narcissistic_finite: every narcissistic m satisfies numDigits m < 61, hence m < 10^61, so the set is a subset of Set.Iio (10^61), which is finite.",
+    "keyInsights": [
+      "Finiteness is a race between digit-power-sum growth (n*9^n) and numeric size (≥ 10^(n-1)); the latter wins for large n.",
+      "The exact crossover is n = 61: for n ≥ 61, n*9^n < 10^(n-1), so no narcissistic number has 61+ digits.",
+      "The digit-power-sum bound is tight in form: n digits, each ≤ 9, each raised to the n-th power.",
+      "Once an explicit digit cap is established, finiteness is immediate — a bounded set of naturals is finite.",
+      "The whole argument is elementary and base-dependent: the same scheme bounds narcissistic numbers in any base b (crossover where n*(b-1)^n < b^(n-1))."
+    ],
+    "prerequisites": [
+      "Elementary number theory (decimal digits)",
+      "Induction and exponential inequalities",
+      "Basic set finiteness"
+    ]
+  },
+  "conclusion": {
+    "summary": "The set of narcissistic (Armstrong) numbers is finite: every such number has fewer than 61 decimal digits, hence lies below 10^61. The proof bounds the digit-power-sum of an n-digit number by n*9^n and the number below by 10^(n-1), and proves the crossover n*9^n < 10^(n-1) for n ≥ 61 by induction. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This turns a recreational fact into a machine-checked theorem and isolates the reusable crossover inequality. The same template (digit-power-sum ≤ n*(b-1)^n versus n-digit lower bound b^(n-1)) proves finiteness of narcissistic numbers in any base, and more generally of any digit-function-defined invariant whose value grows slower than the number itself.",
+    "openQuestions": [
+      "Determine the exact count (88 in base 10) and the largest narcissistic number by a verified finite search below the 10^61 cap.",
+      "Generalize crossover to an arbitrary base b: n*(b-1)^n < b^(n-1) beyond a base-dependent threshold.",
+      "Formalize finiteness of related digit-invariant families (perfect digital invariants, happy numbers' fixed structure)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "happy-number-oq-01",
+      "relationship": "related",
+      "description": "Another digit-function finiteness/iteration problem over decimal digits"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "NarcissisticNumberOQ01",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "sorries": 0,
+    "path": "Proofs/NarcissisticNumberOQ01.lean"
+  }
+}

--- a/src/data/research/problems/narcissistic-number-oq-01.json
+++ b/src/data/research/problems/narcissistic-number-oq-01.json
@@ -1,0 +1,60 @@
+{
+  "slug": "narcissistic-number-oq-01",
+  "title": "Narcissistic (Armstrong) Numbers Are Finite",
+  "phase": "complete",
+  "status": "completed",
+  "tier": "B",
+  "path": "proofs/Proofs/NarcissisticNumberOQ01.lean",
+  "problemStatement": "Prove that the set of narcissistic numbers — naturals equal to the sum of their decimal digits each raised to the power of the digit count — is finite.",
+  "knownResults": "Mathlib provides Nat.digits and the digit-length bounds Nat.digits_lt_base, Nat.base_pow_length_digits_le, Nat.lt_base_pow_length_digits, plus Set.finite_Iio and Set.Finite.subset. The crossover inequality n*9^n < 10^(n-1) for n ≥ 61 is the only nontrivial arithmetic input.",
+  "currentState": "COMPLETE. Proved finiteness: every narcissistic number has < 61 digits, hence < 10^61. Recovered an orphaned file written 2026-06-16 during a Docker/Aristotle blackout (never machine-checked); verified it builds cleanly under Mathlib v4.26.0 and added the missing gallery data. 6 theorems, 2 defs, 136 lines, 0 sorries, 0 axioms (norm_num evaluates the base case 61*9^61 < 10^60; no native_decide).",
+  "knowledge": {
+    "progressSummary": "COMPLETE: The set of narcissistic numbers is finite. Digit-power-sum of an n-digit number ≤ n*9^n; n-digit number ≥ 10^(n-1); crossover n*9^n < 10^(n-1) for n ≥ 61 (Nat.le_induction, base case by norm_num) caps every narcissistic number below 10^61. 6 theorems, 2 defs, 136 lines, 0 sorries, 0 axioms. Verified an orphaned blackout-era file builds under Mathlib v4.26.0 and added gallery data.",
+    "builtItems": [
+      "numDigits / Narcissistic: digit count and the narcissistic predicate",
+      "digit_le_nine: every base-10 digit ≤ 9",
+      "digitPowSum_le: digit-power-sum ≤ numDigits m * 9^(numDigits m)",
+      "crossover: n*9^n < 10^(n-1) for n ≥ 61 (induction, base case by norm_num)",
+      "pow_pred_length_le: an n-digit number is ≥ 10^(n-1)",
+      "numDigits_lt_61 + narcissistic_finite: digit cap < 61, hence the set is finite"
+    ],
+    "insights": [
+      "Finiteness is a race: digit-power-sum (n*9^n) versus numeric size (≥ 10^(n-1)); the latter wins for large n.",
+      "The exact crossover is n = 61, established by induction with the base case evaluated by norm_num (kernel-checked, no native_decide).",
+      "The inductive step turns on 9·(n+1) ≤ 10·n, the factor-10/factor-9 gap absorbing linear digit growth.",
+      "Once an explicit digit cap exists, finiteness is immediate via Set.Finite.subset of Set.Iio (10^61).",
+      "The scheme is base-agnostic: in base b use n*(b-1)^n < b^(n-1)."
+    ],
+    "mathlibGaps": [
+      "Mathlib has the digit-length bounds but no packaged finiteness result for narcissistic / Armstrong numbers.",
+      "The file was an unverified blackout-era orphan; this session confirmed it compiles under current Mathlib and galleried it."
+    ],
+    "nextSteps": [
+      "Determine the exact count (88 in base 10) by a verified finite search below 10^61.",
+      "Generalize crossover to an arbitrary base b.",
+      "Formalize finiteness for related digit-invariant families."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "digits",
+    "narcissistic-number",
+    "armstrong-number",
+    "finiteness",
+    "research"
+  ],
+  "relatedProofs": [
+    "happy-number-oq-01"
+  ],
+  "references": [
+    "Armstrong (1966): popularized base-10 narcissistic (Armstrong) numbers",
+    "Madachy, Mathematics on Vacation (1966): exactly 88 base-10 narcissistic numbers"
+  ],
+  "started": "2026-06-22",
+  "lastUpdate": "2026-06-22",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    "proofs/Proofs/NarcissisticNumberOQ01.lean"
+  ]
+}


### PR DESCRIPTION
## Summary

Recovers and galleries an orphaned proof that **narcissistic (Armstrong) numbers are finite**. `proofs/Proofs/NarcissisticNumberOQ01.lean` was written 2026-06-16 during a Docker/Aristotle blackout, never machine-checked, and had no gallery entry. This session confirms it builds cleanly under Mathlib v4.26.0 (0 sorries, 0 axioms) and adds the missing `meta.json`, `annotations.json`, and research-problem record.

## The result (6 theorems, 2 defs, 136 lines)

A narcissistic number equals the sum of its decimal digits each raised to the power of the digit count (`153 = 1³+5³+3³`, `9474 = 9⁴+4⁴+7⁴+4⁴`). The set of all of them is finite:

- `digitPowSum_le` — an n-digit number's digit-power-sum is `≤ n·9ⁿ`
- `pow_pred_length_le` — an n-digit number is `≥ 10ⁿ⁻¹`
- `crossover` — `n·9ⁿ < 10ⁿ⁻¹` for all `n ≥ 61` (induction; base case `61·9⁶¹ < 10⁶⁰` by `norm_num`)
- `numDigits_lt_61` — hence no narcissistic number has 61+ digits
- `narcissistic_finite` — so the set is `⊆ Iio(10⁶¹)`, finite

## Verification

- `./proofs/scripts/docker-build.sh Proofs.NarcissisticNumberOQ01` — builds successfully.
- `#print axioms` on `narcissistic_finite` and `crossover`: only `[propext, Classical.choice, Quot.sound]`. The crossover base case uses `norm_num` (kernel-checked exact evaluation), **not** `native_decide`. **0-axiom verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)