### PR TITLE
Enrich Wedderburn's little theorem and its arithmetic corollaries

### DIFF
--- a/src/data/proofs/little-wedderburn-oq-01/annotations.json
+++ b/src/data/proofs/little-wedderburn-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "headline-commutativity",
+    "proofId": "little-wedderburn-oq-01",
+    "range": { "startLine": 41, "endLine": 49 },
+    "type": "concept",
+    "title": "Wedderburn's Little Theorem: Commutativity",
+    "content": "mul_comm_of_finite_divisionRing exposes the theorem's defining content as an explicit ∀ x y, x*y = y*x for a finite division ring. The proof is literally mul_comm — but only because Mathlib's littleWedderburn instance has already endowed any finite division ring D with a Field structure, so the commutative-monoid mul_comm is available. Mathlib buries the result inside that instance; naming the commutativity statement makes the gem usable directly. The content is striking: finiteness alone forces multiplicative commutativity, with no commutativity hypothesis anywhere.",
+    "mathContext": "Every finite division ring is a field: $\\forall x, y,\\ xy = yx$. Finiteness alone collapses the multiplicative structure.",
+    "significance": "key",
+    "relatedConcepts": ["division ring", "field", "quaternions", "finite rings"],
+    "prerequisites": ["ring theory", "division rings"]
+  },
+  {
+    "id": "isfield-packaging",
+    "proofId": "little-wedderburn-oq-01",
+    "range": { "startLine": 51, "endLine": 62 },
+    "type": "definition",
+    "title": "IsField Packaging and the Finite-Domain Companion",
+    "content": "isField_of_finite_divisionRing repackages Wedderburn as the structural predicate IsField D (via Field.toIsField). isField_of_finite_domain is the companion form Finite.isDomain_to_isField: a finite ring with no zero divisors is already a field — finiteness simultaneously forces commutativity AND the existence of inverses. Together they record the two standard ways the theorem is invoked: from a division ring (drop noncommutativity) and from a domain (drop the inverse hypothesis).",
+    "mathContext": "$D$ finite division ring $\\Rightarrow \\mathrm{IsField}(D)$; and a finite integral domain is a field (zero divisors are the only obstruction).",
+    "significance": "supporting",
+    "relatedConcepts": ["IsField", "integral domain", "finite domain", "absence of zero divisors"],
+    "prerequisites": ["ring theory", "fields"]
+  },
+  {
+    "id": "prime-power-order",
+    "proofId": "little-wedderburn-oq-01",
+    "range": { "startLine": 64, "endLine": 79 },
+    "type": "insight",
+    "title": "The Order Is a Prime Power",
+    "content": "card_isPrimePow_of_finite_divisionRing and card_eq_primePow_of_finite_divisionRing lift FiniteField.isPrimePow_card / FiniteField.card' from fields to division rings via Wedderburn. The arithmetic shadow: a finite field is a vector space over its prime subfield 𝔽_p (p the characteristic), so |D| = p^n. These Mathlib lemmas fire on a division ring ONLY after littleWedderburn upgrades it to a field — so lifting them to the division-ring level is genuine derived content, not a restatement.",
+    "mathContext": "$|D| = p^n$ with $p = \\operatorname{char}(D)$ prime: $D$ is an $n$-dimensional $\\mathbb{F}_p$-vector space.",
+    "significance": "key",
+    "relatedConcepts": ["finite fields", "characteristic", "prime subfield", "vector space dimension"],
+    "prerequisites": ["finite fields", "characteristic of a ring"]
+  },
+  {
+    "id": "cyclic-units",
+    "proofId": "little-wedderburn-oq-01",
+    "range": { "startLine": 81, "endLine": 100 },
+    "type": "insight",
+    "title": "Cyclic Units and No Noncommutative Example",
+    "content": "isCyclic_units_of_finite_divisionRing: the multiplicative group Dˣ is cyclic — once Wedderburn makes D a field, Dˣ is a finite subgroup of the units of an integral domain, which is always cyclic (the standard 'finite subgroup of Kˣ is cyclic' theorem). units_mul_comm_of_finite_divisionRing notes Dˣ is therefore abelian, and no_noncommutative_finite_divisionRing records the contrapositive headline: no finite analogue of the quaternions exists at any cardinality. The cyclic-units fact is the abstract reason primitive roots exist.",
+    "mathContext": "$D^\\times$ is cyclic (finite subgroup of the units of a domain), hence abelian; no noncommutative finite division ring exists.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic group", "primitive root", "unit group", "finite subgroups of a field"],
+    "prerequisites": ["group theory", "units of a ring"]
+  },
+  {
+    "id": "zmod-instance",
+    "proofId": "little-wedderburn-oq-01",
+    "range": { "startLine": 102, "endLine": 113 },
+    "type": "context",
+    "title": "Worked Instance: ℤ/pℤ",
+    "content": "zmod_card_isPrimePow and zmod_units_isCyclic instantiate the corollaries on ZMod p for prime p: its order is the prime power p^1, and its unit group (ZMod p)ˣ is cyclic — the latter being exactly the classical existence of a primitive root modulo a prime, here recovered as a special case of the division-ring corollary rather than proved from scratch. These ground the abstract results in the most familiar finite field.",
+    "mathContext": "$|\\mathbb{Z}/p\\mathbb{Z}| = p^1$ and $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is cyclic — primitive roots mod $p$ exist.",
+    "significance": "context",
+    "relatedConcepts": ["ℤ/pℤ", "primitive root", "cyclic group", "finite field 𝔽_p"],
+    "prerequisites": ["modular arithmetic", "finite fields"]
+  }
+]

