### PR TITLE
Enrich Combinatorial Characterization of Jordan's Totient J_k (erdos-1000-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/erdos-1000-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "jc-defs",
+    "proofId": "erdos-1000-oq-03-oq-01",
+    "range": { "startLine": 37, "endLine": 47 },
+    "type": "definition",
+    "title": "The combinatorial count C_k(n)",
+    "content": "Three definitions set up the counting model. `gv a` is the gcd of all coordinates of a tuple $a : \\mathrm{Fin}\\,k \\to \\mathrm{Fin}\\,n$, taken as naturals. `coprimeTuples k n` is the finset of tuples whose coordinates are *jointly* coprime to $n$ — meaning $\\gcd(a_0,\\dots,a_{k-1},n)=1$, not pairwise coprimality. `jordanCount k n = C_k(n)` is its cardinality. This is the honest combinatorial definition of Jordan's totient that the parent entry erdos-1000-oq-03 deferred; the whole file exists to prove this count equals the Dirichlet-convolution $J_k = \\mu * \\mathrm{pow}_k$.",
+    "mathContext": "$C_k(n) = \\#\\{(a_0,\\dots,a_{k-1}) \\in (\\mathbb{Z}/n)^k : \\gcd(a_0,\\dots,a_{k-1},n)=1\\}$. At $k=1$ this is $\\#\\{a : \\gcd(a,n)=1\\} = \\varphi(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Jordan totient", "joint coprimality", "gcd of a family", "counting model"],
+    "prerequisites": ["greatest common divisor", "finite types"]
+  },
+  {
+    "id": "jc-gcd-scaling",
+    "proofId": "erdos-1000-oq-03-oq-01",
+    "range": { "startLine": 49, "endLine": 61 },
+    "type": "technique",
+    "title": "How the coordinate-gcd scales",
+    "content": "Two helper lemmas capture the arithmetic that powers the bijection. `gcd_smul` says scaling every coordinate by $d$ multiplies the coordinate-gcd by $d$: $\\gcd(d a_0,\\dots,d a_{k-1}) = d\\gcd(a_0,\\dots,a_{k-1})$, via Mathlib's `Finset.gcd_mul_left` (with `normalize_eq` to discharge ℕ-normalization). `gcd_div` is the inverse: when $d$ divides every coordinate, dividing through by $d$ divides the gcd by $d$. These are exactly the forward/backward content-tracking facts the fiber bijection needs.",
+    "mathContext": "$\\gcd(d a_i) = d\\,\\gcd(a_i)$; and if $d \\mid a_i$ for all $i$, then $\\gcd(a_i/d) = \\gcd(a_i)/d$.",
+    "significance": "supporting",
+    "relatedConcepts": ["gcd scaling law", "Finset.gcd_mul_left", "divisibility"],
+    "prerequisites": ["greatest common divisor", "divisibility"]
+  },
+  {
+    "id": "jc-divisor-sum",
+    "proofId": "erdos-1000-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 136 },
+    "type": "insight",
+    "title": "The Gauss-type divisor identity, by bijective counting",
+    "content": "`jordanCount_divisor_sum` proves $\\sum_{d\\mid n} C_k(d) = n^k$ — the exact generalization of Gauss's $\\sum_{d\\mid n}\\varphi(d) = n$. The proof is purely combinatorial, not a Möbius computation: partition all $n^k$ tuples in $(\\mathbb{Z}/n)^k$ by their *content* $d = \\gcd(a_0,\\dots,a_{k-1},n)$ (`card_eq_sum_card_fiberwise`), then show each fiber over $d$ is in explicit bijection with the jointly-coprime tuples mod $n/d$ (`card_bij'`, via the scaling maps $a \\mapsto a/d$ and $b \\mapsto d\\cdot b$). So $n^k = \\sum_{d\\mid n} C_k(n/d)$, and the divisor reindexing $d\\mapsto n/d$ (`Nat.sum_div_divisors`) yields the stated identity. The two-sided bijection requires proving both maps stay in range and land in the right set — the bulk of the lemma.",
+    "mathContext": "$\\sum_{d\\mid n} C_k(d) = n^k$. Every $k$-tuple mod $n$ is uniquely $d\\cdot(\\text{a jointly-coprime tuple mod } n/d)$ where $d=\\gcd(\\text{coords},n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Gauss divisor-sum identity", "fiberwise counting", "explicit bijection", "content of a tuple"],
+    "prerequisites": ["double counting", "bijective cardinality arguments", "gcd"]
+  },
+  {
+    "id": "jc-moebius",
+    "proofId": "erdos-1000-oq-03-oq-01",
+    "range": { "startLine": 138, "endLine": 152 },
+    "type": "insight",
+    "title": "Möbius inversion to the closed form",
+    "content": "`jordanCount_eq_moebius_sum` inverts the divisor identity into the explicit closed form $C_k(n) = \\sum_{d\\mid n}\\mu(d)(n/d)^k$. Feeding $\\sum_{d\\mid n}C_k(d) = n^k$ into Mathlib's `sum_eq_iff_sum_smul_moebius_eq` (Möbius inversion over the additive group $\\mathbb{Z}$) yields the formula directly. Crucially, the right-hand side is exactly $(\\mu * \\mathrm{pow}_k)(n) = J_k(n)$ — so this theorem is the bridge proving the combinatorial count $C_k$ equals the Dirichlet-convolution $J_k$ defined in the parent entry, closing the equivalence of the two definitions.",
+    "mathContext": "$C_k(n) = \\sum_{d\\mid n}\\mu(d)\\left(\\tfrac{n}{d}\\right)^k = (\\mu * \\mathrm{pow}_k)(n) = J_k(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Mobius inversion", "Dirichlet convolution", "Jordan totient", "closed form"],
+    "prerequisites": ["Mobius inversion", "Mobius function"]
+  },
+  {
+    "id": "jc-euler-recovery",
+    "proofId": "erdos-1000-oq-03-oq-01",
+    "range": { "startLine": 154, "endLine": 176 },
+    "type": "concept",
+    "title": "Euler totient recovery at k = 1",
+    "content": "`jordanCount_one_eq_totient` checks the boundary case $C_1(n) = \\varphi(n)$. A length-one tuple's coordinate-gcd is just its single entry (`hgv`), so a jointly-coprime $1$-tuple is exactly a residue coprime to $n$ — and `card_bij'` matches `coprimeTuples 1 n` with the totient's filter set $\\{x < n : \\gcd(n,x)=1\\}$. This confirms the count genuinely specializes to Euler's totient, anchoring Jordan's $J_k$ as its higher-dimensional generalization and validating the whole counting model.",
+    "mathContext": "$C_1(n) = \\#\\{a < n : \\gcd(a,n)=1\\} = \\varphi(n)$, so $J_1 = \\varphi$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler totient", "base case", "bijective counting"],
+    "prerequisites": ["Euler totient function", "coprimality"]
+  }
+]

