### PR TITLE
Enrich Rational Three Squares (oq-03-oq-06): annotations, overview, sections

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "tsrn-ann-context",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "What is unconditional, and what is not",
+    "content": "The header isolates the logical bookkeeping of the whole entry. Two gallery facts are taken as proved and axiom-free: integral necessity (`ThreeSquares.excluded_form_not_sum_three_sq`: $4^a(8b+7)$ is never a sum of three integer squares) and the Davenport–Cassels descent (`ThreeSquaresDavenportCassels.exists_int_sq_of_rat_sq`: rational representability by $x^2+y^2+z^2$ forces integral representability). Everything in this file is a *consequence* of combining those two. The only genuinely open input — quarantined to a single hypothesis — is sufficiency over $\\mathbb{Q}$ (Hasse–Minkowski solvability), which Mathlib does not yet contain.",
+    "mathContext": "Legendre: $n = x^2+y^2+z^2$ solvable over $\\mathbb{Z}$ $\\iff$ $n \\neq 4^a(8b+7)$. The necessity ($\\Rightarrow$) half is unconditional; this file lifts it to $\\mathbb{Q}$.",
+    "significance": "context",
+    "relatedConcepts": ["three-square theorem", "Davenport-Cassels lemma", "Hasse-Minkowski principle", "local-global principle"],
+    "prerequisites": ["quadratic forms", "additive number theory"]
+  },
+  {
+    "id": "tsrn-ann-imports",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 34, "endLine": 42 },
+    "type": "technique",
+    "title": "Importing the two axiom-free pillars",
+    "content": "The file imports the three sibling modules it depends on — `ThreeSquares` (integral necessity), `ThreeSquaresDavenportCassels` (the descent), and `ThreeSquaresRationalBridge` (the trivial $\\mathbb{Z}\\subseteq\\mathbb{Q}$ inclusion plus the named open hypothesis `ThreeSquaresRationalSolvability`). Opening the `ThreeSquares` and `ThreeSquaresRationalBridge` namespaces brings `IsExcludedForm`, `excluded_form_not_sum_three_sq`, and `rat_sq_of_int_sq` into scope without qualification. No new mathematical content is introduced here; this entry is purely a synthesis layer.",
+    "mathContext": "Dependency graph: this file $= \\text{descent} \\;\\wedge\\; \\text{integral necessity} \\;\\wedge\\; (\\mathbb{Z}\\subseteq\\mathbb{Q})$.",
+    "significance": "technical",
+    "relatedConcepts": ["module dependencies", "namespace management"],
+    "prerequisites": ["Lean 4 module system"]
+  },
+  {
+    "id": "tsrn-ann-iff",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 44, "endLine": 54 },
+    "type": "insight",
+    "title": "Rational = integral, packaged as an honest Iff",
+    "content": "`three_rat_sq_iff_three_int_sq` is the headline result: for the single form $x^2+y^2+z^2$, an integer $n$ is a sum of three *rational* squares exactly when it is a sum of three *integer* squares. The forward direction is the Davenport–Cassels descent (denominators can never help); the reverse is the one-line inclusion of $\\mathbb{Z}$ into $\\mathbb{Q}$. This is the first place the descent is recorded as a clean equivalence rather than a one-way implication — making explicit that the rational and integral representation problems for this form are literally the same problem.",
+    "mathContext": "$(\\exists x,y,z\\in\\mathbb{Q},\\; x^2+y^2+z^2=n) \\iff (\\exists a,b,c\\in\\mathbb{Z},\\; a^2+b^2+c^2=n)$. The descent works because every rational point of the sphere is within squared-distance $\\le 3/4 < 1$ of a lattice point.",
+    "significance": "key",
+    "relatedConcepts": ["Davenport-Cassels descent", "nearest-integer rounding", "rational points on quadrics"],
+    "prerequisites": ["quadratic forms", "rational points"]
+  },
+  {
+    "id": "tsrn-ann-rational-necessity",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 56, "endLine": 72 },
+    "type": "insight",
+    "title": "Rational necessity: the 2-adic obstruction is rational",
+    "content": "`excluded_form_not_sum_three_rat_sq` lifts Legendre's necessity from $\\mathbb{Z}$ to $\\mathbb{Q}$: a number of the form $4^a(8b+7)$ is not even a sum of three *rational* squares. A priori, allowing denominators could only make representability easier, so this is genuinely new content rather than a restatement. The proof is a clean contradiction: a rational representation would, by the Iff above, yield an integral one, contradicting the unconditional integral necessity `excluded_form_not_sum_three_sq`. The `push_cast` step merely reconciles the $\\mathbb{N}\\to\\mathbb{Z}\\to\\mathbb{Q}$ coercions so the hypothesis matches Davenport–Cassels' integer-indexed statement.",
+    "mathContext": "If $n = 4^a(8b+7)$ then $\\neg\\,\\exists x,y,z\\in\\mathbb{Q}:\\, x^2+y^2+z^2=n$. The obstruction lives in $\\mathbb{Q}_2$: the form $x^2+y^2+z^2$ represents $n$ over $\\mathbb{Q}$ only if it does over every completion, and it fails over $\\mathbb{Q}_2$ exactly on this family.",
+    "significance": "key",
+    "relatedConcepts": ["2-adic obstruction", "p-adic numbers", "proof by contradiction", "Legendre three-square theorem"],
+    "prerequisites": ["p-adic numbers", "quadratic forms over local fields"]
+  },
+  {
+    "id": "tsrn-ann-sqclass-rat",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 74, "endLine": 87 },
+    "type": "technique",
+    "title": "Square-class invariance over the rationals",
+    "content": "`three_rat_sq_iff_sq_mul` shows representability is invariant under multiplication by a nonzero rational square: $n$ is a sum of three rational squares iff $m^2 n$ is. The proof is constructive in both directions — scale a representation of $n$ coordinatewise by $m$ to get one of $m^2 n$, or divide by $m$ to go back. Lean discharges the forward identity by `ring` and the backward one by `field_simp` (clearing the $1/m$ denominators) followed by `linear_combination`, which certifies the polynomial identity against the hypothesis. The nonvanishing hypothesis $m \\neq 0$ is essential for the division.",
+    "mathContext": "$(\\exists x,y,z:\\,x^2+y^2+z^2=n) \\iff (\\exists x,y,z:\\,x^2+y^2+z^2=m^2 n)$ for $m\\neq 0$. Forward: $(x,y,z)\\mapsto(mx,my,mz)$. Backward: $(x,y,z)\\mapsto(x/m,y/m,z/m)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["square class", "scaling invariance", "field_simp", "linear_combination"],
+    "prerequisites": ["field arithmetic", "quadratic forms"]
+  },
+  {
+    "id": "tsrn-ann-sqclass-nat",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 89, "endLine": 100 },
+    "type": "concept",
+    "title": "Reduction to the squarefree part",
+    "content": "`three_rat_sq_iff_natSq_mul` is the natural-number specialisation of square-class invariance: $s$ and $m^2 s$ are simultaneously sums of three rational squares. This is precisely the step that powers the gallery's squarefree reduction — every natural number factors as (square) × (squarefree part), so rational three-square representability is a function of the squarefree part alone. Consequently the still-open Hasse–Minkowski input is only ever needed for *squarefree* arguments. The proof rewrites the cast $((m^2 s : \\mathbb{N}):\\mathbb{Q}) = (m:\\mathbb{Q})^2\\cdot(s:\\mathbb{Q})$ via `push_cast` and then defers to the rational version.",
+    "mathContext": "Write $s = k^2 \\cdot \\mathrm{sf}(s)$ with $\\mathrm{sf}(s)$ squarefree. Then $s$ is a sum of three rational squares iff $\\mathrm{sf}(s)$ is — the open sufficiency question reduces to squarefree $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["squarefree part", "square class", "type coercions", "push_cast"],
+    "prerequisites": ["elementary number theory", "type coercions in Lean"]
+  },
+  {
+    "id": "tsrn-ann-full-char",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-06",
+    "range": { "startLine": 102, "endLine": 115 },
+    "type": "insight",
+    "title": "The full characterization, with the open part quarantined",
+    "content": "`three_rat_sq_iff_not_excluded` assembles the complete rational characterization: $n$ is a sum of three rational squares iff $n$ is not of the excluded form. Crucially, the two halves draw on different resources. The necessity ($\\rightarrow$) half is the *unconditional* `excluded_form_not_sum_three_rat_sq` proved above; only the sufficiency ($\\leftarrow$) half consumes the open hypothesis `ThreeSquaresRationalSolvability`, supplied here as the argument `hRat`. This single line pins down exactly how much of the three-square 'if' direction remains open — everything except rational solvability for squarefree non-excluded $n$.",
+    "mathContext": "$(\\exists x,y,z\\in\\mathbb{Q}:\\,x^2+y^2+z^2=n) \\iff \\neg\\,\\mathrm{IsExcludedForm}(n)$, conditional on `ThreeSquaresRationalSolvability`. Forward half unconditional; backward half $=$ Hasse–Minkowski.",
+    "significance": "key",
+    "relatedConcepts": ["local-global principle", "Hasse-Minkowski", "conditional theorem", "open problem isolation"],
+    "prerequisites": ["Hasse-Minkowski principle", "quadratic forms over Q"]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-06/meta.json
@@ -21,6 +21,70 @@
     "sorries": 0
   },
   "title": "Rational Three Squares: the Unconditional Half via Davenport-Cassels",
