### PR TITLE
research(erdos-504-oq-01): 2^d cube vertices realise a non-obtuse configuration in ℝ^d — sharp half of Danzer–Grünbaum [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1854,6 +1854,7 @@ import Proofs.Erdos501ProblemProvable
 import Proofs.Erdos502Problem
 import Proofs.Erdos503Problem
 import Proofs.Erdos504Problem
+import Proofs.Erdos504OQ01
 import Proofs.Erdos505Problem
 import Proofs.Erdos506Problem
 import Proofs.Erdos507Problem

--- a/proofs/Proofs/Erdos504OQ01.lean
+++ b/proofs/Proofs/Erdos504OQ01.lean
@@ -1,0 +1,141 @@
+/-
+  Erdős Problem #504 — Maximum Angle in Point Sets.
+  Open question OQ-01: the higher-dimensional analogue.
+
+  Erdős #504 (Blumenthal's problem, solved by Sendov 1993) concerns `α_n`, the
+  largest angle `α` such that *every* `n`-point planar set contains three points
+  forming an angle `≥ α`.  The natural higher-dimensional analogue asks the same
+  in `ℝ^d`: for which `n` is one *forced* to have an angle exceeding `π/2`?
+
+  The threshold is governed by the **Danzer–Grünbaum theorem (1962)**: the maximum
+  number of points in `ℝ^d` with *all* angles non-obtuse (`≤ π/2`) is exactly `2^d`,
+  realised by the vertices of a cube.  Equivalently, you cannot guarantee an obtuse
+  angle until you have *more than* `2^d` points, so the `d`-dimensional analogue of
+  `α_n` stays `≤ π/2` for all `n ≤ 2^d`.
+
+  This file formalises the **sharp lower-bound (construction) half** of that theorem,
+  which is fully elementary:
+
+    * `inner_edge_nonneg` — for any three vertices `a, b, c ∈ {0,1}^d`, the edge
+      vectors satisfy `⟪a - b, c - b⟫ ≥ 0`.  The inner product expands as a sum of
+      per-coordinate products, each non-negative because, coordinate by coordinate,
+      `a i - b i` and `c i - b i` always have the same sign (both `≥ 0` when `b i = 0`,
+      both `≤ 0` when `b i = 1`).
+
+    * `angle_le_pi_div_two` — consequently every angle `∠ a b c` at a cube vertex is
+      `≤ π/2` (non-obtuse), via `Real.arccos_le_pi_div_two`.
+
+    * `cubeVertices_card` — the cube has exactly `2^d` distinct vertices, and
+      `cubeVertices_pairwise_nonobtuse` packages the construction: `2^d` points in
+      `ℝ^d` with every angle non-obtuse.
+
+  The matching upper bound (`2^d + 1` points *force* an obtuse angle) is the deep
+  half of Danzer–Grünbaum and is left open here.
+
+  Self-contained: `import Mathlib`, no axioms beyond Lean's foundational core,
+  no `sorry`, no `native_decide`.
+-/
+import Mathlib
+
+open scoped RealInnerProductSpace BigOperators
+open Real
+
+namespace Erdos504OQ01
+
+variable {d : ℕ}
+
+/-- A point of `ℝ^d` (here `EuclideanSpace ℝ (Fin d)`) is a **cube vertex** when
+every coordinate is `0` or `1`. -/
+def IsCubeVertex (v : EuclideanSpace ℝ (Fin d)) : Prop := ∀ i, v i = 0 ∨ v i = 1
+
+/-- Each coordinate of a cube vertex is non-negative. -/
+theorem coord_nonneg {v : EuclideanSpace ℝ (Fin d)} (h : IsCubeVertex v) (i : Fin d) :
+    0 ≤ v i := by
+  rcases h i with h | h <;> rw [h] <;> norm_num
+
+/-- Each coordinate of a cube vertex, minus one, is non-positive. -/
+theorem coord_sub_one_nonpos {v : EuclideanSpace ℝ (Fin d)} (h : IsCubeVertex v) (i : Fin d) :
+    v i - 1 ≤ 0 := by
+  rcases h i with h | h <;> rw [h] <;> norm_num
+
+/-- The real inner product of two vectors of `EuclideanSpace ℝ (Fin d)` as a sum of
+coordinatewise products. -/
+theorem inner_eq_sum (x y : EuclideanSpace ℝ (Fin d)) :
+    ⟪x, y⟫ = ∑ i, x i * y i := by
+  simp only [PiLp.inner_apply, RCLike.inner_apply, conj_trivial]
+  exact Finset.sum_congr rfl fun i _ => mul_comm _ _
+
+/-- **Key elementary estimate.** For three cube vertices `a, b, c`, the edge vectors
+`a - b` and `c - b` (emanating from `b`) have non-negative inner product. -/
+theorem inner_edge_nonneg {a b c : EuclideanSpace ℝ (Fin d)}
+    (ha : IsCubeVertex a) (hb : IsCubeVertex b) (hc : IsCubeVertex c) :
+    0 ≤ (⟪a - b, c - b⟫ : ℝ) := by
+  rw [inner_eq_sum]
+  apply Finset.sum_nonneg
+  intro i _
+  simp only [PiLp.sub_apply]
+  rcases hb i with hbi | hbi
+  · -- `b i = 0`: both factors `a i`, `c i` are `≥ 0`.
+    rw [hbi]
+    have := mul_nonneg (coord_nonneg ha i) (coord_nonneg hc i)
+    simpa using this
+  · -- `b i = 1`: both factors `a i - 1`, `c i - 1` are `≤ 0`.
+    rw [hbi]
+    nlinarith [coord_sub_one_nonpos ha i, coord_sub_one_nonpos hc i]
+
+/-- **Non-obtuse angle.** Any angle formed at a cube vertex by two other cube vertices
+is at most `π/2`.  This is the construction half of the Danzer–Grünbaum theorem:
+the `2^d` cube vertices realise a point set with no obtuse angle. -/
+theorem angle_le_pi_div_two {a b c : EuclideanSpace ℝ (Fin d)}
+    (ha : IsCubeVertex a) (hb : IsCubeVertex b) (hc : IsCubeVertex c) :
+    EuclideanGeometry.angle a b c ≤ π / 2 := by
+  rw [EuclideanGeometry.angle, InnerProductGeometry.angle, vsub_eq_sub, vsub_eq_sub,
+    Real.arccos_le_pi_div_two]
+  apply div_nonneg (inner_edge_nonneg ha hb hc)
+  positivity
+
+/-! ### The `2^d` cube vertices -/
+
+/-- The cube vertex indexed by a subset `s ⊆ Fin d`: coordinate `i` is `1` iff `i ∈ s`. -/
+noncomputable def cubeVertex (s : Finset (Fin d)) : EuclideanSpace ℝ (Fin d) :=
+  WithLp.toLp 2 (fun i => if i ∈ s then 1 else 0)
+
+@[simp] theorem cubeVertex_apply (s : Finset (Fin d)) (i : Fin d) :
+    cubeVertex s i = if i ∈ s then 1 else 0 := rfl
+
+theorem cubeVertex_isCubeVertex (s : Finset (Fin d)) : IsCubeVertex (cubeVertex s) := by
+  intro i
+  rw [cubeVertex_apply]
+  split <;> simp
+
+theorem cubeVertex_injective : Function.Injective (cubeVertex (d := d)) := by
+  intro s t h
+  ext i
+  have hi : cubeVertex s i = cubeVertex t i := by rw [h]
+  rw [cubeVertex_apply, cubeVertex_apply] at hi
+  by_cases hs : i ∈ s <;> by_cases ht : i ∈ t <;> simp [hs, ht] at hi ⊢
+
+/-- The finite set of all `2^d` cube vertices in `ℝ^d`. -/
+noncomputable def cubeVertices : Finset (EuclideanSpace ℝ (Fin d)) :=
+  Finset.univ.image cubeVertex
+
+/-- The cube has exactly `2^d` vertices. -/
+theorem cubeVertices_card : (cubeVertices (d := d)).card = 2 ^ d := by
+  rw [cubeVertices, Finset.card_image_of_injective _ cubeVertex_injective, Finset.card_univ,
+    Fintype.card_finset, Fintype.card_fin]
+
+/-- Every vertex in the cube set is genuinely a cube vertex. -/
+theorem mem_cubeVertices {v : EuclideanSpace ℝ (Fin d)} (hv : v ∈ cubeVertices) :
+    IsCubeVertex v := by
+  rw [cubeVertices, Finset.mem_image] at hv
+  obtain ⟨s, _, rfl⟩ := hv
+  exact cubeVertex_isCubeVertex s
+
+/-- **Danzer–Grünbaum construction.** The `2^d` cube vertices form a configuration in
+`ℝ^d` in which every angle is non-obtuse (`≤ π/2`). -/
+theorem cubeVertices_pairwise_nonobtuse {a b c : EuclideanSpace ℝ (Fin d)}
+    (ha : a ∈ cubeVertices) (hb : b ∈ cubeVertices) (hc : c ∈ cubeVertices) :
+    EuclideanGeometry.angle a b c ≤ π / 2 :=
+  angle_le_pi_div_two (mem_cubeVertices ha) (mem_cubeVertices hb) (mem_cubeVertices hc)
+
+end Erdos504OQ01

--- a/src/data/proofs/erdos-504-oq-01/meta.json
+++ b/src/data/proofs/erdos-504-oq-01/meta.json
@@ -1,0 +1,73 @@
+{
+  "id": "erdos-504-oq-01",
+  "title": "Cube Vertices Realise 2^d Non-Obtuse Points in ℝ^d",
+  "slug": "erdos-504-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "RealInnerProductSpace",
+      "BigOperators",
+      "Real"
+    ],
+    "namespace": "Erdos504OQ01",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos504OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Erdős Problem #504 (Blumenthal's problem, solved by Sendov 1993) studies α_n, the largest angle α such that every n-point planar set contains three points forming an angle ≥ α. The natural higher-dimensional analogue (open question OQ-01) asks the same in ℝ^d: for which n is an obtuse angle forced? The answer is governed by the Danzer–Grünbaum theorem (1962): the maximum number of points in ℝ^d with all pairwise angles non-obtuse (≤ π/2) is exactly 2^d, achieved by the vertices of a cube — so one cannot guarantee an obtuse angle until n > 2^d. This entry formalises the sharp lower-bound (construction) half of that theorem, which is fully elementary. The crux (inner_edge_nonneg) is that for any three cube vertices a, b, c ∈ {0,1}^d the edge vectors satisfy ⟪a − b, c − b⟫ ≥ 0: expanding the inner product over EuclideanSpace ℝ (Fin d) as a sum of per-coordinate products, every term (a i − b i)(c i − b i) is non-negative, because coordinate by coordinate the two factors share a sign — both ≥ 0 when b i = 0, both ≤ 0 when b i = 1. Via Real.arccos_le_pi_div_two this gives angle_le_pi_div_two: every angle ∠ a b c at a cube vertex is ≤ π/2. The construction is packaged in cubeVertices (the Finset of all 2^d vertices, indexed injectively by subsets of Fin d), with cubeVertices_card proving |cubeVertices| = 2^d and cubeVertices_pairwise_nonobtuse confirming every angle among them is non-obtuse. The matching upper bound — that 2^d + 1 points force an obtuse angle — is the deep half of Danzer–Grünbaum and is left open. Fully machine-verified: no axioms, no sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos504OQ01.lean",
+    "tags": [
+      "discrete-geometry",
+      "combinatorial-geometry",
+      "angles",
+      "danzer-grunbaum",
+      "hypercube",
+      "euclidean-space",
+      "inner-product",
+      "erdos-504",
+      "higher-dimensional"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "assumptions": ""
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #504 (Blumenthal's problem) asks for the function $\\alpha_n$: the supremum of angles $\\alpha$ guaranteed to appear as an angle $\\angle xyz$ among some three of any $n$ points in the plane. Sendov gave the complete answer in 1993, with the optimal configurations related to vertices of regular polygons. The higher-dimensional version replaces $\\mathbb{R}^2$ by $\\mathbb{R}^d$ and immediately runs into the classical Danzer–Grünbaum theorem (1962): the largest set of points in $\\mathbb{R}^d$ no three of which form an obtuse angle has exactly $2^d$ elements, and the extremal example is the vertex set of a hypercube. The non-trivial direction (that $2^d+1$ points must contain an obtuse angle) uses a clever volume argument on translated convex bodies; the easy and sharp direction — that the $2^d$ cube vertices already avoid obtuse angles — is a one-line coordinate computation. That easy direction is exactly the foundational fact for the $d$-dimensional analogue of $\\alpha_n$: it shows the guaranteed maximum angle stays at most $\\pi/2$ for all $n \\le 2^d$.",
+    "problemStatement": "Work in $\\mathbb{R}^d = \\operatorname{EuclideanSpace}\\ \\mathbb{R}\\ (\\operatorname{Fin} d)$. Call a point a cube vertex if every coordinate lies in $\\{0,1\\}$. Show that the $2^d$ cube vertices form a point configuration in which every angle is non-obtuse: for any three cube vertices $a, b, c$, the angle $\\angle a b c$ at $b$ satisfies $\\angle a b c \\le \\pi/2$. This is the sharp construction underlying the Danzer–Grünbaum bound and the higher-dimensional analogue of Erdős #504.",
+    "proofStrategy": "Three steps. (1) `inner_edge_nonneg` proves the inequality $\\langle a - b,\\, c - b\\rangle \\ge 0$ for cube vertices. The real inner product on $\\operatorname{EuclideanSpace}\\ \\mathbb{R}\\ (\\operatorname{Fin} d)$ expands (`inner_eq_sum`, via `PiLp.inner_apply`) as $\\sum_i (a_i - b_i)(c_i - b_i)$; `Finset.sum_nonneg` reduces to a per-coordinate claim. Splitting on $b_i \\in \\{0,1\\}$: when $b_i = 0$ both factors equal the (non-negative) coordinates $a_i, c_i$ so the product is $\\ge 0$ by `mul_nonneg`; when $b_i = 1$ both factors are $\\le 0$ (`coord_sub_one_nonpos`) so the product is $\\ge 0$ by `nlinarith`. (2) `angle_le_pi_div_two` converts this to a geometric statement: unfolding `EuclideanGeometry.angle` and `InnerProductGeometry.angle` to $\\arccos\\!\\big(\\langle a-b, c-b\\rangle / (\\lVert a-b\\rVert\\,\\lVert c-b\\rVert)\\big)$, the lemma `Real.arccos_le_pi_div_two` reduces $\\angle a b c \\le \\pi/2$ to the non-negativity of that quotient, which follows from `inner_edge_nonneg` and `positivity`. (3) The configuration is assembled: `cubeVertex` indexes a vertex by a subset $s \\subseteq \\operatorname{Fin} d$ (coordinate $i$ is $1$ iff $i \\in s$), `cubeVertex_injective` shows distinct subsets give distinct vertices, and `cubeVertices_card` computes the cardinality $2^d$ via `Fintype.card_finset`. `cubeVertices_pairwise_nonobtuse` then states the headline result over the explicit $2^d$-element set.",
+    "keyInsights": [
+      "The whole construction rests on a single sign observation: for cube vertices, the two edge-vector coordinates $a_i - b_i$ and $c_i - b_i$ always share a sign. If $b_i = 0$ both are $\\ge 0$; if $b_i = 1$ both are $\\le 0$. Either way their product is non-negative, so the inner product — a sum of such products — is non-negative, i.e. no angle is obtuse.",
+      "Non-obtuseness is most cleanly captured by the inner product, not the angle itself: $\\angle a b c \\le \\pi/2 \\iff \\langle a-b, c-b\\rangle \\ge 0$. Working with the inner product keeps the argument purely algebraic (a sum of squares-like terms) and defers all trigonometry to the single library lemma `Real.arccos_le_pi_div_two`.",
+      "The bound $2^d$ is sharp and is exactly the count of cube vertices: indexing vertices by subsets of $\\operatorname{Fin} d$ gives a bijection with $2^d$ points, so the construction is not merely an example but a witness that the Danzer–Grünbaum maximum is attained.",
+      "The formalisation establishes the easy, sharp half of Danzer–Grünbaum; the converse — that $2^d + 1$ points in $\\mathbb{R}^d$ must contain an obtuse angle — is the deep half (a volume/translation argument) and remains open here."
+    ]
+  },
+  "conclusion": {
+    "summary": "For every dimension $d$, the $2^d$ vertices of the unit cube in $\\mathbb{R}^d$ form a point configuration in which every angle is non-obtuse ($\\le \\pi/2$). The proof is fully elementary — the inner product of any two edge vectors expands as a sum of per-coordinate products, each non-negative by a sign argument — and is machine-verified with no axioms, no sorries, and no native_decide.",
+    "implications": "This is the sharp construction half of the Danzer–Grünbaum theorem and the foundational input for the higher-dimensional analogue of Erdős #504: since $2^d$ points in $\\mathbb{R}^d$ can avoid obtuse angles entirely, the guaranteed maximum angle $\\alpha_n^{(d)}$ stays $\\le \\pi/2$ for all $n \\le 2^d$, and an obtuse angle can only be forced once $n > 2^d$. The hypercube is therefore the extremal obstruction in the dimension-$d$ problem.",
+    "openQuestions": [
+      "Can the matching upper bound — that any $2^d + 1$ points in $\\mathbb{R}^d$ must contain an obtuse angle (the deep half of Danzer–Grünbaum) — be formalised, completing the determination that the maximum non-obtuse set has size exactly $2^d$?",
+      "Is the cube the unique extremal configuration up to affine equivalence, and can one quantify how far below $\\pi/2$ all angles of the cube actually lie (the largest angle in the cube configuration as a function of $d$)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "erdos-504",
+      "relationship": "extends",
+      "description": "The parent entry states Erdős #504 in the plane (Sendov's determination of α_n). This entry treats the higher-dimensional analogue in ℝ^d, formalising the sharp construction (the 2^d cube vertices avoid obtuse angles) that underlies the Danzer–Grünbaum threshold."
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-504-oq-01.json
+++ b/src/data/research/problems/erdos-504-oq-01.json
@@ -1,0 +1,30 @@
+{
+  "id": "erdos-504-oq-01",
+  "title": "Erdős #504 OQ-01: higher-dimensional maximum-angle analogue",
+  "status": "in-progress",
+  "phase": "ACT",
+  "knowledge": {
+    "insights": [
+      "The higher-dimensional analogue of Erdős #504 (max guaranteed angle among n points in ℝ^d) is governed by the Danzer–Grünbaum theorem (1962): the max number of points in ℝ^d with all angles ≤ π/2 is exactly 2^d, realised by the hypercube vertices.",
+      "Non-obtuseness of an angle ∠abc is equivalent to ⟪a−b, c−b⟫ ≥ 0; working with the inner product keeps the argument purely algebraic and defers trigonometry to Real.arccos_le_pi_div_two.",
+      "For cube vertices a,b,c ∈ {0,1}^d, each coordinate term (a_i−b_i)(c_i−b_i) ≥ 0 because the two factors share a sign: both ≥0 when b_i=0, both ≤0 when b_i=1. Summing gives ⟪a−b,c−b⟫ ≥ 0 — the entire construction.",
+      "The construction is sharp/attained, not merely an example: indexing cube vertices by subsets of Fin d gives exactly 2^d distinct points (Fintype.card_finset)."
+    ],
+    "builtItems": [
+      "inner_edge_nonneg — 0 ≤ ⟪a−b, c−b⟫ for cube vertices (Proofs/Erdos504OQ01.lean)",
+      "angle_le_pi_div_two — every angle at a cube vertex is ≤ π/2 (Proofs/Erdos504OQ01.lean)",
+      "cubeVertices_card — the cube has exactly 2^d vertices (Proofs/Erdos504OQ01.lean)",
+      "cubeVertices_pairwise_nonobtuse — the 2^d-point non-obtuse configuration (Proofs/Erdos504OQ01.lean)",
+      "inner_eq_sum — real inner product on EuclideanSpace ℝ (Fin d) as ∑ x_i y_i"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no direct 'angle ≤ π/2 ↔ inner ≥ 0' lemma; derived via EuclideanGeometry.angle/InnerProductGeometry.angle unfolding + Real.arccos_le_pi_div_two.",
+      "The deep half of Danzer–Grünbaum (2^d+1 points force an obtuse angle, via a volume/translation argument) is not in Mathlib and was not attempted."
+    ],
+    "nextSteps": [
+      "Formalise the matching upper bound: any 2^d+1 points in ℝ^d contain an obtuse angle (Danzer–Grünbaum volume argument on translated copies of conv(S) scaled by 1/2).",
+      "Quantify the largest angle actually attained by the cube configuration as a function of d, and investigate uniqueness of the extremal configuration up to affine equivalence."
+    ],
+    "progressSummary": "PROGRESS: shipped 0-axiom verified construction half of Danzer–Grünbaum (2^d cube vertices realise a non-obtuse configuration in ℝ^d), PR for erdos-504-oq-01. Upper bound remains open."
+  }
+}


### PR DESCRIPTION
## Summary

Erdős Problem **#504** (Blumenthal's problem, planar max-angle, solved by Sendov 1993) has a natural **higher-dimensional analogue** (open question OQ-01): for which `n` is one forced to have an obtuse angle among `n` points in ℝ^d? The threshold is governed by the **Danzer–Grünbaum theorem (1962)**: the maximum number of points in ℝ^d with *all* angles non-obtuse (≤ π/2) is exactly **2^d**, attained by the vertices of a hypercube.

This PR formalises the **sharp construction (lower-bound) half**, which is fully elementary — a **0-axiom verified original** result (141 lines, 11 theorems, 2 definitions, no `native_decide`).

## Results (`proofs/Proofs/Erdos504OQ01.lean`)

- **`inner_edge_nonneg`** — for any three cube vertices `a, b, c ∈ {0,1}^d`, the edge vectors satisfy `⟪a − b, c − b⟫ ≥ 0`. The inner product on `EuclideanSpace ℝ (Fin d)` expands as `∑ᵢ (aᵢ − bᵢ)(cᵢ − bᵢ)`, and each term is ≥ 0 because the two factors **share a sign**: both ≥ 0 when `bᵢ = 0`, both ≤ 0 when `bᵢ = 1`.
- **`angle_le_pi_div_two`** — consequently every angle `∠ a b c` at a cube vertex is **≤ π/2** (non-obtuse), via `Real.arccos_le_pi_div_two`.
- **`cubeVertices_card`** — the cube has exactly **2^d** distinct vertices (indexed injectively by subsets of `Fin d`).
- **`cubeVertices_pairwise_nonobtuse`** — packages the construction: 2^d points in ℝ^d with every angle non-obtuse.

## Significance

This is the sharp obstruction underlying the dimension-`d` version of Erdős #504: since 2^d points in ℝ^d can avoid obtuse angles entirely, the guaranteed maximum angle stays ≤ π/2 for all `n ≤ 2^d`. An obtuse angle is only forced once `n > 2^d`.

## Verification

`#print axioms` on every headline theorem reports only the foundational `propext / Classical.choice / Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status `verified`, badge `original`, `axiomCount: 0`.

The matching **upper bound** (2^d + 1 points force an obtuse angle, the deep volume/translation half of Danzer–Grünbaum) is left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)