### PR TITLE
research(intermediate-value-theorem-oq-01-oq-01): register orphaned verified file in build manifest

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2886,6 +2886,7 @@ import Proofs.InfinitudePrimesOQ05
 import Proofs.IntegralRootTheoremOQ01
 import Proofs.IntermediateValueTheorem
 import Proofs.IntermediateValueTheoremOQ01
+import Proofs.IntermediateValueTheoremOQ01OQ01
 import Proofs.IntermediateValueTheoremOQ02
 import Proofs.IntermediateValueTheoremOQ02OQ01
 import Proofs.IntermediateValueTheoremOQ02OQ03

--- a/research/problems/intermediate-value-theorem-oq-01-oq-01/knowledge.md
+++ b/research/problems/intermediate-value-theorem-oq-01-oq-01/knowledge.md
@@ -1,0 +1,11 @@
+
+## Session 2026-06-22 (researcher-1) — INTEGRATION FIX (orphaned from build)
+
+PR-batch created `proofs/Proofs/IntermediateValueTheoremOQ01OQ01.lean` (namespace
+BisectionMethod; verified 0-axiom: sign_persist_aux, bisectStep_sign_persist,
+bisect_sign_persist, bisect_sqrt2_contains_root) + gallery entry, but the Lean file was
+**never registered in `proofs/Proofs.lean`** — part of the ~251-file systemic orphan batch.
+Registered `import Proofs.IntermediateValueTheoremOQ01OQ01` (LC_ALL=C sorted, between OQ01
+and OQ02). Host-lean verified (compiled dep IntermediateValueTheoremOQ01→olean, then this
+file): EXIT=0; #print axioms bisect_sqrt2_contains_root = [propext, Classical.choice,
+Quot.sound] only. No new math.


### PR DESCRIPTION
## Summary

Integrity fix. `Proofs/IntermediateValueTheoremOQ01OQ01.lean` (namespace `BisectionMethod`; verified, 0-axiom — sign-persistence of the bisection step `bisect_sign_persist` and a √2 root-enclosure `bisect_sqrt2_contains_root`) plus its gallery entry were created, but the Lean file was **never registered in the auto-generated build manifest `proofs/Proofs.lean`**. It is one of a systemic ~251-file orphan batch from the recent research session.

Fix (no new mathematics): register `import Proofs.IntermediateValueTheoremOQ01OQ01` in the correct `LC_ALL=C` sorted position (between `OQ01` and `OQ02`).

## Verification (Docker was down → host single-file `lean`)

- Compiled the dependency `IntermediateValueTheoremOQ01` to an olean against the prebuilt Mathlib cache, then elaborated this file → **EXIT=0**.
- `#print axioms bisect_sqrt2_contains_root` = `[propext, Classical.choice, Quot.sound]` only — no `Lean.ofReduceBool`, no `sorryAx`, genuinely 0-axiom.

The gallery entry already exists (`status: verified`); this PR only makes the build actually include it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)