### PR TITLE
research(cevas-theorem-oq-04-oq-01): repair bit-rot + gallery data for n-dimensional mass-point Ceva

### DIFF
--- a/proofs/Proofs/CevasTheoremOQ04OQ01.lean
+++ b/proofs/Proofs/CevasTheoremOQ04OQ01.lean
@@ -1,6 +1,6 @@
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Fin.Basic
-import Mathlib.Algebra.BigOperators.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Tactic
 
 /-
@@ -100,8 +100,7 @@ lemma MassPoint.sum_erase_eq_total_sub (i : Fin (n + 1)) :
 lemma MassPoint.ratio_eq_one_sub (i : Fin (n + 1)) :
     mp.ratio i = 1 - mp.mass i / mp.total := by
   unfold MassPoint.ratio
-  rw [mp.sum_erase_eq_total_sub i, sub_div]
-  field_simp
+  rw [mp.sum_erase_eq_total_sub i, sub_div, div_self mp.total_ne_zero]
 
 /-- Each complement-fraction is strictly less than 1
     (regardless of n; the only requirement is that `mass i > 0`). -/
@@ -125,8 +124,7 @@ lemma MassPoint.ratio_pos (i : Fin (n + 1)) (hn : 0 < n) : 0 < mp.ratio i := by
 /-- Auxiliary: the mass fractions `mass i / total` sum to one. -/
 lemma MassPoint.sum_mass_div_total : (∑ i, mp.mass i / mp.total) = 1 := by
   rw [← Finset.sum_div]
-  show (∑ i, mp.mass i) / mp.total = 1
-  rw [div_self mp.total_ne_zero]
+  exact div_self mp.total_ne_zero
 
 /-- **N-dim Mass-Point Ceva Identity**: the complement fractions sum to `n`.
 
@@ -183,6 +181,7 @@ lemma uniform_ratio (n : ℕ) (i : Fin (n + 1)) :
   show 1 - (1 : ℝ) / (n + 1) = (n : ℝ) / (n + 1)
   have hn1 : (n + 1 : ℝ) ≠ 0 := by positivity
   field_simp
