### PR TITLE
research(erdos-1025-oq-04): degenerate pair functions — collapse to g=1 and bounded-degeneracy recovery [0-axiom verified]

### DIFF
--- a/proofs/Proofs/Erdos1025OQ04.lean
+++ b/proofs/Proofs/Erdos1025OQ04.lean
@@ -1,0 +1,189 @@
+/-
+Erdős Problem #1025, Open Question 4 — relaxing the validity constraint.
+
+Parent #1025 (Independent Sets in Pair Functions):
+A *valid* pair function `f` sends each pair `{x,y} ⊆ {1,…,n}` to an element with
+`f x y ≠ x` and `f x y ≠ y`.  A set `X` is *independent* if `f x y ∉ X` for all
+`x, y ∈ X`.  Erdős–Hajnal (1958), Spencer (1972) and Conlon–Fox–Sudakov (2016)
+showed the minimum guaranteed independent set size is `g(n) = Θ(√n)`.
+
+OQ-4 asks: *what happens if we allow the degenerate values `f x y = x` or
+`f x y = y`, with bounded frequency?*
+
+This file gives two sharp, elementary answers (fully verified, 0 axioms / 0
+sorries):
+
+1. **Collapse (unbounded degeneracy).**  Drop the validity constraint entirely
+   and the guarantee collapses: the function `fbad x y = x` admits no independent
+   set of size `≥ 2`, while a singleton is always independent.  Hence the relaxed
+   guarantee is exactly `1` for `n ≥ 2`, versus `Θ(√n)` in the valid case — the
+   validity hypothesis is essential.
+
+2. **Recovery (bounded degeneracy).**  Measure degeneracy by the number `k` of
+   ordered pairs `(x,y)` with `f x y ∈ {x,y}`.  Deleting the (at most `2k`)
+   endpoints of those pairs leaves a set `W` with `|W| ≥ n − 2k` on which `f` is
+   genuinely valid.  So a bounded number of violations only shrinks the effective
+   ground set by a bounded amount, and an independent set of size `2` survives
+   whenever `n − 2k ≥ 2`.
+
+Reference: https://erdosproblems.com/1025
+-/
+
+import Mathlib
+
+open Finset
+
+namespace Erdos1025OQ04
+
+variable {n : ℕ}
+
+/-- A (possibly degenerate) pair function on `Fin n`, given in explicit two-argument
+form.  No validity constraint is imposed. -/
+abbrev RelaxedPairFunction (n : ℕ) := Fin n → Fin n → Fin n
+
+/-- The validity constraint of the original problem: `f x y` avoids both endpoints. -/
+def Valid (f : RelaxedPairFunction n) : Prop :=
+  ∀ x y : Fin n, x ≠ y → f x y ≠ x ∧ f x y ≠ y
+
+/-- A set `X` is independent under `f` if the image of any pair from `X` lies
+outside `X`. -/
+def Independent (f : RelaxedPairFunction n) (X : Finset (Fin n)) : Prop :=
+  ∀ x ∈ X, ∀ y ∈ X, x ≠ y → f x y ∉ X
+
+/-- Validity of `f` restricted to pairs lying inside a subset `W`. -/
+def ValidOn (f : RelaxedPairFunction n) (W : Finset (Fin n)) : Prop :=
+  ∀ x ∈ W, ∀ y ∈ W, x ≠ y → f x y ≠ x ∧ f x y ≠ y
+
+/-! ## Basic independence facts -/
+
+/-- The empty set is independent under any pair function. -/
+theorem empty_independent (f : RelaxedPairFunction n) : Independent f ∅ := by
+  intro x hx; simp at hx
+
+/-- A singleton is independent under any pair function. -/
+theorem singleton_independent (f : RelaxedPairFunction n) (a : Fin n) :
+    Independent f {a} := by
+  intro x hx y hy hxy
+  rw [Finset.mem_singleton] at hx hy
+  exact absurd (hx.trans hy.symm) hxy
+
+/-- For a *valid* pair function, every two-element set is independent: the
+defining constraint is exactly the statement that pairs are independent. Hence the
+valid guarantee is `≥ 2`. -/
+theorem valid_pair_independent (f : RelaxedPairFunction n) (hf : Valid f)
+    {a b : Fin n} (hab : a ≠ b) : Independent f ({a, b} : Finset (Fin n)) := by
+  intro x hx y hy hxy
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
+  simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+  rcases hx with rfl | rfl
+  · rcases hy with rfl | rfl
+    · exact absurd rfl hxy
+    · exact hf x y hxy
+  · rcases hy with rfl | rfl
+    · exact ⟨(hf x y hxy).2, (hf x y hxy).1⟩
+    · exact absurd rfl hxy
+
+/-! ## Part 1 — Collapse under unbounded degeneracy -/
+
+/-- The maximally degenerate pair function: it always returns its first argument
+(`f x y = x ∈ {x,y}` for every pair). -/
+def fbad (n : ℕ) : RelaxedPairFunction n := fun x _ => x
+
+/-- `fbad` is *not* valid for `n ≥ 2`: every pair is degenerate. -/
+theorem fbad_not_valid (hn : 2 ≤ n) : ¬ Valid (fbad n) := by
+  intro hf
+  have h01 : (⟨0, by omega⟩ : Fin n) ≠ ⟨1, by omega⟩ := by
+    simp [Fin.ext_iff]
+  exact (hf _ _ h01).1 rfl
+
+/-- **Collapse.** No set of size `≥ 2` is independent under `fbad`: any two
+distinct elements `a, b ∈ X` give `fbad a b = a ∈ X`, violating independence. -/
+theorem relaxed_collapse (X : Finset (Fin n)) (h : Independent (fbad n) X) :
+    X.card ≤ 1 := by
+  rw [Finset.card_le_one]
+  intro a ha b hb
+  by_contra hab
+  have hh := h a ha b hb hab
+  simp only [fbad] at hh
+  exact hh ha
+
+/-- **The relaxed guarantee is exactly `1`** for `n ≥ 2`: every independent set
+under `fbad` has size `≤ 1`, and some independent set has size `1`.  Contrast with
+`g(n) = Θ(√n)` for valid functions. -/
+theorem relaxed_g_eq_one (hn : 2 ≤ n) :
+    (∀ X : Finset (Fin n), Independent (fbad n) X → X.card ≤ 1) ∧
+      (∃ X : Finset (Fin n), Independent (fbad n) X ∧ X.card = 1) := by
+  refine ⟨fun X hX => relaxed_collapse X hX, ?_⟩
+  refine ⟨{(⟨0, by omega⟩ : Fin n)}, singleton_independent _ _, Finset.card_singleton _⟩
+
+/-! ## Part 2 — Recovery under bounded degeneracy -/
+
+/-- The set of *degenerate ordered pairs*: distinct `(x,y)` with `f x y ∈ {x,y}`.
+Its cardinality measures the frequency of degeneracy. -/
+def degenerateSet (f : RelaxedPairFunction n) : Finset (Fin n × Fin n) :=
+  Finset.univ.filter (fun p => p.1 ≠ p.2 ∧ f p.1 p.2 ∈ ({p.1, p.2} : Finset (Fin n)))
+
+/-- **Recovery.**  If at most `k` ordered pairs are degenerate, then deleting the
+endpoints of degenerate pairs leaves a set `W` with `|W| ≥ n − 2k` on which `f` is
+genuinely valid.  Bounded degeneracy costs only a bounded shrink of the ground
+set. -/
+theorem recovery (f : RelaxedPairFunction n) (k : ℕ)
+    (hk : (degenerateSet f).card ≤ k) :
+    ∃ W : Finset (Fin n), n - 2 * k ≤ W.card ∧ ValidOn f W := by
+  set D := degenerateSet f with hD
+  set T := D.image Prod.fst ∪ D.image Prod.snd with hT
+  have hTle : T.card ≤ 2 * k := by
+    calc T.card ≤ (D.image Prod.fst).card + (D.image Prod.snd).card :=
+          Finset.card_union_le _ _
+      _ ≤ D.card + D.card := Nat.add_le_add Finset.card_image_le Finset.card_image_le
+      _ = 2 * D.card := by ring
+      _ ≤ 2 * k := by omega
+  refine ⟨Finset.univ \ T, ?_, ?_⟩
+  · have hcard : (Finset.univ \ T).card = n - T.card := by
+      rw [Finset.card_univ_diff, Fintype.card_fin]
+    rw [hcard]
+    omega
+  · intro x hx y hy hxy
+    rw [Finset.mem_sdiff] at hx hy
+    constructor
+    · intro hcontra
+      have hmem : f x y ∈ ({x, y} : Finset (Fin n)) := by simp [hcontra]
+      have hxyD : (x, y) ∈ D := by
+        rw [hD, degenerateSet, Finset.mem_filter]
+        exact ⟨Finset.mem_univ _, hxy, hmem⟩
+      exact hx.2 (Finset.mem_union_left _ (Finset.mem_image.mpr ⟨(x, y), hxyD, rfl⟩))
+    · intro hcontra
+      have hmem : f x y ∈ ({x, y} : Finset (Fin n)) := by simp [hcontra]
+      have hxyD : (x, y) ∈ D := by
+        rw [hD, degenerateSet, Finset.mem_filter]
+        exact ⟨Finset.mem_univ _, hxy, hmem⟩
+      exact hy.2 (Finset.mem_union_right _ (Finset.mem_image.mpr ⟨(x, y), hxyD, rfl⟩))
+
+/-- Independence of a pair `{a,b}` follows from validity *on* a set `W` containing
+both endpoints. -/
+theorem validOn_pair_independent (f : RelaxedPairFunction n) {W : Finset (Fin n)}
+    (hf : ValidOn f W) {a b : Fin n} (ha : a ∈ W) (hb : b ∈ W) (hab : a ≠ b) :
+    Independent f ({a, b} : Finset (Fin n)) := by
+  intro x hx y hy hxy
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx hy
+  simp only [Finset.mem_insert, Finset.mem_singleton, not_or]
+  rcases hx with rfl | rfl
+  · rcases hy with rfl | rfl
+    · exact absurd rfl hxy
+    · exact hf x ha y hb hxy
+  · rcases hy with rfl | rfl
+    · exact ⟨(hf x hb y ha hxy).2, (hf x hb y ha hxy).1⟩
+    · exact absurd rfl hxy
+
+/-- **Bounded degeneracy still guarantees an independent pair.**  If at most `k`
+ordered pairs are degenerate and `n − 2k ≥ 2`, then `f` admits an independent set
+of size `2`. -/
+theorem recovery_independent_pair (f : RelaxedPairFunction n) (k : ℕ)
+    (hk : (degenerateSet f).card ≤ k) (hn : 2 ≤ n - 2 * k) :
+    ∃ X : Finset (Fin n), Independent f X ∧ X.card = 2 := by
+  obtain ⟨W, hWcard, hWvalid⟩ := recovery f k hk
+  have h2 : 1 < W.card := by omega
+  obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.1 h2
+  exact ⟨{a, b}, validOn_pair_independent f hWvalid ha hb hab, Finset.card_pair hab⟩
+
+end Erdos1025OQ04

