### PR TITLE
research(fibonacci-identities-oq-04-oq-01): Gibonacci/Horadam Vajda identity with discriminant constant + Gelin–Cesàro (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2653,6 +2653,7 @@ import Proofs.FibonacciIdentitiesOQ01
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ03
 import Proofs.FibonacciIdentitiesOQ04
+import Proofs.FibonacciIdentitiesOQ04OQ01
 import Proofs.FiveColorTheorem
 import Proofs.FodorPressingDown
 import Proofs.FourColorTheorem

--- a/proofs/Proofs/FibonacciIdentitiesOQ04OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ04OQ01.lean
@@ -1,0 +1,212 @@
+import Mathlib
+
+/-
+# Vajda's identity for Gibonacci (Horadam) sequences, with the discriminant constant
+
+`fibonacci-identities-oq-04` proved **Vajda's identity** for the integer Fibonacci
+numbers,
+
+  `F (x+i)·F (x+j) − F x·F (x+i+j) = (−1)^|x| · F i · F j`,
+
+and recovered Cassini, Catalan and d'Ocagne as one-line corollaries.  Its first
+open question asks to *replace the sign constant by a discriminant* and prove the
+analogue for the Lucas numbers and the general Gibonacci (Horadam) sequences.
+Its third open question asks for the **Gelin–Cesàro identity**
+`F(n−2)·F(n−1)·F(n+1)·F(n+2) − F n⁴ = −1`.  This entry supplies both.
+
+A **Gibonacci sequence** is any solution of the Fibonacci recurrence
+`G(n+2) = G(n+1) + G n`.  Over the integers every such sequence has the closed form
+
+  `G n = a · F n + b · F (n−1)`,    where `a = G 1`, `b = G 0`,
+
+so it is parametrised by its two seeds.  The headline result is the
+**Gibonacci Vajda identity**
+
+  `G(x+i)·G(x+j) − G x·G(x+i+j) = (−1)^|x| · (a² − a·b − b²) · F i · F j`,
+
+in which the Fibonacci sign constant `(−1)^|x|` is multiplied by the
+**characteristic** `μ = a² − a·b − b² = G 1² − G 0·G 1 − G 0²`.  This `μ` is
+exactly the "discriminant" the open question refers to:
+
+* the **Fibonacci** numbers are `G = gib 1 0`, with `μ = 1` — Vajda is recovered;
+* the **Lucas** numbers are `G = gib 1 2` (`L 0 = 2`, `L 1 = 1`), with
+  `μ = 1 − 2 − 4 = −5` — the Lucas discriminant `5` appears with a sign.
+
+The proof reduces the Gibonacci identity to four instances of the Fibonacci Vajda
+identity (at base points `x` and `x−1`), a parity sign-flip lemma
+`(−1)^|x−1| = −(−1)^|x|`, and the basic recurrence `F(j+1) = F(j−1) + F j`.
+Everything is over `Int.fib`, so the statements hold for all integer indices.
+No axioms, no `sorry`, no `native_decide`.
+-/
+
+namespace FibonacciIdentitiesOQ04OQ01
+
+open Int
+
+/-! ## Fibonacci Vajda identity (restated locally for a self-contained file)
+
+This is the verified headline of `fibonacci-identities-oq-04`, reproduced here so
+that this file depends only on Mathlib. -/
+
+/-- **Vajda's identity** for the integer Fibonacci numbers. -/
+theorem fib_vajda (x i j : ℤ) :
+    Int.fib (x + i) * Int.fib (x + j) - Int.fib x * Int.fib (x + i + j)
+      = (-1) ^ x.natAbs * (Int.fib i * Int.fib j) := by
+  have e1 := Int.fib_add x i
+  have e2 := Int.fib_add x j
+  have e3 := Int.fib_add x (i + j)
+  have e4 := Int.fib_add i j
+  have e5 := Int.fib_add i (j + 1)
+  have rx : Int.fib (x + 1) = Int.fib (x - 1) + Int.fib x := by
+    rw [show (x : ℤ) + 1 = (x - 1) + 2 by ring, Int.fib_add_two, show (x : ℤ) - 1 + 1 = x by ring]
+  have ri : Int.fib (i + 1) = Int.fib (i - 1) + Int.fib i := by
+    rw [show (i : ℤ) + 1 = (i - 1) + 2 by ring, Int.fib_add_two, show (i : ℤ) - 1 + 1 = i by ring]
+  have rj : Int.fib (j + 1 + 1) = Int.fib j + Int.fib (j + 1) := by
+    rw [show (j : ℤ) + 1 + 1 = j + 2 by ring]; exact Int.fib_add_two j
+  have hc := Int.fib_succ_mul_fib_pred_sub_fib_sq x
+  rw [show x + i + j = x + (i + j) by ring, e1, e2, e3, e4,
+      show i + j + 1 = i + (j + 1) by ring, e5]
+  rw [← hc, rx, ri, rj]
+  ring
+
+/-- Parity sign-flip: `(−1)^|y−1| = −(−1)^|y|`, since consecutive integers have
+opposite parity (and `|n|` has the same parity as `n`). -/
+theorem sign_flip (y : ℤ) : (-1 : ℤ) ^ (y - 1).natAbs = -(-1 : ℤ) ^ y.natAbs := by
+  rcases Int.even_or_odd y with he | ho
+  · have h1 : Even y.natAbs := Int.natAbs_even.mpr he
+    have h2 : Odd (y - 1).natAbs := Int.natAbs_odd.mpr (by simpa using he.sub_odd odd_one)
+    rw [h1.neg_one_pow, h2.neg_one_pow]
+  · have h1 : Odd y.natAbs := Int.natAbs_odd.mpr ho
+    have h2 : Even (y - 1).natAbs := Int.natAbs_even.mpr (by simpa using ho.sub_odd odd_one)
+    rw [h1.neg_one_pow, h2.neg_one_pow]; norm_num
+
+/-! ## Gibonacci sequences -/
+
+/-- The Gibonacci (Horadam) sequence with seeds `G 0 = b`, `G 1 = a`, given in
+closed form by `G n = a · F n + b · F (n−1)`. -/
+def gib (a b n : ℤ) : ℤ := a * Int.fib n + b * Int.fib (n - 1)
+
+@[simp] theorem gib_one (a b : ℤ) : gib a b 1 = a := by simp [gib]
+
+@[simp] theorem gib_two (a b : ℤ) : gib a b 2 = a + b := by
+  simp [gib]
+
+theorem gib_zero (a b : ℤ) : gib a b 0 = b := by
+  simp [gib]
+
+/-- `gib` really is a Gibonacci sequence: it satisfies the Fibonacci recurrence. -/
+theorem gib_recurrence (a b n : ℤ) : gib a b (n + 2) = gib a b (n + 1) + gib a b n := by
+  have h1 : Int.fib (n + 2) = Int.fib n + Int.fib (n + 1) := Int.fib_add_two n
+  have h2 : Int.fib (n + 1) = Int.fib (n - 1) + Int.fib n := by
+    rw [show (n : ℤ) + 1 = (n - 1) + 2 by ring, Int.fib_add_two, show (n : ℤ) - 1 + 1 = n by ring]
+  simp only [gib, show (n : ℤ) + 2 - 1 = n + 1 by ring, show (n : ℤ) + 1 - 1 = n by ring]
+  rw [h1, h2]; ring
+
+/-- The Fibonacci numbers are the Gibonacci sequence with seeds `(a, b) = (1, 0)`. -/
+@[simp] theorem gib_one_zero (n : ℤ) : gib 1 0 n = Int.fib n := by simp [gib]
+
+/-! ## The master identity -/
+
+/-- **Vajda's identity for Gibonacci sequences.**  With characteristic
+`μ = a² − a·b − b²`,
+
+  `G(x+i)·G(x+j) − G x·G(x+i+j) = (−1)^|x| · μ · F i · F j`. -/
+theorem gib_vajda (a b x i j : ℤ) :
+    gib a b (x + i) * gib a b (x + j) - gib a b x * gib a b (x + i + j)
+      = (-1) ^ x.natAbs * (a ^ 2 - a * b - b ^ 2) * (Int.fib i * Int.fib j) := by
+  have V1 := fib_vajda x i j
+  have V2 := fib_vajda (x - 1) i j
+  have V3 := fib_vajda x i (j - 1)
+  have V4 := fib_vajda (x - 1) i (j + 1)
+  rw [show x - 1 + i = x + i - 1 by ring, show x - 1 + j = x + j - 1 by ring,
+      show x + i - 1 + j = x + i + j - 1 by ring, sign_flip x] at V2
+  rw [show x + (j - 1) = x + j - 1 by ring, show x + i + (j - 1) = x + i + j - 1 by ring] at V3
+  rw [show x - 1 + i = x + i - 1 by ring, show x - 1 + (j + 1) = x + j by ring,
+      show x + i - 1 + (j + 1) = x + i + j by ring, sign_flip x] at V4
+  have hj : Int.fib (j + 1) = Int.fib (j - 1) + Int.fib j := by
+    rw [show (j : ℤ) + 1 = (j - 1) + 2 by ring, Int.fib_add_two, show (j : ℤ) - 1 + 1 = j by ring]
+  unfold gib
+  linear_combination a ^ 2 * V1 + b ^ 2 * V2 + a * b * V3 + a * b * V4
+    - a * b * (-1) ^ x.natAbs * Int.fib i * hj
+
+/-- **Gibonacci Cassini** (the `i = j = 1` case): `G(n+1)² − G n·G(n+2) = (−1)^|n|·μ`. -/
+theorem gib_cassini (a b n : ℤ) :
+    gib a b (n + 1) ^ 2 - gib a b n * gib a b (n + 2)
+      = (-1) ^ n.natAbs * (a ^ 2 - a * b - b ^ 2) := by
+  have h := gib_vajda a b n 1 1
+  rw [show n + 1 + 1 = n + 2 by ring] at h
+  simp only [Int.fib_one, mul_one] at h
+  linear_combination h
+
+/-- **Gibonacci Catalan** (the `i = j = r` case):
+`G(x+r)² − G x·G(x+2r) = (−1)^|x|·μ·F r²`. -/
+theorem gib_catalan (a b x r : ℤ) :
+    gib a b (x + r) ^ 2 - gib a b x * gib a b (x + 2 * r)
+      = (-1) ^ x.natAbs * (a ^ 2 - a * b - b ^ 2) * Int.fib r ^ 2 := by
+  have h := gib_vajda a b x r r
+  rw [show x + r + r = x + 2 * r by ring] at h
+  linear_combination h
+
+/-! ## The Lucas specialisation: discriminant `μ = −5` -/
+
+/-- The Lucas numbers `L n = F(n−1) + F(n+1)`, realised as the Gibonacci sequence
+with seeds `(a, b) = (1, 2)` (`L 0 = 2`, `L 1 = 1`). -/
+def lucas (n : ℤ) : ℤ := gib 1 2 n
+
+@[simp] theorem lucas_one : lucas 1 = 1 := by simp [lucas]
+
+theorem lucas_zero : lucas 0 = 2 := by rw [lucas, gib_zero]
+
+theorem lucas_recurrence (n : ℤ) : lucas (n + 2) = lucas (n + 1) + lucas n :=
+  gib_recurrence 1 2 n
+
+/-- Lucas numbers via Fibonacci: `L n = F(n−1) + F(n+1)`. -/
+theorem lucas_eq_fib (n : ℤ) : lucas n = Int.fib (n - 1) + Int.fib (n + 1) := by
+  have hj : Int.fib (n + 1) = Int.fib (n - 1) + Int.fib n := by
+    rw [show (n : ℤ) + 1 = (n - 1) + 2 by ring, Int.fib_add_two, show (n : ℤ) - 1 + 1 = n by ring]
+  simp only [lucas, gib]; rw [hj]; ring
+
+/-- **Lucas Vajda identity**: the discriminant constant is `μ = −5`. -/
+theorem lucas_vajda (x i j : ℤ) :
+    lucas (x + i) * lucas (x + j) - lucas x * lucas (x + i + j)
+      = (-1) ^ x.natAbs * (-5) * (Int.fib i * Int.fib j) := by
+  have h := gib_vajda 1 2 x i j
+  norm_num at h
+  simpa [lucas] using h
+
+/-! ## Gelin–Cesàro identity (open question 3 of oq-04) -/
+
+/-- **Gelin–Cesàro identity**:
+`F(n−2)·F(n−1)·F(n+1)·F(n+2) − F n⁴ = −1`.
+
+Obtained by multiplying Cassini (`F(n−1)·F(n+1) = F n² + (−1)^|n|`) and the
+Catalan `r = 2` instance (`F(n−2)·F(n+2) = F n² − (−1)^|n|`), whose product is a
+difference of squares `(F n²)² − ((−1)^|n|)² = F n⁴ − 1`. -/
+theorem fib_gelin_cesaro (n : ℤ) :
+    Int.fib (n - 2) * Int.fib (n - 1) * Int.fib (n + 1) * Int.fib (n + 2)
+      - Int.fib n ^ 4 = -1 := by
+  -- Cassini: F(n+1)·F(n−1) − F n² = (−1)^|n|
+  have hA := Int.fib_succ_mul_fib_pred_sub_fib_sq n
+  -- Catalan r = 2, via Vajda at base n−2 with i = j = 2
+  have hB := fib_vajda (n - 2) 2 2
+  rw [show n - 2 + 2 = n by ring] at hB
+  have hf2 : Int.fib 2 = 1 := by decide
+  have hs : (-1 : ℤ) ^ (n - 2).natAbs = (-1) ^ n.natAbs := by
+    rw [show (n : ℤ) - 2 = (n - 1) - 1 by ring, sign_flip (n - 1), sign_flip n]; ring
+  rw [hf2, hs] at hB
+  -- explicit product values
+  have hP : Int.fib (n - 1) * Int.fib (n + 1) = Int.fib n ^ 2 + (-1) ^ n.natAbs := by
+    linear_combination hA
+  have hQ : Int.fib (n - 2) * Int.fib (n + 2) = Int.fib n ^ 2 - (-1) ^ n.natAbs := by
+    linear_combination -hB
+  have he2 : ((-1 : ℤ) ^ n.natAbs) ^ 2 = 1 := by
+    rw [← pow_mul, mul_comm, pow_mul]; norm_num
+  calc
+    Int.fib (n - 2) * Int.fib (n - 1) * Int.fib (n + 1) * Int.fib (n + 2) - Int.fib n ^ 4
+        = (Int.fib (n - 2) * Int.fib (n + 2)) * (Int.fib (n - 1) * Int.fib (n + 1))
+            - Int.fib n ^ 4 := by ring
+      _ = (Int.fib n ^ 2 - (-1) ^ n.natAbs) * (Int.fib n ^ 2 + (-1) ^ n.natAbs)
+            - Int.fib n ^ 4 := by rw [hP, hQ]
+      _ = -1 := by linear_combination -he2
+
+end FibonacciIdentitiesOQ04OQ01

--- a/research/registry.json
+++ b/research/registry.json
@@ -25359,6 +25359,13 @@
       "status": "graduated",
       "lastUpdate": "2026-06-23T00:18:50.131Z",
       "completed": "2026-06-23T00:18:50.131Z"
+    },
+    {
+      "slug": "fibonacci-identities-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "status": "completed",
+      "lastUpdate": "2026-06-22"
     }
   ],
   "config": {
@@ -25366,5 +25373,5 @@
     "oodaTimeoutMinutes": 60,
     "attemptsBeforePivot": 5
   },
