### PR TITLE
Enrich Closed-Form Buffon Crossing Factor: sections, annotations, conclusion

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "crossingFactor-def",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 48, "endLine": 65 },
+    "type": "definition",
+    "title": "The Crossing Factor and Its Two-Step Recurrence",
+    "content": "Defines the n-dimensional Buffon crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|] — the constant in the noodle formula E[crossings] = αₙ·L/d — by the two-step recurrence α_{n+4} = ((n+2)/(n+3))·α_{n+2} with base values α₂ = 2/π, α₃ = 1/2 (and 1 for n ≤ 1 by convention). The two-step structure reflects that the spherical average of |u₁| over Sⁿ⁻¹ relates to that over Sⁿ⁺¹ through the dimension ratio, decoupling even and odd dimensions into independent subsequences. The definition is re-declared verbatim from the companion BuffonsNeedleOQ02OQ01.lean, which currently fails to build on the pinned Mathlib (Filter.Tendsto.div API drift), keeping this entry self-contained. The simp lemmas crossingFactor_two, crossingFactor_three, and crossingFactor_succ_succ expose the base values and the recurrence step by rfl.",
+    "mathContext": "$\\alpha_n=\\mathbb{E}_{S^{n-1}}[|u_1|]=\\dfrac{\\Gamma(n/2)}{\\sqrt{\\pi}\\,\\Gamma((n+1)/2)}$, satisfying $\\alpha_{n+2}=\\dfrac{n}{n+1}\\alpha_n$, $\\alpha_2=\\tfrac{2}{\\pi}$, $\\alpha_3=\\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["recurrence relation", "spherical average", "Buffon noodle", "Gamma function"],
+    "prerequisites": ["geometric probability", "recursively defined functions"]
+  },
+  {
+    "id": "crossingFactor-even",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 85 },
+    "type": "theorem",
+    "title": "Even-Dimension Closed Form",
+    "content": "Solves the two-step recurrence on the even subsequence: α_{2m+2} = (2/π)·∏_{j<m} (2j+2)/(2j+3). The proof is induction on m. The base case m=0 collapses the empty product (Finset.prod_range_zero) to recover α₂ = 2/π. The successor step rewrites the index 2(k+1)+2 = 2k+4, applies the recurrence crossingFactor_succ_succ at 2k, substitutes the inductive hypothesis, peels off the new factor with Finset.prod_range_succ, and closes with push_cast and ring. The result is a finite Wallis-type partial product: each factor (2j+2)/(2j+3) is one of the rational ratios whose infinite product gives the Wallis product for π/2.",
+    "mathContext": "$\\alpha_{2m+2}=\\dfrac{2}{\\pi}\\prod_{j=0}^{m-1}\\dfrac{2j+2}{2j+3}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping product", "Wallis product", "induction", "Finset.prod_range_succ"],
+    "prerequisites": ["mathematical induction", "finite products"]
+  },
+  {
+    "id": "crossingFactor-odd",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 102 },
+    "type": "theorem",
+    "title": "Odd-Dimension Closed Form",
+    "content": "The odd-subsequence analogue: α_{2m+3} = (1/2)·∏_{j<m} (2j+3)/(2j+4). The induction mirrors the even case, with base α₃ = 1/2 from the empty product, but requires two index normalizations (2(k+1)+3 = (2k+1)+4 and (2k+1)+2 = 2k+3) so that crossingFactor_succ_succ applies at 2k+1 and the inductive hypothesis lines up. Together with the even formula, the two subsequences fully solve the recurrence; their interleaving is the discrete shadow of the single analytic formula αₙ = Γ(n/2)/(√π Γ((n+1)/2)).",
+    "mathContext": "$\\alpha_{2m+3}=\\dfrac{1}{2}\\prod_{j=0}^{m-1}\\dfrac{2j+3}{2j+4}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping product", "Wallis product", "even/odd subsequences", "induction"],
+    "prerequisites": ["mathematical induction", "finite products"]
+  },
+  {
+    "id": "even-factors",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 108, "endLine": 114 },
+    "type": "technique",
+    "title": "Each Factor Lies in (0,1]",
+    "content": "Two elementary lemmas isolate the key structural property of the even-subsequence factors: evenFactor_pos (each (2j+2)/(2j+3) > 0, by positivity) and evenFactor_le_one (each (2j+2)/(2j+3) ≤ 1, via div_le_one and linarith since 2j+2 ≤ 2j+3). Confining every factor to the unit interval (0,1] is exactly what makes the product simultaneously positive and bounded by 1 — the two facts that the closed form needs to re-derive positivity and the maximum.",
+    "mathContext": "$0<\\dfrac{2j+2}{2j+3}\\le 1$ for every $j\\ge 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "bounded factors", "div_le_one"],
+    "prerequisites": ["inequalities", "division of reals"]
+  },
+  {
+    "id": "even-pos-and-max",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 116, "endLine": 136 },
+    "type": "theorem",
+    "title": "Positivity and the Maximum 2/π From the Closed Form",
+    "content": "crossingFactor_even_pos derives 0 < α_{2m+2} by rewriting via the closed form and applying Finset.prod_pos to the positive factors (with 2/π > 0). crossingFactor_even_le_base derives the maximum α_{2m+2} ≤ 2/π: after rewriting, it bounds the product above by ∏ 1 = 1 using Finset.prod_le_prod (each factor in (0,1]) and Finset.prod_const_one, then multiplies by the positive 2/π. This is the conceptual payoff of solving the recurrence — the structural facts the parent proved by recurrence manipulation now read off directly from the shape of the product.",
+    "mathContext": "$0<\\alpha_{2m+2}\\le\\dfrac{2}{\\pi}$, since $\\prod(0,1]$-factors $\\in(0,1]$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.prod_pos", "Finset.prod_le_prod", "monotonicity", "extremal value"],
+    "prerequisites": ["finite products", "product inequalities"]
+  },
+  {
+    "id": "concrete-values",
+    "proofId": "buffons-needle-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 138, "endLine": 168 },
+    "type": "insight",
+    "title": "First Higher Concrete Values",
+    "content": "Evaluates the product over a small range to obtain the first dimensions beyond the base: crossingFactor_four (α₄ = 4/(3π)), crossingFactor_six (α₆ = 16/(15π)) on the even side, and crossingFactor_five (α₅ = 3/8), crossingFactor_seven (α₇ = 5/16) on the odd side. Each proof instantiates the closed form at m = 1 or 2, unfolds the product with Finset.prod_range_one / Finset.prod_range_succ, and finishes with push_cast and ring. None of these were computed in the parent entry. They make the decay concrete: 2/π ≈ 0.6366 → 4/(3π) ≈ 0.4244 → 16/(15π) ≈ 0.3395 on the even side, and 1/2 → 3/8 → 5/16 on the odd side.",
+    "mathContext": "$\\alpha_4=\\dfrac{4}{3\\pi},\\ \\alpha_6=\\dfrac{16}{15\\pi},\\ \\alpha_5=\\dfrac38,\\ \\alpha_7=\\dfrac{5}{16}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["explicit evaluation", "decay", "Finset.prod_range_succ"],
+    "prerequisites": ["finite products", "ring normalization"]
+  }
+]

