### PR TITLE
Enrich η(4)=7π⁴/720: add annotations.json

### DIFF
--- a/src/data/proofs/basel-problem-oq-14/annotations.json
+++ b/src/data/proofs/basel-problem-oq-14/annotations.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "eta4-summand",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 35,
+      "endLine": 37
+    },
+    "type": "definition",
+    "title": "The Eta-4 Summand (-1)^(n+1)/n⁴",
+    "content": "etaSummand n = (-1)^(n+1)/n⁴ is the alternating fourth-power term, giving the series 1 − 1/16 + 1/81 − 1/256 + ⋯. The sign (-1)^(n+1) is +1 on odd n and −1 on even n, so as with η(2) the proof reduces the alternating sum to two non-alternating Basel-style subseries by analyzing parity. The n = 0 term is the harmless junk value 1/0⁴ = 0 in ℝ.",
+    "mathContext": "$\\eta\\text{-summand}(n) = \\dfrac{(-1)^{n+1}}{n^4}$, giving $\\eta(4) = 1 - \\tfrac1{16} + \\tfrac1{81} - \\cdots$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Dirichlet eta function",
+      "alternating series",
+      "fourth zeta value",
+      "junk-value convention"
+    ],
+    "prerequisites": [
+      "alternating series",
+      "Lean definitions"
+    ]
+  },
+  {
+    "id": "eta4-even-basel",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 39,
+      "endLine": 48
+    },
+    "type": "theorem",
+    "title": "Even-Indexed Fourth-Power Sum: ∑ 1/(2k)⁴ = π⁴/1440",
+    "content": "hasSum_even_zeta_four computes the even part as a sixteenth-scaled ζ(4). Pulling 2 out of (2k)⁴ yields 2⁴ = 16, so 1/(2k)⁴ = (1/16)(1/k⁴); the pointwise identity is closed by `funext; push_cast; ring`, then HasSum.mul_left scales hasSum_zeta_four (π⁴/90) by 1/16 to π⁴/1440. This is one of two non-alternating building blocks for η(4).",
+    "mathContext": "$\\displaystyle\\sum_{k\\ge 1}\\frac{1}{(2k)^4} = \\frac{1}{16}\\cdot\\frac{\\pi^4}{90} = \\frac{\\pi^4}{1440}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasSum.mul_left",
+      "even-indexed subseries",
+      "ζ(4) = π⁴/90",
+      "series rescaling"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "scaling of convergent sums"
+    ]
+  },
+  {
+    "id": "eta4-odd-basel",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 50,
+      "endLine": 66
+    },
+    "type": "theorem",
+    "title": "Odd-Indexed Fourth-Power Sum: ∑ 1/(2k+1)⁴ = π⁴/96",
+    "content": "hasSum_odd_zeta_four recovers λ(4) via the even/odd-then-uniqueness idiom: the odd subseries is summable (injective reindexing k ↦ 2k+1, `omega`), HasSum.even_add_odd reassembles ζ(4) = π⁴/1440 + (∑ odd), and HasSum.unique against hasSum_zeta_four forces ∑ odd = π⁴/90 − π⁴/1440 = π⁴/96 (a `linarith`). This is exactly the standalone result of basel-problem-oq-13; here it serves as the positive half of η(4).",
+    "mathContext": "$\\displaystyle\\sum_{k\\ge 0}\\frac{1}{(2k+1)^4} = \\frac{\\pi^4}{90} - \\frac{\\pi^4}{1440} = \\frac{\\pi^4}{96}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "HasSum.even_add_odd",
+      "HasSum.unique",
+      "Dirichlet lambda function",
+      "Summable.comp_injective"
+    ],
+    "prerequisites": [
+      "uniqueness of sums",
+      "summability"
+    ]
+  },
+  {
+    "id": "eta4-even-sign",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 70,
+      "endLine": 78
+    },
+    "type": "key-step",
+    "title": "Even Indices Carry the Minus Sign",
+    "content": "On even indices n = 2k the exponent n+1 = 2k+1 is odd, so (-1)^(2k+1) = −1 and etaSummand(2k) = −1/(2k)⁴. The sign is collapsed by Odd.neg_one_pow with witness ⟨k, by ring⟩ : Odd (2k+1), and the even part of η(4) is the negative of the even fourth-power sum: −π⁴/1440. This is where the alternation enters.",
+    "mathContext": "$(-1)^{2k+1} = -1 \\Rightarrow \\eta\\text{-summand}(2k) = -\\dfrac{1}{(2k)^4}$, even part $= -\\dfrac{\\pi^4}{1440}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Odd.neg_one_pow",
+      "parity of exponents",
+      "alternating series",
+      "sign analysis"
+    ],
+    "prerequisites": [
+      "parity",
+      "powers of -1"
+    ]
+  },
+  {
+    "id": "eta4-odd-sign",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 79,
+      "endLine": 86
+    },
+    "type": "key-step",
+    "title": "Odd Indices Keep the Plus Sign",
+    "content": "On odd indices n = 2k+1 the exponent n+1 = 2k+2 is even, so (-1)^(2k+2) = +1 and etaSummand(2k+1) = 1/(2k+1)⁴. The sign is collapsed by Even.neg_one_pow with witness ⟨k+1, by ring⟩ : Even (2k+2), and the odd part of η(4) is the positive λ(4) = π⁴/96, unchanged from the non-alternating case.",
+    "mathContext": "$(-1)^{2k+2} = +1 \\Rightarrow \\eta\\text{-summand}(2k+1) = \\dfrac{1}{(2k+1)^4}$, odd part $= +\\dfrac{\\pi^4}{96}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Even.neg_one_pow",
+      "parity of exponents",
+      "Dirichlet lambda function",
+      "sign analysis"
+    ],
+    "prerequisites": [
+      "parity",
+      "powers of -1"
+    ]
+  },
+  {
+    "id": "eta4-assembly",
+    "proofId": "basel-problem-oq-14",
+    "range": {
+      "startLine": 68,
+      "endLine": 94
+    },
+    "type": "theorem",
+    "title": "Assembling η(4) = 7π⁴/720 = (7/8)ζ(4)",
+    "content": "hasSum_eta_four recombines the halves with HasSum.even_add_odd: −π⁴/1440 (even) + π⁴/96 (odd), and `ring` evaluates this to 7π⁴/720. The value confirms the functional relation η(s) = (1 − 2^{1−s})ζ(s) at s = 4, where 1 − 2^{−3} = 7/8 gives η(4) = (7/8)ζ(4) = (7/8)(π⁴/90) = 7π⁴/720. tsum_eta_four restates it as ∑' n, (-1)^(n+1)/n⁴ = 7π⁴/720. The whole alternating sum reduced to non-alternating Basel data plus sign bookkeeping — the verbatim fourth-power analogue of η(2) = π²/12.",
+    "mathContext": "$\\eta(4) = -\\dfrac{\\pi^4}{1440} + \\dfrac{\\pi^4}{96} = \\dfrac{7\\pi^4}{720} = \\tfrac78\\,\\zeta(4) = (1 - 2^{1-4})\\zeta(4).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Dirichlet eta function",
+      "eta-zeta functional relation",
+      "HasSum.even_add_odd",
+      "tsum"
+    ],
+    "prerequisites": [
+      "infinite series",
+      "fourth zeta value"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `basel-problem-oq-14`.

Complete meta.json but **no `annotations.json`**. This adds full inline coverage.

## What was added
6 line-anchored annotations:
1. **The alternating eta-4 summand** (-1)^(n+1)/n⁴
2. **Even fourth-power Basel block** ∑1/(2k)⁴=π⁴/1440 (1/16-scaled ζ(4))
3. **Odd fourth-power Basel block** λ(4)=π⁴/96 (reuses basel-problem-oq-13)
4. **Even indices carry the minus sign** (Odd.neg_one_pow) → -π⁴/1440
5. **Odd indices keep the plus sign** (Even.neg_one_pow) → +π⁴/96
6. **Assembly** η(4)=7π⁴/720=(7/8)ζ(4), framed by η(s)=(1-2^{1-s})ζ(s)

Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm build` passes (exit 0); JSON validated; all `proofId` match slug; no meta/Lean changes.