### PR TITLE
Enrich: Egorov's Theorem — a.e. Convergence Is Almost Uniform

### DIFF
--- a/src/data/proofs/egorov-theorem-oq-01/annotations.json
+++ b/src/data/proofs/egorov-theorem-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-egorov-oq01-docstring",
+    "proofId": "egorov-theorem-oq-01",
+    "range": { "startLine": 7, "endLine": 56 },
+    "type": "context",
+    "title": "Egorov: a.e. Convergence Is Almost Uniform",
+    "content": "The docstring states Egorov's theorem (Egorov 1911, Severini 1910): on a set s of FINITE measure, a.e. convergence fₙ → g of strongly measurable functions upgrades to UNIFORM convergence once a set of arbitrarily small measure is thrown away. Mathlib has the abstract theorem (tendstoUniformlyOn_of_ae_tendsto); restated for sequences as egorov_uniform_off_small_set. The mathematical substance added here is the canonical worked example xⁿ on [0,1], its a.e.-convergence verification, and the matching sharpness result showing the exceptional set is genuinely necessary. Fully verified, 0 sorries, 0 axioms, no native_decide.",
+    "mathContext": "Egorov is Littlewood's second principle: 'every a.e.-convergent sequence of measurable functions is nearly uniformly convergent.' The finiteness of $\\mu(s)$ is essential.",
+    "significance": "context",
+    "relatedConcepts": ["Egorov's theorem", "modes of convergence", "Littlewood's three principles", "uniform vs a.e. convergence", "Lusin's theorem"],
+    "prerequisites": ["measure theory", "almost-everywhere convergence", "uniform convergence"]
+  },
+  {
+    "id": "ann-egorov-oq01-general",
+    "proofId": "egorov-theorem-oq-01",
+    "range": { "startLine": 63, "endLine": 79 },
+    "type": "theorem",
+    "title": "The Sequential Restatement",
+    "content": "egorov_uniform_off_small_set specializes Mathlib's tendstoUniformlyOn_of_ae_tendsto to the index type ℕ. Hypotheses: each fₙ and g strongly measurable, s measurable with μ s ≠ ∞ (finite measure), and fₙ → g almost everywhere on s. Conclusion: for every ε > 0 there is a measurable t ⊆ s with μ t ≤ ENNReal.ofReal ε such that TendstoUniformlyOn f g atTop (s \\ t). The proof is a one-line re-export; its value is exposing the theorem in the ℕ-indexed shape the gallery's examples need, with the finite-measure hypothesis made explicit as μ s ≠ ∞.",
+    "mathContext": "$f_n \\to g$ a.e. on measurable $s$ with $\\mu(s) < \\infty \\Rightarrow \\forall \\varepsilon>0\\ \\exists t \\subseteq s$ measurable, $\\mu(t) \\le \\varepsilon$, $f_n \\to g$ uniformly on $s \\setminus t$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tendstoUniformlyOn_of_ae_tendsto", "strong measurability", "finite measure", "TendstoUniformlyOn"],
+    "prerequisites": ["the abstract Egorov theorem", "ENNReal", "strongly measurable functions"]
+  },
+  {
+    "id": "ann-egorov-oq01-ae",
+    "proofId": "egorov-theorem-oq-01",
+    "range": { "startLine": 81, "endLine": 111 },
+    "type": "insight",
+    "title": "xⁿ → 0 a.e. and Egorov Applied",
+    "content": "pow_ae_tendsto_zero_on_Icc establishes the a.e. hypothesis: via ae_iff, the failure set {x | x ∈ [0,1] ∧ xⁿ ↛ 0} is shown ⊆ {1} (for 0 ≤ x < 1, tendsto_pow_atTop_nhds_zero_of_lt_one gives xⁿ → 0, so any failure forces x = 1), and {1} has Lebesgue measure 0 (Real.volume_singleton), so by measure_mono_null the failure set is null. pow_egorov_on_Icc then discharges Egorov's four hypotheses: strong measurability (continuity of x ↦ xⁿ), finiteness (Real.volume_Icc gives vol[0,1] = 1 ≠ ∞), the a.e. limit just proved, and ε > 0 — producing the small exceptional set off which xⁿ → 0 uniformly. The exceptional point x=1 is exactly where uniformity is lost.",
+    "mathContext": "Failure set $\\subseteq \\{1\\}$, $\\mathrm{vol}\\{1\\} = 0 \\Rightarrow x^n \\to 0$ a.e. on $[0,1]$; $\\mathrm{vol}[0,1]=1 < \\infty$ lets Egorov apply.",
+    "significance": "key",
+    "relatedConcepts": ["ae_iff", "measure_mono_null", "Real.volume_singleton", "tendsto_pow_atTop_nhds_zero_of_lt_one", "null set"],
+    "prerequisites": ["almost-everywhere statements", "Lebesgue measure of intervals/points", "limits of powers"]
+  },
+  {
+    "id": "ann-egorov-oq01-sharpness",
+    "proofId": "egorov-theorem-oq-01",
+    "range": { "startLine": 113, "endLine": 152 },
+    "type": "theorem",
+    "title": "Sharpness: Non-Uniformity on [0,1) via the IVT",
+    "content": "The necessity half. exists_pow_ge_half shows that for every exponent N there is x ∈ [0,1) with xᴺ ≥ 1/2: x ↦ xᴺ is continuous on [0,1] with values 0ᴺ=0 and 1ᴺ=1, so by intermediate_value_Icc it attains 1/2 at some x, and a short case analysis pushes that x into the half-open [0,1). pow_not_tendstoUniformlyOn_Ico then refutes uniform convergence on [0,1): assume it holds, unfold via Metric.tendstoUniformlyOn_iff at ε = 1/2 to get an index N past which dist(0, xᴺ) < 1/2 for all x ∈ [0,1); instantiate at the bad point from exists_pow_ge_half to obtain 1/2 ≤ xᴺ < 1/2, contradiction. So despite xⁿ → 0 at EVERY point of [0,1), the convergence is not uniform — Egorov's removed set is unavoidable.",
+    "mathContext": "$\\forall N\\ \\exists x \\in [0,1),\\ x^N \\ge 1/2$ (IVT), so $\\sup_{[0,1)} x^N \\not\\to 0$: pointwise-everywhere convergence does not imply uniform convergence.",
+    "significance": "key",
+    "relatedConcepts": ["intermediate_value_Icc", "Metric.tendstoUniformlyOn_iff", "non-uniform convergence", "sharpness", "necessity of hypotheses"],
+    "prerequisites": ["intermediate value theorem", "ε-definition of uniform convergence", "proof by contradiction"]
+  }
+]

