### PR TITLE
research(roth-theorem-k3-oq-03-oq-01): foundational identities for the Gowers norm and the k-AP counting operator [0-axiom verified]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01.lean
@@ -1,0 +1,143 @@
+/-
+  Roth Theorem OQ-03-OQ-01: Foundational Identities for the
+  Gowers Norm and the k-AP Counting Operator
+
+  The parent entry `RothTheoremOQ03` introduces, constructively, the two
+  analytic operators at the heart of the density-increment / generalized
+  von Neumann approach to Szemerédi's theorem:
+
+    * the Gowers `U^s` uniformity norm
+        ‖f‖_{U^s}^{2^s} = E_{x,h} ∏_{ω ∈ {0,1}^s} C^{|ω|} f(x + ω·h),
+    * the k-AP counting operator
+        Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏_{i} fᵢ(x + i·d).
+
+  but records *no* algebraic properties of either.  This child proves the
+  foundational degenerate / normalization identities that every later
+  argument relies on, all fully machine-checked (0 axioms, no
+  `native_decide`):
+
+    * `conjugateByWeight_zero`     — the conjugation factor fixes `0`;
+    * `gowersNorm_zero`            — ‖0‖_{U^s} = 0;
+    * `kAPCount_const`             — Λ_k(c,…,c) = cᵏ;
+    * `kAPCount_const_one`         — Λ_k(1,…,1) = 1 (total normalized mass);
+    * `kAPCount_eq_zero_of_zero`   — a single zero slot annihilates Λ_k.
+
+  These are precisely the checks that pin the operators down as genuine
+  averages `E_{x,d} ∏ᵢ fᵢ(x+i·d)` (the `(N⁻¹)²·N² = 1` normalization),
+  and the constant/zero base cases of the multilinear expansion
+  `1_A = δ·1 + (1_A − δ)` that opens the generalized von Neumann argument.
+
+  Self-contained: the operators are re-declared here in their own
+  namespace using the current Mathlib norm `‖·‖` (rather than the parent's
+  `Complex.abs`), so the file is robust to merge order and toolchain drift.
+
+  References:
+  - Gowers, "A new proof of Szemerédi's theorem" (2001)
+  - Tao, "Higher order Fourier analysis" (2012)
+-/
+
+import Mathlib
+
+namespace RothTheoremOQ03OQ01
+
+open Finset BigOperators
+
+-- ============================================================
+-- The operators (constructive; norm via `‖·‖`)
+-- ============================================================
+
+/-- The shift determined by a hypercube vertex `ω` and shift vectors `h`:
+    `ω · h = Σᵢ (if ωᵢ then hᵢ else 0)`. -/
+noncomputable def hypercubeShift {N s : ℕ} (h : Fin s → ZMod N)
+    (ω : Fin s → Bool) : ZMod N :=
+  ∑ i : Fin s, if ω i then h i else 0
+
+/-- Conjugation factor: conjugate exactly when the Hamming weight of `ω`
+    is odd. `C^{|ω|}(z) = z` if `|ω|` even, `conj z` if `|ω|` odd. -/
+noncomputable def conjugateByWeight {s : ℕ} (ω : Fin s → Bool) (z : ℂ) : ℂ :=
+  if (Finset.univ.filter (fun i => ω i = true)).card % 2 = 0
+  then z else starRingEnd ℂ z
+
+/-- The Gowers `U^s` norm of `f : ZMod N → ℂ` (raised to the power `2^s`),
+    `‖f‖_{U^s}^{2^s} = |E_{x,h} ∏_{ω} C^{|ω|} f(x + ω·h)|`, written as the
+    modulus of a normalized finite sum. -/
+noncomputable def gowersNorm (N s : ℕ) [NeZero N] (f : ZMod N → ℂ) : ℝ :=
+  ‖(((N : ℂ)⁻¹) ^ (s + 1) *
+      ∑ x : ZMod N, ∑ h : Fin s → ZMod N,
+        ∏ ω : Fin s → Bool,
+          conjugateByWeight ω (f (x + hypercubeShift h ω)))‖
+
+/-- The k-AP counting operator, a normalized finite average:
+    `Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏_{i} fᵢ(x + i·d)`. -/
+noncomputable def kAPCount {N : ℕ} [NeZero N] (k : ℕ)
+    (f : Fin k → ZMod N → ℂ) : ℂ :=
+  ((N : ℂ)⁻¹) ^ 2 * ∑ x : ZMod N, ∑ d : ZMod N,
+    ∏ i : Fin k, f i (x + i.val • d)
+
+-- ============================================================
+-- Foundational identities
+-- ============================================================
+
+/-- The conjugation-by-weight factor sends `0` to `0`: both branches
+    (the identity and complex conjugation) fix the origin. -/
+@[simp] theorem conjugateByWeight_zero {s : ℕ} (ω : Fin s → Bool) :
+    conjugateByWeight ω 0 = 0 := by
+  unfold conjugateByWeight
+  split <;> simp
+
+/-- The Gowers `U^s` norm of the zero function is `0`: every hypercube
+    factor is `conjugateByWeight ω 0 = 0`, so each `2^s`-fold product
+    vanishes, the averaging sum is `0`, and `‖0‖ = 0`. -/
+theorem gowersNorm_zero (N s : ℕ) [NeZero N] :
+    gowersNorm N s (0 : ZMod N → ℂ) = 0 := by
+  unfold gowersNorm
+  have hzero : ∀ (x : ZMod N) (h : Fin s → ZMod N),
+      (∏ ω : Fin s → Bool,
+        conjugateByWeight ω ((0 : ZMod N → ℂ) (x + hypercubeShift h ω))) = 0 :=
+    fun x h => Finset.prod_eq_zero (Finset.mem_univ (default : Fin s → Bool))
+      (by rw [Pi.zero_apply]; exact conjugateByWeight_zero _)
+  rw [Finset.sum_congr rfl (fun x _ =>
+        Finset.sum_congr rfl (fun h _ => hzero x h))]
+  simp
+
+/-- The k-AP counting operator on the constant tuple `(c,…,c)` equals
+    `c ^ k`: the inner product is `∏_{i} c = cᵏ`, and the normalized
+    double average `(N⁻¹)² · ∑_{x,d} cᵏ = cᵏ` cancels the `N²` pairs
+    against the `(N⁻¹)²` prefactor. -/
+theorem kAPCount_const {N : ℕ} [NeZero N] (k : ℕ) (c : ℂ) :
+    kAPCount k (fun (_ : Fin k) (_ : ZMod N) => c) = c ^ k := by
+  unfold kAPCount
+  have hprod : ∀ (x d : ZMod N),
+      (∏ i : Fin k, (fun (_ : Fin k) (_ : ZMod N) => c) i (x + i.val • d))
+        = c ^ k := by
+    intro x d
+    simp only [Finset.prod_const, Finset.card_univ, Fintype.card_fin]
+  rw [Finset.sum_congr rfl (fun x _ =>
+        Finset.sum_congr rfl (fun d _ => hprod x d))]
+  have hN : (N : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr (NeZero.ne N)
+  simp only [Finset.sum_const, Finset.card_univ, ZMod.card, nsmul_eq_mul]
+  rw [show ((N : ℂ)⁻¹) ^ 2 * ((N : ℂ) * ((N : ℂ) * c ^ k))
+        = ((N : ℂ)⁻¹ * (N : ℂ)) ^ 2 * c ^ k from by ring,
+      inv_mul_cancel₀ hN, one_pow, one_mul]
+
+/-- Normalization: the count of the all-ones tuple is `1`, i.e.
+    `Λ_k(1,…,1) = 1` — the total normalized `k`-AP mass and the base
+    point of the `1_A = δ·1 + (1_A − δ)` decomposition. -/
+theorem kAPCount_const_one {N : ℕ} [NeZero N] (k : ℕ) :
+    kAPCount k (fun (_ : Fin k) (_ : ZMod N) => (1 : ℂ)) = 1 := by
+  rw [kAPCount_const]; simp
+
+/-- A single zero argument annihilates the whole count: if `f j` is the
+    zero function for some position `j`, then `Λ_k(f₀,…,f_{k-1}) = 0`,
+    because the `j`-th factor of every product term vanishes. -/
+theorem kAPCount_eq_zero_of_zero {N : ℕ} [NeZero N] (k : ℕ)
+    (f : Fin k → ZMod N → ℂ) (j : Fin k) (hj : f j = 0) :
+    kAPCount k f = 0 := by
+  unfold kAPCount
+  have hprod : ∀ (x d : ZMod N), (∏ i : Fin k, f i (x + i.val • d)) = 0 :=
+    fun x d => Finset.prod_eq_zero (Finset.mem_univ j) (by simp [hj])
+  rw [Finset.sum_congr rfl (fun x _ =>
+        Finset.sum_congr rfl (fun d _ => hprod x d))]
+  simp
+
+end RothTheoremOQ03OQ01

--- a/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-03-oq-01.json
@@ -1,0 +1,37 @@
+{
+  "id": "roth-theorem-k3-oq-03-oq-01",
+  "name": "Foundational identities for the Gowers norm and the k-AP counting operator",
+  "parentId": "roth-theorem-k3-oq-03",
+  "status": "in-progress",
+  "knowledge": {
+    "score": 10,
+    "insights": [
+      "The parent OQ-03 defines gowersNorm and kAPCount constructively but proves NO algebraic properties of them — this child fills that gap with the foundational degenerate/normalization identities.",
+      "kAPCount on a constant tuple (c,…,c) equals c^k: the inner product is c^k and the normalized double average (N^-1)^2 * sum_{x,d} c^k = c^k cancels N^2 against the (N^-1)^2 prefactor. The all-ones case gives Λ_k(1,…,1)=1, the total normalized k-AP mass.",
+      "A single zero argument annihilates the whole count (Finset.prod_eq_zero on the j-th factor) — the multiplicative analogue of linearity in each slot.",
+      "gowersNorm of the zero function is 0: conjugateByWeight ω 0 = 0 in both branches (identity and conjugation), so every 2^s-fold hypercube product vanishes.",
+      "These constant/zero base cases are exactly the start of the multilinear expansion 1_A = δ·1 + (1_A − δ) that opens the generalized von Neumann argument.",
+      "Parent RothTheoremOQ03.lean has TOOLCHAIN DRIFT on the current Mathlib (Complex.abs removed; Fin.val rewrite patterns and a dangling /-- docstring no longer parse) — this child is therefore SELF-CONTAINED, re-declaring the operators with the modern norm ‖·‖ so it builds independently of the broken parent.",
+      "norm notation ‖ ... ‖ wrapping a ∑/∏ that extends to the right swallows the closing bar — wrap the inner expression in explicit parentheses ‖(...)‖ (the parent dodged this with Complex.abs (...))."
+    ],
+    "builtItems": [
+      "RothTheoremOQ03OQ01.lean: self-contained, 4 noncomputable defs (hypercubeShift, conjugateByWeight, gowersNorm, kAPCount) + 5 proved theorems, 0 axioms, 0 sorries.",
+      "conjugateByWeight_zero: conjugateByWeight ω 0 = 0 (simp lemma).",
+      "gowersNorm_zero: gowersNorm N s 0 = 0.",
+      "kAPCount_const: kAPCount k (fun _ _ => c) = c^k.",
+      "kAPCount_const_one: kAPCount k (fun _ _ => 1) = 1.",
+      "kAPCount_eq_zero_of_zero: f j = 0 ⟹ kAPCount k f = 0."
+    ],
+    "progressSummary": "Child of roth-theorem-k3-oq-03. The parent constructs the Gowers U^s norm and the k-AP counting operator Λ_k but proves nothing about them. This entry supplies the foundational identities: gowersNorm_zero, kAPCount_const (Λ_k(c,…,c)=c^k), kAPCount_const_one (normalization Λ_k(1,…,1)=1), and kAPCount_eq_zero_of_zero (a zero slot annihilates the count). All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained file using the current Mathlib norm ‖·‖ (the parent file uses the now-removed Complex.abs).",
+    "nextSteps": [
+      "Prove multilinearity of kAPCount in each slot (additivity and scalar homogeneity via Function.update), enabling the full 1_A = δ·1 + (1_A − δ) expansion.",
+      "Prove gowersNorm_nonneg and the U^1 mean identity once the parent's Complex.abs drift is repaired (or keep on the self-contained operators).",
+      "Connect kAPCount of an indicator function to the actual count of k-APs in a finset.",
+      "Repair the toolchain drift in the parent RothTheoremOQ03.lean (Complex.abs → ‖·‖, Fin.val rewrites, dangling docstring) so the two files can be merged."
+    ]
+  },
+  "relatedProofs": [
+    "roth-theorem-k3",
+    "roth-theorem-k3-oq-03"
+  ]
+}


### PR DESCRIPTION
## Summary

Child of `roth-theorem-k3-oq-03` (density-increment generalization to k-APs). The parent entry constructs, but proves **no properties of**, the two analytic operators at the heart of the generalized von Neumann / density-increment approach to Szemerédi's theorem:

- the **Gowers $U^s$ norm** $\|f\|_{U^s}^{2^s} = \mathbb{E}_{x,h} \prod_{\omega} C^{|\omega|} f(x+\omega\cdot h)$,
- the **k-AP counting operator** $\Lambda_k(f_0,\dots,f_{k-1}) = \mathbb{E}_{x,d} \prod_i f_i(x+i\cdot d)$.

This PR supplies the foundational degenerate / normalization identities every later argument relies on.

## New theorems (all 0-axiom verified)

| Theorem | Statement |
|---|---|
| `conjugateByWeight_zero` | $C^{|\omega|}(0) = 0$ (both branches fix the origin) |
| `gowersNorm_zero` | $\|0\|_{U^s} = 0$ |
| `kAPCount_const` | $\Lambda_k(c,\dots,c) = c^k$ |
| `kAPCount_const_one` | $\Lambda_k(1,\dots,1) = 1$ (total normalized mass) |
| `kAPCount_eq_zero_of_zero` | a single zero slot annihilates $\Lambda_k$ |

These pin the operators down as genuine averages (the $(N^{-1})^2 \cdot N^2 = 1$ normalization) and are the constant/zero base cases of the multilinear expansion $1_A = \delta\cdot 1 + (1_A - \delta)$ that opens the generalized von Neumann argument.

## Notes

- **Self-contained**: the operators are re-declared in their own namespace using the current Mathlib norm `‖·‖`. The parent `RothTheoremOQ03.lean` has bit-rotted against the current toolchain (it uses the now-removed `Complex.abs`, plus `Fin.val` rewrite patterns and a dangling `/--` docstring that no longer parse), so building independently keeps this contribution robust to merge order. A follow-up can repair the parent's drift.

## Verification

- Docker build: **0 errors**, no `sorry`
- `#print axioms` for all five theorems = `[propext, Classical.choice, Quot.sound]` only ⇒ **0-axiom verified**, no `native_decide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)