### PR TITLE
research(erdos-1054-construction-d-oq-02): sharp boundary — 2 is not representable, yet representable set is infinite [0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos1054ConstructionDOQ02.lean
+++ b/proofs/Proofs/Erdos1054ConstructionDOQ02.lean
@@ -1,0 +1,243 @@
+/-
+Erdős Problem #1054: Construction D — OQ-02
+
+## A sharp boundary for divisor-partial-sum representability
+
+The parent file `Erdos1054ConstructionD` (and its OQ-01 follow-up) prove that various
+families of numbers are *representable* — `n` is representable if it occurs as a partial
+sum of the increasingly-sorted divisor list of some `m ≥ 1`.  Those results only ever
+exhibit numbers that **are** representable (e.g. `σ(m)`, the prime-power geometric sums
+`1 + p + ⋯ + pᵏ`, the Mersenne numbers).
+
+This file complements that one-sided picture with the **two opposite extremes**:
+
+> **Lower boundary.** `2` is *not* representable: it is the smallest positive integer
+> that never appears as a divisor partial sum.  (Indeed the only partial sum below `3`
+> is the first one, which is always `1`.)
+>
+> **Upper boundary.** The set of representable numbers is nonetheless **infinite** — in
+> fact unbounded above — because `p + 1 = σ(p)` is representable for every prime `p`.
+
+Together these say representability is a *proper, infinite* subset of `ℕ`: not everything
+is representable (`2` is a witness), yet representable numbers grow without bound.
+
+The lower boundary rests on a small new monotonicity fact, `le_of_mem_scanl_add`: over `ℕ`
+every entry of `scanl (·+·) b L` is `≥ b`, because addition only increases the running
+total.  Combined with `1` being the smallest divisor and the second-smallest divisor being
+`≥ 2`, this forces every partial sum to be `1` or `≥ 3`.
+
+All results are `Lean.ofReduceBool`-free (no `native_decide`).
+
+## Results
+- `le_of_mem_scanl_add`        — every entry of `scanl (+) b L` over `ℕ` is `≥ b`  (new core)
+- `two_not_representable`      — `¬ IsRepresentable 2`  (sharp lower boundary, headline)
+- `succ_prime_representable`   — `p + 1 = σ(p)` is representable for every prime `p`
+- `representable_unbounded`    — representable numbers are unbounded above
+- `representable_infinite`     — `{n | IsRepresentable n}` is infinite  (headline)
+- `one_representable`          — `1` is representable (the smallest such)
+- `three_representable`, `four_representable` — concrete witnesses `σ(2)`, `σ(3)`
+-/
+
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Data.Finset.Sort
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+
+open Nat Finset
+
+namespace Erdos1054ConstructionDOQ02
+
+-- ============================================================
+-- Definitions (mirrored from `Erdos1054ConstructionD`; we avoid `native_decide`
+-- throughout, keeping every result `Lean.ofReduceBool`-free).
+-- ============================================================
+
+/-- The divisors of `m`, listed in increasing order. -/
+def sortedDivisors (m : ℕ) : List ℕ :=
+  m.divisors.sort (· ≤ ·)
+
+/-- The running (cumulative) sums of the sorted divisors of `m`. -/
+def partialDivisorSums (m : ℕ) : List ℕ :=
+  ((sortedDivisors m).scanl (· + ·) 0).tail
+
+/-- `n` is *representable* if it occurs as a partial divisor sum of some `m ≥ 1`. -/
+def IsRepresentable (n : ℕ) : Prop :=
+  ∃ m : ℕ, m ≥ 1 ∧ n ∈ (partialDivisorSums m)
+
+-- ============================================================
+-- Part 0: List-folding / scanning helpers
+-- ============================================================
+
+/--
+Folding addition over a list with an arbitrary starting accumulator `a`
+just adds `a` to the list's sum.
+-/
+theorem foldl_add_acc (a : ℕ) (L : List ℕ) : L.foldl (· + ·) a = a + L.sum := by
+  induction L generalizing a with
+  | nil => simp
+  | cons x xs ih => rw [List.foldl_cons, ih, List.sum_cons]; ring
+
+/--
+**New core monotonicity lemma.** Over `ℕ`, every entry of the running-sum list
+`scanl (·+·) b L` is at least the initial accumulator `b`: scanning by addition can
+only increase the running total.
+-/
+theorem le_of_mem_scanl_add (b : ℕ) (L : List ℕ) :
+    ∀ x ∈ List.scanl (· + ·) b L, b ≤ x := by
+  induction L generalizing b with
+  | nil => intro x hx; rw [List.scanl_nil, List.mem_singleton] at hx; omega
+  | cons a as ih =>
+    intro x hx
+    rw [List.scanl_cons, List.mem_cons] at hx
+    rcases hx with h | h
+    · omega
+    · have := ih (b + a) x h; omega
+
+-- ============================================================
+-- Part 1: The σ(m) machinery (ported, axiom-free) — gives the upper boundary
+-- ============================================================
+
+/-- The sum of the sorted divisor list of `m` is the sum-of-divisors function `σ(m)`. -/
+theorem sortedDivisors_sum (m : ℕ) :
+    (sortedDivisors m).sum = ∑ d ∈ m.divisors, d := by
+  rw [sortedDivisors, (Finset.sort_perm_toList _ _).sum_eq, Finset.sum_toList]
+
+/-- For every `m ≥ 1`, `σ(m)` occurs as the final divisor partial sum of `m`. -/
+theorem sum_divisors_mem_partialSums (m : ℕ) (hm : 1 ≤ m) :
+    (∑ d ∈ m.divisors, d) ∈ partialDivisorSums m := by
+  rw [← sortedDivisors_sum]
+  obtain ⟨a, l, hal⟩ : ∃ a l, sortedDivisors m = a :: l := by
+    rcases h : sortedDivisors m with _ | ⟨a, l⟩
+    · exfalso
+      have hlen : (sortedDivisors m).length = m.divisors.card := by
+        rw [sortedDivisors, Finset.length_sort]
+      rw [h, List.length_nil] at hlen
+      have h1 : (1 : ℕ) ∈ m.divisors := Nat.one_mem_divisors.mpr (by omega)
+      have := Finset.card_pos.mpr ⟨1, h1⟩
+      omega
+    · exact ⟨a, l, rfl⟩
+  unfold partialDivisorSums
+  rw [hal, List.scanl_cons, List.tail_cons]
+  have hne : List.scanl (· + ·) (0 + a) l ≠ [] := List.scanl_ne_nil
+  have hmem := List.getLast_mem hne
+  rw [List.getLast_scanl hne] at hmem
+  have hval : List.foldl (· + ·) (0 + a) l = (a :: l).sum := by
+    rw [foldl_add_acc, List.sum_cons]; ring
+  rwa [hval] at hmem
+
+/-- **σ representability.** `σ(m)` is representable for every `m ≥ 1`. -/
+theorem sum_divisors_representable (m : ℕ) (hm : 1 ≤ m) :
+    IsRepresentable (∑ d ∈ m.divisors, d) :=
+  ⟨m, hm, sum_divisors_mem_partialSums m hm⟩
+
+/-- The geometric sum `∑_{i=0}^{k} p^i = σ(pᵏ)` is representable for every prime `p`. -/
+theorem geom_sum_representable (p k : ℕ) (hp : p.Prime) :
+    IsRepresentable (∑ i ∈ Finset.range (k + 1), p ^ i) := by
+  have hpk : 1 ≤ p ^ k := Nat.one_le_iff_ne_zero.mpr (pow_ne_zero k hp.pos.ne')
+  have h := sum_divisors_representable (p ^ k) hpk
+  rwa [Nat.sum_divisors_prime_pow (f := fun x => x) hp] at h
+
+-- ============================================================
+-- Part 2: Upper boundary — representable numbers are unbounded / infinite
+-- ============================================================
+
+/--
+For every prime `p`, the successor `p + 1 = σ(p)` is representable.  This is the
+`k = 1` instance of `geom_sum_representable` (`∑_{i=0}^{1} p^i = 1 + p`).
+-/
+theorem succ_prime_representable {p : ℕ} (hp : p.Prime) : IsRepresentable (p + 1) := by
+  have h := geom_sum_representable p 1 hp
+  have hval : (∑ i ∈ Finset.range (1 + 1), p ^ i) = p + 1 := by
+    rw [Finset.sum_range_succ, Finset.sum_range_one, pow_zero, pow_one]; ring
+  rwa [hval] at h
+
+/--
+**Upper boundary.** The representable numbers are unbounded above: beyond any `N` there is
+a representable number, namely `p + 1` for a prime `p > N`.
+-/
+theorem representable_unbounded (N : ℕ) : ∃ n, N < n ∧ IsRepresentable n := by
+  obtain ⟨p, hp, hpp⟩ := Nat.exists_infinite_primes (N + 1)
+  exact ⟨p + 1, by omega, succ_prime_representable hpp⟩
+
+/--
+**Headline (upper boundary).** The set of representable numbers is infinite: it cannot be
+finite, since a finite set of naturals is bounded above but representable numbers are not.
+-/
+theorem representable_infinite : {n | IsRepresentable n}.Infinite := by
+  intro hfin
+  obtain ⟨N, hN⟩ := hfin.bddAbove
+  obtain ⟨n, hn, hrep⟩ := representable_unbounded N
+  have : n ≤ N := hN hrep
+  omega
+
+-- ============================================================
+-- Part 3: Lower boundary — 2 is not representable
+-- ============================================================
+
+/--
+**Headline (lower boundary).** `2` is *not* representable: it never appears as a divisor
+partial sum.  The first partial sum of any `m` is its smallest divisor `1`; every later
+partial sum already includes the second-smallest divisor `≥ 2`, hence is `≥ 1 + 2 = 3`.
+So no partial sum equals `2`.
+-/
+theorem two_not_representable : ¬ IsRepresentable 2 := by
+  rintro ⟨m, hm, hmem⟩
+  -- Standing facts about the sorted divisor list of `m`.
+  have h1S : (1 : ℕ) ∈ sortedDivisors m :=
+    (Finset.mem_sort _).mpr (Nat.one_mem_divisors.mpr (by omega))
+  have hsorted : List.Pairwise (· ≤ ·) (sortedDivisors m) := Finset.pairwise_sort m.divisors (· ≤ ·)
+  have hnodup : (sortedDivisors m).Nodup := Finset.sort_nodup _ _
+  have hmemS : ∀ x ∈ sortedDivisors m, x ∈ m.divisors :=
+    fun x hx => (Finset.mem_sort _).mp hx
+  -- Split on the shape of the sorted divisor list.
+  rcases hS : sortedDivisors m with _ | ⟨a, _ | ⟨b, rest⟩⟩
+  · -- empty: there are no partial sums at all
+    rw [hS] at h1S; simp at h1S
+  · -- single divisor `[a]`: the only partial sum is `a`, and `a = 1`
+    rw [hS] at h1S; rw [List.mem_singleton] at h1S
+    unfold partialDivisorSums at hmem
+    rw [hS, List.scanl_cons, List.tail_cons, List.scanl_nil, List.mem_singleton] at hmem
+    omega
+  · -- two or more divisors `a :: b :: rest`
+    rw [hS] at h1S hsorted hnodup
+    obtain ⟨hall, _⟩ := List.pairwise_cons.mp hsorted
+    -- `a = 1`: `a` is a positive divisor and `a ≤ 1` since `1` is in the list
+    have haDiv : a ∈ m.divisors := hmemS a (by rw [hS]; exact List.mem_cons_self)
+    have hapos : 1 ≤ a := Nat.pos_of_mem_divisors haDiv
+    have hle1 : a ≤ 1 := by
+      rcases List.mem_cons.mp h1S with h | h
+      · omega
+      · exact hall 1 h
+    have ha1 : a = 1 := by omega
+    -- `b ≥ 2`: `a ≤ b` and `a ≠ b` (nodup), with `a = 1`
+    have hab : a ≤ b := hall b (List.mem_cons_self)
+    have hanb : a ≠ b := by
+      intro h
+      exact (List.nodup_cons.mp hnodup).1 (by rw [h]; exact List.mem_cons_self)
+    have hb2 : 2 ≤ b := by omega
+    -- The partial sums of `m` are exactly `scanl (+) (0+a) (b :: rest)`.
+    unfold partialDivisorSums at hmem
+    rw [hS, List.scanl_cons, List.tail_cons, List.scanl_cons, List.mem_cons] at hmem
+    rcases hmem with h | h
+    · omega
+    · have := le_of_mem_scanl_add (0 + a + b) rest 2 h
+      omega
+
+-- ============================================================
+-- Part 4: Concrete witnesses at the boundary
+-- ============================================================
+
+/-- `1 = σ(1)` is representable — the smallest representable number. -/
+theorem one_representable : IsRepresentable 1 := by
+  have h := sum_divisors_representable 1 (le_refl 1)
+  simpa using h
+
+/-- `3 = σ(2)` is representable (`1 + 2`). -/
+theorem three_representable : IsRepresentable 3 := by
+  have h := succ_prime_representable Nat.prime_two; norm_num at h; exact h
+
+/-- `4 = σ(3)` is representable (`1 + 3`). -/
+theorem four_representable : IsRepresentable 4 := by
+  have h := succ_prime_representable (by norm_num : Nat.Prime 3); norm_num at h; exact h
+
+end Erdos1054ConstructionDOQ02

--- a/src/data/proofs/erdos-1054-construction-d-oq-02/meta.json
+++ b/src/data/proofs/erdos-1054-construction-d-oq-02/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "erdos-1054-construction-d-oq-02",
+  "title": "Erdős #1054 Construction D OQ-02: A Sharp Boundary for Divisor-Partial-Sum Representability",
+  "slug": "erdos-1054-construction-d-oq-02",
+  "description": "Complements the one-sided representability families of Erdős #1054 Construction D (and its OQ-01 σ-representability result) with the two opposite extremes. Lower boundary: 2 is NOT representable — it never occurs as a partial sum of any m's sorted divisors, because the only partial sum below 3 is the first one (always 1), and every later partial sum already includes the second-smallest divisor ≥ 2. Upper boundary: the set of representable numbers is nevertheless infinite (unbounded above), since p+1 = σ(p) is representable for every prime p. Together: representability is a proper, infinite subset of ℕ. 13 theorems, 0 sorries, axiom-free (no native_decide).",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1054ConstructionDOQ02.lean",
+    "tags": [
+      "number-theory",
+      "erdos-problems",
+      "divisors",
+      "representability",
+      "sigma-function",
+      "primes",
+      "sharp-boundary"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 243,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Every theorem — including the headline two_not_representable and representable_infinite — was confirmed via #print axioms to depend only on these three; in particular there is no Lean.ofReduceBool (no native_decide) and no sorryAx. Unlike the parent Construction D file, the concrete witnesses here (one/three/four_representable) are derived symbolically from the general theorems, so they too are axiom-free.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_divisors_prime_pow",
+        "description": "σ(pᵏ) = ∑_{i=0}^{k} pⁱ, used to identify p+1 = σ(p) and the geometric-sum family as representable",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "Finset.pairwise_sort",
+        "description": "The sorted divisor list is pairwise ≤-ordered, giving smallest divisor 1 and second-smallest ≥ 2",
+        "module": "Mathlib.Data.Finset.Sort"
+      },
+      {
+        "theorem": "Nat.exists_infinite_primes",
+        "description": "Arbitrarily large primes, used to push p+1 past any bound for the unboundedness/infinitude results",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1054 studies representability: call $n$ *representable* if it occurs as a partial sum of the increasingly-sorted divisor list of some $m \\geq 1$ (equivalently, $f(n)$ — the least such $m$ — exists). The parent gallery entry, **Construction D**, and its OQ-01 follow-up are entirely one-sided: they exhibit numbers that *are* representable — the prime-square values $1+p+p^2$, the prime-power geometric sums $1+p+\\cdots+p^k = \\sigma(p^k)$, the Mersenne numbers $2^{k+1}-1$, and the general fact that $\\sigma(m)$ itself is always representable (the largest partial sum).\n\nThis OQ-02 entry supplies the missing *negative* and *asymptotic* information — the two opposite boundaries of the representable set. On the lower side it isolates the smallest positive integer that is **never** representable, namely $2$: the first partial sum of any $m$ is its smallest divisor $1$, and every subsequent partial sum already includes the second-smallest divisor (which is $\\geq 2$), so every partial sum is either $1$ or $\\geq 3$ — never $2$. On the upper side it shows the representable set is nonetheless **infinite and unbounded above**, because $p+1 = \\sigma(p)$ is representable for every prime $p$ and there are arbitrarily large primes. The picture that emerges is sharp: representability is a *proper, infinite* subset of $\\mathbb{N}$.",
+    "problemStatement": "Establish the boundaries of the representable set for Erdős #1054: (lower) 2 is not representable, and (upper) the representable numbers are unbounded above, hence infinite.",
+    "proofStrategy": "The upper boundary reuses an axiom-free port of the σ-representability machinery: σ(m) is the final divisor partial sum, so σ(p) = p+1 is representable for every prime p; combined with arbitrarily large primes this gives unboundedness, and a finite set of naturals being bounded above then yields infinitude. The lower boundary rests on a new monotonicity lemma le_of_mem_scanl_add: over ℕ every entry of scanl (·+·) b L is ≥ b. Writing the sorted divisors as a :: b :: rest with a = 1 (smallest divisor) and b ≥ 2 (second-smallest, via pairwise-sorted + nodup), the partial-sum list equals scanl (·+·) (0+a) (b :: rest), whose entries are 0+a = 1 and then values ≥ (0+a)+b ≥ 3. Hence 2 never appears.",
+    "keyInsights": [
+      "**Sharp lower boundary**: 2 is the smallest non-representable number. The structural reason is a gap — the only partial sum below 3 is the first one, which is always the smallest divisor 1; the next partial sum jumps to at least 1 + 2 = 3.",
+      "**New scanl monotonicity lemma**: over ℕ, every running-sum entry scanl (·+·) b L is ≥ b. This one-line induction is the engine that forces partial sums past 2.",
+      "**Upper boundary via σ(p)**: p+1 = σ(p) is representable for every prime p (it is the last partial sum of p's divisors [1, p]); arbitrarily large primes make the representable set unbounded.",
+      "**Infinite but proper**: combining the two boundaries, {n | IsRepresentable n} is an infinite yet proper subset of ℕ — the parent's families never establish either fact.",
+      "**Axiom-free throughout**: unlike the parent Construction D (whose concrete witnesses use native_decide / Lean.ofReduceBool), every result here — including the concrete witnesses 1, 3, 4 — is derived symbolically and verified to depend only on propext, Classical.choice, Quot.sound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions and Scanning Helpers",
+      "startLine": 55,
+      "endLine": 94,
+      "summary": "Self-contained definitions sortedDivisors, partialDivisorSums, IsRepresentable (mirrored, native_decide-free). foldl_add_acc: folding (+) with accumulator a adds a to the sum. le_of_mem_scanl_add (new core): over ℕ every entry of scanl (·+·) b L is ≥ b.",
+      "mathContext": "$\\text{IsRepresentable}(n) \\iff \\exists m \\geq 1,\\; n \\in \\text{partialDivisorSums}(m)$; every entry of $\\operatorname{scanl}(+)\\,b\\,L$ is $\\geq b$."
+    },
+    {
+      "id": "sigma-machinery",
+      "title": "Part 1: σ(m) Machinery (Axiom-Free Port)",
+      "startLine": 96,
+      "endLine": 138,
+      "summary": "sortedDivisors_sum (sorted list sums to σ(m)), sum_divisors_mem_partialSums (σ(m) is the final partial sum), sum_divisors_representable (σ(m) representable for m ≥ 1), geom_sum_representable (∑_{i≤k} pⁱ = σ(pᵏ) representable).",
+      "mathContext": "$\\sigma(m) = \\sum_{d \\mid m} d$ is the last entry of the partial-sum list, hence representable; $\\sum_{i=0}^{k} p^i = \\sigma(p^k)$."
+    },
+    {
+      "id": "upper-boundary",
+      "title": "Part 2: Upper Boundary — Unbounded and Infinite",
+      "startLine": 140,
+      "endLine": 171,
+      "summary": "succ_prime_representable (p+1 = σ(p) representable for prime p), representable_unbounded (∀ N, ∃ representable n > N via a prime p > N), representable_infinite (the representable set is infinite: a finite set of naturals would be bounded above).",
+      "mathContext": "$p+1 = \\sigma(p)$ representable; $\\{n : \\text{IsRepresentable }n\\}$ is unbounded above, hence infinite."
+    },
+    {
+      "id": "lower-boundary",
+      "title": "Part 3: Lower Boundary — 2 Is Not Representable",
+      "startLine": 173,
+      "endLine": 229,
+      "summary": "two_not_representable (headline): case split on the sorted divisor list. Empty/singleton cases are immediate; for a :: b :: rest, the pairwise order + nodup give smallest divisor a = 1 and second-smallest b ≥ 2, so partialDivisorSums = scanl (·+·) (0+a) (b :: rest) has entries 1 and (by le_of_mem_scanl_add) ≥ 3. Thus 2 ∉ partialDivisorSums m for every m.",
+      "mathContext": "Every partial sum is $1$ or $\\geq 3$, so $2$ is never a partial divisor sum: $\\neg\\,\\text{IsRepresentable}(2)$."
+    },
+    {
+      "id": "concrete",
+      "title": "Part 4: Concrete Witnesses at the Boundary",
+      "startLine": 231,
+      "endLine": 243,
+      "summary": "one_representable (1 = σ(1), the smallest representable number), three_representable (3 = σ(2)), four_representable (4 = σ(3)). All derived symbolically from the general theorems — no native_decide.",
+      "mathContext": "$1 = \\sigma(1)$, $3 = \\sigma(2) = 1+2$, $4 = \\sigma(3) = 1+3$ are representable; $2$ sits between them and is not."
+    }
+  ],
+  "conclusion": {
+    "summary": "Both boundaries of the Erdős #1054 representable set are pinned down, axiom-free: 2 is the smallest non-representable number (two_not_representable), while the representable set is infinite and unbounded above (representable_infinite, representable_unbounded) because p+1 = σ(p) is representable for every prime p. 13 theorems, 0 sorries, verified to depend only on propext / Classical.choice / Quot.sound.",
+    "implications": "Where the parent Construction D supplies only positive representability families, this entry shows the representable set is a *proper, infinite* subset of ℕ. The lower boundary exhibits a concrete obstruction (2), and the new monotonicity lemma le_of_mem_scanl_add is reusable for any partial-sum gap argument. The result also replaces the parent's native_decide witnesses with symbolic, axiom-free proofs of 1, 3, 4 being representable.",
+    "openQuestions": [
+      "Characterize exactly the non-representable numbers: is the set of non-representable n infinite, and what is its density?",
+      "Is every n ≥ 3 with n ≠ (a value forced out by a divisor gap) representable, and can the gaps be described arithmetically?",
+      "Does the Erdős #1054 main conjecture f(n) = o(n) hold on the representable set?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Divisors",
+      "Mathlib.Data.Finset.Sort",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "Erdos1054ConstructionDOQ02",
+    "lineCount": 243,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1054ConstructionDOQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1054-construction-d",
+      "relationship": "extends",
+      "description": "Adds the opposite (negative + asymptotic) boundaries to Construction D's positive representability families"
+    },
+    {
+      "targetId": "erdos-1054",
+      "relationship": "sub-question",
+      "description": "Boundaries of the representable set for the divisor-partial-sum representability problem"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "two_not_representable",
+      "type": "core",
+      "statement": "¬ IsRepresentable 2",
+      "description": "2 is never a partial sum of any m's sorted divisors — the sharp lower boundary of representability.",
+      "significance": "First negative (non-representability) result for Erdős #1054; 2 is the smallest non-representable number."
+    },
+    {
+      "name": "representable_infinite",
+      "type": "core",
+      "statement": "{n | IsRepresentable n}.Infinite",
+      "description": "The representable set is infinite (unbounded above), since p+1 = σ(p) is representable for every prime p.",
+      "significance": "Establishes representability is a proper, infinite subset of ℕ — the asymptotic upper boundary."
+    },
+    {
+      "name": "le_of_mem_scanl_add",
+      "type": "supporting",
+      "statement": "∀ x ∈ List.scanl (·+·) b L, b ≤ x",
+      "description": "Over ℕ every running-sum entry is at least the initial accumulator; the engine behind the lower boundary.",
+      "significance": "Reusable monotonicity lemma for divisor-partial-sum gap arguments."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A self-generated depth-+1 child of the **verified, axiom-free** Erdős #1054 Construction D OQ-01 work. The parent gallery entry and OQ-01 are entirely *one-sided* — they only exhibit numbers that **are** representable (a number `n` is *representable* if it occurs as a partial sum of the increasingly-sorted divisor list of some `m ≥ 1`). This entry supplies the missing **negative and asymptotic** information: the two opposite boundaries of the representable set.

### Lower boundary (headline)
- **`two_not_representable : ¬ IsRepresentable 2`** — `2` is the smallest positive integer that is *never* a divisor partial sum. The first partial sum of any `m` is its smallest divisor `1`; every later partial sum already includes the second-smallest divisor (`≥ 2`), hence is `≥ 1 + 2 = 3`. So every partial sum is `1` or `≥ 3`, never `2`.
- Engine: a small **new** monotonicity lemma **`le_of_mem_scanl_add`** — over `ℕ`, every entry of `scanl (·+·) b L` is `≥ b`.

### Upper boundary
- **`representable_infinite : {n | IsRepresentable n}.Infinite`** and **`representable_unbounded`** — the representable set is infinite/unbounded above, because `p + 1 = σ(p)` is representable for every prime `p` (`succ_prime_representable`) and primes are unbounded.

Together: **representability is a proper, infinite subset of `ℕ`** — neither fact follows from the parent's families.

### Other results
- Axiom-free σ machinery port: `σ(m)` is always the final partial sum (`sum_divisors_representable`); geometric/prime-power sums (`geom_sum_representable`).
- Concrete witnesses `1 = σ(1)`, `3 = σ(2)`, `4 = σ(3)` derived **symbolically** — replacing the parent's `native_decide` (`Lean.ofReduceBool`) witnesses.

## Verification
- **13 theorems, 3 defs, 0 sorries.**
- `#print axioms` on `two_not_representable`, `representable_infinite`, `succ_prime_representable`, `le_of_mem_scanl_add`: only `propext` / `Classical.choice` / `Quot.sound`.
- **No `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`** → `status: verified`, `badge: original`, `axiomCount: 0`.
- Elaborated against Mathlib v4.26.0 (`leanprover/lean4:v4.26.0`).

## Files
- `proofs/Proofs/Erdos1054ConstructionDOQ02.lean`
- `src/data/proofs/erdos-1054-construction-d-oq-02/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)