### PR TITLE
audit(algebraic-numbers-countable-oq-07): badge original→mathlib, add mathlibDependencies (Tier B)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-07/meta.json
@@ -17,14 +17,36 @@
       "almost-everywhere",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 205,
     "theoremCount": 11,
     "definitionCount": 0,
     "dateAdded": "2026-06-21",
-    "assumptions": "",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "A countable set is null for any measure without atoms. Combined with the parent's countability of the algebraic reals, this directly yields the headline algebraic_reals_null and algebraic_complex_null.",
+        "module": "Mathlib.MeasureTheory.Measure.NoAtoms"
+      },
+      {
+        "theorem": "Real.noAtoms_volume",
+        "description": "Lebesgue measure on ℝ has no atoms (every singleton is null), the atomlessness hypothesis that powers Set.Countable.measure_zero.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "Complex.volume_preserving_equiv_real_prod",
+        "description": "The identification ℂ ≃ᵐ ℝ × ℝ is measure-preserving; used to transport singletons and establish NoAtoms (volume : Measure ℂ) for the complex case.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Complex"
+      },
+      {
+        "theorem": "compl_mem_ae_iff",
+        "description": "A set is conull iff its complement is null; converts algebraic_reals_null into the almost-everywhere statement ae_transcendental.",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      }
+    ],
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. The core result `algebraic_reals_null` is a one-liner: the countability of the algebraic reals is imported from the parent `AlgebraicNumbersCountable.algebraic_reals_countable`, and `Set.Countable.measure_zero` (with Mathlib's atomless `Real.noAtoms_volume`) upgrades countable to null. The file's independent content is the measure-theoretic packaging (conull/ae/interval/existence corollaries) and the `NoAtoms (volume : Measure ℂ)` instance transported through `Complex.volume_preserving_equiv_real_prod`. `#print axioms` reports only propext, Classical.choice, Quot.sound — no `Lean.ofReduceBool`, no `sorryAx`.",
     "originalContributions": [
       "algebraic_reals_null: volume {x : ℝ | IsAlgebraic ℚ x} = 0 — the algebraic reals have Lebesgue measure zero",
       "algebraicRealsOfBoundedDegree_null: each bounded-degree stratum of algebraic reals is null",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17725,6 +17725,12 @@
       "lastAudited": "2026-06-23T03:29:24Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "algebraic-numbers-countable-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-23T03:36:20Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: algebraic-numbers-countable-oq-07 — "The Algebraic Reals are Lebesgue-Null"
**Severity**: MEDIUM (Mathlib-bridged core result carried an `original` badge with no declared dependencies)

## Finding

The headline `algebraic_reals_null` is a single line:

```lean
theorem algebraic_reals_null : volume {x : ℝ | IsAlgebraic ℚ x} = 0 :=
  (AlgebraicNumbersCountable.algebraic_reals_countable).measure_zero volume
```

The countability of the algebraic reals is **imported** from the parent entry, and Mathlib's `Set.Countable.measure_zero` (backed by the atomless `Real.noAtoms_volume`) upgrades countable → null. `algebraic_complex_null` is the same pattern. So the core result is a Mathlib bridge — **Tier B**, matching failure mode #1 (delegation opacity) and #5 (hidden imports).

Notably the `proofStrategy` and `keyInsights` already credit these Mathlib lemmas honestly, but the machine-readable metadata contradicted the prose:
- `badge`: `original` (claims independent work)
- `mathlibDependencies`: **absent**
- `assumptions`: **empty string**

The file's genuinely independent content is the measure-theoretic packaging (conull / a.e. / interval-full / positive-measure existence corollaries) and the `NoAtoms (volume : Measure ℂ)` instance transported through `Complex.volume_preserving_equiv_real_prod`.

## Fix

- `badge`: `original` → `mathlib`
- Add `mathlibDependencies` (4 core lemmas: `Set.Countable.measure_zero`, `Real.noAtoms_volume`, `Complex.volume_preserving_equiv_real_prod`, `compl_mem_ae_iff`)
- Fill `assumptions` to disclose the bridge

`status` stays `verified` (the file is 0-sorry, 0-axiom, `native_decide`-free, kernel-checked).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)