### PR TITLE
research(jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01): Lyapunov's inequality — log-convexity of the weighted moment function [0-axiom verified]

### DIFF
--- a/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,170 @@
+import Proofs.JensenInequalityOQ01OQ01OQ01OQ01
+import Mathlib.Analysis.Convex.Function
+
+/-
+# Lyapunov's inequality: log-convexity of the weighted moment function
+
+Let `w x : ι → ℝ` be strictly positive families on a finite index type and define the
+**weighted moment function**
+`A(t) = ∑ i, w i * (x i) ^ t`.
+
+This file proves that `t ↦ A(t)` is **log-convex**, i.e. `t ↦ log A(t)` is convex on `ℝ`.
+Equivalently, for all real exponents `p, r` and convex weights `a, b > 0` with `a + b = 1`,
+`A(a·p + b·r) ≤ A(p)^a · A(r)^b`  (the **Lyapunov interpolation inequality**), and in the
+symmetric three-exponent form, for `p < q < r`,
+`A(q)^(r-p) ≤ A(p)^(r-q) · A(r)^(q-p)`.
+
+This is a genuine structural refinement of the monotonicity of power means
+(`PowerMeanMonotoneOQ`): monotonicity says `M_r` is increasing in `r`; log-convexity is a
+second-order statement pinning the *shape* of the moment curve, and it implies the power-mean
+inequality by interpolation.
+
+## Engine
+
+The whole result is a one-application consequence of the **two-function discrete Hölder
+inequality** `JensenHolder.inner_le_holder_two` (from the parent file
+`JensenInequalityOQ01OQ01OQ01OQ01`): with conjugate exponents `P = a⁻¹`, `Q = b⁻¹` and
+`u i = (w i · x i^p)^a`, `v i = (w i · x i^r)^b`, Hölder reads exactly
+`A(a·p + b·r) = ∑ u i · v i ≤ (∑ u i^P)^{1/P} · (∑ v i^Q)^{1/Q} = A(p)^a · A(r)^b`.
+
+The pointwise interpolation identity `(w·x^p)^a · (w·x^r)^b = w^{a+b} · x^{a·p+b·r}` is the
+only `rpow` bookkeeping required.
+
+## Main results
+
+* `moment_interp_le` — the Lyapunov interpolation inequality `A(a·p+b·r) ≤ A(p)^a · A(r)^b`.
+* `logConvexOn_moment` — `t ↦ log A(t)` is convex on `ℝ` (log-convexity of moments).
+* `moment_lyapunov` — the symmetric three-exponent form `A(q)^(r-p) ≤ A(p)^(r-q) · A(r)^(q-p)`.
+
+## Mathlib gap
+
+Mathlib has log-convexity statements for specific objects (Gamma function, `Real.Gamma`), but
+no general "log-convexity of the discrete weighted moment / power-sum function", which is the
+classical Lyapunov inequality underlying the interpolation theory of `Lᵖ` spaces.
+-/
+
+open Finset
+
+namespace JensenLyapunov
+
+variable {ι : Type*} [Fintype ι]
+
+/-- The weighted moment function `A(t) = ∑ i, w i · (x i) ^ t`. -/
+noncomputable def moment (w x : ι → ℝ) (t : ℝ) : ℝ := ∑ i, w i * (x i) ^ t
+
+/-- The pointwise interpolation identity behind Lyapunov's inequality:
+`(w·x^p)^a · (w·x^r)^b = w^{a+b} · x^{a·p+b·r}` for `w, x > 0`. -/
+private lemma rpow_interp {w x : ℝ} (hw : 0 < w) (hx : 0 < x) (p r a b : ℝ) :
+    (w * x ^ p) ^ a * (w * x ^ r) ^ b = w ^ (a + b) * x ^ (a * p + b * r) := by
+  have e1 : (w * x ^ p) ^ a = w ^ a * x ^ (p * a) := by
+    rw [Real.mul_rpow hw.le (Real.rpow_nonneg hx.le _), ← Real.rpow_mul hx.le]
+  have e2 : (w * x ^ r) ^ b = w ^ b * x ^ (r * b) := by
+    rw [Real.mul_rpow hw.le (Real.rpow_nonneg hx.le _), ← Real.rpow_mul hx.le]
+  rw [e1, e2, mul_mul_mul_comm, ← Real.rpow_add hw, ← Real.rpow_add hx,
+    show p * a + r * b = a * p + b * r from by ring]
+
+/-- The moment function is nonnegative for nonnegative data. -/
+lemma moment_nonneg (w x : ι → ℝ) (hw : ∀ i, 0 ≤ w i) (hx : ∀ i, 0 ≤ x i) (t : ℝ) :
+    0 ≤ moment w x t :=
+  Finset.sum_nonneg fun i _ => mul_nonneg (hw i) (Real.rpow_nonneg (hx i) t)
+
+/-- The moment function is strictly positive for strictly positive data (nonempty index). -/
+lemma moment_pos (w x : ι → ℝ) [Nonempty ι] (hw : ∀ i, 0 < w i) (hx : ∀ i, 0 < x i) (t : ℝ) :
+    0 < moment w x t :=
+  Finset.sum_pos (fun i _ => mul_pos (hw i) (Real.rpow_pos_of_pos (hx i) t)) Finset.univ_nonempty
+
+/-- **Lyapunov interpolation inequality.** For strictly positive families `w x : ι → ℝ`, real
+exponents `p, r`, and convex weights `a, b > 0` with `a + b = 1`,
+`A(a·p + b·r) ≤ A(p)^a · A(r)^b`, where `A(t) = ∑ i, w i · (x i)^t`. -/
+theorem moment_interp_le (w x : ι → ℝ) (hw : ∀ i, 0 < w i) (hx : ∀ i, 0 < x i)
+    (p r a b : ℝ) (ha : 0 < a) (hb : 0 < b) (hab : a + b = 1) :
+    moment w x (a * p + b * r) ≤ (moment w x p) ^ a * (moment w x r) ^ b := by
+  calc moment w x (a * p + b * r)
+      = ∑ i, (w i * x i ^ p) ^ a * (w i * x i ^ r) ^ b := by
+          simp only [moment]
+          refine Finset.sum_congr rfl fun i _ => ?_
+          rw [rpow_interp (hw i) (hx i) p r a b, hab, Real.rpow_one]
+    _ ≤ (∑ i, ((w i * x i ^ p) ^ a) ^ (a⁻¹)) ^ (a⁻¹)⁻¹
+          * (∑ i, ((w i * x i ^ r) ^ b) ^ (b⁻¹)) ^ (b⁻¹)⁻¹ :=
+          JensenHolder.inner_le_holder_two (univ : Finset ι)
+            (fun i => (w i * x i ^ p) ^ a) (fun i => (w i * x i ^ r) ^ b)
+            (a⁻¹) (b⁻¹)
+            (fun i _ => Real.rpow_nonneg (mul_nonneg (hw i).le (Real.rpow_nonneg (hx i).le _)) _)
+            (fun i _ => Real.rpow_nonneg (mul_nonneg (hw i).le (Real.rpow_nonneg (hx i).le _)) _)
+            (inv_pos.mpr ha) (inv_pos.mpr hb)
+            (by rw [inv_inv, inv_inv]; exact hab)
+    _ = (moment w x p) ^ a * (moment w x r) ^ b := by
+          rw [inv_inv, inv_inv]
+          congr 1
+          · congr 1
+            simp only [moment]
+            refine Finset.sum_congr rfl fun i _ => ?_
+            rw [← Real.rpow_mul (mul_nonneg (hw i).le (Real.rpow_nonneg (hx i).le _)),
+              mul_inv_cancel₀ ha.ne', Real.rpow_one]
+          · congr 1
+            simp only [moment]
+            refine Finset.sum_congr rfl fun i _ => ?_
+            rw [← Real.rpow_mul (mul_nonneg (hw i).le (Real.rpow_nonneg (hx i).le _)),
+              mul_inv_cancel₀ hb.ne', Real.rpow_one]
+
+/-- **Log-convexity of the weighted moment function.** For strictly positive families
+`w x : ι → ℝ` on a nonempty finite index type, `t ↦ log (∑ i, w i · (x i)^t)` is convex on `ℝ`.
+This is the conceptual content of Lyapunov's inequality. -/
+theorem logConvexOn_moment (w x : ι → ℝ) [Nonempty ι]
+    (hw : ∀ i, 0 < w i) (hx : ∀ i, 0 < x i) :
+    ConvexOn ℝ Set.univ (fun t => Real.log (moment w x t)) := by
+  refine ⟨convex_univ, ?_⟩
+  intro p _ r _ a b ha hb hab
+  simp only [smul_eq_mul]
+  obtain rfl | ha0 := ha.eq_or_lt
+  · have hb1 : b = 1 := by linarith
+    subst hb1; simp
+  obtain rfl | hb0 := hb.eq_or_lt
+  · have ha1 : a = 1 := by linarith
+    subst ha1; simp
+  · have hint := moment_interp_le w x hw hx p r a b ha0 hb0 hab
+    calc Real.log (moment w x (a * p + b * r))
+        ≤ Real.log ((moment w x p) ^ a * (moment w x r) ^ b) :=
+          Real.log_le_log (moment_pos w x hw hx _) hint
+      _ = a * Real.log (moment w x p) + b * Real.log (moment w x r) := by
+          rw [Real.log_mul (Real.rpow_pos_of_pos (moment_pos w x hw hx p) a).ne'
+                (Real.rpow_pos_of_pos (moment_pos w x hw hx r) b).ne',
+            Real.log_rpow (moment_pos w x hw hx p), Real.log_rpow (moment_pos w x hw hx r)]
+
+/-- **Lyapunov's inequality (symmetric three-exponent form).** For strictly positive families
+`w x : ι → ℝ` and exponents `p < q < r`,
+`A(q)^(r-p) ≤ A(p)^(r-q) · A(r)^(q-p)`, where `A(t) = ∑ i, w i · (x i)^t`. -/
+theorem moment_lyapunov (w x : ι → ℝ) (hw : ∀ i, 0 < w i) (hx : ∀ i, 0 < x i)
+    (p q r : ℝ) (hpq : p < q) (hqr : q < r) :
+    (moment w x q) ^ (r - p) ≤ (moment w x p) ^ (r - q) * (moment w x r) ^ (q - p) := by
+  have hrp : 0 < r - p := by linarith
+  have hrq : 0 < r - q := by linarith
+  have hqp : 0 < q - p := by linarith
+  have hrp' : r - p ≠ 0 := hrp.ne'
+  set a := (r - q) / (r - p) with ha_def
+  set b := (q - p) / (r - p) with hb_def
+  have ha : 0 < a := div_pos hrq hrp
+  have hb : 0 < b := div_pos hqp hrp
+  have hab : a + b = 1 := by
+    rw [ha_def, hb_def, ← add_div, div_eq_one_iff_eq hrp']; ring
+  have hq_eq : a * p + b * r = q := by rw [ha_def, hb_def]; field_simp; ring
+  have hexp1 : a * (r - p) = r - q := by rw [ha_def, div_mul_cancel₀ _ hrp']
+  have hexp2 : b * (r - p) = q - p := by rw [hb_def, div_mul_cancel₀ _ hrp']
+  have hint := moment_interp_le w x hw hx p r a b ha hb hab
+  rw [hq_eq] at hint
+  calc (moment w x q) ^ (r - p)
+      ≤ ((moment w x p) ^ a * (moment w x r) ^ b) ^ (r - p) :=
+        Real.rpow_le_rpow (moment_nonneg w x (fun i => (hw i).le) (fun i => (hx i).le) q) hint hrp.le
+    _ = (moment w x p) ^ (r - q) * (moment w x r) ^ (q - p) := by
+        rw [Real.mul_rpow
+              (Real.rpow_nonneg (moment_nonneg w x (fun i => (hw i).le) (fun i => (hx i).le) p) a)
+              (Real.rpow_nonneg (moment_nonneg w x (fun i => (hw i).le) (fun i => (hx i).le) r) b),
+          ← Real.rpow_mul (moment_nonneg w x (fun i => (hw i).le) (fun i => (hx i).le) p),
+          ← Real.rpow_mul (moment_nonneg w x (fun i => (hw i).le) (fun i => (hx i).le) r),
+          hexp1, hexp2]
+
+end JensenLyapunov
+
+-- #print axioms JensenLyapunov.moment_interp_le
+-- #print axioms JensenLyapunov.logConvexOn_moment
+-- #print axioms JensenLyapunov.moment_lyapunov

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "Lyapunov's Inequality: Log-Convexity of the Weighted Moment Function",
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "description": "Proves Lyapunov's inequality and, equivalently, the log-convexity of the weighted moment function A(t) = ∑_i w_i · x_i^t for strictly positive families w, x on a finite index type. The main results are: (1) the interpolation inequality A(a·p + b·r) ≤ A(p)^a · A(r)^b for any real exponents p, r and convex weights a, b > 0 with a + b = 1 (no ordering of p, r required); (2) log-convexity, that t ↦ log A(t) is convex on all of ℝ; and (3) the symmetric three-exponent form A(q)^{r-p} ≤ A(p)^{r-q} · A(r)^{q-p} for p < q < r. The entire result is a single application of the two-function discrete Hölder inequality (inner_le_holder_two, from the parent generalized-Hölder entry): with conjugate exponents P = a⁻¹, Q = b⁻¹ and the pointwise functions u_i = (w_i·x_i^p)^a, v_i = (w_i·x_i^r)^b, Hölder reads exactly A(a·p+b·r) = ∑ u_i·v_i ≤ (∑ u_i^P)^{1/P}·(∑ v_i^Q)^{1/Q} = A(p)^a · A(r)^b. This is a genuine structural refinement of the monotonicity of power means: monotonicity says M_r is increasing in r, whereas log-convexity is a second-order statement pinning the shape of the moment curve, and it implies the power-mean inequality by interpolation.",
+  "meta": {
+    "author": "Lean Genius (Lyapunov inequality / log-convexity of moments via two-function Hölder); A. M. Lyapunov",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "convexity",
+      "log-convexity",
+      "lyapunov-inequality",
+      "holder-inequality",
+      "power-means",
+      "interpolation",
+      "inequalities",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 170,
+    "originalContributions": [
+      "moment_interp_le: the Lyapunov interpolation inequality A(a·p + b·r) ≤ A(p)^a · A(r)^b for the weighted moment function A(t) = ∑_i w_i·x_i^t, with strictly positive w, x, real exponents p, r, and convex weights a, b > 0 with a + b = 1 — no ordering of p and r is required. Proved by a single application of the two-function discrete Hölder inequality with conjugate exponents a⁻¹, b⁻¹ on the pointwise data (w_i·x_i^p)^a and (w_i·x_i^r)^b.",
+      "logConvexOn_moment: the log-convexity of the weighted moment function — t ↦ log(∑_i w_i·x_i^t) is convex on all of ℝ. This is the conceptual content of Lyapunov's inequality and is obtained from moment_interp_le by taking logarithms (the boundary cases a = 0 and b = 0 reduce to equality).",
+      "moment_lyapunov: the classical symmetric three-exponent form A(q)^{r-p} ≤ A(p)^{r-q} · A(r)^{q-p} for p < q < r, obtained from moment_interp_le with the convex weights a = (r-q)/(r-p), b = (q-p)/(r-p) by raising both sides to the power r - p.",
+      "rpow_interp: the pointwise interpolation identity (w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r} for w, x > 0, the only rpow bookkeeping the argument requires."
+    ],
+    "assumptions": "None beyond Mathlib's foundational axioms. Fully machine-checked: 0 sorries, 0 axiom declarations, no native_decide; all three headline theorems depend only on [propext, Classical.choice, Quot.sound]. The file imports one other gallery entry (Proofs/JensenInequalityOQ01OQ01OQ01OQ01, the generalized Hölder inequality) to reuse its two-function Hölder lemma inner_le_holder_two.",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Uses the parent's two-function discrete Hölder inequality inner_le_holder_two as the sole engine: Lyapunov's inequality is exactly Hölder applied to the pointwise data (w_i·x_i^p)^a, (w_i·x_i^r)^b with conjugate exponents a⁻¹, b⁻¹."
+    },
+    {
+      "targetId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+      "relationship": "related",
+      "description": "Refines the monotonicity of the power mean (that entry's main result): monotonicity says M_r is increasing in r; log-convexity of the moment function is the second-order statement that pins the shape of the moment curve and implies the power-mean inequality by interpolation."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Lyapunov's inequality (A. M. Lyapunov) is the statement that the moments of a positive measure are a log-convex function of their order: for s < t < u, (∫ f^t)^{u-s} ≤ (∫ f^s)^{u-t}(∫ f^u)^{t-s}. Equivalently the map p ↦ log ∫ f^p is convex. It is the analytic backbone of the interpolation theory of Lᵖ spaces (the Riesz–Thorin interpolation theorem is its operator-theoretic descendant) and refines the monotonicity of power means. The discrete weighted version proved here, with the integral replaced by a finite weighted sum A(t) = ∑_i w_i·x_i^t, is the elementary heart of the result. Mathlib formalizes log-convexity for specific functions (notably the Gamma function) but not the general log-convexity of the discrete moment / power-sum function.",
+    "problemStatement": "For strictly positive families w, x : ι → ℝ on a finite index type, define the weighted moment function A(t) = ∑_i w_i·x_i^t. Prove that A is log-convex: t ↦ log A(t) is convex on ℝ. Equivalently, prove the Lyapunov interpolation inequality A(a·p + b·r) ≤ A(p)^a · A(r)^b for a, b > 0 with a + b = 1, and its symmetric three-exponent form A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p} for p < q < r.",
+    "proofStrategy": "The single engine is the two-function discrete Hölder inequality from the parent entry. Fix convex weights a, b > 0 with a + b = 1 and exponents p, r. Choose conjugate Hölder exponents P = a⁻¹, Q = b⁻¹ (so P⁻¹ + Q⁻¹ = a + b = 1) and the pointwise functions u_i = (w_i·x_i^p)^a, v_i = (w_i·x_i^r)^b. The pointwise interpolation identity (w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r} = w·x^{a·p+b·r} gives ∑_i u_i·v_i = A(a·p+b·r); meanwhile u_i^P = w_i·x_i^p and v_i^Q = w_i·x_i^r, so the Hölder right-hand side (∑ u_i^P)^{P⁻¹}(∑ v_i^Q)^{Q⁻¹} equals A(p)^a · A(r)^b. This is moment_interp_le. Taking logs (and noting A(t) > 0 since the index is nonempty) turns it into the convexity inequality log A(a·p+b·r) ≤ a·log A(p) + b·log A(r), which is exactly ConvexOn after handling the degenerate weights a = 0 and b = 0; this is logConvexOn_moment. The symmetric form moment_lyapunov follows by instantiating a = (r-q)/(r-p), b = (q-p)/(r-p) and raising both sides to the power r - p.",
+    "keyInsights": [
+      "Lyapunov's inequality is not a new analytic fact but a clean re-packaging of Hölder's inequality: writing x_i^q with q = a·p + b·r as the product (x_i^p)^a·(x_i^r)^b and applying Hölder with the dual exponents 1/a, 1/b is the entire content.",
+      "No ordering of the two base exponents p and r is needed — only that the interpolation weights a, b are a convex combination. This is exactly why the result delivers convexity of log A on all of ℝ, not merely a monotonicity statement.",
+      "Log-convexity is strictly stronger than the monotonicity of power means: the power-mean inequality M_p ≤ M_q follows from log-convexity by interpolation, but log-convexity additionally controls the second-order shape of the moment curve.",
+      "The three-exponent form A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p} is the denominator-free face of the same inequality, recovered by raising the interpolation inequality to the power r - p; the weight algebra a·(r-p) = r-q, b·(r-p) = q-p is what produces the symmetric exponents.",
+      "The only real-power bookkeeping is the single pointwise identity rpow_interp, (w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r}, which collects all uses of mul_rpow, rpow_mul, and rpow_add in one place."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "States the goal — log-convexity of the weighted moment function A(t) = ∑_i w_i·x_i^t and the equivalent Lyapunov interpolation inequality — and explains that the whole proof is one application of the two-function discrete Hölder inequality from the parent entry.",
+      "mathContext": "Lyapunov: $t\\mapsto \\log\\big(\\sum_i w_i x_i^t\\big)$ is convex; equivalently $A(ap+br)\\le A(p)^a A(r)^b$ for $a,b>0$, $a+b=1$."
+    },
+    {
+      "id": "moment-and-identity",
+      "title": "Moment function and pointwise interpolation identity",
+      "startLine": 52,
+      "endLine": 74,
+      "summary": "Defines moment w x t = ∑_i w_i·x_i^t; proves rpow_interp, the pointwise identity (w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r}; and records nonnegativity (moment_nonneg) and strict positivity for nonempty index (moment_pos).",
+      "mathContext": "$(w x^p)^a (w x^r)^b = w^{a+b} x^{ap+br}$ via $\\mathrm{mul\\_rpow}$, $\\mathrm{rpow\\_mul}$, $\\mathrm{rpow\\_add}$; $A(t)>0$ for positive data."
+    },
+    {
+      "id": "interp-inequality",
+      "title": "Lyapunov interpolation inequality",
+      "startLine": 76,
+      "endLine": 108,
+      "summary": "moment_interp_le: A(a·p+b·r) ≤ A(p)^a·A(r)^b. A three-step calc — rewrite A(a·p+b·r) as ∑_i (w_i·x_i^p)^a·(w_i·x_i^r)^b via rpow_interp; apply inner_le_holder_two with exponents a⁻¹, b⁻¹; and rewrite (u_i^{a⁻¹})^{(a⁻¹)⁻¹} back to A(p)^a, A(r)^b.",
+      "mathContext": "With $P=a^{-1}$, $Q=b^{-1}$, $u_i=(w_i x_i^p)^a$, $v_i=(w_i x_i^r)^b$: $\\sum u_i v_i = A(ap+br)$, $u_i^P=w_i x_i^p$, $v_i^Q=w_i x_i^r$."
+    },
+    {
+      "id": "log-convexity",
+      "title": "Log-convexity of the moment function",
+      "startLine": 110,
+      "endLine": 132,
+      "summary": "logConvexOn_moment: t ↦ log A(t) is convex on Set.univ. The convexity inequality follows from moment_interp_le by Real.log_le_log and log_mul/log_rpow; the boundary weights a = 0 and b = 0 are dispatched by simp.",
+      "mathContext": "$\\log A(ap+br)\\le \\log\\big(A(p)^a A(r)^b\\big)= a\\log A(p)+b\\log A(r)$, i.e. $\\mathrm{ConvexOn}\\ \\mathbb{R}\\ \\mathrm{univ}\\ (\\log\\circ A)$."
+    },
+    {
+      "id": "three-exponent",
+      "title": "Symmetric three-exponent Lyapunov inequality",
+      "startLine": 134,
+      "endLine": 166,
+      "summary": "moment_lyapunov: A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p} for p < q < r. Instantiates moment_interp_le with a = (r-q)/(r-p), b = (q-p)/(r-p) (so a·p+b·r = q) and raises both sides to the power r - p, using a·(r-p) = r-q and b·(r-p) = q-p.",
+      "mathContext": "$A(q)^{r-p}\\le \\big(A(p)^a A(r)^b\\big)^{r-p}=A(p)^{r-q}A(r)^{q-p}$ with $a=\\tfrac{r-q}{r-p},\\ b=\\tfrac{q-p}{r-p}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This fully verified 170-line file (0 sorries, 0 axioms, no native_decide; all theorems depend only on propext/Classical.choice/Quot.sound) proves Lyapunov's inequality for the weighted moment function A(t) = ∑_i w_i·x_i^t in three faces: the interpolation inequality A(a·p+b·r) ≤ A(p)^a·A(r)^b, the log-convexity of t ↦ log A(t) on ℝ, and the symmetric three-exponent form A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p}. The entire argument is a single application of the two-function discrete Hölder inequality from the parent generalized-Hölder entry.",
+    "implications": "Log-convexity of moments is the discrete, elementary core of the interpolation theory of Lᵖ spaces and a structural refinement of the power-mean inequality. It exposes that the monotonicity of power means is the first-order shadow of a second-order convexity phenomenon, and it is the finite-sum prototype of the Lyapunov / Riesz–Thorin interpolation inequalities.",
+    "openQuestions": [
+      "Prove the strict version and the equality case: A(a·p+b·r) = A(p)^a·A(r)^b iff all x_i are equal (equivalently t ↦ log A(t) is affine on an interval iff the data is a single point), descending from the equality case of Hölder / weighted AM–GM.",
+      "Lift log-convexity from the finite weighted sum to the Lᵖ / integral setting, recovering the measure-theoretic Lyapunov inequality (∫ f^t)^{u-s} ≤ (∫ f^s)^{u-t}(∫ f^u)^{t-s} and connecting to Mathlib's interpolation infrastructure.",
+      "Use log-convexity to re-derive the power-mean inequality and the monotonicity of M_r directly, exhibiting the gallery's power-mean monotonicity entry as a corollary of this second-order result."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 170,
+    "axiomCount": 0,
+    "path": "Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 5,
+    "imports": [
+      "Proofs.JensenInequalityOQ01OQ01OQ01OQ01",
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01.json
@@ -1,0 +1,71 @@
+{
+  "slug": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "Lyapunov's Inequality: Log-Convexity of the Weighted Moment Function",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "A(t)=\\sum_i w_i x_i^t \\ \\Rightarrow\\ A(ap+br)\\le A(p)^a A(r)^b\\ (a,b>0,\\ a+b=1);\\quad t\\mapsto \\log A(t)\\ \\text{convex};\\quad A(q)^{r-p}\\le A(p)^{r-q}A(r)^{q-p}\\ (p<q<r)",
+    "plain": "For strictly positive families w, x on a finite index type, define the weighted moment function A(t) = ∑_i w_i·x_i^t. Prove that A is log-convex (t ↦ log A(t) is convex on ℝ), equivalently the Lyapunov interpolation inequality A(a·p+b·r) ≤ A(p)^a·A(r)^b for a,b>0 with a+b=1, and the symmetric three-exponent form A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p} for p<q<r. This is the discrete weighted core of the measure-theoretic Lyapunov inequality and a structural refinement of the power-mean inequality.",
+    "whyMatters": [
+      "Log-convexity of moments is the analytic backbone of Lᵖ interpolation theory (the elementary prototype of Riesz–Thorin)",
+      "It is strictly stronger than the monotonicity of power means: a second-order shape statement that implies M_p ≤ M_q by interpolation",
+      "Mathlib has log-convexity for specific functions (Gamma) but not for the general discrete moment / power-sum function"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T16:00:00-07:00",
+    "iteration": 1,
+    "focus": "Prove Lyapunov's inequality / log-convexity of the weighted moment function via the two-function discrete Hölder inequality.",
+    "blockers": [],
+    "nextAction": "Complete — proof verified, gallery entry created.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SOLVED (researcher-9, 2026-06-22): proved Lyapunov's inequality and log-convexity of the weighted moment function A(t) = ∑_i w_i·x_i^t. 0-axiom verified (propext/Classical.choice/Quot.sound, no native_decide). File Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean (170L, 1 def, 5 thm). Three faces: moment_interp_le (A(ap+br) ≤ A(p)^a·A(r)^b, no ordering of p,r), logConvexOn_moment (t ↦ log A(t) convex on ℝ), moment_lyapunov (A(q)^{r-p} ≤ A(p)^{r-q}·A(r)^{q-p} for p<q<r). Engine: ONE application of the parent's two-function Hölder inner_le_holder_two with conjugate exponents a⁻¹, b⁻¹ on pointwise data (w_i·x_i^p)^a, (w_i·x_i^r)^b.",
+    "builtItems": [
+      "Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean: moment_interp_le (Lyapunov interpolation inequality)",
+      "logConvexOn_moment (log-convexity of the moment function — Mathlib gap for the general discrete case)",
+      "moment_lyapunov (symmetric three-exponent Lyapunov form)",
+      "rpow_interp (pointwise identity (w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r}), moment_nonneg, moment_pos",
+      "src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01/ gallery entry"
+    ],
+    "insights": [
+      "Lyapunov is a clean re-packaging of Hölder: write x_i^q with q = a·p+b·r as (x_i^p)^a·(x_i^r)^b and apply Hölder with dual exponents 1/a, 1/b — that is the whole argument",
+      "No ordering of the base exponents p, r is needed, only that a, b form a convex combination; this is exactly what yields convexity of log A on all of ℝ rather than mere monotonicity",
+      "Log-convexity is strictly stronger than power-mean monotonicity: M_p ≤ M_q follows by interpolation, but log-convexity additionally controls the second-order shape of the moment curve",
+      "The denominator-free three-exponent form is recovered by raising the interpolation inequality to the power r-p, with the weight algebra a·(r-p)=r-q, b·(r-p)=q-p producing the symmetric exponents"
+    ],
+    "mathlibGaps": [
+      "Mathlib formalizes log-convexity for specific objects (Real.Gamma) but not the general log-convexity of the discrete weighted moment / power-sum function t ↦ ∑_i w_i·x_i^t — the elementary heart of Lyapunov's inequality"
+    ],
+    "nextSteps": [
+      "Prove the strict version / equality case: A(a·p+b·r) = A(p)^a·A(r)^b iff all x_i equal (log A affine iff data is a single point), from the Hölder / weighted AM–GM equality case",
+      "Lift to the Lᵖ / integral setting: the measure-theoretic Lyapunov inequality (∫ f^t)^{u-s} ≤ (∫ f^s)^{u-t}(∫ f^u)^{t-s}",
+      "Re-derive the power-mean inequality and monotonicity of M_r as corollaries of this second-order result"
+    ],
+    "markdown": "# Knowledge Base: jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01\n\n## Problem Understanding\n\nProve Lyapunov's inequality / log-convexity of the weighted moment function A(t) = ∑_i w_i·x_i^t, a refinement of power-mean monotonicity and the discrete core of Lᵖ interpolation.\n\n## Insights\n\nThe entire result is one application of the two-function discrete Hölder inequality (parent entry's inner_le_holder_two). With convex weights a, b > 0 (a+b=1) and exponents p, r, choose conjugate Hölder exponents P = a⁻¹, Q = b⁻¹ and pointwise data u_i = (w_i·x_i^p)^a, v_i = (w_i·x_i^r)^b. The pointwise identity (w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r} gives ∑ u_i·v_i = A(a·p+b·r), while u_i^P = w_i·x_i^p and v_i^Q = w_i·x_i^r, so the Hölder RHS is A(p)^a·A(r)^b. Taking logs yields convexity of log A; raising to the power r-p with a=(r-q)/(r-p), b=(q-p)/(r-p) yields the symmetric three-exponent form.\n\n## Dead Ends\n\nNone substantive — two first-build fixes: positivity cannot see through the opaque `moment` def (supply (rpow_pos_of_pos ...).ne' explicitly for log_mul), and div_add_div_same is deprecated/reversed (use ← add_div).\n"
+  },
+  "tags": [
+    "analysis",
+    "convexity",
+    "log-convexity",
+    "lyapunov-inequality",
+    "holder-inequality",
+    "power-means",
+    "interpolation",
+    "inequalities",
+    "research"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves **Lyapunov's inequality** and, equivalently, the **log-convexity of the weighted moment function** `A(t) = ∑ i, w i · (x i)^t` for strictly positive families `w, x` on a finite index type. A self-generated child of the generalized n-fold Hölder inequality entry (`jensen-inequality-oq-01-oq-01-oq-01-oq-01`).

Three faces of the same result:

| Theorem | Statement |
|---|---|
| `moment_interp_le` | `A(a·p + b·r) ≤ A(p)^a · A(r)^b` for `a, b > 0`, `a + b = 1` (no ordering of `p, r`) |
| `logConvexOn_moment` | `t ↦ log A(t)` is convex on all of `ℝ` |
| `moment_lyapunov` | `A(q)^(r-p) ≤ A(p)^(r-q) · A(r)^(q-p)` for `p < q < r` |

## Engine

The whole proof is **one application** of the parent's two-function discrete Hölder inequality `inner_le_holder_two`: with conjugate exponents `P = a⁻¹`, `Q = b⁻¹` and pointwise data `u_i = (w_i·x_i^p)^a`, `v_i = (w_i·x_i^r)^b`, Hölder reads exactly
`A(a·p+b·r) = ∑ u_i·v_i ≤ (∑ u_i^P)^{1/P}·(∑ v_i^Q)^{1/Q} = A(p)^a · A(r)^b`.
The only `rpow` bookkeeping is the pointwise identity `(w·x^p)^a·(w·x^r)^b = w^{a+b}·x^{a·p+b·r}` (`rpow_interp`).

## Significance

Log-convexity of moments is strictly stronger than the **monotonicity of power means** (gallery entry `jensen-inequality-oq-01-oq-01-oq-01-oq-04`): monotonicity is the first-order shadow of this second-order convexity statement, which implies the power-mean inequality by interpolation. It is the discrete, elementary core of `Lᵖ` interpolation theory (the prototype of Riesz–Thorin). **Mathlib gap:** Mathlib has log-convexity for specific functions (`Real.Gamma`) but not for the general discrete moment / power-sum function.

## Verification

- `Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01.lean` — 170 lines, 1 def + 5 thm
- **0 sorries, 0 axiom declarations, no `native_decide`**
- All three headline theorems depend only on `[propext, Classical.choice, Quot.sound]` (verified via `#print axioms`)
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.JensenInequalityOQ01OQ01OQ01OQ01OQ01`

🤖 Generated with [Claude Code](https://claude.com/claude-code)