### PR TITLE
research(erdos-978-oq-01): Local square-obstruction structure of n⁴+2 [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos978OQ01.lean
+++ b/proofs/Proofs/Erdos978OQ01.lean
@@ -1,0 +1,123 @@
+/-
+Erdős Problem #978 — OQ-01: The local square-obstruction structure of n⁴ + 2
+
+Source: https://erdosproblems.com/978
+Parent: Proofs/Erdos978Problem.lean  (Erdős #978, the (k−2)-power-free question)
+
+## The open problem
+
+Erdős asked whether n⁴ + 2 represents infinitely many squarefree numbers (the
+k = 4, (k−2)-power-free case of #978). This is OPEN: it lies outside the range
+k ≥ 9 reached by Heath-Brown (2006) and Browning (2011), and the squarefree
+square-sieve for a quartic is beyond current technology. Hooley (1967) only gives
+the (k−1) = cubefree result. So the conjecture itself is not a Lean target.
+
+## What IS provable, and what this file contributes
+
+The standard squarefree heuristic predicts a *positive density* of squarefree
+values, hence infinitely many. The two ingredients that are genuinely finite,
+self-contained, and verifiable in Lean are:
+
+1.  **No fixed square obstruction.** There is no integer m > 1 whose square
+    divides n⁴ + 2 for every n — the trivial "answer is NO" route is closed.
+    (`no_fixed_square_obstruction`: the value at n = 0 is 2, and m² ∣ 2 forces
+    m² ≤ 2.)  In particular ρ(p²) := #{n : p² ∣ n⁴+2} never fills all residues.
+
+2.  **The dominant local obstruction at p = 3 is fully explicit.** Among small
+    primes p = 3 is the leading contributor to the local density product
+    C = ∏ₚ (1 − ρ(p²)/p²). Here `9 ∣ n⁴+2 ⟺ n ≡ 2 or 7 (mod 9)`: exactly two of
+    the nine residue classes are obstructed, so 7/9 are "safe". This is a clean
+    `decide`-checked fact over `ZMod 9`, lifted to ℤ, and it yields infinitely
+    many n with 9 ∤ n⁴+2 (every multiple of 9 works).
+
+All results below are 0-axiom and machine-checked (no `native_decide`; the
+`decide` calls reduce inside the kernel over the finite ring `ZMod 9`).
+
+This does not resolve the open conjecture — it formalizes the necessary local
+conditions that the heuristic rests on, at the dominant prime.
+-/
+import Mathlib.Tactic
+import Mathlib.Data.ZMod.Basic
+
+open Finset
+
+namespace Erdos978OQ01
+
+/-- The polynomial value under study, `F n = n⁴ + 2`. -/
+def F (n : ℤ) : ℤ := n ^ 4 + 2
+
+/-! ## Part I — No fixed square obstruction
+
+The first thing one must rule out is a *global* square: some fixed `m > 1` with
+`m² ∣ n⁴ + 2` for all `n`. Such an `m` would make `n⁴ + 2` never squarefree and
+settle the conjecture negatively. There is none, for the cheapest possible
+reason: the value at `n = 0` is `2`. -/
+
+/-- `F 0 = 2`. -/
+@[simp] theorem F_zero : F 0 = 2 := by norm_num [F]
+
+/-- **No fixed square divides every value of `n⁴ + 2`.**
+For any modulus `m > 1`, some value `n⁴ + 2` is not divisible by `m²`
+(witness `n = 0`, value `2`, and `m² ∣ 2` would force `m² ≤ 2 < 4`). -/
+theorem no_fixed_square_obstruction (m : ℤ) (hm : 1 < m) :
+    ∃ n : ℤ, ¬ (m ^ 2 ∣ F n) := by
+  refine ⟨0, ?_⟩
+  rw [F_zero]
+  intro h
+  have hle := Int.le_of_dvd (by norm_num) h
+  have h2 : 2 ≤ m := by omega
+  nlinarith [hle, h2, sq_nonneg (m - 2)]
+
+/-! ## Part II — The dominant local obstruction at `p = 3`
+
+`p = 3` is the smallest prime with `x⁴ ≡ −2 (mod 9)` solvable, and the leading
+term of the local density product. We pin down its contribution exactly. -/
+
+/-- Over the finite ring `ZMod 9`, `n⁴ + 2 = 0` for exactly the residues
+`n = 2` and `n = 7`. -/
+theorem zmod_nine_root_iff (n : ZMod 9) :
+    n ^ 4 + 2 = 0 ↔ n = 2 ∨ n = 7 := by decide +revert
+
+/-- **The 3²-obstruction, over ℤ.** `9 ∣ n⁴ + 2` iff `n ≡ 2` or `n ≡ 7 (mod 9)`. -/
+theorem nine_dvd_iff (n : ℤ) :
+    (9 : ℤ) ∣ F n ↔ (n : ZMod 9) = 2 ∨ (n : ZMod 9) = 7 := by
+  rw [← zmod_nine_root_iff,
+      show (9 : ℤ) = ((9 : ℕ) : ℤ) by norm_num,
+      ← ZMod.intCast_zmod_eq_zero_iff_dvd, F]
+  push_cast
+  tauto
+
+/-- Exactly `2` of the `9` residues mod `9` are obstructed: `ρ(9) = 2`. -/
+theorem obstructed_card :
+    (univ.filter (fun n : ZMod 9 => n ^ 4 + 2 = 0)).card = 2 := by decide
+
+/-- The other `7` residues are "safe": `9 ∤ n⁴+2`. A positive proportion
+(`7/9 > 0`), which is what the squarefree heuristic at `p = 3` requires. -/
+theorem safe_card :
+    (univ.filter (fun n : ZMod 9 => n ^ 4 + 2 ≠ 0)).card = 7 := by decide
+
+/-- The obstruction is non-vacuous: `9 ∣ F 2` (indeed `F 2 = 18 = 2·3²`). -/
+theorem nine_dvd_F_two : (9 : ℤ) ∣ F 2 := by norm_num [F]
+
+/-- And `9 ∣ F 7` (here `F 7 = 2403 = 3³·89`, the second obstructed class). -/
+theorem nine_dvd_F_seven : (9 : ℤ) ∣ F 7 := by norm_num [F]
+
+/-! ## Part III — Infinitely many values avoid the `p = 3` square
+
+Because the obstructed residues are `2, 7 (mod 9)`, every multiple of `9` gives a
+value with `9 ∤ n⁴+2`. There is a multiple of `9` above any bound, so infinitely
+many `n` escape the dominant local square. -/
+
+/-- **Infinitely many `n` with `9 ∤ n⁴ + 2`.** For every bound `N` there is an
+`n > N` (namely a multiple of `9`) whose value escapes the `3²` obstruction. -/
+theorem infinitely_many_nine_safe (N : ℤ) :
+    ∃ n : ℤ, N < n ∧ ¬ (9 : ℤ) ∣ F n := by
+  refine ⟨9 * ((N.natAbs : ℤ) + 1), by omega, ?_⟩
+  rw [nine_dvd_iff]
+  have h0 : ((9 * ((N.natAbs : ℤ) + 1) : ℤ) : ZMod 9) = 0 := by
+    rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
+    exact dvd_mul_right 9 _
+  rw [h0]
+  decide
+
+end Erdos978OQ01

--- a/src/data/proofs/erdos-978-oq-01/meta.json
+++ b/src/data/proofs/erdos-978-oq-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "erdos-978-oq-01",
+  "title": "Erdős #978 OQ-01: Local Square-Obstruction Structure of n⁴ + 2",
+  "slug": "erdos-978-oq-01",
+  "description": "The open conjecture that n⁴+2 is squarefree infinitely often rests on two finite, verifiable local conditions, both formalized here 0-axiom: (1) no fixed square m²>1 divides every value (the n=0 value is 2), and (2) the dominant local obstruction at p=3 is fully explicit — 9∣n⁴+2 iff n≡2,7 (mod 9), so 7 of 9 residues are safe, giving infinitely many n with 9∤n⁴+2.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/978",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos978OQ01.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "squarefree",
+      "power-free",
+      "polynomials",
+      "local-obstruction",
+      "ZMod",
+      "open-problem"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "erdosNumber": 978,
+    "erdosUrl": "https://erdosproblems.com/978",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "(↑a : ZMod b) = 0 ↔ (b:ℤ) ∣ a — bridge between residues mod b and integer divisibility",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Int.le_of_dvd",
+        "description": "0 < b → a ∣ b → a ≤ b — bounds a divisor by the (positive) dividend",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "Finset.filter",
+        "description": "Counting residue classes obstructed mod 9 (ρ(9) = 2)",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "F (def): the value n⁴ + 2 over ℤ",
+      "no_fixed_square_obstruction (theorem): for every m>1 some n⁴+2 is not divisible by m² (witness n=0, value 2), closing the trivial 'never squarefree' route",
+      "zmod_nine_root_iff (theorem): over ZMod 9, n⁴+2=0 iff n=2 or n=7 (decide, kernel-checked)",
+      "nine_dvd_iff (theorem): 9 ∣ n⁴+2 iff n≡2 or n≡7 (mod 9), the explicit dominant 3²-obstruction over ℤ",
+      "obstructed_card / safe_card (theorems): exactly 2 of 9 residues are obstructed (ρ(9)=2), 7 are safe — positive proportion the heuristic requires",
+      "nine_dvd_F_two, nine_dvd_F_seven (theorems): the obstruction is non-vacuous (F 2 = 18 = 2·3², F 7 = 2403 = 3³·89)",
+      "infinitely_many_nine_safe (theorem): for every N there is n>N (a multiple of 9) with 9∤n⁴+2"
+    ],
+    "axiomCount": 0,
+    "lineCount": 123,
+    "assumptions": "0 axioms, 0 sorries. All decide calls reduce inside the Lean kernel over the finite ring ZMod 9 (no native_decide, no Lean.ofReduceBool). Only the foundational axioms propext / Classical.choice / Quot.sound are used.",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**Erdős Problem #978, the n⁴ + 2 squarefree question (OPEN).**\n\nErdős asked whether the irreducible quartic n⁴ + 2 takes infinitely many squarefree values. This is the k = 4, (k−2)-power-free case of #978. It lies *below* the threshold k ≥ 9 reached by Heath-Brown (2006) and Browning (2011), and the squarefree square-sieve for a quartic is beyond current technology. Hooley (1967) only gives the (k−1) = cubefree result (the axiom `n4_plus_2_cubefree` in the parent file). The conjecture itself is therefore not a Lean target.\n\nWhat *is* finite and verifiable is the local input to the standard squarefree heuristic, which predicts a positive density C = ∏ₚ (1 − ρ(p²)/p²) > 0 of squarefree values. This entry formalizes the two pieces of that local picture that can be settled unconditionally.",
+    "problemStatement": "**Setting.** Write F(n) = n⁴ + 2 and ρ(m) = #{ n mod m : m ∣ F(n) }. The squarefree heuristic predicts a positive density of squarefree values of F precisely when (a) no fixed square divides every value and (b) each prime square p² leaves a positive proportion of safe residues.\n\n**Formalized here (0-axiom):**\n1. **No fixed square obstruction:** for every m > 1, some value F(n) is not divisible by m².\n2. **Dominant prime p = 3:** 9 ∣ F(n) ⟺ n ≡ 2 or 7 (mod 9); exactly 2 of the 9 residues are obstructed, so 7/9 are safe, and infinitely many n have 9 ∤ F(n).",
+    "text": "The open conjecture that n⁴+2 is squarefree infinitely often rests on finite local conditions. This entry proves, 0-axiom, that no fixed square divides every value (n=0 gives 2) and that the dominant local obstruction at p=3 is fully explicit: 9∣n⁴+2 iff n≡2,7 (mod 9), leaving 7 of 9 residues safe and infinitely many escaping values.",
+    "proofStrategy": "**1. No fixed square (no_fixed_square_obstruction).** Evaluate at n = 0: F(0) = 2. If m² ∣ 2 then `Int.le_of_dvd` forces m² ≤ 2; but m > 1 gives m ≥ 2, so m² ≥ 4 — contradiction (`nlinarith`). Hence no global square obstruction, ruling out the trivial negative answer and giving ρ(p²) < p² for every prime p.\n\n**2. Residue characterization (zmod_nine_root_iff).** Over the finite ring ZMod 9, the equation n⁴+2 = 0 is settled by `decide +revert`: its roots are exactly 2 and 7.\n\n**3. Lift to ℤ (nine_dvd_iff).** `ZMod.intCast_zmod_eq_zero_iff_dvd` turns 9 ∣ F(n) into (F(n) : ZMod 9) = 0; `push_cast` reduces this to the ZMod 9 equation, yielding 9 ∣ n⁴+2 ⟺ n ≡ 2,7 (mod 9).\n\n**4. Counting and infinitude.** `decide` over ZMod 9 gives ρ(9) = 2 (obstructed_card) and 7 safe residues (safe_card). For infinitude, any multiple of 9 has residue 0 ∉ {2,7}, so n = 9(|N|+1) > N escapes (infinitely_many_nine_safe).",
+    "keyInsights": [
+      "**Local input to a global heuristic:** the open squarefree conjecture cannot be proved, but its necessary local conditions are finite and fully verifiable.",
+      "**The cheapest obstruction-killer:** F(0) = 2 alone rules out any fixed square dividing all values — m² ∣ 2 is impossible for m ≥ 2.",
+      "**p = 3 is the leading term:** 9 ∣ n⁴+2 happens on exactly 2 of 9 residues; the safe proportion 7/9 > 0 is exactly what the density product needs at the dominant prime.",
+      "**Kernel-checked, not native:** every finite check is `decide` over ZMod 9, reducing inside the kernel — 0 axioms, no Lean.ofReduceBool.",
+      "**Honest scope:** this formalizes the local structure, not the (open) analytic conjecture, which needs a large-prime square-sieve beyond Mathlib and beyond current number theory for k = 4."
+    ],
+    "prerequisites": [
+      "Modular arithmetic over ZMod n",
+      "Integer divisibility and the cast bridge ZMod ↔ ℤ",
+      "Squarefree / power-free numbers and local density heuristics"
+    ]
+  },
+  "sections": [
+    {
+      "id": "no-fixed-square",
+      "title": "No Fixed Square Obstruction",
+      "summary": "For every m>1 some value n⁴+2 is not divisible by m² (witness n=0, value 2); ρ(p²)<p² for all primes p.",
+      "startLine": 49,
+      "endLine": 69,
+      "mathContext": "no_fixed_square_obstruction: m² ∣ 2 forces m² ≤ 2 < 4, contradicting m ≥ 2."
+    },
+    {
+      "id": "p3-obstruction",
+      "title": "The Dominant Local Obstruction at p = 3",
+      "summary": "9 ∣ n⁴+2 iff n≡2,7 (mod 9); ρ(9)=2, 7 of 9 residues safe; obstruction non-vacuous (F 2=18, F 7=2403).",
+      "startLine": 71,
+      "endLine": 103,
+      "mathContext": "zmod_nine_root_iff (decide over ZMod 9) lifted via ZMod.intCast_zmod_eq_zero_iff_dvd; obstructed_card/safe_card = 2/7."
+    },
+    {
+      "id": "infinitude",
+      "title": "Infinitely Many Values Avoid the p = 3 Square",
+      "summary": "Every multiple of 9 has safe residue 0; n=9(|N|+1)>N gives infinitely many n with 9∤n⁴+2.",
+      "startLine": 105,
+      "endLine": 123,
+      "mathContext": "infinitely_many_nine_safe: residue 0 ∉ {2,7}, dvd_mul_right plus the cast bridge."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #978's n⁴+2 squarefree conjecture is open and beyond current methods, but its local input is finite and verifiable. This entry establishes, 0-axiom and kernel-checked, that (1) no fixed square divides every value of n⁴+2 (the value at n=0 is 2), and (2) the dominant local obstruction at p=3 is fully explicit: 9 ∣ n⁴+2 iff n ≡ 2,7 (mod 9), so exactly 2 of 9 residues are obstructed, 7 are safe, and infinitely many n escape the 3²-obstruction.",
+    "implications": "**Significance.** These are exactly the local conditions underlying the squarefree-sieve heuristic C = ∏ₚ (1 − ρ(p²)/p²) > 0 that predicts a positive density of squarefree values. Killing the global square obstruction and pinning the dominant prime p=3 turn the qualitative heuristic into verified arithmetic at its leading term, while honestly leaving the open analytic problem (the large-prime square-sieve for a quartic) untouched.",
+    "openQuestions": [
+      "Does n⁴ + 2 represent infinitely many squarefree numbers? (the OPEN conjecture)",
+      "Formalize ρ(p²) ≤ 4 (the degree-4 root bound) for the contributing primes p ∈ {3,11,19,43,…}",
+      "Formalize convergence/positivity of the full local density product ∏ₚ (1 − ρ(p²)/p²)",
+      "Explicit residue characterizations at the next contributing primes (p=11, p=19)"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.ZMod.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos978OQ01",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos978OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-978",
+      "relationship": "specializes",
+      "description": "Parent problem: Erdős #978 power-free values of polynomials; this entry formalizes the local structure of the open n⁴+2 squarefree case."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #978 OQ-01 — Local square-obstruction structure of n⁴ + 2

**Parent:** Erdős Problem #978 (`Proofs/Erdos978Problem.lean`), the open question of whether n⁴ + 2 is squarefree infinitely often.

### The open problem
Erdős asked whether the quartic n⁴ + 2 takes infinitely many squarefree values (the k = 4, (k−2)-power-free case). This is **OPEN**: it lies below the threshold k ≥ 9 of Heath-Brown (2006) / Browning (2011), and the squarefree square-sieve for a quartic is beyond current technology. The conjecture itself is not a Lean target.

### What this contributes (0-axiom, kernel-checked)
The standard squarefree heuristic predicts a positive density `C = ∏ₚ (1 − ρ(p²)/p²) > 0` of squarefree values. The two local inputs that are finite and verifiable are formalized here:

1. **No fixed square obstruction** (`no_fixed_square_obstruction`): for every `m > 1`, some value `n⁴+2` is not divisible by `m²`. Witness `n = 0`, value `2`; `m² ∣ 2` forces `m² ≤ 2 < 4`. This closes the trivial "never squarefree" route and gives `ρ(p²) < p²` for every prime.

2. **The dominant local obstruction at p = 3 is fully explicit**:
   - `zmod_nine_root_iff`: over `ZMod 9`, `n⁴+2 = 0 ⟺ n = 2 ∨ n = 7` (`decide +revert`).
   - `nine_dvd_iff`: lifted to ℤ, `9 ∣ n⁴+2 ⟺ n ≡ 2,7 (mod 9)`.
   - `obstructed_card` / `safe_card`: exactly **2 of 9** residues obstructed (ρ(9)=2), **7 safe** — the positive proportion the heuristic needs at the leading prime.
   - `nine_dvd_F_two`, `nine_dvd_F_seven`: non-vacuous (F 2 = 18 = 2·3², F 7 = 2403 = 3³·89).
   - `infinitely_many_nine_safe`: every multiple of 9 escapes, so infinitely many `n` have `9 ∤ n⁴+2`.

### Verification
- `./proofs/scripts/docker-build.sh Proofs.Erdos978OQ01` — builds clean.
- `#print axioms` on all 8 theorems: only `propext`, `Classical.choice`, `Quot.sound`. **No `sorryAx`, no `Lean.ofReduceBool`** (no `native_decide`; all `decide` reduces in-kernel over the finite ring `ZMod 9`).
- 123 lines, 1 def, 8 theorems, **0 axioms, 0 sorries**.

### Honest scope
This formalizes the *local* structure underlying the heuristic at the dominant prime; it does **not** resolve the open analytic conjecture (which needs a large-prime square-sieve beyond Mathlib and beyond current methods for k = 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)