### PR TITLE
research(erdos-504-oq-01): hypercube gives 2^d non-obtuse points in ℝ^d — Danzer–Grünbaum lower bound, sharp [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/Erdos504OQ01.lean
+++ b/proofs/Proofs/Erdos504OQ01.lean
@@ -1,0 +1,173 @@
+/-
+Erdős Problem #504 — OQ-01: The higher-dimensional analogue (point sets in ℝ^d).
+
+Parent problem (Erdős #504, Blumenthal's problem, solved by Sendov 1993):
+in ℝ², let α_n be the largest angle α such that *every* set of n points contains
+three points forming an angle ≥ α. The natural higher-dimensional open question is:
+given n points in ℝ^d, what is the threshold angle that is always forced?
+
+The key threshold is the right angle π/2.  A finite point set is called
+**non-obtuse** if every angle ∠ a b c determined by three of its points is at
+most π/2 (equivalently, never obtuse).  Danzer and Grünbaum (1962) determined
+that the maximum size of a non-obtuse set in ℝ^d is exactly 2^d, with the
+extremal configuration being the 2^d vertices of a hypercube.  Their lower-bound
+construction is the cornerstone of every higher-dimensional version of #504:
+it shows that 2^d points in ℝ^d need not force any obtuse angle, so the
+right-angle threshold is *not* crossed until one has more than 2^d points.
+
+This file formalises that construction, unconditionally and axiom-free:
+
+  * `angle_le_pi_div_two_of_inner_nonneg` — a dimension-free criterion:
+    a non-negative inner product forces a non-obtuse angle.  (Reusable.)
+  * `cube_inner_nonneg` — for vertices a, b, c ∈ {0,1}^d the inner product
+    ⟪a − b, c − b⟫ is ≥ 0, because in each coordinate the two factors share the
+    sign of b_i.  This is the elementary heart of the argument.
+  * `cube_angle_le_pi_div_two` — hence every angle of the hypercube is ≤ π/2.
+  * `exists_cube_no_obtuse` — there is a set of 2^d points in ℝ^d with no
+    obtuse angle (the Danzer–Grünbaum lower bound).
+  * `cube_angle_pi_div_two_attained` — for d ≥ 2 the bound π/2 is *attained*,
+    so it cannot be improved: the construction is sharp.
+
+What is proved here is the construction (lower bound) direction.  The matching
+upper bound — that 2^d + 1 points in ℝ^d always contain an obtuse angle — is the
+harder half of Danzer–Grünbaum and is not attempted.
+-/
+
+import Mathlib
+
+open Real
+open scoped InnerProductSpace EuclideanGeometry
+
+namespace Erdos504OQ01
+
+/-- Points of `d`-dimensional Euclidean space. -/
+abbrev Point (d : ℕ) := EuclideanSpace ℝ (Fin d)
+
+/-- A point is a **vertex of the unit hypercube** `{0,1}^d` when every coordinate
+is `0` or `1`. -/
+def IsCubeVertex {d : ℕ} (v : Point d) : Prop := ∀ i, v i = 0 ∨ v i = 1
+
+/-! ### A dimension-free non-obtuse criterion -/
+
+/-- **Non-negative inner product ⟹ non-obtuse angle.**  In any real inner product
+space, if `⟪x, y⟫ ≥ 0` then the (unoriented) angle between `x` and `y` is at most
+`π/2`.  This holds because the angle is `arccos (⟪x,y⟫ / (‖x‖‖y‖))` and the
+argument of `arccos` is non-negative. -/
+theorem angle_le_pi_div_two_of_inner_nonneg
+    {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
+    (x y : V) (h : 0 ≤ ⟪x, y⟫_ℝ) :
+    InnerProductGeometry.angle x y ≤ π / 2 := by
+  unfold InnerProductGeometry.angle
+  rw [Real.arccos_le_pi_div_two]
+  exact div_nonneg h (mul_nonneg (norm_nonneg _) (norm_nonneg _))
+
+/-! ### The hypercube has no obtuse angle -/
+
+/-- The coordinatewise sign computation: if `bi, ai, ci ∈ {0,1}` then
+`(ci − bi)·(ai − bi) ≥ 0`, because both factors share the sign of `bi`
+(non-negative if `bi = 0`, non-positive if `bi = 1`). -/
+lemma cube_term_nonneg {bi ai ci : ℝ}
+    (hb : bi = 0 ∨ bi = 1) (ha : ai = 0 ∨ ai = 1) (hc : ci = 0 ∨ ci = 1) :
+    0 ≤ (ci - bi) * (ai - bi) := by
+  rcases hb with hb | hb <;> rcases ha with ha | ha <;> rcases hc with hc | hc <;>
+    subst hb ha hc <;> norm_num
+
+/-- **The hypercube inner product is non-negative.**  For cube vertices
+`a, b, c ∈ {0,1}^d`, `⟪a − b, c − b⟫ ≥ 0`.  The inner product is the sum over
+coordinates of `(a_i − b_i)(c_i − b_i)`, and every summand is non-negative by
+`cube_term_nonneg`. -/
+theorem cube_inner_nonneg {d : ℕ} (a b c : Point d)
+    (ha : IsCubeVertex a) (hb : IsCubeVertex b) (hc : IsCubeVertex c) :
+    0 ≤ ⟪a - b, c - b⟫_ℝ := by
+  rw [PiLp.inner_apply]
+  refine Finset.sum_nonneg (fun i _ => ?_)
+  rw [PiLp.sub_apply, PiLp.sub_apply, RCLike.inner_apply, conj_trivial]
+  exact cube_term_nonneg (hb i) (ha i) (hc i)
+
+/-- **No obtuse angle in the hypercube.**  Every angle `∠ a b c` determined by
+three vertices of `{0,1}^d` is at most `π/2`. -/
+theorem cube_angle_le_pi_div_two {d : ℕ} (a b c : Point d)
+    (ha : IsCubeVertex a) (hb : IsCubeVertex b) (hc : IsCubeVertex c) :
+    ∠ a b c ≤ π / 2 := by
+  unfold EuclideanGeometry.angle
+  apply angle_le_pi_div_two_of_inner_nonneg
+  rw [vsub_eq_sub, vsub_eq_sub]
+  exact cube_inner_nonneg a b c ha hb hc
+
+/-! ### The 2^d-point construction -/
+
+/-- The set of all `2^d` vertices of the unit hypercube `{0,1}^d`, obtained as
+the image of the boolean cube `Fin d → Bool`. -/
+noncomputable def cubeVertices (d : ℕ) : Finset (Point d) :=
+  Finset.univ.image
+    (fun f : Fin d → Bool => WithLp.toLp 2 (fun i => if f i then (1 : ℝ) else 0))
+
+lemma cubeVertices_injective (d : ℕ) :
+    Function.Injective
+      (fun f : Fin d → Bool => WithLp.toLp 2 (fun i => if f i then (1 : ℝ) else 0)) := by
+  intro f g hfg
+  have h2 := WithLp.toLp_injective 2 hfg
+  funext i
+  have hi := congrFun h2 i
+  by_cases hf : f i <;> by_cases hg : g i <;> simp_all
+
+lemma mem_cubeVertices_isCubeVertex {d : ℕ} {v : Point d}
+    (hv : v ∈ cubeVertices d) : IsCubeVertex v := by
+  rw [cubeVertices, Finset.mem_image] at hv
+  obtain ⟨f, _, rfl⟩ := hv
+  intro i
+  rw [PiLp.toLp_apply]
+  by_cases h : f i <;> simp [h]
+
+/-- The hypercube vertex set has exactly `2^d` elements. -/
+lemma cubeVertices_card (d : ℕ) : (cubeVertices d).card = 2 ^ d := by
+  rw [cubeVertices, Finset.card_image_of_injective _ (cubeVertices_injective d)]
+  simp [Finset.card_univ]
+
+/-- **Danzer–Grünbaum lower bound (formalised).**  For every dimension `d` there
+is a set of `2^d` points in ℝ^d in which no three points form an obtuse angle.
+Hence `2^d` points in ℝ^d never force an angle exceeding `π/2`. -/
+theorem exists_cube_no_obtuse (d : ℕ) :
+    ∃ S : Finset (Point d), S.card = 2 ^ d ∧
+      ∀ a ∈ S, ∀ b ∈ S, ∀ c ∈ S, ∠ a b c ≤ π / 2 := by
+  refine ⟨cubeVertices d, cubeVertices_card d, fun a ha b hb c hc => ?_⟩
+  exact cube_angle_le_pi_div_two a b c
+    (mem_cubeVertices_isCubeVertex ha) (mem_cubeVertices_isCubeVertex hb)
+    (mem_cubeVertices_isCubeVertex hc)
+
+/-! ### Sharpness: the bound π/2 is attained -/
+
+/-- The standard `i`-th unit vertex of the cube (`1` in coordinate `i`, else `0`). -/
+noncomputable def unitVertex {d : ℕ} (i : Fin d) : Point d :=
+  WithLp.toLp 2 (fun j => if j = i then 1 else 0)
+
+@[simp] lemma unitVertex_apply {d : ℕ} (i j : Fin d) :
+    unitVertex i j = if j = i then 1 else 0 := by
+  rw [unitVertex, PiLp.toLp_apply]
+
+lemma unitVertex_isCubeVertex {d : ℕ} (i : Fin d) : IsCubeVertex (unitVertex i) := by
+  intro j; by_cases h : j = i <;> simp [h]
+
+lemma zero_isCubeVertex {d : ℕ} : IsCubeVertex (0 : Point d) := by
+  intro i; left; simp
+
+/-- **Sharpness.**  In dimension `d ≥ 2` the bound `π/2` of `cube_angle_le_pi_div_two`
+is attained: the origin together with two distinct unit vertices forms a right
+angle.  Therefore the threshold `π/2` cannot be lowered — the hypercube genuinely
+realises right angles and no smaller universal bound holds. -/
+theorem cube_angle_pi_div_two_attained {d : ℕ} (hd : 2 ≤ d) :
+    ∃ a b c : Point d, IsCubeVertex a ∧ IsCubeVertex b ∧ IsCubeVertex c ∧
+      ∠ a b c = π / 2 := by
+  have hne : (⟨0, by omega⟩ : Fin d) ≠ ⟨1, by omega⟩ := by
+    intro h; simpa using congrArg Fin.val h
+  refine ⟨unitVertex ⟨0, by omega⟩, 0, unitVertex ⟨1, by omega⟩,
+    unitVertex_isCubeVertex _, zero_isCubeVertex, unitVertex_isCubeVertex _, ?_⟩
+  rw [EuclideanGeometry.angle, vsub_eq_sub, vsub_eq_sub, sub_zero, sub_zero,
+    ← InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two, PiLp.inner_apply]
+  refine Finset.sum_eq_zero (fun i _ => ?_)
+  rw [RCLike.inner_apply, conj_trivial, unitVertex_apply, unitVertex_apply]
+  rcases eq_or_ne i ⟨0, by omega⟩ with h | h
+  · subst h; simp [hne]
+  · simp [h]
+
+end Erdos504OQ01

--- a/src/data/proofs/erdos-504-oq-01/meta.json
+++ b/src/data/proofs/erdos-504-oq-01/meta.json
@@ -1,0 +1,177 @@
+{
+  "id": "erdos-504-oq-01",
+  "title": "Erdős #504 OQ: The Hypercube Gives 2^d Non-Obtuse Points in ℝ^d",
+  "slug": "erdos-504-oq-01",
+  "description": "For the higher-dimensional analogue of Erdős #504 (Blumenthal's maximum-angle problem), the 2^d vertices of the unit hypercube {0,1}^d form a set of 2^d points in ℝ^d with no obtuse angle (every angle ≤ π/2), and the bound π/2 is attained — the Danzer–Grünbaum lower-bound construction, fully verified.",
+  "meta": {
+    "author": "Researcher (Lean Genius)",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "erdos-problems",
+      "discrete-geometry",
+      "combinatorial-geometry",
+      "angles",
+      "inner-product-space",
+      "sharp-bound",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "InnerProductGeometry.angle",
+        "description": "The unoriented angle arccos(⟪x,y⟫/(‖x‖‖y‖)) between vectors, and EuclideanGeometry.angle as the angle at the middle point",
+        "module": "Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic"
+      },
+      {
+        "theorem": "Real.arccos_le_pi_div_two",
+        "description": "arccos x ≤ π/2 ↔ 0 ≤ x — turns a non-negative cosine argument into a non-obtuse angle",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse"
+      },
+      {
+        "theorem": "InnerProductGeometry.inner_eq_zero_iff_angle_eq_pi_div_two",
+        "description": "⟪x,y⟫ = 0 ↔ angle x y = π/2 — used to show the right angle is attained",
+        "module": "Mathlib.Geometry.Euclidean.Angle.Unoriented.Basic"
+      },
+      {
+        "theorem": "PiLp.inner_apply",
+        "description": "The Euclidean inner product on EuclideanSpace ℝ (Fin d) is the coordinatewise sum ∑ i, ⟪x i, y i⟫",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Finset.card_image_of_injective",
+        "description": "Image under an injective map preserves cardinality (the boolean cube ↪ hypercube vertices), giving card = 2^d",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "Proved the dimension-free criterion angle_le_pi_div_two_of_inner_nonneg: in any real inner product space a non-negative inner product ⟪x,y⟫ ≥ 0 forces the angle between x and y to be ≤ π/2 (a reusable non-obtuse criterion)",
+      "Proved cube_inner_nonneg: for any three vertices a, b, c of {0,1}^d the inner product ⟪a−b, c−b⟫ ≥ 0, because in every coordinate the two factors share the sign of b_i — the elementary heart of the Danzer–Grünbaum construction",
+      "Proved exists_cube_no_obtuse: for every d there is a 2^d-point set in ℝ^d with no obtuse angle, so 2^d points never force an angle exceeding π/2 (the higher-dimensional lower bound for Erdős #504)",
+      "Proved cube_angle_pi_div_two_attained: in dimension d ≥ 2 the bound π/2 is attained (origin plus two distinct unit vertices form a right angle), so the construction is sharp"
+    ],
+    "dateAdded": "2026-06-23",
+    "erdosNumber": 504,
+    "proofRepoPath": "Proofs/Erdos504OQ01.lean",
+    "axiomCount": 0,
+    "lineCount": 173,
+    "assumptions": "None. 0 axioms (only the standard propext / Classical.choice / Quot.sound foundational axioms, which do not count), 0 sorries, no native_decide. Fully machine-checked.",
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: Euclidean Points and Hypercube Vertices",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Defines Point d = EuclideanSpace ℝ (Fin d) and the predicate IsCubeVertex v (every coordinate of v is 0 or 1, i.e. v is a vertex of the unit hypercube {0,1}^d). The header explains the connection to Erdős #504: the planar maximum-angle problem (Blumenthal/Sendov) generalizes to ℝ^d, where the right angle π/2 is the threshold and the hypercube is the extremal non-obtuse configuration.",
+      "mathContext": "Erdős #504 (Blumenthal's problem, solved by Sendov 1993) asks, in ℝ², for the largest angle forced in every n-point set. In ℝ^d the natural threshold is π/2: a set is non-obtuse if no three of its points form an obtuse angle. Danzer–Grünbaum (1962) proved the maximum size of a non-obtuse set in ℝ^d is exactly 2^d, realized by the hypercube."
+    },
+    {
+      "id": "criterion",
+      "title": "A Dimension-Free Non-Obtuse Criterion",
+      "startLine": 55,
+      "endLine": 67,
+      "summary": "angle_le_pi_div_two_of_inner_nonneg: in any real inner product space, ⟪x,y⟫ ≥ 0 implies the unoriented angle between x and y is ≤ π/2. The angle is arccos(⟪x,y⟫/(‖x‖‖y‖)); the argument of arccos is non-negative (non-negative numerator, non-negative denominator), and arccos is ≤ π/2 exactly on the non-negative reals.",
+      "mathContext": "This isolates the geometric content: 'angle is non-obtuse' is equivalent to 'inner product of the two edge vectors is non-negative'. It holds in arbitrary dimension and is the only analytic ingredient — everything else is the coordinate algebra of the cube."
+    },
+    {
+      "id": "no-obtuse",
+      "title": "The Hypercube Has No Obtuse Angle",
+      "startLine": 68,
+      "endLine": 96,
+      "summary": "cube_term_nonneg: for bi, ai, ci ∈ {0,1}, the product (ci−bi)(ai−bi) ≥ 0. cube_inner_nonneg: hence for cube vertices a, b, c the inner product ⟪a−b, c−b⟫ = ∑ i (a_i−b_i)(c_i−b_i) ≥ 0. cube_angle_le_pi_div_two: combining with the criterion, every angle ∠ a b c of the hypercube is ≤ π/2.",
+      "mathContext": "The key elementary fact: if b_i = 0 then a_i−b_i and c_i−b_i are both ≥ 0; if b_i = 1 they are both ≤ 0. Either way the per-coordinate product is non-negative, so the whole inner product is non-negative — no obtuse angle can occur at any vertex."
+    },
+    {
+      "id": "construction",
+      "title": "The 2^d-Point Construction (Danzer–Grünbaum Lower Bound)",
+      "startLine": 97,
+      "endLine": 139,
+      "summary": "cubeVertices d is the image of the boolean cube Fin d → Bool under f ↦ (i ↦ if f i then 1 else 0). cubeVertices_injective + cubeVertices_card give |cubeVertices d| = 2^d. exists_cube_no_obtuse packages the result: for every d there is a set of 2^d points in ℝ^d in which no three points form an obtuse angle.",
+      "mathContext": "This is the lower-bound half of Danzer–Grünbaum: 2^d points in ℝ^d need not force any obtuse angle, so the right-angle threshold of Erdős #504's higher-dimensional analogue is not crossed until one has more than 2^d points. The matching upper bound (2^d+1 points always contain an obtuse angle) is the harder half and is not attempted here."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: the Bound π/2 Is Attained",
+      "startLine": 140,
+      "endLine": 173,
+      "summary": "unitVertex i is the standard cube vertex with a 1 in coordinate i. cube_angle_pi_div_two_attained: for d ≥ 2 the origin together with two distinct unit vertices realizes an angle of exactly π/2 (their edge vectors are orthogonal: disjoint supports give inner product 0). So the π/2 bound of cube_angle_le_pi_div_two cannot be lowered.",
+      "mathContext": "Right angles genuinely occur in the hypercube (e.g. the corner of any 2-dimensional face), so no universal bound smaller than π/2 holds for the construction. This shows π/2 is the exact non-obtuse threshold the hypercube achieves."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős #504 is Blumenthal's problem: for n points in the plane, what is the largest angle α_n that must occur among some three of them? Erdős and Szekeres (1960) found α_{2^n}, and Sendov (1993) gave the complete answer, with regular-polygon-type configurations extremal. The natural higher-dimensional question — what angle is forced among n points in ℝ^d — is governed by the right-angle threshold. Danzer and Grünbaum (1962) proved that the largest set in ℝ^d with all angles ≤ π/2 has exactly 2^d points, the hypercube being extremal, and conjectured (after Erdős) the analogous 2d−1 bound for strictly acute sets. This entry formalizes the lower-bound (construction) direction in ℝ^d for arbitrary d.",
+    "problemStatement": "What is the higher-dimensional analogue of Erdős #504: among n points in ℝ^d, what angle is forced? At the right-angle threshold, how many points can avoid an obtuse angle? We prove the hypercube {0,1}^d gives 2^d such points and that the threshold π/2 is sharp.",
+    "text": "Take the 2^d corners of the unit cube in ℝ^d. For any three corners a, b, c, the edge vectors a−b and c−b agree in sign coordinate by coordinate (both following the sign of b in that coordinate), so their inner product is non-negative and the angle at b is at most a right angle. Thus 2^d points in ℝ^d need contain no obtuse angle, and right angles do occur, so π/2 is exactly the threshold the cube attains.",
+    "proofStrategy": "Reduce 'non-obtuse angle' to 'non-negative inner product' via a dimension-free arccos criterion. Then the whole problem becomes coordinate algebra on {0,1}^d: each coordinate of (a−b) and (c−b) shares the sign of b_i, so each summand of ⟪a−b, c−b⟫ is ≥ 0, hence the inner product is ≥ 0 and the angle ≤ π/2. The 2^d count comes from injecting the boolean cube Fin d → Bool. Sharpness uses orthogonality of two unit-vertex directions from the origin.",
+    "keyInsights": [
+      "The geometric statement 'no obtuse angle' is exactly the algebraic statement '⟪a−b, c−b⟫ ≥ 0', captured once and for all by the dimension-free criterion angle_le_pi_div_two_of_inner_nonneg.",
+      "The cube works for a one-line reason: a coordinate of b is 0 or 1, and in either case the corresponding coordinates of a−b and c−b have the same sign, so every coordinate contributes a non-negative product.",
+      "The construction is exponentially large in the dimension (2^d points), the sharp Danzer–Grünbaum lower bound; there is no fixed absolute bound on non-obtuse sets across all dimensions.",
+      "Sharpness is exact, not asymptotic: in any dimension d ≥ 2 a right angle of measure exactly π/2 is realized at a face corner, so π/2 cannot be replaced by any smaller universal bound."
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalizes the Danzer–Grünbaum lower bound for the higher-dimensional analogue of Erdős #504: the 2^d vertices of the unit hypercube {0,1}^d give 2^d points in ℝ^d with no obtuse angle (every angle ≤ π/2), and for d ≥ 2 the bound π/2 is attained. Fully verified with 0 axioms and no native_decide.",
+    "implications": "Establishes, unconditionally and in every dimension, the construction half of the right-angle threshold: 2^d points in ℝ^d never force an obtuse angle. The reusable criterion angle_le_pi_div_two_of_inner_nonneg reduces non-obtuse-angle questions to inner-product positivity in any real inner product space, and the IsCubeVertex / coordinate-sign framework supports further hypercube angle results (acute sets, the matching upper bound).",
+    "openQuestions": [
+      "The matching upper bound: prove that any 2^d + 1 points in ℝ^d must contain an obtuse angle (the harder half of Danzer–Grünbaum), giving the exact maximum size 2^d of a non-obtuse set.",
+      "The strictly-acute analogue (Erdős's conjecture, proved by Danzer–Grünbaum): the maximum number of points in ℝ^d with all angles strictly less than π/2 is 2d − 1 — can the lower-bound construction be formalized similarly?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "targetId": "erdos-504",
+      "description": "Answers the open question 'what is the higher-dimensional analogue: given n points in ℝ^d?' for Erdős #504 (Blumenthal's maximum-angle problem) by formalizing the Danzer–Grünbaum hypercube construction giving 2^d non-obtuse points in ℝ^d."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "InnerProductSpace",
+      "EuclideanGeometry"
+    ],
+    "namespace": "Erdos504OQ01",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "path": "Proofs/Erdos504OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "exists_cube_no_obtuse",
+      "type": "theorem",
+      "description": "For every dimension d there is a set of 2^d points in ℝ^d in which no three points form an obtuse angle (every angle ≤ π/2) — the Danzer–Grünbaum lower bound for the higher-dimensional analogue of Erdős #504."
+    },
+    {
+      "name": "cube_angle_le_pi_div_two",
+      "type": "theorem",
+      "description": "Every angle ∠ a b c determined by three vertices of the unit hypercube {0,1}^d is at most π/2."
+    },
+    {
+      "name": "cube_inner_nonneg",
+      "type": "theorem",
+      "description": "For cube vertices a, b, c the inner product ⟪a−b, c−b⟫ is ≥ 0, because in each coordinate the two factors share the sign of b_i — the elementary heart of the argument."
+    },
+    {
+      "name": "angle_le_pi_div_two_of_inner_nonneg",
+      "type": "theorem",
+      "description": "Dimension-free criterion: in any real inner product space, a non-negative inner product ⟪x,y⟫ ≥ 0 forces the angle between x and y to be at most π/2."
+    },
+    {
+      "name": "cube_angle_pi_div_two_attained",
+      "type": "theorem",
+      "description": "For d ≥ 2 the bound π/2 is attained: the origin together with two distinct unit vertices forms a right angle, so the construction is sharp."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Erdős #504 OQ-01 — Higher-dimensional analogue (point sets in ℝ^d)

**Parent (Erdős #504, Blumenthal's problem, solved Sendov 1993):** in ℝ², what is the largest angle α_n forced among some three of any n points? **OQ-01 asks the higher-dimensional analogue in ℝ^d.**

The threshold is the right angle π/2. This PR formalizes the **Danzer–Grünbaum (1962) lower-bound construction**, unconditionally and axiom-free:

> The 2^d vertices of the unit hypercube {0,1}^d form **2^d points in ℝ^d with no obtuse angle** (every angle ≤ π/2), and for d ≥ 2 the bound π/2 is **attained** — so the construction is sharp.

### Results
- `angle_le_pi_div_two_of_inner_nonneg` — dimension-free criterion: `⟪x,y⟫ ≥ 0 ⟹ angle ≤ π/2` (reusable, any real inner product space).
- `cube_inner_nonneg` — for cube vertices a,b,c, `⟪a−b, c−b⟫ ≥ 0`. The heart: in each coordinate a−b and c−b share the sign of b_i, so every summand of `∑(a_i−b_i)(c_i−b_i)` is ≥ 0.
- `cube_angle_le_pi_div_two` — hence every hypercube angle is ≤ π/2.
- `exists_cube_no_obtuse` — a 2^d-point set in ℝ^d with no obtuse angle (card 2^d via injecting `Fin d → Bool`).
- `cube_angle_pi_div_two_attained` — for d ≥ 2, the origin + two distinct unit vertices give a right angle (orthogonal directions), so π/2 is sharp.

The matching **upper bound** (2^d+1 points always contain an obtuse angle) is the harder Danzer–Grünbaum half and is left as a stated open question.

### Verification
- 173 lines, 12 theorems/lemmas, 3 defs.
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`. **0 `axiom` declarations, 0 sorries, no `native_decide`.** Fully machine-checked.
- Built standalone with `lake env lean` against Mathlib (v4.26.0); docker wrapper was down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)