### PR TITLE
Enrich Jordan's Totient J_k Euler Product (erdos-1000-oq-03-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/erdos-1000-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "jordan-def",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 40, "endLine": 43 },
+    "type": "definition",
+    "title": "Jordan's totient as a Dirichlet convolution",
+    "content": "`jordan k := moebius * (pow k)` packages Jordan's totient $J_k$ as the Dirichlet convolution $\\mu * \\mathrm{pow}_k$, valued in $\\mathbb{Z}$. This is the exact $\\mu$-analogue of Mathlib's divisor-sum function $\\sigma_k = \\zeta * \\mathrm{pow}_k$ — replacing the constant function $\\zeta$ by the Möbius function $\\mu$. The choice of definition is the whole strategy: by building $J_k$ as a convolution of two functions Mathlib already knows are multiplicative, every structural property (multiplicativity, Euler product, prime-power values) follows from existing convolution infrastructure rather than from a bespoke combinatorial argument.",
+    "mathContext": "$J_k = \\mu * \\mathrm{pow}_k$ where $(\\mathrm{pow}_k)(n) = n^k$ and $*$ is Dirichlet convolution $(f*g)(n)=\\sum_{d\\mid n} f(d)\\,g(n/d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet convolution", "arithmetic function", "Mobius function", "sigma_k function"],
+    "prerequisites": ["Dirichlet convolution", "arithmetic functions"]
+  },
+  {
+    "id": "jordan-apply",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 55 },
+    "type": "technique",
+    "title": "Unfolding the convolution to the closed form",
+    "content": "`jordan_apply` evaluates the abstract convolution back to the explicit divisor sum $J_k(n) = \\sum_{d\\mid n}\\mu(d)\\,(n/d)^k$ — the formula proved combinatorially in the parent entry as the count of jointly coprime $k$-tuples mod $n$. The proof rewrites `mul_apply` over the divisor antidiagonal and discharges the `pow` branch (the arithmetic function $\\mathrm{pow}_k$ sends $0 \\mapsto 0$, so the `if` guard requires showing $n/d \\neq 0$ for genuine divisors). This bridges the structural definition and the parent's combinatorial identity.",
+    "mathContext": "$J_k(n) = \\sum_{d \\mid n} \\mu(d)\\left(\\tfrac{n}{d}\\right)^k$, the same closed form counting $\\{(a_0,\\dots,a_{k-1}) \\in (\\mathbb{Z}/n)^k : \\gcd(a_0,\\dots,a_{k-1},n)=1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisor sum", "Mobius function", "divisor antidiagonal"],
+    "prerequisites": ["Dirichlet convolution", "Mobius function"]
+  },
+  {
+    "id": "jordan-multiplicative",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 61 },
+    "type": "insight",
+    "title": "Multiplicativity for free",
+    "content": "`isMultiplicative_jordan` is a one-liner: $J_k$ is the convolution of the multiplicative $\\mu$ (`isMultiplicative_moebius`) and the multiplicative $\\mathrm{pow}_k$ (`isMultiplicative_pow.natCast`), and the Dirichlet convolution of multiplicative functions is multiplicative (`IsMultiplicative.mul`). This is the central structural fact of the whole theory — $J_k(mn) = J_k(m)J_k(n)$ for coprime $m,n$ — and the definition-as-convolution makes it almost trivial. It mirrors exactly how Mathlib derives `isMultiplicative_sigma`.",
+    "mathContext": "$\\gcd(m,n)=1 \\Rightarrow J_k(mn) = J_k(m)\\,J_k(n)$. Multiplicativity is preserved by Dirichlet convolution: $(f*g)$ multiplicative whenever $f,g$ are.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative function", "Dirichlet convolution", "coprimality"],
+    "prerequisites": ["multiplicative arithmetic functions", "Dirichlet convolution"]
+  },
+  {
+    "id": "jordan-prime-pow",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 89 },
+    "type": "technique",
+    "title": "Value on prime powers: only two terms survive",
+    "content": "`jordan_prime_pow` computes $J_k(p^i) = p^{ki} - p^{k(i-1)}$. The divisor sum over $p^i$ runs over $1, p, p^2, \\dots, p^i$, but $\\mu(p^j) = 0$ for $j \\ge 2$, so only the $j=0$ term ($\\mu(1)(p^i)^k = p^{ki}$) and the $j=1$ term ($\\mu(p)(p^{i-1})^k = -p^{k(i-1)}$) survive. The proof reindexes the prime-power divisors, peels the first two terms with `sum_range_succ'` twice, kills the tail via `moebius_apply_prime_pow`, and finishes with `ring`. Together with multiplicativity, the prime-power value determines $J_k$ everywhere.",
+    "mathContext": "$J_k(p^i) = p^{ki} - p^{k(i-1)} = p^{k(i-1)}(p^k - 1)$ for prime $p$, $i \\ge 1$. Only the squarefree divisors $1$ and $p$ contribute, since $\\mu(p^j)=0$ for $j\\ge 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Mobius function on prime powers", "prime-power divisors", "telescoping sum"],
+    "prerequisites": ["Mobius function", "prime factorization"]
+  },
+  {
+    "id": "jordan-euler-product",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 102 },
+    "type": "insight",
+    "title": "The integer Euler product",
+    "content": "`jordan_eq_prod_primeFactors` assembles multiplicativity plus the prime-power value into the Euler product $J_k(n) = \\prod_{p\\mid n}(p^{k v_p} - p^{k(v_p-1)})$. The engine is `IsMultiplicative.multiplicative_factorization`, which evaluates any multiplicative function on $n \\ne 0$ as the product of its values on the prime-power components $p^{v_p(n)}$ of $n$'s factorization. Each factor is then rewritten by `jordan_prime_pow`. This is the discrete shadow of the analytic Euler product for the $L$-function of $J_k$.",
+    "mathContext": "$J_k(n) = \\prod_{p \\mid n}\\left(p^{k\\,v_p(n)} - p^{k\\,(v_p(n)-1)}\\right)$, where $v_p(n)$ is the $p$-adic valuation of $n$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler product", "prime factorization", "multiplicative function", "p-adic valuation"],
+    "prerequisites": ["Euler products", "multiplicative functions"]
+  },
+  {
+    "id": "jordan-pos",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 104, "endLine": 118 },
+    "type": "concept",
+    "title": "Positivity: J_k is a genuine totient",
+    "content": "`jordan_pos` proves $J_k(n) > 0$ for $k \\ge 1$, $n \\ge 1$. Each Euler factor $p^{k v_p} - p^{k(v_p-1)}$ is positive because the exponent $k(v_p-1)$ is strictly smaller than $k v_p$ (as $k \\ge 1$) and $p \\ge 2$, so the larger power dominates (`pow_lt_pow_right₀`). A product of positive integers is positive. This sanity check confirms $J_k$ is a true totient — it actually counts something (the jointly coprime $k$-tuples), so it cannot be zero or negative.",
+    "mathContext": "$k \\ge 1,\\ n \\ge 1 \\Rightarrow J_k(n) > 0$, since each factor $p^{k v_p}(1 - p^{-k}) > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "monotonicity of powers", "totient as a count"],
+    "prerequisites": ["ordered fields", "integer powers"]
+  },
+  {
+    "id": "jordan-recovers-euler",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 120, "endLine": 135 },
+    "type": "insight",
+    "title": "Recovering Euler's totient at k = 1",
+    "content": "`jordan_one_apply` shows $J_1 = \\varphi$, anchoring the generalization in the classical case. The proof is Möbius inversion of Gauss's identity $\\sum_{d\\mid n}\\varphi(d) = n$: feeding that identity into `sum_eq_iff_sum_smul_moebius_eq` yields $\\varphi(n) = \\sum_{d\\mid n}\\mu(d)(n/d)$, which is exactly $J_1(n)$ at $k=1$. So Jordan's totient is the honest higher-dimensional generalization of Euler's $\\varphi$: $J_1$ counts the units mod $n$, while $J_k$ counts jointly coprime $k$-tuples.",
+    "mathContext": "$J_1 = \\varphi$. Gauss: $\\sum_{d\\mid n}\\varphi(d) = n$; Möbius inversion gives $\\varphi(n) = \\sum_{d\\mid n}\\mu(d)\\tfrac{n}{d} = J_1(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient", "Mobius inversion", "Gauss divisor-sum identity"],
+    "prerequisites": ["Mobius inversion", "Euler totient function"]
+  },
+  {
+    "id": "jordan-real-euler-product",
+    "proofId": "erdos-1000-oq-03-oq-01-oq-01",
+    "range": { "startLine": 137, "endLine": 168 },
+    "type": "technique",
+    "title": "The classical real Euler product",
+    "content": "`jordan_eq_mul_prod_primeFactors` produces the textbook closed form $J_k(n) = n^k\\prod_{p\\mid n}(1 - p^{-k})$ over $\\mathbb{R}$. The argument factors $n^k = \\prod_{p\\mid n} p^{k v_p}$ out of the integer Euler product and rewrites each term as $p^{k v_p} - p^{k(v_p-1)} = p^{k v_p}(1 - p^{-k})$; the exponent identity $k(v_p - 1) + k = k\\,v_p$ (handled by `Nat.succ_pred_eq_of_pos`) is what lets $(p^k)^{-1}$ cancel cleanly. This is the form most often quoted, directly generalizing $\\varphi(n) = n\\prod_{p\\mid n}(1 - p^{-1})$.",
+    "mathContext": "$J_k(n) = n^k \\prod_{p \\mid n}\\left(1 - p^{-k}\\right)$, the $k$-th-power generalization of $\\varphi(n) = n\\prod_{p\\mid n}(1 - p^{-1})$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler product", "Euler totient product formula", "real-valued arithmetic functions"],
+    "prerequisites": ["Euler products", "real exponentials", "prime factorization"]
+  }
+]

