### PR TITLE
Enrich: Gauss's Eureka Theorem (8n+3 Slice of Three-Square Sufficiency)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-gauss-eureka-oq0301-header",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "Gauss's Eureka Theorem as a Slice of Legendre",
+    "content": "The docstring sets the strategy. The parent file Proofs.ThreeSquares formalizes Legendre's three-square theorem: it proves NECESSITY axiom-free (numbers of the form 4^a(8b+7) are never sums of three squares) and isolates SUFFICIENCY as a single axiom. This file adds a famous classical consequence of sufficiency — Gauss's Eureka theorem (1796): every natural number is a sum of three triangular numbers T(k)=k(k+1)/2. The reduction is elementary and proved axiom-free: it rests on the equivalence eight_mul_add_three_iff and the fact that 8n+3 is never of the excluded form, so three-square sufficiency need only be invoked on the single progression 8n+3. Crucially the equivalence shows the two statements are LOGICALLY EQUIVALENT — Eureka for n ⇔ three-square representability of 8n+3.",
+    "mathContext": "Legendre: $n = x^2+y^2+z^2 \\iff n \\ne 4^a(8b+7)$. Eureka is the $n \\mapsto 8n+3$ slice, since $8n+3$ is always representable and forces three odd squares.",
+    "significance": "context",
+    "relatedConcepts": ["Gauss Eureka theorem", "Legendre three-square theorem", "triangular numbers", "polygonal number theorem", "reduction"],
+    "prerequisites": ["sums of squares", "modular arithmetic", "the parent ThreeSquares formalization"]
+  },
+  {
+    "id": "ann-gauss-eureka-oq0301-defs",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+    "range": { "startLine": 50, "endLine": 65 },
+    "type": "definition",
+    "title": "Triangular Numbers and Exact Halving",
+    "content": "tri k = k*(k+1)/2 is the k-th triangular number, and IsSumThreeTriangular n := ∃ a b c, tri a + tri b + tri c = n is the predicate Gauss's theorem asserts of every n. The simp lemmas tri 0 = 0, tri 1 = 1, tri 2 = 3 hold by rfl. two_mul_tri proves 2 · tri k = k(k+1): the natural-number division by 2 is EXACT because k(k+1) is even (Nat.even_mul_succ_self gives 2 ∣ k(k+1), then Nat.mul_div_cancel'). This exactness is what lets the odd-square identity hold on the nose in ℕ rather than only up to rounding.",
+    "mathContext": "$T(k) = \\tfrac{k(k+1)}2$, with $2T(k) = k(k+1)$ exact since one of $k, k+1$ is even.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers", "Nat.mul_div_cancel'", "Nat.even_mul_succ_self", "exact division"],
+    "prerequisites": ["natural-number division", "divisibility"]
+  },
+  {
+    "id": "ann-gauss-eureka-oq0301-oddsq",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+    "range": { "startLine": 67, "endLine": 95 },
+    "type": "insight",
+    "title": "The Engine: (2a+1)² = 8·T(a) + 1",
+    "content": "These lemmas encode that a triangular number lives inside every odd square. sq_two_mul_add_one proves (2a+1)² = 8·tri a + 1 over ℕ, by expanding (2a+1)² = 4·a(a+1)+1 = 4·(2·tri a)+1 = 8·tri a + 1. odd_sq_eq_eight_tri_add_one lifts this to integers: any odd x has x² = 8·T(j)+1 for some natural j, obtained from |x| = 2j+1 (Int.natAbs_odd) and casting the ℕ identity through sq_abs. odd_of_sq_mod_four_one is the converse-of-parity tool: if x² ≡ 1 (mod 4) then x is odd, because an even x = 2m gives x² = 4m² ≡ 0 (mod 4), an omega contradiction.",
+    "mathContext": "$(2a+1)^2 = 4a(a+1)+1 = 8T(a)+1$. And $x^2 \\equiv 1 \\pmod 4 \\Rightarrow x$ odd (even $x \\Rightarrow x^2 \\equiv 0$).",
+    "significance": "key",
+    "relatedConcepts": ["odd squares", "Int.natAbs_odd", "sq_abs", "mod-4 parity", "ℕ–ℤ casting"],
+    "prerequisites": ["integer/natural casting", "Odd/Even case analysis", "omega"]
+  },
+  {
+    "id": "ann-gauss-eureka-oq0301-equiv",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+    "range": { "startLine": 97, "endLine": 134 },
+    "type": "theorem",
+    "title": "eight_mul_add_three_iff: the Bridge Equivalence",
+    "content": "The central result: 8n+3 = x²+y²+z² (over ℤ) iff n = T(a)+T(b)+T(c). FORWARD — from a three-square representation, reduce mod 4: int_sq_mod_four says each square is 0 or 1 (mod 4), and the total is ≡ 3 (mod 4), so omega forces all three squares ≡ 1 (mod 4), hence x,y,z all ODD (odd_of_sq_mod_four_one). Each odd square is 8·T(j)+1, so 8(T jx + T jy + T jz)+3 = 8n+3, giving n = T jx + T jy + T jz after cancelling. BACKWARD — take x=2a+1, y=2b+1, z=2c+1, expand each via the identity to 8·T+1, and linarith closes 8(Ta+Tb+Tc)+3 = 8n+3 from Ta+Tb+Tc=n. The forced oddness is what makes the equivalence exact, not merely one-directional.",
+    "mathContext": "All $x_i$ odd is forced by $8n+3 \\equiv 3 \\pmod 4$; then $\\sum(2j_i+1)^2 = 8\\sum T(j_i)+3 = 8n+3 \\iff \\sum T(j_i) = n$.",
+    "significance": "key",
+    "relatedConcepts": ["sum of three squares", "ThreeSquares.int_sq_mod_four", "forced oddness", "linarith", "exact_mod_cast"],
+    "prerequisites": ["squares mod 4", "the odd-square identity", "ℕ–ℤ cast transport"]
+  },
+  {
+    "id": "ann-gauss-eureka-oq0301-reduction",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
+    "range": { "startLine": 136, "endLine": 168 },
+    "type": "theorem",
+    "title": "Non-Exclusion and the Axiom-Free Eureka Reduction",
+    "content": "not_excluded_eight_mul_add_three shows 8n+3 is never of the excluded form 4^a(8b+7): it is odd (= 2(4n+1)+1) and ≡ 3 (mod 8) ≠ 7, so ThreeSquares.odd_excluded_iff (odd m is excluded iff m % 8 = 7) plus omega rule it out. gauss_eureka_of_sufficiency then takes the sufficiency direction as an explicit hypothesis `suff`, applies it at 8n+3 (legitimate by non-exclusion) to get a three-square representation, and feeds that through eight_mul_add_three_iff.mp to conclude IsSumThreeTriangular n — entirely axiom-free, the assumption quarantined in `suff` (dischargeable by the parent's legendre_three_squares). eureka_iff_three_square_repr restates the equivalence Eureka-first.",
+    "mathContext": "$8n+3 \\equiv 3 \\pmod 8 \\ne 7 \\Rightarrow \\neg\\,\\mathrm{IsExcludedForm}(8n+3)$, so sufficiency yields $8n+3 = \\sum x_i^2$, hence $n = \\sum T(a_i)$. Eureka $=$ the $8n+3$ slice of Legendre sufficiency.",
+    "significance": "key",
+    "relatedConcepts": ["IsExcludedForm", "ThreeSquares.odd_excluded_iff", "hypothesis-parametrised theorem", "axiom quarantine", "Cauchy polygonal theorem"],
+    "prerequisites": ["the excluded-form criterion", "eight_mul_add_three_iff", "Legendre sufficiency"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-01/meta.json
@@ -123,6 +123,60 @@
       "description": "Cauchy's polygonal number theorem; the triangular case k=3 is Gauss's Eureka theorem formalized here."
     }
   ],
