### PR TITLE
Enrich odd-order boundary of Cauchy's theorem (squaring is a bijection)

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "explicit-root",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 74 },
+    "type": "theorem",
+    "title": "Explicit Square Root in Odd Order",
+    "content": "`exists_sq_eq_of_odd_card`: writing the odd order as |G| = 2m+1, the element x^(m+1) is an explicit square root of x. The whole proof is a single exponent identity: (x^(m+1))^2 = x^((m+1)·2) = x^(|G|+1) = x^|G| · x = x, where the penultimate step kills x^|G| via Lagrange's `pow_card_eq_one`. No prime factorization or Sylow machinery is needed — the result is genuinely elementary, depending only on the order being coprime to 2.",
+    "mathContext": "If $|G|=2m+1$ then $\\bigl(x^{m+1}\\bigr)^2 = x^{2m+2} = x^{|G|+1} = x^{|G|}\\cdot x = x$, since $x^{|G|}=1$. So every element is a square with explicit root $x^{(|G|+1)/2}$.",
+    "significance": "critical",
+    "relatedConcepts": ["Lagrange's theorem", "order of an element", "coprime exponents", "square root in a group"],
+    "prerequisites": ["finite group theory", "Lagrange's theorem"]
+  },
+  {
+    "id": "squaring-bijective",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01",
+    "range": { "startLine": 76, "endLine": 88 },
+    "type": "theorem",
+    "title": "Squaring Is a Bijection",
+    "content": "`sq_surjective_of_odd_card` repackages the explicit root as surjectivity of x ↦ x². `sq_bijective_of_odd_card` then upgrades this to bijectivity via the pigeonhole principle for self-maps of finite types (`Finite.injective_iff_surjective`): a surjective self-map of a finite set is automatically injective. Hence in an odd-order group square roots are not merely existent but unique, and squaring is an automorphism of the underlying set.",
+    "mathContext": "On a finite set, $f$ surjective $\\iff$ $f$ injective $\\iff$ $f$ bijective. So $x\\mapsto x^2$ being onto forces it to be a bijection; every element has a *unique* square root in an odd-order group.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "bijection on finite sets", "unique square roots", "power map"],
+    "prerequisites": ["finite sets", "injective and surjective functions"]
+  },
+  {
+    "id": "no-involution",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 103 },
+    "type": "theorem",
+    "title": "No Involutions in Odd Order",
+    "content": "`no_involution_of_odd_card`: if |G| is odd and x² = 1 then x = 1. From x² = 1, the order of x divides 2 (`orderOf_dvd_of_pow_eq_one`), so it is 1 or 2. If it were 2, Lagrange (`orderOf_dvd_card`) would give 2 ∣ |G|, contradicting oddness; hence the order is 1, i.e. x = 1. This is the exact contrapositive of the parent's even-order corollary that an even-order group must contain an involution.",
+    "mathContext": "$x^2=1 \\Rightarrow \\operatorname{ord}(x)\\mid 2$. If $\\operatorname{ord}(x)=2$ then $2\\mid|G|$ by Lagrange, contradicting $|G|$ odd. So $\\operatorname{ord}(x)=1$ and $x=1$.",
+    "significance": "key",
+    "relatedConcepts": ["involution", "order of an element", "Lagrange's theorem", "contrapositive"],
+    "prerequisites": ["order of an element", "divisibility"]
+  },
+  {
+    "id": "sharp-boundary",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 128 },
+    "type": "theorem",
+    "title": "Sharp Boundary: Involutions Iff Even Order",
+    "content": "`involution_iff_even_card`: a finite group has a nontrivial self-inverse element iff its order is even. The forward direction is the new odd-order result (contrapositive: no involution when odd). The backward direction is Cauchy's theorem at the prime 2 — `exists_prime_orderOf_dvd_card` produces an element of order exactly 2 when 2 ∣ |G|. Together they pin down precisely when involutions exist, upgrading the parent's one-directional corollary to a clean equivalence and exhibiting parity as the sole obstruction.",
+    "mathContext": "$\\bigl(\\exists x\\neq 1,\\ x^2=1\\bigr) \\iff 2\\mid|G|$. Forward by the odd-order theorem; backward by Cauchy's theorem for $p=2$.",
+    "significance": "critical",
+    "relatedConcepts": ["Cauchy's theorem", "involution", "parity", "if and only if"],
+    "prerequisites": ["Cauchy's theorem", "finite group theory"]
+  },
+  {
+    "id": "additive-form",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01",
+    "range": { "startLine": 130, "endLine": 138 },
+    "type": "theorem",
+    "title": "Additive Form: Doubling Is Surjective",
+    "content": "`exists_two_nsmul_eq_of_odd_card`: the additive translation of the squaring result. In a finite additive group of odd order every element is a double, with explicit witness x = 2 • ((m+1) • x) where |G| = 2m+1. The proof mirrors the multiplicative one, replacing `pow_card_eq_one` with its additive twin `card_nsmul_eq_zero`. This is the statement that 2 is invertible in ℤ/|G|ℤ when |G| is odd, packaged group-theoretically.",
+    "mathContext": "In an additive group of odd order $|G|=2m+1$: $2\\cdot\\bigl((m+1)x\\bigr) = (2m+2)x = (|G|+1)x = |G|\\cdot x + x = x$, since $|G|\\cdot x=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["additive group", "doubling map", "invertibility of 2", "scalar multiplication"],
+    "prerequisites": ["additive groups", "module over ℤ"]
+  },
+  {
+    "id": "concrete-instances",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01",
+    "range": { "startLine": 140, "endLine": 151 },
+    "type": "tactic",
+    "title": "Concrete Witnesses in ZMod 3 and ZMod 5",
+    "content": "`zmod3_double_surjective`, `zmod5_double_surjective`, and `zmod3_no_involution` realize the abstract phenomena in the smallest odd-order groups. Each is discharged by kernel `decide` — a finite exhaustive check the Lean kernel reduces directly — deliberately avoiding `native_decide`, whose compiled evaluation would introduce the `Lean.ofReduceBool` axiom. Using kernel `decide` keeps these witnesses genuinely 0-axiom while still being fully automatic.",
+    "mathContext": "In $\\mathbb{Z}/3$ and $\\mathbb{Z}/5$ doubling is a bijection and the only self-inverse element is $0$ — checked exhaustively. Kernel `decide` (not `native_decide`) preserves the 0-axiom status.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod", "decidability", "kernel decide vs native_decide", "axiom hygiene"],
+    "prerequisites": ["cyclic groups", "decidable propositions"]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01/meta.json
@@ -19,6 +19,64 @@
     "sorries": 0
   },
   "description": "The odd-order companion to the parent's even-order corollary of Cauchy's theorem. The parent proves that a finite group of even order contains an involution (the p=2 case of Cauchy); this entry proves the complementary structure on the other side of that dividing line. In a finite group of odd order every element is a square — with the explicit root x = (x^(m+1))^2 where |G| = 2m+1 — so the squaring map is surjective, hence bijective (unique square roots). Dually, an odd-order group has no involutions: x^2 = 1 forces x = 1, the exact contrapositive of the parent's corollary. Combining the two directions yields the sharp boundary involution_iff_even_card: a finite group has a nontrivial self-inverse element iff its order is even. An additive form shows doubling is surjective in odd-order additive groups, with 0-axiom ZMod 3 and ZMod 5 witnesses by kernel decide.",
