### PR TITLE
Enrich Eulerian Numbers explicit closed form ⟨m,k⟩ = ∑ⱼ(−1)ʲC(m+1,j)(k+1−j)ᵐ

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "definition-boundary",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 46, "endLine": 72 },
+    "type": "definition",
+    "title": "The Explicit Alternating Sum and Its Boundary Values",
+    "content": "Defines A(m,k) = eulExpl m k = ∑_{j=0}^{k} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ over ℤ — the candidate closed form. The whole proof shows ⟨m,k⟩ = A(m,k) by verifying A obeys the SAME recurrence and boundary data as the parent's eulerian triangle. The two boundary lemmas establish the base data: `eulExpl_zero_right` (A(m,0) = 1, immediate since only the j=0 term survives) and `eulExpl_zero_left` (A(0,k) = [k=0], using that (k+1−j)⁰ = 1 and C(1,j) = 0 for j ≥ 2, so only j=0,1 contribute and they cancel for k > 0).",
+    "mathContext": "$A(m,k)=\\sum_{j=0}^{k}(-1)^j\\binom{m+1}{j}(k+1-j)^m$; $A(m,0)=1$, $A(0,k)=[k{=}0]$.",
+    "significance": "key",
+    "relatedConcepts": ["closed form", "alternating sum", "inclusion-exclusion", "boundary conditions", "Eulerian numbers"],
+    "prerequisites": ["binomial coefficients", "Finset sums", "alternating sums"]
+  },
+  {
+    "id": "pascal-step",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 74, "endLine": 111 },
+    "type": "technique",
+    "title": "The Pascal Re-Summation Identity",
+    "content": "`eulExpl_pascal_step`: the residual combinatorial fact that ties the order-m sums together — the order-m alternating sum over range(k+1) minus its shifted partner over range(k) equals A(m,k). It is obtained by peeling the leading term off each sum (`Finset.sum_range_succ'`) and matching the remaining terms via Pascal's rule C(m+1,i+1) = C(m,i) + C(m,i+1), re-summed. This is the glue that, after the absorption collapse, lets the order-(m+1) recurrence close in terms of A(m,·).",
+    "mathContext": "$\\sum_{i=0}^{k}(-1)^i\\binom{m}{i}(k{+}1{-}i)^m-\\sum_{i=0}^{k-1}(-1)^i\\binom{m}{i}(k{-}i)^m=A(m,k)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Pascal's rule", "re-summation", "telescoping", "index shift"],
+    "prerequisites": ["Pascal's rule", "Finset.sum_range_succ'", "alternating sums"]
+  },
+  {
+    "id": "absorption",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 113, "endLine": 134 },
+    "type": "technique",
+    "title": "Absorption: Collapsing the j-Weighted Sum",
+    "content": "Two lemmas that handle the factor of j produced when (k+2−j)^{m+1} is split as (k+2−j)·(k+2−j)ᵐ. `habsorb`: the absorption identity (i+1)·C(m+1,i+1) = (m+1)·C(m,i) over ℤ, from Mathlib's `Nat.add_one_mul_choose_eq`. `absorbed_sum`: applies it (with an index shift j ↦ j+1) to collapse the j-weighted alternating sum into −(m+1) times a plain order-m alternating sum. This is the mechanism that lowers the order of the sum, turning the order-(m+1) numerator into order-m pieces.",
+    "mathContext": "$(i{+}1)\\binom{m+1}{i+1}=(m{+}1)\\binom{m}{i}$; $\\sum_j j(-1)^j\\binom{m+1}{j}(N{+}1{-}j)^m=-(m{+}1)\\sum_i(-1)^i\\binom{m}{i}(N{-}i)^m$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial absorption", "order reduction", "index shift", "linear_combination"],
+    "prerequisites": ["binomial absorption", "Finset reindexing", "integer arithmetic"]
+  },
+  {
+    "id": "core-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 136, "endLine": 226 },
+    "type": "theorem",
+    "title": "The Core Recurrence A(m+1,k+1) = (k+2)A(m,k+1) + (m−k)A(m,k)",
+    "content": "`eulExpl_recurrence`: the heart of the proof — A satisfies the Eulerian triangle recurrence over ℤ. The argument: split (k+2−j)^{m+1} = (k+2−j)·(k+2−j)ᵐ in both numerator sums (hstep1/hstep2), collapse the j-weighted parts with `absorbed_sum` (hS1/hS2), use Pascal's rule on C(m+2,j) to write A(m+1,k+1) as the difference of the two order-(m+1) sums (hP), and finally combine everything with the Pascal re-summation step via a single `linear_combination`. This is the most intricate lemma; once it holds, the closed form follows by a routine induction.",
+    "mathContext": "$A(m{+}1,k{+}1)=(k{+}2)A(m,k{+}1)+(m{-}k)A(m,k)$ — the same recurrence as $\\langle m,k\\rangle$.",
+    "significance": "critical",
+    "relatedConcepts": ["triangle recurrence", "Pascal's rule", "absorption", "linear_combination", "order reduction"],
+    "prerequisites": ["Pascal's rule", "binomial absorption", "Finset manipulation"]
+  },
+  {
+    "id": "explicit-formula",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 228, "endLine": 265 },
+    "type": "theorem",
+    "title": "The Explicit Formula ⟨m,k⟩ = ∑ⱼ (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ",
+    "content": "`eulerian_explicit`: the headline result. Induction on m (generalizing k): A matches the Eulerian boundary values and (by `eulExpl_recurrence`) the recurrence, so ⟨m,k⟩ = A(m,k). The one subtlety is reconciling the parent's ℕ-truncated coefficient (m−k) with the integer (m:ℤ)−k — handled by `hcast`, which case-splits on k ≤ m vs k > m (in the latter ⟨m,k⟩ = 0, so the mismatched coefficient is irrelevant). The worked examples reproduce the Eulerian rows 1,1 / 1,4,1 / 1,11,11,1 via kernel `decide`, keeping the entry axiom-clean.",
+    "mathContext": "$\\langle m,k\\rangle=\\sum_{j=0}^{k}(-1)^j\\binom{m+1}{j}(k{+}1{-}j)^m$ — closed form, no recursion.",
+    "significance": "critical",
+    "relatedConcepts": ["explicit closed form", "induction", "ℕ vs ℤ subtraction", "Eulerian numbers", "kernel decide"],
+    "prerequisites": ["induction", "Nat.cast_sub", "the Eulerian recurrence"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04/meta.json
@@ -134,5 +134,60 @@
       "Read the row-end values ⟨m,0⟩ = ⟨m,m−1⟩ = 1 and unimodality off the explicit formula.",
       "Re-derive the closed form by inverting Worpitzky's identity (alternating binomial transform / finite-difference inversion)."
     ]