--- a/src/data/proofs/erdos-1025-oq-04/meta.json
+++ b/src/data/proofs/erdos-1025-oq-04/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "erdos-1025-oq-04",
+  "title": "Erdős #1025 OQ-4: Degenerate Pair Functions — Collapse and Recovery",
+  "slug": "erdos-1025-oq-04",
+  "description": "What happens to the independent-set guarantee for pair functions when the validity constraint f(x,y) ≠ x,y is relaxed to allow degenerate values f(x,y) ∈ {x,y}? Two sharp elementary answers: unbounded degeneracy collapses the guarantee to size 1, while bounded degeneracy (≤ k degenerate pairs) reduces to the valid problem on ≥ n−2k vertices.",
+  "meta": {
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1025OQ04.lean",
+    "tags": [
+      "combinatorics",
+      "set-mappings",
+      "pair-functions",
+      "erdos",
+      "extremal-combinatorics",
+      "independent-sets",
+      "sharp-boundary"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 189,
+    "dateUpdated": "2026-06-23",
+    "assumptions": "None. Fully machine-checked: 0 sorries, 0 axiom declarations, 0 structure-encoded assumptions. #print axioms reports only the foundational propext / Classical.choice / Quot.sound for every main theorem.",
+    "dateAdded": "2026-06-23",
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://erdosproblems.com/1025",
+    "date": "Erdős–Hajnal 1958, Spencer 1972, Conlon–Fox–Sudakov 2016 (parent); OQ-4 formalized 2026",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.card_univ_diff",
+        "description": "Cardinality of the complement of the tainted-vertex set: |univ \\ T| = Fintype.card (Fin n) − |T|, the engine of the |W| ≥ n − 2k recovery bound",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finset.card_union_le / Finset.card_image_le",
+        "description": "Bounds the tainted-vertex count |T| ≤ |D.image fst| + |D.image snd| ≤ 2|D| ≤ 2k",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.one_lt_card",
+        "description": "Extracts two distinct vertices from the recovered set W when |W| ≥ 2, yielding the surviving independent pair",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_pair",
+        "description": "{a,b} has card 2 when a ≠ b, certifying the size-2 independent set in recovery_independent_pair",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "RelaxedPairFunction / Valid / Independent / ValidOn: explicit two-argument formulation of (possibly degenerate) pair functions and the independence and (restricted) validity predicates",
+      "valid_pair_independent: for a valid pair function every 2-element set is independent — the validity constraint IS the statement that pairs are independent, giving the trivial g(n) ≥ 2 floor",
+      "fbad / fbad_not_valid / relaxed_collapse / relaxed_g_eq_one: the maximally degenerate function f(x,y)=x admits no independent set of size ≥ 2, so dropping validity collapses the guarantee from Θ(√n) to exactly 1",
+      "degenerateSet / recovery: bounding the number k of degenerate ordered pairs and deleting their ≤ 2k endpoints leaves a set W with |W| ≥ n − 2k on which f is genuinely valid — a structural reduction of the bounded-degeneracy problem to the original valid problem",
+      "validOn_pair_independent / recovery_independent_pair: bounded degeneracy still guarantees an independent set of size 2 whenever n − 2k ≥ 2"
+    ],
+    "theoremCount": 9,
+    "definitionCount": 6
+  },
+  "overview": {
+    "prerequisites": [
+      "Pair functions / set mappings (Erdős–Hajnal): f maps unordered pairs to elements avoiding the pair",
+      "Independent sets under a pair function and the guarantee function g(n)",
+      "Elementary Finset cardinality combinatorics in Lean 4 (images, unions, complements)"
+    ],
+    "historicalContext": "Erdős and Hajnal (1958) introduced the pair-function (set-mapping) problem: a function f assigns to each pair {x,y} ⊆ {1,…,n} an element f(x,y) ∉ {x,y}, and one seeks the largest set X that is 'free' / independent, meaning f(x,y) ∉ X for all x,y ∈ X. They proved n^(1/3) ≪ g(n) ≪ (n log n)^(1/2). Spencer (1972) and finally Conlon, Fox and Sudakov (2016) pinned the order of magnitude at g(n) = Θ(√n). The defining hypothesis f(x,y) ≠ x,y is what makes the problem nontrivial. OQ-4 of the gallery entry asks what becomes of the theory if this hypothesis is relaxed — if f is allowed to return one of its own arguments, possibly with a controlled frequency.",
+    "problemStatement": "Relax the validity constraint to permit degenerate values f(x,y) ∈ {x,y}. (1) With no restriction on degeneracy, how large an independent set is still guaranteed? (2) If only a bounded number k of pairs are degenerate, can the original Θ(√n) theory be recovered on most of the ground set?",
+    "proofStrategy": "Part 1 (collapse) exhibits the explicit witness f(x,y) = x: any X with two distinct elements a,b contains f(a,b) = a, so no independent set exceeds size 1; a singleton is always independent, pinning the relaxed guarantee at exactly 1. Part 2 (recovery) measures degeneracy by |degenerateSet f|, the number of distinct ordered pairs with f(x,y) ∈ {x,y}; if this is ≤ k, the set T of endpoints of degenerate pairs has |T| ≤ 2k (it is covered by the two coordinate-images of the degenerate set), so W = univ \\ T has |W| ≥ n − 2k, and by construction no pair inside W is degenerate, i.e. f is valid on W. A valid pair function makes every 2-subset independent, so an independent pair survives whenever n − 2k ≥ 2.",
+    "keyInsights": [
+      "The validity hypothesis f(x,y) ≠ x,y is not a technical convenience — it is the entire source of the Θ(√n) guarantee. Removing it collapses the answer all the way to a constant (1), which is the sharpest possible contrast and the cleanest way to certify that the hypothesis is essential.",
+      "Even with full validity, the lower bound g(n) ≥ 2 is automatic and content-free: independence of a pair {x,y} is literally the validity condition f(x,y) ∉ {x,y}. The hard mathematics (Erdős–Hajnal/Spencer/CFS) lives entirely in pushing the guaranteed size from 2 up to Θ(√n).",
+      "Bounded degeneracy is benign: a budget of k degenerate ordered pairs can taint at most 2k vertices, and deleting those vertices restores a genuinely valid instance on ≥ n − 2k vertices. So the relaxed problem with a bounded violation budget is, up to a bounded shrink of the ground set, the original problem — and inherits its Θ(√n) guarantee on the surviving vertices.",
+      "Counting degeneracy by ordered pairs (rather than unordered) is an over-count by at most a factor of two, which is absorbed harmlessly into the 2k endpoint bound; this choice keeps the Finset bookkeeping elementary (a filter over Fin n × Fin n and its two coordinate projections) while losing nothing in the conclusion."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Relaxed Pair Functions and Independence",
+      "startLine": 36,
+      "endLine": 58,
+      "summary": "Defines RelaxedPairFunction (a two-argument function with no constraint), the Valid constraint, the Independent predicate, and ValidOn (validity restricted to pairs inside a subset W).",
+      "mathContext": "RelaxedPairFunction n := Fin n → Fin n → Fin n. Valid f := ∀ x y, x ≠ y → f x y ≠ x ∧ f x y ≠ y. Independent f X := ∀ x ∈ X, ∀ y ∈ X, x ≠ y → f x y ∉ X. ValidOn f W := the validity condition quantified over x,y ∈ W."
+    },
+    {
+      "id": "basic-independence",
+      "title": "Basic Independence Facts",
+      "startLine": 59,
+      "endLine": 88,
+      "summary": "empty and singleton sets are independent under any f; for a valid f every 2-element set is independent (the g(n) ≥ 2 floor).",
+      "mathContext": "valid_pair_independent: Valid f → a ≠ b → Independent f {a,b}. The proof is a four-way case split identifying {a,b} with {x,y}; in the two non-trivial cases the validity facts f x y ≠ x and f x y ≠ y are exactly what is needed."
+    },
+    {
+      "id": "collapse",
+      "title": "Part 1 — Collapse under Unbounded Degeneracy",
+      "startLine": 89,
+      "endLine": 121,
+      "summary": "The maximally degenerate function fbad(x,y)=x is not valid for n ≥ 2, admits no independent set of size ≥ 2 (relaxed_collapse), and a singleton is independent — so the relaxed guarantee is exactly 1 (relaxed_g_eq_one).",
+      "mathContext": "relaxed_collapse: Independent (fbad n) X → X.card ≤ 1, via Finset.card_le_one — any two distinct a,b ∈ X give fbad a b = a ∈ X. relaxed_g_eq_one packages the matching upper bound (≤ 1 always) and witness (a singleton, size 1), contrasting with g(n) = Θ(√n) in the valid case."
+    },
+    {
+      "id": "recovery",
+      "title": "Part 2 — Recovery under Bounded Degeneracy",
+      "startLine": 122,
+      "endLine": 189,
+      "summary": "degenerateSet counts degenerate ordered pairs; recovery deletes their ≤ 2k endpoints to expose a valid sub-instance on ≥ n−2k vertices; validOn_pair_independent and recovery_independent_pair then extract a surviving independent pair when n−2k ≥ 2.",
+      "mathContext": "degenerateSet f := univ.filter (fun p => p.1 ≠ p.2 ∧ f p.1 p.2 ∈ {p.1,p.2}). recovery: |degenerateSet f| ≤ k → ∃ W, n − 2k ≤ |W| ∧ ValidOn f W (W = univ minus the union of the two coordinate-images of the degenerate set). recovery_independent_pair: with n − 2k ≥ 2 the recovered W has two distinct vertices, giving an independent set of size 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "Two sharp, fully verified (0 axioms / 0 sorries) answers to OQ-4. Unbounded degeneracy collapses the pair-function independence guarantee from Θ(√n) to exactly 1 (fbad witness), proving the validity hypothesis essential. Bounded degeneracy is benign: ≤ k degenerate ordered pairs taint ≤ 2k vertices, and deleting them recovers a genuinely valid instance on ≥ n − 2k vertices, on which the original Θ(√n) theory (and at minimum an independent pair) applies.",
+    "implications": "The result frames exactly where the difficulty of the Erdős–Hajnal pair-function problem resides: not in the existence of small independent sets (size 2 is free under validity) but in the validity hypothesis itself, whose removal is catastrophic. The recovery theorem shows the problem is robust to a sublinear number of violations — a budget of o(n) degenerate pairs leaves a (1−o(1))-fraction of the ground set valid, so the asymptotic Θ(√n) guarantee is unaffected.",
+    "openQuestions": [
+      "Sharp recovery: is the n − 2k bound tight? Construct, for each k, a relaxed pair function with exactly k degenerate ordered pairs whose maximum independent set has size Θ(√(n − ck)) for the best constant c, matching the deletion bound up to constants.",
+      "Frequency per vertex: instead of a global budget k, bound the number of degenerate pairs incident to each vertex by d. Does a per-vertex degeneracy degree d still permit an independent set of size Θ(√n) (for d bounded), or does it degrade the exponent?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1025",
+      "relationship": "extends",
+      "description": "Parent: Erdős #1025 establishes g(n) = Θ(√n) for valid pair functions. This OQ probes the effect of relaxing the defining validity hypothesis f(x,y) ≠ x,y."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "relaxed_collapse",
+      "type": "core",
+      "description": "Under the maximally degenerate function fbad(x,y)=x, no independent set has size ≥ 2 — dropping validity collapses the guarantee to a constant.",
+      "leanType": "(X : Finset (Fin n)) → Independent (fbad n) X → X.card ≤ 1"
+    },
+    {
+      "name": "relaxed_g_eq_one",
+      "type": "core",
+      "description": "For n ≥ 2 the relaxed guarantee is exactly 1: every independent set under fbad has size ≤ 1, and a singleton is independent.",
+      "leanType": "2 ≤ n → (∀ X, Independent (fbad n) X → X.card ≤ 1) ∧ (∃ X, Independent (fbad n) X ∧ X.card = 1)"
+    },
+    {
+      "name": "recovery",
+      "type": "core",
+      "description": "If at most k ordered pairs are degenerate, deleting their ≤ 2k endpoints leaves a set W with |W| ≥ n − 2k on which f is genuinely valid.",
+      "leanType": "(f : RelaxedPairFunction n) → (k : ℕ) → (degenerateSet f).card ≤ k → ∃ W, n - 2 * k ≤ W.card ∧ ValidOn f W"
+    },
+    {
+      "name": "recovery_independent_pair",
+      "type": "core",
+      "description": "Bounded degeneracy still guarantees an independent set of size 2 whenever n − 2k ≥ 2.",
+      "leanType": "(f : RelaxedPairFunction n) → (k : ℕ) → (degenerateSet f).card ≤ k → 2 ≤ n - 2 * k → ∃ X, Independent f X ∧ X.card = 2"
+    },
+    {
+      "name": "valid_pair_independent",
+      "type": "supporting",
+      "description": "For a valid pair function every two-element set is independent (the trivial g(n) ≥ 2 lower bound).",
+      "leanType": "Valid f → a ≠ b → Independent f ({a, b} : Finset (Fin n))"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Erdős, P.; Hajnal, A.",
+      "title": "On a property of families of sets",
+      "year": "1958",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae 9, 341-350",
+      "note": "Introduces the set-mapping / pair-function problem and the bounds n^(1/3) ≪ g(n) ≪ (n log n)^(1/2)"
+    },
+    {
+      "authors": "Spencer, J.",
+      "title": "Minimal scrambling sets of simple orders",
+      "year": "1972",
+      "venue": "Acta Mathematica Academiae Scientiarum Hungaricae 22, 349-353",
+      "note": "Improves the bounds toward the √n order of magnitude"
+    },
+    {
+      "authors": "Conlon, D.; Fox, J.; Sudakov, B.",
+      "title": "Short proofs of some extremal results III",
+      "year": "2016",
+      "venue": "Random Structures & Algorithms",
+      "note": "Determines g(n) = Θ(√n), closing the order-of-magnitude gap"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Erdos1025OQ04",
+    "lineCount": 189,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/Erdos1025OQ04.lean",
+    "theoremCount": 9,
+    "definitionCount": 6
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #1025 OQ-4 — relaxing the pair-function validity constraint

**Parent #1025** (Independent Sets in Pair Functions): a *valid* pair function `f` sends each pair `{x,y}` to an element with `f x y ≠ x, y`; an independent set `X` has `f x y ∉ X` for all `x,y ∈ X`. Erdős–Hajnal/Spencer/Conlon–Fox–Sudakov: the minimum guaranteed independent-set size is `g(n) = Θ(√n)`.

**OQ-4** asks what happens when we allow the degenerate values `f x y = x` or `f x y = y`, with bounded frequency. Two sharp, elementary, fully-verified answers:

### 1. Collapse (unbounded degeneracy)
The maximally degenerate function `fbad x y = x` admits **no independent set of size ≥ 2** (`relaxed_collapse`): any distinct `a,b ∈ X` give `fbad a b = a ∈ X`. A singleton is always independent, so the relaxed guarantee is **exactly 1** for `n ≥ 2` (`relaxed_g_eq_one`) — versus `Θ(√n)` in the valid case. The validity hypothesis is essential.

### 2. Recovery (bounded degeneracy)
Measure degeneracy by `k = |degenerateSet f|`, the number of distinct ordered pairs with `f x y ∈ {x,y}`. Their endpoints number `≤ 2k`, so deleting them leaves `W` with `|W| ≥ n − 2k` on which `f` is **genuinely valid** (`recovery`). Since validity makes every pair independent, an independent set of size 2 survives whenever `n − 2k ≥ 2` (`recovery_independent_pair`). Bounded degeneracy only shrinks the effective ground set by a bounded amount.

## Verification
- **189 lines**, 9 theorems / 6 definitions, **0 sorries, 0 axioms**.
- `#print axioms` reports only `propext / Classical.choice / Quot.sound` for every main theorem (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiled against Mathlib with Lean `v4.26.0`.

## Files
- `proofs/Proofs/Erdos1025OQ04.lean` — the proof
- `src/data/proofs/erdos-1025-oq-04/meta.json` — gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)