### PR TITLE
research(automorphic-number-oq-01-oq-03): reduction tower of idempotents — automorphic numbers lift uniquely [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -212,6 +212,7 @@ import Proofs.ArsinhLogFormulaOQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.AutomorphicNumberOQ01OQ02
+import Proofs.AutomorphicNumberOQ01OQ03
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01
 import Proofs.BallotProblemOQ01OQ01

--- a/proofs/Proofs/AutomorphicNumberOQ01OQ03.lean
+++ b/proofs/Proofs/AutomorphicNumberOQ01OQ03.lean
@@ -1,0 +1,154 @@
+import Mathlib
+import Proofs.AutomorphicNumberOQ01
+import Proofs.AutomorphicNumberOQ01OQ02
+
+/-!
+# Automorphic numbers lift uniquely: the reduction tower of idempotents
+
+## What This Proves
+
+The parent files describe the four `k`-digit automorphic residues
+`n ^ 2 ≡ n (mod 10 ^ k)` — equivalently the four idempotents `e * e = e` of
+`ZMod (10 ^ k)` — by **counting** them (`AutomorphicNumberOQ01`: there are exactly
+four; `…OQ01OQ01`: in general `2 ^ ω(n)`) and by describing their **pairing**
+(`…OQ01OQ02`: they are `0, 1` and a complementary pair `a, 1 - a` with distinct last
+digits).  What none of them explains is the *tower* structure: **why** the automorphic
+numbers grow one digit at a time, each `k`-digit automorphic number extending uniquely
+to a `(k+1)`-digit one (`5 → 25 → 625 → 0625 → …`, `6 → 76 → 376 → …`).
+
+This file supplies that missing structural layer.  Write
+`red k : ZMod (10 ^ (k+1)) →+* ZMod (10 ^ k)` for the canonical digit-dropping ring
+homomorphism (reduction modulo `10 ^ k`).  The results:
+
+* **`map_idem`** — any ring homomorphism sends idempotents to idempotents, so `red k`
+  maps the four `(k+1)`-digit automorphic residues into the `k`-digit ones.
+* **`ker_red_nilpotent`** — the kernel of `red k` is a **nil** ideal: every `x` with
+  `red k x = 0` is a multiple of `10 ^ k`, hence `x ^ 2 = 0`.  (This is where the
+  doubly-exponential vanishing `(10 ^ k) ^ 2 = 0` in `ZMod (10 ^ (k+1))` enters.)
+* **`red_injOn_idem`** — therefore `red k` is **injective** on idempotents: two
+  idempotents with the same reduction differ by a nilpotent, so are equal
+  (`idem_eq_of_sub_nilpotent`, from the parent).
+* **`red_image_idem`** — since both idempotent sets have exactly four elements
+  (`automorphic_idempotent_count`) and `red k` is injective on them, the image is the
+  *whole* lower set: `red k` is a **bijection** between the two four-element idempotent
+  sets.
+* **`unique_digit_extension`** (main theorem) — consequently every `k`-digit automorphic
+  residue `ē` has a **unique** `(k+1)`-digit automorphic residue lying above it.  This is
+  the precise sense in which `5, 25, 625, …` is a single coherent sequence, and the
+  reason the two non-trivial automorphic towers converge to the two non-trivial
+  idempotents of the `10`-adic integers `ℤ₁₀ ≅ ℤ₂ × ℤ₅`.
+
+## Status
+
+Fully machine-checked: `0` sorries, `0` axioms.  Builds on the verified parent files
+`AutomorphicNumberOQ01` and `AutomorphicNumberOQ01OQ02`.
+-/
+
+namespace AutomorphicNumberOQ01OQ03
+
+open Finset
+
+/-! ## The digit-dropping reduction homomorphism -/
+
+/-- The canonical reduction `ZMod (10 ^ (k+1)) →+* ZMod (10 ^ k)` — "drop the leading
+digit".  Concretely it sends a residue mod `10 ^ (k+1)` to its class mod `10 ^ k`. -/
+def red (k : ℕ) : ZMod (10 ^ (k + 1)) →+* ZMod (10 ^ k) :=
+  ZMod.castHom (pow_dvd_pow 10 (Nat.le_succ k)) (ZMod (10 ^ k))
+
+/-- A ring homomorphism sends idempotents to idempotents. -/
+theorem map_idem {R S : Type*} [CommRing R] [CommRing S] (f : R →+* S) {e : R}
+    (he : e * e = e) : f e * f e = f e := by
+  rw [← map_mul, he]
+
+/-! ## The kernel of `red` is a nil ideal -/
+
+/-- **The kernel of `red k` is nilpotent.**  If `red k x = 0` then `x` is a multiple of
+`10 ^ k`, and since `(10 ^ k) ^ 2 = 10 ^ (2k) = 0` in `ZMod (10 ^ (k+1))` (for `k ≥ 1`),
+already `x ^ 2 = 0`.  This is the structural fact that makes idempotent lifting unique. -/
+theorem ker_red_nilpotent (k : ℕ) (hk : 0 < k) {x : ZMod (10 ^ (k + 1))}
+    (hx : red k x = 0) : IsNilpotent x := by
+  haveI : NeZero ((10 : ℕ) ^ (k + 1)) := ⟨pow_ne_zero _ (by norm_num)⟩
+  haveI : NeZero ((10 : ℕ) ^ k) := ⟨pow_ne_zero _ (by norm_num)⟩
+  -- Lift `x` to a natural number `m`.
+  obtain ⟨m, rfl⟩ := (ZMod.natCast_rightInverse (n := 10 ^ (k + 1))).surjective x
+  -- `red` commutes with `Nat.cast`, so the hypothesis says `10 ^ k ∣ m`.
+  rw [map_natCast, ZMod.natCast_eq_zero_iff] at hx
+  obtain ⟨t, rfl⟩ := hx
+  -- `x ^ 2 = (10 ^ k * t) ^ 2 = 0` because `10 ^ (k+1) ∣ (10 ^ k * t) ^ 2`.
+  refine ⟨2, ?_⟩
+  rw [show ((((10 : ℕ) ^ k * t : ℕ)) : ZMod (10 ^ (k + 1))) ^ 2
+        = (((10 : ℕ) ^ k * t) ^ 2 : ℕ) from by push_cast; ring]
+  rw [ZMod.natCast_eq_zero_iff]
+  have hle : k + 1 ≤ 2 * k := by omega
+  refine dvd_trans (pow_dvd_pow 10 hle) ⟨t ^ 2, ?_⟩
+  rw [mul_pow, ← pow_mul, Nat.mul_comm k 2]
+
+/-! ## Reduction is a bijection on idempotents -/
+
+/-- **`red k` is injective on idempotents.**  Two idempotents with the same reduction
+differ by a nilpotent (their difference lies in the nil kernel), hence are equal. -/
+theorem red_injOn_idem (k : ℕ) (hk : 0 < k) {e f : ZMod (10 ^ (k + 1))}
+    (he : e * e = e) (hf : f * f = f) (h : red k e = red k f) : e = f := by
+  have hker : red k (e - f) = 0 := by rw [map_sub, h, sub_self]
+  exact AutomorphicNumberOQ01OQ02.idem_eq_of_sub_nilpotent he hf
+    (ker_red_nilpotent k hk hker)
+
+/-- **`red k` is a bijection on idempotents.**  The image under `red k` of the four
+`(k+1)`-digit automorphic residues is *exactly* the four `k`-digit ones.  Injectivity
+(`red_injOn_idem`) plus equal cardinality (`automorphic_idempotent_count`, both `4`)
+forces the image to fill the whole target set. -/
+theorem red_image_idem (k : ℕ) (hk : 0 < k) :
+    (univ.filter (fun e : ZMod (10 ^ (k + 1)) => e * e = e)).image (red k)
+      = univ.filter (fun e : ZMod (10 ^ k) => e * e = e) := by
+  apply Finset.eq_of_subset_of_card_le
+  · -- image lands inside the lower idempotent set
+    intro y hy
+    rw [Finset.mem_image] at hy
+    obtain ⟨e, he, rfl⟩ := hy
+    rw [mem_filter] at he ⊢
+    exact ⟨mem_univ _, map_idem (red k) he.2⟩
+  · -- lower set (card 4) is no bigger than the image (card 4, by injectivity)
+    have hinj : Set.InjOn (red k)
+        (univ.filter (fun e : ZMod (10 ^ (k + 1)) => e * e = e) : Finset _) := by
+      intro e he f hf h
+      simp only [Finset.coe_filter, mem_univ, true_and, Set.mem_setOf_eq] at he hf
+      exact red_injOn_idem k hk he hf h
+    rw [Finset.card_image_of_injOn hinj,
+        AutomorphicNumberOQ01.automorphic_idempotent_count k hk,
+        AutomorphicNumberOQ01.automorphic_idempotent_count (k + 1) (by omega)]
+
+/-! ## Main theorem: unique digit-by-digit extension -/
+
+/-- **Main theorem — unique digit extension.**  Every `k`-digit automorphic residue `ē`
+(idempotent of `ZMod (10 ^ k)`) is the reduction of a **unique** `(k+1)`-digit automorphic
+residue `e` (idempotent of `ZMod (10 ^ (k+1))`).  Thus the automorphic numbers form a
+single coherent tower `5 → 25 → 625 → …`, `6 → 76 → 376 → …`, converging to the two
+non-trivial idempotents of the `10`-adic integers. -/
+theorem unique_digit_extension (k : ℕ) (hk : 0 < k) {ē : ZMod (10 ^ k)} (hē : ē * ē = ē) :
+    ∃! e : ZMod (10 ^ (k + 1)), e * e = e ∧ red k e = ē := by
+  -- `ē` lies in the lower idempotent set, hence in the image of the reduction.
+  have hmem : ē ∈ univ.filter (fun e : ZMod (10 ^ k) => e * e = e) := by
+    rw [mem_filter]; exact ⟨mem_univ _, hē⟩
+  rw [← red_image_idem k hk, Finset.mem_image] at hmem
+  obtain ⟨e, he, hred⟩ := hmem
+  rw [mem_filter] at he
+  refine ⟨e, ⟨he.2, hred⟩, ?_⟩
+  rintro e' ⟨he', hred'⟩
+  exact red_injOn_idem k hk he' he.2 (by rw [hred', hred])
+
+/-! ## Concrete extensions
+
+The reduction really does send each `(k+1)`-digit automorphic number to the `k`-digit one
+below it, in line with `unique_digit_extension`: `25 ↦ 5`, `625 ↦ 25`, `76 ↦ 6`,
+`376 ↦ 76`.  (Here `ZMod.castHom` is reduction; we verify the underlying values.) -/
+
+/-- `25` (mod `100`) reduces to `5` (mod `10`), and both are idempotent. -/
+example : (red 1) (25 : ZMod (10 ^ 2)) = (5 : ZMod (10 ^ 1)) := by decide
+
+/-- `76` (mod `100`) reduces to `6` (mod `10`). -/
+example : (red 1) (76 : ZMod (10 ^ 2)) = (6 : ZMod (10 ^ 1)) := by decide
+
+/-- `625` (mod `1000`) reduces to `25` (mod `100`). -/
+example : (red 2) (625 : ZMod (10 ^ 3)) = (25 : ZMod (10 ^ 2)) := by decide
+
+end AutomorphicNumberOQ01OQ03

