### PR TITLE
Fix: Erdos131Problem.lean Mathlib v4.26.0 bit-rot (#27278)

### DIFF
--- a/proofs/Proofs/Erdos131Problem.lean
+++ b/proofs/Proofs/Erdos131Problem.lean
@@ -124,7 +124,7 @@ theorem F_monotonic : ∀ N M : ℕ, N ≤ M → F N ≤ F M := by
 
 /- ## Upper Bounds -/
 
-/-- ELRSS (1999): F(N) < 3√N + 1 -/
+/- ELRSS (1999): F(N) < 3√N + 1 -/
 /-- Pham-Zakharov (2024): F(N) ≤ N^{1/4 + o(1)}
     This resolves the original question negatively. -/
 axiom pham_zakharov_upper_bound :
@@ -170,7 +170,7 @@ theorem original_question_answered_no :
 axiom csaba_lower_bound :
     ∃ c : ℝ, c > 0 ∧ ∀ N : ℕ, N ≥ 1 → (F N : ℝ) ≥ c * (N : ℝ)^((1 : ℝ)/5)
 
-/-- Straus's lower bound: F(N) > exp((√(2/log 2) + o(1))√(log N)) -/
+/- Straus's lower bound: F(N) > exp((√(2/log 2) + o(1))√(log N)) -/
 /-- exp(3/4) > 2, via Taylor sum of order 3:
     1 + 3/4 + 9/32 = 65/32 > 2 -/
 private theorem exp_three_fourths_gt_two : (2 : ℝ) < Real.exp (3/4) := by
@@ -476,14 +476,14 @@ private lemma nondividing_three_subset {a : ℕ} {T : Finset ℕ} (hT : T.card =
   rcases Nat.eq_or_lt_of_le hCard with h2 | h3
   · -- |S| = 2: T \ S has exactly 1 element
     have hTdiff_card : (T \ S).card = 1 := by
-      rw [Finset.card_sdiff hS, hT]; omega
+      rw [Finset.card_sdiff_of_subset hS, hT]; omega
     obtain ⟨x, hx_eq⟩ := Finset.card_eq_one.mp hTdiff_card
     have hxT : x ∈ T := by
       have : x ∈ T \ S := hx_eq ▸ Finset.mem_singleton_self x
       exact Finset.sdiff_subset this
     -- T.sum = S.sum + x (via Finset.sum_sdiff)
     have hsum : (T \ S).sum id + S.sum id = T.sum id := Finset.sum_sdiff hS
-    rw [hx_eq, Finset.sum_singleton] at hsum
+    rw [hx_eq, Finset.sum_singleton, id_eq] at hsum
     -- So T.sum - x = S.sum
     have hsub : T.sum id - x = S.sum id := by omega
     exact h_pairs x hxT (hsub ▸ hdvd)


### PR DESCRIPTION
## Fix

Repairs the `erdos-131` gallery entry's Lean source, which failed to build on the pinned Mathlib v4.26.0 (so the `status: verified` claim was unsupported).

## Evidence

**Before** — `./proofs/scripts/docker-build.sh Proofs.Erdos131Problem` failed with:
- `unexpected token '/--'; expected 'lemma'` (lines 127, 173) — orphan docstrings
- `Function expected at Finset.card_sdiff … applied to hS` (line 479)
- `omega could not prove the goal` (line 488, cascade)

**After** — three minimal repairs:
1. Convert the two standalone `/-- … -/` notes (ELRSS, Straus) to block comments `/- … -/`; newer Lean requires a docstring to attach to a declaration.
2. `Finset.card_sdiff hS` → `Finset.card_sdiff_of_subset hS` (renamed/re-signed API in v4.26.0).
3. Add `id_eq` to the `sum_singleton` rewrite so `omega` sees the concrete value.

Verified clean build:
```
✔ [7743/7743] Built Proofs.Erdos131Problem (416s)
Build completed successfully (7743 jobs).
```

The mathematics is unchanged — this is pure Mathlib-version bit-rot. Restores honesty of the `verified` claim.

Closes #27278

---
Automated fix by lean-mechanic agent.