### PR TITLE
Enrich Power of a Point (ptolemys-theorem-oq-04)

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-04/annotations.json
+++ b/src/data/proofs/ptolemys-theorem-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "intersecting-chords",
+    "proofId": "ptolemys-theorem-oq-04",
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "concept",
+    "title": "Intersecting Chords Theorem (Freek No. 55)",
+    "content": "`intersecting_chords` states the classical fact: if A, B, C, D lie on a common sphere and P lies between A,B and between C,D (both angles at P are straight, ∠APB = ∠CPD = π), then the chord-segment products agree, PA·PB = PC·PD. It is a thin wrapper over Mathlib's `mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_pi`. This is item No. 55 on Freek Wiedijk's list of 100 theorems to formalize; the angle = π hypothesis encodes 'P is an interior crossing point of the two chords'.",
+    "mathContext": "Cospherical $A,B,C,D$, $\\angle APB = \\angle CPD = \\pi$ $\\Rightarrow$ $PA\\cdot PB = PC\\cdot PD$.",
+    "significance": "key",
+    "relatedConcepts": ["intersecting chords", "cospherical points", "Freek No. 55", "Euclid III.35"],
+    "prerequisites": ["circles", "angles", "cospherical points"]
+  },
+  {
+    "id": "intersecting-secants",
+    "proofId": "ptolemys-theorem-oq-04",
+    "range": { "startLine": 67, "endLine": 73 },
+    "type": "concept",
+    "title": "Intersecting Secants Theorem",
+    "content": "`intersecting_secants` is the exterior-point companion: for cospherical A, B, C, D, when P lies on the two secant lines on the same side (both angles at P are zero, ∠APB = ∠CPD = 0), the secant-segment products agree. It wraps `mul_dist_eq_mul_dist_of_cospherical_of_angle_eq_zero`. The angle = 0 hypothesis (versus π for chords) is exactly what distinguishes an external crossing from an internal one — and the power invariant below shows both are the same statement up to the sign of the power.",
+    "mathContext": "Cospherical $A,B,C,D$, $\\angle APB = \\angle CPD = 0$ $\\Rightarrow$ $PA\\cdot PB = PC\\cdot PD$ (P external).",
+    "significance": "key",
+    "relatedConcepts": ["intersecting secants", "external point", "cospherical points"],
+    "prerequisites": ["circles", "secant lines"]
+  },
+  {
+    "id": "power-invariant",
+    "proofId": "ptolemys-theorem-oq-04",
+    "range": { "startLine": 77, "endLine": 92 },
+    "type": "insight",
+    "title": "The Power Invariant: PA·PB = |power P|",
+    "content": "The keystone of the file. `mul_dist_eq_abs_power` records that for ANY line through P meeting the sphere s at A, B, the segment product equals |power P| = |dist(P,center)² − r²|. Because the right-hand side mentions only P and s — not the chosen line — line-independence (`mul_dist_eq_mul_dist_of_mem_sphere`) is immediate: rewrite the products along two different lines, both become |power P|, done. This single scalar is the conceptual engine from which every classical chord/secant/tangent theorem in the file is a corollary.",
+    "mathContext": "$PA\\cdot PB = |\\operatorname{pow}_s(P)| = |\\operatorname{dist}(P,\\text{center})^2 - r^2|$, independent of the line through $P$.",
+    "significance": "key",
+    "relatedConcepts": ["power of a point", "invariant", "line-independence", "radical axis"],
+    "prerequisites": ["inner-product spaces", "spheres", "distance"]
+  },
+  {
+    "id": "signed-forms",
+    "proofId": "ptolemys-theorem-oq-04",
+    "range": { "startLine": 94, "endLine": 107 },
+    "type": "concept",
+    "title": "Signed Forms: Inside vs Outside the Sphere",
+    "content": "Splitting on the sign of the power makes the geometry explicit. `mul_dist_eq_power_outside`: when P is on or outside the sphere (radius ≤ dist to center), the secant product equals the nonnegative power. `mul_dist_eq_neg_power_inside`: when P is on or inside, the chord product equals minus the (nonpositive) power. The absolute value in the keystone invariant is exactly what reconciles these two signs into one statement — the power is positive outside, negative inside, zero on the sphere.",
+    "mathContext": "Outside: $PA\\cdot PB = \\operatorname{pow}(P)\\ge 0$. Inside: $PA\\cdot PB = -\\operatorname{pow}(P)\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sign of the power", "interior vs exterior point", "secant product"],
+    "prerequisites": ["power of a point", "ordering of reals"]
+  },
+  {
+    "id": "tangents",
+    "proofId": "ptolemys-theorem-oq-04",
+    "range": { "startLine": 111, "endLine": 128 },
+    "type": "technique",
+    "title": "Tangent–Secant and Equal Tangents",
+    "content": "`tangent_sq_eq_secant_product` gives tangent² = PA·PB at a tangent point t, since the power equals the squared tangent length there. `dist_tangent_eq_of_tangent` then derives the Equal Tangents Theorem — the two tangent segments from an external point have equal length — which is NOT a single Mathlib lemma: both squared tangent lengths equal the power of P, and squaring is injective on nonnegative reals (`pow_left_inj₀` with `dist_nonneg`), so the lengths coincide. A clean example of recovering a named classical theorem from an invariant plus a monotonicity fact.",
+    "mathContext": "$PT^2 = PA\\cdot PB = \\operatorname{pow}(P)$; two tangents $T_1,T_2$ give $PT_1^2 = PT_2^2 \\Rightarrow PT_1 = PT_2$.",
+    "significance": "key",
+    "relatedConcepts": ["tangent–secant relation", "equal tangents", "injectivity of squaring", "tangent length"],
+    "prerequisites": ["tangent lines", "power of a point"]
+  },
+  {
+    "id": "concrete-witness",
+    "proofId": "ptolemys-theorem-oq-04",
+    "range": { "startLine": 136, "endLine": 163 },
+    "type": "technique",
+    "title": "A Fully Explicit ℂ Witness",
+    "content": "To show the abstract theorem has real content, the file builds an explicit configuration in ℂ: the unit circle with perpendicular diameters [1,−1] and [I,−I] crossing at the centre 0. `cospherical_unit` certifies the four points lie on the circle (center 0, radius 1); `center_mem_diam_re`/`_im` place 0 on each diameter by exhibiting it as `AffineMap.lineMap` at parameter 1/2 (the midpoint); `concrete_intersecting_chords` then reads off 1·1 = 1·1. This discharges, by hand, the cospherical and on-line hypotheses that the general theorems take as input.",
+    "mathContext": "Unit circle in $\\mathbb{C}$, diameters $[1,-1]\\perp[I,-I]$ meeting at $0$: $\\operatorname{dist}(1,0)\\cdot\\operatorname{dist}(-1,0) = 1 = \\operatorname{dist}(I,0)\\cdot\\operatorname{dist}(-I,0)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "unit circle", "affine line map", "midpoint"],
+    "prerequisites": ["complex plane", "affine combinations"]
+  }
+]

