### PR TITLE
fix(wrapper): rotate accounts on weekly limit (was hammering dead token 300s)

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -340,8 +340,9 @@ classify_error() {
     # wrapper rotates instead of pinning to the dead account for 300s ticks:
     #   - "hit your limit"                              (legacy short form)
     #   - "You've hit your org's monthly usage limit"   (org cap; multi-word gap defeats `hit.your.limit`)
+    #   - "You've hit your weekly limit · resets …"     (weekly cap; same multi-word gap)
     #   - "You're out of extra usage · resets …"        (session/extra-usage cap)
-    if echo "$output" | grep -qi "hit your limit\|monthly usage limit\|out of extra usage"; then
+    if echo "$output" | grep -qi "hit your limit\|monthly usage limit\|weekly limit\|out of extra usage"; then
         echo "TOKEN_EXHAUSTED"
         return
     fi


### PR DESCRIPTION
## Problem
Found via `/lean status`: **researcher-11 had 222 consecutive failures** over ~18h:
```
You've hit your weekly limit · resets Jun 25 at 6am
[wrapper] recoverable error (exit code: 1, consecutive failures: 222)
```
Its account hit a **weekly** quota, but `classify_error`'s `TOKEN_EXHAUSTED` matcher only knew `"hit your limit"`, `"monthly usage limit"`, `"out of extra usage"`. The multi-word gap in `"hit your WEEKLY limit"` also defeats the `"hit your limit"` substring, so it fell through to generic `RECOVERABLE` — the agent **hammered the same dead token every 300s** instead of **rotating to another pool account**.

Fleet-wide impact: deployer, all 3 enrichers, herald, both mechanics, and several researchers hit the same wall; auditor/seeker/mechanic were stuck respawning straight back into exhausted accounts (0 active).

## Fix
One line — add `weekly limit` to the `TOKEN_EXHAUSTED` pattern so weekly caps trigger account rotation exactly like monthly caps. The pool has **13 accounts**, so rotation finds a live one instead of pinning to the exhausted one until the Jun 25 reset.

## Testing
- `bash -n` passes.
- Verified `"You've hit your weekly limit · resets Jun 25"` now matches `TOKEN_EXHAUSTED`.
- Regression-checked: `"hit your limit"`, `"monthly usage limit"`, `"out of extra usage"` still match.
- Running wrappers load the function at start, so affected agents need a respawn to pick up the new classifier — will respawn the failing/missing ones after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)