### PR TITLE
research(prob-method-expectation-oq-02-oq-01): first moment recovers the 2^(k/2) diagonal Ramsey growth — R(2j+1,2j+1)>2^j [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3304,6 +3304,7 @@ import Proofs.QuadraticReciprocityOQ03OQ01
 import Proofs.QuadraticReciprocityOQ03OQ01Exp
 import Proofs.RamanujanSumFallacy
 import Proofs.RamseyFirstMoment
+import Proofs.RamseyFirstMomentOQ01
 import Proofs.RamseyHypergraph
 import Proofs.RamseyR4k
 import Proofs.RamseyR4kExtensions

--- a/proofs/Proofs/RamseyFirstMomentOQ01.lean
+++ b/proofs/Proofs/RamseyFirstMomentOQ01.lean
@@ -1,0 +1,138 @@
+/-
+  The Closed-Form Exponential Diagonal Ramsey Lower Bound (First Moment)
+
+  Open question (prob-method-expectation-oq-02-oq-01):
+    "Derive the explicit asymptotic R(k,k) > ... by estimating C(n,k) and choosing n
+     optimally, showing the first moment method recovers the classical 2^(k/2) growth."
+
+  The parent entry (prob-method-expectation-oq-02, `RamseyFirstMoment.lean`) proves the
+  *implication* form of the Erdős (1947) union bound:
+
+        2 · C(n,k) < 2^(C(k,2))   ⟹   R(k,k) > n,
+
+  but only instantiates it at one numeric point (R(4,4) > 6).  This file closes the gap:
+  it turns that criterion into the recognisable closed-form *growth* statement
+
+        n ≤ 2^((k-1)/2)   ⟹   R(k,k) > n,
+
+  kept entirely over ℕ by writing the threshold in its squared, fraction-free form
+  `n^2 ≤ 2^(k-1)` (which is exactly `n ≤ 2^((k-1)/2)`).  The arithmetic core is the
+  standard estimate
+
+        2 · C(n,k)  <  k! · C(n,k)  =  n^(k underbar)  ≤  n^k  ≤  2^(C(k,2)),
+
+  where the first step uses `2 < k!` (valid for `k ≥ 3`) and `C(n,k) ≥ 1`, the equality is
+  `descFactorial = k! · choose`, and the last step squares `n^2 ≤ 2^(k-1)` and uses
+  `2 · C(k,2) = k(k-1)`.
+
+  From this we extract the headline exponential growth of the diagonal Ramsey number:
+
+        for j ≥ 3,   R(2j+1, 2j+1) > 2^j,
+
+  i.e. `R(k,k)` grows at least like `(√2)^k`, the classical Erdős lower order — recovered
+  purely from the first moment method, with no probability measure.  (We prove the
+  exponential *order*; the sharper `(1+o(1))·(k/e)·2^(k/2)` constant is not addressed here.)
+
+  Status: 0 sorries, 0 axioms, no native_decide.
+-/
+import Mathlib
+import Proofs.RamseyFirstMoment
+
+namespace ProbMethod.RamseyDiagonalGrowth
+
+open Finset ProbMethod.RamseyFirstMoment
+
+variable {n k : ℕ}
+
+/-- `2 · C(k,2) = k · (k-1)`: twice the second binomial coefficient is the falling
+    factorial `k(k-1)`.  Proved through `descFactorial`. -/
+theorem two_mul_choose_two (k : ℕ) : 2 * k.choose 2 = k * (k - 1) := by
+  have h1 : k.descFactorial 2 = 2 * k.choose 2 := by
+    rw [Nat.descFactorial_eq_factorial_mul_choose]; rfl
+  have h2 : k.descFactorial 2 = (k - 1) * k := by
+    simp [Nat.descFactorial]
+  rw [← h1, h2, Nat.mul_comm]
+
+/-- **Arithmetic core.**  The fraction-free `2^((k-1)/2)` threshold `n^2 ≤ 2^(k-1)`
+    implies the first-moment Ramsey criterion `2·C(n,k) < 2^(C(k,2))`, for `k ≥ 3` and
+    `k ≤ n`.  This is the estimation step the parent entry left open. -/
+theorem firstMoment_hyp_of_sq (hk : 3 ≤ k) (hkn : k ≤ n) (hsq : n ^ 2 ≤ 2 ^ (k - 1)) :
+    2 * n.choose k < 2 ^ (k.choose 2) := by
+  -- `C(n,k) ≥ 1` since `k ≤ n`
+  have hcpos : 0 < n.choose k := Nat.choose_pos hkn
+  -- `2 < k!` since `k ≥ 3`
+  have hfact : 2 < k.factorial := by
+    have h6 : (3 : ℕ).factorial ≤ k.factorial := Nat.factorial_le hk
+    have h3 : (3 : ℕ).factorial = 6 := by decide
+    omega
+  -- `2·C(n,k) < k!·C(n,k)`
+  have step1 : 2 * n.choose k < k.factorial * n.choose k :=
+    Nat.mul_lt_mul_of_pos_right hfact hcpos
+  -- `k!·C(n,k) = n^(k underbar) ≤ n^k`
+  have hdesc : k.factorial * n.choose k = n.descFactorial k :=
+    (Nat.descFactorial_eq_factorial_mul_choose n k).symm
+  have hpow : n.descFactorial k ≤ n ^ k := Nat.descFactorial_le_pow n k
+  -- `n^k ≤ 2^(C(k,2))`, obtained by squaring `n^2 ≤ 2^(k-1)`
+  have hsq2 : (n ^ k) ^ 2 ≤ (2 ^ (k.choose 2)) ^ 2 := by
+    calc (n ^ k) ^ 2
+        = n ^ (k * 2) := (pow_mul n k 2).symm
+      _ = n ^ (2 * k) := by rw [Nat.mul_comm]
+      _ = (n ^ 2) ^ k := pow_mul n 2 k
+      _ ≤ (2 ^ (k - 1)) ^ k := Nat.pow_le_pow_left hsq k
+      _ = 2 ^ ((k - 1) * k) := (pow_mul 2 (k - 1) k).symm
+      _ = 2 ^ (2 * k.choose 2) := by
+            rw [show (k - 1) * k = 2 * k.choose 2 from by rw [two_mul_choose_two]; ring]
+      _ = 2 ^ (k.choose 2 * 2) := by rw [Nat.mul_comm]
+      _ = (2 ^ (k.choose 2)) ^ 2 := pow_mul 2 (k.choose 2) 2
+  have hnk : n ^ k ≤ 2 ^ (k.choose 2) := by
+    by_contra hcon
+    push_neg at hcon
+    have := Nat.pow_lt_pow_left hcon (show (2 : ℕ) ≠ 0 by norm_num)
+    omega
+  calc 2 * n.choose k
+      < k.factorial * n.choose k := step1
+    _ = n.descFactorial k := hdesc
+    _ ≤ n ^ k := hpow
+    _ ≤ 2 ^ (k.choose 2) := hnk
+
+/-- **Closed-form first-moment Ramsey lower bound.**  If `k ≥ 3`, `k ≤ n` and
+    `n^2 ≤ 2^(k-1)` (i.e. `n ≤ 2^((k-1)/2)`), then `K_n` has a 2-coloring with no
+    monochromatic `K_k`; equivalently `R(k,k) > n`. -/
+theorem ramsey_no_mono_of_sq (hk : 3 ≤ k) (hkn : k ≤ n) (hsq : n ^ 2 ≤ 2 ^ (k - 1)) :
+    ∃ c : Coloring n, ∀ K : Finset (Fin n), K.card = k → ¬ Mono c K :=
+  first_moment_ramsey (by omega) hkn (firstMoment_hyp_of_sq hk hkn hsq)
+
+/-- For `j ≥ 3`, `2j + 1 ≤ 2^j`: the clique size stays below the vertex count, so the
+    closed-form bound applies along the odd diagonal. -/
+theorem two_mul_add_one_le_pow (j : ℕ) (hj : 3 ≤ j) : 2 * j + 1 ≤ 2 ^ j := by
+  induction j, hj using Nat.le_induction with
+  | base => norm_num
+  | succ m hm ih =>
+      have h2m : (2 : ℕ) ≤ 2 ^ m := by
+        calc (2 : ℕ) = 2 ^ 1 := (pow_one 2).symm
+          _ ≤ 2 ^ m := Nat.pow_le_pow_right (by norm_num) (by omega)
+      have hsplit : 2 ^ (m + 1) = 2 ^ m + 2 ^ m := by rw [pow_succ]; ring
+      omega
+
+/-- **Exponential growth of the diagonal Ramsey number.**  For every `j ≥ 3`,
+    `R(2j+1, 2j+1) > 2^j`: there is a 2-coloring of `K_{2^j}` with no monochromatic
+    `K_{2j+1}`.  Writing `k = 2j+1` this is `R(k,k) > 2^((k-1)/2) = (√2)^(k-1)`, so the
+    first moment method alone forces `R(k,k)` to grow at least like `(√2)^k`. -/
+theorem ramsey_diagonal_growth (j : ℕ) (hj : 3 ≤ j) :
+    ∃ c : Coloring (2 ^ j),
+      ∀ K : Finset (Fin (2 ^ j)), K.card = 2 * j + 1 → ¬ Mono c K := by
+  apply ramsey_no_mono_of_sq
+  · omega
+  · exact two_mul_add_one_le_pow j hj
+  · have heq : (2 ^ j) ^ 2 = 2 ^ (2 * j) := by rw [← pow_mul, Nat.mul_comm]
+    rw [Nat.add_sub_cancel]
+    exact le_of_eq heq
+
+/-- Concrete instance of the growth bound: `R(7,7) > 8`.  The first moment method
+    produces a 2-coloring of `K_8` with no monochromatic `K_7`
+    (here `8^2 = 64 = 2^6 = 2^(7-1)`, the threshold met with equality). -/
+theorem ramsey_seven_gt_eight :
+    ∃ c : Coloring 8, ∀ K : Finset (Fin 8), K.card = 7 → ¬ Mono c K :=
+  ramsey_no_mono_of_sq (by norm_num) (by norm_num) (by decide)
+
+end ProbMethod.RamseyDiagonalGrowth

--- a/src/data/proofs/prob-method-expectation-oq-02-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-02-oq-01/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "prob-method-expectation-oq-02-oq-01",
+  "slug": "prob-method-expectation-oq-02-oq-01",
+  "title": "First Moment Recovers the 2^(k/2) Diagonal Ramsey Growth",
+  "sorries": 0,
+  "description": "Answers open question #1 of the parent entry: turn the first-moment Ramsey criterion 2·C(n,k) < 2^(C(k,2)) into the recognizable closed-form growth statement n ≤ 2^((k-1)/2) ⟹ R(k,k) > n, and extract the headline exponential bound R(2j+1,2j+1) > 2^j for j ≥ 3 — i.e. the diagonal Ramsey number grows at least like (√2)^k, the classical Erdős (1947) lower order, recovered purely from the first moment method over ℕ.",
+  "overview": "The parent entry (prob-method-expectation-oq-02) proves the *implication* form of the Erdős union bound — 2·C(n,k) < 2^(C(k,2)) ⟹ R(k,k) > n — but only instantiates it at one numeric point (R(4,4) > 6). It does not perform the estimate of C(n,k) needed to expose the famous 2^(k/2) growth. This entry closes that gap.\n\nThe arithmetic core (`firstMoment_hyp_of_sq`) shows that the fraction-free threshold n^2 ≤ 2^(k-1) — which is exactly n ≤ 2^((k-1)/2) written without fractional exponents — implies the criterion, for k ≥ 3 and k ≤ n. The chain is\n\n    2·C(n,k)  <  k!·C(n,k)  =  n^(k̲)  ≤  n^k  ≤  2^(C(k,2)),\n\nwhere the first step uses 2 < k! (valid for k ≥ 3) together with C(n,k) ≥ 1; the equality is descFactorial = k!·C(n,k); the bound n^(k̲) ≤ n^k is descFactorial ≤ pow; and the final inequality squares n^2 ≤ 2^(k-1) and uses the identity 2·C(k,2) = k(k-1) so that (n^k)^2 = (n^2)^k ≤ (2^(k-1))^k = 2^(k(k-1)) = (2^(C(k,2)))^2.\n\nFeeding this into the parent's `first_moment_ramsey` gives `ramsey_no_mono_of_sq`: the closed-form bound R(k,k) > n whenever n ≤ 2^((k-1)/2). Specializing to the odd diagonal k = 2j+1, n = 2^j (so n^2 = 2^(k-1) with equality) and checking the side condition 2j+1 ≤ 2^j (for j ≥ 3) yields `ramsey_diagonal_growth`: R(2j+1, 2j+1) > 2^j, the exponential growth of the diagonal Ramsey number. The concrete instance R(7,7) > 8 is `ramsey_seven_gt_eight`.",
+  "conclusion": {
+    "summary": "The first moment method, with the standard estimate of the binomial coefficient, yields the closed-form diagonal Ramsey lower bound R(k,k) > 2^((k-1)/2): along the odd diagonal, R(2j+1,2j+1) > 2^j for all j ≥ 3. This recovers the classical (√2)^k exponential growth of R(k,k) purely from the union bound, with no probability measure, entirely over ℕ.",
+    "implications": "**1. Closes the parent's estimation gap.** The parent stops at the implication form plus one numeric point; here C(n,k) is estimated and n chosen optimally, exposing the recognizable 2^(k/2) growth the parent's open question #1 asked for.\n\n**2. Fraction-free formulation.** The threshold n ≤ 2^((k-1)/2) is kept integer-exact as n^2 ≤ 2^(k-1), so the whole argument stays in ℕ — no real exponentials, no analysis.\n\n**3. Exponential growth, machine-checked.** R(2j+1,2j+1) > 2^j makes the order-of-magnitude lower bound on the diagonal Ramsey number a fully verified theorem.",
+    "openQuestions": [
+      "Sharpen the constant: derive the refined R(k,k) > (1+o(1))·(k/e)·2^(k/2) by carrying the k!^(1/k) ~ k/e factor through the estimate (requires Stirling-type bounds and an o(1) framework — only the exponential order is proved here).",
+      "Prove the bound for the full diagonal, including even k, by choosing the optimal integer n = ⌊2^((k-1)/2)⌋ and verifying k ≤ n for all sufficiently large k."
+    ]
+  },
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.RamseyFirstMoment"],
+    "opens": ["Finset", "ProbMethod.RamseyFirstMoment"],
+    "namespace": "ProbMethod.RamseyDiagonalGrowth",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/RamseyFirstMomentOQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "ramsey_diagonal_growth",
+      "type": "main",
+      "description": "Exponential growth of the diagonal Ramsey number: for every j ≥ 3, R(2j+1, 2j+1) > 2^j — there is a 2-coloring of K_{2^j} with no monochromatic K_{2j+1}. Writing k = 2j+1 this is R(k,k) > 2^((k-1)/2) = (√2)^(k-1).",
+      "leanType": "(j : ℕ) (hj : 3 ≤ j) : ∃ c : Coloring (2 ^ j), ∀ K : Finset (Fin (2 ^ j)), K.card = 2 * j + 1 → ¬ Mono c K"
+    },
+    {
+      "name": "firstMoment_hyp_of_sq",
+      "type": "core",
+      "description": "Arithmetic core: the fraction-free 2^((k-1)/2) threshold n^2 ≤ 2^(k-1) implies the first-moment criterion 2·C(n,k) < 2^(C(k,2)), for k ≥ 3 and k ≤ n. This is the estimation step the parent left open.",
+      "leanType": "(hk : 3 ≤ k) (hkn : k ≤ n) (hsq : n ^ 2 ≤ 2 ^ (k - 1)) : 2 * n.choose k < 2 ^ (k.choose 2)"
+    },
+    {
+      "name": "ramsey_no_mono_of_sq",
+      "type": "main",
+      "description": "Closed-form first-moment Ramsey lower bound: if k ≥ 3, k ≤ n and n ≤ 2^((k-1)/2) (as n^2 ≤ 2^(k-1)), then K_n has a 2-coloring with no monochromatic K_k, i.e. R(k,k) > n.",
+      "leanType": "(hk : 3 ≤ k) (hkn : k ≤ n) (hsq : n ^ 2 ≤ 2 ^ (k - 1)) : ∃ c : Coloring n, ∀ K : Finset (Fin n), K.card = k → ¬ Mono c K"
+    },
+    {
+      "name": "two_mul_choose_two",
+      "type": "lemma",
+      "description": "The exponent identity 2·C(k,2) = k(k-1), proved through the falling factorial, used to align (2^(k-1))^k with (2^(C(k,2)))^2 in the squaring step.",
+      "leanType": "(k : ℕ) : 2 * k.choose 2 = k * (k - 1)"
+    },
+    {
+      "name": "two_mul_add_one_le_pow",
+      "type": "lemma",
+      "description": "Side condition 2j+1 ≤ 2^j for j ≥ 3, so along the odd diagonal the clique size stays below the vertex count and the closed-form bound applies.",
+      "leanType": "(j : ℕ) (hj : 3 ≤ j) : 2 * j + 1 ≤ 2 ^ j"
+    },
+    {
+      "name": "ramsey_seven_gt_eight",
+      "type": "example",
+      "description": "Concrete instance of the growth bound: R(7,7) > 8 (here 8^2 = 64 = 2^6 = 2^(7-1), the threshold met with equality), giving a 2-coloring of K_8 with no monochromatic K_7.",
+      "leanType": "∃ c : Coloring 8, ∀ K : Finset (Fin 8), K.card = 7 → ¬ Mono c K"
+    }
+  ],
+  "sections": [
+    { "title": "Exponent Identity 2·C(k,2) = k(k-1)", "description": "Twice the second binomial coefficient equals the falling factorial k(k-1), proved through descFactorial." },
+    { "title": "Arithmetic Core: Threshold ⟹ Criterion", "description": "n^2 ≤ 2^(k-1) implies 2·C(n,k) < 2^(C(k,2)) via 2·C(n,k) < k!·C(n,k) = n^(k̲) ≤ n^k ≤ 2^(C(k,2)), the last step by squaring the threshold." },
+    { "title": "Closed-Form Ramsey Bound", "description": "Combining the core with the parent's first_moment_ramsey gives R(k,k) > n whenever n ≤ 2^((k-1)/2)." },
+    { "title": "Odd-Diagonal Side Condition", "description": "2j+1 ≤ 2^j for j ≥ 3 (by Nat.le_induction), placing the clique size below the vertex count." },
+    { "title": "Exponential Growth and Concrete Witness", "description": "R(2j+1,2j+1) > 2^j for j ≥ 3, and the instance R(7,7) > 8." }
+  ],
+  "crossReferences": [
+    { "slug": "prob-method-expectation-oq-02", "relation": "parent", "description": "Answers open question #1 — derive the explicit growth from the first-moment criterion by estimating C(n,k) and choosing n optimally; reuses its first_moment_ramsey, Coloring and Mono." },
+    { "slug": "prob-method-expectation", "relation": "ancestor", "description": "Grandparent entry whose placeholder Ramsey lower bound the parent replaced and this entry now quantifies." },
+    { "slug": "prob-method-alteration", "relation": "related", "description": "The alteration method pushes the diagonal lower bound beyond the pure first-moment 2^(k/2) growth proved here." }
+  ],
+  "references": [
+    { "label": "Erdős 1947", "citation": "P. Erdős, Some remarks on the theory of graphs, Bull. Amer. Math. Soc. 53 (1947), 292–294 (the 2^(k/2) diagonal Ramsey lower bound)." },
+    { "label": "Alon–Spencer", "citation": "N. Alon, J. H. Spencer, The Probabilistic Method, Ch. 1 (the first moment bound R(k,k) > 2^(k/2) and the k/e refinement)." }
+  ],
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "lineCount": 138,
+    "proofRepoPath": "Proofs/RamseyFirstMomentOQ01.lean",
+    "author": "Paul Erdős (1947), formalized in Lean 4",
+    "date": "1947",
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "sorries": 0,
+    "tags": ["probabilistic-method", "combinatorics", "ramsey-theory", "union-bound", "lower-bound", "asymptotics", "intermediate"],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on the foundational axioms propext, Classical.choice, Quot.sound; no sorryAx, no native_decide / Lean.ofReduceBool).",
+    "originalContributions": [
+      "firstMoment_hyp_of_sq: the binomial-coefficient estimate the parent left open — the fraction-free threshold n^2 ≤ 2^(k-1) implies the first-moment criterion 2·C(n,k) < 2^(C(k,2)) for 3 ≤ k ≤ n, via 2·C(n,k) < k!·C(n,k) = descFactorial ≤ n^k ≤ 2^(C(k,2)).",
+      "ramsey_no_mono_of_sq: the closed-form diagonal Ramsey lower bound R(k,k) > n whenever n ≤ 2^((k-1)/2), kept entirely over ℕ.",
+      "ramsey_diagonal_growth: the headline exponential bound R(2j+1, 2j+1) > 2^j for j ≥ 3 — the classical (√2)^k growth of the diagonal Ramsey number, recovered from the pure first moment method.",
+      "two_mul_choose_two: the exponent identity 2·C(k,2) = k(k-1) via the falling factorial.",
+      "two_mul_add_one_le_pow: the side condition 2j+1 ≤ 2^j for j ≥ 3.",
+      "ramsey_seven_gt_eight: the concrete witness R(7,7) > 8."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers **open question #1** of the parent entry *The Tightest First-Moment Ramsey Bound* (`prob-method-expectation-oq-02`):

> *Derive the explicit asymptotic R(k,k) > … by estimating C(n,k) and choosing n optimally, showing the first moment method recovers the classical 2^(k/2) growth.*

The parent proves only the **implication** form of the Erdős (1947) union bound — `2·C(n,k) < 2^(C(k,2)) ⟹ R(k,k) > n` — and instantiates it at a single point (R(4,4)>6). It never estimates C(n,k), so the famous 2^(k/2) growth stays hidden. This entry closes that gap.

## What is proved

- **`firstMoment_hyp_of_sq`** (arithmetic core) — the fraction-free threshold `n² ≤ 2^(k-1)` (i.e. `n ≤ 2^((k-1)/2)`) implies the first-moment criterion, for `3 ≤ k ≤ n`, via
  ```
  2·C(n,k) < k!·C(n,k) = n^(k̲) ≤ n^k ≤ 2^(C(k,2)),
  ```
  the last step by squaring the threshold and using `2·C(k,2) = k(k-1)`.
- **`ramsey_no_mono_of_sq`** — closed form: `R(k,k) > n` whenever `n ≤ 2^((k-1)/2)`.
- **`ramsey_diagonal_growth`** (main) — the headline exponential bound **`R(2j+1, 2j+1) > 2^j`** for `j ≥ 3`; with `k = 2j+1` this is `R(k,k) > (√2)^(k-1)`, the classical diagonal growth recovered from the pure first moment method.
- **`ramsey_seven_gt_eight`** — concrete witness `R(7,7) > 8`.

Everything is over ℕ — no probability measure, no real exponentials. Reuses the parent's `first_moment_ramsey`, `Coloring`, `Mono`.

## Verification

- 138 lines, **6 theorems, 0 definitions, 0 sorries, 0 axioms**.
- `#print axioms` on every theorem: only `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Built locally with Lean v4.26.0 + Mathlib (Docker unavailable this session).

## Honesty note

Only the **exponential order** (√2)^k is proved; the sharper `(1+o(1))·(k/e)·2^(k/2)` constant (needing Stirling-type bounds and an o(1) framework) is left as a recorded open question, as is the even-k diagonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)