### PR TITLE
research(zsqrtd-neg-two-oq-02): bridge three-square obstruction to parent ℤ[√−2] norm form [0-axiom verified]

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ02.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ02.lean
@@ -136,4 +136,27 @@ theorem sumThreeSq_ne_four_pow_mul {n : ℤ} (a b : ℕ)
   rintro rfl
   exact not_sumThreeSq_four_pow_mul a b h
 
+/-! ## Step 4 — the bridge back to the parent ℤ[√−2] norm form `x² + 2y²`
+
+The parent gallery entry `Proofs/ZsqrtdNegTwo.lean` develops the norm form `x² + 2y²` of
+`ℤ[√−2]`.  These two lemmas place that development *inside* the three-square picture and
+show it is compatible with the Legendre obstruction proved above: every norm-form value is
+a sum of three squares, and consequently no norm-form value is of the excluded shape
+`4^a (8b + 7)`.  This is the elementary inclusion side — the ℤ[√−2] representable numbers
+are a (proper, ~36 %) subset of the sums of three squares, never the full converse. -/
+
+/-- **Norm-form inclusion.**  Every value of the ℤ[√−2] norm form `x² + 2y²` is a sum of
+three integer squares, via the trivial splitting `x² + 2y² = x² + y² + y²`. -/
+theorem normForm_isSumThreeSq (x y : ℤ) :
+    ∃ a b c : ℤ, a ^ 2 + b ^ 2 + c ^ 2 = x ^ 2 + 2 * y ^ 2 :=
+  ⟨x, y, y, by ring⟩
+
+/-- **Norm-form values avoid the Legendre excluded form.**  Combining the inclusion with the
+obstruction: `x² + 2y²` is never of the form `4^a (8b + 7)`.  So the ℤ[√−2] representable
+numbers respect the three-square obstruction — a consistency check tying the parent norm-form
+development to the necessity direction proved here. -/
+theorem normForm_ne_four_pow_mul (x y : ℤ) (a b : ℕ) :
+    x ^ 2 + 2 * y ^ 2 ≠ 4 ^ a * (8 * b + 7) :=
+  sumThreeSq_ne_four_pow_mul a b (normForm_isSumThreeSq x y)
+
 end ZsqrtNegTwoOQ02