--- a/src/data/proofs/automorphic-number-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-autonum-oq01oq03-context",
+    "proofId": "automorphic-number-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "concept",
+    "title": "From counting and pairing to the tower: why automorphic numbers grow one digit at a time",
+    "content": "The base entry counts the automorphic residues e²≡e mod 10^k (exactly four — the idempotents of ZMod (10^k)); the first follow-up explains the count as 2^ω(n); the second describes their pairing (0, 1 and a complementary pair a, 1-a). All of that is level-by-level. This entry connects the levels: write red k for the digit-dropping reduction ZMod (10^(k+1)) → ZMod (10^k). The claim is that red k restricts to a BIJECTION between the four (k+1)-digit residues and the four k-digit ones, so each k-digit automorphic number extends to exactly one more digit. That is why 5, 25, 625, 0625, … and 6, 76, 376, … are single coherent sequences rather than unrelated solutions at each modulus.",
+    "mathContext": "The rings $\\mathbb{Z}/10^k$ form an inverse system; this entry shows the transition maps induce bijections of idempotent sets, so the inverse limit $\\mathbb{Z}_{10}\\cong\\mathbb{Z}_2\\times\\mathbb{Z}_5$ also has exactly four idempotents — $0,1$ and the two nontrivial $10$-adic idempotents that the $\\dots5$ and $\\dots6$ towers converge to."
+  },
+  {
+    "id": "ann-autonum-oq01oq03-nilkernel",
+    "proofId": "automorphic-number-oq-01-oq-03",
+    "range": {
+      "startLine": 64,
+      "endLine": 88
+    },
+    "type": "technique",
+    "title": "The kernel of reduction is nil: (10^k)² = 0 in ZMod (10^(k+1))",
+    "content": "Injectivity of red k on idempotents rests on a single arithmetic fact: every element x of the kernel squares to zero. Lifting x to a natural number m, the hypothesis red k x = 0 says 10^k ∣ m, so x is a multiple of 10^k; then x² is a multiple of 10^(2k), and 10^(k+1) ∣ 10^(2k) whenever k ≥ 1, so x² = 0. The kernel is therefore a nil ideal, and idempotents lift uniquely across a nil ideal — exactly the lemma idem_eq_of_sub_nilpotent proved in the previous entry, here reused verbatim.",
+    "mathContext": "This is the same nilpotency that drives the parent's last-digit theorem, now one rung higher: there the relevant nil element is $10$ (kernel of reduction mod $10$), here it is $10^k$ (kernel of reduction mod $10^k$)."
+  },
+  {
+    "id": "ann-autonum-oq01oq03-bijection",
+    "proofId": "automorphic-number-oq-01-oq-03",
+    "range": {
+      "startLine": 100,
+      "endLine": 125
+    },
+    "type": "technique",
+    "title": "Injective + equal cardinality = bijective",
+    "content": "The surjectivity half of the bijection needs no explicit idempotent-lifting formula. red k maps idempotents to idempotents (any ring homomorphism does) and is injective on them (nil kernel). Both idempotent sets have exactly four elements by the base entry's count, so the injective image already has four elements and must equal the whole target — Finset.eq_of_subset_of_card_le turns the inclusion into equality. Every k-digit automorphic residue therefore has a lift, and it is unique.",
+    "mathContext": "A clean pigeonhole: a self-injection of equinumerous finite sets is a bijection. The arithmetic content (count $=4$) is imported from the verified parent; this entry only has to add injectivity."
+  }
+]