--- a/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -53,5 +53,72 @@
       "Concrete higher values drop out by expanding the product over a small range: alpha_4 = 4/(3pi), alpha_6 = 16/(15pi) on the even side, alpha_5 = 3/8, alpha_7 = 5/16 on the odd side.",
       "Self-containment is forced by upstream bit-rot in the companion crossing-factor file, but the recurrence is a one-line definition, so the closed form is fully reproducible."
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "recurrence-def",
+      "title": "The Crossing Factor and Its Recurrence",
+      "startLine": 48,
+      "endLine": 65,
+      "summary": "Re-declares the crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|] by the two-step recurrence α_{n+4} = ((n+2)/(n+3))·α_{n+2} with bases α₂ = 2/π, α₃ = 1/2, and exposes the bases and the recurrence step as simp lemmas (crossingFactor_two/three/succ_succ).",
+      "mathContext": "α_{n+2} = (n/(n+1))·αₙ, α₂ = 2/π, α₃ = 1/2."
+    },
+    {
+      "id": "closed-forms",
+      "title": "The Closed-Form Product Formulas",
+      "startLine": 67,
+      "endLine": 102,
+      "summary": "Solves the recurrence by induction on the subsequence index: crossingFactor_even gives α_{2m+2} = (2/π)·∏_{j<m}(2j+2)/(2j+3) and crossingFactor_odd gives α_{2m+3} = (1/2)·∏_{j<m}(2j+3)/(2j+4) — finite Wallis-type partial products, with the empty product recovering the base value.",
+      "mathContext": "α_{2m+2} = (2/π)∏(2j+2)/(2j+3); α_{2m+3} = (1/2)∏(2j+3)/(2j+4)."
+    },
+    {
+      "id": "positivity-maximum",
+      "title": "Positivity and the Maximum, From the Product",
+      "startLine": 104,
+      "endLine": 136,
+      "summary": "From the factor bounds 0 < (2j+2)/(2j+3) ≤ 1 (evenFactor_pos, evenFactor_le_one), re-derives 0 < α_{2m+2} (Finset.prod_pos) and the maximum α_{2m+2} ≤ 2/π (Finset.prod_le_prod against the constant-1 product) directly from the closed form.",
+      "mathContext": "0 < α_{2m+2} ≤ 2/π, since every product factor lies in (0,1]."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Higher Values",
+      "startLine": 138,
+      "endLine": 168,
+      "summary": "Expands the product over a small range to evaluate the first dimensions past the bases: crossingFactor_four (4/(3π)), crossingFactor_six (16/(15π)), crossingFactor_five (3/8), crossingFactor_seven (5/16) — none computed in the parent.",
+      "mathContext": "α₄ = 4/(3π), α₆ = 16/(15π), α₅ = 3/8, α₇ = 5/16."
+    }
+  ],
+  "conclusion": {
+    "summary": "Solves the two-step recurrence α_{n+2} = (n/(n+1))·αₙ (bases α₂ = 2/π, α₃ = 1/2) defining the n-dimensional Buffon crossing factor αₙ = E_{Sⁿ⁻¹}[|u₁|] in the noodle formula E[crossings] = αₙ·L/d. The even subsequence is α_{2m+2} = (2/π)·∏_{j<m}(2j+2)/(2j+3) and the odd subsequence is α_{2m+3} = (1/2)·∏_{j<m}(2j+3)/(2j+4) — finite Wallis-type partial products underlying the analytic value αₙ = Γ(n/2)/(√π Γ((n+1)/2)). From the closed form it re-derives positivity (0 < α_{2m+2}) and the maximum 2/π (each product factor lies in (0,1]), and evaluates the first higher values α₄ = 4/(3π), α₆ = 16/(15π), α₅ = 3/8, α₇ = 5/16. 190 lines, 10 theorems/lemmas, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "Where the parent entry establishes only the qualitative monotone behaviour of αₙ from the recurrence, this entry gives the exact telescoping products, turning structural facts (positivity, the maximum) into transparent consequences of the factors lying in (0,1] and making every concrete dimension computable. The even and odd products are precisely the finite truncations of the Wallis product for π, so the high-dimensional Buffon constant is tied directly to the classical π-product; the decay αₙ → 0 like √(2/(πn)) (from Γ-asymptotics) is the analytic continuation of this elementary picture."
+  },
+  "openQuestions": [
+    {
+      "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-01",
+      "question": "Establish the precise asymptotic αₙ ~ √(2/(πn)) directly from the telescoping products by bounding the partial Wallis products, rather than via Stirling's formula for Γ(n/2)/(√π Γ((n+1)/2)). What are the sharp two-sided rational bounds on αₙ obtainable purely from the factor product?",
+      "significance": "medium"
+    },
+    {
+      "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-02",
+      "question": "Formalize the limit of the ratio α_{2m+2}/α_{2m+3} (even-over-odd interleaving) and connect it explicitly to the Wallis product π/2 = ∏ (2k)²/((2k−1)(2k+1)), recovering Wallis's identity as a corollary of the closed forms.",
+      "significance": "medium"
+    },
+    {
+      "id": "buffons-needle-oq-02-oq-02-oq-01-oq-01-oq-03",
+      "question": "Does an analogous closed-form product solve the crossing-factor recurrence for affine subspaces of intermediate codimension k (k-flats meeting a curve in Rⁿ), where the spherical average is of a k-dimensional projection norm rather than |u₁|?",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-02-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Direct sequel: the parent proves the qualitative monotone behaviour of the crossing factor αₙ (strict two-step decrease, maximum 2/π, uniform sub-one bound) from the recurrence but never solves it. This entry solves the recurrence in closed form (telescoping Wallis-type products) and re-derives positivity and the maximum from that closed form, plus the first concrete higher values."
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "related",
+      "description": "The classical Buffon's needle problem (n = 2), whose crossing constant 2/π is the base value α₂ that anchors the even-subsequence product here."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `buffons-needle-oq-02-oq-02-oq-01-oq-01` (Closed-Form Product Formula for the Buffon Crossing Factor).

The entry previously had only an `overview` (no sections, no annotations, no conclusion). This pass adds:

- **annotations.json** — 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering the recurrence definition, the even/odd closed-form products, the factor bounds in (0,1], positivity & the maximum 2/π, and the concrete higher values.
- **sections** — 4 sections spanning the full Lean file (recurrence/definition, closed-form products, positivity & maximum, concrete values) with line ranges and mathContext.
- **conclusion** — summary + implications tying the even/odd telescoping products to the finite Wallis partial products and the √(2/(πn)) decay.
- **openQuestions** — 3 genuine extensions (asymptotics directly from the products, the Wallis π/2 connection, intermediate-codimension flats).
- **crossReferences** — to the parent `buffons-needle-oq-02-oq-02-oq-01` and base `buffons-needle`.

Verified: `pnpm build` data-generation step (annotations:build / research:build / research:enrich) regenerates the public data cleanly — 4 sections, conclusion, 3 openQuestions, 6 annotations. JSON validated. No changes to the Lean proof or to status/badge/axiomCount (entry remains verified, 0 axioms).