+  ring
 
 end NDimMassPoint
 

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01/annotations.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "ann-ctoq0401-00-header",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 68
+    },
+    "type": "concept",
+    "title": "Module Overview: Mass-Point Geometry on an n-Simplex",
+    "content": "The parent entry cevas-theorem-oq-04 uses mass-point geometry on a triangle (3 vertices) to certify cevian concurrency. This file lifts that structure to an arbitrary n-dimensional simplex with n+1 vertices, indexed by Fin (n+1). The central quantity is each vertex's complement-mass fraction — the share of total mass carried by all other vertices — and the headline result is that these fractions sum to exactly n.",
+    "mathContext": "MassPoint n: n+1 positive masses; ratio i = (Σ_{j≠i} mass j)/total; Σ ratio i = n.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "mass-point geometry",
+      "barycentric coordinates",
+      "simplex",
+      "Ceva's theorem"
+    ],
+    "prerequisites": [
+      "cevas-theorem-oq-04"
+    ]
+  },
+  {
+    "id": "ann-ctoq0401-01-structure",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 70,
+      "endLine": 90
+    },
+    "type": "definition",
+    "title": "The Mass-Point Structure and Total Mass",
+    "content": "MassPoint n bundles a family of n+1 masses (mass : Fin (n+1) → ℝ) with a proof that each is strictly positive. total is the sum of all masses; total_pos (a sum of positives over the nonempty index set) and total_ne_zero make it a valid denominator. This is the n-dimensional lift of the parent's three-vertex MassPoint.",
+    "mathContext": "structure MassPoint n := (mass : Fin (n+1) → ℝ) (pos : ∀ i, 0 < mass i); total = Σ mass i > 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "positive masses",
+      "total mass"
+    ],
+    "prerequisites": [
+      "Finset.sum_pos"
+    ]
+  },
+  {
+    "id": "ann-ctoq0401-02-ratio",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 105
+    },
+    "type": "definition",
+    "title": "The Complement-Mass Fraction",
+    "content": "ratio i = (Σ_{j ∈ univ.erase i} mass j) / total is the fraction of total mass at all vertices other than i. sum_erase_eq_total_sub rewrites the erased sum as total - mass i (Finset.sum_erase_eq_sub), and ratio_eq_one_sub then gives the clean form ratio i = 1 - mass i/total (via sub_div and div_self total_ne_zero). This identity drives every later bound.",
+    "mathContext": "ratio i = (total - mass i)/total = 1 - mass i/total.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complement fraction",
+      "Finset.erase"
+    ],
+    "prerequisites": [
+      "Finset.sum_erase_eq_sub"
+    ]
+  },
+  {
+    "id": "ann-ctoq0401-03-bounds",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 124
+    },
+    "type": "technique",
+    "title": "The Fractions Lie in (0, 1)",
+    "content": "ratio_lt_one is immediate from ratio = 1 - mass i/total with mass i/total > 0. ratio_pos needs at least two vertices: for n ≥ 1 the set univ.erase i is nonempty (card = (n+1) - 1 = n > 0), so the erased sum is positive (Finset.sum_pos). At n = 0 (a single vertex) the erased sum is empty and the fraction is 0, so positivity genuinely requires the hypothesis.",
+    "mathContext": "ratio i < 1 always; 0 < ratio i for n ≥ 1.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "positivity of sums",
+      "cardinality of erase"
+    ],
+    "prerequisites": [
+      "Finset.card_erase_of_mem",
+      "Fintype.card_fin"
+    ]
+  },
+  {
+    "id": "ann-ctoq0401-04-sum-identity",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 125,
+      "endLine": 159
+    },
+    "type": "key-step",
+    "title": "The n-Dimensional Ceva Identity Σ ratio i = n",
+    "content": "sum_mass_div_total first shows the normalized masses sum to 1 (factor the common denominator with Finset.sum_div, then div_self). The headline sum_ratio_eq then proves Σ ratio i = n: rewrite each ratio as 1 - mass i/total (Finset.sum_congr), split the sum with Finset.sum_sub_distrib into (Σ 1) - (Σ mass i/total) = (n+1) - 1, and finish with ring. The n+1 ones minus the single unit of total normalized mass leave exactly n.",
+    "mathContext": "Σ ratio i = Σ(1 - mass i/total) = (n+1) - 1 = n.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.sum_sub_distrib",
+      "normalized masses",
+      "Ceva identity"
+    ],
+    "prerequisites": [
+      "Finset.sum_div",
+      "Finset.sum_sub_distrib"
+    ]
+  },
+  {
+    "id": "ann-ctoq0401-05-triangle",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 160,
+      "endLine": 167
+    },
+    "type": "concept",
+    "title": "Specialization to the Triangle (n = 2)",
+    "content": "An example confirms scope: for a MassPoint 2 (triangle), ratio 0 + ratio 1 + ratio 2 = 2, obtained from sum_ratio_eq by Fin.sum_univ_three. This recovers the triangle case of the parent entry — though the parent parametrizes by edge-split ratios (mC/(mB+mC), ...) rather than complement fractions, so the two are different normalizations of the same mass data (a full bridge is left to future work).",
+    "mathContext": "MassPoint 2: ratio 0 + ratio 1 + ratio 2 = 2.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle Ceva",
+      "Fin.sum_univ_three"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-ctoq0401-06-uniform",
+    "proofId": "cevas-theorem-oq-04-oq-01",
+    "range": {
+      "startLine": 169,
+      "endLine": 186
+    },
+    "type": "concept",
+    "title": "The Centroid: Uniform Masses",
+    "content": "uniform n is the mass point with all masses equal to 1 — the centroid of the n-simplex. uniform_total computes its total as n+1 (sum of n+1 ones), and uniform_ratio gives ratio i = n/(n+1) for every vertex. This recovers the familiar median ratios: 1/2 for a segment (n=1), 2/3 for a triangle (n=2), 3/4 for a tetrahedron (n=3).",
+    "mathContext": "uniform n: total = n+1, ratio i = n/(n+1) for all i.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "centroid",
+      "medians",
+      "uniform mass"
+    ],
+    "prerequisites": [
+      "Finset.sum_const"
+    ]
+  }
+]

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01/meta.json
@@ -1,0 +1,140 @@
+{
+  "id": "cevas-theorem-oq-04-oq-01",
+  "title": "N-Dimensional Mass-Point Ceva: Complement Fractions Sum to n",
+  "slug": "cevas-theorem-oq-04-oq-01",
+  "description": "Generalizes the parent's triangle mass-point structure to an n-simplex with n+1 positive vertex masses. Defines each vertex's complement-mass fraction ratio i = (sum of the other masses)/total = 1 - mass i/total, proves it lies in (0,1), and establishes the n-dimensional Ceva identity: the complement fractions sum to exactly n. For n = 2 this recovers the triangle case sum = 2.",
+  "meta": {
+    "author": "researcher-9 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mass_point_geometry",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CevasTheoremOQ04OQ01.lean",
+    "tags": [
+      "geometry",
+      "cevas-theorem",
+      "mass-point-geometry",
+      "simplex",
+      "affine-geometry",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_erase_eq_sub",
+        "description": "summing over univ.erase i equals the full sum minus the i-th term",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_pos",
+        "description": "a sum of strictly positive terms over a nonempty set is positive",
+        "module": "Mathlib.Algebra.BigOperators.Order"
+      },
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "the sum of a difference splits as the difference of sums",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Fintype.card_fin",
+        "description": "the cardinality of Fin (n+1) is n+1, used for counting vertices",
+        "module": "Mathlib.Data.Fintype.Card"
+      }
+    ],
+    "originalContributions": [
+      "MassPoint n: a structure of n+1 strictly positive vertex masses on an n-simplex (indexed by Fin (n+1))",
+      "MassPoint.total / total_pos / total_ne_zero: the total mass and its positivity",
+      "MassPoint.ratio: the complement-mass fraction (Σ_{j≠i} mass j)/total at vertex i",
+      "MassPoint.ratio_eq_one_sub: ratio i = 1 - mass i/total",
+      "MassPoint.ratio_lt_one (unconditional) and ratio_pos (for n ≥ 1): the fractions lie in (0,1)",
+      "MassPoint.sum_ratio_eq: the n-dimensional Ceva identity Σ ratio i = n",
+      "uniform / uniform_total / uniform_ratio: the centroid (all masses 1) gives ratio i = n/(n+1)",
+      "n = 2 specialization: ratio 0 + ratio 1 + ratio 2 = 2, recovering the triangle case"
+    ],
+    "references": [
+      {
+        "authors": "Hausner, Melvin",
+        "title": "The Center of Mass and Affine Geometry",
+        "year": "1962",
+        "venue": "American Mathematical Monthly",
+        "note": "Foundational treatment of mass-point (barycentric) geometry"
+      },
+      {
+        "authors": "Myers, Joseph",
+        "title": "Mathlib.LinearAlgebra.AffineSpace.Ceva",
+        "year": "2025",
+        "venue": "Mathlib",
+        "note": "Affine-space formulation of Ceva's theorem; the geometric concurrency target for future work"
+      }
+    ],
+    "prerequisites": [
+      "Mass-point (barycentric) geometry of triangles (parent entry cevas-theorem-oq-04)",
+      "Simplices and barycentric coordinates (Fin (n+1)-indexed masses)",
+      "Finite sums over Finset.univ and the erase/complement identity",
+      "Basic real arithmetic with field_simp / linarith"
+    ],
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 215,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound).",
+    "theoremCount": 10,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Mass-point geometry assigns positive masses to the vertices of a figure and reasons about cevians and concurrency through the center of mass. For a triangle with masses at the three vertices, the balance points on the sides yield ratios that automatically satisfy Ceva's concurrency relation — the subject of the parent entry cevas-theorem-oq-04. The natural question (this entry's open question) is whether the mass-point bookkeeping extends from the triangle to an arbitrary n-dimensional simplex with n+1 vertices.\n\nThis file lifts the parent's MassPoint structure to a Fin (n+1)-indexed family of positive masses and studies the per-vertex complement fraction: the share of the total mass carried by all vertices other than i. Each such fraction equals 1 - (normalized mass at i), so it sits strictly between 0 and 1, and the n+1 fractions sum to (n+1) - 1 = n. This clean identity — the complement fractions of an n-simplex sum to n — is the n-dimensional analogue of the triangle relation in which the three complement fractions sum to 2.",
+    "problemStatement": "**Open Question (from parent proof cevas-theorem-oq-04)**: Can the mass-point structure for a triangle (3 vertices) be generalized to an n-dimensional simplex (n+1 vertices)?\n\n**Resolution**: Yes. We define MassPoint n (n+1 positive vertex masses), the complement fraction ratio i = (Σ_{j≠i} mass j)/total, prove ratio i ∈ (0,1), and establish the n-dimensional Ceva identity Σ ratio i = n. The n = 2 case recovers the triangle sum of 2.",
+    "text": "A 215-line, axiom-free development (1 structure, 4 definitions, ~10 theorems). MassPoint n bundles n+1 strictly positive masses on the vertices of an n-simplex. total is their sum (positive, nonzero). The complement fraction ratio i = (Σ_{j∈univ.erase i} mass j)/total is shown to equal 1 - mass i/total (sum_erase_eq_total_sub + field_simp), from which ratio_lt_one is immediate and ratio_pos holds for n ≥ 1. The headline sum_ratio_eq proves Σ ratio i = n: rewrite each ratio as 1 - mass i/total, split the sum (sum_sub_distrib), use that the normalized masses sum to 1 (sum_mass_div_total), and simplify (n+1) - 1 = n. The uniform mass point (all masses 1) is the centroid, with uniform_ratio = n/(n+1); an n = 2 example confirms ratio 0 + ratio 1 + ratio 2 = 2.",
+    "proofStrategy": "ratio_eq_one_sub: rewrite the erased sum as total - mass i (Finset.sum_erase_eq_sub), then sub_div + field_simp. ratio_lt_one: from ratio = 1 - mass i/total with mass i/total > 0 (div_pos). ratio_pos: the erased sum is positive because univ.erase i is nonempty when n ≥ 1 (card_erase_of_mem + card_fin + omega). sum_mass_div_total: factor out the common denominator (sum_div) and div_self. sum_ratio_eq: Finset.sum_congr to replace each ratio by 1 - mass i/total, Finset.sum_sub_distrib to split, sum_mass_div_total for the second sum, and ring for (n+1) - 1 = n. uniform_ratio: ratio_eq_one_sub with uniform_total = n+1, then field_simp.",
+    "keyInsights": [
+      "The right n-dimensional generalization of the triangle ratios is the complement fraction: the share of total mass not at vertex i.",
+      "Each complement fraction is exactly 1 minus a normalized vertex mass, so it is automatically in (0,1).",
+      "The complement fractions of an n-simplex sum to n, because the normalized masses sum to 1 and there are n+1 of them: (n+1) - 1 = n.",
+      "Positivity of a complement fraction needs at least two vertices (n ≥ 1); the upper bound holds unconditionally.",
+      "The uniform mass point is the centroid, with every complement fraction equal to n/(n+1) — recovering the familiar 1/2, 2/3, 3/4, ... for the medians of segment, triangle, tetrahedron."
+    ],
+    "prerequisites": [
+      "Affine and barycentric geometry (simplices, centers of mass)",
+      "Finite sums over an index set",
+      "Elementary real arithmetic"
+    ]
+  },
+  "conclusion": {
+    "summary": "The triangle mass-point structure of the parent entry generalizes to an n-simplex: with n+1 positive vertex masses, each complement fraction ratio i = (Σ_{j≠i} mass j)/total lies in (0,1) and the fractions sum to exactly n. The uniform mass point gives ratio i = n/(n+1) (the centroid), and the n = 2 case recovers the triangle sum of 2. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This establishes the algebraic skeleton of n-dimensional mass-point geometry, the affine setting for cevian concurrency in a simplex. It resolves the parent's generalization question at the level of the mass/ratio identities; connecting these to geometric concurrency via Mathlib.LinearAlgebra.AffineSpace.Ceva, and bridging to the parent's edge-split parametrization, are the natural next steps.",
+    "openQuestions": [
+      "Bridge the parent's triangle edge-split parameters (rD = mC/(mB+mC), ...) to these complement fractions as different normalizations of the same mass data.",
+      "Constructive converse: given a ratio profile with Σ r i = n and r i ∈ (0,1), construct explicit vertex masses.",
+      "Connect to Mathlib.LinearAlgebra.AffineSpace.Ceva for the geometric n-dim cevian concurrency theorem."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cevas-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Generalizes the parent's triangle mass-point structure to an arbitrary n-simplex"
+    },
+    {
+      "targetId": "cevas-theorem",
+      "relationship": "related",
+      "description": "The classical Ceva concurrency theorem these mass-point identities certify"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Data.Fin.Basic",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "NDimMassPoint",
+    "lineCount": 215,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 4,
+    "sorries": 0,
+    "path": "Proofs/CevasTheoremOQ04OQ01.lean"
+  }
+}