--- a/src/data/proofs/erdos-1000-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-01-oq-01/meta.json
@@ -3,6 +3,104 @@
   "title": "Multiplicativity and the Euler Product of Jordan's Totient $J_k$",
   "slug": "erdos-1000-oq-03-oq-01-oq-01",
   "description": "Builds the multiplicative theory of Jordan's totient J_k on top of erdos-1000-oq-03-oq-01, which proved that the count C_k(n) = #{ k-tuples mod n jointly coprime to n } equals the Dirichlet-convolution closed form J_k = μ * pow k. That established what J_k is; this entry establishes its multiplicative structure — the heart of the classical theory. Proves, with 0 axioms and 0 sorries (no native_decide): J_k = μ * pow k is a multiplicative arithmetic function, so J_k(mn) = J_k(m)·J_k(n) for coprime m, n (it is the Dirichlet convolution of the two multiplicative functions μ and pow k); the closed form J_k(n) = ∑_{d∣n} μ(d)·(n/d)^k; the value on prime powers J_k(p^i) = p^{ki} − p^{k(i−1)} for prime p and i ≥ 1 (only the squarefree divisors 1 and p survive the Möbius weights); the integer Euler product J_k(n) = ∏_{p∣n} (p^{k·v_p} − p^{k·(v_p−1)}) over the prime factors of n; positivity J_k(n) > 0 for k ≥ 1, n ≥ 1 (J_k is a genuine totient); the Euler-totient recovery J_1 = φ via Möbius inversion of Gauss's ∑_{d∣n} φ(d) = n; and the real Euler product J_k(n) = n^k · ∏_{p∣n}(1 − p^{−k}), the familiar closed form. Everything rests on Mathlib's arithmetic-function multiplicativity infrastructure (IsMultiplicative.mul, multiplicative_factorization); no analysis beyond the final cast to ℝ.",
