### PR TITLE
research(gcd-algorithm-oq-01-oq-03-oq-01): Lamé sharpness — Fibonacci pairs are the exact Euclidean worst case

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2719,6 +2719,7 @@ import Proofs.GCDAlgorithm
 import Proofs.GCDAlgorithmOQ01
 import Proofs.GcdAlgorithmOQ01OQ01
 import Proofs.GCDAlgorithmOQ01OQ03
+import Proofs.GCDAlgorithmOQ01OQ03OQ01
 import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
 import Proofs.GaussLemmaPrimitiveOQ01

--- a/proofs/Proofs/GCDAlgorithmOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/GCDAlgorithmOQ01OQ03OQ01.lean
@@ -1,0 +1,200 @@
+/-
+  Lamé's Theorem, Sharp Side: Fibonacci Pairs Are the Exact Euclidean Worst Case
+  Open Question OQ-01 from GCDAlgorithmOQ01OQ03
+
+  The parent entry (gcd-algorithm-oq-01-oq-03, "Binet's Formula and Lamé's
+  5-Digit Bound") proves the *upper* side of Lamé's theorem: the number of
+  Euclidean steps on inputs below 10^k is O(k), because Fibonacci numbers grow
+  at least geometrically (fib(5k+2) ≥ 10^k).
+
+  This file proves the matching *sharp* side — that consecutive Fibonacci pairs
+  realize the worst case exactly:
+
+      euclidSteps (fib (n+2)) (fib (n+1)) = n        (for n ≥ 1)
+
+  Together with the upper bound, this pins the Euclidean worst case to the
+  Fibonacci sequence: no input of a given size forces more steps, and the
+  Fibonacci pair forces exactly that many. This is the original content of
+  Lamé (1844), historically the first complexity analysis of an algorithm.
+
+  We additionally prove the *minimality* direction:
+
+      0 < b < a  ∧  euclidSteps a b = n  →  fib (n+1) ≤ b  ∧  fib (n+2) ≤ a
+
+  i.e. any pair taking n steps is at least as large as the n-th Fibonacci pair,
+  so the Fibonacci pairs are the smallest inputs achieving each step count.
+
+  Proof idea (exact count): the Euclidean recursion on (fib(n+2), fib(n+1))
+  reduces in one step to (fib(n+1), fib(n+2) mod fib(n+1)) = (fib(n+1), fib n),
+  because fib(n+2) = fib(n+1) + fib n with 0 ≤ fib n < fib(n+1). Induction.
+
+  References:
+  - Lamé, G. (1844). Note sur la limite du nombre des divisions dans la
+    recherche du plus grand commun diviseur entre deux nombres entiers.
+  - GCDAlgorithmOQ01OQ03.lean (the digit-count upper bound).
+  - BinaryGcdOQ01.lean (definition of euclidSteps).
+-/
+import Mathlib
+import Proofs.BinaryGcdOQ01
+
+namespace GCDAlgorithmOQ01OQ03OQ01
+
+open Nat BinaryGcdOQ01
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: BASIC RECURSION LEMMAS FOR euclidSteps
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- `euclidSteps a 0 = 0`: a run with second argument zero takes no steps. -/
+private lemma euclidSteps_zero_right (a : ℕ) : euclidSteps a 0 = 0 := by
+  cases a with
+  | zero => exact euclidSteps.eq_1 0
+  | succ a' => exact euclidSteps.eq_2 _ (by omega)
+
+/-- Clean recursion for the Euclidean step counter when `0 < b < a`:
+    `euclidSteps a b = 1 + euclidSteps b (a % b)`.
+
+    The definition `euclidSteps` branches on `b' + 1 ≤ a'` (i.e. `b < a`); the
+    hypothesis `b < a` selects exactly the first branch. -/
+private theorem euclidSteps_step (a b : ℕ) (hb : 0 < b) (hba : b < a) :
+    euclidSteps a b = 1 + euclidSteps b (a % b) := by
+  obtain ⟨a', rfl⟩ : ∃ k, a = k + 1 := ⟨a - 1, by omega⟩
+  obtain ⟨b', rfl⟩ : ∃ k, b = k + 1 := ⟨b - 1, by omega⟩
+  rw [euclidSteps.eq_3, if_pos (by omega : b' + 1 ≤ a')]
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: THE FIBONACCI MOD IDENTITY
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- `fib (n+1) < fib (n+2)` for `n ≥ 1` (strict monotonicity above index 1). -/
+private lemma fib_succ_lt (n : ℕ) (hn : 1 ≤ n) : fib (n + 1) < fib (n + 2) :=
+  Nat.fib_lt_fib_succ (show 2 ≤ n + 1 by omega)
+
+/-- The Euclidean reduction step on a Fibonacci pair:
+    `fib (n+2) % fib (n+1) = fib n` for `n ≥ 2`.
+
+    Because `fib (n+2) = fib n + fib (n+1)` with `0 ≤ fib n < fib (n+1)`. -/
+private lemma fib_mod (n : ℕ) (hn : 2 ≤ n) : fib (n + 2) % fib (n + 1) = fib n := by
+  have hadd : fib (n + 2) = fib n + fib (n + 1) := Nat.fib_add_two
+  have hlt : fib n < fib (n + 1) := Nat.fib_lt_fib_succ hn
+  calc fib (n + 2) % fib (n + 1)
+      = (fib n + fib (n + 1)) % fib (n + 1) := by rw [hadd]
+    _ = fib n % fib (n + 1) := by rw [Nat.add_mod_right]
+    _ = fib n := Nat.mod_eq_of_lt hlt
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: EXACT WORST-CASE STEP COUNT (LAMÉ SHARPNESS)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Main Theorem (Lamé sharpness).** Consecutive Fibonacci numbers realize the
+    Euclidean worst case exactly:
+
+        euclidSteps (fib (n+2)) (fib (n+1)) = n        for every n ≥ 1.
+
+    Proof by induction from the base `n = 1`:
+    `euclidSteps (fib 3) (fib 2) = euclidSteps 2 1 = 1`, and the inductive step
+    uses `euclidSteps_step` together with `fib (n+3) % fib (n+2) = fib (n+1)`. -/
+theorem euclidSteps_fib (n : ℕ) (hn : 1 ≤ n) :
+    euclidSteps (fib (n + 2)) (fib (n + 1)) = n := by
+  induction n, hn using Nat.le_induction with
+  | base =>
+    -- fib 3 = 2, fib 2 = 1; euclidSteps 2 1 = 1 + euclidSteps 1 0 = 1
+    have hf2 : fib 2 = 1 := by decide
+    have hf3 : fib 3 = 2 := by decide
+    rw [show (1 : ℕ) + 2 = 3 from rfl, show (1 : ℕ) + 1 = 2 from rfl, hf3, hf2,
+        euclidSteps_step 2 1 (by norm_num) (by norm_num),
+        show (2 : ℕ) % 1 = 0 from rfl, euclidSteps_zero_right]
+  | succ n hn ih =>
+    have hpos : 0 < fib (n + 2) := Nat.fib_pos.mpr (by omega)
+    have hlt : fib (n + 2) < fib (n + 3) := fib_succ_lt (n + 1) (by omega)
+    rw [euclidSteps_step (fib (n + 3)) (fib (n + 2)) hpos hlt,
+        fib_mod (n + 1) (by omega), ih]
+    omega
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART IV: MINIMALITY — FIBONACCI PAIRS ARE THE SMALLEST WORST CASES
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Minimality (Lamé lower bound).** Any pair `0 < b < a` whose Euclidean run
+    takes `n` steps is at least as large as the n-th Fibonacci pair:
+
+        euclidSteps a b = n  →  fib (n + 1) ≤ b  ∧  fib (n + 2) ≤ a.
+
+    Hence the Fibonacci pair `(fib (n+2), fib (n+1))` is the *smallest* input
+    forcing `n` Euclidean steps — the sharp form of Lamé's theorem.
+
+    Proof: strong induction on `a`. One Euclidean step sends `(a, b)` to
+    `(b, a % b)` with `a % b < b`, decreasing the first argument; the inductive
+    hypothesis bounds the smaller pair by Fibonacci numbers, and
+    `a ≥ b + (a % b)` (since the quotient is `≥ 1` as `b ≤ a`) lifts the bound
+    via the Fibonacci recurrence `fib (n+2) = fib (n+1) + fib n`. -/
+theorem fib_le_of_euclidSteps (a : ℕ) :
+    ∀ b n, 0 < b → b < a → euclidSteps a b = n →
+      fib (n + 1) ≤ b ∧ fib (n + 2) ≤ a := by
+  induction a using Nat.strong_induction_on with
+  | _ a ih =>
+    intro b n hb hba hsteps
+    -- Peel one Euclidean step.
+    rw [euclidSteps_step a b hb hba] at hsteps
+    have hr_lt : a % b < b := Nat.mod_lt a hb
+    -- a ≥ b + a % b, since the quotient a / b ≥ 1.
+    have hq1 : 1 ≤ a / b := (Nat.one_le_div_iff hb).mpr (le_of_lt hba)
+    have hdm : b * (a / b) + a % b = a := Nat.div_add_mod a b
+    have hq : b ≤ b * (a / b) := le_mul_of_one_le_right (Nat.zero_le b) hq1
+    have hge : b + a % b ≤ a := by omega
+    cases n with
+    | zero =>
+      -- 1 + euclidSteps b (a % b) = 0 is impossible.
+      exact absurd hsteps (by omega)
+    | succ m =>
+      have hsteps' : euclidSteps b (a % b) = m := by omega
+      rcases Nat.eq_zero_or_pos (a % b) with hr0 | hrpos
+      · -- a % b = 0: the run ends, so m = 0 and n = 1.
+        rw [hr0, euclidSteps_zero_right] at hsteps'
+        subst hsteps'
+        -- need fib 2 ≤ b and fib 3 ≤ a, i.e. 1 ≤ b and 2 ≤ a
+        refine ⟨by simpa using hb, ?_⟩
+        have : 2 ≤ a := by omega
+        simpa using this
+      · -- a % b > 0: apply IH to (b, a % b) with b < a.
+        obtain ⟨hr_fib, hb_fib⟩ := ih b hba (a % b) m hrpos hr_lt hsteps'
+        -- hr_fib : fib (m+1) ≤ a % b,  hb_fib : fib (m+2) ≤ b
+        refine ⟨hb_fib, ?_⟩
+        -- fib (m+3) = fib (m+1) + fib (m+2) ≤ (a % b) + b ≤ a
+        have hrec : fib (m + 3) = fib (m + 1) + fib (m + 2) := Nat.fib_add_two
+        calc fib (m + 1 + 2) = fib (m + 3) := by ring_nf
+          _ = fib (m + 1) + fib (m + 2) := hrec
+          _ ≤ a % b + b := Nat.add_le_add hr_fib hb_fib
+          _ = b + a % b := by ring
+          _ ≤ a := hge
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: COMBINED SHARP CHARACTERIZATION
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Sharp Lamé characterization.** For `n ≥ 1`, the Fibonacci pair
+    `(fib (n+2), fib (n+1))` takes exactly `n` Euclidean steps, and every pair
+    `0 < b < a` taking `n` steps satisfies `fib (n+2) ≤ a` and `fib (n+1) ≤ b`.
+    So the Fibonacci pair is a minimal `n`-step input. -/
+theorem lame_sharp (n : ℕ) (hn : 1 ≤ n) :
+    euclidSteps (fib (n + 2)) (fib (n + 1)) = n ∧
+    (∀ a b, 0 < b → b < a → euclidSteps a b = n → fib (n + 2) ≤ a ∧ fib (n + 1) ≤ b) := by
+  refine ⟨euclidSteps_fib n hn, ?_⟩
+  intro a b hb hba hsteps
+  obtain ⟨h1, h2⟩ := fib_le_of_euclidSteps a b n hb hba hsteps
+  exact ⟨h2, h1⟩
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: CONCRETE VERIFICATIONS
+-- ═══════════════════════════════════════════════════════════════════
+
+-- The exact worst-case counts, verified computationally:
+example : euclidSteps (fib 3) (fib 2) = 1 := by native_decide
+example : euclidSteps (fib 6) (fib 5) = 4 := by native_decide
+example : euclidSteps (fib 10) (fib 9) = 8 := by native_decide
+example : euclidSteps (fib 12) (fib 11) = 10 := by native_decide
+
+-- Minimality witness: (fib 7, fib 6) = (13, 8) takes 5 steps; no smaller pair does.
+example : euclidSteps (fib 7) (fib 6) = 5 := by native_decide
+
+end GCDAlgorithmOQ01OQ03OQ01

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-euclidsteps-step",
+    "proofId": "gcd-algorithm-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 64
+    },
+    "type": "lemma",
+    "title": "One-Step Euclidean Recursion",
+    "content": "For 0 < b < a, one Euclidean step rewrites euclidSteps a b as 1 + euclidSteps b (a % b). The euclidSteps definition branches on b ≤ a-1 (i.e. b < a); the hypothesis selects exactly that branch, so this lemma exposes the recursion cleanly without unfolding the well-founded definition each time.",
+    "mathContext": "$0 < b < a \\implies \\operatorname{euclidSteps}(a,b) = 1 + \\operatorname{euclidSteps}(b,\\, a \\bmod b)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Euclidean algorithm",
+      "well-founded recursion",
+      "equation lemmas"
+    ],
+    "prerequisites": [
+      "Nat modulo",
+      "match equation lemmas"
+    ]
+  },
+  {
+    "id": "ann-fib-mod",
+    "proofId": "gcd-algorithm-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 87
+    },
+    "type": "lemma",
+    "title": "Fibonacci Reduction Identity",
+    "content": "The heart of the worst case: fib(n+2) mod fib(n+1) = fib n for n ≥ 2. Because fib(n+2) = fib(n+1) + fib n and 0 ≤ fib n < fib(n+1), the Euclidean reduction of a Fibonacci pair lands on the previous Fibonacci pair. This is what makes the Fibonacci sequence the slowest possible Euclidean descent: each step removes exactly one quotient of 1.",
+    "mathContext": "$F_{n+2} \\bmod F_{n+1} = F_n$ since $F_{n+2} = F_{n+1} + F_n$ with $0 \\le F_n < F_{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fibonacci recurrence",
+      "strict monotonicity",
+      "quotient one"
+    ],
+    "prerequisites": [
+      "Nat.fib_add_two",
+      "Nat.fib_lt_fib_succ",
+      "Nat.mod_eq_of_lt"
+    ]
+  },
+  {
+    "id": "ann-euclidsteps-fib",
+    "proofId": "gcd-algorithm-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 97,
+      "endLine": 117
+    },
+    "type": "theorem",
+    "title": "Exact Worst-Case Count (Lamé Sharpness)",
+    "content": "The main theorem: euclidSteps(fib(n+2), fib(n+1)) = n for n ≥ 1. Reindexing m = n+1 gives euclidSteps(F_{m+1}, F_m) = m-1, which is exactly open question #1 of the parent entry. The proof is induction from the base (fib 3, fib 2) = (2, 1) using the one-step recursion and the Fibonacci mod identity, so each Fibonacci step contributes exactly one Euclidean step.",
+    "mathContext": "$\\operatorname{euclidSteps}(F_{n+2}, F_{n+1}) = n$ for $n \\ge 1$; equivalently $\\operatorname{euclidSteps}(F_{m+1}, F_m) = m-1$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Lamé's theorem",
+      "worst-case complexity",
+      "Euclidean algorithm",
+      "induction"
+    ],
+    "prerequisites": [
+      "Nat.le_induction",
+      "Fibonacci reduction identity"
+    ]
+  },
+  {
+    "id": "ann-minimality",
+    "proofId": "gcd-algorithm-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 131,
+      "endLine": 176
+    },
+    "type": "theorem",
+    "title": "Minimality of Fibonacci Worst Cases",
+    "content": "Sharpness in the strong sense: any pair 0 < b < a with euclidSteps a b = n satisfies fib(n+1) ≤ b and fib(n+2) ≤ a. So no smaller pair achieves n steps — the Fibonacci pair is the minimal n-step input. Proved by strong induction on a: one Euclidean step reduces to (b, a mod b), the inductive hypothesis bounds that smaller pair, and a ≥ b + (a mod b) (quotient ≥ 1) lifts the bound through fib(n+2) = fib(n+1) + fib n.",
+    "mathContext": "$0 < b < a \\wedge \\operatorname{euclidSteps}(a,b)=n \\implies F_{n+1} \\le b \\wedge F_{n+2} \\le a$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "minimal worst case",
+      "strong induction",
+      "Fibonacci recurrence",
+      "Euclidean division"
+    ],
+    "prerequisites": [
+      "Nat.strong_induction_on",
+      "Nat.div_add_mod"
+    ]
+  }
+]

