### PR TITLE
audit(amgm-inequality-oq-03-oq-02-oq-01-oq-02): badge original→mathlib (Tier B equality-case wrapper)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -17,11 +17,11 @@
       "amgm",
       "equality-case"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 243,
-    "assumptions": "",
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions. No `native_decide` is used; `#print axioms` reports only the standard foundational axioms (propext, Classical.choice, Quot.sound). The equality-case engine of this file is Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'` (the equality case of weighted AM-GM): it is reached through the gallery parent `JensenInequalityOQ01.weighted_amgm_eq_iff`, which is a one-line `rw` wrapper around that Mathlib theorem. This file's contribution is the transport of that equality case — substantial but not an independent AM-GM equality proof: it carries the characterization to every power-mean order `M_r` (`r ≠ 0`) via the substitution `uᵢ = zᵢ^r` and injectivity of `x ↦ x^r` (`Real.rpow_left_inj`), establishes the sign-independence of the equality locus, and derives the strict crossing-zero forms and the sharp HM < GM < AM corner. Because the core equality muscle bottoms out at a Mathlib theorem, the badge is `mathlib` (Tier B) rather than `original`.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "power_mean_eq_geom_mean_iff: M_r = GM ↔ data constant, for EVERY r ≠ 0 — the equality locus is identical for positive and negative orders even though the inequality reverses across zero (sign-independent unification)",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `amgm-inequality-oq-03-oq-02-oq-01-oq-02` — "Equality Case of the Crossing-Zero Power-Mean Chain"
**Problem**: Badge `original` overclaims independent work; the equality-case core is a Mathlib theorem (Tier B).

## Evidence

The file's headline equality characterizations (`power_mean_eq_geom_mean_iff`, `geomMean_rpow_eq_weightedSum_rpow_iff`, the crossing-zero sharp converse and strict forms, `hm_eq_gm_iff`, `hm_lt_gm_lt_am_of_ne`) are all built from `weighted_amgm_eq_iff` in the gallery parent `JensenInequalityOQ01`.

That lemma is a **one-line `rw` wrapper** around Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'`:

```lean
theorem weighted_amgm_eq_iff ... := by
  rw [Real.geom_mean_eq_arith_mean_weighted_iff' s w z hw hw' hz]
```

`JensenInequalityOQ01`'s own docstring states: "This restates Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'`." The audited file's docstring likewise names `weighted_amgm_eq_iff` as "the single fact behind all of this". The `meta.json` already lists `Real.geom_mean_eq_arith_mean_weighted_iff'` in `mathlibDependencies`.

The file does genuine, substantial transport work (carrying the equality case to all power-mean orders `M_r` via `x ↦ x^r` + `Real.rpow_left_inj`, the sign-independence observation, strict crossing-zero forms). But the **core equality muscle bottoms out at a Mathlib theorem**, so per the gallery Tier B rule this is a `mathlib` badge, not `original` — consistent with the prior amgm equality-case badge fixes (#27740, #27743).

## Fix

- `badge`: `original` → `mathlib`
- `assumptions`: filled the previously-empty field with the Mathlib-reliance disclosure
- `status`: stays `verified` (0 sorries, 0 axioms, machine-checked); `originalContributions` unchanged (they correctly describe the transport work)

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)