### PR TITLE
Enrich Davenport Bound for Non-Dividing Sets (Erdős #131)

### DIFF
--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-erdos131-dav-overview",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "concept",
+    "title": "EGZ Constant vs. Davenport Constant: The Right Invariant",
+    "content": "The docstring lays out the sharpening. The parent EGZ follow-up bounds a non-dividing set by |A| ≤ 2a − 1 using only the size-exactly-a zero-sum subset that Erdős–Ginzburg–Ziv guarantees (the EGZ constant s(ℤ/aℤ) = 2a − 1). But non-dividing is much stronger: it forbids a zero-sum subset of EVERY size ≥ 2. The matching invariant is therefore the Davenport constant D(ℤ/aℤ) = a — the least length forcing a nonempty zero-sum subsequence of ANY size. Swapping EGZ for Davenport sharpens the bound to |A| ≤ a + 1. The file is self-contained because the parent does not compile against the pinned Mathlib v4.26.0.",
+    "mathContext": "$s(\\mathbb{Z}/a\\mathbb{Z}) = 2a - 1$ (zero-sum of size exactly $a$) vs. $D(\\mathbb{Z}/a\\mathbb{Z}) = a$ (nonempty zero-sum of any size); the gap drives the improvement from $2a-1$ to $a+1$.",
+    "significance": "key",
+    "relatedConcepts": ["Davenport constant", "Erdős–Ginzburg–Ziv theorem", "zero-sum problems", "non-dividing sets", "Erdős #131"],
+    "prerequisites": ["additive combinatorics", "cyclic groups ℤ/nℤ", "zero-sum sequences"]
+  },
+  {
+    "id": "ann-erdos131-dav-def",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 61 },
+    "type": "definition",
+    "title": "IsNonDividing: No Element Divides a ≥2-Subset Sum",
+    "content": "A finite A ⊆ ℕ is non-dividing if for every a ∈ A and every S ⊆ A.erase a with |S| ≥ 2, a ∤ ∑_{x∈S} x. The |S| ≥ 2 restriction is essential — it is what makes the property a genuine combinatorial constraint rather than a triviality, and it is exactly why the Davenport constant (any size ≥ 1, here ≥ 2 after excluding singletons) rather than a fixed size is the operative invariant. The predicate is copied verbatim from the parent for self-containment.",
+    "mathContext": "$\\forall a\\in A,\\ \\forall S\\subseteq A\\setminus\\{a\\}\\ \\text{with}\\ |S|\\ge 2:\\ a \\nmid \\sum_{x\\in S} x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["non-dividing set", "Finset.erase", "subset sum"],
+    "prerequisites": ["Finsets", "divisibility in ℕ"]
+  },
+  {
+    "id": "ann-erdos131-dav-prefix-sum",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 127 },
+    "type": "technique",
+    "title": "Prefix-Sum Pigeonhole: The Block Between Colliding Indices",
+    "content": "The core of the home-grown Davenport bound. Order s as a sorted (hence nodup) list L. The splitting identity key_eq expresses (L.take n).sum = (L.take m).sum + ((L.take n).drop m).sum for m ≤ n. The key lemma then takes two prefix indices p < q with equal prefix-sum mod a and extracts the block (L.take q).drop p: its sum is ≡ 0 (mod a) (via ZMod.natCast_eq_zero_iff and a linear_combination), it is a nodup sublist of L (so its toFinset has the same sum), and it is nonempty because its length is q − p ≥ 1. That toFinset is the desired zero-sum subset of s.",
+    "mathContext": "If $\\overline{\\sum L_{<p}} = \\overline{\\sum L_{<q}}$ in $\\mathbb{Z}/a\\mathbb{Z}$ with $p<q$, then $a \\mid \\sum_{p\\le i<q} L_i$ and that block is a nonempty sub-multiset of $s$.",
+    "significance": "critical",
+    "relatedConcepts": ["pigeonhole principle", "prefix sums", "ZMod.natCast_eq_zero_iff", "List sublist", "telescoping"],
+    "prerequisites": ["list take/drop lemmas", "casting to ZMod a"]
+  },
+  {
+    "id": "ann-erdos131-dav-pigeonhole",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 137 },
+    "type": "lemma",
+    "title": "exists_nonempty_subset_sum_dvd: D(ℤ/aℤ) ≤ a",
+    "content": "The Davenport bound is closed by pigeonhole. There are L.length + 1 = |s| + 1 ≥ a + 1 prefix-sum values, all living in ZMod a which has only a elements; Fintype.exists_ne_map_eq_of_card_lt forces two distinct indices i ≠ j with equal prefix sum mod a. Whichever is smaller plays the role of p in the key lemma, producing the nonempty zero-sum subset. This is exactly the statement D(ℤ/aℤ) ≤ a (any a integers contain a nonempty subset summing to 0 mod a), reproved from scratch because Mathlib lacks the Davenport constant.",
+    "mathContext": "$|\\mathbb{Z}/a\\mathbb{Z}| = a < a+1 \\le |s|+1$, so the prefix-sum map collides — the engine behind $D(\\mathbb{Z}/a\\mathbb{Z}) \\le a$.",
+    "significance": "key",
+    "relatedConcepts": ["Davenport constant", "Fintype.exists_ne_map_eq_of_card_lt", "ZMod.card", "pigeonhole"],
+    "prerequisites": ["finite cardinality", "pigeonhole principle"]
+  },
+  {
+    "id": "ann-erdos131-dav-main",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 146, "endLine": 199 },
+    "type": "theorem",
+    "title": "davenport_nondividing_card_bound: |A| ≤ a + 1",
+    "content": "The headline bound, by contradiction. Assume |A| > a + 1, so B = A.erase a has ≥ a + 1 elements. Split B by divisibility-by-a using Finset.filter_card_add_filter_neg_card_eq_card. (1) At most one element of B is divisible by a: two would form a size-2 subset {x,y} ⊆ B with a ∣ x + y, violating non-dividing (Finset.dvd_sum + card_pair). (2) Hence ≥ a elements have nonzero residue; the Davenport bound gives a nonempty zero-sum subset t of them. t must have size ≥ 2, because a singleton {x} would force a ∣ x while x was chosen with nonzero residue — contradiction. So t ⊆ B, |t| ≥ 2, a ∣ ∑t, the final non-dividing violation.",
+    "mathContext": "$|B|\\ge a+1$; at most one $a$-divisible element $\\Rightarrow \\ge a$ nonzero-residue elements; Davenport $\\Rightarrow$ zero-sum $t$, $|t|\\ge 2$ (singletons are nonzero) $\\Rightarrow$ contradiction.",
+    "significance": "critical",
+    "relatedConcepts": ["proof by contradiction", "residue classes mod a", "Finset.filter", "non-dividing violation"],
+    "prerequisites": ["the Davenport bound", "Finset cardinality splitting"]
+  },
+  {
+    "id": "ann-erdos131-dav-corollaries",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 201, "endLine": 230 },
+    "type": "theorem",
+    "title": "Corollaries: Smallest Element and Strict Sharpening of EGZ",
+    "content": "davenport_card_le_min_succ applies the main bound at min(A) to get |A| ≤ min(A) + 1 — a non-dividing set is barely larger than its smallest element. davenport_le_egz (a + 1 ≤ 2a − 1 for a ≥ 2) shows the new bound never loses to EGZ, and davenport_strictly_sharper (a + 1 < 2a − 1 for a ≥ 3) shows it strictly beats EGZ — so 2a − 1 is non-sharp for all a ≥ 3, answering the parent's open question. two_in_card_le_three recovers the a = 2 parity bound, and not_nondividing_of_card_gt is the contrapositive certification form. All four are one-line omega/specialization proofs.",
+    "mathContext": "$a+1 \\le 2a-1$ for $a\\ge 2$ (equality at $a=2$); $a+1 < 2a-1$ for $a\\ge 3$. So EGZ's $2a-1$ is sharp only at $a=2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["smallest-element bound", "EGZ non-sharpness", "Finset.min'", "contrapositive"],
+    "prerequisites": ["the main bound", "omega arithmetic"]
+  },
+  {
+    "id": "ann-erdos131-dav-sharpness",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01",
+    "range": { "startLine": 232, "endLine": 264 },
+    "type": "theorem",
+    "title": "Sharpness at a = 2: {2,4,5} Meets the Bound",
+    "content": "Demonstrates the bound is tight at a = 2. two_four_five_nondividing checks {2,4,5} is non-dividing: the only ≥2-subsets are the size-2 erasures, and 2∤(4+5)=9, 4∤(2+5)=7, 5∤(2+4)=6, all by decide. The helper finset_eq_of_subset_of_card_two collapses any size-≥2 subset of a size-≤2 set to equality, reducing each case to a single decidable check. davenport_bound_sharp_at_two then packages that {2,4,5} contains 2 and has card 3 = 2 + 1, meeting davenport_nondividing_card_bound with equality. (Beyond a = 2 sharpness is open.)",
+    "mathContext": "$\\{2,4,5\\}$: $2\\nmid 9,\\ 4\\nmid 7,\\ 5\\nmid 6$; $|\\{2,4,5\\}|=3=2+1$, so the bound is attained at $a=2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sharpness witness", "decide tactic", "extremal example"],
+    "prerequisites": ["decidable divisibility", "Finset.eq_of_subset_of_card_le"]
+  }
+]

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01/meta.json
@@ -17,6 +17,19 @@
     "sorries": 0
   },
   "title": "Sharpening the EGZ Bound for Non-Dividing Sets to |A| ≤ a + 1 (Erdős #131)",
