### PR TITLE
research(quadratic-gauss-sum-square-oq-04): the quadratic Gauss sum generates a quadratic field — minpoly X²−p*, [ℚ(g):ℚ]=2 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3254,6 +3254,7 @@ import Proofs.QuadraticGaussSumSignSmallSeven
 import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticGaussSumSquareOQ02
+import Proofs.QuadraticGaussSumSquareOQ04
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ02

--- a/proofs/Proofs/QuadraticGaussSumSquareOQ04.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ04.lean
@@ -1,0 +1,144 @@
+/-
+  The quadratic Gauss sum generates a quadratic field.
+
+  Setup (parent entry `QuadraticGaussSumSquare`): for an odd prime `p` and a
+  primitive additive character `ψ : ZMod p → ℂ`, the quadratic Gauss sum
+
+      g = gaussSum (chiC p) ψ = ∑ₙ χ(n) · ψ(n)         (χ = quadratic character mod p)
+
+  satisfies the classical square formula
+
+      g² = p* := (-1)^((p-1)/2) · p.
+
+  This entry pushes that one structural step further into field theory.  Because
+  `|p*| = p` is prime, `p*` is **not** the square of any rational, so `g` is a
+  *quadratic irrational*:
+
+    • `minpoly ℚ g = X² − p*`              (its minimal polynomial over ℚ),
+    • `[ℚ(g) : ℚ] = 2`                      (it generates a quadratic extension),
+    • `g ∉ ℚ`                              (it is genuinely irrational).
+
+  Equivalently, the quadratic Gauss sum generates the unique quadratic subfield
+  `ℚ(√p*)` of the `p`-th cyclotomic field `ℚ(ζ_p)`.
+
+  The square formula `gaussSum_sq_eq` is the parent result, re-derived here from
+  Mathlib's generic `gaussSum_sq` so the file is self-contained.  Everything past
+  it (`pstar_not_sq`, `minpoly_gaussSum`, `finrank_adjoin_gaussSum`,
+  `gaussSum_not_rational`) is the new content.
+-/
+import Mathlib
+
+open scoped BigOperators
+open Polynomial IntermediateField
+
+namespace QuadraticGaussSumSquareOQ04
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-! ## The character and the square formula (parent entry, re-derived) -/
+
+/-- `ℂ`-valued quadratic character mod `p`, from the integer-valued
+`quadraticChar (ZMod p)` composed with `ℤ → ℂ`. -/
+noncomputable def chiC (p : ℕ) [Fact p.Prime] : MulChar (ZMod p) ℂ :=
+  (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)
+
+theorem chiC_isQuadratic : (chiC p).IsQuadratic :=
+  (quadraticChar_isQuadratic (ZMod p)).comp (Int.castRingHom ℂ)
+
+theorem chiC_ne_one (hp : p ≠ 2) : chiC p ≠ 1 := by
+  have hchar : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp
+  exact (MulChar.ringHomComp_ne_one_iff ((Int.castRingHom ℂ).injective_int)).mpr
+    (quadraticChar_ne_one hchar)
+
+theorem chiC_neg_one (hp : p ≠ 2) :
+    chiC p (-1) = (-1 : ℂ) ^ ((p - 1) / 2) := by
+  have hpp : p.Prime := Fact.out
+  have hodd : Odd p := hpp.odd_of_ne_two hp
+  have hchar : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp
+  have hq : quadraticChar (ZMod p) (-1) = (-1 : ℤ) ^ (p / 2) := by
+    rw [quadraticChar_neg_one hchar, ZMod.card p]
+    exact ZMod.χ₄_eq_neg_one_pow (Nat.odd_iff.mp hodd)
+  have hpe : p / 2 = (p - 1) / 2 := by obtain ⟨k, rfl⟩ := hodd; omega
+  simp only [chiC, MulChar.ringHomComp_apply, hq, map_pow, map_neg, map_one]
+  rw [hpe]
+
+/-- The integer `p* = (-1)^((p-1)/2) · p`. -/
+def pstar (p : ℕ) : ℤ := (-1) ^ ((p - 1) / 2) * (p : ℤ)
+
+/-- **Square of the quadratic Gauss sum** (the parent result, restated with the
+right-hand side packaged as `p*`). -/
+theorem gaussSum_sq_eq (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ ^ 2 = (pstar p : ℂ) := by
+  calc gaussSum (chiC p) ψ ^ 2
+      = chiC p (-1) * (Fintype.card (ZMod p) : ℂ) :=
+        gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
+    _ = (-1 : ℂ) ^ ((p - 1) / 2) * p := by rw [chiC_neg_one hp, ZMod.card p]
+    _ = (pstar p : ℂ) := by simp only [pstar]; push_cast; ring
+
+/-! ## `p*` is not a rational square -/
+
+/-- `|p*| = p` is prime, so `p*` is not the square of any rational number. -/
+theorem pstar_not_sq : ∀ b : ℚ, b ^ 2 ≠ (pstar p : ℚ) := by
+  intro b hb
+  have hpp : p.Prime := Fact.out
+  -- `p* = p` (when `p ≡ 1 mod 4`) or `p* = -p` (when `p ≡ 3 mod 4`).
+  have hcases : pstar p = (p : ℤ) ∨ pstar p = -(p : ℤ) := by
+    rcases Nat.even_or_odd ((p - 1) / 2) with he | ho
+    · left; simp [pstar, he.neg_one_pow]
+    · right; simp [pstar, ho.neg_one_pow]
+  rcases hcases with hpos | hneg
+  · -- `b² = p` with `p` prime contradicts irrationality of `√p`.
+    rw [hpos] at hb
+    have hbR : ((b : ℝ)) ^ 2 = (p : ℝ) := by exact_mod_cast hb
+    have hsqrt : Real.sqrt p = |(b : ℝ)| := by rw [← hbR, Real.sqrt_sq_eq_abs]
+    have hirr : Irrational (Real.sqrt p) := hpp.irrational_sqrt
+    refine hirr ⟨|b|, ?_⟩
+    rw [hsqrt]; push_cast; ring
+  · -- `b² = -p < 0` is impossible.
+    rw [hneg] at hb
+    have hnn : (0 : ℚ) ≤ b ^ 2 := sq_nonneg b
+    rw [hb] at hnn
+    have hppos : (0 : ℚ) < p := by exact_mod_cast hpp.pos
+    push_cast at hnn
+    linarith
+
+/-! ## The minimal polynomial and the degree -/
+
+/-- `g` is integral over `ℚ`: it is a root of the monic `X² − p*`. -/
+theorem isIntegral_gaussSum (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    IsIntegral ℚ (gaussSum (chiC p) ψ) :=
+  ⟨X ^ 2 - C (pstar p : ℚ), monic_X_pow_sub_C _ (by norm_num), by
+    show (Polynomial.aeval (gaussSum (chiC p) ψ)) (X ^ 2 - C (pstar p : ℚ)) = 0
+    have hsq := gaussSum_sq_eq (p := p) hp hψ
+    simp only [map_sub, map_pow, aeval_X, map_intCast, hsq, sub_self]⟩
+
+/-- **Minimal polynomial of the quadratic Gauss sum.** Over `ℚ` it is `X² − p*`. -/
+theorem minpoly_gaussSum (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    minpoly ℚ (gaussSum (chiC p) ψ) = X ^ 2 - C (pstar p : ℚ) := by
+  have haeval : (Polynomial.aeval (gaussSum (chiC p) ψ)) (X ^ 2 - C (pstar p : ℚ)) = 0 := by
+    have hsq := gaussSum_sq_eq (p := p) hp hψ
+    simp only [map_sub, map_pow, aeval_X, map_intCast, hsq, sub_self]
+  have hmonic : (X ^ 2 - C (pstar p : ℚ)).Monic := monic_X_pow_sub_C _ (by norm_num)
+  have hirr : Irreducible (X ^ 2 - C (pstar p : ℚ)) :=
+    X_pow_sub_C_irreducible_of_prime Nat.prime_two (pstar_not_sq)
+  exact (minpoly.eq_of_irreducible_of_monic hirr haeval hmonic).symm
+
+/-- **`[ℚ(g) : ℚ] = 2`.** The quadratic Gauss sum generates a quadratic extension
+of `ℚ` — the unique quadratic subfield `ℚ(√p*)` of `ℚ(ζ_p)`. -/
+theorem finrank_adjoin_gaussSum (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    Module.finrank ℚ ℚ⟮gaussSum (chiC p) ψ⟯ = 2 := by
+  rw [IntermediateField.adjoin.finrank (isIntegral_gaussSum hp hψ), minpoly_gaussSum hp hψ,
+    natDegree_X_pow_sub_C]
+
+/-- **The quadratic Gauss sum is irrational**: it is not the image of any rational. -/
+theorem gaussSum_not_rational (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ ∉ Set.range ((algebraMap ℚ ℂ)) := by
+  rintro ⟨q, hq⟩
+  -- If `g = q` then `q² = p*`, contradicting `pstar_not_sq`.
+  have hsq := gaussSum_sq_eq (p := p) hp hψ
+  rw [← hq, eq_ratCast (algebraMap ℚ ℂ) q] at hsq
+  -- `hsq : (↑q)² = ↑(pstar p)` in `ℂ`
+  have hq2 : q ^ 2 = (pstar p : ℚ) := by exact_mod_cast hsq
+  exact pstar_not_sq q hq2
+
+end QuadraticGaussSumSquareOQ04

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-04/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-04/meta.json
@@ -1,0 +1,83 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-04",
+  "title": "The Quadratic Gauss Sum Generates a Quadratic Field",
+  "slug": "quadratic-gauss-sum-square-oq-04",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators",
+      "Polynomial",
+      "IntermediateField"
+    ],
+    "namespace": "QuadraticGaussSumSquareOQ04",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/QuadraticGaussSumSquareOQ04.lean",
+    "sorries": 0
+  },
+  "description": "The parent entry proves the classical square identity g² = (−1)^((p−1)/2)·p = p* for the quadratic Gauss sum g = gaussSum(χ, ψ) of an odd prime p and a primitive additive character ψ : ZMod p → ℂ. This entry pushes that one structural step further into field theory: it identifies the minimal polynomial of g over ℚ and the degree of the field it generates. The key arithmetic input is that |p*| = p is prime, so p* is not the square of any rational (when p ≡ 1 mod 4, p* = p is prime hence not a perfect square; when p ≡ 3 mod 4, p* = −p < 0 is not a real square). Combined with g² = p*, this makes g a quadratic irrational: its minimal polynomial over ℚ is exactly X² − p* (irreducible because the prime-exponent Kummer criterion X² − a is irreducible iff a has no square root), so [ℚ(g) : ℚ] = 2 and g ∉ ℚ. Concretely, the quadratic Gauss sum generates the unique quadratic subfield ℚ(√p*) of the p-th cyclotomic field ℚ(ζ_p) — the classical bridge from Gauss sums to quadratic fields. The square identity gaussSum_sq_eq is re-derived in-file from Mathlib's generic gaussSum_sq so the file is self-contained; the minimal-polynomial, degree, and irrationality results (minpoly_gaussSum, finrank_adjoin_gaussSum, gaussSum_not_rational) are the new content. Fully machine-verified with no axioms and no sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-22",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ04.lean",
+    "tags": [
+      "number-theory",
+      "gauss-sum",
+      "quadratic-character",
+      "field-theory",
+      "minimal-polynomial",
+      "quadratic-field",
+      "cyclotomic-field",
+      "irrationality",
+      "zmod"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 144,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "Gauss's evaluation of the quadratic Gauss sum is one of the cornerstones of nineteenth-century number theory. The algebraic half of the story — that $g^2 = p^* := (-1)^{(p-1)/2}p$ — already shows that $g$ is a square root of $\\pm p$, and hence that $g$ lives in a quadratic extension of $\\mathbb{Q}$. In fact $g$ generates the unique quadratic subfield of the cyclotomic field $\\mathbb{Q}(\\zeta_p)$, namely $\\mathbb{Q}(\\sqrt{p^*})$; this is the field-theoretic shadow of quadratic reciprocity, since reciprocity can be read off from how the prime $q$ splits in $\\mathbb{Q}(\\sqrt{p^*})$. The fact that $\\mathbb{Q}(\\zeta_p)$ contains exactly one quadratic subfield (it is cyclic of order $p-1$) and that the Gauss sum pins it down explicitly is what makes the Gauss-sum proof of reciprocity work. This entry formalises the first, purely field-theoretic, link in that chain: $g$ is a quadratic irrational with minimal polynomial $X^2 - p^*$.",
+    "problemStatement": "Let $p$ be an odd prime, $\\chi$ the quadratic character mod $p$ transported to $\\mathbb{C}$, and $\\psi : \\mathbb{Z}/p \\to \\mathbb{C}$ a primitive additive character. Set $g = \\operatorname{gaussSum}(\\chi, \\psi)$ and $p^* = (-1)^{(p-1)/2} p$. Granting the parent's square identity $g^2 = p^*$, prove that the minimal polynomial of $g$ over $\\mathbb{Q}$ is $X^2 - p^*$, that $[\\mathbb{Q}(g) : \\mathbb{Q}] = 2$, and that $g$ is irrational (not in the image of $\\mathbb{Q} \\to \\mathbb{C}$).",
+    "proofStrategy": "Four steps. (1) `gaussSum_sq_eq` re-derives the parent identity $g^2 = (p^* : \\mathbb{C})$ from Mathlib's `gaussSum_sq`, evaluating the quadratic character at $-1$ via `quadraticChar_neg_one` / `ZMod.χ₄_eq_neg_one_pow` and the field cardinality via `ZMod.card`. (2) `pstar_not_sq` shows $p^*$ is not the square of any rational: since $(-1)^{(p-1)/2}$ is $\\pm 1$, $p^*$ equals $p$ or $-p$; in the first case a rational $b$ with $b^2 = p$ would make $\\sqrt p = |b|$ rational, contradicting `Nat.Prime.irrational_sqrt`; in the second case $b^2 = -p < 0$ is impossible. (3) `minpoly_gaussSum` assembles the minimal polynomial: $X^2 - C(p^*)$ is monic (`monic_X_pow_sub_C`), annihilates $g$ (from $g^2 = p^*$), and is irreducible — `X_pow_sub_C_irreducible_of_prime` applied with the prime exponent $2$ and the no-square-root hypothesis `pstar_not_sq` — so `minpoly.eq_of_irreducible_of_monic` identifies it as $\\operatorname{minpoly}_{\\mathbb{Q}} g$. (4) `finrank_adjoin_gaussSum` reads the degree off the minimal polynomial via `IntermediateField.adjoin.finrank` and `natDegree_X_pow_sub_C`, giving $[\\mathbb{Q}(g):\\mathbb{Q}] = 2$; `gaussSum_not_rational` derives irrationality directly from `pstar_not_sq`.",
+    "keyInsights": [
+      "The entire field-theoretic content is unlocked by a single arithmetic fact: $|p^*| = p$ is prime, so $p^*$ is not a rational square. This is what separates $X^2 - p^*$ from a reducible quadratic and forces $[\\mathbb{Q}(g):\\mathbb{Q}] = 2$ rather than $1$.",
+      "The exponent $2$ is itself prime, so Mathlib's `X_pow_sub_C_irreducible_of_prime` (irreducibility of $X^n - a$ for prime $n$ when $a$ has no $n$-th root) applies directly to $X^2 - p^*$ — sidestepping the usual $n = 2$ awkwardness of the Kummer API and reducing irreducibility to exactly the no-square-root statement `pstar_not_sq`.",
+      "Both residue classes of $p$ mod $4$ are handled uniformly by the sign of $p^* = (-1)^{(p-1)/2}p$: $p \\equiv 1$ gives $p^* = p > 0$ (real but irrational), $p \\equiv 3$ gives $p^* = -p < 0$ (not even real), and in either case $p^*$ fails to be a rational square — so the conclusion $[\\mathbb{Q}(g):\\mathbb{Q}] = 2$ is independent of $p \\bmod 4$.",
+      "The result is the field-theoretic counterpart of the parent's algebraic square identity: where the parent computes the value $g^2$, this entry interprets that value structurally, exhibiting $g$ as a generator of the unique quadratic subfield $\\mathbb{Q}(\\sqrt{p^*})$ of $\\mathbb{Q}(\\zeta_p)$."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every odd prime $p$ and primitive additive character $\\psi$, the quadratic Gauss sum $g$ is machine-verified to be a quadratic irrational over $\\mathbb{Q}$: its minimal polynomial is exactly $X^2 - p^*$ with $p^* = (-1)^{(p-1)/2}p$, so $[\\mathbb{Q}(g):\\mathbb{Q}] = 2$ and $g \\notin \\mathbb{Q}$. The proof needs only the parent's square identity together with the primality of $|p^*|$, and uses no axioms and no sorries.",
+    "implications": "Identifying $\\operatorname{minpoly}_{\\mathbb{Q}} g = X^2 - p^*$ pins the Gauss sum to the unique quadratic subfield $\\mathbb{Q}(\\sqrt{p^*})$ of the cyclotomic field $\\mathbb{Q}(\\zeta_p)$. This is the field-theoretic foundation of the Gauss-sum proof of quadratic reciprocity: reciprocity is recovered from the splitting of a second prime $q$ in $\\mathbb{Q}(\\sqrt{p^*})$, which is governed by the value $(p^*/q)$. The entry thus turns the parent's numerical identity into the structural statement that drives reciprocity.",
+    "openQuestions": [
+      "Can one formalise the next link, computing $g^{q-1} = (p^*/q)$ inside a field of characteristic $q$, to obtain a fully self-contained Gauss-sum derivation of quadratic reciprocity from this quadratic-field description?",
+      "Does the analogous statement hold for the quartic or sextic Gauss sum — does it generate the corresponding cyclotomic subfield, and what is its minimal polynomial over $\\mathbb{Q}$?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "extends",
+      "description": "The parent establishes the algebraic square identity g² = (−1)^((p−1)/2)·p. This entry interprets that value structurally, proving the Gauss sum has minimal polynomial X² − p* and generates a quadratic field — the field-theoretic refinement of the square identity."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-01",
+      "relationship": "related",
+      "description": "The sibling oq-01 extracts the real/imaginary dichotomy and magnitude ‖g‖² = p from the square identity over ℂ. This entry instead reads the square identity as a statement of algebraic number theory: g is a quadratic irrational generating ℚ(√p*)."
+    },
+    {
+      "proofId": "quadratic-reciprocity",
+      "relationship": "related",
+      "description": "The quadratic subfield ℚ(√p*) of ℚ(ζ_p) generated by the Gauss sum is the field whose splitting behaviour encodes quadratic reciprocity; this entry pins down that field via the minimal polynomial of g."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The parent entry **Square of the Quadratic Gauss Sum** proves the classical algebraic identity
$$g^2 = (-1)^{(p-1)/2}\,p =: p^*$$
for the quadratic Gauss sum $g = \mathrm{gaussSum}(\chi,\psi)$ of an odd prime $p$ and a primitive additive character $\psi : \mathbb{Z}/p \to \mathbb{C}$.

This entry pushes that one structural step further, into **field theory**: it identifies the minimal polynomial of $g$ over $\mathbb{Q}$ and the degree of the field it generates.

- **`minpoly_gaussSum`** — $\mathrm{minpoly}_{\mathbb{Q}}(g) = X^2 - p^*$
- **`finrank_adjoin_gaussSum`** — $[\mathbb{Q}(g):\mathbb{Q}] = 2$
- **`gaussSum_not_rational`** — $g \notin \mathbb{Q}$ (genuinely irrational)

Equivalently, the quadratic Gauss sum generates the **unique quadratic subfield $\mathbb{Q}(\sqrt{p^*})$** of the $p$-th cyclotomic field $\mathbb{Q}(\zeta_p)$ — the field-theoretic foundation of the Gauss-sum proof of quadratic reciprocity.

## Key ideas

- The whole field-theoretic content is unlocked by one arithmetic fact: $|p^*| = p$ is prime, so $p^*$ is **not a rational square** (`pstar_not_sq`). For $p \equiv 1 \pmod 4$, $p^* = p$ is prime (irrational $\sqrt p$ via `Nat.Prime.irrational_sqrt`); for $p \equiv 3 \pmod 4$, $p^* = -p < 0$ is not even a real square. Either way the conclusion is independent of $p \bmod 4$.
- The exponent $2$ is itself prime, so Mathlib's `X_pow_sub_C_irreducible_of_prime` applies directly to $X^2 - p^*$, reducing irreducibility to exactly `pstar_not_sq` and sidestepping the usual $n=2$ Kummer awkwardness.
- The square identity `gaussSum_sq_eq` is re-derived in-file from Mathlib's generic `gaussSum_sq`, so the file is self-contained.

## Verification

- 144 lines, 9 theorems / 2 definitions
- **0 axioms, 0 sorries** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`)
- Builds against Mathlib (single-file, Lean v4.26.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)