### PR TITLE
research(algebraic-reals-meager-oq-03): the cardinality axis — measure-small & category-small sets need not be countable [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -56,6 +56,7 @@ import Proofs.AlgebraicNumbersCountableOQ02OQ04
 import Proofs.AlgebraicNumbersCountableOQ04
 import Proofs.AlgebraicNumbersCountableOQ05
 import Proofs.AlgebraicRealsMeager
+import Proofs.AlgebraicRealsMeagerOQ03
 import Proofs.AlgebraicRealsNull
 import Proofs.AlternatingSeriesTestOQ01
 import Proofs.AmgmInequalityOQ02

--- a/proofs/Proofs/AlgebraicRealsMeagerOQ03.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerOQ03.lean
@@ -1,0 +1,139 @@
+import Proofs.AlgebraicRealsMeager
+import Proofs.AlgebraicRealsMeagerOQ02
+
+/-!
+# The Cardinality Axis: Measure-Small and Category-Small Sets Need Not Be Countable
+
+## Open Question (algebraic-reals-meager — OQ-03)
+
+The parent `algebraic-reals-meager` records *three* independent notions under which a
+subset of `ℝ` can be "small":
+
+* **cardinality-small** — countable;
+* **measure-small** — Lebesgue-null;
+* **category-small** — meagre (first Baire category).
+
+The companion `algebraic-reals-meager-oq-02` settles the **measure ⊥ category** axis: the
+Liouville numbers are comeagre yet null (category-large but measure-small), so neither of
+those two notions implies the other.
+
+This entry settles the remaining axis — **cardinality vs the other two** — which oq-02 does
+not address. The point is that the separating examples are *uncountable*:
+
+* a **meagre** set can be **uncountable** (category-small ⇏ countable), and
+* a **null** set can be **uncountable** (measure-small ⇏ countable).
+
+Equivalently, while every *countable* set is automatically both meagre and null
+(`countable_isMeagre_and_null`), the converse fails badly in both directions. So
+cardinality-smallness is strictly stronger than — and independent of — measure- and
+category-smallness. Together with oq-02 this completes the pairwise independence of all
+three notions.
+
+The witnesses are the complementary pair `(𝓛ᶜ, 𝓛)` for `𝓛 =` the Liouville numbers:
+
+* `𝓛` is null (Mathlib, via oq-02) yet uncountable — were it countable it would be meagre,
+  contradicting its comeagreness (`not_isMeagre_of_mem_residual`);
+* `𝓛ᶜ` is meagre yet of full Lebesgue measure (so uncountable, since countable sets are
+  null). The full-measure step uses only countable subadditivity of the outer measure, so
+  no measurability hypothesis is needed.
+
+## Main Results
+
+* `meagre_conull_compl_of_residual_null` — abstract engine: the complement of a residual
+  null set is meagre and has full measure (measurability-free).
+* `countable_isMeagre_and_null` — every countable subset of `ℝ` is *both* meagre and null:
+  the "aligned" case from which the separating examples must therefore be uncountable.
+* `exists_meagre_uncountable` — **category-small ⇏ countable**: a meagre set that is
+  uncountable (the non-Liouville reals, uncountable because they have full measure).
+* `exists_null_uncountable` — **measure-small ⇏ countable**: a null set that is uncountable
+  (the Liouville numbers, uncountable because countable would force meagreness).
+* `oq03_resolution` — the cardinality axis as a single statement, completing the three-way
+  independence begun in oq-02.
+-/
+
+open MeasureTheory Filter Set AlgebraicRealsMeager AlgebraicRealsMeagerOQ02
+
+namespace AlgebraicRealsMeagerOQ03
+
+/-- Shorthand for the Liouville numbers, our separating set. -/
+abbrev 𝓛 : Set ℝ := {x : ℝ | Liouville x}
+
+/-! ## The abstract orthogonality engine -/
+
+/-- **The complement of a residual null set is meagre and of full measure.** If `S` is
+residual (comeagre) and Lebesgue-null, then `Sᶜ` is meagre and `volume Sᶜ = volume univ`.
+The full-measure claim uses only countable subadditivity of the outer measure
+(`measure_union_le`, valid for *all* sets), so no measurability hypothesis on `S` is
+required. This is the engine behind the uncountability of the meagre witness below. -/
+theorem meagre_conull_compl_of_residual_null {S : Set ℝ}
+    (hres : S ∈ residual ℝ) (hnull : volume S = 0) :
+    IsMeagre Sᶜ ∧ volume Sᶜ = volume (univ : Set ℝ) := by
+  refine ⟨?_, ?_⟩
+  · -- `IsMeagre Sᶜ` unfolds to `Sᶜᶜ ∈ residual`, i.e. `S ∈ residual`.
+    simpa [IsMeagre, compl_compl] using hres
+  · refine le_antisymm (measure_mono (subset_univ _)) ?_
+    have hcov : (univ : Set ℝ) = Sᶜ ∪ S := by rw [Set.compl_union_self]
+    calc volume (univ : Set ℝ)
+        = volume (Sᶜ ∪ S) := by rw [hcov]
+      _ ≤ volume Sᶜ + volume S := measure_union_le _ _
+      _ = volume Sᶜ := by rw [hnull, add_zero]
+
+/-! ## The aligned case: countable ⇒ small in both senses -/
+
+/-- **Every countable subset of `ℝ` is both meagre and Lebesgue-null.** Topologically,
+a countable set is a countable union of singletons, each nowhere dense because `ℝ` is a
+perfect `T1` space (`countable_isMeagre`); measure-theoretically it is null because
+`volume` is atomless. Hence cardinality-smallness implies *both* of the other two notions —
+so any set separating them must be uncountable. -/
+theorem countable_isMeagre_and_null {s : Set ℝ} (hs : s.Countable) :
+    IsMeagre s ∧ volume s = 0 :=
+  ⟨countable_isMeagre hs, hs.measure_zero volume⟩
+
+/-! ## The cardinality axis: the separating examples are uncountable -/
+
+/-- **Category-small ⇏ cardinality-small.** There is a meagre subset of `ℝ` that is
+uncountable: the complement of the Liouville numbers. It is meagre (its complement, the
+Liouville set, is comeagre) yet has full Lebesgue measure, and a countable set would be
+null — so it cannot be countable. -/
+theorem exists_meagre_uncountable :
+    ∃ A : Set ℝ, IsMeagre A ∧ ¬ A.Countable := by
+  obtain ⟨hmeagre, hfull⟩ :=
+    meagre_conull_compl_of_residual_null liouville_residual liouville_null
+  refine ⟨𝓛ᶜ, hmeagre, fun hc => ?_⟩
+  have hz : volume (𝓛ᶜ) = 0 := hc.measure_zero volume
+  rw [hfull, Real.volume_univ] at hz
+  exact ENNReal.top_ne_zero hz
+
+/-- **Measure-small ⇏ cardinality-small.** There is a Lebesgue-null subset of `ℝ` that is
+uncountable: the Liouville numbers. They are null (Mathlib, via oq-02) yet uncountable —
+were they countable they would be meagre (`countable_isMeagre`), contradicting their
+comeagreness (`not_isMeagre_of_mem_residual`). -/
+theorem exists_null_uncountable :
+    ∃ B : Set ℝ, volume B = 0 ∧ ¬ B.Countable :=
+  ⟨𝓛, liouville_null, fun hc =>
+    not_isMeagre_of_mem_residual liouville_residual (countable_isMeagre hc)⟩
+
+/-! ## OQ-03 resolution -/
+
+/-- **OQ-03 resolution: the cardinality axis.** Cardinality-smallness (countability) is
+independent of both measure-smallness and category-smallness on `ℝ`:
+
+1. every countable set is both meagre and null (`countable_isMeagre_and_null`), but
+2. a meagre set can be uncountable (category-small ⇏ countable), and
+3. a null set can be uncountable (measure-small ⇏ countable).
+
+Combined with oq-02's measure ⊥ category, this completes the pairwise independence of all
+three notions of smallness. The witnesses are the complementary pair `(𝓛ᶜ, 𝓛)`. -/
+theorem oq03_resolution :
+    (∀ s : Set ℝ, s.Countable → IsMeagre s ∧ volume s = 0) ∧
+    (∃ A : Set ℝ, IsMeagre A ∧ ¬ A.Countable) ∧
+    (∃ B : Set ℝ, volume B = 0 ∧ ¬ B.Countable) :=
+  ⟨fun _ hs => countable_isMeagre_and_null hs, exists_meagre_uncountable, exists_null_uncountable⟩
+
+#check @meagre_conull_compl_of_residual_null
+#check @countable_isMeagre_and_null
+#check @exists_meagre_uncountable
+#check @exists_null_uncountable
+#check @oq03_resolution
+
+end AlgebraicRealsMeagerOQ03

--- a/src/data/proofs/algebraic-reals-meager-oq-03/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-03/meta.json
@@ -1,0 +1,155 @@
+{
+  "id": "algebraic-reals-meager-oq-03",
+  "title": "The Cardinality Axis: Measure-Small and Category-Small Sets Need Not Be Countable",
+  "slug": "algebraic-reals-meager-oq-03",
+  "description": "Completes the three-way independence of the smallness notions on ℝ — cardinality (countable), measure (Lebesgue-null), and category (meagre). The companion oq-02 settles the measure ⊥ category axis via the Liouville numbers (comeagre yet null). This entry settles the remaining cardinality axis, which oq-02 does not address: the separating examples are uncountable. Every countable set is automatically both meagre and null, but the converse fails in both directions — a meagre set can be uncountable (the non-Liouville reals, uncountable because they have full Lebesgue measure) and a null set can be uncountable (the Liouville numbers, uncountable because a countable set would be meagre, contradicting comeagreness). Hence cardinality-smallness is strictly stronger than, and independent of, measure- and category-smallness. An abstract engine derives the full-measure meagre complement from any residual null set using only countable subadditivity, so no measurability hypothesis is needed.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Meagre_set",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerOQ03.lean",
+    "tags": [
+      "measure-theory",
+      "baire-category",
+      "liouville-numbers",
+      "cardinality",
+      "uncountable",
+      "residual",
+      "lebesgue-measure",
+      "real-analysis"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Set.Countable.measure_zero",
+        "description": "A countable set has measure zero under any atomless measure — used to show a full-measure set is uncountable",
+        "module": "Mathlib.MeasureTheory.Measure.Typeclasses.NoAtoms"
+      },
+      {
+        "theorem": "not_isMeagre_of_mem_residual",
+        "description": "In a nonempty Baire space a residual set is not meagre — used to show the Liouville set is uncountable",
+        "module": "Mathlib.Topology.Baire.Lemmas"
+      },
+      {
+        "theorem": "measure_union_le",
+        "description": "Countable subadditivity: μ (s ∪ t) ≤ μ s + μ t, valid for all sets (no measurability)",
+        "module": "Mathlib.MeasureTheory.OuterMeasure.Basic"
+      },
+      {
+        "theorem": "Real.volume_univ",
+        "description": "The Lebesgue measure of ℝ is ∞",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "IsMeagre",
+        "description": "s is meagre iff its complement sᶜ is residual",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      }
+    ],
+    "originalContributions": [
+      "exists_meagre_uncountable: PROVED category-small ⇏ cardinality-small — there is a meagre subset of ℝ that is uncountable (the non-Liouville reals); uncountability comes from its full Lebesgue measure (a countable set would be null). This axis is absent from the companion oq-02",
+      "exists_null_uncountable: PROVED measure-small ⇏ cardinality-small — there is a Lebesgue-null subset of ℝ that is uncountable (the Liouville numbers); uncountability comes from comeagreness (a countable set would be meagre, contradicting not_isMeagre_of_mem_residual)",
+      "countable_isMeagre_and_null: PROVED the aligned case — every countable subset of ℝ is BOTH meagre and null, so any set separating cardinality from the other two notions must be uncountable",
+      "meagre_conull_compl_of_residual_null: PROVED the abstract engine — the complement of any residual, Lebesgue-null set is meagre and has full measure, using only countable subadditivity (measure_union_le), so NO measurability of the set is assumed; this supplies the full-measure input behind exists_meagre_uncountable",
+      "oq03_resolution: packaged the cardinality axis (aligned case + the two non-implications), completing the pairwise independence of all three smallness notions begun in oq-02",
+      "Honest scope: the substantive inputs (the Liouville numbers are residual and null; countable sets are meagre in a perfect T1 space) are imported from Mathlib and the parent entry; the new content is the CARDINALITY axis — that measure-small and category-small sets can be uncountable — which neither the parent nor oq-02 establishes"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Lebesgue measure on ℝ; atomless measures (countable ⇒ null); countable subadditivity",
+      "Baire category: meagre / residual (comeagre) sets; countable ⇒ meagre in a perfect T1 space",
+      "Liouville numbers: residual (comeagre) and Lebesgue-null (imported via oq-02)",
+      "Cardinality: countable vs uncountable subsets of ℝ"
+    ],
+    "lineCount": 139,
+    "relatedProblems": [
+      {
+        "id": "algebraic-reals-meager-oq-02",
+        "relationship": "Sibling: oq-02 settles the measure ⊥ category axis (a comeagre null set); this entry settles the remaining cardinality axis (measure-small and category-small sets that are uncountable), completing the three-way independence"
+      },
+      {
+        "id": "algebraic-reals-meager",
+        "relationship": "Parent: the Baire-category smallness of the algebraic reals; this entry uses the parent's countable_isMeagre to show a countable set is meagre, and develops the cardinality axis of the three smallness notions the parent lists"
+      }
+    ],
+    "assumptions": "0 axioms. Depends only on Mathlib's measure-theory and Baire-category infrastructure, the parent's countable-implies-meagre lemma, and, via the companion oq-02, the Mathlib facts that the Liouville numbers are residual and Lebesgue-null.",
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "A subset of ℝ can be 'small' in three classical and independent senses: countable (cardinality), Lebesgue-null (measure), or meagre/first-category (Baire category). Cantor's countability of the algebraic reals, Lebesgue measure, and Baire's category theorem give the three. Oxtoby's 'Measure and Category' (1980) studies how measure and category interact; the parent entry lists all three notions, and the companion oq-02 separates measure from category using the Liouville numbers. The third pairing — cardinality against measure and against category — is what this entry formalizes: the measure-small and category-small separating sets are uncountable, so countability is a strictly stronger notion of smallness.",
+    "problemStatement": "Show that cardinality-smallness (countability) is independent of measure-smallness (Lebesgue-null) and category-smallness (meagre) on ℝ: every countable set is both meagre and null, yet there exist a meagre uncountable set and a null uncountable set. This is the cardinality axis completing the three-way independence begun in oq-02.",
+    "text": "A 0-sorry, 0-axiom development. A countable subset of ℝ is meagre (a countable union of nowhere-dense singletons in the perfect space ℝ) and null (volume is atomless), so cardinality-smallness entails the other two notions. The converse fails: the non-Liouville reals are meagre yet have full Lebesgue measure — hence uncountable, since a countable set is null; and the Liouville numbers are null yet uncountable, since a countable set would be meagre, contradicting their comeagreness. An abstract engine produces the full-measure meagre complement of any residual null set using only countable subadditivity, with no measurability hypothesis.",
+    "proofStrategy": "countable_isMeagre_and_null pairs the parent's countable_isMeagre with Set.Countable.measure_zero. The engine meagre_conull_compl_of_residual_null: IsMeagre Sᶜ is definitional (Sᶜᶜ = S ∈ residual); volume Sᶜ = volume univ from univ = Sᶜ ∪ S, measure_union_le, and volume S = 0, with measure_mono for the reverse. exists_meagre_uncountable instantiates the engine at the Liouville set and rules out countability by rewriting the full measure to Real.volume_univ = ∞ ≠ 0. exists_null_uncountable uses liouville_null and derives a contradiction from countable_isMeagre against not_isMeagre_of_mem_residual liouville_residual.",
+    "keyInsights": [
+      "**The third axis**: oq-02 separates measure from category; this entry separates cardinality from both. Countability is strictly the strongest of the three notions of smallness — it implies the other two but neither implies it.",
+      "**A meagre set can be uncountable** because it can have full measure: the non-Liouville reals. Were it countable it would be null, but it is conull.",
+      "**A null set can be uncountable** because it can be comeagre: the Liouville numbers. Were they countable they would be meagre, contradicting comeagreness.",
+      "**Aligned baseline**: every countable set is automatically meagre AND null, so the separating witnesses for the cardinality axis are necessarily uncountable — the content is precisely that such witnesses exist.",
+      "**Measurability-free engine**: the full-measure step uses only countable subadditivity (measure_union_le holds for all sets), so the meagre full-measure complement is produced from any residual null set without assuming measurability.",
+      "**Honest scope**: the Liouville residual/null facts and countable ⇒ meagre are imported (Mathlib, parent, oq-02); the new mathematics is the cardinality independence, which neither predecessor states."
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℝ and atomless measures",
+      "Baire category: meagre and residual (comeagre) sets; countable sets are meagre in a perfect T1 space",
+      "Liouville numbers: residual and Lebesgue-null (via oq-02)",
+      "Countable versus uncountable subsets of ℝ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Overview: the three smallness notions",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "File docstring and imports. Lists the three independent notions of smallness (cardinality, measure, category), recalls that oq-02 separates measure from category, and previews this entry's cardinality axis: meagre and null sets that are uncountable.",
+      "mathContext": "Countable ⊆ null and countable ⊆ meagre, but the reverse inclusions fail; this entry exhibits the separating uncountable witnesses."
+    },
+    {
+      "id": "engine",
+      "title": "The abstract orthogonality engine",
+      "startLine": 61,
+      "endLine": 80,
+      "summary": "Proves the complement of a residual, Lebesgue-null set is meagre and of full measure — using only countable subadditivity, so no measurability is assumed. This supplies the full-measure input for the meagre uncountable witness.",
+      "mathContext": "univ = Sᶜ ∪ S, measure_union_le, and volume S = 0 force volume Sᶜ = volume univ."
+    },
+    {
+      "id": "aligned",
+      "title": "The aligned case: countable ⇒ meagre and null",
+      "startLine": 81,
+      "endLine": 91,
+      "summary": "Every countable subset of ℝ is both meagre (countable union of nowhere-dense singletons, via the parent's countable_isMeagre) and null (atomless volume), so any set separating cardinality from the other notions must be uncountable.",
+      "mathContext": "Cardinality-smallness is the strongest notion: it implies both measure- and category-smallness."
+    },
+    {
+      "id": "cardinality-axis",
+      "title": "The cardinality axis: the separating examples are uncountable",
+      "startLine": 92,
+      "endLine": 139,
+      "summary": "The two non-implications — a meagre uncountable set (non-Liouville reals, uncountable via full measure) and a null uncountable set (Liouville numbers, uncountable via comeagreness) — packaged with the aligned case as the OQ-03 resolution.",
+      "mathContext": "category-small ⇏ countable and measure-small ⇏ countable, completing the three-way independence."
+    }
+  ],
+  "references": [
+    {
+      "title": "Measure and Category (Oxtoby, GTM 2)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4684-9339-9"
+    },
+    {
+      "title": "Liouville number — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Liouville_number"
+    },
+    {
+      "title": "Meagre set — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/Meagre_set"
+    }
+  ],
+  "crossReferences": [],
+  "conclusion": "Cardinality-smallness (countability) is independent of measure-smallness and category-smallness on ℝ. Every countable set is automatically both meagre and null, but neither converse holds: the non-Liouville reals are meagre yet uncountable (they have full measure), and the Liouville numbers are null yet uncountable (they are comeagre). Together with oq-02's separation of measure from category, this completes the pairwise independence of all three notions of smallness — with zero axioms, and with the full-measure step requiring no measurability hypothesis.",
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Settles **algebraic-reals-meager-oq-03**: the independence of the **three** smallness notions on `ℝ` — cardinality (countable), measure (Lebesgue-null), and category (meagre).

