### PR TITLE
research(erdos-882-oq-03-oq-01): a valid subset-sum set is an antichain, and no element divides its total [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos882ProblemOQ03OQ01.lean
+++ b/proofs/Proofs/Erdos882ProblemOQ03OQ01.lean
@@ -1,0 +1,128 @@
+/-
+# Erdős Problem #882 — OQ-03-OQ-01: A valid set is an antichain, and no element divides its total
+
+Erdős Problem #882 asks for the largest `A ⊆ {1,…,n}` whose non-empty subset
+sums are pairwise non-dividing (answer: `(1+o(1)) log₂ n`).  The sibling file
+`Erdos882ProblemOQ03` establishes that the predicate `ValidSubset` is *downward
+closed* (any subset of a valid set is valid).  That file works "downward" along
+the subset lattice; this one works in the orthogonal direction, extracting
+structure of `A` itself from the constraint on its subset sums.
+
+The pivot is the singleton embedding `A ⊆ subsetSums A`: every element `a ∈ A`
+appears verbatim as the subset sum of `{a}`.  Two structural consequences fall
+out, both fully machine-checked (0 axioms, 0 sorries):
+
+  * `validSubset_antichain`        — **a valid set is itself divisibility-free**:
+    the hypothesis only constrains *subset sums*, yet it forces the underlying
+    set `A` to be an antichain under divisibility (its elements pairwise do not
+    divide one another).
+  * `validSubset_elem_not_dvd_sum` — **no element of a valid set divides the
+    grand total** `∑ A` (whenever `A` has at least two elements): the element is
+    a singleton subset sum, the total is the full subset sum, the two are
+    distinct (the element is strictly smaller, since the others are positive),
+    so the divisibility-free condition applies.
+
+Both are genuine constraints the optimization problem imposes "for free" on its
+admissible sets, complementing the downward-closure monotonicity used by the
+upper-bound argument.
+
+Self-contained: the four predicates are re-declared here using the modern
+Finset API (the original parent file predates the current Mathlib toolchain and
+no longer builds), so this contribution stands on its own.
+
+Reference: Erdős Problem #882, https://erdosproblems.com/882
+-/
+
+import Mathlib
+
+namespace Erdos882OQ03OQ01
+
+open Finset BigOperators
+
+/-- All non-empty subsets of a finite set. -/
+def nonemptySubsets (A : Finset ℕ) : Finset (Finset ℕ) :=
+  A.powerset.filter (· ≠ ∅)
+
+/-- The set of all non-empty subset sums `{∑_{a ∈ S} a : ∅ ≠ S ⊆ A}`. -/
+def subsetSums (A : Finset ℕ) : Finset ℕ :=
+  (nonemptySubsets A).image (fun S => S.sum id)
+
+/-- No two distinct elements of a set divide each other. -/
+def DivisibilityFree (S : Finset ℕ) : Prop :=
+  ∀ a ∈ S, ∀ b ∈ S, a ≠ b → ¬(a ∣ b) ∧ ¬(b ∣ a)
+
+/-- `A` is a valid subset of `{1,…,n}` with divisibility-free subset sums. -/
+def ValidSubset (n : ℕ) (A : Finset ℕ) : Prop :=
+  (∀ a ∈ A, 1 ≤ a ∧ a ≤ n) ∧ DivisibilityFree (subsetSums A)
+
+/-- Every element of `A` is a subset sum of `A`: it is the sum of the
+    singleton `{a}`. -/
+theorem self_mem_subsetSums {A : Finset ℕ} {a : ℕ} (ha : a ∈ A) :
+    a ∈ subsetSums A := by
+  unfold subsetSums nonemptySubsets
+  rw [Finset.mem_image]
+  refine ⟨{a}, ?_, by simp⟩
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨Finset.singleton_subset_iff.mpr ha, Finset.singleton_ne_empty a⟩
+
+/-- The singleton embedding `A ⊆ subsetSums A`. -/
+theorem subset_subsetSums (A : Finset ℕ) : A ⊆ subsetSums A :=
+  fun _ ha => self_mem_subsetSums ha
+
+/-- The total sum `∑ A` is a subset sum of any non-empty `A` (the sum of the
+    full set `A` itself). -/
+theorem total_mem_subsetSums {A : Finset ℕ} (hA : A.Nonempty) :
+    A.sum id ∈ subsetSums A := by
+  unfold subsetSums nonemptySubsets
+  rw [Finset.mem_image]
+  refine ⟨A, ?_, rfl⟩
+  rw [Finset.mem_filter, Finset.mem_powerset]
+  exact ⟨Finset.Subset.refl A, Finset.nonempty_iff_ne_empty.mp hA⟩
+
+/-- **A valid set is itself divisibility-free.**  The hypothesis only constrains
+    the *subset sums*, but since each element appears as a singleton subset sum,
+    divisibility-freeness of `subsetSums A` restricts to `A`.  In particular the
+    elements of an extremal admissible set already form an antichain under
+    divisibility. -/
+theorem validSubset_antichain {n : ℕ} {A : Finset ℕ} (hA : ValidSubset n A) :
+    DivisibilityFree A :=
+  fun a ha b hb hab =>
+    hA.2 a (self_mem_subsetSums ha) b (self_mem_subsetSums hb) hab
+
+/-- Direct corollary: distinct elements of a valid set never divide one
+    another. -/
+theorem validSubset_not_dvd {n : ℕ} {A : Finset ℕ} (hA : ValidSubset n A)
+    {a b : ℕ} (ha : a ∈ A) (hb : b ∈ A) (hab : a ≠ b) : ¬(a ∣ b) :=
+  (validSubset_antichain hA a ha b hb hab).1
+
+/-- In a valid set with at least two elements, every element is strictly smaller
+    than the grand total `∑ A`: the remaining elements are positive, so they
+    contribute a positive amount on top of `a`. -/
+theorem elem_lt_sum {n : ℕ} {A : Finset ℕ} (hA : ValidSubset n A)
+    (hcard : 1 < A.card) {a : ℕ} (ha : a ∈ A) : a < A.sum id := by
+  -- pick a second element `b ≠ a`
+  obtain ⟨b, hb, hba⟩ := Finset.exists_mem_ne hcard a
+  have hbpos : 1 ≤ b := (hA.1 b hb).1
+  have hb_erase : b ∈ A.erase a := Finset.mem_erase.mpr ⟨hba, hb⟩
+  -- the others sum to at least `b ≥ 1`
+  have herase : 1 ≤ (A.erase a).sum id :=
+    le_trans hbpos (Finset.single_le_sum (fun i _ => Nat.zero_le (id i)) hb_erase)
+  -- `∑ A = a + ∑ (A \ {a})`
+  have hsplit : id a + (A.erase a).sum id = A.sum id := Finset.add_sum_erase A id ha
+  rw [id_eq] at hsplit
+  rw [← hsplit]
+  omega
+
+/-- **No element of a valid set divides the grand total.**  For a valid set with
+    at least two elements, an element `a` is a singleton subset sum and the total
+    `∑ A` is the full subset sum; since `a < ∑ A` they are distinct, so the
+    divisibility-free condition forbids `a ∣ ∑ A`. -/
+theorem validSubset_elem_not_dvd_sum {n : ℕ} {A : Finset ℕ}
+    (hA : ValidSubset n A) (hcard : 1 < A.card) {a : ℕ} (ha : a ∈ A) :
+    ¬(a ∣ A.sum id) := by
+  have hne : a ≠ A.sum id := ne_of_lt (elem_lt_sum hA hcard ha)
+  have hAne : A.Nonempty := ⟨a, ha⟩
+  exact (hA.2 a (self_mem_subsetSums ha) (A.sum id)
+    (total_mem_subsetSums hAne) hne).1
+
+end Erdos882OQ03OQ01

--- a/src/data/research/problems/erdos-882-oq-03-oq-01.json
+++ b/src/data/research/problems/erdos-882-oq-03-oq-01.json
@@ -1,0 +1,31 @@
+{
+  "id": "erdos-882-oq-03-oq-01",
+  "name": "A valid subset-sum set is an antichain, and no element divides its total",
+  "parentId": "erdos-882-oq-03",
+  "status": "completed",
+  "knowledge": {
+    "score": 9,
+    "insights": [
+      "Erdős #882: largest A ⊆ {1,…,n} whose non-empty subset sums are pairwise non-dividing (answer (1+o(1))log₂ n). The sibling oq-03 shows ValidSubset is downward closed (subset-lattice direction). This child works the orthogonal direction: it extracts structure of A itself from the constraint on its subset sums.",
+      "Pivot = the singleton embedding A ⊆ subsetSums A: every a ∈ A appears verbatim as the subset sum of {a} (self_mem_subsetSums). The hypothesis constrains only subset sums, yet via singletons it descends to A.",
+      "Headline validSubset_antichain: a valid set is ITSELF divisibility-free. The elements of an admissible (in particular extremal) set already form an antichain under divisibility — a 'free' necessary condition, immediate from DivisibilityFree(subsetSums A) restricted along A ⊆ subsetSums A.",
+      "Headline validSubset_elem_not_dvd_sum: when |A| ≥ 2, no element a ∈ A divides the grand total ∑A. Proof: a is a singleton subset sum, ∑A is the full subset sum, and a < ∑A strictly (the remaining ≥1 elements are positive, elem_lt_sum via Finset.add_sum_erase + single_le_sum), so the two are distinct subset sums and the divisibility-free condition forbids a ∣ ∑A.",
+      "Both results are genuine necessary conditions the optimization imposes on its feasible sets, complementing the downward-closure monotonicity (oq-03) used by the upper bound."
+    ],
+    "builtItems": [
+      "Erdos882ProblemOQ03OQ01.lean: 4 defs + 6 theorems, 0 axioms, 0 sorries, self-contained.",
+      "self_mem_subsetSums (a ∈ A ⟹ a ∈ subsetSums A via singleton), subset_subsetSums (A ⊆ subsetSums A), total_mem_subsetSums (∑A is a subset sum).",
+      "validSubset_antichain (ValidSubset n A ⟹ DivisibilityFree A), validSubset_not_dvd (distinct elements never divide), elem_lt_sum (a < ∑A for |A| ≥ 2), validSubset_elem_not_dvd_sum (no element divides the total)."
+    ],
+    "progressSummary": "COMPLETE. Child of erdos-882-oq-03 (structural theory). Where oq-03 proves the downward closure of ValidSubset, this entry extracts structure of A itself: via the singleton embedding A ⊆ subsetSums A, a valid set is forced to be an antichain under divisibility (validSubset_antichain), and — for |A| ≥ 2 — no element divides the grand total ∑A (validSubset_elem_not_dvd_sum). All 0-axiom verified (#print axioms = propext/Classical.choice/Quot.sound only), no native_decide. Self-contained re-declaration of the four predicates (parent Erdos882Problem.lean no longer builds on the current Mathlib).",
+    "nextSteps": [
+      "Generalize elem_not_dvd: for disjoint nonempty S,T ⊆ A with ∑S < ∑T, the divisibility-free condition forbids ∑S ∣ ∑T — the antichain/total results are the singleton/full special cases.",
+      "Combine with downward closure: a valid set is a divisibility-free antichain all of whose subset sums are pairwise non-dividing, a layered structural picture of the feasible region.",
+      "Quantify: bound how large an antichain in {1,…,n} can have the stronger subset-sum property, connecting back to the (1+o(1))log₂ n answer."
+    ]
+  },
+  "relatedProofs": [
+    "erdos-882",
+    "erdos-882-oq-03"
+  ]
+}


### PR DESCRIPTION
## Summary

Child of `erdos-882-oq-03` (structural theory of valid subset-sum sets). Erdős Problem #882 asks for the largest `A ⊆ {1,…,n}` whose non-empty subset sums are pairwise non-dividing (answer `(1+o(1)) log₂ n`).

Where the sibling `oq-03` proves `ValidSubset` is **downward closed** (subset-lattice direction), this entry works the orthogonal direction — extracting structure of `A` *itself* from the constraint on its subset sums. The pivot is the singleton embedding `A ⊆ subsetSums A`: every element appears verbatim as the subset sum of its own singleton.

### Results (4 defs + 6 theorems, self-contained)

- `self_mem_subsetSums` / `subset_subsetSums` — `A ⊆ subsetSums A` (singleton embedding); `total_mem_subsetSums` — `∑A` is a subset sum.
- **`validSubset_antichain`** — a valid set is **itself divisibility-free**: the hypothesis constrains only subset sums, yet it forces `A` to be an antichain under divisibility. `validSubset_not_dvd` is the pairwise corollary.
- **`validSubset_elem_not_dvd_sum`** — for `|A| ≥ 2`, **no element divides the grand total** `∑A`. The element is a singleton subset sum strictly below the full subset sum (`elem_lt_sum`, via `Finset.add_sum_erase` + `single_le_sum`), so the divisibility-free condition forbids divisibility.

Both are genuine necessary conditions the optimization imposes on its feasible sets, complementing the downward-closure monotonicity used by the upper bound.

### Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos882ProblemOQ03OQ01` — builds clean.
- `#print axioms` on all main results = `[propext, Classical.choice, Quot.sound]` only. **0 axioms, 0 sorries, no native_decide.**
- Self-contained re-declaration of the four predicates (the parent `Erdos882Problem.lean` no longer builds on the current Mathlib toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)