+  "overview": {
+    "historicalContext": "On 10 July 1796 the 19-year-old Carl Friedrich Gauss recorded in his mathematical diary one of its most famous entries: 'ΕΥΡΗΚΑ! num = Δ + Δ + Δ' — *Eureka! every number is a sum of three triangular numbers*. He published the proof in 1801 in *Disquisitiones Arithmeticae* (art. 293). The result is the triangular ($k=3$) case of Fermat's polygonal number conjecture, that every natural number is a sum of at most $k$ $k$-gonal numbers, eventually proved in full by Cauchy in 1813. Gauss's theorem is intimately tied to Legendre's three-square theorem (1798): $n$ is a sum of three integer squares iff $n$ is *not* of the form $4^a(8b+7)$. The link is the substitution $n \\mapsto 8n+3$: because an odd square is congruent to $1 \\bmod 8$, a three-square representation of $8n+3$ must use three odd squares, and unpacking each as $8T(k)+1$ converts the statement into 'three triangular numbers'. This entry formalizes exactly that bridge, axiom-free, on top of the parent `ThreeSquares` development.",
+    "problemStatement": "Let $T(k) = k(k+1)/2$ be the $k$-th triangular number and call $n$ a *sum of three triangular numbers* if $n = T(a)+T(b)+T(c)$ for some naturals $a,b,c$. Gauss's Eureka theorem asserts this holds for **every** $n$. The verified core proved here is the equivalence $$8n+3 = x^2+y^2+z^2 \\ (\\exists\\,x,y,z\\in\\mathbb Z) \\iff n = T(a)+T(b)+T(c)\\ (\\exists\\,a,b,c\\in\\mathbb N).$$ Since $8n+3 \\equiv 3 \\pmod 8$ is never of the excluded form $4^a(8b+7)$, the sufficiency direction of Legendre's theorem applies to it, and Eureka follows. The reduction invokes three-square sufficiency *only* on the arithmetic progression $8n+3$.",
+    "proofStrategy": "Prove the equivalence `eight_mul_add_three_iff` both ways. Forward: given $x^2+y^2+z^2 = 8n+3$, reduce mod 4 — integer squares are $0$ or $1 \\bmod 4$ (`int_sq_mod_four`), and the sum is $\\equiv 3 \\bmod 4$, forcing all three squares $\\equiv 1$, hence $x,y,z$ all odd (`odd_of_sq_mod_four_one`). Each odd square is exactly $8T(j)+1$ (`odd_sq_eq_eight_tri_add_one`, via $|x| = 2j+1$ and the natural-number identity $(2a+1)^2 = 8T(a)+1$), so the equation collapses to $8(T(j_x)+T(j_y)+T(j_z))+3 = 8n+3$, i.e. $n = T(j_x)+T(j_y)+T(j_z)$. Backward: run the identity in reverse, taking $x = 2a+1$ etc. Then `not_excluded_eight_mul_add_three` certifies $8n+3$ is never $4^a(8b+7)$ (it is odd and $\\equiv 3 \\bmod 8 \\ne 7$, via `odd_excluded_iff`), so `gauss_eureka_of_sufficiency` discharges Eureka from a sufficiency hypothesis applied at $8n+3$ alone.",
+    "keyInsights": [
+      "Gauss's Eureka theorem is *logically equivalent* to — neither stronger nor weaker than — the three-square representability of $8n+3$. The entry makes this precise (`eureka_iff_three_square_repr`), isolating Eureka as exactly the $8n+3$ slice of Legendre's sufficiency rather than an independent result.",
+      "The mod-4 argument is the linchpin: $8n+3 \\equiv 3 \\pmod 4$ together with 'squares are $0,1 \\bmod 4$' forces a three-square representation to consist of three ODD squares automatically — there is no freedom, which is what makes the triangular reformulation exact rather than merely sufficient.",
+      "An odd square carries a triangular number inside it: $(2a+1)^2 = 8T(a)+1$. This single identity (`sq_two_mul_add_one`), run forward and backward, is the entire engine of the equivalence; the rest is casting between ℕ and ℤ.",
+      "Separating the hard part from the easy part: the genuinely deep content (three-square sufficiency) stays an explicit hypothesis `suff`, so the reduction itself is fully axiom-free and machine-checked. Discharging `suff` with the parent's `legendre_three_squares` yields the unconditional theorem — the assumption is quarantined, not hidden.",
+      "The triangular division $T(k) = k(k+1)/2$ is exact in ℕ because $k(k+1)$ is even (`Nat.even_mul_succ_self`), so `two_mul_tri` gives $2T(k) = k(k+1)$ with no rounding — a small but essential point for the natural-number identity to hold on the nose."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: Eureka as the 8n+3 Slice of Legendre",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Explains the context — the parent ThreeSquares proves Legendre necessity axiom-free and isolates sufficiency as an axiom — and states what this file adds: Gauss's Eureka theorem (every n is a sum of three triangular numbers), reduced axiom-free to three-square sufficiency applied only at 8n+3, with the connecting equivalence eight_mul_add_three_iff.",
+      "mathContext": "Legendre: $n = x^2+y^2+z^2 \\iff n \\ne 4^a(8b+7)$. Substituting $n \\mapsto 8n+3$ (never excluded) and using that odd squares are $8T(k)+1$ turns sufficiency into Eureka."
+    },
+    {
+      "id": "definitions",
+      "title": "Triangular Numbers and the Three-Triangular Predicate",
+      "startLine": 43,
+      "endLine": 65,
+      "summary": "Imports Mathlib and the parent ThreeSquares, opens its namespace. Defines tri k = k(k+1)/2 and IsSumThreeTriangular n (∃ a b c, T a + T b + T c = n), with simp lemmas tri 0=0, tri 1=1, tri 2=3 and two_mul_tri: 2·T(k)=k(k+1) (exact division since k(k+1) is even).",
+      "mathContext": "$T(k) = \\tfrac{k(k+1)}{2}$; $2T(k) = k(k+1)$ exactly because $k(k+1)$ is even. `IsSumThreeTriangular` is the predicate Gauss's theorem asserts of every $n$."
+    },
+    {
+      "id": "odd-square-identity",
+      "title": "Odd Squares Are 8·T(j)+1",
+      "startLine": 67,
+      "endLine": 95,
+      "summary": "The engine lemmas. sq_two_mul_add_one: (2a+1)² = 8·T(a)+1 over ℕ. odd_sq_eq_eight_tri_add_one: every odd integer's square equals 8·T(j)+1 for some natural j (via |x|=2j+1 and casting). odd_of_sq_mod_four_one: an integer with x²≡1 (mod 4) is odd (the even case gives x²=4m²≡0, contradiction).",
+      "mathContext": "$(2a+1)^2 = 4a(a+1)+1 = 8T(a)+1$. Conversely $x^2 \\equiv 1 \\pmod 4 \\Rightarrow x$ odd, since an even $x=2m$ has $x^2 = 4m^2 \\equiv 0$."
+    },
+    {
+      "id": "key-equivalence",
+      "title": "eight_mul_add_three_iff: the Bridge Equivalence",
+      "startLine": 97,
+      "endLine": 134,
+      "summary": "The central theorem: 8n+3 is a sum of three integer squares iff n is a sum of three triangular numbers. Forward — mod-4 forces x,y,z all odd, each square becomes 8·T(j)+1, and the equation reduces to T(jx)+T(jy)+T(jz)=n. Backward — take x=2a+1 etc. and expand via the identity, closing with linarith.",
+      "mathContext": "$\\sum (2j_i+1)^2 = 8\\sum T(j_i) + 3$, so $8n+3 = \\sum x_i^2$ with all $x_i$ odd $\\iff n = \\sum T(j_i)$. The forced oddness (mod 4) makes the equivalence exact."
+    },
+    {
+      "id": "reduction",
+      "title": "Non-Exclusion and the Eureka Reduction",
+      "startLine": 136,
+      "endLine": 168,
+      "summary": "not_excluded_eight_mul_add_three: 8n+3 is odd and ≡ 3 (mod 8) ≠ 7, so via odd_excluded_iff it is never of the excluded form 4^a(8b+7). gauss_eureka_of_sufficiency: from a sufficiency hypothesis applied at 8n+3, derive IsSumThreeTriangular n axiom-free. eureka_iff_three_square_repr: the equivalence restated Eureka-first.",
+      "mathContext": "$8n+3 \\equiv 3 \\pmod 8 \\ne 7$, so Legendre sufficiency applies; composing with the bridge equivalence yields Gauss's theorem for every $n$, conditional only on the (separately axiom) sufficiency."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "Gauss's Eureka theorem — every natural number is a sum of three triangular numbers T(k)=k(k+1)/2 — is shown to be exactly the 8n+3 slice of Legendre's three-square theorem. The verified, axiom-free core is the equivalence eight_mul_add_three_iff: 8n+3 is a sum of three integer squares iff n is a sum of three triangular numbers. The forward direction observes that 8n+3 ≡ 3 (mod 4) forces a three-square representation to use three ODD squares, each of which is exactly 8·T(j)+1 (via |x|=2j+1); the backward direction runs the identity (2a+1)²=8·T(a)+1 in reverse. Since 8n+3 is odd and ≡ 3 (mod 8) ≠ 7 it is never of the excluded form 4^a(8b+7), so the sufficiency direction of Legendre's theorem always applies: gauss_eureka_of_sufficiency derives Eureka axiom-free from sufficiency supplied as a hypothesis (dischargeable by ThreeSquares.legendre_three_squares). 168 lines, 8 theorems/lemmas, 2 definitions, 0 axioms, 0 sorries; the named theorems depend only on propext, Classical.choice, Quot.sound.",


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-01` (quality 10, pass 0).

## What changed

The entry had **no `overview` field** (so the page rendered nothing for the introduction/overview), an **empty `sections` array**, and **no `annotations.json`**. Its `conclusion`, `originalContributions`, `references`, and `openQuestions` were already strong and are untouched.

- **overview** (new) → structured object: `historicalContext` (Gauss's 10 July 1796 ΕΥΡΗΚΑ diary entry, *Disquisitiones* art. 293, Legendre 1798, Cauchy's 1813 polygonal-number theorem), `problemStatement`, `proofStrategy` (the mod-4 forced-oddness argument), and **5 keyInsights**.
- **sections** (new) → 5 sections covering the whole Lean file (header, definitions, odd-square identity, bridge equivalence, reduction) with per-section `mathContext`.
- **annotations.json** (new) → 5 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, walking $(2a+1)^2 = 8T(a)+1$, the `eight_mul_add_three_iff` equivalence, and the axiom-free Eureka reduction.

## Accuracy / axiom integrity

No status change. The reduction itself is genuinely 0-axiom, 0-sorry — three-square *sufficiency* is kept as an explicit hypothesis `suff` (dischargeable by the parent's `legendre_three_squares`), so nothing is hidden. The annotations and overview state this quarantining explicitly. `status: verified` / `badge: original` preserved. `pnpm build` passes.