### PR TITLE
Enrich Maschke's Theorem (maschke-theorem-oq-01)

### DIFF
--- a/src/data/proofs/maschke-theorem-oq-01/annotations.json
+++ b/src/data/proofs/maschke-theorem-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "hypothesis",
+    "proofId": "maschke-theorem-oq-01",
+    "range": { "startLine": 66, "endLine": 72 },
+    "type": "concept",
+    "title": "The Hypothesis: |G| Invertible in k",
+    "content": "`card_isUnit` makes the running hypothesis legible. Mathlib carries the assumption as a typeclass instance NeZero (Fintype.card G : k); this theorem shows that over a field it is exactly the statement that (Fintype.card G : k) is a unit (via isUnit_iff_ne_zero), which is the classical 'characteristic of k does not divide |G|'. The `omit [Group G]` annotation drops the unused group structure for this purely field-theoretic fact. This invertibility is the one thing the whole proof depends on — it is what lets the averaging step divide by |G|.",
+    "mathContext": "$\\mathrm{NeZero}((\\#G):k) \\iff (\\#G:k)\\in k^\\times \\iff \\operatorname{char} k \\nmid |G|$.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic of a field", "group order", "unit", "modular vs ordinary representation theory"],
+    "prerequisites": ["fields", "characteristic", "units in a ring"]
+  },
+  {
+    "id": "averaging",
+    "proofId": "maschke-theorem-oq-01",
+    "range": { "startLine": 74, "endLine": 81 },
+    "type": "insight",
+    "title": "The Averaging Projection — the Heart of Maschke",
+    "content": "`splitting` exposes the technical core: an injective k[G]-linear map f admits a k[G]-linear left inverse g (g ∘ f = id). The construction (inside Mathlib's MonoidAlgebra.exists_leftInverse_of_injective) takes any k-linear splitting π — which exists because vector spaces are always semisimple — and averages it over the group, π ↦ (1/|G|)∑_g g·π·g⁻¹. The average is k[G]-equivariant by a reindexing of the group sum, and it is well-defined precisely because (card G : k) is invertible. Every other result in the file is a corollary of this one equivariant splitting.",
+    "mathContext": "$g = \\frac{1}{|G|}\\sum_{h\\in G} h\\cdot\\pi\\cdot h^{-1}$, a $k[G]$-equivariant left inverse of an injective $f$.",
+    "significance": "key",
+    "relatedConcepts": ["averaging operator", "equivariant projection", "Reynolds operator", "group action on Hom"],
+    "prerequisites": ["group algebra k[G]", "linear maps", "group averaging"]
+  },
+  {
+    "id": "direct-summand",
+    "proofId": "maschke-theorem-oq-01",
+    "range": { "startLine": 83, "endLine": 94 },
+    "type": "concept",
+    "title": "Every Subrepresentation Is a Direct Summand",
+    "content": "`exists_isCompl` is the classical statement of Maschke's theorem: every k[G]-submodule p of a representation V has a complementary subrepresentation q (IsCompl p q). `exists_complement` unfolds IsCompl into the explicit direct-sum decomposition p ⊓ q = ⊥ (trivial intersection) and p ⊔ q = ⊤ (they span V), i.e. V = p ⊕ q as representations. This is what 'completely reducible' means concretely — no subrepresentation is 'stuck' inside V without a G-invariant complement, in contrast to the modular case.",
+    "mathContext": "$\\forall p \\le V,\\ \\exists q:\\ p\\sqcap q = \\bot \\wedge p\\sqcup q = \\top$, i.e. $V = p\\oplus q$ as $k[G]$-modules.",
+    "significance": "key",
+    "relatedConcepts": ["direct summand", "complemented submodule", "IsCompl", "complete reducibility"],
+    "prerequisites": ["submodules", "direct sums", "lattice of submodules"]
+  },
+  {
+    "id": "semisimple",
+    "proofId": "maschke-theorem-oq-01",
+    "range": { "startLine": 96, "endLine": 103 },
+    "type": "concept",
+    "title": "Semisimplicity of V and of k[G]",
+    "content": "`isSemisimpleModule` states every representation V is a semisimple k[G]-module (a direct sum of irreducible subrepresentations); `isSemisimpleRing` states the group algebra k[G] is itself a semisimple ring. Both are obtained by `inferInstance` — Mathlib's instance graph already derives them from the direct-summand property. Semisimplicity of k[G] is the entry point to Artin–Wedderburn, which decomposes it as a finite product ∏ Mₙᵢ(Dᵢ) of matrix algebras over division rings, the structural backbone from which character theory follows.",
+    "mathContext": "$V$ semisimple over $k[G]$; $k[G]$ semisimple ring $\\Rightarrow k[G]\\cong\\prod_i M_{n_i}(D_i)$ (Artin–Wedderburn).",
+    "significance": "key",
+    "relatedConcepts": ["semisimple module", "semisimple ring", "Artin–Wedderburn theorem", "irreducible representations"],
+    "prerequisites": ["semisimplicity", "group algebra", "ring theory"]
+  },
+  {
+    "id": "ses-splits",
+    "proofId": "maschke-theorem-oq-01",
+    "range": { "startLine": 105, "endLine": 118 },
+    "type": "technique",
+    "title": "Short Exact Sequences Split Both Ways",
+    "content": "`surjection_splits` gives every surjective k[G]-map a section (f ∘ s = id) — projectivity, the lifting form of complete reducibility (IsSemisimpleModule.lifting_property). `injection_splits` gives every injective k[G]-map a retraction (r ∘ f = id) — the extension/injective form (IsSemisimpleModule.extension_property), which re-proves the earlier `splitting` through the semisimplicity API. Together they say every short exact sequence of representations splits, the categorical heart of why representation theory in this setting is 'as easy as linear algebra'.",
+    "mathContext": "Surjective $f$: $\\exists s,\\ f\\circ s = \\mathrm{id}$. Injective $f$: $\\exists r,\\ r\\circ f = \\mathrm{id}$. Every SES splits.",
+    "significance": "supporting",
+    "relatedConcepts": ["split exact sequence", "projective module", "injective module", "lifting property"],
+    "prerequisites": ["exact sequences", "sections and retractions"]
+  },
+  {
+    "id": "quotient-sub",
+    "proofId": "maschke-theorem-oq-01",
+    "range": { "startLine": 120, "endLine": 125 },
+    "type": "concept",
+    "title": "Quotients Are Subrepresentations",
+    "content": "`quotient_iso_submodule` records that for every subrepresentation N, the quotient V ⧸ N is k[G]-linearly isomorphic to some subrepresentation P of V (IsSemisimpleModule.exists_submodule_linearEquiv_quotient). In a completely reducible module, quotients never produce anything genuinely new — they are realized inside V itself, mirroring the direct-summand property at the level of isomorphism type. This fails in the modular case, where quotients can be strictly 'smaller' than any submodule.",
+    "mathContext": "$\\forall N\\le V,\\ \\exists P\\le V:\\ P \\cong_{k[G]} V/N$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quotient representation", "complete reducibility", "linear equivalence"],
+    "prerequisites": ["quotient modules", "module isomorphisms"]
+  }
+]

