### PR TITLE
Enrich: Frobenius' Identity (the moment numerator is the Eulerian polynomial)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-fro-overview",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Frobenius' identity: two faces of the Eulerian polynomial",
+    "content": "The docstring sets up the goal: clearing the denominator (1−r)^{m+1} in the sibling entry's moment formula turns the Stirling sum into a single polynomial numerator Nₘ(X) = ∑ₖ S(m,k)·k!·Xᵏ·(1−X)^{m−k}, which is the Eulerian polynomial Eₘ(X). The entry proves the two standard descriptions coincide — the first-order differential recurrence E₀=1, E_{m+1}=X(1−X)E'ₘ+(m+1)X·Eₘ, and the Stirling closed form — purely algebraically over any commutative ring, with no appeal to analysis. This answers the headline open question recorded on oq-07, oq-10, and oq-07-oq-01: identify the moment numerator with the Eulerian polynomial.",
+    "mathContext": "$N_m(X) = \\sum_{k=0}^m S(m,k)\\,k!\\,X^k(1-X)^{m-k} = E_m(X)$, with $\\sum_n n^m X^n = E_m(X)/(1-X)^{m+1}$.",
+    "significance": "context",
+    "relatedConcepts": ["Eulerian polynomials", "Eulerian numbers", "Stirling numbers", "Worpitzky's identity", "moments"],
+    "prerequisites": ["polynomials", "combinatorics", "generating functions"]
+  },
+  {
+    "id": "ann-fro-definitions",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 73 },
+    "type": "definition",
+    "title": "The two definitions: differential recurrence vs Stirling form",
+    "content": "eulerPoly defines the Eulerian polynomial recursively by its classical first-order differential recurrence E₀ = 1, E_{m+1} = X·(1−X)·E'ₘ + (m+1)·X·Eₘ — a polynomial ODE in the formal derivative. stirlingForm defines the rival closed form Nₘ(X) = ∑_{k=0}^{m} S(m,k)·k!·Xᵏ·(1−X)^{m−k} directly from the Stirling numbers. Both live in R[X] over an arbitrary commutative ring R, so the eventual equality is a ring-level polynomial identity, independent of the analytic moment interpretation.",
+    "mathContext": "$E_0 = 1,\\ E_{m+1} = X(1-X)E_m' + (m+1)X\\,E_m$;\\quad $N_m = \\sum_k S(m,k)k!X^k(1-X)^{m-k}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eulerian polynomials", "formal derivative", "polynomial ring", "Stirling numbers"],
+    "prerequisites": ["polynomial rings", "formal derivatives"]
+  },
+  {
+    "id": "ann-fro-key-term",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01",
+    "range": { "startLine": 75, "endLine": 102 },
+    "type": "technique",
+    "title": "Per-summand derivative computation (key_term)",
+    "content": "key_term is the reusable algebraic workhorse: it computes X·(1−X)·d/dX(a·Xᵏ·(1−X)ᵖ) = a·k·Xᵏ·(1−X)^{p+1} − a·p·X^{k+1}·(1−X)ᵖ. Crucially the X^{k−1} and (1−X)^{p−1} boundary factors are cleared, so each differentiated term lands back in the clean Xᵏ / X^{k+1} basis used by stirlingForm. This makes the term-by-term differentiation of the Stirling form tractable and keeps the result inside the same span of basis monomials.",
+    "mathContext": "$X(1-X)\\frac{d}{dX}\\big(a X^k(1-X)^p\\big) = a\\,k\\,X^k(1-X)^{p+1} - a\\,p\\,X^{k+1}(1-X)^p.$",
+    "significance": "technical",
+    "relatedConcepts": ["formal derivative", "product rule", "polynomial manipulation"],
+    "prerequisites": ["formal derivatives", "polynomial algebra"]
+  },
+  {
+    "id": "ann-fro-stirlingform-succ",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01",
+    "range": { "startLine": 103, "endLine": 182 },
+    "type": "insight",
+    "title": "The heart: the Stirling form satisfies the Eulerian recurrence",
+    "content": "stirlingForm_succ is the algebraic core: it shows Nₘ also satisfies N_{m+1} = X·(1−X)·N'ₘ + (m+1)·X·Nₘ. Differentiating Nₘ term by term via key_term and collecting coefficients, the resulting sum matches the next Stirling form exactly through the Stirling recurrence S(m+1,k+1) = (k+1)·S(m,k+1) + S(m,k), with the boundary terms S(m,m+1) = 0 and S(m+1,0) = 0 vanishing. Since eulerPoly and stirlingForm satisfy the same first-order recurrence with the same initial value N₀ = E₀ = 1, eulerPoly_eq_stirlingForm (Frobenius' identity) concludes they are equal by induction.",
+    "mathContext": "$N_{m+1} = X(1-X)N_m' + (m+1)X\\,N_m \\Rightarrow N_m = E_m$ (same recurrence + $N_0 = 1$).",
+    "significance": "key",
+    "relatedConcepts": ["Frobenius' identity", "Stirling recurrence", "induction", "Eulerian polynomials", "uniqueness of recurrence solution"],
+    "prerequisites": ["formal derivatives", "Stirling numbers", "induction"]
+  },
+  {
+    "id": "ann-fro-rowsum",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01",
+    "range": { "startLine": 183, "endLine": 215 },
+    "type": "concept",
+    "title": "Low-order values and the row sum Eₘ(1) = m!",
+    "content": "The low orders are computed explicitly: E₁ = X, E₂ = X + X², E₃ = X + 4X² + X³, whose integer coefficients are the Eulerian numbers ⟨m,k⟩ (1; 1,1; 1,4,1). eval_eulerPoly_one evaluates the Stirling form at X = 1, where the factor (1−X)^{m−k} = 0^{m−k} kills every term except k = m, leaving S(m,m)·m! = m!. This is the classical row-sum identity: the Eulerian numbers of order m sum to m!, reflecting that they count the n descents/ascents over all m! permutations.",
+    "mathContext": "$E_m(1) = \\sum_k \\langle m,k\\rangle = m!$ — the Eulerian numbers of order $m$ partition the $m!$ permutations by descent count.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eulerian numbers", "row sum", "permutation descents", "factorial"],
+    "prerequisites": ["Eulerian numbers", "polynomial evaluation"]
+  },
+  {
+    "id": "ann-fro-generating",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01",
+    "range": { "startLine": 216, "endLine": 247 },
+    "type": "insight",
+    "title": "The compact generating identity ∑ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1}",
+    "content": "hasSum_pow_mul_geometric_eulerPoly combines Frobenius' identity with the imported analytic moment formula (GeometricSeriesOQ07OQ01.hasSum_pow_mul_geometric) to produce the single-fraction form ∑ₙ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1} for |r| < 1 over ℝ. This is the compact Eulerian-polynomial form anticipated across oq-07, oq-10, and oq-07-oq-01: one polynomial numerator over the single denominator (1−r)^{m+1}, replacing the per-order Stirling sum. The bridge between the algebraic identity (over any ring) and the analytic moment (over ℝ) is exactly the substitution X = r.",
+    "mathContext": "$\\sum_{n\\ge 0} n^m r^n = \\dfrac{E_m(r)}{(1-r)^{m+1}}$ for $|r| < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["generating function", "Eulerian polynomials", "geometric moments", "Worpitzky's identity"],
+    "prerequisites": ["infinite series", "Eulerian polynomials", "generating functions"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01/meta.json
@@ -20,6 +20,56 @@
     "sorries": 0
   },
   "title": "Frobenius' Identity: the Geometric Moment Numerator is the Eulerian Polynomial",
+  "description": "Clearing the denominator (1−r)^{m+1} in the geometric moment formula ∑ₙ nᵐ rⁿ turns its numerator into a single polynomial, the Eulerian polynomial Eₘ(X). This entry proves Frobenius' identity over any commutative ring: the Eulerian polynomial defined by its first-order differential recurrence E₀=1, E_{m+1}=X(1−X)E'ₘ+(m+1)X·Eₘ equals the Stirling closed form ∑ₖ S(m,k)·k!·Xᵏ·(1−X)^{m−k}. The core is that the Stirling form satisfies the same recurrence (a term-by-term formal-derivative computation matched against the Stirling recurrence). It records the row sum Eₘ(1)=m!, the low orders E₁=X, E₂=X+X², E₃=X+4X²+X³, and the compact generating identity ∑ₙ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1}. 247 lines, 10 theorems, 2 definitions, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Eulerian numbers ⟨m,k⟩ count permutations of an m-element set with exactly k descents; their generating polynomials Eₘ(X) = ∑ₖ ⟨m,k⟩ Xᵏ are the Eulerian polynomials, introduced by Leonhard Euler in his 1755 study of the alternating-sign evaluation of ∑ nᵐ xⁿ. The identity proved here — that the moment numerator equals the Eulerian polynomial — is essentially Frobenius' (1910) reformulation, who connected the Eulerian polynomials to the Stirling numbers of the second kind and to the representation theory of the symmetric group. The bridge between the two descriptions is Worpitzky's identity (1883), nᵐ = ∑ₖ ⟨m,k⟩·(n+k choose m). The closed form ∑ₙ nᵐ Xⁿ = Eₘ(X)/(1−X)^{m+1} is the standard 'geometric' normalisation found in Graham–Knuth–Patashnik's Concrete Mathematics and in Comtet's Advanced Combinatorics. Mathlib has the Stirling numbers but neither the Eulerian numbers nor this identity, so the entry builds the Eulerian polynomial from scratch (via its differential recurrence) to make the identification.",
+    "problemStatement": "Identify the numerator of the geometric moment closed form with the Eulerian polynomial: prove that ∑_{k=0}^{m} S(m,k)·k!·Xᵏ·(1−X)^{m−k} equals the Eulerian polynomial Eₘ(X) (defined by its classical differential recurrence) over any commutative ring, and deduce the single-fraction generating identity ∑ₙ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1} for |r| < 1.",
+    "proofStrategy": "Define eulerPoly by the recurrence E₀ = 1, E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ and stirlingForm by the Stirling sum, both in R[X]. The lemma key_term computes the per-summand action X(1−X)·d/dX(a·Xᵏ(1−X)ᵖ), clearing boundary factors so the result stays in the Xᵏ basis. stirlingForm_succ then shows the Stirling form obeys the same differential recurrence, by collecting the differentiated terms and matching coefficients through the Stirling recurrence S(m+1,k+1) = (k+1)S(m,k+1) + S(m,k) with vanishing boundary terms. Since both polynomials satisfy the same first-order recurrence with the same initial value, eulerPoly_eq_stirlingForm follows by induction. Evaluating the Stirling form at X = 1 (where 0^{m−k} kills all but k = m) gives the row sum Eₘ(1) = m!; substituting X = r and combining with the imported analytic moment formula gives the generating identity over ℝ.",
+    "keyInsights": [
+      "Two classically different descriptions of the Eulerian polynomial — a first-order differential recurrence and a Stirling-number sum — define the same object; the proof is a uniqueness-of-recurrence-solution argument, not a coefficient comparison.",
+      "The technical crux is that X(1−X)·d/dX preserves the Xᵏ·(1−X)ᵖ basis (key_term): the derivative of each basis element re-expands cleanly, so the differential recurrence can be checked summand by summand.",
+      "The matching of differentiated terms is exactly the Stirling recurrence S(m+1,k+1) = (k+1)S(m,k+1) + S(m,k) — the same recurrence that drove the sibling entry's monomial expansion, now appearing on the numerator side.",
+      "The row sum Eₘ(1) = m! is immediate from the Stirling form (only the k = m term survives at X = 1), recovering the combinatorial fact that the Eulerian numbers of order m partition the m! permutations by descent count.",
+      "The result is ring-agnostic: Frobenius' identity is proved over an arbitrary commutative ring, and the analytic moment identity over ℝ is then just the specialization X = r — separating the algebraic content from the convergence question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: the Eulerian polynomial and Frobenius' identity",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "The file docstring: clearing (1−r)^{m+1} in the sibling moment formula yields the Eulerian polynomial numerator; the goal is to identify the Stirling closed form with the Eulerian polynomial (defined by its differential recurrence) over any commutative ring, plus imports and the ring variable."
+    },
+    {
+      "id": "definitions",
+      "title": "Part 1: the two definitions",
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "eulerPoly — the Eulerian polynomial by its first-order differential recurrence E₀=1, E_{m+1}=X(1−X)E'ₘ+(m+1)X·Eₘ; and stirlingForm — the Stirling closed form ∑ₖ S(m,k)·k!·Xᵏ·(1−X)^{m−k}. Both in R[X]."
+    },
+    {
+      "id": "frobenius",
+      "title": "Part 2: Frobenius' identity eulerPoly = stirlingForm",
+      "startLine": 75,
+      "endLine": 182,
+      "summary": "key_term (the per-summand derivative, clearing boundary factors), stirlingForm_succ (the Stirling form satisfies the Eulerian differential recurrence, via the Stirling recurrence with vanishing boundaries), and eulerPoly_eq_stirlingForm (the two agree, by induction on matching recurrences)."
+    },
+    {
+      "id": "low-orders-rowsum",
+      "title": "Part 3: low-order values and the row sum",
+      "startLine": 183,
+      "endLine": 215,
+      "summary": "eulerPoly_one/two/three (E₁=X, E₂=X+X², E₃=X+4X²+X³, coefficients the Eulerian numbers 1; 1,1; 1,4,1) and eval_eulerPoly_one (the row sum Eₘ(1)=m!, from evaluating the Stirling form at X=1)."
+    },
+    {
+      "id": "generating-identity",
+      "title": "Part 4: the moment generating identity over ℝ",
+      "startLine": 216,
+      "endLine": 247,
+      "summary": "hasSum_pow_mul_geometric_eulerPoly combines Frobenius' identity with the imported analytic moment formula to give ∑ₙ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1} for |r| < 1 — the compact single-fraction form anticipated by oq-07, oq-10, and oq-07-oq-01."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01`.

Rich `meta.meta` and `conclusion` but no top-level `description`, no `overview`, empty `sections`, and no `annotations.json`. Added all four:

- **`description`** — Frobenius' identity and the compact generating identity.
- **`overview`** — `historicalContext` (Euler 1755, Frobenius 1910, Worpitzky's identity, descent statistics), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **`sections`** — 5 sections covering all 247 lines (overview, the two definitions, Frobenius' identity, low orders + row sum, the generating identity).
- **`annotations.json`** — 6 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the two-faces overview, the differential-recurrence vs Stirling definitions, the `key_term` derivative lemma, the `stirlingForm_succ` core + Frobenius' identity, the row sum Eₘ(1)=m!, and the ∑ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1} generating identity.

**Verification:** both files valid JSON; `annotations:validate` reports no line-resolution warnings. Content added only.