### PR TITLE
Enrich Davenport Constant D(ℤ/nℤ) = n (Erdős #131)

### DIFF
--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-erdos131-davconst-overview",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "The Davenport Constant and Why Mathlib Lacks It",
+    "content": "The docstring sets the goal: formalize the cyclic Davenport constant exactly, D(ℤ/nℤ) = n. The Davenport constant D(G) of a finite abelian group is the least d such that every length-d sequence over G has a nonempty zero-sum subsequence — a fundamental zero-sum invariant from algebraic number theory (it bounds factorization lengths in class groups). Mathlib has the Erdős–Ginzburg–Ziv theorem (the constant s(ℤ/nℤ) = 2n − 1, demanding a zero-sum of length exactly n) but NOT the Davenport constant (any nonempty length). For cyclic groups the two satisfy D = n < 2n − 1 = s. The companion entry proved only D(ℤ/aℤ) ≤ a for distinct naturals; this file proves the exact value in the genuine sequence setting.",
+    "mathContext": "$D(G) = \\min\\{d : \\text{every length-}d\\text{ sequence has a nonempty zero-sum subsequence}\\}$; for cyclic $G$, $D(\\mathbb{Z}/n\\mathbb{Z}) = n$.",
+    "significance": "key",
+    "relatedConcepts": ["Davenport constant", "Erdős–Ginzburg–Ziv constant", "zero-sum sequences", "class group factorization", "Erdős #131"],
+    "prerequisites": ["finite abelian groups", "ZMod n", "additive combinatorics"]
+  },
+  {
+    "id": "ann-erdos131-davconst-def",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 49, "endLine": 53 },
+    "type": "definition",
+    "title": "HasZeroSumSubseq: Nonempty Zero-Sum Subsequence",
+    "content": "HasZeroSumSubseq f (for f : Fin m → ZMod n) holds when some nonempty index set s : Finset (Fin m) has ∑_{i∈s} f i = 0. Modelling a 'sequence' as a function Fin m → ZMod n (rather than a multiset) lets indices repeat values freely, which is exactly the Davenport setting (sequences, not sets). The Davenport constant is the least m such that EVERY such f has this property — captured below as an IsLeast statement.",
+    "mathContext": "$\\mathrm{HasZeroSumSubseq}(f) \\iff \\exists s\\subseteq \\mathrm{Fin}\\,m,\\ s\\ne\\varnothing,\\ \\sum_{i\\in s} f(i) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["zero-sum subsequence", "Finset", "sequences over ZMod n"],
+    "prerequisites": ["Finset sums", "ZMod n arithmetic"]
+  },
+  {
+    "id": "ann-erdos131-davconst-upper",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 55, "endLine": 106 },
+    "type": "theorem",
+    "title": "davenport_upper: The Prefix-Sum Pigeonhole",
+    "content": "The upper bound D(ℤ/nℤ) ≤ n: any length-≥n sequence has a nonempty zero-sum subsequence. The proof forms the m + 1 prefix sums P k = ∑_{i.val < k} f i, all in the n-element type ZMod n. The core sublemma converts a collision P p = P q (p < q) into the zero-sum interval [p, q): it is nonempty (contains p), and splitting the prefix [0, q) = [0, p) ⊔ [p, q) as disjoint filters with Finset.sum_union gives P q = P p + (block sum), so the block sum = P q − P p = 0 (linear_combination). Pigeonhole Fintype.exists_ne_map_eq_of_card_lt forces the collision since |ZMod n| = n < m + 1.",
+    "mathContext": "$P_k = \\sum_{i<k} f(i)$; $n$ values, $m+1$ indices $\\Rightarrow$ collision $P_p = P_q$ ($p<q$); $\\sum_{p\\le i<q} f(i) = 0$.",
+    "significance": "critical",
+    "relatedConcepts": ["pigeonhole principle", "prefix sums", "Finset.sum_union", "Fintype.exists_ne_map_eq_of_card_lt", "telescoping"],
+    "prerequisites": ["prefix-sum collisions", "disjoint filter splitting", "ZMod.card"]
+  },
+  {
+    "id": "ann-erdos131-davconst-lower",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 108, "endLine": 123 },
+    "type": "theorem",
+    "title": "davenport_no_zerosum_const_one: The Sharpness Witness",
+    "content": "The lower bound D(ℤ/nℤ) ≥ n: the constant-1 sequence of any length m < n is zero-sum-free. A nonempty subset s sums (Finset.sum_const, nsmul_eq_mul, mul_one) to (|s| : ZMod n); if that were 0 then n ∣ |s| (ZMod.natCast_eq_zero_iff), but 1 ≤ |s| ≤ m < n makes that impossible (Nat.not_dvd_of_pos_of_lt). So no length below n is a Davenport length — the 'n − 1 repeated ones' configuration is the extremal zero-sum-free sequence, which is precisely the witness for the general lower bound D(G) ≥ 1 + ∑(nᵢ − 1) specialized to cyclic groups.",
+    "mathContext": "$\\sum_{i\\in s} 1 = (|s| \\bmod n)$, $1\\le|s|\\le m<n \\Rightarrow$ sum $\\ne 0$; the sequence $1^{n-1}$ is zero-sum-free.",
+    "significance": "key",
+    "relatedConcepts": ["sharpness", "zero-sum-free sequence", "extremal witness", "ZMod.natCast_eq_zero_iff"],
+    "prerequisites": ["Finset.sum_const", "divisibility bounds in ℕ"]
+  },
+  {
+    "id": "ann-erdos131-davconst-isleast",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 125, "endLine": 153 },
+    "type": "theorem",
+    "title": "davenport_constant_cyclic: D(ℤ/nℤ) = n as IsLeast",
+    "content": "The headline result packages both halves into IsLeast {m | ∀ f : Fin m → ZMod n, HasZeroSumSubseq f} n: (1) n is a member of the set — every length-n sequence has a zero-sum subsequence (davenport_upper at m = n); (2) n is a lower bound — any length m in the set must be ≥ n, since otherwise the constant-1 witness contradicts membership. Stating it as IsLeast is the correct notion of 'the constant', and davenport_isLeast_eq then gives uniqueness for free via IsLeast.unique: any d with this least-property equals n.",
+    "mathContext": "$\\mathrm{IsLeast}\\,\\{m : \\forall f,\\ \\mathrm{HasZeroSumSubseq}\\,f\\}\\ n$ — both 'n works' and 'n minimal', hence $D(\\mathbb{Z}/n\\mathbb{Z}) = n$ uniquely.",
+    "significance": "key",
+    "relatedConcepts": ["IsLeast", "IsLeast.unique", "least element", "exact invariant"],
+    "prerequisites": ["the upper and lower bounds", "order theory (IsLeast)"]
+  },
+  {
+    "id": "ann-erdos131-davconst-strengthen",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 155, "endLine": 170 },
+    "type": "insight",
+    "title": "exists_index_subset_sum_dvd: Strengthening the Companion Bound",
+    "content": "Specializing davenport_upper to the sequence i ↦ (g i : ZMod n) recovers, for ANY function g : Fin m → ℕ with n ≤ m, a nonempty index set whose g-sum is divisible by n — the Davenport bound in integer-divisibility form, now WITHOUT the distinctness restriction of the companion Erdos131DavenportBound (which required a Finset ℕ of distinct values). This shows the companion's bound is the special case, and that the sequence formulation here is strictly more general: repeated values are allowed.",
+    "mathContext": "For $g : \\mathrm{Fin}\\,m \\to \\mathbb{N}$ with $n\\le m$: $\\exists s\\ne\\varnothing,\\ n \\mid \\sum_{i\\in s} g(i)$, via $i\\mapsto (g(i):\\mathbb{Z}/n\\mathbb{Z})$ and ZMod.natCast_eq_zero_iff.",
+    "significance": "supporting",
+    "relatedConcepts": ["integer-divisibility form", "generalization", "non-distinct sequences", "ZMod.natCast_eq_zero_iff"],
+    "prerequisites": ["davenport_upper", "casting ℕ → ZMod n"]
+  }
+]

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -17,6 +17,19 @@
     "sorries": 0
   },
   "title": "The Davenport Constant of the Cyclic Group ℤ/nℤ is Exactly n (Erdős #131)",
