### PR TITLE
Enrich ∛3 degree-3 entry: fix overview/conclusion rendering + add annotations

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-03/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "inherited-facts",
+    "proofId": "cube-root-3-irrational-oq-03",
+    "range": { "startLine": 44, "endLine": 48 },
+    "type": "context",
+    "title": "Inherited Facts from the Parent",
+    "content": "`cbrt3_pow_three` ((∛3)³ = 3) and `cbrt3_irrational` (∛3 ∉ ℚ) are re-exposed from the parent file CubeRoot3Irrational via the imported cbrt3, cbrt3_cubed, irrational_cbrt3. These are the only external inputs: the parent establishes ∛3 as a genuine real cube root of 3 and proves its irrationality, and this entry builds the entire degree-3 algebraic theory on top.",
+    "mathContext": "$(\\sqrt[3]{3})^3 = 3$ and $\\sqrt[3]{3}\\notin\\mathbb{Q}$, inherited from the parent.",
+    "significance": "context",
+    "relatedConcepts": ["cube root", "irrationality", "inherited lemmas"],
+    "prerequisites": ["real analysis", "irrationality"]
+  },
+  {
+    "id": "no-rational-cube",
+    "proofId": "cube-root-3-irrational-oq-03",
+    "range": { "startLine": 50, "endLine": 67 },
+    "type": "technique",
+    "title": "The Single Arithmetic Input: 3 Has No Rational Cube Root",
+    "content": "`no_rat_cube_three`: q³ ≠ 3 for all q ∈ ℚ — the one fact that carries the whole development. The proof casts a hypothetical rational q with q³ = 3 to ℝ, observes (q:ℝ)³ = (∛3)³, and applies injectivity of the odd power map x ↦ x³ on ℝ (Odd.strictMono_pow.injective) to force (q:ℝ) = ∛3, contradicting irrational_cbrt3. The bridge from a real-analytic irrationality fact to the algebraic no-root hypothesis is exactly this injectivity. `no_rat_cube_neg_three` handles −3 by negation.",
+    "mathContext": "$\\forall q\\in\\mathbb{Q},\\ q^3\\neq 3$; proved via injectivity of $x\\mapsto x^3$ on $\\mathbb{R}$.",
+    "significance": "critical",
+    "relatedConcepts": ["rational root", "strict monotonicity", "odd power injectivity", "Odd.strictMono_pow"],
+    "prerequisites": ["real analysis", "monotone functions", "rational/real casts"]
+  },
+  {
+    "id": "irreducibility",
+    "proofId": "cube-root-3-irrational-oq-03",
+    "range": { "startLine": 69, "endLine": 88 },
+    "type": "theorem",
+    "title": "X³ − 3 Is Irreducible over ℚ",
+    "content": "`irreducible_X_cubed_sub_C_three`: X³ − 3 is irreducible over ℚ. For polynomials of degree ≤ 3 over a field, irreducibility is equivalent to having no root — a nontrivial factorization would need a linear factor. The polynomial has natDegree 3 ∈ [1,3], and its evaluation x³ − 3 is nonzero at every rational x by exactly no_rat_cube_three, so Mathlib's irreducible_of_degree_le_three_of_not_isRoot applies directly. `cbrt3_isIntegral` records that ∛3 is integral over ℚ (a root of the monic X³ − 3).",
+    "mathContext": "$X^3-3$ irreducible over $\\mathbb{Q}$: degree $\\le 3$ with no rational root $\\Rightarrow$ irreducible.",
+    "significance": "key",
+    "relatedConcepts": ["irreducible polynomial", "degree-≤3 criterion", "Eisenstein at 3", "no rational root"],
+    "prerequisites": ["polynomial irreducibility", "field theory"]
+  },
+  {
+    "id": "minpoly-and-degree",
+    "proofId": "cube-root-3-irrational-oq-03",
+    "range": { "startLine": 90, "endLine": 101 },
+    "type": "theorem",
+    "title": "Minimal Polynomial and Field Degree [ℚ(∛3):ℚ] = 3",
+    "content": "`minpoly_cbrt3`: since ∛3 is a root of the monic irreducible X³ − 3, Mathlib's minpoly.eq_of_irreducible_of_monic identifies minpoly ℚ ∛3 = X³ − 3. `finrank_adjoin_cbrt3`: the simple-extension dimension formula IntermediateField.adjoin.finrank gives [ℚ(∛3) : ℚ] = Module.finrank ℚ ℚ⟮cbrt3⟯ = natDegree(X³ − 3) = 3. This is the sharp degree statement upgrading the parent's irrationality.",
+    "mathContext": "$\\mathrm{minpoly}_{\\mathbb{Q}}(\\sqrt[3]{3})=X^3-3$ and $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}]=3$.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "field extension degree", "simple extension", "IntermediateField.adjoin.finrank"],
+    "prerequisites": ["field extensions", "minimal polynomial", "linear algebra"]
+  },
+  {
+    "id": "linindep-elementary",
+    "proofId": "cube-root-3-irrational-oq-03",
+    "range": { "startLine": 103, "endLine": 160 },
+    "type": "theorem",
+    "title": "Linear Independence of {1, ∛3, (∛3)²} (Elementary Form)",
+    "content": "`linindep_triple`: a self-contained elimination showing a + b∛3 + c(∛3)² = 0 (a,b,c ∈ ℚ) forces a = b = c = 0. Multiplying the relation by ∛3 and reducing (∛3)³ = 3 gives a second relation; eliminating (∛3)² yields (ac − b²)∛3 = ab − 3c². If ac − b² ≠ 0 then ∛3 = (ab − 3c²)/(ac − b²) ∈ ℚ — contradiction; if ac − b² = 0 then ab = 3c² and ac = b² combine to b³ = 3c³, i.e. (b/c)³ = 3 — impossible by no_rat_cube_three. The degenerate cases c = 0, b = 0 are handled first. This is the original open-question statement, equivalent to degree ≥ 3.",
+    "mathContext": "$a+b\\sqrt[3]{3}+c\\sqrt[3]{3}^2=0,\\ a,b,c\\in\\mathbb{Q}\\Rightarrow a=b=c=0$.",
+    "significance": "key",
+    "relatedConcepts": ["linear independence", "elimination", "minimal polynomial degree", "rational normal form"],
+    "prerequisites": ["linear algebra over ℚ", "algebraic manipulation"]
+  },
+  {
+    "id": "linindep-mathlib-form",
+    "proofId": "cube-root-3-irrational-oq-03",
+    "range": { "startLine": 162, "endLine": 183 },
+    "type": "definition",
+    "title": "Mathlib LinearIndependent Packaging and Negative Restatement",
+    "content": "`linearIndependent_cbrt3_powers`: the same fact in Mathlib's LinearIndependent predicate for the family ![1, ∛3, (∛3)²] : Fin 3 → ℝ over ℚ, obtained from linindep_triple via Fintype.linearIndependent_iff and a Fin 3 case split. This is the reusable form (a basis-sized independent family) that the sibling oq-04 does not provide. `cbrt3_no_quadratic_relation` is the negative restatement: ∛3 satisfies no rational relation (∛3)² = b·∛3 + c, derived by applying linindep_triple to (−c, −b, 1).",
+    "mathContext": "$\\mathrm{LinearIndependent}_{\\mathbb{Q}}\\,[1,\\sqrt[3]{3},\\sqrt[3]{3}^2]$; no quadratic relation $\\sqrt[3]{3}^2=b\\sqrt[3]{3}+c$.",
+    "significance": "supporting",
+    "relatedConcepts": ["LinearIndependent predicate", "Fintype.linearIndependent_iff", "basis", "reusable formalization"],
+    "prerequisites": ["linear algebra", "Mathlib LinearIndependent API"]
+  }
+]

