### PR TITLE
research(pentagonal-number-theorem-oq-01): explicit discriminant roots (6k∓1)² + ±-pairing sum g(k)+g(-k)=3k²

### DIFF
--- a/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01.lean
@@ -127,6 +127,40 @@ theorem isGenPent_iff_isSquare (m : ℤ) :
         rw [hs1] at hs; linear_combination hs
       exact mul_left_cancel₀ (by norm_num) h12
 
+/-! ## Part 2b: Explicit discriminant roots and the ±-pairing
+
+The forward half of the recognition criterion is the algebraic identity
+`24·g(k)+1 = (6k-1)²`.  Where `isGenPent_iff_isSquare` only asserts that *some*
+square equals the discriminant, an enumerator of pentagonal exponents actually
+needs the *explicit* root, so we record it (and its negative-index companion) as
+named witnesses.  The two roots `6k∓1` of the `±k` pair straddle `6k`
+symmetrically, and the values themselves satisfy `g(k)+g(-k) = 3k²` (their
+difference being `k`, by `genPent_neg`). -/
+
+/-- **Explicit discriminant root (positive index).**  `24·g(k)+1 = (6k-1)²` — the
+concrete square witnessing `IsGenPent (g k)` in the recognition criterion, with
+its root named explicitly rather than existentially. -/
+theorem disc_genPent (k : ℤ) : 24 * genPent k + 1 = (6 * k - 1) ^ 2 := by
+  linear_combination 12 * two_mul_genPent k
+
+/-- **Explicit discriminant root (negative index).**  `24·g(-k)+1 = (6k+1)²`; the
+two roots `6k-1` and `6k+1` of the `±k` pair straddle `6k`. -/
+theorem disc_genPent_neg (k : ℤ) : 24 * genPent (-k) + 1 = (6 * k + 1) ^ 2 := by
+  linear_combination 12 * two_mul_genPent (-k)
+
+/-- **The `±k` pairing sum.**  `g(k)+g(-k) = 3k²`: the two pentagonal shifts that
+appear together in Euler's recurrence sum to `3k²` (their difference is `k`, by
+`genPent_neg`), since `2(g(k)+g(-k)) = k(3k-1)+k(3k+1) = 6k²`. -/
+theorem genPent_add_neg (k : ℤ) : genPent k + genPent (-k) = 3 * k ^ 2 := by
+  have h : 2 * (genPent k + genPent (-k)) = 2 * (3 * k ^ 2) := by
+    linear_combination two_mul_genPent k + two_mul_genPent (-k)
+  exact mul_left_cancel₀ (by norm_num) h
+
+/-- Sanity check on the explicit root: `24·g(3)+1 = 17²` with `17 = 6·3-1`,
+strengthening `twelve_isGenPent` (Part 4) to exhibit the concrete square root. -/
+theorem disc_genPent_three : 24 * genPent 3 + 1 = 17 ^ 2 := by
+  rw [disc_genPent 3]; norm_num
+
 /-! ## Part 3: Structural facts -/
 
 /-- Generalized pentagonal numbers are nonnegative: `k(3k-1) ≥ 0` for all `k`. -/

--- a/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01/meta.json
@@ -13,9 +13,9 @@
       "PowerSeries.WithPiTopology"
     ],
     "namespace": "PentagonalNumberTheoremOQ01",
-    "lineCount": 530,
+    "lineCount": 564,
     "axiomCount": 0,
-    "theoremCount": 39,
+    "theoremCount": 43,
     "definitionCount": 6,
     "path": "Proofs/PentagonalNumberTheoremOQ01.lean",
     "sorries": 0
@@ -82,7 +82,9 @@
       "genPent_neg: the +/-k pairing g(-k) = g(k) + k of Euler's recurrence, relating the two pentagonal shifts g(k) and g(-k) that occur together at each level",
       "pentSeriesCoeff: an explicit construction of the right-hand side of Euler's identity — the coefficient [Xⁿ] of the lacunary series ∑_{k∈ℤ}(-1)ᵏ X^{g(k)}, made well-defined by genPent_injective (each exponent is hit by at most one index). pentSeriesCoeff_genPent gives the value (-1)ᵏ at g(k); pentSeriesCoeff_ne_zero_iff shows the support is exactly the generalized pentagonal numbers; pentSeriesCoeff_eq_zero_or bounds every coefficient to 0/±1; concrete [X⁰]=+1, [X¹]=-1 match the leading 1 and -X of ∏(1-Xⁿ). The pentagonal sign pentSign k = (-1)^|k| is recorded with its ±1-valuedness, nonvanishing, and pairing invariance pentSign(-k)=pentSign k.",
       "Both ends of Euler's identity machine-checked through Mathlib's 2025 Partition.GenFun (Weiyi Wang) under the Euler character pentChar i c = (if c = 1 then -1 else 0): genFun_pent_eq_tprod proves the PRODUCT side genFun pentChar = ∏_{i}(1 - X^{i+1}) (each inner tsum collapses to -(X^{i+1}) since the character is supported on multiplicity 1, via tsum_eq_single), and coeff_genFun_pent proves the COEFFICIENT side [Xⁿ] genFun pentChar = ∑_{p ∈ Nat.Partition.distincts n}(-1)^{p.parts.card} = p_even(n)-p_odd(n) (a partition with a repeated part contributes a 0 factor and drops out; a distinct-part partition contributes (-1)^{#parts}, via a Nodup/¬Nodup split over n.Partition and Finset.sum_filter_add_sum_filter_not). Together these reduce the entire remaining open core to the single Franklin-involution identity ∑_{p ∈ distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n).",
