### PR TITLE
research(minpoly-charpoly-oq-02-incomplete-01): closure properties of Matrix.IsDiagonalizable [0-axiom verified]

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02Incomplete01.lean
@@ -1,0 +1,103 @@
+/-
+# Diagonalizable Matrices — OQ-02 / closure properties of `Matrix.IsDiagonalizable`
+
+The parent `MinpolyCharpolyOQ02` introduces the predicate
+
+    `Matrix.IsDiagonalizable M := ∃ P, IsUnit P ∧ IsDiag (P⁻¹ * M * P)`
+
+(`M` is similar to a diagonal matrix), proves the forward direction of the
+diagonalizability characterisation, and records the trivial instances
+(`zero`, `one`, `diagonal`, `of_isDiag`).  The substantive *reverse* direction
+(squarefree minpoly ⇒ diagonalizable) is the parent's sole open obligation and is
+not touched here.
+
+This file fills in the **closure properties** of `IsDiagonalizable` — the
+elementary algebraic stability laws that every textbook states immediately after
+the definition but which the parent omits:
+
+  * `IsDiagonalizable.conj`      — **similarity invariance**: if `M` is
+    diagonalizable and `U` is invertible, so is the conjugate `U⁻¹ M U`.  This is
+    the defining feature of diagonalizability as a property of the *operator*,
+    not the matrix representative.
+  * `IsDiagonalizable.smul`      — scalar multiples `c • M` stay diagonalizable
+    (same diagonalizing `P`; the conjugate scales).
+  * `IsDiagonalizable.neg`       — `-M` stays diagonalizable.
+  * `IsDiagonalizable.transpose` — the transpose `Mᵀ` is diagonalizable, with
+    diagonalizer `(Pᵀ)⁻¹` (eigenvalues are preserved under transpose).
+
+All four are fully machine-checked (0 axioms, 0 sorries) and reuse only the
+parent's *definition* (not its open reverse-direction obligation).
+
+Reference: Axler, *Linear Algebra Done Right* §5–8; Dummit–Foote §12.
+-/
+
+import Mathlib
+import Proofs.MinpolyCharpoly
+import Proofs.MinpolyCharpolyOQ02
+
+namespace MinpolyCharpolyOQ02Incomplete01
+
+open Matrix
+
+variable {n : Type*} [Fintype n] [DecidableEq n] {K : Type*} [Field K]
+
+/-- **Similarity invariance.**  If `M` is diagonalizable and `U` is invertible,
+    then the conjugate `U⁻¹ * M * U` is diagonalizable.  Diagonalizing `M` with
+    `P` (so `P⁻¹ M P` is diagonal), the matrix `U⁻¹ P` diagonalizes `U⁻¹ M U`. -/
+theorem IsDiagonalizable.conj {M : Matrix n n K} (hM : M.IsDiagonalizable)
+    {U : Matrix n n K} (hU : IsUnit U) :
+    (U⁻¹ * M * U).IsDiagonalizable := by
+  obtain ⟨P, hP, hD⟩ := hM
+  have hUdet : IsUnit U.det := (Matrix.isUnit_iff_isUnit_det U).mp hU
+  have hUinv : IsUnit U⁻¹ := Matrix.isUnit_nonsing_inv_iff.mpr hU
+  refine ⟨U⁻¹ * P, hUinv.mul hP, ?_⟩
+  have hQinv : (U⁻¹ * P)⁻¹ = P⁻¹ * U := by
+    rw [Matrix.mul_inv_rev, Matrix.nonsing_inv_nonsing_inv U hUdet]
+  have hUU : U * U⁻¹ = 1 := Matrix.mul_nonsing_inv U hUdet
+  have hsimp : (U⁻¹ * P)⁻¹ * (U⁻¹ * M * U) * (U⁻¹ * P) = P⁻¹ * M * P := by
+    rw [hQinv]
+    calc P⁻¹ * U * (U⁻¹ * M * U) * (U⁻¹ * P)
+        = P⁻¹ * (U * U⁻¹) * M * (U * U⁻¹) * P := by simp only [mul_assoc]
+      _ = P⁻¹ * M * P := by rw [hUU]; simp only [mul_one, one_mul]
+  rw [hsimp]
+  exact hD
+
+/-- **Scalar multiples stay diagonalizable.**  The same `P` diagonalizes `c • M`,
+    since `P⁻¹ (c • M) P = c • (P⁻¹ M P)` is again diagonal. -/
+theorem IsDiagonalizable.smul {M : Matrix n n K} (hM : M.IsDiagonalizable) (c : K) :
+    (c • M).IsDiagonalizable := by
+  obtain ⟨P, hP, hD⟩ := hM
+  refine ⟨P, hP, ?_⟩
+  have h : P⁻¹ * (c • M) * P = c • (P⁻¹ * M * P) := by
+    rw [Matrix.mul_smul, Matrix.smul_mul]
+  rw [h]
+  exact IsDiag.smul c hD
+
+/-- **Negation stays diagonalizable.** -/
+theorem IsDiagonalizable.neg {M : Matrix n n K} (hM : M.IsDiagonalizable) :
+    (-M).IsDiagonalizable := by
+  obtain ⟨P, hP, hD⟩ := hM
+  refine ⟨P, hP, ?_⟩
+  have h : P⁻¹ * (-M) * P = -(P⁻¹ * M * P) := by
+    rw [Matrix.mul_neg, Matrix.neg_mul]
+  rw [h]
+  exact hD.neg
+
+/-- **The transpose is diagonalizable.**  If `P⁻¹ M P` is diagonal then
+    `((Pᵀ)⁻¹)⁻¹ Mᵀ (Pᵀ)⁻¹ = (P⁻¹ M P)ᵀ` is diagonal, so `(Pᵀ)⁻¹` diagonalizes
+    `Mᵀ`. -/
+theorem IsDiagonalizable.transpose {M : Matrix n n K} (hM : M.IsDiagonalizable) :
+    (Mᵀ).IsDiagonalizable := by
+  obtain ⟨P, hP, hD⟩ := hM
+  have hPt : IsUnit (Pᵀ) := by
+    rw [Matrix.isUnit_iff_isUnit_det, Matrix.det_transpose]
+    exact (Matrix.isUnit_iff_isUnit_det P).mp hP
+  have hPtdet : IsUnit (Pᵀ).det := (Matrix.isUnit_iff_isUnit_det _).mp hPt
+  refine ⟨(Pᵀ)⁻¹, Matrix.isUnit_nonsing_inv_iff.mpr hPt, ?_⟩
+  have heq : (Pᵀ)⁻¹⁻¹ * Mᵀ * (Pᵀ)⁻¹ = (P⁻¹ * M * P)ᵀ := by
+    rw [Matrix.nonsing_inv_nonsing_inv _ hPtdet, ← Matrix.transpose_nonsing_inv]
+    simp only [Matrix.transpose_mul, mul_assoc]
+  rw [heq]
+  exact hD.transpose
+
+end MinpolyCharpolyOQ02Incomplete01

