### PR TITLE
research(cauchy-group-theorem-oq-01-oq-01-oq-01): power-map dichotomy — x ↦ xⁿ bijective ⟺ gcd(n,|G|)=1 [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -511,6 +511,7 @@ import Proofs.CarnotTheorem
 import Proofs.CatalanNumbersOQ01
 import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
+import Proofs.CauchyGroupTheoremOQ01OQ01OQ01
 import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral

--- a/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,160 @@
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.GroupTheory.Perm.Cycle.Type
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.Tactic
+
+/-
+# The power-map dichotomy: `x ↦ xⁿ` is a bijection iff `gcd(n, |G|) = 1`
+
+## What This Proves
+
+For a finite group `G` and an exponent `n : ℕ`, the `n`-th power map
+`x ↦ xⁿ : G → G` is a bijection **if and only if** `n` is coprime to the
+order of `G`:
+
+```
+Function.Bijective (· ^ n : G → G)  ↔  (Nat.card G).Coprime n
+```
+
+This is the exact uniform threshold governing when raising to a power permutes
+a finite group, and it sharpens the parent file `CauchyGroupTheoremOQ01OQ01`
+(which handles only the squaring case `n = 2`: squaring is a bijection iff the
+order is odd) into the full statement for every exponent.
+
+### The two directions
+
+* **Coprime ⟹ bijection** (`pow_left_bijective_of_coprime`). This is the easy
+  half and is already in Mathlib as `Nat.Coprime.pow_left_bijective`: if
+  `gcd(n,|G|)=1`, Bézout gives integers `a, b` with `an + b|G| = 1`, so
+  `x ↦ x ^ a` inverts `x ↦ x ^ n` (using `x ^ |G| = 1`). Notably this works for
+  *every* finite group, abelian or not — the inverse is again a power map.
+
+* **Bijection ⟹ coprime** (`not_injective_pow_of_not_coprime`). This is the
+  content of the file. We prove the contrapositive: if `gcd(n,|G|) ≠ 1`, pick a
+  prime `p` dividing the gcd (its `minFac`). Then `p ∣ |G|`, so **Cauchy's
+  theorem** (`exists_prime_orderOf_dvd_card'`) produces an element `g` of order
+  exactly `p`. Since also `p ∣ n` we have `gⁿ = 1 = 1ⁿ` while `g ≠ 1`, so the
+  power map collapses two points — it is not injective, hence not a bijection.
+
+### Consequences packaged here
+
+* **Headline equivalence** (`pow_bijective_iff_coprime`).
+* **Injective / surjective forms** (`pow_injective_iff_coprime`,
+  `pow_surjective_iff_coprime`): on a finite group injectivity, surjectivity and
+  bijectivity of the power map all coincide and are each equivalent to
+  coprimality (`Finite.injective_iff_surjective`).
+* **Recovering the parent** (`sq_bijective_iff_odd_card`): the `n = 2`
+  specialisation, `x ↦ x²` is a bijection iff `|G|` is odd, via
+  `Nat.coprime_two_right`. The parent's odd-order squaring result is exactly
+  this slice.
+* **Concrete instances on the symmetric group** (`card_perm_fin3`,
+  `pow5_bijective_perm_fin3`, `pow2_not_bijective_perm_fin3`): on
+  `Equiv.Perm (Fin 3)` (order `6`), the fifth-power map is a bijection
+  (`gcd(5,6)=1`) while squaring is not (`gcd(2,6)=2`). Coprimality is decided by
+  `decide` on `Nat.gcd` — no `native_decide`, so the file stays genuinely
+  `0`-axiom.
+
+## Context
+
+Cauchy's theorem detects a prime divisor `p` of `|G|` by producing an element
+of order `p`. That single element is exactly the obstruction to the power map
+`x ↦ x^p` being injective. Quantifying over all prime divisors of `gcd(n,|G|)`
+turns Cauchy's existence statement into the sharp iff above. The result is the
+multiplicative analogue of "multiplication by `n` is invertible mod `m` iff
+`gcd(n,m)=1`", and it is the structural fact behind RSA-style exponentiation in
+finite abelian groups.
+-/
+
+namespace CauchyGroupTheoremOQ01OQ01OQ01
+
+open Function
+
+variable {G : Type*} [Group G]
+
+/-- **Easy direction** (Mathlib's `Nat.Coprime.pow_left_bijective`): if `n` is
+coprime to `|G|`, the `n`-th power map is a bijection. Recorded here under a
+descriptive name. -/
+theorem pow_left_bijective_of_coprime [Finite G] {n : ℕ}
+    (h : (Nat.card G).Coprime n) : Bijective (· ^ n : G → G) :=
+  h.pow_left_bijective
+
+/-- **Hard direction (contrapositive).** If `n` is *not* coprime to `|G|`, the
+`n`-th power map fails to be injective: a prime `p ∣ gcd(n,|G|)` produces, via
+Cauchy's theorem, an element of order `p` that the map sends to `1` alongside
+`1` itself. -/
+theorem not_injective_pow_of_not_coprime [Finite G] {n : ℕ}
+    (h : ¬ (Nat.card G).Coprime n) : ¬ Injective (· ^ n : G → G) := by
+  -- `gcd(|G|, n) ≠ 1`, so it has a prime factor `p := minFac`.
+  have hd1 : (Nat.card G).gcd n ≠ 1 := h
+  set p := ((Nat.card G).gcd n).minFac with hp
+  have hpp : p.Prime := Nat.minFac_prime hd1
+  have hdvd : p ∣ (Nat.card G).gcd n := Nat.minFac_dvd _
+  have hpG : p ∣ Nat.card G := hdvd.trans (Nat.gcd_dvd_left _ _)
+  have hpn : p ∣ n := hdvd.trans (Nat.gcd_dvd_right _ _)
+  haveI : Fact p.Prime := ⟨hpp⟩
+  -- Cauchy: an element `g` of order exactly `p`.
+  obtain ⟨g, hg⟩ := exists_prime_orderOf_dvd_card' p hpG
+  -- `p ∣ n` and `orderOf g = p` give `gⁿ = 1`.
+  have hon : orderOf g ∣ n := by rw [hg]; exact hpn
+  have hgn : g ^ n = 1 := orderOf_dvd_iff_pow_eq_one.mp hon
+  -- `g ≠ 1` because `orderOf g = p ≥ 2`.
+  have hgne : g ≠ 1 := by
+    rintro rfl
+    rw [orderOf_one] at hg
+    exact hpp.ne_one hg.symm
+  -- The map sends both `g` and `1` to `1`.
+  intro hinj
+  exact hgne (hinj (show g ^ n = (1 : G) ^ n by simp [hgn]))
+
+/-- **The power-map dichotomy.** On a finite group, `x ↦ xⁿ` is a bijection iff
+`n` is coprime to the order of the group. -/
+theorem pow_bijective_iff_coprime [Finite G] (n : ℕ) :
+    Bijective (· ^ n : G → G) ↔ (Nat.card G).Coprime n := by
+  constructor
+  · intro hbij
+    by_contra hc
+    exact not_injective_pow_of_not_coprime hc hbij.injective
+  · exact pow_left_bijective_of_coprime
+
+/-- Injective form: on a finite group injectivity of the power map already forces
+coprimality (and conversely). -/
+theorem pow_injective_iff_coprime [Finite G] (n : ℕ) :
+    Injective (· ^ n : G → G) ↔ (Nat.card G).Coprime n := by
+  rw [← pow_bijective_iff_coprime]
+  exact ⟨fun hinj => ⟨hinj, Finite.injective_iff_surjective.mp hinj⟩, Bijective.injective⟩
+
+/-- Surjective form: on a finite group surjectivity of the power map already
+forces coprimality (and conversely). -/
+theorem pow_surjective_iff_coprime [Finite G] (n : ℕ) :
+    Surjective (· ^ n : G → G) ↔ (Nat.card G).Coprime n := by
+  rw [← pow_bijective_iff_coprime]
+  exact ⟨fun hsurj => ⟨Finite.injective_iff_surjective.mpr hsurj, hsurj⟩,
+    Bijective.surjective⟩
+
+/-- **Recovering the parent (`n = 2`).** Squaring is a bijection iff the order of
+the group is odd — the `n = 2` slice of `pow_bijective_iff_coprime`, matching
+`CauchyGroupTheoremOQ01OQ01`. -/
+theorem sq_bijective_iff_odd_card [Finite G] :
+    Bijective (· ^ 2 : G → G) ↔ Odd (Nat.card G) := by
+  rw [pow_bijective_iff_coprime, Nat.coprime_two_right]
+
+/-- The symmetric group on three letters has order `6`. -/
+theorem card_perm_fin3 : Nat.card (Equiv.Perm (Fin 3)) = 6 := by
+  rw [Nat.card_eq_fintype_card, Fintype.card_perm, Fintype.card_fin]; rfl
+
+/-- Concrete bijection: on `S₃` (order `6`), the fifth-power map is a bijection,
+since `gcd(5, 6) = 1`. -/
+theorem pow5_bijective_perm_fin3 :
+    Bijective (· ^ 5 : Equiv.Perm (Fin 3) → Equiv.Perm (Fin 3)) := by
+  rw [pow_bijective_iff_coprime, card_perm_fin3]
+  decide
+
+/-- Concrete failure: on `S₃` (order `6`), squaring is *not* a bijection, since
+`gcd(2, 6) = 2 ≠ 1`. (Indeed every transposition squares to `1`.) -/
+theorem pow2_not_bijective_perm_fin3 :
+    ¬ Bijective (· ^ 2 : Equiv.Perm (Fin 3) → Equiv.Perm (Fin 3)) := by
+  rw [pow_bijective_iff_coprime, card_perm_fin3]
+  decide
+
+end CauchyGroupTheoremOQ01OQ01OQ01

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "easy-direction",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 75, "endLine": 80 },
+    "type": "theorem",
+    "title": "Coprime ⟹ Bijection (Easy Direction)",
+    "content": "`pow_left_bijective_of_coprime` records the easy half, supplied directly by Mathlib's `Nat.Coprime.pow_left_bijective`. If gcd(n, |G|) = 1, Bézout produces integers a, b with a·n + b·|G| = 1, and then x ↦ xᵃ inverts x ↦ xⁿ using x^|G| = 1 (Lagrange). The inverse is itself a power map, so this direction holds for every finite group — abelian or not.",
+    "mathContext": "If $\\gcd(n,|G|)=1$, choose $a,b$ with $an+b|G|=1$. Then $(x^n)^a = x^{an} = x^{1-b|G|} = x\\cdot (x^{|G|})^{-b} = x$, so $x\\mapsto x^a$ is a two-sided inverse of $x\\mapsto x^n$.",
+    "significance": "important",
+    "relatedConcepts": ["Bézout's identity", "Lagrange's theorem", "coprime exponents", "power map"],
+    "prerequisites": ["finite group theory", "greatest common divisor"]
+  },
+  {
+    "id": "hard-direction",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 109 },
+    "type": "theorem",
+    "title": "Non-Coprime ⟹ Not Injective (via Cauchy)",
+    "content": "`not_injective_pow_of_not_coprime` is the substantive converse, proved by contrapositive. If gcd(n, |G|) ≠ 1, take p = minFac of the gcd, prime by `Nat.minFac_prime`; then p ∣ |G| and p ∣ n. Cauchy's theorem (`exists_prime_orderOf_dvd_card'`) produces g with orderOf g = p, so orderOf g ∣ n gives gⁿ = 1 = 1ⁿ while g ≠ 1 (since orderOf g = p ≥ 2). The power map collapses two distinct points, so it is not injective.",
+    "mathContext": "If $p\\mid\\gcd(n,|G|)$ is prime, Cauchy gives $g$ with $\\operatorname{ord}(g)=p$. Then $g^n=1=1^n$ but $g\\neq 1$, so $x\\mapsto x^n$ is not injective.",
+    "significance": "critical",
+    "relatedConcepts": ["Cauchy's theorem", "order of an element", "minimal prime factor", "injectivity"],
+    "prerequisites": ["Cauchy's theorem", "order of an element"]
+  },
+  {
+    "id": "headline-iff",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 110, "endLine": 118 },
+    "type": "theorem",
+    "title": "The Power-Map Dichotomy",
+    "content": "`pow_bijective_iff_coprime` is the headline equivalence: on a finite group, x ↦ xⁿ is a bijection if and only if gcd(n, |G|) = 1. The forward direction is the contrapositive of the hard lemma (a non-coprime exponent breaks injectivity), the backward direction is the easy Bézout inverse. This is the full uniform threshold answering the parent entry's lead open question.",
+    "mathContext": "$\\operatorname{Bijective}(x\\mapsto x^n) \\iff \\gcd(n,|G|)=1$ for a finite group $G$.",
+    "significance": "critical",
+    "relatedConcepts": ["bijection", "coprime exponents", "Cauchy's theorem", "finite groups"],
+    "prerequisites": ["finite group theory"]
+  },
+  {
+    "id": "inj-surj-forms",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 120, "endLine": 134 },
+    "type": "theorem",
+    "title": "Injective and Surjective Forms Coincide",
+    "content": "`pow_injective_iff_coprime` and `pow_surjective_iff_coprime` show that on a finite group injectivity, surjectivity and bijectivity of the power map are all equivalent to coprimality. The collapse uses `Finite.injective_iff_surjective`: a self-map of a finite type is injective iff surjective, so the seemingly weaker hypotheses already force gcd(n, |G|) = 1.",
+    "mathContext": "On a finite group: $\\operatorname{Injective}(\\cdot^n)\\iff\\operatorname{Surjective}(\\cdot^n)\\iff\\operatorname{Bijective}(\\cdot^n)\\iff\\gcd(n,|G|)=1$.",
+    "significance": "important",
+    "relatedConcepts": ["pigeonhole principle", "finite self-maps", "injectivity", "surjectivity"],
+    "prerequisites": ["finite group theory"]
+  },
+  {
+    "id": "recover-parent",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 135, "endLine": 140 },
+    "type": "theorem",
+    "title": "Recovering the Parent (n = 2)",
+    "content": "`sq_bijective_iff_odd_card` is the n = 2 slice: squaring is a bijection iff |G| is odd, obtained from the headline iff via `Nat.coprime_two_right` (n coprime to 2 ⟺ n odd). This recovers exactly the parent entry CauchyGroupTheoremOQ01OQ01, exhibiting the odd-order squaring boundary as one slice of the uniform threshold.",
+    "mathContext": "Taking $n=2$: $\\operatorname{Bijective}(x\\mapsto x^2)\\iff\\gcd(2,|G|)=1\\iff |G|\\text{ odd}$.",
+    "significance": "important",
+    "relatedConcepts": ["squaring map", "odd order", "specialization", "involutions"],
+    "prerequisites": ["finite group theory"]
+  },
+  {
+    "id": "s3-witnesses",
+    "proofId": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 142, "endLine": 159 },
+    "type": "theorem",
+    "title": "Concrete Witnesses on S₃ (0-axiom)",
+    "content": "`card_perm_fin3` computes |S₃| = 3! = 6. `pow5_bijective_perm_fin3` then shows x ↦ x⁵ is a bijection on S₃ (gcd 5, 6 = 1), while `pow2_not_bijective_perm_fin3` shows squaring is not (gcd 2, 6 = 2; indeed every transposition squares to 1). Coprimality is decided by kernel `decide` on Nat.gcd — not native_decide — so the entry avoids the Lean.ofReduceBool axiom and stays genuinely 0-axiom.",
+    "mathContext": "On $S_3$ ($|S_3|=6$): $x\\mapsto x^5$ is a bijection since $\\gcd(5,6)=1$, but $x\\mapsto x^2$ is not since $\\gcd(2,6)=2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetric group", "decidability", "axiom hygiene", "concrete instances"],
+    "prerequisites": ["symmetric groups", "decidable propositions"]
+  }
+]

