### PR TITLE
fix(proofs): add missing aggregator import for ErdosDivisibilityPigeonholeOQ01OQ01

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2573,6 +2573,7 @@ import Proofs.Erdos99Problem
 import Proofs.Erdos9Problem
 import Proofs.ErdosDivisibilityPigeonhole
 import Proofs.ErdosDivisibilityPigeonholeOQ01
+import Proofs.ErdosDivisibilityPigeonholeOQ01OQ01
 import Proofs.ErdosGinzburgZivOQ01
 import Proofs.ErdosKoRado
 import Proofs.ErdosKoRadoOQ02


### PR DESCRIPTION
## Summary

The merged research entry **erdos-divisibility-pigeonhole-oq-01-oq-01** (PR #27932 — *"largest divisibility-antichain in {1,…,N} has size ⌈N/2⌉"*, 0-axiom verified) shipped its proof file `proofs/Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean` and gallery data to `main`, but the aggregator `proofs/Proofs.lean` was **not** updated to import it.

It is the **sole omission** among recently-merged proofs — the parent `ErdosDivisibilityPigeonholeOQ01`, `ErdosGinzburgZivOQ01`, `SummationByPartsOQ01OQ01OQ01`, etc. are all imported. Because the aggregator never imports this module, the build does not compile it, so its `verified` claim is not continuously checked (the same present-but-unbuilt gap repaired earlier in #27904).

## Change

A single line — the missing import, placed alphabetically:

```
 import Proofs.ErdosDivisibilityPigeonholeOQ01
+import Proofs.ErdosDivisibilityPigeonholeOQ01OQ01
 import Proofs.ErdosGinzburgZivOQ01
```

## Verification

`proofs/Proofs/ErdosDivisibilityPigeonholeOQ01OQ01.lean` builds **0-axiom** standalone (Lean v4.26.0 + Mathlib): `#print axioms` on both headline theorems (`max_antichainN_card`, `max_antichainN_recovers_parent`) lists only `propext, Classical.choice, Quot.sound` — no `Lean.ofReduceBool` (no `native_decide`), no `sorryAx`. Adding it to the aggregator only restores its continuous compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)