### PR TITLE
Audit: area-of-circle Gaussian-Fourier pair badge original→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03-oq-01/meta.json
@@ -17,10 +17,22 @@
       "complex-analysis",
       "probability"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 242,
+    "mathlibDependencies": [
+      {
+        "theorem": "GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
+        "description": "∫ e^{-b x² + (real linear)·x} dx in closed form (vertical-strip shift of the complex Gaussian integral). The engine behind gaussian_fourier_param/gaussian_fourier_dilated — the parametrized dilation law is obtained by completing the square and applying this Mathlib theorem at width b = 1/(2σ²).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform"
+      },
+      {
+        "theorem": "MeasureTheory.integral_mul_const / MeasureTheory.integral_div",
+        "description": "Pull the constant Fourier factor and the normalizing density constant out of the Lebesgue integral when passing to the normalized dilation identity.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+      }
+    ],
     "assumptions": "0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound). Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). The width parameter is a genuine real σ>0, so the result is the full dilation group, not a single instance.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-21",

--- a/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-03/meta.json
@@ -16,10 +16,22 @@
       "complex-analysis",
       "probability"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 172,
+    "mathlibDependencies": [
+      {
+        "theorem": "GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I",
+        "description": "∫ e^{-b x² + (real linear)·x} dx in closed form (vertical-strip shift of the complex Gaussian integral). The engine behind gaussian_fourier_real — the self-Fourier identity of the Gaussian is obtained by completing the square and applying this Mathlib theorem.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform"
+      },
+      {
+        "theorem": "MeasureTheory.integral_mul_const / MeasureTheory.integral_div",
+        "description": "Pull the constant e^{-t²/2} factor and the normalizing 1/√(2π) out of the Lebesgue integral to pass from the un-normalized to the normalized Fourier identity.",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner"
+      }
+    ],
     "assumptions": "0 axioms, 0 sorries. Builds on Mathlib's Gaussian Fourier transform infrastructure (GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I — the vertical-strip shift of the real Gaussian integral). HONEST SCOPE: CentralLimitTheorem.lean states its gaussian_fourier_identity against an abstract stdGaussian measure introduced by `axiom`; this file proves the full mathematical content as a concrete Lebesgue integral, but discharging that particular CLT axiom additionally requires replacing the abstract measure by ProbabilityTheory.gaussianReal 0 1, a separate bridge not attempted here.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-21",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proofs**:
- area-of-circle-oq-05-oq-03 — "The Gaussian is its own Fourier Transform"
- area-of-circle-oq-05-oq-03-oq-01 — "The Gaussian Dilation Law and the Uncertainty Duality of the Fourier Transform"

**Severity**: MEDIUM (Mathlib wrapper claimed as `original` + empty dependency disclosure)

## Evidence

Both files obtain their headline Fourier identities from Mathlib's `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I`:

```lean
-- oq-05-oq-03
theorem gaussian_fourier_real (t : ℝ) := by
  simp_rw [gaussian_integrand_complete_square t]
  rw [MeasureTheory.integral_mul_const]
  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I (b := ...) ... (-t)]
  ...

-- oq-05-oq-03-oq-01
theorem gaussian_fourier_param (b t : ℝ) (hb : 0 < b) := by
  ...
  rw [GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I ...]
```

The self-Fourier / dilation muscle — the only deep analytic content — is entirely Mathlib's. The files complete the square and rescale. Both `assumptions` fields already state they "build on Mathlib's Gaussian Fourier transform infrastructure", but the badge was `original` and `mathlibDependencies` was **empty `[]`** — a disclosure gap plus a Tier B overclaim.

## Fix

For both entries:
- `badge`: `original` → `mathlib`
- `mathlibDependencies`: `[]` → `GaussianFourier.integral_cexp_neg_mul_sq_add_real_mul_I` + `integral_mul_const`/`integral_div`
- `status`: stays `verified` (fully machine-checked, 0 sorries, 0 axioms)

The complete-the-square lemmas, dilation law, uncertainty duality, and width-product remain genuine infrastructure and stay credited in the descriptions.

---
Discovered during gallery integrity audit — recurrent area-of-circle Gaussian-lineage Tier B pattern (cf. companion PR for `area-of-circle-oq-05-incomplete-01` / `integral_gaussian`).