### PR TITLE
research(erdos-1000-oq-03): Jordan's totient J_k — axiom-free generalization of Euler's φ [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -910,6 +910,7 @@ import Proofs.ElementaryQuadraticReciprocityOQ03OQ02OQ03
 import Proofs.ElementaryQuadraticReciprocityOQ03OQ03
 import Proofs.Erdos1000OQ01
 import Proofs.Erdos1000OQ01Aristotle
+import Proofs.Erdos1000OQ03
 import Proofs.Erdos1000Problem
 import Proofs.Erdos1001OQ02
 import Proofs.Erdos1001OQ02OQ01

--- a/proofs/Proofs/Erdos1000OQ03.lean
+++ b/proofs/Proofs/Erdos1000OQ03.lean
@@ -1,0 +1,170 @@
+import Mathlib.NumberTheory.ArithmeticFunction.Moebius
+import Mathlib.NumberTheory.ArithmeticFunction.Misc
+import Mathlib.NumberTheory.Divisors
+import Mathlib.Data.Nat.Totient
+import Mathlib.Tactic
+
+/-!
+# Jordan's totient `J_k`: an elementary, axiom-free generalization of Euler's `φ`
+
+**Open question (`erdos-1000-oq-03`)**: *does the divisor-sum / multiplicativity
+theory of Euler's totient extend to other generalized totients?*
+
+The canonical generalization is **Jordan's totient** `J_k(n) = n^k ∏_{p∣n}(1 - p^{-k})`,
+introduced by Camille Jordan (1870), which counts the `k`-tuples in `(ℤ/n)^k` whose
+coordinates together with `n` are setwise coprime.  It satisfies `J_1 = φ` and the
+fundamental divisor-sum identity
+
+$$\sum_{d \mid n} J_k(d) = n^k,$$
+
+the exact generalization of Gauss's `∑_{d∣n} φ(d) = n` (`Nat.sum_totient`).
+
+## What this file proves (0 axioms, 0 sorries)
+
+Rather than the combinatorial counting definition, we take the **Dirichlet
+convolution** definition `J_k = μ * pow k` (Möbius times the `k`-th power
+function) inside Mathlib's `ArithmeticFunction ℤ` ring.  This makes the deep
+identities fall out of the ring structure (`μ * ζ = 1`):
+
+* `jordan_mul_zeta`   : `J_k * ζ = pow k`  (the defining Dirichlet relation)
+* `jordan_divisor_sum`: `∑_{d∣n} J_k(d) = n^k`  — **headline**, generalizes `Nat.sum_totient`
+* `jordan_one`        : `J_k(1) = 1`
+* `jordan_isMultiplicative` : `J_k` is multiplicative
+* `jordan_prime_pow`  : `J_k(p^a) = p^{ka} - p^{k(a-1)}`  (prime powers; telescoping)
+* `jordan_eq_prod`    : `J_k(n) = ∏_{p^a ∥ n} (p^{ka} - p^{k(a-1)})`  (the integer product formula)
+* `jordan_one_eq_totient` : `J_1(n) = φ(n)`  (recovers Euler's totient)
+* `jordan_nonneg`, `jordan_le_pow` : `0 ≤ J_k(n) ≤ n^k`
+
+## Significance relative to the gallery
+
+The gallery entry `erdos-1001-oq-03` (a deep analytic density problem) **axiomatizes**
+Jordan's totient via `axiom jordan_one : jordanTotient 1 q = φ q` and
+`axiom jordan_le_pow : jordanTotient d q ≤ q^d`.  Both are *proved* here from an
+honest definition, so the elementary core of that entry is no longer axiomatic.
+The entry `euler-totient-oq-02-oq-01` explicitly poses, as an open question, whether
+the product formula for `φ` generalizes to `J_k`; `jordan_eq_prod` answers it in the
+integer-product form.
+-/
+
+namespace Erdos1000OQ03
+
+open ArithmeticFunction Finset
+open scoped ArithmeticFunction.Moebius ArithmeticFunction.zeta
+
+/-- **Jordan's totient** of order `k`, defined as the Dirichlet convolution
+`μ * pow k` inside the ring of integer arithmetic functions.  For `k = 1` this is
+Euler's `φ` (see `jordan_one_eq_totient`); the value at `n` is
+`∑_{d∣n} μ(d)·(n/d)^k = n^k ∏_{p∣n}(1 - p^{-k})`. -/
+noncomputable def jordanTotient (k : ℕ) : ArithmeticFunction ℤ :=
+  ArithmeticFunction.moebius * (↑(ArithmeticFunction.pow k) : ArithmeticFunction ℤ)
+
+/-- The defining Dirichlet relation: `J_k * ζ = pow k`.  This is the arithmetic-function
+form of the divisor-sum identity, obtained from `μ * ζ = 1`. -/
+theorem jordan_mul_zeta (k : ℕ) :
+    jordanTotient k * ζ = (↑(ArithmeticFunction.pow k) : ArithmeticFunction ℤ) := by
+  have h : jordanTotient k * ζ
+      = (↑(ArithmeticFunction.pow k) : ArithmeticFunction ℤ) * (μ * ζ) := by
+    rw [jordanTotient]; ring
+  rw [h, moebius_mul_coe_zeta, mul_one]
+
+/-- **Headline.** The Jordan totients of the divisors of `n` sum to `n^k`:
+`∑_{d∣n} J_k(d) = n^k`.  For `k = 1` this is Gauss's `∑_{d∣n} φ(d) = n`. -/
+theorem jordan_divisor_sum (k : ℕ) {n : ℕ} (hn : 0 < n) :
+    ∑ d ∈ n.divisors, jordanTotient k d = (n : ℤ) ^ k := by
+  have h := coe_mul_zeta_apply (f := jordanTotient k) (x := n)
+  rw [jordan_mul_zeta] at h
+  rw [natCoe_apply, pow_apply, if_neg (by rintro ⟨-, h0⟩; omega)] at h
+  rw [← h]
+  push_cast
+  ring
+
+/-- `J_k(1) = 1`. -/
+theorem jordan_one (k : ℕ) : jordanTotient k 1 = 1 := by
+  have h := jordan_divisor_sum k (n := 1) one_pos
+  simpa using h
+
+/-- `J_k` is multiplicative (a Dirichlet convolution of multiplicative functions). -/
+theorem jordan_isMultiplicative (k : ℕ) : (jordanTotient k).IsMultiplicative := by
+  rw [jordanTotient]
+  exact isMultiplicative_moebius.mul isMultiplicative_pow.natCast
+
+/-- **Prime-power values.** For a prime `p` and `a ≥ 1`,
+`J_k(p^a) = p^{ka} - p^{k(a-1)}`.  Proved by telescoping the divisor-sum identity
+across `p^a` and `p^{a-1}`. -/
+theorem jordan_prime_pow (k : ℕ) {p : ℕ} (hp : p.Prime) {a : ℕ} (ha : 1 ≤ a) :
+    jordanTotient k (p ^ a) = (p : ℤ) ^ (k * a) - (p : ℤ) ^ (k * (a - 1)) := by
+  have hsum : ∀ m : ℕ,
+      ∑ i ∈ range (m + 1), jordanTotient k (p ^ i) = (p : ℤ) ^ (k * m) := by
+    intro m
+    have hpm : 0 < p ^ m := pow_pos hp.pos m
+    have hd := jordan_divisor_sum k (n := p ^ m) hpm
+    rw [Nat.sum_divisors_prime_pow hp] at hd
+    rw [hd]
+    push_cast
+    rw [← pow_mul, mul_comm m k]
+  have h1 := hsum a
+  have h2 := hsum (a - 1)
+  rw [sum_range_succ] at h1
+  rw [Nat.sub_add_cancel ha] at h2
+  rw [h2] at h1
+  linarith
+
+/-- **Integer product formula** (answers `euler-totient-oq-02-oq-01`):
+`J_k(n) = ∏_{p^a ∥ n} (p^{ka} - p^{k(a-1)})`, the generalization of Euler's product. -/
+theorem jordan_eq_prod (k : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    jordanTotient k n
+      = n.factorization.prod fun p a => (p : ℤ) ^ (k * a) - (p : ℤ) ^ (k * (a - 1)) := by
+  rw [ArithmeticFunction.IsMultiplicative.multiplicative_factorization
+        (jordanTotient k) (jordan_isMultiplicative k) hn]
+  apply Finsupp.prod_congr
+  intro p hp
+  have ha : 1 ≤ n.factorization p :=
+    Nat.one_le_iff_ne_zero.mpr (Finsupp.mem_support_iff.mp hp)
+  rw [Nat.support_factorization] at hp
+  exact jordan_prime_pow k (Nat.prime_of_mem_primeFactors hp) ha
+
+/-- `J_1 = φ`: Jordan's totient of order one is Euler's totient.  This de-axiomatizes
+`axiom jordan_one` in the gallery entry `erdos-1001-oq-03`. -/
+theorem jordan_one_eq_totient {n : ℕ} (hn : 0 < n) :
+    jordanTotient 1 n = (Nat.totient n : ℤ) := by
+  have h : ∀ m : ℕ, 0 < m → ∑ i ∈ m.divisors, (Nat.totient i : ℤ) = (m : ℤ) := by
+    intro m _
+    rw [← Nat.cast_sum]
+    exact_mod_cast Nat.sum_totient m
+  have key := (sum_eq_iff_sum_mul_moebius_eq (R := ℤ)
+      (f := fun i => (Nat.totient i : ℤ)) (g := fun m => (m : ℤ))).mp h n hn
+  rw [jordanTotient, mul_apply, ← key]
+  apply Finset.sum_congr rfl
+  intro x hx
+  have hsnd : (↑(ArithmeticFunction.pow 1) : ArithmeticFunction ℤ) x.snd = (x.snd : ℤ) := by
+    rw [natCoe_apply, pow_apply, if_neg (by rintro ⟨h1, -⟩; exact one_ne_zero h1), pow_one]
+  rw [hsnd]
+  push_cast
+  ring
+
+/-- `0 ≤ J_k(n)`. -/
+theorem jordan_nonneg (k n : ℕ) : 0 ≤ jordanTotient k n := by
+  rcases eq_or_ne n 0 with rfl | hn
+  · simp [jordanTotient]
+  · rw [jordan_eq_prod k hn, Finsupp.prod]
+    apply Finset.prod_nonneg
+    intro p hp
+    have ha : 1 ≤ n.factorization p :=
+      Nat.one_le_iff_ne_zero.mpr (Finsupp.mem_support_iff.mp hp)
+    rw [Nat.support_factorization] at hp
+    have hpp : p.Prime := Nat.prime_of_mem_primeFactors hp
+    have h1 : (1 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hpp.one_lt.le
+    have hexp : k * (n.factorization p - 1) ≤ k * n.factorization p :=
+      Nat.mul_le_mul_left k (by omega)
+    have := pow_le_pow_right₀ h1 hexp
+    linarith
+
+/-- `J_k(n) ≤ n^k`: the divisor-sum identity bounds `J_k` by the top term.  This
+de-axiomatizes `axiom jordan_le_pow` in the gallery entry `erdos-1001-oq-03`. -/
+theorem jordan_le_pow (k : ℕ) {n : ℕ} (hn : 0 < n) :
+    jordanTotient k n ≤ (n : ℤ) ^ k := by
+  rw [← jordan_divisor_sum k hn]
+  exact Finset.single_le_sum (fun d _ => jordan_nonneg k d)
+    (Nat.mem_divisors_self n hn.ne')
+
+end Erdos1000OQ03

--- a/src/data/proofs/erdos-1000-oq-03/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03/meta.json
@@ -1,0 +1,86 @@
+{
+  "id": "erdos-1000-oq-03",
+  "title": "Jordan's Totient J_k: an Axiom-Free Generalization of Euler's φ",
+  "slug": "erdos-1000-oq-03",
+  "description": "A fully verified, axiom-free development of Jordan's totient J_k(n) = n^k ∏_{p∣n}(1 − p^{−k}), the canonical generalization of Euler's φ, answering the open question of whether the divisor-sum / multiplicativity theory of φ extends to other generalized totients. Rather than the combinatorial counting definition, J_k is taken as the Dirichlet convolution μ * pow k inside Mathlib's ring of integer arithmetic functions, so the deep identities fall out of the ring structure μ * ζ = 1. The headline is the exact generalization of Gauss's divisor-sum formula, ∑_{d∣n} J_k(d) = n^k, together with multiplicativity, the prime-power values J_k(p^a) = p^{ka} − p^{k(a−1)}, the integer product formula J_k(n) = ∏_{p^a ∥ n}(p^{ka} − p^{k(a−1)}), the recovery J_1 = φ, and the bounds 0 ≤ J_k(n) ≤ n^k. The product formula answers, in integer-product form, the open question posed by the gallery entry euler-totient-oq-02-oq-01; the J_1 = φ identity and the upper bound give honest proofs of the two elementary facts that the gallery entry erdos-1001-oq-03 takes as axioms.",
+  "meta": {
+    "author": "Camille Jordan (1870); formalization original to Lean Genius",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1000OQ03.lean",
+    "tags": [
+      "number-theory",
+      "arithmetic-functions",
+      "jordan-totient",
+      "euler-totient",
+      "dirichlet-convolution",
+      "multiplicative-functions",
+      "divisor-sums"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-23",
+    "lineCount": 170,
+    "originalContributions": [
+      "jordanTotient k := μ * pow k: Jordan's totient of order k as a Dirichlet convolution in the ring ArithmeticFunction ℤ, sidestepping the combinatorial counting definition",
+      "jordan_mul_zeta: the defining Dirichlet relation J_k * ζ = pow k, obtained directly from μ * ζ = 1",
+      "jordan_divisor_sum: the headline identity ∑_{d∣n} J_k(d) = n^k, the exact generalization of Gauss's ∑_{d∣n} φ(d) = n (Nat.sum_totient)",
+      "jordan_isMultiplicative: J_k is multiplicative (convolution of multiplicative functions)",
+      "jordan_prime_pow: prime-power values J_k(p^a) = p^{ka} − p^{k(a−1)}, proved by telescoping the divisor-sum identity",
+      "jordan_eq_prod: the integer product formula J_k(n) = ∏_{p^a ∥ n}(p^{ka} − p^{k(a−1)}), answering euler-totient-oq-02-oq-01 in integer-product form",
+      "jordan_one_eq_totient: J_1 = φ, recovering Euler's totient (an honest proof of axiom jordan_one in erdos-1001-oq-03)",
+      "jordan_nonneg / jordan_le_pow: the bounds 0 ≤ J_k(n) ≤ n^k (an honest proof of axiom jordan_le_pow in erdos-1001-oq-03)"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations. #print axioms on the main theorems (jordan_divisor_sum, jordan_eq_prod, jordan_one_eq_totient, jordan_le_pow, jordan_prime_pow, jordan_isMultiplicative) reports only the foundational propext / Classical.choice / Quot.sound; there is no native_decide, hence no Lean.ofReduceBool, and no sorryAx. The development is self-contained over Mathlib's ArithmeticFunction library and does not import erdos-1001-oq-03 (whose deeper analytic axiom jordan_mertens is outside this entry's scope and is not addressed here).",
+    "theoremCount": 9,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1001-oq-03",
+      "relationship": "strengthens",
+      "description": "That entry studies a deep analytic density problem and takes the elementary facts J_1 = φ (axiom jordan_one) and J_k(n) ≤ n^k (axiom jordan_le_pow) as axioms over a separate Jordan-totient definition. This entry gives honest, self-contained proofs of both statements (jordan_one_eq_totient, jordan_le_pow) from the Dirichlet-convolution definition, so their elementary core is no longer axiomatic. The deeper Mertens-type axiom jordan_mertens of that entry is not addressed here."
+    },
+    {
+      "targetId": "euler-totient-oq-02-oq-01",
+      "relationship": "answers",
+      "description": "That entry explicitly poses, as an open question, whether the product formula for φ generalizes to the Jordan totient J_k(n) = n^k ∏_{p∣n}(1 − 1/p^k). The theorem jordan_eq_prod answers it in integer-product form: J_k(n) = ∏_{p^a ∥ n}(p^{ka} − p^{k(a−1)})."
+    },
+    {
+      "targetId": "erdos-1000",
+      "relationship": "extends",
+      "description": "The parent Erdős #1000 concerns generalized totients and Diophantine approximation. This entry answers the open question oq-03 — whether the divisor-sum and multiplicativity theory of Euler's φ extends to other generalized totients — affirmatively for the canonical generalization, Jordan's totient."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Camille Jordan introduced J_k in 1870 as the function counting the k-tuples in (ℤ/n)^k whose coordinates together with n are setwise coprime; J_1 is Euler's φ. Jordan's totient satisfies the same structural laws as φ — multiplicativity, a Möbius-inversion product formula, and the divisor-sum identity ∑_{d∣n} J_k(d) = n^k generalizing Gauss's ∑_{d∣n} φ(d) = n. It is the textbook answer to the question of which features of Euler's totient survive in a wider family of generalized totients.",
+    "problemStatement": "Does the divisor-sum / multiplicativity theory of Euler's totient φ extend to other generalized totients? Formalize the canonical generalization, Jordan's totient J_k, and establish the analogues of Gauss's divisor-sum identity, multiplicativity, the prime-power values, and the Euler product formula — all axiom-free.",
+    "proofStrategy": "Define J_k = μ * pow k as a Dirichlet convolution in Mathlib's ring ArithmeticFunction ℤ. The defining relation J_k * ζ = pow k follows from μ * ζ = 1 by ring manipulation; applying it pointwise and unfolding the convolution-with-ζ gives the divisor-sum identity ∑_{d∣n} J_k(d) = n^k. Multiplicativity is inherited because μ and pow k are multiplicative. The prime-power values come from telescoping the divisor-sum identity across p^a and p^{a−1}; the product formula then follows from multiplicativity via the factorization of n. J_1 = φ is obtained by Möbius inversion of Gauss's φ divisor-sum identity, and the bounds 0 ≤ J_k(n) ≤ n^k from the product formula and the divisor-sum identity respectively.",
+    "keyInsights": [
+      "Taking J_k as the Dirichlet convolution μ * pow k rather than a counting function turns the deep identities into algebra: the entire theory is downstream of the single ring fact μ * ζ = 1 in ArithmeticFunction ℤ.",
+      "The headline ∑_{d∣n} J_k(d) = n^k is literally the convolution relation J_k * ζ = pow k read pointwise; for k = 1 it is Gauss's ∑_{d∣n} φ(d) = n, so the generalization is structural, not coincidental.",
+      "Prime-power values J_k(p^a) = p^{ka} − p^{k(a−1)} fall out by telescoping the divisor-sum identity at p^a against p^{a−1}; this is the only genuinely arithmetic step and it feeds both the product formula and the positivity bound.",
+      "Multiplicativity plus the prime-power values give the Euler product formula J_k(n) = ∏_{p^a ∥ n}(p^{ka} − p^{k(a−1)}) in honest integer form — answering the open question of whether φ's product formula generalizes to J_k.",
+      "Recovering J_1 = φ via Möbius inversion certifies that the convolution definition is the right one, and simultaneously discharges, with an honest proof, an axiom that a downstream gallery entry had assumed."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (170 lines, 9 theorems, 1 definition) of Jordan's totient J_k as the Dirichlet convolution μ * pow k. It establishes the full elementary theory — the divisor-sum identity ∑_{d∣n} J_k(d) = n^k, multiplicativity, prime-power values, the Euler product formula, the recovery J_1 = φ, and the bounds 0 ≤ J_k(n) ≤ n^k — answering affirmatively whether the divisor-sum / multiplicativity theory of Euler's φ extends to other generalized totients.",
+    "implications": "The development de-axiomatizes the elementary core (J_1 = φ and J_k(n) ≤ n^k) of the downstream entry erdos-1001-oq-03 and answers, in integer-product form, the open question of euler-totient-oq-02-oq-01 on generalizing φ's product formula. By routing everything through the convolution identity μ * ζ = 1, it isolates the single arithmetic step (the prime-power telescoping) on which the whole theory rests, and provides reusable, axiom-free infrastructure for any future entry needing J_k.",
+    "openQuestions": [
+      "Formalize the combinatorial counting characterization J_k(n) = #{ x ∈ (ℤ/n)^k : gcd(x_1, …, x_k, n) = 1 } and prove it equals the convolution definition, giving the original number-theoretic meaning of J_k.",
+      "Establish the Dirichlet-series / zeta-function identity ∑_n J_k(n) n^{−s} = ζ(s−k)/ζ(s), the analytic counterpart of the divisor-sum relation, and the associated average order of J_k.",
+      "Discharge the remaining Mertens-type axiom jordan_mertens of erdos-1001-oq-03 by proving the J_k-analogue of Mertens' theorem from the elementary product formula established here."
+    ]
+  },
+  "leanFile": {
+    "lineCount": 170,
+    "axiomCount": 0,
+    "path": "Proofs/Erdos1000OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 9
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **erdos-1000-oq-03** — *does the divisor-sum / multiplicativity theory of Euler's φ extend to other generalized totients?* — affirmatively for the canonical generalization, **Jordan's totient** `J_k(n) = n^k ∏_{p∣n}(1 − p^{−k})`.

The key design choice is to define `J_k` as the **Dirichlet convolution** `μ * pow k` inside Mathlib's ring `ArithmeticFunction ℤ`, so the deep identities fall out of the single ring fact `μ * ζ = 1`.

## What is proved (`proofs/Proofs/Erdos1000OQ03.lean`, 170 lines, 9 theorems, 1 def, **0 axioms, 0 sorries**)

- `jordan_mul_zeta` — the defining relation `J_k * ζ = pow k`
- `jordan_divisor_sum` — **headline**: `∑_{d∣n} J_k(d) = n^k`, the exact generalization of Gauss's `∑_{d∣n} φ(d) = n` (`Nat.sum_totient`)
- `jordan_isMultiplicative` — `J_k` is multiplicative
- `jordan_prime_pow` — `J_k(p^a) = p^{ka} − p^{k(a−1)}` (telescoping)
- `jordan_eq_prod` — Euler product formula `J_k(n) = ∏_{p^a ∥ n}(p^{ka} − p^{k(a−1)})`
- `jordan_one_eq_totient` — `J_1 = φ`
- `jordan_nonneg`, `jordan_le_pow` — `0 ≤ J_k(n) ≤ n^k`

## Significance

- **Answers** `euler-totient-oq-02-oq-01`, which explicitly poses generalizing φ's product formula to `J_k` — `jordan_eq_prod` does so in integer-product form.
- **De-axiomatizes the elementary core** of `erdos-1001-oq-03`: that entry takes `J_1 = φ` (`axiom jordan_one`) and `J_k(n) ≤ n^k` (`axiom jordan_le_pow`) as axioms; both get honest, self-contained proofs here. (That entry's deeper Mertens-type `jordan_mertens` axiom is out of scope and is **not** claimed.)

## Verification

`#print axioms` on all main theorems reports only `propext, Classical.choice, Quot.sound` — the standard foundational axioms. No `native_decide`, so **no `Lean.ofReduceBool`**; no `sorryAx`. Compiled standalone against Mathlib oleans with `lean v4.26.0` (Docker build wrapper unavailable this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)