### PR TITLE
research(cauchy-group-theorem-oq-01-oq-01): odd-order boundary of Cauchy — squaring is a bijection [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -506,6 +506,7 @@ import Proofs.CantorsTheoremOQ05
 import Proofs.CarnotTheorem
 import Proofs.CatalanNumbersOQ01
 import Proofs.CauchyGroupTheoremOQ01
+import Proofs.CauchyGroupTheoremOQ01OQ01
 import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01.lean
@@ -1,0 +1,151 @@
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-
+# The odd-order boundary of Cauchy's theorem: squaring is a bijection
+
+## What This Proves
+
+The parent file `CauchyGroupTheoremOQ01` records Cauchy's theorem and its
+*even-order* corollary: a finite group of even order contains an involution
+(`exists_involution_of_even_card`, the `p = 2` case of Cauchy). This file proves
+the complementary *odd-order* structure theory, the sharp boundary on the other
+side of that dividing line. None of these statements are packaged in Mathlib.
+
+* **Explicit square root** (`exists_sq_eq_of_odd_card`). In a finite group of
+  odd order, every element `x` is a square: concretely `x = (x ^ (m+1)) ^ 2`
+  where `|G| = 2m + 1`. The proof is the one-line identity
+  `(x ^ (m+1)) ^ 2 = x ^ (|G| + 1) = x ^ |G| · x = x`, using
+  `pow_card_eq_one`.
+
+* **Squaring is a bijection** (`sq_surjective_of_odd_card`,
+  `sq_bijective_of_odd_card`). The squaring map `x ↦ x²` is surjective, hence
+  (the group being finite) bijective. This is the structural reason every
+  element has a unique square root in an odd-order group, and the engine behind
+  many parity-free arguments.
+
+* **No involutions** (`no_involution_of_odd_card`). If `|G|` is odd then the
+  only solution of `x² = 1` is `x = 1`: an order-`2` element would force
+  `2 ∣ |G|`. This is the exact contrapositive of the parent's even-order
+  involution corollary.
+
+* **Sharp boundary** (`involution_iff_even_card`). Combining the new odd-order
+  result with the Cauchy `p = 2` case gives the clean equivalence: a finite
+  group contains a nontrivial element `x` with `x² = 1` **iff** its order is
+  even. This pins down *exactly* when involutions exist, sharpening the parent's
+  one-directional corollary into an iff.
+
+* **Additive form** (`exists_two_nsmul_eq_of_odd_card`). The additive
+  translation: in a finite additive group of odd order the doubling map
+  `y ↦ 2 • y` is surjective — every element is a double.
+
+* **Concrete instances** (`zmod3_double_surjective`, `zmod3_no_involution`,
+  `zmod5_double_surjective`). In `ZMod 3` and `ZMod 5` (odd orders) doubling is
+  surjective and the only self-inverse element is `0`, witnessed by kernel
+  `decide` (no `native_decide`), keeping the file genuinely `0`-axiom.
+
+## Context
+
+Cauchy's theorem says `p ∣ |G|` produces an element of order `p`. The even
+prime `p = 2` is the source of involutions; the odd-order world is precisely
+where that source is switched off. The fact that squaring is then a bijection
+(equivalently, that odd-order groups have unique square roots) is a standard
+ingredient in the structure theory of finite groups — for instance in the
+opening moves of the Feit–Thompson programme, where odd order is the standing
+hypothesis.
+-/
+
+namespace CauchyGroupTheoremOQ01OQ01
+
+variable {G : Type*}
+
+/-! ### Squaring in odd-order groups -/
+
+/-- **Explicit square root in an odd-order group.** If `|G|` is odd, every
+element `x` is the square of `x ^ (m+1)` where `|G| = 2m + 1`. -/
+theorem exists_sq_eq_of_odd_card [Group G] [Fintype G]
+    (hodd : Odd (Fintype.card G)) (x : G) : ∃ y : G, y ^ 2 = x := by
+  obtain ⟨m, hm⟩ := hodd
+  refine ⟨x ^ (m + 1), ?_⟩
+  rw [← pow_mul]
+  have hk : (m + 1) * 2 = Fintype.card G + 1 := by omega
+  rw [hk, pow_succ, pow_card_eq_one, one_mul]
+
+/-- **Squaring is surjective** in a finite group of odd order. -/
+theorem sq_surjective_of_odd_card [Group G] [Fintype G]
+    (hodd : Odd (Fintype.card G)) : Function.Surjective (fun x : G => x ^ 2) :=
+  fun x => exists_sq_eq_of_odd_card hodd x
+
+/-- **Squaring is bijective** in a finite group of odd order: every element has a
+unique square root. -/
+theorem sq_bijective_of_odd_card [Group G] [Fintype G]
+    (hodd : Odd (Fintype.card G)) : Function.Bijective (fun x : G => x ^ 2) :=
+  ⟨(Finite.injective_iff_surjective).mpr (sq_surjective_of_odd_card hodd),
+   sq_surjective_of_odd_card hodd⟩
+
+/-! ### Absence of involutions -/
+
+/-- **No involutions in an odd-order group.** If `|G|` is odd, the only solution
+of `x ^ 2 = 1` is `x = 1`. This is the contrapositive of the parent's
+even-order involution corollary. -/
+theorem no_involution_of_odd_card [Group G] [Fintype G]
+    (hodd : Odd (Fintype.card G)) {x : G} (hx : x ^ 2 = 1) : x = 1 := by
+  have hdvd : orderOf x ∣ 2 := orderOf_dvd_of_pow_eq_one hx
+  have hcard : orderOf x ∣ Fintype.card G := orderOf_dvd_card
+  rcases (Nat.dvd_prime Nat.prime_two).mp hdvd with h1 | h2
+  · exact orderOf_eq_one_iff.mp h1
+  · exfalso
+    rw [h2] at hcard
+    obtain ⟨k, hk⟩ := hodd
+    obtain ⟨j, hj⟩ := hcard
+    omega
+
+/-- **Sharp boundary: involutions exist iff the order is even.** A finite group
+contains a nontrivial self-inverse element iff its order is even. The forward
+direction is the new odd-order result; the backward direction is the Cauchy
+`p = 2` case. This upgrades the parent's one-directional even-order corollary to
+an equivalence. -/
+theorem involution_iff_even_card [Group G] [Fintype G] :
+    (∃ x : G, x ≠ 1 ∧ x ^ 2 = 1) ↔ Even (Fintype.card G) := by
+  constructor
+  · rintro ⟨x, hx1, hx2⟩
+    by_contra h
+    exact hx1 (no_involution_of_odd_card (Nat.not_even_iff_odd.mp h) hx2)
+  · intro heven
+    obtain ⟨k, hk⟩ := heven
+    have h2 : 2 ∣ Fintype.card G := ⟨k, by omega⟩
+    haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+    obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card 2 h2
+    refine ⟨g, ?_, ?_⟩
+    · intro hg1
+      rw [hg1, orderOf_one] at hg
+      exact absurd hg (by decide)
+    · have h := pow_orderOf_eq_one g
+      rwa [hg] at h
+
+/-! ### Additive form -/
+
+/-- **Doubling is surjective** in a finite additive group of odd order: every
+element is a double, namely `x = 2 • ((m+1) • x)` where `|G| = 2m + 1`. -/
+theorem exists_two_nsmul_eq_of_odd_card [AddGroup G] [Fintype G]
+    (hodd : Odd (Fintype.card G)) (x : G) : ∃ y : G, 2 • y = x := by
+  obtain ⟨m, hm⟩ := hodd
+  refine ⟨(m + 1) • x, ?_⟩
+  rw [two_nsmul, ← add_nsmul]
+  have hk : (m + 1) + (m + 1) = Fintype.card G + 1 := by omega
+  rw [hk, succ_nsmul, card_nsmul_eq_zero, zero_add]
+
+/-! ### Concrete instances (kernel `decide`, no `native_decide`) -/
+
+/-- In `ZMod 3` (odd order), doubling is surjective. -/
+theorem zmod3_double_surjective : ∀ x : ZMod 3, ∃ y : ZMod 3, 2 • y = x := by decide
+
+/-- In `ZMod 3` (odd order), the only self-inverse element is `0`. -/
+theorem zmod3_no_involution : ∀ x : ZMod 3, x + x = 0 → x = 0 := by decide
+
+/-- In `ZMod 5` (odd order), doubling is surjective. -/
+theorem zmod5_double_surjective : ∀ x : ZMod 5, ∃ y : ZMod 5, 2 • y = x := by decide
+
+end CauchyGroupTheoremOQ01OQ01

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01",
+  "title": "The odd-order boundary of Cauchy's theorem: squaring is a bijection",
+  "slug": "cauchy-group-theorem-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.GroupTheory.Perm.Cycle.Type",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CauchyGroupTheoremOQ01OQ01",
+    "lineCount": 151,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "The odd-order companion to the parent's even-order corollary of Cauchy's theorem. The parent proves that a finite group of even order contains an involution (the p=2 case of Cauchy); this entry proves the complementary structure on the other side of that dividing line. In a finite group of odd order every element is a square — with the explicit root x = (x^(m+1))^2 where |G| = 2m+1 — so the squaring map is surjective, hence bijective (unique square roots). Dually, an odd-order group has no involutions: x^2 = 1 forces x = 1, the exact contrapositive of the parent's corollary. Combining the two directions yields the sharp boundary involution_iff_even_card: a finite group has a nontrivial self-inverse element iff its order is even. An additive form shows doubling is surjective in odd-order additive groups, with 0-axiom ZMod 3 and ZMod 5 witnesses by kernel decide.",
+  "meta": {
+    "author": "Lean formalization original (structural follow-up to Cauchy's theorem)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "cauchy-theorem",
+      "order-of-element",
+      "involution",
+      "odd-order",
+      "bijection",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "pow_card_eq_one",
+        "description": "x ^ Fintype.card G = 1 in a finite group; the single fact driving the explicit square root identity (x^(m+1))^2 = x^(|G|+1) = x.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Finite.injective_iff_surjective",
+        "description": "For a self-map of a finite type, injective ↔ surjective; upgrades surjectivity of squaring to bijectivity.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "orderOf_dvd_of_pow_eq_one",
+        "description": "x ^ n = 1 → orderOf x ∣ n; from x^2 = 1 gives orderOf x ∣ 2.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "orderOf_dvd_card",
+        "description": "orderOf x ∣ Fintype.card G (Lagrange); an order-2 element would force 2 ∣ |G|, contradicting odd order.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "exists_prime_orderOf_dvd_card",
+        "description": "Cauchy's theorem itself: p ∣ |G| yields an element of order p; the p=2 case supplies the involution in the backward direction of involution_iff_even_card.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "card_nsmul_eq_zero",
+        "description": "Fintype.card G • x = 0 in a finite additive group; the additive analogue of pow_card_eq_one used for the doubling-surjective form.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      }
+    ],
+    "annotations": [
+      {
+        "id": "explicit-root",
+        "title": "Explicit Square Root in Odd Order",
+        "startLine": 66,
+        "endLine": 74,
+        "summary": "exists_sq_eq_of_odd_card: writing |G| = 2m+1, the element x^(m+1) squares to x via (x^(m+1))^2 = x^((m+1)*2) = x^(|G|+1) = x^|G| * x = x, using pow_card_eq_one.",
+        "mathContext": "Odd order ⟹ every element is a square, with an explicit root."
+      },
+      {
+        "id": "squaring-bijective",
+        "title": "Squaring Is a Bijection",
+        "startLine": 76,
+        "endLine": 88,
+        "summary": "sq_surjective_of_odd_card and sq_bijective_of_odd_card: the explicit root makes x ↦ x^2 surjective, and on a finite group surjective ⟹ bijective, so every element has a unique square root.",
+        "mathContext": "Odd order ⟹ the squaring map is bijective."
+      },
+      {
+        "id": "no-involution",
+        "title": "No Involutions in Odd Order",
+        "startLine": 90,
+        "endLine": 103,
+        "summary": "no_involution_of_odd_card: if x^2 = 1 then orderOf x ∣ 2; being 2 would force 2 ∣ |G| against oddness, so orderOf x = 1 and x = 1. The exact contrapositive of the parent's even-order involution corollary.",
+        "mathContext": "Odd order ⟹ x^2 = 1 forces x = 1."
+      },
+      {
+        "id": "sharp-boundary",
+        "title": "Sharp Boundary: Involutions Iff Even Order",
+        "startLine": 105,
+        "endLine": 128,
+        "summary": "involution_iff_even_card: a finite group has a nontrivial element with x^2 = 1 iff |G| is even. Forward is the new odd-order result; backward is Cauchy at p = 2. Upgrades the parent's one-directional corollary to an equivalence.",
+        "mathContext": "Existence of an involution ⟺ even order."
+      },
+      {
+        "id": "additive-form",
+        "title": "Additive Form: Doubling Is Surjective",
+        "startLine": 130,
+        "endLine": 140,
+        "summary": "exists_two_nsmul_eq_of_odd_card: in a finite additive group of odd order every element is a double, x = 2 • ((m+1) • x), the additive translation of the squaring-surjective result.",
+        "mathContext": "Odd order ⟹ doubling is surjective."
+      },
+      {
+        "id": "concrete-instances",
+        "title": "Concrete Witnesses in ZMod 3 and ZMod 5",
+        "startLine": 142,
+        "endLine": 149,
+        "summary": "zmod3_double_surjective, zmod5_double_surjective and zmod3_no_involution exhibit the odd-order phenomena concretely: doubling is onto and the only self-inverse element is 0. All by kernel decide, no native_decide, so 0 axioms.",
+        "mathContext": "Odd-order phenomena realised in ZMod 3 and ZMod 5, 0 axioms."
+      }
+    ],
+    "references": [
+      {
+        "authors": "Cauchy, Augustin-Louis",
+        "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+        "year": "1845",
+        "note": "Exercices d'analyse et de physique mathématique 3, 151–252 — the original theorem; the even prime p = 2 is the source of involutions, switched off in odd order."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — odd order as the standing hypothesis where squaring is a bijection and no involutions occur."
+      },
+      {
+        "authors": "Feit, Walter; Thompson, John G.",
+        "title": "Solvability of groups of odd order",
+        "year": "1963",
+        "note": "Pacific Journal of Mathematics 13, 775–1029 — the deep structure theory of odd-order groups, whose elementary opening observation is the absence of involutions."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Self-generated structural follow-up to the verified parent **CauchyGroupTheoremOQ01** (#27203). The parent records Cauchy's theorem and its *even-order* corollary — a finite group of even order contains an involution (the `p = 2` case). This entry proves the complementary **odd-order** structure theory, the sharp boundary on the other side of that dividing line. None of these statements are packaged in Mathlib.

## What's proved (8 theorems, 151 lines, 0 axioms)

- **`exists_sq_eq_of_odd_card`** — in a finite group of odd order every element is a square, with the *explicit* root `x = (x^(m+1))^2` where `|G| = 2m+1`. One-line identity `(x^(m+1))^2 = x^(|G|+1) = x^|G| · x = x` via `pow_card_eq_one`.
- **`sq_surjective_of_odd_card` / `sq_bijective_of_odd_card`** — the squaring map is surjective, hence (finite) bijective: unique square roots.
- **`no_involution_of_odd_card`** — `x^2 = 1` forces `x = 1` (an order-2 element would make `2 ∣ |G|`). The exact contrapositive of the parent's corollary.
- **`involution_iff_even_card`** — **sharp boundary**: a finite group has a nontrivial self-inverse element **iff** its order is even. Forward = the new odd-order result; backward = Cauchy at `p = 2`. Upgrades the parent's one-directional corollary to an equivalence.
- **`exists_two_nsmul_eq_of_odd_card`** — additive form: doubling is surjective in odd-order additive groups.
- **`zmod3_double_surjective`, `zmod5_double_surjective`, `zmod3_no_involution`** — concrete witnesses by kernel `decide` (no `native_decide`).

## Verification

`#print axioms` on all 8 theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely **0-axiom verified**. Elaborated with Lean `v4.26.0` against the prebuilt Mathlib oleans.

## Scope honesty

The headline results (explicit root, squaring bijection, no-involution, the iff) are genuine elementary derivations, not in Mathlib. The backward direction of the iff invokes Mathlib's `exists_prime_orderOf_dvd_card` (Cauchy itself); everything else is built from elementary order/`pow_card_eq_one` facts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)