### PR TITLE
research(urysohns-lemma-oq-01-oq-02): metric Urysohn function is δ⁻¹-Lipschitz for positively separated sets [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3651,6 +3651,7 @@ import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence
 import Proofs.UniformBellMultinomialOQ01
 import Proofs.UrysohnsLemmaOQ01
+import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01
 import Proofs.VarignonTheorem

--- a/proofs/Proofs/UrysohnsLemmaOQ01OQ02.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01OQ02.lean
@@ -1,0 +1,198 @@
+import Mathlib
+
+/-
+# The metric Urysohn function is Lipschitz for positively separated sets
+
+**Open question (`urysohns-lemma-oq-01-oq-02`).** The parent entry
+`Proofs/UrysohnsLemmaOQ01.lean` constructs the explicit metric Urysohn function
+separating two disjoint nonempty closed sets `s`, `t` in a metric space,
+$$ f(x) \;=\; \frac{d(x,s)}{d(x,s) + d(x,t)}, $$
+and proves it is continuous, valued in `[0,1]`, and equal to `0` on `s` and `1`
+on `t`. Continuity is purely qualitative. This file supplies the **quantitative**
+regularity the parent leaves open:
+
+> when the two sets are a fixed positive distance apart — `δ ≤ d(a,b)` for every
+> `a ∈ s`, `b ∈ t` — the function `f` is **Lipschitz**, with modulus `δ⁻¹`
+> determined by the separation gap.
+
+The argument is elementary and needs neither closedness nor disjointness as
+separate hypotheses (positive separation subsumes both):
+
+* **Separation lower bound** (`sep_le_infDist_add`). For every `x`,
+  `δ ≤ d(x,s) + d(x,t)`. Indeed for `a ∈ s`, `b ∈ t`,
+  `δ ≤ d(a,b) ≤ d(x,a) + d(x,b)`; taking the infimum over `a` then over `b`
+  (via `Metric.le_infDist`) gives the claim. In particular the denominator is
+  `≥ δ > 0` everywhere.
+
+* **One-Lipschitz distance functions** (`abs_infDist_sub_le`).
+  `|d(x,s) - d(y,s)| ≤ d(x,y)`, from `Metric.infDist_le_infDist_add_dist`.
+
+* **The quotient estimate.** Writing `u = d(·,s)`, `v = d(·,t)`, `g = u+v`,
+  `f(x) - f(y) = (u(x)v(y) - u(y)v(x)) / (g(x)g(y))`, and the numerator is bounded
+  by `g(x)·d(x,y)` because `|u(x)v(y) - u(y)v(x)| = |u(x)(v(y)-v(x)) +
+  v(x)(u(x)-u(y))| ≤ (u(x)+v(x))·d(x,y)`. Dividing,
+  `|f(x) - f(y)| ≤ d(x,y) / g(y) ≤ δ⁻¹·d(x,y)`.
+
+Headline results: the sharp pointwise estimate `δ·|f(x)-f(y)| ≤ d(x,y)`
+(`mul_dist_urysohnFn_le`), the Lipschitz constant `δ⁻¹` (`dist_urysohnFn_le`),
+the bundled `LipschitzWith` statement (`lipschitzWith_urysohnFn`), and uniform
+continuity (`uniformContinuous_urysohnFn`). A concrete instance on `ℝ`
+({0} and {1}, gap `1`) yields a `1`-Lipschitz function.
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+
+namespace UrysohnsLemmaOQ01OQ02
+
+open Set Metric
+
+variable {X : Type*} [MetricSpace X]
+
+/-- The explicit Urysohn function separating two sets in a metric space:
+`x ↦ d(x, s) / (d(x, s) + d(x, t))`. (Same construction as the parent entry,
+restated here so this file is self-contained.) -/
+noncomputable def urysohnFn (s t : Set X) (x : X) : ℝ :=
+  infDist x s / (infDist x s + infDist x t)
+
+/-! ## Two preparatory lemmas -/
+
+/-- **Separation lower bound.** If `s`, `t` are nonempty and separated by a gap
+`δ` (`δ ≤ d(a,b)` for all `a ∈ s`, `b ∈ t`), then `δ ≤ d(x,s) + d(x,t)` for every
+point `x`. In particular the denominator of the Urysohn function is `≥ δ`. -/
+theorem sep_le_infDist_add {s t : Set X} {δ : ℝ}
+    (hsne : s.Nonempty) (htne : t.Nonempty)
+    (hsep : ∀ a ∈ s, ∀ b ∈ t, δ ≤ dist a b) (x : X) :
+    δ ≤ infDist x s + infDist x t := by
+  -- For every `b ∈ t`, `δ - d(x,b) ≤ d(x,s)`, by infimum over `a ∈ s`.
+  have hA : ∀ b ∈ t, δ - dist x b ≤ infDist x s := by
+    intro b hb
+    rw [Metric.le_infDist hsne]
+    intro a ha
+    have hsab := hsep a ha b hb
+    have htri : dist a b ≤ dist x a + dist x b := by
+      rw [dist_comm x a]; exact dist_triangle a x b
+    linarith
+  -- Hence `δ - d(x,s) ≤ d(x,t)`, by infimum over `b ∈ t`.
+  have hB : δ - infDist x s ≤ infDist x t := by
+    rw [Metric.le_infDist htne]
+    intro b hb
+    have := hA b hb
+    linarith
+  linarith
+
+/-- The distance-to-a-set function `x ↦ d(x,s)` is `1`-Lipschitz:
+`|d(x,s) - d(y,s)| ≤ d(x,y)`. -/
+theorem abs_infDist_sub_le (s : Set X) (x y : X) :
+    |infDist x s - infDist y s| ≤ dist x y := by
+  rw [abs_sub_le_iff]
+  refine ⟨?_, ?_⟩
+  · have h := Metric.infDist_le_infDist_add_dist (x := x) (y := y) (s := s)
+    linarith
+  · have h := Metric.infDist_le_infDist_add_dist (x := y) (y := x) (s := s)
+    rw [dist_comm] at h; linarith
+
+/-! ## The Lipschitz estimate -/
+
+/-- **Sharp pointwise estimate.** For positively separated nonempty sets,
+`δ · |f(x) - f(y)| ≤ d(x,y)`, i.e. the explicit Urysohn function `f = urysohnFn s t`
+contracts distances by the gap `δ`. -/
+theorem mul_dist_urysohnFn_le {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsne : s.Nonempty) (htne : t.Nonempty)
+    (hsep : ∀ a ∈ s, ∀ b ∈ t, δ ≤ dist a b) (x y : X) :
+    δ * |urysohnFn s t x - urysohnFn s t y| ≤ dist x y := by
+  have hgx : δ ≤ infDist x s + infDist x t := sep_le_infDist_add hsne htne hsep x
+  have hgy : δ ≤ infDist y s + infDist y t := sep_le_infDist_add hsne htne hsep y
+  have hgx0 : 0 < infDist x s + infDist x t := hδ.trans_le hgx
+  have hgy0 : 0 < infDist y s + infDist y t := hδ.trans_le hgy
+  have hu0 : 0 ≤ infDist x s := infDist_nonneg
+  have hv0 : 0 ≤ infDist x t := infDist_nonneg
+  have hD : 0 ≤ dist x y := dist_nonneg
+  have hu : |infDist x s - infDist y s| ≤ dist x y := abs_infDist_sub_le s x y
+  have hv : |infDist x t - infDist y t| ≤ dist x y := abs_infDist_sub_le t x y
+  unfold urysohnFn
+  set u := infDist x s with hu_def
+  set v := infDist x t with hv_def
+  set u' := infDist y s with hu'_def
+  set v' := infDist y t with hv'_def
+  set D := dist x y with hD_def
+  -- Numerator bound: `|u(u'+v') - (u+v)u'| ≤ (u+v)·D`.
+  have hN : |u * (u' + v') - (u + v) * u'| ≤ (u + v) * D := by
+    have e : u * (u' + v') - (u + v) * u' = u * (v' - v) + v * (u - u') := by ring
+    rw [e]
+    calc |u * (v' - v) + v * (u - u')|
+        ≤ |u * (v' - v)| + |v * (u - u')| := abs_add_le _ _
+      _ = u * |v' - v| + v * |u - u'| := by
+          rw [abs_mul, abs_mul, abs_of_nonneg hu0, abs_of_nonneg hv0]
+      _ ≤ u * D + v * D := by
+          refine add_le_add (mul_le_mul_of_nonneg_left ?_ hu0)
+            (mul_le_mul_of_nonneg_left hu hv0)
+          rw [abs_sub_comm]; exact hv
+      _ = (u + v) * D := by ring
+  rw [div_sub_div _ _ hgx0.ne' hgy0.ne', abs_div,
+    abs_of_pos (mul_pos hgx0 hgy0), ← mul_div_assoc,
+    div_le_iff₀ (mul_pos hgx0 hgy0)]
+  have h_a : δ * |u * (u' + v') - (u + v) * u'| ≤ δ * ((u + v) * D) :=
+    mul_le_mul_of_nonneg_left hN hδ.le
+  have h_b : δ * ((u + v) * D) ≤ (u' + v') * ((u + v) * D) :=
+    mul_le_mul_of_nonneg_right hgy (mul_nonneg hgx0.le hD)
+  nlinarith [h_a, h_b]
+
+/-- **Lipschitz modulus.** For positively separated nonempty sets, the explicit
+Urysohn function satisfies `|f(x) - f(y)| ≤ δ⁻¹·d(x,y)`. -/
+theorem dist_urysohnFn_le {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsne : s.Nonempty) (htne : t.Nonempty)
+    (hsep : ∀ a ∈ s, ∀ b ∈ t, δ ≤ dist a b) (x y : X) :
+    |urysohnFn s t x - urysohnFn s t y| ≤ δ⁻¹ * dist x y := by
+  have hmul := mul_dist_urysohnFn_le hδ hsne htne hsep x y
+  have hδinv : (0 : ℝ) ≤ δ⁻¹ := by positivity
+  have h := mul_le_mul_of_nonneg_left hmul hδinv
+  rwa [← mul_assoc, inv_mul_cancel₀ hδ.ne', one_mul] at h
+
+/-- **`LipschitzWith` packaging.** The explicit Urysohn function for sets
+separated by gap `δ > 0` is `δ⁻¹`-Lipschitz. -/
+theorem lipschitzWith_urysohnFn {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsne : s.Nonempty) (htne : t.Nonempty)
+    (hsep : ∀ a ∈ s, ∀ b ∈ t, δ ≤ dist a b) :
+    LipschitzWith (Real.toNNReal δ⁻¹) (urysohnFn s t) := by
+  rw [lipschitzWith_iff_dist_le_mul]
+  intro x y
+  rw [Real.dist_eq, Real.coe_toNNReal δ⁻¹ (by positivity)]
+  exact dist_urysohnFn_le hδ hsne htne hsep x y
+
+/-- The explicit Urysohn function for positively separated sets is uniformly
+continuous (immediate from the Lipschitz bound). -/
+theorem uniformContinuous_urysohnFn {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsne : s.Nonempty) (htne : t.Nonempty)
+    (hsep : ∀ a ∈ s, ∀ b ∈ t, δ ≤ dist a b) :
+    UniformContinuous (urysohnFn s t) :=
+  (lipschitzWith_urysohnFn hδ hsne htne hsep).uniformContinuous
+
+/-- **Explicit modulus of continuity in terms of the gap.** If `d(x,y) < δ·ε`
+then the Urysohn values are within `ε`. This makes the dependence of the modulus
+on the separation gap quantitative. -/
+theorem dist_urysohnFn_lt {s t : Set X} {δ ε : ℝ} (hδ : 0 < δ)
+    (hsne : s.Nonempty) (htne : t.Nonempty)
+    (hsep : ∀ a ∈ s, ∀ b ∈ t, δ ≤ dist a b) {x y : X}
+    (hxy : dist x y < δ * ε) :
+    |urysohnFn s t x - urysohnFn s t y| < ε := by
+  have h := dist_urysohnFn_le hδ hsne htne hsep x y
+  have hδinv : (0 : ℝ) < δ⁻¹ := inv_pos.mpr hδ
+  calc |urysohnFn s t x - urysohnFn s t y| ≤ δ⁻¹ * dist x y := h
+    _ < δ⁻¹ * (δ * ε) := mul_lt_mul_of_pos_left hxy hδinv
+    _ = ε := by rw [← mul_assoc, inv_mul_cancel₀ hδ.ne', one_mul]
+
+/-! ## A concrete instance on `ℝ` -/
+
+/-- On `ℝ`, the singletons `{0}` and `{1}` are separated by gap `1`, so the
+explicit Urysohn function separating them is `1`-Lipschitz. -/
+example : LipschitzWith 1 (urysohnFn ({0} : Set ℝ) {1}) := by
+  have hcoe : Real.toNNReal (1 : ℝ)⁻¹ = 1 := by
+    rw [inv_one, Real.toNNReal_one]
+  rw [← hcoe]
+  refine lipschitzWith_urysohnFn (by norm_num) ⟨0, rfl⟩ ⟨1, rfl⟩ ?_
+  intro a ha b hb
+  rw [Set.mem_singleton_iff] at ha hb
+  subst ha; subst hb
+  rw [Real.dist_eq]; norm_num
+
+end UrysohnsLemmaOQ01OQ02

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-02/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-02/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "urysohns-lemma-oq-01-oq-02",
+  "slug": "urysohns-lemma-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Metric"
+    ],
+    "namespace": "UrysohnsLemmaOQ01OQ02",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/UrysohnsLemmaOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Metric Urysohn Function Is Lipschitz for Positively Separated Sets",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01OQ02.lean",
+    "tags": [
+      "topology",
+      "metric-space",
+      "urysohns-lemma",
+      "lipschitz",
+      "infdist",
+      "separation",
+      "uniform-continuity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 198,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "sep_le_infDist_add: the separation lower bound — if nonempty s, t are separated by a gap δ (δ ≤ dist a b for all a ∈ s, b ∈ t) then δ ≤ infDist x s + infDist x t for every x, proved by taking the infimum over a ∈ s then over b ∈ t (Metric.le_infDist) of the triangle inequality δ ≤ dist a b ≤ dist x a + dist x b; in particular the Urysohn denominator is ≥ δ > 0 everywhere",
+      "abs_infDist_sub_le: the distance-to-a-set function x ↦ infDist x s is 1-Lipschitz, |infDist x s − infDist y s| ≤ dist x y, from the two-sided Metric.infDist_le_infDist_add_dist",
+      "mul_dist_urysohnFn_le: the sharp pointwise estimate δ · |f(x) − f(y)| ≤ dist x y for f = urysohnFn s t, via the quotient identity f(x) − f(y) = (u(x)v(y) − u(y)v(x))/(g(x)g(y)) and the numerator bound |u(x)v(y) − u(y)v(x)| ≤ g(x)·dist x y with g = infDist·s + infDist·t",
+      "dist_urysohnFn_le: the explicit Lipschitz modulus |f(x) − f(y)| ≤ δ⁻¹ · dist x y, the gap δ governing the constant",
+      "lipschitzWith_urysohnFn: the bundled statement that the explicit metric Urysohn function for sets separated by gap δ > 0 is δ⁻¹-Lipschitz (LipschitzWith (Real.toNNReal δ⁻¹))",
+      "uniformContinuous_urysohnFn: uniform continuity of the explicit Urysohn function, an immediate corollary of the Lipschitz bound",
+      "dist_urysohnFn_lt: the explicit modulus of continuity in terms of the gap — dist x y < δ·ε implies |f(x) − f(y)| < ε",
+      "Concrete instance: on ℝ the sets {0} and {1} have gap 1, so the explicit Urysohn function separating them is 1-Lipschitz (LipschitzWith 1)"
+    ],
+    "prerequisites": [
+      "Metric.infDist (distance from a point to a set) and its API: infDist_nonneg, Metric.le_infDist, Metric.infDist_le_infDist_add_dist",
+      "The explicit metric Urysohn function urysohnFn s t x = infDist x s / (infDist x s + infDist x t) from the parent entry",
+      "LipschitzWith and the characterisation lipschitzWith_iff_dist_le_mul; LipschitzWith.uniformContinuous",
+      "Elementary real-analysis manipulation of quotients and absolute values (div_sub_div, abs_div, abs_add_le)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Metric.le_infDist",
+        "description": "r ≤ infDist x s ↔ ∀ y ∈ s, r ≤ dist x y for nonempty s — the infimum characterisation used twice to derive the separation lower bound δ ≤ infDist x s + infDist x t.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "Metric.infDist_le_infDist_add_dist",
+        "description": "infDist x s ≤ infDist y s + dist x y — the 1-Lipschitz/triangle property of the distance-to-a-set function, yielding |infDist x s − infDist y s| ≤ dist x y.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "lipschitzWith_iff_dist_le_mul",
+        "description": "LipschitzWith K f ↔ ∀ x y, dist (f x) (f y) ≤ K · dist x y — converts the explicit real estimate into the bundled LipschitzWith statement.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      },
+      {
+        "theorem": "LipschitzWith.uniformContinuous",
+        "description": "A Lipschitz map is uniformly continuous — gives uniformContinuous_urysohnFn for free.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-02-oq-01",
+      "question": "Is the modulus sharp? For s = {0}, t = {δ} on ℝ the explicit Urysohn function f(x) = |x|/(|x| + |x − δ|) is exactly δ⁻¹-Lipschitz; determine whether δ⁻¹ is the optimal Lipschitz constant for general separated sets or can be improved to (something)·δ⁻¹ with a smaller absolute factor.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "urysohns-lemma-oq-01",
+      "relationship": "Parent entry constructing the explicit metric Urysohn function urysohnFn and proving it continuous; this entry supplies the quantitative Lipschitz refinement the parent records as an open question."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.MetricSpace.HausdorffDistance",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the Metric.infDist API (le_infDist, infDist_le_infDist_add_dist) underpinning the separation lower bound and the 1-Lipschitz distance functions."
+    },
+    {
+      "title": "Paul Urysohn, Über die Mächtigkeit der zusammenhängenden Mengen",
+      "author": "P. Urysohn",
+      "year": "1925",
+      "venue": "Mathematische Annalen",
+      "description": "Origin of Urysohn's lemma; the explicit metric witness whose Lipschitz regularity is established here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The parent entry urysohns-lemma-oq-01 constructs the explicit metric Urysohn function f(x) = infDist x s / (infDist x s + infDist x t) separating two disjoint nonempty closed sets and proves it continuous — a purely qualitative statement. This entry supplies the quantitative regularity left open: when s and t are a fixed positive distance apart (δ ≤ dist a b for every a ∈ s, b ∈ t with δ > 0), f is Lipschitz with modulus δ⁻¹. The argument is elementary and needs neither closedness nor disjointness as separate hypotheses, since positive separation subsumes both. The three steps are: (1) the separation lower bound δ ≤ infDist x s + infDist x t for every x (sep_le_infDist_add), obtained by taking the infimum over a ∈ s then over b ∈ t of δ ≤ dist a b ≤ dist x a + dist x b — this also pins the denominator ≥ δ > 0; (2) the 1-Lipschitz property of the distance-to-a-set functions (abs_infDist_sub_le); (3) the quotient estimate, where f(x) − f(y) = (u(x)v(y) − u(y)v(x))/(g(x)g(y)) and the numerator is bounded by g(x)·dist x y. These give the sharp pointwise estimate δ·|f(x) − f(y)| ≤ dist x y (mul_dist_urysohnFn_le), the Lipschitz modulus |f(x) − f(y)| ≤ δ⁻¹·dist x y (dist_urysohnFn_le), the bundled LipschitzWith (Real.toNNReal δ⁻¹) statement (lipschitzWith_urysohnFn), uniform continuity (uniformContinuous_urysohnFn), and an explicit gap-dependent modulus of continuity (dist_urysohnFn_lt). A concrete instance on ℝ ({0} and {1}, gap 1) yields a 1-Lipschitz function. 198 lines, 7 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "The qualitative continuity of the metric Urysohn separator is upgraded to a quantitative Lipschitz bound whose constant δ⁻¹ is governed entirely by the separation gap, making explicit how the regularity of the separating function degrades as the two sets approach each other. This is the form needed in quantitative analysis (e.g. controlling the modulus of partitions of unity, or smoothing arguments where the Lipschitz constant must be tracked) and shows the textbook infDist construction is automatically Lipschitz off the diagonal of separated sets, with no appeal to closedness or the abstract Urysohn machinery.",
+    "openQuestions": [
+      "Determine whether the Lipschitz constant δ⁻¹ is optimal or can be improved by an absolute factor for general separated sets."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question `urysohns-lemma-oq-01-oq-02` from the parent entry **Urysohn's Lemma and the Explicit Metric Urysohn Function**.

The parent constructs the explicit metric Urysohn function
```
f(x) = d(x,s) / (d(x,s) + d(x,t))      (urysohnFn s t)
```
separating two sets and proves it **continuous** — a purely qualitative statement. This PR supplies the **quantitative** refinement the parent records as open:

> When `s` and `t` are a fixed positive distance apart (`δ ≤ d(a,b)` for every `a∈s`, `b∈t`, with `δ>0`), `f` is **Lipschitz with modulus `δ⁻¹`**.

## The argument (elementary, no closedness/disjointness needed)

Positive separation subsumes both closedness and disjointness, so the hypotheses are just `δ>0`, `s,t` nonempty, and the gap condition.

1. **Separation lower bound** (`sep_le_infDist_add`): `δ ≤ d(x,s)+d(x,t)` for every `x`, by taking the infimum over `a∈s` then over `b∈t` (`Metric.le_infDist`) of `δ ≤ d(a,b) ≤ d(x,a)+d(x,b)`. This also pins the denominator `≥ δ > 0`.
2. **1-Lipschitz distance functions** (`abs_infDist_sub_le`): `|d(x,s)−d(y,s)| ≤ d(x,y)`.
3. **Quotient estimate**: with `u=d(·,s)`, `v=d(·,t)`, `g=u+v`,
   `f(x)−f(y) = (u(x)v(y)−u(y)v(x))/(g(x)g(y))`, and the numerator is bounded by `g(x)·d(x,y)` because `|u(x)v(y)−u(y)v(x)| = |u(x)(v(y)−v(x)) + v(x)(u(x)−u(y))| ≤ (u(x)+v(x))·d(x,y)`. Dividing gives `|f(x)−f(y)| ≤ d(x,y)/g(y) ≤ δ⁻¹·d(x,y)`.

## Results (7 theorems, 1 def)

- `mul_dist_urysohnFn_le` — sharp pointwise estimate `δ·|f(x)−f(y)| ≤ d(x,y)`
- `dist_urysohnFn_le` — Lipschitz modulus `|f(x)−f(y)| ≤ δ⁻¹·d(x,y)`
- `lipschitzWith_urysohnFn` — bundled `LipschitzWith (Real.toNNReal δ⁻¹)`
- `uniformContinuous_urysohnFn` — uniform continuity corollary
- `dist_urysohnFn_lt` — explicit gap-dependent modulus: `d(x,y) < δ·ε ⟹ |f(x)−f(y)| < ε`
- concrete instance: on `ℝ`, `{0}` and `{1}` (gap 1) ⟹ `LipschitzWith 1`

## Verification

- **198 lines, 7 theorems, 1 definition, 0 sorries, 0 axiom declarations**
- `#print axioms` on all headline results: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **verified / 0-axiom**, badge `original`
- Built against Mathlib v4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)