### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-03): sharpness of generalized Minkowski — homogeneity, definiteness, saturation on a common ray [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2911,6 +2911,7 @@ import Proofs.JacobiSymbolOQ01
 import Proofs.JensenInequalityOQ01
 import Proofs.JensenInequalityOQ01OQ01
 import Proofs.JensenInequalityOQ01OQ01OQ01OQ01
+import Proofs.JensenInequalityOQ01OQ01OQ01OQ03
 import Proofs.KaprekarConstantOQ01
 import Proofs.KeithNumberOQ01
 import Proofs.KeplerConjecture

--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean
@@ -1,0 +1,95 @@
+/-
+# Sharpness of the Generalized Minkowski Inequality: Homogeneity, Definiteness, and Saturation on a Common Ray
+
+The sibling file `JensenInequalityOQ01OQ01OQ01OQ02` proves the finite-family Minkowski inequality
+— subadditivity of the discrete `ℓᵖ` norm `‖g‖_p = (∑ᵢ g(i)ᵖ)^{1/p}` over an arbitrary finite
+family of nonnegative vectors:
+
+    ‖∑ⱼ Fⱼ‖_p ≤ ∑ⱼ ‖Fⱼ‖_p.
+
+This file records *when that inequality is sharp* and the structural facts that make the discrete
+`ℓᵖ` norm a seminorm:
+
+* **Positive homogeneity** `Lpnorm_smul`: `‖c · g‖_p = c · ‖g‖_p` for `c ≥ 0`.
+* **Definiteness** `Lpnorm_eq_zero_iff`: `‖g‖_p = 0 ↔ g` vanishes on the coordinate set.
+* **Saturation on a common ray** `minkowski_finset_eq_of_common_ray`: if every vector of the family
+  is a nonnegative multiple `Fⱼ = cⱼ · h` of a single direction `h`, then Minkowski holds with
+  *equality*, `‖∑ⱼ Fⱼ‖_p = ∑ⱼ ‖Fⱼ‖_p`.
+
+The saturation result is the "easy half" of the equality case of Minkowski's inequality: it
+exhibits the extremal configurations — collinear (proportional) vectors — on which the triangle
+inequality for the `ℓᵖ` norm is tight, for every `p > 0`. (The converse, that equality *forces*
+proportionality, requires `p > 1` and the strict convexity of `t ↦ tᵖ`, and is left open.)
+
+Mathlib provides neither the elementary closed-form homogeneity/definiteness of this discrete
+`ℓᵖ` norm nor the saturation characterization; this file supplies them, self-contained.
+
+## Main results
+
+* `Lpnorm`                            — the discrete `ℓᵖ` norm `(∑ᵢ g(i)ᵖ)^{1/p}`.
+* `Lpnorm_smul`                       — positive homogeneity `‖c · g‖_p = c · ‖g‖_p`.
+* `Lpnorm_eq_zero_iff`                — definiteness: the norm vanishes iff the vector does.
+* `minkowski_finset_eq_of_common_ray` — **Minkowski saturates on a common ray** `Fⱼ = cⱼ · h`.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace JensenMinkowskiSharp
+
+variable {ι κ : Type*} {s : Finset ι} {p : ℝ}
+
+/-- The unnormalised discrete `ℓᵖ` "norm" of a vector `g : ι → ℝ` over the coordinate set `s`:
+`Lpnorm s p g = (∑ i ∈ s, g i ^ p) ^ (1/p)`. -/
+noncomputable def Lpnorm (s : Finset ι) (p : ℝ) (g : ι → ℝ) : ℝ :=
+  (∑ i ∈ s, g i ^ p) ^ (1 / p)
+
+/-- For `a ≥ 0` and `p ≠ 0`, `(aᵖ)^{1/p} = a`: the reciprocal power inverts the `p`-th power. -/
+private theorem rpow_pow_inv {a : ℝ} (ha : 0 ≤ a) (hp : p ≠ 0) : (a ^ p) ^ (1 / p) = a := by
+  rw [← Real.rpow_mul ha, mul_one_div, div_self hp, Real.rpow_one]
+
+/-- **Positive homogeneity of the discrete `ℓᵖ` norm.** For `p > 0`, a scalar `c ≥ 0`, and a
+vector `g` nonnegative on `s`, scaling the vector scales its norm: `‖c · g‖_p = c · ‖g‖_p`. -/
+theorem Lpnorm_smul (hp : 0 < p) {c : ℝ} (hc : 0 ≤ c) {g : ι → ℝ} (hg : ∀ i ∈ s, 0 ≤ g i) :
+    Lpnorm s p (fun i => c * g i) = c * Lpnorm s p g := by
+  unfold Lpnorm
+  have hpow : ∀ i ∈ s, (c * g i) ^ p = c ^ p * g i ^ p :=
+    fun i hi => Real.mul_rpow hc (hg i hi)
+  rw [Finset.sum_congr rfl hpow, ← Finset.mul_sum,
+    Real.mul_rpow (Real.rpow_nonneg hc p) (Finset.sum_nonneg fun i hi => Real.rpow_nonneg (hg i hi) p),
+    rpow_pow_inv hc hp.ne']
+
+/-- **Definiteness of the discrete `ℓᵖ` norm.** For `p > 0` and a vector `g` nonnegative on `s`,
+the norm `‖g‖_p` is zero exactly when `g` vanishes everywhere on `s`. -/
+theorem Lpnorm_eq_zero_iff (hp : 0 < p) {g : ι → ℝ} (hg : ∀ i ∈ s, 0 ≤ g i) :
+    Lpnorm s p g = 0 ↔ ∀ i ∈ s, g i = 0 := by
+  unfold Lpnorm
+  rw [Real.rpow_eq_zero_iff_of_nonneg
+        (Finset.sum_nonneg fun i hi => Real.rpow_nonneg (hg i hi) p),
+    and_iff_left (one_div_ne_zero hp.ne'),
+    Finset.sum_eq_zero_iff_of_nonneg fun i hi => Real.rpow_nonneg (hg i hi) p]
+  exact forall₂_congr fun i hi =>
+    by rw [Real.rpow_eq_zero_iff_of_nonneg (hg i hi), and_iff_left hp.ne']
+
+/-- **Saturation of the finite-family Minkowski inequality on a common ray.** If every vector of a
+finite family is a nonnegative multiple `F j = c j · h` of a single direction `h` (with `c j ≥ 0`
+and `h` nonnegative on `s`), then the Minkowski inequality holds with *equality*:
+
+    Lpnorm s p (fun i => ∑ j ∈ t, c j * h i) = ∑ j ∈ t, Lpnorm s p (fun i => c j * h i).
+
+This identifies the extremal configurations — collinear vectors — on which the `ℓᵖ` triangle
+inequality is tight, for every `p > 0`. Both sides equal `(∑ j ∈ t, c j) · ‖h‖_p`. -/
+theorem minkowski_finset_eq_of_common_ray (hp : 0 < p) (t : Finset κ) (c : κ → ℝ) (h : ι → ℝ)
+    (hc : ∀ j ∈ t, 0 ≤ c j) (hh : ∀ i ∈ s, 0 ≤ h i) :
+    Lpnorm s p (fun i => ∑ j ∈ t, c j * h i)
+      = ∑ j ∈ t, Lpnorm s p (fun i => c j * h i) := by
+  have hsum : 0 ≤ ∑ j ∈ t, c j := Finset.sum_nonneg hc
+  have hL : (fun i => ∑ j ∈ t, c j * h i) = (fun i => (∑ j ∈ t, c j) * h i) := by
+    funext i; rw [← Finset.sum_mul]
+  rw [hL, Lpnorm_smul hp hsum hh,
+    Finset.sum_congr rfl fun j hj => Lpnorm_smul hp (hc j hj) hh, ← Finset.sum_mul]
+
+end JensenMinkowskiSharp

--- a/research/registry.json
+++ b/research/registry.json
@@ -25316,6 +25316,15 @@
       "status": "completed",
       "lastUpdate": "2026-06-22T21:30:00.000Z",
       "completed": "2026-06-22T21:30:00.000Z"
+    },
+    {
+      "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-06-22T22:10:00.000Z",
+      "status": "completed",
+      "lastUpdate": "2026-06-22T22:10:00.000Z",
+      "completed": "2026-06-22T22:10:00.000Z"
     }
   ],
   "config": {

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-03",
+  "title": "Sharpness of the Generalized Minkowski Inequality: Homogeneity, Definiteness, and Saturation on a Common Ray",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-03",
+  "description": "Records when the finite-family Minkowski inequality (proved in the sibling entry) is sharp, together with the structural facts that make the discrete ℓᵖ norm ‖g‖_p = (∑ᵢ g(i)ᵖ)^{1/p} a seminorm: positive homogeneity ‖c·g‖_p = c·‖g‖_p for c ≥ 0, definiteness ‖g‖_p = 0 ↔ g vanishes on the coordinate set, and saturation on a common ray — if every vector of a finite family is a nonnegative multiple F_j = c_j·h of a single direction h, then the Minkowski inequality holds with equality, ‖∑_j F_j‖_p = ∑_j ‖F_j‖_p, for every p > 0. The saturation result is the easy half of the equality case of Minkowski's inequality: it exhibits the extremal (collinear) configurations on which the ℓᵖ triangle inequality is tight. Mathlib provides neither the elementary closed-form homogeneity/definiteness of this discrete ℓᵖ norm nor the saturation characterization; this file supplies them, self-contained.",
+  "meta": {
+    "author": "Lean Genius (sharpness/saturation of finite-family Minkowski); H. Minkowski (1896)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "minkowski-inequality",
+      "lp-spaces",
+      "equality-case",
+      "triangle-inequality",
+      "inequalities",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 95,
+    "originalContributions": [
+      "minkowski_finset_eq_of_common_ray: the saturation case of the finite-family Minkowski inequality — if F_j = c_j·h for a common nonnegative direction h and nonnegative scalars c_j, then ‖∑_j F_j‖_p = ∑_j ‖F_j‖_p with equality, for every p > 0. This pins the extremal (collinear) configurations of the ℓᵖ triangle inequality, the easy half of its equality case; absent from Mathlib.",
+      "Lpnorm_smul: positive homogeneity of the discrete ℓᵖ norm, ‖c·g‖_p = c·‖g‖_p for c ≥ 0 and p > 0, via Real.mul_rpow, Finset.mul_sum, and the telescoping identity (c^p)^{1/p} = c.",
+      "Lpnorm_eq_zero_iff: definiteness of the discrete ℓᵖ norm, ‖g‖_p = 0 ↔ g vanishes everywhere on the coordinate set, for p > 0 and nonnegative g."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Self-contained, importing only Mathlib (Real.mul_rpow, Real.rpow_eq_zero_iff_of_nonneg, and the rpow library); does not depend on any other gallery file (the discrete ℓᵖ norm is re-declared in its own namespace).",
+    "theoremCount": 3,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The sibling entry proves the finite-family Minkowski inequality ‖∑_j F_j‖_p ≤ ∑_j ‖F_j‖_p. This entry records when that inequality is sharp — equality on a common ray F_j = c_j·h — together with the homogeneity and definiteness of the same discrete ℓᵖ norm, completing the Minkowski story for finite families."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Cousin of the generalized n-fold Hölder entry: where that entry generalizes Hölder to finite families, this entry supplies the sharpness/equality structure for the dual Minkowski inequality, both built on the same AM–GM / rpow toolkit."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Minkowski's inequality (H. Minkowski, 1896) makes the Lᵖ-norm a genuine norm for 1 ≤ p. Beyond the inequality itself, the structurally informative content is its equality case: the triangle inequality ‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p is tight exactly when f and g are proportional (collinear). The forward, easy half — that proportional vectors saturate the bound — holds for every p > 0 and is a direct consequence of the positive homogeneity of the norm; the converse requires strict convexity of t ↦ tᵖ and p > 1. This entry formalizes the homogeneity and definiteness of the discrete ℓᵖ norm and the saturation of the finite-family Minkowski inequality on a common ray.",
+    "problemStatement": "Establish the seminorm structure of the discrete ℓᵖ norm ‖g‖_p = (∑ᵢ g(i)ᵖ)^{1/p} — positive homogeneity ‖c·g‖_p = c·‖g‖_p (c ≥ 0) and definiteness ‖g‖_p = 0 ↔ g ≡ 0 — and prove that the finite-family Minkowski inequality saturates on a common ray: if F_j = c_j·h (c_j ≥ 0, h ≥ 0), then ‖∑_j F_j‖_p = ∑_j ‖F_j‖_p for every p > 0.",
+    "proofStrategy": "Positive homogeneity Lpnorm_smul: in (∑ᵢ (c·g(i))ᵖ)^{1/p}, factor each summand (c·g(i))ᵖ = cᵖ·g(i)ᵖ (Real.mul_rpow), pull cᵖ through the sum (Finset.mul_sum), split the outer 1/p power (Real.mul_rpow again), and collapse (cᵖ)^{1/p} = c via the telescoping identity (a ≥ 0, p ≠ 0). Saturation minkowski_finset_eq_of_common_ray: when F_j = c_j·h, the inner sum ∑_j c_j·h(i) = (∑_j c_j)·h(i) (Finset.sum_mul), so the left side is ‖(∑_j c_j)·h‖_p = (∑_j c_j)·‖h‖_p by homogeneity; the right side is ∑_j ‖c_j·h‖_p = ∑_j c_j·‖h‖_p = (∑_j c_j)·‖h‖_p, again by homogeneity and Finset.sum_mul — both sides coincide with no inequality required. Definiteness Lpnorm_eq_zero_iff: the outer power is zero iff the sum is (Real.rpow_eq_zero_iff_of_nonneg, 1/p ≠ 0), the sum of nonnegatives is zero iff each term is (Finset.sum_eq_zero_iff_of_nonneg), and each g(i)ᵖ is zero iff g(i) is (rpow_eq_zero_iff again, p ≠ 0).",
+    "keyInsights": [
+      "Saturation needs no inequality at all: collinearity F_j = c_j·h collapses both sides of Minkowski to (∑_j c_j)·‖h‖_p purely by positive homogeneity, so the triangle inequality is an identity on rays.",
+      "Positive homogeneity is the single workhorse: it drives the saturation result and is the elementary content distinguishing a norm from an arbitrary functional; its proof is the same (cᵖ)^{1/p} = c telescoping used throughout the Young–Hölder family.",
+      "The saturation result is only the forward half of the equality case; the converse — equality forces proportionality — genuinely needs p > 1 and the strict convexity of t ↦ tᵖ, and is recorded as the leading open question.",
+      "Definiteness is a clean two-level rpow_eq_zero argument, exhibiting that the discrete ℓᵖ norm separates points (it vanishes only on the zero vector), the last seminorm axiom needed alongside homogeneity and subadditivity.",
+      "Together with the sibling subadditivity entry, homogeneity and definiteness assemble all three seminorm/norm axioms for the discrete ℓᵖ norm in elementary closed form."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Frames the goal — the sharpness (saturation) of the finite-family Minkowski inequality and the seminorm structure (homogeneity, definiteness) of the discrete ℓᵖ norm — and notes these are gaps in Mathlib's elementary API.",
+      "mathContext": "For $F_j = c_j\\cdot h$ ($c_j\\ge0$, $h\\ge0$): $\\|\\sum_j F_j\\|_p = \\sum_j \\|F_j\\|_p$ for every $p>0$, via homogeneity $\\|c\\cdot g\\|_p = c\\|g\\|_p$."
+    },
+    {
+      "id": "homogeneity",
+      "title": "Positive homogeneity of the discrete ℓᵖ norm",
+      "startLine": 49,
+      "endLine": 72,
+      "summary": "rpow_pow_inv: the telescoping (aᵖ)^{1/p} = a. Lpnorm_smul: ‖c·g‖_p = c·‖g‖_p for c ≥ 0 — factor cᵖ out of each summand (Real.mul_rpow), pull through the sum, split the outer power, telescope (cᵖ)^{1/p} = c.",
+      "mathContext": "$\\|c\\cdot g\\|_p = \\big(\\sum_i (c\\,g(i))^p\\big)^{1/p} = \\big(c^p\\sum_i g(i)^p\\big)^{1/p} = (c^p)^{1/p}\\,\\|g\\|_p = c\\,\\|g\\|_p$."
+    },
+    {
+      "id": "definiteness",
+      "title": "Definiteness of the discrete ℓᵖ norm",
+      "startLine": 74,
+      "endLine": 85,
+      "summary": "Lpnorm_eq_zero_iff: ‖g‖_p = 0 ↔ g vanishes on s — two rpow_eq_zero_iff_of_nonneg steps (outer 1/p power, inner p-th powers) bridged by Finset.sum_eq_zero_iff_of_nonneg, using p ≠ 0 at both ends.",
+      "mathContext": "$\\|g\\|_p = 0 \\iff \\sum_i g(i)^p = 0 \\iff \\forall i\\in s,\\ g(i)^p = 0 \\iff \\forall i\\in s,\\ g(i) = 0$ (for $p>0$, $g\\ge0$)."
+    },
+    {
+      "id": "saturation",
+      "title": "Saturation of Minkowski on a common ray",
+      "startLine": 87,
+      "endLine": 95,
+      "summary": "minkowski_finset_eq_of_common_ray: for F_j = c_j·h, the inner sum is (∑_j c_j)·h (Finset.sum_mul); both sides of Minkowski reduce to (∑_j c_j)·‖h‖_p by homogeneity, so equality holds — for every p > 0.",
+      "mathContext": "$\\|\\textstyle\\sum_j c_j\\,h\\|_p = \\|(\\sum_j c_j)\\,h\\|_p = (\\sum_j c_j)\\|h\\|_p = \\sum_j c_j\\|h\\|_p = \\sum_j \\|c_j\\,h\\|_p$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 95-line file (0 sorries, 0 axioms, no native_decide) establishes the positive homogeneity and definiteness of the discrete ℓᵖ norm and the saturation case of the finite-family Minkowski inequality: equality holds on a common ray F_j = c_j·h for every p > 0. The saturation proof needs no inequality — collinearity collapses both sides to (∑_j c_j)·‖h‖_p by homogeneity. None of these elementary closed-form facts are in Mathlib.",
+    "implications": "Together with the sibling subadditivity entry, this assembles all three seminorm/norm axioms for the discrete ℓᵖ norm — homogeneity, definiteness, and the triangle inequality — in elementary form, and pins the extremal configurations of the ℓᵖ triangle inequality. The saturation-on-rays result is the forward half of the Minkowski equality case and the natural foundation for the converse rigidity statement.",
+    "openQuestions": [
+      "Prove the converse: for p > 1, equality in the finite-family Minkowski inequality forces the nonzero vectors to be pairwise proportional, via the strict convexity of t ↦ tᵖ or the equality case of Hölder's inequality.",
+      "Assemble homogeneity, definiteness, and subadditivity into an explicit seminorm or NormedAddCommGroup instance for the discrete ℓᵖ norm on functions supported on a finite set.",
+      "Transport the saturation characterization from finite sums to the Lᵖ / integral setting and to ℝ≥0∞-valued functions."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 95,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 3,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-03.json
@@ -1,0 +1,69 @@
+{
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-03",
+  "title": "Sharpness of the Generalized Minkowski Inequality: Saturation on a Common Ray",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "F_j = c_j\\cdot h,\\ c_j\\ge 0,\\ h\\ge 0 \\ \\Longrightarrow\\ \\Big\\|\\sum_{j} F_j\\Big\\|_p = \\sum_{j}\\|F_j\\|_p \\quad (p>0)",
+    "plain": "The sibling entry proves the finite-family Minkowski inequality ‖∑ F_j‖_p ≤ ∑ ‖F_j‖_p. This entry records when it is sharp and the seminorm structure of the discrete ℓᵖ norm: positive homogeneity ‖c·g‖_p = c·‖g‖_p, definiteness (‖g‖_p = 0 iff g vanishes), and saturation on a common ray — if every vector of the family is a nonnegative multiple F_j = c_j·h of a single direction h, then Minkowski holds with equality. This is the easy half of the equality case, exhibiting the extremal (collinear) configurations for every p > 0.",
+    "whyMatters": [
+      "Fills a Mathlib gap: the elementary closed-form homogeneity/definiteness of this discrete ℓᵖ norm and the saturation characterization are not in Mathlib",
+      "Identifies the extremal configurations on which the ℓᵖ triangle inequality is tight (collinear vectors), the structurally informative content of an inequality",
+      "Completes the finite-family Minkowski story begun in the sibling entry by pinning down equality on rays"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T15:10:00-07:00",
+    "iteration": 1,
+    "focus": "Prove homogeneity, definiteness, and saturation-on-a-ray for the discrete ℓᵖ norm.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved positive homogeneity Lpnorm_smul (‖c·g‖_p = c·‖g‖_p for c ≥ 0), definiteness Lpnorm_eq_zero_iff (‖g‖_p = 0 ↔ g ≡ 0 on s), and the saturation case minkowski_finset_eq_of_common_ray (F_j = c_j·h ⟹ ‖∑ F_j‖_p = ∑ ‖F_j‖_p), all for p > 0 and nonnegative data. 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean (95L, 1 def, 3 thm). Self-contained (imports only Mathlib); re-declares Lpnorm in its own namespace.",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean: minkowski_finset_eq_of_common_ray (Minkowski saturates on a common ray — Mathlib gap)",
+      "Lpnorm_smul (positive homogeneity of the discrete ℓᵖ norm)",
+      "Lpnorm_eq_zero_iff (definiteness of the discrete ℓᵖ norm)",
+      "src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-03/ gallery entry"
+    ],
+    "insights": [
+      "Homogeneity is the engine of saturation: ‖c·g‖_p = c·‖g‖_p follows from Real.mul_rpow (factor c^p out of each summand), Finset.mul_sum, and the telescoping (c^p)^{1/p} = c",
+      "Saturation on a ray: when F_j = c_j·h, ∑_j F_j = (∑_j c_j)·h, so both sides reduce to (∑_j c_j)·‖h‖_p via homogeneity and Finset.sum_mul — no inequality is even needed",
+      "Definiteness chains two rpow_eq_zero_iff steps (outer 1/p power, inner p-th powers) with Finset.sum_eq_zero_iff_of_nonneg, using p ≠ 0 at both ends",
+      "This is the easy direction of the Minkowski equality case; the converse (equality forces proportionality) needs p > 1 and strict convexity of t ↦ t^p and is left open"
+    ],
+    "mathlibGaps": [
+      "Mathlib does not provide the elementary closed-form homogeneity/definiteness of this discrete ℓᵖ norm over a Finset, nor the saturation characterization of when the finite-family Minkowski inequality is tight"
+    ],
+    "nextSteps": [
+      "Prove the converse direction: for p > 1, equality in Minkowski forces the vectors to be pairwise proportional (via strict convexity / the equality case of Hölder)",
+      "Combine homogeneity, definiteness, and subadditivity into an explicit seminorm/normed-space instance for the discrete ℓᵖ norm",
+      "Transport the saturation result to the Lᵖ / integral setting"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01-oq-01-oq-01-oq-03\n\n## Problem Understanding\n\nRecord the seminorm structure of the discrete ℓᵖ norm (homogeneity, definiteness) and the saturation case of the finite-family Minkowski inequality — equality on a common ray.\n\n## Insights\n\nHomogeneity ‖c·g‖_p = c·‖g‖_p (c ≥ 0) is proved by factoring c^p out of each summand (Real.mul_rpow), pulling it through the sum (Finset.mul_sum), and telescoping (c^p)^{1/p} = c. Saturation: if F_j = c_j·h then ∑_j F_j = (∑_j c_j)·h, and both sides of Minkowski equal (∑_j c_j)·‖h‖_p by homogeneity and Finset.sum_mul. Definiteness uses Real.rpow_eq_zero_iff_of_nonneg twice and Finset.sum_eq_zero_iff_of_nonneg.\n\n## Dead Ends\n\nNone — first build clean after fixing the telescoping helper to use Real.rpow_mul + mul_one_div + div_self rather than rpow_natCast.\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "minkowski-inequality",
+    "lp-spaces",
+    "equality-case",
+    "triangle-inequality",
+    "inequalities",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Records **when the finite-family Minkowski inequality is sharp** (sibling entry oq-02 proves the inequality itself) together with the structural facts that make the discrete ℓᵖ norm `‖g‖_p = (∑ᵢ g(i)ᵖ)^{1/p}` a seminorm. **None of these elementary closed-form facts are in Mathlib.**

## Results (`Proofs/JensenInequalityOQ01OQ01OQ01OQ03.lean`, 95L, 1 def + 3 thm)

- `Lpnorm_smul` — **positive homogeneity** `‖c·g‖_p = c·‖g‖_p` for `c ≥ 0`, via `Real.mul_rpow` + `Finset.mul_sum` + the telescoping `(cᵖ)^{1/p} = c`.
- `Lpnorm_eq_zero_iff` — **definiteness** `‖g‖_p = 0 ↔ g` vanishes on the coordinate set.
- `minkowski_finset_eq_of_common_ray` — **saturation on a common ray**: if every vector of a finite family is a nonnegative multiple `F_j = c_j·h` of a single direction `h`, then Minkowski holds with *equality*, `‖∑_j F_j‖_p = ∑_j ‖F_j‖_p`, for every `p > 0` (both sides reduce to `(∑_j c_j)·‖h‖_p` by homogeneity — no inequality required).

This is the **easy half of the Minkowski equality case**: it exhibits the extremal (collinear) configurations on which the ℓᵖ triangle inequality is tight. The converse — equality forces proportionality, needing `p > 1` and strict convexity of `t ↦ tᵖ` — is recorded as the leading open question.

## Verification

Fully machine-checked: **0 sorries, 0 axioms** (`#print axioms` → `propext, Classical.choice, Quot.sound` only), **no `native_decide`**. Builds via the Docker wrapper against Mathlib v4.26.0. Self-contained (imports only Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)