+  "overview": {
+    "historicalContext": "Augustin-Louis Cauchy proved in 1845 that if a prime p divides the order of a finite group G, then G has an element of order p. The even prime p = 2 is special: it is exactly the source of involutions (self-inverse elements x ≠ 1 with x² = 1). The odd-order world is precisely where that source is switched off, and the resulting structure — squaring is a bijection, square roots are unique, no element has order 2 — is a recurring tool in finite group theory. It is the elementary opening observation of the Feit–Thompson theorem (1963), whose 255-page proof that every finite group of odd order is solvable opened the classification of finite simple groups and where 'odd order' is the standing hypothesis. Isaacs' Finite Group Theory (2008) treats odd order as the canonical setting where these parity-free phenomena hold.",
+    "problemStatement": "Determine the structure forced by odd order, complementary to the parent's even-order involution corollary. Concretely: show that in a finite group G with |G| odd, (i) every element is a square with an explicit root, so x ↦ x² is bijective; (ii) the only solution of x² = 1 is x = 1; and (iii) combined with Cauchy's p = 2 case, a finite group has a nontrivial involution if and only if its order is even.",
+    "proofStrategy": "Everything flows from Lagrange's theorem in the form x^|G| = 1 (`pow_card_eq_one`). Writing |G| = 2m+1, the single exponent identity (x^(m+1))² = x^(|G|+1) = x gives an explicit square root, hence surjectivity of squaring; finiteness promotes surjectivity to bijectivity via `Finite.injective_iff_surjective`. For involutions, x² = 1 forces ord(x) ∣ 2, and ord(x) = 2 would contradict Lagrange against odd |G|. The sharp iff pairs this (forward) with Cauchy's theorem at p = 2 (backward). The additive analogue swaps `pow_card_eq_one` for `card_nsmul_eq_zero`, and ZMod 3 / ZMod 5 witnesses use kernel `decide` to stay 0-axiom.",
+    "keyInsights": [
+      "Odd order is exactly the regime where 2 is invertible modulo |G|, so 'taking square roots' (multiplicatively) or 'halving' (additively) becomes a well-defined bijection — parity is the only obstruction.",
+      "The square root is not merely shown to exist but written down explicitly as x^((|G|+1)/2), turning an existence statement into a constructive one and avoiding any appeal to Sylow theory or prime factorization.",
+      "Finiteness does the heavy lifting twice: it lets Lagrange kill x^|G|, and it lets surjectivity of a self-map upgrade for free to bijectivity (pigeonhole), giving uniqueness of square roots.",
+      "The absence of involutions is the precise contrapositive of the parent's even-order corollary; bundling both directions yields involution_iff_even_card, exhibiting even order as the exact necessary and sufficient condition for an involution to exist.",
+      "Axiom hygiene is deliberate: the concrete ZMod witnesses use kernel `decide` rather than `native_decide`, so the file avoids the `Lean.ofReduceBool` axiom and remains genuinely 0-axiom."
+    ]
+  },
+  "sections": [
+    {
+      "id": "squaring",
+      "title": "Squaring in Odd-Order Groups",
+      "startLine": 64,
+      "endLine": 86,
+      "summary": "The explicit square root x = (x^(m+1))² in a group of odd order |G| = 2m+1 (exists_sq_eq_of_odd_card), giving surjectivity of squaring, then bijectivity on the finite group (sq_surjective/bijective_of_odd_card).",
+      "mathContext": "Odd order ⟹ x ↦ x² is a bijection with explicit inverse x ↦ x^((|G|+1)/2)."
+    },
+    {
+      "id": "involutions",
+      "title": "Absence of Involutions and the Sharp Boundary",
+      "startLine": 88,
+      "endLine": 127,
+      "summary": "no_involution_of_odd_card: x² = 1 forces x = 1 in odd order. Combined with Cauchy at p = 2, involution_iff_even_card characterizes exactly when a nontrivial self-inverse element exists: precisely when |G| is even.",
+      "mathContext": "(∃ x ≠ 1, x² = 1) ⟺ 2 ∣ |G| — even order is necessary and sufficient for an involution."
+    },
+    {
+      "id": "additive",
+      "title": "Additive Form and Concrete Instances",
+      "startLine": 128,
+      "endLine": 151,
+      "summary": "exists_two_nsmul_eq_of_odd_card: doubling is surjective in odd-order additive groups. ZMod 3 and ZMod 5 witnesses (zmod3/zmod5_double_surjective, zmod3_no_involution) by kernel decide keep the file 0-axiom.",
+      "mathContext": "Odd order ⟹ doubling y ↦ 2•y is surjective; realized concretely in ℤ/3 and ℤ/5."
+    }
+  ],
+  "conclusion": {
+    "summary": "On the odd side of the parity divide that governs Cauchy's theorem, the structure is completely pinned down: every element of a finite odd-order group is a unique square (squaring is a bijection with explicit root x^((|G|+1)/2)), no nontrivial element is self-inverse, and bundling this with Cauchy's p = 2 case gives the sharp equivalence that involutions exist iff the order is even. An additive form and 0-axiom ZMod 3 / ZMod 5 witnesses round out the picture.",
+    "implications": [
+      "Upgrades the parent's one-directional even-order involution corollary to a sharp two-sided characterization (involution_iff_even_card), isolating parity as the exact obstruction to the existence of an involution.",
+      "Provides the constructive square-root and unique-square-root facts that underlie many parity-free arguments in finite group theory, including the elementary opening observations of the Feit–Thompson odd-order programme.",
+      "Demonstrates careful axiom hygiene — kernel decide over native_decide — as a template for keeping concrete finite witnesses genuinely 0-axiom."
+    ],
+    "openQuestions": [
+      "Can the bijectivity of the n-th power map be characterized in general, i.e. x ↦ xⁿ is a bijection on a finite group G iff gcd(n, |G|) = 1 (the regular-element / coprime-exponent theorem)?",
+      "How far do these elementary odd-order facts extend toward the structural core of the Feit–Thompson theorem, and which of its preliminary reductions are formalizable on this foundation?",
+      "Is there a clean formalized statement that odd-order groups admit a 'unique square root' functor making (·)^((|G|+1)/2) an explicit group endomorphism inverse to squaring?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Provides the odd-order complement to the parent's even-order involution corollary, upgrading it to the sharp involution_iff_even_card equivalence; this entry uses the p = 2 case of Cauchy to supply the involution in the backward direction of the boundary equivalence."
+    }
+  ],
   "meta": {
     "author": "Lean formalization original (structural follow-up to Cauchy's theorem)",
     "status": "verified",
@@ -68,56 +126,6 @@
         "theorem": "card_nsmul_eq_zero",
         "description": "Fintype.card G • x = 0 in a finite additive group; the additive analogue of pow_card_eq_one used for the doubling-surjective form.",
         "module": "Mathlib.GroupTheory.OrderOfElement"
-      }
-    ],
-    "annotations": [
-      {
-        "id": "explicit-root",
-        "title": "Explicit Square Root in Odd Order",
-        "startLine": 66,
-        "endLine": 74,
-        "summary": "exists_sq_eq_of_odd_card: writing |G| = 2m+1, the element x^(m+1) squares to x via (x^(m+1))^2 = x^((m+1)*2) = x^(|G|+1) = x^|G| * x = x, using pow_card_eq_one.",
-        "mathContext": "Odd order ⟹ every element is a square, with an explicit root."
-      },
-      {
-        "id": "squaring-bijective",
-        "title": "Squaring Is a Bijection",
-        "startLine": 76,
-        "endLine": 88,
-        "summary": "sq_surjective_of_odd_card and sq_bijective_of_odd_card: the explicit root makes x ↦ x^2 surjective, and on a finite group surjective ⟹ bijective, so every element has a unique square root.",
-        "mathContext": "Odd order ⟹ the squaring map is bijective."
-      },
-      {
-        "id": "no-involution",
-        "title": "No Involutions in Odd Order",
-        "startLine": 90,
-        "endLine": 103,
-        "summary": "no_involution_of_odd_card: if x^2 = 1 then orderOf x ∣ 2; being 2 would force 2 ∣ |G| against oddness, so orderOf x = 1 and x = 1. The exact contrapositive of the parent's even-order involution corollary.",
-        "mathContext": "Odd order ⟹ x^2 = 1 forces x = 1."
-      },
-      {
-        "id": "sharp-boundary",
-        "title": "Sharp Boundary: Involutions Iff Even Order",
-        "startLine": 105,
-        "endLine": 128,
-        "summary": "involution_iff_even_card: a finite group has a nontrivial element with x^2 = 1 iff |G| is even. Forward is the new odd-order result; backward is Cauchy at p = 2. Upgrades the parent's one-directional corollary to an equivalence.",
-        "mathContext": "Existence of an involution ⟺ even order."
-      },
-      {
-        "id": "additive-form",
-        "title": "Additive Form: Doubling Is Surjective",
-        "startLine": 130,
-        "endLine": 140,
-        "summary": "exists_two_nsmul_eq_of_odd_card: in a finite additive group of odd order every element is a double, x = 2 • ((m+1) • x), the additive translation of the squaring-surjective result.",
-        "mathContext": "Odd order ⟹ doubling is surjective."
-      },
-      {
-        "id": "concrete-instances",
-        "title": "Concrete Witnesses in ZMod 3 and ZMod 5",
-        "startLine": 142,
-        "endLine": 149,
-        "summary": "zmod3_double_surjective, zmod5_double_surjective and zmod3_no_involution exhibit the odd-order phenomena concretely: doubling is onto and the only self-inverse element is 0. All by kernel decide, no native_decide, so 0 axioms.",
-        "mathContext": "Odd-order phenomena realised in ZMod 3 and ZMod 5, 0 axioms."
       }
     ],
     "references": [


### PR DESCRIPTION
Enrichment pass for `cauchy-group-theorem-oq-01-oq-01`.

## Gaps addressed
- **Missing `annotations.json`** — annotations lived in legacy `meta.annotations` form (no schema fields). Migrated to a proper `annotations.json` with 6 annotations carrying `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, and `prerequisites`; removed the redundant legacy block from `meta.json`.
- **No structured `overview`** — added `ProofOverview` with `historicalContext` (Cauchy 1845, Feit–Thompson 1963, Isaacs), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **No `sections`** — added 3 sections covering squaring, involutions/sharp boundary, and the additive form + concrete instances.
- **No `conclusion`** — added `ProofConclusion` with `summary`, 3 `implications`, and 3 `openQuestions` (coprime-exponent power-map bijectivity, Feit–Thompson reductions, square-root endomorphism).
- **Dangling cross-reference** — the only cauchy-group entries are this one and its parent `-oq-01`; pointed the single `crossReference` at the existing parent (dropped the nonexistent `cauchy-group-theorem` base slug).

## Verification
- JSON validated; `pnpm build` passes.
- Axiom/badge metadata unchanged and accurate: 0 axioms (kernel `decide`, not `native_decide`), 0 sorries, verified/original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)