### PR TITLE
Enrich General Direct-Sum Davenport Lower Bound (Erdős #131)

### DIFF
--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "davenport-defs",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 48, "endLine": 57 },
+    "type": "definition",
+    "title": "Zero-Sum Subsequences and the Davenport Set",
+    "content": "`HasZeroSumSubseq f` says some nonempty index set s of the sequence f : Fin m → G has ∑_{i∈s} f i = 0. The `DavenportSet G` collects the lengths m for which EVERY length-m sequence over G has such a subsequence; the Davenport constant D(G) is its least element. Phrasing D(G) as the least element of an upward-closed set (rather than a raw number) is what lets the lower bound be proved purely order-theoretically via IsLeast.",
+    "mathContext": "$D(G)=\\min\\{m : \\forall f\\in G^m,\\ \\exists\\,\\emptyset\\neq s,\\ \\sum_{i\\in s} f_i = 0\\}$. A sequence with no nonempty zero-sum subsequence is called *zero-sum-free*; the longest such has length $D(G)-1$.",
+    "significance": "key",
+    "relatedConcepts": ["Davenport constant", "zero-sum sequence", "zero-sum-free sequence", "finite abelian group"],
+    "prerequisites": ["finite abelian groups", "Finset sums"]
+  },
+  {
+    "id": "davenport-mono",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 59, "endLine": 72 },
+    "type": "theorem",
+    "title": "The Davenport Set Is Upward Closed",
+    "content": "`davenport_set_mono`: if m ∈ DavenportSet G and m ≤ m', then m' ∈ DavenportSet G. A length-m' sequence is restricted to its first m entries via `Fin.castLE`, the zero-sum witness s on those entries is found, then re-embedded back into Fin m' through the order embedding `Fin.castLEEmb`, with `Finset.sum_map` preserving the sum. Upward closure is the order-theoretic lever: to show D(G₁⊕G₂) is large, one shows a specific smaller length is NOT in the set and lets monotonicity push the conclusion.",
+    "mathContext": "$m\\in D\\text{-set} \\wedge m\\le m' \\Rightarrow m'\\in D\\text{-set}$: longer sequences can only make a zero-sum subsequence easier to find.",
+    "significance": "key",
+    "relatedConcepts": ["upward closed set", "monotonicity", "Fin.castLE", "order embedding"],
+    "prerequisites": ["Finset.map", "order embeddings"]
+  },
+  {
+    "id": "positivity",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 74, "endLine": 89 },
+    "type": "lemma",
+    "title": "Length 0 Is Never a Davenport Length",
+    "content": "`zero_not_mem_davenportSet` and `one_le_of_isLeast_davenport`: the empty sequence has no nonempty index subset, so HasZeroSumSubseq fails vacuously at length 0; hence the least Davenport length is at least 1. Small but essential — it guarantees D(Gᵢ) − 1 is a genuine (nonnegative) zero-sum-free length, so the subtraction in the lower bound never underflows.",
+    "mathContext": "$0\\notin \\mathrm{DavenportSet}(G)$, so $D(G)\\ge 1$ and $D(G)-1$ is a bona fide zero-sum-free length.",
+    "significance": "supporting",
+    "relatedConcepts": ["vacuous truth", "least element", "boundary case"],
+    "prerequisites": ["IsLeast"]
+  },
+  {
+    "id": "concat-seq",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 91, "endLine": 97 },
+    "type": "definition",
+    "title": "Block Concatenation into the Product Group",
+    "content": "`concatSeq f₁ f₂` builds a sequence over G₁ × G₂ of length m₁+m₂: the first block places f₁ in the first coordinate, (f₁ i, 0); the second block places f₂ in the second coordinate, (0, f₂ j). It is defined by `Fin.addCases` on Fin (m₁+m₂), which splits an index by whether it falls in the castAdd (first) or natAdd (second) half. This is the general-group replacement for the rank-2 entry's explicit (1,0)/(0,1) extremal witness.",
+    "mathContext": "$\\mathrm{concatSeq}(f_1,f_2) = (f_1(0),0),\\dots,(f_1(m_1-1),0),(0,f_2(0)),\\dots,(0,f_2(m_2-1))$ over $G_1\\oplus G_2$.",
+    "significance": "key",
+    "relatedConcepts": ["direct sum", "concatenation", "Fin.addCases", "sequence over a product group"],
+    "prerequisites": ["product groups", "Fin arithmetic"]
+  },
+  {
+    "id": "concat-principle",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 99, "endLine": 142 },
+    "type": "theorem",
+    "title": "The Concatenation Principle (Engine)",
+    "content": "`concat_not_hasZeroSum`: if f₁ over G₁ and f₂ over G₂ are each zero-sum-free, so is their concatenation over G₁⊕G₂. This is the heart of the file. A candidate zero-sum index set s ⊆ Fin(m₁+m₂) is reindexed along `finSumFinEquiv : Fin m₁ ⊕ Fin m₂ ≃ Fin(m₁+m₂)` to t, split into blocks t.toLeft / t.toRight. Because the sequence is coordinate-separated, the total sum's first coordinate is exactly ∑ over t.toLeft of f₁ (via `Finset.sum_disjSum`, `Fin.addCases_left/right`, `Prod.fst_sum`) and the second is ∑ over t.toRight of f₂. Both vanish, so zero-sum-freeness of each factor forces both blocks empty, whence t = ∅ (`Finset.disjSum_eq_empty`) and s = ∅ — contradicting nonemptiness.",
+    "mathContext": "A zero-sum over $G_1\\oplus G_2$ vanishes in each coordinate independently; coordinate separation localizes it to a zero-sum within a single factor. Zero-sum-free factors ⟹ zero-sum-free concatenation.",
+    "significance": "critical",
+    "relatedConcepts": ["coordinatewise vanishing", "finSumFinEquiv", "Finset.toLeft/toRight", "reindexing", "disjoint union of Finsets"],
+    "prerequisites": ["product group sums", "sum-type Finset calculus"]
+  },
+  {
+    "id": "main-bound",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 144, "endLine": 176 },
+    "type": "theorem",
+    "title": "General Direct-Sum Lower Bound D(G₁⊕G₂) ≥ D(G₁)+D(G₂)−1",
+    "content": "`davenport_directSum_lower`: the headline result for arbitrary additive groups. Since d₁ = D(G₁) is least, length d₁−1 is below it, so a zero-sum-free f₁ of that length exists; likewise f₂. Their concatenation is zero-sum-free of length (d₁−1)+(d₂−1) = d₁+d₂−2, so that length is NOT a Davenport length. If D(G₁⊕G₂) ≤ d₁+d₂−2, upward closure (davenport_set_mono) would make d₁+d₂−2 a Davenport length — contradiction. Hence D(G₁⊕G₂) ≥ d₁+d₂−1.",
+    "mathContext": "$D(G_1\\oplus G_2)\\ge D(G_1)+D(G_2)-1$. Iterating over an invariant-factor decomposition $G=\\bigoplus \\mathbb Z/n_i$ recovers the Olson–Davenport bound $D(G)\\ge 1+\\sum(n_i-1)$.",
+    "significance": "critical",
+    "relatedConcepts": ["Olson–Davenport lower bound", "invariant factors", "IsLeast", "proof by contradiction"],
+    "prerequisites": ["least element arguments", "Davenport constant"]
+  },
+  {
+    "id": "specializations",
+    "proofId": "erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03",
+    "range": { "startLine": 178, "endLine": 194 },
+    "type": "theorem",
+    "title": "Cyclic and Diagonal Specializations",
+    "content": "`davenport_rank2_lower_of_cyclic` feeds the cyclic Davenport values D(ℤ/aℤ)=a, D(ℤ/bℤ)=b into the general bound to recover the rank-2 cyclic result D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a+b−1 — exactly what the rank-2 companion proves with one explicit witness. `davenport_directSum_diag_lower` gives the diagonal D(G⊕G) ≥ 2·D(G)−1, which for G=ℤ/nℤ is the bound D(ℤ/nℤ ⊕ ℤ/nℤ) ≥ 2n−1 (sharp by Olson's theorem; the matching upper bound is not formalized).",
+    "mathContext": "$D(\\mathbb Z/a\\oplus\\mathbb Z/b)\\ge a+b-1$ and $D(G\\oplus G)\\ge 2D(G)-1$; for $\\mathbb Z/n$ the latter is $2n-1$, sharp (Olson).",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic groups", "rank-2 groups", "Olson's theorem", "sharpness"],
+    "prerequisites": ["cyclic group Davenport constant"]
+  }
+]

