### PR TITLE
research(erdos-1038-wip-01): extremal quadratic x²−1 realizes the supremum 2√2 [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos1038WIP01.lean
+++ b/proofs/Proofs/Erdos1038WIP01.lean
@@ -1,0 +1,100 @@
+/-
+  Erdős Problem #1038 — WIP-01: the extremal quadratic x² − 1 realizes the supremum 2√2
+
+  The gallery stub `Erdos1038Problem` sets up the sublevel-set problem — for monic
+  real-rooted polynomials with roots in `[-1,1]`, study `|{x : |f(x)| < 1}|` — but
+  proves no theorems (the extremal facts are only sketched in prose).  This file
+  formalizes the concrete extremal computation noted there:
+
+      the quadratic `x² − 1 = (x−1)(x+1)` is admissible, and its sublevel set
+      `{x : |x² − 1| < 1} = (−√2, √2) ∖ {0}` has Lebesgue measure `2√2`,
+
+  the supremum value (Erdős–Herzog–Piranian 1958, confirmed by Tao 2025).  The
+  full supremum *bound* over all admissible `f` needs logarithmic potential theory
+  beyond Mathlib and is not attempted; this is the matching lower witness.
+
+  * `quadratic_admissible`        — `x² − 1` is monic with both roots in `[-1,1]`.
+  * `mem_sublevelSet_quadratic`   — `x ∈ sublevelSet (x²−1) ↔ 0 < x² ∧ x² < 2`.
+  * `sublevelSet_quadratic`       — `= Set.Ioo (−√2) √2 ∖ {0}`.
+  * `sublevelMeasure_quadratic`   — `= ENNReal.ofReal (2√2)`.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Erdős–Herzog–Piranian (1958); Tao, *Sublevel Sets of Logarithmic
+  Potentials* (2025); https://erdosproblems.com/1038.
+-/
+
+import Mathlib
+
+open scoped Real ENNReal
+open MeasureTheory Polynomial Set
+
+namespace Erdos1038WIP01
+
+/-- A monic polynomial with all roots real and in `[-1,1]` (re-declared to be
+    self-contained against the stub). -/
+def MonicRealRootedIn01 (f : Polynomial ℝ) : Prop :=
+  f.Monic ∧ (∀ r ∈ f.roots, r ∈ Set.Icc (-1 : ℝ) 1)
+
+/-- The sublevel set `{x : |f(x)| < 1}`. -/
+def sublevelSet (f : Polynomial ℝ) : Set ℝ := {x | |f.eval x| < 1}
+
+/-- Lebesgue measure of the sublevel set. -/
+noncomputable def sublevelMeasure (f : Polynomial ℝ) : ℝ≥0∞ := volume (sublevelSet f)
+
+/-- The extremal quadratic `x² − 1`. -/
+noncomputable def q : Polynomial ℝ := X ^ 2 - C 1
+
+@[simp] theorem eval_q (x : ℝ) : q.eval x = x ^ 2 - 1 := by
+  simp [q]
+
+/-- **The quadratic `x² − 1` is admissible**: monic with both roots in `[-1,1]`. -/
+theorem quadratic_admissible : MonicRealRootedIn01 q := by
+  constructor
+  · -- monic
+    simpa [q] using monic_X_pow_sub_C (1 : ℝ) (n := 2) (by norm_num)
+  · -- roots in [-1, 1]
+    intro r hr
+    rw [Polynomial.mem_roots'] at hr
+    have hroot : r ^ 2 - 1 = 0 := by simpa using hr.2
+    rw [Set.mem_Icc]
+    constructor <;> nlinarith [hroot]
+
+/-- **Membership in the sublevel set of `x² − 1`** in elementary form. -/
+theorem mem_sublevelSet_quadratic (x : ℝ) :
+    x ∈ sublevelSet q ↔ 0 < x ^ 2 ∧ x ^ 2 < 2 := by
+  simp only [sublevelSet, Set.mem_setOf_eq, eval_q, abs_lt]
+  constructor
+  · rintro ⟨h1, h2⟩; exact ⟨by linarith, by linarith⟩
+  · rintro ⟨h1, h2⟩; exact ⟨by linarith, by linarith⟩
+
+/-- **The sublevel set of `x² − 1` is `(−√2, √2) ∖ {0}`.** -/
+theorem sublevelSet_quadratic :
+    sublevelSet q = Set.Ioo (-Real.sqrt 2) (Real.sqrt 2) \ {0} := by
+  have hs : (Real.sqrt 2) ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have hspos : 0 < Real.sqrt 2 := Real.sqrt_pos.mpr (by norm_num)
+  ext x
+  rw [mem_sublevelSet_quadratic, Set.mem_diff, Set.mem_Ioo, Set.mem_singleton_iff]
+  constructor
+  · rintro ⟨h0, h2⟩
+    refine ⟨⟨?_, ?_⟩, ?_⟩
+    · nlinarith [hs, hspos, sq_nonneg (x + Real.sqrt 2)]
+    · nlinarith [hs, hspos, sq_nonneg (x - Real.sqrt 2)]
+    · intro hx; rw [hx] at h0; simpa using h0
+  · rintro ⟨⟨h1, h2⟩, h3⟩
+    refine ⟨?_, ?_⟩
+    · have : x ≠ 0 := h3
+      positivity
+    · nlinarith [hs, hspos, h1, h2]
+
+/-- **The extremal quadratic realizes the supremum `2√2`.**  The sublevel set
+    `(−√2, √2) ∖ {0}` has Lebesgue measure `2√2` (removing the single point `0`
+    does not change the measure). -/
+theorem sublevelMeasure_quadratic :
+    sublevelMeasure q = ENNReal.ofReal (2 * Real.sqrt 2) := by
+  unfold sublevelMeasure
+  rw [sublevelSet_quadratic, measure_diff_null (by simp), Real.volume_Ioo]
+  congr 1
+  ring
+
+end Erdos1038WIP01

--- a/src/data/research/problems/erdos-1038-wip-01.json
+++ b/src/data/research/problems/erdos-1038-wip-01.json
@@ -1,0 +1,65 @@
+{
+  "slug": "erdos-1038-wip-01",
+  "title": "The extremal quadratic x²−1 realizes the Erdős #1038 supremum 2√2",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "q = X²−1 is monic with roots ±1 ∈ [-1,1]; sublevelSet q = {x : |x²−1| < 1} = Ioo(-√2,√2) \\ {0}; volume = ENNReal.ofReal (2√2).",
+    "plain": "Erdős #1038 asks for sup/inf of |{x : |f(x)|<1}| over monic real-rooted f with roots in [-1,1]. The supremum is 2√2 (Tao 2025). This formalizes the extremal witness: the quadratic x²−1 has sublevel set of measure exactly 2√2.",
+    "whyMatters": [
+      "The gallery stub Erdos1038Problem defines the sublevel-set objects but proves NO theorems — the extremal facts are only sketched in prose.",
+      "x²−1 = (x−1)(x+1) is the explicit extremizer realizing the supremum 2√2; this is the matching lower witness to Tao's 2025 upper bound."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Formalized the extremal quadratic and its sublevel-set measure 2√2.",
+    "blockers": [],
+    "nextAction": "None — complete. The full supremum bound over all admissible f needs logarithmic potential theory beyond Mathlib (not attempted).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE. First theorems for Erdős #1038 (the gallery file Erdos1038Problem is a stub: definitions only, all 'theorems' commented as prose). Formalizes the concrete extremal computation: the quadratic q = X²−1 is admissible (monic, roots ±1 ∈ [-1,1]), its sublevel set {x : |x²−1| < 1} = Ioo(-√2,√2) \\ {0}, and its Lebesgue measure is exactly 2√2 — the supremum value (Erdős–Herzog–Piranian 1958, Tao 2025). Erdos1038WIP01.lean, 1 def-eval + 4 theorems, 0 axioms, 0 sorries, no native_decide. The full supremum bound over all f needs logarithmic potential theory (not attempted).",
+    "builtItems": [
+      "Erdos1038WIP01.lean: q := X²−1, eval_q (simp), 4 theorems, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries. Self-contained re-decl of MonicRealRootedIn01/sublevelSet/sublevelMeasure (stub-independent).",
+      "quadratic_admissible: q is monic (monic_X_pow_sub_C 1 (n:=2)) with roots in [-1,1] (mem_roots' → r²−1=0 → nlinarith).",
+      "mem_sublevelSet_quadratic: x ∈ sublevelSet q ↔ 0 < x² ∧ x² < 2 (elementary, abs_lt + linarith).",
+      "sublevelSet_quadratic: = Ioo(-√2,√2) \\ {0} (√2 bounds via Real.sq_sqrt + Real.sqrt_pos + nlinarith with sq_nonneg(x±√2)).",
+      "sublevelMeasure_quadratic: = ENNReal.ofReal (2√2) (measure_diff_null removes {0}, Real.volume_Ioo, ring for √2−(−√2)=2√2)."
+    ],
+    "insights": [
+      "x²−1 is the explicit extremizer for the Erdős #1038 supremum: |x²−1| < 1 ⟺ 0 < x² < 2 ⟺ x ∈ (-√2,√2)\\{0}, measure 2√2.",
+      "Lean: |x²−1| < 1 splits via abs_lt into −1 < x²−1 ∧ x²−1 < 1 = 0 < x² ∧ x² < 2; the elementary form (0 < x² < 2) is certain, the √2 interval form needs Real.sq_sqrt and nlinarith with sq_nonneg(x±√2) to convert x² < 2 ↔ |x| < √2.",
+      "Removing the isolated zero of x² (the point x=0 where x²−1 = −1, |−1| = 1 not < 1) is exactly the \\{0}; measure_diff_null (volume {0} = 0 by simp) discards it for the measure.",
+      "monic_X_pow_sub_C (1) (n:=2) (by norm_num) gives Monic (X²−C 1); roots via Polynomial.mem_roots' (a ∈ roots ↔ p ≠ 0 ∧ IsRoot)."
+    ],
+    "mathlibGaps": [
+      "The supremum BOUND (every admissible f has sublevel measure ≤ 2√2) requires logarithmic potential theory (Tao 2025) not in Mathlib — only the extremal witness is formalized here."
+    ],
+    "nextSteps": [
+      "The infimum side: the polynomial (x+1)(x−1)^m for m ≥ 3 witnesses inf < 2; formalize its sublevel measure as an explicit upper bound on the (open) infimum.",
+      "Products: MonicRealRootedIn01 is preserved under multiplication (monic × monic, roots union), giving a closure structure on admissible polynomials.",
+      "The general upper bound 2√2 over all admissible f (the hard analytic core, Tao's logarithmic-potential argument)."
+    ]
+  },
+  "tags": [
+    "extension",
+    "measure-theory"
+  ],
+  "relatedProofs": [
+    "erdos-1038"
+  ]
+}


### PR DESCRIPTION
## Erdős #1038 — the extremal quadratic realizes the supremum 2√2

Erdős #1038: for monic real-rooted polynomials `f` with roots in `[-1,1]`, study `|{x : |f(x)| < 1}|`. The supremum is `2√2` (Erdős–Herzog–Piranian 1958, confirmed by Tao 2025). The gallery file `Erdos1038Problem` is a stub — it defines the sublevel-set objects but proves **no theorems** (the extremal facts are sketched in prose). This PR adds the first theorems: the concrete extremal witness.

### Theorems

- `quadratic_admissible` — `x² − 1 = (x−1)(x+1)` is monic with both roots in `[-1,1]`.
- `mem_sublevelSet_quadratic` — `x ∈ sublevelSet (x²−1) ↔ 0 < x² ∧ x² < 2`.
- `sublevelSet_quadratic` — `= Set.Ioo (−√2) √2 ∖ {0}`.
- **`sublevelMeasure_quadratic`** — `= ENNReal.ofReal (2√2)`: the quadratic realizes the supremum.

The full supremum *bound* over all admissible `f` needs logarithmic potential theory (Tao 2025) beyond Mathlib; this is the matching lower witness.

### Verification

- `Erdos1038WIP01.lean`: 4 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the headline theorems: `propext, Classical.choice, Quot.sound` only.
- Builds via `./proofs/scripts/docker-build.sh Proofs.Erdos1038WIP01` (7743 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)