### PR TITLE
audit: fix theoremCount 12→8 for amgm-inequality-oq-03-oq-02-oq-01-oq-02

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -53,7 +53,7 @@
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
-    "theoremCount": 12,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -228,7 +228,7 @@
     "namespace": "PowerMeanCrossZeroEq",
     "lineCount": 243,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 8,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean"


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `amgm-inequality-oq-03-oq-02-oq-01-oq-02` ("Equality Case of the Crossing-Zero Power-Mean Chain")

**Problem**: `theoremCount` claimed **12** but the Lean source declares exactly **8** theorems.

## Evidence

`proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean` declares 8 theorems (line-start `theorem` decls):

- `geomMean_rpow_eq_weightedSum_rpow_iff`
- `power_mean_eq_geom_mean_iff`
- `power_mean_crossing_zero_eq_iff`
- `power_mean_lt_geom_mean_neg_of_ne`
- `geom_mean_lt_power_mean_pos_of_ne`
- `power_mean_crossing_zero_lt_of_ne`
- `hm_eq_gm_iff`
- `hm_lt_gm_lt_am_of_ne`

0 `def`/`lemma` declarations in this file — the `weighted*` / `geomMean*` symbols are imported from the parents `AmgmInequalityOQ03`, `JensenInequalityOQ01`, `PowerMeanCrossZeroOQ`.

Both `meta.theoremCount` and `leanFile.theoremCount` read 12.

## Fix

`theoremCount` 12 → 8 in both `meta` and `leanFile` blocks. No change to `status` (verified), `badge` (original — genuine original equality-locus derivations with disclosed Mathlib dependencies), `sorries` (0), or `axiomCount` (0); those are accurate.

---
Discovered during gallery integrity audit.