### PR TITLE
research(algebraic-reals-meager-oq-03): measure & category are orthogonal — a meagre set of full measure + Oxtoby decomposition ℝ = meagre ⊔ null [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -56,6 +56,8 @@ import Proofs.AlgebraicNumbersCountableOQ02OQ04
 import Proofs.AlgebraicNumbersCountableOQ04
 import Proofs.AlgebraicNumbersCountableOQ05
 import Proofs.AlgebraicRealsMeager
+import Proofs.AlgebraicRealsMeagerOQ02
+import Proofs.AlgebraicRealsMeagerOQ03
 import Proofs.AlgebraicRealsNull
 import Proofs.AlternatingSeriesTestOQ01
 import Proofs.AmgmInequalityOQ02

--- a/proofs/Proofs/AlgebraicRealsMeagerOQ03.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ03.lean
@@ -1,0 +1,146 @@
+import Proofs.AlgebraicRealsMeagerOQ02
+
+/-!
+# Measure and Category are Orthogonal: a Meagre Set of Full Measure
+
+## Open Question (algebraic-reals-meager — OQ-03)
+
+The parent entry `algebraic-reals-meager` proves the algebraic reals are **meagre**
+(topologically small) and the companion `algebraic-reals-meager-oq-02` adds the
+**measure** pillar: they are Lebesgue-null, and — via the Liouville numbers — a set can
+be *comeagre yet null* (`exists_residual_dense_null`). That settles one half of the
+independence of the two notions of smallness: **category-large ⇏ measure-large**.
+
+OQ-03 asks for the dual witness and the sharpest structural form:
+
+> "Construct a meagre set of full Lebesgue measure (and a null comeagre set) to show
+>  measure-smallness and category-smallness are genuinely independent on ℝ."
+
+This entry supplies the missing dual direction and packages the whole picture as the
+classical **Lebesgue–Baire orthogonality** of Oxtoby (*Measure and Category*, Thm 1.6):
+the real line splits into two complementary "small" pieces — one topologically small,
+the other measure-theoretically small.
+
+    ℝ  =  A  ⊔  B          with   A meagre   and   B Lebesgue-null.
+
+Concretely `B` is the Liouville numbers (a dense comeagre null set, from OQ-02) and
+`A = Bᶜ` is its complement: a **meagre set of full Lebesgue measure**. The two ideals
+of "smallness" are therefore orthogonal — neither contains the other, and together a
+meagre set and a null set can cover the entire line.
+
+## Main Results
+
+* `meagre_conull_compl_of_residual_null` — abstract engine: a residual null set has a
+  meagre complement of full measure, and the two partition the space (no measurability
+  needed — only countable subadditivity of the outer measure).
+* `real_meagre_null_decomposition` — **headline.** `ℝ = A ⊔ B` with `A` meagre and
+  `B` null: the Oxtoby orthogonal decomposition.
+* `exists_meagre_conull` — the explicitly requested object: a meagre set of full
+  Lebesgue measure (`volume A = volume univ`, equivalently `volume Aᶜ = 0`).
+* `meagre_not_imp_null` / `null_not_imp_meagre` — the two independence non-implications,
+  dual to each other; together they show measure-smallness and category-smallness are
+  logically independent.
+* `oq03_resolution` — the combined statement.
+
+The two non-implications are genuinely dual: OQ-02's `exists_residual_dense_null` gives a
+*comeagre* set that is *null* (category-large but measure-small); here `meagre_not_imp_null`
+gives a *meagre* set that is *conull* (category-small but measure-large).
+-/
+
+open MeasureTheory Filter Set AlgebraicRealsMeagerOQ02
+
+namespace AlgebraicRealsMeagerOQ03
+
+/-- Shorthand for the Liouville numbers, our separating set. -/
+abbrev 𝓛 : Set ℝ := {x : ℝ | Liouville x}
+
+/-! ## The abstract orthogonality engine -/
+
+/-- **Measure–category orthogonality (general form).** If `S` is residual (comeagre) and
+Lebesgue-null, then its complement `Sᶜ` is meagre, has full measure, and the pair
+`Sᶜ, S` partitions `ℝ`. The full-measure claim uses only countable subadditivity of the
+outer measure `volume`, so no measurability hypothesis on `S` is required. -/
+theorem meagre_conull_compl_of_residual_null {S : Set ℝ}
+    (hres : S ∈ residual ℝ) (hnull : volume S = 0) :
+    IsMeagre Sᶜ ∧ volume Sᶜ = volume (univ : Set ℝ) ∧ Sᶜ ∪ S = univ := by
+  refine ⟨?_, ?_, ?_⟩
+  · -- `IsMeagre Sᶜ` unfolds to `Sᶜᶜ ∈ residual`, i.e. `S ∈ residual`.
+    simpa [IsMeagre, compl_compl] using hres
+  · -- Full measure: `univ ≤ vol Sᶜ + vol S = vol Sᶜ`, and `vol Sᶜ ≤ univ`.
+    refine le_antisymm (measure_mono (subset_univ _)) ?_
+    have hcov : (univ : Set ℝ) = Sᶜ ∪ S := by
+      rw [Set.compl_union_self]
+    calc volume (univ : Set ℝ)
+        = volume (Sᶜ ∪ S) := by rw [hcov]
+      _ ≤ volume Sᶜ + volume S := measure_union_le _ _
+      _ = volume Sᶜ := by rw [hnull, add_zero]
+  · rw [Set.compl_union_self]
+
+/-! ## The Oxtoby decomposition and the requested witnesses -/
+
+/-- **Lebesgue–Baire orthogonal decomposition (headline).** The real line is the disjoint
+union of a meagre set and a Lebesgue-null set:
+
+    ℝ  =  A  ⊔  B,     A meagre,    B null.
+
+Here `B` is the Liouville numbers and `A = Bᶜ`. This is the sharpest form of the
+independence of the two ideals of "smallness": together a topologically small set and a
+measure-theoretically small set cover the entire line. -/
+theorem real_meagre_null_decomposition :
+    ∃ A B : Set ℝ, A ∪ B = univ ∧ Disjoint A B ∧ IsMeagre A ∧ volume B = 0 :=
+  ⟨𝓛ᶜ, 𝓛, Set.compl_union_self _, disjoint_compl_left,
+    (meagre_conull_compl_of_residual_null liouville_residual liouville_null).1,
+    liouville_null⟩
+
+/-- **A meagre set of full Lebesgue measure** — the object OQ-03 explicitly requests.
+The complement of the Liouville numbers is meagre (its complement, the Liouville set, is
+residual) yet has full measure (the Liouville set is null). -/
+theorem exists_meagre_conull :
+    ∃ A : Set ℝ, IsMeagre A ∧ volume Aᶜ = 0 ∧ volume A = volume (univ : Set ℝ) := by
+  obtain ⟨hmeagre, hfull, _⟩ :=
+    meagre_conull_compl_of_residual_null liouville_residual liouville_null
+  exact ⟨𝓛ᶜ, hmeagre, by rw [compl_compl]; exact liouville_null, hfull⟩
+
+/-! ## The two independence non-implications -/
+
+/-- **Category-small ⇏ measure-small.** There is a meagre set whose Lebesgue measure is
+*not* zero — in fact it has full (infinite) measure. Dual to OQ-02's
+`exists_residual_dense_null`. -/
+theorem meagre_not_imp_null :
+    ∃ A : Set ℝ, IsMeagre A ∧ volume A ≠ 0 := by
+  obtain ⟨A, hmeagre, _, hfull⟩ := exists_meagre_conull
+  refine ⟨A, hmeagre, ?_⟩
+  rw [hfull, Real.volume_univ]
+  exact ENNReal.top_ne_zero
+
+/-- **Measure-small ⇏ category-small.** There is a Lebesgue-null set that is *not* meagre
+— the Liouville numbers, which are comeagre (residual) and hence not meagre in the Baire
+space `ℝ`. This is the measure-side dual of `meagre_not_imp_null`. -/
+theorem null_not_imp_meagre :
+    ∃ B : Set ℝ, volume B = 0 ∧ ¬ IsMeagre B :=
+  ⟨𝓛, liouville_null, not_isMeagre_of_mem_residual liouville_residual⟩
+
+/-! ## OQ-03 resolution -/
+
+/-- **OQ-03 resolution.** Measure-smallness and category-smallness are independent on `ℝ`,
+in the sharpest (orthogonal-decomposition) form:
+
+1. `ℝ = A ⊔ B` with `A` meagre and `B` Lebesgue-null (Oxtoby orthogonality);
+2. a meagre set can have full measure (category-small ⇏ measure-small);
+3. a null set can fail to be meagre (measure-small ⇏ category-small).
+
+Statements (2) and (3) are exact duals, witnessed by the complementary pair `(𝓛ᶜ, 𝓛)`. -/
+theorem oq03_resolution :
+    (∃ A B : Set ℝ, A ∪ B = univ ∧ Disjoint A B ∧ IsMeagre A ∧ volume B = 0) ∧
+    (∃ A : Set ℝ, IsMeagre A ∧ volume A ≠ 0) ∧
+    (∃ B : Set ℝ, volume B = 0 ∧ ¬ IsMeagre B) :=
+  ⟨real_meagre_null_decomposition, meagre_not_imp_null, null_not_imp_meagre⟩
+
+#check @meagre_conull_compl_of_residual_null
+#check @real_meagre_null_decomposition
+#check @exists_meagre_conull
+#check @meagre_not_imp_null
+#check @null_not_imp_meagre
+#check @oq03_resolution
+
+end AlgebraicRealsMeagerOQ03

--- a/src/data/proofs/algebraic-reals-meager-oq-03/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-03/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "algebraic-reals-meager-oq-03",
+  "title": "Measure and Category are Orthogonal: ℝ = meagre ⊔ null",
+  "slug": "algebraic-reals-meager-oq-03",
+  "description": "Completes the independence of the two notions of smallness on ℝ left open by the parent's Baire-category result and its measure companion (oq-02). Where oq-02 shows comeagre does not imply conull (the Liouville numbers are comeagre yet null), this entry supplies the exact dual: a meagre set of full Lebesgue measure. The two pieces combine into the classical Oxtoby orthogonal decomposition ℝ = A ⊔ B with A meagre and B Lebesgue-null — a topologically small set and a measure-theoretically small set together covering the whole line. Hence measure-smallness and category-smallness are logically independent, and the algebraic reals being both meagre and null is not forced by any general implication.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Meagre_set",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerOQ03.lean",
+    "tags": [
+      "measure-theory",
+      "baire-category",
+      "liouville-numbers",
+      "residual",
+      "meagre-set",
+      "lebesgue-measure",
+      "real-analysis",
+      "sharp-boundary"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "measure_union_le",
+        "description": "Countable subadditivity of an outer measure on a pair: μ (s ∪ t) ≤ μ s + μ t",
+        "module": "Mathlib.MeasureTheory.OuterMeasure.Basic"
+      },
+      {
+        "theorem": "not_isMeagre_of_mem_residual",
+        "description": "In a Baire space a residual (comeagre) set is not meagre",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      },
+      {
+        "theorem": "Real.volume_univ",
+        "description": "The Lebesgue measure of all of ℝ is ∞",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      }
+    ],
+    "dependsOn": [
+      {
+        "theorem": "liouville_residual",
+        "description": "The Liouville numbers are comeagre (residual) in ℝ",
+        "module": "Proofs.AlgebraicRealsMeagerOQ02"
+      },
+      {
+        "theorem": "liouville_null",
+        "description": "The Liouville numbers have Lebesgue measure zero",
+        "module": "Proofs.AlgebraicRealsMeagerOQ02"
+      }
+    ],
+    "originalContributions": [
+      "meagre_conull_compl_of_residual_null: PROVED the abstract orthogonality engine — if S is residual (comeagre) and Lebesgue-null then Sᶜ is meagre, has full measure, and Sᶜ ∪ S = univ; the full-measure claim uses only countable subadditivity of the outer measure, so no measurability hypothesis on S is needed",
+      "real_meagre_null_decomposition: PROVED the Oxtoby orthogonal decomposition ℝ = A ⊔ B with A meagre and B Lebesgue-null (B the Liouville numbers, A their complement)",
+      "exists_meagre_conull: PROVED the object oq-03 explicitly requests — a meagre set of full Lebesgue measure (the complement of the Liouville numbers)",
+      "meagre_not_imp_null: PROVED category-small ⇏ measure-small — a meagre set whose measure is not zero (in fact infinite)",
+      "null_not_imp_meagre: PROVED measure-small ⇏ category-small — a Lebesgue-null set that is not meagre (the Liouville numbers), the exact dual of meagre_not_imp_null",
+      "oq03_resolution: packaged statement combining the orthogonal decomposition with the two dual non-implications",
+      "Synthesis built on the verified oq-02 Liouville facts: closes the dual direction (meagre full-measure) that oq-02 left open, and casts the whole picture as the Lebesgue–Baire orthogonal decomposition of the line"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Lebesgue measure on ℝ; countable subadditivity of the outer measure",
+      "Baire category: meagre / residual (comeagre) sets; a residual set is not meagre",
+      "Liouville numbers: comeagre and Lebesgue-null (from oq-02)"
+    ],
+    "lineCount": 146,
+    "relatedProblems": [
+      {
+        "id": "algebraic-reals-meager-oq-02",
+        "relationship": "Sibling: oq-02 proves comeagre ⇏ conull (Liouville numbers comeagre yet null); this entry supplies the exact dual meagre ⇏ null and the combined orthogonal decomposition, reusing oq-02's verified liouville_residual and liouville_null"
+      },
+      {
+        "id": "algebraic-reals-meager",
+        "relationship": "Parent: the Baire-category (topological) smallness of the algebraic reals; this entry shows that topological smallness and measure smallness are independent, so the parent's meagreness and the measure-zero fact are genuinely distinct"
+      }
+    ],
+    "assumptions": "0 axioms. Relies only on Mathlib's measure-theory and Baire-category infrastructure and on the verified Liouville comeagre/measure-zero results from the sibling oq-02 entry.",
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Lebesgue measure and Baire's category theorem supply two independent notions of 'small' set on ℝ: a set may be Lebesgue-null (measure-small) or meagre (category-small). The parent entry formalized the category side for the algebraic reals; the sibling oq-02 added the measure side and showed the two notions diverge — the Liouville numbers are comeagre yet null. The sharpest expression of this independence is due to Oxtoby (Measure and Category, 1980, Thm 1.6): the real line decomposes as the disjoint union of a meagre set and a null set, so neither σ-ideal contains the other and together they cover everything. This entry formalizes that decomposition and the dual non-implication oq-02 left open.",
+    "problemStatement": "Construct a meagre set of full Lebesgue measure (and, dually, a null comeagre set) to show that measure-smallness and category-smallness are genuinely independent on ℝ — that the algebraic reals being both meagre and Lebesgue-null is not forced by either fact implying the other.",
+    "text": "A 0-sorry, 0-axiom synthesis built on the verified Liouville facts of oq-02. An abstract engine shows any residual null set has a meagre complement of full measure, using only countable subadditivity of the outer measure (no measurability hypothesis). Instantiated at the Liouville numbers this yields the Oxtoby decomposition ℝ = A ⊔ B with A = (Liouville)ᶜ meagre and B = Liouville null, the explicitly requested meagre set of full measure, and the two dual independence non-implications.",
+    "proofStrategy": "meagre_conull_compl_of_residual_null is the core: IsMeagre Sᶜ unfolds to Sᶜᶜ = S ∈ residual; full measure follows from volume univ = volume (Sᶜ ∪ S) ≤ volume Sᶜ + volume S = volume Sᶜ via measure_union_le and volume S = 0. Applying it to the Liouville numbers (liouville_residual, liouville_null) gives the decomposition and the meagre conull witness; meagre_not_imp_null reads off full (infinite) measure via Real.volume_univ, and null_not_imp_meagre uses not_isMeagre_of_mem_residual on the Liouville set.",
+    "keyInsights": [
+      "**The independence is two-sided and dual**: oq-02 gives a comeagre null set (category-large, measure-small); this entry gives a meagre conull set (category-small, measure-large). The witnesses are the complementary pair (Liouvilleᶜ, Liouville).",
+      "**No measurability needed for full measure**: the complement of a null set has full outer measure purely by countable subadditivity — volume univ ≤ volume Sᶜ + volume S — so the argument never invokes a measurability hypothesis on S.",
+      "**Oxtoby orthogonality**: ℝ = A ⊔ B with A meagre and B null is the sharpest form of independence — a topologically small set and a measure-theoretically small set partition the entire line.",
+      "**The algebraic reals' two smallness facts are logically separate**: since neither meagre nor null implies the other, the parent's meagreness and the measure-zero result are independent theorems, each requiring its own proof.",
+      "**Honest scope**: the engine and packaging are new, but the deep inputs (Liouville comeagre/null) come from the verified oq-02 and Mathlib; this is a machine-checked synthesis, not new analysis."
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℝ and countable subadditivity of the outer measure",
+      "Baire category: meagre and residual (comeagre) sets; residual ⇒ not meagre",
+      "Liouville numbers: comeagre and Lebesgue-null (sibling oq-02)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: Measure–Category Orthogonality",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "File docstring and the Liouville-set shorthand. Frames the goal — a meagre set of full measure dual to oq-02's comeagre null set — and previews the Oxtoby decomposition ℝ = A ⊔ B with A meagre and B null.",
+      "mathContext": "A set is meagre if it is a countable union of nowhere-dense sets, comeagre (residual) if its complement is meagre, and conull if its complement is Lebesgue-null. Meagre and null are distinct σ-ideals on ℝ."
+    },
+    {
+      "id": "engine",
+      "title": "The abstract orthogonality engine",
+      "startLine": 57,
+      "endLine": 78,
+      "summary": "meagre_conull_compl_of_residual_null: a residual null set has a meagre complement of full measure, with the pair partitioning ℝ. The full-measure step uses only countable subadditivity of the outer measure.",
+      "mathContext": "volume univ = volume (Sᶜ ∪ S) ≤ volume Sᶜ + volume S, and volume S = 0 forces volume Sᶜ = volume univ; no measurability of S is required."
+    },
+    {
+      "id": "decomposition",
+      "title": "Oxtoby decomposition and the requested witness",
+      "startLine": 79,
+      "endLine": 102,
+      "summary": "real_meagre_null_decomposition (ℝ = A ⊔ B, A meagre, B null) and exists_meagre_conull (a meagre set of full Lebesgue measure), instantiating the engine at the Liouville numbers.",
+      "mathContext": "B = Liouville numbers (comeagre, null); A = Bᶜ is meagre with full measure."
+    },
+    {
+      "id": "non-implications",
+      "title": "The two dual non-implications",
+      "startLine": 104,
+      "endLine": 121,
+      "summary": "meagre_not_imp_null (category-small ⇏ measure-small) and null_not_imp_meagre (measure-small ⇏ category-small), the two halves of the independence, witnessed by the complementary pair (Liouvilleᶜ, Liouville).",
+      "mathContext": "A meagre set can have infinite measure; a null set (the Liouville numbers) can be comeagre and hence not meagre."
+    },
+    {
+      "id": "resolution",
+      "title": "OQ-03 resolution",
+      "startLine": 123,
+      "endLine": 146,
+      "summary": "oq03_resolution combines the orthogonal decomposition with both non-implications into a single statement that measure-smallness and category-smallness are independent on ℝ.",
+      "mathContext": "Independence in the sharpest form: a partition of ℝ into a meagre and a null piece, plus the two non-implications."
+    }
+  ],
+  "references": [
+    {
+      "title": "Measure and Category (Oxtoby, GTM 2)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4684-9339-9"
+    },
+    {
+      "title": "Liouville number — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Liouville_number"
+    },
+    {
+      "title": "Meagre set — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Meagre_set"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": "Measure-smallness and category-smallness are independent on ℝ. Dual to oq-02's comeagre null set, the complement of the Liouville numbers is a meagre set of full Lebesgue measure, and the two combine into the Oxtoby decomposition ℝ = A ⊔ B with A meagre and B null. So neither notion of smallness implies the other, and the algebraic reals being both meagre and Lebesgue-null is a conjunction of two genuinely separate facts — all formalized with zero axioms on top of the verified Liouville infrastructure.",
+  "sorries": []
+}

--- a/src/data/research/problems/algebraic-reals-meager-oq-03.json
+++ b/src/data/research/problems/algebraic-reals-meager-oq-03.json
@@ -1,0 +1,104 @@
+{
+  "slug": "algebraic-reals-meager-oq-03",
+  "title": "The Algebraic Reals are Meagre (Baire Category) — Formalize the independence of the three smallness notions on ℝ: construct a m...",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: Formalize the independence of the three smallness notions on ℝ: construct a meagre set of full Lebesgue measure (and a null comeagre set) to show measure-smallness and category-smallness of the algebr.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-23T05:56:46.289Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "descriptive-set-theory",
+    "measure-category"
+  ],
+  "relatedProofs": [
+    "algebraic-reals-meager",
+    "algebraic-reals-meager-dense-gdelta",
+    "algebraic-reals-meager-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-23T05:56:46.288Z",
+  "lastUpdate": "2026-06-23T05:56:46.288Z",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/AlgebraicRealsMeager.lean",
+      "filename": "AlgebraicRealsMeager.lean",
+      "lineCount": 227,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicRealsMeager.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicRealsMeagerDenseGDelta.lean",
+      "filename": "AlgebraicRealsMeagerDenseGDelta.lean",
+      "lineCount": 166,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicRealsMeagerDenseGDelta.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicRealsMeagerOQ02.lean",
+      "filename": "AlgebraicRealsMeagerOQ02.lean",
+      "lineCount": 178,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicRealsMeagerOQ02.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicRealsMeagerOQ03.lean",
+      "filename": "AlgebraicRealsMeagerOQ03.lean",
+      "lineCount": 147,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicRealsMeagerOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves open question **oq-03** of `algebraic-reals-meager`: *construct a meagre set of full Lebesgue measure (and a null comeagre set) to show measure-smallness and category-smallness are genuinely independent on ℝ.*

The sibling **oq-02** already proved one direction — comeagre ⇏ conull (the Liouville numbers are comeagre yet Lebesgue-null). This entry supplies the **exact dual** — a meagre set of full measure — and combines both into the classical **Oxtoby orthogonal decomposition**

```
ℝ = A ⊔ B,   A meagre,   B Lebesgue-null
```

with `B` the Liouville numbers and `A = Bᶜ`. So neither notion of smallness implies the other, and the algebraic reals being *both* meagre and null is a conjunction of two genuinely separate facts.

## Theorems (6 thm, 1 def, 0 sorries, 0 axioms)

- `meagre_conull_compl_of_residual_null` — abstract engine: a residual null set has a meagre complement of **full measure**, using only countable subadditivity of the outer measure (`volume univ ≤ volume Sᶜ + volume S`); **no measurability hypothesis** on `S`.
- `real_meagre_null_decomposition` — the Oxtoby decomposition `ℝ = A ⊔ B`.
- `exists_meagre_conull` — the explicitly requested object: a meagre set of full Lebesgue measure.
- `meagre_not_imp_null` / `null_not_imp_meagre` — the two dual non-implications.
- `oq03_resolution` — combined statement.

## Verification

- Builds against Mathlib 4.26.0 (Docker daemon was down; compiled directly with the pinned `leanprover/lean4:v4.26.0` toolchain).
- `#print axioms` on every result: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, `Lean.ofReduceBool`, or `native_decide`. **0-axiom verified.**
- Builds on the verified sibling `algebraic-reals-meager-oq-02` (`liouville_residual`, `liouville_null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)