### PR TITLE
Audit: area-of-circle-oq-05-incomplete-01 badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-incomplete-01/meta.json
@@ -17,7 +17,7 @@
       "area-of-circle"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05Incomplete01.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       "integral_gaussian",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: area-of-circle-oq-05-incomplete-01 — "The Normal-Distribution Normalization Family (from the Gaussian Integral)"
**Severity**: MEDIUM (Mathlib wrapper claimed as `original`)

## Evidence

Every analytic theorem opens by invoking Mathlib's `integral_gaussian`:

```lean
theorem gaussian_unit ... := by have h := integral_gaussian 1 ; ...
theorem gaussian_half ... := by have h := integral_gaussian (1 / 2) ; ...
theorem gaussian_variance ... := by have h := integral_gaussian (1 / (2 * σ ^ 2)) ; ...
```

The normalization and mean-shift results then specialize these by elementary algebra. The Gaussian integral — the only deep analytic content — is entirely Mathlib's `integral_gaussian`. The entry's `originalContributions` and `assumptions` already say it "derives everything from integral_gaussian", and `mathlibDependencies` lists it. Only the `original` badge overclaimed independent proof.

## Fix

- `badge`: `original` → `mathlib`
- `status`: stays `verified` (fully machine-checked, 0 sorries, 0 axioms)

The normal-density rescaling/normalization packaging is genuine infrastructure and remains credited in `originalContributions`.

---
Discovered during gallery integrity audit (recurrent Gaussian-lineage Tier B pattern). Sibling entries `angle-trisection-cos-20-gal-oq-02` and `angle-trisection-oq-02-oq-02-oq-02` were checked in the same pass and are correctly `original` — they develop their own totient/Chebyshev/IsPow2 argument using Mathlib lemmas only as infrastructure.