--- a/src/data/proofs/automorphic-number-oq-01-oq-03/meta.json
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "automorphic-number-oq-01-oq-03",
+  "slug": "automorphic-number-oq-01-oq-03",
+  "title": "Automorphic Numbers Lift Uniquely: The Reduction Tower of Idempotents",
+  "description": "The parent entries describe the four k-digit automorphic residues n²≡n (mod 10^k) — the idempotents of ZMod (10^k) — by COUNTING them (the base entry: exactly four; the first follow-up: 2^ω(n) in general) and by PAIRING them (the second follow-up: they are 0, 1 and a complementary pair a, 1-a with distinct last digits). None of them explains the TOWER: why the automorphic numbers grow one digit at a time, each k-digit automorphic number extending uniquely to a (k+1)-digit one (5→25→625→0625→…, 6→76→376→…). This entry supplies that structural layer. Write red k : ZMod (10^(k+1)) →+* ZMod (10^k) for the canonical digit-dropping reduction homomorphism. (1) Any ring homomorphism sends idempotents to idempotents, so red k maps the four (k+1)-digit automorphic residues into the k-digit ones. (2) The kernel of red k is a NIL ideal: every x with red k x = 0 is a multiple of 10^k, and since (10^k)²=10^(2k)=0 in ZMod (10^(k+1)) already x²=0. (3) Therefore red k is INJECTIVE on idempotents — two idempotents with equal reduction differ by a nilpotent, hence are equal (reusing the parent's idem_eq_of_sub_nilpotent). (4) Since both idempotent sets have exactly four elements (the base entry's count) and red k is injective on them, the image is the WHOLE lower set: red k is a bijection between the two four-element idempotent sets. (5) Main theorem: every k-digit automorphic residue has a UNIQUE (k+1)-digit automorphic residue lying above it. This is the precise sense in which 5, 25, 625, … is a single coherent sequence, and the reason the two nontrivial automorphic towers converge to the two nontrivial idempotents of the 10-adic integers ℤ₁₀ ≅ ℤ₂ × ℤ₅. The concrete reductions 25↦5, 76↦6, 625↦25 are verified by decide.",
+  "meta": {
+    "author": "Lean Genius Researcher-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AutomorphicNumberOQ01OQ03.lean",
+    "tags": [
+      "number-theory",
+      "automorphic-numbers",
+      "idempotents",
+      "zmod",
+      "nilpotent",
+      "idempotent-lifting",
+      "ring-homomorphism",
+      "inverse-limit",
+      "p-adic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 154,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "assumptions": "None. 0 axioms, 0 sorries, no native_decide. The three `decide` calls are kernel decisions on concrete finite data (the reductions 25↦5 mod 10, 76↦6 mod 10, 625↦25 mod 100); they occur in anonymous example blocks and do not enter any named result. #print axioms confirms every named theorem (unique_digit_extension, red_image_idem, red_injOn_idem, ker_red_nilpotent, map_idem) depends only on the standard foundational axioms propext / Classical.choice / Quot.sound — no Lean.ofReduceBool, no sorryAx. Builds on the verified parent entries AutomorphicNumberOQ01.lean (reusing automorphic_idempotent_count, the count = 4) and AutomorphicNumberOQ01OQ02.lean (reusing idem_eq_of_sub_nilpotent, uniqueness of idempotent lifts modulo a nil ideal).",
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.castHom",
+        "description": "The canonical ring homomorphism ZMod n →+* R for m ∣ n and CharP R m; instantiated at R = ZMod (10^k) it is the digit-dropping reduction red k : ZMod (10^(k+1)) →+* ZMod (10^k)",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(↑a : ZMod b) = 0 ↔ b ∣ a; converts red k (↑m) = 0 into the divisibility 10^k ∣ m that exhibits a kernel element as a multiple of 10^k",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_rightInverse",
+        "description": "Nat.cast is a right inverse of ZMod.val, hence surjective; used to lift a kernel element of ZMod (10^(k+1)) to a natural number",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "IsNilpotent",
+        "description": "An element x with x^n = 0 for some n; here x² = 0 for every x in the kernel of red k, making the kernel a nil ideal",
+        "module": "Mathlib.RingTheory.Nilpotent.Defs"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "An injective-on map preserves cardinality of the image; combined with the count = 4 on both sides it forces red k's image of the idempotents to be the whole lower idempotent set",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.eq_of_subset_of_card_le",
+        "description": "s ⊆ t and t.card ≤ s.card give s = t; promotes the image ⊆ lower idempotent set (both card 4) to set equality, i.e. surjectivity of the reduction on idempotents",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01.automorphic_idempotent_count",
+        "description": "The verified parent result that ZMod (10^k) has exactly 4 idempotents; supplies the equal-cardinality input that upgrades injectivity to a bijection",
+        "module": "Proofs.AutomorphicNumberOQ01"
+      },
+      {
+        "theorem": "AutomorphicNumberOQ01OQ02.idem_eq_of_sub_nilpotent",
+        "description": "Uniqueness of idempotent lifts modulo a nil ideal (idempotents with nilpotent difference coincide); applied to the nil kernel of red k it yields injectivity on idempotents",
+        "module": "Proofs.AutomorphicNumberOQ01OQ02"
+      }
+    ],
+    "dateAdded": "2026-06-22",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.AutomorphicNumberOQ01",
+      "Proofs.AutomorphicNumberOQ01OQ02"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "AutomorphicNumberOQ01OQ03",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/AutomorphicNumberOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "unique_digit_extension",
+      "type": "headline",
+      "statement": "0 < k → ē*ē=ē → ∃! e : ZMod (10^(k+1)), e*e=e ∧ red k e = ē",
+      "description": "Every k-digit automorphic residue ē (idempotent of ZMod (10^k)) is the reduction of a UNIQUE (k+1)-digit automorphic residue e (idempotent of ZMod (10^(k+1))). So the automorphic numbers form a single coherent tower 5→25→625→…, 6→76→376→…, converging to the two nontrivial idempotents of the 10-adic integers.",
+      "significance": "Explains the digit-by-digit growth left unexplained by the counting and pairing entries: the four-element idempotent set of each level sits coherently over the level below, realizing ZMod (10^k) as an inverse system whose limit ℤ₁₀ ≅ ℤ₂ × ℤ₅ has exactly four idempotents."
+    },
+    {
+      "name": "red_image_idem",
+      "type": "headline",
+      "statement": "0 < k → (univ.filter (e ↦ e*e=e)).image (red k) = univ.filter (e ↦ e*e=e)",
+      "description": "The image under the reduction red k of the four (k+1)-digit automorphic residues is exactly the four k-digit ones: red k is a bijection between the two four-element idempotent sets. Injectivity (red_injOn_idem) plus equal cardinality (automorphic_idempotent_count, both 4) forces the image to fill the whole target.",
+      "significance": "The structural heart: reduction restricts to a bijection of idempotent sets, so the levels of the tower are in canonical one-to-one correspondence."
+    },
+    {
+      "name": "red_injOn_idem",
+      "type": "core",
+      "statement": "0 < k → e*e=e → f*f=f → red k e = red k f → e = f",
+      "description": "The reduction red k is injective on idempotents: two idempotents with the same reduction have nilpotent difference (it lies in the nil kernel), hence are equal by the parent's idem_eq_of_sub_nilpotent.",
+      "significance": "Uniqueness of the lift — the second half of the bijection — derived purely from the kernel being nil."
+    },
+    {
+      "name": "ker_red_nilpotent",
+      "type": "core",
+      "statement": "0 < k → red k x = 0 → IsNilpotent x",
+      "description": "The kernel of red k is a nil ideal: if red k x = 0 then x is a multiple of 10^k, and since (10^k)² = 10^(2k) = 0 in ZMod (10^(k+1)) for k ≥ 1, already x² = 0.",
+      "significance": "The arithmetic engine. The doubly-exponential vanishing (10^k)²=0 in ZMod (10^(k+1)) is exactly what makes idempotent lifting unique; it is the same nilpotency phenomenon that, one digit at a time, pins down the last digit in the parent entry."
+    },
+    {
+      "name": "map_idem",
+      "type": "supporting",
+      "statement": "(f : R →+* S) → e*e=e → f e * f e = f e",
+      "description": "Any ring homomorphism between commutative rings sends idempotents to idempotents (f e · f e = f (e·e) = f e).",
+      "significance": "Makes red k map automorphic residues to automorphic residues — the MapsTo half needed before injectivity and cardinality give a bijection."
+    }
+  ],
+  "sections": [
+    {
+      "id": "reduction-hom",
+      "title": "Part I: The digit-dropping reduction homomorphism",
+      "startLine": 52,
+      "endLine": 62,
+      "summary": "red k := ZMod.castHom (10^k ∣ 10^(k+1)) (ZMod (10^k)) is the canonical reduction ZMod (10^(k+1)) →+* ZMod (10^k). map_idem records that any ring homomorphism preserves idempotency, so red k maps the (k+1)-digit automorphic residues into the k-digit ones.",
+      "mathContext": "The rings ZMod (10^k) form an inverse system under reduction; red k is one transition map. Ring homomorphisms preserve the idempotent equation e·e=e, giving a map of idempotent sets."
+    },
+    {
+      "id": "nil-kernel",
+      "title": "Part II: The kernel of reduction is a nil ideal",
+      "startLine": 64,
+      "endLine": 88,
+      "summary": "ker_red_nilpotent: lift x to a natural number m (ZMod.natCast_rightInverse); red k (↑m)=↑m=0 gives 10^k ∣ m (ZMod.natCast_eq_zero_iff), so m = 10^k·t and x² = (10^k·t)² is a multiple of 10^(2k), which is 0 in ZMod (10^(k+1)) since 10^(k+1) ∣ 10^(2k) for k ≥ 1. Hence x² = 0.",
+      "mathContext": "The kernel of ZMod (10^(k+1)) → ZMod (10^k) is the ideal (10^k), and (10^k)² = 10^(2k) ≡ 0, so the kernel is nil — the hypothesis under which idempotents lift uniquely."
+    },
+    {
+      "id": "bijection",
+      "title": "Part III: Reduction is a bijection on idempotents",
+      "startLine": 90,
+      "endLine": 125,
+      "summary": "red_injOn_idem: idempotents with equal reduction differ by a kernel element, which is nilpotent, so they coincide (idem_eq_of_sub_nilpotent). red_image_idem: the image of the (k+1)-level idempotents is contained in the k-level idempotents (map_idem) and, being injective with both sets of card 4 (automorphic_idempotent_count), fills it — Finset.eq_of_subset_of_card_le upgrades the inclusion to equality.",
+      "mathContext": "Injective + equal finite cardinality = bijective: the four idempotents of each level correspond one-to-one with those of the level below."
+    },
+    {
+      "id": "unique-extension",
+      "title": "Part IV: Unique digit-by-digit extension",
+      "startLine": 127,
+      "endLine": 153,
+      "summary": "unique_digit_extension: membership of ē in the lower idempotent set, rewritten through red_image_idem, exhibits a lift e; uniqueness is red_injOn_idem. The concrete reductions 25↦5, 76↦6, 625↦25 (by decide) show the tower explicitly.",
+      "mathContext": "Each automorphic number extends uniquely by one digit, so 5,25,625,… and 6,76,376,… are coherent sequences — the two nontrivial idempotents of the inverse limit ℤ₁₀ ≅ ℤ₂ × ℤ₅."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A depth follow-up in the **automorphic numbers** family. The base entry counts the residues `n²≡n (mod 10^k)` (the idempotents of `ZMod (10^k)`: exactly four; `2^ω(n)` in general), and the sibling describes their **pairing** (`0, 1` and a complementary pair `a, 1-a`). Neither explains the **tower**: why `5→25→625→…` and `6→76→376→…` are single coherent sequences rather than unrelated solutions at each modulus.

This entry supplies that structural layer. With `red k : ZMod (10^(k+1)) →+* ZMod (10^k)` the digit-dropping reduction homomorphism:

| Theorem | Statement |
|---|---|
| `map_idem` | ring homs send idempotents to idempotents (MapsTo) |
| `ker_red_nilpotent` | the kernel is a **nil ideal**: `red k x = 0 ⟹ x² = 0` (since `(10^k)²=10^(2k)=0` in `ZMod (10^(k+1))`) |
| `red_injOn_idem` | `red k` is **injective** on idempotents (reuses sibling's `idem_eq_of_sub_nilpotent`) |
| `red_image_idem` | injective + both sets card 4 ⟹ `red k` is a **bijection** of the two four-element idempotent sets |
| `unique_digit_extension` | **(main)** every `k`-digit automorphic residue has a *unique* `(k+1)`-digit residue above it |

The conceptual payoff: `ZMod (10^k)` is an inverse system whose transition maps induce bijections of idempotent sets, so the limit `ℤ₁₀ ≅ ℤ₂ × ℤ₅` also has exactly four idempotents — the two nontrivial ones being the `…5` and `…6` 10-adic idempotents the towers converge to.

## Verification

- **154 lines**, 1 def + 5 theorems, **0 sorries, 0 axioms**.
- `#print axioms` confirms every named result depends only on `propext` / `Classical.choice` / `Quot.sound` — no `native_decide`, no `Lean.ofReduceBool`. (The three `decide` examples `25↦5`, `76↦6`, `625↦25` are anonymous `example` blocks and do not enter any named result.)
- Builds on verified parents `AutomorphicNumberOQ01` (reusing `automorphic_idempotent_count`) and `AutomorphicNumberOQ01OQ02` (reusing `idem_eq_of_sub_nilpotent`).
- Lean 4.26.0. Docker was unavailable; verified via single-file compilation against the prebuilt Mathlib oleans plus the two parent modules, with `#print axioms` on each named theorem.

## Files
- `proofs/Proofs/AutomorphicNumberOQ01OQ03.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/automorphic-number-oq-01-oq-03/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)