### PR TITLE
research(markov-equation-oq-03-oq-01): complete classification of the a=1 Markov–Hurwitz slice as 3× the Markov tree [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3680,6 +3680,7 @@ import Proofs.CatalanNumbersOQ01OQ02
 import Proofs.CatalanNumbersOQ01OQ02OQ01
 import Proofs.MarkovEquation
 import Proofs.MarkovHurwitz
+import Proofs.MarkovHurwitzOQ03OQ01
 import Proofs.MantelTheoremOQ04OQ01
 
 

--- a/proofs/Proofs/MarkovHurwitzOQ03OQ01.lean
+++ b/proofs/Proofs/MarkovHurwitzOQ03OQ01.lean
@@ -1,0 +1,208 @@
+/-
+# Complete Classification of the a = 1 Markov–Hurwitz Slice
+
+The classical Markov equation `x² + y² + z² = 3xyz` is the `a = 3` member of the
+one–parameter **Markov–Hurwitz family** `x² + y² + z² = a · x · y · z`. The sibling
+entry `markov-equation-oq-03` carries the *Vieta-jump infrastructure* of the parent
+to this family — the coefficient-agnostic jump, the n-variable descent criterion,
+and the parametric `+k` foliation. What it does **not** do is classify any new
+member of the family.
+
+This file supplies that missing piece for the second coefficient that admits
+solutions, `a = 1`: it proves a **complete classification** of the positive
+solutions of
+
+  x² + y² + z² = x · y · z
+
+by reducing them, exactly, to the Markov tree of the parent `Proofs.MarkovEquation`.
+
+The main results are:
+
+* **Mod-3 obstruction.** Every positive solution of `x²+y²+z² = xyz` has all three
+  coordinates divisible by `3`. Modulo `3` the only residue triple satisfying the
+  equation is `(0,0,0)` — a finite 27-case check (`decide`, not `native_decide`,
+  so the result stays axiom-clean).
+
+* **Scaling bijection.** `(x,y,z) ↦ (x/3, y/3, z/3)` is a bijection between `a = 1`
+  solutions and Markov triples: `x²+y²+z² = xyz` holds iff `(x,y,z) = (3a,3b,3c)`
+  for a Markov triple `(a,b,c)`.
+
+* **Transported classification.** Composing the bijection with the parent's
+  `markov_classification`, every positive `a = 1` solution is `(3a,3b,3c)` with
+  `(a,b,c)` reachable from the root `(1,1,1)` in the Markov tree.
+
+* **Coefficient rigidity.** A symmetric solution `(t,t,t)` of the family forces
+  `a·t = 3`, hence `a ∈ {1, 3}` — exactly the two coefficients whose full solution
+  sets are now classified (`a = 3` by the parent, `a = 1` here).
+
+We also record the coefficient-agnostic Vieta jump in concrete ternary form, to keep
+the file self-contained. Honest scope: we do **not** prove Hurwitz's full theorem
+that no coefficient outside `{1,3}` admits any positive solution (only the diagonal
+obstruction); the parametric `+k` and n-variable infrastructure live in the sibling
+`markov-equation-oq-03` entry. The global non-existence statement needs a genuine
+minimality/descent argument and is left as the natural next step.
+-/
+import Mathlib
+import Proofs.MarkovEquation
+
+namespace MarkovHurwitzOQ03OQ01
+
+open MarkovEquation
+
+/-- A **Markov–Hurwitz triple** with coefficient `a`: positive integers satisfying
+`x² + y² + z² = a · x · y · z`. -/
+def IsHurwitz (a x y z : ℤ) : Prop :=
+  0 < x ∧ 0 < y ∧ 0 < z ∧ x ^ 2 + y ^ 2 + z ^ 2 = a * x * y * z
+
+/-! ## Coefficient-agnostic Vieta jumping
+
+Everything that drives the Markov descent depends only on the shape of the
+equation, not on the value of `a`. We re-derive the core facts for general `a`. -/
+
+/-- The product of the two `z`-roots of `t² − a·xy·t + (x²+y²) = 0` equals
+`x² + y²`, independently of `a`. -/
+theorem hurwitz_root_prod {a x y z : ℤ} (h : IsHurwitz a x y z) :
+    z * (a * x * y - z) = x ^ 2 + y ^ 2 := by
+  obtain ⟨_, _, _, he⟩ := h
+  linear_combination -he
+
+/-- **Vieta jump for general `a`.** Replacing `z` by its conjugate root
+`a·xy − z` yields another Markov–Hurwitz triple with the same coefficient. -/
+theorem hurwitz_vieta {a x y z : ℤ} (h : IsHurwitz a x y z) :
+    IsHurwitz a x y (a * x * y - z) := by
+  obtain ⟨hx, hy, hz, he⟩ := h
+  have hzz : z * (a * x * y - z) = x ^ 2 + y ^ 2 := by linear_combination -he
+  have hpos : 0 < x ^ 2 + y ^ 2 := by positivity
+  refine ⟨hx, hy, ?_, by linear_combination he⟩
+  nlinarith [hzz, hpos, hz]
+
+/-- The Vieta jump is an involution in the third coordinate, for every `a`. -/
+theorem hurwitz_vieta_involutive (a x y z : ℤ) :
+    a * x * y - (a * x * y - z) = z := by ring
+
+/-! ## The `a = 3` slice is the Markov equation -/
+
+/-- For coefficient `a = 3`, the Markov–Hurwitz predicate is *definitionally* the
+Markov predicate of the parent file. -/
+theorem isHurwitz_three_iff_isMarkov (x y z : ℤ) :
+    IsHurwitz 3 x y z ↔ IsMarkov x y z := by
+  unfold IsHurwitz IsMarkov
+  constructor <;> rintro ⟨hx, hy, hz, he⟩ <;> exact ⟨hx, hy, hz, by linear_combination he⟩
+
+/-! ## The `a = 1` slice: divisibility by 3
+
+The arithmetic heart of the `a = 1` classification is that *every* positive
+solution of `x² + y² + z² = xyz` has all coordinates divisible by `3`. Modulo
+`3`, squares are `0` or `1`; a finite (27-case) check shows the only residue
+triple satisfying the equation is `(0,0,0)`. -/
+
+/-- **Mod-3 obstruction.** Any integer solution of `x² + y² + z² = xyz` has all
+three coordinates divisible by `3`. (No positivity needed.) -/
+theorem three_dvd_all_of_hurwitz_one {x y z : ℤ}
+    (he : x ^ 2 + y ^ 2 + z ^ 2 = x * y * z) :
+    (3 : ℤ) ∣ x ∧ (3 : ℤ) ∣ y ∧ (3 : ℤ) ∣ z := by
+  -- The only residue triple mod 3 satisfying the equation is (0,0,0).
+  have key : ∀ a b c : ZMod 3, a ^ 2 + b ^ 2 + c ^ 2 = a * b * c →
+      a = 0 ∧ b = 0 ∧ c = 0 := by decide
+  -- Push the integer equation into `ZMod 3`.
+  have hcast : (x : ZMod 3) ^ 2 + (y : ZMod 3) ^ 2 + (z : ZMod 3) ^ 2
+      = (x : ZMod 3) * (y : ZMod 3) * (z : ZMod 3) := by
+    have h := congrArg (Int.cast : ℤ → ZMod 3) he
+    push_cast at h
+    linear_combination h
+  obtain ⟨hx0, hy0, hz0⟩ := key _ _ _ hcast
+  refine ⟨?_, ?_, ?_⟩
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd x 3).mp hx0
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd y 3).mp hy0
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd z 3).mp hz0
+
+/-! ## The scaling bijection `a = 1  ↔  3 × Markov` -/
+
+/-- **Markov ⇒ Hurwitz(1).** Tripling a Markov triple gives an `a = 1` solution:
+if `(a,b,c)` solves `a²+b²+c² = 3abc`, then `(3a,3b,3c)` solves the `a = 1`
+equation `x²+y²+z² = xyz`. -/
+theorem hurwitz_one_of_markov {a b c : ℤ} (h : IsMarkov a b c) :
+    IsHurwitz 1 (3 * a) (3 * b) (3 * c) := by
+  obtain ⟨ha, hb, hc, he⟩ := h
+  refine ⟨by linarith, by linarith, by linarith, ?_⟩
+  -- 9(a²+b²+c²) = 9·3abc = 27abc = (3a)(3b)(3c)
+  linear_combination (9 : ℤ) * he
+
+/-- **Hurwitz(1) ⇒ Markov.** Conversely every `a = 1` solution is `3 ×` a Markov
+triple: there exist `a, b, c` with `x = 3a`, `y = 3b`, `z = 3c` and
+`IsMarkov a b c`. -/
+theorem markov_of_hurwitz_one {x y z : ℤ} (h : IsHurwitz 1 x y z) :
+    ∃ a b c : ℤ, x = 3 * a ∧ y = 3 * b ∧ z = 3 * c ∧ IsMarkov a b c := by
+  obtain ⟨hx, hy, hz, he⟩ := h
+  have he' : x ^ 2 + y ^ 2 + z ^ 2 = x * y * z := by linear_combination he
+  obtain ⟨⟨a, rfl⟩, ⟨b, rfl⟩, ⟨c, rfl⟩⟩ := three_dvd_all_of_hurwitz_one he'
+  refine ⟨a, b, c, rfl, rfl, rfl, ?_, ?_, ?_, ?_⟩
+  · linarith
+  · linarith
+  · linarith
+  · -- 9(a²+b²+c²) = (3a)(3b)(3c) = 27abc ⟹ a²+b²+c² = 3abc
+    have h9 : (9 : ℤ) * (a ^ 2 + b ^ 2 + c ^ 2) = 9 * (3 * a * b * c) := by
+      linear_combination he
+    linarith
+
+/-- **Bijection form.** `(x,y,z)` is an `a = 1` solution iff it is `3 ×` a Markov
+triple. -/
+theorem hurwitz_one_iff_markov_scaled {x y z : ℤ} :
+    IsHurwitz 1 x y z ↔
+      ∃ a b c : ℤ, x = 3 * a ∧ y = 3 * b ∧ z = 3 * c ∧ IsMarkov a b c := by
+  constructor
+  · exact markov_of_hurwitz_one
+  · rintro ⟨a, b, c, rfl, rfl, rfl, hM⟩
+    exact hurwitz_one_of_markov hM
+
+/-! ## Complete classification of the `a = 1` solutions
+
+Composing the scaling bijection with the parent's Markov-tree classification
+yields a complete description of the `a = 1` solution set. -/
+
+/-- **Classification at `a = 1`.** Every positive solution of `x²+y²+z² = xyz`
+is `(3a, 3b, 3c)` for a triple `(a,b,c)` reachable from the root `(1,1,1)` in the
+Markov tree. -/
+theorem hurwitz_one_classification {x y z : ℤ} (h : IsHurwitz 1 x y z) :
+    ∃ a b c : ℤ, x = 3 * a ∧ y = 3 * b ∧ z = 3 * c ∧
+      Reachable (a, b, c) (1, 1, 1) := by
+  obtain ⟨a, b, c, hx, hy, hz, hM⟩ := markov_of_hurwitz_one h
+  exact ⟨a, b, c, hx, hy, hz, markov_classification hM⟩
+
+/-! ## Coefficient rigidity (diagonal obstruction) -/
+
+/-- A **diagonal** Markov–Hurwitz triple `(t,t,t)` forces `a · t = 3`. -/
+theorem hurwitz_diagonal {a t : ℤ} (h : IsHurwitz a t t t) : a * t = 3 := by
+  obtain ⟨ht, _, _, he⟩ := h
+  -- 3t² = a·t³ and t > 0 ⇒ a·t = 3
+  have ht2 : (0 : ℤ) < t ^ 2 := by positivity
+  have hkey : t ^ 2 * (a * t) = t ^ 2 * 3 := by linear_combination -he
+  exact mul_left_cancel₀ ht2.ne' hkey
+
+/-- **Diagonal coefficients are `1` or `3`.** A positive diagonal solution exists
+only for `a = 1` (with `t = 3`) or `a = 3` (with `t = 1`). -/
+theorem hurwitz_diagonal_coeff {a t : ℤ} (h : IsHurwitz a t t t) :
+    (a = 1 ∧ t = 3) ∨ (a = 3 ∧ t = 1) := by
+  have hat : a * t = 3 := hurwitz_diagonal h
+  obtain ⟨ht, _, _, _⟩ := h
+  have ha : 0 < a := by nlinarith [hat, ht]
+  have ht1 : 1 ≤ t := ht
+  have hat3 : t ≤ 3 := by nlinarith [hat, ha]
+  -- positive factorisations of 3
+  interval_cases t <;> omega
+
+/-! ## Small solutions -/
+
+/-- `(3,3,3)` is the diagonal `a = 1` solution — the image of the Markov root. -/
+theorem hurwitz_one_three_three_three : IsHurwitz 1 3 3 3 :=
+  ⟨by norm_num, by norm_num, by norm_num, by ring⟩
+
+/-- `(3,3,6)` is an `a = 1` solution — the image of the Markov triple `(1,1,2)`. -/
+theorem hurwitz_one_three_three_six : IsHurwitz 1 3 3 6 :=
+  ⟨by norm_num, by norm_num, by norm_num, by ring⟩
+
+/-- `(3,6,15)` is an `a = 1` solution — the image of the Markov triple `(1,2,5)`. -/
+theorem hurwitz_one_three_six_fifteen : IsHurwitz 1 3 6 15 :=
+  ⟨by norm_num, by norm_num, by norm_num, by ring⟩
+
+end MarkovHurwitzOQ03OQ01

