### PR TITLE
research(pell-equation-oq-06-oq-02): negative-Pell chain as odd powers of the fundamental unit of ℤ[√2]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3158,6 +3158,7 @@ import Proofs.PellEquationOQ02
 import Proofs.PellEquationOQ05
 import Proofs.PellEquationOQ06
 import Proofs.PellEquationOQ06OQ01
+import Proofs.PellEquationOQ06OQ02
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ02

--- a/proofs/Proofs/PellEquationOQ06OQ02.lean
+++ b/proofs/Proofs/PellEquationOQ06OQ02.lean
@@ -1,0 +1,179 @@
+/-
+Pell's Equation OQ-06-OQ-02: The Negative-Pell Chain as Powers of the
+Fundamental Unit of ℤ[√2]
+
+The parent entry (`pell-equation-oq-06`) proves, by an elementary ring identity,
+that the substitution
+
+    (x, y) ↦ (3x + 4y, 2x + 3y)
+
+preserves the form x² − 2y² and therefore generates infinitely many solutions of
+the negative Pell equation x² − 2y² = −1 starting from (1, 1). It *remarks* that
+this map "is multiplication by 3 + 2√2 in ℤ[√2]", but never makes the ring
+structure precise. This entry supplies exactly that missing structure, working
+inside Mathlib's ring of quadratic integers `ℤ√2 = Zsqrtd 2`.
+
+The fundamental unit is
+
+    ζ = 1 + √2 = ⟨1, 1⟩ ∈ ℤ[√2],   with   N(ζ) = 1² − 2·1² = −1,
+
+so ζ is a unit of norm −1. Its square is the classical norm-`+1` Pell unit
+
+    ζ² = 3 + 2√2 = ⟨3, 2⟩,   with   N(ζ²) = 1,
+
+and *multiplication by ζ²* reproduces the parent's step map exactly. Consequently
+the parent's chain is realized by the **odd powers of ζ**:
+
+    ⟨xₙ, yₙ⟩ = ζ^(2n+1)        (negPellSeq_eq_pow)
+
+and the multiplicativity of the quadratic-integer norm gives a conceptual, one-line
+re-derivation of the parent's term-by-term computation:
+
+    N(⟨xₙ, yₙ⟩) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1.
+
+This also exposes the full norm dichotomy that the elementary parent cannot see:
+the *odd* powers of ζ solve x² − 2y² = −1 (negative Pell) while the *even* powers
+solve x² − 2y² = +1 (positive Pell). The norm `+1` case is precisely what Mathlib's
+`Pell.Solution₁` machinery models; the norm `−1` case is its still-unformalized
+companion, which this lineage handles from scratch.
+
+Main results:
+  • `norm_ζ`                  — N(ζ) = −1 (ζ is a unit of norm −1).
+  • `isUnit_ζ`                — ζ is a unit of ℤ[√2] (the fundamental unit).
+  • `ζ_sq`                    — ζ² = ⟨3,2⟩ = 3 + 2√2, the norm-+1 Pell unit.
+  • `negPellSeq_succ_eq_mul`  — the parent's step map is multiplication by ζ².
+  • `negPellSeq_eq_pow`       — ⟨xₙ, yₙ⟩ = ζ^(2n+1) (the chain = odd powers of ζ).
+  • `negPellSeq_norm_via_unit`— conceptual re-proof of x² − 2y² = −1 via N multiplicative.
+  • `norm_ζ_pow_odd` / `norm_ζ_pow_even` — the −1 / +1 norm dichotomy of the powers.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Parent entry: `pell-equation-oq-06` (elementary chain; infinitude).
+- Mathlib `Mathlib/NumberTheory/Zsqrtd/Basic.lean` (`Zsqrtd`, `Zsqrtd.norm`,
+  `Zsqrtd.norm_mul`, `Zsqrtd.norm_eq_one_iff`).
+- Mathlib `Mathlib/NumberTheory/Pell.lean` (`Pell.Solution₁`: the norm `+1` case).
+-/
+
+import Mathlib
+import Proofs.PellEquationOQ06
+
+namespace PellEquationOQ06OQ02
+
+open PellEquationOQ06
+
+/-
+## The fundamental unit ζ = 1 + √2 of ℤ[√2]
+-/
+
+/-- The fundamental solution `(1, 1)` viewed as the unit `1 + √2` of `ℤ[√2]`. -/
+def ζ : ℤ√2 := ⟨1, 1⟩
+
+/-- **ζ has norm −1.** `N(1 + √2) = 1² − 2·1² = −1`, so ζ realizes the
+    fundamental solution of the *negative* Pell equation. -/
+theorem norm_ζ : ζ.norm = -1 := by
+  simp [ζ, Zsqrtd.norm_def]
+
+/-- **ζ is a unit of ℤ[√2]** — the fundamental unit. A quadratic integer is a unit
+    iff its norm has absolute value `1`, and `|N(ζ)| = |−1| = 1`. -/
+theorem isUnit_ζ : IsUnit ζ := by
+  rw [← Zsqrtd.norm_eq_one_iff, norm_ζ]
+  decide
+
+/-- **ζ² = 3 + 2√2.** Squaring the norm-`−1` unit gives the classical norm-`+1`
+    fundamental unit of ℤ[√2], the multiplier behind the parent's step map. -/
+theorem ζ_sq : ζ ^ 2 = (⟨3, 2⟩ : ℤ√2) := by
+  rw [pow_two]
+  refine Zsqrtd.ext ?_ ?_ <;> simp [ζ, Zsqrtd.re_mul, Zsqrtd.im_mul]
+
+/-- **N(ζ²) = +1.** The pair `(3, 2)` solves the positive Pell equation
+    `x² − 2y² = 1`; `ζ²` is the fundamental unit of norm `+1`. -/
+theorem norm_ζ_sq : (ζ ^ 2).norm = 1 := by
+  rw [ζ_sq]; decide
+
+/-
+## Multiplicativity of the norm under powers
+-/
+
+/-- The quadratic-integer norm is multiplicative under powers:
+    `N(zᵏ) = N(z)ᵏ`. (A direct induction off `Zsqrtd.norm_mul`.) -/
+theorem norm_pow {d : ℤ} (z : ℤ√d) : ∀ k : ℕ, (z ^ k).norm = z.norm ^ k
+  | 0 => by simp
+  | (k + 1) => by rw [pow_succ, Zsqrtd.norm_mul, norm_pow z k, pow_succ]
+
+/-
+## The parent chain as the odd powers of ζ
+-/
+
+/-- **The parent's step map is multiplication by ζ² in ℤ[√2].** The recurrence
+    `(x, y) ↦ (3x + 4y, 2x + 3y)` is exactly `· * (3 + 2√2)`. -/
+theorem negPellSeq_succ_eq_mul (n : ℕ) :
+    (⟨(negPellSeq (n + 1)).1, (negPellSeq (n + 1)).2⟩ : ℤ√2)
+      = (⟨(negPellSeq n).1, (negPellSeq n).2⟩ : ℤ√2) * ζ ^ 2 := by
+  rw [ζ_sq, negPellSeq_succ]
+  refine Zsqrtd.ext ?_ ?_ <;> simp [Zsqrtd.re_mul, Zsqrtd.im_mul] <;> ring
+
+/-- **The negative-Pell chain is the odd powers of the fundamental unit:**
+    `⟨xₙ, yₙ⟩ = ζ^(2n+1)` in ℤ[√2]. Proved by induction: ζ^(2(n+1)+1) =
+    ζ^(2n+1) · ζ², and multiplication by ζ² is the parent's step map. -/
+theorem negPellSeq_eq_pow (n : ℕ) :
+    (⟨(negPellSeq n).1, (negPellSeq n).2⟩ : ℤ√2) = ζ ^ (2 * n + 1) := by
+  induction n with
+  | zero => simp [negPellSeq_zero, ζ]
+  | succ k ih =>
+    have hexp : 2 * (k + 1) + 1 = 2 * k + 1 + 2 := by ring
+    rw [hexp, pow_add, ← ih, ζ_sq, negPellSeq_succ]
+    refine Zsqrtd.ext ?_ ?_ <;> simp [Zsqrtd.re_mul, Zsqrtd.im_mul] <;> ring
+
+/-
+## Conceptual re-derivation of the negative Pell identity
+-/
+
+/-- **The norm identity, conceptually.** Multiplicativity of the ℤ[√2] norm turns
+    the parent's term-by-term induction (`negPellSeq_norm`) into a single
+    computation: `N(⟨xₙ, yₙ⟩) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1`. -/
+theorem negPellSeq_norm_via_unit (n : ℕ) :
+    (negPellSeq n).1 ^ 2 - 2 * (negPellSeq n).2 ^ 2 = -1 := by
+  have hnorm :
+      (⟨(negPellSeq n).1, (negPellSeq n).2⟩ : ℤ√2).norm
+        = (negPellSeq n).1 ^ 2 - 2 * (negPellSeq n).2 ^ 2 := by
+    rw [Zsqrtd.norm_def]; ring
+  rw [← hnorm, negPellSeq_eq_pow, norm_pow, norm_ζ, Odd.neg_one_pow ⟨n, by ring⟩]
+
+/-
+## The norm dichotomy of the powers of ζ
+-/
+
+/-- **Odd powers of ζ solve the negative Pell equation:** `N(ζ^(2n+1)) = −1`.
+    These are exactly the entries of the parent's chain. -/
+theorem norm_ζ_pow_odd (n : ℕ) : (ζ ^ (2 * n + 1)).norm = -1 := by
+  rw [norm_pow, norm_ζ, Odd.neg_one_pow ⟨n, by ring⟩]
+
+/-- **Even powers of ζ solve the positive Pell equation:** `N(ζ^(2n)) = +1`.
+    These are the powers of the norm-`+1` unit `3 + 2√2` (the case modeled by
+    Mathlib's `Pell.Solution₁`). -/
+theorem norm_ζ_pow_even (n : ℕ) : (ζ ^ (2 * n)).norm = 1 := by
+  rw [norm_pow, norm_ζ, pow_mul]; simp
+
+/-
+## Explicit small powers (sanity checks)
+-/
+
+example : ζ ^ 1 = (⟨1, 1⟩ : ℤ√2) := by rw [pow_one]; rfl
+example : ζ ^ 3 = (⟨7, 5⟩ : ℤ√2) := by decide
+example : ζ ^ 5 = (⟨41, 29⟩ : ℤ√2) := by decide
+
+example : (ζ ^ 1).norm = -1 := norm_ζ_pow_odd 0
+example : (ζ ^ 3).norm = -1 := norm_ζ_pow_odd 1
+example : (ζ ^ 2).norm = 1 := norm_ζ_pow_even 1
+example : (ζ ^ 4).norm = 1 := norm_ζ_pow_even 2
+
+#check @norm_ζ
+#check @isUnit_ζ
+#check @ζ_sq
+#check @negPellSeq_eq_pow
+#check @negPellSeq_norm_via_unit
+#check @norm_ζ_pow_odd
+#check @norm_ζ_pow_even
+
+end PellEquationOQ06OQ02

--- a/src/data/proofs/pell-equation-oq-06-oq-02/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-02/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "pell-equation-oq-06-oq-02",
+  "title": "Negative Pell x² − 2y² = −1: The Chain as Odd Powers of the Fundamental Unit of ℤ[√2]",
+  "slug": "pell-equation-oq-06-oq-02",
+  "description": "Supplies the ring structure the parent only gestured at. The parent generates solutions of x² − 2y² = −1 by the elementary substitution (x,y) ↦ (3x+4y, 2x+3y) and remarks it 'is multiplication by 3 + 2√2 in ℤ[√2]', but never formalizes it. Working inside Mathlib's quadratic-integer ring ℤ√2 = Zsqrtd 2, this entry makes the unit ζ = 1 + √2 = ⟨1,1⟩ precise: N(ζ) = −1, ζ is a unit, ζ² = 3 + 2√2 is the norm +1 Pell unit, and the parent's chain is realized exactly by the odd powers ⟨xₙ, yₙ⟩ = ζ^(2n+1). Multiplicativity of the Zsqrtd norm then re-derives the parent's term-by-term identity in one line — N(ζ^(2n+1)) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1 — and exposes the full norm dichotomy: odd powers solve the negative Pell equation, even powers the positive one.",
+  "meta": {
+    "author": "Lean Genius (ℤ[√2] unit structure); Brahmagupta / Lagrange / Dirichlet (classical theory)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ06OQ02.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "negative-pell",
+      "quadratic-integers",
+      "zsqrtd",
+      "fundamental-unit",
+      "norm-multiplicativity",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 179,
+    "originalContributions": [
+      "ζ : ℤ√2 := ⟨1,1⟩ with norm_ζ — the fundamental solution (1,1) recast as the quadratic integer 1 + √2, of norm N(ζ) = 1² − 2·1² = −1, realizing the negative Pell equation inside Mathlib's Zsqrtd 2",
+      "isUnit_ζ: ζ is a unit of ℤ[√2] (the fundamental unit of norm −1), obtained from Zsqrtd.norm_eq_one_iff since |N(ζ)| = 1",
+      "ζ_sq: ζ² = ⟨3,2⟩ = 3 + 2√2 — squaring the norm −1 unit produces the classical norm +1 Pell unit, with norm_ζ_sq giving N(ζ²) = +1",
+      "negPellSeq_succ_eq_mul: the parent's elementary step map (x,y) ↦ (3x+4y, 2x+3y) is EXACTLY multiplication by ζ² in ℤ[√2], proved by matching real/imaginary parts via Zsqrtd.re_mul / im_mul",
+      "negPellSeq_eq_pow: THE BRIDGE — the parent's chain is the sequence of odd powers of the fundamental unit, ⟨xₙ, yₙ⟩ = ζ^(2n+1), by induction using ζ^(2(n+1)+1) = ζ^(2n+1)·ζ²",
+      "norm_pow: multiplicativity of the Zsqrtd norm under powers, N(zᵏ) = N(z)ᵏ, by induction off Zsqrtd.norm_mul",
+      "negPellSeq_norm_via_unit: a CONCEPTUAL re-proof of the parent's negPellSeq_norm — instead of a term-by-term induction, N(⟨xₙ,yₙ⟩) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1 in a single computation",
+      "norm_ζ_pow_odd / norm_ζ_pow_even: the norm dichotomy of the powers of ζ — odd powers have norm −1 (negative Pell), even powers norm +1 (positive Pell, the case modeled by Mathlib's Pell.Solution₁)"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide (the three `decide` uses are kernel `decide`, not `native_decide`, so no Lean.ofReduceBool). Imports the parent file Proofs/PellEquationOQ06.lean to reuse the chain negPellSeq and its recurrence, and Mathlib's Zsqrtd API (norm_def, norm_mul, norm_eq_one_iff, re_mul, im_mul).",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-06",
+      "relationship": "extends",
+      "description": "The parent builds the chain (1,1)→(7,5)→(41,29)→… by an elementary ring identity and remarks the step map 'is multiplication by 3 + 2√2 in ℤ[√2]' without formalizing it. This entry supplies that ring structure inside Mathlib's Zsqrtd 2: the step map is multiplication by ζ², the chain is the odd powers ζ^(2n+1), and the parent's norm computation follows from multiplicativity of the quadratic-integer norm."
+    },
+    {
+      "targetId": "pell-equation-oq-06-oq-01",
+      "relationship": "related",
+      "description": "The sibling entry classifies all positive solutions by descent along the inverse unit 3 − 2√2 and records the squaring bridge to positive Pell. This entry gives the complementary ascending picture — the chain as ascending odd powers of the unit ζ — and the unifying norm dichotomy (odd powers norm −1, even powers norm +1)."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The classical norm +1 Pell equation x² − Dy² = 1, modeled in Mathlib by Pell.Solution₁. Here the even powers ζ^(2n) = (3 + 2√2)ⁿ are exactly the norm +1 solutions, while the odd powers fall outside the Mathlib API (norm −1), motivating the from-scratch treatment."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Brahmagupta's composition law (628 CE) is the multiplicativity of the norm form of ℤ[√D]: solutions of x² − Dy² = N compose by multiplying the corresponding quadratic integers. For D = 2 the ring is ℤ[√2], whose unit group (Dirichlet's unit theorem, rank 1) is generated up to sign by the fundamental unit 1 + √2 of norm −1; its square 3 + 2√2 is the fundamental unit of norm +1 that drives the classical Pell equation. Lagrange's continued-fraction theory shows that, when the negative Pell equation x² − 2y² = −1 is solvable (the period of √2 being odd), every solution is a power of the fundamental unit. This entry formalizes the smallest case D = 2: it identifies the parent's elementary chain with the odd powers of 1 + √2 and recovers the norm identity from Brahmagupta's composition law, working inside Mathlib's Zsqrtd whose Pell.Solution₁ API covers only the norm +1 case.",
+    "problemStatement": "The parent entry generates the chain (1,1) → (7,5) → (41,29) → … of solutions to x² − 2y² = −1 by the substitution (x,y) ↦ (3x+4y, 2x+3y), and notes in prose that this map 'is multiplication by 3 + 2√2 in ℤ[√2]'. Can that ring-theoretic claim be made precise — is the chain literally the sequence of powers of the fundamental unit of ℤ[√2], and does the multiplicativity of the norm explain why every term satisfies x² − 2y² = −1?",
+    "proofStrategy": "Work in Mathlib's ℤ√2 = Zsqrtd 2. Set ζ = ⟨1,1⟩ (= 1 + √2). Compute N(ζ) = −1 from Zsqrtd.norm_def and obtain isUnit_ζ from Zsqrtd.norm_eq_one_iff. Compute ζ² = ⟨3,2⟩ by matching components (Zsqrtd.re_mul / im_mul), and observe via negPellSeq_succ_eq_mul that the parent's step is exactly · * ζ². An induction then proves the bridge negPellSeq_eq_pow: ⟨xₙ,yₙ⟩ = ζ^(2n+1), since ζ^(2(n+1)+1) = ζ^(2n+1)·ζ² reproduces the step. Finally norm_pow (N(zᵏ)=N(z)ᵏ, from Zsqrtd.norm_mul) gives the conceptual norm identity N(⟨xₙ,yₙ⟩) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1 and the dichotomy norm_ζ_pow_odd / norm_ζ_pow_even.",
+    "keyInsights": [
+      "The parent's step map (x,y) ↦ (3x+4y, 2x+3y) is not an arbitrary substitution: it is precisely multiplication by ζ² = 3 + 2√2 in ℤ[√2], because ⟨x,y⟩ · ⟨3,2⟩ = ⟨3x + 2·2y, 2x + 3y⟩ = ⟨3x+4y, 2x+3y⟩ under the Zsqrtd product. Formalizing this turns an ad hoc recurrence into a single algebraic operation.",
+      "Starting from ζ (a norm −1 element) and advancing by ζ² (norm +1) keeps the norm at −1 and the exponent odd, so the chain is exactly the odd powers ζ^(2n+1). The bridge negPellSeq_eq_pow makes the parent's pairs and the unit powers literally equal as elements of ℤ[√2].",
+      "Multiplicativity of the quadratic-integer norm (Brahmagupta's identity, Mathlib's Zsqrtd.norm_mul) collapses the parent's term-by-term induction into one computation: N(ζ^(2n+1)) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1. The work shifts from arithmetic on each term to a property of the unit.",
+      "The same lens reveals the full dichotomy invisible to the elementary parent: even powers ζ^(2n) = (3+2√2)ⁿ have norm +1 and solve the positive Pell equation, odd powers have norm −1 and solve the negative one. The negative-Pell chain is the 'odd half' of the unit group.",
+      "Mathlib's Pell.Solution₁ models only the norm +1 equation; the norm −1 case is unformalized. Casting the parent's chain inside Zsqrtd and proving the unit-power identity connects the bespoke construction to Mathlib's quadratic-integer infrastructure without needing a norm −1 analogue of Solution₁."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Research Context",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Explains that the parent only remarks the step map is 'multiplication by 3 + 2√2 in ℤ[√2]' without formalizing it, and that this entry supplies that ring structure inside Mathlib's Zsqrtd 2. Lists the main results and notes Mathlib's Pell.Solution₁ covers only the norm +1 case.",
+      "mathContext": "The ring $\\mathbb{Z}[\\sqrt2] = \\texttt{Zsqrtd}\\,2$ has norm $N(\\langle a,b\\rangle) = a^2 - 2b^2$ and fundamental unit $1+\\sqrt2$ of norm $-1$; its square $3+2\\sqrt2$ has norm $+1$."
+    },
+    {
+      "id": "fundamental-unit",
+      "title": "The fundamental unit ζ = 1 + √2",
+      "startLine": 65,
+      "endLine": 92,
+      "summary": "Defines ζ = ⟨1,1⟩ and proves N(ζ) = −1 (norm_ζ), that ζ is a unit (isUnit_ζ, via Zsqrtd.norm_eq_one_iff), that ζ² = ⟨3,2⟩ = 3 + 2√2 (ζ_sq), and N(ζ²) = +1 (norm_ζ_sq).",
+      "mathContext": "$\\zeta = 1+\\sqrt2$, $N(\\zeta)=1^2-2\\cdot1^2=-1$; a quadratic integer is a unit iff $|N|=1$. $\\zeta^2 = 3+2\\sqrt2$ with $N(\\zeta^2)=9-2\\cdot4=1$."
+    },
+    {
+      "id": "norm-pow",
+      "title": "Multiplicativity of the norm under powers",
+      "startLine": 94,
+      "endLine": 103,
+      "summary": "norm_pow: N(zᵏ) = N(z)ᵏ for any z ∈ ℤ√d, a one-line induction off Zsqrtd.norm_mul — the engine behind the conceptual norm identity.",
+      "mathContext": "Brahmagupta composition: the norm is a monoid homomorphism $\\mathbb{Z}[\\sqrt d]^\\times \\to \\mathbb{Z}^\\times$, so $N(z^k)=N(z)^k$."
+    },
+    {
+      "id": "chain-as-powers",
+      "title": "The parent chain as the odd powers of ζ",
+      "startLine": 104,
+      "endLine": 127,
+      "summary": "negPellSeq_succ_eq_mul shows the parent's step map equals multiplication by ζ²; negPellSeq_eq_pow proves by induction that ⟨xₙ,yₙ⟩ = ζ^(2n+1), identifying the chain with the odd powers of the fundamental unit.",
+      "mathContext": "$\\langle x_n,y_n\\rangle\\cdot(3+2\\sqrt2) = \\langle x_{n+1},y_{n+1}\\rangle$ and $\\langle x_n,y_n\\rangle = (1+\\sqrt2)^{2n+1}$."
+    },
+    {
+      "id": "conceptual-norm",
+      "title": "Conceptual re-derivation of the negative Pell identity",
+      "startLine": 128,
+      "endLine": 142,
+      "summary": "negPellSeq_norm_via_unit re-proves the parent's negPellSeq_norm via multiplicativity: N(⟨xₙ,yₙ⟩) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1, in one computation rather than a term-by-term induction.",
+      "mathContext": "$x_n^2-2y_n^2 = N\\big((1+\\sqrt2)^{2n+1}\\big) = (-1)^{2n+1} = -1$."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The norm dichotomy of the powers of ζ",
+      "startLine": 143,
+      "endLine": 179,
+      "summary": "norm_ζ_pow_odd: N(ζ^(2n+1)) = −1 (negative Pell); norm_ζ_pow_even: N(ζ^(2n)) = +1 (positive Pell). Sanity-check examples confirm ζ¹=⟨1,1⟩, ζ³=⟨7,5⟩, ζ⁵=⟨41,29⟩ and their norms.",
+      "mathContext": "Odd powers of $1+\\sqrt2$ have norm $-1$ (solve $x^2-2y^2=-1$); even powers have norm $+1$ (solve $x^2-2y^2=1$, Mathlib's $\\texttt{Pell.Solution}_1$)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 179-line file (0 sorries, 0 axioms, no native_decide) formalizes the ring structure the parent entry only stated in prose. Inside Mathlib's ℤ√2 = Zsqrtd 2, the fundamental unit ζ = 1 + √2 = ⟨1,1⟩ has norm −1 and is a unit; its square ζ² = 3 + 2√2 is the norm +1 Pell unit, and the parent's step map is exactly multiplication by ζ². The bridge negPellSeq_eq_pow identifies the parent's chain with the odd powers ⟨xₙ,yₙ⟩ = ζ^(2n+1), and multiplicativity of the quadratic-integer norm (norm_pow) re-derives the parent's x² − 2y² = −1 identity in one computation while exposing the dichotomy that odd powers solve the negative Pell equation and even powers the positive one.",
+    "implications": "Reframing the parent's bespoke recurrence as powers of a unit in Mathlib's Zsqrtd connects the construction to standard quadratic-integer infrastructure (norm_mul, norm_eq_one_iff) and to the Pell.Solution₁ API (which it complements on the norm −1 side). The pattern — recast an ad hoc integer recurrence as multiplication by a fixed unit in ℤ[√d], then read off invariants from norm multiplicativity — applies to any norm-form Diophantine chain.",
+    "openQuestions": [
+      "Formalize the surjection onto the full norm −1 solution set: every element of norm −1 in ℤ[√2] (up to sign and conjugation) is ±ζ^(2n+1), tying this powers-of-a-unit picture to the sibling's descent classification (pell-equation-oq-06-oq-01).",
+      "Define a norm −1 analogue of Mathlib's Pell.Solution₁ as the odd powers of the fundamental unit, and prove it forms a torsor under the norm +1 solution group Pell.Solution₁ acting by ζ²-multiplication.",
+      "Generalize to ℤ[√D] for other solvable D: identify the negative Pell chain with the odd powers of the fundamental unit whenever the continued-fraction period of √D is odd."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 179,
+    "axiomCount": 0,
+    "path": "Proofs/PellEquationOQ06OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 10,
+    "imports": [
+      "Mathlib",
+      "Proofs.PellEquationOQ06"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Child of `pell-equation-oq-06`. The parent generates solutions of **x² − 2y² = −1** by the elementary substitution (x,y) ↦ (3x+4y, 2x+3y) and *remarks in prose* that this map "is multiplication by 3 + 2√2 in ℤ[√2]" — but never formalizes the ring structure. This entry supplies exactly that, working inside Mathlib's quadratic-integer ring `ℤ√2 = Zsqrtd 2`.

## Main results

| Theorem | Statement |
|---|---|
| `norm_ζ` / `isUnit_ζ` | ζ = 1 + √2 = ⟨1,1⟩ has norm −1 and is the fundamental unit |
| `ζ_sq` / `norm_ζ_sq` | ζ² = 3 + 2√2 = ⟨3,2⟩ is the classical norm +1 Pell unit |
| `negPellSeq_succ_eq_mul` | the parent's step map is **exactly** multiplication by ζ² |
| `negPellSeq_eq_pow` | **the bridge** — the chain is the odd powers: ⟨xₙ,yₙ⟩ = ζ^(2n+1) |
| `norm_pow` | multiplicativity of the Zsqrtd norm: N(zᵏ) = N(z)ᵏ |
| `negPellSeq_norm_via_unit` | conceptual re-proof: N(ζ^(2n+1)) = N(ζ)^(2n+1) = (−1)^(2n+1) = −1 |
| `norm_ζ_pow_odd` / `norm_ζ_pow_even` | the norm dichotomy: odd powers → negative Pell, even powers → positive Pell |

## Why it matters

- Recasts the parent's ad hoc integer recurrence as **powers of a unit** in ℤ[√2], connecting it to Mathlib's quadratic-integer infrastructure (`norm_mul`, `norm_eq_one_iff`).
- Multiplicativity of the norm collapses the parent's term-by-term induction into a one-line computation.
- Exposes the dichotomy invisible to the elementary parent: even powers ζ^(2n) = (3+2√2)ⁿ are the **positive** Pell solutions modeled by Mathlib's `Pell.Solution₁`; odd powers are the **negative** Pell solutions, which Mathlib does not formalize.

## Verification

- **179 lines, 10 theorems, 1 def, 0 sorries, 0 axioms.**
- **No `native_decide`** — the three `decide` uses are kernel `decide` (no `Lean.ofReduceBool`).
- Imports `Proofs.PellEquationOQ06` to reuse the chain `negPellSeq` and its recurrence.
- Built via `./proofs/scripts/docker-build.sh Proofs.PellEquationOQ06OQ02` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)