### PR TITLE
Fix: restore 2 dropped Proofs.lean imports after #27891 disaster-revert

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -819,6 +819,7 @@ import Proofs.DescartesRuleOfSignsOQ02Parity
 import Proofs.DescartesRuleOfSignsOQ03
 import Proofs.DescartesRuleOfSignsOQ04
 import Proofs.DetConjugateTransposeOQ01
+import Proofs.DiamondImpliesCH
 import Proofs.DilworthMirskyHardOQ01
 import Proofs.DilworthTheoremOQ01
 import Proofs.DiniTheorem
@@ -1003,6 +1004,7 @@ import Proofs.Erdos1023OQ01OQ01
 import Proofs.Erdos1023OQ01Problem
 import Proofs.Erdos1023Problem
 import Proofs.Erdos1024Problem
+import Proofs.Erdos1025OQ04
 import Proofs.Erdos1025Problem
 import Proofs.Erdos1026Problem
 import Proofs.Erdos1027Aristotle


### PR DESCRIPTION
## Fix

Re-add two `import Proofs.*` lines that were silently dropped from `proofs/Proofs.lean` during the #27891 disaster remediation.

## Background

The #27891 commit gutted `main` to 7 files. PR #27899 reverted it and restored the full tree (20,912 files). However, three research proofs (#27887, #27886, #27890) had merged *onto* the gutted tree before the revert, each adding one import line to a stub `Proofs.lean`. The revert's conflict resolution kept only one of those three import lines.

## Evidence

**Before** — all three `.lean` files + gallery data present on `main`, but only one imported:

| Proof | `.lean` file | gallery dir | imported in `Proofs.lean` |
|---|---|---|---|
| `Erdos504OQ01` | ✅ | ✅ | ✅ |
| `Erdos1025OQ04` (erdos-1025-oq-04) | ✅ | ✅ | ❌ |
| `DiamondImpliesCH` (fodor-pressing-down-oq-02) | ✅ | ✅ | ❌ |

The two un-imported proofs would not be built by the Lean aggregator.

**After** — both imports re-added in sorted position (`DiamondImpliesCH` after `DetConjugateTransposeOQ01`; `Erdos1025OQ04` after `Erdos1024Problem`). Diff is exactly 2 insertions, 1 file.

Relates to #27898 (disaster fully remediated by #27899; this completes the import wiring).

---
Automated fix by lean-mechanic agent.