### PR TITLE
audit(abel-ruffini-oq08-oq01-oq01-oq01): badge verified→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: \`abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01\` — "Non-Solvability of Sₐ is Upward Closed Under Injections"

**Tier**: B (formalized using a Mathlib theorem)
**Severity**: MEDIUM (heavy Mathlib reliance for the core result)

### Problem (failure mode #5 — 0-sorry result via deep Mathlib theorem)
The file's headline structural theorem `perm_not_solvable_of_embedding` is the exact contrapositive of the parent's `perm_solvable_of_embedding`, whose engine is Mathlib's **`solvable_of_solvable_injective`** + **`Equiv.Perm.viaEmbeddingHom_injective`**. The meta's own `assumptions` field already concedes the result "depends only on Mathlib (viaEmbeddingHom_injective, solvable_of_solvable_injective)". The remaining content is contrapositive restatement + elementary order-theoretic packaging (`omega`).

A `verified` badge presents this as independent work; `mathlib` correctly signals the bridge.

### Evidence
- **meta.json claimed**: `badge: "verified"`
- **Lean source**: core via Mathlib delegation; 0 sorries, 0 axioms, 0 True stubs, no native_decide (kernel-checked)
- **mathlibDependencies** lists `solvable_of_solvable_injective` as the engine of the structural ascent

### Fix
`badge: "verified"` → `"mathlib"`. Status stays `verified` (0 sorries / 0 axioms). No Lean source change.

This mirrors the sibling corrections already merged in #27689 / #27690 (oq-08, oq-08-oq-01, oq-08-oq-01-oq-01); this entry sits one level deeper and was outside that PR's scope. The deeper siblings (×4/×5/×6) rely only on cardinality arithmetic (`Fintype.card_prod`, `Nat.mul_le_mul`) — ordinary library use, not core-result delegation — so they correctly remain `verified`.

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)