### PR TITLE
research(cauchy-group-theorem-oq-01-oq-01-oq-01): n-th power map bijective iff gcd(n,|G|)=1 [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -511,6 +511,7 @@ import Proofs.CarnotTheorem
 import Proofs.CatalanNumbersOQ01
 import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01
 import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,128 @@
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-
+# When is the n-th power map a bijection? The coprimality criterion
+
+## What This Proves
+
+The sibling file `CauchyGroupTheoremOQ01OQ01` settles the **squaring** map
+`x ↦ x²` on a finite group: it is a bijection exactly when `|G|` is odd, i.e.
+exactly when `gcd(2, |G|) = 1`. This file proves the full generalization to the
+`n`-th power map `x ↦ xⁿ`, the sharp two-directional criterion:
+
+> On a finite group `G`, the map `x ↦ xⁿ` is a bijection **iff**
+> `gcd(n, |G|) = 1`.
+
+Mathlib supplies only the *forward* implication, packaged as
+`Nat.Coprime.pow_left_bijective` (built from the explicit inverse
+`powCoprime`). The **converse** — bijectivity forces coprimality — is not in
+Mathlib. It is the genuinely new content here, and it is what turns the
+one-directional Mathlib lemma into an `iff` and recovers the parent's
+squaring boundary as the special case `n = 2`.
+
+## The mathematics
+
+* **Forward** (`pow_bijective_of_coprime`). If `gcd(|G|, n) = 1` then `x ↦ xⁿ`
+  is a bijection. Bézout gives `a·|G| + b·n = 1`, so `(xⁿ)^b = x^{b·n} =
+  x^{1 - a·|G|} = x · (x^{|G|})^{-a} = x` since `x^{|G|} = 1`. The inverse map
+  is `x ↦ x^b`. This is `Nat.Coprime.pow_left_bijective`.
+
+* **Converse** (`coprime_of_pow_bijective`, NEW). If `gcd(|G|, n) ≠ 1`, pick a
+  prime `p ∣ gcd(|G|, n)`. Since `p ∣ |G|`, Cauchy's theorem
+  (`exists_prime_orderOf_dvd_card'`) produces an element `x` of order exactly
+  `p`; in particular `x ≠ 1`. Since `p ∣ n` and `orderOf x = p`, we get
+  `xⁿ = 1 = 1ⁿ`. So `x` and `1` are two distinct elements with the same
+  `n`-th power: the map is not injective, contradicting bijectivity.
+
+* **Criterion** (`pow_bijective_iff_coprime`). The two directions combine into
+  the clean equivalence. On a finite set a self-map is injective iff surjective
+  iff bijective, so the criterion holds verbatim for each of the three notions
+  (`pow_injective_iff_coprime`, `pow_surjective_iff_coprime`).
+
+* **Specializations.** Setting `n = 2` recovers the parent boundary
+  `x ↦ x²` is a bijection `↔ |G| odd` (`pow_bijective_iff_odd_card`). A
+  `Fintype.card` restatement (`pow_bijective_iff_coprime_card`) matches the usual
+  `gcd(n, |G|)` phrasing.
+
+All statements hold for an arbitrary finite group — abelian or not — because the
+power map, while not a homomorphism in the nonabelian case, still acts within
+each cyclic subgroup `⟨x⟩` where everything commutes.
+-/
+
+open Function
+
+variable {G : Type*} [Group G] [Finite G] {n : ℕ}
+
+omit [Finite G] in
+/-- **Forward direction.** If `gcd(|G|, n) = 1` then the `n`-th power map is a
+bijection. This is Mathlib's `Nat.Coprime.pow_left_bijective`, restated here for
+the criterion below; the explicit inverse is `x ↦ x ^ (gcdB |G| n)`. -/
+theorem pow_bijective_of_coprime (h : (Nat.card G).Coprime n) :
+    Bijective (· ^ n : G → G) :=
+  Nat.Coprime.pow_left_bijective h
+
+/-- **Converse direction (new).** If the `n`-th power map on a finite group is a
+bijection, then `gcd(|G|, n) = 1`. Not available in Mathlib. -/
+theorem coprime_of_pow_bijective (h : Bijective (· ^ n : G → G)) :
+    (Nat.card G).Coprime n := by
+  by_contra hcop
+  -- `gcd(|G|, n) ≠ 1`, so it has a prime factor `p`.
+  obtain ⟨p, hp, hpdvd⟩ := Nat.exists_prime_and_dvd hcop
+  have hpcard : p ∣ Nat.card G := hpdvd.trans (Nat.gcd_dvd_left _ _)
+  have hpn : p ∣ n := hpdvd.trans (Nat.gcd_dvd_right _ _)
+  haveI : Fact p.Prime := ⟨hp⟩
+  -- Cauchy: an element of order exactly `p`.
+  obtain ⟨x, hx⟩ := exists_prime_orderOf_dvd_card' p hpcard
+  -- `p ∣ n` and `orderOf x = p` give `xⁿ = 1`.
+  have hxn : x ^ n = 1 := by
+    rw [← orderOf_dvd_iff_pow_eq_one, hx]; exact hpn
+  -- `x ≠ 1` because its order is the prime `p ≠ 1`.
+  have hne : x ≠ 1 := by
+    intro h1; rw [h1, orderOf_one] at hx; exact hp.ne_one hx.symm
+  -- `x` and `1` collide under the power map: contradiction with injectivity.
+  exact hne (h.injective (by simpa using hxn))
+
+/-- **The criterion.** On a finite group, the `n`-th power map is a bijection iff
+`gcd(|G|, n) = 1`. -/
+theorem pow_bijective_iff_coprime :
+    Bijective (· ^ n : G → G) ↔ (Nat.card G).Coprime n :=
+  ⟨coprime_of_pow_bijective, pow_bijective_of_coprime⟩
+
+/-- Injective form of the criterion (on a finite set, injective = bijective). -/
+theorem pow_injective_iff_coprime :
+    Injective (· ^ n : G → G) ↔ (Nat.card G).Coprime n := by
+  rw [← pow_bijective_iff_coprime, Finite.injective_iff_bijective]
+
+/-- Surjective form of the criterion (on a finite set, surjective = bijective). -/
+theorem pow_surjective_iff_coprime :
+    Surjective (· ^ n : G → G) ↔ (Nat.card G).Coprime n := by
+  rw [← pow_bijective_iff_coprime, Finite.surjective_iff_bijective]
+
+/-- `Fintype.card` restatement matching the usual `gcd(n, |G|)` phrasing. -/
+theorem pow_bijective_iff_coprime_card [Fintype G] :
+    Bijective (· ^ n : G → G) ↔ (Fintype.card G).Coprime n := by
+  rw [pow_bijective_iff_coprime, Nat.card_eq_fintype_card]
+
+/-- **Recovering the parent boundary.** Squaring is a bijection iff `|G|` is odd.
+The case `n = 2` of the criterion, via `gcd(|G|, 2) = 1 ↔ Odd |G|`. This is
+exactly the squaring boundary of the sibling file, now a corollary. -/
+theorem pow_bijective_iff_odd_card :
+    Bijective (· ^ 2 : G → G) ↔ Odd (Nat.card G) := by
+  rw [pow_bijective_iff_coprime, Nat.coprime_two_right]
+
+/-- Sanity instance: on the cyclic group of order `5`, cubing is a bijection
+(`gcd(3, 5) = 1`). -/
+example : Bijective (· ^ 3 : Multiplicative (ZMod 5) → Multiplicative (ZMod 5)) := by
+  rw [pow_bijective_iff_coprime, Nat.card_eq_fintype_card, Fintype.card_multiplicative,
+    ZMod.card]
+  decide
+
+/-- Sanity instance: on the cyclic group of order `6`, cubing is **not** a
+bijection (`gcd(3, 6) = 3 ≠ 1`). -/
+example : ¬ Bijective (· ^ 3 : Multiplicative (ZMod 6) → Multiplicative (ZMod 6)) := by
+  rw [pow_bijective_iff_coprime, Nat.card_eq_fintype_card, Fintype.card_multiplicative,
+    ZMod.card]
+  decide

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "forward-coprime",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 65
+    },
+    "type": "theorem",
+    "title": "Forward Direction: Coprime Exponent Gives a Bijection",
+    "content": "`pow_bijective_of_coprime`: if gcd(|G|, n) = 1 then x ↦ xⁿ is a bijection. This is Mathlib's `Nat.Coprime.pow_left_bijective`, built from the explicit equivalence `powCoprime` whose inverse is the power map x ↦ x^(gcdB |G| n). The mechanism is Bézout: from a·|G| + b·n = 1 we get (xⁿ)^b = x^(b·n) = x^(1 - a·|G|) = x, because x^|G| = 1. Restated here so the converse can complete the iff.",
+    "mathContext": "Bézout gives $a|G| + bn = 1$, so $(x^n)^b = x^{bn} = x^{1 - a|G|} = x\\,(x^{|G|})^{-a} = x$. The inverse of $x \\mapsto x^n$ is $x \\mapsto x^b$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "coprime exponents",
+      "powCoprime equivalence",
+      "Lagrange's theorem"
+    ],
+    "prerequisites": [
+      "finite group theory",
+      "Bézout's identity"
+    ]
+  },
+  {
+    "id": "converse-cauchy",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 67,
+      "endLine": 86
+    },
+    "type": "theorem",
+    "title": "Converse Direction (new): Bijectivity Forces Coprimality",
+    "content": "`coprime_of_pow_bijective`: if x ↦ xⁿ is a bijection on the finite group G then gcd(|G|, n) = 1. This direction is NOT in Mathlib and is the genuinely new content. Proof by contraposition: if gcd(|G|, n) ≠ 1, take a prime p ∣ gcd via `Nat.exists_prime_and_dvd`, so p ∣ |G| and p ∣ n. Cauchy's theorem (`exists_prime_orderOf_dvd_card'`) produces x with orderOf x = p, hence x ≠ 1; and since p = orderOf x divides n, `orderOf_dvd_iff_pow_eq_one` gives xⁿ = 1 = 1ⁿ. So x and 1 are distinct elements with equal n-th power, contradicting injectivity. Cauchy is exactly the tool that converts a common prime factor into an obstruction element.",
+    "mathContext": "If $p \\mid \\gcd(|G|,n)$, Cauchy gives $x$ of order $p$ with $x \\ne 1$; since $p \\mid n$, $x^n = 1 = 1^n$, so $x \\mapsto x^n$ is not injective.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Cauchy's theorem",
+      "order of an element",
+      "contrapositive",
+      "prime obstruction"
+    ],
+    "prerequisites": [
+      "Cauchy's theorem",
+      "order of an element"
+    ]
+  },
+  {
+    "id": "criterion-iff",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "The Coprime Criterion and Its Injective/Surjective Forms",
+    "content": "`pow_bijective_iff_coprime` bundles the two directions into the sharp biconditional: x ↦ xⁿ is a bijection ⟺ gcd(|G|, n) = 1, for an arbitrary finite group (no abelian hypothesis — the power map acts within each cyclic subgroup ⟨x⟩ where everything commutes). Because a self-map of a finite type is injective iff surjective iff bijective, `pow_injective_iff_coprime` and `pow_surjective_iff_coprime` follow at once from `Finite.injective_iff_bijective` and `Finite.surjective_iff_bijective`.",
+    "mathContext": "$\\text{Bijective}(x \\mapsto x^n) \\iff \\gcd(n,|G|)=1$, equivalently injective or surjective, for every finite group $G$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "biconditional characterization",
+      "finite self-maps",
+      "injective iff surjective",
+      "coprime-exponent theorem"
+    ],
+    "prerequisites": [
+      "finite group theory",
+      "pigeonhole principle"
+    ]
+  },
+  {
+    "id": "fintype-card-form",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 107
+    },
+    "type": "theorem",
+    "title": "Fintype.card Restatement",
+    "content": "`pow_bijective_iff_coprime_card`: the same criterion phrased with `Fintype.card G` in place of `Nat.card G`, matching the customary gcd(n, |G|) wording. The two cardinalities agree on a finite group via `Nat.card_eq_fintype_card`.",
+    "mathContext": "$\\text{Bijective}(x \\mapsto x^n) \\iff \\gcd(n, |G|)=1$ with $|G| = \\text{Fintype.card } G$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.card vs Fintype.card",
+      "cardinality of finite groups"
+    ],
+    "prerequisites": [
+      "finite types in Lean"
+    ]
+  },
+  {
+    "id": "odd-card-corollary",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 109,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "Recovering the Sibling's Squaring Boundary",
+    "content": "`pow_bijective_iff_odd_card`: the n = 2 instance of the criterion. Since `Nat.coprime_two_right` says n.Coprime 2 ↔ Odd n, the criterion specializes to: squaring x ↦ x² is a bijection ⟺ |G| is odd. This reproduces in one line the central boundary of the sibling entry cauchy-group-theorem-oq-01-oq-01, exhibiting that result as the prime-2 shadow of the uniform coprimality phenomenon.",
+    "mathContext": "$\\text{Bijective}(x \\mapsto x^2) \\iff \\text{Odd}(|G|)$ — the $n = 2$ case, recovering the sibling's odd-order squaring boundary.",
+    "significance": "important",
+    "relatedConcepts": [
+      "squaring map",
+      "odd order",
+      "involutions",
+      "specialization"
+    ],
+    "prerequisites": [
+      "parity of group order"
+    ]
+  },
+  {
+    "id": "zmod-witnesses",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 117,
+      "endLine": 128
+    },
+    "type": "example",
+    "title": "Concrete ZMod Witnesses (0-axiom)",
+    "content": "Two concrete instances of the criterion on cyclic groups. Cubing is a bijection on Multiplicative (ZMod 5) since gcd(3, 5) = 1, and is NOT a bijection on Multiplicative (ZMod 6) since gcd(3, 6) = 3 ≠ 1. Each check rewrites the noncomputable `Nat.card` to a literal via `Nat.card_eq_fintype_card`, `Fintype.card_multiplicative` and `ZMod.card`, then closes by kernel `decide`. Using kernel decide rather than native_decide avoids the `Lean.ofReduceBool` axiom, so the whole file depends only on the three foundational axioms.",
+    "mathContext": "$x \\mapsto x^3$ is a bijection on $\\mathbb{Z}/5$ ($\\gcd(3,5)=1$) but not on $\\mathbb{Z}/6$ ($\\gcd(3,6)=3$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic groups",
+      "kernel decide",
+      "axiom hygiene",
+      "ZMod"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "decidability in Lean"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+  "title": "The n-th power map is a bijection on a finite group iff gcd(n, |G|) = 1",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.GroupTheory.Perm.Cycle.Type",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Function"
+    ],
+    "namespace": "",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "The full coprime-exponent criterion for the power map, answering the sibling entry's first open question. On any finite group G, the n-th power map x ↦ xⁿ is a bijection if and only if gcd(n, |G|) = 1 — abelian or not. Mathlib supplies only the forward implication (Nat.Coprime.pow_left_bijective, built from the explicit inverse powCoprime via Bézout). The converse — bijectivity forces coprimality — is the new content and is not in Mathlib: if a prime p divides gcd(n, |G|), Cauchy's theorem produces an element x of order p, and since p ∣ n we get xⁿ = 1 = 1ⁿ with x ≠ 1, defeating injectivity. The two directions combine into pow_bijective_iff_coprime, restated for injective and surjective forms (on a finite self-map all three coincide), a Fintype.card phrasing, and the corollary pow_bijective_iff_odd_card that recovers the sibling's squaring boundary (n = 2 ⟺ |G| odd) as a special case. Two 0-axiom ZMod witnesses (cubing bijective on ℤ/5, not on ℤ/6) by kernel decide.",
+  "overview": {
+    "historicalContext": "Cauchy's 1845 theorem — a prime p dividing |G| forces an element of order p — is the seed of all local structure theory of finite groups. One of its cleanest consequences concerns the power map x ↦ xⁿ. When gcd(n, |G|) = 1 this map is a bijection (its inverse is another power map, supplied by Bézout coefficients), the multiplicative shadow of 'n is invertible modulo the exponent of G'. The converse — that bijectivity can only happen when n is coprime to |G| — is exactly where Cauchy re-enters: a common prime factor manufactures a nontrivial element killed by the n-th power. The element-of-coprime-order map underlies regular elements in algebraic groups, the coprime action machinery of the odd-order theorem, and the Schur–Zassenhaus splitting (where Mathlib's powCoprime is used). The sibling entry settled the n = 2 boundary (squaring is a bijection iff |G| is odd); this entry proves the general statement and lists the squaring case as the corollary.",
+    "problemStatement": "Characterize exactly when the n-th power map on a finite group is a bijection. Prove the two-directional criterion: for a finite group G and n : ℕ, the map x ↦ xⁿ is a bijection if and only if gcd(n, |G|) = 1, valid for arbitrary (not necessarily abelian) finite groups, and exhibit the n = 2 special case as the odd-order squaring boundary of the sibling entry.",
+    "proofStrategy": "Forward (coprime ⟹ bijection) is Mathlib's Nat.Coprime.pow_left_bijective: from Bézout a·|G| + b·n = 1 the map x ↦ x^b inverts x ↦ xⁿ because x^|G| = 1. The converse (bijection ⟹ coprime) is proved by contraposition: if gcd(|G|, n) ≠ 1 take a prime p ∣ gcd via Nat.exists_prime_and_dvd; then p ∣ |G| and p ∣ n. Cauchy (exists_prime_orderOf_dvd_card') yields x with orderOf x = p, so x ≠ 1, while orderOf_dvd_iff_pow_eq_one and p ∣ n give xⁿ = 1 = 1ⁿ — two distinct elements with equal n-th power, contradicting injectivity. Bundling the directions gives the iff; Finite.injective_iff_bijective / surjective_iff_bijective propagate it to the injective and surjective forms; Nat.coprime_two_right rewrites the n = 2 case to 'Odd |G|'. Concrete ZMod 5 / ZMod 6 witnesses rewrite Nat.card via Fintype.card_multiplicative and ZMod.card, then kernel decide — no native_decide, so 0 axioms.",
+    "keyInsights": [
+      "The criterion holds for ALL finite groups, not just abelian ones: although x ↦ xⁿ is not a homomorphism when G is nonabelian, it still acts within each cyclic subgroup ⟨x⟩ where powers commute, and both the Bézout inverse and the Cauchy obstruction live entirely inside such cyclic subgroups.",
+      "The converse is genuinely new relative to Mathlib, which packages only the coprime ⟹ bijection direction (powCoprime / pow_left_bijective). Cauchy's theorem is precisely the tool that turns the one-directional lemma into an iff: a shared prime factor of n and |G| is exactly an element the power map cannot avoid collapsing.",
+      "The obstruction is local and explicit: a single prime p ∣ gcd(n, |G|) already breaks injectivity, via one Cauchy element of order p, with no need to analyze the whole group.",
+      "The n = 2 instance reproduces the sibling entry's boundary 'squaring is a bijection ⟺ |G| odd' as a one-line corollary (Nat.coprime_two_right), showing that result was the prime-2 shadow of a uniform coprimality phenomenon.",
+      "Axiom hygiene is preserved: the concrete ZMod witnesses use kernel decide (after rewriting Nat.card to a literal), avoiding native_decide and the Lean.ofReduceBool axiom, so every statement depends only on the three foundational axioms."
+    ]
+  },
+  "sections": [
+    {
+      "id": "two-directions",
+      "title": "The Two Directions",
+      "startLine": 59,
+      "endLine": 86,
+      "summary": "pow_bijective_of_coprime restates the Mathlib forward implication (coprime ⟹ bijection, inverse x ↦ x^(gcdB |G| n)). coprime_of_pow_bijective is the new converse: a prime p ∣ gcd(n, |G|) yields a Cauchy element of order p with xⁿ = 1 = 1ⁿ, breaking injectivity.",
+      "mathContext": "x ↦ xⁿ bijective ⟸ gcd(n,|G|)=1 (Bézout inverse); bijective ⟹ gcd(n,|G|)=1 (Cauchy obstruction)."
+    },
+    {
+      "id": "criterion",
+      "title": "The Coprime Criterion and Its Forms",
+      "startLine": 88,
+      "endLine": 116,
+      "summary": "pow_bijective_iff_coprime bundles the two directions. On a finite self-map injective = surjective = bijective, so pow_injective_iff_coprime and pow_surjective_iff_coprime hold verbatim. pow_bijective_iff_coprime_card gives the Fintype.card phrasing, and pow_bijective_iff_odd_card recovers the sibling's squaring boundary at n = 2.",
+      "mathContext": "Bijective (·^n) ↔ (Nat.card G).Coprime n, equivalently for injective/surjective, and ↔ Odd |G| when n = 2."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete ZMod Witnesses",
+      "startLine": 117,
+      "endLine": 128,
+      "summary": "Cubing is a bijection on the cyclic group of order 5 (gcd(3,5)=1) and fails to be one on the cyclic group of order 6 (gcd(3,6)=3). Both checks rewrite Nat.card via Fintype.card_multiplicative and ZMod.card to a literal, then close by kernel decide, keeping the file 0-axiom.",
+      "mathContext": "x ↦ x³ on ℤ/5 is a bijection; on ℤ/6 it is not — concrete instances of the criterion."
+    }
+  ],
+  "conclusion": {
+    "summary": "The power map x ↦ xⁿ on a finite group is a bijection exactly when gcd(n, |G|) = 1, with no abelian hypothesis. Mathlib's one-directional coprime ⟹ bijection lemma becomes a sharp iff once Cauchy's theorem supplies the converse obstruction, and the criterion descends to the injective and surjective forms and to a Fintype.card restatement. The sibling entry's odd-order squaring boundary falls out as the n = 2 corollary, and concrete ℤ/5 and ℤ/6 witnesses keep the development genuinely 0-axiom.",
+    "implications": [
+      "Answers the first open question of the sibling entry cauchy-group-theorem-oq-01-oq-01 in full generality, generalizing its squaring (n = 2) boundary to every exponent n.",
+      "Contributes the converse direction missing from Mathlib (which exports only Nat.Coprime.pow_left_bijective / powCoprime), packaged as a clean biconditional usable as a regular-element / coprime-exponent criterion.",
+      "Isolates Cauchy's theorem as the exact mechanism behind the converse: a common prime factor of n and |G| is precisely an obstruction element, a viewpoint that recurs in coprime-action arguments."
+    ],
+    "openQuestions": [
+      "Does the same biconditional hold for the n-th power map on an infinite group under a suitable finiteness-of-torsion or finite-exponent hypothesis, or does the converse genuinely require |G| < ∞?",
+      "Can the explicit inverse be packaged as a group-theoretic functor sending each finite group with gcd(n,|G|)=1 to the power automorphism, functorially in G, mirroring the additive 'division by n' on coprime-order modules?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers this sibling's first listed open question: it generalizes the squaring (n = 2) bijection boundary to the full coprime-exponent criterion for arbitrary n, and recovers the sibling's 'squaring bijective ⟺ odd order' as the corollary pow_bijective_iff_odd_card."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01",
+      "relationship": "builds-on",
+      "description": "Uses Cauchy's theorem (the existence of an element of prime order p whenever p ∣ |G|), the grandparent entry's subject, as the engine of the converse direction."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (structural follow-up to Cauchy's theorem)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "cauchy-theorem",
+      "order-of-element",
+      "power-map",
+      "coprime-exponent",
+      "bijection",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Coprime.pow_left_bijective",
+        "description": "If gcd(|G|, n) = 1 then x ↦ xⁿ is bijective (built from the explicit inverse powCoprime via Bézout); the forward direction of the criterion.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "exists_prime_orderOf_dvd_card'",
+        "description": "Cauchy's theorem (Finite/Nat.card form): p ∣ |G| yields an element of order exactly p; supplies the obstruction element in the converse direction.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "Nat.exists_prime_and_dvd",
+        "description": "Any n ≠ 1 has a prime factor; applied to gcd(|G|, n) ≠ 1 to extract the prime p dividing both |G| and n.",
+        "module": "Mathlib.Data.Nat.Prime.Defs"
+      },
+      {
+        "theorem": "orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf x ∣ n ↔ xⁿ = 1; with orderOf x = p ∣ n this gives xⁿ = 1, collapsing x onto 1.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Finite.injective_iff_bijective",
+        "description": "For a self-map of a finite type, injective ↔ bijective; propagates the criterion to the injective and surjective forms.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Nat.coprime_two_right",
+        "description": "n.Coprime 2 ↔ Odd n; rewrites the n = 2 instance of the criterion into the sibling's odd-order squaring boundary.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Cauchy, Augustin-Louis",
+        "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+        "year": "1845",
+        "note": "Exercices d'analyse et de physique mathématique 3, 151–252 — the existence of elements of prime order, the engine of the converse direction."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — coprime power/automorphism maps and regular elements in finite groups."
+      },
+      {
+        "authors": "Robinson, Derek J. S.",
+        "title": "A Course in the Theory of Groups",
+        "year": "1996",
+        "note": "Graduate Texts in Mathematics 80, Springer — coprime actions and the role of gcd(n, |G|) in power and fixed-point arguments."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves the full **coprime-exponent criterion** for the power map, answering the first open question of the sibling entry `cauchy-group-theorem-oq-01-oq-01`:

> On any finite group `G` (abelian or not), the map `x ↦ xⁿ` is a bijection **iff** `gcd(n, |G|) = 1`.

Mathlib supplies only the **forward** implication (`Nat.Coprime.pow_left_bijective`, built from the explicit inverse `powCoprime` via Bézout). The **converse** — bijectivity forces coprimality — is **not in Mathlib** and is the new content: if a prime `p ∣ gcd(n, |G|)`, Cauchy's theorem (`exists_prime_orderOf_dvd_card'`) yields an element `x` of order `p`, and since `p ∣ n` we get `xⁿ = 1 = 1ⁿ` with `x ≠ 1`, defeating injectivity.

## Contents

- `pow_bijective_of_coprime` — forward (Mathlib restatement)
- `coprime_of_pow_bijective` — **converse (new)**, via Cauchy
- `pow_bijective_iff_coprime` — the criterion, plus `pow_injective_iff_coprime` / `pow_surjective_iff_coprime` (finite self-map: injective = surjective = bijective)
- `pow_bijective_iff_coprime_card` — `Fintype.card` phrasing
- `pow_bijective_iff_odd_card` — `n = 2` corollary recovering the sibling's squaring boundary (`⟺ Odd |G|`)
- Two concrete `ZMod` witnesses (cubing bijective on ℤ/5, not on ℤ/6) by **kernel** `decide`

## Verification

- 128 lines, 7 theorems, 0 definitions, 0 sorries, 0 `axiom` declarations
- `#print axioms` on every named theorem: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`)
- Built with Lean v4.26.0 + Mathlib (docker unavailable; single-file elaboration against prebuilt oleans)
- Status: **verified**, badge **original**, 0 axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)