--- a/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-group-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+  "title": "The power-map dichotomy: x ↦ xⁿ is a bijection iff gcd(n, |G|) = 1",
+  "slug": "cauchy-group-theorem-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.OrderOfElement",
+      "Mathlib.GroupTheory.Perm.Cycle.Type",
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.ZMod.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Function"],
+    "namespace": "CauchyGroupTheoremOQ01OQ01OQ01",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Answers the parent entry's lead open question by characterizing exactly when raising to a fixed power permutes a finite group: for a finite group G and exponent n, the map x ↦ xⁿ is a bijection if and only if gcd(n, |G|) = 1. The easy direction (coprime ⟹ bijection) is Mathlib's Nat.Coprime.pow_left_bijective, whose inverse is again a power map x ↦ xᵃ obtained from Bézout. The substantive converse is proved by contrapositive: if gcd(n, |G|) ≠ 1, pick a prime p = minFac dividing it; Cauchy's theorem (exists_prime_orderOf_dvd_card') produces an element g of order exactly p, and since p ∣ n we get gⁿ = 1 = 1ⁿ with g ≠ 1, so the map is not injective. On a finite group injectivity, surjectivity and bijectivity of the power map coincide (Finite.injective_iff_surjective), so all three are equivalent to coprimality. The n = 2 slice recovers the parent (squaring is a bijection iff |G| is odd), and concrete 0-axiom witnesses on S₃ (order 6) show the fifth-power map is a bijection while squaring is not — coprimality decided by kernel decide, no native_decide.",
+  "overview": {
+    "historicalContext": "Cauchy's 1845 theorem detects a prime divisor p of |G| by producing an element of order p. That element is precisely the obstruction to the power map x ↦ xᵖ being injective, so quantifying Cauchy over all prime divisors of gcd(n, |G|) turns an existence statement into a sharp characterization of when x ↦ xⁿ permutes the group. The result is the multiplicative analogue of the elementary fact that multiplication by n is invertible modulo m iff gcd(n, m) = 1, and it is the structural reason exponentiation maps (as in RSA over finite abelian groups, or the regular elements of a finite group) are bijective exactly in the coprime regime. The parent entry CauchyGroupTheoremOQ01OQ01 isolated the n = 2 case — squaring is a bijection iff the order is odd — and explicitly posed the general statement as its first open question; this entry settles it for every exponent.",
+    "problemStatement": "Characterize, for a finite group G and a natural number n, exactly when the n-th power map x ↦ xⁿ : G → G is a bijection. Prove the dichotomy: it is a bijection if and only if n is coprime to the order |G| of the group, and deduce that injectivity, surjectivity and bijectivity of the power map are mutually equivalent on a finite group.",
+    "proofStrategy": "Split into the two implications. Coprime ⟹ bijection is supplied directly by Mathlib's Nat.Coprime.pow_left_bijective: Bézout gives a, b with an + b|G| = 1, so x ↦ xᵃ inverts x ↦ xⁿ using x^|G| = 1; the inverse is itself a power map, so the argument is valid for non-abelian groups. The converse is the contrapositive: assuming gcd(n, |G|) ≠ 1, let p be its minFac (a prime by Nat.minFac_prime); then p ∣ |G| and p ∣ n. Cauchy (exists_prime_orderOf_dvd_card') yields g with orderOf g = p, so orderOf g ∣ n gives gⁿ = 1 (orderOf_dvd_iff_pow_eq_one) while g ≠ 1 since orderOf g = p ≥ 2 — two distinct points with the same image, defeating injectivity. Finiteness (Finite.injective_iff_surjective) collapses the injective, surjective and bijective forms into one. Specializing n = 2 with Nat.coprime_two_right recovers the parent's odd-order squaring result, and S₃ witnesses use kernel decide on Nat.gcd to stay 0-axiom.",
+    "keyInsights": [
+      "A single element of order p — the output of Cauchy's theorem — is the entire obstruction to injectivity of x ↦ xᵖ; the power map collapses it onto the identity. Coprimality is exactly the absence of every such obstruction.",
+      "The dichotomy is sharp and symmetric: the coprime side is constructive (the inverse is the explicit power map x ↦ xᵃ from Bézout), the non-coprime side is destructive (Cauchy hands back a concrete collision), so the iff is witnessed in both directions.",
+      "On a finite group the three notions injective / surjective / bijective for a self-map coincide by pigeonhole, so the seemingly weaker 'x ↦ xⁿ is injective' already forces coprimality — there is no room between the conditions.",
+      "Setting n = 2 reduces to gcd(2, |G|) = 1 ⟺ |G| odd, recovering the parent entry exactly; the general theorem subsumes the squaring boundary as one slice of a uniform threshold over all n.",
+      "Axiom hygiene is preserved: the concrete S₃ witnesses decide gcd(5,6)=1 and gcd(2,6)≠1 with kernel decide, avoiding Lean.ofReduceBool, so the entry is genuinely 0-axiom."
+    ]
+  },
+  "sections": [
+    {
+      "id": "directions",
+      "title": "The Two Directions of the Dichotomy",
+      "startLine": 76,
+      "endLine": 110,
+      "summary": "pow_left_bijective_of_coprime records the easy half (Mathlib's Nat.Coprime.pow_left_bijective). not_injective_pow_of_not_coprime proves the substantive converse by contrapositive: a prime p = minFac(gcd(n,|G|)) yields, via Cauchy, an element of order p that the map sends to 1 alongside 1, breaking injectivity.",
+      "mathContext": "gcd(n,|G|)=1 ⟹ bijection (Bézout inverse); gcd(n,|G|)≠1 ⟹ a Cauchy element of order p∣gcd collides with 1."
+    },
+    {
+      "id": "equivalences",
+      "title": "Headline Iff and Injective/Surjective Forms",
+      "startLine": 111,
+      "endLine": 136,
+      "summary": "pow_bijective_iff_coprime is the headline equivalence. pow_injective_iff_coprime and pow_surjective_iff_coprime use Finite.injective_iff_surjective to show that on a finite group injectivity, surjectivity and bijectivity of the power map are all equivalent to coprimality.",
+      "mathContext": "On a finite group: Injective(·ⁿ) ⟺ Surjective(·ⁿ) ⟺ Bijective(·ⁿ) ⟺ (|G|).Coprime n."
+    },
+    {
+      "id": "specializations",
+      "title": "Recovering the Parent and Concrete Witnesses",
+      "startLine": 137,
+      "endLine": 160,
+      "summary": "sq_bijective_iff_odd_card is the n = 2 slice (squaring is a bijection iff |G| is odd) via Nat.coprime_two_right, recovering CauchyGroupTheoremOQ01OQ01. card_perm_fin3, pow5_bijective_perm_fin3 and pow2_not_bijective_perm_fin3 instantiate on S₃ (order 6): the fifth-power map is a bijection, squaring is not, decided by kernel decide.",
+      "mathContext": "n=2: bijection ⟺ |G| odd. On S₃ (|G|=6): x↦x⁵ bijective (gcd 5,6=1), x↦x² not (gcd 2,6=2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The bijectivity of the n-th power map on a finite group is governed by a single arithmetic condition: x ↦ xⁿ permutes G if and only if gcd(n, |G|) = 1. The coprime direction is Mathlib's Bézout-based power inverse; the converse extracts, from any common prime factor of n and |G|, a Cauchy element of that prime order that the map collapses onto the identity. Finiteness makes injectivity, surjectivity and bijectivity interchangeable, the n = 2 slice recovers the parent's odd-order squaring boundary, and 0-axiom S₃ witnesses make the threshold concrete.",
+    "implications": [
+      "Settles the parent entry's lead open question, upgrading the n = 2 squaring boundary to the full uniform threshold over every exponent n.",
+      "Exhibits Cauchy's theorem as the exact engine of the converse: each prime divisor of gcd(n, |G|) furnishes a concrete injectivity-breaking collision, so coprimality is precisely the absence of all of them.",
+      "Provides the finite-group form of 'exponentiation by n is invertible iff gcd(n, order) = 1', the structural fact underlying power/regular-element maps and exponentiation cryptography over finite abelian groups."
+    ],
+    "openQuestions": [
+      "When x ↦ xⁿ fails to be a bijection, what is the exact size of its image and fibers in terms of the p-parts of |G| for primes p ∣ gcd(n, |G|)?",
+      "For which finite groups is the power-map inverse on the coprime regime realized by a single uniform exponent independent of the element (always true here via Bézout), and how does the minimal such exponent relate to the group exponent?",
+      "Does an analogous coprime-exponent characterization hold for the n-th power map on a finite monoid or on the regular elements of a finite semigroup, where Cauchy's theorem is unavailable?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-group-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Generalizes the parent's n = 2 result (squaring is a bijection iff |G| is odd) to arbitrary exponents, directly answering its lead open question; sq_bijective_iff_odd_card recovers the parent as the n = 2 slice."
+    },
+    {
+      "targetId": "cauchy-group-theorem-oq-01",
+      "relationship": "uses",
+      "description": "Cauchy's theorem (exists_prime_orderOf_dvd_card') is the engine of the converse direction: a prime divisor of gcd(n, |G|) produces an element of that order which the power map collapses onto the identity."
+    }
+  ],
+  "meta": {
+    "author": "Lean formalization original (structural follow-up to Cauchy's theorem)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyGroupTheoremOQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "finite-groups",
+      "cauchy-theorem",
+      "order-of-element",
+      "power-map",
+      "coprime-exponent",
+      "bijection",
+      "classic"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Coprime.pow_left_bijective",
+        "description": "If gcd(|G|, n) = 1 then x ↦ xⁿ is bijective, with inverse the power map x ↦ x^(gcdB) from Bézout; supplies the easy direction directly.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "exists_prime_orderOf_dvd_card'",
+        "description": "Cauchy's theorem (Finite form): a prime p ∣ Nat.card G yields an element of order exactly p; the engine of the converse direction.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      },
+      {
+        "theorem": "Nat.minFac_prime",
+        "description": "For d ≠ 1, minFac d is prime; supplies the prime divisor of gcd(n, |G|) fed to Cauchy.",
+        "module": "Mathlib.Data.Nat.Prime.Defs"
+      },
+      {
+        "theorem": "orderOf_dvd_iff_pow_eq_one",
+        "description": "orderOf g ∣ n ↔ gⁿ = 1; converts orderOf g = p ∣ n into the collision gⁿ = 1.",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Finite.injective_iff_surjective",
+        "description": "A self-map of a finite type is injective iff surjective; collapses the injective, surjective and bijective forms of the power map into one.",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Nat.coprime_two_right",
+        "description": "n.Coprime 2 ↔ Odd n; reduces the n = 2 slice to the parent's odd-order statement.",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Fintype.card_perm",
+        "description": "Fintype.card (Equiv.Perm α) = (Fintype.card α)!; gives |S₃| = 6 for the concrete witnesses.",
+        "module": "Mathlib.GroupTheory.Perm.Cycle.Type"
+      }
+    ],
+    "references": [
+      {
+        "authors": "Cauchy, Augustin-Louis",
+        "title": "Mémoire sur les arrangements que l'on peut former avec des lettres données",
+        "year": "1845",
+        "note": "Exercices d'analyse et de physique mathématique 3, 151–252 — the theorem producing an element of order p for each prime p ∣ |G|, the engine of the converse direction."
+      },
+      {
+        "authors": "Isaacs, I. Martin",
+        "title": "Finite Group Theory",
+        "year": "2008",
+        "note": "Graduate Studies in Mathematics 92, AMS — power maps and regular elements of finite groups; the coprime-exponent regime where x ↦ xⁿ is a permutation."
+      },
+      {
+        "authors": "Rivest, Ronald L.; Shamir, Adi; Adleman, Leonard",
+        "title": "A Method for Obtaining Digital Signatures and Public-Key Cryptosystems",
+        "year": "1978",
+        "note": "Communications of the ACM 21(2), 120–126 — invertibility of exponentiation modulo the group order exemplifies the coprime-exponent bijection in finite abelian groups."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

For a finite group `G` and exponent `n`, the `n`-th power map `x ↦ xⁿ : G → G` is a **bijection if and only if `gcd(n, |G|) = 1`**. This directly answers the lead open question of the parent entry `cauchy-group-theorem-oq-01-oq-01` (which proved only the `n = 2` squaring case).

## The two directions

- **Coprime ⟹ bijection** (`pow_left_bijective_of_coprime`): Mathlib's `Nat.Coprime.pow_left_bijective`. Bézout gives `an + b|G| = 1`, so `x ↦ xᵃ` inverts `x ↦ xⁿ` using `x^|G| = 1`. The inverse is again a power map → valid for non-abelian groups.
- **Bijection ⟹ coprime** (`not_injective_pow_of_not_coprime`, the content): contrapositive. If `gcd(n,|G|) ≠ 1`, take `p = minFac` (prime). Cauchy's theorem (`exists_prime_orderOf_dvd_card'`) gives `g` of order `p`; since `p ∣ n`, `gⁿ = 1 = 1ⁿ` with `g ≠ 1` — injectivity fails.

## Packaged consequences

- `pow_bijective_iff_coprime` — headline equivalence.
- `pow_injective_iff_coprime`, `pow_surjective_iff_coprime` — on a finite group all three notions coincide (`Finite.injective_iff_surjective`).
- `sq_bijective_iff_odd_card` — the `n=2` slice recovers the parent (squaring bijective ⟺ `|G|` odd).
- `card_perm_fin3`, `pow5_bijective_perm_fin3`, `pow2_not_bijective_perm_fin3` — concrete `S₃` (order 6) witnesses: `x↦x⁵` is a bijection, `x↦x²` is not. Coprimality by kernel `decide` (no `native_decide`).

## Verification

- Builds clean against Mathlib 4.26.0 (single-file `lake env lean`; Docker unavailable).
- `#print axioms pow_bijective_iff_coprime` → `[propext, Classical.choice, Quot.sound]` only. No `Lean.ofReduceBool`, no `sorryAx`.
- 8 theorems / 0 definitions / 0 sorries / 160 lines.
- **Status:** `verified`, badge `original`, axiomCount 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)