### PR TITLE
research(quadratic-gauss-sum-square-oq-03): sign-free quadratic reciprocity (p*/q)=(q/p) from g²=p*

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2715,8 +2715,8 @@ import Proofs.Erdos892Aristotle
 import Proofs.Erdos892Problem
 import Proofs.Erdos893Problem
 import Proofs.Erdos894Problem
-import Proofs.Erdos895CounterexampleFin18
 import Proofs.Erdos895Aristotle
+import Proofs.Erdos895CounterexampleFin18
 import Proofs.Erdos895OQ01Problem
 import Proofs.Erdos895Problem
 import Proofs.Erdos895ProblemAristotle
@@ -3286,13 +3286,13 @@ import Proofs.Hilbert20OQ01OQ03Aristotle
 import Proofs.Hilbert21RiemannHilbert
 import Proofs.Hilbert22OQ01
 import Proofs.Hilbert22OQ01OQ03
-import Proofs.Hilbert22OQ01OQ03Universal
 import Proofs.Hilbert22OQ01OQ03Pseudohyperbolic
+import Proofs.Hilbert22OQ01OQ03Universal
 import Proofs.Hilbert22Uniformization
 import Proofs.Hilbert23CalculusVariations
 import Proofs.Hilbert23CalculusVariationsOQ01
-import Proofs.Hilbert3ScissorsCongruence
 import Proofs.Hilbert3OQ02
+import Proofs.Hilbert3ScissorsCongruence
 import Proofs.Hilbert4Geodesics
 import Proofs.Hilbert5LieGroups
 import Proofs.Hilbert5OQ02
@@ -3792,6 +3792,7 @@ import Proofs.QuadraticGaussSumSignSmallThirteen
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticGaussSumSquareOQ02
+import Proofs.QuadraticGaussSumSquareOQ03
 import Proofs.QuadraticGaussSumSquareOQ04
 import Proofs.QuadraticGaussSumSquareOQ04OQ01
 import Proofs.QuadraticReciprocity

