### PR TITLE
research(roth-theorem-k3-oq-03-oq-01-oq-01): Multilinearity of the k-AP counting operator Λ_k [0-axiom verified]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01OQ01.lean
@@ -1,0 +1,88 @@
+/-
+Roth/Szemerédi — OQ-03-OQ-01-OQ-01: Multilinearity of the k-AP counting operator Λ_k
+
+Source: open question of the roth-theorem-k3 gallery (Gowers norms, OQ-03)
+Parent: Proofs/RothTheoremOQ03OQ01.lean  (defines Λ_k = kAPCount and the Gowers norm,
+        proves the constant/normalization/annihilation identities)
+
+## What this adds
+
+The parent file builds the k-AP counting operator
+
+  Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏_{i<k} fᵢ(x + i·d)
+
+and proves Λ_k(c,…,c) = cᵏ, Λ_k(1,…,1) = 1, and that a zero slot annihilates the
+count. The single most important *structural* fact, however — the one that powers the
+generalized von Neumann inequality and every density-increment argument in the
+Roth/Szemerédi circle — is that **Λ_k is multilinear**: it is additive and homogeneous
+in each of its k arguments separately.
+
+This file imports the parent operator and proves exactly that, 0-axiom:
+
+* `prod_update_factor` — pull the j-th factor out of the k-AP product (the engine);
+* `kAPCount_add_slot`   — additivity in slot j: Λ_k(…, a+b, …) = Λ_k(…,a,…) + Λ_k(…,b,…);
+* `kAPCount_smul_slot`  — homogeneity in slot j: Λ_k(…, c•a, …) = c · Λ_k(…,a,…);
+* `gowersNorm_nonneg`   — the Gowers norm is nonnegative (it is a genuine modulus).
+
+Slots are addressed with `Function.update`, so "the tuple `f` with its j-th entry
+replaced by `v`" is `Function.update f j v`. All results are machine-checked with only
+the foundational axioms (`propext`/`Classical.choice`/`Quot.sound`), no `native_decide`.
+-/
+import Proofs.RothTheoremOQ03OQ01
+
+open Finset BigOperators
+
+namespace RothTheoremOQ03OQ01
+
+variable {N : ℕ} [NeZero N]
+
+/-- **The factorization engine.** Replacing slot `j` of the tuple by `v` pulls the
+`j`-th factor `v(x + j·d)` clean out of the `k`-AP product, leaving the product of the
+untouched factors over the remaining indices. -/
+theorem prod_update_factor (k : ℕ) (f : Fin k → ZMod N → ℂ) (j : Fin k)
+    (v : ZMod N → ℂ) (x d : ZMod N) :
+    (∏ i : Fin k, Function.update f j v i (x + i.val • d))
+      = v (x + j.val • d) * ∏ i ∈ univ.erase j, f i (x + i.val • d) := by
+  rw [← Finset.mul_prod_erase univ
+        (fun i => Function.update f j v i (x + i.val • d)) (mem_univ j)]
+  congr 1
+  · rw [Function.update_self]
+  · refine Finset.prod_congr rfl (fun i hi => ?_)
+    rw [Function.update_of_ne (Finset.ne_of_mem_erase hi)]
+
+/-- **Additivity in a slot.** `Λ_k` is additive in its `j`-th argument:
+`Λ_k(…, a + b, …) = Λ_k(…, a, …) + Λ_k(…, b, …)`. -/
+theorem kAPCount_add_slot (k : ℕ) (f : Fin k → ZMod N → ℂ) (j : Fin k)
+    (a b : ZMod N → ℂ) :
+    kAPCount k (Function.update f j (a + b))
+      = kAPCount k (Function.update f j a) + kAPCount k (Function.update f j b) := by
+  unfold kAPCount
+  simp only [prod_update_factor, Pi.add_apply, add_mul]
+  rw [← mul_add]
+  congr 1
+  rw [← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl (fun x _ => ?_)
+  rw [← Finset.sum_add_distrib]
+
+/-- **Homogeneity in a slot.** `Λ_k` is homogeneous in its `j`-th argument:
+`Λ_k(…, c • a, …) = c · Λ_k(…, a, …)`. -/
+theorem kAPCount_smul_slot (k : ℕ) (f : Fin k → ZMod N → ℂ) (j : Fin k)
+    (c : ℂ) (a : ZMod N → ℂ) :
+    kAPCount k (Function.update f j (c • a)) = c * kAPCount k (Function.update f j a) := by
+  unfold kAPCount
+  simp only [prod_update_factor, Pi.smul_apply, smul_eq_mul]
+  rw [mul_left_comm]
+  congr 1
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun x _ => ?_)
+  rw [Finset.mul_sum]
+  refine Finset.sum_congr rfl (fun d _ => ?_)
+  ring
+
+/-- The Gowers `Uˢ` norm is nonnegative — it is defined as a genuine modulus `‖·‖`. -/
+theorem gowersNorm_nonneg (N s : ℕ) [NeZero N] (f : ZMod N → ℂ) :
+    0 ≤ gowersNorm N s f := by
+  unfold gowersNorm
+  exact norm_nonneg _
+
+end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
@@ -1,0 +1,131 @@
+{
+  "id": "roth-theorem-k3-oq-03-oq-01-oq-01",
+  "title": "Roth/Szemerédi OQ-03-OQ-01-OQ-01: Multilinearity of the k-AP Counting Operator Λ_k",
+  "slug": "roth-theorem-k3-oq-03-oq-01-oq-01",
+  "description": "The k-AP counting operator Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d) from the parent file is shown to be multilinear: additive (kAPCount_add_slot) and homogeneous (kAPCount_smul_slot) in each of its k arguments separately, via a factorization engine (prod_update_factor) that pulls one slot out of the k-AP product. Plus gowersNorm_nonneg. Multilinearity is the structural fact behind the generalized von Neumann inequality. 0-axiom verified.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gowers_norm",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RothTheoremOQ03OQ01OQ01.lean",
+    "tags": [
+      "roth-theorem",
+      "szemeredi",
+      "gowers-norm",
+      "additive-combinatorics",
+      "multilinear",
+      "counting-operator",
+      "ZMod"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.mul_prod_erase",
+        "description": "f a * ∏ x∈s.erase a, f x = ∏ x∈s, f x — isolate one factor of a finite product",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Function.update_self / Function.update_of_ne",
+        "description": "Evaluate Function.update at the updated index and elsewhere — addresses one slot of the tuple",
+        "module": "Mathlib.Logic.Function.Basic"
+      },
+      {
+        "theorem": "Finset.sum_add_distrib / Finset.mul_sum",
+        "description": "Distribute sums over addition and pull scalars through finite sums",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "prod_update_factor: replacing slot j by v pulls v(x+j·d) out of the k-AP product, leaving ∏_{i≠j} fᵢ(x+i·d) (the factorization engine)",
+      "kAPCount_add_slot: Λ_k is additive in slot j — Λ_k(…,a+b,…) = Λ_k(…,a,…) + Λ_k(…,b,…)",
+      "kAPCount_smul_slot: Λ_k is homogeneous in slot j — Λ_k(…,c•a,…) = c · Λ_k(…,a,…)",
+      "gowersNorm_nonneg: the Gowers Uˢ norm is ≥ 0 (it is a genuine modulus ‖·‖)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 88,
+    "assumptions": "0 axioms, 0 sorries. Only foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide. Imports the parent operator Proofs.RothTheoremOQ03OQ01.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**The counting operator and multilinearity.** In the Fourier-analytic and Gowers-norm approach to Roth's and Szemerédi's theorems, the central object is the normalized k-term arithmetic-progression count Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d). Density-increment and energy-increment arguments split an indicator 1_A as δ·1 + (1_A − δ) and expand Λ_k by **multilinearity**, controlling the error terms by Gowers norms (the generalized von Neumann inequality). The parent file defined Λ_k and the Gowers norm and proved the constant/normalization/annihilation identities; this entry supplies the structural property — multilinearity — that those expansions actually use.",
+    "problemStatement": "**Λ_k is multilinear.** With slots addressed by `Function.update` (so `Function.update f j v` is the tuple `f` with its j-th entry replaced by `v`):\n\n- **additive:** Λ_k(update f j (a+b)) = Λ_k(update f j a) + Λ_k(update f j b);\n- **homogeneous:** Λ_k(update f j (c•a)) = c · Λ_k(update f j a),\n\nfor every slot j. The proofs run off one factorization lemma that pulls the j-th factor out of the k-AP product. Also: the Gowers norm is nonnegative.",
+    "text": "The k-AP counting operator Λ_k from the parent file is shown to be multilinear — additive and homogeneous in each of its k arguments separately — via a factorization engine that isolates one slot of the k-AP product. Plus the Gowers norm is nonnegative. Multilinearity is the structural fact behind the generalized von Neumann inequality. 0-axiom verified.",
+    "proofStrategy": "**Engine (prod_update_factor).** `Finset.mul_prod_erase` isolates the j-th factor of `∏ i, (update f j v) i (x+i·d)`; `Function.update_self` evaluates it to `v(x+j·d)`, and `Function.update_of_ne` restores the untouched factors over `univ.erase j`.\n\n**Additivity.** Rewrite both sides with the engine; `Pi.add_apply` and `add_mul` split the j-th factor as `a(x+j·d)·P + b(x+j·d)·P`; `Finset.sum_add_distrib` (twice) and `mul_add` distribute the double average over the sum.\n\n**Homogeneity.** Same engine; `Pi.smul_apply`/`smul_eq_mul` turn the j-th factor into `c · a(x+j·d) · P`; `mul_left_comm` and `Finset.mul_sum` (twice) pull `c` out through the double average, closing with `ring`.\n\n**Gowers norm nonnegativity.** Immediate from `norm_nonneg`, since the norm is defined as a modulus `‖·‖`.",
+    "keyInsights": [
+      "**Multilinearity is the structural workhorse:** every density/energy-increment expansion of Λ_k over a decomposition 1_A = δ·1 + (1_A − δ) is an instance of additivity + homogeneity in one slot.",
+      "**One lemma does the work:** `prod_update_factor` isolates a single slot of the k-AP product; additivity and homogeneity are then bookkeeping over the double average E_{x,d}.",
+      "**Function.update is the right slot address:** it lets the statements quantify over 'the tuple with its j-th entry changed' without naming the other k−1 functions.",
+      "**The Gowers norm is a real norm:** nonnegativity is definitional, the first of the metric properties needed to use it as a control on the error terms."
+    ],
+    "prerequisites": [
+      "The parent operators: Λ_k = kAPCount and the Gowers norm (Proofs.RothTheoremOQ03OQ01)",
+      "Finite products/sums over Fin k and ZMod N, Function.update",
+      "Additive combinatorics: Gowers norms and the generalized von Neumann inequality (motivation)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "engine",
+      "title": "The Factorization Engine",
+      "summary": "prod_update_factor: replacing slot j by v pulls v(x+j·d) out of the k-AP product, leaving the untouched factors over univ.erase j.",
+      "startLine": 39,
+      "endLine": 53,
+      "mathContext": "Finset.mul_prod_erase + Function.update_self/update_of_ne isolate the j-th factor."
+    },
+    {
+      "id": "multilinear",
+      "title": "Multilinearity of Λ_k",
+      "summary": "kAPCount_add_slot (additive in slot j) and kAPCount_smul_slot (homogeneous in slot j).",
+      "startLine": 55,
+      "endLine": 81,
+      "mathContext": "Distribute the double average E_{x,d} over the split/scaled j-th factor (sum_add_distrib, mul_sum)."
+    },
+    {
+      "id": "norm",
+      "title": "Gowers Norm Nonnegativity",
+      "summary": "gowersNorm_nonneg: the Gowers Uˢ norm is ≥ 0, being a modulus ‖·‖.",
+      "startLine": 82,
+      "endLine": 88,
+      "mathContext": "Immediate from norm_nonneg."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the parent file's k-AP counting operator Λ_k and Gowers norm, this entry proves the structural property that those constructions exist to be used through: Λ_k is multilinear — additive (kAPCount_add_slot) and homogeneous (kAPCount_smul_slot) in each argument — established via a single factorization lemma (prod_update_factor) that isolates one slot of the k-AP product. It also records that the Gowers norm is nonnegative. All 0-axiom and machine-checked.",
+    "implications": "Multilinearity is exactly the algebraic identity invoked when one expands Λ_k(1_A,…,1_A) along a decomposition 1_A = δ·1 + g and bounds the cross terms by Gowers norms — the generalized von Neumann inequality at the heart of the density-increment proof of Roth/Szemerédi. With it verified, a Lean development of that inequality can cite these slot lemmas directly.",
+    "openQuestions": [
+      "Generalized von Neumann inequality: bound a multilinear Λ_k term with a non-trivial g-slot by ‖g‖_{U^{k-1}}",
+      "Conjugate-symmetry and positivity (‖f‖_{U^s} ≥ 0 as an s-fold average) of the Gowers norm",
+      "Translation-invariance of Λ_k and the k=3 (Roth) specialization Λ_3",
+      "Triangle inequality / genuine seminorm structure of the Gowers norm"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.RothTheoremOQ03OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "RothTheoremOQ03OQ01",
+    "lineCount": 88,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/RothTheoremOQ03OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "specializes",
+      "description": "Grandparent: Gowers norms and the k-AP counting operator for Roth's theorem."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Roth/Szemerédi OQ-03-OQ-01-OQ-01 — Multilinearity of the k-AP counting operator Λ_k

**Parent:** `Proofs/RothTheoremOQ03OQ01.lean` (defines `Λ_k = kAPCount` and the Gowers norm; proves the constant / normalization / annihilation identities). This entry **imports** that operator and adds its key structural property.

### Why this matters
`Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d)` is the central object of the Gowers-norm approach to Roth/Szemerédi. Density- and energy-increment arguments split an indicator `1_A = δ·1 + (1_A − δ)` and expand `Λ_k` by **multilinearity**, bounding the cross terms by Gowers norms — the generalized von Neumann inequality. Multilinearity is exactly the algebraic fact those expansions rely on, and the parent file did not have it.

### Contribution (0-axiom)
Slots are addressed with `Function.update`:

- **`prod_update_factor`** (engine) — replacing slot `j` by `v` pulls `v(x+j·d)` out of the k-AP product, leaving `∏_{i≠j} fᵢ(x+i·d)`.
- **`kAPCount_add_slot`** — additivity in slot `j`: `Λ_k(…,a+b,…) = Λ_k(…,a,…) + Λ_k(…,b,…)`.
- **`kAPCount_smul_slot`** — homogeneity in slot `j`: `Λ_k(…,c•a,…) = c · Λ_k(…,a,…)`.
- **`gowersNorm_nonneg`** — the Gowers `Uˢ` norm is `≥ 0` (it is a genuine modulus).

### Verification
- `./proofs/scripts/docker-build.sh Proofs.RothTheoremOQ03OQ01OQ01` — builds clean (7744 jobs).
- `#print axioms` on all 4 theorems: only `propext`, `Classical.choice`, `Quot.sound`. **No `sorryAx`, no `Lean.ofReduceBool`** (no `native_decide`).
- 88 lines, 4 theorems, **0 axioms, 0 sorries**.

### Scope
This proves the multilinearity identities; the generalized von Neumann inequality itself (bounding a Λ_k term by a Gowers norm) is the natural next step, listed in `openQuestions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)