### PR TITLE
Enrich Worpitzky's Identity (geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "worp-term",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 39, "endLine": 73 },
+    "type": "technique",
+    "title": "The per-term absorption identity",
+    "content": "`worpitzky_term` is the algebraic engine of the whole proof: for $k\\le m$, $(k+1)\\binom{x+k}{m+1} + (m-k)\\binom{x+k+1}{m+1} = x\\binom{x+k}{m}$, an identity of naturals. The proof splits on $x+k$ vs $m$: when $x+k<m$ every binomial vanishes and `ring` closes it; otherwise it transfers to $\\mathbb{Z}$ (where subtraction is honest), combines Pascal's rule $\\binom{x+k+1}{m+1}=\\binom{x+k}{m}+\\binom{x+k}{m+1}$ with the absorption $\\binom{a}{m+1}(m+1)=\\binom{a}{m}(a-m)$, and closes by `linear_combination`. Casting carefully with `Nat.cast_sub` avoids ℕ's truncated subtraction.",
+    "mathContext": "$(k+1)\\binom{x+k}{m+1} + (m-k)\\binom{x+k+1}{m+1} = x\\binom{x+k}{m}$ for $k \\le m$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial absorption identity", "Pascal's rule", "linear_combination", "natural vs integer subtraction"],
+    "prerequisites": ["binomial coefficients", "Lean coercions"]
+  },
+  {
+    "id": "worp-sum-def",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 75, "endLine": 85 },
+    "type": "definition",
+    "title": "The Worpitzky sum",
+    "content": "`worpitzkySum m n` packages the right-hand side $W_m(n) = \\sum_{j=0}^{m}\\langle m,j\\rangle\\binom{n+j}{m}$ as a standalone object, so the identity becomes the clean claim $W_m(n) = n^m$. The helper `eulerian_zero_left` records $\\langle m,0\\rangle = 1$ (the all-ascending permutation is the unique one with zero descents), used to evaluate the boundary term of the reindexed row.",
+    "mathContext": "$W_m(n) = \\sum_{j=0}^{m}\\langle m,j\\rangle\\binom{n+j}{m}$; $\\langle m,0\\rangle = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Worpitzky's identity", "Eulerian numbers", "shifted binomial basis"],
+    "prerequisites": ["finite sums", "Eulerian numbers"]
+  },
+  {
+    "id": "worp-reindex",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 87, "endLine": 132 },
+    "type": "technique",
+    "title": "Reindexing through the triangle recurrence",
+    "content": "`worpitzkySum_succ_eq` is the structural lemma: it rewrites the order-$(m{+}1)$ Worpitzky sum by expanding each Eulerian entry through the triangle recurrence $\\langle m{+}1,k{+}1\\rangle = (k{+}2)\\langle m,k{+}1\\rangle + (m{-}k)\\langle m,k\\rangle$. Peeling the $j=0$ term (`sum_range_succ'`) and using the off-diagonal vanishing $\\langle m,m{+}1\\rangle = 0$ makes the boundary term disappear, so $W_{m+1}(n) = \\sum_k \\langle m,k\\rangle[(k{+}1)\\binom{n+k}{m+1} + (m{-}k)\\binom{n+k+1}{m+1}]$. The proof carefully matches two range sums (`hL`, `hR`) and reconciles the leftover binomial terms with `omega`.",
+    "mathContext": "$W_{m+1}(n) = \\sum_{k=0}^{m}\\langle m,k\\rangle\\bigl[(k{+}1)\\binom{n+k}{m+1} + (m{-}k)\\binom{n+k+1}{m+1}\\bigr]$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian triangle recurrence", "index shifting", "off-diagonal vanishing", "Finset reindexing"],
+    "prerequisites": ["recurrences", "Finset sum manipulation"]
+  },
+  {
+    "id": "worp-main",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 134, "endLine": 161 },
+    "type": "insight",
+    "title": "Worpitzky's identity, by induction",
+    "content": "`worpitzkySum_eq_pow` closes the induction $W_m(n) = n^m$: applying `worpitzky_term` to every summand turns the reindexed order-$(m{+}1)$ sum into $\\sum_k \\langle m,k\\rangle\\,(n\\binom{n+k}{m}) = n\\cdot W_m(n)$, and the inductive hypothesis gives $n\\cdot n^m = n^{m+1}$. `worpitzky` is then just the symmetric statement $n^m = \\sum_{j=0}^{m}\\langle m,j\\rangle\\binom{n+j}{m}$ — the classical change of basis expressing the power basis in the shifted-binomial basis, with the Eulerian numbers as the nonnegative integer connection coefficients.",
+    "mathContext": "$n^m = \\sum_{j=0}^{m}\\langle m,j\\rangle\\binom{n+j}{m}$ (Worpitzky's identity).",
+    "significance": "key",
+    "relatedConcepts": ["Worpitzky's identity", "change of basis", "Eulerian numbers", "induction"],
+    "prerequisites": ["induction", "binomial coefficients", "Eulerian numbers"]
+  },
+  {
+    "id": "worp-succ",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 163, "endLine": 168 },
+    "type": "concept",
+    "title": "Dropping the vanishing top term",
+    "content": "`worpitzky_succ` refines the identity by noting $\\langle m{+}1,m{+}1\\rangle = 0$ (a permutation of $m{+}1$ elements has at most $m$ descents), so the $j=m{+}1$ term is zero and the descent index runs only to $m$: $n^{m+1} = \\sum_{j=0}^{m}\\langle m{+}1,j\\rangle\\binom{n+j}{m+1}$. This is the form in which Worpitzky's identity is usually quoted, with exactly $m{+}1$ nonzero Eulerian coefficients.",
+    "mathContext": "$\\langle m{+}1,m{+}1\\rangle = 0 \\Rightarrow n^{m+1} = \\sum_{j=0}^{m}\\langle m{+}1,j\\rangle\\binom{n+j}{m+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["descent statistic", "off-diagonal vanishing", "Eulerian numbers"],
+    "prerequisites": ["Eulerian numbers", "binomial coefficients"]
+  },
+  {
+    "id": "worp-instances",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 170, "endLine": 190 },
+    "type": "context",
+    "title": "Low-order instances",
+    "content": "Three concrete checks exhibit the identity in action: $n^2 = \\binom{n}{2}+\\binom{n+1}{2}$ (Eulerian row $1,1$), $n^3 = \\binom{n}{3}+4\\binom{n+1}{3}+\\binom{n+2}{3}$ (row $1,4,1$), and the numeric instance $4^3 = 64 = 4 + 40 + 20$. The Eulerian values are discharged by kernel `decide` (not `native_decide`), keeping the file genuinely 0-axiom. These make concrete that the connection coefficients are precisely the Eulerian numbers $\\langle m,j\\rangle$.",
+    "mathContext": "$n^2 = \\binom{n}{2}+\\binom{n+1}{2}$; $n^3 = \\binom{n}{3}+4\\binom{n+1}{3}+\\binom{n+2}{3}$; $4^3 = 4+40+20$.",
+    "significance": "context",
+    "relatedConcepts": ["Eulerian triangle rows", "kernel decide", "worked examples"],
+    "prerequisites": ["binomial coefficients"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -19,6 +19,77 @@
     "sorries": 0
   },
   "title": "Worpitzky's Identity: nᵐ = ∑ⱼ ⟨m,j⟩·C(n+j, m)",
