### PR TITLE
Enrich Explicit Transitive Point of the Shift (Universal Sequence)

### DIFF
--- a/src/data/proofs/furstenberg-correspondence-oq-01-incomplete-01-oq-01/annotations.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01-incomplete-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-furstenberg-trans-overview",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "Mixing vs. Birkhoff Transitivity: Why a Single Universal Point Is Stronger",
+    "content": "The docstring sets up the gap this file closes. The parent proves topological transitivity in MIXING form: for each pair of nonempty open sets U, V it builds a bridge point of U whose orbit enters V — a separate witness per target. Birkhoff transitivity is the uniform strengthening: one point z whose entire forward orbit is dense, approximating every configuration at once. On a perfect Polish space like Cantor space these are equivalent (Birkhoff's theorem, with the transitive points forming a comeager set by Baire category), but the abstract theorem is non-constructive. This file gives the explicit witness: a disjunctive/universal sequence in which every finite word occurs as a factor.",
+    "mathContext": "Mixing: $\\forall U,V\\ \\exists x\\in U,\\ \\exists t,\\ T^t x\\in V$. Transitive point: $\\exists z\\ \\forall U\\ \\exists t,\\ T^t z\\in U$, i.e. $\\overline{\\{T^t z\\}} = X$.",
+    "significance": "key",
+    "relatedConcepts": ["Birkhoff transitivity", "topological mixing", "dense orbit", "Baire category theorem", "disjunctive sequence"],
+    "prerequisites": ["topological dynamics", "symbolic dynamics", "Cantor space"]
+  },
+  {
+    "id": "ann-furstenberg-trans-enum",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 58, "endLine": 63 },
+    "type": "definition",
+    "title": "enum: A Surjective Enumeration of All Finite Words",
+    "content": "enum k = (Encodable.decode (α := List Bool) k).getD [] enumerates every finite binary word by decoding the natural number k against the Encodable instance on List Bool (falling back to the empty word when decode returns none). enum_surjective proves every word w is hit — take k = Encodable.encode w, and Encodable.encodek (decode (encode w) = some w) makes enum k reduce to w. This surjectivity is the ONLY existence input to the entire construction; everything downstream is explicit concatenation.",
+    "mathContext": "List Bool is countable (Encodable), so there is a surjection $\\mathbb{N} \\twoheadrightarrow \\text{List Bool}$. $\\mathrm{enum}(\\mathrm{encode}\\,w) = w$ via $\\mathrm{decode}\\circ\\mathrm{encode} = \\mathrm{some}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Encodable", "countability", "surjection", "decode/encode"],
+    "prerequisites": ["countable sets", "Encodable.encodek"]
+  },
+  {
+    "id": "ann-furstenberg-trans-block-offset",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 69, "endLine": 96 },
+    "type": "insight",
+    "title": "Padded Blocks Force Offsets to Grow",
+    "content": "block k = enum k ++ [false] appends one separator bit so that every block has length ≥ 1 (block_length). The running concatenation concatPrefix k = block 0 ++ ⋯ ++ block (k-1) has length offset k. The crucial consequence is le_offset: k ≤ offset k, proved by induction using offset_succ (offset (k+1) = offset k + (enum k).length + 1). Because offsets grow at least linearly, any bit index n is eventually inside a finite concatenation — which is what makes the infinite sequence well-defined pointwise. Without the pad, empty words would stall the offsets.",
+    "mathContext": "$\\mathrm{offset}(k+1) = \\mathrm{offset}\\,k + |\\mathrm{enum}\\,k| + 1$, hence $k \\le \\mathrm{offset}\\,k$; offsets are strictly increasing because every block is nonempty.",
+    "significance": "supporting",
+    "relatedConcepts": ["concatenation", "padding", "monotone offsets", "induction"],
+    "prerequisites": ["list length arithmetic", "induction on ℕ"]
+  },
+  {
+    "id": "ann-furstenberg-trans-stability",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 114, "endLine": 135 },
+    "type": "technique",
+    "title": "Prefix Stability: The Infinite Concatenation Is Well-Defined",
+    "content": "getD_concatPrefix_stable shows that whenever an index n is realized in two finite concatenations (n < offset a and n < offset b), they agree at n. The proof uses the nesting lemma concatPrefix_prefix (the longer concatenation extends the shorter, concatPrefix b = concatPrefix a ++ t) and List.getD_append (indexing within the left part ignores the tail). The universal sequence is then z n = (concatPrefix (n+1)).getD n false, and z_eq lifts stability: bit n may be read from concatPrefix N for ANY N with n < offset N. This is exactly the well-definedness one needs to treat the infinite concatenation as a genuine point of Cantor space.",
+    "mathContext": "If $n < \\mathrm{offset}\\,a$ and $n < \\mathrm{offset}\\,b$ then $(\\mathrm{concatPrefix}\\,a)[n] = (\\mathrm{concatPrefix}\\,b)[n]$; so $z(n)$ is independent of the chosen prefix.",
+    "significance": "supporting",
+    "relatedConcepts": ["well-definedness", "List.getD_append", "nested prefixes", "pointwise limit"],
+    "prerequisites": ["list indexing (getD)", "append lemmas"]
+  },
+  {
+    "id": "ann-furstenberg-trans-occ",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 137, "endLine": 147 },
+    "type": "lemma",
+    "title": "occ: Locating enum k Verbatim Inside z",
+    "content": "The occurrence lemma: z (offset k + j) = (enum k).getD j false for every j < (enum k).length. The proof reads bit offset k + j from concatPrefix (k+1) (valid since offset k + j < offset (k+1)), splits off block k via List.getD_append_right, simplifies the shifted index offset k + j − offset k = j with omega, and finally uses List.getD_append to drop the padding bit and land in enum k. This is the precise bridge from the abstract enumeration to concrete factor occurrences in the sequence.",
+    "mathContext": "For $j < |\\mathrm{enum}\\,k|$: $z(\\mathrm{offset}\\,k + j) = (\\mathrm{enum}\\,k)[j]$ — the word $\\mathrm{enum}\\,k$ occupies positions $[\\mathrm{offset}\\,k,\\ \\mathrm{offset}\\,k+|\\mathrm{enum}\\,k|)$ of $z$.",
+    "significance": "key",
+    "relatedConcepts": ["factor occurrence", "List.getD_append_right", "index arithmetic", "block decomposition"],
+    "prerequisites": ["list append indexing", "offset arithmetic"]
+  },
+  {
+    "id": "ann-furstenberg-trans-disjunctive",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 153, "endLine": 160 },
+    "type": "theorem",
+    "title": "disjunctive: Every Finite Word Occurs as a Factor",
+    "content": "The combinatorial heart: for every finite word w there is a start position t at which z reads off w. Given w, enum_surjective produces k with enum k = w; taking t = offset k and applying occ gives z (offset k + i) = w.getD i false for all i < w.length. This is the definition of a disjunctive (universal) sequence — and it is the topological skeleton of a normal number, which additionally controls the frequency of each word, not merely its presence.",
+    "mathContext": "$\\forall w\\ \\exists t\\ \\forall i<|w|:\\ z(t+i) = w[i]$. Disjunctivity (every block appears) is the qualitative core of normality (every block appears with frequency $2^{-|w|}$).",
+    "significance": "key",
+    "relatedConcepts": ["disjunctive sequence", "normal number", "universal sequence", "Champernowne construction"],
+    "prerequisites": ["the occurrence lemma", "surjectivity of enum"]
+  },
+  {
+    "id": "ann-furstenberg-trans-orbit-mem",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 162, "endLine": 172 },
+    "type": "technique",
+    "title": "orbit_mem: Disjunctivity ⟹ the Orbit Enters Every Open Set",
+    "content": "Converts the combinatorial property into a topological one. Given a nonempty open U, pick y ∈ U and shrink to a prefix cylinder of depth m around y (exists_cyl_subset from the parent). Realize that length-m prefix as enum k via enum_surjective, then shift^[offset k] z agrees with y on the first m coordinates (shift_iterate + occ + prefixWord_getD), so it lands in the cylinder, hence in U. This is where the reused word-cylinder neighbourhood basis does its work.",
+    "mathContext": "Cylinders $\\mathrm{Cyl}(w) = \\{x : x\\restriction|w| = w\\}$ form a basis; $T^{\\mathrm{offset}\\,k} z$ matches the chosen prefix, so it enters any cylinder, hence any nonempty open set.",
+    "significance": "supporting",
+    "relatedConcepts": ["cylinder sets", "neighbourhood basis", "shift iterate", "open cover"],
+    "prerequisites": ["product topology on Cantor space", "parent's cylinder API"]
+  },
+  {
+    "id": "ann-furstenberg-trans-dense",
+    "proofId": "furstenberg-correspondence-oq-01-incomplete-01-oq-01",
+    "range": { "startLine": 174, "endLine": 192 },
+    "type": "theorem",
+    "title": "dense_orbit / exists_transitive_point: The Explicit Transitive Point",
+    "content": "dense_orbit concludes the forward orbit {shift^[t] z} is dense, via dense_iff_inter_open (density ⟺ meeting every nonempty open set) fed by orbit_mem. exists_transitive_point packages this as ∃ x, Dense (range (shift^[·] x)), witnessed by z. The closing #print axioms confirms the result depends only on the foundational propext / Classical.choice / Quot.sound — no extra axioms, no sorries. This is the constructive Birkhoff transitive point that strengthens the parent's per-target mixing witness.",
+    "mathContext": "$\\mathrm{Dense}(\\{T^t z\\}) \\iff \\forall U\\ \\text{open nonempty},\\ \\{T^t z\\}\\cap U \\ne \\varnothing$. Axiom audit: only propext, Classical.choice, Quot.sound.",
+    "significance": "key",
+    "relatedConcepts": ["dense_iff_inter_open", "Birkhoff transitivity", "axiom audit", "constructive existence"],
+    "prerequisites": ["density in topological spaces", "orbit_mem"]
+  }
+]

