### PR TITLE
research(erdos-1017-oq-03): closed forms and strict growth of the Turán bound ⌊n²/4⌋

### DIFF
--- a/proofs/Proofs/Erdos1017OQ03.lean
+++ b/proofs/Proofs/Erdos1017OQ03.lean
@@ -1,0 +1,107 @@
+import Mathlib
+
+/-
+# Erdős #1017 (OQ-03): closed forms and strict growth of the Turán extremal bound
+# (erdos-1017-oq-03)
+
+## Background
+
+Erdős Problem #1017 concerns `f(n,k)`, the minimum number of complete subgraphs
+needed to edge-partition every `n`-vertex `k`-edge graph. The Erdős–Goodman–Pósa
+bound is `f ≤ ⌊n²/4⌋`, with the complete bipartite graph `K_{⌊n/2⌋,⌈n/2⌉}` (the
+Turán extremal graph) achieving equality. The governing quantity is the **Turán
+bound** `T(n) = ⌊n²/4⌋`, formalized in `Erdos1017OQ01.lean` with its product form
+`T(n) = ⌊n/2⌋·(n − ⌊n/2⌋)` and basic monotonicity.
+
+This sibling entry supplies the **explicit even/odd closed forms** and the
+**strict** growth of `T`, which the parametric estimates of the partition problem
+rely on. (Self-contained: `T` is re-declared, depending only on Mathlib.)
+
+## Result
+
+1. `turanBound_two_mul` — `T(2m) = m²`.
+2. `turanBound_two_mul_add_one` — `T(2m+1) = m(m+1)`.
+   (Together: the extremal `K_{m,m}` has `m²` edges, and `K_{m,m+1}` has
+   `m(m+1)` edges.)
+3. `turanBound_succ_diff` — the exact increment `T(n+1) − T(n) = ⌊(n+1)/2⌋`.
+4. `turanBound_strictMono` — `T` is **strictly increasing** for `n ≥ 1`
+   (`T(n) < T(n+1)`), sharpening the file's non-strict monotonicity.
+5. `turanBound_le_sq_div_four` — the real-valued envelope `T(n) ≤ n²/4`.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos1017OQ03
+
+/-- The Turán extremal bound `T(n) = ⌊n²/4⌋` (re-declared from `Erdos1017OQ01`). -/
+def turanBound (n : ℕ) : ℕ := n ^ 2 / 4
+
+/-- **Even closed form:** `T(2m) = m²` — the extremal `K_{m,m}` has `m²` edges. -/
+theorem turanBound_two_mul (m : ℕ) : turanBound (2 * m) = m ^ 2 := by
+  unfold turanBound
+  rw [show (2 * m) ^ 2 = 4 * m ^ 2 by ring, Nat.mul_div_cancel_left _ (by norm_num)]
+
+/-- **Odd closed form:** `T(2m+1) = m(m+1)` — the extremal `K_{m,m+1}` has
+    `m(m+1)` edges. -/
+theorem turanBound_two_mul_add_one (m : ℕ) : turanBound (2 * m + 1) = m * (m + 1) := by
+  unfold turanBound
+  rw [show (2 * m + 1) ^ 2 = 4 * (m * (m + 1)) + 1 by ring]
+  omega
+
+/-- **The exact increment:** `T(n+1) − T(n) = ⌊(n+1)/2⌋`. Adding a vertex to the
+    balanced complete bipartite graph adds `⌈n/2⌉ = ⌊(n+1)/2⌋` edges. -/
+theorem turanBound_succ_diff (n : ℕ) :
+    turanBound (n + 1) - turanBound n = (n + 1) / 2 := by
+  rcases Nat.even_or_odd n with ⟨m, rfl⟩ | ⟨m, rfl⟩
+  · -- n = m + m
+    rw [show m + m + 1 = 2 * m + 1 from by ring, show m + m = 2 * m from by ring,
+      turanBound_two_mul_add_one, turanBound_two_mul]
+    have h : m * (m + 1) = m ^ 2 + m := by ring
+    omega
+  · -- n = 2m + 1
+    rw [show 2 * m + 1 + 1 = 2 * (m + 1) from by ring, turanBound_two_mul,
+      turanBound_two_mul_add_one]
+    have h : (m + 1) ^ 2 = m * (m + 1) + (m + 1) := by ring
+    omega
+
+/-- **Strict monotonicity:** `T(n) < T(n+1)` for `n ≥ 1`, sharpening the
+    non-strict bound — each added vertex strictly increases the extremal edge
+    count once the graph is nonempty. -/
+theorem turanBound_strictMono (n : ℕ) (hn : 1 ≤ n) :
+    turanBound n < turanBound (n + 1) := by
+  have hdiff : turanBound (n + 1) - turanBound n = (n + 1) / 2 := turanBound_succ_diff n
+  have hpos : 0 < (n + 1) / 2 := by omega
+  omega
+
+/-- **Real envelope:** `T(n) ≤ n²/4` over `ℝ` — the floor never exceeds the exact
+    quarter-square. -/
+theorem turanBound_le_sq_div_four (n : ℕ) :
+    (turanBound n : ℝ) ≤ (n : ℝ) ^ 2 / 4 := by
+  unfold turanBound
+  have h : (((n ^ 2 / 4 : ℕ)) : ℝ) ≤ ((n ^ 2 : ℕ) : ℝ) / 4 := Nat.cast_div_le
+  calc ((n ^ 2 / 4 : ℕ) : ℝ) ≤ ((n ^ 2 : ℕ) : ℝ) / 4 := h
+    _ = (n : ℝ) ^ 2 / 4 := by push_cast; ring
+
+/-
+## Significance
+
+The Turán bound `T(n) = ⌊n²/4⌋` is the extremal value in the Erdős–Goodman–Pósa
+clique-partition theorem underlying Erdős #1017: it is both the worst-case number
+of complete subgraphs needed and the edge count of the extremal complete
+bipartite graph. The companion file records its product form and monotonicity;
+this entry adds the explicit parity-split closed forms `T(2m) = m²`,
+`T(2m+1) = m(m+1)`, the exact one-step increment `⌊(n+1)/2⌋`, the strict growth
+for `n ≥ 1`, and the real envelope `T(n) ≤ n²/4`.
+
+The closed forms make the extremal edge counts (`K_{m,m}` has `m²`, `K_{m,m+1}`
+has `m(m+1)`) explicit, and the increment formula is exactly the quantity the
+parametric question "can `f < ⌊n²/4⌋` once `k > n²/4`?" measures against: each
+unit of edge surplus over `T(n)` is what a `K_4`-or-larger clique might convert
+into a saving. The strict monotonicity guarantees the extremal threshold genuinely
+grows with `n`, with no plateaus, so the dense regime `k > T(n)` is always
+nonempty for `n ≥ 1`.
+-/
+
+end Erdos1017OQ03