+  "description": "Proves Worpitzky's identity — the most celebrated identity satisfied by the Eulerian numbers — for the combinatorial ⟨m,j⟩ built in the parent entry, as an identity of natural numbers: nᵐ = ∑_{j=0}^{m} ⟨m,j⟩·C(n+j, m). It expresses the power basis nᵐ in the shifted-binomial basis C(n+j,m) with the Eulerian numbers as the nonnegative integer connection coefficients. The proof is an induction on m driven by a single binomial absorption identity worpitzky_term, (k+1)·C(x+k,m+1) + (m−k)·C(x+k+1,m+1) = x·C(x+k,m); reindexing the order-(m+1) Eulerian row through its triangle recurrence (the off-diagonal ⟨m,m+1⟩ = 0 killing the boundary term) turns the order-(m+1) Worpitzky sum into n times the order-m sum, closing n^{m+1} = n·n^m. Verifies the order-2/3 instances n² = C(n,2)+C(n+1,2) and n³ = C(n,3)+4·C(n+1,3)+C(n+2,3). 192 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Worpitzky's identity, published by Julius Worpitzky in 1883, expresses any power xⁿ as a nonnegative-integer combination of the shifted binomial coefficients C(x+k,n), with the Eulerian numbers ⟨n,k⟩ as coefficients. It is the most famous identity satisfied by the Eulerian numbers — introduced by Euler in 1755 to count permutations by descents — and is a cornerstone of the finite-difference calculus and the theory of the descent statistic (Concrete Mathematics, Graham–Knuth–Patashnik). The identity is the combinatorial dual of the Eulerian-polynomial generating function ∑_{j≥0} jⁿ xʲ = A_n(x)/(1−x)^{n+1}: summing Worpitzky's expansion against a geometric series reproduces that numerator, tying the combinatorial Eulerian numbers back to the geometric-moment lineage this entry descends from. Mathlib formalizes neither the Eulerian numbers nor Worpitzky's identity, so both are built from scratch here on top of the parent's triangle.",
+    "problemStatement": "Given the combinatorial Eulerian numbers ⟨m,j⟩ defined by the triangle recurrence in the parent entry, prove Worpitzky's identity nᵐ = ∑_{j=0}^{m} ⟨m,j⟩·C(n+j, m) for all m,n, as an identity of natural numbers, with 0 axioms and 0 sorries.",
+    "proofStrategy": "Define the Worpitzky sum W_m(n) = ∑_{j=0}^{m} ⟨m,j⟩·C(n+j,m) and prove W_m(n) = nᵐ by induction on m. The inductive step rests on the per-term absorption identity worpitzky_term, (k+1)·C(x+k,m+1) + (m−k)·C(x+k+1,m+1) = x·C(x+k,m) for k ≤ m, obtained from Pascal's rule and the binomial absorption C(a,m+1)(m+1) = C(a,m)(a−m) (transferred once to ℤ and closed by linear_combination). The structural lemma worpitzkySum_succ_eq reindexes the order-(m+1) Eulerian row through the triangle recurrence ⟨m+1,k+1⟩ = (k+2)⟨m,k+1⟩ + (m−k)⟨m,k⟩, the off-diagonal vanishing ⟨m,m+1⟩ = 0 killing the boundary term. Applying worpitzky_term termwise then collapses W_{m+1}(n) to n·W_m(n), so n^{m+1} = n·nᵐ closes the induction. The corollary worpitzky_succ drops the vanishing top term.",
+    "keyInsights": [
+      "Worpitzky's identity is the change of basis from the power basis nᵐ to the shifted-binomial basis C(n+j,m), and it makes manifest that the connection coefficients are exactly the nonnegative integer Eulerian numbers ⟨m,j⟩.",
+      "The entire induction is powered by one absorption identity, worpitzky_term, which encodes both Pascal's rule and the binomial absorption C(a,m+1)(m+1) = C(a,m)(a−m) in a single per-term equation closed by linear_combination over ℤ.",
+      "Reindexing the order-(m+1) Eulerian row through its own triangle recurrence is what converts W_{m+1}(n) into n·W_m(n); the off-diagonal vanishing ⟨m,m+1⟩ = 0 is precisely what makes the boundary term of the shifted sum disappear.",
+      "Working over ℤ for the absorption step (then casting back to ℕ) sidesteps truncated natural subtraction, which would otherwise break the (m−k) and (a−m) factors.",
+      "Summed against a geometric series, Worpitzky's identity reproduces the Eulerian-polynomial numerator E_m(r)/(1−r)^{m+1} of the geometric moment up the lineage — closing the loop between the combinatorial Eulerian numbers and the analytic generating function."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context and method",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Docstring stating Worpitzky's identity, the low-order examples, and the induction-via-absorption method; notes the file is 0-axiom and sorry-free."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and namespace",
+      "startLine": 32,
+      "endLine": 37,
+      "summary": "Imports Mathlib and the parent module, opens Finset and the parent namespace to reuse the eulerian triangle and its recurrence/vanishing lemmas."
+    },
+    {
+      "id": "worpitzky-term",
+      "title": "The per-term absorption identity (worpitzky_term)",
+      "startLine": 39,
+      "endLine": 73,
+      "summary": "Proves (k+1)·C(x+k,m+1) + (m−k)·C(x+k+1,m+1) = x·C(x+k,m) for k ≤ m, by case split on x+k vs m, Pascal's rule, and absorption over ℤ closed by linear_combination."
+    },
+    {
+      "id": "worpitzky-sum",
+      "title": "The Worpitzky sum (worpitzkySum, eulerian_zero_left)",
+      "startLine": 75,
+      "endLine": 85,
+      "summary": "Defines W_m(n) = ∑_{j=0}^{m} ⟨m,j⟩·C(n+j,m) and records ⟨m,0⟩ = 1 for the boundary term."
+    },
+    {
+      "id": "reindex",
+      "title": "Triangle-recurrence reindexing (worpitzkySum_succ_eq)",
+      "startLine": 87,
+      "endLine": 132,
+      "summary": "Rewrites W_{m+1}(n) via the Eulerian triangle recurrence and ⟨m,m+1⟩ = 0, expressing it as ∑_k ⟨m,k⟩·[(k+1)C(n+k,m+1) + (m−k)C(n+k+1,m+1)]."
+    },
+    {
+      "id": "main-identity",
+      "title": "Worpitzky's identity (worpitzkySum_eq_pow, worpitzky)",
+      "startLine": 134,
+      "endLine": 161,
+      "summary": "Induction W_m(n) = nᵐ: applying worpitzky_term termwise collapses the reindexed sum to n·W_m(n); worpitzky restates it as nᵐ = ∑_{j} ⟨m,j⟩·C(n+j,m)."
+    },
+    {
+      "id": "worpitzky-succ",
+      "title": "Dropping the top term (worpitzky_succ)",
+      "startLine": 163,
+      "endLine": 168,
+      "summary": "Uses ⟨m+1,m+1⟩ = 0 to drop the vanishing top term, giving the descent index running only to m."
+    },
+    {
+      "id": "instances",
+      "title": "Low-order instances",
+      "startLine": 170,
+      "endLine": 190,
+      "summary": "Verifies n² = C(n,2)+C(n+1,2), n³ = C(n,3)+4C(n+1,3)+C(n+2,3) (Eulerian rows 1,1 and 1,4,1), and 4³ = 64 = 4+40+20, with Eulerian values by kernel decide."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03` (Worpitzky's Identity: nᵐ = ∑ⱼ ⟨m,j⟩·C(n+j, m)). The entry had meta.json with conclusion/crossReferences/originalContributions but no description, overview, sections, or annotations.

## Added
- **annotations.json** (new): 6 annotations covering the per-term absorption identity, the Worpitzky sum definition, the triangle-recurrence reindexing, the main induction + identity, the top-term drop, and the low-order instances — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Line ranges validated against the Lean source (0 annotation errors).
- **overview** (new): `historicalContext` (Worpitzky 1883; Euler's descent statistic; the Eulerian-polynomial GF dual ∑ jⁿxʲ = A_n(x)/(1−x)^{n+1}), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 8 sections covering the full 192-line Lean file.
- **description** (new): top-level summary.

## Notes
- No changes to the Lean source or to status/badge/axiomCount — meta accurately reports `verified` / `original` / 0 axioms / 0 sorries (low-order checks use kernel `decide`, not native_decide).
- Annotations drawn directly from the proof: the Pascal+absorption per-term identity over ℤ, the off-diagonal-vanishing reindexing, and the n·W_m(n) collapse closing the induction.