+  "description": "For a non-dividing set A ⊆ ℕ (no element divides the sum of any ≥2-element subset of the others) and any a ∈ A with a ≥ 2, the EGZ-derived bound |A| ≤ 2a − 1 is sharpened to |A| ≤ a + 1. The key is that non-dividing forbids zero-sum subsets of every size ≥ 2, so the governing invariant is the Davenport constant D(ℤ/aℤ) = a, not the Erdős–Ginzburg–Ziv constant 2a − 1. The Davenport bound is built from scratch (Mathlib lacks it) by a prefix-sum pigeonhole. The new bound is strictly stronger for a ≥ 3 (so 2a − 1 is non-sharp there) and tight at a = 2 via {2,4,5}. Fully verified, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Erdős problem #131 (from his 1975 'On some problems in combinatorial number theory') concerns non-dividing sets: subsets A of {1,…,N} in which no element divides the sum of any collection of distinct others, and the maximal size F(N) of such a set. The structural bounds here sit inside the theory of zero-sum problems over finite abelian groups, a field opened by the Erdős–Ginzburg–Ziv theorem (1961): among any 2n − 1 integers, some n have a sum divisible by n — the constant s(ℤ/nℤ) = 2n − 1. A subtler invariant is the Davenport constant D(G), introduced by H. Davenport in the 1960s, the least d such that every length-d sequence over G has a nonempty zero-sum subsequence; for cyclic groups D(ℤ/nℤ) = n. The two constants encode different demands — EGZ fixes the subset size at exactly n, Davenport allows any nonempty size — and the gap between 2n − 1 and n is precisely what this entry exploits. The non-dividing growth problem remains active: Pham and Zakharov (2024) proved F(N) ≤ N^{1/4+o(1)} via a connection to non-averaging sets. Because Mathlib has EGZ (Int.erdos_ginzburg_ziv) but not the Davenport constant, the cyclic case D(ℤ/aℤ) ≤ a is reproved here from first principles.",
+    "problemStatement": "A finite A ⊆ ℕ is non-dividing if for every a ∈ A and every S ⊆ A \\ {a} with |S| ≥ 2, a does not divide ∑S. The parent EGZ follow-up proved that if a ∈ A with a ≥ 2 then |A| ≤ 2a − 1. The question taken up here: can this be sharpened, and is 2a − 1 ever sharp? The answer: |A| ≤ a + 1, which is strictly smaller than 2a − 1 for all a ≥ 3, so the EGZ bound is non-sharp beyond a = 2.",
+    "proofStrategy": "Work inside B = A \\ {a}, which has |A| − 1 elements. Two observations bound |B| by a. (1) At most ONE element of B is divisible by a: two such elements would form a size-2 subset with sum ≡ 0 (mod a), violating non-dividing. (2) The remaining ≥ |B| − 1 elements all have nonzero residue mod a; if |B| ≥ a + 1 there are ≥ a of them, so the Davenport bound exists_nonempty_subset_sum_dvd yields a nonempty subset with sum divisible by a — and since every element is nonzero mod a, that subset has size ≥ 2, again violating non-dividing. Hence |B| ≤ a, i.e. |A| ≤ a + 1. The Davenport bound itself is proved by listing the a integers, forming the a + 1 prefix sums mod a, and applying pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) into the a-element type ZMod a: two equal prefix sums bracket a nonempty block whose sum is ≡ 0.",
+    "keyInsights": [
+      "The whole sharpening turns on choosing the right additive-combinatorial invariant: EGZ (constant 2a − 1) demands a zero-sum subset of size EXACTLY a, but the non-dividing hypothesis is far stronger — it forbids zero-sum subsets of EVERY size ≥ 2 — so the Davenport constant D(ℤ/aℤ) = a, which forbids zero-sum subsets of ANY nonempty size, is the natural governing quantity.",
+      "The proof is a clean two-part pigeonhole: residues mod a split B into 'divisible by a' (at most one, else a size-2 violation) and 'nonzero residue' (≥ a of them force a Davenport zero-sum subset, necessarily size ≥ 2, another violation).",
+      "Davenport's D(ℤ/nℤ) ≤ n is proved here by the textbook prefix-sum argument: a + 1 prefix sums into the a-element group ZMod a must collide, and the block between the colliding indices is the desired zero-sum subset. This is a reusable, axiom-free formalization Mathlib currently lacks.",
+      "Sharpness is genuinely a = 2 only: at a = 2 the Davenport and EGZ bounds coincide (a + 1 = 3 = 2a − 1) and {2,4,5} witnesses equality, but for a ≥ 3 the strict inequality a + 1 < 2a − 1 shows the published EGZ bound was never tight.",
+      "The smallest-element corollary |A| ≤ min(A) + 1 says a non-dividing set is barely larger than its least element — the tightest single-element constraint available, and the seed for the open problem of aggregating per-element bounds into a global bound on F(N)."
+    ]
+  },
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -127,9 +140,65 @@
       "description": "Proves F(N) ≤ N^{1/4+o(1)} via the non-dividing ⟹ non-averaging connection; context for the open question of recovering global F(N) bounds elementarily from per-element constraints."
     }
   ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: EGZ vs. Davenport, and Self-Containment",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Frames the contribution: sharpen the EGZ follow-up's |A| ≤ 2a − 1 to the Davenport bound |A| ≤ a + 1. Explains why the Davenport constant D(ℤ/aℤ) = a (forbidding zero-sum subsets of every size) is the right invariant rather than the EGZ constant 2a − 1, sketches the A\\{a} mechanism, and notes the file is deliberately self-contained (the parent does not compile against the pinned Mathlib v4.26.0).",
