### PR TITLE
research(markov-equation-oq-04): Markov triples are pairwise coprime [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3673,6 +3673,7 @@ import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06
 import Proofs.ZetaRegularization
 import Proofs.CatalanNumbersOQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ02OQ01
+import Proofs.MarkovCoprime
 import Proofs.MarkovEquation
 import Proofs.MantelTheoremOQ04OQ01
 

--- a/proofs/Proofs/MarkovCoprime.lean
+++ b/proofs/Proofs/MarkovCoprime.lean
@@ -1,0 +1,165 @@
+/-
+# Pairwise Coprimality of Markov Triples
+
+The Markov equation `x² + y² + z² = 3xyz` (studied in `Proofs.MarkovEquation`,
+where every positive solution is shown to be reachable from the root `(1,1,1)`
+by *Vieta jumps* and coordinate transpositions) has a striking arithmetic
+rigidity that the geometric classification does not directly expose: **the three
+coordinates of any positive Markov triple are pairwise coprime.**
+
+This file proves that fact and draws its standard consequences. The proof is a
+clean *invariance* argument rather than a fresh descent:
+
+* pairwise coprimality holds at the root `(1,1,1)` (trivially, `gcd 1 1 = 1`);
+* every generating move — a transposition or a Vieta jump `z ↦ 3xy − z` —
+  **preserves** pairwise coprimality, and each move is its own inverse, so the
+  property is preserved *along the reachability relation in both directions*.
+
+Since `markov_classification` (from `Proofs.MarkovEquation`) shows every positive
+Markov triple is reachable from `(1,1,1)`, pairwise coprimality propagates to the
+whole Markov tree.
+
+The crucial algebraic step is that a Vieta jump shifts a coordinate by a multiple
+of the *other two*:
+`3xy − z = (−z) + x·(3y) = (−z) + y·(3x)`,
+so `gcd(x, 3xy−z) = gcd(x, z)` and `gcd(y, 3xy−z) = gcd(y, z)` — coprimality of a
+coordinate with its Vieta partner is unchanged.
+
+## Main results
+
+* `markov_coprime` — every positive Markov triple is pairwise coprime
+  (`IsCoprime` over `ℤ`).
+* `markov_gcd_eq_one` — the same stated with `Int.gcd · · = 1`.
+* `markov_at_most_one_even` — no two coordinates of a Markov triple share the
+  factor `2`; equivalently, **at most one Markov number in a triple is even**.
+
+All results are elementary and fully machine-checked (0 axioms, 0 sorries).
+-/
+import Mathlib
+import Proofs.MarkovEquation
+
+namespace MarkovCoprime
+
+open MarkovEquation
+
+/-- A triple of integers is *pairwise coprime* when each of the three pairs is
+coprime (`IsCoprime`, i.e. an `ℤ`-linear combination equals `1`). We phrase it on
+the product type `ℤ × ℤ × ℤ` so it lines up with the `Step`/`Reachable`
+machinery of `Proofs.MarkovEquation`. -/
+def Coprime3 (p : ℤ × ℤ × ℤ) : Prop :=
+  IsCoprime p.1 p.2.1 ∧ IsCoprime p.2.1 p.2.2 ∧ IsCoprime p.1 p.2.2
+
+/-! ## The Vieta jump preserves coprimality with the jumped coordinate -/
+
+/-- Coprimality of the first coordinate with the third is invariant under the
+Vieta jump `z ↦ 3xy − z`, because `3xy − z` differs from `−z` by the multiple
+`x·(3y)` of `x`. -/
+theorem coprime_fst_vieta (x y z : ℤ) :
+    IsCoprime x (3 * x * y - z) ↔ IsCoprime x z := by
+  rw [show 3 * x * y - z = (-z) + x * (3 * y) from by ring,
+    IsCoprime.add_mul_left_right_iff, IsCoprime.neg_right_iff]
+
+/-- Coprimality of the second coordinate with the third is invariant under the
+Vieta jump, because `3xy − z` differs from `−z` by the multiple `y·(3x)` of `y`. -/
+theorem coprime_snd_vieta (x y z : ℤ) :
+    IsCoprime y (3 * x * y - z) ↔ IsCoprime y z := by
+  rw [show 3 * x * y - z = (-z) + y * (3 * x) from by ring,
+    IsCoprime.add_mul_left_right_iff, IsCoprime.neg_right_iff]
+
+/-! ## Coprimality is an invariant of the Markov tree -/
+
+/-- The root `(1,1,1)` is pairwise coprime. -/
+theorem coprime3_one : Coprime3 (1, 1, 1) :=
+  ⟨isCoprime_one_left, isCoprime_one_left, isCoprime_one_left⟩
+
+/-- **Each move is coprimality-preserving (both directions).** If a single move
+`Step p q` connects `p` and `q`, then `q` is pairwise coprime iff `p` is. Because
+every move (transposition or Vieta jump) is its own inverse, the equivalence is
+symmetric; we record the direction `Coprime3 q → Coprime3 p` needed to propagate
+the property *back* from the root along a reachability path. -/
+theorem coprime3_of_step {p q : ℤ × ℤ × ℤ} (hs : Step p q) (hq : Coprime3 q) :
+    Coprime3 p := by
+  obtain ⟨h12, h23, h13⟩ := hq
+  cases hs with
+  | swap12 x y z =>
+    -- q = (y, x, z): reorder the three coprimalities
+    exact ⟨h12.symm, h13, h23⟩
+  | swap23 x y z =>
+    -- q = (x, z, y): reorder the three coprimalities
+    exact ⟨h13, h23.symm, h12⟩
+  | vieta x y z =>
+    -- q = (x, y, 3xy − z): undo the Vieta jump on the last coordinate
+    exact ⟨h12, (coprime_snd_vieta x y z).1 h23, (coprime_fst_vieta x y z).1 h13⟩
+
+/-- **Pairwise coprimality of Markov triples (triple form).** Every positive
+solution of `x² + y² + z² = 3xyz` is pairwise coprime. The proof inducts on the
+reachability path to the root `(1,1,1)` produced by `markov_classification`,
+pushing coprimality back one move at a time via `coprime3_of_step`. -/
+theorem coprime3_of_isMarkov {x y z : ℤ} (h : IsMarkov x y z) :
+    Coprime3 (x, y, z) := by
+  have hr : Reachable (x, y, z) (1, 1, 1) := markov_classification h
+  -- Generalize the start triple so the induction index is a genuine variable.
+  suffices hgen : ∀ p : ℤ × ℤ × ℤ, Reachable p (1, 1, 1) → Coprime3 p from hgen _ hr
+  intro p hp
+  induction hp using Relation.ReflTransGen.head_induction_on with
+  | refl => exact coprime3_one
+  | head hstep _ ih => exact coprime3_of_step hstep ih
+
+/-! ## Headline statements and consequences -/
+
+/-- **Pairwise coprimality of Markov triples.** In any positive Markov triple the
+three pairs `(x,y)`, `(y,z)`, `(x,z)` are each coprime over `ℤ`. -/
+theorem markov_coprime {x y z : ℤ} (h : IsMarkov x y z) :
+    IsCoprime x y ∧ IsCoprime y z ∧ IsCoprime x z :=
+  coprime3_of_isMarkov h
+
+/-- The first two coordinates of a Markov triple are coprime. -/
+theorem markov_coprime_12 {x y z : ℤ} (h : IsMarkov x y z) : IsCoprime x y :=
+  (markov_coprime h).1
+
+/-- The last two coordinates of a Markov triple are coprime. -/
+theorem markov_coprime_23 {x y z : ℤ} (h : IsMarkov x y z) : IsCoprime y z :=
+  (markov_coprime h).2.1
+
+/-- The outer two coordinates of a Markov triple are coprime. -/
+theorem markov_coprime_13 {x y z : ℤ} (h : IsMarkov x y z) : IsCoprime x z :=
+  (markov_coprime h).2.2
+
+/-- **`gcd` form.** All three pairwise greatest common divisors of a Markov
+triple equal `1`. -/
+theorem markov_gcd_eq_one {x y z : ℤ} (h : IsMarkov x y z) :
+    Int.gcd x y = 1 ∧ Int.gcd y z = 1 ∧ Int.gcd x z = 1 := by
+  obtain ⟨h12, h23, h13⟩ := markov_coprime h
+  exact ⟨Int.isCoprime_iff_gcd_eq_one.1 h12,
+    Int.isCoprime_iff_gcd_eq_one.1 h23,
+    Int.isCoprime_iff_gcd_eq_one.1 h13⟩
+
+/-- A coprime pair of integers cannot share the (non-unit) factor `2`. -/
+theorem not_two_dvd_both {a b : ℤ} (h : IsCoprime a b) : ¬ (2 ∣ a ∧ 2 ∣ b) := by
+  rintro ⟨ha, hb⟩
+  have hu : IsUnit (2 : ℤ) := h.isUnit_of_dvd' ha hb
+  rcases Int.isUnit_iff.1 hu with h1 | h1 <;> norm_num at h1
+
+/-- **At most one Markov number in a triple is even.** No two coordinates of a
+Markov triple are simultaneously even — equivalently they cannot share the factor
+`2`. Stated for all three pairs. -/
+theorem markov_at_most_one_even {x y z : ℤ} (h : IsMarkov x y z) :
+    ¬ (2 ∣ x ∧ 2 ∣ y) ∧ ¬ (2 ∣ y ∧ 2 ∣ z) ∧ ¬ (2 ∣ x ∧ 2 ∣ z) := by
+  obtain ⟨h12, h23, h13⟩ := markov_coprime h
+  exact ⟨not_two_dvd_both h12, not_two_dvd_both h23, not_two_dvd_both h13⟩
+
+/-- The even-coordinate count of a Markov triple is at most one (`Even` phrasing
+of `markov_at_most_one_even` for the first pair, the typical statement
+"two Markov numbers cannot both be even"). -/
+theorem markov_not_both_even {x y z : ℤ} (h : IsMarkov x y z) :
+    ¬ (Even x ∧ Even y) := by
+  rintro ⟨hx, hy⟩
+  exact (markov_at_most_one_even h).1 ⟨hx.two_dvd, hy.two_dvd⟩
+
+/-! ## Sanity checks on the small Markov triples -/
+
+example : IsCoprime (2 : ℤ) 5 := markov_coprime_12 markov_two_five_twentynine
+example : Int.gcd (2 : ℤ) 29 = 1 := (markov_gcd_eq_one markov_two_five_twentynine).2.2
+example : ¬ ((2 : ℤ) ∣ 1 ∧ (2 : ℤ) ∣ 1) := (markov_at_most_one_even markov_one).1
+
+end MarkovCoprime

--- a/src/data/proofs/markov-equation-oq-04/meta.json
+++ b/src/data/proofs/markov-equation-oq-04/meta.json
@@ -1,0 +1,72 @@
+{
+  "id": "markov-equation-oq-04",
+  "title": "Markov Triples Are Pairwise Coprime",
+  "slug": "markov-equation-oq-04",
+  "description": "An axiom-free proof that the three coordinates of every positive Markov triple x² + y² + z² = 3xyz are pairwise coprime. Rather than a fresh descent, the result is an invariance argument over the Markov tree of Proofs/MarkovEquation.lean: pairwise coprimality holds at the root (1,1,1), and each generating move — a transposition or a Vieta jump z ↦ 3xy − z — preserves it, because 3xy − z = −z + x·(3y) = −z + y·(3x) shifts a coordinate by a multiple of each of the other two, leaving gcd(x, 3xy−z) = gcd(x, z) and gcd(y, 3xy−z) = gcd(y, z). Coprimality therefore propagates from the root to the whole tree along the reachability relation. Consequences: all three pairwise gcds equal 1, and no two coordinates of a Markov triple share the factor 2, i.e. at most one Markov number in a triple is even.",
+  "meta": {
+    "author": "Markov theory (classical); formalization original to Lean Genius",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MarkovCoprime.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "markov-equation",
+      "coprimality",
+      "vieta-jumping",
+      "markov-tree"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 165,
+    "originalContributions": [
+      "Coprime3: pairwise-coprimality predicate on triples ℤ × ℤ × ℤ, aligned with the Step/Reachable move relation",
+      "coprime_fst_vieta / coprime_snd_vieta: a Vieta jump z ↦ 3xy − z leaves coprimality with the jumped coordinate unchanged (gcd(x, 3xy−z) = gcd(x, z) and gcd(y, 3xy−z) = gcd(y, z))",
+      "coprime3_of_step: every generating move (two transpositions and the Vieta jump) preserves pairwise coprimality in both directions, since each move is an involution",
+      "coprime3_of_isMarkov: pairwise coprimality propagates from the root (1,1,1) to every positive Markov triple via head-induction on the reachability path from markov_classification",
+      "markov_coprime: headline theorem — every positive Markov triple is pairwise coprime over ℤ",
+      "markov_gcd_eq_one: the three pairwise gcds of a Markov triple all equal 1",
+      "not_two_dvd_both / markov_at_most_one_even / markov_not_both_even: no two coordinates share the factor 2 — at most one Markov number per triple is even"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound. No native_decide is used. The proof imports the verified classification (markov_classification, Step, Reachable) from the parent entry Proofs/MarkovEquation.lean.",
+    "theoremCount": 13,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "markov-equation",
+      "relationship": "extends",
+      "description": "Builds directly on the parent's tree classification: markov_classification gives a reachability path from any positive Markov triple to the root (1,1,1), and pairwise coprimality is shown to be invariant along the Step relation (transpositions + Vieta jumps), so it transports from the root to the whole tree."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Markov numbers — coordinates of the triples solving x² + y² + z² = 3xyz — carry rich arithmetic structure beyond the tree shape itself. A basic, classical such property is that within any triple the three numbers are pairwise coprime; it underlies, for instance, the reduction theory of the associated indefinite binary quadratic forms and the standard normalizations in work on the Markov uniqueness conjecture. The fact is usually stated in passing as 'obviously the entries of a Markov triple are coprime'; here it is given a clean machine-checked proof as a structural invariant of the Markov tree.",
+    "problemStatement": "Show that for every positive integer solution (x, y, z) of x² + y² + z² = 3xyz, the three coordinates are pairwise coprime: gcd(x,y) = gcd(y,z) = gcd(x,z) = 1. Deduce that at most one coordinate of any Markov triple is even.",
+    "proofStrategy": "An invariance argument over the Markov tree rather than a new descent. (1) Pairwise coprimality holds at the root (1,1,1). (2) Each generating move preserves it: transpositions only permute the three coprimality statements, and the Vieta jump z ↦ 3xy − z leaves gcd(x, ·) and gcd(y, ·) with the jumped coordinate unchanged because 3xy − z = −z + x·(3y) = −z + y·(3x) differs from −z by a multiple of x and of y. (3) Each move is its own inverse, so coprimality is preserved along the reachability relation in both directions. Since markov_classification (parent entry) reaches the root from any positive triple, head-induction on that path pushes coprimality from (1,1,1) back to the given triple.",
+    "keyInsights": [
+      "Coprimality with the jumped coordinate is a Vieta invariant. The Vieta partner 3xy − z is congruent to −z modulo both x and y (3xy ≡ 0 mod x and mod y), so IsCoprime x (3xy − z) ↔ IsCoprime x z and IsCoprime y (3xy − z) ↔ IsCoprime y z. These two `IsCoprime.add_mul_left_right_iff`/`neg_right_iff` equivalences are the entire arithmetic content.",
+      "The proof needs no infinite descent of its own. The parent file already supplies a reachability path to (1,1,1); coprimality is simply transported along it. Because the moves are involutions, the same preservation lemma works in the 'backward' direction required by ReflTransGen.head_induction_on.",
+      "Pairwise coprimality immediately yields the parity statement: 2 is not a unit in ℤ, so IsCoprime a b forbids 2 | a and 2 | b simultaneously (IsCoprime.isUnit_of_dvd' would make 2 a unit). Hence at most one coordinate of a Markov triple is even — consistent with the triples (1,1,1), (1,1,2), (1,2,5), (1,5,13), (2,5,29), … in which the even entries are isolated.",
+      "Stating the predicate on the product type ℤ × ℤ × ℤ (Coprime3) is what makes the induction line up cleanly with the Step/Reachable infrastructure, avoiding any higher-order unification trouble in the head-induction."
+    ]
+  },
+  "conclusion": {
+    "summary": "A 0-axiom, 0-sorry formalization (165 lines, 13 theorems, 1 definition) proving that every positive Markov triple is pairwise coprime, together with the gcd-form and the parity corollary that at most one coordinate is even. The proof reuses the parent's verified tree classification and reduces the whole statement to the single observation that a Vieta jump shifts a coordinate by a multiple of the other two.",
+    "implications": "Pairwise coprimality is a basic normalization used throughout Markov theory and the study of the Lagrange spectrum; isolating it as an invariant of the move relation shows how arithmetic properties of Markov triples can be read off the tree structure without re-running descent. The same template (verify at the root, check preservation under each move, transport along reachability) applies to other tree-invariant properties — e.g. parity patterns or congruence conditions of Markov numbers.",
+    "openQuestions": [
+      "Which exact residue/parity pattern do the three coordinates of a Markov triple realize (e.g. the standard fact that each triple has the parity profile odd-odd-even up to the root), proved as a tree invariant in the same style?",
+      "Markov uniqueness conjecture: does the largest coordinate determine the triple? Pairwise coprimality is one of the standard hypotheses in attacks on this still-open problem, but the conjecture itself is not addressed here."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 165,
+    "axiomCount": 0,
+    "path": "Proofs/MarkovCoprime.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 13
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A 0-axiom, 0-sorry formalization proving that **every positive Markov triple is pairwise coprime**: for any positive solution of `x² + y² + z² = 3xyz`, `gcd(x,y) = gcd(y,z) = gcd(x,z) = 1`. Plus the standard parity corollary: **at most one coordinate of a Markov triple is even**.

Builds directly on the verified parent entry `markov-equation` (`Proofs/MarkovEquation.lean`), which classifies the positive solutions as the Vieta-jump tree rooted at `(1,1,1)`.

## Approach — invariance, not a new descent

Rather than re-run infinite descent, coprimality is shown to be an **invariant of the Markov tree**:

1. Pairwise coprimality holds at the root `(1,1,1)` (trivially).
2. Each generating move preserves it:
   - transpositions only permute the three coprimality statements;
   - the Vieta jump `z ↦ 3xy − z` leaves `gcd` with the jumped coordinate unchanged, because
     `3xy − z = (−z) + x·(3y) = (−z) + y·(3x)` differs from `−z` by a multiple of `x` and of `y`, so
     `IsCoprime x (3xy−z) ↔ IsCoprime x z` and `IsCoprime y (3xy−z) ↔ IsCoprime y z`.
3. Every move is its own inverse, so coprimality propagates along the reachability relation in both directions. `markov_classification` (parent) gives a path from any positive triple to `(1,1,1)`, and `ReflTransGen.head_induction_on` transports coprimality from the root back to the triple.

The entire arithmetic content is the two `IsCoprime.add_mul_left_right_iff` / `IsCoprime.neg_right_iff` equivalences.

## Main results

| Theorem | Statement |
|---|---|
| `markov_coprime` | every positive Markov triple is pairwise coprime over ℤ |
| `markov_gcd_eq_one` | the three pairwise `Int.gcd`s all equal `1` |
| `markov_at_most_one_even` | no two coordinates share the factor `2` |
| `markov_not_both_even` | `¬ (Even x ∧ Even y)` |

## Verification

- `Proofs/MarkovCoprime.lean`: 165 lines, 13 theorems, 1 definition.
- `0` sorries, `0` axiom declarations, no `native_decide`.
- `#print axioms` on the headline results reports only `propext`, `Classical.choice`, `Quot.sound`.
- Compiled with the pinned toolchain `leanprover/lean4:v4.26.0` against the prebuilt Mathlib + parent olean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)