### PR TITLE
research(fodor-pressing-down-oq-02): Jensen's Diamond ◇ ⟹ CH (𝔠 = ℵ₁) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/DiamondImpliesCH.lean
+++ b/proofs/Proofs/DiamondImpliesCH.lean
@@ -1,0 +1,157 @@
+/-
+  Jensen's Diamond Principle implies the Continuum Hypothesis
+  (`Proofs/DiamondImpliesCH.lean`, slug `fodor-pressing-down-oq-02`)
+
+  This entry answers the open-question follow-up of `fodor-pressing-down`:
+  *what does the combinatorial guessing principle `◇` (diamond) buy us?*  The
+  classical answer is **`◇ ⟹ CH`**: a single guessing sequence on `ω₁` already
+  forces `2^{ℵ₀} ≤ ℵ₁`.
+
+  `◇` (Jensen, 1972) postulates a sequence `⟨A_α : α < ω₁⟩` with `A_α ⊆ α`
+  such that for *every* `X ⊆ ω₁` the *guessing set*
+  `{α < ω₁ | X ∩ α = A_α}` is **stationary** in `ω₁`.  We take `◇` itself as
+  the hypothesis (constructing such a sequence requires `V = L`, which is a
+  *consistency* statement, not a theorem of `ZFC`); the implication
+  `◇ ⟹ CH` below is a genuine, assumption-free theorem of `ZFC`.
+
+  ## Proof outline
+
+  1. `isClubBelow_Ioo_omega`: the tail `{β | ω < β < ω₁}` is a club below `ω₁`.
+     (Closed: an accumulation point of the tail lies above some tail member,
+     hence above `ω`.  Unbounded: `max α ω + 1` works.)
+  2. `IsDiamondSeq.guesses`: for any `X ⊆ Iio ω`, the guessing set is
+     stationary, hence meets the tail club, producing an `α` with `ω < α` and
+     `seq α = X`.  (Here `X ∩ Iio α = X` because `X ⊆ Iio ω ⊆ Iio α`.)
+  3. `IsDiamondSeq.powerset_omega_inj`: `X ↦ (chosen α)` injects
+     `𝒫(Iio ω)` into `Iio ω₁` (distinct `X` give distinct `seq α`, hence
+     distinct `α`).
+  4. `diamond_continuum_le`: cardinal bookkeeping turns the injection into
+     `𝔠 = 2^{ℵ₀} ≤ ℵ₁` (working one universe up — sets of ordinals live in
+     `Type 1` — and descending with `Cardinal.lift_le`).
+  5. `diamond_CH`: combined with the `ZFC` theorem `ℵ₁ ≤ 𝔠` we get `𝔠 = ℵ₁`.
+
+  ## Status
+
+  - 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.
+  - `◇` is a *hypothesis* (`IsDiamondSeq seq`), not an axiom: the theorems are
+    implications, fully machine-checked over Mathlib.
+-/
+
+import Mathlib.SetTheory.Cardinal.Aleph
+import Mathlib.SetTheory.Cardinal.Continuum
+import Mathlib.SetTheory.Ordinal.Arithmetic
+import Mathlib.Tactic
+import Proofs.Club.Basic
+
+open Cardinal Ordinal Set
+open scoped Cardinal Ordinal
+
+namespace DiamondImpliesCH
+
+/-! ### The Diamond principle as a hypothesis -/
+
+/-- A `◇`-sequence on `ω₁`: a family `seq α ⊆ α` such that every subset `X` of
+`ω₁` is *guessed* on a stationary set, i.e. `{α < ω₁ | X ∩ α = seq α}` is
+stationary below `ω₁`.  This is Jensen's combinatorial principle `◇`. -/
+def IsDiamondSeq (seq : Ordinal.{0} → Set Ordinal.{0}) : Prop :=
+  (∀ α, seq α ⊆ Iio α) ∧
+    ∀ X : Set Ordinal.{0}, X ⊆ Iio ω₁ →
+      IsStationaryBelow {α | α < ω₁ ∧ X ∩ Iio α = seq α} ω₁
+
+/-! ### The tail club `{β | ω < β < ω₁}` -/
+
+/-- The ordinals strictly between `ω` and `ω₁` form a club below `ω₁`.  We use
+this to upgrade "stationary" (meets every club) into "contains an ordinal
+above `ω`", which is what is needed to guess countable sets. -/
+theorem isClubBelow_Ioo_omega :
+    IsClubBelow {β : Ordinal.{0} | ω < β ∧ β < ω₁} ω₁ where
+  subset_Iio := fun _ hβ => hβ.2
+  closed := by
+    rw [isClosedBelow_iff]
+    intro p hp hAcc
+    refine ⟨?_, hp⟩
+    obtain ⟨s, hsmem, _, hsp⟩ := hAcc.forall_lt 0 hAcc.pos
+    exact hsmem.1.trans hsp
+  unbounded := by
+    intro α hα
+    refine ⟨max α ω + 1, ⟨?_, ?_⟩, ?_, ?_⟩
+    · exact lt_of_le_of_lt (le_max_right α ω) (lt_add_one _)
+    · exact (isSuccLimit_omega 1).succ_lt (max_lt hα omega0_lt_omega1)
+    · exact lt_of_le_of_lt (le_max_left α ω) (lt_add_one _)
+    · exact (isSuccLimit_omega 1).succ_lt (max_lt hα omega0_lt_omega1)
+
+/-! ### The guessing lemma -/
+
+/-- **Guessing of countable sets.**  A `◇`-sequence guesses every `X ⊆ Iio ω`:
+there is some `α` with `ω < α < ω₁` and `seq α = X`.  This is the heart of the
+argument — the guessing happens above `ω`, so `X ∩ Iio α = X`. -/
+theorem IsDiamondSeq.guesses {seq : Ordinal → Set Ordinal} (h : IsDiamondSeq seq)
+    {X : Set Ordinal.{0}} (hX : X ⊆ Iio ω) : ∃ α, ω < α ∧ α < ω₁ ∧ seq α = X := by
+  have hXω₁ : X ⊆ Iio ω₁ := hX.trans (Iio_subset_Iio omega0_lt_omega1.le)
+  obtain ⟨α, hαS, hαC⟩ := h.2 X hXω₁ _ isClubBelow_Ioo_omega
+  obtain ⟨hαω₁, hαeq⟩ := hαS
+  obtain ⟨hωα, _⟩ := hαC
+  refine ⟨α, hωα, hαω₁, ?_⟩
+  have hXsub : X ⊆ Iio α := hX.trans (Iio_subset_Iio hωα.le)
+  rw [← hαeq, Set.inter_eq_left.mpr hXsub]
+
+/-! ### The injection `𝒫(Iio ω) ↪ Iio ω₁` -/
+
+/-- For `X ⊆ Iio ω`, the chosen ordinal `< ω₁` that the sequence uses to guess
+`X`.  Packaged as an element of the subtype `Iio ω₁`. -/
+noncomputable def IsDiamondSeq.guessIndex {seq : Ordinal → Set Ordinal}
+    (h : IsDiamondSeq seq) (X : ↥(𝒫 (Iio (ω : Ordinal.{0})))) : ↥(Iio ω₁) :=
+  ⟨Classical.choose (h.guesses X.2), (Classical.choose_spec (h.guesses X.2)).2.1⟩
+
+/-- The guessing index is injective: distinct subsets of `Iio ω` are guessed at
+distinct ordinals, because `seq` recovers the subset from the ordinal. -/
+theorem IsDiamondSeq.guessIndex_injective {seq : Ordinal → Set Ordinal}
+    (h : IsDiamondSeq seq) : Function.Injective h.guessIndex := by
+  intro X Y hXY
+  have hX := (Classical.choose_spec (h.guesses X.2)).2.2
+  have hY := (Classical.choose_spec (h.guesses Y.2)).2.2
+  have hαeq : Classical.choose (h.guesses X.2) = Classical.choose (h.guesses Y.2) :=
+    Subtype.ext_iff.mp hXY
+  apply Subtype.ext
+  rw [← hX, ← hY, hαeq]
+
+/-- Cardinal form of the injection: `#𝒫(Iio ω) ≤ #(Iio ω₁)`. -/
+theorem IsDiamondSeq.mk_powerset_le {seq : Ordinal → Set Ordinal}
+    (h : IsDiamondSeq seq) :
+    #(↥(𝒫 (Iio (ω : Ordinal.{0})))) ≤ #(↥(Iio (ω₁ : Ordinal.{0}))) :=
+  Cardinal.mk_le_of_injective h.guessIndex_injective
+
+/-! ### Cardinal bookkeeping: `◇ ⟹ CH` -/
+
+/-- `#(Iio ω) = lift ℵ₀`: there are countably many ordinals below `ω`. -/
+theorem mk_Iio_omega : #(↥(Iio (ω : Ordinal.{0}))) = Cardinal.lift.{1, 0} ℵ₀ := by
+  rw [mk_Iio_ordinal, card_omega0]
+
+/-- `#(Iio ω₁) = lift ℵ₁`: there are `ℵ₁`-many ordinals below `ω₁`. -/
+theorem mk_Iio_omega1 : #(↥(Iio (ω₁ : Ordinal.{0}))) = Cardinal.lift.{1, 0} ℵ₁ := by
+  rw [mk_Iio_ordinal, card_omega]
+
+/-- **Diamond implies the continuum bound.**  If a `◇`-sequence exists then
+`𝔠 ≤ ℵ₁`, i.e. there are at most `ℵ₁` subsets of `ℕ`. -/
+theorem diamond_continuum_le {seq : Ordinal → Set Ordinal} (h : IsDiamondSeq seq) :
+    (𝔠 : Cardinal.{0}) ≤ ℵ₁ := by
+  -- The injection lives one universe up; lift the target inequality back down.
+  have key := h.mk_powerset_le
+  rw [Cardinal.mk_powerset, mk_Iio_omega, mk_Iio_omega1, ← Cardinal.lift_two_power,
+    two_power_aleph0] at key
+  exact Cardinal.lift_le.mp key
+
+/-- **Diamond implies the Continuum Hypothesis.**  If a `◇`-sequence exists then
+`𝔠 = ℵ₁`: the cardinality of the continuum is exactly the first uncountable
+cardinal.  (`ℵ₁ ≤ 𝔠` is a theorem of `ZFC`; `◇` supplies the reverse bound.) -/
+theorem diamond_CH {seq : Ordinal → Set Ordinal} (h : IsDiamondSeq seq) :
+    (𝔠 : Cardinal.{0}) = ℵ₁ :=
+  le_antisymm (diamond_continuum_le h) aleph_one_le_continuum
+
+/-- Restatement: under `◇`, every uncountable set of reals has size `ℵ₁`
+(equivalently, `CH` holds in the form `2^{ℵ₀} = ℵ₁`). -/
+theorem diamond_two_pow_aleph0 {seq : Ordinal → Set Ordinal} (h : IsDiamondSeq seq) :
+    (2 : Cardinal.{0}) ^ ℵ₀ = ℵ₁ := by
+  rw [two_power_aleph0]; exact diamond_CH h
+
+end DiamondImpliesCH

