### PR TITLE
research(erdos-divisibility-pigeonhole-oq-01-oq-01): general-N extremal bound — largest divisibility-antichain in {1,…,N} has size ⌈N/2⌉ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2572,6 +2572,7 @@ import Proofs.Erdos99Problem
 import Proofs.Erdos9Problem
 import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosDivisibilityPigeonholeOQ01
+import Proofs.ErdosDivisibilityPigeonholeOQ01OQ01
 import Proofs.ErdosGinzburgZivOQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosKoRadoOQ02

--- a/proofs/Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean
+++ b/proofs/Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean
@@ -1,0 +1,185 @@
+/-
+# Largest divisibility-antichain in `{1, …, N}` has size `⌈N/2⌉`
+
+This generalizes the extremal Erdős divisibility pigeonhole from the even
+interval `{1, …, 2n}` (where the answer is `n`) to an **arbitrary** upper bound
+`N`. The maximum size of a divisibility-antichain (a set no two distinct members
+of which are related by divisibility) in `{1, …, N}` is exactly
+
+> `⌈N/2⌉ = (N + 1) / 2`  (natural-number division),
+
+attained by the block of integers in `(N/2, N]`, namely `{⌊N/2⌋+1, …, N}`.
+
+## Why `(N + 1) / 2`
+
+* **Upper bound.** Write each `m ≥ 1` as `m = 2^k · o(m)` with odd part
+  `o(m) := ordCompl[2] m`. The half-index `m ↦ (o(m) − 1)/2` sends `{1, …, N}`
+  into `Finset.range ((N+1)/2)` (there are exactly `⌈N/2⌉` odd numbers `≤ N`).
+  A set larger than `⌈N/2⌉` therefore has two members with equal odd part, and
+  the one with the smaller power of two divides the other.
+
+* **Construction.** The block `{⌊N/2⌋+1, …, N}` is a divisibility-antichain: a
+  proper multiple of any `a > N/2` is `≥ 2a > N`, so it cannot also lie in the
+  block. Its cardinality `N − ⌊N/2⌋ = ⌈N/2⌉` matches the upper bound.
+
+Specializing `N = 2n` gives `(2n+1)/2 = n` and the block `{n+1, …, 2n}`,
+recovering `ErdosDivisibilityPigeonhole.max_antichain_card` (`erdos-divisibility-
+pigeonhole-oq-01`).
+
+Axiom-free: built from foundational Mathlib lemmas only (no `sorry`, no `axiom`,
+no `native_decide`).
+-/
+import Mathlib
+
+namespace ErdosDivisibilityPigeonhole
+
+open Finset
+
+/-- For an odd `o`, halving and rebuilding recovers `o`: `2·((o−1)/2) + 1 = o`.
+    This makes `o ↦ (o−1)/2` injective on odd numbers. -/
+private lemma odd_recoverN {o : ℕ} (h : Odd o) : 2 * ((o - 1) / 2) + 1 = o := by
+  obtain ⟨k, rfl⟩ := h; omega
+
+/-- The odd part `ordCompl[2] m` is odd whenever `m ≠ 0`. -/
+private lemma odd_ordComplN {m : ℕ} (hm : m ≠ 0) : Odd (ordCompl[2] m) := by
+  rw [Nat.odd_iff]
+  have h2 : ¬ (2 ∣ ordCompl[2] m) := Nat.not_dvd_ordCompl (by norm_num) hm
+  omega
+
+/-- If two positive numbers share an odd part, one divides the other: with
+    `a = 2^{v₂ a}·o` and `b = 2^{v₂ b}·o`, the smaller power of two wins. -/
+private lemma dvd_or_dvd_of_ordCompl_eqN {a b : ℕ}
+    (h : ordCompl[2] a = ordCompl[2] b) : a ∣ b ∨ b ∣ a := by
+  have ea : 2 ^ (a.factorization 2) * ordCompl[2] a = a :=
+    Nat.ordProj_mul_ordCompl_eq_self a 2
+  have eb : 2 ^ (b.factorization 2) * ordCompl[2] b = b :=
+    Nat.ordProj_mul_ordCompl_eq_self b 2
+  rcases le_total (a.factorization 2) (b.factorization 2) with hle | hle
+  · left
+    calc a = 2 ^ (a.factorization 2) * ordCompl[2] a := ea.symm
+      _ ∣ 2 ^ (b.factorization 2) * ordCompl[2] b := by
+          rw [h]; exact mul_dvd_mul_right (pow_dvd_pow 2 hle) _
+      _ = b := eb
+  · right
+    calc b = 2 ^ (b.factorization 2) * ordCompl[2] b := eb.symm
+      _ ∣ 2 ^ (a.factorization 2) * ordCompl[2] a := by
+          rw [h]; exact mul_dvd_mul_right (pow_dvd_pow 2 hle) _
+      _ = a := ea
+
+/-- **General divisibility pigeonhole.** Among any `⌈N/2⌉ + 1` integers chosen
+    from `{1, …, N}`, some one divides another: if `S ⊆ Icc 1 N` and
+    `(N+1)/2 + 1 ≤ |S|`, then there exist distinct `a, b ∈ S` with `a ∣ b`. -/
+theorem erdos_divisibility_pigeonhole_general {N : ℕ} {S : Finset ℕ}
+    (hsub : S ⊆ Finset.Icc 1 N) (hcard : (N + 1) / 2 + 1 ≤ S.card) :
+    ∃ a ∈ S, ∃ b ∈ S, a ≠ b ∧ a ∣ b := by
+  -- The half-index of the odd part lands in `range ((N+1)/2)`.
+  set f : ℕ → ℕ := fun m => (ordCompl[2] m - 1) / 2 with hf
+  have hmaps : ∀ m ∈ S, f m ∈ Finset.range ((N + 1) / 2) := by
+    intro m hm
+    obtain ⟨hm1, hm2⟩ := Finset.mem_Icc.mp (hsub hm)
+    have hmne : m ≠ 0 := by omega
+    have ho_pos : 0 < ordCompl[2] m := Nat.ordCompl_pos 2 hmne
+    have ho_le : ordCompl[2] m ≤ N := le_trans (Nat.ordCompl_le m 2) hm2
+    rw [Finset.mem_range]
+    show (ordCompl[2] m - 1) / 2 < (N + 1) / 2
+    omega
+  -- Pigeonhole: `range ((N+1)/2)` is strictly smaller than `S`.
+  have hlt : (Finset.range ((N + 1) / 2)).card < S.card := by
+    rw [Finset.card_range]; omega
+  obtain ⟨a, ha, b, hb, hab, hfab⟩ :=
+    Finset.exists_ne_map_eq_of_card_lt_of_maps_to hlt hmaps
+  have hane : a ≠ 0 := by
+    obtain ⟨h, _⟩ := Finset.mem_Icc.mp (hsub ha); omega
+  have hbne : b ≠ 0 := by
+    obtain ⟨h, _⟩ := Finset.mem_Icc.mp (hsub hb); omega
+  have hoa : Odd (ordCompl[2] a) := odd_ordComplN hane
+  have hob : Odd (ordCompl[2] b) := odd_ordComplN hbne
+  have hocc : ordCompl[2] a = ordCompl[2] b := by
+    have hhalf : (ordCompl[2] a - 1) / 2 = (ordCompl[2] b - 1) / 2 := by
+      have := hfab; simp only [hf] at this; exact this
+    rw [← odd_recoverN hoa, ← odd_recoverN hob, hhalf]
+  rcases dvd_or_dvd_of_ordCompl_eqN hocc with hd | hd
+  · exact ⟨a, ha, b, hb, hab, hd⟩
+  · exact ⟨b, hb, a, ha, hab.symm, hd⟩
+
+/-- A **divisibility-antichain** in `{1, …, N}`: a finite set of integers drawn
+    from `{1, …, N}`, no two distinct members of which are related by
+    divisibility. -/
+def IsDivAntichainN (N : ℕ) (S : Finset ℕ) : Prop :=
+  S ⊆ Finset.Icc 1 N ∧ ∀ a ∈ S, ∀ b ∈ S, a ≠ b → ¬ a ∣ b
+
+/-- `IsDivAntichainN N S` matches Mathlib's order-theoretic `IsAntichain` for
+    the divisibility relation, restricted to `{1, …, N}`. -/
+theorem isDivAntichainN_iff {N : ℕ} {S : Finset ℕ} :
+    IsDivAntichainN N S ↔
+      S ⊆ Finset.Icc 1 N ∧ IsAntichain (· ∣ ·) (S : Set ℕ) := by
+  unfold IsDivAntichainN
+  refine and_congr_right fun _ => ?_
+  constructor
+  · intro h a ha b hb hab; exact h a ha b hb hab
+  · intro h a ha b hb hab; exact h ha hb hab
+
+/-- **Upper bound.** A divisibility-antichain in `{1, …, N}` has at most
+    `⌈N/2⌉ = (N+1)/2` elements: a larger one would, by
+    `erdos_divisibility_pigeonhole_general`, contain a divisible pair. -/
+theorem antichainN_card_le {N : ℕ} {S : Finset ℕ} (hS : IsDivAntichainN N S) :
+    S.card ≤ (N + 1) / 2 := by
+  by_contra h
+  push_neg at h
+  obtain ⟨a, ha, b, hb, hab, hdvd⟩ :=
+    erdos_divisibility_pigeonhole_general hS.1 (by omega)
+  exact hS.2 a ha b hb hab hdvd
+
+/-- **Construction.** The block `{⌊N/2⌋+1, …, N}` of integers in `(N/2, N]` is a
+    divisibility-antichain of size `⌈N/2⌉ = (N+1)/2`. A proper multiple of any
+    `a > N/2` is at least `2a > N`, hence outside the block. -/
+theorem blockN_isDivAntichain (N : ℕ) :
+    IsDivAntichainN N (Finset.Icc (N / 2 + 1) N) ∧
+      (Finset.Icc (N / 2 + 1) N).card = (N + 1) / 2 := by
+  refine ⟨⟨?_, ?_⟩, ?_⟩
+  · intro x hx
+    rw [Finset.mem_Icc] at hx ⊢; omega
+  · intro a ha b hb hab hdvd
+    rw [Finset.mem_Icc] at ha hb
+    have hble : a ≤ b := Nat.le_of_dvd (by omega) hdvd
+    have hlt : a < b := lt_of_le_of_ne hble hab
+    obtain ⟨c, hc⟩ := hdvd
+    have hc2 : 2 ≤ c := by
+      rcases c with _ | _ | c
+      · simp at hc; omega
+      · simp at hc; omega
+      · omega
+    have hba : 2 * a ≤ b := by subst hc; nlinarith [hc2]
+    omega
+  · rw [Nat.card_Icc]; omega
+
+/-- **Extremal form (general `N`).** The maximum size of a divisibility-antichain
+    in `{1, …, N}` is exactly `⌈N/2⌉ = (N+1)/2`: the block `{⌊N/2⌋+1, …, N}`
+    attains it, and `antichainN_card_le` bounds everything else. -/
+theorem max_antichainN_card (N : ℕ) :
+    IsGreatest { k : ℕ | ∃ S : Finset ℕ, IsDivAntichainN N S ∧ S.card = k }
+      ((N + 1) / 2) := by
+  constructor
+  · obtain ⟨hanti, hcard⟩ := blockN_isDivAntichain N
+    exact ⟨Finset.Icc (N / 2 + 1) N, hanti, hcard⟩
+  · rintro k ⟨S, hS, rfl⟩
+    exact antichainN_card_le hS
+
+/-- **Specialization to the parent.** For `N = 2n` the general bound `(N+1)/2`
+    equals `n`, and the block `{⌊N/2⌋+1, …, N}` becomes `{n+1, …, 2n}` — exactly
+    the extremal statement `ErdosDivisibilityPigeonhole.max_antichain_card`. -/
+theorem max_antichainN_recovers_parent (n : ℕ) :
+    (2 * n + 1) / 2 = n ∧ IsGreatest
+      { k : ℕ | ∃ S : Finset ℕ, IsDivAntichainN (2 * n) S ∧ S.card = k } n := by
+  have hhalf : (2 * n + 1) / 2 = n := by omega
+  refine ⟨hhalf, ?_⟩
+  have := max_antichainN_card (2 * n)
+  rwa [hhalf] at this
+
+-- Axiom audit: the extremal result depends only on the standard foundational
+-- axioms (propext, Classical.choice, Quot.sound) — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms max_antichainN_card
+#print axioms max_antichainN_recovers_parent
+
+end ErdosDivisibilityPigeonhole

