### PR TITLE
research(egorov-theorem-oq-01-oq-01): Egorov's finiteness hypothesis is essential — marching-indicator counterexample [0-axiom verified]

### DIFF
--- a/proofs/Proofs/EgorovMarching.lean
+++ b/proofs/Proofs/EgorovMarching.lean
@@ -1,0 +1,159 @@
+import Mathlib.MeasureTheory.Function.Egorov
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Tactic
+
+/-
+# Egorov's Theorem is Sharp: the Finiteness Hypothesis is Essential
+
+## What This Proves
+
+**Egorov's theorem** says that on a set `s` of *finite* measure, almost-everywhere
+convergence `fₙ → g` upgrades to uniform convergence off an arbitrarily small set.
+The finiteness hypothesis `μ s ≠ ∞` is not a technical convenience -- it is genuinely
+necessary. This file makes that precise with the canonical counterexample on the
+σ-finite-but-infinite space `(ℝ, Lebesgue)`.
+
+The **marching indicators** are the unit-width bumps that walk off to infinity:
+
+  `marching n = 𝟙_{[n, n+1)}`,   i.e.   `marching n x = 1` if `n ≤ x < n+1`, else `0`.
+
+We prove three facts that together show Egorov's conclusion *fails* once the ambient
+measure is infinite:
+
+* `marching_stronglyMeasurable` -- each `marching n` is (strongly) measurable, so the
+  family satisfies every hypothesis of Egorov's theorem *except* finiteness.
+
+* `marching_tendsto_zero` -- the sequence converges to `0` at **every** point of `ℝ`
+  (not merely almost everywhere): for fixed `x`, once `n > x` the point `x` has been
+  passed, so `marching n x = 0` for all large `n`.
+
+* `marching_not_tendstoUniformlyOn` -- for **every** set `t` of finite Lebesgue
+  measure, the sequence does *not* converge uniformly to `0` on the complement `tᶜ`.
+  In particular no exceptional set of finite (let alone arbitrarily small) measure can
+  be removed to obtain uniform convergence.
+
+The capstone `egorov_finiteness_essential` bundles the three. The contrast with the
+finite-measure case (`EgorovTheorem.pow_egorov_on_Icc`, where Egorov *does* apply) is
+exactly the point: on `[0,1]` removing a small set works; on `ℝ` it cannot.
+
+### Why `marching_not_tendstoUniformlyOn` holds
+
+If `t` has finite measure then `t` cannot contain the whole ray `[N, ∞)` (which has
+infinite measure), so for every `N` there is an integer `n ≥ N` and a point
+`x ∈ [n, n+1) \ t`. At that point `marching n x = 1`, keeping `supₓ∈tᶜ |marching n x|`
+equal to `1` infinitely often -- the negation of uniform convergence.
+
+## Why It Is Not in Mathlib
+
+Mathlib has the abstract Egorov theorem (`MeasureTheory.tendstoUniformlyOn_of_ae_tendsto`)
+and the sibling gallery file `EgorovTheorem.lean` exhibits its non-vacuity on `[0,1]`.
+Neither states the *necessity of the finiteness hypothesis*; the marching-indicator
+counterexample, its everywhere-convergence, and the no-finite-exceptional-set witness
+are the new content. This answers the open question `egorov-theorem-oq-01-oq-01`.
+
+## Axiom Status
+
+Fully verified, 0 sorries, 0 `axiom` declarations, no `native_decide`. Relies only on
+Mathlib's measure theory and the foundational axioms `propext`, `Classical.choice`,
+`Quot.sound`.
+-/
+
+open MeasureTheory Filter Set Topology
+open scoped ENNReal
+
+namespace EgorovMarching
+
+/-! ## The marching indicators -/
+
+/-- The marching indicators `marching n = 𝟙_{[n, n+1)}`: a unit-height bump on the
+half-open interval `[n, n+1)` that walks off to `+∞` as `n → ∞`. -/
+noncomputable def marching (n : ℕ) : ℝ → ℝ :=
+  (Set.Ico (n : ℝ) (n + 1)).indicator (fun _ => 1)
+
+/-- On its own block the bump has value `1`. -/
+theorem marching_apply_mem {n : ℕ} {x : ℝ} (hx : x ∈ Set.Ico (n : ℝ) (n + 1)) :
+    marching n x = 1 := by
+  rw [marching, Set.indicator_of_mem hx]
+
+/-- Each marching indicator is strongly measurable, so the family meets every
+hypothesis of Egorov's theorem *except* the finiteness of the ambient measure. -/
+theorem marching_stronglyMeasurable (n : ℕ) : StronglyMeasurable (marching n) :=
+  (stronglyMeasurable_const).indicator measurableSet_Ico
+
+/-! ## Everywhere (hence a.e.) convergence to zero -/
+
+/-- The marching indicators converge to `0` at **every** real point: for fixed `x`,
+all blocks past `⌊x⌋₊` lie strictly to the right of `x`, so `marching n x = 0` for
+every `n > ⌊x⌋₊`. -/
+theorem marching_tendsto_zero (x : ℝ) :
+    Tendsto (fun n => marching n x) atTop (𝓝 (0 : ℝ)) := by
+  have hev : ∀ᶠ n in atTop, marching n x = 0 := by
+    filter_upwards [eventually_gt_atTop ⌊x⌋₊] with n hn
+    have hnotmem : x ∉ Set.Ico (n : ℝ) (n + 1) := by
+      rw [Set.mem_Ico]
+      rintro ⟨h1, _⟩
+      have hcast : (⌊x⌋₊ : ℝ) + 1 ≤ (n : ℝ) := by
+        exact_mod_cast Nat.add_one_le_iff.mpr hn
+      have hlt := Nat.lt_floor_add_one x
+      linarith
+    rw [marching, Set.indicator_of_notMem hnotmem]
+  exact tendsto_const_nhds.congr' (hev.mono fun n hn => hn.symm)
+
+/-! ## No finite-measure exceptional set: failure of Egorov's conclusion -/
+
+/-- Key geometric obstruction. If `t` has *finite* Lebesgue measure then it cannot
+contain the entire ray `[N, ∞)`, so beyond any threshold `N` some block `[n, n+1)`
+(with `n ≥ N`) still pokes out of `t`: there is `x ∈ [n, n+1)` with `x ∉ t`. -/
+theorem exists_uncovered {t : Set ℝ} (ht : volume t ≠ ∞) (N : ℕ) :
+    ∃ n ≥ N, ∃ x, x ∈ Set.Ico (n : ℝ) (n + 1) ∧ x ∉ t := by
+  by_contra h
+  push_neg at h
+  -- Then every block past `N` lies inside `t`, forcing `[N, ∞) ⊆ t`.
+  have hsub : Set.Ici (N : ℝ) ⊆ t := by
+    intro x hx
+    rw [Set.mem_Ici] at hx
+    have hxnn : (0 : ℝ) ≤ x := le_trans (Nat.cast_nonneg N) hx
+    have hnN : N ≤ ⌊x⌋₊ := Nat.le_floor hx
+    have hxlo : (⌊x⌋₊ : ℝ) ≤ x := Nat.floor_le hxnn
+    have hxhi : x < (⌊x⌋₊ : ℝ) + 1 := Nat.lt_floor_add_one x
+    exact h ⌊x⌋₊ hnN x ⟨hxlo, hxhi⟩
+  -- But `[N, ∞)` has infinite measure, contradicting `volume t ≠ ∞`.
+  have hbig : volume (Set.Ici (N : ℝ)) ≤ volume t := measure_mono hsub
+  rw [Real.volume_Ici] at hbig
+  exact ht (top_le_iff.mp hbig)
+
+/-- **The finiteness hypothesis of Egorov's theorem is essential.** For every set `t`
+of finite Lebesgue measure, the marching indicators do *not* converge uniformly to `0`
+on `tᶜ` -- even though they converge to `0` everywhere on `ℝ`. Hence no finite-measure
+(in particular no arbitrarily small) exceptional set can be removed to recover uniform
+convergence on the σ-finite-but-infinite space `(ℝ, Lebesgue)`. -/
+theorem marching_not_tendstoUniformlyOn {t : Set ℝ} (ht : volume t ≠ ∞) :
+    ¬ TendstoUniformlyOn marching (fun _ => (0 : ℝ)) atTop tᶜ := by
+  intro h
+  rw [Metric.tendstoUniformlyOn_iff] at h
+  have key := h (1 / 2) (by norm_num)
+  rw [eventually_atTop] at key
+  obtain ⟨N, hN⟩ := key
+  obtain ⟨n, hnN, x, hxmem, hxnt⟩ := exists_uncovered ht N
+  have hxc : x ∈ tᶜ := hxnt
+  have hfx : marching n x = 1 := marching_apply_mem hxmem
+  have hlt := hN n hnN x hxc
+  simp only [hfx, Real.dist_eq] at hlt
+  norm_num at hlt
+
+/-! ## Capstone -/
+
+/-- **Egorov's theorem is sharp.** The marching indicators on `(ℝ, Lebesgue)` are
+strongly measurable and converge to `0` at every point, yet no finite-measure set can
+be removed to make the convergence uniform. The single failing hypothesis relative to
+Egorov's theorem is finiteness of the ambient measure, so that hypothesis cannot be
+dropped. -/
+theorem egorov_finiteness_essential :
+    (∀ n, StronglyMeasurable (marching n)) ∧
+      (∀ x, Tendsto (fun n => marching n x) atTop (𝓝 (0 : ℝ))) ∧
+      (∀ t : Set ℝ, volume t ≠ ∞ →
+        ¬ TendstoUniformlyOn marching (fun _ => (0 : ℝ)) atTop tᶜ) :=
+  ⟨marching_stronglyMeasurable, marching_tendsto_zero,
+    fun _ ht => marching_not_tendstoUniformlyOn ht⟩
+
+end EgorovMarching

