### PR TITLE
audit(abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01): badge verified→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17719,6 +17719,12 @@
       "lastAudited": "2026-06-23T03:16:14Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-23T03:29:24Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01 — "Non-Solvability of Sₐ is Upward Closed Under Injections"
**Severity**: MEDIUM (Mathlib wrapper presented with `verified` badge)

## Finding

The proof's structural engine `perm_not_solvable_of_embedding` is the literal contrapositive of the parent's `perm_solvable_of_embedding`, which is a one-liner over Mathlib's `solvable_of_solvable_injective` and `Equiv.Perm.viaEmbeddingHom_injective`. The remaining theorems (`perm_not_solvable_mono`, `alternating_not_solvable_mono`, the up-set packaging, partition, boundary) are `omega` / `Fintype.card_fin` corollaries layered on that bridge plus the parent/grandparent classification.

This is **Tier B** (formalized using a Mathlib theorem), matching narrative failure mode #5 ("0 sorries with hidden imports"): technically sorry-free and axiom-free, but the core result is obtained via a Mathlib call.

This mirrors the already-merged badge fixes on the parent (`…-oq-01-oq-01`, #27689) and ancestors.

## Fix

- `badge`: `verified` → `mathlib`

No other change. The proof remains 0-axiom, 0-sorry, `native_decide`-free and kernel-checked, so `status` stays `verified`. The Mathlib dependency was already disclosed in `assumptions` and `mathlibDependencies`, and `originalContributions` already scopes only the embedding/packaging work.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)