### PR TITLE
research(prob-method-expectation-oq-04): non-strict first moment method (some outcome meets the mean) [0-axiom verified]

### DIFF
--- a/proofs/Proofs/ProbMethodExpectationOQ04.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ04.lean
@@ -1,0 +1,83 @@
+/-
+  First Moment Method — OQ-04: non-strict averaging (some outcome meets the mean)
+
+  The gallery entry `ProbMethodExpectation` proves the *strict* first moment
+  principle: `E[X] > t ⟹ ∃ ω, X(ω) > t` (`first_moment_principle`) and its dual.
+  The strict form cannot conclude anything at the threshold `E[X] = t`, yet the
+  most common use of the probabilistic method is exactly the non-strict statement
+  *"some outcome is at least the average"* — used to extract a witness meeting the
+  expectation.  This file supplies the non-strict averaging lemmas.
+
+  * `exists_ge_of_card_mul_le` / `exists_le_of_card_mul_ge` — the division-free
+    practical forms: `t·|s| ≤ ∑ f ⟹ ∃ a, t ≤ f a` (and dual).  This is the shape
+    actually used in lower-bound arguments (avoids dividing by `|s|`).
+  * `exists_ge_average` / `exists_le_average` — *some element is at least / at most
+    the mean*: `∃ a ∈ s, (∑ f)/|s| ≤ f a` and the dual.  The pigeonhole core of the
+    first moment method.
+  * `first_moment_ge` / `first_moment_le` — the non-strict threshold forms,
+    `E[X] ≥ t ⟹ ∃ a, f a ≥ t`, completing the strict `first_moment_principle` at
+    the boundary.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Alon–Spencer, *The Probabilistic Method*, Ch. 2 (first moment).
+-/
+
+import Mathlib
+
+namespace ProbMethod.ExpectationOQ04
+
+open Finset BigOperators
+
+variable {α : Type*} [DecidableEq α] {s : Finset α} {f : α → ℚ} {t : ℚ}
+
+/-- **Division-free first moment (≥).**  If `t·|s| ≤ ∑ f` over a nonempty set, then
+    some element is at least `t`.  This is the practical lower-bound shape of the
+    first moment method (no division by `|s|`). -/
+theorem exists_ge_of_card_mul_le (hs : s.Nonempty) (h : t * s.card ≤ s.sum f) :
+    ∃ a ∈ s, t ≤ f a := by
+  by_contra hc
+  push_neg at hc
+  have hlt : s.sum f < s.sum (fun _ => t) := Finset.sum_lt_sum_of_nonempty hs hc
+  rw [Finset.sum_const, nsmul_eq_mul, mul_comm] at hlt
+  linarith
+
+/-- **Division-free first moment (≤).**  If `∑ f ≤ t·|s|`, some element is at most
+    `t`. -/
+theorem exists_le_of_card_mul_ge (hs : s.Nonempty) (h : s.sum f ≤ t * s.card) :
+    ∃ a ∈ s, f a ≤ t := by
+  by_contra hc
+  push_neg at hc
+  have hlt : s.sum (fun _ => t) < s.sum f := Finset.sum_lt_sum_of_nonempty hs hc
+  rw [Finset.sum_const, nsmul_eq_mul, mul_comm] at hlt
+  linarith
+
+/-- **Some element is at least the mean.**  `∃ a ∈ s, (∑ f)/|s| ≤ f a`. -/
+theorem exists_ge_average (hs : s.Nonempty) :
+    ∃ a ∈ s, (s.sum f) / s.card ≤ f a := by
+  have hne : (s.card : ℚ) ≠ 0 := ne_of_gt (Nat.cast_pos.mpr hs.card_pos)
+  refine exists_ge_of_card_mul_le hs (le_of_eq ?_)
+  field_simp
+
+/-- **Some element is at most the mean.**  `∃ a ∈ s, f a ≤ (∑ f)/|s|`. -/
+theorem exists_le_average (hs : s.Nonempty) :
+    ∃ a ∈ s, f a ≤ (s.sum f) / s.card := by
+  have hne : (s.card : ℚ) ≠ 0 := ne_of_gt (Nat.cast_pos.mpr hs.card_pos)
+  refine exists_le_of_card_mul_ge hs (le_of_eq ?_)
+  field_simp
+
+/-- **Non-strict first moment principle (≥).**  If the average is at least `t`,
+    some element is at least `t` — the boundary case the strict
+    `first_moment_principle` cannot reach. -/
+theorem first_moment_ge (hs : s.Nonempty) (havg : t ≤ (s.sum f) / s.card) :
+    ∃ a ∈ s, t ≤ f a := by
+  obtain ⟨a, ha, hfa⟩ := exists_ge_average hs
+  exact ⟨a, ha, le_trans havg hfa⟩
+
+/-- **Non-strict first moment principle (≤).**  Dual of `first_moment_ge`. -/
+theorem first_moment_le (hs : s.Nonempty) (havg : (s.sum f) / s.card ≤ t) :
+    ∃ a ∈ s, f a ≤ t := by
+  obtain ⟨a, ha, hfa⟩ := exists_le_average hs
+  exact ⟨a, ha, le_trans hfa havg⟩
+
+end ProbMethod.ExpectationOQ04

