### PR TITLE
research(szemeredi-regularity-oq-01): symmetry of edge density and ε-regularity [0-axiom verified]

### DIFF
--- a/proofs/Proofs/SzemerediRegularityOQ01.lean
+++ b/proofs/Proofs/SzemerediRegularityOQ01.lean
@@ -1,0 +1,86 @@
+/-
+  Szemerédi Regularity Lemma — OQ-01: symmetry of edge density and ε-regularity
+
+  The gallery file `SzemerediRegularity.lean` (bridged to Mathlib's
+  `szemeredi_regularity`) develops the edge density `edgeDensity G A B` and the
+  ε-regularity predicate `IsEpsilonRegular G eps A B`, but never records the basic
+  structural fact that both are *symmetric* in their two vertex-set arguments:
+  for an undirected graph the pair `(A, B)` and the pair `(B, A)` carry the same
+  edge density, and one is ε-regular iff the other is.
+
+  Standard textbook treatments state regularity for unordered pairs precisely
+  because of this symmetry; this file supplies it formally.
+
+  * `edgeDensity_comm`        — `d(A, B) = d(B, A)`, via the gallery's
+    `edgeDensity_eq_mathlib` bridge and Mathlib's `SimpleGraph.edgeDensity_comm`.
+  * `isEpsilonRegular_comm`   — `IsEpsilonRegular G ε A B ↔ IsEpsilonRegular G ε B A`:
+    the ε-regularity witnesses `(A', B')` for one orientation are exactly the
+    swapped witnesses for the other, and the density difference is unchanged by
+    `edgeDensity_comm`.
+  * `edgeDensity_empty_left` / `edgeDensity_empty_right` — the degenerate
+    boundary values `d(∅, B) = d(A, ∅) = 0`.
+  * `irregularPairs_swap_mem` — the set of ordered irregular pairs underlying
+    `IsRegularPartition` is closed under swapping coordinates: irregularity is a
+    symmetric relation on parts.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Szemerédi (1975); Komlós–Simonovits (1996).
+-/
+
+import Mathlib
+import Proofs.SzemerediRegularity
+
+namespace Szemeredi.Regularity.OQ01
+
+open Classical Szemeredi.Core Szemeredi.Regularity
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- **Symmetry of edge density.**  For an undirected graph the edge density is
+    unchanged by swapping the two vertex sets: `d(A, B) = d(B, A)`.  Proved by
+    transporting along the gallery's `edgeDensity_eq_mathlib` bridge to Mathlib's
+    `SimpleGraph.edgeDensity`, which is symmetric (`G.symm`). -/
+theorem edgeDensity_comm (G : SimpleGraph V) [DecidableRel G.Adj] (A B : Finset V) :
+    edgeDensity G A B = edgeDensity G B A := by
+  rw [edgeDensity_eq_mathlib, edgeDensity_eq_mathlib, G.edgeDensity_comm]
+
+/-- **Symmetry of ε-regularity.**  `IsEpsilonRegular G ε A B` holds iff
+    `IsEpsilonRegular G ε B A`.  A witness `(A', B')` for the `(B, A)` orientation
+    becomes the witness `(B', A')` for `(A, B)`, and the density difference
+    `|d(A', B') − d(B, A)|` equals `|d(B', A') − d(A, B)|` by `edgeDensity_comm`. -/
+theorem isEpsilonRegular_comm (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (A B : Finset V) :
+    IsEpsilonRegular G eps A B ↔ IsEpsilonRegular G eps B A := by
+  -- One implication suffices by symmetry of the statement.
+  have key : ∀ X Y : Finset V, IsEpsilonRegular G eps X Y →
+      IsEpsilonRegular G eps Y X := by
+    intro X Y h A' B' hA' hB' hcA' hcB'
+    have hxy := h B' A' hB' hA' hcB' hcA'
+    rwa [edgeDensity_comm G B' A', edgeDensity_comm G X Y] at hxy
+  exact ⟨key A B, key B A⟩
+
+/-- The empty left set has zero edge density. -/
+theorem edgeDensity_empty_left (G : SimpleGraph V) [DecidableRel G.Adj]
+    (B : Finset V) : edgeDensity G ∅ B = 0 := by
+  simp [edgeDensity]
+
+/-- The empty right set has zero edge density. -/
+theorem edgeDensity_empty_right (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A : Finset V) : edgeDensity G A ∅ = 0 := by
+  simp [edgeDensity]
+
+/-- **Irregularity is a symmetric relation on parts.**  The ordered-pair set that
+    `IsRegularPartition` thresholds — distinct parts that fail to be ε-regular —
+    is closed under swapping coordinates.  Combined with `isEpsilonRegular_comm`,
+    this shows the irregular pairs come in matched `(P, Q)`/`(Q, P)` transpositions. -/
+theorem irregularPairs_swap_mem (G : SimpleGraph V) [DecidableRel G.Adj]
+    (eps : ℚ) (parts : Finset (Finset V)) (P Q : Finset V)
+    (_hP : P ∈ parts) (_hQ : Q ∈ parts)
+    (hpair : P ≠ Q ∧ ¬IsEpsilonRegular G eps P Q) :
+    Q ≠ P ∧ ¬IsEpsilonRegular G eps Q P := by
+  refine ⟨fun h => hpair.1 h.symm, ?_⟩
+  rw [isEpsilonRegular_comm]
+  exact hpair.2
+
+end Szemeredi.Regularity.OQ01

--- a/src/data/research/problems/szemeredi-regularity-oq-01.json
+++ b/src/data/research/problems/szemeredi-regularity-oq-01.json
@@ -1,0 +1,29 @@
+{
+  "id": "szemeredi-regularity-oq-01",
+  "name": "Symmetry of edge density and ε-regularity",
+  "parentId": "szemeredi-regularity",
+  "status": "completed",
+  "knowledge": {
+    "score": 8,
+    "insights": [
+      "The Szemerédi Regularity gallery file (bridged to Mathlib's szemeredi_regularity) develops edgeDensity G A B and IsEpsilonRegular G eps A B but never records that BOTH are symmetric in their two vertex-set arguments — standard textbook treatments state regularity for UNORDERED pairs precisely because of this symmetry. This entry supplies it.",
+      "edgeDensity_comm (d(A,B) = d(B,A)): proved by transporting along the gallery's edgeDensity_eq_mathlib bridge to Mathlib's SimpleGraph.edgeDensity, which is symmetric via G.symm (SimpleGraph.edgeDensity_comm). One-line rw [edgeDensity_eq_mathlib, edgeDensity_eq_mathlib, G.edgeDensity_comm].",
+      "isEpsilonRegular_comm (IsEpsilonRegular G ε A B ↔ ... B A): a witness (A',B') for one orientation is the swapped witness (B',A') for the other; the density difference |d(A',B')−d(B,A)| equals |d(B',A')−d(A,B)| by edgeDensity_comm. Proved via a single `key : ∀ X Y, regular X Y → regular Y X` reused both ways (statement is self-symmetric).",
+      "irregularPairs_swap_mem: the ordered-pair set thresholded by IsRegularPartition (distinct parts failing ε-regularity) is closed under coordinate swap — irregularity is a symmetric relation on parts, so irregular pairs come in matched (P,Q)/(Q,P) transpositions.",
+      "edgeDensity_empty_left/right: degenerate boundary values d(∅,B)=d(A,∅)=0 (the dite guard (card·card=0) fires)."
+    ],
+    "builtItems": [
+      "SzemerediRegularityOQ01.lean: 5 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Imports Proofs.SzemerediRegularity (reuses edgeDensity_eq_mathlib bridge + Core defs).",
+      "edgeDensity_comm (headline symmetry), isEpsilonRegular_comm (regularity symmetry), edgeDensity_empty_left, edgeDensity_empty_right, irregularPairs_swap_mem (irregularity is symmetric on parts)."
+    ],
+    "progressSummary": "COMPLETE. First child of the (Mathlib-bridged, complete) szemeredi-regularity gallery entry. Fills a structural gap: the gallery's edgeDensity and IsEpsilonRegular were never shown symmetric in their two arguments, yet regularity is conventionally an unordered-pair notion. edgeDensity_comm (d(A,B)=d(B,A)) via the existing Mathlib bridge + SimpleGraph.edgeDensity_comm; isEpsilonRegular_comm (the iff) via witness-swap; irregularPairs_swap_mem (irregular-pair set closed under swap). All 0-axiom verified, no native_decide.",
+    "nextSteps": [
+      "Complement transfer: for disjoint A,B (so every cross pair is non-adjacent-or-not), d_{Gᶜ}(A,B) = 1 − d_G(A,B), hence IsEpsilonRegular Gᶜ ε A B ↔ IsEpsilonRegular G ε A B — regularity passes to the complement graph.",
+      "Use isEpsilonRegular_comm to halve the irregular-pair count bookkeeping: the IsRegularPartition threshold counts ordered pairs, but symmetry means the underlying unordered irregular pairs are half as many.",
+      "edgeDensity range packaged: edgeDensity G A B ∈ Set.Icc 0 1 (combine edgeDensity_nonneg + edgeDensity_le_one) as a single membership lemma for downstream positivity/interval reasoning."
+    ]
+  },
+  "relatedProofs": [
+    "szemeredi-regularity"
+  ]
+}


### PR DESCRIPTION
## Szemerédi Regularity — OQ-01 (symmetry of density and regularity)

The gallery file `SzemerediRegularity.lean` (bridged to Mathlib's `szemeredi_regularity`) develops `edgeDensity G A B` and `IsEpsilonRegular G eps A B`, but never records that both are **symmetric** in their two vertex-set arguments — even though regularity is conventionally an *unordered-pair* notion. This first child fills that gap.

### Theorems

- **`edgeDensity_comm`** — `d(A, B) = d(B, A)`, via the gallery's `edgeDensity_eq_mathlib` bridge and Mathlib's symmetric `SimpleGraph.edgeDensity_comm` (`G.symm`).
- **`isEpsilonRegular_comm`** — `IsEpsilonRegular G ε A B ↔ IsEpsilonRegular G ε B A`: a witness `(A', B')` for one orientation is the swapped witness `(B', A')` for the other, with the density difference unchanged by `edgeDensity_comm`.
- `edgeDensity_empty_left` / `edgeDensity_empty_right` — boundary values `d(∅, B) = d(A, ∅) = 0`.
- `irregularPairs_swap_mem` — the ordered irregular-pair set underlying `IsRegularPartition` is closed under coordinate swap: irregularity is a symmetric relation on parts.

### Verification

- `SzemerediRegularityOQ01.lean`: 5 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the three headline theorems: `propext, Classical.choice, Quot.sound` only.
- Builds via `./proofs/scripts/docker-build.sh Proofs.SzemerediRegularityOQ01` (7745 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)