### PR TITLE
research(roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01): affine covariance of Λ_k — completing the GA(1) symmetry group [0-axiom verified]

### DIFF
--- a/proofs/Proofs/RothTheoremOQ03OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/RothTheoremOQ03OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,132 @@
+/-
+Roth/Szemerédi — OQ-03-OQ-01-OQ-01-OQ-01-OQ-01:
+Affine covariance of the k-AP counting operator Λ_k
+
+Source: open question of the roth-theorem-k3 gallery (Gowers norms, OQ-03)
+Parent:        Proofs/RothTheoremOQ03OQ01OQ01OQ01.lean (symmetries of Λ_k)
+Grandparent:   Proofs/RothTheoremOQ03OQ01OQ01.lean   (multilinearity of Λ_k)
+Greatgrandpa:  Proofs/RothTheoremOQ03OQ01.lean       (defines Λ_k, foundational identities)
+
+## What this adds
+
+The lineage builds the k-AP counting operator
+
+  Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏_{i<k} fᵢ(x + i·d)
+
+and records its degenerate identities (greatgrandparent), its *multilinearity*
+(grandparent), and two *symmetries* — translation invariance and reflection
+(parent). The parent's translation invariance handles the **additive** part of
+the symmetry group of an arithmetic progression. It leaves out the
+**multiplicative** part: the count is also invariant under *dilation* of the
+configuration by any invertible scalar.
+
+This file proves the full **affine covariance** of Λ_k, 0-axiom:
+
+* `kAPCount_affine` — for any unit `a : (ZMod N)ˣ` and any translate `t`,
+  replacing every function `fᵢ` by `y ↦ fᵢ(a·y + t)` leaves the count
+  unchanged:
+  `Λ_k(f₀(a·+t),…) = Λ_k(f₀,…)`.
+  The affine map `φ(y) = a·y + t` carries the progression `{x + i·d}` to
+  `{φ(x) + i·(a·d)}`, again an arithmetic progression, and `(x,d) ↦ (a·x+t, a·d)`
+  is a bijection of `(ZMod N)²` precisely because `a` is invertible. So the
+  averaging measure is preserved and the count is fixed.
+
+This exhibits the **one-dimensional affine group** `GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N`
+acting on Λ_k by symmetries. Two corollaries isolate the pieces:
+
+* `kAPCount_dilate` — the genuinely new **dilation invariance** (`t = 0`):
+  `Λ_k(f₀(a·),…) = Λ_k(f₀,…)` for any unit `a`. This is *not* a consequence of
+  translation (parent) or reflection: e.g. `a = -1` gives `Λ_k(f₀(-·),…) = Λ_k(f₀,…)`,
+  the point reflection through the origin without reversing the slot order, which
+  the reflection symmetry `i ↦ k-1-i` does not provide.
+
+* `kAPCount_translate_of_affine` — recovers the parent's **translation invariance**
+  as the `a = 1` case, confirming that affine covariance subsumes it.
+
+The multiplicative reindexing is packaged as `mulUnit a`, the bijection
+`y ↦ a·y` of `ZMod N` (an `Equiv` because `a` is a unit); the additive part reuses
+`Equiv.addRight`. All results are machine-checked with only the foundational
+axioms (`propext`/`Classical.choice`/`Quot.sound`), no `native_decide`.
+
+References:
+- Gowers, "A new proof of Szemerédi's theorem" (2001)
+- Tao, "Higher order Fourier analysis" (2012)
+-/
+import Proofs.RothTheoremOQ03OQ01OQ01OQ01
+
+open Finset BigOperators
+
+namespace RothTheoremOQ03OQ01
+
+variable {N : ℕ} [NeZero N]
+
+-- ============================================================
+-- Multiplication by a unit is a bijection of `ZMod N`
+-- ============================================================
+
+/-- Multiplication by a unit `a : (ZMod N)ˣ` is a permutation of `ZMod N`, with
+inverse multiplication by `a⁻¹`. This is the multiplicative (dilation) part of
+the affine reindexing `(x, d) ↦ (a·x + t, a·d)`. -/
+def mulUnit (a : (ZMod N)ˣ) : ZMod N ≃ ZMod N where
+  toFun x := (a : ZMod N) * x
+  invFun x := ((a⁻¹ : (ZMod N)ˣ) : ZMod N) * x
+  left_inv x := Units.inv_mul_cancel_left a x
+  right_inv x := Units.mul_inv_cancel_left a x
+
+@[simp] theorem mulUnit_apply (a : (ZMod N)ˣ) (x : ZMod N) :
+    mulUnit a x = (a : ZMod N) * x := rfl
+
+-- ============================================================
+-- Affine covariance
+-- ============================================================
+
+/-- **Affine covariance.** For any unit `a : (ZMod N)ˣ` and any translate
+`t : ZMod N`, replacing every function `fᵢ` by `y ↦ fᵢ(a·y + t)` does not change
+the count:
+`Λ_k(f₀(a·+t),…,f_{k-1}(a·+t)) = Λ_k(f₀,…,f_{k-1})`.
+
+The affine map `φ(y) = a·y + t` sends the progression `x, x+d, …, x+(k-1)d` to the
+progression with base point `a·x+t` and common difference `a·d`; the average is
+reindexed by `x ↦ a·x+t` (outer) and `d ↦ a·d` (inner), each a bijection because
+`a` is a unit. -/
+theorem kAPCount_affine (k : ℕ) (f : Fin k → ZMod N → ℂ)
+    (a : (ZMod N)ˣ) (t : ZMod N) :
+    kAPCount k (fun i y => f i ((a : ZMod N) * y + t)) = kAPCount k f := by
+  unfold kAPCount
+  congr 1
+  -- reindex the outer base-point average `x ↦ a·x + t`
+  refine Fintype.sum_equiv ((mulUnit a).trans (Equiv.addRight t)) _ _ (fun x => ?_)
+  -- reindex the inner common-difference average `d ↦ a·d`
+  refine Fintype.sum_equiv (mulUnit a) _ _ (fun d => ?_)
+  refine Finset.prod_congr rfl (fun i _ => ?_)
+  -- both reindexings reduce the AP shift to the matching forward shift
+  simp only [Equiv.trans_apply, mulUnit_apply, Equiv.coe_addRight, nsmul_eq_mul]
+  congr 1
+  ring
+
+-- ============================================================
+-- Corollaries: dilation invariance and translation invariance
+-- ============================================================
+
+/-- **Dilation invariance** (the `t = 0` case of affine covariance): for any unit
+`a`, scaling the configuration by `a` leaves the count unchanged,
+`Λ_k(f₀(a·),…,f_{k-1}(a·)) = Λ_k(f₀,…,f_{k-1})`.
+
+This is the genuinely new (multiplicative) symmetry: it is not implied by the
+parent's translation invariance, nor by reflection. For instance `a = -1` gives
+`Λ_k(f₀(-·),…) = Λ_k(f₀,…)`, the reflection through the origin that keeps the slot
+order, distinct from the order-reversing reflection symmetry `i ↦ k-1-i`. -/
+theorem kAPCount_dilate (k : ℕ) (f : Fin k → ZMod N → ℂ) (a : (ZMod N)ˣ) :
+    kAPCount k (fun i y => f i ((a : ZMod N) * y)) = kAPCount k f := by
+  have h := kAPCount_affine k f a 0
+  simpa using h
+
+/-- **Translation invariance** recovered as the `a = 1` case of affine covariance,
+confirming that affine covariance subsumes the parent's `kAPCount_translate`. -/
+theorem kAPCount_translate_of_affine (k : ℕ) (f : Fin k → ZMod N → ℂ)
+    (t : ZMod N) :
+    kAPCount k (fun i y => f i (y + t)) = kAPCount k f := by
+  have h := kAPCount_affine k f 1 t
+  simpa using h
+
+end RothTheoremOQ03OQ01

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,146 @@
+{
+  "id": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01",
+  "title": "Roth/Szemerédi OQ-03-OQ-01-OQ-01-OQ-01-OQ-01: Affine Covariance of the k-AP Counting Operator Λ_k",
+  "slug": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01-oq-01",
+  "description": "Affine covariance of the k-AP counting operator Λ_k(f₀,…,f_{k-1}) = E_{x,d} ∏ᵢ fᵢ(x+i·d): for any unit a ∈ (ZMod N)ˣ and translate t, replacing every fᵢ by y↦fᵢ(a·y+t) leaves the count unchanged (kAPCount_affine). The affine map φ(y)=a·y+t carries the progression {x+i·d} to {φ(x)+i·(a·d)}, and (x,d)↦(a·x+t, a·d) is a bijection of (ZMod N)² precisely because a is invertible. This exhibits the one-dimensional affine group GA(1,ZMod N)=(ZMod N)ˣ⋉ZMod N acting on Λ_k. Two corollaries: kAPCount_dilate (the genuinely new multiplicative dilation invariance, t=0) and kAPCount_translate_of_affine (recovers the parent's translation invariance, a=1). Directly answers the parent's first open question. 0-axiom verified.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gowers_norm",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/RothTheoremOQ03OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "roth-theorem",
+      "szemeredi",
+      "gowers-norm",
+      "additive-combinatorics",
+      "symmetry",
+      "affine-group",
+      "counting-operator",
+      "ZMod"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Units.inv_mul_cancel_left / Units.mul_inv_cancel_left",
+        "description": "↑a⁻¹·(↑a·x)=x and ↑a·(↑a⁻¹·x)=x for a unit a — supply the two inverse laws making multiplication-by-a unit an Equiv of ZMod N",
+        "module": "Mathlib.Algebra.Group.Units.Defs"
+      },
+      {
+        "theorem": "Fintype.sum_equiv",
+        "description": "Reindex a finite sum along an equivalence; used twice — the base-point average x↦a·x+t (outer) and the common-difference average d↦a·d (inner)",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "Equiv.addRight / Equiv.trans",
+        "description": "The additive translate y↦y+t as an Equiv, composed with mulUnit a to form the full affine reindexing y↦a·y+t",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "nsmul_eq_mul",
+        "description": "i.val • z = ↑i.val · z in the commutative ring ZMod N, reducing the AP-shift identity a·(x+i·d)+t = (a·x+t)+i·(a·d) to a ring identity",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "kAPCount_affine: affine covariance — for a unit a ∈ (ZMod N)ˣ and translate t, Λ_k(f₀(a·+t),…,f_{k-1}(a·+t)) = Λ_k(f₀,…,f_{k-1}); the affine map y↦a·y+t reindexes the (x,d)-average bijectively",
+      "kAPCount_dilate: dilation invariance (t=0) — Λ_k(f₀(a·),…,f_{k-1}(a·)) = Λ_k(f₀,…,f_{k-1}) for any unit a; the genuinely new multiplicative symmetry, not implied by translation or reflection",
+      "kAPCount_translate_of_affine: translation invariance (a=1) recovered as a special case, confirming affine covariance subsumes the parent's kAPCount_translate",
+      "mulUnit: multiplication by a unit a ∈ (ZMod N)ˣ packaged as a permutation of ZMod N (Equiv with inverse multiplication by a⁻¹) — the dilation part of the affine reindexing"
+    ],
+    "axiomCount": 0,
+    "lineCount": 132,
+    "assumptions": "0 axioms, 0 sorries. Only foundational axioms propext / Classical.choice / Quot.sound are used; no native_decide. Imports the symmetries parent Proofs.RothTheoremOQ03OQ01OQ01OQ01 (hence the multilinearity grandparent and the great-grandparent operator definitions).",
+    "theoremCount": 3,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "**The affine symmetry group of the AP-counting average.** In the Gowers-norm approach to Roth's and Szemerédi's theorems the central object is the normalized k-term arithmetic-progression count Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d). The set of arithmetic progressions in ZMod N is preserved by the one-dimensional affine group GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N: an invertible affine substitution y ↦ a·y + t sends a progression to a progression. The parent file recorded the additive (translation) part of this symmetry; this entry completes it with the multiplicative (dilation) part, so that the full affine group acts on Λ_k by symmetries. This affine covariance is what lets one normalize a configuration — fixing the base point and rescaling the common difference to a convenient value — throughout the density-increment argument.",
+    "problemStatement": "**Λ_k is affine-covariant.** For the operator Λ_k from the great-grandparent file, every invertible affine map φ(y) = a·y + t with a ∈ (ZMod N)ˣ leaves the count fixed:\n\nΛ_k(f₀∘φ,…,f_{k-1}∘φ) = Λ_k(f₀,…,f_{k-1}).\n\nIn particular the multiplicative part (dilation, t=0) is a new symmetry beyond the parent's translation invariance and reflection symmetry.",
+    "text": "The k-AP counting operator Λ_k is shown to be invariant under every invertible affine substitution y ↦ a·y + t of its arguments. The affine map carries the progression {x+i·d} to {(a·x+t)+i·(a·d)}, and the reindexing (x,d) ↦ (a·x+t, a·d) is a bijection of (ZMod N)² exactly because a is a unit; the outer x-average is reindexed by x↦a·x+t and the inner d-average by d↦a·d. Dilation invariance (t=0) and translation invariance (a=1) follow as corollaries. 0-axiom verified.",
+    "proofStrategy": "**Affine covariance (kAPCount_affine).** Because the affine map is diagonal in the averaging variables — the new base point a·x+t depends only on x and the new difference a·d only on d — the double average is reindexed by two independent single-variable bijections. `mulUnit a` is multiplication by the unit a, an Equiv of ZMod N with inverse multiplication by a⁻¹ (the inverse laws are exactly `Units.inv_mul_cancel_left` and `Units.mul_inv_cancel_left`). `Fintype.sum_equiv ((mulUnit a).trans (Equiv.addRight t))` reindexes the outer x-average, `Fintype.sum_equiv (mulUnit a)` the inner d-average; the product then matches term-by-term via the pointwise identity a·(x+i·d)+t = (a·x+t)+i·(a·d), which `nsmul_eq_mul` + `ring` discharge.\n\n**Dilation (kAPCount_dilate).** The t=0 case: `simpa` removes the `+0`.\n\n**Translation (kAPCount_translate_of_affine).** The a=1 case: `simpa` reduces ↑(1:(ZMod N)ˣ)·y to y, recovering the parent's translation invariance.",
+    "keyInsights": [
+      "**Invertibility is exactly what makes dilation a symmetry:** d ↦ a·d permutes ZMod N iff a is a unit, so the count is preserved precisely for a ∈ (ZMod N)ˣ; for a non-unit the substitution collapses the average and the identity fails.",
+      "**The affine map is diagonal in (x,d):** the new base point a·x+t depends only on x and the new common difference a·d only on d, so a single product Equiv is unnecessary — two independent single-variable reindexings suffice (outer x↦a·x+t, inner d↦a·d).",
+      "**Dilation is genuinely new:** it is not a consequence of translation (parent) or reflection. For a=−1 it gives Λ_k(f₀(−·),…) = Λ_k(f₀,…), the point reflection through the origin that keeps the slot order — distinct from the order-reversing reflection symmetry i↦k−1−i.",
+      "**Affine covariance unifies the symmetry group:** translation (a=1) and the new dilations (t=0) together generate the full GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N action, completing the additive picture of the parent file."
+    ],
+    "prerequisites": [
+      "The great-grandparent operator Λ_k = kAPCount (Proofs.RothTheoremOQ03OQ01), its multilinearity (Proofs.RothTheoremOQ03OQ01OQ01), and its symmetries (Proofs.RothTheoremOQ03OQ01OQ01OQ01)",
+      "Units of a commutative ring and the cancel-left laws (Units.inv_mul_cancel_left, Units.mul_inv_cancel_left)",
+      "Reindexing finite sums along equivalences (Fintype.sum_equiv, Equiv.addRight, Equiv.trans); nsmul arithmetic in ZMod N"
+    ]
+  },
+  "sections": [
+    {
+      "id": "mul-unit",
+      "title": "Multiplication by a Unit is a Bijection",
+      "summary": "mulUnit a: multiplication by a unit a ∈ (ZMod N)ˣ is a permutation of ZMod N, with inverse multiplication by a⁻¹ — the dilation part of the affine reindexing.",
+      "startLine": 64,
+      "endLine": 76,
+      "mathContext": "Equiv from Units.inv_mul_cancel_left and Units.mul_inv_cancel_left."
+    },
+    {
+      "id": "affine-covariance",
+      "title": "Affine Covariance of Λ_k",
+      "summary": "kAPCount_affine: for a unit a and translate t, Λ_k(f₀(a·+t),…) = Λ_k(f₀,…), reindexing the outer x-average by x↦a·x+t and the inner d-average by d↦a·d.",
+      "startLine": 88,
+      "endLine": 107,
+      "mathContext": "Two Fintype.sum_equiv; pointwise a·(x+i·d)+t = (a·x+t)+i·(a·d) by nsmul_eq_mul + ring."
+    },
+    {
+      "id": "corollaries",
+      "title": "Dilation and Translation Invariance",
+      "summary": "kAPCount_dilate (t=0, the new multiplicative symmetry) and kAPCount_translate_of_affine (a=1, recovering the parent's translation invariance).",
+      "startLine": 113,
+      "endLine": 131,
+      "mathContext": "simpa from kAPCount_affine specialized at t=0 and a=1."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the great-grandparent's operator Λ_k, the grandparent's multilinearity, and the parent's symmetries, this entry completes the symmetry picture: Λ_k is covariant under every invertible affine substitution y↦a·y+t of its arguments (kAPCount_affine), so the one-dimensional affine group GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N acts on Λ_k. The new multiplicative dilation invariance (kAPCount_dilate) and the recovered translation invariance (kAPCount_translate_of_affine) isolate the two pieces. All 0-axiom and machine-checked.",
+    "implications": "Affine covariance is the symmetry used to normalize AP counts — fixing the base point and rescaling the common difference — which underlies the freedom to choose a convenient progression in the density-increment / generalized von Neumann argument. It directly resolves the parent file's first open question (dilation/affine symmetry of Λ_k under d↦λ·d for a unit λ).",
+    "openQuestions": [
+      "Equivariance under the full general affine action on the index set as well (combining dilation with the reflection i↦k−1−i of the parent) to describe the complete symmetry group of Λ_k",
+      "The failure of dilation for non-units: quantify how Λ_k(f₀(a·),…) deviates from Λ_k(f₀,…) when a is a zero-divisor in ZMod N",
+      "Conjugate symmetry Λ_k(conj f₀,…,conj f_{k-1}) = conj Λ_k(f₀,…,f_{k-1}) and its interaction with affine covariance"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.RothTheoremOQ03OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "RothTheoremOQ03OQ01",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 1,
+    "path": "Proofs/RothTheoremOQ03OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3-oq-03-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: symmetries of Λ_k (translation + reflection). This entry answers its first open question by adding the multiplicative dilation, completing the affine symmetry group."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+      "relationship": "specializes",
+      "description": "Grandparent: multilinearity of Λ_k."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "specializes",
+      "description": "Great-grandparent: Gowers norms and the k-AP counting operator for Roth's theorem."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the symmetry picture of the **k-AP counting operator** Λ_k(f₀,…,f_{k-1}) = E_{x,d ∈ ZMod N} ∏ᵢ fᵢ(x + i·d). The parent file proved its two *symmetries* — translation invariance and reflection. This child adds the **multiplicative** part of the symmetry group: invariance under invertible **dilation**, so that the full one-dimensional affine group **GA(1, ZMod N) = (ZMod N)ˣ ⋉ ZMod N** acts on Λ_k.

This **directly answers the parent's first open question** ("Dilation/affine symmetry: Λ_k under d↦λ·d for a unit λ ∈ (ZMod N)ˣ, completing the affine symmetry group of the AP").

## Results (`Proofs/RothTheoremOQ03OQ01OQ01OQ01OQ01.lean`)

- **`kAPCount_affine`** — affine covariance: for any unit `a : (ZMod N)ˣ` and translate `t`, replacing every `fᵢ` by `y ↦ fᵢ(a·y+t)` leaves the count unchanged. The affine map carries `{x+i·d}` to `{(a·x+t)+i·(a·d)}`, and `(x,d) ↦ (a·x+t, a·d)` is a bijection of `(ZMod N)²` precisely because `a` is invertible.
- **`kAPCount_dilate`** — the genuinely new **dilation invariance** (`t=0`): `Λ_k(f₀(a·),…) = Λ_k(f₀,…)`. Not implied by translation or reflection (e.g. `a=−1` gives point reflection through the origin *without* reversing slot order, distinct from the reflection `i↦k−1−i`).
- **`kAPCount_translate_of_affine`** — recovers the parent's **translation invariance** as the `a=1` case, confirming affine covariance subsumes it.
- **`mulUnit`** — multiplication by a unit packaged as an `Equiv` of `ZMod N` (inverse: multiply by `a⁻¹`).

## Proof idea

The affine map is **diagonal in the averaging variables** — the new base point `a·x+t` depends only on `x`, the new difference `a·d` only on `d` — so the double average is reindexed by two independent single-variable bijections (`Fintype.sum_equiv`), avoiding any product Equiv. The product matches term-by-term via `a·(x+i·d)+t = (a·x+t)+i·(a·d)`, discharged by `nsmul_eq_mul` + `ring`.

## Verification

- **0 axioms, 0 sorries, no `native_decide`** — `#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound` for all three theorems.
- Builds against Mathlib 4.26 (132 lines, 3 theorems + 1 definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)