### PR TITLE
Enrich λ(4)=∑1/(2k+1)⁴=π⁴/96: add annotations.json

### DIFF
--- a/src/data/proofs/basel-problem-oq-13/annotations.json
+++ b/src/data/proofs/basel-problem-oq-13/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "even-fourth",
+    "proofId": "basel-problem-oq-13",
+    "range": {
+      "startLine": 34,
+      "endLine": 43
+    },
+    "type": "theorem",
+    "title": "Even Part: ∑ 1/(2k)⁴ = π⁴/1440 (a Sixteenth of ζ(4))",
+    "content": "hasSum_even_zeta_four computes the even-indexed fourth-power sum. The scaling factor is 1/16, not 1/4 as in the second-power case: pulling 2 out of (2k)⁴ gives 2⁴ = 16 in the denominator, so 1/(2k)⁴ = (1/16)(1/k⁴). The pointwise identity is closed by `funext; push_cast; ring`, then HasSum.mul_left scales Mathlib's hasSum_zeta_four (ζ(4)=π⁴/90) by 1/16, yielding π⁴/1440. This sixteenth-scaling is the fourth-power analogue of the quarter-scaling used for ζ(2).",
+    "mathContext": "$\\displaystyle\\sum_{k\\ge 1}\\frac{1}{(2k)^4} = \\frac{1}{16}\\sum_{k\\ge 1}\\frac{1}{k^4} = \\frac{1}{16}\\cdot\\frac{\\pi^4}{90} = \\frac{\\pi^4}{1440}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum.mul_left",
+      "even-indexed subseries",
+      "ζ(4) = π⁴/90",
+      "series rescaling"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "scaling of convergent sums"
+    ]
+  },
+  {
+    "id": "odd-fourth",
+    "proofId": "basel-problem-oq-13",
+    "range": {
+      "startLine": 45,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "The Main Result: λ(4) = ∑ 1/(2k+1)⁴ = π⁴/96",
+    "content": "hasSum_odd_zeta_four is the headline, obtained by the same even/odd-then-uniqueness idiom as the ζ(2) odd-square entry. The odd subseries is summable (injective reindexing k ↦ 2k+1, dispatched by `omega`); HasSum.even_add_odd reassembles ζ(4) = π⁴/1440 + (∑ odd); and HasSum.unique against hasSum_zeta_four forces ∑ odd = π⁴/90 − π⁴/1440 = π⁴/96 (a one-line `linarith`). The value is the s = 4 case of the Dirichlet lambda λ(s) = (1 − 2^{−s})ζ(s): (1 − 1/16)·π⁴/90 = (15/16)·π⁴/90 = π⁴/96.",
+    "mathContext": "$\\lambda(4) = \\sum_{k\\ge 0}\\frac{1}{(2k+1)^4} = \\Big(1-\\tfrac{1}{16}\\Big)\\zeta(4) = \\frac{15}{16}\\cdot\\frac{\\pi^4}{90} = \\frac{\\pi^4}{96}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum.even_add_odd",
+      "HasSum.unique",
+      "Dirichlet lambda function",
+      "Summable.comp_injective"
+    ],
+    "prerequisites": [
+      "uniqueness of sums",
+      "summability"
+    ]
+  },
+  {
+    "id": "parity-template",
+    "proofId": "basel-problem-oq-13",
+    "range": {
+      "startLine": 48,
+      "endLine": 62
+    },
+    "type": "observation",
+    "title": "The Reusable Parity Template Across Powers",
+    "content": "This proof is the verbatim fourth-power instance of the template introduced for ζ(2): (i) even part = (1/2^s)·ζ(s) by mul_left, (ii) odd summability by injective reindexing, (iii) odd value by even_add_odd + unique + linarith. The only changes from the second-power case are the exponent (4 vs 2) and the scaling constant (1/16 vs 1/4). This demonstrates that the entire family of odd-index lambda values λ(2m) is mechanically derivable from the corresponding ζ(2m) with no fresh analytic input — exactly the generalization flagged in the open question.",
+    "mathContext": "$\\lambda(2m) = (1 - 2^{-2m})\\,\\zeta(2m)$ for all $m$, via the same even/odd split.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dirichlet lambda function",
+      "even zeta values",
+      "proof templates",
+      "parity decomposition"
+    ],
+    "prerequisites": [
+      "Riemann zeta function"
+    ]
+  },
+  {
+    "id": "tsum-fourth",
+    "proofId": "basel-problem-oq-13",
+    "range": {
+      "startLine": 64,
+      "endLine": 67
+    },
+    "type": "observation",
+    "title": "The tsum Form",
+    "content": "tsum_odd_zeta_four repackages the result as ∑' k, 1/(2k+1)⁴ = π⁴/96 via HasSum.tsum_eq, the citation-friendly statement. Convergence is never in doubt — the terms are a subseries of the absolutely convergent ζ(4) (p = 4 > 1) — so the tsum value is well-defined and the rearrangement into even/odd halves is justified.",
+    "mathContext": "$\\displaystyle\\sum_{k=0}^{\\infty}\\frac{1}{(2k+1)^4} = \\frac{\\pi^4}{96}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "tsum",
+      "HasSum.tsum_eq",
+      "p-series",
+      "absolute convergence"
+    ],
+    "prerequisites": [
+      "tsum notation"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-13`.

Complete meta.json but **no `annotations.json`**. This adds full inline coverage.

## What was added
4 line-anchored annotations:
1. **Even part** ∑1/(2k)⁴=π⁴/1440 — the 1/16-scaling (vs 1/4 for ζ(2))
2. **The main result** λ(4)=π⁴/96 via even_add_odd + HasSum.unique, framed as (1−2⁻⁴)ζ(4)
3. **The reusable cross-power parity template** (this is the verbatim 4th-power instance of the ζ(2) idiom)
4. **The tsum form**

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm build` passes (exit 0); JSON validated; all `proofId` match slug; no meta/Lean changes.