### PR TITLE
Enrich Two-Square Sufficiency Slice of the Three-Square Theorem

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "predicates",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": { "startLine": 54, "endLine": 60 },
+    "type": "definition",
+    "title": "Two- and Three-Square Predicates",
+    "content": "`IsSumTwoSq n` and `IsSumThreeSq n` are the representability predicates over ℤ: n = x²+y² and n = x²+y²+z² respectively. Working over the integers (rather than ℕ) keeps the modular obstruction arguments and the embedding clean. These two predicates and the relationship between them are the subject of the whole file.",
+    "mathContext": "$\\mathrm{IsSumTwoSq}(n):\\exists x,y\\in\\mathbb Z,\\ x^2+y^2=n$; $\\mathrm{IsSumThreeSq}(n):\\exists x,y,z\\in\\mathbb Z,\\ x^2+y^2+z^2=n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sums of squares", "quadratic forms", "representability"],
+    "prerequisites": ["integer arithmetic"]
+  },
+  {
+    "id": "modular-obstructions",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": { "startLine": 62, "endLine": 102 },
+    "type": "theorem",
+    "title": "Elementary Modular Obstructions (mod 8, mod 4)",
+    "content": "The necessity-side facts, each a finite kernel `decide` check over a small ZMod. Squares in ZMod 8 lie in {0,1,4}, so no three sum to 7: a sum of three squares is never ≡ 7 (mod 8) (`sumThreeSq_ne_seven_mod_eight`, lifted to `not_isSumThreeSq_of_mod_eight`). Squares in ZMod 4 lie in {0,1}, so no two sum to 3: a sum of two squares is never ≡ 3 (mod 4) (`sumTwoSq_ne_three_mod_four`, `not_isSumTwoSq_of_mod_four`). These drive the concrete separating witness 3 and the non-closure witness 63. Using kernel `decide` (not `native_decide`) keeps the file 0-axiom.",
+    "mathContext": "Squares mod 8 ∈ {0,1,4} ⟹ $x^2+y^2+z^2\\not\\equiv 7\\ (8)$; squares mod 4 ∈ {0,1} ⟹ $x^2+y^2\\not\\equiv 3\\ (4)$. The full excluded family for three squares is $4^a(8b+7)$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residues", "ZMod", "Legendre's excluded family", "kernel decide"],
+    "prerequisites": ["modular arithmetic", "quadratic residues mod 8"]
+  },
+  {
+    "id": "embedding",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": { "startLine": 104, "endLine": 121 },
+    "type": "theorem",
+    "title": "The Embedding: Two Squares ⟹ Three Squares",
+    "content": "`isSumTwoSq_imp_isSumThreeSq`: every sum of two squares is a sum of three — just append 0². Trivial in itself, but it is the bridge that turns Mathlib's complete two-square theory into unconditional progress on the OPEN three-square sufficiency direction. `isSumTwoSq_ne_seven_mod_eight` confirms consistency: a two-square number is never ≡ 7 (mod 8), so the whole two-square slice avoids Legendre's excluded family 4^a(8b+7).",
+    "mathContext": "$x^2+y^2=n \\Rightarrow x^2+y^2+0^2=n$. The two-square numbers $\\subseteq$ three-square numbers, and never lie in $4^a(8b+7)$.",
+    "significance": "critical",
+    "relatedConcepts": ["embedding", "Legendre three-square theorem", "open sufficiency direction"],
+    "prerequisites": ["sums of squares"]
+  },
+  {
+    "id": "dirichlet-free-slice",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": { "startLine": 123, "endLine": 141 },
+    "type": "theorem",
+    "title": "A Dirichlet-Free Infinite Slice of the Open Sufficiency Direction",
+    "content": "Composing the embedding with Mathlib's two-square results yields unconditional three-square families with no appeal to Dirichlet's theorem. `prime_mod_four_ne_three_isSumThreeSq`: every prime p with p % 4 ≠ 3 is a sum of three squares (via Fermat's `Nat.Prime.sq_add_sq`). `isSumThreeSq_of_forall_threeMod_even`: every n whose primes ≡ 3 (mod 4) all occur to even power is a sum of three squares (via the full characterization `Nat.eq_sq_add_sq_iff`). These are explicit, infinite, axiom-free verifications of the open 'if' direction — exactly what the two-square theorem hands the three-square problem for free.",
+    "mathContext": "$p\\not\\equiv 3\\ (4)\\Rightarrow p$ is a sum of three squares; more generally any $n$ with $v_q(n)$ even for all $q\\equiv 3\\ (4)$ is. An infinite Dirichlet-free family in the open sufficiency direction.",
+    "significance": "critical",
+    "relatedConcepts": ["Fermat's Christmas theorem", "Dirichlet's theorem", "p-adic valuation", "two-square characterization"],
+    "prerequisites": ["two-square theorem", "prime factorization"]
+  },
+  {
+    "id": "two-square-closure",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": { "startLine": 143, "endLine": 152 },
+    "type": "theorem",
+    "title": "Brahmagupta–Fibonacci: Two Squares Are Multiplicatively Closed",
+    "content": "`isSumTwoSq_mul`: the product of two sums of two squares is a sum of two squares, via Mathlib's `sq_add_sq_mul` (the Brahmagupta–Fibonacci two-square identity (a²+b²)(c²+d²) = (ac−bd)²+(ad+bc)²). This is the foil for the three-square non-closure below: it is precisely the multiplicativity that lets the two- and four-square theorems be assembled from prime cases, and which the three-square case fatally lacks.",
+    "mathContext": "$(a^2+b^2)(c^2+d^2)=(ac-bd)^2+(ad+bc)^2$ — sums of two squares form a multiplicative monoid (the norm form of the Gaussian integers).",
+    "significance": "key",
+    "relatedConcepts": ["Brahmagupta–Fibonacci identity", "Gaussian integers", "norm form", "multiplicativity"],
+    "prerequisites": ["polynomial identities"]
+  },
+  {
+    "id": "non-closure",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
+    "range": { "startLine": 154, "endLine": 187 },
+    "type": "theorem",
+    "title": "Three Squares Fail Multiplicative Closure — Why Analysis Is Needed",
+    "content": "The structural heart of the entry. `isSumThreeSq_strictly_contains_twoSq`: 3 = 1²+1²+1² is a sum of three squares but not two (it is ≡ 3 mod 4), so three-square numbers strictly extend two-square numbers. `isSumThreeSq_not_mul_closed`: 3 and 21 = 4²+2²+1² are each sums of three squares, yet 3·21 = 63 = 8·7+7 is excluded by the mod-8 obstruction. This concrete counterexample is the precise reason the three-square sufficiency direction CANNOT be bootstrapped multiplicatively from a prime slice (as the two- and four-square theorems are) and genuinely requires the analytic Dirichlet / Hasse–Minkowski input still axiomatized in the parent entry.",
+    "mathContext": "$3,\\,21$ are sums of three squares but $3\\cdot 21=63=4^0(8\\cdot 7+7)$ is excluded. The three-square representable set is not closed under multiplication — unlike two and four squares.",
+    "significance": "critical",
+    "relatedConcepts": ["multiplicative closure failure", "ternary quadratic forms", "Hasse–Minkowski", "Legendre excluded family"],
+    "prerequisites": ["modular obstructions", "sums of squares"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-03/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-03/meta.json
@@ -15,6 +15,45 @@
     "sorries": 0
   },
   "title": "The Two-Square Sufficiency Slice of the Three-Square Theorem",
+  "description": "An elementary, axiom-free slice of the OPEN sufficiency direction of Legendre's three-square theorem, obtained by bridging Mathlib's complete two-square theory into the still-open three-square question. The embedding 'two squares ⟹ three squares' (append 0²) yields an explicit infinite Dirichlet-free family of three-square representable numbers, while the failure of multiplicative closure (3 and 21 are sums of three squares but 3·21 = 63 = 8·7+7 is not) pins down exactly why the full sufficiency direction genuinely requires analytic input.",
+  "overview": {
+    "historicalContext": "Legendre's three-square theorem (1798) states that a natural number n is a sum of three squares iff it is not of the form 4^a(8b+7). The necessity ('only if') half is elementary — a mod-8 obstruction plus a 4-power descent. The sufficiency ('if') half is the deep one: Legendre's and Gauss's proofs rely on the theory of ternary quadratic forms and, ultimately, on Dirichlet's theorem on primes in arithmetic progressions (or the Hasse–Minkowski local–global principle). This is in sharp contrast to the two- and four-square theorems (Fermat/Euler 1749, Lagrange 1770), whose representable sets are multiplicatively closed (Brahmagupta–Fibonacci and Euler's four-square identity), letting them be assembled from prime cases. Mathlib has the full two-square theory but no three-square theorem; the parent oq-03 entry reduces three-square sufficiency to an axiom. This entry extracts the largest slice of that open direction reachable from the two-square theorem alone, and exhibits the concrete obstruction (non-multiplicativity) that blocks the rest.",
+    "problemStatement": "Without assuming three-square sufficiency, prove an explicit infinite family of the open 'if' direction of Legendre's theorem using only Mathlib's two-square theory: every prime p ≢ 3 (mod 4), and more generally every n whose primes ≡ 3 (mod 4) occur to even powers, is a sum of three squares. Then exhibit the structural obstruction — three-square representability is not multiplicatively closed — that prevents extending this slice to the full theorem.",
+    "proofStrategy": "Bridge via the trivial embedding IsSumTwoSq n ⟹ IsSumThreeSq n (append 0²). Composing with Fermat's two-square theorem (Nat.Prime.sq_add_sq) gives the prime slice, and with the full characterization Nat.eq_sq_add_sq_iff gives the even-power-of-3-mod-4 family — both Dirichlet-free. Separately, kernel-decide modular obstructions over ZMod 4 / ZMod 8 (squares mod 8 ∈ {0,1,4}, mod 4 ∈ {0,1}) give the concrete witnesses: 3 is three-square but not two-square (strict containment), and 3·21 = 63 ≡ 7 (mod 8) is excluded though 3 and 21 are not — the failure of multiplicative closure, contrasted with the Brahmagupta–Fibonacci closure isSumTwoSq_mul.",
+    "keyInsights": [
+      "The trivial 'append 0²' embedding is leveraged into substantive unconditional progress: it converts Mathlib's entire two-square theory into an explicit, infinite, Dirichlet-free family verifying the open three-square sufficiency direction.",
+      "The decisive structural fact is negative: three-square representability is NOT multiplicatively closed (3·21 = 63 is excluded), unlike two and four squares — this is precisely why the sufficiency direction cannot be bootstrapped from primes and genuinely needs analytic input.",
+      "The single counterexample 63 = 8·7+7 cleanly localizes 'where the elementary approach stops', making concrete the boundary between the formalizable slice and the axiomatized remainder of the parent entry.",
+      "Strict containment is witnessed minimally: 3 = 1²+1²+1² is three-square but ≡ 3 (mod 4) so not two-square, separating the two families with the smallest possible example.",
+      "All modular obstructions are kernel-decide checks over tiny ZMod rings, keeping the entire development genuinely 0-axiom (no native_decide, no Lean.ofReduceBool)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "predicates-obstructions",
+      "title": "Predicates and Modular Obstructions",
+      "startLine": 54,
+      "endLine": 102,
+      "summary": "Defines IsSumTwoSq / IsSumThreeSq over ℤ and proves the elementary necessity obstructions: a sum of three squares is never ≡ 7 (mod 8) and a sum of two squares never ≡ 3 (mod 4), each a finite kernel-decide check over ZMod 8 / ZMod 4.",
+      "mathContext": "Squares mod 8 ∈ {0,1,4}, mod 4 ∈ {0,1}; excluded family for three squares is 4^a(8b+7)."
+    },
+    {
+      "id": "embedding-slice",
+      "title": "Embedding and the Dirichlet-Free Slice",
+      "startLine": 104,
+      "endLine": 141,
+      "summary": "The embedding isSumTwoSq_imp_isSumThreeSq (append 0²) turns the two-square theory into unconditional three-square families: every prime p ≢ 3 (mod 4) (prime_mod_four_ne_three_isSumThreeSq) and every n with even powers of primes ≡ 3 mod 4 (isSumThreeSq_of_forall_threeMod_even) — an explicit infinite Dirichlet-free slice of the open 'if' direction.",
+      "mathContext": "Two-square numbers ⊆ three-square numbers; Fermat + Nat.eq_sq_add_sq_iff give an infinite family with no Dirichlet input."
+    },
+    {
+      "id": "closure-contrast",
+      "title": "Multiplicative Closure Contrast",
+      "startLine": 143,
+      "endLine": 187,
+      "summary": "Two-square numbers are multiplicatively closed (isSumTwoSq_mul, Brahmagupta–Fibonacci), but three-square numbers are NOT: strict containment (3 is three- but not two-square) and the non-closure witness 3·21 = 63 = 8·7+7, the structural reason the sufficiency direction needs analytic input.",
+      "mathContext": "(a²+b²)(c²+d²) is a sum of two squares, but 3·21 = 63 is excluded though 3, 21 are sums of three squares."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -89,11 +128,6 @@
     }
   ],
   "crossReferences": [
-    {
-      "targetId": "lagrange-four-squares-waring-g2-oq-03",
-      "relationship": "depends-on",
-      "description": "Companion to the parent three-square sufficiency study. Where the parent reduces the full 'if' direction to a Dirichlet/Hasse–Minkowski axiom, this entry carves out an explicit, infinite, axiom-free slice of that same direction using only Mathlib's two-square theory, and isolates (via the 3·21=63 non-closure) exactly why the remaining gap needs analytic input."
-    },
     {
       "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-02",
       "relationship": "extends",


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-03`.

## Gaps addressed
- **Missing `annotations.json`** — added 6 annotations with `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`, covering the predicates, the mod-8/mod-4 obstructions, the two→three-square embedding, the Dirichlet-free infinite slice, and the multiplicative-closure contrast (Brahmagupta–Fibonacci vs the 3·21=63 failure).
- **No structured `overview`** — added `ProofOverview` (historicalContext: Legendre 1798, Dirichlet/Hasse–Minkowski, two/four-square multiplicativity; problemStatement; proofStrategy; 5 keyInsights).
- **No `sections`** — added 3 sections spanning the full Lean file.
- **Missing top-level `description`** — added one.
- **Dangling cross-reference** — removed the `depends-on` ref to the nonexistent `lagrange-four-squares-waring-g2-oq-03` gallery entry (kept the two valid sibling refs).

## Verification
- JSON validated; `pnpm build` passes.
- Axiom/badge metadata unchanged and accurate: 0 axioms, 0 sorries, verified/original (kernel decide over ZMod, no native_decide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)