### PR TITLE
research(uniformbell-multinomial-oq-01-oq-01): non-uniform bridge — Multiset.bell · ∏(multiplicities)! = multinomial of size profile (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3650,6 +3650,7 @@ import Proofs.UnitDistanceHN7
 import Proofs.UnitDistanceHN7Aristotle
 import Proofs.UnitDistanceIndependence
 import Proofs.UniformBellMultinomialOQ01
+import Proofs.UniformBellMultinomialOQ01OQ01
 import Proofs.UrysohnsLemmaOQ01
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01

--- a/proofs/Proofs/UniformBellMultinomialOQ01OQ01.lean
+++ b/proofs/Proofs/UniformBellMultinomialOQ01OQ01.lean
@@ -1,0 +1,188 @@
+/-
+# The non-uniform bridge: `Multiset.bell` is a multinomial coefficient
+
+The parent entry (`UniformBellMultinomialOQ01`) proved the *equal-block* bridge
+
+    uniformBell m n · m! = multinomial (range m) (const n),
+
+making precise that forgetting the order of the `m` equal-size blocks divides the
+ordered count by `m!`.  Its first open question asks whether this bridge
+generalises to blocks of **prescribed, non-uniform** sizes:
+
+> Does `Multiset.bell m · ∏ (multiplicities)! = multinomial` of the size profile?
+
+This file answers it affirmatively.  Fix a *size profile* `s : Multiset ℕ`
+(the multiset of block sizes; `s.sum` is the size of the ground set).  Mathlib's
+`Multiset.bell s` counts the **unordered** set-partitions of an `s.sum`-element
+set whose block sizes are exactly `s`, and records the cornerstone
+
+    bell s · (s.map (·!)).prod · ∏_{j ∈ s.toFinset.erase 0} (s.count j)!  =  s.sum!   (`Multiset.bell_mul_eq`)
+
+The **ordered** count — the number of ways to drop `s.sum` labelled items into a
+*sequence* of disjoint blocks of the prescribed sizes — is the multinomial
+coefficient `multinomial s.toEnumFinset Prod.fst = s.sum! / (s.map (·!)).prod`
+(here `s.toEnumFinset` indexes the `|s|` blocks, `Prod.fst` reads off each block's
+size, so repeated sizes are kept distinct).  The bridge is then exactly the
+statement that passing from ordered to unordered blocks divides by
+`∏_j (s.count j)!`, the number of ways to permute the equal-size blocks among
+themselves:
+
+    bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)!  =  multinomial s.toEnumFinset Prod.fst.
+
+## Main results (0 sorry, 0 axiom, no `native_decide`)
+* `sum_fst_toEnumFinset`           — `∑ i ∈ s.toEnumFinset, i.1 = s.sum`
+* `prod_factorial_fst_toEnumFinset`— `∏ i ∈ s.toEnumFinset, (i.1)! = (s.map (·!)).prod`
+* `factorialProd_mul_multinomial`  — `(s.map (·!)).prod · multinomial = s.sum!` (ordered count)
+* `bell_mul_count_eq_multinomial`  — **the bridge** `bell s · ∏ count! = multinomial`
+* `multinomial_eq_bell_mul_count`  — the bridge, multinomial-side
+* `factorialProd_dvd_factorial_sum`— `(s.map (·!)).prod ∣ s.sum!`
+* `bell_dvd_multinomial`           — `bell s ∣ multinomial s.toEnumFinset Prod.fst`
+* `bell_mul_factorial_recovers_uniform` — specialises to the parent's `uniformBell · m!`
+* concrete `bell {1,1,2} = 6`, `multinomial … = 12`
+
+Fully machine-checked, no extra axioms, no `native_decide`.
+-/
+
+import Mathlib.Combinatorics.Enumerative.Bell
+import Mathlib.Data.Nat.Choose.Multinomial
+import Mathlib.Data.Multiset.Fintype
+import Mathlib.Tactic
+
+namespace UniformBellMultinomialOQ01OQ01
+
+open Nat Finset
+
+variable (s : Multiset ℕ)
+
+/-- **Sum over the enumeration Finset.**  Reading off the size `i.1` of each of the
+`|s|` indexed blocks and summing recovers the ground-set size `s.sum`. -/
+theorem sum_fst_toEnumFinset : (∑ i ∈ s.toEnumFinset, i.1) = s.sum := by
+  rw [← Multiset.sum_eq_sum_toEnumFinset]
+
+/-- **Product of block-size factorials over the enumeration Finset** equals the
+multiset product of factorials `(s.map (·!)).prod`.  This is the denominator of
+the multinomial coefficient written in `toEnumFinset` form. -/
+theorem prod_factorial_fst_toEnumFinset :
+    (∏ i ∈ s.toEnumFinset, (i.1)!) = (s.map (fun j => j !)).prod := by
+  conv_rhs => rw [← Multiset.map_toEnumFinset_fst s, Multiset.map_map]
+  rfl
+
+/-- **Ordered equal-block count, non-uniform version.**  The multinomial
+coefficient indexed by `s.toEnumFinset` (one index per block, valued by its size)
+is the number of ways to drop `s.sum` labelled items into an ordered sequence of
+disjoint blocks of the prescribed sizes, and satisfies
+`(s.map (·!)).prod · multinomial = s.sum!`. -/
+theorem factorialProd_mul_multinomial :
+    (s.map (fun j => j !)).prod * Nat.multinomial s.toEnumFinset Prod.fst = (s.sum)! := by
+  have h := Nat.multinomial_spec s.toEnumFinset (Prod.fst)
+  rw [prod_factorial_fst_toEnumFinset, sum_fst_toEnumFinset] at h
+  exact h
+
+/-- Positivity of the factorial denominator `0 < (s.map (·!)).prod`. -/
+theorem factorialProd_pos : 0 < (s.map (fun j => j !)).prod := by
+  apply Nat.pos_of_ne_zero
+  apply Multiset.prod_ne_zero
+  rw [Multiset.mem_map]
+  rintro ⟨a, _, ha⟩
+  exact Nat.factorial_ne_zero a ha
+
+/-- **The non-uniform bridge** (answer to the open question).  For any size
+profile `s`, the unordered partition count `bell s` times the number of
+permutations of the equal-size blocks `∏_{j} (s.count j)!` equals the ordered
+count, i.e. the multinomial coefficient of the profile:
+
+    bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)!  =  multinomial s.toEnumFinset Prod.fst.
+
+Forgetting the order of equal-size blocks divides the ordered count by exactly
+the product of the block-multiplicity factorials. -/
+theorem bell_mul_count_eq_multinomial :
+    Multiset.bell s * ∏ j ∈ s.toFinset.erase 0, (s.count j)!
+      = Nat.multinomial s.toEnumFinset Prod.fst := by
+  have hP : 0 < (s.map (fun j => j !)).prod := factorialProd_pos s
+  refine Nat.eq_of_mul_eq_mul_left hP ?_
+  calc
+    (s.map (fun j => j !)).prod * (Multiset.bell s * ∏ j ∈ s.toFinset.erase 0, (s.count j)!)
+        = Multiset.bell s * (s.map (fun j => j !)).prod
+            * ∏ j ∈ s.toFinset.erase 0, (s.count j)! := by ring
+    _ = (s.sum)! := Multiset.bell_mul_eq s
+    _ = (s.map (fun j => j !)).prod * Nat.multinomial s.toEnumFinset Prod.fst :=
+        (factorialProd_mul_multinomial s).symm
+
+/-- The bridge, stated multinomial-side. -/
+theorem multinomial_eq_bell_mul_count :
+    Nat.multinomial s.toEnumFinset Prod.fst
+      = Multiset.bell s * ∏ j ∈ s.toFinset.erase 0, (s.count j)! :=
+  (bell_mul_count_eq_multinomial s).symm
+
+/-- **Integrality of the multinomial closed form.**  The denominator
+`(s.map (·!)).prod` divides `s.sum!`, witnessed by the multinomial coefficient. -/
+theorem factorialProd_dvd_factorial_sum :
+    (s.map (fun j => j !)).prod ∣ (s.sum)! :=
+  ⟨Nat.multinomial s.toEnumFinset Prod.fst, (factorialProd_mul_multinomial s).symm⟩
+
+/-- `bell s` divides the multinomial coefficient of its size profile: the
+unordered count is a genuine divisor of the ordered count. -/
+theorem bell_dvd_multinomial :
+    Multiset.bell s ∣ Nat.multinomial s.toEnumFinset Prod.fst :=
+  ⟨∏ j ∈ s.toFinset.erase 0, (s.count j)!, (bell_mul_count_eq_multinomial s).symm⟩
+
+/-- **Positivity of `bell`.**  An ordered count is positive, hence so is the
+unordered count: `0 < bell s`. -/
+theorem bell_pos : 0 < Multiset.bell s := by
+  rcases Nat.eq_zero_or_pos (Multiset.bell s) with h0 | h0
+  · exfalso
+    have h := bell_mul_count_eq_multinomial s
+    rw [h0, zero_mul] at h
+    exact (Nat.multinomial_pos s.toEnumFinset Prod.fst).ne' h.symm
+  · exact h0
+
+end UniformBellMultinomialOQ01OQ01
+
+namespace UniformBellMultinomialOQ01OQ01
+
+open Nat Finset
+
+/-! ### Recovering the parent's equal-block bridge
+
+When the size profile is constant, `s = replicate m n`, `Multiset.bell` is by
+definition `Nat.uniformBell m n`, and for `n ≠ 0`, `m ≠ 0` the multiplicity
+product collapses to the single factor `m!`.  The general bridge then specialises
+to the parent's `uniformBell m n · m! = multinomial`. -/
+
+/-- The multiplicity-factorial product collapses to `m!` for the constant profile
+`replicate m n` with `n ≠ 0`, `m ≠ 0`. -/
+theorem count_prod_replicate (m : ℕ) {n : ℕ} (hn : n ≠ 0) (hm : m ≠ 0) :
+    ∏ j ∈ (Multiset.replicate m n).toFinset.erase 0, ((Multiset.replicate m n).count j)!
+      = m ! := by
+  rw [Multiset.toFinset_replicate, if_neg hm]
+  rw [Finset.erase_eq_of_notMem (by simp only [Finset.mem_singleton]; omega)]
+  rw [Finset.prod_singleton, Multiset.count_replicate_self]
+
+/-- **The general bridge specialises to the parent's equal-block bridge.**  For a
+constant size profile, `bell (replicate m n) · m! = multinomial`, i.e.
+`uniformBell m n · m! = multinomial (replicate m n).toEnumFinset Prod.fst`. -/
+theorem bell_mul_factorial_recovers_uniform (m : ℕ) {n : ℕ} (hn : n ≠ 0) (hm : m ≠ 0) :
+    Nat.uniformBell m n * m !
+      = Nat.multinomial (Multiset.replicate m n).toEnumFinset Prod.fst := by
+  have h := bell_mul_count_eq_multinomial (Multiset.replicate m n)
+  rw [count_prod_replicate m hn hm] at h
+  rw [← h]
+  rfl
+
+/-! ### Concrete instance: profile `{1, 1, 2}`
+
+Partitions of a 4-element set into two singletons and one pair: choose the pair
+`C(4,2) = 6`, the remaining two elements are forced singletons, so `bell = 6`.
+The ordered (multinomial) count is `4!/(1!·1!·2!) = 12`, and the equal-block
+multiplicity factor is `(count 1)! = 2! = 2`, giving `6 · 2 = 12`. -/
+
+/-- `bell {1,1,2} = 6`. -/
+theorem bell_one_one_two : Multiset.bell {1, 1, 2} = 6 := by decide
+
+/-- The ordered count of the profile `{1,1,2}` is `12`. -/
+theorem multinomial_one_one_two :
+    Nat.multinomial ({1, 1, 2} : Multiset ℕ).toEnumFinset Prod.fst = 12 := by
+  rw [multinomial_eq_bell_mul_count]
+  decide
+
+end UniformBellMultinomialOQ01OQ01

