### PR TITLE
Enrich Homogeneous-Power Davenport Bound D(Gⁿ) ≥ n·(D(G)−1)+1 (Erdős #131)

### DIFF
--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-haszerosum-davenportset",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "definition",
+    "title": "Zero-sum subsequences and the Davenport set",
+    "content": "A sequence $f : \\mathrm{Fin}\\,m \\to G$ has a nonempty zero-sum subsequence when some nonempty index set $s$ satisfies $\\sum_{i \\in s} f(i) = 0$. The Davenport set of $G$ collects the lengths $m$ at which EVERY length-$m$ sequence is forced to contain such a subsequence. Packaging the constant as a set (rather than a number) lets `IsLeast` carry both the membership ($m$ is forcing) and the minimality (no shorter length is) in one hypothesis, sidestepping any need to assume $G$ is finite.",
+    "mathContext": "$D(G) = \\min\\{\\,m : \\forall f \\in G^m,\\ \\exists\\, \\emptyset \\neq s,\\ \\textstyle\\sum_{i\\in s} f_i = 0\\,\\}$",
+    "significance": "key",
+    "relatedConcepts": ["Davenport constant", "zero-sum sequence", "sequence over an abelian group", "additive combinatorics"],
+    "prerequisites": ["finite abelian groups", "Finset summation"]
+  },
+  {
+    "id": "ann-davenport-set-mono",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 68, "endLine": 75 },
+    "type": "lemma",
+    "title": "Upward closure of the Davenport set",
+    "content": "If length $m$ already forces a zero-sum subsequence then so does any longer length $m' \\geq m$: restrict the longer sequence to its first $m$ entries via the order embedding `Fin.castLE`, extract the zero-sum set there, and push it back along `Fin.castLEEmb` (the sum is preserved by `Finset.sum_map`). This monotonicity is the lever that converts 'length $n(d-1)$ is NOT forcing' into a strict lower bound on $D(G^n)$ — without it, exhibiting one zero-sum-free sequence would not bound the constant.",
+    "mathContext": "$m \\in \\mathcal{D}(G) \\ \\wedge\\ m \\le m' \\ \\Longrightarrow\\ m' \\in \\mathcal{D}(G)$",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity", "order embedding", "Fin.castLE", "Finset.sum_map"],
+    "prerequisites": ["Finset.map and embeddings", "Fin order structure"]
+  },
+  {
+    "id": "ann-davenport-helpers",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 77, "endLine": 90 },
+    "type": "lemma",
+    "title": "Length 0 is never forcing; the constant is positive",
+    "content": "Length $0$ can never lie in the Davenport set — a length-$0$ sequence has empty index space, so no nonempty $s$ exists — and therefore the least Davenport length is at least $1$. This positivity makes $d - 1$ a genuine (well-defined, non-degenerate) zero-sum-free length, which is exactly the length the extremal power sequence is built on. These three small facts are reproduced verbatim from the binary direct-sum companion to keep the file self-contained and independently axiom-free.",
+    "mathContext": "$0 \\notin \\mathcal{D}(G) \\ \\Longrightarrow\\ D(G) \\ge 1 \\ \\Longrightarrow\\ d - 1 \\text{ is a valid zero-sum-free length}$",
+    "significance": "supporting",
+    "relatedConcepts": ["empty sequence", "IsLeast", "positivity"],
+    "prerequisites": ["Nat case analysis", "Fin n has no elements when n = 0"]
+  },
+  {
+    "id": "ann-powerseq",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 92, "endLine": 99 },
+    "type": "definition",
+    "title": "The power sequence: the explicit extremal construction",
+    "content": "The single construction that powers the whole bound. Decode each index $x \\in \\mathrm{Fin}(n\\ell)$ as a pair $(i,k) \\in \\mathrm{Fin}\\,n \\times \\mathrm{Fin}\\,\\ell$ through the product equivalence `finProdFinEquiv`, then emit the standard-basis vector `Pi.single i (f k)` — the value $f(k)$ placed in coordinate $i$ of $G^n$, zero elsewhere. So `powerSeq n f` lays $n$ disjoint copies of the zero-sum-free sequence $f$ along the $n$ coordinate axes of $G^n$, giving an extremal sequence of length $n\\ell$. This is the homogeneous-power analogue of the binary companion's `concatSeq`, with one product reindexing replacing the binary left/right split.",
+    "mathContext": "$\\mathrm{powerSeq}_n f\\,(x) = \\mathbf{e}_i \\cdot f(k), \\quad (i,k) = \\mathrm{finProdFinEquiv}^{-1}(x), \\quad \\mathbf{e}_i = \\mathrm{Pi.single}\\,i\\,1$",
+    "significance": "critical",
+    "relatedConcepts": ["direct power Gⁿ", "standard basis vector", "finProdFinEquiv", "Pi.single", "extremal construction"],
+    "prerequisites": ["Pi types (Fin n → G)", "Fin m × Fin n ≃ Fin (m·n)"]
+  },
+  {
+    "id": "ann-engine-reindex",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 110, "endLine": 119 },
+    "type": "insight",
+    "title": "Reindexing a candidate zero-sum set into the product",
+    "content": "The proof that `powerSeq n f` is zero-sum-free begins by transporting a hypothetical zero-sum index set $s \\subseteq \\mathrm{Fin}(n\\ell)$ to $t \\subseteq \\mathrm{Fin}\\,n \\times \\mathrm{Fin}\\,\\ell$ along `finProdFinEquiv`. Because the equivalence is a bijection, mapping $t$ back recovers $s$ and (via `Finset.sum_map`) preserves the total; after `simp` unfolds `powerSeq` the hypothesis reads $\\sum_{(i,k)\\in t} \\mathrm{Pi.single}\\,i\\,(f\\,k) = 0$. Working in the product index is what makes the subsequent coordinate-by-coordinate slicing possible.",
+    "mathContext": "$\\sum_{x \\in s} \\mathrm{powerSeq}_n f\\,(x) = \\sum_{(i,k) \\in t} \\mathrm{Pi.single}\\,i\\,(f\\,k) = 0$",
+    "significance": "key",
+    "relatedConcepts": ["change of index", "Finset.map_map", "Finset.sum_map", "Equiv.symm_apply_apply"],
+    "prerequisites": ["Finset reindexing along an Equiv", "simp only with definitional unfolding"]
+  },
+  {
+    "id": "ann-engine-slices",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 120, "endLine": 148 },
+    "type": "insight",
+    "title": "Coordinatewise slicing forces every slice empty",
+    "content": "The heart of the argument. Read coordinate $j$ of the vanishing vector sum: by `Finset.sum_apply` and `Pi.single_apply` only the terms with first component $i = j$ survive, so $\\sum_{(j,k)\\in t} f(k) = 0$ — a vanishing sum of $f$ over the slice $\\{k : (j,k)\\in t\\}$. On that slice the second-projection `Prod.snd` is injective (the first coordinate is pinned to $j$), so `Finset.sum_image` identifies the slice with a genuine `Finset (Fin ℓ)` $K$ and the slice sum with $\\sum_{k\\in K} f(k) = 0$. Zero-sum-freeness of $f$ forbids any nonempty such $K$, so every slice is empty. The whole $n$-dimensional zero-sum problem decouples into $n$ independent copies of the $G$-problem — the structural reason the bound is exactly additive across coordinates.",
+    "mathContext": "$\\forall j,\\ \\sum_{k:\\,(j,k)\\in t} f(k) = 0 \\ \\xrightarrow{f \\text{ zero-sum-free}}\\ \\{k:(j,k)\\in t\\} = \\emptyset$",
+    "significance": "critical",
+    "relatedConcepts": ["Finset.sum_apply", "Pi.single_apply", "Finset.sum_filter", "Finset.sum_image", "injectivity on a slice"],
+    "prerequisites": ["evaluating a Pi-valued Finset sum coordinatewise", "Finset.sum_image with an injectivity hypothesis"]
+  },
+  {
+    "id": "ann-engine-conclude",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 149, "endLine": 158 },
+    "type": "tactic",
+    "title": "Empty slices collapse the whole set",
+    "content": "Each element $x \\in t$ lies in the slice over its own first coordinate $x.1$ (the filter condition $x.1 = x.1$ holds by `rfl`); since that slice was just shown empty, $t$ can have no elements, so $t = \\emptyset$ and hence $s = \\emptyset$, contradicting the assumed nonemptiness. This closes `powerseq_not_hasZeroSum`. Note the v4.26.0 idioms `Finset.eq_empty_iff_forall_notMem` and `Finset.notMem_empty` (the renamed successors of the older `not_mem` lemmas).",
+    "mathContext": "$(\\forall j,\\ t_j = \\emptyset) \\ \\Longrightarrow\\ t = \\emptyset \\ \\Longrightarrow\\ s = \\emptyset \\ \\bot$",
+    "significance": "supporting",
+    "relatedConcepts": ["proof by contradiction", "Finset.eq_empty_iff_forall_notMem", "Finset.filter"],
+    "prerequisites": ["Finset emptiness lemmas"]
+  },
+  {
+    "id": "ann-davenport-pow-lower",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 160, "endLine": 184 },
+    "type": "theorem",
+    "title": "The headline bound D(Gⁿ) ≥ n·(D(G) − 1) + 1",
+    "content": "The main result. Since $d = D(G)$ is least, length $d-1$ is NOT forcing, so a zero-sum-free $f : \\mathrm{Fin}(d-1) \\to G$ exists. Its power sequence is a zero-sum-free sequence over $G^n$ of length $n(d-1)$, so $n(d-1) \\notin \\mathcal{D}(G^n)$. If we had $d_n \\le n(d-1)$, upward closure (`davenport_set_mono`) would make $n(d-1)$ forcing — contradiction. Hence $d_n \\ge n(d-1)+1$. The decisive efficiency: this is proved in ONE shot from `IsLeast` for $G$ and for $G^n$ alone, with no `IsLeast`/finiteness hypotheses on the intermediate powers $G^k$ that an induction on the binary bound would demand.",
+    "mathContext": "$D(G^n) \\ge n\\,(D(G) - 1) + 1$",
+    "significance": "critical",
+    "relatedConcepts": ["Olson–Davenport lower bound", "extremal sequence", "IsLeast", "iterated direct sum", "proof by contradiction"],
+    "prerequisites": ["IsLeast and minimality reasoning", "the power-concatenation lemma"]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01",
+    "range": { "startLine": 186, "endLine": 208 },
+    "type": "theorem",
+    "title": "Specializations: elementary abelian p-groups and the diagonal n = 2",
+    "content": "Two corollaries instantiate the bound. Feeding the cyclic value $D(\\mathbb{Z}/p\\mathbb{Z}) = p$ yields $D((\\mathbb{Z}/p\\mathbb{Z})^n) \\ge n(p-1)+1$ — the lower-bound half of Olson's 1969 theorem for elementary abelian $p$-groups, where equality in fact holds (the matching upper bound is Olson's Chevalley–Warning argument, not formalized here). Taking $n = 2$ gives $D(G^2) \\ge 2D(G) - 1$, matching the diagonal special case of the binary direct-sum companion but obtained directly from the power construction rather than by composing two binary steps.",
+    "mathContext": "$D((\\mathbb{Z}/p\\mathbb{Z})^n) \\ge n(p-1)+1 \\qquad D(G^2) \\ge 2D(G) - 1$",
+    "significance": "key",
+    "relatedConcepts": ["Olson's theorem", "elementary abelian p-group", "Chevalley–Warning", "diagonal case"],
+    "prerequisites": ["cyclic Davenport constant D(ℤ/pℤ) = p"]
+  }
+]

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01/meta.json
@@ -17,6 +17,70 @@
     "sorries": 0
   },
   "title": "The Homogeneous-Power Davenport Lower Bound D(Gⁿ) ≥ n·(D(G) − 1) + 1 (Erdős #131)",
