### PR TITLE
audit(abel-ruffini ⊕/× chain): badge verified→mathlib for 4 Tier B descendants

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -27,7 +27,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery Integrity Audit — Tier B badge correction

The `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01…` ⊕/× chain studies how the
solvability threshold (`card ≤ 4`) behaves under disjoint union and product of
finite types. Each entry obtains **all** of its solvability content from the
**imported** threshold engine and adds only elementary `Nat` arithmetic:

```lean
theorem perm_sum_solvable_iff  ... := by rw [perm_solvable_iff_card, Fintype.card_sum]
theorem perm_prod_solvable_iff ... := by rw [perm_solvable_iff_card, Fintype.card_prod]
-- reflect/escape/survivor lemmas: imported threshold + omega
```

`perm_solvable_iff_card`, `alternating_solvable_iff_card`, and
`not_solvable_perm_card_eq_ge_five` come from the parent chain, which bridges to
Mathlib's symmetric/alternating-group solvability (the genuinely deep content,
S₅ non-solvable).

This is auditor **Tier B** (core argument relies on an imported Mathlib-derived
theorem) + **failure mode #5** (0 sorries with hidden imports). Badge must be
`mathlib`, not `verified`. Status stays `verified` — all four files are
genuinely sorry-free, 0-axiom, kernel-checked; the combinatorial corollaries are
real elementary-arithmetic contributions on top of the imported threshold.

This also brings the four `verified` outliers in line with the rest of the
chain, which is already badged `mathlib` / status `verified`.

### Entries corrected (`badge: verified → mathlib`)
- `…-oq-08-oq-01-oq-01-oq-01-oq-01` — ⊕/× boundary arithmetic (products reflect, sums do not)
- `…-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01` — reflect/escape arithmetic
- `…-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` — unique (2,2) preservation survivor
- `…-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` — survival-containment (4ab ≤ (a+b)²)

### Not changed (audited, left as-is)
- `abel-ruffini-oq-04-oq-02-oq-02` — independently formalizes A₄ solvability (V₄ subgroup, derived series); borderline, substantial original work.
- `abel-ruffini-oq-07` / `oq-07-discriminant` — different branch (Galois group / discriminant of X⁵−X−1); substantial original lemmas, not trivial bridges.

---
Discovered during gallery integrity audit.