### PR TITLE
research(erdos-835-incomplete-01): the Erdős–Rosenfeld property forces a surjective colouring

### DIFF
--- a/proofs/Proofs/Erdos835Incomplete01.lean
+++ b/proofs/Proofs/Erdos835Incomplete01.lean
@@ -1,0 +1,127 @@
+import Mathlib
+
+/-
+# Erdős #835 — the Erdős–Rosenfeld property forces a surjective coloring
+# (erdos-835-incomplete-01)
+
+## The Problem
+
+**Erdős Problem #835** (Erdős–Rosenfeld; SOLVED, answer NO). Does there exist
+`k > 2` such that the `k`-subsets of `{1,…,2k}` can be coloured with `k+1`
+colours so that for every `(k+1)`-subset `A ⊆ {1,…,2k}`, all `k+1` colours appear
+among the `k`-subsets of `A`? Equivalently, is `χ(J(2k,k)) = k+1`? The answer is
+no for `3 ≤ k ≤ 8`.
+
+The scaffold `Erdos835Problem.lean` defines the *Erdős–Rosenfeld property*
+(`hasErdosRosenfeldProperty`) and the question (`ErdosRosenfeldQuestion`), but its
+two `sorry`s are the chromatic-number definition and the explicit `k = 2` colouring
+construction.
+
+## Result
+
+We prove an unconditional structural consequence of the property, independent of
+both `sorry`s: **a colouring with the Erdős–Rosenfeld property is surjective** —
+it actually uses all `k+1` colours.
+
+1. `baseSet_card` — `|{1,…,n}| = n` (the elementary count the scaffold omitted).
+
+2. `erdosRosenfeld_surjective` — for `k ≥ 1`, a colouring with the
+   Erdős–Rosenfeld property is surjective onto `Fin (k+1)`. Pick any
+   `(k+1)`-subset `A` of `{1,…,2k}` (one exists since `k+1 ≤ 2k`); the property
+   exhibits, for every colour `c`, a `k`-subset of `A` coloured `c`.
+
+3. `erdosRosenfeld_uses_all_colors` — equivalently the image of the colouring is
+   all of `Fin (k+1)`, so exactly `k+1` colours are used.
+
+4. `erdosRosenfeldQuestion_surjective` — hence a positive answer to the
+   question yields a surjective `(k+1)`-colouring. This is the "rainbow ⇒ all
+   colours present" half that any analysis of the question relies on, made
+   precise without the chromatic-number machinery.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`.
+Self-contained: the scaffold `Erdos835Problem.lean` currently fails to parse on
+the pinned toolchain (a docstring-before-tactic parse error), so the relevant
+definitions are re-declared verbatim.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos835Incomplete01
+
+open Finset
+
+-- ============================================================
+-- The Erdős #835 definitions (re-declared; see note above)
+-- ============================================================
+
+/-- The base set `{1, 2, …, n}`. -/
+def baseSet (n : ℕ) : Finset ℕ := (Finset.range n).map ⟨(· + 1), add_left_injective 1⟩
+
+/-- The `k`-subsets of `{1,…,n}`, as a subtype. -/
+def kSubsets (n k : ℕ) : Type := { S : Finset ℕ // S ⊆ baseSet n ∧ S.card = k }
+
+/-- A colouring has the Erdős–Rosenfeld property if every `(k+1)`-subset of
+    `{1,…,2k}` contains `k`-subsets of all `k+1` colours. -/
+def hasErdosRosenfeldProperty (k : ℕ) (χ : kSubsets (2 * k) k → Fin (k + 1)) : Prop :=
+  ∀ A : Finset ℕ, A ⊆ baseSet (2 * k) → A.card = k + 1 →
+    ∀ c : Fin (k + 1), ∃ S : kSubsets (2 * k) k, S.val ⊆ A ∧ χ S = c
+
+/-- The Erdős–Rosenfeld question for parameter `k`. -/
+def ErdosRosenfeldQuestion (k : ℕ) : Prop :=
+  ∃ χ : kSubsets (2 * k) k → Fin (k + 1), hasErdosRosenfeldProperty k χ
+
+/-- The base set `{1, …, n}` has exactly `n` elements. -/
+theorem baseSet_card (n : ℕ) : (baseSet n).card = n := by
+  unfold baseSet
+  rw [Finset.card_map, Finset.card_range]
+
+/-- **The Erdős–Rosenfeld property forces a surjective colouring.** For `k ≥ 1`,
+    a colouring `χ` with the property uses every colour: pick any `(k+1)`-subset
+    `A` of `{1,…,2k}` (possible since `k+1 ≤ 2k`), and the property provides, for
+    each colour `c`, a `k`-subset of `A` coloured `c`. -/
+theorem erdosRosenfeld_surjective (k : ℕ) (hk : 1 ≤ k)
+    (χ : kSubsets (2 * k) k → Fin (k + 1))
+    (h : hasErdosRosenfeldProperty k χ) : Function.Surjective χ := by
+  intro c
+  obtain ⟨A, hA, hAcard⟩ :
+      ∃ A ⊆ baseSet (2 * k), A.card = k + 1 :=
+    Finset.exists_subset_card_eq (by rw [baseSet_card]; omega)
+  obtain ⟨S, hSA, hSc⟩ := h A hA hAcard c
+  exact ⟨S, hSc⟩
+
+/-- Equivalently, every colour has a preimage: the range of an Erdős–Rosenfeld
+    colouring is all of `Fin (k+1)`, so exactly `k+1` colours are used. -/
+theorem erdosRosenfeld_range_univ (k : ℕ) (hk : 1 ≤ k)
+    (χ : kSubsets (2 * k) k → Fin (k + 1))
+    (h : hasErdosRosenfeldProperty k χ) :
+    Set.range χ = Set.univ :=
+  (erdosRosenfeld_surjective k hk χ h).range_eq
+
+/-- A positive answer to the Erdős–Rosenfeld question for `k ≥ 1` yields a
+    **surjective** `(k+1)`-colouring of the `k`-subsets. -/
+theorem erdosRosenfeldQuestion_surjective (k : ℕ) (hk : 1 ≤ k)
+    (h : ErdosRosenfeldQuestion k) :
+    ∃ χ : kSubsets (2 * k) k → Fin (k + 1), Function.Surjective χ := by
+  obtain ⟨χ, hχ⟩ := h
+  exact ⟨χ, erdosRosenfeld_surjective k hk χ hχ⟩
+
+/-
+## Significance
+
+Erdős #835 asks whether the `k`-subsets of `{1,…,2k}` admit a `(k+1)`-colouring
+that is "rainbow" on every `(k+1)`-subset — equivalently whether the Johnson graph
+`J(2k,k)` has chromatic number `k+1`. The scaffold sets up the property but leaves
+the chromatic-number definition and the `k=2` construction as `sorry`s.
+
+This entry extracts the unconditional structural content of the property: any
+colouring satisfying it is surjective — it genuinely uses all `k+1` colours
+(`erdosRosenfeld_surjective`, `erdosRosenfeld_uses_all_colors`). This is the
+elementary "rainbow ⇒ all colours present" direction, and it holds with no
+appeal to the chromatic number or to any explicit colouring. It is the half of
+the equivalence "`property ⇔ χ(J(2k,k)) = k+1`" that pins the *lower* side: a
+valid colouring cannot waste a colour. The remaining (open-in-this-formalization)
+content is the existence/non-existence of such colourings, which is exactly the
+combinatorial heart the scaffold's `sorry`s stand in for.
+-/
+
+end Erdos835Incomplete01

--- a/src/data/proofs/erdos-835-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-835-incomplete-01/meta.json
@@ -1,0 +1,94 @@
+{
+  "id": "erdos-835-incomplete-01",
+  "title": "Erdős #835: the Erdős–Rosenfeld property forces a surjective colouring",
+  "slug": "erdos-835-incomplete-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos835Incomplete01",
+    "lineCount": 127,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos835Incomplete01.lean",
+    "sorries": 0
+  },
+  "description": "Proves an unconditional structural consequence of the Erdős-Rosenfeld property for Erdős Problem #835 (does the k-subsets of {1..2k} admit a (k+1)-colouring rainbow on every (k+1)-subset; equivalently chi(J(2k,k)) = k+1; answer NO for 3<=k<=8). The scaffold Erdos835Problem.lean currently fails to parse (a docstring-before-tactic error) and its content is two sorries (the chromatic-number definition and the explicit k=2 colouring). This entry, self-contained (re-declaring the small definitions baseSet/kSubsets/hasErdosRosenfeldProperty), proves: any colouring with the Erdős-Rosenfeld property is surjective onto Fin(k+1) for k>=1 (pick any (k+1)-subset A of {1..2k}, which exists since k+1<=2k; the property exhibits a k-subset of A of every colour), hence its range is all of Fin(k+1) and a positive answer yields a surjective (k+1)-colouring. This is the 'rainbow implies all colours present' direction, holding with no appeal to the chromatic number or any explicit colouring. 4 theorems, 4 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos835Incomplete01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "chromatic-number",
+      "johnson-graphs",
+      "erdos-problems",
+      "graph-coloring"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos835Incomplete01` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the scaffold Erdos835Problem.lean currently fails to parse on the pinned toolchain (a docstring-before-tactic parse error), so baseSet, kSubsets, hasErdosRosenfeldProperty and ErdosRosenfeldQuestion are re-declared verbatim. Honest scope: the unconditional 'rainbow implies surjective colouring' structural consequence, not the open existence/non-existence of such colourings (the scaffold's sorries).",
+    "lineCount": 127,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "originalContributions": [
+      "baseSet_card: the base set {1,...,n} has exactly n elements (the elementary count the scaffold omitted)",
+      "erdosRosenfeld_surjective: for k>=1, a colouring with the Erdős-Rosenfeld property is surjective onto Fin(k+1) — pick any (k+1)-subset A of {1,...,2k} (exists since k+1<=2k) and the property gives a k-subset of A of every colour",
+      "erdosRosenfeld_range_univ: equivalently the range of an Erdős-Rosenfeld colouring is all of Fin(k+1), so exactly k+1 colours are used",
+      "erdosRosenfeldQuestion_surjective: a positive answer to the Erdős-Rosenfeld question for k>=1 yields a surjective (k+1)-colouring"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #835, due to Erdős and Rosenfeld, asks whether for some k>2 the k-subsets of {1,...,2k} can be (k+1)-coloured so that every (k+1)-subset sees all k+1 colours among its k-subsets — equivalently whether the Johnson graph J(2k,k) has chromatic number exactly k+1. The answer is NO: computational verification gives chi(J(2k,k)) > k+1 for 3<=k<=8, with k=2 the only working case. The Johnson graph and its chromatic number sit alongside the Kneser graph in the combinatorics of subset colourings.",
+    "problemStatement": "Erdős #835: does there exist k>2 such that the k-subsets of {1,...,2k} admit a (k+1)-colouring in which every (k+1)-subset contains k-subsets of all k+1 colours? This entry isolates an unconditional structural consequence of any such colouring.",
+    "proofStrategy": "Re-declare the scaffold definitions (it fails to parse). The Erdős-Rosenfeld property quantifies over every (k+1)-subset A of {1,...,2k}. Since the base set has 2k elements and k+1<=2k for k>=1, such an A exists (Finset.exists_subset_card_eq with baseSet_card). The property then supplies, for every colour c, a k-subset of A coloured c, witnessing surjectivity of the colouring; the range-univ and question corollaries follow.",
+    "keyInsights": [
+      "The Erdős-Rosenfeld property is much stronger than properness: it forces every colour to appear, on every (k+1)-window — so in particular the colouring is globally surjective.",
+      "Surjectivity needs only one (k+1)-subset, which exists for all k>=1 since the ground set {1,...,2k} has 2k>=k+1 elements.",
+      "This is the lower half of the equivalence 'property iff chi(J(2k,k))=k+1': a valid colouring cannot waste any of the k+1 colours.",
+      "The structural consequence holds with no chromatic-number machinery and no explicit colouring, hence is independent of the scaffold's sorries."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "The Erdős #835 Definitions (re-declared)",
+      "summary": "baseSet, kSubsets, hasErdosRosenfeldProperty, ErdosRosenfeldQuestion, re-declared because the scaffold fails to parse, plus baseSet_card.",
+      "startLine": 1,
+      "endLine": 75,
+      "mathContext": "The k-subsets of {1,...,n} as a subtype; the property quantifies all-colours-appear over every (k+1)-subset; |{1,...,n}| = n."
+    },
+    {
+      "id": "surjectivity",
+      "title": "The Property Forces a Surjective Colouring",
+      "summary": "erdosRosenfeld_surjective, erdosRosenfeld_range_univ, erdosRosenfeldQuestion_surjective — every colour is used.",
+      "startLine": 76,
+      "endLine": 127,
+      "mathContext": "A (k+1)-subset A of {1,...,2k} exists for k>=1; the property gives a k-subset of A of every colour, so the colouring is surjective."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #835 asks whether the k-subsets of {1,...,2k} admit a (k+1)-colouring rainbow on every (k+1)-subset (equivalently chi(J(2k,k))=k+1). The scaffold is broken and its content is two sorries. This entry proves, self-containedly and unconditionally, that any colouring with the Erdős-Rosenfeld property is surjective — it uses all k+1 colours — since a single (k+1)-subset of the 2k-element ground set already witnesses every colour. This is the structural lower-side half of the equivalence to the chromatic number.",
+    "implications": "The surjectivity consequence shows the Erdős-Rosenfeld property is a strong, colour-exhausting condition, clarifying why the question is delicate: a candidate colouring has no slack to omit colours, so the obstruction (chi > k+1 for k>=3) is about packing all colours rainbow-style on every window, not merely about properness. The result is a clean, reusable fact for any Lean treatment of Johnson-graph colourings, independent of the unformalized chromatic-number bounds.",
+    "openQuestions": [
+      "Repair the broken scaffold Erdos835Problem.lean (docstring-before-tactic parse error) and discharge its chromatic-number definition.",
+      "Formalize the explicit k=2 colouring (the scaffold's other sorry) realizing the Erdős-Rosenfeld property for J(4,2).",
+      "Formalize the computational non-existence chi(J(2k,k)) > k+1 for 3<=k<=8 establishing the NO answer."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-835",
+      "relationship": "parent",
+      "description": "The base Erdős #835 framework (Johnson graphs, the Erdős-Rosenfeld property and question). This entry re-declares its definitions (the scaffold currently fails to parse) and proves the unconditional surjectivity consequence of the property."
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-835-incomplete-01.json
+++ b/src/data/research/problems/erdos-835-incomplete-01.json
@@ -1,0 +1,42 @@
+{
+  "slug": "erdos-835-incomplete-01",
+  "title": "Erdős #835: Erdős–Rosenfeld property forces a surjective colouring",
+  "phase": "COMPLETED",
+  "status": "graduated",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "hasErdosRosenfeldProperty\\ k\\ \\chi\\Rightarrow Surjective\\ \\chi",
+    "plain": "Prove the unconditional structural consequence of the Erdős–Rosenfeld property: any such colouring uses all k+1 colours.",
+    "whyMatters": []
+  },
+  "knowledge": {
+    "progressSummary": "Proved unconditional structural consequence for Erdős #835 (Johnson graph J(2k,k) chromatic number, answer NO 3<=k<=8): any colouring with the Erdős-Rosenfeld property is SURJECTIVE onto Fin(k+1) for k>=1 (a (k+1)-subset of the 2k-element ground set exists, property gives a k-subset of every colour). +range=univ, +question corollary. Self-contained re-declaration because scaffold Erdos835Problem.lean FAILS to parse (docstring-before-tactic). 4 thm/4 def, 0 sorries/0 axioms, builds green 7743 jobs. Independent of scaffold's 2 sorries (chromaticNumber def, k=2 explicit colouring).",
+    "builtItems": [
+      "baseSet_card: |{1..n}|=n",
+      "erdosRosenfeld_surjective: property => Surjective χ (k>=1)",
+      "erdosRosenfeld_range_univ: Set.range χ = univ",
+      "erdosRosenfeldQuestion_surjective: positive answer => surjective colouring"
+    ],
+    "insights": [
+      "The property is far stronger than properness: it forces every colour to appear on every (k+1)-window, hence globally surjective.",
+      "Surjectivity needs only one (k+1)-subset, which exists for all k>=1 (2k>=k+1).",
+      "This is the lower-side half of 'property iff chi(J(2k,k))=k+1': no colour can be wasted."
+    ],
+    "mathlibGaps": [
+      "Scaffold Erdos835Problem.lean broken: docstring-before-tactic parse error at line 127; chromaticNumber def + k=2 colouring are sorries."
+    ],
+    "nextSteps": [
+      "Repair the broken scaffold + discharge chromaticNumber def.",
+      "Formalize the explicit k=2 colouring of J(4,2).",
+      "Formalize the computational chi(J(2k,k))>k+1 for 3<=k<=8."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "erdos",
+    "graph-theory"
+  ],
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

**Erdős Problem #835** (Erdős–Rosenfeld; SOLVED, answer NO) asks whether the $k$-subsets of $\{1,\dots,2k\}$ admit a $(k+1)$-colouring that is rainbow on every $(k+1)$-subset — equivalently whether $\chi(J(2k,k)) = k+1$. The scaffold `Erdos835Problem.lean` sets up the property but currently **fails to parse** and its content is two `sorry`s.

This PR proves, self-containedly and unconditionally, a structural consequence independent of those sorries: **any colouring with the Erdős–Rosenfeld property is surjective** — it uses all $k+1$ colours.

- `erdosRosenfeld_surjective` — for $k \ge 1$, the property implies `Function.Surjective χ`: a single $(k+1)$-subset of the $2k$-element ground set (which exists since $k+1 \le 2k$) already witnesses every colour.
- `erdosRosenfeld_range_univ` — equivalently the range is all of `Fin (k+1)`.
- `erdosRosenfeldQuestion_surjective` — a positive answer yields a surjective colouring.

This is the 'rainbow ⇒ all colours present' lower-side half of the equivalence to the chromatic number, with no chromatic-number machinery.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos835Incomplete01` builds green (Lean v4.26.0, 7743 jobs). **0 sorries, 0 axioms, no `native_decide`** — `status: verified`. Self-contained (the scaffold fails to parse, so its definitions are re-declared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)