+  "description": "A complete, axiom-free formalization of the cyclic Davenport constant: D(ℤ/nℤ) = n, stated as an IsLeast theorem. The upper bound D(ℤ/nℤ) ≤ n is the prefix-sum pigeonhole — among the n+1 prefix sums of any length-≥n sequence over ℤ/nℤ, two collide, and the index interval between them is a nonempty zero-sum subsequence. The matching lower bound is witnessed by the constant-1 sequence of length n−1, which is zero-sum-free. Mathlib has the larger EGZ constant 2n−1 but not the Davenport constant, so this is built from scratch and supplies the exact invariant behind the companion non-dividing-set bounds. Fully verified, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Davenport constant D(G) of a finite abelian group G is the least d such that every length-d sequence over G contains a nonempty zero-sum subsequence. The invariant is named for Harold Davenport, who in the 1960s popularized the question (motivated by algebraic number theory: D(G) for G the ideal class group bounds the number of prime ideals in an irreducible factorization). For cyclic groups the answer D(ℤ/nℤ) = n is classical and elementary — the prefix-sum pigeonhole goes back to the folklore behind the Erdős–Ginzburg–Ziv theorem (1961) itself. The Davenport and EGZ constants are the two fundamental zero-sum invariants: D(G) asks for a zero-sum subsequence of ANY nonempty length, while the EGZ constant s(G) asks for one of length exactly exp(G); for cyclic groups D(ℤ/nℤ) = n < 2n − 1 = s(ℤ/nℤ). The general-group Davenport constant is far harder: Olson (1969) computed it for p-groups and rank ≤ 2, and D(G) ≥ 1 + ∑(nᵢ − 1) always, but equality can fail for rank ≥ 4. This entry formalizes the cyclic case in full, which Mathlib lacks despite having EGZ.",
+    "problemStatement": "Prove that the Davenport constant of ℤ/nℤ is exactly n: the least m such that every sequence f : Fin m → ZMod n has a nonempty index set s with ∑_{i∈s} f i = 0 is m = n. This requires both an upper bound (length n always suffices) and a sharpness/lower bound (no length m < n suffices), stated jointly as IsLeast {m | ∀ f, HasZeroSumSubseq f} n.",
+    "proofStrategy": "Upper bound (davenport_upper): for a length-m sequence with n ≤ m, consider the m + 1 prefix sums P k = ∑_{i.val < k} f i, all valued in the n-element type ZMod n. Since n < m + 1, pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) gives two indices p < q with P p = P q; the index interval [p, q) is nonempty (contains p) and, by splitting the prefix [0, q) = [0, p) ⊔ [p, q) via Finset.sum_union, sums to P q − P p = 0. Lower bound (davenport_no_zerosum_const_one): the constant-1 sequence of length m < n is zero-sum-free — a nonempty subset of size k sums to (k : ZMod n) with 1 ≤ k ≤ m < n, hence ≠ 0 (via ZMod.natCast_eq_zero_iff and Nat.not_dvd_of_pos_of_lt). Combining the two as IsLeast gives D(ℤ/nℤ) = n; davenport_isLeast_eq extracts uniqueness, and exists_index_subset_sum_dvd specializes to the integer-divisibility form for arbitrary (non-distinct) index sequences.",
+    "keyInsights": [
+      "The prefix-sum pigeonhole is the canonical proof of D(ℤ/nℤ) ≤ n: n + 1 prefix sums into an n-element group must collide, and a collision IS a zero-sum block. This is the cyclic-group skeleton underlying the Erdős–Ginzburg–Ziv theorem.",
+      "Sharpness needs only one witness — the constant-1 sequence of length n − 1: every nonempty subsequence sums to its own length k ∈ {1,…,n−1}, never 0 mod n. This 'n − 1 repeated ones' configuration is the extremal zero-sum-free sequence, exactly the lower-bound witness for the general D(G) ≥ 1 + ∑(nᵢ − 1) bound specialized to cyclic.",
+      "Stating the result as IsLeast (rather than two separate inequalities) packages 'n works' and 'n is minimal' into the single correct notion of a constant, and yields uniqueness for free via IsLeast.unique.",
+      "This entry works in the GENUINE Davenport setting — arbitrary sequences f : Fin m → ZMod n — whereas the companion Erdos131DavenportBound only proved the upper bound for distinct naturals (a Finset ℕ). exists_index_subset_sum_dvd shows the companion's bound is the special case, removing the distinctness restriction.",
+      "The Davenport constant, not the EGZ constant, is the invariant that sharpens the non-dividing set bound to |A| ≤ a + 1: because non-dividing forbids zero-sum subsets of every size, the 'any nonempty length' Davenport constant n is what governs, versus the 'length exactly a' EGZ constant 2a − 1."
+    ]
+  },
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -131,9 +144,57 @@
       "description": "The Erdős–Ginzburg–Ziv theorem and its constant s(ℤ/nℤ) = 2n − 1; the Davenport constant n is strictly smaller (it forbids zero-sum subsequences of every length, not just length n), the distinction exploited by the parent EGZ-sharpening entry."
     }
   ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Docstring: The Davenport Constant vs. EGZ",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Defines the Davenport constant D(G) (least d forcing a nonempty zero-sum subsequence) and contrasts it with the EGZ constant s(ℤ/nℤ) = 2n − 1 that Mathlib already has. States the goal — D(ℤ/nℤ) = n exactly, as an IsLeast — and previews both halves: the prefix-sum pigeonhole upper bound and the constant-1 sharpness witness. Notes the file is self-contained (only import Mathlib).",
