### PR TITLE
Enrich Beta integral: recurrence and the integer closed form

### DIFF
--- a/src/data/proofs/beta-integral-recurrence-oq-01/annotations.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "recurrence",
+    "proofId": "beta-integral-recurrence-oq-01",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "concept",
+    "title": "The Beta Parameter Recurrence",
+    "content": "beta_recurrence re-exports Mathlib's Complex.betaIntegral_recurrence: u·B(u, v+1) = v·B(u+1, v) for Re u, Re v > 0. This functional equation is the Beta-function analogue of the Gamma recurrence Γ(z+1) = z·Γ(z) — it relates Beta values at neighbouring parameter points and, iterated from a base value, determines the Beta function on a lattice. It is the headline identity the entry advertises; the closed form is its destination.",
+    "mathContext": "$u\\,B(u, v+1) = v\\,B(u+1, v)$ for $\\operatorname{Re} u, \\operatorname{Re} v > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Beta function", "functional equation", "Gamma recurrence", "Euler integral"],
+    "prerequisites": ["Beta integral", "complex analysis"]
+  },
+  {
+    "id": "integer-closed-form",
+    "proofId": "beta-integral-recurrence-oq-01",
+    "range": { "startLine": 59, "endLine": 77 },
+    "type": "insight",
+    "title": "The Symmetric Integer Closed Form",
+    "content": "betaIntegral_nat_nat is the centerpiece: B(m+1, n+1) = m!·n!/(m+n+1)! for all m, n : ℕ. Mathlib records only the ASYMMETRIC one-sided evaluation B(u, n+1) = n!/∏(u+j); this symmetric two-integer value is not in Mathlib. The proof feeds both integer arguments through the Beta–Gamma relation B(u,v) = Γu·Γv/Γ(u+v), rewrites the denominator argument (m+1)+(n+1) as (m+n+1)+1, and collapses all three Gamma values to factorials via Complex.Gamma_nat_eq_factorial (Γ(k+1) = k!). The positivity side-conditions on the real parts are discharged by positivity.",
+    "mathContext": "$B(m+1, n+1) = \\dfrac{m!\\,n!}{(m+n+1)!}$, from $B(u,v) = \\dfrac{\\Gamma u\\,\\Gamma v}{\\Gamma(u+v)}$ with $\\Gamma(k+1) = k!$.",
+    "significance": "key",
+    "relatedConcepts": ["Beta–Gamma relation", "factorial", "Gamma function", "binomial coefficients"],
+    "prerequisites": ["Gamma function", "Beta–Gamma relation"]
+  },
+  {
+    "id": "symmetry",
+    "proofId": "beta-integral-recurrence-oq-01",
+    "range": { "startLine": 79, "endLine": 85 },
+    "type": "technique",
+    "title": "Symmetry on the Integer Lattice",
+    "content": "betaIntegral_nat_nat_symm reads off B(m+1, n+1) = B(n+1, m+1) directly from the closed form, whose right-hand side m!·n!/(m+n+1)! is manifestly symmetric under m ↔ n (using Nat.add_comm in the denominator). The Beta function's general symmetry B(u,v) = B(v,u) reflects the substitution t ↦ 1−t in the defining integral; here it becomes the visible algebraic symmetry of a factorial quotient.",
+    "mathContext": "$B(m+1, n+1) = B(n+1, m+1)$, the $m \\leftrightarrow n$ symmetry of $m!\\,n!/(m+n+1)!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetry of the Beta function", "substitution t ↦ 1−t", "factorial symmetry"],
+    "prerequisites": ["the integer closed form"]
+  },
+  {
+    "id": "concrete-values",
+    "proofId": "beta-integral-recurrence-oq-01",
+    "range": { "startLine": 87, "endLine": 103 },
+    "type": "context",
+    "title": "Concrete Evaluations",
+    "content": "betaIntegral_one_one, betaIntegral_two_three, betaIntegral_three_three machine-check B(1,1) = 1, B(2,3) = 1/12, B(3,3) = 1/30 by instantiating the closed form at m,n ∈ {0,1,2} and simplifying with norm_num [Nat.factorial] + linear_combination. B(1,1) = 1 is the integral of the constant 1 over [0,1]; the others are exact rational areas under tᵐ(1−t)ⁿ. These ground the abstract closed form in checkable arithmetic.",
+    "mathContext": "$B(1,1) = 1$, $B(2,3) = 1/12$, $B(3,3) = 1/30$ — instances of $m!\\,n!/(m+n+1)!$.",
+    "significance": "context",
+    "relatedConcepts": ["definite integrals", "rational areas", "norm_num"],
+    "prerequisites": ["the integer closed form"]
+  }
+]