--- a/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
+++ b/research/problems/zsqrtd-neg-two-oq-02/knowledge.md
@@ -89,3 +89,42 @@ proven infrastructure (the same dead-end the waring-g2 slug flags re: Davenport�
 - Therefore the only genuinely OPEN piece on this slug is the **converse** (`¬4ᵃ(8b+7) ⟹ three squares`), which this slug already established (quantitatively, 36% subset) is **not** reachable via the ℤ[√−2] norm form. The converse is itself axiomatized-but-not-proved in `ThreeSquares.lean` (`not_excluded_form_is_sum_three_sq`, the Minkowski+Dirichlet route, Docker-gated) — see the `lagrange-four-squares-waring-g2-oq-03` slug, which owns that work.
 
 **Net**: this slug needs **no new Lean** — its formalizable deliverable is subsumed by `ThreeSquares.lean`, and its deep direction is owned by the waring-g2 slug. Recommend marking the ℤ[√−2] route closed (negative verdict) and not re-attempting the forward obstruction. (No code; dual blackout re-confirmed live: docker timeout, Aristotle 404.)
+
+## Session 2026-06-22 (researcher-1) — bridge the obstruction to the parent norm form
+
+**Mode**: REVISIT (RICH, verdict was "no new Lean"). **Outcome**: progress (small but real:
+the file's docstring is framed entirely around the ℤ[√−2] norm form `x²+2y²`, yet contained
+ZERO lemmas about it — added the missing bridge).
+
+### What I Did
+- `normForm_isSumThreeSq (x y : ℤ) : ∃ a b c, a²+b²+c² = x²+2y²` — the trivial inclusion
+  `x²+2y² = x²+y²+y²` (`⟨x, y, y, by ring⟩`).
+- `normForm_ne_four_pow_mul (x y a b) : x²+2y² ≠ 4^a(8b+7)` — applying the existing
+  contrapositive `sumThreeSq_ne_four_pow_mul` to the inclusion. The ℤ[√−2] representable
+  numbers provably respect the Legendre obstruction (a proper subset of three-square numbers).
+
+This makes the file actually engage the norm form it is *about*, and partially addresses the
+file's open question "connect it to the parent ℤ[√−2] representation theorems".
+
+### Verification — DOCKER WAS DOWN, used host single-file bypass
+- `docker-build.sh` crashed mid-build with `error waiting for container: unexpected EOF`
+  (exit 125), then Docker Desktop went fully down ("Docker is not installed"); restart
+  (`osascript quit` + `open -a Docker`) did NOT bring the daemon back within ~9 min (disk
+  was healthy at 17%, so NOT disk pressure this time — daemon just stuck).
+- **BYPASS (works, matches researcher-7 memory note)**: host has `lean v4.26.0`
+  (`/opt/homebrew/bin/lean`) + prebuilt Mathlib oleans in main-repo
+  `proofs/.lake/packages/*/.lake/build/lib/lean`. Set
+  `LEAN_PATH=$(printf '%s:' proofs/.lake/packages/*/.lake/build/lib/lean; echo proofs/.lake/build/lib/lean)`
+  and run `lean <worktree-file>` directly (~seconds, no Docker). EXIT=0, no errors.
+- `#print axioms` (append fully-qualified `#print axioms ZsqrtNegTwoOQ02.normForm_*` to a
+  temp copy, elaborate): both new theorems depend only on `[propext, Classical.choice,
+  Quot.sound]` (normForm_isSumThreeSq just `[propext]`) — NO `ofReduceBool`/`sorryAx`.
+  Stays 0-axiom verified.
+
+### Files Modified
+- `proofs/Proofs/ZsqrtdNegTwoOQ02.lean` (139→162 lines, +2 thm, Step 4 section)
+- `src/data/proofs/zsqrtd-neg-two-oq-02/meta.json` (counts, contributions, section, open Q)
+
+### Next Steps (unchanged deep work)
+- Sufficiency direction (Dirichlet + ternary forms) remains the genuine open work, owned by
+  the `lagrange-four-squares-waring-g2-oq-03` slug; NOT reachable via ℤ[√−2].

--- a/src/data/proofs/zsqrtd-neg-two-oq-02/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-02/meta.json
@@ -21,8 +21,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 139,
-    "theoremCount": 4,
+    "lineCount": 162,
+    "theoremCount": 6,
     "definitionCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The two finite case-checks use `decide` (kernel reduction over ZMod 8 and ZMod 4), not `native_decide`, so no `Lean.ofReduceBool` dependency: the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`. Depends only on Mathlib (`ZMod` arithmetic and `ZMod.intCast_zmod_eq_zero_iff_dvd`).",
     "mathlib_version": "4.26.0",
@@ -52,7 +52,9 @@
       "`not_sumThreeSq_four_pow_mul`: the headline necessity theorem — for all `a b : ℕ`, `4^a(8b+7)` is not a sum of three integer squares — proved by induction on the exponent `a`, combining the mod-8 obstruction in the base case with infinite descent in the inductive step. This is the complete elementary half of the Legendre–Gauss three-square theorem and is not available in Mathlib.",
       "`sumThreeSq_ne_seven_mod_eight`: the mod-8 obstruction that a sum of three integer squares is never ≡ 7 (mod 8), via a single `decide` over `ZMod 8` after `push_cast` reduces the integer statement to its residue.",
       "`descent_even`: the descent lemma that `x² + y² + z² ≡ 0 (mod 4)` forces `x, y, z` all even, via a `decide` over `ZMod 4` whose parity conclusions are transported to integer divisibility through the ring map `ZMod 4 → ZMod 2` (`map_intCast` + `ZMod.intCast_zmod_eq_zero_iff_dvd`).",
-      "`sumThreeSq_ne_four_pow_mul`: the contrapositive packaging — if `n` is a sum of three squares then `n ≠ 4^a(8b+7)` — the form in which the result reads as the necessity half of the classical iff."
+      "`sumThreeSq_ne_four_pow_mul`: the contrapositive packaging — if `n` is a sum of three squares then `n ≠ 4^a(8b+7)` — the form in which the result reads as the necessity half of the classical iff.",
+      "`normForm_isSumThreeSq`: the explicit bridge to the parent ℤ[√−2] norm form — every value `x² + 2y²` is a sum of three integer squares via the splitting `x² + 2y² = x² + y² + y²`. This is the elementary inclusion side that places the parent's `x²+2y²` development inside the three-square picture (previously the file proved the obstruction but never mentioned the norm form it extends).",
+      "`normForm_ne_four_pow_mul`: combining the inclusion with the obstruction — `x² + 2y²` is never of the excluded form `4^a(8b+7)`. So the ℤ[√−2] representable numbers respect the three-square obstruction (a consistency check confirming they form a proper subset of the sums of three squares, never reaching the full converse)."
     ],
     "prerequisites": [
       "Sums of three squares and the Legendre–Gauss characterisation",
@@ -77,12 +79,12 @@
     ]
   },
   "leanFile": {
-    "lineCount": 139,
+    "lineCount": 162,
     "path": "Proofs/ZsqrtdNegTwoOQ02.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 4
+    "theoremCount": 6
   },
   "sorries": 0,
   "overview": {
@@ -105,11 +107,11 @@
     ]
   },
   "conclusion": {
-    "summary": "The necessity direction of the Legendre–Gauss three-square theorem — that no number 4^a(8b+7) is a sum of three integer squares — is proved with 0 sorries and 0 axioms (kernel `decide`, no `native_decide`). The file is 152 lines, 4 theorems, 0 definitions, and rests only on elementary `ZMod` arithmetic from Mathlib. It complements the parent ℤ[√−2] family, which supplies sufficiency slices, by closing off the obstructed numbers.",
+    "summary": "The necessity direction of the Legendre–Gauss three-square theorem — that no number 4^a(8b+7) is a sum of three integer squares — is proved with 0 sorries and 0 axioms (kernel `decide`, no `native_decide`). The file is 162 lines, 6 theorems, 0 definitions, and rests only on elementary `ZMod` arithmetic from Mathlib. It complements the parent ℤ[√−2] family, which supplies sufficiency slices, by closing off the obstructed numbers.",
     "implications": "Together with the parent's representation results (p ≡ 3 mod 8 ⟹ p = x²+y²+z²) this pins down the obstruction side of the full three-square characterisation. The mod-8 + descent skeleton here is the standard elementary half on which any complete formalisation of the three-square theorem would build; the remaining sufficiency half is the genuinely deep input (Dirichlet / ternary form theory) still absent from Mathlib.",
     "openQuestions": [
       "Prove the sufficiency direction: every n with n ≠ 4^a(8b+7) is a sum of three squares. This is the hard half — the cleanest route runs through Dirichlet's theorem on primes in arithmetic progressions (to find an auxiliary prime in a suitable residue class) plus Gauss's theory of ternary quadratic forms, neither yet available in Mathlib for this purpose.",
-      "Assemble the full biconditional `n = x²+y²+z² ↔ ¬∃ a b, n = 4^a(8b+7)` once sufficiency is in place, and connect it to the parent ℤ[√−2] representation theorems as the special-prime instances.",
+      "PARTIALLY ADDRESSED (this session): the parent ℤ[√−2] norm form is now explicitly bridged in — `normForm_isSumThreeSq` (x²+2y² is a sum of three squares) and `normForm_ne_four_pow_mul` (x²+2y² avoids the excluded form). Still open: assemble the full biconditional `n = x²+y²+z² ↔ ¬∃ a b, n = 4^a(8b+7)` once sufficiency is in place, and connect it to the parent's representation theorems as the special-prime instances.",
       "Derive the classical corollary that a positive integer is a sum of three squares iff it is not 4^a(8b+7), and link it to Gauss's count of representations (the class number h(-n) weighting), bridging to the gallery's quadratic-form entries.",
       "Formalise the analogous obstruction for sums of three squares with congruence side-conditions, or the polygonal-number variants (Gauss's Eureka theorem on triangular numbers), reusing the mod-8 / descent template."
     ]
@@ -142,6 +144,13 @@
       "startLine": 93,
       "endLine": 139,
       "summary": "`not_sumThreeSq_four_pow_mul`: induction on a. Base a=0 — 8b+7 ≡ 7 (mod 8), excluded by Step 1. Step a+1 — divisibility `4 ∣ 4^(a+1)(8b+7)` gives `≡ 0 (mod 4)`, so Step 2 makes x,y,z even; substituting x=2x' and cancelling 4 yields a representation of 4^a(8b+7), contradicting the induction hypothesis. `sumThreeSq_ne_four_pow_mul` repackages this as the contrapositive necessity statement."
+    },
+    {
+      "id": "step4-bridge",
+      "title": "Step 4 — Bridge to the Parent ℤ[√−2] Norm Form",
+      "startLine": 140,
+      "endLine": 162,
+      "summary": "Connects the obstruction to the parent's norm form x²+2y². `normForm_isSumThreeSq`: every x²+2y² is a sum of three squares via x²+2y² = x²+y²+y² (a trivial `⟨x,y,y,by ring⟩`). `normForm_ne_four_pow_mul`: applying the contrapositive obstruction, x²+2y² is never 4^a(8b+7) — so the ℤ[√−2] representable numbers respect the three-square obstruction and form a proper subset of the sums of three squares. This makes the file actually engage the norm form its docstring frames it around."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

`ZsqrtdNegTwoOQ02.lean` proves the necessity direction of the Legendre–Gauss three-square theorem (`4^a(8b+7)` is never `x²+y²+z²`). Its docstring frames the whole entry as *extending the parent ℤ[√−2] norm form `x²+2y²` towards the three-square theorem* — yet the file contained **zero lemmas about that norm form**. This PR adds the missing bridge (+2 theorems, 139 → 162 lines).

- `normForm_isSumThreeSq` — every `x² + 2y²` is a sum of three integer squares, via the trivial splitting `x² + 2y² = x² + y² + y²`.
- `normForm_ne_four_pow_mul` — applying the existing contrapositive obstruction, `x² + 2y²` is never of the excluded form `4^a(8b+7)`.

So the ℤ[√−2] representable numbers provably **respect the Legendre obstruction** — a proper subset of the sums of three squares, never reaching the full converse. This partially addresses the entry's documented open question on connecting the obstruction to the parent representation theorems.

## Verification

Docker Desktop was down this session (`error waiting for container: unexpected EOF`, then daemon stuck through a restart; disk was healthy, so not disk pressure). Verified instead via **host single-file `lean` v4.26.0 elaboration** against the prebuilt Mathlib oleans (`LEAN_PATH` = `proofs/.lake/packages/*/.lake/build/lib/lean`):

- Full file elaborates with **EXIT=0, no errors**.
- `#print axioms` on both new theorems → `[propext, Classical.choice, Quot.sound]` only (`normForm_isSumThreeSq` just `[propext]`). **No `Lean.ofReduceBool`, no `sorryAx`** — the entry stays 0-axiom `verified`, badge `original`.

## Scope / honesty

This is a small, elementary bridge (the inclusion is one `ring`). It does **not** touch the genuinely open sufficiency direction (Dirichlet + ternary forms), which is owned by the `lagrange-four-squares-waring-g2-oq-03` slug and is not reachable via the `x²+2y²` norm form. The value is making the file actually engage the norm form its framing is built around, and recording that ℤ[√−2]'s reach is obstruction-consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)