### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-04): power-mean inequality — monotonicity of the weighted power mean in its exponent [0-axiom verified]

### DIFF
--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ04.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ04.lean
@@ -1,0 +1,131 @@
+import Mathlib
+
+/-
+# Monotonicity of the Weighted Power Mean in its Exponent
+
+For a finite family of nonnegative reals `x i` (`i ∈ s`) with nonnegative weights `w i`
+summing to `1`, the **weighted power mean of exponent `p`** is
+
+    M_p(x) = (∑ i, w i * x i ^ p) ^ (1 / p).
+
+This file proves the classical **power-mean inequality**: the map `p ↦ M_p(x)` is monotone
+non-decreasing on `p > 0`,
+
+    0 < p ≤ q  ⟹  M_p(x) ≤ M_q(x).
+
+This single statement contains the comparison of the weighted arithmetic mean `M_1` with every
+higher power mean, and in particular the quadratic-mean / arithmetic-mean (QM–AM, or
+root-mean-square) inequality. It is the canonical consequence of Jensen's inequality applied to
+the convex map `t ↦ tʳ` (`r ≥ 1`), and sits at the head of the AM–GM / Young / Hölder / Minkowski
+family developed in the sibling files of this lineage.
+
+Mathlib provides the *single-exponent* Jensen building block
+`Real.rpow_arith_mean_le_arith_mean_rpow` — `(∑ w i z i) ^ r ≤ ∑ w i * z i ^ r` for `r ≥ 1` —
+but **no closed-form power mean nor its monotonicity in the exponent**; this file supplies them,
+self-contained.
+
+## Main results
+
+* `powerMean`               — the weighted power mean `(∑ i, w i * x i ^ p) ^ (1 / p)`.
+* `powerMean_nonneg`        — power means of nonnegative data are nonnegative.
+* `powerMean_one`           — `M_1` is the weighted arithmetic mean `∑ i, w i * x i`.
+* `powerMean_le_powerMean`  — **monotonicity in the exponent**: `0 < p ≤ q ⟹ M_p ≤ M_q`.
+* `arith_mean_le_powerMean` — `M_1 ≤ M_p` for `p ≥ 1`: the weighted arithmetic mean is the
+  smallest power mean of exponent `≥ 1`.
+* `qm_am_inequality`        — the weighted QM–AM inequality `∑ w i x i ≤ (∑ w i x i²)^{1/2}`.
+
+## Strategy
+
+To compare `M_p` and `M_q` for `0 < p ≤ q`, set `r = q / p ≥ 1` and apply
+`Real.rpow_arith_mean_le_arith_mean_rpow` to the data `z i = x i ^ p` with exponent `r`:
+
+    (∑ i, w i * x i ^ p) ^ r ≤ ∑ i, w i * (x i ^ p) ^ r = ∑ i, w i * x i ^ q,
+
+using `(x i ^ p) ^ r = x i ^ (p * r) = x i ^ q`.  The left side is `M_p ^ q` and the right side
+is `M_q ^ q`; since `q > 0` and both means are nonnegative, `rpow`-monotonicity
+(`Real.rpow_le_rpow_iff`) yields `M_p ≤ M_q`.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+-/
+
+open Finset
+
+namespace JensenPowerMean
+
+variable {ι : Type*} {s : Finset ι} {w x : ι → ℝ} {p q : ℝ}
+
+/-- The **weighted power mean of exponent `p`** of a family `x : ι → ℝ` over the finite set `s`
+with weights `w`: `powerMean s w x p = (∑ i ∈ s, w i * x i ^ p) ^ (1 / p)`. -/
+noncomputable def powerMean (s : Finset ι) (w x : ι → ℝ) (p : ℝ) : ℝ :=
+  (∑ i ∈ s, w i * x i ^ p) ^ (1 / p)
+
+/-- The inner sum `∑ i, w i * x i ^ p` of a power mean is nonnegative when the weights and data
+are nonnegative. -/
+theorem sum_term_nonneg (hw : ∀ i ∈ s, 0 ≤ w i) (hx : ∀ i ∈ s, 0 ≤ x i) :
+    0 ≤ ∑ i ∈ s, w i * x i ^ p :=
+  sum_nonneg fun i hi => mul_nonneg (hw i hi) (Real.rpow_nonneg (hx i hi) _)
+
+/-- **Power means of nonnegative data are nonnegative.** -/
+theorem powerMean_nonneg (hw : ∀ i ∈ s, 0 ≤ w i) (hx : ∀ i ∈ s, 0 ≤ x i) :
+    0 ≤ powerMean s w x p :=
+  Real.rpow_nonneg (sum_term_nonneg hw hx) _
+
+/-- **The power mean of exponent `1` is the weighted arithmetic mean.** -/
+theorem powerMean_one : powerMean s w x 1 = ∑ i ∈ s, w i * x i := by
+  unfold powerMean
+  simp only [Real.rpow_one, div_one]
+
+/-- **Monotonicity of the weighted power mean in the exponent.** For nonnegative weights `w`
+summing to `1`, nonnegative data `x`, and exponents `0 < p ≤ q`, the power means satisfy
+`M_p ≤ M_q`.
+
+This is the power-mean inequality: among positive exponents, a larger exponent yields a larger
+mean. It is proved by applying Jensen's inequality for `t ↦ tʳ` with `r = q / p ≥ 1` to the
+powered data `x i ^ p`. -/
+theorem powerMean_le_powerMean (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 ≤ x i) (hp : 0 < p) (hpq : p ≤ q) :
+    powerMean s w x p ≤ powerMean s w x q := by
+  have hq : 0 < q := lt_of_lt_of_le hp hpq
+  have hpne : p ≠ 0 := hp.ne'
+  have hr1 : 1 ≤ q / p := (one_le_div hp).2 hpq
+  have hSp_nonneg : 0 ≤ ∑ i ∈ s, w i * x i ^ p := sum_term_nonneg hw hx
+  have hSq_nonneg : 0 ≤ ∑ i ∈ s, w i * x i ^ q := sum_term_nonneg hw hx
+  -- Jensen for `t ↦ t^(q/p)` (exponent `≥ 1`) applied to the powered data `z i = x i ^ p`.
+  have hjensen : (∑ i ∈ s, w i * x i ^ p) ^ (q / p) ≤ ∑ i ∈ s, w i * x i ^ q := by
+    have h := Real.rpow_arith_mean_le_arith_mean_rpow s w (fun i => x i ^ p) hw hw'
+      (fun i hi => Real.rpow_nonneg (hx i hi) _) hr1
+    refine h.trans_eq (sum_congr rfl fun i hi => ?_)
+    have hexp : p * (q / p) = q := by field_simp
+    rw [← Real.rpow_mul (hx i hi), hexp]
+  -- It suffices to compare the `q`-th powers of the two means.
+  rw [← Real.rpow_le_rpow_iff (powerMean_nonneg (p := p) hw hx)
+        (powerMean_nonneg (p := q) hw hx) hq]
+  -- `M_p ^ q = (∑ w x^p)^(q/p)` and `M_q ^ q = ∑ w x^q`, reducing the goal to `hjensen`.
+  have hMp : powerMean s w x p ^ q = (∑ i ∈ s, w i * x i ^ p) ^ (q / p) := by
+    unfold powerMean
+    rw [← Real.rpow_mul hSp_nonneg]
+    congr 1
+    field_simp
+  have hMq : powerMean s w x q ^ q = ∑ i ∈ s, w i * x i ^ q := by
+    unfold powerMean
+    rw [← Real.rpow_mul hSq_nonneg, one_div, inv_mul_cancel₀ hq.ne', Real.rpow_one]
+  rw [hMp, hMq]
+  exact hjensen
+
+/-- **The weighted arithmetic mean is the smallest power mean of exponent `≥ 1`.** For `p ≥ 1`,
+`∑ i, w i * x i ≤ M_p`. This is the `p = 1` slice of `powerMean_le_powerMean`. -/
+theorem arith_mean_le_powerMean (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 ≤ x i) (hp : 1 ≤ p) :
+    ∑ i ∈ s, w i * x i ≤ powerMean s w x p := by
+  rw [← powerMean_one]
+  exact powerMean_le_powerMean hw hw' hx one_pos hp
+
+/-- **Weighted QM–AM (root-mean-square) inequality.** The weighted arithmetic mean is at most the
+weighted quadratic mean: `∑ i, w i * x i ≤ (∑ i, w i * x i²)^{1/2}`.  This is the `p = 1`, `q = 2`
+case of the power-mean inequality. -/
+theorem qm_am_inequality (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hx : ∀ i ∈ s, 0 ≤ x i) :
+    ∑ i ∈ s, w i * x i ≤ (∑ i ∈ s, w i * x i ^ (2 : ℝ)) ^ (1 / 2 : ℝ) :=
+  arith_mean_le_powerMean (p := 2) hw hw' hx (by norm_num)
+
+end JensenPowerMean

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+  "title": "Monotonicity of the Weighted Power Mean in its Exponent",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+  "description": "Proves the classical power-mean inequality, which Mathlib does not provide. For a finite family of nonnegative reals x_i (i ∈ s) with nonnegative weights w_i summing to 1, the weighted power mean of exponent p is M_p(x) = (∑_i w_i·x_i^p)^{1/p}. The main result is that p ↦ M_p(x) is monotone non-decreasing on the positive exponents: 0 < p ≤ q ⟹ M_p(x) ≤ M_q(x). This single statement subsumes the comparison of the weighted arithmetic mean M_1 with every higher power mean, and in particular the quadratic-mean/arithmetic-mean (QM–AM, or root-mean-square) inequality. The proof is the canonical application of Jensen's inequality for the convex map t ↦ t^r (r ≥ 1): to compare M_p and M_q, set r = q/p ≥ 1 and apply Mathlib's single-exponent Jensen bound Real.rpow_arith_mean_le_arith_mean_rpow to the powered data x_i^p, giving (∑ w_i x_i^p)^r ≤ ∑ w_i x_i^q; this is exactly M_p^q ≤ M_q^q, and rpow-monotonicity finishes. Mathlib supplies the single-exponent Jensen building block but neither the closed-form power mean nor its monotonicity in the exponent.",
+  "meta": {
+    "author": "Lean Genius (power-mean monotonicity via Jensen for t↦t^r); the power-mean inequality is classical (cf. Hardy–Littlewood–Pólya, Inequalities, 1934)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01OQ04.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "power-mean-inequality",
+      "jensen-inequality",
+      "am-gm-inequality",
+      "qm-am-inequality",
+      "inequalities",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 131,
+    "originalContributions": [
+      "powerMean_le_powerMean: the power-mean inequality — for nonnegative weights w summing to 1, nonnegative data x, and exponents 0 < p ≤ q, the weighted power means satisfy M_p(x) ≤ M_q(x). Absent from Mathlib, which provides only the single-exponent Jensen bound. Proved by applying Real.rpow_arith_mean_le_arith_mean_rpow with exponent r = q/p ≥ 1 to the powered data x_i^p, yielding M_p^q ≤ M_q^q, then dividing out the q-th power via Real.rpow_le_rpow_iff.",
+      "powerMean: a closed-form definition of the weighted power mean M_p(x) = (∑_{i∈s} w_i·x_i^p)^{1/p}, together with powerMean_nonneg (nonnegativity) and powerMean_one (M_1 is the weighted arithmetic mean ∑_i w_i·x_i) — basic structural facts Mathlib does not package.",
+      "arith_mean_le_powerMean: the weighted arithmetic mean is the smallest power mean of exponent ≥ 1, i.e. ∑_i w_i·x_i ≤ M_p(x) for p ≥ 1, obtained as the p = 1 slice of the monotonicity theorem.",
+      "qm_am_inequality: the weighted QM–AM (root-mean-square) inequality ∑_i w_i·x_i ≤ (∑_i w_i·x_i²)^{1/2}, the p = 1, q = 2 specialization of the power-mean inequality."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Self-contained, importing only Mathlib (Real.rpow_arith_mean_le_arith_mean_rpow and the rpow library); does not depend on any other gallery file.",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the n-variable Young product inequality, the AM–GM step that underlies this lineage. The power-mean inequality is the sibling Jensen consequence obtained from the convexity of t ↦ t^r; together they organize the AM–GM / Young / Hölder / Minkowski family of inequalities."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Both entries are direct applications of Jensen's inequality for finite sums. The Hölder entry normalizes by Lᵖ-norms to bound a sum of products; this entry compares power means of a single family across exponents. Both reduce to a single-exponent Mathlib Jensen bound (geom_mean_le_arith_mean_weighted there, rpow_arith_mean_le_arith_mean_rpow here)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The power-mean (or generalized-mean) inequality states that the weighted mean M_p(x) = (∑ w_i x_i^p)^{1/p} is a non-decreasing function of the exponent p. It is one of the central classical inequalities (Hardy, Littlewood and Pólya, Inequalities, 1934), interpolating between the harmonic, geometric, arithmetic and quadratic means as p ranges over -1, 0, 1, 2, and containing AM–GM (p → 0 vs p = 1) and QM–AM (p = 1 vs p = 2) as special cases. It is the prototypical consequence of Jensen's inequality for the convex map t ↦ t^r. Mathlib formalizes the single-exponent Jensen bound rpow_arith_mean_le_arith_mean_rpow and the arithmetic-mean lower bound arith_mean_le_rpow_mean, but not the closed-form power mean nor its monotonicity across exponents; this entry supplies them for positive exponents.",
+    "problemStatement": "Mathlib provides the single-exponent Jensen bound (∑ w_i z_i)^r ≤ ∑ w_i z_i^r for r ≥ 1, but not the power-mean inequality. Prove that for nonnegative weights w_i summing to 1, nonnegative data x_i, and exponents 0 < p ≤ q, the weighted power means satisfy (∑ w_i x_i^p)^{1/p} ≤ (∑ w_i x_i^q)^{1/q}.",
+    "proofStrategy": "Define M_p(x) = (∑_{i∈s} w_i·x_i^p)^{1/p}. To compare M_p and M_q for 0 < p ≤ q, set r = q/p ≥ 1 and apply Real.rpow_arith_mean_le_arith_mean_rpow to the data z_i = x_i^p with exponent r: (∑ w_i x_i^p)^r ≤ ∑ w_i (x_i^p)^r. The right-hand side equals ∑ w_i x_i^q because (x_i^p)^r = x_i^{p·(q/p)} = x_i^q (Real.rpow_mul and p·(q/p) = q). Now (∑ w_i x_i^p)^r = M_p^q (since ((∑ w_i x_i^p)^{1/p})^q = (∑ w_i x_i^p)^{q/p}) and ∑ w_i x_i^q = M_q^q (since ((∑ w_i x_i^q)^{1/q})^q = ∑ w_i x_i^q). Thus M_p^q ≤ M_q^q, and since q > 0 with both means nonnegative, Real.rpow_le_rpow_iff gives M_p ≤ M_q. The arithmetic-mean and QM–AM corollaries follow by specializing p = 1 (with powerMean_one identifying M_1 as ∑ w_i x_i) and (p,q) = (1,2).",
+    "keyInsights": [
+      "Power-mean monotonicity is a one-substitution corollary of the single-exponent Jensen bound: comparing exponents p ≤ q is the same as applying Jensen for t ↦ t^{q/p} to the data x_i^p, because raising the whole inequality to the power q linearizes the two reciprocal exponents 1/p and 1/q.",
+      "The exponent bookkeeping is the crux: (x_i^p)^{q/p} = x_i^q and ((∑·)^{1/p})^q = (∑·)^{q/p} are both instances of Real.rpow_mul, and the algebraic identities p·(q/p) = q and (1/q)·q = 1 are what collapse the powered means to the raw Jensen inequality.",
+      "Reducing M_p ≤ M_q to M_p^q ≤ M_q^q via Real.rpow_le_rpow_iff (valid because q > 0 and both means are nonnegative) is what lets the proof avoid handling the reciprocal exponents directly — one compares the means after raising to the common power q.",
+      "The result is the head of the classical mean hierarchy on positive exponents: arith_mean_le_powerMean (M_1 ≤ M_p, p ≥ 1) and qm_am_inequality (the root-mean-square inequality, p=1, q=2) are immediate specializations, and the same theorem governs every comparison of power means with positive exponents."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "States the goal — the power-mean inequality (monotonicity of M_p in the exponent), a gap in Mathlib — and outlines the Jensen-for-t↦t^r substitution strategy.",
+      "mathContext": "Power-mean inequality: $0<p\\le q \\Rightarrow \\big(\\sum_i w_i x_i^p\\big)^{1/p} \\le \\big(\\sum_i w_i x_i^q\\big)^{1/q}$ for $w_i\\ge0$, $\\sum_i w_i=1$, $x_i\\ge0$."
+    },
+    {
+      "id": "definition",
+      "title": "The weighted power mean and basic facts",
+      "startLine": 53,
+      "endLine": 82,
+      "summary": "powerMean s w x p = (∑ w_i x_i^p)^{1/p}, with sum_term_nonneg (nonnegativity of the inner sum), powerMean_nonneg, and powerMean_one (M_1 = ∑ w_i x_i, the weighted arithmetic mean).",
+      "mathContext": "$M_p(x)=\\big(\\sum_{i\\in s} w_i x_i^p\\big)^{1/p}$; $M_1(x)=\\sum_{i\\in s} w_i x_i$."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Power-mean monotonicity in the exponent",
+      "startLine": 83,
+      "endLine": 120,
+      "summary": "powerMean_le_powerMean: apply Real.rpow_arith_mean_le_arith_mean_rpow with r = q/p to data x_i^p, rewrite (x_i^p)^{q/p} = x_i^q, identify both sides as q-th powers of M_p and M_q, and divide out via Real.rpow_le_rpow_iff.",
+      "mathContext": "$M_p^q=\\big(\\sum w_i x_i^p\\big)^{q/p}\\le \\sum w_i x_i^q=M_q^q$, hence $M_p\\le M_q$ since $q>0$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Arithmetic-mean and QM–AM corollaries",
+      "startLine": 121,
+      "endLine": 130,
+      "summary": "arith_mean_le_powerMean: ∑ w_i x_i ≤ M_p for p ≥ 1 (the p = 1 slice). qm_am_inequality: ∑ w_i x_i ≤ (∑ w_i x_i²)^{1/2}, the root-mean-square inequality (p = 1, q = 2).",
+      "mathContext": "$\\sum_i w_i x_i \\le M_p$ for $p\\ge1$; QM–AM: $\\sum_i w_i x_i \\le \\big(\\sum_i w_i x_i^2\\big)^{1/2}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified file (0 sorries, 0 axioms, no native_decide) supplies the classical power-mean inequality — monotonicity of the weighted power mean M_p(x) = (∑ w_i x_i^p)^{1/p} in the exponent p on the positive reals — which Mathlib does not provide. The proof is a single application of Mathlib's single-exponent Jensen bound rpow_arith_mean_le_arith_mean_rpow to the powered data x_i^p with exponent q/p, followed by rpow-monotonicity. The weighted arithmetic-mean lower bound and the QM–AM (root-mean-square) inequality are recovered as specializations.",
+    "implications": "The power-mean inequality is the unifying statement behind the elementary mean inequalities on positive exponents: AM ≤ QM (root-mean-square), and more generally M_p ≤ M_q for 0 < p ≤ q. Combined with the parent Young/AM–GM entry and the sibling Hölder entry, it rounds out the Jensen-driven family of finite-sum inequalities, all of which descend from convexity of a single elementary function.",
+    "openQuestions": [
+      "Extend the monotonicity to all real exponents, including p < 0 (harmonic mean M_{-1}) and the p → 0 limit (the weighted geometric mean), recovering the full hierarchy HM ≤ GM ≤ AM ≤ QM as a single chain.",
+      "Prove the equality case: for strictly positive weights, M_p(x) = M_q(x) with p < q holds iff x is constant on the support of w, descending from the strict-convexity equality case of t ↦ t^r.",
+      "Lift the power mean and its monotonicity from finite sums to the integral (probability-measure) setting, matching the L^p-norm monotonicity ‖·‖_{L^p} ≤ ‖·‖_{L^q} on a probability space."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 131,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ04.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 6,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the classical **power-mean inequality**, which Mathlib does not provide: for a finite family of nonnegative reals `x_i` (`i ∈ s`) with nonnegative weights `w_i` summing to `1`, the weighted power mean

    M_p(x) = (∑_i w_i·x_i^p)^{1/p}

is **monotone non-decreasing in the exponent** on `p > 0`:

    0 < p ≤ q  ⟹  M_p(x) ≤ M_q(x).

This single statement subsumes the comparison of the weighted arithmetic mean `M_1` with every higher power mean, and in particular the quadratic-mean / arithmetic-mean (QM–AM, root-mean-square) inequality.

## Mathlib gap

Mathlib ships the single-exponent Jensen bound `Real.rpow_arith_mean_le_arith_mean_rpow` (`(∑ w_i z_i)^r ≤ ∑ w_i z_i^r` for `r ≥ 1`) and the arithmetic-mean lower bound `arith_mean_le_rpow_mean`, but **neither the closed-form power mean nor its monotonicity across exponents**. This file supplies them for positive exponents, self-contained.

## Proof strategy

The canonical Jensen application. To compare `M_p` and `M_q` for `0 < p ≤ q`, set `r = q/p ≥ 1` and apply `Real.rpow_arith_mean_le_arith_mean_rpow` to the powered data `z_i = x_i^p`:

    (∑ w_i x_i^p)^r ≤ ∑ w_i (x_i^p)^r = ∑ w_i x_i^q,

using `(x_i^p)^r = x_i^{p·(q/p)} = x_i^q`. The left side is `M_p^q` and the right side is `M_q^q`; since `q > 0` and both means are nonnegative, `Real.rpow_le_rpow_iff` yields `M_p ≤ M_q`.

## Main results

- `powerMean`, `powerMean_nonneg`, `powerMean_one` — the closed-form weighted power mean and its basic facts (`M_1` is the weighted arithmetic mean).
- `powerMean_le_powerMean` — **the power-mean inequality** (main result).
- `arith_mean_le_powerMean` — `∑ w_i x_i ≤ M_p` for `p ≥ 1`.
- `qm_am_inequality` — the weighted QM–AM (root-mean-square) inequality `∑ w_i x_i ≤ (∑ w_i x_i²)^{1/2}`.

## Verification

- **131 lines, 6 theorems / 1 definition**
- **0 sorries, 0 axioms, no `native_decide`**
- Self-contained — imports only Mathlib; does not depend on any other gallery file.
- Built successfully via `./proofs/scripts/docker-build.sh Proofs.JensenInequalityOQ01OQ01OQ01OQ04` (7743 jobs).

Extends the AM–GM / Young / Hölder / Minkowski lineage (`jensen-inequality-oq-01-oq-01-oq-01` and siblings) with the power-mean strand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)