### PR TITLE
research(erdos-1000-oq-03): closed forms for generalized totients with restricted denominator conditions [0-axiom verified original]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -908,6 +908,7 @@ import Proofs.ElementaryQuadraticReciprocityOQ03OQ02OQ03
 import Proofs.ElementaryQuadraticReciprocityOQ03OQ03
 import Proofs.Erdos1000OQ01
 import Proofs.Erdos1000OQ01Aristotle
+import Proofs.Erdos1000OQ03
 import Proofs.Erdos1000Problem
 import Proofs.Erdos1001OQ02
 import Proofs.Erdos1001OQ02OQ01

--- a/proofs/Proofs/Erdos1000OQ03.lean
+++ b/proofs/Proofs/Erdos1000OQ03.lean
@@ -1,0 +1,240 @@
+/-
+  Erdős Problem #1000 — Open Question OQ-03:
+  Generalized totients with *different denominator conditions*.
+
+  Source of the open question: src/data/proofs/erdos-1000 (parent),
+  openQuestion: "Does the result extend to other generalized totients
+  (e.g., with different denominator conditions)?"
+
+  ## Context
+
+  The parent entry (Proofs/Erdos1000Problem.lean) studies Cassels' generalized
+  totient φ_A(k) = #{m ≤ n_k : reduced denominator of m/n_k is "unused"}.
+  Its master structural theorem is the *exact divisor decomposition*
+
+      φ_A(k) = Σ_{e | n_k, e admissible} φ(e),
+
+  i.e. counting m by the reduced denominator e = n/gcd(m,n) of m/n turns the
+  generalized totient into a *restricted Gauss sum* Σ_{e | n} φ(e) over an
+  admissible set of divisors. The classical Gauss identity Σ_{e | n} φ(e) = n
+  corresponds to the unrestricted count.
+
+  ## This file
+
+  We answer OQ-03 by evaluating these restricted Gauss sums *in closed form*
+  for natural "denominator conditions", and by giving the corresponding
+  closed-form counts of m. The headline results:
+
+  * `sum_totient_filter_not_dvd` :
+        Σ_{d | n, p ∤ d} φ(d) = ordCompl[p] n   (the p-free part of n)
+  * `sum_totient_filter_odd` :
+        Σ_{d | n, d odd} φ(d) = odd part of n      (the p = 2 case)
+  * `sum_totient_filter_dvd` :
+        Σ_{d | n, p ∣ d} φ(d) = n − ordCompl[p] n  (the complementary count)
+  * `card_reducedDenom_not_dvd` / `card_reducedDenom_odd` :
+        the *counting* form — #{m < n : the reduced denominator of m/n is
+        coprime to p (resp. odd)} = ordCompl[p] n (resp. the odd part of n).
+
+  These are genuinely different generalized totients from the parent's, sharing
+  the same reduced-denominator engine but with a multiplicative denominator
+  condition, and they all collapse to the classical Gauss identity Σ_{d|n} φ(d)=n
+  when the condition is vacuous.
+
+  No axioms, no native_decide.
+
+  Tags: number-theory, totient-function, gauss-identity, divisor-sums,
+  generalized-totient, erdos-1000
+-/
+
+import Mathlib
+
+namespace Erdos1000OQ03
+
+open Finset Nat
+
+/- ## Part I: A generic "restricted Gauss sum" evaluator -/
+
+/-- If the divisors of `n` satisfying a predicate `P` are *exactly* the divisors
+    of some `m`, then the totient sum over them telescopes to `m` by Gauss'
+    identity `Σ_{d | m} φ(d) = m`. This is the engine behind every closed form
+    below: each denominator condition is shown to carve out `m.divisors` for an
+    appropriate `m | n`. -/
+theorem sum_totient_filter_eq_of_divisors_eq {n m : ℕ} (P : ℕ → Prop)
+    [DecidablePred P] (h : n.divisors.filter P = m.divisors) :
+    ∑ d ∈ n.divisors.filter P, φ d = m := by
+  rw [h]; exact Nat.sum_totient m
+
+/- ## Part II: The prime-free denominator condition -/
+
+/-- For a prime `p` and `n ≠ 0`, a divisor `d | n` is coprime-to-`p`
+    (equivalently `p ∤ d`) **iff** it divides the `p`-free part `ordCompl[p] n`.
+
+    Forward: `d | n = p^a · ordCompl` and `gcd(d, p^a) = 1`, so `d | ordCompl`.
+    Backward: `d | ordCompl` and `p ∤ ordCompl`, so `p ∤ d`. -/
+theorem not_dvd_iff_dvd_ordCompl {n p d : ℕ} (hp : p.Prime) (hn : n ≠ 0)
+    (hd : d ∣ n) : ¬ p ∣ d ↔ d ∣ ordCompl[p] n := by
+  constructor
+  · intro hpd
+    -- `d` is coprime to `ordProj[p] n = p ^ (n.factorization p)`.
+    have hcop : Nat.Coprime d (ordProj[p] n) :=
+      (Nat.Coprime.pow_right _ ((hp.coprime_iff_not_dvd.mpr hpd).symm))
+    -- `d ∣ ordProj * ordCompl = n`.
+    have hdvd : d ∣ ordProj[p] n * ordCompl[p] n := by
+      rwa [Nat.ordProj_mul_ordCompl_eq_self]
+    exact hcop.dvd_of_dvd_mul_left hdvd
+  · intro hdc hpd
+    exact Nat.not_dvd_ordCompl hp hn (dvd_trans hpd hdc)
+
+/-- **The `p`-free restricted Gauss sum.**
+    `Σ_{d | n, p ∤ d} φ(d) = ordCompl[p] n`, the largest divisor of `n` coprime
+    to `p`. This is a generalized totient with the denominator condition
+    "denominator not divisible by `p`". -/
+theorem sum_totient_filter_not_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors.filter (fun d => ¬ p ∣ d), φ d = ordCompl[p] n := by
+  apply sum_totient_filter_eq_of_divisors_eq
+  have hcongr : n.divisors.filter (fun d => ¬ p ∣ d)
+      = n.divisors.filter (fun d => d ∣ ordCompl[p] n) := by
+    apply Finset.filter_congr
+    intro d hd
+    simpa using not_dvd_iff_dvd_ordCompl hp hn (Nat.dvd_of_mem_divisors hd)
+  rw [hcongr]
+  exact Nat.divisors_filter_dvd_of_dvd hn (Nat.ordCompl_dvd n p)
+
+/-- **The odd-denominator restricted Gauss sum** (the `p = 2` headline).
+    `Σ_{d | n, d odd} φ(d) = ordCompl[2] n`, the odd part of `n`.
+    Equivalently: the number of `m ∈ [1, n]` whose reduced fraction `m/n` has an
+    odd denominator equals the odd part of `n`. -/
+theorem sum_totient_filter_odd (n : ℕ) (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors.filter (fun d => Odd d), φ d = ordCompl[2] n := by
+  have hcongr : n.divisors.filter (fun d => Odd d)
+      = n.divisors.filter (fun d => ¬ (2 : ℕ) ∣ d) := by
+    apply Finset.filter_congr
+    intro d _
+    simp [Nat.odd_iff, Nat.two_dvd_ne_zero]
+  rw [hcongr]
+  exact sum_totient_filter_not_dvd Nat.prime_two hn
+
+/- ## Part III: The complementary (`p ∣ d`) condition -/
+
+/-- **The `p`-divisible restricted Gauss sum.**
+    `Σ_{d | n, p ∣ d} φ(d) = n − ordCompl[p] n`. Together with
+    `sum_totient_filter_not_dvd` this partitions Gauss' identity
+    `Σ_{d|n} φ(d) = n` according to divisibility by `p`. -/
+theorem sum_totient_filter_dvd {n p : ℕ} (hp : p.Prime) (hn : n ≠ 0) :
+    ∑ d ∈ n.divisors.filter (fun d => p ∣ d), φ d = n - ordCompl[p] n := by
+  have hsplit := Finset.sum_filter_add_sum_filter_not n.divisors
+    (fun d => p ∣ d) φ
+  rw [Nat.sum_totient] at hsplit
+  -- The "¬ p ∣ d" part is the p-free sum = ordCompl[p] n.
+  have hnot : ∑ d ∈ n.divisors.filter (fun d => ¬ p ∣ d), φ d = ordCompl[p] n :=
+    sum_totient_filter_not_dvd hp hn
+  rw [hnot] at hsplit
+  omega
+
+/- ## Part IV: Recovering the classical Gauss identity -/
+
+/-- When the denominator condition is vacuous, the restricted sum is the full
+    Gauss identity `Σ_{d | n} φ(d) = n`. (Sanity check that our generalized
+    totients specialize correctly.) -/
+theorem sum_totient_filter_true (n : ℕ) :
+    ∑ d ∈ n.divisors.filter (fun _ => True), φ d = n := by
+  simp [Nat.sum_totient]
+
+/-- Every restricted generalized totient is bounded by `n` (it is a sub-sum of
+    Gauss' identity). -/
+theorem sum_totient_filter_le (n : ℕ) (P : ℕ → Prop) [DecidablePred P] :
+    ∑ d ∈ n.divisors.filter P, φ d ≤ n := by
+  calc ∑ d ∈ n.divisors.filter P, φ d
+      ≤ ∑ d ∈ n.divisors, φ d :=
+        Finset.sum_le_sum_of_subset_of_nonneg (Finset.filter_subset _ _)
+          (fun _ _ _ => Nat.zero_le _)
+    _ = n := Nat.sum_totient n
+
+/- ## Part V: The counting form (connection to the φ_A engine) -/
+
+/-- The reduced denominator of the fraction `m / n`: writing `m/n` in lowest
+    terms, the denominator is `n / gcd(n, m)`. This is the same quantity that
+    drives the parent's generalized totient `φ_A`. -/
+def reducedDenom (m n : ℕ) : ℕ := n / Nat.gcd n m
+
+/-- For `g, e` both dividing `n > 0`: `n / g = e ↔ g = n / e`.
+    (Both say `g · e = n`.) -/
+private lemma div_eq_iff_eq_div {n g e : ℕ} (hg : g ∣ n) (he : e ∣ n)
+    (hgpos : 0 < g) (hepos : 0 < e) : n / g = e ↔ g = n / e := by
+  constructor
+  · intro h
+    have hmul : g * e = n := by rw [← h, Nat.mul_div_cancel' hg]
+    rw [← hmul, Nat.mul_div_cancel _ hepos]
+  · intro h
+    have hmul : e * g = n := by rw [h]; exact Nat.mul_div_cancel' he
+    rw [← hmul, Nat.mul_div_cancel _ hgpos]
+
+/-- **Fiber count.** For a divisor `e | n` (with `n > 0`), exactly `φ(e)` of the
+    integers `m ∈ {0,…,n−1}` have reduced denominator `e` in `m/n`. This is the
+    bijection underlying `Nat.sum_totient`, expressed via the reduced
+    denominator. -/
+theorem card_reducedDenom_eq_totient {n e : ℕ} (hn : 0 < n) (he : e ∣ n) :
+    #{m ∈ range n | reducedDenom m n = e} = φ e := by
+  have hepos : 0 < e := pos_of_dvd_of_pos he hn
+  have hd : (n / e) ∣ n := Nat.div_dvd_of_dvd he
+  have hee : n / (n / e) = e := Nat.div_div_self he hn.ne'
+  have hfib : #{m ∈ range n | n.gcd m = n / e} = φ e := by
+    rw [← Nat.totient_div_of_dvd hd, hee]
+  rw [← hfib]
+  congr 1
+  apply Finset.filter_congr
+  intro m hm
+  have hg : Nat.gcd n m ∣ n := Nat.gcd_dvd_left n m
+  have hgpos : 0 < Nat.gcd n m := by
+    rcases Nat.eq_zero_or_pos (Nat.gcd n m) with h | h
+    · rw [Nat.gcd_eq_zero_iff] at h; omega
+    · exact h
+  simpa [reducedDenom] using div_eq_iff_eq_div hg he hgpos hepos
+
+/-- **Master counting identity.** For any denominator condition `P`, the number
+    of `m ∈ {0,…,n−1}` whose reduced denominator satisfies `P` equals the
+    restricted Gauss sum `Σ_{e | n, P e} φ(e)`. This is the exact analogue of
+    the parent's `phiA_decomposition`, with the admissibility condition `P`
+    applied to the reduced denominator. -/
+theorem card_reducedDenom_filter {n : ℕ} (hn : 0 < n) (P : ℕ → Prop)
+    [DecidablePred P] :
+    #{m ∈ range n | P (reducedDenom m n)}
+      = ∑ e ∈ n.divisors.filter P, φ e := by
+  -- Each `m` maps to its reduced denominator, a divisor of `n` satisfying `P`.
+  have H : Set.MapsTo (fun m => reducedDenom m n)
+      ({m ∈ range n | P (reducedDenom m n)} : Finset ℕ) (n.divisors.filter P) := by
+    intro m hm
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_range] at hm
+    simp only [Finset.mem_coe, Finset.mem_filter, Nat.mem_divisors, reducedDenom]
+    exact ⟨⟨Nat.div_dvd_of_dvd (Nat.gcd_dvd_left n m), hn.ne'⟩, hm.2⟩
+  rw [Finset.card_eq_sum_card_fiberwise H]
+  apply Finset.sum_congr rfl
+  intro e he
+  simp only [Finset.mem_filter, Nat.mem_divisors] at he
+  -- The fiber over `e` is exactly {m < n : reducedDenom m n = e}.
+  have hfilt : {m ∈ range n | P (reducedDenom m n)}.filter
+      (fun m => reducedDenom m n = e)
+      = {m ∈ range n | reducedDenom m n = e} := by
+    ext m
+    simp only [Finset.mem_filter, Finset.mem_range]
+    constructor
+    · rintro ⟨⟨hmr, _⟩, hrd⟩; exact ⟨hmr, hrd⟩
+    · rintro ⟨hmr, hrd⟩; exact ⟨⟨hmr, by rw [hrd]; exact he.2⟩, hrd⟩
+  rw [hfilt, card_reducedDenom_eq_totient hn he.1.1]
+
+/-- **Counting form of the `p`-free Gauss sum.**
+    The number of `m ∈ {0,…,n−1}` whose reduced fraction `m/n` has denominator
+    coprime to the prime `p` equals `ordCompl[p] n`, the `p`-free part of `n`. -/
+theorem card_reducedDenom_not_dvd {n p : ℕ} (hp : p.Prime) (hn : 0 < n) :
+    #{m ∈ range n | ¬ p ∣ reducedDenom m n} = ordCompl[p] n := by
+  rw [card_reducedDenom_filter hn (fun e => ¬ p ∣ e),
+      sum_totient_filter_not_dvd hp hn.ne']
+
+/-- **Counting form of the odd Gauss sum** (`p = 2`).
+    The number of `m ∈ {0,…,n−1}` whose reduced fraction `m/n` has an *odd*
+    denominator equals the odd part of `n`. -/
+theorem card_reducedDenom_odd {n : ℕ} (hn : 0 < n) :
+    #{m ∈ range n | Odd (reducedDenom m n)} = ordCompl[2] n := by
+  rw [card_reducedDenom_filter hn (fun e => Odd e), sum_totient_filter_odd n hn.ne']
+
+end Erdos1000OQ03

--- a/src/data/proofs/erdos-1000-oq-03/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "erdos-1000-oq-03",
+  "title": "Erdős #1000 OQ-03: Generalized Totients with Restricted Denominator Conditions",
+  "slug": "erdos-1000-oq-03",
+  "description": "Answers the parent's open question — 'Does the result extend to other generalized totients with different denominator conditions?' — by evaluating the restricted Gauss sums Σ_{d|n, cond} φ(d) in closed form. Headline: Σ_{d|n, p∤d} φ(d) = ordCompl[p] n (the p-free part of n); the p=2 case gives Σ_{d|n, d odd} φ(d) = odd part of n; and the complementary Σ_{d|n, p∣d} φ(d) = n − ordCompl[p] n. A reduced-denominator counting bridge turns each identity into a count of fractions m/n: #{m<n : reduced denominator of m/n is coprime to p} = ordCompl[p] n.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1000",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1000OQ03.lean",
+    "tags": [
+      "number-theory",
+      "totient-function",
+      "gauss-identity",
+      "divisor-sums",
+      "generalized-totient",
+      "erdos"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 1000,
+    "erdosUrl": "https://erdosproblems.com/1000",
+    "erdosProblemStatus": "solved",
+    "relatedProblems": [
+      "erdos-1000"
+    ],
+    "axiomCount": 0,
+    "lineCount": 240,
+    "assumptions": "No axioms, no native_decide. Every result is proved from Mathlib (Nat.sum_totient, Nat.divisors_filter_dvd_of_dvd, ordProj/ordCompl factorization lemmas, Nat.totient_div_of_dvd). #print axioms reports only propext, Classical.choice, Quot.sound for all headline theorems. This entry proves new closed-form side results about restricted totient sums; it does not resolve any open conjecture (Erdős #1000 was itself settled by Haight).",
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Gauss' divisor-sum identity Σ_{d|n} φ(d) = n (Disquisitiones Arithmeticae, 1801) is the prototype of a 'generalized totient': it reorganizes the n fractions 0/n, 1/n, …, (n−1)/n by their reduced denominator d | n, each value d being hit exactly φ(d) times. Cassels' generalized totient φ_A, the subject of Erdős Problem #1000, is built on exactly this reduced-denominator bookkeeping: φ_A(k) counts the m ≤ n_k whose reduced denominator avoids the earlier terms of a sequence A, and the parent formalization's master theorem expresses it as a restricted Gauss sum Σ_{e | n_k, e admissible} φ(e). Erdős asked (1964) whether the Cesàro average of φ_A(k)/n_k could vanish; Haight answered yes, against Erdős' expectation, using highly composite numbers.\n\nThe parent entry leaves open (OQ-03) whether 'the result extends to other generalized totients with different denominator conditions.' This entry takes the natural reading: replace the sequence-dependent admissibility condition with a fixed arithmetic condition on the reduced denominator — coprimality to a prime p, oddness, divisibility by p — and evaluate the resulting restricted Gauss sums in closed form. The key phenomenon is that a multiplicative denominator condition carves the divisor lattice of n into the divisor lattice of a sub-number: the divisors of n coprime to p are exactly the divisors of the p-free part ordCompl[p] n, so the restricted sum collapses back to a full Gauss sum over that sub-number and equals it.",
+    "problemStatement": "**Generalized totients with restricted denominator conditions.** For the reduced denominator d = n/gcd(n,m) of a fraction m/n, evaluate the restricted Gauss sums Σ_{d | n, cond d} φ(d) — equivalently the counts #{m < n : cond(reduced denominator of m/n)} — for natural arithmetic conditions 'cond':\n\n1. p ∤ d (denominator coprime to a prime p),\n2. d odd (the p = 2 case),\n3. p ∣ d (the complementary condition).",
+    "text": "Evaluates the restricted totient divisor-sums Σ_{d|n, cond} φ(d) in closed form: the p-free condition gives ordCompl[p] n, oddness gives the odd part of n, and divisibility by p gives n − ordCompl[p] n. A reduced-denominator counting bridge expresses each as a count of fractions m/n. All results are 0-axiom verified from Mathlib.",
+    "proofStrategy": "**The engine** (`sum_totient_filter_eq_of_divisors_eq`): if the divisors of n satisfying a condition P are *exactly* the divisors of some m, then Σ_{d|n, P d} φ(d) = Σ_{d|m} φ(d) = m by Gauss' identity (`Nat.sum_totient`). Every closed form below identifies the right m | n.\n\n**Prime-free condition**: for a prime p and d | n, the equivalence p ∤ d ↔ d ∣ ordCompl[p] n holds (`not_dvd_iff_dvd_ordCompl`). Forward: d | n = ordProj·ordCompl with gcd(d, ordProj[p] n) = 1 (since p ∤ d and ordProj is a power of p), so d ∣ ordCompl by `Nat.Coprime.dvd_of_dvd_mul_left`. Backward: d ∣ ordCompl and p ∤ ordCompl force p ∤ d. Then `Nat.divisors_filter_dvd_of_dvd` rewrites the filtered divisor set as (ordCompl[p] n).divisors, and the engine fires.\n\n**Odd case**: rewrite 'Odd d' to '¬ 2 ∣ d' (`Nat.odd_iff` + `Nat.two_dvd_ne_zero`) and specialize p = 2.\n\n**Complement**: `Finset.sum_filter_add_sum_filter_not` splits Gauss' identity Σ_{d|n} φ(d) = n into the p ∣ d and p ∤ d parts; subtracting the p-free part (= ordCompl[p] n) gives n − ordCompl[p] n.\n\n**Counting bridge**: the reduced denominator m ↦ n/gcd(n,m) has fibers of size φ(e) over each divisor e | n (`card_reducedDenom_eq_totient`, via Mathlib's gcd-fiber lemma `Nat.totient_div_of_dvd` after the division identity n/g = e ↔ g = n/e). Partitioning range n over these fibers (`Finset.card_eq_sum_card_fiberwise`) turns each restricted Gauss sum into a count of fractions.",
+    "keyInsights": [
+      "A *multiplicative* denominator condition collapses a restricted Gauss sum to a full one: the divisors of n coprime to p are exactly the divisors of the p-free part ordCompl[p] n, so Σ_{d|n, p∤d} φ(d) = Σ_{d | ordCompl[p] n} φ(d) = ordCompl[p] n.",
+      "The odd-denominator restricted totient evaluates to the odd part of n — the count of m < n whose reduced fraction m/n has an odd denominator is exactly n / 2^{v₂(n)}.",
+      "The p ∣ d and p ∤ d conditions partition Gauss' identity Σ_{d|n} φ(d) = n, giving the complement Σ_{d|n, p∣d} φ(d) = n − ordCompl[p] n for free.",
+      "The reduced denominator n/gcd(n,m) has fiber size φ(e) over each divisor e | n — the same fibration that proves Nat.sum_totient — which lifts every divisor-sum identity to a statement counting fractions m/n, exactly mirroring the parent's phiA_decomposition.",
+      "The whole family degenerates to the classical Gauss identity (`sum_totient_filter_true`) when the denominator condition is vacuous, and every restricted sum is bounded by n (`sum_totient_filter_le`), since it is a sub-sum of Gauss' identity."
+    ],
+    "prerequisites": [
+      "Euler's totient and Gauss' identity Σ_{d|n} φ(d) = n",
+      "p-adic valuation and the factorization split n = ordProj[p] n · ordCompl[p] n",
+      "Coprimality and the divisor lattice of a natural number",
+      "Reduced fractions and the reduced denominator n/gcd(n,m)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "engine",
+      "title": "The Restricted Gauss-Sum Engine",
+      "summary": "`sum_totient_filter_eq_of_divisors_eq`: if {d | n : P d} = m.divisors, then Σ_{d|n, P d} φ(d) = m. A one-line consequence of Gauss' identity Nat.sum_totient, and the engine behind every closed form below.",
+      "startLine": 56,
+      "endLine": 67,
+      "mathContext": "Gauss' identity Σ_{d|m} φ(d) = m says the totient sum over a complete divisor lattice recovers the top element. The engine reduces every restricted sum to this by identifying the sub-number m whose divisor lattice the condition carves out."
+    },
+    {
+      "id": "prime-free",
+      "title": "The Prime-Free and Odd Denominator Conditions",
+      "summary": "`not_dvd_iff_dvd_ordCompl` (for d | n, p∤d ↔ d ∣ ordCompl[p] n), `sum_totient_filter_not_dvd` (Σ_{d|n, p∤d} φ(d) = ordCompl[p] n), and `sum_totient_filter_odd` (the p=2 case: Σ_{d|n, d odd} φ(d) = odd part of n).",
+      "startLine": 69,
+      "endLine": 119,
+      "mathContext": "Writing n = p^a · m with m = ordCompl[p] n coprime to p, a divisor d | n is coprime to p iff it divides m. The Coprime.dvd_of_dvd_mul_left step extracts d | m from d | p^a·m and gcd(d, p^a) = 1; not_dvd_ordCompl supplies the converse. The filtered divisor set is then (ordCompl[p] n).divisors by Nat.divisors_filter_dvd_of_dvd."
+    },
+    {
+      "id": "complement",
+      "title": "The Complementary p ∣ d Condition",
+      "summary": "`sum_totient_filter_dvd`: Σ_{d|n, p∣d} φ(d) = n − ordCompl[p] n, obtained by partitioning Gauss' identity with Finset.sum_filter_add_sum_filter_not and subtracting the p-free part.",
+      "startLine": 121,
+      "endLine": 136,
+      "mathContext": "The conditions p ∣ d and p ∤ d partition the divisors of n, so their totient sums add to Σ_{d|n} φ(d) = n. Since the p-free part equals ordCompl[p] n ≤ n, the divisible part is exactly the deficit n − ordCompl[p] n = (1 − 1/p^?)·… the p-power contribution to n."
+    },
+    {
+      "id": "gauss-recovery",
+      "title": "Degeneration to Gauss and the Universal Bound",
+      "summary": "`sum_totient_filter_true` (vacuous condition recovers Σ_{d|n} φ(d) = n) and `sum_totient_filter_le` (every restricted generalized totient is ≤ n, being a sub-sum of Gauss' identity).",
+      "startLine": 138,
+      "endLine": 152,
+      "mathContext": "Consistency checks: the restricted totients specialize correctly (no condition ⟹ the classical Gauss identity) and are uniformly dominated by n, reflecting that each is a partial sum of the same complete divisor-lattice sum."
+    },
+    {
+      "id": "counting-bridge",
+      "title": "The Reduced-Denominator Counting Bridge",
+      "summary": "`reducedDenom`, the division identity `div_eq_iff_eq_div`, the fiber count `card_reducedDenom_eq_totient` (φ(e) values m < n with reduced denominator e), the master identity `card_reducedDenom_filter`, and the headline counts `card_reducedDenom_not_dvd` / `card_reducedDenom_odd`.",
+      "startLine": 154,
+      "endLine": 239,
+      "mathContext": "The reduced denominator of m/n is n/gcd(n,m). Mathlib's Nat.totient_div_of_dvd gives #{k < n : gcd(n,k) = n/e} = φ(e) for e | n; reframing via n/g = e ↔ g = n/e turns this into a fiber count over reduced denominators. Finset.card_eq_sum_card_fiberwise then assembles #{m<n : P(reducedDenom m n)} = Σ_{e|n, P e} φ(e), the exact analogue of the parent's phiA_decomposition with admissibility condition P."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #1000 OQ-03 asks whether the generalized-totient theory extends to other denominator conditions. It does, cleanly: restricting Gauss' divisor-sum Σ_{d|n} φ(d) = n to a multiplicative condition on the denominator yields a closed form. The p-free condition gives the p-free part ordCompl[p] n, oddness gives the odd part of n, divisibility by p gives the complement n − ordCompl[p] n, and a reduced-denominator counting bridge expresses each as a count of fractions m/n. All results are 0-axiom verified from Mathlib, with no native_decide.",
+    "implications": "These closed forms isolate the structural core of the parent's generalized totient: the reduced-denominator fibration (each divisor e | n is the denominator of exactly φ(e) fractions m/n) is condition-agnostic, so any divisor condition that respects the multiplicative structure produces a sub-number whose Gauss sum gives the answer. The engine `sum_totient_filter_eq_of_divisors_eq` and the master count `card_reducedDenom_filter` are reusable for any future denominator condition that carves a divisor sub-lattice.",
+    "openQuestions": [
+      "Does the coprime-to-q condition Σ_{d|n, gcd(d,q)=1} φ(d) admit an equally clean closed form (the q-coprime part of n) for composite q, via iterated ordCompl over the prime factors of q?",
+      "Can the restricted sums be assembled into a Dirichlet-series / multiplicative-function identity, expressing Σ_{d|n, p∤d} φ(d) = ordCompl[p] n as a statement about the convolution φ ∗ 1 restricted to p-free divisors?",
+      "Do the closed forms transfer to Jordan's higher totient J_k, where Σ_{d|n} J_k(d) = n^k, giving restricted sums equal to (ordCompl[p] n)^k?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "Directly answers open question OQ-03 of the parent Erdős #1000 formalization ('Does the result extend to other generalized totients with different denominator conditions?') by evaluating restricted Gauss sums Σ_{d|n, cond} φ(d) in closed form; the counting bridge card_reducedDenom_filter is the exact analogue of the parent's phiA_decomposition.",
+      "targetId": "erdos-1000"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "C. F. Gauss"
+      ],
+      "title": "Disquisitiones Arithmeticae",
+      "venue": "Leipzig",
+      "year": "1801",
+      "notes": "The source of the divisor-sum identity Σ_{d|n} φ(d) = n that every restricted generalized totient in this file degenerates to. Article 39 establishes the totient's multiplicativity and the reduced-fraction bookkeeping underlying the counting bridge."
+    },
+    {
+      "authors": [
+        "J. W. S. Cassels"
+      ],
+      "title": "Some metrical theorems in Diophantine approximation. I",
+      "venue": "Proceedings of the Cambridge Philosophical Society",
+      "year": "1950",
+      "volume": "46",
+      "pages": "209–218",
+      "notes": "Introduces the generalized totient φ_A whose denominator condition this file varies. The reduced-denominator fibration used here is the same bookkeeping Cassels exploits to relate φ_A to Diophantine approximation."
+    },
+    {
+      "authors": [
+        "P. Erdős"
+      ],
+      "title": "Problem 1000",
+      "venue": "erdosproblems.com",
+      "year": "1964",
+      "notes": "The parent problem: whether the Cesàro average of φ_A(k)/n_k can vanish (settled affirmatively by Haight). OQ-03 asks about extending the generalized-totient framework to other denominator conditions, which this entry resolves with closed forms."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
+    "namespace": "Erdos1000OQ03",
+    "lineCount": 240,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1000OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers open question **OQ-03** of Erdős #1000 — *"Does the result extend to other generalized totients (e.g., with different denominator conditions)?"* — with concrete **closed forms**.

The parent's generalized totient $\varphi_A$ is a *restricted Gauss sum* $\sum_{e\mid n,\ e\text{ adm.}}\varphi(e)$ over the reduced denominator $e=n/\gcd(m,n)$ of $m/n$. Replacing the sequence-dependent admissibility with a fixed **multiplicative denominator condition** collapses the sum to a full Gauss sum over a sub-number:

| condition on reduced denominator $d$ | closed form |
|---|---|
| $p \nmid d$ (coprime to prime $p$) | $\sum_{d\mid n,\ p\nmid d}\varphi(d) = \mathrm{ordCompl}[p]\,n$ (the $p$-free part) |
| $d$ odd ($p=2$) | $\sum_{d\mid n,\ d\text{ odd}}\varphi(d) = $ odd part of $n$ |
| $p \mid d$ | $\sum_{d\mid n,\ p\mid d}\varphi(d) = n-\mathrm{ordCompl}[p]\,n$ |

A **reduced-denominator counting bridge** (each divisor $e\mid n$ is the denominator of exactly $\varphi(e)$ fractions $m/n$, via `Nat.totient_div_of_dvd`) lifts every divisor-sum identity to a count of fractions:
$\#\{m<n : \text{reduced denom of }m/n\text{ coprime to }p\} = \mathrm{ordCompl}[p]\,n$.
This is the exact analogue of the parent's `phiA_decomposition`.

## Verification

- **240 lines, 12 theorems / 1 definition, 0 axioms, 0 sorries, no `native_decide`.**
- `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all headline theorems.
- Compiles against Mathlib (Lean v4.26.0); gallery `pnpm build` passes.
- Status `verified` / badge `original`: proves new side results, does not resolve the (already-solved-by-Haight) parent problem.

## Files
- `proofs/Proofs/Erdos1000OQ03.lean` — the proof
- `proofs/Proofs.lean` — import registration
- `src/data/proofs/erdos-1000-oq-03/meta.json` — gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)