### PR TITLE
research(erdos101-problem-oq-04-oq-01): a general-position arc has zero k-point lines for every k ≥ 3 [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos101OQ04OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ04OQ01.lean
@@ -1,0 +1,112 @@
+/-
+# Erdős Problem #101 — OQ-04-OQ-01: a general-position arc has zero k-point lines for every k ≥ 3
+
+Erdős Problem #101 concerns the maximum number of lines through exactly four
+points (`fourPointLineCount`) of a planar `n`-point set with no five collinear.
+The parent `Proofs/Erdos101OQ04` builds the **mod-`p` Grünbaum parabola**,
+realizes it in ℝ² as an explicit `p`-point arc (`realParabolaSet`), proves it
+has *no three collinear* points, and records — as the honest scope of the bare
+arc — that its `fourPointLineCount` is `0` (`realParabolaSet_fourPointLineCount_zero`):
+the Ω(p^{3/2}) four-point-line count must come from a sumset/grid construction
+*on top of* this general-position base, not from the arc itself.
+
+This child sharpens and uniformizes that observation.  The `fourPointLineCount`
+being `0` is the `k = 4` shadow of a single general-position fact: a set with no
+three collinear points has **no `k` points on a common line for any `k ≥ 3`**.
+We make this precise.
+
+  * `kPointLineCount P k` — the obvious `k`-parameterised generalization of the
+    gallery's `fourPointLineCount` (`fourPointLineCount = kPointLineCount · 4`,
+    `rfl`).
+  * `kPointLineCount_eq_zero_of_no_three_collinear` — **the reusable engine**: if
+    `P` has no three collinear points then `kPointLineCount P k = 0` for every
+    `k ≥ 3`.  Any `k`-set on a line through `a ≠ b` has `k ≥ 3 > 2` points, hence
+    a third point `c ∉ {a, b}`, and `a, b, c` are three distinct collinear points
+    — impossible.
+  * `realParabolaSet_kPointLineCount_zero` — the arc instance: the lifted
+    Grünbaum parabola has zero `k`-point lines for *every* `k ≥ 3`.
+  * `realParabolaSet_fourPointLineCount_zero'` — recovers the parent's headline
+    as the `k = 4` special case, now via the uniform certificate.
+
+The picture: an arc is "line-poor" at every scale `≥ 3` simultaneously; the
+four-point obstruction is not special, it is the general-position property read
+off at one value of `k`.
+
+Reference: Erdős Problem #101, https://erdosproblems.com/101
+-/
+
+import Proofs.Erdos101OQ04
+
+namespace Erdos101OQ04OQ01
+
+open Erdos101OQ04 Erdos101OQ04.Grunbaum Classical
+
+/-- `kPointLineCount P k` counts the `k`-element subsets of `P` that lie on a
+common line (witnessed by two distinct anchors `a ≠ b` with everything collinear
+with `a, b`).  For `k = 4` this is the gallery's `fourPointLineCount`. -/
+noncomputable def kPointLineCount (P : PlanarPointSet) (k : ℕ) : ℕ :=
+  (P.points.powerset.filter (fun S =>
+    S.card = k ∧
+    ∃ a b : ℝ × ℝ, a ∈ S ∧ b ∈ S ∧ a ≠ b ∧
+      ∀ p ∈ S, collinear a b p)).card
+
+/-- `kPointLineCount` at `k = 4` is exactly the gallery's `fourPointLineCount`
+(definitional). -/
+theorem fourPointLineCount_eq_kPointLineCount (P : PlanarPointSet) :
+    fourPointLineCount P = kPointLineCount P 4 := rfl
+
+/-- **General-position engine.**  If no three points of `P` are collinear, then
+for every `k ≥ 3` there are *no* `k` points on a common line: `kPointLineCount P k = 0`.
+
+The witnessing `k`-set on a line through `a ≠ b` has `k ≥ 3 > 2 = |{a, b}|`
+elements, so it contains a third point `c ∉ {a, b}`; then `a, b, c` are three
+distinct collinear points, contradicting the hypothesis. -/
+theorem kPointLineCount_eq_zero_of_no_three_collinear
+    (P : PlanarPointSet) {k : ℕ} (hk : 3 ≤ k)
+    (h3 : ∀ a b c : ℝ × ℝ, a ∈ P.points → b ∈ P.points → c ∈ P.points →
+      a ≠ b → a ≠ c → b ≠ c → ¬ collinear a b c) :
+    kPointLineCount P k = 0 := by
+  rw [kPointLineCount, Finset.card_eq_zero, Finset.filter_eq_empty_iff]
+  intro S hS
+  simp only [Finset.mem_powerset] at hS
+  rintro ⟨hScard, a, b, ha, hb, hab, hline⟩
+  -- `|S| = k ≥ 3 > 2`, so `S` is not contained in `{a, b}`: a third point exists.
+  have hthird : ∃ c ∈ S, c ∉ ({a, b} : Finset (ℝ × ℝ)) := by
+    by_contra hcon
+    push_neg at hcon
+    have hSsub : S ⊆ ({a, b} : Finset (ℝ × ℝ)) := fun x hx => hcon x hx
+    have hle := Finset.card_le_card hSsub
+    rw [hScard, Finset.card_pair hab] at hle
+    omega
+  obtain ⟨c, hcS, hcab⟩ := hthird
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hcab
+  push_neg at hcab
+  exact h3 a b c (hS ha) (hS hb) (hS hcS) hab
+    (fun h => hcab.1 h.symm) (fun h => hcab.2 h.symm) (hline c hcS)
+
+/-- **The lifted Grünbaum arc has zero `k`-point lines for every `k ≥ 3`.**
+The uniform general-position certificate: the bare parabola is line-poor at
+every scale `≥ 3`, not merely at `k = 4`. -/
+theorem realParabolaSet_kPointLineCount_zero (p : ℕ) [NeZero p] [Fact p.Prime]
+    (hp : p ≠ 2) {k : ℕ} (hk : 3 ≤ k) :
+    kPointLineCount (realParabolaSet p hp) k = 0 :=
+  kPointLineCount_eq_zero_of_no_three_collinear (realParabolaSet p hp) hk
+    (fun a b c hA hB hC hab hac hbc =>
+      realParabola_no_three_collinear p hp a b c hA hB hC hab hac hbc)
+
+/-- The parent's headline `realParabolaSet_fourPointLineCount_zero` recovered as
+the `k = 4` instance of the uniform certificate. -/
+theorem realParabolaSet_fourPointLineCount_zero' (p : ℕ) [NeZero p]
+    [Fact p.Prime] (hp : p ≠ 2) :
+    fourPointLineCount (realParabolaSet p hp) = 0 := by
+  rw [fourPointLineCount_eq_kPointLineCount]
+  exact realParabolaSet_kPointLineCount_zero p hp (by norm_num)
+
+/-- The three-point version: the arc has zero *triangles-on-a-line*, the
+defining general-position property stated as a count. -/
+theorem realParabolaSet_threePointLineCount_zero (p : ℕ) [NeZero p]
+    [Fact p.Prime] (hp : p ≠ 2) :
+    kPointLineCount (realParabolaSet p hp) 3 = 0 :=
+  realParabolaSet_kPointLineCount_zero p hp (le_refl 3)
+
+end Erdos101OQ04OQ01

