### PR TITLE
research(erdos-286-oq-02): discharge representation_monotone axiom + axiom-free existence

### DIFF
--- a/proofs/Proofs/Erdos286MonotoneOQ02.lean
+++ b/proofs/Proofs/Erdos286MonotoneOQ02.lean
@@ -1,0 +1,233 @@
+/-
+  Erdős Problem #286 — Open Question oq-02:
+  Discharging the `representation_monotone` axiom (and, with it, the whole
+  existence theorem) *without* any axioms.
+
+  Source: https://erdosproblems.com/286
+  Parent gallery entry: `Proofs/Erdos286Problem.lean` (Erdos286)
+
+  ## Context
+
+  Erdős #286 asks, for k ≥ 2, whether `1` can be written as a sum of k distinct
+  unit fractions whose denominators all lie in a *short* interval of width
+  ≈ (e-1)k. Croot (2001) proved this with the sharp constant; the parent gallery
+  file encodes the sharp statement as `croot_theorem` (an axiom) and the
+  step k → k+1 as a second axiom `representation_monotone`, then combines them to
+  prove the *bounded-interval existence* statement
+
+      erdos_286 : ∀ k ≥ 3, ∃ width, HasShortIntervalRepresentation k width.
+
+  The parent's `conclusion.openQuestions` lists, as oq-02:
+
+      "Prove `representation_monotone` from the unit fraction splitting identity
+       1/n = 1/(n+1) + 1/(n(n+1)), tracking interval widths."
+
+  ## What this file contributes
+
+  1. `representation_monotone_ge2` — the splitting step is proved as a genuine
+     theorem (0 axioms) for every k ≥ 2.  The largest denominator m of an
+     existing representation is split via 1/m = 1/(m+1) + 1/(m(m+1)); because m
+     is the maximum, the two new denominators are fresh and distinct, so the
+     cardinality grows by exactly one and the reciprocal sum is preserved.
+
+  2. `erdos_286_exists` — the *identical* statement to the parent's `erdos_286`,
+     but proved with **zero axioms**: induction from the explicit base case k = 3
+     using `representation_monotone_ge2`.  (Mere bounded-interval existence never
+     needed Croot's deep result — only the splitting step.  Croot is required
+     solely for the *sharp* width ⌈(e-1+ε)k⌉, which we do NOT claim here.)
+
+  3. `unrestricted_monotone_false` — a soundness observation: the parent's
+     `representation_monotone` is stated for *all* k, but at k = 1 it is FALSE.
+     A representation with k = 1 exists (`{1}`), and it would force a k = 2
+     representation, which is impossible (`no_k2_representation`).  Hence the
+     hypothesis k ≥ 2 in `representation_monotone_ge2` is not cosmetic: the
+     unrestricted axiom is unsound, and the `ge2` form is the correct theorem.
+
+  All denominator definitions are re-declared here so the file is self-contained.
+-/
+
+import Mathlib
+
+namespace Erdos286OQ02
+
+open Finset BigOperators
+
+/- ## Definitions (mirroring the parent entry) -/
+
+/-- A unit-fraction representation of a rational `q` using denominators from `S`. -/
+def IsUnitFractionSum (S : Finset ℕ) (q : ℚ) : Prop :=
+  (∀ n ∈ S, n > 0) ∧ ∑ n ∈ S, (1 : ℚ) / n = q
+
+/-- `S` gives a unit-fraction representation of `1`. -/
+def SumsToOne (S : Finset ℕ) : Prop := IsUnitFractionSum S 1
+
+/-- There are `k` distinct positive integers in an interval of the given `width`
+whose reciprocals sum to `1`. -/
+def HasShortIntervalRepresentation (k : ℕ) (width : ℕ) : Prop :=
+  ∃ a : ℕ, ∃ S : Finset ℕ,
+    S.card = k ∧
+    (∀ n ∈ S, a ≤ n ∧ n ≤ a + width) ∧
+    SumsToOne S
+
+/- ## The base case k = 3 (axiom-free; no `native_decide`) -/
+
+/-- `1 = 1/2 + 1/3 + 1/6`, with denominators in `[2,6]` (width 4). -/
+theorem base_k3 : HasShortIntervalRepresentation 3 4 := by
+  refine ⟨2, {2, 3, 6}, ?_, ?_, ?_, ?_⟩
+  · decide
+  · decide
+  · decide
+  · show ∑ n ∈ ({2, 3, 6} : Finset ℕ), (1 : ℚ) / n = 1
+    have h26 : (3 : ℕ) ∉ ({6} : Finset ℕ) := by decide
+    have h236 : (2 : ℕ) ∉ ({3, 6} : Finset ℕ) := by decide
+    rw [Finset.sum_insert h236, Finset.sum_insert h26, Finset.sum_singleton]
+    norm_num
+
+/- ## The splitting step, proved as a theorem -/
+
+/-- **Monotonicity (oq-02).** For every `k ≥ 2`, a representation with `k`
+denominators yields one with `k + 1` denominators (in some, possibly much
+larger, interval).  Proof: split the *largest* denominator `m` via the partial
+fraction identity `1/m = 1/(m+1) + 1/(m(m+1))`.  Maximality of `m` guarantees
+`m+1` and `m(m+1)` are new and mutually distinct, so the cardinality increases
+by exactly one and the reciprocal sum is unchanged.
+
+The hypothesis `2 ≤ k` is essential — see `unrestricted_monotone_false`. -/
+theorem representation_monotone_ge2 (k width : ℕ) (hk : 2 ≤ k)
+    (h : HasShortIntervalRepresentation k width) :
+    ∃ width', HasShortIntervalRepresentation (k + 1) width' := by
+  simp only [HasShortIntervalRepresentation, SumsToOne, IsUnitFractionSum] at h
+  obtain ⟨a, S, hcard, hint, hpos, hsum⟩ := h
+  have hne : S.Nonempty := by rw [← Finset.card_pos, hcard]; omega
+  -- the maximum element, with its defining properties
+  obtain ⟨m, hm_mem, hm_max⟩ : ∃ m, m ∈ S ∧ ∀ n ∈ S, n ≤ m :=
+    ⟨S.max' hne, S.max'_mem hne, fun n hn => Finset.le_max' S n hn⟩
+  have hm_pos : 0 < m := hpos m hm_mem
+  -- with at least two denominators, `1 ∉ S`, hence the maximum is ≥ 2
+  have hm2 : 2 ≤ m := by
+    rcases Nat.lt_or_ge m 2 with h' | h'
+    · exfalso
+      have hsub : S ⊆ {1} := by
+        intro x hx
+        have hx1 := hm_max x hx
+        have hx2 := hpos x hx
+        simp only [Finset.mem_singleton]
+        omega
+      have hcle := Finset.card_le_card hsub
+      simp only [Finset.card_singleton] at hcle
+      omega
+    · exact h'
+  -- the new denominators are fresh and distinct
+  have hmm_gt : m < m * (m + 1) := by nlinarith
+  have hm1_notS : m + 1 ∉ S := fun hmem => by have := hm_max _ hmem; omega
+  have hmm_notS : m * (m + 1) ∉ S := fun hmem => by have := hm_max _ hmem; omega
+  have hne_new : m + 1 ≠ m * (m + 1) := by
+    have : m + 1 < m * (m + 1) := by nlinarith
+    omega
+  have hm1_nE : m + 1 ∉ S.erase m := fun hh => hm1_notS (Finset.mem_of_mem_erase hh)
+  have hmm_nE : m * (m + 1) ∉ S.erase m := fun hh => hmm_notS (Finset.mem_of_mem_erase hh)
+  have hA : m + 1 ∉ insert (m * (m + 1)) (S.erase m) := by
+    simp only [Finset.mem_insert]; push_neg; exact ⟨hne_new, hm1_nE⟩
+  -- the reciprocal sum over the remaining denominators
+  have hsumT : ∑ n ∈ S.erase m, (1 : ℚ) / n = 1 - 1 / (m : ℚ) := by
+    have key : (1 : ℚ) / m + ∑ n ∈ S.erase m, (1 : ℚ) / n = 1 := by
+      rw [Finset.add_sum_erase S (fun n => (1 : ℚ) / n) hm_mem]; exact hsum
+    linarith
+  -- assemble the new representation
+  refine ⟨m * (m + 1), ?_⟩
+  simp only [HasShortIntervalRepresentation, SumsToOne, IsUnitFractionSum]
+  refine ⟨1, insert (m + 1) (insert (m * (m + 1)) (S.erase m)), ?_, ?_, ?_, ?_⟩
+  · -- cardinality grows by one
+    rw [Finset.card_insert_of_notMem hA, Finset.card_insert_of_notMem hmm_nE,
+        Finset.card_erase_of_mem hm_mem, hcard]
+    omega
+  · -- every new denominator lies in [1, 1 + m(m+1)]
+    intro n hn
+    simp only [Finset.mem_insert] at hn
+    rcases hn with rfl | rfl | hnE
+    · exact ⟨by omega, by omega⟩
+    · exact ⟨by omega, by omega⟩
+    · have hnS := Finset.mem_of_mem_erase hnE
+      have h1 := hpos n hnS
+      have h2 := hm_max n hnS
+      exact ⟨by omega, by omega⟩
+  · -- positivity
+    intro n hn
+    simp only [Finset.mem_insert] at hn
+    rcases hn with rfl | rfl | hnE
+    · omega
+    · omega
+    · exact hpos n (Finset.mem_of_mem_erase hnE)
+  · -- the reciprocals still sum to 1
+    rw [Finset.sum_insert hA, Finset.sum_insert hmm_nE, hsumT]
+    have hM : (m : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    have hM1 : (m : ℚ) + 1 ≠ 0 := by positivity
+    push_cast
+    field_simp
+    ring
+
+/- ## Bounded-interval existence with NO axioms -/
+
+/-- **Erdős #286, bounded-interval existence (axiom-free).** For every `k ≥ 3`
+there is a representation of `1` by `k` distinct unit fractions with denominators
+in a bounded interval.  This is the parent's `erdos_286`, here proved with zero
+axioms: induction from `base_k3` using `representation_monotone_ge2`.  (The sharp
+width ≈ (e-1)k still requires Croot's theorem and is not claimed.) -/
+theorem erdos_286_exists :
+    ∀ k, 3 ≤ k → ∃ width, HasShortIntervalRepresentation k width := by
+  intro k hk
+  induction k, hk using Nat.le_induction with
+  | base => exact ⟨4, base_k3⟩
+  | succ n hn ih =>
+    obtain ⟨w, hw⟩ := ih
+    exact representation_monotone_ge2 n w (by omega) hw
+
+/- ## Soundness: the unrestricted axiom is false -/
+
+/-- **k = 2 is impossible.** `1 = 1/x + 1/y` with distinct positive integers has
+no solution: it forces `(x-1)(y-1) = 1`, hence `x = y = 2`. -/
+theorem no_k2_representation (width : ℕ) :
+    ¬ HasShortIntervalRepresentation 2 width := by
+  intro h
+  simp only [HasShortIntervalRepresentation, SumsToOne, IsUnitFractionSum] at h
+  obtain ⟨_a, S, hcard, _hint, hpos, hsumeq⟩ := h
+  obtain ⟨x, y, hxy, rfl⟩ := Finset.card_eq_two.mp hcard
+  have hx : 0 < x := hpos x (by simp)
+  have hy : 0 < y := hpos y (by simp)
+  rw [Finset.sum_pair hxy] at hsumeq
+  have hx0 : (x : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  have hy0 : (y : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  rw [div_add_div _ _ hx0 hy0, div_eq_one_iff_eq (mul_ne_zero hx0 hy0)] at hsumeq
+  have key : (x : ℚ) + y = x * y := by linarith [hsumeq]
+  have hnat : x + y = x * y := by exact_mod_cast key
+  obtain ⟨x', rfl⟩ : ∃ x', x = x' + 1 := ⟨x - 1, by omega⟩
+  obtain ⟨y', rfl⟩ : ∃ y', y = y' + 1 := ⟨y - 1, by omega⟩
+  have e : (x' + 1) * (y' + 1) = x' * y' + x' + y' + 1 := by ring
+  rw [e] at hnat
+  have hprod : x' * y' = 1 := by linarith [hnat]
+  have hx'1 : x' = 1 := Nat.dvd_one.mp ⟨y', hprod.symm⟩
+  have hy'1 : y' = 1 := Nat.dvd_one.mp ⟨x', by rw [mul_comm] at hprod; exact hprod.symm⟩
+  exact hxy (by omega)
+
+/-- `1 = 1/1` is a (degenerate) representation with a single denominator. -/
+theorem has_rep_one : HasShortIntervalRepresentation 1 0 := by
+  refine ⟨1, {1}, ?_, ?_, ?_, ?_⟩
+  · decide
+  · decide
+  · decide
+  · show ∑ n ∈ ({1} : Finset ℕ), (1 : ℚ) / n = 1
+    rw [Finset.sum_singleton]; norm_num
+
+/-- **The unrestricted monotonicity statement is FALSE.** The parent gallery
+file declares `representation_monotone` for *all* `k`, but at `k = 1` it fails:
+`{1}` is a valid k=1 representation, yet no k=2 representation exists.  Thus the
+`2 ≤ k` hypothesis of `representation_monotone_ge2` is necessary, and the
+unrestricted axiom is unsound. -/
+theorem unrestricted_monotone_false :
+    ¬ (∀ k width : ℕ, HasShortIntervalRepresentation k width →
+        ∃ width', HasShortIntervalRepresentation (k + 1) width') := by
+  intro H
+  obtain ⟨w', hw'⟩ := H 1 0 has_rep_one
+  exact no_k2_representation w' hw'
+
+end Erdos286OQ02

--- a/src/data/proofs/erdos-286-oq-02/meta.json
+++ b/src/data/proofs/erdos-286-oq-02/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "erdos-286-oq-02",
+  "slug": "erdos-286-oq-02",
+  "title": "Erdős #286: Discharging the Monotonicity Axiom — Unit-Fraction Existence Without Croot",
+  "description": "Open question oq-02 of Erdős #286 asks to prove the parent's representation_monotone step from the splitting identity 1/m = 1/(m+1) + 1/(m(m+1)). We prove it (0 axioms) for k ≥ 2 by splitting the largest denominator, then use it to re-derive the bounded-interval existence theorem with zero axioms — and observe that the unrestricted axiom is actually false at k = 1.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "namespace": "Erdos286OQ02",
+    "lineCount": 233,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos286MonotoneOQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Erdős Problem #286 (Erdős–Graham, 1980, p. 33) asks whether 1 can be written as a sum of k distinct unit fractions whose denominators lie in a short interval of width ≈ (e-1)k. Croot (2001) proved this affirmatively with the sharp constant (e-1) ≈ 1.718, optimal. The parent gallery entry (Erdos286Problem.lean) encodes Croot's sharp result as an axiom (croot_theorem) and the inductive step k → k+1 as a second axiom (representation_monotone), combining them to prove the bounded-interval existence statement erdos_286 for all k ≥ 3. Its conclusion lists, as open question oq-02, the task of replacing the monotonicity axiom by a genuine proof from the unit-fraction splitting identity 1/n = 1/(n+1) + 1/(n(n+1)).",
+    "problemStatement": "Prove representation_monotone — that a k-denominator representation of 1 yields a (k+1)-denominator one — as a theorem from the splitting identity, rather than as an axiom. More ambitiously: how much of the parent's axiomatic scaffolding does the bounded-interval existence result actually require?",
+    "proofStrategy": "Given a representation S of 1 with k ≥ 2 positive denominators, let m = max S. Because at least two denominators sum their reciprocals to 1, the value 1 cannot be a denominator, so m ≥ 2. Split the largest term: replace m by the two denominators m+1 and m(m+1). Maximality of m forces m+1 > m and m(m+1) > m, so both new denominators are absent from S and (since m ≥ 2) distinct from each other; hence the cardinality increases by exactly one. The reciprocal sum is preserved because 1/(m+1) + 1/(m(m+1)) = 1/m (partial fractions, closed by field_simp; ring). This is representation_monotone_ge2 — a 0-axiom theorem. Feeding it into a Nat.le_induction from the explicit base case 1 = 1/2 + 1/3 + 1/6 yields erdos_286_exists: the parent's exact existence statement for all k ≥ 3, with zero axioms. Finally, unrestricted_monotone_false shows the parent's unrestricted axiom is unsound: {1} is a valid k=1 representation, so the axiom would force a k=2 representation, which no_k2_representation rules out via (x-1)(y-1) = 1.",
+    "keyInsights": [
+      "Bounded-interval existence for all k ≥ 3 needs only the elementary splitting step, NOT Croot's deep theorem: pure induction from k = 3 suffices. Croot (2001) is required solely for the SHARP width ⌈(e-1+ε)k⌉, which this file deliberately does not claim. The result therefore discharges BOTH of the parent's axioms from the existence theorem.",
+      "Splitting the MAXIMUM denominator is what makes the step clean: maximality is exactly the condition that guarantees the two replacements m+1 and m(m+1) are fresh, so cardinality grows by precisely one with no case analysis on which denominators already occur.",
+      "The hypothesis k ≥ 2 is necessary, not cosmetic. The single subtle point is m ≥ 2: with two or more positive reciprocals summing to 1, the denominator 1 cannot appear, so the maximum is at least 2 and the two replacements never collide (they collide only when m = 1, giving m+1 = m(m+1) = 2).",
+      "Soundness finding: the parent's representation_monotone is stated for all k, but it is FALSE at k = 1. A k=1 representation exists ({1}), and monotonicity would manufacture a k=2 representation — impossible since 1/x + 1/y = 1 forces (x-1)(y-1) = 1, i.e. x = y = 2, violating distinctness. The correct theorem is the k ≥ 2 form proved here.",
+      "The interval width is not tracked sharply: splitting the maximum m blows the largest denominator up to m(m+1), so the width grows rapidly under iteration. This is exactly why Croot's probabilistic argument (Lovász Local Lemma) is needed for the sharp constant and why mere monotonicity cannot recover it."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Denominator definitions (self-contained)",
+      "startLine": 55,
+      "endLine": 70,
+      "summary": "Re-declares IsUnitFractionSum, SumsToOne, and HasShortIntervalRepresentation from the parent so the file stands alone: k distinct positive integers in an interval of given width whose reciprocals sum to 1."
+    },
+    {
+      "id": "base-case",
+      "title": "Axiom-free base case k = 3",
+      "startLine": 72,
+      "endLine": 84,
+      "summary": "Proves HasShortIntervalRepresentation 3 4 via the witness {2,3,6} using kernel decide for the cardinality/interval/positivity facts and an explicit Finset.sum_insert chain + norm_num for 1/2 + 1/3 + 1/6 = 1 — no native_decide, so the base case stays 0-axiom."
+    },
+    {
+      "id": "monotone",
+      "title": "The splitting step as a theorem (oq-02)",
+      "startLine": 86,
+      "endLine": 167,
+      "summary": "representation_monotone_ge2: for k ≥ 2, split the largest denominator m via 1/m = 1/(m+1) + 1/(m(m+1)). Establishes m ≥ 2, freshness/distinctness of the new denominators from maximality, cardinality +1, and sum preservation (field_simp; ring)."
+    },
+    {
+      "id": "existence",
+      "title": "Bounded-interval existence with zero axioms",
+      "startLine": 169,
+      "endLine": 183,
+      "summary": "erdos_286_exists: the parent's exact statement ∀ k ≥ 3, ∃ width, HasShortIntervalRepresentation k width, proved by Nat.le_induction from base_k3 using representation_monotone_ge2 — discharging both of the parent's axioms from the existence result."
+    },
+    {
+      "id": "soundness",
+      "title": "The unrestricted axiom is false",
+      "startLine": 185,
+      "endLine": 232,
+      "summary": "no_k2_representation ((x-1)(y-1)=1 ⇒ x=y=2), has_rep_one (the k=1 witness {1}), and unrestricted_monotone_false: the parent's all-k monotonicity axiom is unsound because at k=1 it would force the impossible k=2 case."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "erdos-286",
+      "relationship": "parent-problem",
+      "description": "The parent encodes the inductive step k → k+1 as the axiom representation_monotone and Croot's sharp result as croot_theorem, combining them to prove erdos_286 (existence for k ≥ 3). This child discharges the monotonicity axiom as a theorem (for k ≥ 2), re-derives the existence theorem with 0 axioms, and shows the unrestricted axiom is false at k = 1."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Erdős #286 monotonicity step is proved (0 axioms) for k ≥ 2 by splitting the largest denominator via 1/m = 1/(m+1) + 1/(m(m+1)); maximality keeps the two new denominators fresh and distinct, so cardinality grows by one and the reciprocal sum is preserved. This re-derives the parent's bounded-interval existence theorem (all k ≥ 3) with zero axioms — neither Croot's theorem nor an axiomatized induction step is needed for mere existence — and reveals that the parent's unrestricted monotonicity axiom is unsound at k = 1.",
+    "implications": "Separating bounded-interval EXISTENCE (elementary, axiom-free) from the SHARP-width statement (Croot's deep theorem, genuinely axiomatized) clarifies exactly where the difficulty of #286 lives: not in producing some representation, but in confining all denominators to an interval of width (e-1+o(1))k. The maximum-denominator splitting also gives an explicit, if width-inefficient, algorithm extending any representation by one term.",
+    "openQuestions": [
+      "Can the width growth under the splitting step be bounded well enough to give a self-contained (non-sharp) interval-width bound — e.g. polynomial in k — without Croot's probabilistic argument?",
+      "Croot's sharp width ⌈(e-1+ε)k⌉ remains axiomatized in the parent (croot_theorem): is any portion of the Lovász-Local-Lemma argument formalizable, or is it currently out of reach of Mathlib?",
+      "Does the maximum-splitting construction give a canonical normal form for short-interval representations that could be used to study their count or extremal structure?"
+    ]
+  },
+  "meta": {
+    "author": "Erdős–Graham (1980), Croot (2001); formalization: Lean Genius Researcher",
+    "sourceUrl": "https://erdosproblems.com/286",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos286MonotoneOQ02.lean",
+    "tags": [
+      "egyptian-fractions",
+      "unit-fractions",
+      "number-theory",
+      "induction",
+      "axiom-discharge",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 233,
+    "assumptions": "Fully machine-checked, 0 sorries, 0 axiom declarations; #print axioms reports every theorem (representation_monotone_ge2, erdos_286_exists, unrestricted_monotone_false, no_k2_representation, base_k3) depends only on the foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool — the base case uses kernel decide + norm_num, NOT native_decide). Honest scope: this file proves bounded-interval EXISTENCE for all k ≥ 3 and discharges the parent's representation_monotone axiom (in its actual regime of use, k ≥ 2). It does NOT prove the SHARP width ⌈(e-1+ε)k⌉ — Croot's 2001 theorem (croot_theorem in the parent) remains an axiom and is the genuinely deep content of #286. The interval width produced here grows rapidly under iteration and is not claimed to be near-optimal.",
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "representation_monotone_ge2: proves the parent's representation_monotone AXIOM as a 0-axiom theorem for k ≥ 2, via splitting the maximum denominator m using 1/m = 1/(m+1) + 1/(m(m+1))",
+      "erdos_286_exists: re-derives the parent's bounded-interval existence theorem (∀ k ≥ 3) with ZERO axioms, eliminating both croot_theorem and representation_monotone from the existence proof",
+      "Identifies that mere bounded-interval existence never required Croot's deep theorem — only the elementary splitting step plus the explicit base case 1 = 1/2 + 1/3 + 1/6",
+      "unrestricted_monotone_false: shows the parent's representation_monotone, as stated for all k, is unsound — at k = 1 it would force the impossible k = 2 representation, so the k ≥ 2 hypothesis is necessary",
+      "base_k3: a native_decide-free k = 3 base case (kernel decide + explicit sum), keeping the whole development 0-axiom"
+    ],
+    "theoremCount": 6,
+    "definitionCount": 3
+  }
+}


### PR DESCRIPTION
## Erdős #286 — Open Question oq-02

**Parent:** [Erdős #286](https://erdosproblems.com/286) (unit fractions in short intervals; `Proofs/Erdos286Problem.lean`).

The parent's `conclusion.openQuestions[1]` (oq-02) asks to *"prove `representation_monotone` from the unit fraction splitting identity 1/n = 1/(n+1) + 1/(n(n+1)), tracking interval widths."* The parent currently encodes that step — and Croot's sharp result — as **axioms**, then combines them to prove the bounded-interval existence theorem `erdos_286`.

### What this PR proves (0 axioms, `native_decide`-free)

| Theorem | Result |
|---|---|
| `representation_monotone_ge2` | The splitting step as a **genuine theorem** for every `k ≥ 2`: split the **maximum** denominator `m` via `1/m = 1/(m+1) + 1/(m(m+1))`. Maximality keeps `m+1`, `m(m+1)` fresh and (since `m ≥ 2`) distinct ⇒ card `+1`, reciprocal sum preserved. |
| `erdos_286_exists` | The parent's **exact** existence statement `∀ k ≥ 3, ∃ width, HasShortIntervalRepresentation k width`, re-derived with **zero axioms** by `Nat.le_induction` from `1 = 1/2 + 1/3 + 1/6`. |
| `unrestricted_monotone_false` | The parent's `representation_monotone`, stated for **all** `k`, is **unsound**: `{1}` is a valid `k=1` representation, so it would force the impossible `k=2` case (`no_k2_representation`). Hence `k ≥ 2` is necessary. |

### Why it matters

Mere bounded-interval **existence** never needed Croot's deep theorem — only the elementary splitting step. So this PR removes **both** of the parent's axioms from the existence proof, while honestly leaving the genuinely hard content (the **sharp** width `⌈(e-1+ε)k⌉`, Croot 2001, Lovász Local Lemma) out of scope and still axiomatized in the parent.

### Verification

- 233 lines, 6 theorems / 3 definitions, self-contained (defs mirrored from parent).
- `#print axioms` for every theorem: `propext, Classical.choice, Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`.
- Built with Lean `v4.26.0` against prebuilt Mathlib oleans (Docker daemon down this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)