### PR TITLE
research(subset-count-oq-01): infinite analogue of subset counting — Cantor's theorem |𝒫(S)| > |S| [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/SubsetCountOQ01.lean
+++ b/proofs/Proofs/SubsetCountOQ01.lean
@@ -1,0 +1,90 @@
+/-
+  The infinite analogue of subset counting: Cantor's theorem |𝒫(S)| > |S|.
+
+  The parent entry `subset-count` proves the finite count: an `n`-element set has
+  exactly `2^n` subsets (`Fintype.card (Finset α) = 2 ^ Fintype.card α`).  Two facts
+  are hiding inside that formula.  First, the count `2^n` already *strictly* exceeds
+  `n` — a finite set has strictly more subsets than elements.  Second, this strict
+  gap is not an accident of finiteness: it persists at *every* cardinality.  That is
+  Cantor's theorem, the infinite analogue of subset counting.
+
+  This file makes the lineage explicit:
+
+    * an explicit diagonal set `diagonalSet f = {x | x ∉ f x}`, proved never to lie in
+      the range of any `f : α → Set α` — a self-contained diagonal argument;
+    * Cantor's theorem in surjection form (`not_surjective_to_set`) and injection form
+      (`not_injective_from_set`);
+    * the cardinal form `#α < #(Set α) = 2 ^ #α`, the literal infinite analogue of the
+      parent's finite `2^n`;
+    * the finite shadow `Fintype.card α < Fintype.card (Finset α)`, i.e. the parent's
+      `2^n` already strictly dominates `n`.
+
+  The core inequality reuses Mathlib's `Cardinal.cantor` / `Cardinal.mk_set`; the
+  contributions are the explicit diagonal witness and the bridge tying the finite
+  subset count to its infinite analogue.  Fully verified: 0 sorries, 0 axioms, no
+  `native_decide`.
+-/
+import Mathlib
+
+open Function
+open scoped Cardinal
+
+namespace SubsetCountOQ01
+
+universe u
+variable {α : Type u}
+
+/-- The **diagonal set** of a candidate enumeration `f : α → Set α`: the elements
+that are *not* contained in their own image set.  This is the set Cantor's argument
+uses to defeat any attempt to list every subset of `α` by elements of `α`. -/
+def diagonalSet (f : α → Set α) : Set α := {x | x ∉ f x}
+
+/-- **The diagonal argument, explicitly.** The diagonal set of `f` is never in the
+range of `f`: if `f a = diagonalSet f` then `a ∈ f a ↔ a ∉ f a`, a contradiction. -/
+theorem diagonalSet_not_mem_range (f : α → Set α) :
+    diagonalSet f ∉ Set.range f := by
+  rintro ⟨a, ha⟩
+  have h : a ∈ f a ↔ a ∉ f a := by
+    have hmem : a ∈ f a ↔ a ∈ diagonalSet f := by rw [ha]
+    simpa [diagonalSet, Set.mem_setOf_eq] using hmem
+  tauto
+
+/-- **Cantor's theorem, surjection form.** No map `f : α → Set α` is surjective: the
+subsets of `α` cannot be enumerated by the elements of `α`.  Witnessed by the diagonal
+set, which lies outside every range. -/
+theorem not_surjective_to_set (f : α → Set α) : ¬ Surjective f := fun hf =>
+  diagonalSet_not_mem_range f (Set.mem_range.mpr (hf (diagonalSet f)))
+
+/-- **Cantor's theorem, injection form.** No map `g : Set α → α` is injective: there is
+no way to label distinct subsets of `α` by distinct elements of `α`. -/
+theorem not_injective_from_set (g : Set α → α) : ¬ Injective g :=
+  cantor_injective g
+
+/-- The cardinality of the powerset: `#(Set α) = 2 ^ #α` — the infinite-cardinal
+analogue of the parent's finite count `Fintype.card (Finset α) = 2 ^ Fintype.card α`. -/
+theorem mk_set_eq_two_pow (α : Type u) : #(Set α) = 2 ^ #α := Cardinal.mk_set
+
+/-- **Cantor's theorem, cardinal form.** `#α < #(Set α)`: every set has strictly fewer
+elements than subsets.  Equivalently `#α < 2 ^ #α`. -/
+theorem mk_lt_mk_set (α : Type u) : #α < #(Set α) := by
+  rw [mk_set_eq_two_pow]
+  exact Cardinal.cantor _
+
+/-- The strict cardinal inequality in exponential form: `#α < 2 ^ #α`. -/
+theorem mk_lt_two_pow_mk (α : Type u) : #α < 2 ^ #α := Cardinal.cantor _
+
+/-- **Finite shadow / bridge to the parent.** For a finite type the number of subsets
+strictly exceeds the number of elements: `Fintype.card α < Fintype.card (Finset α)`.
+Since `Fintype.card (Finset α) = 2 ^ Fintype.card α` (the parent's count), this says
+`n < 2^n` — the parent's `2^n` already strictly dominates `n`, the finite case of
+Cantor. -/
+theorem card_lt_card_finset (α : Type u) [Fintype α] :
+    Fintype.card α < Fintype.card (Finset α) := by
+  rw [Fintype.card_finset]
+  exact Nat.lt_two_pow_self
+
+/-- The finite inequality stated arithmetically: an `n`-element set has strictly more
+than `n` subsets, `n < 2^n`. -/
+theorem card_lt_two_pow (n : ℕ) : n < 2 ^ n := Nat.lt_two_pow_self
+
+end SubsetCountOQ01

--- a/src/data/proofs/subset-count-oq-01/meta.json
+++ b/src/data/proofs/subset-count-oq-01/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "subset-count-oq-01",
+  "title": "The Infinite Analogue of Subset Counting: Cantor's Theorem |𝒫(S)| > |S|",
+  "slug": "subset-count-oq-01",
+  "description": "The parent entry proves the finite subset count: an n-element set has exactly 2^n subsets (Fintype.card (Finset α) = 2^Fintype.card α). This entry answers its first open question — what happens for infinite sets — by making the lineage explicit. It records an explicit diagonal set diagonalSet f = {x | x ∉ f x} and proves it never lies in the range of any f : α → Set α (a self-contained diagonal argument), gives Cantor's theorem in surjection and injection form, the cardinal form #α < #(Set α) = 2^#α (the literal infinite analogue of the parent's 2^n), and the finite shadow Fintype.card α < Fintype.card (Finset α) showing the parent's 2^n already strictly dominates n. 8 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_theorem",
+    "date": "Georg Cantor (1891)",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinal-arithmetic",
+      "cantor-theorem",
+      "counting",
+      "diagonal-argument",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/SubsetCountOQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere.",
+    "originalContributions": [
+      "diagonalSet: the explicit diagonal set {x | x ∉ f x} of a candidate enumeration f : α → Set α",
+      "diagonalSet_not_mem_range: a self-contained diagonal argument — the diagonal set lies outside the range of every f : α → Set α, since f a = diagonalSet f forces a ∈ f a ↔ a ∉ f a",
+      "not_surjective_to_set: Cantor's theorem in surjection form, no α → Set α is surjective, witnessed by the diagonal set",
+      "not_injective_from_set: Cantor's theorem in injection form, no Set α → α is injective",
+      "mk_set_eq_two_pow / mk_lt_mk_set / mk_lt_two_pow_mk: the cardinal statement #α < #(Set α) = 2^#α — the infinite-cardinal analogue of the parent's finite 2^n",
+      "card_lt_card_finset / card_lt_two_pow: the finite shadow Fintype.card α < Fintype.card (Finset α), i.e. n < 2^n — the parent's count already strictly dominates the element count, the finite case of Cantor"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 90,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Cantor's theorem (1891) — that the power set of any set is strictly larger than the set itself — is the source of the hierarchy of infinities and, via the diagonal argument, the template for Gödel incompleteness, the halting problem, and Russell's paradox. Its finite face is the elementary count |𝒫(S)| = 2^n: with n elements there are 2^n subsets, and 2^n already strictly exceeds n. Cantor's theorem says this strict gap is universal, holding at every cardinality.",
+    "problemStatement": "**Open Question (OQ-01, subset counting)**: The parent counts the subsets of a finite set (2^n). What happens for infinite sets? Establish Cantor's theorem |𝒫(S)| > |S| as the infinite analogue, and connect it to the finite count.\n\n**Formalized**: diagonalSet, diagonalSet_not_mem_range, not_surjective_to_set, not_injective_from_set, mk_set_eq_two_pow, mk_lt_mk_set, mk_lt_two_pow_mk, card_lt_card_finset, card_lt_two_pow.",
+    "text": "A 90-line formalization tying the finite subset count to its infinite analogue. The explicit diagonal set diagonalSet f := {x | x ∉ f x} is proved (diagonalSet_not_mem_range) never to lie in the range of any f : α → Set α — a self-contained diagonal argument — from which Cantor's surjection form not_surjective_to_set follows immediately. The injection form not_injective_from_set re-exports Mathlib's cantor_injective. On the cardinal side, mk_set_eq_two_pow records #(Set α) = 2^#α (the infinite analogue of the parent's Fintype.card (Finset α) = 2^n), and mk_lt_mk_set / mk_lt_two_pow_mk give the strict inequality #α < 2^#α via Cardinal.cantor. The finite shadow card_lt_card_finset shows Fintype.card α < Fintype.card (Finset α), unfolding to n < 2^n — the parent's 2^n already strictly dominates n. All verified with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**diagonalSet_not_mem_range**: assume f a = diagonalSet f; then a ∈ f a ↔ a ∈ diagonalSet f ↔ a ∉ f a, a contradiction (tauto).\n\n**not_surjective_to_set**: a surjection would put diagonalSet f in the range of f, contradicting diagonalSet_not_mem_range.\n\n**not_injective_from_set**: Mathlib's Function.cantor_injective.\n\n**mk_set_eq_two_pow**: Mathlib's Cardinal.mk_set.\n\n**mk_lt_mk_set / mk_lt_two_pow_mk**: rewrite #(Set α) = 2^#α and apply Cardinal.cantor.\n\n**card_lt_card_finset**: rewrite Fintype.card_finset = 2^(Fintype.card α) and apply Nat.lt_two_pow_self.\n\n**card_lt_two_pow**: Nat.lt_two_pow_self.",
+    "keyInsights": [
+      "**The diagonal set defeats every enumeration**: for any f : α → Set α, the set {x | x ∉ f x} disagrees with each f(a) precisely at a, so it cannot equal any f(a) — a single set that escapes the entire range.",
+      "**The finite count already contains the strict gap**: the parent's 2^n is not merely a count but a strict upper bound, n < 2^n; a finite set has strictly more subsets than elements. Cantor's theorem says this gap never closes, at any cardinality.",
+      "**Surjection, injection, and cardinal forms are one theorem**: 'no α → Set α surjective', 'no Set α → α injective', and '#α < 2^#α' are three faces of the same diagonal phenomenon.",
+      "**The infinite analogue is literal**: the parent's Fintype.card (Finset α) = 2^n becomes #(Set α) = 2^#α verbatim at the cardinal level, with strictness supplied by Cantor in place of n < 2^n.",
+      "**0-axiom, no native_decide**: every step is kernel-checked, depending only on propext / Classical.choice / Quot.sound."
+    ],
+    "prerequisites": [
+      "The parent entry subset-count and its finite count Fintype.card (Finset α) = 2 ^ Fintype.card α",
+      "Mathlib's Function.cantor_injective and Set.range / Set.mem_range",
+      "Cardinal arithmetic: Cardinal.mk_set (#(Set α) = 2^#α) and Cardinal.cantor (a < 2^a)",
+      "Nat.lt_two_pow_self (n < 2^n) and Fintype.card_finset"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "subset-count",
+      "relationship": "parent",
+      "description": "The parent counts the subsets of a finite set (2^n). This entry answers its first open question — the infinite case — establishing Cantor's theorem |𝒫(S)| > |S| as the infinite analogue and exhibiting the finite count's strict gap n < 2^n as the finite shadow."
+    },
+    {
+      "proofId": "cantors-theorem",
+      "relationship": "related",
+      "description": "Both formalize Cantor's theorem; this entry approaches it from the subset-counting lineage (finite 2^n strictly dominates n, generalized to every cardinal) and supplies an explicit diagonal-set witness."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "SubsetCountOQ01",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/SubsetCountOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "mk_lt_mk_set",
+      "type": "core",
+      "statement": "$\\#\\alpha < \\#(\\mathrm{Set}\\,\\alpha) = 2^{\\#\\alpha}$",
+      "significance": "Cantor's theorem, cardinal form: every set has strictly fewer elements than subsets. The literal infinite analogue of the parent's finite count 2^n.",
+      "description": "Cantor's theorem: |S| < |𝒫(S)|."
+    },
+    {
+      "name": "diagonalSet_not_mem_range",
+      "type": "core",
+      "statement": "$\\{x \\mid x \\notin f(x)\\} \\notin \\mathrm{range}\\,f$ for every $f : \\alpha \\to \\mathrm{Set}\\,\\alpha$",
+      "significance": "The explicit diagonal argument: the diagonal set escapes the range of any candidate enumeration, since f(a) = diagonalSet f forces a ∈ f(a) ↔ a ∉ f(a).",
+      "description": "The diagonal set lies outside every range."
+    },
+    {
+      "name": "not_surjective_to_set",
+      "type": "core",
+      "statement": "no $f : \\alpha \\to \\mathrm{Set}\\,\\alpha$ is surjective",
+      "significance": "Cantor's theorem, surjection form: the subsets of α cannot be enumerated by the elements of α — witnessed by the diagonal set.",
+      "description": "No map α → 𝒫(α) is onto."
+    },
+    {
+      "name": "card_lt_card_finset",
+      "type": "supporting",
+      "statement": "$\\mathrm{card}\\,\\alpha < \\mathrm{card}(\\mathrm{Finset}\\,\\alpha) = 2^{\\mathrm{card}\\,\\alpha}$ for finite $\\alpha$",
+      "significance": "The finite shadow: the parent's count 2^n already strictly dominates n — a finite set has strictly more subsets than elements, the finite case of Cantor.",
+      "description": "Finite: a set has strictly more subsets than elements."
+    },
+    {
+      "name": "not_injective_from_set",
+      "type": "supporting",
+      "statement": "no $g : \\mathrm{Set}\\,\\alpha \\to \\alpha$ is injective",
+      "significance": "Cantor's theorem, injection form: distinct subsets cannot be labelled by distinct elements.",
+      "description": "No map 𝒫(α) → α is injective."
+    }
+  ],
+  "references": [
+    {
+      "text": "Cantor's theorem: the power set of any set has strictly greater cardinality than the set itself; the diagonal argument.",
+      "url": "https://en.wikipedia.org/wiki/Cantor%27s_theorem"
+    },
+    {
+      "text": "Power set and the count |𝒫(S)| = 2^|S| with its bijection to characteristic functions.",
+      "url": "https://en.wikipedia.org/wiki/Power_set"
+    },
+    {
+      "text": "Mathlib4: Function.cantor_injective, Cardinal.mk_set (#(Set α) = 2^#α), Cardinal.cantor (a < 2^a), Nat.lt_two_pow_self, Fintype.card_finset.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Answers the parent's first open question — the infinite case of subset counting — by establishing Cantor's theorem |𝒫(S)| > |S| as the infinite analogue of the finite count 2^n. Supplies an explicit diagonal set and proves it escapes every range (diagonalSet_not_mem_range), gives Cantor in surjection (not_surjective_to_set) and injection (not_injective_from_set) form, the cardinal inequality #α < #(Set α) = 2^#α (mk_lt_mk_set), and the finite shadow Fintype.card α < Fintype.card (Finset α) showing the parent's 2^n already strictly dominates n. All verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "The strict gap between a set and its power set is the engine of the transfinite hierarchy and, through the diagonal argument, of the great undecidability and incompleteness results. Anchoring it to the subset-counting lineage shows the finite count 2^n is already a strict inequality whose universality is Cantor's theorem.",
+    "openQuestions": [
+      "Formalize that the power-set operation has no fixed point in cardinals (no infinite cardinal κ with 2^κ = κ), and locate the first cardinal above #ℕ",
+      "Make the diagonal argument's structural role explicit by deriving the abstract Lawvere fixed-point theorem and recovering Cantor as a corollary"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **subset-count**'s first open question — the *infinite* case of subset counting. The parent proves the finite count `Fintype.card (Finset α) = 2^Fintype.card α`; this entry makes the lineage to Cantor's theorem explicit.

- **`diagonalSet f = {x | x ∉ f x}`** and **`diagonalSet_not_mem_range`** — a self-contained diagonal argument: the diagonal set lies outside the range of every `f : α → Set α`.
- **`not_surjective_to_set`** / **`not_injective_from_set`** — Cantor's theorem in surjection and injection form.
- **`mk_lt_mk_set` : `#α < #(Set α) = 2^#α`** — the cardinal form, the literal infinite analogue of the parent's `2^n`.
- **`card_lt_card_finset` : `Fintype.card α < Fintype.card (Finset α)`** — the finite shadow `n < 2^n`: the parent's `2^n` already strictly dominates `n`.

## Verification

- Builds against Mathlib (Lean 4.26.0).
- **8 theorems, 1 definition, 0 sorries.**
- **0 axioms**: every theorem depends only on `propext` / `Classical.choice` / `Quot.sound`. No `native_decide`.

## Files

- `proofs/Proofs/SubsetCountOQ01.lean` (90 lines)
- `src/data/proofs/subset-count-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)