### PR TITLE
research(cauchy-interlacing-theorem-oq-01-oq-01): orthogonal compression to a coordinate hyperplane IS the principal submatrix [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -512,6 +512,7 @@ import Proofs.CatalanNumbersOQ01
 import Proofs.CauchyGroupTheoremOQ01
 import Proofs.CauchyGroupTheoremOQ01OQ01
 import Proofs.CauchyInterlacingKeystone
+import Proofs.CauchyInterlacingOQ01OQ01
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral
 import Proofs.CauchySchwarzIntegralOQ01

--- a/proofs/Proofs/CauchyInterlacingOQ01OQ01.lean
+++ b/proofs/Proofs/CauchyInterlacingOQ01OQ01.lean
@@ -1,0 +1,145 @@
+import Mathlib
+
+/-
+# The Orthogonal Compression to a Coordinate Hyperplane Is the Principal Submatrix
+
+`Proofs/CauchyInterlacingCompression.lean` builds, for a symmetric operator `T` on a finite
+dimensional inner product space `V` and a codimension-one subspace `H ≤ V`, the **orthogonal
+compression**
+
+  `compress T H := P_H ∘ T ∘ ι_H : H →ₗ[𝕜] H`,
+
+and proves its eigenvalues interlace those of `T` (`cauchy_interlacing_compression`). Its
+docstring asserts — but does not prove — that *"for a Hermitian matrix and a coordinate
+hyperplane this is exactly the principal submatrix obtained by deleting a row and column."*
+That identification is the first open question left by that file.
+
+This file proves it. Fix a square matrix `A : Matrix (Fin (n+1)) (Fin (n+1)) 𝕜`, an index
+`j`, and view `A` as the operator `toEuclideanLin A` on `EuclideanSpace 𝕜 (Fin (n+1))`. Take
+the coordinate hyperplane
+
+  `H = span 𝕜 { e_{j.succAbove i} : i : Fin n }`,
+
+the span of the `n` standard basis vectors *other than* `e_j`. We show that the sesquilinear
+form of the orthogonal compression `compress (toEuclideanLin A) H`, read off on the natural
+orthonormal basis `(e_{j.succAbove i})` of `H`, is **exactly** the principal submatrix
+`A.submatrix j.succAbove j.succAbove` obtained by deleting row `j` and column `j`:
+
+  `⟪e_{j.succAbove i'}, compress (toEuclideanLin A) H e_{j.succAbove i}⟫
+      = A (j.succAbove i') (j.succAbove i)`.    (`compress_inner_eq_principalSubmatrix`)
+
+The two ingredients are (i) the orthogonal-projection adjoint identity, which collapses the
+compression's inner product on `H` to `T`'s inner product on `V`
+(`inner_compress_eq`), and (ii) the elementary entry formula
+`⟪e_a, toEuclideanLin A e_b⟫ = A a b` (`inner_single_toEuclideanLin_single`).
+
+We also record that the principal submatrix is Hermitian when `A` is
+(`isHermitian_principalSubmatrix`), and that the coordinate hyperplane really is `n`
+dimensional (`finrank_coordinateHyperplane`), so that this identification slots directly into
+`cauchy_interlacing_compression` to yield interlacing of the principal submatrix's
+eigenvalues. The eigenvalue-level corollary itself is left for follow-up.
+
+All results hold over any `RCLike` field `𝕜` (so `ℝ` and `ℂ`). Absent from Mathlib.
+-/
+
+open scoped InnerProductSpace
+open Matrix
+
+namespace CauchyInterlacingOQ01OQ01
+
+section Compress
+
+variable {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- The orthogonal **compression** of `T` to a subspace `H`: project `T ↑y` back into `H`.
+This mirrors `CauchyInterlacing.Compression.compress`; it is reproduced here so the file is
+self-contained. -/
+noncomputable def compress (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) : H →ₗ[𝕜] H :=
+  (H.orthogonalProjection : V →L[𝕜] H).toLinearMap ∘ₗ (T ∘ₗ H.subtype)
+
+@[simp] theorem compress_apply (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y : H) :
+    compress T H y = H.orthogonalProjection (T (y : V)) := rfl
+
+/-- **The compression's inner product collapses to `T`'s.** On `H`, the sesquilinear form of
+the orthogonal compression equals that of `T` on the ambient space: the orthogonal projection
+is invisible to inner products with vectors already in `H`. -/
+theorem inner_compress_eq (T : V →ₗ[𝕜] V) (H : Submodule 𝕜 V) (y z : H) :
+    @inner 𝕜 H _ y (compress T H z) = @inner 𝕜 V _ (y : V) (T (z : V)) := by
+  rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_left]
+
+end Compress
+
+section Matrix
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : ℕ}
+
+/-- The standard basis vector `e_a = single a 1` of `EuclideanSpace 𝕜 (Fin (n+1))`. -/
+noncomputable abbrev e (a : Fin (n + 1)) : EuclideanSpace 𝕜 (Fin (n + 1)) :=
+  EuclideanSpace.single a (1 : 𝕜)
+
+/-- **Matrix entries via inner products of basis vectors.** Viewing `A` as the operator
+`toEuclideanLin A`, the `(a, b)` entry is recovered as `⟪e_a, A e_b⟫`. -/
+theorem inner_single_toEuclideanLin_single (A : Matrix (Fin (n + 1)) (Fin (n + 1)) 𝕜)
+    (a b : Fin (n + 1)) :
+    @inner 𝕜 _ _ (e a) (Matrix.toEuclideanLin A (e b)) = A a b := by
+  rw [EuclideanSpace.inner_single_left, map_one, one_mul]
+  show (Matrix.toEuclideanLin A (EuclideanSpace.single b (1 : 𝕜))) a = A a b
+  rw [Matrix.toEuclideanLin_apply, EuclideanSpace.ofLp_single, Matrix.mulVec_single_one]
+  rfl
+
+variable (A : Matrix (Fin (n + 1)) (Fin (n + 1)) 𝕜) (j : Fin (n + 1))
+
+/-- The **coordinate hyperplane** for index `j`: the span of the `n` standard basis vectors
+`e_{j.succAbove i}`, i.e. every standard basis vector except `e_j`. -/
+noncomputable def coordinateHyperplane : Submodule 𝕜 (EuclideanSpace 𝕜 (Fin (n + 1))) :=
+  Submodule.span 𝕜 (Set.range fun i : Fin n => e (𝕜 := 𝕜) (j.succAbove i))
+
+/-- `e_{j.succAbove i}` lies in the coordinate hyperplane. -/
+theorem mem_coordinateHyperplane (i : Fin n) :
+    e (𝕜 := 𝕜) (j.succAbove i) ∈ coordinateHyperplane (𝕜 := 𝕜) j :=
+  Submodule.subset_span ⟨i, rfl⟩
+
+/-- The `i`-th natural basis vector of the coordinate hyperplane, as an element of the
+subspace. -/
+noncomputable def hyperplaneBasis (i : Fin n) : coordinateHyperplane (𝕜 := 𝕜) j :=
+  ⟨e (j.succAbove i), mem_coordinateHyperplane j i⟩
+
+/-- **Main identification.** The orthogonal compression of `toEuclideanLin A` to the
+coordinate hyperplane `H`, evaluated as a sesquilinear form on the natural basis
+`(e_{j.succAbove i})` of `H`, is exactly the principal submatrix of `A` obtained by deleting
+row `j` and column `j`:
+
+`⟪e_{j.succAbove i'}, compress (toEuclideanLin A) H e_{j.succAbove i}⟫
+    = (A.submatrix j.succAbove j.succAbove) i' i`. -/
+theorem compress_inner_eq_principalSubmatrix (i i' : Fin n) :
+    @inner 𝕜 _ _ (hyperplaneBasis j i')
+        (compress (Matrix.toEuclideanLin A) (coordinateHyperplane j) (hyperplaneBasis j i))
+      = (A.submatrix j.succAbove j.succAbove) i' i := by
+  rw [inner_compress_eq]
+  exact inner_single_toEuclideanLin_single A (j.succAbove i') (j.succAbove i)
+
+/-- The principal submatrix obtained by deleting row `j` and column `j` is Hermitian whenever
+`A` is. Together with the identification above, the compression is a Hermitian operator with
+matrix the principal submatrix. -/
+theorem isHermitian_principalSubmatrix (hA : A.IsHermitian) :
+    (A.submatrix j.succAbove j.succAbove).IsHermitian :=
+  hA.submatrix j.succAbove
+
+/-- The coordinate hyperplane has dimension `n`: it is a genuine codimension-one subspace of
+the `(n+1)`-dimensional ambient space, so it is exactly the kind of hyperplane
+`cauchy_interlacing_compression` expects. -/
+theorem finrank_coordinateHyperplane :
+    Module.finrank 𝕜 (coordinateHyperplane (𝕜 := 𝕜) (n := n) j) = n := by
+  classical
+  have hortho : Orthonormal 𝕜 (fun i : Fin n => e (𝕜 := 𝕜) (j.succAbove i)) := by
+    have hbase : Orthonormal 𝕜 (fun a : Fin (n + 1) => e (𝕜 := 𝕜) a) :=
+      EuclideanSpace.orthonormal_single (𝕜 := 𝕜) (ι := Fin (n + 1))
+    exact hbase.comp _ (Fin.succAbove_right_injective (p := j))
+  have hli : LinearIndependent 𝕜 (fun i : Fin n => e (𝕜 := 𝕜) (j.succAbove i)) :=
+    hortho.linearIndependent
+  rw [coordinateHyperplane, finrank_span_eq_card hli, Fintype.card_fin]
+
+end Matrix
+
+end CauchyInterlacingOQ01OQ01

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-inner-compress-eq",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 70 },
+    "type": "insight",
+    "title": "The Compression's Inner Product Collapses to the Ambient One",
+    "content": "`inner_compress_eq`: for `y, z ∈ H`, `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`. The single rewrite `Submodule.inner_orthogonalProjection_eq_of_mem_left` does all the work: pairing the projected vector `P_H (T ↑z)` against `y`, which already lives in `H`, equals pairing `T ↑z` against `↑y`. The orthogonal projection is simply invisible to inner products with vectors of the subspace.",
+    "mathContext": "P_H is self-adjoint and fixes H pointwise, so ⟪y, P_H w⟫_H = ⟪↑y, w⟫_V for y ∈ H.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal projection adjoint", "compression", "sesquilinear form"],
+    "prerequisites": ["inner product adjoint of orthogonal projection"]
+  },
+  {
+    "id": "ann-entry-inner",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 90 },
+    "type": "insight",
+    "title": "Matrix Entries Are Basis Inner Products",
+    "content": "`inner_single_toEuclideanLin_single`: `⟪e_a, (toEuclideanLin A) e_b⟫ = A a b`. `EuclideanSpace.inner_single_left` reads off coordinate `a` of the image, `Matrix.toEuclideanLin_apply` says the operator is matrix-vector multiplication, and `Matrix.mulVec_single_one` extracts the `b`-th column when the input is the standard basis vector `e_b`. The abstract operator identity becomes a one-line column lookup.",
+    "mathContext": "⟪e_a, A e_b⟫ = (A·e_b)_a = (column b of A)_a = A_{a b}.",
+    "significance": "important",
+    "relatedConcepts": ["standard basis", "matrix-vector multiplication", "toEuclideanLin"],
+    "prerequisites": ["EuclideanSpace coordinates", "column of a matrix"]
+  },
+  {
+    "id": "ann-coordinate-hyperplane",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 113 },
+    "type": "definition",
+    "title": "The Coordinate Hyperplane",
+    "content": "`coordinateHyperplane j = span 𝕜 { e_{j.succAbove i} : i : Fin n }`: the span of every standard basis vector except `e_j`. `Fin.succAbove j` is the order-preserving injection `Fin n ↪ Fin (n+1)` that skips `j`, so this is exactly the codimension-one coordinate subspace `{x : x_j = 0}`. `finrank_coordinateHyperplane` confirms its dimension is `n`, because the spanning family is an orthonormal sub-family of the standard basis and hence linearly independent.",
+    "mathContext": "H = {x ∈ 𝕜^{n+1} : x_j = 0}, an n-dimensional coordinate hyperplane.",
+    "significance": "key",
+    "relatedConcepts": ["coordinate subspace", "Fin.succAbove", "orthonormal family", "finrank of a span"],
+    "prerequisites": ["span and finrank", "orthonormal implies linearly independent"]
+  },
+  {
+    "id": "ann-identification",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 130 },
+    "type": "theorem",
+    "title": "Compression Equals Principal Submatrix",
+    "content": "`compress_inner_eq_principalSubmatrix`: `⟪e_{j.succAbove i'}, compress (toEuclideanLin A) H e_{j.succAbove i}⟫ = (A.submatrix j.succAbove j.succAbove) i' i`. One rewrite by `inner_compress_eq` reduces the compression's form to the ambient form `⟪e_{j.succAbove i'}, A e_{j.succAbove i}⟫`, which the entry lemma evaluates to `A (j.succAbove i') (j.succAbove i)` — definitionally the principal-submatrix entry. This is the textbook identification the parent file only asserted.",
+    "mathContext": "The matrix of the compression in the coordinate basis of H is precisely A with row j and column j deleted.",
+    "significance": "key",
+    "relatedConcepts": ["principal submatrix", "compression", "Cauchy interlacing"],
+    "prerequisites": ["Matrix.submatrix", "the two ingredient lemmas above"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-01",
+  "title": "The Orthogonal Compression to a Coordinate Hyperplane Is the Principal Submatrix",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-01",
+  "description": "The compression corollary of Cauchy interlacing (cauchy-interlacing-theorem-oq-01) builds the abstract orthogonal compression compress T H = P_H ∘ T ∘ ι_H of a symmetric operator T to a codimension-one subspace H and proves its eigenvalues interlace those of T. Its docstring asserts, but does not prove, that for a Hermitian matrix and a coordinate hyperplane this compression is exactly the principal submatrix obtained by deleting a row and column. This entry proves that identification. Viewing a square matrix A : Matrix (Fin (n+1)) (Fin (n+1)) 𝕜 as the operator toEuclideanLin A on EuclideanSpace 𝕜 (Fin (n+1)), and taking the coordinate hyperplane H = span{e_{j.succAbove i} : i : Fin n} (all standard basis vectors except e_j), the sesquilinear form of the orthogonal compression of A to H, read off on the natural orthonormal basis (e_{j.succAbove i}) of H, equals exactly the principal submatrix A.submatrix j.succAbove j.succAbove obtained by deleting row j and column j. The coordinate hyperplane is shown to have dimension n and the principal submatrix is shown to be Hermitian, so the identification slots directly into cauchy_interlacing_compression.",
+  "meta": {
+    "author": "Cauchy (interlacing); formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CauchyInterlacingOQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "spectral",
+      "hermitian",
+      "cauchy-interlacing",
+      "principal-submatrix",
+      "compression",
+      "eigenvalues"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Submodule.inner_orthogonalProjection_eq_of_mem_left",
+        "description": "⟪u, P_H v⟫ = ⟪↑u, v⟫ for u ∈ H — collapses the compression's inner product on H to T's on the ambient space",
+        "module": "Mathlib.Analysis.InnerProductSpace.Projection.Basic"
+      },
+      {
+        "theorem": "EuclideanSpace.inner_single_left",
+        "description": "⟪single i a, v⟫ = conj a · v i — reads off a single coordinate of a Euclidean vector",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Matrix.toEuclideanLin_apply",
+        "description": "toEuclideanLin M v = toLp (M *ᵥ ofLp v) — the matrix acts as matrix-vector multiplication",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Matrix.mulVec_single_one",
+        "description": "M *ᵥ Pi.single j 1 = M.col j — multiplying a matrix by a standard basis vector extracts a column",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "EuclideanSpace.orthonormal_single",
+        "description": "the standard basis vectors single i 1 form an orthonormal family — restricted along j.succAbove to give an orthonormal basis of the coordinate hyperplane",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Matrix.IsHermitian.submatrix",
+        "description": "(A.submatrix f f).IsHermitian when A.IsHermitian — the principal submatrix is Hermitian",
+        "module": "Mathlib.LinearAlgebra.Matrix.Hermitian"
+      }
+    ],
+    "originalContributions": [
+      "compress: the orthogonal compression P_H ∘ T ∘ ι_H of an operator to a subspace (reproduced self-contained from the parent)",
+      "inner_compress_eq: the compression's sesquilinear form on H equals T's form on the ambient space, via the orthogonal-projection adjoint identity",
+      "inner_single_toEuclideanLin_single: the matrix entry A a b is recovered as ⟪e_a, (toEuclideanLin A) e_b⟫",
+      "coordinateHyperplane / finrank_coordinateHyperplane: the coordinate hyperplane span{e_{j.succAbove i}} is an n-dimensional subspace (orthonormal sub-family of the standard basis)",
+      "compress_inner_eq_principalSubmatrix: the main identification — the compression of toEuclideanLin A to the coordinate hyperplane has, on its natural basis, exactly the entries of the principal submatrix A.submatrix j.succAbove j.succAbove",
+      "isHermitian_principalSubmatrix: the principal submatrix obtained by deleting row/column j is Hermitian when A is"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 145,
+    "theoremCount": 7,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Cauchy's interlacing theorem (1829) states that the eigenvalues of a principal submatrix of a Hermitian matrix interlace those of the matrix itself: if A is (n+1)×(n+1) Hermitian with descending eigenvalues λ₁ ≥ … ≥ λ_{n+1} and B is the n×n principal submatrix obtained by deleting one row and the matching column, with eigenvalues μ₁ ≥ … ≥ μ_n, then λ_{k+1} ≤ μ_k ≤ λ_k. The conceptual proof passes through the variational (Courant–Fischer) characterization of eigenvalues and the observation that B represents the compression of A to a coordinate subspace. The lean-genius gallery proves the abstract compression interlacing inequality; what remained was to verify that, for a matrix and a coordinate hyperplane, the abstract compression genuinely is the principal submatrix.",
+    "problemStatement": "Given a square matrix A : Matrix (Fin (n+1)) (Fin (n+1)) 𝕜 and an index j, view A as an operator on EuclideanSpace 𝕜 (Fin (n+1)) and let H be the coordinate hyperplane spanned by all standard basis vectors except e_j. Is the orthogonal compression of A to H — project A·v back into H — exactly the principal submatrix obtained by deleting row j and column j?\n\n**Answer: yes.** On the natural orthonormal basis (e_{j.succAbove i}) of H, the compression's matrix entries are ⟪e_{j.succAbove i'}, compress(A) e_{j.succAbove i}⟫ = A (j.succAbove i') (j.succAbove i), which is precisely (A.submatrix j.succAbove j.succAbove) i' i.",
+    "text": "The orthogonal compression of a Hermitian matrix to a coordinate hyperplane is, in the natural basis, exactly the principal submatrix obtained by deleting the corresponding row and column.",
+    "proofStrategy": "Two ingredients. (1) The orthogonal-projection adjoint identity ⟪u, P_H v⟫ = ⟪↑u, v⟫ for u ∈ H makes the projection invisible to inner products against vectors already in H, so the compression's sesquilinear form on H collapses to T's form on the ambient space: ⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V (inner_compress_eq). (2) An elementary entry computation: ⟪e_a, (toEuclideanLin A) e_b⟫ = A a b, obtained from EuclideanSpace.inner_single_left (read off coordinate a), Matrix.toEuclideanLin_apply (the operator is matrix-vector multiplication) and Matrix.mulVec_single_one (multiplying by a basis vector extracts a column). Combining the two with ↑(hyperplaneBasis i) = e_{j.succAbove i} gives the entries A (j.succAbove i') (j.succAbove i) = (A.submatrix j.succAbove j.succAbove) i' i. The hyperplane has dimension n because (e_{j.succAbove i}) is an orthonormal sub-family of the standard basis (orthonormal_single composed with the injection j.succAbove), hence linearly independent; finrank_span_eq_card finishes. The submatrix is Hermitian by Matrix.IsHermitian.submatrix.",
+    "keyInsights": [
+      "The orthogonal-projection adjoint identity is the entire content of 'compression preserves inner products with vectors that already live in the subspace' — the projection drops out and the compression's form is just the ambient form restricted",
+      "Reading a matrix entry as the inner product ⟪e_a, A e_b⟫ of standard basis vectors turns the abstract operator identity into a one-line column-extraction computation",
+      "The coordinate hyperplane is the span of all standard basis vectors except one; restricting an orthonormal basis along the injection j.succAbove keeps it orthonormal, so the hyperplane is automatically n-dimensional",
+      "This identification is exactly the bridge from the gallery's abstract compression-interlacing to the textbook statement that a principal submatrix's eigenvalues interlace the parent matrix's"
+    ],
+    "prerequisites": [
+      "Hermitian matrices and their real eigenvalues",
+      "Inner product spaces, orthogonal projection, and the adjoint identity",
+      "EuclideanSpace, standard basis vectors, and the matrix↔operator correspondence toEuclideanLin",
+      "Principal submatrices via Matrix.submatrix and the deletion map Fin.succAbove"
+    ]
+  },
+  "sections": [
+    {
+      "id": "compression",
+      "title": "The Compression and Its Inner Product",
+      "startLine": 52,
+      "endLine": 81,
+      "summary": "compress T H = P_H ∘ T ∘ ι_H, with the key identity ⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V from the orthogonal-projection adjoint.",
+      "mathContext": "$\\langle y, \\operatorname{compress}_H T\\, z\\rangle_H = \\langle \\iota_H y, T\\, \\iota_H z\\rangle_V$."
+    },
+    {
+      "id": "entries",
+      "title": "Matrix Entries via Basis Inner Products",
+      "startLine": 83,
+      "endLine": 99,
+      "summary": "⟪e_a, (toEuclideanLin A) e_b⟫ = A a b, by reading off a coordinate and extracting a column.",
+      "mathContext": "$\\langle e_a, A e_b\\rangle = A_{a b}$."
+    },
+    {
+      "id": "identification",
+      "title": "Compression Equals Principal Submatrix",
+      "startLine": 101,
+      "endLine": 145,
+      "summary": "The compression to the coordinate hyperplane has, on its natural basis, the entries of A.submatrix j.succAbove j.succAbove; the hyperplane is n-dimensional and the submatrix is Hermitian.",
+      "mathContext": "$\\langle e_{j\\triangleleft i'}, \\operatorname{compress}_H A\\, e_{j\\triangleleft i}\\rangle = A_{j\\triangleleft i',\\, j\\triangleleft i}$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cauchy, A.-L.",
+      "title": "Sur l'équation à l'aide de laquelle on détermine les inégalités séculaires des mouvements des planètes",
+      "year": "1829",
+      "note": "Original interlacing theorem"
+    },
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "note": "Cauchy interlacing and the compression/principal-submatrix correspondence (Theorem 4.3.17)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Closes the first open question of the compression corollary: identifies the abstract orthogonal compression with the principal submatrix, the step its docstring asserts but leaves unproved."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem",
+      "relationship": "related",
+      "description": "Supplies the concrete matrix meaning of the compression whose eigenvalues the interlacing theorem bounds."
+    }
+  ],
+  "conclusion": {
+    "summary": "The orthogonal compression of a Hermitian matrix to a coordinate hyperplane is identified, with 0 axioms, as exactly the principal submatrix obtained by deleting the matching row and column: on the natural orthonormal basis of the hyperplane the compression's sesquilinear form is A.submatrix j.succAbove j.succAbove. The hyperplane is shown to be n-dimensional and the submatrix Hermitian, so this slots directly into the gallery's abstract compression-interlacing corollary.",
+    "implications": "Bridges the gallery's abstract compression interlacing to the textbook statement about principal submatrices, completing the reduction the parent file's docstring promised; the entry-level identification is the reusable kernel.",
+    "openQuestions": [
+      "Assemble the matrix-level eigenvalue corollary: show compress(toEuclideanLin A) H is unitarily equivalent to toEuclideanLin (A.submatrix j.succAbove j.succAbove) via the isometry e_{j.succAbove i} ↦ e_i, so that the principal submatrix's eigenvalues literally interlace A's (λ_{k+1} ≤ μ_k ≤ λ_k).",
+      "Iterate the deletion to the Poincaré separation theorem for compression onto an arbitrary k-dimensional coordinate subspace, λ_i ≤ μ_i ≤ λ_{i+n-m}."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "Matrix"
+    ],
+    "namespace": "CauchyInterlacingOQ01OQ01",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 4,
+    "path": "Proofs/CauchyInterlacingOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the **first open question** of `cauchy-interlacing-theorem-oq-01` (the compression corollary). That file builds the abstract orthogonal compression `compress T H = P_H ∘ T ∘ ι_H` of a symmetric operator to a codimension-one subspace and proves its eigenvalues interlace those of `T` — but its docstring only *asserts* that, for a Hermitian matrix and a coordinate hyperplane, this compression is the principal submatrix obtained by deleting a row/column. **This PR proves that identification.**

For `A : Matrix (Fin (n+1)) (Fin (n+1)) 𝕜` viewed as `toEuclideanLin A`, and the coordinate hyperplane `H = span{e_{j.succAbove i} : i : Fin n}` (all standard basis vectors except `e_j`):

```
⟪e_{j.succAbove i'}, compress (toEuclideanLin A) H e_{j.succAbove i}⟫
    = (A.submatrix j.succAbove j.succAbove) i' i
```

i.e. on the natural orthonormal basis of `H`, the compression's matrix is exactly `A` with row `j` and column `j` deleted.

## Proof ingredients
- **`inner_compress_eq`** — the orthogonal-projection adjoint identity collapses the compression's sesquilinear form on `H` to `T`'s form on the ambient space: `⟪y, compress T H z⟫_H = ⟪↑y, T ↑z⟫_V`.
- **`inner_single_toEuclideanLin_single`** — the elementary entry formula `⟪e_a, (toEuclideanLin A) e_b⟫ = A a b` (read off a coordinate, extract a column).
- **`compress_inner_eq_principalSubmatrix`** — the main identification, one rewrite combining the two.
- **`finrank_coordinateHyperplane`** — `H` is `n`-dimensional (orthonormal sub-family of the standard basis).
- **`isHermitian_principalSubmatrix`** — the principal submatrix is Hermitian when `A` is.

So the identification slots directly into `cauchy_interlacing_compression`.

## Verification
- 7 theorems / 4 definitions, 145 lines, single file `Proofs/CauchyInterlacingOQ01OQ01.lean`, self-contained (imports only `Mathlib`).
- **0 sorries, 0 axioms.** `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.
- Compiles against Mathlib v4.26.0 (Docker daemon down this session; verified with a direct `lean` build + registered in `Proofs.lean`).
- Status `verified`, badge `mathlib`.

## Honest scope
This proves the **entry-level identification** the parent docstring promised. The matrix-level *eigenvalue* corollary (compression unitarily equivalent to `toEuclideanLin` of the submatrix, so the submatrix's eigenvalues literally interlace `A`'s) is left as a documented follow-up open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)