### PR TITLE
Enrich Eulerian Numbers Explicit Formula (geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "eul-explicit-def",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 43, "endLine": 47 },
+    "type": "definition",
+    "title": "The explicit (inclusion–exclusion) form",
+    "content": "`eulerianExplicit n k` is the right-hand side of the target identity, defined directly as the alternating binomial sum $\\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n$, valued in $\\mathbb{Z}$. The whole proof strategy hinges on treating this sum as an object in its own right: rather than evaluating it by clever algebra, the file shows it satisfies the same triangle recurrence as the combinatorial Eulerian numbers $\\langle n,k\\rangle$, and then matches the two by induction. Working in $\\mathbb{Z}$ (not $\\mathbb{N}$) is deliberate — it keeps the signs and the subtraction $k+1-i$ honest throughout.",
+    "mathContext": "$\\mathrm{eulerianExplicit}(n,k) = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n$. This is the $(n+1)$-st finite difference of $t^n$ evaluated combinatorially.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian numbers", "inclusion-exclusion", "finite differences", "alternating binomial sum"],
+    "prerequisites": ["binomial coefficients", "finite sums"]
+  },
+  {
+    "id": "eul-absorb-up",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 58 },
+    "type": "technique",
+    "title": "Upward binomial absorption",
+    "content": "`absorb_up` is the integer form of the absorption identity $\\binom{n+1}{j+1}(j+1) = (n+1)\\binom{n}{j}$. It is obtained by casting Mathlib's natural-number `Nat.add_one_mul_choose_eq` to $\\mathbb{Z}$ via `push_cast` and `linarith`. This identity is the algebraic engine that lets a factor of $i$ (or $j+1$) inside a binomial sum be 'absorbed' into a shift of the upper index — the move that collapses one of the two defect sums in the recurrence proof.",
+    "mathContext": "$\\binom{n+1}{j+1}(j+1) = (n+1)\\binom{n}{j}$ over $\\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial absorption identity", "Pascal's triangle", "type coercion"],
+    "prerequisites": ["binomial coefficients", "Lean coercions"]
+  },
+  {
+    "id": "eul-absorb-down",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 84 },
+    "type": "technique",
+    "title": "Downward absorption, via symmetry",
+    "content": "`absorb_down` proves $\\binom{n+1}{i}(n+1-i) = (n+1)\\binom{n}{i}$ for all $i$ — including the degenerate range $i>n$ where both sides vanish. Rather than a fresh factorial computation, it reflects the index using the binomial symmetry $\\binom{n}{n-i}=\\binom{n}{i}$ to deduce the statement from `absorb_up`. The proof splits into $i\\le n$ (genuine identity by symmetry) and $i>n$ (subdivided at $i=n+1$, where the factor $n+1-i$ kills the term, and $i>n+1$, where the binomial $\\binom{n+1}{i}$ itself vanishes). Stating it for all $i$ is what lets the sum collapse cleanly without range surgery.",
+    "mathContext": "$\\binom{n+1}{i}(n+1-i) = (n+1)\\binom{n}{i}$ for all $i$, using $\\binom{n}{n-i}=\\binom{n}{i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial symmetry", "binomial absorption identity", "degenerate cases"],
+    "prerequisites": ["binomial coefficients", "case analysis"]
+  },
+  {
+    "id": "eul-collapse",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 114 },
+    "type": "technique",
+    "title": "The two defect sums collapse",
+    "content": "`x_collapse` and `y_collapse` are the heart of the finite-difference computation. After Pascal-splitting and reindexing, the recurrence proof produces two 'defect' sums — one weighted by $i$, one by $(n+1-i)$ — that obstruct matching the target recurrence. `x_collapse` uses `absorb_up` (after a `sum_range_succ'` shift that drops the $i=0$ boundary term) to show the $i$-weighted sum equals $-(n+1)$ times a row-$n$ alternating sum $\\Sigma$; `y_collapse` uses `absorb_down` to show the $(n+1-i)$-weighted sum equals $+(n+1)\\Sigma$. Both are closed termwise by `linear_combination` against the absorption lemmas, so the two stray $(n+1)\\Sigma$ contributions cancel exactly.",
+    "mathContext": "The $i$-weighted defect $= -(n+1)\\Sigma$ and the $(n+1-i)$-weighted defect $= +(n+1)\\Sigma$, where $\\Sigma = \\sum_i(-1)^i\\binom{n}{i}(k+1-i)^n$; the two cancel.",
+    "significance": "key",
+    "relatedConcepts": ["finite differences", "summation by parts", "linear_combination", "index shifting"],
+    "prerequisites": ["binomial absorption identity", "Finset sum manipulation"]
+  },
+  {
+    "id": "eul-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 116, "endLine": 200 },
+    "type": "insight",
+    "title": "eulerianExplicit obeys the Eulerian recurrence",
+    "content": "`eulerianExplicit_succ_succ` is the crux: the alternating sum satisfies the very triangle recurrence that defines the Eulerian numbers, $E(n+1,k+1) = (k+2)E(n,k+1) + (n-k)E(n,k)$ (with honest integer subtraction). The proof normalizes the three sums to a common base, then assembles three pieces by `linear_combination`: a Pascal step (`hLHS`, splitting $\\binom{n+2}{i}$ into $\\binom{n+1}{i-1}+\\binom{n+1}{i}$ so $\\mathrm{LHS}=S_1-S_2$), and the two collapses repackaged as $S_1=(k+2)A+(n+1)\\Sigma$ (`hS1`) and $S_2=(n+1)\\Sigma-(n-k)B$ (`hS2`). The $(n+1)\\Sigma$ terms annihilate, leaving exactly the recurrence. This single lemma is what the sibling oq-01 had flagged as the missing binomial recurrence.",
+    "mathContext": "$E(n+1,k+1) = (k+2)\\,E(n,k+1) + (n-k)\\,E(n,k)$, the defining triangle recurrence of $\\langle n,k\\rangle$, with $E=\\mathrm{eulerianExplicit}$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian triangle recurrence", "Pascal's rule", "finite differences"],
+    "prerequisites": ["recurrences", "binomial coefficients", "Finset sums"]
+  },
+  {
+    "id": "eul-base-row",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 202, "endLine": 210 },
+    "type": "technique",
+    "title": "Base row n = 0 vanishes",
+    "content": "`base_row_sum` proves $\\sum_{i=0}^{k+1}(-1)^i\\binom{1}{i}=0$, the alternating sum of row 1 of Pascal's triangle past the leading terms. Since $\\binom{1}{i}=0$ for $i\\ge 2$, the sum is $1-1+0+\\cdots = 0$; a short induction peels the vanishing tail. This is the base case that makes $\\mathrm{eulerianExplicit}(0,k+1)=0$, matching $\\langle 0,k+1\\rangle = 0$ — the boundary condition the induction needs.",
+    "mathContext": "$\\sum_{i=0}^{k+1}(-1)^i\\binom{1}{i} = 0$ (equals $\\langle 0,k+1\\rangle$).",
+    "significance": "technical",
+    "relatedConcepts": ["alternating sum", "base case", "induction"],
+    "prerequisites": ["binomial coefficients", "induction"]
+  },
+  {
+    "id": "eul-main",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 212, "endLine": 244 },
+    "type": "insight",
+    "title": "Matching the combinatorial definition",
+    "content": "`eulerian_eq_explicit` is the headline theorem: $\\langle n,k\\rangle = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n$, an identity of integers. With the recurrence and base row established, a single induction on $n$ (generalizing $k$) identifies $\\mathrm{eulerianExplicit}$ with the parent's combinatorial `eulerian`. The one subtlety is reconciling the parent's truncated natural subtraction $(n-k:\\mathbb{N})$ in `eulerian_succ_succ` with the integer $(n-k:\\mathbb{Z})$ of the recurrence: the `hbridge` step shows they agree exactly on the diagonal-vanishing locus, using the parent's $\\langle n,k\\rangle = 0$ for $n<k$ to kill the discrepant term. This settles the general open question left by the sibling oq-01.",
+    "mathContext": "$\\langle n,k\\rangle = \\sum_{i=0}^{k}(-1)^i\\binom{n+1}{i}(k+1-i)^n$ for all $n,k$. The $\\mathbb{N}$ vs $\\mathbb{Z}$ subtraction is reconciled via $\\langle n,k\\rangle=0$ when $n<k$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian numbers", "induction on two indices", "natural vs integer subtraction"],
+    "prerequisites": ["strong induction", "Eulerian triangle recurrence"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -19,6 +19,77 @@
     "sorries": 0
   },
   "title": "The Explicit Formula for the Eulerian Numbers: ⟨n,k⟩ = ∑ᵢ (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ",
