### PR TITLE
Enrich Non-Three-Square Density Error: finer annotation coverage

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/annotations.json
@@ -2,49 +2,137 @@
   {
     "id": "one-sided",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
-    "range": { "startLine": 56, "endLine": 81 },
+    "range": {
+      "startLine": 56,
+      "endLine": 77
+    },
     "type": "theorem",
     "title": "One-Sided Sharpness: 6·excludedCount N ≤ N",
     "content": "`six_excludedCount_le`: the density 1/6 is approached strictly from below — 6·excludedCount N ≤ N for ALL N (equivalently excludedCount N ≤ ⌊N/6⌋). The proof telescopes the oq-03-oq-05 recursion: writing E(N) = 6·excludedCount N − N, each descent step changes it by δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8), which depends only on N mod 8 and takes the eight values 0,0,−1,−2,−3,−3,−4,−5 — all ≤ 0. So the running total never turns positive (strong induction; the residue arithmetic discharged entirely by omega via the division identities). This is strictly stronger than the parent's two-sided bound whose upper half was +6(log₂N+1).",
     "mathContext": "$6\\,\\mathrm{excludedCount}(N)\\le N$, i.e. $\\mathrm{excludedCount}(N)\\le\\lfloor N/6\\rfloor$. The per-step increment $\\delta(N)\\le 0$ depends only on $N\\bmod 8$.",
     "significance": "critical",
-    "relatedConcepts": ["one-sided bound", "telescoping", "residue reduction", "strong induction"],
-    "prerequisites": ["strong induction", "modular arithmetic"]
+    "relatedConcepts": [
+      "one-sided bound",
+      "telescoping",
+      "residue reduction",
+      "strong induction"
+    ],
+    "prerequisites": [
+      "strong induction",
+      "modular arithmetic"
+    ]
+  },
+  {
+    "id": "floor-form",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 81
+    },
+    "type": "theorem",
+    "title": "Floor Form: excludedCount N ≤ ⌊N/6⌋",
+    "content": "`excludedCount_le_div_six`: a clean restatement of the one-sided bound in floor form, obtained from 6·excludedCount N ≤ N via `Nat.le_div_iff_mul_le`. It is the sharpest finite-N statement of the density-1/6 law from above: the count of non-three-squares below N never exceeds a whole sixth of N, with no logarithmic slack — the +6(log₂N+1) of the parent's two-sided bound is entirely absent on the upper side.",
+    "mathContext": "$\\mathrm{excludedCount}(N)\\le\\lfloor N/6\\rfloor$ for every $N$ — no upper-side error term at all.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "floor function",
+      "density upper bound",
+      "exact inequality"
+    ],
+    "prerequisites": [
+      "Nat division",
+      "floor inequalities"
+    ]
   },
   {
     "id": "extremal-family",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
-    "range": { "startLine": 83, "endLine": 108 },
+    "range": {
+      "startLine": 83,
+      "endLine": 108
+    },
     "type": "definition",
     "title": "The Extremal Family a k = (4^{k+2}+2)/3",
     "content": "The worst-case family for the descent: a 0 = 6, a (k+1) = 4·a k − 2, with closed form a k = (4^{k+2}+2)/3. Two structural lemmas make it the right witness: `a_mod8` shows every member is ≡ 6 (mod 8) — the residue with the most negative sustainable increment δ = −4 (residue 7 has δ = −5 but cannot chain to another 7), and `a_step` shows the descent stays on the family, ⌈a(k+1)/4⌉ = a k. This self-sustaining maximal-loss orbit is what forces the error to diverge.",
     "mathContext": "$a_0=6,\\ a_{k+1}=4a_k-2,\\ a_k=\\frac{4^{k+2}+2}{3}$; $a_k\\equiv 6\\ (8)$ and $\\lceil a_{k+1}/4\\rceil=a_k$. Each step costs $\\delta=-4$.",
     "significance": "key",
-    "relatedConcepts": ["extremal family", "recurrence", "worst-case residue", "self-similar orbit"],
-    "prerequisites": ["recurrences", "modular arithmetic"]
+    "relatedConcepts": [
+      "extremal family",
+      "recurrence",
+      "worst-case residue",
+      "self-similar orbit"
+    ],
+    "prerequisites": [
+      "recurrences",
+      "modular arithmetic"
+    ]
   },
   {
     "id": "exact-error",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
-    "range": { "startLine": 110, "endLine": 144 },
+    "range": {
+      "startLine": 110,
+      "endLine": 144
+    },
     "type": "theorem",
     "title": "Exact Error Along the Family: 4k+6",
     "content": "`excludedCount_a`: along the extremal family, 6·excludedCount (a k) = a k − (4k+6) exactly. Proved by induction using the oq-03-oq-05 recursion and a_step: each step adds δ = −4 (the residue-6 increment), so the accumulated deficit is 4k+6. `error_eq` restates this as a k − 6·excludedCount (a k) = 4k+6. Since a k ≈ 4^k, the error 4k+6 = Θ(log a k), matching the parent's logarithmic upper bound up to a constant.",
     "mathContext": "$6\\,\\mathrm{excludedCount}(a_k)=a_k-(4k+6)$, so the error $a_k-6\\,\\mathrm{excludedCount}(a_k)=4k+6=\\Theta(\\log a_k)$ as $a_k\\sim 4^k$.",
     "significance": "critical",
-    "relatedConcepts": ["exact asymptotics", "Θ(log N)", "induction", "error term"],
-    "prerequisites": ["induction", "integer casts"]
+    "relatedConcepts": [
+      "exact asymptotics",
+      "Θ(log N)",
+      "induction",
+      "error term"
+    ],
+    "prerequisites": [
+      "induction",
+      "integer casts"
+    ]
+  },
+  {
+    "id": "unbounded",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 162
+    },
+    "type": "theorem",
+    "title": "Genuine Unboundedness via an Explicit Witness",
+    "content": "`error_unbounded`: for every target C there is an N with C ≤ N − 6·excludedCount N. The witness is fully explicit — N = a ⌈C⌉ (concretely a C.toNat) — and `error_eq` evaluates the error there to exactly 4·⌈C⌉ + 6 ≥ C. This is the constructive half of the dichotomy: it rules out the 'O(1) along subsequences' possibility the parent left open, because the gap demonstrably reaches every prescribed height along the residue-6 family.",
+    "mathContext": "$\\forall C,\\ \\exists N,\\ C\\le N-6\\,\\mathrm{excludedCount}(N)$; the witness $N=a_{\\lceil C\\rceil}$ realises error $4\\lceil C\\rceil+6$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "unboundedness",
+      "explicit witness",
+      "constructive existence",
+      "extremal family"
+    ],
+    "prerequisites": [
+      "existential proofs",
+      "integer order"
+    ]
   },
   {
     "id": "dichotomy",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
-    "range": { "startLine": 146, "endLine": 172 },
+    "range": {
+      "startLine": 164,
+      "endLine": 172
+    },
     "type": "theorem",
     "title": "The Dichotomy Settled: One-Sided and Unbounded",
     "content": "`error_unbounded`: for every target C there is an N (concretely N = a ⌈C⌉) with C ≤ N − 6·excludedCount N, since the error there is 4·C+6. Combined with the one-sided bound, `density_error_one_sided_and_unbounded` records the full picture: 0 ≤ N − 6·excludedCount N for all N, AND the quantity is unbounded above. So the oq-03-oq-05 oscillation is NOT O(1) — it is one-sided (always ≥ 0) and of true order Θ(log N), settling the parent's open dichotomy completely.",
     "mathContext": "$0\\le N-6\\,\\mathrm{excludedCount}(N)$ for all $N$, and $\\sup_N\\bigl(N-6\\,\\mathrm{excludedCount}(N)\\bigr)=\\infty$: the error is one-sided and $\\Theta(\\log N)$, not $O(1)$.",
     "significance": "critical",
-    "relatedConcepts": ["unboundedness", "dichotomy", "Θ(log N)", "one-sided oscillation"],
-    "prerequisites": ["asymptotic order notation"]
+    "relatedConcepts": [
+      "unboundedness",
+      "dichotomy",
+      "Θ(log N)",
+      "one-sided oscillation"
+    ],
+    "prerequisites": [
+      "asymptotic order notation"
+    ]
   }
 ]


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01` (*The Non-Three-Square Density Error Is One-Sided and Genuinely Unbounded*).

This entry was already enriched on main (full overview, sections, conclusion, 4 annotations). This pass builds on that without regressing any content, raising annotation coverage **4 → 6** so every named theorem in the 172-line file gets its own annotation:

- **floor-form** (lines 78–81): dedicated annotation for `excludedCount_le_div_six` (the ⌊N/6⌋ form), split out of the one-sided block.
- **unbounded** (lines 146–162): dedicated annotation for `error_unbounded`'s explicit witness N = a⌈C⌉, split out of the dichotomy block.

All annotation ranges remain contiguous (56–172); existing `one-sided`, `extremal-family`, `exact-error`, `dichotomy` annotations preserved (ranges tightened only where they overlapped the new ones). Each of the 6 annotations carries `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

JSON validated via the build's data-generation prebuild (pure JSON data change).