--- a/src/data/research/problems/erdos101-problem-oq-04-oq-01.json
+++ b/src/data/research/problems/erdos101-problem-oq-04-oq-01.json
@@ -1,0 +1,31 @@
+{
+  "id": "erdos101-problem-oq-04-oq-01",
+  "name": "A general-position arc has zero k-point lines for every k ≥ 3",
+  "parentId": "erdos101-problem-oq-04",
+  "status": "completed",
+  "knowledge": {
+    "score": 9,
+    "insights": [
+      "Erdős #101 concerns the max number of lines through exactly four points (fourPointLineCount) of a planar n-set with no five collinear. Parent oq-04 builds the mod-p Grünbaum parabola, lifts it to ℝ² as an explicit p-point arc (realParabolaSet) with no three collinear, and records the honest scope: its fourPointLineCount = 0 (the Ω(p^{3/2}) count must come from a sumset/grid construction on top of the arc, not the arc itself).",
+      "This child sharpens and uniformizes that: fourPointLineCount = 0 is just the k = 4 shadow of a single general-position fact — a set with no three collinear has NO k points on a common line for ANY k ≥ 3.",
+      "kPointLineCount P k generalizes fourPointLineCount (same powerset-filter with S.card = k); fourPointLineCount = kPointLineCount · 4 holds by rfl (definitional).",
+      "Reusable engine kPointLineCount_eq_zero_of_no_three_collinear: no-three-collinear ⟹ kPointLineCount P k = 0 for all k ≥ 3. Proof mirrors the parent's k = 4 argument: a k-set on a line through a ≠ b has k ≥ 3 > 2 = |{a,b}| points, so a third point c ∉ {a,b} exists (Finset.card_pair + card_le_card + omega), and a,b,c distinct collinear contradicts the hypothesis.",
+      "realParabolaSet_kPointLineCount_zero applies the engine to the arc for every k ≥ 3; realParabolaSet_fourPointLineCount_zero' recovers the parent's headline as the k = 4 instance; realParabolaSet_threePointLineCount_zero is the k = 3 'no triangle on a line' certificate (the defining general-position property stated as a count)."
+    ],
+    "builtItems": [
+      "Erdos101OQ04OQ01.lean: 1 def + 5 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Imports Proofs.Erdos101OQ04 and reuses realParabola_no_three_collinear / realParabolaSet; does NOT inherit the parents' open-construction sorries (grunbaum / solymosi lower bounds).",
+      "kPointLineCount (k-parameterised generalization of fourPointLineCount), fourPointLineCount_eq_kPointLineCount (rfl bridge).",
+      "kPointLineCount_eq_zero_of_no_three_collinear (general engine), realParabolaSet_kPointLineCount_zero (arc, all k ≥ 3), realParabolaSet_fourPointLineCount_zero' (k = 4 recovery), realParabolaSet_threePointLineCount_zero (k = 3)."
+    ],
+    "progressSummary": "COMPLETE. Child of erdos101-problem-oq-04. The parent records realParabolaSet_fourPointLineCount_zero (the lifted Grünbaum arc has no four points on a line). This entry shows that is the k = 4 case of a uniform certificate: a general-position set (no three collinear) has zero k-point lines for EVERY k ≥ 3 (kPointLineCount_eq_zero_of_no_three_collinear), applied to the arc (realParabolaSet_kPointLineCount_zero) and recovering the parent headline (fourPointLineCount_zero'). All 0-axiom verified, no native_decide. The open Ω(p^{3/2}) and Solymosi–Stojaković lower-bound constructions remain deferred in the parent and are untouched here.",
+    "nextSteps": [
+      "Count secant (2-point) lines: with no three collinear, all C(p,2) pairs determine distinct connecting lines — formalize a Line type or a pair-to-direction injection to certify exactly p(p-1)/2 secants.",
+      "Build the sumset/grid construction ON TOP of the arc to realize the Ω(p^{3/2}) four-point-line lower bound (the open obligation grunbaum_lower_bound_three_halves).",
+      "Generalize the engine: relate kPointLineCount monotonicity in k for arbitrary P (k-point-line-free ⟹ (k+1)-point-line-free)."
+    ]
+  },
+  "relatedProofs": [
+    "erdos101-problem",
+    "erdos101-problem-oq-04"
+  ]
+}


