### PR TITLE
audit(abel-ruffini deep OQ chain ×3): badge verified→mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -27,7 +27,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -25,7 +25,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Gallery integrity audit

**Proofs** (3):
- abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01
- abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01
- abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01

**Severity**: MEDIUM (Mathlib wrapper carrying a `verified` badge)

### Problem

These three deepest descendants in the abel-ruffini OQ chain carried `badge: verified`, but each is a Tier B bridge: every solvability-bearing result routes through the imported, Mathlib-backed threshold lemmas

- `perm_solvable_iff_card`
- `perm_sum_solvable_iff` / `perm_prod_solvable_iff`
- `not_solvable_perm_card_eq_ge_five`

whose core engine (symmetric group solvable ↔ `card ≤ 4`) reduces to Mathlib's symmetric-group solvability via `sym_solvable_iff`. The deep mathematical content is Mathlib's.

### Evidence

- The **entire ancestor chain** already carries `badge: mathlib` (through `…-oq-01-oq-01-oq-01`, flipped in #27692; `…-oq-01-oq-01-oq-01-oq-01` in #27705).
- The original content these files add is elementary `Nat` arithmetic on top of the threshold: `5` is prime so products skip `5`; `4·(a·b) ≤ (a+b)²`; the additive-escape-`5` vs multiplicative-escape-`6` asymmetry. None of it reproves the solvability classification.

### Fix

`badge: "verified" → "mathlib"` for all three. Status stays `verified` (each file is genuinely 0-sorry, 0-axiom, no `native_decide`, machine-checked). The `originalContributions` remain accurate descriptions of the elementary arithmetic added on top of the Mathlib threshold.

---
Discovered during gallery integrity audit.