### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01): the equality case of the power mean inequality — M_r = M_t iff the data is constant [0-axiom verified]

### DIFF
--- a/proofs/Proofs/PowerMeanEqualityOQ.lean
+++ b/proofs/Proofs/PowerMeanEqualityOQ.lean
@@ -1,0 +1,176 @@
+import Mathlib
+import Proofs.AmgmInequalityOQ03
+import Proofs.JensenInequalityOQ01
+
+/-
+# The Equality Case of the Power Mean Inequality
+
+## Open Question (jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01)
+
+The power mean monotonicity theorem (`power_mean_monotone`, the parent result) shows that the
+weighted power mean `M_p = (∑ wᵢ zᵢ^p)^{1/p}` is a *non-decreasing* function of the exponent `p`.
+This file answers the sharpness question it leaves open: **when is the inequality strict?**
+
+The answer is the classical one. For `0 < r < t`, with strictly positive weights summing to `1`
+and strictly positive data,
+
+    M_r = M_t   ↔   all the data `zᵢ` are equal.
+
+Equivalently, `M_r < M_t` unless the data is constant. This is the exact converse companion to the
+monotonicity inequality: monotonicity says `M_r ≤ M_t`, and this file pins down the equality locus.
+
+## Proof Strategy
+
+The engine is a single application of **strict** Jensen to the strictly convex function
+`x ↦ x^{t/r}` (strictly convex on `[0,∞)` since `t/r > 1`), applied to the powered data
+`uᵢ = zᵢ^r`:
+
+    (∑ wᵢ uᵢ)^{t/r} = ∑ wᵢ uᵢ^{t/r}   ↔   every `uᵢ` equals the mean,
+
+which is exactly `jensen_eq_iff` (the equality case of strict Jensen, from `JensenInequalityOQ01`).
+The left-hand equality rewrites, via `(zᵢ^r)^{t/r} = zᵢ^t` and a monotone change of `rpow`
+exponent, to `M_r = M_t`; the right-hand condition rewrites, via injectivity of `x ↦ x^r` on the
+nonnegative reals, to "all `zᵢ` equal".
+
+## Main results
+
+* `power_mean_eq_iff_pos` — the equality case: `M_r = M_t ↔ ∀ j k, zⱼ = zₖ` (`0 < r < t`).
+* `power_mean_lt_of_ne` — strict monotonicity off the diagonal: non-constant data ⇒ `M_r < M_t`.
+* `am_eq_qm_iff` — `AM = QM ↔` all data equal (the `r = 1, t = 2` instance).
+* `am_lt_qm_of_ne` — non-constant data ⇒ `AM < QM` strictly.
+
+All results are fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+
+## Prerequisites
+
+- `AmgmInequalityOQ03.lean`: `weightedPowerMean`, `power_mean_monotone_pos`.
+- `JensenInequalityOQ01.lean`: `jensen_eq_iff` (equality case of strict Jensen).
+- Mathlib: `strictConvexOn_rpow`, `Real.rpow_left_inj`, `Real.rpow_mul`.
+-/
+
+open Finset Real
+
+namespace PowerMeanEquality
+
+variable {ι : Type*} (s : Finset ι) (w z : ι → ℝ)
+
+/-- The weighted power-sum `∑ wᵢ zᵢ^p` is strictly positive when the weights are nonnegative and
+sum to `1` and the data is strictly positive. (Re-derived here; the analogous helper in
+`AmgmInequalityOQ03` is private.) -/
+private lemma wsum_pos (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1)
+    (hz : ∀ i ∈ s, 0 < z i) {p : ℝ} : 0 < ∑ i ∈ s, w i * z i ^ p := by
+  obtain ⟨i₀, hi₀, hwi₀⟩ : ∃ i ∈ s, 0 < w i := by
+    by_contra h
+    push_neg at h
+    have hzero : ∀ i ∈ s, w i = 0 := fun i hi => le_antisymm (h i hi) (hw i hi)
+    rw [Finset.sum_eq_zero hzero] at hw'
+    norm_num at hw'
+  exact lt_of_lt_of_le
+    (mul_pos hwi₀ (Real.rpow_pos_of_pos (hz i₀ hi₀) p))
+    (Finset.single_le_sum
+      (fun i hi => mul_nonneg (hw i hi) (Real.rpow_nonneg (hz i hi).le p)) hi₀)
+
+/-- **Equality case of the power mean inequality.**
+
+For `0 < r < t`, strictly positive weights summing to `1`, and strictly positive data, the two
+power means coincide exactly when the data is constant:
+
+    M_r(z, w) = M_t(z, w)   ↔   ∀ j k, zⱼ = zₖ.
+
+This is the sharp converse to power mean monotonicity (`power_mean_monotone`). -/
+theorem power_mean_eq_iff_pos
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r t : ℝ} (hr : 0 < r) (hrt : r < t) :
+    weightedPowerMean s w z r (ne_of_gt hr)
+        = weightedPowerMean s w z t (ne_of_gt (hr.trans hrt))
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  have hr_ne : r ≠ 0 := ne_of_gt hr
+  have ht : 0 < t := hr.trans hrt
+  have ht_ne : t ≠ 0 := ne_of_gt ht
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  have hA : 0 < ∑ i ∈ s, w i * z i ^ r := wsum_pos s w z hwnn hw' hz
+  have hB : 0 < ∑ i ∈ s, w i * z i ^ t := wsum_pos s w z hwnn hw' hz
+  -- exponent identity used to fold `(zᵢ^r)^(t/r)` back to `zᵢ^t`
+  have hrt_eq : r * (t / r) = t := by field_simp
+  -- 1 < t / r ⇒ `x ↦ x^(t/r)` is strictly convex on [0,∞)
+  have hgt1 : 1 < t / r := (one_lt_div hr).mpr hrt
+  have hconv : StrictConvexOn ℝ (Set.Ici 0) (fun x : ℝ => x ^ (t / r)) :=
+    strictConvexOn_rpow hgt1
+  have hmem : ∀ i ∈ s, z i ^ r ∈ Set.Ici (0 : ℝ) :=
+    fun i hi => Set.mem_Ici.mpr (Real.rpow_nonneg (hz i hi).le r)
+  -- equality case of strict Jensen for the powered data uᵢ = zᵢ^r
+  have hJ := jensen_eq_iff hconv hw hw' hmem
+  simp only [smul_eq_mul] at hJ
+  -- fold the right summand: ∑ wᵢ (zᵢ^r)^(t/r) = ∑ wᵢ zᵢ^t
+  have hpow : ∑ i ∈ s, w i * (z i ^ r) ^ (t / r) = ∑ i ∈ s, w i * z i ^ t :=
+    Finset.sum_congr rfl fun i hi => by rw [← Real.rpow_mul (hz i hi).le, hrt_eq]
+  rw [hpow] at hJ
+  -- bridge 1: M_r = M_t ↔ (∑ wᵢ zᵢ^r)^(t/r) = ∑ wᵢ zᵢ^t
+  have eqI : weightedPowerMean s w z r hr_ne = weightedPowerMean s w z t ht_ne
+      ↔ (∑ i ∈ s, w i * z i ^ r) ^ (t / r) = ∑ i ∈ s, w i * z i ^ t := by
+    simp only [weightedPowerMean]
+    constructor
+    · intro h
+      have h2 : ((∑ i ∈ s, w i * z i ^ r) ^ (1 / r)) ^ t
+              = ((∑ i ∈ s, w i * z i ^ t) ^ (1 / t)) ^ t := by rw [h]
+      rwa [← Real.rpow_mul hA.le, ← Real.rpow_mul hB.le,
+           show (1 / r) * t = t / r from by ring,
+           show (1 / t) * t = 1 from one_div_mul_cancel ht_ne, Real.rpow_one] at h2
+    · intro h
+      have h2 : ((∑ i ∈ s, w i * z i ^ r) ^ (1 / r)) ^ t
+              = ((∑ i ∈ s, w i * z i ^ t) ^ (1 / t)) ^ t := by
+        rw [← Real.rpow_mul hA.le, ← Real.rpow_mul hB.le,
+            show (1 / r) * t = t / r from by ring,
+            show (1 / t) * t = 1 from one_div_mul_cancel ht_ne, Real.rpow_one]
+        exact h
+      exact (Real.rpow_left_inj (Real.rpow_nonneg hA.le _) (Real.rpow_nonneg hB.le _) ht_ne).mp h2
+  -- bridge 2: every zⱼ^r equals the mean ↔ all data equal
+  have eqII : (∀ j ∈ s, z j ^ r = ∑ i ∈ s, w i * z i ^ r)
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+    constructor
+    · intro h j hj k hk
+      exact (Real.rpow_left_inj (hz j hj).le (hz k hk).le hr_ne).mp
+        (by rw [h j hj, h k hk])
+    · intro h j hj
+      calc z j ^ r
+          = (∑ i ∈ s, w i) * z j ^ r := by rw [hw', one_mul]
+        _ = ∑ i ∈ s, w i * z j ^ r := by rw [Finset.sum_mul]
+        _ = ∑ i ∈ s, w i * z i ^ r :=
+            Finset.sum_congr rfl fun i hi => by rw [h i hi j hj]
+  exact eqI.trans (hJ.trans eqII)
+
+/-- **Strict power mean inequality off the diagonal.** For `0 < r < t`, if the data is not constant
+(two values differ) then the power mean inequality is strict: `M_r < M_t`. -/
+theorem power_mean_lt_of_ne
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r t : ℝ} (hr : 0 < r) (hrt : r < t)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    weightedPowerMean s w z r (ne_of_gt hr)
+      < weightedPowerMean s w z t (ne_of_gt (hr.trans hrt)) := by
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  have hle : weightedPowerMean s w z r (ne_of_gt hr)
+      ≤ weightedPowerMean s w z t (ne_of_gt (hr.trans hrt)) :=
+    power_mean_monotone_pos s w z hwnn hw' hz hr hrt.le (ne_of_gt hr)
+      (ne_of_gt (hr.trans hrt))
+  refine lt_of_le_of_ne hle ?_
+  intro hEq
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  exact hjk ((power_mean_eq_iff_pos s w z hw hw' hz hr hrt).mp hEq j hj k hk)
+
+/-- **AM = QM iff the data is constant.** Specializing the equality case to `r = 1, t = 2`: the
+arithmetic mean equals the quadratic mean exactly when all the data are equal. -/
+theorem am_eq_qm_iff
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) :
+    weightedPowerMean s w z 1 (by norm_num) = weightedPowerMean s w z 2 (by norm_num)
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k :=
+  power_mean_eq_iff_pos s w z hw hw' hz (by norm_num) (by norm_num)
+
+/-- **AM < QM for non-constant data.** If two of the values differ, the arithmetic mean is strictly
+below the quadratic mean. -/
+theorem am_lt_qm_of_ne
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    weightedPowerMean s w z 1 (by norm_num) < weightedPowerMean s w z 2 (by norm_num) :=
+  power_mean_lt_of_ne s w z hw hw' hz (by norm_num) (by norm_num) hne
+
+end PowerMeanEquality

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+  "title": "The Equality Case of the Power Mean Inequality",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+  "description": "Determines exactly when the power-mean inequality is an equality, sharpening the parent monotonicity result M_p ≤ M_q (0 < p ≤ q) into a strict characterization. For a finite family of strictly positive reals z_i (i ∈ s) with strictly positive weights w_i summing to 1, and exponents 0 < r < t, the weighted power means M_r(z) = (∑_i w_i·z_i^r)^{1/r} and M_t(z) = (∑_i w_i·z_i^t)^{1/t} coincide if and only if all the data z_i are equal; equivalently, M_r < M_t strictly whenever the data is non-constant. The proof is a single application of the equality case of strict Jensen to the strictly convex map x ↦ x^{t/r} (strictly convex on [0,∞) because t/r > 1), applied to the powered data u_i = z_i^r: strict Jensen gives equality (∑ w_i u_i)^{t/r} = ∑ w_i u_i^{t/r} iff every u_i equals the weighted mean. The left-hand equality rewrites to M_r = M_t via (z_i^r)^{t/r} = z_i^t and a monotone change of the rpow exponent; the right-hand condition rewrites, via injectivity of x ↦ x^r on the nonnegative reals, to 'all z_i equal'. Mathlib provides neither the power mean nor its equality case.",
+  "meta": {
+    "author": "Lean Genius (power-mean equality case via the equality case of strict Jensen for x↦x^{t/r}); the result is classical (cf. Hardy–Littlewood–Pólya, Inequalities, 1934)",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PowerMeanEqualityOQ.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "power-mean-inequality",
+      "jensen-inequality",
+      "equality-case",
+      "strict-convexity",
+      "qm-am-inequality",
+      "inequalities",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 176,
+    "originalContributions": [
+      "power_mean_eq_iff_pos: the equality case of the power-mean inequality — for strictly positive weights w summing to 1, strictly positive data z, and exponents 0 < r < t, the weighted power means satisfy M_r(z) = M_t(z) if and only if all the data z_i are equal. This is the sharp converse companion to the parent monotonicity theorem (which gives only M_r ≤ M_t) and is absent from Mathlib. Proved by feeding the powered data u_i = z_i^r into jensen_eq_iff (the equality case of strict Jensen) for the strictly convex map x ↦ x^{t/r}, then translating both sides through rpow algebra and injectivity of x ↦ x^r on the nonnegatives.",
+      "power_mean_lt_of_ne: strict monotonicity off the diagonal — for 0 < r < t, if two of the values differ then M_r(z) < M_t(z) strictly. Obtained by combining the parent's non-strict bound M_r ≤ M_t (power_mean_monotone_pos) with power_mean_eq_iff_pos: non-constant data forbids equality, so the inequality is strict.",
+      "am_eq_qm_iff: the arithmetic mean equals the quadratic mean (root-mean-square) if and only if all the data are equal — the r = 1, t = 2 specialization of the equality case.",
+      "am_lt_qm_of_ne: the weighted AM < QM strictly for non-constant data — the strict r = 1, t = 2 instance, the sharp form of the classical QM–AM inequality."
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide. Depends only on Mathlib (strictConvexOn_rpow, Real.rpow_left_inj, Real.rpow_mul) and two merged gallery files: AmgmInequalityOQ03 (the weightedPowerMean definition and power_mean_monotone_pos) and JensenInequalityOQ01 (jensen_eq_iff, the equality case of strict Jensen).",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "lineCount": 176,
+    "axiomCount": 0,
+    "path": "Proofs/PowerMeanEqualityOQ.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4,
+    "imports": [
+      "Mathlib",
+      "Proofs.AmgmInequalityOQ03",
+      "Proofs.JensenInequalityOQ01"
+    ]
+  },
+  "sorries": 0,
+  "sections": [
+    {
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 53,
+      "id": "header"
+    },
+    {
+      "title": "Positivity of the weighted power-sum",
+      "startLine": 55,
+      "endLine": 73,
+      "id": "wsum-pos"
+    },
+    {
+      "title": "The equality case of the power mean inequality",
+      "startLine": 75,
+      "endLine": 142,
+      "id": "equality-case"
+    },
+    {
+      "title": "Strict monotonicity off the diagonal",
+      "startLine": 144,
+      "endLine": 160,
+      "id": "strict-lt"
+    },
+    {
+      "title": "AM = QM iff constant, and strict AM < QM",
+      "startLine": 162,
+      "endLine": 176,
+      "id": "am-qm-corollaries"
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 176-line file (0 sorries, 0 axioms, no native_decide) determines the equality case of the power-mean inequality: for 0 < r < t with strictly positive weights summing to 1 and strictly positive data, M_r(z) = M_t(z) if and only if all the data z_i are equal, hence M_r < M_t strictly off the constant diagonal. The engine is a single application of the equality case of strict Jensen (jensen_eq_iff) to the strictly convex map x ↦ x^{t/r} on the powered data z_i^r, with the two translations between the means and the data both supplied by injectivity of x ↦ x^c on the nonnegative reals. Neither the power mean nor its equality case is in Mathlib.",
+    "implications": "This sharpens the parent's non-strict power-mean monotonicity into a strict characterization, pinning the extremal (constant-data) configuration of the entire positive-exponent mean hierarchy. The r=1, t=2 instance is the strict QM–AM inequality — the algebraic statement that the quadratic mean strictly exceeds the arithmetic mean for any non-constant family, i.e. strict positivity of variance. It mirrors, for power functions, the AM–GM equality case the grandparent obtains from the same jensen_eq_iff applied to exp.",
+    "openQuestions": [
+      "Extend the equality characterization to all nonzero exponents r < t (including negative r, and the crossing-zero and geometric-mean p → 0 limits), via the reciprocal-data trick M_r(z) = M_{-r}(z⁻¹)⁻¹ used for the parent's negative-exponent monotonicity.",
+      "Quantify the gap: give a lower bound on M_t − M_r in terms of the spread (e.g. variance) of the data, refining the strict inequality into an effective one.",
+      "Transport the equality case from finite weighted sums to the Lᵖ / integral setting, characterizing when the integral power means of a positive function coincide."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "The parent proves power-mean monotonicity M_p ≤ M_q for 0 < p ≤ q. This entry supplies the sharpness: it characterizes the equality locus M_r = M_t as exactly the constant data, turning the parent's non-strict inequality into a strict one off the diagonal."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "uses",
+      "description": "The grandparent isolates jensen_eq_iff, the equality case of strict Jensen (a re-export of Mathlib's StrictConvexOn.map_sum_eq_iff). This entry instantiates it at the strictly convex map x ↦ x^{t/r} to obtain the power-mean equality case, exactly as the grandparent instantiates it at exp to obtain the AM–GM equality case."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The power-mean inequality states that M_p(z) = (∑ w_i z_i^p)^{1/p} is a non-decreasing function of p; its equality case is the classical statement that the inequality is strict unless the data is constant (Hardy, Littlewood and Pólya, Inequalities, 1934). This sharpness is what underlies, e.g., the fact that the quadratic mean strictly exceeds the arithmetic mean for any non-constant sample — the algebraic heart of variance positivity. Mathlib formalizes the single-exponent Jensen bound and (in the grandparent gallery entry) the equality case of strict Jensen, but not the power mean nor its equality case; this entry supplies the latter for positive exponents.",
+    "problemStatement": "The parent gallery entry proves M_p ≤ M_q for 0 < p ≤ q but leaves open when the inequality is strict. Determine the equality locus: show that for strictly positive weights summing to 1, strictly positive data, and 0 < r < t, one has M_r(z) = M_t(z) if and only if all the z_i are equal.",
+    "proofStrategy": "Write A = ∑ w_i z_i^r and B = ∑ w_i z_i^t, both strictly positive. The key step is the equality case of strict Jensen (jensen_eq_iff) applied to the strictly convex function x ↦ x^{t/r} — strictly convex on [0,∞) since t/r > 1 — and the powered data u_i = z_i^r: it gives A^{t/r} = ∑ w_i (z_i^r)^{t/r} ↔ ∀ j, z_j^r = A. Two bridges convert this to the statement about M_r and M_t. First, ∑ w_i (z_i^r)^{t/r} = B because (z_i^r)^{t/r} = z_i^{r·(t/r)} = z_i^t (Real.rpow_mul), and A^{t/r} = B is equivalent to M_r = M_t after raising both means to the common power t (using injectivity of x ↦ x^t on the nonnegatives, Real.rpow_left_inj, and the exponent identities (1/r)·t = t/r, (1/t)·t = 1). Second, the condition ∀ j, z_j^r = A says every z_j^r equals the mean, hence all z_j^r are equal, hence all z_j are equal by injectivity of x ↦ x^r on the nonnegatives; the converse is the computation A = ∑ w_i z_j^r = (∑ w_i) z_j^r = z_j^r when the data is constant. Chaining the three equivalences yields M_r = M_t ↔ all z_i equal. The strict inequality power_mean_lt_of_ne then combines this with the parent's non-strict bound, and the AM/QM corollaries are the r=1, t=2 instances.",
+    "keyInsights": [
+      "Power-mean equality is governed by a single instance of the strict-Jensen equality case: feeding the powered data z_i^r into the equality criterion for the strictly convex map x ↦ x^{t/r} pins down equality of the means exactly when the data is constant — the same engine the grandparent uses with exp for AM–GM, here with a power function.",
+      "Strict convexity of x ↦ x^{t/r} requires t/r > 1, i.e. r < t strictly; this is precisely why the equality characterization needs strict inequality of exponents (at r = t the means are trivially equal regardless of the data).",
+      "Both translations — from A^{t/r} = B to M_r = M_t, and from 'each z_j^r equals the mean' to 'all z_j equal' — are powered by injectivity of x ↦ x^c on the nonnegative reals (Real.rpow_left_inj), once for the exponent t (comparing the means) and once for r (comparing the data).",
+      "The strict QM–AM inequality (am_lt_qm_of_ne) drops out as the r=1, t=2 instance: the quadratic mean strictly exceeds the arithmetic mean for any non-constant family, the inequality underlying strict positivity of variance."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Determines the **equality case** of the power-mean inequality, sharpening the parent monotonicity result (`power_mean_monotone`, M_r ≤ M_t for 0 < r ≤ t) into a strict characterization.

For `0 < r < t`, strictly positive weights `w_i` summing to 1, and strictly positive data `z_i`:

> **M_r(z) = M_t(z)  ⟺  all the data `z_i` are equal.**

Equivalently, `M_r < M_t` strictly whenever the data is non-constant.

This is a genuine Mathlib gap — Mathlib provides neither the weighted power mean nor its equality case.

## Main results (`Proofs/PowerMeanEqualityOQ.lean`, 176 lines, 4 theorems)

- **`power_mean_eq_iff_pos`** — the equality case: `M_r = M_t ↔ ∀ j k, z_j = z_k`.
- **`power_mean_lt_of_ne`** — strict monotonicity off the diagonal: non-constant data ⇒ `M_r < M_t`.
- **`am_eq_qm_iff`** — `AM = QM ↔` all data equal (the `r=1, t=2` instance).
- **`am_lt_qm_of_ne`** — non-constant data ⇒ `AM < QM` strictly (the sharp QM–AM inequality / variance positivity).

## Proof engine

A single application of the equality case of strict Jensen (`jensen_eq_iff` from `JensenInequalityOQ01`) to the strictly convex map `x ↦ x^{t/r}` (`strictConvexOn_rpow`, strictly convex on `[0,∞)` since `t/r > 1`), applied to the powered data `u_i = z_i^r`. The two translations — between the means and between the data — are both supplied by injectivity of `x ↦ x^c` on the nonnegatives (`Real.rpow_left_inj`). It mirrors the way the grandparent obtains the AM–GM equality case from the same `jensen_eq_iff` applied to `exp`.

## Verification

- **0 sorries, 0 axioms, no `native_decide`.** `#print axioms` lists only `propext, Classical.choice, Quot.sound` (the foundational axioms, which do not count).
- Builds via `./proofs/scripts/docker-build.sh Proofs.PowerMeanEqualityOQ` (7745 jobs, success).
- Depends only on Mathlib and two merged gallery files: `AmgmInequalityOQ03` (`weightedPowerMean`, `power_mean_monotone_pos`) and `JensenInequalityOQ01` (`jensen_eq_iff`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)