### PR TITLE
research(sum-of-divisors-oq-04-oq-01): prime powers are deficient — almost-perfect powers of two + sharp abundancy bound (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3440,6 +3440,7 @@ import Proofs.SubsetCountOQ02OQ01
 import Proofs.SumOfDivisors
 import Proofs.SumOfDivisorsOQ02
 import Proofs.SumOfDivisorsOQ04
+import Proofs.SumOfDivisorsOQ04OQ01
 import Proofs.SumOfDivisorsOQ05
 import Proofs.SumOfDivisorsOQ06
 import Proofs.SumOfDivisorsOQ07

--- a/proofs/Proofs/Erdos1023OQ04.lean
+++ b/proofs/Proofs/Erdos1023OQ04.lean
@@ -1,0 +1,133 @@
+/-
+# Erdős Problem #1023 — Elementary growth brackets for the union-free maximum
+
+## Background
+
+Let `F(n)` be the maximum size of a family of subsets of `{1, …, n}` in which no set
+is the union of (two or more distinct) other members of the family ("union-free").
+Erdős asked whether `F(n) ~ c · 2ⁿ / √n`.  The answer is **yes**: the middle layer
+(all subsets of size `⌊n/2⌋`) is union-free and, by a theorem of Erdős–Kleitman, optimal,
+so
+                    F(n) = C(n, ⌊n/2⌋),
+the central binomial coefficient.  This identity is recorded in the parent gallery entry
+`erdos-1023` (`Erdos1023Problem.lean`).
+
+The parent entry establishes the asymptotic `F(n) ~ √(2/π) · 2ⁿ / √n` only through an
+**axiom** (`stirling_central` / `unionFreeMax_asymptotic`), because the precise constant
+requires Stirling's formula.  The qualitative growth, however, does **not** need Stirling.
+
+## What this file adds (0 axioms, fully verified)
+
+Taking the established value `F(n) = C(n, ⌊n/2⌋)` as the *definition* of `unionFreeMax`,
+we prove rigorous, completely elementary growth brackets:
+
+* `central_le_pow`            : `F(n) ≤ 2ⁿ`                       (trivial upper bound)
+* `pow_le_succ_mul_central`   : `2ⁿ ≤ (n+1) · F(n)`              ⟶  `F(n) ≥ 2ⁿ / (n+1)`
+* `unionFreeMax_bracket`      : both bounds together
+* `unionFreeMax_unbounded`    : `F(n) → ∞`  (∀ M, ∃ n, M ≤ F(n))
+
+The lower bound is the interesting direction: averaging the binomial identity
+`∑_{m≤n} C(n,m) = 2ⁿ` against the maximality of the central column
+(`Nat.choose_le_middle`) gives `2ⁿ ≤ (n+1)·C(n,⌊n/2⌋)` in one line.  Hence
+`2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ`, pinning down the growth of `F` up to a polynomial factor
+**without any appeal to Stirling's formula** — replacing the qualitative content of the
+parent's asymptotic axiom by a machine-checked elementary statement.
+
+The divergence `F(n) → ∞` is proved purely over `ℕ` using `choose_le_centralBinom`:
+`F(2n) = C(2n,n) = centralBinom n ≥ C(2n,1) = 2n`.
+
+We do **not** reprove the Erdős–Kleitman optimality (the hard, axiomatized direction in
+the parent); this file is solely about the elementary growth of the central column.
+-/
+import Mathlib.Data.Nat.Choose.Sum
+import Mathlib.Data.Nat.Choose.Bounds
+import Mathlib.Data.Nat.Choose.Central
+import Mathlib.Tactic
+
+namespace Erdos1023OQ04
+
+open Finset
+
+/-- The maximum size of a union-free family of subsets of `{1, …, n}`.
+By Erdős–Kleitman this equals the size of the middle layer, the central binomial
+coefficient `C(n, ⌊n/2⌋)` (see the parent entry `erdos-1023`). We take that value
+as the definition here and study its elementary growth. -/
+def unionFreeMax (n : ℕ) : ℕ := Nat.choose n (n / 2)
+
+@[simp] theorem unionFreeMax_def (n : ℕ) : unionFreeMax n = Nat.choose n (n / 2) := rfl
+
+/-- The union-free maximum is positive: the empty set is always available. -/
+theorem unionFreeMax_pos (n : ℕ) : 0 < unionFreeMax n :=
+  Nat.choose_pos (Nat.div_le_self n 2)
+
+/-- Trivial upper bound: a union-free family is a family of subsets, so its size is at
+most `2ⁿ`. Concretely, the central column is one term of the binomial sum. -/
+theorem central_le_pow (n : ℕ) : unionFreeMax n ≤ 2 ^ n :=
+  Nat.choose_le_two_pow n (n / 2)
+
+/-- **Key elementary lower bound.** Summing the binomial identity
+`∑_{m ≤ n} C(n,m) = 2ⁿ` and bounding every term by the maximal central column
+`C(n, ⌊n/2⌋)` gives `2ⁿ ≤ (n+1) · F(n)`. Equivalently `F(n) ≥ 2ⁿ / (n+1)`, an
+exponential lower bound that needs no Stirling estimate. -/
+theorem pow_le_succ_mul_central (n : ℕ) : 2 ^ n ≤ (n + 1) * unionFreeMax n := by
+  have h : (∑ m ∈ range (n + 1), n.choose m) ≤ ∑ _m ∈ range (n + 1), n.choose (n / 2) :=
+    Finset.sum_le_sum (fun m _ => Nat.choose_le_middle m n)
+  calc 2 ^ n = ∑ m ∈ range (n + 1), n.choose m := (Nat.sum_range_choose n).symm
+    _ ≤ ∑ _m ∈ range (n + 1), n.choose (n / 2) := h
+    _ = (n + 1) * unionFreeMax n := by
+        rw [Finset.sum_const, Finset.card_range, smul_eq_mul, unionFreeMax_def]
+
+/-- The two elementary brackets together:
+`2ⁿ ≤ (n+1)·F(n)` and `F(n) ≤ 2ⁿ`. These pin down the growth of `F` up to a
+polynomial factor, with no use of Stirling's formula. -/
+theorem unionFreeMax_bracket (n : ℕ) :
+    2 ^ n ≤ (n + 1) * unionFreeMax n ∧ unionFreeMax n ≤ 2 ^ n :=
+  ⟨pow_le_succ_mul_central n, central_le_pow n⟩
+
+/-- Real-valued form of the lower bracket: `2ⁿ / (n+1) ≤ F(n)`. -/
+theorem pow_div_succ_le_central (n : ℕ) :
+    (2 : ℝ) ^ n / (n + 1) ≤ (unionFreeMax n : ℝ) := by
+  have hpos : (0 : ℝ) < (n : ℝ) + 1 := by positivity
+  rw [div_le_iff₀ hpos]
+  have := pow_le_succ_mul_central n
+  have hcast : ((2 ^ n : ℕ) : ℝ) ≤ (((n + 1) * unionFreeMax n : ℕ) : ℝ) := by
+    exact_mod_cast this
+  push_cast at hcast
+  linarith [hcast]
+
+/-- `F(2n) = C(2n, n) = centralBinom n`, the central binomial coefficient. -/
+theorem unionFreeMax_two_mul (n : ℕ) : unionFreeMax (2 * n) = Nat.centralBinom n := by
+  unfold unionFreeMax Nat.centralBinom
+  rw [Nat.mul_div_cancel_left n (by norm_num : 0 < 2)]
+
+/-- A clean elementary linear lower bound on the even-index subsequence:
+`2n ≤ F(2n)`. (`F(2n) = C(2n,n) ≥ C(2n,1) = 2n`.) -/
+theorem two_mul_le_unionFreeMax_two_mul (n : ℕ) : 2 * n ≤ unionFreeMax (2 * n) := by
+  rw [unionFreeMax_two_mul]
+  have h : Nat.choose (2 * n) 1 ≤ Nat.centralBinom n := Nat.choose_le_centralBinom 1 n
+  rwa [Nat.choose_one_right] at h
+
+/-- **Divergence.** The union-free maximum is unbounded: `F(n) → ∞`.
+Proved purely over `ℕ` via the even subsequence `F(2M) ≥ 2M ≥ M`. -/
+theorem unionFreeMax_unbounded : ∀ M : ℕ, ∃ n, M ≤ unionFreeMax n := by
+  intro M
+  refine ⟨2 * M, ?_⟩
+  calc M ≤ 2 * M := by omega
+    _ ≤ unionFreeMax (2 * M) := two_mul_le_unionFreeMax_two_mul M
+
+/-! ### Concrete values
+
+`F(n) = C(n, ⌊n/2⌋)`: `1, 1, 2, 3, 6, 10, 20, …` for `n = 0, 1, 2, 3, 4, 5, 6`. -/
+
+example : unionFreeMax 0 = 1 := by decide
+example : unionFreeMax 1 = 1 := by decide
+example : unionFreeMax 2 = 2 := by decide
+example : unionFreeMax 3 = 3 := by decide
+example : unionFreeMax 4 = 6 := by decide
+example : unionFreeMax 5 = 10 := by decide
+example : unionFreeMax 6 = 20 := by decide
+
+/-- Sanity check of the lower bracket at `n = 6`: `2⁶ = 64 ≤ 7 · 20 = 140`. -/
+example : 2 ^ 6 ≤ (6 + 1) * unionFreeMax 6 := pow_le_succ_mul_central 6
+
+end Erdos1023OQ04

--- a/proofs/Proofs/SumOfDivisorsOQ04OQ01.lean
+++ b/proofs/Proofs/SumOfDivisorsOQ04OQ01.lean
@@ -1,0 +1,123 @@
+/-
+# Sum of Divisors OQ-04-OQ-01: prime powers are deficient — never perfect, almost-perfect powers of two, sharp abundancy bound
+
+## Open Question
+OQ-04 establishes the *structural* divisor-sum identities on prime powers
+(`σ(pⁱ)·(p−1) = pⁱ⁺¹−1`). The base entry classifies particular numbers as
+deficient / perfect / abundant by `native_decide`. This entry proves the
+*qualitative classification of every prime power*, axiom-free and once-and-for-all
+in `p` and `k`:
+
+* **Deficiency.** `σ(pᵏ) < 2·pᵏ` for every prime `p` and exponent `k`. Hence no
+  prime power is perfect or abundant — it is always strictly deficient.
+* **Almost-perfect powers of two.** `σ(2ᵏ) + 1 = 2·2ᵏ`: powers of two are
+  deficient by *exactly one*, the smallest possible positive deficiency (this is
+  the classical "almost perfect" property of `2ᵏ`).
+* **No prime power is perfect.** `¬ Nat.Perfect (pᵏ)`, connecting the deficiency
+  bound back to the base entry's perfection predicate.
+* **Sharp abundancy bound.** Over ℚ, `σ(pᵏ)/pᵏ < p/(p−1) ≤ 2`. The bound
+  `p/(p−1)` is the supremum of the abundancy index over the powers of a fixed
+  prime `p` (approached as `k → ∞`), and is `≤ 2` exactly because `p ≥ 2`.
+
+## Approach
+Everything reduces to the integer identity `σ(pᵏ)·(p−1) = pᵏ⁺¹−1`
+(`sigma_one_apply_prime_pow` + `geom_sum_mul`). Multiplying the target deficiency
+gap by the positive quantity `p−1` turns it into `pᵏ·(p−2)+1 ≥ 1 > 0`, an
+elementary nonnegativity. The abundancy bound is the same identity read over ℚ via
+`div_lt_div_iff`.
+
+Sorry-free and axiom-free (no `native_decide`).
+-/
+import Mathlib
+
+namespace SumOfDivisorsOQ04OQ01
+
+open ArithmeticFunction Finset
+
+/-- **The defining integer identity** (OQ-04): `σ(pⁱ)·(p−1) = pⁱ⁺¹−1` over ℤ.
+Restated locally as the engine for every result below. -/
+theorem sigma_one_prime_pow_mul {p : ℕ} (hp : p.Prime) (i : ℕ) :
+    (sigma 1 (p ^ i) : ℤ) * ((p : ℤ) - 1) = (p : ℤ) ^ (i + 1) - 1 := by
+  rw [sigma_one_apply_prime_pow hp]
+  push_cast
+  rw [geom_sum_mul]
+
+/-- **Every prime power is deficient:** `σ(pᵏ) < 2·pᵏ` for every prime `p` and `k`.
+The deficiency gap, scaled by the positive factor `p−1`, equals `pᵏ·(p−2)+1 ≥ 1`. -/
+theorem sigma_one_prime_pow_deficient {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    sigma 1 (p ^ k) < 2 * p ^ k := by
+  have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
+  have key := sigma_one_prime_pow_mul hp k
+  -- The deficiency gap times `(p − 1)` is `pᵏ·(p − 2) + 1`.
+  have expand :
+      ((2 : ℤ) * (p : ℤ) ^ k - (sigma 1 (p ^ k) : ℤ)) * ((p : ℤ) - 1)
+        = (p : ℤ) ^ k * ((p : ℤ) - 2) + 1 := by
+    linear_combination -key
+  have hpk : (0 : ℤ) ≤ (p : ℤ) ^ k := by positivity
+  have hrhs : (0 : ℤ) < (p : ℤ) ^ k * ((p : ℤ) - 2) + 1 := by
+    have : (0 : ℤ) ≤ (p : ℤ) ^ k * ((p : ℤ) - 2) :=
+      mul_nonneg hpk (by linarith)
+    linarith
+  have hp1 : (0 : ℤ) < (p : ℤ) - 1 := by linarith
+  zify
+  nlinarith [expand, hrhs, hp1]
+
+/-- **Powers of two are almost perfect:** `σ(2ᵏ) + 1 = 2·2ᵏ`. The divisor sum falls
+exactly one short of `2·2ᵏ` — the minimal possible positive deficiency, so `2ᵏ` is
+the "least deficient" prime power. -/
+theorem pow_two_almost_perfect (k : ℕ) :
+    sigma 1 (2 ^ k) + 1 = 2 * 2 ^ k := by
+  have key := sigma_one_prime_pow_mul Nat.prime_two k
+  have hpow : (2 : ℤ) ^ (k + 1) = 2 * 2 ^ k := by ring
+  zify
+  push_cast at key
+  linarith [key, hpow]
+
+/-- **No prime power is perfect.** Combines the deficiency bound with the base
+entry's `Nat.Perfect` predicate: perfection requires `σ(n) = 2n`, which prime
+powers never satisfy. -/
+theorem prime_pow_not_perfect {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    ¬ Nat.Perfect (p ^ k) := by
+  intro hperf
+  have hpos : 0 < p ^ k := pow_pos hp.pos k
+  rw [Nat.perfect_iff_sum_divisors_eq_two_mul hpos, ← sigma_one_apply] at hperf
+  have hdef := sigma_one_prime_pow_deficient hp k
+  omega
+
+/-- **Sharp abundancy bound:** the abundancy index `σ(pᵏ)/pᵏ` of a prime power is
+strictly below `p/(p−1)`. As `k → ∞` the index increases to this bound, so
+`p/(p−1)` is its supremum over the powers of `p`. -/
+theorem abundancy_prime_pow_lt {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    (sigma 1 (p ^ k) : ℚ) / (p ^ k : ℚ) < (p : ℚ) / ((p : ℚ) - 1) := by
+  have hp2 : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp.two_le
+  have hb : (0 : ℚ) < (p ^ k : ℚ) := by
+    have : 0 < p ^ k := pow_pos hp.pos k
+    exact_mod_cast this
+  have hd : (0 : ℚ) < (p : ℚ) - 1 := by linarith
+  rw [div_lt_div_iff₀ hb hd]
+  have key : (sigma 1 (p ^ k) : ℚ) * ((p : ℚ) - 1) = (p : ℚ) ^ (k + 1) - 1 := by
+    rw [sigma_one_apply_prime_pow hp]
+    push_cast
+    rw [geom_sum_mul]
+  rw [key]
+  have hpow : (p : ℚ) ^ (k + 1) = (p : ℚ) * (p : ℚ) ^ k := by ring
+  linarith [hpow]
+
+/-- **Abundancy of a prime power is below 2** (the deficiency bound, over ℚ): since
+`p ≥ 2`, the supremum `p/(p−1)` is itself `≤ 2`, so `σ(pᵏ)/pᵏ < 2`. -/
+theorem abundancy_prime_pow_lt_two {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    (sigma 1 (p ^ k) : ℚ) / (p ^ k : ℚ) < 2 := by
+  have hp2 : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp.two_le
+  have hd : (0 : ℚ) < (p : ℚ) - 1 := by linarith
+  have hsup : (p : ℚ) / ((p : ℚ) - 1) ≤ 2 := by
+    rw [div_le_iff₀ hd]
+    linarith
+  exact lt_of_lt_of_le (abundancy_prime_pow_lt hp k) hsup
+
+/-- **Divisor count of a prime power:** `τ(pᵏ) = k + 1` (bonus structural identity,
+generalising OQ-04's `τ(p) = 2`). -/
+theorem sigma_zero_prime_pow {p : ℕ} (hp : p.Prime) (k : ℕ) :
+    sigma 0 (p ^ k) = k + 1 := by
+  rw [sigma_zero_apply_prime_pow hp]
+
+end SumOfDivisorsOQ04OQ01

--- a/src/data/proofs/erdos-1023-oq-04/meta.json
+++ b/src/data/proofs/erdos-1023-oq-04/meta.json
@@ -1,0 +1,100 @@
+{
+  "id": "erdos-1023-oq-04",
+  "title": "Erdős #1023: elementary growth brackets 2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ for the union-free maximum",
+  "slug": "erdos-1023-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Data.Nat.Choose.Bounds",
+      "Mathlib.Data.Nat.Choose.Central",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1023OQ04",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1023OQ04.lean",
+    "sorries": 0
+  },
+  "description": "Supplies rigorous, completely elementary growth brackets for the union-free maximum F(n) of Erdős Problem #1023. F(n) is the largest family of subsets of {1,...,n} in which no set is the union of two or more distinct other members; Erdős asked whether F(n) ~ c·2^n/√n, and the answer is YES with F(n) = C(n, floor(n/2)), the central binomial coefficient (middle layer optimal by Erdős-Kleitman). The parent file Erdos1023Problem.lean establishes the exact asymptotic only through axioms (stirling_central, unionFreeMax_asymptotic) because the constant √(2/π) needs Stirling's formula. This sibling takes the established value F(n) = C(n, floor(n/2)) as a definition and proves, with ZERO axioms beyond Mathlib's foundations: the upper bound F(n) ≤ 2^n (central_le_pow), the KEY lower bound 2^n ≤ (n+1)·F(n) i.e. F(n) ≥ 2^n/(n+1) (pow_le_succ_mul_central, by averaging ∑ C(n,m) = 2^n against the maximal central column Nat.choose_le_middle), the combined bracket, its real-valued form 2^n/(n+1) ≤ F(n), and divergence F(n) → ∞ (unionFreeMax_unbounded, proved purely over ℕ via F(2n) = centralBinom n ≥ C(2n,1) = 2n). This replaces the qualitative content of the parent's Stirling axiom — that F grows like 2^n up to a polynomial factor and tends to infinity — by a machine-checked elementary statement. 9 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1023OQ04.lean",
+    "tags": [
+      "combinatorics",
+      "extremal-set-theory",
+      "union-free-families",
+      "central-binomial-coefficient",
+      "binomial-coefficients",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with Lean v4.26.0 against the repository Mathlib pin (elaborated clean, #print axioms on every substantive theorem reports only propext / Classical.choice / Quot.sound). 0 sorries, 0 axiom declarations, no native_decide (the concrete-value examples use kernel `decide`, so no Lean.ofReduceBool). Self-contained: F(n) is defined directly as Nat.choose n (n/2); the parent file's axioms (problem_447_solution Erdős-Kleitman optimality, stirling_central, unionFreeMax_asymptotic) are NOT imported or used. Honest scope: this is the ELEMENTARY growth of the central binomial column (brackets up to a polynomial factor and divergence), NOT the exact asymptotic constant √(2/π) (which needs Stirling) and NOT the Erdős-Kleitman optimality that identifies F(n) with the central column.",
+    "lineCount": 133,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "originalContributions": [
+      "pow_le_succ_mul_central: the key elementary lower bound 2^n ≤ (n+1)·F(n) — averaging the binomial identity ∑_{m≤n} C(n,m) = 2^n against the maximality of the central column (Nat.choose_le_middle); gives F(n) ≥ 2^n/(n+1) with no Stirling estimate",
+      "central_le_pow: the trivial upper bound F(n) ≤ 2^n (the central column is one term of the binomial sum)",
+      "unionFreeMax_bracket: the two-sided bracket 2^n ≤ (n+1)·F(n) and F(n) ≤ 2^n, pinning down the growth of F up to a polynomial factor",
+      "pow_div_succ_le_central: the real-valued lower bound 2^n/(n+1) ≤ F(n)",
+      "unionFreeMax_two_mul: the identity F(2n) = C(2n,n) = centralBinom n linking the even subsequence to the central binomial coefficient",
+      "two_mul_le_unionFreeMax_two_mul: the clean linear lower bound 2n ≤ F(2n) via Nat.choose_le_centralBinom",
+      "unionFreeMax_unbounded: divergence F(n) → ∞ (∀ M, ∃ n, M ≤ F(n)), proved purely over ℕ on the even subsequence"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1023 asks for F(n), the maximum size of a family of subsets of {1,...,n} in which no member is the union of two or more distinct other members (a 'union-free' family). Erdős conjectured F(n) ~ c·2^n/√n. The conjecture is true: the middle layer of all floor(n/2)-element subsets is union-free (two distinct sets of the same size cannot have a union of that size), giving F(n) ≥ C(n, floor(n/2)), and Erdős-Kleitman proved this is optimal, so F(n) = C(n, floor(n/2)) ~ √(2/π)·2^n/√n by Stirling. The central binomial coefficient C(n, floor(n/2)) is the largest entry of row n of Pascal's triangle.",
+    "problemStatement": "With F(n) = C(n, floor(n/2)) (the value established by the parent entry), bound the growth of F elementarily. This entry proves 2^n/(n+1) ≤ F(n) ≤ 2^n and F(n) → ∞ without invoking Stirling's formula.",
+    "proofStrategy": "Upper bound: the central column is a single term of ∑_{m≤n} C(n,m) = 2^n, so F(n) ≤ 2^n (Nat.choose_le_two_pow). Lower bound: every term of that sum is at most the maximal central column (Nat.choose_le_middle), so 2^n = ∑_{m≤n} C(n,m) ≤ (n+1)·C(n, floor(n/2)) = (n+1)·F(n); a one-line Finset.sum_le_sum followed by Finset.sum_const. The real-valued form follows by div_le_iff₀ and a cast. Divergence is shown over ℕ: F(2n) = C(2n, n) = centralBinom n, and centralBinom n ≥ C(2n,1) = 2n by Nat.choose_le_centralBinom, so F(2M) ≥ 2M ≥ M for every M.",
+    "keyInsights": [
+      "The qualitative growth of the union-free maximum needs NO Stirling estimate: a single averaging of the binomial identity ∑ C(n,m) = 2^n against the maximality of the central column gives 2^n ≤ (n+1)·F(n) in one line.",
+      "Combined with the trivial upper bound F(n) ≤ 2^n, this pins F(n) between 2^n/(n+1) and 2^n — capturing the 'order 2^n up to a polynomial factor' content of the parent's asymptotic axiom, but fully machine-checked.",
+      "Divergence is purely combinatorial: the even subsequence F(2n) equals the central binomial coefficient centralBinom n, which dominates C(2n,1) = 2n, so F is unbounded without any analysis.",
+      "The central binomial coefficient is the largest entry of Pascal's row n; Nat.choose_le_middle is exactly the maximality statement that powers the lower bracket."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition-bounds",
+      "title": "Definition and the Two-Sided Bracket",
+      "summary": "unionFreeMax (= C(n, floor(n/2))), positivity, the upper bound F(n) ≤ 2^n (central_le_pow), the key lower bound 2^n ≤ (n+1)·F(n) (pow_le_succ_mul_central), the combined bracket, and its real form.",
+      "startLine": 1,
+      "endLine": 96,
+      "mathContext": "Average the binomial identity ∑_{m≤n} C(n,m) = 2^n against the maximal central column (Nat.choose_le_middle) to get the lower bound; the upper bound is one term of the same sum."
+    },
+    {
+      "id": "divergence",
+      "title": "Even Subsequence and Divergence",
+      "summary": "unionFreeMax_two_mul (F(2n) = centralBinom n), two_mul_le_unionFreeMax_two_mul (2n ≤ F(2n)), unionFreeMax_unbounded (F(n) → ∞), and concrete values F(0..6) = 1,1,2,3,6,10,20.",
+      "startLine": 97,
+      "endLine": 133,
+      "mathContext": "F(2n) = C(2n,n) = centralBinom n ≥ C(2n,1) = 2n via Nat.choose_le_centralBinom, giving unboundedness over ℕ with no real analysis."
+    }
+  ],
+  "conclusion": {
+    "summary": "The union-free maximum F(n) = C(n, floor(n/2)) of Erdős Problem #1023 is bracketed elementarily by 2^n/(n+1) ≤ F(n) ≤ 2^n, and shown to diverge F(n) → ∞, with zero axioms beyond Mathlib's foundations. The lower bracket is a one-line average of the binomial identity ∑ C(n,m) = 2^n against the maximality of the central column; the upper bracket is a single term of that sum; divergence uses F(2n) = centralBinom n ≥ 2n. This captures the qualitative growth content of the parent file's Stirling-based asymptotic axiom as a machine-checked elementary statement.",
+    "implications": "The brackets make rigorous, without Stirling's formula, the fact that the maximum union-free family has size of order 2^n up to a polynomial factor and grows without bound. They isolate exactly what the exact asymptotic F(n) ~ √(2/π)·2^n/√n adds beyond the elementary picture (only the precise constant and the √n power, which genuinely require Stirling). The central-binomial bracket 2^n/(n+1) ≤ C(n, floor(n/2)) ≤ 2^n is reusable wherever the central column appears.",
+    "openQuestions": [
+      "Sharpen the lower bracket to the true order: prove 2^n/√(c·n) ≤ C(n, floor(n/2)) (the √n rather than n denominator), which requires a Stirling-type estimate.",
+      "Discharge the parent file's axioms (problem_447_solution Erdős-Kleitman optimality, stirling_central) to make the exact asymptotic fully proved.",
+      "Establish strict monotonicity F(n) < F(n+2) of the central binomial column directly from a Pascal recurrence, strengthening the unboundedness proved here."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1023",
+      "relationship": "parent",
+      "description": "The main Erdős #1023 union-free families file (isUnionFree, middleLayer, the lower bound unionFreeMax_ge_middle, and the axiomatized Erdős-Kleitman optimality and Stirling asymptotic). It establishes F(n) = C(n, floor(n/2)); this sibling supplies the elementary, 0-axiom growth brackets 2^n/(n+1) ≤ F(n) ≤ 2^n and divergence that the parent only obtains through its Stirling axiom."
+    }
+  ]
+}

--- a/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
+++ b/src/data/proofs/sum-of-divisors-oq-04-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "sum-of-divisors-oq-04-oq-01",
+  "title": "Prime Powers Are Deficient: Almost-Perfect Powers of Two and the Sharp Abundancy Bound",
+  "slug": "sum-of-divisors-oq-04-oq-01",
+  "description": "Qualitative classification of every prime power, axiom-free and once-and-for-all in p and k: σ(pᵏ) < 2·pᵏ (every prime power is strictly deficient, hence never perfect or abundant); σ(2ᵏ)+1 = 2·2ᵏ (powers of two are almost perfect — deficient by exactly one, the minimal positive deficiency); ¬ Perfect(pᵏ); and the sharp abundancy bound σ(pᵏ)/pᵏ < p/(p−1) ≤ 2 over ℚ, with p/(p−1) the supremum of the abundancy index over the powers of a fixed prime. Builds on OQ-04's integer identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1, scaling the deficiency gap by p−1 into the elementary nonnegativity pᵏ·(p−2)+1 ≥ 1. No native_decide.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Almost_perfect_number",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "divisor-function",
+      "sigma",
+      "prime-powers",
+      "perfect-numbers",
+      "deficient-numbers",
+      "almost-perfect-numbers",
+      "abundancy-index",
+      "arithmetic-functions",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfDivisorsOQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ArithmeticFunction.sigma_one_apply_prime_pow",
+        "description": "σ₁(pⁱ) = ∑_{k<i+1} pᵏ — the open geometric sum on a prime power",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "ArithmeticFunction.sigma_zero_apply_prime_pow",
+        "description": "σ₀(pⁱ) = i+1 — the divisor count of a prime power",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "geom_sum_mul",
+        "description": "(∑_{i<n} xⁱ)·(x−1) = xⁿ−1 — collapses the open sum to the closed geometric form",
+        "module": "Mathlib.Algebra.Ring.GeomSum"
+      },
+      {
+        "theorem": "Nat.perfect_iff_sum_divisors_eq_two_mul",
+        "description": "0 < n → (Perfect n ↔ ∑_{d∣n} d = 2n) — perfection as a divisor-sum equation",
+        "module": "Mathlib.NumberTheory.Divisors"
+      },
+      {
+        "theorem": "ArithmeticFunction.sigma_one_apply",
+        "description": "σ₁(n) = ∑_{d∣n} d — links the σ function to the raw divisor sum",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
+      },
+      {
+        "theorem": "div_lt_div_iff₀",
+        "description": "0 < b, 0 < d → (a/b < c/d ↔ a·d < c·b) — cross-multiplication for the abundancy bound over ℚ",
+        "module": "Mathlib.Algebra.Order.Field.Basic"
+      }
+    ],
+    "originalContributions": [
+      "sigma_one_prime_pow_deficient: σ(pᵏ) < 2·pᵏ — EVERY prime power is strictly deficient, for all primes p and exponents k (the general law behind the base entry's case-by-case deficiency checks)",
+      "pow_two_almost_perfect: σ(2ᵏ)+1 = 2·2ᵏ — powers of two are almost perfect (deficient by exactly one, the minimal possible positive deficiency)",
+      "prime_pow_not_perfect: ¬ Perfect(pᵏ) — no prime power is perfect, derived from the deficiency bound and the σ-form of perfection",
+      "abundancy_prime_pow_lt: σ(pᵏ)/pᵏ < p/(p−1) over ℚ — the sharp abundancy bound, with p/(p−1) the supremum over the powers of p",
+      "abundancy_prime_pow_lt_two: σ(pᵏ)/pᵏ < 2 over ℚ — the deficiency bound in abundancy form, sharp because p/(p−1) ≤ 2 ⇔ p ≥ 2",
+      "sigma_zero_prime_pow: τ(pᵏ) = k+1 — divisor count of a prime power (generalising OQ-04's τ(p) = 2)"
+    ],
+    "dateAdded": "2026-06-22",
+    "lineCount": 123,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries; no native_decide (axiom check reports only propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "A positive integer is deficient, perfect, or abundant according as σ(n) is less than, equal to, or greater than 2n. The Greeks knew 6 and 28 to be perfect; the much larger family of deficient numbers includes every prime power. The powers of two occupy a special place: σ(2ᵏ) = 2ᵏ⁺¹ − 1 = 2·2ᵏ − 1 falls exactly one short of perfection, which is the defining property of an almost-perfect number — and whether any almost-perfect number other than a power of two exists is still open. The base gallery entry classified particular numbers as deficient, perfect, or abundant by direct computation (native_decide); OQ-04 supplied the structural divisor-sum identities on prime powers. This entry combines them into the qualitative classification of the entire family of prime powers, axiom-free.",
+    "problemStatement": "**Open Question (sum-of-divisors-oq-04-oq-01)**: Determine, once and for all in p and k, the divisor-sum classification of an arbitrary prime power pᵏ. Is it ever perfect or abundant? How close to perfect can it get, and what is the supremum of its abundancy index?\n\n**Result**: every prime power is strictly deficient (σ(pᵏ) < 2·pᵏ), so none is perfect or abundant; powers of two are almost perfect (σ(2ᵏ)+1 = 2·2ᵏ); and the abundancy index obeys the sharp bound σ(pᵏ)/pᵏ < p/(p−1) ≤ 2.",
+    "text": "For every prime p and exponent k, σ(pᵏ) < 2·pᵏ; in particular σ(2ᵏ)+1 = 2·2ᵏ and no prime power is perfect. Over ℚ the abundancy index satisfies σ(pᵏ)/pᵏ < p/(p−1) ≤ 2.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sigma_one_prime_pow_mul`: re-establish OQ-04's integer identity σ(pᵏ)·(p−1) = pᵏ⁺¹−1 via `sigma_one_apply_prime_pow` and `geom_sum_mul`.\n2. `sigma_one_prime_pow_deficient`: multiply the target gap 2·pᵏ − σ(pᵏ) by the positive factor p−1; `linear_combination` against the identity collapses it to pᵏ·(p−2)+1, which is ≥ 1 because p ≥ 2 and pᵏ ≥ 0. Since p−1 > 0, the gap itself is positive, giving σ(pᵏ) < 2·pᵏ after `zify`/`nlinarith`.\n3. `pow_two_almost_perfect`: specialise the identity at p = 2, where p−1 = 1, so σ(2ᵏ) = 2ᵏ⁺¹ − 1; `linarith` with 2ᵏ⁺¹ = 2·2ᵏ gives σ(2ᵏ)+1 = 2·2ᵏ.\n4. `prime_pow_not_perfect`: `perfect_iff_sum_divisors_eq_two_mul` + `sigma_one_apply` turn perfection into σ(pᵏ) = 2·pᵏ, contradicted by the strict deficiency bound (`omega`).\n5. `abundancy_prime_pow_lt`: `div_lt_div_iff₀` reduces σ(pᵏ)/pᵏ < p/(p−1) to σ(pᵏ)·(p−1) < p·pᵏ, i.e. pᵏ⁺¹ − 1 < pᵏ⁺¹, immediate from the identity.\n6. `abundancy_prime_pow_lt_two`: p/(p−1) ≤ 2 ⇔ p ≤ 2(p−1) ⇔ p ≥ 2, so the supremum is itself ≤ 2.",
+    "keyInsights": [
+      "**Scaling the gap linearises the problem.** The deficiency gap 2·pᵏ − σ(pᵏ) is awkward directly, but multiplying by the positive p−1 and substituting the closed geometric identity reduces it to pᵏ·(p−2)+1 — a quantity manifestly ≥ 1 for every prime. One ring identity classifies the entire infinite family.",
+      "**Powers of two are exactly one short.** σ(2ᵏ) = 2·2ᵏ − 1, the smallest possible positive deficiency: 2ᵏ is 'almost perfect'. This is the sharp endpoint of the deficiency bound and the reason powers of two are the only known almost-perfect numbers.",
+      "**p/(p−1) is the supremum, not a perfect number.** The abundancy index σ(pᵏ)/pᵏ = (p − p⁻ᵏ)/(p−1) increases in k toward p/(p−1) but never reaches it; since p/(p−1) ≤ 2 for p ≥ 2, a prime power can approach but never attain perfection (abundancy 2).",
+      "**Deficiency over ℕ and abundancy over ℚ agree.** σ(pᵏ) < 2·pᵏ in ℕ and σ(pᵏ)/pᵏ < 2 in ℚ are the same fact in two registers; both follow from the single identity pᵏ⁺¹ − 1 < pᵏ⁺¹."
+    ],
+    "prerequisites": [
+      "Mathlib's ArithmeticFunction.sigma and its prime-power API",
+      "The geometric sum identity geom_sum_mul",
+      "Nat.Perfect and its divisor-sum characterisation",
+      "Ordered-field cross-multiplication (div_lt_div_iff₀)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and the Defining Identity",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Module docstring framing the deficiency classification of prime powers, the Mathlib import, namespace, opens, and sigma_one_prime_pow_mul (OQ-04's integer identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1, the engine for everything below).",
+      "mathContext": "$\\sigma(p^i)\\,(p-1) = p^{i+1}-1$."
+    },
+    {
+      "id": "deficiency",
+      "title": "Deficiency and Almost-Perfect Powers of Two",
+      "startLine": 45,
+      "endLine": 84,
+      "summary": "sigma_one_prime_pow_deficient (σ(pᵏ) < 2·pᵏ for every prime power), pow_two_almost_perfect (σ(2ᵏ)+1 = 2·2ᵏ), and prime_pow_not_perfect (no prime power is perfect).",
+      "mathContext": "$\\sigma(p^k) < 2p^k$, $\\sigma(2^k)+1 = 2\\cdot 2^k$, $\\neg\\,\\mathrm{Perfect}(p^k)$."
+    },
+    {
+      "id": "abundancy",
+      "title": "The Sharp Abundancy Bound",
+      "startLine": 86,
+      "endLine": 123,
+      "summary": "abundancy_prime_pow_lt (σ(pᵏ)/pᵏ < p/(p−1)), abundancy_prime_pow_lt_two (σ(pᵏ)/pᵏ < 2), and sigma_zero_prime_pow (τ(pᵏ) = k+1).",
+      "mathContext": "$\\dfrac{\\sigma(p^k)}{p^k} < \\dfrac{p}{p-1} \\le 2$ and $\\tau(p^k) = k+1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-divisors-oq-04",
+      "relationship": "extends",
+      "description": "Uses OQ-04's closed geometric identity σ(pⁱ)·(p−1) = pⁱ⁺¹−1 as the engine and turns it into the qualitative deficiency/abundancy classification of every prime power"
+    },
+    {
+      "targetId": "sum-of-divisors-oq-05",
+      "relationship": "related",
+      "description": "OQ-05 proves the abundancy index is multiplicative and exceeds 1 for n ≥ 2; this entry pins the abundancy of a prime power strictly below 2 with sharp supremum p/(p−1)"
+    },
+    {
+      "targetId": "sum-of-divisors",
+      "relationship": "extends",
+      "description": "Generalises the base entry's native_decide deficiency checks on specific numbers to the universally quantified family of prime powers, 0-axiom"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms, no native_decide) classification of prime powers by their divisor sums: σ(pᵏ) < 2·pᵏ so every prime power is strictly deficient and never perfect or abundant; σ(2ᵏ)+1 = 2·2ᵏ so powers of two are almost perfect; and σ(pᵏ)/pᵏ < p/(p−1) ≤ 2 over ℚ with p/(p−1) the supremum of the abundancy index.",
+    "implications": "Replaces the base entry's per-number native_decide deficiency checks with a single axiom-free theorem covering the whole infinite family of prime powers, and isolates powers of two as the extremal (almost-perfect) case — the natural setting of the open almost-perfect-number problem.",
+    "openQuestions": [
+      "Are there almost-perfect numbers other than powers of two (σ(n) = 2n − 1)? No example is known and none is proved impossible.",
+      "Give the exact deficiency 2·pᵏ − σ(pᵏ) = (pᵏ(p−2)+1)/(p−1) as a closed-form arithmetic function and characterise when it is minimal."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ArithmeticFunction",
+      "Finset"
+    ],
+    "namespace": "SumOfDivisorsOQ04OQ01",
+    "lineCount": 123,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfDivisorsOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Chapter XVI: σ(n), the geometric formula on prime powers, and perfect/deficient/abundant numbers"
+    },
+    {
+      "authors": "Guy, Richard K.",
+      "title": "Unsolved Problems in Number Theory",
+      "year": "2004",
+      "venue": "Springer, 3rd ed.",
+      "note": "Section B2: almost perfect numbers σ(n) = 2n − 1; powers of two are the only known examples"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Self-generated child of **sum-of-divisors-oq-04**. OQ-04 established the structural divisor-sum identity on prime powers, `σ(pⁱ)·(p−1) = pⁱ⁺¹−1`; this entry turns it into the **qualitative divisor-sum classification of every prime power**, axiom-free and once-and-for-all in `p` and `k`.

## Results (`proofs/Proofs/SumOfDivisorsOQ04OQ01.lean`, 123 L, 7 thm / 0 def)

- **`sigma_one_prime_pow_deficient`**: `σ(pᵏ) < 2·pᵏ` — every prime power is *strictly deficient*, hence never perfect or abundant.
- **`pow_two_almost_perfect`**: `σ(2ᵏ) + 1 = 2·2ᵏ` — powers of two are *almost perfect* (deficient by exactly one, the minimal positive deficiency).
- **`prime_pow_not_perfect`**: `¬ Nat.Perfect (pᵏ)` — connects the deficiency bound to the base entry's perfection predicate.
- **`abundancy_prime_pow_lt` / `abundancy_prime_pow_lt_two`**: `σ(pᵏ)/pᵏ < p/(p−1) ≤ 2` over ℚ — the sharp abundancy bound, with `p/(p−1)` the supremum of the abundancy index over the powers of a fixed prime.
- **`sigma_zero_prime_pow`**: `τ(pᵏ) = k+1` (generalises OQ-04's `τ(p) = 2`).

## Method

Scaling the deficiency gap `2·pᵏ − σ(pᵏ)` by the positive factor `p−1` and substituting OQ-04's identity collapses it to `pᵏ·(p−2)+1 ≥ 1` — one ring identity classifies the entire infinite family. The abundancy bound is the same identity read over ℚ via `div_lt_div_iff₀`.

## Verification

- Builds clean against Mathlib (lean v4.26.0), 0 sorries, **no `native_decide`** (the base entry uses `native_decide`; this de-axiomatizes the classification for prime powers).
- `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom, badge `original`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)