### PR TITLE
audit(amgm-inequality-oq-02-oq-03-oq-03-oq-03): badge verified→mathlib (Tier B Jensen specialization)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
   "slug": "amgm-inequality-oq-02-oq-03-oq-03-oq-03",
   "title": "Power-Mean Inequality: Mₚ ≤ M_q for 0 < p ≤ q",
-  "description": "Proves the unweighted power-mean (generalized mean) inequality Mₚ ≤ M_q for positive exponents 0 < p ≤ q — the case Mathlib's MeanInequalities lists as a TODO. Answers the parent open question on generalizing the Maclaurin chain to Lᵖ means, and corrects its stated direction (power means increase, not decrease, in the exponent). Fully verified (0 axioms, 0 sorries).",
+  "description": "Derives the unweighted power-mean (generalized mean) inequality Mₚ ≤ M_q for positive exponents 0 < p ≤ q — the case Mathlib's MeanInequalities lists as a TODO — by specialising Mathlib's weighted Jensen inequality (NNReal.rpow_arith_mean_le_arith_mean_rpow) to uniform weights 1/|s|. Defines the unweighted power mean and provides the bridge from weighted Jensen to its unweighted monotonicity; the inequality's analytic content (convexity of t↦t^r for r≥1) is Mathlib's. Answers the parent open question on generalizing the Maclaurin chain to Lᵖ means, and corrects its stated direction (power means increase, not decrease, in the exponent). 0 axioms, 0 sorries (core inequality via Mathlib's Jensen).",
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03OQ03",
     "lineCount": 128,
@@ -109,7 +109,7 @@
       "jensen",
       "convexity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: amgm-inequality-oq-02-oq-03-oq-03-oq-03 — *"Power-Mean Inequality: Mₚ ≤ M_q for 0 < p ≤ q"*
**Severity**: MEDIUM (Mathlib wrapper carrying a `verified` badge + delegation opacity)

### Problem

The headline `powerMean_le_powerMean` obtains its entire inequality content from a single Mathlib call:

```lean
have key := NNReal.rpow_arith_mean_le_arith_mean_rpow
  s (fun _ => n⁻¹) (fun i => (x i) ^ p) hw hr   -- weighted Jensen at uniform weights
```

The remaining ~25 lines are algebraic bookkeeping (weights sum to 1, exponent simplification `((xᵢ)^p)^{q/p} = (xᵢ)^q`, raising to `1/q`) to massage Mathlib's weighted Jensen into the `powerMean` definition. The deep analytic content — convexity of `t ↦ t^r` for `r ≥ 1` — is entirely Mathlib's. This is Tier B (failure mode #5: main result obtained by calling a deep Mathlib theorem), where the badge must be `mathlib`, not `verified`.

The two other theorems (`arithMean_le_quadraticMean`, `powerMean_mono`) are one-line specializations of the headline.

### Evidence

- The Lean docstring already concedes the dependency ("specialises `NNReal.rpow_arith_mean_le_arith_mean_rpow` … to the uniform weights `1/|s|`").
- The public `description` did **not** name that dependency — it led with *"Proves the unweighted power-mean inequality … Fully verified"* (delegation opacity, failure mode #1).

### Fix

- `badge: "verified" → "mathlib"`.
- Rewrote the `description` to lead with the Mathlib Jensen reliance and state the analytic content is Mathlib's.
- Status stays `verified` — the file is genuinely 0-sorry, 0-axiom, no `native_decide`, and the unweighted case is a real, useful gap (Mathlib `MeanInequalities` TODO). `originalContributions` (the `powerMean` definition + the specialization) are honestly worded and left unchanged.

---
Discovered during gallery integrity audit.