### PR TITLE
research(erdos-1054-oq-01): σ(m) is always representable (axiom-free generalization of Construction D)

### DIFF
--- a/proofs/Proofs/Erdos1054ConstructionDOQ01.lean
+++ b/proofs/Proofs/Erdos1054ConstructionDOQ01.lean
@@ -1,0 +1,168 @@
+/-
+Erdős Problem #1054: Construction D — OQ-01
+
+## The sum-of-divisors function is always representable
+
+The parent file `Erdos1054ConstructionD` proves, case by case via `native_decide`,
+that specific values such as `1 + p + p²` (= σ(p²) for a prime `p`) and the Mersenne
+numbers `2^{k+1} - 1` (= σ(2^k)) are *representable* — i.e. each appears as a partial
+sum of the sorted divisors of some `m ≥ 1`.
+
+This file isolates the **structural reason** behind every one of those verifications
+and turns it into a single fully general, axiom-free theorem:
+
+> **For every `m ≥ 1`, the sum of divisors `σ(m) = ∑_{d ∣ m} d` is representable.**
+
+The proof is one observation: the *last* partial sum of the sorted divisor list is the
+total sum of all divisors, which is exactly `σ(m)`. Concretely, `partialDivisorSums m`
+is the tail of `scanl (·+·) 0 (sortedDivisors m)`, whose last entry equals
+`foldl (·+·) 0 (sortedDivisors m) = (sortedDivisors m).sum = σ(m)`.
+
+This subsumes the parent's concrete checks **without** `native_decide` (hence
+`Lean.ofReduceBool`-free): the prime-square case is `m = p²`, the Mersenne case is
+`m = 2^k`, and we additionally obtain a clean prime-power corollary
+`∑_{i=0}^{k} p^i` is representable for every prime `p` and every `k`.
+
+## Results
+- `foldl_add_acc`              — accumulator identity `foldl (+) a L = a + L.sum`
+- `sortedDivisors_sum`         — `(sortedDivisors m).sum = ∑_{d ∣ m} d`
+- `sum_divisors_mem_partialSums` — `σ(m) ∈ partialDivisorSums m` for `m ≥ 1`
+- `sum_divisors_representable` — `σ(m)` is representable for every `m ≥ 1`  (headline)
+- `geom_sum_representable`     — `∑_{i=0}^{k} p^i` representable for prime `p`
+- `prime_sq_sum_representable'` — recovers the parent's `1 + p + p²` case
+- `mersenne_representable`     — recovers the Mersenne case `2^{k+1} - 1`
+-/
+
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Data.Finset.Sort
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+open Nat Finset
+
+namespace Erdos1054ConstructionDOQ01
+
+-- ============================================================
+-- Definitions (mirrored from `Erdos1054ConstructionD` so this file is
+-- self-contained; the parent's concrete checks use `native_decide`, which
+-- we deliberately avoid here to keep these results `Lean.ofReduceBool`-free).
+-- ============================================================
+
+/-- The divisors of `m`, listed in increasing order. -/
+def sortedDivisors (m : ℕ) : List ℕ :=
+  m.divisors.sort (· ≤ ·)
+
+/-- The running (cumulative) sums of the sorted divisors of `m`. -/
+def partialDivisorSums (m : ℕ) : List ℕ :=
+  ((sortedDivisors m).scanl (· + ·) 0).tail
+
+/-- `n` is *representable* if it occurs as a partial divisor sum of some `m ≥ 1`. -/
+def IsRepresentable (n : ℕ) : Prop :=
+  ∃ m : ℕ, m ≥ 1 ∧ n ∈ (partialDivisorSums m)
+
+-- ============================================================
+-- Part 0: A list-folding helper
+-- ============================================================
+
+/--
+Folding addition over a list with an arbitrary starting accumulator `a`
+just adds `a` to the list's sum.  This lets us identify the final entry of
+the `scanl` (which carries the running total) with the list sum.
+-/
+theorem foldl_add_acc (a : ℕ) (L : List ℕ) : L.foldl (· + ·) a = a + L.sum := by
+  induction L generalizing a with
+  | nil => simp
+  | cons x xs ih => rw [List.foldl_cons, ih, List.sum_cons]; ring
+
+-- ============================================================
+-- Part 1: The sorted divisor list sums to σ(m)
+-- ============================================================
+
+/--
+The sum of the sorted divisor list of `m` is the sum-of-divisors function `σ(m)`.
+The sorted list is a permutation of the divisor finset, so sums agree.
+-/
+theorem sortedDivisors_sum (m : ℕ) :
+    (sortedDivisors m).sum = ∑ d ∈ m.divisors, d := by
+  rw [sortedDivisors, (Finset.sort_perm_toList _ _).sum_eq, Finset.sum_toList]
+
+-- ============================================================
+-- Part 2: σ(m) is the final partial sum, hence representable
+-- ============================================================
+
+/--
+**Key lemma.** For every `m ≥ 1`, the sum of divisors `σ(m)` occurs as a partial
+sum of the sorted divisors of `m`: it is the *last* such partial sum.
+-/
+theorem sum_divisors_mem_partialSums (m : ℕ) (hm : 1 ≤ m) :
+    (∑ d ∈ m.divisors, d) ∈ partialDivisorSums m := by
+  -- Work with the list sum; the divisor finset is nonempty since `1 ∣ m`.
+  rw [← sortedDivisors_sum]
+  obtain ⟨a, l, hal⟩ : ∃ a l, sortedDivisors m = a :: l := by
+    rcases h : sortedDivisors m with _ | ⟨a, l⟩
+    · exfalso
+      have hlen : (sortedDivisors m).length = m.divisors.card := by
+        rw [sortedDivisors, Finset.length_sort]
+      rw [h, List.length_nil] at hlen
+      have h1 : (1 : ℕ) ∈ m.divisors := Nat.one_mem_divisors.mpr (by omega)
+      have := Finset.card_pos.mpr ⟨1, h1⟩
+      omega
+    · exact ⟨a, l, rfl⟩
+  -- Unfold the partial-sum list and reduce to the final `scanl` entry.
+  unfold partialDivisorSums
+  rw [hal, List.scanl_cons, List.tail_cons]
+  -- Goal: `(a :: l).sum ∈ scanl (·+·) (0 + a) l`
+  have hne : List.scanl (· + ·) (0 + a) l ≠ [] := List.scanl_ne_nil
+  have hmem := List.getLast_mem hne
+  rw [List.getLast_scanl hne] at hmem
+  have hval : List.foldl (· + ·) (0 + a) l = (a :: l).sum := by
+    rw [foldl_add_acc, List.sum_cons]; ring
+  rwa [hval] at hmem
+
+/--
+**Headline.** The sum-of-divisors function `σ(m) = ∑_{d ∣ m} d` is representable for
+every `m ≥ 1` — it is always realised by the witness `m` itself (the largest partial
+sum of `m`'s sorted divisors).
+
+This generalises, in one stroke and without `native_decide`, every concrete
+representability check in the parent file.
+-/
+theorem sum_divisors_representable (m : ℕ) (hm : 1 ≤ m) :
+    IsRepresentable (∑ d ∈ m.divisors, d) :=
+  ⟨m, hm, sum_divisors_mem_partialSums m hm⟩
+
+-- ============================================================
+-- Part 3: Corollaries recovering and extending the parent results
+-- ============================================================
+
+/--
+**Prime-power corollary.** For every prime `p` and every `k`, the geometric sum
+`∑_{i=0}^{k} p^i` is representable (witness `m = p^k`).  Indeed it equals `σ(p^k)`.
+-/
+theorem geom_sum_representable (p k : ℕ) (hp : p.Prime) :
+    IsRepresentable (∑ i ∈ Finset.range (k + 1), p ^ i) := by
+  have hpk : 1 ≤ p ^ k := Nat.one_le_iff_ne_zero.mpr (pow_ne_zero k hp.pos.ne')
+  have h := sum_divisors_representable (p ^ k) hpk
+  rwa [Nat.sum_divisors_prime_pow (f := fun x => x) hp] at h
+
+/--
+Recovers the parent's **Construction D** statement: `σ(p²) = 1 + p + p²` is
+representable, here as the `k = 2` instance of `geom_sum_representable`.
+-/
+theorem prime_sq_sum_representable' (p : ℕ) (hp : p.Prime) :
+    IsRepresentable (1 + p + p ^ 2) := by
+  have h := geom_sum_representable p 2 hp
+  -- `∑_{i=0}^{2} p^i = 1 + p + p²`
+  simpa [Finset.sum_range_succ, pow_zero, pow_one, add_comm, add_left_comm, add_assoc]
+    using h
+
+/--
+Recovers the parent's **Mersenne** family: `σ(2^k) = 2^{k+1} - 1` is representable.
+We state it in the additive form `∑_{i=0}^{k} 2^i` to avoid `ℕ` subtraction; this is
+exactly the Mersenne number `2^{k+1} - 1`.
+-/
+theorem mersenne_representable (k : ℕ) :
+    IsRepresentable (∑ i ∈ Finset.range (k + 1), 2 ^ i) :=
+  geom_sum_representable 2 k Nat.prime_two
+
+end Erdos1054ConstructionDOQ01

--- a/src/data/proofs/erdos-1054-construction-d-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1054-construction-d-oq-01/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ann-cd-oq01-overview",
+    "proofId": "erdos-1054-construction-d-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "From case-by-case checks to one structural theorem",
+    "content": "The parent file `Erdos1054ConstructionD` verifies *specific* numbers as representable — $1+p+p^2$ for $p=2,3,5,7,11,13$, and the Mersenne numbers $3,7,15,31,\\ldots$ — each by a separate `native_decide` computation. This file replaces all of them with a single observation.\n\nRecall $n$ is **representable** if it occurs as a partial sum of the *sorted* divisor list of some $m \\geq 1$. The partial sums of $[d_1 < d_2 < \\cdots < d_t]$ are $[d_1,\\; d_1{+}d_2,\\; \\ldots,\\; d_1{+}\\cdots{+}d_t]$. The **last** one is the sum of *all* divisors, i.e. the sum-of-divisors function $\\sigma(m) = \\sum_{d \\mid m} d$.\n\nHence: **for every $m \\geq 1$, $\\sigma(m)$ is representable**, witnessed by $m$ itself. Every concrete check in the parent is a special case — $\\sigma(p^2) = 1+p+p^2$, $\\sigma(2^k) = 2^{k+1}-1$ — and the general theorem needs no `native_decide`, so it is free of the `Lean.ofReduceBool` axiom.",
+    "mathContext": "σ(m) = ∑_{d∣m} d is the classical sum-of-divisors function. The result says the entire image of σ lands inside the representable set, for a completely elementary structural reason: σ(m) is the final cumulative sum of the increasing divisor sequence.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Erdős #1054",
+      "sum-of-divisors function σ",
+      "partial divisor sums",
+      "representability",
+      "native_decide elimination"
+    ],
+    "prerequisites": [
+      "divisors of a natural number",
+      "cumulative (scan) sums of a list"
+    ]
+  },
+  {
+    "id": "ann-cd-oq01-foldl",
+    "proofId": "erdos-1054-construction-d-oq-01",
+    "range": { "startLine": 65, "endLine": 75 },
+    "type": "technique",
+    "title": "The accumulator identity for scanl",
+    "content": "`partialDivisorSums m` is the tail of `scanl (·+·) 0 (sortedDivisors m)`. Batteries' `List.getLast_scanl` says the last entry of a `scanl` is `foldl (·+·) 0 L` — the running total. To identify that total with the list *sum*, we prove the small generalized lemma `foldl_add_acc : L.foldl (·+·) a = a + L.sum` by induction on `L` with the accumulator `a` generalized.\n\nGeneralizing the accumulator is essential: the naive statement `L.foldl (·+·) 0 = L.sum` does not strengthen the induction hypothesis enough, because the recursive call threads a *non-zero* accumulator `0 + d_1`.",
+    "mathContext": "foldl with a moving accumulator: foldl (+) a [x₁,…,xₙ] = a + (x₁ + ⋯ + xₙ). Proven by induction generalizing a.",
+    "significance": "supporting",
+    "relatedConcepts": ["list folds", "scanl/foldl", "induction generalization"],
+    "prerequisites": ["structural induction on lists"]
+  },
+  {
+    "id": "ann-cd-oq01-key",
+    "proofId": "erdos-1054-construction-d-oq-01",
+    "range": { "startLine": 85, "endLine": 120 },
+    "type": "technique",
+    "title": "σ(m) is the final partial sum",
+    "content": "The membership proof `sum_divisors_mem_partialSums` proceeds in three moves. (1) Rewrite the finset sum $\\sum_{d\\mid m} d$ to the list sum of `sortedDivisors m` using that the sort is a permutation of the divisor finset (`Finset.sort_perm_toList` + `Finset.sum_toList`). (2) Since $1 \\mid m$ (so the divisor finset is nonempty), the sorted list is `a :: l`, and `partialDivisorSums m` unfolds to `scanl (·+·) (0+a) l`. (3) The `getLast` of that `scanl` is in the list (`List.getLast_mem`) and equals `foldl (·+·) (0+a) l = (a::l).sum` by the accumulator identity. Therefore the divisor sum is a member.\n\nThe headline `sum_divisors_representable` then packages this with the witness `m`.",
+    "mathContext": "Nonemptiness from 1 ∈ m.divisors (Nat.one_mem_divisors, m ≥ 1); the last scanl entry carries the total of all divisors.",
+    "significance": "key",
+    "relatedConcepts": ["sorted divisors", "permutation invariance of sums", "scanl last element"],
+    "prerequisites": ["Finset.sort", "List.getLast"]
+  },
+  {
+    "id": "ann-cd-oq01-geom",
+    "proofId": "erdos-1054-construction-d-oq-01",
+    "range": { "startLine": 130, "endLine": 168 },
+    "type": "concept",
+    "title": "Prime-power corollary and recovered families",
+    "content": "Specializing $m = p^k$ and using `Nat.sum_divisors_prime_pow` ($\\sum_{d \\mid p^k} d = \\sum_{i=0}^{k} p^i$) yields `geom_sum_representable`: **every geometric sum $1 + p + \\cdots + p^k$ for a prime $p$ is representable**, with witness $p^k$.\n\nTwo families fall out immediately. With $k=2$ we recover the parent's Construction D headline $1+p+p^2$ (`prime_sq_sum_representable'`). With $p=2$ we recover the Mersenne numbers $\\sum_{i=0}^{k} 2^i = 2^{k+1}-1$ (`mersenne_representable`). Both are now fully verified, without the `native_decide` the parent used for its concrete instances.",
+    "mathContext": "∑_{i=0}^k p^i = (p^{k+1}-1)/(p-1) is the geometric sum; for p=2 it is the Mersenne number 2^{k+1}-1. All such values are σ of a prime power, hence representable.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "Mersenne numbers", "prime powers", "Erdős #1054 Construction D"],
+    "prerequisites": ["sum of divisors of a prime power", "geometric sums"]
+  }
+]

