### PR TITLE
research(sqrt2357-oq-04-oq-01): ℚ-linear independence of √2,√3,√5 + distinctness of the eight conjugates [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01.lean
+++ b/proofs/Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01.lean
@@ -1,0 +1,177 @@
+/-
+# ℚ-linear independence of `{√2, √3, √5}` and distinctness of the eight conjugates
+
+(OQ-04-OQ-01 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`)
+
+The parent open question OQ-04 (`Sqrt2Sqrt3Sqrt5MultiquadraticOQ04`) supplies the
+explicit degree-8 minimal polynomial `p(x) = x⁸ - 40x⁶ + 352x⁴ - 960x² + 576`
+of `α = √2 + √3 + √5`, proving that all eight sign-conjugates `±√2 ± √3 ± √5`
+are roots and hence `[ℚ(α):ℚ] ≤ 8`.  That file explicitly flags as *open/hard*:
+
+> ℚ-linear independence of `{√2, √3, √5}`, full pairwise distinctness of the
+> eight conjugates.
+
+This file closes exactly that gap, **elementarily and without `native_decide`**:
+
+* `linearIndependent` — the three surds `√2, √3, √5` are linearly independent over
+  `ℚ`: if `a·√2 + b·√3 + c·√5 = 0` with `a, b, c ∈ ℚ` then `a = b = c = 0`.
+* `conjugates_distinct` — consequently the map
+  `(ε₁, ε₂, ε₃) ↦ ε₁√2 + ε₂√3 + ε₃√5` is injective on rational sign vectors, so
+  the eight conjugates `±√2 ± √3 ± √5` are pairwise distinct.
+
+## Method
+
+Everything reduces to the irrationality of `√6, √10, √15` (composite
+non-squares), which Mathlib supplies via `irrational_sqrt_natCast_iff`.
+
+* `sqrt_irrat_lin` packages the contradiction "if `k·√m = r` with `k, r ∈ ℚ`,
+  `k ≠ 0` and `m` a non-square, then `√m = r/k ∈ ℚ` — impossible."
+* `two_term_zero` handles a two-surd relation `p·√M + q·√N = 0`: multiplying by
+  `√M` turns it into `q·√(MN) = -M·p`, killing `q` via `sqrt_irrat_lin`
+  (`MN` not a square), then `p` since `√M > 0`.
+* `linearIndependent` squares `a·√2 = -(b·√3 + c·√5)` to expose the cross term
+  `2bc·√15`; non-squareness of `15` forces `bc = 0`, and the two resulting
+  two-surd relations are dispatched by `two_term_zero` (`M·N ∈ {6, 10}`).
+
+Every algebraic identity is discharged by `linear_combination` over the square
+relations `(√k)² = k` — no `native_decide`, no axioms beyond Lean's core.
+
+## Honest scope
+
+This is the `ℚ`-linear independence of the three generators, equivalently the
+separability/distinctness of the eight conjugate embeddings.  It does **not**
+formalize the full degree-8 basis `{1, √2, √3, √5, √6, √10, √15, √30}`,
+irreducibility of `p`, or the Galois group `(ℤ/2ℤ)³`.  Combined with the parent's
+`[ℚ(α):ℚ] ≤ 8`, the eight distinct conjugates give eight distinct real
+embeddings, which is the standard route to `[ℚ(α):ℚ] = 8` (not formalized here).
+-/
+
+import Mathlib.Data.Real.Sqrt
+import Mathlib.NumberTheory.Real.Irrational
+import Mathlib.Tactic
+
+open Real
+
+namespace Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01
+
+/-- **Irrationality packaging.** If `k·√m = r` with `k, r` rational, `k ≠ 0`, and
+`m` is not a perfect square, we reach a contradiction: `√m` would equal the
+rational `r/k`. -/
+private theorem sqrt_irrat_lin {m : ℕ} (hm : ¬ IsSquare m) (k r : ℚ) (hk : k ≠ 0)
+    (h : (k : ℝ) * Real.sqrt (m : ℝ) = (r : ℝ)) : False := by
+  have hk' : (k : ℝ) ≠ 0 := by exact_mod_cast hk
+  have hsqrt : Real.sqrt (m : ℝ) = ((r / k : ℚ) : ℝ) := by
+    rw [Rat.cast_div, eq_div_iff hk', mul_comm]; exact h
+  exact (irrational_sqrt_natCast_iff.mpr hm) ⟨r / k, hsqrt.symm⟩
+
+/-- `6` is not a perfect square (the kernel cannot `decide` this through
+`Nat.sqrt`, so we check the finitely many candidates directly). -/
+private theorem ns6 : ¬ IsSquare (6 : ℕ) := by
+  rintro ⟨r, hr⟩
+  have : r ≤ 6 := Nat.le_of_dvd (by norm_num) ⟨r, hr⟩
+  interval_cases r <;> omega
+
+/-- `10` is not a perfect square. -/
+private theorem ns10 : ¬ IsSquare (10 : ℕ) := by
+  rintro ⟨r, hr⟩
+  have : r ≤ 10 := Nat.le_of_dvd (by norm_num) ⟨r, hr⟩
+  interval_cases r <;> omega
+
+/-- `15` is not a perfect square. -/
+private theorem ns15 : ¬ IsSquare (15 : ℕ) := by
+  rintro ⟨r, hr⟩
+  have : r ≤ 15 := Nat.le_of_dvd (by norm_num) ⟨r, hr⟩
+  interval_cases r <;> omega
+
+/-- **Two-surd relation.** For naturals `M ≥ 1`, `N` with `M·N` not a perfect
+square, a relation `p·√M + q·√N = 0` over `ℚ` forces `p = q = 0`. -/
+private theorem two_term_zero {M N : ℕ} (hM : 1 ≤ M) (hMN : ¬ IsSquare (M * N))
+    (p q : ℚ)
+    (h : (p : ℝ) * Real.sqrt (M : ℝ) + (q : ℝ) * Real.sqrt (N : ℝ) = 0) :
+    p = 0 ∧ q = 0 := by
+  have hMpos : (0 : ℝ) ≤ (M : ℝ) := by positivity
+  have hmm : Real.sqrt (M : ℝ) * Real.sqrt (N : ℝ) = Real.sqrt ((M : ℝ) * (N : ℝ)) :=
+    (Real.sqrt_mul hMpos (N : ℝ)).symm
+  have hsqM : Real.sqrt (M : ℝ) * Real.sqrt (M : ℝ) = (M : ℝ) := Real.mul_self_sqrt hMpos
+  -- First kill `q`: multiplying `h` by `√M` gives `q·√(MN) = -M·p`.
+  have hq : q = 0 := by
+    by_contra hq
+    refine sqrt_irrat_lin (m := M * N) hMN q (-(M : ℚ) * p) hq ?_
+    push_cast
+    linear_combination (Real.sqrt (M : ℝ)) * h - (p : ℝ) * hsqM - (q : ℝ) * hmm
+  -- Now `p·√M = 0` and `√M > 0`, so `p = 0`.
+  refine ⟨?_, hq⟩
+  have hMrpos : (0 : ℝ) < (M : ℝ) := by exact_mod_cast hM
+  have hsqrtpos : (0 : ℝ) < Real.sqrt (M : ℝ) := Real.sqrt_pos.mpr hMrpos
+  have hpM : (p : ℝ) * Real.sqrt (M : ℝ) = 0 := by
+    rw [hq] at h; push_cast at h; linarith [h]
+  rcases mul_eq_zero.mp hpM with h1 | h2
+  · exact_mod_cast h1
+  · exact absurd h2 (ne_of_gt hsqrtpos)
+
+/-- **`√2, √3, √5` are linearly independent over `ℚ`.** If
+`a·√2 + b·√3 + c·√5 = 0` with `a, b, c ∈ ℚ`, then `a = b = c = 0`. -/
+theorem linearIndependent (a b c : ℚ)
+    (h : (a : ℝ) * Real.sqrt 2 + (b : ℝ) * Real.sqrt 3 + (c : ℝ) * Real.sqrt 5 = 0) :
+    a = 0 ∧ b = 0 ∧ c = 0 := by
+  have sq2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  have sq3 : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have sq5 : Real.sqrt 5 ^ 2 = 5 := Real.sq_sqrt (by norm_num)
+  have h35 : Real.sqrt 3 * Real.sqrt 5 = Real.sqrt 15 := by
+    rw [← Real.sqrt_mul (by norm_num : (0 : ℝ) ≤ 3)]; norm_num
+  -- Squaring `a·√2 = -(b·√3 + c·√5)` exposes the cross term `2bc·√15`.
+  have key : 2 * (b : ℝ) * (c : ℝ) * Real.sqrt 15
+      = 2 * (a : ℝ) ^ 2 - 3 * (b : ℝ) ^ 2 - 5 * (c : ℝ) ^ 2 := by
+    have e1 : ((a : ℝ) * Real.sqrt 2) ^ 2
+        = ((b : ℝ) * Real.sqrt 3 + (c : ℝ) * Real.sqrt 5) ^ 2 := by
+      have hh : (a : ℝ) * Real.sqrt 2
+          = -((b : ℝ) * Real.sqrt 3 + (c : ℝ) * Real.sqrt 5) := by linarith [h]
+      rw [hh]; ring
+    linear_combination -e1 + (a : ℝ) ^ 2 * sq2 - (b : ℝ) ^ 2 * sq3
+      - (c : ℝ) ^ 2 * sq5 - 2 * (b : ℝ) * (c : ℝ) * h35
+  -- `15` is not a square, so the only way out is `bc = 0`.
+  have hbc : b * c = 0 := by
+    by_contra hbc
+    have hk : (2 * b * c : ℚ) ≠ 0 := fun hh => hbc (by linear_combination (1 / 2 : ℚ) * hh)
+    refine sqrt_irrat_lin (m := 15) ns15 (2 * b * c)
+      (2 * a ^ 2 - 3 * b ^ 2 - 5 * c ^ 2) hk ?_
+    push_cast
+    linear_combination key
+  rcases mul_eq_zero.mp hbc with hb | hc
+  · -- `b = 0`: reduce to `a·√2 + c·√5 = 0`.
+    have h' : (a : ℝ) * Real.sqrt ((2 : ℕ) : ℝ) + (c : ℝ) * Real.sqrt ((5 : ℕ) : ℝ) = 0 := by
+      rw [hb] at h; push_cast at h ⊢; linarith [h]
+    obtain ⟨ha, hc⟩ := two_term_zero (M := 2) (N := 5) (by norm_num) ns10 a c h'
+    exact ⟨ha, hb, hc⟩
+  · -- `c = 0`: reduce to `a·√2 + b·√3 = 0`.
+    have h' : (a : ℝ) * Real.sqrt ((2 : ℕ) : ℝ) + (b : ℝ) * Real.sqrt ((3 : ℕ) : ℝ) = 0 := by
+      rw [hc] at h; push_cast at h ⊢; linarith [h]
+    obtain ⟨ha, hb⟩ := two_term_zero (M := 2) (N := 3) (by norm_num) ns6 a b h'
+    exact ⟨ha, hb, hc⟩
+
+/-- **The eight conjugates are pairwise distinct.** More generally, the map
+sending a rational sign vector `(ε₁, ε₂, ε₃)` to `ε₁√2 + ε₂√3 + ε₃√5` is
+injective: equal values force equal coefficients.  Specializing each `εᵢ, δᵢ` to
+`±1` shows the eight sign-conjugates `±√2 ± √3 ± √5` are pairwise distinct. -/
+theorem conjugates_distinct (e₁ e₂ e₃ d₁ d₂ d₃ : ℚ)
+    (h : (e₁ : ℝ) * Real.sqrt 2 + (e₂ : ℝ) * Real.sqrt 3 + (e₃ : ℝ) * Real.sqrt 5
+       = (d₁ : ℝ) * Real.sqrt 2 + (d₂ : ℝ) * Real.sqrt 3 + (d₃ : ℝ) * Real.sqrt 5) :
+    e₁ = d₁ ∧ e₂ = d₂ ∧ e₃ = d₃ := by
+  obtain ⟨h1, h2, h3⟩ := linearIndependent (e₁ - d₁) (e₂ - d₂) (e₃ - d₃)
+    (by push_cast; linear_combination h)
+  exact ⟨sub_eq_zero.mp h1, sub_eq_zero.mp h2, sub_eq_zero.mp h3⟩
+
+/-- Concrete instance: `α = √2 + √3 + √5` differs from its conjugate
+`√2 + √3 - √5` (the simplest nontrivial sign flip). -/
+theorem alpha_ne_conjugate :
+    Real.sqrt 2 + Real.sqrt 3 + Real.sqrt 5 ≠ Real.sqrt 2 + Real.sqrt 3 - Real.sqrt 5 := by
+  intro h
+  -- Cast to the `±1` sign-vector form and apply `conjugates_distinct`.
+  have h' : ((1 : ℚ) : ℝ) * Real.sqrt 2 + ((1 : ℚ) : ℝ) * Real.sqrt 3
+        + ((1 : ℚ) : ℝ) * Real.sqrt 5
+      = ((1 : ℚ) : ℝ) * Real.sqrt 2 + ((1 : ℚ) : ℝ) * Real.sqrt 3
+        + ((-1 : ℚ) : ℝ) * Real.sqrt 5 := by push_cast; linarith [h]
+  have := (conjugates_distinct 1 1 1 1 1 (-1) h').2.2
+  norm_num at this
+
+end Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sqrt2357-oq0401-overview",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Closing the OQ-04 Independence Gap",
+    "content": "The parent OQ-04 entry constructed the explicit degree-8 minimal polynomial p(x)=x⁸−40x⁶+352x⁴−960x²+576 of α=√2+√3+√5 and proved that all eight sign-conjugates ±√2±√3±√5 are roots, giving [ℚ(α):ℚ] ≤ 8. It explicitly named two open ingredients: ℚ-linear independence of {√2,√3,√5} and pairwise distinctness of the eight conjugates. This file supplies both. The strategy is uniform: a single squaring turns the rank-3 relation a√2+b√3+c√5=0 into one with an isolated irrational cross term 2bc√15, whose rational coefficient must vanish; the leftover two-surd relations are killed by promoting them to a product radical (√10 or √6). Every step reduces to the irrationality of a composite-radical surd (√6, √10, √15), pulled from Mathlib via irrational_sqrt_natCast_iff.",
+    "mathContext": "Linear independence of $\\{\\sqrt2,\\sqrt3,\\sqrt5\\}$ over $\\mathbb{Q}$ is the rank-3 case of Besicovitch's 1940 independence theorem, absent from Mathlib v4.26.0. Combined with the parent's $[\\mathbb{Q}(\\alpha):\\mathbb{Q}]\\le8$, the eight distinct conjugates supply eight distinct real embeddings — the standard path to the exact degree $8$ and Galois group $(\\mathbb{Z}/2\\mathbb{Z})^3$.",
+    "significance": "key",
+    "relatedConcepts": ["linear independence", "multiquadratic field", "Galois conjugates", "Besicovitch independence"],
+    "prerequisites": ["irrationality of √n for non-square n", "minimal polynomial and field degree"]
+  },
+  {
+    "id": "ann-sqrt2357-oq0401-irrat-packaging",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+    "range": { "startLine": 57, "endLine": 84 },
+    "type": "insight",
+    "title": "The Irrational Obstruction, and Non-Squares Without decide",
+    "content": "sqrt_irrat_lin isolates the one place the argument meets number theory: if k·√m = r with k,r∈ℚ, k≠0, and m not a perfect square, then √m = r/k would be rational, contradicting Mathlib's irrational_sqrt_natCast_iff. The non-square facts ¬IsSquare 6, 10, 15 cannot be discharged by decide — Lean's Decidable (IsSquare n) instance routes through well-founded Nat.sqrt, which the kernel will not reduce — so ns6/ns10/ns15 instead bound a hypothetical root r ≤ n via Nat.le_of_dvd and exhaust the finitely many candidates with interval_cases and omega. This keeps the proof free of native_decide and hence genuinely 0-axiom (no Lean.ofReduceBool).",
+    "mathContext": "$\\mathrm{Irrational}(\\sqrt m)\\iff\\neg\\mathrm{IsSquare}\\,m$; for $m\\in\\{6,10,15\\}$ this holds since each sits strictly between consecutive perfect squares. A rational $k\\sqrt m=r$ with $k\\neq0$ would put $\\sqrt m=r/k$ in $\\mathbb{Q}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["irrational_sqrt_natCast_iff", "IsSquare", "Nat.sqrt", "kernel reduction", "native_decide avoidance"],
+    "prerequisites": ["Irrational as non-membership in range of ℚ↪ℝ", "decidability pitfalls of Nat.sqrt"]
+  },
+  {
+    "id": "ann-sqrt2357-oq0401-two-term",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+    "range": { "startLine": 86, "endLine": 110 },
+    "type": "insight",
+    "title": "two_term_zero — Killing a Two-Surd Relation by a Product Radical",
+    "content": "For naturals M≥1 and N with M·N not a perfect square, p·√M+q·√N=0 over ℚ forces p=q=0. The trick is to multiply by √M rather than square: linear_combination over √M·√M=M and √M·√N=√(MN) turns the relation into q·√(MN)=−M·p, an equation of the form handled by sqrt_irrat_lin. Non-squareness of M·N kills q; then p·√M=0 with √M>0 (Real.sqrt_pos) kills p. This is the rank-2 independence engine, reused twice inside the headline.",
+    "mathContext": "Promoting $p\\sqrt M+q\\sqrt N=0$ to the product radical $\\sqrt{MN}$ exposes a single irrational term whose rational coefficient $q$ must vanish; positivity of $\\sqrt M$ then forces $p=0$. The radical exponents never grow, unlike repeated squaring.",
+    "significance": "key",
+    "relatedConcepts": ["Real.sqrt_mul", "Real.mul_self_sqrt", "Real.sqrt_pos", "linear_combination"],
+    "prerequisites": ["√M·√N = √(MN) for M ≥ 0", "positivity of √M for M > 0"]
+  },
+  {
+    "id": "ann-sqrt2357-oq0401-lin-indep",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+    "range": { "startLine": 112, "endLine": 150 },
+    "type": "insight",
+    "title": "linearIndependent — Squaring Out the Cross Term",
+    "content": "The headline: a·√2+b·√3+c·√5=0 with a,b,c∈ℚ forces a=b=c=0. From a·√2 = −(b·√3+c·√5), squaring gives (a√2)²=(b√3+c√5)², which the lemma key rewrites — by linear_combination over (√2)²=2, (√3)²=3, (√5)²=5 and √3·√5=√15 — into 2bc·√15 = 2a²−3b²−5c². The right side is rational, so since √15 is irrational the coefficient 2bc must be 0, hence bc=0. The two branches b=0 (residual relation has product radical √10) and c=0 (product radical √6) are closed by two_term_zero, and the zero variable is carried along to assemble a=b=c=0.",
+    "mathContext": "Squaring cancels the $\\sqrt2$ and leaves exactly one cross term $2bc\\,\\sqrt{15}$ against an otherwise rational equation; irrationality of $\\sqrt{15}$ forces $bc=0$, splitting the rank-3 relation into two rank-2 relations that the two-surd lemma destroys.",
+    "significance": "key",
+    "relatedConcepts": ["linear independence over ℚ", "successive squaring", "Real.sq_sqrt", "mul_eq_zero"],
+    "prerequisites": ["square relations (√k)² = k", "two_term_zero", "case split on bc = 0"]
+  },
+  {
+    "id": "ann-sqrt2357-oq0401-distinctness",
+    "proofId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+    "range": { "startLine": 152, "endLine": 177 },
+    "type": "concept",
+    "title": "conjugates_distinct — Eight Distinct Conjugates",
+    "content": "conjugates_distinct restates linear independence as injectivity: if ε₁√2+ε₂√3+ε₃√5 = δ₁√2+δ₂√3+δ₃√5 with rational coefficients, then linearIndependent applied to the differences (εᵢ−δᵢ) forces εᵢ=δᵢ. Specialising each εᵢ,δᵢ to ±1 shows the eight sign-conjugates ±√2±√3±√5 are pairwise distinct. alpha_ne_conjugate is the concrete witness: α=√2+√3+√5 ≠ √2+√3−√5, the simplest sign flip, obtained by reading off the third coordinate of conjugates_distinct on the vectors (1,1,1) and (1,1,−1).",
+    "mathContext": "Injectivity of the rational-coefficient-to-value map is exactly $\\mathbb{Q}$-linear independence restated; on sign vectors $\\{\\pm1\\}^3$ it produces the eight distinct Galois conjugates of $\\alpha$, equivalently eight distinct real embeddings of $\\mathbb{Q}(\\alpha)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["injectivity", "Galois conjugates", "sub_eq_zero", "real embeddings"],
+    "prerequisites": ["linearIndependent", "coefficient differences as a relation"]
+  }
+]

--- a/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01/meta.json
@@ -1,0 +1,144 @@
+{
+  "id": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+  "title": "ℚ-Linear Independence of √2, √3, √5 and Distinctness of the Eight Conjugates",
+  "slug": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04-oq-01",
+  "description": "Closes the open gap flagged by OQ-04 (the degree-8 minimal polynomial of √2+√3+√5): proves that √2, √3, √5 are linearly independent over ℚ, hence the eight sign-conjugates ±√2±√3±√5 are pairwise distinct. The OQ-04 entry constructed the explicit degree-8 polynomial p(x)=x⁸−40x⁶+352x⁴−960x²+576 and showed all eight sign-conjugates are roots (giving [ℚ(α):ℚ] ≤ 8), but explicitly left as open/hard the ℚ-linear independence of {√2,√3,√5} and the distinctness of those eight conjugates. This entry supplies exactly that, elementarily and without native_decide. linearIndependent: a·√2+b·√3+c·√5=0 with a,b,c∈ℚ forces a=b=c=0. The proof squares a·√2 = −(b·√3+c·√5) to expose the cross term 2bc·√15; since 15 is not a perfect square (√15 irrational, via Mathlib's irrational_sqrt_natCast_iff) the rational coefficient 2bc must vanish, and each resulting two-surd relation p·√M+q·√N=0 collapses by multiplying through by √M (turning it into q·√(MN)=−M·p with MN∈{6,10} non-square). conjugates_distinct then restates this as injectivity of (ε₁,ε₂,ε₃)↦ε₁√2+ε₂√3+ε₃√5 on rational sign vectors, so the eight conjugates are pairwise distinct. 8 theorems, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01.lean",
+    "tags": [
+      "linear-independence",
+      "irrationality",
+      "algebraic-numbers",
+      "square-roots",
+      "multiquadratic-field",
+      "number-theory",
+      "field-theory",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only the foundational propext, Classical.choice, Quot.sound (no Lean.ofReduceBool — no native_decide; no sorryAx). Uses Mathlib's irrational_sqrt_natCast_iff (Irrational (√n) ↔ ¬IsSquare n) as the only number-theoretic leaf, supplying the irrationality of √6, √10, √15; everything else (the squaring/reduction argument) is elementary and self-contained.",
+    "lineCount": 177,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "linearIndependent: √2, √3, √5 are linearly independent over ℚ — a·√2+b·√3+c·√5=0 (a,b,c∈ℚ) ⟹ a=b=c=0. This statement is absent from Mathlib v4.26.0 and is exactly the open gap named by the parent OQ-04 entry. Proof: square to expose the cross term 2bc·√15, force bc=0 by non-squareness of 15, then dispatch the two residual two-surd relations.",
+      "conjugates_distinct: the map (ε₁,ε₂,ε₃)↦ε₁√2+ε₂√3+ε₃√5 is injective on rational coefficient vectors; specialising εᵢ,δᵢ∈{±1} shows the eight sign-conjugates ±√2±√3±√5 are pairwise distinct — the second open item flagged by OQ-04.",
+      "two_term_zero: reusable two-surd lemma — for naturals M≥1, N with M·N not a perfect square, a relation p·√M+q·√N=0 over ℚ forces p=q=0. Multiplying by √M converts it to q·√(MN)=−M·p, killing q via the irrationality of √(MN), then p since √M>0.",
+      "sqrt_irrat_lin: the irrationality-packaging core — if k·√m=r with k,r∈ℚ, k≠0, and m not a perfect square, then √m=r/k∈ℚ, contradicting irrational_sqrt_natCast_iff. The single point of contact with Mathlib's irrationality API.",
+      "ns6 / ns10 / ns15: ¬IsSquare 6, 10, 15 proved by bounded case-checking (Nat.le_of_dvd + interval_cases + omega) rather than decide, since kernel reduction of Nat.sqrt stalls — keeping the file native_decide-free and 0-axiom.",
+      "alpha_ne_conjugate: concrete instance — α = √2+√3+√5 ≠ √2+√3−√5, the simplest nontrivial sign flip, derived from conjugates_distinct."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The multiquadratic field $\\mathbb{Q}(\\sqrt2,\\sqrt3,\\sqrt5)$ has degree $2^3=8$ over $\\mathbb{Q}$ with Galois group $(\\mathbb{Z}/2\\mathbb{Z})^3$; $\\alpha=\\sqrt2+\\sqrt3+\\sqrt5$ is a primitive element whose eight Galois conjugates are the sign-combinations $\\pm\\sqrt2\\pm\\sqrt3\\pm\\sqrt5$. The parent open question OQ-04 produced the explicit degree-8 minimal polynomial $p(x)=x^8-40x^6+352x^4-960x^2+576$ and verified that all eight conjugates are roots, establishing $[\\mathbb{Q}(\\alpha):\\mathbb{Q}]\\le 8$, but flagged as open the two ingredients needed for the matching lower bound: $\\mathbb{Q}$-linear independence of $\\{\\sqrt2,\\sqrt3,\\sqrt5\\}$ and pairwise distinctness of the eight conjugates. Both are instances of A. S. Besicovitch's 1940 theorem (linear independence of fractional powers of integers), which Mathlib does not yet carry. This entry proves the rank-3 case directly and elementarily.",
+    "problemStatement": "Prove that $\\sqrt2,\\sqrt3,\\sqrt5$ are linearly independent over $\\mathbb{Q}$, and deduce that the eight sign-conjugates $\\pm\\sqrt2\\pm\\sqrt3\\pm\\sqrt5$ are pairwise distinct (the open ingredients of OQ-04 of `sqrt2-plus-sqrt3-plus-sqrt5-irrational`).",
+    "text": "Suppose $a\\sqrt2+b\\sqrt3+c\\sqrt5=0$ with $a,b,c\\in\\mathbb{Q}$. Move and square: $(a\\sqrt2)^2=(b\\sqrt3+c\\sqrt5)^2$ gives $2a^2=3b^2+5c^2+2bc\\sqrt{15}$, so $2bc\\sqrt{15}=2a^2-3b^2-5c^2\\in\\mathbb{Q}$. Since $\\sqrt{15}$ is irrational ($15$ is not a perfect square), the rational coefficient $2bc$ must be $0$, i.e. $bc=0$. If $b=0$ the relation becomes $a\\sqrt2+c\\sqrt5=0$; multiplying by $\\sqrt2$ yields $c\\sqrt{10}=-2a$, and $\\sqrt{10}$ irrational forces $c=0$, whence $a\\sqrt2=0$ and $a=0$. The case $c=0$ is symmetric with $\\sqrt6$ in place of $\\sqrt{10}$. Hence $a=b=c=0$. Distinctness of the eight conjugates is the contrapositive: if two sign-conjugates coincide, their difference is a relation $(\\varepsilon_1-\\delta_1)\\sqrt2+(\\varepsilon_2-\\delta_2)\\sqrt3+(\\varepsilon_3-\\delta_3)\\sqrt5=0$ with rational coefficients, forcing $\\varepsilon_i=\\delta_i$.",
+    "proofStrategy": "Successive squaring + irrationality of composite-radical surds. The squaring step isolates a single cross term whose surd ($\\sqrt{15}$, resp. $\\sqrt6,\\sqrt{10}$) is irrational, so its rational coefficient must vanish; this peels the rank-3 relation down to rank-1 surd equations that close by positivity of $\\sqrt M$. Every algebraic identity is a `linear_combination` over the square relations $(\\sqrt k)^2=k$; the only number-theoretic input is Mathlib's `irrational_sqrt_natCast_iff`, applied through the reusable wrapper `sqrt_irrat_lin`. No `native_decide`: the non-square facts $\\neg\\mathrm{IsSquare}\\,6,10,15$ are proved by bounded `interval_cases`+`omega` because kernel `Nat.sqrt` reduction stalls under `decide`.",
+    "keyInsights": [
+      "Squaring turns a rank-3 surd relation into a single irrational obstruction. From $a\\sqrt2=-(b\\sqrt3+c\\sqrt5)$, squaring cancels $\\sqrt2$ and leaves exactly one cross term $2bc\\sqrt{15}$ against an otherwise rational equation. Irrationality of $\\sqrt{15}$ then forces $bc=0$ — a clean rank reduction without computing any minimal polynomial.",
+      "Multiplying (not squaring) clears the two-surd tail. For $p\\sqrt M+q\\sqrt N=0$, multiplying by $\\sqrt M$ gives $pM+q\\sqrt{MN}=0$, i.e. $q\\sqrt{MN}=-pM$; the product radical $\\sqrt{MN}$ (with $MN$ non-square) is the obstruction killing $q$, after which $p\\sqrt M=0$ and $\\sqrt M>0$ kill $p$. The exponents never blow up.",
+      "Linear independence ⟺ distinct conjugates ⟺ distinct embeddings. `conjugates_distinct` is `linearIndependent` applied to coefficient differences; with $\\varepsilon_i,\\delta_i\\in\\{\\pm1\\}$ it gives the eight distinct conjugates, equivalently eight distinct real embeddings of $\\mathbb{Q}(\\alpha)$ — the standard route from the parent's $[\\mathbb{Q}(\\alpha):\\mathbb{Q}]\\le8$ to the exact value $8$.",
+      "Composite-radical irrationality from a single Mathlib lemma. The whole argument bottoms out at $\\neg\\mathrm{IsSquare}\\,n$ for $n\\in\\{6,10,15\\}$ fed through `irrational_sqrt_natCast_iff`; this is the only non-elementary ingredient, and Mathlib supplies it for arbitrary non-square $n$, so the method generalises to any three squarefree radicals with pairwise non-square products.",
+      "Kernel `decide` cannot evaluate `Nat.sqrt`. The non-square facts must avoid `decide` (its `Decidable (IsSquare n)` instance stalls on well-founded `Nat.sqrt` in the kernel); a three-line `Nat.le_of_dvd`/`interval_cases`/`omega` check keeps the proof `native_decide`-free and therefore genuinely 0-axiom."
+    ],
+    "prerequisites": [
+      "irrational_sqrt_natCast_iff : Irrational (√n) ↔ ¬IsSquare n (Mathlib)",
+      "Real.sqrt_mul / Real.sq_sqrt / Real.mul_self_sqrt : square-root product and squaring identities",
+      "Real.sqrt_pos : 0 < √x ↔ 0 < x",
+      "linear_combination over the square relations (√k)² = k",
+      "Nat.le_of_dvd + interval_cases + omega for ¬IsSquare on small numbers"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-method",
+      "title": "Overview — Closing the OQ-04 Independence Gap",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring: the parent OQ-04 entry built the degree-8 minimal polynomial and proved [ℚ(α):ℚ] ≤ 8, leaving ℚ-linear independence of {√2,√3,√5} and distinctness of the eight conjugates open. This file closes both, reducing everything to the irrationality of √6, √10, √15 via squaring and a two-surd elimination lemma.",
+      "mathContext": "Linear independence of $\\{\\sqrt2,\\sqrt3,\\sqrt5\\}$ over $\\mathbb{Q}$ is the rank-3 case of Besicovitch's theorem; combined with the parent's upper bound it yields $[\\mathbb{Q}(\\alpha):\\mathbb{Q}]=8$ via eight distinct real embeddings."
+    },
+    {
+      "id": "irrat-packaging",
+      "title": "sqrt_irrat_lin — Packaging the Irrational Obstruction",
+      "startLine": 57,
+      "endLine": 65,
+      "summary": "If k·√m = r with k,r∈ℚ, k≠0, and m not a perfect square, derive a contradiction: √m would equal the rational r/k. This is the single point of contact with Mathlib's irrationality API (irrational_sqrt_natCast_iff).",
+      "mathContext": "$k\\sqrt m=r$ with $k\\neq0$ gives $\\sqrt m=r/k\\in\\mathbb{Q}$, contradicting $\\mathrm{Irrational}(\\sqrt m)$, which holds exactly when $m$ is not a perfect square."
+    },
+    {
+      "id": "non-squares",
+      "title": "ns6 / ns10 / ns15 — Non-Squares Without decide",
+      "startLine": 67,
+      "endLine": 84,
+      "summary": "¬IsSquare 6, 10, 15, each proved by bounding a hypothetical root r ≤ n via Nat.le_of_dvd and exhausting the finitely many cases with interval_cases and omega — avoiding decide, whose Decidable (IsSquare n) instance stalls on kernel Nat.sqrt reduction.",
+      "mathContext": "$6,10,15$ lie strictly between consecutive squares ($4{<}6{<}9$, $9{<}10{<}16$, $9{<}15{<}16$), so none is a perfect square; the bounded check certifies this in the kernel without native code."
+    },
+    {
+      "id": "two-term",
+      "title": "two_term_zero — The Two-Surd Elimination",
+      "startLine": 86,
+      "endLine": 110,
+      "summary": "For M≥1 and N with M·N not a square, p·√M+q·√N=0 forces p=q=0. Multiplying through by √M (linear_combination over √M·√M=M and √M·√N=√(MN)) gives q·√(MN)=−M·p; sqrt_irrat_lin kills q, then p·√M=0 with √M>0 kills p.",
+      "mathContext": "A rank-2 surd relation $p\\sqrt M+q\\sqrt N=0$ is destroyed by promoting it to the product radical $\\sqrt{MN}$: non-squareness of $MN$ forces $q=0$, and positivity of $\\sqrt M$ then forces $p=0$."
+    },
+    {
+      "id": "lin-indep",
+      "title": "linearIndependent — The Headline",
+      "startLine": 112,
+      "endLine": 150,
+      "summary": "a·√2+b·√3+c·√5=0 (a,b,c∈ℚ) ⟹ a=b=c=0. Squaring a·√2 = −(b·√3+c·√5) exposes the cross term 2bc·√15 (key, by linear_combination over the square relations and √3·√5=√15); non-squareness of 15 forces bc=0, and the cases b=0 (M·N=10) and c=0 (M·N=6) close via two_term_zero.",
+      "mathContext": "The squaring isolates one irrational cross term; $\\sqrt{15}\\notin\\mathbb{Q}$ forces $bc=0$, splitting into two rank-2 relations whose product radicals $\\sqrt{10},\\sqrt6$ finish the descent. The three surds are therefore $\\mathbb{Q}$-linearly independent."
+    },
+    {
+      "id": "distinctness",
+      "title": "conjugates_distinct & alpha_ne_conjugate — Distinct Conjugates",
+      "startLine": 152,
+      "endLine": 177,
+      "summary": "conjugates_distinct: equal values of ε₁√2+ε₂√3+ε₃√5 force equal rational coefficients (linearIndependent on the differences). alpha_ne_conjugate: the concrete instance √2+√3+√5 ≠ √2+√3−√5 via the ±1 sign-vector form.",
+      "mathContext": "Injectivity of the coefficient-to-value map is linear independence restated; on sign vectors $\\{\\pm1\\}^3$ it yields the eight pairwise-distinct Galois conjugates of $\\alpha$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms; #print axioms shows only propext/Classical.choice/Quot.sound, no Lean.ofReduceBool): linearIndependent proves √2,√3,√5 are ℚ-linearly independent, and conjugates_distinct deduces the eight sign-conjugates ±√2±√3±√5 are pairwise distinct. Build verified at Mathlib v4.26.0 by single-file elaboration. The argument is elementary — successive squaring/multiplication reducing to the irrationality of √6, √10, √15 — with no native_decide and no minimal-polynomial machinery. 8 theorems, 177 lines.",
+    "implications": "Closes the two open ingredients (ℚ-linear independence of {√2,√3,√5} and distinctness of the eight conjugates) flagged by OQ-04 of the parent `sqrt2-plus-sqrt3-plus-sqrt5-irrational` entry. Combined with OQ-04's [ℚ(α):ℚ] ≤ 8, the eight distinct conjugates give eight distinct real embeddings — the standard route to the exact degree [ℚ(α):ℚ] = 8 (the field-degree count itself is not formalized here). two_term_zero and sqrt_irrat_lin are reusable for any rank-≤3 surd-independence question with non-square pairwise products.",
+    "openQuestions": [
+      "Formalize the full degree-8 ℚ-basis {1,√2,√3,√5,√6,√10,√15,√30} as linearly independent, upgrading rank-3 independence of the generators to the field-degree statement [ℚ(√2,√3,√5):ℚ] = 8.",
+      "Prove [ℚ(α):ℚ] = 8 by combining these eight distinct embeddings with OQ-04's degree-8 annihilator (i.e. irreducibility of p over ℚ, equivalently that the eight conjugates are a single Galois orbit), and identify the Galois group as (ℤ/2ℤ)³.",
+      "Generalize two_term_zero / linearIndependent to n squarefree radicals with pairwise non-square products (the rank-n Besicovitch independence theorem), currently absent from Mathlib."
+    ]
+  },
+  "leanFile": {
+    "namespace": "Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01",
+    "lineCount": 177,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational-oq-04",
+      "relationship": "extends",
+      "description": "Parent open question: the explicit degree-8 minimal polynomial p(x)=x⁸−40x⁶+352x⁴−960x²+576 of √2+√3+√5 and the fact that all eight sign-conjugates are roots, giving [ℚ(α):ℚ] ≤ 8. OQ-04 explicitly left ℚ-linear independence of {√2,√3,√5} and distinctness of the eight conjugates as open/hard; this entry supplies both, providing the distinct-roots half of the matching lower bound."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+      "relationship": "related",
+      "description": "Root gallery entry: irrationality of √2+√3+√5. Linear independence of the three generators is the structural fact underlying that irrationality and the degree-8 multiquadratic field."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational-oq-03",
+      "relationship": "related",
+      "description": "Rank-2 analogue: the degree-4 minimal polynomial X⁴−10X²+1 of √2+√3 and linear independence of {√2,√3}. The two-surd lemma two_term_zero here is exactly the rank-2 independence engine, here promoted to settle the rank-3 case."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the open gap explicitly flagged by **OQ-04** (the degree-8 minimal polynomial of √2+√3+√5, PR #27757). That entry built `p(x)=x⁸−40x⁶+352x⁴−960x²+576`, proved all eight sign-conjugates `±√2±√3±√5` are roots (`[ℚ(α):ℚ] ≤ 8`), and named as *open/hard*:

> ℚ-linear independence of `{√2, √3, √5}`, full pairwise distinctness of the eight conjugates.

This PR supplies **both**, elementarily and **without `native_decide`**.

## Results (`Proofs/Sqrt2Sqrt3Sqrt5MultiquadraticOQ04OQ01.lean`)

- **`linearIndependent`** — `a·√2 + b·√3 + c·√5 = 0` with `a,b,c ∈ ℚ` ⟹ `a=b=c=0`. Square `a·√2 = −(b·√3+c·√5)` to expose the single cross term `2bc·√15`; non-squareness of `15` forces `bc=0`; the two residual two-surd relations collapse via `two_term_zero` (product radicals `√10`, `√6`).
- **`conjugates_distinct`** — injectivity of `(ε₁,ε₂,ε₃) ↦ ε₁√2+ε₂√3+ε₃√5` on rational sign vectors, so the eight conjugates `±√2±√3±√5` are pairwise distinct.
- **`two_term_zero` / `sqrt_irrat_lin`** — reusable two-surd elimination, bottoming out at Mathlib's `irrational_sqrt_natCast_iff` (irrationality of `√6, √10, √15`).
- **`alpha_ne_conjugate`** — concrete instance `√2+√3+√5 ≠ √2+√3−√5`.

## Verification

- **8 theorems, 0 sorries, 0 axioms.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`** (the `¬IsSquare 6/10/15` facts use bounded `interval_cases`+`omega`, avoiding `decide`'s stalling `Nat.sqrt` kernel reduction).
- Built at Mathlib v4.26.0 via single-file elaboration (docker fleet down this session).
- Badge `original`: the linear-independence assembly is new (absent from Mathlib v4.26.0); only the composite-radical irrationality leaves come from Mathlib.

## Honest scope

This is rank-3 independence of the generators, equivalently distinctness of the eight conjugate embeddings. It does **not** formalize the full degree-8 basis `{1,√2,√3,√5,√6,√10,√15,√30}`, irreducibility of `p`, the field-degree count `[ℚ(α):ℚ]=8`, or the Galois group `(ℤ/2ℤ)³`. Combined with OQ-04's `≤ 8`, the eight distinct conjugates give eight distinct real embeddings — the standard route to the exact degree (not formalized here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)