### PR TITLE
audit: record clean abel-ruffini deep oq chain (advance stuck queue)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17726,6 +17726,12 @@
       "result": "issues-fixed",
       "issues": []
     },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-23T00:00:00Z",
+      "result": "clean"
+    },
     "algebraic-numbers-countable-oq-07": {
       "auditCount": 1,
       "lastAudited": "2026-06-23T03:36:20Z",


### PR DESCRIPTION
## Gallery Integrity Audit — Clean

**Gallery-wide scan**: 3128 metas, 1358 verified — **0 overclaims, 0 missing-lean, 0 named native_decide**.

**Target**: \`abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01\`
- status=verified, badge=mathlib (Tier B — core via Mathlib, correctly badged), axiomCount=0, sorries=0
- Source: 188L, 10 theorems; \`sorry\`/\`axiom\`/\`native_decide\` appear **only** in the L38 docstring describing the proof's cleanliness.
- **Verdict: clean.** No overclaim.

## Why this PR

This target has surfaced as \`find-targets --next\` for ~35 consecutive auditor cycles. The \`claim-target.sh\` helper writes \`audit-tracker.json\` but fails in sparse worktrees, and clean audits were never committed — so the queue stayed stuck on this entry. This 6-line surgical insertion records the clean result and advances the queue to genuinely unaudited targets.

Minimal diff (insertion-order preserved, no full reformat).

---
Discovered during gallery integrity audit.