### PR TITLE
Enrich Natural Density of the Non-Three-Square Integers Is 1/6

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "descent-facts",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": { "startLine": 51, "endLine": 83 },
+    "type": "theorem",
+    "title": "2-Adic Descent Facts for the Excluded Family",
+    "content": "Three elementary facts about E = {4^a(8b+7)}, reusing the predicate and decidability from the sibling oq-03-oq-04. `mod8_seven_excluded`: any n ≡ 7 (mod 8) is excluded (take a=0). `four_mul_excluded_iff`: 4k is excluded iff k is — multiplying by 4 just shifts the exponent a. `excluded_not_dvd_four_iff`: for n not divisible by 4, being excluded is the same as n ≡ 7 (mod 8). These are the self-similarity facts that power the counting recursion: the excluded set splits into a residue class plus a scaled copy of itself.",
+    "mathContext": "$n\\equiv 7\\ (8)\\Rightarrow n\\in E$; $4k\\in E\\iff k\\in E$; and for $4\\nmid n$, $n\\in E\\iff n\\equiv 7\\ (8)$.",
+    "significance": "key",
+    "relatedConcepts": ["self-similarity", "2-adic descent", "excluded family", "residue classes"],
+    "prerequisites": ["modular arithmetic", "divisibility"]
+  },
+  {
+    "id": "counting-function",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": { "startLine": 85, "endLine": 108 },
+    "type": "definition",
+    "title": "The Counting Function and Residue Count",
+    "content": "`excludedCount N` = #{n < N : n ∈ E}, a genuine Finset.card thanks to oq-03-oq-04's computable decidability. It vanishes for N ≤ 7 (no excluded number is below 7). `card_mod8_seven` proves the exact residue count #{n < N : n ≡ 7 (mod 8)} = ⌊N/8⌋ by a clean Finset induction matching the divisibility recurrence — the elementary half of the descent.",
+    "mathContext": "$\\mathrm{excludedCount}(N)=\\#\\{n<N:n\\in E\\}$; $\\#\\{n<N:n\\equiv 7\\ (8)\\}=\\lfloor N/8\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": ["counting function", "Finset.card", "residue counting"],
+    "prerequisites": ["Finset cardinality", "induction"]
+  },
+  {
+    "id": "bijection",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": { "startLine": 110, "endLine": 152 },
+    "type": "theorem",
+    "title": "Splitting the Excluded Set: Residue Class + Scaled Copy",
+    "content": "The two halves of the descent. `filter_notdvd_eq_mod8`: the part of E below N not divisible by 4 is exactly the ≡ 7 (mod 8) residue class. `excludedCount_dvd_part`: the divisible-by-4 part is in explicit bijection (via n ↦ n/4 with inverse k ↦ 4k, using `Finset.card_bij'`) with the excluded set below ⌈N/4⌉. The bijection rests on the multiply-by-4 descent four_mul_excluded_iff. Together they exhibit E ∩ [0,N) as a residue class disjointly unioned with a 1/4-scaled copy of itself.",
+    "mathContext": "$E\\cap[0,N) = \\{n\\equiv 7\\,(8)\\} \\sqcup 4\\cdot\\bigl(E\\cap[0,\\lceil N/4\\rceil)\\bigr)$; the second part is in bijection with $E\\cap[0,\\lceil N/4\\rceil)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_bij'", "explicit bijection", "self-similar set", "disjoint partition"],
+    "prerequisites": ["Finset bijections", "divisibility"]
+  },
+  {
+    "id": "recursion",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": { "startLine": 154, "endLine": 164 },
+    "type": "theorem",
+    "title": "The 4-Descent Counting Recursion",
+    "content": "`excludedCount_rec`: excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉. Assembled from the residue count and the bijection via `Finset.filter_card_add_filter_neg_card_eq_card` (split by divisibility-by-4) and omega. This self-similar recursion is the engine of the entire density computation — it encodes the geometric series Σ 1/(8·4^a) = 1/6 without ever forming an infinite sum.",
+    "mathContext": "$\\mathrm{excludedCount}(N)=\\lfloor N/8\\rfloor + \\mathrm{excludedCount}(\\lceil N/4\\rceil)$; unrolling gives $\\sum_a \\frac{N}{8\\cdot 4^a}=\\frac{N}{6}$.",
+    "significance": "critical",
+    "relatedConcepts": ["recursion", "geometric series", "self-similarity", "Waring g(2)=4"],
+    "prerequisites": ["counting recursions"]
+  },
+  {
+    "id": "error-bound",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": { "startLine": 166, "endLine": 206 },
+    "type": "theorem",
+    "title": "Logarithmic Error Bound by Strong Induction",
+    "content": "`excludedCount_error_bound`: |6·excludedCount N − N| ≤ 6·(log₂ N + 1). Proved by strong induction directly from the recursion. Each descent step perturbs the error 6·excludedCount N − N by a bounded amount (the per-step δ = 6⌊N/8⌋ + ⌈N/4⌉ − N is ≤ 6 in absolute value, via the division identities), and the descent depth is log₂-controlled (each step at most halves N, so log₂ M + 1 ≤ log₂ N). This pins the constant 1/6 as a single inductive invariant rather than through an infinite sum.",
+    "mathContext": "$|6\\,\\mathrm{excludedCount}(N)-N|\\le 6(\\log_2 N+1)$: the deviation from $N/6$ is only logarithmic, established by a bounded per-step perturbation over a log-depth descent.",
+    "significance": "critical",
+    "relatedConcepts": ["strong induction", "error term", "Nat.log", "inductive invariant"],
+    "prerequisites": ["strong induction", "logarithms", "integer arithmetic"]
+  },
+  {
+    "id": "density",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05",
+    "range": { "startLine": 208, "endLine": 284 },
+    "type": "theorem",
+    "title": "The Density Theorem: Exactly 1/6 (Headline)",
+    "content": "`excludedCount_density`: excludedCount N / N → 1/6 — asymptotically one integer in six is NOT a sum of three squares (equivalently requires all four squares of Lagrange's theorem, the extremal numbers for Waring's g(2)=4). It follows by a squeeze: the deviation |excludedCount N / N − 1/6| equals |6·excludedCount N − N| / (6N) ≤ (log₂ N + 1)/N, and the helper lemmas (natLog2_le_realLog, tendsto_logBound_zero) drive that to 0 using the standard Real.log N / N → 0 (`Real.isLittleO_log_id_atTop`). Sanity checks confirm excludedCount 8 = 1, 16 = 2, 32 = 5.",
+    "mathContext": "$\\frac{\\mathrm{excludedCount}(N)}{N}\\to\\frac16$. The non-three-square integers have natural density exactly $1/6$.",
+    "significance": "critical",
+    "relatedConcepts": ["natural density", "squeeze theorem", "asymptotic density", "log N / N → 0", "Lagrange four-square theorem"],
+    "prerequisites": ["limits", "asymptotic analysis", "little-o notation"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05/meta.json
@@ -20,6 +20,45 @@
     "sorries": 0
   },
   "title": "The Natural Density of the Non-Three-Square Integers Is 1/6",
+  "description": "The quantitative capstone of the three-square exceptional family E = {4^a(8b+7)}: the integers that are NOT sums of three squares have natural density exactly 1/6. The proof builds a 4-descent counting recursion excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉ from the self-similar structure of E, derives an explicit logarithmic error bound by strong induction, and concludes via the standard log N / N → 0. Asymptotically, one integer in six requires all four squares of Lagrange's theorem.",
+  "overview": {
+    "historicalContext": "By Legendre's three-square theorem (1798), the integers not representable as x²+y²+z² are exactly the excluded family E = {4^a(8b+7)} — precisely the numbers that require the full four squares in Lagrange's four-square theorem (1770), i.e. the extremal numbers for Waring's problem g(2) = 4. While which integers lie in E is classical, how RARE they are is a natural quantitative question not previously formalized in the gallery. The heuristic answer is a geometric series: the disjoint 2-adic layers 4^a·(8b+7) contribute densities 1/(8·4^a) summing to (1/8)(4/3) = 1/6. Turning this heuristic into a theorem — a rigorous natural-density statement with a controlled error term — is the content of this entry, the quantitative sequel to oq-03-oq-04's structural 2-adic normal form.",
+    "problemStatement": "Prove that the excluded family E = {4^a(8b+7)} has natural density exactly 1/6: with excludedCount N = #{n < N : n ∈ E}, show excludedCount N / N → 1/6 as N → ∞. Equivalently, the asymptotic proportion of integers that are not sums of three squares (that need all four squares) is one in six.",
+    "proofStrategy": "Exploit the self-similarity of E. The descent facts (n ≡ 7 mod 8 ⟹ excluded; 4k excluded ⟺ k excluded) split E ∩ [0,N) into the residue class {n ≡ 7 mod 8} (exactly ⌊N/8⌋ elements) and a bijective 1/4-scaled copy of E (via n ↦ n/4), giving the recursion excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉. Strong induction on this recursion yields the explicit bound |6·excludedCount N − N| ≤ 6(log₂ N + 1): each step perturbs the error by ≤ 6 over a log-depth descent. Dividing by 6N and squeezing with (log₂ N + 1)/N → 0 (from Real.log N / N → 0) gives the density 1/6.",
+    "keyInsights": [
+      "The excluded family is 2-adically self-similar — a residue class plus a 1/4-scaled copy of itself — and that single structural fact reduces the whole density computation to one recursion.",
+      "The constant 1/6 = Σ 1/(8·4^a) is the value of a geometric series, but the proof never forms an infinite sum: it is captured as a single inductive invariant (the logarithmic error bound), which is both cleaner and constructively sharper.",
+      "The deviation from perfect density is only logarithmic, |6·excludedCount N − N| ≤ 6(log₂ N + 1), so the convergence is fast and the error is explicit — more than the bare density limit requires.",
+      "The result quantifies Waring's g(2) = 4: a positive proportion, exactly 1/6, of all integers genuinely need the fourth square; the four-square theorem is not 'almost always' overkill but necessary one-sixth of the time.",
+      "The descent-plus-residue method is general: it computes the density of any 2-adically self-similar set as a geometric series plus a logarithmic remainder, and should transfer to the exceptional sets of other ternary quadratic genera."
+    ]
+  },
+  "sections": [
+    {
+      "id": "structure",
+      "title": "2-Adic Structure and the Counting Function",
+      "startLine": 51,
+      "endLine": 152,
+      "summary": "Records the descent facts (n ≡ 7 mod 8 ⟹ excluded; 4k excluded ⟺ k excluded), defines excludedCount, counts the residue class (card_mod8_seven = ⌊N/8⌋), and exhibits the divisible-by-4 part as a bijective scaled copy of E (excludedCount_dvd_part via Finset.card_bij').",
+      "mathContext": "E ∩ [0,N) splits as {n ≡ 7 mod 8} ⊔ 4·(E ∩ [0,⌈N/4⌉))."
+    },
+    {
+      "id": "recursion-bound",
+      "title": "The Recursion and Logarithmic Error Bound",
+      "startLine": 154,
+      "endLine": 206,
+      "summary": "Assembles the 4-descent recursion excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉ (excludedCount_rec), then proves the explicit bound |6·excludedCount N − N| ≤ 6(log₂ N + 1) by strong induction (excludedCount_error_bound), pinning the constant 1/6.",
+      "mathContext": "excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉; |6·excludedCount N − N| ≤ 6(log₂ N + 1)."
+    },
+    {
+      "id": "density-section",
+      "title": "The Density Theorem and Sanity Checks",
+      "startLine": 208,
+      "endLine": 303,
+      "summary": "Squeezes the deviation |excludedCount N / N − 1/6| ≤ (log₂ N + 1)/N to 0 via the standard log N / N → 0, proving excludedCount N / N → 1/6 (excludedCount_density). Sanity checks confirm excludedCount 8 = 1, 16 = 2, 32 = 5.",
+      "mathContext": "excludedCount N / N → 1/6 — the non-three-square integers have natural density exactly one in six."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -96,11 +135,6 @@
       "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-04",
       "relationship": "extends",
       "description": "Direct sequel: oq-03-oq-04 supplies the 2-adic normal form, uniqueness of the 4^a(8b+7) parametrisation, and the computable Decidable instance for E; this entry uses that decidability to define the counting function excludedCount and answers oq-03-oq-04's own follow-up question (density 1/6), realizing the geometric-series heuristic stated there as a fully verified limit."
-    },
-    {
-      "targetId": "lagrange-four-squares-waring-g2-oq-03",
-      "relationship": "depends-on",
-      "description": "Companion to the parent three-square sufficiency study. By Legendre's theorem the non-three-square integers are exactly E; this entry quantifies how rare they are (density 1/6), giving the asymptotic frequency of the numbers that require all four squares in Waring's g(2) = 4."
     },
     {
       "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-03",


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-05`.

## Gaps addressed
- **Missing `annotations.json`** — added 6 annotations with `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`, covering the 2-adic descent facts, the counting function & residue count, the residue-class/scaled-copy split (Finset.card_bij'), the 4-descent recursion, the logarithmic error bound (strong induction), and the headline density theorem.
- **No structured `overview`** — added `ProofOverview` (historicalContext: Legendre 1798, Lagrange, Waring g(2)=4, the geometric-series heuristic; problemStatement; proofStrategy; 5 keyInsights).
- **No `sections`** — added 3 sections spanning the full Lean file.
- **Missing top-level `description`** — added one.
- **Dangling cross-reference** — removed the `depends-on` ref to the nonexistent `lagrange-four-squares-waring-g2-oq-03` entry (kept the valid `-oq-03-oq-04` and `-oq-03-oq-03` sibling refs).

## Verification
- JSON validated; `pnpm build` passes.
- Axiom/badge metadata unchanged and accurate: 0 axioms, 0 sorries, verified/original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)