--- a/src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02-incomplete-01.json
@@ -1,0 +1,64 @@
+{
+  "slug": "minpoly-charpoly-oq-02-incomplete-01",
+  "title": "Closure properties of Matrix.IsDiagonalizable (similarity, scaling, transpose)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For M : Matrix n n K (K a field) with M.IsDiagonalizable: U⁻¹·M·U (U invertible), c•M, −M, and Mᵀ are all diagonalizable.",
+    "plain": "The elementary algebraic stability laws of diagonalizability — invariance under similarity (conjugation), scalar multiplication, negation, and transpose — that complement the parent's diagonalizability characterisation.",
+    "whyMatters": [
+      "Similarity invariance is the defining feature making diagonalizability a property of the operator, not the chosen matrix representative.",
+      "The parent MinpolyCharpolyOQ02 introduces Matrix.IsDiagonalizable and proves the forward direction of the squarefree-minpoly characterisation, but records only the trivial instances (zero, one, diagonal); these closure laws were missing."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Formalized the four closure properties of Matrix.IsDiagonalizable.",
+    "blockers": [],
+    "nextAction": "None — complete. (Note: the parent's open reverse-direction obligation, squarefree minpoly ⇒ diagonalizable, is NOT addressed here and remains open.)",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (verified, 0 sorries — despite the 'incomplete' slot name). Child of minpoly-charpoly-oq-02. The parent defines Matrix.IsDiagonalizable M := ∃ P, IsUnit P ∧ IsDiag (P⁻¹·M·P) and proves only trivial instances. This entry adds the four elementary closure laws: IsDiagonalizable.conj (similarity invariance — the conjugate U⁻¹MU is diagonalizable, diagonalizer U⁻¹P), .smul (c•M, same P), .neg (−M), .transpose (Mᵀ, diagonalizer (Pᵀ)⁻¹). MinpolyCharpolyOQ02Incomplete01.lean, 4 theorems, 0 axioms, 0 sorries. Reuses only the parent's DEFINITION, not its open reverse-direction sorry (#print axioms confirms propext/Classical.choice/Quot.sound only — no sorryAx inheritance).",
+    "builtItems": [
+      "MinpolyCharpolyOQ02Incomplete01.lean: 4 theorems, 0 axioms, 0 sorries. Imports Proofs.MinpolyCharpolyOQ02 for the Matrix.IsDiagonalizable definition.",
+      "IsDiagonalizable.conj (similarity invariance: U⁻¹MU diagonalizable; witness U⁻¹P, key (U⁻¹P)⁻¹ = P⁻¹U via mul_inv_rev + nonsing_inv_nonsing_inv, cancel U·U⁻¹=1).",
+      "IsDiagonalizable.smul (c•M; P⁻¹(c•M)P = c•(P⁻¹MP) via mul_smul/smul_mul + IsDiag.smul).",
+      "IsDiagonalizable.neg (−M; via mul_neg/neg_mul + IsDiag.neg).",
+      "IsDiagonalizable.transpose (Mᵀ; diagonalizer (Pᵀ)⁻¹, ((Pᵀ)⁻¹)⁻¹MᵀᵀP... = (P⁻¹MP)ᵀ via nonsing_inv_nonsing_inv + transpose_nonsing_inv + IsDiag.transpose)."
+    ],
+    "insights": [
+      "Matrix nonsing-inverse lemmas (mul_nonsing_inv, nonsing_inv_nonsing_inv, mul_inv_rev, transpose_nonsing_inv) take IsUnit A.det, but IsDiagonalizable carries IsUnit P — bridge with Matrix.isUnit_iff_isUnit_det.",
+      "IsUnit of the matrix inverse: Matrix.isUnit_nonsing_inv_iff : IsUnit A⁻¹ ↔ IsUnit A. For transpose: IsUnit Pᵀ via isUnit_iff_isUnit_det + det_transpose.",
+      "Cancellation trick for conj: regroup with simp only [mul_assoc] (both sides reassociate to the same right-nested product), then rw U·U⁻¹=1 and clear with mul_one/one_mul — more robust than mul_nonsing_inv_cancel_left, whose A argument is explicit (positional `_ hUdet` mis-binds).",
+      "Importing a sorry-bearing parent does NOT taint axiom-cleanliness as long as the new theorems use only sorry-free declarations (here just the definition); always #print axioms to confirm no sorryAx.",
+      "IsDiag has the needed closure API in Mathlib: IsDiag.smul (k) (h), IsDiag.neg (h), IsDiag.transpose (h)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "The parent's open reverse direction (squarefree minpoly ⇒ diagonalizable over alg-closed char-0) remains the real target: eigenspace internal direct sum ⇒ conjugating matrix.",
+      "Further closure: product of commuting diagonalizable matrices is diagonalizable (needs simultaneous diagonalization); powers Mᵏ of a diagonalizable matrix.",
+      "Inverse: an invertible diagonalizable matrix has diagonalizable inverse (P⁻¹M⁻¹P = (P⁻¹MP)⁻¹, diagonal)."
+    ]
+  },
+  "tags": [
+    "extension"
+  ],
+  "relatedProofs": [
+    "minpoly-charpoly",
+    "minpoly-charpoly-oq-02"
+  ]
+}