--- a/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "gcd-algorithm-oq-01-oq-03-oq-01",
+  "slug": "gcd-algorithm-oq-01-oq-03-oq-01",
+  "title": "Lamé's Theorem Is Sharp: Fibonacci Pairs Are the Exact Euclidean Worst Case",
+  "description": "Proves the sharp side of Lamé's theorem (1844): consecutive Fibonacci numbers realize the Euclidean worst case exactly, with euclidSteps(fib(n+2), fib(n+1)) = n, and any pair taking n steps is at least as large as the n-th Fibonacci pair. Directly answers open question #1 of the parent entry.",
+  "leanFile": {
+    "namespace": "GCDAlgorithmOQ01OQ03OQ01",
+    "lineCount": 200,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/GCDAlgorithmOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GCDAlgorithmOQ01OQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "euclidean-algorithm",
+      "fibonacci",
+      "algorithm-complexity",
+      "lame-theorem",
+      "worst-case-analysis"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified from the foundational axioms (propext, Classical.choice, Quot.sound). The named theorems use no native_decide; native_decide appears only in anonymous example sanity checks. Depends on BinaryGcdOQ01 (definition of euclidSteps).",
+    "lineCount": 200,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "originalContributions": [
+      "euclidSteps_fib: euclidSteps(fib(n+2), fib(n+1)) = n for n ≥ 1 — the exact worst-case step count, answering the parent's open question #1 (Lamé sharpness)",
+      "fib_le_of_euclidSteps: any pair 0 < b < a with euclidSteps a b = n satisfies fib(n+1) ≤ b and fib(n+2) ≤ a — Fibonacci pairs are the smallest n-step inputs (minimality)",
+      "lame_sharp: combined sharp characterization packaging the exact count with minimality",
+      "euclidSteps_step: clean one-step recursion euclidSteps a b = 1 + euclidSteps b (a % b) for 0 < b < a",
+      "fib_mod: the Euclidean reduction identity fib(n+2) % fib(n+1) = fib n for n ≥ 2"
+    ]
+  },
+  "conclusion": {
+    "summary": "Machine-verifies the sharp side of Lamé's theorem for the Euclidean algorithm. The exact worst-case count euclidSteps(fib(n+2), fib(n+1)) = n is proved by induction via the one-step recursion and the Fibonacci mod identity fib(n+2) % fib(n+1) = fib n; minimality (any n-step pair dominates the n-th Fibonacci pair) is proved by strong induction on the larger argument. 7 theorems, 0 definitions, 0 axioms, 200 lines.",
+    "implications": "The parent entry (gcd-algorithm-oq-01-oq-03) proves the upper side of Lamé's bound — inputs below 10^k force O(k) steps because Fibonacci numbers grow geometrically. This entry supplies the matching lower side: the Fibonacci pairs achieve that bound exactly and are the minimal inputs to do so. Together they pin the Euclidean worst case to the Fibonacci sequence, recovering the original content of Lamé's 1844 analysis — historically the first complexity analysis of an algorithm. The argument is fully elementary: it needs only the one-step Euclidean recursion, the Fibonacci recurrence, and strict monotonicity of fib above index 1.",
+    "openQuestions": [
+      "Translate the exact count into the closed-form bound steps ≈ log_φ(b) using Binet's formula from the parent entry, making the constant 1/log₂(φ) ≈ 1.4404 explicit.",
+      "Formalize the analogous sharp worst case for the binary (Stein) GCD: the family (1, 2^n − 1) is already known tight in binary-gcd-oq-01-oq-04; characterize its minimal n-step inputs."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "gcd-algorithm-oq-01-oq-03",
+      "relationship": "parent",
+      "description": "Parent entry proving the upper side of Lamé's bound (digit count) and Binet's formula; its open question #1 asks exactly for the sharp worst case proved here."
+    },
+    {
+      "targetId": "gcd-algorithm-oq-01",
+      "relationship": "related",
+      "description": "Average-case complexity of the Euclidean algorithm; the worst case proved here complements the average-case picture."
+    },
+    {
+      "targetId": "binary-gcd-oq-01-oq-04",
+      "relationship": "related",
+      "description": "The analogous tight worst-case family (1, 2^n − 1) for the binary GCD algorithm, providing a structural contrast with the Fibonacci worst case for the Euclidean algorithm."
+    }
+  ],
+  "sections": [
+    "Module Overview and References",
+    "Basic Recursion Lemmas for euclidSteps",
+    "The Fibonacci Mod Identity",
+    "Exact Worst-Case Step Count (Lamé Sharpness)",
+    "Minimality: Fibonacci Pairs Are the Smallest Worst Cases",
+    "Combined Sharp Characterization",
+    "Concrete Verifications"
+  ],
+  "sorries": [],
+  "overview": [
+    "Lamé's theorem (1844) bounds the number of steps the Euclidean algorithm takes, and is often cited as the first complexity analysis of an algorithm. The standard statement has two halves: an upper bound (no input of a given size forces more than ~5 steps per decimal digit) and a sharpness claim (consecutive Fibonacci numbers force exactly that many).",
+    "The parent gallery entry formalizes the upper half via Fibonacci growth and Binet's formula. This entry formalizes the sharp half. Working with the Euclidean step counter euclidSteps from the binary-GCD development, it proves euclidSteps(fib(n+2), fib(n+1)) = n for every n ≥ 1.",
+    "The proof rests on two elementary facts. First, a clean one-step recursion: when 0 < b < a, euclidSteps a b = 1 + euclidSteps b (a mod b). Second, the Fibonacci reduction identity: fib(n+2) mod fib(n+1) = fib n, which holds because fib(n+2) = fib(n+1) + fib n with fib n < fib(n+1). Induction from the base case (fib 3, fib 2) = (2, 1) then gives the exact count.",
+    "A companion minimality theorem shows the Fibonacci pairs are not merely worst cases but the smallest worst cases: any pair 0 < b < a taking n steps satisfies fib(n+1) ≤ b and fib(n+2) ≤ a. This is proved by strong induction on a, lifting the bound on the reduced pair (b, a mod b) through the Fibonacci recurrence.",
+    "Everything is verified from the foundational axioms only; the named theorems use no native_decide (it appears solely in anonymous example sanity checks)."
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **sharp side of Lamé's theorem** (1844): consecutive Fibonacci numbers realize the Euclidean worst case *exactly*. This directly answers **open question #1** of the parent entry `gcd-algorithm-oq-01-oq-03` ("the Euclidean algorithm on $(F_{n+1}, F_n)$ requires exactly $n-1$ steps, showing Lamé's bound is sharp").

The parent entry proves the *upper* half of Lamé's bound (inputs below $10^k$ force $O(k)$ steps, via Fibonacci growth + Binet's formula). This PR supplies the matching *sharp* half.

