### PR TITLE
Enrich One-Sided, Unbounded Non-Three-Square Density Error

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "one-sided",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": { "startLine": 56, "endLine": 81 },
+    "type": "theorem",
+    "title": "One-Sided Sharpness: 6·excludedCount N ≤ N",
+    "content": "`six_excludedCount_le`: the density 1/6 is approached strictly from below — 6·excludedCount N ≤ N for ALL N (equivalently excludedCount N ≤ ⌊N/6⌋). The proof telescopes the oq-03-oq-05 recursion: writing E(N) = 6·excludedCount N − N, each descent step changes it by δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8), which depends only on N mod 8 and takes the eight values 0,0,−1,−2,−3,−3,−4,−5 — all ≤ 0. So the running total never turns positive (strong induction; the residue arithmetic discharged entirely by omega via the division identities). This is strictly stronger than the parent's two-sided bound whose upper half was +6(log₂N+1).",
+    "mathContext": "$6\\,\\mathrm{excludedCount}(N)\\le N$, i.e. $\\mathrm{excludedCount}(N)\\le\\lfloor N/6\\rfloor$. The per-step increment $\\delta(N)\\le 0$ depends only on $N\\bmod 8$.",
+    "significance": "critical",
+    "relatedConcepts": ["one-sided bound", "telescoping", "residue reduction", "strong induction"],
+    "prerequisites": ["strong induction", "modular arithmetic"]
+  },
+  {
+    "id": "extremal-family",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": { "startLine": 83, "endLine": 108 },
+    "type": "definition",
+    "title": "The Extremal Family a k = (4^{k+2}+2)/3",
+    "content": "The worst-case family for the descent: a 0 = 6, a (k+1) = 4·a k − 2, with closed form a k = (4^{k+2}+2)/3. Two structural lemmas make it the right witness: `a_mod8` shows every member is ≡ 6 (mod 8) — the residue with the most negative sustainable increment δ = −4 (residue 7 has δ = −5 but cannot chain to another 7), and `a_step` shows the descent stays on the family, ⌈a(k+1)/4⌉ = a k. This self-sustaining maximal-loss orbit is what forces the error to diverge.",
+    "mathContext": "$a_0=6,\\ a_{k+1}=4a_k-2,\\ a_k=\\frac{4^{k+2}+2}{3}$; $a_k\\equiv 6\\ (8)$ and $\\lceil a_{k+1}/4\\rceil=a_k$. Each step costs $\\delta=-4$.",
+    "significance": "key",
+    "relatedConcepts": ["extremal family", "recurrence", "worst-case residue", "self-similar orbit"],
+    "prerequisites": ["recurrences", "modular arithmetic"]
+  },
+  {
+    "id": "exact-error",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": { "startLine": 110, "endLine": 144 },
+    "type": "theorem",
+    "title": "Exact Error Along the Family: 4k+6",
+    "content": "`excludedCount_a`: along the extremal family, 6·excludedCount (a k) = a k − (4k+6) exactly. Proved by induction using the oq-03-oq-05 recursion and a_step: each step adds δ = −4 (the residue-6 increment), so the accumulated deficit is 4k+6. `error_eq` restates this as a k − 6·excludedCount (a k) = 4k+6. Since a k ≈ 4^k, the error 4k+6 = Θ(log a k), matching the parent's logarithmic upper bound up to a constant.",
+    "mathContext": "$6\\,\\mathrm{excludedCount}(a_k)=a_k-(4k+6)$, so the error $a_k-6\\,\\mathrm{excludedCount}(a_k)=4k+6=\\Theta(\\log a_k)$ as $a_k\\sim 4^k$.",
+    "significance": "critical",
+    "relatedConcepts": ["exact asymptotics", "Θ(log N)", "induction", "error term"],
+    "prerequisites": ["induction", "integer casts"]
+  },
+  {
+    "id": "dichotomy",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": { "startLine": 146, "endLine": 172 },
+    "type": "theorem",
+    "title": "The Dichotomy Settled: One-Sided and Unbounded",
+    "content": "`error_unbounded`: for every target C there is an N (concretely N = a ⌈C⌉) with C ≤ N − 6·excludedCount N, since the error there is 4·C+6. Combined with the one-sided bound, `density_error_one_sided_and_unbounded` records the full picture: 0 ≤ N − 6·excludedCount N for all N, AND the quantity is unbounded above. So the oq-03-oq-05 oscillation is NOT O(1) — it is one-sided (always ≥ 0) and of true order Θ(log N), settling the parent's open dichotomy completely.",
+    "mathContext": "$0\\le N-6\\,\\mathrm{excludedCount}(N)$ for all $N$, and $\\sup_N\\bigl(N-6\\,\\mathrm{excludedCount}(N)\\bigr)=\\infty$: the error is one-sided and $\\Theta(\\log N)$, not $O(1)$.",
+    "significance": "critical",
+    "relatedConcepts": ["unboundedness", "dichotomy", "Θ(log N)", "one-sided oscillation"],
+    "prerequisites": ["asymptotic order notation"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/meta.json
@@ -2,6 +2,45 @@
   "id": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
   "slug": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
   "title": "The Non-Three-Square Density Error Is One-Sided and Genuinely Unbounded",
+  "description": "A complete answer to the second-order question left open by the density-1/6 entry: the oscillation E(N) = N − 6·excludedCount N of the non-three-square counting function is one-sided (always ≥ 0, so the density is approached strictly from below) and genuinely unbounded above (Θ(log N), not O(1)). The whole analysis collapses to a single mod-8 increment table, which simultaneously fixes the sign and exhibits an explicit divergent extremal family.",
+  "overview": {
+    "historicalContext": "The sibling entry oq-03-oq-05 proved that the excluded family E = {4^a(8b+7)} (the integers not representable as a sum of three squares) has natural density 1/6, with a two-sided logarithmic error bound |6·excludedCount N − N| ≤ 6(log₂ N + 1), and explicitly asked whether the oscillation is O(1) along subsequences or genuinely unbounded — and what its true order is. Such second-order questions about counting functions (the size and sign of the remainder after the leading density term) are the natural refinement of any density law, paralleling the study of error terms for the prime-counting and divisor functions. This entry settles the dichotomy completely and constructively.",
+    "problemStatement": "For the non-three-square counting function excludedCount N = #{n < N : n ∈ E}, analyze the error E(N) = N − 6·excludedCount N: determine its sign and its true asymptotic order. Show E(N) ≥ 0 for all N (the density 1/6 is never overshot) and that E(N) is unbounded above, hence Θ(log N) rather than O(1).",
+    "proofStrategy": "Telescope the oq-03-oq-05 recursion excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉ into E(N) = E(⌈N/4⌉) + δ(N), where the increment δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) depends only on N mod 8 and takes the eight values 0,0,−1,−2,−3,−3,−4,−5. Since all δ ≤ 0, strong induction gives 6·excludedCount N ≤ N (one-sided). For unboundedness, build the extremal family a 0 = 6, a (k+1) = 4·a k − 2: every member is ≡ 6 (mod 8) (the residue with sustainable maximal loss δ = −4) and the descent stays on the family, so 6·excludedCount (a k) = a k − (4k+6), giving error 4k+6 → ∞. All residue and division arithmetic is discharged by omega.",
+    "keyInsights": [
+      "A two-variable error analysis collapses to a single mod-8 lookup: the per-step increment δ(N) depends only on N mod 8, and its eight-value table answers both the sign question and the worst-case question at once.",
+      "All eight increment values are ≤ 0, so the counting function never overshoots N/6 — the density 1/6 is approached strictly from below, a one-sided sharpness strictly stronger than the parent's symmetric bound.",
+      "Unboundedness is witnessed constructively by a self-sustaining maximal-loss orbit: the family a k = (4^{k+2}+2)/3 stays on residue 6 (δ = −4) under descent, accumulating error 4k+6.",
+      "The residue 6 — not 7 — is the extremal one: residue 7 has the most negative δ = −5 but cannot chain to another 7, so the sustainable worst case is residue 6, a subtlety the increment table makes explicit.",
+      "The true order of the oscillation is pinned to Θ(log N): the explicit family realizes the lower bound 4k+6 ≈ log₂ a k, matching the parent's logarithmic upper bound up to a constant."
+    ]
+  },
+  "sections": [
+    {
+      "id": "one-sided-section",
+      "title": "One-Sided Sharpness",
+      "startLine": 56,
+      "endLine": 81,
+      "summary": "six_excludedCount_le proves 6·excludedCount N ≤ N for all N (excludedCount_le_div_six: ≤ ⌊N/6⌋), by telescoping the recursion into per-step increments δ(N) ≤ 0 depending only on N mod 8 — the density 1/6 is approached strictly from below.",
+      "mathContext": "6·excludedCount N ≤ N always; δ(N) ∈ {0,0,−1,−2,−3,−3,−4,−5}, all ≤ 0."
+    },
+    {
+      "id": "extremal-section",
+      "title": "The Extremal Family and Its Exact Error",
+      "startLine": 83,
+      "endLine": 144,
+      "summary": "Defines a k = (4^{k+2}+2)/3 (a 0 = 6, a (k+1) = 4·a k − 2), proves every member ≡ 6 (mod 8) (a_mod8) with descent staying on the family (a_step), and computes the exact error 6·excludedCount (a k) = a k − (4k+6) (excludedCount_a, error_eq).",
+      "mathContext": "Along a k: error = 4k+6 = Θ(log a k), since a k ≈ 4^k."
+    },
+    {
+      "id": "dichotomy-section",
+      "title": "The Dichotomy Settled",
+      "startLine": 146,
+      "endLine": 172,
+      "summary": "error_unbounded shows the error reaches every height (N = a ⌈C⌉), and density_error_one_sided_and_unbounded combines both halves: E(N) ≥ 0 for all N and unbounded above — the oscillation is one-sided and Θ(log N), not O(1).",
+      "mathContext": "0 ≤ N − 6·excludedCount N for all N, and unbounded above: one-sided, Θ(log N)."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -81,9 +120,9 @@
       "description": "Transitively relies on the 2-adic normal form and computable Decidable instance for the excluded family E = {4^a(8b+7)} supplied by oq-03-oq-04, through which excludedCount is a genuine Finset.card."
     },
     {
-      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-03",
       "relationship": "related",
-      "description": "Refines the quantitative picture of the three-square exceptional set: where oq-03-oq-05 gave the leading density 1/6, this entry pins the exact one-sided sign and the Θ(log N) order of the second-order fluctuation."
+      "description": "Refines the quantitative picture of the three-square exceptional set: where the density entry gave the leading density 1/6, this entry pins the exact one-sided sign and the Θ(log N) order of the second-order fluctuation; the two-square sufficiency slice studies the complementary representable side."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01`.

## Gaps addressed
- **Missing `annotations.json`** — added 4 annotations with `range`, `type`, `significance`, `mathContext` (LaTeX), `relatedConcepts`, `prerequisites`, covering the one-sided bound (6·excludedCount N ≤ N), the extremal family a k = (4^{k+2}+2)/3, the exact 4k+6 error, and the settled one-sided/unbounded dichotomy.
- **No structured `overview`** — added `ProofOverview` (historicalContext, problemStatement, proofStrategy, 5 keyInsights).
- **No `sections`** — added 3 sections spanning the full Lean file.
- **Missing top-level `description`** — added one.
- **Dangling cross-reference** — repointed the `related` ref from the nonexistent `lagrange-four-squares-waring-g2-oq-03` to the valid `-oq-03-oq-03` sibling.

## Verification
- JSON validated; `pnpm build` passes.
- Axiom/badge metadata unchanged and accurate: 0 axioms, 0 sorries, verified/original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)