### PR TITLE
research(brouwer-fixed-point-oq-02-oq-02-oq-01): a priori / a posteriori Banach error estimates for contraction iteration [0-axiom verified]

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ02OQ02OQ01.lean
@@ -1,0 +1,127 @@
+/-
+# Brouwer Fixed Point — OQ-02-OQ-02-OQ-01: a priori / a posteriori error estimates for contraction iteration
+
+The parent `BrouwerFixedPointOQ02OQ02` studies the query complexity of finding
+approximate fixed points of contractions, proving the *a posteriori-free* error
+bound `|xₙ − x*| ≤ Lⁿ·|x₀ − x*|` (which presupposes knowledge of the unknown
+distance `|x₀ − x*|`).  This child supplies the two estimates that make the
+contraction iteration *practically computable*, both standard consequences of the
+Banach fixed-point setup and both absent from the parent:
+
+  * `apriori_estimate`     — `|xₙ − x*| ≤ Lⁿ/(1−L) · |x₁ − x₀|`.  The bound is
+    expressed entirely in terms of the *first step* `|x₁ − x₀|`, computable before
+    iterating; it answers "how many steps for accuracy ε?" without knowing `x*`.
+  * `aposteriori_estimate` — `|xₙ₊₁ − x*| ≤ L/(1−L) · |xₙ₊₁ − xₙ|`.  The bound
+    uses only the *latest step* `|xₙ₊₁ − xₙ|`, giving a computable stopping
+    criterion: iterate until the increment is below `(1−L)/L · ε`.
+
+Both follow from the geometric decay `|xₙ − x*| ≤ Lⁿ·|x₀ − x*|` (`iterate_dist`,
+reproved here self-containedly) together with the one-step distance estimate
+`(1−L)·|x₀ − x*| ≤ |x₁ − x₀|` (`initial_dist`).  We also record the Lipschitz
+composition law `|g(f x) − g(f y)| ≤ L₂L₁·|x − y|` (`lipschitz_comp`) and its
+corollary that a composite of contractions is a contraction (`contraction_comp`),
+the structural fact behind iterating several maps.
+
+All results are fully machine-checked (0 axioms, 0 sorries) and self-contained:
+the contraction is given abstractly as `∀ x y, |f x − f y| ≤ L·|x − y|` with a
+fixed point `f x* = x*` and the iteration `xₙ₊₁ = f xₙ`.
+
+Reference: Banach (1922); see also the query-complexity parent OQ-02-OQ-02.
+-/
+
+import Mathlib
+
+namespace BrouwerOQ02OQ02OQ01
+
+/-- **Geometric decay of the iteration error.**  For a contraction `f` with
+    constant `L ≥ 0`, fixed point `x*`, and iteration `xₙ₊₁ = f xₙ`,
+    `|xₙ − x*| ≤ Lⁿ · |x₀ − x*|`.  Reproved self-containedly (the parent states
+    the analogous bound on `[0,1]`). -/
+theorem iterate_dist (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n))
+    (xstar : ℝ) (hfp : f xstar = xstar) (n : ℕ) :
+    |x n - xstar| ≤ L ^ n * |x 0 - xstar| := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    have h := hf (x n) xstar
+    rw [hfp, ← hx n] at h
+    calc |x (n + 1) - xstar| ≤ L * |x n - xstar| := h
+      _ ≤ L * (L ^ n * |x 0 - xstar|) := mul_le_mul_of_nonneg_left ih hL0
+      _ = L ^ (n + 1) * |x 0 - xstar| := by ring
+
+/-- **One-step distance estimate.**  `(1 − L)·|x₀ − x*| ≤ |x₁ − x₀|`, equivalently
+    `|x₀ − x*| ≤ |x₁ − x₀| / (1 − L)`: the unknown distance to the fixed point is
+    controlled by the (computable) first increment. -/
+theorem initial_dist (f : ℝ → ℝ) (L : ℝ) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n))
+    (xstar : ℝ) (hfp : f xstar = xstar) :
+    |x 0 - xstar| ≤ |x 1 - x 0| / (1 - L) := by
+  have hcontr : (0 : ℝ) < 1 - L := by linarith
+  have ht : |x 0 - xstar| ≤ |x 0 - x 1| + |x 1 - xstar| := abs_sub_le _ _ _
+  rw [abs_sub_comm (x 0) (x 1)] at ht
+  have hL : |x 1 - xstar| ≤ L * |x 0 - xstar| := by
+    have h := hf (x 0) xstar
+    rw [hfp, ← hx 0] at h
+    exact h
+  rw [le_div_iff₀ hcontr]
+  nlinarith [ht, hL]
+
+/-- **A priori error estimate.**  `|xₙ − x*| ≤ Lⁿ/(1−L) · |x₁ − x₀|`.  Expressed
+    purely in terms of the first increment `|x₁ − x₀|`, so the number of
+    iterations needed for a target accuracy can be bounded *before* iterating. -/
+theorem apriori_estimate (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n))
+    (xstar : ℝ) (hfp : f xstar = xstar) (n : ℕ) :
+    |x n - xstar| ≤ L ^ n / (1 - L) * |x 1 - x 0| := by
+  have hcontr : (0 : ℝ) < 1 - L := by linarith
+  have h1 := iterate_dist f L hL0 hf x hx xstar hfp n
+  have h2 := initial_dist f L hL1 hf x hx xstar hfp
+  have hLn : (0 : ℝ) ≤ L ^ n := pow_nonneg hL0 n
+  calc |x n - xstar| ≤ L ^ n * |x 0 - xstar| := h1
+    _ ≤ L ^ n * (|x 1 - x 0| / (1 - L)) := mul_le_mul_of_nonneg_left h2 hLn
+    _ = L ^ n / (1 - L) * |x 1 - x 0| := by ring
+
+/-- **A posteriori error estimate.**  `|xₙ₊₁ − x*| ≤ L/(1−L) · |xₙ₊₁ − xₙ|`.
+    Expressed in terms of the latest increment, giving a computable stopping
+    criterion: stop once `|xₙ₊₁ − xₙ| ≤ (1−L)/L · ε`. -/
+theorem aposteriori_estimate (f : ℝ → ℝ) (L : ℝ) (hL0 : 0 ≤ L) (hL1 : L < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L * |x - y|)
+    (x : ℕ → ℝ) (hx : ∀ n, x (n + 1) = f (x n))
+    (xstar : ℝ) (hfp : f xstar = xstar) (n : ℕ) :
+    |x (n + 1) - xstar| ≤ L / (1 - L) * |x (n + 1) - x n| := by
+  have hcontr : (0 : ℝ) < 1 - L := by linarith
+  have hstep := hf (x n) xstar
+  rw [hfp, ← hx n] at hstep
+  have ht : |x n - xstar| ≤ |x n - x (n + 1)| + |x (n + 1) - xstar| := abs_sub_le _ _ _
+  rw [abs_sub_comm (x n) (x (n + 1))] at ht
+  have hLt := mul_le_mul_of_nonneg_left ht hL0
+  have key : (1 - L) * |x (n + 1) - xstar| ≤ L * |x (n + 1) - x n| := by
+    nlinarith [hstep, hLt]
+  rw [div_mul_eq_mul_div, le_div_iff₀ hcontr]
+  nlinarith [key]
+
+/-- **Lipschitz composition law.**  If `f` is `L₁`-Lipschitz and `g` is
+    `L₂`-Lipschitz (`L₂ ≥ 0`), then `g ∘ f` is `L₂L₁`-Lipschitz. -/
+theorem lipschitz_comp (f g : ℝ → ℝ) (L1 L2 : ℝ) (hL2 : 0 ≤ L2)
+    (hf : ∀ x y, |f x - f y| ≤ L1 * |x - y|)
+    (hg : ∀ x y, |g x - g y| ≤ L2 * |x - y|) (x y : ℝ) :
+    |g (f x) - g (f y)| ≤ (L2 * L1) * |x - y| := by
+  calc |g (f x) - g (f y)| ≤ L2 * |f x - f y| := hg (f x) (f y)
+    _ ≤ L2 * (L1 * |x - y|) := mul_le_mul_of_nonneg_left (hf x y) hL2
+    _ = (L2 * L1) * |x - y| := by ring
+
+/-- **A composite of contractions is a contraction.**  If `f` is an `L₁`-contraction
+    and `g` an `L₂`-contraction (`0 ≤ L₁, L₂ < 1`), then `g ∘ f` is a contraction
+    with constant `L₂L₁ < 1`. -/
+theorem contraction_comp (f g : ℝ → ℝ) (L1 L2 : ℝ)
+    (hL1_0 : 0 ≤ L1) (hL1_1 : L1 < 1) (hL2_0 : 0 ≤ L2) (hL2_1 : L2 < 1)
+    (hf : ∀ x y, |f x - f y| ≤ L1 * |x - y|)
+    (hg : ∀ x y, |g x - g y| ≤ L2 * |x - y|) :
+    L2 * L1 < 1 ∧ ∀ x y, |g (f x) - g (f y)| ≤ (L2 * L1) * |x - y| :=
+  ⟨by nlinarith, fun x y => lipschitz_comp f g L1 L2 hL2_0 hf hg x y⟩
+
+end BrouwerOQ02OQ02OQ01

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -1,13 +1,13 @@
 {
   "slug": "brouwer-fixed-point-oq-02-oq-02-oq-01",
-  "title": "brouwer-fixed-point-oq-02-oq-02-oq-01",
-  "phase": "OBSERVE",
-  "status": "active",
+  "title": "A priori and a posteriori error estimates for contraction iteration",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
-    "formal": "",
-    "plain": "",
+    "formal": "For an L-contraction f on ℝ (0 ≤ L < 1) with fixed point x* and iteration xₙ₊₁ = f xₙ: |xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀| (a priori) and |xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ| (a posteriori).",
+    "plain": "The two classical Banach error estimates that make contraction iteration practically computable: bound the distance to the fixed point using either the first step (a priori) or the latest step (a posteriori).",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,235 +16,48 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-30T11:03:20-07:00",
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Formalized the a priori / a posteriori Banach error estimates for contraction iteration, plus Lipschitz composition.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None — complete.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE. Child of brouwer-fixed-point-oq-02-oq-02 (query complexity for function classes). The parent proves |xₙ − x*| ≤ Lⁿ·|x₀ − x*|, which presupposes the unknown distance |x₀ − x*|. This entry supplies the two computable Banach estimates: apriori_estimate |xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀| (uses only the first increment) and aposteriori_estimate |xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ| (uses only the latest increment, a stopping criterion). Plus the Lipschitz composition law and the contraction-composition corollary. BrouwerFixedPointOQ02OQ02OQ01.lean, 6 theorems, 0 axioms, 0 sorries, self-contained, no native_decide.",
+    "builtItems": [
+      "BrouwerFixedPointOQ02OQ02OQ01.lean: 6 theorems, 0 axioms (propext/Classical.choice/Quot.sound only), 0 sorries. Self-contained: contraction given as ∀ x y, |f x − f y| ≤ L·|x − y| with f x* = x* and xₙ₊₁ = f xₙ.",
+      "iterate_dist: |xₙ − x*| ≤ Lⁿ·|x₀ − x*| (geometric decay, induction; reproves parent's bound self-containedly).",
+      "initial_dist: (1−L)·|x₀ − x*| ≤ |x₁ − x₀| — one-step distance estimate via triangle inequality + contraction on the first step.",
+      "apriori_estimate: |xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀| (combine iterate_dist + initial_dist).",
+      "aposteriori_estimate: |xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ| (triangle + contraction, clear denominator via le_div_iff₀ + nlinarith).",
+      "lipschitz_comp: |g(f x) − g(f y)| ≤ L₂L₁·|x − y|; contraction_comp: L₂L₁ < 1 ∧ composite is a contraction."
+    ],
+    "insights": [
+      "Parent oq-02-oq-02 proves the bound |xₙ − x*| ≤ Lⁿ·|x₀ − x*| which is not directly usable (|x₀ − x*| unknown). The classical fix is the a priori estimate, expressing the bound via the computable first increment |x₁ − x₀|.",
+      "Key lemma initial_dist: |x₀ − x*| ≤ |x₀ − x₁| + |x₁ − x*| (triangle) and |x₁ − x*| = |f x₀ − f x*| ≤ L|x₀ − x*| give (1−L)|x₀ − x*| ≤ |x₁ − x₀|.",
+      "A posteriori uses the same idea one step later: |xₙ₊₁ − x*| ≤ L|xₙ − x*| ≤ L(|xₙ − xₙ₊₁| + |xₙ₊₁ − x*|), so (1−L)|xₙ₊₁ − x*| ≤ L|xₙ₊₁ − xₙ|.",
+      "Lean: rw [hfp, ← hx n] at h turns |f xₙ − f x*| ≤ L|xₙ − x*| into |xₙ₊₁ − x*| ≤ L|xₙ − x*| (hfp : f x* = x*; ← hx n : f xₙ → xₙ₊₁). Clear divisions with le_div_iff₀ + div_mul_eq_mul_div then nlinarith. Multiply a hypothesis by L≥0 via mul_le_mul_of_nonneg_left before nlinarith so it sees the product.",
+      "Composition: |g(f x) − g(f y)| ≤ L₂|f x − f y| ≤ L₂L₁|x − y|; L₂L₁ < 1 from 0 ≤ Lᵢ < 1 by nlinarith. Self-contained, no domain restriction needed (contraction stated on all of ℝ)."
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge Base: brouwer-fixed-point-oq-02-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "nextSteps": [
+      "Convergence/existence: the iterates are Cauchy (|xₘ − xₙ| ≤ Lⁿ/(1−L)|x₁ − x₀|) so converge in ℝ to a fixed point — formalize existence from the a priori bound (currently x* is a hypothesis).",
+      "Turn the a priori estimate into an explicit query count: solve Lⁿ/(1−L)|x₁ − x₀| ≤ ε for n to recover the parent's O(log 1/ε) iteration bound with explicit constants.",
+      "Iterating m maps: chain contraction_comp to bound a composite of m contractions by the product of their constants."
+    ]
   },
-  "tags": [],
+  "tags": [
+    "extension"
+  ],
   "relatedProofs": [
     "brouwer-fixed-point",
-    "brouwer-fixed-point-oq-01",
-    "brouwer-fixed-point-oq-01-oq-02",
-    "brouwer-fixed-point-oq-01-oq-02-oq-03",
-    "brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01",
-    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
-    "brouwer-fixed-point-oq-02-oq-02",
-    "brouwer-fixed-point-oq-04",
-    "brouwer-fixed-point-oq-04-oq-02",
-    "brouwer-fixed-point-oq-04-oq-03",
-    "brouwer-fixed-point-oq-04-oq-04"
-  ],
-  "references": {
-    "papers": [],
-    "urls": [],
-    "mathlib": []
-  },
-  "started": "2026-03-30T18:27:56.397Z",
-  "lastUpdate": "2026-03-30T18:27:56.408Z",
-  "leanFiles": [
-    {
-      "path": "Proofs/BrouwerFixedPoint.lean",
-      "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 249,
-      "theoremCount": 5,
-      "axiomCount": 2,
-      "defCount": 5,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPoint.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ01.lean",
-      "filename": "BrouwerFixedPointOQ01.lean",
-      "lineCount": 403,
-      "theoremCount": 16,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-      "filename": "BrouwerFixedPointOQ01OQ02.lean",
-      "lineCount": 462,
-      "theoremCount": 14,
-      "axiomCount": 4,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ01OQ02OQ03.lean",
-      "filename": "BrouwerFixedPointOQ01OQ02OQ03.lean",
-      "lineCount": 172,
-      "theoremCount": 5,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02OQ03.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ01OQ02OQ03OQ01.lean",
-      "filename": "BrouwerFixedPointOQ01OQ02OQ03OQ01.lean",
-      "lineCount": 215,
-      "theoremCount": 12,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02OQ03OQ01.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
-      "filename": "BrouwerFixedPointOQ01OQ03.lean",
-      "lineCount": 217,
-      "theoremCount": 6,
-      "axiomCount": 1,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ02.lean",
-      "filename": "BrouwerFixedPointOQ02.lean",
-      "lineCount": 392,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ02Ext.lean",
-      "filename": "BrouwerFixedPointOQ02Ext.lean",
-      "lineCount": 204,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02Ext.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
-      "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1071,
-      "theoremCount": 33,
-      "axiomCount": 0,
-      "defCount": 14,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ02OQ02.lean",
-      "filename": "BrouwerFixedPointOQ02OQ02.lean",
-      "lineCount": 269,
-      "theoremCount": 15,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02OQ02.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ02OQ03.lean",
-      "filename": "BrouwerFixedPointOQ02OQ03.lean",
-      "lineCount": 215,
-      "theoremCount": 5,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 1,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02OQ03.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ02Stability.lean",
-      "filename": "BrouwerFixedPointOQ02Stability.lean",
-      "lineCount": 198,
-      "theoremCount": 7,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ02Stability.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ04.lean",
-      "filename": "BrouwerFixedPointOQ04.lean",
-      "lineCount": 506,
-      "theoremCount": 22,
-      "axiomCount": 2,
-      "defCount": 11,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
-      "filename": "BrouwerFixedPointOQ04OQ01.lean",
-      "lineCount": 297,
-      "theoremCount": 8,
-      "axiomCount": 2,
-      "defCount": 6,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
-      "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
-      "theoremCount": 15,
-      "axiomCount": 0,
-      "defCount": 8,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ02.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",
-      "filename": "BrouwerFixedPointOQ04OQ03.lean",
-      "lineCount": 157,
-      "theoremCount": 2,
-      "axiomCount": 2,
-      "defCount": 8,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ03.lean"
-    },
-    {
-      "path": "Proofs/BrouwerFixedPointOQ04OQ04.lean",
-      "filename": "BrouwerFixedPointOQ04OQ04.lean",
-      "lineCount": 406,
-      "theoremCount": 12,
-      "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean"
-    }
+    "brouwer-fixed-point-oq-02-oq-02"
   ]
 }


