### PR TITLE
research(erdos-835-incomplete-01): register orphaned verified file in build manifest

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2319,6 +2319,7 @@ import Proofs.Erdos831Problem
 import Proofs.Erdos832Problem
 import Proofs.Erdos833Problem
 import Proofs.Erdos834Problem
+import Proofs.Erdos835Incomplete01
 import Proofs.Erdos835Problem
 import Proofs.Erdos836Problem
 import Proofs.Erdos837Problem

--- a/research/problems/erdos-835-incomplete-01/knowledge.md
+++ b/research/problems/erdos-835-incomplete-01/knowledge.md
@@ -1,0 +1,22 @@
+
+## Session 2026-06-22 (researcher-1) — INTEGRATION FIX (orphaned from build)
+
+**Mode**: REVISIT (pool re-served already-completed slug). **Outcome**: progress
+(integrity fix, no new math).
+
+### Finding
+researcher-9's PR #27684 created `proofs/Proofs/Erdos835Incomplete01.lean` (verified,
+0-axiom: erdosRosenfeld_surjective etc.) and a gallery `meta.json`, but the Lean file was
+**never registered in `proofs/Proofs.lean`** (only `Erdos835Problem` was) — so it was not
+part of the build and its verified claim went unchecked by CI. Same orphan pattern as
+erdos-11-wip-01 (PR #27788) this session.
+
+### What I Did
+- Registered `import Proofs.Erdos835Incomplete01` in `proofs/Proofs.lean` (LC_ALL=C sorted:
+  before `Erdos835Problem`, since 'I' < 'P').
+- Verified via host single-file `lean` (Docker down): EXIT=0; `#print axioms
+  erdosRosenfeld_surjective` = [propext, Classical.choice, Quot.sound] only — 0-axiom.
+
+### Next Steps
+- Erdős #835 main question is SOLVED (answer NO, 3≤k≤8); the scaffold's two sorries
+  (chromatic-number def + k=2 construction) remain in `Erdos835Problem.lean`, not this file.


### PR DESCRIPTION
## Summary

Integrity fix for Erdős #835. PR #27684 created `Proofs/Erdos835Incomplete01.lean` (verified, 0-axiom — the Erdős–Rosenfeld property ⇒ surjective colouring chain) plus its gallery entry, but the Lean file was **never registered in the auto-generated build manifest `proofs/Proofs.lean`** (only `Erdos835Problem` was). So the file was not part of the Lean build and its `verified` claim went unchecked by CI.

This is the same orphan pattern as `erdos-11-wip-01` (#27788) from this session — several files from the recent research batch were created but not added to `Proofs.lean`.

Fix (no new mathematics): register `import Proofs.Erdos835Incomplete01` in the correct `LC_ALL=C` sorted position (before `Erdos835Problem`, since `I` < `P`).

## Verification (Docker was down → host single-file `lean`)

- `Erdos835Incomplete01.lean` (imports Mathlib) elaborates with host `lean v4.26.0` against the prebuilt Mathlib oleans → **EXIT=0**.
- `#print axioms erdosRosenfeld_surjective` = `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`, genuinely 0-axiom. (`sorry` appears only in the file's prose docstring describing the scaffold it sidesteps.)

The gallery entry already exists and is unchanged (`status: verified`); this PR only makes the build actually check it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)