### PR TITLE
Enrich: Geometric Series at the Boundary (Abel Summability)

### DIFF
--- a/src/data/proofs/geometric-series-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-gsoq03-eventually",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 47, "endLine": 63 },
+    "type": "technique",
+    "title": "Filter setup: near 1 from below, |x| < 1",
+    "content": "The helper abs_lt_one_eventually packages the basic fact driving every closed-form step: as x → 1⁻, eventually |x| < 1, so each geometric Abel function ∑ aₙ xⁿ converges. It combines x < 1 (from self_mem_nhdsWithin on the left-neighborhood filter 𝓝[<] 1) with −1 < x (an open condition pulled back through nhdsWithin_le_nhds). Working with the filter 𝓝[<] 1 rather than a sequence is what lets the proof speak of the radial limit x → 1⁻ directly.",
+    "mathContext": "$\\forall^f x \\in \\mathcal{N}^{<}(1),\\ |x| < 1$ — the eventual hypothesis for $\\sum a_n x^n$ to converge.",
+    "significance": "technical",
+    "relatedConcepts": ["filter", "neighborhood within", "left limit", "eventually"],
+    "prerequisites": ["filters", "topology of ℝ"]
+  },
+  {
+    "id": "ann-gsoq03-predicate",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 65, "endLine": 82 },
+    "type": "definition",
+    "title": "The Abel-summability predicate and uniqueness",
+    "content": "AbelSummableTo a L is the boundary regularization at the heart of the entry: the power series A(x) = ∑ₙ aₙ xⁿ converges for every x ∈ [0,1), and its value tends to L as x → 1⁻. This is the converse of Abel's continuity theorem used as a summation method. abelSummableTo_unique shows the assigned value is well-defined: since the left-neighborhood filter 𝓝[<] 1 is nontrivial (NeBot) and ℝ is Hausdorff, tendsto_nhds_unique forces any two Abel sums to coincide.",
+    "mathContext": "$a$ is Abel summable to $L$ iff $\\sum_n a_n x^n$ converges on $[0,1)$ and $\\sum_n a_n x^n \\to L$ as $x \\to 1^-$; the value is unique.",
+    "significance": "key",
+    "relatedConcepts": ["Abel summation", "divergent series", "summability method", "regularization", "uniqueness of limits"],
+    "prerequisites": ["power series", "summability", "Abel's theorem"]
+  },
+  {
+    "id": "ann-gsoq03-grandi-hassum",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 93 },
+    "type": "concept",
+    "title": "Grandi's Abel function: ∑ (−1)ⁿ xⁿ = 1/(1+x)",
+    "content": "grandi_abel_hasSum computes the closed form of the Abel function of Grandi's series 1 − 1 + 1 − ⋯. Recognizing (−1)ⁿ xⁿ = (−x)ⁿ, it reduces to Mathlib's geometric-series sum hasSum_geometric_of_abs_lt_one at ratio −x (valid since |−x| = |x| < 1), giving 1/(1−(−x)) = 1/(1+x). This is the analytic object whose radial limit at 1 will deliver Euler's regularized value.",
+    "mathContext": "$\\sum_n (-1)^n x^n = \\sum_n (-x)^n = \\frac{1}{1+x}$ for $|x| < 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Grandi's series", "geometric series", "power series", "Euler regularization"],
+    "prerequisites": ["geometric series", "power series"]
+  },
+  {
+    "id": "ann-gsoq03-grandi-half",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 95, "endLine": 118 },
+    "type": "insight",
+    "title": "Grandi is Abel summable to 1/2 (matching Cesàro and Euler)",
+    "content": "grandi_abel_tendsto takes the left-limit of 1/(1+x) at x = 1 by continuity of inversion (Tendsto.inv₀, since 1 + x → 2 ≠ 0), giving 1/2; the congr' step rewrites the tsum to the closed form on the eventual |x| < 1 set. grandi_abelSummableTo_half then bundles convergence on [0,1) with this limit to conclude Grandi is Abel summable to 1/2. This recovers exactly the parent entry's Cesàro mean and Euler's celebrated value 1 − 1 + 1 − ⋯ = 1/2 — by a genuinely different mechanism (radial limit of a power series vs. average of partial sums).",
+    "mathContext": "$\\lim_{x\\to 1^-} \\frac{1}{1+x} = \\frac{1}{2}$, so $1 - 1 + 1 - \\cdots \\overset{A}{=} \\frac12$.",
+    "significance": "key",
+    "relatedConcepts": ["Grandi's series", "Cesàro summation", "Abel summation", "Euler", "radial limit"],
+    "prerequisites": ["limits", "continuity", "summability methods"]
+  },
+  {
+    "id": "ann-gsoq03-r1-diverges",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 120, "endLine": 155 },
+    "type": "insight",
+    "title": "r = 1 is NOT Abel summable — the boundary discriminator",
+    "content": "one_abel_tendsto_atTop shows the Abel function of the constant sequence 1, namely ∑ₙ xⁿ = 1/(1−x), diverges to +∞ as x → 1⁻: the map x ↦ 1−x carries 𝓝[<] 1 to 𝓝[>] 0, and inversion sends 𝓝[>] 0 to atTop (tendsto_inv_nhdsGT_zero). one_not_abelSummable then rules out any finite Abel sum via not_tendsto_nhds_of_tendsto_atTop on the NeBot filter — a function cannot tend to both +∞ and a finite L. Crucially this refines the parent's blanket '|r| ≥ 1 ⇒ not summable': Abel summation discriminates between r = −1 (summable to 1/2) and r = 1 (genuinely divergent), keeping the truly divergent boundary point divergent.",
+    "mathContext": "$\\sum_n x^n = \\frac{1}{1-x} \\to +\\infty$ as $x \\to 1^-$, so $r = 1$ has no Abel sum.",
+    "significance": "key",
+    "relatedConcepts": ["divergent series", "Abel summation", "limit at infinity", "boundary behavior"],
+    "prerequisites": ["limits", "filters", "summability"]
+  },
+  {
+    "id": "ann-gsoq03-geom-limit",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 157, "endLine": 198 },
+    "type": "concept",
+    "title": "The general Abel function: ∑ rⁿ xⁿ = 1/(1−rx) → 1/(1−r)",
+    "content": "For |r| < 1, geom_abel_hasSum sums the Abel function ∑ₙ rⁿ xⁿ = ∑ₙ (rx)ⁿ = 1/(1−rx) (valid because |rx| ≤ |r| < 1), and geom_abel_tendsto takes its left-limit at x = 1 by continuity of inversion at 1 − r ≠ 0, yielding 1/(1−r). geom_abelSummableTo packages convergence on [0,1) with this limit, establishing Abel summability of rⁿ to 1/(1−r) for every |r| < 1.",
+    "mathContext": "$\\sum_n r^n x^n = \\frac{1}{1-rx} \\to \\frac{1}{1-r}$ as $x \\to 1^-$, for $|r| < 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["geometric series", "Abel summation", "radial limit", "continuity of inversion"],
+    "prerequisites": ["geometric series", "limits", "power series"]
+  },
+  {
+    "id": "ann-gsoq03-regular",
+    "proofId": "geometric-series-oq-01-oq-03",
+    "range": { "startLine": 200, "endLine": 205 },
+    "type": "insight",
+    "title": "Regularity: the Abel sum equals the ordinary sum",
+    "content": "geom_abel_regular is the consistency theorem: for |r| < 1 the Abel sum of rⁿ equals its ordinary sum ∑ₙ rⁿ = 1/(1−r). A summability method is called regular when it reproduces ordinary sums wherever those exist; this proves Abel summation regular on the geometric family. The conceptual payoff: Abel summation never contradicts convergence — it only extends it to divergent boundary cases like Grandi — placing it as the third regularization lens (after divergence analysis and Cesàro) that all agree on 1/2.",
+    "mathContext": "For $|r| < 1$: Abel sum of $r^n$ $= \\sum_n r^n = \\frac{1}{1-r}$ — Abel summation is regular.",
+    "significance": "key",
+    "relatedConcepts": ["regularity of summation", "Abel summation", "geometric series", "Frobenius theorem", "Cesàro summation"],
+    "prerequisites": ["summability methods", "geometric series"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03/meta.json
@@ -20,6 +20,63 @@
     "sorries": 0
   },
   "title": "Geometric Series at the Boundary: Abel Summability",
+  "description": "At the critical boundary |r| = 1 of the geometric series, this entry develops Abel summability — the third regularization lens after divergence analysis and the parent's Cesàro mean. A sequence is Abel summable to L when its power series ∑ₙ aₙ xⁿ converges on [0,1) and tends to L as x → 1⁻. Three boundary outcomes: Grandi's series 1 − 1 + 1 − ⋯ has Abel function 1/(1+x) → 1/2 (matching Euler and Cesàro); r = 1 has Abel function 1/(1−x) → +∞ (no Abel sum); and for |r| < 1 the Abel sum 1/(1−r) equals the ordinary sum (regularity). 205 lines, 10 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Niels Henrik Abel proved in 1826 (in his memoir on the binomial series, Crelle's Journal vol. 1) what is now called Abel's continuity theorem: if ∑ₙ aₙ converges to L, then the power series ∑ₙ aₙ xⁿ tends to L as x → 1⁻. Reading this implication backwards turns it into a summation method — Abel summation — that can assign finite values to certain divergent series. Like Cesàro's method of arithmetic means, Abel's method is regular (it reproduces ordinary sums) and assigns Grandi's series 1 − 1 + 1 − ⋯ the value 1/2, the same value Euler had defended on formal grounds via 1/(1+x) at x = 1. Frobenius (1880) showed Abel summation strictly dominates Cesàro: every Cesàro-summable series is Abel summable to the same value, but not conversely. The classical theory of these regular linear summation methods and their inclusions is the subject of G. H. Hardy's Divergent Series (1949). This entry formalizes the Abel lens on the geometric boundary |r| = 1, complementing the parent entry's Cesàro treatment.",
+    "problemStatement": "Define Abel summability at the boundary and determine the Abel behaviour of the geometric sequence rⁿ at |r| = 1: show Grandi's series (r = −1) is Abel summable to 1/2, that r = 1 is Abel summable to no value, and that for |r| < 1 the method is regular (Abel sum = ordinary sum 1/(1−r)).",
+    "proofStrategy": "Each Abel function is a geometric power series in the auxiliary variable x, summed in closed form by Mathlib's hasSum_geometric_of_abs_lt_one: ∑(−x)ⁿ = 1/(1+x), ∑xⁿ = 1/(1−x), ∑(rx)ⁿ = 1/(1−rx), all valid on the eventual set |x| < 1 near x = 1⁻ (the helper abs_lt_one_eventually). The radial limits x → 1⁻ are then computed on the left-neighborhood filter 𝓝[<] 1: continuity of inversion (Tendsto.inv₀) gives the finite limits 1/2 and 1/(1−r), while x ↦ 1−x mapping 𝓝[<] 1 to 𝓝[>] 0 plus tendsto_inv_nhdsGT_zero gives the +∞ divergence at r = 1. Uniqueness of the Abel sum follows from Hausdorffness and the NeBot of 𝓝[<] 1; non-summability at r = 1 from not_tendsto_nhds_of_tendsto_atTop.",
+    "keyInsights": [
+      "Abel summation is built from a different object than Cesàro — the radial limit of a power series rather than the average of partial sums — yet agrees with it on Grandi's series, both giving 1/2. Distinct constructions, same regularized value.",
+      "Abel summation discriminates between the two boundary ratios: r = −1 regularizes to 1/2, but r = 1 stays divergent (its Abel function 1/(1−x) blows up). This refines the parent's blanket '|r| ≥ 1 ⇒ not summable' into a finer classification.",
+      "Regularity (geom_abel_regular) is the crucial sanity check: for |r| < 1 the Abel sum equals the ordinary sum 1/(1−r), so the method extends ordinary convergence without ever contradicting it.",
+      "The proofs are entirely filter-theoretic: the boundary limit x → 1⁻ is the left-neighborhood filter 𝓝[<] 1, and every result is a Tendsto statement, sidestepping any explicit sequence of partial sums.",
+      "The whole development reduces to one Mathlib lemma (the geometric sum) plus continuity of inversion — the analytic content of Abel's method on the geometric family is exactly the boundary behaviour of x ↦ 1/(1−rx)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "intro",
+      "title": "Overview: Abel summability at the boundary",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "The file docstring: the geometric series at |r| = 1, the three regularization lenses (divergence, the parent's Cesàro mean, and Abel summability), the definition of Abel summability, the three outcomes proved (Grandi → 1/2, r = 1 divergent, |r| < 1 regular), and the historical context (Abel 1826, Frobenius, Hardy)."
+    },
+    {
+      "id": "setup",
+      "title": "Filter setup",
+      "startLine": 47,
+      "endLine": 63,
+      "summary": "Namespace, open Filter Topology, and the helper abs_lt_one_eventually: near 1 from below, eventually |x| < 1 — the hypothesis that makes every geometric Abel function converge, expressed on the left-neighborhood filter 𝓝[<] 1."
+    },
+    {
+      "id": "predicate",
+      "title": "The Abel-summability predicate",
+      "startLine": 65,
+      "endLine": 82,
+      "summary": "AbelSummableTo a L: the power series ∑ₙ aₙ xⁿ converges on [0,1) and tends to L as x → 1⁻. abelSummableTo_unique proves the assigned value is unique (Hausdorff + NeBot of 𝓝[<] 1)."
+    },
+    {
+      "id": "grandi",
+      "title": "Grandi's series is Abel summable to 1/2",
+      "startLine": 84,
+      "endLine": 118,
+      "summary": "grandi_abel_hasSum: ∑ₙ (−1)ⁿ xⁿ = 1/(1+x); grandi_abel_tendsto: its left-limit at 1 is 1/2 (continuity of inversion); grandi_abelSummableTo_half: Grandi is Abel summable to 1/2, matching Euler and the parent's Cesàro mean."
+    },
+    {
+      "id": "r-equals-one",
+      "title": "r = 1 is not Abel summable",
+      "startLine": 120,
+      "endLine": 155,
+      "summary": "one_abel_tendsto_atTop: ∑ₙ xⁿ = 1/(1−x) → +∞ as x → 1⁻ (via tendsto_inv_nhdsGT_zero); one_not_abelSummable: no finite Abel sum exists, refining the parent's blanket non-summability and discriminating r = 1 from r = −1."
+    },
+    {
+      "id": "regularity",
+      "title": "Abel summability is regular for |r| < 1",
+      "startLine": 157,
+      "endLine": 205,
+      "summary": "geom_abel_hasSum / geom_abel_tendsto: ∑ₙ rⁿ xⁿ = 1/(1−rx) → 1/(1−r); geom_abelSummableTo and the capstone geom_abel_regular: the Abel sum equals the ordinary sum ∑ₙ rⁿ, so Abel summation extends ordinary convergence without contradicting it."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-01-oq-03`.

This entry had a rich `meta.meta` block and a `conclusion`, but no top-level `description`, no `overview`, an empty `sections` array, and no `annotations.json`. Added all four:

- **`description`** — concise summary of Abel summability at the |r| = 1 boundary and the three outcomes.
- **`overview`** — `historicalContext` (Abel 1826, Frobenius's Abel ⊋ Cesàro, Hardy's *Divergent Series*), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **`sections`** — 6 sections covering all 205 lines (overview, filter setup, the predicate, Grandi → 1/2, r = 1 divergence, regularity).
- **`annotations.json`** — 7 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, mapped to declaration ranges: the 𝓝[<]1 filter setup, the `AbelSummableTo` definition + uniqueness, Grandi's 1/(1+x) → 1/2, the r=1 1/(1−x) → +∞ non-summability, the general 1/(1−rx) → 1/(1−r) limit, and regularity.

**Verification:** both files are valid JSON; `annotations:validate` reports no line-resolution warnings — every range resolves to a Lean construct. Content added only; nothing deleted.