--- a/src/data/proofs/beta-integral-recurrence-oq-01/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01/meta.json
@@ -65,6 +65,52 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The Beta integral B(u,v) = ∫₀¹ t^(u−1)(1−t)^(v−1) dt was studied by Euler and Legendre in the 18th–19th centuries as the 'Eulerian integral of the first kind' (the Gamma function being the second kind). Its defining relation to Gamma, B(u,v) = Γ(u)Γ(v)/Γ(u+v), makes it the continuous interpolation of the reciprocal binomial coefficients: B(m+1,n+1) = m!·n!/(m+n+1)! = 1/((m+n+1)·C(m+n,m)). The Beta function is ubiquitous — it is the normalizing constant of the Beta probability distribution (conjugate prior to the binomial in Bayesian statistics), it appears in the Veneziano amplitude that launched string theory, and its half-integer values encode the volumes of balls and the arcsine law. The parameter recurrence u·B(u,v+1) = v·B(u+1,v) is the analogue of the Gamma recurrence and, with the Beta–Gamma relation, determines the function on the integer lattice. Mathlib has the recurrence, the Beta–Gamma relation, and the one-sided integer evaluation, but not the symmetric two-integer factorial closed form; this entry supplies it.",
+    "problemStatement": "Starting from Mathlib's Beta parameter recurrence u·B(u,v+1) = v·B(u+1,v) and the Beta–Gamma relation B(u,v) = Γ(u)Γ(v)/Γ(u+v), establish the symmetric two-integer closed form B(m+1,n+1) = m!·n!/(m+n+1)! for all m, n : ℕ (which Mathlib records only in the asymmetric one-argument form B(u,n+1) = n!/∏(u+j)), read off the integer-lattice symmetry B(m+1,n+1) = B(n+1,m+1), and instantiate concrete values B(1,1) = 1, B(2,3) = 1/12, B(3,3) = 1/30.",
+    "proofStrategy": "beta_recurrence re-exports Complex.betaIntegral_recurrence. The centerpiece betaIntegral_nat_nat rewrites B(m+1,n+1) with the Beta–Gamma relation betaIntegral_eq_Gamma_mul_div (real parts positive, via positivity), rewrites the summed argument (m+1)+(n+1) as (m+n+1)+1 (push_cast; ring), and collapses each of the three Gamma values Γ(m+1), Γ(n+1), Γ(m+n+2) to factorials with Complex.Gamma_nat_eq_factorial. betaIntegral_nat_nat_symm reads the m ↔ n symmetry off the factorial quotient (Nat.add_comm). The numeric corollaries instantiate the closed form at small m, n and finish with norm_num [Nat.factorial] and linear_combination.",
+    "keyInsights": [
+      "The Beta function interpolates reciprocal binomial coefficients: B(m+1,n+1) = m!·n!/(m+n+1)! = 1/((m+n+1)·C(m+n,m)). The closed form is thus the continuous shadow of the discrete binomial world, the bridge the entry makes explicit.",
+      "The factorial value is bought entirely through Gamma: each integer Beta value becomes Γ(m+1)Γ(n+1)/Γ(m+n+2), and Γ(k+1) = k! turns the three Gamma factors into the factorial quotient. No integration is performed — the Beta–Gamma relation does all the work.",
+      "Symmetry B(u,v) = B(v,u) comes from the substitution t ↦ 1−t in the integral, but on the integer lattice it is simply the visible m ↔ n symmetry of m!·n!/(m+n+1)! — a clean illustration of an analytic symmetry becoming algebraic after evaluation.",
+      "Mathlib's gap is real and specific: it has the asymmetric one-argument evaluation B(u,n+1) = n!/∏(u+j) but not the symmetric two-integer form, so deriving the latter (and its numeric instances) is genuine added content over the library.",
+      "The 'mathlib' badge is honest: the recurrence and Beta–Gamma relation are imported deep theorems; the original content is the symmetric closed form and the Gamma-to-factorial collapse, packaging the textbook 'Beta of two integers' value in machine-checked form."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Recurrence and Integer Closed Form",
+      "startLine": 4,
+      "endLine": 43,
+      "summary": "States the Beta integral, its parameter recurrence u·B(u,v+1) = v·B(u+1,v) (Mathlib), and the Beta–Gamma relation, then announces the centerpiece B(m+1,n+1) = m!·n!/(m+n+1)!. Explains Mathlib has only the asymmetric one-argument evaluation, and outlines the derivation (Beta–Gamma + Gamma_nat_eq_factorial) and the numeric corollaries.",
+      "mathContext": "$B(u,v) = \\int_0^1 t^{u-1}(1-t)^{v-1}\\,dt$; goal $B(m+1,n+1) = m!\\,n!/(m+n+1)!$."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Beta Recurrence",
+      "startLine": 49,
+      "endLine": 57,
+      "summary": "beta_recurrence re-exports Complex.betaIntegral_recurrence: u·B(u,v+1) = v·B(u+1,v) for Re u, Re v > 0 — the headline functional equation, analogue of the Gamma recurrence.",
+      "mathContext": "$u\\,B(u,v+1) = v\\,B(u+1,v)$."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Integer Closed Form and Symmetry",
+      "startLine": 59,
+      "endLine": 85,
+      "summary": "betaIntegral_nat_nat: B(m+1,n+1) = m!·n!/(m+n+1)!, via betaIntegral_eq_Gamma_mul_div, the argument rewrite (m+1)+(n+1) = (m+n+1)+1, and Gamma_nat_eq_factorial on all three Gamma values. betaIntegral_nat_nat_symm: B(m+1,n+1) = B(n+1,m+1), the m ↔ n symmetry of the closed form.",
+      "mathContext": "$B(m+1,n+1) = \\dfrac{m!\\,n!}{(m+n+1)!} = B(n+1,m+1)$."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Evaluations",
+      "startLine": 87,
+      "endLine": 103,
+      "summary": "betaIntegral_one_one (B(1,1)=1), betaIntegral_two_three (B(2,3)=1/12), betaIntegral_three_three (B(3,3)=1/30): instances of the closed form at small m, n, finished by norm_num [Nat.factorial] and linear_combination.",
+      "mathContext": "$B(1,1)=1,\\ B(2,3)=1/12,\\ B(3,3)=1/30$."
+    }
+  ],
   "openQuestions": [
     {
       "id": "beta-integral-recurrence-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `beta-integral-recurrence-oq-01`.

The entry had `conclusion`/`openQuestions`/`crossReferences`/`references`/`meta` but no `overview`, `sections`, or `annotations.json`.

## Changes
- **overview** (new): `historicalContext` (Euler/Legendre Eulerian integral, Beta distribution, Veneziano amplitude), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 4 sections covering the full file.
- **annotations.json** (new): 4 annotations with full schema.
- Preserved all existing fields.

## Axiom integrity
0 sorries, 0 axiom declarations, no `native_decide`. `status: verified`, `badge: mathlib` (recurrence + Beta–Gamma relation from Mathlib; the symmetric integer closed form is the original content) preserved accurately. `pnpm build` passes.