### PR TITLE
research(erdos-1000-oq-03-oq-01): combinatorial characterization of Jordan's totient J_k [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -913,6 +913,7 @@ import Proofs.ElementaryQuadraticReciprocityOQ03OQ03
 import Proofs.Erdos1000OQ01
 import Proofs.Erdos1000OQ01Aristotle
 import Proofs.Erdos1000OQ03
+import Proofs.Erdos1000OQ03OQ01
 import Proofs.Erdos1000Problem
 import Proofs.Erdos1001OQ02
 import Proofs.Erdos1001OQ02OQ01

--- a/proofs/Proofs/Erdos1000OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1000OQ03OQ01.lean
@@ -1,0 +1,179 @@
+import Mathlib
+
+/-!
+# The combinatorial characterization of Jordan's totient `J_k`
+
+**Follow-up open question (`erdos-1000-oq-03-oq-01`).**  The gallery entry
+`erdos-1000-oq-03` builds the divisor-sum / multiplicativity theory of **Jordan's
+totient** `J_k` from its *Dirichlet-convolution* definition `J_k = μ * pow k`,
+explicitly *deferring* the combinatorial counting definition.  This file closes
+that gap: it proves that the convolution closed form really does **count tuples**.
+
+Define
+$$ C_k(n) \;=\; \#\bigl\{\, (a_0,\dots,a_{k-1}) \in (\mathbb{Z}/n)^k \;:\;
+      \gcd(a_0,\dots,a_{k-1},n) = 1 \,\bigr\}. $$
+
+## What this file proves (0 axioms, 0 sorries)
+
+* `jordanCount_divisor_sum` : `∑_{d ∣ n} C_k(d) = n^k`
+  — the Gauss-type divisor identity (generalizes `∑_{d∣n} φ(d) = n`), proved by a
+  *bijective* fiberwise count: every tuple mod `n` scales uniquely from a
+  jointly-coprime tuple mod `n/d`, where `d = gcd(a₀,…,a_{k-1},n)`.
+* `jordanCount_eq_moebius_sum` : `C_k(n) = ∑_{d ∣ n} μ(d)·(n/d)^k`
+  — the explicit **Jordan totient** closed form, obtained from the divisor sum by
+  Möbius inversion.  This is exactly `(μ * pow k)(n)`, so the combinatorial count
+  `C_k` agrees with the Dirichlet-convolution `J_k` of `erdos-1000-oq-03`.
+* `jordanCount_one_eq_totient` : `C_1(n) = φ(n)` — recovers Euler's totient,
+  confirming the count specializes correctly at `k = 1`.
+
+The whole development rests on one elementary bijection plus Mathlib's Möbius
+inversion (`ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq`); no analysis.
+-/
+
+open Finset ArithmeticFunction
+
+namespace Erdos1000OQ03OQ01
+
+/-- The gcd of all coordinates of a tuple `a : Fin k → Fin n`, taken as naturals.
+This is `gcd(a₀, …, a_{k-1})`; jointly coprime to `n` means `gcd(this, n) = 1`. -/
+def gv {k n : ℕ} (a : Fin k → Fin n) : ℕ := univ.gcd (fun i => (a i).val)
+
+/-- The set of `k`-tuples in `(ℤ/n)^k` whose coordinates are *jointly coprime* to
+`n`, i.e. `gcd(a₀, …, a_{k-1}, n) = 1`. -/
+def coprimeTuples (k n : ℕ) : Finset (Fin k → Fin n) :=
+  univ.filter (fun a => Nat.Coprime (gv a) n)
+
+/-- Jordan's totient as a count: `C_k(n) = #{ jointly-coprime k-tuples mod n }`. -/
+def jordanCount (k n : ℕ) : ℕ := (coprimeTuples k n).card
+
+/-- Scaling all coordinates by `d` multiplies the coordinate-gcd by `d`. -/
+private lemma gcd_smul (k d : ℕ) (f : Fin k → ℕ) :
+    univ.gcd (fun i => d * f i) = d * univ.gcd f := by
+  simpa [normalize_eq] using
+    Finset.gcd_mul_left (s := (univ : Finset (Fin k))) (f := f) (a := d)
+
+/-- Dividing all coordinates (each a multiple of `d`) by `d` divides the gcd by `d`. -/
+private lemma gcd_div (k d : ℕ) (f : Fin k → ℕ) (hd : 0 < d) (hdf : ∀ i, d ∣ f i) :
+    univ.gcd (fun i => f i / d) = (univ.gcd f) / d := by
+  have key : d * univ.gcd (fun i => f i / d) = univ.gcd f := by
+    rw [← gcd_smul k d (fun i => f i / d)]
+    exact Finset.gcd_congr rfl fun i _ => Nat.mul_div_cancel' (hdf i)
+  rw [← key, Nat.mul_div_cancel_left _ hd]
+
+/-- **Gauss-type divisor identity for Jordan's totient.**
+`∑_{d ∣ n} C_k(d) = n^k`, the exact generalization of `∑_{d∣n} φ(d) = n`. -/
+theorem jordanCount_divisor_sum (k : ℕ) {n : ℕ} (hn : 0 < n) :
+    ∑ d ∈ n.divisors, jordanCount k d = n ^ k := by
+  classical
+  -- content of a tuple: the gcd of its coordinates together with `n`.
+  -- every content lands in `n.divisors`
+  have hmaps : ∀ a ∈ (univ : Finset (Fin k → Fin n)),
+      Nat.gcd (gv a) n ∈ n.divisors := by
+    intro a _
+    exact Nat.mem_divisors.mpr ⟨Nat.gcd_dvd_right _ _, hn.ne'⟩
+  -- fiberwise count of all `n^k` tuples
+  have hcard : (univ : Finset (Fin k → Fin n)).card
+      = ∑ d ∈ n.divisors, (univ.filter (fun a => Nat.gcd (gv a) n = d)).card :=
+    Finset.card_eq_sum_card_fiberwise hmaps
+  -- each fiber over `d` has exactly `C_k(n/d)` elements
+  have hfiber : ∀ d ∈ n.divisors,
+      (univ.filter (fun a : Fin k → Fin n => Nat.gcd (gv a) n = d)).card
+        = jordanCount k (n / d) := by
+    intro d hd
+    obtain ⟨hdn, hn0⟩ := Nat.mem_divisors.mp hd
+    have hdpos : 0 < d := Nat.pos_of_mem_divisors hd
+    have hdmul : d * (n / d) = n := Nat.mul_div_cancel' hdn
+    rw [jordanCount]
+    -- key per-tuple facts inside the fiber: `d ∣ (a i).val` for all `i`.
+    have hdvd : ∀ a : Fin k → Fin n, Nat.gcd (gv a) n = d → ∀ i, d ∣ (a i).val := by
+      intro a hca i
+      have h1 : d ∣ gv a := by rw [← hca]; exact Nat.gcd_dvd_left _ _
+      exact h1.trans (Finset.gcd_dvd (mem_univ i))
+    refine Finset.card_bij'
+      (i := fun a ha => fun i => (⟨(a i).val / d, ?_⟩ : Fin (n / d)))
+      (j := fun b _ => fun i => (⟨d * (b i).val, ?_⟩ : Fin n))
+      ?hi ?hj ?hl ?hr
+    · -- bound: `(a i).val / d < n / d`
+      have hca : Nat.gcd (gv a) n = d := (mem_filter.mp ha).2
+      have : d * ((a i).val / d) < d * (n / d) := by
+        rw [Nat.mul_div_cancel' (hdvd a hca i), hdmul]; exact (a i).isLt
+      exact lt_of_mul_lt_mul_left this (Nat.zero_le d)
+    · -- bound: `d * (b i).val < n`
+      have : d * (b i).val < d * (n / d) := mul_lt_mul_of_pos_left (b i).isLt hdpos
+      rwa [hdmul] at this
+    · -- forward map lands in `coprimeTuples k (n/d)`
+      intro a ha
+      have hgcd : Nat.gcd (gv a) n = d := (mem_filter.mp ha).2
+      refine mem_filter.mpr ⟨mem_univ _, ?_⟩
+      show Nat.Coprime (univ.gcd (fun i => (a i).val / d)) (n / d)
+      rw [gcd_div k d (fun i => (a i).val) hdpos (hdvd a hgcd)]
+      have hpos : 0 < Nat.gcd (gv a) n := hgcd ▸ hdpos
+      have := Nat.coprime_div_gcd_div_gcd hpos
+      rwa [hgcd] at this
+    · -- backward map lands in the fiber `gcd = d`
+      intro b hb
+      refine mem_filter.mpr ⟨mem_univ _, ?_⟩
+      have hcop : Nat.gcd (univ.gcd (fun i => (b i).val)) (n / d) = 1 := (mem_filter.mp hb).2
+      show Nat.gcd (univ.gcd (fun i => d * (b i).val)) n = d
+      rw [gcd_smul k d (fun i => (b i).val)]
+      have hkey : Nat.gcd (d * univ.gcd (fun i => (b i).val)) (d * (n / d))
+          = d * Nat.gcd (univ.gcd (fun i => (b i).val)) (n / d) := Nat.gcd_mul_left _ _ _
+      rw [hcop, mul_one, hdmul] at hkey
+      exact hkey
+    · -- left inverse: scaling back recovers `a`
+      intro a ha
+      have hca : Nat.gcd (gv a) n = d := (mem_filter.mp ha).2
+      funext i
+      exact Fin.ext (Nat.mul_div_cancel' (hdvd a hca i))
+    · -- right inverse: dividing back recovers `b`
+      intro b _
+      funext i
+      exact Fin.ext (Nat.mul_div_cancel_left _ hdpos)
+  rw [Finset.card_univ, Fintype.card_fun] at hcard
+  simp only [Fintype.card_fin] at hcard
+  -- `n^k = ∑_{d|n} C_k(n/d) = ∑_{d|n} C_k(d)`
+  rw [hcard, Finset.sum_congr rfl hfiber]
+  exact (Nat.sum_div_divisors n (jordanCount k)).symm
+
+/-- **The explicit Jordan-totient closed form, from Möbius inversion of the divisor
+sum.**  `C_k(n) = ∑_{d ∣ n} μ(d)·(n/d)^k`, which is exactly `(μ * pow k)(n)` — so the
+combinatorial count `C_k` coincides with the Dirichlet-convolution `J_k` of
+`erdos-1000-oq-03`. -/
+theorem jordanCount_eq_moebius_sum (k : ℕ) {n : ℕ} (hn : 0 < n) :
+    (jordanCount k n : ℤ)
+      = ∑ d ∈ n.divisors, (moebius d : ℤ) * (((n / d) ^ k : ℕ) : ℤ) := by
+  have H : ∀ m, 0 < m → ∑ i ∈ m.divisors, (jordanCount k i : ℤ) = ((m ^ k : ℕ) : ℤ) := by
+    intro m hm
+    rw [← Nat.cast_sum, jordanCount_divisor_sum k hm]
+  have hinv := (ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq
+      (f := fun i => (jordanCount k i : ℤ))
+      (g := fun m => ((m ^ k : ℕ) : ℤ))).mp H n hn
+  rw [← hinv, Nat.sum_divisorsAntidiagonal (fun p q => (moebius p : ℤ) • ((q ^ k : ℕ) : ℤ))]
+  exact Finset.sum_congr rfl fun d _ => by simp
+
+/-- **Euler recovery: `C_1(n) = φ(n)`.**  The `k = 1` count of integers coprime to
+`n` is precisely Euler's totient, confirming `J_1 = φ`. -/
+theorem jordanCount_one_eq_totient (n : ℕ) : jordanCount 1 n = Nat.totient n := by
+  classical
+  -- `gv` of a length-one tuple is just its single coordinate.
+  have hgv : ∀ a : Fin 1 → Fin n, gv a = (a 0).val := by
+    intro a
+    rw [gv, Finset.univ_unique, Finset.gcd_singleton, normalize_eq]
+    rfl
+  rw [jordanCount, coprimeTuples, Nat.totient]
+  refine Finset.card_bij' (fun a _ => (a 0).val)
+    (fun x hx => fun _ => ⟨x, Finset.mem_range.mp (Finset.mem_filter.mp hx).1⟩) ?_ ?_ ?_ ?_
+  · intro a ha
+    have : Nat.Coprime (gv a) n := (mem_filter.mp ha).2
+    rw [hgv] at this
+    exact mem_filter.mpr ⟨Finset.mem_range.mpr (a 0).isLt, this.symm⟩
+  · intro x hx
+    have hc : Nat.Coprime n x := (mem_filter.mp hx).2
+    refine mem_filter.mpr ⟨mem_univ _, ?_⟩
+    rw [hgv]
+    exact hc.symm
+  · intro a _; funext i; fin_cases i; rfl
+  · intro x _; rfl
+
+end Erdos1000OQ03OQ01
+

--- a/src/data/proofs/erdos-1000-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-01/meta.json
@@ -1,0 +1,83 @@
+{
+  "id": "erdos-1000-oq-03-oq-01",
+  "title": "The Combinatorial Characterization of Jordan's Totient $J_k$",
+  "slug": "erdos-1000-oq-03-oq-01",
+  "description": "Closes the gap left open by erdos-1000-oq-03, which built Jordan's totient J_k from its Dirichlet-convolution definition J_k = μ * pow k while explicitly deferring the combinatorial counting definition. This entry proves the convolution closed form really does count tuples. Define C_k(n) = #{ (a_0,…,a_{k-1}) ∈ (ℤ/n)^k : gcd(a_0,…,a_{k-1},n) = 1 }, the number of k-tuples mod n jointly coprime to n. Proves, with 0 axioms and 0 sorries (no native_decide): the Gauss-type divisor identity ∑_{d∣n} C_k(d) = n^k (the exact generalization of ∑_{d∣n} φ(d) = n), via an explicit bijection showing every tuple mod n scales uniquely from a jointly-coprime tuple mod n/d where d = gcd(a_0,…,a_{k-1},n); the explicit Jordan closed form C_k(n) = ∑_{d∣n} μ(d)·(n/d)^k obtained by Möbius inversion, establishing that the combinatorial count C_k coincides with the Dirichlet-convolution J_k = μ * pow k of erdos-1000-oq-03; and the Euler recovery C_1(n) = φ(n), confirming the count specializes to Euler's totient at k = 1. The whole development rests on one elementary scaling bijection plus Mathlib's Möbius inversion — no analysis.",
+  "meta": {
+    "author": "Classical combinatorial identity for Jordan's totient (Camille Jordan, 1870); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Jordan%27s_totient_function",
+    "date": "1870",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1000OQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "jordan-totient",
+      "euler-totient",
+      "combinatorics",
+      "moebius-inversion",
+      "divisor-sum",
+      "bijective-counting",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 179,
+    "theoremCount": 5,
+    "definitionCount": 3,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (no native_decide). #print axioms confirms all three headline theorems (jordanCount_divisor_sum, jordanCount_eq_moebius_sum, jordanCount_one_eq_totient) depend only on the foundational propext, Classical.choice, Quot.sound. The proof rests on: fiberwise cardinality counting (Finset.card_eq_sum_card_fiberwise), an explicit two-sided scaling bijection (Finset.card_bij'), the gcd scaling law Finset.gcd_mul_left and Nat.coprime_div_gcd_div_gcd, and Mathlib's Möbius inversion sum_eq_iff_sum_smul_moebius_eq over ℤ.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_eq_sum_card_fiberwise",
+        "description": "Partitions a finset by a fibering map: #s = ∑_{b∈t} #(fiber over b). Applied to all n^k tuples in (Fin n)^k fibred by their content d = gcd(coordinates, n), giving n^k = ∑_{d∣n} #(fiber over d).",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.card_bij'",
+        "description": "Cardinality equality from an explicit two-sided bijection. Realizes the fiber over d as the jointly-coprime tuples mod n/d via the scaling maps a ↦ a/d and b ↦ d·b.",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.gcd_mul_left",
+        "description": "`s.gcd (a·f) = normalize a · s.gcd f`. Over ℕ this is the gcd scaling law gcd(d·b_0,…,d·b_{k-1}) = d·gcd(b_0,…,b_{k-1}), the heart of both directions of the scaling bijection.",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Nat.coprime_div_gcd_div_gcd",
+        "description": "`0 < gcd m n → Coprime (m / gcd m n) (n / gcd m n)`. Proves the scaled-down tuple mod n/d is jointly coprime to n/d, so the forward map lands in C_k(n/d).",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "ArithmeticFunction.sum_eq_iff_sum_smul_moebius_eq",
+        "description": "Möbius inversion over an AddCommGroup: ∀ n>0, ∑_{d∣n} f(d) = g(n) ⟺ ∀ n>0, ∑_{(a,b): ab=n} μ(a)·g(b) = f(n). Inverts ∑_{d∣n} C_k(d) = n^k into the explicit form C_k(n) = ∑_{d∣n} μ(d)·(n/d)^k.",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.Moebius"
+      },
+      {
+        "theorem": "Nat.sum_div_divisors",
+        "description": "`∑_{d∣n} f(n/d) = ∑_{d∣n} f(d)`, the divisor-reindexing d ↦ n/d. Converts ∑_{d∣n} C_k(n/d) (output of the fiber count) into the headline ∑_{d∣n} C_k(d).",
+        "module": "Mathlib.NumberTheory.Divisors"
+      }
+    ],
+    "originalContributions": [
+      "`jordanCount k n := #{ a : Fin k → Fin n | gcd(a_0,…,a_{k-1}, n) = 1 }`: the honest combinatorial counting definition of Jordan's totient that erdos-1000-oq-03 explicitly deferred.",
+      "`jordanCount_divisor_sum`: the Gauss-type divisor identity ∑_{d∣n} C_k(d) = n^k, proved by an explicit scaling bijection (not Möbius computation) — every k-tuple mod n is d·(a coprime tuple mod n/d) for a unique divisor d = gcd(coordinates, n).",
+      "`jordanCount_eq_moebius_sum`: the explicit closed form C_k(n) = ∑_{d∣n} μ(d)·(n/d)^k via Möbius inversion of the divisor sum — this is exactly (μ * pow k)(n), so the combinatorial count agrees with the Dirichlet-convolution J_k of erdos-1000-oq-03, completing the equivalence of the two definitions.",
+      "`jordanCount_one_eq_totient`: C_1(n) = φ(n), recovering Euler's totient as the k = 1 count of residues coprime to n.",
+      "`gcd_smul`, `gcd_div`: reusable ℕ-valued lemmas that the coordinate-gcd of a tuple scales/divides by a common factor d (gcd(d·a) = d·gcd(a) and gcd(a/d) = gcd(a)/d when d divides every coordinate)."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and Gauss's divisor-sum identity ∑_{d∣n} φ(d) = n",
+      "The gcd of a finite family and its behaviour under common scaling",
+      "Fiberwise (double) counting and bijective cardinality arguments on finsets",
+      "Möbius inversion over a commutative group"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "erdos-1000-oq-03",
+        "relationship": "Parent entry. Builds J_k from the Dirichlet-convolution definition J_k = μ * pow k and explicitly defers the combinatorial counting definition; this entry supplies that definition C_k and proves C_k = J_k, equating the two."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Closes the gap explicitly left open by **erdos-1000-oq-03** (#27844), which built Jordan's totient `J_k` from its *Dirichlet-convolution* definition `J_k = μ * pow k` while stating: *"Rather than the combinatorial counting definition, we take the Dirichlet convolution definition."* This entry supplies that combinatorial definition and proves it agrees with the convolution.

Define
$$ C_k(n) = \#\{\,(a_0,\dots,a_{k-1}) \in (\mathbb{Z}/n)^k : \gcd(a_0,\dots,a_{k-1},n) = 1\,\}. $$

## Results (0 axioms, 0 sorries, no `native_decide`)

- **`jordanCount_divisor_sum`** — `∑_{d∣n} C_k(d) = n^k`, the Gauss-type divisor identity generalizing `∑_{d∣n} φ(d) = n`. Proved by an **explicit scaling bijection**: fibre all `n^k` tuples mod `n` by their content `d = gcd(coords, n)`; the fibre over `d` is exactly `d ·` (a jointly-coprime tuple mod `n/d`), via `Finset.gcd_mul_left` and `Nat.coprime_div_gcd_div_gcd`. No inclusion–exclusion.
- **`jordanCount_eq_moebius_sum`** — `C_k(n) = ∑_{d∣n} μ(d)·(n/d)^k`, obtained by Möbius inversion of the divisor sum. This is exactly `(μ * pow k)(n)`, so the combinatorial count **coincides with the Dirichlet-convolution `J_k`** of the parent entry — the two definitions are equal.
- **`jordanCount_one_eq_totient`** — `C_1(n) = φ(n)`, recovering Euler's totient at `k = 1`.

## Verification

`#print axioms` confirms all three headline theorems depend only on `propext, Classical.choice, Quot.sound`. Built against Mathlib v4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)