--- a/src/data/proofs/maschke-theorem-oq-01/meta.json
+++ b/src/data/proofs/maschke-theorem-oq-01/meta.json
@@ -17,6 +17,7 @@
     "sorries": 0
   },
   "title": "Maschke's Theorem and Complete Reducibility of Group Representations",
+  "description": "Maschke's 1899 theorem and its complete-reducibility corollaries for a finite group G over a field k with char k ∤ |G| (encoded as NeZero (Fintype.card G : k), shown equivalent to (Fintype.card G : k) being a unit). The technical heart is the averaging projection (1/|G|)∑_g g·π·g⁻¹, which turns a k-linear splitting into a k[G]-equivariant one — the single place the order-invertibility hypothesis is consumed. From it: every k[G]-submodule is a direct summand (IsCompl and the explicit p ⊓ q = ⊥ ∧ p ⊔ q = ⊤), every representation is a semisimple k[G]-module, k[G] is a semisimple ring (the Artin–Wedderburn setup), every short exact sequence splits in both the surjective (projectivity) and injective (extension) directions, and every quotient representation is isomorphic to a subrepresentation. The gateway to character theory.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -75,6 +76,62 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Heinrich Maschke proved in 1898–99 that a finite-dimensional representation of a finite group G over a field k of characteristic not dividing |G| is completely reducible — it decomposes as a direct sum of irreducible subrepresentations. This is the foundational theorem of ordinary (characteristic-0 or coprime-characteristic) representation theory: it makes the group algebra k[G] semisimple, so by Artin–Wedderburn k[G] ≅ ∏ᵢ Mₙᵢ(Dᵢ) is a finite product of matrix algebras over division rings, which over an algebraically closed field of characteristic 0 yields the orthogonality of characters, the count of irreducibles = number of conjugacy classes, and ∑(dim Vᵢ)² = |G|. The proof's mechanism is averaging over the group: any k-linear projection onto a subrepresentation can be symmetrized to a G-equivariant one by averaging its conjugates, and the average requires dividing by |G| — the precise point where char k ∤ |G| is indispensable. When the characteristic does divide |G| (the modular case, studied by Brauer) the theorem fails: 𝔽_p[ℤ/p] is not semisimple. This entry packages the non-modular theorem from Mathlib's averaging primitive and records the modular boundary as framing.",
+    "problemStatement": "**Open Question (oq-01)**: assemble Maschke's theorem and the full complete-reducibility package over k[G] for char k ∤ |G| — the equivariant splitting of injections, the direct-summand property of every submodule, semisimplicity of representations and of k[G] itself, the splitting of short exact sequences in both directions, and the quotient-as-subrepresentation property — as a single gallery entry, with the hypothesis stated in the classical 'order is a unit' form.",
+    "proofStrategy": "Everything flows from one Mathlib primitive, MonoidAlgebra.exists_leftInverse_of_injective (the averaging projection). (1) card_isUnit bridges the hypothesis: over a field NeZero (card G : k) ⟺ (card G : k) is a unit, via isUnit_iff_ne_zero — this is the 'char k ∤ |G|' condition. (2) splitting exposes the averaging primitive directly: an injective k[G]-map has an equivariant left inverse. (3) exists_isCompl / exists_complement give the classical direct-summand statement (every submodule has a complement, both as IsCompl and unfolded to p ⊓ q = ⊥ ∧ p ⊔ q = ⊤). (4) isSemisimpleModule / isSemisimpleRing are inferInstance — Mathlib's instance graph already derives semisimplicity of V and of k[G] from the Maschke setup. (5) surjection_splits and injection_splits invoke IsSemisimpleModule.lifting_property and extension_property to split short exact sequences in both directions (the latter re-deriving splitting through the API). (6) quotient_iso_submodule uses exists_submodule_linearEquiv_quotient. The work is the curation: surfacing the heart, stating the hypothesis classically, and packaging the corollaries that no single Mathlib lemma collects.",
+    "keyInsights": [
+      "The entire theorem turns on one move — averaging a k-linear splitting over G to make it k[G]-equivariant — and the average (1/|G|)∑_g g·π·g⁻¹ exists precisely because |G| is invertible in k; this is the sole place char k ∤ |G| is used.",
+      "Complete reducibility has several equivalent faces, and the entry exhibits them all: direct summands (IsCompl), semisimple module, semisimple ring, splitting of every short exact sequence (both projectivity and injectivity), and quotients realized as subrepresentations — each a standard corollary, here derived through Mathlib's semisimplicity API.",
+      "Stating the hypothesis as '(card G : k) is a unit' (card_isUnit) rather than as a NeZero instance reconnects Mathlib's formalization to Maschke's classical 'characteristic does not divide the order' — the same condition, made legible.",
+      "Semisimplicity of k[G] is the entry point to Artin–Wedderburn: k[G] ≅ ∏ Mₙᵢ(Dᵢ), from which character theory (number of irreducibles = conjugacy classes, ∑ dim² = |G|) follows — the open questions point exactly here.",
+      "The hypothesis is sharp: in the modular case char k ∣ |G|, the augmentation sequence 0 → aug → 𝔽_p[ℤ/p] → 𝔽_p → 0 does not split, so 𝔽_p[ℤ/p] is not semisimple — recorded as framing and as the first open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "hypothesis",
+      "title": "The Hypothesis: |G| Is a Unit in k",
+      "startLine": 66,
+      "endLine": 72,
+      "summary": "card_isUnit bridges Mathlib's NeZero (Fintype.card G : k) instance to the classical condition that (Fintype.card G : k) is a unit — i.e. char k ∤ |G| — via isUnit_iff_ne_zero. This is exactly what permits dividing by |G| in the averaging step."
+    },
+    {
+      "id": "averaging",
+      "title": "The Heart: the Averaging Projection",
+      "startLine": 74,
+      "endLine": 81,
+      "summary": "splitting exposes the technical core: an injective k[G]-linear map admits a k[G]-equivariant left inverse, realized by averaging a k-linear splitting over G — (1/|G|)∑_g g·π·g⁻¹. This is MonoidAlgebra.exists_leftInverse_of_injective, the only place the order-invertibility hypothesis is consumed."
+    },
+    {
+      "id": "direct-summand",
+      "title": "Classical Maschke: Every Submodule Splits Off",
+      "startLine": 83,
+      "endLine": 94,
+      "summary": "exists_isCompl gives the classical statement — every k[G]-submodule has a complementary subrepresentation (IsCompl) — and exists_complement unfolds it to the explicit V = p ⊕ q decomposition p ⊓ q = ⊥ ∧ p ⊔ q = ⊤."
+    },
+    {
+      "id": "semisimple",
+      "title": "Semisimplicity of Representations and of k[G]",
+      "startLine": 96,
+      "endLine": 103,
+      "summary": "isSemisimpleModule (every representation is a semisimple k[G]-module — a direct sum of irreducibles) and isSemisimpleRing (k[G] is a semisimple ring) are obtained by inferInstance from Mathlib's Maschke instance graph — the Artin–Wedderburn backbone of representation theory."
+    },
+    {
+      "id": "ses-splits",
+      "title": "Splitting Short Exact Sequences (Both Directions)",
+      "startLine": 105,
+      "endLine": 118,
+      "summary": "surjection_splits (every surjective k[G]-map has a section — projectivity/lifting) and injection_splits (every injective k[G]-map has a retraction — extension), via IsSemisimpleModule.lifting_property and extension_property. The injective form re-derives splitting through the semisimplicity API."
+    },
+    {
+      "id": "quotient-sub",
+      "title": "Quotients Are Subrepresentations",
+      "startLine": 120,
+      "endLine": 125,
+      "summary": "quotient_iso_submodule: every quotient V ⧸ N is k[G]-linearly isomorphic to a subrepresentation of V (exists_submodule_linearEquiv_quotient) — a hallmark of complete reducibility, where quotients never produce anything not already inside V."
+    }
+  ],
   "openQuestions": [
     {
       "id": "maschke-theorem-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `maschke-theorem-oq-01` (quality 15, passes 0). Good meta existed, but no `description`, no `overview`, no `sections`, no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary.
- **overview** — `historicalContext` (Maschke 1898–99, Artin–Wedderburn → character theory, the averaging mechanism, modular failure), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** — 6, covering all 127 lines (hypothesis, averaging projection, direct summand, semisimplicity, SES splitting both ways, quotient-as-subrepresentation).

## Added annotations.json (6 annotations)
The |G|-invertible hypothesis bridge, the averaging-projection heart, the direct-summand property, semisimplicity of V and k[G], two-directional SES splitting, and quotients-as-subreps — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on declarations.

## Provenance / axiom integrity
Unchanged and accurate: `status: verified`, **`badge: mathlib` (Tier B)**, `axiomCount: 0`, `sorries: 0`. The averaging splitting is Mathlib's `exists_leftInverse_of_injective`; this entry packages the theorem and its complete-reducibility corollaries (none of which sit as a dedicated gallery entry) and restates the hypothesis classically — the enrichment says so rather than overclaiming.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry.
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)