### PR TITLE
Enrich Leibniz Series for π (conditional convergence)

### DIFF
--- a/src/data/proofs/basel-problem-oq-10/annotations.json
+++ b/src/data/proofs/basel-problem-oq-10/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-basel-oq10-overview",
+    "proofId": "basel-problem-oq-10",
+    "range": { "startLine": 3, "endLine": 33 },
+    "type": "concept",
+    "title": "Conditional Convergence and Mathlib's tsum Semantics",
+    "content": "The docstring frames the whole entry around a formalization subtlety. The Leibniz–Madhava–Gregory series 1 − 1/3 + 1/5 − ⋯ = π/4 is true only as an ORDERED limit of partial sums. Mathlib's Summable, tsum, and HasSum encode UNCONDITIONAL convergence — convergence of the net indexed by all finite subsets — which for real-valued families is equivalent to absolute convergence. Since the Leibniz terms are not absolutely summable, the family is not Summable, and Mathlib's tsum returns its junk value 0, which is ≠ π/4. The four results make this precise; the non-summability lemma is the new content.",
+    "mathContext": "$\\sum_k \\frac{(-1)^k}{2k+1} = \\frac{\\pi}{4}$ as $\\lim_k \\sum_{i<k}$, but $\\sum'_k \\frac{(-1)^k}{2k+1} = 0$ since the family is not absolutely summable.",
+    "significance": "key",
+    "relatedConcepts": ["conditional convergence", "unconditional convergence", "absolute convergence", "Riemann rearrangement theorem", "tsum semantics"],
+    "prerequisites": ["infinite series", "summability", "Leibniz formula for π"]
+  },
+  {
+    "id": "ann-basel-oq10-correct-form",
+    "proofId": "basel-problem-oq-10",
+    "range": { "startLine": 39, "endLine": 44 },
+    "type": "theorem",
+    "title": "leibniz_tendsto_pi_div_four: The Statement That Actually Holds",
+    "content": "The correct form of the Leibniz formula: the ordered partial sums ∑_{i<k} (-1)^i/(2i+1) over range k converge to π/4. This is a direct re-export of Mathlib's tendsto_sum_pi_div_four, which Mathlib proves by applying Abel's limit theorem to the arctangent Maclaurin series arctan x = ∑ (-1)^k x^{2k+1}/(2k+1) at the boundary point x = 1, where arctan 1 = π/4. The essential feature is that this is a Tendsto over an inherently ordered family of finite partial sums — not a tsum.",
+    "mathContext": "$\\displaystyle \\lim_{k\\to\\infty}\\sum_{i<k}\\frac{(-1)^i}{2i+1} = \\arctan 1 = \\frac{\\pi}{4}$, via Abel summation of the arctan series at $x=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Abel's limit theorem", "arctangent series", "ordered partial sums", "Tendsto"],
+    "prerequisites": ["Taylor series of arctan", "limits of sequences"]
+  },
+  {
+    "id": "ann-basel-oq10-abs-reduce",
+    "proofId": "basel-problem-oq-10",
+    "range": { "startLine": 49, "endLine": 59 },
+    "type": "tactic",
+    "title": "Reducing Summability to the Absolute-Value Series",
+    "content": "The non-summability proof opens by rewriting with ← summable_abs_iff, which for real-valued families converts Summable f into Summable |f| — the bridge from the conditional-convergence question to a question about a series of nonnegative terms. The absolute value is then simplified pointwise: |(-1)^k/(2k+1)| = 1/(2k+1), discharged by abs_div, abs_pow, abs_neg, abs_one, one_pow, and abs_of_pos (the denominator is positive by positivity). After this rewrite the goal is the non-summability of the clean harmonic-type series 1/(2k+1).",
+    "mathContext": "$\\left|\\frac{(-1)^k}{2k+1}\\right| = \\frac{|(-1)^k|}{|2k+1|} = \\frac{1}{2k+1}$; over $\\mathbb{R}$, $\\mathrm{Summable}\\,f \\iff \\mathrm{Summable}\\,|f|$.",
+    "significance": "technical",
+    "relatedConcepts": ["summable_abs_iff", "absolute value simplification", "absolute convergence"],
+    "prerequisites": ["absolute value identities", "summability over ℝ"]
+  },
+  {
+    "id": "ann-basel-oq10-minorant",
+    "proofId": "basel-problem-oq-10",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "insight",
+    "title": "The Harmonic Minorant: Comparison From Below",
+    "content": "The crux is a comparison against a divergent MINORANT, not a majorant. Assuming 1/(2k+1) were summable, the smaller terms 1/(2k+2) ≤ 1/(2k+1) would be summable too (Summable.of_nonneg_of_le with one_div_le_one_div_of_le). But 1/(2k+2) = ½·1/(k+1), so scaling by 2 (hmin.mul_left 2) and rewriting gives summability of 1/(k+1); a further index shift (summable_nat_add_iff 1) and push_cast turn this into summability of 1/n — contradicting not_summable_one_div_natCast, the divergence of the harmonic series. The logic is: a series dominating a divergent one must itself diverge.",
+    "mathContext": "$\\frac{1}{2k+1} \\ge \\frac{1}{2k+2} = \\frac12\\cdot\\frac{1}{k+1}$; summability of the left side would force summability of $\\sum\\frac1n$, which diverges.",
+    "significance": "critical",
+    "relatedConcepts": ["comparison test", "harmonic series divergence", "minorant", "index reindexing"],
+    "prerequisites": ["Summable.of_nonneg_of_le", "not_summable_one_div_natCast", "summable_nat_add_iff"]
+  },
+  {
+    "id": "ann-basel-oq10-tsum-zero",
+    "proofId": "basel-problem-oq-10",
+    "range": { "startLine": 74, "endLine": 78 },
+    "type": "theorem",
+    "title": "tsum_leibniz_eq_zero: The Junk Value of a Non-Summable tsum",
+    "content": "An immediate corollary: tsum_eq_zero_of_not_summable applied to not_summable_leibniz yields ∑' k, (-1)^k/(2k+1) = 0. This is the convention Mathlib uses — the tsum of a non-summable family is defined to be 0 (the identity of the topological additive monoid), a default 'junk' value with no analytic meaning. It is the formal trap the whole entry warns against.",
+    "mathContext": "$\\sum'_k \\frac{(-1)^k}{2k+1} = 0$ by `tsum_eq_zero_of_not_summable`.",
+    "significance": "supporting",
+    "relatedConcepts": ["junk value", "tsum convention", "tsum_eq_zero_of_not_summable"],
+    "prerequisites": ["definition of tsum"]
+  },
+  {
+    "id": "ann-basel-oq10-tsum-ne",
+    "proofId": "basel-problem-oq-10",
+    "range": { "startLine": 80, "endLine": 88 },
+    "type": "insight",
+    "title": "tsum_leibniz_ne_pi_div_four: The Naive Reading Is Literally False",
+    "content": "The cautionary punchline: ∑' k, (-1)^k/(2k+1) ≠ π/4. The proof rewrites with the junk value 0 (tsum_leibniz_eq_zero) and then notes 0 < π/4 (positivity), so 0 ≠ π/4 by linarith. The contrast with leibniz_tendsto_pi_div_four is the entire pedagogical point: the ordered limit equals π/4, but the order-free tsum equals 0 — a conditionally convergent series simply has no unconditional sum, the analytic content of the Riemann rearrangement theorem.",
+    "mathContext": "$0 = \\sum'_k \\frac{(-1)^k}{2k+1} \\ne \\frac{\\pi}{4}$ since $\\frac{\\pi}{4}>0$. Ordered limit $\\ne$ tsum for conditionally convergent series.",
+    "significance": "key",
+    "relatedConcepts": ["Riemann rearrangement theorem", "conditional convergence", "ordered vs unordered sums"],
+    "prerequisites": ["positivity of π/4", "the junk-value corollary"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-10/meta.json
+++ b/src/data/proofs/basel-problem-oq-10/meta.json
@@ -22,6 +22,18 @@
   },
   "title": "Leibniz's Series for π — and Why It Is Only Conditional",
   "description": "The Leibniz–Madhava–Gregory series 1 − 1/3 + 1/5 − 1/7 + ⋯ converges to π/4, but only as an ordered limit of partial sums. The series is conditionally (not absolutely) convergent, so its Mathlib tsum/HasSum value is 0, not π/4 — a subtlety this entry makes precise.",
+  "overview": {
+    "historicalContext": "The alternating series 1 − 1/3 + 1/5 − 1/7 + ⋯ = π/4 is one of the oldest infinite series for π. It was discovered by the Kerala-school mathematician Mādhava of Sangamagrāma around 1400, rediscovered by James Gregory (1671) as a special case of his arctangent series, and published by Gottfried Wilhelm Leibniz in 1676 — hence the name 'Leibniz formula', though 'Madhava–Gregory–Leibniz' is the historically faithful attribution. It is the arctangent Taylor series arctan(x) = x − x³/3 + x⁵/5 − ⋯ evaluated at x = 1, where arctan(1) = π/4. Famously, the series converges agonizingly slowly: roughly 10^k terms are needed for k correct digits, so it is of theoretical rather than computational interest. Its conditional convergence makes it a classic cautionary example, going back to Dirichlet and Riemann's 19th-century work on rearrangement of series.",
+    "problemStatement": "The naive unconditional reading $\\sum'_{k} \\frac{(-1)^k}{2k+1} = \\frac{\\pi}{4}$ is FALSE in Mathlib. The Leibniz family $k \\mapsto \\frac{(-1)^k}{2k+1}$ is only conditionally convergent — its absolute values $\\frac{1}{2k+1}$ form a divergent harmonic-type series. Since Mathlib's `Summable` / `tsum` / `HasSum` demand unconditional (net) convergence, the family is not `Summable`, and `tsum` returns the junk value $0 \\ne \\pi/4$. The task is to make this precise: prove non-summability, derive the cautionary `tsum = 0` corollaries, and state the correct ordered-limit form.",
+    "proofStrategy": "Four results pin down the situation. (1) `leibniz_tendsto_pi_div_four` re-exports Mathlib's `tendsto_sum_pi_div_four`: the ORDERED partial sums ∑_{i<k} (-1)^i/(2i+1) → π/4. (2) `not_summable_leibniz` is the substantive new lemma: via `summable_abs_iff`, summability over ℝ is equivalent to absolute summability; the absolute values simplify to 1/(2k+1); a comparison `1/(2k+2) ≤ 1/(2k+1)` against the half-harmonic series (which equals ½·∑1/(k+1), a reindexed divergent harmonic series) shows the latter would have to be summable — contradiction with `not_summable_one_div_natCast`. (3) `tsum_leibniz_eq_zero` applies `tsum_eq_zero_of_not_summable`. (4) `tsum_leibniz_ne_pi_div_four` combines 0 ≠ π/4 (positivity) with (3).",
+    "keyInsights": [
+      "The headline lesson is a formalization subtlety, not new mathematics: in Mathlib `tsum`/`HasSum` mean UNCONDITIONAL convergence (convergence of the net over all finite subsets), which for real series coincides with absolute convergence. The Leibniz series, being only conditionally convergent, is therefore NOT `Summable` and its `tsum` is the default junk value 0.",
+      "This is exactly the analytic shadow of the Riemann rearrangement theorem: a conditionally convergent series can be reordered to sum to any value (or diverge), so no order-independent 'sum' exists — which is precisely why the unordered `tsum` cannot equal π/4.",
+      "Non-summability is proved by a comparison MINORANT, not a majorant: to show 1/(2k+1) is non-summable, one bounds it BELOW by the (still divergent) half-harmonic 1/(2k+2); the contrapositive of the comparison test then forces divergence.",
+      "The correct statement is a `Tendsto` of finite partial sums over `range k`, an inherently ORDERED object, contrasting with the order-free `tsum`. The gap between `Tendsto (∑_{i<k})` and `tsum` is the whole point of the entry.",
+      "The badge is 'mathlib' because the convergence π/4 itself is Mathlib's `tendsto_sum_pi_div_four` (proved there via Abel's limit theorem on the arctan series); the original contribution is the negative/cautionary half — the non-summability and the `tsum ≠ π/4` corollaries."
+    ]
+  },
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -71,6 +83,92 @@
         "description": "The harmonic series ∑ 1/n diverges (¬ Summable (fun n => 1/n : ℕ → ℝ)); the divergent minorant behind non-summability.",
         "module": "Mathlib.Analysis.PSeries"
       }
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: The Conditional-Convergence Subtlety",
+      "startLine": 3,
+      "endLine": 33,
+      "summary": "States the open question (formalize the Leibniz series for π/4) and immediately flags the trap: the naive tsum reading is false because the series is only conditionally convergent. Explains that Mathlib's Summable demands unconditional convergence, so the family is not Summable and its tsum is the junk value 0 ≠ π/4. Lists the four results and confirms 0 axioms / 0 sorries.",
+      "mathContext": "$\\sum_k \\frac{(-1)^k}{2k+1} = \\frac{\\pi}{4}$ holds only as $\\lim_k \\sum_{i<k}$; the unordered $\\sum'_k$ is $0$ because the family is not absolutely summable."
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and Opens",
+      "startLine": 35,
+      "endLine": 37,
+      "summary": "Opens BaselOQ10 and the Filter, Topology, BigOperators, Real, and Finset namespaces — supplying Tendsto/atTop/𝓝 notation, π, the range-sum notation, and the summability API used throughout.",
+      "mathContext": "Brings `Tendsto`, `atTop`, `𝓝`, `π`, `∑ i ∈ range k`, and `Summable` into scope."
+    },
+    {
+      "id": "correct-form",
+      "title": "leibniz_tendsto_pi_div_four: The Correct (Ordered) Statement",
+      "startLine": 39,
+      "endLine": 44,
+      "summary": "The statement that actually holds: the ordered partial sums ∑_{i<k} (-1)^i/(2i+1) tend to π/4. A direct re-export of Mathlib's tendsto_sum_pi_div_four (proved there via Abel's limit theorem applied to the arctan Maclaurin series at x = 1).",
+      "mathContext": "$\\displaystyle \\lim_{k\\to\\infty} \\sum_{i<k} \\frac{(-1)^i}{2i+1} = \\frac{\\pi}{4} = \\arctan 1$."
+    },
+    {
+      "id": "not-summable",
+      "title": "not_summable_leibniz: The Substantive New Lemma",
+      "startLine": 46,
+      "endLine": 72,
+      "summary": "Proves the Leibniz family is not Summable. Uses summable_abs_iff to reduce to absolute summability; rewrites |(-1)^k/(2k+1)| = 1/(2k+1) via abs_div/abs_pow/abs_neg; then assumes summability and derives a contradiction by a minorant comparison: 1/(2k+2) ≤ 1/(2k+1) would make the half-harmonic series 1/(2k+2) summable, equal (after scaling by 2 and reindexing) to the harmonic series ∑1/n, contradicting not_summable_one_div_natCast.",
+      "mathContext": "$\\left|\\frac{(-1)^k}{2k+1}\\right| = \\frac{1}{2k+1} \\ge \\frac{1}{2k+2} = \\frac12\\cdot\\frac{1}{k+1}$; the harmonic minorant diverges, so the family is not summable."
+    },
+    {
+      "id": "tsum-zero",
+      "title": "tsum_leibniz_eq_zero: The Junk Value",
+      "startLine": 74,
+      "endLine": 78,
+      "summary": "Because the family is not summable, tsum_eq_zero_of_not_summable gives ∑' k, (-1)^k/(2k+1) = 0 — the default value Mathlib assigns to the tsum of a non-summable family.",
+      "mathContext": "$\\sum'_k \\frac{(-1)^k}{2k+1} = 0$ by the non-summable convention, NOT $\\pi/4$."
+    },
+    {
+      "id": "tsum-ne",
+      "title": "tsum_leibniz_ne_pi_div_four: The Naive Reading Is False",
+      "startLine": 80,
+      "endLine": 88,
+      "summary": "Concludes ∑' k, (-1)^k/(2k+1) ≠ π/4 by rewriting with the junk value 0 and noting 0 < π/4 (positivity) gives 0 ≠ π/4. This is the cautionary punchline: the unconditional reading of the Leibniz formula is literally false in Mathlib's tsum semantics.",
+      "mathContext": "$0 = \\sum'_k \\frac{(-1)^k}{2k+1} \\ne \\frac{\\pi}{4}$ since $\\frac{\\pi}{4} > 0$."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "not_summable_leibniz",
+      "type": "main",
+      "description": "The Leibniz family (-1)^k/(2k+1) is not Summable: its absolute values 1/(2k+1) dominate the divergent half-harmonic series, so convergence is only conditional. The substantive original contribution.",
+      "leanType": "¬ Summable (fun k : ℕ => (-1 : ℝ) ^ k / (2 * k + 1))"
+    },
+    {
+      "name": "leibniz_tendsto_pi_div_four",
+      "type": "main",
+      "description": "The correct Leibniz statement: the ordered partial sums ∑_{i<k} (-1)^i/(2i+1) converge to π/4. Re-exports Mathlib's tendsto_sum_pi_div_four.",
+      "leanType": "Tendsto (fun k => ∑ i ∈ range k, (-1 : ℝ) ^ i / (2 * i + 1)) atTop (𝓝 (π / 4))"
+    },
+    {
+      "name": "tsum_leibniz_eq_zero",
+      "type": "corollary",
+      "description": "Because the family is not summable, its tsum collapses to the junk value 0.",
+      "leanType": "∑' k : ℕ, (-1 : ℝ) ^ k / (2 * k + 1) = 0"
+    },
+    {
+      "name": "tsum_leibniz_ne_pi_div_four",
+      "type": "corollary",
+      "description": "The naive unconditional reading 1 − 1/3 + 1/5 − ⋯ = π/4 is false: the tsum is 0 ≠ π/4; only the ordered limit holds.",
+      "leanType": "∑' k : ℕ, (-1 : ℝ) ^ k / (2 * k + 1) ≠ π / 4"
+    }
+  ],
+  "conclusion": {
+    "summary": "The Leibniz–Madhava–Gregory series for π/4 is formalized correctly as an ordered limit of partial sums (Mathlib's tendsto_sum_pi_div_four), together with the substantive negative result that the underlying family is not Summable. The non-summability is proved by a harmonic minorant comparison after reducing to absolute summability. As corollaries, the unordered tsum equals the junk value 0 and is therefore ≠ π/4, so the naive 'unconditional' reading of the formula is literally false. Fully machine-checked, 0 axioms, 0 sorries.",
+    "implications": "The entry sharpens a recurring formalization pitfall: in Mathlib, tsum/HasSum/Summable encode UNCONDITIONAL (net) convergence, which for real series is absolute convergence — so any conditionally convergent series (Leibniz for π/4, the alternating harmonic series for ln 2, etc.) has tsum 0 and must be stated via Tendsto of ordered partial sums. This is the constructive face of the Riemann rearrangement theorem. It also sets up a clean contrast within the Basel cluster: ζ(2) = ∑1/n² = π²/6 is absolutely convergent (its tsum genuinely equals π²/6), whereas the Leibniz series is not.",
+    "openQuestions": [
+      "Quantify the conditional convergence: prove the alternating-series error bound |∑_{i<k} (-1)^i/(2i+1) − π/4| ≤ 1/(2k+1), giving an explicit (slow) rate (tracked as basel-problem-oq-10-oq-01).",
+      "Formalize a Riemann-rearrangement instance for this specific series: exhibit a permutation of ℕ for which the rearranged ordered partial sums converge to a value other than π/4, concretely witnessing why no unconditional sum exists.",
+      "State and prove the analogous cautionary pair for the alternating harmonic series ∑ (-1)^{n+1}/n (ordered limit ln 2, tsum 0), unifying the conditional-convergence pitfall into a reusable lemma.",
+      "Can a `HasSum`-style API over a fixed summation order (e.g. an ordered/Abel-summation typeclass) be introduced so conditionally convergent series have a faithful unconditional-looking statement?"
     ]
   },
   "openQuestions": [


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-10` (quality 0, passes 0). The entry had `meta`, `references`, `crossReferences`, and `openQuestions` but no `overview`, `sections`, `conclusion`, or annotations.

## Changes
- **overview**: added structured `ProofOverview` — `historicalContext` (Madhava ~1400, Gregory 1671, Leibniz 1676; arctan(1)=π/4; slow convergence; Dirichlet/Riemann rearrangement lineage), `problemStatement`, `proofStrategy`, 5 `keyInsights` on Mathlib's unconditional `tsum` semantics vs. conditional convergence.
- **sections**: 6 sections covering the full 93-line Lean file (docstring, opens, the correct ordered-limit form, the non-summability lemma, the two cautionary `tsum` corollaries), each with `mathContext`.
- **mainTheorems**: 4 entries with `leanType` signatures.
- **conclusion**: structured `summary` / `implications` / 4 `openQuestions` (error-bound rate, an explicit Riemann-rearrangement witness, the alternating-harmonic analogue, an ordered-summation API).
- **annotations.json**: created with 6 annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Axiom integrity
Verified against the Lean source: 0 `axiom` declarations, 0 sorries, no `native_decide`. `badge: mathlib` is accurate — the π/4 convergence is Mathlib's `tendsto_sum_pi_div_four`; the original contribution is the non-summability / `tsum ≠ π/4` half.

`pnpm build` passes.