### PR TITLE
audit(amgm-inequality-oq-02-oq-03-oq-03-oq-01): badge verified→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/meta.json
@@ -16,14 +16,14 @@
       "cauchy-schwarz",
       "newton-identities"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
     "lineCount": 130,
     "theoremCount": 3,
     "definitionCount": 0,
-    "assumptions": "None. All three theorems are fully machine-checked with 0 axioms and 0 sorries, building only on the parent AmgmInequalityOQ02 public API and Mathlib's Cauchy-Schwarz inequality (sq_sum_le_card_mul_sum_sq).",
+    "assumptions": "0 axioms, 0 sorries (core inequality via Mathlib bridge). All three theorems are fully machine-checked, but the analytic engine is imported: the headline maclaurin_step_one obtains its M₁ ≥ M₂ bound from newton_inequality_k1, which delegates to the parent AmgmInequalityOQ02's maclaurin_sq_m1_ge_m2_general — itself a packaging of Mathlib's Cauchy-Schwarz inequality (sq_sum_le_card_mul_sum_sq). This file's independent content is the Real.sqrt-monotonicity assembly de-axiomatizing the k=1 step and the resolution of the Newton-identities open question; the core positivity input is Mathlib's. Hence the `mathlib` badge (Tier B).",
     "originalContributions": [
       "Resolves the open question (No): Mathlib's NewtonIdentities are ring equalities (e_k ↔ p_k) over an arbitrary CommRing and carry no order information, so they cannot yield Newton's log-concavity inequality e_k² ≥ e_{k-1}·e_{k+1} that maclaurin_step depends on",
       "Identifies the correct engine: Cauchy-Schwarz (cauchy_schwarz_engine, from Mathlib's sq_sum_le_card_mul_sum_sq) is the ℝ-specific positivity input that NewtonIdentities cannot supply",


### PR DESCRIPTION
## Gallery integrity audit — badge correction

**Proof**: `amgm-inequality-oq-02-oq-03-oq-03-oq-01` — "Maclaurin's Step via Mathlib Symmetric Functions"
**Severity**: MEDIUM (Mathlib wrapper badged as `verified`)

## Problem

The headline theorem `maclaurin_step_one` (M₁ ≥ M₂) derives its core inequality from:

```
maclaurin_step_one  →  newton_inequality_k1 := maclaurin_sq_m1_ge_m2_general (parent)
                    →  packages Mathlib's Cauchy-Schwarz sq_sum_le_card_mul_sum_sq
```

The analytic muscle (the `(∑x)² ≤ n·∑x²` bound) is Mathlib's. The file's own
title ("via Mathlib Symmetric Functions") and docstrings ("the analytic engine",
"the real content behind maclaurin_step") already credit Mathlib as the core
engine — so the `verified` (Tier A) badge was inconsistent with the entry's own
honest framing.

This is the standard Tier B pattern: a `verified` headline whose core inequality
is an imported deep theorem must carry the `mathlib` badge.

## Fix

- `badge`: `verified` → `mathlib`
- `assumptions`: clarified that the core inequality comes via the Mathlib bridge,
  while noting the file's genuine independent content (the `Real.sqrt`-monotonicity
  assembly de-axiomatizing the k=1 Maclaurin step, and resolving the
  Newton-identities open question).

**Unchanged**: `status` stays `verified` (still 0 axioms, 0 sorries, fully
kernel-checked); `theoremCount` (3), `sorries` (0), `axiomCount` (0) all already
correct. No Lean source changes.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)