### PR TITLE
research(erdos-124-complete-sequences-oq-02-oq-01): critical case of Brown's criterion = binary sequence 2^n with unique representation [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1290,6 +1290,7 @@ import Proofs.Erdos121Problem
 import Proofs.Erdos122Problem
 import Proofs.Erdos123Problem
 import Proofs.Erdos124CompleteSequences
+import Proofs.Erdos124CompleteSequencesOQ02OQ01
 import Proofs.Erdos124Problem
 import Proofs.Erdos125PositiveLowerDensity
 import Proofs.Erdos125PositiveLowerDensityAristotle

--- a/proofs/Proofs/Erdos124CompleteSequencesOQ02OQ01.lean
+++ b/proofs/Proofs/Erdos124CompleteSequencesOQ02OQ01.lean
@@ -1,0 +1,151 @@
+/-
+# Erdős Problem #124 — the critical case of Brown's criterion
+
+Brown's criterion (formalized in the parent entry `erdos-124-complete-sequences`)
+states that a sequence `f : ℕ → ℕ` with `f 0 = 1` and the *small-gap* property
+
+  `f (n+1) ≤ 1 + ∑_{i < n+1} f i`
+
+is *complete*: every natural number is a subset sum `∑_{i ∈ s} f i`.
+
+The follow-up open question for #124 asks what happens *at the boundary* of the
+reciprocal-sum condition `∑ 1/(dᵢ - 1) ≥ 1`, i.e. when the sum is exactly `1`.
+This file studies the abstract sharp boundary of Brown's criterion itself: the
+**critical (tight-gap) case**, where the gap inequality holds with equality.
+
+The results below show the critical case is completely rigid:
+
+* `brown_le_pow2`     — `2^n` is the pointwise upper envelope of *every* Brown
+                        sequence with `f 0 = 1`;
+* `critical_eq_pow2`  — a sequence with the *tight* gap `f (n+1) = 1 + ∑_{i<n+1} f i`
+                        is forced to be exactly `f n = 2^n`;
+* `sum_two_pow_injective` / `exists_sum_two_pow` / `unique_representation`
+                      — on the critical sequence `2^n` every natural number has a
+                        *unique* binary subset-sum representation, so completeness
+                        holds with no redundancy at all.
+
+Thus the boundary case of Brown's criterion is exactly binary representation:
+maximally efficient (it attains the bound) and rigid (representations are unique),
+whereas strictly above the threshold representations become redundant.  The single
+base `d = 2` has reciprocal sum `1/(2-1) = 1` and realises this extremal sequence.
+
+This is a self-contained companion to the parent proof: nothing here is imported
+from the parent file.  The binary-uniqueness backbone is built on Mathlib's
+`Nat.bitIndices` API.
+-/
+
+import Mathlib
+
+open Finset
+
+namespace Erdos124OQ02OQ01
+
+/-! ## Geometric sum of powers of two -/
+
+/-- The partial sums of the binary sequence: `∑_{i < n} 2^i = 2^n - 1`. -/
+lemma sum_range_two_pow (n : ℕ) : ∑ i ∈ Finset.range n, 2 ^ i = 2 ^ n - 1 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ih, pow_succ]
+    have : 1 ≤ 2 ^ n := Nat.one_le_two_pow
+    omega
+
+/-! ## The Brown bound and its critical (tight) case -/
+
+/-- `2^n` is the pointwise upper envelope of every Brown sequence with `f 0 = 1`:
+any sequence satisfying the small-gap inequality lies below the binary sequence. -/
+theorem brown_le_pow2 {f : ℕ → ℕ} (h0 : f 0 = 1)
+    (hgap : ∀ n, f (n + 1) ≤ 1 + ∑ i ∈ Finset.range (n + 1), f i) :
+    ∀ n, f n ≤ 2 ^ n := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases n with _ | m
+    · simp [h0]
+    · refine (hgap m).trans ?_
+      have hsum : ∑ i ∈ Finset.range (m + 1), f i ≤ ∑ i ∈ Finset.range (m + 1), 2 ^ i :=
+        Finset.sum_le_sum (fun i hi => ih i (Finset.mem_range.mp hi))
+      rw [sum_range_two_pow] at hsum
+      have : 1 ≤ 2 ^ (m + 1) := Nat.one_le_two_pow
+      omega
+
+/-- **Rigidity of the critical case.** A sequence with `f 0 = 1` saturating the
+Brown gap, `f (n+1) = 1 + ∑_{i < n+1} f i`, is forced to be the binary sequence
+`f n = 2^n`.  This is the unique sequence attaining the Brown bound with equality. -/
+theorem critical_eq_pow2 {f : ℕ → ℕ} (h0 : f 0 = 1)
+    (hgap : ∀ n, f (n + 1) = 1 + ∑ i ∈ Finset.range (n + 1), f i) :
+    ∀ n, f n = 2 ^ n := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases n with _ | m
+    · simpa using h0
+    · rw [hgap m]
+      have hsum : ∑ i ∈ Finset.range (m + 1), f i = ∑ i ∈ Finset.range (m + 1), 2 ^ i :=
+        Finset.sum_congr rfl (fun i hi => ih i (Finset.mem_range.mp hi))
+      rw [hsum, sum_range_two_pow]
+      have : 1 ≤ 2 ^ (m + 1) := Nat.one_le_two_pow
+      omega
+
+/-! ## Uniqueness of binary subset-sum representations
+
+On the critical sequence `2^n`, completeness holds with **no redundancy**: every
+natural number is a subset sum in exactly one way (binary representation).  The
+backbone is the `Nat.bitIndices` API: `bitIndices` of a binary subset sum recovers
+the (sorted) index set, giving injectivity directly. -/
+
+/-- Bridge: a `Finset` sum equals the sum over its sorted list. -/
+lemma sum_eq_sortMap (s : Finset ℕ) (f : ℕ → ℕ) :
+    ∑ i ∈ s, f i = ((s.sort (· ≤ ·)).map f).sum := by
+  rw [← Multiset.sum_coe, ← Multiset.map_coe, Finset.sort_eq]
+  rfl
+
+/-- The bit-indices of a binary subset sum recover the sorted index set. -/
+lemma bitIndices_sum_two_pow (s : Finset ℕ) :
+    (∑ i ∈ s, 2 ^ i).bitIndices = s.sort (· ≤ ·) := by
+  rw [sum_eq_sortMap s (fun i => 2 ^ i)]
+  exact Nat.bitIndices_twoPowsum (Finset.sortedLT_sort s)
+
+/-- **Injectivity.** Distinct index sets give distinct binary subset sums. -/
+theorem sum_two_pow_injective :
+    Function.Injective (fun s : Finset ℕ => ∑ i ∈ s, 2 ^ i) := by
+  intro s t h
+  have hsort : s.sort (· ≤ ·) = t.sort (· ≤ ·) := by
+    rw [← bitIndices_sum_two_pow s, ← bitIndices_sum_two_pow t]
+    exact congrArg Nat.bitIndices h
+  have := congrArg List.toFinset hsort
+  simpa [Finset.sort_toFinset] using this
+
+/-- **Existence.** Every natural number is a binary subset sum (binary expansion). -/
+theorem exists_sum_two_pow (m : ℕ) : ∃ s : Finset ℕ, m = ∑ i ∈ s, 2 ^ i := by
+  refine ⟨m.bitIndices.toFinset, ?_⟩
+  rw [List.sum_toFinset _ Nat.bitIndices_sorted.nodup]
+  exact (Nat.twoPowSum_bitIndices m).symm
+
+/-- **Unique representation in the critical case.** Every natural number has
+exactly one binary subset-sum representation: completeness with zero redundancy. -/
+theorem unique_representation (m : ℕ) :
+    ∃! s : Finset ℕ, m = ∑ i ∈ s, 2 ^ i := by
+  obtain ⟨s, hs⟩ := exists_sum_two_pow m
+  refine ⟨s, hs, fun t ht => ?_⟩
+  exact sum_two_pow_injective (ht.symm.trans hs)
+
+/-! ## The critical sequence, characterised -/
+
+/-- **Sharp boundary of Brown's criterion.** A sequence attaining the Brown gap
+with equality (`f 0 = 1`, `f (n+1) = 1 + ∑_{i<n+1} f i`) is exactly `n ↦ 2^n`,
+and on it every natural number has a *unique* subset-sum representation. -/
+theorem critical_sequence_characterization {f : ℕ → ℕ} (h0 : f 0 = 1)
+    (hgap : ∀ n, f (n + 1) = 1 + ∑ i ∈ Finset.range (n + 1), f i) :
+    (∀ n, f n = 2 ^ n) ∧ (∀ m, ∃! s : Finset ℕ, m = ∑ i ∈ s, f i) := by
+  have hpow := critical_eq_pow2 h0 hgap
+  refine ⟨hpow, fun m => ?_⟩
+  simp only [hpow]
+  exact unique_representation m
+
+/-- The single base `d = 2` has reciprocal sum `1/(2-1) = 1` (the boundary value),
+and its greedy power sequence is the critical sequence `n ↦ 2^n`. -/
+example : (1 : ℚ) / (2 - 1) = 1 := by norm_num
+
+end Erdos124OQ02OQ01

