### PR TITLE
research(erdos-1005-oq-03-oq-01): The Farey Next-Term Recurrence — successor of c/d in F_n is (kc−a)/(kd−b), k=⌊(n+b)/d⌋

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -932,6 +932,7 @@ import Proofs.Erdos1004Problem
 import Proofs.Erdos1005Problem
 import Proofs.Erdos1005ProblemProvable
 import Proofs.Erdos1005ProblemOQ03
+import Proofs.Erdos1005ProblemOQ03OQ01
 import Proofs.Erdos1006OQ01
 import Proofs.Erdos1006OQ01OQ02
 import Proofs.Erdos1006OQ02

--- a/proofs/Proofs/Erdos1005ProblemOQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1005ProblemOQ03OQ01.lean
@@ -1,0 +1,370 @@
+import Mathlib.Tactic
+import Mathlib.Data.Rat.Defs
+
+/-
+# Erdős Problem #1005 (OQ-03 / OQ-01): The Farey Next-Term Recurrence
+
+## Parent
+
+Erdős #1005 asks for the structure of the *longest run of consecutive
+similarly ordered Farey fractions* of order `n`. Any analysis of runs must be
+able to **walk** the Farey sequence: given two consecutive terms it must
+produce the next one. The sibling entry `Erdos1005ProblemOQ03` (the Farey
+adjacency criterion `b + d > n`) tells us *when* two unimodular neighbours are
+adjacent. This file supplies the missing constructive half: the explicit
+**successor formula** that generates the whole sequence — and hence every run.
+
+## This file
+
+Let `a/b < c/d` be adjacent in `F_n` (unimodular, `bc - ad = 1`, with
+`b + d > n`), and suppose `c/d < 1` (so a successor exists). Put
+
+  `k := ⌊(n + b) / d⌋`,   `e := k·c - a`,   `f := k·d - b`.
+
+We prove that `e/f` is exactly the **next** Farey fraction of order `n` after
+`c/d`:
+
+* `succ_unimodular` — `e·d - c·f = 1`: the new pair `c/d, e/f` is again
+  unimodular. This is *automatic* algebra: `ed - cf = (kc-a)d - c(kd-b) =
+  bc - ad = 1`. The recurrence preserves the unimodular invariant for free.
+
+* `succ_den_le` — `f ≤ n`: the successor stays in `F_n`. Immediate from
+  `k·d ≤ n + b` (definition of `⌊·⌋`).
+
+* `succ_den_pos` / `succ_num_pos` — `f ≥ 1` and `e ≥ 1`.
+
+* `succ_adjacent_pair` — `n < d + f`: by the sibling's adjacency criterion,
+  `c/d` and `e/f` are adjacent, because `(k+1)·d > n + b`.
+
+* `cur_lt_succ` — `c/d < e/f`: the successor lies to the right.
+
+* `succ_coprime` — `gcd(e, f) = 1`: `e/f` is in lowest terms.
+
+* `is_successor` — the headline: **no** Farey fraction of order `n` lies
+  strictly between `c/d` and `e/f`. So `e/f` is *the* immediate successor.
+
+* `den_recurrence` — the denominator recurrence in closed form,
+  `f = ⌊(n + b)/d⌋ · d - b`, the engine that drives any run analysis:
+  `q_{i+1} = ⌊(n + q_{i-1})/q_i⌋ · q_i - q_{i-1}`.
+
+Every theorem is fully machine-checked: 0 sorries, 0 axioms, no `native_decide`.
+
+(Self-contained: the small `FareyFraction` scaffold and the adjacency lemma
+`intermediate_denom_ge` are re-declared here, matching the sibling file, because
+the parent's `import Mathlib.Data.Rat.Basic` no longer resolves under Mathlib
+`v4.26.0`.)
+
+Reference: https://erdosproblems.com/1005
+-/
+
+namespace Erdos1005OQ03OQ01
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 1: Farey fractions (mirrors the sibling scaffold)
+-- ══════════════════════════════════════════════════════════════════
+
+/-- A Farey fraction of order `n`: a pair `(p, q)` with `0 ≤ p ≤ q`,
+    `1 ≤ q ≤ n`, and `gcd(p, q) = 1`. -/
+structure FareyFraction (n : ℕ) where
+  p : ℕ
+  q : ℕ
+  hq_pos : 1 ≤ q
+  hq_le : q ≤ n
+  hp_le : p ≤ q
+  hcoprime : Nat.Coprime p q
+
+/-- The rational value of a Farey fraction. -/
+def FareyFraction.toRat {n : ℕ} (f : FareyFraction n) : ℚ :=
+  f.p / f.q
+
+/-- Two unimodular neighbours satisfy `bc - ad = 1`. -/
+def IsConsecutiveFarey {n : ℕ} (f g : FareyFraction n) : Prop :=
+  g.p * f.q - f.p * g.q = 1
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 2: Order is cross-multiplication; the denominator-sum lemma
+-- ══════════════════════════════════════════════════════════════════
+
+/-- Strict order of two Farey fractions is cross-multiplication. -/
+theorem toRat_lt_iff {n : ℕ} (f g : FareyFraction n) :
+    f.toRat < g.toRat ↔ f.p * g.q < g.p * f.q := by
+  unfold FareyFraction.toRat
+  have hf : (0 : ℚ) < f.q := Nat.cast_pos.mpr f.hq_pos
+  have hg : (0 : ℚ) < g.q := Nat.cast_pos.mpr g.hq_pos
+  rw [div_lt_div_iff₀ hf hg]
+  constructor <;> intro h <;> exact_mod_cast h
+
+/-- **Denominator-sum lemma** (sibling `intermediate_denom_ge`). If
+    `a/b < p/q < c/d` and the outer pair is unimodular (`bc - ad = 1`), then
+    `q ≥ b + d`. Re-proved here so the file stands alone. -/
+theorem intermediate_denom_ge {n : ℕ} (f g h : FareyFraction n)
+    (huni : IsConsecutiveFarey f g)
+    (h1 : f.toRat < h.toRat) (h2 : h.toRat < g.toRat) :
+    f.q + g.q ≤ h.q := by
+  have hcb : g.p * f.q = f.p * g.q + 1 := by
+    have := huni; unfold IsConsecutiveFarey at this; omega
+  have hfh : f.p * h.q < h.p * f.q := (toRat_lt_iff f h).mp h1
+  have hhg : h.p * g.q < g.p * h.q := (toRat_lt_iff h g).mp h2
+  have hcbZ : (g.p : ℤ) * f.q = (f.p : ℤ) * g.q + 1 := by exact_mod_cast hcb
+  have h1Z : (f.p : ℤ) * h.q + 1 ≤ (h.p : ℤ) * f.q := by exact_mod_cast hfh
+  have h2Z : (h.p : ℤ) * g.q + 1 ≤ (g.p : ℤ) * h.q := by exact_mod_cast hhg
+  have key : (h.q : ℤ)
+      = (g.q : ℤ) * ((h.p : ℤ) * f.q - (f.p : ℤ) * h.q)
+        + (f.q : ℤ) * ((g.p : ℤ) * h.q - (h.p : ℤ) * g.q) := by
+    linear_combination (-(h.q : ℤ)) * hcbZ
+  have t1 : (1 : ℤ) ≤ (h.p : ℤ) * f.q - (f.p : ℤ) * h.q := by linarith
+  have t2 : (1 : ℤ) ≤ (g.p : ℤ) * h.q - (h.p : ℤ) * g.q := by linarith
+  have bound : (f.q : ℤ) + g.q ≤ h.q := by
+    nlinarith [mul_le_mul_of_nonneg_left t1 (by linarith : (0:ℤ) ≤ (g.q : ℤ)),
+               mul_le_mul_of_nonneg_left t2 (by linarith : (0:ℤ) ≤ (f.q : ℤ)), key]
+  exact_mod_cast bound
+
+/-- **Adjacency (sufficiency)** — a unimodular pair with `b + d > n` is adjacent
+    in `F_n`. -/
+theorem farey_adjacent_of_denom_sum_gt {n : ℕ} (f g : FareyFraction n)
+    (huni : IsConsecutiveFarey f g) (hsum : n < f.q + g.q) :
+    ∀ h : FareyFraction n, ¬ (f.toRat < h.toRat ∧ h.toRat < g.toRat) := by
+  rintro h ⟨h1, h2⟩
+  have hge : f.q + g.q ≤ h.q := intermediate_denom_ge f g h huni h1 h2
+  exact absurd (le_trans hge h.hq_le) (by omega)
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 3: The successor and its arithmetic certificates
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The integer multiplier `k = ⌊(n + b)/d⌋` that defines the successor. -/
+def succK {n : ℕ} (pred cur : FareyFraction n) : ℕ :=
+  (n + pred.q) / cur.q
+
+/-- The successor numerator `e = k·c - a`. -/
+def succNum {n : ℕ} (pred cur : FareyFraction n) : ℕ :=
+  succK pred cur * cur.p - pred.p
+
+/-- The successor denominator `f = k·d - b`. -/
+def succDen {n : ℕ} (pred cur : FareyFraction n) : ℕ :=
+  succK pred cur * cur.q - pred.q
+
+variable {n : ℕ} (pred cur : FareyFraction n)
+
+/-- `k·d ≤ n + b`: upper half of the floor-division bracket. -/
+theorem succK_mul_le : succK pred cur * cur.q ≤ n + pred.q := by
+  unfold succK
+  exact Nat.div_mul_le_self _ _
+
+/-- `n + b < (k+1)·d`: lower half of the floor-division bracket. -/
+theorem lt_succK_succ_mul : n + pred.q < (succK pred cur + 1) * cur.q := by
+  unfold succK
+  have hpos : 0 < cur.q := cur.hq_pos
+  have h1 : cur.q * ((n + pred.q) / cur.q) + (n + pred.q) % cur.q = n + pred.q :=
+    Nat.div_add_mod (n + pred.q) cur.q
+  have h2 : (n + pred.q) % cur.q < cur.q := Nat.mod_lt _ hpos
+  calc n + pred.q
+      = cur.q * ((n + pred.q) / cur.q) + (n + pred.q) % cur.q := h1.symm
+    _ < cur.q * ((n + pred.q) / cur.q) + cur.q := by omega
+    _ = ((n + pred.q) / cur.q + 1) * cur.q := by ring
+
+/-- `k·d > b`, so the successor denominator is a genuine `ℕ` subtraction.
+    Reason: `k·d > (n + b) - d ≥ b` since `d ≤ n`. -/
+theorem den_lt_succK_mul : pred.q < succK pred cur * cur.q := by
+  have hlt := lt_succK_succ_mul pred cur
+  have hdn : cur.q ≤ n := cur.hq_le
+  -- (k+1)·d = k·d + d, and n + b < k·d + d ⇒ k·d > n + b - d ≥ b
+  have : n + pred.q < succK pred cur * cur.q + cur.q := by
+    have := hlt; simpa [Nat.add_mul, Nat.one_mul] using this
+  omega
+
+/-- `k·c > a`, so the successor numerator is a genuine `ℕ` subtraction.
+    Reason: `d·(k·c) = c·(k·d) ≥ c·(b+1) = bc + c > bc - 1 = a·d`. -/
+theorem num_lt_succK_mul (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) :
+    pred.p < succK pred cur * cur.p := by
+  -- unimodular: c·b = a·d + 1
+  have hcb : cur.p * pred.q = pred.p * cur.q + 1 := by
+    have := huni; unfold IsConsecutiveFarey at this; omega
+  -- c ≥ 1: from a/b < c/d and a ≥ 0 we get c ≥ 1
+  have hc_pos : 0 < cur.p := by
+    rcases Nat.eq_zero_or_pos cur.p with h0 | h0
+    · exfalso
+      have hcross : pred.p * cur.q < cur.p * pred.q := (toRat_lt_iff pred cur).mp hlt
+      simp [h0] at hcross
+    · exact h0
+  have hkd : pred.q < succK pred cur * cur.q := den_lt_succK_mul pred cur
+  -- c·b < c·(k·d) = (k·c)·d, and c·b = a·d + 1, so a·d < (k·c)·d ⇒ a < k·c
+  have step1 : cur.p * pred.q < cur.p * (succK pred cur * cur.q) :=
+    mul_lt_mul_of_pos_left hkd hc_pos
+  have hrw : cur.p * (succK pred cur * cur.q) = (succK pred cur * cur.p) * cur.q := by ring
+  rw [hrw, hcb] at step1
+  have hmul : pred.p * cur.q < succK pred cur * cur.p * cur.q := by omega
+  exact lt_of_mul_lt_mul_right hmul (Nat.zero_le _)
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 4: The successor relations
+-- ══════════════════════════════════════════════════════════════════
+
+/-- **Unimodular preservation.** `e·d - c·f = 1`: the new pair `c/d, e/f` is
+    again unimodular. Pure algebra: `ed - cf = bc - ad = 1`. -/
+theorem succ_unimodular (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) :
+    succNum pred cur * cur.q - cur.p * succDen pred cur = 1 := by
+  have hcb : cur.p * pred.q = pred.p * cur.q + 1 := by
+    have := huni; unfold IsConsecutiveFarey at this; omega
+  have hkd : pred.q < succK pred cur * cur.q := den_lt_succK_mul pred cur
+  have hkc : pred.p < succK pred cur * cur.p :=
+    num_lt_succK_mul pred cur huni hlt
+  -- The clean identity e·d = c·f + 1 (no truncated subtraction).
+  have hed : succNum pred cur * cur.q = cur.p * succDen pred cur + 1 := by
+    unfold succNum succDen
+    zify [le_of_lt hkc, le_of_lt hkd]
+    have hcbZ : (cur.p : ℤ) * pred.q = (pred.p : ℤ) * cur.q + 1 := by exact_mod_cast hcb
+    linear_combination hcbZ
+  omega
+
+/-- The successor denominator is `≤ n`: it stays in `F_n`. -/
+theorem succ_den_le : succDen pred cur ≤ n := by
+  unfold succDen
+  have := succK_mul_le pred cur
+  omega
+
+/-- The successor denominator is positive. -/
+theorem succ_den_pos : 1 ≤ succDen pred cur := by
+  unfold succDen
+  have := den_lt_succK_mul pred cur
+  omega
+
+/-- `c/d` and `e/f` are an adjacent pair: `n < d + f`.
+    Because `(k+1)·d > n + b`, so `d + f = (k+1)d - b > n`. -/
+theorem succ_adjacent_pair : n < cur.q + succDen pred cur := by
+  unfold succDen
+  have h := lt_succK_succ_mul pred cur
+  have hk : pred.q < succK pred cur * cur.q := den_lt_succK_mul pred cur
+  -- (k+1)·d = k·d + d > n + b ⇒ d + (k·d - b) > n
+  have : n + pred.q < succK pred cur * cur.q + cur.q := by
+    simpa [Nat.add_mul, Nat.one_mul] using h
+  omega
+
+/-- The successor numerator is positive. -/
+theorem succ_num_pos (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) :
+    1 ≤ succNum pred cur := by
+  unfold succNum
+  have := num_lt_succK_mul pred cur huni hlt
+  omega
+
+/-- **Lowest terms.** `gcd(e, f) = 1`, from the unimodular relation
+    `e·d - c·f = 1`. -/
+theorem succ_coprime (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) :
+    Nat.Coprime (succNum pred cur) (succDen pred cur) := by
+  have huni2 := succ_unimodular pred cur huni hlt
+  rw [Nat.Coprime]
+  set g := Nat.gcd (succNum pred cur) (succDen pred cur) with hg
+  have hge : g ∣ succNum pred cur * cur.q :=
+    dvd_mul_of_dvd_left (Nat.gcd_dvd_left _ _) _
+  have hgf : g ∣ cur.p * succDen pred cur :=
+    dvd_mul_of_dvd_right (Nat.gcd_dvd_right _ _) _
+  -- e·d = c·f + 1
+  have hkc : pred.p < succK pred cur * cur.p :=
+    num_lt_succK_mul pred cur huni hlt
+  have hkd : pred.q < succK pred cur * cur.q := den_lt_succK_mul pred cur
+  have hed : succNum pred cur * cur.q = cur.p * succDen pred cur + 1 := by
+    have := huni2
+    omega
+  rw [hed] at hge
+  exact Nat.dvd_one.mp ((Nat.dvd_add_right hgf).mp hge)
+
+/-- **The successor stays in `[0,1]`:** `e ≤ f`, provided `c < d` (i.e.
+    `c/d < 1`, so a successor below `1` exists). From `e·d = c·f + 1` with
+    `c ≤ d - 1` and `f ≥ 1`: `e·d ≤ (d-1)f + 1 ≤ d·f`. -/
+theorem succ_num_le_den (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) :
+    succNum pred cur ≤ succDen pred cur := by
+  have hkc : pred.p < succK pred cur * cur.p :=
+    num_lt_succK_mul pred cur huni hlt
+  have hkd : pred.q < succK pred cur * cur.q := den_lt_succK_mul pred cur
+  have hed : succNum pred cur * cur.q = cur.p * succDen pred cur + 1 := by
+    have := succ_unimodular pred cur huni hlt
+    omega
+  have hfpos : 1 ≤ succDen pred cur := succ_den_pos pred cur
+  -- e·d = c·f + 1 ≤ (d-1)·f + 1 ≤ d·f
+  have hbound : succNum pred cur * cur.q ≤ succDen pred cur * cur.q := by
+    calc succNum pred cur * cur.q
+        = cur.p * succDen pred cur + 1 := hed
+      _ ≤ (cur.q - 1) * succDen pred cur + 1 := by
+            have hle : cur.p ≤ cur.q - 1 := by omega
+            have : cur.p * succDen pred cur ≤ (cur.q - 1) * succDen pred cur := by gcongr
+            omega
+      _ ≤ succDen pred cur * cur.q := by
+            have h1 : (cur.q - 1) * succDen pred cur + succDen pred cur
+                = succDen pred cur * cur.q := by
+              have hq1 : cur.q - 1 + 1 = cur.q := by have := cur.hq_pos; omega
+              calc (cur.q - 1) * succDen pred cur + succDen pred cur
+                  = (cur.q - 1 + 1) * succDen pred cur := by ring
+                _ = cur.q * succDen pred cur := by rw [hq1]
+                _ = succDen pred cur * cur.q := by ring
+            omega
+  have hq_pos : 0 < cur.q := cur.hq_pos
+  exact le_of_mul_le_mul_right hbound hq_pos
+
+-- ══════════════════════════════════════════════════════════════════
+-- § 5: Packaging the successor as a Farey fraction of order `n`
+-- ══════════════════════════════════════════════════════════════════
+
+/-- The successor `e/f`, packaged as a Farey fraction of order `n`. -/
+def succFarey (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) : FareyFraction n where
+  p := succNum pred cur
+  q := succDen pred cur
+  hq_pos := succ_den_pos pred cur
+  hq_le := succ_den_le pred cur
+  hp_le := succ_num_le_den pred cur huni hlt hcd
+  hcoprime := succ_coprime pred cur huni hlt
+
+@[simp] theorem succFarey_p (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) :
+    (succFarey pred cur huni hlt hcd).p = succNum pred cur := rfl
+
+@[simp] theorem succFarey_q (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) :
+    (succFarey pred cur huni hlt hcd).q = succDen pred cur := rfl
+
+/-- **The successor lies to the right:** `c/d < e/f`. From `e·d = c·f + 1`. -/
+theorem cur_lt_succ (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) :
+    cur.toRat < (succFarey pred cur huni hlt hcd).toRat := by
+  rw [toRat_lt_iff]
+  simp only [succFarey_p, succFarey_q]
+  have hed : succNum pred cur * cur.q = cur.p * succDen pred cur + 1 := by
+    have := succ_unimodular pred cur huni hlt
+    omega
+  omega
+
+/-- `c/d` and `e/f` form a consecutive (unimodular) pair. -/
+theorem isConsecutive_cur_succ (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) :
+    IsConsecutiveFarey cur (succFarey pred cur huni hlt hcd) := by
+  unfold IsConsecutiveFarey
+  simp only [succFarey_p, succFarey_q]
+  exact succ_unimodular pred cur huni hlt
+
+/-- **Headline: `e/f` is the immediate successor of `c/d` in `F_n`.** No Farey
+    fraction of order `n` lies strictly between `c/d` and `e/f`. -/
+theorem is_successor (huni : IsConsecutiveFarey pred cur)
+    (hlt : pred.toRat < cur.toRat) (hcd : cur.p < cur.q) :
+    ∀ h : FareyFraction n,
+      ¬ (cur.toRat < h.toRat ∧ h.toRat < (succFarey pred cur huni hlt hcd).toRat) := by
+  have hcons := isConsecutive_cur_succ pred cur huni hlt hcd
+  have hsum : n < cur.q + (succFarey pred cur huni hlt hcd).q := by
+    simp only [succFarey_q]; exact succ_adjacent_pair pred cur
+  exact farey_adjacent_of_denom_sum_gt cur (succFarey pred cur huni hlt hcd) hcons hsum
+
+/-- **Denominator recurrence (closed form).** The denominator of the successor
+    is `f = ⌊(n + b)/d⌋ · d - b`. Iterating gives the run-generating recurrence
+    `q_{i+1} = ⌊(n + q_{i-1})/q_i⌋ · q_i - q_{i-1}`. -/
+theorem den_recurrence :
+    succDen pred cur = ((n + pred.q) / cur.q) * cur.q - pred.q := rfl
+
+/-- **Numerator recurrence (closed form).** `e = ⌊(n + b)/d⌋ · c - a`. -/
+theorem num_recurrence :
+    succNum pred cur = ((n + pred.q) / cur.q) * cur.p - pred.p := rfl
+
+end Erdos1005OQ03OQ01

