### PR TITLE
Fix: amgm-oq-03-oq-02-oq-01-oq-02 badge original→mathlib (Tier B overclaim)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -17,11 +17,11 @@
       "amgm",
       "equality-case"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 243,
-    "assumptions": "",
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions; no `native_decide` (`#print axioms` reports only propext, Classical.choice, Quot.sound). The equality engine is NOT independent: the core characterization `GM = ∑ wᵢ zᵢ` (constant data) ⟺ equality bottoms out at Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'`, reached one step away through the local `weighted_amgm_eq_iff` (JensenInequalityOQ01), which is a direct `rw`-restatement of that Mathlib lemma. This file's independent content is the transport on top of that core: extending the equality locus to power means of every order r ≠ 0 via injectivity of x ↦ xʳ on the positives (`Real.rpow_left_inj`), the sign-independence observation, the crossing-zero converse, and the strict (off-diagonal) forms. Because the central ⟺ rests on a Mathlib theorem, the badge is `mathlib` (Tier B) rather than `original`.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "power_mean_eq_geom_mean_iff: M_r = GM ↔ data constant, for EVERY r ≠ 0 — the equality locus is identical for positive and negative orders even though the inequality reverses across zero (sign-independent unification)",


### PR DESCRIPTION
## Integrity Issue

**Proof**: amgm-inequality-oq-03-oq-02-oq-01-oq-02 ("Equality Case of the Crossing-Zero Power-Mean Chain")
**Problem**: Tier B proof badged `original` (Mathlib wrapper claimed as independent); `assumptions` field empty.

## Evidence

The central characterization `M_r = GM ⟺ data constant` rests on the equality case of weighted AM–GM. Its engine is the local `weighted_amgm_eq_iff` (JensenInequalityOQ01.lean), which is itself a one-line restatement:

```lean
theorem weighted_amgm_eq_iff ... := by
  rw [Real.geom_mean_eq_arith_mean_weighted_iff' s w z hw hw' hz]
  ...
```

i.e. the ⟺ muscle bottoms out at Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'` (already listed in `mathlibDependencies`). Per the Tier B rule, a core result obtained via a Mathlib theorem takes badge `mathlib`, not `original`.

The file's genuine independent content is the **transport** on top of that core: extension to power means of every order `r ≠ 0` via injectivity of `x ↦ xʳ` (`Real.rpow_left_inj`), the sign-independence observation, the crossing-zero converse, and the strict off-diagonal forms. Substantial, but built on a Mathlib-backed equality core.

## Fix

- `badge`: `original` → `mathlib`
- `assumptions`: was `""`; now discloses the Mathlib bridge and scopes the independent contribution
- `status` unchanged (`verified` — 0 sorries, 0 axioms, no `native_decide`)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)