### PR TITLE
research(roth-theorem-k3-oq-03-oq-01-oq-01-oq-01): symmetries of the k-AP counting operator Λ_k — translation invariance + reflection symmetry [0-axiom verified]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01OQ01OQ01.lean
@@ -1,0 +1,134 @@
+/-
+Roth/Szemerédi — OQ-03-OQ-01-OQ-01-OQ-01: Symmetries of the k-AP counting operator Λ_k
+
+Source: open question of the roth-theorem-k3 gallery (Gowers norms, OQ-03)
+Parent: Proofs/RothTheoremOQ03OQ01OQ01.lean (multilinearity of Λ_k)
+Grandparent: Proofs/RothTheoremOQ03OQ01.lean (defines Λ_k = kAPCount, foundational identities)
+
+## What this adds
+
+The grandparent builds the k-AP counting operator
+
+  Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏_{i<k} fᵢ(x + i·d)
+
+and proves the degenerate/normalization identities; the parent proves it is
+*multilinear*. Neither records the **geometric symmetries** of the underlying
+configuration `{x, x+d, …, x+(k-1)d}` — the symmetries of an arithmetic
+progression as a set. These are genuinely new facts, not consequences of
+multilinearity: they come from reindexing bijections of the averaging variables
+`(x, d)`, not from the algebra of a single slot.
+
+This file proves the two basic symmetries, 0-axiom:
+
+* `kAPCount_translate` — **translation invariance**: shifting every function by a
+  common translate `t` leaves the count unchanged,
+  `Λ_k(f₀(·+t),…,f_{k-1}(·+t)) = Λ_k(f₀,…,f_{k-1})`. (The AP is shifted as a
+  whole by `−t`; reindex `x ↦ x + t`.)
+
+* `kAPCount_reflect` — **reflection symmetry**: reversing the tuple leaves the
+  count unchanged, `Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀)`. The progression
+  `x, x+d, …, x+(k-1)d` read backwards is the progression with base point
+  `x+(k-1)d` and common difference `−d`; reindex `(x,d) ↦ (x+(k-1)d, −d)`, an
+  involution of `(ZMod N)²`, together with the index reversal `i ↦ k-1-i`.
+
+Reversal of the tuple is `fun i => f (Fin.rev i)` (`Fin.rev i = k-1-i`). The
+helper `prod_rev_reindex` performs the index reversal inside the product; the
+involution `reflectShift` performs the variable substitution. All results are
+machine-checked with only the foundational axioms
+(`propext`/`Classical.choice`/`Quot.sound`), no `native_decide`.
+-/
+import Proofs.RothTheoremOQ03OQ01OQ01
+
+open Finset BigOperators
+
+namespace RothTheoremOQ03OQ01
+
+variable {N : ℕ} [NeZero N]
+
+-- ============================================================
+-- Translation invariance
+-- ============================================================
+
+/-- **Translation invariance.** Replacing every function `fᵢ` by its translate
+`y ↦ fᵢ(y + t)` does not change the count: the progression is shifted as a whole
+by `−t`, which is absorbed by reindexing the base-point average `x ↦ x + t`. -/
+theorem kAPCount_translate (k : ℕ) (f : Fin k → ZMod N → ℂ) (t : ZMod N) :
+    kAPCount k (fun i y => f i (y + t)) = kAPCount k f := by
+  unfold kAPCount
+  congr 1
+  -- Reindex the base-point average `x ↦ x + t`; the common translate is absorbed.
+  refine Fintype.sum_equiv (Equiv.addRight t) _ _ (fun x => ?_)
+  refine Finset.sum_congr rfl (fun d _ => ?_)
+  refine Finset.prod_congr rfl (fun i _ => ?_)
+  simp only [Equiv.coe_addRight]
+  congr 1
+  abel
+
+-- ============================================================
+-- Reflection symmetry
+-- ============================================================
+
+/-- **Index reversal inside the product.** Reversing which function is paired
+with which AP term is the same as reversing the AP terms: the product of
+`f (rev i)` over the AP `x + i·d` equals the product of `f i` over the reversed
+shifts `x + (rev i)·d`. -/
+theorem prod_rev_reindex (k : ℕ) (f : Fin k → ZMod N → ℂ) (x d : ZMod N) :
+    (∏ i : Fin k, f (Fin.rev i) (x + i.val • d))
+      = ∏ i : Fin k, f i (x + (Fin.rev i).val • d) := by
+  have h := Equiv.Perm.prod_comp' (Fin.revPerm) Finset.univ
+    (fun a b : Fin k => f a (x + b.val • d)) (by intro a _; exact Finset.mem_univ a)
+  simpa [Fin.revPerm_apply, Fin.revPerm_symm] using h
+
+/-- The base-point/difference substitution behind reflection symmetry:
+`(x, d) ↦ (x + (k-1)·d, −d)`. It is an involution of `(ZMod N)²` and it sends the
+reversed AP shift `x + (k-1-i)·d` to the forward shift of the reflected
+progression, `(x + (k-1)d) + i·(−d)`. -/
+def reflectShift (k : ℕ) : ZMod N × ZMod N → ZMod N × ZMod N :=
+  fun p => (p.1 + (k - 1) • p.2, -p.2)
+
+theorem reflectShift_involutive (k : ℕ) :
+    Function.Involutive (reflectShift (N := N) k) := by
+  intro p
+  refine Prod.ext ?_ ?_
+  · show p.1 + (k - 1) • p.2 + (k - 1) • -p.2 = p.1
+    rw [smul_neg]; abel
+  · show - -p.2 = p.2
+    rw [neg_neg]
+
+/-- The pointwise identity driving reflection: the reversed-AP shift equals the
+forward shift of the reflected progression. -/
+theorem reflect_shift_eq (k : ℕ) (i : Fin k) (x d : ZMod N) :
+    x + (Fin.rev i).val • d = (x + (k - 1) • d) + i.val • (-d) := by
+  have hle : i.val ≤ k - 1 := by have := i.isLt; omega
+  have hrev : (Fin.rev i).val = k - 1 - i.val := by rw [Fin.val_rev]; omega
+  have hsum : (k - 1 - i.val) • d + i.val • d = (k - 1) • d := by
+    rw [← add_nsmul]; congr 1; omega
+  rw [hrev, smul_neg, ← hsum]; abel
+
+/-- **Reflection symmetry.** Reversing the tuple of functions leaves the count
+unchanged: `Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀)`. An AP read backwards is the
+AP with base point `x+(k-1)d` and common difference `−d`; the involution
+`reflectShift` reindexes the average accordingly. -/
+theorem kAPCount_reflect (k : ℕ) (f : Fin k → ZMod N → ℂ) :
+    kAPCount k (fun i => f (Fin.rev i)) = kAPCount k f := by
+  unfold kAPCount
+  congr 1
+  -- reduce to the double-sum identity, with the index reversal already applied
+  have step : (∑ x : ZMod N, ∑ d : ZMod N,
+        ∏ i : Fin k, f i (x + (Fin.rev i).val • d))
+      = ∑ x : ZMod N, ∑ d : ZMod N, ∏ i : Fin k, f i (x + i.val • d) := by
+    rw [← Fintype.sum_prod_type', ← Fintype.sum_prod_type']
+    rw [← Equiv.sum_comp (Function.Involutive.toPerm _ (reflectShift_involutive (N := N) k))
+          (fun p : ZMod N × ZMod N => ∏ i : Fin k, f i (p.1 + i.val • p.2))]
+    refine Finset.sum_congr rfl (fun p _ => ?_)
+    refine Finset.prod_congr rfl (fun i _ => ?_)
+    congr 1
+    simp only [Function.Involutive.coe_toPerm, reflectShift]
+    exact reflect_shift_eq k i p.1 p.2
+  -- now insert the index reversal on the left
+  rw [← step]
+  refine Finset.sum_congr rfl (fun x _ => ?_)
+  refine Finset.sum_congr rfl (fun d _ => ?_)
+  simpa using prod_rev_reindex k f x d
+
+end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01",
+  "title": "Roth/Szemerédi OQ-03-OQ-01-OQ-01-OQ-01: Symmetries of the k-AP Counting Operator Λ_k",
+  "slug": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01",
+  "description": "The geometric symmetries of the k-AP counting operator Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d): translation invariance (kAPCount_translate — a common shift of every function leaves the count unchanged) and reflection symmetry (kAPCount_reflect — reversing the tuple, Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀)). These are not consequences of multilinearity; they come from reindexing bijections of the averaging variables (x,d): the shift x↦x+t and the AP-reversal involution (x,d)↦(x+(k-1)d,−d) combined with the index reversal i↦k-1-i. Directly answers a parent open question. 0-axiom verified.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gowers_norm",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RothTheoremOQ03OQ01OQ01OQ01.lean",
+    "tags": [
+      "roth-theorem",
+      "szemeredi",
+      "gowers-norm",
+      "additive-combinatorics",
+      "symmetry",
+      "counting-operator",
+      "ZMod"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Equiv.Perm.prod_comp'",
+        "description": "∏ x∈s, f (σ x) x = ∏ x∈s, f x (σ.symm x) — reindex a product where the permutation acts on one of two slots; used with Fin.revPerm to reverse the index",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "Equiv.sum_comp / Fintype.sum_equiv",
+        "description": "Reindex a finite sum along an equivalence; here the AP-reversal involution on (ZMod N)² and the base-point shift on ZMod N",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "Function.Involutive.toPerm",
+        "description": "Package an involution as an Equiv.Perm — turns reflectShift into a usable reindexing bijection",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Fintype.sum_prod_type' / Fin.val_rev / add_nsmul",
+        "description": "Uncurry a double sum to a sum over the product type; the value of Fin.rev (k-1-i); split nsmul over a sum of naturals",
+        "module": "Mathlib.Data.Fintype.BigOperators"
+      }
+    ],
+    "originalContributions": [
+      "kAPCount_translate: translation invariance — Λ_k(f₀(·+t),…,f_{k-1}(·+t)) = Λ_k(f₀,…,f_{k-1}); the common shift is absorbed by reindexing the base-point average x↦x+t",
+      "kAPCount_reflect: reflection symmetry — Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀) (tuple reversal fun i => f (Fin.rev i))",
+      "reflectShift + reflectShift_involutive: the AP-reversal substitution (x,d)↦(x+(k-1)d,−d) is an involution of (ZMod N)²",
+      "prod_rev_reindex: index reversal inside the k-AP product via Fin.revPerm",
+      "reflect_shift_eq: the pointwise identity x+(k-1-i)·d = (x+(k-1)d)+i·(−d) relating the reversed AP shift to the reflected progression"
+    ],
+    "axiomCount": 0,
+    "lineCount": 134,
+    "assumptions": "0 axioms, 0 sorries. Only foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide. Imports the multilinearity parent Proofs.RothTheoremOQ03OQ01OQ01 (hence the grandparent operator definitions).",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**Symmetries of the AP-counting average.** In the Gowers-norm approach to Roth's and Szemerédi's theorems the central object is the normalized k-term arithmetic-progression count Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d). Beyond its algebraic structure (multilinearity, proved in the parent file), Λ_k inherits the geometric symmetries of an arithmetic progression viewed as a set: it is unchanged when the whole configuration is translated, and when the progression is read backwards. These symmetries are used routinely — e.g. to normalize a configuration to a convenient base point, or to move the 'distinguished' slot to either end — and underlie the symmetric role the two endpoints play in the van der Corput / generalized von Neumann estimates.",
+    "problemStatement": "**Λ_k respects the symmetries of an AP.** For the operator Λ_k from the grandparent file:\n\n- **translation invariance:** Λ_k(f₀(·+t),…,f_{k-1}(·+t)) = Λ_k(f₀,…,f_{k-1}) for every t ∈ ZMod N;\n- **reflection symmetry:** Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀), i.e. Λ_k(fun i => f (Fin.rev i)) = Λ_k f.\n\nNeither follows from multilinearity; each is a reindexing of the averaging variables (x,d).",
+    "text": "The k-AP counting operator Λ_k is shown to be invariant under a common translation of its functions and under reversal of its argument tuple. The first follows by reindexing the base-point average x↦x+t; the second by the AP-reversal involution (x,d)↦(x+(k-1)d,−d) on (ZMod N)² together with the Fin index reversal i↦k-1-i. 0-axiom verified.",
+    "proofStrategy": "**Translation (kAPCount_translate).** Reading fᵢ((x+i·d)+t) = fᵢ((x+t)+i·d), the shift lands entirely on the base point x; `Fintype.sum_equiv (Equiv.addRight t)` reindexes the x-average, and the d-average and product are untouched (closed by `abel`).\n\n**Reflection (kAPCount_reflect).** Two independent bijections. (1) `prod_rev_reindex` reverses the index inside the product using `Equiv.Perm.prod_comp'` with `Fin.revPerm`, turning ∏ᵢ f(rev i)(x+i·d) into ∏ᵢ f i (x+(rev i)·d). (2) The pointwise identity `reflect_shift_eq`, x+(k-1-i)·d = (x+(k-1)d)+i·(−d), shows the reversed shift is the forward shift of the reflected progression (base point x+(k-1)d, difference −d); the map `reflectShift (x,d) = (x+(k-1)d, −d)` is an involution (`reflectShift_involutive`), so `Equiv.sum_comp` of its `toPerm` reindexes the double average (after uncurrying it with `Fintype.sum_prod_type'`).",
+    "keyInsights": [
+      "**The symmetries are reindexings, not algebra:** translation invariance and reflection live in the bijection group of the averaging variables (x,d), orthogonal to the slot-by-slot multilinearity of the parent file.",
+      "**Reflection = two commuting reversals:** reverse the index (which function sits where) with Fin.rev, and reverse the progression (base point and common difference) with the involution (x,d)↦(x+(k-1)d,−d); together they fix Λ_k.",
+      "**An AP read backwards is an AP:** the set {x, x+d, …, x+(k-1)d} equals {y, y+e, …, y+(k-1)e} with y = x+(k-1)d and e = −d, which is exactly the substitution reflectShift encodes.",
+      "**Translation absorbs into the base point:** a common shift t of all functions is the same as translating x by t, because (x+i·d)+t = (x+t)+i·d for every term simultaneously."
+    ],
+    "prerequisites": [
+      "The grandparent operator Λ_k = kAPCount (Proofs.RothTheoremOQ03OQ01) and its multilinearity (Proofs.RothTheoremOQ03OQ01OQ01)",
+      "Reindexing finite sums/products along equivalences (Equiv.sum_comp, Equiv.Perm.prod_comp', Fintype.sum_equiv)",
+      "Fin.rev and the involution i↦k-1-i; nsmul arithmetic in ZMod N"
+    ]
+  },
+  "sections": [
+    {
+      "id": "translation",
+      "title": "Translation Invariance",
+      "summary": "kAPCount_translate: a common shift fᵢ(·+t) of every function leaves Λ_k unchanged, by reindexing the base-point average x↦x+t.",
+      "startLine": 55,
+      "endLine": 65,
+      "mathContext": "Fintype.sum_equiv (Equiv.addRight t); (x+i·d)+t = (x+t)+i·d."
+    },
+    {
+      "id": "index-reversal",
+      "title": "Index Reversal in the Product",
+      "summary": "prod_rev_reindex: ∏ᵢ f(rev i)(x+i·d) = ∏ᵢ f i (x+(rev i)·d), via Equiv.Perm.prod_comp' with Fin.revPerm.",
+      "startLine": 75,
+      "endLine": 80,
+      "mathContext": "Permuting one slot of a two-slot product; Fin.revPerm is its own inverse."
+    },
+    {
+      "id": "reversal-involution",
+      "title": "The AP-Reversal Involution",
+      "summary": "reflectShift (x,d) = (x+(k-1)d, −d) is an involution (reflectShift_involutive); reflect_shift_eq is the pointwise shift identity.",
+      "startLine": 82,
+      "endLine": 106,
+      "mathContext": "x+(k-1-i)·d = (x+(k-1)d)+i·(−d); add_nsmul + Fin.val_rev."
+    },
+    {
+      "id": "reflection",
+      "title": "Reflection Symmetry of Λ_k",
+      "summary": "kAPCount_reflect: Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀), combining the index reversal with the AP-reversal involution on the (x,d)-average.",
+      "startLine": 108,
+      "endLine": 132,
+      "mathContext": "Fintype.sum_prod_type' to uncurry, then Equiv.sum_comp of reflectShift.toPerm."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the grandparent's operator Λ_k and the parent's multilinearity, this entry records the geometric symmetries of Λ_k: it is invariant under a common translation of its functions (kAPCount_translate) and under reversal of its argument tuple (kAPCount_reflect). The reflection rests on an AP-reversal involution (x,d)↦(x+(k-1)d,−d) of the averaging variables together with the Fin index reversal. All 0-axiom and machine-checked.",
+    "implications": "Translation invariance and reflection symmetry are the configuration symmetries used to normalize AP counts (fix a base point, or move a distinguished slot to an endpoint) and they explain the symmetric role of the two extreme terms of the progression in the van der Corput / generalized von Neumann estimates. They directly resolve the parent file's open question on translation-invariance of Λ_k.",
+    "openQuestions": [
+      "Dilation/affine symmetry: Λ_k under d↦λ·d for a unit λ ∈ (ZMod N)ˣ, completing the affine symmetry group of the AP",
+      "Concrete k=3 (Roth) specialization: deduce Λ_3(f₀,f₁,f₂) = Λ_3(f₂,f₁,f₀) by evaluating Fin.rev on Fin 3",
+      "Conjugate symmetry Λ_k(conj f₀,…,conj f_{k-1}) = conj Λ_k(f₀,…,f_{k-1}) and its interaction with reflection"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.RothTheoremOQ03OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "RothTheoremOQ03OQ01",
+    "lineCount": 134,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/RothTheoremOQ03OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: multilinearity of Λ_k. This entry adds the orthogonal geometric symmetries."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "specializes",
+      "description": "Great-grandparent: Gowers norms and the k-AP counting operator for Roth's theorem."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends the Roth/Szemerédi **Λ_k** lineage with the **geometric symmetries** of the k-AP counting operator
`Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d)`.

The grandparent (`RothTheoremOQ03OQ01`) defines Λ_k and proves degenerate/normalization identities; the parent (`RothTheoremOQ03OQ01OQ01`) proves Λ_k is **multilinear**. Neither records the symmetries of an arithmetic progression *as a configuration*. These are **not** consequences of multilinearity — they are reindexing bijections of the averaging variables (x,d). This **directly answers the parent file's open question** "Translation-invariance of Λ_k".

## What's proved (0-axiom, no `native_decide`)

- **`kAPCount_translate`** — translation invariance: `Λ_k(f₀(·+t),…,f_{k-1}(·+t)) = Λ_k(f₀,…,f_{k-1})`. The common shift lands on the base point ((x+i·d)+t = (x+t)+i·d) and is absorbed by reindexing the x-average (`Fintype.sum_equiv (Equiv.addRight t)`).
- **`kAPCount_reflect`** — reflection symmetry: `Λ_k(f₀,…,f_{k-1}) = Λ_k(f_{k-1},…,f₀)` (tuple reversal `fun i => f (Fin.rev i)`).

Supporting:
- **`prod_rev_reindex`** — index reversal inside the k-AP product via `Equiv.Perm.prod_comp'` with `Fin.revPerm`.
- **`reflectShift` / `reflectShift_involutive`** — the AP-reversal substitution (x,d)↦(x+(k-1)d, −d) is an involution of (ZMod N)².
- **`reflect_shift_eq`** — pointwise identity x+(k-1-i)·d = (x+(k-1)d)+i·(−d): a reversed AP shift is the forward shift of the reflected progression.

## Mathematical content

An AP read backwards is an AP: {x, x+d, …, x+(k-1)d} = {y, y+e, …, y+(k-1)e} with base point y = x+(k-1)d and common difference e = −d. Reflection symmetry is the composition of two reversals — the index (which function sits where, `Fin.rev`) and the progression (base point + difference, `reflectShift`). These configuration symmetries are used to normalize AP counts and explain the symmetric role of the two endpoints in the van der Corput / generalized von Neumann estimates.

## Verification

- `#print axioms` on all five results: only `propext` / `Classical.choice` / `Quot.sound` (`reflectShift_involutive`: `propext` / `Quot.sound`). No `sorryAx`, no `Lean.ofReduceBool`.
- Builds under the Docker wrapper (`Proofs.RothTheoremOQ03OQ01OQ01OQ01`, 7745 jobs).
- 134 lines, 5 theorems, 1 definition, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)