### PR TITLE
Enrich arsinh: logarithmic form and addition law

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "closed-log-form",
+    "proofId": "arsinh-log-formula-oq-01",
+    "range": { "startLine": 32, "endLine": 40 },
+    "type": "definition",
+    "title": "The Closed Logarithmic Form",
+    "content": "arsinh_eq_log names the closed form arsinh x = log(x + √(1 + x²)) — proved by rfl, since this is exactly Mathlib's definition of Real.arsinh, but recorded as a stable named lemma for downstream rewriting. exp_arsinh' re-exports the exponential form exp(arsinh x) = x + √(1 + x²). The logarithmic form is what makes arsinh elementary: unlike a black-box special function, every value is a logarithm of a surd, so concrete evaluations reduce to arithmetic.",
+    "mathContext": "$\\operatorname{arsinh} x = \\log\\bigl(x + \\sqrt{1 + x^2}\\bigr)$; equivalently $e^{\\operatorname{arsinh} x} = x + \\sqrt{1+x^2}$.",
+    "significance": "key",
+    "relatedConcepts": ["inverse hyperbolic sine", "logarithm", "hyperbolic functions", "closed form"],
+    "prerequisites": ["hyperbolic functions", "logarithms"]
+  },
+  {
+    "id": "inverse-pair-pythagorean",
+    "proofId": "arsinh-log-formula-oq-01",
+    "range": { "startLine": 42, "endLine": 56 },
+    "type": "concept",
+    "title": "Inverse-Pair and Pythagorean Companion",
+    "content": "sinh_arsinh' and arsinh_sinh' re-export the inverse-pair identities sinh(arsinh x) = x and arsinh(sinh x) = x (arsinh is the genuine inverse of the bijective sinh). cosh_arsinh' is the Pythagorean companion cosh(arsinh x) = √(1 + x²), from cosh² − sinh² = 1 with cosh > 0. arsinh_neg' records oddness arsinh(−x) = −arsinh x. These supply the API the addition law is assembled from: the inverse pair converts statements about arsinh into statements about sinh, and the Pythagorean companion supplies the cosh factors.",
+    "mathContext": "$\\sinh(\\operatorname{arsinh} x) = x$, $\\cosh(\\operatorname{arsinh} x) = \\sqrt{1+x^2}$, $\\operatorname{arsinh}(-x) = -\\operatorname{arsinh} x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["inverse functions", "Pythagorean identity", "odd functions", "cosh/sinh"],
+    "prerequisites": ["hyperbolic functions"]
+  },
+  {
+    "id": "addition-law",
+    "proofId": "arsinh-log-formula-oq-01",
+    "range": { "startLine": 58, "endLine": 71 },
+    "type": "insight",
+    "title": "The Addition Law",
+    "content": "arsinh_add is the headline new result: arsinh x + arsinh y = arsinh(x·√(1+y²) + y·√(1+x²)), the inverse-hyperbolic analogue of the arctangent addition formula, absent from Mathlib. The proof applies arsinh∘sinh = id to the left side (Real.arsinh_sinh), then expands sinh(arsinh x + arsinh y) via the hyperbolic addition formula sinh_add = sinh a cosh b + cosh a sinh b, substituting sinh(arsinh ·) = · and cosh(arsinh ·) = √(1+·²); ring finishes. This is exactly the rapidity-addition structure: arsinh of momentum is (up to constants) the relativistic rapidity, which adds when velocities compose.",
+    "mathContext": "$\\operatorname{arsinh} x + \\operatorname{arsinh} y = \\operatorname{arsinh}\\bigl(x\\sqrt{1+y^2} + y\\sqrt{1+x^2}\\bigr)$.",
+    "significance": "key",
+    "relatedConcepts": ["addition formula", "arctangent analogue", "rapidity (special relativity)", "sinh_add"],
+    "prerequisites": ["hyperbolic addition formula", "the inverse-pair identities"]
+  },
+  {
+    "id": "subtraction-doubling",
+    "proofId": "arsinh-log-formula-oq-01",
+    "range": { "startLine": 73, "endLine": 88 },
+    "type": "technique",
+    "title": "Subtraction and Doubling Corollaries",
+    "content": "arsinh_sub derives the subtraction law arsinh x − arsinh y = arsinh(x·√(1+y²) − y·√(1+x²)) from the addition law and oddness (sub_eq_add_neg + arsinh_neg, with neg_sq absorbing the (−y)² in the surd). two_arsinh is the diagonal doubling law 2·arsinh x = arsinh(2x·√(1+x²)) from arsinh_add with y = x. Together they complete the elementary calculus of arsinh, mirroring the standard add/sub/double identities of the circular and inverse-circular functions.",
+    "mathContext": "$\\operatorname{arsinh} x - \\operatorname{arsinh} y = \\operatorname{arsinh}(x\\sqrt{1+y^2} - y\\sqrt{1+x^2})$; $2\\operatorname{arsinh} x = \\operatorname{arsinh}(2x\\sqrt{1+x^2})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["subtraction formula", "double-angle analogue", "oddness", "corollaries"],
+    "prerequisites": ["the addition law"]
+  },
+  {
+    "id": "concrete-values",
+    "proofId": "arsinh-log-formula-oq-01",
+    "range": { "startLine": 90, "endLine": 106 },
+    "type": "context",
+    "title": "Concrete Closed-Form Values",
+    "content": "arsinh_three_quarters (arsinh(3/4) = log 2) and arsinh_four_thirds (arsinh(4/3) = log 3) exhibit the closed form on rational arguments coming from Pythagorean triples: √(1+(3/4)²) = 5/4 so 3/4 + 5/4 = 2, and √(1+(4/3)²) = 5/3 so 4/3 + 5/3 = 3. Each reduces via arsinh_eq_log + Real.sqrt_sq + norm_num to a clean logarithm — concrete evidence that the logarithmic form turns special-function values into elementary arithmetic.",
+    "mathContext": "$\\operatorname{arsinh}(3/4) = \\log 2$, $\\operatorname{arsinh}(4/3) = \\log 3$, from the $(3,4,5)$ Pythagorean triple.",
+    "significance": "context",
+    "relatedConcepts": ["Pythagorean triples", "logarithmic values", "Real.sqrt_sq", "norm_num"],
+    "prerequisites": ["the closed logarithmic form"]
+  }
+]