-      "The two ends joined with no genFun intermediary visible: coeff_tprod_pent composes the product side genFun_pent_eq_tprod with the coefficient side coeff_genFun_pent to state Euler's identity directly on Mathlib's power-series product — [Xⁿ] ∏'_{i}(1 - X^{i+1}) = ∑_{p ∈ Nat.Partition.distincts n}(-1)^{p.parts.card}. coeff_tprod_pent_eq_evenOdd_diff then splits that signed sum by the parity of the number of parts to read the coefficient as the literal difference p_even(n) - p_odd(n): [Xⁿ]∏(1-Xᵐ) = #{distinct-part partitions of n with an even number of parts} - #{those with an odd number}. This is the directly-citable form of Euler's product/partition identity, leaving only the Franklin involution ∑_{p∈distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n) as the open core."
+      "The two ends joined with no genFun intermediary visible: coeff_tprod_pent composes the product side genFun_pent_eq_tprod with the coefficient side coeff_genFun_pent to state Euler's identity directly on Mathlib's power-series product — [Xⁿ] ∏'_{i}(1 - X^{i+1}) = ∑_{p ∈ Nat.Partition.distincts n}(-1)^{p.parts.card}. coeff_tprod_pent_eq_evenOdd_diff then splits that signed sum by the parity of the number of parts to read the coefficient as the literal difference p_even(n) - p_odd(n): [Xⁿ]∏(1-Xᵐ) = #{distinct-part partitions of n with an even number of parts} - #{those with an odd number}. This is the directly-citable form of Euler's product/partition identity, leaving only the Franklin involution ∑_{p∈distincts n}(-1)^{p.parts.card} = pentSeriesCoeff(n) as the open core.",
+      "disc_genPent / disc_genPent_neg: explicit discriminant roots 24·g(±k)+1 = (6k∓1)², naming the concrete square in the recognition criterion (where isGenPent_iff_isSquare only asserts existence); the two roots 6k∓1 of the ±k pair straddle 6k symmetrically",
+      "genPent_add_neg: the ±-pairing sum g(k)+g(-k) = 3k² (complementing genPent_neg's difference g(-k)-g(k)=k), so the two pentagonal shifts in Euler's recurrence have sum 3k² and difference k"
     ],
     "dateAdded": "2026-06-18",
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

Strengthens the number-theoretic recognition-criterion theory of the **generalized pentagonal numbers** `g(k) = k(3k-1)/2` (exponents of Euler's lacunary series `∏(1-xⁿ)=∑(-1)ᵏx^{g(k)}`) with the **explicit discriminant roots** and the **±k pairing arithmetic**.

The existing headline `isGenPent_iff_isSquare` only asserts that *some* square equals `24m+1`. But an enumerator of pentagonal exponents in Euler's partition recurrence actually computes the *explicit* root. This PR names it:

| Theorem | Statement |
|---|---|
| `disc_genPent` | `24·g(k)+1 = (6k-1)²` (positive-index root) |
| `disc_genPent_neg` | `24·g(-k)+1 = (6k+1)²` (negative-index root) |
| `genPent_add_neg` | `g(k)+g(-k) = 3k²` (±-pairing sum) |
| `disc_genPent_three` | `24·g(3)+1 = 17²` sanity check, `17 = 6·3-1` |

The two roots `6k-1` and `6k+1` of the `±k` pair straddle `6k` symmetrically; combined with the existing `genPent_neg` (`g(-k)-g(k)=k`), the pair now has both an explicit **sum** (`3k²`) and **difference** (`k`).

## Method

All identities are division-free, derived from the exact doubling relation `two_mul_genPent : 2·g(k) = k(3k-1)` via `linear_combination` / `mul_left_cancel₀`. No new dependencies.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PentagonalNumberTheoremOQ01` — **green**
- 0 sorries, 0 `axiom` declarations, no `native_decide` → **verified**
- 4 new theorems (theoremCount 39→43, lineCount 530→564)

## Scope (honest)

This is structural arithmetic that **upgrades the headline criterion to constructive form**; it does **not** touch the genuinely hard open core (Franklin's sign-reversing involution `∑_{p∈distincts n}(-1)^{#parts} = pentSeriesCoeff(n)`), which remains a multi-file development absent from Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)