--- a/src/data/proofs/egorov-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,96 @@
+{
+  "id": "egorov-theorem-oq-01-oq-01",
+  "slug": "egorov-theorem-oq-01-oq-01",
+  "title": "Egorov's Theorem is Sharp: the Finiteness Hypothesis is Essential",
+  "conclusion": {
+    "summary": "Egorov's theorem upgrades almost-everywhere convergence to uniform convergence off an arbitrarily small set, but ONLY on a finite-measure space. This entry proves the finiteness hypothesis μ s ≠ ∞ cannot be dropped, via the canonical counterexample on the σ-finite-but-infinite space (ℝ, Lebesgue): the marching indicators marching n = 𝟙_[n,n+1). marching_stronglyMeasurable shows each bump is strongly measurable (so the family meets every Egorov hypothesis except finiteness); marching_tendsto_zero shows the sequence converges to 0 at EVERY point of ℝ (once n > ⌊x⌋₊ the block has passed x, so marching n x = 0 for all large n); and marching_not_tendstoUniformlyOn shows that for EVERY set t of finite Lebesgue measure the sequence fails to converge uniformly to 0 on tᶜ. The geometric heart (exists_uncovered) is that a finite-measure t cannot contain the ray [N,∞) (which has infinite measure Real.volume_Ici), so beyond any threshold some unit block [n,n+1) still pokes out of t, keeping the sup of |marching n| equal to 1 infinitely often. The capstone egorov_finiteness_essential bundles the three. 159 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "This is the sharpness companion to egorov-theorem-oq-01. That entry shows Egorov's exceptional set cannot be omitted (xⁿ on [0,1) converges everywhere but not uniformly); this one shows the orthogonal necessity: the finiteness of the ambient measure is itself essential. On [0,1] removing a small set works (EgorovTheorem.pow_egorov_on_Icc); on ℝ no finite-measure set removal suffices. Together the two entries pin down exactly which hypotheses of Egorov's theorem are load-bearing. Mathlib has the abstract theorem but records neither failure mode.",
+    "openQuestions": [
+      "Derive Lusin's theorem (every measurable function is continuous off a set of arbitrarily small measure) from Egorov's theorem via density of continuous/simple functions, completing the classical Egorov ⇒ Lusin route.",
+      "Quantify the failure: show that for the marching indicators the infimum over finite-measure sets t of limsupₙ supₓ∈tᶜ |marching n x| equals 1, i.e. removing finite measure buys no uniform control at all."
+    ]
+  },
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.MeasureTheory.Function.Egorov",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Filter",
+      "Set",
+      "Topology"
+    ],
+    "namespace": "EgorovMarching",
+    "lineCount": 159,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/EgorovMarching.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "title": "Egorov's theorem (necessity of finite measure)",
+      "url": "https://en.wikipedia.org/wiki/Egorov%27s_theorem"
+    }
+  ],
+  "crossReferences": [
+    "egorov-theorem-oq-01"
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EgorovMarching.lean",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "convergence",
+      "uniform-convergence",
+      "real-analysis",
+      "egorov",
+      "counterexample",
+      "sharpness",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 159,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "marching_not_tendstoUniformlyOn: the headline necessity result — for EVERY set t of finite Lebesgue measure, the marching indicators 𝟙_[n,n+1) do NOT converge uniformly to 0 on tᶜ, even though they converge to 0 at every point of ℝ. This proves Egorov's finiteness hypothesis μ s ≠ ∞ is essential: no finite-measure (let alone arbitrarily small) exceptional set can be removed to recover uniform convergence on the σ-finite-but-infinite line. Not in Mathlib.",
+      "exists_uncovered: the geometric obstruction — a finite-measure set t cannot contain the ray [N,∞) (infinite measure), so beyond any threshold N some unit block [n,n+1) with n ≥ N still contains a point outside t. Proved by sending x ≥ N to its block ⌊x⌋₊ and contradicting Real.volume_Ici = ∞ via measure_mono.",
+      "marching_tendsto_zero: the marching indicators converge to 0 at EVERY real point (not merely a.e.) — for fixed x, every block past ⌊x⌋₊ lies strictly right of x, so marching n x = 0 eventually; proved by eventual-constancy (tendsto_const_nhds.congr').",
+      "marching_stronglyMeasurable: each 𝟙_[n,n+1) is strongly measurable, certifying that the family satisfies every hypothesis of Egorov's theorem EXCEPT finiteness of the ambient measure — isolating finiteness as the single load-bearing assumption.",
+      "egorov_finiteness_essential: the capstone bundling measurability + everywhere-convergence + no-finite-exceptional-set, the machine-checked statement that Egorov's theorem is sharp in its finiteness hypothesis."
+    ],
+    "prerequisites": [
+      "Real.volume_Ici: the ray [a,∞) has infinite Lebesgue measure — the source of the contradiction in exists_uncovered",
+      "Metric.tendstoUniformlyOn_iff: the ε-characterization of uniform convergence on a set, used to refute uniform convergence on tᶜ",
+      "Set.indicator_of_mem / Set.indicator_of_notMem: the defining values of the indicator function on and off its support set",
+      "Nat.le_floor, Nat.floor_le, Nat.lt_floor_add_one: the floor sandwich ⌊x⌋₊ ≤ x < ⌊x⌋₊ + 1 locating x in its unit block",
+      "StronglyMeasurable.indicator: the indicator of a measurable set by a measurable function is strongly measurable"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.volume_Ici",
+        "description": "The Lebesgue measure of the ray [a, ∞) is ∞. The keystone: a finite-measure set cannot contain such a ray, which forces the marching indicators to keep escaping any finite-measure exceptional set.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "Metric.tendstoUniformlyOn_iff",
+        "description": "Uniform convergence on a set s is equivalent to: for every ε > 0, eventually dist (f x) (Fₙ x) < ε for all x ∈ s. Used to refute uniform convergence of the marching indicators on tᶜ.",
+        "module": "Mathlib.Topology.MetricSpace.Pseudo.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.tendstoUniformlyOn_of_ae_tendsto",
+        "description": "Egorov's theorem: a.e. convergence on a measurable FINITE-measure set upgrades to uniform convergence off an arbitrarily small subset. This entry exhibits the precise way it breaks when the finite-measure hypothesis is removed.",
+        "module": "Mathlib.MeasureTheory.Function.Egorov"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question `egorov-theorem-oq-01-oq-01`: **the finiteness hypothesis `μ s ≠ ∞` of Egorov's theorem is essential.**

Egorov's theorem upgrades a.e. convergence to uniform convergence off an arbitrarily small set — but only on a *finite-measure* space. This entry exhibits the canonical counterexample on the σ-finite-but-infinite space `(ℝ, Lebesgue)`: the **marching indicators** `marching n = 𝟙_[n,n+1)`, unit-height bumps walking off to `+∞`.

They converge to `0` at **every** point of `ℝ`, yet **no** finite-measure exceptional set can be removed to make the convergence uniform.

## Theorems

- `marching_tendsto_zero` — converges to 0 at every real point (for fixed `x`, every block past `⌊x⌋₊` lies right of `x`, so `marching n x = 0` eventually).
- `exists_uncovered` — geometric obstruction: a finite-measure `t` cannot contain the ray `[N,∞)` (infinite measure, `Real.volume_Ici`), so beyond any threshold some unit block still pokes out of `t`.
- `marching_not_tendstoUniformlyOn` — headline: for **every** finite-measure `t`, no uniform convergence to 0 on `tᶜ`.
- `marching_stronglyMeasurable` — the family meets every Egorov hypothesis *except* finiteness, isolating it as the single load-bearing assumption.
- `egorov_finiteness_essential` — capstone bundling the three.

This is the sharpness companion to the parent entry (which shows the exceptional set itself cannot be omitted). Together they pin down exactly which hypotheses of Egorov's theorem are load-bearing. Not recorded in Mathlib.

## Verification

- **159 lines, 6 theorems, 1 definition, 0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms egorov_finiteness_essential` → `[propext, Classical.choice, Quot.sound]` (foundational only).
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.EgorovMarching`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)