--- a/src/data/proofs/cube-root-3-irrational-oq-03/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-03/meta.json
@@ -3,8 +3,27 @@
   "slug": "cube-root-3-irrational-oq-03",
   "title": "∛3 has degree 3 over ℚ: irreducibility of X³ − 3 and [ℚ(∛3):ℚ] = 3",
   "description": "Extends the irrationality of ∛3 to the full degree-3 statement: X³ − 3 is irreducible over ℚ, it is the minimal polynomial of ∛3, the field extension ℚ(∛3)/ℚ has degree 3, and {1, ∛3, (∛3)²} is linearly independent over ℚ — all reduced to the single arithmetic fact that 3 has no rational cube root.",
-  "overview": "The parent entry proves ∛3 ∉ ℚ. This open-question child upgrades that to the sharp algebraic statement that ∛3 has degree exactly 3 over ℚ.\n\nEverything rests on one arithmetic input, `no_rat_cube_three`: there is no q ∈ ℚ with q³ = 3. (If q³ = 3 then (q:ℝ) is a real cube root of 3, hence equal to ∛3 since x ↦ x³ is injective on ℝ — making ∛3 rational, contradicting the parent.)\n\nFrom this single fact we obtain, via Mathlib's degree-≤3 \"no root ⇒ irreducible\" criterion, that **X³ − 3 is irreducible over ℚ**. Monicity plus (∛3)³ = 3 then identify it as the **minimal polynomial** of ∛3, and the simple-extension dimension formula gives **[ℚ(∛3) : ℚ] = 3**. We also record the linear independence of {1, ∛3, (∛3)²} directly — in explicit form and in Mathlib's `LinearIndependent` predicate form.\n\nA sibling entry (cube-root-3-irrational-oq-04, file CubeRoot3IrrationalOQ04NotQuadratic.lean) had already proved the elementary \"no quadratic relation\" half by an abstract elimination that deliberately avoids field-theory machinery. The new contribution here is the field-theoretic layer — irreducibility, minimal polynomial, and field degree — together with the `LinearIndependent` packaging, none of which the sibling provides.",
-  "conclusion": "X³ − 3 is irreducible over ℚ and is the minimal polynomial of ∛3, so [ℚ(∛3) : ℚ] = 3 and {1, ∛3, (∛3)²} is a basis-sized ℚ-linearly-independent set. All eleven theorems are fully machine-checked with no sorries and no axioms beyond Lean/Mathlib's foundational propext, Classical.choice, and Quot.sound (no native_decide). The entire development bottoms out at the lemma that 3 has no rational cube root.",
+  "overview": {
+    "historicalContext": "The irrationality of ∛3 is a first-year algebra staple; the genuinely structural fact is that ∛3 has degree exactly 3 over ℚ — equivalently, X³ − 3 is irreducible over ℚ. Irreducibility here is classical (X³ − 3 is Eisenstein at the prime 3, or has no rational root because 3 is not a perfect cube), but the modern field-theoretic packaging — minimal polynomial, simple-extension degree [ℚ(∛3):ℚ] = 3, and the basis {1, ∛3, (∛3)²} — is what connects irrationality to Galois theory and the theory of field extensions (e.g. it is exactly the obstruction that makes ∛3 non-constructible by ruler and compass, since 3 ∤ a power of 2). This entry sits in the cube-root-3 lineage: the parent proves ∛3 ∉ ℚ, and a sibling (oq-04) handles the elementary 'no quadratic relation' half by abstract elimination; the new contribution here is the full field-theoretic layer.",
+    "problemStatement": "Extend the irrationality of ∛3 to the sharp degree-3 statement. Prove that X³ − 3 is irreducible over ℚ, that it is the minimal polynomial of ∛3, that the simple extension ℚ(∛3)/ℚ has degree 3, and that {1, ∛3, (∛3)²} is linearly independent over ℚ — both in explicit elementary form and in Mathlib's LinearIndependent predicate form.",
+    "proofStrategy": "Everything rests on one arithmetic input, no_rat_cube_three: there is no q ∈ ℚ with q³ = 3 (if q³ = 3 then (q:ℝ) is a real cube root of 3, hence equal to ∛3 by injectivity of x ↦ x³ on ℝ — making ∛3 rational, contradicting the parent's irrational_cbrt3). From this single fact, Mathlib's degree-≤3 'no root ⇒ irreducible' criterion (irreducible_of_degree_le_three_of_not_isRoot) gives that X³ − 3 is irreducible over ℚ. Monicity plus (∛3)³ = 3 then identify it as the minimal polynomial of ∛3 (minpoly.eq_of_irreducible_of_monic), and the simple-extension dimension formula (IntermediateField.adjoin.finrank) gives [ℚ(∛3) : ℚ] = 3. The linear independence of {1, ∛3, (∛3)²} is given a self-contained elementary elimination (multiply a + b∛3 + c(∛3)² = 0 by ∛3, reduce (∛3)³ = 3, eliminate (∛3)²; the degenerate case forces (b/c)³ = 3, the nondegenerate case forces ∛3 ∈ ℚ — both impossible) and is repackaged in Mathlib's LinearIndependent form.",
+    "keyInsights": [
+      "A single arithmetic fact carries the entire development: 'X³ − 3 has no rational root' (no_rat_cube_three) is the only input, and irreducibility, the minimal polynomial, the field degree, and linear independence all follow from it formally.",
+      "For cubics, irreducibility over a field is equivalent to having no root (a degree-≤3 polynomial factors nontrivially iff it has a linear factor) — Mathlib's irreducible_of_degree_le_three_of_not_isRoot turns the arithmetic non-cube fact directly into irreducibility, no factorization search needed.",
+      "Linear independence of {1, ∛3, (∛3)²} is not an extra fact but a restatement of degree 3: it is exactly the assertion that the minimal polynomial has degree ≥ 3, so the elementary elimination and the field-degree computation are two views of the same content.",
+      "The bridge from a real-analytic fact (∛3 irrational) to algebra is injectivity of x ↦ x³ on ℝ (Odd.strictMono_pow): it is what lets a hypothetical rational cube root be identified with ∛3, transferring irrationality into the no-rational-root hypothesis the polynomial criterion needs.",
+      "Providing both the explicit elimination (linindep_triple) and the Mathlib LinearIndependent packaging (linearIndependent_cbrt3_powers) makes the result usable both pedagogically and as a reusable hypothesis in further field-theory developments — the sibling oq-04 supplies only the elementary half."
+    ]
+  },
+  "conclusion": {
+    "summary": "X³ − 3 is irreducible over ℚ and is the minimal polynomial of ∛3, so [ℚ(∛3) : ℚ] = 3 and {1, ∛3, (∛3)²} is a ℚ-linearly-independent set of basis size. All eleven theorems are fully machine-checked with no sorries and no axioms beyond Lean/Mathlib's foundational propext, Classical.choice, and Quot.sound (no native_decide). The entire development bottoms out at the single lemma that 3 has no rational cube root.",
+    "implications": "Pinning the degree at exactly 3 places ∛3 firmly in the theory of field extensions: ℚ(∛3) is a degree-3 extension, hence (3 being odd) not contained in any tower of quadratic extensions — the precise algebraic reason ∛3 is not constructible by ruler and compass. The explicit basis {1, ∛3, (∛3)²} gives normal-form arithmetic in ℚ(∛3), and the reusable LinearIndependent statement is the natural starting point for studying the splitting field ℚ(∛3, ω) and the (non-abelian, S₃) Galois group of X³ − 3.",
+    "openQuestions": [
+      "Compute the Galois group of the splitting field ℚ(∛3, ω) of X³ − 3 over ℚ (degree 6, isomorphic to S₃) and exhibit its subgroup/subfield lattice — the natural next step beyond the simple extension.",
+      "Formalize the non-constructibility of ∛3 by ruler and compass as a direct corollary of [ℚ(∛3):ℚ] = 3 not being a power of 2 (the classical resolution of doubling the cube).",
+      "Generalize the whole development to ∛p for an arbitrary prime p (or to X^n − p, Eisenstein at p), giving [ℚ(ⁿ√p):ℚ] = n uniformly."
+    ]
+  },
   "leanFile": {
     "lineCount": 185,
     "path": "Proofs/CubeRoot3IrrationalOQ03.lean",
@@ -62,25 +81,49 @@
     }
   ],
   "crossReferences": [
-    "cube-root-3-irrational",
-    "cube-root-3-irrational-oq-04"
+    {
+      "targetId": "cube-root-3-irrational",
+      "relationship": "extends",
+      "description": "Parent entry proving ∛3 ∉ ℚ. This child upgrades irrationality to the sharp degree-3 statement; the parent's irrational_cbrt3 (with cbrt3, cbrt3_cubed) is the single fact every downstream result here bottoms out at, via no_rat_cube_three."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-04",
+      "relationship": "related",
+      "description": "Sibling that proved the elementary 'no quadratic relation' half by an abstract elimination deliberately avoiding field-theory machinery. This entry adds the field-theoretic layer (irreducibility, minimal polynomial, field degree) and the Mathlib LinearIndependent packaging the sibling does not provide; the two linindep proofs overlap mathematically."
+    }
   ],
   "sections": [
     {
-      "title": "The single arithmetic input: 3 is not a rational cube",
-      "content": "no_rat_cube_three shows q³ ≠ 3 for all q ∈ ℚ. The proof casts q to ℝ, notes (q:ℝ)³ = (∛3)³, and uses injectivity of the odd power x ↦ x³ on ℝ (Odd.strictMono_pow) to conclude (q:ℝ) = ∛3, contradicting irrational_cbrt3. The companion no_rat_cube_neg_three handles −3."
+      "id": "inherited-and-arithmetic-input",
+      "title": "Inherited Facts and the Single Arithmetic Input",
+      "startLine": 44,
+      "endLine": 67,
+      "summary": "Re-exposes the parent's cbrt3_pow_three ((∛3)³ = 3) and cbrt3_irrational, then proves the load-bearing no_rat_cube_three: q³ ≠ 3 for all q ∈ ℚ. The proof casts q to ℝ, notes (q:ℝ)³ = (∛3)³, and uses injectivity of the odd power x ↦ x³ on ℝ (Odd.strictMono_pow) to conclude (q:ℝ) = ∛3, contradicting irrational_cbrt3. The companion no_rat_cube_neg_three handles −3.",
+      "mathContext": "$\\forall q\\in\\mathbb{Q},\\ q^3\\neq 3$ (and $q^3\\neq -3$); the single input for everything downstream."
     },
     {
+      "id": "irreducibility",
       "title": "Irreducibility of X³ − 3 over ℚ",
-      "content": "A monic cubic over a field is irreducible iff it has no root. The polynomial X³ − 3 has natDegree 3 ∈ [1,3], and (X³ − 3).eval x = x³ − 3 ≠ 0 for every x ∈ ℚ exactly by no_rat_cube_three, so Mathlib's irreducible_of_degree_le_three_of_not_isRoot yields irreducibility."
+      "startLine": 69,
+      "endLine": 88,
+      "summary": "A monic cubic over a field is irreducible iff it has no root. X³ − 3 has natDegree 3 ∈ [1,3], and (X³ − 3).eval x = x³ − 3 ≠ 0 for every x ∈ ℚ exactly by no_rat_cube_three, so Mathlib's irreducible_of_degree_le_three_of_not_isRoot yields irreducibility (irreducible_X_cubed_sub_C_three). cbrt3_isIntegral records that ∛3 is a root of the monic X³ − 3.",
+      "mathContext": "$X^3-3$ irreducible over $\\mathbb{Q}$ (degree $\\le 3$, no rational root)."
     },
     {
-      "title": "Minimal polynomial and field degree",
-      "content": "Since ∛3 is a root of the monic irreducible X³ − 3, minpoly.eq_of_irreducible_of_monic gives minpoly ℚ ∛3 = X³ − 3. The simple-extension dimension formula IntermediateField.adjoin.finrank then gives [ℚ(∛3) : ℚ] = natDegree(X³ − 3) = 3."
+      "id": "minpoly-degree",
+      "title": "Minimal Polynomial and Field Degree",
+      "startLine": 90,
+      "endLine": 101,
+      "summary": "Since ∛3 is a root of the monic irreducible X³ − 3, minpoly.eq_of_irreducible_of_monic gives minpoly ℚ ∛3 = X³ − 3 (minpoly_cbrt3). The simple-extension dimension formula IntermediateField.adjoin.finrank then gives [ℚ(∛3) : ℚ] = natDegree(X³ − 3) = 3 (finrank_adjoin_cbrt3).",
+      "mathContext": "$\\mathrm{minpoly}_{\\mathbb{Q}}(\\sqrt[3]{3})=X^3-3$, so $[\\mathbb{Q}(\\sqrt[3]{3}):\\mathbb{Q}]=3$."
     },
     {
-      "title": "Linear independence of {1, ∛3, (∛3)²}",
-      "content": "An elementary elimination: from a + b∛3 + c(∛3)² = 0, multiplying by ∛3 and reducing (∛3)³ = 3 gives a second relation; eliminating (∛3)² yields (ac − b²)∛3 = ab − 3c². If ac − b² ≠ 0 then ∛3 is rational; otherwise ab = 3c² and ac = b² force b³ = 3c³, i.e. (b/c)³ = 3 — impossible. This is packaged both explicitly (linindep_triple) and as Mathlib's LinearIndependent ℚ ![1, ∛3, (∛3)²]."
+      "id": "linear-independence",
+      "title": "Linear Independence of {1, ∛3, (∛3)²}",
+      "startLine": 103,
+      "endLine": 183,
+      "summary": "An elementary elimination: from a + b∛3 + c(∛3)² = 0, multiplying by ∛3 and reducing (∛3)³ = 3 gives a second relation; eliminating (∛3)² yields (ac − b²)∛3 = ab − 3c². If ac − b² ≠ 0 then ∛3 is rational (contradiction); otherwise ab = 3c² and ac = b² force b³ = 3c³, i.e. (b/c)³ = 3 — impossible by no_rat_cube_three. Packaged explicitly (linindep_triple), in Mathlib's LinearIndependent form (linearIndependent_cbrt3_powers), and as the negative restatement cbrt3_no_quadratic_relation.",
+      "mathContext": "$a+b\\sqrt[3]{3}+c\\sqrt[3]{3}^2=0\\Rightarrow a=b=c=0$ over $\\mathbb{Q}$; $\\{1,\\sqrt[3]{3},\\sqrt[3]{3}^2\\}$ a basis."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `cube-root-3-irrational-oq-03` (X³ − 3 irreducible / [ℚ(∛3):ℚ] = 3).

## Why this matters
The entry stored `overview` and `conclusion` as plain **strings**, but the gallery renderer reads `overview.historicalContext`, `overview.proofStrategy`, `overview.keyInsights`, `conclusion.summary`, `conclusion.implications`, etc. (see `ProofOverview.tsx` / `ProofConclusion.tsx`). In string form those fields are `undefined`, so the Overview and Conclusion panels rendered effectively blank on the live page. This PR converts them to the canonical object schema, fixing the rendering.

## Added / fixed
- **overview** → object form: historicalContext (Eisenstein/constructibility framing), problemStatement, proofStrategy, 5 keyInsights.
- **conclusion** → object form: summary, implications, 3 openQuestions (Galois group of the splitting field, ruler-and-compass non-constructibility, generalization to ∛p).
- **sections** → upgraded from title/content to the canonical `{id, startLine, endLine, summary, mathContext}`, anchored to the Lean source (lines 44–183).
- **annotations.json** — 6 annotations with mathContext/significance/relatedConcepts/prerequisites.
- Migrated legacy string-array `crossReferences` to `{targetId, relationship, description}`.

## Integrity
status `verified` / badge `original` / axiomCount 0 confirmed against the Lean source (11 theorems, 0 axioms, 0 sorries, no native_decide). `pnpm build` passes.