### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-02): second-derivative Fourier identity ĉₙ(f'')=−n²·ĉₙ(f) [0-axiom verified]

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ02.lean
@@ -1,0 +1,82 @@
+/-
+  Isoperimetric Inequality: the second-derivative Fourier identity
+  Open Question: area-of-circle-oq-01-oq-02-oq-02-oq-02
+
+  The parent file `AreaOfCircleOQ01OQ02OQ02` proves the integration-by-parts
+  identity for Fourier coefficients of periodic C¹ functions,
+
+      ĉₙ(f') = i·n · ĉₙ(f).
+
+  Iterating it once more gives the *second*-derivative identity
+
+      ĉₙ(f'') = (i·n)² · ĉₙ(f) = −n² · ĉₙ(f),
+
+  the `−n²` eigenvalue that drives Wirtinger's inequality and hence the
+  Fourier (Hurwitz) proof of the isoperimetric inequality `C² ≥ 4πA`: each
+  Fourier mode contributes a factor `n² ≥ 1`, with equality exactly on the
+  first harmonic (the circle).
+
+  This file supplies that identity, together with the supporting fact that
+  the derivative of a periodic function is periodic (which Mathlib does not
+  package directly).
+
+  References:
+  - Hurwitz (1901): Fourier proof of the isoperimetric inequality
+  - AreaOfCircleOQ01OQ02OQ02.lean (the first-order IBP identity, reused here)
+-/
+
+import Mathlib
+import Proofs.AreaOfCircleOQ01OQ02OQ02
+
+open Real Filter Topology Complex MeasureTheory IsoperimetricFourier
+
+noncomputable section
+
+namespace IsoperimetricFourier
+
+-- ============================================================
+-- SECTION II: Second-derivative Fourier identity
+-- ============================================================
+
+/-- The derivative of a periodic function is periodic with the same period.
+    From `f (x + T) = f x` for all `x`, the shifted function `fun x ↦ f (x + T)`
+    *is* `f`, so their derivatives agree: `f' (t + T) = f' t`. -/
+theorem deriv_periodic_of_periodic (f : ℝ → ℝ) (T : ℝ)
+    (hperiod : ∀ t, f (t + T) = f t) (t : ℝ) :
+    deriv f (t + T) = deriv f t := by
+  have hshift : (fun x => f (x + T)) = f := funext hperiod
+  have hstep : deriv (fun x => f (x + T)) t = deriv f (t + T) :=
+    deriv_comp_add_const f T t
+  rw [hshift] at hstep
+  exact hstep.symm
+
+/-- **Second-order IBP for Fourier coefficients**: for a `C²` periodic
+    function `f` (period `2π`) and `n ≠ 0`,
+
+        ĉₙ(f'') = −n² · ĉₙ(f).
+
+    Proof: apply the first-order identity `fourierCoeffOn_deriv_periodic`
+    twice — once to `f` and once to `f'` (which is again `C¹` and periodic) —
+    and collapse `(i·n)·(i·n) = i²·n² = −n²` via `I_mul_I`. -/
+theorem fourierCoeffOn_deriv2_periodic (f : ℝ → ℝ) (hf : ContDiff ℝ 2 f)
+    (hperiod : ∀ t, f (t + 2 * π) = f t)
+    (hab : (0 : ℝ) < 2 * π) (n : ℤ) (hn : n ≠ 0) :
+    fourierCoeffOn hab (ofReal ∘ deriv (deriv f)) n =
+      -(n : ℂ) ^ 2 * fourierCoeffOn hab (ofReal ∘ f) n := by
+  -- `f` is `C¹`, and so is its derivative.
+  have hf1 : ContDiff ℝ 1 f := hf.of_le (by norm_num)
+  have hdf1 : ContDiff ℝ 1 (deriv f) :=
+    (contDiff_succ_iff_deriv (n := 1)).mp hf |>.2.2
+  -- The derivative inherits the periodicity of `f`.
+  have hperiod' : ∀ t, deriv f (t + 2 * π) = deriv f t :=
+    deriv_periodic_of_periodic f (2 * π) hperiod
+  -- First-order identity applied to `f` and to `deriv f`.
+  have h1 := fourierCoeffOn_deriv_periodic f hf1 hperiod hab n hn
+  have h2 := fourierCoeffOn_deriv_periodic (deriv f) hdf1 hperiod' hab n hn
+  rw [h2, h1]
+  rw [show I * (n : ℂ) * (I * (n : ℂ) * fourierCoeffOn hab (ofReal ∘ f) n)
+        = (I * I) * (n : ℂ) ^ 2 * fourierCoeffOn hab (ofReal ∘ f) n from by ring,
+      I_mul_I]
+  ring
+
+end IsoperimetricFourier

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-02.json
@@ -1,0 +1,33 @@
+{
+  "id": "area-of-circle-oq-01-oq-02-oq-02-oq-02",
+  "name": "Second-derivative Fourier identity: ĉₙ(f'') = −n²·ĉₙ(f)",
+  "parentId": "area-of-circle-oq-01-oq-02-oq-02",
+  "status": "in-progress",
+  "knowledge": {
+    "score": 10,
+    "insights": [
+      "The parent OQ-02 proves the first-order IBP identity ĉₙ(f') = i·n·ĉₙ(f) for periodic C¹ functions (Hurwitz's Fourier route to the isoperimetric inequality). Iterating it once gives the second-derivative identity ĉₙ(f'') = (i·n)²·ĉₙ(f) = −n²·ĉₙ(f).",
+      "The −n² eigenvalue is exactly what drives Wirtinger's inequality: every Fourier mode of f'' contributes a factor n² ≥ 1, with equality only on the first harmonic — the circle, the equality case of C² ≥ 4πA.",
+      "Mathlib does NOT package 'derivative of a periodic function is periodic' (no Function.Periodic.deriv on this toolchain). Proved here from deriv_comp_add_const: since (fun x ↦ f (x+T)) = f, their derivatives agree, giving f'(t+T) = f'(t).",
+      "ContDiff ℝ 1 (deriv f) is extracted from ContDiff ℝ 2 f via contDiff_succ_iff_deriv (n := 1) |>.2.2 — note the current 3-way conjunction (Differentiable ∧ (n=ω→AnalyticOn) ∧ ContDiff n (deriv f)).",
+      "(i·n)·(i·n) collapses to −n² via Complex.I_mul_I (I*I = -1) after a ring normalization that pulls out (I*I)·n²."
+    ],
+    "builtItems": [
+      "AreaOfCircleOQ01OQ02OQ02OQ02.lean: 2 theorems, 0 axioms, 0 sorries, imports and reuses the parent IBP identity.",
+      "deriv_periodic_of_periodic: the derivative of a T-periodic function is T-periodic.",
+      "fourierCoeffOn_deriv2_periodic: ĉₙ(f'') = −n²·ĉₙ(f) for C² periodic f, n ≠ 0."
+    ],
+    "progressSummary": "Child of area-of-circle-oq-01-oq-02-oq-02 (Isoperimetric Inequality via Fourier analysis). The parent gives the first-order IBP identity ĉₙ(f')=i·n·ĉₙ(f); this entry iterates it to the second-order identity ĉₙ(f'')=−n²·ĉₙ(f), the −n² eigenvalue underlying Wirtinger's inequality and the equality case (the circle). Also supplies the missing lemma that the derivative of a periodic function is periodic. Both 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide.",
+    "nextSteps": [
+      "Assemble Wirtinger's inequality ∫|f'|² ≥ ∫|f|² (mean-zero f, period 2π) from the n²≥1 Fourier-mode bound and Parseval.",
+      "Prove the n=0 companion ĉ₀(f') = 0 (derivative of a periodic function has zero mean) to complete the spectral picture.",
+      "Combine with the area/perimeter Fourier expansions to close the isoperimetric inequality C² ≥ 4πA with the circle as the equality case."
+    ]
+  },
+  "relatedProofs": [
+    "area-of-circle",
+    "area-of-circle-oq-01-oq-02",
+    "area-of-circle-oq-01-oq-02-oq-02",
+    "area-of-circle-oq-01-oq-02-oq-02-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Child of `area-of-circle-oq-01-oq-02-oq-02` (**Isoperimetric Inequality** $C^2 \ge 4\pi A$ via Fourier analysis — Hurwitz's proof). The parent file proves the first-order integration-by-parts identity for Fourier coefficients of periodic $C^1$ functions:

$$\hat{c}_n(f') = i n \cdot \hat{c}_n(f).$$

This PR iterates it to the **second-derivative identity**

$$\hat{c}_n(f'') = (in)^2 \hat{c}_n(f) = -n^2 \hat{c}_n(f).$$

The $-n^2$ eigenvalue is exactly what drives **Wirtinger's inequality** and hence the equality case of the isoperimetric inequality: every Fourier mode of $f''$ carries a factor $n^2 \ge 1$, with equality only on the first harmonic — the circle.

## New theorems (both 0-axiom verified)

- `deriv_periodic_of_periodic` — the derivative of a $T$-periodic function is $T$-periodic. (Mathlib has no `Function.Periodic.deriv` on the current toolchain; proved from `deriv_comp_add_const` since `(fun x ↦ f (x+T)) = f`.)
- `fourierCoeffOn_deriv2_periodic` — $\hat{c}_n(f'') = -n^2 \hat{c}_n(f)$ for $C^2$ periodic $f$ and $n \ne 0$, by applying the parent's first-order identity to $f$ and to $f'$ and collapsing $(in)(in) = i^2 n^2 = -n^2$ via `Complex.I_mul_I`.

## Verification

- Docker build: **0 errors**, no `sorry`, first-try
- `#print axioms` for both theorems = `[propext, Classical.choice, Quot.sound]` only ⇒ **0-axiom verified**, no `native_decide`
- Reuses the parent IBP lemma directly (`import Proofs.AreaOfCircleOQ01OQ02OQ02`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)