### PR TITLE
Enrich Power-Mean Inequality (Mₚ ≤ M_q for 0 < p ≤ q)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-overview",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Power Means vs. Maclaurin Means: Answering and Correcting the Open Question",
+    "content": "The module docstring answers the parent entry's open question and fixes a directional error in it. The parent asked whether the Maclaurin chain generalizes to power means with 'Mₚ ≥ M_q for p ≤ q'. The honest answer is yes, there is a clean power-mean generalization — but its correct direction is the opposite: power means are monotone INCREASING in the exponent, so Mₚ ≤ M_q for 0 < p ≤ q. The decreasing ordering the question had in mind belongs to the Maclaurin means Mₖ = (eₖ/C(n,k))^{1/k}, indexed by symmetric-function degree k, a genuinely different family. Both interpolate AM–GM but only share the two endpoints.",
+    "mathContext": "Power means: $M_p(x) = \\left(\\tfrac1n\\sum_i x_i^p\\right)^{1/p}$, increasing in $p$. Maclaurin means: $M_k = \\left(e_k/\\binom{n}{k}\\right)^{1/k}$, decreasing in $k$. Here $e_k$ is the $k$-th elementary symmetric polynomial.",
+    "significance": "key",
+    "relatedConcepts": ["power means", "Maclaurin means", "generalized mean inequality", "AM-GM inequality", "Hölder means"],
+    "prerequisites": ["arithmetic and geometric means", "elementary symmetric polynomials"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-mathlib-todo",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 36, "endLine": 56 },
+    "type": "context",
+    "title": "Filling a Mathlib TODO via the Jensen Convexity Engine",
+    "content": "Mathlib.Analysis.MeanInequalities lists, verbatim in its TODO section, 'generalized mean inequality with any p ≤ q, including negative numbers'. So unweighted power-mean monotonicity is not presently a Mathlib theorem. What Mathlib DOES provide is the convexity engine NNReal.rpow_arith_mean_le_arith_mean_rpow — Jensen for t ↦ tʳ with r ≥ 1 and arbitrary weights summing to 1. This file specializes that engine to uniform weights 1/n, supplying the positive-exponent case (0 < p ≤ q) and leaving the negative-exponent case as future work, mirroring Mathlib's own TODO.",
+    "mathContext": "Jensen for the convex $t \\mapsto t^r$, $r \\ge 1$, weights $w_i \\ge 0$ with $\\sum_i w_i = 1$: $\\left(\\sum_i w_i z_i\\right)^r \\le \\sum_i w_i z_i^r$.",
+    "significance": "context",
+    "relatedConcepts": ["Jensen's inequality", "convexity", "Mathlib TODO", "weighted means"],
+    "prerequisites": ["convex functions", "weighted averages"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-def",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 68, "endLine": 72 },
+    "type": "definition",
+    "title": "The Power Mean with Weights Distributed Inside the Sum",
+    "content": "powerMean s x p is defined as (Σᵢ∈ₛ (|s|)⁻¹·(x i)^p)^{1/p}. Crucially, the uniform weight (|s|)⁻¹ is distributed across the sum rather than pulled out front as a single scalar factor. This is a deliberate choice: it puts the body in exactly the Σ wᵢ zᵢ shape that NNReal.rpow_arith_mean_le_arith_mean_rpow expects, so no algebraic re-massaging of the weight is needed before Jensen applies. Values live in ℝ≥0 (NNReal), so real powers via rpow require no separate nonnegativity hypotheses on x.",
+    "mathContext": "$M_p(x) = \\left(\\sum_{i\\in s} |s|^{-1}\\,(x_i)^p\\right)^{1/p}$, with explicit weights $w_i = |s|^{-1}$ satisfying $\\sum_{i\\in s} w_i = 1$ on a nonempty $s$.",
+    "significance": "key",
+    "relatedConcepts": ["NNReal.rpow", "uniform weights", "generalized mean"],
+    "prerequisites": ["real powers of nonnegative reals", "finite sums over Finset"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-weights-sum-one",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 85, "endLine": 96 },
+    "type": "tactic",
+    "title": "Setup: Nonzero Cardinality, q > 0, q/p ≥ 1, and Weights Summing to One",
+    "content": "Before invoking Jensen the proof discharges its hypotheses. It abbreviates n = |s| and shows n ≠ 0 from s.Nonempty (Finset.card_pos). From 0 < p ≤ q it derives 0 < q and the key exponent bound 1 ≤ q/p via one_le_div. The decisive setup step is hw: the uniform weights sum to one, proved by Finset.sum_const turning Σ n⁻¹ into |s|•n⁻¹, then nsmul_eq_mul and mul_inv_cancel₀ collapsing |s|·|s|⁻¹ = 1. This is the normalization Jensen requires.",
+    "mathContext": "$\\sum_{i\\in s} |s|^{-1} = |s|\\cdot|s|^{-1} = 1$ since $|s| \\ne 0$. The exponent $r = q/p \\ge 1$ exactly when $p \\le q$ with $p > 0$ (`one_le_div`).",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_const", "mul_inv_cancel₀", "normalization", "convex combination"],
+    "prerequisites": ["Finset cardinality", "division and inverses in NNReal"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-jensen-rhs",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 97, "endLine": 104 },
+    "type": "insight",
+    "title": "Applying Jensen and Simplifying the Right-Hand Exponent",
+    "content": "The line `key := NNReal.rpow_arith_mean_le_arith_mean_rpow s (fun _ => n⁻¹) (fun i => (x i)^p) hw hr` is the heart of the proof: Jensen for t ↦ t^{q/p} applied to zᵢ = (x i)^p with uniform weights. It produces (Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ (xᵢᵖ)^{q/p}. The right side is then simplified term-by-term via the power identity (xᵢᵖ)^{q/p} = xᵢ^q: NNReal.rpow_mul converts the iterated power to xᵢ^{p·(q/p)}, and field_simp proves the exponent p·(q/p) = q. After rewriting, key reads (Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ xᵢ^q.",
+    "mathContext": "$\\left(\\sum_i w_i x_i^p\\right)^{q/p} \\le \\sum_i w_i (x_i^p)^{q/p} = \\sum_i w_i x_i^q$, using $(x_i^p)^{q/p} = x_i^{p\\cdot(q/p)} = x_i^q$.",
+    "significance": "key",
+    "relatedConcepts": ["Jensen's inequality", "NNReal.rpow_mul", "exponent arithmetic", "convexity"],
+    "prerequisites": ["laws of exponents", "Jensen's inequality"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-raise-1q",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 105, "endLine": 110 },
+    "type": "insight",
+    "title": "Raising to 1/q and Collapsing the Iterated Exponent",
+    "content": "With key now reading (Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ xᵢ^q, the final move raises both sides to the power 1/q. NNReal.rpow_le_rpow preserves the inequality because 1/q ≥ 0 (positivity from q > 0). On the left, NNReal.rpow_mul merges the powers to (Σ wᵢ xᵢᵖ)^{(q/p)·(1/q)}, and hexp: (q/p)·(1/q) = 1/p (by field_simp) collapses this to (Σ wᵢ xᵢᵖ)^{1/p} = Mₚ. The right side is already (Σ wᵢ xᵢ^q)^{1/q} = M_q, so rwa closes the goal Mₚ ≤ M_q.",
+    "mathContext": "$\\left(\\left(\\sum_i w_i x_i^p\\right)^{q/p}\\right)^{1/q} = \\left(\\sum_i w_i x_i^p\\right)^{(q/p)(1/q)} = \\left(\\sum_i w_i x_i^p\\right)^{1/p} = M_p$, with $\\tfrac{q}{p}\\cdot\\tfrac1q = \\tfrac1p$.",
+    "significance": "key",
+    "relatedConcepts": ["NNReal.rpow_le_rpow", "monotonicity of powers", "exponent collapse"],
+    "prerequisites": ["monotonicity of x ↦ x^z", "laws of exponents"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-rms-corollary",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 112, "endLine": 117 },
+    "type": "theorem",
+    "title": "Corollary: Arithmetic Mean ≤ Root-Mean-Square (p=1, q=2)",
+    "content": "arithMean_le_quadraticMean is the p=1, q=2 instance: the arithmetic mean never exceeds the quadratic mean (RMS). It is a one-line specialization of powerMean_le_powerMean, with the hypotheses 0 < 1 and 1 ≤ 2 discharged by norm_num. This single inequality is classically equivalent to the Cauchy–Schwarz inequality and to the nonnegativity of variance, Var(X) = E[X²] − E[X]² ≥ 0 — it is the most-used corner of the whole power-mean family.",
+    "mathContext": "$M_1 = \\tfrac1n\\sum_i x_i \\le \\left(\\tfrac1n\\sum_i x_i^2\\right)^{1/2} = M_2$. Equivalent to $\\left(\\sum x_i\\right)^2 \\le n\\sum x_i^2$ (Cauchy–Schwarz) and to $\\mathrm{Var} \\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["root-mean-square", "Cauchy-Schwarz inequality", "variance", "quadratic mean"],
+    "prerequisites": ["arithmetic mean", "quadratic mean"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-oq03-mono-corollary",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
+    "range": { "startLine": 119, "endLine": 124 },
+    "type": "theorem",
+    "title": "Corollary: Monotonicity-Style Restatement",
+    "content": "powerMean_mono restates the main inequality with both 0 < p and 0 < q hypotheses listed explicitly (the second is logically redundant given 0 < p ≤ q). The point is API ergonomics: a downstream consumer reasoning about monotonicity of p ↦ Mₚ over the positive reals will naturally phrase the hypotheses this way. The body simply delegates to powerMean_le_powerMean, discarding the redundant _hq.",
+    "mathContext": "For $0 < p \\le q$, the map $p \\mapsto M_p(x)$ is monotone nondecreasing on $(0,\\infty)$. The redundant $0 < q$ follows from $0 < p \\le q$.",
+    "significance": "technical",
+    "relatedConcepts": ["monotonicity", "API design", "power means"],
+    "prerequisites": ["monotone functions"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/meta.json
@@ -15,7 +15,18 @@
       "Mathlib"
     ]
   },
-  "overview": "The power means Mₚ(x) = ((1/n)·Σᵢ xᵢᵖ)^{1/p} are monotone increasing in the exponent: for 0 < p ≤ q one has Mₚ ≤ M_q. The classical instance M₁ ≤ M₂ is the arithmetic-mean ≤ root-mean-square inequality. This file establishes the general positive-exponent case by specializing Mathlib's weighted Jensen inequality NNReal.rpow_arith_mean_le_arith_mean_rpow (convexity of t ↦ t^{q/p} for q/p ≥ 1) to the uniform weights 1/n. With r = q/p and zᵢ = xᵢᵖ, Jensen gives (Σ wᵢ xᵢᵖ)^{q/p} ≤ Σ wᵢ xᵢ^q; raising both sides to 1/q (monotone since q > 0) yields Mₚ ≤ M_q. The result is exactly the entry 'generalized mean inequality with any p ≤ q' that Mathlib.Analysis.MeanInequalities records in its TODO section, so it is not currently available upstream as a theorem. The negative-exponent case (p < 0, requiring xᵢ > 0) remains future work, mirroring Mathlib's own TODO.",
+  "overview": {
+    "historicalContext": "The power means (also called Hölder or generalized means) $M_p(x) = \\left(\\tfrac{1}{n}\\sum_i x_i^p\\right)^{1/p}$ form a one-parameter family interpolating the classical means: $M_{-1}$ is the harmonic mean, $M_0$ (the limit) is the geometric mean, $M_1$ is the arithmetic mean, and $M_2$ is the quadratic mean / root-mean-square. Their monotonicity in the exponent — $M_p \\le M_q$ whenever $p \\le q$ — was systematized by Hardy, Littlewood, and Pólya in *Inequalities* (1934, §2.9), building on the 19th-century work of Otto Hölder and the convexity theory of Jensen (1906). The single inequality $M_1 \\le M_2$, equivalent to the Cauchy–Schwarz inequality, predates the general statement and underlies the variance identity $\\mathrm{Var}(X) = \\mathbb{E}[X^2] - \\mathbb{E}[X]^2 \\ge 0$ in probability. The family unifies the AM–GM and RMS–AM inequalities under a single convexity principle.",
+    "problemStatement": "For a nonempty finite index set $s$, nonnegative reals $x : \\iota \\to \\mathbb{R}_{\\ge 0}$, and exponents $0 < p \\le q$, the unweighted power means satisfy $$M_p(x) = \\left(\\tfrac{1}{|s|}\\sum_{i \\in s} x_i^p\\right)^{1/p} \\;\\le\\; \\left(\\tfrac{1}{|s|}\\sum_{i \\in s} x_i^q\\right)^{1/q} = M_q(x).$$ This is exactly the entry 'generalized mean inequality with any $p \\le q$' that `Mathlib.Analysis.MeanInequalities` records, verbatim, in its `TODO` section — so it is not currently available upstream as a theorem.",
+    "proofStrategy": "The proof specializes Mathlib's weighted Jensen inequality `NNReal.rpow_arith_mean_le_arith_mean_rpow` — convexity of $t \\mapsto t^r$ for $r \\ge 1$ — to uniform weights $w_i = 1/|s|$. Setting $r = q/p \\ge 1$ and $z_i = x_i^p$, Jensen gives $\\left(\\sum_i w_i x_i^p\\right)^{q/p} \\le \\sum_i w_i (x_i^p)^{q/p} = \\sum_i w_i x_i^q$, using the power identity $(x_i^p)^{q/p} = x_i^q$. Raising both sides to the power $1/q$ (monotone since $q > 0$) and collapsing the iterated exponent $(q/p)\\cdot(1/q) = 1/p$ yields $M_p \\le M_q$. Working over $\\mathbb{R}_{\\ge 0}$ (NNReal) sidesteps positivity side-conditions on the bases.",
+    "keyInsights": [
+      "Power-mean monotonicity is a *convexity* statement in disguise: $M_p \\le M_q$ for $0 < p \\le q$ is precisely Jensen's inequality applied to the convex map $t \\mapsto t^{q/p}$ with $q/p \\ge 1$, evaluated at the data raised to the $p$-th power.",
+      "The choice of NNReal ($\\mathbb{R}_{\\ge 0}$) as the value type is a deliberate engineering decision: it lets `rpow` and the Jensen lemma apply without carrying explicit $x_i > 0$ hypotheses, since nonnegativity is built into the type.",
+      "The exponent bookkeeping is the crux of the formalization — the identities $(x^p)^{q/p} = x^q$ and $(q/p)\\cdot(1/q) = 1/p$ (both discharged by `field_simp` after `rpow_mul`) are what turn the raw Jensen output into the two power means.",
+      "The open question this entry answers states the inequality in the *wrong direction* ($M_p \\ge M_q$): power means increase in the exponent. The decreasing family the parent had in mind is the degree-indexed *Maclaurin means*, a genuinely different object that merely shares the AM–GM endpoints.",
+      "Only the positive-exponent regime is covered; the negative-exponent case ($p < 0$, which forces $x_i > 0$ and inverts several monotonicity steps) remains, as in Mathlib itself, future work."
+    ]
+  },
   "mainTheorems": [
     {
       "name": "powerMean_le_powerMean",
@@ -36,7 +47,56 @@
       "leanType": "(s : Finset ι) (x : ι → ℝ≥0) (hs : s.Nonempty) {p q : ℝ} (hp : 0 < p) (hq : 0 < q) (hpq : p ≤ q) → powerMean s x p ≤ powerMean s x q"
     }
   ],
-  "sections": [],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: Question, Answer, and Mechanism",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Restates the parent open question (generalize Maclaurin to power means), answers it, and corrects the stated direction: power means increase in the exponent, so the correct form is Mₚ ≤ M_q for 0 < p ≤ q, not Mₚ ≥ M_q. Distinguishes power means from the degree-indexed Maclaurin means, notes that Mathlib lists this as a TODO, and sketches the Jensen-with-uniform-weights mechanism.",
+      "mathContext": "The two families coincide only at the AM–GM endpoints. Power means $M_p$ are indexed by a real exponent and increase in $p$; Maclaurin means $M_k = (e_k/\\binom{n}{k})^{1/k}$ are indexed by symmetric-function degree $k$ and decrease in $k$."
+    },
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 57,
+      "endLine": 66,
+      "summary": "Imports all of Mathlib, opens the Finset and NNReal namespaces and the BigOperators scope, declares the namespace, enters a noncomputable section (rpow is noncomputable), and introduces the implicit index type ι.",
+      "mathContext": "Working in $\\mathbb{R}_{\\ge 0}$ (`NNReal`) means real powers via `NNReal.rpow` are noncomputable, hence the `noncomputable section`."
+    },
+    {
+      "id": "definition",
+      "title": "powerMean: The Unweighted Power Mean",
+      "startLine": 68,
+      "endLine": 72,
+      "summary": "Defines Mₚ = (Σᵢ (|s|)⁻¹·(x i)^p)^{1/p} over a finite set s, distributing the uniform weight (|s|)⁻¹ across the sum rather than factoring it out — so the body is already in the weighted form that Jensen's inequality consumes.",
+      "mathContext": "$M_p(x) = \\left(\\sum_{i \\in s} |s|^{-1} (x_i)^p\\right)^{1/p}$. Distributing $|s|^{-1}$ inside the sum makes the weights $w_i = |s|^{-1}$ explicit, matching `rpow_arith_mean_le_arith_mean_rpow`'s signature."
+    },
+    {
+      "id": "main-theorem",
+      "title": "powerMean_le_powerMean: The Power-Mean Inequality",
+      "startLine": 74,
+      "endLine": 110,
+      "summary": "The main result: Mₚ ≤ M_q for 0 < p ≤ q. After unfolding, it establishes |s|⁻¹ ≠ 0, the derived bounds q > 0 and q/p ≥ 1, and that the uniform weights sum to one. It then invokes Jensen (`NNReal.rpow_arith_mean_le_arith_mean_rpow`), rewrites the right side via (xᵢ^p)^{q/p} = xᵢ^q, raises both sides to 1/q via `NNReal.rpow_le_rpow`, and collapses (q/p)·(1/q) = 1/p.",
+      "mathContext": "Jensen: $\\left(\\sum_i w_i x_i^p\\right)^{q/p} \\le \\sum_i w_i x_i^q$. Raising to $1/q$: $\\left(\\sum_i w_i x_i^p\\right)^{1/p} \\le \\left(\\sum_i w_i x_i^q\\right)^{1/q}$, i.e. $M_p \\le M_q$. Key identities $(x^p)^{q/p}=x^q$ and $\\tfrac{q}{p}\\cdot\\tfrac1q=\\tfrac1p$ are closed by `field_simp`."
+    },
+    {
+      "id": "corollary-rms",
+      "title": "arithMean_le_quadraticMean: AM ≤ RMS",
+      "startLine": 112,
+      "endLine": 117,
+      "summary": "The p=1, q=2 special case: the arithmetic mean is at most the quadratic mean (root-mean-square). A one-line specialization of the main theorem with the exponent hypotheses discharged by norm_num.",
+      "mathContext": "$M_1 = \\tfrac1n\\sum x_i \\le \\left(\\tfrac1n\\sum x_i^2\\right)^{1/2} = M_2$. Equivalent to Cauchy–Schwarz and to $\\mathrm{Var}(X) \\ge 0$."
+    },
+    {
+      "id": "corollary-mono",
+      "title": "powerMean_mono: Monotonicity-Style Restatement",
+      "startLine": 119,
+      "endLine": 124,
+      "summary": "Restates the main inequality with both 0 < p and 0 < q hypotheses bundled (the second is redundant given p ≤ q) to provide a monotonicity-style API surface; delegates directly to powerMean_le_powerMean.",
+      "mathContext": "Provides a signature matching how a `Monotone`-style consumer would phrase the hypotheses; the extra $0 < q$ is implied by $0 < p \\le q$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-22",
@@ -124,6 +184,15 @@
       "description": "Base AM-GM inequality; the power means interpolate between AM-GM endpoints, and M₁ ≤ M₂ recovers the AM ≤ RMS instance."
     }
   ],
-  "conclusion": "The unweighted power-mean inequality Mₚ ≤ M_q holds for all 0 < p ≤ q, fully verified with no axioms. This fills the positive-exponent case of an inequality Mathlib currently lists only as a TODO, and clarifies that the correct power-mean ordering is increasing in the exponent — distinct from the degree-decreasing Maclaurin means of the parent entry.",
+  "conclusion": {
+    "summary": "The unweighted power-mean inequality Mₚ ≤ M_q holds for all 0 < p ≤ q, fully verified with 0 axioms and 0 sorries. The proof reduces the statement to a single application of Mathlib's weighted Jensen inequality at uniform weights, plus careful exponent bookkeeping. The p=1, q=2 corollary recovers the classical AM ≤ RMS (root-mean-square) inequality.",
+    "implications": "This fills the positive-exponent case of the 'generalized mean inequality with any p ≤ q' that Mathlib's MeanInequalities module lists only as a TODO, making the result available as a reusable theorem rather than a documented gap. It also corrects a directional error in the parent open question: power means increase in the exponent (Mₚ ≤ M_q), which is the opposite ordering from the degree-decreasing Maclaurin means — clarifying that these are two distinct families that merely share the AM–GM endpoints. The NNReal-valued formulation gives a clean, hypothesis-light API for downstream use.",
+    "openQuestions": [
+      "The negative-exponent case (p ≤ q with p < 0, which requires xᵢ > 0 and includes the harmonic mean at p = -1) remains open here, exactly as in Mathlib's own TODO. Can the same Jensen specialization be adapted, or does the sign change demand a separate argument?",
+      "Can this unweighted result be generalized to arbitrary (non-uniform) weights summing to one, recovering the full weighted power-mean inequality, and could that generalization be the form ultimately upstreamed to Mathlib?",
+      "What is the equality case? The inequality is strict unless all xᵢ are equal (or p = q); formalizing the equality characterization would complete the analytic picture.",
+      "Does the limiting behavior connect cleanly to the geometric mean as p → 0⁺ (so that AM–GM appears as the p → 0 boundary of this monotone family) within the gallery's existing AM–GM formalizations?"
+    ]
+  },
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-03-oq-03-oq-03` (quality 0, passes 0).

## Changes
- **overview**: converted from a flat string to a structured `ProofOverview` — added a real `historicalContext` (Hölder/Hardy–Littlewood–Pólya lineage, the harmonic→geometric→arithmetic→quadratic mean chain), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **conclusion**: converted from a flat string to a structured `ProofConclusion` — `summary`, `implications`, and 4 substantive `openQuestions` (negative-exponent case, weighted generalization, equality characterization, p→0 GM limit).
- **sections**: filled the previously-empty array with 6 sections covering the full 128-line Lean file (docstring, imports, `powerMean` definition, main theorem, two corollaries), each with `mathContext`.
- **annotations.json**: created (the entry had none) with 8 annotations, every one carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Schema fix
The `overview` and `conclusion` fields were stored as plain strings, which do not match the `ProofOverview`/`ProofConclusion` interfaces the loader expects — now corrected to the structured form used across the gallery.

## Axiom integrity
Verified against the Lean source: 0 `axiom` declarations, 0 sorries, no assumption-carrying structures, no `native_decide`. `status: verified` / `badge: verified` / `axiomCount: 0` are accurate.

`pnpm build` passes.