### PR TITLE
Enrich Fatou's lemma: strictness of the liminf inequality

### DIFF
--- a/src/data/proofs/fatou-lemma-oq-01/annotations.json
+++ b/src/data/proofs/fatou-lemma-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "fatou-restatements",
+    "proofId": "fatou-lemma-oq-01",
+    "range": { "startLine": 64, "endLine": 80 },
+    "type": "concept",
+    "title": "Fatou's Lemma (Mathlib Restatements)",
+    "content": "fatou_lintegral_liminf_le and its AEMeasurable variant fatou_lintegral_liminf_le' restate Mathlib's lintegral_liminf_le / lintegral_liminf_le' for the gallery: for nonnegative measurable fₙ, ∫⁻ liminfₙ fₙ ≤ liminfₙ ∫⁻ fₙ. The inequality direction is fixed by the fact that integration cannot detect mass that the pointwise liminf discards — the entire point the rest of the file makes concrete. The 'mathlib' badge is honest: the inequality is imported; the original content is the strictness witness.",
+    "mathContext": "$\\int^- \\liminf_n f_n \\le \\liminf_n \\int^- f_n$ for nonnegative measurable $f_n : \\alpha \\to [0,\\infty]$.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue integral", "liminf", "monotone convergence theorem", "dominated convergence theorem"],
+    "prerequisites": ["measure theory", "lower Lebesgue integral"]
+  },
+  {
+    "id": "escaping-def",
+    "proofId": "fatou-lemma-oq-01",
+    "range": { "startLine": 82, "endLine": 90 },
+    "type": "definition",
+    "title": "The Escaping-Mass Sequence 𝟙_[n,n+1)",
+    "content": "escaping n is the indicator of the half-open block [n, n+1) (valued in ℝ≥0∞), a unit bump marching off to +∞. escaping_measurable certifies measurability (indicator of a measurable interval). This is the canonical mechanism of mass loss in the limit: the mass is always present somewhere, but the location runs off to infinity, so no point retains it. The same sequence underlies the Egorov finiteness counterexample — measured there by uniform convergence, here by the integral.",
+    "mathContext": "$\\mathrm{escaping}\\,n = \\mathbf{1}_{[n,n+1)} : \\mathbb{R} \\to [0,\\infty]$, a unit bump escaping to $+\\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["indicator function", "escaping mass", "concentration at infinity", "counterexample construction"],
+    "prerequisites": ["indicator functions", "measurable sets"]
+  },
+  {
+    "id": "unit-mass",
+    "proofId": "fatou-lemma-oq-01",
+    "range": { "startLine": 92, "endLine": 98 },
+    "type": "technique",
+    "title": "Each Bump Carries Unit Mass",
+    "content": "escaping_lintegral computes ∫⁻ escaping n = 1 for every n, via lintegral_indicator_one (the integral of an indicator is the measure of the set) and Real.volume_Ico ([n,n+1) has length 1, so ENNReal.ofReal 1 = 1). This is the conserved quantity: every integral in the sequence equals 1, so liminfₙ ∫⁻ escaping n = 1. Mass is never created or destroyed — it merely escapes.",
+    "mathContext": "$\\int^- \\mathrm{escaping}\\,n = \\mathrm{vol}[n,n+1) = 1$ for all $n$; the integrals form the constant sequence $1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lintegral_indicator_one", "Lebesgue measure of intervals", "conserved mass"],
+    "prerequisites": ["Lebesgue integral", "measure of intervals"]
+  },
+  {
+    "id": "liminf-zero",
+    "proofId": "fatou-lemma-oq-01",
+    "range": { "startLine": 100, "endLine": 119 },
+    "type": "insight",
+    "title": "The Pointwise Liminf Is Zero Everywhere",
+    "content": "escaping_liminf_zero shows liminfₙ escaping n x = 0 at every x. The sequence n ↦ escaping n x is eventually 0: once n ≥ ⌊x⌋₊ + 1 the block [n, n+1) lies strictly right of x (Nat.lt_floor_add_one), so escaping n x = 0; tendsto_const_nhds.congr' makes it converge to 0 and Tendsto.liminf_eq reads off liminf = 0. Thus the integrand of the left-hand side of Fatou is identically 0 — the mass present in every integral is absent from the pointwise limit.",
+    "mathContext": "For fixed $x$, $\\mathrm{escaping}\\,n\\,x = 0$ for all $n > \\lfloor x \\rfloor$, so $\\liminf_n \\mathrm{escaping}\\,n\\,x = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["liminf of a convergent sequence", "eventual constancy", "Tendsto.liminf_eq", "pointwise convergence"],
+    "prerequisites": ["limits and liminf", "floor function"]
+  },
+  {
+    "id": "strict-gap",
+    "proofId": "fatou-lemma-oq-01",
+    "range": { "startLine": 121, "endLine": 140 },
+    "type": "concept",
+    "title": "Fatou's Inequality Is Genuinely Strict",
+    "content": "fatou_strict_on_escaping assembles the witness: the left side ∫⁻ liminfₙ escaping n = ∫⁻ 0 = 0 (escaping_liminf_zero + lintegral_zero), the right side liminfₙ ∫⁻ escaping n = liminf of the constant 1 = 1 (escaping_lintegral + liminf_const), so 0 < 1 strictly. This proves Fatou cannot be upgraded to an equality without extra hypotheses — it pinpoints why the monotone convergence theorem (needs monotonicity) and dominated convergence theorem (needs an integrable majorant) carry their conditions: the escaping-mass example violates exactly those, having no integrable dominating function.",
+    "mathContext": "$\\int^- \\liminf_n \\mathrm{escaping}\\,n = 0 < 1 = \\liminf_n \\int^- \\mathrm{escaping}\\,n$.",
+    "significance": "key",
+    "relatedConcepts": ["strict inequality", "monotone convergence theorem", "dominated convergence theorem", "loss of mass"],
+    "prerequisites": ["Fatou's lemma", "Lebesgue integral"]
+  }
+]

