### PR TITLE
research(composition-parts-choose-oq-01-oq-01): total & mean number of parts of a composition — ∑ length = (n+1)·2^(n−2), mean (n+1)/2 [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -719,6 +719,7 @@ import Proofs.CompactnessFiniteSubcover
 import Proofs.ComplexityCore
 import Proofs.CompositionCard2PowOQ01
 import Proofs.CompositionPartsChooseOQ01
+import Proofs.CompositionPartsChooseOQ01OQ01
 import Proofs.ConjugacyClassEquationOQ01
 import Proofs.ConnectedSpaceOQ01
 import Proofs.ContinuumHypothesis

--- a/proofs/Proofs/CompositionPartsChooseOQ01OQ01.lean
+++ b/proofs/Proofs/CompositionPartsChooseOQ01OQ01.lean
@@ -1,0 +1,207 @@
+import Mathlib.Combinatorics.Enumerative.Composition
+import Mathlib.Tactic
+
+/-
+# The total and mean number of parts of a composition
+
+## What This Proves
+
+A *composition* of `n` is an ordered tuple of positive integers summing to `n`
+(Mathlib's `Composition n`), with `c.length` parts. The grandparent entry
+(`composition-card-2pow-oq-01`) counts compositions: `card (Composition n) = 2^(n−1)`.
+The parent (`composition-parts-choose-oq-01`) *grades* that count by the number of
+parts: there are `C(n−1, k−1)` compositions of `n` with exactly `k` parts.
+
+This entry computes the **first moment** of the number of parts — its total and
+mean across all compositions of `n`:
+
+* `total_parts` — summed over all `2^(n−1)` compositions of `n ≥ 2`, the **total
+  number of parts is `(n+1)·2^(n−2)`**;
+* `two_mul_total_parts` / `mean_parts` — equivalently the **mean number of parts is
+  exactly `(n+1)/2`**.
+
+So while a composition of `n` can have anywhere from `1` to `n` parts, on average it
+has `(n+1)/2` of them — the midpoint of the range, reflecting the symmetry
+`C(n−1,k−1) = C(n−1,n−k)` of the part-count distribution.
+
+## The Mechanism
+
+The clean route avoids re-summing the graded count `∑ₖ k·C(n−1,k−1)` directly.
+Instead it uses the combinatorial bijection `Composition n ≃ Finset (Fin (n−1))`
+(`gapsEquiv`, the "subset of internal gaps" model underlying the `2^(n−1)` count)
+together with the part-count bridge
+
+  **`length c = (gaps of c).card + 1`**   (`length_eq_card_gaps`)
+
+— a composition with `k` parts cuts `k − 1` of the `n − 1` gaps. Summing over all
+compositions and transporting along the bijection turns the total into
+
+  `∑_{s ⊆ Fin (n−1)} (|s| + 1) = (∑_{s} |s|) + 2^(n−1)`,
+
+and `∑_{s ⊆ [m]} |s| = m·2^(m−1)` (`sum_finset_card`, every element lies in half of
+the subsets, via the binomial identity `∑ₖ k·C(m,k) = m·2^(m−1)` in `sum_choose_mul`).
+With `m = n − 1` this gives `(n−1)·2^(n−2) + 2^(n−1) = (n+1)·2^(n−2)`.
+
+The bridge `length_eq_card_gaps` and the gap embedding `boundaries_eq` are derived
+here from Mathlib's `compositionAsSetEquiv`; they are the same combinatorial heart as
+in the parent, redeveloped self-containedly so this moment computation stands alone.
+
+## Status
+- [x] Complete proof (0 sorries, 0 axiom declarations, no native_decide)
+- [x] Headline `total_parts`: total number of parts `= (n+1)·2^(n−2)`
+- [x] `mean_parts` / `two_mul_total_parts`: mean number of parts `= (n+1)/2`
+- [x] Supporting: gap bridge `length_eq_card_gaps`, `sum_finset_card`, `sum_choose_mul`
+- [x] Worked totals for `n = 2, 3, 4` (`3, 8, 20`)
+-/
+
+namespace CompositionPartsChooseOQ01OQ01
+
+open Finset
+
+/-! ## The gap-shift embedding and the boundary set
+
+Mathlib's `compositionAsSetEquiv n : CompositionAsSet n ≃ Finset (Fin (n−1))`
+identifies a composition's boundary set in `Fin (n+1)` with the subset of internal
+gaps it cuts. The embedding below is the inverse shift `i ↦ i + 1` onto the internal
+points `{1, …, n−1}`. -/
+
+/-- The shift `Fin (n−1) ↪ Fin (n+1)`, `i ↦ i + 1`. -/
+def shiftEmb (n : ℕ) : Fin (n - 1) ↪ Fin (n + 1) :=
+  ⟨fun i => ⟨1 + (i : ℕ), by omega⟩, by
+    intro a b h; simp only [Fin.mk.injEq] at h; exact Fin.ext (by omega)⟩
+
+/-- For `n ≥ 1`, the boundary set of a `CompositionAsSet n` is the two forced
+endpoints `0` and `n` together with the shifted internal gap-subset. -/
+theorem boundaries_eq (n : ℕ) (hn : 1 ≤ n) (d : CompositionAsSet n) :
+    d.boundaries =
+      insert 0 (insert (Fin.last n) ((compositionAsSetEquiv n d).map (shiftEmb n))) := by
+  ext x
+  simp only [compositionAsSetEquiv, Equiv.coe_fn_mk, Set.toFinset_setOf, mem_insert, mem_map,
+    mem_filter, Finset.mem_univ, true_and, shiftEmb, Function.Embedding.coeFn_mk]
+  constructor
+  · intro hx
+    by_cases h0 : x = 0
+    · exact Or.inl h0
+    by_cases hl : x = Fin.last n
+    · exact Or.inr (Or.inl hl)
+    have hx0 : (x : ℕ) ≠ 0 := fun h => h0 (Fin.ext (by simpa using h))
+    have hxn : (x : ℕ) ≠ n := fun h => hl (Fin.ext (by simp [Fin.last]; omega))
+    have hxlt : (x : ℕ) < n + 1 := x.isLt
+    have key : (⟨1 + ((x : ℕ) - 1), by omega⟩ : Fin (n + 1)) = x := Fin.ext (by simp; omega)
+    refine Or.inr (Or.inr ⟨⟨(x : ℕ) - 1, by omega⟩, ?_, ?_⟩)
+    · rw [key]; exact hx
+    · exact key
+  · rintro (rfl | rfl | ⟨i, hi, rfl⟩)
+    · exact d.zero_mem
+    · exact d.getLast_mem
+    · exact hi
+
+/-- For `n ≥ 1`, the boundary set has exactly two more elements than the gap-subset
+(the forced endpoints `0` and `n`). -/
+theorem boundaries_card (n : ℕ) (hn : 1 ≤ n) (d : CompositionAsSet n) :
+    d.boundaries.card = (compositionAsSetEquiv n d).card + 2 := by
+  set s := compositionAsSetEquiv n d with hs
+  rw [boundaries_eq n hn d, ← hs]
+  have hlast_not : (Fin.last n) ∉ (s.map (shiftEmb n)) := by
+    simp only [mem_map, shiftEmb, Function.Embedding.coeFn_mk]
+    rintro ⟨i, _, hi⟩; have := i.isLt
+    rw [Fin.ext_iff] at hi; simp [Fin.last] at hi; omega
+  have hzero_not : (0 : Fin (n + 1)) ∉ insert (Fin.last n) (s.map (shiftEmb n)) := by
+    simp only [mem_insert, mem_map, shiftEmb, Function.Embedding.coeFn_mk, not_or]
+    refine ⟨?_, ?_⟩
+    · rw [Fin.ext_iff]; simp [Fin.last]; omega
+    · rintro ⟨i, _, hi⟩; rw [Fin.ext_iff] at hi; simp at hi
+  rw [card_insert_of_notMem hzero_not, card_insert_of_notMem hlast_not, card_map]
+
+/-! ## The length ↔ gap-count bridge -/
+
+/-- The number of parts of a `CompositionAsSet n` (`= boundaries.card − 1`) is one
+more than the size of its gap-subset. -/
+theorem casLength_bridge (n : ℕ) (hn : 1 ≤ n) (d : CompositionAsSet n) :
+    d.length = (compositionAsSetEquiv n d).card + 1 := by
+  have := boundaries_card n hn d; simp only [CompositionAsSet.length]; omega
+
+/-- The composite bijection `Composition n ≃ Finset (Fin (n−1))`: a composition is the
+subset of the `n − 1` internal gaps that it cuts. -/
+noncomputable def gapsEquiv (n : ℕ) : Composition n ≃ Finset (Fin (n - 1)) :=
+  (compositionEquiv n).trans (compositionAsSetEquiv n)
+
+/-- **The part-count bridge.** For `n ≥ 1`, the number of parts of a composition is one
+more than the number of gaps it cuts: `length c = (gaps c).card + 1`. -/
+theorem length_eq_card_gaps (n : ℕ) (hn : 1 ≤ n) (c : Composition n) :
+    c.length = (gapsEquiv n c).card + 1 := by
+  have h1 : c.length = (compositionEquiv n c).length :=
+    (Composition.toCompositionAsSet_length c).symm
+  rw [h1, casLength_bridge n hn (compositionEquiv n c)]; rfl
+
+/-! ## Two binomial sums -/
+
+/-- `∑_{k} k·C(m,k) = m·2^(m−1)` (the "every element lies in half the subsets"
+identity, via the absorption rule `(k+1)·C(m,k+1) = m·C(m−1,k)`). -/
+theorem sum_choose_mul (m : ℕ) :
+    ∑ k ∈ range (m + 1), m.choose k * k = m * 2 ^ (m - 1) := by
+  cases m with
+  | zero => simp
+  | succ M =>
+    rw [Finset.sum_range_succ']
+    simp only [Nat.mul_zero, Nat.choose_zero_right, add_zero]
+    have step : ∀ k ∈ range (M + 1),
+        (M + 1).choose (k + 1) * (k + 1) = (M + 1) * M.choose k := by
+      intro k _; rw [← Nat.add_one_mul_choose_eq]
+    rw [Finset.sum_congr rfl step, ← Finset.mul_sum, Nat.sum_range_choose]; simp
+
+/-- The total size of all subsets of an `m`-element type is `m·2^(m−1)`. -/
+theorem sum_finset_card (m : ℕ) :
+    ∑ s : Finset (Fin m), s.card = m * 2 ^ (m - 1) := by
+  have h1 : ∑ s : Finset (Fin m), s.card
+      = ∑ s ∈ (univ : Finset (Fin m)).powerset, s.card := by rw [Finset.powerset_univ]
+  rw [h1, Finset.sum_powerset_apply_card (fun k => k)]
+  simp only [smul_eq_mul, Finset.card_univ, Fintype.card_fin]
+  exact sum_choose_mul m
+
+/-! ## The first moment: total and mean number of parts -/
+
+/-- **Total number of parts.** Summed over all `2^(n−1)` compositions of `n ≥ 2`, the
+total number of parts is `(n+1)·2^(n−2)`. -/
+theorem total_parts (n : ℕ) (hn : 2 ≤ n) :
+    ∑ c : Composition n, c.length = (n + 1) * 2 ^ (n - 2) := by
+  have hn1 : 1 ≤ n := by omega
+  have e1 : ∑ c : Composition n, c.length
+      = ∑ c : Composition n, ((gapsEquiv n c).card + 1) :=
+    Finset.sum_congr rfl (fun c _ => length_eq_card_gaps n hn1 c)
+  rw [e1, Finset.sum_add_distrib, Equiv.sum_comp (gapsEquiv n) (fun s => s.card),
+      sum_finset_card, Finset.sum_const, Finset.card_univ, composition_card, smul_eq_mul, mul_one]
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 2 := ⟨n - 2, by omega⟩
+  rw [show M + 2 - 1 - 1 = M from by omega, show M + 2 - 1 = M + 1 from by omega,
+      show M + 2 - 2 = M from by omega, pow_succ]
+  ring
+
+/-- **Mean number of parts is `(n+1)/2`** (multiplicative form): twice the total part
+count equals `(n+1)` times the number of compositions. -/
+theorem two_mul_total_parts (n : ℕ) (hn : 2 ≤ n) :
+    2 * ∑ c : Composition n, c.length = (n + 1) * Fintype.card (Composition n) := by
+  rw [total_parts n hn, composition_card]
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 2 := ⟨n - 2, by omega⟩
+  rw [show M + 2 - 2 = M from by omega, show M + 2 - 1 = M + 1 from by omega, pow_succ]; ring
+
+/-- **Mean number of parts is exactly `(n+1)/2`** (rational form, `n ≥ 2`). -/
+theorem mean_parts (n : ℕ) (hn : 2 ≤ n) :
+    (∑ c : Composition n, (c.length : ℚ)) / (Fintype.card (Composition n) : ℚ)
+      = (n + 1) / 2 := by
+  have hcard : (Fintype.card (Composition n) : ℚ) = 2 ^ (n - 1) := by
+    rw [composition_card]; push_cast; ring
+  have hpos : (Fintype.card (Composition n) : ℚ) ≠ 0 := by rw [hcard]; positivity
+  have hcast : (∑ c : Composition n, (c.length : ℚ))
+      = ((∑ c : Composition n, c.length : ℕ) : ℚ) := by push_cast; ring
+  rw [hcast, total_parts n hn, hcard]
+  obtain ⟨M, rfl⟩ : ∃ M, n = M + 2 := ⟨n - 2, by omega⟩
+  rw [show M + 2 - 2 = M from by omega, show M + 2 - 1 = M + 1 from by omega]
+  push_cast [pow_succ]; field_simp
+
+/-! ## Worked totals: `n = 2, 3, 4` give `3, 8, 20` -/
+
+example : ∑ c : Composition 2, c.length = 3 := by rw [total_parts 2 (by norm_num)]; decide
+example : ∑ c : Composition 3, c.length = 8 := by rw [total_parts 3 (by norm_num)]; decide
+example : ∑ c : Composition 4, c.length = 20 := by rw [total_parts 4 (by norm_num)]; decide
+
+end CompositionPartsChooseOQ01OQ01

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01/annotations.json
@@ -1,0 +1,91 @@
+[
+  {
+    "id": "ann-gap-bridge",
+    "proofId": "composition-parts-choose-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 138
+    },
+    "type": "theorem",
+    "title": "The Gap Bijection and the Part-Count Bridge (gapsEquiv, boundaries_eq, length_eq_card_gaps)",
+    "content": "gapsEquiv n composes Mathlib's compositionEquiv : Composition n ≃ CompositionAsSet n with compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), identifying a composition with the subset of the n−1 internal gaps it cuts. The part-count bridge is built up from the boundary set: boundaries_eq exhibits d.boundaries (a Finset of Fin (n+1)) as insert 0 (insert (Fin.last n) (gap-subset.map shiftEmb)), where shiftEmb : Fin (n−1) ↪ Fin (n+1) is the shift i ↦ i+1 onto the internal points {1, …, n−1}. boundaries_card counts this as gap-subset.card + 2, since the two endpoints 0 and n are distinct (n ≥ 1) and neither is a shift of a gap; casLength_bridge then divides by the definition length = boundaries.card − 1 to get the CompositionAsSet form, and length_eq_card_gaps transports it to Composition n via Composition.toCompositionAsSet_length, giving the headline bridge length c = (gaps of c).card + 1. A composition with k parts cuts exactly k−1 of the n−1 gaps.",
+    "mathContext": "$c.\\mathrm{length} = \\#(\\mathrm{gapsEquiv}\\ n\\ c) + 1$.",
+    "prerequisites": [
+      "Compositions and the boundary-set model CompositionAsSet n with length = boundaries.card − 1",
+      "The bijections compositionEquiv and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1))",
+      "Finset.card_insert_of_notMem and Finset.card_map"
+    ],
+    "relatedConcepts": [
+      "enumerative combinatorics",
+      "compositions of an integer",
+      "stars and bars",
+      "cuts in gaps model"
+    ]
+  },
+  {
+    "id": "ann-binomial-sums",
+    "proofId": "composition-parts-choose-oq-01-oq-01",
+    "range": {
+      "startLine": 137,
+      "endLine": 164
+    },
+    "type": "theorem",
+    "title": "Two Binomial Sums (sum_choose_mul, sum_finset_card)",
+    "content": "sum_choose_mul proves the absorption identity ∑_{k=0}^{m} k·C(m,k) = m·2^(m−1): the k = 0 term vanishes, and the absorption rule (k+1)·C(m,k+1) = m·C(m,k) (Nat.add_one_mul_choose_eq) rewrites each remaining term to m·C(m−1,k), whose sum is m·2^(m−1) by Nat.sum_range_choose. sum_finset_card turns this into the geometric statement that the subsets of an m-element type have total size m·2^(m−1): Finset.powerset_univ identifies the universal Finset of subsets with univ.powerset, and Finset.sum_powerset_apply_card reduces ∑_{s ⊆ Fin m} s.card to ∑_k C(m,k)·k. This is the 'every element lies in exactly half the subsets' count, the engine of the mean computation.",
+    "mathContext": "$\\sum_{k} k\\binom{m}{k} = m\\,2^{m-1} = \\sum_{s \\subseteq \\mathrm{Fin}\\,m} \\#s$.",
+    "prerequisites": [
+      "The absorption rule Nat.add_one_mul_choose_eq",
+      "The binomial sum ∑_{j} C(m, j) = 2^m (Nat.sum_range_choose)",
+      "Finset.powerset_univ and Finset.sum_powerset_apply_card"
+    ],
+    "relatedConcepts": [
+      "binomial coefficients",
+      "absorption identity",
+      "subset sums",
+      "power set cardinality"
+    ]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "composition-parts-choose-oq-01-oq-01",
+    "range": {
+      "startLine": 162,
+      "endLine": 201
+    },
+    "type": "theorem",
+    "title": "The Total and Mean Number of Parts (total_parts, two_mul_total_parts, mean_parts)",
+    "content": "total_parts is the headline: for n ≥ 2 the total number of parts over all compositions is (n+1)·2^(n−2). The proof rewrites ∑_{c} c.length via the bridge as ∑_{c} ((gapsEquiv n c).card + 1), splits with Finset.sum_add_distrib into (∑_c (gapsEquiv n c).card) + card(Composition n), reindexes the first summand to ∑_{s : Finset (Fin (n−1))} s.card by Equiv.sum_comp, and evaluates with sum_finset_card ((n−1)·2^(n−2)) and composition_card (2^(n−1)); substituting n = M + 2 closes (n−1)·2^(n−2) + 2^(n−1) = (n+1)·2^(n−2) by ring. The two summands are 'one extra part per cut' and 'one base part per composition'. two_mul_total_parts repackages this as the mean (n+1)/2 multiplicatively (2·total = (n+1)·card), and mean_parts as the rational average (∑_c length)/card = (n+1)/2 — the midpoint of the range [1, n] of possible part-counts, reflecting the symmetry C(n−1,k−1) = C(n−1,n−k) of the distribution.",
+    "mathContext": "$\\sum_{c} c.\\mathrm{length} = (n+1)\\,2^{n-2}$, mean $= \\tfrac{n+1}{2}$ for $n \\ge 2$.",
+    "prerequisites": [
+      "The part-count bridge length_eq_card_gaps and the subset-sum sum_finset_card",
+      "Finset.sum_add_distrib and Equiv.sum_comp for reindexing along the gap bijection",
+      "composition_card : card (Composition n) = 2^(n−1)"
+    ],
+    "relatedConcepts": [
+      "first moment / expectation",
+      "mean number of parts",
+      "uniformly random composition",
+      "symmetry of the part-count distribution"
+    ]
+  },
+  {
+    "id": "ann-worked-totals",
+    "proofId": "composition-parts-choose-oq-01-oq-01",
+    "range": {
+      "startLine": 201,
+      "endLine": 205
+    },
+    "type": "example",
+    "title": "Worked Totals: n = 2, 3, 4 Give 3, 8, 20",
+    "content": "The examples specialise total_parts. The compositions of 2 are 2 (one part) and 1+1 (two parts), total 1 + 2 = 3 = 3·2^0. The compositions of 3 are 3, 1+2, 2+1, 1+1+1 with 1+2+2+3 = 8 = 4·2^1 parts. The compositions of 4 total 20 = 5·2^2 parts. Each matches (n+1)·2^(n−2); the residual closed Nat arithmetic is discharged by the kernel's decide, introducing no Lean.ofReduceBool.",
+    "mathContext": "$(n+1)\\,2^{n-2} = 3, 8, 20$ for $n = 2, 3, 4$.",
+    "prerequisites": [
+      "The headline total_parts",
+      "Kernel decision procedure decide on closed Nat arithmetic"
+    ],
+    "relatedConcepts": [
+      "worked examples",
+      "compositions of small n"
+    ]
+  }
+]

--- a/src/data/proofs/composition-parts-choose-oq-01-oq-01/meta.json
+++ b/src/data/proofs/composition-parts-choose-oq-01-oq-01/meta.json
@@ -1,0 +1,115 @@
+{
+  "id": "composition-parts-choose-oq-01-oq-01",
+  "title": "Composition Parts OQ-01-OQ-01: The Total and Mean Number of Parts of a Composition",
+  "slug": "composition-parts-choose-oq-01-oq-01",
+  "description": "A composition of a natural number n is an ordered tuple of positive integers summing to n (Mathlib's Composition n); its number of parts is c.length. The grandparent entry counts compositions (card (Composition n) = 2^(n−1)) and the parent grades that count by number of parts (compositions of n into exactly k parts number C(n−1, k−1)). This entry computes the first moment of the number of parts — its total and mean across all compositions of n. The headline total_parts proves that summed over all 2^(n−1) compositions of n ≥ 2 the total number of parts is (n+1)·2^(n−2); equivalently (two_mul_total_parts, mean_parts) the mean number of parts is exactly (n+1)/2 — the midpoint of the range [1, n] of possible part-counts, reflecting the symmetry C(n−1,k−1) = C(n−1,n−k) of the part-count distribution. The clean route avoids re-summing ∑_k k·C(n−1,k−1) directly: it uses the gap bijection gapsEquiv : Composition n ≃ Finset (Fin (n−1)) together with the part-count bridge length_eq_card_gaps (length c = (gaps of c).card + 1 — a composition with k parts cuts k−1 of the n−1 internal gaps), transports the sum along the bijection to ∑_{s ⊆ Fin (n−1)} (|s|+1) = (∑_s |s|) + 2^(n−1), and evaluates ∑_{s ⊆ [m]} |s| = m·2^(m−1) (sum_finset_card, via the binomial identity ∑_k k·C(m,k) = m·2^(m−1) in sum_choose_mul). With m = n−1 this gives (n−1)·2^(n−2) + 2^(n−1) = (n+1)·2^(n−2). Mathlib supplies the bijections compositionEquiv and compositionAsSetEquiv and the count composition_card but records neither the part-count bridge nor any moment of the part-count distribution; all of that is original content here.",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Enumerative.Composition",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "CompositionPartsChooseOQ01OQ01",
+    "lineCount": 207,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/CompositionPartsChooseOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Composition_(combinatorics)",
+    "date": "classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompositionPartsChooseOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "enumerative-combinatorics",
+      "compositions",
+      "counting",
+      "binomial-coefficients",
+      "expectation",
+      "first-moment"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "relatedProblems": [
+      {
+        "id": "composition-parts-choose-oq-01",
+        "relationship": "Direct parent: that entry proves the part-graded count — compositions of n into exactly k parts number C(n−1, k−1). This entry computes the first moment of that distribution: total number of parts (n+1)·2^(n−2) and mean (n+1)/2. It reuses the same part-count bridge (cut-count = length − 1), redeveloped self-containedly, and applies it to a sum rather than a fixed k."
+      },
+      {
+        "id": "composition-card-2pow-oq-01",
+        "relationship": "Grandparent: the ungraded total card (Composition n) = 2^(n−1). It appears here as the count of compositions (the additive `+ 2^(n−1)` term in the total-parts computation) and the denominator of the mean."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 207,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. The three small numeric examples (total parts for n = 2, 3, 4 are 3, 8, 20) close with the kernel decision procedure `decide` evaluating closed Nat arithmetic; plain `decide` is kernel-checked and introduces no Lean.ofReduceBool. The named theorems total_parts, two_mul_total_parts and mean_parts were verified with #print axioms to depend only on the foundational propext / Classical.choice / Quot.sound. Mathlib does NOT contain the part-count bridge (length = gap-subset.card + 1) nor any moment of the part-count distribution; both are original content here, built on Mathlib's compositionEquiv, compositionAsSetEquiv, composition_card, Finset.sum_powerset_apply_card, Nat.sum_range_choose, and Nat.add_one_mul_choose_eq. The result is unconditional; the hypothesis n ≥ 2 is the natural domain (for n = 1 the single composition has 1 part, and the closed form (n+1)·2^(n−2) degenerates under truncated subtraction).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Compositions of n are ordered sequences of positive parts summing to n (order matters, unlike partitions). There are 2^(n−1) of them, and — refining by number of parts — C(n−1, k−1) with exactly k parts (the 'cuts in n−1 gaps' model). A natural next question, once the distribution of the number of parts is known, is its average: across all 2^(n−1) compositions of n, how many parts does a composition have on average? Because the part-counts range over 1, 2, …, n with the symmetric multiplicities C(n−1,0), C(n−1,1), …, C(n−1,n−1), the distribution is symmetric about its midpoint, and the mean is exactly (n+1)/2. Equivalently the total number of parts summed over all compositions is (n+1)·2^(n−2). This is the first moment of the part-count statistic, the expectation of the number of parts of a uniformly random composition.",
+    "problemStatement": "Across all 2^(n−1) compositions of n, compute the total number of parts ∑_{c : Composition n} c.length and the mean number of parts. Show, for n ≥ 2,\n\n$$\\sum_{c : \\mathrm{Composition}\\ n} c.\\mathrm{length} = (n+1)\\,2^{\\,n-2}, \\qquad \\text{mean number of parts} = \\frac{n+1}{2}.$$",
+    "text": "Mathlib proves composition_card : card (Composition n) = 2^(n−1) and supplies the bijections compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), the latter sending a boundary set to the subset of internal gaps it cuts. It records neither the bridge length c = (gaps of c).card + 1 nor any moment of the part-count distribution. Both are supplied here. The total number of parts is obtained by summing the bridge over all compositions and transporting along the gap bijection, reducing the computation to the elementary subset-sum ∑_{s ⊆ [m]} |s| = m·2^(m−1).",
+    "proofStrategy": "The gap bridge length_eq_card_gaps (length c = (gapsEquiv n c).card + 1, for n ≥ 1) is built from Mathlib's compositionAsSetEquiv: boundaries_eq exhibits a composition's boundary set as {0, n} together with the shifted gap-subset (image under the embedding i ↦ i+1), boundaries_card counts it as gap-subset.card + 2 (the two forced endpoints are distinct and not shifts of gaps), and casLength_bridge divides by the length = boundaries.card − 1 definition. For the headline total_parts, ∑_c c.length is rewritten via the bridge as ∑_c ((gapsEquiv n c).card + 1), split with Finset.sum_add_distrib into (∑_c (gapsEquiv n c).card) + card(Composition n), reindexed by Equiv.sum_comp to ∑_{s : Finset (Fin (n−1))} s.card, and evaluated: sum_finset_card gives this as (n−1)·2^(n−2) (Finset.powerset_univ + Finset.sum_powerset_apply_card reduce it to ∑_k k·C(n−1,k), which sum_choose_mul evaluates to (n−1)·2^(n−2) via the absorption identity (k+1)·C(m,k+1) = m·C(m,k) and Nat.sum_range_choose), and composition_card gives card(Composition n) = 2^(n−1); the closed form (n+1)·2^(n−2) follows by ring after substituting n = M + 2. two_mul_total_parts and mean_parts repackage the same identity as the multiplicative and rational statements of the mean (n+1)/2, the latter via field_simp using card(Composition n) = 2^(n−1) ≠ 0.",
+    "keyInsights": [
+      "**The expectation collapses to a subset-sum.** Rather than evaluate ∑_k k·C(n−1,k−1) by hand, the part-count bridge length = (gaps).card + 1 turns the total number of parts into ∑_{s ⊆ Fin (n−1)} (|s| + 1) under the gap bijection — i.e. into the elementary fact that the subsets of an (n−1)-set have total size (n−1)·2^(n−2), plus one part per composition. The two summands (n−1)·2^(n−2) and 2^(n−1) are exactly 'one extra part beyond each cut' and 'one base part per composition'.",
+      "**Mean = midpoint of the range.** A composition of n has between 1 and n parts, and the mean is exactly (n+1)/2, the midpoint — a manifestation of the symmetry C(n−1,k−1) = C(n−1,n−k) of the part-count distribution: pairing a composition with k parts against the one with n+1−k parts (complementing its cut-set) averages the part-counts to (n+1)/2.",
+      "**∑_k k·C(m,k) = m·2^(m−1) from absorption.** The arithmetic core sum_choose_mul is the 'every element lies in half the subsets' identity, proved by the absorption rule (k+1)·C(m,k+1) = m·C(m,k) (Nat.add_one_mul_choose_eq) reindexing the sum to m·∑_j C(m−1,j) = m·2^(m−1).",
+      "**Mathlib stops at the count.** composition_card and the two equivalences are available, but neither the part-count bridge nor the moment computation is in Mathlib; that is the original content of this entry, extending the parent's fixed-k graded count to a statistic averaged over all compositions."
+    ],
+    "prerequisites": [
+      "Compositions of a natural number (Mathlib's Composition n), the number of parts c.length, and the boundary-set model CompositionAsSet n with length = boundaries.card − 1",
+      "The bijections compositionEquiv : Composition n ≃ CompositionAsSet n and compositionAsSetEquiv : CompositionAsSet n ≃ Finset (Fin (n−1)), and Equiv.sum_comp for reindexing finite sums",
+      "Finset cardinality and sum API: Finset.sum_add_distrib, Finset.powerset_univ, Finset.sum_powerset_apply_card, Finset.card_insert_of_notMem, Finset.card_map",
+      "Binomial identities: the absorption rule Nat.add_one_mul_choose_eq and ∑_{j=0}^{m} C(m, j) = 2^m (Nat.sum_range_choose); composition_card for card (Composition n) = 2^(n−1)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "gap-bridge",
+      "title": "The Gap Bijection and the Part-Count Bridge",
+      "startLine": 61,
+      "endLine": 138,
+      "mathContext": "$\\mathrm{gapsEquiv}\\ n : \\mathrm{Composition}\\ n \\simeq \\mathrm{Finset}\\,(\\mathrm{Fin}\\,(n-1))$ and $c.\\mathrm{length} = \\#(\\text{gaps of } c) + 1$.",
+      "summary": "boundaries_eq exhibits a composition's boundary set in Fin (n+1) as the two forced endpoints 0 and Fin.last n together with the shifted gap-subset (image of compositionAsSetEquiv n d under the embedding shiftEmb : i ↦ i+1). boundaries_card counts it as gap-subset.card + 2 — the endpoints are distinct (n ≥ 1) and are not shifts of gaps — and casLength_bridge divides by the definition length = boundaries.card − 1 to get length = gap-subset.card + 1. gapsEquiv composes Mathlib's two bijections and length_eq_card_gaps transports the bridge to Composition n via Composition.toCompositionAsSet_length."
+    },
+    {
+      "id": "binomial-sums",
+      "title": "Two Binomial Sums",
+      "startLine": 137,
+      "endLine": 164,
+      "mathContext": "$\\sum_{k} k\\binom{m}{k} = m\\,2^{m-1}$ and $\\sum_{s \\subseteq \\mathrm{Fin}\\,m} \\#s = m\\,2^{m-1}$.",
+      "summary": "sum_choose_mul proves ∑_{k=0}^{m} k·C(m,k) = m·2^(m−1) by peeling the k = 0 term, applying the absorption identity (k+1)·C(m,k+1) = m·C(m,k) (Nat.add_one_mul_choose_eq), and summing with Nat.sum_range_choose. sum_finset_card turns the total size of all subsets of an m-element type into that sum via Finset.powerset_univ and Finset.sum_powerset_apply_card, giving ∑_{s ⊆ Fin m} s.card = m·2^(m−1)."
+    },
+    {
+      "id": "first-moment",
+      "title": "The Total and Mean Number of Parts",
+      "startLine": 162,
+      "endLine": 201,
+      "mathContext": "$\\sum_{c} c.\\mathrm{length} = (n+1)\\,2^{n-2}$ and mean $= \\tfrac{n+1}{2}$ for $n \\ge 2$.",
+      "summary": "total_parts rewrites ∑_c c.length via the bridge as ∑_c ((gapsEquiv n c).card + 1), splits with Finset.sum_add_distrib, reindexes the gap-sum to ∑_{s : Finset (Fin (n−1))} s.card by Equiv.sum_comp, and evaluates with sum_finset_card and composition_card to (n−1)·2^(n−2) + 2^(n−1) = (n+1)·2^(n−2). two_mul_total_parts states the mean (n+1)/2 multiplicatively (2·total = (n+1)·card), and mean_parts states it as the rational average (∑ c, length)/card = (n+1)/2, cleared with field_simp using card = 2^(n−1) ≠ 0."
+    },
+    {
+      "id": "worked-totals",
+      "title": "Worked Totals: n = 2, 3, 4",
+      "startLine": 201,
+      "endLine": 205,
+      "mathContext": "$(n+1)\\,2^{n-2}$ gives $3, 8, 20$ for $n = 2, 3, 4$.",
+      "summary": "The examples specialise total_parts: the compositions of 2 (namely 2 and 1+1) have 1+2 = 3 parts in total, those of 3 have 1+2+2+3 = 8, and those of 4 have 20 — matching (n+1)·2^(n−2). The residual closed Nat arithmetic is discharged by the kernel's decide."
+    }
+  ],
+  "conclusion": "The first moment of the number of parts of a composition is formalised sorry-free and axiom-free: across all 2^(n−1) compositions of n ≥ 2, the total number of parts is (n+1)·2^(n−2) (total_parts) and the mean is exactly (n+1)/2 (two_mul_total_parts, mean_parts), the midpoint of the range [1, n]. The content beyond Mathlib is the part-count bridge length = (gap-subset).card + 1 — derived here from compositionAsSetEquiv via boundaries_eq and boundaries_card — together with its application to a sum: transporting ∑_c c.length along the gap bijection collapses the expectation to the elementary subset-sum ∑_{s ⊆ [m]} |s| = m·2^(m−1) (sum_finset_card, sum_choose_mul). This extends the parent's fixed-k graded count C(n−1, k−1) to a statistic averaged over all compositions. A natural follow-up is the second moment / variance of the number of parts, or the analogous mean part-size n / (mean number of parts) = 2n/(n+1).",
+  "crossReferences": [
+    "composition-parts-choose-oq-01",
+    "composition-card-2pow-oq-01"
+  ]
+}


### PR DESCRIPTION
## Summary

Computes the **first moment** of the number of parts of a composition — a child of `composition-parts-choose-oq-01` (which grades the `2^(n−1)` compositions of `n` by their number of parts as `C(n−1, k−1)`).

For `n ≥ 2`:
- **`total_parts`** — summed over all `2^(n−1)` compositions of `n`, the total number of parts is `(n+1)·2^(n−2)`;
- **`two_mul_total_parts` / `mean_parts`** — equivalently the **mean number of parts is exactly `(n+1)/2`**, the midpoint of the range `[1, n]` (reflecting the symmetry `C(n−1,k−1) = C(n−1,n−k)`).

## Mechanism

The clean route avoids re-summing `∑_k k·C(n−1,k−1)` directly. It uses the gap bijection `gapsEquiv : Composition n ≃ Finset (Fin (n−1))` and the **part-count bridge**

> `length_eq_card_gaps` : `length c = (gaps of c).card + 1`

(derived here from Mathlib's `compositionAsSetEquiv` via `boundaries_eq` / `boundaries_card`: a composition's boundary set is `{0, n}` plus the shifted gap-subset). Transporting `∑_c c.length` along the bijection collapses it to `∑_{s ⊆ Fin(n−1)} (|s| + 1) = (n−1)·2^(n−2) + 2^(n−1) = (n+1)·2^(n−2)`, where `∑_{s ⊆ [m]} |s| = m·2^(m−1)` (`sum_finset_card`, via the binomial identity `∑_k k·C(m,k) = m·2^(m−1)` in `sum_choose_mul`).

Mathlib supplies the bijections and `composition_card` but records neither the part-count bridge nor any moment of the distribution.

## Verification

- **207 lines, 9 theorems / 2 definitions, 0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms` confirms `total_parts`, `two_mul_total_parts`, `mean_parts` depend only on `propext` / `Classical.choice` / `Quot.sound`.
- Worked totals for `n = 2, 3, 4` give `3, 8, 20`.
- Built single-file against the pinned Lean `v4.26.0` / Mathlib toolchain (Docker fleet down); gallery `meta.json` + `annotations.json` validated via `pnpm annotations:build` / `research:build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)