+  "description": "For any additive group G, the Davenport constant of the n-fold direct power Gⁿ = (Fin n → G) satisfies D(Gⁿ) ≥ n·(D(G) − 1) + 1. The bound is proved in one shot from a single explicit extremal construction — the power sequence, which lays n disjoint copies of a zero-sum-free sequence along the coordinate axes — rather than by iterating the binary direct-sum bound, so it needs no per-stage finiteness hypotheses. Specializing D(ℤ/pℤ) = p recovers the lower-bound half of Olson's theorem D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1 for elementary abelian p-groups. Verified, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Davenport constant D(G) — the least d such that every length-d sequence over a finite abelian group G contains a nonempty zero-sum subsequence — was popularized by Harold Davenport in the 1960s in connection with the ideal class group of a number field: D(G) bounds the maximal length of an irreducible factorization. Its exact value is known only for special families. John Olson settled the elementary abelian p-group case in his 1969 paper 'A combinatorial problem on finite Abelian groups, I', proving D((ℤ/pℤ)ⁿ) = n·(p − 1) + 1, and the cyclic case D(ℤ/nℤ) = n is classical. The general structure — whether D(G₁ ⊕ G₂) = D(G₁) + D(G₂) − 1 holds for all finite abelian groups — remains a famous open problem (false in general; the rank-3 counterexamples of the 1970s show the easy lower bound need not be sharp). Within Erdős problem #131 on non-dividing sets, the Davenport constant is the additive-combinatorial invariant governing the per-element size bounds, and its direct-power growth is the higher-rank generalization of the cyclic case.",
+    "problemStatement": "Let $G$ be an additive group and $G^n = (\\mathrm{Fin}\\,n \\to G)$ its $n$-fold direct power. Writing $D(\\cdot)$ for the Davenport constant (the least length forcing a nonempty zero-sum subsequence, packaged here as $\\mathrm{IsLeast}$ of the Davenport set), prove the lower bound $D(G^n) \\ge n\\,(D(G) - 1) + 1$. Equivalently: exhibit a zero-sum-free sequence over $G^n$ of length $n\\,(D(G)-1)$.",
+    "proofStrategy": "Avoid the obvious induction on the binary bound $D(G_1 \\oplus G_2) \\ge D(G_1) + D(G_2) - 1$, which would require an $\\mathrm{IsLeast}$ (hence finiteness) hypothesis for every intermediate power $G^k$. Instead give one explicit extremal sequence. Take a zero-sum-free $f : \\mathrm{Fin}(d-1) \\to G$ (it exists because $d = D(G)$ is least, so length $d-1$ is not forcing). Build the power sequence $\\mathrm{powerSeq}_n f$ over $G^n$ of length $n(d-1)$ that places $f(k)$ in coordinate $i$ for the index decoding to $(i,k)$ via $\\mathrm{finProdFinEquiv}$. Show it is zero-sum-free: any candidate zero-sum index set, reindexed into $\\mathrm{Fin}\\,n \\times \\mathrm{Fin}\\,\\ell$, must vanish in each coordinate $j$; reading off coordinate $j$ isolates the slice $\\{k : (j,k) \\text{ chosen}\\}$ as a genuine zero-sum subset of $f$, which zero-sum-freeness forces empty. All slices empty ⟹ the set is empty. So $n(d-1) \\notin \\mathcal{D}(G^n)$, and upward closure of the Davenport set turns this into $D(G^n) \\ge n(d-1)+1$.",
+    "keyInsights": [
+      "The n-dimensional zero-sum problem DECOUPLES into n independent one-dimensional copies: because the extremal sequence lives on disjoint coordinate axes, a zero-sum total must vanish coordinatewise, and each coordinate is just the original zero-sum problem over G. This is the structural reason the lower bound is exactly additive across the n factors.",
+      "Packaging the Davenport constant as IsLeast of a SET rather than as a number is what makes the one-shot proof possible: it carries minimality without assuming G is finite, so no separate finiteness argument is needed — unlike an induction on the binary bound, which would force IsLeast at every intermediate power.",
+      "A single product reindexing finProdFinEquiv : Fin n × Fin ℓ ≃ Fin (n·ℓ) replaces the binary companion's left/right sum split finSumFinEquiv; the homogeneous case collapses what would be n − 1 nested binary concatenations into one bijection.",
+      "The coordinate slice is exhibited as an honest zero-sum subset of f by Finset.sum_image, exploiting that Prod.snd is injective on a slice whose first coordinate is pinned — turning a filtered sum back into a sum over a genuine Finset (Fin ℓ).",
+      "The bound is SHARP exactly for elementary abelian p-groups (Olson), where the matching upper bound is the deep half; the construction here is elementary and unconditional, isolating precisely the easy direction of a result whose hard direction needs Chevalley–Warning."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-and-imports",
+      "title": "Header: the homogeneous-power bound",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Docstring stating the goal D(Gⁿ) ≥ n·(D(G) − 1) + 1, the one-shot-vs-induction design rationale, the elementary-abelian specialization, and the self-contained import policy (only `import Mathlib`; helper lemmas reproduced verbatim from the binary companion)."
+    },
+    {
+      "id": "definitions",
+      "title": "Zero-sum subsequences and the Davenport set",
+      "startLine": 57,
+      "endLine": 66,
+      "summary": "Defines `HasZeroSumSubseq f` (some nonempty index set sums to zero) and `DavenportSet G` (the lengths at which every sequence is forced to contain one); the Davenport constant is the least element."
+    },
+    {
+      "id": "davenport-helpers",
+      "title": "Upward closure and positivity helpers",
+      "startLine": 68,
+      "endLine": 90,
+      "summary": "`davenport_set_mono` (the Davenport set is upward closed), `zero_not_mem_davenportSet` (length 0 is never forcing), and `one_le_of_isLeast_davenport` (the constant is positive, so d − 1 is a valid zero-sum-free length)."
+    },
+    {
+      "id": "power-sequence",
+      "title": "The power sequence construction",
+      "startLine": 92,
+      "endLine": 99,
+      "summary": "`powerSeq n f` decodes each index via `finProdFinEquiv` to (i,k) and emits `Pi.single i (f k)`, placing f along the n coordinate axes of Gⁿ — the explicit extremal sequence of length n·ℓ."
+    },
+    {
+      "id": "power-zerosumfree",
+      "title": "The engine: the power sequence is zero-sum-free",
+      "startLine": 101,
+      "endLine": 158,
+      "summary": "`powerseq_not_hasZeroSum`: reindex a candidate zero-sum set into Fin n × Fin ℓ, read off each coordinate j (sum_apply, Pi.single_apply, sum_filter) to get a slice sum of f, identify it with a genuine zero-sum subset via sum_image, force every slice empty, hence the whole set empty."
+    },
+    {
+      "id": "headline-bound",
+      "title": "Homogeneous-power Davenport lower bound",
+      "startLine": 160,
+      "endLine": 184,
+      "summary": "`davenport_pow_lower`: a zero-sum-free f of length d − 1 exists by minimality; its power sequence shows n·(d − 1) is not a Davenport length; upward closure then forces D(Gⁿ) ≥ n·(d − 1) + 1."
+    },
+    {
+      "id": "corollaries",
+      "title": "Specializations: Olson's bound and the diagonal",
+      "startLine": 186,
+      "endLine": 210,
+      "summary": "`davenport_elementary_abelian_lower` (D((ℤ/pℤ)ⁿ) ≥ n·(p − 1) + 1 from D(ℤ/pℤ) = p, the lower half of Olson's theorem) and `davenport_pow_two_lower` (the n = 2 diagonal D(G²) ≥ 2·D(G) − 1)."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03-oq-01` (quality 10, pass 0).

## Quality improvements
- **annotations.json** (new): 10 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering every section of the 210-line Lean file — the definitions, the upward-closure/positivity helpers, the `powerSeq` construction, the coordinatewise-slicing engine `powerseq_not_hasZeroSum`, the headline `davenport_pow_lower`, and the Olson / diagonal corollaries.
- **description** (new): top-level summary read by the gallery loader.
- **overview** (new): `historicalContext` (Davenport's class-group origin, Olson 1969, the rank-3 counterexamples to the general additivity conjecture), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (notably the coordinate decoupling and the IsLeast-as-a-set design that avoids per-stage finiteness).
- **sections** (new): 7 sections covering all 210 lines.

## Notes
- No `index.ts` created: this repo loads proof data at runtime from generated `public/data/proofs/<slug>/` via a central manifest (only 3 legacy per-proof `index.ts` files remain), so it is not required.
- Axiom integrity: meta states `status: verified`, `badge: original`, `axiomCount: 0`. The Lean file has no `axiom` declarations and no assumption-carrying structures (`IsLeast` hypotheses are inputs to theorems, not encoded assumptions); `#print axioms` reports only propext/Classical.choice/Quot.sound. Accurate as-is.
- Verified with `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)