--- a/src/data/proofs/erdos-1005-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1005-oq-03-oq-01/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "erdos-1005-oq-03-oq-01",
+  "slug": "erdos-1005-oq-03-oq-01",
+  "sorries": 0,
+  "title": "The Farey Next-Term Recurrence: The Successor of c/d in F_n is (kc−a)/(kd−b) with k = ⌊(n+b)/d⌋",
+  "description": "A self-contained, axiom-free formalization of the classical Farey successor formula — the constructive engine that generates the entire Farey sequence and hence every run. Given two adjacent fractions a/b < c/d in F_n (unimodular, bc − ad = 1, with b + d > n) and c/d < 1, the immediate next fraction after c/d is exactly e/f with e = k·c − a, f = k·d − b, where k = ⌊(n+b)/d⌋. The multiplier k is the unique value making f the largest denominator ≤ n that keeps the new pair adjacent. The proof certifies every requirement: unimodular preservation e·d − c·f = 1 is automatic algebra (ed − cf = bc − ad = 1, so the recurrence keeps the invariant for free); the floor bracket k·d ≤ n+b < (k+1)·d gives both f ≤ n and the adjacency d + f > n; c/d < e/f follows from e·d = c·f + 1; gcd(e,f) = 1 from the same relation; and 1 ≤ e ≤ f packages e/f as a genuine FareyFraction of order n. Feeding the adjacency back through the sibling's denominator-sum criterion proves the headline: no order-n fraction lies strictly between c/d and e/f, so e/f is THE successor. The denominator recurrence q_{i+1} = ⌊(n+q_{i−1})/q_i⌋·q_i − q_{i−1} is the closed-form tool any analysis of Erdős #1005's similarly-ordered runs must walk along.",
+  "leanFile": {
+    "lineCount": 370,
+    "axiomCount": 0,
+    "path": "Proofs/Erdos1005ProblemOQ03OQ01.lean",
+    "sorries": 0,
+    "definitionCount": 6,
+    "theoremCount": 19
+  },
+  "meta": {
+    "author": "Formalization original to Lean Genius (classical Farey/Stern–Brocot theory)",
+    "date": "1816",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1005ProblemOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "farey-fractions",
+      "stern-brocot",
+      "mediant",
+      "continued-fractions",
+      "recurrence",
+      "diophantine-approximation"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-23",
+    "lineCount": 370,
+    "originalContributions": [
+      "succ_unimodular: the new pair c/d, e/f is again unimodular, e·d − c·f = 1. This is automatic algebra — (kc−a)d − c(kd−b) = bc − ad = 1 — so the successor recurrence preserves the unimodular invariant for free; proved by clearing the ℕ truncated subtractions via zify against the established bounds k·c > a, k·d > b and a single linear_combination against bc − ad = 1",
+      "succK_mul_le / lt_succK_succ_mul: the floor-division bracket k·d ≤ n+b < (k+1)·d for k = ⌊(n+b)/d⌋, the two inequalities that simultaneously force f = k·d − b ≤ n (stays in F_n) and d + f > n (the pair c/d, e/f is adjacent)",
+      "den_lt_succK_mul / num_lt_succK_mul: k·d > b and k·c > a, certifying that the successor denominator f = k·d − b and numerator e = k·c − a are genuine (non-truncated) ℕ subtractions; k·c > a is obtained by multiplying k·d > b by c and collapsing against bc = ad + 1",
+      "succ_den_le, succ_den_pos, succ_num_pos, succ_adjacent_pair: f ≤ n, f ≥ 1, e ≥ 1, and n < d + f — the membership and adjacency certificates, all read off from the floor bracket",
+      "succ_num_le_den: e ≤ f when c < d (c/d < 1), so e/f ≤ 1; from e·d = c·f + 1 with c ≤ d−1 and f ≥ 1 one gets e·d ≤ (d−1)f + 1 ≤ d·f, hence e ≤ f. This is exactly the condition that the successor stays inside [0,1]",
+      "succ_coprime: gcd(e,f) = 1, so e/f is in lowest terms, from the unimodular relation e·d − c·f = 1 (any common divisor of e and f divides 1)",
+      "succFarey: packages e/f as a bona fide FareyFraction of order n, bundling the five certificates (1 ≤ f ≤ n, e ≤ f, coprimality)",
+      "is_successor: the headline — no FareyFraction of order n lies strictly between c/d and e/f, obtained by feeding the adjacency d + f > n back through the sibling's denominator-sum criterion (farey_adjacent_of_denom_sum_gt). Thus e/f is THE immediate successor of c/d in F_n",
+      "den_recurrence / num_recurrence: the closed-form recurrence f = ⌊(n+b)/d⌋·d − b and e = ⌊(n+b)/d⌋·c − a (definitional), i.e. q_{i+1} = ⌊(n+q_{i−1})/q_i⌋·q_i − q_{i−1}, the iterable engine that walks the Farey sequence and generates every run"
+    ],
+    "assumptions": "None. The file is fully machine-checked with 0 sorries and 0 axiom declarations; #print axioms reports only the foundational propext / Classical.choice / Quot.sound for all theorems (and den_recurrence depends on no axioms at all). No native_decide is used (so no Lean.ofReduceBool).",
+    "theoremCount": 19,
+    "definitionCount": 6
+  },
+  "overview": {
+    "historicalContext": "The Farey sequence F_n — all reduced fractions in [0,1] with denominator ≤ n, in increasing order — has two classical pillars: the unimodular relation bc − ad = 1 for adjacent fractions a/b < c/d, and the explicit successor formula that, given two consecutive terms, produces the next. This successor rule (e = kc − a, f = kd − b with k = ⌊(n+b)/d⌋) is the standard way to enumerate F_n in linear time and is the discrete analogue of the continued-fraction algorithm. Erdős Problem #1005 asks for the longest run of consecutive 'similarly ordered' Farey fractions; the sibling entry settles when two fractions are adjacent, and this entry supplies the constructive other half — how to walk from one adjacency to the next.",
+    "problemStatement": "Given two adjacent Farey fractions a/b < c/d of order n (unimodular bc − ad = 1, denominators summing past n) with c/d < 1, produce in closed form the immediate next fraction e/f after c/d in F_n, and certify that it is again a reduced order-n fraction, adjacent to c/d, with nothing of order n strictly between.",
+    "proofStrategy": "Define k := ⌊(n+b)/d⌋, e := k·c − a, f := k·d − b. The floor-division bracket k·d ≤ n+b < (k+1)·d is the workhorse: the upper half gives f = k·d − b ≤ n, and since d ≤ n it also gives k·d > b (so f ≥ 1 and the subtraction is genuine); the lower half rearranges to d + f > n. Multiplying k·d > b by c and using bc = ad + 1 yields k·c > a (so e ≥ 1). The unimodular preservation e·d = c·f + 1 is one linear_combination after clearing the truncated subtractions over ℤ; from it, c/d < e/f (since c·f < c·f + 1 = e·d), gcd(e,f) = 1, and — using c ≤ d − 1 — the bound e ≤ f that keeps e/f in [0,1]. These five facts package e/f as a FareyFraction of order n adjacent to c/d. The headline 'e/f is the successor' is then immediate: the adjacency d + f > n feeds the sibling's denominator-sum criterion, which rules out any order-n fraction strictly between c/d and e/f.",
+    "keyInsights": [
+      "The successor is fully explicit and local: it depends only on the two previous terms a/b, c/d and the order n, via one floor division k = ⌊(n+b)/d⌋ — no search or enumeration of F_n is needed.",
+      "Unimodularity is conserved automatically: e·d − c·f = (kc−a)d − c(kd−b) = bc − ad = 1, so the recurrence carries the bc − ad = 1 invariant forward with no extra work; the entire 'next neighbour' structure is preserved by construction.",
+      "The single floor bracket k·d ≤ n+b < (k+1)·d does double duty: the upper inequality keeps the successor inside F_n (f ≤ n), the lower inequality forces the adjacency d + f > n. The multiplier k is precisely the largest one keeping f ≤ n, equivalently the one making the pair adjacent.",
+      "Composability with the sibling: the adjacency criterion (b + d > n ⇔ adjacent) and this successor formula are exact converses of one construction — the formula produces the unique adjacent right-neighbour, and the criterion certifies nothing lies between.",
+      "Iterating den_recurrence gives q_{i+1} = ⌊(n+q_{i−1})/q_i⌋·q_i − q_{i−1}, the concrete generator of the whole Farey denominator sequence. Any quantitative attack on Erdős #1005's run lengths must walk this recurrence; this entry makes it a machine-checked primitive."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (370 lines, 19 theorems, 6 definitions) of the Farey successor formula. Given adjacent a/b < c/d in F_n with c/d < 1, the next fraction is e/f = (k·c − a)/(k·d − b) with k = ⌊(n+b)/d⌋: it is reduced, lies in F_n, is adjacent to c/d, and (the headline is_successor) nothing of order n lies strictly between — so it is the immediate successor. Unimodularity e·d − c·f = 1 is preserved for free.",
+    "implications": "Together with the sibling adjacency criterion, this completes the constructive description of consecutive Farey fractions: one can now walk F_n term by term via the closed-form recurrence q_{i+1} = ⌊(n+q_{i−1})/q_i⌋·q_i − q_{i−1}. This is the missing primitive for any quantitative analysis of Erdős #1005's longest similarly-ordered runs, which are chains of these successor steps. The successor formula and its certificates are also reusable infrastructure for continued-fraction and Stern–Brocot formalizations, where the same k = ⌊(n+b)/d⌋ governs the linear-time enumeration of the mediant tree.",
+    "openQuestions": [
+      "Run generation: formalize a single 'similarly ordered' run as a maximal chain of successor steps with monotone denominators, and derive a lower bound on its length directly from the recurrence k = ⌊(n+b)/d⌋ (k = 1 steps decrease the denominator, k ≥ 2 increase it).",
+      "Symmetry / predecessor: prove the dual predecessor formula and the reflection a/b ↔ (1−)·, exhibiting the involution that reverses the Farey sequence and shows the successor recurrence is time-reversible."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1005-oq-03",
+      "relationship": "extends",
+      "description": "The constructive complement of the sibling adjacency criterion. That entry proves WHEN two unimodular neighbours are adjacent (b + d > n); this entry proves HOW to produce the next neighbour explicitly (e = kc − a, f = kd − b, k = ⌊(n+b)/d⌋) and reuses the sibling's denominator-sum lemma to certify nothing lies between."
+    },
+    {
+      "targetId": "erdos-1005",
+      "relationship": "extends",
+      "description": "Supplies the successor recurrence the parent's run problem must walk. A run of consecutive similarly ordered Farey fractions is a chain of successor steps; this entry formalizes the step in closed form, q_{i+1} = ⌊(n+q_{i−1})/q_i⌋·q_i − q_{i−1}."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The **constructive complement** to the sibling Farey adjacency criterion (`erdos-1005-oq-03`). That entry proves *when* two Farey fractions are adjacent (`b + d > n`); this entry proves *how to produce the next one explicitly* — the successor formula that generates the whole sequence and hence every run in Erdős #1005.

Given two adjacent fractions `a/b < c/d` in `F_n` (unimodular `bc − ad = 1`, `b + d > n`) with `c/d < 1`, the immediate next fraction after `c/d` is exactly

```
e/f   with   e = k·c − a,   f = k·d − b,   k = ⌊(n + b)/d⌋.
```

## What is proved (0-axiom, 0-sorry)

- **`succ_unimodular`** — `e·d − c·f = 1`: the new pair is again unimodular. Automatic algebra, `(kc−a)d − c(kd−b) = bc − ad = 1`, so the recurrence preserves the invariant for free.
- **floor bracket** `succK_mul_le` / `lt_succK_succ_mul` — `k·d ≤ n+b < (k+1)·d` simultaneously forces `f ≤ n` (stays in `F_n`) and `d + f > n` (the new pair is adjacent).
- **`den_lt_succK_mul` / `num_lt_succK_mul`** — `k·d > b`, `k·c > a`: the subtractions defining `e, f` are genuine.
- **`succ_num_le_den`** — `e ≤ f` when `c < d`, so `e/f ≤ 1`.
- **`succ_coprime`** — `gcd(e, f) = 1`: lowest terms.
- **`succFarey`** — packages `e/f` as a bona fide `FareyFraction n`.
- **`is_successor`** (headline) — no order-`n` fraction lies strictly between `c/d` and `e/f`, via the sibling's denominator-sum criterion. So `e/f` is *the* immediate successor.
- **`den_recurrence`** — closed form `q_{i+1} = ⌊(n + q_{i−1})/q_i⌋·q_i − q_{i−1}`, the iterable engine any analysis of #1005's similarly-ordered runs must walk along.

## Verification

- **370 lines, 19 theorems, 6 definitions, 0 sorries, 0 `axiom` declarations.**
- `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` (`den_recurrence` depends on none). **No `native_decide`** (no `Lean.ofReduceBool`).
- Compiles cleanly under Mathlib `v4.26.0` (self-contained; re-declares the small `FareyFraction` scaffold and the sibling's denominator-sum lemma since the parent's `Mathlib.Data.Rat.Basic` import no longer resolves).
- Status: `verified` / badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)