### PR TITLE
research(prob-method-expectation-oq-02): genuine Erdős 1947 first-moment Ramsey lower bound [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3222,6 +3222,7 @@ import Proofs.ProbMethodAlterationOQ02
 import Proofs.ProbMethodApplications
 import Proofs.ProbMethodExpectation
 import Proofs.ProbMethodExpectationOQ01
+import Proofs.ProbMethodExpectationOQ02
 import Proofs.ProbMethodSecondMoment
 import Proofs.ProbMethodSecondMomentOQ01
 import Proofs.ProbMethodSecondMomentOQ02

--- a/proofs/Proofs/ProbMethodExpectationOQ02.lean
+++ b/proofs/Proofs/ProbMethodExpectationOQ02.lean
@@ -1,0 +1,298 @@
+/-
+  First Moment Method — OQ-02: the genuine Erdős (1947) Ramsey lower bound.
+
+  The parent entry `ProbMethodExpectation` states `erdos_ramsey_lower_bound` as
+  `∃ n, n ≥ 2^(k/2) ∧ n > 0` — which is *vacuously true* and proves nothing about
+  Ramsey numbers.  This file supplies the real content of the first-moment method:
+  the union-bound counting argument that actually produces a good 2-colouring.
+
+  We model a 2-colouring of the edges of the complete graph `K_n` as a function
+  `c : Edge n → Bool`, where `Edge n` is the (finite) type of 2-element subsets of
+  `Fin n`.  A `k`-subset `S` is a **monochromatic clique** under `c` when every edge
+  inside `S` receives the same colour.
+
+  Headline result (`ramsey_lower_bound`): if
+
+        C(n,k) · 2 ^ (C(n,2) − C(k,2) + 1)  <  2 ^ C(n,2)
+
+  then there is a 2-colouring of `K_n` with **no** monochromatic `K_k` — equivalently
+  `R(k,k) > n`.  This is the exact statement obtained from the first moment method:
+  the expected number of monochromatic `k`-cliques is `C(n,k)·2^(1−C(k,2))`, and when
+  this is `< 1` a good colouring must exist.
+
+  Supporting infrastructure:
+  * `card_const_le` — the core counting bound: the number of colourings constant on a
+    nonempty set `I` of coordinates is `≤ 2 ^ (|ι| − |I| + 1)`.  (A clean, reusable
+    "fix |I|−1 degrees of freedom" lemma proved by an injection.)
+  * `ramsey_lower_bound_rat` — the textbook form with the hypothesis stated over `ℚ`
+    as `C(n,k)·2^(1−C(k,2)) < 1`.
+  * `ramsey_K6_no_mono_K4` — a concrete non-vacuous instance: a 2-colouring of `K_6`
+    with no monochromatic `K_4` (so `R(4,4) > 6`).
+
+  All results are fully machine-checked: 0 sorries, 0 axioms.
+
+  Reference: Alon–Spencer, *The Probabilistic Method*, Ch. 1 (Ramsey numbers).
+-/
+
+import Mathlib
+
+namespace ProbMethod.ExpectationOQ02
+
+open Finset BigOperators
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part I: Core counting bound (reusable, type-generic)
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Counting colourings constant on a set of coordinates.**
+    For a finite index type `ι` and a nonempty coordinate set `I` (with a chosen
+    base point `i₀ ∈ I`), the number of Boolean colourings that are constant on `I`
+    is at most `2 ^ (|ι| − |I| + 1)`: such a colouring is determined by its common
+    value on `I` (1 degree of freedom) together with its values off `I`
+    (`|ι| − |I|` degrees of freedom).
+
+    This is the engine behind every "expected number of bad events" computation in
+    the probabilistic method. -/
+theorem card_const_le {ι : Type*} [Fintype ι] [DecidableEq ι]
+    (I : Finset ι) (i₀ : ι) (hi₀ : i₀ ∈ I) :
+    (univ.filter (fun c : ι → Bool => ∀ i ∈ I, c i = c i₀)).card
+      ≤ 2 ^ (Fintype.card ι - I.card + 1) := by
+  -- Inject a constant-on-`I` colouring into `(common value, values off I)`.
+  classical
+  set φ : (ι → Bool) → Bool × ({x : ι // x ∉ I} → Bool) :=
+    fun c => (c i₀, fun x => c x.val) with hφ
+  have hsub : (univ.filter (fun c : ι → Bool => ∀ i ∈ I, c i = c i₀)).card
+      ≤ (univ : Finset (Bool × ({x : ι // x ∉ I} → Bool))).card := by
+    apply Finset.card_le_card_of_injOn φ
+    · intro c _; exact mem_univ _
+    · intro c hc c' hc' hcc'
+      simp only [mem_coe, mem_filter, mem_univ, true_and] at hc hc'
+      -- equate the two colourings pointwise
+      funext y
+      by_cases hy : y ∈ I
+      · -- on `I`: both equal their (common, equal) base value
+        have h1 : c y = c i₀ := hc y hy
+        have h2 : c' y = c' i₀ := hc' y hy
+        have hbase : c i₀ = c' i₀ := congrArg Prod.fst hcc'
+        rw [h1, hbase, ← h2]
+      · -- off `I`: read off the second component
+        have hsnd : (fun x : {x : ι // x ∉ I} => c x.val)
+            = (fun x : {x : ι // x ∉ I} => c' x.val) := congrArg Prod.snd hcc'
+        have := congrFun hsnd ⟨y, hy⟩
+        simpa using this
+  -- evaluate the cardinality of the codomain
+  have hcompl : Fintype.card {x : ι // x ∉ I} = Fintype.card ι - I.card := by
+    have : Fintype.card {x : ι // x ∈ I} = I.card := by
+      rw [Fintype.card_subtype]
+      congr 1
+      ext x; simp
+    rw [Fintype.card_subtype_compl, this]
+  have hcard : (univ : Finset (Bool × ({x : ι // x ∉ I} → Bool))).card
+      = 2 ^ (Fintype.card ι - I.card + 1) := by
+    rw [Finset.card_univ, Fintype.card_prod, Fintype.card_bool, Fintype.card_fun,
+        Fintype.card_bool, hcompl, pow_succ]
+    ring
+  rw [← hcard]
+  exact hsub
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part II: Edge / clique model for the complete graph K_n
+-- ═══════════════════════════════════════════════════════════════════
+
+section Graph
+
+variable (n : ℕ)
+
+/-- An **edge** of `K_n`: a 2-element subset of the vertex set `Fin n`. -/
+abbrev Edge := {e : Finset (Fin n) // e.card = 2}
+
+variable {n}
+
+/-- The edges lying inside a vertex set `S` (the internal edges of the clique on `S`). -/
+def internal (S : Finset (Fin n)) : Finset (Edge n) :=
+  univ.filter (fun e => (e : Finset (Fin n)) ⊆ S)
+
+/-- The internal edges of `S` are in bijection with the 2-subsets of `S`, hence there
+    are `C(|S|, 2)` of them. -/
+theorem card_internal (S : Finset (Fin n)) :
+    (internal S).card = S.card.choose 2 := by
+  classical
+  have himg : (internal S).image (Subtype.val) = S.powersetCard 2 := by
+    ext e'
+    simp only [internal, mem_image, mem_filter, mem_univ, true_and, mem_powersetCard]
+    constructor
+    · rintro ⟨e, he, rfl⟩
+      exact ⟨he, e.2⟩
+    · rintro ⟨hsub, hcard⟩
+      exact ⟨⟨e', hcard⟩, hsub, rfl⟩
+  calc (internal S).card
+      = ((internal S).image (Subtype.val)).card :=
+        (Finset.card_image_of_injective _ Subtype.val_injective).symm
+    _ = (S.powersetCard 2).card := by rw [himg]
+    _ = S.card.choose 2 := Finset.card_powersetCard _ _
+
+/-- There are `C(n,2)` edges in `K_n`. -/
+theorem card_edge : Fintype.card (Edge n) = n.choose 2 := by
+  classical
+  have : (internal (univ : Finset (Fin n))) = (univ : Finset (Edge n)) := by
+    ext e; simp [internal]
+  have h := card_internal (univ : Finset (Fin n))
+  rw [this] at h
+  rwa [Finset.card_univ, Finset.card_univ, Fintype.card_fin] at h
+
+/-- A vertex set `S` is a **monochromatic clique** under colouring `c` when every pair
+    of internal edges shares a colour. -/
+def Mono (c : Edge n → Bool) (S : Finset (Fin n)) : Prop :=
+  ∀ e₁ ∈ internal S, ∀ e₂ ∈ internal S, c e₁ = c e₂
+
+instance (c : Edge n → Bool) (S : Finset (Fin n)) : Decidable (Mono c S) := by
+  unfold Mono; infer_instance
+
+end Graph
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part III: The first-moment Ramsey lower bound
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Erdős 1947 — first-moment Ramsey lower bound (colouring-existence form).**
+
+    If `C(n,k) · 2 ^ (C(n,2) − C(k,2) + 1) < 2 ^ C(n,2)`, then there is a 2-colouring
+    of the edges of `K_n` with **no** monochromatic `K_k`: every `k`-subset of
+    vertices contains two internal edges of different colours.  Equivalently,
+    `R(k,k) > n`.
+
+    Proof: the bad colourings (those admitting *some* monochromatic `k`-clique) are a
+    union, over the `C(n,k)` choices of `k`-set `S`, of the colourings constant on the
+    `C(k,2)` internal edges of `S`.  By `card_const_le` each such set has at most
+    `2 ^ (C(n,2) − C(k,2) + 1)` colourings, so the bad set has fewer than `2^C(n,2)`
+    colourings — leaving a good one. -/
+theorem ramsey_lower_bound (n k : ℕ) (hk : 2 ≤ k)
+    (hbound : n.choose k * 2 ^ (n.choose 2 - k.choose 2 + 1) < 2 ^ n.choose 2) :
+    ∃ c : Edge n → Bool, ∀ S : Finset (Fin n), S.card = k →
+      ∃ e₁ ∈ internal S, ∃ e₂ ∈ internal S, c e₁ ≠ c e₂ := by
+  classical
+  -- the family of k-subsets of vertices
+  set K : Finset (Finset (Fin n)) := (univ : Finset (Fin n)).powersetCard k with hK
+  have hKcard : K.card = n.choose k := by
+    rw [hK, Finset.card_powersetCard, Finset.card_univ, Fintype.card_fin]
+  -- the set of "bad" colourings (admitting some monochromatic k-clique)
+  set bad : Finset (Edge n → Bool) :=
+    univ.filter (fun c => ∃ S ∈ K, Mono c S) with hbad
+  -- bound the number of bad colourings
+  have hbad_le : bad.card ≤ n.choose k * 2 ^ (n.choose 2 - k.choose 2 + 1) := by
+    have hsub : bad ⊆ K.biUnion (fun S => univ.filter (fun c => Mono c S)) := by
+      intro c hc
+      rw [hbad, mem_filter] at hc
+      obtain ⟨_, S, hS, hmono⟩ := hc
+      exact mem_biUnion.mpr ⟨S, hS, mem_filter.mpr ⟨mem_univ _, hmono⟩⟩
+    -- per-clique bound on the number of monochromatic colourings
+    have hper : ∀ S ∈ K, (univ.filter (fun c : Edge n → Bool => Mono c S)).card
+        ≤ 2 ^ (n.choose 2 - k.choose 2 + 1) := by
+      intro S hS
+      rw [hK, mem_powersetCard] at hS
+      obtain ⟨_, hScard⟩ := hS
+      -- the internal edges of S are nonempty (k ≥ 2 ⟹ C(k,2) ≥ 1)
+      have hpos : 0 < (internal S).card := by
+        rw [card_internal, hScard]; exact Nat.choose_pos hk
+      obtain ⟨e₀, he₀⟩ := Finset.card_pos.mp hpos
+      -- a fully-monochromatic colouring is constant relative to e₀
+      have hsub2 : (univ.filter (fun c : Edge n → Bool => Mono c S))
+          ⊆ univ.filter (fun c : Edge n → Bool => ∀ e ∈ internal S, c e = c e₀) := by
+        intro c hc
+        rw [mem_filter] at hc ⊢
+        exact ⟨hc.1, fun e he => hc.2 e he e₀ he₀⟩
+      calc (univ.filter (fun c : Edge n → Bool => Mono c S)).card
+          ≤ (univ.filter (fun c : Edge n → Bool => ∀ e ∈ internal S, c e = c e₀)).card :=
+            Finset.card_le_card hsub2
+        _ ≤ 2 ^ (Fintype.card (Edge n) - (internal S).card + 1) :=
+            card_const_le _ e₀ he₀
+        _ = 2 ^ (n.choose 2 - k.choose 2 + 1) := by
+            rw [card_edge, card_internal, hScard]
+    calc bad.card
+        ≤ (K.biUnion (fun S => univ.filter (fun c => Mono c S))).card :=
+          Finset.card_le_card hsub
+      _ ≤ ∑ S ∈ K, (univ.filter (fun c : Edge n → Bool => Mono c S)).card :=
+          Finset.card_biUnion_le
+      _ ≤ ∑ _S ∈ K, 2 ^ (n.choose 2 - k.choose 2 + 1) := Finset.sum_le_sum hper
+      _ = K.card * 2 ^ (n.choose 2 - k.choose 2 + 1) := by
+          rw [Finset.sum_const, smul_eq_mul]
+      _ = n.choose k * 2 ^ (n.choose 2 - k.choose 2 + 1) := by rw [hKcard]
+  -- hence the bad set is strictly smaller than the whole colouring space
+  have htot : Fintype.card (Edge n → Bool) = 2 ^ n.choose 2 := by
+    rw [Fintype.card_fun, Fintype.card_bool, card_edge]
+  have hlt : bad.card < (univ : Finset (Edge n → Bool)).card := by
+    rw [Finset.card_univ, htot]
+    exact lt_of_le_of_lt hbad_le hbound
+  -- so some good colouring exists
+  have hne : (univ.filter (fun c : Edge n → Bool => ¬ (∃ S ∈ K, Mono c S))).Nonempty := by
+    rw [← Finset.card_pos]
+    have hsplit := Finset.filter_card_add_filter_neg_card_eq_card
+      (s := (univ : Finset (Edge n → Bool))) (p := fun c => ∃ S ∈ K, Mono c S)
+    rw [← hbad] at hsplit
+    have huniv : (univ : Finset (Edge n → Bool)).card = 2 ^ n.choose 2 := by
+      rw [Finset.card_univ, htot]
+    omega
+  obtain ⟨c, hc⟩ := hne
+  rw [mem_filter] at hc
+  refine ⟨c, ?_⟩
+  intro S hScard
+  -- S is one of the k-subsets
+  have hSK : S ∈ K := by
+    rw [hK, mem_powersetCard]; exact ⟨Finset.subset_univ _, hScard⟩
+  -- c is not monochromatic on S
+  have hnotmono : ¬ Mono c S := fun h => hc.2 ⟨S, hSK, h⟩
+  unfold Mono at hnotmono
+  push_neg at hnotmono
+  obtain ⟨e₁, he₁, e₂, he₂, hne'⟩ := hnotmono
+  exact ⟨e₁, he₁, e₂, he₂, hne'⟩
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part IV: Textbook rational form  C(n,k)·2^(1−C(k,2)) < 1
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **First-moment Ramsey bound, textbook form.**
+
+    If the expected number of monochromatic `k`-cliques is `< 1`, i.e.
+
+          C(n,k) · 2 ^ (1 − C(k,2))  <  1     (over ℚ),
+
+    then `K_n` has a 2-colouring with no monochromatic `K_k`.  This is the statement
+    as it appears in Alon–Spencer; it is equivalent to the integer hypothesis of
+    `ramsey_lower_bound` (using `C(k,2) ≤ C(n,2)`, valid since `k ≤ n`). -/
+theorem ramsey_lower_bound_rat (n k : ℕ) (hk : 2 ≤ k) (hkn : k ≤ n)
+    (hexp : (n.choose k : ℚ) * (2 : ℚ) ^ (1 - (k.choose 2 : ℤ)) < 1) :
+    ∃ c : Edge n → Bool, ∀ S : Finset (Fin n), S.card = k →
+      ∃ e₁ ∈ internal S, ∃ e₂ ∈ internal S, c e₁ ≠ c e₂ := by
+  apply ramsey_lower_bound n k hk
+  have hle : k.choose 2 ≤ n.choose 2 := Nat.choose_le_choose 2 hkn
+  have hk1 : 1 ≤ k.choose 2 := Nat.choose_pos hk
+  -- Step 1: collapse the ℚ hypothesis (with its negative ℤ exponent) into the clean
+  -- ℕ bound  C(n,k) < 2 ^ (C(k,2) − 1).
+  have hexp' : (n.choose k : ℚ) < 2 ^ (k.choose 2 - 1) := by
+    have heq : (1 : ℤ) - (k.choose 2 : ℤ) = -((k.choose 2 - 1 : ℕ) : ℤ) := by
+      rw [Nat.cast_sub hk1]; push_cast; ring
+    rw [heq, zpow_neg, zpow_natCast] at hexp
+    have hb : (0 : ℚ) < 2 ^ (k.choose 2 - 1) := by positivity
+    have h2 := mul_lt_mul_of_pos_right hexp hb
+    rwa [inv_mul_cancel_right₀ (ne_of_gt hb), one_mul] at h2
+  have hnat : n.choose k < 2 ^ (k.choose 2 - 1) := by exact_mod_cast hexp'
+  -- Step 2: multiply by 2 ^ (C(n,2) − C(k,2) + 1) and recombine the exponents.
+  calc n.choose k * 2 ^ (n.choose 2 - k.choose 2 + 1)
+      < 2 ^ (k.choose 2 - 1) * 2 ^ (n.choose 2 - k.choose 2 + 1) :=
+        mul_lt_mul_of_pos_right hnat (by positivity)
+    _ = 2 ^ n.choose 2 := by rw [← pow_add]; congr 1; omega
+
+-- ═══════════════════════════════════════════════════════════════════
+-- Part V: A concrete non-vacuous instance
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Concrete instance: `R(4,4) > 6`.**
+    There is a 2-colouring of the edges of `K_6` with no monochromatic `K_4`.
+    Here `C(6,4)·2^(C(6,2)−C(4,2)+1) = 15·2^10 = 15360 < 32768 = 2^15`. -/
+theorem ramsey_K6_no_mono_K4 :
+    ∃ c : Edge 6 → Bool, ∀ S : Finset (Fin 6), S.card = 4 →
+      ∃ e₁ ∈ internal S, ∃ e₂ ∈ internal S, c e₁ ≠ c e₂ := by
+  apply ramsey_lower_bound 6 4 (by norm_num)
+  decide
+
+end ProbMethod.ExpectationOQ02

--- a/src/data/proofs/prob-method-expectation-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-02/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-pmeoq02-card-const-le",
+    "proofId": "prob-method-expectation-oq-02",
+    "range": {
+      "startLine": 56,
+      "endLine": 96
+    },
+    "type": "theorem",
+    "title": "card_const_le: The Reusable First-Moment Counting Engine",
+    "content": "`card_const_le` bounds the number of Boolean colourings `c : ι → Bool` that are constant on a nonempty coordinate set `I` (with base point `i₀ ∈ I`) by `2 ^ (Fintype.card ι − I.card + 1)`. The proof injects each such colouring into the pair `(c i₀, c restricted to {x // x ∉ I})` via `Finset.card_le_card_of_injOn`: injectivity is `funext` with a case split on `y ∈ I` (on I both equal their common base value; off I read the second component). The codomain cardinality is `2 · 2^(card ι − I.card)` computed with `Fintype.card_prod`, `Fintype.card_fun`, `Fintype.card_subtype_compl`, and `pow_succ`.",
+    "mathContext": "A function constant on a set $I$ of coordinates has only $1 + (|\\iota| - |I|)$ degrees of freedom: one binary choice for the common value on $I$, plus a free binary choice at each of the $|\\iota| - |I|$ coordinates outside $I$. Hence at most $2^{|\\iota| - |I| + 1}$ such functions. This is the combinatorial core of every 'expected number of bad events' computation in the probabilistic method.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.card_le_card_of_injOn",
+      "Fintype.card_subtype_compl",
+      "Fintype.card_fun",
+      "union bound"
+    ],
+    "prerequisites": [
+      "Finset cardinality and injections",
+      "Fintype.card of products and function types",
+      "subtype complements"
+    ]
+  },
+  {
+    "id": "ann-pmeoq02-edge-model",
+    "proofId": "prob-method-expectation-oq-02",
+    "range": {
+      "startLine": 102,
+      "endLine": 151
+    },
+    "type": "definition",
+    "title": "Edge / Clique Model for K_n",
+    "content": "`Edge n := {e : Finset (Fin n) // e.card = 2}` is the finite type of edges of the complete graph. `internal S` collects the edges contained in a vertex set S; `card_internal` proves `(internal S).card = C(|S|,2)` by imaging through `Subtype.val` onto `S.powersetCard 2` (`Finset.card_image_of_injective`, `Finset.card_powersetCard`), and `card_edge` specialises it to `Fintype.card (Edge n) = C(n,2)`. `Mono c S` says every two internal edges of S share a colour, with a `Decidable` instance so the bad set is a `Finset.filter`.",
+    "mathContext": "A 2-colouring of $K_n$ is a map from its $\\binom{n}{2}$ edges to $\\{0,1\\}$. A vertex set $S$ of size $k$ spans $\\binom{k}{2}$ internal edges, and $S$ is a *monochromatic clique* under $c$ when all of these receive the same colour. Identifying edges with 2-element subsets and internal edges with `powersetCard 2` gives the exact binomial counts $\\binom{n}{2}$ and $\\binom{k}{2}$ used in the expected-value calculation.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Finset.powersetCard",
+      "Finset.card_powersetCard",
+      "complete graph K_n",
+      "monochromatic clique"
+    ],
+    "prerequisites": [
+      "subtypes over Finset",
+      "powersetCard and binomial coefficients",
+      "Decidable instances"
+    ]
+  },
+  {
+    "id": "ann-pmeoq02-ramsey-lower-bound",
+    "proofId": "prob-method-expectation-oq-02",
+    "range": {
+      "startLine": 169,
+      "endLine": 244
+    },
+    "type": "theorem",
+    "title": "ramsey_lower_bound: The Union-Bound Existence of a Good Colouring",
+    "content": "Under `C(n,k)·2^(C(n,2)−C(k,2)+1) < 2^C(n,2)`, produces a colouring `c : Edge n → Bool` such that every k-set S has two internal edges of different colours. The bad colourings (filter of `∃ S ∈ K, Mono c S`, K = `powersetCard k univ`) inject into `K.biUnion (fun S => filter (Mono · S))`; each block is bounded by reducing `Mono c S` to constant-relative-to-a-base-edge and applying `card_const_le` (internal S nonempty since C(k,2) ≥ 1), giving the per-clique bound 2^(C(n,2)−C(k,2)+1). `Finset.card_biUnion_le` + `Finset.sum_le_sum` + `Finset.sum_const` yield bad.card ≤ C(n,k)·2^(…). Since the total colouring count is 2^C(n,2), `filter_card_add_filter_neg_card_eq_card` and `omega` force a good colouring to exist, and `push_neg` on `¬ Mono c S` extracts the witnessing pair of edges.",
+    "mathContext": "Erdős's 1947 first-moment argument: the expected number of monochromatic $k$-cliques in a uniformly random 2-colouring is $\\binom{n}{k}\\,2^{1-\\binom{k}{2}}$. Equivalently, the number of colourings containing *some* monochromatic $k$-clique is at most $\\binom{n}{k}\\,2^{\\binom{n}{2}-\\binom{k}{2}+1}$ by the union bound over the $\\binom{n}{k}$ candidate cliques. When this is strictly below the total $2^{\\binom{n}{2}}$, at least one colouring avoids every monochromatic $K_k$, so $R(k,k) > n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "union bound",
+      "Finset.card_biUnion_le",
+      "filter_card_add_filter_neg_card_eq_card",
+      "Ramsey number R(k,k)",
+      "probabilistic method"
+    ],
+    "prerequisites": [
+      "card_const_le",
+      "Finset biUnion and filter cardinalities",
+      "pigeonhole via complementary counts"
+    ]
+  },
+  {
+    "id": "ann-pmeoq02-rational-form",
+    "proofId": "prob-method-expectation-oq-02",
+    "range": {
+      "startLine": 259,
+      "endLine": 287
+    },
+    "type": "theorem",
+    "title": "ramsey_lower_bound_rat: The Textbook Expected-Value Criterion",
+    "content": "Restates the bound with the Alon–Spencer hypothesis `(C(n,k) : ℚ)·2^(1−C(k,2)) < 1` (a zpow with negative ℤ exponent). The proof collapses the negative exponent: since C(k,2) ≥ 1 (`Nat.choose_pos`), `1 − C(k,2) = −(C(k,2)−1)` (`Nat.cast_sub`), so `zpow_neg`/`zpow_natCast` rewrite the hypothesis to `(C(n,k) : ℚ) < 2^(C(k,2)−1)`; `mul_lt_mul_of_pos_right` then `mul_inv_cancel_right₀` clear the inverse, and `exact_mod_cast` lands the ℕ bound `C(n,k) < 2^(C(k,2)−1)`. Multiplying by `2^(C(n,2)−C(k,2)+1)` and recombining exponents (`← pow_add`, `omega`, using C(k,2) ≤ C(n,2)) recovers the integer hypothesis of `ramsey_lower_bound`.",
+    "mathContext": "The expected number of monochromatic $k$-cliques is $\\binom{n}{k}\\,2^{1-\\binom{k}{2}}$; the first moment method applies precisely when this is $< 1$. This is the form in which the result is usually stated. Translating between the rational expected-value inequality and the integer counting inequality is the routine but technically fiddly bridge between 'expected value $< 1$' and 'fewer bad objects than total objects'.",
+    "significance": "important",
+    "relatedConcepts": [
+      "zpow_neg",
+      "Nat.cast_sub",
+      "expected value < 1",
+      "Alon–Spencer"
+    ],
+    "prerequisites": [
+      "zpow arithmetic over ℚ",
+      "ℕ truncated subtraction and omega",
+      "casting inequalities"
+    ]
+  },
+  {
+    "id": "ann-pmeoq02-k6-instance",
+    "proofId": "prob-method-expectation-oq-02",
+    "range": {
+      "startLine": 289,
+      "endLine": 294
+    },
+    "type": "theorem",
+    "title": "ramsey_K6_no_mono_K4: A Concrete Non-Vacuous Instance (R(4,4) > 6)",
+    "content": "Instantiates `ramsey_lower_bound` at n = 6, k = 4: the hypothesis `C(6,4)·2^(C(6,2)−C(4,2)+1) = 15·2^(15−6+1) = 15·2^10 = 15360 < 32768 = 2^15 = 2^C(6,2)` is discharged by `decide` (kernel computation, not native_decide — axiom-free). The conclusion is a genuine 2-colouring of K_6 with no monochromatic K_4, witnessing R(4,4) > 6.",
+    "mathContext": "The first nontrivial diagonal Ramsey instance the union bound resolves: $\\binom{6}{4} = 15$ candidate cliques, each fixing $\\binom{4}{2}=6$ of the $\\binom{6}{2}=15$ edges, so $15\\cdot 2^{15-6+1}=15360$ bad colourings out of $2^{15}=32768$. Strict inequality guarantees a good colouring, so $R(4,4)>6$. (The true value is $R(4,4)=18$; the first-moment bound is far from tight but genuinely non-vacuous, unlike the parent statement.)",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide (kernel)",
+      "Ramsey number R(4,4)",
+      "concrete instantiation"
+    ],
+    "prerequisites": [
+      "ramsey_lower_bound",
+      "Nat.choose evaluation"
+    ]
+  }
+]

--- a/src/data/proofs/prob-method-expectation-oq-02/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02/meta.json
@@ -1,0 +1,69 @@
+{
+  "id": "prob-method-expectation-oq-02",
+  "title": "First Moment Method: The Genuine Erdős Ramsey Lower Bound",
+  "slug": "prob-method-expectation-oq-02",
+  "description": "Supplies the real content of Erdős's 1947 first-moment Ramsey bound, which the parent entry only stated vacuously. Via a union-bound counting argument over edge-2-colourings of K_n, proves that C(n,k)·2^(C(n,2)−C(k,2)+1) < 2^C(n,2) implies a 2-colouring with no monochromatic K_k, i.e. R(k,k) > n. Includes the textbook rational form C(n,k)·2^(1−C(k,2)) < 1 and the concrete instance R(4,4) > 6.",
+  "meta": {
+    "author": "Erdős (1947), formalized via first-moment counting",
+    "date": "1947",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodExpectationOQ02.lean",
+    "tags": [
+      "probabilistic-method",
+      "ramsey-theory",
+      "first-moment-method",
+      "union-bound",
+      "combinatorics",
+      "extremal-graph-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-22",
+    "axiomCount": 0,
+    "lineCount": 298,
+    "theoremCount": 6,
+    "definitionCount": 3
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "extends",
+      "description": "Replaces the parent's vacuous statement `∃ n, n ≥ 2^(k/2) ∧ n > 0` (which says nothing about Ramsey numbers) with the genuine first-moment union-bound argument that actually produces a good 2-colouring."
+    },
+    {
+      "targetId": "prob-method-expectation-oq-01",
+      "relationship": "complements",
+      "description": "Sibling open question of the same parent: OQ-01 builds the measure-theoretic first-moment machinery; OQ-02 carries out the discrete counting form on the original Ramsey application."
+    }
+  ],
+  "overview": {
+    "historicalContext": "In 1947 Paul Erdős gave a two-line probabilistic proof that the Ramsey number R(k,k) grows at least exponentially: a random 2-colouring of the edges of K_n has expected number of monochromatic K_k equal to C(n,k)·2^(1−C(k,2)), and when this is below 1 a colouring with no monochromatic K_k must exist. This is widely regarded as the founding application of the probabilistic method. The parent gallery entry `prob-method-expectation` stated an `erdos_ramsey_lower_bound` of the form `∃ n, n ≥ 2^(k/2) ∧ n > 0`, which is vacuously true and proves nothing about colourings or Ramsey numbers. This entry supplies the real content: the union bound over k-sets and the explicit counting of monochromatic colourings.",
+    "problemStatement": "Formalize the genuine first-moment Ramsey lower bound: give a hypothesis on n and k under which a 2-colouring of the edges of K_n with no monochromatic K_k provably exists, and prove it by the counting/union-bound argument (not a vacuous existential). Confirm the textbook expected-value form C(n,k)·2^(1−C(k,2)) < 1 and exhibit a concrete non-vacuous instance.",
+    "proofStrategy": "Model an edge 2-colouring as a function c : Edge n → Bool, where Edge n is the finite type of 2-element subsets of Fin n. (1) Prove the reusable counting engine `card_const_le`: the number of Boolean colourings constant on a nonempty coordinate set I is at most 2^(|ι|−|I|+1) (fix the common value plus the free coordinates, via an injection). (2) Build the edge/clique model: `internal S` (edges inside S) has C(|S|,2) elements, and there are C(n,2) edges total. (3) The headline `ramsey_lower_bound`: the bad colourings (those with some monochromatic k-clique) inject into a biUnion over the C(n,k) k-sets, each block bounded by `card_const_le` at 2^(C(n,2)−C(k,2)+1); summing gives bad.card ≤ C(n,k)·2^(C(n,2)−C(k,2)+1) < 2^C(n,2) = |all colourings|, leaving a good one extracted by `filter_card_add_filter_neg_card_eq_card`. (4) `ramsey_lower_bound_rat`: transport the ℚ hypothesis C(n,k)·2^(1−C(k,2)) < 1 to the integer hypothesis. (5) `ramsey_K6_no_mono_K4`: instantiate at n=6, k=4 (15·2^10 = 15360 < 32768) to get R(4,4) > 6.",
+    "keyInsights": [
+      "The parent entry's `erdos_ramsey_lower_bound : ∃ n, n ≥ 2^(k/2) ∧ n > 0` is vacuously true — it asserts a number exists, not that a good colouring does. The genuine theorem must produce, for the given n and k, an actual colouring c with a witnessed pair of differently-coloured internal edges in every k-set. This entry proves exactly that existential over colourings.",
+      "`card_const_le` is the reusable counting heart of every first-moment argument: a colouring constant on a coordinate set I is pinned down by its single common value together with its values off I, so there are at most 2^(1 + (|ι|−|I|)) of them. The bound is proved by an explicit injection c ↦ (c i₀, c restricted to the complement of I) and `Finset.card_le_card_of_injOn`.",
+      "Monochromatic-on-S is reduced to constant-on-internal-edges: `Mono c S` means all internal edges share a colour, and choosing any base edge e₀ ∈ internal S shows the monochromatic colourings are a subset of those constant relative to e₀ — exactly the hypothesis of `card_const_le` with ι = Edge n, I = internal S (nonempty because C(k,2) ≥ 1 when k ≥ 2).",
+      "The union bound is `Finset.card_biUnion_le` followed by `Finset.sum_le_sum` against the per-clique bound, giving the clean product C(n,k)·2^(C(n,2)−C(k,2)+1). Combined with the total count 2^C(n,2) and the strict hypothesis, the good set `filter (¬ ∃ S, Mono c S)` is forced nonempty by `filter_card_add_filter_neg_card_eq_card` and `omega`.",
+      "The rational form is the bridge to the textbook statement. The negative ℤ exponent in 2^(1−C(k,2)) is collapsed to ℕ by rewriting 1−C(k,2) = −(C(k,2)−1) (valid since C(k,2) ≥ 1) and using `zpow_neg`/`zpow_natCast`, turning the hypothesis into C(n,k) < 2^(C(k,2)−1); multiplying by 2^(C(n,2)−C(k,2)+1) and recombining exponents with `omega` recovers the integer hypothesis."
+    ]
+  },
+  "conclusion": {
+    "summary": "This 295-line fully verified (0 sorries, 0 axioms, no native_decide) file gives the genuine Erdős 1947 first-moment Ramsey lower bound, replacing the parent entry's vacuous existential. The headline `ramsey_lower_bound` proves that C(n,k)·2^(C(n,2)−C(k,2)+1) < 2^C(n,2) forces a 2-colouring of K_n with no monochromatic K_k; the rational form `ramsey_lower_bound_rat` matches the textbook expected-value criterion C(n,k)·2^(1−C(k,2)) < 1; and `ramsey_K6_no_mono_K4` exhibits the concrete instance R(4,4) > 6. The reusable engine `card_const_le` isolates the counting bound common to all first-moment arguments.",
+    "implications": "The union-bound counting form proved here is the discrete backbone of the probabilistic method as it actually appears in Erdős's original argument and in Alon–Spencer Chapter 1. Having `card_const_le` and the Edge/clique model in the gallery enables further first-moment results (e.g. lower bounds for off-diagonal Ramsey numbers R(s,t), or hypergraph/property-B style bounds) to be formalized by changing only the per-event count, without re-deriving the union-bound scaffolding.",
+    "openQuestions": [
+      "Can the symmetric closed-form threshold be derived: that C(n,k)·2^(1−C(k,2)) < 1 holds whenever n ≤ 2^(k/2) (for k ≥ 3), recovering the clean statement R(k,k) > 2^(k/2)? This requires bounding C(n,k) ≤ n^k/k! and comparing exponents.",
+      "Can the argument be extended to off-diagonal Ramsey numbers R(s,t) by counting monochromatic K_s in one colour and K_t in the other, giving the asymmetric first-moment bound?",
+      "Can `card_const_le` be sharpened to an exact count (2^(|ι|−|I|+1) when I is nonempty, 2^|ι| when empty) and reused to compute the exact expected number of monochromatic k-cliques rather than just the upper bound?"
+    ]
+  },
+  "leanFile": {
+    "axiomCount": 0,
+    "lineCount": 298,
+    "path": "Proofs/ProbMethodExpectationOQ02.lean",
+    "sorries": 0,
+    "definitionCount": 3,
+    "theoremCount": 6
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies the **real mathematical content** of Erdős's 1947 first-moment Ramsey lower bound. The parent gallery entry `prob-method-expectation` stated `erdos_ramsey_lower_bound : ∃ n, n ≥ 2^(k/2) ∧ n > 0` — *vacuously true*, asserting only that a number exists, nothing about colourings or Ramsey numbers. This entry proves the genuine union-bound counting theorem.

## Results (`proofs/Proofs/ProbMethodExpectationOQ02.lean`, 298L, 6 thm / 3 def)

- **`ramsey_lower_bound`** (headline): if `C(n,k)·2^(C(n,2)−C(k,2)+1) < 2^C(n,2)` then there is a 2-colouring of the edges of `K_n` with **no** monochromatic `K_k` — equivalently `R(k,k) > n`. Proof: the bad colourings inject into a `biUnion` over the `C(n,k)` `k`-sets; each block is bounded by `card_const_le`; summing beats the total `2^C(n,2)`, leaving a good colouring.
- **`card_const_le`** (reusable engine): the number of Boolean colourings constant on a nonempty coordinate set `I` is `≤ 2^(|ι|−|I|+1)`, via an explicit injection `c ↦ (c i₀, c restricted off I)`. This is the counting heart of every first-moment argument and is type-generic.
- **`ramsey_lower_bound_rat`**: the textbook Alon–Spencer form with the hypothesis `C(n,k)·2^(1−C(k,2)) < 1` stated over `ℚ` (negative ℤ exponent collapsed to ℕ).
- **`ramsey_K6_no_mono_K4`**: concrete non-vacuous instance `R(4,4) > 6` (`15·2^10 = 15360 < 32768 = 2^15`), discharged by kernel `decide`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all three main theorems.
- **No `native_decide`** — the `K6` instance uses kernel `decide`, so no `Lean.ofReduceBool`.
- Compiled against Mathlib (toolchain `v4.26.0`); Docker build wrapper unavailable this session, verified by single-file compile against the prebuilt Mathlib oleans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)