### PR TITLE
research(algebraic-reals-meager-oq-02): measure vs category — Liouville witness, independence, and the meagre+null decomposition of ℝ [verified]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerOQ02.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ02.lean
@@ -1,0 +1,223 @@
+/-
+# Measure versus Category: the two independent notions of "smallness" on ℝ
+
+The parent entry `algebraic-reals-meager` shows that the algebraic reals
+`{x : ℝ | IsAlgebraic ℚ x}` are **meagre** (topologically small, of the first
+Baire category), and its measure-theoretic companion shows they are **null**
+(Lebesgue measure zero). The algebraic reals are thus small in *both* senses at
+once.
+
+This is, however, exceptional rather than typical. The two notions of smallness
+— meagre (category) and null (measure) — are genuinely *independent*: a set can
+be topologically large yet have measure zero, and topologically small yet have
+full measure. The canonical witness is the set of **Liouville numbers**, which
+is simultaneously
+
+* **comeagre** (residual): its complement is meagre — Mathlib's
+  `eventually_residual_liouville`; and
+* **null**: it has Lebesgue measure zero — Mathlib's `volume_setOf_liouville`.
+
+From this single witness we extract:
+
+1. The measure–category independence in both directions (a comeagre null set and
+   a meagre conull set), and the abstract statement that the two genericity
+   filters `residual ℝ` and `ae volume` are disjoint (`Real.disjoint_residual_ae`).
+2. An **Erdős–Sierpiński-style decomposition** `ℝ = A ∪ B` with `A` meagre and
+   `B` null — a partition of the line into a topologically negligible piece and a
+   measure-negligible piece.
+3. A refinement of the parent: since every Liouville number is transcendental,
+   the comeagre-yet-null Liouville set sits *inside* the transcendental reals, so
+   the transcendentals — already known to be comeagre — contain a comeagre subset
+   of measure zero.
+4. The capstone contrast: the algebraic reals are small in both senses (meagre
+   AND null), while the transcendentals are large in both senses (comeagre AND
+   conull) — the special "aligned" case that the Liouville phenomenon shows is
+   not forced.
+
+Everything is derived from Mathlib's Liouville machinery and `Algebraic.countable`;
+the file is self-contained over Mathlib (no project imports) and uses no axioms
+beyond Mathlib's foundational `propext` / `Classical.choice` / `Quot.sound`.
+
+Child of `algebraic-reals-meager-oq-01` (#26822), which packaged the abstract
+Baire Category Theorem; this entry instead exploits the *failure* of the two
+smallness notions to coincide.
+-/
+import Mathlib.NumberTheory.Transcendental.Liouville.Residual
+import Mathlib.NumberTheory.Transcendental.Liouville.Measure
+import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.RingTheory.Localization.Integral
+import Mathlib.Algebra.AlgebraicCard
+import Mathlib.Topology.GDelta.Basic
+import Mathlib.Topology.Perfect
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Tactic
+
+open Set Topology MeasureTheory Filter
+
+namespace AlgebraicRealsMeagerOQ02
+
+-- ============================================================================
+-- § 0. Supporting lemmas: countable ⟹ meagre on ℝ
+--
+-- These mirror the parent entry's helpers but are restated here so the file is
+-- self-contained over Mathlib. `ℝ` is `T1` and a `PerfectSpace` (it is `T1`,
+-- connected and nontrivial), so singletons are nowhere dense and any countable
+-- set is a countable union of them, hence meagre.
+-- ============================================================================
+
+/-- A nowhere-dense set is meagre: it is the union of the one-element (hence
+countable) family `{t}` of nowhere-dense sets. -/
+theorem isMeagre_of_isNowhereDense {t : Set ℝ} (ht : IsNowhereDense t) :
+    IsMeagre t := by
+  rw [isMeagre_iff_countable_union_isNowhereDense]
+  refine ⟨{t}, ?_, Set.countable_singleton t, ?_⟩
+  · intro u hu
+    rwa [Set.mem_singleton_iff.mp hu]
+  · exact (Set.sUnion_singleton t).ge
+
+/-- A singleton in `ℝ` is nowhere dense: it is closed and has empty interior
+because `ℝ` has no isolated points (`PerfectSpace`). -/
+theorem isNowhereDense_singleton (x : ℝ) : IsNowhereDense ({x} : Set ℝ) :=
+  (isClosed_singleton.isNowhereDense_iff).mpr (interior_singleton x)
+
+/-- **Countable subsets of `ℝ` are meagre.** A countable set is a countable union
+of nowhere-dense singletons. -/
+theorem countable_isMeagre {s : Set ℝ} (hs : s.Countable) : IsMeagre s := by
+  rw [← Set.biUnion_of_singleton s, Set.biUnion_eq_iUnion]
+  haveI : Countable s := hs.to_subtype
+  exact isMeagre_iUnion fun i => isMeagre_of_isNowhereDense (isNowhereDense_singleton (i : ℝ))
+
+-- ============================================================================
+-- § 1. The Liouville witness: comeagre yet null
+-- ============================================================================
+
+/-- **The Liouville numbers are residual (comeagre).** A residual property holds
+on a dense `Gδ`; here it is exactly Mathlib's `eventually_residual_liouville`,
+recast as set membership. -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-- **The non-Liouville reals are meagre.** `IsMeagre s` means `sᶜ ∈ residual`,
+and the complement of the non-Liouville reals is the (residual) Liouville set. -/
+theorem nonLiouville_isMeagre : IsMeagre {x : ℝ | ¬ Liouville x} := by
+  rw [IsMeagre, compl_setOf]
+  simp only [not_not]
+  exact liouville_residual
+
+/-- **The Liouville numbers are null** (Lebesgue measure zero): Mathlib's
+`volume_setOf_liouville`. -/
+theorem liouville_volume_zero : volume {x : ℝ | Liouville x} = 0 :=
+  volume_setOf_liouville
+
+/-- **The Liouville set is comeagre *and* null simultaneously.** This is the core
+witness that topological largeness and measure largeness can diverge: a single
+set that is residual (topologically "almost all" of `ℝ`) yet has Lebesgue
+measure zero (measure-theoretically negligible). -/
+theorem liouville_comeagre_and_null :
+    {x : ℝ | Liouville x} ∈ residual ℝ ∧ volume {x : ℝ | Liouville x} = 0 :=
+  ⟨liouville_residual, liouville_volume_zero⟩
+
+-- ============================================================================
+-- § 2. Measure–category independence
+-- ============================================================================
+
+/-- **The two genericity filters are disjoint.** `residual ℝ` (topological
+genericity) and `ae volume` (measure-theoretic genericity) have trivial
+intersection: no nonempty filter refines both, so a single set cannot be
+"generic" in both senses with a "generic" complement. This is Mathlib's
+`Real.disjoint_residual_ae`; we surface it as the abstract statement underlying
+the concrete witnesses below. -/
+theorem residual_ae_disjoint : Disjoint (residual ℝ) (ae (volume : Measure ℝ)) :=
+  Real.disjoint_residual_ae
+
+/-- **A comeagre set can have measure zero.** Topological genericity does not
+imply full measure: the Liouville set is residual yet null. -/
+theorem exists_residual_volume_zero :
+    ∃ s : Set ℝ, s ∈ residual ℝ ∧ volume s = 0 :=
+  ⟨{x : ℝ | Liouville x}, liouville_residual, liouville_volume_zero⟩
+
+/-- **A meagre set can have full measure.** Measure genericity does not imply
+topological genericity: the non-Liouville reals are meagre, yet their complement
+(the Liouville set) is null, so they have full measure. -/
+theorem exists_isMeagre_compl_volume_zero :
+    ∃ s : Set ℝ, IsMeagre s ∧ volume sᶜ = 0 := by
+  refine ⟨{x : ℝ | ¬ Liouville x}, nonLiouville_isMeagre, ?_⟩
+  rw [compl_setOf]
+  simp only [not_not]
+  exact liouville_volume_zero
+
+/-- **Erdős–Sierpiński-style decomposition.** The real line splits as a disjoint
+union `ℝ = A ∪ B` where `A` is meagre (topologically negligible) and `B` is null
+(measure-theoretically negligible). One cannot do this with a single notion of
+smallness — a Baire space is not meagre in itself, and `ℝ` does not have measure
+zero — so the decomposition is precisely a manifestation of measure–category
+independence. Here `A` = non-Liouville reals, `B` = Liouville reals. -/
+theorem exists_meagre_null_decomposition :
+    ∃ A B : Set ℝ, A ∪ B = Set.univ ∧ Disjoint A B ∧ IsMeagre A ∧ volume B = 0 := by
+  refine ⟨{x : ℝ | Liouville x}ᶜ, {x : ℝ | Liouville x},
+    compl_union_self _, disjoint_compl_left, ?_, liouville_volume_zero⟩
+  rw [IsMeagre, compl_compl]
+  exact liouville_residual
+
+-- ============================================================================
+-- § 3. Tie to the algebraic / transcendental dichotomy
+-- ============================================================================
+
+/-- **Every Liouville number is transcendental.** Liouville's theorem gives
+transcendence over `ℤ` (`Liouville.transcendental`); transcendence over `ℤ` and
+over `ℚ` coincide for real numbers because `ℚ` is the field of fractions of `ℤ`
+(`IsFractionRing.isAlgebraic_iff`). Hence the Liouville set is contained in the
+transcendental reals. -/
+theorem liouville_subset_transcendental :
+    {x : ℝ | Liouville x} ⊆ {x : ℝ | ¬ IsAlgebraic ℚ x} := by
+  intro x hx
+  rw [Set.mem_setOf_eq, ← IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ]
+  exact hx.transcendental
+
+/-- **Refinement of the parent.** The parent shows the transcendental reals are
+residual. This sharpens that: the transcendentals *contain* a comeagre set that
+is also null (the Liouville numbers). So even within the topologically generic
+transcendentals there is a residual subset of Lebesgue measure zero. -/
+theorem transcendental_contains_comeagre_null :
+    ∃ s : Set ℝ, s ⊆ {x : ℝ | ¬ IsAlgebraic ℚ x} ∧
+      s ∈ residual ℝ ∧ volume s = 0 :=
+  ⟨{x : ℝ | Liouville x}, liouville_subset_transcendental,
+    liouville_residual, liouville_volume_zero⟩
+
+-- ============================================================================
+-- § 4. Capstone: the algebraic reals are the "aligned" exceptional case
+-- ============================================================================
+
+/-- The algebraic reals are meagre (re-derived self-containedly from
+`Algebraic.countable` and `countable_isMeagre`). -/
+theorem algebraicReals_isMeagre : IsMeagre {x : ℝ | IsAlgebraic ℚ x} :=
+  countable_isMeagre (Algebraic.countable ℚ ℝ)
+
+/-- The algebraic reals are null (a countable set has Lebesgue measure zero). -/
+theorem algebraicReals_volume_zero : volume {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  (Algebraic.countable ℚ ℝ).measure_zero volume
+
+/-- **The algebraic reals are small in *both* senses.** Unlike the generic
+situation exhibited by the Liouville set, the algebraic reals are simultaneously
+meagre (category) and null (measure). They are the exceptional "aligned" set
+where the two smallness notions agree — a coincidence forced here by mere
+countability, not by either notion alone. -/
+theorem algebraicReals_meagre_and_null :
+    IsMeagre {x : ℝ | IsAlgebraic ℚ x} ∧ volume {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  ⟨algebraicReals_isMeagre, algebraicReals_volume_zero⟩
+
+/-- The transcendental reals are residual (comeagre): the complement of the
+meagre algebraic reals. -/
+theorem transcendentalReals_residual : {x : ℝ | ¬ IsAlgebraic ℚ x} ∈ residual ℝ := by
+  have h := algebraicReals_isMeagre
+  rwa [IsMeagre, compl_setOf] at h
+
+/-- **The transcendental reals are large in both senses**, dually to the
+algebraic reals being small in both: they are comeagre (category) and conull
+(full measure — their complement, the algebraic reals, is null). -/
+theorem transcendentalReals_comeagre_and_conull :
+    {x : ℝ | ¬ IsAlgebraic ℚ x} ∈ residual ℝ ∧
+      volume {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  ⟨transcendentalReals_residual, algebraicReals_volume_zero⟩
+
+end AlgebraicRealsMeagerOQ02

--- a/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "algebraic-reals-meager-oq-02",
+  "title": "Measure versus category: the algebraic reals are small in both senses, but the two notions diverge",
+  "slug": "algebraic-reals-meager-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Transcendental.Liouville.Residual",
+      "Mathlib.NumberTheory.Transcendental.Liouville.Measure",
+      "Mathlib.RingTheory.Algebraic.Basic",
+      "Mathlib.RingTheory.Localization.Integral",
+      "Mathlib.Algebra.AlgebraicCard",
+      "Mathlib.Topology.GDelta.Basic",
+      "Mathlib.Topology.Perfect",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Set",
+      "Topology",
+      "MeasureTheory",
+      "Filter"
+    ],
+    "namespace": "AlgebraicRealsMeagerOQ02",
+    "lineCount": 223,
+    "axiomCount": 0,
+    "theoremCount": 18,
+    "definitionCount": 0,
+    "path": "Proofs/AlgebraicRealsMeagerOQ02.lean",
+    "sorries": 0
+  },
+  "description": "The parent entry shows the algebraic reals are meagre (topologically small); its measure-theoretic companion shows they are also null (Lebesgue measure zero). So the algebraic reals are small in both senses at once — but this entry shows that is exceptional, not typical. The two notions of smallness, meagre (category) and null (measure), are genuinely independent, witnessed by the Liouville numbers: that set is simultaneously comeagre (residual — Mathlib's eventually_residual_liouville) and null (volume_setOf_liouville). From this one witness the entry extracts (1) measure-category independence in both directions — a comeagre null set and a meagre conull set — plus the abstract disjointness of the two genericity filters residual ℝ and ae volume (Real.disjoint_residual_ae); (2) an Erdős–Sierpiński-style decomposition ℝ = A ∪ B with A meagre and B null, a partition of the line into a topologically negligible piece and a measure-negligible piece; (3) a refinement of the parent — since every Liouville number is transcendental (bridging ℤ- and ℚ-transcendence via IsFractionRing.isAlgebraic_iff), the comeagre-yet-null Liouville set sits inside the transcendental reals, so the transcendentals contain a comeagre subset of measure zero; (4) the capstone contrast: the algebraic reals are small in both senses (meagre AND null) while the transcendentals are large in both (comeagre AND conull) — the special aligned case the Liouville phenomenon shows is not forced. Self-contained over Mathlib (no project imports), 18 theorems, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean formalization original (structural follow-up to the meagre algebraic reals)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerOQ02.lean",
+    "tags": [
+      "topology",
+      "baire-category",
+      "measure-theory",
+      "meagre-set",
+      "residual-set",
+      "liouville-numbers",
+      "transcendental-numbers",
+      "real-analysis",
+      "descriptive-set-theory",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "eventually_residual_liouville",
+        "description": "∀ᶠ x in residual ℝ, Liouville x — the Liouville numbers are a residual (comeagre) set. Recast as set membership, this is the comeagre half of the comeagre-yet-null witness.",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "volume_setOf_liouville",
+        "description": "volume {x : ℝ | Liouville x} = 0 — the Liouville numbers have Lebesgue measure zero; the null half of the witness.",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "Real.disjoint_residual_ae",
+        "description": "Disjoint (residual ℝ) (ae volume) — the two genericity filters (topological and measure-theoretic) are disjoint; the abstract statement of measure-category independence.",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "Liouville.transcendental",
+        "description": "Liouville x → Transcendental ℤ x — every Liouville number is transcendental over ℤ; used to place the Liouville witness inside the transcendental reals.",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Basic"
+      },
+      {
+        "theorem": "IsFractionRing.isAlgebraic_iff",
+        "description": "IsAlgebraic A x ↔ IsAlgebraic K x for K the fraction field of A; with ℤ ⊂ ℚ ⊂ ℝ this identifies ℤ- and ℚ-transcendence, bridging Liouville.transcendental (over ℤ) to the parent's ¬ IsAlgebraic ℚ.",
+        "module": "Mathlib.RingTheory.Localization.Integral"
+      },
+      {
+        "theorem": "Algebraic.countable",
+        "description": "{x : A | IsAlgebraic R x} is countable for countable R; with R = ℚ gives the countability used to re-derive that the algebraic reals are meagre and null self-containedly.",
+        "module": "Mathlib.Algebra.AlgebraicCard"
+      },
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "A countable set has measure zero under any atomless measure; applied to the (countable) algebraic reals to get nullity.",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "isMeagre_iff_countable_union_isNowhereDense",
+        "description": "A set is meagre iff contained in a countable union of nowhere-dense sets; the basis for the self-contained countable ⟹ meagre lemma on ℝ.",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      }
+    ],
+    "annotations": [
+      {
+        "id": "countable-meagre",
+        "title": "Self-contained: countable ⟹ meagre on ℝ",
+        "startLine": 70,
+        "endLine": 90,
+        "summary": "isMeagre_of_isNowhereDense, isNowhereDense_singleton and countable_isMeagre re-derive (over Mathlib, no project import) that a countable subset of ℝ is meagre: singletons are nowhere dense because ℝ has no isolated points, and a countable set is a countable union of them.",
+        "mathContext": "A countable set in a perfect T1 Baire space is meagre."
+      },
+      {
+        "id": "liouville-witness",
+        "title": "The Liouville witness: comeagre yet null",
+        "startLine": 97,
+        "endLine": 127,
+        "summary": "liouville_residual, nonLiouville_isMeagre, liouville_volume_zero and liouville_comeagre_and_null assemble the single set that is residual (topologically almost all of ℝ) and yet has Lebesgue measure zero — the engine of the whole entry.",
+        "mathContext": "The Liouville numbers are simultaneously comeagre and null."
+      },
+      {
+        "id": "independence",
+        "title": "Measure–category independence",
+        "startLine": 130,
+        "endLine": 153,
+        "summary": "residual_ae_disjoint (the two genericity filters are disjoint), exists_residual_volume_zero (a comeagre set can be null) and exists_isMeagre_compl_volume_zero (a meagre set can have full measure) record the independence in both directions.",
+        "mathContext": "Topological genericity and full measure are mutually independent."
+      },
+      {
+        "id": "decomposition",
+        "title": "Erdős–Sierpiński-style decomposition ℝ = A ∪ B",
+        "startLine": 155,
+        "endLine": 168,
+        "summary": "exists_meagre_null_decomposition splits the line as a disjoint union of a meagre set A (non-Liouville reals) and a null set B (Liouville reals). Impossible with a single smallness notion — a Baire space is not meagre in itself and ℝ is not null — so this is precisely measure-category independence made concrete.",
+        "mathContext": "ℝ partitions into a meagre set and a null set."
+      },
+      {
+        "id": "transcendental-tie",
+        "title": "Refining the parent: a comeagre null set inside the transcendentals",
+        "startLine": 171,
+        "endLine": 191,
+        "summary": "liouville_subset_transcendental (every Liouville number is transcendental, via Liouville.transcendental and the ℤ/ℚ fraction-field bridge) and transcendental_contains_comeagre_null show the comeagre-yet-null Liouville set lies inside the transcendental reals — sharpening the parent's residual-transcendentals result.",
+        "mathContext": "The transcendental reals contain a comeagre subset of measure zero."
+      },
+      {
+        "id": "capstone",
+        "title": "Capstone: the aligned exceptional case",
+        "startLine": 193,
+        "endLine": 222,
+        "summary": "algebraicReals_meagre_and_null (algebraic reals small in both senses) versus transcendentalReals_comeagre_and_conull (transcendentals large in both) — the special aligned situation that the Liouville phenomenon shows is not forced by either smallness notion alone.",
+        "mathContext": "Algebraic reals: meagre AND null; transcendentals: comeagre AND conull."
+      }
+    ],
+    "references": [
+      {
+        "authors": "Oxtoby, John C.",
+        "title": "Measure and Category: A Survey of the Analogies between Topological and Measure Spaces",
+        "year": "1980",
+        "note": "Graduate Texts in Mathematics 2, Springer (2nd ed.) — the canonical treatment of the measure/category duality and the meagre-versus-null decomposition of ℝ."
+      },
+      {
+        "authors": "Liouville, Joseph",
+        "title": "Sur des classes très-étendues de quantités dont la valeur n'est ni algébrique ni même réductible à des irrationnelles algébriques",
+        "year": "1851",
+        "note": "Journal de mathématiques pures et appliquées 16, 133–142 — the Liouville numbers, here the explicit comeagre-yet-null witness."
+      },
+      {
+        "authors": "Erdős, Paul; Sierpiński, Wacław",
+        "title": "On the dual of the measure-category theorem",
+        "year": "1934",
+        "note": "Classical results on the symmetry between meagre and null sets, including decompositions of ℝ of the form proved here."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Child of **algebraic-reals-meager** (the algebraic reals are meagre) and its measure-zero companion. The parent's two faces — algebraic reals are *meagre* AND *null* — are an exceptional **alignment** of the two notions of smallness. This entry shows those notions (category vs measure) are genuinely **independent**, using the **Liouville numbers** as the comeagre-yet-null witness.

**18 theorems, 0 axioms, 0 sorries, no `native_decide`. Self-contained over Mathlib (no project imports).**

### Results
- `liouville_comeagre_and_null` — the Liouville set is residual (comeagre) **and** has Lebesgue measure 0.
- `residual_ae_disjoint`, `exists_residual_volume_zero`, `exists_isMeagre_compl_volume_zero` — measure–category independence in both directions; the genericity filters `residual ℝ` and `ae volume` are disjoint (`Real.disjoint_residual_ae`).
- `exists_meagre_null_decomposition` — **Erdős–Sierpiński-style** split `ℝ = A ∪ B` with `A` meagre and `B` null.
- `liouville_subset_transcendental` — every Liouville number is transcendental, bridging ℤ- and ℚ-transcendence via `IsFractionRing.isAlgebraic_iff`; this places the comeagre-yet-null set **inside** the transcendental reals, refining the parent.
- `algebraicReals_meagre_and_null` vs `transcendentalReals_comeagre_and_conull` — the aligned exceptional case that the Liouville phenomenon shows is *not forced*.

### Verification
Elaborated with Lean `v4.26.0` against prebuilt Mathlib oleans. `#print axioms` on all headline theorems returns only `propext`, `Classical.choice`, `Quot.sound` (foundational) — 0 substantive axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)