### PR TITLE
research(cevas-theorem-oq-04-oq-01-oq-01): constructive converse of n-dim mass-point Ceva

### DIFF
--- a/proofs/Proofs/CevasTheoremOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/CevasTheoremOQ04OQ01OQ01.lean
@@ -1,0 +1,155 @@
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.Fin.Basic
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+import Mathlib.Tactic
+import Proofs.CevasTheoremOQ04OQ01
+
+/-
+# N-Dimensional Mass-Point Ceva: Constructive Converse (Mass from Ratios)
+
+## Research Question (cevas-theorem-oq-04-oq-01, S3 follow-up)
+
+The parent file `CevasTheoremOQ04OQ01.lean` proves the *forward* direction of the
+n-dimensional mass-point Ceva identity: a `MassPoint n` (n+1 positive vertex
+masses on an n-simplex) yields complement fractions
+
+  ratio i = (Σ_{j ≠ i} mass j) / total = 1 - mass i / total
+
+that satisfy the **dimensional Ceva identity** `Σ_i ratio i = n` with each
+`ratio i ∈ (0, 1)`.
+
+This file proves the **converse / realisation** direction (listed as S3
+candidate #2 in the parent's "Next iteration" section), the n-dimensional
+analogue of the triangle file's `masses_from_ceva`:
+
+> Given a *ratio profile* `r : Fin (n+1) → ℝ` with each `r i < 1` and
+> `Σ_i r i = n`, there exist positive masses realising it, i.e. a
+> `MassPoint n` whose complement fractions are exactly `r`.
+
+The construction is the canonical normalised one: take `mass i = 1 - r i`.
+Positivity is exactly `r i < 1`; the sum constraint `Σ r i = n` forces
+`total = (n+1) - n = 1`, hence `mass i / total = 1 - r i` and
+`ratio i = 1 - (1 - r i) = r i`.
+
+We also record the **normalised uniqueness** statement: among mass points of
+total mass `1`, the ratio profile determines the masses (so the realisation
+above is the unique normalised representative of its ratio class).
+
+## What this file does
+
+* `massesFromRatio` — the canonical `MassPoint n` with `mass i = 1 - r i`
+* `massesFromRatio_total` — its total mass is `1`
+* `massesFromRatio_ratio` — its complement fractions are exactly `r`
+* `exists_massPoint_of_ratioProfile` — the realisation theorem (∃ form)
+* `massPoint_normalized_unique` — total-`1` mass points are determined by ratios
+* `massesFromRatio_pos` — restated positivity of the constructed masses
+* n = 2 (triangle) specialisation as a sanity check
+
+## What this file does NOT do (still deferred)
+
+* `AffineSpace`/`AffineCombination` geometric concurrency (S3 candidate #3).
+* The triangle bridge to `MassPointCeva.MassPoint` edge-split parameters
+  (S3 candidate #1).
+
+## References
+
+* Parent: `proofs/Proofs/CevasTheoremOQ04OQ01.lean`
+* Grandparent: `proofs/Proofs/CevasTheoremOQ04.lean` (`masses_from_ceva`)
+* Mathlib: `Mathlib.LinearAlgebra.AffineSpace.Ceva` (Joseph Myers 2025)
+-/
+
+namespace NDimMassPoint
+
+variable {n : ℕ}
+
+/-- The canonical **mass-from-ratios** construction: given a ratio profile
+    `r` with each `r i < 1`, the masses `mass i = 1 - r i` are positive.
+    (The sum constraint `Σ r i = n` is not needed for positivity, only for
+    the total to normalise to `1`.) -/
+noncomputable def massesFromRatio (r : Fin (n + 1) → ℝ) (hr1 : ∀ i, r i < 1) :
+    MassPoint n where
+  mass := fun i => 1 - r i
+  pos  := fun i => by have := hr1 i; linarith
+
+@[simp] lemma massesFromRatio_mass (r : Fin (n + 1) → ℝ) (hr1 : ∀ i, r i < 1)
+    (i : Fin (n + 1)) : (massesFromRatio r hr1).mass i = 1 - r i := rfl
+
+/-- Restated positivity of the constructed masses. -/
+lemma massesFromRatio_pos (r : Fin (n + 1) → ℝ) (hr1 : ∀ i, r i < 1)
+    (i : Fin (n + 1)) : 0 < (massesFromRatio r hr1).mass i :=
+  (massesFromRatio r hr1).pos i
+
+/-- The constraint `Σ r i = n` forces the constructed total mass to be `1`. -/
+lemma massesFromRatio_total (r : Fin (n + 1) → ℝ) (hr1 : ∀ i, r i < 1)
+    (hsum : (∑ i, r i) = (n : ℝ)) : (massesFromRatio r hr1).total = 1 := by
+  unfold MassPoint.total
+  have hone : (∑ _i : Fin (n + 1), (1 : ℝ)) = (n + 1 : ℝ) := by
+    rw [Finset.sum_const, Finset.card_univ, Fintype.card_fin]
+    simp
+  simp only [massesFromRatio_mass]
+  rw [Finset.sum_sub_distrib, hone, hsum]
+  ring
+
+/-- **Realisation, explicit form**: the constructed mass point has complement
+    fractions exactly equal to the given ratio profile `r`. -/
+lemma massesFromRatio_ratio (r : Fin (n + 1) → ℝ) (hr1 : ∀ i, r i < 1)
+    (hsum : (∑ i, r i) = (n : ℝ)) (i : Fin (n + 1)) :
+    (massesFromRatio r hr1).ratio i = r i := by
+  rw [MassPoint.ratio_eq_one_sub, massesFromRatio_total r hr1 hsum,
+      massesFromRatio_mass, div_one]
+  ring
+
+/-- **N-dim Mass-Point Ceva, converse / realisation theorem.**
+
+    Every ratio profile `r : Fin (n+1) → ℝ` that satisfies the necessary
+    conditions — each `r i < 1` and `Σ_i r i = n` — is realised by an actual
+    positive-mass assignment on the n-simplex.  This is the n-dimensional
+    analogue of the triangle file's `masses_from_ceva`. -/
+theorem exists_massPoint_of_ratioProfile (r : Fin (n + 1) → ℝ)
+    (hr1 : ∀ i, r i < 1) (hsum : (∑ i, r i) = (n : ℝ)) :
+    ∃ mp : MassPoint n, ∀ i, mp.ratio i = r i :=
+  ⟨massesFromRatio r hr1, massesFromRatio_ratio r hr1 hsum⟩
+
+/-- **Normalised uniqueness**: among mass points whose total mass is `1`,
+    the complement-fraction profile determines the masses uniquely.  Combined
+    with `massesFromRatio_total`, this says `massesFromRatio` is *the* unique
+    total-`1` representative of each realisable ratio class. -/
+theorem massPoint_normalized_unique (mp₁ mp₂ : MassPoint n)
+    (h₁ : mp₁.total = 1) (h₂ : mp₂.total = 1)
+    (hr : ∀ i, mp₁.ratio i = mp₂.ratio i) :
+    ∀ i, mp₁.mass i = mp₂.mass i := by
+  intro i
+  have e₁ := mp₁.ratio_eq_one_sub i
+  have e₂ := mp₂.ratio_eq_one_sub i
+  rw [h₁, div_one] at e₁
+  rw [h₂, div_one] at e₂
+  have key := hr i
+  rw [e₁, e₂] at key
+  linarith
+
+/- ## Specialisation to n = 2 (triangle): sanity check -/
+
+/-- For a triangle ratio profile `(r₀, r₁, r₂)` with each `rᵢ < 1` and
+    `r₀ + r₁ + r₂ = 2`, there is a positive-mass triangle realising it. -/
+example (r : Fin 3 → ℝ) (hr1 : ∀ i, r i < 1)
+    (hsum : r 0 + r 1 + r 2 = 2) :
+    ∃ mp : MassPoint 2, ∀ i, mp.ratio i = r i := by
+  refine exists_massPoint_of_ratioProfile r hr1 ?_
+  rw [Fin.sum_univ_three]
+  exact_mod_cast hsum
+
+end NDimMassPoint
+
+/-
+## Summary
+
+* `massesFromRatio r hr1` — canonical realising masses `mass i = 1 - r i`
+* `massesFromRatio_total` — total normalises to `1` under `Σ r i = n`
+* `massesFromRatio_ratio` — complement fractions recover `r` exactly
+* `exists_massPoint_of_ratioProfile` — realisation theorem (n-dim converse)
+* `massPoint_normalized_unique` — total-`1` masses determined by ratios
+* n = 2 triangle specialisation verified
+
+**Sorry count**: 0
+**Axiom count**: 0
+-/

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,144 @@
+[
+  {
+    "id": "ann-ctoq040101-00-header",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 66
+    },
+    "type": "concept",
+    "title": "Module Overview: Constructive Converse of n-Dim Mass-Point Ceva",
+    "content": "The parent entry cevas-theorem-oq-04-oq-01 proves the forward direction: an n-simplex mass point (n+1 positive masses) yields complement fractions ratio i with Σ ratio i = n and each ratio in (0,1). This file proves the converse — its open question #2 — showing those necessary conditions are also sufficient: any ratio profile with each r i < 1 and Σ r i = n is realised by an explicit positive-mass assignment, namely mass i = 1 - r i.",
+    "mathContext": "Given r : Fin (n+1) → ℝ, r i < 1, Σ r i = n  ⟹  ∃ MassPoint n with ratio i = r i.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "mass-point geometry",
+      "barycentric coordinates",
+      "realisation theorem",
+      "converse direction"
+    ],
+    "prerequisites": [
+      "cevas-theorem-oq-04-oq-01"
+    ]
+  },
+  {
+    "id": "ann-ctoq040101-01-construction",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 67,
+      "endLine": 81
+    },
+    "type": "definition",
+    "title": "The Canonical Mass-from-Ratios Construction",
+    "content": "massesFromRatio r hr1 packages the masses mass i = 1 - r i into a MassPoint n. Positivity of each mass is exactly the hypothesis r i < 1 (discharged by linarith). Notably the construction needs only r i < 1, not the full admissibility r i ∈ (0,1) — the lower bound is unused, a small strengthening of sufficiency. massesFromRatio_mass records the defining equation, and massesFromRatio_pos restates positivity.",
+    "mathContext": "massesFromRatio r hr1 : MassPoint n with mass i = 1 - r i; pos from r i < 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "positive masses",
+      "inverting the complement fraction"
+    ],
+    "prerequisites": [
+      "MassPoint structure (parent)"
+    ]
+  },
+  {
+    "id": "ann-ctoq040101-02-total",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 93
+    },
+    "type": "proof-step",
+    "title": "The Sum Condition Normalises the Total to 1",
+    "content": "massesFromRatio_total shows that under Σ r i = n the constructed total equals 1. Expand Σ (1 - r i) via Finset.sum_sub_distrib into (Σ 1) - (Σ r i); the constant part is n+1 (Finset.sum_const + Fintype.card_fin) and the variable part is n (the hypothesis), so the total is (n+1) - n = 1 by ring. This is exactly the self-consistency that makes the recovered ratios equal r with no rescaling.",
+    "mathContext": "Σ_{i:Fin(n+1)} (1 - r i) = (n+1) - n = 1.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_sub_distrib",
+      "normalisation"
+    ],
+    "prerequisites": [
+      "finite sums"
+    ]
+  },
+  {
+    "id": "ann-ctoq040101-03-ratio",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 95,
+      "endLine": 106
+    },
+    "type": "proof-step",
+    "title": "Recovering the Ratios: ratio i = r i",
+    "content": "massesFromRatio_ratio confirms the construction is correct: the complement fraction of massesFromRatio at vertex i is exactly r i. Use the parent's ratio_eq_one_sub (ratio i = 1 - mass i/total), substitute total = 1 (massesFromRatio_total) and mass i = 1 - r i (massesFromRatio_mass), then div_one and ring collapse 1 - (1 - r i) to r i.",
+    "mathContext": "ratio i = 1 - (1 - r i)/1 = r i.",
+    "significance": "key",
+    "relatedConcepts": [
+      "complement fraction",
+      "ratio_eq_one_sub"
+    ],
+    "prerequisites": [
+      "parent ratio_eq_one_sub"
+    ]
+  },
+  {
+    "id": "ann-ctoq040101-04-realisation",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 115
+    },
+    "type": "theorem",
+    "title": "Realisation Theorem (the n-dim converse)",
+    "content": "exists_massPoint_of_ratioProfile is the headline: every ratio profile r with each r i < 1 and Σ r i = n is realised by an actual MassPoint n whose complement fractions are exactly r. It packages the construction and its correctness as ⟨massesFromRatio r hr1, massesFromRatio_ratio …⟩. This is the n-dimensional analogue of the triangle file's masses_from_ceva, closing the forward/converse loop for the n-dim mass-point Ceva identity.",
+    "mathContext": "∀ r, (∀ i, r i < 1) → Σ r i = n → ∃ mp : MassPoint n, ∀ i, mp.ratio i = r i.",
+    "significance": "key",
+    "relatedConcepts": [
+      "realisation / sufficiency",
+      "masses_from_ceva analogue"
+    ],
+    "prerequisites": [
+      "massesFromRatio_ratio"
+    ]
+  },
+  {
+    "id": "ann-ctoq040101-05-uniqueness",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 132
+    },
+    "type": "theorem",
+    "title": "Normalised Uniqueness",
+    "content": "massPoint_normalized_unique shows the ratio profile determines the masses among total-1 mass points: if mp₁.total = mp₂.total = 1 and they have equal complement fractions, their masses agree. Instantiating ratio_eq_one_sub for each and using total = 1 (div_one), the equal-ratio hypothesis becomes 1 - mass₁ i = 1 - mass₂ i, so linarith finishes. Fixing the total removes the one scaling degree of freedom, so massesFromRatio is the unique normalised realiser of each profile.",
+    "mathContext": "total = 1 ∧ (∀ i, ratio₁ i = ratio₂ i) ⟹ ∀ i, mass₁ i = mass₂ i.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "uniqueness up to scaling",
+      "normalisation"
+    ],
+    "prerequisites": [
+      "ratio_eq_one_sub"
+    ]
+  },
+  {
+    "id": "ann-ctoq040101-06-triangle",
+    "proofId": "cevas-theorem-oq-04-oq-01-oq-01",
+    "range": {
+      "startLine": 134,
+      "endLine": 142
+    },
+    "type": "concept",
+    "title": "Triangle Specialisation (n = 2)",
+    "content": "A worked example at n = 2: any triangle ratio profile (r0, r1, r2) with each ri < 1 and r0 + r1 + r2 = 2 is realised by a positive-mass triangle. The Σ over Fin 3 is expanded with Fin.sum_univ_three and the cast n = 2 handled by exact_mod_cast, applying the general realisation theorem. This recovers, in the converse direction, the triangle sum-of-2 identity from the parent chain.",
+    "mathContext": "(∀ i, r i < 1) ∧ r 0 + r 1 + r 2 = 2 ⟹ ∃ mp : MassPoint 2, ∀ i, mp.ratio i = r i.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "triangle case",
+      "Fin.sum_univ_three"
+    ],
+    "prerequisites": [
+      "realisation theorem"
+    ]
+  }
+]

