### PR TITLE
audit: badge verified→mathlib for AbelRuffini OQ08 solvability bridge family (Tier B)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01/meta.json
@@ -25,7 +25,7 @@
       "research",
       "transport"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -67,7 +67,7 @@
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
     "lineCount": 174,
-    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. `#print axioms` on perm_solvable_iff_card, alternating_solvable_iff_card, alternating_solvable_iff_of_card_eq, nonempty_alternatingCongr_of_card_eq, and sharp_threshold_card reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`. (The classification corollaries depend transitively on the parent's Fin n results, which are themselves decide-based and native_decide-free.)",
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions (core result via Mathlib bridge: the solvability conclusions are transported by Mathlib's `solvable_of_surjective`/`permCongrHom`/`sign_permCongr` machinery composed with the parent's classification — this file supplies the cardinality-invariance transport, not an independent solvability proof, hence the `mathlib` badge). No `native_decide` is used. `#print axioms` on perm_solvable_iff_card, alternating_solvable_iff_card, alternating_solvable_iff_of_card_eq, nonempty_alternatingCongr_of_card_eq, and sharp_threshold_card reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`. (The classification corollaries depend transitively on the parent's Fin n results, which are themselves decide-based and native_decide-free.)",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 1,

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08/meta.json
@@ -20,7 +20,7 @@
       "research",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -59,7 +59,7 @@
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
     "lineCount": 167,
-    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used; the named small-case instances (s4_solvable etc.) reach back through the parent's `decide`-based, native_decide-free A₄ argument, so the kernel-checked status is preserved. `#print axioms` on the main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions (core result via Mathlib bridge: the forward direction is Mathlib's `solvable_of_ker_le_range` applied to the sign sequence, the backward direction is Mathlib's `subgroup_solvable_of_solvable` instance — this file supplies the bridge, not an independent solvability proof, hence the `mathlib` badge). No `native_decide` is used; the named small-case instances (s4_solvable etc.) reach back through the parent's `decide`-based, native_decide-free A₄ argument, so the kernel-checked status is preserved. `#print axioms` on the main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 0,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17713,6 +17713,12 @@
       "lastAudited": "2026-06-23T03:14:54Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-23T03:16:14Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17701,6 +17701,12 @@
       "lastAudited": "2026-06-21T13:34:55Z",
       "result": "clean",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-23T03:13:12Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17707,6 +17707,12 @@
       "lastAudited": "2026-06-23T03:13:12Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-23T03:14:54Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery integrity audit — Tier B badge corrections

Three sibling entries in the AbelRuffini OQ-08 solvability-bridge family present a `verified` badge while their core results are obtained **via Mathlib theorems** (delegation). All are genuinely 0-axiom / 0-sorry / kernel-checked, so `status` stays `verified` — but per the auditor **Tier B** classification and **narrative failure mode #5** ("0 sorries" with hidden imports), the badge must be `mathlib`.

### 1. `abel-ruffini-oq-04-oq-02-oq-02-oq-08` — The Aα ↔ Sα Solvability Bridge
Headline `alternating_solvable_iff_sym_solvable` is built entirely from Mathlib:
- **Forward**: `solvable_of_ker_le_range (alternatingGroup α).subtype Perm.sign`
- **Backward**: `subgroup_solvable_of_solvable` instance (`infer_instance`)

### 2. `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01` — Solvability intrinsic to the cardinality
Headline `perm_solvable_iff_card` / `alternating_solvable_iff_card` transport the solvability conclusion via Mathlib's `solvable_of_surjective` (MulEquiv invariance), `Equiv.permCongrHom`, `Equiv.Perm.sign_permCongr`, composed with the (already Tier B) parent classification.

### 3. `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01` — Solvability downward closed under injections
Headline `perm_solvable_of_embedding` is a one-liner over Mathlib's `solvable_of_solvable_injective` + `Perm.viaEmbeddingHom_injective`; cardinality-monotonicity / down-set corollaries compose with the parent threshold.

## Changes (each entry)
- `badge`: `verified` → `mathlib`
- `assumptions`: Tier B qualifier disclosing the core result comes via the Mathlib bridge (entries 1–2; entry 3 already disclosed it).
- `status`, `originalContributions`, titles, overviews unchanged — already honestly scoped.
- Updates `audit-tracker.json` (all three marked `issues-fixed`).

The genuine original contributions in each file (the bridge equivalence, the cardinality-invariance transport, the embedding/down-set packaging) are real and remain credited; only the headline solvability conclusions are delegated, which is exactly what the `mathlib` badge signals.

---
Discovered during gallery integrity audit.