--- a/src/data/proofs/erdos-1017-oq-03/meta.json
+++ b/src/data/proofs/erdos-1017-oq-03/meta.json
@@ -1,0 +1,93 @@
+{
+  "id": "erdos-1017-oq-03",
+  "title": "Erdős #1017: closed forms and strict growth of the Turán extremal bound ⌊n²/4⌋",
+  "slug": "erdos-1017-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos1017OQ03",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1017OQ03.lean",
+    "sorries": 0
+  },
+  "description": "Supplies the explicit parity-split closed forms and strict growth of the Turán extremal bound T(n) = floor(n^2/4) underlying Erdős Problem #1017 (clique partition of dense graphs: f(n,k) = min complete subgraphs to edge-partition an n-vertex k-edge graph, with the Erdős-Goodman-Pósa bound f <= floor(n^2/4) and extremal complete bipartite graph). The companion file Erdos1017OQ01.lean records the product form T(n) = floor(n/2)(n - floor(n/2)) and non-strict monotonicity; this sibling adds: T(2m) = m^2 (K_{m,m} has m^2 edges), T(2m+1) = m(m+1) (K_{m,m+1} has m(m+1) edges), the exact one-step increment T(n+1) - T(n) = floor((n+1)/2), STRICT monotonicity T(n) < T(n+1) for n >= 1, and the real envelope T(n) <= n^2/4. Self-contained (re-declares T, depends only on Mathlib). 5 theorems, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1017OQ03.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "extremal-graph-theory",
+      "turan",
+      "clique-partition",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the Turán bound T(n) = n^2/4 is re-declared (the companion Erdos1017OQ01.lean carries 2 axioms egp_theorem and k4free_partition_number, which are not imported or used here). Honest scope: elementary closed-form and monotonicity arithmetic of the extremal bound, not the open clique-partition question itself.",
+    "lineCount": 107,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "turanBound_two_mul: even closed form T(2m) = m^2 (the extremal K_{m,m} has m^2 edges)",
+      "turanBound_two_mul_add_one: odd closed form T(2m+1) = m(m+1) (the extremal K_{m,m+1} has m(m+1) edges)",
+      "turanBound_succ_diff: the exact one-step increment T(n+1) - T(n) = floor((n+1)/2)",
+      "turanBound_strictMono: STRICT monotonicity T(n) < T(n+1) for n >= 1, sharpening the companion's non-strict bound",
+      "turanBound_le_sq_div_four: the real-valued envelope T(n) <= n^2/4 (the floor never exceeds the exact quarter-square)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1017 (Erdős-Goodman-Pósa, 1966) asks for f(n,k), the minimum number of complete subgraphs needed to edge-partition every n-vertex k-edge graph. The bound f <= floor(n^2/4) is achieved by the balanced complete bipartite (Turán) graph K_{floor(n/2),ceil(n/2)}, which is triangle-free and thus needs each of its floor(n^2/4) edges as a separate clique. The open question is whether f < floor(n^2/4) is possible once k > n^2/4 and large cliques (K_4 or bigger) are present; the K_4-free case is resolved by Gyori-Keszegh (2017). The Turán quantity floor(n^2/4) is the quarter-square sequence, central to extremal graph theory.",
+    "problemStatement": "The extremal bound governing Erdős #1017 is T(n) = floor(n^2/4). The companion file gives its product form and monotonicity; this entry supplies its explicit even/odd closed forms, exact increment, strict growth, and real envelope.",
+    "proofStrategy": "For the closed forms, expand the square: (2m)^2 = 4m^2 so T(2m) = m^2 by exact division, and (2m+1)^2 = 4(m(m+1)) + 1 so T(2m+1) = m(m+1) by floor division (remainder 1 < 4), discharged by omega after a ring rewrite. The increment splits on parity of n via Nat.even_or_odd, reducing each case to the closed forms plus a ring identity (m(m+1) = m^2 + m, (m+1)^2 = m(m+1) + (m+1)) fed to omega. Strict monotonicity follows since the increment floor((n+1)/2) is positive for n >= 1. The real envelope is Nat.cast_div_le.",
+    "keyInsights": [
+      "The Turán bound is the quarter-square sequence, with clean parity-split forms m^2 (even) and m(m+1) (odd) — exactly the edge counts of the balanced and near-balanced complete bipartite extremal graphs.",
+      "The one-step increment T(n+1) - T(n) = floor((n+1)/2) = ceil(n/2) is the number of edges a new vertex adds to the balanced complete bipartite graph.",
+      "That increment is the exact unit of 'edge surplus' the parametric question measures against: each edge above T(n) is what a K_4-or-larger clique might convert into a partition saving.",
+      "Strict monotonicity for n >= 1 guarantees the extremal threshold grows without plateaus, so the dense regime k > T(n) is always nonempty."
+    ]
+  },
+  "sections": [
+    {
+      "id": "closed-forms",
+      "title": "Even/Odd Closed Forms",
+      "summary": "turanBound_two_mul (T(2m) = m^2) and turanBound_two_mul_add_one (T(2m+1) = m(m+1)).",
+      "startLine": 1,
+      "endLine": 55,
+      "mathContext": "Expand the square and divide: (2m)^2/4 = m^2 exactly; (2m+1)^2/4 = (4 m(m+1)+1)/4 = m(m+1) by floor."
+    },
+    {
+      "id": "growth",
+      "title": "Increment, Strict Growth, and Real Envelope",
+      "summary": "turanBound_succ_diff (increment floor((n+1)/2)), turanBound_strictMono (strict for n >= 1), turanBound_le_sq_div_four (T(n) <= n^2/4 over R).",
+      "startLine": 56,
+      "endLine": 107,
+      "mathContext": "Parity case-split for the increment; positivity of the increment for strict monotonicity; Nat.cast_div_le for the real bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "The extremal Turán bound T(n) = floor(n^2/4) of the Erdős-Goodman-Pósa clique-partition theorem is given explicit parity-split closed forms T(2m) = m^2 and T(2m+1) = m(m+1) — the edge counts of the balanced and near-balanced complete bipartite extremal graphs — together with the exact increment floor((n+1)/2), strict monotonicity for n >= 1, and the real envelope T(n) <= n^2/4. Self-contained over Mathlib, complementing the companion file's product form and non-strict monotonicity.",
+    "implications": "The closed forms and increment make the extremal arithmetic of Erdős #1017 fully explicit, expressing the threshold against which the open question (can f < T(n) once k > T(n)?) is posed: each unit of edge surplus above T(n) is a candidate saving for a large clique. Strict monotonicity certifies the dense regime is always nonempty. The quarter-square closed forms are reusable across extremal graph theory (Turán/Mantel and complete-bipartite edge counts).",
+    "openQuestions": [
+      "Resolve the parametric Erdős #1017 question: can f(n,k) < floor(n^2/4) when k > n^2/4 and the graph contains K_4 or larger cliques?",
+      "Discharge the companion file's two axioms (egp_theorem, the Gyori-Keszegh k4free_partition_number) to make the clique-partition bounds fully proved.",
+      "Quantify the saving as a function of the clique sizes present, building on the increment formula here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1017-oq-01",
+      "relationship": "parent",
+      "description": "The main Erdős #1017 clique-partition file (cliquePartitionNum, the Erdős-Goodman-Pósa bound, complete bipartite extremal constructions) which defines turanBound and proves its product form and non-strict monotonicity. This sibling adds the explicit even/odd closed forms, exact increment, strict growth, and real envelope of the same bound."
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-1017-oq-03.json
+++ b/src/data/research/problems/erdos-1017-oq-03.json
@@ -1,0 +1,43 @@
+{
+  "slug": "erdos-1017-oq-03",
+  "title": "Erdős #1017: closed forms and strict growth of the Turán bound ⌊n²/4⌋",
+  "phase": "COMPLETED",
+  "status": "graduated",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "T(2m)=m^2,\\ T(2m+1)=m(m+1),\\ T(n)<T(n+1)",
+    "plain": "Supply explicit even/odd closed forms, increment, and strict growth of the Turán extremal bound floor(n^2/4) for Erdős #1017.",
+    "whyMatters": []
+  },
+  "knowledge": {
+    "progressSummary": "Supplied explicit parity-split closed forms + strict growth of the Turán extremal bound T(n)=floor(n^2/4) of Erdős #1017 (clique partition of dense graphs). Companion Erdos1017OQ01.lean has product form + non-strict mono; added T(2m)=m^2, T(2m+1)=m(m+1) (extremal K_{m,m}/K_{m,m+1} edge counts), increment T(n+1)-T(n)=floor((n+1)/2), STRICT T(n)<T(n+1) n>=1, real envelope T(n)<=n^2/4. Self-contained re-decl (companion has 2 axioms egp_theorem/k4free_partition_number, not used). 5 thm/1 def, 0 sorries/0 axioms, builds green 7743 jobs.",
+    "builtItems": [
+      "turanBound_two_mul: T(2m)=m^2",
+      "turanBound_two_mul_add_one: T(2m+1)=m(m+1)",
+      "turanBound_succ_diff: T(n+1)-T(n)=floor((n+1)/2)",
+      "turanBound_strictMono: T(n)<T(n+1) n>=1",
+      "turanBound_le_sq_div_four: T(n)<=n^2/4 over R"
+    ],
+    "insights": [
+      "Turán bound = quarter-square sequence with parity forms m^2 (even) / m(m+1) (odd) = balanced/near-balanced complete bipartite edge counts.",
+      "Increment floor((n+1)/2)=ceil(n/2) = edges a new vertex adds to the balanced bipartite graph; the unit of edge surplus the OQ measures.",
+      "Strict monotonicity n>=1 => dense regime k>T(n) always nonempty, no plateaus."
+    ],
+    "mathlibGaps": [
+      "Companion has 2 axioms: egp_theorem (Erdős-Goodman-Pósa), k4free_partition_number (Gyori-Keszegh 2017)."
+    ],
+    "nextSteps": [
+      "Resolve the parametric OQ: f<floor(n^2/4) when k>n^2/4 with K_4+?",
+      "Discharge the 2 companion axioms.",
+      "Quantify saving as a function of clique sizes via the increment formula."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "erdos",
+    "extremal-graph-theory"
+  ],
+  "significance": 6,
+  "tractability": 6
+}


### PR DESCRIPTION
## Summary

Erdős Problem #1017 (Erdős–Goodman–Pósa clique partition of dense graphs) is governed by the **Turán extremal bound** $T(n) = \lfloor n^2/4\rfloor$ — the worst-case number of complete subgraphs and the edge count of the extremal complete bipartite graph. The companion file `Erdos1017OQ01.lean` records its product form and non-strict monotonicity; this sibling adds the explicit arithmetic.

- `turanBound_two_mul` — $T(2m) = m^2$ (the extremal $K_{m,m}$).
- `turanBound_two_mul_add_one` — $T(2m+1) = m(m+1)$ (the extremal $K_{m,m+1}$).
- `turanBound_succ_diff` — the exact increment $T(n+1) - T(n) = \lfloor (n+1)/2\rfloor$.
- `turanBound_strictMono` — **strict** monotonicity $T(n) < T(n+1)$ for $n \ge 1$.
- `turanBound_le_sq_div_four` — the real envelope $T(n) \le n^2/4$.

## Verification

`./proofs/scripts/docker-build.sh Proofs.Erdos1017OQ03` builds green (Lean v4.26.0, 7743 jobs). **0 sorries, 0 axioms, no `native_decide`** — `status: verified`. Self-contained over Mathlib (the companion's 2 axioms are not used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)