--- a/src/data/proofs/fatou-lemma-oq-01/meta.json
+++ b/src/data/proofs/fatou-lemma-oq-01/meta.json
@@ -79,6 +79,60 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Fatou's lemma is due to Pierre Fatou, who introduced it in his 1906 thesis 'Séries trigonométriques et séries de Taylor' (Acta Mathematica 30) while studying boundary behaviour of analytic functions and the convergence of trigonometric series. It is one of the three pillars of Lebesgue integration — alongside the monotone convergence theorem (Beppo Levi) and the dominated convergence theorem — and in fact the logical hub of the trio: MCT yields Fatou, and Fatou yields DCT (applied to g ± fₙ for an integrable majorant g). The lemma's defining feature is that it is an INEQUALITY, not an equality, and the reason is the phenomenon of mass escaping to infinity. The unit bumps 𝟙_[n,n+1) marching off along ℝ are the textbook illustration (Folland Thm 2.18 and its discussion), showing that integral and pointwise-liminf genuinely disagree. Mathlib formalizes the inequality (lintegral_liminf_le) but records no witness that it is strict; this entry supplies that witness, and ties it to the same escaping-mass sequence behind the Egorov finiteness counterexample.",
+    "problemStatement": "Restate Fatou's lemma for the gallery (∫⁻ liminfₙ fₙ ≤ liminfₙ ∫⁻ fₙ for nonnegative measurable fₙ, in both Measurable and AEMeasurable forms) and prove that the inequality is genuinely strict by an explicit witness. Concretely, for the escaping-mass sequence escaping n = 𝟙_[n,n+1) on (ℝ, Lebesgue): each bump has ∫⁻ escaping n = 1, yet liminfₙ escaping n x = 0 at every x, so ∫⁻ liminfₙ escaping n = 0 < 1 = liminfₙ ∫⁻ escaping n.",
+    "proofStrategy": "The headline inequalities are direct re-exports of Mathlib's lintegral_liminf_le / lintegral_liminf_le'. The strictness witness is built from three computations on escaping n = 𝟙_[n,n+1). (1) escaping_lintegral: ∫⁻ escaping n = 1, via lintegral_indicator_one and Real.volume_Ico (the block has length 1). (2) escaping_liminf_zero: at fixed x the sequence is eventually 0 — once n ≥ ⌊x⌋₊ + 1 the block sits strictly right of x (Nat.lt_floor_add_one) — so it converges to 0 and Tendsto.liminf_eq gives liminf = 0. (3) fatou_strict_on_escaping: the left side is ∫⁻ 0 = 0 (lintegral_zero), the right side is liminf of the constant sequence 1 = 1 (liminf_const), hence 0 < 1. The gap is exactly the unit mass that every integral sees but the pointwise liminf loses.",
+    "keyInsights": [
+      "Fatou is an inequality precisely because mass can leak to infinity: the escaping bumps keep their unit mass in every integral, but no fixed point retains any of it, so the pointwise liminf collapses to 0. The strict gap 0 < 1 is the formal fingerprint of that leakage.",
+      "The witness pinpoints why the stronger convergence theorems need their hypotheses. The escaping-mass sequence has NO integrable majorant (sup over n of escaping n is 𝟙_[0,∞), of infinite integral), so the dominated convergence theorem does not apply — exactly the hypothesis that would have forced equality.",
+      "It is the SAME sequence that breaks Egorov on an infinite-measure space: loss of mass to infinity is one phenomenon viewed through two lenses — the integral here, uniform convergence in the Egorov entry. The cross-reference makes the unity explicit.",
+      "Strictness is the maximally strong failure: the gap is not a small ε but the full unit mass (0 versus 1). The inequality is as far from equality as the normalization allows, so no quantitative weakening of the hypotheses could rescue equality on this example.",
+      "The clean separation — import the inequality, originate only the witness — keeps the 'mathlib' badge honest: the deep theorem is Mathlib's, the new mathematical content is the explicit demonstration that it cannot be improved to an equality."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Fatou and the Strict Gap",
+      "startLine": 5,
+      "endLine": 57,
+      "summary": "States Fatou's lemma (∫⁻ liminf ≤ liminf ∫⁻), names the Mathlib vehicle lintegral_liminf_le, and lays out the escaping-mass witness 𝟙_[n,n+1) showing strictness: unit mass per bump, pointwise liminf 0, strict gap 0 < 1. Explains why this is the reason Fatou is only an inequality (mass escapes to infinity) and notes Mathlib records no strict witness. Confirms 0 sorries, 0 axioms, no native_decide.",
+      "mathContext": "$\\int^- \\liminf_n f_n \\le \\liminf_n \\int^- f_n$; strict on the escaping-mass example."
+    },
+    {
+      "id": "restatements",
+      "title": "Fatou's Lemma: Mathlib Restatements",
+      "startLine": 64,
+      "endLine": 80,
+      "summary": "fatou_lintegral_liminf_le (Measurable) and fatou_lintegral_liminf_le' (AEMeasurable) re-export Mathlib's lintegral_liminf_le / lintegral_liminf_le' as the headline gallery statements of Fatou's inequality for nonnegative ℝ≥0∞-valued sequences.",
+      "mathContext": "For nonnegative (AE)measurable $f_n$: $\\int^- \\liminf_n f_n \\le \\liminf_n \\int^- f_n$."
+    },
+    {
+      "id": "escaping-sequence",
+      "title": "The Escaping-Mass Sequence",
+      "startLine": 82,
+      "endLine": 98,
+      "summary": "escaping n = 𝟙_[n,n+1) (ℝ≥0∞-valued), measurable via escaping_measurable. escaping_lintegral computes its unit mass ∫⁻ escaping n = 1 using lintegral_indicator_one and Real.volume_Ico (the block has length 1). This is the conserved quantity that escapes to infinity.",
+      "mathContext": "$\\mathrm{escaping}\\,n = \\mathbf{1}_{[n,n+1)}$, with $\\int^- \\mathrm{escaping}\\,n = 1$ for every $n$."
+    },
+    {
+      "id": "liminf-zero",
+      "title": "Pointwise Liminf Is Zero Everywhere",
+      "startLine": 100,
+      "endLine": 119,
+      "summary": "escaping_liminf_zero: at every x the sequence n ↦ escaping n x is eventually 0 (once n ≥ ⌊x⌋₊ + 1 the block lies strictly right of x, via Nat.lt_floor_add_one), so it converges to 0 and Tendsto.liminf_eq gives liminf = 0. The left-hand integrand of Fatou is thus identically 0.",
+      "mathContext": "For fixed $x$, $\\mathrm{escaping}\\,n\\,x = 0$ for all $n > \\lfloor x \\rfloor$, hence $\\liminf_n \\mathrm{escaping}\\,n\\,x = 0$."
+    },
+    {
+      "id": "strict-gap",
+      "title": "The Headline: Fatou Is Strict",
+      "startLine": 121,
+      "endLine": 140,
+      "summary": "fatou_strict_on_escaping: left side ∫⁻ liminfₙ escaping n = ∫⁻ 0 = 0 (escaping_liminf_zero + lintegral_zero), right side liminfₙ ∫⁻ escaping n = liminf of constant 1 = 1 (escaping_lintegral + liminf_const), so 0 < 1 strictly. The unit mass survives in every integral but vanishes from the pointwise liminf — the witness that Fatou cannot be upgraded to equality.",
+      "mathContext": "$\\int^- \\liminf_n \\mathrm{escaping}\\,n = 0 < 1 = \\liminf_n \\int^- \\mathrm{escaping}\\,n$."
+    }
+  ],
   "openQuestions": [
     {
       "id": "fatou-lemma-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `fatou-lemma-oq-01` (escaping-mass witness that Fatou's inequality is strict).

The entry had `conclusion`/`openQuestions`/`crossReferences`/`references`/`meta` but no `overview`, `sections`, or `annotations.json`.

## Changes
- **overview** (new): `historicalContext` (Fatou 1906, the MCT→Fatou→DCT logical hub, escaping mass), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 5 sections covering the full file (docstring → restatements → escaping sequence → liminf-zero → strict gap).
- **annotations.json** (new): 5 annotations with full schema.
- Preserved all existing fields.

## Axiom integrity
0 sorries, 0 axiom declarations, no `native_decide`. `status: verified`, `badge: mathlib` (inequality imported from Mathlib; strict witness is the original content) preserved accurately. `pnpm build` passes.