### PR TITLE
research(erdos-866-oq-01): lower bound g_k(N) ≥ 1 for all k ≥ 3 [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos866OQ01.lean
+++ b/proofs/Proofs/Erdos866OQ01.lean
@@ -1,0 +1,134 @@
+/-
+  # Erdős Problem #866 — The lower bound `g_k(N) ≥ 1` holds for ALL `k ≥ 3`
+  # (erdos-866-oq-01)
+
+  ## Background
+
+  For `k ≥ 3`, Erdős #866 studies the minimal threshold `g_k(N)` such that every
+  `A ⊆ {1, …, 2N}` with `|A| ≥ N + g_k(N)` contains all pairwise sums
+  `b_i + b_j` (`i < j`) of some `k`-tuple `b₁, …, b_k`.
+
+  The basic lower bound `g_k(N) ≥ 1` is witnessed by the extremal set of the `N`
+  odd numbers in `{1, …, 2N}`: no `k` integers can have **all** of their pairwise
+  sums land in this odd set, because among any three integers two share parity and
+  their sum is even.
+
+  The companion file `Erdos866Problem.lean` formalizes this obstruction only for the
+  case `k = 3` (`oddNumbers_no_triple`), even though the headline claim is
+  "`g_k(N) ≥ 1` for all `k`". This file closes that gap: the parity obstruction is
+  promoted to **every** `k ≥ 3` by restricting an alleged `k`-tuple to its first
+  three coordinates, where the `k = 3` argument already applies.
+
+  ## Main results
+
+  * `oddNumbers_no_triple` — base case (`k = 3`): no three integers have all
+    pairwise sums in the odd set (self-contained re-proof of the parent lemma).
+  * `oddNumbers_no_ktuple` — **the generalization**: for every `k ≥ 3`, no
+    `k`-tuple of integers has all pairwise sums in the odd set. This is exactly the
+    statement `g_k(N) ≥ 1` for all `k ≥ 3`.
+  * `upperExponent_nonneg`, `upperExponent_lt_one` — the upper-bound exponent
+    `1 - 2^{-k}` lies in `[0, 1)`, so the general upper bound `g_k(N) ≪ N^{1-2^{-k}}`
+    is genuinely sub-linear for every `k`.
+  * `upperExponent_strictMono` — the exponent is strictly increasing in `k` as a
+    full `StrictMono` (sharpening the parent's consecutive-step version).
+  * `upperExponent_tendsto_one` — the exponents converge to the limiting value `1`.
+
+  No new axioms, no sorries: the proofs compose existing Mathlib lemmas and a parity
+  pigeonhole.
+
+  ## Honest scope
+
+  The lower bound `g_k(N) ≥ 1` and the elementary exponent facts are the *settled*
+  shell of #866. The hard content — the exact growth rates `g₄`, `g₅ ≍ log N`,
+  `g₆ ≍ √N`, and the true exponent `α_k` — is the open frontier and is not touched
+  here.
+
+  Tags: additive-combinatorics, sumsets, pairwise-sums, threshold-functions, erdos
+-/
+import Mathlib
+
+open Finset Real
+
+namespace Erdos866OQ01
+
+/-- The interval `{1, 2, …, 2N}`. -/
+def Interval (N : ℕ) : Finset ℕ :=
+  (Finset.range (2 * N + 1)).filter (fun n => n ≥ 1)
+
+/-- A set `A` contains all pairwise sums of `b₁, …, b_k` if `b_i + b_j ∈ A` for all
+    `i < j`. -/
+def HasAllPairwiseSums (A : Finset ℕ) (b : Fin k → ℤ) : Prop :=
+  ∀ i j : Fin k, i < j → (b i + b j).toNat ∈ A
+
+/-- The set of odd numbers in `{1, …, 2N}`. -/
+def oddNumbers (N : ℕ) : Finset ℕ :=
+  (Interval N).filter (fun n => n % 2 = 1)
+
+/-- The exponent `1 - 2^{-k}` in the general upper bound `g_k(N) ≪ N^{1-2^{-k}}`. -/
+noncomputable def upperExponent (k : ℕ) : ℝ :=
+  1 - (2 : ℝ)⁻¹ ^ k
+
+-- ============================================================================
+-- Part I: The parity obstruction `g_k(N) ≥ 1` for all `k ≥ 3`
+-- ============================================================================
+
+/-- **Base case (`k = 3`).** No three integers can have all of their pairwise sums
+    inside the odd numbers of `{1, …, 2N}`: among any three integers two share
+    parity, so their sum is even and cannot be odd. -/
+theorem oddNumbers_no_triple (N : ℕ) :
+    ¬∃ b : Fin 3 → ℤ, HasAllPairwiseSums (oddNumbers N) b := by
+  rintro ⟨b, hb⟩
+  have h_odd : ∀ i j : Fin 3, i < j → (b i + b j).toNat % 2 = 1 := by
+    intro i j hij; have := hb i j hij; unfold oddNumbers at this; aesop
+  simp_all +decide [Fin.forall_fin_succ]
+  grind +ring
+
+/-- **The generalization: `g_k(N) ≥ 1` for every `k ≥ 3`.** No `k`-tuple of integers
+    can have all of its pairwise sums inside the odd numbers of `{1, …, 2N}`.
+
+    The proof restricts an alleged `k`-tuple to its first three coordinates (using
+    `3 ≤ k`); since `Fin.castLE` preserves the underlying order, the restricted
+    triple again has all pairwise sums in the odd set, contradicting
+    `oddNumbers_no_triple`. -/
+theorem oddNumbers_no_ktuple {k : ℕ} (hk : 3 ≤ k) (N : ℕ) :
+    ¬∃ b : Fin k → ℤ, HasAllPairwiseSums (oddNumbers N) b := by
+  rintro ⟨b, hb⟩
+  refine oddNumbers_no_triple N ⟨fun i => b (Fin.castLE hk i), ?_⟩
+  intro i j hij
+  -- `Fin.castLE` preserves the underlying value, so `i < j` transports verbatim.
+  exact hb (Fin.castLE hk i) (Fin.castLE hk j) hij
+
+-- ============================================================================
+-- Part II: The upper-bound exponent `1 - 2^{-k}`
+-- ============================================================================
+
+/-- The exponent `1 - 2^{-k}` is non-negative for every `k` (since `2^{-k} ≤ 1`). -/
+theorem upperExponent_nonneg (k : ℕ) : 0 ≤ upperExponent k := by
+  have h : (2 : ℝ)⁻¹ ^ k ≤ 1 := pow_le_one₀ (by norm_num) (by norm_num)
+  simp only [upperExponent]; linarith
+
+/-- The exponent `1 - 2^{-k}` is strictly below `1` for every `k` (since
+    `2^{-k} > 0`). Hence the general upper bound `g_k(N) ≪ N^{1-2^{-k}}` is genuinely
+    sub-linear in `N` for all `k`. -/
+theorem upperExponent_lt_one (k : ℕ) : upperExponent k < 1 := by
+  have h : (0 : ℝ) < (2 : ℝ)⁻¹ ^ k := by positivity
+  simp only [upperExponent]; linarith
+
+/-- **Strict monotonicity of the exponent** (full `StrictMono`, sharpening the
+    parent's consecutive-step lemma): `i < j → 1 - 2^{-i} < 1 - 2^{-j}`, because the
+    geometric sequence `2^{-k}` is strictly decreasing. -/
+theorem upperExponent_strictMono : StrictMono upperExponent := by
+  intro i j hij
+  have h : (2 : ℝ)⁻¹ ^ j < (2 : ℝ)⁻¹ ^ i :=
+    pow_lt_pow_right_of_lt_one₀ (by norm_num) (by norm_num) hij
+  simp only [upperExponent]; linarith
+
+/-- The exponents `1 - 2^{-k}` converge to the limiting value `1` as `k → ∞`. -/
+theorem upperExponent_tendsto_one :
+    Filter.Tendsto upperExponent Filter.atTop (nhds 1) := by
+  have h : Filter.Tendsto (fun k => (2 : ℝ)⁻¹ ^ k) Filter.atTop (nhds 0) :=
+    tendsto_pow_atTop_nhds_zero_of_lt_one (by norm_num) (by norm_num)
+  unfold upperExponent
+  simpa using (tendsto_const_nhds (x := (1 : ℝ))).sub h
+
+end Erdos866OQ01

--- a/src/data/proofs/erdos-866-oq-01/meta.json
+++ b/src/data/proofs/erdos-866-oq-01/meta.json
@@ -1,0 +1,74 @@
+{
+  "id": "erdos-866-oq-01",
+  "slug": "erdos-866-oq-01",
+  "title": "Erdős #866: the lower bound g_k(N) ≥ 1 holds for all k ≥ 3 (parity obstruction)",
+  "description": "Promotes the parity obstruction behind Erdős #866 from the single case k = 3 to every k ≥ 3: no k-tuple of integers can have all of its pairwise sums inside the odd numbers of {1,…,2N}. This is exactly the lower bound g_k(N) ≥ 1 for all k ≥ 3, which the companion file states but proves only for k = 3. Also sharpens the upper-bound exponent 1 − 2^{-k}: it lies in [0,1) (sub-linearity), is strictly increasing as a full StrictMono, and converges to 1.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Finset", "Real"],
+    "namespace": "Erdos866OQ01",
+    "lineCount": 134,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "path": "Proofs/Erdos866OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos866OQ01.lean",
+    "tags": [
+      "additive-combinatorics",
+      "sumsets",
+      "pairwise-sums",
+      "threshold-functions",
+      "parity",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with Lean v4.26.0 against the pinned Mathlib oleans (the Docker daemon was unresponsive this session, so verification was run by direct `lean` elaboration of the single file against the prebuilt Mathlib build artifacts; exit code 0, no errors). 0 sorries, 0 axiom declarations, no native_decide. `#print axioms` on all six theorems lists only the standard foundational axioms [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Self-contained: the interval {1,…,2N}, the odd-number set, the HasAllPairwiseSums predicate and the exponent 1−2^{-k} are re-declared, so nothing is imported from the companion Erdos866Problem.lean. Honest scope: the elementary lower bound g_k(N) ≥ 1 and the [0,1)-boundedness, monotonicity and limit of the upper exponent — the open content (exact g_4, g_5 ≍ log N, g_6 ≍ √N, and the true exponent α_k) is untouched.",
+    "lineCount": 134,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "originalContributions": [
+      "oddNumbers_no_ktuple: THE GENERALIZATION — for every k ≥ 3, no k-tuple of integers has all pairwise sums in the odd set, i.e. g_k(N) ≥ 1 for all k ≥ 3 (the companion proves only the k = 3 case oddNumbers_no_triple). Proof restricts an alleged k-tuple to its first three coordinates via Fin.castLE.",
+      "oddNumbers_no_triple: self-contained re-proof of the base case k = 3 (parity pigeonhole: among three integers two share parity, so their sum is even and cannot be odd).",
+      "upperExponent_nonneg: the upper-bound exponent 1 − 2^{-k} ≥ 0 for all k.",
+      "upperExponent_lt_one: 1 − 2^{-k} < 1 for all k, so the general upper bound g_k(N) ≪ N^{1−2^{-k}} is genuinely sub-linear in N.",
+      "upperExponent_strictMono: the exponent is strictly increasing as a full StrictMono (sharpening the companion's consecutive-step lemma).",
+      "upperExponent_tendsto_one: the exponents converge to the limiting value 1 as k → ∞."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #866 asks, for k ≥ 3, for the minimal threshold g_k(N) such that every A ⊆ {1,…,2N} with |A| ≥ N + g_k(N) contains all pairwise sums b_i + b_j (i < j) of some k-tuple. Known values and rates: g_3 = 2, g_4 ≤ 2032, g_5 ≍ log N, g_6 ≍ √N, with a general upper bound g_k(N) ≪ N^{1−2^{-k}}. The basic lower bound g_k(N) ≥ 1 is witnessed by the N odd numbers in {1,…,2N}: among any three integers, two share parity, so their sum is even and cannot be odd.",
+    "problemStatement": "The companion file formalizes the parity obstruction only for k = 3 (oddNumbers_no_triple), even though the lower bound g_k(N) ≥ 1 is claimed for all k. This entry closes that gap and records the elementary facts about the upper-bound exponent 1 − 2^{-k}.",
+    "proofStrategy": "For the lower bound, the k = 3 base case is the parity pigeonhole discharged by grind. The generalization restricts an alleged k-tuple b : Fin k → ℤ to its first three coordinates through the order-embedding Fin.castLE (using 3 ≤ k); since Fin.castLE preserves the underlying value, the restricted triple again has all pairwise sums in the odd set, contradicting the base case. For the exponent, 1 − 2^{-k} ∈ [0,1) follows from 0 < 2^{-k} ≤ 1, strict monotonicity from the strict decrease of the geometric sequence 2^{-k} (pow_lt_pow_right_of_lt_one₀), and the limit 1 from tendsto_pow_atTop_nhds_zero_of_lt_one.",
+    "keyInsights": [
+      "The obstruction is purely about the first three coordinates: any k-tuple with all pairwise sums odd would in particular give three integers with all pairwise sums odd, which is impossible. So g_k(N) ≥ 1 for every k ≥ 3 reduces to the k = 3 parity argument.",
+      "Fin.castLE is the clean formal vehicle for 'restrict to the first three coordinates': it is an order embedding preserving the underlying natural number, so it transports the all-pairwise-sums hypothesis without arithmetic.",
+      "The general upper exponent 1 − 2^{-k} sits strictly below 1 for every k, so the upper bound g_k(N) ≪ N^{1−2^{-k}} is always sub-linear; its strict increase and limit 1 quantify how the bound degrades toward linearity as k grows.",
+      "Formalization cleanly separates the settled shell of #866 (lower bound 1, exponent bookkeeping) from the open frontier (exact g_4, the log and √N rates, the true exponent α_k)."
+    ]
+  },
+  "conclusion": {
+    "summary": "Six machine-checked results (0 axioms, 0 sorries) for Erdős #866. The headline oddNumbers_no_ktuple promotes the parity obstruction to all k ≥ 3, establishing g_k(N) ≥ 1 for every k ≥ 3 (the companion proved only k = 3). The remaining results pin down the upper-bound exponent 1 − 2^{-k}: it lies in [0,1), is strictly increasing (full StrictMono), and converges to 1.",
+    "implications": "The lower bound g_k(N) ≥ 1 is now formalized at the full generality claimed for the problem, and the qualitative behaviour of the general upper exponent (sub-linear, monotone, limit 1) is recorded precisely. Together they fix the elementary envelope inside which the hard rates g_5 ≍ log N and g_6 ≍ √N live.",
+    "openQuestions": [
+      "What is the exact value of g_4(N)? Is it bounded by a constant?",
+      "What are the optimal constants in g_5(N) ≍ log N, and does g_5(N)/log N converge?",
+      "Can the gap between the upper exponent 1 − 2^{-k} and the true exponent α_k be closed for large k?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-866",
+      "relationship": "parent",
+      "description": "The main Erdős #866 pairwise-sums-threshold file, which defines the interval {1,…,2N}, the odd-number extremal set, the HasAllPairwiseSums predicate and the exponent 1 − 2^{-k}, and proves the k = 3 parity obstruction, the odd-count N, and the consecutive monotonicity of the exponent. This entry generalizes the parity obstruction to all k ≥ 3 and sharpens the exponent facts."
+    }
+  ]
+}


### PR DESCRIPTION
## Erdős #866 — pairwise-sums threshold

The companion `Erdos866Problem.lean` formalizes the parity obstruction behind the lower bound `g_k(N) ≥ 1` **only for `k = 3`** (`oddNumbers_no_triple`), even though the bound is claimed for all `k ≥ 3`. This PR closes that gap and records sharper facts about the general upper-bound exponent `1 − 2^{-k}`.

### New theorems (6, self-contained, 0 sorries, 0 axiom declarations)

- **`oddNumbers_no_ktuple`** — *the generalization*: for every `k ≥ 3`, no `k`-tuple of integers has all of its pairwise sums in the odd numbers of `{1,…,2N}`, i.e. **`g_k(N) ≥ 1` for all `k ≥ 3`**. Proof restricts an alleged `k`-tuple to its first three coordinates through the order-embedding `Fin.castLE` and applies the base case.
- `oddNumbers_no_triple` — self-contained re-proof of the `k = 3` base case (parity pigeonhole).
- `upperExponent_nonneg`, `upperExponent_lt_one` — the exponent `1 − 2^{-k} ∈ [0,1)`, so the upper bound `g_k(N) ≪ N^{1−2^{-k}}` is genuinely sub-linear for every `k`.
- `upperExponent_strictMono` — strict monotonicity as a full `StrictMono` (sharpening the companion's consecutive-step lemma).
- `upperExponent_tendsto_one` — the exponents converge to the limiting value `1`.

### Verification

`#print axioms` on all six theorems lists only `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`** → 0-axiom verified.

The Docker daemon was unresponsive this session, so the file was verified by direct `lean` v4.26.0 elaboration against the pinned prebuilt Mathlib oleans (exit 0, no errors).

### Honest scope

Only the settled shell of #866 — the lower bound `g_k(N) ≥ 1` and the `[0,1)`-boundedness/monotonicity/limit of the upper exponent. The open content (exact `g_4`, the `g_5 ≍ log N` and `g_6 ≍ √N` rates, the true exponent `α_k`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)