### PR TITLE
research(circumference-via-differentiation-oq-02): radial-shell decomposition — volume as the integral of surface area

### DIFF
--- a/proofs/Proofs/BallVolumeSurfaceDuality.lean
+++ b/proofs/Proofs/BallVolumeSurfaceDuality.lean
@@ -1,0 +1,161 @@
+/-
+  OQ-02: Radial-Shell Decomposition — Volume as the Integral of Surface Area
+  (circumference-via-differentiation-oq-02)
+
+  The parent `CircumferenceViaDifferentiation` proves the *differential* half of
+  the area–circumference duality, `d/dr(πr²) = 2πr`, and OQ-01 generalizes the
+  derivative direction to every dimension, `d/dr(ω_n rⁿ) = n·ω_n·rⁿ⁻¹`. But the
+  parent's own conclusion notes that the *integral* half —
+
+      "A(r) = ∫₀ʳ C(t) dt — the disk read as a union of concentric circles"
+
+  — is stated only informally and "does not separately formalize the integral."
+
+  This file fills exactly that gap, in general dimension, via the Fundamental
+  Theorem of Calculus:
+
+      V_n(r) = ∫₀ʳ S_{n-1}(ρ) dρ            (radial-shell decomposition)
+      V_n(b) − V_n(a) = ∫ₐᵇ S_{n-1}(ρ) dρ   (volume of an annular shell)
+
+  where V_n and S_{n-1} are OQ-01's genuine n-ball volume and (n-1)-sphere
+  surface functions (with ω_n = π^(n/2)/Γ(n/2+1)). The ball is literally the
+  union of its concentric bounding spheres, and integrating their surface areas
+  radially recovers the volume.
+
+  Concrete consequences are double-checked by direct integration:
+      ∫₀ʳ 2πρ dρ  = πr²        (n = 2, recovering the parent)
+      ∫₀ʳ 4πρ² dρ = (4/3)πr³   (n = 3, the sphere)
+
+  This is the antiderivative direction the parent and OQ-01 leave open; it is
+  *not* a restatement of the derivative direction. Self-contained on top of
+  OQ-01. Status: 0 sorries, 0 axioms (beyond Mathlib's).
+-/
+
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+import Mathlib.Tactic
+import Proofs.CircumferenceViaDifferentiationOQ01
+
+open Real intervalIntegral
+open CircumferenceViaDifferentiationOQ01
+
+noncomputable section
+
+namespace BallVolumeSurfaceDuality
+
+/-
+## Continuity of the surface function
+-/
+
+/-- The (n−1)-sphere surface function `S(ρ) = n·ω_n·ρⁿ⁻¹` is continuous: it is a
+constant times a monomial. Needed for interval integrability in the FTC. -/
+theorem nSphereSurfaceFn_continuous (n : ℕ) :
+    Continuous (nSphereSurfaceFn n) := by
+  unfold nSphereSurfaceFn
+  fun_prop
+
+/-
+## The integral direction (Fundamental Theorem of Calculus)
+-/
+
+/-- The radial integral of the surface function over `[a, b]` telescopes to the
+difference of volumes. Direct application of the FTC to OQ-01's core derivative
+identity `dV/dr = S`. -/
+theorem integral_surface_eq_sub (n : ℕ) (a b : ℝ) :
+    ∫ ρ in a..b, nSphereSurfaceFn n ρ = nBallVolumeFn n b - nBallVolumeFn n a :=
+  intervalIntegral.integral_eq_sub_of_hasDerivAt
+    (fun x _ => nBallVolumeFn_hasDerivAt n x)
+    ((nSphereSurfaceFn_continuous n).intervalIntegrable a b)
+
+/-- **Annular-shell volume.** The volume of the shell `a ≤ |x| ≤ b` of the
+n-ball equals the radial integral of the bounding-sphere surface area over
+`[a, b]`. -/
+theorem shell_volume_eq_integral (n : ℕ) (a b : ℝ) :
+    nBallVolumeFn n b - nBallVolumeFn n a = ∫ ρ in a..b, nSphereSurfaceFn n ρ :=
+  (integral_surface_eq_sub n a b).symm
+
+/-- **Radial-shell decomposition** (the gap left open by the parent and OQ-01).
+For `n ≥ 1`, the volume of the n-ball of radius `r` is the radial integral of the
+surface area of its concentric bounding spheres:
+
+  `V_n(r) = ∫₀ʳ S_{n-1}(ρ) dρ`.
+
+The n-ball is the union of its concentric bounding spheres. -/
+theorem nBallVolume_eq_integral (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :
+    nBallVolumeFn n r = ∫ ρ in (0 : ℝ)..r, nSphereSurfaceFn n ρ := by
+  rw [integral_surface_eq_sub]
+  have hz : nBallVolumeFn n 0 = 0 := by
+    unfold nBallVolumeFn
+    rw [zero_pow (by omega : n ≠ 0), mul_zero]
+  rw [hz, sub_zero]
+
+/-- **Volume–surface duality, both directions.** OQ-01 supplies the derivative
+direction (`dV/dr = S`); this file supplies the integral direction
+(`V = ∫₀ʳ S`). Together they are inverse statements of the same geometric fact. -/
+theorem volume_surface_duality (n : ℕ) (hn : 1 ≤ n) (r : ℝ) :
+    deriv (nBallVolumeFn n) r = nSphereSurfaceFn n r ∧
+      nBallVolumeFn n r = ∫ ρ in (0 : ℝ)..r, nSphereSurfaceFn n ρ :=
+  ⟨deriv_nBallVolume n r, nBallVolume_eq_integral n hn r⟩
+
+/-
+## Clean form of the integrand in low dimensions
+-/
+
+/-- The 1-sphere (circle) surface integrand is the circumference `2πρ`. -/
+theorem nSphereSurfaceFn_two_eq (ρ : ℝ) : nSphereSurfaceFn 2 ρ = 2 * π * ρ := by
+  unfold nSphereSurfaceFn
+  rw [nSphereSurfaceConst_two, show (2 : ℕ) - 1 = 1 from rfl]
+  ring
+
+/-- The 2-sphere surface integrand is the spherical area `4πρ²`. -/
+theorem nSphereSurfaceFn_three_eq (ρ : ℝ) : nSphereSurfaceFn 3 ρ = 4 * π * ρ ^ 2 := by
+  unfold nSphereSurfaceFn
+  rw [nSphereSurfaceConst_three, show (3 : ℕ) - 1 = 2 from rfl]
+
+/-
+## Concrete radial integrals, computed directly
+
+These independently verify that integrating the surface area really reproduces
+the classical volume formulas — a cross-check of the general theorem above.
+-/
+
+/-- `∫₀ʳ 2πρ dρ = πr²` — integrating the circumference recovers the disk area. -/
+theorem circumference_integral_eq (r : ℝ) :
+    (∫ ρ in (0 : ℝ)..r, 2 * π * ρ) = π * r ^ 2 := by
+  rw [intervalIntegral.integral_const_mul, integral_id]
+  ring
+
+/-- `∫₀ʳ 4πρ² dρ = (4/3)πr³` — integrating the sphere surface recovers the
+ball volume. -/
+theorem sphere_surface_integral_eq (r : ℝ) :
+    (∫ ρ in (0 : ℝ)..r, 4 * π * ρ ^ 2) = 4 * π / 3 * r ^ 3 := by
+  rw [intervalIntegral.integral_const_mul, integral_pow]
+  norm_num
+  ring
+
+/-- **n = 2 (parent recovery).** The disk area is the radial integral of the
+circumference, with the integrand written explicitly: `πr² = ∫₀ʳ 2πρ dρ`. This
+is precisely the integral form the parent states informally. -/
+theorem disk_area_radial_shell (r : ℝ) :
+    nBallVolumeFn 2 r = ∫ ρ in (0 : ℝ)..r, 2 * π * ρ := by
+  rw [circumference_integral_eq]
+  show unitBallVolume 2 * r ^ 2 = π * r ^ 2
+  rw [unitBallVolume_two]
+
+/-- **n = 3 (the sphere).** The ball volume is the radial integral of the
+sphere's surface area, written explicitly: `(4/3)πr³ = ∫₀ʳ 4πρ² dρ`. -/
+theorem ball_volume_radial_shell (r : ℝ) :
+    nBallVolumeFn 3 r = ∫ ρ in (0 : ℝ)..r, 4 * π * ρ ^ 2 := by
+  rw [sphere_surface_integral_eq]
+  show unitBallVolume 3 * r ^ 3 = 4 * π / 3 * r ^ 3
+  rw [unitBallVolume_three]
+
+/-- Consistency of the two n = 2 presentations: the abstract surface integrand
+`S_1` and the explicit circumference `2πρ` give the same integral. -/
+theorem disk_area_presentations_agree (r : ℝ) :
+    (∫ ρ in (0 : ℝ)..r, nSphereSurfaceFn 2 ρ) = ∫ ρ in (0 : ℝ)..r, 2 * π * ρ := by
+  simp_rw [nSphereSurfaceFn_two_eq]
+
+end BallVolumeSurfaceDuality
+
+end -- noncomputable section

--- a/src/data/proofs/circumference-via-differentiation-oq-02/annotations.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-02/annotations.json
@@ -1,0 +1,76 @@
+[
+  {
+    "id": "cvd02-ann-01",
+    "proofId": "circumference-via-differentiation-oq-02",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "Header, Strategy, and Imports",
+    "content": "The docstring frames the contribution precisely: the parent CircumferenceViaDifferentiation proves the differential half of the area-circumference duality and OQ-01 generalizes the derivative direction to all dimensions, but the integral half $V_n(r) = \\int_0^r S_{n-1}(\\rho)\\,d\\rho$ — the parent's own conclusion admits it 'does not separately formalize the integral' — is left open. This file fills it via the Fundamental Theorem of Calculus. Four imports do the work: `IntervalIntegral.FundThmCalculus` provides `integral_eq_sub_of_hasDerivAt` (the FTC), `SpecialFunctions.Integrals.Basic` provides `integral_id` and `integral_pow` for the concrete evaluations, `Mathlib.Tactic` supplies the tactic suite, and `Proofs.CircumferenceViaDifferentiationOQ01` supplies the genuine n-ball volume/surface definitions and the derivative identity that is fed into the FTC.",
+    "mathContext": "$V_n(r) = \\omega_n r^n$, $S_{n-1}(r) = n\\,\\omega_n r^{n-1}$, $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$. Goal: $V_n(r) = \\int_0^r S_{n-1}(\\rho)\\,d\\rho$ for $n \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fundamental Theorem of Calculus",
+      "shell method",
+      "Archimedes onion-peel argument",
+      "antiderivative direction"
+    ],
+    "prerequisites": [
+      "Lean 4 imports and namespaces",
+      "interval integrals in Mathlib",
+      "the parent and OQ-01 entries"
+    ]
+  },
+  {
+    "id": "cvd02-ann-02",
+    "proofId": "circumference-via-differentiation-oq-02",
+    "range": { "startLine": 47, "endLine": 56 },
+    "type": "technique",
+    "title": "Continuity Supplies Integrability",
+    "content": "`nSphereSurfaceFn_continuous` proves the surface function $S(\\rho) = n\\,\\omega_n\\,\\rho^{n-1}$ is continuous via `fun_prop`. This is not decoration: the FTC lemma `integral_eq_sub_of_hasDerivAt` requires the derivative (here the surface function) to be interval-integrable, and `Continuous.intervalIntegrable` converts continuity into exactly that hypothesis. Because the surface function is a constant times a monomial, continuity is automatic.",
+    "mathContext": "$S_{n-1}$ is a monomial $\\Rightarrow$ continuous $\\Rightarrow$ interval-integrable on every $[a,b]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["continuity", "interval integrability", "fun_prop automation"],
+    "prerequisites": ["continuous functions", "Riemann/Bochner interval integral"]
+  },
+  {
+    "id": "cvd02-ann-03",
+    "proofId": "circumference-via-differentiation-oq-02",
+    "range": { "startLine": 58, "endLine": 93 },
+    "type": "key-step",
+    "title": "The FTC Core: Surface Integrates to Volume",
+    "content": "The heart of the file. `integral_surface_eq_sub` applies `intervalIntegral.integral_eq_sub_of_hasDerivAt` to OQ-01's derivative identity `nBallVolumeFn_hasDerivAt` (every point of $[a,b]$) plus the integrability just established, yielding $\\int_a^b S = V(b) - V(a)$ in a single term. `shell_volume_eq_integral` is its symmetric statement — the volume of the annular shell between radii $a$ and $b$ equals the radial integral of the bounding-sphere surface area. `nBallVolume_eq_integral` then specializes to $a=0$: since $V_n(0) = \\omega_n \\cdot 0^n = 0$ for $n \\ge 1$ (discharged by `zero_pow`), the difference collapses to the radial-shell decomposition $V_n(r) = \\int_0^r S_{n-1}(\\rho)\\,d\\rho$.",
+    "mathContext": "FTC: $\\int_a^b f' = f(b) - f(a)$. With $f = V_n$, $f' = S_{n-1}$ (OQ-01), $a=0$, $V_n(0)=0$: $V_n(r) = \\int_0^r S_{n-1}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Fundamental Theorem of Calculus",
+      "boundary term vanishing",
+      "shell method",
+      "radial decomposition"
+    ],
+    "prerequisites": ["FTC", "OQ-01 derivative identity", "zero_pow for n ≥ 1"]
+  },
+  {
+    "id": "cvd02-ann-04",
+    "proofId": "circumference-via-differentiation-oq-02",
+    "range": { "startLine": 95, "endLine": 121 },
+    "type": "key-step",
+    "title": "Both Directions Bundled; Closed-Form Integrands",
+    "content": "`volume_surface_duality` packages the two halves of the duality together: OQ-01's derivative direction $\\mathrm{deriv}\\,V_n = S_{n-1}$ and this file's integral direction $V_n = \\int_0^r S_{n-1}$ — inverse statements of one geometric fact. The two integrand lemmas then translate OQ-01's abstract surface function into classical closed form: `nSphereSurfaceFn_two_eq` gives $S_1(\\rho) = 2\\pi\\rho$ (the circumference) and `nSphereSurfaceFn_three_eq` gives $S_2(\\rho) = 4\\pi\\rho^2$ (the sphere's surface area), each by rewriting the surface constant ($n\\,\\omega_n$) to its evaluated value and reducing the exponent $n-1$.",
+    "mathContext": "$S_1(\\rho) = 2\\pi\\rho$, $S_2(\\rho) = 4\\pi\\rho^2$. Duality: $\\frac{d}{dr}V_n = S_{n-1}$ and $V_n(r) = \\int_0^r S_{n-1}$.",
+    "significance": "central",
+    "relatedConcepts": ["derivative-integral duality", "circumference", "spherical surface area"],
+    "prerequisites": ["OQ-01 surface constants", "rewriting in Lean"]
+  },
+  {
+    "id": "cvd02-ann-05",
+    "proofId": "circumference-via-differentiation-oq-02",
+    "range": { "startLine": 123, "endLine": 159 },
+    "type": "key-step",
+    "title": "Concrete Cross-Checks: πr² and (4/3)πr³ from Scratch",
+    "content": "Rather than trusting only the abstract FTC chain, the classical integrals are evaluated directly. `circumference_integral_eq` computes $\\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2$ by pulling out the constant and applying `integral_id` ($\\int x = (b^2-a^2)/2$). `sphere_surface_integral_eq` computes $\\int_0^r 4\\pi\\rho^2\\,d\\rho = \\tfrac{4}{3}\\pi r^3$ via `integral_pow` ($\\int x^n = (b^{n+1}-a^{n+1})/(n+1)$). `disk_area_radial_shell` and `ball_volume_radial_shell` then state the $n=2$ disk area and $n=3$ ball volume as these explicit radial integrals, recovering the parent's $\\pi r^2$ and the classical $\\tfrac{4}{3}\\pi r^3$. `disk_area_presentations_agree` confirms the abstract surface integrand and the explicit $2\\pi\\rho$ yield the same integral.",
+    "mathContext": "$\\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2$; $\\int_0^r 4\\pi\\rho^2\\,d\\rho = \\tfrac{4}{3}\\pi r^3$.",
+    "significance": "central",
+    "relatedConcepts": ["direct integration", "integral_id", "integral_pow", "disk area", "ball volume"],
+    "prerequisites": ["polynomial interval integrals", "constant factor out of integral"]
+  }
+]

