### PR TITLE
Enrich Γ(1/2)=√π (area-of-circle-oq-07-oq-03)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "special-value",
+    "proofId": "area-of-circle-oq-07-oq-03",
+    "range": { "startLine": 35, "endLine": 37 },
+    "type": "concept",
+    "title": "Γ(1/2) = √π — Euler's Archetypal Special Value",
+    "content": "`gamma_one_half_eq_sqrt_pi` restates Mathlib's `Real.Gamma_one_half_eq`: the Euler Gamma function Γ(s) = ∫₀^∞ u^{s−1} e^{−u} du, evaluated at s = 1/2, equals √π. This is the canonical non-integer value of the factorial's analytic continuation, and the first place the circle constant π appears in the theory of Γ. The whole entry is anchored on this one line — the remaining theorems exhibit the same √π from the Gaussian side.",
+    "mathContext": "$\\Gamma(1/2) = \\int_0^\\infty u^{-1/2}e^{-u}\\,du = \\sqrt{\\pi}$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler Gamma function", "special values", "factorial interpolation"],
+    "prerequisites": ["Gamma function", "improper integrals"]
+  },
+  {
+    "id": "full-line-bridge",
+    "proofId": "area-of-circle-oq-07-oq-03",
+    "range": { "startLine": 39, "endLine": 47 },
+    "type": "insight",
+    "title": "Γ(1/2) Is Literally the Gaussian Integral",
+    "content": "`gamma_one_half_eq_gaussian` identifies Γ(1/2) with the full-line Gaussian integral ∫_ℝ e^{−x²} — the exact quantity the parent entry area-of-circle-oq-07 proves equal to √π. The proof rewrites Γ(1/2) to √π via the special value, then matches Mathlib's `integral_gaussian` at b = 1 (after `simp` normalizes the coefficient −1·x² and the ratio π/1). This makes explicit that the two famous √π's — Gamma's special value and the Gaussian normalization — are the same number, not merely numerically equal.",
+    "mathContext": "$\\Gamma(1/2) = \\int_{\\mathbb{R}} e^{-x^2}\\,dx = \\sqrt{\\pi}$ (via `integral_gaussian` at $b=1$).",
+    "significance": "key",
+    "relatedConcepts": ["Gaussian integral", "Poisson integral", "identification of constants"],
+    "prerequisites": ["Gaussian integral", "Lebesgue integration"]
+  },
+  {
+    "id": "half-line-substitution",
+    "proofId": "area-of-circle-oq-07-oq-03",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "technique",
+    "title": "The Half-Line Form: Image of u = x²",
+    "content": "`gamma_one_half_eq_two_mul_gaussian_Ioi` records Γ(1/2) = 2·∫_{x>0} e^{−x²}. This is the faithful image of the substitution u = x² in Γ(1/2) = ∫₀^∞ u^{−1/2} e^{−u} du: with du = 2x dx and u^{−1/2} = x^{−1}, the integrand becomes 2 e^{−x²} on the positive half-line, and even symmetry then folds it onto the full line. The proof uses Mathlib's `integral_gaussian_Ioi` at b = 1 (value √π/2) and closes with `ring` to supply the factor 2 — surfacing the very change of variables that Mathlib performs internally to prove the special value.",
+    "mathContext": "$\\Gamma(1/2) = 2\\int_0^\\infty e^{-x^2}\\,dx$; substitution $u=x^2$, $du=2x\\,dx$, $u^{-1/2}=x^{-1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["change of variables", "half-line integral", "even symmetry"],
+    "prerequisites": ["substitution rule", "improper integrals"]
+  },
+  {
+    "id": "squared-form",
+    "proofId": "area-of-circle-oq-07-oq-03",
+    "range": { "startLine": 59, "endLine": 62 },
+    "type": "concept",
+    "title": "Γ(1/2)² = π — the Circle Constant Returns",
+    "content": "`gamma_one_half_sq` squares the special value to recover π itself: Γ(1/2)² = π, with `Real.sq_sqrt` discharging (√π)² = π from π ≥ 0. This is the Gamma-function counterpart of the parent entry's squared Gaussian identity (∫_ℝ e^{−x²})² = π — both routes extract the area constant π from a one-dimensional exponential integral, mirroring Poisson's squaring trick that produces a 2D integral over the plane.",
+    "mathContext": "$\\Gamma(1/2)^2 = (\\sqrt{\\pi})^2 = \\pi$, the same $\\pi$ as $(\\int_{\\mathbb{R}} e^{-x^2})^2 = \\pi$.",
+    "significance": "supporting",
+    "relatedConcepts": ["circle constant", "Poisson squaring trick", "Beta function B(1/2,1/2)=π"],
+    "prerequisites": ["square roots", "nonnegativity of π"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03/meta.json
@@ -19,6 +19,7 @@
     "sorries": 0
   },
   "title": "Γ(1/2) = √π: the Gamma-Function Shadow of the Gaussian Integral",
+  "description": "The Euler Gamma function at 1/2 equals √π — the same number as the parent entry's Gaussian integral ∫_ℝ e^{-x²} = √π. This short entry records Mathlib's special value Real.Gamma_one_half_eq and adds two bridges making the identification explicit: Γ(1/2) = ∫_ℝ e^{-x²} (full line) and Γ(1/2) = 2·∫_{x>0} e^{-x²} (half line, the image of the substitution u = x² that underlies the value), plus the squared form Γ(1/2)² = π. An honest Tier-B (mathlib badge) consequence of existing library results, valued for tying the factorial-interpolation viewpoint to the Gaussian-normalization viewpoint on a single √π.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -68,6 +69,47 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The Gamma function Γ(s) = ∫₀^∞ u^{s−1} e^{−u} du was introduced by Leonhard Euler around 1729 (in correspondence with Goldbach) to interpolate the factorial: Γ(n+1) = n!. Its archetypal non-integer special value is Γ(1/2) = √π, the first hint that the factorial's analytic continuation entangles with the circle constant π. The same √π is the value of the Gaussian integral ∫_ℝ e^{−x²} dx, computed classically by Poisson's polar-coordinates trick (squaring the integral and passing to a 2D integral over the plane). That these two quantities coincide is not a coincidence: the substitution u = x² carries the integral defining Γ(1/2) directly onto the Gaussian. This entry sits in the area-of-circle family because the Gaussian normalization √π is, via polar coordinates, a cousin of the area constant π — the parent area-of-circle-oq-07 establishes ∫_ℝ e^{−x²} = √π, and this entry exhibits the same number from the Gamma side.",
+    "problemStatement": "**Open Question (oq-03)**: is the Gamma-function special value Γ(1/2) = √π literally the same number as the parent entry's Gaussian integral ∫_ℝ e^{−x²} = √π, and can the bridge be made explicit in Lean? Answer: yes. Γ(1/2) = ∫_ℝ e^{−x²} = 2·∫_{x>0} e^{−x²} = √π, and Γ(1/2)² = π.",
+    "proofStrategy": "Every result is a thin, honest wrapper over existing Mathlib lemmas — the entry's value is the explicit bridging, not new mathematics. (1) gamma_one_half_eq_sqrt_pi restates Mathlib's Real.Gamma_one_half_eq. (2) gamma_one_half_eq_gaussian rewrites Γ(1/2) to √π and matches it against integral_gaussian specialized at b = 1 (after simp normalizes −1·x² and π/1). (3) gamma_one_half_eq_two_mul_gaussian_Ioi does the same with integral_gaussian_Ioi (half-line, value √π/2), then `ring` supplies the factor 2 — this is the form that mirrors the u = x² substitution Mathlib uses internally to prove the special value. (4) gamma_one_half_sq squares the special value, with Real.sq_sqrt discharging (√π)² = π using π ≥ 0.",
+    "keyInsights": [
+      "Γ(1/2) = √π and the Gaussian ∫_ℝ e^{−x²} = √π are the SAME number, not merely numerically equal: the substitution u = x² maps Γ(1/2) = ∫₀^∞ u^{−1/2} e^{−u} du onto 2∫₀^∞ e^{−x²} = ∫_ℝ e^{−x²}.",
+      "The half-line form Γ(1/2) = 2·∫_{x>0} e^{−x²} is the faithful image of that substitution — it is where the change of variables lands before even symmetry folds it into the full line.",
+      "Squaring gives Γ(1/2)² = π, the Gamma-side counterpart of the parent's (∫_ℝ e^{−x²})² = π, both surfacing the circle constant π from a 1-D exponential integral.",
+      "The entry is deliberately honest about provenance: badge 'mathlib' (Tier B), because Real.Gamma_one_half_eq already proves the headline; the contribution is the explicit identification with the parent Gaussian, not an independent derivation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "special-value",
+      "title": "The Special Value Γ(1/2) = √π",
+      "startLine": 35,
+      "endLine": 37,
+      "summary": "gamma_one_half_eq_sqrt_pi restates Mathlib's Real.Gamma_one_half_eq: the Euler Gamma function at 1/2 evaluates to √π. The headline identity, recorded as the anchor for the Gaussian bridges that follow."
+    },
+    {
+      "id": "full-line-bridge",
+      "title": "Bridge to the Full-Line Gaussian",
+      "startLine": 39,
+      "endLine": 47,
+      "summary": "gamma_one_half_eq_gaussian identifies Γ(1/2) with ∫_ℝ e^{−x²}, the quantity the parent area-of-circle-oq-07 proves equal to √π. Proof rewrites Γ(1/2) to √π and matches integral_gaussian at b = 1 (simp normalizes −1·x² and π/1)."
+    },
+    {
+      "id": "half-line-bridge",
+      "title": "The Half-Line Form (the u = x² Substitution)",
+      "startLine": 49,
+      "endLine": 57,
+      "summary": "gamma_one_half_eq_two_mul_gaussian_Ioi records Γ(1/2) = 2·∫_{x>0} e^{−x²}, the direct image of the substitution u = x² in the integral defining Γ(1/2). Uses integral_gaussian_Ioi at b = 1 (value √π/2) and `ring` for the factor 2."
+    },
+    {
+      "id": "squared-form",
+      "title": "The Squared Identity Γ(1/2)² = π",
+      "startLine": 59,
+      "endLine": 62,
+      "summary": "gamma_one_half_sq squares the special value to recover the circle constant: Γ(1/2)² = π, with Real.sq_sqrt discharging (√π)² = π from π ≥ 0. The Gamma-function counterpart of the parent's squared Gaussian identity."
+    }
+  ],
   "openQuestions": [
     {
       "id": "area-of-circle-oq-07-oq-03-oq-01",


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-07-oq-03` (quality 15, passes 0). The entry had solid meta (originalContributions, conclusion, openQuestions, crossReferences, references) but no `description`, no `overview`, no `sections`, and no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary.
- **overview** — `historicalContext` (Euler ~1729, Γ as factorial interpolation, the u=x² link to the Gaussian √π, Poisson squaring), `problemStatement`, `proofStrategy`, and 4 `keyInsights`.
- **sections** — 4, covering all 62 lines (special value, full-line bridge, half-line substitution, squared form).

## Added annotations.json (4 annotations)
One per theorem — the special value Γ(1/2)=√π, the full-line Gaussian bridge, the half-line u=x² form, and Γ(1/2)²=π — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on the declarations.

## Provenance / axiom integrity
Framing kept deliberately honest and unchanged: `status: verified`, **`badge: mathlib` (Tier B)**, `axiomCount: 0`, `sorries: 0`. The headline Γ(1/2)=√π is Mathlib's `Real.Gamma_one_half_eq`; this entry's contribution is the explicit identification with the parent Gaussian integral, not an independent derivation — the enrichment states this rather than overclaiming originality.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)