### PR TITLE
research(quadratic-reciprocity-algorithm-oq-02-oq-01): Euler's criterion breaks on composites — the Solovay–Strassen test

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3249,6 +3249,7 @@ import Proofs.QuadraticGaussSumSquareOQ02
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ02
+import Proofs.QuadraticReciprocityAlgorithmOQ02OQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ03
 import Proofs.QuadraticReciprocityAlgorithmOQ03FieldBridge
 import Proofs.QuadraticReciprocityAlgorithmOQ03M2

--- a/proofs/Proofs/QuadraticReciprocityAlgorithmOQ02OQ01.lean
+++ b/proofs/Proofs/QuadraticReciprocityAlgorithmOQ02OQ01.lean
@@ -1,0 +1,159 @@
+import Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol
+import Mathlib.Tactic
+import Proofs.QuadraticReciprocityAlgorithmOQ02
+
+/-
+# Euler's Criterion Breaks on Composites — and That Break Is a Primality Test
+
+## Open Question
+
+The parent entry `quadratic-reciprocity-algorithm-oq-02` showed that, going from
+a prime modulus to a composite one, the Jacobi symbol keeps the nonresidue
+certificate `J(a | n) = −1 ⟹ a` is a nonsquare, but *loses* the converse
+`J(a | n) = 1 ⟹ a` is a square (witness a = 2, n = 15).
+
+OQ-02-OQ-01 asks: there is a second, sharper identity that the Legendre symbol
+satisfies — **Euler's criterion** `(a | p) ≡ a^((p−1)/2) (mod p)`. Does the
+Jacobi symbol inherit it on composite moduli, and if not, is the failure
+*usable*? The answer is the foundation of the **Solovay–Strassen primality
+test**: Euler's criterion holds for the Jacobi symbol exactly when the modulus
+is prime, so any `a` violating the congruence is a certificate of compositeness.
+
+## What This File Establishes
+
+* **Euler's criterion, Jacobi form, prime modulus** (`jacobi_eq_pow_of_prime`):
+  for prime `p`, `(J(a | p) : ZMod p) = a^(p/2)`. This is the prime-only identity;
+  it follows from `J(a | p) = legendreSym p a` (parent) and `legendreSym.eq_pow`.
+
+* **The Solovay–Strassen compositeness test** (`not_prime_of_eulerWitness`):
+  if some `a` is an *Euler witness* for `n` — i.e. `(J(a | n) : ZMod n) ≠ a^(n/2)`
+  — then `n` is not prime. A single witness certifies compositeness with no
+  factorization of `n`.
+
+* **A concrete witness** (`two_eulerWitness_fifteen`, `fifteen_not_prime`):
+  `a = 2` witnesses the compositeness of `n = 15`. Here `J(2 | 15) = 1`
+  (the parent's lost-direction witness) while `2^7 ≡ 8 (mod 15)`, so the
+  congruence fails: `1 ≠ 8`. The same `a = 2` that the parent showed the
+  Jacobi symbol *fails* to certify as a nonsquare turns out to *succeed* at
+  certifying 15 as composite.
+
+* **The test is one-sided** (`negOne_eulerLiar_fifteen`): not every `a` exposes a
+  composite `n`. For `n = 15`, `a = −1` is an *Euler liar*:
+  `J(−1 | 15) = −1` and `(−1)^7 ≡ −1 (mod 15)`, so the congruence *holds*
+  even though 15 is composite. Hence a single non-witness can never prove
+  primality — Solovay–Strassen is inherently a one-sided (Monte Carlo) test.
+
+All Jacobi/Legendre values are computed through the parent's residuosity route
+and `ZMod` power evaluations are discharged by `decide`; there is no
+`native_decide` anywhere.
+
+## Status: 0 sorries, 0 `axiom`s, no `native_decide`.
+-/
+
+namespace QuadraticReciprocityAlgorithmOQ02OQ01
+
+open scoped NumberTheorySymbols
+open QuadraticReciprocityAlgorithmOQ02
+
+-- ============================================================================
+-- Part 1: Euler's criterion for the Jacobi symbol — the prime-only identity
+-- ============================================================================
+
+/-- **Euler's criterion, Jacobi form (prime modulus).**  For a prime `p`,
+    `(J(a | p) : ZMod p) = a^(p/2)`.  Over a prime the Jacobi symbol equals the
+    Legendre symbol, and the Legendre symbol satisfies Euler's criterion. -/
+theorem jacobi_eq_pow_of_prime (p : ℕ) [Fact p.Prime] (a : ℤ) :
+    (J(a | p) : ZMod p) = (a : ZMod p) ^ (p / 2) := by
+  rw [jacobi_eq_legendre_of_prime]
+  exact legendreSym.eq_pow p a
+
+-- ============================================================================
+-- Part 2: The Solovay–Strassen compositeness witness
+-- ============================================================================
+
+/-- `a` is an **Euler witness** for `n` when it violates Euler's criterion:
+    `(J(a | n) : ZMod n) ≠ a^(n/2)`.  Such an `a` certifies that `n` is composite. -/
+def IsEulerWitness (a : ℤ) (n : ℕ) : Prop :=
+  (J(a | n) : ZMod n) ≠ (a : ZMod n) ^ (n / 2)
+
+/-- **The Solovay–Strassen test.**  An Euler witness certifies compositeness:
+    if `a` violates Euler's criterion modulo `n`, then `n` is not prime.  No
+    factorization of `n` is required — the contrapositive of the prime-case
+    identity `jacobi_eq_pow_of_prime`. -/
+theorem not_prime_of_eulerWitness {a : ℤ} {n : ℕ} (h : IsEulerWitness a n) :
+    ¬ n.Prime := by
+  intro hp
+  haveI : Fact n.Prime := ⟨hp⟩
+  exact h (jacobi_eq_pow_of_prime n a)
+
+/-- Contrapositive: a prime modulus admits no Euler witness — every `a` satisfies
+    Euler's criterion. -/
+theorem no_eulerWitness_of_prime {n : ℕ} (hp : n.Prime) (a : ℤ) :
+    ¬ IsEulerWitness a n :=
+  fun h => not_prime_of_eulerWitness h hp
+
+-- ============================================================================
+-- Part 3: A concrete witness — a = 2 certifies that 15 is composite
+-- ============================================================================
+
+/-- `2^7 ≡ 8 (mod 15)`: the right-hand side of Euler's criterion at `a = 2`,
+    `n = 15` (note `15 / 2 = 7`). -/
+theorem two_pow_seven_fifteen : (2 : ZMod 15) ^ (15 / 2) = 8 := by decide
+
+/-- **A concrete Euler witness.**  `a = 2` violates Euler's criterion modulo `15`:
+    `J(2 | 15) = 1` (the parent's lost-direction witness) but `2^7 ≡ 8`, and
+    `1 ≠ 8` in `ZMod 15`. -/
+theorem two_eulerWitness_fifteen : IsEulerWitness 2 15 := by
+  unfold IsEulerWitness
+  rw [jacobi_two_fifteen]
+  decide
+
+/-- **The test in action.**  The single witness `a = 2` proves that `15` is
+    composite, with no appeal to its factorization `15 = 3·5`. -/
+theorem fifteen_not_prime : ¬ Nat.Prime 15 :=
+  not_prime_of_eulerWitness two_eulerWitness_fifteen
+
+-- ============================================================================
+-- Part 4: The test is one-sided — an Euler liar for 15
+-- ============================================================================
+
+/-- `J(−1 | 15) = −1`, from multiplicativity `J(−1|15) = J(−1|3)·J(−1|5) =
+    (−1)·(1)`.  `−1 ≡ 2 (mod 3)` is a nonsquare while `−1 ≡ 4 = 2² (mod 5)` is a
+    square, so exactly one factor contributes a `−1`. -/
+theorem jacobi_negOne_fifteen : J(-1 | 15) = -1 := by
+  rw [show (15 : ℕ) = 3 * 5 from by norm_num, jacobi_mul_right]
+  have h3 : J(-1 | 3) = -1 := by
+    haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+    rw [jacobi_eq_legendre_of_prime, legendreSym.eq_neg_one_iff 3 (a := -1)]
+    decide +revert
+  have h5 : J(-1 | 5) = 1 := by
+    haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+    rw [jacobi_eq_legendre_of_prime, legendreSym.eq_one_iff 5 (a := -1) (by decide +revert)]
+    decide +revert
+  rw [h3, h5]; norm_num
+
+/-- `(−1)^7 ≡ −1 (mod 15)`: the right-hand side of Euler's criterion at `a = −1`. -/
+theorem negOne_pow_seven_fifteen : ((-1 : ℤ) : ZMod 15) ^ (15 / 2) = -1 := by decide
+
+/-- **An Euler liar.**  `a = −1` is *not* an Euler witness for `15`, even though
+    `15` is composite: `J(−1 | 15) = −1` and `(−1)^7 ≡ −1 (mod 15)`, so Euler's
+    criterion holds.  A single non-witness therefore cannot certify primality —
+    Solovay–Strassen is inherently one-sided. -/
+theorem negOne_eulerLiar_fifteen : ¬ IsEulerWitness (-1) 15 := by
+  unfold IsEulerWitness
+  rw [jacobi_negOne_fifteen]
+  decide
+
+/-- The two faces of `n = 15` together: `a = 2` is a witness (the criterion
+    fails) and `a = −1` is a liar (the criterion holds).  The gap between them is
+    exactly why the test is probabilistic, not deterministic. -/
+theorem fifteen_witness_and_liar :
+    IsEulerWitness 2 15 ∧ ¬ IsEulerWitness (-1) 15 :=
+  ⟨two_eulerWitness_fifteen, negOne_eulerLiar_fifteen⟩
+
+#check @jacobi_eq_pow_of_prime
+#check @not_prime_of_eulerWitness
+#check @two_eulerWitness_fifteen
+#check @negOne_eulerLiar_fifteen
+
+end QuadraticReciprocityAlgorithmOQ02OQ01

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-02-oq-01/annotations.json
@@ -1,0 +1,119 @@
+[
+  {
+    "id": "euler-criterion-break-context",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "Euler's Criterion Breaks on Composites — and That Break Is a Primality Test",
+    "content": "Over a prime p the Legendre symbol satisfies Euler's criterion: (a | p) ≡ a^((p−1)/2) (mod p). The parent entry showed the Jacobi symbol loses the residuosity converse on composite moduli; this entry shows it also loses Euler's criterion — and that the loss is usable. For prime p the Jacobi symbol equals the Legendre symbol, so the congruence (J(a | n) : ZMod n) = a^(n/2) holds for every a. Hence any a violating it certifies that n is composite. That contrapositive is exactly the Solovay–Strassen primality test, and a = 2, n = 15 — the parent's lost-direction witness — is a concrete Euler witness.",
+    "mathContext": "Prime $p$: $\\left(\\tfrac{a}{p}\\right) \\equiv a^{(p-1)/2} \\pmod p$ (Euler's criterion). Composite $n$: there is $a$ with $J(a\\mid n) \\not\\equiv a^{(n-1)/2}$, certifying $n$ composite. Witness $a=2,\\ n=15$: $J(2\\mid 15)=1$ but $2^{7}\\equiv 8 \\pmod{15}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler's criterion",
+      "Jacobi symbol",
+      "Legendre symbol",
+      "Solovay–Strassen primality test",
+      "Euler witness",
+      "Euler liar"
+    ],
+    "prerequisites": [
+      "quadratic residues mod p",
+      "the Legendre and Jacobi symbols",
+      "Euler's criterion"
+    ]
+  },
+  {
+    "id": "euler-criterion-jacobi-prime",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+    "range": {
+      "startLine": 57,
+      "endLine": 68
+    },
+    "type": "theorem",
+    "title": "Euler's Criterion, Jacobi Form (Prime Modulus)",
+    "content": "jacobi_eq_pow_of_prime states that for a prime p, (J(a | p) : ZMod p) = a^(p/2). Over a prime the Jacobi symbol coincides with the Legendre symbol (the parent's jacobi_eq_legendre_of_prime), and the Legendre symbol obeys Euler's criterion (Mathlib's legendreSym.eq_pow). This is the prime-only identity whose failure on composites drives the whole entry: it is the precise sense in which 'J(a | n) ≡ a^(n/2)' is a primality condition.",
+    "mathContext": "$\\left(J(a\\mid p)\\bmod p\\right) = a^{\\lfloor p/2\\rfloor}$ for prime $p$. Since $p/2 = (p-1)/2$ in $\\mathbb{N}$ for odd $p$, this is Euler's criterion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "legendreSym.eq_pow",
+      "Euler's criterion",
+      "jacobi_eq_legendre_of_prime"
+    ],
+    "prerequisites": [
+      "Legendre symbol",
+      "Euler's criterion",
+      "ZMod p arithmetic"
+    ]
+  },
+  {
+    "id": "solovay-strassen-witness",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 95
+    },
+    "type": "theorem",
+    "title": "The Solovay–Strassen Compositeness Test",
+    "content": "IsEulerWitness a n is defined as the failure of Euler's criterion, (J(a | n) : ZMod n) ≠ a^(n/2). not_prime_of_eulerWitness proves that any Euler witness certifies compositeness: if such an a exists then n is not prime. The proof is a one-line contrapositive of jacobi_eq_pow_of_prime — were n prime, the criterion would hold for that very a. no_eulerWitness_of_prime states the converse contrapositive: a prime admits no Euler witness. No factorization of n is used, which is what makes the test efficient.",
+    "mathContext": "If $(J(a\\mid n)\\bmod n) \\neq a^{\\lfloor n/2\\rfloor}$ for some $a$, then $n$ is composite. Equivalently, $n$ prime $\\Rightarrow$ every $a$ satisfies Euler's criterion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Solovay–Strassen primality test",
+      "Euler witness",
+      "contrapositive",
+      "Monte Carlo primality testing"
+    ],
+    "prerequisites": [
+      "Euler's criterion (prime case)",
+      "contrapositive reasoning"
+    ]
+  },
+  {
+    "id": "concrete-witness-fifteen",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+    "range": {
+      "startLine": 99,
+      "endLine": 117
+    },
+    "type": "example",
+    "title": "A Concrete Witness: a = 2 Certifies 15 Composite",
+    "content": "two_pow_seven_fifteen computes 2^7 ≡ 8 (mod 15) by kernel decide (note 15/2 = 7). two_eulerWitness_fifteen then shows a = 2 is an Euler witness: J(2 | 15) = 1 (imported from the parent) but the right-hand side is 8, and 1 ≠ 8 in ZMod 15. fifteen_not_prime concludes ¬ Nat.Prime 15 from the single witness, without using the factorization 15 = 3·5. The same a = 2 that the parent showed the Jacobi symbol fails to certify as a nonsquare here succeeds at certifying 15 as composite.",
+    "mathContext": "$J(2\\mid 15)=1$, $2^{7}=128\\equiv 8\\pmod{15}$, $1\\neq 8$, so $2$ is an Euler witness and $15$ is composite.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Euler witness",
+      "kernel decide",
+      "jacobi_two_fifteen"
+    ],
+    "prerequisites": [
+      "modular exponentiation",
+      "ZMod 15 arithmetic"
+    ]
+  },
+  {
+    "id": "euler-liar-onesided",
+    "proofId": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+    "range": {
+      "startLine": 121,
+      "endLine": 156
+    },
+    "type": "insight",
+    "title": "The Test Is One-Sided: an Euler Liar for 15",
+    "content": "jacobi_negOne_fifteen computes J(−1 | 15) = J(−1 | 3)·J(−1 | 5) = (−1)·(1) = −1 (−1 is a nonsquare mod 3 but a square mod 5). negOne_pow_seven_fifteen gives (−1)^7 ≡ −1 (mod 15). negOne_eulerLiar_fifteen then shows a = −1 is an Euler liar: the criterion J(−1 | 15) ≡ (−1)^7 holds even though 15 is composite. fifteen_witness_and_liar bundles both faces. The existence of a liar means a single non-witness can never prove primality, so Solovay–Strassen is inherently one-sided (Monte Carlo): primality only follows after many random a fail to witness.",
+    "mathContext": "$J(-1\\mid 15)=-1$, $(-1)^{7}\\equiv -1\\pmod{15}$, so the criterion holds — $a=-1$ is an Euler liar. One liar $\\Rightarrow$ a single trial cannot certify primality.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler liar",
+      "one-sided error",
+      "Monte Carlo algorithm",
+      "Solovay–Strassen primality test"
+    ],
+    "prerequisites": [
+      "Euler witness",
+      "multiplicativity of the Jacobi symbol"
+    ]
+  }
+]

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-02-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-02-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+  "title": "Euler's Criterion Breaks on Composites — and That Break Is the Solovay–Strassen Test",
+  "slug": "quadratic-reciprocity-algorithm-oq-02-oq-01",
+  "description": "The parent entry showed that going from a prime to a composite modulus, the Jacobi symbol loses the residuosity converse J(a | n) = 1 ⟹ a is a square. This follow-up shows it also loses Euler's criterion (a | p) ≡ a^((p−1)/2) (mod p) — and that the loss is usable. For a prime p the Jacobi symbol equals the Legendre symbol, so the congruence (J(a | n) : ZMod n) = a^(n/2) holds for every a; jacobi_eq_pow_of_prime establishes this prime-only identity from jacobiSym.legendreSym.to_jacobiSym and legendreSym.eq_pow. Its contrapositive is the Solovay–Strassen primality test: not_prime_of_eulerWitness shows any a violating the congruence (an Euler witness) certifies that n is composite, with no factorization. The parent's lost-direction witness a = 2, n = 15 reappears as a concrete Euler witness (J(2 | 15) = 1 but 2^7 ≡ 8 mod 15, so 1 ≠ 8), yielding ¬ Nat.Prime 15 from a single witness. Finally a = −1 is exhibited as an Euler liar for 15 (J(−1 | 15) = −1 and (−1)^7 ≡ −1 mod 15, the congruence holds though 15 is composite), proving the test is inherently one-sided. All Jacobi/Legendre values route through the parent's residuosity lemmas and ZMod powers are discharged by kernel decide; there is no native_decide.",
+  "meta": {
+    "author": "Lean Genius researcher-8",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticReciprocityAlgorithmOQ02OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 159,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "assumptions": "None. Every result is fully machine-checked. The prime-case Euler identity is Mathlib's legendreSym.eq_pow composed with the parent's jacobi_eq_legendre_of_prime; all numeric values (Jacobi symbols and ZMod powers) reduce to kernel `decide` over small finite rings (the `+revert` modifier removes the local `Fact p.Prime` instance before deciding). There is no `native_decide`, hence no Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound; no axiom declaration, no structure-encoded hypothesis, no sorryAx.",
+    "tags": [
+      "number-theory",
+      "jacobi-symbol",
+      "legendre-symbol",
+      "euler-criterion",
+      "quadratic-residues",
+      "solovay-strassen",
+      "primality-test",
+      "composite-moduli"
+    ],
+    "dateAdded": "2026-06-22",
+    "originalContributions": [
+      "jacobi_eq_pow_of_prime: Euler's criterion in Jacobi form for a prime modulus, (J(a | p) : ZMod p) = a^(p/2), obtained by composing the parent's jacobi_eq_legendre_of_prime with Mathlib's legendreSym.eq_pow",
+      "IsEulerWitness / not_prime_of_eulerWitness: the Solovay–Strassen compositeness test — an a violating Euler's criterion modulo n certifies n composite, proved as the one-line contrapositive of the prime-case identity, with no factorization of n",
+      "no_eulerWitness_of_prime: the converse contrapositive that a prime modulus admits no Euler witness",
+      "two_eulerWitness_fifteen / fifteen_not_prime: a concrete witness — a = 2 (the parent's lost-direction witness) certifies 15 composite via J(2 | 15) = 1 ≠ 8 = 2^7 mod 15",
+      "jacobi_negOne_fifteen / negOne_eulerLiar_fifteen / fifteen_witness_and_liar: a = −1 is an Euler liar for 15 (J(−1 | 15) = −1 = (−1)^7 mod 15), proving the test is inherently one-sided — a single non-witness cannot certify primality",
+      "Native-decide-free numeric evaluation of J(−1|3), J(−1|5), J(−1|15) and of the ZMod 15 powers 2^7 and (−1)^7 through the IsSquare residuosity criterion and kernel decide"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "legendreSym.eq_pow",
+        "description": "(legendreSym p a : ZMod p) = a^(p/2) for prime p — Euler's criterion for the Legendre symbol. Composed with the parent's jacobi_eq_legendre_of_prime to give the Jacobi-form criterion that powers the whole entry.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      },
+      {
+        "theorem": "jacobiSym.legendreSym.to_jacobiSym",
+        "description": "legendreSym p a = J(a | p) for prime p (via the parent's jacobi_eq_legendre_of_prime). Lets the prime-case Euler identity be stated for the Jacobi symbol.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "jacobiSym.mul_right",
+        "description": "J(a | m·n) = J(a | m)·J(a | n) (via the parent's jacobi_mul_right). Used to evaluate J(−1 | 15) = J(−1 | 3)·J(−1 | 5) for the Euler-liar example.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
+      },
+      {
+        "theorem": "legendreSym.eq_one_iff / legendreSym.eq_neg_one_iff",
+        "description": "legendreSym p a = 1 ↔ IsSquare (a : ZMod p) (for a ≠ 0) and = −1 ↔ ¬IsSquare. Reduce the prime-modulus symbol values J(−1|3), J(−1|5) to kernel-decidable IsSquare statements, avoiding native_decide.",
+        "module": "Mathlib.NumberTheory.LegendreSymbol.Basic"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/QuadraticReciprocityAlgorithmOQ02OQ01.lean",
+    "namespace": "QuadraticReciprocityAlgorithmOQ02OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 159,
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Euler's criterion (1748) states that for an odd prime p and a coprime to p, a is a quadratic residue mod p iff a^((p−1)/2) ≡ 1 (mod p); more sharply, the Legendre symbol satisfies (a | p) ≡ a^((p−1)/2) (mod p). When Jacobi extended the symbol to composite odd moduli by multiplicativity, this congruence ceased to hold in general: there are composite n and units a for which J(a | n) ≢ a^((n−1)/2). In 1977 Solovay and Strassen turned that failure into one of the first practical probabilistic primality tests. Because a prime never produces such a violation, any a with J(a | n) ≢ a^((n−1)/2) is a certificate — an 'Euler witness' — that n is composite. Conversely, composite n always have many 'Euler liars' (at least one trivially, a = 1), so no single non-witness proves primality; Solovay–Strassen is a one-sided Monte Carlo test, with at least half of the units in (ℤ/nℤ)ˣ being witnesses for a composite n.",
+    "problemStatement": "Open Question OQ-02-OQ-01 (child of quadratic-reciprocity-algorithm-oq-02, answering its first stated open question): formalize directly the Solovay–Strassen compositeness witness — show that for prime p the Jacobi symbol satisfies Euler's criterion (J(a | p) : ZMod p) = a^(p/2), so that any a violating the congruence certifies n composite, and exhibit a concrete Euler witness and a concrete Euler liar that together show the resulting test is one-sided.",
+    "proofStrategy": "The prime-case identity jacobi_eq_pow_of_prime rewrites J(a | p) to legendreSym p a (the parent's jacobi_eq_legendre_of_prime) and then applies Mathlib's legendreSym.eq_pow, which is Euler's criterion for the Legendre symbol. The compositeness test not_prime_of_eulerWitness is the contrapositive: assuming n prime supplies a Fact n.Prime instance, and jacobi_eq_pow_of_prime then contradicts the witness inequality. The concrete witness uses the parent's jacobi_two_fifteen (J(2|15) = 1) together with the kernel computation (2 : ZMod 15)^7 = 8 to show 1 ≠ 8, so 2 is an Euler witness and fifteen_not_prime follows from the single witness. The Euler liar evaluates J(−1 | 15) = J(−1|3)·J(−1|5) by multiplicativity — J(−1|3) = −1 and J(−1|5) = 1 obtained through the residuosity iff lemmas with decide +revert — and pairs it with (−1 : ZMod 15)^7 = −1 to show the congruence holds for a = −1, exhibiting a liar. All ZMod-power and IsSquare computations are discharged by kernel decide, keeping the entry free of native_decide.",
+    "keyInsights": [
+      "The single asymmetry the parent identified — that the Jacobi symbol can read +1 on a genuine nonresidue over a composite modulus — has a second face: it can also satisfy Euler's congruence on a composite modulus. The first face loses a residuosity test; the second face is precisely what makes a *primality* test possible.",
+      "A compositeness certificate needs no factorization: jacobi_eq_pow_of_prime holds for every prime, so its contrapositive turns any single a that violates Euler's criterion into a proof that n is composite — exactly the efficiency that makes Solovay–Strassen practical.",
+      "The parent's lost-direction witness a = 2, n = 15 is not two separate phenomena: the very a that the Jacobi symbol fails to certify as a nonsquare mod 15 is the a that succeeds at certifying 15 composite. One witness, two readings.",
+      "The existence of an Euler liar (a = −1 for n = 15) is the precise reason Solovay–Strassen is probabilistic rather than deterministic: passing one trial cannot prove primality, because composite moduli have liars; only a low failure probability accumulates over many random trials.",
+      "Euler's criterion is available native-decide-free: routing the symbol through legendreSym.eq_pow and the residuosity iff lemmas keeps every concrete computation inside the kernel's reach (decide over small ZMod), so the entry incurs no Lean.ofReduceBool."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Overview",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "States OQ-02-OQ-01: Euler's criterion for the Jacobi symbol holds only on primes, so its failure is a usable compositeness witness — the Solovay–Strassen test. Previews the prime identity, the witness a=2/n=15, and the liar a=−1/n=15."
+    },
+    {
+      "id": "euler-prime",
+      "title": "Euler's Criterion, Jacobi Form (Prime Modulus)",
+      "startLine": 53,
+      "endLine": 68,
+      "summary": "jacobi_eq_pow_of_prime: for prime p, (J(a | p) : ZMod p) = a^(p/2), from jacobi_eq_legendre_of_prime composed with legendreSym.eq_pow."
+    },
+    {
+      "id": "solovay-strassen",
+      "title": "The Solovay–Strassen Compositeness Witness",
+      "startLine": 70,
+      "endLine": 95,
+      "summary": "IsEulerWitness (failure of Euler's criterion), not_prime_of_eulerWitness (a witness certifies compositeness, contrapositive of the prime identity), and no_eulerWitness_of_prime (a prime admits no witness)."
+    },
+    {
+      "id": "concrete-witness",
+      "title": "A Concrete Witness: a = 2 Certifies 15 Composite",
+      "startLine": 97,
+      "endLine": 117,
+      "summary": "two_pow_seven_fifteen (2^7 ≡ 8 mod 15), two_eulerWitness_fifteen (J(2|15) = 1 ≠ 8, the parent's witness reappears), and fifteen_not_prime from the single witness."
+    },
+    {
+      "id": "euler-liar",
+      "title": "The Test Is One-Sided: an Euler Liar for 15",
+      "startLine": 119,
+      "endLine": 159,
+      "summary": "jacobi_negOne_fifteen (J(−1|15) = −1 via multiplicativity), negOne_pow_seven_fifteen ((−1)^7 ≡ −1), negOne_eulerLiar_fifteen (the criterion holds for a=−1 though 15 is composite), and fifteen_witness_and_liar bundling both faces."
+    }
+  ],
+  "conclusion": {
+    "summary": "10 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide. Over a prime modulus the Jacobi symbol satisfies Euler's criterion (J(a | p) : ZMod p) = a^(p/2); on a composite modulus it need not, and any violation certifies compositeness. The witness a = 2 proves 15 composite (J(2|15) = 1 ≠ 8 = 2^7) while the liar a = −1 satisfies the criterion (J(−1|15) = −1 = (−1)^7), so the resulting Solovay–Strassen test is one-sided.",
+    "implications": "Answers the parent entry's first open question by formalizing the Solovay–Strassen compositeness witness directly. Together the witness and liar exhibit, in a single concrete modulus, both why the test works (a prime would have no witness) and why it is probabilistic (composites have liars). The native-decide-free evaluation of Euler's criterion and the underlying symbols is a reusable, axiom-honest pattern for computing residuosity data over concrete inputs.",
+    "openQuestions": [
+      "Can the ≤ 1/2 density bound — that at least half of (ℤ/nℤ)ˣ are Euler witnesses for composite n — be proved in Lean, giving the full error bound of the Solovay–Strassen test?",
+      "How does the Euler-witness set relate to the Fermat-witness set (Miller–Rabin / strong pseudoprimes): is every Euler witness a Fermat witness, and can the strict containment be witnessed concretely?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "quadratic-reciprocity-algorithm-oq-02",
+      "relationship": "parent — characterizes what the Jacobi symbol decides over composite moduli and asks for the Solovay–Strassen witness; this entry supplies it"
+    },
+    {
+      "targetId": "quadratic-reciprocity-algorithm-oq-01",
+      "relationship": "grandparent — implements the verified recursive Legendre/Jacobi algorithm jacobiAlgo"
+    },
+    {
+      "targetId": "quadratic-reciprocity-algorithm-oq-03",
+      "relationship": "sibling — a further development of the quadratic-reciprocity algorithm line"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** posed by the parent entry `quadratic-reciprocity-algorithm-oq-02` ("Can the Euler-criterion failure be formalized directly as a Solovay–Strassen compositeness witness?").

The Legendre symbol satisfies **Euler's criterion** `(a | p) ≡ a^((p−1)/2) (mod p)`. The Jacobi symbol inherits it **only on prime moduli** — and that failure is exactly the **Solovay–Strassen primality test**.

## Results (10 theorems, 1 definition)

- **`jacobi_eq_pow_of_prime`** — Euler's criterion, Jacobi form: for prime `p`, `(J(a | p) : ZMod p) = a^(p/2)`. Composes the parent's `jacobi_eq_legendre_of_prime` with Mathlib's `legendreSym.eq_pow`.
- **`IsEulerWitness` / `not_prime_of_eulerWitness`** — the compositeness test: any `a` violating the congruence certifies `n` composite, as the one-line contrapositive of the prime-case identity. No factorization of `n` used.
- **`two_eulerWitness_fifteen` / `fifteen_not_prime`** — the parent's lost-direction witness `a = 2, n = 15` reappears as an **Euler witness**: `J(2|15) = 1` but `2^7 ≡ 8 (mod 15)`, so `1 ≠ 8`, and a single witness yields `¬ Nat.Prime 15`.
- **`jacobi_negOne_fifteen` / `negOne_eulerLiar_fifteen` / `fifteen_witness_and_liar`** — `a = −1` is an **Euler liar** for 15 (`J(−1|15) = −1 = (−1)^7 mod 15`), so the test is inherently one-sided.

## Verification

- **0 sorries, 0 axioms, no `native_decide`.** All Jacobi/Legendre values route through the parent's residuosity `iff` lemmas; ZMod powers are discharged by kernel `decide`.
- `#print axioms` on the key theorems confirms dependence only on `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`, no `sorryAx`).
- Built via `./proofs/scripts/docker-build.sh Proofs.QuadraticReciprocityAlgorithmOQ02OQ01` — `Build completed successfully (3059 jobs)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)