--- a/src/data/proofs/circumference-via-differentiation-oq-02/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-02/meta.json
@@ -1,0 +1,147 @@
+{
+  "id": "circumference-via-differentiation-oq-02",
+  "title": "Radial-Shell Decomposition: Volume as the Integral of Surface Area",
+  "slug": "circumference-via-differentiation-oq-02",
+  "description": "The parent CircumferenceViaDifferentiation proves the differential half of the area-circumference duality (d/dr(πr²) = 2πr), and OQ-01 generalizes the derivative direction to all dimensions. But the integral half — A(r) = ∫₀ʳ C(t)dt, the disk read as a union of concentric circles — was stated only informally; the parent's conclusion explicitly notes it 'does not separately formalize the integral.' This entry fills that gap in general dimension via the Fundamental Theorem of Calculus: V_n(r) = ∫₀ʳ S_{n-1}(ρ)dρ, with the annular-shell form V_n(b)−V_n(a) = ∫ₐᵇ S_{n-1}, and concrete cross-checks ∫₀ʳ 2πρ dρ = πr² and ∫₀ʳ 4πρ² dρ = (4/3)πr³ computed directly. Built on OQ-01's genuine Gamma-function n-ball definitions.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BallVolumeSurfaceDuality.lean",
+    "tags": [
+      "geometry",
+      "calculus",
+      "integration",
+      "fundamental-theorem-of-calculus",
+      "n-dimensional",
+      "surface-area",
+      "radial-shell",
+      "verified"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 161,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "assumptions": "None beyond Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Reuses OQ-01's n-ball volume and sphere-surface definitions; the integral direction is the Fundamental Theorem of Calculus applied to OQ-01's derivative identity, plus direct evaluation of ∫ρ and ∫ρ² for the concrete cases.",
+    "mathlibDependencies": [
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+        "description": "Fundamental Theorem of Calculus: ∫ₐᵇ f' = f(b) − f(a) when f has derivative f' on [a,b] and f' is interval-integrable",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus"
+      },
+      {
+        "theorem": "Continuous.intervalIntegrable",
+        "description": "A continuous function is interval-integrable (used to discharge the FTC integrability hypothesis for the surface function)",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic"
+      },
+      {
+        "theorem": "integral_id",
+        "description": "∫ₐᵇ x dx = (b² − a²)/2 (direct evaluation for the n=2 circumference integral)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrals.Basic"
+      },
+      {
+        "theorem": "integral_pow",
+        "description": "∫ₐᵇ xⁿ dx = (bⁿ⁺¹ − aⁿ⁺¹)/(n+1) (direct evaluation for the n=3 sphere integral)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Integrals.Basic"
+      },
+      {
+        "theorem": "CircumferenceViaDifferentiationOQ01.nBallVolumeFn_hasDerivAt",
+        "description": "OQ-01's core identity dV/dr = S, the hypothesis fed into the FTC to obtain the integral direction",
+        "module": "Proofs.CircumferenceViaDifferentiationOQ01"
+      }
+    ],
+    "originalContributions": [
+      "The integral direction of the volume-surface duality, V_n(r) = ∫₀ʳ S_{n-1}(ρ)dρ, formalized for general dimension n ≥ 1 — the antiderivative half the parent and OQ-01 leave unformalized",
+      "The annular-shell volume identity V_n(b) − V_n(a) = ∫ₐᵇ S_{n-1}(ρ)dρ over an arbitrary radial interval",
+      "volume_surface_duality bundling both directions (dV/dr = S from OQ-01 and V = ∫₀ʳ S from this file) as inverse statements",
+      "Direct independent evaluation of the concrete radial integrals: ∫₀ʳ 2πρ dρ = πr² (recovering the parent's disk area) and ∫₀ʳ 4πρ² dρ = (4/3)πr³ (the sphere), with the integrands shown equal to OQ-01's surface functions"
+    ],
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Archimedes' onion-peel intuition — a disk or ball is the union of concentric thin shells — is the geometric content behind both d/dr(volume) = surface and its inverse, volume = ∫ surface dr. The parent entry CircumferenceViaDifferentiation formalizes the derivative direction in 2D and OQ-01 extends it to all dimensions using the Gamma-function form ω_n = π^(n/2)/Γ(n/2+1) of the unit-ball volume. The companion integral statement — the disk (or ball) reconstituted by integrating the surface areas of its bounding spheres — has the more classical 'shell method' flavor but had not been machine-checked: the parent's conclusion explicitly records that its Lean theorem 'states the derivative direction and does not separately formalize the integral.' This entry supplies that missing half via the Fundamental Theorem of Calculus, in general dimension.",
+    "problemStatement": "Let $V_n(r) = \\omega_n r^n$ be the volume of the $n$-ball of radius $r$ and $S_{n-1}(r) = n\\,\\omega_n r^{n-1}$ the surface area of its bounding $(n-1)$-sphere (OQ-01's definitions, with $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$). Formalize the integral direction of the volume–surface duality: $V_n(r) = \\int_0^r S_{n-1}(\\rho)\\,d\\rho$ for $n \\ge 1$, together with the annular-shell form $V_n(b) - V_n(a) = \\int_a^b S_{n-1}(\\rho)\\,d\\rho$, and verify the concrete cases $\\int_0^r 2\\pi\\rho\\,d\\rho = \\pi r^2$ and $\\int_0^r 4\\pi\\rho^2\\,d\\rho = \\tfrac{4}{3}\\pi r^3$.",
+    "proofStrategy": "The engine is `intervalIntegral.integral_eq_sub_of_hasDerivAt`: feeding it OQ-01's derivative identity `nBallVolumeFn_hasDerivAt` (the surface function is the derivative of the volume) together with `Continuous.intervalIntegrable` for the surface function yields `∫ₐᵇ S = V(b) − V(a)` immediately (`integral_surface_eq_sub`). Specializing to `a = 0` and using `V_n(0) = 0` for `n ≥ 1` (via `zero_pow`) gives the radial-shell decomposition `V_n(r) = ∫₀ʳ S`. The annular-shell identity is the symmetric statement. For the concrete cross-checks, the integrands are first rewritten to closed form (`nSphereSurfaceFn_two_eq`, `nSphereSurfaceFn_three_eq`) and the integrals evaluated directly with `integral_id` (∫ρ) and `integral_pow` (∫ρ²), confirming the classical πr² and (4/3)πr³.",
+    "keyInsights": [
+      "The integral direction is genuinely distinct from the derivative direction: the parent proves dA/dr = C and OQ-01 generalizes it, but neither establishes A(r) = ∫₀ʳ C — that requires the Fundamental Theorem of Calculus, which converts the pointwise derivative statement into an antiderivative/integral statement.",
+      "`integral_eq_sub_of_hasDerivAt` needs two inputs: the derivative at every point of the interval (supplied verbatim by OQ-01's `nBallVolumeFn_hasDerivAt`) and interval-integrability of the derivative (discharged by `Continuous.intervalIntegrable`, since the surface function is a constant times a monomial). Reusing OQ-01's lemma keeps this file a clean cap on the existing tower rather than a re-derivation.",
+      "The boundary term V_n(0) = 0 holds precisely because n ≥ 1 (so 0ⁿ = 0); the n = 0 'ball' is a point with constant volume ω_0 = 1 and no surface, which is exactly the degenerate case the hypothesis 1 ≤ n excludes.",
+      "The two concrete integrals provide an independent check: rather than trusting the abstract FTC chain alone, ∫₀ʳ 2πρ dρ and ∫₀ʳ 4πρ² dρ are evaluated from scratch via integral_id and integral_pow and shown to equal πr² and (4/3)πr³ — the classical area and volume — and these integrands are proved equal to OQ-01's surface functions.",
+      "The annular-shell form V(b) − V(a) = ∫ₐᵇ S is the 'shell method' of elementary calculus made rigorous and dimension-uniform: the volume between two concentric spheres is the radial integral of the surface area swept out."
+    ]
+  },
+  "sections": [
+    {
+      "id": "continuity",
+      "title": "Continuity of the Surface Function",
+      "startLine": 47,
+      "endLine": 56,
+      "summary": "Proves `nSphereSurfaceFn_continuous`: the (n−1)-sphere surface function S(ρ) = n·ω_n·ρⁿ⁻¹ is continuous, being a constant times a monomial. This is the integrability input the Fundamental Theorem of Calculus requires."
+    },
+    {
+      "id": "ftc-integral",
+      "title": "The Integral Direction via the FTC",
+      "startLine": 58,
+      "endLine": 103,
+      "summary": "The core results. `integral_surface_eq_sub` applies `integral_eq_sub_of_hasDerivAt` to OQ-01's derivative identity to get ∫ₐᵇ S = V(b) − V(a). `shell_volume_eq_integral` is the annular-shell form. `nBallVolume_eq_integral` specializes to a=0 (using V(0)=0 for n≥1) to give the radial-shell decomposition V_n(r) = ∫₀ʳ S. `volume_surface_duality` bundles both directions."
+    },
+    {
+      "id": "low-dim-integrands",
+      "title": "Closed Form of the Integrand in Low Dimensions",
+      "startLine": 105,
+      "endLine": 121,
+      "summary": "Rewrites OQ-01's abstract surface function to classical closed form: `nSphereSurfaceFn_two_eq` gives S_1(ρ) = 2πρ (circumference) and `nSphereSurfaceFn_three_eq` gives S_2(ρ) = 4πρ² (sphere surface area)."
+    },
+    {
+      "id": "concrete-integrals",
+      "title": "Concrete Radial Integrals, Computed Directly",
+      "startLine": 123,
+      "endLine": 159,
+      "summary": "Independent cross-checks. `circumference_integral_eq` evaluates ∫₀ʳ 2πρ dρ = πr² via integral_id; `sphere_surface_integral_eq` evaluates ∫₀ʳ 4πρ² dρ = (4/3)πr³ via integral_pow. `disk_area_radial_shell` and `ball_volume_radial_shell` then state the n=2 and n=3 volumes as these explicit radial integrals, and `disk_area_presentations_agree` confirms the abstract and explicit integrands give the same integral."
+    }
+  ],
+  "conclusion": {
+    "summary": "The integral half of the volume–surface duality is now machine-checked in general dimension: for n ≥ 1, V_n(r) = ∫₀ʳ S_{n-1}(ρ)dρ (`nBallVolume_eq_integral`), with the annular-shell generalization V_n(b) − V_n(a) = ∫ₐᵇ S_{n-1} (`shell_volume_eq_integral`). The proof is a clean application of the Fundamental Theorem of Calculus to OQ-01's derivative identity, with continuity supplying integrability. Concrete radial integrals are evaluated independently — ∫₀ʳ 2πρ dρ = πr² and ∫₀ʳ 4πρ² dρ = (4/3)πr³ — recovering the classical disk area and ball volume and closing the loop the parent left open. Zero sorries, zero axioms beyond Mathlib's foundational three.",
+    "implications": "Together with the parent (2D derivative direction) and OQ-01 (general-n derivative direction), this completes both directions of the radial duality: differentiating volume gives surface area, and integrating surface area gives volume. The annular-shell identity is the rigorous, dimension-uniform 'shell method.' The same FTC pattern would extend to any radial density, suggesting a route to the co-area formula and to weighted/Riemannian volumes (cf. OQ-03's Riemannian witnesses).",
+    "openQuestions": [
+      "Can the radial-shell decomposition be transported to Mathlib's actual Lebesgue measure of Euclidean balls (via the co-area formula), so that V_n(r) = ∫₀ʳ S_{n-1} holds for volume (ball 0 r) directly rather than for the symbolic ω_n rⁿ?",
+      "Does the annular-shell identity generalize to anisotropic or weighted volumes, where the 'surface' is a flux integral of a radial density?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "circumference-via-differentiation",
+      "relationship": "extends",
+      "description": "The parent proves the derivative direction d/dr(πr²) = 2πr and states the integral direction A(r) = ∫₀ʳ C(t)dt only informally, explicitly noting its Lean theorem 'does not separately formalize the integral.' This entry formalizes exactly that integral direction, in general dimension."
+    },
+    {
+      "proofId": "circumference-via-differentiation-oq-01",
+      "relationship": "uses",
+      "description": "Reuses OQ-01's genuine n-ball volume and (n-1)-sphere surface definitions (nBallVolumeFn, nSphereSurfaceFn with ω_n = π^(n/2)/Γ(n/2+1)) and its core derivative identity nBallVolumeFn_hasDerivAt, which is the hypothesis fed into the Fundamental Theorem of Calculus here."
+    },
+    {
+      "proofId": "circumference-via-differentiation-oq-03",
+      "relationship": "complementary",
+      "description": "OQ-03 supplies Euclidean witnesses of the Riemannian dV/dr = A identity (the derivative direction with Mathlib's actual ball volume); this entry supplies the inverse integral direction for the symbolic volume functions."
+    },
+    {
+      "proofId": "fundamental-theorem-calculus",
+      "relationship": "uses",
+      "description": "The entire integral direction rests on intervalIntegral.integral_eq_sub_of_hasDerivAt: applying the FTC to OQ-01's pointwise derivative identity turns 'surface is the derivative of volume' into 'volume is the radial integral of surface.'"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/BallVolumeSurfaceDuality.lean",
+    "filename": "BallVolumeSurfaceDuality.lean",
+    "lineCount": 161,
+    "theoremCount": 12,
+    "axiomCount": 0,
+    "definitionCount": 0,
+    "sorries": 0,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallVolumeSurfaceDuality.lean"
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **integral direction** of the volume–surface duality, the half the parent and OQ-01 leave open.

- The parent `CircumferenceViaDifferentiation` proves `d/dr(πr²) = 2πr` and its conclusion explicitly states its Lean theorem *"does not separately formalize the integral"* `A(r) = ∫₀ʳ C(t)dt`.
- OQ-01 generalizes the **derivative** direction to all dimensions (`d/dr(ω_n rⁿ) = n·ω_n·rⁿ⁻¹`).
- This entry supplies the missing **antiderivative** direction via the Fundamental Theorem of Calculus, in general dimension, built on OQ-01's genuine Gamma-function n-ball definitions.

## Results

```
V_n(r) = ∫₀ʳ S_{n-1}(ρ) dρ            -- radial-shell decomposition (n ≥ 1)
V_n(b) − V_n(a) = ∫ₐᵇ S_{n-1}(ρ) dρ   -- annular-shell volume
volume_surface_duality                -- both directions bundled
```

Concrete cross-checks computed directly (not just via the abstract chain):
- `∫₀ʳ 2πρ dρ = πr²` (via `integral_id`) — recovers the disk area
- `∫₀ʳ 4πρ² dρ = (4/3)πr³` (via `integral_pow`) — the sphere

## Verification

- **12 theorems, 0 definitions, 161 lines**
- **0 sorries, 0 axioms** beyond Mathlib's foundational three (`propext`, `Classical.choice`, `Quot.sound`)
- No `native_decide`
- Built and `#print axioms`-checked with lean v4.26.0 against prebuilt Mathlib oleans

## Distinctness

Confirmed non-duplicative: the integral/FTC direction appears in neither the parent, OQ-01, nor OQ-03 (`grep` for `intervalIntegral`/`∫` returns nothing in those files). This is the inverse statement of the existing derivative results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)