--- a/proofs/Proofs/QuadraticGaussSumSquareOQ03.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ03.lean
@@ -1,0 +1,209 @@
+/-
+  Sign-free quadratic reciprocity from the square of the Gauss sum.
+
+  Open-question follow-up `quadratic-gauss-sum-square-oq-03`:
+  combine the parent entry `g² = (-1)^((p-1)/2)·p` with a Gauss-sum proof of
+  quadratic reciprocity to obtain a *self-contained, sign-free* statement of the
+  law.
+
+  The parent computes the square of the quadratic Gauss sum,
+
+      g = ∑ₙ χ(n)·ψ(n),     g² = (-1)^((p-1)/2)·p,
+
+  whose right-hand side is the integer
+
+      p* := (-1)^((p-1)/2)·p.
+
+  The whole point of introducing `p*` is conceptual: in terms of `p*` the law of
+  quadratic reciprocity loses its `(-1)^…` sign factor and becomes the symmetric
+
+      (p* / q) = (q / p)                            (`pStar_reciprocity`)
+
+  for all odd primes `p, q`.  This is exactly the form the Gauss-sum computation
+  produces, and it is the natural endpoint of "combining `g² = p*` with
+  reciprocity": the awkward `(-1)^((p-1)(q-1)/4)` of the classical statement is
+  absorbed once for all into the definition of `p*`.
+
+  We make three points.
+
+  1. `gaussSquare_eq_pStar` : the bridge — for a primitive additive character
+     `ψ : ZMod p → ℂ`, the complex quadratic Gauss sum squares to `(p* : ℂ)`.
+     (This re-derives the parent's headline using Mathlib's generic `gaussSum_sq`,
+     so the file is self-contained.)
+
+  2. `pStar_mod_four` : `p* ≡ 1 (mod 4)` for every odd prime `p`.  This is *why*
+     `p*` is the right normalisation — it is the fundamental discriminant of the
+     quadratic field `ℚ(√p*) = ℚ(g)`, and it is what makes the sign-free law
+     consistent.
+
+  3. `pStar_reciprocity` : the sign-free law `(p*/q) = (q/p)`, with the symmetric
+     companion `pStar_reciprocity_symm` `(q*/p) = (p/q)` and the square-test
+     corollary `pStar_isSquare_iff`.  As a sanity check we also recover the
+     classical product form `classical_reciprocity_of_pStar`.
+
+  No axioms beyond Mathlib's; verified.
+-/
+import Mathlib
+
+open scoped BigOperators
+
+namespace QuadraticGaussSumSquareOQ03
+
+/-- The *starred prime* `p* = (-1)^((p-1)/2)·p` (an integer).  This is the value of
+the square of the quadratic Gauss sum, and the fundamental discriminant of the
+quadratic subfield of the `p`-th cyclotomic field. -/
+def pStar (p : ℕ) : ℤ := (-1) ^ ((p - 1) / 2) * (p : ℤ)
+
+/-! ### 1. The bridge: `g² = p*` for the complex Gauss sum -/
+
+section Bridge
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-- `ℂ`-valued quadratic character mod `p`, transported from the integer-valued
+`quadraticChar (ZMod p)` along the ring hom `ℤ → ℂ`. -/
+noncomputable def chiC (p : ℕ) [Fact p.Prime] : MulChar (ZMod p) ℂ :=
+  (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)
+
+theorem chiC_isQuadratic : (chiC p).IsQuadratic :=
+  (quadraticChar_isQuadratic (ZMod p)).comp (Int.castRingHom ℂ)
+
+theorem chiC_ne_one (hp : p ≠ 2) : chiC p ≠ 1 := by
+  have hchar : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp
+  exact (MulChar.ringHomComp_ne_one_iff
+    ((Int.castRingHom ℂ).injective_int)).mpr (quadraticChar_ne_one hchar)
+
+/-- Value of the character at `-1`: the first supplement, `χ(-1) = (-1)^((p-1)/2)`,
+transported to `ℂ`. -/
+theorem chiC_neg_one (hp : p ≠ 2) :
+    chiC p (-1) = (-1 : ℂ) ^ ((p - 1) / 2) := by
+  have hpp : p.Prime := Fact.out
+  have hodd : Odd p := hpp.odd_of_ne_two hp
+  have hchar : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp
+  have hq : quadraticChar (ZMod p) (-1) = (-1 : ℤ) ^ (p / 2) := by
+    rw [quadraticChar_neg_one hchar, ZMod.card p]
+    exact ZMod.χ₄_eq_neg_one_pow (Nat.odd_iff.mp hodd)
+  have hpe : p / 2 = (p - 1) / 2 := by obtain ⟨k, rfl⟩ := hodd; omega
+  simp only [chiC, MulChar.ringHomComp_apply, hq, map_pow, map_neg, map_one]
+  rw [hpe]
+
+/-- **Bridge to the parent entry.**  For a primitive additive character
+`ψ : ZMod p → ℂ`, the complex quadratic Gauss sum squares to `(p* : ℂ)`:
+
+    (∑ₙ χ(n)·ψ(n))² = (-1)^((p-1)/2)·p = p*.
+
+This is the parent's `g² = (-1)^((p-1)/2)·p`, re-stated with the `p*` normalisation
+and re-derived from Mathlib's generic `gaussSum_sq` so the development is
+self-contained. -/
+theorem gaussSquare_eq_pStar (hp : p ≠ 2) (ψ : AddChar (ZMod p) ℂ)
+    (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ ^ 2 = (pStar p : ℂ) := by
+  calc gaussSum (chiC p) ψ ^ 2
+      = chiC p (-1) * (Fintype.card (ZMod p) : ℂ) :=
+        gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
+    _ = (pStar p : ℂ) := by
+        rw [chiC_neg_one hp, ZMod.card p, pStar]; push_cast; ring
+
+end Bridge
+
+/-! ### 2. `p*` is `≡ 1 (mod 4)` -/
+
+/-- For every odd prime `p`, the starred prime satisfies `p* ≡ 1 (mod 4)`.
+
+This is the arithmetic reason `p*` (rather than `±p`) is the natural object: it is
+the fundamental discriminant of `ℚ(√p*)`, and it is what makes the sign-free
+reciprocity law below consistent. -/
+theorem pStar_mod_four {p : ℕ} [Fact p.Prime] (hp : p ≠ 2) :
+    pStar p ≡ 1 [ZMOD 4] := by
+  have hpp : p.Prime := Fact.out
+  have hodd : Odd p := hpp.odd_of_ne_two hp
+  obtain ⟨m, hm⟩ := hodd
+  have hk : (p - 1) / 2 = m := by omega
+  rw [pStar, hk]
+  rcases Nat.even_or_odd m with he | ho
+  · have hsign : (-1 : ℤ) ^ m = 1 := he.neg_one_pow
+    obtain ⟨j, hj⟩ := he
+    have hp4 : p = 4 * j + 1 := by omega
+    have hpz : (p : ℤ) = 4 * (j : ℤ) + 1 := by exact_mod_cast hp4
+    rw [hsign, one_mul, hpz]
+    exact Int.modEq_iff_dvd.mpr ⟨-(j : ℤ), by ring⟩
+  · have hsign : (-1 : ℤ) ^ m = -1 := ho.neg_one_pow
+    obtain ⟨j, hj⟩ := ho
+    have hp4 : p = 4 * j + 3 := by omega
+    have hpz : (p : ℤ) = 4 * (j : ℤ) + 3 := by exact_mod_cast hp4
+    rw [hsign, neg_one_mul, hpz]
+    exact Int.modEq_iff_dvd.mpr ⟨(j : ℤ) + 1, by ring⟩
+
+/-! ### 3. Sign-free quadratic reciprocity -/
+
+/-- **Sign-free quadratic reciprocity.**  For all odd primes `p` and `q`,
+
+    (p* / q) = (q / p).
+
+This is the law of quadratic reciprocity with its `(-1)^((p-1)(q-1)/4)` sign factor
+absorbed into the normalisation `p* = (-1)^((p-1)/2)·p` coming from the Gauss-sum
+identity `g² = p*`.  It is exactly the symmetric statement the Gauss-sum proof
+produces, and is cleaner than the classical product form because the right-hand
+side carries no sign. -/
+theorem pStar_reciprocity {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) :
+    legendreSym q (pStar p) = legendreSym p q := by
+  have hpp : p.Prime := Fact.out
+  have hqq : q.Prime := Fact.out
+  have hpodd : p % 2 = 1 := hpp.eq_two_or_odd.resolve_left hp
+  have hqodd : q % 2 = 1 := hqq.eq_two_or_odd.resolve_left hq
+  -- `legendreSym q` is multiplicative on powers of `-1`.
+  have hpow : ∀ k : ℕ, legendreSym q ((-1) ^ k) = (legendreSym q (-1)) ^ k := by
+    intro k
+    induction k with
+    | zero => simp [legendreSym.at_one]
+    | succ n ih => rw [pow_succ, legendreSym.mul, ih, pow_succ]
+  -- first supplement: value at `-1`.
+  have hneg : legendreSym q (-1) = (-1) ^ (q / 2) := by
+    rw [legendreSym.at_neg_one hq, ZMod.χ₄_eq_neg_one_pow hqodd]
+  have hpe : (p - 1) / 2 = p / 2 := by omega
+  -- expand the starred prime through the multiplicative Legendre symbol.
+  have key : legendreSym q (pStar p)
+      = (-1) ^ (q / 2 * (p / 2)) * legendreSym q p := by
+    rw [pStar, legendreSym.mul, hpow, hneg, ← pow_mul, hpe]
+  rw [key, legendreSym.quadratic_reciprocity' hp hq, ← mul_assoc]
+  have hsign : ((-1 : ℤ)) ^ (q / 2 * (p / 2)) * (-1) ^ (p / 2 * (q / 2)) = 1 := by
+    rw [mul_comm (p / 2) (q / 2), ← pow_add]
+    exact Even.neg_one_pow ⟨q / 2 * (p / 2), rfl⟩
+  rw [hsign, one_mul]
+
+/-- The symmetric companion `(q* / p) = (p / q)` — just `pStar_reciprocity` with the
+roles of `p` and `q` exchanged.  Together with `pStar_reciprocity` this exhibits the
+law as genuinely symmetric in the starred variables. -/
+theorem pStar_reciprocity_symm {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) :
+    legendreSym p (pStar q) = legendreSym q p :=
+  pStar_reciprocity hq hp
+
+/-- **Square-test form.**  For distinct odd primes, `p*` is a square mod `q` iff `q`
+is a square mod `p`.  This is the sign-free law packaged as an equivalence of
+solvability of `x² ≡ p* (mod q)` and `x² ≡ q (mod p)`. -/
+theorem pStar_isSquare_iff {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    (hp : p ≠ 2) (hq : q ≠ 2) (hpq : p ≠ q) :
+    IsSquare ((pStar p : ℤ) : ZMod q) ↔ IsSquare ((q : ℤ) : ZMod p) := by
+  have hpp : p.Prime := Fact.out
+  have hqq : q.Prime := Fact.out
+  -- `q ∤ p` and `p ∤ q` as integers.
+  have hqp : ¬ (q : ℤ) ∣ (p : ℤ) := by
+    rw [Int.natCast_dvd_natCast]; intro h
+    exact hpq.symm ((Nat.prime_dvd_prime_iff_eq hqq hpp).mp h)
+  have hpq' : ¬ (p : ℤ) ∣ (q : ℤ) := by
+    rw [Int.natCast_dvd_natCast]; intro h
+    exact hpq ((Nat.prime_dvd_prime_iff_eq hpp hqq).mp h)
+  -- the relevant residues are nonzero.
+  have hpz : ((pStar p : ℤ) : ZMod q) ≠ 0 := by
+    rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd, pStar]
+    rcases Nat.even_or_odd ((p - 1) / 2) with he | ho
+    · rw [he.neg_one_pow, one_mul]; exact hqp
+    · rw [ho.neg_one_pow, neg_one_mul, dvd_neg]; exact hqp
+  have hqz : ((q : ℤ) : ZMod p) ≠ 0 := by
+    rw [Ne, ZMod.intCast_zmod_eq_zero_iff_dvd]; exact hpq'
+  rw [← legendreSym.eq_one_iff q hpz, ← legendreSym.eq_one_iff p hqz,
+    pStar_reciprocity hp hq]
+
+end QuadraticGaussSumSquareOQ03

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-03/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-03/meta.json
@@ -1,0 +1,84 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-03",
+  "title": "Sign-Free Quadratic Reciprocity from the Gauss Sum Square",
+  "slug": "quadratic-gauss-sum-square-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators"
+    ],
+    "namespace": "QuadraticGaussSumSquareOQ03",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/QuadraticGaussSumSquareOQ03.lean",
+    "sorries": 0
+  },
+  "description": "The parent computes the square of the quadratic Gauss sum, g² = (−1)^((p−1)/2)·p, whose right-hand side is the integer p* := (−1)^((p−1)/2)·p. This entry carries out the open-question follow-up: combine that identity with a Gauss-sum proof of quadratic reciprocity to obtain a self-contained, sign-free statement of the law. The conceptual payoff of introducing p* is that quadratic reciprocity loses its (−1)^((p−1)(q−1)/4) sign factor and becomes the symmetric (p*/q) = (q/p) for all odd primes p, q — exactly the form the Gauss-sum computation produces. Three points are formalized: (1) gaussSquare_eq_pStar re-derives the parent's headline g² = (p* : ℂ) for a primitive additive character from Mathlib's generic gaussSum_sq, so the development is self-contained; (2) pStar_mod_four proves p* ≡ 1 (mod 4) for every odd prime, the arithmetic reason p* (rather than ±p) is the natural normalisation — it is the fundamental discriminant of ℚ(√p*) = ℚ(g); (3) pStar_reciprocity proves the sign-free law (p*/q) = (q/p), with the symmetric companion pStar_reciprocity_symm and the square-test corollary pStar_isSquare_iff (p* is a square mod q iff q is a square mod p, for distinct odd primes). Verified, no axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ03.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "gauss-sum",
+      "legendre-symbol",
+      "quadratic-character",
+      "discriminant",
+      "zmod"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 209,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "Gauss's own favourite among his many proofs of quadratic reciprocity ran through the quadratic Gauss sum $g = \\sum_n \\chi(n)\\zeta^n$, whose square is the 'starred prime' $p^* = (-1)^{(p-1)/2} p$. The starred prime is not a cosmetic device: $p^*$ is the discriminant of the quadratic field $\\mathbb{Q}(\\sqrt{p^*}) = \\mathbb{Q}(g)$ sitting inside the $p$-th cyclotomic field, and it is the unique squarefree-up-to-units integer $\\equiv 1 \\pmod 4$ associated to $\\pm p$. Phrased through $p^*$, the law of quadratic reciprocity sheds its awkward sign $(-1)^{(p-1)(q-1)/4}$ and becomes the perfectly symmetric statement $(p^*/q) = (q/p)$. This is the form Eisenstein and Gauss-sum arguments produce most naturally, and it is the conceptual endpoint of 'combining $g^2 = p^*$ with reciprocity': the sign is absorbed once and for all into the definition of $p^*$.",
+    "problemStatement": "Let $p$ and $q$ be odd primes and write $p^* = (-1)^{(p-1)/2}\\,p$, the value of the square of the quadratic Gauss sum at $p$. Prove (i) the bridge $g^2 = (p^* : \\mathbb{C})$ for a primitive additive character, re-derived from Mathlib's generic Gauss-sum square so the development stands alone; (ii) $p^* \\equiv 1 \\pmod 4$ for every odd prime $p$; and (iii) the sign-free reciprocity law $\\left(\\frac{p^*}{q}\\right) = \\left(\\frac{q}{p}\\right)$, together with its symmetric companion and the square-solvability equivalence $x^2 \\equiv p^* \\pmod q \\iff x^2 \\equiv q \\pmod p$ for distinct odd primes.",
+    "proofStrategy": "The bridge gaussSquare_eq_pStar specialises Mathlib's `gaussSum_sq` to the ℂ-valued quadratic character chiC = (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ): the square equals χ(−1)·#(ZMod p), and evaluating χ(−1) = (−1)^((p−1)/2) (first supplement, via `quadraticChar_neg_one` and `ZMod.χ₄_eq_neg_one_pow`) with #(ZMod p) = p gives p*. The congruence pStar_mod_four splits on the parity of (p−1)/2: for p ≡ 1 (mod 4) the sign is +1 and p* = p ≡ 1; for p ≡ 3 (mod 4) the sign is −1 and p* = −p ≡ 1; each case closes by `Int.modEq_iff_dvd` and `ring`. The heart, pStar_reciprocity, expands the multiplicative Legendre symbol over p* = (−1)^((p−1)/2)·p using `legendreSym.mul`, evaluates the power factor with the first supplement `legendreSym.at_neg_one` and `ZMod.χ₄_eq_neg_one_pow` to obtain (−1)^(q/2·p/2)·(q/p), then substitutes Mathlib's classical `legendreSym.quadratic_reciprocity'` and collapses the doubled sign (−1)^(q/2·p/2)·(−1)^(p/2·q/2) = 1 via `Even.neg_one_pow`. The square-test pStar_isSquare_iff rewrites both sides through `legendreSym.eq_one_iff` (the residues p* mod q and q mod p are nonzero because distinct primes do not divide each other) and applies the sign-free law.",
+    "keyInsights": [
+      "Introducing $p^* = (-1)^{(p-1)/2} p$ is exactly what removes the sign from reciprocity: the classical $\\left(\\frac{q}{p}\\right) = (-1)^{(p-1)(q-1)/4}\\left(\\frac{p}{q}\\right)$ becomes the symmetric $\\left(\\frac{p^*}{q}\\right) = \\left(\\frac{q}{p}\\right)$, because the factor $\\left(\\frac{(-1)^{(p-1)/2}}{q}\\right) = (-1)^{(p-1)(q-1)/4}$ contributed by the sign cancels the classical one.",
+      "The cancellation is structurally an 'even power of $-1$': the sign from expanding $(p^*/q)$ and the sign from classical reciprocity are equal, $(-1)^{a}\\cdot(-1)^{a} = (-1)^{2a} = 1$, which is the entire content of the final step.",
+      "$p^* \\equiv 1 \\pmod 4$ is forced by the same sign: $p \\equiv 1$ keeps $p^* = p \\equiv 1$, while $p \\equiv 3$ flips to $p^* = -p \\equiv 1$. This is why $p^*$, not $\\pm p$, is the fundamental discriminant attached to the Gauss sum.",
+      "The square-solvability form $x^2 \\equiv p^* \\pmod q \\iff x^2 \\equiv q \\pmod p$ is the sign-free law read through `eq_one_iff`; the only side condition is that $p \\ne q$, which guarantees both residues are units."
+    ]
+  },
+  "conclusion": {
+    "summary": "For all odd primes $p, q$ the entry machine-verifies the sign-free reciprocity law $\\left(\\frac{p^*}{q}\\right) = \\left(\\frac{q}{p}\\right)$ with $p^* = (-1)^{(p-1)/2} p$, the value of the square of the quadratic Gauss sum, together with $p^* \\equiv 1 \\pmod 4$ and the equivalence of $x^2 \\equiv p^* \\pmod q$ and $x^2 \\equiv q \\pmod p$. The Gauss-sum square $g^2 = p^*$ is re-derived from Mathlib so the development is self-contained, with no axioms and no sorries.",
+    "implications": "The sign-free form is the practically useful one: it makes reciprocity a symmetric relation between $p^*$ and $q$, eliminates parity bookkeeping in Legendre-symbol computations, and exposes $p^*$ as the discriminant governing the quadratic subfield of the cyclotomic field. It packages the parent's algebraic square identity and Mathlib's classical reciprocity into a single clean statement, completing the 'combine $g^2 = p^*$ with reciprocity' programme posed by the parent entry.",
+    "openQuestions": [
+      "Can the sign-free law be lifted to the Jacobi symbol, proving $\\left(\\frac{m^*}{n}\\right) = \\left(\\frac{n}{m}\\right)$ for odd coprime $m, n$ with $m^* = (-1)^{(m-1)/2} m$, directly from Mathlib's `jacobiSym` reciprocity?",
+      "Does the characteristic-zero (cyclotomic) Gauss-sum congruence argument — reducing $g^q \\equiv \\pm g \\pmod q$ in $\\mathbb{Z}[\\zeta_p]$ — give an independent formal proof of the sign-free law, complementing Mathlib's finite-field derivation used here?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "extends",
+      "description": "The parent establishes g² = (−1)^((p−1)/2)·p for the quadratic Gauss sum. This entry names the right-hand side p*, re-derives the identity as gaussSquare_eq_pStar, and uses it to motivate and state the sign-free reciprocity law (p*/q) = (q/p)."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-01",
+      "relationship": "related",
+      "description": "The sibling oq-01 extracts the real/imaginary dichotomy and magnitude ‖g‖² = p from the square identity. This entry instead pushes the square identity outward into number theory, recovering quadratic reciprocity in sign-free form."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-02",
+      "relationship": "related",
+      "description": "The sibling oq-02 develops the orthogonality (equidistribution) side of the quadratic character. This entry develops the algebraic-square side to its reciprocity conclusion."
+    },
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "This entry repackages Mathlib's classical law of quadratic reciprocity (legendreSym.quadratic_reciprocity') into the symmetric sign-free form (p*/q) = (q/p) natural to the Gauss-sum proof, using the starred prime p* = (−1)^((p−1)/2)·p."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Open-question follow-up **quadratic-gauss-sum-square-oq-03**: combine the parent's Gauss-sum square identity `g² = (−1)^((p−1)/2)·p` with quadratic reciprocity to get a self-contained, **sign-free** statement of the law.

With `p* := (−1)^((p−1)/2)·p` (the value of the Gauss sum square), reciprocity sheds its `(−1)^((p−1)(q−1)/4)` sign factor and becomes the symmetric

> **(p*/q) = (q/p)**   for all odd primes p, q.

This is exactly the form the Gauss-sum computation produces; the sign is absorbed once and for all into `p*`.

## Results (`Proofs/QuadraticGaussSumSquareOQ03.lean`, 209 L, 8 thm / 2 def, 0 axioms)

- `gaussSquare_eq_pStar` — the bridge: for a primitive additive character ψ, `gaussSum (chiC p) ψ ^ 2 = (p* : ℂ)`, re-derived from Mathlib's generic `gaussSum_sq` so the file stands alone (reproves the parent's headline).
- `pStar_mod_four` — `p* ≡ 1 (mod 4)` for every odd prime: the arithmetic reason `p*` (not `±p`) is the natural normalisation — it is the fundamental discriminant of `ℚ(√p*) = ℚ(g)`.
- `pStar_reciprocity` — **the sign-free law** `(p*/q) = (q/p)`. Expands the multiplicative Legendre symbol over `p*`, evaluates the `−1` power via the first supplement, substitutes Mathlib's classical `quadratic_reciprocity'`, and collapses the doubled sign `(−1)^a·(−1)^a = 1` via `Even.neg_one_pow`.
- `pStar_reciprocity_symm` — symmetric companion `(q*/p) = (p/q)`.
- `pStar_isSquare_iff` — square-test form: for distinct odd primes, `x² ≡ p* (mod q)` is solvable iff `x² ≡ q (mod p)` is.

## Verification

`#print axioms` on all four headline theorems lists only `propext, Classical.choice, Quot.sound` — **0 axioms, no `native_decide`, no sorries**. Status `verified`.

Built single-file against prebuilt Mathlib oleans (Docker build unavailable); `lean v4.26.0`.

## Honesty note

This entry repackages Mathlib's classical reciprocity (`legendreSym.quadratic_reciprocity'`) plus the first supplement into the sign-free form — that exact symmetric statement is not in Mathlib — and connects it to the parent's `g² = p*`. It does not give an independent characteristic-zero Gauss-sum proof of reciprocity (flagged as an open question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)