### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-02): generalized finite-family Minkowski inequality for discrete ℓᵖ norms [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2910,6 +2910,7 @@ import Proofs.JacobiSumDiagonalIntegral
 import Proofs.JacobiSymbolOQ01
 import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01
+import Proofs.JensenInequalityOQ01OQ01OQ01OQ02
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,116 @@
+/-
+# The Generalized (Finite-Family) Minkowski Inequality
+
+The two-vector Minkowski inequality — the triangle inequality for the discrete `ℓᵖ` "norm" —
+states that for `1 ≤ p`, a coordinate set `s`, and nonnegative vectors `f, g : ι → ℝ`,
+
+    ‖f + g‖_p ≤ ‖f‖_p + ‖g‖_p,    where ‖h‖_p := (∑ᵢ h(i)ᵖ)^{1/p}.
+
+Mathlib provides exactly this two-vector form (`Real.Lp_add_le_of_nonneg`), but **not** the
+generalization to an arbitrary *finite family* of vectors. This file supplies that gap:
+
+    ‖∑ⱼ Fⱼ‖_p ≤ ∑ⱼ ‖Fⱼ‖_p,
+
+i.e. for a finite index set `t` of vectors `Fⱼ : ι → ℝ` (all nonnegative on `s`),
+
+    (∑ᵢ (∑ⱼ Fⱼ(i))ᵖ)^{1/p} ≤ ∑ⱼ (∑ᵢ Fⱼ(i)ᵖ)^{1/p}.
+
+This is the `ℓᵖ`-norm analogue, and the exact sibling, of the parent file's generalization of the
+two-term to the `n`-term Young/Hölder inequality (`JensenInequalityOQ01OQ01OQ01`): there the
+*two-factor* product inequality was lifted to a *finite family of factors*; here the *two-vector*
+triangle inequality is lifted to a *finite family of vectors*. The proof is the textbook one:
+induction on the family, using the two-vector case at each step (subadditivity of a seminorm).
+
+While Mathlib's abstract `PiLp`/`WithLp` machinery yields a triangle inequality through the general
+normed-space API, the elementary closed-form `Finset.sum` statement below — directly comparable to
+`Real.Lp_add_le_of_nonneg` and usable without instantiating any normed-space structure — is not
+available in Mathlib.
+
+## Main results
+
+* `Lpnorm`            — the unnormalised discrete `ℓᵖ` "norm" `(∑ᵢ h(i)ᵖ)^{1/p}`.
+* `Lpnorm_nonneg`     — the norm of a nonnegative vector is nonnegative.
+* `Lpnorm_add_le`     — the two-vector triangle inequality (Mathlib's, in this notation).
+* `minkowski_finset`  — **the finite-family Minkowski inequality** `‖∑ⱼ Fⱼ‖_p ≤ ∑ⱼ ‖Fⱼ‖_p`.
+* `Lpnorm_add3`       — the three-vector instance, derived from `minkowski_finset` (a case Mathlib
+                        does not provide), witnessing that the family form genuinely generalizes.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace JensenMinkowski
+
+variable {ι κ : Type*} {s : Finset ι} {p : ℝ}
+
+/-- The unnormalised discrete `ℓᵖ` "norm" of a vector `g : ι → ℝ` over the coordinate set `s`:
+`Lpnorm s p g = (∑ i ∈ s, g i ^ p) ^ (1/p)`. For `1 ≤ p` and nonnegative `g` this is the genuine
+`ℓᵖ` norm of the restriction of `g` to `s`. -/
+noncomputable def Lpnorm (s : Finset ι) (p : ℝ) (g : ι → ℝ) : ℝ :=
+  (∑ i ∈ s, g i ^ p) ^ (1 / p)
+
+/-- The `ℓᵖ` norm of a nonnegative vector is nonnegative. -/
+theorem Lpnorm_nonneg {g : ι → ℝ} (hg : ∀ i ∈ s, 0 ≤ g i) : 0 ≤ Lpnorm s p g := by
+  refine Real.rpow_nonneg (Finset.sum_nonneg fun i hi => ?_) _
+  exact Real.rpow_nonneg (hg i hi) _
+
+/-- **Two-vector Minkowski inequality** in the `Lpnorm` notation: `‖f + g‖_p ≤ ‖f‖_p + ‖g‖_p`.
+This is `Real.Lp_add_le_of_nonneg` restated; it is the base step of the finite-family form. -/
+theorem Lpnorm_add_le (hp : 1 ≤ p) {f g : ι → ℝ} (hf : ∀ i ∈ s, 0 ≤ f i)
+    (hg : ∀ i ∈ s, 0 ≤ g i) :
+    Lpnorm s p (fun i => f i + g i) ≤ Lpnorm s p f + Lpnorm s p g :=
+  Real.Lp_add_le_of_nonneg (s := s) hp hf hg
+
+/-- **The finite-family Minkowski inequality.** For `1 ≤ p`, a finite family of vectors
+`F j : ι → ℝ` (`j ∈ t`) that are nonnegative on the coordinate set `s`, the `ℓᵖ` norm of their sum
+is at most the sum of their `ℓᵖ` norms:
+
+    Lpnorm s p (fun i => ∑ j ∈ t, F j i) ≤ ∑ j ∈ t, Lpnorm s p (F j).
+
+The proof is by induction on the family `t`. The empty family gives the zero vector (norm `0`); the
+inductive step peels one vector off with `Finset.sum_insert`, applies the two-vector triangle
+inequality `Lpnorm_add_le`, and closes with the induction hypothesis. -/
+theorem minkowski_finset (hp : 1 ≤ p) (t : Finset κ) (F : κ → ι → ℝ)
+    (hF : ∀ j ∈ t, ∀ i ∈ s, 0 ≤ F j i) :
+    Lpnorm s p (fun i => ∑ j ∈ t, F j i) ≤ ∑ j ∈ t, Lpnorm s p (F j) := by
+  classical
+  induction t using Finset.induction with
+  | empty =>
+      have hp0 : (0 : ℝ) < p := lt_of_lt_of_le one_pos hp
+      simp only [Finset.sum_empty, Lpnorm, Real.zero_rpow hp0.ne', Finset.sum_const_zero,
+        Real.zero_rpow (one_div_ne_zero hp0.ne'), le_refl]
+  | @insert a u ha ih =>
+      have hFa : ∀ i ∈ s, 0 ≤ F a i := hF a (Finset.mem_insert_self a u)
+      have hFu : ∀ j ∈ u, ∀ i ∈ s, 0 ≤ F j i :=
+        fun j hj => hF j (Finset.mem_insert_of_mem hj)
+      have hG : ∀ i ∈ s, 0 ≤ ∑ j ∈ u, F j i :=
+        fun i hi => Finset.sum_nonneg fun j hj => hFu j hj i hi
+      have hstep : (fun i => ∑ j ∈ insert a u, F j i)
+          = (fun i => F a i + ∑ j ∈ u, F j i) := by
+        funext i; exact Finset.sum_insert ha
+      rw [hstep, Finset.sum_insert ha]
+      calc Lpnorm s p (fun i => F a i + ∑ j ∈ u, F j i)
+          ≤ Lpnorm s p (F a) + Lpnorm s p (fun i => ∑ j ∈ u, F j i) :=
+            Lpnorm_add_le hp hFa hG
+        _ ≤ Lpnorm s p (F a) + ∑ j ∈ u, Lpnorm s p (F j) := by
+            gcongr
+            exact ih hFu
+
+/-- The three-vector triangle inequality, obtained as the `m = 3` instance of `minkowski_finset`
+(a case Mathlib does not provide): `‖f + g + h‖_p ≤ ‖f‖_p + ‖g‖_p + ‖h‖_p`. -/
+theorem Lpnorm_add3 (hp : 1 ≤ p) {f g h : ι → ℝ} (hf : ∀ i ∈ s, 0 ≤ f i)
+    (hg : ∀ i ∈ s, 0 ≤ g i) (hh : ∀ i ∈ s, 0 ≤ h i) :
+    Lpnorm s p (fun i => f i + g i + h i)
+      ≤ Lpnorm s p f + Lpnorm s p g + Lpnorm s p h := by
+  have key := minkowski_finset (s := s) hp (Finset.univ : Finset (Fin 3)) ![f, g, h] ?_
+  · simpa [Fin.sum_univ_three, add_assoc] using key
+  · intro j _ i hi
+    fin_cases j
+    · simpa using hf i hi
+    · simpa using hg i hi
+    · simpa using hh i hi
+
+end JensenMinkowski

--- a/research/registry.json
+++ b/research/registry.json
@@ -25307,6 +25307,15 @@
       "status": "graduated",
       "lastUpdate": "2026-06-22T20:10:41.158Z",
       "completed": "2026-06-22T20:10:41.158Z"
+    },
+    {
+      "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-06-22T21:45:00.000Z",
+      "status": "completed",
+      "lastUpdate": "2026-06-22T21:45:00.000Z",
+      "completed": "2026-06-22T21:45:00.000Z"
     }
   ],
   "config": {

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+  "title": "Generalized (Finite-Family) Minkowski Inequality for Discrete ℓᵖ Norms",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+  "description": "Proves the finite-family Minkowski inequality — the triangle inequality (subadditivity) for the discrete ℓᵖ norm over an arbitrary finite family of vectors — which Mathlib does not provide: it ships only the two-vector form (Real.Lp_add_le_of_nonneg). For 1 ≤ p, a coordinate set s, and finitely many nonnegative vectors F_j : ι → ℝ indexed by j ∈ t, the ℓᵖ norm of their pointwise sum is bounded by the sum of their ℓᵖ norms: (∑_{i∈s} (∑_{j∈t} F_j(i))^p)^{1/p} ≤ ∑_{j∈t} (∑_{i∈s} F_j(i)^p)^{1/p}. The proof is the textbook induction on the family, applying the two-vector Minkowski inequality at each step. This is the ℓᵖ-norm sibling of the parent ladder's generalization of the two-term to the n-term Young/Hölder inequality, and was explicitly flagged as the next step of the n-fold Hölder entry. The three-vector instance is derived from the general theorem over Fin 3, exhibiting a case Mathlib does not provide.",
+  "meta": {
+    "author": "Lean Genius (finite-family Minkowski via induction); H. Minkowski (1896)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "minkowski-inequality",
+      "holder-inequality",
+      "lp-spaces",
+      "triangle-inequality",
+      "inequalities",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 116,
+    "originalContributions": [
+      "minkowski_finset: the finite-family Minkowski inequality Lpnorm s p (fun i => ∑_{j∈t} F_j(i)) ≤ ∑_{j∈t} Lpnorm s p (F_j) for 1 ≤ p and nonnegative vectors F_j — absent from Mathlib, which provides only the two-vector case Real.Lp_add_le_of_nonneg. Proved by Finset.induction on the family, using the two-vector case at each step and the nonnegativity of the partial sums.",
+      "Lpnorm: the discrete ℓᵖ norm Lpnorm s p g = (∑_{i∈s} g(i)^p)^{1/p}, the object whose subadditivity is the Minkowski inequality.",
+      "Lpnorm_add3: the three-vector triangle inequality ‖f+g+h‖_p ≤ ‖f‖_p+‖g‖_p+‖h‖_p, obtained as the m = 3 instance of minkowski_finset over Fin 3 — a case Mathlib does not provide, witnessing that the family form strictly generalizes the two-vector inequality.",
+      "Lpnorm_nonneg: the ℓᵖ norm of a nonnegative vector is nonnegative (used for the partial sums in the induction)."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Self-contained, importing only Mathlib (the two-vector Minkowski inequality Real.Lp_add_le_of_nonneg and the rpow library); does not depend on any other gallery file.",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling of the generalized n-fold Hölder entry, which generalized the two-exponent Hölder inequality to a finite family of exponents. This entry performs the parallel generalization for Minkowski's inequality — two vectors to a finite family of vectors — and was named as the next step in that entry's open questions ('Derive the generalized Minkowski inequality from the same normalization machinery')."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The grandparent of this entry in the Jensen/AM–GM ladder generalizes two-term Young to the n-variable Young product inequality; here the analogous two-vector-to-finite-family generalization is carried out for the ℓᵖ triangle inequality, completing the Hölder–Minkowski pair for finite families."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Minkowski's inequality (H. Minkowski, 1896) is the triangle inequality that makes the Lᵖ-norm a genuine norm for 1 ≤ p; together with Hölder's inequality it is one of the two pillars of Lᵖ-space theory. For two vectors it reads ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p; iterating, the ℓᵖ norm of a sum of finitely many vectors is at most the sum of their ℓᵖ norms (subadditivity of a seminorm). Mathlib formalizes the two-vector form in elementary Finset.sum terms (Real.Lp_add_le_of_nonneg) but not the finite-family generalization in that form; this entry supplies it.",
+    "problemStatement": "Mathlib provides Minkowski's inequality only for the sum of two vectors in elementary Finset.sum form. Prove the finite-family form: for 1 ≤ p, a coordinate set s, and finitely many nonnegative vectors F_j : ι → ℝ (j ∈ t), (∑_{i∈s} (∑_{j∈t} F_j(i))^p)^{1/p} ≤ ∑_{j∈t} (∑_{i∈s} F_j(i)^p)^{1/p}.",
+    "proofStrategy": "Define the discrete ℓᵖ norm Lpnorm s p g = (∑_{i∈s} g(i)^p)^{1/p}. The finite-family Minkowski inequality is precisely subadditivity of this seminorm over the family t, proved by Finset.induction on t. The empty family gives the zero vector: (0:ℝ)^p = 0 (since p ≥ 1 ≠ 0) and the sum vanishes, so the norm is 0^{1/p} = 0, matching the empty sum on the right. For the inductive step on insert a u, write ∑_{j∈insert a u} F_j(i) = F_a(i) + ∑_{j∈u} F_j(i) (Finset.sum_insert), apply the two-vector Minkowski inequality Lpnorm_add_le (Mathlib's Real.Lp_add_le_of_nonneg, restated) — whose second hypothesis needs the partial sum ∑_{j∈u} F_j(i) ≥ 0, a sum of nonnegatives — and close with the induction hypothesis on u. The three-vector case follows by instantiating the family theorem at Fin 3.",
+    "keyInsights": [
+      "The finite-family Minkowski inequality carries no new analytic content beyond the two-vector case: it is exactly subadditivity of the ℓᵖ seminorm over a Finset, so a single induction with the two-vector inequality at each step proves it.",
+      "The empty family is the base case and forces the convention that the ℓᵖ norm of the zero vector is 0, which holds because raising 0 to the positive power p gives 0 and the outer 1/p power of 0 is again 0.",
+      "Each inductive step requires the partial sum of the remaining vectors to be nonnegative so that the two-vector Minkowski inequality applies; this is immediate since a sum of nonnegative reals is nonnegative.",
+      "Deriving the three-vector inequality from the general family theorem (over Fin 3, via Fin.sum_univ_three) exhibits a concrete case absent from Mathlib, confirming the generalization is strict rather than cosmetic.",
+      "Pairing this with the sibling n-fold Hölder entry gives both pillars — Hölder and Minkowski — for finite families in elementary closed form, the natural finite-sum analogues of Mathlib's measure-theoretic Lᵖ results."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "States the goal — the finite-family Minkowski inequality, a gap in Mathlib's elementary Finset.sum API — and outlines the induction-on-the-family strategy built on the two-vector case.",
+      "mathContext": "Finite-family Minkowski: $\\big(\\sum_{i\\in s}(\\sum_{j\\in t} F_j(i))^p\\big)^{1/p} \\le \\sum_{j\\in t}\\big(\\sum_{i\\in s} F_j(i)^p\\big)^{1/p}$ for $1\\le p$, $F_j\\ge 0$."
+    },
+    {
+      "id": "lpnorm",
+      "title": "The discrete ℓᵖ norm and its nonnegativity",
+      "startLine": 48,
+      "endLine": 73,
+      "summary": "Lpnorm s p g = (∑_{i∈s} g(i)^p)^{1/p} is defined, and Lpnorm_nonneg shows it is nonnegative for nonnegative data (each g(i)^p ≥ 0, sum ≥ 0, and 1/p power preserves nonnegativity).",
+      "mathContext": "$\\mathrm{Lpnorm}\\,s\\,p\\,g = \\big(\\sum_{i\\in s} g(i)^p\\big)^{1/p} \\ge 0$ when $g\\ge 0$ on $s$, by $\\mathrm{Real.rpow\\_nonneg}$."
+    },
+    {
+      "id": "add-le",
+      "title": "Two-vector Minkowski inequality (base step)",
+      "startLine": 60,
+      "endLine": 74,
+      "summary": "Lpnorm_add_le restates Mathlib's Real.Lp_add_le_of_nonneg in the Lpnorm notation: ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p. This is the base case of the induction.",
+      "mathContext": "$\\|f+g\\|_p \\le \\|f\\|_p + \\|g\\|_p$ for $1\\le p$, $f,g\\ge0$ — Mathlib's two-vector Minkowski inequality."
+    },
+    {
+      "id": "minkowski-finset",
+      "title": "The finite-family Minkowski inequality",
+      "startLine": 76,
+      "endLine": 102,
+      "summary": "minkowski_finset: induction on the family t. Empty case gives the zero vector (norm 0); the insert case peels one vector off with Finset.sum_insert, applies Lpnorm_add_le with the nonnegative partial sum, and closes with the induction hypothesis.",
+      "mathContext": "$\\|\\sum_{j\\in t} F_j\\|_p \\le \\sum_{j\\in t}\\|F_j\\|_p$ by induction: $\\|F_a + \\sum_{j\\in u} F_j\\|_p \\le \\|F_a\\|_p + \\|\\sum_{j\\in u} F_j\\|_p \\le \\|F_a\\|_p + \\sum_{j\\in u}\\|F_j\\|_p$."
+    },
+    {
+      "id": "add3",
+      "title": "Three-vector instance from the family theorem",
+      "startLine": 104,
+      "endLine": 116,
+      "summary": "Lpnorm_add3: the m = 3 instance ‖f+g+h‖_p ≤ ‖f‖_p+‖g‖_p+‖h‖_p, obtained by applying minkowski_finset to the family ![f,g,h] over Fin 3 and evaluating with Fin.sum_univ_three — a case Mathlib does not provide.",
+      "mathContext": "$\\|f+g+h\\|_p \\le \\|f\\|_p + \\|g\\|_p + \\|h\\|_p$, the $m=3$ specialization of $\\mathrm{minkowski\\_finset}$ over $\\mathrm{Fin}\\,3$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 116-line file (0 sorries, 0 axioms, no native_decide) supplies the finite-family Minkowski inequality — the triangle inequality for the discrete ℓᵖ norm over an arbitrary finite family of vectors — which Mathlib provides only for two vectors. The proof is a single Finset.induction on the family, using the two-vector Minkowski inequality (Real.Lp_add_le_of_nonneg) at each step. The three-vector instance is derived from the general theorem to exhibit a case beyond Mathlib's two-vector form.",
+    "implications": "Together with the sibling n-fold Hölder entry this establishes both pillars of Lᵖ theory — Hölder and Minkowski — for finite families in elementary closed form, the natural finite-sum companions to Mathlib's measure-theoretic Lᵖ results. Subadditivity over a finite family is the standard tool for bounding the norm of a sum of many vectors, where the two-vector inequality must otherwise be iterated by hand.",
+    "openQuestions": [
+      "Prove the equality case of the finite-family Minkowski inequality: equality holds iff all the nonzero vectors F_j are pairwise proportional.",
+      "Lift the finite-family Minkowski inequality from finite sums to the Lᵖ / integral setting and to ℝ≥0∞-valued functions, matching Mathlib's measure-theoretic Minkowski inequality.",
+      "Combine with the n-fold Hölder entry to state the full ℓᵖ–ℓᵍ duality for finite families (norm as a supremum of inner products)."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 116,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 4,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-02.json
@@ -1,0 +1,71 @@
+{
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+  "title": "Generalized (Finite-Family) Minkowski Inequality for Discrete ℓᵖ Norms",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\Big(\\sum_{i\\in s}\\Big(\\sum_{j\\in t} F_j(i)\\Big)^{p}\\Big)^{1/p} \\le \\sum_{j\\in t}\\Big(\\sum_{i\\in s} F_j(i)^{p}\\Big)^{1/p} \\quad (1\\le p,\\ F_j\\ge 0)",
+    "plain": "Mathlib provides Minkowski's inequality only for the sum of two vectors (Real.Lp_add_le_of_nonneg), but not for an arbitrary finite family of vectors. Prove the finite-family form: for 1 ≤ p and a finite family of nonnegative vectors F_j over a coordinate set s, the ℓᵖ norm of their sum is at most the sum of their ℓᵖ norms — the triangle inequality (subadditivity of the discrete ℓᵖ seminorm) for finitely many summands.",
+    "whyMatters": [
+      "Fills a real Mathlib gap: only the two-vector Minkowski inequality is available in elementary Finset.sum form",
+      "It is the ℓᵖ-norm sibling of the parent ladder's generalization of two-term to n-term Young/Hölder",
+      "The finite-family triangle inequality is the standard tool for bounding norms of sums of many vectors, and was explicitly flagged as the next step of the n-fold Hölder entry"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T14:40:00-07:00",
+    "iteration": 1,
+    "focus": "Prove the finite-family Minkowski inequality by induction on the family using the two-vector case.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved the generalized finite-family Minkowski inequality Lpnorm s p (fun i => ∑ j ∈ t, F j i) ≤ ∑ j ∈ t, Lpnorm s p (F j) for 1 ≤ p and nonnegative vectors F j. 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean (116L, 1 def, 4 thm). The discrete ℓᵖ norm Lpnorm s p g = (∑ i ∈ s, g i ^ p)^{1/p} is defined; minkowski_finset is proved by Finset.induction on the family, using the two-vector case Lpnorm_add_le (= Mathlib's Real.Lp_add_le_of_nonneg restated) at the inductive step and Lpnorm_nonneg for the partial sums. The three-vector instance Lpnorm_add3 is derived from minkowski_finset over Fin 3 (a case Mathlib does not provide).",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean: minkowski_finset (finite-family Minkowski for finite sums — Mathlib gap)",
+      "Lpnorm (the discrete ℓᵖ norm (∑ g i^p)^{1/p})",
+      "Lpnorm_nonneg (norm of a nonnegative vector is nonnegative)",
+      "Lpnorm_add_le (two-vector Minkowski in this notation, base step)",
+      "Lpnorm_add3 (three-vector instance derived from the family theorem)",
+      "src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-02/ gallery entry"
+    ],
+    "insights": [
+      "The finite-family Minkowski inequality is exactly subadditivity of the ℓᵖ seminorm over a Finset, so a single Finset.induction on the family with the two-vector case at each step suffices — no new analytic content beyond Real.Lp_add_le_of_nonneg",
+      "The empty family yields the zero vector, whose ℓᵖ norm is 0 because (0:ℝ)^p = 0 (p ≠ 0) and 0^{1/p} = 0; this is the induction base",
+      "At the inductive step the partial sum ∑ j ∈ u, F j i must be shown nonnegative (sum of nonnegatives) so the two-vector case applies",
+      "Deriving the three-vector instance from the general family theorem (over Fin 3, via Fin.sum_univ_three) exhibits a case absent from Mathlib, confirming the generalization is strict"
+    ],
+    "mathlibGaps": [
+      "Mathlib has only the two-vector Minkowski inequality in Finset.sum form (Real.Lp_add_le_of_nonneg); the finite-family generalization minkowski_finset here is the missing elementary result and a natural upstream contribution. The abstract PiLp/WithLp triangle inequality is not the same elementary closed-form statement"
+    ],
+    "nextSteps": [
+      "Prove the equality case: equality holds iff all the nonzero vectors F j are pairwise proportional",
+      "Lift to the Lᵖ / integral and ℝ≥0∞ settings, matching Mathlib's measure-theoretic Minkowski",
+      "Combine with the n-fold Hölder entry to state the full ℓᵖ–ℓᵍ duality for finite families"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01-oq-01-oq-01-oq-02\n\n## Problem Understanding\n\nProve the generalized finite-family Minkowski inequality (a Mathlib gap) — the triangle inequality for the discrete ℓᵖ norm over an arbitrary finite family of vectors — from the two-vector case by induction.\n\n## Insights\n\nThe ℓᵖ norm Lpnorm s p g = (∑ i ∈ s, g i ^ p)^{1/p} is subadditive: induction on the family t, with the empty case giving the zero vector (norm 0) and the inductive step peeling one vector off via Finset.sum_insert, applying the two-vector Minkowski inequality (Mathlib's Real.Lp_add_le_of_nonneg), and closing with the induction hypothesis on the rest. The partial sums are nonnegative as sums of nonnegatives.\n\n## Dead Ends\n\nNone substantive — one first-build fix: Finset.induction re-introduces the family-nonnegativity hypothesis in each branch (so it must not be `intro`-ed; the induction hypothesis is already the implication form).\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "minkowski-inequality",
+    "holder-inequality",
+    "lp-spaces",
+    "triangle-inequality",
+    "inequalities",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **finite-family Minkowski inequality** — the triangle inequality (subadditivity) for the discrete ℓᵖ norm over an arbitrary finite family of vectors — which **Mathlib does not provide**: it ships only the two-vector form (`Real.Lp_add_le_of_nonneg`).

For `1 ≤ p`, a coordinate set `s`, and finitely many nonnegative vectors `F_j : ι → ℝ` indexed by `j ∈ t`:

```
(∑_{i∈s} (∑_{j∈t} F_j(i))^p)^{1/p}  ≤  ∑_{j∈t} (∑_{i∈s} F_j(i)^p)^{1/p}
```

This is the **ℓᵖ-norm sibling** of the generalized n-fold Hölder entry (#27632): there the two-exponent Hölder inequality was lifted to a finite family of exponents; here the two-vector triangle inequality is lifted to a finite family of vectors. It was explicitly named as the next step in that entry's open questions ("Derive the generalized Minkowski inequality").

## Results (`Proofs/JensenInequalityOQ01OQ01OQ01OQ02.lean`, 116L, 1 def + 4 thm)

- `Lpnorm` — the discrete ℓᵖ norm `(∑ i ∈ s, g i ^ p)^{1/p}`.
- `Lpnorm_nonneg` — the norm of a nonnegative vector is nonnegative.
- `Lpnorm_add_le` — the two-vector Minkowski inequality in this notation (Mathlib's, the base step).
- `minkowski_finset` — **the finite-family Minkowski inequality**, by `Finset.induction` on the family.
- `Lpnorm_add3` — the three-vector instance, derived from `minkowski_finset` over `Fin 3` (a case Mathlib does not provide).

## Verification

Fully machine-checked: **0 sorries, 0 axioms** (`#print axioms` → `propext, Classical.choice, Quot.sound` only), **no `native_decide`**. Builds via the Docker wrapper against Mathlib v4.26.0. Self-contained (imports only Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)