### PR TITLE
Fix: angle-trisection-oq-04 badge/assumptions overclaim (#27230)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04/meta.json
@@ -15,11 +15,11 @@
       "constructibility",
       "field-extensions"
     ],
-    "badge": "original",
+    "badge": "infrastructure",
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified.",
+    "assumptions": "0 sorries, 0 axioms — the 2-3 number arithmetic and degree-set inclusions are fully machine-verified. However, the constructibility predicates are degree-only and α-independent: `IsNeusisConstructible (_α : ℝ) (d : ℕ) := IsTwoThreeNumber d` and `IsConstructible (_α : ℝ) (d : ℕ) := d > 0 ∧ ∃ n, d ∣ 2^n` both ignore their real-number argument. So statements like `cos_20_neusis_constructible : IsNeusisConstructible (cos (π/9)) 3` are definitionally just `IsTwoThreeNumber 3`; the degree literal `3` is hand-supplied and is NOT proven to be the minimal-polynomial degree of cos(π/9) or ∛2. The geometric constructibility claims (angle trisection / cube duplication with a marked ruler) are therefore presented at the level of Gleason's (1988) algebraic-degree characterization, not formally established for the named angles. The genuinely original, fully-proven content is the 2-3-number / Pierpont-prime arithmetic and the degree-set hierarchy.",
     "lineCount": 599,
     "theoremCount": 43,
     "definitionCount": 10,
@@ -30,7 +30,7 @@
       "Poncelet-Steiner theorem: straightedge plus one given circle equals compass-and-straightedge",
       "Pierpont prime characterization of neusis-constructible regular polygons (7-gon YES, 9-gon YES, 11-gon NO)",
       "two_three_mul: 2-3 numbers closed under multiplication",
-      "Strict hierarchy witness: cos(20°) is neusis-constructible but not compass-constructible",
+      "Strict hierarchy witness at the degree level: degree 3 is a 2-3 number but does not divide any 2^n (so the named-angle constructibility statements hold by the hand-supplied degree-3 literal, not a proven minimal-polynomial degree)",
       "five_not_two_three and eleven_not_pierpont: explicit failures of neusis-constructibility"
     ]
   },


### PR DESCRIPTION
## Fix

`angle-trisection-oq-04` claimed `badge: original` with `assumptions: "None. Fully machine-verified."`, but its constructibility predicates are **degree-only and α-independent** — they ignore the real-number argument and pair named reals with hand-supplied degree literals.

## Evidence

```lean
def IsNeusisConstructible (_α : ℝ) (d : ℕ) : Prop := IsTwoThreeNumber d   -- _α unused
def IsConstructible      (_α : ℝ) (d : ℕ) : Prop := d > 0 ∧ ∃ n, d ∣ 2^n  -- _α unused
```

So `cos_20_neusis_constructible : IsNeusisConstructible (cos (π/9)) 3` is definitionally just `IsTwoThreeNumber 3`. The mathematically substantive fact — that `cos(π/9)` and `∛2` have minimal-polynomial degree 3 — is asserted via the literal `3`, not proven.

**Before**: `badge: original`, `assumptions: "None. Fully machine-verified."`, originalContribution claiming "cos(20°) is neusis-constructible but not compass-constructible".
**After**: `badge: infrastructure`; `assumptions` discloses the degree-only / α-independent framing and that degree literals are hand-supplied; the strict-hierarchy contribution reworded to the degree level. `status` stays `verified` (genuinely 0 sorry, 0 axiom — the 2-3-number arithmetic and degree-set inclusions are sound).

Closes #27230

---
Automated fix by lean-mechanic agent.