### PR TITLE
Enrich Thomae's Function & Lebesgue's Criterion (lebesgue-measure-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "definition",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-01",
+    "range": { "startLine": 54, "endLine": 67 },
+    "type": "definition",
+    "title": "Thomae's Function: 1/q.den at Rationals, 0 Elsewhere",
+    "content": "`thomae` sends a rational q (in lowest terms) to 1/q.den and every irrational to 0, implemented by a decidable check for the existence of a rational casting to x (with Classical choice extracting the witness). `thomae_irrational` and `thomae_rat` fix the two cases; the latter uses Rat.cast_inj to confirm the chosen witness is q itself, so the value is exactly 1/q.den. The function is bounded by 1, equals 0 a.e., yet is discontinuous on the dense rationals — the whole point of studying it.",
+    "mathContext": "$\\mathrm{thomae}(x) = \\begin{cases} 1/q_{\\text{den}} & x = q\\in\\mathbb{Q}\\text{ (lowest terms)}\\\\ 0 & x\\notin\\mathbb{Q}\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["Thomae function", "popcorn function", "modified Dirichlet function", "rational denominator"],
+    "prerequisites": ["rational numbers", "piecewise definitions"]
+  },
+  {
+    "id": "finite-rat-bounded",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 104 },
+    "type": "technique",
+    "title": "Only Finitely Many Low-Denominator Rationals Are Nearby",
+    "content": "`finite_rat_bounded` is the combinatorial engine of continuity: the set of rationals q with |q − x| ≤ 1 and denominator ≤ N is finite. The proof exhibits it as a subset of an explicit finite set — for each denominator d ≤ N, the numerator q.num is an integer bracketed between ⌊(x−1)d⌋ and ⌈(x+1)d⌉ (via rat_num_eq_mul_den: q.num = q·q.den over ℝ), so only finitely many numerator/denominator pairs qualify. `Set.Finite.subset` of a Finset.biUnion image realizes this. This is what makes the ε–δ argument possible: large Thomae values (small denominator) occur at only finitely many nearby points.",
+    "mathContext": "$\\{q\\in\\mathbb{Q} : |q-x|\\le 1,\\ q_{\\text{den}}\\le N\\}$ is finite; numerator $\\in [\\lfloor(x-1)d\\rfloor, \\lceil(x+1)d\\rceil]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finiteness", "floor and ceiling", "bounded denominator", "Finset.biUnion"],
+    "prerequisites": ["finite sets", "integer bracketing"]
+  },
+  {
+    "id": "pos-min-dist",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 119 },
+    "type": "technique",
+    "title": "Positive Distance from an Irrational to a Finite Rational Set",
+    "content": "`pos_min_dist` shows an irrational x sits a strictly positive distance δ from any finite set of rationals, by induction over the finite set (Finset.induction_on). The empty case takes δ = 1; the insert step takes δ = min(δ₀, |x − a|), where |x − a| > 0 because x is irrational so x ≠ a (abs_pos + sub_ne_zero, contradicting irrationality otherwise). Irrationality is exactly what guarantees no rational coincides with x, keeping every distance positive. Combined with finite_rat_bounded, this furnishes the δ in the continuity proof.",
+    "mathContext": "$x$ irrational, $S\\subseteq\\mathbb{Q}$ finite $\\Rightarrow \\exists\\delta>0,\\ \\forall q\\in S,\\ \\delta\\le|x-q|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite induction", "irrationality", "minimum distance", "isolated point"],
+    "prerequisites": ["Finset induction", "absolute value"]
+  },
+  {
+    "id": "continuity-irrational",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-01",
+    "range": { "startLine": 121, "endLine": 155 },
+    "type": "insight",
+    "title": "Thomae Is Continuous at Every Irrational",
+    "content": "`thomae_continuous_at_irrational` is the crux of Part 1. For irrational x and ε > 0: choose N with 1/(N+1) < ε; the finitely many rationals of denominator ≤ N within distance 1 of x lie at distance ≥ δ (finite_rat_bounded + pos_min_dist). Within min(δ,1) of x, an irrational point gives thomae = 0 < ε, while a rational point q must have denominator > N (else it would be one of the nearby low-denominator points, contradicting |y−x| < δ), so thomae(q) = 1/q.den ≤ 1/(N+1) < ε. This rebuilds the classical argument against the current Mathlib API (div_lt_iff₀, one_div_le_one_div_of_le), repairing a bit-rotted file.",
+    "mathContext": "$x$ irrational $\\Rightarrow \\mathrm{ContinuousAt}\\ \\mathrm{thomae}\\ x$: $|y-x|<\\min(\\delta,1)\\Rightarrow \\mathrm{thomae}(y)<\\varepsilon$.",
+    "significance": "key",
+    "relatedConcepts": ["continuity at irrationals", "epsilon-delta", "Archimedean property", "API bit-rot repair"],
+    "prerequisites": ["continuity", "epsilon-delta limits", "irrational numbers"]
+  },
+  {
+    "id": "criterion-null",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-01",
+    "range": { "startLine": 161, "endLine": 183 },
+    "type": "insight",
+    "title": "The Measure Side of Lebesgue's Criterion",
+    "content": "This block delivers the criterion's content. thomae_discontinuitySet_subset is the contrapositive of Part 1: every discontinuity point is rational (a non-rational, i.e. irrational, point is a continuity point). rat_range_null makes the rationals null — they are countable, and countable sets have measure zero for the atomless Lebesgue volume (Set.Countable.measure_zero). thomae_discontinuitySet_null then concludes the discontinuity set is null (measure_mono_null), and thomae_ae_continuousAt restates this as continuity almost everywhere (ae_iff) — the exact hypothesis of Lebesgue's criterion.",
+    "mathContext": "$\\{x: \\neg\\mathrm{ContinuousAt}\\ \\mathrm{thomae}\\ x\\}\\subseteq\\mathbb{Q}$, $\\mathrm{vol}(\\mathbb{Q})=0 \\Rightarrow$ continuous a.e.",
+    "significance": "key",
+    "relatedConcepts": ["Lebesgue criterion", "null set", "countable sets", "almost everywhere", "atomless measure"],
+    "prerequisites": ["Lebesgue measure", "countability", "almost-everywhere properties"]
+  },
+  {
+    "id": "integrability",
+    "proofId": "lebesgue-measure-oq-01-oq-01-oq-01",
+    "range": { "startLine": 189, "endLine": 227 },
+    "type": "concept",
+    "title": "Integrability and the Value, Packaged via the Criterion",
+    "content": "Part 3 recovers the integral. thomae_ae_zero shows the function vanishes a.e. (its nonzero set is again contained in the null rationals), so thomae_integrable proves Lebesgue integrability by congruence with the zero function, and thomae_integral_zero / thomae_intervalIntegral_zero give ∫ = 0 on the line and on [0,1] (intervalIntegral.integral_congr_ae). thomae_riemann_via_lebesgue_criterion bundles the three headline facts — null discontinuity set, integrable, ∫₀¹ = 0 — i.e. classically 'Riemann integrable on [0,1] with value 0', now obtained THROUGH the criterion rather than around it.",
+    "mathContext": "$\\mathrm{thomae} =^{\\text{a.e.}} 0 \\Rightarrow$ integrable, $\\int_0^1 \\mathrm{thomae} = 0$; bundled with the null discontinuity set.",
+    "significance": "key",
+    "relatedConcepts": ["Riemann integrability", "a.e.-vanishing", "Lebesgue integral", "integral_congr_ae"],
+    "prerequisites": ["Lebesgue integration", "interval integrals"]
+  }
+]

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01-oq-01/meta.json
@@ -17,6 +17,7 @@
     "sorries": 0
   },
   "title": "Thomae's Function and Lebesgue's Criterion for Riemann Integrability",