--- a/src/data/proofs/uniformbell-multinomial-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/uniformbell-multinomial-oq-01-oq-01/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-imports-docstring",
+    "proofId": "uniformbell-multinomial-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "concept",
+    "title": "Block-Size Profiles and Multiset.bell",
+    "content": "For a multiset s : Multiset ℕ of prescribed block sizes, Multiset.bell s counts the partitions of an s.sum-element set into unordered blocks whose sizes are exactly s. Mathlib records the cornerstone bell s · (s.map (·!)).prod · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = s.sum!. The parent entry handled the constant profile s = replicate m n (uniformBell m n) and asked whether the bridge to the multinomial coefficient generalises. It does, for any profile."
+  },
+  {
+    "id": "ann-bookkeeping",
+    "proofId": "uniformbell-multinomial-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 80 },
+    "type": "technique",
+    "title": "Reading the Multinomial off toEnumFinset",
+    "content": "Indexing the |s| blocks by s.toEnumFinset and reading each size with Prod.fst keeps equal sizes distinct. sum_fst_toEnumFinset (via Multiset.sum_eq_sum_toEnumFinset) gives ∑ i.1 = s.sum; prod_factorial_fst_toEnumFinset (via map_toEnumFinset_fst + map_map) gives ∏ (i.1)! = (s.map (·!)).prod. Feeding these into Nat.multinomial_spec yields factorialProd_mul_multinomial: (s.map (·!)).prod · multinomial s.toEnumFinset Prod.fst = s.sum! — the ordered non-uniform count."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "uniformbell-multinomial-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 130 },
+    "type": "key-step",
+    "title": "The Non-Uniform Bridge",
+    "content": "Both Multiset.bell_mul_eq and factorialProd_mul_multinomial pin s.sum! as (s.map (·!)).prod times a cofactor. Since the factorial product is positive (factorialProd_pos), left-cancellation in ℕ (Nat.eq_of_mul_eq_mul_left) gives bell_mul_count_eq_multinomial: bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = multinomial s.toEnumFinset Prod.fst. Corollaries: bell s ∣ multinomial, (s.map (·!)).prod ∣ s.sum!, and 0 < bell s. Forgetting the order of equal-size blocks divides the ordered count by exactly the product of block-multiplicity factorials."
+  },
+  {
+    "id": "ann-recover-uniform",
+    "proofId": "uniformbell-multinomial-oq-01-oq-01",
+    "range": { "startLine": 131, "endLine": 167 },
+    "type": "key-step",
+    "title": "Recovering the Equal-Block Bridge",
+    "content": "For the constant profile replicate m n with n, m ≠ 0, Multiset.toFinset_replicate collapses the multiplicity product to (count n)! = m! (count_prod_replicate). The general bridge then specialises to uniformBell m n · m! = multinomial (replicate m n).toEnumFinset Prod.fst (bell_mul_factorial_recovers_uniform), recovering the parent entry's identity as the constant-profile case."
+  },
+  {
+    "id": "ann-instance",
+    "proofId": "uniformbell-multinomial-oq-01-oq-01",
+    "range": { "startLine": 168, "endLine": 188 },
+    "type": "example",
+    "title": "Worked Instance {1,1,2}",
+    "content": "Partitions of a 4-element set into two singletons and one pair: choose the pair (C(4,2) = 6), the remaining two elements are forced singletons, so bell {1,1,2} = 6 (kernel decide). The ordered count is multinomial = 4!/(1!·1!·2!) = 12, and indeed 6 · (count 1)! = 6 · 2! = 12 (multinomial_one_one_two via the bridge)."
+  }
+]

