### PR TITLE
Enrich: Baire Category Theorem & the Uncountability of ℝ

### DIFF
--- a/src/data/proofs/baire-category-theorem-oq-01/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-baire-oq01-docstring",
+    "proofId": "baire-category-theorem-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Baire's Theorem and Why It Matters",
+    "content": "The docstring frames the entry. Baire's category theorem (1899) says a complete (pseudo)metric space — or any BaireSpace — cannot be topologically 'small' (meagre) in itself. Mathlib packages the abstract theorem through named lemmas (dense_iInter_of_isOpen, nonempty_interior_of_iUnion_of_closed, not_isMeagre_of_isOpen, and the BaireSpace.of_completelyPseudoMetrizable instance), which this file re-exports — hence the mathlib badge. On top it records the content the gallery lacked: the contrapositive category form, the non-meagreness of the whole space, and the classical uncountability of ℝ derived from Baire. Everything is machine-checked with no sorry and no native_decide.",
+    "mathContext": "A set is *meagre* (first category) if it is a countable union of nowhere-dense sets. Baire: a nonempty complete metric space is *not* meagre in itself.",
+    "significance": "context",
+    "relatedConcepts": ["Baire category theorem", "meagre sets", "complete metric space", "functional analysis", "descriptive set theory"],
+    "prerequisites": ["metric/topological spaces", "open and closed sets", "countable unions"]
+  },
+  {
+    "id": "ann-baire-oq01-abstract",
+    "proofId": "baire-category-theorem-oq-01",
+    "range": { "startLine": 39, "endLine": 72 },
+    "type": "theorem",
+    "title": "The Two Dual Forms and the Contrapositive",
+    "content": "Part (a). baire_dense_iInter re-exports the dense-Gδ form: in any BaireSpace, a countable intersection of dense open sets is dense. baire_nonempty_interior re-exports the category form: if countably many closed sets cover a nonempty Baire space, one has nonempty interior. The genuinely new baire_not_iUnion_empty_interior is the contrapositive: assume a countable closed cover with all interiors empty, apply the category form to get a piece with nonempty interior, and derive a contradiction (not_nonempty_empty after rewriting interior = ∅). baire_univ_not_meagre specializes not_isMeagre_of_isOpen to the open, nonempty universal set: the whole space is non-meagre. The contrapositive form is the one functional-analysis arguments actually consume.",
+    "mathContext": "Dense-$G_\\delta$: $\\overline{\\bigcap_i U_i} = X$ for dense open $U_i$. Category: $\\bigcup_i F_i = X$, $F_i$ closed $\\Rightarrow \\exists i,\\ \\mathrm{int}\\,F_i \\ne \\emptyset$. Contrapositive: all $\\mathrm{int}\\,F_i = \\emptyset \\Rightarrow \\bigcup_i F_i \\ne X$.",
+    "significance": "key",
+    "relatedConcepts": ["dense_iInter_of_isOpen", "nonempty_interior_of_iUnion_of_closed", "contrapositive", "non-meagre space", "interior"],
+    "prerequisites": ["Baire space", "interior and closure", "proof by contradiction"]
+  },
+  {
+    "id": "ann-baire-oq01-instance",
+    "proofId": "baire-category-theorem-oq-01",
+    "range": { "startLine": 74, "endLine": 78 },
+    "type": "technique",
+    "title": "ℝ Is a Baire Space — for Free",
+    "content": "Part (b). baireSpace_real : BaireSpace ℝ is obtained by inferInstance, resolved automatically through BaireSpace.of_completelyPseudoMetrizable: every complete metrizable space is a Baire space, and ℝ is complete and metrizable. This is the single piece where the genuinely deep theorem (completeness ⇒ Baire) is invoked; everything downstream is elementary topology over the meagre/nowhere-dense API. The one-liner makes explicit that the entire uncountability argument rests on the completeness of ℝ.",
+    "mathContext": "Completeness $\\Rightarrow$ Baire is Mathlib's `BaireSpace.of_completelyPseudoMetrizable`; ℝ being a complete metric space inherits the `BaireSpace` instance.",
+    "significance": "supporting",
+    "relatedConcepts": ["BaireSpace.of_completelyPseudoMetrizable", "completeness", "metrizability", "typeclass inference"],
+    "prerequisites": ["complete metric spaces", "Lean typeclass resolution"]
+  },
+  {
+    "id": "ann-baire-oq01-singletons",
+    "proofId": "baire-category-theorem-oq-01",
+    "range": { "startLine": 80, "endLine": 105 },
+    "type": "insight",
+    "title": "Singletons and Countable Sets Are Meagre in ℝ",
+    "content": "Part (c), the engine of uncountability. isMeagre_singleton_real proves {x} ⊆ ℝ is meagre: via isMeagre_iff_countable_union_isNowhereDense it suffices that {x} is nowhere dense, and IsClosed.isNowhereDense_iff reduces this to interior {x} = ∅ — which holds because ℝ has no isolated points (interior_singleton). isMeagre_of_countable_real then writes any countable s as the countable union of its singletons (the image of s under x ↦ {x}), each nowhere dense, so s is meagre. The key topological fact is that points in ℝ are nowhere dense; this is exactly what fails in a discrete space, where singletons are open and the argument breaks.",
+    "mathContext": "$\\mathrm{int}\\{x\\} = \\emptyset$ (no isolated points) $\\Rightarrow \\{x\\}$ nowhere dense $\\Rightarrow$ countable $s = \\bigcup_{x\\in s}\\{x\\}$ is meagre.",
+    "significance": "key",
+    "relatedConcepts": ["IsMeagre", "IsNowhereDense", "interior_singleton", "no isolated points", "countable union"],
+    "prerequisites": ["meagre/nowhere-dense characterization", "interior of singletons", "countable image"]
+  },
+  {
+    "id": "ann-baire-oq01-uncountable",
+    "proofId": "baire-category-theorem-oq-01",
+    "range": { "startLine": 107, "endLine": 118 },
+    "type": "theorem",
+    "title": "Uncountability of ℝ via Baire",
+    "content": "real_uncountable is the payoff: if ℝ were countable then by isMeagre_of_countable_real the whole space would be meagre, contradicting baire_univ_not_meagre (a nonempty Baire space is non-meagre). real_not_iUnion_singletons restates this concretely through the contrapositive category form: ℝ is never the union of countably many singletons ⋃ₙ {g n}, since each {g n} is closed with empty interior. This is the textbook theorem 'a nonempty perfect complete metric space is uncountable', specialized to ℝ and made fully explicit — a categorically different proof from Cantor's diagonal argument, using completeness rather than a digit construction.",
+    "mathContext": "Countable ℝ $\\Rightarrow$ ℝ meagre in itself $\\Rightarrow\\!\\Leftarrow$ Baire non-meagreness. Hence $\\neg(\\mathrm{univ} : \\mathrm{Set}\\,\\mathbb R).\\mathrm{Countable}$.",
+    "significance": "key",
+    "relatedConcepts": ["uncountability of ℝ", "Baire non-meagreness", "perfect set", "Cantor's theorem (alternative)"],
+    "prerequisites": ["isMeagre_of_countable_real", "baire_univ_not_meagre", "the contrapositive category form"]
+  }
+]

