### PR TITLE
Enrich 2-Adic Normal Form of the Non-Three-Square Integers

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-04/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "excluded-def",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+    "range": { "startLine": 44, "endLine": 47 },
+    "type": "definition",
+    "title": "The Excluded Family E = {4^a(8b+7)}",
+    "content": "`IsExcludedForm n` is the existential predicate n = 4^a(8b+7) for some a, b ≥ 0. By Legendre's three-square theorem, this is exactly the set of natural numbers that are NOT sums of three squares. As stated it is an unbounded existential search over the parameters (a,b); the whole point of the file is to replace it with an effective, read-off-from-n characterization.",
+    "mathContext": "$E=\\{4^a(8b+7): a,b\\ge 0\\}$ is the excluded family of Legendre's theorem: $n=x^2+y^2+z^2$ solvable $\\iff n\\notin E$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre three-square theorem", "excluded family", "existential predicate"],
+    "prerequisites": ["sums of three squares"]
+  },
+  {
+    "id": "valuation-engine",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+    "range": { "startLine": 49, "endLine": 62 },
+    "type": "theorem",
+    "title": "The 2-Adic Valuation Engine: v₂(4^a(8b+7)) = 2a",
+    "content": "`factorization_two_of_excluded`: the 2-adic valuation of 4^a(8b+7) is exactly 2a. The odd factor 8b+7 contributes nothing (it is not divisible by 2, so `Nat.factorization_eq_zero_of_not_dvd` applies) and 4^a = 2^(2a) contributes 2a (via `Nat.factorization_pow` and `Nat.Prime.factorization_self`). This single computation is the engine behind both the normal form and the uniqueness of the parametrisation.",
+    "mathContext": "$v_2\\bigl(4^a(8b+7)\\bigr)=v_2(2^{2a})+v_2(8b+7)=2a+0=2a$.",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "Nat.factorization", "2-adic valuation"],
+    "prerequisites": ["prime factorization", "p-adic valuation"]
+  },
+  {
+    "id": "uniqueness",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+    "range": { "startLine": 64, "endLine": 75 },
+    "type": "theorem",
+    "title": "Uniqueness of the Parametrisation",
+    "content": "`excludedForm_unique`: if 4^a(8b+7) = 4^a'(8b'+7) then a = a' and b = b'. Reading the 2-adic valuation off both sides gives 2a = 2a', hence a = a'; cancelling the common 4^a then forces 8b+7 = 8b'+7, hence b = b'. This well-definedness is what any counting or density statement about the excluded family must rest on — e.g. the natural density 1/6 of non-three-square integers (open question oq-04-oq-01).",
+    "mathContext": "The map $(a,b)\\mapsto 4^a(8b+7)$ is injective: $a$ is recovered as $v_2/2$, then $b$ by cancellation. Layers $4^a\\cdot(\\text{odd}\\equiv 7\\bmod 8)$ are disjoint.",
+    "significance": "key",
+    "relatedConcepts": ["injectivity", "well-definedness", "natural density", "disjoint layering"],
+    "prerequisites": ["p-adic valuation", "cancellation"]
+  },
+  {
+    "id": "normal-form",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+    "range": { "startLine": 77, "endLine": 104 },
+    "type": "theorem",
+    "title": "The 2-Adic Normal Form (Headline)",
+    "content": "`isExcludedForm_iff`: a positive integer n lies in the excluded family iff its 2-adic valuation v₂(n) is EVEN and its odd part n / 2^(v₂ n) is ≡ 7 (mod 8). This is the canonical 'solved' description — it converts the unbounded existential search over (a,b) into two arithmetic conditions read directly off n. The reverse direction reconstructs n = 2^(v₂ n) · (odd part) via `Nat.ordProj_mul_ordCompl_eq_self`, writes the odd part as 8b+7, and identifies 2^(v₂ n) = 4^a using evenness of v₂.",
+    "mathContext": "$n\\in E \\iff 0<n \\wedge \\operatorname{Even}(v_2(n)) \\wedge \\bigl(n/2^{v_2(n)}\\bigr)\\bmod 8 = 7$. The obstruction is read off the 2-adic valuation and the odd part's residue mod 8.",
+    "significance": "critical",
+    "relatedConcepts": ["normal form", "ordProj/ordCompl decomposition", "odd part", "decidability"],
+    "prerequisites": ["p-adic valuation", "modular arithmetic"]
+  },
+  {
+    "id": "lower-bound",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+    "range": { "startLine": 106, "endLine": 113 },
+    "type": "lemma",
+    "title": "Every Excluded Number Is At Least 7",
+    "content": "`excludedForm_ge_seven`: since 4^a ≥ 1 and 8b+7 ≥ 7, every element of the excluded family is ≥ 7. A clean elementary certificate that small numbers like 6 are not excluded (hence eligible to be sums of three squares) without computing any factorization.",
+    "mathContext": "$4^a(8b+7)\\ge 1\\cdot 7 = 7$, so $n<7 \\Rightarrow n\\notin E$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lower bound", "elementary certificate"],
+    "prerequisites": ["natural number inequalities"]
+  },
+  {
+    "id": "decision-procedure",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
+    "range": { "startLine": 115, "endLine": 154 },
+    "type": "definition",
+    "title": "A Computable, Classical-Free Decision Procedure",
+    "content": "`isExcludedB n` is a Bool-valued test implementing the normal form (positivity ∧ v₂ even ∧ odd part ≡ 7 mod 8), proved equivalent to IsExcludedForm by `isExcludedForm_iff_isExcludedB`. This yields the `DecidablePred IsExcludedForm` instance `instExcluded` via `decidable_of_iff` — with NO Classical.choice, an effective replacement for the parent ThreeSquares.lean's noncomputable instance. Concrete witnesses (7, 15, 28, 112 excluded; 6 not; uniqueness of 28 = 4¹(8·0+7)) confirm the machinery.",
+    "mathContext": "Membership in $E$ becomes an effective Bool computation, giving a Classical-free Decidable instance that subsumes all future membership checks.",
+    "significance": "critical",
+    "relatedConcepts": ["decidability", "computability", "Classical.choice avoidance", "decidable_of_iff"],
+    "prerequisites": ["decidable propositions", "Bool predicates"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-04/meta.json
@@ -15,6 +15,45 @@
     "sorries": 0
   },
   "title": "The 2-Adic Normal Form of the Non-Three-Square Integers",
+  "description": "The effective/structural layer of the excluded family E = {4^a(8b+7)} of Legendre's three-square theorem — the integers that are NOT sums of three squares. The headline 2-adic normal form characterizes membership by two arithmetic conditions read directly off n (even 2-adic valuation, odd part ≡ 7 mod 8), replacing the unbounded existential search over (a,b). Uniqueness of the parametrisation and a computable Classical-free decision procedure complete the picture.",
+  "overview": {
+    "historicalContext": "Legendre's three-square theorem (1798) characterizes the natural numbers representable as x²+y²+z² as exactly those NOT of the form 4^a(8b+7). The excluded set E = {4^a(8b+7)} is the carrier of the obstruction. While the representability question is classical, the *structure* of E — its 2-adic shape and the well-definedness of its (a,b) parametrisation — is the kind of effective detail formal libraries need but textbooks leave implicit. The gallery's parent ThreeSquares.lean defines E by an existential and decides membership only noncomputably (via Classical.choice). The natural density of E is exactly 1/6 (the disjoint 2-adic layers 4^a·(8b+7) contribute densities summing to (1/8)(4/3) = 1/6), a fact that rests on the uniqueness proved here. This entry supplies the canonical solved form of E and an effective decision procedure.",
+    "problemStatement": "Give an effective characterization of the excluded family E = {4^a(8b+7)}: (i) a 2-adic normal form deciding membership of a positive integer n directly from its 2-adic valuation and odd part; (ii) uniqueness of the (a,b) parametrisation; and (iii) a genuinely computable, Classical-free Decidable instance for membership.",
+    "proofStrategy": "Everything rests on one valuation computation: v₂(4^a(8b+7)) = 2a (the odd factor contributes 0, and 4^a = 2^(2a)). From it, uniqueness reads a = v₂/2 off both sides then cancels 4^a to fix b. The normal form's forward direction is immediate; the reverse reconstructs n = 2^(v₂ n)·(odd part) via Nat.ordProj_mul_ordCompl_eq_self, writes the odd part as 8b+7 (its residue mod 8 is 7), and matches 2^(v₂ n) = 4^a using evenness of v₂. The Bool test isExcludedB transcribes the normal form, and decidable_of_iff turns the equivalence into a Classical-free Decidable instance.",
+    "keyInsights": [
+      "The whole excluded family collapses to a single valuation identity v₂(4^a(8b+7)) = 2a: every structural fact (normal form, uniqueness, decidability) is a corollary of reading off the 2-adic valuation.",
+      "The 2-adic normal form replaces an unbounded existential search over (a,b) with two arithmetic conditions on n itself — the canonical move from a 'defined' set to a 'solved' one.",
+      "Uniqueness of the parametrisation is the well-definedness that any counting or density statement (the 1/6 density of non-three-square integers) silently depends on.",
+      "Choosing kernel-level factorization arithmetic over Classical yields a genuinely computable Decidable instance, an effective upgrade over the parent file's noncomputable one that subsumes all future membership checks.",
+      "Studying the EXCLUDED complement complements the sibling oq-03-oq-03's study of which non-excluded numbers are reachable — together they give the full structural picture of the three-square dichotomy."
+    ]
+  },
+  "sections": [
+    {
+      "id": "valuation",
+      "title": "The 2-Adic Valuation Engine and Uniqueness",
+      "startLine": 44,
+      "endLine": 75,
+      "summary": "Defines IsExcludedForm and computes v₂(4^a(8b+7)) = 2a (factorization_two_of_excluded), then derives uniqueness of the (a,b) parametrisation (excludedForm_unique) by reading off the valuation and cancelling.",
+      "mathContext": "v₂(4^a(8b+7)) = 2a; the parametrisation (a,b) ↦ 4^a(8b+7) is injective."
+    },
+    {
+      "id": "normal-form-section",
+      "title": "The 2-Adic Normal Form",
+      "startLine": 77,
+      "endLine": 113,
+      "summary": "isExcludedForm_iff: n ∈ E iff v₂(n) is even and the odd part is ≡ 7 (mod 8) — the existential search replaced by two read-off conditions. excludedForm_ge_seven gives the elementary lower bound n ≥ 7.",
+      "mathContext": "n ∈ E ⟺ Even(v₂ n) ∧ (n / 2^{v₂ n}) % 8 = 7; every excluded n ≥ 7."
+    },
+    {
+      "id": "decision",
+      "title": "Computable Decision Procedure and Witnesses",
+      "startLine": 115,
+      "endLine": 154,
+      "summary": "isExcludedB packages the normal form as a Bool test (isExcludedForm_iff_isExcludedB), giving a Classical-free DecidablePred instance. Concrete witnesses (7, 15, 28, 112 ∈ E; 6 ∉ E; uniqueness of 28) validate it.",
+      "mathContext": "An effective, Classical-free Decidable membership test for the excluded family."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -86,11 +125,6 @@
     }
   ],
   "crossReferences": [
-    {
-      "targetId": "lagrange-four-squares-waring-g2-oq-03",
-      "relationship": "depends-on",
-      "description": "Companion to the parent three-square sufficiency study. The parent's ThreeSquares.lean defines IsExcludedForm by the existential 4^a(8b+7) and supplies only a noncomputable decidability instance; this entry supplies the effective layer — the 2-adic normal form, the uniqueness of the parametrisation, and a computable (Classical-free) decision procedure."
-    },
     {
       "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
       "relationship": "extends",


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-04`.

## Gaps addressed
- **Missing `annotations.json`** — added 6 annotations with `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`, covering the excluded-family definition, the v₂(4^a(8b+7))=2a engine, uniqueness of the parametrisation, the 2-adic normal form, the ≥7 lower bound, and the Classical-free computable decision procedure.
- **No structured `overview`** — added `ProofOverview` (historicalContext: Legendre 1798, the 1/6 density; problemStatement; proofStrategy; 5 keyInsights).
- **No `sections`** — added 3 sections spanning the full Lean file.
- **Missing top-level `description`** — added one.
- **Dangling cross-reference** — removed the `depends-on` ref to the nonexistent `lagrange-four-squares-waring-g2-oq-03` entry (kept the valid `-oq-03-oq-03` sibling ref).

## Verification
- JSON validated; `pnpm build` passes.
- Axiom/badge metadata unchanged and accurate: 0 axioms, 0 sorries, verified/original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)