### PR TITLE
Fix: algebraic-reals-meager-oq-02 theoremCount 7→8 (gallery integrity)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-02/meta.json
@@ -86,7 +86,7 @@
       }
     ],
     "assumptions": "0 axioms. Relies only on Mathlib's measure-theory and Baire-category infrastructure, the Liouville residual/measure-zero results, and the countability of the algebraic reals.",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "additionalFiles": []
   },


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: algebraic-reals-meager-oq-02
**Problem**: `theoremCount` mismatch — meta.json reported 7, Lean file has 8 theorems.

## Evidence

`proofs/Proofs/AlgebraicRealsMeagerOQ02.lean` declares **8** theorems:
`algebraicReals_null`, `ae_transcendental`, `liouville_residual`, `liouville_dense`, `liouville_null`, `exists_residual_dense_null`, `residual_ae_disjoint`, `oq02_resolution`.

meta.json had `theoremCount: 7`.

## Audit Result

All credibility-relevant claims verified **accurate**:
- `status: verified` ✓ (0 sorries, 0 axioms confirmed in source)
- `badge: mathlib` ✓ — Tier B, honest 1-line wrappers over Mathlib (`Algebraic.countable`, Liouville residual/measure results, `Real.disjoint_residual_ae`); `originalContributions` correctly states "Synthesis (no new mathematics)".

Only the cosmetic `theoremCount` was off by one.

---
Discovered during gallery integrity audit.