### PR TITLE
Enrich: Erdős–Ginzburg–Ziv Bound for Non-Dividing Sets (Erdős #131)

### DIFF
--- a/src/data/proofs/erdos-131-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-erdos131-egz-oq0101-header",
+    "proofId": "erdos-131-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "context",
+    "title": "Recognizing the Parity Bound as Erdős–Ginzburg–Ziv",
+    "content": "The docstring makes the key conceptual move explicit: the parent file's parity bound (2 ∈ A ⟹ |A| ≤ 3), proved by pigeonholing A\\{2} into the two parity classes mod 2, is precisely the prime case p = 2 of the Erdős–Ginzburg–Ziv theorem. EGZ says that among any 2n − 1 integers there are n with sum divisible by n; Mathlib has it for every modulus (Int.erdos_ginzburg_ziv), so the parity argument generalizes verbatim to an arbitrary element a ≥ 2 of the set, yielding |A| ≤ 2a − 1. The note also records why the file re-states IsNonDividing rather than importing the parent: the parent does not compile against pinned Mathlib v4.26 (orphan docstrings before axioms, pre-v4.26 Finset.card_sdiff argument order), so decoupling keeps this contribution axiom-free.",
+    "mathContext": "EGZ: any $2n-1$ integers contain $n$ summing to $0 \\bmod n$. The parent's mod-2 pigeonhole is the $n=2$ instance; general $n=a$ gives $|A| \\le 2a-1$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős–Ginzburg–Ziv theorem", "zero-sum problems", "Erdős problem #131", "non-dividing sets", "self-contained formalization"],
+    "prerequisites": ["additive combinatorics", "divisibility", "the parent #131 entry"]
+  },
+  {
+    "id": "ann-erdos131-egz-oq0101-def",
+    "proofId": "erdos-131-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 60 },
+    "type": "definition",
+    "title": "The Non-Dividing Property",
+    "content": "IsNonDividing A holds when no element of A divides the sum of any ≥2-element subset of the remaining elements: ∀ a ∈ A, ∀ S ⊆ A.erase a, |S| ≥ 2 → ¬(a ∣ S.sum id). The size-≥2 restriction is essential — singletons and the empty set are excluded, since e.g. a ∣ a trivially and the property is about genuine combinations. This is a verbatim copy of Erdos131.IsNonDividing from the parent (kept local for self-containment). F(N), the object of Erdős #131, is the maximum size of such a set inside {1,…,N}.",
+    "mathContext": "$\\mathrm{IsNonDividing}(A) \\iff \\forall a \\in A,\\ \\forall S \\subseteq A\\setminus\\{a\\}\\ \\text{with}\\ |S|\\ge 2,\\ a \\nmid \\sum_{i\\in S} i$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.erase", "subset sums", "non-averaging sets", "extremal set theory"],
+    "prerequisites": ["Finset operations", "divisibility in ℕ"]
+  },
+  {
+    "id": "ann-erdos131-egz-oq0101-main",
+    "proofId": "erdos-131-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 89 },
+    "type": "theorem",
+    "title": "egz_nondividing_card_bound: the Structural Bound |A| ≤ 2a − 1",
+    "content": "The main theorem. The proof is by contradiction: assume |A| > 2a − 1, i.e. |A| ≥ 2a. Then card_erase_of_mem gives |A.erase a| = |A| − 1 ≥ 2a − 1, exactly EGZ's input size at modulus n = a. Int.erdos_ginzburg_ziv applied to the integer-cast sequence i ↦ (i:ℤ) on A.erase a returns t ⊆ A.erase a with |t| = a and a ∣ ∑_{i∈t} (i:ℤ). The ℤ-divisibility is transported to ℕ via push_cast and exact_mod_cast (hdvdNat). Finally, because a ≥ 2, the subset t has |t| = a ≥ 2, so (t, hts, htge, hdvdNat) is exactly a witness against IsNonDividing at a — contradiction.",
+    "mathContext": "If $|A| \\ge 2a$ then $|A\\setminus\\{a\\}| \\ge 2a-1$, so EGZ yields an $a$-subset $t$ with $a \\mid \\sum t$; $|t| = a \\ge 2$ violates non-dividing. Hence $|A| \\le 2a-1$.",
+    "significance": "key",
+    "relatedConcepts": ["Int.erdos_ginzburg_ziv", "Finset.card_erase_of_mem", "proof by contradiction", "ℤ-to-ℕ cast transport", "push_cast"],
+    "prerequisites": ["Erdős–Ginzburg–Ziv theorem", "Finset cardinality arithmetic", "casting divisibility"]
+  },
+  {
+    "id": "ann-erdos131-egz-oq0101-min",
+    "proofId": "erdos-131-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 107 },
+    "type": "insight",
+    "title": "Smallest-Element Bound and Parent Recovery",
+    "content": "nondividing_card_le_two_min applies the main bound at the LEAST element A.min' (a member by min'_mem). Because 2a − 1 is increasing in a, the smallest element gives the tightest bound: |A| ≤ 2·min(A) − 1. This formalizes the heuristic that a small element forces a small non-dividing set — the structural reason F(N) grows slowly. two_in_card_le_three then recovers the parent's parity result as the a = 2 instance: 2 ∈ A ⟹ |A| ≤ 2·2 − 1 = 3 (closed by omega), demonstrating the EGZ bound strictly subsumes the hand-rolled mod-2 argument.",
+    "mathContext": "$|A| \\le 2\\min(A) - 1$ is optimal among $\\{2a-1 : a \\in A\\}$ since the map $a \\mapsto 2a-1$ is monotone. At $a=2$: $|A| \\le 3$, the parent bound.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.min'", "Finset.min'_mem", "monotonicity", "special-case recovery"],
+    "prerequisites": ["least element of a finset", "egz_nondividing_card_bound"]
+  },
+  {
+    "id": "ann-erdos131-egz-oq0101-filter",
+    "proofId": "erdos-131-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 116 },
+    "type": "technique",
+    "title": "Contrapositive Certification Filter",
+    "content": "not_nondividing_of_card_gt is the contrapositive form: if a candidate set A has more than 2a − 1 elements for some a ∈ A with a ≥ 2, then A is provably NOT non-dividing. The one-line proof feeds the assumed IsNonDividing into egz_nondividing_card_bound to derive |A| ≤ 2a − 1, contradicting hcard via omega. This is a fast structural filter for search procedures: rather than checking every ≥2-subset for a dividing relation (exponential), one only needs the size and the smallest element to disqualify a set.",
+    "mathContext": "$2a - 1 < |A| \\ \\Rightarrow\\ \\neg\\,\\mathrm{IsNonDividing}(A)$. Disqualifies a candidate from its cardinality and one element alone, no subset enumeration needed.",
+    "significance": "supporting",
+    "relatedConcepts": ["contrapositive", "search pruning", "certification", "extremal filters"],
+    "prerequisites": ["egz_nondividing_card_bound", "absurd / omega"]
+  },
+  {
+    "id": "ann-erdos131-egz-oq0101-sharp",
+    "proofId": "erdos-131-oq-01-oq-01",
+    "range": { "startLine": 118, "endLine": 153 },
+    "type": "theorem",
+    "title": "Sharpness at a = 2: {2, 4, 5}",
+    "content": "The bound 2a − 1 cannot be lowered in general, and this is witnessed at a = 2. two_four_five_nondividing proves {2,4,5} is non-dividing: for each a ∈ {2,4,5}, erasing it leaves a 2-element set, and the helper finset_eq_of_subset_of_card_two forces any size-≥2 subset S to BE that whole erased set; then decide checks the single divisibility — 2∤(4+5)=9, 4∤(2+5)=7, 5∤(2+4)=6. egz_bound_sharp_at_two bundles the three facts: 2 ∈ {2,4,5}, the set is non-dividing, and its card is 3 = 2·2 − 1, so two_in_card_le_three is met with equality. Whether the bound is sharp for a > 2 is left as an open question.",
+    "mathContext": "Erasing any element of $\\{2,4,5\\}$ leaves a 2-set, whose only $\\ge 2$-subset is itself; $2\\nmid 9,\\ 4\\nmid 7,\\ 5\\nmid 6$. Card $= 3 = 2\\cdot 2 - 1$ attains the bound at $a=2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sharpness/extremal example", "Finset.eq_of_subset_of_card_le", "decide", "tightness of bounds"],
+    "prerequisites": ["finset cardinality", "decidable divisibility", "subset-of-small-set reasoning"]
+  }
+]

