### PR TITLE
research(harmonic-divergence-oq-03): alternating harmonic series = log 2 via Abel's theorem [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2799,6 +2799,7 @@ import Proofs.HappyNumberOQ01
 import Proofs.HarmonicDivergence
 import Proofs.HarmonicDivergenceOQ01
 import Proofs.HarmonicDivergenceOQ02
+import Proofs.HarmonicDivergenceOQ03
 import Proofs.HarmonicDivergenceOQ04
 import Proofs.HarmonicDivergenceOQ05
 import Proofs.HermiteLindemann

--- a/proofs/Proofs/HarmonicDivergenceOQ03.lean
+++ b/proofs/Proofs/HarmonicDivergenceOQ03.lean
@@ -1,0 +1,153 @@
+import Mathlib
+
+/-!
+# The Alternating Harmonic Series Sums to `log 2`
+
+## What This Proves
+Where the parent entry shows the *harmonic* series `∑ 1/n` diverges, this
+companion settles its alternating cousin: the **alternating harmonic series**
+
+  `1 - 1/2 + 1/3 - 1/4 + ⋯ = log 2`
+
+converges, and its value is exactly `Real.log 2` (the Mercator / Mengoli
+series). Inserting a sign turns a divergent series into a convergent one with a
+clean closed form.
+
+## Why this is not immediate from Mathlib
+Mathlib provides the Mercator power series only on the *open* interval:
+`Real.hasSum_pow_div_log_of_abs_lt_one` gives
+`∑ x^(n+1)/(n+1) = -log(1-x)` for `|x| < 1`. The alternating harmonic series is
+the **boundary value** `x → 1⁻`, which is *not* covered by that lemma — the
+power series there is only conditionally convergent. Bridging the interior
+series to the boundary requires **Abel's limit theorem**
+(`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`), exactly as Mathlib's
+`Real.tendsto_sum_pi_div_four` does for Leibniz's series for `π`.
+
+## Approach (mirrors Mathlib's Leibniz proof)
+1. **Convergence.** The terms `1/(n+1)` are antitone and tend to `0`, so the
+   alternating series test gives convergence to *some* limit `l`.
+2. **Generating function.** For `0 < x < 1`,
+   `∑' n, (-1)^n/(n+1) · xⁿ = log(1+x)/x`, obtained from the Mercator series at
+   `-x` by multiplying by `-1/x`.
+3. **Abel.** Abel's theorem identifies the boundary limit of the power series
+   with `l`, so `l = lim_{x→1⁻} log(1+x)/x`.
+4. **Continuity.** `x ↦ log(1+x)/x` is continuous at `1` with value
+   `log 2 / 1 = log 2`, pinning `l = log 2`.
+
+## Status
+- [x] Complete proof, 0 sorries
+- [x] `altHarmonic_tendsto_log_two`: partial sums `→ log 2`
+- [x] `not_summable_altTerm`: the series is only *conditionally* convergent
+  (no `tsum`/`HasSum` value exists), justifying the ordered-limit formulation
+- [x] Generating-function identity and convergence as reusable lemmas
+
+## Mathlib Dependencies
+- `Real.hasSum_pow_div_log_of_abs_lt_one` (Mercator series, `|x| < 1`)
+- `Real.tendsto_tsum_powerSeries_nhdsWithin_lt` (Abel's limit theorem)
+- `Antitone.tendsto_alternating_series_of_tendsto_zero` (alternating series test)
+-/
+
+namespace HarmonicAlt
+
+open Filter Finset
+open scoped Topology
+
+/-- The `n`-th term of the alternating harmonic series, `(-1)^n / (n+1)`.
+Indexing from `0`, so `altTerm 0 = 1`, `altTerm 1 = -1/2`, `altTerm 2 = 1/3`, … -/
+noncomputable def altTerm (n : ℕ) : ℝ := (-1) ^ n / (n + 1)
+
+/-- The `N`-th partial sum `∑_{i<N} (-1)^i/(i+1)`. -/
+noncomputable def altPartial (N : ℕ) : ℝ := ∑ i ∈ range N, altTerm i
+
+/-- **Generating function of the alternating harmonic series.**
+For `|x| < 1` and `x ≠ 0`, the power series `∑ (-1)^n/(n+1) · xⁿ` evaluates to
+`log(1+x)/x`. Derived from the Mercator series `∑ y^(n+1)/(n+1) = -log(1-y)` at
+`y = -x`, scaled by `-1/x`. -/
+theorem hasSum_altTerm_mul_pow {x : ℝ} (hx : |x| < 1) (hx0 : x ≠ 0) :
+    HasSum (fun n => altTerm n * x ^ n) (Real.log (1 + x) / x) := by
+  -- Mercator series at `-x`.
+  have hbase : HasSum (fun n : ℕ => (-x) ^ (n + 1) / ((n : ℝ) + 1)) (-Real.log (1 - -x)) :=
+    Real.hasSum_pow_div_log_of_abs_lt_one (x := -x) (by rwa [abs_neg])
+  -- Scale by `-1/x`.
+  have hscaled := hbase.mul_left (-1 / x)
+  -- Identify the value.
+  have hval : (-1 / x) * (-Real.log (1 - -x)) = Real.log (1 + x) / x := by
+    rw [show (1 : ℝ) - -x = 1 + x by ring]
+    field_simp
+  -- Identify the terms.
+  have hterm : (fun n : ℕ => (-1 / x) * ((-x) ^ (n + 1) / ((n : ℝ) + 1)))
+      = (fun n : ℕ => altTerm n * x ^ n) := by
+    funext n
+    have hn : (n : ℝ) + 1 ≠ 0 := by positivity
+    simp only [altTerm]
+    rw [neg_pow, pow_succ (-1 : ℝ) n, pow_succ x n]
+    field_simp
+  rw [hval, hterm] at hscaled
+  exact hscaled
+
+/-- **Convergence of the alternating harmonic series** via the alternating
+series test: the terms `1/(n+1)` are antitone and tend to `0`. -/
+theorem exists_tendsto_altPartial : ∃ l : ℝ, Tendsto altPartial atTop (𝓝 l) := by
+  have hanti : Antitone (fun n : ℕ => (1 : ℝ) / (n + 1)) := by
+    intro a b hab
+    exact one_div_le_one_div_of_le (by positivity)
+      (by exact_mod_cast Nat.add_le_add_right hab 1)
+  have hzero : Tendsto (fun n : ℕ => (1 : ℝ) / (n + 1)) atTop (𝓝 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat
+  obtain ⟨l, hl⟩ := hanti.tendsto_alternating_series_of_tendsto_zero hzero
+  refine ⟨l, hl.congr fun n => ?_⟩
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [altTerm]
+  ring
+
+/-- **The alternating harmonic series sums to `log 2`** (partial-sum form):
+`1 - 1/2 + 1/3 - 1/4 + ⋯ → log 2`. -/
+theorem altHarmonic_tendsto_log_two :
+    Tendsto altPartial atTop (𝓝 (Real.log 2)) := by
+  obtain ⟨l, hl⟩ := exists_tendsto_altPartial
+  -- Abel's limit theorem: the power series has boundary limit `l` as `x → 1⁻`.
+  have abel : Tendsto (fun x => ∑' n, altTerm n * x ^ n) (𝓝[<] (1 : ℝ)) (𝓝 l) :=
+    Real.tendsto_tsum_powerSeries_nhdsWithin_lt hl
+  -- On `(0,1)` the power series equals `log(1+x)/x`.
+  have hgen : Tendsto (fun x : ℝ => Real.log (1 + x) / x) (𝓝[<] (1 : ℝ)) (𝓝 l) := by
+    refine abel.congr' ?_
+    filter_upwards
+      [(eventually_gt_nhds (show (0 : ℝ) < 1 by norm_num)).filter_mono nhdsWithin_le_nhds,
+       (eventually_mem_nhdsWithin : ∀ᶠ x in 𝓝[<] (1 : ℝ), x ∈ Set.Iio (1 : ℝ))]
+      with x hx0 hxlt
+    have hax : |x| < 1 := by
+      rw [abs_lt]; exact ⟨by linarith, hxlt⟩
+    exact (hasSum_altTerm_mul_pow hax (ne_of_gt hx0)).tsum_eq
+  -- Continuity pins the limit to `log 2`.
+  have hcont : Tendsto (fun x : ℝ => Real.log (1 + x) / x) (𝓝[<] (1 : ℝ))
+      (𝓝 (Real.log 2)) := by
+    have hlog : Tendsto (fun x : ℝ => Real.log (1 + x)) (𝓝 (1 : ℝ)) (𝓝 (Real.log 2)) := by
+      have : Real.log 2 = Real.log (1 + 1) := by norm_num
+      rw [this]
+      exact ((Real.continuousAt_log (by norm_num : (1 : ℝ) + 1 ≠ 0)).comp
+        (by fun_prop : ContinuousAt (fun x : ℝ => 1 + x) 1)).tendsto
+    have hden : Tendsto (fun x : ℝ => x) (𝓝 (1 : ℝ)) (𝓝 (1 : ℝ)) := tendsto_id
+    have hdiv := hlog.div hden (by norm_num : (1 : ℝ) ≠ 0)
+    rw [div_one] at hdiv
+    exact hdiv.mono_left nhdsWithin_le_nhds
+  -- Uniqueness of limits forces `l = log 2`.
+  have : l = Real.log 2 := tendsto_nhds_unique hgen hcont
+  rwa [this] at hl
+
+/-- **The alternating harmonic series is not (unconditionally) summable.**
+Although the partial sums converge to `log 2`, the convergence is only
+*conditional*: `∑ |(-1)^n/(n+1)| = ∑ 1/(n+1)` diverges. Over `ℝ` (a
+finite-dimensional space) unconditional summability coincides with absolute
+summability, so `altTerm` is not `Summable`. This is exactly why the value
+must be defined via the *ordered* limit of partial sums (and reached through
+Abel's theorem), not via `tsum`. -/
+theorem not_summable_altTerm : ¬ Summable altTerm := by
+  rw [← summable_norm_iff]
+  have hnorm : (fun n => ‖altTerm n‖) = (fun n : ℕ => 1 / ((n : ℝ) + 1)) := by
+    funext n
+    simp only [altTerm, norm_div, norm_pow, norm_neg, norm_one, one_pow]
+    rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
+  rw [hnorm]
+  have h := mt (summable_nat_add_iff (f := fun n : ℕ => 1 / (n : ℝ)) 1).mp
+    Real.not_summable_one_div_natCast
+  simpa using h

--- a/research/registry.json
+++ b/research/registry.json
@@ -18201,11 +18201,11 @@
     },
     {
       "slug": "harmonic-divergence-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-22T13:25:40.357Z",
       "status": "active",
-      "lastUpdate": "2026-04-22T13:25:40.357Z"
+      "lastUpdate": "2026-06-22T22:15:31-07:00"
     },
     {
       "slug": "harmonic-divergence-oq-04",

--- a/src/data/proofs/harmonic-divergence-oq-03/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-03/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "harmonic-divergence-oq-03",
+  "title": "The Alternating Harmonic Series Sums to log 2 (Mercator/Mengoli)",
+  "slug": "harmonic-divergence-oq-03",
+  "description": "Settles the alternating cousin of the divergent harmonic series: 1 − 1/2 + 1/3 − 1/4 + ⋯ converges, and its value is exactly log 2. Because this is the boundary value x → 1⁻ of the Mercator power series — outside Mathlib's |x| < 1 lemma — the proof routes through Abel's limit theorem, mirroring Mathlib's Leibniz-series-for-π proof. Also records that the series is only conditionally convergent (not Summable), which is precisely why the value must be taken as an ordered limit of partial sums rather than a tsum.",
+  "meta": {
+    "author": "Mercator/Mengoli (17th c.); formalization original to this gallery",
+    "status": "verified",
+    "proofRepoPath": "Proofs/HarmonicDivergenceOQ03.lean",
+    "tags": [
+      "analysis",
+      "series",
+      "harmonic-series",
+      "alternating-series",
+      "logarithm",
+      "abel-theorem",
+      "conditional-convergence",
+      "power-series"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.hasSum_pow_div_log_of_abs_lt_one",
+        "description": "Mercator power series ∑ xⁿ⁺¹/(n+1) = −log(1−x) for |x| < 1 (interior only)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Deriv"
+      },
+      {
+        "theorem": "Real.tendsto_tsum_powerSeries_nhdsWithin_lt",
+        "description": "Abel's limit theorem: a real power series converging at 1 is left-continuous there",
+        "module": "Mathlib.Analysis.Complex.AbelLimit"
+      },
+      {
+        "theorem": "Antitone.tendsto_alternating_series_of_tendsto_zero",
+        "description": "Alternating series test: antitone terms tending to 0 give a convergent alternating series",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "summable_norm_iff",
+        "description": "In finite dimensions, unconditional summability coincides with absolute summability",
+        "module": "Mathlib.Analysis.Normed.Module.FiniteDimension"
+      },
+      {
+        "theorem": "Real.not_summable_one_div_natCast",
+        "description": "The harmonic series ∑ 1/n is not summable",
+        "module": "Mathlib.Analysis.PSeries"
+      }
+    ],
+    "originalContributions": [
+      "altHarmonic_tendsto_log_two: the headline result — the partial sums of 1 − 1/2 + 1/3 − ⋯ converge to Real.log 2 — obtained by Abel's limit theorem on the boundary x → 1⁻ of the Mercator series, a value not directly available in Mathlib",
+      "hasSum_altTerm_mul_pow: the generating-function identity ∑ (−1)ⁿ/(n+1)·xⁿ = log(1+x)/x for 0 < x < 1, derived from the Mercator series at −x scaled by −1/x",
+      "exists_tendsto_altPartial: conditional convergence of the alternating harmonic series via the alternating series test (antitone 1/(n+1) → 0)",
+      "not_summable_altTerm: the series is NOT (unconditionally) summable — ∑|(−1)ⁿ/(n+1)| = ∑ 1/(n+1) diverges — so it has no tsum/HasSum value, justifying the ordered-limit formulation of the sum"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. #print axioms reports only propext, Classical.choice, Quot.sound for all theorems.",
+    "lineCount": 153,
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The series 1 − 1/2 + 1/3 − 1/4 + ⋯ = log 2 is the Mercator series (Nicolaus Mercator, 1668; also attributed to Mengoli), the alternating-sign sibling of the harmonic series. Where inserting all-positive signs gives a divergent series (the parent entry), the alternating signs produce a conditionally convergent series whose sum is the natural logarithm of 2. The cleanest modern route is Abel's limit theorem: the Maclaurin series of log(1+x) converges for |x| < 1, and Abel's theorem lets one pass to the boundary value at x = 1. Mathlib uses exactly this device for Leibniz's series for π (arctan at 1); here the same machinery delivers log 2.",
+    "problemStatement": "How does the alternating harmonic series 1 − 1/2 + 1/3 − 1/4 + ⋯ = ln 2 relate to the (divergent) harmonic series?\n\n**Answer:** Inserting alternating signs converts divergence into conditional convergence with the closed value log 2. The sum is an ordered limit of partial sums (the series is not absolutely — hence not unconditionally — summable), and its value is pinned by Abel's limit theorem applied to the Mercator power series at the boundary x → 1⁻.",
+    "text": "A fully verified proof that the alternating harmonic series converges to log 2, via Abel's limit theorem on the boundary of the Mercator power series, together with the fact that the convergence is only conditional.",
+    "proofStrategy": "1. hasSum_altTerm_mul_pow: for 0 < x < 1, start from Mathlib's Mercator series at −x, ∑ (−x)ⁿ⁺¹/(n+1) = −log(1+x); multiply by −1/x and simplify the terms to ∑ (−1)ⁿ/(n+1)·xⁿ = log(1+x)/x.\n2. exists_tendsto_altPartial: the alternating series test (terms 1/(n+1) antitone, → 0) gives convergence of the partial sums to some limit l.\n3. altHarmonic_tendsto_log_two: Abel's theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt) sends the power series to l as x → 1⁻; on (0,1) the power series equals log(1+x)/x, which is continuous at 1 with value log 2 / 1 = log 2. Uniqueness of limits forces l = log 2.\n4. not_summable_altTerm: via summable_norm_iff, Summable would force ∑|(−1)ⁿ/(n+1)| = ∑ 1/(n+1) to converge, contradicting harmonic divergence.",
+    "keyInsights": [
+      "**Signs tame divergence**: the harmonic series diverges, but the same magnitudes with alternating signs converge — to log 2. The contrast is the whole point of the entry.",
+      "**A genuine boundary value**: Mathlib's Mercator lemma only covers |x| < 1; the alternating harmonic series sits exactly at x = 1, where the series is merely conditionally convergent. Abel's limit theorem is what bridges interior to boundary.",
+      "**Same device as Leibniz/π**: the proof structurally mirrors Mathlib's Real.tendsto_sum_pi_div_four (arctan at 1 ↦ π/4); here log(1+x)/x at 1 ↦ log 2.",
+      "**Conditional, not absolute**: not_summable_altTerm records that the series has no tsum/HasSum value. The sum log 2 is intrinsically an ordered limit — a clean illustration of why HasSum (unconditional) ≠ convergence of partial sums for real series.",
+      "**Generating function as the workhorse**: the identity ∑ (−1)ⁿ/(n+1)·xⁿ = log(1+x)/x packages all the analytic content; everything else is the alternating series test plus a continuity/uniqueness argument."
+    ],
+    "prerequisites": [
+      "Real analysis (power series, radius of convergence, conditional vs absolute convergence)",
+      "Abel's limit theorem",
+      "The logarithm and its Maclaurin (Mercator) series",
+      "Filters and limits (nhdsWithin, Tendsto) in Lean/Mathlib"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "The Alternating Term and Partial Sums",
+      "startLine": 55,
+      "endLine": 60,
+      "summary": "Defines altTerm n = (−1)ⁿ/(n+1) (so altTerm 0 = 1, altTerm 1 = −1/2, …) and altPartial N = ∑_{i<N} altTerm i, the ordered partial sums whose limit is the value of the series.",
+      "mathContext": "altPartial N = ∑_{i=0}^{N−1} (−1)ⁱ/(i+1) = 1 − 1/2 + 1/3 − ⋯ ± 1/N."
+    },
+    {
+      "id": "generating-function",
+      "title": "Generating Function: ∑ (−1)ⁿ/(n+1) xⁿ = log(1+x)/x",
+      "startLine": 62,
+      "endLine": 87,
+      "summary": "hasSum_altTerm_mul_pow: for |x| < 1, x ≠ 0, the power series sums to log(1+x)/x. Obtained from Mathlib's Mercator series at −x by scaling by −1/x and simplifying (−x)ⁿ⁺¹ via neg_pow/pow_succ.",
+      "mathContext": "From ∑ (−x)ⁿ⁺¹/(n+1) = −log(1+x), multiply by −1/x: ∑ (−1)ⁿ/(n+1)·xⁿ = log(1+x)/x."
+    },
+    {
+      "id": "convergence",
+      "title": "Conditional Convergence (Alternating Series Test)",
+      "startLine": 88,
+      "endLine": 102,
+      "summary": "exists_tendsto_altPartial: the terms 1/(n+1) are antitone (one_div_le_one_div_of_le) and tend to 0 (tendsto_one_div_add_atTop_nhds_zero_nat), so the alternating series test yields convergence of altPartial to some limit l.",
+      "mathContext": "Leibniz's alternating series test: ∑ (−1)ⁿ aₙ converges whenever aₙ ↓ 0; here aₙ = 1/(n+1)."
+    },
+    {
+      "id": "main-abel",
+      "title": "The Value is log 2 (Abel's Limit Theorem)",
+      "startLine": 104,
+      "endLine": 142,
+      "summary": "altHarmonic_tendsto_log_two: Abel's theorem identifies the boundary limit of the power series with l. On (0,1) the power series equals log(1+x)/x, continuous at 1 with value log 2. Uniqueness of limits gives l = log 2.",
+      "mathContext": "lim_{x→1⁻} ∑ altTerm n · xⁿ = lim_{x→1⁻} log(1+x)/x = log 2, so the partial-sum limit l equals log 2."
+    },
+    {
+      "id": "not-summable",
+      "title": "Only Conditionally Convergent",
+      "startLine": 144,
+      "endLine": 153,
+      "summary": "not_summable_altTerm: via summable_norm_iff, Summable altTerm would force ∑ 1/(n+1) to converge, contradicting harmonic divergence. Hence no tsum/HasSum value — the sum is intrinsically an ordered limit.",
+      "mathContext": "‖altTerm n‖ = 1/(n+1); ∑ 1/(n+1) diverges, so altTerm is not (unconditionally) summable over ℝ."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Mercator, Nicolaus",
+      "title": "Logarithmotechnia",
+      "year": "1668",
+      "note": "Series expansion of log(1+x); the value at x=1 is the alternating harmonic series = log 2"
+    },
+    {
+      "authors": "Abel, Niels Henrik",
+      "title": "Untersuchungen über die Reihe 1 + (m/1)x + …",
+      "year": "1826",
+      "note": "Abel's limit theorem, used here to pass to the boundary value of the power series"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "harmonic-divergence",
+      "relationship": "contrasts",
+      "description": "The parent shows ∑ 1/n diverges; this entry shows the same magnitudes with alternating signs converge to log 2 (conditionally)"
+    },
+    {
+      "targetId": "harmonic-divergence-oq-05",
+      "relationship": "sibling",
+      "description": "OQ-05 quantifies the divergence rate of the positive harmonic series; OQ-03 treats the alternating series and its closed value log 2"
+    }
+  ],
+  "conclusion": {
+    "summary": "The alternating harmonic series 1 − 1/2 + 1/3 − ⋯ converges to log 2. The proof passes from Mathlib's interior Mercator series to the boundary x = 1 via Abel's limit theorem (the same device Mathlib uses for Leibniz's π/4 series), and records that the convergence is only conditional, so the value is an ordered limit rather than a tsum.",
+    "implications": "A clean worked example of (i) extracting a boundary value of a power series with Abel's theorem and (ii) the distinction between conditional convergence of partial sums and Mathlib's unconditional Summable/HasSum. The generating-function identity log(1+x)/x is reusable for related logarithmic series.",
+    "openQuestions": [
+      "Can the general Dirichlet-eta / alternating p-series ∑ (−1)ⁿ/(n+1)^s be given closed boundary values (e.g. η(1) = log 2) by the same Abel route?",
+      "Does the same method formalize ∑ (−1)ⁿ/(2n+1) = π/4 from arctan, unifying the Leibniz and Mercator boundary values under one lemma?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Finset"
+    ],
+    "namespace": "HarmonicAlt",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 2,
+    "path": "Proofs/HarmonicDivergenceOQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/harmonic-divergence-oq-03.json
+++ b/src/data/research/problems/harmonic-divergence-oq-03.json
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: alternating harmonic = log 2, 0-axiom verified (PR pending)",
+    "builtItems": [
+      "altHarmonic_tendsto_log_two: partial sums → log 2 (HarmonicDivergenceOQ03.lean)",
+      "hasSum_altTerm_mul_pow: generating function ∑(−1)ⁿ/(n+1)xⁿ = log(1+x)/x",
+      "exists_tendsto_altPartial: convergence via alternating series test",
+      "not_summable_altTerm: conditional (not unconditional) convergence"
+    ],
+    "insights": [
+      "Alternating harmonic series 1−1/2+1/3−⋯ = log 2 is the boundary value x→1⁻ of the Mercator power series; Mathlib only has the interior |x|<1 lemma (hasSum_pow_div_log_of_abs_lt_one), so Abel's limit theorem is required.",
+      "Series is only conditionally convergent: ¬Summable altTerm (via summable_norm_iff + harmonic divergence), so the sum is an ordered limit of partial sums, not a tsum/HasSum."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

Settles the alternating cousin of the divergent harmonic series:
```
1 − 1/2 + 1/3 − 1/4 + ⋯ = log 2
```
the **Mercator/Mengoli series**. This answers `harmonic-divergence-oq-03` ("how does the alternating harmonic series = ln 2 relate?").

## Why this isn't a Mathlib one-liner

Mathlib's Mercator series `Real.hasSum_pow_div_log_of_abs_lt_one` covers only the **open** interval `|x| < 1`. The alternating harmonic series is the **boundary value** `x → 1⁻`, where the series is merely *conditionally* convergent. Bridging interior to boundary requires **Abel's limit theorem** (`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`) — exactly the device Mathlib uses for its Leibniz-series-for-π proof (`Real.tendsto_sum_pi_div_four`).

## Results (`proofs/Proofs/HarmonicDivergenceOQ03.lean`)

| Theorem | Statement |
|---|---|
| `altHarmonic_tendsto_log_two` | partial sums `→ Real.log 2` (headline) |
| `hasSum_altTerm_mul_pow` | generating function `∑ (−1)ⁿ/(n+1)·xⁿ = log(1+x)/x` for `0<x<1` |
| `exists_tendsto_altPartial` | convergence via the alternating series test |
| `not_summable_altTerm` | only **conditionally** convergent — no `tsum`/`HasSum` value |

The last lemma is a deliberate honesty point: `HasSum altTerm (log 2)` would be **false** in Mathlib (it requires *unconditional* convergence), so the value is correctly stated as the ordered limit of partial sums.

## Verification

- 153 lines, 4 theorems / 2 defs, **0 sorries**
- `#print axioms` on all theorems reports only `propext`, `Classical.choice`, `Quot.sound` → **0 axioms** by project policy (no `sorryAx`, no `Lean.ofReduceBool`)
- Built against Mathlib v4.26.0 (Docker daemon down this session; verified via single-file Lean v4.26.0 elaboration against prebuilt Mathlib oleans + olean axiom check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)