### PR TITLE
Enrich: Multiplier–QR Reduction for Three-Square Sufficiency

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-oq07-background",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 3, "endLine": 66 },
+    "type": "context",
+    "title": "The multiplier mechanism of the Dirichlet/Minkowski route",
+    "content": "The file opens with a careful account of why three-square sufficiency (n ≠ 4^a(8b+7) ⟹ n = x²+y²+z²) is hard for the residue classes n mod 8 ∈ {1,2,5,6}. The geometry-of-numbers step ThreeSquares.dirichlet_key_lemma consumes a multiplier d ≥ 1, a prime p = d·n − 1, and a quadratic-residue condition legendreSym p (−d) = 1; from these it extracts a short lattice vector descending to a representation of n. The apparent obstruction is that d must grow unboundedly for these classes, so the Dirichlet selection looks like it must control a moving target. This file dissolves that appearance.",
+    "mathContext": "$n = x^2+y^2+z^2 \\iff n \\neq 4^a(8b+7)$, with the sublattice $L=\\{(x,y,z): p\\mid x-ry,\\ p\\mid z\\}$ and prime $p = d\\cdot n - 1$.",
+    "significance": "context",
+    "relatedConcepts": ["geometry of numbers", "Minkowski's theorem", "three-square theorem", "quadratic residues", "lattice reduction"],
+    "prerequisites": ["additive number theory", "geometry of numbers", "Legendre symbol"]
+  },
+  {
+    "id": "ann-oq07-natcast-mul",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 70, "endLine": 78 },
+    "type": "technique",
+    "title": "The key residue identity d·n ≡ 1 (mod p)",
+    "content": "The whole reduction rests on one elementary congruence. Encoding p = d·n − 1 as the ℕ-equation d·n = p + 1 and casting into ZMod p, the term p vanishes (ZMod.natCast_self) and 1 survives, giving (d : ZMod p)·(n : ZMod p) = 1. Working with d·n = p + 1 rather than a subtraction keeps everything in ℕ and avoids truncated-subtraction pitfalls. This single line is what makes −d and −n mutually inverse mod p downstream.",
+    "mathContext": "$d\\cdot n = p+1 \\implies d\\cdot n \\equiv 1 \\pmod p$, i.e. $(\\bar d)(\\bar n) = 1$ in $\\mathbb{Z}/p\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["modular arithmetic", "ZMod", "ring homomorphism", "casting"],
+    "prerequisites": ["modular arithmetic", "ring theory"]
+  },
+  {
+    "id": "ann-oq07-multiplier-reduction",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 80, "endLine": 110 },
+    "type": "insight",
+    "title": "Multiplier–QR reduction: legendreSym p (−d) = legendreSym p (−n)",
+    "content": "The headline theorem. Because (−d)·(−n) = d·n ≡ 1 (mod p), the product −d · −n is the unit 1, which is a square; hence its Legendre symbol is 1. By multiplicativity legendreSym p (−d) · legendreSym p (−n) = 1, and since each factor is ±1 (legendreSym.eq_one_or_neg_one, valid because both arguments are nonzero mod p), a product equal to 1 forces the two symbols to be equal. Crucially this is reciprocity-free — it uses only multiplicativity, the square-characterisation legendreSym.eq_one_iff, and the ±1 dichotomy. The unbounded multiplier d is thereby eliminated from the residue bookkeeping: the QR condition becomes a condition on −n alone.",
+    "mathContext": "$(-d)(-n) = dn \\equiv 1 \\pmod p$, so $\\left(\\tfrac{-d}{p}\\right)\\left(\\tfrac{-n}{p}\\right)=1$ with each factor $\\pm 1 \\implies \\left(\\tfrac{-d}{p}\\right)=\\left(\\tfrac{-n}{p}\\right)$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre symbol", "multiplicativity", "quadratic residues", "units modulo p", "Euler's criterion"],
+    "prerequisites": ["Legendre symbol", "quadratic residues", "finite fields"]
+  },
+  {
+    "id": "ann-oq07-selection-criterion",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 112, "endLine": 124 },
+    "type": "concept",
+    "title": "Selection criterion: the QR hypothesis depends only on n",
+    "content": "Two corollaries package the reduction for downstream use. legendreSym_neg_d_eq_one_iff rewrites the equality into a biconditional: legendreSym p (−d) = 1 ⟺ legendreSym p (−n) = 1. legendreSym_neg_n_one_imp_neg_d_one extracts the single direction actually consumed by dirichlet_key_lemma — that legendreSym p (−n) = 1 forces the geometry's hypothesis legendreSym p (−d) = 1. The point is that legendreSym p (−n) = 1 is governed entirely by p mod 4n (via reciprocity for the Jacobi symbol), an honestly fixed congruence target, whereas legendreSym p (−d) appeared to depend on the moving multiplier.",
+    "mathContext": "$\\left(\\tfrac{-d}{p}\\right)=1 \\iff \\left(\\tfrac{-n}{p}\\right)=1$, the latter determined by $p \\bmod 4n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quadratic reciprocity", "Jacobi symbol", "congruence conditions", "biconditional"],
+    "prerequisites": ["quadratic reciprocity", "Legendre symbol"]
+  },
+  {
+    "id": "ann-oq07-coprime-pred",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 126, "endLine": 129 },
+    "type": "technique",
+    "title": "Coprimality of consecutive integers (n−1, n)",
+    "content": "A small helper feeding Dirichlet's hypothesis: gcd(n−1, n) = 1 for n ≥ 1, since consecutive integers share no common factor. It is proved by Nat.coprime_self_sub_left reducing gcd(n−1, n) to gcd(1, n), then Nat.coprime_one_left. This coprimality is exactly what licenses choosing the residue class p ≡ n − 1 ≡ −1 (mod n) in Dirichlet's theorem.",
+    "mathContext": "$\\gcd(n-1, n) = 1$ for all $n \\geq 1$.",
+    "significance": "technical",
+    "relatedConcepts": ["coprimality", "Euclidean algorithm", "consecutive integers"],
+    "prerequisites": ["elementary number theory"]
+  },
+  {
+    "id": "ann-oq07-dirichlet-supply",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 131, "endLine": 156 },
+    "type": "technique",
+    "title": "Dirichlet supply of multiplier primes p ≡ −1 (mod n)",
+    "content": "For every n ≥ 2 and bound N there is a prime p > N of multiplier shape p = d·n − 1. The prime is produced by Mathlib's recently-added Dirichlet theorem Nat.forall_exists_prime_gt_and_modEq in the class p ≡ n − 1 (mod n), legitimate by the coprimality above. The proof then pins p % n = n − 1 (via Nat.mod_eq_of_lt) and — to keep divisibility inside omega's linear fragment — repackages the quotient p / n as a fresh existential variable q with n·q + (n−1) = p, so the multiplier is d := q + 1. This sidesteps omega's inability to reason about p / n for a symbolic divisor n.",
+    "mathContext": "$\\forall n\\geq 2,\\ \\forall N,\\ \\exists\\, p > N$ prime with $p \\equiv -1 \\pmod n$, i.e. $p = d\\cdot n - 1$, $d\\geq 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet's theorem", "primes in arithmetic progressions", "L-functions", "omega decision procedure"],
+    "prerequisites": ["analytic number theory", "Dirichlet's theorem on primes in AP"]
+  },
+  {
+    "id": "ann-oq07-assembled",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-07",
+    "range": { "startLine": 158, "endLine": 169 },
+    "type": "insight",
+    "title": "Assembled selection layer: a d-free fixed-target problem",
+    "content": "The capstone combines supply and reduction: for every n ≥ 2 and bound N there is a multiplier prime p > N for which legendreSym p (−n) = 1 already forces the geometry's hypothesis legendreSym p (−d) = 1. This is precisely the number-theoretic input the unbounded-multiplier classes need, now stated with d entirely absent from the residue side condition. The Fact p.Prime instance is threaded through as the standard hook required by legendreSym. Honest scope: this does not by itself discharge sufficiency — the companion geometry dirichlet_key_lemma is established only for d ∈ {1,2}; the residual gap is purely geometric (a d-uniform descent), as recorded in the open questions.",
+    "mathContext": "$\\exists\\, p>N$ prime, $p = d\\cdot n-1$, with $\\left(\\tfrac{-n}{p}\\right)=1 \\implies \\left(\\tfrac{-d}{p}\\right)=1$.",
+    "significance": "key",
+    "relatedConcepts": ["three-square theorem", "geometry of numbers", "Dirichlet's theorem", "ternary quadratic forms"],
+    "prerequisites": ["geometry of numbers", "quadratic forms", "Legendre symbol"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/meta.json
@@ -15,6 +15,63 @@
     "sorries": 0
   },
   "title": "The Multiplier–Quadratic-Residue Reduction for Three-Square Sufficiency",
+  "description": "In the classical Dirichlet/Minkowski route to Legendre's three-square theorem, the geometry-of-numbers step needs a multiplier d, a prime p = d·n − 1, and a quadratic-residue condition legendreSym p (−d) = 1. This entry proves that condition collapses to a condition on n alone: since d·n ≡ 1 (mod p), the values −d and −n are inverse mod p and hence simultaneously (non)squares, so legendreSym p (−d) = legendreSym p (−n). A reciprocity-free identity that eliminates the unbounded multiplier from the residue bookkeeping, plus a Dirichlet supply of such primes — 171 lines, 7 theorems, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Legendre stated the three-square theorem in his Essai sur la théorie des nombres (1798): a natural number n is a sum of three integer squares iff n is not of the form 4^a(8b+7). The necessity direction is an elementary mod-8 congruence argument, but sufficiency is genuinely deep. Gauss gave the first complete proof in Disquisitiones Arithmeticae (1801) via his theory of ternary quadratic forms and class numbers. Dirichlet (1850) supplied a cleaner route built on his own 1837 theorem on primes in arithmetic progressions: one selects an auxiliary prime in a prescribed residue class and runs a quadratic-form / geometry-of-numbers descent. Minkowski's geometry of numbers (1890s) later recast that descent as the existence of a short vector in a lattice cut out by congruence conditions. The friction in formalizing this route is the 'multiplier' d in the auxiliary prime p = d·n − 1: for the residue classes n mod 8 ∈ {1,2,5,6} no bounded d works, so the quadratic-residue side condition appears to track a moving target. This entry isolates and dissolves exactly that friction, leveraging the fact that Dirichlet's theorem is now available in Mathlib (Nat.forall_exists_prime_gt_and_modEq).",
+    "problemStatement": "Show that the quadratic-residue hypothesis $\\left(\\tfrac{-d}{p}\\right)=1$ consumed by the geometry-of-numbers lemma — for a multiplier prime $p = d\\cdot n - 1$ — is equivalent to the multiplier-free condition $\\left(\\tfrac{-n}{p}\\right)=1$, and that arbitrarily large primes of this multiplier shape exist for every $n \\geq 2$.",
+    "proofStrategy": "Three layers. (1) Residue identity: encode $p = d\\cdot n - 1$ as $d\\cdot n = p + 1$, cast to $\\mathbb{Z}/p\\mathbb{Z}$ where $p \\mapsto 0$, obtaining $\\bar d\\,\\bar n = 1$, so $d$ and $n$ — hence $-d$ and $-n$ — are mutually inverse units mod $p$. (2) Symbol reduction: $(-d)(-n) = d\\cdot n \\equiv 1$ is a square, so by multiplicativity $\\left(\\tfrac{-d}{p}\\right)\\left(\\tfrac{-n}{p}\\right) = 1$; since each factor is $\\pm 1$, equality of the two symbols follows — entirely without quadratic reciprocity. (3) Dirichlet supply: pick the residue class $p \\equiv n-1 \\equiv -1 \\pmod n$, coprime to $n$ because $\\gcd(n-1,n)=1$, and invoke Mathlib's Dirichlet theorem for arbitrarily large primes; repackage the quotient as a fresh variable to keep the divisibility arithmetic inside omega's linear fragment. Assembling (2) and (3) gives, for every bound, a multiplier prime whose QR side condition is governed solely by $-n$.",
+    "keyInsights": [
+      "The quadratic-residue condition on the multiplier d is not really about d at all: because (−d)(−n) ≡ 1 (mod p), the symbols legendreSym p (−d) and legendreSym p (−n) are forced equal. The unbounded multiplier vanishes from the residue bookkeeping.",
+      "The reduction is reciprocity-free. It needs only that a unit and its inverse are simultaneously squares — multiplicativity of the Legendre symbol plus its ±1 dichotomy — not the quadratic reciprocity law itself.",
+      "Eliminating d turns a moving-target selection into a fixed-target one: legendreSym p (−n) = 1 is controlled by p mod 4n, exactly the kind of congruence class Dirichlet's theorem delivers.",
+      "Mathlib's recent formalization of Dirichlet's theorem on primes in arithmetic progressions (Nat.forall_exists_prime_gt_and_modEq) is what makes the supply layer constructive here; the entry chooses the class p ≡ −1 (mod n) using the coprimality of consecutive integers.",
+      "Honest scope is built into the result: the selection layer is now complete and d-free, but the companion geometry lemma is proved only for d ∈ {1,2}. The remaining gap toward full sufficiency is isolated to a single d-uniform geometric construction, not a number-theoretic one."
+    ]
+  },
+  "sections": [
+    {
+      "id": "background",
+      "title": "Background: the multiplier mechanism",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "Imports and the file docstring: the Dirichlet/Minkowski route to three-square sufficiency, the geometry-of-numbers lemma's hypotheses (multiplier d, prime p = d·n − 1, QR condition legendreSym p (−d) = 1), and the unbounded-multiplier friction for n mod 8 ∈ {1,2,5,6} that this file removes."
+    },
+    {
+      "id": "residue-identity",
+      "title": "The key residue identity",
+      "startLine": 68,
+      "endLine": 78,
+      "summary": "Namespace ThreeSquaresMultiplierQR and the lemma natCast_mul_eq_one: from d·n = p + 1, casting into ZMod p gives (d̄)(n̄) = 1 — d and n are mutually inverse units mod p."
+    },
+    {
+      "id": "multiplier-reduction",
+      "title": "Multiplier–QR reduction",
+      "startLine": 80,
+      "endLine": 110,
+      "summary": "The headline theorem legendreSym_neg_multiplier_eq: legendreSym p (−d) = legendreSym p (−n), proved reciprocity-free from (−d)(−n) ≡ 1 via multiplicativity and the ±1 dichotomy of the Legendre symbol."
+    },
+    {
+      "id": "selection-criterion",
+      "title": "Selection criterion",
+      "startLine": 112,
+      "endLine": 124,
+      "summary": "Corollaries legendreSym_neg_d_eq_one_iff (biconditional) and legendreSym_neg_n_one_imp_neg_d_one (the direction consumed by dirichlet_key_lemma): the geometry's QR hypothesis is equivalent to a condition on n alone."
+    },
+    {
+      "id": "dirichlet-supply",
+      "title": "Dirichlet supply of multiplier primes",
+      "startLine": 126,
+      "endLine": 156,
+      "summary": "Helper coprime_pred_self (gcd(n−1,n)=1) and exists_multiplier_prime: for every n ≥ 2 and bound N, Mathlib's Dirichlet theorem yields a prime p > N with p ≡ −1 (mod n), repackaged as p = d·n − 1 with the quotient made an explicit variable for omega."
+    },
+    {
+      "id": "assembled",
+      "title": "Assembled selection layer",
+      "startLine": 158,
+      "endLine": 171,
+      "summary": "Capstone exists_multiplier_prime_qr_reduces: for every n ≥ 2 and bound N a multiplier prime p > N exists for which legendreSym p (−n) = 1 forces legendreSym p (−d) = 1 — the d-free, fixed-target number-theoretic input the harder residue classes need."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-07` (0 prior passes, quality 10).

This research entry had a rich `meta.meta` block but was missing the reader-facing
structure used by the gallery proof page. Added:

- **Top-level `description`** — concise summary of the d-free QR reduction (previously absent, so the listing/page had no description).
- **`overview`** with:
  - `historicalContext` — Legendre (1798) → Gauss (1801, ternary forms) → Dirichlet (1850, primes in AP) → Minkowski (geometry of numbers), and why the unbounded multiplier d for n mod 8 ∈ {1,2,5,6} is the friction this file removes.
  - `problemStatement` (LaTeX), `proofStrategy` (the three layers: residue identity → reciprocity-free symbol reduction → Dirichlet supply), and 5 `keyInsights`.
- **`sections`** — 6 sections covering all 171 lines (background, residue identity, multiplier reduction, selection criterion, Dirichlet supply, assembled layer).
- **`annotations.json`** — 7 new annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, mapped to the actual declaration line ranges.

**Verification:** meta.json + annotations.json are valid JSON; the `annotations:build` / `research:build` data pipeline processed the entry without error, and `annotations:validate` (strict) reports no line-resolution warnings for this entry. All annotation ranges resolve to Lean constructs. Mathematical content preserved/extended only — nothing deleted.

Note: the full `pnpm build` could not complete the `tsc`/`vite` stages in this worktree due to an environmental native-dependency failure (`better-sqlite3` won't compile under node v26); this is unrelated to the JSON data changes, which validate cleanly.