+      "mathContext": "$D(\\mathbb{Z}/n\\mathbb{Z}) = n$ (any-length zero-sum) vs. $s(\\mathbb{Z}/n\\mathbb{Z}) = 2n-1$ (length-exactly-$n$ zero-sum)."
+    },
+    {
+      "id": "definition",
+      "title": "HasZeroSumSubseq: The Zero-Sum Subsequence Predicate",
+      "startLine": 43,
+      "endLine": 53,
+      "summary": "Defines HasZeroSumSubseq f for f : Fin m → ZMod n: some nonempty index set s : Finset (Fin m) has ∑_{i∈s} f i = 0. The Davenport constant is the least m for which every such sequence satisfies this.",
+      "mathContext": "$\\mathrm{HasZeroSumSubseq}(f) \\iff \\exists s\\ne\\varnothing,\\ \\sum_{i\\in s} f(i) = 0$ in $\\mathbb{Z}/n\\mathbb{Z}$."
+    },
+    {
+      "id": "upper-bound",
+      "title": "davenport_upper: D(ℤ/nℤ) ≤ n by Prefix-Sum Pigeonhole",
+      "startLine": 55,
+      "endLine": 106,
+      "summary": "Every length-≥n sequence has a nonempty zero-sum subsequence. The core sublemma turns a collision of two prefix sums P p = P q (p < q) into the zero-sum interval [p, q): it is nonempty (contains p) and sums to 0 via the prefix split [0,q) = [0,p) ⊔ [p,q) (Finset.sum_union on disjoint filters) plus linear_combination. Pigeonhole (Fintype.exists_ne_map_eq_of_card_lt) on the m + 1 prefix sums into the n-element ZMod n forces the collision.",
+      "mathContext": "$P_k = \\sum_{i<k} f(i) \\in \\mathbb{Z}/n\\mathbb{Z}$ ($n$ values, $m+1>n$ indices) collide at $p<q$; $\\sum_{p\\le i<q} f(i) = P_q - P_p = 0$."
+    },
+    {
+      "id": "lower-bound",
+      "title": "davenport_no_zerosum_const_one: Sharpness D(ℤ/nℤ) ≥ n",
+      "startLine": 108,
+      "endLine": 123,
+      "summary": "The constant-1 sequence of length m < n is zero-sum-free. A nonempty subset s sums (Finset.sum_const) to (|s| : ZMod n); = 0 would force n ∣ |s| (ZMod.natCast_eq_zero_iff), impossible since 1 ≤ |s| ≤ m < n (Nat.not_dvd_of_pos_of_lt). So no length below n is a Davenport length.",
+      "mathContext": "$\\sum_{i\\in s} 1 = (|s|\\bmod n)$ with $1\\le|s|\\le m<n$, so the sum is $\\ne 0$; the sequence $1^{n-1}$ is the extremal zero-sum-free witness."
+    },
+    {
+      "id": "main-isleast",
+      "title": "davenport_constant_cyclic: D(ℤ/nℤ) = n, and Corollaries",
+      "startLine": 125,
+      "endLine": 170,
+      "summary": "davenport_constant_cyclic packages both halves as IsLeast {m | ∀ f, HasZeroSumSubseq f} n: n is in the set (davenport_upper) and is a lower bound (any smaller length is refuted by the constant-1 witness). mem_davenport_set_of_ge is the membership form; davenport_isLeast_eq extracts uniqueness via IsLeast.unique; exists_index_subset_sum_dvd specializes to the integer-divisibility form for arbitrary g : Fin m → ℕ, dropping the companion's distinctness restriction.",
+      "mathContext": "$\\mathrm{IsLeast}\\,\\{m : \\forall f,\\ \\mathrm{HasZeroSumSubseq}\\,f\\}\\ n$, i.e. $D(\\mathbb{Z}/n\\mathbb{Z}) = n$ exactly, with uniqueness."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "The Davenport constant of the cyclic group ℤ/nℤ — the least length d such that every length-d sequence over ℤ/nℤ has a nonempty zero-sum subsequence — is exactly n (davenport_constant_cyclic, stated as IsLeast). The upper bound D(ℤ/nℤ) ≤ n (davenport_upper) holds for arbitrary sequences f : Fin m → ZMod n with n ≤ m: the m + 1 prefix sums collide in the n-element type ZMod n by pigeonhole, and the index interval between a collision sums to zero (prefix split via Finset.sum_union) and is nonempty. The matching lower bound (davenport_no_zerosum_const_one) shows sharpness: for every m < n the constant sequence 1 of length m is zero-sum-free, since any nonempty subsequence of size k sums to (k : ZMod n) with 1 ≤ k ≤ m < n. A corollary (exists_index_subset_sum_dvd) recovers and strengthens the companion entry's integer-divisibility bound to arbitrary (non-distinct) index sequences, and davenport_isLeast_eq extracts uniqueness. 170 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
-    "implications": "The entry provides a complete, exact, axiom-free formalization of the cyclic Davenport constant D(ℤ/nℤ) = n — a named additive-combinatorial invariant Mathlib lacks (it has only the larger EGZ constant 2n − 1). Where the companion EGZ-sharpening entry needed only the upper bound (and only for distinct naturals) to bound non-dividing sets, this entry pins the invariant exactly and in its proper sequence generality, supplying the prefix-sum pigeonhole upper bound and the extremal zero-sum-free witness (n − 1 repeated ones) as reusable infrastructure. It sets up the natural generalisations to rank-2 and p-group Davenport constants posed in the open questions."
+    "implications": "The entry provides a complete, exact, axiom-free formalization of the cyclic Davenport constant D(ℤ/nℤ) = n — a named additive-combinatorial invariant Mathlib lacks (it has only the larger EGZ constant 2n − 1). Where the companion EGZ-sharpening entry needed only the upper bound (and only for distinct naturals) to bound non-dividing sets, this entry pins the invariant exactly and in its proper sequence generality, supplying the prefix-sum pigeonhole upper bound and the extremal zero-sum-free witness (n − 1 repeated ones) as reusable infrastructure. It sets up the natural generalisations to rank-2 and p-group Davenport constants posed in the open questions.",
+    "openQuestions": [
+      "Can the prefix-sum pigeonhole upper bound be lifted to the rank-2 group D(ℤ/n₁ ⊕ ℤ/n₂) = n₁ + n₂ − 1 by an elementary, axiom-free argument? The general-group Davenport constant satisfies D(G) ≥ 1 + ∑(nᵢ − 1) with equality for rank ≤ 2 and for p-groups (Olson) but not in general.",
+      "The exact constant D(ℤ/nℤ) = n drives the non-dividing set bound |A| ≤ a + 1, but the SET version (distinct elements) may have a strictly smaller threshold than the sequence version. What is the least m such that every m-element subset of ℕ contains a nonempty zero-sum subset mod n, and does it differ from the Davenport constant n?",
+      "Could this be packaged as a reusable Mathlib API — a general definition of the Davenport constant for finite abelian groups with the cyclic value D(ℤ/nℤ) = n as the first instance — alongside the existing EGZ formalization?",
+      "Is there a decidable / computable formulation of HasZeroSumSubseq enabling concrete Davenport-constant computations for small non-cyclic groups by decision procedure?"
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for `erdos-131-oq-01-oq-01-oq-01-oq-03` (quality **10 → 100**, passes 0). The entry had `meta`, `references`, `crossReferences`, top-level `openQuestions`, and a structured `conclusion` (summary + implications) but no `description`, `overview`, `sections`, or annotations.

## Changes
- **description**: added (entry had none).
- **overview**: structured `ProofOverview` — historicalContext (Davenport constant, Olson 1969, EGZ 1961, the D(G) vs s(G) distinction), problemStatement, proofStrategy (prefix-sum pigeonhole + constant-1 witness), 5 keyInsights.
- **sections**: 5 sections covering the full 170-line Lean file (docstring, HasZeroSumSubseq, the upper-bound pigeonhole, the sharpness witness, the IsLeast headline + corollaries), each with mathContext.
- **conclusion.openQuestions**: added 4 (rank-2 D(G), set-vs-sequence threshold, Mathlib Davenport API, decidability).
- **annotations.json**: created with 6 annotations, each with mathContext (LaTeX), significance, relatedConcepts, prerequisites.

Quality 10 → 100 across all rubric categories.

## Axiom integrity
0 `axiom` declarations, 0 sorries, no `native_decide`. `status: verified` / `badge: original` / `axiomCount: 0` accurate (propext, Classical.choice, Quot.sound only).

`pnpm build` passes.