+  "description": "Proves the classical explicit (inclusion–exclusion) closed form for the combinatorial Eulerian numbers built in the parent entry, as an identity of integers: ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ. The strategy defines the alternating binomial sum eulerianExplicit and shows it satisfies the very triangle recurrence that defines ⟨n,k⟩, via a finite-difference computation: Pascal-split C(n+2,i), reindex, and collapse the two defect sums with the binomial absorption identities absorb_up and absorb_down. A single induction on n then matches the two objects, reconciling the truncated ℕ-subtraction of the Eulerian recurrence with the integer subtraction of eulerianExplicit on the diagonal-vanishing locus. Settles the general open question left by the sibling oq-01 (which had only computed columns k=0,1,2). 246 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨n,k⟩, introduced by Leonhard Euler in his 1755 study of finite differences and the summation of series, count the permutations of {1,…,n} with exactly k descents. They sit at the crossroads of combinatorics and analysis: their generating polynomials (the Eulerian polynomials) appear in the closed form ∑_{j≥0} jⁿ xʲ = A_n(x)/(1−x)^{n+1}, tying them directly to the geometric-series lineage this entry descends from. The explicit inclusion–exclusion formula ⟨n,k⟩ = ∑_i (−1)ⁱ C(n+1,i)(k+1−i)ⁿ is the standard closed form (Concrete Mathematics, Graham–Knuth–Patashnik), expressing each Eulerian number as a finite alternating sum of powers — equivalently the (n+1)-st finite difference of the monomial tⁿ. Mathlib contains neither the Eulerian numbers nor this formula, so both the combinatorial object (in the parent entry) and its explicit form (here) are built from scratch on top of Mathlib's binomial-coefficient theory.",
+    "problemStatement": "Given the combinatorial Eulerian numbers ⟨n,k⟩ (eulerian n k) defined by the triangle recurrence in the parent entry, prove the explicit closed form ⟨n,k⟩ = ∑_{i=0}^{k} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ for all n,k, as an identity of integers, with 0 axioms and 0 sorries.",
+    "proofStrategy": "Define eulerianExplicit n k as the alternating binomial sum (the RHS, over ℤ). Establish the two binomial absorption identities absorb_up [C(n+1,j+1)(j+1) = (n+1)C(n,j)] and absorb_down [C(n+1,i)(n+1−i) = (n+1)C(n,i)], the latter deduced from the former by binomial symmetry and stated for all i. Prove the key recurrence eulerianExplicit_succ_succ — that eulerianExplicit obeys the Eulerian triangle recurrence — by Pascal-splitting C(n+2,i), reindexing with Finset.sum_range_succ', and collapsing the two resulting defect sums (x_collapse, y_collapse) so the stray (n+1)·Σ terms cancel. Prove the base row eulerianExplicit 0 (k+1) = 0. Finally, a single induction on n (generalizing k) matches eulerianExplicit to eulerian, bridging the ℕ-vs-ℤ subtraction discrepancy on the locus where ⟨n,k⟩ = 0 (n < k).",
+    "keyInsights": [
+      "The proof never evaluates the alternating sum directly: it shows eulerianExplicit satisfies the same triangle recurrence as ⟨n,k⟩ and matches them by induction — turning a daunting closed-form identity into a verifiable recurrence check.",
+      "Two binomial absorption identities do all the algebraic work: absorb_up and absorb_down let factors of i and (n+1−i) be absorbed into index shifts, and the two defect sums they produce collapse to ±(n+1)·Σ, cancelling exactly.",
+      "Stating absorb_down for ALL i (including the degenerate i > n where both sides vanish) avoids range surgery, so the per-term collapse closes uniformly by linear_combination without truncated subtraction.",
+      "The ℕ/ℤ subtraction mismatch — the parent's recurrence uses truncated (n−k : ℕ) while eulerianExplicit_succ_succ uses honest (n−k : ℤ) — is reconciled precisely on the diagonal-vanishing locus, using the parent's ⟨n,k⟩ = 0 for n < k to kill the discrepant term.",
+      "The formula realizes each Eulerian number as the (n+1)-st finite difference of tⁿ, the inverse change of basis to Worpitzky's identity (sibling oq-03), and makes manifest that the ⟨n,k⟩ are integers despite being defined by a recurrence."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context and method",
+      "startLine": 4,
+      "endLine": 37,
+      "summary": "Docstring situating the entry as the settlement of the sibling oq-01's general open question, stating the target formula, and outlining the recurrence-plus-induction method."
+    },
+    {
+      "id": "definition",
+      "title": "Definition: eulerianExplicit",
+      "startLine": 39,
+      "endLine": 47,
+      "summary": "Defines eulerianExplicit n k = ∑_{i<k+1} (−1)ⁱ·C(n+1,i)·(k+1−i)ⁿ over ℤ — the right-hand side to be matched with the combinatorial eulerian."
+    },
+    {
+      "id": "absorb-up",
+      "title": "Upward absorption (absorb_up)",
+      "startLine": 49,
+      "endLine": 58,
+      "summary": "C(n+1,j+1)·(j+1) = (n+1)·C(n,j) over ℤ, cast from Mathlib's Nat.add_one_mul_choose_eq."
+    },
+    {
+      "id": "absorb-down",
+      "title": "Downward absorption (absorb_down)",
+      "startLine": 60,
+      "endLine": 84,
+      "summary": "C(n+1,i)·(n+1−i) = (n+1)·C(n,i) for all i, deduced from absorb_up via binomial symmetry, with degenerate cases i = n+1 and i > n+1 handled separately."
+    },
+    {
+      "id": "collapses",
+      "title": "The two defect-sum collapses (x_collapse, y_collapse)",
+      "startLine": 86,
+      "endLine": 114,
+      "summary": "x_collapse and y_collapse show the i-weighted and (n+1−i)-weighted defect sums equal ∓(n+1)·Σ via the absorption identities, so they cancel in the recurrence proof."
+    },
+    {
+      "id": "recurrence",
+      "title": "The key recurrence (eulerianExplicit_succ_succ)",
+      "startLine": 116,
+      "endLine": 200,
+      "summary": "Proves eulerianExplicit obeys the Eulerian triangle recurrence E(n+1,k+1) = (k+2)E(n,k+1) + (n−k)E(n,k), assembling a Pascal step and the two collapses by linear_combination."
+    },
+    {
+      "id": "base-row",
+      "title": "Base row (base_row_sum)",
+      "startLine": 202,
+      "endLine": 210,
+      "summary": "∑_{i<k+2} (−1)ⁱ·C(1,i) = 0, the alternating row-1 sum making eulerianExplicit 0 (k+1) vanish, by induction peeling the C(1,i)=0 tail."
+    },
+    {
+      "id": "matching",
+      "title": "Matching to the combinatorial definition (eulerian_eq_explicit)",
+      "startLine": 212,
+      "endLine": 244,
+      "summary": "The headline theorem ⟨n,k⟩ = eulerianExplicit n k, by induction on n, with hbridge reconciling the ℕ/ℤ subtraction on the diagonal-vanishing locus."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-02` (The Explicit Formula for the Eulerian Numbers). The entry previously had meta.json with conclusion/crossReferences/originalContributions but no description, overview, sections, or annotations.

## Added
- **annotations.json** (new): 7 annotations covering the `eulerianExplicit` definition, both absorption identities, the two defect-sum collapses, the key recurrence, the base row, and the main matching theorem — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Line ranges validated against the Lean source (0 validation errors for this entry).
- **overview** (new): `historicalContext` (Euler 1755; descents; Eulerian polynomials and the geometric-series connection ∑ jⁿxʲ = A_n(x)/(1−x)^{n+1}), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 8 sections covering the full 246-line Lean file.
- **description** (new): top-level summary.

## Notes
- No changes to the Lean source or to status/badge/axiomCount — meta accurately reports `verified` / `original` / 0 axioms / 0 sorries, consistent with the source (no axiom/sorry/native_decide).
- Annotations are drawn directly from the proof structure: the recurrence-then-induction strategy, Pascal split, absorption-driven collapse, and the ℕ-vs-ℤ subtraction bridge on the diagonal-vanishing locus.