### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-03): p-group Galois → power-of-p degree criterion (general prime) [0-axiom verified]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ03.lean
@@ -1,0 +1,81 @@
+/-
+  Angle Trisection - OQ-02 / sub-01 / sub-03:
+  The p-group Galois → power-of-p degree criterion (general prime)
+
+  The parent `AngleTrisectionOQ02OQ01` proves, for the prime `2`, that a
+  2-group Galois group forces the minimal-polynomial degree to be a power
+  of 2 — the algebraic core of the impossibility of angle trisection.
+
+  The argument never used anything special about `2`: it rests only on
+  `natDegree ∣ |Gal|` together with `IsPGroup.iff_card`.  This file lifts
+  the result to an **arbitrary prime `p`**:
+
+      Gal(minpoly ℚ α) is a p-group  ⟹  natDegree(minpoly ℚ α) = p^k,
+
+  and records the contrapositive non-constructibility criterion plus the
+  concrete degree-3 obstruction behind the 60° trisection (cos 20° has
+  minimal degree 3, which is not a power of 2).
+
+  Parent: AngleTrisectionOQ02OQ01.lean (natDegree_dvd_card_gal, reused here)
+-/
+
+import Mathlib
+import Proofs.AngleTrisectionOQ02OQ01
+
+open Polynomial AngleTrisectionOQ02OQ01
+
+namespace AngleTrisectionOQ02OQ01OQ03
+
+/-- **p-group Galois ⟹ degree divides a power of p.**
+    Generalizes `galois_2group_implies_degree_pow2` to any prime `p`:
+    `natDegree ∣ |Gal| = p^n`. -/
+theorem galois_pgroup_implies_degree_pow_p (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hGal : IsPGroup p (minpoly ℚ α).Gal) :
+    ∃ n : ℕ, (minpoly ℚ α).natDegree ∣ p ^ n := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have hirr := minpoly.irreducible hα
+  have hdvd := natDegree_dvd_card_gal hirr
+  obtain ⟨n, hn⟩ := IsPGroup.iff_card.mp hGal
+  exact ⟨n, hn ▸ hdvd⟩
+
+/-- **p-group Galois ⟹ degree IS a power of p.**
+    Strengthens the divisibility to an equality via `Nat.dvd_prime_pow`. -/
+theorem galois_pgroup_implies_degree_is_pow_p (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime) (hGal : IsPGroup p (minpoly ℚ α).Gal) :
+    ∃ k : ℕ, (minpoly ℚ α).natDegree = p ^ k := by
+  obtain ⟨n, hdvd⟩ := galois_pgroup_implies_degree_pow_p α hα hp hGal
+  obtain ⟨m, _, hm⟩ := (Nat.dvd_prime_pow hp).mp hdvd
+  exact ⟨m, hm⟩
+
+/-- **Non-constructibility criterion (contrapositive).**
+    If the minimal-polynomial degree of `α` is not a power of the prime `p`,
+    then `Gal(minpoly ℚ α)` is not a p-group. -/
+theorem not_pgroup_of_degree_ne_pow_p (α : ℝ) (hα : IsIntegral ℚ α)
+    {p : ℕ} (hp : p.Prime)
+    (h : ∀ k : ℕ, (minpoly ℚ α).natDegree ≠ p ^ k) :
+    ¬ IsPGroup p (minpoly ℚ α).Gal := by
+  intro hGal
+  obtain ⟨k, hk⟩ := galois_pgroup_implies_degree_is_pow_p α hα hp hGal
+  exact h k hk
+
+/-- **The degree-3 obstruction.**
+    An algebraic real whose minimal polynomial has degree `3` cannot have a
+    2-group Galois group — this is precisely the obstruction making the 60°
+    angle impossible to trisect (`cos 20°` has minimal degree `3`, and `3`
+    is not a power of `2`). -/
+theorem degree_three_not_2group (α : ℝ) (hα : IsIntegral ℚ α)
+    (h3 : (minpoly ℚ α).natDegree = 3) :
+    ¬ IsPGroup 2 (minpoly ℚ α).Gal := by
+  refine not_pgroup_of_degree_ne_pow_p α hα Nat.prime_two (fun k hk => ?_)
+  rw [h3] at hk
+  -- `3 = 2 ^ k` is impossible: `2^0 = 1`, `2^1 = 2`, and `2^k ≥ 4` for `k ≥ 2`.
+  have h2k : 2 ^ k ≠ 3 := by
+    rcases Nat.lt_or_ge k 2 with hlt | hge
+    · interval_cases k <;> decide
+    · have : 4 ≤ 2 ^ k := by
+        calc (4 : ℕ) = 2 ^ 2 := rfl
+          _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hge
+      omega
+  exact h2k hk.symm
+
+end AngleTrisectionOQ02OQ01OQ03

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-03.json
@@ -1,0 +1,36 @@
+{
+  "id": "angle-trisection-oq-02-oq-01-oq-03",
+  "name": "p-group Galois → power-of-p degree criterion (general prime)",
+  "parentId": "angle-trisection-oq-02-oq-01",
+  "status": "in-progress",
+  "knowledge": {
+    "score": 10,
+    "insights": [
+      "The parent OQ-02-OQ-01 proves, for the prime 2, that a 2-group Galois group forces the minimal-polynomial degree to be a power of 2 — the algebraic core of the impossibility of angle trisection. The argument never used anything special about 2: it rests only on natDegree ∣ |Gal| (natDegree_dvd_card_gal) plus IsPGroup.iff_card.",
+      "This child lifts the result to an ARBITRARY prime p: Gal(minpoly ℚ α) a p-group ⟹ natDegree = p^k. Divisibility natDegree ∣ p^n is upgraded to equality via Nat.dvd_prime_pow.",
+      "IsPGroup.iff_card requires [Fact p.Prime] [Finite G] — supplied via haveI : Fact p.Prime := ⟨hp⟩; the Gal group's Finite instance is automatic (separable polynomial over CharZero).",
+      "Contrapositive non-constructibility criterion: if natDegree is not a power of p, Gal is not a p-group.",
+      "Concrete degree-3 obstruction: a real with minimal degree 3 has no 2-group Galois group (3 ≠ 2^k for all k), precisely why the 60° angle cannot be trisected (cos 20° has minimal degree 3)."
+    ],
+    "builtItems": [
+      "AngleTrisectionOQ02OQ01OQ03.lean: 4 theorems, 0 axioms, 0 sorries, reuses parent natDegree_dvd_card_gal.",
+      "galois_pgroup_implies_degree_pow_p: p-group Gal ⟹ natDegree ∣ p^n.",
+      "galois_pgroup_implies_degree_is_pow_p: p-group Gal ⟹ natDegree = p^k.",
+      "not_pgroup_of_degree_ne_pow_p: degree not a power of p ⟹ Gal not a p-group.",
+      "degree_three_not_2group: minimal degree 3 ⟹ not a 2-group (the trisection obstruction)."
+    ],
+    "progressSummary": "Child of angle-trisection-oq-02-oq-01 (Galois → degree criterion). The parent handles the prime 2; this entry generalizes to an arbitrary prime p — p-group Galois group ⟹ minimal-polynomial degree is a power of p — together with the contrapositive non-constructibility criterion and the concrete degree-3 (cos 20°) obstruction behind the impossibility of trisecting 60°. All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide.",
+    "nextSteps": [
+      "Instantiate degree_three_not_2group at α = cos 20° using the cluster's cos20 minimal-polynomial degree result to obtain a fully concrete non-trisectability corollary.",
+      "Mirror the criterion at the field-degree / finrank level (not just minpoly natDegree) to align with IsConstructibleFromQ.",
+      "Generalize to the converse direction (degree a power of p does not by itself force a p-group) to clarify the gap between necessary and sufficient conditions."
+    ]
+  },
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-02",
+    "angle-trisection-oq-02-oq-01",
+    "angle-trisection-oq-02-oq-01-oq-01",
+    "angle-trisection-oq-02-oq-01-oq-02"
+  ]
+}