--- a/src/data/proofs/erdos-124-complete-sequences-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02-oq-01/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "erdos-124-complete-sequences-oq-02-oq-01",
+  "slug": "erdos-124-complete-sequences-oq-02-oq-01",
+  "title": "Erdős #124: the critical (tight-gap) case of Brown's criterion is the binary sequence, with unique representation",
+  "description": "Studies the sharp boundary of Brown's criterion behind Erdős #124. Brown's criterion (parent entry) shows a sequence with f 0 = 1 and the small-gap property f(n+1) ≤ 1 + ∑_{i<n+1} f i is complete (every n is a subset sum). This entry pins down the boundary case where the gap is tight. Three results: (1) 2^n is the pointwise upper envelope of every Brown sequence; (2) the tight gap f(n+1) = 1 + ∑_{i<n+1} f i forces f n = 2^n exactly; (3) on the critical sequence 2^n every natural number has a UNIQUE binary subset-sum representation — completeness with zero redundancy. The single base d = 2 has reciprocal sum 1/(2-1) = 1 (the boundary value of ∑ 1/(dᵢ-1) ≥ 1) and realises this extremal sequence.",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos124OQ02OQ01",
+    "lineCount": 151,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "path": "Proofs/Erdos124CompleteSequencesOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos124CompleteSequencesOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "complete-sequences",
+      "browns-criterion",
+      "binary-representation",
+      "subset-sums",
+      "erdos-problems"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with Lean v4.26.0 against the pinned Mathlib oleans (the Docker daemon was unresponsive this session, so verification was run by direct `lean` elaboration of the single file against the prebuilt Mathlib build artifacts; exit code 0, no errors, no warnings). 0 sorries, 0 axiom declarations, no native_decide. `#print axioms` on critical_eq_pow2, unique_representation, brown_le_pow2 and critical_sequence_characterization lists only the standard foundational axioms [propext, Classical.choice, Quot.sound] — no sorryAx, no Lean.ofReduceBool. Self-contained: Brown's gap hypotheses, the partial-sum geometric identity and the binary subset-sum machinery are re-declared, so nothing is imported from the parent Erdos124CompleteSequences.lean. The binary-uniqueness backbone is built on Mathlib's Nat.bitIndices API (bitIndices_twoPowsum, twoPowSum_bitIndices). Honest scope: this characterises the abstract critical case of Brown's criterion (tight gap ⟹ binary sequence ⟹ unique representation); it does NOT claim that every reciprocal-sum-exactly-1 multiset of bases (e.g. d = (3,3)) yields the tight gap — only that the single base d = 2 realises the extremal sequence. The strong version of #124 (gcd condition, P(d,1)) is untouched.",
+    "lineCount": 151,
+    "theoremCount": 9,
+    "definitionCount": 0,
+    "originalContributions": [
+      "critical_eq_pow2: RIGIDITY — a sequence with f 0 = 1 saturating Brown's gap, f(n+1) = 1 + ∑_{i<n+1} f i, is forced to be exactly f n = 2^n. The unique sequence attaining the Brown bound with equality.",
+      "brown_le_pow2: 2^n is the pointwise upper envelope of EVERY Brown sequence with f 0 = 1 (strong-induction over the gap inequality and the geometric partial-sum bound). Together with critical_eq_pow2 this exhibits 2^n as the extremal complete sequence.",
+      "unique_representation: on the critical sequence every natural number has EXACTLY ONE binary subset-sum representation — completeness with zero redundancy, the hallmark of the boundary case.",
+      "sum_two_pow_injective: injectivity of s ↦ ∑_{i∈s} 2^i on Finset ℕ, proved by recovering the sorted index set as the bit-indices of the sum (bitIndices_sum_two_pow + Nat.bitIndices_twoPowsum).",
+      "exists_sum_two_pow: existence half of binary representation via Nat.twoPowSum_bitIndices and List.sum_toFinset over the (nodup) bit-index list.",
+      "critical_sequence_characterization: packaged statement — tight Brown gap ⟹ (f = 2^n) ∧ (unique subset-sum representation for every m).",
+      "sum_range_two_pow: the geometric partial sum ∑_{i<n} 2^i = 2^n − 1, the quantitative engine of both the envelope bound and the rigidity step."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #124 (the weak version) asks whether, given bases dᵢ ≥ 2 with ∑ 1/(dᵢ−1) ≥ 1, every natural number can be written as ∑ aᵢ with each aᵢ having only 0/1 digits in base dᵢ. It was the first open conjecture solved autonomously by an AI system (Harmonic's Aristotle, November 2025) using Brown's criterion: a greedy power sequence with the small-gap property f(n+1) ≤ 1 + ∑_{i<n+1} f i is complete. A natural follow-up records what happens at the boundary of the reciprocal-sum condition, where ∑ 1/(dᵢ−1) is exactly 1.",
+    "problemStatement": "Brown's criterion only gives a sufficient inequality. This entry asks: what is the extremal/critical case — when the gap is tight — and how rigid is it? The answer: the tight case is uniquely the binary sequence 2^n, and on it representations are unique.",
+    "proofStrategy": "First, the geometric identity ∑_{i<n} 2^i = 2^n − 1 (induction). brown_le_pow2 runs strong induction over the gap inequality: assuming f i ≤ 2^i for i ≤ n, the gap gives f(n+1) ≤ 1 + (2^{n+1}−1) = 2^{n+1}. critical_eq_pow2 replaces the inequality by equality and the same induction gives f n = 2^n exactly. For uniqueness, the map s ↦ ∑_{i∈s} 2^i is shown injective by computing its bit-indices: sum_eq_sortMap bridges the Finset sum to the sum over its sorted list, and Nat.bitIndices_twoPowsum recovers the sorted index set, so the sum determines the set. Existence is binary expansion via Nat.twoPowSum_bitIndices. Combining gives unique_representation, and critical_sequence_characterization packages rigidity with uniqueness.",
+    "keyInsights": [
+      "Brown's gap inequality has 2^n as its pointwise ceiling: no sequence starting at 1 with the small-gap property ever exceeds the binary sequence. The tight case is the unique one that attains the ceiling everywhere.",
+      "Tightness forces binary: equality in the gap recursion is exactly the recursion f(n+1) = 1 + (2^{n+1}−1) defining 2^{n+1}, so the critical sequence is rigidly determined with no freedom.",
+      "Completeness and uniqueness are complementary: strictly above the reciprocal-sum threshold a number can be a subset sum in many ways, but at the critical sequence representations are unique — the boundary is precisely where redundancy vanishes.",
+      "Mathlib's Nat.bitIndices API turns subset-sum injectivity into a one-line fact: the bit-indices of ∑_{i∈s} 2^i are exactly the sorted elements of s.",
+      "Honesty: not every reciprocal-sum-exactly-1 base multiset gives a tight gap (d = (3,3) gives a strict gap at the first step); the clean rigidity statement is about the abstract critical gap, realised concretely by the single base d = 2."
+    ]
+  },
+  "conclusion": {
+    "summary": "Nine machine-checked results (0 axioms, 0 sorries, no native_decide) characterising the sharp boundary of Brown's criterion behind Erdős #124. 2^n is the pointwise upper envelope of every Brown sequence (brown_le_pow2); the tight gap forces f n = 2^n exactly (critical_eq_pow2); and on this critical sequence every natural number has a unique binary subset-sum representation (unique_representation), so completeness holds with zero redundancy.",
+    "implications": "The boundary case of Brown's criterion is identified as binary representation: maximally efficient (it attains the gap bound) and rigid (representations are unique). This isolates the elementary, fully settled extremal structure underlying #124's completeness phenomenon, separating it from the open strong version (gcd condition, P(d,1)).",
+    "openQuestions": [
+      "Which base multisets with ∑ 1/(dᵢ−1) = 1 produce sequences with bounded redundancy (number of representations) for large n?",
+      "Can the strong version of #124 (excluding d^0 = 1, with the gcd condition) be settled?",
+      "Is there a clean characterisation of the greedy sequences that attain Brown's bound infinitely often versus only finitely often?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-124-complete-sequences-oq-02",
+      "relationship": "parent",
+      "description": "The sibling Erdős #124 boundary entry, which characterises the reciprocal-sum boundary ∑ 1/(dᵢ−1) = 1 as exactly an Egyptian-fraction decomposition of 1 (which BASE multisets sit on the boundary). This entry is complementary: it characterises the SEQUENCE-level critical case of Browns criterion — the tight gap forces the binary sequence 2^n with unique subset-sum representation. The single base d = 2 (the siblings base-2 singleton) realises this extremal sequence."
+    },
+    {
+      "targetId": "erdos-124-complete-sequences",
+      "relationship": "ancestor",
+      "description": "The main AI-solved Erdős #124 entry proving Brown's criterion (a sequence with f 0 = 1 and small-gap f(n+1) ≤ 1 + ∑_{i<n+1} f i is complete). This entry characterises the boundary/critical case of that gap inequality."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A follow-up to the Erdős #124 boundary question (OQ-02), **complementary** to the recently merged sibling [`erdos-124-complete-sequences-oq-02`](https://github.com/rjwalters/lean-genius/commit/0af0c57) (#27790). That entry characterises *which base multisets* sit on the reciprocal-sum boundary `∑ 1/(dᵢ−1) = 1` (exactly the Egyptian-fraction decompositions of 1). **This entry characterises the SEQUENCE-level critical case of Brown's criterion** — what the *sequence* and its representations look like when the gap inequality is tight.

Brown's criterion (parent entry): a sequence with `f 0 = 1` and the small-gap property `f(n+1) ≤ 1 + ∑_{i<n+1} f i` is *complete* (every `n` is a subset sum). Here the boundary/critical case is pinned down:

- **`brown_le_pow2`** — `2^n` is the pointwise upper envelope of *every* Brown sequence with `f 0 = 1`.
- **`critical_eq_pow2`** — the *tight* gap `f(n+1) = 1 + ∑_{i<n+1} f i` forces `f n = 2^n` exactly (rigidity).
- **`unique_representation`** — on the critical sequence `2^n` every natural number has a **unique** binary subset-sum representation: completeness with **zero redundancy**.
- **`sum_two_pow_injective` / `exists_sum_two_pow`** — injectivity (via `Nat.bitIndices_twoPowsum`) and existence (via `Nat.twoPowSum_bitIndices`) of binary representation.
- **`critical_sequence_characterization`** — packaged: tight gap ⟹ `(f = 2^n) ∧ unique representation`.

Interpretation: the boundary of Brown's criterion is exactly binary representation — maximally efficient (attains the gap bound) and rigid (unique representations). Above the threshold representations become redundant; at the critical sequence redundancy vanishes. The single base `d = 2` (the sibling's base-2 singleton) realises this extremal sequence.

## Verification

- **9 results, 151 lines, 0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms` on `critical_eq_pow2`, `unique_representation`, `brown_le_pow2`, `critical_sequence_characterization` lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- Machine-checked with Lean v4.26.0 against the pinned Mathlib oleans (Docker daemon unresponsive this session; verified by direct `lean` elaboration of the single file against the prebuilt Mathlib build artifacts; exit 0, no errors/warnings).
- Self-contained: nothing imported from the parent/sibling files. Binary-uniqueness backbone built on Mathlib's `Nat.bitIndices` API.

## Honest scope

Characterises the *abstract* critical case of Brown's criterion (tight gap ⟹ binary sequence ⟹ unique representation). It does **not** claim every reciprocal-sum-exactly-1 base multiset yields the tight gap (e.g. `d = (3,3)` gives a strict gap at the first step) — only that the single base `d = 2` realises the extremal sequence. The strong version of #124 (gcd condition, P(d,1)) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)