--- a/src/data/proofs/egorov-theorem-oq-01/meta.json
+++ b/src/data/proofs/egorov-theorem-oq-01/meta.json
@@ -115,6 +115,52 @@
       "description": "Standard reference for Egorov's theorem (Thm 2.33), its finite-measure hypothesis, the canonical xⁿ example on [0,1], and the Egorov ⇒ Lusin implication."
     }
   ],
+  "overview": {
+    "historicalContext": "Egorov's theorem (Dmitri Egorov, 1911; independently Carlo Severini, 1910) is one of the 'three principles of Littlewood' that organize real analysis — Littlewood's heuristic that 'every measurable function is nearly continuous, every convergent sequence of measurable functions is nearly uniformly convergent, and every measurable set is nearly a finite union of intervals'. Egorov's is the second principle: it bridges the gap between pointwise (almost-everywhere) convergence and the much stronger uniform convergence, at the cost of discarding a set of arbitrarily small measure. The finiteness of the ambient measure is essential — the theorem fails on infinite measure spaces (the marching-bump sequence $1_{[n,n+1]}$ on ℝ converges to 0 everywhere but never uniformly off a small set). Egorov is the standard route to Lusin's theorem (Littlewood's first principle) and a workhorse in the theory of $L^p$ spaces and convergence in measure. Mathlib has the abstract theorem; this entry supplies the canonical worked example $x^n$ on $[0,1]$ together with the matching sharpness witness, which Mathlib lacks.",
+    "problemStatement": "Egorov's theorem: on a measurable set $s$ of finite measure, if strongly-measurable $f_n \\to g$ almost everywhere on $s$, then for every $\\varepsilon > 0$ there is a measurable $t \\subseteq s$ with $\\mu(t) \\le \\varepsilon$ such that $f_n \\to g$ *uniformly* on $s \\setminus t$. The entry restates this for sequences (`egorov_uniform_off_small_set`), then makes it concrete and non-vacuous on $f_n(x) = x^n$ over $[0,1]$: $x^n \\to 0$ Lebesgue-a.e. (the lone exceptional point $x=1$ is null), so Egorov extracts a small exceptional set off which convergence is uniform — and crucially the exceptional set cannot be dropped, since $x^n$ does *not* converge uniformly on the whole $[0,1)$ despite converging to 0 at every point there.",
+    "proofStrategy": "Three pieces. (1) `pow_ae_tendsto_zero_on_Icc`: the failure set $\\{x \\in [0,1] : x^n \\not\\to 0\\}$ is contained in $\\{1\\}$ (for $0 \\le x < 1$, $x^n \\to 0$ by `tendsto_pow_atTop_nhds_zero_of_lt_one`), and $\\{1\\}$ is Lebesgue-null (`Real.volume_singleton`), so convergence is a.e. (2) `pow_egorov_on_Icc`: feed strong measurability of $x \\mapsto x^n$ (continuity), finiteness $\\mathrm{vol}[0,1]=1<\\infty$, and the a.e. hypothesis into Mathlib's `tendstoUniformlyOn_of_ae_tendsto`. (3) Sharpness: `exists_pow_ge_half` uses the intermediate value theorem to find, for each $N$, an $x \\in [0,1)$ with $x^N \\ge 1/2$ (since $x \\mapsto x^N$ is continuous, $0^N=0$, $1^N=1$); then `pow_not_tendstoUniformlyOn_Ico` assumes uniform convergence, instantiates the $\\varepsilon = 1/2$ definition at that bad point, and derives $1/2 \\le x^N < 1/2$, a contradiction.",
+    "keyInsights": [
+      "Egorov is the precise statement that a.e. convergence is 'almost' uniform: you can always salvage uniform convergence by deleting an arbitrarily small (but generally nonempty) set. The entry pairs the theorem with its sharpness so both halves of 'almost, but not quite' are formal.",
+      "The example $x^n$ on $[0,1]$ is the canonical illustration precisely because its non-uniformity is so concrete: $\\sup_{x \\in [0,1)} x^n = 1$ for every $n$, so the convergence is never uniform, yet the obstruction is confined to a neighborhood of the single point $x=1$ — exactly the small set Egorov removes.",
+      "Sharpness is driven by the intermediate value theorem, not by measure theory: for any exponent $N$ there is a point in $[0,1)$ where $x^N \\ge 1/2$, so no uniform $\\varepsilon$-bound can hold past any index. This cleanly separates the pointwise convergence (which is genuine) from uniformity (which fails).",
+      "The finite-measure hypothesis is doing real work and is highlighted as an open question: on $[0,1]$ it is automatic ($\\mathrm{vol} = 1$), but on an infinite measure space Egorov is false — making the worked finite-measure instance the right place to see the theorem's content.",
+      "The `mathlib` badge is honest: the abstract theorem is Mathlib's `tendstoUniformlyOn_of_ae_tendsto`. The original, non-vacuous content is assembling a concrete instance (strong measurability + finiteness + a.e. convergence) and proving the non-uniformity witness, neither of which Mathlib records."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: a.e. Convergence Is Almost Uniform",
+      "startLine": 7,
+      "endLine": 56,
+      "summary": "States Egorov's theorem (Egorov 1911 / Severini 1910), names the Mathlib vehicle tendstoUniformlyOn_of_ae_tendsto, and lays out the file's substance: the canonical xⁿ-on-[0,1] example, its a.e.-convergence verification, and the matching sharpness (non-uniformity on [0,1)). Records the axiom status (0 sorries, 0 axioms, no native_decide).",
+      "mathContext": "On a finite-measure set, $f_n \\to g$ a.e. $\\Rightarrow$ for all $\\varepsilon>0$ there is measurable $t$ with $\\mu(t)\\le\\varepsilon$ and $f_n \\to g$ uniformly on $s \\setminus t$."
+    },
+    {
+      "id": "general-theorem",
+      "title": "Egorov's Theorem, Sequential Form",
+      "startLine": 63,
+      "endLine": 79,
+      "summary": "egorov_uniform_off_small_set restates Mathlib's tendstoUniformlyOn_of_ae_tendsto for ℕ-indexed sequences: strongly measurable fₙ → g a.e. on a finite-measure measurable s yields, for each ε > 0, a measurable t ⊆ s with μ t ≤ ENNReal.ofReal ε and uniform convergence on s \\ t.",
+      "mathContext": "The abstract theorem specialized to the index type ℕ; hypotheses are strong measurability of each $f_n$ and $g$, measurability and finiteness of $s$, and a.e. convergence on $s$."
+    },
+    {
+      "id": "canonical-example",
+      "title": "The Canonical Example: xⁿ on [0,1]",
+      "startLine": 81,
+      "endLine": 111,
+      "summary": "pow_ae_tendsto_zero_on_Icc: xⁿ → 0 Lebesgue-a.e. on [0,1], with the failure set ⊆ {1} (a null point). pow_egorov_on_Icc: applies Egorov to xⁿ — strong measurability via continuity, finiteness vol[0,1]=1, and the a.e. hypothesis — to extract, for each ε > 0, a measure-≤-ε set off which xⁿ → 0 uniformly.",
+      "mathContext": "For $0 \\le x < 1$, $x^n \\to 0$; the only exceptional point is $x=1$ with $\\mathrm{vol}\\{1\\}=0$. Hence the a.e. hypothesis holds and Egorov applies on the unit-measure interval."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: the Convergence Is Genuinely Non-Uniform",
+      "startLine": 113,
+      "endLine": 152,
+      "summary": "exists_pow_ge_half: for every N there is x ∈ [0,1) with xᴺ ≥ 1/2, via the intermediate value theorem on x ↦ xᴺ (from 0 to 1). pow_not_tendstoUniformlyOn_Ico: xⁿ does NOT converge uniformly to 0 on [0,1) — assuming it does, the ε = 1/2 definition at a bad point gives 1/2 ≤ xᴺ < 1/2, a contradiction. So Egorov's exceptional set cannot be omitted.",
+      "mathContext": "$\\sup_{x \\in [0,1)} x^N \\ge 1/2$ for every $N$, so uniform convergence (which would force $\\sup \\to 0$) fails — pointwise-everywhere convergence does not upgrade to uniform."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "Egorov's theorem states that on a finite-measure set, almost-everywhere convergence of (strongly) measurable functions upgrades to uniform convergence off a measurable subset of arbitrarily small measure. The abstract theorem is Mathlib's MeasureTheory.tendstoUniformlyOn_of_ae_tendsto, restated for sequences as egorov_uniform_off_small_set. The entry's substance is the canonical worked example xⁿ on [0,1]: pow_ae_tendsto_zero_on_Icc shows xⁿ → 0 Lebesgue-a.e. (the only exceptional point is the null point x = 1), pow_egorov_on_Icc feeds this into Egorov to extract, for every ε > 0, a measure-≤-ε exceptional set off which the convergence is uniform, and pow_not_tendstoUniformlyOn_Ico proves the matching sharpness statement: xⁿ does NOT converge uniformly on [0,1) despite converging to 0 at every point there — so Egorov's exceptional set is genuinely necessary. 153 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",


### PR DESCRIPTION
Enrichment pass for `egorov-theorem-oq-01` (quality 15, pass 0).

## What changed

The entry had **no `overview` field** (so the page rendered nothing for the introduction/overview), an **empty `sections` array**, and **no `annotations.json`**. Its `conclusion`, `originalContributions`, `references`, and `openQuestions` were already strong and are untouched.

- **overview** (new) → structured object: `historicalContext` (Egorov 1911 / Severini 1910, Littlewood's three principles, the essential finite-measure hypothesis, the Egorov ⇒ Lusin route), `problemStatement`, `proofStrategy`, and **5 keyInsights**.
- **sections** (new) → 4 sections covering the whole Lean file (docstring, sequential restatement, the $x^n$ example, sharpness) with per-section `mathContext`.
- **annotations.json** (new) → 4 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering the a.e.-convergence verification (failure set ⊆ {1}), the Egorov application, and the IVT-driven non-uniformity witness on $[0,1)$.

## Accuracy / axiom integrity

No status change. The `mathlib` badge is accurate and stated explicitly in the new content: the abstract theorem is Mathlib's `tendstoUniformlyOn_of_ae_tendsto`; the original content is the non-vacuous worked instance plus the non-uniformity sharpness witness. 0 axioms, 0 sorries, no `native_decide`. `pnpm build` passes.