### PR TITLE
Audit: amgm-oq-03-oq-02-oq-01-oq-02 badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -17,11 +17,11 @@
       "amgm",
       "equality-case"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 243,
-    "assumptions": "",
+    "assumptions": "0 `axiom` declarations, 0 sorries, 0 structure-encoded assumptions; no `native_decide`. The core equality characterization — `geomMean_rpow_eq_weightedSum_rpow_iff` (GM^r = ∑ wᵢ zᵢ^r ↔ data constant) — is obtained from Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'` (the equality case of weighted AM–GM), reached via `weighted_amgm_eq_iff` in JensenInequalityOQ01, which is a one-line `rw` wrapper around that Mathlib theorem. Every downstream result (`power_mean_eq_geom_mean_iff`, the crossing-zero equality/strictness lemmas, the sharp HM < GM < AM corner) specializes that equality case after transport. This file's independent contribution is the transport infrastructure — rpow injectivity collapsing zⱼ^r = zₖ^r to zⱼ = zₖ, raising to the bijective 1/r power to convert GM^r = ∑ wᵢ zᵢ^r into GM = M_r independently of the sign of r, and the strictness/squeeze arguments — not an independent proof of the AM–GM equality case. Hence the `mathlib` (Tier B) badge; status remains `verified` as the file is fully machine-checked.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "power_mean_eq_geom_mean_iff: M_r = GM ↔ data constant, for EVERY r ≠ 0 — the equality locus is identical for positive and negative orders even though the inequality reverses across zero (sign-independent unification)",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: amgm-inequality-oq-03-oq-02-oq-01-oq-02 — "Equality Case of the Crossing-Zero Power-Mean Chain"
**Severity**: MEDIUM (Mathlib wrapper claimed as `original`)

## Evidence

The file's core equality characterization `geomMean_rpow_eq_weightedSum_rpow_iff` (GM^r = ∑ wᵢ zᵢ^r ↔ data constant) is obtained from `weighted_amgm_eq_iff` (JensenInequalityOQ01), which is a **one-line `rw` wrapper** around Mathlib's `Real.geom_mean_eq_arith_mean_weighted_iff'`:

```lean
theorem weighted_amgm_eq_iff ... := by
  rw [Real.geom_mean_eq_arith_mean_weighted_iff' s w z hw hw' hz]
  ...
```

Every headline result in the file (`power_mean_eq_geom_mean_iff`, `power_mean_crossing_zero_eq_iff`, the strict crossing-zero bounds, the sharp HM < GM < AM corner) specializes that equality case after transport. The `mathlibDependencies` field already honestly listed `Real.geom_mean_eq_arith_mean_weighted_iff'` — only the badge overclaimed.

## What is genuinely original

The transport infrastructure is real work and is preserved in `originalContributions`: rpow injectivity collapsing `zⱼ^r = zₖ^r` to `zⱼ = zₖ`, raising to the bijective `1/r` power to make the equality locus sign-independent, and the strictness/squeeze arguments. This is Tier B (infrastructure + bridge over a Mathlib theorem), not an independent proof of the AM–GM equality case.

## Fix

- `badge`: `original` → `mathlib`
- `assumptions`: filled the empty field to disclose the Mathlib equality-case core
- `status`: stays `verified` (fully machine-checked, 0 sorries, 0 axioms)

---
Discovered during gallery integrity audit. Sibling `amgm-inequality-oq-04-oq-04` (AGM quadratic convergence) was checked in the same pass and is correctly `original` — its proof uses only elementary sqrt lemmas, no deep Mathlib headline.