--- a/src/data/proofs/ptolemys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-04/meta.json
@@ -87,6 +87,93 @@
   "overview": {
     "historicalContext": "The Power of a Point, studied systematically by Jakob Steiner in the 19th century, assigns to each point P and circle (or sphere) the scalar dist(P,center)² − radius². Its sign tells whether P is inside, on, or outside the circle, and its magnitude controls the products of distances along secant lines through P. Classical consequences — the Intersecting Chords Theorem (Euclid, Elements III.35; Freek/Wiedijk No. 55), the Intersecting Secants Theorem, and the Tangent–Secant relation — all fall out of the single fact that PA·PB is the same for every line through P.",
     "problemStatement": "**Open Question (oq-04)**: Beyond Ptolemy's additive relation AC·BD = AB·CD + AD·BC for a cyclic quadrilateral, what is the multiplicative theory of distances from a fixed point to a circle? This entry answers it via the Power of a Point: PA·PB = |power P| for any chord/secant, giving Intersecting Chords, Intersecting Secants, Tangent–Secant, and Equal Tangents as corollaries — coordinate-free and in any dimension.",
-    "text": "Working over an arbitrary real inner-product space, the file proves PA·PB = |power P| for any line through P meeting the sphere at A, B (mul_dist_eq_abs_power), from which line-independence (mul_dist_eq_mul_dist_of_mem_sphere) follows immediately. The Intersecting Chords and Secants theorems are obtained via Mathlib's cospherical-angle lemmas; the signed forms record PA·PB = power for exterior points and = −power for interior points. The Tangent–Secant relation gives tangent² = PA·PB, and the Equal Tangents Theorem — both tangents from an external point have equal length — is derived since each squared tangent length equals the power. A concrete witness in ℂ verifies the chord product for two perpendicular diameters of the unit circle meeting at the centre."
-  }
+    "text": "Working over an arbitrary real inner-product space, the file proves PA·PB = |power P| for any line through P meeting the sphere at A, B (mul_dist_eq_abs_power), from which line-independence (mul_dist_eq_mul_dist_of_mem_sphere) follows immediately. The Intersecting Chords and Secants theorems are obtained via Mathlib's cospherical-angle lemmas; the signed forms record PA·PB = power for exterior points and = −power for interior points. The Tangent–Secant relation gives tangent² = PA·PB, and the Equal Tangents Theorem — both tangents from an external point have equal length — is derived since each squared tangent length equals the power. A concrete witness in ℂ verifies the chord product for two perpendicular diameters of the unit circle meeting at the centre.",
+    "proofStrategy": "The whole package is organized around a single scalar invariant rather than around coordinates or angles. (1) The power of P with respect to a sphere s is $\\operatorname{pow}(P) = \\operatorname{dist}(P,\\text{center})^2 - r^2$, a Mathlib primitive. (2) The keystone `mul_dist_eq_abs_power` records that for any line through P meeting s at A, B, the segment product $PA\\cdot PB = |\\operatorname{pow}(P)|$; since the right side does not mention the line, line-independence (`mul_dist_eq_mul_dist_of_mem_sphere`) is immediate by rewriting both products to the same $|\\operatorname{pow}(P)|$. (3) The classical Intersecting Chords / Secants theorems are then thin wrappers over Mathlib's cospherical-angle lemmas (angle $=\\pi$ for an interior crossing, angle $=0$ for an exterior one). (4) Splitting on the sign of the power (whether P is inside or outside) yields the signed forms. (5) For tangents, $\\operatorname{pow}(P)$ equals the squared tangent length, so the Tangent–Secant relation is direct and Equal Tangents follows because two squared tangent lengths share the same power and distances are nonnegative (`pow_left_inj₀`). (6) A concrete ℂ witness discharges the cospherical and on-line hypotheses explicitly via `AffineMap.lineMap`.",
+    "keyInsights": [
+      "A single signed scalar — the power dist(P,center)² − r² — controls the entire multiplicative theory of distances from P to a sphere; every classical theorem here is a corollary of 'PA·PB depends only on P, not on the line'.",
+      "Phrasing the result over an arbitrary real inner-product space (via NormedAddTorsor) makes Intersecting Chords/Secants dimension-free: the same proof covers the plane, space, and ℝⁿ, where the classical synthetic arguments are 2D-specific.",
+      "The sign of the power is geometrically meaningful: positive outside the sphere (secant product = power), negative inside (chord product = −power), zero on it — so the absolute-value invariant cleanly unifies the interior and exterior cases that classical treatments state separately.",
+      "Equal Tangents is not a single Mathlib lemma but falls out structurally: both squared tangent lengths equal the power, and squaring is injective on nonnegative reals — a clean example of deriving a named theorem from an invariant plus a monotonicity fact.",
+      "The entry deliberately exercises Mathlib's product/power sphere API (mul_dist_eq_*, IsTangentAt.power_eq_dist_sq), previously unused in the gallery, complementing rather than duplicating the additive Ptolemy and 2D-coordinate chord-product proofs."
+    ]
+  },
+  "sections": [
+    {
+      "id": "classical-products",
+      "title": "The Classical Product Theorems",
+      "startLine": 56,
+      "endLine": 73,
+      "summary": "intersecting_chords (Freek No. 55) and intersecting_secants package Mathlib's cospherical-angle lemmas: for four cospherical points and a crossing point P, equal chord/secant products PA·PB = PC·PD hold when the angles at P are π (interior crossing) or 0 (exterior crossing)."
+    },
+    {
+      "id": "power-invariant",
+      "title": "The Power Invariant and Line-Independence",
+      "startLine": 75,
+      "endLine": 107,
+      "summary": "mul_dist_eq_abs_power is the keystone: PA·PB = |power P| for any line through P meeting the sphere. Line-independence (mul_dist_eq_mul_dist_of_mem_sphere) follows by rewriting two products to the same |power P|. The signed forms record PA·PB = power for exterior points (mul_dist_eq_power_outside) and = −power for interior points (mul_dist_eq_neg_power_inside)."
+    },
+    {
+      "id": "tangents",
+      "title": "Tangent–Secant and Equal Tangents",
+      "startLine": 109,
+      "endLine": 128,
+      "summary": "tangent_sq_eq_secant_product gives tangent² = PA·PB from the power equality at a tangent point. dist_tangent_eq_of_tangent derives the Equal Tangents Theorem: both squared tangent lengths equal the power, and squaring is injective on nonnegative reals (pow_left_inj₀), so the tangent lengths coincide — a derivation not packaged as a single Mathlib lemma."
+    },
+    {
+      "id": "concrete-witness",
+      "title": "A Concrete Witness in ℂ",
+      "startLine": 130,
+      "endLine": 165,
+      "summary": "The unit circle in ℂ with perpendicular diameters [1,−1] and [I,−I] crossing at 0. cospherical_unit places the four points on the circle; center_mem_diam_re/_im put the centre on each diameter via AffineMap.lineMap at parameter 1/2; concrete_intersecting_chords verifies 1·1 = 1·1, instantiating the abstract theorem on an explicit configuration."
+    }
+  ],
+  "conclusion": {
+    "summary": "A coordinate-free Power of a Point package over an arbitrary real inner-product space, organized around the single invariant PA·PB = |power P|. From it the entry derives the Intersecting Chords Theorem (Freek No. 55), Intersecting Secants, the signed exterior/interior forms, the Tangent–Secant relation, and the Equal Tangents Theorem, plus a fully explicit ℂ witness. 12 theorems, 0 definitions, 0 axioms, 0 sorries, verified to depend only on propext / Classical.choice / Quot.sound.",
+    "implications": "By routing every classical distance-product result through Mathlib's power/product sphere API — previously unused in the gallery — the entry shows these theorems are not separate facts but readings of one scalar invariant, and it makes them dimension-free: the same proofs apply in the plane, in space, and in ℝⁿ. It complements the gallery's additive Ptolemy entry (AC·BD = AB·CD + AD·BC) and its 2D Vec2 chord-product proof, exhibiting the multiplicative half of the circle-distance theory in maximal generality.",
+    "openQuestions": [
+      "Can the power invariant be promoted to the radical axis / radical center theory — the locus of points of equal power with respect to two or three spheres — and formalized coordinate-free in the same generality?",
+      "Does an inversive-distance or cross-ratio formulation unify the additive Ptolemy relation and the multiplicative power-of-a-point relation under a single projective invariant?",
+      "What is the sharp generalization of Equal Tangents to higher dimension — the cone of tangent lines from an external point to a sphere in ℝⁿ — and can its 'equal tangent length' content be stated via the power alone?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "product-of-segments-of-chords",
+      "relationship": "related",
+      "description": "The gallery's 2-dimensional coordinate (Vec2) proof of the chord-segment product. This entry proves the same Intersecting Chords content coordinate-free in any dimension via Mathlib's power invariant, deliberately using a disjoint set of lemmas."
+    },
+    {
+      "targetId": "product-of-segments-of-chords-oq-01",
+      "relationship": "related",
+      "description": "A 3D / general-dimension generalization of the chord-segment product. This entry reaches arbitrary real inner-product spaces through the abstract power-of-a-point API rather than explicit coordinates."
+    },
+    {
+      "targetId": "ptolemys-theorem",
+      "relationship": "extends",
+      "description": "The additive Ptolemy relation AC·BD = AB·CD + AD·BC for a cyclic quadrilateral. As open question oq-04 of the Ptolemy family, this entry develops the complementary multiplicative theory of distances from a fixed point to a circle: PA·PB = |power P|."
+    },
+    {
+      "targetId": "ptolemys-theorem-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The spherical-geometry extension of Ptolemy. Both entries push circle/distance theorems beyond the classical 2D Euclidean setting; this one stays in flat inner-product spaces but works in every dimension at once via the power invariant."
+    }
+  ],
+  "references": [
+    {
+      "title": "Power of a point",
+      "url": "https://en.wikipedia.org/wiki/Power_of_a_point"
+    },
+    {
+      "title": "Intersecting chords theorem (Euclid, Elements III.35; Freek/Wiedijk No. 55)",
+      "url": "https://en.wikipedia.org/wiki/Intersecting_chords_theorem"
+    },
+    {
+      "title": "Mathlib: EuclideanGeometry.Sphere.power and the product/power lemmas",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Geometry/Euclidean/Sphere/Power.html"
+    },
+    {
+      "title": "Jakob Steiner and the systematic theory of the power of a point",
+      "url": "https://en.wikipedia.org/wiki/Radical_axis"
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `ptolemys-theorem-oq-04` (quality 10, passes 0). The entry had a good description and partial overview but was missing reader-facing depth: no proofStrategy/keyInsights, no sections, no conclusion, no cross-references, and no annotations.

## Added to meta.json
- **overview.proofStrategy** — the invariant-first organization (power → keystone PA·PB = |power P| → line-independence → classical corollaries → signed forms → tangents → ℂ witness).
- **overview.keyInsights** — 5 insights (single scalar controls everything; dimension-free via NormedAddTorsor; geometric meaning of the power's sign; Equal Tangents as invariant + injectivity; deliberate use of previously-unused Mathlib power API).
- **sections** — 4, covering all 165 lines.
- **conclusion** — summary, implications, and 3 open questions (radical axis/center, inversive-distance/cross-ratio unification of additive Ptolemy + multiplicative power, higher-dimensional Equal Tangents).
- **crossReferences** — 4 (`product-of-segments-of-chords` ×2, `ptolemys-theorem`, `ptolemys-theorem-oq-01-oq-02`).
- **references** — 4 (Power of a point, Intersecting chords / Freek No. 55, Mathlib Sphere.Power, Steiner/radical axis).

## Added annotations.json (7 annotations)
Intersecting Chords, Intersecting Secants, the power invariant + line-independence, signed inside/outside forms, Tangent–Secant + Equal Tangents, and the explicit ℂ witness — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on the relevant declarations.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

## Axiom integrity
Unchanged and accurate: `status: verified`, `badge: verified`, `axiomCount: 0`, `sorries: 0` — `PtolemysTheoremOQ04.lean` has no `axiom`/`sorry`/`native_decide`; all results derive from Mathlib's Sphere.power API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)