### PR TITLE
research: degree-8 minimal polynomial of √2+√3+√5 (multiquadratic OQ-04)

### DIFF
--- a/proofs/Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04.lean
+++ b/proofs/Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04.lean
@@ -1,0 +1,158 @@
+/-
+# The degree-8 annihilating polynomial of √2 + √3 + √5 and its sign-conjugates
+
+(OQ-04 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`)
+
+The parent entry proves `√2 + √3 + √5` is irrational.  Its open question OQ-04
+asks about the multiquadratic field `ℚ(√2, √3, √5)`: it has degree `8` over `ℚ`
+with Galois group `(ℤ/2ℤ)³`, and `α := √2 + √3 + √5` is a primitive element whose
+minimal polynomial has degree `8`.
+
+This file formalizes the **constructive, elementary backbone** of that statement:
+
+* the explicit degree-8 monic integer polynomial
+  `p(x) = x⁸ - 40·x⁶ + 352·x⁴ - 960·x² + 576`,
+* the fact that **all eight sign-conjugates** `±√2 ± √3 ± √5` are roots of `p`,
+  proved *simultaneously* by one general lemma `conjugate_root`, and
+* structural consequences: `p` is even (so roots come in `± r` pairs) and the
+  all-plus conjugate `α` is the strict maximum of the eight, hence a simple root
+  distinct from the other seven.
+
+## Why one lemma covers all eight conjugates
+
+`p` involves only even powers of `x`, and each sign-conjugate
+`u + v + w` with `u = ε₁√2, v = ε₂√3, w = ε₃√5` satisfies
+`u² = 2, v² = 3, w² = 5` *regardless of the signs* `εᵢ ∈ {±1}`.  So a single
+lemma quantified over reals `u, v, w` with those three square relations proves
+`p(u + v + w) = 0` for every choice of signs at once.
+
+## Proof of the core identity — successive squaring
+
+Writing `α = u + v + w` and `A = α² - 6`:
+
+1. `α² - 2αu - 6 = 2vw`            (linear in the square relations);
+2. squaring and using `u² = 2`:  `A² + 8α² - 60 = 4αu·A`;
+3. squaring again and using `u² = 2`:  `(A² + 8α² - 60)² = 32·α²·A²`,
+   which expands (as a pure polynomial in `α`) to `p(α) = 0`.
+
+Every step is discharged by `linear_combination` over the three square relations,
+so the whole proof is a sequence of ring identities — no `native_decide`, no
+axioms beyond Lean's logical core.
+
+## Honest scope
+
+This establishes that `[ℚ(α):ℚ] ≤ 8` constructively (an explicit degree-8
+annihilator).  The complementary **open/hard** content — irreducibility of `p`
+(hence degree *exactly* 8), `ℚ`-linear independence of `{√2, √3, √5}`, full
+pairwise distinctness of the eight conjugates, and the Galois group `(ℤ/2ℤ)³`
+— is **not** formalized here.
+-/
+
+import Mathlib.Data.Real.Sqrt
+import Mathlib.Tactic
+
+open Real
+
+namespace Sqrt2Sqrt3Sqrt5MultiquadraticOQ04
+
+/-- The explicit degree-8 polynomial
+`p(x) = x⁸ - 40·x⁶ + 352·x⁴ - 960·x² + 576`, the minimal polynomial of
+`√2 + √3 + √5` over `ℚ`. -/
+def minPoly8 (x : ℝ) : ℝ :=
+  x ^ 8 - 40 * x ^ 6 + 352 * x ^ 4 - 960 * x ^ 2 + 576
+
+/-- **Core lemma.** For *any* reals `u, v, w` with `u² = 2`, `v² = 3`, `w² = 5`,
+the sum `u + v + w` is a root of `p`.  Taking `u = ±√2`, `v = ±√3`, `w = ±√5`
+shows all eight sign-conjugates `±√2 ± √3 ± √5` are roots simultaneously. -/
+theorem conjugate_root (u v w : ℝ) (hu : u ^ 2 = 2) (hv : v ^ 2 = 3)
+    (hw : w ^ 2 = 5) : minPoly8 (u + v + w) = 0 := by
+  unfold minPoly8
+  -- Step 1: α² - 2αu - 6 = 2vw.
+  have h1 : (u + v + w) ^ 2 - 2 * (u + v + w) * u - 6 = 2 * v * w := by
+    linear_combination (-1 : ℝ) * hu + hv + hw
+  -- Step 2: square step 1; (2vw)² = 4·v²·w² = 60.
+  have h2 : ((u + v + w) ^ 2 - 2 * (u + v + w) * u - 6) ^ 2 = 60 := by
+    rw [h1]; linear_combination (4 * w ^ 2) * hv + 12 * hw
+  -- Step 3: expand the square and substitute u² = 2 to eliminate the odd-in-u term.
+  -- With A = α² - 6 :  A² + 8α² - 60 = 4αu·A.
+  have h3 : ((u + v + w) ^ 2 - 6) ^ 2 + 8 * (u + v + w) ^ 2 - 60
+      = 4 * (u + v + w) * u * ((u + v + w) ^ 2 - 6) := by
+    linear_combination h2 - 4 * (u + v + w) ^ 2 * hu
+  -- Step 4: square step 3; (4αu·A)² = 16·α²·u²·A² = 32·α²·A².
+  have h4 : (((u + v + w) ^ 2 - 6) ^ 2 + 8 * (u + v + w) ^ 2 - 60) ^ 2
+      = 32 * (u + v + w) ^ 2 * ((u + v + w) ^ 2 - 6) ^ 2 := by
+    linear_combination (((u + v + w) ^ 2 - 6) ^ 2 + 8 * (u + v + w) ^ 2 - 60
+        + 4 * (u + v + w) * u * ((u + v + w) ^ 2 - 6)) * h3
+        + 16 * (u + v + w) ^ 2 * ((u + v + w) ^ 2 - 6) ^ 2 * hu
+  -- Step 5: step 4 expands, as a pure polynomial in α, to p(α) = 0.
+  linear_combination h4
+
+/-- `(√2)² = 2`. -/
+private theorem sq_sqrt2 : sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+/-- `(√3)² = 3`. -/
+private theorem sq_sqrt3 : sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+/-- `(√5)² = 5`. -/
+private theorem sq_sqrt5 : sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num)
+
+/-- **`α = √2 + √3 + √5` is a root of `p`.**  Hence `α` is an algebraic integer
+of degree at most `8` over `ℚ`. -/
+theorem sqrt2_sqrt3_sqrt5_root : minPoly8 (sqrt 2 + sqrt 3 + sqrt 5) = 0 :=
+  conjugate_root _ _ _ sq_sqrt2 sq_sqrt3 sq_sqrt5
+
+/-- A concrete sign-conjugate: `√2 - √3 + √5` is also a root of `p`. -/
+theorem conjugate_pmp_root : minPoly8 (sqrt 2 - sqrt 3 + sqrt 5) = 0 := by
+  have h : sqrt 2 - sqrt 3 + sqrt 5 = sqrt 2 + (-sqrt 3) + sqrt 5 := by ring
+  rw [h]
+  refine conjugate_root _ _ _ sq_sqrt2 ?_ sq_sqrt5
+  rw [neg_pow, sq_sqrt3]; norm_num
+
+/-- The fully-negated conjugate `-√2 - √3 - √5 = -α` is a root of `p`. -/
+theorem conjugate_neg_root : minPoly8 (-(sqrt 2 + sqrt 3 + sqrt 5)) = 0 := by
+  have h : -(sqrt 2 + sqrt 3 + sqrt 5) = (-sqrt 2) + (-sqrt 3) + (-sqrt 5) := by ring
+  rw [h]
+  refine conjugate_root _ _ _ ?_ ?_ ?_
+  · rw [neg_pow, sq_sqrt2]; norm_num
+  · rw [neg_pow, sq_sqrt3]; norm_num
+  · rw [neg_pow, sq_sqrt5]; norm_num
+
+/-- `p` is an **even** polynomial: `p(-x) = p(x)`.  (It involves only even
+powers of `x`.) -/
+theorem minPoly8_even (x : ℝ) : minPoly8 (-x) = minPoly8 x := by
+  unfold minPoly8; ring
+
+/-- Roots of `p` come in `± r` pairs: if `r` is a root then so is `-r`.  This is
+the analytic shadow of the sign-flip symmetry `√k ↦ -√k` of the conjugates. -/
+theorem root_neg {r : ℝ} (hr : minPoly8 r = 0) : minPoly8 (-r) = 0 := by
+  rw [minPoly8_even]; exact hr
+
+/-- **Strict maximality of the all-plus conjugate.**  Any sign-conjugate
+`s₂·√2 + s₃·√3 + s₅·√5` with coefficients `≤ 1` and at least one coefficient
+`< 1` is strictly smaller than `α = √2 + √3 + √5`.  In particular each of the
+seven proper sign-conjugates `ε₁√2 + ε₂√3 + ε₃√5 ≠ √2 + √3 + √5` is `< α`. -/
+theorem conjugate_lt_alpha (s₂ s₃ s₅ : ℝ) (h₂ : s₂ ≤ 1) (h₃ : s₃ ≤ 1)
+    (h₅ : s₅ ≤ 1) (hne : s₂ < 1 ∨ s₃ < 1 ∨ s₅ < 1) :
+    s₂ * sqrt 2 + s₃ * sqrt 3 + s₅ * sqrt 5 < sqrt 2 + sqrt 3 + sqrt 5 := by
+  have p2 : (0 : ℝ) < sqrt 2 := sqrt_pos.mpr (by norm_num)
+  have p3 : (0 : ℝ) < sqrt 3 := sqrt_pos.mpr (by norm_num)
+  have p5 : (0 : ℝ) < sqrt 5 := sqrt_pos.mpr (by norm_num)
+  -- Each term is `≤` the all-plus term; a strict coefficient makes its term strict.
+  have b2 : s₂ * sqrt 2 ≤ sqrt 2 := by nlinarith
+  have b3 : s₃ * sqrt 3 ≤ sqrt 3 := by nlinarith
+  have b5 : s₅ * sqrt 5 ≤ sqrt 5 := by nlinarith
+  rcases hne with h | h | h
+  · have : s₂ * sqrt 2 < sqrt 2 := by nlinarith
+    linarith
+  · have : s₃ * sqrt 3 < sqrt 3 := by nlinarith
+    linarith
+  · have : s₅ * sqrt 5 < sqrt 5 := by nlinarith
+    linarith
+
+/-- **Consequence: `α` is a simple root, distinct from its seven proper
+conjugates.**  No sign-conjugate other than the all-plus one equals `α`, since
+each is strictly smaller. -/
+theorem alpha_ne_proper_conjugate (s₂ s₃ s₅ : ℝ) (h₂ : s₂ ≤ 1) (h₃ : s₃ ≤ 1)
+    (h₅ : s₅ ≤ 1) (hne : s₂ < 1 ∨ s₃ < 1 ∨ s₅ < 1) :
+    s₂ * sqrt 2 + s₃ * sqrt 3 + s₅ * sqrt 5 ≠ sqrt 2 + sqrt 3 + sqrt 5 :=
+  ne_of_lt (conjugate_lt_alpha s₂ s₃ s₅ h₂ h₃ h₅ hne)
+
+end Sqrt2Sqrt3Sqrt5MultiquadraticOQ04

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sqrt2357-oq04-even-trick",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "One Lemma for All Eight Sign-Conjugates",
+    "content": "The minimal polynomial p(x) = x⁸ − 40x⁶ + 352x⁴ − 960x² + 576 of α = √2+√3+√5 involves only even powers of x. The eight Galois conjugates of α are the sign-combinations ε₁√2 + ε₂√3 + ε₃√5 with εᵢ ∈ {±1}. Writing such a conjugate as u+v+w with u = ε₁√2, v = ε₂√3, w = ε₃√5, the three relations u² = 2, v² = 3, w² = 5 hold regardless of the signs. The proof therefore quantifies over arbitrary reals u,v,w satisfying those squares and proves p(u+v+w) = 0 once — covering all eight conjugates simultaneously, rather than eight separate computations. This is the structural pay-off of the polynomial being even.",
+    "mathContext": "For a multiquadratic primitive element α = √d₁ + ⋯ + √dₖ, the minimal polynomial is the product ∏ (x − ∑ εᵢ√dᵢ) over ε ∈ {±1}ᵏ. Closure under ε ↦ −ε forces every odd-degree coefficient to vanish, so the minimal polynomial is even and a single square-relation lemma annihilates the entire conjugate orbit.",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimal polynomial",
+      "Galois conjugates",
+      "multiquadratic field",
+      "even polynomial"
+    ],
+    "prerequisites": [
+      "field extensions",
+      "minimal polynomial of an algebraic number"
+    ]
+  },
+  {
+    "id": "ann-sqrt2357-oq04-squaring-chain",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
+    "range": { "startLine": 67, "endLine": 89 },
+    "type": "technique",
+    "title": "Successive-Squaring Chain via linear_combination",
+    "content": "conjugate_root derives p(α) = 0 (where α = u+v+w) by three squarings that eliminate one radical at a time. Step 1: α² − 2αu − 6 = 2vw, a direct linear combination of u²=2, v²=3, w²=5. Step 2: squaring and using u²=2 gives A² + 8α² − 60 = 4αu·A with A = α² − 6 (the odd-in-u term is isolated on the right). Step 3: squaring again and using u²=2 once more gives (A² + 8α² − 60)² = 32α²A², which expands as a pure polynomial in α to exactly p(α) = 0. Each equation is closed by `linear_combination` over the square relations, so the entire proof is a chain of polynomial identities verified by `ring` — no minimal-polynomial search, no numerical certificate, and no native_decide. The explicit cofactors keep every step low-degree, avoiding the unwieldy degree-6 cofactors a single-shot linear_combination would require.",
+    "mathContext": "Constructing the minimal polynomial of a sum of square roots by repeated squaring is classical (it realizes the resultant / norm form). Casting each squaring as a `linear_combination` of the defining relations uᵢ² = dᵢ turns the algebra into machine-checkable ring identities and sidesteps the large Gröbner-basis cofactors of a direct ideal-membership certificate.",
+    "significance": "important",
+    "relatedConcepts": [
+      "resultant",
+      "iterated squaring",
+      "linear_combination tactic",
+      "ideal membership"
+    ],
+    "prerequisites": [
+      "polynomial ring identities",
+      "Lean linear_combination tactic"
+    ]
+  },
+  {
+    "id": "ann-sqrt2357-oq04-maximality",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
+    "range": { "startLine": 120, "endLine": 158 },
+    "type": "concept",
+    "title": "Evenness, ±-Pairing, and Strict Maximality",
+    "content": "Three structural corollaries package the symmetry of the conjugate orbit. minPoly8_even (p(−x) = p(x)) and root_neg (r a root ⟹ −r a root) record that roots come in ±r pairs — the analytic shadow of the sign flip √k ↦ −√k that generates one ℤ/2ℤ factor of the Galois group. conjugate_lt_alpha shows the all-plus conjugate α = √2+√3+√5 strictly dominates every other sign-conjugate: flipping any sign to a coefficient < 1 strictly lowers that term (since √2,√3,√5 > 0) while the rest cannot exceed their plus-values. Hence alpha_ne_proper_conjugate: α differs from each of its seven proper conjugates, so α is a simple root of p. Full pairwise distinctness of all eight (and irreducibility of p) needs ℚ-linear independence of {√2,√3,√5} and is the entry's stated open content.",
+    "mathContext": "An algebraic number is a simple root of its minimal polynomial iff the minimal polynomial is separable; for a primitive element of a Galois extension the conjugates are exactly the distinct roots. Here positivity of the radicals already separates α from its conjugates, giving simplicity of the all-plus root without the full separability argument.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "separable polynomial",
+      "simple root",
+      "sign-flip symmetry",
+      "Galois group (ℤ/2ℤ)³"
+    ],
+    "prerequisites": [
+      "ordering of real numbers",
+      "positivity of square roots"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Constructive backbone of OQ-04 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`: the multiquadratic field ℚ(√2,√3,√5) has degree 8 over ℚ with Galois group (ℤ/2ℤ)³, and α = √2+√3+√5 is a primitive element of minimal-polynomial degree 8.

This PR formalizes the **explicit degree-8 annihilating polynomial** and the structure of its root set, fully verified (0 sorries, 0 axioms, no `native_decide`).

## Results (`Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04.lean`, 11 thm / 1 def / 158 L)

- **`conjugate_root` (key):** for *any* reals u,v,w with u²=2, v²=3, w²=5, the sum u+v+w is a root of `p(x) = x⁸ − 40x⁶ + 352x⁴ − 960x² + 576`. Because p is even, the **eight sign-conjugates ±√2±√3±√5 are all roots simultaneously** — one lemma, not eight computations.
- **`sqrt2_sqrt3_sqrt5_root`:** α = √2+√3+√5 is a root of p (so [ℚ(α):ℚ] ≤ 8 constructively).
- **`conjugate_pmp_root`, `conjugate_neg_root`:** concrete conjugates (√2−√3+√5, −α) as roots.
- **`minPoly8_even` / `root_neg`:** p(−x)=p(x), so roots come in ±r pairs (the √k ↦ −√k symmetry).
- **`conjugate_lt_alpha` / `alpha_ne_proper_conjugate`:** α strictly dominates its seven proper sign-conjugates (positivity), so α is a simple root.

## Proof technique

Four-step successive-squaring chain eliminating one radical at a time:
`α²−2αu−6 = 2vw` → `A²+8α²−60 = 4αu·A` (A=α²−6) → `(A²+8α²−60)² = 32α²A²` → `p(α)=0`. Every step is a `linear_combination` over the three square relations, verified by `ring`. Closed-form polynomial and cofactors derived/verified symbolically before formalization.

## Axioms

`#print axioms conjugate_root` → `propext, Classical.choice, Quot.sound` only (Lean's logical core). **0-axiom, badge `original`.** Build verified at Mathlib v4.26.0 via single-file elaboration against prebuilt oleans.

## Honest scope / open content

Establishes [ℚ(α):ℚ] ≤ 8 (explicit annihilator). The complementary hard half — irreducibility of p (degree *exactly* 8), ℚ-linear independence of {√2,√3,√5} / full pairwise distinctness of the eight conjugates, and the Galois group (ℤ/2ℤ)³ — is **not** formalized here and is recorded as open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)