### PR TITLE
research(erdos-18-oq-01): representability algebra and verified practical numbers 4,6,8 [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos18OQ01.lean
+++ b/proofs/Proofs/Erdos18OQ01.lean
@@ -1,0 +1,70 @@
+/-
+  Erdős Problem #18 — OQ-01: representability algebra and verified practical numbers
+
+  Erdős Problem #18 (OPEN, $250) studies *practical numbers*: `m` is practical if
+  every `1 ≤ k < m` is a sum of distinct divisors of `m`.  The gallery parent
+  `Erdos18Problem` sets up `IsRepresentable`, `IsPractical`, and the function
+  `h(m)`, and verifies that `1` and `2` are practical.  The open questions concern
+  the asymptotic size of `h(m)` (Mertens/Vose-type bounds), out of elementary
+  reach.  This file fills in the elementary groundwork the parent omits:
+
+  * the **representability algebra** — `0`, every divisor, `1`, and `m` itself are
+    representable (`zero_representable`, `mem_divisors_representable`,
+    `one_representable`, `self_representable`);
+  * a **decidable bridge** `practical_of_check` turning `IsPractical m` into a
+    finite check over `(divisors m).powerset`, and the verified practical numbers
+    `4`, `6`, `8` (extending the parent's `1`, `2` along OEIS A005153).
+
+  All results are fully machine-checked (0 axioms, 0 sorries).
+
+  Reference: Srinivasan (1948); OEIS A005153; https://erdosproblems.com/18.
+-/
+
+import Mathlib
+import Proofs.Erdos18Problem
+
+namespace Erdos18OQ01
+
+open Erdos18 Finset
+
+/-- **0 is representable** (by the empty set of divisors). -/
+theorem zero_representable (m : ℕ) : IsRepresentable 0 m :=
+  ⟨∅, Finset.empty_subset _, by simp⟩
+
+/-- **Every divisor is representable** (as a singleton). -/
+theorem mem_divisors_representable {d m : ℕ} (hd : d ∈ divisors m) :
+    IsRepresentable d m :=
+  ⟨{d}, Finset.singleton_subset_iff.mpr hd, by simp⟩
+
+/-- **1 is representable** for any `m ≥ 1` (since `1 ∣ m`). -/
+theorem one_representable {m : ℕ} (hm : 1 ≤ m) : IsRepresentable 1 m :=
+  mem_divisors_representable (Nat.one_mem_divisors.mpr (by omega))
+
+/-- **`m` is representable by its own divisors** for `m ≥ 1` (the singleton `{m}`). -/
+theorem self_representable {m : ℕ} (hm : 1 ≤ m) : IsRepresentable m m :=
+  mem_divisors_representable (Nat.mem_divisors_self m (by omega))
+
+/-- **Decidable bridge.**  To certify `IsPractical m` it suffices to check, for
+    every `1 ≤ k < m`, that some subset of `divisors m` sums to `k` — a finite,
+    `decide`-able condition over `(divisors m).powerset`. -/
+theorem practical_of_check {m : ℕ} (hm : 1 ≤ m)
+    (h : ∀ k ∈ Finset.range m, 1 ≤ k →
+      ∃ S ∈ (divisors m).powerset, S.sum id = k) :
+    IsPractical m := by
+  refine ⟨hm, fun k hk1 hkm => ?_⟩
+  obtain ⟨S, hS, hsum⟩ := h k (Finset.mem_range.mpr hkm) hk1
+  exact ⟨S, Finset.mem_powerset.mp hS, hsum⟩
+
+/-- **4 is practical** (divisors `{1,2,4}`: `1, 2, 1+2`). -/
+theorem four_practical : IsPractical 4 :=
+  practical_of_check (by norm_num) (by decide)
+
+/-- **6 is practical** (divisors `{1,2,3,6}`: `1, 2, 3, 1+3, 2+3`). -/
+theorem six_practical : IsPractical 6 :=
+  practical_of_check (by norm_num) (by decide)
+
+/-- **8 is practical** (divisors `{1,2,4,8}`: `1, 2, 1+2, 4, 1+4, 2+4, 1+2+4`). -/
+theorem eight_practical : IsPractical 8 :=
+  practical_of_check (by norm_num) (by decide)
+
+end Erdos18OQ01

--- a/src/data/research/problems/erdos-18-oq-01.json
+++ b/src/data/research/problems/erdos-18-oq-01.json
@@ -1,0 +1,62 @@
+{
+  "slug": "erdos-18-oq-01",
+  "title": "Representability algebra and verified practical numbers (Erdős #18)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "IsRepresentable 0 m; d ∈ divisors m → IsRepresentable d m; 1≤m → IsRepresentable 1 m ∧ IsRepresentable m m; IsPractical 4 ∧ IsPractical 6 ∧ IsPractical 8.",
+    "plain": "Elementary groundwork for practical numbers (Erdős #18): basic representability lemmas and verified small practical numbers, extending the gallery parent's 1 and 2.",
+    "whyMatters": [
+      "Erdős #18 (OPEN, $250) asks for the asymptotic size of h(m) for practical m — an analytic question; the elementary representability algebra and concrete examples are the groundwork the parent omits.",
+      "Verified practical numbers 4, 6, 8 extend the parent's 1, 2 along OEIS A005153."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Representability algebra + decidable bridge + verified practical numbers 4, 6, 8.",
+    "blockers": [],
+    "nextAction": "None for the groundwork. The open h(m) asymptotics (Vose, Mertens-type) need analytic number theory.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (elementary groundwork). Child of erdos-18 (practical numbers, OPEN $250). The parent defines IsRepresentable/IsPractical/h and verifies 1, 2 practical; the open questions concern h(m) asymptotics (out of elementary reach). This entry adds the representability algebra (0, every divisor, 1, and m itself are representable) and a decidable bridge practical_of_check that turns IsPractical m into a finite check over (divisors m).powerset, yielding verified practical numbers 4, 6, 8 (extending 1, 2 along OEIS A005153). Erdos18OQ01.lean, 7 theorems, 0 axioms, 0 sorries, no native_decide (the `decide` for 4/6/8 is KERNEL-based, axioms = propext/Classical.choice/Quot.sound only, NO ofReduceBool).",
+    "builtItems": [
+      "Erdos18OQ01.lean: 7 theorems, 0 axioms, 0 sorries. Imports Proofs.Erdos18Problem for the definitions.",
+      "zero_representable (∅), mem_divisors_representable (singleton {d}), one_representable (1∣m), self_representable ({m}).",
+      "practical_of_check: IsPractical m from ∀ k ∈ range m, 1≤k → ∃ S ∈ (divisors m).powerset, S.sum id = k (decidable via Finset.decidableBExists/BAll).",
+      "four_practical, six_practical, eight_practical via practical_of_check + decide."
+    ],
+    "insights": [
+      "IsRepresentable k m = ∃ S ⊆ divisors m, S.sum id = k; the bounded form ∃ S ∈ (divisors m).powerset (via Finset.mem_powerset) is DECIDABLE, so IsPractical m reduces to a finite decidable check and small cases follow by `decide`.",
+      "KERNEL `decide` (not native_decide) on the powerset check stays 0-axiom (propext/Classical.choice/Quot.sound only, no Lean.ofReduceBool) — verified via #print axioms; computing Nat.divisors m for small m is cheap enough for the kernel.",
+      "Representability building blocks: 0 by ∅, d by {d} (Finset.sum_singleton), 1 by Nat.one_mem_divisors.mpr (m≠0), m by Nat.mem_divisors_self.",
+      "The open content (h(m) < (log log m)^O(1) infinitely often; h(n!) bounds) is analytic and far from these elementary facts."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Necessary condition: a practical number m ≥ 2 is even (2 ∣ m), since representing 2 forces the divisor 2 (sum of distinct odd divisors is never 2) — a clean structural theorem.",
+      "Closure / monotonicity facts about IsRepresentable (additivity over disjoint divisor sets), and IsPractical ⟹ representability of σ(m) ranges.",
+      "The Stewart–Sierpiński characterization of practical numbers via prime factorization (the route to denser families)."
+    ]
+  },
+  "tags": [
+    "extension",
+    "number-theory"
+  ],
+  "relatedProofs": [
+    "erdos-18"
+  ]
+}


### PR DESCRIPTION
## Erdős #18 — OQ-01 (practical numbers groundwork)

Erdős #18 (OPEN, \$250): `m` is *practical* if every `1 ≤ k < m` is a sum of distinct divisors of `m`. The gallery parent `Erdos18Problem` defines `IsRepresentable`/`IsPractical`/`h` and verifies `1`, `2` practical; the open questions concern `h(m)` asymptotics (analytic, out of elementary reach). This child adds the elementary groundwork.

### Theorems

- Representability algebra: `zero_representable` (∅), `mem_divisors_representable` (singleton `{d}`), `one_representable` (`1 ∣ m`), `self_representable` (`{m}`).
- `practical_of_check` — a decidable bridge: `IsPractical m` from a finite check over `(divisors m).powerset`.
- **`four_practical`**, **`six_practical`**, **`eight_practical`** — verified via the bridge + `decide`, extending the parent's `1`, `2` along OEIS A005153.

### Verification

- `Erdos18OQ01.lean`: 7 theorems, **0 axioms, 0 sorries**, **no `native_decide`** — the `decide` for `4/6/8` is **kernel-based**, so `#print axioms` shows `propext, Classical.choice, Quot.sound` only (no `Lean.ofReduceBool`).
- Builds via `./proofs/scripts/docker-build.sh Proofs.Erdos18OQ01` (7744 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)