-  "lastUpdated": "2026-06-22T21:30:00.000Z"
+  "lastUpdated": "2026-06-22T23:30:00.000Z"
 }

--- a/src/data/proofs/fibonacci-identities-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-04-oq-01/meta.json
@@ -1,0 +1,214 @@
+{
+  "id": "fibonacci-identities-oq-04-oq-01",
+  "title": "Vajda's Identity for Gibonacci (Horadam) Sequences — the Discriminant Constant, and Gelin–Cesàro",
+  "slug": "fibonacci-identities-oq-04-oq-01",
+  "description": "The parent entry (fibonacci-identities-oq-04) proved Vajda's master identity over the integer Fibonacci numbers and asked, as its first open question, to replace the sign constant by a discriminant and prove the analogue for the Lucas numbers and the general Gibonacci (Horadam) sequences; its third open question asked for the Gelin–Cesàro identity. This entry supplies both. A Gibonacci sequence is any solution of the Fibonacci recurrence G(n+2)=G(n+1)+G(n); over ℤ every such sequence has the closed form G(n) = a·Fₙ + b·Fₙ₋₁ with seeds a=G(1), b=G(0). The headline result is the Gibonacci Vajda identity G(x+i)·G(x+j) − G(x)·G(x+i+j) = (−1)^|x|·(a²−ab−b²)·Fᵢ·Fⱼ, in which the Fibonacci sign constant (−1)^|x| is multiplied by the characteristic μ = a²−ab−b² = G(1)²−G(0)G(1)−G(0)² — exactly the 'discriminant' the open question refers to. Setting (a,b)=(1,0) gives the Fibonacci numbers (μ=1) and recovers Vajda; setting (a,b)=(1,2) gives the Lucas numbers L(0)=2, L(1)=1 (μ=1−2−4=−5), so the Lucas discriminant 5 appears with a sign. Gibonacci Cassini and Catalan follow as the i=j=1 and i=j cases. Finally the Gelin–Cesàro identity Fₙ₋₂·Fₙ₋₁·Fₙ₊₁·Fₙ₊₂ − Fₙ⁴ = −1 is derived by multiplying Cassini (Fₙ₋₁Fₙ₊₁ = Fₙ²+(−1)^|n|) and the Catalan r=2 instance (Fₙ₋₂Fₙ₊₂ = Fₙ²−(−1)^|n|), a difference of squares (Fₙ²)²−((−1)^|n|)² = Fₙ⁴−1. Everything is over Int.fib and holds at all integer indices. Fully verified: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Steven Vajda / E. Gelin / E. Cesàro (classical); A. F. Horadam (Gibonacci/Horadam sequences, 1965); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Identities",
+    "date": "1965",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas-numbers",
+      "gibonacci",
+      "horadam",
+      "vajda",
+      "gelin-cesaro",
+      "cassini",
+      "catalan-identity",
+      "integer-sequences",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ04OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Int.fib_add",
+        "description": "fib (m + n) = fib (m − 1) · fib n + fib m · fib (n + 1) — the integer Fibonacci addition formula; powers the local proof of the Fibonacci Vajda identity that the Gibonacci result reduces to",
+        "module": "Mathlib.Data.Int.Fib.Basic"
+      },
+      {
+        "theorem": "Int.fib_succ_mul_fib_pred_sub_fib_sq",
+        "description": "Cassini's identity fib (n + 1) · fib (n − 1) − fib n ^ 2 = (−1)^|n| — supplies the alternating sign in the Vajda proof and is one of the two factors of the Gelin–Cesàro product",
+        "module": "Mathlib.Data.Int.Fib.Lemmas"
+      },
+      {
+        "theorem": "Int.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining integer Fibonacci recurrence, used to normalize shifted indices and to prove the Gibonacci recurrence and L(n)=F(n−1)+F(n+1)",
+        "module": "Mathlib.Data.Int.Fib.Basic"
+      },
+      {
+        "theorem": "Int.natAbs_even / Int.natAbs_odd",
+        "description": "Even/Odd n.natAbs ↔ Even/Odd n — transfers the parity of an integer to its absolute value, the heart of the sign-flip lemma (−1)^|y−1| = −(−1)^|y|",
+        "module": "Mathlib.Data.Int.Parity"
+      },
+      {
+        "theorem": "Even.neg_one_pow / Odd.neg_one_pow",
+        "description": "(−1)^n = 1 for even n and −1 for odd n — turns the parity of |y| and |y−1| into the explicit sign flip",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "gib (a b n : ℤ) := a·fib n + b·fib (n−1): the integer Gibonacci (Horadam) sequence in closed form, with seeds G(0)=b, G(1)=a; gib_recurrence proves it solves the Fibonacci recurrence and gib_one_zero shows gib 1 0 = Int.fib",
+      "gib_vajda: ∀ a b x i j : ℤ, gib(x+i)·gib(x+j) − gib(x)·gib(x+i+j) = (−1)^|x|·(a²−ab−b²)·(fib i·fib j) — the master identity, replacing Vajda's sign constant by the characteristic μ = a²−ab−b² (the requested 'discriminant'); reduces to four Fibonacci-Vajda instances plus a parity sign-flip",
+      "sign_flip: ∀ y : ℤ, (−1)^|y−1| = −(−1)^|y| — the parity lemma that links Vajda at base x to Vajda at base x−1",
+      "gib_cassini / gib_catalan: the i=j=1 and i=j specializations of the Gibonacci Vajda identity, generalizing Cassini and Catalan with the μ constant",
+      "lucas (n : ℤ) := gib 1 2 n, with lucas_eq_fib (L n = F(n−1)+F(n+1)), lucas_recurrence, lucas_zero=2, lucas_one=1, and lucas_vajda: the Vajda identity for the Lucas numbers with explicit discriminant constant μ = −5",
+      "fib_gelin_cesaro: ∀ n : ℤ, fib(n−2)·fib(n−1)·fib(n+1)·fib(n+2) − fib n⁴ = −1 — the Gelin–Cesàro identity (open question 3 of the parent), obtained as a difference of squares from Cassini and the Catalan r=2 instance"
+    ],
+    "dateAdded": "2026-06-22",
+    "lineCount": 212,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No native_decide is used; the single `decide` evaluates the closed value Int.fib 2 = 1 (kernel decision, axiom-free) and #print axioms on every result lists only the foundational three.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 16,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Steven Vajda's 1989 monograph systematized the Fibonacci product identities; the master identity Fₙ₊ᵢFₙ₊ⱼ − FₙFₙ₊ᵢ₊ⱼ = (−1)ⁿFᵢFⱼ contains Cassini (1680), Catalan, and d'Ocagne as special cases. The same product structure holds for any sequence satisfying the Fibonacci recurrence — A. F. Horadam's 'Gibonacci' (generalized Fibonacci) sequences (1965) — provided the unit sign constant is replaced by the sequence's characteristic μ = G₁² − G₀G₁ − G₀². For the Lucas numbers this characteristic is −5, the negative of the discriminant of x²−x−1. The Gelin–Cesàro identity (E. Gelin, proved by E. Cesàro, 1880s) Fₙ₋₂Fₙ₋₁Fₙ₊₁Fₙ₊₂ − Fₙ⁴ = −1 is a fourth-degree relative obtained by multiplying two product identities. This entry formalizes the Gibonacci generalization and Gelin–Cesàro, the first and third open questions of the parent Vajda entry, all over the two-sided integer Fibonacci sequence so they hold at negative indices.",
+    "problemStatement": "**Open Questions (fibonacci-identities-oq-04, #1 and #3)**: (1) Prove Vajda's identity for the Lucas numbers and the general Gibonacci (Horadam) sequences, where the sign constant is replaced by a discriminant. (3) Prove the Gelin–Cesàro identity Fₙ₋₂Fₙ₋₁Fₙ₊₁Fₙ₊₂ − Fₙ⁴ = −1.\n\n**Result**: gib_vajda — gib(x+i)·gib(x+j) − gib(x)·gib(x+i+j) = (−1)^|x|·(a²−ab−b²)·Fᵢ·Fⱼ for the Gibonacci sequence gib a b n = a·Fₙ + b·Fₙ₋₁ — together with its Lucas specialization lucas_vajda (μ = −5) and the Gelin–Cesàro identity fib_gelin_cesaro.",
+    "text": "A Gibonacci sequence is any solution of G(n+2)=G(n+1)+G(n); over ℤ it has the closed form G(n)=a·Fₙ+b·Fₙ₋₁ parametrised by its seeds a=G(1), b=G(0). The Gibonacci Vajda identity multiplies the Fibonacci sign constant (−1)^|x| by the characteristic μ=a²−ab−b². Fibonacci (a,b)=(1,0) has μ=1 (recovering Vajda); Lucas (a,b)=(1,2) has μ=−5; the discriminant of the recurrence's characteristic polynomial appears explicitly.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Reduce to Fibonacci Vajda.** Restate (and locally re-prove) the Fibonacci Vajda identity fib_vajda. Writing gib(m)=a·Fₘ+b·Fₘ₋₁ and expanding the bilinear product, gib(x+i)gib(x+j) − gib(x)gib(x+i+j) splits as a²·[Vajda at x] + b²·[Vajda at x−1] + ab·([Vajda at (x, i, j−1)] + [Vajda at (x−1, i, j+1)]).\n2. **Parity sign-flip.** The b² and one ab term sit at base x−1, where Cassini's sign is (−1)^|x−1|. The lemma sign_flip proves (−1)^|x−1| = −(−1)^|x| by transferring the parity of x and x−1 to their absolute values (Int.natAbs_even/odd) and evaluating (−1)^· via Even/Odd.neg_one_pow.\n3. **Collapse the cross term.** Using F_{j−1} − F_{j+1} = −F_j (the recurrence), the ab contribution becomes −(−1)^|x|·Fᵢ·Fⱼ, and the four pieces combine to (a²−ab−b²)·(−1)^|x|·Fᵢ·Fⱼ. A single linear_combination of the four Vajda instances and the recurrence closes the goal.\n4. **Specializations.** gib_cassini (i=j=1) and gib_catalan (i=j) drop out by linear_combination. The Lucas numbers are lucas n = gib 1 2 n; lucas_eq_fib identifies them with F(n−1)+F(n+1) and lucas_vajda reads off μ = 1−2−4 = −5.\n5. **Gelin–Cesàro.** Cassini gives Fₙ₋₁Fₙ₊₁ = Fₙ²+(−1)^|n|; the Catalan r=2 instance (fib_vajda (n−2) 2 2, with (−1)^|n−2| = (−1)^|n| via two sign-flips) gives Fₙ₋₂Fₙ₊₂ = Fₙ²−(−1)^|n|. Their product is (Fₙ²)²−((−1)^|n|)² = Fₙ⁴−1, so the four-factor product minus Fₙ⁴ equals −1.",
+    "keyInsights": [
+      "**The discriminant is the characteristic μ = a²−ab−b².** For a Gibonacci sequence with seeds (a,b)=(G₁,G₀) this single quadratic in the seeds controls every product identity: Fibonacci has μ=1, Lucas has μ=−5 (the negated discriminant of x²−x−1). The Fibonacci identities are exactly the μ=1 case.",
+      "**Bilinearity reduces Gibonacci to Fibonacci.** Because gib is ℤ-linear in (a,b) over the Fibonacci basis {Fₙ, Fₙ₋₁}, the Gibonacci Vajda identity is a fixed ℤ-bilinear combination of four ordinary Fibonacci Vajda instances — no new induction is needed, only the parity sign-flip and one recurrence step.",
+      "**Parity sign-flip is the only genuinely new lemma.** Linking Vajda at base x to base x−1 needs (−1)^|x−1| = −(−1)^|x|, which is false-looking until one notes |n| has the same parity as n; the lemma transfers parity through Int.natAbs.",
+      "**Gelin–Cesàro is a difference of squares.** Pairing Cassini (Fₙ²+(−1)^|n|) with Catalan r=2 (Fₙ²−(−1)^|n|) turns the degree-four product into (Fₙ²)²−1, so the identity is immediate once the two signs are aligned."
+    ],
+    "prerequisites": [
+      "The integer Fibonacci addition formula Int.fib_add, recurrence Int.fib_add_two, and Cassini's identity Int.fib_succ_mul_fib_pred_sub_fib_sq",
+      "Parity transfer Int.natAbs_even/Int.natAbs_odd and Even/Odd.neg_one_pow",
+      "The ring and linear_combination tactics for closing polynomial identities"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the Gibonacci closed form G(n)=a·Fₙ+b·Fₙ₋₁, the characteristic μ=a²−ab−b² as the discriminant, and the Fibonacci/Lucas specializations; import Mathlib and open Int.",
+      "mathContext": "$G(x+i)G(x+j) - G(x)G(x+i+j) = (-1)^{|x|}\\,(a^2-ab-b^2)\\,F_i F_j$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "fib-vajda",
+      "title": "Fibonacci Vajda Identity (restated locally)",
+      "startLine": 51,
+      "endLine": 70,
+      "summary": "fib_vajda: the verified parent headline reproduced so the file depends only on Mathlib; five Int.fib_add expansions plus Cassini reduce the two-parameter product to a ring identity.",
+      "mathContext": "$F_{x+i}F_{x+j} - F_x F_{x+i+j} = (-1)^{|x|} F_i F_j$."
+    },
+    {
+      "id": "sign-flip",
+      "title": "Parity Sign-Flip Lemma",
+      "startLine": 72,
+      "endLine": 81,
+      "summary": "sign_flip: (−1)^|y−1| = −(−1)^|y|, proved by transferring the parity of y and y−1 to their absolute values via Int.natAbs_even/odd and evaluating (−1)^· through Even/Odd.neg_one_pow.",
+      "mathContext": "$(-1)^{|y-1|} = -(-1)^{|y|}$ since $|n| \\equiv n \\pmod 2$."
+    },
+    {
+      "id": "gibonacci",
+      "title": "Gibonacci Sequences",
+      "startLine": 83,
+      "endLine": 106,
+      "summary": "def gib a b n = a·fib n + b·fib (n−1) with seed anchors gib_one/gib_two/gib_zero, gib_recurrence (it solves the Fibonacci recurrence), and gib_one_zero (gib 1 0 = Int.fib).",
+      "mathContext": "$G(n) = a F_n + b F_{n-1},\\quad G(0)=b,\\ G(1)=a$."
+    },
+    {
+      "id": "gib-vajda",
+      "title": "The Master Gibonacci Vajda Identity",
+      "startLine": 108,
+      "endLine": 130,
+      "summary": "gib_vajda: the headline, reducing to four Fibonacci-Vajda instances (at x and x−1), the parity sign-flip, and the recurrence F(j+1)=F(j−1)+F(j), closed by one linear_combination. The constant is μ = a²−ab−b².",
+      "mathContext": "$G(x+i)G(x+j) - G(x)G(x+i+j) = (-1)^{|x|}(a^2-ab-b^2)F_i F_j$."
+    },
+    {
+      "id": "gib-cassini-catalan",
+      "title": "Gibonacci Cassini and Catalan",
+      "startLine": 132,
+      "endLine": 148,
+      "summary": "gib_cassini (i=j=1) and gib_catalan (i=j) specializations, generalizing Cassini and Catalan with the characteristic μ in place of the unit sign constant.",
+      "mathContext": "$G(n+1)^2 - G(n)G(n+2) = (-1)^{|n|}(a^2-ab-b^2)$."
+    },
+    {
+      "id": "lucas",
+      "title": "The Lucas Specialisation (μ = −5)",
+      "startLine": 150,
+      "endLine": 183,
+      "summary": "lucas n = gib 1 2 n with lucas_eq_fib (L n = F(n−1)+F(n+1)), lucas_recurrence, lucas_zero=2, lucas_one=1, and lucas_vajda — Vajda for the Lucas numbers with explicit discriminant constant μ = −5.",
+      "mathContext": "$L(x+i)L(x+j) - L(x)L(x+i+j) = -5\\,(-1)^{|x|}F_i F_j$."
+    },
+    {
+      "id": "gelin-cesaro",
+      "title": "Gelin–Cesàro Identity",
+      "startLine": 185,
+      "endLine": 212,
+      "summary": "fib_gelin_cesaro: Fₙ₋₂Fₙ₋₁Fₙ₊₁Fₙ₊₂ − Fₙ⁴ = −1, obtained as the difference of squares of Cassini (Fₙ²+(−1)^|n|) and the Catalan r=2 instance (Fₙ²−(−1)^|n|), with the two signs aligned by the sign-flip lemma.",
+      "mathContext": "$F_{n-2}F_{n-1}F_{n+1}F_{n+2} - F_n^4 = -1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-04",
+      "relationship": "extends",
+      "description": "Resolves open questions #1 (Gibonacci/Lucas Vajda with discriminant constant) and #3 (Gelin–Cesàro identity) of the parent Vajda entry, building on its fib_vajda master identity"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "generalizes",
+      "description": "The oq-01 Cassini entry sits at the base of the product-identity hierarchy; this entry lifts the whole hierarchy from Fibonacci to arbitrary Gibonacci sequences via the characteristic μ"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms, no native_decide) proof of Vajda's identity for arbitrary integer Gibonacci (Horadam) sequences, with the sign constant replaced by the characteristic μ = a²−ab−b²; the Lucas specialization (μ = −5); and the Gelin–Cesàro identity Fₙ₋₂Fₙ₋₁Fₙ₊₁Fₙ₊₂ − Fₙ⁴ = −1.",
+    "implications": "Answers the parent Vajda entry's open questions #1 and #3, showing the Fibonacci product hierarchy lifts uniformly to every sequence satisfying the Fibonacci recurrence with the discriminant μ as the single controlling constant, and that the Lucas discriminant 5 falls out automatically from the seeds (1, 2).",
+    "openQuestions": [
+      "Formalize the matrix form det([[1,1],[1,0]]ⁿ) = (−1)ⁿ and deduce the Fibonacci Vajda identity from Cauchy–Binet / multiplicativity of determinants (open question #2 of the parent, still open).",
+      "Extend the characteristic μ to the full Horadam recurrence W(n+2) = pW(n+1) + qW(n) with p, q ≠ 1, where the constant becomes a function of p, q and the seeds.",
+      "Prove the Gibonacci analogue of d'Ocagne's identity, G(m)G(n+1) − G(m+1)G(n) = (−1)^|n|·μ·F(m−n)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Int"
+    ],
+    "namespace": "FibonacciIdentitiesOQ04OQ01",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "path": "Proofs/FibonacciIdentitiesOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "Vajda's identity and its specializations to Catalan, Cassini, and d'Ocagne"
+    },
+    {
+      "authors": "Horadam, A. F.",
+      "title": "Generalized Fibonacci Sequences",
+      "year": "1961",
+      "venue": "American Mathematical Monthly 68 (5): 455–459",
+      "note": "Gibonacci / Horadam sequences satisfying the Fibonacci recurrence with arbitrary seeds"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Lucas numbers, the Gelin–Cesàro identity, and Gibonacci product identities"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open questions #1 and #3** of the merged parent `fibonacci-identities-oq-04` (Vajda's identity).

A **Gibonacci (Horadam) sequence** — any solution of `G(n+2)=G(n+1)+G(n)` — has the integer closed form `G(n) = a·Fₙ + b·Fₙ₋₁` with seeds `a=G(1)`, `b=G(0)`. The headline is the **Gibonacci Vajda identity**:

```
gib_vajda :  G(x+i)·G(x+j) − G(x)·G(x+i+j) = (−1)^|x| · (a²−ab−b²) · Fᵢ · Fⱼ
```

The Fibonacci sign constant `(−1)^|x|` is multiplied by the **characteristic** `μ = a²−ab−b² = G(1)²−G(0)G(1)−G(0)²` — exactly the *discriminant* the open question asks for:

- **Fibonacci** `(a,b)=(1,0)`: `μ = 1`, recovering Vajda (`gib_one_zero : gib 1 0 = Int.fib`).
- **Lucas** `(a,b)=(1,2)` (`L 0 = 2`, `L 1 = 1`): `μ = 1−2−4 = −5` (`lucas_vajda`) — the negated discriminant of `x²−x−1`.

## Contents (16 theorems, 2 defs, 212 lines)

- `gib` / `gib_recurrence` / `gib_one,two,zero` / `gib_one_zero` — the sequence and its anchors
- `sign_flip : (−1)^|y−1| = −(−1)^|y|` — parity lemma linking Vajda at base `x` and `x−1`
- `gib_vajda` — master identity; `gib_cassini`, `gib_catalan` — specializations
- `lucas`, `lucas_eq_fib` (`L n = F(n−1)+F(n+1)`), `lucas_recurrence`, `lucas_zero`, `lucas_one`, `lucas_vajda`
- `fib_gelin_cesaro : Fₙ₋₂Fₙ₋₁Fₙ₊₁Fₙ₊₂ − Fₙ⁴ = −1` — open question #3, a Cassini × Catalan-`r=2` difference of squares

## Proof approach

Standalone (`import Mathlib` only): the Fibonacci Vajda identity is re-proved locally, then by ℤ-bilinearity of `gib` over the basis `{Fₙ, Fₙ₋₁}` the Gibonacci result reduces to **four** Fibonacci-Vajda instances (at `x` and `x−1`), the parity sign-flip, and one recurrence step — closed by a single `linear_combination`. No new induction.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` on every result lists only `propext`/`Classical.choice`/`Quot.sound`.
- **No `native_decide`**; the single `decide` evaluates the closed value `Int.fib 2 = 1`.
- Compiled standalone against Mathlib `v4.26.0` (Docker build infra down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)