--- a/src/data/research/problems/cevas-theorem-oq-04-oq-01.json
+++ b/src/data/research/problems/cevas-theorem-oq-04-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "cevas-theorem-oq-04-oq-01",
   "title": "[Problem Title]",
-  "phase": "SCAFFOLD",
-  "status": "active",
+  "phase": "complete",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -29,10 +29,25 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
+    "progressSummary": "COMPLETE: Generalized the parent's triangle mass-point structure to an n-simplex (n+1 positive vertex masses). Defined the complement-mass fraction ratio i = (Σ_{j≠i} mass j)/total = 1 - mass i/total, proved ratio i ∈ (0,1) (positivity needs n ≥ 1), and established the n-dim Ceva identity Σ ratio i = n. Uniform masses give ratio i = n/(n+1) (centroid); n=2 recovers the triangle sum 2. ~10 theorems, 4 defs, 215 lines, 0 sorries, 0 axioms. Repaired bit-rot (removed import Mathlib.Algebra.BigOperators.Basic → .Group.Finset.Basic; field_simp/div_self drift) and added gallery data.",
+    "builtItems": [
+      "MassPoint n: structure of n+1 positive vertex masses on an n-simplex",
+      "MassPoint.total / total_pos / total_ne_zero: total mass and positivity",
+      "MassPoint.ratio + ratio_eq_one_sub: complement fraction = 1 - mass i/total",
+      "ratio_lt_one (unconditional) + ratio_pos (n ≥ 1): fractions lie in (0,1)",
+      "MassPoint.sum_ratio_eq: the n-dim Ceva identity Σ ratio i = n",
+      "uniform / uniform_ratio: centroid gives ratio i = n/(n+1); n=2 example sums to 2"
+    ],
+    "insights": [
+      "The n-dim generalization of the triangle ratios is the complement fraction: the share of total mass not at vertex i.",
+      "Each complement fraction is 1 minus a normalized vertex mass, so it is automatically in (0,1).",
+      "The complement fractions of an n-simplex sum to n: (n+1) normalized masses summing to 1 give (n+1) - 1 = n.",
+      "Positivity needs n ≥ 1 (two vertices); the upper bound is unconditional. Uniform masses give the centroid ratios n/(n+1)."
+    ],
+    "mathlibGaps": [
+      "Bit-rot: Mathlib.Algebra.BigOperators.Basic removed in v4.26.0 → Mathlib.Algebra.BigOperators.Group.Finset.Basic.",
+      "field_simp/div_self drift in the proof bodies required repair."
+    ],
     "nextSteps": [],
     "markdown": "# Knowledge Base: cevas-theorem-oq-04-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n",
     "archivedSessions": [
@@ -69,7 +84,7 @@
     "mathlib": []
   },
   "started": "2026-05-13T00:55:42.236Z",
