### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-01): generalized n-fold Hölder inequality for finite sums [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2910,6 +2910,7 @@ import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
 import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01
+import Proofs.JensenInequalityOQ01OQ01OQ01OQ01
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,134 @@
+import Mathlib.Analysis.MeanInequalities
+
+/-
+# Generalized (n-fold) Hölder inequality for finite sums
+
+This file proves the **generalized Hölder inequality** for finite sums with `n` exponents,
+filling a gap in Mathlib, which provides only the two-exponent discrete Hölder inequality
+`NNReal.inner_le_Lp_mul_Lq` / `Real.inner_le_Lp_mul_Lq_of_nonneg`.
+
+Given finitely many nonnegative functions `f j : ι → ℝ` (`j ∈ t`) and positive exponents
+`p j` with `∑ j, (p j)⁻¹ = 1`, we prove
+`∑ i ∈ s, ∏ j ∈ t, f j i ≤ ∏ j ∈ t, (∑ i ∈ s, f j i ^ p j) ^ (p j)⁻¹`.
+
+The two-function case `t = {a, b}` with `1 / p a + 1 / p b = 1` recovers the classical Hölder
+inequality `∑ᵢ uᵢ vᵢ ≤ (∑ᵢ uᵢ ^ p) ^ (1/p) · (∑ᵢ vᵢ ^ q) ^ (1/q)`.
+
+## Main results
+
+* `young_product` : the pointwise `n`-variable Young product inequality
+  `∏ j, a j ≤ ∑ j, (p j)⁻¹ * a j ^ p j`, a direct consequence of the weighted AM–GM
+  inequality `Real.geom_mean_le_arith_mean_weighted`.
+* `generalized_holder` : the generalized Hölder inequality for finite sums.
+* `inner_le_holder_two` : the two-function specialization, the shape of the classical discrete
+  Hölder inequality.
+
+## Strategy
+
+`young_product` follows from weighted AM–GM with weights `w j = (p j)⁻¹` and data
+`z j = a j ^ p j`, using the telescoping identity `(a j ^ p j) ^ (p j)⁻¹ = a j`.
+
+`generalized_holder` follows by the standard normalization argument: divide each `f j` by its
+`Lᵖ`-norm `C j = (∑ i, f j i ^ p j) ^ (p j)⁻¹`, apply `young_product` pointwise to the
+normalized functions, and sum.  The `C j = 0` columns are handled separately (the left-hand side
+is then `0`).
+-/
+
+open Finset
+
+namespace JensenHolder
+
+variable {ι κ : Type*}
+
+/-- **`n`-variable Young product inequality.** For nonnegative reals `a j` and positive exponents
+`p j` whose reciprocals sum to `1`, the product `∏ a j` is bounded by the weighted sum of
+`p j`-th powers `∑ (p j)⁻¹ * a j ^ p j`.  This is the pointwise tool behind the generalized
+Hölder inequality. -/
+theorem young_product (t : Finset κ) (a p : κ → ℝ)
+    (ha : ∀ j ∈ t, 0 ≤ a j) (hp : ∀ j ∈ t, 0 < p j)
+    (hsum : ∑ j ∈ t, (p j)⁻¹ = 1) :
+    ∏ j ∈ t, a j ≤ ∑ j ∈ t, (p j)⁻¹ * a j ^ p j :=
+  calc
+    ∏ j ∈ t, a j = ∏ j ∈ t, (a j ^ p j) ^ (p j)⁻¹ := by
+        refine prod_congr rfl fun j hj => ?_
+        rw [← Real.rpow_mul (ha j hj), mul_inv_cancel₀ (hp j hj).ne', Real.rpow_one]
+    _ ≤ ∑ j ∈ t, (p j)⁻¹ * a j ^ p j :=
+        Real.geom_mean_le_arith_mean_weighted t (fun j => (p j)⁻¹) (fun j => a j ^ p j)
+          (fun j hj => inv_nonneg.2 (hp j hj).le) hsum
+          (fun j hj => Real.rpow_nonneg (ha j hj) _)
+
+/-- **Generalized (n-fold) Hölder inequality for finite sums.** For nonnegative functions
+`f j : ι → ℝ` indexed by `j ∈ t` and positive exponents `p j` whose reciprocals sum to `1`,
+the sum of the products is bounded by the product of the `Lᵖ`-norms:
+`∑ i ∈ s, ∏ j ∈ t, f j i ≤ ∏ j ∈ t, (∑ i ∈ s, f j i ^ p j) ^ (p j)⁻¹`. -/
+theorem generalized_holder (s : Finset ι) (t : Finset κ) (f : κ → ι → ℝ) (p : κ → ℝ)
+    (hf : ∀ j ∈ t, ∀ i ∈ s, 0 ≤ f j i) (hp : ∀ j ∈ t, 0 < p j)
+    (hsum : ∑ j ∈ t, (p j)⁻¹ = 1) :
+    ∑ i ∈ s, ∏ j ∈ t, f j i ≤ ∏ j ∈ t, (∑ i ∈ s, f j i ^ p j) ^ (p j)⁻¹ := by
+  have hNnonneg : ∀ j ∈ t, 0 ≤ ∑ i ∈ s, f j i ^ p j := fun j hj =>
+    sum_nonneg fun i hi => Real.rpow_nonneg (hf j hj i hi) _
+  by_cases hzero : ∃ j ∈ t, (∑ i ∈ s, f j i ^ p j) = 0
+  · -- a column `j₀` is identically zero ⇒ the left-hand side is `0`.
+    obtain ⟨j₀, hj₀, hNj₀⟩ := hzero
+    have hfzero : ∀ i ∈ s, f j₀ i = 0 := by
+      intro i hi
+      have hterm : f j₀ i ^ p j₀ = 0 :=
+        (sum_eq_zero_iff_of_nonneg
+          (fun i hi => Real.rpow_nonneg (hf j₀ hj₀ i hi) _)).1 hNj₀ i hi
+      exact ((Real.rpow_eq_zero_iff_of_nonneg (hf j₀ hj₀ i hi)).1 hterm).1
+    have hLHS : ∑ i ∈ s, ∏ j ∈ t, f j i = 0 :=
+      sum_eq_zero fun i hi => prod_eq_zero hj₀ (hfzero i hi)
+    rw [hLHS]
+    exact prod_nonneg fun j hj => Real.rpow_nonneg (hNnonneg j hj) _
+  · -- every column is strictly positive: normalize and apply `young_product`.
+    push_neg at hzero
+    have hNpos : ∀ j ∈ t, 0 < ∑ i ∈ s, f j i ^ p j := fun j hj =>
+      (hNnonneg j hj).lt_of_ne (Ne.symm (hzero j hj))
+    set C : κ → ℝ := fun j => (∑ i ∈ s, f j i ^ p j) ^ (p j)⁻¹ with hCdef
+    have hCpos : ∀ j ∈ t, 0 < C j := fun j hj => Real.rpow_pos_of_pos (hNpos j hj) _
+    have hCp : ∀ j ∈ t, C j ^ p j = ∑ i ∈ s, f j i ^ p j := by
+      intro j hj
+      show ((∑ i ∈ s, f j i ^ p j) ^ (p j)⁻¹) ^ p j = ∑ i ∈ s, f j i ^ p j
+      rw [← Real.rpow_mul (hNnonneg j hj), inv_mul_cancel₀ (hp j hj).ne', Real.rpow_one]
+    have hprodCpos : 0 < ∏ j ∈ t, C j := prod_pos fun j hj => hCpos j hj
+    rw [← div_le_one hprodCpos]
+    have hrw : (∑ i ∈ s, ∏ j ∈ t, f j i) / (∏ j ∈ t, C j)
+        = ∑ i ∈ s, ∏ j ∈ t, f j i / C j := by
+      rw [sum_div]
+      exact sum_congr rfl fun i hi => (prod_div_distrib _ _).symm
+    rw [hrw]
+    calc
+      ∑ i ∈ s, ∏ j ∈ t, f j i / C j
+          ≤ ∑ i ∈ s, ∑ j ∈ t, (p j)⁻¹ * (f j i / C j) ^ p j := by
+            refine sum_le_sum fun i hi => ?_
+            exact young_product t (fun j => f j i / C j) p
+              (fun j hj => div_nonneg (hf j hj i hi) (hCpos j hj).le) hp hsum
+      _ = ∑ j ∈ t, (p j)⁻¹ * ∑ i ∈ s, (f j i / C j) ^ p j := by
+            rw [sum_comm]
+            exact sum_congr rfl fun j hj => (mul_sum _ _ _).symm
+      _ = ∑ j ∈ t, (p j)⁻¹ * 1 := by
+            refine sum_congr rfl fun j hj => ?_
+            congr 1
+            have hpoint : ∑ i ∈ s, (f j i / C j) ^ p j
+                = ∑ i ∈ s, f j i ^ p j / C j ^ p j :=
+              sum_congr rfl fun i hi => Real.div_rpow (hf j hj i hi) (hCpos j hj).le _
+            rw [hpoint, ← sum_div, hCp j hj, div_self (hNpos j hj).ne']
+      _ = 1 := by simp only [mul_one]; exact hsum
+
+/-- **Two-function (classical) Hölder inequality** for finite sums, as the `t = {0, 1}`
+specialization of `generalized_holder`.  For nonnegative `u v : ι → ℝ` and conjugate exponents
+`1 < p`, `1 < q` with `p⁻¹ + q⁻¹ = 1`,
+`∑ i, u i * v i ≤ (∑ i, u i ^ p) ^ p⁻¹ * (∑ i, v i ^ q) ^ q⁻¹`. -/
+theorem inner_le_holder_two (s : Finset ι) (u v : ι → ℝ) (p q : ℝ)
+    (hu : ∀ i ∈ s, 0 ≤ u i) (hv : ∀ i ∈ s, 0 ≤ v i)
+    (hp : 0 < p) (hq : 0 < q) (hpq : p⁻¹ + q⁻¹ = 1) :
+    ∑ i ∈ s, u i * v i
+      ≤ (∑ i ∈ s, u i ^ p) ^ p⁻¹ * (∑ i ∈ s, v i ^ q) ^ q⁻¹ := by
+  have h := generalized_holder s (univ : Finset (Fin 2))
+    (fun j i => if j = 0 then u i else v i) (fun j => if j = 0 then p else q)
+    (by intro j _ i hi; fin_cases j <;> simp [hu i hi, hv i hi])
+    (by intro j _; fin_cases j <;> simp [hp, hq])
+    (by simp [Fin.sum_univ_two, hpq])
+  simpa [Fin.sum_univ_two, Fin.prod_univ_two] using h
+
+end JensenHolder

--- a/research/registry.json
+++ b/research/registry.json
@@ -25307,6 +25307,15 @@
       "status": "graduated",
       "lastUpdate": "2026-06-22T20:10:41.158Z",
       "completed": "2026-06-22T20:10:41.158Z"
+    },
+    {
+      "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-06-22T21:30:00.000Z",
+      "status": "completed",
+      "lastUpdate": "2026-06-22T21:30:00.000Z",
+      "completed": "2026-06-22T21:30:00.000Z"
     }
   ],
   "config": {
@@ -25314,5 +25323,5 @@
     "oodaTimeoutMinutes": 60,
     "attemptsBeforePivot": 5
   },
-  "lastUpdated": "2026-06-16"
+  "lastUpdated": "2026-06-22T21:30:00.000Z"
 }

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+  "title": "Generalized n-fold Hölder Inequality for Finite Sums",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+  "description": "Proves the generalized (n-exponent) Hölder inequality for finite sums, which Mathlib does not provide — it ships only the two-exponent discrete Hölder inequality. For finitely many nonnegative functions f_j : ι → ℝ indexed by j ∈ t and positive exponents p_j whose reciprocals sum to 1, the sum of the products is bounded by the product of the Lᵖ-norms: ∑_{i∈s} ∏_{j∈t} f_j(i) ≤ ∏_{j∈t} (∑_{i∈s} f_j(i)^{p_j})^{1/p_j}. The pointwise engine is the n-variable Young product inequality ∏_j a_j ≤ ∑_j (1/p_j)·a_j^{p_j} (itself a one-line consequence of Mathlib's weighted AM–GM, Real.geom_mean_le_arith_mean_weighted); the sum form then follows by the classical normalization argument — divide each f_j by its Lᵖ-norm and apply Young pointwise. The two-function specialization recovers the classical Hölder inequality ∑ u_i v_i ≤ (∑ u_i^p)^{1/p}(∑ v_i^q)^{1/q}.",
+  "meta": {
+    "author": "Lean Genius (generalized n-fold Hölder via normalization); O. Hölder (1889), L. J. Rogers (1888)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "holder-inequality",
+      "young-inequality",
+      "am-gm-inequality",
+      "lp-spaces",
+      "inequalities",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 134,
+    "originalContributions": [
+      "generalized_holder: the generalized n-fold Hölder inequality for finite sums ∑_{i∈s} ∏_{j∈t} f_j(i) ≤ ∏_{j∈t} (∑_{i∈s} f_j(i)^{p_j})^{1/p_j} for any finite family of nonnegative functions and positive exponents with ∑_j 1/p_j = 1 — absent from Mathlib, which provides only the two-exponent case. Proved by normalizing each f_j by its Lᵖ-norm and applying the pointwise Young product inequality, with the degenerate (zero-norm) columns handled separately.",
+      "young_product: the n-variable Young product inequality ∏_{j∈t} a_j ≤ ∑_{j∈t} (p_j)⁻¹·a_j^{p_j} for nonnegative a_j and positive exponents with ∑_j 1/p_j = 1, obtained from Mathlib's weighted AM–GM with weights 1/p_j and data a_j^{p_j} via the telescoping identity (a_j^{p_j})^{1/p_j} = a_j",
+      "inner_le_holder_two: the classical two-function Hölder inequality ∑ u_i v_i ≤ (∑ u_i^p)^{1/p}(∑ v_i^q)^{1/q} for conjugate exponents, recovered as the t = {0,1} (Fin 2) specialization of generalized_holder"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Self-contained, importing only Mathlib (Real.geom_mean_le_arith_mean_weighted and the rpow library); does not depend on any other gallery file.",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the pointwise n-variable Young product inequality ∏ a_i ≤ ∑ a_i^{p_i}/p_i with its equality case. This entry uses that pointwise inequality (re-proved here self-contained as young_product) as the engine to derive the generalized Hölder inequality for finite sums."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the first open question of the Young's-inequality entry: 'Lift to the equality/inequality case of Hölder's inequality for finite sums.' Here we establish the n-fold inequality form for finite sums."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Hölder's inequality (O. Hölder, 1889; anticipated by L. J. Rogers, 1888) is the cornerstone inequality of Lᵖ-space duality. Its pointwise engine is Young's inequality, itself the two-term weighted AM–GM. The generalized n-fold form — with n exponents p_1,…,p_n satisfying ∑ 1/p_j = 1 — bounds a sum of products of n functions by the product of their individual Lᵖ-norms, and is the standard tool for estimating products of more than two factors. Mathlib formalizes the two-exponent discrete Hölder inequality and the general weighted AM–GM, but not the n-fold Hölder inequality for finite sums; this entry supplies it.",
+    "problemStatement": "Mathlib provides the two-exponent discrete Hölder inequality and the general weighted AM–GM inequality, but not the generalized n-fold Hölder inequality for finite sums. Prove that for nonnegative functions f_j : ι → ℝ (j ∈ t) and positive exponents p_j with ∑_j 1/p_j = 1, ∑_{i∈s} ∏_{j∈t} f_j(i) ≤ ∏_{j∈t} (∑_{i∈s} f_j(i)^{p_j})^{1/p_j}.",
+    "proofStrategy": "First establish the pointwise n-variable Young product inequality ∏_j a_j ≤ ∑_j (1/p_j)·a_j^{p_j}: apply Mathlib's weighted AM–GM Real.geom_mean_le_arith_mean_weighted with weights w_j = 1/p_j and data z_j = a_j^{p_j}; the geometric-mean side ∏_j (a_j^{p_j})^{1/p_j} telescopes to ∏_j a_j because (a_j^{p_j})^{1/p_j} = a_j^{p_j·p_j⁻¹} = a_j. For the sum form, set C_j = (∑_i f_j(i)^{p_j})^{1/p_j}, the Lᵖ-norm of f_j. If some C_j = 0 then f_j ≡ 0 and the left-hand side vanishes. Otherwise every C_j > 0; normalizing g_j = f_j/C_j gives ∑_i g_j(i)^{p_j} = 1, and applying Young pointwise then summing over i yields ∑_i ∏_j g_j(i) ≤ ∑_j (1/p_j)·1 = 1. Since ∑_i ∏_j g_j(i) = (∑_i ∏_j f_j(i))/∏_j C_j, multiplying through by ∏_j C_j gives the inequality.",
+    "keyInsights": [
+      "The n-fold Hölder inequality is, like its two-exponent ancestor, a corollary of weighted AM–GM: the only pointwise fact needed is the n-variable Young product inequality, which is weighted AM–GM applied to the data a_j^{p_j} with weights 1/p_j.",
+      "Normalization converts the arithmetic-mean bound into the geometric-mean (product-of-norms) bound: applying Young directly to f_j gives only ∑_i ∏_j f_j(i) ≤ ∑_j (1/p_j)·‖f_j‖_p^{p}, the weaker arithmetic bound; dividing by the Lᵖ-norms first is exactly what sharpens it to the product ∏_j ‖f_j‖_p.",
+      "The degenerate columns C_j = 0 must be split off before normalizing (one cannot divide by a zero norm); in that case the corresponding f_j vanishes identically, forcing every product to contain a zero factor, so the left-hand side is 0 and the bound is trivial.",
+      "The telescoping (a^p)^{1/p} = a, via Real.rpow_mul and p·p⁻¹ = 1, is the same exponent-bookkeeping trick that drives Young's inequality, reused here uniformly across all n exponents.",
+      "The two-function Hölder inequality is recovered with no extra work as the t = {0,1} instance over Fin 2, evaluated with Fin.prod_univ_two / Fin.sum_univ_two."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "States the goal — the generalized n-fold Hölder inequality for finite sums, a gap in Mathlib — and outlines the normalization strategy built on the n-variable Young product inequality.",
+      "mathContext": "Generalized Hölder: $\\sum_{i\\in s}\\prod_{j\\in t} f_j(i) \\le \\prod_{j\\in t}\\big(\\sum_{i\\in s} f_j(i)^{p_j}\\big)^{1/p_j}$ when $\\sum_j 1/p_j = 1$, $p_j>0$, $f_j\\ge 0$."
+    },
+    {
+      "id": "young-product",
+      "title": "n-variable Young product inequality",
+      "startLine": 46,
+      "endLine": 62,
+      "summary": "young_product: ∏_j a_j ≤ ∑_j (p_j)⁻¹·a_j^{p_j}, from weighted AM–GM with weights 1/p_j and data a_j^{p_j}; the geometric mean ∏_j (a_j^{p_j})^{1/p_j} telescopes to ∏_j a_j.",
+      "mathContext": "For $a_j\\ge0$, $p_j>0$, $\\sum_j p_j^{-1}=1$: $\\prod_j a_j = \\prod_j (a_j^{p_j})^{1/p_j} \\le \\sum_j p_j^{-1} a_j^{p_j}$ by $\\mathrm{geom\\_mean\\_le\\_arith\\_mean\\_weighted}$."
+    },
+    {
+      "id": "generalized-holder",
+      "title": "Generalized Hölder inequality",
+      "startLine": 63,
+      "endLine": 120,
+      "summary": "generalized_holder: normalize each f_j by its Lᵖ-norm C_j, handle C_j = 0 columns separately, apply young_product pointwise to g_j = f_j/C_j and sum to get ∑_i ∏_j g_j(i) ≤ 1, then multiply through by ∏_j C_j.",
+      "mathContext": "With $C_j=(\\sum_i f_j(i)^{p_j})^{1/p_j}$: $\\sum_i\\prod_j (f_j(i)/C_j) \\le \\sum_j p_j^{-1}\\sum_i (f_j(i)/C_j)^{p_j} = \\sum_j p_j^{-1} = 1$, and the LHS equals $(\\sum_i\\prod_j f_j(i))/\\prod_j C_j$."
+    },
+    {
+      "id": "holder-two",
+      "title": "Two-function (classical) Hölder inequality",
+      "startLine": 121,
+      "endLine": 134,
+      "summary": "inner_le_holder_two: the t = {0,1} specialization over Fin 2, recovering ∑ u_i v_i ≤ (∑ u_i^p)^{1/p}(∑ v_i^q)^{1/q} for conjugate exponents 1/p + 1/q = 1.",
+      "mathContext": "$\\sum_i u_i v_i \\le \\big(\\sum_i u_i^p\\big)^{1/p}\\big(\\sum_i v_i^q\\big)^{1/q}$ for $p,q>0$ with $p^{-1}+q^{-1}=1$, evaluated via $\\mathrm{Fin.prod\\_univ\\_two}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 134-line file (0 sorries, 0 axioms, no native_decide) supplies the generalized n-fold Hölder inequality for finite sums, which Mathlib does not provide. The proof factors through the n-variable Young product inequality (young_product), itself a one-line consequence of Mathlib's weighted AM–GM, and the standard normalization-by-Lᵖ-norm argument. The classical two-function Hölder inequality is recovered as a Fin 2 specialization.",
+    "implications": "Together with the parent entries this completes the AM–GM → Young → Hölder ladder for finite sums: weighted AM–GM gives the pointwise Young product inequality, and normalization lifts it to the n-fold Hölder bound. The generalized form is the tool for estimating sums of products of more than two factors (e.g. interpolation inequalities and products of Lᵖ functions), where the two-exponent Hölder inequality does not directly apply.",
+    "openQuestions": [
+      "Prove the equality case of the generalized Hölder inequality: equality holds iff the normalized columns f_j^{p_j}/‖f_j‖_p^{p_j} are all equal (proportionality of the f_j^{p_j}), descending from the weighted AM–GM equality case.",
+      "Lift the generalized Hölder inequality from finite sums to the Lᵖ / integral setting and to ℝ≥0∞-valued functions, matching the generality of Mathlib's two-exponent ENNReal Hölder inequality.",
+      "Derive the generalized Minkowski inequality (triangle inequality for the Lᵖ-norm of a sum) from the same normalization machinery."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 134,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 3,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-01.json
@@ -1,0 +1,69 @@
+{
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+  "title": "Generalized n-fold Hölder Inequality for Finite Sums",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\sum_{i\\in s}\\prod_{j\\in t} f_j(i) \\le \\prod_{j\\in t}\\Big(\\sum_{i\\in s} f_j(i)^{p_j}\\Big)^{1/p_j} \\quad\\Big(\\sum_{j} 1/p_j = 1,\\ p_j>0,\\ f_j\\ge 0\\Big)",
+    "plain": "Mathlib provides the two-exponent discrete Hölder inequality and the general weighted AM–GM inequality, but not the generalized n-fold Hölder inequality for finite sums. Prove that for nonnegative functions f_j and positive exponents p_j with ∑_j 1/p_j = 1, the sum of products is bounded by the product of the Lᵖ-norms, by normalizing each f_j by its norm and applying the n-variable Young product inequality pointwise.",
+    "whyMatters": [
+      "Fills a real Mathlib gap: only the two-exponent discrete Hölder inequality is available",
+      "The n-fold form is the standard tool for bounding products of more than two factors (interpolation, products of Lᵖ functions)",
+      "Completes the AM–GM → Young → Hölder ladder for finite sums"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T14:30:00-07:00",
+    "iteration": 1,
+    "focus": "Prove the generalized n-fold Hölder inequality for finite sums via normalization and the n-variable Young product inequality.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved the generalized n-fold Hölder inequality for finite sums ∑_{i∈s} ∏_{j∈t} f_j(i) ≤ ∏_{j∈t} (∑_{i∈s} f_j(i)^{p_j})^{1/p_j} for any finite family with ∑ 1/p_j = 1. 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean (134L, 3 thm). Self-contained: young_product re-derives the n-variable Young product inequality from Real.geom_mean_le_arith_mean_weighted (weights 1/p_j, data a_j^{p_j}, telescoping (a^p)^{1/p}=a); generalized_holder normalizes by the Lᵖ-norm C_j = (∑ f_j^{p_j})^{1/p_j} (handling C_j=0 columns separately) and sums; inner_le_holder_two is the Fin 2 specialization recovering classical two-function Hölder.",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01OQ01OQ01OQ01.lean: generalized_holder (n-fold Hölder for finite sums — Mathlib gap)",
+      "young_product (n-variable Young product inequality, from weighted AM–GM)",
+      "inner_le_holder_two (classical two-function Hölder, Fin 2 specialization)",
+      "src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01/ gallery entry"
+    ],
+    "insights": [
+      "The n-fold Hölder inequality is a corollary of weighted AM–GM: the only pointwise fact needed is the n-variable Young product inequality ∏ a_j ≤ ∑ (1/p_j) a_j^{p_j}",
+      "Normalization by the Lᵖ-norm is what sharpens the arithmetic-mean bound (∑_i ∏_j f_j ≤ ∑_j (1/p_j)‖f_j‖_p^p) into the geometric-mean product-of-norms bound ∏_j ‖f_j‖_p",
+      "Zero-norm columns must be split off before dividing; there the f_j vanishes identically, so the left-hand side is 0 and the bound is trivial",
+      "The two-function Hölder inequality is recovered with no extra work as the t = {0,1} instance over Fin 2 (Fin.prod_univ_two / Fin.sum_univ_two)"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the two-exponent discrete Hölder inequality (inner_le_Lp_mul_Lq) and general weighted AM–GM, but NOT the generalized n-fold Hölder inequality for finite sums; generalized_holder here is the missing result and a natural upstream contribution"
+    ],
+    "nextSteps": [
+      "Prove the equality case: equality iff the normalized columns f_j^{p_j}/‖f_j‖_p^{p_j} are all equal",
+      "Lift to the Lᵖ / integral and ℝ≥0∞ settings, matching Mathlib's two-exponent ENNReal Hölder",
+      "Derive the generalized Minkowski inequality from the same normalization machinery"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01-oq-01-oq-01-oq-01\n\n## Problem Understanding\n\nProve the generalized n-fold Hölder inequality for finite sums (a Mathlib gap) from the n-variable Young product inequality by the standard normalization argument.\n\n## Insights\n\nWeighted AM–GM with weights 1/p_j and data a_j^{p_j} gives the pointwise Young product inequality ∏ a_j ≤ ∑ (1/p_j) a_j^{p_j} (the geometric mean ∏ (a_j^{p_j})^{1/p_j} telescopes to ∏ a_j). Dividing each f_j by its Lᵖ-norm C_j and applying Young pointwise, then summing, gives ∑_i ∏_j (f_j/C_j) ≤ ∑_j (1/p_j) = 1; since this sum equals (∑_i ∏_j f_j)/∏_j C_j, the result follows. The C_j = 0 columns are handled separately (left side vanishes).\n\n## Dead Ends\n\nNone substantive — two first-build fixes: prod_div_distrib needs explicit function arguments, and the per-column normalization needs div_rpow applied pointwise before sum_div.\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "holder-inequality",
+    "young-inequality",
+    "am-gm-inequality",
+    "lp-spaces",
+    "inequalities",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **generalized n-fold Hölder inequality for finite sums**, a gap in Mathlib (which provides only the two-exponent discrete Hölder inequality `inner_le_Lp_mul_Lq` and the general weighted AM–GM):

For nonnegative functions `f_j : ι → ℝ` (`j ∈ t`) and positive exponents `p_j` with `∑_j 1/p_j = 1`,
```
∑_{i∈s} ∏_{j∈t} f_j(i) ≤ ∏_{j∈t} (∑_{i∈s} f_j(i)^{p_j})^{1/p_j}.
```

This answers the first open question of the parent Young's-inequality entry (lift to Hölder for finite sums), and is the natural child of the n-variable Young product inequality.

## Results (3 theorems, 0 definitions)

- **`young_product`** — the pointwise n-variable Young product inequality `∏_j a_j ≤ ∑_j (p_j)⁻¹·a_j^{p_j}`, derived in two lines from `Real.geom_mean_le_arith_mean_weighted` (weights `1/p_j`, data `a_j^{p_j}`, telescoping `(a^p)^{1/p}=a`).
- **`generalized_holder`** — the n-fold Hölder inequality, by normalizing each `f_j` by its Lᵖ-norm `C_j = (∑_i f_j(i)^{p_j})^{1/p_j}` (zero-norm columns handled separately) and applying `young_product` pointwise, then summing.
- **`inner_le_holder_two`** — the classical two-function Hölder inequality `∑ u_i v_i ≤ (∑ u_i^p)^{1/p}(∑ v_i^q)^{1/q}`, recovered as the `t = {0,1}` (Fin 2) specialization.

## Verification

- 134 lines, 0 sorries, **no `native_decide`**.
- `#print axioms` for all three theorems: `[propext, Classical.choice, Quot.sound]` only — fully verified, 0 axioms by project policy.
- Self-contained: imports only Mathlib; does not depend on any other gallery file.
- Builds via `./proofs/scripts/docker-build.sh Proofs.JensenInequalityOQ01OQ01OQ01OQ01`.

## Key idea

The n-fold Hölder inequality is a corollary of weighted AM–GM. Applying Young directly to the `f_j` gives only the weaker arithmetic-mean bound `∑_i ∏_j f_j ≤ ∑_j (1/p_j)‖f_j‖_p^p`; **dividing by the Lᵖ-norms first** is exactly what sharpens it to the geometric-mean product-of-norms bound `∏_j ‖f_j‖_p`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)