### PR TITLE
research(algebraic-reals-meager-oq-02): measure vs category — comeagre ⇏ conull [0-axiom verified]

### DIFF
--- a/proofs/Proofs/AlgebraicRealsMeagerOQ02.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ02.lean
@@ -1,0 +1,177 @@
+import Mathlib
+
+/-
+  Measure versus Category: the algebraic reals are null, yet comeagreness
+  and conullness disagree
+  (algebraic-reals-meager — OQ-02)
+
+  The parent gallery entry ("The Algebraic Reals are Meagre") proves the
+  *topological* smallness of the algebraic reals: they are meagre (a
+  countable union of nowhere-dense sets), so the transcendentals are
+  comeagre (residual) and dense. This file develops the **measure-theoretic**
+  counterpart and pins down how the two notions of "size" relate.
+
+  ## The two notions of largeness
+
+  A subset of `ℝ` can be "large" in two independent senses:
+  - **topologically large** = *comeagre* (residual): its complement is meagre;
+  - **measure-theoretically large** = *conull*: its complement is Lebesgue-null.
+
+  For the algebraic / transcendental dichotomy the two notions agree and
+  reinforce each other:
+
+  - `algebraicReals_null`     : the algebraic reals are Lebesgue-null
+                                (measure counterpart of the parent's
+                                 meagreness);
+  - `ae_transcendental`       : almost every real is transcendental
+                                (the transcendentals are conull — measure
+                                 large — matching the parent's "comeagre").
+
+  But the two notions are *not equivalent*. The Liouville numbers are the
+  classical separating example:
+
+  - `liouville_residual`      : the Liouville numbers are comeagre
+                                (topologically large);
+  - `liouville_null`          : the Liouville numbers are Lebesgue-null
+                                (measure-theoretically small);
+  - `exists_residual_dense_null` (**headline**): there is a dense, comeagre
+                                subset of `ℝ` of measure zero. Hence
+                                *comeagre does not imply conull*: topological
+                                largeness and measure largeness are genuinely
+                                independent.
+
+  The abstract reason behind the separation is the orthogonality of the two
+  σ-ideals on `ℝ`:
+
+  - `residual_ae_disjoint`    : `Disjoint (residual ℝ) (ae volume)` — a set
+                                cannot be simultaneously "comeagre-large" and
+                                "null-large" as filters; the comeagre filter
+                                and the a.e. filter share no nontrivial set.
+
+  ## Honesty / novelty
+
+  All ingredients are already in Mathlib (`Algebraic.countable`,
+  `Set.Countable.measure_zero`, `eventually_residual_liouville`,
+  `volume_setOf_liouville`, `Real.disjoint_residual_ae`). The contribution
+  of this entry is the *synthesis*: it assembles the measure side of the
+  parent's category result and exhibits the sharp-boundary phenomenon —
+  comeagre ⇏ conull, witnessed concretely by the Liouville numbers — which
+  the parent (a purely Baire-category entry) does not record. There is no new
+  mathematics here; the value is the explicit, machine-checked statement of
+  the measure/category contrast.
+
+  No new axioms (standard Mathlib triple inherited).
+
+  References:
+  - Oxtoby, J.C. (1980). "Measure and Category", Springer GTM 2 (the
+    measure/category duality and the role of Liouville numbers).
+  - Mathlib: NumberTheory.Transcendental.Liouville.{Residual,Measure},
+             Algebra.AlgebraicCard.
+
+  Tags: measure-theory, baire-category, liouville-numbers, residual,
+        transcendental-numbers, lebesgue-measure, sharp-boundary
+-/
+
+set_option maxHeartbeats 400000
+
+namespace AlgebraicRealsMeagerOQ02
+
+open MeasureTheory Filter
+
+-- ============================================================================
+-- Part I: the measure side of the parent's meagreness result
+-- ============================================================================
+
+/-- **The algebraic reals are Lebesgue-null.** Being countable
+    (`Algebraic.countable`), the algebraic reals carry no Lebesgue mass, since
+    `volume` has no atoms. This is the measure-theoretic counterpart of the
+    parent's "the algebraic reals are meagre". -/
+theorem algebraicReals_null : volume {x : ℝ | IsAlgebraic ℚ x} = 0 :=
+  (Algebraic.countable ℚ ℝ).measure_zero volume
+
+/-- **Almost every real is transcendental.** Equivalently, the transcendentals
+    are conull (measure-theoretically large), matching the parent's result
+    that they are comeagre. -/
+theorem ae_transcendental : ∀ᵐ x : ℝ, ¬ IsAlgebraic ℚ x := by
+  filter_upwards [compl_mem_ae_iff.mpr algebraicReals_null] with x hx
+  exact hx
+
+-- ============================================================================
+-- Part II: Liouville numbers — comeagre yet null
+-- ============================================================================
+
+/-- The Liouville numbers are comeagre (residual) in `ℝ`. -/
+theorem liouville_residual : {x : ℝ | Liouville x} ∈ residual ℝ :=
+  eventually_residual_liouville
+
+/-- The Liouville numbers are dense in `ℝ`. -/
+theorem liouville_dense : Dense {x : ℝ | Liouville x} :=
+  dense_liouville
+
+/-- The Liouville numbers are Lebesgue-null. -/
+theorem liouville_null : volume {x : ℝ | Liouville x} = 0 :=
+  volume_setOf_liouville
+
+-- ============================================================================
+-- Part III: the sharp boundary — comeagre does not imply conull
+-- ============================================================================
+
+/-- **Comeagre ⇏ conull.** There is a dense, comeagre (residual) subset of `ℝ`
+    that nevertheless has Lebesgue measure zero. The Liouville numbers witness
+    it: topological largeness and measure-theoretic largeness are genuinely
+    independent notions of "size". -/
+theorem exists_residual_dense_null :
+    ∃ S : Set ℝ, S ∈ residual ℝ ∧ Dense S ∧ volume S = 0 :=
+  ⟨{x : ℝ | Liouville x}, liouville_residual, liouville_dense, liouville_null⟩
+
+/-- **Orthogonality of the two ideals.** On `ℝ` the comeagre filter
+    `residual ℝ` and the almost-everywhere filter `ae volume` are disjoint:
+    no nontrivial set is both comeagre and conull-detected by the same filter.
+    This is the abstract reason a single set can be comeagre while its
+    complement is conull (as for the Liouville numbers and their complement). -/
+theorem residual_ae_disjoint : Disjoint (residual ℝ) (ae volume) :=
+  Real.disjoint_residual_ae
+
+-- ============================================================================
+-- Part IV: OQ-02 resolution
+-- ============================================================================
+
+/-- **OQ-02 resolution.** The measure-theoretic counterpart to the parent's
+    category result, together with the sharp-boundary phenomenon:
+
+    (1) the algebraic reals are Lebesgue-null (so the transcendentals are
+        conull, mirroring "the transcendentals are comeagre"), and
+    (2) comeagreness and conullness are nevertheless independent — there is a
+        dense comeagre set (the Liouville numbers) of measure zero. -/
+theorem oq02_resolution :
+    volume {x : ℝ | IsAlgebraic ℚ x} = 0 ∧
+    (∃ S : Set ℝ, S ∈ residual ℝ ∧ Dense S ∧ volume S = 0) :=
+  ⟨algebraicReals_null, exists_residual_dense_null⟩
+
+#check @algebraicReals_null
+#check @ae_transcendental
+#check @liouville_residual
+#check @liouville_null
+#check @exists_residual_dense_null
+#check @residual_ae_disjoint
+#check @oq02_resolution
+
+/-
+  ## Results Summary
+
+  | Theorem | Statement | Status |
+  |---------|-----------|--------|
+  | `algebraicReals_null` | algebraic reals are Lebesgue-null | Proved |
+  | `ae_transcendental` | a.e. real is transcendental | Proved |
+  | `liouville_residual` | Liouville numbers comeagre | Proved (Mathlib) |
+  | `liouville_dense` | Liouville numbers dense | Proved (Mathlib) |
+  | `liouville_null` | Liouville numbers Lebesgue-null | Proved (Mathlib) |
+  | `exists_residual_dense_null` | ∃ dense comeagre null set (comeagre ⇏ conull) | Proved |
+  | `residual_ae_disjoint` | `Disjoint (residual ℝ) (ae volume)` | Proved (Mathlib) |
+  | `oq02_resolution` | measure side + sharp boundary | Proved |
+
+  **Sorries**: 0
+  **Axioms**: 0 declared (Mathlib triple inherited)
+-/
+
+end AlgebraicRealsMeagerOQ02

--- a/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "algebraic-reals-meager-oq-02",
+  "title": "Measure versus Category: comeagre does not imply conull",
+  "slug": "algebraic-reals-meager-oq-02",
+  "description": "Develops the measure-theoretic counterpart of the parent's Baire-category result. The algebraic reals, being countable, are Lebesgue-null, so almost every real is transcendental — mirroring the parent's 'the transcendentals are comeagre'. But the two notions of largeness are independent: the Liouville numbers are a dense, comeagre (residual) set of Lebesgue measure zero, witnessing that comeagre does not imply conull. The abstract reason is the disjointness of the comeagre filter and the a.e. filter on ℝ, Disjoint (residual ℝ) (ae volume).",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Meagre_set",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerOQ02.lean",
+    "tags": [
+      "measure-theory",
+      "baire-category",
+      "liouville-numbers",
+      "residual",
+      "transcendental-numbers",
+      "lebesgue-measure",
+      "real-analysis",
+      "sharp-boundary"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Algebraic.countable",
+        "description": "The algebraic elements over a countable ring form a countable set",
+        "module": "Mathlib.Algebra.AlgebraicCard"
+      },
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "A countable set has measure zero under any atomless measure",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "eventually_residual_liouville",
+        "description": "The set of Liouville numbers is residual (comeagre)",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "dense_liouville",
+        "description": "The set of Liouville numbers is dense in ℝ",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Residual"
+      },
+      {
+        "theorem": "volume_setOf_liouville",
+        "description": "The set of Liouville numbers has Lebesgue measure zero",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "Real.disjoint_residual_ae",
+        "description": "On ℝ the comeagre filter and the a.e. filter are disjoint",
+        "module": "Mathlib.NumberTheory.Transcendental.Liouville.Measure"
+      },
+      {
+        "theorem": "compl_mem_ae_iff",
+        "description": "sᶜ ∈ ae μ ↔ μ s = 0",
+        "module": "Mathlib.MeasureTheory.OuterMeasure.AE"
+      }
+    ],
+    "originalContributions": [
+      "algebraicReals_null: PROVED the algebraic reals {x : ℝ | IsAlgebraic ℚ x} are Lebesgue-null — the measure counterpart of the parent's meagreness, via countability + atomless volume",
+      "ae_transcendental: PROVED almost every real is transcendental (the transcendentals are conull), the measure-theoretic mirror of the parent's 'transcendentals are comeagre'",
+      "exists_residual_dense_null: PROVED there is a dense, comeagre subset of ℝ of measure zero (the Liouville numbers) — the headline sharp-boundary fact that comeagre does NOT imply conull",
+      "oq02_resolution: packaged statement combining the measure side with the comeagre-vs-conull independence",
+      "Synthesis (no new mathematics): assembles Mathlib's Algebraic.countable, the Liouville residual/measure-zero results, and the residual/ae disjointness into the explicit measure-versus-category contrast that the parent (a purely Baire-category entry) records only in prose"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Lebesgue measure on ℝ; atomless (NoAtoms) measures; the a.e. filter",
+      "Baire category: meagre / residual (comeagre) sets",
+      "Liouville numbers: residual, dense, and Lebesgue-null",
+      "Countability of the algebraic reals (Algebraic.countable)"
+    ],
+    "lineCount": 175,
+    "relatedProblems": [
+      {
+        "id": "algebraic-reals-meager",
+        "relationship": "Parent: the Baire-category (topological) smallness of the algebraic reals; this entry supplies the measure-theoretic side and the comeagre-vs-conull sharp boundary the parent only mentions in prose"
+      },
+      {
+        "id": "algebraic-numbers-countable",
+        "relationship": "Grandparent: the algebraic reals are countable (the countability input used to derive Lebesgue-nullity)"
+      }
+    ],
+    "assumptions": "0 axioms. Relies only on Mathlib's measure-theory and Baire-category infrastructure, the Liouville residual/measure-zero results, and the countability of the algebraic reals.",
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Cantor (1874) showed the algebraic reals are countable and ℝ uncountable, so transcendentals exist by a cardinality gap. Lebesgue's measure theory and Baire's category theorem (1899) supply two further, independent notions of 'smallness': a set can be Lebesgue-null (measure-small) or meagre (category-small). The parent entry formalized the category side — the algebraic reals are meagre, the transcendentals comeagre. Oxtoby's 'Measure and Category' (1980) is the classic account of how these two notions interact: they agree for the algebraic/transcendental split but diverge for the Liouville numbers, which are comeagre yet null. This entry formalizes that contrast.",
+    "problemStatement": "Formalize the measure-theoretic counterpart of the parent's Baire-category result — that the algebraic reals are Lebesgue-null, hence almost every real is transcendental — and exhibit the sharp boundary that topological largeness (comeagre) and measure largeness (conull) are independent, witnessed by the Liouville numbers.",
+    "text": "A 0-sorry, 0-axiom synthesis. The algebraic reals are null because they are countable and Lebesgue measure is atomless; equivalently almost every real is transcendental. The Liouville numbers are then exhibited as a dense, comeagre set of measure zero, so comeagreness does not imply conullness — the two ideals of 'small' sets are different. The abstract reason is recorded as the disjointness of the comeagre filter residual ℝ and the a.e. filter ae volume.",
+    "proofStrategy": "Lebesgue-nullity of the algebraic reals follows from Algebraic.countable and Set.Countable.measure_zero (volume is atomless). Conullity of the transcendentals (ae_transcendental) is the complement form via compl_mem_ae_iff. The sharp-boundary witness packages the Mathlib facts eventually_residual_liouville, dense_liouville, and volume_setOf_liouville into a single existential. The orthogonality of the two notions is Real.disjoint_residual_ae.",
+    "keyInsights": [
+      "**Measure mirrors category for transcendentals**: the algebraic reals are Lebesgue-null exactly as they are meagre, so 'almost every real is transcendental' holds in BOTH the measure and the category sense.",
+      "**But the two senses are independent**: the Liouville numbers are comeagre and dense yet have measure zero. Topological largeness does not entail measure largeness — comeagre ⇏ conull.",
+      "**The Liouville numbers are the canonical separating example**: explicit transcendentals that are category-large but measure-small, dual to the parent's transcendentals which are large in every sense.",
+      "**Orthogonal σ-ideals**: Disjoint (residual ℝ) (ae volume) is the abstract statement that the comeagre filter and the a.e. filter detect no common nontrivial set, the structural reason a single set can be comeagre while its complement is conull.",
+      "**Honest scope**: every ingredient is already in Mathlib; the contribution is the explicit, machine-checked synthesis of the measure/category contrast that the parent entry leaves in prose."
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℝ and atomless (NoAtoms) measures",
+      "Baire category: meagre and residual (comeagre) sets",
+      "Liouville numbers and their residual / measure-zero properties",
+      "Countability of algebraic elements over ℚ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: Measure versus Category",
+      "startLine": 1,
+      "endLine": 78,
+      "summary": "File docstring and imports. Frames the two independent notions of largeness — comeagre (topological) and conull (measure-theoretic) — explains that they agree for the algebraic/transcendental split but diverge for the Liouville numbers, and previews the headline that comeagre does not imply conull.",
+      "mathContext": "A set is comeagre (residual) if its complement is meagre; conull if its complement is Lebesgue-null. These are distinct σ-ideals on ℝ."
+    },
+    {
+      "id": "measure-side",
+      "title": "The measure side of meagreness",
+      "startLine": 79,
+      "endLine": 100,
+      "summary": "Proves the algebraic reals are Lebesgue-null (countable + atomless volume) and the equivalent statement that almost every real is transcendental.",
+      "mathContext": "A countable set has measure zero under any atomless measure; the transcendentals are the conull complement."
+    },
+    {
+      "id": "liouville",
+      "title": "Liouville numbers: comeagre yet null",
+      "startLine": 101,
+      "endLine": 120,
+      "summary": "Records the three Liouville facts used as the separating witness: residual, dense, and Lebesgue-null.",
+      "mathContext": "The Liouville numbers form a dense Gδ (hence comeagre) of measure zero."
+    },
+    {
+      "id": "sharp-boundary",
+      "title": "Comeagre does not imply conull",
+      "startLine": 121,
+      "endLine": 175,
+      "summary": "The headline existential — a dense comeagre set of measure zero — and the abstract disjointness of the comeagre and a.e. filters, packaged with the measure side as the OQ-02 resolution.",
+      "mathContext": "Disjoint (residual ℝ) (ae volume): topological and measure-theoretic largeness are independent."
+    }
+  ],
+  "references": [
+    {
+      "title": "Measure and Category (Oxtoby, GTM 2)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4684-9339-9"
+    },
+    {
+      "title": "Liouville number — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Liouville_number"
+    },
+    {
+      "title": "Meagre set — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Meagre_set"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": "The algebraic reals are small and the transcendentals large in the measure sense exactly as in the category sense — but the two senses are not interchangeable. The Liouville numbers are a dense, comeagre set of Lebesgue measure zero, so comeagre does not imply conull; the comeagre filter and the a.e. filter on ℝ are disjoint. This formalizes, with zero axioms, the measure-versus-category contrast that the parent Baire-category entry records only informally.",
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

A child of **algebraic-reals-meager** (OQ-02). The parent proves the *topological* (Baire-category) smallness of the algebraic reals; this entry develops the **measure-theoretic counterpart** and pins down the sharp boundary between the two notions of largeness.

### Theorems (7, 0 sorries, 0 axioms)
- `algebraicReals_null` — the algebraic reals are Lebesgue-null (countable + atomless `volume`), the measure mirror of the parent's meagreness.
- `ae_transcendental` — almost every real is transcendental (transcendentals conull), mirroring the parent's "transcendentals comeagre".
- `liouville_residual` / `liouville_dense` / `liouville_null` — the Liouville numbers are comeagre, dense, and Lebesgue-null.
- **`exists_residual_dense_null`** (headline) — there is a dense, comeagre set of measure zero, so **comeagre ⇏ conull**: topological and measure largeness are independent.
- `residual_ae_disjoint` — `Disjoint (residual ℝ) (ae volume)`, the abstract orthogonality of the two filters.

### Verification
- Single-file elaboration against prebuilt **Mathlib 4.26.0** oleans (Docker fleet was contended).
- `#print axioms` on the headline theorems → `[propext, Classical.choice, Quot.sound]` only. **No `sorryAx`, no `Lean.ofReduceBool`/`native_decide`.** → `axiomCount: 0`, `status: verified`.

### Honesty / scope
All ingredients already exist in Mathlib (`Algebraic.countable`, the Liouville residual/measure-zero results, `Real.disjoint_residual_ae`). The contribution is the **synthesis** — the explicit, machine-checked measure-versus-category contrast that the parent (a purely Baire-category entry) records only in prose. Badged **`mathlib`** accordingly; not claimed as new mathematics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)