### PR TITLE
research(summation-by-parts-oq-01-oq-01): closed form for ∑ k²·rᵏ (second-order arithmetico-geometric sum)

### DIFF
--- a/proofs/Proofs/SummationByPartsOQ01OQ01.lean
+++ b/proofs/Proofs/SummationByPartsOQ01OQ01.lean
@@ -1,0 +1,103 @@
+import Mathlib.Algebra.BigOperators.Module
+import Mathlib.Tactic
+
+/-
+# Closed form for the second-order arithmetico-geometric sum `∑ k²·rᵏ`
+
+## What This Proves
+
+For a field element `r ≠ 1` and a natural number `n`,
+
+    ∑_{k=0}^{n-1} k² · rᵏ
+      = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r) / (r − 1)³
+
+(the natural-number coefficients are read in `K`).  This is the **second-order**
+arithmetico-geometric sum: each term carries the quadratic arithmetic weight `k²`
+times the geometric factor `rᵏ`.  It is the next step beyond the parent entry
+`SummationByPartsOQ01`, which gives the first-order sum `∑ k·rᵏ`, and it is the
+finite, hypothesis-free analogue of the twice-differentiated geometric series
+whose `n → ∞` limit (for `|r| < 1`) is the classical `∑ k²·rᵏ = r(1+r)/(1−r)³`.
+
+## Why It Is Not Already in the Gallery / Mathlib
+
+Mathlib has `geom_sum_eq` (the geometric closed form) and, via the parent entry,
+the gallery now records the first-order `∑ k·rᵏ`.  Neither Mathlib nor the
+gallery contains a closed form for the **quadratically weighted** sum `∑ k²·rᵏ`
+over a general field.  The infinite gallery entries (`GeometricSeriesOQ06`) are
+analytic limits with `‖r‖ < 1`; the identity here is the exact finite sum over
+any field with the single algebraic hypothesis `r ≠ 1`.
+
+## Method
+
+`sum_range_sq_mul_geom` is proved by induction on `n`: the inductive step adds
+`m²·rᵐ` (via `Finset.sum_range_succ`) to the closed form at `m`; clearing the
+common denominator `(r−1)³` reduces the goal to a polynomial identity closed by
+`ring`.
+
+`sum_range_sq_mul_geom_eq_byParts` re-derives the same sum through **Abel's
+summation by parts** (`Finset.sum_range_by_parts`).  Unlike the first-order case,
+the quadratic weight `f k = k²` has *non-constant* forward differences
+`f(k+1) − f k = 2k+1`, so summation by parts reduces the second-order sum to a
+genuinely first-order weighted sum of geometric partial sums — exhibiting the
+recursive ladder `∑ k²·rᵏ ↝ ∑ (2k+1)·(geom) ↝ …`.
+
+`sum_range_sq_mul_geom_two` specializes to `r = 2`, where the cube `(r−1)³ = 1`
+collapses the closed form to the clean integer-coefficient identity
+`∑_{k<n} k²·2ᵏ = 2ⁿ·(n²−4n+6) − 6`.
+-/
+
+namespace SummationByPartsOQ01OQ01
+
+open Finset
+
+variable {K : Type*} [Field K]
+
+/-- **Second-order arithmetico-geometric sum, closed form.**
+For `r ≠ 1` in a field,
+`∑_{k<n} k²·rᵏ = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³`. -/
+theorem sum_range_sq_mul_geom {r : K} (hr : r ≠ 1) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * r ^ k
+      = ((n : K) ^ 2 * r ^ n - (2 * n ^ 2 - 2 * n - 1) * r ^ (n + 1)
+          + ((n : K) - 1) ^ 2 * r ^ (n + 2) - r ^ 2 - r) / (r - 1) ^ 3 := by
+  have hr1 : r - 1 ≠ 0 := sub_ne_zero.mpr hr
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [Finset.sum_range_succ, ih]
+      push_cast
+      field_simp
+      ring
+
+/-- The same second-order sum, re-derived through **Abel's summation by parts**.
+Taking the quadratic weight `f k = (k : K)²` and the geometric sequence
+`g k = rᵏ`, `Finset.sum_range_by_parts` rewrites the weighted sum as a boundary
+term minus a correction term.  Here the forward differences
+`f(k+1) − f k = 2k+1` are *not* constant, so summation by parts reduces the
+second-order sum to a first-order weighted sum of geometric partial sums. -/
+theorem sum_range_sq_mul_geom_eq_byParts (r : K) (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * r ^ k
+      = (↑(n - 1) : K) ^ 2 * (∑ i ∈ range n, r ^ i)
+        - ∑ i ∈ range (n - 1), (2 * (i : K) + 1) * (∑ j ∈ range (i + 1), r ^ j) := by
+  have h := Finset.sum_range_by_parts (fun k => (k : K) ^ 2) (fun k => r ^ k) n
+  simp only [smul_eq_mul] at h
+  rw [h]
+  congr 1
+  apply Finset.sum_congr rfl
+  intro i _
+  push_cast
+  ring
+
+/-- **Concrete specialization at `r = 2`.**
+`∑_{k<n} k²·2ᵏ = 2ⁿ·(n²−4n+6) − 6`.  Direct induction (no division), since at
+`r = 2` the denominator `(r−1)³ = 1`. -/
+theorem sum_range_sq_mul_geom_two (n : ℕ) :
+    ∑ k ∈ range n, (k : K) ^ 2 * 2 ^ k
+      = 2 ^ n * ((n : K) ^ 2 - 4 * n + 6) - 6 := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [Finset.sum_range_succ, ih]
+      push_cast
+      ring
+
+end SummationByPartsOQ01OQ01

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01/meta.json
@@ -1,0 +1,126 @@
+{
+  "id": "summation-by-parts-oq-01-oq-01",
+  "title": "Closed Form of the Second-Order Arithmetico-Geometric Sum ∑ k²·rᵏ",
+  "slug": "summation-by-parts-oq-01-oq-01",
+  "description": "Over any field, for r ≠ 1 the quadratically weighted sum ∑_{k<n} k²·rᵏ equals (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³ — the finite refinement of the classical ∑ k²·rᵏ = r(1+r)/(1−r)³. Proved by induction, re-derived via Abel's summation by parts (whose non-constant differences 2k+1 expose the recursive ladder down to first order), and specialized to ∑_{k<n} k²·2ᵏ = 2ⁿ(n²−4n+6)−6. Answers the parent entry's first open question.",
+  "meta": {
+    "author": "Classical (Abel summation); formalized for the lean-genius gallery",
+    "sourceUrl": "https://github.com/leanprover-community/mathlib4",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SummationByPartsOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "finite-sums",
+      "arithmetico-geometric",
+      "summation-by-parts",
+      "abel-summation",
+      "geometric-series",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_by_parts",
+        "description": "Abel's summation by parts for ranges: ∑ i<n, f i • g i = f(n-1)•G n − ∑ i<n-1, (f(i+1)−f i)•G(i+1), where G is the partial sum of g",
+        "module": "Mathlib.Algebra.BigOperators.Module"
+      },
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n, the step driving the induction",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Closed form for the second-order arithmetico-geometric sum ∑_{k<n} k²·rᵏ = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³ over an arbitrary field, for every r ≠ 1 — absent from Mathlib and from the gallery, which carried only the first-order ∑ k·rᵏ (parent entry summation-by-parts-oq-01)",
+      "A second, independent derivation through Abel's summation by parts (Finset.sum_range_by_parts): unlike the first-order case, the quadratic weight f(k)=k² has non-constant forward differences f(k+1)−f k = 2k+1, so summation by parts reduces the second-order sum to a genuinely first-order weighted sum of geometric partial sums — exhibiting the recursive ladder ∑ k²·rᵏ ↝ ∑ (2k+1)·(geom) of degree-lowering",
+      "A clean integer-coefficient specialization at r = 2, where (r−1)³ = 1 collapses the formula to ∑_{k<n} k²·2ᵏ = 2ⁿ·(n²−4n+6) − 6, proved by direct division-free induction"
+    ],
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 103,
+    "theoremCount": 3,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound; no native_decide).",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The geometric series $\\sum_k r^k$ and the first-order arithmetico-geometric sum $\\sum_k k\\,r^k$ (parent entry) are the first two rungs of a ladder: multiplying the geometric terms by higher powers of the index $k$ produces sums $\\sum_k k^m r^k$ that are the discrete analogues of repeatedly applying the operator $r\\,\\frac{d}{dr}$ to $(1-r)^{-1}$. The second rung, $\\sum_k k^2 r^k$, is the workhorse of variance computations for geometric distributions and of generating-function manipulation. The classical tool remains **Abel's summation by parts**; but here the arithmetic weight $f(k)=k^2$ has *non-constant* differences $2k+1$, so the by-parts transform no longer collapses to pure geometric data — it lands on a first-order weighted sum, making the degree-lowering recursion explicit. The $n\\to\\infty$ limit (for $|r|<1$) is the textbook $\\sum_{k\\ge0} k^2 r^k = r(1+r)/(1-r)^3$.",
+    "problemStatement": "**Theorem.** For $r$ in a field with $r \\neq 1$ and $n \\in \\mathbb{N}$,\n$$\\sum_{k=0}^{n-1} k^2\\,r^{k} = \\frac{n^2 r^{n} - (2n^2-2n-1)\\,r^{n+1} + (n-1)^2 r^{n+2} - r^2 - r}{(r-1)^3},$$\nwhere the integer coefficients are read in $K$. The $|r|<1$ limit recovers $\\sum_{k\\ge 0} k^2 r^k = r(1+r)/(1-r)^3$. At $r=2$ the cube $(r-1)^3=1$ collapses the formula to $\\sum_{k<n} k^2\\,2^k = 2^n(n^2-4n+6)-6$.",
+    "proofStrategy": "**Induction (headline).** The base case $n=0$ is the empty sum. For the step, `Finset.sum_range_succ` adds the term $m^2 r^{m}$ to the closed form at $m$; clearing the common denominator $(r-1)^3$ (using $r-1\\neq 0$) reduces the goal to a polynomial identity discharged by `ring` after `push_cast`/`field_simp`.\n\n**Summation by parts (companion).** Specializing `Finset.sum_range_by_parts` to the weight $f(k)=k^2$ and sequence $g(k)=r^k$ rewrites the sum as $(n-1)^2 G_n - \\sum_{i<n-1} (2i+1)\\,G_{i+1}$ where $G_m = \\sum_{j<m} r^j$. The forward differences $f(k+1)-f(k)=2k+1$ are now linear in $k$, so the correction is a *first-order* arithmetico-geometric sum — one rung down the ladder.\n\n**Specialization at $r=2$.** A direct, division-free induction proves $\\sum_{k<n} k^2 2^k = 2^n(n^2-4n+6)-6$; the step identity $2^{m}\\big[2((m+1)^2-4(m+1)+6) - (m^2-4m+6)\\cdot\\tfrac12\\big]$ reduces to $m^2 2^m$ and closes by `ring`.",
+    "keyInsights": [
+      "**Non-constant differences expose the ladder.** Where the first-order weight $k$ has constant differences $1$ (collapsing Abel's correction to pure geometric data), the quadratic weight $k^2$ has differences $2k+1$. Summation by parts therefore drops $\\sum k^2 r^k$ to a first-order sum $\\sum (2k+1) G_{i+1}$ — making visible the recursion $\\deg \\to \\deg-1$ that produces every $\\sum k^m r^k$ in closed form.",
+      "**Field, not analysis.** Like its parent, the identity needs no norm and no convergence hypothesis: it is an exact rational-function-in-$r$ identity over $(r-1)^3$, valid for every $r\\neq 1$ in any field. The familiar $r(1+r)/(1-r)^3$ is only its $n\\to\\infty$ shadow when $|r|<1$.",
+      "**The cube vanishes at $r=2$.** Because $(2-1)^3=1$, the second-order formula specializes to a clean polynomial-times-$2^n$ identity with integer coefficients, a memorable closed form $\\sum_{k<n} k^2 2^k = 2^n(n^2-4n+6)-6$ that the division-free induction confirms independently."
+    ]
+  },
+  "sections": [
+    {
+      "id": "closed-form",
+      "title": "The Second-Order Closed Form by Induction",
+      "startLine": 54,
+      "endLine": 75,
+      "summary": "sum_range_sq_mul_geom: ∑_{k<n} k²·rᵏ = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³ for r ≠ 1, proved by induction with field_simp + ring on the step.",
+      "mathContext": "The inductive step absorbs the new term m²·rᵐ by a degree-(n+2) polynomial identity over the denominator (r−1)³, the second-order analogue of the parent's (r−1)² identity."
+    },
+    {
+      "id": "by-parts",
+      "title": "Re-derivation via Abel Summation by Parts",
+      "startLine": 76,
+      "endLine": 91,
+      "summary": "sum_range_sq_mul_geom_eq_byParts: the same sum equals (n−1)²·Gₙ − ∑_{i<n−1} (2i+1)·G_{i+1} with Gₘ = ∑_{j<m} rʲ, directly from Finset.sum_range_by_parts.",
+      "mathContext": "The weight f k = k² has linear forward differences f(k+1)−f k = 2k+1, so the Abel transform lands on a first-order weighted sum of geometric partial sums — one rung down the degree ladder."
+    },
+    {
+      "id": "specialization",
+      "title": "Concrete Specialization at r = 2",
+      "startLine": 92,
+      "endLine": 102,
+      "summary": "sum_range_sq_mul_geom_two: ∑_{k<n} k²·2ᵏ = 2ⁿ·(n²−4n+6) − 6, by direct division-free induction since (2−1)³ = 1.",
+      "mathContext": "At r=2 the denominator collapses, giving a clean integer-coefficient closed form proved without field_simp."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry supplies the exact finite second-order arithmetico-geometric identity ∑_{k<n} k²·rᵏ = (n²·rⁿ − (2n²−2n−1)·rⁿ⁺¹ + (n−1)²·rⁿ⁺² − r² − r)/(r−1)³ over any field, by induction and via Abel's summation by parts, plus the clean specialization ∑_{k<n} k²·2ᵏ = 2ⁿ(n²−4n+6)−6 — directly answering the parent entry's first open question.",
+    "implications": "The closed form is the second rung of the ladder ∑ k^m r^k; the by-parts derivation, whose non-constant differences 2k+1 drop the sum to first order, makes the degree-lowering recursion that generates every such formula explicit, and is the finite refinement underpinning the geometric-distribution variance identity ∑ k² r^k = r(1+r)/(1−r)³.",
+    "openQuestions": [
+      "Does the by-parts ladder iterate to a uniform closed form for ∑_{k<n} k^m·rᵏ for every fixed m, with the correction term recursing on m−1 down to the geometric base case?",
+      "Is there a single statement ∑_{k<n} P(k)·rᵏ = (Q(n,r)·rⁿ − Q(0,r))/(r−1)^{deg P + 1} for an arbitrary polynomial P, packaging all of these as one theorem with Q determined by the finite differences of P?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "summation-by-parts-oq-01",
+      "relationship": "extension",
+      "description": "The parent entry: the first-order sum ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)². This entry is the next rung k², and answers that entry's first open question."
+    },
+    {
+      "targetId": "geometric-series-oq-06",
+      "relationship": "refinement",
+      "description": "The infinite arithmetico-geometric series ∑ k·rⁿ = r/(1−r)² (‖r‖<1); the second-order analogue ∑ k² rᵏ = r(1+r)/(1−r)³ is the limit refined here over an arbitrary field."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "foundation",
+      "description": "The base geometric series ∑ rᵏ = (rⁿ−1)/(r−1); summation by parts expresses the quadratically weighted sum ∑ k²·rᵏ through its partial sums."
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Module",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SummationByPartsOQ01OQ01",
+    "lineCount": 103,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/SummationByPartsOQ01OQ01.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the closed form for the **second-order arithmetico-geometric sum** over any field — the next rung above the parent entry `summation-by-parts-oq-01` (∑ k·rᵏ), and a **direct answer to that entry's first open question**.

For a field element `r ≠ 1` and `n : ℕ`:
$$\sum_{k=0}^{n-1} k^2\,r^{k} = \frac{n^2 r^{n} - (2n^2-2n-1)\,r^{n+1} + (n-1)^2 r^{n+2} - r^2 - r}{(r-1)^3}.$$

This identity is **absent from Mathlib and the gallery** (which carried only the first-order ∑ k·rᵏ and the analytic infinite limits). It is the finite, hypothesis-free refinement of the classical ∑ k²·rᵏ = r(1+r)/(1−r)³.

## Theorems (3, all 0-sorry)

1. **`sum_range_sq_mul_geom`** — the closed form above, by induction (`field_simp` + `ring` on the step over the denominator `(r−1)³`).
2. **`sum_range_sq_mul_geom_eq_byParts`** — re-derivation via Abel's summation by parts (`Finset.sum_range_by_parts`). The key contrast with the first-order case: the quadratic weight `f k = k²` has **non-constant** forward differences `2k+1`, so summation by parts reduces the second-order sum to a genuinely *first-order* weighted sum of geometric partial sums — making the degree-lowering recursion `∑ kᵐrᵏ ↝ ∑ kᵐ⁻¹rᵏ` explicit.
3. **`sum_range_sq_mul_geom_two`** — concrete specialization at `r = 2`, where `(r−1)³ = 1` collapses the formula to the clean integer-coefficient identity `∑_{k<n} k²·2ᵏ = 2ⁿ(n²−4n+6) − 6`, proved by direct division-free induction.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` on all three theorems lists only `[propext, Classical.choice, Quot.sound]` (no `native_decide`, no `Lean.ofReduceBool`).
- Builds clean against Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.SummationByPartsOQ01OQ01`.
- Closed form independently verified symbolically (sympy) across multiple `(n, r)`.

## Files

- `proofs/Proofs/SummationByPartsOQ01OQ01.lean` (103 lines)
- `src/data/proofs/summation-by-parts-oq-01-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)