### PR TITLE
research(jensen-inequality-oq-01): equality case of strict Jensen → sharp weighted AM–GM equality [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2908,6 +2908,7 @@ import Proofs.IsoscelesTriangleOQ02
 import Proofs.IsoscelesTriangleOQ01
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
+import Proofs.JensenInequalityOQ01
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs/JensenInequalityOQ01.lean
+++ b/proofs/Proofs/JensenInequalityOQ01.lean
@@ -1,0 +1,124 @@
+/-
+# The Equality Case of Strict Jensen, and the Sharp Weighted AM–GM Equality
+
+This file isolates the **equality case** of the finite weighted Jensen inequality for a
+*strictly* convex function, and specializes it — through the strict convexity of `exp` — to the
+sharp equality case of the **weighted arithmetic–geometric mean inequality**.
+
+The abstract input is Mathlib's `StrictConvexOn.map_sum_eq_iff`: for a strictly convex `f`,
+strictly positive weights `w` summing to `1`, and points `p i` in the domain,
+
+    f (∑ i, w i • p i) = ∑ i, w i • f (p i)   ↔   the points `p i` are all (equal to their mean).
+
+Specializing `f = exp` and `p i = log (z i)` turns Jensen's inequality into weighted AM–GM, and the
+equality case into the statement that geometric and arithmetic means coincide **iff all the data
+are equal**. This is precisely the route by which Mathlib establishes
+`Real.geom_mean_eq_arith_mean_weighted_iff'`; here we package the bridge explicitly and supply the
+strict inequality directly from `StrictConvexOn.map_sum_lt`, together with the familiar
+two-variable instance `√(ab) = (a+b)/2 ↔ a = b`.
+
+## Main results
+
+* `jensen_eq_iff` — the abstract equality case of strict Jensen (a clean re-export).
+* `weighted_amgm_le` — the weighted AM–GM inequality `∏ zᵢ^{wᵢ} ≤ ∑ wᵢ zᵢ`.
+* `weighted_amgm_eq_iff` — equality `∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ` holds **iff** all `zᵢ` are equal.
+* `weighted_amgm_lt_of_ne` — if some two values differ, the inequality is strict; proved directly
+  through `strictConvexOn_exp.map_sum_lt`, making the Jensen → AM–GM bridge explicit.
+* `amgm_two_eq_iff` — the concrete two-variable equality case `√(ab) = (a+b)/2 ↔ a = b`.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+
+open Finset Real
+
+variable {ι : Type*} {s : Finset ι} {w z : ι → ℝ}
+
+/-! ## The abstract equality case of strict Jensen -/
+
+/-- **Equality case of strict Jensen's inequality.**
+
+For a strictly convex `f`, strictly positive weights `ω` summing to `1`, and points `p i` in the
+domain `S`, Jensen's inequality `f(∑ ω • p) ≤ ∑ ω • f(p)` is an *equality* exactly when every point
+equals the (weighted) center of mass — i.e. the data are constant. This is a clean re-export of
+Mathlib's `StrictConvexOn.map_sum_eq_iff`, recorded here as the foundation for the AM–GM corollary
+below. -/
+theorem jensen_eq_iff {f : ℝ → ℝ} {S : Set ℝ} {t : Finset ι} {ω : ι → ℝ} {p : ι → ℝ}
+    (hf : StrictConvexOn ℝ S f) (h₀ : ∀ i ∈ t, 0 < ω i) (h₁ : ∑ i ∈ t, ω i = 1)
+    (hmem : ∀ i ∈ t, p i ∈ S) :
+    f (∑ i ∈ t, ω i • p i) = ∑ i ∈ t, ω i • f (p i) ↔ ∀ j ∈ t, p j = ∑ i ∈ t, ω i • p i :=
+  hf.map_sum_eq_iff h₀ h₁ hmem
+
+/-! ## Weighted AM–GM and its equality case -/
+
+/-- **Weighted arithmetic–geometric mean inequality.** For nonnegative weights summing to `1` and
+nonnegative data, the weighted geometric mean is at most the weighted arithmetic mean. -/
+theorem weighted_amgm_le (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i ≤ ∑ i ∈ s, w i * z i :=
+  Real.geom_mean_le_arith_mean_weighted s w z hw hw' hz
+
+/-- **Equality case of weighted AM–GM.** With *strictly positive* weights summing to `1` and
+nonnegative data, the weighted geometric and arithmetic means coincide **iff all the data are
+equal**.
+
+This restates Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'` (whose center-of-mass right
+side `∀ j, z j = ∑ w • z` we convert to the symmetric "all equal" form), the latter itself being a
+specialization of `strictConvexOn_exp.map_sum_eq_iff`. -/
+theorem weighted_amgm_eq_iff (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  rw [Real.geom_mean_eq_arith_mean_weighted_iff' s w z hw hw' hz]
+  constructor
+  · intro h j hj k hk; rw [h j hj, h k hk]
+  · intro h j hj
+    calc z j = ∑ i ∈ s, w i * z j := by rw [← Finset.sum_mul, hw', one_mul]
+      _ = ∑ i ∈ s, w i * z i := Finset.sum_congr rfl fun i hi => by rw [h i hi j hj]
+
+/-- **Strict weighted AM–GM.** With strictly positive weights summing to `1` and strictly positive
+data, if two of the values differ then the weighted geometric mean is *strictly* less than the
+weighted arithmetic mean.
+
+The proof goes directly through the strict Jensen inequality `StrictConvexOn.map_sum_lt` for
+`exp`: writing `z i = exp (log (z i))`, the geometric mean is `exp (∑ w • log z)` and the arithmetic
+mean is `∑ w • exp (log z)`, so strict convexity of `exp` on a non-constant family gives the strict
+gap. This is the explicit Jensen → AM–GM bridge. -/
+theorem weighted_amgm_lt_of_ne (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i) (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    ∏ i ∈ s, z i ^ w i < ∑ i ∈ s, w i * z i := by
+  -- The geometric mean rewrites as `exp` of the weighted mean of the logs.
+  have hgeo : Real.exp (∑ i ∈ s, w i • Real.log (z i)) = ∏ i ∈ s, z i ^ w i := by
+    rw [Real.exp_sum]
+    refine Finset.prod_congr rfl fun i hi => ?_
+    rw [smul_eq_mul, Real.rpow_def_of_pos (hz i hi), mul_comm]
+  -- The arithmetic mean rewrites as the weighted mean of `exp (log (z i)) = z i`.
+  have harith : ∑ i ∈ s, w i • Real.exp (Real.log (z i)) = ∑ i ∈ s, w i * z i := by
+    refine Finset.sum_congr rfl fun i hi => ?_
+    rw [smul_eq_mul, Real.exp_log (hz i hi)]
+  -- Non-constant data ⇒ non-constant logs, by injectivity of `log` on the positives.
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  have hlog : ∃ j ∈ s, ∃ k ∈ s, Real.log (z j) ≠ Real.log (z k) :=
+    ⟨j, hj, k, hk, fun h =>
+      hjk (Real.log_injOn_pos (Set.mem_Ioi.mpr (hz j hj)) (Set.mem_Ioi.mpr (hz k hk)) h)⟩
+  have hlt := strictConvexOn_exp.map_sum_lt hw hw' (fun i _ => Set.mem_univ (Real.log (z i))) hlog
+  rwa [hgeo, harith] at hlt
+
+/-! ## The two-variable instance -/
+
+/-- **Two-variable AM–GM equality case.** For nonnegative reals, the geometric mean `√(ab)` equals
+the arithmetic mean `(a+b)/2` exactly when `a = b`. The forward direction is the classic
+`(√a − √b)² = 0`. -/
+theorem amgm_two_eq_iff {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) :
+    Real.sqrt (a * b) = (a + b) / 2 ↔ a = b := by
+  constructor
+  · intro h
+    have hab : Real.sqrt a * Real.sqrt b = (a + b) / 2 := by rw [← Real.sqrt_mul ha]; exact h
+    have hu : Real.sqrt a ^ 2 = a := Real.sq_sqrt ha
+    have hv : Real.sqrt b ^ 2 = b := Real.sq_sqrt hb
+    have key : (Real.sqrt a - Real.sqrt b) ^ 2 = 0 := by nlinarith [hu, hv, hab]
+    have huv : Real.sqrt a = Real.sqrt b :=
+      sub_eq_zero.mp (pow_eq_zero_iff (n := 2) (by norm_num) |>.mp key)
+    rw [← Real.sq_sqrt ha, ← Real.sq_sqrt hb, huv]
+  · rintro rfl
+    rw [Real.sqrt_mul_self ha]; ring

--- a/src/data/proofs/jensen-inequality-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "jensen-inequality-oq-01",
+  "title": "The Equality Case of Strict Jensen, and the Sharp Weighted AM–GM Equality",
+  "slug": "jensen-inequality-oq-01",
+  "description": "Isolates the equality case of the finite weighted Jensen inequality for a strictly convex function — Jensen is an equality exactly when the data are constant — and specializes it, through the strict convexity of exp, to the sharp equality case of the weighted arithmetic–geometric mean inequality: the weighted geometric and arithmetic means of positive data coincide if and only if all the data are equal. The strict AM–GM gap is obtained directly from StrictConvexOn.map_sum_lt for exp, making the Jensen → AM–GM bridge explicit, and the classic two-variable instance √(ab) = (a+b)/2 ↔ a = b is proved from (√a − √b)² = 0.",
+  "meta": {
+    "author": "Lean Genius (Jensen → AM–GM packaging); Jensen, Hölder (classical theory)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "jensen-inequality",
+      "am-gm-inequality",
+      "inequalities",
+      "equality-case",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 124,
+    "originalContributions": [
+      "jensen_eq_iff: a clean entry-point restatement of the equality case of strict Jensen — for a strictly convex f, positive weights summing to 1, and points in the domain, f(∑ ω•p) = ∑ ω•f(p) holds iff every point equals the weighted center of mass (the data are constant)",
+      "weighted_amgm_eq_iff: the equality case of weighted AM–GM in symmetric form — ∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ ↔ ∀ j k ∈ s, z j = z k — obtained by converting the center-of-mass right side of Mathlib's geom_mean_eq_arith_mean_weighted_iff' into the 'all values equal' form",
+      "weighted_amgm_lt_of_ne: the STRICT weighted AM–GM gap, proved directly through strictConvexOn_exp.map_sum_lt — rewriting the geometric mean as exp(∑ w•log z) and the arithmetic mean as ∑ w•exp(log z) exhibits the Jensen → AM–GM bridge explicitly, with non-constant data forced from injectivity of log on the positives",
+      "weighted_amgm_le: the weighted AM–GM inequality ∏ zᵢ^{wᵢ} ≤ ∑ wᵢ zᵢ recorded as the companion of the equality case",
+      "amgm_two_eq_iff: the concrete two-variable instance √(ab) = (a+b)/2 ↔ a = b, with the forward direction the classic (√a − √b)² = 0"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Built entirely on Mathlib's convexity (Analysis.Convex.Jensen) and mean-inequality (Analysis.MeanInequalities) libraries plus the strict convexity of exp.",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "A sibling AM–GM entry. This entry supplies the sharp EQUALITY characterization (geometric mean = arithmetic mean iff all data equal) and the strict gap, deriving them from the convexity side via the equality case of Jensen."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Jensen's inequality (J. L. W. V. Jensen, 1906) states that for a convex function f and a probability-weighted family of points, f of the weighted average is at most the weighted average of f. When f is strictly convex the inequality is strict unless the points coincide — this is the equality case. Applying Jensen to the strictly convex exponential and reading off the result in terms of the original data is the standard route from convexity to the arithmetic–geometric mean inequality of Cauchy and its weighted (Hölder) refinement: the weighted geometric mean never exceeds the weighted arithmetic mean, with equality exactly when all the data agree. Mathlib formalizes both the abstract Jensen equality case (StrictConvexOn.map_sum_eq_iff) and the AM–GM equality case (Real.geom_mean_eq_arith_mean_weighted_iff'), the latter proved precisely by the exp specialization; this entry packages the bridge as a single self-contained development.",
+    "problemStatement": "Formalize the equality case of finite weighted Jensen for a strictly convex f — if the weights are strictly positive and sum to 1 and Jensen holds with equality, then all the points are equal — and specialize f = exp to obtain the sharp equality case of the weighted AM–GM inequality: ∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ if and only if all zᵢ are equal.",
+    "proofStrategy": "The abstract equality case is Mathlib's StrictConvexOn.map_sum_eq_iff, re-exported as jensen_eq_iff. For AM–GM, the weighted geometric mean ∏ zᵢ^{wᵢ} rewrites as exp(∑ wᵢ • log zᵢ) (via Real.rpow_def_of_pos and Real.exp_sum) and the weighted arithmetic mean ∑ wᵢ zᵢ as ∑ wᵢ • exp(log zᵢ) (via Real.exp_log). Strict convexity of exp (strictConvexOn_exp) then gives the strict gap whenever the logs — equivalently, by injectivity of log on the positive reals, the data — are non-constant (weighted_amgm_lt_of_ne). The equality characterization weighted_amgm_eq_iff restates Mathlib's geom_mean_eq_arith_mean_weighted_iff', converting its center-of-mass right side ∀ j, z j = ∑ w • z into the symmetric 'all equal' form by an elementary weighted-average computation. The two-variable case is the classic (√a − √b)² ≥ 0 with equality iff √a = √b iff a = b.",
+    "keyInsights": [
+      "The equality case of a strict inequality is a structural statement, not a numerical one: Jensen is tight exactly on constant families, and that single fact propagates through every convex-function specialization, including AM–GM.",
+      "Exponentiation is the dictionary between the additive (Jensen) and multiplicative (AM–GM) worlds: ∏ zᵢ^{wᵢ} = exp(∑ wᵢ log zᵢ) turns the weighted geometric mean into exp of a weighted average, so the convexity of exp on a non-constant log-family is exactly the strict AM–GM gap.",
+      "Non-constancy transfers cleanly: log is injective on (0, ∞), so the data being non-constant is equivalent to their logs being non-constant — the hypothesis StrictConvexOn.map_sum_lt actually needs.",
+      "Mathlib's own proof of the AM–GM equality case (geom_mean_eq_arith_mean_weighted_iff') is exactly this exp-Jensen specialization, so the bridge formalized here is not an alternative route but the canonical one, here surfaced as named, citeable lemmas.",
+      "The symmetric 'all values equal' form ∀ j k, z j = z k is interchangeable with the center-of-mass form ∀ j, z j = ∑ w z by a one-line weighted-average identity, and is the form most often quoted in applications."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "States the goal — isolate the equality case of strict Jensen and specialize it via exp to the sharp weighted AM–GM equality — and lists the five main results.",
+      "mathContext": "Jensen's inequality $f(\\sum_i w_i p_i) \\le \\sum_i w_i f(p_i)$ for convex $f$ becomes an equality, when $f$ is strictly convex and the $w_i>0$ sum to $1$, exactly when the $p_i$ are constant. Specializing $f=\\exp$, $p_i=\\log z_i$ yields the weighted AM–GM inequality and its equality case."
+    },
+    {
+      "id": "jensen",
+      "title": "The abstract equality case of strict Jensen",
+      "startLine": 48,
+      "endLine": 67,
+      "summary": "jensen_eq_iff re-exports StrictConvexOn.map_sum_eq_iff: strict Jensen is an equality iff every point equals the weighted center of mass.",
+      "mathContext": "For strictly convex $f$, weights $w_i>0$ with $\\sum w_i=1$: $f(\\sum_i w_i\\bullet p_i)=\\sum_i w_i\\bullet f(p_i)\\iff \\forall j,\\ p_j=\\sum_i w_i\\bullet p_i$. The right side says the family is constant (all equal to its mean)."
+    },
+    {
+      "id": "amgm",
+      "title": "Weighted AM–GM and its equality case",
+      "startLine": 68,
+      "endLine": 110,
+      "summary": "weighted_amgm_le gives the inequality; weighted_amgm_eq_iff characterizes equality as 'all values equal'; weighted_amgm_lt_of_ne derives the strict gap directly from strictConvexOn_exp.map_sum_lt, exhibiting the Jensen → AM–GM bridge.",
+      "mathContext": "$\\prod_i z_i^{w_i}\\le\\sum_i w_i z_i$ with equality iff all $z_i$ are equal. The strict version uses $\\prod_i z_i^{w_i}=\\exp(\\sum_i w_i\\log z_i)$ and $\\sum_i w_i z_i=\\sum_i w_i\\exp(\\log z_i)$, so strict convexity of $\\exp$ on a non-constant log-family forces a strict inequality."
+    },
+    {
+      "id": "two-var",
+      "title": "The two-variable instance",
+      "startLine": 111,
+      "endLine": 124,
+      "summary": "amgm_two_eq_iff: √(ab) = (a+b)/2 ↔ a = b for nonnegative reals, with the forward direction the classic (√a − √b)² = 0.",
+      "mathContext": "The $n=2$ unweighted case: $\\sqrt{ab}=\\tfrac{a+b}{2}\\iff a=b$. Writing $u=\\sqrt a$, $v=\\sqrt b$, equality reads $uv=\\tfrac{u^2+v^2}{2}$, i.e. $(u-v)^2=0$, so $u=v$ and $a=b$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 124-line file (0 sorries, 0 axioms, no native_decide) packages the equality case of strict Jensen and its specialization to the sharp weighted AM–GM equality. The headline characterization weighted_amgm_eq_iff states that the weighted geometric and arithmetic means of positive data coincide iff all the data are equal, and weighted_amgm_lt_of_ne derives the strict gap directly from the strict convexity of exp, making the Jensen → AM–GM bridge explicit. The classic two-variable instance √(ab) = (a+b)/2 ↔ a = b is included as a concrete corollary.",
+    "implications": "Equality characterizations are what make mean inequalities usable in optimization and probability: knowing AM–GM is tight exactly on constant data turns a bound into a rigidity statement (e.g. extremizers of geometric-vs-arithmetic-mean ratios are forced to be balanced). Recording the convexity bridge as named lemmas — jensen_eq_iff, weighted_amgm_eq_iff, weighted_amgm_lt_of_ne — makes the standard 'apply exp-Jensen' argument reusable for the other classical inequalities (Hölder, Young) that descend from convexity.",
+    "openQuestions": [
+      "Specialize the same exp-Jensen bridge to Young's inequality and Hölder's inequality, recording their equality cases in the same named-lemma style.",
+      "State the weighted power-mean inequality M_p ≤ M_q and its equality case (all data equal) as a uniform family in p ≤ q, again via convexity of the relevant power map.",
+      "Generalize amgm_two_eq_iff to the unweighted n-variable geometric/arithmetic mean equality case as a direct corollary of weighted_amgm_eq_iff with uniform weights 1/n."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 124,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 5,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01.json
+++ b/src/data/research/problems/jensen-inequality-oq-01.json
@@ -1,0 +1,68 @@
+{
+  "slug": "jensen-inequality-oq-01",
+  "title": "The Equality Case of Strict Jensen, and the Sharp Weighted AM–GM Equality",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\prod_{i\\in s} z_i^{w_i} = \\sum_{i\\in s} w_i z_i \\iff \\forall j,k\\in s,\\ z_j = z_k",
+    "plain": "Formalize the equality case of finite weighted Jensen for a strictly convex f (Jensen is an equality iff the data are constant), then specialize f = exp to the sharp equality case of the weighted arithmetic–geometric mean inequality: the weighted geometric and arithmetic means of positive data coincide if and only if all the data are equal.",
+    "whyMatters": [
+      "Equality cases turn mean inequalities into rigidity statements usable in optimization and probability",
+      "Records the canonical convexity → AM–GM bridge (apply exp-Jensen) as named, reusable lemmas"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T12:30:00-07:00",
+    "iteration": 1,
+    "focus": "Isolate the equality case of strict Jensen and specialize it via exp to the sharp weighted AM–GM equality.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): packaged the equality case of strict Jensen and its exp-specialization to weighted AM–GM, 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01.lean (124L, 5 thm). jensen_eq_iff re-exports StrictConvexOn.map_sum_eq_iff; weighted_amgm_le re-exports geom_mean_le_arith_mean_weighted; weighted_amgm_eq_iff converts geom_mean_eq_arith_mean_weighted_iff' (center-of-mass right side) to symmetric 'all equal' form; weighted_amgm_lt_of_ne derives the strict gap DIRECTLY through strictConvexOn_exp.map_sum_lt by rewriting ∏ z^w = exp(∑ w•log z) and ∑ w z = ∑ w•exp(log z) (Real.rpow_def_of_pos, Real.exp_sum, Real.exp_log), with non-constant logs from Real.log_injOn_pos; amgm_two_eq_iff proves √(ab)=(a+b)/2 ↔ a=b via (√a−√b)²=0.",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01.lean: jensen_eq_iff (abstract Jensen equality case, re-export)",
+      "weighted_amgm_le (weighted AM–GM inequality), weighted_amgm_eq_iff (equality iff all data equal)",
+      "weighted_amgm_lt_of_ne (strict gap via strictConvexOn_exp.map_sum_lt — the explicit Jensen → AM–GM bridge)",
+      "amgm_two_eq_iff (two-variable instance √(ab) = (a+b)/2 ↔ a = b)",
+      "src/data/proofs/jensen-inequality-oq-01/ gallery entry"
+    ],
+    "insights": [
+      "Exponentiation is the dictionary between additive Jensen and multiplicative AM–GM: ∏ zᵢ^{wᵢ} = exp(∑ wᵢ log zᵢ) turns the weighted geometric mean into exp of a weighted average, so convexity of exp on a non-constant log-family is exactly the strict AM–GM gap",
+      "Non-constancy transfers cleanly through log: it is injective on (0,∞), so non-constant data ⟺ non-constant logs, which is the hypothesis StrictConvexOn.map_sum_lt needs",
+      "Mathlib's own proof of geom_mean_eq_arith_mean_weighted_iff' IS this exp-Jensen specialization, so the bridge here is the canonical route surfaced as named lemmas, not an alternative",
+      "The symmetric 'all values equal' form ∀ j k, z j = z k is interchangeable with the center-of-mass form ∀ j, z j = ∑ w z by a one-line weighted-average identity, and is the form most often quoted"
+    ],
+    "mathlibGaps": [
+      "Mathlib already has both the abstract Jensen equality case (StrictConvexOn.map_sum_eq_iff) and the AM–GM equality case (Real.geom_mean_eq_arith_mean_weighted_iff'); the contribution here is packaging the bridge as named lemmas and the symmetric 'all equal' restatement, plus a direct strictConvexOn_exp.map_sum_lt derivation of the strict gap"
+    ],
+    "nextSteps": [
+      "Specialize the same exp-Jensen bridge to Young's and Hölder's inequalities, recording their equality cases in matching style",
+      "State the weighted power-mean inequality M_p ≤ M_q and its equality case as a uniform family in p ≤ q",
+      "Derive the unweighted n-variable AM–GM equality case from weighted_amgm_eq_iff with uniform weights 1/n"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01\n\n## Problem Understanding\n\nIsolate the equality case of finite weighted Jensen for a strictly convex f, and specialize f = exp to obtain the sharp equality case of the weighted AM–GM inequality.\n\n## Insights\n\nThe weighted geometric mean is exp of a weighted average of logs, so the strict convexity of exp on a non-constant log-family is exactly the strict AM–GM gap. log is injective on the positive reals, so non-constant data is equivalent to non-constant logs. Mathlib's proof of the AM–GM equality case is itself this exp-Jensen specialization; the contribution is to surface the bridge as named, citeable lemmas and to restate equality in the symmetric 'all values equal' form.\n\n## Dead Ends\n\nNone — the build succeeded on the first attempt.\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "jensen-inequality",
+    "am-gm-inequality",
+    "inequalities",
+    "equality-case",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Isolates the **equality case of finite weighted Jensen** for a strictly convex function and specializes it, through the strict convexity of `exp`, to the **sharp equality case of weighted AM–GM**: the weighted geometric and arithmetic means of positive data coincide **iff all the data are equal**.

`Proofs/JensenInequalityOQ01.lean` — **124 lines, 5 theorems, 0 sorries, 0 axioms, no `native_decide`** (axioms: `propext`/`Classical.choice`/`Quot.sound` only). Builds cleanly via `docker-build.sh Proofs.JensenInequalityOQ01` (first try).

## Results

- **`jensen_eq_iff`** — abstract equality case of strict Jensen (clean re-export of `StrictConvexOn.map_sum_eq_iff`): `f(∑ ω•p) = ∑ ω•f(p) ↔ every point equals the weighted center of mass`.
- **`weighted_amgm_le`** — the weighted AM–GM inequality `∏ zᵢ^{wᵢ} ≤ ∑ wᵢ zᵢ`.
- **`weighted_amgm_eq_iff`** — equality `∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ ↔ ∀ j k ∈ s, z j = z k` (symmetric "all equal" form, converted from Mathlib's center-of-mass form).
- **`weighted_amgm_lt_of_ne`** — the **strict** gap, derived directly through `strictConvexOn_exp.map_sum_lt`: rewriting `∏ zᵢ^{wᵢ} = exp(∑ wᵢ•log zᵢ)` and `∑ wᵢ zᵢ = ∑ wᵢ•exp(log zᵢ)` exhibits the Jensen → AM–GM bridge explicitly, with non-constant data forced from `Real.log_injOn_pos`.
- **`amgm_two_eq_iff`** — the classic two-variable instance `√(ab) = (a+b)/2 ↔ a = b` via `(√a − √b)² = 0`.

## Context

Mathlib already contains both the abstract Jensen equality case (`StrictConvexOn.map_sum_eq_iff`) and the AM–GM equality case (`Real.geom_mean_eq_arith_mean_weighted_iff'`) — and the latter is proved by *exactly* this `exp`-Jensen specialization. This entry surfaces that canonical bridge as named, citeable lemmas, adds the symmetric "all values equal" restatement, and supplies a direct `strictConvexOn_exp.map_sum_lt` derivation of the strict inequality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)