## Main results (0 axioms, 0 sorries)

- **`euclidSteps_fib`** — `euclidSteps (fib (n+2)) (fib (n+1)) = n` for $n \ge 1$. The exact worst-case step count.
- **`fib_le_of_euclidSteps`** — any $0 < b < a$ with `euclidSteps a b = n` satisfies `fib (n+1) ≤ b` and `fib (n+2) ≤ a`. Fibonacci pairs are the *smallest* $n$-step inputs (minimality).
- **`lame_sharp`** — combined sharp characterization.

## Proof structure

- One-step recursion: `euclidSteps a b = 1 + euclidSteps b (a % b)` for $0 < b < a$.
- Fibonacci reduction identity: `fib (n+2) % fib (n+1) = fib n` (since $F_{n+2} = F_{n+1} + F_n$ with $F_n < F_{n+1}$). Induction gives the exact count.
- Minimality by strong induction on the larger argument, lifting the bound through the Fibonacci recurrence.

## Verification

Built with Lean v4.26.0 (single-file fallback; Docker daemon was down). `#print axioms` on all three headline theorems reports only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. `native_decide` appears only in anonymous `example` sanity checks, not in any named theorem.

- Lean: `proofs/Proofs/GCDAlgorithmOQ01OQ03OQ01.lean` (200 lines, 7 theorems)
- Gallery: `src/data/proofs/gcd-algorithm-oq-01-oq-03-oq-01/`
- Registered in `proofs/Proofs.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)