--- a/src/data/proofs/arsinh-log-formula-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01/meta.json
@@ -75,6 +75,52 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The inverse hyperbolic functions arose alongside the hyperbolic functions themselves, introduced by Vincenzo Riccati and Johann Heinrich Lambert in the 18th century. Their defining feature is that, unlike the inverse circular functions, they have elementary closed forms in terms of logarithms and square roots: arsinh x = log(x + √(1 + x²)). This logarithmic form is far more than a curiosity — arsinh is the antiderivative of 1/√(1 + x²) (so it computes the arc length of the catenary y = cosh x and appears in countless integration tables), and it is the function that linearizes the relativistic velocity-addition law: the rapidity φ = arsinh(p/mc) adds when collinear velocities compose, which is exactly the addition law proved here. The inverse hyperbolic sine also underlies the Box–Cox-like asinh data transform in statistics (a signed log that handles zero and negative values). Mathlib defines Real.arsinh by its logarithmic form and supplies the inverse-pair and Pythagorean identities, but records neither a named closed-form lemma nor the addition calculus; this entry adds both, introducing the arsinh domain to the gallery (previously only arctanh appeared).",
+    "problemStatement": "For Real.arsinh, give the logarithmic closed form as a named lemma (arsinh x = log(x + √(1 + x²))) and develop its addition calculus: the addition law arsinh x + arsinh y = arsinh(x·√(1+y²) + y·√(1+x²)) (the inverse-hyperbolic analogue of arctan's addition formula, absent from Mathlib), the subtraction and doubling corollaries, and concrete closed-form values arsinh(3/4) = log 2 and arsinh(4/3) = log 3.",
+    "proofStrategy": "arsinh_eq_log is rfl against Mathlib's definition; the supporting identities (sinh_arsinh, arsinh_sinh, cosh_arsinh, arsinh_neg) are re-exported. The addition law arsinh_add is the crux: rewrite the left side as arsinh(sinh(arsinh x + arsinh y)) using arsinh_sinh, then expand sinh(arsinh x + arsinh y) by the hyperbolic addition formula sinh_add and substitute sinh(arsinh ·) = · and cosh(arsinh ·) = √(1+·²), with ring closing the algebra. arsinh_sub follows from arsinh_add via oddness (sub_eq_add_neg, arsinh_neg, neg_sq); two_arsinh is the y = x diagonal. The concrete values use arsinh_eq_log, evaluate the surd via Real.sqrt_sq on a perfect-square rewrite (norm_num), and simplify the resulting argument to 2 or 3.",
+    "keyInsights": [
+      "The logarithmic closed form is what distinguishes inverse hyperbolic from inverse circular functions: arcsin has no elementary closed form, but arsinh x = log(x + √(1+x²)) is built from log and √ — so its values are elementary and its addition law is provable by pure algebra.",
+      "The addition law IS relativistic rapidity addition. Writing rapidity φ = arsinh(p), the identity arsinh x + arsinh y = arsinh(x√(1+y²) + y√(1+x²)) is exactly how rapidities (hence collinear velocities, via tanh) compose — the hyperbolic mirror of how angles add under rotation.",
+      "Everything is bootstrapped from one expansion: applying the inverse pair arsinh∘sinh = id and the hyperbolic addition formula sinh_add, with the Pythagorean companion cosh(arsinh x) = √(1+x²) supplying the cosh factors. Subtraction and doubling are then free corollaries via oddness and the diagonal.",
+      "Concrete values come from Pythagorean triples: 1 + (3/4)² = (5/4)² gives arsinh(3/4) = log(3/4 + 5/4) = log 2. The (3,4,5) triple makes the surd rational, turning a special-function value into a clean logarithm — a vivid demonstration of the closed form's power.",
+      "The 'mathlib' badge is honest: the closed form is the definition unfolded (rfl), but the addition / subtraction / doubling calculus and the concrete logarithmic values are genuinely new, none recorded by Mathlib, and they bring the inverse hyperbolic sine to a gallery that previously had only arctanh."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: arsinh Logarithmic Form and Addition Law",
+      "startLine": 3,
+      "endLine": 26,
+      "summary": "States arsinh x = log(x + √(1 + x²)) (Mathlib's definition), lists what Mathlib provides (inverse-pair, Pythagorean, exponential form) and what it lacks (named closed form, addition/subtraction/doubling laws, concrete values). Notes the headline is rfl (mathlib badge) while the addition calculus and rational values are new, introducing arsinh to a gallery that previously had only arctanh.",
+      "mathContext": "$\\operatorname{arsinh} x = \\log(x + \\sqrt{1+x^2})$, antiderivative of $1/\\sqrt{1+x^2}$, inverse of $\\sinh$."
+    },
+    {
+      "id": "closed-form-and-api",
+      "title": "Closed Form and Supporting Identities",
+      "startLine": 32,
+      "endLine": 56,
+      "summary": "arsinh_eq_log (the named closed form, rfl) and exp_arsinh' (exponential form). Re-exports of the inverse pair sinh_arsinh' / arsinh_sinh', the Pythagorean companion cosh_arsinh' (= √(1+x²)), and oddness arsinh_neg' — the API the addition law is built on.",
+      "mathContext": "$\\sinh(\\operatorname{arsinh} x) = x$, $\\cosh(\\operatorname{arsinh} x) = \\sqrt{1+x^2}$, $\\operatorname{arsinh}(-x) = -\\operatorname{arsinh} x$."
+    },
+    {
+      "id": "addition-calculus",
+      "title": "The Addition Law and Corollaries",
+      "startLine": 58,
+      "endLine": 88,
+      "summary": "arsinh_add: arsinh x + arsinh y = arsinh(x√(1+y²) + y√(1+x²)), via arsinh_sinh + sinh_add + the inverse-pair/Pythagorean substitutions + ring. arsinh_sub (from oddness) and two_arsinh (the y = x diagonal) follow as corollaries.",
+      "mathContext": "$\\operatorname{arsinh} x \\pm \\operatorname{arsinh} y = \\operatorname{arsinh}(x\\sqrt{1+y^2} \\pm y\\sqrt{1+x^2})$; $2\\operatorname{arsinh} x = \\operatorname{arsinh}(2x\\sqrt{1+x^2})$."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Closed-Form Values",
+      "startLine": 90,
+      "endLine": 106,
+      "summary": "arsinh_three_quarters (arsinh(3/4) = log 2) and arsinh_four_thirds (arsinh(4/3) = log 3), from the (3,4,5) Pythagorean triple making √(1+x²) rational, via arsinh_eq_log + Real.sqrt_sq + norm_num.",
+      "mathContext": "$\\operatorname{arsinh}(3/4) = \\log 2$, $\\operatorname{arsinh}(4/3) = \\log 3$."
+    }
+  ],
   "openQuestions": [
     {
       "id": "arsinh-log-formula-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01`.

The entry had `conclusion`/`openQuestions`/`crossReferences`/`references`/`meta` but no `overview`, `sections`, or `annotations.json`.

## Changes
- **overview** (new): `historicalContext` (Riccati/Lambert inverse hyperbolics, catenary, relativistic rapidity addition), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 4 sections covering the full file.
- **annotations.json** (new): 5 annotations with full schema.
- Preserved all existing fields.

## Axiom integrity
0 sorries, 0 axiom declarations, no `native_decide`. `status: verified`, `badge: mathlib` (closed form is the definition unfolded; the addition/subtraction/doubling calculus and concrete values are the original content) preserved accurately. `pnpm build` passes.