### PR TITLE
audit(abel-ruffini-oq-04…oq-01-oq-01-oq-01-oq-01): badge verified→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01
**Severity**: MEDIUM (Mathlib wrapper carrying an `original`/`verified` badge)

### Problem

The badge was `verified`, but the headline results are Tier B bridges, not independent formalizations. The three threshold theorems

- `perm_sum_solvable_iff`  — `rw [perm_solvable_iff_card, Fintype.card_sum]`
- `perm_prod_solvable_iff` — `rw [perm_solvable_iff_card, Fintype.card_prod]`
- `alternating_sum_solvable_iff` — `rw [alternating_solvable_iff_card, Fintype.card_sum]`

are one-line rewrites of the imported classification `perm_solvable_iff_card`, whose core engine (symmetric group solvable ↔ `card ≤ 4`) reduces to Mathlib's symmetric-group solvability via `sym_solvable_iff`. The deep mathematical content is Mathlib's.

### Evidence

- The **entire ancestor chain** already carries `badge: mathlib` (`…-oq-08`, `…-oq-08-oq-01`, `…-oq-01-oq-01`, `…-oq-01-oq-01-oq-01`; flipped in #27692 and siblings). This deepest descendant was the lone `verified` outlier.
- `perm_solvable_iff_card` (parent `AbelRuffiniOQ04OQ02OQ02OQ08OQ01.lean:120`) proves the threshold via `perm_solvable_congr … sym_solvable_iff` — a Mathlib bridge.

### Fix

`badge: "verified" → "mathlib"`. Status stays `verified` (the file is genuinely 0-sorry, 0-axiom, no `native_decide`, machine-checked). The original arithmetic contributions (products reflect solvability, multiplicative escape, additive-escape, the closure dichotomy) remain accurately listed and are real elementary additions on top of the Mathlib-backed threshold.

---
Discovered during gallery integrity audit.