--- a/src/data/proofs/fodor-pressing-down-oq-02/meta.json
+++ b/src/data/proofs/fodor-pressing-down-oq-02/meta.json
@@ -1,0 +1,78 @@
+{
+  "id": "fodor-pressing-down-oq-02",
+  "title": "Jensen's Diamond Principle Implies the Continuum Hypothesis",
+  "slug": "fodor-pressing-down-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib.SetTheory.Cardinal.Aleph",
+      "Mathlib.SetTheory.Cardinal.Continuum",
+      "Mathlib.SetTheory.Ordinal.Arithmetic",
+      "Mathlib.Tactic",
+      "Proofs.Club.Basic"
+    ],
+    "opens": [
+      "Cardinal",
+      "Ordinal",
+      "Set"
+    ],
+    "namespace": "DiamondImpliesCH",
+    "lineCount": 157,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/DiamondImpliesCH.lean",
+    "sorries": 0
+  },
+  "description": "Jensen's combinatorial principle ◇ (diamond), introduced in 1972 to build a Suslin tree in L, is the prototypical guessing principle of modern set theory. A ◇-sequence on ω₁ is a family ⟨A_α : α < ω₁⟩ with A_α ⊆ α such that for every X ⊆ ω₁ the guessing set {α < ω₁ | X ∩ α = A_α} is stationary. This entry formalises the classical implication ◇ ⟹ CH: the existence of a single ◇-sequence already forces 2^ℵ₀ = ℵ₁. ◇ enters only as a hypothesis (IsDiamondSeq seq) — constructing such a sequence requires V = L, a consistency statement rather than a ZFC theorem — so diamond_CH : 𝔠 = ℵ₁ is a genuine, assumption-free theorem of ZFC. The proof reuses the gallery's own club/stationary infrastructure (Proofs.Club.Basic, lifted from the Fodor pressing-down parent): it shows the tail {β | ω < β < ω₁} is a club below ω₁ (isClubBelow_Ioo_omega), so by stationarity every countable X ⊆ Iio ω is guessed above ω, where X ∩ Iio α = X recovers seq α = X (IsDiamondSeq.guesses). Since seq recovers X from its guessing ordinal, X ↦ (chosen α) injects 𝒫(Iio ω) into Iio ω₁ (guessIndex_injective); cardinal bookkeeping (mk_powerset, mk_Iio_ordinal, card_omega0/card_omega, lift_two_power), carried out one universe up because sets of ordinals live in Type 1 and descended via Cardinal.lift_le, turns the injection into 𝔠 = 2^ℵ₀ ≤ ℵ₁ (diamond_continuum_le). Combined with the ZFC bound ℵ₁ ≤ 𝔠 (aleph_one_le_continuum) this gives 𝔠 = ℵ₁. Fully machine-verified, no axioms and no sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DiamondImpliesCH.lean",
+    "tags": [
+      "set-theory",
+      "diamond-principle",
+      "continuum-hypothesis",
+      "stationary-sets",
+      "club-sets",
+      "ordinals",
+      "cardinal-arithmetic",
+      "omega1",
+      "guessing-principle",
+      "jensen"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 157,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "assumptions": "Diamond (◇) is taken as a hypothesis (IsDiamondSeq seq), not an axiom: every theorem is an implication. The constructive existence of a ◇-sequence is not claimed (it needs V = L). The headline theorems depend only on the standard foundational axioms propext, Classical.choice, Quot.sound."
+  },
+  "overview": {
+    "historicalContext": "Ronald Jensen isolated the principle ◇ (\"diamond\") in his 1972 study of the fine structure of the constructible universe L, where he used it to construct a Suslin tree — settling that Suslin's Hypothesis fails in L. ◇ asserts the existence of a single ω₁-sequence ⟨A_α⟩ that simultaneously guesses every subset of ω₁ on a stationary set. It is strictly stronger than the Continuum Hypothesis: ◇ ⟹ CH, but CH does not imply ◇. Diamond rapidly became one of the most useful combinatorial principles in set theory, driving constructions of rigid structures, Whitehead groups, and pathological topological spaces, all carried out in L. The implication ◇ ⟹ CH is the first thing one proves about diamond: it shows the guessing power of a single sequence is already enough to bound the continuum.",
+    "problemStatement": "A ◇-sequence is a family seq : Ordinal → Set Ordinal with seq α ⊆ α such that for every X ⊆ ω₁ the set {α < ω₁ | X ∩ α = seq α} is stationary below ω₁. Assuming such a sequence exists, prove the Continuum Hypothesis: 𝔠 = ℵ₁, equivalently 2^ℵ₀ = ℵ₁.",
+    "proofStrategy": "Four steps. (1) `isClubBelow_Ioo_omega`: the tail {β | ω < β < ω₁} is a club below ω₁ — closed because an accumulation point lies above some tail member (hence above ω) and is given < ω₁, unbounded because max α ω + 1 is a member above any α < ω₁ (using IsSuccLimit.succ_lt for the first uncountable ordinal). (2) `IsDiamondSeq.guesses`: for X ⊆ Iio ω, the guessing set is stationary, so it meets the tail club, yielding α with ω < α < ω₁ and X ∩ Iio α = seq α; since X ⊆ Iio ω ⊆ Iio α the intersection is all of X, giving seq α = X. (3) `IsDiamondSeq.guessIndex_injective`: the map sending X ∈ 𝒫(Iio ω) to its (chosen) guessing ordinal in Iio ω₁ is injective because seq recovers X from the ordinal. (4) `diamond_continuum_le`: Cardinal.mk_le_of_injective gives #𝒫(Iio ω) ≤ #(Iio ω₁); rewriting with mk_powerset, mk_Iio_ordinal, card_omega0, card_omega and lift_two_power turns this into lift 𝔠 ≤ lift ℵ₁ one universe up (sets of ordinals inhabit Type 1), and Cardinal.lift_le descends it to 𝔠 ≤ ℵ₁. `diamond_CH` adds the ZFC bound aleph_one_le_continuum to conclude 𝔠 = ℵ₁.",
+    "keyInsights": [
+      "Diamond is a genuine hypothesis, not an axiom. The theorems are implications ◇ ⟹ … and are fully verified over ZFC (only propext, Classical.choice, Quot.sound). Constructing a ◇-sequence requires V = L and is deliberately not claimed, which is exactly why the result is honest: it bounds the continuum conditionally on a guessing structure, not unconditionally.",
+      "Only countable subsets are needed. Although ◇ guesses every X ⊆ ω₁, the continuum bound uses only X ⊆ Iio ω. The tail club {β | ω < β < ω₁} forces the guess to occur above ω, where X ∩ α collapses to X — so the guessing sequence, restricted to countable sets, surjects onto 𝒫(ω) and pins #𝒫(ω) ≤ ℵ₁.",
+      "Stationarity is used through exactly one club. The whole strength of ◇ that the proof consumes is: a stationary set meets the single tail club {β | ω < β < ω₁}. This is the minimal use of the gallery's club/stationary API (Proofs.Club.Basic), reused verbatim from the Fodor pressing-down development.",
+      "The universe bump is unavoidable but cheap. Because Ordinal.{0} : Type 1, subsets of ordinals have cardinality in Cardinal.{1}; the injection therefore proves lift 𝔠 ≤ lift ℵ₁ at universe 1, and Cardinal.lift_le brings it back to the intended 𝔠 ≤ ℵ₁ at universe 0 — the only bookkeeping cost of working with ordinals rather than ℕ directly."
+    ]
+  },
+  "conclusion": {
+    "summary": "Assuming Jensen's diamond principle ◇ (as the hypothesis that a guessing sequence exists), the Continuum Hypothesis is machine-verified: 𝔠 = ℵ₁, equivalently 2^ℵ₀ = ℵ₁. The argument needs only that a stationary set meets one tail club, that diamond therefore guesses every countable set above ω, and standard cardinal arithmetic. No axioms and no sorries.",
+    "implications": "This is the canonical first consequence of ◇ and explains its place in the hierarchy of cardinal-arithmetic hypotheses: ◇ ⟹ CH (but not conversely). Formalising it on top of the gallery's club/stationary infrastructure demonstrates that the Fodor pressing-down machinery is strong enough to support guessing-principle arguments, opening the door to further L-style constructions (Suslin trees, ◇ ⟹ ◇⁻ equivalences, Ostaszewski/Whitehead constructions) within the same framework.",
+    "openQuestions": [
+      "Can the converse non-implication be formalised — exhibiting (consistently) a model of CH in which ◇ fails — or at least the ZFC theorem ◇ ⟺ ◇⁻ (the equivalence of diamond with its weaker guessing variant)?",
+      "Does the gallery's club/stationary API suffice to formalise Jensen's original use of ◇, namely the construction of a Suslin tree, giving a machine-checked ◇ ⟹ ¬SH?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "fodor-pressing-down",
+      "relationship": "extends",
+      "description": "The parent develops Fodor's pressing-down lemma and the club/stationary infrastructure (Proofs.Club.Basic: IsClubBelow, IsStationaryBelow, IsStationaryBelow.nonempty). This entry reuses that infrastructure to prove a different theorem about ω₁ — that the diamond guessing principle implies the Continuum Hypothesis."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalises the classical theorem **◇ ⟹ CH**: Jensen's combinatorial *diamond* principle on `ω₁` implies the Continuum Hypothesis `𝔠 = ℵ₁`. Answers the `fodor-pressing-down` open-question follow-up **oq-02** — *what does the combinatorial guessing principle buy us?*

`◇` enters as a **hypothesis** (`IsDiamondSeq seq`), not an axiom. A `◇`-sequence is a family `⟨A_α : α < ω₁⟩` with `A_α ⊆ α` whose guessing set `{α < ω₁ | X ∩ α = A_α}` is *stationary* for every `X ⊆ ω₁`. Building one requires `V = L` (a consistency statement, not a `ZFC` theorem), so `diamond_CH : 𝔠 = ℵ₁` is a genuine **assumption-free `ZFC` implication**.

## Proof outline

Reuses the gallery's own club/stationary infrastructure `Proofs.Club.Basic` (lifted from the Fodor pressing-down parent):

1. `isClubBelow_Ioo_omega` — the tail `{β | ω < β < ω₁}` is a club below `ω₁`.
2. `IsDiamondSeq.guesses` — by stationarity the guessing set meets that tail club, so every countable `X ⊆ Iio ω` equals `seq α` for some `ω < α < ω₁` (above `ω`, `X ∩ Iio α = X`).
3. `IsDiamondSeq.guessIndex_injective` — `X ↦ (chosen α)` injects `𝒫(Iio ω) ↪ Iio ω₁`.
4. `diamond_continuum_le` — `mk_le_of_injective` + `mk_powerset` / `mk_Iio_ordinal` / `card_omega0` / `card_omega` / `lift_two_power` gives `𝔠 = 2^ℵ₀ ≤ ℵ₁`, computed one universe up (sets of ordinals live in `Type 1`) and descended with `Cardinal.lift_le`.
5. `diamond_CH` — combined with the `ZFC` bound `aleph_one_le_continuum` (`ℵ₁ ≤ 𝔠`) yields `𝔠 = ℵ₁`.

## Verification

- **157 lines, 9 theorems / 2 definitions, 0 sorries, 0 `axiom` declarations.**
- `#print axioms diamond_CH` → `[propext, Classical.choice, Quot.sound]` (the standard foundational three; no `sorryAx`, no `Lean.ofReduceBool`).
- Status `verified`, badge `original`.
- Compiled against Mathlib v4.26.0 (Docker down → single-file build with the pinned toolchain; `Proofs.Club.Basic` rebuilt as a dependency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)