--- a/src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "cevas-theorem-oq-04-oq-01-oq-01",
+  "title": "N-Dimensional Mass-Point Ceva: Constructive Converse (Mass from Ratios)",
+  "slug": "cevas-theorem-oq-04-oq-01-oq-01",
+  "description": "Proves the converse (realisation) direction of the n-dimensional mass-point Ceva identity, answering open question #2 of the parent entry. Given a ratio profile r : Fin (n+1) → ℝ with each r i < 1 and Σ r i = n, constructs explicit positive vertex masses mass i = 1 - r i whose complement fractions are exactly r, and shows the total normalises to 1. Establishes the realisation theorem (every admissible profile is realised by an actual mass point) and normalised uniqueness (among total-1 mass points, the ratio profile determines the masses). The n-dimensional analogue of the triangle file's masses_from_ceva.",
+  "meta": {
+    "author": "researcher-10 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Mass_point_geometry",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CevasTheoremOQ04OQ01OQ01.lean",
+    "tags": [
+      "geometry",
+      "cevas-theorem",
+      "mass-point-geometry",
+      "simplex",
+      "affine-geometry",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_sub_distrib",
+        "description": "the sum of a difference splits as the difference of sums (used to compute the total of mass i = 1 - r i)",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum_const",
+        "description": "a sum of a constant over a finite set is the cardinality times the constant",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "Fintype.card_fin",
+        "description": "the cardinality of Fin (n+1) is n+1, used to evaluate the constant sum",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Fin.sum_univ_three",
+        "description": "expands a sum over Fin 3 as three explicit terms, used in the n = 2 triangle specialization",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      }
+    ],
+    "originalContributions": [
+      "massesFromRatio r hr1: the canonical realising mass point with mass i = 1 - r i (positivity is exactly r i < 1)",
+      "massesFromRatio_total: under Σ r i = n the constructed total mass equals 1 ((n+1) - n = 1)",
+      "massesFromRatio_ratio: the constructed mass point has complement fractions exactly equal to r",
+      "exists_massPoint_of_ratioProfile: the realisation theorem — every profile with r i < 1 and Σ r i = n is realised by an actual MassPoint n",
+      "massPoint_normalized_unique: among mass points of total mass 1, the ratio profile determines the masses uniquely",
+      "n = 2 triangle specialization: any (r0, r1, r2) with each ri < 1 and r0 + r1 + r2 = 2 is realised by a positive-mass triangle"
+    ],
+    "references": [
+      {
+        "authors": "Hausner, Melvin",
+        "title": "The Center of Mass and Affine Geometry",
+        "year": "1962",
+        "venue": "American Mathematical Monthly",
+        "note": "Foundational treatment of mass-point (barycentric) geometry"
+      },
+      {
+        "authors": "Myers, Joseph",
+        "title": "Mathlib.LinearAlgebra.AffineSpace.Ceva",
+        "year": "2025",
+        "venue": "Mathlib",
+        "note": "Affine-space formulation of Ceva's theorem; the geometric concurrency target for future work"
+      }
+    ],
+    "prerequisites": [
+      "The forward n-dim mass-point Ceva identity (parent entry cevas-theorem-oq-04-oq-01)",
+      "Mass-point (barycentric) geometry of triangles (cevas-theorem-oq-04, masses_from_ceva)",
+      "Finite sums over Finset.univ and the constant/difference sum identities",
+      "Basic real arithmetic with linarith / ring"
+    ],
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 155,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). No native_decide.",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Mass-point geometry assigns positive masses to the vertices of a figure and reasons about cevians and concurrency through the center of mass. The parent entry cevas-theorem-oq-04-oq-01 lifted this from the triangle to an n-simplex, defining for n+1 positive masses the per-vertex complement fraction ratio i = (Σ_{j≠i} mass j)/total and proving the n-dimensional Ceva identity Σ ratio i = n with each ratio in (0,1). That development goes from masses to ratios. The natural converse — listed as open question #2 of the parent — asks whether the necessary conditions on a ratio profile (each value below 1, summing to n) are also sufficient: can every such profile be realised by an actual assignment of positive masses?\n\nThis entry answers yes, constructively, mirroring the triangle file's masses_from_ceva (which recovers vertex masses from a Ceva ratio). The construction is the canonical normalised one, and it comes with a uniqueness statement pinning down the normalised representative of each ratio class.",
+    "problemStatement": "**Open Question (#2 from parent cevas-theorem-oq-04-oq-01)**: Constructive converse — given a ratio profile r : Fin (n+1) → ℝ with Σ r i = n and each r i in (0,1), construct explicit vertex masses realising it.\n\n**Resolution**: Take mass i = 1 - r i. Positivity is exactly r i < 1 (the lower bound r i > 0 is not even needed for the construction). The constraint Σ r i = n forces total = (n+1) - n = 1, hence mass i / total = 1 - r i and ratio i = 1 - (1 - r i) = r i. This gives the realisation theorem exists_massPoint_of_ratioProfile. We further prove normalised uniqueness: any two total-1 mass points with equal ratio profiles have equal masses, so massesFromRatio is the unique normalised realiser.",
+    "text": "A 155-line, axiom-free development (1 definition, 6 theorems). massesFromRatio r hr1 packages the masses mass i = 1 - r i, with positivity discharged directly from the hypothesis r i < 1 via linarith. massesFromRatio_total evaluates the total: expand the sum of (1 - r i) with Finset.sum_sub_distrib, evaluate the constant part as n+1 (Finset.sum_const + Fintype.card_fin) and the variable part as n (the hypothesis Σ r i = n), giving (n+1) - n = 1 by ring. massesFromRatio_ratio then rewrites ratio i = 1 - mass i/total (the parent's ratio_eq_one_sub) with total = 1 and mass i = 1 - r i, simplifying to r i. exists_massPoint_of_ratioProfile packages these as an existence statement. massPoint_normalized_unique shows that two total-1 mass points with identical complement fractions have identical masses (each ratio equation collapses to 1 - mass i = 1 - mass' i under total = 1). An n = 2 example specialises the realisation theorem to triangles.",
+    "proofStrategy": "massesFromRatio: structure with pos field proved by `have := hr1 i; linarith`. massesFromRatio_total: unfold total, simp the masses to 1 - r i, Finset.sum_sub_distrib, rewrite the constant sum to n+1 and the r-sum to n via the hypothesis, then ring. massesFromRatio_ratio: rw [ratio_eq_one_sub, massesFromRatio_total, massesFromRatio_mass, div_one] then ring. exists_massPoint_of_ratioProfile: provide ⟨massesFromRatio r hr1, massesFromRatio_ratio …⟩. massPoint_normalized_unique: instantiate ratio_eq_one_sub for both mass points, rewrite total = 1 and div_one, then linarith on the two ratio equations. n = 2 example: refine exists_massPoint_of_ratioProfile, expand Σ over Fin 3 (Fin.sum_univ_three), exact_mod_cast the hypothesis.",
+    "keyInsights": [
+      "The canonical realiser of a ratio profile is mass i = 1 - r i: the complement fraction equation ratio i = 1 - mass i/total inverts to mass i = total·(1 - r i), and normalising total to 1 gives the clean form.",
+      "The sum condition Σ r i = n is exactly what makes the construction self-consistent: it forces the total to be 1, so the recovered ratios equal r without any rescaling.",
+      "Only r i < 1 is needed for positivity of the masses; the lower bound r i > 0 (part of the original admissibility) is not used by the construction — a minor strengthening of sufficiency.",
+      "Normalised masses are uniquely determined by the ratio profile: fixing total = 1 removes the one degree of scaling freedom, so each realisable profile has a unique normalised representative.",
+      "This is the n-dimensional analogue of the triangle file's masses_from_ceva, closing the forward/converse loop for n-dim mass-point Ceva at the level of the mass/ratio identities."
+    ],
+    "prerequisites": [
+      "Affine and barycentric geometry (simplices, centers of mass)",
+      "Finite sums over an index set",
+      "Elementary real arithmetic"
+    ]
+  },
+  "conclusion": {
+    "summary": "The necessary conditions for an n-simplex complement-fraction profile — each r i < 1 and Σ r i = n — are also sufficient: the explicit masses mass i = 1 - r i realise any such profile, with total mass 1, and these normalised masses are uniquely determined by the profile. This closes the converse direction of the parent's n-dimensional mass-point Ceva identity. Fully verified, 0 axioms, 0 sorries.",
+    "implications": "Together with the parent's forward identity (masses → ratios with Σ ratio i = n), this gives a complete characterisation of realisable complement-fraction profiles on an n-simplex and pins down the normalised mass representative of each. It is the n-dim analogue of recovering vertex masses from a triangle Ceva ratio (masses_from_ceva). The remaining open directions are geometric: bridging to the parent's edge-split parametrization and to Mathlib.LinearAlgebra.AffineSpace.Ceva for cevian concurrency.",
+    "openQuestions": [
+      "Bridge these complement fractions and the canonical masses to the triangle file's edge-split parameters (rD = mC/(mB+mC), ...).",
+      "Connect the realisation to Mathlib.LinearAlgebra.AffineSpace.Ceva for the geometric n-dimensional cevian concurrency theorem.",
+      "Characterise the full (unnormalised) family of mass points realising a given profile as the positive scalar multiples of massesFromRatio."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cevas-theorem-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Proves the constructive converse (open question #2) of the parent's n-dimensional mass-point Ceva identity"
+    },
+    {
+      "targetId": "cevas-theorem-oq-04",
+      "relationship": "related",
+      "description": "n-dimensional analogue of the triangle file's masses_from_ceva (mass recovery from a Ceva ratio)"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Data.Fin.Basic",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
+      "Mathlib.Tactic",
+      "Proofs.CevasTheoremOQ04OQ01"
+    ],
+    "opens": [],
+    "namespace": "NDimMassPoint",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/CevasTheoremOQ04OQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Answers **open question #2** of the parent entry `cevas-theorem-oq-04-oq-01` (N-Dimensional Mass-Point Ceva): the *constructive converse* / realisation direction. The parent goes masses → ratios (Σ ratio i = n); this goes ratios → masses.

Given a ratio profile `r : Fin (n+1) → ℝ` with each `r i < 1` and `Σ r i = n`, the explicit masses `mass i = 1 - r i` realise it: total normalises to 1 and the complement fractions recover `r` exactly. This is the n-dimensional analogue of the triangle file's `masses_from_ceva`.

## New results (`proofs/Proofs/CevasTheoremOQ04OQ01OQ01.lean`)

- `massesFromRatio r hr1` — canonical realising mass point, `mass i = 1 - r i` (positivity is exactly `r i < 1`; the lower bound `r i > 0` is not even needed)
- `massesFromRatio_total` — the constraint `Σ r i = n` forces `total = (n+1) - n = 1`
- `massesFromRatio_ratio` — the constructed complement fractions equal `r`
- `exists_massPoint_of_ratioProfile` — **realisation theorem** (every admissible profile is realised)
- `massPoint_normalized_unique` — among total-1 mass points, the ratio profile determines the masses
- n = 2 triangle specialisation

## Verification

- **155 lines, 1 definition / 6 theorems, 0 sorries, 0 axioms, no `native_decide`.**
- Docker build verified: `✔ Built Proofs.CevasTheoremOQ04OQ01OQ01 (3059 jobs)`, `Build completed successfully`.
- Status `verified`, badge `original`. Imports only the sorry-free, 0-axiom parent entry.

## Gallery

New entry `src/data/proofs/cevas-theorem-oq-04-oq-01-oq-01/` (meta.json + annotations.json) cross-referenced to the parent (`extends`) and grandparent (`related`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)