### PR TITLE
research(erdos-1023-oq-03): axiom-free exponential lower bound F(n) ≥ 2ⁿ/(n+1) for union-free families [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos1023ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos1023ProblemOQ03.lean
@@ -1,0 +1,196 @@
+/-
+Erdős Problem #1023 (OQ-03): Single-layer constructions and an explicit
+exponential lower bound for union-free families.
+
+Parent: `Erdos1023Problem.lean` proves the union-free extremal function
+satisfies `F(n) = C(n, ⌊n/2⌋)`, with the lower bound coming from the single
+*middle* layer (`unionFreeMax_ge_middle`) and the matching upper bound routed
+through Problem 447 (`problem_447_solution`, an external input).
+
+This file isolates the part of the story that is fully self-contained and
+**axiom-free**: the lower-bound construction. It makes three points.
+
+  1. The middle layer is not special — *every* layer (the family of all
+     `k`-element subsets, for any fixed `k`) is an antichain, hence union-free.
+     So `F(n) ≥ C(n, k)` for every `k`, generalising the middle-layer bound.
+
+  2. Summing the binomial row and bounding each term by the central one gives
+     `2^n ≤ (n+1) · C(n, ⌊n/2⌋)`.
+
+  3. Combining (1) and (2) yields an explicit, axiom-free exponential lower
+     bound
+
+        `2^n ≤ (n + 1) · F(n)`,      equivalently   `F(n) ≥ 2^n / (n + 1)`,
+
+     proved purely from the single middle-layer construction and independent of
+     the (harder) matching upper bound. This already certifies that `F(n)` grows
+     exponentially — the crude pigeonhole `2^n / (n+1)` differs from the true
+     `~ √(2/π) · 2^n / √n` only by the polynomial factor `√n / (n+1)`.
+
+## Self-contained
+To keep this contribution axiom-free and independent of the parent's asymptotic
+section (which carries the 5 axioms routing the *upper* bound through Problem
+447), the small amount of lower-bound infrastructure it needs — set families,
+`isUnionFree`, `isAntichain`, `antichain_unionFree`, the extremal function
+`unionFreeMax`, and the `layer` construction — is re-declared here verbatim from
+the parent. Nothing below depends on any axiom: only `Classical.choice`,
+`propext`, `Quot.sound` are used.
+
+## Mathlib API used
+- `Nat.choose_le_middle` (`Mathlib.Data.Nat.Choose.Basic`)
+- `Nat.sum_range_choose` (`Mathlib.Data.Nat.Choose.Sum`)
+- `Finset.sum_le_sum`, `Finset.sum_const`, `Finset.card_range`
+- `Nat.div_le_div_right`, `Nat.mul_div_cancel_left`
+
+Tags: combinatorics, extremal-set-theory, union-free, antichain, sperner,
+      binomial-coefficients, lower-bound
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Fintype.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Lattice
+import Mathlib.Order.ConditionallyCompleteLattice.Basic
+
+open Finset
+
+namespace Erdos1023OQ03
+
+/-!
+## Lower-bound infrastructure (re-declared from the parent, axiom-free)
+-/
+
+/-- A set family is a collection of subsets of `Fin n`. -/
+abbrev SetFamily (n : ℕ) := Finset (Finset (Fin n))
+
+/-- The union of a subfamily. -/
+def familyUnion (F : SetFamily n) : Finset (Fin n) :=
+  F.sup id
+
+/-- A set is a union of a subfamily (of size ≥ 2). -/
+def isUnionOf (A : Finset (Fin n)) (F : SetFamily n) : Prop :=
+  ∃ G : SetFamily n, G ⊆ F ∧ G.card ≥ 2 ∧ A ∉ G ∧ familyUnion G = A
+
+/-- A family is union-free: no member is the union of other members. -/
+def isUnionFree (F : SetFamily n) : Prop :=
+  ∀ A ∈ F, ¬isUnionOf A (F.erase A)
+
+/-- A family is an antichain if no set contains another. -/
+def isAntichain (F : SetFamily n) : Prop :=
+  ∀ A ∈ F, ∀ B ∈ F, A ⊆ B → A = B
+
+/-- Each element of a subfamily contributes to the union. -/
+lemma mem_sub_familyUnion {F : SetFamily n} {B : Finset (Fin n)} (hB : B ∈ F) :
+    B ⊆ familyUnion F := by
+  intro x hx
+  simp only [familyUnion]
+  exact Finset.mem_sup.mpr ⟨B, hB, hx⟩
+
+/-- Antichains are union-free. -/
+theorem antichain_unionFree (F : SetFamily n) : isAntichain F → isUnionFree F := by
+  intro hanti A hA ⟨G, hGsub, hGcard, hAnotG, hGunion⟩
+  have hBsubA : ∀ B ∈ G, B ⊆ A := by
+    intro B hB
+    rw [← hGunion]
+    exact mem_sub_familyUnion hB
+  have hBeqA : ∀ B ∈ G, B = A := by
+    intro B hB
+    have hBF : B ∈ F := Finset.mem_of_mem_erase (hGsub hB)
+    exact hanti B hBF A hA (hBsubA B hB)
+  have : G.card ≤ 1 := by
+    by_contra h
+    push_neg at h
+    obtain ⟨B, hB, C, hC, hBC⟩ := Finset.one_lt_card.mp h
+    exact hBC (by rw [hBeqA B hB, hBeqA C hC])
+  omega
+
+/-- The set of achievable cardinalities is bounded above by `2^n`. -/
+theorem unionFree_sizes_bddAbove (n : ℕ) :
+    BddAbove { k : ℕ | ∃ F : SetFamily n, isUnionFree F ∧ F.card = k } :=
+  ⟨2 ^ n, fun k ⟨F, _, hk⟩ => hk ▸ (Finset.card_le_univ F).trans (by simp)⟩
+
+/-- `F(n)`: maximum size of a union-free family on `{0,…,n-1}`. -/
+noncomputable def unionFreeMax (n : ℕ) : ℕ :=
+  sSup { k : ℕ | ∃ F : SetFamily n, isUnionFree F ∧ F.card = k }
+
+/-- The `k`-th layer: all `k`-element subsets of `Fin n`. -/
+def layer (n k : ℕ) : SetFamily n :=
+  (univ.powerset).filter (fun A => A.card = k)
+
+/-- Size of a layer equals the binomial coefficient. -/
+theorem layer_card (n k : ℕ) : (layer n k).card = Nat.choose n k := by
+  simp [layer]
+
+/-!
+## OQ-03 results
+-/
+
+/-- **Every layer is an antichain.** The family of all `k`-element subsets of
+`Fin n` contains no two distinct comparable sets: if `A ⊆ B` and both have
+cardinality `k`, then `A = B`. This generalises the parent's
+`middleLayer_antichain` (the `k = n/2` case). -/
+theorem layer_antichain (n k : ℕ) : isAntichain (layer n k) := by
+  intro A hA B hB hAB
+  simp only [layer, mem_filter] at hA hB
+  exact Finset.eq_of_subset_of_card_le hAB (hA.2 ▸ hB.2 ▸ le_refl _)
+
+/-- **Every layer is union-free.** Immediate from `layer_antichain` and
+`antichain_unionFree`. -/
+theorem layer_unionFree (n k : ℕ) : isUnionFree (layer n k) :=
+  antichain_unionFree _ (layer_antichain n k)
+
+/-- **Lower bound at every layer.** Each binomial coefficient `C(n, k)` is
+realised by a union-free family (the `k`-th layer), so `F(n) ≥ C(n, k)` for
+*every* `k`. This strictly generalises the parent's middle-layer bound. -/
+theorem unionFreeMax_ge_choose (n k : ℕ) :
+    unionFreeMax n ≥ Nat.choose n k := by
+  apply le_csSup (unionFree_sizes_bddAbove n)
+  exact ⟨layer n k, layer_unionFree n k, layer_card n k⟩
+
+/-- The middle-layer bound, recovered as the `k = n/2` instance of
+`unionFreeMax_ge_choose`, confirming the generalisation subsumes it. -/
+theorem unionFreeMax_ge_middle (n : ℕ) :
+    unionFreeMax n ≥ Nat.choose n (n / 2) :=
+  unionFreeMax_ge_choose n (n / 2)
+
+/-- **Row sum bounded by the central term.** The binomial coefficients in row `n`
+sum to `2^n`, and each is at most the central coefficient `C(n, ⌊n/2⌋)`, so
+`2^n ≤ (n + 1) · C(n, ⌊n/2⌋)`. -/
+theorem two_pow_le_succ_mul_central (n : ℕ) :
+    2 ^ n ≤ (n + 1) * Nat.choose n (n / 2) := by
+  calc 2 ^ n = ∑ k ∈ Finset.range (n + 1), Nat.choose n k := (Nat.sum_range_choose n).symm
+    _ ≤ ∑ _k ∈ Finset.range (n + 1), Nat.choose n (n / 2) :=
+        Finset.sum_le_sum (fun k _ => Nat.choose_le_middle k n)
+    _ = (n + 1) * Nat.choose n (n / 2) := by
+        rw [Finset.sum_const, Finset.card_range, smul_eq_mul]
+
+/-- **Explicit exponential lower bound (axiom-free).** Purely from the single
+middle-layer construction,
+
+  `2^n ≤ (n + 1) · F(n)`.
+
+In particular `F(n)` grows at least like `2^n / (n + 1)` — exponentially —
+without invoking the matching (harder) upper bound. -/
+theorem unionFreeMax_exponential_lower_bound (n : ℕ) :
+    2 ^ n ≤ (n + 1) * unionFreeMax n := by
+  refine (two_pow_le_succ_mul_central n).trans ?_
+  gcongr
+  exact unionFreeMax_ge_middle n
+
+/-- Division form of the exponential lower bound: `2^n / (n + 1) ≤ F(n)`. -/
+theorem unionFreeMax_ge_two_pow_div (n : ℕ) :
+    2 ^ n / (n + 1) ≤ unionFreeMax n := by
+  calc 2 ^ n / (n + 1)
+      ≤ ((n + 1) * unionFreeMax n) / (n + 1) :=
+        Nat.div_le_div_right (unionFreeMax_exponential_lower_bound n)
+    _ = unionFreeMax n := Nat.mul_div_cancel_left _ (Nat.succ_pos n)
+
+#check @layer_antichain
+#check @unionFreeMax_ge_choose
+#check @unionFreeMax_exponential_lower_bound
+
+end Erdos1023OQ03

--- a/src/data/proofs/erdos-1023-oq-03/meta.json
+++ b/src/data/proofs/erdos-1023-oq-03/meta.json
@@ -1,0 +1,97 @@
+{
+  "id": "erdos-1023-oq-03",
+  "title": "Erdős #1023: an axiom-free exponential lower bound F(n) ≥ 2ⁿ/(n+1) for union-free families from single-layer constructions",
+  "slug": "erdos-1023-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1023OQ03",
+    "lineCount": 196,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1023ProblemOQ03.lean",
+    "sorries": 0
+  },
+  "description": "Isolates the fully self-contained, axiom-free part of Erdős Problem #1023 (union-free families: F(n) = max size of a family of subsets of {1,…,n} with no member the union of two or more others). The parent file proves F(n) = C(n, ⌊n/2⌋) but routes the matching UPPER bound through Problem 447 as an external input (5 axioms). This entry develops only the LOWER-bound construction, which needs no axioms. Three points: (1) the middle layer is not special — EVERY layer (all k-element subsets, any fixed k) is an antichain, hence union-free, so F(n) ≥ C(n, k) for every k (unionFreeMax_ge_choose), strictly generalising the parent's middle-layer bound; (2) summing the binomial row 2ⁿ = Σ C(n,k) and bounding each term by the central one gives 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋) (two_pow_le_succ_mul_central); (3) combining them yields the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), i.e. F(n) ≥ 2ⁿ/(n+1), proved purely from the single middle-layer construction and independent of the harder upper bound. This already certifies F(n) grows exponentially — the crude pigeonhole 2ⁿ/(n+1) differs from the true ~√(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1). Self-contained: the small lower-bound infrastructure (set families, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared from the parent so nothing depends on the axiom-carrying asymptotic section. 11 theorems, 7 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1023ProblemOQ03.lean",
+    "tags": [
+      "combinatorics",
+      "extremal-set-theory",
+      "union-free-families",
+      "antichain",
+      "sperner",
+      "binomial-coefficients",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked against the Mathlib pin (Lean v4.26.0). 0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound] for every theorem (verified on unionFreeMax_exponential_lower_bound, unionFreeMax_ge_choose, layer_antichain, unionFreeMax_ge_two_pow_div). Self-contained: the lower-bound infrastructure (SetFamily, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared here verbatim from the parent Erdos1023Problem.lean, whose asymptotic section carries the 5 axioms routing the matching upper bound through Problem 447 — those are neither imported nor used here. Honest scope: this is the unconditional LOWER bound F(n) ≥ 2ⁿ/(n+1) (the exponential growth certificate), not the sharp value F(n) = C(n, ⌊n/2⌋), whose upper half remains the parent's axiomatised external input.",
+    "lineCount": 196,
+    "theoremCount": 11,
+    "definitionCount": 7,
+    "originalContributions": [
+      "layer_antichain: every layer (the family of all k-element subsets of Fin n) is an antichain, for every k — generalising the parent's middleLayer_antichain (the k = n/2 case)",
+      "layer_unionFree: every layer is union-free, immediate from layer_antichain and antichain_unionFree",
+      "unionFreeMax_ge_choose: the lower bound F(n) ≥ C(n, k) holds at EVERY layer k, strictly generalising the parent's single middle-layer bound F(n) ≥ C(n, ⌊n/2⌋)",
+      "two_pow_le_succ_mul_central: the row-sum bound 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋), from Σ_{k} C(n,k) = 2ⁿ with each term ≤ the central coefficient (Nat.choose_le_middle)",
+      "unionFreeMax_exponential_lower_bound: the explicit axiom-free bound 2ⁿ ≤ (n+1)·F(n), certifying exponential growth of F(n) without the harder upper bound",
+      "unionFreeMax_ge_two_pow_div: the division form 2ⁿ/(n+1) ≤ F(n)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1023 asks whether the maximum union-free family of subsets of {1,…,n} — one in which no member equals the union of two or more other members — has size ~ c·2ⁿ/√n. The answer is YES: F(n) = C(n, ⌊n/2⌋) ~ √(2/π)·2ⁿ/√n. The lower bound comes from a single layer of Sperner's middle level (any antichain is union-free, because a union of an antichain's members would contain — hence equal — each of them), and the matching upper bound is the harder Erdős–Kleitman direction, in this formalization routed through Problem 447. This entry isolates the elementary lower-bound half, which is fully constructive and axiom-free.",
+    "problemStatement": "Without invoking the (harder, axiomatised) upper bound, give an explicit unconditional lower bound certifying that the union-free extremal function F(n) grows exponentially. Generalise the parent's single middle-layer construction to all layers, and combine with the central-binomial row bound to obtain 2ⁿ ≤ (n+1)·F(n), i.e. F(n) ≥ 2ⁿ/(n+1).",
+    "proofStrategy": "Each layer (all k-subsets) is an antichain by Finset.eq_of_subset_of_card_le (two equal-cardinality sets with A ⊆ B coincide); antichains are union-free; the layer has C(n,k) members (layer_card), so le_csSup against the boundedness of achievable sizes gives F(n) ≥ C(n,k) for every k. Independently, Nat.sum_range_choose gives Σ_{k≤n} C(n,k) = 2ⁿ, and Nat.choose_le_middle bounds each term by the central coefficient, so 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋) (Finset.sum_le_sum + sum_const). Chaining the k = ⌊n/2⌋ instance of the layer bound with the row bound yields 2ⁿ ≤ (n+1)·F(n) (gcongr); Nat.div_le_div_right + Nat.mul_div_cancel_left give the division form.",
+    "keyInsights": [
+      "The lower bound F(n) ≥ C(n, ⌊n/2⌋) is not special to the middle level: EVERY binomial coefficient C(n,k) is realised by a union-free family, because every layer is an antichain and antichains are union-free.",
+      "The central binomial coefficient already controls the whole row: 2ⁿ = Σ_k C(n,k) ≤ (n+1)·C(n, ⌊n/2⌋), so a single layer captures at least a 1/(n+1) fraction of all 2ⁿ subsets.",
+      "Combining the two gives an unconditional exponential lower bound 2ⁿ/(n+1) ≤ F(n) that needs none of the axiomatised upper-bound machinery — the crude pigeonhole differs from the sharp √(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1).",
+      "Separating the axiom-free lower-bound half from the axiom-carrying upper-bound half makes the unconditional content of the formalization explicit and machine-verifiable as 0-axiom."
+    ]
+  },
+  "sections": [
+    {
+      "id": "infrastructure",
+      "title": "Lower-bound infrastructure (re-declared, axiom-free)",
+      "summary": "Set families, familyUnion, isUnionOf/isUnionFree, isAntichain, antichain_unionFree, the boundedness of achievable sizes, the extremal function unionFreeMax, and the layer construction with layer_card.",
+      "startLine": 62,
+      "endLine": 126,
+      "mathContext": "Re-declared verbatim from the parent's axiom-free lower-bound section so the file depends only on Mathlib and the standard foundational axioms, not on the parent's Problem-447 input."
+    },
+    {
+      "id": "single-layer-lower-bound",
+      "title": "Single-layer constructions and the exponential lower bound",
+      "summary": "layer_antichain, layer_unionFree, unionFreeMax_ge_choose (F(n) ≥ C(n,k) for every k), two_pow_le_succ_mul_central (2ⁿ ≤ (n+1)·C(n,⌊n/2⌋)), unionFreeMax_exponential_lower_bound (2ⁿ ≤ (n+1)·F(n)), unionFreeMax_ge_two_pow_div (2ⁿ/(n+1) ≤ F(n)).",
+      "startLine": 128,
+      "endLine": 196,
+      "mathContext": "Finset.eq_of_subset_of_card_le for the antichain property, le_csSup for the per-layer lower bound, Nat.sum_range_choose + Nat.choose_le_middle for the row bound, gcongr and Nat.div lemmas to assemble the exponential bound."
+    }
+  ],
+  "conclusion": {
+    "summary": "The union-free extremal function satisfies the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), equivalently F(n) ≥ 2ⁿ/(n+1). It is obtained by generalising the parent's single middle-layer construction to all layers (F(n) ≥ C(n,k) for every k) and combining the k = ⌊n/2⌋ case with the row bound 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋). This certifies exponential growth of F(n) using none of the axiomatised upper-bound machinery, and is verified 0-axiom over Mathlib.",
+    "implications": "Separates the unconditional lower-bound content of Erdős #1023 from the harder, externally-routed upper bound, making the machine-verifiable axiom-free core explicit. The single-layer construction and the central-binomial row bound 2ⁿ ≤ (n+1)·C(n,⌊n/2⌋) are reusable across extremal set theory (Sperner-type antichain bounds, LYM, union-free and cover-free families).",
+    "openQuestions": [
+      "Tighten the elementary lower bound from 2ⁿ/(n+1) toward the sharp C(n, ⌊n/2⌋) by replacing the crude row bound with Stirling-type central-binomial estimates, keeping the argument axiom-free.",
+      "Give an axiom-free formalization of the Erdős–Kleitman upper bound F(n) ≤ C(n, ⌊n/2⌋), removing the parent's dependence on the Problem-447 external input.",
+      "Generalise the single-layer lower bound to k-union-free families (no member the union of at most k others) and to other forbidden Boolean operations (intersection-free, difference-free)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1023",
+      "relationship": "parent",
+      "description": "The main Erdős #1023 file proving F(n) = C(n, ⌊n/2⌋), with the lower bound from the single middle layer and the matching upper bound routed through Problem 447 (its 5 axioms). This child isolates and generalises the axiom-free lower-bound half."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Erdős Problem #1023 (union-free families): `F(n)` = max size of a family of subsets of `{1,…,n}` in which no member is the union of two or more others. The answer is `F(n) = C(n, ⌊n/2⌋) ~ √(2/π)·2ⁿ/√n`. The parent file proves this, but routes the **matching upper bound** through Problem 447 as an external input (5 axioms).

This entry isolates the **lower-bound half**, which is fully constructive and **axiom-free**, and pushes it slightly further:

1. **`layer_antichain` / `layer_unionFree`** — the middle layer is not special: *every* layer (all `k`-element subsets, any fixed `k`) is an antichain, hence union-free.
2. **`unionFreeMax_ge_choose`** — therefore `F(n) ≥ C(n, k)` for **every** `k`, strictly generalising the parent's single middle-layer bound.
3. **`two_pow_le_succ_mul_central`** — `2ⁿ = Σ_k C(n,k) ≤ (n+1)·C(n, ⌊n/2⌋)` (each term ≤ the central coefficient).
4. **`unionFreeMax_exponential_lower_bound`** — combining (2) at `k = ⌊n/2⌋` with (3): `2ⁿ ≤ (n+1)·F(n)`, i.e. `F(n) ≥ 2ⁿ/(n+1)`.

This certifies that `F(n)` grows **exponentially** without invoking the harder upper bound; the crude `2ⁿ/(n+1)` differs from the sharp `√(2/π)·2ⁿ/√n` only by the polynomial factor `√n/(n+1)`.

## Verification

- 11 theorems, 7 definitions, 196 lines, **0 sorries, 0 axiom declarations, no `native_decide`**.
- `#print axioms` on the headline results (`unionFreeMax_exponential_lower_bound`, `unionFreeMax_ge_choose`, `layer_antichain`, `unionFreeMax_ge_two_pow_div`) reports only `[propext, Classical.choice, Quot.sound]`.
- **Self-contained**: the lower-bound infrastructure (set families, `isUnionFree`, `isAntichain`, `antichain_unionFree`, `unionFreeMax`, `layer`) is re-declared from the parent so nothing depends on the parent's axiom-carrying asymptotic section. Verified against the Mathlib pin (Lean v4.26.0) via single-file elaboration.

## Honest scope

This is the unconditional **lower** bound `F(n) ≥ 2ⁿ/(n+1)` (the exponential-growth certificate), **not** the sharp value `F(n) = C(n, ⌊n/2⌋)` — the upper half remains the parent's axiomatised Problem-447 input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)