--- a/src/data/proofs/erdos-131-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01/meta.json
@@ -117,6 +117,60 @@
       "description": "Proves F(N) ≤ N^{1/4+o(1)} via the non-dividing ⟹ non-averaging connection, refuting Erdős's original F(N) > N^{1/2−o(1)} guess; context for the open question of recovering global bounds elementarily."
     }
   ],
+  "overview": {
+    "historicalContext": "Erdős problem #131 asks for the growth rate of $F(N)$, the largest size of a subset of $\\{1,\\dots,N\\}$ in which no element divides the sum of any collection of distinct others — a *non-dividing* (or *non-averaging*-adjacent) set. Erdős originally guessed $F(N) > N^{1/2 - o(1)}$, but this was dramatically overturned: Pham and Zakharov (2024) proved $F(N) \\le N^{1/4 + o(1)}$ via a connection to non-averaging sets, so non-dividing sets are far sparser than Erdős expected. The structural engine behind this entry is the Erdős–Ginzburg–Ziv theorem (EGZ, 1961): among any $2n-1$ integers, some $n$ of them have a sum divisible by $n$. EGZ is itself a landmark of additive combinatorics, the prototypical *zero-sum* theorem and the seed of the Davenport-constant literature; it follows from the Chevalley–Warning theorem and is fully formalized in Mathlib as `Int.erdos_ginzburg_ziv`. The parent gallery entry on #131 proves only a mod-2 parity bound ($2 \\in A \\Rightarrow |A| \\le 3$); this entry recognizes that bound as exactly the prime case $p=2$ of EGZ and lifts it to every element.",
+    "problemStatement": "Call $A \\subseteq \\mathbb N$ *non-dividing* if for every $a \\in A$, no subset $S \\subseteq A \\setminus \\{a\\}$ with $|S| \\ge 2$ has $a \\mid \\sum_{i \\in S} i$. The theorem proved here is: if $a \\in A$, $a \\ge 2$, and $A$ is non-dividing, then $$|A| \\le 2a - 1.$$ In particular, instantiating at the least element, a non-dividing set of integers all $\\ge 2$ satisfies $|A| \\le 2\\min(A) - 1$ — its smallest element controls its size. The bound is sharp at $a = 2$, where $\\{2,4,5\\}$ attains $|A| = 3 = 2\\cdot 2 - 1$.",
+    "proofStrategy": "Argue by contradiction. Suppose $|A| \\ge 2a$. Removing $a$ leaves $|A \\setminus \\{a\\}| \\ge 2a - 1$ (`Finset.card_erase_of_mem`), exactly the hypothesis size for EGZ at modulus $n = a$. Apply `Int.erdos_ginzburg_ziv` to the integer-cast sequence $i \\mapsto (i : \\mathbb Z)$ on $A \\setminus \\{a\\}$: it returns an $a$-element subset $t \\subseteq A \\setminus \\{a\\}$ with $a \\mid \\sum_{i \\in t} i$ over $\\mathbb Z$. Transport the divisibility back to $\\mathbb N$ via `push_cast` / `exact_mod_cast`. Since $a \\ge 2$, the subset $t$ has $|t| = a \\ge 2$ elements, so it is a legitimate witness against the non-dividing property at $a$ — contradiction. The corollaries (smallest-element bound, $a=2$ recovery, contrapositive filter, sharpness) are short specializations.",
+    "keyInsights": [
+      "The parent's mod-2 parity pigeonhole is not an ad-hoc trick but precisely the $p = 2$ instance of Erdős–Ginzburg–Ziv: two integers of equal parity sum to an even number ⇔ among $2\\cdot2-1 = 3$ integers some $2$ sum to a multiple of $2$. Naming this reveals the right generalization for free.",
+      "EGZ converts a *size* hypothesis ($|A|$ large) directly into a *divisibility* witness (a zero-sum subset), which is exactly the shape the non-dividing property forbids — the two notions are dual, and the bound $2a-1$ is just EGZ's threshold $2n-1$ read back.",
+      "Applying the bound at the smallest element is optimal because $2a-1$ is increasing in $a$: the least element gives the tightest constraint, formalizing the heuristic that small elements force small non-dividing sets and explaining qualitatively why $F(N)$ grows slowly.",
+      "Self-containment was a deliberate engineering choice: the parent `Erdos131Problem` does not compile against the pinned Mathlib v4.26 (orphan docstrings before axioms, old `Finset.card_sdiff` argument order), so `IsNonDividing` is re-stated verbatim to keep this contribution axiom-free and independently verifiable.",
+      "Sharpness is witnessed concretely and decidably: $\\{2,4,5\\}$ is non-dividing ($2 \\nmid 9,\\ 4 \\nmid 7,\\ 5 \\nmid 6$), verified by `decide` after reducing each case to the full erased set — so the constant $2a-1$ cannot be lowered in general."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: From a Parity Bound to Erdős–Ginzburg–Ziv",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Frames the contribution: the parent's parity bound (2 ∈ A ⟹ |A| ≤ 3) is the p = 2 case of EGZ, which Mathlib has for every modulus, so it lifts to |A| ≤ 2a − 1 for any a ∈ A with a ≥ 2. Explains the EGZ mechanism and why the file is deliberately self-contained (the parent does not compile against pinned Mathlib v4.26).",
+      "mathContext": "EGZ: among any $2n-1$ integers, some $n$ have sum divisible by $n$. At $n = 2$ this is the parity pigeonhole; for general $n = a$ it yields the structural bound $|A| \\le 2a - 1$."
+    },
+    {
+      "id": "definition",
+      "title": "IsNonDividing: the Non-Dividing Property",
+      "startLine": 49,
+      "endLine": 60,
+      "summary": "Imports Mathlib, opens Finset, and re-states IsNonDividing verbatim from the parent: A is non-dividing if for every a ∈ A, no subset S ⊆ A.erase a of size ≥ 2 has a ∣ S.sum id.",
+      "mathContext": "$\\mathrm{IsNonDividing}(A) := \\forall a \\in A,\\ \\forall S \\subseteq A\\setminus\\{a\\},\\ |S| \\ge 2 \\Rightarrow a \\nmid \\textstyle\\sum_{i\\in S} i$."
+    },
+    {
+      "id": "main-bound",
+      "title": "egz_nondividing_card_bound: the EGZ Structural Bound",
+      "startLine": 62,
+      "endLine": 89,
+      "summary": "The headline theorem |A| ≤ 2a − 1. By contradiction: if |A| ≥ 2a then |A.erase a| ≥ 2a − 1, EGZ at modulus a returns an a-element subset t of A\\{a} with a ∣ ∑t over ℤ, transported to ℕ; since a ≥ 2, |t| ≥ 2 violates the non-dividing property at a.",
+      "mathContext": "Contradiction hypothesis $|A| \\ge 2a$ feeds EGZ's threshold $2a-1 \\le |A\\setminus\\{a\\}|$; the returned zero-sum $a$-subset is the forbidden divisor witness. `push_cast`/`exact_mod_cast` move $a \\mid \\sum t$ from $\\mathbb Z$ to $\\mathbb N$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Smallest-Element Bound, Parent Recovery, and Certification Form",
+      "startLine": 91,
+      "endLine": 116,
+      "summary": "Three corollaries: nondividing_card_le_two_min applies the bound at min'(A) for the tightest constraint; two_in_card_le_three recovers the parent's |A| ≤ 3 as the a = 2 case; not_nondividing_of_card_gt is the contrapositive filter — any set with |A| > 2a − 1 for some a ≥ 2 in A is not non-dividing.",
+      "mathContext": "$|A| \\le 2\\min(A) - 1$ (optimal since $2a-1$ increases in $a$); $a=2 \\Rightarrow |A| \\le 3$; contrapositive: $2a-1 < |A| \\Rightarrow \\neg\\,\\mathrm{IsNonDividing}(A)$."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness at a = 2 via {2, 4, 5}",
+      "startLine": 118,
+      "endLine": 153,
+      "summary": "Proves {2,4,5} is non-dividing (a helper collapses any size-≥2 subset of a size-≤2 erased set to the whole, then decide checks 2∤9, 4∤7, 5∤6) and packages egz_bound_sharp_at_two: {2,4,5} contains 2, is non-dividing, and has card 3 = 2·2 − 1 — meeting two_in_card_le_three with equality.",
+      "mathContext": "$\\{2,4,5\\}$: erasing any element leaves a 2-set, whose only size-$\\ge 2$ subset is itself; $2\\nmid 4+5=9$, $4\\nmid 2+5=7$, $5\\nmid 2+4=6$. Card $3 = 2\\cdot 2 - 1$ shows the bound is tight at $a=2$."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "For a non-dividing set A ⊆ ℕ (no a ∈ A divides the sum of any ≥2-element subset of A \\ {a}) and any a ∈ A with a ≥ 2, the Erdős–Ginzburg–Ziv theorem gives |A| ≤ 2a − 1 (egz_nondividing_card_bound). The argument: if |A| ≥ 2a then |A.erase a| ≥ 2a − 1, so EGZ at modulus a produces an a-element subset t ⊆ A\\{a} with a ∣ ∑_{i∈t} i; as a ≥ 2 this subset has ≥ 2 elements and violates the non-dividing property at a. Instantiating at the least element yields |A| ≤ 2·min(A) − 1 (nondividing_card_le_two_min), and the a = 2 case recovers the parent's parity bound |A| ≤ 3 (two_in_card_le_three), which is sharp via {2,4,5} (egz_bound_sharp_at_two). 153 lines, 7 theorems/lemmas, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",


### PR DESCRIPTION
Enrichment pass for `erdos-131-oq-01-oq-01` (quality 10, pass 0).

## What changed

The entry had **no `overview` field at all** (so the proof page rendered nothing for the introduction/overview), an **empty `sections` array**, and **no `annotations.json`**. Its `conclusion`, `originalContributions`, `references`, and `openQuestions` were already strong and are left untouched.

- **overview** (new) → structured object: `historicalContext` (Erdős #131 and $F(N)$, EGZ 1961, the Pham–Zakharov $N^{1/4+o(1)}$ upset of Erdős's $N^{1/2}$ guess), `problemStatement`, `proofStrategy` (EGZ-by-contradiction), and **5 keyInsights**.
- **sections** (new) → 5 sections covering the whole Lean file (header, definition, main bound, corollaries, sharpness) with per-section `mathContext`.
- **annotations.json** (new) → 6 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, walking the proof: recognizing the parity bound as EGZ $p=2$, the non-dividing definition, the main $|A|\le 2a-1$ contradiction argument, the smallest-element/parent-recovery corollaries, the contrapositive filter, and the $\{2,4,5\}$ sharpness witness.

## Accuracy / axiom integrity

No status change. The file is genuinely 0-axiom, 0-sorry — its only nontrivial dependency is the fully-proved Mathlib `Int.erdos_ginzburg_ziv` (a Chevalley–Warning corollary), and the entry is deliberately self-contained because the parent does not compile against pinned Mathlib v4.26. `status: verified` / `badge: original` preserved. `pnpm build` passes.