### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01): general n-variable Young product inequality + equality case [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2909,6 +2909,7 @@ import Proofs.IsoscelesTriangleOQ01
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
 import Proofs.JensenInequalityOQ01
+import Proofs.JensenInequalityOQ01OQ01
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2908,6 +2908,7 @@ import Proofs.IsoscelesTriangleOQ02
 import Proofs.IsoscelesTriangleOQ01
 import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
+import Proofs.JensenInequalityOQ01
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs/JensenInequalityOQ01.lean
+++ b/proofs/Proofs/JensenInequalityOQ01.lean
@@ -1,0 +1,124 @@
+/-
+# The Equality Case of Strict Jensen, and the Sharp Weighted AM–GM Equality
+
+This file isolates the **equality case** of the finite weighted Jensen inequality for a
+*strictly* convex function, and specializes it — through the strict convexity of `exp` — to the
+sharp equality case of the **weighted arithmetic–geometric mean inequality**.
+
+The abstract input is Mathlib's `StrictConvexOn.map_sum_eq_iff`: for a strictly convex `f`,
+strictly positive weights `w` summing to `1`, and points `p i` in the domain,
+
+    f (∑ i, w i • p i) = ∑ i, w i • f (p i)   ↔   the points `p i` are all (equal to their mean).
+
+Specializing `f = exp` and `p i = log (z i)` turns Jensen's inequality into weighted AM–GM, and the
+equality case into the statement that geometric and arithmetic means coincide **iff all the data
+are equal**. This is precisely the route by which Mathlib establishes
+`Real.geom_mean_eq_arith_mean_weighted_iff'`; here we package the bridge explicitly and supply the
+strict inequality directly from `StrictConvexOn.map_sum_lt`, together with the familiar
+two-variable instance `√(ab) = (a+b)/2 ↔ a = b`.
+
+## Main results
+
+* `jensen_eq_iff` — the abstract equality case of strict Jensen (a clean re-export).
+* `weighted_amgm_le` — the weighted AM–GM inequality `∏ zᵢ^{wᵢ} ≤ ∑ wᵢ zᵢ`.
+* `weighted_amgm_eq_iff` — equality `∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ` holds **iff** all `zᵢ` are equal.
+* `weighted_amgm_lt_of_ne` — if some two values differ, the inequality is strict; proved directly
+  through `strictConvexOn_exp.map_sum_lt`, making the Jensen → AM–GM bridge explicit.
+* `amgm_two_eq_iff` — the concrete two-variable equality case `√(ab) = (a+b)/2 ↔ a = b`.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+
+open Finset Real
+
+variable {ι : Type*} {s : Finset ι} {w z : ι → ℝ}
+
+/-! ## The abstract equality case of strict Jensen -/
+
+/-- **Equality case of strict Jensen's inequality.**
+
+For a strictly convex `f`, strictly positive weights `ω` summing to `1`, and points `p i` in the
+domain `S`, Jensen's inequality `f(∑ ω • p) ≤ ∑ ω • f(p)` is an *equality* exactly when every point
+equals the (weighted) center of mass — i.e. the data are constant. This is a clean re-export of
+Mathlib's `StrictConvexOn.map_sum_eq_iff`, recorded here as the foundation for the AM–GM corollary
+below. -/
+theorem jensen_eq_iff {f : ℝ → ℝ} {S : Set ℝ} {t : Finset ι} {ω : ι → ℝ} {p : ι → ℝ}
+    (hf : StrictConvexOn ℝ S f) (h₀ : ∀ i ∈ t, 0 < ω i) (h₁ : ∑ i ∈ t, ω i = 1)
+    (hmem : ∀ i ∈ t, p i ∈ S) :
+    f (∑ i ∈ t, ω i • p i) = ∑ i ∈ t, ω i • f (p i) ↔ ∀ j ∈ t, p j = ∑ i ∈ t, ω i • p i :=
+  hf.map_sum_eq_iff h₀ h₁ hmem
+
+/-! ## Weighted AM–GM and its equality case -/
+
+/-- **Weighted arithmetic–geometric mean inequality.** For nonnegative weights summing to `1` and
+nonnegative data, the weighted geometric mean is at most the weighted arithmetic mean. -/
+theorem weighted_amgm_le (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i ≤ ∑ i ∈ s, w i * z i :=
+  Real.geom_mean_le_arith_mean_weighted s w z hw hw' hz
+
+/-- **Equality case of weighted AM–GM.** With *strictly positive* weights summing to `1` and
+nonnegative data, the weighted geometric and arithmetic means coincide **iff all the data are
+equal**.
+
+This restates Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'` (whose center-of-mass right
+side `∀ j, z j = ∑ w • z` we convert to the symmetric "all equal" form), the latter itself being a
+specialization of `strictConvexOn_exp.map_sum_eq_iff`. -/
+theorem weighted_amgm_eq_iff (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 ≤ z i) :
+    ∏ i ∈ s, z i ^ w i = ∑ i ∈ s, w i * z i ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  rw [Real.geom_mean_eq_arith_mean_weighted_iff' s w z hw hw' hz]
+  constructor
+  · intro h j hj k hk; rw [h j hj, h k hk]
+  · intro h j hj
+    calc z j = ∑ i ∈ s, w i * z j := by rw [← Finset.sum_mul, hw', one_mul]
+      _ = ∑ i ∈ s, w i * z i := Finset.sum_congr rfl fun i hi => by rw [h i hi j hj]
+
+/-- **Strict weighted AM–GM.** With strictly positive weights summing to `1` and strictly positive
+data, if two of the values differ then the weighted geometric mean is *strictly* less than the
+weighted arithmetic mean.
+
+The proof goes directly through the strict Jensen inequality `StrictConvexOn.map_sum_lt` for
+`exp`: writing `z i = exp (log (z i))`, the geometric mean is `exp (∑ w • log z)` and the arithmetic
+mean is `∑ w • exp (log z)`, so strict convexity of `exp` on a non-constant family gives the strict
+gap. This is the explicit Jensen → AM–GM bridge. -/
+theorem weighted_amgm_lt_of_ne (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i) (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    ∏ i ∈ s, z i ^ w i < ∑ i ∈ s, w i * z i := by
+  -- The geometric mean rewrites as `exp` of the weighted mean of the logs.
+  have hgeo : Real.exp (∑ i ∈ s, w i • Real.log (z i)) = ∏ i ∈ s, z i ^ w i := by
+    rw [Real.exp_sum]
+    refine Finset.prod_congr rfl fun i hi => ?_
+    rw [smul_eq_mul, Real.rpow_def_of_pos (hz i hi), mul_comm]
+  -- The arithmetic mean rewrites as the weighted mean of `exp (log (z i)) = z i`.
+  have harith : ∑ i ∈ s, w i • Real.exp (Real.log (z i)) = ∑ i ∈ s, w i * z i := by
+    refine Finset.sum_congr rfl fun i hi => ?_
+    rw [smul_eq_mul, Real.exp_log (hz i hi)]
+  -- Non-constant data ⇒ non-constant logs, by injectivity of `log` on the positives.
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  have hlog : ∃ j ∈ s, ∃ k ∈ s, Real.log (z j) ≠ Real.log (z k) :=
+    ⟨j, hj, k, hk, fun h =>
+      hjk (Real.log_injOn_pos (Set.mem_Ioi.mpr (hz j hj)) (Set.mem_Ioi.mpr (hz k hk)) h)⟩
+  have hlt := strictConvexOn_exp.map_sum_lt hw hw' (fun i _ => Set.mem_univ (Real.log (z i))) hlog
+  rwa [hgeo, harith] at hlt
+
+/-! ## The two-variable instance -/
+
+/-- **Two-variable AM–GM equality case.** For nonnegative reals, the geometric mean `√(ab)` equals
+the arithmetic mean `(a+b)/2` exactly when `a = b`. The forward direction is the classic
+`(√a − √b)² = 0`. -/
+theorem amgm_two_eq_iff {a b : ℝ} (ha : 0 ≤ a) (hb : 0 ≤ b) :
+    Real.sqrt (a * b) = (a + b) / 2 ↔ a = b := by
+  constructor
+  · intro h
+    have hab : Real.sqrt a * Real.sqrt b = (a + b) / 2 := by rw [← Real.sqrt_mul ha]; exact h
+    have hu : Real.sqrt a ^ 2 = a := Real.sq_sqrt ha
+    have hv : Real.sqrt b ^ 2 = b := Real.sq_sqrt hb
+    have key : (Real.sqrt a - Real.sqrt b) ^ 2 = 0 := by nlinarith [hu, hv, hab]
+    have huv : Real.sqrt a = Real.sqrt b :=
+      sub_eq_zero.mp (pow_eq_zero_iff (n := 2) (by norm_num) |>.mp key)
+    rw [← Real.sq_sqrt ha, ← Real.sq_sqrt hb, huv]
+  · rintro rfl
+    rw [Real.sqrt_mul_self ha]; ring

--- a/proofs/Proofs/JensenInequalityOQ01OQ01.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01.lean
@@ -1,0 +1,89 @@
+/-
+# Young's Inequality and its Equality Case, from Weighted AM–GM
+
+Young's inequality states that for Hölder-conjugate exponents `p, q` (so `1/p + 1/q = 1`,
+`p, q > 1`) and nonnegative reals `a, b`,
+
+    a * b ≤ aᵖ / p + bᵍ / q,
+
+with **equality exactly when `aᵖ = bᵍ`**. Mathlib provides the inequality
+(`Real.young_inequality_of_nonneg`) but not its equality case; this file supplies it.
+
+The whole statement is the two-term weighted arithmetic–geometric mean inequality in disguise:
+taking weights `wₓ = 1/p`, `w_y = 1/q` (which sum to `1`) and data `x = aᵖ`, `y = bᵍ`, the weighted
+geometric mean `x^{wₓ} · y^{w_y} = (aᵖ)^{1/p} · (bᵍ)^{1/q} = a · b` and the weighted arithmetic
+mean `wₓ x + w_y y = aᵖ/p + bᵍ/q`. So Young's inequality, and its equality case, are exactly the
+two-variable weighted AM–GM and *its* equality case — which we obtain from the parent file's
+`weighted_amgm_eq_iff`.
+
+## Main results
+
+* `amgm_two_weighted_eq_iff` — the two-variable weighted AM–GM equality case
+  `x^{wₓ} y^{w_y} = wₓ x + w_y y ↔ x = y`, specialized from `weighted_amgm_eq_iff`.
+* `young_le` — Young's inequality `a b ≤ aᵖ/p + bᵍ/q` (re-export).
+* `young_eq_iff` — **Young's equality case**: `a b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ`.
+* `young_lt_of_ne` — the strict form when `aᵖ ≠ bᵍ`.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.JensenInequalityOQ01
+
+open Finset Real
+
+/-- The **two-variable weighted AM–GM equality case**: for strictly positive weights `wₓ, w_y`
+summing to `1` and nonnegative data `x, y`, the weighted geometric mean equals the weighted
+arithmetic mean exactly when `x = y`. This is `weighted_amgm_eq_iff` (parent file) on a two-element
+index set. -/
+theorem amgm_two_weighted_eq_iff {wx wy x y : ℝ} (hwx : 0 < wx) (hwy : 0 < wy)
+    (hw : wx + wy = 1) (hx : 0 ≤ x) (hy : 0 ≤ y) :
+    x ^ wx * y ^ wy = wx * x + wy * y ↔ x = y := by
+  have hwsum : ∑ i ∈ (Finset.univ : Finset (Fin 2)), ![wx, wy] i = 1 := by
+    rw [Fin.sum_univ_two]; exact hw
+  have hwpos : ∀ i ∈ (Finset.univ : Finset (Fin 2)), 0 < ![wx, wy] i := by
+    intro i _; fin_cases i
+    · simpa using hwx
+    · simpa using hwy
+  have hznn : ∀ i ∈ (Finset.univ : Finset (Fin 2)), 0 ≤ ![x, y] i := by
+    intro i _; fin_cases i
+    · simpa using hx
+    · simpa using hy
+  have key := weighted_amgm_eq_iff hwpos hwsum hznn
+  rw [Fin.prod_univ_two, Fin.sum_univ_two] at key
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one] at key
+  rw [key]
+  constructor
+  · intro h; simpa using h 0 (Finset.mem_univ _) 1 (Finset.mem_univ _)
+  · intro h j _ k _; fin_cases j <;> fin_cases k <;> simp [h]
+
+/-- **Young's inequality** for nonnegative reals (re-export of `Real.young_inequality_of_nonneg`). -/
+theorem young_le {a b p q : ℝ} (hpq : p.HolderConjugate q) (ha : 0 ≤ a) (hb : 0 ≤ b) :
+    a * b ≤ a ^ p / p + b ^ q / q :=
+  Real.young_inequality_of_nonneg ha hb hpq
+
+/-- **Equality case of Young's inequality.** For Hölder-conjugate exponents `p, q` and nonnegative
+`a, b`, Young's inequality `a b ≤ aᵖ/p + bᵍ/q` is an equality if and only if `aᵖ = bᵍ`.
+
+The proof applies the two-variable weighted AM–GM equality case with weights `1/p, 1/q` and data
+`aᵖ, bᵍ`, using `(aᵖ)^{1/p} = a` (and likewise for `b`). -/
+theorem young_eq_iff {a b p q : ℝ} (hpq : p.HolderConjugate q) (ha : 0 ≤ a) (hb : 0 ≤ b) :
+    a * b = a ^ p / p + b ^ q / q ↔ a ^ p = b ^ q := by
+  have hp : 0 < p := hpq.pos
+  have hq : 0 < q := hpq.symm.pos
+  have hinv : p⁻¹ + q⁻¹ = 1 := (Real.holderConjugate_iff.mp hpq).2
+  have hxa : (a ^ p) ^ p⁻¹ = a := by
+    rw [← Real.rpow_mul ha, mul_inv_cancel₀ hp.ne', Real.rpow_one]
+  have hxb : (b ^ q) ^ q⁻¹ = b := by
+    rw [← Real.rpow_mul hb, mul_inv_cancel₀ hq.ne', Real.rpow_one]
+  have key := amgm_two_weighted_eq_iff (inv_pos.mpr hp) (inv_pos.mpr hq) hinv
+    (Real.rpow_nonneg ha p) (Real.rpow_nonneg hb q)
+  rw [hxa, hxb] at key
+  rw [show a ^ p / p + b ^ q / q = p⁻¹ * a ^ p + q⁻¹ * b ^ q from by ring]
+  exact key
+
+/-- **Strict Young's inequality.** When `aᵖ ≠ bᵍ`, Young's inequality is strict. -/
+theorem young_lt_of_ne {a b p q : ℝ} (hpq : p.HolderConjugate q) (ha : 0 ≤ a) (hb : 0 ≤ b)
+    (hne : a ^ p ≠ b ^ q) :
+    a * b < a ^ p / p + b ^ q / q :=
+  lt_of_le_of_ne (young_le hpq ha hb) fun h => hne ((young_eq_iff hpq ha hb).mp h)

--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01.lean
@@ -1,0 +1,95 @@
+/-
+# The General n-Variable Young Product Inequality and its Equality Case
+
+The two-term Young inequality (parent file `JensenInequalityOQ01OQ01`) reads, for Hölder-conjugate
+exponents `p, q` (so `1/p + 1/q = 1`) and nonnegative reals `a, b`,
+
+    a * b ≤ aᵖ/p + bᵍ/q,   with equality iff aᵖ = bᵍ.
+
+This file proves the **`n`-variable generalization**: given a finite family of exponents
+`p i > 0` whose reciprocals sum to `1` (i.e. `∑ 1/pᵢ = 1`) and nonnegative data `a i`,
+
+    ∏ᵢ aᵢ ≤ ∑ᵢ aᵢ^{pᵢ}/pᵢ,   with equality iff all the `aᵢ^{pᵢ}` are equal.
+
+This is to the two-variable Young inequality exactly what the parent's general weighted AM–GM
+(`weighted_amgm_eq_iff`) is to its two-variable instance: take weights `wᵢ = 1/pᵢ` (strictly
+positive, summing to `1`) and data `zᵢ = aᵢ^{pᵢ}`. Then the weighted geometric mean
+`∏ᵢ zᵢ^{wᵢ} = ∏ᵢ (aᵢ^{pᵢ})^{1/pᵢ} = ∏ᵢ aᵢ` and the weighted arithmetic mean
+`∑ᵢ wᵢ zᵢ = ∑ᵢ aᵢ^{pᵢ}/pᵢ`, so the general AM–GM inequality and *its* equality case are exactly the
+general Young product inequality and its equality case.
+
+Mathlib provides the two-variable Young inequality (`Real.young_inequality_of_nonneg`) but not the
+`n`-variable product form, nor any of the equality cases; this file supplies all of them.
+
+## Main results
+
+* `young_prod_le` — the `n`-variable Young product inequality `∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ`.
+* `young_prod_eq_iff` — its **equality case**: equality holds iff all the `aᵢ^{pᵢ}` are equal.
+* `young_prod_lt_of_ne` — the strict form when two of the `aᵢ^{pᵢ}` differ.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+import Proofs.JensenInequalityOQ01
+import Proofs.JensenInequalityOQ01OQ01
+
+open Finset Real
+
+variable {ι : Type*} {s : Finset ι} {p a : ι → ℝ}
+
+/-- For nonnegative `a` and nonzero exponent `p`, `(a^p)^{1/p} = a`. This is the pointwise identity
+that turns the weighted geometric mean of the `aᵢ^{pᵢ}` (with weights `1/pᵢ`) into the plain product
+`∏ aᵢ`. -/
+private theorem rpow_pow_inv {a p : ℝ} (ha : 0 ≤ a) (hp : p ≠ 0) : (a ^ p) ^ p⁻¹ = a := by
+  rw [← Real.rpow_mul ha, mul_inv_cancel₀ hp, Real.rpow_one]
+
+/-- **The `n`-variable Young product inequality.** For strictly positive exponents `p i` whose
+reciprocals sum to `1` and nonnegative data `a i`, the product `∏ aᵢ` is at most the sum
+`∑ aᵢ^{pᵢ}/pᵢ`.
+
+The proof specializes the parent's weighted AM–GM inequality `weighted_amgm_le` with weights
+`wᵢ = 1/pᵢ` and data `zᵢ = aᵢ^{pᵢ}`: the geometric mean `∏ (aᵢ^{pᵢ})^{1/pᵢ}` collapses to `∏ aᵢ`,
+and the arithmetic mean `∑ (1/pᵢ) aᵢ^{pᵢ}` is `∑ aᵢ^{pᵢ}/pᵢ`. -/
+theorem young_prod_le (hp : ∀ i ∈ s, 0 < p i) (hp' : ∑ i ∈ s, (p i)⁻¹ = 1)
+    (ha : ∀ i ∈ s, 0 ≤ a i) :
+    ∏ i ∈ s, a i ≤ ∑ i ∈ s, a i ^ p i / p i := by
+  have key := weighted_amgm_le (w := fun i => (p i)⁻¹) (z := fun i => a i ^ p i)
+    (fun i hi => le_of_lt (inv_pos.mpr (hp i hi))) hp'
+    (fun i hi => Real.rpow_nonneg (ha i hi) (p i))
+  -- Geometric mean collapses to the plain product.
+  have hgeo : ∏ i ∈ s, (a i ^ p i) ^ (p i)⁻¹ = ∏ i ∈ s, a i :=
+    Finset.prod_congr rfl fun i hi => rpow_pow_inv (ha i hi) (hp i hi).ne'
+  -- Arithmetic mean is the Young sum.
+  have harith : ∑ i ∈ s, (p i)⁻¹ * a i ^ p i = ∑ i ∈ s, a i ^ p i / p i :=
+    Finset.sum_congr rfl fun i _ => by rw [div_eq_inv_mul]
+  rw [hgeo, harith] at key
+  exact key
+
+/-- **Equality case of the `n`-variable Young product inequality.** Under the same hypotheses,
+`∏ aᵢ = ∑ aᵢ^{pᵢ}/pᵢ` holds **iff all the `aᵢ^{pᵢ}` are equal**.
+
+The proof applies the parent's weighted AM–GM equality case `weighted_amgm_eq_iff` with weights
+`wᵢ = 1/pᵢ` and data `zᵢ = aᵢ^{pᵢ}`, then rewrites both means as above. For `n = 2` with
+`p i ∈ {p, q}` Hölder-conjugate this recovers the two-variable `young_eq_iff` of the parent file. -/
+theorem young_prod_eq_iff (hp : ∀ i ∈ s, 0 < p i) (hp' : ∑ i ∈ s, (p i)⁻¹ = 1)
+    (ha : ∀ i ∈ s, 0 ≤ a i) :
+    ∏ i ∈ s, a i = ∑ i ∈ s, a i ^ p i / p i ↔ ∀ j ∈ s, ∀ k ∈ s, a j ^ p j = a k ^ p k := by
+  have key := weighted_amgm_eq_iff (w := fun i => (p i)⁻¹) (z := fun i => a i ^ p i)
+    (fun i hi => inv_pos.mpr (hp i hi)) hp'
+    (fun i hi => Real.rpow_nonneg (ha i hi) (p i))
+  have hgeo : ∏ i ∈ s, (a i ^ p i) ^ (p i)⁻¹ = ∏ i ∈ s, a i :=
+    Finset.prod_congr rfl fun i hi => rpow_pow_inv (ha i hi) (hp i hi).ne'
+  have harith : ∑ i ∈ s, (p i)⁻¹ * a i ^ p i = ∑ i ∈ s, a i ^ p i / p i :=
+    Finset.sum_congr rfl fun i _ => by rw [div_eq_inv_mul]
+  rw [hgeo, harith] at key
+  exact key
+
+/-- **Strict `n`-variable Young product inequality.** If two of the values `aᵢ^{pᵢ}` differ, the
+product is *strictly* less than the Young sum. -/
+theorem young_prod_lt_of_ne (hp : ∀ i ∈ s, 0 < p i) (hp' : ∑ i ∈ s, (p i)⁻¹ = 1)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hne : ∃ j ∈ s, ∃ k ∈ s, a j ^ p j ≠ a k ^ p k) :
+    ∏ i ∈ s, a i < ∑ i ∈ s, a i ^ p i / p i := by
+  refine lt_of_le_of_ne (young_prod_le hp hp' ha) fun h => ?_
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  exact hjk ((young_prod_eq_iff hp hp' ha).mp h j hj k hk)

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,108 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01",
+  "title": "The General n-Variable Young Product Inequality and its Equality Case",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01",
+  "description": "Generalizes the two-variable Young inequality to an arbitrary finite family of exponents: for strictly positive p i whose reciprocals sum to 1 (∑ 1/pᵢ = 1) and nonnegative data a i, the product ∏ aᵢ is bounded by the Young sum ∑ aᵢ^{pᵢ}/pᵢ, with equality if and only if all the aᵢ^{pᵢ} are equal. This stands to the parent entry's two-variable Young inequality exactly as the grandparent's general weighted AM–GM stands to its two-variable instance: take weights wᵢ = 1/pᵢ and data zᵢ = aᵢ^{pᵢ}, so the weighted geometric mean ∏ (aᵢ^{pᵢ})^{1/pᵢ} collapses to ∏ aᵢ and the weighted arithmetic mean ∑ (1/pᵢ)·aᵢ^{pᵢ} is the Young sum. Mathlib supplies only the two-variable Young inequality and none of the equality cases; this entry adds the full n-variable form. It directly answers the parent entry's listed open question on the n-fold generalized Young / weighted AM–GM equality case.",
+  "meta": {
+    "author": "Lean Genius (n-variable Young product inequality via weighted AM–GM); W. H. Young (1912)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "young-inequality",
+      "am-gm-inequality",
+      "holder-conjugate",
+      "inequalities",
+      "equality-case",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 95,
+    "originalContributions": [
+      "young_prod_eq_iff: the EQUALITY CASE of the n-variable Young product inequality, absent from Mathlib — ∏ aᵢ = ∑ aᵢ^{pᵢ}/pᵢ ↔ all aᵢ^{pᵢ} equal — obtained by applying the grandparent's general weighted AM–GM equality case weighted_amgm_eq_iff with weights 1/pᵢ and data aᵢ^{pᵢ}",
+      "young_prod_le: the n-variable Young product inequality ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ for ∑ 1/pᵢ = 1, generalizing the two-variable Real.young_inequality_of_nonneg, via the grandparent's weighted_amgm_le",
+      "young_prod_lt_of_ne: the strict form when two of the aᵢ^{pᵢ} differ, as lt_of_le_of_ne against the equality case",
+      "rpow_pow_inv: the pointwise identity (aᵖ)^{1/p} = a for a ≥ 0, p ≠ 0 (Real.rpow_mul with p·p⁻¹ = 1) that telescopes the weighted geometric mean ∏ (aᵢ^{pᵢ})^{1/pᵢ} to the plain product ∏ aᵢ"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Imports the parent file Proofs/JensenInequalityOQ01OQ01.lean and grandparent Proofs/JensenInequalityOQ01.lean to reuse weighted_amgm_le and weighted_amgm_eq_iff.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the two-variable Young inequality a·b ≤ aᵖ/p + bᵍ/q and its equality case aᵖ = bᵍ. This entry generalizes both to an arbitrary finite family of exponents with ∑ 1/pᵢ = 1, recovering the parent as the n = 2 Hölder-conjugate case. It answers the parent's listed open question on the n-fold generalized Young equality case."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "uses",
+      "description": "Applies the grandparent's general weighted AM–GM inequality weighted_amgm_le and its equality case weighted_amgm_eq_iff (geometric mean = arithmetic mean iff all data equal) with weights 1/pᵢ and data aᵢ^{pᵢ}."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Young's inequality (W. H. Young, 1912), a·b ≤ aᵖ/p + bᵍ/q for Hölder-conjugate p, q, is the pointwise engine behind Hölder's inequality. Its multi-exponent generalization — for any p₁,…,pₙ > 1 with ∑ 1/pᵢ = 1 one has ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ — underlies the generalized Hölder inequality for products of n functions. Both the n-variable inequality and its equality case (all aᵢ^{pᵢ} equal) are instances of the weighted arithmetic–geometric mean inequality; Mathlib formalizes only the two-variable Young inequality, so this entry adds the general product form together with its sharp equality characterization.",
+    "problemStatement": "Mathlib provides only the two-variable Young inequality. Prove the n-variable product form: for strictly positive exponents p i with ∑ 1/pᵢ = 1 and nonnegative data a i, ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ, with equality if and only if all the aᵢ^{pᵢ} are equal.",
+    "proofStrategy": "The n-variable Young product inequality is the general weighted AM–GM inequality in disguise. With weights wᵢ = 1/pᵢ (strictly positive, summing to 1) and data zᵢ = aᵢ^{pᵢ} (nonnegative), the weighted geometric mean ∏ zᵢ^{wᵢ} = ∏ (aᵢ^{pᵢ})^{1/pᵢ} telescopes to ∏ aᵢ — because (aᵢ^{pᵢ})^{1/pᵢ} = aᵢ^{pᵢ·pᵢ⁻¹} = aᵢ (Real.rpow_mul, pᵢ·pᵢ⁻¹ = 1) — and the weighted arithmetic mean ∑ wᵢ zᵢ = ∑ aᵢ^{pᵢ}/pᵢ. The grandparent's weighted_amgm_le then gives the inequality and weighted_amgm_eq_iff gives equality iff all the zᵢ = aᵢ^{pᵢ} are equal. The strict form follows as lt_of_le_of_ne. Specializing to a two-element index set with Hölder-conjugate p, q recovers the parent's young_eq_iff.",
+    "keyInsights": [
+      "The n-variable Young product inequality requires no new convexity argument: it is the general weighted AM–GM with weights 1/pᵢ on data aᵢ^{pᵢ}, so the inequality and its equality case descend wholesale from the grandparent's weighted AM–GM and its equality characterization.",
+      "The exponent bookkeeping is the entire trick: choosing data aᵢ^{pᵢ} makes the weighted geometric mean telescope, since raising aᵢ^{pᵢ} to the reciprocal power 1/pᵢ inverts the pᵢ-th power, (aᵢ^{pᵢ})^{1/pᵢ} = aᵢ.",
+      "The generalized Hölder-conjugacy condition ∑ 1/pᵢ = 1 is exactly the 'weights sum to 1' hypothesis of weighted AM–GM, so n conjugate exponents are precisely n probability weights.",
+      "The equality case is the structurally informative content: it pins the extremizers — equality forces all aᵢ^{pᵢ} equal — which is what makes the bound usable as a rigidity tool for the generalized Hölder inequality.",
+      "Working over a general Finset index set rather than Fin 2 makes the parent's two-variable Young the n = 2 special case, demonstrating depth-over-breadth: one general statement subsumes the prior entry."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Frames the n-variable Young product inequality as the general weighted AM–GM, notes Mathlib has only the two-variable Young inequality and none of the equality cases, and lists the three main results.",
+      "mathContext": "For $p_i>0$ with $\\sum 1/p_i=1$ and $a_i\\ge0$: $\\prod_i a_i \\le \\sum_i a_i^{p_i}/p_i$, equality iff all $a_i^{p_i}$ equal. Weights $w_i=1/p_i$, data $z_i=a_i^{p_i}$; geometric mean $\\prod (a_i^{p_i})^{1/p_i}=\\prod a_i$."
+    },
+    {
+      "id": "rpow-pow-inv",
+      "title": "The telescoping identity (aᵖ)^{1/p} = a",
+      "startLine": 41,
+      "endLine": 47,
+      "summary": "rpow_pow_inv: for a ≥ 0 and p ≠ 0, raising aᵖ to the reciprocal power recovers a, via Real.rpow_mul and p·p⁻¹ = 1. This collapses the weighted geometric mean of the aᵢ^{pᵢ} to the plain product.",
+      "mathContext": "$(a^p)^{p^{-1}} = a^{p\\cdot p^{-1}} = a^1 = a$ for $a\\ge0$, $p\\neq0$."
+    },
+    {
+      "id": "young-prod",
+      "title": "The n-variable Young product inequality and its equality case",
+      "startLine": 48,
+      "endLine": 95,
+      "summary": "young_prod_le proves the inequality from the grandparent's weighted_amgm_le; young_prod_eq_iff proves equality ↔ all aᵢ^{pᵢ} equal from weighted_amgm_eq_iff; young_prod_lt_of_ne gives the strict form.",
+      "mathContext": "$\\prod_i a_i = \\sum_i a_i^{p_i}/p_i \\iff \\forall j,k,\\ a_j^{p_j}=a_k^{p_k}$. Apply weighted AM–GM with $w_i=p_i^{-1}$, $z_i=a_i^{p_i}$; rewrite $\\prod z_i^{w_i}=\\prod a_i$ and $\\sum w_i z_i=\\sum a_i^{p_i}/p_i$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 95-line file (0 sorries, 0 axioms, no native_decide) adds the general n-variable Young product inequality ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ (for ∑ 1/pᵢ = 1) together with its equality case — equality iff all the aᵢ^{pᵢ} are equal — neither of which Mathlib provides beyond the two-variable Young inequality. Both descend from the grandparent entry's general weighted AM–GM inequality and equality characterization, applied with weights 1/pᵢ and data aᵢ^{pᵢ}. The strict form young_prod_lt_of_ne rounds out the entry. It directly answers the parent entry's listed open question on the n-fold generalized Young equality case.",
+    "implications": "The general product form is the pointwise engine behind the generalized Hölder inequality for n functions, and its equality case identifies exactly when that bound is tight (all aᵢ^{pᵢ} proportional pointwise), making it a rigidity tool. Deriving it as a corollary of weighted AM–GM exhibits the uniform mechanism — apply the AM–GM equality case in the coordinates wᵢ = 1/pᵢ, zᵢ = aᵢ^{pᵢ} — that yields the equality cases throughout the Young–Hölder family, with the two-variable Young inequality recovered as the n = 2 case.",
+    "openQuestions": [
+      "Lift young_prod_eq_iff to the equality case of the generalized Hölder inequality for finite sums of n sequences, characterizing equality by simultaneous proportionality of the |fₖ|^{pₖ}.",
+      "Formulate the n-variable Young product inequality for measurable functions (integral form) and transport the equality case via the same weighted AM–GM reduction."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 95,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4,
+    "imports": [
+      "Mathlib",
+      "Proofs.JensenInequalityOQ01",
+      "Proofs.JensenInequalityOQ01OQ01"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01",
+  "title": "Young's Inequality and its Equality Case, from Weighted AM–GM",
+  "slug": "jensen-inequality-oq-01-oq-01",
+  "description": "Supplies the equality case of Young's inequality, which Mathlib's library leaves open: for Hölder-conjugate exponents p, q (so 1/p + 1/q = 1) and nonnegative reals a, b, the bound a·b ≤ aᵖ/p + bᵍ/q holds with equality if and only if aᵖ = bᵍ. Young's inequality is the two-term weighted arithmetic–geometric mean inequality with weights 1/p, 1/q applied to the data aᵖ, bᵍ — the weighted geometric mean (aᵖ)^{1/p}·(bᵍ)^{1/q} collapses to a·b — so both the inequality and its equality case descend from the parent entry's weighted AM–GM equality characterization.",
+  "meta": {
+    "author": "Lean Genius (Young equality case via AM–GM bridge); W. H. Young (1912)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "young-inequality",
+      "am-gm-inequality",
+      "holder-conjugate",
+      "inequalities",
+      "equality-case",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 89,
+    "originalContributions": [
+      "young_eq_iff: the EQUALITY CASE of Young's inequality, absent from Mathlib — a·b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ — obtained by applying the two-variable weighted AM–GM equality case with weights 1/p, 1/q and data aᵖ, bᵍ, using (aᵖ)^{1/p} = a (Real.rpow_mul with p·p⁻¹ = 1)",
+      "amgm_two_weighted_eq_iff: the two-variable weighted AM–GM equality case x^{wₓ}·y^{w_y} = wₓx + w_y y ↔ x = y, specialized from the parent's weighted_amgm_eq_iff over a two-element (Fin 2) index set",
+      "young_lt_of_ne: the strict form of Young's inequality when aᵖ ≠ bᵍ, as lt_of_le_of_ne against the equality case",
+      "young_le: Young's inequality itself, recorded as the companion re-export of Real.young_inequality_of_nonneg"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Imports the parent file Proofs/JensenInequalityOQ01.lean to reuse weighted_amgm_eq_iff, plus Mathlib's Hölder-conjugate (Real.HolderConjugate) and Young-inequality machinery.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the sharp equality case of weighted AM–GM (geometric mean = arithmetic mean iff all data equal). This entry specializes it to two terms with weights 1/p, 1/q and data aᵖ, bᵍ, recovering Young's inequality and — the new content — its equality case aᵖ = bᵍ."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Young's inequality (W. H. Young, 1912) — a·b ≤ aᵖ/p + bᵍ/q for Hölder-conjugate exponents — is the pointwise engine behind Hölder's inequality and the duality of Lᵖ spaces. Its equality case, a·b = aᵖ/p + bᵍ/q exactly when aᵖ = bᵍ, is precisely what identifies the extremizers in Hölder's inequality. Mathlib formalizes Young's inequality (Real.young_inequality_of_nonneg) but not its equality case; this entry adds it by recognizing Young's inequality as a two-term instance of weighted AM–GM and inheriting the equality characterization from the parent.",
+    "problemStatement": "Mathlib provides Young's inequality a·b ≤ aᵖ/p + bᵍ/q for Hölder-conjugate p, q and nonnegative a, b, but not the equality case. Prove that equality holds if and only if aᵖ = bᵍ.",
+    "proofStrategy": "Young's inequality is weighted AM–GM in disguise. With weights wₓ = 1/p, w_y = 1/q (positive and summing to 1 by Hölder conjugacy) and data x = aᵖ, y = bᵍ, the two-variable weighted geometric mean x^{wₓ}·y^{w_y} = (aᵖ)^{1/p}·(bᵍ)^{1/q} equals a·b (since (aᵖ)^{1/p} = a^{p·p⁻¹} = a^1 = a by Real.rpow_mul and p·p⁻¹ = 1), and the weighted arithmetic mean wₓx + w_y y = aᵖ/p + bᵍ/q. The two-variable weighted AM–GM equality case amgm_two_weighted_eq_iff — itself the parent's weighted_amgm_eq_iff specialized to a Fin 2 index set — then gives equality iff x = y, i.e. aᵖ = bᵍ. The strict form follows as lt_of_le_of_ne.",
+    "keyInsights": [
+      "Young's inequality is not a separate phenomenon from AM–GM: it is exactly the two-term weighted AM–GM with weights 1/p, 1/q, so its equality case is forced by the AM–GM equality case rather than requiring a new argument.",
+      "The exponent bookkeeping is the whole trick: choosing data aᵖ, bᵍ makes the weighted geometric mean (aᵖ)^{1/p}·(bᵍ)^{1/q} telescope to a·b because raising to the conjugate-reciprocal power inverts the p-th power, (aᵖ)^{1/p} = a^{p·p⁻¹} = a.",
+      "Hölder conjugacy 1/p + 1/q = 1 is exactly the 'weights sum to 1' hypothesis of weighted AM–GM, so the two notions of 'conjugate exponents' and 'probability weights' coincide here.",
+      "Reducing a two-variable inequality to the general weighted statement over a Fin 2 index set (via Fin.prod_univ_two / Fin.sum_univ_two) keeps the equality case a one-line specialization rather than a fresh convexity computation.",
+      "The equality case is the useful part downstream: it pins the extremizers of Hölder's inequality (equality iff |f|ᵖ and |g|ᵍ are proportional), which the bare inequality cannot."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Frames Young's inequality as two-term weighted AM–GM, notes Mathlib has the inequality but not the equality case, and lists the four results.",
+      "mathContext": "Young: $ab \\le a^p/p + b^q/q$ for $1/p+1/q=1$, $p,q>1$. With weights $1/p, 1/q$ and data $a^p, b^q$ this is weighted AM–GM; the geometric mean $(a^p)^{1/p}(b^q)^{1/q}=ab$."
+    },
+    {
+      "id": "amgm-two",
+      "title": "Two-variable weighted AM–GM equality case",
+      "startLine": 39,
+      "endLine": 65,
+      "summary": "amgm_two_weighted_eq_iff specializes the parent's weighted_amgm_eq_iff to a Fin 2 index set: x^{wₓ}y^{w_y} = wₓx + w_y y ↔ x = y.",
+      "mathContext": "For $w_x,w_y>0$ with $w_x+w_y=1$ and $x,y\\ge0$: $x^{w_x}y^{w_y}=w_xx+w_yy\\iff x=y$. Proved by evaluating the general statement on $\\mathrm{Fin}\\,2$ with $w=![w_x,w_y]$, $z=![x,y]$."
+    },
+    {
+      "id": "young",
+      "title": "Young's inequality and its equality case",
+      "startLine": 66,
+      "endLine": 89,
+      "summary": "young_le re-exports the inequality; young_eq_iff proves equality ↔ aᵖ = bᵍ by the two-variable AM–GM equality case with weights 1/p, 1/q; young_lt_of_ne gives the strict form.",
+      "mathContext": "$ab=a^p/p+b^q/q\\iff a^p=b^q$. Apply amgm_two_weighted_eq_iff with $w_x=p^{-1}$, $w_y=q^{-1}$, $x=a^p$, $y=b^q$; $(a^p)^{p^{-1}}=a$ via $a^{p\\cdot p^{-1}}=a^1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 89-line file (0 sorries, 0 axioms, no native_decide) adds the equality case of Young's inequality — a·b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ — which Mathlib's library does not provide. It is obtained by recognizing Young's inequality as the two-term weighted AM–GM inequality (weights 1/p, 1/q on data aᵖ, bᵍ) and inheriting the equality characterization from the parent entry's weighted_amgm_eq_iff. The strict form young_lt_of_ne and a re-export young_le of the inequality itself round out the entry.",
+    "implications": "The equality case is what makes Young's inequality usable as a rigidity tool: it identifies exactly when the pointwise bound underlying Hölder's inequality is tight, hence the extremizers of Hölder (proportional |f|ᵖ and |g|ᵍ). Recording Young as a corollary of weighted AM–GM also shows the uniform mechanism — apply the AM–GM equality case in the right coordinates — that yields the equality cases of the whole Hölder–Minkowski family.",
+    "openQuestions": [
+      "Lift young_eq_iff to the equality case of Hölder's inequality for finite sums and for Lᵖ, characterizing equality by proportionality of |f|ᵖ and |g|ᵍ.",
+      "State the equality case of Young's inequality for products (the integral / convolution form) using the same AM–GM reduction.",
+      "Provide the n-fold generalized Young / weighted AM–GM equality case ∏ aᵢ^{wᵢ} = ∑ wᵢ aᵢ ↔ all aᵢ equal directly from weighted_amgm_eq_iff with general index set."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 89,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4,
+    "imports": [
+      "Mathlib",
+      "Proofs.JensenInequalityOQ01"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/jensen-inequality-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "jensen-inequality-oq-01",
+  "title": "The Equality Case of Strict Jensen, and the Sharp Weighted AM–GM Equality",
+  "slug": "jensen-inequality-oq-01",
+  "description": "Isolates the equality case of the finite weighted Jensen inequality for a strictly convex function — Jensen is an equality exactly when the data are constant — and specializes it, through the strict convexity of exp, to the sharp equality case of the weighted arithmetic–geometric mean inequality: the weighted geometric and arithmetic means of positive data coincide if and only if all the data are equal. The strict AM–GM gap is obtained directly from StrictConvexOn.map_sum_lt for exp, making the Jensen → AM–GM bridge explicit, and the classic two-variable instance √(ab) = (a+b)/2 ↔ a = b is proved from (√a − √b)² = 0.",
+  "meta": {
+    "author": "Lean Genius (Jensen → AM–GM packaging); Jensen, Hölder (classical theory)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "jensen-inequality",
+      "am-gm-inequality",
+      "inequalities",
+      "equality-case",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 124,
+    "originalContributions": [
+      "jensen_eq_iff: a clean entry-point restatement of the equality case of strict Jensen — for a strictly convex f, positive weights summing to 1, and points in the domain, f(∑ ω•p) = ∑ ω•f(p) holds iff every point equals the weighted center of mass (the data are constant)",
+      "weighted_amgm_eq_iff: the equality case of weighted AM–GM in symmetric form — ∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ ↔ ∀ j k ∈ s, z j = z k — obtained by converting the center-of-mass right side of Mathlib's geom_mean_eq_arith_mean_weighted_iff' into the 'all values equal' form",
+      "weighted_amgm_lt_of_ne: the STRICT weighted AM–GM gap, proved directly through strictConvexOn_exp.map_sum_lt — rewriting the geometric mean as exp(∑ w•log z) and the arithmetic mean as ∑ w•exp(log z) exhibits the Jensen → AM–GM bridge explicitly, with non-constant data forced from injectivity of log on the positives",
+      "weighted_amgm_le: the weighted AM–GM inequality ∏ zᵢ^{wᵢ} ≤ ∑ wᵢ zᵢ recorded as the companion of the equality case",
+      "amgm_two_eq_iff: the concrete two-variable instance √(ab) = (a+b)/2 ↔ a = b, with the forward direction the classic (√a − √b)² = 0"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Built entirely on Mathlib's convexity (Analysis.Convex.Jensen) and mean-inequality (Analysis.MeanInequalities) libraries plus the strict convexity of exp.",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "A sibling AM–GM entry. This entry supplies the sharp EQUALITY characterization (geometric mean = arithmetic mean iff all data equal) and the strict gap, deriving them from the convexity side via the equality case of Jensen."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Jensen's inequality (J. L. W. V. Jensen, 1906) states that for a convex function f and a probability-weighted family of points, f of the weighted average is at most the weighted average of f. When f is strictly convex the inequality is strict unless the points coincide — this is the equality case. Applying Jensen to the strictly convex exponential and reading off the result in terms of the original data is the standard route from convexity to the arithmetic–geometric mean inequality of Cauchy and its weighted (Hölder) refinement: the weighted geometric mean never exceeds the weighted arithmetic mean, with equality exactly when all the data agree. Mathlib formalizes both the abstract Jensen equality case (StrictConvexOn.map_sum_eq_iff) and the AM–GM equality case (Real.geom_mean_eq_arith_mean_weighted_iff'), the latter proved precisely by the exp specialization; this entry packages the bridge as a single self-contained development.",
+    "problemStatement": "Formalize the equality case of finite weighted Jensen for a strictly convex f — if the weights are strictly positive and sum to 1 and Jensen holds with equality, then all the points are equal — and specialize f = exp to obtain the sharp equality case of the weighted AM–GM inequality: ∏ zᵢ^{wᵢ} = ∑ wᵢ zᵢ if and only if all zᵢ are equal.",
+    "proofStrategy": "The abstract equality case is Mathlib's StrictConvexOn.map_sum_eq_iff, re-exported as jensen_eq_iff. For AM–GM, the weighted geometric mean ∏ zᵢ^{wᵢ} rewrites as exp(∑ wᵢ • log zᵢ) (via Real.rpow_def_of_pos and Real.exp_sum) and the weighted arithmetic mean ∑ wᵢ zᵢ as ∑ wᵢ • exp(log zᵢ) (via Real.exp_log). Strict convexity of exp (strictConvexOn_exp) then gives the strict gap whenever the logs — equivalently, by injectivity of log on the positive reals, the data — are non-constant (weighted_amgm_lt_of_ne). The equality characterization weighted_amgm_eq_iff restates Mathlib's geom_mean_eq_arith_mean_weighted_iff', converting its center-of-mass right side ∀ j, z j = ∑ w • z into the symmetric 'all equal' form by an elementary weighted-average computation. The two-variable case is the classic (√a − √b)² ≥ 0 with equality iff √a = √b iff a = b.",
+    "keyInsights": [
+      "The equality case of a strict inequality is a structural statement, not a numerical one: Jensen is tight exactly on constant families, and that single fact propagates through every convex-function specialization, including AM–GM.",
+      "Exponentiation is the dictionary between the additive (Jensen) and multiplicative (AM–GM) worlds: ∏ zᵢ^{wᵢ} = exp(∑ wᵢ log zᵢ) turns the weighted geometric mean into exp of a weighted average, so the convexity of exp on a non-constant log-family is exactly the strict AM–GM gap.",
+      "Non-constancy transfers cleanly: log is injective on (0, ∞), so the data being non-constant is equivalent to their logs being non-constant — the hypothesis StrictConvexOn.map_sum_lt actually needs.",
+      "Mathlib's own proof of the AM–GM equality case (geom_mean_eq_arith_mean_weighted_iff') is exactly this exp-Jensen specialization, so the bridge formalized here is not an alternative route but the canonical one, here surfaced as named, citeable lemmas.",
+      "The symmetric 'all values equal' form ∀ j k, z j = z k is interchangeable with the center-of-mass form ∀ j, z j = ∑ w z by a one-line weighted-average identity, and is the form most often quoted in applications."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "States the goal — isolate the equality case of strict Jensen and specialize it via exp to the sharp weighted AM–GM equality — and lists the five main results.",
+      "mathContext": "Jensen's inequality $f(\\sum_i w_i p_i) \\le \\sum_i w_i f(p_i)$ for convex $f$ becomes an equality, when $f$ is strictly convex and the $w_i>0$ sum to $1$, exactly when the $p_i$ are constant. Specializing $f=\\exp$, $p_i=\\log z_i$ yields the weighted AM–GM inequality and its equality case."
+    },
+    {
+      "id": "jensen",
+      "title": "The abstract equality case of strict Jensen",
+      "startLine": 48,
+      "endLine": 67,
+      "summary": "jensen_eq_iff re-exports StrictConvexOn.map_sum_eq_iff: strict Jensen is an equality iff every point equals the weighted center of mass.",
+      "mathContext": "For strictly convex $f$, weights $w_i>0$ with $\\sum w_i=1$: $f(\\sum_i w_i\\bullet p_i)=\\sum_i w_i\\bullet f(p_i)\\iff \\forall j,\\ p_j=\\sum_i w_i\\bullet p_i$. The right side says the family is constant (all equal to its mean)."
+    },
+    {
+      "id": "amgm",
+      "title": "Weighted AM–GM and its equality case",
+      "startLine": 68,
+      "endLine": 110,
+      "summary": "weighted_amgm_le gives the inequality; weighted_amgm_eq_iff characterizes equality as 'all values equal'; weighted_amgm_lt_of_ne derives the strict gap directly from strictConvexOn_exp.map_sum_lt, exhibiting the Jensen → AM–GM bridge.",
+      "mathContext": "$\\prod_i z_i^{w_i}\\le\\sum_i w_i z_i$ with equality iff all $z_i$ are equal. The strict version uses $\\prod_i z_i^{w_i}=\\exp(\\sum_i w_i\\log z_i)$ and $\\sum_i w_i z_i=\\sum_i w_i\\exp(\\log z_i)$, so strict convexity of $\\exp$ on a non-constant log-family forces a strict inequality."
+    },
+    {
+      "id": "two-var",
+      "title": "The two-variable instance",
+      "startLine": 111,
+      "endLine": 124,
+      "summary": "amgm_two_eq_iff: √(ab) = (a+b)/2 ↔ a = b for nonnegative reals, with the forward direction the classic (√a − √b)² = 0.",
+      "mathContext": "The $n=2$ unweighted case: $\\sqrt{ab}=\\tfrac{a+b}{2}\\iff a=b$. Writing $u=\\sqrt a$, $v=\\sqrt b$, equality reads $uv=\\tfrac{u^2+v^2}{2}$, i.e. $(u-v)^2=0$, so $u=v$ and $a=b$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 124-line file (0 sorries, 0 axioms, no native_decide) packages the equality case of strict Jensen and its specialization to the sharp weighted AM–GM equality. The headline characterization weighted_amgm_eq_iff states that the weighted geometric and arithmetic means of positive data coincide iff all the data are equal, and weighted_amgm_lt_of_ne derives the strict gap directly from the strict convexity of exp, making the Jensen → AM–GM bridge explicit. The classic two-variable instance √(ab) = (a+b)/2 ↔ a = b is included as a concrete corollary.",
+    "implications": "Equality characterizations are what make mean inequalities usable in optimization and probability: knowing AM–GM is tight exactly on constant data turns a bound into a rigidity statement (e.g. extremizers of geometric-vs-arithmetic-mean ratios are forced to be balanced). Recording the convexity bridge as named lemmas — jensen_eq_iff, weighted_amgm_eq_iff, weighted_amgm_lt_of_ne — makes the standard 'apply exp-Jensen' argument reusable for the other classical inequalities (Hölder, Young) that descend from convexity.",
+    "openQuestions": [
+      "Specialize the same exp-Jensen bridge to Young's inequality and Hölder's inequality, recording their equality cases in the same named-lemma style.",
+      "State the weighted power-mean inequality M_p ≤ M_q and its equality case (all data equal) as a uniform family in p ≤ q, again via convexity of the relevant power map.",
+      "Generalize amgm_two_eq_iff to the unweighted n-variable geometric/arithmetic mean equality case as a direct corollary of weighted_amgm_eq_iff with uniform weights 1/n."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 124,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 5,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01-oq-01.json
+++ b/src/data/research/problems/jensen-inequality-oq-01-oq-01.json
@@ -1,0 +1,68 @@
+{
+  "slug": "jensen-inequality-oq-01-oq-01",
+  "title": "Young's Inequality and its Equality Case, from Weighted AM–GM",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "a\\,b = \\frac{a^p}{p} + \\frac{b^q}{q} \\iff a^p = b^q \\quad (1/p+1/q=1,\\ a,b\\ge 0)",
+    "plain": "Mathlib has Young's inequality a·b ≤ aᵖ/p + bᵍ/q for Hölder-conjugate exponents p, q and nonnegative a, b, but not its equality case. Prove that equality holds if and only if aᵖ = bᵍ, by recognizing Young's inequality as the two-term weighted AM–GM inequality (weights 1/p, 1/q on data aᵖ, bᵍ) and inheriting the equality characterization from the parent entry.",
+    "whyMatters": [
+      "Fills a real Mathlib gap: the equality case of Young's inequality is absent",
+      "The equality case identifies the extremizers of Hölder's inequality"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T13:15:00-07:00",
+    "iteration": 1,
+    "focus": "Add the equality case of Young's inequality by specializing the parent's weighted AM–GM equality case to two terms.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved the equality case of Young's inequality a·b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ, 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01OQ01.lean (89L, 4 thm). amgm_two_weighted_eq_iff specializes the parent's weighted_amgm_eq_iff to a Fin 2 index set (w = ![1/p,1/q], z = ![aᵖ,bᵍ]); young_eq_iff applies it with (aᵖ)^{1/p} = a (Real.rpow_mul, p·p⁻¹ = 1, rpow_one), Hölder conjugacy giving p⁻¹+q⁻¹ = 1; young_le re-exports Real.young_inequality_of_nonneg; young_lt_of_ne is lt_of_le_of_ne against the equality case.",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01OQ01.lean: young_eq_iff (equality case of Young's inequality — Mathlib gap)",
+      "amgm_two_weighted_eq_iff (two-variable weighted AM–GM equality case, from parent over Fin 2)",
+      "young_le (Young's inequality re-export), young_lt_of_ne (strict form)",
+      "src/data/proofs/jensen-inequality-oq-01-oq-01/ gallery entry"
+    ],
+    "insights": [
+      "Young's inequality IS the two-term weighted AM–GM with weights 1/p, 1/q, so its equality case is forced by the AM–GM equality case — no new convexity argument needed",
+      "Choosing data aᵖ, bᵍ makes the weighted geometric mean (aᵖ)^{1/p}·(bᵍ)^{1/q} telescope to a·b, because (aᵖ)^{1/p} = a^{p·p⁻¹} = a",
+      "Hölder conjugacy 1/p+1/q=1 is exactly the 'weights sum to 1' hypothesis of weighted AM–GM",
+      "Reducing a two-variable inequality to the general weighted statement over a Fin 2 index set keeps the equality case a one-line specialization"
+    ],
+    "mathlibGaps": [
+      "Mathlib has Young's inequality (Real.young_inequality_of_nonneg) but NOT its equality case; young_eq_iff here is the missing characterization and a natural upstream contribution"
+    ],
+    "nextSteps": [
+      "Lift to the equality case of Hölder's inequality (proportionality of |f|ᵖ and |g|ᵍ)",
+      "State the integral / convolution form of Young's inequality equality case",
+      "n-fold generalized Young / weighted AM–GM equality case directly from weighted_amgm_eq_iff"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01-oq-01\n\n## Problem Understanding\n\nAdd the equality case of Young's inequality (missing from Mathlib) by recognizing Young's inequality as two-term weighted AM–GM and inheriting the parent's equality characterization.\n\n## Insights\n\nWith weights 1/p, 1/q and data aᵖ, bᵍ, the weighted geometric mean (aᵖ)^{1/p}·(bᵍ)^{1/q} collapses to a·b and the weighted arithmetic mean is aᵖ/p + bᵍ/q. The two-variable weighted AM–GM equality case (parent's weighted_amgm_eq_iff over Fin 2) then gives equality iff aᵖ = bᵍ. Hölder conjugacy 1/p+1/q=1 is the 'weights sum to 1' hypothesis.\n\n## Dead Ends\n\nNone — the build succeeded after removing one unused simp argument.\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "young-inequality",
+    "am-gm-inequality",
+    "holder-conjugate",
+    "inequalities",
+    "equality-case",
+    "research"
+  ]
+}

--- a/src/data/research/problems/jensen-inequality-oq-01.json
+++ b/src/data/research/problems/jensen-inequality-oq-01.json
@@ -1,0 +1,68 @@
+{
+  "slug": "jensen-inequality-oq-01",
+  "title": "The Equality Case of Strict Jensen, and the Sharp Weighted AM–GM Equality",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\prod_{i\\in s} z_i^{w_i} = \\sum_{i\\in s} w_i z_i \\iff \\forall j,k\\in s,\\ z_j = z_k",
+    "plain": "Formalize the equality case of finite weighted Jensen for a strictly convex f (Jensen is an equality iff the data are constant), then specialize f = exp to the sharp equality case of the weighted arithmetic–geometric mean inequality: the weighted geometric and arithmetic means of positive data coincide if and only if all the data are equal.",
+    "whyMatters": [
+      "Equality cases turn mean inequalities into rigidity statements usable in optimization and probability",
+      "Records the canonical convexity → AM–GM bridge (apply exp-Jensen) as named, reusable lemmas"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T12:30:00-07:00",
+    "iteration": 1,
+    "focus": "Isolate the equality case of strict Jensen and specialize it via exp to the sharp weighted AM–GM equality.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): packaged the equality case of strict Jensen and its exp-specialization to weighted AM–GM, 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01.lean (124L, 5 thm). jensen_eq_iff re-exports StrictConvexOn.map_sum_eq_iff; weighted_amgm_le re-exports geom_mean_le_arith_mean_weighted; weighted_amgm_eq_iff converts geom_mean_eq_arith_mean_weighted_iff' (center-of-mass right side) to symmetric 'all equal' form; weighted_amgm_lt_of_ne derives the strict gap DIRECTLY through strictConvexOn_exp.map_sum_lt by rewriting ∏ z^w = exp(∑ w•log z) and ∑ w z = ∑ w•exp(log z) (Real.rpow_def_of_pos, Real.exp_sum, Real.exp_log), with non-constant logs from Real.log_injOn_pos; amgm_two_eq_iff proves √(ab)=(a+b)/2 ↔ a=b via (√a−√b)²=0.",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01.lean: jensen_eq_iff (abstract Jensen equality case, re-export)",
+      "weighted_amgm_le (weighted AM–GM inequality), weighted_amgm_eq_iff (equality iff all data equal)",
+      "weighted_amgm_lt_of_ne (strict gap via strictConvexOn_exp.map_sum_lt — the explicit Jensen → AM–GM bridge)",
+      "amgm_two_eq_iff (two-variable instance √(ab) = (a+b)/2 ↔ a = b)",
+      "src/data/proofs/jensen-inequality-oq-01/ gallery entry"
+    ],
+    "insights": [
+      "Exponentiation is the dictionary between additive Jensen and multiplicative AM–GM: ∏ zᵢ^{wᵢ} = exp(∑ wᵢ log zᵢ) turns the weighted geometric mean into exp of a weighted average, so convexity of exp on a non-constant log-family is exactly the strict AM–GM gap",
+      "Non-constancy transfers cleanly through log: it is injective on (0,∞), so non-constant data ⟺ non-constant logs, which is the hypothesis StrictConvexOn.map_sum_lt needs",
+      "Mathlib's own proof of geom_mean_eq_arith_mean_weighted_iff' IS this exp-Jensen specialization, so the bridge here is the canonical route surfaced as named lemmas, not an alternative",
+      "The symmetric 'all values equal' form ∀ j k, z j = z k is interchangeable with the center-of-mass form ∀ j, z j = ∑ w z by a one-line weighted-average identity, and is the form most often quoted"
+    ],
+    "mathlibGaps": [
+      "Mathlib already has both the abstract Jensen equality case (StrictConvexOn.map_sum_eq_iff) and the AM–GM equality case (Real.geom_mean_eq_arith_mean_weighted_iff'); the contribution here is packaging the bridge as named lemmas and the symmetric 'all equal' restatement, plus a direct strictConvexOn_exp.map_sum_lt derivation of the strict gap"
+    ],
+    "nextSteps": [
+      "Specialize the same exp-Jensen bridge to Young's and Hölder's inequalities, recording their equality cases in matching style",
+      "State the weighted power-mean inequality M_p ≤ M_q and its equality case as a uniform family in p ≤ q",
+      "Derive the unweighted n-variable AM–GM equality case from weighted_amgm_eq_iff with uniform weights 1/n"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01\n\n## Problem Understanding\n\nIsolate the equality case of finite weighted Jensen for a strictly convex f, and specialize f = exp to obtain the sharp equality case of the weighted AM–GM inequality.\n\n## Insights\n\nThe weighted geometric mean is exp of a weighted average of logs, so the strict convexity of exp on a non-constant log-family is exactly the strict AM–GM gap. log is injective on the positive reals, so non-constant data is equivalent to non-constant logs. Mathlib's proof of the AM–GM equality case is itself this exp-Jensen specialization; the contribution is to surface the bridge as named, citeable lemmas and to restate equality in the symmetric 'all values equal' form.\n\n## Dead Ends\n\nNone — the build succeeded on the first attempt.\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "jensen-inequality",
+    "am-gm-inequality",
+    "inequalities",
+    "equality-case",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the parent entry's **two-variable Young inequality** to an arbitrary finite family of exponents. For strictly positive exponents `p i` whose reciprocals sum to `1` (`∑ 1/pᵢ = 1`) and nonnegative data `a i`:

$$\prod_i a_i \;\le\; \sum_i \frac{a_i^{p_i}}{p_i}, \qquad \text{equality} \iff \text{all the } a_i^{p_i} \text{ are equal.}$$

This stands to the parent's two-variable Young inequality exactly as the grandparent's general weighted AM–GM stands to its two-variable instance. It **directly answers the parent entry's listed open question** on the n-fold generalized Young / weighted AM–GM equality case.

## Proof strategy

The n-variable Young product inequality *is* the general weighted AM–GM in disguise. Take weights `wᵢ = 1/pᵢ` (strictly positive, summing to `1`) and data `zᵢ = aᵢ^{pᵢ}` (nonnegative):

- the weighted geometric mean `∏ (aᵢ^{pᵢ})^{1/pᵢ}` **telescopes to `∏ aᵢ`**, since `(aᵢ^{pᵢ})^{1/pᵢ} = aᵢ^{pᵢ·pᵢ⁻¹} = aᵢ` (`Real.rpow_mul`, `pᵢ·pᵢ⁻¹ = 1`);
- the weighted arithmetic mean `∑ (1/pᵢ)·aᵢ^{pᵢ}` is the Young sum `∑ aᵢ^{pᵢ}/pᵢ`.

The grandparent's `weighted_amgm_le` then gives the inequality and `weighted_amgm_eq_iff` gives the equality case. Specializing to a two-element index set with Hölder-conjugate `p, q` recovers the parent's `young_eq_iff`.

## Main results

- `young_prod_le` — the n-variable Young product inequality `∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ`.
- `young_prod_eq_iff` — its **equality case**: equality iff all the `aᵢ^{pᵢ}` are equal.
- `young_prod_lt_of_ne` — the strict form when two of the `aᵢ^{pᵢ}` differ.

## Verification

- 95 lines, 4 theorems, 0 definitions.
- **0 sorries, 0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), **no `native_decide`**.
- Docker build succeeds: `./proofs/scripts/docker-build.sh Proofs.JensenInequalityOQ01OQ01OQ01`.
- Builds on `Proofs.JensenInequalityOQ01OQ01` (parent) and `Proofs.JensenInequalityOQ01` (grandparent).

Mathlib provides only the two-variable Young inequality (`Real.young_inequality_of_nonneg`) and none of the equality cases; this entry adds the general product form together with its sharp equality characterization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)