### PR TITLE
Enrich Subordinate Finite ε-Nets (compactness-finite-subcover-oq-02)

### DIFF
--- a/src/data/proofs/compactness-finite-subcover-oq-02/annotations.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "subordinate-net",
+    "proofId": "compactness-finite-subcover-oq-02",
+    "range": { "startLine": 60, "endLine": 73 },
+    "type": "insight",
+    "title": "The Subordinate Net: Two Lemmas at One Radius",
+    "content": "`exists_subordinate_finite_ball_cover` is the headline and the conceptual heart. It first extracts a Lebesgue radius δ for the cover from `lebesgue_number_lemma_of_metric` (applied to the compact `univ`), so that every δ-ball lands inside some cover member U i. It then runs `exists_finite_cover_balls_of_isCompact_closure` at THAT SAME δ to get finitely many centers t whose δ-balls cover X. The two facts are compatible precisely because they share the radius δ: the balls both cover X (total boundedness) and refine the cover (Lebesgue). No single Mathlib lemma states this conjunction — the assembly is the content.",
+    "mathContext": "$\\exists\\,\\delta>0,\\ t$ finite: $\\bigcup_{x\\in t}B(x,\\delta)=X$ and $\\forall x\\in t,\\ \\exists i,\\ B(x,\\delta)\\subseteq U_i$.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue number lemma", "total boundedness", "ε-net", "subordinate cover"],
+    "prerequisites": ["compact metric spaces", "open covers", "metric balls"]
+  },
+  {
+    "id": "lebesgue-extract",
+    "proofId": "compactness-finite-subcover-oq-02",
+    "range": { "startLine": 66, "endLine": 73 },
+    "type": "technique",
+    "title": "Extracting δ and the Finite Net",
+    "content": "The proof body is a tight two-step. `lebesgue_number_lemma_of_metric isCompact_univ hU hsub` yields δ > 0 and the subordination witness `hlb`. Then `exists_finite_cover_balls_of_isCompact_closure` is invoked on `univ` (with `closure_univ` rewriting closure univ = univ so the relative-compactness hypothesis is just `isCompact_univ`) at radius δ, producing the finite center set t with htfin and htcov. The final term packages δ, t, positivity, finiteness, the cover equality (`univ_subset_iff.mp htcov`), and subordination (`fun x _ => hlb x (mem_univ x)`).",
+    "mathContext": "Lebesgue: $\\forall x,\\ \\exists i,\\ B(x,\\delta)\\subseteq U_i$. Total boundedness at $\\delta$: finite $t$ with $\\bigcup_{x\\in t}B(x,\\delta)\\supseteq X$.",
+    "significance": "technical",
+    "relatedConcepts": ["closure_univ", "isCompact_univ", "univ_subset_iff"],
+    "prerequisites": ["Mathlib metric API", "relative compactness"]
+  },
+  {
+    "id": "finite-subcover",
+    "proofId": "compactness-finite-subcover-oq-02",
+    "range": { "startLine": 79, "endLine": 93 },
+    "type": "technique",
+    "title": "Constructive Heine–Borel from the Net",
+    "content": "`exists_finite_subcover_via_net` recovers the finite subcover constructively. After making t a Finite subtype (`htfin.to_subtype`), `choose g hg` selects, for each center x ∈ t, a cover index g x with ball x δ ⊆ U (g x). The finite subfamily is then `range g` (finite since t is finite, via `Set.finite_range`). Covering is checked pointwise: any y lands in some net ball `ball x δ` (from htcov), which is inside U (g ⟨x,hx⟩), so y is covered. This derives Heine–Borel from the Lebesgue number rather than from abstract compactness — complementing the by-hand general-topology derivation in the sibling oq-01.",
+    "mathContext": "$\\exists\\,s\\subseteq\\iota$ finite: $\\bigcup_{i\\in s}U_i = X$, with $s=\\operatorname{range}g$ and $g$ chosen so $B(x,\\delta)\\subseteq U_{g(x)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Heine–Borel theorem", "choice function", "finite subcover", "range of a map"],
+    "prerequisites": ["axiom of choice (choose)", "finite types"]
+  },
+  {
+    "id": "fineness",
+    "proofId": "compactness-finite-subcover-oq-02",
+    "range": { "startLine": 99, "endLine": 107 },
+    "type": "concept",
+    "title": "Fineness: Controlled Diameters",
+    "content": "`exists_subordinate_fine_cover` reuses the same net and adds a diameter bound: `Metric.diam_ball` gives diam (ball x δ) ≤ 2δ for each member. So an arbitrary open cover refines to a finite cover by sets of uniformly small, controlled diameter, each still inside one cover element. This 'fineness' is the metric analogue of refining to an arbitrarily fine cover, and is the precise structure needed for Heine–Cantor uniform continuity (take the Lebesgue number of the cover by preimages of ε/2-balls) and for localizing bump functions in a partition of unity.",
+    "mathContext": "Each net member satisfies $\\operatorname{diam}\\,B(x,\\delta)\\le 2\\delta$ in addition to $B(x,\\delta)\\subseteq U_i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["diameter", "fine cover", "Heine–Cantor theorem", "partition of unity"],
+    "prerequisites": ["diameter of a set", "metric balls"]
+  }
+]

