### PR TITLE
research(buffons-needle-oq-02-oq-02-oq-01-oq-01): closed-form Wallis product solving the Buffon crossing-factor recurrence [0-axiom verified]

### DIFF
--- a/proofs/Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean
@@ -1,0 +1,190 @@
+import Mathlib
+
+/-
+# Closed-Form Product Formula for the Buffon Crossing Factor
+# (buffons-needle-oq-02-oq-02-oq-01-oq-01)
+
+## The Open Question
+
+The n-dimensional Buffon noodle formula `E[crossings] = αₙ · L/d` is governed by
+the **crossing factor** `αₙ = E_{Sⁿ⁻¹}[|u₁|]`, defined by the two-step recurrence
+`α_{n+2} = (n/(n+1)) · αₙ` with base values `α₂ = 2/π` and `α₃ = 1/2`. The parent
+entry `buffons-needle-oq-02-oq-02-oq-01` proves the *structural* monotonicity of
+`αₙ` (strict two-step decrease, maximum `2/π`, uniform sub-one bound) directly
+from the recurrence, but never solves the recurrence: it leaves open the explicit
+**closed form** of the even- and odd-dimension subsequences.
+
+## Result
+
+We *solve* the two-step recurrence, giving the exact telescoping products that
+unfold it. Writing the recurrence factors out, every even (resp. odd) dimension
+is the base value `2/π` (resp. `1/2`) times a finite product of the rational
+ratios `(2j+2)/(2j+3)` (resp. `(2j+3)/(2j+4)`):
+
+1. `crossingFactor_even` — **even subsequence closed form**:
+   `α_{2m+2} = (2/π) · ∏_{j<m} (2j+2)/(2j+3)`.
+
+2. `crossingFactor_odd` — **odd subsequence closed form**:
+   `α_{2m+3} = (1/2) · ∏_{j<m} (2j+3)/(2j+4)`.
+
+3. `crossingFactor_even_pos` / `crossingFactor_even_le_base` — each product factor
+   lies in `(0,1]`, so the formula re-derives positivity and the maximum `2/π`
+   for the even subsequence *from the closed form*.
+
+4. `crossingFactor_four`, `crossingFactor_six`, `crossingFactor_five`,
+   `crossingFactor_seven` — the first higher concrete values
+   `α₄ = 4/(3π)`, `α₆ = 16/(15π)`, `α₅ = 3/8`, `α₇ = 5/16`, evaluated directly
+   from the product formula (none are computed in the parent).
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
+-/
+
+set_option linter.unusedVariables false
+
+namespace BuffonsNeedleOQ02OQ02OQ01OQ01
+
+open Real
+
+/-- The n-dimensional crossing factor `αₙ = E_{Sⁿ⁻¹}[|u₁|]`, by the recurrence
+    `α_{n+2} = (n/(n+1)) · αₙ` with `α₂ = 2/π`, `α₃ = 1/2` (and `1` for `n ≤ 1`
+    by convention). Re-declared verbatim from `BuffonsNeedleOQ02OQ01.lean`, whose
+    companion currently fails to build on the pinned Mathlib. -/
+noncomputable def crossingFactor : ℕ → ℝ
+  | 0 => 1
+  | 1 => 1
+  | 2 => 2 / π
+  | 3 => 1 / 2
+  | (n + 4) => ((n + 2 : ℝ) / (n + 3 : ℝ)) * crossingFactor (n + 2)
+
+@[simp] lemma crossingFactor_two : crossingFactor 2 = 2 / π := rfl
+
+@[simp] lemma crossingFactor_three : crossingFactor 3 = 1 / 2 := rfl
+
+/-- The fundamental recurrence `α_{n+4} = ((n+2)/(n+3)) · α_{n+2}`. -/
+@[simp] lemma crossingFactor_succ_succ (n : ℕ) :
+    crossingFactor (n + 4) = ((n + 2 : ℝ) / (n + 3 : ℝ)) * crossingFactor (n + 2) := rfl
+
+-- ============================================================
+-- PART 1: The closed-form product formulas
+-- ============================================================
+
+/-- **Even-dimension closed form.** Solving the two-step recurrence on the even
+    subsequence: `α_{2m+2} = (2/π) · ∏_{j<m} (2j+2)/(2j+3)`. The empty product
+    (`m = 0`) recovers `α₂ = 2/π`, and each step appends the recurrence factor. -/
+theorem crossingFactor_even (m : ℕ) :
+    crossingFactor (2 * m + 2)
+      = (2 / π) * ∏ j ∈ Finset.range m, (2 * (j : ℝ) + 2) / (2 * (j : ℝ) + 3) := by
+  induction m with
+  | zero =>
+      show crossingFactor 2 = (2 / π) * ∏ j ∈ Finset.range 0, (2 * (j : ℝ) + 2) / (2 * (j : ℝ) + 3)
+      rw [Finset.prod_range_zero, mul_one, crossingFactor_two]
+  | succ k ih =>
+      have hidx : 2 * (k + 1) + 2 = 2 * k + 4 := by ring
+      rw [hidx, crossingFactor_succ_succ (2 * k), ih, Finset.prod_range_succ]
+      push_cast
+      ring
+
+/-- **Odd-dimension closed form.** Solving the two-step recurrence on the odd
+    subsequence: `α_{2m+3} = (1/2) · ∏_{j<m} (2j+3)/(2j+4)`. The empty product
+    (`m = 0`) recovers `α₃ = 1/2`, and each step appends the recurrence factor. -/
+theorem crossingFactor_odd (m : ℕ) :
+    crossingFactor (2 * m + 3)
+      = (1 / 2) * ∏ j ∈ Finset.range m, (2 * (j : ℝ) + 3) / (2 * (j : ℝ) + 4) := by
+  induction m with
+  | zero =>
+      show crossingFactor 3 = (1 / 2) * ∏ j ∈ Finset.range 0, (2 * (j : ℝ) + 3) / (2 * (j : ℝ) + 4)
+      rw [Finset.prod_range_zero, mul_one, crossingFactor_three]
+  | succ k ih =>
+      have hidx : 2 * (k + 1) + 3 = (2 * k + 1) + 4 := by ring
+      have hidx2 : (2 * k + 1) + 2 = 2 * k + 3 := by ring
+      rw [hidx, crossingFactor_succ_succ (2 * k + 1), hidx2, ih, Finset.prod_range_succ]
+      push_cast
+      ring
+
+-- ============================================================
+-- PART 2: Positivity and the maximum, re-derived from the product
+-- ============================================================
+
+/-- Each even-subsequence factor is positive. -/
+lemma evenFactor_pos (j : ℕ) : 0 < (2 * (j : ℝ) + 2) / (2 * (j : ℝ) + 3) := by
+  positivity
+
+/-- Each even-subsequence factor is at most one (`(2j+2)/(2j+3) ≤ 1`). -/
+lemma evenFactor_le_one (j : ℕ) : (2 * (j : ℝ) + 2) / (2 * (j : ℝ) + 3) ≤ 1 := by
+  rw [div_le_one (by positivity)]; linarith [Nat.cast_nonneg (α := ℝ) j]
+
+/-- **Positivity from the closed form.** `0 < α_{2m+2}`, since `2/π > 0` and the
+    product is a finite product of positive factors. -/
+theorem crossingFactor_even_pos (m : ℕ) : 0 < crossingFactor (2 * m + 2) := by
+  rw [crossingFactor_even]
+  apply mul_pos (by positivity)
+  apply Finset.prod_pos
+  intro j _
+  exact evenFactor_pos j
+
+/-- **The maximum `2/π`, from the closed form.** `α_{2m+2} ≤ 2/π`, since the
+    product of factors each `≤ 1` is itself `≤ 1`. -/
+theorem crossingFactor_even_le_base (m : ℕ) : crossingFactor (2 * m + 2) ≤ 2 / π := by
+  rw [crossingFactor_even]
+  nth_rewrite 2 [← mul_one (2 / π)]
+  apply mul_le_mul_of_nonneg_left _ (by positivity)
+  calc ∏ j ∈ Finset.range m, (2 * (j : ℝ) + 2) / (2 * (j : ℝ) + 3)
+      ≤ ∏ _j ∈ Finset.range m, (1 : ℝ) := by
+        apply Finset.prod_le_prod
+        · intro j _; exact (evenFactor_pos j).le
+        · intro j _; exact evenFactor_le_one j
+    _ = 1 := by rw [Finset.prod_const_one]
+
+-- ============================================================
+-- PART 3: Concrete higher values, evaluated from the product
+-- ============================================================
+
+/-- `α₄ = 4/(3π)` — the first even value past the base, from the product formula. -/
+theorem crossingFactor_four : crossingFactor 4 = 4 / (3 * π) := by
+  have h := crossingFactor_even 1
+  rw [Finset.prod_range_one] at h
+  rw [show (4 : ℕ) = 2 * 1 + 2 from rfl, h]
+  push_cast; ring
+
+/-- `α₆ = 16/(15π)` — the second even value, from the product formula. -/
+theorem crossingFactor_six : crossingFactor 6 = 16 / (15 * π) := by
+  have h := crossingFactor_even 2
+  rw [Finset.prod_range_succ, Finset.prod_range_one] at h
+  rw [show (6 : ℕ) = 2 * 2 + 2 from rfl, h]
+  push_cast; ring
+
+/-- `α₅ = 3/8` — the first odd value past the base, from the product formula. -/
+theorem crossingFactor_five : crossingFactor 5 = 3 / 8 := by
+  have h := crossingFactor_odd 1
+  rw [Finset.prod_range_one] at h
+  rw [show (5 : ℕ) = 2 * 1 + 3 from rfl, h]
+  push_cast; ring
+
+/-- `α₇ = 5/16` — the second odd value, from the product formula. -/
+theorem crossingFactor_seven : crossingFactor 7 = 5 / 16 := by
+  have h := crossingFactor_odd 2
+  rw [Finset.prod_range_succ, Finset.prod_range_one] at h
+  rw [show (7 : ℕ) = 2 * 2 + 3 from rfl, h]
+  push_cast; ring
+
+/-
+## Significance
+
+The parent entry establishes the *qualitative* monotone behaviour of the Buffon
+crossing factor `αₙ = E_{Sⁿ⁻¹}[|u₁|]` directly from its two-step recurrence
+`α_{n+2} = (n/(n+1))αₙ`. This entry *solves* that recurrence in closed form: the
+even and odd subsequences are the base values `2/π` and `1/2` times explicit
+telescoping products of the rational factors `(2j+2)/(2j+3)` and `(2j+3)/(2j+4)`
+(`crossingFactor_even`, `crossingFactor_odd`). These are the finite Wallis-type
+partial products underlying the exact value `αₙ = Γ(n/2)/(√π Γ((n+1)/2))`.
+
+The closed form makes the structural facts transparent: positivity and the
+maximum `2/π` follow because the products are built from factors in `(0,1]`
+(`crossingFactor_even_pos`, `crossingFactor_even_le_base`), and the higher values
+`α₄ = 4/(3π)`, `α₆ = 16/(15π)`, `α₅ = 3/8`, `α₇ = 5/16` drop out by direct
+evaluation (`crossingFactor_four`, `crossingFactor_six`, `crossingFactor_five`,
+`crossingFactor_seven`). Everything is verified from the recurrence and its base
+values, with no axioms.
+-/
+
+end BuffonsNeedleOQ02OQ02OQ01OQ01

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,57 @@
+{
+  "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+  "title": "Closed-Form Product Formula for the Buffon Crossing Factor",
+  "slug": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Real"],
+    "namespace": "BuffonsNeedleOQ02OQ02OQ01OQ01",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Solves the two-step recurrence defining the n-dimensional Buffon crossing factor alpha_n = E over S^{n-1} of |u_1| (governing the noodle formula E[crossings] = alpha_n * L/d), giving the explicit closed-form telescoping products for the even and odd dimension subsequences. The parent entry buffons-needle-oq-02-oq-02-oq-01 proves the qualitative monotone behaviour of alpha_n directly from the recurrence alpha_{n+2} = (n/(n+1)) alpha_n with base alpha_2 = 2/pi, alpha_3 = 1/2, but never solves it; this entry unfolds the recurrence: alpha_{2m+2} = (2/pi) * prod_{j<m} (2j+2)/(2j+3) and alpha_{2m+3} = (1/2) * prod_{j<m} (2j+3)/(2j+4), the finite Wallis-type partial products underlying the exact value Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)). From the closed form it re-derives positivity and the maximum 2/pi for the even subsequence (the products are built from factors in (0,1]) and evaluates the first higher concrete values alpha_4 = 4/(3pi), alpha_6 = 16/(15pi), alpha_5 = 3/8, alpha_7 = 5/16. 10 theorems/lemmas, 1 definition, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean",
+    "tags": [
+      "probability",
+      "geometric-probability",
+      "buffon-needle",
+      "integral-geometry",
+      "wallis-product",
+      "closed-form",
+      "high-dimensional"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked: `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ02OQ02OQ01OQ01` builds green (Lean v4.26.0, Mathlib pin, 7743 jobs). 0 sorries, 0 axiom declarations, no native_decide; only the standard foundational axioms via Mathlib. Self-contained: the companion BuffonsNeedleOQ02OQ01.lean currently fails to build on the pinned Mathlib (Filter.Tendsto.div API drift), so the crossingFactor recurrence and its base lemmas are re-declared verbatim here. Honest scope: the exact closed-form solution of the two-step recurrence (telescoping products) plus positivity, the maximum, and concrete values derived from it.",
+    "lineCount": 190,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "originalContributions": [
+      "crossingFactor_even: the even-dimension closed form alpha_{2m+2} = (2/pi) * prod_{j<m} (2j+2)/(2j+3), solving the two-step recurrence on the even subsequence by induction (empty product recovers alpha_2 = 2/pi, each step appends the recurrence factor)",
+      "crossingFactor_odd: the odd-dimension closed form alpha_{2m+3} = (1/2) * prod_{j<m} (2j+3)/(2j+4), solving the recurrence on the odd subsequence",
+      "crossingFactor_even_pos and crossingFactor_even_le_base: positivity and the maximum 2/pi for the even subsequence re-derived FROM the closed form (each product factor lies in (0,1], so the product is positive and at most one)",
+      "crossingFactor_four = 4/(3pi), crossingFactor_six = 16/(15pi), crossingFactor_five = 3/8, crossingFactor_seven = 5/16: the first higher concrete values, evaluated directly from the product formula (none computed in the parent)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Buffon's needle (1777) computes the probability that a dropped needle crosses parallel lines; Barbier's noodle theorem shows the expected number of crossings depends only on the curve's length. In R^n with parallel hyperplanes, the expected crossings of a unit-length curve equal alpha_n = E over S^{n-1} of |u_1| = Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)), which satisfies the two-step recurrence alpha_{n+2} = (n/(n+1)) alpha_n. Unfolding the recurrence produces finite Wallis-type partial products, the classical building blocks of the Wallis product for pi.",
+    "problemStatement": "The parent entry proves the qualitative monotone behaviour of the crossing factor alpha_n directly from its two-step recurrence but never solves the recurrence. What is the explicit closed form of the even- and odd-dimension subsequences?",
+    "proofStrategy": "Re-declare the recurrence crossingFactor (the companion is bit-rotted) and solve it by induction on the subsequence index m. For the even subsequence, the base case m=0 gives alpha_2 = 2/pi (empty product = 1), and the successor step applies the recurrence at index 2m+2 and Finset.prod_range_succ, closing by push_cast and ring. The odd subsequence is identical with base alpha_3 = 1/2. Positivity and the maximum follow from Finset.prod_pos and Finset.prod_le_prod applied to the factors (2j+2)/(2j+3) in (0,1]. Concrete values expand the product over a small range.",
+    "keyInsights": [
+      "Solving the two-step recurrence gives exact telescoping products: alpha_{2m+2} = (2/pi) prod (2j+2)/(2j+3) and alpha_{2m+3} = (1/2) prod (2j+3)/(2j+4), the finite Wallis partial products behind alpha_n = Gamma(n/2)/(sqrt(pi) Gamma((n+1)/2)).",
+      "The closed form makes the structural facts transparent: positivity and the maximum 2/pi hold because every product factor lies in (0,1], so the product is positive and at most one.",
+      "Concrete higher values drop out by expanding the product over a small range: alpha_4 = 4/(3pi), alpha_6 = 16/(15pi) on the even side, alpha_5 = 3/8, alpha_7 = 5/16 on the odd side.",
+      "Self-containment is forced by upstream bit-rot in the companion crossing-factor file, but the recurrence is a one-line definition, so the closed form is fully reproducible."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Solves the two-step recurrence defining the **n-dimensional Buffon crossing factor** `αₙ = E_{Sⁿ⁻¹}[|u₁|]` (governing the noodle formula `E[crossings] = αₙ · L/d`), giving the explicit **closed-form telescoping products** for the even and odd dimension subsequences.

The parent entry `buffons-needle-oq-02-oq-02-oq-01` (PR #27678) proves the *qualitative* monotone behaviour of `αₙ` directly from the recurrence `α_{n+2} = (n/(n+1))αₙ` with base `α₂ = 2/π`, `α₃ = 1/2`, but never **solves** it. This child unfolds the recurrence into the finite Wallis-type partial products behind `αₙ = Γ(n/2)/(√π Γ((n+1)/2))`.

## Results (`Proofs/BuffonsNeedleOQ02OQ02OQ01OQ01.lean`, 190 lines, 10 thm / 1 def)

1. **`crossingFactor_even`** — even-dimension closed form: `α_{2m+2} = (2/π) · ∏_{j<m} (2j+2)/(2j+3)`.
2. **`crossingFactor_odd`** — odd-dimension closed form: `α_{2m+3} = (1/2) · ∏_{j<m} (2j+3)/(2j+4)`.
3. **`crossingFactor_even_pos` / `crossingFactor_even_le_base`** — positivity and the maximum `2/π` re-derived *from the closed form* (each product factor lies in `(0,1]`).
4. **`crossingFactor_four/six/five/seven`** — first higher concrete values `α₄ = 4/(3π)`, `α₆ = 16/(15π)`, `α₅ = 3/8`, `α₇ = 5/16`, evaluated directly from the product (none computed in the parent).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ02OQ02OQ01OQ01` builds green (Lean v4.26.0, Mathlib pin, **7743 jobs**, 483s).
- **0 sorries, 0 axiom declarations, no `native_decide`** — only the standard foundational axioms via Mathlib.
- Self-contained: the bit-rotted companion `BuffonsNeedleOQ02OQ01.lean` (Filter.Tendsto.div API drift) is re-declared verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)