### PR TITLE
Enrich Eulerian Palindromy & Vanishing Alternating Row Sum (geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "eul-top",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 40, "endLine": 50 },
+    "type": "technique",
+    "title": "The right corner of each row is 1",
+    "content": "`eulerian_top` proves $\\langle n{+}1,n\\rangle = 1$ — the rightmost entry of each Eulerian row. Combinatorially this counts the unique permutation of $\\{1,\\dots,n{+}1\\}$ with the maximal $n$ descents (the decreasing/reversal permutation). The proof is a short induction using the triangle recurrence and the off-diagonal vanishing $\\langle n{+}1,n{+}1\\rangle = 0$. This lemma supplies both corner cases of the palindromy induction, where the symmetry pairs the leftmost $\\langle m,0\\rangle = 1$ with this rightmost $1$.",
+    "mathContext": "$\\langle n{+}1,n\\rangle = 1$; together with $\\langle m,0\\rangle = 1$ these are the two unit corners of each Eulerian row.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eulerian numbers", "descent statistic", "off-diagonal vanishing", "induction"],
+    "prerequisites": ["Eulerian numbers", "induction"]
+  },
+  {
+    "id": "eul-palindrome",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 52, "endLine": 87 },
+    "type": "insight",
+    "title": "Combinatorial palindromy of the Eulerian numbers",
+    "content": "`eulerian_palindrome` is the main result: $\\langle n{+}1,k\\rangle = \\langle n{+}1,n{-}k\\rangle$ for $k\\le n$, the reflection symmetry of each Eulerian row, proved directly from the triangle recurrence with no polynomial machinery. The interior inductive step expands both $\\langle n{+}2,k{+}1\\rangle$ and its mirror $\\langle n{+}2,n{-}k\\rangle$ via the recurrence, then folds the two row-$(n{+}1)$ entries that appear back onto each other using the inductive hypothesis (`e1`, `e2`); the coefficient identities $n{+}1{-}k = (n{-}k{-}1){+}2$ and $n{+}1{-}(n{-}k{-}1) = k{+}2$ then make the two expansions literally equal (`ring`). The two corners are handled by `eulerian_top`. Combinatorially this is descent–ascent reversal: reversing a permutation turns $j$ descents into $m{-}1{-}j$.",
+    "mathContext": "$\\langle n{+}1,k\\rangle = \\langle n{+}1,n{-}k\\rangle$ ($k \\le n$), equivalently $\\langle m,k\\rangle = \\langle m,m{-}1{-}k\\rangle$ — the descent-reversal symmetry.",
+    "significance": "key",
+    "relatedConcepts": ["palindromy", "descent statistic", "reflection symmetry", "Eulerian triangle recurrence"],
+    "prerequisites": ["induction", "Eulerian numbers", "permutation descents"]
+  },
+  {
+    "id": "eul-palindrome-row",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 89, "endLine": 94 },
+    "type": "technique",
+    "title": "Row-form restatement",
+    "content": "`eulerian_palindrome'` repackages the symmetry in the cleaner row form $\\langle r,k\\rangle = \\langle r,r{-}1{-}k\\rangle$ for $1\\le r$ and $k<r$, by rewriting $r = n{+}1$ and reconciling the index $n{-}k$ with $r{-}1{-}k$. This is the convenience wrapper consumed by the alternating-sum proof and by downstream entries, since the index $r{-}1{-}k$ is exactly the reflection used there.",
+    "mathContext": "$\\langle r,k\\rangle = \\langle r,r{-}1{-}k\\rangle$ for $1 \\le r$, $k < r$.",
+    "significance": "supporting",
+    "relatedConcepts": ["palindromy", "index reflection"],
+    "prerequisites": ["Eulerian numbers"]
+  },
+  {
+    "id": "eul-alt-row-sum",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 96, "endLine": 134 },
+    "type": "insight",
+    "title": "The alternating row sum vanishes on even rows",
+    "content": "`eulerian_alt_row_sum_eq_zero` is the new consequence: $\\sum_{k=0}^{2m-1}(-1)^k\\langle 2m,k\\rangle = 0$ for $m\\ge 1$. The argument is a slick involution: reflecting the index $k\\mapsto 2m{-}1{-}k$ (`Finset.sum_range_reflect`) sends each term to its negation, because palindromy gives $\\langle 2m,2m{-}1{-}k\\rangle = \\langle 2m,k\\rangle$ while the sign flips, $(-1)^{2m-1-k} = -(-1)^k$ (the exponent $2m{-}1$ is odd, via `Odd.neg_one_pow`). So the sum equals its own negation, $S = -S$, forcing $S = 0$. This is the first rigorous step of the classical Eulerian → tangent-number phenomenon.",
+    "mathContext": "$\\sum_{k=0}^{2m-1}(-1)^k\\langle 2m,k\\rangle = 0$. Reflection $k\\mapsto 2m{-}1{-}k$ is a fixed-point-free involution pairing equal Eulerian numbers with opposite signs, so $S = -S$.",
+    "significance": "key",
+    "relatedConcepts": ["alternating sum", "involution", "sum_range_reflect", "parity", "tangent numbers"],
+    "prerequisites": ["finite sums", "parity of exponents", "palindromy"]
+  },
+  {
+    "id": "eul-corroboration",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 136, "endLine": 153 },
+    "type": "context",
+    "title": "Corroboration and the tangent-number phenomenon",
+    "content": "A battery of `decide` checks corroborates the theory: palindromy on concrete rows ($1,11,11,1$ and $1,26,66,26,1$), the vanishing alternating sums on even rows $2,4,6$, and — strikingly — the odd-row alternating sums $1,-2,16,-272$. The latter are (up to sign) the tangent (zag) numbers $1,2,16,272$, the Taylor coefficients of $\\tan x = x + 2\\tfrac{x^3}{3!} + 16\\tfrac{x^5}{5!} + 272\\tfrac{x^7}{7!} + \\cdots$. So $A_m(-1)$ vanishes on even rows and yields tangent numbers on odd rows — exactly the open question oq-05-oq-01 flagged for future work. All checks use kernel `decide`, keeping the file 0-axiom.",
+    "mathContext": "Odd rows: $\\sum_k(-1)^k\\langle m,k\\rangle = 1,-2,16,-272$ for $m=1,3,5,7$; even rows vanish. These are $\\pm$ the tangent numbers, Taylor coefficients of $\\tan x$.",
+    "significance": "context",
+    "relatedConcepts": ["tangent numbers", "Eulerian polynomial at -1", "kernel decide", "exponential generating function"],
+    "prerequisites": ["Eulerian numbers", "Taylor series"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05/meta.json
@@ -19,6 +19,70 @@
     "sorries": 0
   },
   "title": "Combinatorial Palindromy of the Eulerian Numbers and the Vanishing Alternating Row Sum",