+  "overview": {
+    "historicalContext": "Jordan's totient J_k was introduced by the French mathematician Camille Jordan around 1870 in his Traité des substitutions et des équations algébriques, where it counts the k-tuples of residues mod n that, together with n, are jointly coprime — equivalently, the order of certain matrix groups over ℤ/n. It is the natural higher-dimensional generalization of Euler's totient φ = J_1, and it shares φ's entire structural theory: multiplicativity, an Euler product, and a Möbius-convolution closed form. In the modern language of Dirichlet series, J_k corresponds to ζ(s-k)/ζ(s), placing it alongside the divisor-power sums σ_k (which correspond to ζ(s)ζ(s-k)). Mathlib already formalizes σ_k = ζ * pow k and its multiplicativity; this entry develops the parallel μ-side theory J_k = μ * pow k, with the Möbius function μ replacing the constant function ζ. The parent entry (erdos-1000-oq-03-oq-01) supplied the combinatorial meaning — that the count of jointly coprime k-tuples equals this convolution — and this entry supplies the algebra.",
+    "problemStatement": "Develop the multiplicative theory of Jordan's totient J_k(n) = ∑_{d∣n} μ(d)(n/d)^k in Lean 4: prove it is a multiplicative arithmetic function, compute its value on prime powers, derive both the integer and the real Euler product, establish positivity, and recover Euler's totient as the case k = 1 — all with 0 axioms and 0 sorries.",
+    "proofStrategy": "Define J_k as the Dirichlet convolution μ * pow k so that multiplicativity comes for free from IsMultiplicative.mul. Unfold the convolution to the explicit divisor-sum closed form (jordan_apply). Compute the prime-power value J_k(p^i) = p^{ki} − p^{k(i−1)} by observing only the squarefree divisors 1 and p survive the Möbius weights (jordan_prime_pow). Combine multiplicativity with the prime-power value via multiplicative_factorization to get the integer Euler product (jordan_eq_prod_primeFactors). Specialize to k = 1 by Möbius-inverting Gauss's ∑_{d∣n} φ(d) = n to recover φ (jordan_one_apply). Establish positivity factorwise (jordan_pos), and finally cast to ℝ and factor n^k out of the product to obtain the classical real Euler product (jordan_eq_mul_prod_primeFactors).",
+    "keyInsights": [
+      "The right definition does the work: choosing J_k := μ * pow k as a Dirichlet convolution of two known-multiplicative functions reduces the central structural theorem (multiplicativity) to a one-line application of IsMultiplicative.mul — the exact μ-analogue of Mathlib's σ_k = ζ * pow k.",
+      "On a prime power p^i, the Möbius weights annihilate every divisor except 1 and p, collapsing the i+1-term divisor sum to the two-term value p^{ki} − p^{k(i−1)}; multiplicativity then propagates this single computation to all n.",
+      "J_k is a genuine generalization of Euler's φ, not a formal analogue: J_1 = φ is recovered by Möbius inversion of Gauss's divisor-sum identity, and the real Euler product J_k(n) = n^k ∏(1 − p^{−k}) reduces at k = 1 to the textbook φ(n) = n ∏(1 − p^{−1}).",
+      "Positivity confirms J_k counts something: each Euler factor p^{k v_p}(1 − p^{−k}) is strictly positive, so J_k(n) > 0 — consistent with the parent entry's interpretation as a cardinality of jointly coprime k-tuples.",
+      "Working over ℤ throughout (with a single final cast to ℝ) keeps the entire development algebraic and axiom-free; no analytic machinery beyond ℝ-arithmetic is needed for the Euler products."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context: from the count to the structure",
+      "startLine": 3,
+      "endLine": 34,
+      "summary": "Module docstring situating the entry as the multiplicative-structure follow-up to the parent count C_k(n) = J_k, and enumerating the eight results proved (0 axioms, 0 sorries)."
+    },
+    {
+      "id": "definition",
+      "title": "Definition: J_k as μ * pow k",
+      "startLine": 36,
+      "endLine": 43,
+      "summary": "Opens Finset and ArithmeticFunction, and defines jordan k = moebius * (pow k) over ℤ — the μ-analogue of Mathlib's σ_k = ζ * pow k."
+    },
+    {
+      "id": "closed-form",
+      "title": "Closed form (jordan_apply)",
+      "startLine": 45,
+      "endLine": 55,
+      "summary": "Unfolds the convolution to J_k(n) = ∑_{d∣n} μ(d)(n/d)^k, recovering the divisor-sum formula proved combinatorially by the parent entry."
+    },
+    {
+      "id": "multiplicativity",
+      "title": "Multiplicativity (isMultiplicative_jordan)",
+      "startLine": 57,
+      "endLine": 61,
+      "summary": "One-line proof that J_k is multiplicative as the convolution of the multiplicative μ and pow k, via IsMultiplicative.mul."
+    },
+    {
+      "id": "prime-power",
+      "title": "Value on prime powers (jordan_prime_pow)",
+      "startLine": 63,
+      "endLine": 89,
+      "summary": "Computes J_k(p^i) = p^{ki} − p^{k(i−1)} by peeling the j=0 and j=1 terms of the prime-power divisor sum; all higher terms vanish because μ(p^j)=0 for j≥2."
+    },
+    {
+      "id": "integer-euler-product",
+      "title": "Integer Euler product (jordan_eq_prod_primeFactors)",
+      "startLine": 91,
+      "endLine": 102,
+      "summary": "Combines multiplicativity and the prime-power value via multiplicative_factorization to give J_k(n) = ∏_{p∣n}(p^{k v_p} − p^{k(v_p−1)})."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity (jordan_pos)",
+      "startLine": 104,
+      "endLine": 118,
+      "summary": "Shows J_k(n) > 0 for k,n ≥ 1: each Euler factor is positive since k(v_p−1) < k v_p and p ≥ 2."
+    },
+    {
+      "id": "euler-recovery",
+      "title": "Euler totient recovery (jordan_one_apply)",
+      "startLine": 120,
+      "endLine": 135,
+      "summary": "Proves J_1 = φ by Möbius inversion of Gauss's identity ∑_{d∣n} φ(d) = n, anchoring J_k as the generalization of Euler's totient."
+    },
+    {
+      "id": "real-euler-product",
+      "title": "Real Euler product (jordan_eq_mul_prod_primeFactors)",
+      "startLine": 137,
+      "endLine": 168,
+      "summary": "Casts to ℝ and factors n^k = ∏ p^{k v_p} out of the integer product to obtain the classical J_k(n) = n^k ∏_{p∣n}(1 − p^{−k})."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry develops the full multiplicative theory of Jordan's totient J_k on top of the parent's combinatorial identity, all with 0 axioms and 0 sorries. By defining J_k = μ * pow k as a Dirichlet convolution, multiplicativity follows immediately (isMultiplicative_jordan); the prime-power value J_k(p^i) = p^{ki} − p^{k(i−1)} (jordan_prime_pow) and multiplicative_factorization then yield the integer Euler product (jordan_eq_prod_primeFactors), its positivity (jordan_pos), and — after casting to ℝ — the classical real Euler product J_k(n) = n^k ∏_{p∣n}(1 − p^{−k}) (jordan_eq_mul_prod_primeFactors). The case k = 1 recovers Euler's totient φ via Möbius inversion (jordan_one_apply), confirming J_k as the faithful higher-dimensional generalization of φ. The development is the exact μ-side mirror of Mathlib's existing σ_k theory.",
+    "implications": "Multiplicativity plus the prime-power value reduce any computation of J_k(n) to the prime factorization of n, exactly as for φ and σ_k. The closed forms make J_k a drop-in tool for the surrounding Erdős-totient thread (counting jointly coprime tuples, density questions) without re-deriving structure each time, and the μ * pow k packaging means it inherits, for free, any future Mathlib lemma about Dirichlet convolutions of multiplicative functions.",
+    "openQuestions": [
+      "Formalize the Dirichlet series identity ∑_n J_k(n)/n^s = ζ(s−k)/ζ(s), placing J_k in the analytic framework alongside σ_k's ζ(s)ζ(s−k) and enabling average-order and density results.",
+      "Derive the average order ∑_{n≤x} J_k(n) ∼ x^{k+1}/((k+1)ζ(k+1)) and the natural density of jointly coprime k-tuples, generalizing the classical asymptotic for φ.",
+      "Establish the converse Möbius-side relations (e.g. ∑_{d∣n} J_k(d) = n^k) as a formal counterpart to Gauss's identity, completing the convolution-inverse pair within Mathlib's arithmetic-function library."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1000-oq-03-oq-01",
+      "relationship": "depends-on",
+      "description": "Parent entry. Proves the count C_k(n) = #{ jointly coprime k-tuples mod n } equals the Dirichlet-convolution closed form J_k = μ * pow k. That fixes the meaning of J_k; this entry develops its multiplicative structure (multiplicativity, prime-power value, Euler products, φ recovery, positivity)."
+    },
+    {
+      "targetId": "erdos-1000-oq-03",
+      "relationship": "related",
+      "description": "Grandparent entry on generalized totients with restricted denominator conditions, the source of the Jordan-totient thread descending through oq-03-oq-01 to this entry."
+    }
+  ],
   "meta": {
     "author": "Classical theory of Jordan's totient (Camille Jordan, 1870); formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jordan%27s_totient_function",


### PR DESCRIPTION
Enrichment pass for `erdos-1000-oq-03-oq-01-oq-01` (Multiplicativity and the Euler Product of Jordan's Totient $J_k$). The entry previously had only a meta.json with description/originalContributions but no overview, sections, conclusion, or annotations.

## Added
- **annotations.json** (new): 8 annotations covering the `jordan` definition and all 7 theorems — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line ranges validated against the Lean source (0 validation errors for this entry).
- **overview** (new): `historicalContext` (Camille Jordan 1870; the Dirichlet series ζ(s−k)/ζ(s); the μ-side mirror of Mathlib's σ_k = ζ * pow k), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **sections** (new): 9 sections covering the full 169-line Lean file.
- **conclusion** (new): `summary`, `implications`, and 3 `openQuestions` (Dirichlet series, average order/density, converse convolution identity).
- **crossReferences** (new): to parent `erdos-1000-oq-03-oq-01` (depends-on) and grandparent `erdos-1000-oq-03` (related).

## Notes
- No changes to the Lean source or to status/badge/axiomCount — meta accurately reports `verified` / `original` / 0 axioms / 0 sorries, consistent with the source (no axiom/sorry/native_decide).
- All annotation content is drawn directly from the Lean proof (convolution definition, prime-power term-peeling, multiplicative_factorization, Möbius inversion of Gauss's identity, real Euler product cast).