### PR DESCRIPTION
## Erdős Problem #101 — OQ-04-OQ-01 (uniform general-position certificate)

Parent `oq-04` builds the mod-`p` Grünbaum parabola, lifts it to ℝ² as an explicit `p`-point arc `realParabolaSet` (no three collinear), and records the honest scope: its `fourPointLineCount = 0`. The Ω(p^{3/2}) four-point-line count must come from a sumset/grid construction *on top of* the arc, not the arc itself.

This child shows `fourPointLineCount = 0` is just the `k = 4` shadow of a single general-position fact.

### Result

- `kPointLineCount P k` — the `k`-parameterised generalization of the gallery's `fourPointLineCount`; `fourPointLineCount = kPointLineCount · 4` holds by `rfl`.
- **`kPointLineCount_eq_zero_of_no_three_collinear`** — reusable engine: a set with no three collinear points has `kPointLineCount P k = 0` for *every* `k ≥ 3` (a `k`-set on a line through `a ≠ b` has `k ≥ 3 > 2` points, hence a third point `c ∉ {a,b}`, giving three distinct collinear points).
- `realParabolaSet_kPointLineCount_zero` — the arc has zero `k`-point lines for every `k ≥ 3`.
- `realParabolaSet_fourPointLineCount_zero'` — recovers the parent's headline as the `k = 4` instance.
- `realParabolaSet_threePointLineCount_zero` — the `k = 3` "no triangle on a line" certificate.

The four-point obstruction is not special: it is the general-position property read off at one value of `k`.

### Verification

- `Erdos101OQ04OQ01.lean`: 1 def + 5 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the three headline theorems: `propext, Classical.choice, Quot.sound` only — the results do **not** inherit the parents' open-construction sorries (`grunbaum_lower_bound_three_halves`, `solymosi_stojakovic_lower_bound`).
- Builds via `./proofs/scripts/docker-build.sh Proofs.Erdos101OQ04OQ01` (3063 jobs, success).

The open Ω(p^{3/2}) and Solymosi–Stojaković lower-bound constructions remain deferred in the parent and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)