### PR TITLE
research(vandermonde-interpolation-oq-01-oq-01): explicit Lagrange interpolant realizes the unique interpolant [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3653,6 +3653,7 @@ import Proofs.UniformBellMultinomialOQ01
 import Proofs.UrysohnsLemmaOQ01
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01
+import Proofs.VandermondeInterpolationOQ01OQ01
 import Proofs.VarignonTheorem
 import Proofs.VietasFormulas
 import Proofs.VietasFormulasOQ02

--- a/proofs/Proofs/VandermondeInterpolationOQ01OQ01.lean
+++ b/proofs/Proofs/VandermondeInterpolationOQ01OQ01.lean
@@ -1,0 +1,135 @@
+/-
+  Explicit Lagrange interpolant realizes the unique polynomial interpolant.
+
+  Over a field `F`, fix `n` DISTINCT nodes `v : Fin n → F` and target values
+  `r : Fin n → F`.  The companion entry `VandermondeInterpolationOQ01` proves
+  the *uniqueness* half of the interpolation problem (via the nonvanishing of
+  the Vandermonde determinant): a polynomial of degree `< n` is determined by
+  its values at `n` distinct points.  This file supplies the complementary
+  *existence* half and packages the two together into a clean well-posedness
+  statement.
+
+  The existence witness is the explicit **Lagrange interpolant**
+  `interp v r = ∑ i, r i · ℓ_i`, where `ℓ_i` is the `i`-th Lagrange basis
+  polynomial.  We show:
+
+    * **Existence (the realizer)** `eval_interp`: the Lagrange interpolant takes
+      the prescribed value `r j` at every node `v j`;
+    * **Degree bound** `degree_interp_lt` / `natDegree_interp_lt`: it has degree
+      `< n`;
+    * **It is the answer** `eq_interp_of_eval_eq`: *any* polynomial of degree
+      `< n` matching the values equals the Lagrange interpolant;
+    * **Well-posedness** `existsUnique_interp` (degree form) and
+      `existsUnique_interp_natDegree` (the `natDegree` form matching the
+      companion): there is a *unique* polynomial of degree `< n` interpolating
+      the data, and it is exactly the Lagrange interpolant;
+    * **Reproduction** `interp_eval_self`: interpolating the values of a
+      polynomial of degree `< n` returns that polynomial — Lagrange
+      interpolation is a left inverse to evaluation on `degree < n` polynomials.
+
+  The mathematical engine is Mathlib's `Lagrange.*` API
+  (`eval_interpolate_at_node`, `degree_interpolate_lt`,
+  `eq_interpolate_of_eval_eq`); the contribution here is to recast it in the
+  `Fin n` / `Function.Injective` / `natDegree` idiom of the companion entry and
+  to expose the interpolation problem's existence-and-uniqueness explicitly.
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Polynomial Finset
+
+namespace VandermondeInterpolationOQ01OQ01
+
+variable {F : Type*} [Field F] {n : ℕ} {v : Fin n → F} {r : Fin n → F}
+
+omit [Field F] in
+/-- A globally injective node map is injective on `univ`. -/
+private theorem injOn_univ (hv : Function.Injective v) :
+    Set.InjOn v ↑(Finset.univ : Finset (Fin n)) := hv.injOn
+
+/-- The number of nodes is `n`. -/
+private theorem card_univ_fin : #(Finset.univ : Finset (Fin n)) = n := by simp
+
+/-- The explicit **Lagrange interpolant** through the nodes `v` with values `r`. -/
+noncomputable def interp (v r : Fin n → F) : F[X] :=
+  Lagrange.interpolate Finset.univ v r
+
+/-- **Existence (the realizer).** The Lagrange interpolant takes the prescribed
+value `r j` at each node `v j`. -/
+theorem eval_interp (hv : Function.Injective v) (j : Fin n) :
+    (interp v r).eval (v j) = r j := by
+  unfold interp
+  exact Lagrange.eval_interpolate_at_node r (injOn_univ hv) (mem_univ j)
+
+/-- The Lagrange interpolant has degree `< n`. -/
+theorem degree_interp_lt (hv : Function.Injective v) :
+    (interp v r).degree < (n : ℕ) := by
+  have h := Lagrange.degree_interpolate_lt (v := v) (r := r) (injOn_univ hv)
+  rwa [card_univ_fin] at h
+
+/-- If `p` has degree `< n`, then `natDegree p < n`. -/
+private theorem natDegree_lt_of_degree_lt {p : F[X]} (h : p.degree < (n : ℕ))
+    (hn : 0 < n) : p.natDegree < n := by
+  rcases eq_or_ne p 0 with rfl | hp
+  · simpa using hn
+  · rwa [degree_eq_natDegree hp, Nat.cast_lt] at h
+
+/-- If `natDegree p < n`, then `p` has degree `< n`. -/
+private theorem degree_lt_of_natDegree_lt {p : F[X]} (h : p.natDegree < n) :
+    p.degree < (n : ℕ) := by
+  rcases eq_or_ne p 0 with rfl | hp
+  · simp
+  · rw [degree_eq_natDegree hp, Nat.cast_lt]; exact h
+
+/-- For `n ≥ 1` the Lagrange interpolant has `natDegree < n` (the idiom of the
+companion entry). -/
+theorem natDegree_interp_lt (hv : Function.Injective v) (hn : 0 < n) :
+    (interp v r).natDegree < n :=
+  natDegree_lt_of_degree_lt (degree_interp_lt hv) hn
+
+/-- **The interpolant is the answer.** Any polynomial of degree `< n` that
+matches the prescribed values at the nodes equals the Lagrange interpolant. -/
+theorem eq_interp_of_eval_eq (hv : Function.Injective v) {p : F[X]}
+    (hdeg : p.degree < (n : ℕ)) (hp : ∀ j, p.eval (v j) = r j) :
+    p = interp v r := by
+  unfold interp
+  refine Lagrange.eq_interpolate_of_eval_eq r (injOn_univ hv) ?_ ?_
+  · rwa [card_univ_fin]
+  · intro i _; exact hp i
+
+/-- **Well-posedness (degree form).** There is a unique polynomial of degree
+`< n` interpolating the data, and it is the Lagrange interpolant. -/
+theorem existsUnique_interp (hv : Function.Injective v) :
+    ∃! p : F[X], p.degree < (n : ℕ) ∧ ∀ j, p.eval (v j) = r j := by
+  refine ⟨interp v r, ⟨degree_interp_lt hv, eval_interp hv⟩, ?_⟩
+  rintro q ⟨hqdeg, hqeval⟩
+  exact eq_interp_of_eval_eq hv hqdeg hqeval
+
+/-- **Well-posedness (`natDegree` form, `n ≥ 1`).** Mirrors the companion
+entry's `natDegree < n` framing: there is a unique polynomial of `natDegree < n`
+interpolating the data. -/
+theorem existsUnique_interp_natDegree (hv : Function.Injective v) (hn : 0 < n) :
+    ∃! p : F[X], p.natDegree < n ∧ ∀ j, p.eval (v j) = r j := by
+  refine ⟨interp v r, ⟨natDegree_interp_lt hv hn, eval_interp hv⟩, ?_⟩
+  rintro q ⟨hqdeg, hqeval⟩
+  exact eq_interp_of_eval_eq hv (degree_lt_of_natDegree_lt hqdeg) hqeval
+
+/-- **Reproduction.** Interpolating the values of a polynomial of degree `< n`
+returns the polynomial: Lagrange interpolation is a left inverse to evaluation
+on polynomials of degree `< n`. -/
+theorem interp_eval_self (hv : Function.Injective v) {f : F[X]}
+    (hdeg : f.degree < (n : ℕ)) :
+    interp v (fun i => f.eval (v i)) = f :=
+  (eq_interp_of_eval_eq hv hdeg (fun _ => rfl)).symm
+
+/-- The Lagrange interpolant is `F`-linear in the value vector `r`. -/
+theorem interp_add (v : Fin n → F) (r r' : Fin n → F) :
+    interp v (r + r') = interp v r + interp v r' := by
+  unfold interp; exact map_add _ r r'
+
+/-- The Lagrange interpolant commutes with scalar multiplication of the data. -/
+theorem interp_smul (v : Fin n → F) (c : F) (r : Fin n → F) :
+    interp v (c • r) = c • interp v r := by
+  unfold interp; exact map_smul _ c r
+
+end VandermondeInterpolationOQ01OQ01

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/annotations.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-module-header",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "concept",
+    "range": { "startLine": 1, "endLine": 36 },
+    "title": "Module Header: The Lagrange Interpolant as the Realizer",
+    "content": "The companion entry proves **uniqueness** of the degree-$<n$ interpolant through $n$ distinct nodes $v$. This file supplies the matching **existence** half: the explicit **Lagrange interpolant** $\\mathrm{interp}\\,v\\,r = \\sum_i r_i\\,\\ell_i$ (with $\\ell_i$ the $i$-th Lagrange basis polynomial, $\\ell_i(v_j) = \\delta_{ij}$) takes the value $r_j$ at each node and has degree $<n$, so the interpolation problem is **well-posed** — a unique solution exists, and it is exactly this formula. Mathlib's `Lagrange.*` API supplies the engine; the work is recasting it in the $\\mathrm{Fin}\\,n$ / `Polynomial.eval` / `natDegree` idiom and exposing existence-and-uniqueness as $\\exists!$."
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-interp-def",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "definition",
+    "range": { "startLine": 53, "endLine": 54 },
+    "title": "The Explicit Lagrange Interpolant",
+    "content": "`interp v r := Lagrange.interpolate univ v r`. Concretely $\\sum_{i} C(r_i)\\cdot \\mathrm{basis}\\,v\\,i$, the degree-$<n$ polynomial $\\sum_i r_i\\,\\ell_i$ whose value at $v_j$ is $r_j$. This is the explicit existence witness complementing the companion's abstract uniqueness."
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-eval",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 56, "endLine": 61 },
+    "title": "Existence: the Interpolant Hits the Data",
+    "content": "`eval_interp`: $(\\mathrm{interp}\\,v\\,r)(v_j) = r_j$ for every node $j$. Immediate from Mathlib's `Lagrange.eval_interpolate_at_node` (using $v$ injective on `univ`, $j \\in$ `univ`). This is the existence half — the interpolation system is solvable, and the Lagrange formula is a solution."
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-degree",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 63, "endLine": 87 },
+    "title": "Degree Bound and the degree ↔ natDegree Bridge",
+    "content": "`degree_interp_lt`: $\\deg(\\mathrm{interp}\\,v\\,r) < n$, from `Lagrange.degree_interpolate_lt` with $\\#\\mathrm{univ} = n$. `natDegree_interp_lt` recasts this in the companion's $\\deg_{\\mathbb N} < n$ idiom for $n \\ge 1$: Mathlib's `degree < \\#s` form correctly includes the zero polynomial, so the bridge case-splits on $\\mathrm{interp} = 0$ (then $\\deg_{\\mathbb N} = 0 < n$ needs $0 < n$) versus nonzero (then `degree_eq_natDegree` + `Nat.cast_lt` transfer the bound)."
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-eq-interp",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 89, "endLine": 97 },
+    "title": "The Interpolant Is the Unique Answer",
+    "content": "`eq_interp_of_eval_eq`: any polynomial $p$ of degree $<n$ with $p(v_j) = r_j$ at every node **equals** $\\mathrm{interp}\\,v\\,r$ (via `Lagrange.eq_interpolate_of_eval_eq`). So the explicit Lagrange formula is not merely *a* solution but *the* solution — the realizer of the unique interpolant from the companion entry."
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-existsunique",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 99, "endLine": 114 },
+    "title": "Well-Posedness: ∃! Interpolant",
+    "content": "`existsUnique_interp`: $\\exists!\\,p,\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$. Existence from `eval_interp` + `degree_interp_lt`; uniqueness from `eq_interp_of_eval_eq`. `existsUnique_interp_natDegree` ($n \\ge 1$) gives the same in the companion's $\\deg_{\\mathbb N} < n$ framing via the degree↔natDegree bridge. This is the complete well-posedness statement: the interpolation problem has exactly one degree-$<n$ solution, and it is the Lagrange interpolant."
+  },
+  {
+    "id": "vandermonde-interpolation-oq-01-oq-01-reproduction-linearity",
+    "proofId": "vandermonde-interpolation-oq-01-oq-01",
+    "type": "theorem",
+    "range": { "startLine": 116, "endLine": 132 },
+    "title": "Reproduction and Linearity",
+    "content": "`interp_eval_self`: interpolating the sampled values of a degree-$<n$ polynomial $f$ returns $f$ — Lagrange interpolation is a **left inverse to evaluation** on the degree-$<n$ subspace. `interp_add` / `interp_smul`: the data-to-interpolant map $r \\mapsto \\mathrm{interp}\\,v\\,r$ is $F$-**linear** (`map_add` / `map_smul` of Mathlib's `LinearMap` `interpolate`), the structural fact behind superposition and basis expansion in interpolation."
+  }
+]

--- a/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/meta.json
+++ b/src/data/proofs/vandermonde-interpolation-oq-01-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "vandermonde-interpolation-oq-01-oq-01",
+  "title": "The Explicit Lagrange Interpolant Realizes the Unique Interpolant",
+  "slug": "vandermonde-interpolation-oq-01-oq-01",
+  "description": "Over a field, fix n distinct nodes v and target values r. The companion entry vandermonde-interpolation-oq-01 proves the uniqueness half of the interpolation problem (a polynomial of degree < n is determined by its values at n distinct points). This entry supplies the complementary existence half: the explicit Lagrange interpolant interp v r = ∑ i, r_i·ℓ_i takes the value r_j at each node v_j and has degree < n, so the interpolation problem is well-posed — there is a unique polynomial of degree < n through the data, and it is exactly the Lagrange interpolant. Packaged as ∃! in both the degree and natDegree idioms, plus reproduction (interpolation is a left inverse to evaluation) and F-linearity of r ↦ interp v r. 13 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lagrange_polynomial",
+    "date": "Joseph-Louis Lagrange (1795); Edward Waring (1779)",
+    "status": "verified",
+    "tags": [
+      "linear-algebra",
+      "polynomials",
+      "interpolation",
+      "lagrange",
+      "vandermonde",
+      "existence-uniqueness",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/VandermondeInterpolationOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere.",
+    "originalContributions": [
+      "interp: the explicit Lagrange interpolant Lagrange.interpolate over Fin n nodes, recast in the Function.Injective / Polynomial.eval idiom of the companion entry",
+      "eval_interp: existence — the Lagrange interpolant takes the prescribed value r_j at every node v_j",
+      "natDegree_interp_lt: the interpolant has natDegree < n for n ≥ 1, matching the companion's natDegree framing (bridging Mathlib's degree < #s form)",
+      "eq_interp_of_eval_eq: any degree-< n polynomial matching the values equals the Lagrange interpolant (the realizer is the unique answer)",
+      "existsUnique_interp / existsUnique_interp_natDegree: well-posedness — ∃! polynomial of degree < n (resp. natDegree < n) interpolating the data, in both idioms",
+      "interp_eval_self: reproduction — interpolating the values of a degree-< n polynomial returns it; interpolation is a left inverse to evaluation",
+      "interp_add / interp_smul: the value-vector ↦ interpolant map is F-linear"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 135,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Polynomial interpolation through n distinct points is well-posed: there is exactly one polynomial of degree < n matching the data. The companion entry established uniqueness from the nonvanishing of the Vandermonde determinant; the existence half is classically witnessed by the explicit Lagrange interpolating polynomial ∑_i r_i · ℓ_i, where ℓ_i is the i-th Lagrange basis polynomial (ℓ_i(v_j) = δ_{ij}). Lagrange's construction (1795), anticipated by Waring (1779) and Euler (1783), turns the abstract existence-uniqueness statement into a usable formula and is the foundation of Newton–Cotes quadrature, Reed–Solomon codes, and finite-element shape functions.",
+    "problemStatement": "**Open Question (OQ-01 of vandermonde-interpolation-oq-01)**: Construct the explicit Lagrange interpolant and prove it realizes the unique interpolant guaranteed by the uniqueness theorem.\n\n**Formalized**: interp (the explicit Lagrange interpolant), eval_interp (it interpolates), degree_interp_lt / natDegree_interp_lt (degree bound), eq_interp_of_eval_eq (it is the unique answer), existsUnique_interp / existsUnique_interp_natDegree (well-posedness), interp_eval_self (reproduction), interp_add / interp_smul (linearity).",
+    "text": "A 135-line formalization completing the interpolation problem begun in the companion entry. The witness interp v r is Mathlib's Lagrange.interpolate over the full node set univ : Finset (Fin n). The two characteristic facts come straight from Mathlib's Lagrange API: eval_interpolate_at_node gives eval_interp (the interpolant hits r_j at v_j), and degree_interpolate_lt gives degree_interp_lt (degree < #univ = n). The contribution is to recast these in the Fin n / Function.Injective / Polynomial.eval / natDegree idiom of the companion uniqueness entry and to expose existence-and-uniqueness explicitly: eq_interp_of_eval_eq (from eq_interpolate_of_eval_eq) shows any degree-< n match equals the interpolant, and combining with eval_interp / degree_interp_lt yields existsUnique_interp — a clean ∃! well-posedness statement. The natDegree form existsUnique_interp_natDegree (for n ≥ 1) mirrors the companion's natDegree < n framing, via the degree ↔ natDegree bridge that handles the zero polynomial. interp_eval_self states the reproduction property (interpolation is a left inverse to evaluation on degree-< n polynomials), and interp_add / interp_smul record that r ↦ interp v r is F-linear (Mathlib's interpolate is a LinearMap). All theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**eval_interp**: Lagrange.eval_interpolate_at_node with the node map injective on univ (hv.injOn) and j ∈ univ.\n\n**degree_interp_lt**: Lagrange.degree_interpolate_lt gives degree < #univ; rewrite #(univ : Finset (Fin n)) = n.\n\n**natDegree_interp_lt**: from degree < ↑n, split on interp = 0 (then natDegree = 0 < n needs n ≥ 1) versus interp ≠ 0 (then degree = ↑natDegree and Nat.cast_lt transfers the bound).\n\n**eq_interp_of_eval_eq**: Lagrange.eq_interpolate_of_eval_eq with the degree bound (#univ = n) and the per-node value match.\n\n**existsUnique_interp**: provide interp v r with ⟨degree_interp_lt, eval_interp⟩; any other q with the same properties equals it by eq_interp_of_eval_eq. The natDegree variant routes through the degree ↔ natDegree bridge.\n\n**interp_eval_self**: eq_interp_of_eval_eq applied with r_i := f.eval (v_i) and the trivial match, then symmetry.\n\n**interp_add / interp_smul**: map_add / map_smul of the LinearMap Lagrange.interpolate univ v.",
+    "keyInsights": [
+      "**Existence by explicit construction**: the abstract guarantee 'an interpolant exists' is realized by the concrete formula ∑_i r_i·ℓ_i, where the Lagrange basis polynomial ℓ_i is built to satisfy ℓ_i(v_j) = δ_{ij}, so eval at v_j picks out exactly r_j.",
+      "**Existence + uniqueness = well-posedness**: combining this entry's existence (eval_interp, degree_interp_lt) with the companion's uniqueness gives ∃! — the interpolation problem has exactly one solution of degree < n, and it is the Lagrange interpolant.",
+      "**The interpolant is the unique answer**: any degree-< n polynomial agreeing with the data at the nodes is forced to equal the Lagrange interpolant, so the explicit formula is not merely a solution but the solution.",
+      "**Reproduction / left inverse**: interpolating the sampled values of a degree-< n polynomial f returns f exactly — Lagrange interpolation inverts evaluation on the degree-< n subspace.",
+      "**Linearity of the solution operator**: the data-to-interpolant map r ↦ ∑_i r_i·ℓ_i is F-linear, the structural fact behind superposition in interpolation and the basis-expansion view of the degree-< n polynomial space.",
+      "**The degree ↔ natDegree bridge**: Mathlib states the characteristic property with degree < #s (which correctly includes the zero polynomial); recasting in the companion's natDegree < n idiom requires the 0 < n hypothesis and a case split on the zero polynomial.",
+      "**0-axiom, no native_decide**: every step is kernel-checked, depending only on propext / Classical.choice / Quot.sound."
+    ],
+    "prerequisites": [
+      "The companion entry vandermonde-interpolation-oq-01 (interpolation uniqueness from Vandermonde nonvanishing)",
+      "Mathlib's Lagrange interpolation API: Lagrange.interpolate, Lagrange.basis, eval_interpolate_at_node, degree_interpolate_lt, eq_interpolate_of_eval_eq (LinearAlgebra/Lagrange.lean)",
+      "Polynomial degree vs natDegree and the bridge degree_eq_natDegree / natDegree_lt_iff_degree_lt for the natDegree form",
+      "Set.InjOn from Function.Injective (Function.Injective.injOn) and Finset.card_fin",
+      "ExistsUnique and LinearMap.map_add / map_smul for the well-posedness and linearity statements"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "vandermonde-interpolation-oq-01",
+      "relationship": "extends",
+      "description": "The companion entry proves interpolation uniqueness (at most one degree-< n interpolant) from the nonvanishing of the Vandermonde determinant. This entry supplies the matching existence half via the explicit Lagrange interpolant and packages the two into a single ∃! well-posedness statement in the same Fin n / natDegree idiom."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "VandermondeInterpolationOQ01OQ01",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/VandermondeInterpolationOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "existsUnique_interp",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $\\exists!\\, p,\\ \\deg p < n \\wedge \\forall j,\\ p(v_j) = r_j$",
+      "significance": "Well-posedness of polynomial interpolation: there is a unique polynomial of degree < n through the data, and the existence witness is the explicit Lagrange interpolant. Combines this entry's existence with the companion's uniqueness.",
+      "description": "A unique degree-< n interpolant exists; it is the Lagrange interpolant."
+    },
+    {
+      "name": "eval_interp",
+      "type": "core",
+      "statement": "$v$ injective $\\Rightarrow$ $(\\mathrm{interp}\\,v\\,r)(v_j) = r_j$",
+      "significance": "Existence (the realizer): the explicit Lagrange interpolant takes the prescribed value at every node, witnessing solvability of the interpolation system.",
+      "description": "The Lagrange interpolant interpolates the data."
+    },
+    {
+      "name": "eq_interp_of_eval_eq",
+      "type": "core",
+      "statement": "$v$ injective, $\\deg p < n$, $p(v_j) = r_j\\ \\forall j$ $\\Rightarrow$ $p = \\mathrm{interp}\\,v\\,r$",
+      "significance": "The interpolant is the unique answer: any degree-< n polynomial matching the data equals the Lagrange interpolant, so the explicit formula is the solution.",
+      "description": "Any degree-< n match equals the Lagrange interpolant."
+    },
+    {
+      "name": "existsUnique_interp_natDegree",
+      "type": "supporting",
+      "statement": "$v$ injective, $0 < n$ $\\Rightarrow$ $\\exists!\\, p,\\ \\deg_{\\mathbb{N}} p < n \\wedge \\forall j,\\ p(v_j) = r_j$",
+      "significance": "Well-posedness in the natDegree < n idiom of the companion uniqueness entry, via the degree ↔ natDegree bridge.",
+      "description": "Unique interpolant in the natDegree framing (n ≥ 1)."
+    },
+    {
+      "name": "interp_eval_self",
+      "type": "supporting",
+      "statement": "$v$ injective, $\\deg f < n$ $\\Rightarrow$ $\\mathrm{interp}\\,v\\,(f \\circ v) = f$",
+      "significance": "Reproduction: interpolating the sampled values of a degree-< n polynomial returns it. Lagrange interpolation is a left inverse to evaluation on the degree-< n subspace.",
+      "description": "Interpolation inverts evaluation on degree-< n polynomials."
+    },
+    {
+      "name": "interp_add",
+      "type": "supporting",
+      "statement": "$\\mathrm{interp}\\,v\\,(r + r') = \\mathrm{interp}\\,v\\,r + \\mathrm{interp}\\,v\\,r'$",
+      "significance": "The data-to-interpolant operator is additive (and, with interp_smul, F-linear) — superposition for interpolation.",
+      "description": "The interpolation operator is F-linear in the data."
+    }
+  ],
+  "references": [
+    {
+      "text": "Lagrange polynomial: the explicit interpolant ∑_i y_i ∏_{j≠i} (x − x_j)/(x_i − x_j) through n distinct points.",
+      "url": "https://en.wikipedia.org/wiki/Lagrange_polynomial"
+    },
+    {
+      "text": "Polynomial interpolation — existence and uniqueness of the degree-< n interpolant through n distinct points.",
+      "url": "https://en.wikipedia.org/wiki/Polynomial_interpolation"
+    },
+    {
+      "text": "Mathlib4: Lagrange.interpolate, Lagrange.eval_interpolate_at_node, Lagrange.degree_interpolate_lt, Lagrange.eq_interpolate_of_eval_eq (LinearAlgebra/Lagrange.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Lagrange.html"
+    }
+  ],
+  "conclusion": {
+    "summary": "Completes the polynomial interpolation problem begun in vandermonde-interpolation-oq-01. The explicit Lagrange interpolant interp v r realizes the unique degree-< n interpolant: it takes the prescribed value r_j at each node (eval_interp) and has degree < n (degree_interp_lt / natDegree_interp_lt), and any degree-< n polynomial matching the data equals it (eq_interp_of_eval_eq). Packaged as existsUnique_interp / existsUnique_interp_natDegree (well-posedness in both idioms), with reproduction (interp_eval_self) and F-linearity (interp_add, interp_smul). All 13 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "Together with the companion uniqueness entry, this shows polynomial interpolation through n distinct nodes is well-posed in the strongest sense: existence, uniqueness, an explicit formula, reproduction, and linearity of the solution operator. These are the structural facts underlying Lagrange/Newton interpolation, Reed–Solomon encoding/decoding, Newton–Cotes quadrature, and finite-element shape functions.",
+    "openQuestions": [
+      "Identify the Lagrange and Newton forms: prove interp v r equals the Newton divided-difference interpolant, exposing the change of basis between the two classical representations.",
+      "Generalize the existence witness from a field to an integral domain (or to its fraction field), pinning down exactly when an explicit interpolant of degree < n exists."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Completes the polynomial **interpolation problem** begun in the companion entry [`vandermonde-interpolation-oq-01`](https://github.com/rjwalters/lean-genius/pull/27097) (which proved **uniqueness** — at most one degree-`< n` interpolant). This entry supplies the matching **existence** half and packages the two into a clean well-posedness statement.

It answers that entry's first open question verbatim:
> *Construct the explicit Lagrange interpolant and prove it realizes the unique interpolant guaranteed here.*

The existence witness is the explicit **Lagrange interpolant** `interp v r = ∑ i, r_i·ℓ_i` (Mathlib's `Lagrange.interpolate` over `Fin n` nodes):

| Theorem | Statement |
|---|---|
| `eval_interp` | the interpolant takes value `r_j` at each node `v_j` — **existence** |
| `degree_interp_lt` / `natDegree_interp_lt` | degree `< n` (both idioms) |
| `eq_interp_of_eval_eq` | any degree-`< n` polynomial matching the data **equals** the interpolant — it is *the* answer |
| `existsUnique_interp` / `existsUnique_interp_natDegree` | `∃!` well-posedness, `degree` and `natDegree` forms |
| `interp_eval_self` | **reproduction**: interpolation is a left inverse to evaluation on degree-`< n` polynomials |
| `interp_add` / `interp_smul` | the data `↦` interpolant map is `F`-**linear** |

## What's the contribution over Mathlib?

Mathlib states the characteristic property in `degree < #s` / `Finset` form (`Lagrange.eq_interpolate_iff`). This entry recasts the existence/uniqueness in the `Fin n` / `Function.Injective` / `Polynomial.eval` / `natDegree` idiom of the companion uniqueness entry, packages existence-and-uniqueness as a single `∃!` (in both `degree` and `natDegree` forms, the latter requiring the `degree ↔ natDegree` bridge that handles the zero polynomial), and adds reproduction and linearity.

## Verification

- **13 theorems, 1 definition, 135 lines**
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` for every theorem
- **No `native_decide`** anywhere
- Compiles cleanly under **Mathlib v4.26.0** (zero warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)