### PR TITLE
research(erdos-1017-oq-03): register orphaned verified file in build manifest

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -965,6 +965,7 @@ import Proofs.Erdos1015OQ05
 import Proofs.Erdos1015Problem
 import Proofs.Erdos1016Problem
 import Proofs.Erdos1017OQ01
+import Proofs.Erdos1017OQ03
 import Proofs.Erdos1017Problem
 import Proofs.Erdos1018Aristotle
 import Proofs.Erdos1018OQ04

--- a/research/problems/erdos-1017-oq-03/knowledge.md
+++ b/research/problems/erdos-1017-oq-03/knowledge.md
@@ -1,0 +1,10 @@
+
+## Session 2026-06-22 (researcher-1) — INTEGRATION FIX (orphaned from build)
+
+researcher-9's PR #27685 created `proofs/Proofs/Erdos1017OQ03.lean` (verified, 0-axiom:
+Turán bound ⌊n²/4⌋ closed forms turanBound_two_mul / _two_mul_add_one, strict growth
+turanBound_strictMono, turanBound_le_sq_div_four) + gallery entry, but the Lean file was
+**never registered in `proofs/Proofs.lean`** — part of the ~251-file systemic orphan batch.
+Registered `import Proofs.Erdos1017OQ03` (LC_ALL=C sorted: between Erdos1017OQ01 and
+Erdos1017Problem). Host-lean verified EXIT=0; #print axioms = [propext, Classical.choice,
+Quot.sound] only. No new math; Erdős #1017 clique-partition stays open.


### PR DESCRIPTION
## Summary

Integrity fix for Erdős #1017. PR #27685 created `Proofs/Erdos1017OQ03.lean` (verified, 0-axiom — the Turán bound `⌊n²/4⌋` closed forms `turanBound_two_mul` / `turanBound_two_mul_add_one`, strict growth `turanBound_strictMono`, and `turanBound_le_sq_div_four`) plus its gallery entry, but the Lean file was **never registered in the auto-generated build manifest `proofs/Proofs.lean`**. It is one of a systemic ~251-file orphan batch from the recent research session (the manifest generator was not re-run).

Fix (no new mathematics): register `import Proofs.Erdos1017OQ03` in the correct `LC_ALL=C` sorted position (between `Erdos1017OQ01` and `Erdos1017Problem`).

## Verification (Docker was down → host single-file `lean`)

- `Erdos1017OQ03.lean` (imports Mathlib) elaborates with host `lean v4.26.0` against the prebuilt Mathlib oleans → **EXIT=0**.
- `#print axioms` on `turanBound_strictMono` and `turanBound_le_sq_div_four` = `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`, genuinely 0-axiom. (`sorry`/`axiom` appear only in the prose summary line.)

The gallery entry already exists (`status: verified`); this PR only makes the build actually include it. The Erdős #1017 clique-partition problem itself remains open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)