+  "description": "Combines the gallery's two axiom-free pillars — integral necessity for the three-square theorem and the Davenport-Cassels descent — into the unconditional half of the rational characterization: rational and integral three-square representability coincide, the excluded family 4^a(8b+7) is non-representable even over ℚ, and representability is invariant under square classes (so only the squarefree part matters). The residual open content is isolated to a single Hasse-Minkowski solvability hypothesis.",
+  "overview": {
+    "historicalContext": "Legendre's three-square theorem (1798) characterizes the integers represented by x²+y²+z² as exactly those not of the form 4^a(8b+7). Its necessity half is elementary 2-adic arithmetic; its sufficiency half is deep, classically resting on the theory of ternary quadratic forms or on Dirichlet's theorem on primes in arithmetic progressions. The Davenport-Cassels lemma — due in essence to Aubry (1912) and given its standard form by Cassels, popularized through Davenport and Mordell's 1955 work — observes that for forms whose every rational point lies within distance < 1 of a lattice point, rational representability already implies integral representability via a nearest-integer descent. The sum of three squares is the boundary case: the maximal squared distance from a rational point of the sphere to the integer lattice is 3/4 < 1, whereas for four squares it is exactly 1 and the descent breaks. This entry packages that descent as a clean equivalence and traces out precisely which parts of the rational analogue of Legendre's theorem follow unconditionally.",
+    "problemStatement": "Over ℚ, characterize the integers $n$ representable as $x^2+y^2+z^2$ with $x,y,z\\in\\mathbb{Q}$. Determine which portion of this characterization is unconditional (derivable from already-formalized, axiom-free facts) and which portion requires the still-unformalized Hasse-Minkowski solvability input.",
+    "proofStrategy": "Treat the file as a synthesis layer over two proved gallery facts. (1) Promote the Davenport-Cassels descent to an honest Iff `three_rat_sq_iff_three_int_sq` by pairing it with the trivial $\\mathbb{Z}\\subseteq\\mathbb{Q}$ inclusion. (2) Lift Legendre's necessity to ℚ by contradiction: a rational representation of an excluded number would descend to an integral one, contradicting `excluded_form_not_sum_three_sq`. (3) Establish square-class invariance constructively by coordinatewise scaling, discharged with `ring`, `field_simp`, and `linear_combination`. (4) Specialize scaling to ℕ to expose the squarefree reduction. (5) Assemble the full characterization `three_rat_sq_iff_not_excluded` so that only its sufficiency half consumes the open hypothesis, quarantining the open content to a single statement.",
+    "keyInsights": [
+      "Denominators never help: for x²+y²+z² the rational and integral representation problems are literally identical (an Iff, not merely an implication), because the sphere's rational points are always within squared-distance 3/4 < 1 of the integer lattice.",
+      "The 2-adic obstruction is rational, not merely integral: the family 4^a(8b+7) fails to be a sum of three squares even when arbitrary rational coordinates are allowed, so the local failure at the prime 2 is intrinsic to the form over ℚ.",
+      "Representability is a square-class invariant: n and m²·n behave identically, so the entire question depends only on the squarefree part of n — collapsing the open sufficiency problem to squarefree arguments.",
+      "The open frontier is a single point: every part of the rational three-square characterization except sufficiency for squarefree non-excluded n is now unconditional and machine-checked; the lone missing input is the Hasse-Minkowski local-global solvability statement absent from Mathlib.",
+      "Four squares is the boundary failure of the same method: the Davenport-Cassels descent that makes three squares 'rational = integral' breaks for four squares precisely because the maximal lattice distance rises from 3/4 to 1."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-header",
+      "title": "Context: the unconditional vs. the open",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Docstring laying out the two axiom-free inputs (integral necessity and the Davenport-Cassels descent) and quarantining the single open piece (rational sufficiency / Hasse-Minkowski). States the file is free of axiom, sorry, and native_decide."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and namespace",
+      "startLine": 34,
+      "endLine": 42,
+      "summary": "Imports the three dependency modules and opens the ThreeSquares and ThreeSquaresRationalBridge namespaces, bringing IsExcludedForm, excluded_form_not_sum_three_sq, and rat_sq_of_int_sq into scope."
+    },
+    {
+      "id": "iff-rational-integral",
+      "title": "Rational equals integral (Davenport-Cassels Iff)",
+      "startLine": 44,
+      "endLine": 54,
+      "summary": "`three_rat_sq_iff_three_int_sq`: the descent packaged as an equivalence — n is a sum of three rational squares iff it is a sum of three integer squares. Forward = the descent, reverse = ℤ ⊆ ℚ."
+    },
+    {
+      "id": "rational-necessity",
+      "title": "Rational necessity",
+      "startLine": 56,
+      "endLine": 72,
+      "summary": "`excluded_form_not_sum_three_rat_sq`: the excluded family 4^a(8b+7) is not even a sum of three rational squares, proved by descending a hypothetical rational representation to an integer one and invoking integral necessity."
+    },
+    {
+      "id": "square-class-rational",
+      "title": "Square-class invariance (rational scalar)",
+      "startLine": 74,
+      "endLine": 87,
+      "summary": "`three_rat_sq_iff_sq_mul`: n is a sum of three rational squares iff m²·n is, for m ≠ 0, by coordinatewise scaling; discharged with ring, field_simp, and linear_combination."
+    },
+    {
+      "id": "square-class-nat",
+      "title": "Square-class invariance (natural scalar) and squarefree reduction",
+      "startLine": 89,
+      "endLine": 100,
+      "summary": "`three_rat_sq_iff_natSq_mul`: the ℕ-indexed scaling form, the rational step behind the gallery's squarefree reduction — representability depends only on the squarefree part of n."
+    },
+    {
+      "id": "full-characterization",
+      "title": "Full rational characterization (conditional)",
+      "startLine": 102,
+      "endLine": 115,
+      "summary": "`three_rat_sq_iff_not_excluded`: n is a sum of three rational squares iff ¬IsExcludedForm n, conditional only on ThreeSquaresRationalSolvability; necessity half unconditional, sufficiency half consumes the hypothesis."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-06` (Rational Three Squares: the Unconditional Half via Davenport-Cassels). The entry previously had only meta.json with no annotations, overview, or sections.

## Added
- **annotations.json** (new): 7 annotations covering the context header, imports, and all 5 theorems — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **overview** (new): `historicalContext` (Legendre 1798; Aubry/Cassels/Davenport-Mordell descent; the 3/4 < 1 vs. 1 boundary distinguishing three squares from four), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **sections** (new): 7 sections covering the full 115-line Lean file.
- **description** (new): top-level summary.

## Notes
- No changes to the Lean source or to status/badge/axiomCount — meta already accurately reports `verified` / `original` / 0 axioms, consistent with the source (no axiom/sorry/native_decide).
- The conditional `three_rat_sq_iff_not_excluded` correctly carries its Hasse-Minkowski hypothesis as an explicit argument; annotations and overview emphasize that only its sufficiency half is conditional.
- Build's data-generation/validation step passes; the entry now appears in generated listings.