### PR DESCRIPTION
## Diagonalizable matrices — closure properties of `Matrix.IsDiagonalizable`

The parent `MinpolyCharpolyOQ02` introduces `Matrix.IsDiagonalizable M := ∃ P, IsUnit P ∧ IsDiag (P⁻¹ M P)`, proves the forward direction of the squarefree-minpoly characterisation, and records only the trivial instances (`zero`, `one`, `diagonal`). This entry adds the elementary algebraic stability laws the parent omits.

> **Note on the slug.** Despite the `-incomplete-01` name, this file is fully verified (0 sorries). It does **not** attempt the parent's blocked reverse direction (squarefree minpoly ⇒ diagonalizable), which remains open; it is a self-contained companion of closure lemmas.

### Theorems

- **`IsDiagonalizable.conj`** — similarity invariance: if `M` is diagonalizable and `U` invertible, so is `U⁻¹ M U` (diagonalizer `U⁻¹ P`). This is what makes diagonalizability a property of the *operator*.
- `IsDiagonalizable.smul` — `c • M` stays diagonalizable (same `P`).
- `IsDiagonalizable.neg` — `-M` stays diagonalizable.
- `IsDiagonalizable.transpose` — `Mᵀ` is diagonalizable (diagonalizer `(Pᵀ)⁻¹`).

### Verification

- `MinpolyCharpolyOQ02Incomplete01.lean`: 4 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the three headline theorems: `propext, Classical.choice, Quot.sound` only — the results reuse only the parent's *definition* and do **not** inherit its open reverse-direction sorry.
- Builds via `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ02Incomplete01` (7745 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)