### PR DESCRIPTION
## Summary

Child of `angle-trisection-oq-02-oq-01` (Galois group → degree criterion). The parent proves, **for the prime 2**, that a 2-group Galois group forces the minimal-polynomial degree to be a power of 2 — the algebraic core of the impossibility of angle trisection. That argument never used anything special about 2: it rests only on `natDegree ∣ |Gal|` (`natDegree_dvd_card_gal`) together with `IsPGroup.iff_card`.

This PR lifts it to an **arbitrary prime $p$**.

## New theorems (all 0-axiom verified)

| Theorem | Statement |
|---|---|
| `galois_pgroup_implies_degree_pow_p` | p-group $\mathrm{Gal} \Rightarrow \deg \mid p^n$ |
| `galois_pgroup_implies_degree_is_pow_p` | p-group $\mathrm{Gal} \Rightarrow \deg = p^k$ (via `Nat.dvd_prime_pow`) |
| `not_pgroup_of_degree_ne_pow_p` | $\deg$ not a power of $p \Rightarrow \mathrm{Gal}$ not a p-group (non-constructibility criterion) |
| `degree_three_not_2group` | minimal degree $3 \Rightarrow$ not a 2-group — the concrete $60°$ trisection obstruction (`cos 20°` has degree 3) |

## Verification

- Docker build: **0 errors**, no `sorry`, first-try
- `#print axioms` = `[propext, Classical.choice, Quot.sound]` only ⇒ **0-axiom verified**, no `native_decide`
- Reuses the parent's `natDegree_dvd_card_gal` directly (`import Proofs.AngleTrisectionOQ02OQ01`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)