### PR TITLE
Enrich General Moment of Geometric Series (geometric-series-oq-07-oq-01)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "mul-descfactorial",
+    "proofId": "geometric-series-oq-07-oq-01",
+    "range": { "startLine": 48, "endLine": 56 },
+    "type": "technique",
+    "title": "The Side-Condition-Free Falling-Factorial Recurrence",
+    "content": "`mul_descFactorial` proves n·n^{underline k} = n^{underline k+1} + k·n^{underline k} for ALL n, k — crucially with no hypothesis k ≤ n. The proof rewrites via Nat.descFactorial_succ and splits on k ≤ n versus k > n; in the latter case both falling factorials vanish (descFactorial_eq_zero_iff_lt) and the identity is 0 = 0. This unconditional form is what lets the main induction proceed without ever case-splitting on whether k exceeds n — a small lemma that removes a pervasive side condition.",
+    "mathContext": "$n\\cdot n^{\\underline k} = n^{\\underline{k+1}} + k\\cdot n^{\\underline k}$, valid for all $n,k$ (both sides vanish when $k>n$).",
+    "significance": "supporting",
+    "relatedConcepts": ["falling factorial", "descFactorial", "recurrence relation"],
+    "prerequisites": ["falling factorials", "natural-number arithmetic"]
+  },
+  {
+    "id": "stirling-expansion",
+    "proofId": "geometric-series-oq-07-oq-01",
+    "range": { "startLine": 58, "endLine": 104 },
+    "type": "insight",
+    "title": "Stirling's Monomial Expansion — the Missing Mathlib Bridge",
+    "content": "`pow_eq_sum_stirlingSecond_descFactorial` proves nᵐ = ∑_{k≤m} S(m,k)·n^{underline k}: every power expands over the falling factorials with Stirling-number-of-the-second-kind coefficients. Mathlib defines Nat.stirlingSecond with its recurrences but provides NO connection to powers — this lemma supplies it. The induction on m multiplies the hypothesis by n, rewrites each summand with mul_descFactorial, then reconciles two reindexed sums using the Stirling recurrence S(m+1,k+1) = (k+1)S(m,k+1)+S(m,k) and a telescoping shift (Finset.sum_range_succ'), with the final coefficient bookkeeping discharged by omega. This is reusable combinatorial infrastructure, not just a step.",
+    "mathContext": "$n^m = \\sum_{k=0}^{m} S(m,k)\\, n^{\\underline k}$, where $S(m,k)$ partitions an $m$-set into $k$ blocks.",
+    "significance": "key",
+    "relatedConcepts": ["Stirling numbers of the second kind", "falling-factorial basis", "change of basis", "Worpitzky"],
+    "prerequisites": ["Stirling numbers", "induction", "Finset sums"]
+  },
+  {
+    "id": "asc-factorial-gf",
+    "proofId": "geometric-series-oq-07-oq-01",
+    "range": { "startLine": 108, "endLine": 127 },
+    "type": "technique",
+    "title": "Rephrasing Mathlib's Ascending-Factorial Sum",
+    "content": "`hasSum_ascFactorial_geometric` turns Mathlib's binomial geometric sum ∑(n+k choose k)rⁿ = 1/(1−r)^{k+1} into falling-factorial language: ∑_n (n+k)^{underline k}·rⁿ = k!/(1−r)^{k+1}. It multiplies the Mathlib result by k! and uses descFactorial_eq_factorial_mul_choose ((n+k)^{underline k} = k!·(n+k choose k)) to match summands. This is the bridge from the form Mathlib provides to the falling-factorial form the moment formula needs, and it is where the k! in the numerator originates.",
+    "mathContext": "$\\sum_{n\\ge0} (n+k)^{\\underline k}\\, r^n = \\dfrac{k!}{(1-r)^{k+1}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ascending factorial", "binomial coefficients", "generating function"],
+    "prerequisites": ["geometric series", "factorial identities"]
+  },
+  {
+    "id": "desc-factorial-gf",
+    "proofId": "geometric-series-oq-07-oq-01",
+    "range": { "startLine": 129, "endLine": 155 },
+    "type": "technique",
+    "title": "The Falling-Factorial Generating Function via an Index Shift",
+    "content": "`hasSum_descFactorial_geometric` evaluates ∑_n n^{underline k}·rⁿ = k!·rᵏ/(1−r)^{k+1} — the second pillar of the proof. It multiplies the ascending-factorial sum by rᵏ, recognizes the result as the k-shifted version of the target (with summand (n+k)^{underline k}·r^{n+k}), and applies `hasSum_nat_add_iff` to shift back down. The first k terms of the unshifted sum vanish because n^{underline k} = 0 for n < k (descFactorial_eq_zero_iff_lt), so no correction term survives. The factor rᵏ accounts for the index displacement.",
+    "mathContext": "$\\sum_{n\\ge0} n^{\\underline k}\\, r^n = \\dfrac{k!\\, r^k}{(1-r)^{k+1}}$ (shift Mathlib's ascending sum down by $k$).",
+    "significance": "key",
+    "relatedConcepts": ["index shift", "hasSum_nat_add_iff", "falling factorial", "generating function"],
+    "prerequisites": ["HasSum", "reindexing series"]
+  },
+  {
+    "id": "general-moment",
+    "proofId": "geometric-series-oq-07-oq-01",
+    "range": { "startLine": 159, "endLine": 196 },
+    "type": "insight",
+    "title": "Assembling the All-Orders Moment",
+    "content": "`hasSum_pow_mul_geometric` is the headline. It casts the Stirling expansion nᵐ = ∑_k S(m,k)·n^{underline k} to ℝ (hcast), makes each k-summand a HasSum via the falling-factorial generating function multiplied by S(m,k) (hterm), sums these finitely many HasSum facts over 0 ≤ k ≤ m with `hasSum_sum` (hbig), and finally collapses the inner finite sum back to nᵐ·rⁿ (hfun). The result is ∑_{n} nᵐrⁿ = ∑_{k=0}^{m} S(m,k)·k!·rᵏ/(1−r)^{k+1}. `tsum_pow_mul_geometric` is the one-line tsum corollary. Convergence is inherited from the summands — only the value is new content.",
+    "mathContext": "$\\sum_{n\\ge0} n^m r^n = \\sum_{k=0}^{m} S(m,k)\\, k!\\, \\dfrac{r^k}{(1-r)^{k+1}}$ for $|r|<1$.",
+    "significance": "key",
+    "relatedConcepts": ["moments", "HasSum linearity", "hasSum_sum", "change of basis"],
+    "prerequisites": ["HasSum", "finite sums of series"]
+  },
+  {
+    "id": "low-order",
+    "proofId": "geometric-series-oq-07-oq-01",
+    "range": { "startLine": 198, "endLine": 243 },
+    "type": "concept",
+    "title": "Recovering Orders 0–3 (decide on Stirling Values)",
+    "content": "Four worked examples specialize the general formula to m = 0,1,2,3, recovering the gallery's geometric-series (1/(1−r)), oq-07 (∑n²rⁿ = r(1+r)/(1−r)³), and oq-10 (∑n³rⁿ = r(1+4r+r²)/(1−r)⁴). Each expands the finite k-sum, evaluates the small Stirling numbers S(m,k) by kernel `decide` (e.g. S(3,2) = 3 — note this is `decide`, not native_decide, so the file stays propext/Classical/Quot-only and 0-axiom), then closes the r-rational identity with field_simp; ring after clearing 1−r ≠ 0. These double as regression checks linking the general theorem to known special cases.",
+    "mathContext": "$m=2$: $\\sum n^2 r^n = \\tfrac{r(1+r)}{(1-r)^3}$; $m=3$: $\\sum n^3 r^n = \\tfrac{r(1+4r+r^2)}{(1-r)^4}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "Stirling number values", "decide", "moment family"],
+    "prerequisites": ["kernel decidability", "field_simp"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "The General Moment of the Geometric Series: ∑ nᵐ rⁿ = ∑ₖ S(m,k)·k!·rᵏ/(1−r)^{k+1}",
+  "description": "The m-th moment of the geometric series to ALL orders: for |r| < 1 over ℝ, ∑_{n≥0} nᵐ·rⁿ = ∑_{k=0}^{m} S(m,k)·k!·rᵏ/(1−r)^{k+1}, where S(m,k) = Nat.stirlingSecond is the Stirling number of the second kind. Mathlib proves only summability of nᵐrⁿ and the m=0,1 values; this gives the closed value at arbitrary order. Two pillars: the combinatorial change of basis nᵐ = ∑_k S(m,k)·n^{underline k} (monomial over falling factorials, proved by induction — a Stirling↔power bridge Mathlib lacks) and the falling-factorial generating function ∑_n n^{underline k}·rⁿ = k!·rᵏ/(1−r)^{k+1} (an index shift of Mathlib's ascending-factorial sum). Recovers the gallery's order-0/1/2/3 moments (geometric-series, oq-07, oq-10) as special cases.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -82,6 +83,48 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The moments ∑ nᵐ rⁿ of the geometric weights are classically computed by repeatedly applying the operator r·d/dr to ∑ rⁿ = 1/(1−r), producing rational functions A_m(r)/(1−r)^{m+1} whose numerators are the Eulerian polynomials — the generating functions of permutation descents (Worpitzky, 1883). A second, combinatorially cleaner route runs through the falling factorials n^{underline k} = n(n−1)···(n−k+1) and the Stirling numbers of the second kind S(m,k), which count partitions of an m-set into k nonempty blocks: every monomial expands as nᵐ = ∑_k S(m,k)·n^{underline k}, and each falling factorial has an elementary geometric generating function. This entry formalizes the Stirling route, which is the one Mathlib can support (it has Nat.stirlingSecond but no Eulerian numbers). The coefficient S(m,k)·k! is the number of surjections from an m-set onto a k-set — so the moment formula reads each power's contribution as a sum over surjection counts. Mathlib knows the Stirling recurrences and the ascending-factorial geometric sum, but neither the link between Stirling numbers and powers nor the moment value; both gaps are filled here.",
+    "problemStatement": "**Open Question (oq-07-oq-01)**: generalize the second-moment computation ∑ n²rⁿ = r(1+r)/(1−r)³ to arbitrary order m, with a polynomial-in-r numerator over (1−r)^{m+1}. Answer: ∑_{n≥0} nᵐ·rⁿ = ∑_{k=0}^{m} S(m,k)·k!·rᵏ/(1−r)^{k+1} for |r| < 1, uniform in m, recovering orders 0,1,2,3 as the gallery's existing entries.",
+    "proofStrategy": "Two pillars assembled by HasSum linearity. **Pillar 1 (combinatorics, in ℕ):** pow_eq_sum_stirlingSecond_descFactorial proves nᵐ = ∑_{k≤m} S(m,k)·n^{underline k} by induction on m. The step multiplies the inductive hypothesis by n, rewrites each summand with the side-condition-free falling-factorial recurrence n·n^{underline k} = n^{underline k+1} + k·n^{underline k} (mul_descFactorial), reindexes both the LHS (via the Stirling recurrence S(m+1,k+1) = (k+1)S(m,k+1)+S(m,k)) and a telescoping shift (Finset.sum_range_succ'), and closes the bookkeeping with omega. **Pillar 2 (analysis, over ℝ):** hasSum_descFactorial_geometric evaluates ∑_n n^{underline k}·rⁿ = k!·rᵏ/(1−r)^{k+1} by taking Mathlib's ascending-factorial sum (k!·(n+k choose k) form), multiplying by rᵏ, and shifting the index down by k via hasSum_nat_add_iff (the first k terms vanish since n^{underline k} = 0 for n < k). **Assembly:** hasSum_pow_mul_geometric casts the Stirling expansion to ℝ, makes each k-term a HasSum, sums over 0 ≤ k ≤ m by hasSum_sum, and collapses the inner finite sum back to nᵐ·rⁿ. Orders 0–3 are checked by evaluating the small Stirling numbers with kernel `decide` and the r-rational identity with field_simp; ring.",
+    "keyInsights": [
+      "The whole computation is one change of basis: every monomial nᵐ lies in the span of the falling factorials {n^{underline k}}, and each falling factorial has an elementary geometric generating function — so the moment at ANY order is a single finite linear combination, no per-order convergence argument and no separate algebraic identity (as orders 2 and 3 each needed individually).",
+      "The Stirling coefficient S(m,k)·k! is exactly the number of surjections from an m-set onto a k-set, giving the moment numerator a clean combinatorial meaning that the Eulerian-polynomial form (which Mathlib cannot yet express) only obscures.",
+      "Mathlib has Nat.stirlingSecond and its recurrences but NO link between Stirling numbers and powers; the monomial expansion proved here (pow_eq_sum_stirlingSecond_descFactorial) supplies that missing bridge as reusable infrastructure.",
+      "The side-condition-free recurrence n·n^{underline k} = n^{underline k+1} + k·n^{underline k} (valid even when k > n, where both falling factorials vanish) is what lets the induction proceed without case-splitting on k ≤ n — a small but essential simplification.",
+      "Working in HasSum throughout means convergence is inherited from Mathlib's summable_pow_mul_geometric; the contribution is purely the VALUE, which is why the open question's 'summability is known, value is not' framing is answered exactly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "stirling-expansion",
+      "title": "Stirling's Monomial Expansion (a Combinatorial ℕ-Identity)",
+      "startLine": 46,
+      "endLine": 104,
+      "summary": "mul_descFactorial proves the side-condition-free falling-factorial recurrence n·n^{underline k} = n^{underline k+1} + k·n^{underline k}. pow_eq_sum_stirlingSecond_descFactorial then proves nᵐ = ∑_{k≤m} S(m,k)·n^{underline k} by induction on m, using the Stirling recurrence and a telescoping reindex (Finset.sum_range_succ'), closed by omega — the Stirling↔power bridge Mathlib lacks."
+    },
+    {
+      "id": "falling-factorial-gf",
+      "title": "The Falling-Factorial Geometric Sum",
+      "startLine": 106,
+      "endLine": 155,
+      "summary": "hasSum_ascFactorial_geometric rephrases Mathlib's ascending-factorial sum as ∑_n (n+k)^{underline k}·rⁿ = k!/(1−r)^{k+1} via descFactorial_eq_factorial_mul_choose. hasSum_descFactorial_geometric then shifts the index down by k (hasSum_nat_add_iff; the first k terms vanish since n^{underline k} = 0 for n < k) to get ∑_n n^{underline k}·rⁿ = k!·rᵏ/(1−r)^{k+1}."
+    },
+    {
+      "id": "general-moment",
+      "title": "The General Moment Closed Form",
+      "startLine": 157,
+      "endLine": 196,
+      "summary": "hasSum_pow_mul_geometric assembles the headline: cast the Stirling expansion to ℝ, make each k-term a HasSum via the falling-factorial generating function, sum over 0 ≤ k ≤ m with hasSum_sum, and collapse the inner finite sum back to nᵐ·rⁿ. tsum_pow_mul_geometric gives the tsum form."
+    },
+    {
+      "id": "low-order",
+      "title": "Recovering the Gallery's Low-Order Moments",
+      "startLine": 198,
+      "endLine": 244,
+      "summary": "The general formula specializes to orders m = 0,1,2,3 — the gallery's geometric-series, oq-07 (∑n²rⁿ), and oq-10 (∑n³rⁿ). The small Stirling numbers are evaluated by kernel `decide` and the resulting r-rational identities by field_simp; ring (after clearing 1−r ≠ 0)."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-07-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01` (quality 15, passes 0). Rich meta existed, but no `description`, no `overview`, no `sections`, no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary of the all-orders moment formula.
- **overview** — `historicalContext` (Eulerian-polynomial vs Stirling/falling-factorial routes, Worpitzky, the surjection-count meaning of S(m,k)·k!, the two Mathlib gaps), `problemStatement`, `proofStrategy` (both pillars + assembly), 5 `keyInsights`.
- **sections** — 4, covering all 244 lines (Stirling monomial expansion, falling-factorial generating function, general-moment assembly, low-order recovery).

## Added annotations.json (6 annotations)
The side-condition-free falling-factorial recurrence, Stirling's monomial expansion (the missing Mathlib bridge), the ascending- and falling-factorial generating functions, the all-orders assembly, and the order-0..3 recovery — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on declarations.

## Axiom integrity
Unchanged and accurate: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`. The low-order checks use kernel **`decide`** (not `native_decide`) on small Stirling values, so the file remains propext/Classical.choice/Quot.sound-only and genuinely 0-axiom — the enrichment calls this out explicitly. The closed value at arbitrary order is a real gap fill over Mathlib (which has only summability + m=0,1).

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)