--- a/src/data/proofs/erdos-1000-oq-03-oq-01/meta.json
+++ b/src/data/proofs/erdos-1000-oq-03-oq-01/meta.json
@@ -3,6 +3,83 @@
   "title": "The Combinatorial Characterization of Jordan's Totient $J_k$",
   "slug": "erdos-1000-oq-03-oq-01",
   "description": "Closes the gap left open by erdos-1000-oq-03, which built Jordan's totient J_k from its Dirichlet-convolution definition J_k = μ * pow k while explicitly deferring the combinatorial counting definition. This entry proves the convolution closed form really does count tuples. Define C_k(n) = #{ (a_0,…,a_{k-1}) ∈ (ℤ/n)^k : gcd(a_0,…,a_{k-1},n) = 1 }, the number of k-tuples mod n jointly coprime to n. Proves, with 0 axioms and 0 sorries (no native_decide): the Gauss-type divisor identity ∑_{d∣n} C_k(d) = n^k (the exact generalization of ∑_{d∣n} φ(d) = n), via an explicit bijection showing every tuple mod n scales uniquely from a jointly-coprime tuple mod n/d where d = gcd(a_0,…,a_{k-1},n); the explicit Jordan closed form C_k(n) = ∑_{d∣n} μ(d)·(n/d)^k obtained by Möbius inversion, establishing that the combinatorial count C_k coincides with the Dirichlet-convolution J_k = μ * pow k of erdos-1000-oq-03; and the Euler recovery C_1(n) = φ(n), confirming the count specializes to Euler's totient at k = 1. The whole development rests on one elementary scaling bijection plus Mathlib's Möbius inversion — no analysis.",
