### PR TITLE
research(quadratic-gauss-sum-square-oq-04-oq-01): the squared Gauss sum p*=g² is a fundamental discriminant [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3274,6 +3274,7 @@ import Proofs.QuadraticGaussSumSquare
 import Proofs.QuadraticGaussSumSquareOQ01
 import Proofs.QuadraticGaussSumSquareOQ02
 import Proofs.QuadraticGaussSumSquareOQ04
+import Proofs.QuadraticGaussSumSquareOQ04OQ01
 import Proofs.QuadraticReciprocity
 import Proofs.QuadraticReciprocityAlgorithmOQ01
 import Proofs.QuadraticReciprocityAlgorithmOQ02

--- a/proofs/Proofs/QuadraticGaussSumSquareOQ04OQ01.lean
+++ b/proofs/Proofs/QuadraticGaussSumSquareOQ04OQ01.lean
@@ -1,0 +1,173 @@
+/-
+  The squared quadratic Gauss sum `p*` is a fundamental discriminant.
+
+  Setup (parent entry `QuadraticGaussSumSquareOQ04`): for an odd prime `p` and a
+  primitive additive character `ψ : ZMod p → ℂ`, the quadratic Gauss sum
+  `g = gaussSum (chiC p) ψ` satisfies
+
+      g² = p* := (-1)^((p-1)/2) · p,            and      minpoly ℚ g = X² − p*,
+
+  so `g` generates the unique quadratic subfield `ℚ(√p*)` of the `p`-th
+  cyclotomic field `ℚ(ζ_p)`.  The parent settled *that* `ℚ(g)` is quadratic; the
+  sibling `oq-01` settled the sign/reality of `g`.  This child settles the
+  **arithmetic type of the discriminant** `p*` itself.
+
+  The arithmetic engine is the *first supplement to quadratic reciprocity*
+  repackaged for `p*`:
+
+      p ≡ 1 (mod 4)  ⟹  p* =  p   (positive),
+      p ≡ 3 (mod 4)  ⟹  p* = −p   (negative),
+
+  and — the new point — in **both** cases
+
+      p* ≡ 1 (mod 4).
+
+  Since `|p*| = p` is prime, `p*` is squarefree; together with `p* ≡ 1 (mod 4)`
+  this makes `p*` a **fundamental discriminant** (`pstar_isFundamentalDiscriminant`).
+  It is therefore exactly the discriminant of the quadratic field `ℚ(√p*) = ℚ(g)`
+  the Gauss sum generates — not merely a number whose square root lies there.
+  (The congruence `p* ≡ 1 (mod 4)` is also the arithmetic reason that field is
+  ramified only at `p`, with conductor `p` rather than `4p`; and it explains why
+  the order `ℤ[g]`, of polynomial discriminant `4p*`, is the non-maximal order of
+  index `2` inside the ring of integers `ℤ[(1+√p*)/2]`.)
+
+  The capstone `gaussSum_sq_isFundamentalDiscriminant` packages this as a single
+  statement about the Gauss sum: `g²` equals an integer that is a fundamental
+  discriminant.  This is distinct from the sibling `oq-01` (which proves the
+  real/imaginary dichotomy `g.im = 0` ⟺ `p ≡ 1 mod 4`) and from the parent
+  `oq-04` (the minimal polynomial and field degree); neither identifies `p*` as a
+  fundamental discriminant.
+
+  The parent infrastructure (`chiC`, `gaussSum_sq_eq`) is re-derived here from
+  Mathlib's generic `gaussSum_sq` so this file stands alone; everything from
+  `pstar_eq_self` onward is the new content.
+-/
+import Mathlib
+
+open scoped BigOperators
+open Polynomial
+
+namespace QuadraticGaussSumSquareOQ04OQ01
+
+variable {p : ℕ} [Fact p.Prime]
+
+/-! ## The character and the square formula (parent entry, re-derived) -/
+
+/-- `ℂ`-valued quadratic character mod `p`, from the integer-valued
+`quadraticChar (ZMod p)` composed with `ℤ → ℂ`. -/
+noncomputable def chiC (p : ℕ) [Fact p.Prime] : MulChar (ZMod p) ℂ :=
+  (quadraticChar (ZMod p)).ringHomComp (Int.castRingHom ℂ)
+
+theorem chiC_isQuadratic : (chiC p).IsQuadratic :=
+  (quadraticChar_isQuadratic (ZMod p)).comp (Int.castRingHom ℂ)
+
+theorem chiC_ne_one (hp : p ≠ 2) : chiC p ≠ 1 := by
+  have hchar : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp
+  exact (MulChar.ringHomComp_ne_one_iff ((Int.castRingHom ℂ).injective_int)).mpr
+    (quadraticChar_ne_one hchar)
+
+theorem chiC_neg_one (hp : p ≠ 2) :
+    chiC p (-1) = (-1 : ℂ) ^ ((p - 1) / 2) := by
+  have hpp : p.Prime := Fact.out
+  have hodd : Odd p := hpp.odd_of_ne_two hp
+  have hchar : ringChar (ZMod p) ≠ 2 := by rw [ZMod.ringChar_zmod_n]; exact hp
+  have hq : quadraticChar (ZMod p) (-1) = (-1 : ℤ) ^ (p / 2) := by
+    rw [quadraticChar_neg_one hchar, ZMod.card p]
+    exact ZMod.χ₄_eq_neg_one_pow (Nat.odd_iff.mp hodd)
+  have hpe : p / 2 = (p - 1) / 2 := by obtain ⟨k, rfl⟩ := hodd; omega
+  simp only [chiC, MulChar.ringHomComp_apply, hq, map_pow, map_neg, map_one]
+  rw [hpe]
+
+/-- The integer `p* = (-1)^((p-1)/2) · p`. -/
+def pstar (p : ℕ) : ℤ := (-1) ^ ((p - 1) / 2) * (p : ℤ)
+
+/-- **Square of the quadratic Gauss sum** (the parent result, restated with the
+right-hand side packaged as `p*`). -/
+theorem gaussSum_sq_eq (hp : p ≠ 2) {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    gaussSum (chiC p) ψ ^ 2 = (pstar p : ℂ) := by
+  calc gaussSum (chiC p) ψ ^ 2
+      = chiC p (-1) * (Fintype.card (ZMod p) : ℂ) :=
+        gaussSum_sq (chiC_ne_one hp) chiC_isQuadratic hψ
+    _ = (-1 : ℂ) ^ ((p - 1) / 2) * p := by rw [chiC_neg_one hp, ZMod.card p]
+    _ = (pstar p : ℂ) := by simp only [pstar]; push_cast; ring
+
+/-! ## The arithmetic type of `p*` -/
+
+/-- The mod-4 case split for an odd prime: `p % 4 = 1` or `p % 4 = 3`. -/
+theorem mod_four_cases (hp : p ≠ 2) : p % 4 = 1 ∨ p % 4 = 3 := by
+  have hpp : p.Prime := Fact.out
+  have hodd : p % 2 = 1 := Nat.odd_iff.mp (hpp.odd_of_ne_two hp)
+  omega
+
+omit [Fact p.Prime] in
+/-- **First supplement, positive branch.** When `p ≡ 1 (mod 4)`, `p* = p`. -/
+theorem pstar_eq_self (hp1 : p % 4 = 1) : pstar p = (p : ℤ) := by
+  have he : Even ((p - 1) / 2) := by rw [Nat.even_iff]; omega
+  simp [pstar, he.neg_one_pow]
+
+omit [Fact p.Prime] in
+/-- **First supplement, negative branch.** When `p ≡ 3 (mod 4)`, `p* = -p`. -/
+theorem pstar_eq_neg (hp3 : p % 4 = 3) : pstar p = -(p : ℤ) := by
+  have ho : Odd ((p - 1) / 2) := by rw [Nat.odd_iff]; omega
+  rw [pstar, ho.neg_one_pow]; ring
+
+/-- `|p*| = p`. -/
+theorem pstar_natAbs (hp : p ≠ 2) : (pstar p).natAbs = p := by
+  rcases mod_four_cases hp with h | h
+  · rw [pstar_eq_self h]; simp
+  · rw [pstar_eq_neg h]; simp
+
+/-- **`p*` is positive iff `p ≡ 1 (mod 4)`.** -/
+theorem pstar_pos_iff (hp : p ≠ 2) : 0 < pstar p ↔ p % 4 = 1 := by
+  have hpp : p.Prime := Fact.out
+  have hppos : (0 : ℤ) < p := by exact_mod_cast hpp.pos
+  constructor
+  · intro hpos
+    rcases mod_four_cases hp with h | h
+    · exact h
+    · rw [pstar_eq_neg h] at hpos; linarith
+  · intro h; rw [pstar_eq_self h]; exact hppos
+
+/-- **`p*` is negative iff `p ≡ 3 (mod 4)`.** -/
+theorem pstar_neg_iff (hp : p ≠ 2) : pstar p < 0 ↔ p % 4 = 3 := by
+  have hpp : p.Prime := Fact.out
+  have hppos : (0 : ℤ) < p := by exact_mod_cast hpp.pos
+  constructor
+  · intro hneg
+    rcases mod_four_cases hp with h | h
+    · rw [pstar_eq_self h] at hneg; linarith
+    · exact h
+  · intro h; rw [pstar_eq_neg h]; linarith
+
+/-- **`p* ≡ 1 (mod 4)`** for every odd prime `p`.  This is the arithmetic heart
+of the first supplement: in both residue classes `p*` lands in `1 + 4ℤ`. -/
+theorem pstar_one_mod_four (hp : p ≠ 2) : pstar p ≡ 1 [ZMOD 4] := by
+  rcases mod_four_cases hp with h | h
+  · rw [pstar_eq_self h]; exact Int.modEq_iff_dvd.mpr (by omega)
+  · rw [pstar_eq_neg h]; exact Int.modEq_iff_dvd.mpr (by omega)
+
+/-- **`p*` is squarefree** (its absolute value `p` is prime). -/
+theorem pstar_squarefree (hp : p ≠ 2) : Squarefree (pstar p) := by
+  have hpp : p.Prime := Fact.out
+  rw [← Int.squarefree_natAbs, pstar_natAbs hp]
+  exact hpp.squarefree
+
+/-- **`p*` is a fundamental discriminant**: it is squarefree and `≡ 1 (mod 4)`.
+Equivalently, `p*` is exactly the discriminant of the quadratic field `ℚ(√p*)`
+that the Gauss sum generates. -/
+theorem pstar_isFundamentalDiscriminant (hp : p ≠ 2) :
+    Squarefree (pstar p) ∧ pstar p ≡ 1 [ZMOD 4] :=
+  ⟨pstar_squarefree hp, pstar_one_mod_four hp⟩
+
+/-! ## The Gauss sum squares to a fundamental discriminant -/
+
+/-- **Capstone.** The square of the quadratic Gauss sum is (the image of) an
+integer `D = p*` that is a *fundamental discriminant*: squarefree and `≡ 1
+(mod 4)`.  Equivalently, `g² = D` where `D` is exactly the discriminant of the
+quadratic field `ℚ(g) = ℚ(√D)`. -/
+theorem gaussSum_sq_isFundamentalDiscriminant (hp : p ≠ 2)
+    {ψ : AddChar (ZMod p) ℂ} (hψ : ψ.IsPrimitive) :
+    ∃ D : ℤ, gaussSum (chiC p) ψ ^ 2 = (D : ℂ) ∧ Squarefree D ∧ D ≡ 1 [ZMOD 4] :=
+  ⟨pstar p, gaussSum_sq_eq hp hψ, pstar_squarefree hp, pstar_one_mod_four hp⟩
+
+end QuadraticGaussSumSquareOQ04OQ01

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-04-oq-01/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-04-oq-01/meta.json
@@ -1,0 +1,82 @@
+{
+  "id": "quadratic-gauss-sum-square-oq-04-oq-01",
+  "title": "The Squared Quadratic Gauss Sum is a Fundamental Discriminant",
+  "slug": "quadratic-gauss-sum-square-oq-04-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "BigOperators",
+      "Polynomial"
+    ],
+    "namespace": "QuadraticGaussSumSquareOQ04OQ01",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 2,
+    "path": "Proofs/QuadraticGaussSumSquareOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "description": "The parent oq-04 proves the quadratic Gauss sum g = gaussSum(χ, ψ) of an odd prime p generates the unique quadratic subfield ℚ(√p*) of the cyclotomic field ℚ(ζ_p), where p* = (−1)^((p−1)/2)·p and g² = p*; the sibling oq-01 settles the real/imaginary sign of g. This entry settles the arithmetic type of the discriminant p* itself. The first supplement to quadratic reciprocity gives p* = p when p ≡ 1 (mod 4) and p* = −p when p ≡ 3 (mod 4), so |p*| = p is prime and p* is squarefree; the new arithmetic point is that in BOTH residue classes p* ≡ 1 (mod 4) (for p ≡ 1 the value p is ≡ 1; for p ≡ 3 the value −p ≡ −3 ≡ 1). Squarefree together with ≡ 1 (mod 4) means p* is a fundamental discriminant — it is exactly the discriminant of the quadratic field ℚ(√p*) = ℚ(g) the Gauss sum generates, not merely a number whose square root lies there. The congruence p* ≡ 1 (mod 4) is the arithmetic reason that field is ramified only at p (conductor p, not 4p) and that the order ℤ[g], of polynomial discriminant 4p*, is the index-2 non-maximal suborder of the ring of integers ℤ[(1+√p*)/2]. The capstone gaussSum_sq_isFundamentalDiscriminant packages this as a single statement about the Gauss sum: g² equals an integer that is a fundamental discriminant. This is distinct from oq-01 (the reality dichotomy) and oq-04 (minimal polynomial and field degree); neither identifies p* as a fundamental discriminant. The parent square identity gaussSum_sq_eq is re-derived in-file from Mathlib's generic gaussSum_sq so the file is self-contained. Fully machine-verified with no axioms and no sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/QuadraticGaussSumSquareOQ04OQ01.lean",
+    "tags": [
+      "number-theory",
+      "gauss-sum",
+      "quadratic-character",
+      "fundamental-discriminant",
+      "quadratic-field",
+      "cyclotomic-field",
+      "quadratic-reciprocity",
+      "discriminant",
+      "zmod"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 173,
+    "theoremCount": 14,
+    "definitionCount": 2,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "The quadratic Gauss sum $g$ of an odd prime $p$ squares to $p^* = (-1)^{(p-1)/2}p$, a sign-corrected version of $p$ that is the central character of the Gauss-sum proof of quadratic reciprocity. The sign $(-1)^{(p-1)/2}$ — the first supplement to reciprocity — is precisely what makes $p^*$ congruent to $1$ modulo $4$ in every case, and that congruence is no accident: $p^*$ is the *discriminant* of the quadratic field $\\mathbb{Q}(\\sqrt{p^*})$, the unique quadratic subfield of $\\mathbb{Q}(\\zeta_p)$. Among integers $D$, those that arise as discriminants of quadratic fields — the *fundamental discriminants* — are exactly the squarefree $D \\equiv 1 \\pmod 4$ together with $4m$ for squarefree $m \\equiv 2,3 \\pmod 4$. That $p^*$ falls into the first family, with conductor $p$ rather than $4p$, is the arithmetic fact underlying the tame ramification of $\\mathbb{Q}(\\sqrt{p^*})$ at $p$ and the conductor–discriminant formula for the quadratic subfield of the cyclotomic field.",
+    "problemStatement": "Let $p$ be an odd prime and $p^* = (-1)^{(p-1)/2}p$, so that the quadratic Gauss sum satisfies $g^2 = p^*$. Prove that $p^*$ is a fundamental discriminant: it is squarefree and $p^* \\equiv 1 \\pmod 4$. Equivalently, show $g^2$ is (the image of) an integer that is exactly the discriminant of the quadratic field $\\mathbb{Q}(g) = \\mathbb{Q}(\\sqrt{p^*})$ it generates.",
+    "proofStrategy": "The work splits on $p \\bmod 4$, which for an odd prime is $1$ or $3$ (`mod_four_cases`). The parity of the exponent $(p-1)/2$ is read off directly: $p \\equiv 1 \\pmod 4$ makes it even, so $p^* = p$ (`pstar_eq_self`); $p \\equiv 3 \\pmod 4$ makes it odd, so $p^* = -p$ (`pstar_eq_neg`). From these, $|p^*| = p$ (`pstar_natAbs`), and the sign of $p^*$ is determined by the residue (`pstar_pos_iff`, `pstar_neg_iff`). The two arithmetic pillars follow: $p^* \\equiv 1 \\pmod 4$ uniformly (`pstar_one_mod_four`, via `Int.modEq_iff_dvd` and `omega` in each branch — $p-1$ resp. $p+1$ is divisible by $4$), and $p^*$ is squarefree because its absolute value $p$ is prime (`pstar_squarefree`, via `Int.squarefree_natAbs` and `Nat.Prime.squarefree`). Bundling gives `pstar_isFundamentalDiscriminant`. The capstone `gaussSum_sq_isFundamentalDiscriminant` combines the re-derived square identity `gaussSum_sq_eq` with the fundamental-discriminant property to state that $g^2$ is the image of a fundamental discriminant.",
+    "keyInsights": [
+      "The single new arithmetic fact is uniform: $p^* \\equiv 1 \\pmod 4$ in BOTH residue classes. For $p \\equiv 1 \\pmod 4$ the value is $p \\equiv 1$; for $p \\equiv 3 \\pmod 4$ the value is $-p \\equiv -3 \\equiv 1$. The sign $(-1)^{(p-1)/2}$ is exactly engineered to land $p^*$ in $1 + 4\\mathbb{Z}$ regardless of the class of $p$.",
+      "Squarefree plus $\\equiv 1 \\pmod 4$ is the definition of a fundamental discriminant of the first family. So $p^*$ is not just an integer whose square root generates $\\mathbb{Q}(g)$ — it is the genuine field discriminant, with conductor $p$ rather than $4p$.",
+      "This is the discriminant-level refinement that the siblings do not reach: oq-04 identifies the minimal polynomial $X^2 - p^*$ and the field degree $2$, and oq-01 identifies the real/imaginary sign of $g$, but neither records that $p^*$ is a fundamental discriminant — the arithmetic content that pins down ramification and the index-$2$ relationship between $\\mathbb{Z}[g]$ and the maximal order.",
+      "The polynomial discriminant of the minimal polynomial $X^2 - p^*$ is $4p^* = 2^2 \\cdot p^*$; since the field discriminant is the fundamental discriminant $p^*$, the factor $2^2$ is exactly the squared index $[\\mathcal{O}_K : \\mathbb{Z}[g]]^2$, exhibiting $\\mathbb{Z}[g]$ as the non-maximal order of index $2$ inside $\\mathbb{Z}[(1+\\sqrt{p^*})/2]$."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every odd prime $p$, the discriminant $p^* = (-1)^{(p-1)/2}p$ — the square of the quadratic Gauss sum — is machine-verified to be a fundamental discriminant: squarefree and $\\equiv 1 \\pmod 4$. The capstone states this directly for the Gauss sum: $g^2$ is the image of an integer that is a fundamental discriminant. The proof is elementary (a mod-4 case split feeding `omega` and `Int.squarefree_natAbs`) and uses no axioms and no sorries.",
+    "implications": "Recording $p^*$ as a fundamental discriminant upgrades the parent's field identity $\\mathbb{Q}(g) = \\mathbb{Q}(\\sqrt{p^*})$ to a statement about the field's discriminant: $\\mathbb{Q}(\\sqrt{p^*})$ has discriminant exactly $p^*$, conductor $p$, and is ramified only at $p$. This is the arithmetic input to the conductor–discriminant formula for the quadratic subfield of $\\mathbb{Q}(\\zeta_p)$ and to the Gauss-sum proof of quadratic reciprocity, where the splitting of a second prime $q$ in this field is governed by $(p^*/q)$.",
+    "openQuestions": [
+      "Can one formalise the ring of integers $\\mathcal{O}_K = \\mathbb{Z}[(1+\\sqrt{p^*})/2]$ and prove $[\\mathcal{O}_K : \\mathbb{Z}[g]] = 2$ directly, turning the index-2 remark into a verified statement about the order generated by the Gauss sum?",
+      "For the quartic Gauss sum attached to a prime $p \\equiv 1 \\pmod 4$, is the analogous squared quantity a fundamental discriminant (or conductor) of the corresponding subfield of $\\mathbb{Q}(\\zeta_p)$?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-04",
+      "relationship": "extends",
+      "description": "The parent proves g has minimal polynomial X² − p* and generates the quadratic field ℚ(√p*). This entry refines that by identifying p* itself as a fundamental discriminant — the actual discriminant of ℚ(√p*) = ℚ(g)."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square-oq-01",
+      "relationship": "related",
+      "description": "The sibling oq-01 reads the sign of p* as the real/imaginary dichotomy of g (g.im = 0 iff p ≡ 1 mod 4). This entry instead reads the arithmetic of p*: it is squarefree and ≡ 1 mod 4, hence a fundamental discriminant."
+    },
+    {
+      "proofId": "quadratic-gauss-sum-square",
+      "relationship": "related",
+      "description": "The grandparent establishes the square identity g² = p*. This entry classifies the value p* arithmetically, showing it is the fundamental discriminant of the quadratic field the Gauss sum generates."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

A follow-up child of the merged **oq-04** (*The Quadratic Gauss Sum Generates a Quadratic Field*, #27840). Where oq-04 proved `g² = p*`, `minpoly_ℚ(g) = X²−p*`, and `ℚ(g) = ℚ(√p*)`, and the sibling **oq-01** settled the real/imaginary sign of `g`, this entry settles the **arithmetic type of the discriminant `p*` itself**:

> For every odd prime `p`, `p* = (−1)^((p−1)/2)·p` (the square of the quadratic Gauss sum) is a **fundamental discriminant** — squarefree and `≡ 1 (mod 4)` — hence the *genuine field discriminant* of `ℚ(√p*) = ℚ(g)`, not merely a number whose square root lies there.

The new arithmetic point is uniform across both residue classes:
- `p ≡ 1 (mod 4)` ⟹ `p* = p ≡ 1 (mod 4)`,
- `p ≡ 3 (mod 4)` ⟹ `p* = −p ≡ −3 ≡ 1 (mod 4)`.

The sign `(−1)^((p−1)/2)` is exactly engineered to land `p*` in `1 + 4ℤ` regardless of the class of `p`. Together with squarefreeness (`|p*| = p` is prime), this is the definition of a fundamental discriminant. It is the arithmetic reason `ℚ(√p*)` has conductor `p` (not `4p`) and that `ℤ[g]` is the index-2 non-maximal suborder of `ℤ[(1+√p*)/2]`.

**Capstone** `gaussSum_sq_isFundamentalDiscriminant`: `g²` equals (the image of) an integer that is a fundamental discriminant.

## Distinctness from siblings
- **oq-04** (parent): minimal polynomial `X²−p*` and field degree `[ℚ(g):ℚ]=2`.
- **oq-01** (sibling): real/imaginary dichotomy `g.im = 0 ⟺ p ≡ 1 mod 4`.
- **This entry**: `p*` is a fundamental discriminant (`p* ≡ 1 mod 4` ∧ squarefree). Neither sibling records this discriminant-level fact. The reality dichotomy was deliberately *not* duplicated.

## Verification
- 14 theorems, 2 defs, 173 lines, **0 axioms, 0 sorries**.
- `#print axioms` on the capstone reports only `propext, Classical.choice, Quot.sound` (the foundational three; no `Lean.ofReduceBool`, no `sorryAx`).
- Builds against Mathlib v4.26.0. Self-contained (re-derives the parent square identity `gaussSum_sq_eq` from Mathlib's generic `gaussSum_sq`).
- `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)