-  }
+  },
+  "description": "Proves the celebrated explicit closed form solving the Eulerian triangle recurrence outright: ⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ, a single alternating binomial sum with no recursion. The proof shows the candidate sum A(m,k) satisfies the same recurrence and boundary values as the parent's combinatorial Eulerian numbers, via Pascal's rule, binomial absorption, and an index shift — all over ℤ, 0 axioms.",
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨m,k⟩, counting permutations of {1,…,m} with k descents, were studied by Leonhard Euler (1755) through the polynomials Aₘ(t) = ∑ₖ ⟨m,k⟩ tᵏ. Beyond the triangle recurrence and Worpitzky's identity, the numbers admit a striking non-recursive description: the alternating inclusion–exclusion sum ⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ, which expresses each Eulerian number directly as a finite signed sum of powers. This formula is the discrete-derivative / finite-difference reading of the descent count and appears in Graham–Knuth–Patashnik's Concrete Mathematics and Comtet's Advanced Combinatorics. Within this gallery it sits alongside the sibling entries on Worpitzky's identity (oq-03) and the palindromy (oq-02) as one of the four classical facts proved from the parent's from-scratch Eulerian triangle; Mathlib has none of these, so the closed form and its proof are built here on top of the parent's recurrence.",
+    "problemStatement": "For the combinatorial Eulerian numbers ⟨m,k⟩ defined by the parent via the triangle recurrence ⟨m+1,k+1⟩ = (k+2)⟨m,k+1⟩ + (m−k)⟨m,k⟩ with ⟨m,0⟩ = 1, prove the explicit closed form ⟨m,k⟩ = ∑_{j=0}^{k} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ (as an identity over ℤ) — a single alternating binomial sum that solves the recurrence with no recursion of its own.",
+    "proofStrategy": "Define the candidate A(m,k) = ∑_{j=0}^{k} (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ and prove ⟨m,k⟩ = A(m,k) by showing A satisfies the SAME defining data as eulerian — the standard 'verify the closed form obeys the recurrence' technique. (1) BOUNDARY: A(m,0) = 1 and A(0,k) = [k=0] are direct. (2) RECURRENCE (the core, `eulExpl_recurrence`): split (k+2−j)^{m+1} = (k+2−j)·(k+2−j)ᵐ; the resulting j-weighted sum collapses via the absorption identity (i+1)C(m+1,i+1) = (m+1)C(m,i) plus an index shift (`absorbed_sum`) to −(m+1) times an order-m sum; Pascal's rule on C(m+2,j) writes A(m+1,k+1) as a difference of order-(m+1) sums; and a Pascal re-summation identity (`eulExpl_pascal_step`) closes everything by a single linear_combination. (3) INDUCTION (`eulerian_explicit`): induct on m; the only subtlety is reconciling the parent's ℕ-truncated coefficient (m−k) with the integer (m:ℤ)−k, handled by case-splitting on k ≤ m (using ⟨m,k⟩ = 0 when k > m). All over ℤ, 0-axiom.",
+    "keyInsights": [
+      "The closed form is proved not by deriving it but by VERIFYING it: show the candidate sum A(m,k) satisfies the same recurrence and boundary values as ⟨m,k⟩, then uniqueness of the recurrence forces equality. This sidesteps any need to 'guess and check' the inclusion–exclusion coefficients.",
+      "Splitting the power (k+2−j)^{m+1} = (k+2−j)·(k+2−j)ᵐ is the move that drops the order by one: the leftover linear factor produces a j-weight that the absorption identity converts into a clean order-m sum, so the order-(m+1) recurrence reduces to order-m data.",
+      "Two distinct binomial identities do all the work — Pascal's rule (for the additive C(m+2,j) split and the re-summation) and absorption (i+1)C(m+1,i+1) = (m+1)C(m,i) (for the multiplicative j-weight). Isolating each as its own lemma keeps the intricate core recurrence a single linear_combination.",
+      "The whole development lives over ℤ precisely to avoid ℕ's truncated subtraction; the only place the gap matters is the final induction, where (m−k) is reconciled with (m:ℤ)−k by noting both sides vanish (⟨m,k⟩ = 0) exactly when the truncation would bite (k > m).",
+      "The formula is the finite-difference signature of the descent statistic: ∑_j (−1)ʲ C(m+1,j)(k+1−j)ᵐ is the (m+1)-st forward difference of the power, so the Eulerian numbers are literally the difference table of nᵐ — the dual view to Worpitzky's expansion of nᵐ in the binomial basis (sibling oq-03)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "def-boundary",
+      "title": "The Explicit Sum and Boundary Values",
+      "startLine": 46,
+      "endLine": 72,
+      "summary": "Defines eulExpl A(m,k) = ∑ⱼ (−1)ʲ·C(m+1,j)·(k+1−j)ᵐ over ℤ and proves the boundary lemmas eulExpl_zero_right (A(m,0)=1) and eulExpl_zero_left (A(0,k)=[k=0]).",
+      "mathContext": "$A(m,k)=\\sum_{j=0}^{k}(-1)^j\\binom{m+1}{j}(k{+}1{-}j)^m$."
+    },
+    {
+      "id": "pascal",
+      "title": "The Pascal Re-Summation Identity",
+      "startLine": 74,
+      "endLine": 111,
+      "summary": "eulExpl_pascal_step: the order-m sum over range(k+1) minus its shifted partner over range(k) equals A(m,k), by peeling leading terms and matching via Pascal's rule C(m+1,i+1)=C(m,i)+C(m,i+1).",
+      "mathContext": "Pascal re-summation gluing the order-$m$ sums into $A(m,k)$."
+    },
+    {
+      "id": "absorption",
+      "title": "Absorption and the Weighted Sum",
+      "startLine": 113,
+      "endLine": 134,
+      "summary": "habsorb ((i+1)C(m+1,i+1)=(m+1)C(m,i)) and absorbed_sum, which collapses the j-weighted alternating sum to −(m+1) times an order-m sum via absorption and an index shift — the order-reduction mechanism.",
+      "mathContext": "$(i{+}1)\\binom{m+1}{i+1}=(m{+}1)\\binom{m}{i}$."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Core Recurrence",
+      "startLine": 136,
+      "endLine": 226,
+      "summary": "eulExpl_recurrence: A satisfies A(m+1,k+1)=(k+2)A(m,k+1)+(m−k)A(m,k) over ℤ, by splitting the power, collapsing via absorbed_sum, applying Pascal to C(m+2,j), and closing with eulExpl_pascal_step in one linear_combination.",
+      "mathContext": "$A(m{+}1,k{+}1)=(k{+}2)A(m,k{+}1)+(m{-}k)A(m,k)$."
+    },
+    {
+      "id": "explicit",
+      "title": "The Explicit Formula and Examples",
+      "startLine": 228,
+      "endLine": 265,
+      "summary": "eulerian_explicit: ⟨m,k⟩ = A(m,k) by induction on m (boundaries + recurrence), reconciling the ℕ-truncated (m−k) with (m:ℤ)−k via ⟨m,k⟩=0 for k>m. Worked examples reproduce rows 1,1 / 1,4,1 / 1,11,11,1 by kernel decide.",
+      "mathContext": "$\\langle m,k\\rangle=\\sum_{j=0}^{k}(-1)^j\\binom{m+1}{j}(k{+}1{-}j)^m$."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-04` (*The Explicit Closed Form for the Eulerian Numbers*).

This entry had `conclusion`, `crossReferences`, and `openQuestions` but no `overview`, `sections`, `description`, or `annotations.json`. Added all of them:

- **description** + full **overview**: historicalContext (Euler, the finite-difference reading of the descent count, the four-fact tower with Worpitzky/palindromy siblings), problemStatement, proofStrategy, 5 keyInsights.
- **5 sections** covering the whole 265-line file (def+boundary, Pascal re-summation, absorption, core recurrence, explicit formula).
- **annotations.json** with **5 annotations** — each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

Validated via `pnpm annotations:build` (0 errors for this entry; pure JSON data change).