### PR TITLE
Enrich Second Moment of Geometric Series (geometric-series-oq-07)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "basis-identity",
+    "proofId": "geometric-series-oq-07",
+    "range": { "startLine": 71, "endLine": 75 },
+    "type": "insight",
+    "title": "n² in the Rising-Binomial Basis",
+    "content": "`two_choose_two_sub` proves the algebraic key of the whole entry: n² = 2·(n+2 choose 2) − 3n − 2 over ℝ. The point is that (n+2 choose 2) = (n+1)(n+2)/2, so 2·(n+2 choose 2) = n² + 3n + 2, and subtracting 3n + 2 recovers n². This rewrites the quadratic weight n² as a linear combination of the three functions {1, n, (n+2 choose 2)} that Mathlib can already sum against rⁿ — converting an analytic moment computation into a finite basis change. The proof is `Nat.cast_choose_two` then `push_cast; ring`.",
+    "mathContext": "$n^2 = 2\\binom{n+2}{2} - 3n - 2$, since $\\binom{n+2}{2} = \\tfrac{(n+1)(n+2)}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["rising-binomial basis", "binomial coefficients", "change of basis", "Nat.cast_choose_two"],
+    "prerequisites": ["binomial coefficients", "polynomial identities"]
+  },
+  {
+    "id": "moment-family",
+    "proofId": "geometric-series-oq-07",
+    "range": { "startLine": 79, "endLine": 88 },
+    "type": "context",
+    "title": "The Zeroth and First Moments",
+    "content": "`tsum_geometric` (∑rⁿ = 1/(1-r)) and `tsum_mul_geometric` (∑n·rⁿ = r/(1-r)²) restate Mathlib's geometric series and first moment. They are included to display the full low-order moment family — 1/(1-r), r/(1-r)², r(1+r)/(1-r)³ — into which the new second moment fits, and they also name the h₀ and h₁ ingredients reused in the main proof.",
+    "mathContext": "$\\sum r^n = \\tfrac{1}{1-r}$, $\\sum n r^n = \\tfrac{r}{(1-r)^2}$ for $\\|r\\|<1$.",
+    "significance": "context",
+    "relatedConcepts": ["geometric series", "first moment", "moment family"],
+    "prerequisites": ["infinite series", "summability"]
+  },
+  {
+    "id": "second-moment",
+    "proofId": "geometric-series-oq-07",
+    "range": { "startLine": 96, "endLine": 120 },
+    "type": "technique",
+    "title": "Assembling the Second Moment from Three HasSum Facts",
+    "content": "`hasSum_sq_mul_geometric` is the headline result, ∑n²rⁿ = r(1+r)/(1-r)³. It takes three Mathlib HasSum facts — h₂ (the k=2 rising-binomial sum = 1/(1-r)³), h₁ (the first moment), h₀ (the geometric series) — and forms the combination 2·h₂ − 3·h₁ − 2·h₀ using `HasSum.mul_left` and `HasSum.sub`. The summand of that combination equals n²rⁿ by the basis identity (`funext` then `ring` via `two_choose_two_sub`); after `rw [hfun]` the functions match, so `convert hcomb using 1` leaves only the value, simplified by `field_simp; ring` (legal since 1 − r ≠ 0). Crucially, convergence is inherited from the three summands — no summability is re-proved.",
+    "mathContext": "$\\sum n^2 r^n = 2\\cdot\\tfrac{1}{(1-r)^3} - 3\\cdot\\tfrac{r}{(1-r)^2} - 2\\cdot\\tfrac{1}{1-r} = \\tfrac{r(1+r)}{(1-r)^3}$.",
+    "significance": "key",
+    "relatedConcepts": ["HasSum arithmetic", "linear combination of series", "rising-binomial sums", "field_simp"],
+    "prerequisites": ["HasSum", "geometric series", "normed fields"]
+  },
+  {
+    "id": "tsum-summable",
+    "proofId": "geometric-series-oq-07",
+    "range": { "startLine": 122, "endLine": 130 },
+    "type": "technique",
+    "title": "tsum and Summability Forms",
+    "content": "`tsum_sq_mul_geometric` and `summable_sq_mul_geometric` package the HasSum result in the two forms a reader usually wants: the explicit value ∑'n, n²rⁿ = r(1+r)/(1-r)³ (via `HasSum.tsum_eq`) and plain summability (via `HasSum.summable`). Both are one-liners off the keystone HasSum, illustrating why proving the HasSum form first is economical — the tsum value and convergence both follow without extra work.",
+    "mathContext": "$\\sum' n,\\ n^2 r^n = \\tfrac{r(1+r)}{(1-r)^3}$ and $\\text{Summable}(n \\mapsto n^2 r^n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tsum", "summability", "HasSum.tsum_eq"],
+    "prerequisites": ["unconditional convergence"]
+  },
+  {
+    "id": "concrete",
+    "proofId": "geometric-series-oq-07",
+    "range": { "startLine": 134, "endLine": 138 },
+    "type": "concept",
+    "title": "Sanity Check: ∑ n²/2ⁿ = 6",
+    "content": "A concrete evaluation at r = 1/2: the closed form gives r(1+r)/(1-r)³ = (1/2)(3/2)/(1/2)³ = (3/4)/(1/8) = 6, discharged by rewriting with tsum_sq_mul_geometric and `norm_num`. This pins the abstract identity to a recognizable number and doubles as a regression guard against sign or exponent slips in the closed form.",
+    "mathContext": "$\\sum_{n\\ge0} \\tfrac{n^2}{2^n} = \\tfrac{(1/2)(3/2)}{(1/2)^3} = 6$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "geometric distribution second moment"],
+    "prerequisites": ["arithmetic of series"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07/meta.json
+++ b/src/data/proofs/geometric-series-oq-07/meta.json
@@ -20,6 +20,7 @@
     "sorries": 0
   },
   "title": "The Second Moment of the Geometric Series: ∑ n² rⁿ = r(1+r)/(1-r)³",
+  "description": "The second moment of the geometric series: for ‖r‖ < 1 over ℝ, ∑_{n≥0} n²·rⁿ = r(1+r)/(1-r)³, completing the low-order family ∑rⁿ = 1/(1-r), ∑n·rⁿ = r/(1-r)², ∑n²·rⁿ = r(1+r)/(1-r)³. Mathlib has the zeroth and first moments but no closed form for ∑n²rⁿ. The proof avoids re-deriving convergence: it writes n² in the rising-binomial basis via n² = 2·(n+2 choose 2) − 3n − 2 and assembles the sum as the linear combination 2·h₂ − 3·h₁ − 2·h₀ of three Mathlib HasSum facts, simplifying with field_simp; ring. Provides HasSum, tsum, and summability forms plus the concrete check ∑n²/2ⁿ = 6.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -76,6 +77,48 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The geometric series ∑rⁿ = 1/(1-r) is the oldest convergent infinite series, and its weighted relatives ∑n·rⁿ, ∑n²·rⁿ have been computed since the 18th century by repeatedly differentiating it with respect to r: applying r·d/dr to 1/(1-r) yields r/(1-r)², and again gives r(1+r)/(1-r)³. These are exactly the (unnormalized) moments of the geometric distribution, and the operator r·d/dr is the generating-function avatar of multiplication by n. The numerators 1, r, r(1+r), … are governed by the Eulerian numbers, the same triangle that counts permutation descents. This entry formalizes the second moment, but takes a route that sidesteps term-by-term differentiation of a power series (delicate to justify rigorously): it expresses n² in a basis of binomial sums Mathlib already knows how to sum, reducing the analytic computation to a finite algebraic identity.",
+    "problemStatement": "**Open Question (oq-07)**: extend the gallery's geometric-series base entry to the weighted moment ∑_{n≥0} n²·rⁿ for ‖r‖ < 1, giving an honest closed form with HasSum / tsum / summability witnesses. Answer: ∑n²·rⁿ = r(1+r)/(1-r)³, proved without re-deriving convergence by reducing n² to the rising-binomial basis {1, n, (n+2 choose 2)} that Mathlib sums in closed form.",
+    "proofStrategy": "The key is the basis identity n² = 2·(n+2 choose 2) − 3n − 2 (since (n+2 choose 2) = (n+1)(n+2)/2, so 2·(n+2 choose 2) = n² + 3n + 2). This places n² in the span of three functions Mathlib sums against rⁿ: the k=2 rising-binomial sum h₂ = ∑(n+2 choose 2)rⁿ = 1/(1-r)³, the first moment h₁ = ∑n·rⁿ = r/(1-r)², and the geometric series h₀ = ∑rⁿ = (1-r)⁻¹. Forming the HasSum combination 2·h₂ − 3·h₁ − 2·h₀ (via HasSum.mul_left and HasSum.sub) gives a series whose summand is exactly n²·rⁿ; `funext` + `ring` rewrites the summand using the basis identity, `convert … using 1` reduces the goal to matching the value, and `field_simp; ring` (legal since 1 − r ≠ 0) simplifies 2/(1-r)³ − 3r/(1-r)² − 2/(1-r) to r(1+r)/(1-r)³. Because convergence is inherited from the three Mathlib HasSum facts, no summability is re-proved.",
+    "keyInsights": [
+      "The whole computation reduces to a basis change: n² lies in the span of {1, n, (n+2 choose 2)}, the rising-binomial functions Mathlib already sums against rⁿ — so the second moment is a finite linear combination, not a fresh limit computation.",
+      "Working with HasSum (not just tsum) means convergence is carried along for free: the combination 2·h₂ − 3·h₁ − 2·h₀ inherits summability from its three summands, so summable_sq_mul_geometric falls out without an independent comparison test.",
+      "This sidesteps differentiating a power series term-by-term — the classical route via r·d/dr 1/(1-r) — which is analytically delicate; the binomial-basis identity reduces everything to a ring identity plus field_simp.",
+      "The same template generalizes verbatim: expressing nᵏ in the rising-binomial basis {(n+j choose j)} yields ∑nᵏrⁿ as an Eulerian-numerator polynomial over (1-r)^{k+1}, the content of the child entry oq-07-oq-01.",
+      "These are precisely the geometric-distribution moments: with P(X=n) = (1-r)rⁿ, the closed forms give E[X] = r/(1-r), E[X²] = r(1+r)/(1-r)², Var(X) = r/(1-r)²."
+    ]
+  },
+  "sections": [
+    {
+      "id": "basis-identity",
+      "title": "The Polynomial Basis Identity",
+      "startLine": 65,
+      "endLine": 75,
+      "summary": "two_choose_two_sub proves the algebraic key n² = 2·(n+2 choose 2) − 3n − 2 over ℝ, via Nat.cast_choose_two ((n+2 choose 2) = (n+1)(n+2)/2), push_cast, and ring. This expresses n² in the rising-binomial basis Mathlib sums against rⁿ."
+    },
+    {
+      "id": "moment-family",
+      "title": "The Zeroth and First Moments",
+      "startLine": 77,
+      "endLine": 88,
+      "summary": "tsum_geometric (∑rⁿ = 1/(1-r)) and tsum_mul_geometric (∑n·rⁿ = r/(1-r)²) restate Mathlib's zeroth and first moments, displaying the full low-order family for which the second moment is the new member."
+    },
+    {
+      "id": "second-moment",
+      "title": "The Second Moment via a Linear Combination",
+      "startLine": 90,
+      "endLine": 130,
+      "summary": "one_sub_ne_zero gives 1 − r ≠ 0 from ‖r‖ < 1. hasSum_sq_mul_geometric assembles ∑n²rⁿ = r(1+r)/(1-r)³ as the HasSum combination 2·h₂ − 3·h₁ − 2·h₀ of the k=2 rising-binomial sum, the first moment, and the geometric series, rewriting the summand by the basis identity and simplifying the value with field_simp; ring. tsum and summability forms follow."
+    },
+    {
+      "id": "concrete",
+      "title": "A Concrete Value: ∑ n²/2ⁿ = 6",
+      "startLine": 132,
+      "endLine": 140,
+      "summary": "A sanity check at r = 1/2: substituting into the closed form gives r(1+r)/(1-r)³ = (1/2)(3/2)/(1/8) = 6, discharged by tsum_sq_mul_geometric and norm_num."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-07-oq-01",
@@ -98,6 +141,16 @@
       "targetId": "geometric-series-oq-03",
       "relationship": "sibling",
       "description": "A sibling extension of the geometric series: oq-03 builds the Euler product ζ(s) = ∏_p ∑_k (p^{-s})^k from the geometric series, while this entry builds the weighted moment sums ∑ nᵏ rⁿ."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01",
+      "relationship": "extends",
+      "description": "Child. The arbitrary-order generalization ∑ nᵏ rⁿ = (Eulerian-numerator polynomial of degree k)/(1-r)^{k+1}, obtained by expressing nᵏ in the rising-binomial basis {(n+j choose j)} — the k = 2 case is exactly this entry's second moment."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-05",
+      "relationship": "related",
+      "description": "The continuous analogue: the second moment of the Gaussian, ∫ x² e^{-x²} = √π/2. Both compute a second moment of a fundamental decaying weight — discrete (∑ n² rⁿ) versus continuous (∫ x² e^{-x²}) — by reducing it to lower-order known quantities."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07` (quality 15, passes 0). Good meta existed, but no `description`, no `overview`, no `sections`, no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary.
- **overview** — `historicalContext` (the r·d/dr moment ladder, Eulerian-number numerators, why this route sidesteps term-by-term differentiation), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** — 4, covering all 140 lines (basis identity, moment family, second-moment assembly, concrete value).
- **crossReferences** — +2 (child `geometric-series-oq-07-oq-01` arbitrary-order generalization; `area-of-circle-oq-07-oq-05` continuous second-moment analogue), alongside the existing parent/sibling refs.

## Added annotations.json (5 annotations)
The n² basis identity, the zeroth/first moment family, the three-HasSum linear-combination assembly, the tsum/summability forms, and the ∑n²/2ⁿ = 6 check — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on declarations.

## Axiom integrity
Unchanged and accurate: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`. ∑n²rⁿ is a genuine gap in Mathlib (it has only the zeroth/first moments); the entry assembles it from library HasSum facts via a basis identity — original, no `axiom`/`sorry`/`native_decide`.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)