+  "description": "Proves the combinatorial palindromy of the Eulerian numbers ⟨n+1,k⟩ = ⟨n+1,n−k⟩ (k ≤ n) directly from the triangle recurrence by induction on the row — no polynomial machinery — and deduces a genuinely new consequence: the alternating row sum vanishes on every even row, ∑_{k=0}^{2m−1} (−1)ᵏ·⟨2m,k⟩ = 0. The vanishing follows from palindromy alone, via the fixed-point-free involution k ↦ 2m−1−k that pairs equal Eulerian numbers with opposite signs (2m−1 odd), forcing S = −S. Concrete rows and the signed tangent (zag) numbers 1,−2,16,−272 of the odd rows are corroborated by kernel decide. 155 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨m,k⟩, introduced by Euler in 1755, count permutations of {1,…,m} by their number of descents. Their reflection symmetry ⟨m,k⟩ = ⟨m,m−1−k⟩ is one of their most basic structural properties — the combinatorial shadow of the palindromicity of the Eulerian polynomial A_m(t) = t^{m-1}A_m(1/t) — and corresponds to reversing a permutation, which turns j descents into m−1−j. Beyond symmetry, evaluating the alternating row sums (the Eulerian polynomial at t = −1) reveals a celebrated phenomenon: the sums vanish on even rows and reproduce the tangent (zag) numbers 1, 2, 16, 272, … on odd rows — the Taylor coefficients of tan x. These tangent numbers, studied by André (1879) via alternating permutations and encoded by the boustrophedon recurrence, sit at the heart of the combinatorics of the trigonometric functions (Stanley, Enumerative Combinatorics). Mathlib formalizes none of this; the entry builds the symmetry and the even-row vanishing from scratch on the parent's triangle.",
+    "problemStatement": "Given the combinatorial Eulerian numbers ⟨m,k⟩ defined by the triangle recurrence in the parent entry, prove the palindromy ⟨n+1,k⟩ = ⟨n+1,n−k⟩ for k ≤ n directly from the recurrence, and deduce that the alternating row sum ∑_{k=0}^{2m−1} (−1)ᵏ⟨2m,k⟩ vanishes for m ≥ 1 — all with 0 axioms and 0 sorries.",
+    "proofStrategy": "First prove eulerian_top (⟨n+1,n⟩ = 1) by induction using the off-diagonal vanishing. Then prove palindromy by induction on the row: in the interior step, expand both ⟨n+2,k+1⟩ and its mirror ⟨n+2,n−k⟩ through the triangle recurrence, fold the two resulting row-(n+1) entries onto each other with the inductive hypothesis, and observe the coefficients match (n+1−k = (n−k−1)+2 and n+1−(n−k−1) = k+2) so the expansions coincide; corners use eulerian_top. Repackage as the row form eulerian_palindrome'. Finally, for the alternating row sum, reflect the index k ↦ 2m−1−k (Finset.sum_range_reflect): palindromy keeps the Eulerian factor fixed while the sign flips ((−1)^{2m−1−k} = −(−1)ᵏ, using that 2m−1 is odd), so the reflected sum equals −S; hence S = −S and S = 0.",
+    "keyInsights": [
+      "The palindromy is proved purely at the recurrence level — expanding both an entry and its mirror through the triangle recurrence and folding with the inductive hypothesis — giving a proof object independent of the polynomial coefficient-extraction proof in the sibling entry.",
+      "The matching of coefficients (n+1−k = (n−k−1)+2 and n+1−(n−k−1) = k+2) is the precise algebraic reason the two recurrence expansions of mirrored entries become identical.",
+      "Even-row vanishing needs nothing but palindromy plus parity: the reflection k ↦ 2m−1−k is a fixed-point-free involution pairing equal Eulerian numbers with opposite signs, so the sum is forced to equal its own negation.",
+      "The sign flip relies essentially on 2m−1 being odd; on odd rows m the reflection has a fixed point and the same argument fails — which is exactly why the odd-row sums need not vanish and instead produce the tangent numbers.",
+      "The corroborating examples make the Eulerian → tangent-number phenomenon concrete: A_m(−1) = 0 on even rows and ±(1,2,16,272) on odd rows, the Taylor coefficients of tan x, isolating the open question of identifying the odd-row sums with the tangent numbers in general."
+    ]
+  },
+  "sections": [
+    {
+      "id": "context-docstring",
+      "title": "Context and method",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Docstring stating the palindromy and the even-row vanishing, the recurrence-level method, and the tangent-number phenomenon corroborated at the end; notes 0-axiom, sorry-free."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports and namespace",
+      "startLine": 33,
+      "endLine": 38,
+      "summary": "Imports Mathlib and the parent module, opens Finset and the parent namespace to reuse the eulerian triangle and its recurrence/vanishing lemmas."
+    },
+    {
+      "id": "eulerian-top",
+      "title": "Right corner of each row (eulerian_top)",
+      "startLine": 40,
+      "endLine": 50,
+      "summary": "Proves ⟨n+1,n⟩ = 1 by induction, using the off-diagonal vanishing — the unit corner used in the palindromy induction."
+    },
+    {
+      "id": "palindrome",
+      "title": "Combinatorial palindromy (eulerian_palindrome)",
+      "startLine": 52,
+      "endLine": 87,
+      "summary": "Proves ⟨n+1,k⟩ = ⟨n+1,n−k⟩ by induction on the row; the interior step expands both an entry and its mirror via the recurrence and folds them with the IH, the coefficients matching exactly."
+    },
+    {
+      "id": "palindrome-row",
+      "title": "Row-form restatement (eulerian_palindrome')",
+      "startLine": 89,
+      "endLine": 94,
+      "summary": "Restates the symmetry as ⟨r,k⟩ = ⟨r,r−1−k⟩ for 1 ≤ r, k < r — the form used by the alternating-sum proof and downstream entries."
+    },
+    {
+      "id": "alt-row-sum",
+      "title": "Even-row alternating sum vanishes (eulerian_alt_row_sum_eq_zero)",
+      "startLine": 96,
+      "endLine": 134,
+      "summary": "Proves ∑_{k<2m} (−1)ᵏ⟨2m,k⟩ = 0 by reflecting the index (sum_range_reflect): palindromy fixes the Eulerian factor, the odd exponent 2m−1 flips the sign, so S = −S."
+    },
+    {
+      "id": "corroboration",
+      "title": "Corroboration: palindromy and tangent numbers",
+      "startLine": 136,
+      "endLine": 153,
+      "summary": "decide checks of palindromy on rows 4,5; even-row vanishing on rows 2,4,6; and the odd-row signed sums 1,−2,16,−272 (the tangent numbers)."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05` (Combinatorial Palindromy of the Eulerian Numbers and the Vanishing Alternating Row Sum). The entry had meta.json with conclusion/crossReferences/originalContributions but no description, overview, sections, or annotations.

## Added
- **annotations.json** (new): 5 annotations covering eulerian_top, the combinatorial palindromy, its row-form restatement, the even-row alternating-sum vanishing, and the tangent-number corroboration — each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. Line ranges validated against the Lean source (0 annotation errors).
- **overview** (new): `historicalContext` (Euler 1755 descents; André 1879 tangent numbers; the A_m(−1) phenomenon), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **sections** (new): 7 sections covering the full 155-line Lean file.
- **description** (new): top-level summary.

## Notes
- No changes to the Lean source or to status/badge/axiomCount — meta accurately reports `verified` / `original` / 0 axioms / 0 sorries (corroboration uses kernel `decide`, not native_decide).
- Annotations drawn directly from the proof: the recurrence-level palindromy induction (coefficient matching n+1−k = (n−k−1)+2), and the reflection-involution argument (sum_range_reflect + odd-exponent sign flip) forcing S = −S.