--- a/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/meta.json
+++ b/src/data/proofs/erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03/meta.json
@@ -17,6 +17,45 @@
     "sorries": 0
   },
   "title": "The General Direct-Sum Davenport Lower Bound D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1 (Erdős #131)",
+  "description": "For arbitrary additive groups G₁, G₂, the Davenport constant of their direct sum satisfies D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1. The engine is the concatenation principle for zero-sum-free sequences: block-concatenating zero-sum-free sequences over each factor yields a zero-sum-free sequence over G₁ ⊕ G₂. This lifts the rank-2 cyclic companion's single explicit extremal witness to the structural principle behind the Olson–Davenport lower bound D(G) ≥ 1 + Σ(nᵢ − 1), unconditionally and axiom-free.",
+  "overview": {
+    "historicalContext": "The Davenport constant D(G) of a finite abelian group — the least d such that every length-d sequence over G has a nonempty zero-sum subsequence — was popularized by H. Davenport in the 1960s in connection with the factorization of algebraic integers (the maximal number of prime ideals in a product equalling a principal ideal). John Olson's two 1969 papers computed D(G) exactly for p-groups and for groups of rank ≤ 2, establishing the lower bound D(G) ≥ 1 + Σ(nᵢ − 1) over the invariant-factor decomposition G ≅ ⨁ ℤ/nᵢℤ. Whether this lower bound is an equality in general is a celebrated open problem: it holds for rank ≤ 2 and p-groups but FAILS for some groups of rank ≥ 4. The constant governs Erdős problem #131 on non-dividing sets, where it controls per-element size bounds. This entry formalizes the binary direct-sum step — the structural mechanism behind Olson's lower bound — for arbitrary group summands.",
+    "problemStatement": "Prove that for any additive (abelian) groups G₁, G₂, the Davenport constants satisfy D(G₁ ⊕ G₂) ≥ D(G₁) + D(G₂) − 1, with D defined as the least element (IsLeast) of the Davenport set. Specialize to recover the rank-2 cyclic bound D(ℤ/aℤ ⊕ ℤ/bℤ) ≥ a + b − 1 and the diagonal D(G ⊕ G) ≥ 2·D(G) − 1.",
+    "proofStrategy": "Package D(G) as the least element of the upward-closed Davenport set. The least value being d means length d−1 admits a zero-sum-free sequence. Take zero-sum-free f₁ (length D(G₁)−1) and f₂ (length D(G₂)−1) and block-concatenate them into concatSeq f₁ f₂ over G₁ ⊕ G₂, placing each fᵢ in its own coordinate. The concatenation principle concat_not_hasZeroSum shows it is zero-sum-free: a candidate zero-sum reindexes (finSumFinEquiv) into a disjoint pair of blocks (toLeft/toRight) whose two coordinate sums must each vanish, forcing both blocks — hence the whole index set — empty. So length D(G₁)+D(G₂)−2 is not a Davenport length; upward closure then forces D(G₁⊕G₂) ≥ D(G₁)+D(G₂)−1.",
+    "keyInsights": [
+      "A zero-sum in a direct sum vanishes coordinatewise and independently, so coordinate-separated concatenation localizes any putative zero-sum to within a single factor — that is the entire idea behind the lower bound.",
+      "Phrasing D(G) as IsLeast of an upward-closed set turns the bound into a clean order-theoretic contradiction: exhibit one zero-sum-free sequence of length D(G₁)+D(G₂)−2 and let monotonicity do the rest.",
+      "The result generalizes the rank-2 cyclic companion from a single explicit extremal witness (1,0)^{a−1}(0,1)^{b−1} to the structural principle for arbitrary group summands, isolating the reusable concatenation argument.",
+      "Iterating the binary bound over the invariant-factor decomposition recovers the full Olson–Davenport lower bound D(G) ≥ 1 + Σ(nᵢ − 1); the matching upper bound (Olson's theorem) is the deep, generally-open other half.",
+      "The Fin.addCases / finSumFinEquiv / toLeft–toRight encoding provides general-group zero-sum-free infrastructure that Mathlib currently lacks, reusable for further Davenport-constant formalization."
+    ]
+  },
+  "sections": [
+    {
+      "id": "davenport-framework",
+      "title": "Davenport Set Framework",
+      "startLine": 48,
+      "endLine": 89,
+      "summary": "Defines HasZeroSumSubseq and DavenportSet, with D(G) as the least element. Establishes upward closure (davenport_set_mono via Fin.castLE re-embedding) and positivity of the least Davenport length (0 is never a Davenport length).",
+      "mathContext": "D(G) = least m with every length-m sequence containing a nonempty zero-sum subsequence; the set is upward closed and excludes 0."
+    },
+    {
+      "id": "concatenation",
+      "title": "The Concatenation Principle",
+      "startLine": 91,
+      "endLine": 142,
+      "summary": "concatSeq block-concatenates sequences into G₁ × G₂ via Fin.addCases. concat_not_hasZeroSum proves the engine: concatenating zero-sum-free sequences stays zero-sum-free, by reindexing along finSumFinEquiv, splitting into toLeft/toRight blocks, and forcing both coordinate sums to vanish.",
+      "mathContext": "Zero-sum-free over G₁ and over G₂ ⟹ zero-sum-free over G₁ ⊕ G₂; coordinatewise vanishing localizes any zero-sum to one factor."
+    },
+    {
+      "id": "lower-bound",
+      "title": "The Lower Bound and Specializations",
+      "startLine": 144,
+      "endLine": 196,
+      "summary": "davenport_directSum_lower assembles the framework and the concatenation principle into D(G₁⊕G₂) ≥ D(G₁)+D(G₂)−1. Specializations recover the rank-2 cyclic bound a+b−1 and the diagonal 2·D(G)−1.",
+      "mathContext": "D(G₁⊕G₂) ≥ D(G₁)+D(G₂)−1; for cyclic factors a+b−1, diagonal 2·D(G)−1."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `erdos-131-oq-01-oq-01-oq-01-oq-04-oq-03`.

## Gaps addressed
- **Missing `annotations.json`** — added 7 annotations with `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`, covering the Davenport-set framework (definitions, upward closure, positivity), the concatenation principle engine, the main lower bound, and the cyclic/diagonal specializations.
- **No structured `overview`** — added `ProofOverview` with `historicalContext` (Davenport, Olson 1969, the open equality problem failing for rank ≥ 4), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **No `sections`** — added 3 sections spanning the full Lean file.
- **Missing top-level `description`** — added one.

## Verification
- JSON validated; `pnpm build` passes. All 3 cross-reference targets confirmed to exist.
- Axiom/badge metadata unchanged and accurate: 0 axioms, 0 sorries, verified/original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)