### PR TITLE
research(chevalley-warning-theorem-oq-01-oq-01-oq-01): reify the solution count into an explicit Finset [0-axiom verified]

### DIFF
--- a/proofs/Proofs/ChevalleyWarningTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/ChevalleyWarningTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,157 @@
+import Proofs.ChevalleyWarningTheoremOQ01OQ01
+
+/-
+# Chevalley–Warning: reifying the solution count into an explicit finite set
+
+## What This Proves
+
+The parent files record the Chevalley–Warning divisibility `p ∣ #solutions`
+(`ChevalleyWarningTheoremOQ01`) and its first structural consequences — the `0`-or-`≥ p`
+characteristic lower bound, the no-unique-solution law, and the *second-solution*
+theorem producing **one** further common zero from any known one
+(`ChevalleyWarningTheoremOQ01OQ01`).
+
+Those results live at the level of cardinalities and existence. The pigeonhole arguments
+that *use* Chevalley–Warning downstream — most notably the Erdős–Ginzburg–Ziv proof —
+need more than "there is a second zero": they iterate over an **explicit finite set** of
+common zeros. This file supplies that reification, which neither Mathlib nor the parents
+package:
+
+* **The explicit solution set** (`exists_finset_common_zeros`,
+  `exists_finset_common_zeros_single`). If a low-degree system has even one common zero,
+  there is a concrete `Finset (σ → K)` of **at least `p`** common zeros — the abstract
+  bound `p ≤ Fintype.card {x // …}` turned into a finite set you can range over.
+
+* **The `p − 1` other zeros** (`exists_finset_other_common_zeros`,
+  `exists_finset_other_common_zeros_single`). From any known common zero `x₀`, there is an
+  explicit finite set of **at least `p − 1`** common zeros, *none equal to `x₀`*. This is
+  the quantitative strengthening of the parent's second-solution theorem: not just one
+  other zero, but `p − 1` of them, packaged for pigeonhole.
+
+* **The nonzero-zero count** (`exists_finset_nonzero_common_zeros`). The origin-vanishing
+  case `x₀ = 0`: an origin-vanishing low-degree system has at least `p − 1` **nonzero**
+  common zeros, as an explicit finite set.
+
+All proofs reify the parent's `char_le_card_of_exists` through
+`Finset.map`/`Finset.erase` cardinality lemmas; everything is `0`-axiom (no `sorry`, no
+`axiom`, no `native_decide`).
+
+## Context
+
+The Erdős–Ginzburg–Ziv theorem is proved by applying Chevalley–Warning to two degree-`p−1`
+polynomials in `2p − 1` variables: the common zeros are `{0,1}`-vectors selecting a
+`p`-element zero-sum subset, and one argues there is a *nonzero* such selection by counting
+solutions. Having the solution set as an honest `Finset` — rather than only its cardinality
+— is exactly what lets one feed it into `Finset`-level pigeonhole and extract the
+combinatorial object. Isolating the reification makes that step reusable.
+-/
+
+namespace ChevalleyWarningTheoremOQ01OQ01OQ01
+
+open MvPolynomial
+
+/-! ## The explicit solution set: a `Finset` of at least `p` common zeros -/
+
+/-- **Explicit solution set (Finset form).** If a low-degree system `f` (total degrees
+summing to less than the number of variables) has even one common zero, then there is a
+concrete `Finset (σ → K)` containing **at least `p`** common zeros.
+
+This reifies the parent's existence lower bound `char_le_card_of_exists`
+(`p ≤ Fintype.card {x // …}`) into a finite set one can iterate over: take the image of the
+solution subtype's universal finset under the injection `↑ : {x // …} → (σ → K)`. -/
+theorem exists_finset_common_zeros
+    {K σ ι : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {s : Finset ι} {f : ι → MvPolynomial σ K}
+    (hdeg : (∑ i ∈ s, (f i).totalDegree) < Fintype.card σ)
+    (hx : ∃ x : σ → K, ∀ i ∈ s, eval x (f i) = 0) :
+    ∃ T : Finset (σ → K), p ≤ T.card ∧ ∀ x ∈ T, ∀ i ∈ s, eval x (f i) = 0 := by
+  have hcard : p ≤ Fintype.card {x : σ → K // ∀ i ∈ s, eval x (f i) = 0} :=
+    ChevalleyWarningTheoremOQ01OQ01.char_le_card_of_exists p hdeg hx
+  refine ⟨(Finset.univ : Finset {x : σ → K // ∀ i ∈ s, eval x (f i) = 0}).map
+      (Function.Embedding.subtype _), ?_, ?_⟩
+  · rw [Finset.card_map, Finset.card_univ]; exact hcard
+  · intro x hx'
+    rw [Finset.mem_map] at hx'
+    obtain ⟨y, -, rfl⟩ := hx'
+    exact y.property
+
+/-- **Explicit solution set (single polynomial).** A single polynomial of total degree less
+than the number of variables, with one known zero, has an explicit `Finset` of at least `p`
+zeros. -/
+theorem exists_finset_common_zeros_single
+    {K σ : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {f : MvPolynomial σ K} (hdeg : f.totalDegree < Fintype.card σ)
+    (hx : ∃ x : σ → K, eval x f = 0) :
+    ∃ T : Finset (σ → K), p ≤ T.card ∧ ∀ x ∈ T, eval x f = 0 := by
+  have hdvd : p ∣ Fintype.card {x : σ → K // eval x f = 0} :=
+    char_dvd_card_solutions p hdeg
+  obtain ⟨x₀, hx₀⟩ := hx
+  have hpos : 0 < Fintype.card {x : σ → K // eval x f = 0} :=
+    Fintype.card_pos_iff.mpr ⟨⟨x₀, hx₀⟩⟩
+  have hcard : p ≤ Fintype.card {x : σ → K // eval x f = 0} := Nat.le_of_dvd hpos hdvd
+  refine ⟨(Finset.univ : Finset {x : σ → K // eval x f = 0}).map
+      (Function.Embedding.subtype _), ?_, ?_⟩
+  · rw [Finset.card_map, Finset.card_univ]; exact hcard
+  · intro x hx'
+    rw [Finset.mem_map] at hx'
+    obtain ⟨y, -, rfl⟩ := hx'
+    exact y.property
+
+/-! ## The `p − 1` other zeros: an explicit `Finset` avoiding a known solution -/
+
+/-- **The `p − 1` other zeros (Finset form).** From **any** known common zero `x₀` of a
+low-degree system, there is an explicit `Finset` of at least `p − 1` common zeros, **none of
+which equals `x₀`**.
+
+This is the quantitative strengthening of the parent's `exists_second_common_zero`, which
+produces a single distinct zero: here we get `p − 1` of them, as a finite set ready for
+pigeonhole. Obtained by deleting `x₀` from the explicit `p`-element solution set. -/
+theorem exists_finset_other_common_zeros
+    {K σ ι : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {s : Finset ι} {f : ι → MvPolynomial σ K}
+    (hdeg : (∑ i ∈ s, (f i).totalDegree) < Fintype.card σ)
+    {x₀ : σ → K} (hx₀ : ∀ i ∈ s, eval x₀ (f i) = 0) :
+    ∃ T : Finset (σ → K), x₀ ∉ T ∧ p - 1 ≤ T.card ∧ ∀ x ∈ T, ∀ i ∈ s, eval x (f i) = 0 := by
+  obtain ⟨T, hTcard, hTmem⟩ := exists_finset_common_zeros p hdeg ⟨x₀, hx₀⟩
+  refine ⟨T.erase x₀, Finset.notMem_erase _ _, ?_, ?_⟩
+  · by_cases hmem : x₀ ∈ T
+    · rw [Finset.card_erase_of_mem hmem]; omega
+    · rw [Finset.erase_eq_of_notMem hmem]; omega
+  · intro x hx'
+    exact hTmem x (Finset.mem_of_mem_erase hx')
+
+/-- **The `p − 1` other zeros (single polynomial).** From any known zero `x₀` of a single
+low-degree polynomial, an explicit `Finset` of at least `p − 1` zeros, none equal to `x₀`. -/
+theorem exists_finset_other_common_zeros_single
+    {K σ : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {f : MvPolynomial σ K} (hdeg : f.totalDegree < Fintype.card σ)
+    {x₀ : σ → K} (hx₀ : eval x₀ f = 0) :
+    ∃ T : Finset (σ → K), x₀ ∉ T ∧ p - 1 ≤ T.card ∧ ∀ x ∈ T, eval x f = 0 := by
+  obtain ⟨T, hTcard, hTmem⟩ := exists_finset_common_zeros_single p hdeg ⟨x₀, hx₀⟩
+  refine ⟨T.erase x₀, Finset.notMem_erase _ _, ?_, ?_⟩
+  · by_cases hmem : x₀ ∈ T
+    · rw [Finset.card_erase_of_mem hmem]; omega
+    · rw [Finset.erase_eq_of_notMem hmem]; omega
+  · intro x hx'
+    exact hTmem x (Finset.mem_of_mem_erase hx')
+
+/-! ## The nonzero-zero count: the origin-vanishing case -/
+
+/-- **Nonzero common zeros (Finset form).** If every `f i` vanishes at the origin, then the
+system has an explicit `Finset` of at least `p − 1` **nonzero** common zeros. This is the
+`x₀ = 0` instance of `exists_finset_other_common_zeros`: the deleted point is the origin, so
+every member of the returned set is a nonzero common zero. It is the explicit-set form of
+the parent's `nontrivial_of_origin`. -/
+theorem exists_finset_nonzero_common_zeros
+    {K σ ι : Type*} [Field K] [Fintype K] [DecidableEq K] [Fintype σ] [DecidableEq σ]
+    (p : ℕ) [CharP K p] {s : Finset ι} {f : ι → MvPolynomial σ K}
+    (hdeg : (∑ i ∈ s, (f i).totalDegree) < Fintype.card σ)
+    (h0 : ∀ i ∈ s, eval (0 : σ → K) (f i) = 0) :
+    ∃ T : Finset (σ → K),
+      (0 : σ → K) ∉ T ∧ p - 1 ≤ T.card ∧ ∀ x ∈ T, x ≠ 0 ∧ ∀ i ∈ s, eval x (f i) = 0 := by
+  obtain ⟨T, hT0, hTcard, hTmem⟩ := exists_finset_other_common_zeros p hdeg h0
+  refine ⟨T, hT0, hTcard, ?_⟩
+  intro x hx
+  exact ⟨fun hc => hT0 (hc ▸ hx), hTmem x hx⟩
+
+end ChevalleyWarningTheoremOQ01OQ01OQ01

--- a/src/data/proofs/chevalley-warning-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chevalley-warning-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "chevalley-warning-theorem-oq-01-oq-01-oq-01",
+  "title": "Chevalley–Warning: reifying the solution count into an explicit finite set",
+  "slug": "chevalley-warning-theorem-oq-01-oq-01-oq-01",
+  "description": "A follow-up to the Chevalley–Warning structural-consequences entry that turns its abstract cardinality bound into a concrete finite set. The parent proves the count of common zeros is 0 or at least p and that any known zero forces ONE other; this entry produces an explicit Finset of at least p common zeros whenever one exists, hence an explicit set of at least p − 1 zeros distinct from any given x₀, and — in the origin-vanishing case — an explicit set of at least p − 1 nonzero common zeros. This answers the parent's open question of whether the second-solution theorem extends to an effective count of p − 1 additional zeros. The reification is the form actually consumed by Finset-level pigeonhole in the Erdős–Ginzburg–Ziv argument. All results reify char_le_card_of_exists through Finset.map / Finset.erase cardinality lemmas; 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Claude Chevalley, Ewald Warning (1935); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChevalleyWarningTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "finite-fields",
+      "chevalley-warning",
+      "polynomials",
+      "combinatorial-nullstellensatz",
+      "erdos-ginzburg-ziv",
+      "classic"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "char_dvd_card_solutions",
+        "description": "Chevalley–Warning (single polynomial): if f.totalDegree < Fintype.card σ then p ∣ #{x // eval x f = 0}; witnesses the single-polynomial cardinality bound reified here",
+        "module": "Mathlib.FieldTheory.ChevalleyWarning"
+      },
+      {
+        "theorem": "Finset.map",
+        "description": "Image of a Finset under an embedding; Finset.univ over the solution subtype mapped by the injection ↑ : {x // P x} → (σ → K) is the explicit solution Finset",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Finset.card_map",
+        "description": "(s.map e).card = s.card; the explicit solution Finset has cardinality equal to Fintype.card of the solution subtype, hence ≥ p",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Function.Embedding.subtype",
+        "description": "The coercion {x // p x} ↪ α as an embedding; provides the injection used to map the subtype's universal Finset into σ → K",
+        "module": "Mathlib.Logic.Embedding.Basic"
+      },
+      {
+        "theorem": "Finset.card_erase_of_mem",
+        "description": "a ∈ s → (s.erase a).card = s.card - 1; deleting the known zero x₀ from the p-element solution set leaves ≥ p − 1",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.erase_eq_of_notMem",
+        "description": "a ∉ s → s.erase a = s; the complementary case for the p − 1 lower bound on the erased set's cardinality",
+        "module": "Mathlib.Data.Finset.Erase"
+      },
+      {
+        "theorem": "Finset.mem_of_mem_erase",
+        "description": "x ∈ s.erase a → x ∈ s; every member of the erased solution set is still a common zero",
+        "module": "Mathlib.Data.Finset.Erase"
+      }
+    ],
+    "originalContributions": [
+      "exists_finset_common_zeros / exists_finset_common_zeros_single: the explicit solution set — if a low-degree system (resp. single polynomial) has even one common zero, there is a concrete Finset (σ → K) of at least p common zeros. Reifies the parent's abstract bound p ≤ Fintype.card {x // …} into a finite set one can range over, by mapping the solution subtype's universal Finset under the injection ↑.",
+      "exists_finset_other_common_zeros / exists_finset_other_common_zeros_single: the p − 1 other zeros — from ANY known common zero x₀ there is an explicit Finset of at least p − 1 common zeros, none equal to x₀. This is the quantitative strengthening of the parent's exists_second_common_zero (which gives a single distinct zero), obtained by deleting x₀ from the explicit p-element solution set.",
+      "exists_finset_nonzero_common_zeros: the nonzero-zero count — an origin-vanishing low-degree system has an explicit Finset of at least p − 1 nonzero common zeros (the x₀ = 0 instance). This is the explicit-set form of the parent's nontrivial_of_origin and answers the parent entry's open question of whether the second-solution theorem extends to an effective count of p − 1 additional zeros."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 157,
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "references": [
+    {
+      "authors": "Chevalley, Claude",
+      "title": "Démonstration d'une hypothèse de M. Artin",
+      "year": "1935",
+      "note": "Abh. Math. Sem. Univ. Hamburg 11, 73–75 — a form of degree less than its number of variables over a finite field has a nontrivial zero"
+    },
+    {
+      "authors": "Warning, Ewald",
+      "title": "Bemerkung zur vorstehenden Arbeit von Herrn Chevalley",
+      "year": "1935",
+      "note": "Abh. Math. Sem. Univ. Hamburg 11, 76–83 — the number of common zeros of a low-degree system is divisible by the characteristic"
+    },
+    {
+      "authors": "Erdős, Paul; Ginzburg, Abraham; Ziv, Abraham",
+      "title": "Theorem in the additive number theory",
+      "year": "1961",
+      "note": "Bull. Res. Council Israel 10F, 41–43 — among any 2n − 1 integers, some n sum to a multiple of n; the canonical Chevalley–Warning application whose pigeonhole step consumes an explicit solution set"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Warning's divisibility theorem (1935) gives p ∣ #solutions for a low-degree polynomial system over a finite field of characteristic p. The parent gallery entries draw the elementary structural consequences — the 0-or-≥-p dichotomy, the no-unique-solution law, and the existence of one second zero. But the celebrated application of Chevalley–Warning, the Erdős–Ginzburg–Ziv theorem (1961), does not stop at 'a second solution exists': it sets up two degree-(p−1) polynomials whose common zeros encode p-element zero-sum subsets and then argues combinatorially over the SET of solutions. Feeding that argument requires the solution count as an honest finite set, not merely a cardinal.",
+    "problemStatement": "The parent proves p ≤ Fintype.card {x // …} (an abstract cardinal bound) and exhibits ONE common zero distinct from a known x₀. Its open question asks: can the second-solution theorem be made effective — exhibiting p − 1 explicit additional zeros? \n\n**Answer:** Yes. Whenever a common zero exists there is an explicit Finset of at least p common zeros; deleting any known x₀ leaves an explicit Finset of at least p − 1 zeros distinct from x₀; and in the origin-vanishing case this is an explicit Finset of at least p − 1 nonzero common zeros.",
+    "text": "Three new results reify the Chevalley–Warning count: an explicit Finset of at least p common zeros (family and single-polynomial forms), an explicit Finset of at least p − 1 zeros avoiding any given solution x₀, and an explicit Finset of at least p − 1 nonzero zeros in the origin-vanishing case. The parent's existence bound and second-solution theorem are recovered as the cardinality and the 'one element' shadows of these finite sets.",
+    "proofStrategy": "Let S = {x // ∀ i ∈ s, eval x (f i) = 0} be the subtype of common zeros; the parent's char_le_card_of_exists gives p ≤ Fintype.card S.\n1. exists_finset_common_zeros: map (Finset.univ : Finset S) by the embedding ↑ : S ↪ (σ → K). Finset.card_map + Finset.card_univ give the cardinality is Fintype.card S ≥ p; membership unfolds via Finset.mem_map to y.property.\n2. exists_finset_other_common_zeros: erase x₀ from the explicit p-element set. Finset.notMem_erase gives x₀ ∉ the result; card ≥ p − 1 by casing x₀ ∈ T (Finset.card_erase_of_mem, omega) or x₀ ∉ T (Finset.erase_eq_of_notMem, omega); membership via Finset.mem_of_mem_erase.\n3. exists_finset_nonzero_common_zeros: instantiate (2) at x₀ = 0; each member x ≠ 0 because 0 ∉ the returned set (fun hc => hT0 (hc ▸ hx)).",
+    "keyInsights": [
+      "**A cardinality is not a set**: the parent's p ≤ Fintype.card {x // …} certifies how many solutions exist but hands you nothing to iterate over. Combinatorial applications (pigeonhole, double counting) operate on a Finset, so the reification — map the subtype's universal Finset by the coercion embedding — is the bridge from 'how many' to 'which ones'.",
+      "**One other becomes p − 1 others, for free**: the parent's second-solution theorem extracts a single zero ≠ x₀ via Fintype.exists_ne_of_one_lt_card. Once you have the explicit p-element set, deleting x₀ leaves p − 1 of them at once — the effective count the parent left open, with no extra mathematics beyond a card_erase bookkeeping step.",
+      "**The erase lower bound needs no membership hypothesis**: (s.erase a).card ≥ s.card − 1 holds whether or not a ∈ s — if a ∉ s the erase is a no-op and the bound is slack. Casing on membership and discharging each branch with omega avoids needing to know in advance whether x₀ landed in the constructed set.",
+      "**This is the EGZ-shaped output**: the origin-vanishing case returns an explicit Finset of nonzero common zeros, which is exactly the object the Erdős–Ginzburg–Ziv pigeonhole consumes after Chevalley–Warning produces the solutions to the two degree-(p−1) forms."
+    ],
+    "prerequisites": [
+      "Finite fields and their (prime) characteristic (CharP)",
+      "Multivariate polynomials and evaluation (MvPolynomial, eval, totalDegree)",
+      "Cardinality of subtypes and the Chevalley–Warning theorem (Fintype.card, char_dvd_card_solutions)",
+      "Finset operations: image under an embedding (Finset.map), deletion (Finset.erase), and their cardinality lemmas"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Statement",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "File-level docstring framing the reification: the parents give the divisibility and abstract cardinality consequences; this file turns the count into an explicit Finset for use in Finset-level pigeonhole (Erdős–Ginzburg–Ziv). Imports the structural-consequences parent (and through it Mathlib's ChevalleyWarning).",
+      "mathContext": "From the abstract bound p ≤ Fintype.card {x // …} to a concrete Finset of common zeros."
+    },
+    {
+      "id": "explicit-solution-set",
+      "title": "The Explicit Solution Set: a Finset of at least p common zeros",
+      "startLine": 52,
+      "endLine": 98,
+      "summary": "exists_finset_common_zeros and exists_finset_common_zeros_single: if a low-degree system (resp. single polynomial) has one common zero, an explicit Finset of at least p common zeros exists, built as the image of the solution subtype's universal Finset under the coercion embedding (Finset.map + Finset.card_map + Finset.card_univ).",
+      "mathContext": "Reify p ≤ Fintype.card S into a Finset (σ → K) of cardinality ≥ p whose members are all common zeros."
+    },
+    {
+      "id": "p-minus-one-others",
+      "title": "The p − 1 Other Zeros",
+      "startLine": 100,
+      "endLine": 136,
+      "summary": "exists_finset_other_common_zeros and exists_finset_other_common_zeros_single: deleting any known zero x₀ from the explicit p-element set yields an explicit Finset of at least p − 1 common zeros, none equal to x₀ — the effective strengthening of the parent's single second-solution, with the erase cardinality handled by casing on membership and omega.",
+      "mathContext": "From any known zero, p − 1 explicit further zeros at once, packaged for pigeonhole."
+    },
+    {
+      "id": "nonzero-count",
+      "title": "The Nonzero-Zero Count: the origin-vanishing case",
+      "startLine": 138,
+      "endLine": 157,
+      "summary": "exists_finset_nonzero_common_zeros: the x₀ = 0 instance, returning an explicit Finset of at least p − 1 NONZERO common zeros for an origin-vanishing system. This is the explicit-set form of the parent's nontrivial_of_origin and the EGZ-shaped output.",
+      "mathContext": "An origin-vanishing low-degree system has p − 1 explicit nonzero common zeros as a finite set."
+    }
+  ],
+  "conclusion": {
+    "summary": "Three results reify the Chevalley–Warning solution count with 0 axioms: an explicit Finset of at least p common zeros whenever one exists (exists_finset_common_zeros, exists_finset_common_zeros_single), an explicit Finset of at least p − 1 zeros distinct from any known x₀ (exists_finset_other_common_zeros, exists_finset_other_common_zeros_single), and an explicit Finset of at least p − 1 nonzero common zeros in the origin-vanishing case (exists_finset_nonzero_common_zeros).",
+    "implications": "Turns the parent's abstract cardinality bound and single second-solution into the explicit finite set that Finset-level combinatorics consumes. The origin-vanishing form is precisely the object fed into the Erdős–Ginzburg–Ziv pigeonhole after Chevalley–Warning supplies the common zeros of the two degree-(p−1) forms; isolating it makes the 'extract many solutions' step a one-line application. Answers the parent's open question on an effective count of p − 1 additional zeros.",
+    "openQuestions": [
+      "Can the explicit nonzero-solution set be specialized to the Erdős–Ginzburg–Ziv forms — the two degree-(p−1) polynomials in 2p − 1 variables — to extract an actual p-element zero-sum subset as a Finset, completing the combinatorial half of EGZ in Lean?",
+      "Does Warning's second theorem (count is 0 or ≥ qⁿ⁻ᵈ with q = |K|) admit an analogous reification, yielding an explicit Finset of qⁿ⁻ᵈ common zeros rather than just p?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "chevalley-warning-theorem-oq-01-oq-01",
+      "reason": "Direct parent: proves the abstract cardinality bound char_le_card_of_exists and the single second-solution theorem that this entry reifies into explicit finite sets, and whose open question on an effective p − 1 count this entry answers"
+    },
+    {
+      "id": "chevalley-warning-theorem-oq-01",
+      "reason": "Grandparent: the Chevalley–Warning divisibility p ∣ #solutions underlying the whole chain"
+    },
+    {
+      "id": "erdos-ginzburg-ziv-oq-01",
+      "reason": "The origin-vanishing explicit nonzero-solution set is the object consumed by the EGZ pigeonhole after Chevalley–Warning produces the common zeros of the two degree-(p−1) forms"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Depth-1 follow-up to **chevalley-warning-theorem-oq-01-oq-01** (the structural-consequences entry). The parent proves the count of common zeros of a low-degree polynomial system over a finite field is `0` or `≥ p`, and that any known zero `x₀` forces **one** other. This entry turns those *abstract cardinality* statements into the **explicit finite set** that the downstream combinatorial applications (Erdős–Ginzburg–Ziv pigeonhole) actually consume.

It directly answers the parent entry's stated open question: *"can one exhibit `p − 1` explicit additional zeros?"*

## What's proved (5 theorems, 0 sorries, 0 axioms)

- `exists_finset_common_zeros` / `_single` — one common zero ⟹ an explicit `Finset (σ → K)` of **at least `p`** common zeros (image of the solution subtype's universal finset under the coercion embedding).
- `exists_finset_other_common_zeros` / `_single` — from **any** known zero `x₀`, an explicit `Finset` of **at least `p − 1`** common zeros, none equal to `x₀`. The effective strengthening of the parent's single second-solution, by deleting `x₀` from the `p`-element set.
- `exists_finset_nonzero_common_zeros` — origin-vanishing case (`x₀ = 0`): an explicit `Finset` of **at least `p − 1` nonzero** common zeros. This is the EGZ-shaped output and the explicit-set form of the parent's `nontrivial_of_origin`.

## Verification

- Builds clean against **Mathlib 4.26.0** via `./proofs/scripts/docker-build.sh` (0 errors, 0 warnings).
- `#print axioms` on all three headline theorems: `[propext, Classical.choice, Quot.sound]` only — **no `sorryAx`, no `Lean.ofReduceBool`** (no `native_decide`). Genuinely 0-axiom verified.

## Honest scope

A *reification* of the parent's bounds, not new analytic content: the math beyond the parent is a `Finset.map` to build the explicit set and a `Finset.erase` cardinality bookkeeping step. Its value is the packaging — handing combinatorial arguments an honest `Finset` instead of a cardinal. Does **not** specialize to the EGZ forms or prove Warning's second theorem (left as open questions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)