### PR TITLE
audit(abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01): badge verified→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -67,7 +67,7 @@
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
     "lineCount": 188,
-    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. All thresholds rewrite the parent chain's intrinsic classification (perm_solvable_iff_card / alternating_solvable_iff_card) through Fintype.card_sum / Fintype.card_prod; the reflection and escape lemmas use only elementary Nat arithmetic (Nat.le_mul_of_pos_right, Nat.mul_le_mul, omega). `#print axioms` on all main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used. All thresholds rewrite the parent chain's intrinsic classification (perm_solvable_iff_card / alternating_solvable_iff_card) through Fintype.card_sum / Fintype.card_prod; that classification descends from Mathlib's symmetric-group solvability result (Equiv.Perm.not_solvable / the A₅ non-solvability core), so this file supplies the ⊕/× boundary arithmetic and the reflection/escape derivations on top of a Mathlib-backed classification rather than an independent solvability proof — hence the `mathlib` badge (Tier B). The reflection and escape lemmas use only elementary Nat arithmetic (Nat.le_mul_of_pos_right, Nat.mul_le_mul, omega). `#print axioms` on all main results reports only the standard foundational axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`, no `sorryAx`.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
     "definitionCount": 0,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01`
**Severity**: MEDIUM (Mathlib bridge presented with a stronger-than-warranted badge)

### Problem

The entry carried `badge: "verified"`, which signals an independent/full machine-checked proof. But its load-bearing result — the solvability threshold `perm_solvable_iff_card` (`IsSolvable (Perm α) ↔ Fintype.card α ≤ 4`) and its alternating analogue — descends through the parent chain from **Mathlib's symmetric-group solvability core** (`Equiv.Perm.not_solvable` / A₅ non-solvability). The file's own theorems (`perm_sum_solvable_iff`, `perm_prod_solvable_iff`, the reflection lemmas, `abel_ruffini_is_additive_escape`) are genuine new derivations, but they obtain their mathematical force from that Mathlib-backed classification.

This is **Tier B** (formalized using a Mathlib theorem) → badge should be `mathlib`.

### Evidence

- `proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01.lean` proves every threshold by `rw [perm_solvable_iff_card, ...]`.
- `perm_solvable_iff_card` (defined in `...OQ08OQ01.lean`) reduces via `sym_solvable_iff` to the `Fin n` classification, ultimately Mathlib's S₅ result.
- **All five ancestors** in this chain already carry `status: verified, badge: mathlib`:
  - `...OQ08-oq-01-oq-01-oq-01`, `...OQ08-oq-01-oq-01`, `...OQ08-oq-01`, `...OQ08`, `abel-ruffini`.
  - This descendant was inconsistently badged `verified`.

### Verification

- 0 `sorry` in source (the two "sorry" hits are docstring text "No `sorry`, no `axiom`...").
- 0 `axiom` declarations, 0 `True` stubs, no `native_decide`.
- `theoremCount` (10) matches source.

### Fix

- `badge`: `"verified"` → `"mathlib"`
- `assumptions`: disclose the Mathlib bridge behind the classification (matching the ancestor convention)
- `status` stays `"verified"` (0 sorries, 0 axiom declarations, 0 structure-encoded assumptions — consistent with the rest of the chain)

Metadata-only change; no Lean source modified.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)