### PR TITLE
research(eisenstein-criterion-oq-01-oq-03): general Eisenstein polynomials Xⁿ+p·g and irreducibility over ℚ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -879,6 +879,7 @@ import Proofs.EhrhartPolynomialOQ03
 import Proofs.EhrhartPolynomials
 import Proofs.EhrhartSimplexProven
 import Proofs.EisensteinCriterionOQ01
+import Proofs.EisensteinCriterionOQ01OQ03
 import Proofs.ElementaryQuadraticReciprocity
 import Proofs.ElementaryQuadraticReciprocityOQ01
 import Proofs.ElementaryQuadraticReciprocityOQ01OQ01

--- a/proofs/Proofs/EisensteinCriterionOQ01OQ03.lean
+++ b/proofs/Proofs/EisensteinCriterionOQ01OQ03.lean
@@ -1,0 +1,214 @@
+/-
+  Eisenstein's criterion for GENERAL integer polynomials, and irreducibility over ℚ.
+
+  The companion entry `eisenstein-criterion-oq-01` restates the abstract criterion
+  (over an arbitrary integral domain, phrased with a prime ideal `P`) and carries
+  out the concrete coefficient bookkeeping for the single family `Xⁿ − p`.
+
+  This file answers its third open question:
+
+    > Generalize the coefficient bookkeeping to Eisenstein-at-`p` polynomials with
+    > arbitrary lower coefficients divisible by `p` (general `IsEisensteinAt`
+    > instances).
+
+  We do three genuinely new things relative to the parent.
+
+  **1. Concrete general criterion over `ℤ`.**  We trade the abstract ideal
+  hypotheses for plain divisibility by a prime integer `p`: a monic `f` of positive
+  degree with `p ∣ f.coeff k` for every `k` below the degree and `p² ∤ f.coeff 0`
+  is irreducible over `ℤ`.  The lower coefficients are completely arbitrary subject
+  to divisibility by `p`.
+
+  **2. The general Eisenstein family `Xⁿ + p·g`.**  Concretely, for *any* `g` with
+  `deg g < n` and `p ∤ g.coeff 0`, the polynomial `Xⁿ + p·g` is Eisenstein at `p`.
+  This is the "arbitrary lower coefficients" the parent could not reach — e.g.
+  `X² + 2X + 2`, `X³ + 3X + 3` — and it specializes back to `Xⁿ − p` at `g = −1`.
+
+  **3. Irreducibility over `ℚ` (Gauss's lemma).**  Eisenstein's criterion earns its
+  keep precisely because it produces irreducibility over `ℚ`: a monic integer
+  Eisenstein polynomial is irreducible in `ℚ[X]`, so it is the minimal polynomial of
+  each of its roots and `[ℚ(α):ℚ] = deg f`.  The parent only proves irreducibility
+  over `ℤ`; here we cross Gauss's lemma
+  (`Polynomial.Monic.irreducible_iff_irreducible_map_fraction_map`, with `ℚ` the
+  fraction field of `ℤ`) to land in `ℚ[X]`.
+
+  Everything is fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Polynomial
+
+namespace EisensteinCriterionOQ01OQ03
+
+/-! ### Eisenstein's criterion for general integer polynomials -/
+
+/-- Local restatement of Mathlib's abstract Eisenstein criterion
+(`Polynomial.irreducible_of_eisenstein_criterion`), used below. -/
+theorem aux_irreducible_of_eisenstein {R : Type*} [CommRing R] [IsDomain R]
+    {f : R[X]} {P : Ideal R} (hP : P.IsPrime)
+    (hlead : f.leadingCoeff ∉ P)
+    (hlow : ∀ k : ℕ, (k : WithBot ℕ) < f.degree → f.coeff k ∈ P)
+    (hdeg : 0 < f.degree)
+    (hconst : f.coeff 0 ∉ P ^ 2)
+    (hprim : f.IsPrimitive) : Irreducible f :=
+  irreducible_of_eisenstein_criterion hP hlead hlow hdeg hconst hprim
+
+/-- **Eisenstein's criterion over `ℤ`, concrete divisibility form.**
+A monic integer polynomial `f` of positive degree, all of whose coefficients below
+the leading one are divisible by a prime `p`, and whose constant term is *not*
+divisible by `p²`, is irreducible over `ℤ`.
+
+The lower coefficients are arbitrary subject to `p ∣ f.coeff k`; this generalizes
+the `Xⁿ − p` family of the parent entry, where the only nonzero lower coefficient is
+the constant term. -/
+theorem irreducible_int_of_eisenstein {f : ℤ[X]} {p : ℤ} (hp : Prime p)
+    (hmonic : f.Monic) (hdeg : 0 < f.natDegree)
+    (hlow : ∀ k < f.natDegree, p ∣ f.coeff k)
+    (hconst : ¬ (p ^ 2 ∣ f.coeff 0)) :
+    Irreducible f := by
+  have hP : (Ideal.span {p}).IsPrime := (Ideal.span_singleton_prime hp.ne_zero).mpr hp
+  have hdeg' : f.degree = (f.natDegree : WithBot ℕ) := degree_eq_natDegree hmonic.ne_zero
+  refine aux_irreducible_of_eisenstein hP ?_ ?_ ?_ ?_ hmonic.isPrimitive
+  · -- leading coefficient `1 ∉ (p)`
+    rw [hmonic.leadingCoeff, Ideal.mem_span_singleton]
+    exact fun h => hp.not_unit (isUnit_of_dvd_one h)
+  · -- every lower coefficient lies in `(p)`
+    intro k hk
+    rw [hdeg'] at hk
+    have hkn : k < f.natDegree := by exact_mod_cast hk
+    rw [Ideal.mem_span_singleton]
+    exact hlow k hkn
+  · -- positive degree
+    rw [hdeg']; exact_mod_cast hdeg
+  · -- constant coefficient `∉ (p²)`
+    rw [Ideal.span_singleton_pow, Ideal.mem_span_singleton]
+    exact hconst
+
+/-- **A monic integer Eisenstein polynomial is irreducible over `ℚ`.**
+Crossing Gauss's lemma (`ℚ` is the fraction field of `ℤ`) upgrades irreducibility
+over `ℤ` to irreducibility over `ℚ`. This is the form in which Eisenstein's
+criterion is actually used: such an `f` is the minimal polynomial of each of its
+roots, giving `[ℚ(α) : ℚ] = deg f`. -/
+theorem irreducible_rat_of_eisenstein {f : ℤ[X]} {p : ℤ} (hp : Prime p)
+    (hmonic : f.Monic) (hdeg : 0 < f.natDegree)
+    (hlow : ∀ k < f.natDegree, p ∣ f.coeff k)
+    (hconst : ¬ (p ^ 2 ∣ f.coeff 0)) :
+    Irreducible (f.map (algebraMap ℤ ℚ)) :=
+  (hmonic.irreducible_iff_irreducible_map_fraction_map).mp
+    (irreducible_int_of_eisenstein hp hmonic hdeg hlow hconst)
+
+/-! ### The general Eisenstein family `Xⁿ + p·g`
+
+For any `g` with `deg g < n` and `p ∤ g.coeff 0`, the polynomial `Xⁿ + p·g` is
+Eisenstein at `p`: monic of degree `n`, every lower coefficient is `p · g.coeff k`
+(divisible by `p`), and the constant coefficient `p · g.coeff 0` is divisible by `p`
+but not `p²`. This is the "arbitrary lower coefficients" generalization. -/
+
+/-- `Xⁿ + p·g` is monic when `deg g < n`. -/
+theorem monic_X_pow_add_CP_mul {p : ℤ} (hp : Prime p) {n : ℕ} {g : ℤ[X]}
+    (hg : g.natDegree < n) : ((X : ℤ[X]) ^ n + C p * g).Monic := by
+  apply monic_X_pow_add
+  rw [degree_C_mul hp.ne_zero]
+  exact lt_of_le_of_lt degree_le_natDegree (by exact_mod_cast hg)
+
+/-- `Xⁿ + p·g` has degree exactly `n` when `0 < n` and `deg g < n`. -/
+theorem natDegree_X_pow_add_CP_mul {p : ℤ} (hp : Prime p) {n : ℕ} {g : ℤ[X]}
+    (hg : g.natDegree < n) : ((X : ℤ[X]) ^ n + C p * g).natDegree = n := by
+  apply natDegree_eq_of_degree_eq_some
+  have hlt : (C p * g).degree < ((X : ℤ[X]) ^ n).degree := by
+    rw [degree_X_pow, degree_C_mul hp.ne_zero]
+    exact lt_of_le_of_lt degree_le_natDegree (by exact_mod_cast hg)
+  rw [degree_add_eq_left_of_degree_lt hlt, degree_X_pow]
+
+/-- **The general Eisenstein family is irreducible over `ℤ`.**
+For any `g` with `deg g < n` (`0 < n`) and `p ∤ g.coeff 0`, the monic polynomial
+`Xⁿ + p·g` is irreducible. This realizes "Eisenstein-at-`p` with arbitrary lower
+coefficients divisible by `p`". -/
+theorem irreducible_int_X_pow_add_CP_mul {p : ℤ} (hp : Prime p) {n : ℕ} (hn : 0 < n)
+    {g : ℤ[X]} (hg : g.natDegree < n) (hg0 : ¬ p ∣ g.coeff 0) :
+    Irreducible ((X : ℤ[X]) ^ n + C p * g) := by
+  have hmonic := monic_X_pow_add_CP_mul hp hg
+  have hnd := natDegree_X_pow_add_CP_mul hp hg
+  have hcoeff : ∀ k, ((X : ℤ[X]) ^ n + C p * g).coeff k
+      = (if k = n then 1 else 0) + p * g.coeff k := by
+    intro k; rw [coeff_add, coeff_X_pow, coeff_C_mul]
+  refine irreducible_int_of_eisenstein hp hmonic (by rw [hnd]; exact hn) ?_ ?_
+  · -- lower coefficients: `p · g.coeff k`, divisible by `p`
+    intro k hk
+    rw [hnd] at hk
+    rw [hcoeff, if_neg (by omega : k ≠ n), zero_add]
+    exact dvd_mul_right p (g.coeff k)
+  · -- constant coefficient `p · g.coeff 0` is not divisible by `p²`
+    rw [hcoeff, if_neg (by omega : (0 : ℕ) ≠ n), zero_add, pow_two]
+    intro h
+    exact hg0 ((mul_dvd_mul_iff_left hp.ne_zero).mp h)
+
+/-- **The general Eisenstein family is irreducible over `ℚ`.** -/
+theorem irreducible_rat_X_pow_add_CP_mul {p : ℤ} (hp : Prime p) {n : ℕ} (hn : 0 < n)
+    {g : ℤ[X]} (hg : g.natDegree < n) (hg0 : ¬ p ∣ g.coeff 0) :
+    Irreducible (((X : ℤ[X]) ^ n + C p * g).map (algebraMap ℤ ℚ)) :=
+  ((monic_X_pow_add_CP_mul hp hg).irreducible_iff_irreducible_map_fraction_map).mp
+    (irreducible_int_X_pow_add_CP_mul hp hn hg hg0)
+
+/-! ### Recovering the parent family `Xⁿ − p`
+
+`Xⁿ − p = Xⁿ + p·(−1)`, so it is the `g = −1` member of the family above. We obtain
+irreducibility over `ℚ` as well, which is what gives `[ℚ(ⁿ√p) : ℚ] = n`. -/
+
+/-- **`Xⁿ − p` is irreducible over `ℤ`**, recovered from the general family. -/
+theorem irreducible_int_X_pow_sub_C {p : ℤ} (hp : Prime p) {n : ℕ} (hn : 0 < n) :
+    Irreducible ((X : ℤ[X]) ^ n - C p) := by
+  have heq : (X : ℤ[X]) ^ n - C p = X ^ n + C p * C (-1) := by
+    rw [map_neg, map_one, mul_neg, mul_one, sub_eq_add_neg]
+  rw [heq]
+  refine irreducible_int_X_pow_add_CP_mul hp hn ?_ ?_
+  · rw [natDegree_C]; exact hn
+  · rw [coeff_C_zero]
+    exact fun h => hp.not_unit (isUnit_of_dvd_unit h isUnit_one.neg)
+
+/-- **`Xⁿ − p` is irreducible over `ℚ`** — the parent's flagship example, lifted to
+the rationals (which is what underlies `[ℚ(ⁿ√p) : ℚ] = n`). -/
+theorem irreducible_rat_X_pow_sub_C {p : ℤ} (hp : Prime p) {n : ℕ} (hn : 0 < n) :
+    Irreducible (((X : ℤ[X]) ^ n - C p).map (algebraMap ℤ ℚ)) := by
+  have hmonic : ((X : ℤ[X]) ^ n - C p).Monic := monic_X_pow_sub_C p hn.ne'
+  exact (hmonic.irreducible_iff_irreducible_map_fraction_map).mp
+    (irreducible_int_X_pow_sub_C hp hn)
+
+/-! ### Concrete instances with genuinely nonzero lower coefficients
+
+These are the cases the parent could *not* reach: Eisenstein polynomials whose
+lower coefficients other than the constant term are nonzero. -/
+
+/-- `X² + 2X + 2` is irreducible over `ℤ` (Eisenstein at `2`; the linear coefficient
+`2` is a nonzero lower coefficient divisible by `2`). -/
+theorem irreducible_int_X_sq_add_two_X_add_two :
+    Irreducible ((X : ℤ[X]) ^ 2 + C 2 * X + C 2) := by
+  have heq : (X : ℤ[X]) ^ 2 + C 2 * X + C 2 = X ^ 2 + C 2 * (X + C 1) := by
+    rw [C_1]; ring
+  rw [heq]
+  refine irreducible_int_X_pow_add_CP_mul Int.prime_two (by norm_num) ?_ ?_
+  · rw [natDegree_add_C, natDegree_X]; norm_num
+  · rw [coeff_add, coeff_X_zero, coeff_C_zero]; norm_num
+
+/-- `X³ + 3X + 3` is irreducible over `ℤ` (Eisenstein at `3`). -/
+theorem irreducible_int_X_cube_add_three_X_add_three :
+    Irreducible ((X : ℤ[X]) ^ 3 + C 3 * X + C 3) := by
+  have heq : (X : ℤ[X]) ^ 3 + C 3 * X + C 3 = X ^ 3 + C 3 * (X + C 1) := by
+    rw [C_1]; ring
+  rw [heq]
+  refine irreducible_int_X_pow_add_CP_mul Int.prime_three (by norm_num) ?_ ?_
+  · rw [natDegree_add_C, natDegree_X]; norm_num
+  · rw [coeff_add, coeff_X_zero, coeff_C_zero]; norm_num
+
+/-- `X² + 2X + 2` is irreducible over `ℚ` — a concrete Eisenstein polynomial with a
+nonzero middle coefficient, irreducible over the rationals. -/
+theorem irreducible_rat_X_sq_add_two_X_add_two :
+    Irreducible (((X : ℤ[X]) ^ 2 + C 2 * X + C 2).map (algebraMap ℤ ℚ)) := by
+  have heq : (X : ℤ[X]) ^ 2 + C 2 * X + C 2 = X ^ 2 + C 2 * (X + C 1) := by
+    rw [C_1]; ring
+  rw [heq]
+  refine irreducible_rat_X_pow_add_CP_mul Int.prime_two (by norm_num) ?_ ?_
+  · rw [natDegree_add_C, natDegree_X]; norm_num
+  · rw [coeff_add, coeff_X_zero, coeff_C_zero]; norm_num
+
+end EisensteinCriterionOQ01OQ03

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03/annotations.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "eisenstein-criterion-oq-01-oq-03-module-header",
+    "proofId": "eisenstein-criterion-oq-01-oq-03",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 41
+    },
+    "title": "Module Header: General Eisenstein Polynomials over ℤ and ℚ",
+    "content": "Answers the third open question of `eisenstein-criterion-oq-01`. The parent restated the abstract criterion and handled the single family $X^n - p$ over $\\mathbb{Z}$. This file does three new things: (1) a **concrete divisibility-form** criterion over $\\mathbb{Z}$ — monic $f$, $p \\mid f_k$ for all $k$ below the degree, $p^2 \\nmid f_0$ $\\Rightarrow$ irreducible; (2) the **general family** $X^n + p\\,g$ for arbitrary $g$ with $\\deg g < n$ and $p \\nmid g(0)$ — the genuine 'arbitrary lower coefficients' case; (3) **irreducibility over $\\mathbb{Q}$** via Gauss's lemma, the form in which Eisenstein is actually used."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-03-int-criterion",
+    "proofId": "eisenstein-criterion-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 64,
+      "endLine": 90
+    },
+    "title": "Concrete Eisenstein Criterion over ℤ",
+    "content": "`irreducible_int_of_eisenstein`: trades the abstract prime ideal of the parent for plain divisibility by a prime integer $p$. For a monic $f$ of positive degree with $p \\mid f.\\mathrm{coeff}\\,k$ for every $k$ below the degree and $p^2 \\nmid f.\\mathrm{coeff}\\,0$, $f$ is irreducible over $\\mathbb{Z}$. The proof takes $P = $ `Ideal.span {p}` and converts the four hypotheses via `Ideal.mem_span_singleton` (membership $\\iff$ divisibility) and `Ideal.span_singleton_pow` ($(p)^2 = (p^2)$); primitivity is `Monic.isPrimitive`. The lower coefficients are now arbitrary subject only to divisibility by $p$."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-03-rat-criterion",
+    "proofId": "eisenstein-criterion-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 92,
+      "endLine": 98
+    },
+    "title": "Irreducibility over ℚ via Gauss's Lemma",
+    "content": "`irreducible_rat_of_eisenstein`: the operative form of Eisenstein's criterion. Because the polynomial is **monic** and $\\mathbb{Q}$ is the **fraction field** of $\\mathbb{Z}$, Gauss's lemma (`Monic.irreducible_iff_irreducible_map_fraction_map`) lifts irreducibility over $\\mathbb{Z}$ to irreducibility over $\\mathbb{Q}$. It is over $\\mathbb{Q}$ that an irreducible monic polynomial is the minimal polynomial of each of its roots, giving $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\deg f$. The parent stopped at $\\mathbb{Z}$."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-03-general-family",
+    "proofId": "eisenstein-criterion-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 100,
+      "endLine": 151
+    },
+    "title": "The General Family Xⁿ + p·g",
+    "content": "`irreducible_int_X_pow_add_CP_mul` (with helpers `monic_X_pow_add_CP_mul`, `natDegree_X_pow_add_CP_mul`): for any $g$ with $\\deg g < n$ ($0 < n$) and $p \\nmid g(0)$, the polynomial $X^n + p\\,g$ is irreducible over $\\mathbb{Z}$, and over $\\mathbb{Q}$ (`irreducible_rat_X_pow_add_CP_mul`). This is the direct answer to the open question: the coefficient formula $\\mathrm{coeff}\\,k = [k = n] + p\\cdot g.\\mathrm{coeff}\\,k$ makes every lower coefficient $p\\cdot g.\\mathrm{coeff}\\,k$ (divisible by $p$), while the constant coefficient $p\\cdot g(0)$ avoids $p^2$ exactly when $p \\nmid g(0)$ (cancelling one factor of $p$ via `mul_dvd_mul_iff_left`). Monicity and $\\deg = n$ follow from `monic_X_pow_add` and `degree_add_eq_left_of_degree_lt` since $\\deg(p\\,g) < n$."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-03-recover-xn-p",
+    "proofId": "eisenstein-criterion-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 153,
+      "endLine": 175
+    },
+    "title": "Recovering Xⁿ − p (over ℤ and ℚ)",
+    "content": "`irreducible_int_X_pow_sub_C` and `irreducible_rat_X_pow_sub_C`: the parent's flagship $X^n - p$ is the $g = -1$ member of the family, since $X^n - p = X^n + p\\cdot(-1)$ and $p \\nmid -1$ (as $p$ is not a unit). The $\\mathbb{Q}$ version is what underlies $[\\mathbb{Q}(\\sqrt[n]{p}):\\mathbb{Q}] = n$ — the parent only had the $\\mathbb{Z}$ statement."
+  },
+  {
+    "id": "eisenstein-criterion-oq-01-oq-03-instances",
+    "proofId": "eisenstein-criterion-oq-01-oq-03",
+    "type": "example",
+    "range": {
+      "startLine": 177,
+      "endLine": 213
+    },
+    "title": "Concrete Instances with Nonzero Middle Coefficients",
+    "content": "`irreducible_int_X_sq_add_two_X_add_two` ($X^2 + 2X + 2$, Eisenstein at $2$), `irreducible_int_X_cube_add_three_X_add_three` ($X^3 + 3X + 3$, at $3$), and `irreducible_rat_X_sq_add_two_X_add_two` (the first over $\\mathbb{Q}$). Each is the $g = X + 1$ member of the family at the relevant prime: $C\\,p \\cdot (X + 1) = pX + p$, so $g(0) = 1$ is not divisible by $p$. These are genuine Eisenstein polynomials with **nonzero middle coefficients** — exactly the cases the parent's $X^n - p$ form could not express."
+  }
+]

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "eisenstein-criterion-oq-01-oq-03",
+  "title": "Eisenstein's Criterion for General Integer Polynomials, and Irreducibility over ℚ",
+  "slug": "eisenstein-criterion-oq-01-oq-03",
+  "description": "Answers the third open question of eisenstein-criterion-oq-01: generalize the coefficient bookkeeping beyond Xⁿ − p to Eisenstein-at-p polynomials with arbitrary lower coefficients divisible by p. Three new contributions: (1) a concrete divisibility-form criterion over ℤ (monic f, p ∣ coeff k for k below the degree, p² ∤ coeff 0 ⇒ irreducible); (2) the general family Xⁿ + p·g for any g with deg g < n and p ∤ g.coeff 0 — the genuine 'arbitrary lower coefficients' case the parent could not reach, with Xⁿ − p recovered as g = −1; (3) irreducibility over ℚ via Gauss's lemma, the form in which Eisenstein is actually used (minimal polynomials, [ℚ(α):ℚ] = deg f). Concrete instances X² + 2X + 2, X³ + 3X + 3 (nonzero middle coefficients) over ℤ and ℚ. 12 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion",
+    "date": "Gotthold Eisenstein, 1850 (Theodor Schönemann, 1846)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "irreducibility",
+      "number-theory",
+      "ring-theory",
+      "gauss-lemma",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/EisensteinCriterionOQ01OQ03.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.irreducible_of_eisenstein_criterion",
+        "description": "Eisenstein's irreducibility criterion over an integral domain with a prime ideal P — the core engine, re-exported as aux_irreducible_of_eisenstein and specialized to the concrete ℤ divisibility form.",
+        "module": "Mathlib.RingTheory.Polynomial.Eisenstein.Basic"
+      },
+      {
+        "theorem": "Polynomial.Monic.irreducible_iff_irreducible_map_fraction_map",
+        "description": "Gauss's lemma for integrally closed domains: a monic polynomial is irreducible iff its image in the fraction field is. With ℚ the fraction field of ℤ, this lifts irreducibility over ℤ to irreducibility over ℚ.",
+        "module": "Mathlib.RingTheory.Polynomial.GaussLemma"
+      },
+      {
+        "theorem": "Polynomial.monic_X_pow_add / Polynomial.degree_C_mul / Polynomial.degree_add_eq_left_of_degree_lt",
+        "description": "Monicity and degree of Xⁿ + p·g when deg(p·g) < n: supplies the monic, positive-degree, and natDegree = n inputs for the general family.",
+        "module": "Mathlib.Algebra.Polynomial.Monic / Degree"
+      },
+      {
+        "theorem": "Ideal.span_singleton_prime / Ideal.mem_span_singleton / Ideal.span_singleton_pow",
+        "description": "Primality of (p), membership x ∈ (p) ↔ p ∣ x, and (p)² = (p²); converts the abstract ideal hypotheses into concrete divisibility by p and p².",
+        "module": "Mathlib.RingTheory.Ideal.Operations"
+      }
+    ],
+    "assumptions": "None. All 12 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide is used anywhere.",
+    "originalContributions": [
+      "irreducible_int_of_eisenstein: Eisenstein's criterion over ℤ in concrete divisibility form — monic f of positive degree, p ∣ f.coeff k for all k below the degree, p² ∤ f.coeff 0 ⇒ f irreducible. The lower coefficients are arbitrary subject to divisibility by p, generalizing the parent's Xⁿ − p (where only the constant term is a nonzero lower coefficient).",
+      "irreducible_int_X_pow_add_CP_mul: the general Eisenstein family Xⁿ + p·g is irreducible over ℤ for any g with deg g < n and p ∤ g.coeff 0 — the explicit 'arbitrary lower coefficients divisible by p' construction, with supporting monic_X_pow_add_CP_mul and natDegree_X_pow_add_CP_mul.",
+      "irreducible_rat_of_eisenstein and irreducible_rat_X_pow_add_CP_mul: irreducibility over ℚ via Gauss's lemma (ℚ = Frac ℤ) — the form Eisenstein is actually used in, giving minimal polynomials and [ℚ(α):ℚ] = deg f. The parent stopped at irreducibility over ℤ.",
+      "irreducible_int_X_pow_sub_C / irreducible_rat_X_pow_sub_C: the parent's flagship Xⁿ − p recovered as the g = −1 member of the family, now also over ℚ (underlying [ℚ(ⁿ√p):ℚ] = n).",
+      "irreducible_int_X_sq_add_two_X_add_two, irreducible_int_X_cube_add_three_X_add_three, irreducible_rat_X_sq_add_two_X_add_two: concrete Eisenstein polynomials with genuinely nonzero middle coefficients (X² + 2X + 2 at p = 2, X³ + 3X + 3 at p = 3) — cases the parent's Xⁿ − p machinery could not express."
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 214,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Eisenstein's criterion (Eisenstein 1850; Schönemann 1846) is the standard elementary irreducibility test: a single prime p dividing all coefficients below the leader but not the leader itself, with p² not dividing the constant term, forces irreducibility over the fraction field. The parent entry eisenstein-criterion-oq-01 restated the abstract criterion and carried out the coefficient bookkeeping for the single family Xⁿ − p, over ℤ. This entry answers its third open question by treating general Eisenstein-at-p polynomials with arbitrary lower coefficients, and by crossing Gauss's lemma to reach irreducibility over ℚ — the setting in which the criterion is genuinely applied.",
+    "problemStatement": "**Open Question (OQ-01-OQ-03)**: Generalize the coefficient bookkeeping to Eisenstein-at-p polynomials with arbitrary lower coefficients divisible by p (general IsEisensteinAt instances).\n\n**Formalized**: a concrete divisibility-form criterion over ℤ (irreducible_int_of_eisenstein); the general family Xⁿ + p·g (irreducible_int_X_pow_add_CP_mul); the upgrade to ℚ via Gauss's lemma (irreducible_rat_of_eisenstein, irreducible_rat_X_pow_add_CP_mul); the recovery of Xⁿ − p over both ℤ and ℚ; and concrete instances X² + 2X + 2, X³ + 3X + 3 with nonzero middle coefficients.",
+    "text": "A 214-line formalization in 12 theorems. The abstract Mathlib criterion (irreducible_of_eisenstein_criterion) is re-exported, then specialized to a concrete statement over ℤ in which the ideal hypotheses become plain divisibility by a prime p: this is irreducible_int_of_eisenstein. The centerpiece is the general family Xⁿ + p·g, where g is an arbitrary integer polynomial of degree below n with p ∤ g.coeff 0 — every lower coefficient is p·g.coeff k (divisible by p) and the constant coefficient p·g.coeff 0 is divisible by p but not p². Gauss's lemma (ℚ being the fraction field of ℤ) then lifts every irreducibility statement from ℤ to ℚ. The parent's Xⁿ − p is the g = −1 instance, and the concrete polynomials X² + 2X + 2 (p = 2) and X³ + 3X + 3 (p = 3) exhibit nonzero middle coefficients beyond the parent's reach. All 12 theorems compile with 0 sorries and 0 axioms, no native_decide.",
+    "proofStrategy": "**Concrete ℤ criterion (irreducible_int_of_eisenstein)**: take P = Ideal.span {p}, prime via Ideal.span_singleton_prime. degree = natDegree since a monic polynomial is nonzero. Discharge the four abstract hypotheses by Ideal.mem_span_singleton (membership ↔ divisibility) and Ideal.span_singleton_pow ((p)² = (p²)); primitivity from Monic.isPrimitive.\n\n**General family (irreducible_int_X_pow_add_CP_mul)**: monic_X_pow_add reduces monicity to degree(C p·g) < n, obtained from degree_C_mul (p ≠ 0) and degree_le_natDegree with deg g < n; natDegree = n via degree_add_eq_left_of_degree_lt against degree_X_pow. The coefficient formula coeff k = (if k = n then 1 else 0) + p·g.coeff k (coeff_add, coeff_X_pow, coeff_C_mul) makes the lower coefficients p·g.coeff k (divisible by p) and the constant coefficient p·g.coeff 0; p² ∤ p·g.coeff 0 reduces to p ∤ g.coeff 0 by cancelling one factor of p (mul_dvd_mul_iff_left).\n\n**Over ℚ (irreducible_rat_*)**: apply Monic.irreducible_iff_irreducible_map_fraction_map with K = ℚ.\n\n**Recovery and instances**: Xⁿ − p = Xⁿ + p·(−1), so it is the g = −1 family member (p ∤ −1 since p is not a unit). X² + 2X + 2 = X² + 2·(X + 1) and X³ + 3X + 3 = X³ + 3·(X + 1) are the g = X + 1 members at p = 2, 3, with g.coeff 0 = 1 not divisible by p.",
+    "keyInsights": [
+      "**Arbitrary lower coefficients, one construction**: Xⁿ + p·g packages every monic Eisenstein-at-p polynomial whose lower part is p times something — the lower coefficients are literally p·(coefficients of g), automatically divisible by p, and the single non-divisibility condition p ∤ g.coeff 0 controls the constant term mod p².",
+      "**Gauss's lemma is where Eisenstein pays off**: irreducibility over ℤ is upgraded to irreducibility over ℚ because ℚ is the fraction field of ℤ and the polynomials are monic. This is the operative statement — it is over ℚ that an irreducible monic polynomial is the minimal polynomial of its roots, giving [ℚ(α):ℚ] = deg f.",
+      "**Xⁿ − p is just g = −1**: the parent's flagship family is a single member of the general construction; the unit −1 has p ∤ −1 for free, so no separate bookkeeping is needed.",
+      "**Nonzero middle coefficients**: X² + 2X + 2 and X³ + 3X + 3 are genuine Eisenstein polynomials the parent's Xⁿ − p form cannot express — they show the criterion is about a divisibility pattern, not a specific shape.",
+      "**0-axiom, no native_decide**: all 12 theorems are kernel-checked, depending only on propext / Classical.choice / Quot.sound, which do not count as assumptions."
+    ],
+    "prerequisites": [
+      "Polynomial rings R[X]: coefficients, degree/natDegree, leading coefficient, monicity (Mathlib Polynomial)",
+      "Prime ideals and ideal powers; Ideal.span {p}, membership x ∈ (p) ↔ p ∣ x, (p)² = (p²)",
+      "Primitive polynomials; monic ⇒ primitive (Polynomial.Monic.isPrimitive)",
+      "Gauss's lemma and fraction fields: Monic.irreducible_iff_irreducible_map_fraction_map, ℚ = Frac ℤ",
+      "Basic ℤ divisibility: p ∣ 1 ↔ IsUnit p, cancelling a factor of p (mul_dvd_mul_iff_left)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "eisenstein-criterion-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. It states the abstract Eisenstein criterion and proves Xⁿ − p irreducible over ℤ. This entry answers its third open question: general Eisenstein-at-p polynomials with arbitrary lower coefficients (the family Xⁿ + p·g), and irreducibility over ℚ via Gauss's lemma."
+    },
+    {
+      "proofId": "cyclotomic-polynomials-oq-01",
+      "relationship": "related",
+      "description": "Irreducibility of the p-th cyclotomic polynomial Φ_p is the other classical Eisenstein application (after X ↦ X + 1); the irreducibility-over-ℚ machinery developed here is exactly what such arguments conclude with."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "EisensteinCriterionOQ01OQ03",
+    "lineCount": 214,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/EisensteinCriterionOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "irreducible_int_X_pow_add_CP_mul",
+      "type": "core",
+      "statement": "$p$ prime, $0 < n$, $\\deg g < n$, $p \\nmid g(0)$ $\\Rightarrow$ $X^n + p\\,g$ is irreducible over $\\mathbb{Z}$",
+      "significance": "The general Eisenstein family with arbitrary lower coefficients divisible by p — the direct answer to the open question. Every lower coefficient is p·g.coeff k and the constant term p·g.coeff 0 avoids p² exactly when p ∤ g.coeff 0.",
+      "description": "Xⁿ + p·g is irreducible over ℤ for arbitrary g of degree < n with p ∤ g.coeff 0."
+    },
+    {
+      "name": "irreducible_int_of_eisenstein",
+      "type": "core",
+      "statement": "$f$ monic, $\\deg f > 0$, $p \\mid f_k$ for all $k < \\deg f$, $p^2 \\nmid f_0$ $\\Rightarrow$ $f$ irreducible over $\\mathbb{Z}$",
+      "significance": "Eisenstein's criterion over ℤ in concrete divisibility form, trading the abstract prime ideal for plain divisibility by a prime integer p. The lower coefficients are arbitrary subject to p ∣ f.coeff k.",
+      "description": "Concrete divisibility-form Eisenstein criterion over ℤ."
+    },
+    {
+      "name": "irreducible_rat_of_eisenstein",
+      "type": "core",
+      "statement": "A monic integer Eisenstein-at-$p$ polynomial is irreducible over $\\mathbb{Q}$",
+      "significance": "The form in which Eisenstein's criterion is actually used. Via Gauss's lemma (ℚ = Frac ℤ), irreducibility over ℤ becomes irreducibility over ℚ, so such an f is the minimal polynomial of each of its roots and [ℚ(α):ℚ] = deg f. The parent stopped at ℤ.",
+      "description": "Monic integer Eisenstein polynomials are irreducible over ℚ."
+    },
+    {
+      "name": "irreducible_rat_X_pow_sub_C",
+      "type": "supporting",
+      "statement": "$p$ prime, $n \\ge 1$ $\\Rightarrow$ $X^n - p$ is irreducible over $\\mathbb{Q}$",
+      "significance": "The parent's flagship Xⁿ − p (recovered as the g = −1 family member) lifted to ℚ — the statement underlying [ℚ(ⁿ√p):ℚ] = n.",
+      "description": "Xⁿ − p is irreducible over ℚ."
+    },
+    {
+      "name": "irreducible_int_X_sq_add_two_X_add_two",
+      "type": "supporting",
+      "statement": "$X^2 + 2X + 2$ is irreducible over $\\mathbb{Z}$",
+      "significance": "A concrete Eisenstein polynomial at p = 2 with a nonzero middle coefficient — a case the parent's Xⁿ − p machinery could not express. Also given over ℚ (irreducible_rat_X_sq_add_two_X_add_two).",
+      "description": "X² + 2X + 2 is irreducible over ℤ (Eisenstein at 2)."
+    },
+    {
+      "name": "irreducible_int_X_cube_add_three_X_add_three",
+      "type": "supporting",
+      "statement": "$X^3 + 3X + 3$ is irreducible over $\\mathbb{Z}$",
+      "significance": "A degree-3 Eisenstein polynomial at p = 3 with a nonzero linear coefficient, illustrating the general family for a different prime.",
+      "description": "X³ + 3X + 3 is irreducible over ℤ (Eisenstein at 3)."
+    }
+  ],
+  "references": [
+    {
+      "text": "Eisenstein, G. (1850). Über die Irreductibilität und einige andere Eigenschaften der Gleichung, von welcher die Theilung der ganzen Lemniscate abhängt. Crelle's Journal. (Schönemann, 1846, gave an equivalent criterion.)",
+      "url": "https://en.wikipedia.org/wiki/Eisenstein%27s_criterion"
+    },
+    {
+      "text": "Dummit, D. & Foote, R. Abstract Algebra. Eisenstein's criterion, Gauss's lemma, and irreducibility over ℚ.",
+      "url": "https://en.wikipedia.org/wiki/Gauss%27s_lemma_(polynomials)"
+    },
+    {
+      "text": "Mathlib4: Polynomial.irreducible_of_eisenstein_criterion, Polynomial.Monic.irreducible_iff_irreducible_map_fraction_map, Polynomial.monic_X_pow_add, Polynomial.degree_C_mul, Ideal.span_singleton_prime, Ideal.mem_span_singleton, Ideal.span_singleton_pow.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Answers the third open question of eisenstein-criterion-oq-01. It restates Eisenstein's criterion over ℤ in concrete divisibility form (irreducible_int_of_eisenstein), introduces the general family Xⁿ + p·g of Eisenstein polynomials with arbitrary lower coefficients divisible by p (irreducible_int_X_pow_add_CP_mul), and crosses Gauss's lemma to obtain irreducibility over ℚ (irreducible_rat_of_eisenstein, irreducible_rat_X_pow_add_CP_mul) — the form in which Eisenstein is actually applied. The parent's Xⁿ − p is recovered as the g = −1 member over both ℤ and ℚ, and concrete instances X² + 2X + 2, X³ + 3X + 3 exhibit nonzero middle coefficients. All 12 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "By landing irreducibility over ℚ, the entry connects Eisenstein's criterion to its principal uses: such polynomials are minimal polynomials of their roots, fixing field degrees [ℚ(α):ℚ] = deg f, and supply the standard examples in field and Galois theory. The general Xⁿ + p·g family makes explicit that Eisenstein is about a divisibility pattern on the coefficients, not a particular polynomial shape.",
+    "openQuestions": [
+      "Specialize the ℚ-irreducibility to compute minimal polynomials and field degrees explicitly: for Eisenstein f of degree n, [ℚ(α):ℚ] = n for any root α.",
+      "Establish irreducibility of the p-th cyclotomic polynomial Φ_p by applying irreducible_rat_of_eisenstein to Φ_p(X + 1)."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `eisenstein-criterion-oq-01`:

> *Generalize the coefficient bookkeeping to Eisenstein-at-p polynomials with arbitrary lower coefficients divisible by p (general IsEisensteinAt instances).*

The parent restated the abstract criterion and proved `Xⁿ − p` irreducible **over ℤ**. This entry adds three genuinely new pieces of theory.

### New contributions
1. **Concrete divisibility-form criterion over ℤ** — `irreducible_int_of_eisenstein`: a monic `f` of positive degree with `p ∣ f.coeff k` for every `k` below the degree and `p² ∤ f.coeff 0` is irreducible. Lower coefficients are arbitrary subject to divisibility by `p`.
2. **The general family `Xⁿ + p·g`** — `irreducible_int_X_pow_add_CP_mul`: for any `g` with `deg g < n` and `p ∤ g.coeff 0`, `Xⁿ + p·g` is irreducible. This is the explicit 'arbitrary lower coefficients divisible by p' construction; `Xⁿ − p` is the `g = −1` member.
3. **Irreducibility over ℚ via Gauss's lemma** — `irreducible_rat_of_eisenstein`, `irreducible_rat_X_pow_add_CP_mul`: with ℚ the fraction field of ℤ, irreducibility over ℤ lifts to ℚ. This is the form Eisenstein is actually used in (minimal polynomials, `[ℚ(α):ℚ] = deg f`); the parent stopped at ℤ.

Concrete instances **X² + 2X + 2** (Eisenstein at 2) and **X³ + 3X + 3** (at 3) — nonzero middle coefficients the parent's `Xⁿ − p` form could not express — over both ℤ and ℚ.

### Verification
- **12 theorems, 0 sorries, 0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`), **no `native_decide`**.
- Compiled with lean `v4.26.0`; `#print axioms` clean on all 9 public results.
- New file `proofs/Proofs/EisensteinCriterionOQ01OQ03.lean` (214 lines), added to `Proofs.lean`; gallery entry under `src/data/proofs/eisenstein-criterion-oq-01-oq-03/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)