### PR TITLE
audit(abel-ruffini deep oq chain): record clean — additive 5 vs multiplicative 6 [verified/mathlib Tier B]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1,5 +1,11 @@
 {
   "entries": {
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-23T08:06:42Z",
+      "result": "clean"
+    },
     "abel-ruffini": {
       "auditCount": 6,
       "issues": [],


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Target**: `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01`
**Title**: *Reflection Is Symmetric, the Escape Cost Is Not: Additive 5 vs Multiplicative 6 at the Abel–Ruffini Boundary*
**Lean**: `proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01.lean`

This target was repeatedly returned by `find-targets --next` (absent from the tracker); this PR records the completed clean audit to advance the queue.

### Findings — no issues

| Check | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| theoremCount | 10 | 10 | ✅ |
| definitionCount | 0 | 0 | ✅ |
| lineCount | 205 | 205 | ✅ |
| sorries | 0 | 0 (only docstring L40 disclaimer) | ✅ |
| axiomCount | 0 | 0 `axiom` decls, 0 structure assumptions | ✅ |
| status / badge | verified / mathlib | Tier B (Mathlib bridge) | ✅ |

### Tier classification — correct (Tier B)
- Core solvability content (`Sₙ` unsolvable for n ≥ 5) comes from Mathlib's `Equiv.Perm.not_solvable` via the parent chain's `perm_solvable_iff_card`. The file supplies combinatorial packaging only → `mathlib` badge, **not** `original`.
- `assumptions` field honestly credits the Mathlib dependency and confirms `#print axioms` reports only propext / Classical.choice / Quot.sound (no `Lean.ofReduceBool`, no `sorryAx`).
- Title names the Abel–Ruffini boundary but is properly qualified; no delegation opacity, no axiom masking, no inequality-as-theorem inflation.

**Result**: `clean`. No overclaim, no missing-lean, no named `native_decide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)