### PR TITLE
audit(amgm-inequality-oq-02-oq-01-oq-01): badge original→mathlib (Tier B re-export)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "elementary-symmetric-polynomials",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: amgm-inequality-oq-02-oq-01-oq-01 — *"The Full Newton–Girard Recurrence over Any Number of Variables"*
**Severity**: MEDIUM (Mathlib wrapper carrying an `original` badge)

### Problem

Badge was `original`, but the file is a Tier B re-export. Three of its four theorems are verbatim term-mode aliases of Mathlib lemmas:

| Entry theorem | Mathlib source |
|---|---|
| `newton_esymm_recurrence` | `:= mul_esymm_eq_sum σ R k` |
| `newton_psum_recurrence` (the OQ's headline target) | `:= psum_eq_mul_esymm_sub_sum σ R k hk` |
| `newton_sum_zero` | `:= sum_antidiagonal_card_esymm_psum_eq_zero σ R` |

The fourth, `psum_one_eq_esymm_one`, is `by rw [psum_one, esymm_one]`. The titular "full Newton–Girard recurrence" **is** Mathlib's `psum_eq_mul_esymm_sub_sum`, restated verbatim.

### Evidence

The file's own docstring and `assumptions` field already concede this: *"Mathlib in fact proves the identities in full generality… This file packages those."* Only the **badge** overclaims (`original` is forbidden for Tier B).

### Fix

`badge: "original" → "mathlib"`. Status stays `verified` (0-sorry, 0-axiom, no `native_decide`). Prose, `assumptions`, and `originalContributions` (already worded as "gallery-form statement of…", "the OQ's target") are left unchanged.

---
Discovered during gallery integrity audit.