+  "overview": {
+    "historicalContext": "Camille Jordan introduced the totient J_k around 1870 as the count of k-tuples of residues mod n that are jointly coprime to n — equivalently, the order of the group of k×... configurations he studied in his theory of substitutions. For k=1 it is Euler's classical φ. The two faces of J_k — the combinatorial count C_k and the Dirichlet-convolution closed form μ * pow k — are classically known to coincide, but the equivalence is usually asserted via the formula rather than proved bijectively. The parent gallery entry (erdos-1000-oq-03) developed the convolution side (multiplicativity, divisor-sum theory) but deliberately deferred the counting definition. This entry supplies it and proves the two definitions agree, mirroring the classical derivation of φ's properties from ∑_{d∣n} φ(d) = n. The argument is elementary and self-contained: a single explicit scaling bijection establishes the Gauss-type divisor identity, and Möbius inversion does the rest — no analytic number theory.",
+    "problemStatement": "Define C_k(n) = #{ (a_0,…,a_{k-1}) ∈ (ℤ/n)^k : gcd(a_0,…,a_{k-1},n) = 1 } and prove it equals Jordan's totient: establish the divisor identity ∑_{d∣n} C_k(d) = n^k, derive the closed form C_k(n) = ∑_{d∣n} μ(d)(n/d)^k (so C_k = J_k = μ * pow k), and confirm C_1 = φ — all with 0 axioms and 0 sorries.",
+    "proofStrategy": "Prove the Gauss-type divisor identity ∑_{d∣n} C_k(d) = n^k by a bijective fiberwise count: partition all n^k tuples in (ℤ/n)^k by their content d = gcd(coordinates, n), and exhibit an explicit two-sided bijection (card_bij') between the fiber over d and the jointly-coprime tuples mod n/d, via the scaling maps a ↦ a/d and b ↦ d·b — using the gcd scaling lemmas gcd_smul and gcd_div to track coprimality through the maps. Reindex d ↦ n/d (Nat.sum_div_divisors) to reach the stated form. Then Möbius-invert the divisor sum (sum_eq_iff_sum_smul_moebius_eq) to obtain the explicit closed form, which is literally (μ * pow k)(n) = J_k(n), proving C_k = J_k. Finally specialize to k = 1 by another bijection identifying jointly-coprime 1-tuples with the residues counted by φ.",
+    "keyInsights": [
+      "The divisor identity ∑_{d∣n} C_k(d) = n^k is proved combinatorially, not by Möbius computation: it is the cleaner direction, since every k-tuple mod n factors uniquely as d·(a jointly-coprime tuple mod n/d) with d = gcd(coordinates, n).",
+      "Content stratification: classifying all n^k tuples by their content d turns the brute total n^k into a sum of jointly-coprime counts, exactly the generalization of how ∑_{d∣n} φ(d) = n stratifies {0,…,n−1} by gcd with n.",
+      "The scaling maps a ↦ a/d and b ↦ d·b form a genuine two-sided bijection because the coordinate-gcd scales linearly (gcd_smul / gcd_div) and Nat.coprime_div_gcd_div_gcd guarantees the scaled-down tuple is coprime to n/d.",
+      "Möbius inversion is the only non-elementary input, and it does exactly one job: turn the proved divisor identity into the closed form ∑_{d∣n} μ(d)(n/d)^k — which is by definition (μ * pow k)(n), equating the combinatorial C_k with the parent's Dirichlet-convolution J_k.",
+      "The k = 1 specialization C_1 = φ both validates the counting model and pins down J_k as the faithful higher-dimensional generalization of Euler's totient."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context: closing the counting gap",
+      "startLine": 3,
+      "endLine": 31,
+      "summary": "Docstring situating the entry as the combinatorial half of the parent's Jordan-totient theory, defining C_k(n), and stating the three results (divisor sum, closed form, φ recovery)."
+    },
+    {
+      "id": "definitions",
+      "title": "Definitions: gv, coprimeTuples, jordanCount",
+      "startLine": 33,
+      "endLine": 47,
+      "summary": "Defines the coordinate-gcd gv, the finset coprimeTuples of jointly-coprime k-tuples, and the count jordanCount k n = C_k(n)."
+    },
+    {
+      "id": "gcd-lemmas",
+      "title": "Scaling lemmas (gcd_smul, gcd_div)",
+      "startLine": 49,
+      "endLine": 61,
+      "summary": "Proves gcd(d·a_i) = d·gcd(a_i) and, when d divides every coordinate, gcd(a_i/d) = gcd(a_i)/d — the content-tracking facts for the bijection."
+    },
+    {
+      "id": "divisor-sum",
+      "title": "Gauss-type divisor identity (jordanCount_divisor_sum)",
+      "startLine": 63,
+      "endLine": 136,
+      "summary": "Proves ∑_{d∣n} C_k(d) = n^k by fibering all n^k tuples by content d = gcd(coords,n) and exhibiting the explicit scaling bijection between each fiber and coprimeTuples k (n/d)."
+    },
+    {
+      "id": "moebius-closed-form",
+      "title": "Closed form via Möbius inversion (jordanCount_eq_moebius_sum)",
+      "startLine": 138,
+      "endLine": 152,
+      "summary": "Möbius-inverts the divisor sum to C_k(n) = ∑_{d∣n} μ(d)(n/d)^k = (μ * pow k)(n), equating the combinatorial count with the parent's Dirichlet-convolution J_k."
+    },
+    {
+      "id": "euler-recovery",
+      "title": "Euler recovery (jordanCount_one_eq_totient)",
+      "startLine": 154,
+      "endLine": 176,
+      "summary": "Proves C_1(n) = φ(n) by matching jointly-coprime 1-tuples with the residues coprime to n via card_bij'."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry supplies the combinatorial counting definition of Jordan's totient that the parent erdos-1000-oq-03 deferred, and proves it agrees with the Dirichlet-convolution definition. Define C_k(n) = #{ jointly-coprime k-tuples mod n }. The Gauss-type identity ∑_{d∣n} C_k(d) = n^k (jordanCount_divisor_sum) is proved by an explicit scaling bijection: every k-tuple mod n is uniquely d·(a coprime tuple mod n/d) for d = gcd(coordinates, n). Möbius inversion (jordanCount_eq_moebius_sum) then gives C_k(n) = ∑_{d∣n} μ(d)(n/d)^k = (μ * pow k)(n) = J_k(n), so the count and the convolution coincide. The case k = 1 recovers Euler's totient C_1 = φ (jordanCount_one_eq_totient). 179 lines, 5 theorems, 3 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Equating C_k with J_k turns every structural fact about the convolution J_k (multiplicativity, prime-power values, Euler products — developed in the child entry erdos-1000-oq-03-oq-01-oq-01) into a statement about an honest count of tuples, and conversely lets combinatorial intuition guide the algebra. The bijective proof of ∑_{d∣n} C_k(d) = n^k is reusable and Mathlib-free beyond the Möbius-inversion step, and it models the classical Gauss-identity argument for φ in arbitrary dimension k.",
+    "openQuestions": [
+      "Prove the multiplicativity of C_k directly from the counting model via the Chinese Remainder Theorem (jointly-coprime tuples mod mn correspond to pairs mod m and mod n for coprime m,n), giving a combinatorial route to isMultiplicative_jordan independent of the convolution.",
+      "Establish the natural density of jointly-coprime k-tuples, lim_{n→∞} C_k(n)/n^k = 1/ζ(k+1) for k ≥ 1, generalizing the classical 6/π² probability that two integers are coprime (k=1 limit of φ(n)/n averages).",
+      "Give an inclusion–exclusion derivation of the closed form C_k(n) = ∑_{d∣n} μ(d)(n/d)^k directly from the counting set, complementing the Möbius-inversion proof with a sieve over the prime divisors of n."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1000-oq-03",
+      "relationship": "extends",
+      "description": "Parent entry. Builds J_k from the Dirichlet-convolution definition J_k = μ * pow k and explicitly defers the combinatorial counting definition. This entry supplies that definition C_k and proves C_k = J_k via the divisor identity and Möbius inversion, equating the two."
+    },
+    {
+      "targetId": "erdos-1000-oq-03-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Child entry. Takes the convolution J_k = μ * pow k (shown here to equal the count C_k) and develops its multiplicative structure: multiplicativity, prime-power values, the integer and real Euler products, positivity, and the recovery J_1 = φ."
+    }
+  ],
   "meta": {
     "author": "Classical combinatorial identity for Jordan's totient (Camille Jordan, 1870); formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Jordan%27s_totient_function",


### PR DESCRIPTION
Enrichment pass for `erdos-1000-oq-03-oq-01` (The Combinatorial Characterization of Jordan's Totient $J_k$). The merged research entry had only meta.json (description + originalContributions) with no overview, sections, conclusion, or annotations.

## Added
- **annotations.json** (new): 5 annotations covering the definitions (gv / coprimeTuples / jordanCount), the gcd scaling lemmas, the bijective Gauss-type divisor identity, the Möbius-inversion closed form, and the Euler recovery — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Line ranges validated against the Lean source (0 annotation errors).
- **overview** (new): `historicalContext` (Camille Jordan 1870; the count vs. convolution faces of J_k), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 6 sections covering the full 179-line Lean file.
- **conclusion** (new): `summary`, `implications`, and 3 `openQuestions` (CRT multiplicativity, density 1/ζ(k+1), inclusion–exclusion derivation).
- **crossReferences** (new): to parent `erdos-1000-oq-03` (extends) and child `erdos-1000-oq-03-oq-01-oq-01` (related).

## Notes
- No changes to the Lean source or to status/badge/axiomCount — meta accurately reports `verified` / `original` / 0 axioms / 0 sorries (no axiom/sorry/native_decide).
- Annotations drawn directly from the proof: content stratification + the two-sided scaling bijection (card_bij'), gcd_smul/gcd_div tracking, Nat.sum_div_divisors reindexing, and Möbius inversion identifying C_k with (μ * pow k) = J_k.