--- a/src/data/proofs/uniformbell-multinomial-oq-01-oq-01/meta.json
+++ b/src/data/proofs/uniformbell-multinomial-oq-01-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "uniformbell-multinomial-oq-01-oq-01",
+  "title": "The non-uniform bridge: Multiset.bell is a multinomial coefficient",
+  "slug": "uniformbell-multinomial-oq-01-oq-01",
+  "description": "Answers the parent entry's first open question: does the equal-block bridge uniformBell m n · m! = multinomial generalise to blocks of prescribed, non-uniform sizes? For an arbitrary size profile s : Multiset ℕ, it does — Multiset.bell s · ∏_{j} (s.count j)! = multinomial s.toEnumFinset Prod.fst. The unordered partition count times the number of ways to permute equal-size blocks equals the ordered (multinomial) count. Forgetting the order of equal-size blocks divides the ordered count by exactly the product of the block-multiplicity factorials. The bridge specialises back to the parent's constant-profile identity, and yields positivity, integrality, and a bell ∣ multinomial divisibility.",
+  "meta": {
+    "author": "E. T. Bell / classical combinatorics",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UniformBellMultinomialOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "bell-numbers",
+      "multinomial",
+      "set-partitions",
+      "enumerative",
+      "factorial",
+      "open-question-answer"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Multiset.bell_mul_eq",
+        "description": "The cornerstone identity bell m · (m.map (·!)).prod · ∏_{j ∈ m.toFinset.erase 0} (m.count j)! = m.sum! for an arbitrary size profile m",
+        "module": "Mathlib.Combinatorics.Enumerative.Bell"
+      },
+      {
+        "theorem": "Nat.multinomial_spec",
+        "description": "(∏ i ∈ s, (f i)!) · multinomial s f = (∑ i ∈ s, f i)!, applied with s = profile.toEnumFinset and f = Prod.fst to express the ordered count",
+        "module": "Mathlib.Data.Nat.Choose.Multinomial"
+      },
+      {
+        "theorem": "Multiset.map_toEnumFinset_fst",
+        "description": "m.toEnumFinset.val.map Prod.fst = m, used to evaluate the product of block-size factorials over the enumeration Finset",
+        "module": "Mathlib.Data.Multiset.Fintype"
+      },
+      {
+        "theorem": "Multiset.sum_eq_sum_toEnumFinset",
+        "description": "m.sum = ∑ x ∈ m.toEnumFinset, x.1, identifying the multinomial's numerator s.sum!",
+        "module": "Mathlib.Data.Multiset.Fintype"
+      },
+      {
+        "theorem": "Multiset.toFinset_replicate",
+        "description": "(replicate m n).toFinset = if m = 0 then ∅ else {n}, used to collapse the multiplicity product to m! in the constant-profile specialisation",
+        "module": "Mathlib.Data.Multiset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "bell_mul_count_eq_multinomial: the non-uniform bridge bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = multinomial s.toEnumFinset Prod.fst — the affirmative answer to the parent's open question, generalising uniformBell_mul_factorial from constant to arbitrary size profiles",
+      "factorialProd_mul_multinomial: the ordered non-uniform count (s.map (·!)).prod · multinomial s.toEnumFinset Prod.fst = s.sum!, the toEnumFinset form of multinomial_spec",
+      "prod_factorial_fst_toEnumFinset and sum_fst_toEnumFinset: the bookkeeping identities ∏ i ∈ s.toEnumFinset, (i.1)! = (s.map (·!)).prod and ∑ i ∈ s.toEnumFinset, i.1 = s.sum that align Mathlib's toEnumFinset multinomial with the bell cornerstone",
+      "bell_dvd_multinomial and factorialProd_dvd_factorial_sum: bell s ∣ multinomial and (s.map (·!)).prod ∣ s.sum!, the divisor/integrality consequences",
+      "bell_pos: 0 < bell s for every size profile (a partition with the prescribed sizes always exists)",
+      "bell_mul_factorial_recovers_uniform: the general bridge specialises to the parent's uniformBell m n · m! = multinomial for the constant profile replicate m n",
+      "bell_one_one_two, multinomial_one_one_two: the worked instance bell {1,1,2} = 6 and its ordered count 12, checked with kernel decide"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound. Concrete instances use kernel `decide` (no `native_decide`, so no `Lean.ofReduceBool`).",
+    "lineCount": 188,
+    "theoremCount": 13,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Counting set partitions by their block-size profile is the most refined of the Bell-number questions. For an unlabelled multiset of block sizes s, Multiset.bell s counts the partitions of an s.sum-element ground set whose blocks have exactly those sizes; the equal-block special case bell (replicate m n) = uniformBell m n is the subject of the parent entry. Mathlib records the structural identity bell s · ∏(sizes!) · ∏(multiplicities!) = s.sum! but, as in the uniform case, stops short of the multinomial dictionary that makes it meaningful.",
+    "problemStatement": "The parent entry proved the equal-block bridge uniformBell m n · m! = multinomial (range m) (const n) and asked: does it generalise to prescribed, non-uniform block sizes, i.e. is Multiset.bell s · ∏(multiplicities)! = the multinomial coefficient of the size profile? Answer this affirmatively and derive the surrounding theory (ordered count, positivity, integrality, divisibility, and the reduction back to the uniform case).",
+    "text": "For a size profile s : Multiset ℕ, the ordered count of ways to drop s.sum labelled items into a sequence of disjoint blocks of the prescribed sizes is the multinomial coefficient multinomial s.toEnumFinset Prod.fst = s.sum! / (s.map (·!)).prod. The unordered count is Multiset.bell s. The bridge bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = multinomial says that passing from ordered to unordered blocks divides by exactly the number of ways to permute the equal-size blocks among themselves.",
+    "proofStrategy": "1. sum_fst_toEnumFinset / prod_factorial_fst_toEnumFinset: read the multinomial's numerator and denominator off s.toEnumFinset using Multiset.sum_eq_sum_toEnumFinset and map_toEnumFinset_fst (with map_map), giving ∑ i.1 = s.sum and ∏ (i.1)! = (s.map (·!)).prod. 2. factorialProd_mul_multinomial: specialise Nat.multinomial_spec to s.toEnumFinset with f = Prod.fst and rewrite by the two bookkeeping identities to get (s.map (·!)).prod · multinomial = s.sum!. 3. bell_mul_count_eq_multinomial: both this and Multiset.bell_mul_eq pin s.sum! as (s.map (·!)).prod times a cofactor; the factorial product is positive (factorialProd_pos), so left-cancellation in ℕ (Nat.eq_of_mul_eq_mul_left) reads off bell s · ∏(count)! = multinomial. 4. Divisibility and positivity fall out as cofactor witnesses and a non-vanishing argument. 5. bell_mul_factorial_recovers_uniform: for s = replicate m n with n, m ≠ 0, toFinset_replicate collapses the multiplicity product to (count n)! = m!, recovering the parent identity. 6. Concrete instance {1,1,2}: bell = 6 by kernel decide, ordered count 12 via the bridge.",
+    "keyInsights": [
+      "**The right index set is toEnumFinset.** Indexing the |s| blocks by s.toEnumFinset and reading each block's size with Prod.fst keeps equal sizes distinct, so multinomial s.toEnumFinset Prod.fst = s.sum! / ∏(sizes!) is the honest ordered count for a non-uniform profile — exactly the object Multiset.bell_mul_eq compares against.",
+      "**Multiplicities, not block count, measure the over-count.** Going from ordered to unordered blocks, two orderings agree iff they permute equal-size blocks; there are ∏_j (s.count j)! such permutations, so the ordered count is the unordered count times that product — the content of the bridge.",
+      "**Cancellation over ℕ, no division.** Both the bell cornerstone and multinomial_spec express s.sum! as (s.map (·!)).prod times a cofactor; since the factorial product is positive, left-cancellation gives the bridge with no rationals and no integrality side-condition.",
+      "**The uniform case is a corollary.** Setting s = replicate m n collapses ∏_j (s.count j)! to the single factor m!, so the general bridge contains the parent's uniformBell m n · m! = multinomial as the constant-profile specialisation."
+    ],
+    "prerequisites": [
+      "Set partitions by block-size profile and the multiset Bell number Multiset.bell",
+      "Multinomial coefficients and Nat.multinomial_spec",
+      "Multiset.toEnumFinset and natural-number cancellation/divisibility"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "File-level docstring stating the open question, the size-profile interpretation of Multiset.bell, the cornerstone bell_mul_eq, and the multinomial-coefficient target. Imports Mathlib's Bell, Multinomial, and Multiset.Fintype files.",
+      "mathContext": "bell s counts unordered partitions with block-size profile s; multinomial s.toEnumFinset Prod.fst counts the ordered version."
+    },
+    {
+      "id": "bookkeeping",
+      "title": "Reading the Multinomial off toEnumFinset",
+      "startLine": 55,
+      "endLine": 80,
+      "summary": "sum_fst_toEnumFinset and prod_factorial_fst_toEnumFinset identify ∑ i.1 = s.sum and ∏ (i.1)! = (s.map (·!)).prod over the enumeration Finset, then factorialProd_mul_multinomial assembles multinomial_spec into (s.map (·!)).prod · multinomial = s.sum!.",
+      "mathContext": "The multinomial's numerator is s.sum! and its denominator is the product of block-size factorials."
+    },
+    {
+      "id": "bridge",
+      "title": "The Non-Uniform Bridge",
+      "startLine": 81,
+      "endLine": 130,
+      "summary": "factorialProd_pos gives positivity of the denominator; bell_mul_count_eq_multinomial cancels it from bell_mul_eq and factorialProd_mul_multinomial to obtain bell s · ∏(count)! = multinomial. multinomial_eq_bell_mul_count, factorialProd_dvd_factorial_sum, bell_dvd_multinomial, and bell_pos record the symmetric form and the divisor/positivity consequences.",
+      "mathContext": "Forgetting the order of equal-size blocks divides the ordered count by ∏_j (s.count j)!."
+    },
+    {
+      "id": "recover-uniform",
+      "title": "Recovering the Equal-Block Bridge",
+      "startLine": 131,
+      "endLine": 167,
+      "summary": "count_prod_replicate collapses the multiplicity product to m! for the constant profile (n, m ≠ 0); bell_mul_factorial_recovers_uniform then specialises the general bridge to uniformBell m n · m! = multinomial (replicate m n).toEnumFinset Prod.fst, matching the parent.",
+      "mathContext": "The general bridge contains the parent's equal-block identity as the constant-profile case."
+    },
+    {
+      "id": "instance",
+      "title": "Concrete Instance {1,1,2}",
+      "startLine": 168,
+      "endLine": 188,
+      "summary": "bell_one_one_two: bell {1,1,2} = 6 (choose the pair, C(4,2)=6, two forced singletons) by kernel decide; multinomial_one_one_two: the ordered count is 12 = 6 · 2! via the bridge.",
+      "mathContext": "Partitions of a 4-set into two singletons and a pair: 6 unordered, 12 ordered."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Bell, E. T.",
+      "title": "Exponential numbers",
+      "year": "1934",
+      "note": "Origin of the Bell numbers counting set partitions"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6 develops set partitions, multinomial coefficients, and block-size profiles"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "uniformbell-multinomial-oq-01",
+      "relationship": "answers",
+      "description": "Answers the first open question of the parent entry: the equal-block bridge generalises to arbitrary non-uniform size profiles via Multiset.bell"
+    },
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "related",
+      "description": "Stirling S(n,k) fixes the number of blocks; this entry fixes the full multiset of block sizes and relates the count to the multinomial coefficient"
+    }
+  ],
+  "conclusion": {
+    "summary": "For an arbitrary size profile s : Multiset ℕ, the unordered partition count Multiset.bell s and the ordered multinomial count multinomial s.toEnumFinset Prod.fst satisfy bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)! = multinomial — forgetting the order of equal-size blocks divides the ordered count by exactly the product of the block-multiplicity factorials. This answers the parent entry's open question affirmatively, generalising the constant-profile bridge. The entry also supplies the ordered count identity, positivity 0 < bell s, the integrality (s.map (·!)).prod ∣ s.sum!, the divisibility bell s ∣ multinomial, the reduction back to uniformBell m n · m!, and the worked instance {1,1,2}. All results are verified with 0 axioms and 0 sorries.",
+    "implications": "Completes the multinomial dictionary for block-size-profile set partitions: bell, the multinomial coefficient, and the multiplicity correction are now linked by a single cancellation identity usable for any profile, not just equal blocks.",
+    "openQuestions": [
+      "Can Multiset.bell s be realised as the cardinality of an explicit Finset of set-partitions with block-size profile s, upgrading the arithmetic bridge to a bijective count?",
+      "Does the bridge refine to a generating-function identity ∑_s bell s · x^(s.sum) / aut(s) = exp(∑ x^k/k!) recovering the exponential formula for set partitions?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Enumerative.Bell",
+      "Mathlib.Data.Nat.Choose.Multinomial",
+      "Mathlib.Data.Multiset.Fintype",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "UniformBellMultinomialOQ01OQ01",
+    "lineCount": 188,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 0,
+    "path": "Proofs/UniformBellMultinomialOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `uniformbell-multinomial-oq-01`:

> *Does the bridge generalise to blocks of prescribed (non-uniform) sizes, i.e. `Multiset.bell m · ∏ (multiplicities)! = multinomial` of the size profile?*

**Yes.** For any size profile `s : Multiset ℕ`:

```
Multiset.bell s · ∏_{j ∈ s.toFinset.erase 0} (s.count j)!  =  Nat.multinomial s.toEnumFinset Prod.fst
```

The **unordered** partition count (`bell s`) times the number of ways to permute the equal-size blocks (`∏_j (s.count j)!`) equals the **ordered** count — the multinomial coefficient `s.sum! / (s.map (·!)).prod` of the profile. Forgetting block order divides the ordered count by exactly the product of the block-multiplicity factorials.

## Proof

Both `Multiset.bell_mul_eq` and the `toEnumFinset` form of `Nat.multinomial_spec` pin `s.sum!` as `(s.map (·!)).prod` times a cofactor. The factorial denominator is positive, so left-cancellation in ℕ reads off the bridge — no division, no integrality side-condition.

## Contents (13 theorems, 0 defs, 188 lines)

- `bell_mul_count_eq_multinomial` — **the bridge** (the OQ answer)
- `factorialProd_mul_multinomial` — ordered non-uniform count `(s.map (·!)).prod · multinomial = s.sum!`
- `sum_fst_toEnumFinset`, `prod_factorial_fst_toEnumFinset` — bookkeeping over `toEnumFinset`
- `bell_dvd_multinomial`, `factorialProd_dvd_factorial_sum` — divisor / integrality corollaries
- `bell_pos` — `0 < bell s` for every profile
- `bell_mul_factorial_recovers_uniform` — specialises back to the parent's `uniformBell m n · m! = multinomial`
- `bell_one_one_two` / `multinomial_one_one_two` — worked instance `{1,1,2}` (6 unordered, 12 ordered), kernel `decide`

## Verification

- `#print axioms` on every theorem: `propext`, `Classical.choice`, `Quot.sound` only.
- **0 axioms, 0 sorries, no `native_decide`** (no `Lean.ofReduceBool`). Status: `verified`.
- Built with Lean `v4.26.0` + Mathlib (docker unavailable; single-file kernel compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)