### PR TITLE
research(erdos-124-complete-sequences-oq-02): boundary ∑1/(dᵢ-1)=1 is exactly an Egyptian fraction [0-axiom verified]

### DIFF
--- a/proofs/Proofs/CircumferenceViaDifferentiationOQ02.lean
+++ b/proofs/Proofs/CircumferenceViaDifferentiationOQ02.lean
@@ -1,0 +1,144 @@
+/-
+  OQ-02: The n-Ball Volume Model Is the Euclidean Lebesgue Measure
+  (circumference-via-differentiation-oq-02)
+
+  The sibling entry OQ-01 proves the volume–surface duality
+
+    d/dr (ω_n · rⁿ) = n · ω_n · r^(n-1) = S_{n-1}(r)
+
+  for the *polynomial model* `nBallVolumeFn n r = unitBallVolume n * rⁿ`, where
+  `unitBallVolume n = π^(n/2)/Γ(n/2+1)` is defined purely through the Gamma
+  function. What OQ-01 leaves open for general n is whether that abstract
+  constant ω_n really is the *Lebesgue measure* of a ball: OQ-01 only connects
+  the n = 2 case to the parent's `areaFn` (itself built on `Complex.volume_ball`).
+
+  This file closes that gap for ALL dimensions, answering the parent's open
+  question "can the n-dimensional analog be formalized using Mathlib's geometric
+  measure theory?":
+
+    1.  `nBallVolume_eq_measure` — the polynomial model equals the genuine
+        Lebesgue measure of a Euclidean n-ball:
+            (volume (ball 0 r)).toReal = unitBallVolume n · rⁿ      (n ≥ 1, r ≥ 0),
+        via Mathlib's `EuclideanSpace.volume_ball`. This grounds OQ-01's
+        Gamma-defined ω_n as a true volume.
+
+    2.  `measure_ball_hasDerivAt_surface` — consequently the radial derivative of
+        the *actual* Lebesgue measure of the ball equals the surface area:
+            d/dr [ (volume (ball 0 r)).toReal ] = S_{n-1}(r)        (n ≥ 1, r > 0).
+        Here the duality is a statement about genuine geometric volume, not the
+        algebraic model. (Restricted to r > 0 because for r < 0 the ball is empty
+        while the polynomial ω_n rⁿ is not.)
+
+  Reuses OQ-01's definitions (`unitBallVolume`, `nBallVolumeFn`, `nSphereSurfaceFn`).
+  Status: 0 sorries, 0 axioms.
+-/
+
+import Mathlib
+import Proofs.CircumferenceViaDifferentiation
+import Proofs.CircumferenceViaDifferentiationOQ01
+
+open MeasureTheory Metric Real
+open CircumferenceViaDifferentiationOQ01
+
+namespace CircumferenceViaDifferentiationOQ02
+
+/-! ## Reconciling the two forms of the unit-ball constant
+
+OQ-01 writes `ω_n = π^(n/2)/Γ(n/2+1)` (a real power of π), whereas Mathlib's
+`EuclideanSpace.volume_ball` produces `√π ^ n / Γ(n/2+1)` (a natural power of √π).
+These agree because `π^(n/2) = (√π)ⁿ`. -/
+
+/-- `π^(n/2) = (√π)ⁿ`: the real power and the natural power of √π coincide. -/
+theorem pi_rpow_half_eq_sqrt_pow (n : ℕ) : π ^ ((n : ℝ) / 2) = Real.sqrt π ^ n := by
+  rw [Real.sqrt_eq_rpow, ← Real.rpow_natCast (π ^ ((1 : ℝ) / 2)) n,
+      ← Real.rpow_mul Real.pi_nonneg]
+  congr 1
+  ring
+
+/-! ## The measure bridge -/
+
+/-- **Grounding OQ-01's volume in measure theory.** For `n ≥ 1` and `r ≥ 0`, the
+polynomial model `nBallVolumeFn n r = ω_n · rⁿ` equals the genuine Lebesgue
+measure of the Euclidean n-ball of radius `r`. This is the specialization of
+Mathlib's `EuclideanSpace.volume_ball` that justifies calling `unitBallVolume n`
+a *volume* in every dimension. -/
+theorem nBallVolume_eq_measure {n : ℕ} (hn : 1 ≤ n) (r : ℝ) (hr : 0 ≤ r) :
+    (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) r)).toReal = nBallVolumeFn n r := by
+  haveI : Nonempty (Fin n) := ⟨⟨0, hn⟩⟩
+  have hC : (0 : ℝ) ≤ Real.sqrt π ^ n / Real.Gamma ((n : ℝ) / 2 + 1) := by positivity
+  rw [EuclideanSpace.volume_ball, Fintype.card_fin, ENNReal.toReal_mul,
+      ← ENNReal.ofReal_pow hr,
+      ENNReal.toReal_ofReal (pow_nonneg hr n),
+      ENNReal.toReal_ofReal hC]
+  unfold nBallVolumeFn unitBallVolume
+  rw [pi_rpow_half_eq_sqrt_pow]
+  ring
+
+/-- In particular, `unitBallVolume n` is the Lebesgue measure of the *unit* ball. -/
+theorem unitBallVolume_eq_measure {n : ℕ} (hn : 1 ≤ n) :
+    (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) 1)).toReal = unitBallVolume n := by
+  rw [nBallVolume_eq_measure hn 1 zero_le_one]
+  unfold nBallVolumeFn
+  simp
+
+/-! ## Duality on the genuine Lebesgue measure -/
+
+/-- **Volume–surface duality for the true measure.** For `n ≥ 1` and `r > 0`, the
+radial derivative of the *actual Lebesgue measure* of the Euclidean n-ball equals
+the `(n-1)`-sphere surface area `S_{n-1}(r) = n · ω_n · r^(n-1)`.
+
+This upgrades OQ-01's model-level duality to a statement about genuine geometric
+volume. The measure agrees with the polynomial model on the neighbourhood
+`{ρ : 0 < ρ}` of `r`, so `HasDerivAt.congr_of_eventuallyEq` transports OQ-01's
+derivative `nBallVolumeFn_hasDerivAt`. -/
+theorem measure_ball_hasDerivAt_surface {n : ℕ} (hn : 1 ≤ n) {r : ℝ} (hr : 0 < r) :
+    HasDerivAt (fun ρ => (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) ρ)).toReal)
+      (nSphereSurfaceFn n r) r := by
+  have hEq : (fun ρ => (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) ρ)).toReal)
+      =ᶠ[nhds r] nBallVolumeFn n := by
+    filter_upwards [Ioi_mem_nhds hr] with ρ hρ
+    exact nBallVolume_eq_measure hn ρ (le_of_lt hρ)
+  exact (nBallVolumeFn_hasDerivAt n r).congr_of_eventuallyEq hEq
+
+/-- The `deriv` form of the measure-level duality (for `r > 0`). -/
+theorem deriv_measure_ball {n : ℕ} (hn : 1 ≤ n) {r : ℝ} (hr : 0 < r) :
+    deriv (fun ρ => (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin n)) ρ)).toReal) r
+      = nSphereSurfaceFn n r :=
+  (measure_ball_hasDerivAt_surface hn hr).deriv
+
+/-! ## Concrete dimensions -/
+
+/-- **n = 2.** The Lebesgue measure of a disk of radius `r` is `π r²`. -/
+theorem measure_disk_eq (r : ℝ) (hr : 0 ≤ r) :
+    (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin 2)) r)).toReal = π * r ^ 2 := by
+  rw [nBallVolume_eq_measure (by norm_num) r hr]
+  unfold nBallVolumeFn
+  rw [unitBallVolume_two]
+
+/-- **n = 2.** Differentiating the genuine disk area gives the circumference `2π r`
+(for `r > 0`) — the parent theorem, now on the Lebesgue measure itself. -/
+theorem deriv_measure_disk (r : ℝ) (hr : 0 < r) :
+    deriv (fun ρ => (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin 2)) ρ)).toReal) r
+      = 2 * π * r := by
+  rw [deriv_measure_ball (by norm_num) hr]
+  unfold nSphereSurfaceFn
+  rw [nSphereSurfaceConst_two]
+  norm_num
+
+/-- **n = 3.** The Lebesgue measure of a ball of radius `r` is `(4π/3) r³`. -/
+theorem measure_ball_three_eq (r : ℝ) (hr : 0 ≤ r) :
+    (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin 3)) r)).toReal = 4 * π / 3 * r ^ 3 := by
+  rw [nBallVolume_eq_measure (by norm_num) r hr]
+  unfold nBallVolumeFn
+  rw [unitBallVolume_three]
+
+/-- **n = 3.** Differentiating the genuine ball volume gives the sphere surface
+area `4π r²` (for `r > 0`) — the spatial case of the duality on the true measure. -/
+theorem deriv_measure_ball_three (r : ℝ) (hr : 0 < r) :
+    deriv (fun ρ => (volume (Metric.ball (0 : EuclideanSpace ℝ (Fin 3)) ρ)).toReal) r
+      = 4 * π * r ^ 2 := by
+  rw [deriv_measure_ball (by norm_num) hr]
+  unfold nSphereSurfaceFn
+  rw [nSphereSurfaceConst_three, show (3 : ℕ) - 1 = 2 from rfl]
+
+end CircumferenceViaDifferentiationOQ02

