### PR TITLE
research(amgm-inequality-oq-03-oq-02-oq-01-oq-02): equality case of the crossing-zero power-mean chain [0-axiom verified]

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean
@@ -1,0 +1,243 @@
+/-
+  Equality case of the crossing-zero power-mean chain
+  Open Question: amgm-inequality-oq-03-oq-02-oq-01-oq-02
+
+  The crossing-zero file `PowerMeanCrossZeroOQ` proves the *inequalities*
+
+      M_r(z,w) ≤ GM(z,w) ≤ M_s(z,w)        for  r < 0 < s,
+
+  where GM is the weighted geometric mean and M_p the weighted power mean of
+  order p. Those bounds are all non-strict. This file supplies the **sharp
+  converse**: it characterizes exactly when equality holds, and upgrades the
+  bounds to strict inequalities off the diagonal.
+
+  ## Headline results
+
+  * `power_mean_eq_geom_mean_iff` — for **every** exponent `r ≠ 0` (positive or
+    negative!), `M_r = GM ↔ all data equal`. The equality locus is the *same*
+    for both signs of `r`, even though the inequality flips direction across
+    zero (GM ≤ M_r for r > 0, M_r ≤ GM for r < 0). This sign-independent
+    unification is the main observation.
+  * `power_mean_crossing_zero_eq_iff` — for `r < 0 < t`,
+    `M_r = M_t ↔ all data equal`, the sharp converse to
+    `power_mean_monotone_crossing_zero`.
+  * `power_mean_lt_geom_mean_neg_of_ne`, `geom_mean_lt_power_mean_pos_of_ne`,
+    `power_mean_crossing_zero_lt_of_ne` — the strict forms for non-constant data.
+  * `hm_lt_gm_lt_am_of_ne`, `hm_eq_gm_iff` — the classical HM < GM < AM corner.
+
+  ## Engine
+
+  The single fact behind all of this is the equality case of weighted AM–GM,
+  `weighted_amgm_eq_iff` (root `JensenInequalityOQ01`), applied to the *powered*
+  data `uᵢ = zᵢ^r`:
+
+      GM^r = ∑ wᵢ zᵢ^r   ↔   ∀ j k, zⱼ^r = zₖ^r   ↔   ∀ j k, zⱼ = zₖ,
+
+  the last step by injectivity of `x ↦ x^r` on the positives (`r ≠ 0`). Raising
+  to the (bijective) power `1/r` then converts `GM^r = ∑ wᵢ zᵢ^r` to `GM = M_r`,
+  *independently of the sign of `r`*. No limit arguments are used.
+-/
+
+import Proofs.AmgmInequalityOQ03
+import Proofs.JensenInequalityOQ01
+import Proofs.PowerMeanCrossZeroOQ
+import Mathlib.Tactic
+
+open Real Finset
+
+namespace PowerMeanCrossZeroEq
+
+variable {ι : Type*} (s : Finset ι) (w z : ι → ℝ)
+
+-- ============================================================
+-- §1. POSITIVITY AND ALGEBRAIC HELPERS
+-- ============================================================
+
+/-- The weighted sum `∑ wᵢ zᵢ^r > 0` when the weights sum to `1` and all `zᵢ > 0`. -/
+private lemma weightedSum_rpow_pos
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) (r : ℝ) :
+    0 < ∑ i ∈ s, w i * z i ^ r := by
+  obtain ⟨i₀, hi₀, hwi₀⟩ : ∃ i ∈ s, 0 < w i := by
+    by_contra h; push_neg at h
+    linarith [Finset.sum_eq_zero (fun i hi => le_antisymm (h i hi) (hw i hi))]
+  exact lt_of_lt_of_le
+    (mul_pos hwi₀ (Real.rpow_pos_of_pos (hz i₀ hi₀) r))
+    (Finset.single_le_sum
+      (fun i hi => mul_nonneg (hw i hi) (Real.rpow_nonneg (hz i hi).le r)) hi₀)
+
+/-- The weighted geometric mean `GM(z,w) > 0` when all `zᵢ > 0`. -/
+private lemma weightedGeomMean_pos (hz : ∀ i ∈ s, 0 < z i) :
+    0 < weightedGeomMean s w z :=
+  Finset.prod_pos (fun i hi => Real.rpow_pos_of_pos (hz i hi) (w i))
+
+/-- `(∏ fᵢ)^r = ∏ fᵢ^r` for nonnegative `f` (induction on the index set). -/
+private lemma finset_prod_rpow (f : ι → ℝ) (hf : ∀ i ∈ s, 0 ≤ f i) (r : ℝ) :
+    (∏ i ∈ s, f i) ^ r = ∏ i ∈ s, f i ^ r := by
+  classical
+  induction s using Finset.induction_on with
+  | empty => simp
+  | @insert a s' ha ih =>
+    rw [Finset.prod_insert ha,
+        Real.mul_rpow (hf a (Finset.mem_insert_self a s'))
+          (Finset.prod_nonneg fun i hi => hf i (Finset.mem_insert_of_mem hi)),
+        Finset.prod_insert ha,
+        ih (fun i hi => hf i (Finset.mem_insert_of_mem hi))]
+
+/-- `GM^r = ∏ (zᵢ^r)^wᵢ`: both sides equal `∏ zᵢ^(r·wᵢ)`. -/
+private lemma geomMean_rpow_eq (hz : ∀ i ∈ s, 0 ≤ z i) (r : ℝ) :
+    (weightedGeomMean s w z) ^ r = ∏ i ∈ s, (z i ^ r) ^ w i := by
+  simp only [weightedGeomMean]
+  rw [finset_prod_rpow s (fun i => z i ^ w i) (fun i hi => Real.rpow_nonneg (hz i hi) (w i)) r]
+  apply Finset.prod_congr rfl
+  intro i hi
+  rw [← Real.rpow_mul (hz i hi), ← Real.rpow_mul (hz i hi)]
+  congr 1; ring
+
+-- ============================================================
+-- §2. CORE EQUALITY LEMMA:  GM^r = ∑ wᵢ zᵢ^r  ↔  constant
+-- ============================================================
+
+/-- **Equality case of the core inequality.** For any `r ≠ 0`, strictly positive
+weights summing to `1`, and strictly positive data,
+
+    GM^r = ∑ wᵢ zᵢ^r   ↔   all the data are equal.
+
+This is `weighted_amgm_eq_iff` applied to the powered data `zᵢ^r`, with the
+right-hand equalities `zⱼ^r = zₖ^r` collapsed to `zⱼ = zₖ` by injectivity of
+`x ↦ x^r` on the positives. -/
+theorem geomMean_rpow_eq_weightedSum_rpow_iff
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r : ℝ} (hrne : r ≠ 0) :
+    (weightedGeomMean s w z) ^ r = ∑ i ∈ s, w i * z i ^ r
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  have key := weighted_amgm_eq_iff (s := s) (w := w) (z := fun i => z i ^ r)
+    hw hw' (fun i hi => Real.rpow_nonneg (hz i hi).le r)
+  simp only [] at key
+  rw [geomMean_rpow_eq s w z (fun i hi => (hz i hi).le) r, key]
+  constructor
+  · intro h j hj k hk
+    exact (Real.rpow_left_inj (hz j hj).le (hz k hk).le hrne).mp (h j hj k hk)
+  · intro h j hj k hk
+    rw [h j hj k hk]
+
+-- ============================================================
+-- §3. THE SIGN-INDEPENDENT EQUALITY CASE:  M_r = GM  ↔  constant
+-- ============================================================
+
+/-- **The geometric mean equals the power mean of order `r` iff the data is
+constant — for every `r ≠ 0`.**
+
+Although the *inequality* between `GM` and `M_r` reverses across zero
+(`GM ≤ M_r` for `r > 0`, `M_r ≤ GM` for `r < 0`), the *equality locus* is
+identical and sign-independent: in both cases `M_r = GM` exactly when all the
+`zᵢ` coincide. -/
+theorem power_mean_eq_geom_mean_iff
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r : ℝ} (hrne : r ≠ 0) :
+    weightedPowerMean s w z r hrne = weightedGeomMean s w z
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  have hSum := weightedSum_rpow_pos s w z hwnn hw' hz r
+  have hGM := weightedGeomMean_pos s w z hz
+  have hMr_pos : 0 < weightedPowerMean s w z r hrne := by
+    simp only [weightedPowerMean]; exact Real.rpow_pos_of_pos hSum _
+  -- M_r raised back to the r-th power recovers the underlying weighted sum.
+  have hMr_eq : weightedPowerMean s w z r hrne ^ r = ∑ i ∈ s, w i * z i ^ r := by
+    simp only [weightedPowerMean]
+    rw [← Real.rpow_mul hSum.le, one_div_mul_cancel hrne, Real.rpow_one]
+  rw [← geomMean_rpow_eq_weightedSum_rpow_iff s w z hw hw' hz hrne,
+      ← Real.rpow_left_inj hMr_pos.le hGM.le hrne, hMr_eq]
+  exact eq_comm
+
+-- ============================================================
+-- §4. CROSSING-ZERO EQUALITY AND STRICTNESS
+-- ============================================================
+
+/-- **Sharp converse to crossing-zero monotonicity.** For `r < 0 < t`,
+
+    M_r = M_t   ↔   all the data are equal.
+
+The forward direction squeezes `M_r ≤ GM ≤ M_t` against the assumed equality to
+force `M_r = GM`, then applies `power_mean_eq_geom_mean_iff`. -/
+theorem power_mean_crossing_zero_eq_iff
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r t : ℝ} (hr : r < 0) (ht : 0 < t) (hrne : r ≠ 0) (htne : t ≠ 0) :
+    weightedPowerMean s w z r hrne = weightedPowerMean s w z t htne
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k := by
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  constructor
+  · intro h
+    have h1 := PowerMeanCrossZero.power_mean_le_geom_mean_neg s w z hwnn hw' hz hr hrne
+    have h2 := PowerMeanCrossZero.geom_mean_le_power_mean_pos s w z hwnn hw' hz ht htne
+    have hge : weightedGeomMean s w z ≤ weightedPowerMean s w z r hrne := by
+      rw [h]; exact h2
+    exact (power_mean_eq_geom_mean_iff s w z hw hw' hz hrne).mp (le_antisymm h1 hge)
+  · intro h
+    rw [(power_mean_eq_geom_mean_iff s w z hw hw' hz hrne).mpr h,
+        (power_mean_eq_geom_mean_iff s w z hw hw' hz htne).mpr h]
+
+/-- **Strict lower bound for negative order.** If two of the values differ then
+`M_r < GM` for `r < 0`. -/
+theorem power_mean_lt_geom_mean_neg_of_ne
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r : ℝ} (hr : r < 0) (hrne : r ≠ 0)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    weightedPowerMean s w z r hrne < weightedGeomMean s w z := by
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  refine lt_of_le_of_ne
+    (PowerMeanCrossZero.power_mean_le_geom_mean_neg s w z hwnn hw' hz hr hrne) ?_
+  intro hEq
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  exact hjk ((power_mean_eq_geom_mean_iff s w z hw hw' hz hrne).mp hEq j hj k hk)
+
+/-- **Strict upper bound for positive order.** If two of the values differ then
+`GM < M_t` for `t > 0`. -/
+theorem geom_mean_lt_power_mean_pos_of_ne
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {t : ℝ} (ht : 0 < t) (htne : t ≠ 0)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    weightedGeomMean s w z < weightedPowerMean s w z t htne := by
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  refine lt_of_le_of_ne
+    (PowerMeanCrossZero.geom_mean_le_power_mean_pos s w z hwnn hw' hz ht htne) ?_
+  intro hEq
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  exact hjk ((power_mean_eq_geom_mean_iff s w z hw hw' hz htne).mp hEq.symm j hj k hk)
+
+/-- **Strict crossing-zero inequality.** For `r < 0 < t` and non-constant data,
+`M_r < M_t`. -/
+theorem power_mean_crossing_zero_lt_of_ne
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    {r t : ℝ} (hr : r < 0) (ht : 0 < t) (hrne : r ≠ 0) (htne : t ≠ 0)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    weightedPowerMean s w z r hrne < weightedPowerMean s w z t htne := by
+  have hwnn : ∀ i ∈ s, 0 ≤ w i := fun i hi => (hw i hi).le
+  refine lt_of_le_of_ne
+    (PowerMeanCrossZero.power_mean_monotone_crossing_zero s w z hwnn hw' hz hr ht hrne htne) ?_
+  intro hEq
+  obtain ⟨j, hj, k, hk, hjk⟩ := hne
+  exact hjk ((power_mean_crossing_zero_eq_iff s w z hw hw' hz hr ht hrne htne).mp hEq j hj k hk)
+
+-- ============================================================
+-- §5. THE CLASSICAL HM ≤ GM ≤ AM CORNER (SHARP)
+-- ============================================================
+
+/-- **HM = GM iff the data is constant.** The `r = -1` specialization of
+`power_mean_eq_geom_mean_iff`. -/
+theorem hm_eq_gm_iff
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i) :
+    weightedPowerMean s w z (-1) (by norm_num) = weightedGeomMean s w z
+      ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k :=
+  power_mean_eq_geom_mean_iff s w z hw hw' hz (by norm_num)
+
+/-- **Strict HM < GM < AM for non-constant data.** Combines the two strict
+crossing-zero bounds at `r = -1` and `t = 1`. -/
+theorem hm_lt_gm_lt_am_of_ne
+    (hw : ∀ i ∈ s, 0 < w i) (hw' : ∑ i ∈ s, w i = 1) (hz : ∀ i ∈ s, 0 < z i)
+    (hne : ∃ j ∈ s, ∃ k ∈ s, z j ≠ z k) :
+    weightedPowerMean s w z (-1) (by norm_num) < weightedGeomMean s w z ∧
+    weightedGeomMean s w z < weightedPowerMean s w z 1 (by norm_num) :=
+  ⟨power_mean_lt_geom_mean_neg_of_ne s w z hw hw' hz (by norm_num) (by norm_num) hne,
+   geom_mean_lt_power_mean_pos_of_ne s w z hw hw' hz (by norm_num) (by norm_num) hne⟩
+
+end PowerMeanCrossZeroEq

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,236 @@
+{
+  "id": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+  "title": "Equality Case of the Crossing-Zero Power-Mean Chain",
+  "slug": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+  "description": "Sharp converse to the crossing-zero power-mean inequalities M_r ≤ GM ≤ M_s (r < 0 < s). For EVERY exponent r ≠ 0 — positive or negative — M_r = GM holds iff all the data are equal; the equality locus is sign-independent even though the inequality flips direction across zero. Consequently M_r = M_t (r < 0 < t) iff the data is constant, and all the crossing-zero bounds (including the classical HM < GM < AM) are strict off the diagonal. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Generalized_mean",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "power-means",
+      "mean-inequalities",
+      "amgm",
+      "equality-case"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 243,
+    "assumptions": "",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "power_mean_eq_geom_mean_iff: M_r = GM ↔ data constant, for EVERY r ≠ 0 — the equality locus is identical for positive and negative orders even though the inequality reverses across zero (sign-independent unification)",
+      "geomMean_rpow_eq_weightedSum_rpow_iff: GM^r = ∑ wᵢ zᵢ^r ↔ data constant (equality case of the crossing-zero core inequality, via weighted AM-GM equality applied to the powered data zᵢ^r)",
+      "power_mean_crossing_zero_eq_iff: M_r = M_t ↔ data constant, for r < 0 < t — the sharp converse to power_mean_monotone_crossing_zero",
+      "power_mean_lt_geom_mean_neg_of_ne / geom_mean_lt_power_mean_pos_of_ne / power_mean_crossing_zero_lt_of_ne: the strict forms of all three crossing-zero bounds for non-constant data",
+      "hm_lt_gm_lt_am_of_ne and hm_eq_gm_iff: the sharp classical HM < GM < AM corner as the r = -1, t = 1 specialization"
+    ],
+    "prerequisites": [
+      "Crossing-zero inequalities (PowerMeanCrossZeroOQ.lean): M_r ≤ GM ≤ M_s for r < 0 < s",
+      "Equality case of weighted AM-GM (JensenInequalityOQ01.lean, weighted_amgm_eq_iff): ∏ zᵢ^wᵢ = ∑ wᵢ zᵢ ↔ all zᵢ equal",
+      "Weighted power mean / geometric mean definitions (AmgmInequalityOQ03.lean)",
+      "Injectivity of x ↦ x^r on the positives for r ≠ 0 (Real.rpow_left_inj)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.geom_mean_eq_arith_mean_weighted_iff'",
+        "description": "Equality case of weighted AM-GM (used inside weighted_amgm_eq_iff)",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "Real.rpow_left_inj",
+        "description": "x^r = y^r ↔ x = y for 0 ≤ x, y and r ≠ 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "x^(p*q) = (x^p)^q for 0 ≤ x — folds M_r back to the weighted sum",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ],
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The power mean inequality M_r ≤ M_s for r ≤ s (Schur 1923; Hardy–Littlewood–Pólya, *Inequalities* 1934, Thm 16) is classically accompanied by its equality statement: the two means coincide exactly when the data is constant. For same-sign exponents this falls out of the *strict* convexity of x ↦ x^{s/r}. Across zero, however, the convexity argument breaks (the function changes convexity at 0), and the limiting mean M_0 = GM sits exactly at the crossover. The companion entry amgm-inequality-oq-03-oq-02-oq-01 proved the crossing-zero *inequalities* M_r ≤ GM ≤ M_s by a direct AM-GM reduction. This entry supplies the matching equality theory by reading off the equality case of that same AM-GM step.",
+    "problemStatement": "**Open Question (OQ-03-OQ-02-OQ-01-OQ-02):** Characterize equality in the crossing-zero power-mean chain. When does M_r = GM (r ≠ 0), and when does M_r = M_t for r < 0 < t? Upgrade the non-strict bounds M_r ≤ GM ≤ M_s to strict inequalities for non-constant data.",
+    "proofStrategy": "**Core equality** (§2): Apply the equality case of weighted AM-GM, weighted_amgm_eq_iff, to the powered data uᵢ = zᵢ^r. Its geometric side ∏ (zᵢ^r)^wᵢ equals GM^r (identity (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ), and its arithmetic side is ∑ wᵢ zᵢ^r. The resulting right-hand equalities zⱼ^r = zₖ^r collapse to zⱼ = zₖ by injectivity of x ↦ x^r on the positives (r ≠ 0). This gives GM^r = ∑ wᵢ zᵢ^r ↔ data constant.\n\n**Sign-independent equality** (§3): M_r raised to the r-th power recovers ∑ wᵢ zᵢ^r (since (1/r)·r = 1, valid for any r ≠ 0). Hence M_r = GM ↔ M_r^r = GM^r ↔ ∑ wᵢ zᵢ^r = GM^r ↔ data constant — with no dependence on the sign of r.\n\n**Crossing-zero & strictness** (§4–§5): For r < 0 < t, M_r = M_t squeezed against M_r ≤ GM ≤ M_t forces M_r = GM, hence constant; the converse is immediate from §3. The strict bounds follow from lt_of_le_of_ne together with the equality characterization.",
+    "keyInsights": [
+      "The whole equality theory is one application of weighted AM-GM's equality case to the powered data zᵢ^r — the same AM-GM step whose *inequality* drives the crossing-zero bounds. Sharpening an inequality to its equality locus costs only the equality version of the lemma already in hand.",
+      "The equality locus M_r = GM is SIGN-INDEPENDENT: it is 'all data equal' for every r ≠ 0, even though M_r ≤ GM for r < 0 reverses to GM ≤ M_r for r > 0. The asymmetry of the inequality and the symmetry of its equality case live side by side.",
+      "Raising M_r to the r-th power is a bijective move on the positive reals for any r ≠ 0, so the equivalence M_r = GM ↔ M_r^r = GM^r needs no case split on sign — the analytic content is entirely in the AM-GM equality.",
+      "The crossing-zero equality M_r = M_t (r < 0 < t) is obtained by a squeeze: equality of the endpoints of M_r ≤ GM ≤ M_t collapses the chain, pinning M_r = GM = M_t and forcing constancy.",
+      "The classical strict HM < GM < AM for non-constant data is recovered verbatim as the r = -1, t = 1 instance, exhibiting all three strict inequalities as one specialization."
+    ],
+    "prerequisites": [
+      "PowerMeanCrossZeroOQ.lean: crossing-zero inequalities M_r ≤ GM ≤ M_s",
+      "JensenInequalityOQ01.lean: weighted_amgm_eq_iff (equality case of AM-GM)",
+      "AmgmInequalityOQ03.lean: weightedPowerMean and weightedGeomMean definitions"
+    ],
+    "furtherWork": [
+      "Combine with the equality case for same-sign exponents (PowerMeanEqualityOQ, 0 < r < t) into a single all-exponent statement M_r = M_t ↔ constant for all r < t (r, t ≠ 0)",
+      "Equality in the endpoint limits: when do min, M_r, GM, M_s, max coincide?",
+      "Quantitative stability: a lower bound on M_t − M_r in terms of the spread (variance) of the data, sharpening the strict inequality"
+    ]
+  },
+  "sections": [
+    {
+      "id": "helpers",
+      "title": "§1: Positivity and Algebraic Helpers",
+      "startLine": 52,
+      "endLine": 94,
+      "summary": "weightedSum_rpow_pos (∑ wᵢ zᵢ^r > 0), weightedGeomMean_pos (GM > 0), finset_prod_rpow ((∏ fᵢ)^r = ∏ fᵢ^r), and geomMean_rpow_eq ((∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ).",
+      "mathContext": "geomMean_rpow_eq is the structural bridge: it rewrites GM^r into the product form ∏ (zᵢ^r)^wᵢ that the AM-GM equality lemma consumes."
+    },
+    {
+      "id": "core-eq",
+      "title": "§2: Core Equality GM^r = ∑ wᵢ zᵢ^r ↔ constant",
+      "startLine": 96,
+      "endLine": 121,
+      "summary": "geomMean_rpow_eq_weightedSum_rpow_iff: for r ≠ 0, GM^r = ∑ wᵢ zᵢ^r ↔ all data equal. The equality case of weighted AM-GM on the powered data zᵢ^r.",
+      "mathContext": "weighted_amgm_eq_iff on uᵢ = zᵢ^r gives ∏ (zᵢ^r)^wᵢ = ∑ wᵢ zᵢ^r ↔ ∀ j k, zⱼ^r = zₖ^r; Real.rpow_left_inj collapses zⱼ^r = zₖ^r to zⱼ = zₖ."
+    },
+    {
+      "id": "sign-indep",
+      "title": "§3: Sign-Independent Equality M_r = GM ↔ constant",
+      "startLine": 123,
+      "endLine": 150,
+      "summary": "power_mean_eq_geom_mean_iff: for every r ≠ 0, M_r = GM ↔ all data equal — the same locus for positive and negative orders.",
+      "mathContext": "M_r^r = ∑ wᵢ zᵢ^r since (1/r)·r = 1; with Real.rpow_left_inj, M_r = GM ↔ M_r^r = GM^r ↔ GM^r = ∑ wᵢ zᵢ^r ↔ constant."
+    },
+    {
+      "id": "crossing-eq",
+      "title": "§4: Crossing-Zero Equality and Strictness",
+      "startLine": 152,
+      "endLine": 224,
+      "summary": "power_mean_crossing_zero_eq_iff (M_r = M_t ↔ constant for r < 0 < t) and the three strict bounds power_mean_lt_geom_mean_neg_of_ne, geom_mean_lt_power_mean_pos_of_ne, power_mean_crossing_zero_lt_of_ne.",
+      "mathContext": "Forward: squeeze M_r ≤ GM ≤ M_t with M_r = M_t to force M_r = GM, then §3. Strictness: lt_of_le_of_ne against the equality characterization."
+    },
+    {
+      "id": "hm-gm-am",
+      "title": "§5: The Sharp HM ≤ GM ≤ AM Corner",
+      "startLine": 226,
+      "endLine": 243,
+      "summary": "hm_eq_gm_iff (M_{-1} = GM ↔ constant) and hm_lt_gm_lt_am_of_ne (strict HM < GM < AM for non-constant data).",
+      "mathContext": "The r = -1, t = 1 specialization of the sign-independent equality and the strict crossing-zero bounds."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02-oq-01",
+      "relationship": "parent",
+      "description": "Parent: the crossing-zero inequalities M_r ≤ GM ≤ M_s for r < 0 < s. This entry supplies their equality cases and strict forms."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling: the unified single-theorem extended monotonicity. This entry instead characterizes when that monotonicity is an equality."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Related: the equality case M_r = M_t ↔ constant for same-sign 0 < r < t (via strict convexity of x ↦ x^{t/r}). Together they cover both the same-sign and crossing-zero equality regimes."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01",
+      "relationship": "foundational",
+      "description": "Foundational: weighted_amgm_eq_iff (the equality case of weighted AM-GM) is the single engine driving this entry."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "ancestor",
+      "description": "Ancestor: the base AM-GM inequality, whose strict/equality case the HM < GM < AM corner here directly generalizes."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization completes the crossing-zero power-mean story with its equality theory: for every r ≠ 0, M_r = GM iff the data is constant (sign-independent), so M_r = M_t iff constant for r < 0 < t, and every crossing-zero bound — including the classical HM < GM < AM — is strict off the diagonal. 0 sorries, 0 axioms.",
+    "implications": "The inequality and its equality case now come as a matched pair across the whole power-mean range. The proof reuses the *equality* version of the same weighted AM-GM step that produced the inequality, showing that sharpening a mean inequality to its equality locus is essentially free once the convexity/AM-GM lemma is stated in iff form.",
+    "openQuestions": [
+      "Can the same-sign equality case (0 < r < t) and this crossing-zero case be merged into one statement M_r = M_t ↔ constant valid for all r < t with r, t ≠ 0?",
+      "Is there a quantitative stability bound: M_t − M_r ≥ c · (variance of the data) for r < 0 < t?",
+      "Does the equality characterization extend to the endpoint limits min = M_{-∞} and max = M_{+∞}?"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "power_mean_eq_geom_mean_iff",
+      "type": "core",
+      "description": "For every r ≠ 0 (positive or negative), the power mean of order r equals the geometric mean iff all the data are equal. The equality locus is sign-independent, in contrast with the inequality, which reverses direction across zero.",
+      "leanType": "weightedPowerMean s w z r hrne = weightedGeomMean s w z ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k"
+    },
+    {
+      "name": "geomMean_rpow_eq_weightedSum_rpow_iff",
+      "type": "core",
+      "description": "Equality case of the crossing-zero core inequality: GM^r = ∑ wᵢ zᵢ^r iff the data is constant, for any r ≠ 0. Obtained from the equality case of weighted AM-GM applied to the powered data zᵢ^r.",
+      "leanType": "(weightedGeomMean s w z) ^ r = ∑ i ∈ s, w i * z i ^ r ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k"
+    },
+    {
+      "name": "power_mean_crossing_zero_eq_iff",
+      "type": "core",
+      "description": "Sharp converse to crossing-zero monotonicity: for r < 0 < t, M_r = M_t iff all the data are equal. Proved by squeezing M_r ≤ GM ≤ M_t against the assumed equality.",
+      "leanType": "weightedPowerMean s w z r hrne = weightedPowerMean s w z t htne ↔ ∀ j ∈ s, ∀ k ∈ s, z j = z k"
+    },
+    {
+      "name": "power_mean_crossing_zero_lt_of_ne",
+      "type": "core",
+      "description": "Strict crossing-zero inequality: for r < 0 < t and non-constant data, M_r < M_t. Upgrades the parent's non-strict bound.",
+      "leanType": "weightedPowerMean s w z r hrne < weightedPowerMean s w z t htne"
+    },
+    {
+      "name": "hm_lt_gm_lt_am_of_ne",
+      "type": "supporting",
+      "description": "Sharp classical chain: for non-constant data, HM < GM < AM, as the r = -1, t = 1 specialization of the strict crossing-zero bounds.",
+      "leanType": "weightedPowerMean s w z (-1) _ < weightedGeomMean s w z ∧ weightedGeomMean s w z < weightedPowerMean s w z 1 _"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "Theorem 16 and §2.9–2.11 state the power mean inequality M_r ≤ M_s together with its equality case (equality iff the data is constant). This entry formalizes that equality case for the crossing-zero regime."
+    },
+    {
+      "authors": "Bullen, P. S.",
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications, Vol. 560, Springer (Kluwer)",
+      "doi": "10.1007/978-94-017-0399-4",
+      "note": "Chapter III §2 treats weighted power means and records that M_r = M_s exactly when the data is constant, the statement made precise here for r < 0 < s."
+    },
+    {
+      "authors": "Mathlib contributors",
+      "title": "Real.geom_mean_eq_arith_mean_weighted_iff' (Mathlib.Analysis.MeanInequalities)",
+      "year": "2024",
+      "venue": "Mathlib4 (mathlib_version 4.26.0)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/MeanInequalities.html",
+      "note": "Equality case of weighted AM-GM in Lean 4. Re-exported as weighted_amgm_eq_iff and applied here to the powered data zᵢ^r to obtain the equality characterization."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.AmgmInequalityOQ03",
+      "Proofs.JensenInequalityOQ01",
+      "Proofs.PowerMeanCrossZeroOQ",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "PowerMeanCrossZeroEq",
+    "lineCount": 243,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean"
+  }
+}

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-02.json
@@ -1,0 +1,69 @@
+{
+  "slug": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+  "title": "Equality case of the crossing-zero power-mean chain: M_r = GM iff data constant (all r ≠ 0)",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 7,
+  "significance": 6,
+  "started": "2026-06-22T00:00:00-07:00",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For strictly positive weights summing to 1 and strictly positive data: (1) for every r ≠ 0, weightedPowerMean r = weightedGeomMean ↔ all data equal; (2) for r < 0 < t, weightedPowerMean r = weightedPowerMean t ↔ all data equal; (3) the crossing-zero bounds are strict for non-constant data.",
+    "plain": "Characterize equality in the crossing-zero power-mean inequalities M_r ≤ GM ≤ M_s (r < 0 < s). The geometric mean equals the power mean of order r exactly when the data is constant — and this holds for every nonzero r, positive or negative, even though the inequality reverses direction across zero. Hence M_r = M_t iff constant for r < 0 < t, and all bounds (including HM < GM < AM) are strict off the diagonal.",
+    "whyMatters": [
+      "Completes the crossing-zero power-mean story by pairing the inequality (parent oq-03-oq-02-oq-01) with its sharp equality case.",
+      "Exhibits a sign-independent equality locus sitting underneath a sign-dependent inequality.",
+      "Recovers the classical strict HM < GM < AM as a single specialization."
+    ]
+  },
+  "tags": [
+    "analysis",
+    "inequalities",
+    "mean-inequalities",
+    "power-means",
+    "amgm",
+    "equality-case",
+    "research"
+  ],
+  "tractability": 7,
+  "knowledge": {
+    "insights": [
+      "The equality case of the crossing-zero chain is one application of weighted AM-GM's equality case (weighted_amgm_eq_iff) to the powered data uᵢ = zᵢ^r — the same AM-GM step whose inequality drives the parent's bounds.",
+      "The equality locus M_r = GM is sign-independent: 'all data equal' for every r ≠ 0, even though M_r ≤ GM for r < 0 reverses to GM ≤ M_r for r > 0.",
+      "Raising M_r to the r-th power is bijective on the positive reals for any r ≠ 0, so M_r = GM ↔ M_r^r = GM^r needs no case split on the sign of r.",
+      "The crossing-zero equality M_r = M_t (r < 0 < t) follows by squeezing the endpoints of M_r ≤ GM ≤ M_t.",
+      "The strict classical HM < GM < AM for non-constant data is the r = -1, t = 1 instance."
+    ],
+    "builtItems": [
+      "geomMean_rpow_eq_weightedSum_rpow_iff (Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean:108): GM^r = ∑ wᵢ zᵢ^r ↔ data constant",
+      "power_mean_eq_geom_mean_iff (Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean:134): M_r = GM ↔ data constant, all r ≠ 0",
+      "power_mean_crossing_zero_eq_iff (Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean:162): M_r = M_t ↔ data constant for r < 0 < t",
+      "power_mean_lt_geom_mean_neg_of_ne / geom_mean_lt_power_mean_pos_of_ne / power_mean_crossing_zero_lt_of_ne (Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean:181,195,209): strict bounds",
+      "hm_eq_gm_iff and hm_lt_gm_lt_am_of_ne (Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean:227,235): sharp HM < GM < AM corner"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no equality/strictness characterization for the weighted power-mean inequality across zero; only the inequalities (and the same-sign convexity argument) are available."
+    ],
+    "nextSteps": [
+      "Merge the same-sign equality case (PowerMeanEqualityOQ, 0 < r < t) with this crossing-zero case into one all-exponent statement M_r = M_t ↔ constant for all r < t (r, t ≠ 0).",
+      "Quantitative stability: lower-bound M_t − M_r by the variance/spread of the data.",
+      "Equality in the endpoint limits min = M_{-∞}, max = M_{+∞}."
+    ],
+    "progressSummary": "COMPLETE: 0 sorries, 0 axioms, 12 declarations verified. Equality case + strictness of the crossing-zero power-mean chain.",
+    "markdown": ""
+  },
+  "knownResults": [],
+  "leanFiles": [
+    "Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean"
+  ],
+  "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean",
+  "references": [],
+  "relatedProofs": [
+    "amgm-inequality-oq-03-oq-02-oq-01",
+    "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "jensen-inequality-oq-01"
+  ],
+  "currentState": "Completed and verified.",
+  "tier": "B"
+}


### PR DESCRIPTION
## Summary

Sharp **converse** to the crossing-zero power-mean inequalities `M_r ≤ GM ≤ M_s` (`r < 0 < s`) proved in the parent `amgm-inequality-oq-03-oq-02-oq-01` (`PowerMeanCrossZeroOQ`). Those bounds are all non-strict; this entry characterizes exactly when equality holds and upgrades them to strict inequalities off the diagonal.

## Headline results (`Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean`)

- **`power_mean_eq_geom_mean_iff`** — for **every** `r ≠ 0` (positive *or* negative), `M_r = GM ↔ all data equal`. The equality locus is **sign-independent**, even though the inequality reverses direction across zero (`GM ≤ M_r` for `r > 0`, `M_r ≤ GM` for `r < 0`). This unification is the main observation.
- **`power_mean_crossing_zero_eq_iff`** — for `r < 0 < t`, `M_r = M_t ↔ all data equal`; the sharp converse to `power_mean_monotone_crossing_zero`.
- **`geomMean_rpow_eq_weightedSum_rpow_iff`** — the core equality `GM^r = ∑ wᵢ zᵢ^r ↔ constant`.
- **strict forms** `power_mean_lt_geom_mean_neg_of_ne`, `geom_mean_lt_power_mean_pos_of_ne`, `power_mean_crossing_zero_lt_of_ne`, and the sharp **`hm_lt_gm_lt_am_of_ne`** / **`hm_eq_gm_iff`** corner.

## Engine

One application of the equality case of weighted AM-GM (`weighted_amgm_eq_iff`, root `JensenInequalityOQ01`) to the *powered* data `uᵢ = zᵢ^r`:
```
GM^r = ∑ wᵢ zᵢ^r  ↔  ∀ j k, zⱼ^r = zₖ^r  ↔  ∀ j k, zⱼ = zₖ
```
the last step by injectivity of `x ↦ x^r` on the positives (`r ≠ 0`). Raising to the bijective power `1/r` converts this to `M_r = GM` *independently of the sign of `r`*. No limit arguments.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` shows only `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`/`native_decide`).
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ03OQ02OQ01OQ02` (7746 jobs), first try.
- 243 lines, 12 declarations (8 public theorems + 4 private helpers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)