### PR TITLE
audit: fix theoremCount 16→17 for angle-trisection-oq-02-oq-02-oq-02

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 246,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "assumptions": "None. 0 axioms, 0 sorries, no native_decide (only kernel `decide` for the finite-product instances 15 = 3·5 and 240 = 2^4·3·5, which depends only on the standard foundational axioms). The geometric step of Gauss–Wantzel (constructibility ⇔ φ(n) a power of two) is NOT used here; this entry isolates the purely number-theoretic characterization.",
     "mathlibDependencies": [
       {
@@ -65,7 +65,7 @@
     "namespace": "AngleTrisectionOQ02OQ02OQ02",
     "lineCount": 246,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ02OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `angle-trisection-oq-02-oq-02-oq-02` ("Gauss–Wantzel: the Number-Theoretic Core for General n")

**Problem**: `theoremCount` claimed **16** but the Lean source declares **17** theorem-level results.

## Evidence

`proofs/Proofs/AngleTrisectionOQ02OQ02OQ02.lean` has 16 public `theorem`s plus **1 `private theorem`** the count omitted:

```
71: private theorem totient_primePow_dvd {n p : ℕ} (hn : n ≠ 0) (hp : p.Prime) (hdvd : p ∣ n) :
```

Total = 17 theorem/lemma declarations. The gallery convention counts private declarations (cf. sibling `angle-trisection-oq-01-oq-04`, whose `theoremCount: 24` = 22 public + 2 private).

## Fix

`theoremCount` 16 → 17 in both `meta` and `leanFile` blocks. No change to `status` (verified), `badge` (original), `sorries` (0), `axiomCount` (0), or `definitionCount` (1 — `IsPow2`); those are accurate.

---
Discovered during gallery integrity audit.