The companion **oq-02** separates *measure* from *category* (the Liouville numbers are comeagre yet null). This entry settles the remaining **cardinality axis**, which oq-02 does not touch: the separating sets are **uncountable**.

| theorem | statement |
|---|---|
| `countable_isMeagre_and_null` | every countable subset of ℝ is **both** meagre and null (so any separator must be uncountable) |
| `exists_meagre_uncountable` | **category-small ⇏ countable**: a meagre set that is uncountable (non-Liouville reals — uncountable via full measure) |
| `exists_null_uncountable` | **measure-small ⇏ countable**: a null set that is uncountable (Liouville numbers — uncountable via comeagreness) |
| `meagre_conull_compl_of_residual_null` | abstract engine: complement of a residual null set is meagre and of full measure, **measurability-free** (only countable subadditivity) |
| `oq03_resolution` | the cardinality axis packaged; completes the pairwise independence begun in oq-02 |

## Distinction from the sibling oq-02 (PR #27756)

PR #27756 develops the **measure ⊥ category** axis (the meagre+null decomposition and the meagre-conull / null-not-meagre non-implications). To avoid duplicating it, this entry deliberately does **not** restate that decomposition and instead supplies the **third axis** — cardinality vs the other two — which #27756 does not address. The new mathematics here is that the measure-small and category-small witnesses are *uncountable*.

## Verification

- Lean 4 / Mathlib v4.26.0, single-file dependency-chain compile (docker unavailable this session).
- `#print axioms` on every theorem: only `propext, Classical.choice, Quot.sound` — **0 axioms**, no `sorry`, no `native_decide`.
- 5 theorems, 0 definitions, 139 lines. Imports the parent (`countable_isMeagre`) and oq-02 (Liouville residual+null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)