--- a/src/data/proofs/baire-category-theorem-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01/meta.json
@@ -116,6 +116,52 @@
       "description": "Source of dense_iInter_of_isOpen, nonempty_interior_of_iUnion_of_closed, not_isMeagre_of_isOpen and the BaireSpace.of_completelyPseudoMetrizable instance re-exported in this entry."
     }
   ],
+  "overview": {
+    "historicalContext": "René-Louis Baire introduced his category theorem in his 1899 thesis *Sur les fonctions de variables réelles*, alongside the notions of *first category* (meagre) and *second category* sets. The terminology is unfortunate — 'category' here has nothing to do with category theory — but the idea is fundamental: a *meagre* set (a countable union of nowhere-dense sets) is 'topologically small', and Baire's theorem says a complete metric space is *not* small in itself. This is the topological 'largeness' principle that powers three of the cornerstone theorems of functional analysis — the Banach–Steinhaus uniform boundedness principle, the open mapping theorem, and the closed graph theorem — each of which extracts a point of nonempty interior from a Baire-category argument. The theorem also gives the slickest proof that ℝ is uncountable: were ℝ countable it would be a countable union of (nowhere-dense) singletons, hence meagre in itself, contradicting Baire. Mathlib formalizes the abstract theorem through the `BaireSpace` typeclass; this entry re-exports those forms (hence the `mathlib` badge) and adds the dual 'not meagre in itself' packaging together with the explicit ℝ-uncountability application.",
+    "problemStatement": "Baire's theorem, for any `BaireSpace` $X$ (e.g. any complete metric space), in two dual forms: (dense-$G_\\delta$) a countable intersection of dense open sets is dense; (category) if countably many closed sets cover a nonempty $X$, one has nonempty interior. The entry supplies the contrapositive form Mathlib lacks — a nonempty Baire space is never a countable union of closed sets all with empty interior (`baire_not_iUnion_empty_interior`) — equivalently the whole space is non-meagre (`baire_univ_not_meagre`). It then instantiates $X = \\mathbb R$ and derives: every singleton is meagre, every countable subset is meagre, and therefore $\\mathbb R$ is uncountable (`real_uncountable`), never a countable union of singletons.",
+    "proofStrategy": "Part (a) re-exports the abstract lemmas: `baire_dense_iInter := dense_iInter_of_isOpen`, `baire_nonempty_interior := nonempty_interior_of_iUnion_of_closed`. The new `baire_not_iUnion_empty_interior` is the contrapositive: assume a countable closed cover with all-empty interiors; the category form yields some piece with nonempty interior, contradicting the hypothesis. `baire_univ_not_meagre` specializes `not_isMeagre_of_isOpen` to the (open, nonempty) universal set. Part (b) gets `BaireSpace ℝ` for free from `BaireSpace.of_completelyPseudoMetrizable` (ℝ is complete metrizable), via `inferInstance`. Part (c): a singleton $\\{x\\} \\subseteq \\mathbb R$ is closed with empty interior (`interior_singleton`, as ℝ has no isolated points), hence nowhere dense and meagre; a countable set is the countable union of its singletons, so meagre (`isMeagre_iff_countable_union_isNowhereDense`); finally, a countable ℝ would be meagre in itself, contradicting `baire_univ_not_meagre`.",
+    "keyInsights": [
+      "Baire's theorem is a 'largeness' dichotomy: a complete metric space cannot be the countable union of nowhere-dense pieces. Everything else here is bookkeeping that converts that one fact into either a dense-intersection statement or a nonempty-interior statement, depending on whether you phrase smallness via open or closed sets.",
+      "The uncountability of ℝ becomes a one-line corollary once you have two ingredients: ℝ is a Baire space (completeness), and points are nowhere dense (no isolated points). A countable set is then meagre, but the whole space is not — so the space is uncountable. The same argument gives that *any* perfect complete metric space is uncountable.",
+      "The contrapositive 'category form' `baire_not_iUnion_empty_interior` is the shape actually used in practice (and the piece Mathlib did not expose directly): functional-analysis applications start from a countable closed cover and need to *produce* a fat piece, so the negation of 'all interiors empty' is exactly the usable statement.",
+      "The `mathlib` badge is honest: the deep theorem (completeness ⇒ Baire) is delegated to Mathlib's `BaireSpace.of_completelyPseudoMetrizable`. The original content is the dual-form packaging and the fully explicit meagre/nowhere-dense derivation of ℝ's uncountability, which the gallery previously lacked.",
+      "Meagreness is the right abstraction layer: working through `IsMeagre` / `IsNowhereDense` rather than raw open covers makes the singleton ⟹ countable ⟹ uncountable chain almost mechanical, each step a short rewrite via the meagre-set characterization."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Baire and Its Consequences",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "States Baire's theorem (1899) as the backbone of functional analysis and descriptive set theory, lists the Mathlib lemmas re-exported (justifying the mathlib badge), and previews the added content: the contrapositive category form, non-meagreness of the whole space, and the Baire-based uncountability of ℝ.",
+      "mathContext": "A complete (pseudo)metric space — any `BaireSpace` — is not 'small': it is not a countable union of nowhere-dense sets. Dense-$G_\\delta$ and category forms are the two faces of this."
+    },
+    {
+      "id": "abstract-baire",
+      "title": "Part (a): The Abstract Baire Category Theorem",
+      "startLine": 39,
+      "endLine": 72,
+      "summary": "baire_dense_iInter (countable intersection of dense open sets is dense) and baire_nonempty_interior (a countable closed cover has a piece with nonempty interior) re-export Mathlib. baire_not_iUnion_empty_interior is the new contrapositive — a nonempty Baire space is not a countable union of empty-interior closed sets — and baire_univ_not_meagre states the whole space is non-meagre.",
+      "mathContext": "Category form: $\\bigcup_i F_i = X$ with $F_i$ closed $\\Rightarrow \\exists i,\\ \\mathrm{int}(F_i) \\ne \\emptyset$. Contrapositive: all $\\mathrm{int}(F_i) = \\emptyset \\Rightarrow \\bigcup_i F_i \\ne X$."
+    },
+    {
+      "id": "real-baire-instance",
+      "title": "Part (b): ℝ Is a Baire Space",
+      "startLine": 74,
+      "endLine": 78,
+      "summary": "baireSpace_real : BaireSpace ℝ, obtained by inferInstance from BaireSpace.of_completelyPseudoMetrizable — every complete metrizable space is Baire, and ℝ is complete and metrizable.",
+      "mathContext": "Completeness ⇒ Baire is the deep theorem; ℝ inherits it as a complete metric space. This is the one piece delegated entirely to Mathlib."
+    },
+    {
+      "id": "uncountability",
+      "title": "Part (c): ℝ Is Uncountable via Baire",
+      "startLine": 80,
+      "endLine": 118,
+      "summary": "isMeagre_singleton_real: a singleton is closed with empty interior, hence meagre (ℝ has no isolated points). isMeagre_of_countable_real: a countable set is a countable union of such singletons, hence meagre. real_uncountable: a countable ℝ would be meagre in itself, contradicting baire_univ_not_meagre. real_not_iUnion_singletons: concretely, ℝ ≠ ⋃ₙ {g n}.",
+      "mathContext": "$\\{x\\}$ nowhere dense (no isolated points) $\\Rightarrow$ countable sets meagre $\\Rightarrow$ ℝ (non-meagre) is uncountable. The textbook 'perfect complete metric space is uncountable' made explicit."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "The Baire category theorem states that a complete (pseudo)metric space — more generally any BaireSpace — is 'large': a countable intersection of dense open sets is dense (baire_dense_iInter), and dually a countable closed cover of a nonempty space has a member with nonempty interior (baire_nonempty_interior). This entry re-exports those abstract forms from Mathlib and adds the content the gallery lacked: the contrapositive 'not meagre in itself' statement that a nonempty Baire space is never a countable union of closed sets with empty interior (baire_not_iUnion_empty_interior), the non-meagreness of the whole space (baire_univ_not_meagre), the BaireSpace instance for ℝ (baireSpace_real), and a concrete application chain — singletons in ℝ are meagre (isMeagre_singleton_real), hence every countable subset is meagre (isMeagre_of_countable_real), so ℝ is uncountable (real_uncountable) and is never a countable union of singletons (real_not_iUnion_singletons). 119 lines, 9 theorems, 0 axioms, 0 sorries.",


### PR DESCRIPTION
Enrichment pass for `baire-category-theorem-oq-01` (quality 15, pass 0).

## What changed

The entry had **no `overview` field** (so the page rendered nothing for the introduction/overview), an **empty `sections` array**, and **no `annotations.json`**. Its `conclusion`, `originalContributions`, `references`, and `openQuestions` were already strong and are untouched.

- **overview** (new) → structured object: `historicalContext` (Baire's 1899 thesis, meagre/first-category terminology, the theorem's role behind Banach–Steinhaus / open mapping / closed graph), `problemStatement`, `proofStrategy`, and **5 keyInsights**.
- **sections** (new) → 4 sections covering the whole Lean file (docstring, abstract Baire forms, ℝ Baire instance, uncountability) with per-section `mathContext`.
- **annotations.json** (new) → 5 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, walking the dual forms + contrapositive, the `BaireSpace ℝ` instance, and the meagre-singleton ⟹ uncountable chain.

## Accuracy / axiom integrity

No status change. The `mathlib` badge is accurate and called out explicitly in the new content: the deep theorem (completeness ⇒ Baire) is delegated to Mathlib's `BaireSpace.of_completelyPseudoMetrizable`; the original content is the dual-form packaging + the explicit ℝ-uncountability derivation. 0 axioms, 0 sorries preserved. `pnpm build` passes.