### PR TITLE
Enrich: Euler's Reflection Formula & Special-Value Products

### DIFF
--- a/src/data/proofs/gamma-reflection-formula-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-gamma-refl-oq01-docstring",
+    "proofId": "gamma-reflection-formula-oq-01",
+    "range": { "startLine": 3, "endLine": 24 },
+    "type": "context",
+    "title": "Euler's Reflection Formula and Its Reach",
+    "content": "The docstring states Euler's reflection formula Γ(s)·Γ(1−s) = π/sin(πs) for real and complex s. The core identity is Mathlib's Real./Complex.Gamma_mul_Gamma_one_sub, re-exported here under stable names — hence the mathlib badge. The file then derives the genuine new content: concrete special-value PRODUCTS obtained by feeding rational arguments into reflection and evaluating sin at the corresponding special angle (Γ(1/2)²=π, Γ(1/4)Γ(3/4)=π√2, Γ(1/3)Γ(2/3)=2π/√3, Γ(1/6)Γ(5/6)=2π), and the non-vanishing corollary that sin(πs) ≠ 0 ⟹ Γ s ≠ 0. The striking point: reflection evaluates these products exactly even though the individual values Γ(1/4), Γ(1/3) are not elementary.",
+    "mathContext": "$\\Gamma(s)\\Gamma(1-s) = \\pi/\\sin(\\pi s)$, equivalent to $\\sin(\\pi s) = \\pi s\\prod_{n\\ge1}(1 - s^2/n^2)$ and to the cotangent partial-fraction expansion.",
+    "significance": "context",
+    "relatedConcepts": ["Euler reflection formula", "Gamma function", "sine product formula", "transcendental values", "special functions"],
+    "prerequisites": ["the Gamma function", "the sine function", "complex analysis basics"]
+  },
+  {
+    "id": "ann-gamma-refl-oq01-reflection",
+    "proofId": "gamma-reflection-formula-oq-01",
+    "range": { "startLine": 26, "endLine": 41 },
+    "type": "theorem",
+    "title": "The Reflection Identity, Real and Complex",
+    "content": "gamma_reflection re-exports Γ(s)·Γ(1−s) = π/sin(πs) for the real Gamma function (Real.Gamma_mul_Gamma_one_sub), and gamma_reflection_complex does the same for the complex Gamma function with Complex.sin. These stable re-exports are the foundation every downstream result rewrites against. Delegating the deep identity to Mathlib is exactly what the mathlib badge records; the value added here is the catalogue of consequences built on top.",
+    "mathContext": "Real: $\\Gamma(s)\\Gamma(1-s) = \\pi/\\sin(\\pi s)$. Complex: $\\Gamma(z)\\Gamma(1-z) = \\pi/\\sin(\\pi z)$, the analytic continuation valid off the poles.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.Gamma_mul_Gamma_one_sub", "Complex.Gamma_mul_Gamma_one_sub", "re-export", "analytic continuation"],
+    "prerequisites": ["Mathlib Gamma API", "real vs complex Gamma"]
+  },
+  {
+    "id": "ann-gamma-refl-oq01-special",
+    "proofId": "gamma-reflection-formula-oq-01",
+    "range": { "startLine": 43, "endLine": 80 },
+    "type": "insight",
+    "title": "Four Special-Value Products from One Recipe",
+    "content": "Each product is the same three-step specialization of reflection. gamma_half_sq: at s=1/2, the complement is also 1/2 and sin(π/2)=1, so Γ(1/2)² = π/1 = π — recovering the squared form of Γ(1/2)=√π WITHOUT the Gaussian integral. gamma_quarter_mul: at s=1/4, sin(π/4)=√2/2, and clearing the surd (Real.mul_self_sqrt) gives Γ(1/4)Γ(3/4)=π√2. gamma_third_mul: at s=1/3, sin(π/3)=√3/2 gives 2π/√3. gamma_sixth_mul: at s=1/6, sin(π/6)=1/2 gives 2π. The denominators k ∈ {2,4,3,6} are precisely those for which sin(π/k) has an elementary surd value. None of these product evaluations are in Mathlib.",
+    "mathContext": "$\\Gamma(1/2)^2=\\pi$; $\\Gamma(1/4)\\Gamma(3/4)=\\pi\\sqrt2$; $\\Gamma(1/3)\\Gamma(2/3)=2\\pi/\\sqrt3$; $\\Gamma(1/6)\\Gamma(5/6)=2\\pi$ — products elementary though the factors are transcendental.",
+    "significance": "key",
+    "relatedConcepts": ["special angles of sine", "Real.sin_pi_div_two/four/three/six", "Real.mul_self_sqrt", "transcendental factors", "elementary products"],
+    "prerequisites": ["reflection formula", "special values of sine", "surd manipulation"]
+  },
+  {
+    "id": "ann-gamma-refl-oq01-nonvanish",
+    "proofId": "gamma-reflection-formula-oq-01",
+    "range": { "startLine": 82, "endLine": 106 },
+    "type": "theorem",
+    "title": "Non-Vanishing of Γ via Reflection",
+    "content": "gamma_ne_zero_of_sin_ne_zero argues by contradiction: if Γ(s)=0 then the reflection product Γ(s)Γ(1−s) is 0, but it equals π/sin(πs), which is nonzero when sin(πs) ≠ 0 (div_ne_zero with π ≠ 0) — contradiction. gamma_ne_zero_of_not_int upgrades this: for a non-integer s, Real.sin_eq_zero_iff says a zero of sin(πs) would force s ∈ ℤ (the obtained n with n·π = π·s cancels to n = s via mul_right_cancel₀), so sin(πs) ≠ 0 and hence Γ(s) ≠ 0. This is the analytic fact that 1/Γ is entire — Γ never vanishes, its reciprocal having only the zeros at non-positive integers where Γ has poles.",
+    "mathContext": "$\\sin(\\pi s)\\ne0 \\Rightarrow \\Gamma(s)\\Gamma(1-s)=\\pi/\\sin(\\pi s)\\ne0 \\Rightarrow \\Gamma(s)\\ne0$. Zeros of $\\sin(\\pi s)$ are exactly $s\\in\\mathbb Z$.",
+    "significance": "key",
+    "relatedConcepts": ["non-vanishing of Gamma", "1/Γ entire", "Real.sin_eq_zero_iff", "div_ne_zero", "mul_right_cancel₀"],
+    "prerequisites": ["reflection formula", "zeros of sine", "proof by contradiction"]
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01/meta.json
@@ -109,6 +109,52 @@
       "description": "Euler's reflection formula Γ(s)Γ(1−s) = π/sin(πs) links the Gamma function to the sine and underlies its non-vanishing and the 1/Γ entire-function picture."
     }
   ],
