### PR TITLE
research(wilsons-theorem-oq-05-oq-01): complete trichotomy of (n-1)! mod n [0-axiom verified]

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ05OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ05OQ01.lean
@@ -1,0 +1,169 @@
+import Mathlib.NumberTheory.Wilson
+import Mathlib.Tactic
+
+/-
+# The complete trichotomy of `(n-1)! mod n`
+
+**Open Question (`wilsons-theorem-oq-05-oq-01`)**: assemble the *complete*
+classification of the residue `(n - 1)! mod n` for every `n ≥ 2`, in the
+classical natural-number form (no `ZMod`).  The parent entry
+`wilsons-theorem-oq-05` supplied the prime branch — Wilson's theorem as the
+remainder identity `(n - 1)! % n = n - 1 ⟺ n` prime.  What remains is the
+*composite* side, which Wilson's theorem leaves open, and which turns out to be
+governed by a single exception:
+
+  `(n - 1)! % n =  n - 1`   if `n` is prime,
+  `(n - 1)! % n =  2`       if `n = 4`,
+  `(n - 1)! % n =  0`       if `n` is composite and `n ≠ 4`.
+
+The mathematical content of the new (composite) case is the divisibility
+`n ∣ (n - 1)!` for composite `n ≠ 4`.  Writing `n = p·q` with `p = minFac n`
+its least prime factor and `q = n / p`:
+
+* if `p < q`, then `p` and `q` are *distinct* factors below `n`, so
+  `n = p·q ∣ (n-1)!`;
+* if `p = q`, then `n = p²` with `p ≥ 3` (the case `p = 2`, i.e. `n = 4`, is the
+  lone exception), and now `p` and `2p` are distinct factors below `n`, giving
+  `2n = p·(2p) ∣ (n-1)!`, hence `n ∣ (n-1)!`.
+
+The engine for "two distinct factors below `m` multiply into `m!`" is the small
+lemma `mul_dvd_factorial` (`0 < a → a < b → b ≤ m → a*b ∣ m!`), proved from
+`Nat.dvd_factorial` and `Nat.factorial_dvd_factorial`.
+
+Relation to the sibling `wilsons-theorem-oq-01`: that entry records the same
+classification, but valued in `ZMod n` and as a three-way disjunction, with the
+`n = 4` value discharged by `native_decide` (which depends on `Lean.ofReduceBool`).
+This entry instead gives the **ZMod-free natural-number remainder** as a single
+closed-form equation, and is **axiom-free** — the `n = 4` value is closed by
+ordinary kernel `decide`, so the only axioms are `propext`, `Classical.choice`,
+`Quot.sound`.
+
+Main results (all `ZMod`-free):
+
+* `mul_dvd_factorial` — distinct factors below `m` divide `m!`.
+* `dvd_factorial_pred_of_not_prime` — `2 ≤ n → ¬n.Prime → n ≠ 4 → n ∣ (n-1)!`.
+* `factorial_pred_mod_of_not_prime` — the composite residue is `0`.
+* `factorial_pred_mod` — **the trichotomy**, a single classification theorem.
+* `factorial_pred_mod_eq_zero_iff` — `(n-1)! % n = 0 ⟺ ¬n.Prime ∧ n ≠ 4`
+  (for `n ≥ 2`): the residue `0` detects "composite and not `4`" exactly.
+
+Fully machine-checked: `0` sorries, `0` axioms (the `n = 4` value is closed by
+`decide`, which is kernel-checked and does **not** invoke `native_decide`).
+-/
+
+namespace WilsonsTheoremOQ05OQ01
+
+open Nat
+open scoped Nat
+
+/-- Two *distinct* positive factors below `m` multiply into `m!`: if
+`0 < a < b ≤ m` then `a * b ∣ m !`.  Proof: `a ∣ (b-1)!` (as `a ≤ b-1`), so
+`a * b ∣ b * (b-1)! = b!`, and `b! ∣ m!` since `b ≤ m`. -/
+theorem mul_dvd_factorial {a b m : ℕ} (ha : 0 < a) (hab : a < b) (hbm : b ≤ m) :
+    a * b ∣ m ! := by
+  have hbfac : b ! = b * (b - 1)! := by
+    cases b with
+    | zero => exact absurd hab (Nat.not_lt_zero a)
+    | succ k => simp [Nat.factorial_succ]
+  obtain ⟨c, hc⟩ := Nat.dvd_factorial ha (show a ≤ b - 1 by omega)
+  have hab_dvd : a * b ∣ b ! := ⟨c, by rw [hbfac, hc]; ring⟩
+  exact dvd_trans hab_dvd (Nat.factorial_dvd_factorial hbm)
+
+/-- **Composite divisibility (the new content).**  For a composite `n ≥ 2` with
+`n ≠ 4`, the modulus divides the factorial: `n ∣ (n - 1)!`.  Equivalently, the
+classical Wilson remainder `(n-1)! % n` vanishes off the single exception
+`n = 4`. -/
+theorem dvd_factorial_pred_of_not_prime {n : ℕ} (h2 : 2 ≤ n) (hnp : ¬ Nat.Prime n)
+    (h4 : n ≠ 4) : n ∣ (n - 1)! := by
+  have hn1 : n ≠ 1 := by omega
+  have hp : (n.minFac).Prime := Nat.minFac_prime hn1
+  obtain ⟨q, hq⟩ := Nat.minFac_dvd n
+  set p := n.minFac with hp_def
+  have hp2 : 2 ≤ p := hp.two_le
+  -- `p = minFac n < n` because `n` is not prime.
+  have hp_lt : p < n := by
+    rcases (Nat.minFac_le (show 0 < n by omega)).lt_or_eq with h | h
+    · exact h
+    · exact absurd (Nat.prime_def_minFac.mpr ⟨h2, h⟩) hnp
+  -- the cofactor `q` is ≥ 2 (else `n` would be `0` or prime).
+  have hq2 : 2 ≤ q := by
+    rcases Nat.lt_or_ge q 2 with h | h
+    · exfalso; interval_cases q <;> omega
+    · exact h
+  have hq_dvd : q ∣ n := ⟨p, by rw [hq, mul_comm]⟩
+  -- `p` is the *least* prime factor, so `p ≤ q`.
+  have hpq_le : p ≤ q := by
+    have := Nat.minFac_le_of_dvd hq2 hq_dvd; rwa [← hp_def] at this
+  have hqn : q < n := by nlinarith [hq, hp2, hq2]
+  rcases hpq_le.lt_or_eq with hlt | heq
+  · -- distinct factors `p < q`, both `≤ n - 1`: `n = p*q ∣ (n-1)!`.
+    have hdvd := mul_dvd_factorial (show 0 < p by omega) hlt (show q ≤ n - 1 by omega)
+    rwa [← hq] at hdvd
+  · -- `n = p²`, and `p ≥ 3` since `n ≠ 4`: use the distinct factors `p < 2p`.
+    have hn_sq : n = p * p := by rw [hq, heq]
+    have hp3 : 3 ≤ p := by
+      by_contra h; push_neg at h
+      have hp_eq : p = 2 := by omega
+      rw [hp_eq] at hn_sq; omega
+    have h2p1 : 2 * p + 1 ≤ n := by nlinarith [hn_sq, hp3]
+    have hdvd := mul_dvd_factorial (show 0 < p by omega)
+      (show p < 2 * p by omega) (show 2 * p ≤ n - 1 by omega)
+    exact dvd_trans ⟨2, by rw [hn_sq]; ring⟩ hdvd
+
+/-- The composite branch as a remainder identity: for composite `n ≥ 2` with
+`n ≠ 4`, `(n - 1)! % n = 0`.  This is the `ZMod`-free counterpart, on the
+compositeness side, of the parent entry's prime remainder identity. -/
+theorem factorial_pred_mod_of_not_prime {n : ℕ} (h2 : 2 ≤ n) (hnp : ¬ Nat.Prime n)
+    (h4 : n ≠ 4) : (n - 1)! % n = 0 :=
+  Nat.dvd_iff_mod_eq_zero.mp (dvd_factorial_pred_of_not_prime h2 hnp h4)
+
+/-- Re-derivation of the prime branch (parent `wilsons-theorem-oq-05`), kept
+self-contained here: for a prime `n`, `(n - 1)! % n = n - 1`.  Transported from
+Mathlib's `ZMod`-valued Wilson biconditional via the identity
+`((n - 1 : ℕ) : ZMod n) = -1`. -/
+theorem factorial_pred_mod_of_prime {n : ℕ} (hp : Nat.Prime n) :
+    (n - 1)! % n = n - 1 := by
+  have hn1 : (1 : ℕ) ≤ n := hp.one_lt.le
+  have hcast : ((n - 1 : ℕ) : ZMod n) = -1 := by
+    rw [Nat.cast_sub hn1, Nat.cast_one, ZMod.natCast_self, zero_sub]
+  have hmod : (n - 1)! ≡ n - 1 [MOD n] := by
+    rw [← ZMod.natCast_eq_natCast_iff, hcast]
+    exact (Nat.prime_iff_fac_equiv_neg_one hp.ne_one).mp hp
+  rwa [Nat.ModEq, Nat.mod_eq_of_lt (show n - 1 < n by omega)] at hmod
+
+/-- **The complete trichotomy of `(n - 1)! mod n`.**  For every `n ≥ 2`, the
+classical Wilson remainder is determined by the arithmetic type of `n`:
+
+* `n - 1` when `n` is prime (Wilson's theorem),
+* `2` at the single exception `n = 4`,
+* `0` for every other (composite) `n`.
+
+A single classification theorem combining the prime branch (parent
+`wilsons-theorem-oq-05`) with the composite branch proved here. -/
+theorem factorial_pred_mod {n : ℕ} (hn : 2 ≤ n) :
+    (n - 1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0 := by
+  by_cases hp : n.Prime
+  · rw [if_pos hp]; exact factorial_pred_mod_of_prime hp
+  · rw [if_neg hp]
+    by_cases h4 : n = 4
+    · subst h4; rw [if_pos rfl]; decide
+    · rw [if_neg h4]; exact factorial_pred_mod_of_not_prime hn hp h4
+
+/-- The residue `0` characterizes "composite and not `4`" exactly: for `n ≥ 2`,
+`(n - 1)! % n = 0 ⟺ ¬ n.Prime ∧ n ≠ 4`.  (For a prime the residue is `n - 1 ≥ 1`,
+and for `n = 4` it is `2`; both are nonzero.) -/
+theorem factorial_pred_mod_eq_zero_iff {n : ℕ} (hn : 2 ≤ n) :
+    (n - 1)! % n = 0 ↔ ¬ Nat.Prime n ∧ n ≠ 4 := by
+  constructor
+  · intro h
+    refine ⟨fun hp => ?_, fun h4 => ?_⟩
+    · rw [factorial_pred_mod_of_prime hp] at h; omega
+    · subst h4; revert h; decide
+  · rintro ⟨hnp, h4⟩; exact factorial_pred_mod_of_not_prime hn hnp h4
+
+/-- The lone exceptional value, recorded explicitly: `(4 - 1)! % 4 = 2`.  This is
+the unique `n` at which the composite residue fails to vanish, because `4 = 2²`
+is too small for `2` and `2·2` to be *distinct* factors below `4`. -/
+theorem four_factorial_pred_mod : (4 - 1)! % 4 = 2 := by decide
+
+end WilsonsTheoremOQ05OQ01

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "wilsons-theorem-oq-05-oq-01",
+  "title": "The Complete Trichotomy of $(n-1)! \\bmod n$: Prime $\\Rightarrow n-1$, $n=4 \\Rightarrow 2$, Composite $\\Rightarrow 0$",
+  "slug": "wilsons-theorem-oq-05-oq-01",
+  "description": "Answers the first open question raised by the parent entry `wilsons-theorem-oq-05`: assemble the complete classification of the residue (n-1)! mod n for every n ≥ 2, in the classical natural-number form (no ZMod). Wilson's theorem pins the prime branch ((n-1)! % n = n-1 ⟺ n prime); this entry adds the composite side and packages all three cases as a single closed-form equation: `factorial_pred_mod` states (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0 for n ≥ 2. The mathematical content is the divisibility n ∣ (n-1)! for composite n ≠ 4 (`dvd_factorial_pred_of_not_prime`): writing n = p·q with p = minFac n and q = n/p, either p < q gives two distinct factors below n whose product is n, or p = q forces n = p² with p ≥ 3 (n = 4 the lone exception) where p and 2p are distinct factors below n with p² ∣ p·(2p). The engine `mul_dvd_factorial` (0 < a < b ≤ m ⟹ a·b ∣ m!) is proved from Nat.dvd_factorial and Nat.factorial_dvd_factorial. The sharp characterization `factorial_pred_mod_eq_zero_iff` shows the residue 0 detects 'composite and not 4' exactly. Relation to sibling `wilsons-theorem-oq-01`: that entry records the same classification valued in ZMod n as a three-way disjunction, with the n = 4 value closed by native_decide (which depends on Lean.ofReduceBool); this entry gives the ZMod-free natural-number remainder as a single equation and is axiom-free, the n = 4 value closed by ordinary kernel `decide`. Fully machine-checked: 0 sorries, 0 axioms (only the foundational propext, Classical.choice, Quot.sound; no decide on substantive results beyond the kernel-checked n = 4 value, no native_decide).",
+  "meta": {
+    "author": "Ibn al-Haytham (c. 1000); Wilson/Lagrange (1771); complete ℕ-remainder trichotomy formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Wilson%27s_theorem",
+    "date": "1771",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ05OQ01.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "primality",
+      "factorial",
+      "modular-arithmetic",
+      "classification",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 169,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Rests on Mathlib's `Nat.prime_iff_fac_equiv_neg_one` (the ZMod-valued Wilson biconditional, for the prime branch) and elementary divisibility/factorial lemmas (`Nat.dvd_factorial`, `Nat.factorial_dvd_factorial`, `Nat.minFac_prime`, `Nat.minFac_le_of_dvd`, `Nat.prime_def_minFac`). The single exceptional value (4-1)! % 4 = 2 is discharged by ordinary kernel `decide` (NOT `native_decide`), so the proof does not depend on `Lean.ofReduceBool`. The only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.prime_iff_fac_equiv_neg_one",
+        "description": "`n ≠ 1 → (Nat.Prime n ↔ ((n-1)! : ZMod n) = -1)`, Mathlib's ZMod-valued Wilson biconditional. Used (via the ℕ-cast bridge ((n-1 : ℕ) : ZMod n) = -1) to obtain the prime branch (n-1)! % n = n - 1.",
+        "module": "Mathlib.NumberTheory.Wilson"
+      },
+      {
+        "theorem": "Nat.dvd_factorial",
+        "description": "`0 < m → m ≤ n → m ∣ n!`. The base divisibility fact behind `mul_dvd_factorial`: the smaller factor a divides (b-1)!.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_dvd_factorial",
+        "description": "`m ≤ n → m! ∣ n!`, monotonicity of the factorial under divisibility; lifts a·b ∣ b! up to a·b ∣ (n-1)! once b ≤ n-1.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.minFac_prime / Nat.minFac_le_of_dvd / Nat.prime_def_minFac",
+        "description": "Least-prime-factor API: minFac n is prime (for n ≠ 1), it is ≤ any divisor ≥ 2 (giving p ≤ q), and n is prime iff 2 ≤ n and minFac n = n (giving the strict inequality p < n for composite n).",
+        "module": "Mathlib.Data.Nat.Prime.Defs"
+      },
+      {
+        "theorem": "Nat.dvd_iff_mod_eq_zero",
+        "description": "`k ∣ n ↔ n % k = 0`, converting the composite divisibility n ∣ (n-1)! into the remainder identity (n-1)! % n = 0.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "`factorial_pred_mod`: the complete trichotomy as a single closed-form equation — for n ≥ 2, (n-1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0. The ZMod-free natural-number form (the parent oq-05's stated goal), and a function rather than a three-way disjunction.",
+      "`dvd_factorial_pred_of_not_prime`: the composite divisibility n ∣ (n-1)! for composite n ≥ 2 with n ≠ 4 — the new mathematical content — via a uniform argument splitting on whether the least prime factor equals its cofactor (n = p² case) or is strictly smaller.",
+      "`mul_dvd_factorial`: the reusable engine `0 < a < b ≤ m → a·b ∣ m!` ('two distinct factors below m multiply into m!'), the combinatorial heart of the composite case.",
+      "`factorial_pred_mod_of_not_prime`: the composite branch as the ℕ remainder identity (n-1)! % n = 0.",
+      "`factorial_pred_mod_eq_zero_iff`: the sharp characterization — for n ≥ 2, (n-1)! % n = 0 ⟺ ¬n.Prime ∧ n ≠ 4 — so the vanishing residue detects 'composite and not 4' exactly.",
+      "Axiom-free packaging: unlike the sibling oq-01's ZMod disjunction, the n = 4 value is closed by ordinary kernel `decide`, keeping the entire classification free of `Lean.ofReduceBool`/`native_decide`."
+    ],
+    "prerequisites": [
+      "Wilson's theorem and its ZMod formulation",
+      "Least prime factor `Nat.minFac` and the prime/composite dichotomy",
+      "Factorials and divisibility (`Nat.dvd_factorial`, `Nat.factorial_dvd_factorial`)",
+      "Natural-number remainder `%` and `Nat.dvd_iff_mod_eq_zero`"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem-oq-05",
+        "relationship": "Parent: oq-05 gives Wilson's theorem in classical ℕ-congruence form (n prime ⟺ (n-1)! % n = n-1) and a compositeness witness ((n-1)! % n ≠ n-1 ⟹ ¬prime), but leaves open what the residue equals for composites. This entry answers the parent's first stated open question — the complete trichotomy — and re-derives the prime branch self-contained."
+      },
+      {
+        "id": "wilsons-theorem-oq-01",
+        "relationship": "Sibling: oq-01 records the same classification valued in ZMod n as a three-way disjunction, with the n = 4 case (and small examples) discharged by native_decide. This entry gives the ZMod-free ℕ-remainder as a single closed-form equation and is axiom-free (kernel `decide` for n = 4), trading the algebraic ZMod statement for the elementary remainder and a smaller trusted base."
+      },
+      {
+        "id": "wilsons-theorem-oq-03",
+        "relationship": "Sibling: oq-03 computes the p-adic valuation ν_p((p-1)!) = 0; this entry pins the exact remainder across all moduli, sharpening 'p ∤ (p-1)!' to the full value of (n-1)! mod n for prime, composite, and the exceptional n = 4."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 169,
+    "path": "Proofs/WilsonsTheoremOQ05OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Wilson's theorem — a natural number n > 1 is prime iff (n-1)! ≡ -1 (mod n) — was known to Ibn al-Haytham (c. 1000), stated by John Wilson, and first proved by Lagrange in 1771. The theorem characterizes the residue of (n-1)! modulo n only at primes; the composite side is folklore: for composite n the factorial (n-1)! collects enough small factors to be divisible by n, with the single exception n = 4 = 2² where the factor 2 appears only once in 3! = 6, leaving 6 ≡ 2 (mod 4). Pinning down the residue across all moduli — n-1 for primes, 0 for composite n ≠ 4, and 2 at n = 4 — gives the complete classical trichotomy of (n-1)! mod n. Mathlib carries Wilson's theorem in ZMod form; this entry assembles the full ℕ-remainder classification requested by the parent gallery entry.",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-05-oq-01):** assemble the complete trichotomy of (n-1)! mod n — ≡ n-1 for n prime, ≡ 0 for composite n > 4, and the exceptional ≡ 2 for n = 4 — as a single classification theorem in classical natural-number form, complementing the parent entry's prime-only criterion.",
+    "text": "For n ≥ 2, the remainder (n-1)! % n equals n-1 when n is prime, 2 when n = 4, and 0 for every other composite n. The three conditions are mutually exclusive and exhaustive, so the residue determines, and is determined by, the arithmetic type of n.",
+    "proofStrategy": "The prime branch is Wilson's theorem, transported from Mathlib's ZMod-valued biconditional to a ℕ remainder via the cast identity ((n-1 : ℕ) : ZMod n) = -1 (factorial_pred_mod_of_prime). The composite branch is the new content: dvd_factorial_pred_of_not_prime proves n ∣ (n-1)! for composite n ≠ 4. Set p = minFac n (prime, p < n since n is composite) and q = n/p (≥ 2). Since p is the least prime factor, p ≤ q. If p < q, then p and q are distinct factors with q ≤ n-1, and mul_dvd_factorial gives p·q = n ∣ (n-1)!. If p = q, then n = p²; because n ≠ 4 we have p ≠ 2, hence p ≥ 3, so 2p ≤ n-1 and the distinct factors p, 2p give p·(2p) ∣ (n-1)!, whence n = p² ∣ p·(2p) ∣ (n-1)!. Converting via Nat.dvd_iff_mod_eq_zero yields (n-1)! % n = 0. The trichotomy factorial_pred_mod assembles the three cases by by_cases on primality and on n = 4 (the n = 4 value by kernel decide). The engine mul_dvd_factorial proves 0 < a < b ≤ m → a·b ∣ m! from a ∣ (b-1)! and b! ∣ m!.",
+    "keyInsights": [
+      "**Two distinct factors below n multiply into (n-1)!.** The lemma mul_dvd_factorial isolates the combinatorial core: if 0 < a < b ≤ m then a·b ∣ m!, because a ∣ (b-1)! and a·b ∣ b·(b-1)! = b! ∣ m!. Distinctness (a ≠ b) is exactly what lets both factors be drawn from m! simultaneously.",
+      "**n = 4 is exceptional because it is too small to split.** Every composite n factors as a product of two numbers below n, but realizing both as *distinct* factors of (n-1)! fails only at n = 4: there 4 = 2·2, and 2 occurs just once in 3!. For n = p² with p ≥ 3 the substitute pair (p, 2p) restores distinctness, and for n with two different prime factors the pair (minFac, cofactor) works directly.",
+      "**The least prime factor organizes the whole composite case.** Taking p = minFac n guarantees p prime, p < n, and p ≤ q = n/p, which is precisely the structure needed to decide between the 'two distinct prime-type factors' case and the 'perfect square of a prime' case.",
+      "**ZMod-free and axiom-free.** Stating the result as the ℕ remainder (n-1)! % n and closing the single sporadic value with kernel decide keeps the classification free of ZMod and of Lean.ofReduceBool — strictly smaller trusted base than the sibling oq-01's ZMod disjunction with native_decide."
+    ],
+    "prerequisites": [
+      "Wilson's theorem (ZMod form) and Nat.prime_iff_fac_equiv_neg_one",
+      "Least prime factor Nat.minFac and prime/composite structure",
+      "Factorials and the divisibility lemmas Nat.dvd_factorial, Nat.factorial_dvd_factorial",
+      "Natural-number remainder % and Nat.dvd_iff_mod_eq_zero"
+    ]
+  },
+  "conclusion": {
+    "summary": "The residue of (n-1)! modulo n is completely classified for all n ≥ 2: it equals n-1 exactly for primes (Wilson), takes the sporadic value 2 at n = 4, and vanishes for every other composite. The classification is packaged as a single ZMod-free closed-form equation factorial_pred_mod, with the sharp converse factorial_pred_mod_eq_zero_iff identifying the vanishing case as 'composite and not 4'. 7 theorems, 169 lines, 0 sorries, 0 axioms (kernel decide for the n = 4 value; no native_decide).",
+    "implications": "Completes the parent oq-05's prime-only criterion into the full trichotomy in elementary form, directly usable in ℕ-level number theory without ZMod. Combined with the sibling oq-01 (the equivalent ZMod disjunction), the gallery now carries both the algebraic and the elementary, axiom-free statements of the same classification. The reusable engine mul_dvd_factorial ('distinct factors below m divide m!') is generally useful for composite-divisibility arguments.",
+    "openQuestions": [
+      "Promote factorial_pred_mod to a genuine Decidable-instance-flavored primality certificate and benchmark the (exponential) cost of the factorial-remainder test against Lucas/Pratt certificates.",
+      "State the analogous trichotomy for the double factorial or for ∏_{k<n, gcd(k,n)=1} k (the Gauss–Wilson product over units), classifying its residue by the structure of (ℤ/nℤ)ˣ."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Module docstring stating the trichotomy, the composite-case strategy (minFac split, the n = 4 exception, the (p, 2p) substitute pair), the relation to sibling oq-01 (ZMod disjunction with native_decide vs this entry's ZMod-free axiom-free remainder), and the result list; imports Mathlib.NumberTheory.Wilson and Mathlib.Tactic, opens Nat and scoped Nat."
+    },
+    {
+      "id": "engine",
+      "title": "The Engine: Distinct Factors Multiply into the Factorial",
+      "startLine": 62,
+      "endLine": 75,
+      "summary": "mul_dvd_factorial: 0 < a < b ≤ m → a·b ∣ m!. Proof writes b! = b·(b-1)!, uses Nat.dvd_factorial to get a ∣ (b-1)! (as a ≤ b-1), assembles a·b ∣ b!, and lifts via Nat.factorial_dvd_factorial since b ≤ m."
+    },
+    {
+      "id": "composite",
+      "title": "The Composite Case: n ∣ (n-1)! for Composite n ≠ 4",
+      "startLine": 76,
+      "endLine": 123,
+      "summary": "dvd_factorial_pred_of_not_prime sets p = minFac n (prime, p < n via Nat.prime_def_minFac), q = n/p (≥ 2), proves p ≤ q from Nat.minFac_le_of_dvd, then splits: p < q uses the distinct pair (p, q) with p·q = n; p = q gives n = p² with p ≥ 3 (excluding 4) and uses the distinct pair (p, 2p) with p² ∣ p·(2p). factorial_pred_mod_of_not_prime converts to (n-1)! % n = 0."
+    },
+    {
+      "id": "trichotomy",
+      "title": "The Prime Branch and the Complete Trichotomy",
+      "startLine": 124,
+      "endLine": 169,
+      "summary": "factorial_pred_mod_of_prime transports Mathlib's ZMod Wilson statement to (n-1)! % n = n-1 via the cast ((n-1 : ℕ) : ZMod n) = -1. factorial_pred_mod bundles all three cases as (n-1)! % n = if n.Prime then n-1 else if n = 4 then 2 else 0 (n = 4 by kernel decide). factorial_pred_mod_eq_zero_iff characterizes the vanishing residue, and four_factorial_pred_mod records (4-1)! % 4 = 2 explicitly."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-05",
+      "relationship": "parent",
+      "description": "The parent entry states Wilson's theorem in classical ℕ-congruence form and supplies a compositeness witness but leaves the composite residue open. This entry answers its first stated open question with the complete trichotomy of (n-1)! mod n."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "oq-01 records the same classification valued in ZMod n as a three-way disjunction with the n = 4 value by native_decide. This entry gives the ZMod-free ℕ remainder as a single closed-form equation and is axiom-free (kernel decide for n = 4)."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-03",
+      "relationship": "sibling",
+      "description": "oq-03 computes ν_p((p-1)!) = 0; this entry pins the exact remainder of (n-1)! mod n across prime, composite, and the exceptional n = 4 cases."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** raised by the parent entry `wilsons-theorem-oq-05`: assemble the *complete* classification of the residue `(n-1)! mod n` for every `n ≥ 2`, in classical natural-number form (no `ZMod`), as a single closed-form equation.

**Headline** (`factorial_pred_mod`, for `n ≥ 2`):
```
(n-1)! % n = if n.Prime then n - 1 else if n = 4 then 2 else 0
```

| n | (n-1)! % n |
|---|------------|
| prime | `n - 1` (Wilson) |
| `4` | `2` (the lone exception, `3! = 6 ≡ 2`) |
| composite, `≠ 4` | `0` |

## New mathematical content

The composite side, which Wilson's theorem leaves open:
- `dvd_factorial_pred_of_not_prime` — composite `n ≥ 2`, `n ≠ 4` ⟹ `n ∣ (n-1)!`. Set `p = minFac n` (prime, `p < n`) and `q = n/p` (`≥ 2`, `p ≤ q`). If `p < q`, the distinct factors `p, q` give `p·q = n ∣ (n-1)!`; if `p = q` then `n = p²` with `p ≥ 3` (excluding `4`), and the distinct factors `p, 2p` give `p² ∣ p·(2p) ∣ (n-1)!`.
- `mul_dvd_factorial` — reusable engine: `0 < a < b ≤ m ⟹ a·b ∣ m!`.
- `factorial_pred_mod_eq_zero_iff` — sharp converse: for `n ≥ 2`, `(n-1)! % n = 0 ⟺ ¬n.Prime ∧ n ≠ 4`.

## Relation to sibling `wilsons-theorem-oq-01`

oq-01 records the same classification **valued in `ZMod n`, as a three-way disjunction**, with the `n = 4` case discharged by `native_decide` (which depends on `Lean.ofReduceBool`). This entry instead gives the **ZMod-free ℕ-remainder** as a single equation and is **axiom-free** — `n = 4` closed by ordinary kernel `decide`. Smaller trusted base, elementary statement; complementary to the algebraic form.

## Verification

- 169 lines, **7 theorems, 0 definitions, 0 sorries, 0 axioms**
- `#print axioms` → `propext, Classical.choice, Quot.sound` only (no `sorryAx`, no `Lean.ofReduceBool`); `four_factorial_pred_mod` depends on **no axioms**
- Built with Lean v4.26.0 + Mathlib

Files: `proofs/Proofs/WilsonsTheoremOQ05OQ01.lean`, `src/data/proofs/wilsons-theorem-oq-05-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)