### PR TITLE
research(urysohns-lemma-oq-01-oq-02): metric Urysohn function is (1/δ)-Lipschitz for positively separated sets [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3651,6 +3651,7 @@ import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence
 import Proofs.UniformBellMultinomialOQ01
 import Proofs.UrysohnsLemmaOQ01
+import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01
 import Proofs.VarignonTheorem

--- a/proofs/Proofs/UrysohnsLemmaOQ01OQ02.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01OQ02.lean
@@ -1,0 +1,166 @@
+import Mathlib
+
+/-!
+# The metric Urysohn function is Lipschitz for positively separated sets
+
+The companion file `UrysohnsLemmaOQ01` builds, for disjoint nonempty closed sets `s`, `t`
+in a metric space, the explicit Urysohn separator
+$$ f(x) \;=\; \frac{d(x,s)}{d(x,s) + d(x,t)} $$
+and proves it is *continuous*, vanishes on `s`, equals `1` on `t`, and is `[0,1]`-valued.
+Continuity is the qualitative statement; it gives no modulus.
+
+This file upgrades continuity to a **quantitative Lipschitz estimate** whenever the two
+sets are *positively separated* — i.e. when the denominator
+`D(x) = d(x,s) + d(x,t)` is bounded below by some `δ > 0` (equivalently, when `s` and `t`
+sit at positive mutual distance). The headline result `lipschitzWith_urysohnFn` shows that
+`f` is then `(1/δ)`-Lipschitz, with the sharp pointwise bound
+$$ |f(x) - f(y)| \;\le\; \frac{d(x,y)}{\delta}. $$
+
+The engine is purely algebraic. Writing `a(·) = d(·,s)`, `b(·) = d(·,t)` (each
+`1`-Lipschitz, `Metric.lipschitz_infDist_pt`), the quotient difference telescopes to
+$$ f(x)-f(y) \;=\; \frac{a(x)\,b(y) - a(y)\,b(x)}{D(x)\,D(y)}, \qquad
+   |a(x)b(y) - a(y)b(x)| \;\le\; D(x)\,d(x,y), $$
+so `|f(x)-f(y)| ≤ d(x,y)/D(y) ≤ d(x,y)/δ`. A separate lemma
+(`delta_le_infDist_add`) discharges the hypothesis from genuine set separation
+`∀ p ∈ s, ∀ q ∈ t, δ ≤ dist p q`, and a concrete capstone shows the standard separator of
+`{0}` and `{1}` on `ℝ` is `1`-Lipschitz.
+
+All results are over a general `MetricSpace X`, fully machine-checked with no `sorry` and no
+extra axioms. The Lipschitz modulus of this explicit function is not a named result in
+Mathlib.
+-/
+
+namespace UrysohnsLemmaOQ01OQ02
+
+open Set Metric
+
+variable {X : Type*} [MetricSpace X]
+
+/-- The explicit Urysohn function `x ↦ d(x,s) / (d(x,s) + d(x,t))`, repeated from the
+companion file `UrysohnsLemmaOQ01` so this file is self-contained. -/
+noncomputable def urysohnFn (s t : Set X) (x : X) : ℝ :=
+  infDist x s / (infDist x s + infDist x t)
+
+/-- The distance-to-a-set function is `1`-Lipschitz, in the explicit absolute-value form
+`|d(x,s) - d(y,s)| ≤ dist x y`. This is the only metric input the Lipschitz estimate needs. -/
+theorem abs_infDist_sub_le (s : Set X) (x y : X) :
+    |infDist x s - infDist y s| ≤ dist x y := by
+  have h := (lipschitz_infDist_pt s).dist_le_mul x y
+  simp only [Real.dist_eq, NNReal.coe_one, one_mul] at h
+  exact h
+
+/-- **Positive separation gives a denominator lower bound.** If every pair `p ∈ s`, `q ∈ t`
+is at distance at least `δ`, then `d(x,s) + d(x,t) ≥ δ` for *every* `x`: the triangle
+inequality propagates the separation of the sets to the sum of distances from an arbitrary
+point. Requires `s`, `t` nonempty (else `infDist` collapses to `0`). -/
+theorem delta_le_infDist_add {s t : Set X} (hsne : s.Nonempty) (htne : t.Nonempty)
+    {δ : ℝ} (hsep : ∀ p ∈ s, ∀ q ∈ t, δ ≤ dist p q) (x : X) :
+    δ ≤ infDist x s + infDist x t := by
+  have key : δ - infDist x s ≤ infDist x t := by
+    rw [le_infDist htne]
+    intro q hq
+    have hqs : δ ≤ infDist q s := by
+      rw [le_infDist hsne]
+      intro p hp
+      rw [dist_comm]
+      exact hsep p hp q hq
+    have htri : infDist q s ≤ infDist x s + dist q x := infDist_le_infDist_add_dist
+    have hcomb : δ ≤ infDist x s + dist q x := le_trans hqs htri
+    rw [dist_comm q x] at hcomb
+    linarith
+  linarith
+
+/-- **Quantitative Lipschitz bound for the metric Urysohn function.** If the denominator
+`d(x,s) + d(x,t)` is bounded below by `δ > 0` everywhere, then
+`|f(x) - f(y)| ≤ dist x y / δ`. -/
+theorem urysohnFn_abs_sub_le {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsep : ∀ x, δ ≤ infDist x s + infDist x t) (x y : X) :
+    |urysohnFn s t x - urysohnFn s t y| ≤ dist x y / δ := by
+  have hDx : 0 < infDist x s + infDist x t := lt_of_lt_of_le hδ (hsep x)
+  have hDy : 0 < infDist y s + infDist y t := lt_of_lt_of_le hδ (hsep y)
+  have hDx' := hDx.ne'
+  have hDy' := hDy.ne'
+  -- telescoping identity for the quotient difference
+  have hid : urysohnFn s t x - urysohnFn s t y
+      = (infDist x s * infDist y t - infDist y s * infDist x t)
+          / ((infDist x s + infDist x t) * (infDist y s + infDist y t)) := by
+    unfold urysohnFn
+    field_simp
+    ring
+  -- numerator estimate `|a(x)b(y) - a(y)b(x)| ≤ D(x) · dist x y`
+  have hnum : |infDist x s * infDist y t - infDist y s * infDist x t|
+      ≤ (infDist x s + infDist x t) * dist x y := by
+    have e : infDist x s * infDist y t - infDist y s * infDist x t
+        = infDist x s * (infDist y t - infDist x t)
+          + infDist x t * (infDist x s - infDist y s) := by ring
+    have ha : |infDist x s - infDist y s| ≤ dist x y := abs_infDist_sub_le s x y
+    have hb : |infDist y t - infDist x t| ≤ dist x y := by
+      rw [abs_sub_comm]; exact abs_infDist_sub_le t x y
+    rw [e]
+    calc |infDist x s * (infDist y t - infDist x t)
+            + infDist x t * (infDist x s - infDist y s)|
+        ≤ |infDist x s * (infDist y t - infDist x t)|
+            + |infDist x t * (infDist x s - infDist y s)| := abs_add_le _ _
+      _ = infDist x s * |infDist y t - infDist x t|
+            + infDist x t * |infDist x s - infDist y s| := by
+          rw [abs_mul, abs_mul, abs_of_nonneg infDist_nonneg, abs_of_nonneg infDist_nonneg]
+      _ ≤ infDist x s * dist x y + infDist x t * dist x y := by
+          have h1 := mul_le_mul_of_nonneg_left hb (infDist_nonneg (x := x) (s := s))
+          have h2 := mul_le_mul_of_nonneg_left ha (infDist_nonneg (x := x) (s := t))
+          linarith
+      _ = (infDist x s + infDist x t) * dist x y := by ring
+  -- assemble
+  rw [hid, abs_div, abs_of_pos (mul_pos hDx hDy), div_le_div_iff₀ (mul_pos hDx hDy) hδ]
+  -- goal: |num| * δ ≤ dist x y * (D(x) * D(y))
+  have hDxd : 0 ≤ (infDist x s + infDist x t) * dist x y :=
+    mul_nonneg hDx.le dist_nonneg
+  nlinarith [mul_le_mul_of_nonneg_right hnum hδ.le,
+    mul_le_mul_of_nonneg_left (hsep y) hDxd, (dist_nonneg : (0:ℝ) ≤ dist x y), hDx, hDy]
+
+/-- **The metric Urysohn function is Lipschitz under positive separation.** Packaged as
+`LipschitzWith (1/δ)` for the bundled modulus. -/
+theorem lipschitzWith_urysohnFn {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsep : ∀ x, δ ≤ infDist x s + infDist x t) :
+    LipschitzWith (1 / δ).toNNReal (urysohnFn s t) := by
+  apply LipschitzWith.of_dist_le_mul
+  intro x y
+  rw [Real.dist_eq, Real.coe_toNNReal (1 / δ) (by positivity)]
+  calc |urysohnFn s t x - urysohnFn s t y| ≤ dist x y / δ :=
+        urysohnFn_abs_sub_le hδ hsep x y
+    _ = 1 / δ * dist x y := by ring
+
+/-- Lipschitz from genuine set separation: disjoint sets at mutual distance `≥ δ > 0` give a
+`(1/δ)`-Lipschitz separator (nonempty closed sets not even required to be closed here — only
+nonempty, since separation already forces the denominator bound). -/
+theorem lipschitzWith_urysohnFn_of_separated {s t : Set X} (hsne : s.Nonempty)
+    (htne : t.Nonempty) {δ : ℝ} (hδ : 0 < δ) (hsep : ∀ p ∈ s, ∀ q ∈ t, δ ≤ dist p q) :
+    LipschitzWith (1 / δ).toNNReal (urysohnFn s t) :=
+  lipschitzWith_urysohnFn hδ (fun x => delta_le_infDist_add hsne htne hsep x)
+
+/-- As a consequence of being Lipschitz, the separator is (uniformly) continuous — recovering
+the companion file's qualitative continuity, now with a modulus. -/
+theorem uniformContinuous_urysohnFn {s t : Set X} {δ : ℝ} (hδ : 0 < δ)
+    (hsep : ∀ x, δ ≤ infDist x s + infDist x t) :
+    UniformContinuous (urysohnFn s t) :=
+  (lipschitzWith_urysohnFn hδ hsep).uniformContinuous
+
+/-! ## A concrete capstone on `ℝ` -/
+
+/-- The standard separator of `{0}` and `{1}` on the real line,
+`x ↦ |x| / (|x| + |x-1|)`, is `1`-Lipschitz: the two points are at distance `1`, so
+`δ = 1` and the modulus is `1/δ = 1`. -/
+theorem lipschitzWith_urysohnFn_zero_one :
+    LipschitzWith 1 (urysohnFn ({0} : Set ℝ) {1}) := by
+  have hsep : ∀ x : ℝ, (1 : ℝ) ≤ infDist x {0} + infDist x {1} := by
+    intro x
+    rw [infDist_singleton, infDist_singleton, Real.dist_eq, Real.dist_eq]
+    have h := abs_add_le x (1 - x)
+    have hsum : x + (1 - x) = 1 := by ring
+    rw [hsum, abs_one] at h
+    have hflip : |1 - x| = |x - 1| := abs_sub_comm 1 x
+    rw [hflip] at h
+    simpa [sub_zero] using h
+  have := lipschitzWith_urysohnFn (s := ({0} : Set ℝ)) (t := {1}) (δ := 1) one_pos hsep
+  simpa using this
+
+end UrysohnsLemmaOQ01OQ02

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-02/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-02/meta.json
@@ -1,0 +1,124 @@
+{
+  "id": "urysohns-lemma-oq-01-oq-02",
+  "slug": "urysohns-lemma-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Metric"
+    ],
+    "namespace": "UrysohnsLemmaOQ01OQ02",
+    "lineCount": 165,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/UrysohnsLemmaOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "The Metric Urysohn Function Is Lipschitz for Positively Separated Sets",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01OQ02.lean",
+    "tags": [
+      "topology",
+      "metric-space",
+      "urysohns-lemma",
+      "lipschitz",
+      "infDist",
+      "separation",
+      "modulus-of-continuity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 165,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "urysohnFn: the explicit metric Urysohn function urysohnFn s t x = infDist x s / (infDist x s + infDist x t), repeated from the companion entry urysohns-lemma-oq-01 so this file is self-contained",
+      "abs_infDist_sub_le: the distance-to-a-set function is 1-Lipschitz in absolute-value form, |infDist x s - infDist y s| ≤ dist x y (the only metric input the estimate needs), derived from Metric.lipschitz_infDist_pt",
+      "delta_le_infDist_add: positive separation of the sets propagates to the denominator — if every p ∈ s, q ∈ t satisfy δ ≤ dist p q, then δ ≤ infDist x s + infDist x t for every point x (triangle inequality plus the inf characterisation Metric.le_infDist)",
+      "urysohnFn_abs_sub_le: the sharp quantitative bound |f(x) - f(y)| ≤ dist x y / δ when the denominator is bounded below by δ > 0, via the telescoping identity f(x)-f(y) = (a(x)b(y)-a(y)b(x))/(D(x)D(y)) and the numerator estimate |a(x)b(y)-a(y)b(x)| ≤ D(x)·dist x y",
+      "lipschitzWith_urysohnFn: the headline result — under a uniform denominator lower bound δ > 0 the explicit Urysohn function is LipschitzWith (1/δ), upgrading the companion file's qualitative continuity to a modulus",
+      "lipschitzWith_urysohnFn_of_separated: the same conclusion from genuine set separation (nonempty sets at mutual distance ≥ δ > 0), combining delta_le_infDist_add with the headline bound",
+      "uniformContinuous_urysohnFn: uniform continuity of the separator as an immediate consequence of being Lipschitz, recovering the companion file's continuity with an explicit modulus",
+      "lipschitzWith_urysohnFn_zero_one: concrete capstone — the standard separator of {0} and {1} on ℝ, x ↦ |x|/(|x|+|x-1|), is 1-Lipschitz (the points are distance 1 apart, so the modulus is 1/δ = 1)"
+    ],
+    "prerequisites": [
+      "The explicit metric Urysohn function urysohnFn s t x = infDist x s / (infDist x s + infDist x t) (companion entry urysohns-lemma-oq-01)",
+      "Metric.infDist and its 1-Lipschitz property Metric.lipschitz_infDist_pt, plus Metric.infDist_nonneg and the inf characterisation Metric.le_infDist",
+      "Metric.infDist_le_infDist_add_dist: the triangle inequality for distance-to-a-set",
+      "LipschitzWith and LipschitzWith.of_dist_le_mul / LipschitzWith.uniformContinuous",
+      "Real.toNNReal and Real.coe_toNNReal for bundling the modulus 1/δ as a ℝ≥0 constant"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Metric.lipschitz_infDist_pt",
+        "description": "The map x ↦ infDist x s is 1-Lipschitz; unwound to |infDist x s - infDist y s| ≤ dist x y, the single metric input driving the Lipschitz estimate.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "Metric.le_infDist",
+        "description": "For a nonempty set, r ≤ infDist x s ↔ ∀ y ∈ s, r ≤ dist x y — used to propagate set separation to the denominator lower bound.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "Metric.infDist_le_infDist_add_dist",
+        "description": "infDist x s ≤ infDist y s + dist x y, the triangle inequality for distance-to-a-set, completing the denominator separation lemma.",
+        "module": "Mathlib.Topology.MetricSpace.HausdorffDistance"
+      },
+      {
+        "theorem": "LipschitzWith.of_dist_le_mul",
+        "description": "A map satisfying dist (f x) (f y) ≤ K · dist x y is LipschitzWith K — packages the pointwise bound into the bundled modulus.",
+        "module": "Mathlib.Topology.MetricSpace.Lipschitz"
+      },
+      {
+        "theorem": "div_le_div_iff₀",
+        "description": "Cross-multiplication for inequalities of positive-denominator quotients, reducing the assembled bound to a polynomial inequality discharged by nlinarith.",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-02-oq-01",
+      "question": "Is the modulus 1/δ sharp? Exhibit sets (e.g. two points at distance δ in ℝ or a normed space) where the best Lipschitz constant of urysohnFn equals 1/δ, and characterise when a strictly smaller constant is attainable.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "urysohns-lemma-oq-01",
+      "relationship": "parent",
+      "description": "Defines urysohnFn and proves it continuous, [0,1]-valued, and equal to 0 on s and 1 on t; this entry resolves that entry's open question oq-01-oq-02 by supplying the Lipschitz modulus."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.MetricSpace.HausdorffDistance",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Metric.infDist and its 1-Lipschitz property, the engine behind the modulus bound."
+    },
+    {
+      "title": "Paul Urysohn, Über die Mächtigkeit der zusammenhängenden Mengen",
+      "author": "P. Urysohn",
+      "year": "1925",
+      "venue": "Mathematische Annalen",
+      "description": "Origin of Urysohn's lemma; the explicit metric witness whose modulus is quantified here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The companion entry urysohns-lemma-oq-01 constructs the explicit metric Urysohn function urysohnFn s t x = infDist x s / (infDist x s + infDist x t) for disjoint nonempty closed sets and proves it continuous — a qualitative statement carrying no modulus. This entry upgrades continuity to a quantitative Lipschitz estimate for positively separated sets. Writing a(·) = infDist · s and b(·) = infDist · t (each 1-Lipschitz, abs_infDist_sub_le), the quotient difference telescopes to f(x)-f(y) = (a(x)b(y)-a(y)b(x))/(D(x)D(y)) with |a(x)b(y)-a(y)b(x)| ≤ D(x)·dist x y, giving the sharp pointwise bound |f(x)-f(y)| ≤ dist x y / δ whenever the denominator D = a+b is bounded below by δ > 0 (urysohnFn_abs_sub_le). The headline lipschitzWith_urysohnFn packages this as LipschitzWith (1/δ); lipschitzWith_urysohnFn_of_separated discharges the denominator bound from genuine set separation (δ ≤ dist p q for all p ∈ s, q ∈ t) via delta_le_infDist_add; uniformContinuous_urysohnFn recovers the companion continuity with a modulus; and lipschitzWith_urysohnFn_zero_one verifies the concrete separator of {0} and {1} on ℝ is 1-Lipschitz. 165 lines, 7 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "The result turns the textbook Urysohn separator into a genuinely quantitative tool: on the complement of a fixed separation gap it is Lipschitz with an explicit, dimension-free modulus 1/δ depending only on the gap, not on the ambient space. This is the estimate behind uniform smoothing constructions and partitions of unity with controlled gradients, and it cleanly recovers the companion file's continuity. The modulus is governed entirely by the inf-distance triangle inequality, so it holds verbatim in any metric space.",
+    "openQuestions": [
+      "Is the modulus 1/δ sharp, and when is a strictly smaller Lipschitz constant attainable?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the open question **urysohns-lemma-oq-01-oq-02** from the parent gallery entry *Urysohn's Lemma and the Explicit Metric Urysohn Function*: it asks to show the explicit metric Urysohn function is Lipschitz when the two sets are a fixed positive distance apart, quantifying the modulus in terms of the gap.

The parent builds, for disjoint nonempty closed sets `s`, `t` in a metric space, the explicit separator
```
f(x) = infDist x s / (infDist x s + infDist x t)
```
and proves it *continuous* — a qualitative statement with no modulus. This entry upgrades continuity to a **quantitative Lipschitz estimate**.

## Math

Write `a(·) = infDist · s`, `b(·) = infDist · t` (each `1`-Lipschitz). The quotient difference telescopes:
```
f(x) − f(y) = (a(x)b(y) − a(y)b(x)) / (D(x)·D(y)),   D = a + b
```
with `|a(x)b(y) − a(y)b(x)| ≤ D(x)·dist x y`, giving the sharp pointwise bound
```
|f(x) − f(y)| ≤ dist x y / δ
```
whenever `D ≥ δ > 0`. Positive separation `δ ≤ dist p q` for all `p ∈ s, q ∈ t` propagates to `D(x) ≥ δ` everywhere (triangle inequality + `Metric.le_infDist`), so `f` is `(1/δ)`-Lipschitz.

## Results (7 theorems, 1 def, 165 lines)

- `urysohnFn` — explicit separator (self-contained copy of the parent's definition)
- `abs_infDist_sub_le` — `|infDist x s − infDist y s| ≤ dist x y`
- `delta_le_infDist_add` — set separation ⟹ denominator lower bound
- `urysohnFn_abs_sub_le` — sharp pointwise bound `|f(x)−f(y)| ≤ dist x y / δ`
- `lipschitzWith_urysohnFn` — **headline**: `LipschitzWith (1/δ) (urysohnFn s t)`
- `lipschitzWith_urysohnFn_of_separated` — Lipschitz from genuine set separation
- `uniformContinuous_urysohnFn` — recovers the parent's continuity with a modulus
- `lipschitzWith_urysohnFn_zero_one` — capstone: the `{0},{1}` separator on `ℝ` is `1`-Lipschitz

## Verification

- Fully machine-checked, **0 sorries, 0 axiom declarations**.
- `#print axioms` on all results: only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`, no `sorryAx`. Status: `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)