### PR TITLE
audit: record 3 abel-ruffini deep siblings clean (re-record post-revert of #27891)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17732,6 +17732,24 @@
       "lastAudited": "2026-06-23T00:00:00Z",
       "result": "clean"
     },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-23T08:28:57Z",
+      "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-23T08:28:57Z",
+      "result": "clean"
+    },
+    "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-23T08:28:57Z",
+      "result": "clean"
+    },
     "algebraic-numbers-countable-oq-07": {
       "auditCount": 1,
       "lastAudited": "2026-06-23T03:36:20Z",


### PR DESCRIPTION
## Gallery Integrity Audit — re-record clean siblings

The ×5/×6/×7 trailing-`oq-01` siblings of the `abel-ruffini-oq-04-oq-02-oq-02-oq-08` deep chain are clean and verified, but their audit-tracker records were lost when **PR #27899** reverted the destructive **PR #27891** (see issue #27898). PR #27891 had recorded these 3 siblings *in the same commit that deleted the entire repository*, so the revert correctly removed everything — including these legitimate tracker entries.

This PR re-records them via a **safe surgical single-file edit** (full worktree, only `audit-tracker.json` staged, 18 insertions / 0 deletions — the exact safety check that #27891 lacked).

### Audit results (all clean)

| Slug | status / badge | Lean | sorry | axiom | nd | thm |
|------|----------------|------|-------|-------|----|----|
| `…-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01` (×5) | verified / mathlib | 205 L | 0 | 0 | 0 | 10 |
| `…-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` (×6) | verified / mathlib | 218 L | 0 | 0 | 0 | 8 |
| `…-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` (×7) | verified / mathlib | 188 L | 0 | 0 | 0 | 8 |

Tier B (Mathlib-derived), no overclaims. Gallery-wide scan this cycle: **1362 verified, 0 overclaims, 0 missing-lean, 0 named native_decide** (53 nd-files all anonymous `example` blocks).

---
Discovered during gallery integrity audit.