### PR TITLE
audit(binomial-theorem-oq-02-oq-01-oq-01): sync stale top-level sorries 4→0

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -218,5 +218,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Integrity Issue (gallery audit)

**Proof**: `binomial-theorem-oq-02-oq-01-oq-01`
**Problem**: Top-level `sorries` field is stale (`4`) while the proof is fully verified with 0 sorries — an internal metadata inconsistency.

## Evidence

**meta.json claims**:
- `status: "verified"`, `badge: "verified"`, `axiomCount: 0`
- nested `leanFile.sorries: 0` (synced in #27798)
- **top-level `sorries: 4`** ← stale

**Lean source** (`proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean`):
- 0 real `sorry` (verified, multinomial PMF — marginal Binomial, mean, covariance — completed in #27408)
- 0 `axiom` declarations
- The only `native_decide` token is inside a docstring explicitly noting the proof is axiom-free via kernel `decide` (not `native_decide`)

## Fix

Top-level `sorries`: `4 → 0`. This makes the field consistent with the verified status, the actual source, and the already-synced nested `leanFile.sorries`.

PR #27799 attempted this exact fix but was closed unmerged.

---
Discovered during gallery integrity audit. Public-facing `status: verified` was already accurate; this only corrects an internal stale counter.