### PR DESCRIPTION
## Brouwer Fixed Point — OQ-02-OQ-02-OQ-01 (computable contraction error estimates)

The parent `BrouwerFixedPointOQ02OQ02` (query complexity of fixed points) proves the geometric error bound `|xₙ − x*| ≤ Lⁿ·|x₀ − x*|`, which presupposes the **unknown** distance `|x₀ − x*|`. This child supplies the two classical Banach estimates that make the iteration *practically computable*, both absent from the parent.

### Theorems

- `iterate_dist` — `|xₙ − x*| ≤ Lⁿ·|x₀ − x*|` (geometric decay, reproved self-containedly).
- `initial_dist` — `(1 − L)·|x₀ − x*| ≤ |x₁ − x₀|` (one-step distance estimate).
- **`apriori_estimate`** — `|xₙ − x*| ≤ Lⁿ/(1−L)·|x₁ − x₀|`: uses only the *first* increment, so the step count for a target ε is known *before* iterating.
- **`aposteriori_estimate`** — `|xₙ₊₁ − x*| ≤ L/(1−L)·|xₙ₊₁ − xₙ|`: uses only the *latest* increment — a computable stopping criterion.
- `lipschitz_comp` / `contraction_comp` — `|g(f x) − g(f y)| ≤ L₂L₁·|x − y|`, and a composite of contractions is a contraction (`L₂L₁ < 1`).

### Verification

- `BrouwerFixedPointOQ02OQ02OQ01.lean`: 6 theorems, **0 axioms, 0 sorries**, no `native_decide`, self-contained (contraction given abstractly, no parent import).
- `#print axioms` on the headline theorems: `propext, Classical.choice, Quot.sound` only.
- Builds via `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ02OQ02OQ01` (7743 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)