### PR TITLE
audit(abel-ruffini-oq-04-oq-02-oq-02-oq-08): badge verified→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/meta.json
@@ -20,7 +20,7 @@
       "research",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: abel-ruffini-oq-04-oq-02-oq-02-oq-08 — "The Aα ↔ Sα Solvability Bridge"
**Severity**: MEDIUM (heavy Mathlib reliance for core result)

## Finding

The badge was `verified` but this is a **Tier B** bridge: the core mathematical content is supplied by imported Mathlib theorems, and the file's contribution is assembly/recognition.

- Forward direction `sym_solvable_of_alternating_solvable` — the file's own docstring calls this "the substantive half" — is `solvable_of_ker_le_range` (Mathlib's solvable-extension closure) applied to the sign sequence.
- Backward direction `alternating_solvable_of_sym_solvable` is the `subgroup_solvable_of_solvable` instance.
- The headline `alternating_solvable_iff_sym_solvable` packages the two; the `Fin n` specialisations transport the **parent's** classification.

Per the auditor tier rules (Tier B → badge `mathlib`) and failure mode #5 ("0 sorries with hidden imports"), the badge must be `mathlib`, not `verified`.

## Static checks (all match meta.json)

| Check | Value |
|-------|-------|
| sorries | 0 |
| `axiom` declarations | 0 |
| native_decide | none |
| True stubs | 0 |
| theorems / defs / lines | 12 / 0 / 167 |

## Fix

`meta.badge`: `verified` → `mathlib`.

`status` stays `verified` — the result is fully machine-checked with 0 sorries, 0 axioms, 0 structure-encoded assumptions. The meta text (description, sections, mathlibDependencies, originalContributions, assumptions, conclusion) was already transparent about the Mathlib reliance; only the badge label mis-stated the tier.

---
Discovered during gallery integrity audit.