### PR TITLE
Enrich Sums of Two Triangular Numbers (4n+1 two-square slice)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "tri-defs",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 41, "endLine": 58 },
+    "type": "definition",
+    "title": "Triangular Numbers and Exact Halving",
+    "content": "`tri k = k(k+1)/2` is the k-th triangular number, and `IsSumTwoTriangular n` asserts n = T(a)+T(b) for some naturals a, b. The key technical lemma `two_mul_tri` records that the division by 2 is exact: 2·T(k) = k(k+1), because k(k+1) is always even (`Nat.even_mul_succ_self`). Working with the doubled quantity k(k+1) throughout avoids division entirely and is what keeps every later computation in ℤ clean.",
+    "mathContext": "$T(k)=\\binom{k+1}{2}=\\frac{k(k+1)}{2}$, and $2T(k)=k(k+1)$ exactly since one of $k,k+1$ is even.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangular numbers", "binomial coefficients", "parity", "exact division"],
+    "prerequisites": ["natural number arithmetic"]
+  },
+  {
+    "id": "negative-indices",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "lemma",
+    "title": "Negative Indices Give Nothing New: T(k) = T(−1−k)",
+    "content": "`exists_nat_tri_index` (and its doubled form `exists_nat_two_mul_tri`) show that for any *integer* index k, the value k(k+1) equals j(j+1) for some *natural* j. The symmetry T(k) = T(−1−k) means a negative integer index maps to the natural index −1−k. This is the lemma that lets the backward construction — which naturally produces integer indices p, q — land back inside the natural-number predicate `IsSumTwoTriangular`.",
+    "mathContext": "$k(k+1)=(-1-k)(-k)$, so $T(k)=T(-1-k)$; every integer triangular value is a natural triangular value. Witness: $j=k$ if $k\\ge 0$, else $j=-1-k$.",
+    "significance": "key",
+    "relatedConcepts": ["index symmetry", "integer-to-natural bridge", "Int.toNat"],
+    "prerequisites": ["integers", "casting ℤ↔ℕ"]
+  },
+  {
+    "id": "rotation-identity",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 74, "endLine": 80 },
+    "type": "lemma",
+    "title": "The Rotation Identity",
+    "content": "`sum_tri_identity`: the algebraic heart of the whole entry, 4·(T(a)+T(b))+1 = (a+b+1)² + (a−b)². This is a lattice rotation (a,b) ↦ (a+b+1, a−b) that converts a sum of two triangular numbers (scaled by 4 and shifted by 1) into a sum of two squares. The proof is a one-line `linear_combination` of the doubled-triangular identities. Reading it left-to-right is the forward direction; inverting the rotation is the backward direction.",
+    "mathContext": "$4\\bigl(T(a)+T(b)\\bigr)+1 = (a+b+1)^2 + (a-b)^2$. The map $(a,b)\\mapsto(a+b+1,\\,a-b)$ is a change of variables with constant Jacobian — a 'rotation' of the integer lattice.",
+    "significance": "critical",
+    "relatedConcepts": ["change of variables", "quadratic forms", "lattice rotation", "completing the square"],
+    "prerequisites": ["polynomial identities", "integer arithmetic"]
+  },
+  {
+    "id": "forward",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 82, "endLine": 90 },
+    "type": "theorem",
+    "title": "Forward Direction: Two Triangles ⟹ 4n+1 Two Squares",
+    "content": "`isSumTwoTriangular_to_sq`: if n = T(a)+T(b) then 4n+1 = (a+b+1)² + (a−b)² is visibly a sum of two integer squares. This is just the rotation identity read forward, with the explicit square roots X = a+b+1 and Y = a−b. No case analysis is needed in this direction.",
+    "mathContext": "$n=T(a)+T(b)\\ \\Rightarrow\\ 4n+1=(a+b+1)^2+(a-b)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["constructive proof", "explicit witness"],
+    "prerequisites": ["integer arithmetic"]
+  },
+  {
+    "id": "backward-parity",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 92, "endLine": 139 },
+    "type": "theorem",
+    "title": "Backward Direction: Division-Free Parity Inversion",
+    "content": "`sq_to_isSumTwoTriangular` inverts the rotation. Since 4n+1 ≡ 1 (mod 4), of the two squares X²+Y² exactly one is odd and one even — the two same-parity cases (both even ⟹ sum ≡ 0, both odd ⟹ sum ≡ 2) are dispatched as `4 ∣ 1` contradictions. Writing the even square as 2t and the odd as 2s+1, the inverse rotation p = s+t, q = s−t (integers, no halving) gives 2n = p(p+1)+q(q+1) via the `core_pq` lemma. Finally the integer indices p, q are pulled back to natural triangular numbers using T(k)=T(−1−k). The division-free design is what keeps the whole argument inside ℤ without parity-of-half headaches.",
+    "mathContext": "$4n+1\\equiv 1\\pmod 4$ forces one of $X,Y$ odd. With $X=2t,\\ Y=2s+1$, set $p=s+t,\\ q=s-t$: then $2n=p(p+1)+q(q+1)$, and each $p(p+1)/2$ is a natural triangular number.",
+    "significance": "critical",
+    "relatedConcepts": ["parity argument", "inverse change of variables", "modular obstruction", "case analysis"],
+    "prerequisites": ["modular arithmetic", "even and odd integers"]
+  },
+  {
+    "id": "main-iff",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 141, "endLine": 165 },
+    "type": "theorem",
+    "title": "Main Equivalence and Natural-Number Form",
+    "content": "`isSumTwoTriangular_iff` packages the two directions into the headline equivalence: n is a sum of two triangular numbers iff 4n+1 is a sum of two integer squares. `int_sq_iff_nat_sq` bridges integer squares to natural squares (the squares depend only on |X|, |Y|), and `isSumTwoTriangular_iff_nat` restates the result purely over ℕ: n = T(a)+T(b) iff 4n+1 = x²+y² for naturals x, y.",
+    "mathContext": "$n=T(a)+T(b)\\iff 4n+1=X^2+Y^2\\ (X,Y\\in\\mathbb Z)\\iff 4n+1=x^2+y^2\\ (x,y\\in\\mathbb N)$.",
+    "significance": "key",
+    "relatedConcepts": ["sum of two squares", "if and only if", "ℤ↔ℕ bridge"],
+    "prerequisites": ["sums of two squares"]
+  },
+  {
+    "id": "factorization",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
+    "range": { "startLine": 167, "endLine": 177 },
+    "type": "theorem",
+    "title": "Complete Arithmetic Characterization",
+    "content": "`isSumTwoTriangular_iff_factorization` composes the equivalence with Mathlib's two-square theorem (`Nat.eq_sq_add_sq_iff`): n is a sum of two triangular numbers iff every prime q ≡ 3 (mod 4) divides 4n+1 to an even power. Because the two-square theorem is fully in Mathlib (unlike three-square sufficiency), this is a *decidable* test — strictly stronger than the still-axiomatized Gauss Eureka companion. The docstring flags the trap that the naive 'no prime factor ≡ 3 (mod 4)' form is false: n = 2 = T₁+T₁ yet 4·2+1 = 9 = 3².",
+    "mathContext": "$n=T(a)+T(b)\\iff \\forall q\\equiv 3\\ (4),\\ q\\mid 4n+1\\Rightarrow \\operatorname{Even}\\bigl(v_q(4n+1)\\bigr)$. The 'no factor $\\equiv 3$' form fails: $9=3^2$ is a sum of two squares.",
+    "significance": "critical",
+    "relatedConcepts": ["two-square theorem", "p-adic valuation", "prime factorization", "decidability", "Fermat's Christmas theorem"],
+    "prerequisites": ["sum of two squares theorem", "prime factorization"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-02/meta.json
@@ -15,6 +15,45 @@
     "sorries": 0
   },
   "title": "Sums of Two Triangular Numbers and the 4n+1 Two-Square Slice",
+  "description": "The two-summand analogue of Gauss's Eureka theorem. For every natural number n, n is a sum of two triangular numbers T(k)=k(k+1)/2 if and only if 4n+1 is a sum of two integer squares — proved unconditionally and axiom-free via the rotation identity 4·(T(a)+T(b))+1 = (a+b+1)²+(a−b)². Composing with Mathlib's two-square theorem yields a complete, decidable arithmetic test: n is a sum of two triangular numbers iff every prime ≡ 3 (mod 4) divides 4n+1 to an even power.",
+  "overview": {
+    "historicalContext": "The interplay between polygonal numbers and sums of squares runs through the heart of classical number theory. Fermat's 'polygonal number theorem' (stated 1638, proved in special cases by Lagrange, Gauss, and Cauchy) asserts every natural number is a sum of m m-gonal numbers; Gauss's 1796 diary entry 'EΥΡΗΚΑ! num = Δ+Δ+Δ' records the triangular case, equivalent to Legendre's three-square theorem on the 8n+3 progression. The two-summand story told here is the cleaner sibling: sums of two triangular numbers correspond to sums of two squares on the 4n+1 progression. The two-square theorem itself — a prime is a sum of two squares iff it is 2 or ≡ 1 (mod 4), with the general characterization via even exponents of primes ≡ 3 (mod 4) — is Fermat's 'Christmas theorem' of 1640, first proved by Euler (1749). Because that theorem is fully formalized in Mathlib while three-square sufficiency is not, this entry is unconditional where the Gauss Eureka companion still rests on an axiom.",
+    "problemStatement": "Characterize the natural numbers expressible as a sum of two triangular numbers T(a)+T(b), T(k)=k(k+1)/2. Show (i) n = T(a)+T(b) iff 4n+1 is a sum of two integer (equivalently natural) squares, and (ii) the resulting complete arithmetic test: n is a sum of two triangular numbers iff every prime q ≡ 3 (mod 4) occurs to an even power in 4n+1.",
+    "proofStrategy": "The bridge is the rotation identity 4·(T(a)+T(b))+1 = (a+b+1)²+(a−b)², a unimodular change of variables (a,b) ↦ (a+b+1, a−b). Forward: read the identity left-to-right with explicit roots X = a+b+1, Y = a−b. Backward: 4n+1 ≡ 1 (mod 4) forces exactly one square odd; writing the even one 2t and the odd one 2s+1, the inverse rotation p = s+t, q = s−t gives 2n = p(p+1)+q(q+1) with NO division, and the symmetry T(k)=T(−1−k) pulls the integer indices back to natural triangular numbers. Composing the natural-number form with Mathlib's Nat.eq_sq_add_sq_iff delivers the prime-factorization test.",
+    "keyInsights": [
+      "Sums of two triangular numbers are exactly the 4n+1 arithmetic-progression slice of sums of two squares — the two-summand mirror of the three-triangular ⟺ 8n+3 three-square correspondence.",
+      "The whole correspondence is a single unimodular lattice rotation (a,b) ↦ (a+b+1, a−b); the forward and backward directions are just reading this map in the two directions, with parity selecting the valid inverse.",
+      "Designing the inverse with p = s+t, q = s−t keeps the entire argument division-free inside ℤ, sidestepping the 'half of an odd number' obstructions that plague naive triangular-number manipulations.",
+      "Because Mathlib has the two-square theorem (but not three-square sufficiency), this result is unconditional AND decidable, strictly stronger than the still-axiomatized Gauss Eureka companion it mirrors.",
+      "The characterization is genuinely subtle: the naive 'no prime factor ≡ 3 (mod 4)' criterion is FALSE — n = 2 = T₁+T₁ while 4·2+1 = 9 = 3² — the even-exponent condition is essential."
+    ]
+  },
+  "sections": [
+    {
+      "id": "triangular-setup",
+      "title": "Triangular Numbers and Index Symmetry",
+      "startLine": 41,
+      "endLine": 72,
+      "summary": "Defines tri k = k(k+1)/2 and IsSumTwoTriangular; establishes exact halving 2·T(k)=k(k+1) (two_mul_tri) and the symmetry T(k)=T(−1−k) (exists_nat_tri_index) that lets integer indices return to natural triangular numbers.",
+      "mathContext": "T(k)=k(k+1)/2 with 2T(k)=k(k+1) exact, and T(k)=T(−1−k)."
+    },
+    {
+      "id": "rotation",
+      "title": "The Rotation Identity and Both Directions",
+      "startLine": 74,
+      "endLine": 145,
+      "summary": "The identity 4·(T(a)+T(b))+1 = (a+b+1)²+(a−b)² (sum_tri_identity) drives the forward direction (isSumTwoTriangular_to_sq) and, via the division-free parity inversion core_pq, the backward direction (sq_to_isSumTwoTriangular), assembled into the main equivalence isSumTwoTriangular_iff.",
+      "mathContext": "n = T(a)+T(b) ⟺ 4n+1 = X²+Y² over ℤ, via the unimodular rotation (a,b)↦(a+b+1,a−b)."
+    },
+    {
+      "id": "characterization",
+      "title": "Natural-Number Form and Arithmetic Characterization",
+      "startLine": 147,
+      "endLine": 177,
+      "summary": "The int↔nat square bridge (int_sq_iff_nat_sq) gives the ℕ restatement isSumTwoTriangular_iff_nat, and composing with Mathlib's two-square theorem yields the decidable factorization test isSumTwoTriangular_iff_factorization.",
+      "mathContext": "n = T(a)+T(b) ⟺ every prime q ≡ 3 (mod 4) divides 4n+1 to an even power."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -89,12 +128,7 @@
     {
       "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-01",
       "relationship": "extends",
-      "description": "The two-summand analogue of the Gauss Eureka companion. Where that entry needs the still-open three-square sufficiency axiom to conclude unconditionally, this entry is fully unconditional and axiom-free because Mathlib supplies the two-square theorem, and it adds the complete arithmetic characterization via prime factorization of 4n+1."
-    },
-    {
-      "targetId": "lagrange-four-squares-waring-g2-oq-03",
-      "relationship": "depends-on",
-      "description": "Companion to the parent three-square sufficiency study: it records the elementary 4n+1 ⟷ two-triangular bijection in the same sums-of-squares ↔ triangular-numbers circle of ideas, using the (a,b)↦(a+b+1,a−b) rotation."
+      "description": "The two-summand analogue of the Gauss Eureka companion (three triangular ⟺ 8n+3 three squares). Where that entry needs the still-open three-square sufficiency axiom to conclude unconditionally, this entry is fully unconditional and axiom-free because Mathlib supplies the two-square theorem, and it adds the complete arithmetic characterization via prime factorization of 4n+1."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-02`.

## Gaps addressed
- **Missing `annotations.json`** — added 7 annotations with `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`, covering triangular setup & index symmetry, the rotation identity, the forward/backward (division-free parity) directions, the ℤ↔ℕ bridge, and the prime-factorization characterization.
- **No structured `overview`** — added `ProofOverview` with `historicalContext` (Gauss's 1796 EΥΡΗΚΑ diary entry, Fermat's Christmas theorem, Euler), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **No `sections`** — added 3 sections spanning the full Lean file.
- **Missing top-level `description`** — added one.
- **Dangling cross-reference** — removed the `depends-on` ref to `lagrange-four-squares-waring-g2-oq-03` (no such gallery entry); folded its content into the valid `-oq-01` (Gauss Eureka companion) reference.

## Verification
- JSON validated; `pnpm build` passes.
- Axiom/badge metadata unchanged and accurate: 0 axioms, 0 sorries, verified/original (unconditional via Mathlib's two-square theorem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)