### PR TITLE
research(erdos-11-wip-01): decidable characterization of squarefree + power of 2 [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos11WIP01.lean
+++ b/proofs/Proofs/Erdos11WIP01.lean
@@ -1,0 +1,96 @@
+/-
+  Erdős Problem #11 — WIP-01: a decidable characterization and a verified range
+
+  Erdős Problem #11 (OPEN): is every odd `n > 1` the sum of a squarefree number and
+  a power of 2?  The gallery parent `Erdos11Problem` sets up `IsSquarefree`,
+  `IsPowerOfTwo`, `IsSquarefreePlusPow2` and checks `3, 5, 7, 9` by hand — but it no
+  longer builds on the current Mathlib.  This file re-establishes that content
+  self-contained and adds the key reusable tool: a **bounded, decidable
+  characterization** of the representation.
+
+  * `isSquarefreePlusPow2_iff` — `IsSquarefreePlusPow2 n ↔ ∃ k ≤ n, 2^k ≤ n ∧
+    Squarefree (n − 2^k)`: a bounded characterization (the power of two `2^k` must
+    satisfy `k < 2^k ≤ n`), reducing the unbounded existential to a finite search.
+  * `squarefreePlusPow2_of_witness` — the easy construction direction (a witnessing
+    `k` with `2^k ≤ n` and `n − 2^k` squarefree gives the representation).
+  * `three_works … seventeen_works` — odd `3, 5, 7, 9, 11, 13, 15, 17` as squarefree
+    + power of two, with explicit `squarefree_one` / `Nat.Prime.squarefree` witnesses.
+
+  All results are fully machine-checked (0 axioms, 0 sorries).  A kernel `decide`
+  over a whole range is *not* available — the `Squarefree` decidability instance
+  routes through `Nat.minSqFac`, which the kernel does not reduce — so the worked
+  examples use explicit witnesses.
+
+  Reference: Hercher (2024); Granville–Soundararajan (1998); https://erdosproblems.com/11.
+-/
+
+import Mathlib
+
+namespace Erdos11WIP01
+
+open Finset
+
+/-- `n` is squarefree (re-declared self-contained: the parent `Erdos11Problem`
+    no longer builds on the current Mathlib). -/
+def IsSquarefree (n : ℕ) : Prop := Squarefree n
+
+/-- `n` is a power of two. -/
+def IsPowerOfTwo (n : ℕ) : Prop := ∃ k : ℕ, n = 2 ^ k
+
+/-- `n` is the sum of a squarefree number and a power of two. -/
+def IsSquarefreePlusPow2 (n : ℕ) : Prop :=
+  ∃ (s p : ℕ), IsSquarefree s ∧ IsPowerOfTwo p ∧ n = s + p
+
+/-- **Easy construction direction.**  A witnessing exponent `k` with `2^k ≤ n` and
+    `n − 2^k` squarefree yields the representation `n = (n − 2^k) + 2^k`. -/
+theorem squarefreePlusPow2_of_witness {n k : ℕ} (hle : 2 ^ k ≤ n)
+    (hsf : Squarefree (n - 2 ^ k)) : IsSquarefreePlusPow2 n :=
+  ⟨n - 2 ^ k, 2 ^ k, hsf, ⟨k, rfl⟩, by omega⟩
+
+/-- **Decidable characterization.**  `n` is squarefree + a power of two iff some
+    `k ≤ n` has `2^k ≤ n` and `n − 2^k` squarefree.  The bound `k ≤ n` comes from
+    `k < 2^k ≤ n`, making the existential a finite (decidable) search. -/
+theorem isSquarefreePlusPow2_iff (n : ℕ) :
+    IsSquarefreePlusPow2 n ↔
+      ∃ k ∈ Finset.range (n + 1), 2 ^ k ≤ n ∧ Squarefree (n - 2 ^ k) := by
+  constructor
+  · rintro ⟨s, p, hs, ⟨k, rfl⟩, rfl⟩
+    have hle : 2 ^ k ≤ s + 2 ^ k := Nat.le_add_left _ _
+    have hk : k < 2 ^ k := Nat.lt_two_pow_self
+    refine ⟨k, Finset.mem_range.mpr (by omega), hle, ?_⟩
+    rwa [Nat.add_sub_cancel]
+  · rintro ⟨k, _, hle, hsf⟩
+    exact squarefreePlusPow2_of_witness hle hsf
+
+/- ## Worked examples (recovered self-contained — the parent no longer builds)
+
+   Small odd numbers as squarefree + power of two, with explicit squarefree
+   witnesses (`squarefree_one` and `Nat.Prime.squarefree`).  A kernel `decide`
+   over a whole range is *not* available: the `Squarefree` decidability instance
+   routes through `Nat.minSqFac`, which the kernel cannot reduce. -/
+
+theorem three_works : IsSquarefreePlusPow2 3 :=
+  ⟨1, 2, squarefree_one, ⟨1, rfl⟩, rfl⟩
+
+theorem five_works : IsSquarefreePlusPow2 5 :=
+  ⟨1, 4, squarefree_one, ⟨2, rfl⟩, rfl⟩
+
+theorem seven_works : IsSquarefreePlusPow2 7 :=
+  ⟨5, 2, (by norm_num : Nat.Prime 5).squarefree, ⟨1, rfl⟩, rfl⟩
+
+theorem nine_works : IsSquarefreePlusPow2 9 :=
+  ⟨1, 8, squarefree_one, ⟨3, rfl⟩, rfl⟩
+
+theorem eleven_works : IsSquarefreePlusPow2 11 :=
+  ⟨3, 8, (by norm_num : Nat.Prime 3).squarefree, ⟨3, rfl⟩, rfl⟩
+
+theorem thirteen_works : IsSquarefreePlusPow2 13 :=
+  ⟨5, 8, (by norm_num : Nat.Prime 5).squarefree, ⟨3, rfl⟩, rfl⟩
+
+theorem fifteen_works : IsSquarefreePlusPow2 15 :=
+  ⟨7, 8, (by norm_num : Nat.Prime 7).squarefree, ⟨3, rfl⟩, rfl⟩
+
+theorem seventeen_works : IsSquarefreePlusPow2 17 :=
+  ⟨1, 16, squarefree_one, ⟨4, rfl⟩, rfl⟩
+
+end Erdos11WIP01

--- a/src/data/research/problems/erdos-11-wip-01.json
+++ b/src/data/research/problems/erdos-11-wip-01.json
@@ -1,0 +1,64 @@
+{
+  "slug": "erdos-11-wip-01",
+  "title": "Decidable characterization of squarefree + power of 2 (Erdős #11)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "IsSquarefreePlusPow2 n ↔ ∃ k ∈ range (n+1), 2^k ≤ n ∧ Squarefree (n - 2^k); plus odd 3..17 verified.",
+    "plain": "Is every odd n > 1 the sum of a squarefree number and a power of 2? (Erdős #11, OPEN). A bounded decidable characterization plus verified small odd cases.",
+    "whyMatters": [
+      "The unbounded existential ∃ s p (s squarefree, p power of 2, n = s+p) becomes a finite search over k < 2^k ≤ n — the form a verification (Hercher 2024 up to 2^50) needs.",
+      "The gallery parent Erdos11Problem no longer builds on the current Mathlib; this re-establishes its content self-contained."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "COMPLETED",
+    "since": "2026-06-22T00:00:00-07:00",
+    "iteration": 1,
+    "focus": "Decidable characterization + construction lemma + verified odd 3..17 (self-contained).",
+    "blockers": [],
+    "nextAction": "None for the groundwork. The conjecture itself (all odd n) is OPEN; a large-range verification would need native_decide (Squarefree's kernel decide is stuck on minSqFac).",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE (groundwork). Erdős #11 (OPEN): every odd n>1 = squarefree + power of 2. The gallery parent Erdos11Problem no longer builds on the current Mathlib (recursion-depth/synthesis/docstring-parse failures). This entry re-establishes the content self-contained and adds the reusable tool: isSquarefreePlusPow2_iff (the unbounded existential ⟺ a bounded search ∃ k ∈ range(n+1), 2^k ≤ n ∧ Squarefree (n-2^k), the bound from k < 2^k ≤ n via Nat.lt_two_pow_self), squarefreePlusPow2_of_witness (easy construction), and odd 3,5,7,9,11,13,15,17 verified with explicit squarefree witnesses. Erdos11WIP01.lean, 3 defs + 10 theorems, 0 axioms, 0 sorries, no native_decide.",
+    "builtItems": [
+      "Erdos11WIP01.lean: 3 defs (IsSquarefree/IsPowerOfTwo/IsSquarefreePlusPow2) + 10 theorems, 0 axioms (propext/Classical.choice/Quot.sound), 0 sorries. Self-contained (parent bit-rotted).",
+      "isSquarefreePlusPow2_iff: bounded decidable characterization (forward uses Nat.le_add_left + Nat.lt_two_pow_self for k ≤ n; backward is the construction).",
+      "squarefreePlusPow2_of_witness: ⟨n-2^k, 2^k, hsf, ⟨k,rfl⟩, by omega⟩.",
+      "three/five/seven/nine/eleven/thirteen/fifteen/seventeen_works: odd cases via squarefree_one and (by norm_num : Nat.Prime p).squarefree."
+    ],
+    "insights": [
+      "The representation predicate's existential is bounded: a power of two 2^k in n = s + 2^k satisfies 2^k ≤ n (Nat.le_add_left) and k < 2^k ≤ n (Nat.lt_two_pow_self), so the search is finite — the characterization isSquarefreePlusPow2_iff reduces it to k ∈ range(n+1).",
+      "KERNEL `decide` over a range FAILS for Squarefree: the DecidablePred instance routes through Nat.minSqFac, which the kernel does not reduce (gets stuck at `match m.minSqFac, none`). A whole-range verification would require native_decide (→ Lean.ofReduceBool axiom, axiomatized). Hence explicit witnesses for the examples.",
+      "Explicit squarefree witnesses: squarefree_one (Squarefree 1) and Nat.Prime.squarefree (norm_num proves Nat.Prime p, then .squarefree) — 0-axiom, no decide.",
+      "The parent Erdos11Problem.lean is bit-rotted (max recursion in Wieferich decides, synthesis failure, docstring parse errors), so import is impossible → self-contained re-declaration."
+    ],
+    "mathlibGaps": [
+      "Squarefree's kernel decidability is impractical (minSqFac non-reducing); large-range verification of Erdős #11 needs native_decide (axiomatized) or a manually-reducing squarefree check."
+    ],
+    "nextSteps": [
+      "A manually-reducible squarefree predicate (∀ d ≤ √n, ¬ d²∣n with Nat.decidable_dvd) + an iff to Squarefree, enabling a kernel-`decide` range verification that stays 0-axiom.",
+      "native_decide verification of all odd n < 2^k for a chosen k (explicitly axiomatized, status axiomatized).",
+      "Structural necessary conditions and the Granville–Soundararajan link to non-Wieferich primes."
+    ]
+  },
+  "tags": [
+    "extension",
+    "number-theory"
+  ],
+  "relatedProofs": [
+    "erdos-11"
+  ]
+}


### PR DESCRIPTION
## Erdős #11 — WIP-01 (squarefree + power of 2)

Erdős #11 (OPEN): is every odd `n > 1` the sum of a squarefree number and a power of 2? The gallery parent `Erdos11Problem` set this up and checked `3, 5, 7, 9` by hand — but it **no longer builds** on the current Mathlib (recursion-depth / synthesis / docstring-parse failures). This PR re-establishes the content self-contained and adds the key reusable tool.

### Theorems

- **`isSquarefreePlusPow2_iff`** — `IsSquarefreePlusPow2 n ↔ ∃ k ∈ range (n+1), 2^k ≤ n ∧ Squarefree (n − 2^k)`: the unbounded existential becomes a **finite, bounded search** (the bound `k < 2^k ≤ n` from `Nat.lt_two_pow_self`).
- `squarefreePlusPow2_of_witness` — the easy construction direction.
- `three_works … seventeen_works` — odd `3, 5, 7, 9, 11, 13, 15, 17` as squarefree + power of two, with explicit `squarefree_one` / `Nat.Prime.squarefree` witnesses.

A kernel `decide` over a whole range is **not** available — `Squarefree`'s decidability instance routes through `Nat.minSqFac`, which the kernel does not reduce — so the examples use explicit witnesses (keeping the file 0-axiom).

### Verification

- `Erdos11WIP01.lean`: 3 defs + 10 theorems, **0 axioms, 0 sorries**, no `native_decide`.
- `#print axioms` on the headline theorems: `propext, Classical.choice, Quot.sound` only.
- Builds via `./proofs/scripts/docker-build.sh Proofs.Erdos11WIP01` (7743 jobs, success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)