-  "lastUpdate": "2026-05-14T20:35:00.000Z",
+  "lastUpdate": "2026-06-22",
   "leanFiles": [
     {
       "path": "Proofs/CevasTheorem.lean",


### PR DESCRIPTION
## Summary

Recovers an orphaned, bit-rotted proof generalizing mass-point Ceva to an **n-dimensional simplex**. `proofs/Proofs/CevasTheoremOQ04OQ01.lean` lived in `main` with **no gallery entry** and no longer compiled under Mathlib v4.26.0: the import `Mathlib.Algebra.BigOperators.Basic` was removed (→ `.Group.Finset.Basic`), and three proof bodies had drifted (`field_simp`/`div_self`, a stale `rw` target). This PR repairs all of them, restores a clean axiom-free build, and adds the missing `meta.json` + `annotations.json` plus the research-problem knowledge.

## The result (1 structure, 4 defs, ~10 theorems, 215 lines, 0 sorries, 0 axioms)

Generalizes the parent's triangle mass-point structure to an n-simplex with `n+1` positive vertex masses:

- `MassPoint n` — `n+1` strictly positive vertex masses; `total > 0`
- `ratio i = (Σ_{j≠i} mass j)/total = 1 - mass i/total`, shown to lie in `(0,1)` (positivity needs `n ≥ 1`)
- `sum_ratio_eq` — **headline**: the n-dimensional Ceva identity `Σ ratio i = n`
- `uniform` (centroid): `ratio i = n/(n+1)`; the `n = 2` case recovers the triangle sum `2`

## Verification

- `./proofs/scripts/docker-build.sh Proofs.CevasTheoremOQ04OQ01` — builds successfully.
- `#print axioms` on `sum_ratio_eq` and `uniform_ratio`: only `[propext, Classical.choice, Quot.sound]`. No `native_decide`, no `sorryAx`. **0-axiom verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)