### PR TITLE
research(erdos-1012-oq-01-oq-02): structural arithmetic of the Woodall edge threshold in n [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos1012OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos1012OQ01OQ02.lean
@@ -1,0 +1,81 @@
+/-
+  Erdős Problem #1012 — OQ-01-OQ-02: structural arithmetic of the edge threshold in n
+
+  The parent `Erdos1012OQ01` formalizes the Woodall function `f(k)` and the edge
+  threshold
+
+      edgeThreshold n k = C(n-k-1, 2) + C(k+2, 2) + 1,
+
+  evaluating it at the boundary points `n = 2k+2` and `n = 2k+3` (`threshold_at_extremal`,
+  `threshold_symmetric`, `threshold_diff`).  What the parent does *not* record is how
+  the threshold behaves as `n` varies — yet that monotonicity is exactly what makes
+  `f(k)` a well-defined "minimum `n₀`": the edge requirement tightens with each extra
+  vertex.  This file supplies that structure.
+
+  * `edgeThreshold_eq`        — the explicit polynomial form
+    `(n-k-1)(n-k-2)/2 + (k+2)(k+1)/2 + 1`.
+  * `edgeThreshold_succ_left` — the **recurrence in `n`** (for `n ≥ k+1`):
+    `edgeThreshold (n+1) k = edgeThreshold n k + (n-k-1)`.  Adding a vertex raises
+    the threshold by exactly `n-k-1` (the discrete derivative `C(m+1,2)-C(m,2)=m`).
+  * `edgeThreshold_lt_succ` / `edgeThreshold_mono` — strict and weak monotonicity
+    in `n` on the meaningful range `n ≥ k+2` / `n ≥ k+1`.
+
+  All results are fully machine-checked (0 axioms, 0 sorries), reusing the parent's
+  `edgeThreshold` definition.
+
+  Reference: Woodall (1972); https://erdosproblems.com/1012
+-/
+
+import Mathlib
+import Proofs.Erdos1012OQ01
+
+namespace Erdos1012OQ01OQ02
+
+open Erdos1012OQ01
+
+/-- Pascal's discrete-derivative identity for the second binomial coefficient:
+    `C(m+1, 2) = C(m, 2) + m`. -/
+theorem choose_two_succ (m : ℕ) : (m + 1).choose 2 = m.choose 2 + m := by
+  rw [Nat.choose_succ_succ m 1, Nat.choose_one_right]
+  show m + m.choose 2 = m.choose 2 + m
+  omega
+
+/-- **Explicit polynomial form of the edge threshold.** -/
+theorem edgeThreshold_eq (n k : ℕ) :
+    edgeThreshold n k =
+      (n - k - 1) * (n - k - 2) / 2 + (k + 2) * (k + 1) / 2 + 1 := by
+  unfold edgeThreshold
+  have e1 : n - k - 1 - 1 = n - k - 2 := by omega
+  have e2 : k + 2 - 1 = k + 1 := by omega
+  rw [Nat.choose_two_right, Nat.choose_two_right, e1, e2]
+
+/-- **Recurrence in `n`.**  For `n ≥ k+1`, adding one vertex raises the threshold
+    by exactly `n - k - 1`:  `edgeThreshold (n+1) k = edgeThreshold n k + (n-k-1)`.
+    This is the discrete derivative `C(m+1,2) − C(m,2) = m` with `m = n-k-1`. -/
+theorem edgeThreshold_succ_left (n k : ℕ) (h : k + 1 ≤ n) :
+    edgeThreshold (n + 1) k = edgeThreshold n k + (n - k - 1) := by
+  unfold edgeThreshold
+  have e : n + 1 - k - 1 = (n - k - 1) + 1 := by omega
+  rw [e, choose_two_succ (n - k - 1)]
+  ring
+
+/-- **Strict monotonicity in `n`.**  On the meaningful range `n ≥ k+2` (so the
+    leading binomial coefficient is genuinely growing), the threshold strictly
+    increases with each added vertex. -/
+theorem edgeThreshold_lt_succ (n k : ℕ) (h : k + 2 ≤ n) :
+    edgeThreshold n k < edgeThreshold (n + 1) k := by
+  rw [edgeThreshold_succ_left n k (by omega)]
+  omega
+
+/-- **Weak monotonicity in `n`.**  For `k+1 ≤ n ≤ m`,
+    `edgeThreshold n k ≤ edgeThreshold m k`. -/
+theorem edgeThreshold_mono (k : ℕ) {n m : ℕ} (hn : k + 1 ≤ n) (hnm : n ≤ m) :
+    edgeThreshold n k ≤ edgeThreshold m k := by
+  induction hnm with
+  | refl => exact le_refl _
+  | @step m h ih =>
+    have hkm : k + 1 ≤ m := le_trans hn h
+    rw [edgeThreshold_succ_left m k hkm]
+    omega
+
+end Erdos1012OQ01OQ02

--- a/src/data/research/problems/erdos-1012-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-01-oq-02.json
@@ -1,0 +1,63 @@
+{
+  "slug": "erdos-1012-oq-01-oq-02",
+  "title": "Structural arithmetic of the Woodall edge threshold in n (recurrence and monotonicity)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "edgeThreshold n k = C(n-k-1,2)+C(k+2,2)+1. For n ≥ k+1: edgeThreshold (n+1) k = edgeThreshold n k + (n-k-1); for n ≥ k+2 it is strictly increasing in n; for k+1 ≤ n ≤ m, edgeThreshold n k ≤ edgeThreshold m k.",
+    "plain": "How the Erdős/Woodall edge threshold C(n-k-1,2)+C(k+2,2)+1 varies with the vertex count n: an explicit polynomial form, an exact recurrence (each added vertex raises the threshold by n-k-1), and monotonicity — the structure that makes f(k) a well-defined minimum n₀.",
+    "whyMatters": [
+      "The parent Erdos1012OQ01 evaluates edgeThreshold only at the fixed boundary points n=2k+2 and n=2k+3; the variation in n was not recorded.",
+      "Monotonicity of the threshold in n is exactly what makes f(k) (the minimum n₀ with the long-cycle property) well-defined."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Formalized closed form, n-recurrence, and monotonicity of edgeThreshold.",
+    "blockers": [],
+    "nextAction": "None — complete.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE. Child of erdos-1012-oq-01 (Woodall function f(k) and edge threshold). The parent evaluates edgeThreshold n k = C(n-k-1,2)+C(k+2,2)+1 only at the boundary points n=2k+2, 2k+3. This entry supplies the variation in n: edgeThreshold_eq (explicit polynomial form), edgeThreshold_succ_left (recurrence: adding a vertex raises the threshold by exactly n-k-1, for n≥k+1), edgeThreshold_lt_succ (strict monotonicity for n≥k+2), edgeThreshold_mono (weak monotonicity for k+1≤n≤m). Erdos1012OQ01OQ02.lean, 1 helper + 4 theorems, 0 axioms, 0 sorries, no native_decide.",
+    "builtItems": [
+      "Erdos1012OQ01OQ02.lean: 5 theorems, 0 axioms (propext/Quot.sound only — no Classical.choice), 0 sorries. Imports Proofs.Erdos1012OQ01 for the edgeThreshold definition.",
+      "choose_two_succ: Pascal discrete-derivative C(m+1,2) = C(m,2) + m (via Nat.choose_succ_succ + Nat.choose_one_right).",
+      "edgeThreshold_eq: explicit form (n-k-1)(n-k-2)/2 + (k+2)(k+1)/2 + 1 (via Nat.choose_two_right + omega subtraction identities).",
+      "edgeThreshold_succ_left: edgeThreshold (n+1) k = edgeThreshold n k + (n-k-1) for n≥k+1 (the C(m+1,2)-C(m,2)=m recurrence with m=n-k-1).",
+      "edgeThreshold_lt_succ (strict mono, n≥k+2), edgeThreshold_mono (weak mono via induction on the ≤ proof)."
+    ],
+    "insights": [
+      "The threshold's discrete derivative in n is exactly n-k-1: C((n-k-1)+1,2) - C(n-k-1,2) = n-k-1. This is the structural reason the edge requirement tightens with each added vertex and f(k) is a well-defined minimum.",
+      "Lean gotcha: Nat.choose_succ_succ m 1 produces m.choose (1+1) (NOT m.choose 2); omega treats those as distinct atoms. Force the defeq with `show m + m.choose 2 = ...` before omega.",
+      "edgeThreshold_eq cannot be finished by omega alone (the m*(m-1) product is nonlinear); use Nat.choose_two_right and only the linear subtraction identities (n-k-1-1 = n-k-2, k+2-1 = k+1) under omega.",
+      "Weak monotonicity proved by `induction hnm with | refl | @step m h ih` on the ≤ proof (Nat.le.rec); the step case applies the n-recurrence and omega (treating edgeThreshold terms as atoms, n-k-1 ≥ 0)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Non-degeneracy: edgeThreshold n k ≤ C(n,2) (the complete-graph edge count) on the Woodall range n ≥ 2k+3, so the long-cycle hypothesis is satisfiable rather than vacuous.",
+      "Monotonicity in k for fixed n, and the joint growth rate Θ(n²) of the threshold.",
+      "Connect the n-recurrence to the parent's threshold_diff (the boundary difference C(k+2,2)-C(k+1,2) is the single step at n=2k+2)."
+    ]
+  },
+  "tags": [
+    "extension"
+  ],
+  "relatedProofs": [
+    "erdos-1012",
+    "erdos-1012-oq-01"
+  ]
+}


### PR DESCRIPTION
## Erdős #1012 — OQ-01-OQ-02 (variation of the edge threshold in n)

The parent `Erdos1012OQ01` formalizes the Woodall function `f(k)` and the edge threshold `edgeThreshold n k = C(n-k-1,2) + C(k+2,2) + 1`, evaluating it only at the boundary points `n = 2k+2`, `2k+3`. This child records how the threshold varies with the vertex count `n` — the structure that makes `f(k)` a well-defined minimum `n₀`.

### Theorems

- `choose_two_succ` — Pascal discrete derivative `C(m+1,2) = C(m,2) + m`.
- `edgeThreshold_eq` — explicit form `(n-k-1)(n-k-2)/2 + (k+2)(k+1)/2 + 1`.
- **`edgeThreshold_succ_left`** — the recurrence in `n` (for `n ≥ k+1`): `edgeThreshold (n+1) k = edgeThreshold n k + (n-k-1)`. Adding a vertex raises the threshold by exactly `n-k-1`.
- `edgeThreshold_lt_succ` / `edgeThreshold_mono` — strict (`n ≥ k+2`) and weak (`k+1 ≤ n ≤ m`) monotonicity in `n`.

### Verification

- `Erdos1012OQ01OQ02.lean`: 5 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the headline theorems: `propext, Quot.sound` only.
- Builds via `./proofs/scripts/docker-build.sh Proofs.Erdos1012OQ01OQ02` (7744 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)