### PR TITLE
research(erdos-1023-oq-04): elementary growth brackets 2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ for the union-free maximum [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos1023OQ04.lean
+++ b/proofs/Proofs/Erdos1023OQ04.lean
@@ -1,0 +1,133 @@
+/-
+# Erdős Problem #1023 — Elementary growth brackets for the union-free maximum
+
+## Background
+
+Let `F(n)` be the maximum size of a family of subsets of `{1, …, n}` in which no set
+is the union of (two or more distinct) other members of the family ("union-free").
+Erdős asked whether `F(n) ~ c · 2ⁿ / √n`.  The answer is **yes**: the middle layer
+(all subsets of size `⌊n/2⌋`) is union-free and, by a theorem of Erdős–Kleitman, optimal,
+so
+                    F(n) = C(n, ⌊n/2⌋),
+the central binomial coefficient.  This identity is recorded in the parent gallery entry
+`erdos-1023` (`Erdos1023Problem.lean`).
+
+The parent entry establishes the asymptotic `F(n) ~ √(2/π) · 2ⁿ / √n` only through an
+**axiom** (`stirling_central` / `unionFreeMax_asymptotic`), because the precise constant
+requires Stirling's formula.  The qualitative growth, however, does **not** need Stirling.
+
+## What this file adds (0 axioms, fully verified)
+
+Taking the established value `F(n) = C(n, ⌊n/2⌋)` as the *definition* of `unionFreeMax`,
+we prove rigorous, completely elementary growth brackets:
+
+* `central_le_pow`            : `F(n) ≤ 2ⁿ`                       (trivial upper bound)
+* `pow_le_succ_mul_central`   : `2ⁿ ≤ (n+1) · F(n)`              ⟶  `F(n) ≥ 2ⁿ / (n+1)`
+* `unionFreeMax_bracket`      : both bounds together
+* `unionFreeMax_unbounded`    : `F(n) → ∞`  (∀ M, ∃ n, M ≤ F(n))
+
+The lower bound is the interesting direction: averaging the binomial identity
+`∑_{m≤n} C(n,m) = 2ⁿ` against the maximality of the central column
+(`Nat.choose_le_middle`) gives `2ⁿ ≤ (n+1)·C(n,⌊n/2⌋)` in one line.  Hence
+`2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ`, pinning down the growth of `F` up to a polynomial factor
+**without any appeal to Stirling's formula** — replacing the qualitative content of the
+parent's asymptotic axiom by a machine-checked elementary statement.
+
+The divergence `F(n) → ∞` is proved purely over `ℕ` using `choose_le_centralBinom`:
+`F(2n) = C(2n,n) = centralBinom n ≥ C(2n,1) = 2n`.
+
+We do **not** reprove the Erdős–Kleitman optimality (the hard, axiomatized direction in
+the parent); this file is solely about the elementary growth of the central column.
+-/
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Choose.Bounds
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Tactic
+
+namespace Erdos1023OQ04
+
+open Finset
+
+/-- The maximum size of a union-free family of subsets of `{1, …, n}`.
+By Erdős–Kleitman this equals the size of the middle layer, the central binomial
+coefficient `C(n, ⌊n/2⌋)` (see the parent entry `erdos-1023`). We take that value
+as the definition here and study its elementary growth. -/
+def unionFreeMax (n : ℕ) : ℕ := Nat.choose n (n / 2)
+
+@[simp] theorem unionFreeMax_def (n : ℕ) : unionFreeMax n = Nat.choose n (n / 2) := rfl
+
+/-- The union-free maximum is positive: the empty set is always available. -/
+theorem unionFreeMax_pos (n : ℕ) : 0 < unionFreeMax n :=
+  Nat.choose_pos (Nat.div_le_self n 2)
+
+/-- Trivial upper bound: a union-free family is a family of subsets, so its size is at
+most `2ⁿ`. Concretely, the central column is one term of the binomial sum. -/
+theorem central_le_pow (n : ℕ) : unionFreeMax n ≤ 2 ^ n :=
+  Nat.choose_le_two_pow n (n / 2)
+
+/-- **Key elementary lower bound.** Summing the binomial identity
+`∑_{m ≤ n} C(n,m) = 2ⁿ` and bounding every term by the maximal central column
+`C(n, ⌊n/2⌋)` gives `2ⁿ ≤ (n+1) · F(n)`. Equivalently `F(n) ≥ 2ⁿ / (n+1)`, an
+exponential lower bound that needs no Stirling estimate. -/
+theorem pow_le_succ_mul_central (n : ℕ) : 2 ^ n ≤ (n + 1) * unionFreeMax n := by
+  have h : (∑ m ∈ range (n + 1), n.choose m) ≤ ∑ _m ∈ range (n + 1), n.choose (n / 2) :=
+    Finset.sum_le_sum (fun m _ => Nat.choose_le_middle m n)
+  calc 2 ^ n = ∑ m ∈ range (n + 1), n.choose m := (Nat.sum_range_choose n).symm
+    _ ≤ ∑ _m ∈ range (n + 1), n.choose (n / 2) := h
+    _ = (n + 1) * unionFreeMax n := by
+        rw [Finset.sum_const, Finset.card_range, smul_eq_mul, unionFreeMax_def]
+
+/-- The two elementary brackets together:
+`2ⁿ ≤ (n+1)·F(n)` and `F(n) ≤ 2ⁿ`. These pin down the growth of `F` up to a
+polynomial factor, with no use of Stirling's formula. -/
+theorem unionFreeMax_bracket (n : ℕ) :
+    2 ^ n ≤ (n + 1) * unionFreeMax n ∧ unionFreeMax n ≤ 2 ^ n :=
+  ⟨pow_le_succ_mul_central n, central_le_pow n⟩
+
+/-- Real-valued form of the lower bracket: `2ⁿ / (n+1) ≤ F(n)`. -/
+theorem pow_div_succ_le_central (n : ℕ) :
+    (2 : ℝ) ^ n / (n + 1) ≤ (unionFreeMax n : ℝ) := by
+  have hpos : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  rw [div_le_iff₀ hpos]
+  have := pow_le_succ_mul_central n
+  have hcast : ((2 ^ n : ℕ) : ℝ) ≤ (((n + 1) * unionFreeMax n : ℕ) : ℝ) := by
+    exact_mod_cast this
+  push_cast at hcast
+  linarith [hcast]
+
+/-- `F(2n) = C(2n, n) = centralBinom n`, the central binomial coefficient. -/
+theorem unionFreeMax_two_mul (n : ℕ) : unionFreeMax (2 * n) = Nat.centralBinom n := by
+  unfold unionFreeMax Nat.centralBinom
+  rw [Nat.mul_div_cancel_left n (by norm_num : 0 < 2)]
+
+/-- A clean elementary linear lower bound on the even-index subsequence:
+`2n ≤ F(2n)`. (`F(2n) = C(2n,n) ≥ C(2n,1) = 2n`.) -/
+theorem two_mul_le_unionFreeMax_two_mul (n : ℕ) : 2 * n ≤ unionFreeMax (2 * n) := by
+  rw [unionFreeMax_two_mul]
+  have h : Nat.choose (2 * n) 1 ≤ Nat.centralBinom n := Nat.choose_le_centralBinom 1 n
+  rwa [Nat.choose_one_right] at h
+
+/-- **Divergence.** The union-free maximum is unbounded: `F(n) → ∞`.
+Proved purely over `ℕ` via the even subsequence `F(2M) ≥ 2M ≥ M`. -/
+theorem unionFreeMax_unbounded : ∀ M : ℕ, ∃ n, M ≤ unionFreeMax n := by
+  intro M
+  refine ⟨2 * M, ?_⟩
+  calc M ≤ 2 * M := by omega
+    _ ≤ unionFreeMax (2 * M) := two_mul_le_unionFreeMax_two_mul M
+
+/-! ### Concrete values
+
+`F(n) = C(n, ⌊n/2⌋)`: `1, 1, 2, 3, 6, 10, 20, …` for `n = 0, 1, 2, 3, 4, 5, 6`. -/
+
+example : unionFreeMax 0 = 1 := by decide
+example : unionFreeMax 1 = 1 := by decide
+example : unionFreeMax 2 = 2 := by decide
+example : unionFreeMax 3 = 3 := by decide
+example : unionFreeMax 4 = 6 := by decide
+example : unionFreeMax 5 = 10 := by decide
+example : unionFreeMax 6 = 20 := by decide
+
+/-- Sanity check of the lower bracket at `n = 6`: `2⁶ = 64 ≤ 7 · 20 = 140`. -/
+example : 2 ^ 6 ≤ (6 + 1) * unionFreeMax 6 := pow_le_succ_mul_central 6
+
+end Erdos1023OQ04

--- a/src/data/proofs/erdos-1023-oq-04/meta.json
+++ b/src/data/proofs/erdos-1023-oq-04/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "erdos-1023-oq-04",
+  "title": "Erdős #1023: elementary growth brackets 2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ for the union-free maximum",
+  "slug": "erdos-1023-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Data.Nat.Choose.Bounds",
+      "Mathlib.Data.Nat.Choose.Central",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1023OQ04",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1023OQ04.lean",
+    "sorries": 0
+  },
+  "description": "Supplies rigorous, completely elementary growth brackets for the union-free maximum F(n) of Erdős Problem #1023. F(n) is the largest family of subsets of {1,...,n} in which no set is the union of two or more distinct other members; Erdős asked whether F(n) ~ c·2^n/√n, and the answer is YES with F(n) = C(n, floor(n/2)), the central binomial coefficient (middle layer optimal by Erdős-Kleitman). The parent file Erdos1023Problem.lean establishes the exact asymptotic only through axioms (stirling_central, unionFreeMax_asymptotic) because the constant √(2/π) needs Stirling's formula. This sibling takes the established value F(n) = C(n, floor(n/2)) as a definition and proves, with ZERO axioms beyond Mathlib's foundations: the upper bound F(n) ≤ 2^n (central_le_pow), the KEY lower bound 2^n ≤ (n+1)·F(n) i.e. F(n) ≥ 2^n/(n+1) (pow_le_succ_mul_central, by averaging ∑ C(n,m) = 2^n against the maximal central column Nat.choose_le_middle), the combined bracket, its real-valued form 2^n/(n+1) ≤ F(n), and divergence F(n) → ∞ (unionFreeMax_unbounded, proved purely over ℕ via F(2n) = centralBinom n ≥ C(2n,1) = 2n). This replaces the qualitative content of the parent's Stirling axiom — that F grows like 2^n up to a polynomial factor and tends to infinity — by a machine-checked elementary statement. 9 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1023OQ04.lean",
+    "tags": [
+      "combinatorics",
+      "extremal-set-theory",
+      "union-free-families",
+      "central-binomial-coefficient",
+      "binomial-coefficients",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with Lean v4.26.0 against the repository Mathlib pin (elaborated clean, #print axioms on every substantive theorem reports only propext / Classical.choice / Quot.sound). 0 sorries, 0 axiom declarations, no native_decide (the concrete-value examples use kernel `decide`, so no Lean.ofReduceBool). Self-contained: F(n) is defined directly as Nat.choose n (n/2); the parent file's axioms (problem_447_solution Erdős-Kleitman optimality, stirling_central, unionFreeMax_asymptotic) are NOT imported or used. Honest scope: this is the ELEMENTARY growth of the central binomial column (brackets up to a polynomial factor and divergence), NOT the exact asymptotic constant √(2/π) (which needs Stirling) and NOT the Erdős-Kleitman optimality that identifies F(n) with the central column.",
+    "lineCount": 133,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "pow_le_succ_mul_central: the key elementary lower bound 2^n ≤ (n+1)·F(n) — averaging the binomial identity ∑_{m≤n} C(n,m) = 2^n against the maximality of the central column (Nat.choose_le_middle); gives F(n) ≥ 2^n/(n+1) with no Stirling estimate",
+      "central_le_pow: the trivial upper bound F(n) ≤ 2^n (the central column is one term of the binomial sum)",
+      "unionFreeMax_bracket: the two-sided bracket 2^n ≤ (n+1)·F(n) and F(n) ≤ 2^n, pinning down the growth of F up to a polynomial factor",
+      "pow_div_succ_le_central: the real-valued lower bound 2^n/(n+1) ≤ F(n)",
+      "unionFreeMax_two_mul: the identity F(2n) = C(2n,n) = centralBinom n linking the even subsequence to the central binomial coefficient",
+      "two_mul_le_unionFreeMax_two_mul: the clean linear lower bound 2n ≤ F(2n) via Nat.choose_le_centralBinom",
+      "unionFreeMax_unbounded: divergence F(n) → ∞ (∀ M, ∃ n, M ≤ F(n)), proved purely over ℕ on the even subsequence"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1023 asks for F(n), the maximum size of a family of subsets of {1,...,n} in which no member is the union of two or more distinct other members (a 'union-free' family). Erdős conjectured F(n) ~ c·2^n/√n. The conjecture is true: the middle layer of all floor(n/2)-element subsets is union-free (two distinct sets of the same size cannot have a union of that size), giving F(n) ≥ C(n, floor(n/2)), and Erdős-Kleitman proved this is optimal, so F(n) = C(n, floor(n/2)) ~ √(2/π)·2^n/√n by Stirling. The central binomial coefficient C(n, floor(n/2)) is the largest entry of row n of Pascal's triangle.",
+    "problemStatement": "With F(n) = C(n, floor(n/2)) (the value established by the parent entry), bound the growth of F elementarily. This entry proves 2^n/(n+1) ≤ F(n) ≤ 2^n and F(n) → ∞ without invoking Stirling's formula.",
+    "proofStrategy": "Upper bound: the central column is a single term of ∑_{m≤n} C(n,m) = 2^n, so F(n) ≤ 2^n (Nat.choose_le_two_pow). Lower bound: every term of that sum is at most the maximal central column (Nat.choose_le_middle), so 2^n = ∑_{m≤n} C(n,m) ≤ (n+1)·C(n, floor(n/2)) = (n+1)·F(n); a one-line Finset.sum_le_sum followed by Finset.sum_const. The real-valued form follows by div_le_iff₀ and a cast. Divergence is shown over ℕ: F(2n) = C(2n, n) = centralBinom n, and centralBinom n ≥ C(2n,1) = 2n by Nat.choose_le_centralBinom, so F(2M) ≥ 2M ≥ M for every M.",
+    "keyInsights": [
+      "The qualitative growth of the union-free maximum needs NO Stirling estimate: a single averaging of the binomial identity ∑ C(n,m) = 2^n against the maximality of the central column gives 2^n ≤ (n+1)·F(n) in one line.",
+      "Combined with the trivial upper bound F(n) ≤ 2^n, this pins F(n) between 2^n/(n+1) and 2^n — capturing the 'order 2^n up to a polynomial factor' content of the parent's asymptotic axiom, but fully machine-checked.",
+      "Divergence is purely combinatorial: the even subsequence F(2n) equals the central binomial coefficient centralBinom n, which dominates C(2n,1) = 2n, so F is unbounded without any analysis.",
+      "The central binomial coefficient is the largest entry of Pascal's row n; Nat.choose_le_middle is exactly the maximality statement that powers the lower bracket."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition-bounds",
+      "title": "Definition and the Two-Sided Bracket",
+      "summary": "unionFreeMax (= C(n, floor(n/2))), positivity, the upper bound F(n) ≤ 2^n (central_le_pow), the key lower bound 2^n ≤ (n+1)·F(n) (pow_le_succ_mul_central), the combined bracket, and its real form.",
+      "startLine": 1,
+      "endLine": 96,
+      "mathContext": "Average the binomial identity ∑_{m≤n} C(n,m) = 2^n against the maximal central column (Nat.choose_le_middle) to get the lower bound; the upper bound is one term of the same sum."
+    },
+    {
+      "id": "divergence",
+      "title": "Even Subsequence and Divergence",
+      "summary": "unionFreeMax_two_mul (F(2n) = centralBinom n), two_mul_le_unionFreeMax_two_mul (2n ≤ F(2n)), unionFreeMax_unbounded (F(n) → ∞), and concrete values F(0..6) = 1,1,2,3,6,10,20.",
+      "startLine": 97,
+      "endLine": 133,
+      "mathContext": "F(2n) = C(2n,n) = centralBinom n ≥ C(2n,1) = 2n via Nat.choose_le_centralBinom, giving unboundedness over ℕ with no real analysis."
+    }
+  ],
+  "conclusion": {
+    "summary": "The union-free maximum F(n) = C(n, floor(n/2)) of Erdős Problem #1023 is bracketed elementarily by 2^n/(n+1) ≤ F(n) ≤ 2^n, and shown to diverge F(n) → ∞, with zero axioms beyond Mathlib's foundations. The lower bracket is a one-line average of the binomial identity ∑ C(n,m) = 2^n against the maximality of the central column; the upper bracket is a single term of that sum; divergence uses F(2n) = centralBinom n ≥ 2n. This captures the qualitative growth content of the parent file's Stirling-based asymptotic axiom as a machine-checked elementary statement.",
+    "implications": "The brackets make rigorous, without Stirling's formula, the fact that the maximum union-free family has size of order 2^n up to a polynomial factor and grows without bound. They isolate exactly what the exact asymptotic F(n) ~ √(2/π)·2^n/√n adds beyond the elementary picture (only the precise constant and the √n power, which genuinely require Stirling). The central-binomial bracket 2^n/(n+1) ≤ C(n, floor(n/2)) ≤ 2^n is reusable wherever the central column appears.",
+    "openQuestions": [
+      "Sharpen the lower bracket to the true order: prove 2^n/√(c·n) ≤ C(n, floor(n/2)) (the √n rather than n denominator), which requires a Stirling-type estimate.",
+      "Discharge the parent file's axioms (problem_447_solution Erdős-Kleitman optimality, stirling_central) to make the exact asymptotic fully proved.",
+      "Establish strict monotonicity F(n) < F(n+2) of the central binomial column directly from a Pascal recurrence, strengthening the unboundedness proved here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1023",
+      "relationship": "parent",
+      "description": "The main Erdős #1023 union-free families file (isUnionFree, middleLayer, the lower bound unionFreeMax_ge_middle, and the axiomatized Erdős-Kleitman optimality and Stirling asymptotic). It establishes F(n) = C(n, floor(n/2)); this sibling supplies the elementary, 0-axiom growth brackets 2^n/(n+1) ≤ F(n) ≤ 2^n and divergence that the parent only obtains through its Stirling axiom."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

**Erdős Problem #1023** asks for `F(n)`, the maximum size of a *union-free* family of subsets of `{1,…,n}` (no member is the union of two or more distinct others). The answer is `F(n) = C(n, ⌊n/2⌋)`, the central binomial coefficient: the middle layer is union-free and Erdős–Kleitman proved it optimal, giving `F(n) ~ √(2/π)·2ⁿ/√n`.

The parent gallery entry `erdos-1023` establishes that exact asymptotic only through **axioms** (`stirling_central`, `unionFreeMax_asymptotic`) — the constant `√(2/π)` genuinely needs Stirling's formula. This sibling proves the **qualitative growth with zero axioms** beyond Mathlib's foundations.

> **Slug note:** filed under `erdos-1023-oq-04`; `erdos-1023-oq-03` was concurrently taken by PR #27791 (a different result — the k-union-free hierarchy). No overlap in content or files.

## Results (`Proofs/Erdos1023OQ04.lean`, namespace `Erdos1023OQ04`)

Taking the established value `F(n) := C(n, ⌊n/2⌋)`:

| Theorem | Statement |
|---|---|
| `central_le_pow` | `F(n) ≤ 2ⁿ` |
| `pow_le_succ_mul_central` | **`2ⁿ ≤ (n+1)·F(n)`** (key lower bound) |
| `unionFreeMax_bracket` | both ⟹ `2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ` |
| `pow_div_succ_le_central` | real-valued `2ⁿ/(n+1) ≤ F(n)` |
| `unionFreeMax_two_mul` | `F(2n) = centralBinom n` |
| `unionFreeMax_unbounded` | `F(n) → ∞` (`∀ M, ∃ n, M ≤ F(n)`) |

**Key idea (lower bracket):** average the binomial identity `∑_{m≤n} C(n,m) = 2ⁿ` against the maximality of the central column (`Nat.choose_le_middle`) — one line gives `2ⁿ ≤ (n+1)·C(n,⌊n/2⌋)`. Divergence is purely combinatorial over ℕ: `F(2n) = C(2n,n) = centralBinom n ≥ C(2n,1) = 2n`, no real analysis.

This captures the parent's asymptotic *qualitative content* (order `2ⁿ` up to a polynomial factor, and `F(n)→∞`) as a machine-checked elementary statement.

## Verification

- 9 theorems, 1 definition, **0 sorries, 0 axiom declarations, no `native_decide`**.
- Elaborated clean with Lean v4.26.0 against the repo Mathlib pin.
- `#print axioms` on every substantive theorem reports only `propext / Classical.choice / Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. → **`verified`**.

## Honest scope

Elementary growth (brackets up to a polynomial factor + divergence) only. This does **not** reprove the exact Stirling constant `√(2/π)` or the Erdős–Kleitman optimality that identifies `F(n)` with the central column — both remain axiomatized in the parent and are not imported here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)