### PR TITLE
research(pell-equation-oq-04-oq-01): finiteness classification of x²−Dy²=N — empty, {(0,0)}, or infinite [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3179,6 +3179,7 @@ import Proofs.PascalsHexagonOQ02
 import Proofs.PascalsHexagonOQ03
 import Proofs.PellEquation
 import Proofs.PellEquationOQ01
+import Proofs.PellEquationOQ04OQ01
 import Proofs.PellEquationOQ02
 import Proofs.PellEquationOQ05
 import Proofs.PellEquationOQ06

--- a/proofs/Proofs/PellEquationOQ04OQ01.lean
+++ b/proofs/Proofs/PellEquationOQ04OQ01.lean
@@ -1,0 +1,276 @@
+import Mathlib
+
+/-!
+# Pell OQ-04-OQ-01: Complete finiteness classification of `x² − D y² = N`
+
+## The open question
+
+The parent entry `pell-equation-oq-04` (`PellEquationOQ04.lean`) develops the general norm
+form `x² − D y² = N`: Brahmagupta multiplicativity, the Pell group of norm-`1` units, the
+group action on the `N`-solutions, and *infinitude from a single positive seed*. It explicitly
+left open the **classification side** ("how many orbit classes a given `N` has … is deeper and
+not attempted here"). The most basic classification question is the **finiteness dichotomy**:
+
+> For which right-hand sides `N` is the solution set of `x² − D y² = N` finite?
+
+This entry settles that completely for every positive non-square `D`.
+
+## Main results
+
+Write `S_N = {(x, y) : ℤ × ℤ | x² − D y² = N}`. For a positive non-square `D`:
+
+* `solutions_zero` — **the only finite *nonempty* case is `N = 0`**, where `S_0 = {(0,0)}` is the
+  single trivial point (non-squareness forces `x = y = 0`, via `Zsqrtd.norm_eq_zero`).
+* `solutions_infinite` — if `N ≠ 0` and `S_N` is nonempty, then `S_N` is **infinite**: a single
+  solution, pushed around the orbit of a fundamental unit, yields infinitely many.
+* `empty_or_infinite` — consequently, for `N ≠ 0`, `S_N` is **empty or infinite**.
+* `infinite_iff` — **the clean equivalence**: `S_N` is infinite `⟺ N ≠ 0 ∧ S_N` nonempty.
+* `nonempty_finite_iff_zero` — a nonempty `S_N` is finite `⟺ N = 0`.
+* `solution_set_trichotomy` — **the headline trichotomy**: every `S_N` is *empty*, the *single
+  point `{(0,0)}`* (exactly when `N = 0`), or *infinite*. There is no other possibility.
+
+The two engines are Mathlib's `Pell.exists_of_not_isSquare` (a nontrivial unit exists for any
+positive non-square `D`) and `Zsqrtd.norm_eq_zero` (the norm form vanishes only at the origin).
+The orbit machinery is re-derived locally so the file is **self-contained** (imports only
+Mathlib), mirroring the parent's `comp`/`orbit` constructions.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+namespace PellEquationOQ04OQ01
+
+/-- The **norm form** `normForm D x y = x² − D y²`, the norm of `x + y√D` in `ℤ[√D]`. -/
+def normForm (D x y : ℤ) : ℤ := x ^ 2 - D * y ^ 2
+
+/-- **Composition** of integer points (multiplication in `ℤ[√D]`):
+`(x + y√D)(u + v√D) = (xu + Dyv) + (xv + yu)√D`. -/
+def comp (D : ℤ) (p q : ℤ × ℤ) : ℤ × ℤ :=
+  (p.1 * q.1 + D * p.2 * q.2, p.1 * q.2 + p.2 * q.1)
+
+/-- **Brahmagupta multiplicativity**, packaged for `comp`: the norm of a product is the product
+of the norms. -/
+theorem normForm_comp (D : ℤ) (p q : ℤ × ℤ) :
+    normForm D (comp D p q).1 (comp D p q).2
+      = normForm D p.1 p.2 * normForm D q.1 q.2 := by
+  simp only [normForm, comp]; ring
+
+/-- The norm form is invariant under taking absolute values of both coordinates
+(`|x|² = x²`). -/
+theorem normForm_abs (D x y : ℤ) : normForm D |x| |y| = normForm D x y := by
+  simp only [normForm, sq_abs]
+
+/-! ## Orbit of a seed under a unit (re-derived compactly) -/
+
+/-- The **orbit** of a seed `(a, b)` under repeated composition with a fixed unit `(u, v)`. -/
+def orbit (D u v a b : ℤ) : ℕ → ℤ × ℤ
+  | 0 => (a, b)
+  | (k + 1) => comp D (orbit D u v a b k) (u, v)
+
+/-- Every point of the orbit of an `N`-solution is again an `N`-solution. -/
+theorem orbit_sol {D u v a b N : ℤ} (huv : normForm D u v = 1) (hab : normForm D a b = N) :
+    ∀ k, normForm D (orbit D u v a b k).1 (orbit D u v a b k).2 = N := by
+  intro k
+  induction k with
+  | zero => simpa [orbit] using hab
+  | succ k ih =>
+      have hstep : normForm D (orbit D u v a b (k + 1)).1 (orbit D u v a b (k + 1)).2
+           = normForm D (orbit D u v a b k).1 (orbit D u v a b k).2 * normForm D u v := by
+        simp only [orbit]; exact normForm_comp D _ (u, v)
+      rw [hstep, ih, huv, mul_one]
+
+/-- Positivity is preserved along the orbit when the seed and unit are positive. -/
+theorem orbit_pos {D u v a b : ℤ} (hD : 1 ≤ D) (hu : 2 ≤ u) (hv : 1 ≤ v)
+    (ha : 1 ≤ a) (hb : 0 ≤ b) :
+    ∀ k, 1 ≤ (orbit D u v a b k).1 ∧ 0 ≤ (orbit D u v a b k).2 := by
+  intro k
+  induction k with
+  | zero => exact ⟨ha, hb⟩
+  | succ k ih =>
+      obtain ⟨h1, h2⟩ := ih
+      simp only [orbit, comp]
+      refine ⟨?_, ?_⟩
+      · nlinarith [mul_le_mul h1 hu (by norm_num : (0:ℤ) ≤ 2) (by linarith : (0:ℤ) ≤ (orbit D u v a b k).1),
+          mul_nonneg (mul_nonneg (le_trans zero_le_one hD) h2) (le_trans zero_le_one hv)]
+      · nlinarith [mul_nonneg (le_trans zero_le_one h1) (le_trans zero_le_one hv),
+          mul_nonneg h2 (by linarith : (0:ℤ) ≤ u)]
+
+/-- The first coordinate strictly increases along the orbit (it at least doubles each step). -/
+theorem orbit_fst_strictMono {D u v a b : ℤ} (hD : 1 ≤ D) (hu : 2 ≤ u) (hv : 1 ≤ v)
+    (ha : 1 ≤ a) (hb : 0 ≤ b) :
+    StrictMono (fun k => (orbit D u v a b k).1) := by
+  apply strictMono_nat_of_lt_succ
+  intro k
+  obtain ⟨h1, h2⟩ := orbit_pos hD hu hv ha hb k
+  simp only [orbit, comp]
+  nlinarith [mul_le_mul_of_nonneg_left hu (le_trans zero_le_one h1),
+    mul_nonneg (mul_nonneg (le_trans zero_le_one hD) h2) (le_trans zero_le_one hv)]
+
+/-- **Infinitude from one positive seed.** If `D ≥ 1` admits a nontrivial unit `(u, v)` with
+`u ≥ 2`, `v ≥ 1`, and `x² − D y² = N` has a positive solution `(a, b)` (`a ≥ 1`, `b ≥ 0`), then
+the equation has infinitely many solutions. -/
+theorem infinite_solutions {D u v a b N : ℤ}
+    (hD : 1 ≤ D) (hu : 2 ≤ u) (hv : 1 ≤ v) (ha : 1 ≤ a) (hb : 0 ≤ b)
+    (huv : normForm D u v = 1) (hab : normForm D a b = N) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite := by
+  have hmono := orbit_fst_strictMono hD hu hv ha hb
+  have hinj : Function.Injective (fun k => orbit D u v a b k) := by
+    intro i j hij
+    exact hmono.injective (congrArg Prod.fst hij)
+  apply Set.infinite_of_injective_forall_mem hinj
+  intro k
+  simp only [Set.mem_setOf_eq]
+  exact orbit_sol huv hab k
+
+/-! ## A fundamental unit exists for positive non-squares -/
+
+/-- **A nontrivial Pell unit exists** for any positive non-square `D`: there are `u ≥ 2`, `v ≥ 1`
+with `u² − D v² = 1`. (From Mathlib's `Pell.exists_of_not_isSquare`, normalised by absolute
+values.) -/
+theorem exists_unit {D : ℤ} (hD : 0 < D) (hsq : ¬ IsSquare D) :
+    ∃ u v : ℤ, 2 ≤ u ∧ 1 ≤ v ∧ normForm D u v = 1 := by
+  obtain ⟨x, y, hxy, hy⟩ := Pell.exists_of_not_isSquare hD hsq
+  have hD1 : 1 ≤ D := by omega
+  have hya : 1 ≤ |y| := Int.one_le_abs hy
+  have hy2 : 1 ≤ y ^ 2 := by
+    nlinarith [sq_abs y, hya, abs_nonneg y, mul_le_mul hya hya zero_le_one (abs_nonneg y)]
+  have hDy : 1 ≤ D * y ^ 2 := by nlinarith [mul_le_mul hD1 hy2 zero_le_one (by linarith : (0:ℤ) ≤ D)]
+  have hx2 : 2 ≤ x ^ 2 := by nlinarith [hxy, hDy]
+  have hx0 : x ≠ 0 := by rintro rfl; norm_num at hx2
+  have hxa : 1 ≤ |x| := Int.one_le_abs hx0
+  refine ⟨|x|, |y|, ?_, hya, ?_⟩
+  · -- 2 ≤ |x| : from x² ≥ 2 we cannot have |x| ≤ 1
+    have hne1 : |x| ≠ 1 := by
+      rintro h1
+      have : x ^ 2 = 1 := by rw [← sq_abs, h1]; norm_num
+      omega
+    omega
+  · rw [normForm_abs]; simpa only [normForm] using hxy
+
+/-! ## The N = 0 case: only the trivial solution -/
+
+/-- **For a non-square `D`, the only solution of `x² − D y² = 0` is `(0,0)`.** Non-squareness
+makes the norm form anisotropic — it vanishes only at the origin (`Zsqrtd.norm_eq_zero`). -/
+theorem solutions_zero {D : ℤ} (hsq : ¬ IsSquare D) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = 0} = {(0, 0)} := by
+  have hns : ∀ n : ℤ, D ≠ n * n := fun n hn => hsq ⟨n, hn⟩
+  ext ⟨x, y⟩
+  simp only [Set.mem_setOf_eq, Set.mem_singleton_iff, Prod.mk.injEq]
+  constructor
+  · intro h
+    simp only [normForm] at h
+    have hz : Zsqrtd.norm (⟨x, y⟩ : Zsqrtd D) = 0 := by
+      show x * x - D * y * y = 0
+      linear_combination h
+    have h0 := (Zsqrtd.norm_eq_zero hns (⟨x, y⟩ : Zsqrtd D)).mp hz
+    rw [Zsqrtd.ext_iff] at h0
+    simpa using h0
+  · rintro ⟨rfl, rfl⟩
+    simp [normForm]
+
+/-! ## From any nonzero-`N` solution to a positive seed -/
+
+/-- **Normalising a solution to a positive seed.** Given a unit `(u, v)` and a solution `(x, y)`
+of `x² − D y² = N` with `N ≠ 0`, there is a *positive* seed `(a, b)` (`a ≥ 1`, `b ≥ 0`) of the
+same norm. If `x ≠ 0` take `(|x|, |y|)`; otherwise compose `(0, |y|)` once with the unit. -/
+theorem exists_pos_seed {D u v x y N : ℤ} (hD : 1 ≤ D) (hu : 2 ≤ u) (hv : 1 ≤ v)
+    (huv : normForm D u v = 1) (hN : N ≠ 0) (hxy : normForm D x y = N) :
+    ∃ a b : ℤ, 1 ≤ a ∧ 0 ≤ b ∧ normForm D a b = N := by
+  rcases eq_or_ne x 0 with hx | hx
+  · subst hx
+    have hy : y ≠ 0 := by
+      rintro rfl
+      apply hN
+      have hz : normForm D 0 0 = 0 := by simp [normForm]
+      rw [hz] at hxy; exact hxy.symm
+    have hya : 1 ≤ |y| := Int.one_le_abs hy
+    refine ⟨D * |y| * v, |y| * u, ?_, ?_, ?_⟩
+    · calc (1 : ℤ) = 1 * 1 * 1 := by norm_num
+        _ ≤ D * |y| * v := by gcongr
+    · exact mul_nonneg (abs_nonneg y) (by linarith)
+    · simp only [normForm] at huv hxy ⊢
+      linear_combination (-D * |y| ^ 2) * huv + hxy + (-D) * (sq_abs y)
+  · exact ⟨|x|, |y|, Int.one_le_abs hx, abs_nonneg y, by rw [normForm_abs]; exact hxy⟩
+
+/-! ## The infinitude dichotomy for `N ≠ 0` -/
+
+/-- **A nonempty nonzero-`N` solution set is infinite.** -/
+theorem solutions_infinite {D u v N : ℤ} (hD : 1 ≤ D) (hu : 2 ≤ u) (hv : 1 ≤ v)
+    (huv : normForm D u v = 1) (hN : N ≠ 0)
+    (hne : {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Nonempty) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite := by
+  obtain ⟨⟨x, y⟩, hxy⟩ := hne
+  simp only [Set.mem_setOf_eq] at hxy
+  obtain ⟨a, b, ha, hb, hab⟩ := exists_pos_seed hD hu hv huv hN hxy
+  exact infinite_solutions hD hu hv ha hb huv hab
+
+/-- **Empty-or-infinite** for `N ≠ 0` (given a fundamental unit). -/
+theorem empty_or_infinite {D u v N : ℤ} (hD : 1 ≤ D) (hu : 2 ≤ u) (hv : 1 ≤ v)
+    (huv : normForm D u v = 1) (hN : N ≠ 0) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = N} = ∅ ∨
+      {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite := by
+  rcases Set.eq_empty_or_nonempty {p : ℤ × ℤ | normForm D p.1 p.2 = N} with h | h
+  · exact Or.inl h
+  · exact Or.inr (solutions_infinite hD hu hv huv hN h)
+
+/-! ## The complete classification (positive non-square `D`) -/
+
+/-- **The clean equivalence.** For positive non-square `D`, the solution set of `x² − D y² = N`
+is infinite if and only if `N ≠ 0` and the set is nonempty. -/
+theorem infinite_iff {D N : ℤ} (hD : 0 < D) (hsq : ¬ IsSquare D) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite ↔
+      (N ≠ 0 ∧ {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Nonempty) := by
+  have hD1 : 1 ≤ D := by omega
+  obtain ⟨u, v, hu, hv, huv⟩ := exists_unit hD hsq
+  constructor
+  · intro hinf
+    refine ⟨?_, hinf.nonempty⟩
+    rintro rfl
+    rw [solutions_zero hsq] at hinf
+    exact hinf (Set.finite_singleton _)
+  · rintro ⟨hN, hne⟩
+    exact solutions_infinite hD1 hu hv huv hN hne
+
+/-- **A nonempty solution set is finite iff `N = 0`** (positive non-square `D`). -/
+theorem nonempty_finite_iff_zero {D N : ℤ} (hD : 0 < D) (hsq : ¬ IsSquare D)
+    (hne : {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Nonempty) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Finite ↔ N = 0 := by
+  constructor
+  · intro hfin
+    by_contra hN
+    exact (infinite_iff hD hsq).mpr ⟨hN, hne⟩ hfin
+  · rintro rfl
+    rw [solutions_zero hsq]; exact Set.finite_singleton _
+
+/-- **The headline trichotomy.** For positive non-square `D`, every solution set of
+`x² − D y² = N` is exactly one of: empty, the single point `{(0,0)}` (which happens precisely
+when `N = 0`), or infinite. -/
+theorem solution_set_trichotomy {D N : ℤ} (hD : 0 < D) (hsq : ¬ IsSquare D) :
+    {p : ℤ × ℤ | normForm D p.1 p.2 = N} = ∅ ∨
+      {p : ℤ × ℤ | normForm D p.1 p.2 = N} = {(0, 0)} ∨
+      {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite := by
+  rcases eq_or_ne N 0 with rfl | hN
+  · exact Or.inr (Or.inl (solutions_zero hsq))
+  · have hD1 : 1 ≤ D := by omega
+    obtain ⟨u, v, hu, hv, huv⟩ := exists_unit hD hsq
+    rcases empty_or_infinite hD1 hu hv huv hN with h | h
+    · exact Or.inl h
+    · exact Or.inr (Or.inr h)
+
+/-! ## Worked instances -/
+
+/-- `x² − 2y² = 0` has only the trivial solution `(0,0)` (since `2` is not a square). -/
+example : {p : ℤ × ℤ | normForm 2 p.1 p.2 = 0} = {(0, 0)} :=
+  solutions_zero Int.prime_two.not_isSquare
+
+/-- **`x² − 2y² = 7` has infinitely many integer solutions** — `7 ≠ 0` and `(3, 1)` is a
+solution (`9 − 2 = 7`), so by the classification the set is infinite. -/
+example : {p : ℤ × ℤ | normForm 2 p.1 p.2 = 7}.Infinite :=
+  (infinite_iff (by norm_num) Int.prime_two.not_isSquare).mpr
+    ⟨by norm_num, ⟨(3, 1), by norm_num [normForm]⟩⟩
+
+/-- **`x² − 2y² = 2` has infinitely many integer solutions** — witness `(2, 1)` (`4 − 2 = 2`). -/
+example : {p : ℤ × ℤ | normForm 2 p.1 p.2 = 2}.Infinite :=
+  (infinite_iff (by norm_num) Int.prime_two.not_isSquare).mpr
+    ⟨by norm_num, ⟨(2, 1), by norm_num [normForm]⟩⟩
+
+end PellEquationOQ04OQ01

--- a/research/problems/pell-equation-oq-04-oq-01/knowledge.md
+++ b/research/problems/pell-equation-oq-04-oq-01/knowledge.md
@@ -1,0 +1,72 @@
+# pell-equation-oq-04-oq-01: Finiteness classification of x² − Dy² = N
+
+**Status**: COMPLETED (0-axiom verified, no native_decide)
+**Lean file**: `proofs/Proofs/PellEquationOQ04OQ01.lean` (276 lines, 14 theorems, 3 defs)
+**PR**: (this session)
+
+## Problem
+
+Child of `pell-equation-oq-04` (the general norm form x²−Dy²=N: Brahmagupta
+multiplicativity, the Pell group, infinitude from a positive seed). The parent left
+the *classification* of solution sets open. This entry settles the **finiteness**
+half completely.
+
+## Result
+
+For a **positive non-square D**, the solution set `S_N = {(x,y) : x²−Dy²=N}` is
+exactly one of:
+
+* **empty** (no representation),
+* **the single point `{(0,0)}`** — precisely when `N = 0`,
+* **infinite**.
+
+Headline theorems:
+- `solution_set_trichotomy` — the three-way classification above.
+- `infinite_iff` — `S_N` infinite ⟺ `N ≠ 0 ∧ S_N` nonempty.
+- `nonempty_finite_iff_zero` — a nonempty `S_N` is finite ⟺ `N = 0`.
+- `solutions_zero` — anisotropy: `x²−Dy²=0` ⟹ `(0,0)` (non-square D).
+
+## Proof architecture
+
+Two Mathlib engines (both needing non-squareness):
+1. `Pell.exists_of_not_isSquare` → `exists_unit`: a normalized fundamental unit
+   (u ≥ 2, v ≥ 1, u²−Dv²=1). The bound u ≥ 2 comes from u² = 1 + Dv² ≥ 2.
+2. `Zsqrtd.norm_eq_zero` → `solutions_zero`: the ℤ[√D]-norm is anisotropic, so
+   `normForm D x y = 0` ⟹ x = y = 0. (Identify `normForm D x y` with the norm of
+   `⟨x,y⟩ : Zsqrtd D` via `show x*x − D*y*y = 0` + `linear_combination`.)
+
+Bridge: `exists_pos_seed` normalizes ANY nonzero-N solution to a positive seed of
+the same norm — `(|x|,|y|)` when x≠0, else compose `(0,|y|)` once with the unit
+(`(D|y|v, |y|u)`, norm N·1=N by `linear_combination (-D*|y|^2)*huv + hxy + (-D)*sq_abs y`).
+Then the parent-style orbit (re-derived locally) injects ℕ into `S_N`.
+
+## Gotchas / techniques
+
+- `¬ IsSquare (2:ℤ)` is NOT `by decide` (IsSquare = ∃ r, n = r*r, not decidable by
+  enumeration). Use `Int.prime_two.not_isSquare` (`Prime.not_isSquare` in
+  `Mathlib.Algebra.Prime.Lemmas`).
+- `Zsqrtd.norm_eq_zero` hypothesis is `∀ n, d ≠ n*n` (NOT `¬IsSquare`); convert via
+  `fun n hn => hsq ⟨n, hn⟩` (IsSquare unfolds to `∃ r, d = r*r`).
+- `Zsqrtd.norm ⟨x,y⟩` is defeq `x*x − D*y*y`; prove the value with `show x*x − D*y*y = 0`
+  then `linear_combination h` (ring won't unfold the `normForm` def — `simp only [normForm]`
+  the hypothesis first).
+- `gcongr` discharges `1*1*1 ≤ D*|y|*v` from `1≤D, 1≤|y|, 1≤v` in context by itself
+  (a trailing `<;> assumption` is then an unreachable-tactic warning — drop it).
+- `Int.one_le_abs (h : z ≠ 0) : 1 ≤ |z|`; `sq_abs : |a|^2 = a^2`.
+- 2 ≤ |x| from x²≥2: get x≠0 (`norm_num at hx2` after `rintro rfl`), |x|≥1, and
+  |x|≠1 (else x²=1), then `omega` (treats |x|, x^2 as atoms).
+- Docker was down → built single-file via `lake env lean` (pinned 4.26.0), produced
+  the olean with `-o .lake/build/lib/lean/Proofs/...olean` to run `#print axioms`.
+- MAIN-PATH WRITE TRAP again: first Write landed in the main repo (cwd resets to
+  worktree but absolute paths to main repo write there); copied into worktree and
+  removed the stray. Keep all writes under the worktree path.
+
+## Axioms
+
+All headline theorems: `[propext, Classical.choice, Quot.sound]` only — 0-axiom
+verified, no `sorryAx`, no `Lean.ofReduceBool`.
+
+## Follow-up open questions (left for future work)
+
+- Count the Pell-group orbit classes of a solvable N (class-number / genus theory).
+- Effective solvability criterion + smallest-solution bound in terms of D, N.

--- a/research/registry.json
+++ b/research/registry.json
@@ -21331,6 +21331,15 @@
       "lastUpdate": "2026-06-13T12:52:52.046Z"
     },
     {
+      "slug": "pell-equation-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-06-23",
+      "status": "graduated",
+      "lastUpdate": "2026-06-23",
+      "completed": "2026-06-23"
+    },
+    {
       "slug": "pell-equation-oq-05",
       "phase": "OBSERVE",
       "path": "full",

--- a/src/data/proofs/pell-equation-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/pell-equation-oq-04-oq-01/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-engines",
+    "proofId": "pell-equation-oq-04-oq-01",
+    "range": { "startLine": 124, "endLine": 191 },
+    "type": "insight",
+    "title": "Two Arithmetic Engines: A Unit Exists, and the Form is Anisotropic",
+    "content": "The classification rests on two Mathlib facts about non-square D. `exists_unit` takes the nontrivial Pell solution from `Pell.exists_of_not_isSquare` (Lagrange's theorem) and normalizes it by absolute values to a unit (|x|,|y|) with |x| ≥ 2 — the bound |x| ≥ 2 holds because x² = 1 + Dy² ≥ 2 when D,y² ≥ 1. `solutions_zero` handles the degenerate right-hand side: identifying normForm D x y with the ℤ[√D]-norm of ⟨x,y⟩, `Zsqrtd.norm_eq_zero` (the norm is anisotropic for non-square D) forces x = y = 0, so x²−Dy²=0 has only the trivial solution (0,0). These are exactly the two places non-squareness is used — for square D both fail."
+  },
+  {
+    "id": "ann-pos-seed",
+    "proofId": "pell-equation-oq-04-oq-01",
+    "range": { "startLine": 178, "endLine": 191 },
+    "type": "insight",
+    "title": "Infinitude Needs Only One Solution — Not a Positive One",
+    "content": "The parent proved infinitude from a *positive* seed; here `exists_pos_seed` removes that restriction. Given any solution (x,y) of x²−Dy²=N with N ≠ 0, it produces a positive seed (first coordinate ≥ 1, second ≥ 0) of the same norm. If x ≠ 0, take (|x|,|y|) — the norm is unchanged because |x|²=x². If x = 0, then N = −Dy² ≠ 0 forces y ≠ 0, and a single composition of (0,|y|) with the unit yields (D|y|v, |y|u), whose first coordinate D|y|v ≥ 1 and whose norm is still N·1 = N (a one-line `linear_combination` over the unit and seed norm equations). This is what upgrades the parent's seed-dependent infinitude into the clean dichotomy."
+  },
+  {
+    "id": "ann-trichotomy",
+    "proofId": "pell-equation-oq-04-oq-01",
+    "range": { "startLine": 230, "endLine": 261 },
+    "type": "insight",
+    "title": "The Complete Trichotomy: Empty, {(0,0)}, or Infinite",
+    "content": "Assembling the engines gives the full finiteness picture for positive non-square D. `solutions_infinite` says a nonempty nonzero-N set is infinite (normalize to a positive seed, then run the orbit). `infinite_iff` packages this as the sharp equivalence: the set is infinite ⟺ N ≠ 0 and it is nonempty — so deciding infinitude reduces entirely to deciding solvability. `nonempty_finite_iff_zero` says a nonempty set is finite ⟺ N = 0. Finally `solution_set_trichotomy` case-splits on N=0 (→ {(0,0)}) and otherwise on emptiness, concluding every solution set is empty, the single point {(0,0)}, or infinite — there is no nontrivial finite solution set."
+  }
+]

--- a/src/data/proofs/pell-equation-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-04-oq-01/meta.json
@@ -1,0 +1,198 @@
+{
+  "id": "pell-equation-oq-04-oq-01",
+  "slug": "pell-equation-oq-04-oq-01",
+  "title": "Finiteness Classification of x² − Dy² = N: Empty, the Single Point (0,0), or Infinite",
+  "sorries": 0,
+  "description": "Answers the parent (pell-equation-oq-04) open question on classifying the general norm form by settling the finiteness dichotomy completely. For a positive non-square D, the solution set of x² − Dy² = N is exactly one of: empty (no representation), the single trivial point {(0,0)} (precisely when N = 0), or infinite. Equivalently, the set is infinite iff N ≠ 0 and it is nonempty, and the only finite nonempty case is N = 0.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": [],
+    "namespace": "PellEquationOQ04OQ01",
+    "lineCount": 276,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 3,
+    "mainTheorems": [
+      {
+        "name": "solution_set_trichotomy",
+        "type": "headline",
+        "description": "The complete trichotomy: for positive non-square D, the solution set of x²−Dy²=N is empty, the single point {(0,0)} (exactly when N=0), or infinite — there is no other possibility.",
+        "leanType": "{D N : ℤ} → 0 < D → ¬ IsSquare D → ({p : ℤ × ℤ | normForm D p.1 p.2 = N} = ∅ ∨ {p : ℤ × ℤ | normForm D p.1 p.2 = N} = {(0, 0)} ∨ {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite)"
+      },
+      {
+        "name": "infinite_iff",
+        "type": "headline",
+        "description": "The clean equivalence: for positive non-square D, the solution set is infinite iff N ≠ 0 and the set is nonempty.",
+        "leanType": "{D N : ℤ} → 0 < D → ¬ IsSquare D → ({p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite ↔ (N ≠ 0 ∧ {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Nonempty))"
+      },
+      {
+        "name": "nonempty_finite_iff_zero",
+        "type": "key",
+        "description": "A nonempty solution set is finite iff N = 0 — the only finite nonempty representation problem is the trivial one.",
+        "leanType": "{D N : ℤ} → 0 < D → ¬ IsSquare D → {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Nonempty → ({p : ℤ × ℤ | normForm D p.1 p.2 = N}.Finite ↔ N = 0)"
+      },
+      {
+        "name": "solutions_zero",
+        "type": "key",
+        "description": "For non-square D the norm form is anisotropic: x²−Dy²=0 has only the trivial solution (0,0). Proved via Mathlib's Zsqrtd.norm_eq_zero.",
+        "leanType": "{D : ℤ} → ¬ IsSquare D → {p : ℤ × ℤ | normForm D p.1 p.2 = 0} = {(0, 0)}"
+      },
+      {
+        "name": "solutions_infinite",
+        "type": "key",
+        "description": "A nonempty nonzero-N solution set is infinite: any single solution is normalized to a positive seed and pushed around the orbit of a fundamental unit.",
+        "leanType": "{D u v N : ℤ} → 1 ≤ D → 2 ≤ u → 1 ≤ v → normForm D u v = 1 → N ≠ 0 → {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Nonempty → {p : ℤ × ℤ | normForm D p.1 p.2 = N}.Infinite"
+      },
+      {
+        "name": "exists_unit",
+        "type": "core",
+        "description": "A nontrivial Pell unit (u ≥ 2, v ≥ 1, u²−Dv²=1) exists for every positive non-square D, extracted and normalized by absolute values from Mathlib's Pell.exists_of_not_isSquare.",
+        "leanType": "{D : ℤ} → 0 < D → ¬ IsSquare D → ∃ u v : ℤ, 2 ≤ u ∧ 1 ≤ v ∧ normForm D u v = 1"
+      },
+      {
+        "name": "exists_pos_seed",
+        "type": "core",
+        "description": "Any nonzero-N solution can be replaced by a positive seed (first coord ≥ 1, second ≥ 0) of the same norm — directly via |x|,|y| when x≠0, or by one composition with the unit when x=0.",
+        "leanType": "{D u v x y N : ℤ} → 1 ≤ D → 2 ≤ u → 1 ≤ v → normForm D u v = 1 → N ≠ 0 → normForm D x y = N → ∃ a b : ℤ, 1 ≤ a ∧ 0 ≤ b ∧ normForm D a b = N"
+      }
+    ],
+    "path": "Proofs/PellEquationOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lagrange (1768), Brahmagupta (628 CE); formalized in Lean 4",
+    "date": "1768",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ04OQ01.lean",
+    "tags": [
+      "number-theory",
+      "pell-equation",
+      "diophantine",
+      "quadratic-forms",
+      "finiteness",
+      "classification"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 276,
+    "theoremCount": 14,
+    "definitionCount": 3,
+    "originalContributions": [
+      "solution_set_trichotomy: the complete finiteness picture for the general norm form — for positive non-square D, every solution set of x²−Dy²=N is empty, the single point {(0,0)}, or infinite, with the middle case occurring exactly when N=0.",
+      "infinite_iff: the sharp equivalence 'infinite ⟺ N≠0 and nonempty', isolating exactly when a representation problem has infinitely many solutions.",
+      "nonempty_finite_iff_zero: a nonempty solution set is finite iff N=0 — the only finite nonempty representation is the trivial origin.",
+      "solutions_zero: anisotropy of the norm form for non-square D (x²−Dy²=0 only at (0,0)), via Mathlib's Zsqrtd.norm_eq_zero, distinguishing the N=0 case from the square-D case where it would be infinite.",
+      "solutions_infinite + exists_pos_seed: upgrading the parent's 'infinitude from a positive seed' to 'infinitude from any single solution' by normalizing an arbitrary solution (including the x=0 case) to a positive seed of the same norm.",
+      "exists_unit: a self-contained extraction of a normalized fundamental unit (u≥2, v≥1) from Mathlib's Pell.exists_of_not_isSquare, the existence engine for the dichotomy.",
+      "A self-contained re-derivation of the orbit machinery (orbit, orbit_sol, orbit_pos, orbit_fst_strictMono, infinite_solutions) so the file imports only Mathlib."
+    ],
+    "prerequisites": [
+      "The general norm form x²−Dy²=N and Brahmagupta composition (parent pell-equation-oq-04)",
+      "Existence of a fundamental unit for positive non-square D (Lagrange)",
+      "The norm of ℤ[√D] vanishes only at 0 for non-square D (anisotropy)",
+      "Set.Infinite vs Set.Finite and injections from ℕ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Pell.exists_of_not_isSquare",
+        "description": "for positive non-square d there is a nontrivial solution of x²−dy²=1 with y≠0 — the existence of a fundamental unit that drives the infinitude side",
+        "module": "Mathlib.NumberTheory.Pell"
+      },
+      {
+        "theorem": "Zsqrtd.norm_eq_zero",
+        "description": "for non-square d the norm on ℤ[√d] is zero only at 0 — gives x²−Dy²=0 ⟹ x=y=0, the N=0 case",
+        "module": "Mathlib.NumberTheory.Zsqrtd.Basic"
+      },
+      {
+        "theorem": "Prime.not_isSquare",
+        "description": "a prime is not a square — used (with Int.prime_two) to discharge ¬IsSquare 2 in the worked instances",
+        "module": "Mathlib.Algebra.Prime.Lemmas"
+      },
+      {
+        "theorem": "Set.infinite_of_injective_forall_mem",
+        "description": "an injection ℕ → s forces s infinite — turns the strictly increasing orbit into infinitude of the solution set",
+        "module": "Mathlib.Data.Set.Finite"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Lagrange (1768) proved that for every positive non-square D the Pell equation x² − Dy² = 1 has a nontrivial solution — a fundamental unit of ℤ[√D]. Combined with Brahmagupta's composition law (628 CE), this makes the unit group act on the solutions of the general equation x² − Dy² = N. The parent entry built that action and showed 'one positive seed ⟹ infinitely many solutions'. The natural next question — the one this entry answers — is the qualitative finiteness classification: for which N is the solution set finite? The answer is strikingly clean: the only finite nonempty case is the degenerate N = 0, where non-squareness (anisotropy of the norm form) pins the solutions to the single point (0,0).",
+    "problemStatement": "**Open Question (parent pell-equation-oq-04, openQuestions[0])**: Classify the orbits / when is the solution set of x² − Dy² = N empty?\n\n**This entry**: settles the finiteness half completely. For positive non-square D, the solution set S_N = {(x,y) : x²−Dy²=N} is empty, equal to {(0,0)} (iff N=0), or infinite. Equivalently S_N is infinite ⟺ N≠0 and S_N is nonempty; a nonempty S_N is finite ⟺ N=0.",
+    "text": "A 276-line, fully verified (0 sorries, 0 axioms, no native_decide) self-contained file building on the parent's general norm form. Two Mathlib facts supply the engines — Pell.exists_of_not_isSquare (a fundamental unit exists for positive non-square D) and Zsqrtd.norm_eq_zero (the norm form is anisotropic for non-square D). The orbit machinery is re-derived locally. The contribution is the complete finiteness trichotomy and the sharp 'infinite ⟺ N≠0 ∧ nonempty' equivalence.",
+    "proofStrategy": "Three pieces combine. (1) exists_unit extracts a fundamental unit from Pell.exists_of_not_isSquare and normalizes it by absolute values to (|x|,|y|) with |x|≥2 (since x²=1+Dy²≥2) and |y|≥1. (2) solutions_zero handles N=0: identifying normForm D x y with the ℤ[√D]-norm of ⟨x,y⟩, Zsqrtd.norm_eq_zero (valid for non-square D) forces x=y=0. (3) For N≠0, exists_pos_seed normalizes an arbitrary solution to a positive seed of the same norm — directly (|x|,|y|) when x≠0, or by composing (0,|y|) once with the unit when x=0 (a linear_combination identity over the unit and seed norms) — and the parent-style orbit then injects ℕ into S_N, giving solutions_infinite. The headline theorems (infinite_iff, nonempty_finite_iff_zero, solution_set_trichotomy) assemble these by case-splitting on N=0 and on emptiness/nonemptiness.",
+    "keyInsights": [
+      "The general Pell equation obeys a perfect '0-or-∞' law away from N=0: with a fundamental unit available, a nonempty nonzero-N solution set is automatically infinite.",
+      "The single exception is N=0, and it is forced by anisotropy: for non-square D the form x²−Dy² vanishes only at the origin, so S_0 = {(0,0)} is the lone finite nonempty solution set.",
+      "Infinitude needs only one solution, not a positive one: any solution normalizes to a positive seed of the same norm — the x=0 case is repaired by a single composition with the unit.",
+      "A nontrivial unit necessarily has u ≥ 2 (because u² = 1 + Dv² ≥ 2), which is exactly the growth needed to make the orbit's first coordinate strictly increasing.",
+      "Non-squareness is the right hypothesis throughout: it both guarantees the unit exists (Lagrange) and makes the form anisotropic (the N=0 rigidity) — for square D both fail and N=0 has infinitely many solutions instead."
+    ]
+  },
+  "sections": [
+    {
+      "id": "orbit-machinery",
+      "title": "Norm Form, Composition, and the Orbit",
+      "startLine": 40,
+      "endLine": 122,
+      "summary": "normForm, comp, normForm_comp (Brahmagupta multiplicativity), normForm_abs, and the orbit infrastructure (orbit, orbit_sol, orbit_pos, orbit_fst_strictMono, infinite_solutions) re-derived to keep the file self-contained.",
+      "mathContext": "Multiplicativity of the ℤ[√D]-norm and a strictly increasing orbit are the tools for infinitude."
+    },
+    {
+      "id": "engines",
+      "title": "Fundamental Unit and Anisotropy",
+      "startLine": 124,
+      "endLine": 191,
+      "summary": "exists_unit (a normalized fundamental unit for positive non-square D, from Pell.exists_of_not_isSquare), solutions_zero (the N=0 case is {(0,0)} via Zsqrtd.norm_eq_zero), and exists_pos_seed (normalize any nonzero-N solution to a positive seed).",
+      "mathContext": "Lagrange existence and norm-form anisotropy are the two arithmetic inputs."
+    },
+    {
+      "id": "classification",
+      "title": "The Finiteness Classification",
+      "startLine": 192,
+      "endLine": 276,
+      "summary": "solutions_infinite and empty_or_infinite (the N≠0 dichotomy), then the headline results infinite_iff, nonempty_finite_iff_zero, and solution_set_trichotomy; worked instances for x²−2y²=0, x²−2y²=7, x²−2y²=2.",
+      "mathContext": "Assembling the engines into the complete empty / single-point / infinite trichotomy."
+    }
+  ],
+  "conclusion": {
+    "summary": "For every positive non-square D, the finiteness of x² − Dy² = N is fully classified: the solution set is empty, the single point {(0,0)} (exactly when N=0), or infinite. The qualitative theory thus reduces to a binary solvability question (is the set nonempty?) plus the degenerate N=0 case — there is never a nontrivial finite solution set.",
+    "implications": [
+      "Completes the finiteness half of the parent's classification open question, leaving only the quantitative orbit-count / class-number question.",
+      "Gives the sharp dichotomy 'infinite ⟺ N≠0 and nonempty', so deciding infinitude of x²−Dy²=N reduces entirely to deciding solvability.",
+      "Pinpoints non-squareness as the joint hypothesis behind both unit existence and the N=0 rigidity."
+    ],
+    "openQuestions": [
+      "Count the orbits: how many Pell-group orbit classes does a solvable N have (the class-number / genus theory of the form x²−Dy²)?",
+      "Give an effective solvability criterion and a bound on the smallest solution of x²−Dy²=N in terms of D and N."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Lagrange, Joseph-Louis",
+      "title": "Solution d'un problème d'arithmétique",
+      "year": "1768",
+      "venue": "Miscellanea Taurinensia",
+      "note": "Existence of a nontrivial unit (fundamental solution) for every positive non-square D."
+    },
+    {
+      "authors": "Brahmagupta",
+      "title": "Brāhmasphuṭasiddhānta",
+      "year": "628",
+      "venue": "—",
+      "note": "The composition law (samasa) for x² − Dy², underlying the orbit action used for infinitude."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-04",
+      "relationship": "extends",
+      "description": "Parent: the general norm form x²−Dy²=N, Brahmagupta multiplicativity, the Pell group, and infinitude from a positive seed. This entry settles the finiteness classification it left open."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The classical Pell equation x²−Dy²=1 (N=1): a nonempty nonzero-N case, hence infinite — a special instance of the classification."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Child of **pell-equation-oq-04** (the general norm form x²−Dy²=N: Brahmagupta multiplicativity, the Pell group, infinitude from a positive seed), which explicitly left the **classification of solution sets** open. This entry settles the **finiteness** half completely.

For a **positive non-square D**, the solution set `S_N = {(x,y) : x²−Dy²=N}` is exactly one of:

- **empty** (no representation),
- **the single point `{(0,0)}`** — precisely when `N = 0`,
- **infinite**.

There is no nontrivial finite solution set.

## Main theorems

- `solution_set_trichotomy` — the complete three-way classification.
- `infinite_iff` — `S_N` infinite ⟺ `N ≠ 0 ∧ S_N` nonempty (so deciding infinitude reduces entirely to deciding solvability).
- `nonempty_finite_iff_zero` — a nonempty `S_N` is finite ⟺ `N = 0`.
- `solutions_zero` — anisotropy of the form for non-square D: `x²−Dy²=0 ⟹ (0,0)`.
- `exists_unit` / `exists_pos_seed` — the supporting engines.

## Mechanism

Two Mathlib facts (both needing non-squareness): `Pell.exists_of_not_isSquare` (a fundamental unit exists → normalized to u≥2, v≥1) and `Zsqrtd.norm_eq_zero` (the ℤ[√D]-norm is anisotropic → the N=0 rigidity). `exists_pos_seed` upgrades the parent's "infinitude from a positive seed" to "infinitude from any single solution" (the x=0 case repaired by one composition with the unit), and a locally re-derived orbit injects ℕ into `S_N`.

## Verification

- 276 lines, 14 theorems, 3 defs.
- **0 sorries, 0 axiom declarations, no `native_decide`.**
- `#print axioms` on all headline theorems: `[propext, Classical.choice, Quot.sound]` only.
- Compiled against Mathlib (Lean v4.26.0). Self-contained (imports only Mathlib).

🤖 Generated with [Claude Code](https://claude.com/claude-code)