### PR TITLE
Fix stale leanFile cache: binomial-theorem-oq-02-oq-01-oq-01 (sorries 3→0)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -186,14 +186,14 @@
       "MeasureTheory"
     ],
     "namespace": "BinomialTheoremOQ02OQ01OQ01",
-    "lineCount": 308,
+    "lineCount": 707,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,
     "definitionCount": 4,
     "path": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
-    "sorries": 3,
+    "sorries": 0,
     "additionalFiles": [
       "Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean"
     ]


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `binomial-theorem-oq-02-oq-01-oq-01` (Multinomial PMF Integration)
**Severity**: LOW (stale auto-generated cache; no overclaim — public status was already correct)

## Evidence

The `leanFile` cache block in `meta.json` was stale relative to the current headline source:

| field | cache (stale) | actual file | meta block (already correct) |
|-------|---------------|-------------|------------------------------|
| `sorries` | 3 | **0** | 0 |
| `lineCount` | 308 | **707** | 707 |
| `theoremCount` | 8 | 7 (`^theorem`) | 7 |

`proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean` is fully verified: 0 `sorry`, 0 `axiom`, and the only `native_decide` token is inside a comment (the dice example uses kernel `decide`, so no `Lean.ofReduceBool`). `status: verified` / `badge: verified` are correct.

The contradiction was purely internal: the public-facing `meta` block read `sorries: 0`, but the separate `leanFile` cache still showed `sorries: 3` from an earlier WIP version that has since been completed.

## Fix

Aligned the `leanFile` cache to reality: `sorries` 3→0, `lineCount` 308→707, `theoremCount` 8→7.

---
Discovered during gallery-wide integrity audit (3089 entries scanned; verified-tier overclaim check came back clean — this was the single metadata drift found).