### PR TITLE
Fix: area-of-circle-oq-05-oq-03 badge original→mathlib (Tier B overclaim)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -16,12 +16,29 @@
       "complex-analysis",
       "probability"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 172,
     "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). HONEST SCOPE: CentralLimitTheorem.lean states its gaussian_fourier_identity against an abstract stdGaussian measure introduced by `axiom`; this file proves the full mathematical content as a concrete Lebesgue integral, but discharging that particular CLT axiom additionally requires replacing the abstract measure by ProbabilityTheory.gaussianReal 0 1, a separate bridge not attempted here.",
     "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
+        "description": "Core analytic engine: evaluates the vertical-strip-shifted Gaussian contour integral ∫ e^{-b(x+c·i)²} dx = (π/b)^{1/2} (Cauchy vertical-strip argument). Specialised at b=1/2, c=-t this is the √(2π) value behind the Fourier self-duality; the file's own work is completing the square to reduce e^{itx}·e^{-x²/2} to this form.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform"
+      },
+      {
+        "theorem": "MeasureTheory.integral_mul_const / MeasureTheory.integral_div",
+        "description": "Pull the constant e^{-t²/2} and the normalizing √(2π) out of the Lebesgue integral.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+      },
+      {
+        "theorem": "Complex.ofReal_cpow / Real.sqrt_eq_rpow",
+        "description": "Identify the Mathlib contour constant (π/(1/2))^{1/2} with the real √(2π) (cpow_half_eq_sqrt_two_pi).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
+      }
+    ],
     "dateAdded": "2026-06-21",
     "theoremCount": 6,
     "definitionCount": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: area-of-circle-oq-05-oq-03 ("The Gaussian is its own Fourier Transform")
**Problem**: Tier B proof badged `original`; `mathlibDependencies` was `null` (empty), hiding the core dependency in the structured metadata.

## Evidence

The headline `gaussian_fourier_real` is proved by completing the square pointwise (own lemma) and then reducing to Mathlib's contour-integral evaluation:

```lean
theorem gaussian_fourier_real (t : ℝ) : ... := by
  simp_rw [gaussian_integrand_complete_square t]
  rw [MeasureTheory.integral_mul_const]
  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I (b := ...) ... (-t)]
  rw [cpow_half_eq_sqrt_two_pi]
  ring
```

The actual analytic content — the value `∫ e^{-½(x-it)²} dx = √(2π)` (the vertical-strip Cauchy shift) — is `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I`. The file's own contribution is the complete-the-square reduction and the constant identity. That is genuine bridge work, but a core result obtained via a Mathlib theorem takes badge `mathlib` (Tier B), not `original`. The file docstring already credits the Mathlib lemma; only the structured metadata overclaimed.

## Fix

- `badge`: `original` → `mathlib`
- `mathlibDependencies`: was `null`; now lists the contour-integral engine + supporting lemmas
- `status` unchanged (`verified` — 0 sorries, 0 axioms, no `native_decide`)
- `assumptions` already honestly scoped (left as-is)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)