--- a/src/data/proofs/furstenberg-correspondence-oq-01-incomplete-01-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01-incomplete-01-oq-01/meta.json
@@ -93,34 +93,78 @@
       "description": "Topological-recurrence structure of the same shift system whose measure-theoretic side the parent develops"
     }
   ],
-  "overview": "The parent file establishes that the shift T(x)(n) = x(n+1) on Cantor space is chaotic in the sense of Devaney, with topological transitivity stated in mixing form: for each pair of nonempty open sets U, V it produces an ad-hoc point of U whose orbit later enters V. Birkhoff transitivity asks for something uniform and stronger — a SINGLE point whose entire forward orbit is dense, simultaneously approximating every configuration. This entry constructs such a transitive point explicitly. The idea is the classical universal (disjunctive) sequence: enumerate all finite binary words via Encodable, then concatenate them into one infinite sequence z = block 0 ++ block 1 ++ block 2 ++ …, where each block is a word followed by a single padding bit (so blocks are nonempty and the n-th bit of z is always read from a finite prefix). Because the enumeration is surjective, every word w equals enum k for some k and therefore appears verbatim in z at the offset where block k begins — z is disjunctive. Given any nonempty open set U, shrink it to a prefix cylinder, realize that prefix as some enum k, and the shift T^{offset k} z lands in U. Hence the orbit of z meets every nonempty open set and is dense. The construction reuses the parent's word-cylinder neighbourhood basis and is verified with no axioms or sorries.",
+  "overview": {
+    "historicalContext": "The notion of a transitive point — a single point whose forward orbit is dense — goes back to George D. Birkhoff's foundational *Dynamical Systems* (1927), where topological transitivity entered the qualitative theory of dynamics. Birkhoff's transitivity theorem says that on a perfect, separable, complete metric space (such as Cantor space) a system is topologically transitive iff it possesses such a point; the residual (comeager) set of transitive points is guaranteed abstractly by the Baire category theorem. The shift map on a finite-alphabet sequence space is the prototypical chaotic system in Robert Devaney's influential *An Introduction to Chaotic Dynamical Systems* (1989), and its transitive points are exactly the *disjunctive* (or *universal*) sequences — sequences containing every finite word as a factor. These are the topological cousins of Émile Borel's *normal numbers* (1909): where normality is a measure-theoretic statement about asymptotic digit frequencies, disjunctivity is the purely combinatorial requirement that every block appears at all. The explicit 'concatenate all words' construction used here is the symbolic analogue of the Champernowne (1933) and Copeland–Erdős (1946) constructions of normal numbers. Hillel Furstenberg's *Recurrence in Ergodic Theory and Combinatorial Number Theory* (1981) places such symbolic-recurrence objects at the heart of the correspondence principle linking dynamics to combinatorial number theory.",
+    "problemStatement": "The parent entry proves the shift $T(x)(n) = x(n+1)$ on Cantor space $\\{0,1\\}^{\\mathbb{N}}$ is chaotic in Devaney's sense, with topological transitivity stated in MIXING form: for each pair of nonempty open sets $U, V$ it exhibits a target-dependent bridge point of $U$ whose orbit later enters $V$. The stronger Birkhoff form — listed by the parent as its first 'next step' — asks for a single UNIFORM witness: one point $z$ whose entire forward orbit $\\{T^t z : t \\in \\mathbb{N}\\}$ is dense, simultaneously approximating every configuration. The task is to construct such a transitive point explicitly and verify density with no axioms or sorries.",
+    "proofStrategy": "The witness is the classical universal (disjunctive) sequence. Enumerate all finite binary words surjectively via Encodable (List Bool) as enum : ℕ → List Bool, then form z = block 0 ++ block 1 ++ block 2 ++ ⋯ where block k = enum k ++ [false]; the one-bit pad makes every block nonempty, so bit n of z can always be read from a finite prefix concatPrefix (n+1). Prefix-stability lemmas show this reading is independent of which sufficiently long finite concatenation is used. The occurrence lemma (occ) then locates enum k verbatim inside z at offset k; surjectivity of enum upgrades this to disjunctive: every finite word occurs as a factor. For density, reduce a nonempty open U to a prefix cylinder (the parent's word-cylinder basis), realize that prefix as some enum k, and conclude shift^[offset k] z ∈ U via orbit_mem; dense_iff_inter_open then yields dense_orbit and exists_transitive_point.",
+    "keyInsights": [
+      "A transitive point is a strictly UNIFORM strengthening of mixing: mixing supplies a fresh, target-dependent starting point for each pair (U, V); a transitive point is one orbit that is dense against ALL targets at once. Birkhoff's theorem makes the two equivalent on Cantor space, but exhibiting the explicit sequence is the constructive content.",
+      "The whole construction rests on a single countability fact: the set of finite words List Bool is countable (Encodable). Surjectivity of the enumeration enum is the only 'existence' input — everything else is explicit concatenation and indexing arithmetic.",
+      "The one-bit padding (block k = enum k ++ [false]) is not cosmetic: it guarantees every block has length ≥ 1, forcing offsets to grow (k ≤ offset k), which is exactly what makes the infinite concatenation well-defined pointwise — bit n is always already realized in concatPrefix (n+1).",
+      "Disjunctivity is the combinatorial heart and density is its topological shadow: 'every finite word occurs as a factor' translates directly, via the cylinder neighbourhood basis, into 'the orbit enters every nonempty open set'. The proof never leaves the symbolic/combinatorial level.",
+      "This is the topological analogue of a normal number: disjunctivity (every block appears) is the qualitative skeleton of normality (every block appears with the right asymptotic frequency). The concatenation construction mirrors Champernowne's and Copeland–Erdős's explicit normal numbers."
+    ]
+  },
   "sections": [
     {
-      "id": "enumeration",
-      "title": "A Surjective Enumeration of All Finite Words",
-      "startLine": 55,
-      "endLine": 64,
-      "summary": "enum k = (decode k).getD [] enumerates all finite binary words via Encodable (List Bool); enum_surjective shows every word is hit, using Encodable.encodek.",
-      "mathContext": "Countability of the set of finite words is the combinatorial input that makes a single universal sequence possible."
+      "id": "header",
+      "title": "Module Docstring: From Mixing to Birkhoff Transitivity",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Contrasts the parent's mixing-form transitivity (a target-dependent bridge point per pair U, V) with the stronger Birkhoff statement proved here: a single point z with dense forward orbit. Sketches the universal/disjunctive-sequence construction and notes the 0-axiom, 0-sorry status.",
+      "mathContext": "A transitive point is a uniform witness; on a perfect Polish space (Cantor space) Birkhoff's theorem makes transitivity equivalent to existence of a dense orbit. Disjunctive sequence = every finite word occurs as a factor."
     },
     {
-      "id": "universal-sequence",
-      "title": "The Universal (Disjunctive) Sequence",
-      "startLine": 66,
-      "endLine": 148,
-      "summary": "Padded blocks block k = enum k ++ [false], their running concatenation concatPrefix and offsets offset, prefix stability (concatPrefix_prefix, getD_concatPrefix_stable, z_eq), the sequence z itself, and the occurrence lemma occ: enum k appears in z at offset k.",
-      "mathContext": "Concatenating an enumeration of all words yields a sequence containing every word; padding keeps offsets growing so the infinite concatenation is well-defined pointwise."
+      "id": "imports",
+      "title": "Imports, Namespace, and Reused Parent API",
+      "startLine": 47,
+      "endLine": 52,
+      "summary": "Imports Mathlib and the parent Proofs.FurstenbergShiftChaos, opening FurstenbergShiftChaos to reuse the Cantor type, shift map, word cylinders, and the neighbourhood-basis lemmas (exists_cyl_subset, mem_Cyl_prefixWord_iff, prefixWord, shift_iterate).",
+      "mathContext": "Building on the parent's word-cylinder basis keeps the new content focused on the combinatorics of the universal sequence."
+    },
+    {
+      "id": "enumeration",
+      "title": "Part I — A Surjective Enumeration of All Finite Words",
+      "startLine": 54,
+      "endLine": 64,
+      "summary": "enum k = (Encodable.decode k).getD [] enumerates all finite binary words via Encodable (List Bool); enum_surjective shows every word is hit, using Encodable.encodek (decode (encode w) = some w).",
+      "mathContext": "Countability of the set of finite words (List Bool is Encodable) is the sole existence input that makes one universal sequence possible."
+    },
+    {
+      "id": "blocks-offsets",
+      "title": "Part II.a — Padded Blocks, Concatenations, and Offsets",
+      "startLine": 65,
+      "endLine": 112,
+      "summary": "Defines block k = enum k ++ [false] (one-bit pad → length ≥ 1), the running concatenation concatPrefix, and offset k = length of concatPrefix k. Establishes offset_succ, le_offset (k ≤ offset k, so offsets grow), and the nesting lemmas concatPrefix_add / concatPrefix_prefix (a longer concatenation extends a shorter one).",
+      "mathContext": "Padding forces offsets to grow at least linearly ($k \\le \\mathrm{offset}\\,k$), guaranteeing every bit index is eventually realized in a finite prefix."
+    },
+    {
+      "id": "prefix-stability",
+      "title": "Part II.b — Prefix Stability and the Universal Sequence z",
+      "startLine": 113,
+      "endLine": 147,
+      "summary": "getD_concatPrefix_stable: a bit realized in two finite concatenations has the same value in both. Defines z n = (concatPrefix (n+1)).getD n false and proves z_eq (bit n may be read from any sufficiently long prefix) and the occurrence lemma occ: enum k appears verbatim in z starting at offset k.",
+      "mathContext": "Well-definedness of the infinite concatenation: $z(n)$ is independent of which finite prefix (past index $n$) it is read from; $\\mathrm{enum}\\,k$ sits in $z$ at $[\\mathrm{offset}\\,k,\\ \\mathrm{offset}\\,k + |\\mathrm{enum}\\,k|)$."
     },
     {
       "id": "transitive-point",
-      "title": "z Is Disjunctive and Its Orbit Is Dense",
-      "startLine": 150,
+      "title": "Part III — z Is Disjunctive and Its Orbit Is Dense",
+      "startLine": 149,
       "endLine": 192,
-      "summary": "disjunctive: every finite word occurs as a factor of z. orbit_mem: some iterate of z enters any nonempty open set. dense_orbit / exists_transitive_point: the forward orbit of z is dense — an explicit Birkhoff transitive point.",
-      "mathContext": "A dense orbit is the defining property of a transitive point; the explicit universal sequence makes Birkhoff transitivity constructive."
+      "summary": "disjunctive: every finite word occurs as a factor of z (via enum_surjective + occ). orbit_mem: some iterate shift^[t] z enters any nonempty open U (reduce U to a prefix cylinder, realize the prefix as enum k, apply occ). dense_orbit and exists_transitive_point: the forward orbit of z is dense — an explicit Birkhoff transitive point. Ends with #print axioms confirming only propext / Classical.choice / Quot.sound.",
+      "mathContext": "$\\mathrm{dense\\_iff\\_inter\\_open}$ reduces density to 'the orbit meets every nonempty open set', which disjunctivity supplies through the cylinder basis."
     }
   ],
