### PR TITLE
research(erdos-1005-oq-03): Farey adjacency criterion via denominator sums [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -924,6 +924,7 @@ import Proofs.Erdos1004OQ04
 import Proofs.Erdos1004Problem
 import Proofs.Erdos1005Problem
 import Proofs.Erdos1005ProblemProvable
+import Proofs.Erdos1005ProblemOQ03
 import Proofs.Erdos1006OQ01
 import Proofs.Erdos1006OQ01OQ02
 import Proofs.Erdos1006OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ03.lean
@@ -1,0 +1,212 @@
+import Mathlib.Tactic
+import Mathlib.Data.Rat.Defs
+
+/-
+# Erdős Problem #1005 (OQ-03): The Farey Adjacency Criterion via Denominator Sums
+
+## Parent
+
+Erdős #1005 studies *runs of consecutive Farey fractions*. The single most
+basic structural fact any run analysis rests on is the answer to:
+
+> Given two Farey fractions of order `n`, when are they **adjacent** in `F_n`
+> (no order-`n` fraction strictly between them)?
+
+The parent entry (`Erdos1005Problem.lean`) supplies the **unimodular** package:
+the gap formula `c/d - a/b = 1/(bd)`, mediant coprimality, and the fact that
+the mediant lies strictly between two unimodular neighbours. What it does *not*
+supply -- and what actually controls adjacency -- is the denominator arithmetic.
+
+(This file is self-contained: it re-declares the small `FareyFraction`
+scaffold from the parent rather than importing it, because the parent's
+`import Mathlib.Data.Rat.Basic` no longer resolves under Mathlib `v4.26.0`.
+The definitions below mirror the parent exactly.)
+
+## This file
+
+We prove the classical **denominator-sum criterion**:
+
+* `intermediate_denom_ge` -- if `a/b < p/q < c/d` and the outer pair is
+  unimodular (`bc - ad = 1`), then **`q ≥ b + d`**. Any fraction squeezed
+  between two unimodular neighbours has denominator at least the sum of theirs.
+  This is the engine; it is pure integer arithmetic and follows from the
+  identity `q·(bc - ad) = d·(pb - aq) + b·(cq - pd)`.
+
+* `farey_adjacent_of_denom_sum_gt` -- if a unimodular pair has `b + d > n`,
+  then **no** Farey fraction of order `n` lies strictly between them: they are
+  adjacent in `F_n`.
+
+* `mediant_lt_n_not_adjacent` -- sharpness. If `b + d ≤ n`, the mediant
+  `(a+c)/(b+d)` is itself a Farey fraction of order `n` strictly between them,
+  so the pair is **not** adjacent.
+
+* `farey_adjacency_iff` -- combining the two: a unimodular pair `a/b < c/d` is
+  adjacent in `F_n` **iff** `b + d > n`. The mediant first appears at order
+  exactly `b + d` (Stern–Brocot insertion order).
+
+Every theorem below is fully machine-checked: 0 sorries, 0 axioms,
+no `native_decide`.
+
+Reference: https://erdosproblems.com/1005
+-/
+
+namespace Erdos1005OQ03
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 1: Farey fractions (mirrors the parent scaffold)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- A Farey fraction of order `n`: a pair `(p, q)` with `0 ≤ p ≤ q`,
+    `1 ≤ q ≤ n`, and `gcd(p, q) = 1`. -/
+structure FareyFraction (n : ℕ) where
+  p : ℕ
+  q : ℕ
+  hq_pos : 1 ≤ q
+  hq_le : q ≤ n
+  hp_le : p ≤ q
+  hcoprime : Nat.Coprime p q
+
+/-- The rational value of a Farey fraction. -/
+def FareyFraction.toRat {n : ℕ} (f : FareyFraction n) : ℚ :=
+  f.p / f.q
+
+/-- Two unimodular neighbours satisfy `bc - ad = 1`. -/
+def IsConsecutiveFarey {n : ℕ} (f g : FareyFraction n) : Prop :=
+  g.p * f.q - f.p * g.q = 1
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 2: Mediant facts (mirrors the parent; reused for sharpness)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The mediant of a unimodular pair is in lowest terms: if `bc = ad + 1`
+    then `gcd(a+c, b+d) = 1`. -/
+theorem mediant_coprime {a b c d : ℕ} (h : b * c = a * d + 1) :
+    Nat.Coprime (a + c) (b + d) := by
+  rw [Nat.Coprime]
+  set g := Nat.gcd (a + c) (b + d) with hg
+  have h1 : g ∣ b * (a + c) := dvd_mul_of_dvd_right (Nat.gcd_dvd_left (a + c) (b + d)) b
+  have h2 : g ∣ a * (b + d) := dvd_mul_of_dvd_right (Nat.gcd_dvd_right (a + c) (b + d)) a
+  have heq : b * (a + c) = a * (b + d) + 1 := by nlinarith
+  rw [heq] at h1
+  exact Nat.dvd_one.mp ((Nat.dvd_add_right h2).mp h1)
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 3: Order is cross-multiplication
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Strict order of two Farey fractions is cross-multiplication of the
+    numerator/denominator pairs (denominators are positive). -/
+theorem toRat_lt_iff {n : ℕ} (f g : FareyFraction n) :
+    f.toRat < g.toRat ↔ f.p * g.q < g.p * f.q := by
+  unfold FareyFraction.toRat
+  have hf : (0 : ℚ) < f.q := Nat.cast_pos.mpr f.hq_pos
+  have hg : (0 : ℚ) < g.q := Nat.cast_pos.mpr g.hq_pos
+  rw [div_lt_div_iff₀ hf hg]
+  constructor <;> intro h <;> exact_mod_cast h
+
+/-- The mediant `(a+c)/(b+d)` of a unimodular pair `a/b < c/d` lies strictly
+    between them. -/
+theorem mediant_between {n : ℕ} (f g : FareyFraction n)
+    (hlt : f.toRat < g.toRat) :
+    f.toRat < (f.p + g.p : ℚ) / (f.q + g.q : ℚ) ∧
+    (f.p + g.p : ℚ) / (f.q + g.q : ℚ) < g.toRat := by
+  have hcross : f.p * g.q < g.p * f.q := (toRat_lt_iff f g).mp hlt
+  unfold FareyFraction.toRat
+  have hfq : (0 : ℚ) < f.q := Nat.cast_pos.mpr f.hq_pos
+  have hgq : (0 : ℚ) < g.q := Nat.cast_pos.mpr g.hq_pos
+  have hsum : (0 : ℚ) < (f.q + g.q : ℚ) := by positivity
+  have hcrossQ : (f.p : ℚ) * g.q < (g.p : ℚ) * f.q := by exact_mod_cast hcross
+  refine ⟨?_, ?_⟩
+  · rw [div_lt_div_iff₀ hfq hsum]; nlinarith
+  · rw [div_lt_div_iff₀ hsum hgq]; nlinarith
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 4: The denominator-sum criterion
+-- ══════════════════════════════════════════════════════════════════
+
+/-- **Key lemma.** If `a/b < p/q < c/d` and the outer pair is unimodular
+    (`bc - ad = 1`), then the inner denominator satisfies `q ≥ b + d`.
+
+    Proof: from the strict inequalities, `pb - aq ≥ 1` and `cq - pd ≥ 1`
+    (as integers), and the identity
+    `q·(bc - ad) = d·(pb - aq) + b·(cq - pd)` collapses, via `bc - ad = 1`,
+    to `q = d·(pb - aq) + b·(cq - pd) ≥ d + b`. -/
+theorem intermediate_denom_ge {n : ℕ} (f g h : FareyFraction n)
+    (huni : IsConsecutiveFarey f g)
+    (h1 : f.toRat < h.toRat) (h2 : h.toRat < g.toRat) :
+    f.q + g.q ≤ h.q := by
+  -- Unimodular relation as a clean ℕ equation.
+  have hcb : g.p * f.q = f.p * g.q + 1 := by
+    have := huni; unfold IsConsecutiveFarey at this; omega
+  -- Strict orders → ℕ inequalities.
+  have hfh : f.p * h.q < h.p * f.q := (toRat_lt_iff f h).mp h1
+  have hhg : h.p * g.q < g.p * h.q := (toRat_lt_iff h g).mp h2
+  -- integer versions
+  have hcbZ : (g.p : ℤ) * f.q = (f.p : ℤ) * g.q + 1 := by exact_mod_cast hcb
+  have h1Z : (f.p : ℤ) * h.q + 1 ≤ (h.p : ℤ) * f.q := by exact_mod_cast hfh
+  have h2Z : (h.p : ℤ) * g.q + 1 ≤ (g.p : ℤ) * h.q := by exact_mod_cast hhg
+  have hbZ : (1 : ℤ) ≤ (f.q : ℤ) := by exact_mod_cast f.hq_pos
+  have hdZ : (1 : ℤ) ≤ (g.q : ℤ) := by exact_mod_cast g.hq_pos
+  -- The collapsing identity (uses bc - ad = 1).
+  have key : (h.q : ℤ)
+      = (g.q : ℤ) * ((h.p : ℤ) * f.q - (f.p : ℤ) * h.q)
+        + (f.q : ℤ) * ((g.p : ℤ) * h.q - (h.p : ℤ) * g.q) := by
+    linear_combination (-(h.q : ℤ)) * hcbZ
+  -- q = d·(pb - aq) + b·(cq - pd) ≥ d·1 + b·1 = d + b.
+  have t1 : (1 : ℤ) ≤ (h.p : ℤ) * f.q - (f.p : ℤ) * h.q := by linarith
+  have t2 : (1 : ℤ) ≤ (g.p : ℤ) * h.q - (h.p : ℤ) * g.q := by linarith
+  have bound : (f.q : ℤ) + g.q ≤ h.q := by
+    nlinarith [mul_le_mul_of_nonneg_left t1 (by linarith : (0:ℤ) ≤ (g.q : ℤ)),
+               mul_le_mul_of_nonneg_left t2 (by linarith : (0:ℤ) ≤ (f.q : ℤ)), key]
+  exact_mod_cast bound
+
+/-- **Adjacency criterion (sufficiency).** A unimodular pair `a/b < c/d` whose
+    denominators sum past the order, `b + d > n`, is adjacent in `F_n`: no
+    Farey fraction of order `n` lies strictly between them. -/
+theorem farey_adjacent_of_denom_sum_gt {n : ℕ} (f g : FareyFraction n)
+    (huni : IsConsecutiveFarey f g) (hsum : n < f.q + g.q) :
+    ∀ h : FareyFraction n, ¬ (f.toRat < h.toRat ∧ h.toRat < g.toRat) := by
+  rintro h ⟨h1, h2⟩
+  have hge : f.q + g.q ≤ h.q := intermediate_denom_ge f g h huni h1 h2
+  exact absurd (le_trans hge h.hq_le) (by omega)
+
+/-- **Sharpness.** If a unimodular pair `a/b < c/d` has `b + d ≤ n`, then the
+    mediant `(a+c)/(b+d)` is a Farey fraction of order `n` lying strictly
+    between them -- so the pair is **not** adjacent. The mediant first enters
+    the Farey sequence at order exactly `b + d`. -/
+theorem mediant_lt_n_not_adjacent {n : ℕ} (f g : FareyFraction n)
+    (huni : IsConsecutiveFarey f g) (hlt : f.toRat < g.toRat)
+    (hsum : f.q + g.q ≤ n) :
+    ∃ h : FareyFraction n, f.toRat < h.toRat ∧ h.toRat < g.toRat := by
+  -- unimodular relation in the form `mediant_coprime` expects: b*c = a*d + 1
+  have hcb0 : g.p * f.q = f.p * g.q + 1 := by
+    have := huni; unfold IsConsecutiveFarey at this; omega
+  have hbc : f.q * g.p = f.p * g.q + 1 := by rw [Nat.mul_comm]; exact hcb0
+  refine ⟨{ p := f.p + g.p
+          , q := f.q + g.q
+          , hq_pos := by have := f.hq_pos; omega
+          , hq_le := hsum
+          , hp_le := by have := f.hp_le; have := g.hp_le; omega
+          , hcoprime := mediant_coprime hbc }, ?_, ?_⟩
+  · have := (mediant_between f g hlt).1
+    simpa [FareyFraction.toRat, Nat.cast_add] using this
+  · have := (mediant_between f g hlt).2
+    simpa [FareyFraction.toRat, Nat.cast_add] using this
+
+/-- **Farey adjacency criterion (iff).** A unimodular pair `a/b < c/d` is
+    adjacent in `F_n` (no order-`n` fraction strictly between) **iff**
+    `b + d > n`. Equivalently, their mediant first appears at order `b + d`. -/
+theorem farey_adjacency_iff {n : ℕ} (f g : FareyFraction n)
+    (huni : IsConsecutiveFarey f g) (hlt : f.toRat < g.toRat) :
+    (∀ h : FareyFraction n, ¬ (f.toRat < h.toRat ∧ h.toRat < g.toRat))
+      ↔ n < f.q + g.q := by
+  constructor
+  · intro hadj
+    by_contra hle
+    push_neg at hle
+    obtain ⟨h, hh1, hh2⟩ := mediant_lt_n_not_adjacent f g huni hlt hle
+    exact hadj h ⟨hh1, hh2⟩
+  · intro hsum
+    exact farey_adjacent_of_denom_sum_gt f g huni hsum
+
+end Erdos1005OQ03

--- a/src/data/proofs/erdos-1005-oq-03/meta.json
+++ b/src/data/proofs/erdos-1005-oq-03/meta.json
@@ -1,0 +1,72 @@
+{
+  "id": "erdos-1005-oq-03",
+  "slug": "erdos-1005-oq-03",
+  "sorries": 0,
+  "title": "The Farey Adjacency Criterion: Two Fractions Are Neighbours in F_n iff Their Denominators Sum Past n",
+  "description": "A self-contained, axiom-free formalization of the classical denominator-sum criterion that governs when two Farey fractions are adjacent. The parent entry (Erdős #1005, runs of consecutive Farey fractions) supplies the unimodular package — the gap formula c/d − a/b = 1/(bd), mediant coprimality, and mediant betweenness — but leaves the adjacency question itself open. The key result here is purely arithmetic: any fraction p/q lying strictly between two unimodular neighbours a/b < c/d (bc − ad = 1) has denominator q ≥ b + d, via the identity q·(bc − ad) = d·(pb − aq) + b·(cq − pd). Consequently a unimodular pair is adjacent in the Farey sequence F_n (nothing of order n strictly between) if and only if b + d > n — and when b + d ≤ n the mediant (a+c)/(b+d) is itself the intermediate order-n fraction, so the mediant first appears at order exactly b + d (Stern–Brocot insertion order). This adjacency criterion is the structural foundation any analysis of Farey runs must rest on.",
+  "leanFile": {
+    "lineCount": 212,
+    "axiomCount": 0,
+    "path": "Proofs/Erdos1005ProblemOQ03.lean",
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 7
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot theory)",
+    "date": "1816",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1005ProblemOQ03.lean",
+    "tags": [
+      "number-theory",
+      "farey-fractions",
+      "stern-brocot",
+      "mediant",
+      "continued-fractions",
+      "diophantine-approximation"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-22",
+    "lineCount": 212,
+    "originalContributions": [
+      "intermediate_denom_ge: the engine — if a/b < p/q < c/d and the outer pair is unimodular (bc − ad = 1), then q ≥ b + d. Proved by deriving the integer inequalities pb − aq ≥ 1 and cq − pd ≥ 1 from the strict orders and collapsing the identity q·(bc − ad) = d·(pb − aq) + b·(cq − pd) via bc − ad = 1; no Farey-sequence enumeration is used",
+      "farey_adjacent_of_denom_sum_gt: sufficiency — a unimodular pair a/b < c/d with b + d > n is adjacent in F_n (no order-n fraction lies strictly between), since any intermediate fraction would have denominator ≥ b + d > n",
+      "mediant_lt_n_not_adjacent: sharpness — if b + d ≤ n the mediant (a+c)/(b+d) is a genuine FareyFraction of order n strictly between a/b and c/d (using mediant coprimality and betweenness), so the pair is NOT adjacent; equivalently the mediant first enters the Farey sequence at order exactly b + d",
+      "farey_adjacency_iff: the headline equivalence — a unimodular pair a/b < c/d is adjacent in F_n if and only if b + d > n, packaging sufficiency and sharpness into a single iff",
+      "toRat_lt_iff: the order of two Farey fractions is the cross-multiplication of their numerator/denominator pairs (f.p·g.q < g.p·f.q), the bridge between the rational ordering and the integer arithmetic that drives every proof",
+      "mediant_coprime / mediant_between: self-contained re-proofs of the mediant lemmas (the parent's own copies are unreachable under Mathlib v4.26.0, whose removal of Mathlib.Data.Rat.Basic breaks the parent's imports), supplying the coprimality gcd(a+c,b+d)=1 and strict betweenness needed for sharpness"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for all seven theorems. No native_decide is used (so no Lean.ofReduceBool).",
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The Farey sequence F_n — all reduced fractions in [0,1] with denominator ≤ n, in increasing order — was popularized by John Farey (1816) and given its foundational proof by Cauchy. Its two pillars are the unimodular relation bc − ad = 1 for adjacent fractions a/b < c/d and the mediant (a+c)/(b+d), which is the fraction of smallest denominator strictly between them and the organizing operation of the Stern–Brocot tree. Erdős Problem #1005 asks for the longest run of consecutive 'similarly ordered' Farey fractions; any such run analysis presupposes an exact criterion for when two fractions are neighbours, which is precisely what this entry formalizes.",
+    "problemStatement": "Determine, for a unimodular pair of Farey fractions a/b < c/d (bc − ad = 1), exactly when they are adjacent in the Farey sequence of order n — i.e. when no fraction of denominator ≤ n lies strictly between them — and quantify the obstruction when they are not.",
+    "proofStrategy": "Everything reduces to one integer inequality. Cross-multiplying the strict orders a/b < p/q and p/q < c/d (denominators positive) gives pb − aq ≥ 1 and cq − pd ≥ 1 over ℤ. The algebraic identity q·(bc − ad) = d·(pb − aq) + b·(cq − pd) — verified by linear_combination against the unimodular relation — then collapses, since bc − ad = 1, to q = d·(pb − aq) + b·(cq − pd) ≥ d·1 + b·1 = b + d. This single lemma (intermediate_denom_ge) yields sufficiency immediately (an intermediate order-n fraction would force b + d ≤ q ≤ n). For sharpness, when b + d ≤ n the mediant (a+c)/(b+d) is exhibited as a bona fide order-n Farey fraction lying strictly between the pair, using the parent's mediant coprimality (gcd(a+c,b+d)=1 from bc = ad+1) and the mediant betweenness inequality. The two directions assemble into the iff.",
+    "keyInsights": [
+      "Adjacency in F_n is not a sequence-ordering fact but an arithmetic one: it is decided entirely by the single inequality b + d > n on the two denominators, with no need to construct or enumerate the Farey sequence.",
+      "The bound q ≥ b + d for any in-between fraction is sharp and constructive: equality is achieved exactly by the mediant, which therefore is the unique fraction of minimal denominator between two unimodular neighbours and first appears at order b + d — the Stern–Brocot insertion order.",
+      "The proof is a one-line consequence of the identity q·(bc − ad) = d·(pb − aq) + b·(cq − pd); the unimodular hypothesis bc − ad = 1 turns the left side into q and the positivity of the two bracketed integers into the b + d lower bound.",
+      "Sufficiency and sharpness are genuine converses: 'b + d > n' is not merely sufficient but necessary for adjacency, because below the threshold the mediant is an explicit witness that adjacency fails. This pins the adjacency threshold exactly at b + d.",
+      "These facts are the missing structural prerequisite for Erdős #1005: a run of consecutive Farey fractions is a chain of adjacencies, so controlling runs requires first controlling when adjacency holds, which the denominator-sum criterion does exactly."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (212 lines, 7 theorems, 2 definitions) of the Farey adjacency criterion. The core lemma shows any fraction strictly between two unimodular neighbours a/b < c/d has denominator at least b + d; this yields the equivalence 'adjacent in F_n ⇔ b + d > n', with the mediant (a+c)/(b+d) as the explicit witness when adjacency fails, entering the Farey sequence at order exactly b + d.",
+    "implications": "The criterion supplies the structural foundation Erdős #1005 (longest run of consecutive similarly ordered Farey fractions) implicitly relies on: every run is a chain of adjacent fractions, and adjacency is now reduced to a denominator-sum inequality. The intermediate_denom_ge bound is reusable infrastructure for Farey/Stern–Brocot formalizations and for continued-fraction best-approximation arguments, where the same q ≥ b + d inequality controls convergent denominators.",
+    "openQuestions": [
+      "Run lengths from the criterion: can the denominator-sum criterion be combined with a counting argument over consecutive mediants to recover the known bounds (1/12 − o(1))n ≤ f(n) ≤ n/4 + O(1) on the longest similarly ordered run?",
+      "Best-approximation transfer: formalize the corollary that for two consecutive convergents of a continued fraction the denominator-sum criterion forces the standard 'no better approximation with smaller denominator' property, linking this entry to Diophantine approximation."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1005",
+      "relationship": "extends",
+      "description": "Supplies the adjacency criterion the parent's run problem presupposes. The parent proves the unimodular gap formula, mediant coprimality, and mediant betweenness; this entry uses those facts to determine exactly when two Farey fractions are neighbours (b + d > n) and to locate the order at which the mediant first appears."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A self-contained, **0-axiom, 0-sorry** formalization (212 lines, 7 theorems, 2 defs) of the classical **Farey adjacency criterion**, the structural prerequisite underlying Erdős #1005 (longest run of consecutive Farey fractions).

The parent entry supplies the unimodular package (gap formula, mediant coprimality, mediant betweenness) but leaves the adjacency question open. This entry answers it:

- **`intermediate_denom_ge`** (engine): if `a/b < p/q < c/d` and the outer pair is unimodular (`bc − ad = 1`), then `q ≥ b + d`. Proof: derive `pb − aq ≥ 1` and `cq − pd ≥ 1` from the strict orders, then collapse the identity `q·(bc − ad) = d·(pb − aq) + b·(cq − pd)` via `bc − ad = 1`. No Farey-sequence enumeration.
- **`farey_adjacent_of_denom_sum_gt`** (sufficiency): a unimodular pair with `b + d > n` is adjacent in `F_n` — nothing of order `n` strictly between.
- **`mediant_lt_n_not_adjacent`** (sharpness): if `b + d ≤ n`, the mediant `(a+c)/(b+d)` is itself an order-`n` Farey fraction strictly between, so adjacency fails. The mediant first appears at order exactly `b + d` (Stern–Brocot insertion order).
- **`farey_adjacency_iff`**: the headline — adjacent in `F_n` ⇔ `b + d > n`.

## Verification

`#print axioms` reports only `propext / Classical.choice / Quot.sound` for all seven theorems — **no custom axioms, no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`**. Verified by single-file compilation against the pinned Mathlib `v4.26.0` oleans (Docker build unavailable this session).

The file is self-contained: the parent `Erdos1005Problem.lean` imports `Mathlib.Data.Rat.Basic`, which was removed in Mathlib `v4.26.0`, so the small `FareyFraction` scaffold and the two mediant lemmas are re-declared locally (mirroring the parent).

## Files
- `proofs/Proofs/Erdos1005ProblemOQ03.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/erdos-1005-oq-03/meta.json` (new gallery entry, status `verified`, badge `original`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)