### PR TITLE
Fix: area-of-circle-oq-05-incomplete-01 badge original→mathlib (Tier B overclaim)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
@@ -17,7 +17,7 @@
       "area-of-circle"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05Incomplete01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       "integral_gaussian",


### PR DESCRIPTION
## Integrity Issue

**Proof**: area-of-circle-oq-05-incomplete-01 ("The Normal-Distribution Normalization Family")
**Problem**: Tier B proof badged `original`.

## Evidence

Every theorem is a rescaling of Mathlib's `integral_gaussian`:

```lean
theorem gaussian_half : ∫ x : ℝ, Real.exp (-x ^ 2 / 2) = Real.sqrt (2 * π) := by
  have h := integral_gaussian (1 / 2)
  ...
  rw [hfun, h]
```

The file's own docstring says it derives "everything from `integral_gaussian`", and the `assumptions` field states "Every theorem is derived from Mathlib's `integral_gaussian` by elementary algebra." The normalization-constant infrastructure (variance forms, translation invariance) is useful bridge work, but the core integral value is Mathlib's — so the badge should be `mathlib` (Tier B), not `original`.

## Fix

- `badge`: `original` → `mathlib`
- `status` unchanged (`verified` — 0 sorries, 0 axioms, no `native_decide`)
- `assumptions` and `mathlibDependencies` already honest (left as-is)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)