### PR TITLE
research(erdos-1002-oq-03): rational case — linear drift slope 1/(2q) of the weighted fractional sum [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -919,6 +919,7 @@ import Proofs.Erdos1001Problem
 import Proofs.Erdos1002OQ01
 import Proofs.Erdos1002OQ01OQ01
 import Proofs.Erdos1002OQ01OQ01Aristotle
+import Proofs.Erdos1002OQ03
 import Proofs.Erdos1002Problem
 import Proofs.Erdos1003Problem
 import Proofs.Erdos1004OQ02

--- a/proofs/Proofs/Erdos1002OQ03.lean
+++ b/proofs/Proofs/Erdos1002OQ03.lean
@@ -1,0 +1,212 @@
+/-
+Erdős Problem #1002 — OQ-03: How the inner sum behaves for rational α
+(dependence on the continued-fraction expansion of α, rational case).
+
+Background.  Erdős #1002 studies the limiting distribution of the inner sum
+    S(α, n) = Σ_{k=1}^{n} (1/2 − {αk}),
+where {·} is the fractional part.  The qualitative behaviour of S(α, n)
+depends sharply on the arithmetic of α — concretely, on its continued-fraction
+expansion.  For a quadratic irrational (eventually periodic CF, bounded partial
+quotients) S stays bounded; for general irrationals it can be unbounded; and for
+**rational** α the expansion terminates and the behaviour is the cleanest of all.
+
+This file resolves the rational case completely, with no axioms.
+
+Main results (for a reduced fraction α = p/q, i.e. gcd(p,q) = 1, q ≥ 1):
+
+  * `innerSum_period_sum` :  S(p/q, q) = 1/2.
+        The sum over one full period is the **universal constant 1/2**,
+        independent of p and of q.  (The denominator q is the length of the
+        continued-fraction period — here a terminating expansion.)
+
+  * `innerSum_linear` :  S(p/q, n·q) = n/2.
+        Hence for rational α the inner sum grows **exactly linearly**, with the
+        per-step rate 1/(2q) governed solely by the denominator q.
+
+The crux is an elementary fact: as m runs over a full period, the residues
+p·m mod q run over a complete residue system (multiplication by a unit permutes
+ℤ/qℤ), so Σ {pm/q} = (q−1)/2 and the deviations telescope to 1/2.
+
+Self-contained: imports only Mathlib.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 800000
+
+open Real
+
+namespace Erdos1002OQ03
+
+/-! ## Definitions (mirrored from `Erdos1002Problem.lean`) -/
+
+/-- Deviation from the midpoint: `1/2 − {x}`. -/
+noncomputable def deviation (x : ℝ) : ℝ :=
+  1 / 2 - Int.fract x
+
+/-- Inner sum: `S(α, n) = Σ_{k=1}^{n} (1/2 − {αk})`. -/
+noncomputable def innerSum (α : ℝ) (n : ℕ) : ℝ :=
+  ∑ k ∈ Finset.range n, deviation (α * (↑k + 1))
+
+/-! ## Part I: A complete residue system
+
+As `k` ranges over `range q`, the shifted residues `(p·(k+1)) mod q` form a
+permutation of `range q` when `gcd(p, q) = 1`.  Hence the sum of residues is
+unchanged. -/
+
+/-- `k ↦ (p·(k+1)) mod q` is injective on `range q` when `gcd(p,q)=1`. -/
+private theorem mulmod_shift_injOn (p q : ℕ) (_hq : q ≥ 1) (hcop : Nat.gcd p q = 1) :
+    Set.InjOn (fun k => (p * (k + 1)) % q) (Finset.range q) := by
+  intro a ha b hb hab
+  simp only at hab
+  have hcop' : Nat.gcd q p = 1 := by rwa [Nat.gcd_comm]
+  have hmod : p * (a + 1) ≡ p * (b + 1) [MOD q] := hab
+  have h1 : a + 1 ≡ b + 1 [MOD q] := Nat.ModEq.cancel_left_of_coprime hcop' hmod
+  have h2 : a ≡ b [MOD q] := Nat.ModEq.add_right_cancel' 1 h1
+  have halt : a < q := Finset.mem_range.mp ha
+  have hblt : b < q := Finset.mem_range.mp hb
+  have hmm : a % q = b % q := h2
+  rwa [Nat.mod_eq_of_lt halt, Nat.mod_eq_of_lt hblt] at hmm
+
+/-- The image of `range q` under `k ↦ (p·(k+1)) mod q` is all of `range q`. -/
+private theorem mulmod_shift_image (p q : ℕ) (hq : q ≥ 1) (hcop : Nat.gcd p q = 1) :
+    (Finset.range q).image (fun k => (p * (k + 1)) % q) = Finset.range q := by
+  apply Finset.eq_of_subset_of_card_le
+  · intro y hy
+    rw [Finset.mem_image] at hy
+    obtain ⟨m, _, rfl⟩ := hy
+    exact Finset.mem_range.mpr (Nat.mod_lt _ hq)
+  · exact le_of_eq (Finset.card_image_of_injOn (mulmod_shift_injOn p q hq hcop)).symm
+
+/-- **Complete residue system.**  For `gcd(p,q)=1`,
+    `Σ_{k<q} (p·(k+1) mod q) = Σ_{m<q} m`. -/
+private theorem sum_mulmod_shift (p q : ℕ) (hq : q ≥ 1) (hcop : Nat.gcd p q = 1) :
+    ∑ k ∈ Finset.range q, ((p * (k + 1)) % q) = ∑ m ∈ Finset.range q, m := by
+  conv_rhs => rw [← mulmod_shift_image p q hq hcop]
+  rw [Finset.sum_image (mulmod_shift_injOn p q hq hcop)]
+
+/-! ## Part II: Fractional part of `a / q` -/
+
+/-- `Int.fract (a / q) = (a mod q) / q` for naturals `a`, `q` with `q > 0`. -/
+private theorem fract_natDiv (a q : ℕ) (hq : 0 < q) :
+    Int.fract ((↑a : ℝ) / ↑q) = (↑(a % q) : ℝ) / ↑q := by
+  have hq0 : (0 : ℝ) < (q : ℝ) := by exact_mod_cast hq
+  have hqne : (q : ℝ) ≠ 0 := ne_of_gt hq0
+  have hd : (↑a : ℝ) = ↑q * ↑(a / q) + ↑(a % q) := by
+    exact_mod_cast (Nat.div_add_mod a q).symm
+  rw [hd, add_div, mul_div_cancel_left₀ _ hqne, Int.fract_natCast_add]
+  refine Int.fract_eq_self.mpr ⟨by positivity, ?_⟩
+  rw [div_lt_one hq0]
+  exact_mod_cast Nat.mod_lt a hq
+
+/-! ## Part III: The per-period sum equals 1/2 -/
+
+/-- **Per-period sum.**  For a reduced fraction `p/q` (gcd = 1, q ≥ 1),
+    the inner sum over one full period equals the universal constant `1/2`:
+        `S(p/q, q) = 1/2`. -/
+theorem innerSum_period_sum (p q : ℕ) (hq : q ≥ 1) (hcop : Nat.gcd p q = 1) :
+    innerSum (↑p / ↑q) q = 1 / 2 := by
+  have hq0 : (0 : ℝ) < (q : ℝ) := by exact_mod_cast hq
+  have hqne : (q : ℝ) ≠ 0 := ne_of_gt hq0
+  -- rewrite each deviation term as `1/2 − residue/q`
+  have hterm : ∀ k ∈ Finset.range q,
+      deviation (↑p / ↑q * (↑k + 1)) = 1 / 2 - (↑((p * (k + 1)) % q) : ℝ) / ↑q := by
+    intro k _
+    unfold deviation
+    congr 1
+    rw [show (↑p / ↑q * (↑k + 1) : ℝ) = (↑(p * (k + 1)) : ℝ) / ↑q from by push_cast; ring,
+        fract_natDiv (p * (k + 1)) q hq]
+  simp only [innerSum]
+  rw [Finset.sum_congr rfl hterm, Finset.sum_sub_distrib, Finset.sum_const,
+      Finset.card_range, nsmul_eq_mul, ← Finset.sum_div]
+  -- goal: ↑q * (1/2) − (Σ residues) / ↑q = 1/2
+  have hcrs : (∑ k ∈ Finset.range q, (↑((p * (k + 1)) % q) : ℝ)) = (↑q * (↑q - 1)) / 2 := by
+    have hnat : ∑ k ∈ Finset.range q, ((p * (k + 1)) % q) = ∑ m ∈ Finset.range q, m :=
+      sum_mulmod_shift p q hq hcop
+    have h2 : (∑ m ∈ Finset.range q, m) * 2 = q * (q - 1) := Finset.sum_range_id_mul_two q
+    have hc : (((∑ m ∈ Finset.range q, m) * 2 : ℕ) : ℝ) = ((q * (q - 1) : ℕ) : ℝ) := by
+      exact_mod_cast h2
+    have hh : ((∑ m ∈ Finset.range q, m : ℕ) : ℝ) * 2 = ↑q * (↑q - 1) := by
+      calc ((∑ m ∈ Finset.range q, m : ℕ) : ℝ) * 2
+          = (((∑ m ∈ Finset.range q, m) * 2 : ℕ) : ℝ) := by push_cast; ring
+        _ = ((q * (q - 1) : ℕ) : ℝ) := hc
+        _ = ↑q * (↑q - 1) := by rw [Nat.cast_mul, Nat.cast_sub hq, Nat.cast_one]
+    calc (∑ k ∈ Finset.range q, (↑((p * (k + 1)) % q) : ℝ))
+        = ((∑ k ∈ Finset.range q, ((p * (k + 1)) % q) : ℕ) : ℝ) := by push_cast; rfl
+      _ = ((∑ m ∈ Finset.range q, m : ℕ) : ℝ) := by rw [hnat]
+      _ = (↑q * (↑q - 1)) / 2 := by linarith [hh]
+  rw [hcrs]
+  field_simp
+  ring
+
+/-! ## Part IV: Linear growth `S(p/q, n·q) = n/2`
+
+We reuse the additive period recurrence (`deviation` is `q`-periodic in the
+index), proved here locally, then induct on the number of periods. -/
+
+/-- `deviation` is invariant under natural shifts. -/
+private theorem deviation_add_nat (x : ℝ) (n : ℕ) :
+    deviation (x + ↑n) = deviation x := by
+  unfold deviation
+  rw [Int.fract_add_natCast]
+
+/-- The map `k ↦ deviation(p/q · (k+1))` has period `q`. -/
+private theorem deviation_rational_periodic (p q : ℕ) (hq : q ≥ 1) (k : ℕ) :
+    deviation (↑p / ↑q * (↑(k + q) + 1)) = deviation (↑p / ↑q * (↑k + 1)) := by
+  have hqne : (↑q : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+  push_cast
+  rw [show (↑k : ℝ) + ↑q + 1 = (↑k + 1) + ↑q from by ring, mul_add,
+      show (↑p : ℝ) / ↑q * ↑q = ↑p from by field_simp]
+  exact deviation_add_nat (↑p / ↑q * (↑k + 1)) p
+
+/-- Summing a `q`-periodic function over any `q` consecutive values is constant. -/
+private theorem cyclic_sum_periodic (g : ℕ → ℝ) (q : ℕ) (hper : ∀ k, g (k + q) = g k)
+    (n : ℕ) : ∑ k ∈ Finset.range q, g (n + k) = ∑ k ∈ Finset.range q, g k := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+    have h_rw : ∀ k, g (m + 1 + k) = g (m + (k + 1)) := fun k => by congr 1; omega
+    simp_rw [h_rw]
+    have hr := Finset.sum_range_succ (fun k => g (m + k)) q
+    have hr' := Finset.sum_range_succ' (fun k => g (m + k)) q
+    have hper_m : g (m + q) = g m := hper m
+    have hz : g (m + 0) = g m := by rw [Nat.add_zero]
+    linarith
+
+/-- The inner-sum period recurrence: `S(p/q, n+q) = S(p/q, n) + S(p/q, q)`. -/
+private theorem innerSum_period_rec (p q : ℕ) (hq : q ≥ 1) (n : ℕ) :
+    innerSum (↑p / ↑q) (n + q) = innerSum (↑p / ↑q) n + innerSum (↑p / ↑q) q := by
+  simp only [innerSum]
+  rw [Finset.sum_range_add]
+  congr 1
+  exact cyclic_sum_periodic (fun k => deviation (↑p / ↑q * (↑k + 1))) q
+    (deviation_rational_periodic p q hq) n
+
+/-- **Linear growth.**  For a reduced fraction `p/q`, the inner sum over `n`
+    full periods is exactly `n/2`:
+        `S(p/q, n·q) = n/2`. -/
+theorem innerSum_linear (p q : ℕ) (hq : q ≥ 1) (hcop : Nat.gcd p q = 1) (n : ℕ) :
+    innerSum (↑p / ↑q) (n * q) = ↑n / 2 := by
+  induction n with
+  | zero => simp [innerSum]
+  | succ m ih =>
+    have hrec : innerSum (↑p / ↑q) (m * q + q)
+        = innerSum (↑p / ↑q) (m * q) + innerSum (↑p / ↑q) q :=
+      innerSum_period_rec p q hq (m * q)
+    have hstep : (m + 1) * q = m * q + q := by ring
+    rw [hstep, hrec, ih, innerSum_period_sum p q hq hcop]
+    push_cast; ring
+
+/-! ## Part V: Sanity-check corollaries -/
+
+/-- The growth is genuinely unbounded: e.g. after two periods the sum is `1`. -/
+example (p q : ℕ) (hq : q ≥ 1) (hcop : Nat.gcd p q = 1) :
+    innerSum (↑p / ↑q) (2 * q) = 1 := by
+  rw [innerSum_linear p q hq hcop 2]; norm_num
+
+/-- Concretely, for `α = 1/2` (q = 2): one period sums to `1/2`. -/
+example : innerSum (1 / 2 : ℝ) 2 = 1 / 2 := by
+  have h := innerSum_period_sum 1 2 (by norm_num) (by decide)
+  simpa using h
+
+end Erdos1002OQ03

--- a/src/data/proofs/erdos-1002-oq-03/meta.json
+++ b/src/data/proofs/erdos-1002-oq-03/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "erdos-1002-oq-03",
+  "title": "Erdős #1002 OQ-03: The Rational Case — Linear Drift of the Weighted Fractional Sum with Slope 1/(2q)",
+  "slug": "erdos-1002-oq-03",
+  "description": "Companion to Erdős #1002 (asymptotic distribution of the weighted fractional sum S(α,n) = Σ_{k=1}^n (1/2 − {αk})). The parent open question asks how the limiting behaviour of S(α,n) depends on the arithmetic of α — concretely on its continued-fraction expansion. This entry resolves the RATIONAL case completely and axiom-free. For a reduced fraction α = p/q (gcd(p,q)=1, q ≥ 1), the continued fraction terminates and the behaviour is the cleanest of all: the sum over one full period is the universal constant 1/2, independent of both p and q (innerSum_period_sum: S(p/q, q) = 1/2), and over n periods the sum is exactly n/2 (innerSum_linear: S(p/q, n·q) = n/2). Hence for rational α the weighted fractional sum grows EXACTLY LINEARLY with per-step drift 1/(2q) governed solely by the denominator q (the final continued-fraction convergent), so the limiting distribution is degenerate — a sharp contrast with the bounded/Cauchy behaviour in the irrational case. The crux is an elementary complete-residue-system fact: as k runs over one period the residues p·(k+1) mod q permute {0,…,q−1} (multiplication by a unit permutes ℤ/qℤ), so Σ {p(k+1)/q} = (q−1)/2 and the deviations 1/2 − {p(k+1)/q} telescope to exactly 1/2; linear growth follows from q-periodicity of the summand and induction on the number of periods. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://erdosproblems.com/1002",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1002OQ03.lean",
+    "erdosNumber": 1002,
+    "erdosUrl": "https://erdosproblems.com/1002",
+    "erdosProblemStatus": "open",
+    "erdosPrizeValue": null,
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "fractional-parts",
+      "continued-fractions",
+      "complete-residue-system",
+      "equidistribution",
+      "erdos",
+      "axiom-free"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.ModEq.cancel_left_of_coprime",
+        "description": "Cancellation p·a ≡ p·b [MOD q] ⟹ a ≡ b [MOD q] when gcd(q,p)=1 — the engine making k ↦ p·(k+1) mod q injective on a period",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "An injective-on map preserves cardinality — promotes injectivity of the residue map to a bijection of range q onto itself (complete residue system)",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.sum_range_id_mul_two",
+        "description": "(Σ_{m<q} m)·2 = q·(q−1) — evaluates the residue sum to (q−1)/2, giving the per-period deviation 1/2",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Int.fract_add_natCast",
+        "description": "{x + n} = {x} for natural n — yields q-periodicity of the summand k ↦ 1/2 − {(p/q)(k+1)}, the basis of the linear-growth induction",
+        "module": "Mathlib.Algebra.Order.Floor"
+      }
+    ],
+    "originalContributions": [
+      "innerSum_period_sum: PROVED that for any reduced fraction p/q the weighted fractional sum over one full period is the universal constant 1/2 = S(p/q, q), independent of p and q (0 axioms)",
+      "innerSum_linear: PROVED exact linear growth S(p/q, n·q) = n/2, so rational α gives per-step drift 1/(2q) and a degenerate limiting distribution (0 axioms)",
+      "sum_mulmod_shift: PROVED the complete-residue-system identity Σ_{k<q} (p·(k+1) mod q) = Σ_{m<q} m for gcd(p,q)=1 — the arithmetic crux",
+      "fract_natDiv: PROVED Int.fract(a/q) = (a mod q)/q for naturals, the bridge from fractional parts to residues",
+      "deviation_rational_periodic / cyclic_sum_periodic: PROVED q-periodicity of the deviation summand and that a q-periodic function sums to the same value over any q consecutive indices — the period recurrence behind linear growth"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Erdős #1002 parent (asymptotic distribution of weighted fractional sums)",
+      "Fractional part {x} and its translation invariance {x+n} = {x}",
+      "Complete residue systems: multiplication by a unit permutes ℤ/qℤ",
+      "Continued fractions of rationals terminate; the last denominator is q"
+    ],
+    "lineCount": 212,
+    "relatedProblems": [
+      {
+        "id": "erdos-1002",
+        "relationship": "Direct parent: asks how the limiting distribution of S(α,n) depends on α; this entry settles the rational case (terminating continued fraction) with exact linear drift 1/(2q)"
+      },
+      {
+        "id": "erdos-1002-oq-01-oq-01-incomplete-01",
+        "relationship": "Sibling: establishes the a-priori envelope |S(α,n)| ≤ n/2 and the zero-mean ∫₀¹(1/2−{x})dx = 0 underlying the irrational/equidistributed case; this entry gives the exact value in the rational case where the drift is non-zero"
+      }
+    ],
+    "assumptions": "None. 0 axioms, 0 sorries (the theorems depend only on the foundational axioms propext, Classical.choice, Quot.sound; the two numeric corollary examples use kernel `decide`/`norm_num`, NOT `native_decide`, so no `Lean.ofReduceBool` is introduced). The per-period value 1/2 and the linear law S(p/q,n·q)=n/2 are elementary classical facts; the contribution is a clean, fully verified, 0-axiom formalization isolating the rational case of Erdős #1002 and exhibiting the continued-fraction dependence (drift slope 1/(2q)) explicitly.",
+    "theoremCount": 10,
+    "definitionCount": 2,
+    "structureCount": 0
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1002 concerns the limiting distribution of the weighted fractional sum f(α,n) = (1/log n)·Σ_{k=1}^n (1/2 − {αk}). Kesten (1960) proved that a two-parameter variant has a Cauchy limiting distribution; the one-parameter case remains open. The qualitative behaviour of the inner sum S(α,n) = Σ_{k=1}^n (1/2 − {αk}) depends sharply on the arithmetic of α: for badly approximable irrationals (bounded partial quotients, e.g. quadratic irrationals) the Denjoy–Koksma inequality keeps S bounded along continued-fraction denominators, while for general irrationals it can be unbounded. The rational endpoint of this spectrum — where the continued fraction terminates — is the cleanest case, and is what this entry pins down exactly.",
+    "problemStatement": "Determine, axiom-free, the exact behaviour of the inner sum S(α,n) = Σ_{k=1}^n (1/2 − {αk}) when α = p/q is rational (the terminating continued-fraction case of Erdős #1002), and exhibit the dependence on the continued-fraction data (the denominator q).",
+    "text": "A 212-line self-contained file proving that for a reduced fraction p/q the inner sum over one period is the universal constant 1/2 (S(p/q, q) = 1/2), and over n periods is exactly n/2 (S(p/q, n·q) = n/2) — hence linear growth with drift 1/(2q). All 0 sorries, 0 axioms, no native_decide.",
+    "proofStrategy": "Write each deviation term 1/2 − {(p/q)(k+1)} as 1/2 − (p·(k+1) mod q)/q using fract_natDiv (Int.fract(a/q) = (a mod q)/q). Over one period k ∈ {0,…,q−1}, the map k ↦ p·(k+1) mod q is injective because gcd(p,q)=1 (Nat.ModEq.cancel_left_of_coprime), hence — having the right cardinality — a bijection of range q onto itself (Finset.card_image_of_injOn); so Σ residues = Σ_{m<q} m = q(q−1)/2 (Finset.sum_range_id_mul_two). Summing, the q copies of 1/2 minus (q−1)/2 give exactly 1/2 (innerSum_period_sum). For linear growth, the summand is q-periodic (deviation_rational_periodic, from Int.fract_add_natCast), so its sum over any q consecutive indices is constant (cyclic_sum_periodic); this yields the period recurrence S(p/q, n+q) = S(p/q, n) + S(p/q, q), and induction on the number of periods gives S(p/q, n·q) = n/2 (innerSum_linear).",
+    "keyInsights": [
+      "**Rational = degenerate distribution.** Unlike the bounded (quadratic-irrational) or Cauchy (Kesten) regimes, rational α forces S(p/q,n) to grow linearly, so f(p/q,n) = S/log n → ∞: the limiting distribution is degenerate. This is the terminating-continued-fraction endpoint of the parent's spectrum.",
+      "**The per-period drift is a universal constant 1/2.** Over one full period the sum is exactly 1/2, independent of both the numerator p and the denominator q — a clean invariant hiding inside a p- and q-dependent sum.",
+      "**Continued-fraction dependence is exactly the denominator q.** The per-step drift is 1/(2q), where q is the last continued-fraction convergent denominator of the terminating expansion; this is the precise way the rational case 'depends on the continued fraction'.",
+      "**Complete residue system is the whole arithmetic.** The non-trivial cancellation comes solely from gcd(p,q)=1 making p·(k+1) mod q permute {0,…,q−1}, collapsing Σ{p(k+1)/q} to (q−1)/2.",
+      "**Periodicity ⟹ linearity for free.** Once the summand is shown q-periodic, no further arithmetic is needed: a periodic function sums identically over each block, so the whole growth is the single per-period constant repeated."
+    ],
+    "prerequisites": [
+      "Fractional part and its translation invariance {x+n} = {x}",
+      "Complete residue systems / units of ℤ/qℤ",
+      "Erdős #1002 parent entry (weighted fractional sums)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1002",
+      "relationship": "extends",
+      "description": "Settles the rational case of the parent's open question (dependence of S(α,n) on the continued-fraction expansion): terminating CF ⟹ linear drift with slope 1/(2q)."
+    },
+    {
+      "targetId": "erdos-1002-oq-01-oq-01-incomplete-01",
+      "relationship": "complements",
+      "description": "The sibling proves the a-priori envelope |S(α,n)| ≤ n/2 and zero mean for the equidistributed/irrational regime; this entry gives the exact non-zero drift in the rational regime."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 212,
+    "namespace": "Erdos1002OQ03",
+    "opens": ["Real"],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "substantiveTheoremCount": 2,
+    "computationalVerifications": 2,
+    "lemmaCount": 8,
+    "imports": ["Mathlib"],
+    "path": "Proofs/Erdos1002OQ03.lean",
+    "sorries": 0,
+    "definitionCount": 2
+  },
+  "conclusion": {
+    "summary": "A fully machine-checked (0 sorries, 0 axioms) resolution of the rational case of Erdős #1002: for a reduced fraction p/q the weighted fractional sum S(p/q,n) = Σ_{k=1}^n (1/2 − {(p/q)k}) over one period equals the universal constant 1/2, and over n periods equals exactly n/2 — hence linear growth with per-step drift 1/(2q) determined by the (terminating) continued-fraction denominator q.",
+    "implications": "Pins down the degenerate endpoint of Erdős #1002's distribution spectrum: rational α (terminating continued fraction) gives strictly linear drift, so f(α,n) = S/log n diverges and admits no proper limiting distribution — in sharp contrast to the bounded behaviour for badly approximable irrationals and the Cauchy law in Kesten's two-parameter variant. The explicit slope 1/(2q) makes the parent's 'dependence on the continued-fraction expansion' concrete in the rational case.",
+    "openQuestions": [
+      "Formalize the Denjoy–Koksma bound |S(α, q_k)| ≤ 1 along continued-fraction denominators q_k, giving the bounded-S regime for badly approximable α and a clean contrast with the rational linear drift.",
+      "For α with bounded partial quotients, bound the maximal excursion of S(α,n) in terms of Σ a_i (sum of partial quotients) via the Ostrowski representation, quantifying the continued-fraction dependence in the irrational case."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "innerSum_period_sum",
+      "type": "core",
+      "description": "Per-period value: for a reduced fraction p/q, S(p/q, q) = 1/2 — the universal per-period drift, independent of p and q (PROVED, 0 axioms)",
+      "leanType": "∀ (p q : ℕ), q ≥ 1 → Nat.gcd p q = 1 → innerSum (↑p / ↑q) q = 1 / 2"
+    },
+    {
+      "name": "innerSum_linear",
+      "type": "core",
+      "description": "Linear growth: S(p/q, n·q) = n/2 over n full periods, so rational α has per-step drift 1/(2q) and a degenerate limiting distribution (PROVED, 0 axioms)",
+      "leanType": "∀ (p q : ℕ), q ≥ 1 → Nat.gcd p q = 1 → ∀ (n : ℕ), innerSum (↑p / ↑q) (n * q) = ↑n / 2"
+    },
+    {
+      "name": "sum_mulmod_shift",
+      "type": "supporting",
+      "description": "Complete residue system: Σ_{k<q} (p·(k+1) mod q) = Σ_{m<q} m for gcd(p,q)=1 — the arithmetic crux (PROVED, 0 axioms)",
+      "leanType": "∀ (p q : ℕ), q ≥ 1 → Nat.gcd p q = 1 → ∑ k ∈ Finset.range q, (p * (k + 1)) % q = ∑ m ∈ Finset.range q, m"
+    },
+    {
+      "name": "fract_natDiv",
+      "type": "supporting",
+      "description": "Fractional part of a natural quotient: Int.fract(a/q) = (a mod q)/q for q > 0 — bridges fractional parts to residues (PROVED, 0 axioms)",
+      "leanType": "∀ (a q : ℕ), 0 < q → Int.fract ((↑a : ℝ) / ↑q) = (↑(a % q) : ℝ) / ↑q"
+    },
+    {
+      "name": "cyclic_sum_periodic",
+      "type": "supporting",
+      "description": "A q-periodic function sums to the same value over any q consecutive indices — the period recurrence behind linear growth (PROVED, 0 axioms)",
+      "leanType": "∀ (g : ℕ → ℝ) (q : ℕ), (∀ k, g (k + q) = g k) → ∀ (n : ℕ), ∑ k ∈ Finset.range q, g (n + k) = ∑ k ∈ Finset.range q, g k"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #1002 OQ-03 — the rational case (terminating continued fraction)

Erdős #1002 studies the limiting distribution of the weighted fractional sum
`S(α,n) = Σ_{k=1}^n (1/2 − {αk})`. The parent open question asks **how the behaviour depends on the continued-fraction expansion of α**. This PR resolves the **rational case** completely and axiom-free.

For a reduced fraction `α = p/q` (`gcd(p,q)=1`, `q ≥ 1`) the continued fraction terminates and the behaviour is the cleanest of all:

| Theorem | Statement | Meaning |
|---|---|---|
| `innerSum_period_sum` | `S(p/q, q) = 1/2` | the per-period drift is a **universal constant 1/2**, independent of `p` and `q` |
| `innerSum_linear` | `S(p/q, n·q) = n/2` | **exact linear growth**, per-step drift `1/(2q)` |

So for rational `α` the sum grows strictly linearly with slope `1/(2q)` set by the denominator `q` (the last continued-fraction convergent), and `f(α,n)=S/log n → ∞`: the limiting distribution is **degenerate** — the endpoint of the parent's spectrum, contrasting the bounded behaviour for badly approximable irrationals and Kesten's Cauchy law.

### Proof crux
- Write each deviation `1/2 − {(p/q)(k+1)} = 1/2 − (p·(k+1) mod q)/q` (`fract_natDiv`).
- Over one period, `k ↦ p·(k+1) mod q` is injective by `gcd(p,q)=1` (`Nat.ModEq.cancel_left_of_coprime`), hence a **bijection of `range q` onto itself** (`Finset.card_image_of_injOn`) — a complete residue system, so `Σ residues = Σ_{m<q} m = q(q−1)/2` (`Finset.sum_range_id_mul_two`). The `q` copies of `1/2` minus `(q−1)/2` give exactly `1/2`.
- The summand is `q`-periodic (`Int.fract_add_natCast`); a periodic function sums identically over each block (`cyclic_sum_periodic`), giving the recurrence `S(p/q,n+q)=S(p/q,n)+S(p/q,q)` and linear growth by induction.

### Verification
- **212 lines, 10 theorems / 2 definitions, 0 sorries, 0 axioms.**
- `#print axioms` on both headline theorems lists only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (no `native_decide`; the two numeric corollary examples use kernel `decide`/`norm_num`).
- Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)