--- a/src/data/proofs/markov-equation-oq-03-oq-01/meta.json
+++ b/src/data/proofs/markov-equation-oq-03-oq-01/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "markov-equation-oq-03-oq-01",
+  "title": "Complete Classification of the a=1 Markov–Hurwitz Slice (3× the Markov Tree)",
+  "slug": "markov-equation-oq-03-oq-01",
+  "description": "A fully verified, axiom-free complete classification of the positive solutions of the a=1 Markov–Hurwitz equation x² + y² + z² = xyz. Where the sibling entry markov-equation-oq-03 carries the Vieta-jump infrastructure to the family x²+y²+z²=a·xyz, this entry classifies a genuinely new member: the a=1 slice. The key is a mod-3 obstruction — modulo 3 the only residue triple satisfying the equation is (0,0,0), a finite 27-case decide check — forcing 3 to divide every coordinate. Dividing through by 3 yields a Markov triple, so (x,y,z) ↦ (x/3,y/3,z/3) is a bijection between a=1 solutions and Markov triples; composing with the parent's markov_classification gives a complete classification: every a=1 solution is (3a,3b,3c) with (a,b,c) reachable from (1,1,1) in the Markov tree. A diagonal-solution argument shows a·t=3, so the only coefficients with a symmetric solution are a∈{1,3} — exactly the two slices now fully classified (a=3 by the parent, a=1 here).",
+  "meta": {
+    "author": "A. Hurwitz (1907); formalization original to Lean Genius",
+    "date": "1907",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MarkovHurwitzOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "markov-equation",
+      "markov-hurwitz",
+      "vieta-jumping",
+      "infinite-descent"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 208,
+    "originalContributions": [
+      "IsHurwitz a x y z: the Markov–Hurwitz predicate x²+y²+z²=a·xyz with positivity",
+      "three_dvd_all_of_hurwitz_one: every solution of x²+y²+z²=xyz has 3 dividing all coordinates (decide over (ZMod 3)³, no native_decide)",
+      "hurwitz_one_of_markov / markov_of_hurwitz_one: the scaling bijection between a=1 solutions and 3× Markov triples",
+      "hurwitz_one_iff_markov_scaled: the a=1 equation holds iff (x,y,z) is 3× a Markov triple",
+      "hurwitz_one_classification: complete classification of a=1 solutions via the parent's Markov tree",
+      "hurwitz_diagonal / hurwitz_diagonal_coeff: a diagonal solution forces a·t=3, hence a∈{1,3}",
+      "isHurwitz_three_iff_isMarkov: the a=3 slice is definitionally the parent's Markov predicate",
+      "hurwitz_root_prod / hurwitz_vieta: the coefficient-agnostic Vieta jump z ↦ a·xy − z in concrete ternary form (positivity preserved)"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations. #print axioms on the main theorems (hurwitz_one_classification, three_dvd_all_of_hurwitz_one, hurwitz_diagonal_coeff) reports only the foundational propext / Classical.choice / Quot.sound; the divisibility lemma uses decide, not native_decide, so there is no Lean.ofReduceBool dependency. The result imports the parent Proofs/MarkovEquation.lean (itself 0-axiom verified) to transport its Markov-tree classification.",
+    "theoremCount": 14,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "markov-equation-oq-03",
+      "relationship": "extends",
+      "description": "The sibling oq-03 entry carries the Vieta-jump infrastructure (coefficient-agnostic jump, parametric +k foliation, n-variable descent criterion) to the Markov–Hurwitz family but classifies no new member. This entry supplies the complete classification of the a=1 slice, the second coefficient (after a=3) that admits positive solutions."
+    },
+    {
+      "targetId": "markov-equation",
+      "relationship": "extends",
+      "description": "The parent classifies the Markov equation x²+y²+z²=3xyz (the a=3 member). This entry reuses the parent's IsMarkov predicate and markov_classification to transport the tree structure to the a=1 slice via the scaling bijection (x,y,z) ↦ (3x,3y,3z)."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "uses",
+      "description": "Fixing x and y turns x²+y²+z²=a·xyz into the quadratic t²−a·xy·t+(x²+y²)=0 in z, whose roots z, z'=a·xy−z satisfy z·z'=x²+y². The coefficient-agnostic Vieta jump is exactly the root swap."
+    }
+  ],
+  "overview": {
+    "historicalContext": "After Markov's 1879–1880 study of x²+y²+z²=3xyz, Adolf Hurwitz (1907) considered the family x²+y²+z²=a·xyz, asking for which a positive solutions exist. In three variables only a=1 and a=3 admit solutions, and the two solution sets are isomorphic: tripling a Markov triple turns the a=3 equation into the a=1 equation, so the a=1 numbers 3, 6, 15, 39, … are exactly 3× the Markov numbers. This entry formalizes that isomorphism — the mod-3 obstruction and the scaling bijection — and transports the parent's Markov-tree classification to the a=1 slice.",
+    "problemStatement": "Classify completely the positive integer solutions of x²+y²+z²=xyz (the a=1 Markov–Hurwitz slice), and determine which coefficients a admit a symmetric (diagonal) solution.",
+    "proofStrategy": "Reduce modulo 3: squares mod 3 are 0 or 1, and a 27-case decision over (ZMod 3)³ shows the only residue triple satisfying x²+y²+z²=xyz is (0,0,0); hence 3 divides every coordinate. Writing x=3a, y=3b, z=3c and cancelling 9 turns the equation into a²+b²+c²=3abc — the Markov equation. The map (3a,3b,3c) ↔ (a,b,c) is the bijection; composing with the parent's markov_classification classifies all a=1 solutions. Separately, a diagonal solution (t,t,t) gives 3t²=a·t³, so a·t=3 with a,t>0, forcing (a,t)∈{(1,3),(3,1)}.",
+    "keyInsights": [
+      "The arithmetic heart is a congruence obstruction: in ZMod 3 the only solution of x²+y²+z²=xyz is (0,0,0). This is a finite check (decide, not native_decide, so it stays axiom-clean) and it forces 3 ∣ x, y, z.",
+      "After dividing every coordinate by 3, cancelling the common factor 9 turns x²+y²+z²=xyz into a²+b²+c²=3abc — the Markov equation. So the a=1 solution set is in explicit bijection with the Markov tree.",
+      "The bijection is concrete: (x,y,z) solves x²+y²+z²=xyz iff (x,y,z)=(3a,3b,3c) for a Markov triple (a,b,c). The smallest a=1 solutions 3,3,3 / 3,3,6 / 3,6,15 are 3× the Markov triples 1,1,1 / 1,1,2 / 1,2,5.",
+      "Transporting the parent's complete classification, every positive a=1 solution is reachable from the root: it is (3a,3b,3c) with (a,b,c) reachable from (1,1,1) by Vieta jumps and transpositions in the Markov tree.",
+      "Coefficient rigidity is elementary on the diagonal: (t,t,t) Markov–Hurwitz forces a·t=3, so among all a only a=1 (t=3) and a=3 (t=1) have a symmetric solution — exactly the two coefficients whose full solution sets are now classified (a=3 by the parent, a=1 here).",
+      "The descent engine is coefficient-agnostic even before the a=1 specialization: fixing x,y the equation is the monic quadratic t²−a·xy·t+(x²+y²) in z with positive root product, so the Vieta partner a·xy−z is always positive — recorded here in concrete ternary form."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (208 lines, 14 theorems, 1 definition) completing the classification of the a=1 Markov–Hurwitz slice. The positive solutions of x²+y²+z²=xyz are shown to be exactly 3× the Markov tree, via a mod-3 divisibility argument and a scaling bijection composed with the parent's markov_classification; a diagonal obstruction pins the symmetric-solution coefficients to a∈{1,3}.",
+    "implications": "Together with the parent (a=3) and the sibling oq-03 (Vieta infrastructure), this gives a complete picture of the two solvable Markov–Hurwitz coefficients in three variables: both solution sets are the same Markov tree up to the scaling factor 3. The mod-3 obstruction plus scaling bijection is the standard route by which Markov theory absorbs the a=1 case; making it machine-checked isolates exactly which step is arithmetic (the congruence) and which is structural (the transported descent).",
+    "openQuestions": [
+      "Hurwitz's full theorem: prove that no coefficient a outside {1,3} admits any positive solution of x²+y²+z²=a·xyz. This needs a genuine minimality/descent argument bounding a non-diagonal solution, not just the diagonal obstruction proved here.",
+      "Markov–Hurwitz in n variables: x₁²+···+xₙ²=a·x₁···xₙ admits solutions only for finitely many a (Hurwitz); the n-variable Vieta jump and descent criterion are formalized in the sibling oq-03, but a full tree classification for n ≥ 4 remains open.",
+      "Effective enumeration: combine the scaling bijection with quantitative Markov-tree growth to count a=1 solutions with maximal coordinate ≤ N (asymptotically (log N)²)."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 208,
+    "axiomCount": 0,
+    "path": "Proofs/MarkovHurwitzOQ03OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 14
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

A child of the freshly-merged `markov-equation-oq-03` (PR #27824). That sibling carried the **Vieta-jump infrastructure** to the Markov–Hurwitz family `x²+y²+z²=a·xyz` (coefficient-agnostic jump, parametric `+k` foliation, n-variable descent criterion) but **classified no new family member**. This PR supplies that missing piece for the second solvable coefficient, `a = 1`:

**The positive solutions of `x²+y²+z² = xyz` are exactly `3 ×` the Markov tree.**

`proofs/Proofs/MarkovHurwitzOQ03OQ01.lean` — **208 lines, 14 theorems, 1 definition, 0 sorries, 0 `axiom`, no `native_decide`.** Imports the parent `Proofs.MarkovEquation` (itself 0-axiom verified) to transport its `markov_classification`.

### Results
- **`three_dvd_all_of_hurwitz_one`** — mod-3 obstruction: modulo 3 the only residue triple solving `x²+y²+z²=xyz` is `(0,0,0)` (a 27-case `decide` over `(ZMod 3)³`, *not* `native_decide`), forcing `3 ∣ x, y, z`.
- **`hurwitz_one_iff_markov_scaled`** — the scaling bijection: `x²+y²+z²=xyz` holds iff `(x,y,z)=(3a,3b,3c)` for a Markov triple `(a,b,c)`. Cancelling the common factor 9 turns the `a=1` equation into `a²+b²+c²=3abc`.
- **`hurwitz_one_classification`** — composing with the parent's `markov_classification`: every positive `a=1` solution is `(3a,3b,3c)` with `(a,b,c)` reachable from the root `(1,1,1)` in the Markov tree. The smallest are `(3,3,3), (3,3,6), (3,6,15) = 3×(1,1,1), 3×(1,1,2), 3×(1,2,5)`.
- **`hurwitz_diagonal_coeff`** — coefficient rigidity: a symmetric solution `(t,t,t)` forces `a·t=3`, so the only coefficients with a diagonal solution are `a ∈ {1,3}` — exactly the two slices now fully classified (`a=3` by the parent, `a=1` here).
- **`isHurwitz_three_iff_isMarkov`** + the concrete coefficient-agnostic Vieta jump (`hurwitz_root_prod`, `hurwitz_vieta`).

### Relationship to #27824
Disjoint and complementary: #27824 owns the generalized Vieta *infrastructure* (parametric `+k`, n-variable); this PR owns the *complete classification* of the `a=1` slice (mod-3 divisibility + scaling bijection + transported tree). Distinct namespace (`MarkovHurwitzOQ03OQ01`), file, and gallery slug (`markov-equation-oq-03-oq-01`) — no overlap. Re-slugged from `oq-03` to `oq-03-oq-01` after detecting #27824 merged concurrently.

## Verification
`#print axioms` on `hurwitz_one_classification`, `three_dvd_all_of_hurwitz_one`, `hurwitz_diagonal_coeff`, `hurwitz_one_iff_markov_scaled` reports only `propext / Classical.choice / Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`. Compiled against Mathlib with Lean `v4.26.0`. Status `verified`, badge `original`.

## Honesty
Scope is the two solvable coefficients. We do **not** prove Hurwitz's full non-existence theorem (no positive solution for `a ∉ {1,3}`) — only the diagonal obstruction; that global statement needs a genuine minimality argument and is stated as the remaining open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)