### PR TITLE
Enrich Alternating Series Test (two-sided error bound): add annotations

### DIFF
--- a/src/data/proofs/alternating-series-test-oq-01/annotations.json
+++ b/src/data/proofs/alternating-series-test-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "partial-sum-recurrence",
+    "proofId": "alternating-series-test-oq-01",
+    "range": { "startLine": 29, "endLine": 34 },
+    "type": "technique",
+    "title": "The One-Step Partial-Sum Recurrence",
+    "content": "`partialSum_succ`: S_{n+1} = S_n + (-1)ⁿ f n, an immediate consequence of Finset.sum_range_succ. This trivial-looking recurrence is the hinge of the whole argument: it converts the gap between consecutive partial sums into a single signed term (-1)ⁿ f n, whose sign is governed entirely by the parity of n. That sign control is what lets the two one-directional Mathlib bracketing lemmas be combined into a symmetric bound.",
+    "mathContext": "$S_{n+1} = S_n + (-1)^n f_n$, where $S_n = \\sum_{i<n}(-1)^i f_i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["partial sums", "telescoping", "Finset.sum_range_succ", "parity"],
+    "prerequisites": ["finite sums", "series"]
+  },
+  {
+    "id": "two-sided-bound",
+    "proofId": "alternating-series-test-oq-01",
+    "range": { "startLine": 36, "endLine": 67 },
+    "type": "theorem",
+    "title": "The Two-Sided Remainder Bound |S_N − l| ≤ f N",
+    "content": "`abs_partialSum_sub_limit_le`: the headline result Mathlib omits. For antitone f → 0 with alternating series converging to l, the N-th partial sum approximates l with error at most f N. The proof splits on the parity of N and uses Mathlib's two ONE-DIRECTIONAL bracketing lemmas: even partial sums underestimate the limit (alternating_series_le_tendsto), odd partial sums overestimate it (tendsto_le_alternating_series). For N = 2k: S_N ≤ l ≤ S_N + f N (the next term f(2k) added by the recurrence), so 0 ≤ l − S_N ≤ f N. For N = 2k+1: S_N − f N ≤ l ≤ S_N. Either way |S_N − l| ≤ f N — the symmetric estimate that makes the alternating series test practical.",
+    "mathContext": "$f$ antitone, $f\\to 0$, $S_N\\to l$ $\\Rightarrow$ $|S_N - l|\\le f_N$.",
+    "significance": "critical",
+    "relatedConcepts": ["alternating series test", "remainder estimate", "bracketing", "parity case split", "Leibniz criterion"],
+    "prerequisites": ["series convergence", "limits", "monotone sequences"]
+  },
+  {
+    "id": "bracketing-insight",
+    "proofId": "alternating-series-test-oq-01",
+    "range": { "startLine": 44, "endLine": 67 },
+    "type": "insight",
+    "title": "From One-Sided Bracketing to a Symmetric Bound",
+    "content": "The conceptual core: Mathlib gives only that consecutive partial sums bracket the limit from alternating sides, S_{2k} ≤ l ≤ S_{2k+1}. The limit therefore lies in an interval of width |S_{2k+1} − S_{2k}| = f(2k). Knowing which endpoint S_N is (via the parity of N) and that the OTHER endpoint is exactly one recurrence step away (±f N) collapses the two one-sided facts into the single absolute bound |S_N − l| ≤ f N. No knowledge of the limit value l is needed — the estimate is purely structural.",
+    "mathContext": "$S_{2k}\\le l\\le S_{2k+1}$ and $S_{2k+1}-S_{2k}=f_{2k}$ $\\Rightarrow$ $l$ within $f_N$ of $S_N$.",
+    "significance": "key",
+    "relatedConcepts": ["nested intervals", "monotone bracketing", "error term", "alternating series"],
+    "prerequisites": ["limits", "interval estimates"]
+  },
+  {
+    "id": "antitone-coefficients",
+    "proofId": "alternating-series-test-oq-01",
+    "range": { "startLine": 69, "endLine": 74 },
+    "type": "definition",
+    "title": "Antitonicity of the Harmonic Coefficients",
+    "content": "`antitone_one_div_succ`: the coefficients f i = 1/(i+1) are antitone (decreasing), via one_div_le_one_div_of_le on the positive denominators. This is the hypothesis the general bound needs to specialize to the alternating harmonic series — together with f → 0 (the standard Mathlib limit tendsto_one_div_add_atTop_nhds_zero_nat).",
+    "mathContext": "$i\\mapsto \\frac{1}{i+1}$ is antitone on $\\mathbb{N}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["antitone sequence", "harmonic coefficients", "monotonicity of reciprocals"],
+    "prerequisites": ["monotone functions", "real inequalities"]
+  },
+  {
+    "id": "harmonic-capstone",
+    "proofId": "alternating-series-test-oq-01",
+    "range": { "startLine": 76, "endLine": 86 },
+    "type": "theorem",
+    "title": "Capstone: Alternating Harmonic Series with Error ≤ 1/(N+1)",
+    "content": "`abs_alternatingHarmonic_sub_limit_le`: the alternating harmonic series ∑ (-1)ⁱ/(i+1) converges to a limit l (namely log 2, though the value is irrelevant to the estimate) and its N-th partial sum approximates l with error at most 1/(N+1). Obtained by feeding antitone_one_div_succ and the f → 0 limit into hfa.tendsto_alternating_series_of_tendsto_zero (for existence) and abs_partialSum_sub_limit_le (for the bound). This is the practical payoff: a fully explicit, quantitative convergence rate for the canonical conditionally-convergent series.",
+    "mathContext": "$\\left|\\sum_{i<N}\\frac{(-1)^i}{i+1} - l\\right|\\le \\frac{1}{N+1}$, with $l=\\log 2$.",
+    "significance": "key",
+    "relatedConcepts": ["alternating harmonic series", "log 2", "conditional convergence", "convergence rate", "Leibniz"],
+    "prerequisites": ["series convergence", "harmonic series"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `alternating-series-test-oq-01`. The entry already had a complete object-form overview, conclusion, and line-anchored sections but no `annotations.json`.

## Added
- **annotations.json** — 5 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the one-step partial-sum recurrence, the two-sided remainder bound |S_N − l| ≤ f N, the insight turning Mathlib's one-sided bracketing into a symmetric bound, the antitone harmonic coefficients, and the alternating-harmonic capstone (error ≤ 1/(N+1)).

## Integrity
status `verified` / badge confirmed against the Lean source (4 theorems, 0 axioms, 0 sorries, no native_decide). `pnpm build` passes.