-  "conclusion": "The shift on Cantor space has an explicit transitive point: the universal sequence z formed by concatenating all finite binary words. Every finite word occurs as a factor of z (z is disjunctive), so the forward orbit of z meets every nonempty open set and is therefore dense. This upgrades the parent's mixing condition — a separate, target-dependent witness for each pair of open sets — to a single uniform universal point, the constructive content of Birkhoff transitivity. The whole development is machine-checked with 0 axioms and 0 sorries, reusing the parent's word-cylinder neighbourhood basis.",
+  "conclusion": {
+    "summary": "The shift on Cantor space has an explicit Birkhoff transitive point: the universal sequence z built by concatenating padded blocks enum 0, enum 1, … that enumerate all finite binary words. Surjectivity of the enumeration plus the occurrence lemma show z is disjunctive (every finite word occurs as a factor), and via the word-cylinder neighbourhood basis this makes the forward orbit of z meet every nonempty open set, hence dense. The development is fully machine-checked with 0 axioms and 0 sorries, reusing only the parent's cylinder API.",
+    "implications": "This upgrades the parent's mixing condition — a separate, target-dependent witness for each pair of open sets — to a single uniform universal point, delivering the constructive content of Birkhoff's transitivity theorem on Cantor space (where the abstract theorem only guarantees a comeager set of such points via Baire category). It also formalizes the topological skeleton of normality: disjunctive sequences are the qualitative core of Borel normal numbers, and the concatenation construction is the symbolic analogue of the Champernowne and Copeland–Erdős normal numbers. The transitive point is the topological-recurrence object dual to the measure-theoretic side of the Furstenberg correspondence.",
+    "openQuestions": [
+      "Strengthen disjunctivity to full normality: equip Cantor space with the (1/2,1/2)-Bernoulli measure and prove a concatenation sequence in which every word of length n appears with asymptotic frequency 2^{-n}, recovering a Champernowne-style normal sequence.",
+      "Quantify recurrence: bound the gap function — for each word w, the maximal spacing between consecutive occurrences of w in z — turning the qualitative 'occurs as a factor' into an explicit recurrence rate.",
+      "Generalize the alphabet from {0,1} to an arbitrary finite (or countable) alphabet, and to two-sided shifts, isolating exactly where Encodability of finite words is used.",
+      "Connect to the measure-theoretic Furstenberg correspondence: derive a multiple-recurrence statement for z and relate it to the combinatorial consequences (e.g. Szemerédi-type configurations) that the correspondence principle extracts."
+    ]
+  },
   "leanFile": {
     "path": "Proofs/FurstenbergShiftTransitive.lean",
     "lineCount": 192,


### PR DESCRIPTION
Enrichment pass for `furstenberg-correspondence-oq-01-incomplete-01-oq-01` (quality **6 → 100**, passes 0).

## Changes
- **overview**: converted from a flat string to structured `ProofOverview` — added `historicalContext` (Birkhoff 1927 transitive points, Devaney chaos, Borel normal numbers, the Champernowne / Copeland–Erdős concatenation analogy, Furstenberg's correspondence), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **conclusion**: converted from a flat string to structured `ProofConclusion` — `summary`, `implications`, 4 `openQuestions` (full normality, recurrence-rate bounds, alphabet generalization, the measure-theoretic correspondence link).
- **sections**: expanded 3 → 6, now covering the full 192-line Lean file (docstring, imports/reused parent API, enumeration, blocks+offsets, prefix-stability+z, the disjunctive/dense-orbit finale), each with `mathContext`.
- **annotations.json**: created with 8 annotations, every one carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Schema fix
`overview` and `conclusion` were stored as plain strings (which score 0 and do not match the `ProofOverview`/`ProofConclusion` interfaces); now corrected to the structured form. Quality score went from 6 to a full 100 across all rubric categories.

## Axiom integrity
Verified against the Lean source: 0 `axiom` declarations, 0 sorries, no `native_decide`; `#print axioms exists_transitive_point` reports only propext / Classical.choice / Quot.sound. `status: verified` / `badge: original` / `axiomCount: 0` are accurate.

`pnpm build` passes.