--- a/src/data/research/problems/prob-method-expectation-oq-04.json
+++ b/src/data/research/problems/prob-method-expectation-oq-04.json
@@ -1,0 +1,62 @@
+{
+  "slug": "prob-method-expectation-oq-04",
+  "title": "Non-strict first moment method (some outcome meets the mean)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For nonempty finite s and f : α → ℚ: t·|s| ≤ ∑ f ⟹ ∃ a ∈ s, t ≤ f a; ∃ a ∈ s, (∑ f)/|s| ≤ f a; E[X] ≥ t ⟹ ∃ a, f a ≥ t (and duals).",
+    "plain": "The non-strict averaging lemmas of the first moment method: some outcome is at least (resp. at most) the mean, completing the parent's strict E[X] > t principle at the boundary.",
+    "whyMatters": [
+      "The parent ProbMethodExpectation proves only the strict first moment principle (E[X] > t ⟹ ∃ ω, X(ω) > t), which says nothing at the threshold E[X] = t.",
+      "The non-strict 'some outcome ≥ the average' is the form actually used to extract a witness meeting the expectation in probabilistic-method lower bounds."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Formalized the non-strict averaging lemmas of the first moment method.",
+    "blockers": [],
+    "nextAction": "None — complete.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE. Child of prob-method-expectation (strict first moment principle over ℚ on finite sets). The parent's strict E[X] > t ⟹ ∃ X(ω) > t cannot conclude at the threshold E[X] = t. This entry adds the non-strict averaging lemmas: exists_ge_of_card_mul_le / exists_le_of_card_mul_ge (division-free practical forms t·|s| ≤ ∑f ⟹ ∃ f a ≥ t), exists_ge_average / exists_le_average (some element at least/at most the mean), first_moment_ge / first_moment_le (non-strict threshold). ProbMethodExpectationOQ04.lean, 6 theorems, 0 axioms, 0 sorries, no native_decide.",
+    "builtItems": [
+      "ProbMethodExpectationOQ04.lean: 6 theorems, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries.",
+      "exists_ge_of_card_mul_le / exists_le_of_card_mul_ge: division-free first moment via by_contra + Finset.sum_lt_sum_of_nonempty + sum_const/nsmul_eq_mul + linarith.",
+      "exists_ge_average / exists_le_average: some element ≥/≤ the mean (∑f)/|s| (reduce to the division-free form via le_of_eq + field_simp).",
+      "first_moment_ge / first_moment_le: non-strict threshold (E[X] ≥ t ⟹ ∃ f a ≥ t) via the average lemma + le_trans."
+    ],
+    "insights": [
+      "The division-free shapes (t·|s| ≤ ∑f ⟹ ∃ f a ≥ t) are the practical lower-bound forms of the first moment method — they avoid dividing by |s| and feed directly into existence arguments.",
+      "Core proof: by_contra, push_neg gives ∀ a ∈ s, f a < t; Finset.sum_lt_sum_of_nonempty (strict, needs Nonempty) gives ∑ f < ∑ t = |s|·t; mul_comm + linarith contradicts the hypothesis.",
+      "Average forms reduce to the division-free forms: the side goal (∑f/|s|)·|s| = ∑f (or its ≤) is closed by le_of_eq + field_simp with |s| ≠ 0 (from Nonempty.card_pos).",
+      "Non-strict completes strict: first_moment_principle (parent) handles E[X] > t; first_moment_ge handles E[X] ≥ t, the boundary the strict form misses."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Two-sided / spread: combine exists_ge_average and exists_le_average to bound max − min ≥ 0 and relate to variance (second-moment sibling).",
+      "Generalize the base field to any LinearOrderedField (the proofs are field-agnostic; only ℚ is used here for consistency with the parent).",
+      "Probabilistic-method application: derive an explicit witness meeting E[X] for a concrete combinatorial random variable (e.g. expected number of monochromatic edges)."
+    ]
+  },
+  "tags": [
+    "extension"
+  ],
+  "relatedProofs": [
+    "prob-method-expectation",
+    "prob-method-expectation-oq-01"
+  ]
+}


### PR DESCRIPTION
## First Moment Method — OQ-04 (non-strict averaging)

The gallery entry `ProbMethodExpectation` proves the *strict* first moment principle `E[X] > t ⟹ ∃ ω, X(ω) > t`, which says nothing at the threshold `E[X] = t`. Yet the most common use of the probabilistic method is the non-strict *"some outcome is at least the average"*. This child supplies it.

### Theorems

- **`exists_ge_of_card_mul_le`** / `exists_le_of_card_mul_ge` — division-free practical forms: `t·|s| ≤ ∑ f ⟹ ∃ a, t ≤ f a` (and dual). The shape used in lower-bound arguments.
- `exists_ge_average` / `exists_le_average` — some element is at least / at most the mean `(∑ f)/|s|`.
- `first_moment_ge` / `first_moment_le` — non-strict threshold `E[X] ≥ t ⟹ ∃ a, f a ≥ t`, completing the parent's strict principle at the boundary.

### Verification

- `ProbMethodExpectationOQ04.lean`: 6 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the headline theorems: `propext, Classical.choice, Quot.sound` only.
- Builds via `./proofs/scripts/docker-build.sh Proofs.ProbMethodExpectationOQ04` (7743 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)