### PR TITLE
Enrich Finite Geometric Sums & the Infinite Limit (geometric-series-oq-08)

### DIFF
--- a/src/data/proofs/geometric-series-oq-08/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "closed-form",
+    "proofId": "geometric-series-oq-08",
+    "range": { "startLine": 57, "endLine": 63 },
+    "type": "definition",
+    "title": "The Closed Form in the (1−rⁿ)/(1−r) Convention",
+    "content": "`geometric_sum_closed` records the textbook finite geometric sum ∑_{k<n} rᵏ = (1−rⁿ)/(1−r) for r ≠ 1. It wraps Mathlib's `geom_sum_eq`, which uses the (rⁿ−1)/(r−1) convention; the conversion is `div_eq_div_iff` (both denominators nonzero since r ≠ 1) followed by `ring`. This convention is chosen so the infinite limit 1/(1−r) is read off by sending rⁿ → 0, and it is the anchor every later theorem rewrites against.",
+    "mathContext": "$\\sum_{k<n} r^k = \\dfrac{1 - r^n}{1 - r}$ for $r \\neq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite geometric sum", "Euclid Elements IX.35", "geom_sum_eq"],
+    "prerequisites": ["finite sums", "Finset.range"]
+  },
+  {
+    "id": "truncation-defect",
+    "proofId": "geometric-series-oq-08",
+    "range": { "startLine": 65, "endLine": 72 },
+    "type": "insight",
+    "title": "The Keystone: Defect = rⁿ/(1−r)",
+    "content": "`geometric_sum_tail` is the heart of the entry: for r < 1, the gap between the infinite value and the n-term partial sum is exactly 1/(1−r) − S n = rⁿ/(1−r). In other words the infinite tail ∑_{k≥n} rᵏ is itself a scaled geometric power. The proof substitutes the closed form and clears denominators with `field_simp; ring` (legal since 1 − r ≠ 0). This single identity is the source of all the bounds and the explicit error term — every subsequent theorem is a corollary of the sign or limit of rⁿ/(1−r).",
+    "mathContext": "$\\dfrac{1}{1-r} - \\sum_{k<n} r^k = \\dfrac{r^n}{1-r}$, i.e. $\\sum_{k\\ge n} r^k = \\dfrac{r^n}{1-r}$.",
+    "significance": "key",
+    "relatedConcepts": ["truncation error", "tail of a series", "comparison test", "ratio-test remainder"],
+    "prerequisites": ["geometric series", "algebra of fractions"]
+  },
+  {
+    "id": "bounds",
+    "proofId": "geometric-series-oq-08",
+    "range": { "startLine": 74, "endLine": 93 },
+    "type": "technique",
+    "title": "Strict vs Non-Strict Bounds from the Defect's Sign",
+    "content": "`geometric_sum_le_inv` (S n ≤ 1/(1−r) for 0 ≤ r < 1, all n) and `geometric_sum_lt_inv` (strict, for 0 < r < 1) both read off the sign of the defect rⁿ/(1−r): `div_nonneg` gives ≥ 0 (hence ≤), `div_pos` gives > 0 (hence <). Each rewrites the tail identity into the goal and closes with `linarith`. The strict/non-strict split is exactly the r > 0 versus r = 0 (or n = 0) distinction — whether the missing tail can vanish — making the bound's strictness a transparent consequence of one positivity fact.",
+    "mathContext": "$0\\le r<1 \\Rightarrow S_n \\le \\tfrac{1}{1-r}$; $0<r<1 \\Rightarrow S_n < \\tfrac{1}{1-r}$.",
+    "significance": "key",
+    "relatedConcepts": ["upper bound", "positivity", "div_pos / div_nonneg"],
+    "prerequisites": ["inequalities", "linarith"]
+  },
+  {
+    "id": "monotone-converge",
+    "proofId": "geometric-series-oq-08",
+    "range": { "startLine": 95, "endLine": 114 },
+    "type": "concept",
+    "title": "Monotone, Bounded, Convergent: the Limit as a Supremum",
+    "content": "`geometric_sum_monotone` shows n ↦ S n increases for 0 ≤ r (each new term rⁿ ≥ 0, exposed by `Finset.sum_range_succ` and `monotone_nat_of_le_succ`). `geometric_sum_tendsto_inv` shows S n → 1/(1−r): it converts 0 ≤ r < 1 to |r| < 1, invokes `hasSum_geometric_of_abs_lt_one`, and reads off partial-sum convergence via `HasSum.tendsto_sum_nat`. Combined with the upper bound, these exhibit 1/(1−r) as the supremum of an increasing, bounded sequence — the order-theoretic face of the analytic limit, the very structure Archimedes used to sum ∑(1/4)ᵏ.",
+    "mathContext": "$n\\mapsto S_n$ monotone, $S_n\\le \\tfrac{1}{1-r}$, $S_n\\to \\tfrac{1}{1-r}$, so $\\tfrac{1}{1-r}=\\sup_n S_n$.",
+    "significance": "key",
+    "relatedConcepts": ["monotone convergence", "supremum", "bounded sequence", "HasSum.tendsto_sum_nat"],
+    "prerequisites": ["limits of sequences", "monotone sequences"]
+  },
+  {
+    "id": "concrete",
+    "proofId": "geometric-series-oq-08",
+    "range": { "startLine": 116, "endLine": 127 },
+    "type": "concept",
+    "title": "Sanity Check at r = 1/2",
+    "content": "Three worked examples at r = 1/2: the four-term sum ∑_{k<4} (1/2)ᵏ = 15/8, the truncation defect (1/2)⁴/(1−1/2) = 1/8 (verified via geometric_sum_tail), and the strict bound 15/8 < 2 (via geometric_sum_lt_inv). These pin the abstract defect and bound to concrete fractions and serve as a regression guard against arithmetic slips in the general identities.",
+    "mathContext": "$\\sum_{k<4}(1/2)^k = \\tfrac{15}{8}$, defect $= \\tfrac{(1/2)^4}{1/2} = \\tfrac18$, and $\\tfrac{15}{8} < 2 = \\tfrac{1}{1-1/2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "truncation error", "numerical check"],
+    "prerequisites": ["arithmetic of fractions"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08/meta.json
+++ b/src/data/proofs/geometric-series-oq-08/meta.json
@@ -19,6 +19,7 @@
     "sorries": 0
   },
   "title": "Finite Geometric Sums and the Infinite Limit: Defect, Bounds, and Monotonicity",
+  "description": "The quantitative bridge between the finite geometric partial sum S n = ∑_{k<n} rᵏ = (1−rⁿ)/(1−r) and the infinite value 1/(1−r), for 0 ≤ r < 1. The exact truncation defect is 1/(1−r) − S n = rⁿ/(1−r) — the infinite tail is itself a scaled power. From it: the strict bound S n < 1/(1−r) (and non-strict ≤), monotonicity of n ↦ S n, and upward convergence S n → 1/(1−r), together realizing the infinite value as the supremum of an increasing bounded sequence with explicit error rⁿ/(1−r). Mathlib has the closed form and the infinite value separately; this packages their difference — the estimate behind the comparison test, the ratio-test remainder, and numerical truncation bounds.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -65,6 +66,55 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The finite geometric sum 1 + r + ··· + rⁿ⁻¹ = (1−rⁿ)/(1−r) is among the oldest closed forms in mathematics — Euclid's Elements IX.35 states it geometrically, and it is the engine behind Archimedes' quadrature of the parabola, where the convergent series ∑(1/4)ᵏ = 4/3 is summed by bounding partial sums. The modern viewpoint separates two facts: the algebraic identity for the finite sum (valid in any commutative ring, r ≠ 1) and the analytic statement that for |r| < 1 the partial sums converge to 1/(1−r). The quantitative content tying them together is the truncation error rⁿ/(1−r): it is exactly what Cauchy's comparison and ratio tests use to certify convergence of a general series by domination by a geometric one, and what numerical analysis uses to bound the cost of truncating a series at n terms. This entry isolates that error term as a typed identity and derives from it the order structure (monotone, bounded, supremum) that makes 1/(1−r) the least upper bound of the finite sums.",
+    "problemStatement": "**Open Question (oq-08)**: make explicit the relationship between the finite geometric partial sums S n = ∑_{k<n} rᵏ and the infinite value 1/(1−r) for 0 ≤ r < 1 — not just that S n → 1/(1−r), but the exact defect, the strict/non-strict bounds, and the monotonic-bounded structure realizing the limit as a supremum. Answer: 1/(1−r) − S n = rⁿ/(1−r), S n < 1/(1−r), n ↦ S n monotone, S n ↑ 1/(1−r).",
+    "proofStrategy": "Everything is anchored on the closed form. (1) geometric_sum_closed rewrites Mathlib's geom_sum_eq from the (rⁿ−1)/(r−1) convention into (1−rⁿ)/(1−r) via div_eq_div_iff and ring. (2) geometric_sum_tail computes the defect 1/(1−r) − S n = rⁿ/(1−r) by substituting the closed form and clearing denominators (field_simp; ring) — this single identity drives the rest. (3) The bounds follow because the defect rⁿ/(1−r) is nonnegative (≤, via div_nonneg) or strictly positive (<, via div_pos), discharged by linarith with the tail identity rewritten in. (4) geometric_sum_monotone uses Finset.sum_range_succ to expose the new term rⁿ ≥ 0 and monotone_nat_of_le_succ. (5) geometric_sum_tendsto_inv converts |r| < 1 from 0 ≤ r < 1, applies hasSum_geometric_of_abs_lt_one, and reads off convergence of partial sums via HasSum.tendsto_sum_nat. Concrete r = 1/2 examples (sum 15/8, defect 1/8) close the file.",
+    "keyInsights": [
+      "The infinite tail of the geometric series is itself a scaled geometric power: 1/(1−r) − S n = rⁿ/(1−r). This one identity is the source of every bound and the explicit truncation error simultaneously.",
+      "That error term rⁿ/(1−r) is precisely the estimate behind the comparison test, the ratio-test remainder, and numerical truncation bounds — packaging it as a typed identity makes it reusable rather than re-derived inline each time.",
+      "The strict bound S n < 1/(1−r) versus the non-strict S n ≤ 1/(1−r) is exactly the distinction between r > 0 (missing tail strictly positive) and allowing r = 0 or n = 0 (tail can vanish) — the sign of rⁿ/(1−r) decides it.",
+      "Monotone + bounded-above + the convergence statement together realize 1/(1−r) as the SUPREMUM of the partial sums, the order-theoretic face of the analytic limit (and the structure Archimedes used for the parabola).",
+      "The development needs only two Mathlib inputs — the finite closed form and the infinite value — with the entire finite/infinite bridge (defect, bounds, monotonicity) assembled by elementary linarith/field_simp reasoning."
+    ]
+  },
+  "sections": [
+    {
+      "id": "closed-form",
+      "title": "The Closed Form (1−rⁿ)/(1−r)",
+      "startLine": 57,
+      "endLine": 63,
+      "summary": "geometric_sum_closed wraps Mathlib's geom_sum_eq (stated as (rⁿ−1)/(r−1)) into the (1−rⁿ)/(1−r) convention via div_eq_div_iff and ring — the anchor from which the defect and bounds are derived."
+    },
+    {
+      "id": "truncation-defect",
+      "title": "The Exact Truncation Defect",
+      "startLine": 65,
+      "endLine": 72,
+      "summary": "geometric_sum_tail proves the keystone identity 1/(1−r) − S n = rⁿ/(1−r) for r < 1, by substituting the closed form and clearing denominators (field_simp; ring). The infinite tail is a scaled power — the single fact that drives every subsequent result."
+    },
+    {
+      "id": "bounds",
+      "title": "Strict and Non-Strict Bounds",
+      "startLine": 74,
+      "endLine": 93,
+      "summary": "geometric_sum_le_inv (S n ≤ 1/(1−r) for 0 ≤ r < 1, all n) and geometric_sum_lt_inv (strict, for 0 < r < 1) follow from the sign of the defect rⁿ/(1−r): nonnegative gives ≤, strictly positive gives <. Both close by linarith with the tail identity rewritten in."
+    },
+    {
+      "id": "monotone-converge",
+      "title": "Monotonicity and Upward Convergence",
+      "startLine": 95,
+      "endLine": 114,
+      "summary": "geometric_sum_monotone (partial sums increase, via Finset.sum_range_succ exposing rⁿ ≥ 0) and geometric_sum_tendsto_inv (S n → 1/(1−r), via hasSum_geometric_of_abs_lt_one and HasSum.tendsto_sum_nat) together realize the infinite value as the supremum of an increasing, bounded sequence."
+    },
+    {
+      "id": "concrete",
+      "title": "A Concrete Instance: r = 1/2",
+      "startLine": 116,
+      "endLine": 129,
+      "summary": "Worked examples at r = 1/2: the four-term sum is 15/8, strictly below the limit 2, with truncation defect (1/2)⁴/(1−1/2) = 1/8 — pinning the abstract defect and bound to recognizable numbers."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08` (quality 15, passes 0). Good meta existed, but no `description`, no `overview`, no `sections`, no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary.
- **overview** — `historicalContext` (Euclid IX.35, Archimedes' parabola quadrature, the truncation error behind the comparison/ratio tests), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** — 5, covering all 129 lines (closed form, truncation defect, bounds, monotonicity+convergence, concrete instance).

## Added annotations.json (5 annotations)
The closed form, the keystone defect identity rⁿ/(1−r), the strict/non-strict bounds from the defect's sign, monotone+bounded+convergent (limit as supremum), and the r=1/2 worked instance — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on declarations.

## Axiom integrity
Unchanged and accurate: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`. The finite/infinite bridge (defect, bounds, monotonicity) is assembled from two Mathlib inputs — not single library lemmas — with no `axiom`/`sorry`/`native_decide`.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)