--- a/src/data/proofs/erdos-1054-construction-d-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-construction-d-oq-01/meta.json
@@ -1,0 +1,103 @@
+{
+  "id": "erdos-1054-construction-d-oq-01",
+  "title": "Erdős #1054 OQ-01: The Sum-of-Divisors Function is Always Representable",
+  "slug": "erdos-1054-construction-d-oq-01",
+  "description": "Generalizes Construction D (Erdős #1054) from case-by-case native_decide checks to a single axiom-free theorem: for every m ≥ 1, the sum of divisors σ(m) = ∑_{d∣m} d is representable, because it is always the LAST partial sum of m's sorted divisor list. This subsumes the parent's prime-square witnesses (σ(p²)=1+p+p²) and the entire Mersenne family (σ(2^k)=2^{k+1}-1) without the Lean.ofReduceBool axiom, and adds a prime-power corollary that ∑_{i=0}^k p^i is representable for every prime p.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Divisors",
+      "Mathlib.Data.Finset.Sort",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "Erdos1054ConstructionDOQ01",
+    "lineCount": 168,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1054ConstructionDOQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1054ConstructionDOQ01.lean",
+    "tags": [
+      "number-theory",
+      "erdos-problems",
+      "divisors",
+      "sum-of-divisors",
+      "prime-powers",
+      "representability",
+      "mersenne-numbers"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 168,
+    "theoremCount": 7,
+    "definitionCount": 3,
+    "assumptions": "None. All seven theorems are fully machine-checked and depend only on the standard foundational axioms propext, Classical.choice, and Quot.sound. In particular, NO native_decide is used, so the results are free of Lean.ofReduceBool — a deliberate strengthening of the parent file, whose concrete witnesses (constr_d_*, mersenne_repr_*) rely on native_decide. axiomCount=0.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sort_perm_toList",
+        "description": "The sorted divisor list is a permutation of the divisor finset, so their sums agree (sortedDivisors_sum).",
+        "module": "Mathlib.Data.Finset.Sort"
+      },
+      {
+        "theorem": "List.getLast_scanl",
+        "description": "The last entry of scanl (·+·) 0 L equals foldl (·+·) 0 L, i.e. the running total — the crux that identifies the final partial sum with σ(m).",
+        "module": "Batteries.Data.List.Scan"
+      },
+      {
+        "theorem": "Nat.sum_divisors_prime_pow",
+        "description": "∑_{d∣p^k} d = ∑_{i=0}^k p^i, giving the prime-power geometric-sum corollary.",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0"
+  },
+  "mainTheorems": [
+    {
+      "name": "sum_divisors_representable",
+      "type": "core",
+      "statement": "∀ m ≥ 1, IsRepresentable (∑ d ∈ m.divisors, d)",
+      "description": "The sum-of-divisors function σ(m) is representable for every m ≥ 1, witnessed by m itself.",
+      "significance": "Single axiom-free theorem subsuming every concrete representability check in the parent file — the structural reason all of them hold."
+    },
+    {
+      "name": "sum_divisors_mem_partialSums",
+      "type": "core",
+      "statement": "∀ m ≥ 1, (∑ d ∈ m.divisors, d) ∈ partialDivisorSums m",
+      "description": "σ(m) is the LAST partial sum of m's sorted divisor list — the running total of all divisors.",
+      "significance": "The key structural insight: representability of σ(m) is automatic, not a coincidence to be checked case by case."
+    },
+    {
+      "name": "geom_sum_representable",
+      "type": "corollary",
+      "statement": "∀ p prime, ∀ k, IsRepresentable (∑ i ∈ range (k+1), p^i)",
+      "description": "Every geometric sum 1 + p + ⋯ + p^k for a prime p is representable (witness p^k), since it equals σ(p^k).",
+      "significance": "Generalizes the parent's prime-square family (k=2) and Mersenne family (p=2) into one axiom-free statement."
+    },
+    {
+      "name": "prime_sq_sum_representable'",
+      "type": "corollary",
+      "statement": "∀ p prime, IsRepresentable (1 + p + p^2)",
+      "description": "Recovers the parent's Construction D headline as the k=2 instance, now without native_decide.",
+      "significance": "Re-derives a previously native_decide-flavoured result in fully verified form."
+    },
+    {
+      "name": "mersenne_representable",
+      "type": "corollary",
+      "statement": "∀ k, IsRepresentable (∑ i ∈ range (k+1), 2^i)",
+      "description": "Recovers the Mersenne family (∑ 2^i = 2^{k+1}-1 = σ(2^k)) without native_decide.",
+      "significance": "The infinite Mersenne family of representable numbers, axiom-free."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**Erdős #1054, OQ-01.** The parent gallery proof `erdos-1054-construction-d` verifies *specific* numbers as representable — `1+p+p²` for `p = 2,3,5,7,11,13` and the Mersenne numbers — each by a separate `native_decide` computation (hence carrying the `Lean.ofReduceBool` axiom). This PR isolates the structural reason behind all of them and turns it into one fully **axiom-free** theorem.

A number `n` is *representable* if it occurs as a partial sum of the sorted divisor list of some `m ≥ 1`. The **last** such partial sum is the running total of *all* divisors, i.e. the sum-of-divisors function `σ(m) = ∑_{d∣m} d`. Therefore:

> **For every `m ≥ 1`, `σ(m)` is representable** — witnessed by `m` itself.

This subsumes every concrete check in the parent, with **no `native_decide`**.

## Results (7 theorems, 3 defs, 168 lines, 0 sorries, 0 axioms)

| Theorem | Statement |
|---|---|
| `sum_divisors_mem_partialSums` | `∀ m ≥ 1, (∑ d ∈ m.divisors, d) ∈ partialDivisorSums m` |
| `sum_divisors_representable` | `∀ m ≥ 1, IsRepresentable (∑ d ∈ m.divisors, d)` *(headline)* |
| `geom_sum_representable` | `∀ p prime, ∀ k, IsRepresentable (∑ i ∈ range (k+1), p^i)` |
| `prime_sq_sum_representable'` | recovers parent's `1 + p + p²` (k=2) |
| `mersenne_representable` | recovers `∑ 2^i = 2^{k+1}−1` (p=2) |

## Proof idea

`partialDivisorSums m` is the tail of `scanl (·+·) 0 (sortedDivisors m)`. Batteries' `List.getLast_scanl` gives its last entry as `foldl (·+·) 0 L`; a small accumulator-generalized induction (`foldl_add_acc`) identifies that with `L.sum`, and `Finset.sort_perm_toList` identifies `L.sum` with `σ(m)`. Nonemptiness comes from `1 ∈ m.divisors`.

## Verification

Builds under Lean `v4.26.0` / Mathlib `4.26.0`. `#print axioms` on all headline theorems lists only `propext, Classical.choice, Quot.sound` — **no `Lean.ofReduceBool`, no `sorryAx`**.

Self-contained: re-declares the three base definitions so it does not depend on the parent's `native_decide`-bearing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)