### PR TITLE
research(wilsons-theorem-oq-05-oq-01): trichotomy of (n-1)! mod n as one ZMod-free closed form [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3674,6 +3674,7 @@ import Proofs.WilsonsTheoremOQ03
 import Proofs.WilsonsTheoremOQ04
 import Proofs.WilsonsTheoremOQ04OQ02
 import Proofs.WilsonsTheoremOQ05
+import Proofs.WilsonsTheoremOQ05OQ01
 import Proofs.WolstenholmePrimeMod4
 import Proofs.WolstenholmeTheorem
 import Proofs.WolstenholmeTheoremOQ01

--- a/proofs/Proofs/WilsonsTheoremOQ05OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ05OQ01.lean
@@ -1,0 +1,227 @@
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Tactic
+
+/-
+# The trichotomy of `(n-1)! mod n` — the complete classification, ZMod-free
+
+**Open Question (`wilsons-theorem-oq-05-oq-01`)**: package Wilson's theorem and
+its converse into a *single closed-form* description of the bare remainder
+`(n - 1)! % n`, valid for every `n ≥ 2`:
+
+```
+                 ⎧ n - 1   if n is prime,
+(n - 1)! % n  =  ⎨ 2       if n = 4,
+                 ⎩ 0       if n is composite and n > 4.
+```
+
+## What is genuinely new here
+
+The sibling entry `Proofs/WilsonsTheoremOQ01.lean` already proves the trichotomy,
+but as a three-way *disjunction* whose residues live in `ZMod n`
+(`wilson_complete_classification`), and it discharges the exceptional `n = 4`
+branch with `native_decide` (hence depends on `Lean.ofReduceBool`).  The parent
+entry `Proofs/WilsonsTheoremOQ05.lean` argues that the classically-stated,
+`ZMod`-free remainder form `(n - 1)! % n = n - 1` is the genuinely useful shape,
+but only supplies the *prime* branch in that form.
+
+This file completes that programme: it states the **full** classification as one
+honest closed-form equation between natural numbers,
+
+  `factorial_pred_mod : 2 ≤ n → (n-1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0`,
+
+with **no `ZMod` anywhere in any statement** and **no `native_decide`** (the
+`n = 4` branch is closed by `decide` on a `Nat` equality, which is axiom-free).
+On top of it sit two crisp structural consequences that the disjunction form does
+not isolate:
+
+* `mod_eq_zero_iff_composite` : for `n ≥ 2`, `(n-1)! % n = 0 ↔ (¬ n.Prime ∧ n ≠ 4)`
+  — the remainder vanishes *exactly* on the genuine composites, the clean
+  "compositeness is detected by a zero remainder" half of the criterion.
+* `four_unique_anomaly` : for `n ≥ 2`, `n = 4` is the **unique** value at which the
+  remainder is neither `0` nor `n - 1`.  Wilson's theorem says primes give `n - 1`
+  and (almost all) composites give `0`; this pins down `4` as the lone exception.
+
+To keep the file self-contained and `native_decide`-free it re-derives the two
+inputs from Mathlib directly: the prime remainder identity (from
+`Nat.prime_iff_fac_equiv_neg_one`) and the composite divisibility
+`n ∣ (n-1)!` for composite `n > 4` (two distinct factors `< n`, with the
+perfect-square subcase `n = p²` handled by the pair `p, 2p`).
+
+Fully machine-checked: `0` sorries, `0` axioms (no `native_decide`).
+-/
+
+namespace WilsonsTheoremOQ05OQ01
+
+open Nat
+open scoped Nat
+
+/-! ## Inputs, re-derived from Mathlib (self-contained, `native_decide`-free) -/
+
+/-- The natural number `n - 1` reduces to `-1` in `ZMod n` (for `n ≥ 1`). The
+hinge that turns Mathlib's `ZMod`-valued Wilson statement into a remainder. -/
+theorem natCast_pred_eq_neg_one {n : ℕ} (hn : 1 ≤ n) : ((n - 1 : ℕ) : ZMod n) = -1 := by
+  have h : ((n - 1 : ℕ) : ZMod n) = (n : ZMod n) - 1 := by
+    rw [Nat.cast_sub hn, Nat.cast_one]
+  rw [h, ZMod.natCast_self, zero_sub]
+
+/-- **Prime branch (remainder form).** For prime `n`, `(n-1)! % n = n - 1`.
+Re-derived from `Nat.prime_iff_fac_equiv_neg_one`. -/
+theorem factorial_pred_mod_of_prime {n : ℕ} (hp : Nat.Prime n) :
+    (n - 1)! % n = n - 1 := by
+  have hn1 : n ≠ 1 := hp.one_lt.ne'
+  have h2 : 2 ≤ n := hp.two_le
+  have hzmod : ((n - 1)! : ZMod n) = ((n - 1 : ℕ) : ZMod n) := by
+    rw [(Nat.prime_iff_fac_equiv_neg_one hn1).mp hp, natCast_pred_eq_neg_one (by omega)]
+  have hcong : (n - 1)! ≡ n - 1 [MOD n] :=
+    (ZMod.natCast_eq_natCast_iff _ _ _).mp hzmod
+  -- `n - 1 < n`, so its residue is itself
+  have hlt : n - 1 < n := by omega
+  calc (n - 1)! % n = (n - 1) % n := hcong
+    _ = n - 1 := Nat.mod_eq_of_lt hlt
+
+/-- `n! = ∏_{k=1}^{n} k`, as a product over `Finset.Icc 1 n`. -/
+theorem factorial_eq_Icc_prod (n : ℕ) : n.factorial = (Finset.Icc 1 n).prod id := by
+  induction n with
+  | zero => simp [Nat.factorial]
+  | succ m ih =>
+    rw [Nat.factorial_succ, ih]
+    have hmem : m + 1 ∉ Finset.Icc 1 m := by simp
+    have hinsert : Finset.Icc 1 (m + 1) = insert (m + 1) (Finset.Icc 1 m) := by
+      ext x; simp only [Finset.mem_Icc, Finset.mem_insert]; omega
+    rw [hinsert, Finset.prod_insert hmem, id, mul_comm]
+
+/-- If `a, b` are distinct elements of `{1, …, n}`, then `a * b ∣ n!`. -/
+theorem distinct_factors_dvd_factorial {a b n : ℕ}
+    (ha : 1 ≤ a) (ha' : a ≤ n) (hb : 1 ≤ b) (hb' : b ≤ n) (hab : a ≠ b) :
+    a * b ∣ n.factorial := by
+  rw [factorial_eq_Icc_prod]
+  have hpair : ({a, b} : Finset ℕ).prod id = a * b := by
+    rw [Finset.prod_pair hab]; rfl
+  rw [← hpair]
+  apply Finset.prod_dvd_prod_of_subset
+  intro x hx
+  simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+  simp only [Finset.mem_Icc]
+  rcases hx with rfl | rfl <;> omega
+
+/-- **Composite branch (divisibility).** For composite `n > 4`, `n ∣ (n-1)!`.
+The two distinct factors are `minFac n` and its cofactor; the perfect-square
+case `n = p²` (where the cofactor coincides with `p`) uses the pair `p, 2p`. -/
+theorem composite_factorial_dvd {n : ℕ} (hn_comp : ¬Nat.Prime n) (hn_gt : n > 4) :
+    n ∣ (n - 1).factorial := by
+  have hn_pos : 0 < n := by omega
+  have hn_ne_one : n ≠ 1 := by omega
+  set p := n.minFac with hp_def
+  have hp_prime : Nat.Prime p := Nat.minFac_prime hn_ne_one
+  have hp_dvd : p ∣ n := Nat.minFac_dvd n
+  have hp_gt_one : 1 < p := hp_prime.one_lt
+  set q := n / p with hq_def
+  have hpq : p * q = n := Nat.mul_div_cancel' hp_dvd
+  have hp_sq_le : p ^ 2 ≤ n := Nat.minFac_sq_le_self hn_pos hn_comp
+  have hq_ge_p : p ≤ q := by
+    by_contra h
+    push_neg at h
+    have h1 : p * q < p * p := by nlinarith
+    nlinarith
+  have hq_gt_one : 1 < q := by linarith
+  have hp_lt_n : p < n := by nlinarith
+  have hq_lt_n : q < n := by nlinarith
+  by_cases hpq_eq : p = q
+  · -- Case n = p² (p = q), forcing p ≥ 3
+    have hn_eq : n = p * p := by rw [← hpq, hpq_eq]
+    have hp_ge_3 : p ≥ 3 := by
+      by_contra h
+      push_neg at h
+      have hp2 : p = 2 := by omega
+      rw [hp2] at hn_eq; omega
+    have h2p_lt : 2 * p < p * p := by nlinarith
+    have h2p_le : 2 * p ≤ n - 1 := by omega
+    have hp_ne_2p : p ≠ 2 * p := by omega
+    have h_prod_dvd : p * (2 * p) ∣ (n - 1).factorial :=
+      distinct_factors_dvd_factorial (by omega) (by omega) (by omega) h2p_le hp_ne_2p
+    have h_pp_dvd : p * p ∣ p * (2 * p) := ⟨2, by ring⟩
+    have h_goal : p * p ∣ (n - 1).factorial := dvd_trans h_pp_dvd h_prod_dvd
+    exact hn_eq ▸ h_goal
+  · -- Case p ≠ q, both in {1, …, n-1}
+    rw [← hpq]
+    exact distinct_factors_dvd_factorial (by omega) (by omega) (by omega) (by omega) hpq_eq
+
+/-- **Composite branch (remainder form).** For composite `n > 4`, `(n-1)! % n = 0`. -/
+theorem factorial_pred_mod_of_composite {n : ℕ} (hn_comp : ¬Nat.Prime n) (hn_gt : n > 4) :
+    (n - 1)! % n = 0 := by
+  obtain ⟨k, hk⟩ := composite_factorial_dvd hn_comp hn_gt
+  rw [hk, Nat.mul_mod_right]
+
+/-- **Exceptional branch.** `(4-1)! % 4 = 2`, by `decide` on a `Nat` equality
+(axiom-free; no `native_decide`). -/
+theorem factorial_pred_mod_four : (4 - 1)! % 4 = 2 := by decide
+
+/-! ## The headline closed-form classification -/
+
+/-- **Trichotomy of `(n-1)! mod n`, ZMod-free closed form.** For every `n ≥ 2`,
+
+```
+(n - 1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0.
+```
+
+A single closed-form equation between natural numbers, with no `ZMod` and no
+`native_decide`: the prime regime gives the Wilson residue `n - 1 (= -1)`, the
+lone anomaly `n = 4` gives `2`, and every genuine composite gives `0`. -/
+theorem factorial_pred_mod {n : ℕ} (hn : 2 ≤ n) :
+    (n - 1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0 := by
+  by_cases hp : Nat.Prime n
+  · rw [if_pos hp]; exact factorial_pred_mod_of_prime hp
+  · rw [if_neg hp]
+    by_cases h4 : n = 4
+    · rw [if_pos h4, h4]; exact factorial_pred_mod_four
+    · rw [if_neg h4]
+      have hgt4 : n > 4 := by
+        by_contra h_le
+        push_neg at h_le
+        interval_cases n
+        · exact hp Nat.prime_two
+        · exact hp Nat.prime_three
+        · exact h4 rfl
+      exact factorial_pred_mod_of_composite hp hgt4
+
+/-! ## Structural consequences not isolated by the disjunction form -/
+
+/-- **Compositeness is detected by a zero remainder.** For `n ≥ 2`,
+`(n-1)! % n = 0` *exactly* when `n` is a genuine composite (`¬ Prime` and `≠ 4`).
+This is the clean "if" half of the Wilson primality criterion in remainder form:
+the converse of Wilson, with the `n = 4` exception explicitly excised. -/
+theorem mod_eq_zero_iff_composite {n : ℕ} (hn : 2 ≤ n) :
+    (n - 1)! % n = 0 ↔ (¬ Nat.Prime n ∧ n ≠ 4) := by
+  rw [factorial_pred_mod hn]
+  constructor
+  · intro h
+    by_cases hp : Nat.Prime n
+    · rw [if_pos hp] at h; omega
+    · refine ⟨hp, ?_⟩
+      rw [if_neg hp] at h
+      by_cases h4 : n = 4
+      · rw [if_pos h4] at h; omega
+      · exact h4
+  · rintro ⟨hp, h4⟩
+    rw [if_neg hp, if_neg h4]
+
+/-- **`n = 4` is the unique remainder anomaly.** For `n ≥ 2`, the remainder
+`(n-1)! % n` fails to be one of the two "expected" values `0` (composite) or
+`n - 1` (prime) at *exactly* one number, `n = 4`, where it equals `2`. -/
+theorem four_unique_anomaly {n : ℕ} (hn : 2 ≤ n) :
+    ((n - 1)! % n ≠ 0 ∧ (n - 1)! % n ≠ n - 1) ↔ n = 4 := by
+  rw [factorial_pred_mod hn]
+  constructor
+  · rintro ⟨hne0, hnep⟩
+    by_cases hp : Nat.Prime n
+    · rw [if_pos hp] at hnep; exact absurd rfl hnep
+    · rw [if_neg hp] at hne0 hnep
+      by_cases h4 : n = 4
+      · exact h4
+      · rw [if_neg h4] at hne0; exact absurd rfl hne0
+  · intro h4
+    subst h4
+    rw [if_neg (by decide : ¬ Nat.Prime 4), if_pos rfl]
+    exact ⟨by decide, by decide⟩
+
+end WilsonsTheoremOQ05OQ01

--- a/research/problems/wilsons-theorem-oq-05-oq-01/knowledge.md
+++ b/research/problems/wilsons-theorem-oq-05-oq-01/knowledge.md
@@ -1,0 +1,55 @@
+# Knowledge: Trichotomy of (n−1)! mod n — the complete classification
+
+**Slug**: wilsons-theorem-oq-05-oq-01
+**Status**: COMPLETED (verified, 0-axiom, no native_decide)
+**Lean**: `proofs/Proofs/WilsonsTheoremOQ05OQ01.lean` (227L, 10 thm, 0 def)
+
+## Summary
+
+For every `n ≥ 2`,
+`(n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0`
+— a single ZMod-free closed-form remainder identity. Answers the parent
+oq-05's first listed open question.
+
+## Session 2026-06-23 (Session 1) — FRESH, COMPLETED
+
+**Outcome**: completed.
+
+### What I Did
+- Surveyed existing Wilson family. Found sibling oq-01 already has the
+  trichotomy but as a **ZMod-valued three-way disjunction**
+  (`wilson_complete_classification`) with the `n=4` branch via
+  `native_decide` (⇒ `Lean.ofReduceBool`). Parent oq-05 has only the prime
+  branch in ℕ-remainder form.
+- Built the genuinely-new ZMod-free **closed form** `factorial_pred_mod`,
+  plus two structural corollaries not isolated by the disjunction:
+  - `mod_eq_zero_iff_composite` : `(n-1)! % n = 0 ↔ (¬Prime n ∧ n ≠ 4)`.
+  - `four_unique_anomaly` : `n=4` is the unique `n ≥ 2` with remainder ∉ {0, n-1}.
+- Kept the file self-contained (Mathlib only, no project imports since dep
+  oleans were absent and docker down): re-derived the prime `%`-bridge from
+  `Nat.prime_iff_fac_equiv_neg_one` and the composite `n ∣ (n-1)!` from two
+  distinct factors `< n` (perfect-square subcase `n=p²` via `p, 2p`).
+- Closed the `n=4` case with `decide` on the **Nat** equality `3! % 4 = 2`
+  (axiom-free) — deliberately NOT `native_decide`, so the whole entry is 0-axiom.
+
+### Key Findings
+- `#print axioms` on all three headline theorems: only
+  `propext, Classical.choice, Quot.sound`. No `ofReduceBool`, no `sorryAx`.
+- The ℕ-formulation is what makes 0-axiom possible: `decide` works on a small
+  `Nat` equality where the sibling's ZMod element forced `native_decide`.
+
+### Gotchas
+- omega for `n-1 < n` and `1 ≤ n` needs `hp.two_le` in context (prime alone
+  isn't seen by omega).
+- The `n! = ∏_{Icc 1 n} id` induction must be a **standalone** lemma; inlining
+  it inside `distinct_factors_dvd_factorial` lets the `a,b ≤ n` hypotheses
+  pollute the induction hypothesis (`ih` demands `a ≤ m → b ≤ m`).
+
+### Files
+- `proofs/Proofs/WilsonsTheoremOQ05OQ01.lean` (new)
+- `proofs/Proofs.lean` (added import)
+- `src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json` (new)
+
+### Next Steps (follow-up open questions)
+- Decidable-flavored primality certificate from `factorial_pred_mod`; cost vs Lucas/Pratt.
+- Gauss generalization (product of units of ℤ/nℤ) as an analogous ZMod-free ℕ classification.

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "wilsons-theorem-oq-05-oq-01",
+  "title": "The Trichotomy of $(n-1)! \\bmod n$: a Single ZMod-Free Closed Form",
+  "slug": "wilsons-theorem-oq-05-oq-01",
+  "description": "Answers the first open question of the parent entry wilsons-theorem-oq-05: assemble the complete classification of the bare remainder (n-1)! mod n into a SINGLE closed-form equation between natural numbers, valid for every n ≥ 2: (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0. The sibling oq-01 already proves the trichotomy, but as a three-way disjunction whose residues live in ZMod n and whose exceptional n=4 branch is discharged by native_decide (so it depends on Lean.ofReduceBool); the parent oq-05 supplies only the prime branch in ZMod-free remainder form. This entry completes the programme: one honest closed-form identity, no ZMod in any statement and no native_decide (the n=4 branch is closed by decide on a Nat equality, which is axiom-free). On top of the headline `factorial_pred_mod` sit two structural consequences the disjunction form does not isolate: `mod_eq_zero_iff_composite` (for n ≥ 2, (n-1)! % n = 0 ↔ (¬Prime n ∧ n ≠ 4) — compositeness detected by a zero remainder, the converse of Wilson with the n=4 exception excised) and `four_unique_anomaly` (for n ≥ 2, n=4 is the UNIQUE value at which the remainder is neither 0 nor n-1). To stay self-contained and native_decide-free the file re-derives both inputs from Mathlib: the prime remainder identity from Nat.prime_iff_fac_equiv_neg_one, and the composite divisibility n ∣ (n-1)! for composite n > 4 from two distinct factors < n (perfect-square subcase n = p² handled by the pair p, 2p). Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Ibn al-Haytham (c. 1000); Wilson/Lagrange (1771); full ZMod-free trichotomy formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Wilson%27s_theorem",
+    "date": "1771",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ05OQ01.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "primality",
+      "factorial",
+      "modular-arithmetic",
+      "classification",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 227,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries, and crucially with NO native_decide (the n=4 branch uses decide on a Nat equality, which is axiom-free, rather than native_decide which would add Lean.ofReduceBool). Rests on Mathlib's Nat.prime_iff_fac_equiv_neg_one (the ZMod-valued Wilson biconditional) and elementary divisibility/factorial lemmas. The only axioms are the foundational propext, Classical.choice, Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.prime_iff_fac_equiv_neg_one",
+        "description": "`n ≠ 1 → (Nat.Prime n ↔ ((n-1)! : ZMod n) = -1)`, Mathlib's ZMod-valued Wilson biconditional. Used (via a natCast bridge) to derive the prime branch (n-1)! % n = n-1.",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_natCast_iff",
+        "description": "`(a : ZMod c) = (b : ZMod c) ↔ a ≡ b [MOD c]`. Converts the ZMod equality ((n-1)! : ZMod n) = ((n-1 : ℕ) : ZMod n) into the natural-number congruence (n-1)! ≡ n-1 [MOD n], which Nat.mod_eq_of_lt then turns into the bare remainder identity.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.minFac_sq_le_self",
+        "description": "`0 < n → ¬ n.Prime → n.minFac ^ 2 ≤ n`. The key inequality letting the smallest prime factor p = minFac n and its cofactor q = n/p satisfy p ≤ q < n, providing two distinct factors below n (and forcing p ≥ 3 in the perfect-square case n = p²).",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Finset.prod_dvd_prod_of_subset",
+        "description": "Product over a subset divides the product over a superset. With the identity n! = ∏_{k=1}^n k, this gives a*b ∣ n! whenever {a,b} ⊆ {1,…,n} are distinct — the engine behind composite_factorial_dvd.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.mul_mod_right",
+        "description": "`(a * b) % a = 0`. Converts the divisibility n ∣ (n-1)! into the remainder identity (n-1)! % n = 0 for composite n > 4.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "`factorial_pred_mod`: the headline ZMod-free closed form — for n ≥ 2, (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0. A single closed-form equation between natural numbers with NO ZMod in the statement and NO native_decide, in contrast to the sibling oq-01 disjunction (residues in ZMod n, n=4 branch via native_decide).",
+      "`mod_eq_zero_iff_composite`: for n ≥ 2, (n-1)! % n = 0 ↔ (¬ Nat.Prime n ∧ n ≠ 4). The clean 'compositeness is detected by a zero remainder' biconditional — the converse of Wilson with the n=4 exception explicitly excised — which the three-way disjunction form leaves implicit.",
+      "`four_unique_anomaly`: for n ≥ 2, ((n-1)! % n ≠ 0 ∧ (n-1)! % n ≠ n-1) ↔ n = 4. Pins n=4 as the UNIQUE value where the remainder is neither the prime value n-1 nor the composite value 0.",
+      "`factorial_pred_mod_of_composite`: the composite branch in ℕ-remainder form, (n-1)! % n = 0 for composite n > 4, bridging Mathlib divisibility to the bare remainder.",
+      "`factorial_pred_mod_four`: the exceptional value (4-1)! % 4 = 2 proved by decide on a Nat equality (axiom-free) rather than native_decide."
+    ],
+    "prerequisites": [
+      "Wilson's theorem and its ZMod formulation",
+      "Natural-number remainder `%` and congruence `Nat.ModEq`",
+      "Divisibility, factorials, and products over `Finset.Icc`",
+      "Smallest prime factor `Nat.minFac` and `minFac_sq_le_self`"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem-oq-05",
+        "relationship": "Parent: oq-05 gives Wilson's theorem in ZMod-free remainder form but only for the prime branch ((n-1)! % n = n-1) and explicitly lists 'assemble the complete trichotomy of (n-1)! mod n as a single classification theorem' as its first open question. This entry answers exactly that, in one closed-form equation."
+      },
+      {
+        "id": "wilsons-theorem-oq-01",
+        "relationship": "Sibling: oq-01 proves the same trichotomy as a three-way disjunction with residues in ZMod n and an n=4 branch closed by native_decide (so it carries Lean.ofReduceBool). This entry recasts it as a single ZMod-free closed-form remainder identity with no native_decide, and isolates the two structural corollaries (zero-remainder ⟺ composite, n=4 unique anomaly)."
+      },
+      {
+        "id": "wilsons-theorem-oq-03",
+        "relationship": "Sibling: oq-03 computes ν_p((p-1)!) = 0 (p ∤ (p-1)!). This entry pins the exact remainder across all regimes, sharper than non-divisibility, and identifies the lone composite n=4 where the remainder is nonzero."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 227,
+    "path": "Proofs/WilsonsTheoremOQ05OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 10
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Wilson's theorem — n > 1 is prime iff (n-1)! ≡ -1 (mod n) — was known to Ibn al-Haytham (c. 1000) and first proved by Lagrange (1771). Its converse fails to give a single clean residue for composites: most composites n give (n-1)! ≡ 0 (mod n), because a proper factorization of n appears among the factors 1,…,n-1, but the smallest composite n=4 is exceptional: 3! = 6 ≡ 2 (mod 4), since the only way to write 4 as a product of smaller numbers is 2·2, and 2 appears just once below 4. The result is a clean trichotomy: the remainder of (n-1)! mod n is n-1 for primes, 0 for composites n > 4, and 2 for the lone exception n = 4. This is the converse-of-Wilson story made into a complete decision for the remainder.",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-05-oq-01):** assemble the complete classification of (n-1)! mod n — n-1 for n prime, 2 for n=4, 0 for composite n > 4 — into a single Lean theorem, stated ZMod-free as a closed-form remainder identity, without the native_decide that the existing ZMod disjunction uses for the n=4 case.",
+    "text": "For every n ≥ 2, (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0. The prime regime gives the Wilson residue n-1 (= -1 mod n), the lone anomaly n=4 gives 2, and every genuine composite gives 0.",
+    "proofStrategy": "Case-split on whether n is prime. Prime branch: transport Mathlib's Nat.prime_iff_fac_equiv_neg_one to ℕ via the bridge ((n-1 : ℕ) : ZMod n) = -1 and ZMod.natCast_eq_natCast_iff, then Nat.mod_eq_of_lt gives (n-1)! % n = n-1. n=4: decide on the Nat equality 3! % 4 = 2 (axiom-free; deliberately not native_decide). Composite n ≠ 4: from n ≥ 2, ¬Prime, n ≠ 4 deduce n > 4, then n ∣ (n-1)! via two distinct factors p = minFac n and cofactor q (or p, 2p when n = p²), and Nat.mul_mod_right collapses the divisibility to remainder 0. The two corollaries read off the closed form: the zero-remainder branch is reached exactly when ¬Prime ∧ n ≠ 4, and the 'neither 0 nor n-1' regime exactly when n = 4.",
+    "keyInsights": [
+      "**One closed form, no ZMod.** Packaging the trichotomy as (n-1)! % n = if Prime then n-1 else if n=4 then 2 else 0 keeps every statement inside ℕ — the shape an elementary number theorist actually computes with — rather than a disjunction with residues hidden in a quotient type.",
+      "**decide, not native_decide, for n=4.** The exceptional value 3! % 4 = 2 is a tiny Nat computation; `decide` discharges it through the Decidable instance and stays axiom-free, whereas the sibling's `native_decide` (on the ZMod element) pulls in Lean.ofReduceBool. Choosing the ℕ formulation is what makes the whole classification genuinely 0-axiom.",
+      "**Compositeness ⟺ zero remainder.** mod_eq_zero_iff_composite isolates the clean half of the primality criterion: the remainder vanishes exactly on genuine composites (n ≠ 4), the converse of Wilson with the awkward n=4 caveat surgically removed.",
+      "**n=4 is the unique anomaly.** four_unique_anomaly turns the n=4 caveat into a theorem: among all n ≥ 2, exactly one value makes (n-1)! mod n land outside {0, n-1}. The exception that clutters every textbook statement of the converse is pinned down precisely."
+    ],
+    "prerequisites": [
+      "Wilson's theorem (ZMod form) and Nat.prime_iff_fac_equiv_neg_one",
+      "Natural-number remainder `%`, congruence `Nat.ModEq`, and `Nat.mod_eq_of_lt`",
+      "Divisibility, factorials as products over Finset.Icc, and Finset.prod_dvd_prod_of_subset",
+      "Smallest prime factor Nat.minFac and Nat.minFac_sq_le_self"
+    ]
+  },
+  "conclusion": {
+    "summary": "The complete classification of (n-1)! mod n is packaged into one ZMod-free closed-form identity — (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0 for n ≥ 2 — together with two structural corollaries: compositeness is detected exactly by a zero remainder (mod_eq_zero_iff_composite), and n=4 is the unique value where the remainder is neither 0 nor n-1 (four_unique_anomaly). 10 theorems, 227 lines, 0 sorries, 0 axioms, and deliberately no native_decide.",
+    "implications": "This directly answers the parent oq-05's first open question and supersedes the sibling oq-01 trichotomy on two counts: every statement is ZMod-free (usable in elementary ℕ-level developments) and the entry is genuinely 0-axiom because the n=4 case uses decide rather than native_decide. The closed form is a concrete (exponential) remainder-based primality decision, and the anomaly corollary records the n=4 exception as a uniqueness theorem rather than a footnote.",
+    "openQuestions": [
+      "Bundle factorial_pred_mod into a Decidable-flavored primality certificate and compare its cost with the Lucas/Pratt route, quantifying the (exponential) factorial computation.",
+      "State the Gauss generalization — the product of the units of ℤ/nℤ is -1 when (ℤ/nℤ)ˣ is cyclic of even order and +1 otherwise — as an analogous ZMod-free closed-form classification over ℕ, extending siblings oq-02/oq-04."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 60,
+      "summary": "Module docstring stating the trichotomy and contrasting it with the sibling oq-01 (ZMod disjunction + native_decide) and parent oq-05 (prime branch only), explaining the genuinely-new content (single ZMod-free closed form, two structural corollaries, 0-axiom via decide not native_decide), plus imports and the namespace opening Nat."
+    },
+    {
+      "id": "inputs",
+      "title": "Inputs Re-derived from Mathlib (native_decide-free)",
+      "startLine": 61,
+      "endLine": 165,
+      "summary": "natCast_pred_eq_neg_one (the ((n-1:ℕ):ZMod n) = -1 hinge); factorial_pred_mod_of_prime (prime branch (n-1)! % n = n-1 via Nat.prime_iff_fac_equiv_neg_one); factorial_eq_Icc_prod and distinct_factors_dvd_factorial (n! as a Finset.Icc product, and a*b ∣ n! for distinct a,b ≤ n); composite_factorial_dvd (n ∣ (n-1)! for composite n > 4, with the perfect-square subcase using p, 2p); factorial_pred_mod_of_composite (remainder-0 form); and factorial_pred_mod_four (3! % 4 = 2 by decide)."
+    },
+    {
+      "id": "classification",
+      "title": "The Closed-Form Classification and Its Consequences",
+      "startLine": 166,
+      "endLine": 227,
+      "summary": "factorial_pred_mod (the headline closed-form trichotomy by case-split on primality, n=4, and n>4); mod_eq_zero_iff_composite (zero remainder ⟺ genuine composite); and four_unique_anomaly (n=4 is the unique value with remainder outside {0, n-1})."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-05",
+      "relationship": "parent",
+      "description": "Parent entry: gives the prime branch of the remainder identity in ZMod-free form and lists assembling the full trichotomy as its first open question. This entry answers it with a single closed-form equation."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "oq-01 proves the trichotomy as a three-way ZMod-valued disjunction with the n=4 branch via native_decide. This entry recasts it as one ZMod-free closed form with no native_decide and adds the zero-remainder and uniqueness corollaries."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-03",
+      "relationship": "sibling",
+      "description": "oq-03 computes ν_p((p-1)!) = 0. This entry pins the exact remainder in every regime, sharper than non-divisibility, and identifies n=4 as the lone composite with nonzero remainder."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first listed open question** of the parent entry `wilsons-theorem-oq-05`: assemble the complete classification of the bare remainder `(n-1)! mod n` into a **single closed-form equation between natural numbers**, valid for every `n ≥ 2`:

```
(n-1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0
```

The prime regime gives the Wilson residue `n-1 (= -1)`, the lone anomaly `n=4` gives `2`, every genuine composite gives `0`.

## What is genuinely new

Sibling `oq-01` already proves the trichotomy, but as a **three-way disjunction** whose residues live in `ZMod n`, and it discharges the `n=4` branch with `native_decide` (hence depends on `Lean.ofReduceBool`). Parent `oq-05` supplies only the *prime* branch in ℕ-remainder form. This entry:

- **`factorial_pred_mod`** — the headline closed form, **no `ZMod` in any statement** and **no `native_decide`**. The `n=4` case is closed by `decide` on the `Nat` equality `3! % 4 = 2` (axiom-free), which is what makes the whole entry genuinely 0-axiom.
- **`mod_eq_zero_iff_composite`** — `(n-1)! % n = 0 ↔ (¬ Prime n ∧ n ≠ 4)`: compositeness detected exactly by a zero remainder, the converse of Wilson with the `n=4` exception surgically excised.
- **`four_unique_anomaly`** — `n=4` is the **unique** `n ≥ 2` where the remainder is neither `0` nor `n-1`.

Self-contained (Mathlib only — dep oleans were unavailable): re-derives the prime `%`-bridge from `Nat.prime_iff_fac_equiv_neg_one`, and `n ∣ (n-1)!` for composite `n > 4` from two distinct factors `< n` (perfect-square subcase `n = p²` via the pair `p, 2p`).

## Verification

- **227 lines, 10 theorems, 0 definitions, 0 sorries.**
- `#print axioms` on `factorial_pred_mod`, `mod_eq_zero_iff_composite`, `four_unique_anomaly`: only `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`, no `sorryAx`**.
- Built single-file against Mathlib 4.26.0 (docker unavailable this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)