+  "description": "Thomae's (popcorn) function — 1/q.den at a rational q, 0 at irrationals — treated through Lebesgue's criterion: a bounded function on [a,b] is Riemann integrable iff its discontinuity set is Lebesgue-null. Continuity at every irrational is reproved self-containedly (only finitely many rationals of bounded denominator lie near an irrational, at a positive distance), so the discontinuity set sits inside the rationals, which are countable hence null. This gives the MEASURE side of the criterion (thomae_discontinuitySet_null) and a.e.-continuity — exactly what the prior Riemann entry sidestepped via the cheaper thomae =ᵐ 0 route. Integrability and the value ∫₀¹ = 0 are recovered and packaged as thomae_riemann_via_lebesgue_criterion. Also repairs a bit-rotted continuity proof against the current Mathlib API.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -84,6 +85,48 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Thomae's function (1875), also called the popcorn, raindrop, or modified Dirichlet function, is the textbook example of a function that is continuous at every irrational and discontinuous at every rational — a discontinuity set (the rationals) that is dense yet 'small'. It is the canonical witness for Lebesgue's criterion (Henri Lebesgue, 1902): a bounded function on a closed interval is Riemann integrable if and only if its set of discontinuities has Lebesgue measure zero. Where Riemann's own integrability condition is phrased via oscillation and upper/lower sums, Lebesgue's reformulation is purely measure-theoretic — the discontinuity set being null is exactly what makes the upper and lower Darboux integrals coincide. Thomae's function passes the test: its discontinuities are the countable, hence null, rationals, so it is Riemann integrable with integral 0, despite being discontinuous on a dense set. This entry formalizes the measure-theoretic heart of that argument in Lean and, as a side effect, rebuilds the continuity-at-irrationals proof against the current Mathlib API, repairing a bit-rotted gallery file.",
+    "problemStatement": "**Open Question (oq-01-oq-01-oq-01)**: formalize the Riemann integrability of Thomae's function via Lebesgue's criterion — i.e. by showing its discontinuity set has Lebesgue measure zero — rather than through the cheaper a.e.-vanishing route used by the prior Riemann entry. Answer: the discontinuity set {x | ¬ContinuousAt thomae x} ⊆ ℚ is null, so Thomae is continuous a.e., hence (classically) Riemann integrable on [0,1] with ∫ = 0.",
+    "proofStrategy": "Three parts. **Part 1 (continuity at irrationals, self-contained):** for irrational x and ε > 0, pick N with 1/(N+1) < ε. Only finitely many rationals of denominator ≤ N lie within distance 1 of x (finite_rat_bounded, by bracketing the numerator between ⌊(x−1)d⌋ and ⌈(x+1)d⌉ for each denominator d ≤ N), and these finitely many points sit a positive distance δ from x (pos_min_dist, by induction over the finite set using irrationality to keep each distance strictly positive). Within min(δ,1) of x, any rational point has denominator > N, so thomae < 1/(N+1) < ε; irrational points give thomae = 0. **Part 2 (the criterion's measure side):** the discontinuity set is contained in the rationals (contrapositive of Part 1), the rationals are countable hence null for the atomless volume measure (Set.Countable.measure_zero), so the discontinuity set is null (measure_mono_null) and Thomae is continuous a.e. (ae_iff). **Part 3 (integrability/value):** Thomae vanishes a.e. (same null-rationals argument), so it is Lebesgue integrable with ∫ = 0 on the line and ∫₀¹ = 0 (integral_congr_ae), all packaged into thomae_riemann_via_lebesgue_criterion.",
+    "keyInsights": [
+      "A function can be discontinuous on a dense set yet Riemann integrable — what matters is not topological density but measure: the rationals are dense but null, so Thomae's discontinuities cost nothing for integrability.",
+      "Continuity at the irrationals is a finiteness phenomenon: near any point, only finitely many rationals have small denominator (hence large Thomae value), and an irrational keeps a positive distance from all of them — so the value can be forced below any ε.",
+      "Lebesgue's criterion replaces Riemann's oscillation condition with a clean measure statement (discontinuity set null), and this entry formalizes exactly that measure content — the part Mathlib's lack of a first-class Riemann integral leaves implicit.",
+      "The entry deliberately supplies what a sibling sidestepped: the prior Riemann entry proved ∫ = 0 via thomae =ᵐ 0 and explicitly noted it bypassed the criterion; here the null discontinuity set and a.e.-continuity are proved head-on.",
+      "Formal proofs bit-rot: the continuity-at-irrationals argument is rebuilt against the current Mathlib (div_lt_iff → div_lt_iff₀, Set.Finite.subset for the finiteness, one_div_le_one_div_of_le, the @insert induction pattern), a concrete instance of API-drift maintenance."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Thomae's Function: Definition and Values",
+      "startLine": 51,
+      "endLine": 67,
+      "summary": "thomae is defined as 1/q.den at a rational q and 0 at irrationals (via a decidable existence check). thomae_irrational and thomae_rat record the two value cases, the latter pinning the rational value to 1/q.den in lowest terms."
+    },
+    {
+      "id": "continuity-irrational",
+      "title": "Part 1: Continuity at Every Irrational",
+      "startLine": 69,
+      "endLine": 155,
+      "summary": "The ε–δ core. rat_num_eq_mul_den and finite_rat_bounded show only finitely many rationals of denominator ≤ N lie within distance 1 of x (numerator bracketed by floor/ceil per denominator). pos_min_dist gives a positive minimum distance δ from an irrational x to that finite set (induction using irrationality). thomae_continuous_at_irrational assembles these: within min(δ,1), rationals have denominator > N so thomae < 1/(N+1) < ε."
+    },
+    {
+      "id": "criterion-null",
+      "title": "Part 2: Lebesgue's Criterion — Null Discontinuity Set",
+      "startLine": 157,
+      "endLine": 183,
+      "summary": "thomae_discontinuitySet_subset (contrapositive of Part 1: every discontinuity is rational), rat_range_null (the rationals are countable hence null for atomless volume), thomae_discontinuitySet_null (the measure side of Lebesgue's criterion), and thomae_ae_continuousAt (continuous a.e., via ae_iff)."
+    },
+    {
+      "id": "integrability",
+      "title": "Part 3: Integrability and the Value 0",
+      "startLine": 185,
+      "endLine": 227,
+      "summary": "thomae_ae_zero (vanishes a.e., same null-rationals argument), thomae_integrable (Lebesgue integrable by congruence with 0), thomae_integral_zero / thomae_integrableOn_Icc / thomae_intervalIntegral_zero (∫ = 0 on the line and on [0,1]), packaged with the null discontinuity set into thomae_riemann_via_lebesgue_criterion."
+    }
+  ],
   "openQuestions": [
     {
       "id": "lebesgue-measure-oq-01-oq-01-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `lebesgue-measure-oq-01-oq-01-oq-01` (quality 15, passes 0). Rich meta existed, but no `description`, no `overview`, no `sections`, no `annotations.json`.

## Added to meta.json
- **description** — gallery-listing summary.
- **overview** — `historicalContext` (Thomae 1875, Lebesgue 1902 criterion, dense-but-null discontinuities), `problemStatement`, `proofStrategy` (all three parts), 5 `keyInsights`.
- **sections** — 4, covering all 229 lines (definition, continuity at irrationals, null discontinuity set, integrability).

## Added annotations.json (6 annotations)
The definition, the finiteness lemma, the positive-min-distance lemma, continuity at irrationals, the measure side of Lebesgue's criterion, and integrability/packaging — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, line-anchored on declarations.

## Axiom integrity
Unchanged and accurate: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0`. The entry supplies the measure-theoretic content of Lebesgue's criterion that the prior Riemann entry sidestepped, and rebuilds a bit-rotted continuity proof against the current Mathlib — no `axiom`/`sorry`/`native_decide`.

## Verification
- Both JSON files parse; `pnpm annotations:validate` (strict) reports **0 errors** for this entry (a startLine was corrected from an `open ... in` modifier to the `def` line so all ranges resolve to Lean constructs).
- `tsc -b`/`vite build` can't run in this worktree (native `better-sqlite3` install fails — pre-existing environment issue, unrelated to this data-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)