--- a/src/data/proofs/little-wedderburn-oq-01/meta.json
+++ b/src/data/proofs/little-wedderburn-oq-01/meta.json
@@ -74,6 +74,52 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Joseph Wedderburn proved his 'little theorem' — every finite division ring is commutative, hence a field — in 1905 (Trans. AMS 6). The result has an unusually rich proof history: Wedderburn's original paper gave three proofs, but the first contained a gap, and Leonard Dickson independently gave a correct proof the same year (the priority and the gap are a well-known episode in the history of algebra). The modern textbook proof, due essentially to Ernst Witt (1931), is a gem of elementary algebra: it combines the class equation of the multiplicative group Dˣ with a divisibility argument on cyclotomic polynomials Φ_n evaluated at q = |Z(D)|, showing the cyclotomic factor would have to divide q − 1 yet exceed it in absolute value unless n = 1, forcing D = Z(D). The theorem rules out any finite analogue of Hamilton's quaternions: noncommutative division algebras exist only in infinite dimension or over infinite fields. It is the cornerstone behind the classification of finite fields (every finite field has prime-power order and cyclic multiplicative group) and feeds the Artin–Wedderburn structure theory. Mathlib formalizes the theorem as the littleWedderburn instance but exposes none of its standard arithmetic corollaries at the division-ring level; this entry supplies them.",
+    "problemStatement": "Expose Wedderburn's little theorem as a named commutativity statement (∀ x y : D, x*y = y*x for a finite division ring D) and derive, at the division-ring level, the arithmetic corollaries that Mathlib states only for fields: the order |D| is a prime power p^n (p = char D); the multiplicative group Dˣ is cyclic and hence abelian; no noncommutative finite division ring exists; and instantiate these on ZMod p to recover its prime-power order and the existence of a primitive root modulo a prime.",
+    "proofStrategy": "Every result bottoms out at Mathlib's littleWedderburn instance, which turns [DivisionRing D] [Finite D] into Field D. The headline mul_comm_of_finite_divisionRing is then just mul_comm against that instance; isField_of_finite_divisionRing packages it as IsField (and isField_of_finite_domain gives the finite-domain companion via Finite.isDomain_to_isField). The arithmetic corollaries are obtained by lifting field-level Mathlib lemmas that only fire once D is a field: card_isPrimePow_of_finite_divisionRing / card_eq_primePow_of_finite_divisionRing apply FiniteField.isPrimePow_card / FiniteField.card', and isCyclic_units_of_finite_divisionRing is the integral-domain instance IsCyclic Rˣ (finite subgroup of the units of a domain). units_mul_comm and no_noncommutative restate commutativity at the unit-group and contrapositive levels. The ZMod p theorems specialize the corollaries to the prime residue field.",
+    "keyInsights": [
+      "Finiteness alone forces commutativity — there is no commutativity hypothesis anywhere. This is the surprise of the theorem: the quaternions and other noncommutative division algebras are possible only because they are infinite.",
+      "The value added over Mathlib is the LIFT from fields to division rings. The corollaries (prime-power order, cyclic units) are stated in Mathlib only for Field; they fire on a division ring exactly because littleWedderburn first upgrades it to a field, so naming them at the division-ring level is genuine derived content.",
+      "Prime-power order is the vector-space shadow: a finite field is a finite-dimensional vector space over its prime subfield 𝔽_p, so |D| = p^n. This is why finite fields exist only in prime-power orders — a fact Wedderburn is needed to extend to a priori-noncommutative division rings.",
+      "Cyclicity of Dˣ is the abstract source of primitive roots: a finite subgroup of the units of any integral domain is cyclic, so (ZMod p)ˣ being cyclic — the classical existence of a primitive root mod p — is a special case, not a separate theorem.",
+      "The 'mathlib' badge is honest: the deep theorem (and Witt's cyclotomic argument) lives in Mathlib's littleWedderburn; the original content here is the corralling of its arithmetic consequences into named, division-ring-level statements that Mathlib does not record."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Wedderburn and Its Corollaries",
+      "startLine": 3,
+      "endLine": 37,
+      "summary": "States Wedderburn's little theorem (every finite division ring is a field), names the Mathlib engine littleWedderburn, and lists the arithmetic corollaries the file lifts to the division-ring level — prime-power order, cyclic and abelian units, non-existence of a noncommutative finite division ring — which Mathlib states only for fields. Notes the distinction from the Artin–Wedderburn structure theorem already in the gallery.",
+      "mathContext": "Every finite division ring is commutative (a field); finiteness rules out any finite analogue of the quaternions."
+    },
+    {
+      "id": "headline",
+      "title": "The Headline Theorem",
+      "startLine": 41,
+      "endLine": 62,
+      "summary": "mul_comm_of_finite_divisionRing exposes the theorem as an explicit ∀ x y, x*y = y*x (proved by mul_comm against Mathlib's littleWedderburn Field instance). isField_of_finite_divisionRing packages it as IsField, and isField_of_finite_domain gives the finite-domain companion (Finite.isDomain_to_isField).",
+      "mathContext": "$D$ finite division ring (or finite domain) $\\Rightarrow D$ is a field: $\\forall x,y,\\ xy = yx$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Arithmetic Corollaries (Division-Ring Level)",
+      "startLine": 64,
+      "endLine": 100,
+      "summary": "card_isPrimePow / card_eq_primePow: |D| is a prime power p^n (p = char D), lifting FiniteField.isPrimePow_card / card'. isCyclic_units: Dˣ is cyclic (finite subgroup of a domain's units). units_mul_comm: Dˣ is abelian. no_noncommutative_finite_divisionRing: the contrapositive headline — no noncommutative finite division ring exists at any cardinality.",
+      "mathContext": "$|D| = p^n$; $D^\\times$ cyclic and abelian; no noncommutative finite division ring exists."
+    },
+    {
+      "id": "zmod-instance",
+      "title": "Worked Instance: ℤ/pℤ",
+      "startLine": 102,
+      "endLine": 113,
+      "summary": "zmod_card_isPrimePow: |ZMod p| = p^1 is a prime power. zmod_units_isCyclic: (ZMod p)ˣ is cyclic — the existence of a primitive root mod a prime, recovered as a special case of the division-ring corollary.",
+      "mathContext": "$|\\mathbb{Z}/p\\mathbb{Z}| = p^1$; $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ cyclic (primitive roots exist)."
+    }
+  ],
   "openQuestions": [
     {
       "id": "little-wedderburn-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `little-wedderburn-oq-01`.

The entry had `conclusion`/`openQuestions`/`crossReferences`/`references`/`meta` but no `overview`, `sections`, or `annotations.json`.

## Changes
- **overview** (new): `historicalContext` (Wedderburn 1905, Dickson's independent proof + the gap, Witt's cyclotomic argument), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 4 sections covering the full file (docstring → headline → corollaries → ℤ/pℤ instance).
- **annotations.json** (new): 5 annotations with full schema.
- Preserved all existing fields.

## Axiom integrity
0 sorries, 0 axiom declarations, no `native_decide`. `status: verified`, `badge: mathlib` (theorem from Mathlib's `littleWedderburn`; the division-ring-level arithmetic corollaries are the original content) preserved accurately. `pnpm build` passes.