### PR TITLE
Enrich Neusis-Constructible Degrees (3-smooth number criterion)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-angle-tri-oq04-oq01-overview",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 3, "endLine": 56 },
+    "type": "concept",
+    "title": "From Gleason's Degree Condition to a 3-Smoothness Test",
+    "content": "The docstring frames the whole development. By Gleason's theorem (1988), a real is neusis-constructible (constructible with a marked ruler — the tool that trisects angles and duplicates the cube) iff its degree over ℚ divides some 2^a·3^b, a so-called '2-3 number'. The parent entry certifies these existentially by finding witnesses a, b. The goal here is to prove the existential definition equals an intrinsic test on the prime factorization: d is a 2-3 number iff every prime factor of d is 2 or 3 — exactly the 3-smooth numbers. The honest-scope paragraph is important: this is the number-theoretic layer; it does NOT re-prove Gleason's field-theoretic equivalence, which is taken as the modelling assumption.",
+    "mathContext": "Gleason: $\\alpha$ neusis-constructible $\\iff [\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\mid 2^a 3^b$. Target: $\\mathrm{IsTwoThreeNumber}(d) \\iff$ every prime factor of $d$ is in $\\{2,3\\}$ (i.e. $d$ is 3-smooth).",
+    "significance": "key",
+    "relatedConcepts": ["Gleason's theorem", "neusis construction", "marked ruler", "smooth numbers", "constructibility"],
+    "prerequisites": ["field extension degree", "angle trisection impossibility", "prime factorization"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-def",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 58, "endLine": 69 },
+    "type": "definition",
+    "title": "IsTwoThreeNumber: The Existential Predicate to Be Eliminated",
+    "content": "The predicate is re-stated verbatim from the parent AngleTrisectionOQ04 so the file is self-contained: d is a 2-3 number iff 0 < d and there exist a, b with d ∣ 2^a·3^b. This existential form is exactly what makes membership awkward — certifying d requires producing witnesses a, b — and is what the rest of the file works to replace with a structural test.",
+    "mathContext": "$\\mathrm{IsTwoThreeNumber}(d) := 0 < d \\wedge \\exists\\, a\\, b : \\mathbb{N},\\ d \\mid 2^a \\cdot 3^b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["existential quantifier", "divisibility", "self-contained restatement"],
+    "prerequisites": ["divisibility in ℕ"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-backward",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 71, "endLine": 105 },
+    "type": "lemma",
+    "title": "exists_dvd_of_primes: Strong Induction on minFac (the Technical Heart)",
+    "content": "This is the hard backward direction and the only nontrivial proof in the file. It uses Nat.strong_induction_on. If d = 1, take a = b = 0. Otherwise let p = d.minFac, which is prime (Nat.minFac_prime, valid since d ≠ 1) and divides d, so d = p·e. One shows e > 0 and e < d (since p > 1), and that e ∣ d, so every prime factor of e is also a prime factor of d — hence in {2,3}. The induction hypothesis applied to e gives e ∣ 2^a·3^b. Finally p ∈ {2,3} (it is a prime factor of d), and we re-absorb it: if p = 2, then d = 2e ∣ 2·(2^a·3^b) = 2^{a+1}·3^b; symmetrically for p = 3. The ring lemma 2^{a+1}·3^b = 2·(2^a·3^b) and mul_dvd_mul_left close it.",
+    "mathContext": "Peel $p = \\mathrm{minFac}(d) \\in \\{2,3\\}$, write $d = p\\cdot e$ with $e < d$; from $e \\mid 2^a 3^b$ get $d = pe \\mid p\\cdot 2^a 3^b$, which is $2^{a+1}3^b$ or $2^a 3^{b+1}$.",
+    "significance": "critical",
+    "relatedConcepts": ["strong induction", "Nat.minFac", "Euclid's lemma", "smooth numbers", "divisibility"],
+    "prerequisites": ["strong induction on ℕ", "minimal prime factor", "induction hypothesis on a proper divisor"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-iff",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 107, "endLine": 122 },
+    "type": "theorem",
+    "title": "isTwoThreeNumber_iff: The Intrinsic Criterion",
+    "content": "The headline equivalence. The forward direction is the easy one: given d ∣ 2^a·3^b and a prime p ∣ d, then p ∣ 2^a·3^b; by Nat.Prime.dvd_mul it divides 2^a or 3^b, and Nat.Prime.dvd_of_dvd_pow reduces to p ∣ 2 or p ∣ 3, so by Nat.prime_dvd_prime_iff_eq we get p = 2 or p = 3. The backward direction is exactly exists_dvd_of_primes. The result turns membership from an existential witness search into a finite, decidable inspection of the prime factorization.",
+    "mathContext": "$\\mathrm{IsTwoThreeNumber}(d) \\iff 0 < d \\wedge \\forall p\\ \\text{prime},\\ p \\mid d \\Rightarrow p = 2 \\vee p = 3$. Forward uses Euclid's lemma; backward is the strong induction.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's lemma", "Nat.Prime.dvd_mul", "decidability", "if and only if"],
+    "prerequisites": ["prime divisibility", "Nat.Prime.dvd_of_dvd_pow"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-obstruction",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 124, "endLine": 145 },
+    "type": "insight",
+    "title": "not_isTwoThreeNumber_of_prime: One Lemma for All Obstructions",
+    "content": "The uniform obstruction: any prime p ∉ {2,3} fails the criterion (it divides itself but is neither 2 nor 3), so it is not a neusis-constructible degree. This single lemma supersedes the parent's hand-written per-number proofs — five_/seven_/eleven_not_isTwoThreeNumber are now one-line instances. Conceptually it pinpoints that the obstruction to trisection-style problems is always a 'bad' prime factor (≥ 5) in the degree, e.g. why the regular heptagon (linked to 7) resists.",
+    "mathContext": "For prime $p \\notin \\{2,3\\}$: $p \\mid p$ yet $p \\neq 2,3$, so $p$ violates the criterion. Recovers $5,7,11 \\notin$ instantly.",
+    "significance": "key",
+    "relatedConcepts": ["uniform obstruction", "regular heptagon", "prime obstruction", "factor-based impossibility"],
+    "prerequisites": ["the intrinsic criterion"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-closure",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 147, "endLine": 163 },
+    "type": "theorem",
+    "title": "Closure Under Divisors and Products",
+    "content": "isTwoThreeNumber_of_dvd: a positive divisor e ∣ d of a 2-3 number is again a 2-3 number — its prime factors are a subset of d's, so still ⊆ {2,3}. isTwoThreeNumber_mul: the product d·e is a 2-3 number, since a prime dividing d·e divides d or e (Euclid) and hence is in {2,3}. Both proofs simply rewrite with isTwoThreeNumber_iff and chase prime divisibility — no witness arithmetic, illustrating the leverage the criterion provides over the existential definition.",
+    "mathContext": "$e \\mid d$, primes of $e$ $\\subseteq$ primes of $d$ $\\subseteq \\{2,3\\}$; primes of $d\\cdot e$ = primes of $d$ $\\cup$ primes of $e$.",
+    "significance": "supporting",
+    "relatedConcepts": ["closure properties", "divisor closure", "multiplicative structure"],
+    "prerequisites": ["transitivity of divisibility", "Euclid's lemma"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-lcm",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 165, "endLine": 177 },
+    "type": "insight",
+    "title": "isTwoThreeNumber_lcm: Closure That the Existential Definition Hides",
+    "content": "The lcm of two 2-3 numbers is a 2-3 number. This is the genuinely new structural fact: it is NOT obvious from the existential definition (there is no canonical way to combine two witnessed factorizations into a witness for the lcm), but it is a one-liner from the criterion. The key step is Nat.lcm d e ∣ d·e, so any prime dividing the lcm divides d·e, hence d or e, hence is in {2,3}. This makes the neusis-constructible degrees closed under the natural multiplicative 'join'.",
+    "mathContext": "$\\mathrm{lcm}(d,e) \\mid d\\cdot e$; primes of $\\mathrm{lcm}(d,e)$ $\\subseteq$ primes of $d\\cdot e$ $\\subseteq \\{2,3\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["least common multiple", "lattice join", "closure under lcm"],
+    "prerequisites": ["lcm divides product", "the intrinsic criterion"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-examples",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 179, "endLine": 196 },
+    "type": "theorem",
+    "title": "Composite Non-Members and a Positive Witness",
+    "content": "ten_not_isTwoThreeNumber (10 = 2·5) and fifteen_not_isTwoThreeNumber (15 = 3·5) are dispatched by exhibiting the bad prime 5 dividing them — read straight off the criterion, with omega closing 5 ≠ 2 ∧ 5 ≠ 3. twelve_isTwoThreeNumber (12 = 2²·3) shows the positive side, still given via the explicit existential witness (a,b) = (2,1) since that is the most direct certificate for a specific small number. Together they illustrate both directions of the criterion in action.",
+    "mathContext": "$10 = 2\\cdot 5$, $15 = 3\\cdot 5$: factor $5$ obstructs. $12 = 2^2\\cdot 3 \\mid 2^2\\cdot 3^1$: witness $(2,1)$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "concrete obstructions", "explicit witnesses"],
+    "prerequisites": ["the uniform obstruction lemma"]
+  },
+  {
+    "id": "ann-angle-tri-oq04-oq01-trisection",
+    "proofId": "angle-trisection-oq-04-oq-01",
+    "range": { "startLine": 198, "endLine": 217 },
+    "type": "insight",
+    "title": "The Geometry Payoff: cos(20°) Is Neusis-Constructible",
+    "content": "IsNeusisConstructible packages the degree condition geometrically, and isNeusisConstructible_iff restates the criterion as the marked-ruler analogue of the Gauss–Wantzel prime-factor test. The capstone trisection_degree_neusis proves cos(20°) = cos(π/9) — which has minimal polynomial 8x³−6x−1 of degree 3 — passes the criterion because 3's only prime factor is 3. This is exactly why a marked ruler trisects 60° though compass-and-straightedge cannot: 3 is 3-smooth but not a power of 2. The contrast crisply separates the two construction regimes.",
+    "mathContext": "$\\cos(\\pi/9)$ has degree $3$ over $\\mathbb{Q}$ (min. poly $8x^3 - 6x - 1$). $3$ passes the neusis test ($3 \\in \\{2,3\\}$) but fails the compass test ($3$ is not a power of $2$).",
+    "significance": "key",
+    "relatedConcepts": ["cos(20°)", "Gauss–Wantzel theorem", "compass vs marked ruler", "minimal polynomial degree"],
+    "prerequisites": ["minimal polynomial of cos(π/9)", "compass-constructibility degree condition"]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-01/meta.json
@@ -3,6 +3,18 @@
   "title": "Neusis-Constructible Degrees Are Exactly the 3-Smooth Numbers",
   "slug": "angle-trisection-oq-04-oq-01",
   "description": "Replaces the existential definition of a 2-3 number (d ∣ 2^a·3^b for some a,b) with an intrinsic, witness-free criterion: a positive d is a 2-3 number iff every prime factor of d is 2 or 3 — i.e. the neusis-constructible degrees are exactly the 3-smooth numbers. The hard backward direction is a strong induction peeling off Nat.minFac. From the criterion the structural theory falls out with no witness bookkeeping: closure under divisors, products, and least common multiples; a uniform prime obstruction superseding all of the parent's individual n_not_two_three results; and the geometry-facing form with the trisection witness (degree 3 passes). Answers OQ-04-OQ-01 of the tool-hierarchy study angle-trisection-oq-04.",
+  "overview": {
+    "historicalContext": "The trisection of an arbitrary angle was one of the three classical construction problems posed by the ancient Greeks, alongside duplicating the cube and squaring the circle. Its impossibility with compass and straightedge was settled by Pierre Wantzel in 1837, who showed (via what is now Galois/field theory) that a length is compass-constructible only if its minimal polynomial over ℚ has degree a power of 2 — and cos(20°) has degree 3, so 60° cannot be trisected. The Greeks themselves, however, knew the trisection could be done with a *neusis* (marked-ruler / verging) construction, as in Archimedes' method. The modern characterization of exactly which constructions a marked ruler permits is due to Andrew M. Gleason (1988), who proved that the marked ruler (equivalently, conic-assisted / origami constructions of the relevant order) constructs precisely those reals whose degree over ℚ divides some 2^a·3^b. These '2-3 numbers' are exactly the *3-smooth numbers* in the language of number theory (numbers with no prime factor exceeding 3), connecting Gauss–Wantzel constructibility to the theory of smooth numbers.",
+    "problemStatement": "The parent entry encodes Gleason's degree condition existentially: $\\mathrm{IsTwoThreeNumber}(d) := 0 < d \\wedge \\exists\\, a\\, b,\\ d \\mid 2^a \\cdot 3^b$, and certifies each specific $d$ by exhibiting witnesses $a, b$. The task here is to prove this is equivalent to the intrinsic, witness-free criterion $$\\mathrm{IsTwoThreeNumber}(d) \\iff 0 < d \\wedge \\forall p\\ \\text{prime},\\ p \\mid d \\Rightarrow p = 2 \\vee p = 3,$$ and to rebuild the structural theory of neusis-constructible degrees on top of it.",
+    "proofStrategy": "The forward direction is routine: if $d \\mid 2^a 3^b$ and a prime $p \\mid d$, then $p \\mid 2^a 3^b$, so $p \\in \\{2,3\\}$ by Euclid's lemma (`Nat.Prime.dvd_mul` plus `dvd_of_dvd_pow`). The backward direction — `exists_dvd_of_primes`, the technical heart — is a strong induction on $d$: if $d = 1$ take $a=b=0$; otherwise peel off the smallest prime factor $p = \\mathrm{minFac}(d) \\in \\{2,3\\}$, write $d = p\\cdot e$ with $e < d$, apply the induction hypothesis to $e$ (its prime factors are a subset of $d$'s), obtaining $e \\mid 2^a 3^b$, and re-absorb the factor $p$ by bumping the corresponding exponent ($a{+}1$ or $b{+}1$). Once the iff is established, every structural property (closure under divisors / products / lcm, the uniform prime obstruction, the geometry-facing restatement) follows by simply rewriting with the criterion and chasing prime divisibility — no witness arithmetic.",
+    "keyInsights": [
+      "The conceptual payoff is replacing an existential ('there exist exponents a, b such that ...') with a decidable structural test on the prime factorization. Deciding neusis-constructibility of a degree no longer means *searching* for witnesses — one just reads off the prime factors.",
+      "2-3 numbers are exactly the 3-smooth numbers, so this entry quietly recasts a geometry problem as an instance of smooth-number theory; the same shape recovers the Gauss–Wantzel '2-smooth (= power of 2, modulo Fermat primes)' picture for compass-and-straightedge.",
+      "A single lemma, not_isTwoThreeNumber_of_prime, supersedes all of the parent's hand-written per-number non-membership proofs: any prime ≠ 2,3 (and hence any number divisible by one) is obstructed, instantly recovering 5, 7, 10, 11, 15 ∉.",
+      "Closure under least common multiples is genuinely new information — it is NOT immediate from the existential definition (combining two witnessed factorizations does not obviously bound the lcm's), but is a one-line consequence of the prime-factor criterion since primes dividing lcm(d,e) divide d·e.",
+      "The strong-induction-on-minFac pattern is the canonical Lean idiom for 'reduce a multiplicative claim to its prime factors one prime at a time'; here the key is that minFac of a 3-smooth number is itself 2 or 3, which keeps the recursion inside the smooth-number class."
+    ]
+  },
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-21",
@@ -40,6 +52,163 @@
     "sorries": 0,
     "definitionCount": 2,
     "theoremCount": 14
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: Gleason's Theorem and the 2-3 Number Criterion",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Sets up the open question as a slice of the tool-hierarchy study. Recalls Gleason's theorem (a real is neusis-constructible iff its degree over ℚ divides some 2^a·3^b), states the goal of replacing the parent's existential definition with the intrinsic prime-factor criterion, and delimits the honest scope: this is the number-theoretic layer, not a re-derivation of Gleason's field-theoretic equivalence.",
+      "mathContext": "Gleason (1988): $\\alpha$ neusis-constructible $\\iff [\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\mid 2^a 3^b$. The 2-3 numbers are exactly the 3-smooth numbers."
+    },
+    {
+      "id": "definition-twothree",
+      "title": "IsTwoThreeNumber: The Existential Definition",
+      "startLine": 58,
+      "endLine": 69,
+      "summary": "Re-states the parent's predicate verbatim to keep the file self-contained: d is a 2-3 number iff 0 < d and d ∣ 2^a·3^b for some a, b. This is the existential form the rest of the file works to eliminate.",
+      "mathContext": "$\\mathrm{IsTwoThreeNumber}(d) := 0 < d \\wedge \\exists\\, a\\, b,\\ d \\mid 2^a \\cdot 3^b$."
+    },
+    {
+      "id": "backward-direction",
+      "title": "exists_dvd_of_primes: The Hard Backward Direction",
+      "startLine": 71,
+      "endLine": 105,
+      "summary": "The technical core. By strong induction on d: the d=1 base takes a=b=0; otherwise peel off p = minFac(d) ∈ {2,3}, write d = p·e with e < d, apply the IH to e (its primes are among d's), get e ∣ 2^a·3^b, and re-absorb p by incrementing a or b. The witness for d is built by bumping the appropriate exponent.",
+      "mathContext": "If every prime factor of $d>0$ lies in $\\{2,3\\}$ then $d \\mid 2^a 3^b$. Inductive step: $d = p \\cdot e$, $e \\mid 2^a 3^b$, so $d \\mid p \\cdot 2^a 3^b = 2^{a+1}3^b$ or $2^a 3^{b+1}$."
+    },
+    {
+      "id": "main-iff",
+      "title": "isTwoThreeNumber_iff: The Intrinsic Criterion",
+      "startLine": 107,
+      "endLine": 122,
+      "summary": "The headline equivalence: a positive d is a 2-3 number iff every prime dividing d is 2 or 3. Forward uses Euclid's lemma (a prime dividing 2^a·3^b must be 2 or 3); backward is exactly exists_dvd_of_primes. This converts an existential search into a decidable inspection of the factorization.",
+      "mathContext": "$\\mathrm{IsTwoThreeNumber}(d) \\iff 0 < d \\wedge \\forall p\\,(\\text{prime}),\\ p \\mid d \\Rightarrow p \\in \\{2,3\\}$."
+    },
+    {
+      "id": "uniform-obstruction",
+      "title": "not_isTwoThreeNumber_of_prime and Concrete Non-Members",
+      "startLine": 124,
+      "endLine": 145,
+      "summary": "A single uniform obstruction: any prime other than 2 or 3 fails the criterion, hence is not a neusis-constructible degree. Instantiated for 5, 7, 11 — one lemma replacing all of the parent's individual n_not_two_three results.",
+      "mathContext": "For prime $p \\notin \\{2,3\\}$: $\\neg\\,\\mathrm{IsTwoThreeNumber}(p)$, since $p \\mid p$ but $p \\neq 2,3$."
+    },
+    {
+      "id": "closure-divisors-products",
+      "title": "Closure Under Divisors and Products",
+      "startLine": 147,
+      "endLine": 163,
+      "summary": "isTwoThreeNumber_of_dvd: a positive divisor of a 2-3 number is a 2-3 number (its primes are a subset). isTwoThreeNumber_mul: the product of two 2-3 numbers is one (a prime dividing d·e divides d or e). Both are witness-free re-derivations via the criterion.",
+      "mathContext": "$e \\mid d$ and $\\mathrm{IsTwoThreeNumber}(d) \\Rightarrow \\mathrm{IsTwoThreeNumber}(e)$; the class is closed under multiplication."
+    },
+    {
+      "id": "closure-lcm",
+      "title": "isTwoThreeNumber_lcm: Closure Under Least Common Multiples",
+      "startLine": 165,
+      "endLine": 177,
+      "summary": "The lcm of two 2-3 numbers is a 2-3 number — the natural 'join' of two neusis-constructible degrees. Crucially this is NOT immediate from the existential definition; it relies on the prime-factor criterion (primes dividing lcm(d,e) divide d·e).",
+      "mathContext": "$\\mathrm{lcm}(d,e) \\mid d \\cdot e$, so every prime factor of the lcm is a factor of $d$ or $e$, hence in $\\{2,3\\}$."
+    },
+    {
+      "id": "more-nonmembers",
+      "title": "Composite Non-Members and a Positive Witness",
+      "startLine": 179,
+      "endLine": 196,
+      "summary": "ten_not_isTwoThreeNumber (10 = 2·5) and fifteen_not_isTwoThreeNumber (15 = 3·5): the factor 5 is the obstruction, read directly off the criterion with no witness search. twelve_isTwoThreeNumber (12 = 2²·3) shows the positive side with the explicit witness 2^2·3^1.",
+      "mathContext": "$10 = 2\\cdot 5$, $15 = 3\\cdot 5$ obstructed by the prime $5$; $12 = 2^2\\cdot 3$ passes with witness $(a,b)=(2,1)$."
+    },
+    {
+      "id": "geometry-facing",
+      "title": "IsNeusisConstructible and the Trisection Witness",
+      "startLine": 198,
+      "endLine": 217,
+      "summary": "Defines IsNeusisConstructible (a degree-d real is neusis-constructible iff d is a 2-3 number), restates the criterion in geometry-facing form (isNeusisConstructible_iff — the marked-ruler analogue of Gauss–Wantzel), and proves trisection_degree_neusis: cos(20°) = cos(π/9) has degree 3, whose only prime factor is 3, so trisecting 60° is neusis-constructible.",
+      "mathContext": "$\\cos(\\pi/9)$ has minimal polynomial of degree 3 ($8x^3 - 6x - 1$); since $3$'s only prime factor is $3$, it passes the neusis criterion though it fails the compass test (3 is not a power of 2)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isTwoThreeNumber_iff",
+      "type": "main",
+      "description": "The intrinsic prime-factor criterion: a positive d is a 2-3 number iff every prime dividing d is 2 or 3. Replaces the parent's existential ∃ a b witness with a decidable inspection of the factorization.",
+      "leanType": "(d : ℕ) → (IsTwoThreeNumber d ↔ 0 < d ∧ ∀ p : ℕ, p.Prime → p ∣ d → p = 2 ∨ p = 3)"
+    },
+    {
+      "name": "exists_dvd_of_primes",
+      "type": "lemma",
+      "description": "The hard backward direction, by strong induction peeling off Nat.minFac: if every prime factor of a positive d is 2 or 3, then d ∣ 2^a·3^b for some a, b.",
+      "leanType": "∀ d : ℕ, 0 < d → (∀ p : ℕ, p.Prime → p ∣ d → p = 2 ∨ p = 3) → ∃ a b : ℕ, d ∣ 2 ^ a * 3 ^ b"
+    },
+    {
+      "name": "not_isTwoThreeNumber_of_prime",
+      "type": "corollary",
+      "description": "Uniform obstruction: any prime other than 2 or 3 is not a 2-3 number, superseding all of the parent's individual non-membership lemmas.",
+      "leanType": "{p : ℕ} (hp : p.Prime) (h2 : p ≠ 2) (h3 : p ≠ 3) → ¬ IsTwoThreeNumber p"
+    },
+    {
+      "name": "isTwoThreeNumber_lcm",
+      "type": "corollary",
+      "description": "Closure under least common multiples — the natural join of two neusis-constructible degrees, not immediate from the existential definition.",
+      "leanType": "{d e : ℕ} (hd : IsTwoThreeNumber d) (he : IsTwoThreeNumber e) → IsTwoThreeNumber (Nat.lcm d e)"
+    },
+    {
+      "name": "isNeusisConstructible_iff",
+      "type": "corollary",
+      "description": "Geometry-facing form: a degree-d real is neusis-constructible iff every prime factor of d is 2 or 3 — the marked-ruler analogue of the Gauss–Wantzel prime-factor test.",
+      "leanType": "(α : ℝ) (d : ℕ) → (IsNeusisConstructible α d ↔ 0 < d ∧ ∀ p : ℕ, p.Prime → p ∣ d → p = 2 ∨ p = 3)"
+    },
+    {
+      "name": "trisection_degree_neusis",
+      "type": "corollary",
+      "description": "The degree-3 extension realizing cos(20°) = cos(π/9) passes the criterion (only prime factor is 3), so trisecting 60° is neusis-constructible though not compass-constructible.",
+      "leanType": "IsNeusisConstructible (Real.cos (Real.pi / 9)) 3"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Gleason, Andrew M.",
+      "title": "Angle Trisection, the Heptagon, and the Triskaidecagon",
+      "year": "1988",
+      "venue": "The American Mathematical Monthly, 95(3), 185–194",
+      "note": "Proves that the marked ruler (neusis) constructs exactly the reals whose degree over ℚ divides some 2^a·3^b — the field-theoretic equivalence this entry's criterion characterizes number-theoretically."
+    },
+    {
+      "authors": "Wantzel, Pierre Laurent",
+      "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
+      "year": "1837",
+      "venue": "Journal de Mathématiques Pures et Appliquées, 1(2), 366–372",
+      "note": "Original impossibility proof for angle trisection and cube duplication via the power-of-2 degree condition for compass-and-straightedge constructibility."
+    },
+    {
+      "authors": "Martin, George E.",
+      "title": "Geometric Constructions",
+      "year": "1998",
+      "venue": "Springer, Undergraduate Texts in Mathematics",
+      "note": "Textbook treatment of marked-ruler and origami constructions, including the 2-3 number / 3-smooth degree characterization."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-04",
+      "relationship": "extends",
+      "description": "Parent tool-hierarchy study that defines IsTwoThreeNumber existentially and verifies membership by exhibiting witnesses; this entry replaces that with the intrinsic prime-factor criterion and rebuilds the structural theory on it."
+    },
+    {
+      "targetId": "angle-trisection",
+      "relationship": "related",
+      "description": "Base angle-trisection impossibility entry (compass-and-straightedge); the neusis criterion here explains why the marked ruler succeeds where compass-and-straightedge fails — degree 3 is 3-smooth but not a power of 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "The existential definition of a 2-3 number (d ∣ 2^a·3^b for some a, b) is shown equivalent to the intrinsic, witness-free criterion that every prime factor of d is 2 or 3 — i.e. the neusis-constructible degrees are exactly the 3-smooth numbers. The hard backward direction is a strong induction peeling off Nat.minFac. On top of the criterion the full structural theory is rebuilt with no witness bookkeeping: closure under divisors, products, and lcm; a single uniform prime obstruction; and the geometry-facing restatement with the cos(20°) trisection witness. Fully machine-verified, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Recasting neusis-constructibility as a 3-smoothness test makes deciding it a matter of reading a prime factorization rather than searching for exponent witnesses, and exposes the parallel with the Gauss–Wantzel compass criterion (2-smooth, modulo Fermat primes). The uniform obstruction lemma collapses an open-ended family of per-number impossibility proofs into one, and closure under lcm gives the neusis-constructible degrees the structure of a multiplicatively closed, divisor-closed set — a lattice-like 'join' the existential definition could not easily supply.",
+    "openQuestions": [
+      "Can this be upgraded to a Decidable instance for IsTwoThreeNumber that computes via Nat.factorization, making membership checkable by decide/native_decide for concrete d?",
+      "The entry deliberately does not re-derive Gleason's field-theoretic equivalence (degree ↔ neusis construction). Can that bridge — minimal polynomial degree controlling marked-ruler constructibility — be formalized to close the geometry-to-number-theory gap?",
+      "How does the criterion extend to the n-fold origami / higher-marked-tool hierarchy, where the relevant smooth-number base grows beyond {2,3} (e.g. the Pierpont-prime polygon criterion of the sibling oq-04-oq-03)?",
+      "Is there a clean characterization of which 2-3 numbers arise as actual minimal-polynomial degrees of geometrically meaningful angles, as opposed to abstract 3-smooth integers?"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-04-oq-01` (quality 0, passes 0). The entry previously had only `description` + `meta` — no overview, sections, conclusion, references, cross-references, or annotations.

## Changes
- **overview**: added structured `ProofOverview` — `historicalContext` (Greek classical problems, Wantzel 1837, Gleason 1988 marked-ruler theorem, the 2-3 = 3-smooth correspondence), `problemStatement`, `proofStrategy` (the strong-induction-on-minFac argument), and 5 `keyInsights`.
- **sections**: 9 sections covering the full 217-line Lean file (docstring, definition, the hard backward direction, the main iff, the uniform obstruction, divisor/product closure, lcm closure, examples, the geometry-facing trisection witness), each with `mathContext`.
- **mainTheorems**: 6 entries with `leanType` signatures.
- **references**: Gleason (1988, *Amer. Math. Monthly*), Wantzel (1837), Martin (*Geometric Constructions*).
- **crossReferences**: parent `angle-trisection-oq-04` (extends) and base `angle-trisection` (related).
- **conclusion**: structured `summary` / `implications` / 4 `openQuestions` (Decidable instance, the Gleason field-theory bridge, the origami/Pierpont hierarchy, geometric realizability of 2-3 degrees).
- **annotations.json**: created with 9 annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Axiom integrity
Verified against the Lean source: 0 `axiom` declarations, 0 sorries, no `native_decide`, no assumption-carrying structures. `status: verified` / `badge: original` / `axiomCount: 0` are accurate (depends only on propext, Classical.choice, Quot.sound).

`pnpm build` passes.