+      "mathContext": "EGZ constant $s(\\mathbb{Z}/a\\mathbb{Z}) = 2a-1$ (zero-sum of size exactly $a$) vs. Davenport constant $D(\\mathbb{Z}/a\\mathbb{Z}) = a$ (nonempty zero-sum of any size)."
+    },
+    {
+      "id": "definition",
+      "title": "IsNonDividing: The Non-Dividing Predicate",
+      "startLine": 50,
+      "endLine": 61,
+      "summary": "Re-states IsNonDividing verbatim from the parent (for self-containment): for every a ∈ A and every S ⊆ A.erase a with |S| ≥ 2, a does not divide ∑_{x∈S} x. The size restriction |S| ≥ 2 is what makes the property nontrivial (it never constrains singletons).",
+      "mathContext": "$A$ non-dividing: $\\forall a\\in A,\\ \\forall S\\subseteq A\\setminus\\{a\\},\\ |S|\\ge 2 \\Rightarrow a\\nmid \\sum S$."
+    },
+    {
+      "id": "davenport-bound",
+      "title": "exists_nonempty_subset_sum_dvd: Davenport D(ℤ/aℤ) ≤ a From Scratch",
+      "startLine": 63,
+      "endLine": 137,
+      "summary": "The home-grown Davenport bound: any a natural numbers contain a nonempty subset with sum divisible by a. Sorts s into a nodup list L, sets up the prefix-sum splitting identity key_eq, and the core lemma key: two prefix indices with equal prefix-sum mod a bracket a nonempty block (a sublist of L) whose sum is ≡ 0 (mod a), whose toFinset is the witness. Finishes by pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) on the a + 1 prefix sums into the a-element type ZMod a.",
+      "mathContext": "$a+1$ prefix sums into $\\mathbb{Z}/a\\mathbb{Z}$ (size $a$) collide (pigeonhole); the block between colliding indices has sum $\\equiv 0\\ (\\mathrm{mod}\\ a)$."
+    },
+    {
+      "id": "main-bound",
+      "title": "davenport_nondividing_card_bound: The Headline |A| ≤ a + 1",
+      "startLine": 139,
+      "endLine": 199,
+      "summary": "The main theorem. By contradiction, assume |A| > a + 1 so B = A.erase a has ≥ a + 1 elements. At most one element of B is divisible by a (two would give a size-2 zero-sum pair, violating non-dividing); hence ≥ a elements have nonzero residue. Davenport on that part yields a nonempty zero-sum subset t, which must have size ≥ 2 (a singleton would be ≡ 0, but its elements are nonzero mod a) — contradicting non-dividing.",
+      "mathContext": "$|B|\\ge a+1$, $|\\{x\\in B: a\\mid x\\}|\\le 1 \\Rightarrow |\\{x\\in B: a\\nmid x\\}|\\ge a$; Davenport gives a zero-sum $t$ with $|t|\\ge 2$, contradiction."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Smallest-Element, EGZ Comparison, Certification",
+      "startLine": 201,
+      "endLine": 230,
+      "summary": "davenport_card_le_min_succ: |A| ≤ min(A) + 1 (apply the main bound at the least element). davenport_le_egz: a + 1 ≤ 2a − 1 for a ≥ 2. davenport_strictly_sharper: a + 1 < 2a − 1 for a ≥ 3 (so EGZ is non-sharp). two_in_card_le_three: recovers the parent's parity bound at a = 2. not_nondividing_of_card_gt: contrapositive certification form.",
+      "mathContext": "$a+1 \\le 2a-1$ ($a\\ge 2$), strict for $a\\ge 3$; at $a=2$ both bounds equal $3$."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness at a = 2: the Witness {2,4,5}",
+      "startLine": 232,
+      "endLine": 266,
+      "summary": "two_four_five_nondividing proves {2,4,5} is non-dividing (2∤9, 4∤7, 5∤6), via the helper finset_eq_of_subset_of_card_two (a size-≥2 subset of a size-≤2 set equals it) plus decide. davenport_bound_sharp_at_two packages that {2,4,5} contains 2 and has card 3 = 2 + 1, meeting the bound with equality.",
+      "mathContext": "$\\{2,4,5\\}$: $2\\nmid 4+5=9$, $4\\nmid 2+5=7$, $5\\nmid 2+4=6$; $|\\{2,4,5\\}| = 3 = 2+1$."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "For a non-dividing set A ⊆ ℕ and any a ∈ A with a ≥ 2, the size bound |A| ≤ 2a − 1 coming from Erdős–Ginzburg–Ziv can be sharpened to |A| ≤ a + 1 (davenport_nondividing_card_bound). The point is that non-dividing forbids a zero-sum subset of EVERY size ≥ 2, not just of size a, so the relevant invariant is the Davenport constant D(ℤ/aℤ) = a rather than the EGZ constant 2a − 1. The Davenport bound itself (exists_nonempty_subset_sum_dvd: any a integers have a nonempty subset with sum divisible by a) is proved from scratch by a prefix-sum pigeonhole, since Mathlib lacks it. Working inside A\\{a}: at most one element is ≡ 0 (mod a) (else a size-2 zero-sum pair), and the remaining ≥ a nonzero-residue elements yield, via Davenport, a zero-sum subset of size ≥ 2 — a contradiction; hence |A\\{a}| ≤ a. The new bound is ≤ the EGZ bound for all a ≥ 2 and strictly smaller for a ≥ 3 (davenport_strictly_sharper), so 2a − 1 is not sharp beyond a = 2; it recovers |A| ≤ 3 at a = 2 (two_in_card_le_three) and is sharp there via {2,4,5} (davenport_bound_sharp_at_two). 266 lines, 9 theorems + 1 private lemma, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
-    "implications": "The entry pinpoints the correct additive-combinatorial invariant behind the non-dividing size bound — the cyclic Davenport constant, not the EGZ constant — and in doing so nearly halves the previously published bound and shows the EGZ bound is non-sharp for every a ≥ 3. It also supplies a reusable, axiom-free formalization of D(ℤ/nℤ) ≤ n (a nonempty zero-sum subsequence in any length-n sequence over ℤ/nℤ), which Mathlib currently lacks. The smallest-element corollary |A| ≤ min(A) + 1 is essentially the tightest single-element constraint available and sets up the open problem of aggregating per-element Davenport bounds into a global, elementary upper bound on F(N)."
+    "implications": "The entry pinpoints the correct additive-combinatorial invariant behind the non-dividing size bound — the cyclic Davenport constant, not the EGZ constant — and in doing so nearly halves the previously published bound and shows the EGZ bound is non-sharp for every a ≥ 3. It also supplies a reusable, axiom-free formalization of D(ℤ/nℤ) ≤ n (a nonempty zero-sum subsequence in any length-n sequence over ℤ/nℤ), which Mathlib currently lacks. The smallest-element corollary |A| ≤ min(A) + 1 is essentially the tightest single-element constraint available and sets up the open problem of aggregating per-element Davenport bounds into a global, elementary upper bound on F(N).",
+    "openQuestions": [
+      "Is the Davenport bound |A| ≤ a + 1 itself sharp for a ≥ 3? It is tight at a = 2 ({2,4,5}); achieving |A| = a + 1 would require A\\{a} to be one element ≡ 0 (mod a) plus a − 1 elements of equal nonzero residue (a maximal zero-sum-free configuration over ℤ/aℤ), all distinct naturals AND non-dividing at every element of A — not just at a. Does such a set exist, or does the cross-element constraint force a smaller maximum?",
+      "Can |A| ≤ min(A) + 1 be combined with the spread of A (e.g. Davenport on residue-class restrictions, or on A ∩ [1,t] for varying t) to extract a nontrivial GLOBAL bound on F(N) = max non-dividing subset of {1,…,N}, ideally approaching the Pham–Zakharov F(N) ≤ N^{1/4+o(1)} ceiling by elementary means?",
+      "Does the Davenport-constant method extend from cyclic ℤ/aℤ to the structural bounds for non-dividing sets governed by other finite abelian groups, where D(G) and s(G) genuinely differ (e.g. D(ℤ/n ⊕ ℤ/n) = 2n − 1)?",
+      "Could the from-scratch exists_nonempty_subset_sum_dvd be upstreamed to Mathlib as the cyclic case of a general Davenport-constant API (zero-sum-free sequences over finite abelian groups)?"
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `erdos-131-oq-01-oq-01-oq-01` (quality **10 → 100**, passes 0). The entry had `meta`, `references`, `crossReferences`, top-level `openQuestions`, and a structured `conclusion` (summary + implications) but no `description`, `overview`, `sections`, or annotations.

## Changes
- **description**: added (entry had none — used in gallery listings).
- **overview**: added structured `ProofOverview` — `historicalContext` (Erdős #131, EGZ 1961, Davenport's constant, Pham–Zakharov 2024 F(N) ≤ N^{1/4+o(1)}), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections**: 6 sections covering the full 266-line Lean file (docstring, definition, the from-scratch Davenport bound, the headline |A| ≤ a+1, corollaries, the a=2 sharpness witness), each with `mathContext`.
- **conclusion.openQuestions**: added 4 (sharpness for a ≥ 3, aggregating to a global F(N) bound, non-cyclic groups, Mathlib upstreaming) — the scored `conclusion` previously lacked openQuestions.
- **annotations.json**: created with 7 annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Quality score went from 10 to a full 100 across all rubric categories.

## Axiom integrity
Verified against the Lean source: 0 `axiom` declarations, 0 sorries, no `native_decide` (only kernel `decide` for the {2,4,5} witness). `status: verified` / `badge: original` / `axiomCount: 0` are accurate (depends only on propext, Classical.choice, Quot.sound).

`pnpm build` passes.