--- a/src/data/proofs/erdos-divisibility-pigeonhole-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-divisibility-pigeonhole-oq-01-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+  "title": "Largest divisibility-antichain in {1,…,N} has size ⌈N/2⌉ — the arbitrary-N generalization",
+  "slug": "erdos-divisibility-pigeonhole-oq-01-oq-01",
+  "description": "Answers the parent entry's first open question: generalize the extremal Erdős divisibility pigeonhole from the even interval {1,…,2n} (maximum n) to an arbitrary upper bound N. The maximum size of a divisibility-antichain — a primitive set, no member of which divides another — in {1,…,N} is exactly ⌈N/2⌉ = (N+1)/2 in natural-number division, attained by the block {⌊N/2⌋+1,…,N} of integers in (N/2, N]. The upper bound is a general odd-part pigeonhole (the half-index m ↦ (ordCompl[2] m − 1)/2 lands in range ((N+1)/2)); the lower bound is the explicit top-half block. Specializing N = 2n recovers max_antichain_card of the parent. Formalized over Mathlib with zero sorries and zero axioms (no native_decide).",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pigeonhole_principle",
+    "date": "folklore",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "number-theory",
+      "pigeonhole-principle",
+      "divisibility",
+      "antichain",
+      "primitive-set",
+      "extremal",
+      "erdos"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.ordProj_mul_ordCompl_eq_self",
+        "description": "The factorization identity 2^(v₂ m) · ordCompl[2] m = m, expressing every m as a power of two times its odd part. Drives dvd_or_dvd_of_ordCompl_eqN: two numbers with equal odd parts differ only in their power of two, so the smaller power divides the larger.",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      },
+      {
+        "theorem": "Finset.exists_ne_map_eq_of_card_lt_of_maps_to",
+        "description": "The pigeonhole principle for Finsets: a map from S into a smaller target set must identify two distinct elements. Applied to the half-index map m ↦ (ordCompl[2] m − 1)/2 from S into range ((N+1)/2), it produces two members of S sharing an odd part.",
+        "module": "Mathlib.Combinatorics.Pigeonhole"
+      },
+      {
+        "theorem": "IsGreatest",
+        "description": "IsGreatest s a means a ∈ s ∧ a ∈ upperBounds s. Used to state that ⌈N/2⌉ is exactly the maximum of the set of achievable divisibility-antichain sizes — membership from the top-half block, upper bound from the general pigeonhole.",
+        "module": "Mathlib.Order.Bounds.Basic"
+      }
+    ],
+    "originalContributions": [
+      "max_antichainN_card: the arbitrary-N extremal form — IsGreatest { k | ∃ S, IsDivAntichainN N S ∧ S.card = k } ((N+1)/2) — establishing that the largest divisibility-antichain (primitive subset) of {1,…,N} has size exactly ⌈N/2⌉ for every N, not only even N = 2n.",
+      "erdos_divisibility_pigeonhole_general: the general odd-part pigeonhole over an arbitrary interval {1,…,N}: any subset of size > (N+1)/2 contains a pair a ∣ b. The half-index m ↦ (ordCompl[2] m − 1)/2 is shown to land in range ((N+1)/2) — counting the ⌈N/2⌉ odd numbers ≤ N without enumerating them.",
+      "blockN_isDivAntichain: the explicit extremal witness {⌊N/2⌋+1,…,N} is a divisibility-antichain of size ⌈N/2⌉ = (N+1)/2, with the key cardinality identity N − ⌊N/2⌋ = ⌈N/2⌉ handled uniformly across the parities of N.",
+      "antichainN_card_le with IsDivAntichainN and isDivAntichainN_iff: the arbitrary-N divisibility-antichain predicate, its identification with Mathlib's IsAntichain (· ∣ ·), and the clean upper bound |S| ≤ (N+1)/2.",
+      "max_antichainN_recovers_parent: verifies the generalization specializes correctly — for N = 2n the bound (2n+1)/2 collapses to n, reproducing the parent's max_antichain_card over {1,…,2n}."
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "erdos-divisibility-pigeonhole-oq-01",
+        "relationship": "Parent. This entry answers its first stated open question — generalize the extremal divisibility pigeonhole from {1,…,2n} (maximum n) to {1,…,N} (maximum ⌈N/2⌉). The parent's even case N = 2n is recovered as max_antichainN_recovers_parent."
+      },
+      {
+        "id": "erdos-divisibility-pigeonhole",
+        "relationship": "Grandparent. Supplies the odd-part pigeonhole template (classify by ordCompl[2]) that is here re-proved over an arbitrary interval rather than {1,…,2n}."
+      }
+    ],
+    "lineCount": 185,
+    "assumptions": "0 axioms, 0 sorries. Self-contained over Mathlib: the odd-part decomposition (Nat.ordProj_mul_ordCompl_eq_self, Nat.ordCompl_le, Nat.ordCompl_pos), the Finset pigeonhole (Finset.exists_ne_map_eq_of_card_lt_of_maps_to), and order-theoretic packaging (IsAntichain, IsGreatest). The arithmetic of ⌈N/2⌉ = (N+1)/2 and N − ⌊N/2⌋ = ⌈N/2⌉ is discharged by omega across both parities. Badge is 'original' because the arbitrary-N extremal value and its uniform-parity proof are formalized from first principles; Mathlib does not contain this max-primitive-subset statement.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Erdős divisibility pigeonhole — that any n+1 elements of {1,…,2n} contain a pair related by divisibility — is a competition staple, with the even interval {1,…,2n} the case usually stated. Its true extremal content is a statement about primitive sets (sets of integers no member of which divides another, in Erdős's terminology): the largest primitive subset of {1,…,N} has size ⌈N/2⌉, attained by the top half (N/2, N]. This arbitrary-N value is folklore and underlies Erdős's lifelong study of primitive sequences (e.g. his 1935 theorem bounding ∑ 1/(a log a) over primitive sets). This entry formalizes the finite extremal value for every N.",
+    "problemStatement": "Let $N \\ge 0$. Call $S \\subseteq \\{1, \\dots, N\\}$ a *divisibility-antichain* (primitive set) if no two distinct $a, b \\in S$ satisfy $a \\mid b$. Then $\\max\\{|S| : S \\text{ a divisibility-antichain in } \\{1,\\dots,N\\}\\} = \\lceil N/2 \\rceil = (N+1)/2$ (natural-number division), attained by $\\{\\lfloor N/2\\rfloor + 1, \\dots, N\\}$.",
+    "text": "The maximum size of a divisibility-antichain in $\\{1,\\dots,N\\}$ is exactly $\\lceil N/2\\rceil$. Upper bound: there are exactly $\\lceil N/2\\rceil$ odd numbers $\\le N$, and the odd-part map $m \\mapsto \\mathrm{ordCompl}[2]\\,m$ sends any larger set to a collision, forcing a divisible pair. Lower bound: the block $(N/2, N]$ is primitive (a proper multiple of $a > N/2$ exceeds $N$) and has $N - \\lfloor N/2\\rfloor = \\lceil N/2\\rceil$ elements.",
+    "proofStrategy": "Re-prove the odd-part pigeonhole over an arbitrary interval: the half-index f(m) = (ordCompl[2] m − 1)/2 satisfies f(m) < (N+1)/2 because the odd part o = ordCompl[2] m is odd with 1 ≤ o ≤ N (omega closes (o−1)/2 < (N+1)/2 from o ≤ N). A set of size > (N+1)/2 therefore collides under f; since f is injective on odd numbers (odd_recoverN), the colliding members share an odd part, and dvd_or_dvd_of_ordCompl_eqN orients the division. Package the bound (antichainN_card_le) and the explicit top-half witness (blockN_isDivAntichain) into IsGreatest (max_antichainN_card), then specialize N = 2n to recover the parent (max_antichainN_recovers_parent).",
+    "keyInsights": [
+      "**The answer is ⌈N/2⌉ = (N+1)/2 for every N, not just even N**: the parent's value n is the N = 2n shadow of a single uniform statement. Working in natural-number division, both the bound (N+1)/2 and the block cardinality N − ⌊N/2⌋ equal ⌈N/2⌉, and omega verifies this across both parities without a case split.",
+      "**Counting odd numbers without enumerating them**: rather than building a bijection to the ⌈N/2⌉ odd numbers ≤ N, the proof shows the half-index (ordCompl[2] m − 1)/2 lands in range ((N+1)/2) directly from 1 ≤ ordCompl[2] m ≤ N — a single omega call subsumes the parity bookkeeping that an explicit count would require.",
+      "**The pigeonhole template is interval-agnostic**: the odd-part classification (every m is 2^k · odd) never used the specific bound 2n; re-proving over {1,…,N} shows the gem is really about the number of odd residues, which is ⌈N/2⌉.",
+      "**Primitive sets and the top half**: a divisibility-antichain is exactly a *primitive set*; the extremal construction is always the top half (N/2, N], the largest interval whose smallest element already exceeds half of N, so no element can divide another.",
+      "**Specialization certifies the generalization**: max_antichainN_recovers_parent proves (2n+1)/2 = n and re-derives the parent IsGreatest over {1,…,2n}, confirming the new statement strictly contains the old one rather than merely resembling it."
+    ],
+    "prerequisites": [
+      "The odd-part / 2-adic decomposition of natural numbers (ordCompl[2], ordProj[2])",
+      "The Finset pigeonhole principle (exists_ne_map_eq_of_card_lt_of_maps_to)",
+      "Mathlib's IsAntichain and IsGreatest / upperBounds",
+      "Natural-number division arithmetic for ⌈N/2⌉ = (N+1)/2"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Problem Statement & Setup",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring stating the arbitrary-N extremal form: the largest divisibility-antichain (primitive subset) of {1,…,N} has size ⌈N/2⌉ = (N+1)/2, attained by the top-half block (N/2, N]. Notes the specialization N = 2n to the parent. Imports Mathlib and opens Finset."
+    },
+    {
+      "id": "odd-part-helpers",
+      "title": "Odd-Part Helper Lemmas",
+      "startLine": 37,
+      "endLine": 67,
+      "summary": "Three reusable lemmas on the odd part ordCompl[2] m: odd_recoverN (rebuilding an odd number from its half-index, giving injectivity of m ↦ (o−1)/2 on odds), odd_ordComplN (the odd part is odd for m ≠ 0), and dvd_or_dvd_of_ordCompl_eqN (equal odd parts ⇒ one divides the other, via the 2^k factorization)."
+    },
+    {
+      "id": "general-pigeonhole",
+      "title": "General Pigeonhole over {1,…,N}",
+      "startLine": 68,
+      "endLine": 103,
+      "summary": "erdos_divisibility_pigeonhole_general: any S ⊆ {1,…,N} with |S| > (N+1)/2 contains a divisible pair. The half-index map lands in range ((N+1)/2) (proved by omega from 1 ≤ ordCompl[2] m ≤ N), pigeonhole forces a collision, and equal odd parts orient the division."
+    },
+    {
+      "id": "antichain-predicate",
+      "title": "Antichain Predicate & Upper Bound",
+      "startLine": 105,
+      "endLine": 131,
+      "summary": "IsDivAntichainN N S defines a divisibility-antichain in {1,…,N}; isDivAntichainN_iff identifies it with Mathlib's IsAntichain (· ∣ ·). antichainN_card_le derives the bound |S| ≤ (N+1)/2 as the contrapositive of the general pigeonhole."
+    },
+    {
+      "id": "construction-extremal",
+      "title": "Top-Half Construction & Extremal Form",
+      "startLine": 133,
+      "endLine": 166,
+      "summary": "blockN_isDivAntichain shows the block {⌊N/2⌋+1,…,N} is a divisibility-antichain of size (N+1)/2 (a proper multiple of a > N/2 exceeds N; cardinality via N − ⌊N/2⌋ = ⌈N/2⌉). max_antichainN_card packages attainment and bound into IsGreatest ((N+1)/2)."
+    },
+    {
+      "id": "parent-specialization",
+      "title": "Specialization to the Parent (N = 2n)",
+      "startLine": 168,
+      "endLine": 177,
+      "summary": "max_antichainN_recovers_parent proves (2n+1)/2 = n and rewrites max_antichainN_card to obtain IsGreatest over {1,…,2n} with maximum n — the parent's max_antichain_card — certifying the generalization strictly contains the even case."
+    },
+    {
+      "id": "axiom-audit",
+      "title": "Axiom Audit",
+      "startLine": 179,
+      "endLine": 185,
+      "summary": "#print axioms on max_antichainN_card and max_antichainN_recovers_parent confirms dependence only on the standard foundational axioms (propext, Classical.choice, Quot.sound) — no Lean.ofReduceBool (no native_decide) and no sorryAx."
+    }
+  ],
+  "conclusion": {
+    "summary": "The arbitrary-N extremal Erdős divisibility pigeonhole is formalized with zero sorries and zero axioms: the maximum size of a divisibility-antichain (primitive subset) of {1,…,N} is exactly ⌈N/2⌉ = (N+1)/2 (max_antichainN_card, an IsGreatest), with the upper bound from a general odd-part pigeonhole over {1,…,N} and the value attained by the top-half block (N/2, N]. The even case N = 2n recovers the parent's max_antichain_card (max_antichainN_recovers_parent).",
+    "implications": "This closes the parent's first open question by lifting its even-interval optimum to every N, turning a parity-specific competition fact into the general max-primitive-subset value ⌈N/2⌉. The proof shows the odd-part pigeonhole is interval-agnostic — its content is the count of odd residues — and the uniform omega handling of ⌈N/2⌉ across parities means no case split is needed. As a building block, max_antichainN_card is the Dilworth/Mirsky optimum for the divisibility poset on {1,…,N} (one chain per odd part ≤ N), and the primitive-set framing connects the finite statement to Erdős's quantitative theory of primitive sequences.",
+    "openQuestions": [
+      "Formalize the Dilworth/Mirsky duality directly for general N: partition {1,…,N} into exactly ⌈N/2⌉ divisibility chains (one per odd part o ≤ N, namely o, 2o, 4o, …) and derive max_antichainN_card as the min–max consequence, rather than via the pigeonhole count.",
+      "Refine the structure of extremal primitive sets: is the top half (N/2, N] the unique maximum-size divisibility-antichain in {1,…,N}, or characterize all primitive subsets attaining ⌈N/2⌉ (e.g. via swaps along chains)?",
+      "Generalize the interval to arbitrary finite S ⊆ ℕ₊: express the largest primitive subset of S in terms of its chain decomposition under divisibility, recovering the {1,…,N} value ⌈N/2⌉ as the special case."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-divisibility-pigeonhole-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes its extremal value (maximum n over {1,…,2n}) to the arbitrary-N value ⌈N/2⌉ over {1,…,N}, recovering the parent as the even case N = 2n."
+    },
+    {
+      "targetId": "erdos-divisibility-pigeonhole",
+      "relationship": "uses-similar-technique",
+      "description": "Re-proves the grandparent's odd-part pigeonhole (classify by ordCompl[2]) over an arbitrary interval {1,…,N} instead of {1,…,2n}, showing the argument depends only on the number of odd residues."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ErdosDivisibilityPigeonhole",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 6
+  },
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `erdos-divisibility-pigeonhole-oq-01`: generalize the extremal Erdős divisibility pigeonhole from the even interval `{1,…,2n}` (where the maximum is `n`) to an **arbitrary** upper bound `N`.

**Result.** The maximum size of a divisibility-antichain — equivalently a *primitive set*, no member of which divides another — in `{1,…,N}` is exactly

> `⌈N/2⌉ = (N+1)/2` (natural-number division),

attained by the top-half block `(N/2, N] = {⌊N/2⌋+1,…,N}`.

## Proof

- **`erdos_divisibility_pigeonhole_general`** — a *self-contained* odd-part pigeonhole over `{1,…,N}` (re-proved from the 2-adic decomposition, not inherited from the parent's even-case theorem): the half-index `m ↦ (ordCompl[2] m − 1)/2` maps `Icc 1 N` into `range ((N+1)/2)`, so any set of size `> ⌈N/2⌉` collides on odd parts and the smaller power of two divides the larger.
- **`antichainN_card_le`** — upper bound `|S| ≤ (N+1)/2` as the contrapositive.
- **`blockN_isDivAntichain`** — the explicit witness `(N/2, N]` is an antichain (a proper multiple of `a > N/2` already exceeds `N`) of size `⌈N/2⌉`.
- **`max_antichainN_card`** — `IsGreatest` packaging of the optimum.
- **`max_antichainN_recovers_parent`** — specializes `N = 2n`: `(2n+1)/2 = n` and the block becomes `{n+1,…,2n}`, recovering the parent's value `n` as a corollary.

The bespoke `IsDivAntichainN` predicate is identified with Mathlib's order-theoretic `IsAntichain (· ∣ ·)` (`isDivAntichainN_iff`).

## Verification

- 185 lines, 6 theorems + 3 lemmas, 1 definition.
- **0 sorries, 0 axioms.** `#print axioms max_antichainN_card` / `max_antichainN_recovers_parent` confirm dependence only on `propext`, `Classical.choice`, `Quot.sound` — **no `Lean.ofReduceBool`** (no `native_decide`) and **no `sorryAx`**.
- Self-contained: imports only `Mathlib`; added to the `Proofs.lean` aggregator.
- Built locally with Lean v4.26.0 / Mathlib (Docker unavailable; built directly against the project's Mathlib oleans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)