--- a/proofs/Proofs/Erdos124CompleteSequencesOQ02.lean
+++ b/proofs/Proofs/Erdos124CompleteSequencesOQ02.lean
@@ -1,0 +1,316 @@
+import Mathlib
+
+/-
+# Erdős Problem 124 — the exact boundary `∑ 1/(dᵢ-1) = 1`
+
+## Background
+
+The (weak version of the) Erdős–Burr–Graham–Li problem #124, solved and formally
+verified by Harmonic's "Aristotle" in 2025 (see `Erdos124CompleteSequences.lean`),
+states: given bases `d₁,…,d_k ≥ 2` with
+
+    ∑ 1/(dᵢ - 1) ≥ 1,
+
+every natural number is a sum `∑ aᵢ` where each `aᵢ` has only digits `0,1` in base
+`dᵢ`. This file studies the open follow-up question **OQ-02: what happens exactly at
+the boundary `∑ 1/(dᵢ - 1) = 1`?**
+
+## What this file proves
+
+The central observation is a clean structural identity. Writing `eᵢ = dᵢ - 1 ≥ 1`,
+the boundary condition
+
+    ∑ 1/(dᵢ - 1) = 1     ⟺     ∑ 1/eᵢ = 1,
+
+i.e. **the boundary configurations of Erdős 124 are exactly the Egyptian-fraction
+(unit-fraction) decompositions of `1`.** So the "technique needed at the boundary"
+is the arithmetic of Egyptian fractions / the Sylvester splitting identity, not any
+new completeness machinery — the parent theorem already covers the closed condition
+`≥ 1`, and equality is its extreme face.
+
+Concretely we prove, all `0`-axiom and machine checked:
+
+* `reciSum_eq_egyptSum`  — the bridge `∑ 1/(dᵢ-1) = ∑ 1/eᵢ` with `eᵢ = dᵢ-1`.
+* `egyptSum_split`       — Sylvester splitting `1/e = 1/(e+1) + 1/(e(e+1))`.
+* `sylvester` / `sylvester_egyptSum` / `sylvester_length` — an explicit family of
+  boundary Egyptian decompositions of length `k+1` for **every** `k`, i.e. Erdős-124
+  boundary configurations exist with an arbitrary number of bases.
+* `exists_boundary_config` — restated in base language: for every `k ≥ 1` there is a
+  list of `k` bases `≥ 2` with `reciSum = 1`.
+* `egypt_one_forces_singleton` / `base_two_forces_singleton` — the rigidity at the
+  bottom: if a boundary configuration uses the base `d = 2` (equivalently the unit
+  fraction `1/1`), then it is the singleton `[2]` (plain binary representation).
+* concrete witnesses `[2]`, `[3,3]`, `[3,4,7]`, `[3,4,8,43]` (Sylvester's sequence).
+
+These are elementary but genuinely characterize the boundary face; nothing here is in
+Mathlib. The deep `≥ 1` completeness theorem is the parent file's contribution and is
+not reproved.
+-/
+
+namespace Erdos124OQ02
+
+open scoped BigOperators
+
+/-- Sum of unit fractions `∑ 1/eᵢ` over a list of (positive) denominators. -/
+def egyptSum (e : List ℕ) : ℚ := (e.map (fun x => (1 : ℚ) / x)).sum
+
+/-- Erdős-124 reciprocal sum `∑ 1/(dᵢ - 1)` over a list of bases. -/
+def reciSum (d : List ℕ) : ℚ := (d.map (fun x => (1 : ℚ) / ((x : ℚ) - 1))).sum
+
+@[simp] theorem egyptSum_nil : egyptSum [] = 0 := rfl
+
+@[simp] theorem egyptSum_cons (a : ℕ) (l : List ℕ) :
+    egyptSum (a :: l) = (1 : ℚ) / a + egyptSum l := by
+  simp [egyptSum]
+
+@[simp] theorem reciSum_nil : reciSum [] = 0 := rfl
+
+@[simp] theorem reciSum_cons (a : ℕ) (l : List ℕ) :
+    reciSum (a :: l) = (1 : ℚ) / ((a : ℚ) - 1) + reciSum l := by
+  simp [reciSum]
+
+/-- **Bridge.** With `eᵢ = dᵢ - 1`, the Erdős-124 reciprocal sum is an Egyptian-fraction
+sum.  Hence the boundary face `reciSum d = 1` is exactly a unit-fraction decomposition
+of `1`. Requires the bases to be `≥ 1` so the natural subtraction casts correctly. -/
+theorem reciSum_eq_egyptSum (d : List ℕ) (h : ∀ x ∈ d, 1 ≤ x) :
+    reciSum d = egyptSum (d.map (fun x => x - 1)) := by
+  induction d with
+  | nil => simp
+  | cons a l ih =>
+    have ha : 1 ≤ a := h a (List.mem_cons_self ..)
+    have htl : ∀ x ∈ l, 1 ≤ x := fun x hx => h x (List.mem_cons_of_mem a hx)
+    have hcast : ((a - 1 : ℕ) : ℚ) = (a : ℚ) - 1 := by
+      rw [Nat.cast_sub ha]; simp
+    simp only [reciSum_cons, List.map_cons, egyptSum_cons, hcast, ih htl]
+
+/-- Each unit-fraction term is nonnegative, hence the whole Egyptian sum is. -/
+theorem egyptSum_nonneg {l : List ℕ} : 0 ≤ egyptSum l := by
+  induction l with
+  | nil => simp
+  | cons a l ih =>
+    rw [egyptSum_cons]
+    have : (0 : ℚ) ≤ 1 / a := by positivity
+    linarith
+
+/-- **Sylvester splitting identity** `1/e = 1/(e+1) + 1/(e·(e+1))`, the engine that
+produces longer boundary configurations. Valid for `e ≥ 1`. -/
+theorem egyptSum_split {e : ℕ} (he : 1 ≤ e) :
+    (1 : ℚ) / (e + 1) + (1 : ℚ) / (e * (e + 1)) = 1 / e := by
+  have he0 : (e : ℚ) ≠ 0 := by
+    have : e ≠ 0 := by omega
+    exact_mod_cast this
+  have he1 : (e : ℚ) + 1 ≠ 0 := by positivity
+  field_simp
+
+/-- The explicit Sylvester construction in `e`-space: repeatedly split the head unit
+fraction.  `sylvester 0 = [1]`, and each step replaces the head `e` by `e+1, e(e+1)`. -/
+def sylvester : ℕ → List ℕ
+  | 0 => [1]
+  | (k + 1) =>
+      match sylvester k with
+      | [] => []                        -- unreachable; kept total
+      | (e :: rest) => (e + 1) :: e * (e + 1) :: rest
+
+/-- The construction is never empty. -/
+theorem sylvester_ne_nil : ∀ k, sylvester k ≠ []
+  | 0 => by simp [sylvester]
+  | (k + 1) => by
+      rw [sylvester]
+      cases hk : sylvester k with
+      | nil => exact (sylvester_ne_nil k hk).elim
+      | cons e rest => simp
+
+/-- Every denominator produced is `≥ 1`. -/
+theorem sylvester_pos : ∀ k, ∀ x ∈ sylvester k, 1 ≤ x
+  | 0 => by simp [sylvester]
+  | (k + 1) => by
+      have ih := sylvester_pos k
+      rw [sylvester]
+      cases hk : sylvester k with
+      | nil => simp
+      | cons e rest =>
+          have he : 1 ≤ e := by
+            have := ih; rw [hk] at this; exact this e (List.mem_cons_self ..)
+          have hrest : ∀ x ∈ rest, 1 ≤ x := by
+            intro x hx; have := ih; rw [hk] at this
+            exact this x (List.mem_cons_of_mem e hx)
+          intro x hx
+          simp only [List.mem_cons] at hx
+          rcases hx with h | h | h
+          · omega
+          · subst h; nlinarith
+          · exact hrest x h
+
+/-- **Length.** The `k`-th Sylvester list has exactly `k + 1` denominators. -/
+theorem sylvester_length : ∀ k, (sylvester k).length = k + 1
+  | 0 => by simp [sylvester]
+  | (k + 1) => by
+      rw [sylvester]
+      cases hk : sylvester k with
+      | nil => exact (sylvester_ne_nil k hk).elim
+      | cons e rest =>
+          have hl := sylvester_length k
+          rw [hk] at hl
+          simp only [List.length_cons] at hl ⊢
+          omega
+
+/-- **Boundary invariant.** Every Sylvester list is an Egyptian decomposition of `1`. -/
+theorem sylvester_egyptSum : ∀ k, egyptSum (sylvester k) = 1
+  | 0 => by simp [sylvester, egyptSum]
+  | (k + 1) => by
+      have ih := sylvester_egyptSum k
+      have hpos := sylvester_pos k
+      rw [sylvester]
+      cases hk : sylvester k with
+      | nil => exact (sylvester_ne_nil k hk).elim
+      | cons e rest =>
+          have he : 1 ≤ e := by
+            have := hpos; rw [hk] at this; exact this e (List.mem_cons_self ..)
+          rw [hk] at ih
+          rw [egyptSum_cons] at ih           -- 1/e + egyptSum rest = 1
+          rw [egyptSum_cons, egyptSum_cons]   -- 1/(e+1) + (1/(e(e+1)) + egyptSum rest)
+          have hsplit := egyptSum_split he
+          push_cast
+          push_cast at hsplit
+          linarith [hsplit, ih]
+
+/-- **Boundary configurations of every size, in base language.** For every `k ≥ 1`
+there is a list of `k` bases, each `≥ 2`, lying exactly on the Erdős-124 boundary
+`reciSum = 1`. (Take the Sylvester denominators `+ 1`.) -/
+theorem exists_boundary_config :
+    ∀ k : ℕ, 1 ≤ k → ∃ d : List ℕ, d.length = k ∧ (∀ x ∈ d, 2 ≤ x) ∧ reciSum d = 1 := by
+  intro k hk
+  obtain ⟨m, rfl⟩ : ∃ m, k = m + 1 := ⟨k - 1, by omega⟩
+  refine ⟨(sylvester m).map (fun x => x + 1), ?_, ?_, ?_⟩
+  · rw [List.length_map, sylvester_length]
+  · intro x hx
+    rw [List.mem_map] at hx
+    obtain ⟨y, hy, rfl⟩ := hx
+    have := sylvester_pos m y hy
+    omega
+  · -- reciSum (e+1 list) = egyptSum (e list) since (e+1) - 1 = e
+    have hbridge : reciSum ((sylvester m).map (fun x => x + 1))
+        = egyptSum (((sylvester m).map (fun x => x + 1)).map (fun x => x - 1)) := by
+      apply reciSum_eq_egyptSum
+      intro x hx
+      rw [List.mem_map] at hx; obtain ⟨y, hy, rfl⟩ := hx; omega
+    rw [hbridge]
+    have hmap : ∀ l : List ℕ, (l.map (fun x => x + 1)).map (fun x => x - 1) = l := by
+      intro l; induction l with
+      | nil => rfl
+      | cons a t ih => simp [ih]
+    rw [hmap, sylvester_egyptSum]
+
+/-- If the unit denominator `1` occurs, the Egyptian sum is already `≥ 1` (its term is
+`1/1 = 1` and all other terms are nonnegative). -/
+theorem egyptSum_ge_one_of_mem_one {l : List ℕ}
+    (h1 : (1 : ℕ) ∈ l) (hpos : ∀ x ∈ l, 1 ≤ x) : (1 : ℚ) ≤ egyptSum l := by
+  induction l with
+  | nil => simp at h1
+  | cons a t ih =>
+    rw [egyptSum_cons]
+    rcases List.mem_cons.mp h1 with h | h
+    · -- head is the unit
+      subst h
+      simp only [Nat.cast_one, div_one]
+      have : (0 : ℚ) ≤ egyptSum t := egyptSum_nonneg
+      linarith
+    · -- unit is further down the tail
+      have htpos : ∀ x ∈ t, 1 ≤ x := fun x hx => hpos x (List.mem_cons_of_mem a hx)
+      have htail := ih h htpos
+      have hhead : (0 : ℚ) ≤ 1 / (a : ℚ) := by positivity
+      linarith
+
+/-- If a denominator `1` (the unit fraction `1/1`) appears in an Egyptian decomposition
+of `1` with all denominators `≥ 1`, then the list is exactly `[1]`: no other fraction
+fits in the budget.  This is the rigidity that makes binary `(d = 2)` the only single
+boundary base. -/
+theorem egypt_one_forces_singleton (l : List ℕ)
+    (hpos : ∀ x ∈ l, 1 ≤ x) (hsum : egyptSum l = 1) (h1 : (1 : ℕ) ∈ l) :
+    l = [1] := by
+  cases l with
+  | nil => exact absurd h1 (by simp)
+  | cons a t =>
+    rw [egyptSum_cons] at hsum
+    have ha : 1 ≤ a := hpos a (List.mem_cons_self ..)
+    by_cases hae : a = 1
+    · -- head is the unit; the tail must vanish
+      subst hae
+      simp only [Nat.cast_one, div_one] at hsum      -- 1 + egyptSum t = 1
+      have ht0 : egyptSum t = 0 := by linarith
+      -- a nonempty tail of positive unit fractions has positive sum
+      cases t with
+      | nil => rfl
+      | cons b s =>
+        rw [egyptSum_cons] at ht0
+        have hb : 1 ≤ b := hpos b (by simp)
+        have hbq : (0 : ℚ) < 1 / b := by
+          have : (0 : ℚ) < b := by exact_mod_cast hb
+          positivity
+        have hsn : 0 ≤ egyptSum s := egyptSum_nonneg
+        linarith
+    · -- head is ≥ 2, so the unit fraction sits in the tail and overflows the budget
+      exfalso
+      have ha2 : 2 ≤ a := by omega
+      have h1t : (1 : ℕ) ∈ t := by
+        rcases List.mem_cons.mp h1 with h | h
+        · exact absurd h.symm hae
+        · exact h
+      have htpos : ∀ x ∈ t, 1 ≤ x := fun x hx => hpos x (List.mem_cons_of_mem a hx)
+      -- the unit fraction `1/1` already saturates the tail's budget
+      have hle : (1 : ℚ) ≤ egyptSum t := egyptSum_ge_one_of_mem_one h1t htpos
+      have hapos : (0 : ℚ) < 1 / a := by
+        have : (0 : ℚ) < a := by exact_mod_cast ha
+        positivity
+      linarith
+
+/-- **Base-2 rigidity.** Any boundary configuration of Erdős 124 that uses the base
+`d = 2` is the singleton `[2]` — i.e. plain base-2 (binary) representation. -/
+theorem base_two_forces_singleton (d : List ℕ)
+    (hpos : ∀ x ∈ d, 2 ≤ x) (hsum : reciSum d = 1) (h2 : (2 : ℕ) ∈ d) :
+    d = [2] := by
+  have h1pos : ∀ x ∈ d, 1 ≤ x := fun x hx => le_trans (by norm_num) (hpos x hx)
+  have hsum' : egyptSum (d.map (fun x => x - 1)) = 1 := by
+    rw [← reciSum_eq_egyptSum d h1pos]; exact hsum
+  have hepos : ∀ x ∈ d.map (fun x => x - 1), 1 ≤ x := by
+    intro x hx
+    obtain ⟨y, hy, rfl⟩ := List.mem_map.mp hx
+    have := hpos y hy; omega
+  have he1 : (1 : ℕ) ∈ d.map (fun x => x - 1) := by
+    simpa using List.mem_map_of_mem (f := fun x : ℕ => x - 1) h2
+  have hsingle := egypt_one_forces_singleton _ hepos hsum' he1
+  -- d.map (·-1) = [1] forces d to be one element which subtracts to 1, i.e. 2
+  rcases d with _ | ⟨a, t⟩
+  · exact absurd h2 (by simp)
+  · rw [List.map_cons] at hsingle
+    obtain ⟨ha1, ht⟩ := List.cons_eq_cons.mp hsingle
+    have ht' : t = [] := by simpa using ht
+    subst ht'
+    have ha : 2 ≤ a := hpos a (by simp)
+    have : a = 2 := by omega
+    rw [this]
+
+/-! ## Concrete boundary witnesses (Egyptian decompositions of 1). -/
+
+/-- Single base: `d = 2`, plain binary.  `1/(2-1) = 1`. -/
+theorem witness_binary : reciSum [2] = 1 := by
+  simp only [reciSum_cons, reciSum_nil]; norm_num
+
+/-- Two bases: `d = 3, 3`.  `1/2 + 1/2 = 1`. -/
+theorem witness_two : reciSum [3, 3] = 1 := by
+  simp only [reciSum_cons, reciSum_nil]; norm_num
+
+/-- Three bases: `d = 3, 4, 7`, the decomposition `1/2 + 1/3 + 1/6 = 1`. -/
+theorem witness_three : reciSum [3, 4, 7] = 1 := by
+  simp only [reciSum_cons, reciSum_nil]; norm_num
+
+/-- Four bases: `d = 3, 4, 8, 43` — Sylvester's sequence `1/2 + 1/3 + 1/7 + 1/42 = 1`. -/
+theorem witness_sylvester_four : reciSum [3, 4, 8, 43] = 1 := by
+  simp only [reciSum_cons, reciSum_nil]; norm_num
+
+/-- Sanity check of the recursion: `sylvester 3 = [4, 12, 6, 2]` in `e`-space, i.e. the
+boundary configuration with bases `e + 1 = [5, 13, 7, 3]` (`1/4 + 1/12 + 1/6 + 1/2 = 1`).
+This is a different length-4 Egyptian decomposition than `witness_sylvester_four`. -/
+example : sylvester 3 = [4, 12, 6, 2] := by decide
+
+end Erdos124OQ02

--- a/src/data/proofs/erdos-124-complete-sequences-oq-02/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "erdos-124-complete-sequences-oq-02",
+  "title": "Erdős 124 at the boundary: ∑ 1/(dᵢ−1) = 1 is exactly an Egyptian fraction",
+  "slug": "erdos-124-complete-sequences-oq-02",
+  "description": "A follow-up to the AI-solved Erdős 124 entry, answering OQ-02: what happens exactly at the boundary ∑ 1/(dᵢ−1) = 1 of the reciprocal condition? Substituting eᵢ = dᵢ − 1 shows the boundary configurations are precisely the Egyptian-fraction (unit-fraction) decompositions of 1. From this we prove: (1) the bridge reciSum d = egyptSum (d.map (·−1)); (2) the Sylvester splitting 1/e = 1/(e+1) + 1/(e(e+1)) and an explicit family of boundary configurations of every length k+1, hence boundary configs exist with any number of bases; (3) base-2 rigidity — any boundary configuration using d = 2 is the singleton [2] (plain binary); plus concrete witnesses [2], [3,3], [3,4,7], [3,4,8,43]. All elementary, 0 axioms, 0 sorries; the parent's deep ≥ 1 completeness theorem is not reproved.",
+  "meta": {
+    "author": "Lean formalization original (builds on the Burr–Erdős–Graham–Li / Aristotle Erdős 124 entry)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos124CompleteSequencesOQ02.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "erdos",
+      "complete-sequences",
+      "egyptian-fractions",
+      "unit-fractions",
+      "sylvester-sequence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "List.sum / List.map",
+        "description": "Underlying definition of the unit-fraction sum egyptSum as a list-map-sum; cons/nil computation rules drive every induction",
+        "module": "Mathlib (Init.Data.List / Mathlib.Algebra.BigOperators)"
+      },
+      {
+        "theorem": "field_simp",
+        "description": "Clears denominators to verify the Sylvester splitting identity 1/(e+1) + 1/(e(e+1)) = 1/e for e ≥ 1",
+        "module": "Mathlib.Tactic.FieldSimp"
+      },
+      {
+        "theorem": "Nat.cast_sub",
+        "description": "((x − 1 : ℕ) : ℚ) = (x : ℚ) − 1 for x ≥ 1, the cast making the eᵢ = dᵢ − 1 bridge typecheck",
+        "module": "Mathlib.Data.Nat.Cast.Order.Basic"
+      },
+      {
+        "theorem": "List.cons_eq_cons / List.mem_cons",
+        "description": "Destructuring list equalities and memberships used in the base-2 rigidity argument",
+        "module": "Mathlib (Init.Data.List.Lemmas)"
+      }
+    ],
+    "originalContributions": [
+      "reciSum_eq_egyptSum: the bridge identity reciSum d = egyptSum (d.map (·−1)), establishing that the Erdős-124 boundary face ∑ 1/(dᵢ−1) = 1 is exactly an Egyptian-fraction decomposition ∑ 1/eᵢ = 1 with eᵢ = dᵢ − 1. This reframing is the structural answer to OQ-02: the 'technique at the boundary' is the arithmetic of Egyptian fractions, not new completeness machinery.",
+      "egyptSum_split + sylvester / sylvester_egyptSum / sylvester_length: the Sylvester splitting identity 1/e = 1/(e+1) + 1/(e(e+1)) and an explicit recursive construction producing, for every k, an Egyptian decomposition of 1 with exactly k+1 unit fractions (and ≥ 1 denominators).",
+      "exists_boundary_config: in base language, for every k ≥ 1 there is a list of k bases, each ≥ 2, lying exactly on the boundary reciSum = 1 — boundary configurations of Erdős 124 exist with an arbitrary number of bases.",
+      "egypt_one_forces_singleton / base_two_forces_singleton: the rigidity at the bottom — any boundary configuration that uses the base d = 2 (equivalently the unit fraction 1/1) must be the singleton [2], i.e. plain binary representation; no other base fits in the unit budget.",
+      "Concrete boundary witnesses [2], [3,3], [3,4,7], [3,4,8,43] (the last from Sylvester's sequence 2,3,7,43)."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas. The deep ≥ 1 completeness theorem of Erdős 124 is the parent entry's contribution and is not reproved here.",
+    "lineCount": 316,
+    "theoremCount": 15,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #124 (the weak Burr–Erdős–Graham–Li version) asks whether bases d₁,…,d_k ≥ 2 with ∑ 1/(dᵢ−1) ≥ 1 make every natural number a sum of numbers each having only 0/1 digits in its base. It was solved and formally verified by Harmonic's AI 'Aristotle' in November 2025 via Brown's criterion (see the parent entry). The reciprocal condition is a closed half-line ∑ 1/(dᵢ−1) ≥ 1, and its extreme face is equality. This follow-up studies that boundary.",
+    "problemStatement": "**OQ-02:** what techniques are needed at the exact boundary ∑ 1/(dᵢ−1) = 1?\n\n**Answer:** none beyond the parent theorem — the boundary is contained in the closed region the parent already covers. The genuinely new content is structural: writing eᵢ = dᵢ − 1 ≥ 1, the boundary condition becomes\n$$\\sum 1/e_i = 1,$$\nso the Erdős-124 boundary configurations are *exactly the Egyptian-fraction decompositions of 1*. The relevant 'technique' is therefore the arithmetic of unit fractions / the Sylvester splitting.",
+    "text": "The boundary ∑ 1/(dᵢ−1) = 1 of Erdős 124 is exactly an Egyptian-fraction decomposition of 1 (set eᵢ = dᵢ − 1). Boundary configurations exist with any number of bases (Sylvester splitting), and any boundary configuration containing the base d = 2 is the singleton [2] (binary).",
+    "proofStrategy": "Work with egyptSum e = ∑ 1/eᵢ and reciSum d = ∑ 1/(dᵢ−1) as list-map-sums over ℚ.\n1. reciSum_eq_egyptSum: list induction; the cons step needs ((a−1:ℕ):ℚ) = (a:ℚ)−1 (Nat.cast_sub, a ≥ 1).\n2. egyptSum_split: field_simp clears denominators in 1/(e+1)+1/(e(e+1)) = 1/e for e ≥ 1.\n3. sylvester k: recursively split the head unit fraction (e ↦ e+1, e(e+1)); induction proves the sum stays 1, length is k+1, and denominators stay ≥ 1.\n4. exists_boundary_config: map the Sylvester denominators by (+1) to get k bases ≥ 2 with reciSum = 1.\n5. egypt_one_forces_singleton: if the unit 1 occurs, its term is 1/1 = 1, so egyptSum ≥ 1 (egyptSum_ge_one_of_mem_one) with all other terms positive forces the rest empty; base_two_forces_singleton transports this through the bridge.",
+    "keyInsights": [
+      "**The boundary is Egyptian fractions.** The single substitution eᵢ = dᵢ − 1 turns the opaque reciprocal-sum boundary ∑ 1/(dᵢ−1) = 1 into ∑ 1/eᵢ = 1, a classical unit-fraction decomposition of 1. This is the whole point: the 'hard technique at the boundary' is just the arithmetic of Egyptian fractions.",
+      "**Boundary configs exist for every k.** The Sylvester splitting 1/e = 1/(e+1) + 1/(e(e+1)) lets one trade a unit fraction for two, so a boundary configuration of length k can be grown to length k+1; the parameter k (number of bases) is completely unconstrained.",
+      "**Binary is rigid.** The base d = 2 contributes the full unit fraction 1/1 = 1, leaving zero budget for any other base — so the only boundary configuration using d = 2 is the singleton [2], which is ordinary base-2 representation. This isolates exactly when the boundary degenerates.",
+      "**No new completeness machinery is needed.** Equality is a face of the closed condition ∑ ≥ 1 the parent already proves complete, so the boundary inherits completeness for free; what the boundary adds is combinatorial structure, not a harder analytic theorem."
+    ],
+    "prerequisites": [
+      "Egyptian / unit fractions and decompositions of 1",
+      "The Sylvester sequence and the splitting identity 1/n = 1/(n+1) + 1/(n(n+1))",
+      "List induction and rational arithmetic in Lean (field_simp, Nat.cast_sub)",
+      "Erdős Problem 124 and Brown's criterion for complete sequences (parent entry)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Egyptian and reciprocal sums",
+      "startLine": 60,
+      "endLine": 110,
+      "summary": "egyptSum (∑ 1/eᵢ) and reciSum (∑ 1/(dᵢ−1)) as list-map-sums over ℚ, with cons/nil simp rules and the bridge reciSum_eq_egyptSum showing the Erdős-124 reciprocal sum is an Egyptian-fraction sum under eᵢ = dᵢ − 1.",
+      "mathContext": "Reframing the boundary face ∑ 1/(dᵢ−1) = 1 as a unit-fraction decomposition of 1."
+    },
+    {
+      "id": "sylvester",
+      "title": "Sylvester splitting and boundary configurations of every size",
+      "startLine": 111,
+      "endLine": 195,
+      "summary": "egyptSum_split (1/e = 1/(e+1) + 1/(e(e+1))) and the explicit construction sylvester k, with sylvester_egyptSum, sylvester_length and sylvester_pos, culminating in exists_boundary_config: for every k ≥ 1 a list of k bases ≥ 2 with reciSum = 1.",
+      "mathContext": "The number of bases at the boundary is unconstrained: Sylvester splitting produces decompositions of 1 of every length."
+    },
+    {
+      "id": "rigidity",
+      "title": "Base-2 rigidity",
+      "startLine": 196,
+      "endLine": 290,
+      "summary": "egyptSum_ge_one_of_mem_one, egypt_one_forces_singleton, and base_two_forces_singleton: the unit fraction 1/1 saturates the budget, so any boundary configuration containing the base d = 2 is exactly [2] (plain binary).",
+      "mathContext": "The boundary degenerates to ordinary binary representation precisely when the base 2 is used."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete boundary witnesses",
+      "startLine": 291,
+      "endLine": 316,
+      "summary": "reciSum [2] = reciSum [3,3] = reciSum [3,4,7] = reciSum [3,4,8,43] = 1, the last realizing Sylvester's sequence 2,3,7,43, plus a sanity check of the recursion sylvester 3 = [4,12,6,2].",
+      "mathContext": "Explicit Egyptian decompositions of 1 in base language."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burr, Stefan A.; Erdős, Paul; Graham, Ronald L.; Li, Wen-Ching Winnie",
+      "title": "Complete sequences of sets of integer powers",
+      "year": "1996",
+      "note": "Acta Arithmetica 77.2 — the origin of Problem 124"
+    },
+    {
+      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "note": "Background on complete sequences and the reciprocal-sum condition"
+    },
+    {
+      "authors": "Graham, Ronald L.",
+      "title": "On finite sums of unit fractions",
+      "year": "1964",
+      "note": "Proc. London Math. Soc. — Egyptian-fraction decompositions, the structure underlying the boundary"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "erdos-124-complete-sequences",
+      "reason": "Direct parent: the AI-solved weak Erdős 124 entry whose reciprocal condition ∑ 1/(dᵢ−1) ≥ 1 this file analyzes at equality"
+    }
+  ],
+  "conclusion": {
+    "summary": "The exact boundary ∑ 1/(dᵢ−1) = 1 of Erdős 124 is shown to be precisely an Egyptian-fraction decomposition of 1 (eᵢ = dᵢ − 1), via the bridge reciSum_eq_egyptSum. The Sylvester splitting identity yields an explicit family of boundary configurations of every length (sylvester / exists_boundary_config), and the unit fraction 1/1 saturates the budget so that any boundary configuration using the base d = 2 is the singleton [2] (base_two_forces_singleton). 15 theorems, 3 definitions, 0 axioms, 0 sorries.",
+    "implications": "Gives a clean structural answer to OQ-02: the boundary needs no new completeness machinery (it is a face of the parent's closed condition), but it carries the full combinatorial richness of Egyptian fractions — arbitrarily many bases, with binary as the unique degenerate single-base case.",
+    "openQuestions": [
+      "Which boundary configurations (Egyptian decompositions of 1) give the strong, gcd-restricted version of Erdős 124, where the digit-1 power is excluded?",
+      "Among length-k boundary configurations, what is the minimal largest base d_max(k), and how does it compare with the doubly-exponential growth of the Sylvester sequence?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators"
+    ],
+    "namespace": "Erdos124OQ02",
+    "lineCount": 316,
+    "axiomCount": 0,
+    "theoremCount": 15,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos124CompleteSequencesOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to the AI-solved **Erdős 124** entry (complete sequences), answering **OQ-02**: *what techniques are needed at the exact boundary `∑ 1/(dᵢ−1) = 1`* of the reciprocal condition?

**Key observation.** Substituting `eᵢ = dᵢ − 1 ≥ 1`, the boundary condition becomes `∑ 1/eᵢ = 1` — so the Erdős-124 boundary configurations are *exactly the Egyptian-fraction (unit-fraction) decompositions of 1*. The "technique at the boundary" is the arithmetic of Egyptian fractions, not new completeness machinery (equality is a face of the closed `≥ 1` region the parent already proves complete).

## Results (15 theorems, 3 defs, **0 axioms, 0 sorries**)

- `reciSum_eq_egyptSum` — the bridge `reciSum d = egyptSum (d.map (·−1))`.
- `egyptSum_split` + `sylvester` family — the Sylvester splitting `1/e = 1/(e+1) + 1/(e(e+1))` and an explicit boundary decomposition of length `k+1` for every `k`; `exists_boundary_config`: for all `k ≥ 1` there are `k` bases `≥ 2` with `reciSum = 1`. **Boundary configurations exist with any number of bases.**
- `base_two_forces_singleton` — any boundary configuration using `d = 2` is the singleton `[2]` (the unit fraction `1/1` saturates the budget) — plain binary representation is the unique degenerate single-base case.
- Concrete witnesses `[2]`, `[3,3]`, `[3,4,7]`, `[3,4,8,43]` (the last from Sylvester's sequence `2,3,7,43`).

## Verification

- Elaborated against Mathlib 4.26.0 (single-file `lean`, prebuilt oleans).
- `#print axioms` on all headline theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. **0-axiom verified.**
- The parent's deep `≥ 1` completeness theorem is **not** reproved.

Badge `original`; the core (Egyptian-fraction characterization, Sylvester chain, base-2 rigidity) is an elementary self-contained construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)