### PR TITLE
Enrich Fixed-Target Dirichlet Selection and the n=3 Obstruction

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "periodicity-in-prime",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": { "startLine": 87, "endLine": 109 },
+    "type": "theorem",
+    "title": "Periodicity of the Legendre Symbol in the Prime",
+    "content": "`legendreSym_eq_of_prime_modeq`: for odd primes p ≡ q (mod 4|a|), legendreSym p a = legendreSym q a. Mathlib packages jacobiSym.mod_right (J(a|b) depends on b only mod 4|a|) but NOT its Legendre-symbol-in-the-prime counterpart; the proof bridges the two by rewriting both Legendre symbols as Jacobi symbols (legendreSym.to_jacobiSym) and applying mod_right. `qr_condition_class_invariant` is the iff form; specialized to a = −n it is exactly the statement that the geometry's QR hypothesis legendreSym p (−n) = 1 depends only on p mod 4n — the parent's prose-only claim, now proved.",
+    "mathContext": "$p\\equiv q\\ (\\mathrm{mod}\\ 4|a|)\\Rightarrow\\left(\\tfrac{a}{p}\\right)=\\left(\\tfrac{a}{q}\\right)$; the QR condition is constant on residue classes $p\\bmod 4n$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre symbol", "Jacobi symbol", "quadratic reciprocity", "jacobiSym.mod_right", "residue-class invariance"],
+    "prerequisites": ["quadratic reciprocity", "modular arithmetic", "Legendre/Jacobi symbols"]
+  },
+  {
+    "id": "value-transport",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": { "startLine": 111, "endLine": 141 },
+    "type": "technique",
+    "title": "Transporting the QR Value Across a Dirichlet Residue Class",
+    "content": "`legendreSym_neg_eq_of_modEq`: if p is an odd prime and r is any ODD natural with p ≡ r (mod 4n), then legendreSym p (−n) = J(−n | r). Crucially the second argument r need not be prime — only odd — which is what lets it stand for a Dirichlet residue class rather than a specific prime. The helper `odd_of_coprime_four_mul` supplies that oddness: gcd(r,4n)=1 forces r odd since 2 ∣ 4n. Both Legendre and Jacobi sides are reduced mod 4n via jacobiSym.mod_right and matched.",
+    "mathContext": "$p\\equiv r\\ (\\mathrm{mod}\\ 4n),\\ r\\ \\text{odd}\\Rightarrow \\left(\\tfrac{-n}{p}\\right)=J(-n\\mid r)$; $\\gcd(r,4n)=1\\Rightarrow r$ odd.",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi symbol", "residue class", "coprimality", "modular reduction"],
+    "prerequisites": ["Jacobi symbol", "modular arithmetic"]
+  },
+  {
+    "id": "unconditional-supply",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": { "startLine": 143, "endLine": 192 },
+    "type": "theorem",
+    "title": "Unconditional Multiplier-Prime Supply via Dirichlet",
+    "content": "`exists_qr_qualified_multiplier_prime`: given a residue r with gcd(r,4n)=1, r ≡ −1 (mod n) and J(−n|r)=1, then for every bound N there is a prime p > N of multiplier shape p = d·n − 1 (d ≥ 1) with legendreSym p (−n) = 1 holding UNCONDITIONALLY. Dirichlet's theorem (Nat.forall_exists_prime_gt_and_modEq, modulus 4n) supplies p ≡ r (mod 4n); p inherits oddness and the residue −1 (mod n) for the multiplier shape, while §1 forces the QR value to J(−n|r) = 1. `exists_qr_qualified_multiplier_prime_full` additionally forces legendreSym p (−d) = 1 by routing through the parent reduction legendreSym_neg_n_one_imp_neg_d_one. The parent's CONDITIONAL reduction becomes an unconditional supply.",
+    "mathContext": "$\\exists r$ qualifying $\\Rightarrow \\forall N\\,\\exists$ prime $p>N,\\ p=dn-1,\\ \\left(\\tfrac{-n}{p}\\right)=\\left(\\tfrac{-d}{p}\\right)=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["Dirichlet's theorem", "primes in arithmetic progressions", "multiplier prime", "unconditional reduction"],
+    "prerequisites": ["Dirichlet's theorem", "arithmetic progressions", "Legendre symbols"]
+  },
+  {
+    "id": "non-vacuous-two",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": { "startLine": 194, "endLine": 201 },
+    "type": "context",
+    "title": "Non-Vacuousness at n = 2",
+    "content": "`qr_qualified_multiplier_prime_two`: for n = 2 the residue r = 3 qualifies — gcd(3,8)=1, 3 ≡ −1 (mod 2), J(−2 | 3) = 1 — all discharged by decide/norm_num. So the unconditional supply of §2 is genuinely populated: for every N there is a prime p > N with p = 2d − 1 and legendreSym p (−2) = 1. This confirms the §2 hypothesis is satisfiable and the theorem non-trivial before §3 shows it can fail.",
+    "mathContext": "$n=2,\\ r=3$: $\\gcd(3,8)=1,\\ 3\\equiv-1\\ (2),\\ J(-2\\mid 3)=1$ — the supply is non-empty.",
+    "significance": "context",
+    "relatedConcepts": ["worked instance", "non-vacuousness", "Jacobi symbol evaluation"],
+    "prerequisites": ["Jacobi symbol"]
+  },
+  {
+    "id": "obstruction-value",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": { "startLine": 203, "endLine": 229 },
+    "type": "theorem",
+    "title": "The QR Value Is Forced to −1 at n = 3",
+    "content": "`legendreSym_neg_three_eq_neg_one`: every odd prime p ≡ 2 (mod 3) has legendreSym p (−3) = −1. By jacobiSym.mod_right the value depends only on p mod 12, and the constraints (p odd, p ≡ 2 mod 3) force p mod 12 ∈ {5, 11}, on both of which norm_num's reciprocity extension evaluates J(−3 | ·) = −1. `multiplier_prime_neg_three_qr_fails` applies this to multiplier primes p = 3d − 1 (which satisfy p ≡ 2 mod 3 by omega). The 0-axiom symbol evaluation uses norm_num, not native_decide, preserving the clean axiom profile.",
+    "mathContext": "$p\\ \\text{odd},\\ p\\equiv 2\\ (3)\\Rightarrow p\\bmod 12\\in\\{5,11\\}\\Rightarrow \\left(\\tfrac{-3}{p}\\right)=-1$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic reciprocity", "case analysis mod 12", "norm_num LegendreSymbol", "forced symbol value"],
+    "prerequisites": ["quadratic reciprocity", "modular arithmetic"]
+  },
+  {
+    "id": "honest-capstone",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
+    "range": { "startLine": 231, "endLine": 242 },
+    "type": "insight",
+    "title": "Honest Capstone: the −n-Route Cannot Certify n = 3",
+    "content": "`multiplier_route_incomplete_at_three`: 3 = 1²+1²+1² is plainly a sum of three squares, yet NO multiplier prime for n = 3 satisfies the geometry's QR hypothesis legendreSym p (−3) = 1 — equivalently, the qualifying-residue hypothesis of §2 fails at n = 3. This is a genuine negative result documenting why the −n-multiplier development of oq-03-oq-07 is only established for the small multipliers d ∈ {1,2}: the naive −n-residue condition cannot on its own certify representability. A qualifying class exists iff n is not of Legendre's excluded form 4^a(8b+7), so the existence of r in §2 is exactly the genus condition — the actual open content of the parent umbrella, here exhibited concretely failing.",
+    "mathContext": "$3=1^2+1^2+1^2$ but $\\nexists$ multiplier prime $p$ with $\\left(\\tfrac{-3}{p}\\right)=1$; qualifying $r$ exists $\\iff n\\neq 4^a(8b+7)$.",
+    "significance": "critical",
+    "relatedConcepts": ["honest scope", "negative result", "genus condition", "Legendre excluded form", "limits of a method"],
+    "prerequisites": ["Legendre's three-square theorem", "quadratic residues"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/meta.json
@@ -2,6 +2,46 @@
   "id": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
   "slug": "lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01",
   "title": "Fixed-Target Dirichlet Selection and a Sharp Obstruction at n = 3",
+  "description": "A follow-up to the multiplier–quadratic-residue reduction (oq-03-oq-07) that does three things, all 0-axiom. (1) Periodicity: it proves the parent's prose-only claim that the QR condition legendreSym p (−n) = 1 depends only on the residue class p mod 4n, via Mathlib's jacobiSym.mod_right routed through legendreSym.to_jacobiSym — a Legendre-symbol-in-the-prime statement Mathlib does not package. (2) Unconditional supply: from a single qualifying residue r (gcd(r,4n)=1, r ≡ −1 mod n, J(−n|r)=1), Dirichlet's theorem yields arbitrarily large multiplier primes p = d·n − 1 for which the QR hypothesis holds outright. (3) A sharp obstruction: for n = 3 no multiplier prime satisfies legendreSym p (−3) = 1, even though 3 = 1²+1²+1² — so the naive −n-multiplier route cannot certify representability, and a qualifying class exists iff n avoids Legendre's excluded form 4^a(8b+7).",
+  "overview": {
+    "historicalContext": "Legendre's three-square theorem (1798) characterizes the integers representable as x²+y²+z² as exactly those not of the form 4^a(8b+7). One classical route to sufficiency multiplies the target by a well-chosen prime to reduce to a previously handled case, but it requires a quadratic-residue side condition. The parent slice oq-03-oq-07 collapsed that condition on the multiplier d to a condition on n alone, legendreSym p (−n) = 1 for a prime p = d·n − 1, and asserted in prose — by quadratic reciprocity — that this depends only on p mod 4n. Quadratic reciprocity (Gauss) and Dirichlet's theorem on primes in arithmetic progressions (1837) are exactly the classical tools needed to turn that assertion into a genuine fixed-target selection problem. This entry supplies the missing periodicity fact, makes the selection unconditional once a qualifying class exists, and — most honestly — exhibits n = 3 where no qualifying class exists at all, pinning the true open content to the genus condition itself.",
+    "problemStatement": "Establish three things about the −n-multiplier route to Legendre's three-square sufficiency. (1) Prove that the quadratic-residue condition legendreSym p (−n) = 1 is invariant on residue classes p mod 4n (the parent's unproved prose claim). (2) Given a residue r with gcd(r,4n)=1, r ≡ −1 (mod n), and J(−n | r) = 1, produce, for every bound N, a prime p > N of multiplier shape p = d·n − 1 with legendreSym p (−n) = 1 (and hence legendreSym p (−d) = 1) holding unconditionally. (3) Determine whether such a qualifying residue r always exists — and show it does NOT at n = 3, where every multiplier prime forces legendreSym p (−3) = −1.",
+    "proofStrategy": "§1 Periodicity: bridge the Legendre symbol to the Jacobi symbol via legendreSym.to_jacobiSym, then invoke jacobiSym.mod_right (J(a|b) depends on b only mod 4|a|) to get legendreSym_eq_of_prime_modeq for odd primes agreeing mod 4|a|; specialize to a = −n. §2 Supply: transport the QR value through a Dirichlet residue class (legendreSym_neg_eq_of_modEq, where the second argument need only be odd, not prime), then feed Nat.forall_exists_prime_gt_and_modEq with modulus 4n to extract a prime p ≡ r (mod 4n); p ≡ −1 (mod n) gives the multiplier shape and §1 forces the QR value to J(−n|r) = 1. Route through the parent reduction for the d-condition. Non-vacuous at n=2, r=3 (decide/norm_num). §3 Obstruction: every multiplier prime for n=3 has p ≡ 2 (mod 3); combined with oddness this forces p mod 12 ∈ {5,11}, where norm_num's reciprocity extension evaluates J(−3 | ·) = −1 — so the QR hypothesis fails for all multiplier primes despite 3 = 1²+1²+1².",
+    "keyInsights": [
+      "The QR side condition is a residue-class invariant, not a per-prime accident: legendreSym p (−n) = 1 depends only on p mod 4n. This is the precise fact (a Mathlib gap for the Legendre-symbol-in-the-prime) that turns multiplier selection into a fixed-target Dirichlet problem, exactly as the parent claimed but did not prove.",
+      "Dirichlet's theorem converts a single qualifying residue class into an unconditional infinite supply: once one r with J(−n|r)=1, r ≡ −1 (mod n), gcd(r,4n)=1 exists, every bound N is beaten by a multiplier prime whose QR hypothesis holds outright — the parent's conditional reduction becomes an unconditional production.",
+      "The entire residual difficulty is isolated into one statement — the existence of a qualifying residue r — and everything around it is discharged unconditionally. This is the value of the reduction: it names the genuine open content precisely.",
+      "The n = 3 obstruction is a sharp negative result: 3 is manifestly a sum of three squares, yet NO multiplier prime certifies it via the −n-route, because p ≡ 2 (mod 3) forces legendreSym p (−3) = −1. The naive residue condition is provably insufficient; the classical proof must refine the sign/residue analysis.",
+      "Existence of a qualifying class is equivalent to the genus condition itself: a qualifying r exists iff n is not of Legendre's excluded form 4^a(8b+7). So the reduction does not trivialize the theorem — it relocates the whole difficulty to the genus condition, with n = 3 the first concrete witness of non-existence.",
+      "Methodologically: a real Dirichlet character J(−n | ·) restricted to the coset p ≡ −1 (mod n) governs everything, and the proof keeps the symbol computations 0-axiom by using norm_num's reciprocity extension rather than native_decide — preserving propext/Classical.choice/Quot.sound as the only axioms."
+    ]
+  },
+  "sections": [
+    {
+      "id": "periodicity",
+      "title": "§1 Periodicity of the Legendre Symbol in the Prime",
+      "startLine": 87,
+      "endLine": 109,
+      "summary": "legendreSym_eq_of_prime_modeq: for odd primes p ≡ q (mod 4|a|), legendreSym p a = legendreSym q a, obtained by passing through legendreSym.to_jacobiSym and jacobiSym.mod_right — the Legendre-symbol-in-the-prime counterpart Mathlib lacks. qr_condition_class_invariant specializes the iff form, confirming the QR hypothesis depends only on p mod 4n.",
+      "mathContext": "p ≡ q (mod 4|a|) ⟹ legendreSym p a = legendreSym q a; specialized to a = −n it is a condition on p mod 4n."
+    },
+    {
+      "id": "supply",
+      "title": "§2 Unconditional Supply from a Qualifying Residue Class",
+      "startLine": 111,
+      "endLine": 201,
+      "summary": "legendreSym_neg_eq_of_modEq transports the QR value across a Dirichlet residue class (the residue r need only be odd). exists_qr_qualified_multiplier_prime then uses Nat.forall_exists_prime_gt_and_modEq (modulus 4n) to produce, for every N, a prime p > N of shape p = d·n − 1 with legendreSym p (−n) = 1 forced; …_full additionally forces legendreSym p (−d) = 1 via the parent reduction. qr_qualified_multiplier_prime_two witnesses non-vacuousness at n=2, r=3.",
+      "mathContext": "Given r with gcd(r,4n)=1, r ≡ −1 (mod n), J(−n|r)=1: ∀N ∃ prime p>N, p=d·n−1, legendreSym p (−n)=1."
+    },
+    {
+      "id": "obstruction",
+      "title": "§3 A Sharp Obstruction at n = 3",
+      "startLine": 203,
+      "endLine": 242,
+      "summary": "legendreSym_neg_three_eq_neg_one: every odd prime p ≡ 2 (mod 3) has legendreSym p (−3) = −1 (forced onto p mod 12 ∈ {5,11}). multiplier_prime_neg_three_qr_fails applies it to multiplier primes p = 3d − 1. multiplier_route_incomplete_at_three is the honest capstone: 3 = 1²+1²+1² yet no multiplier prime satisfies legendreSym p (−3) = 1 — the qualifying class of §2 does not exist at n = 3.",
+      "mathContext": "n=3: p ≡ 2 (mod 3) ⟹ legendreSym p (−3) = −1; no multiplier prime certifies 3 via the −n-route."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -84,7 +124,15 @@
     }
   ],
   "crossReferences": [
-    "lagrange-four-squares-waring-g2-oq-03-oq-07",
-    "lagrange-four-squares-waring-g2-oq-03"
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+      "relationship": "extends",
+      "description": "Direct follow-up to the multiplier–quadratic-residue reduction. The parent collapsed the geometry's QR hypothesis on the multiplier d to a hypothesis on n (legendreSym p (−n) = 1 for p = d·n − 1) but only asserted in prose that this depends on p mod 4n. This entry proves that periodicity, upgrades the conditional reduction to an unconditional supply via Dirichlet, and exhibits the obstruction at n = 3 that explains why the parent's geometry is established only for d ∈ {1,2}."
+    },
+    {
+      "targetId": "lagrange-four-squares-waring-g2-oq-03",
+      "relationship": "related",
+      "description": "Part of the Lagrange/Waring g(2)=4 three-square program: where the umbrella entry frames sufficiency for the non-excluded form, this slice analyses the multiplier-prime selection layer and pins its open content to the genus condition n ≠ 4^a(8b+7)."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01` (Legendre three-square / Waring g(2)=4 multiplier-QR selection lineage). The entry had only meta.json with originalContributions, conclusion and openQuestions — no annotations, overview, or sections.

## Added
- **annotations.json** — 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: §1 periodicity of the Legendre symbol in the prime, the residue-class value transport, §2 the unconditional Dirichlet supply (+ n=2 non-vacuousness), and §3 the n=3 obstruction value and honest capstone.
- **overview** — historicalContext (Legendre/Gauss/Dirichlet framing), problemStatement, proofStrategy (§1→§2→§3 mechanics), and 6 keyInsights.
- **sections** — 3 sections spanning lines 87–242 of the Lean file.
- **description** — top-level summary.
- Migrated legacy string-array `crossReferences` to the canonical `{targetId, relationship, description}` object form.

## Integrity
status `verified` / badge `original` / axiomCount 0 confirmed against the Lean source (0 axiom, 0 sorry, no native_decide — symbol evaluations use norm_num's reciprocity extension). `pnpm build` passes.