--- a/src/data/proofs/compactness-finite-subcover-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-02/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "Subordinate Finite ε-Nets on Compact Metric Spaces",
+  "description": "A metric-space refinement of compactness: every open cover U of a compact metric space admits a single Lebesgue radius δ > 0 and a finite set of centers whose δ-balls cover the space, with each ball lying inside one cover member (a subordinate finite ε-net). No single Mathlib lemma states this — it is the compatible pairing of the Lebesgue number lemma with a finite δ-net from total boundedness at that same radius. From the net the entry constructively re-derives the Heine–Borel finite subcover and adds a fineness refinement bounding each member's diameter by 2δ — the structure underlying Heine–Cantor uniform continuity and partitions of unity.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -73,6 +74,41 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Compactness has three classical faces on a metric space: every open cover has a finite subcover (Heine–Borel), every sequence has a convergent subsequence (Bolzano–Weierstrass), and the space is complete and totally bounded. The bridge between the covering face and the metric face is the Lebesgue number lemma (Henri Lebesgue, early 1900s): for any open cover of a compact metric space there is a δ > 0 so small that every set of diameter < δ — in particular every δ-ball — lies inside some single cover member. Combined with total boundedness (finitely many δ-balls cover the space), this yields finite ε-nets that are adapted to a prescribed cover. Such subordinate nets are the standard engine behind Heine–Cantor (continuous functions on compacta are uniformly continuous) and the construction of partitions of unity. This entry formalizes the subordinate net itself and reads the classical corollaries off it.",
+    "problemStatement": "**Open Question (oq-02)**: refine the finite-subcover characterization of compactness to the metric setting with explicit geometric control. Produce, for any open cover U of a compact metric space X, a uniform radius δ > 0 and a finite center set t such that the δ-balls about t cover X and each ball lies in some U i — and recover both the Heine–Borel finite subcover and a diameter-controlled (fine) refinement from that single net.",
+    "proofStrategy": "The whole entry rests on one compatibility observation. (1) `exists_subordinate_finite_ball_cover` extracts a Lebesgue radius δ from `lebesgue_number_lemma_of_metric` applied to the compact `univ`, then runs `exists_finite_cover_balls_of_isCompact_closure` at that SAME δ to get finitely many centers t whose δ-balls cover X; the Lebesgue property gives the subordination (each ball ⊆ some U i) for free. (2) `exists_finite_subcover_via_net` makes t a Finite subtype, uses `choose` to pick for each center a containing cover member g, and shows `range g` is a finite subfamily covering X — a constructive Heine–Borel from the net rather than from abstract compactness. (3) `exists_subordinate_fine_cover` augments the net with `Metric.diam_ball`, bounding each member's diameter by 2δ. The mathematical content is the COMBINATION; no Mathlib lemma packages it.",
+    "keyInsights": [
+      "The crux is running the Lebesgue number lemma and total boundedness at the SAME radius δ: the Lebesgue δ makes every δ-ball subordinate to the cover, and total boundedness at δ makes finitely many δ-balls suffice — neither lemma alone yields the subordinate net.",
+      "The Heine–Borel finite subcover is recovered CONSTRUCTIVELY: `choose` selects, for each of finitely many net balls, a cover member containing it, so the finite subfamily is the explicit range of that choice function — not an existence pulled from abstract compactness.",
+      "Subordination plus a uniform radius is strictly more than a bare finite subcover: it is exactly the geometric control (a single δ that works everywhere, each piece inside one cover element) that powers Heine–Cantor uniform continuity and partitions of unity.",
+      "The fineness corollary (diam ≤ 2δ) shows an arbitrary open cover can be refined to a finite cover by sets of uniformly small, controlled diameter — the metric analogue of refining to an arbitrarily fine cover.",
+      "Honest provenance: the ingredients (Lebesgue number, total boundedness) are Mathlib's, hence the 'mathlib' badge; the formalized content is their compatible assembly and the constructive corollaries, not the ingredients themselves."
+    ]
+  },
+  "sections": [
+    {
+      "id": "subordinate-net",
+      "title": "The Subordinate Finite ε-Net",
+      "startLine": 56,
+      "endLine": 73,
+      "summary": "exists_subordinate_finite_ball_cover, the headline: a Lebesgue radius δ from lebesgue_number_lemma_of_metric (on the compact univ) is fed to exists_finite_cover_balls_of_isCompact_closure at the same δ, producing finitely many centers whose δ-balls cover X, each ball subordinate to some cover member. The compatibility of the two lemmas at one radius is the whole content."
+    },
+    {
+      "id": "finite-subcover",
+      "title": "Finite Subcover Re-Derived Through the Net",
+      "startLine": 75,
+      "endLine": 93,
+      "summary": "exists_finite_subcover_via_net recovers Heine–Borel constructively: with t made a Finite subtype, `choose` picks for each net ball a containing cover member g, and `range g` is shown to be a finite subfamily of U covering X — the finite subcover obtained from the Lebesgue number rather than abstract compactness."
+    },
+    {
+      "id": "fineness",
+      "title": "The Fineness Refinement (diam ≤ 2δ)",
+      "startLine": 95,
+      "endLine": 107,
+      "summary": "exists_subordinate_fine_cover augments the net with Metric.diam_ball, bounding each member's diameter by 2δ. An arbitrary open cover thus refines to a finite cover by sets of uniformly small controlled diameter, each inside one cover element — the structure behind uniform continuity and partitions of unity."
+    }
+  ],
   "openQuestions": [
     {
       "id": "compactness-finite-subcover-oq-02-oq-01",


### PR DESCRIPTION
Enrichment pass for `compactness-finite-subcover-oq-02` (quality 15, passes 0). Solid meta existed, but no `description`, no `overview`, no `sections`, no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary.
- **overview** — `historicalContext` (three faces of compactness; Lebesgue number lemma; total boundedness; Heine–Cantor / partitions of unity), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** — 3, covering all 109 lines (subordinate net, constructive Heine–Borel via the net, fineness refinement).

## Added annotations.json (4 annotations)
The subordinate net (two lemmas at one radius), the δ/finite-net extraction body, the constructive Heine–Borel `choose`/`range g` derivation, and the fineness (diam ≤ 2δ) corollary — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on declarations.

## Provenance / axiom integrity
Unchanged and accurate: `status: verified`, **`badge: mathlib` (Tier B)**, `axiomCount: 0`, `sorries: 0`. The ingredients (Lebesgue number lemma, total boundedness) are Mathlib's; the formalized content is their compatible assembly into a subordinate net plus the constructive subcover and fineness corollaries — the enrichment states this explicitly rather than overclaiming.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)