+  "overview": {
+    "historicalContext": "Euler's reflection formula, $\\Gamma(s)\\,\\Gamma(1-s) = \\pi/\\sin(\\pi s)$, is one of the most beautiful identities in classical analysis, tying the Gamma function — the continuous interpolation of the factorial — to the elementary sine. Euler discovered it in the 1770s; it is equivalent to the Weierstrass product $\\sin(\\pi s) = \\pi s \\prod_{n\\ge1}(1 - s^2/n^2)$ and to the partial-fraction expansion of the cotangent. The formula immediately yields the celebrated $\\Gamma(1/2) = \\sqrt\\pi$ (so $\\Gamma(1/2)^2 = \\pi$), and more strikingly it shows that although individual values like $\\Gamma(1/4)$ or $\\Gamma(1/3)$ are transcendental and not expressible in elementary closed form, the *products* $\\Gamma(1/4)\\Gamma(3/4)$ and $\\Gamma(1/3)\\Gamma(2/3)$ collapse to elementary multiples of $\\pi$. Reflection also underlies the fact that $\\Gamma$ has no zeros and that $1/\\Gamma$ is entire (its only singularities being the simple poles of $\\Gamma$ at the non-positive integers). Mathlib proves the reflection identity itself; this entry re-exports it (hence the `mathlib` badge) and supplies the concrete special-value products and the sine-based non-vanishing argument, which Mathlib does not record.",
+    "problemStatement": "Euler's reflection formula for the real and complex Gamma function: $\\Gamma(s)\\,\\Gamma(1-s) = \\pi/\\sin(\\pi s)$. The entry re-exports this and derives, by specializing at rational $s$ and evaluating $\\sin$ at the corresponding special angle, four concrete product evaluations — $\\Gamma(1/2)^2 = \\pi$, $\\Gamma(1/4)\\Gamma(3/4) = \\pi\\sqrt2$, $\\Gamma(1/3)\\Gamma(2/3) = 2\\pi/\\sqrt3$, $\\Gamma(1/6)\\Gamma(5/6) = 2\\pi$ — together with the non-vanishing corollaries that $\\Gamma(s) \\ne 0$ whenever $\\sin(\\pi s) \\ne 0$, in particular at every non-integer real $s$.",
+    "proofStrategy": "Each special value is the same three-step recipe applied to `Real.Gamma_mul_Gamma_one_sub`: (1) instantiate the reflection formula at $s = 1/k$; (2) simplify the complementary argument $1 - 1/k$ and the angle $\\pi \\cdot (1/k) = \\pi/k$ by `norm_num`/`ring`; (3) substitute the known special sine value (`Real.sin_pi_div_two`, `_div_four`, `_div_three`, `_div_six`) and clear the resulting $\\sqrt2$, $\\sqrt3$ denominators via `Real.mul_self_sqrt` / `ring`. The non-vanishing `gamma_ne_zero_of_sin_ne_zero` is a contradiction: if $\\Gamma(s) = 0$ then the reflection product is $0$, but it equals the nonzero $\\pi/\\sin(\\pi s)$ (`div_ne_zero`). Finally `gamma_ne_zero_of_not_int` uses `Real.sin_eq_zero_iff`: a zero of $\\sin(\\pi s)$ forces $s \\in \\mathbb Z$, so a non-integer $s$ has $\\sin(\\pi s) \\ne 0$, hence $\\Gamma(s) \\ne 0$.",
+    "keyInsights": [
+      "The headline phenomenon is that reflection evaluates *products* exactly even when the *factors* are transcendental: $\\Gamma(1/4)$ has no elementary closed form, yet $\\Gamma(1/4)\\Gamma(3/4) = \\pi\\sqrt2$ is elementary. The formula trades knowledge of two hard values for one easy product.",
+      "$\\Gamma(1/2)^2 = \\pi$ is recovered here *purely from reflection* (at $s=1/2$, where $\\sin(\\pi/2)=1$), independent of the Gaussian-integral route Mathlib uses for $\\Gamma(1/2)=\\sqrt\\pi$ — a different and more elementary derivation of the same fact.",
+      "Non-vanishing of $\\Gamma$ falls straight out of the identity: the product $\\Gamma(s)\\Gamma(1-s)$ equals the nonzero $\\pi/\\sin(\\pi s)$ whenever $\\sin(\\pi s)\\ne 0$, so neither factor can be zero. This is the analytic fact behind $1/\\Gamma$ being entire.",
+      "The whole family is a single recipe parameterized by the denominator $k$: instantiate reflection at $1/k$, plug in the special value of $\\sin(\\pi/k)$, and simplify. The choices $k \\in \\{2,4,3,6\\}$ are exactly those where $\\sin(\\pi/k)$ has an elementary surd value.",
+      "The `mathlib` badge is honest: the deep identity is Mathlib's `Real.Gamma_mul_Gamma_one_sub`. The original content is the concrete special-value catalogue and the sine-based non-vanishing argument — the textbook Gamma special values packaged in machine-checked form, which Mathlib lacks."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Reflection and Its Consequences",
+      "startLine": 3,
+      "endLine": 24,
+      "summary": "States Euler's reflection formula Γ(s)·Γ(1−s) = π/sin(πs), names the Mathlib source (Real./Complex.Gamma_mul_Gamma_one_sub), and previews the new content: the concrete special-value products at rational arguments and the sine-based non-vanishing corollary. Notes the mathlib badge (identity delegated) and full verification.",
+      "mathContext": "$\\Gamma(s)\\,\\Gamma(1-s) = \\dfrac{\\pi}{\\sin(\\pi s)}$, equivalent to the sine product $\\sin(\\pi s) = \\pi s\\prod_{n\\ge1}(1 - s^2/n^2)$."
+    },
+    {
+      "id": "reflection",
+      "title": "The Reflection Formula (Re-exported)",
+      "startLine": 26,
+      "endLine": 41,
+      "summary": "gamma_reflection and gamma_reflection_complex re-export Euler's reflection identity for the real and complex Gamma function under stable names, delegating to Real.Gamma_mul_Gamma_one_sub and Complex.Gamma_mul_Gamma_one_sub.",
+      "mathContext": "Real and complex forms: $\\Gamma(s)\\Gamma(1-s) = \\pi/\\sin(\\pi s)$ and $\\Gamma(z)\\Gamma(1-z) = \\pi/\\sin(\\pi z)$."
+    },
+    {
+      "id": "special-values",
+      "title": "Concrete Special-Value Products",
+      "startLine": 43,
+      "endLine": 80,
+      "summary": "Four product evaluations via reflection at rational s and special sine angles: gamma_half_sq (Γ(1/2)²=π, sin(π/2)=1), gamma_quarter_mul (Γ(1/4)Γ(3/4)=π√2, sin(π/4)=√2/2), gamma_third_mul (Γ(1/3)Γ(2/3)=2π/√3, sin(π/3)=√3/2), gamma_sixth_mul (Γ(1/6)Γ(5/6)=2π, sin(π/6)=1/2). None are in Mathlib.",
+      "mathContext": "Same recipe at $s=1/k$: substitute $\\sin(\\pi/k)$ and clear surds. $\\Gamma(1/2)^2=\\pi$, $\\Gamma(1/4)\\Gamma(3/4)=\\pi\\sqrt2$, $\\Gamma(1/3)\\Gamma(2/3)=2\\pi/\\sqrt3$, $\\Gamma(1/6)\\Gamma(5/6)=2\\pi$."
+    },
+    {
+      "id": "non-vanishing",
+      "title": "Non-Vanishing via Reflection",
+      "startLine": 82,
+      "endLine": 106,
+      "summary": "gamma_ne_zero_of_sin_ne_zero: if sin(πs) ≠ 0 then Γ s ≠ 0, since Γ(s)Γ(1−s) = π/sin(πs) ≠ 0 forces both factors nonzero. gamma_ne_zero_of_not_int: Γ does not vanish at any non-integer real s, via Real.sin_eq_zero_iff (a sine zero forces s ∈ ℤ).",
+      "mathContext": "$\\sin(\\pi s) \\ne 0 \\Rightarrow \\Gamma(s)\\Gamma(1-s) = \\pi/\\sin(\\pi s) \\ne 0 \\Rightarrow \\Gamma(s) \\ne 0$. Sine zeros are exactly the integers, so non-integers are safe."
+    }
+  ],
   "sorries": 0,
   "conclusion": {
     "summary": "Euler's reflection formula Γ(s)·Γ(1−s) = π/sin(πs) is re-exported for the real and complex Gamma function from Mathlib's Real./Complex.Gamma_mul_Gamma_one_sub. Specializing at rational arguments and evaluating the sine at the corresponding special angle yields four concrete product evaluations — Γ(1/2)² = π, Γ(1/4)·Γ(3/4) = π√2, Γ(1/3)·Γ(2/3) = 2π/√3, Γ(1/6)·Γ(5/6) = 2π — none of which are in Mathlib, where the products are elementary even though the individual factors are transcendental. Two non-vanishing results (gamma_ne_zero_of_sin_ne_zero and gamma_ne_zero_of_not_int) are read directly off the reflection identity. 108 lines, 8 theorems, 0 definitions, 0 axioms, 0 sorries.",


### PR DESCRIPTION
Enrichment pass for `gamma-reflection-formula-oq-01` (quality 15, pass 0).

## What changed

The entry had **no `overview` field** (so the page rendered nothing for the introduction/overview), an **empty `sections` array**, and **no `annotations.json`**. Its `conclusion`, `originalContributions`, `references`, and cross-references were already strong and are untouched.

- **overview** (new) → structured object: `historicalContext` (Euler's 1770s reflection formula, the sine/cotangent product equivalences, transcendental factors with elementary products, $1/\Gamma$ entire), `problemStatement`, `proofStrategy`, and **5 keyInsights**.
- **sections** (new) → 4 sections covering the whole Lean file (docstring, reflection re-export, special-value products, non-vanishing) with per-section `mathContext`.
- **annotations.json** (new) → 4 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering the reflection identity, the four $\Gamma(1/k)$ product evaluations, and the sine-based non-vanishing argument.

## Accuracy / axiom integrity

No status change. The `mathlib` badge is accurate and stated explicitly: the reflection identity is Mathlib's `Real./Complex.Gamma_mul_Gamma_one_sub`; the original content is the special-value product catalogue and the non-vanishing corollaries. 0 axioms, 0 sorries. `pnpm build` passes.