### PR TITLE
Research: chinese-remainder-non-coprime-oq-03-oq-01 — n-moduli non-coprime CRT over any Euclidean domain

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -691,6 +691,7 @@ import Proofs.ChineseRemainderNonCoprimeOQ01OQ01
 import Proofs.ChineseRemainderNonCoprimeOQ02
 import Proofs.ChineseRemainderNonCoprimeOQ03
 import Proofs.ChineseRemainderNonCoprimeOQ03Aristotle
+import Proofs.ChineseRemainderNonCoprimeOQ03OQ01
 import Proofs.ChineseRemainderNonCoprimeOQ03OQ02
 import Proofs.ChineseRemainderNonCoprimeOQ04
 import Proofs.CircumferenceFromArea

--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ01.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ01.lean
@@ -1,0 +1,380 @@
+/-
+  CRT Non-Coprime OQ-03-OQ-01: n-Moduli Generalization by Induction
+
+  Answers the first open question of ChineseRemainderNonCoprimeOQ03:
+  generalize the non-coprime Chinese Remainder Theorem from a fixed number
+  of moduli (2, 3) to an ARBITRARY finite family, organized as a list of
+  (modulus, residue) pairs over a EuclideanDomain R.
+
+  Main results (0 axioms, 0 sorries):
+  * `crt_list_iff`        : the system { x ≡ aᵢ [mod mᵢ] } is solvable
+                             ↔ for every pair i, j: gcd(mᵢ, mⱼ) ∣ (aᵢ - aⱼ).
+  * `crt_list_sufficient` : the (hard) sufficiency direction, by induction
+                             on the list, combining the head modulus with the
+                             lcm of the tail via the GCD–LCM distributive law.
+  * `crt_list_necessary`  : the (easy) necessity direction.
+  * `crt_list_unique`     : any two solutions agree modulo the lcm of all moduli.
+
+  The engine is a generalized GCD–LCM distributive law over a list,
+  `gcd_lcmList_dvd : gcd (lcmList l) c ∣ lcmList (l.map (gcd · c))`,
+  obtained by a one-step induction from the binary distributive law.
+
+  The binary hard direction `gcd_lcm_dvd_lcm_gcd` (gcd(lcm a b, c) ∣
+  lcm(gcd a c, gcd b c)) is reproduced verbatim from the parent entry
+  ChineseRemainderNonCoprimeOQ03.lean (where it was proved, 0 axioms) so
+  that this file is self-contained; the genuinely new contribution is the
+  n-fold generalization (lcmList infrastructure + the list-indexed CRT).
+
+  Parent: ChineseRemainderNonCoprimeOQ03.lean (0 axioms, 0 sorries)
+-/
+import Mathlib
+
+set_option linter.unusedSectionVars false
+
+namespace ChineseRemainderNonCoprimeOQ03OQ01
+
+variable {R : Type*} [EuclideanDomain R] [DecidableEq R]
+
+/-
+## Part 0: Binary CRT core and the binary GCD–LCM distributive law
+
+`ed_crt_sufficient` and `gcd_lcm_dvd_lcm_gcd` are reproduced from the parent
+entry ChineseRemainderNonCoprimeOQ03 (verified there, 0 axioms). They serve as
+imported infrastructure for the new n-fold results below.
+-/
+
+/-- Binary sufficiency: if gcd(m,n) ∣ (a - b), construct a solution via Bézout. -/
+theorem ed_crt_sufficient {m n a b : R}
+    (h : EuclideanDomain.gcd m n ∣ (a - b)) :
+    ∃ x : R, m ∣ (x - a) ∧ n ∣ (x - b) := by
+  obtain ⟨q, hq⟩ := h
+  refine ⟨a - m * (EuclideanDomain.gcdA m n * q), ?_, ?_⟩
+  · exact ⟨-(EuclideanDomain.gcdA m n * q), by ring⟩
+  · refine ⟨EuclideanDomain.gcdB m n * q, ?_⟩
+    have hbez := EuclideanDomain.gcd_eq_gcd_ab m n
+    have hkey : EuclideanDomain.gcd m n - m * EuclideanDomain.gcdA m n =
+        n * EuclideanDomain.gcdB m n := by rw [hbez]; ring
+    calc a - m * (EuclideanDomain.gcdA m n * q) - b
+        = (a - b) - m * EuclideanDomain.gcdA m n * q := by ring
+      _ = EuclideanDomain.gcd m n * q - m * EuclideanDomain.gcdA m n * q := by rw [hq]
+      _ = (EuclideanDomain.gcd m n - m * EuclideanDomain.gcdA m n) * q := by ring
+      _ = n * EuclideanDomain.gcdB m n * q := by rw [hkey]
+      _ = n * (EuclideanDomain.gcdB m n * q) := by ring
+
+/-- Hard direction of the GCD–LCM distributive law:
+    gcd(lcm(a,b), c) divides lcm(gcd(a,c), gcd(b,c)).
+    Reproduced verbatim from the parent (ChineseRemainderNonCoprimeOQ03). -/
+theorem gcd_lcm_dvd_lcm_gcd (a b c : R) :
+    EuclideanDomain.gcd (EuclideanDomain.lcm a b) c ∣
+    EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) := by
+  by_cases hg : EuclideanDomain.gcd a b = 0
+  · have ha : a = 0 := by
+      have := EuclideanDomain.gcd_dvd_left a b; rw [hg] at this
+      exact (zero_dvd_iff.mp this)
+    have hb : b = 0 := by
+      have := EuclideanDomain.gcd_dvd_right a b; rw [hg] at this
+      exact (zero_dvd_iff.mp this)
+    rw [ha, hb]
+    have h0 : EuclideanDomain.lcm (0 : R) 0 = 0 := by
+      simp [EuclideanDomain.lcm]
+    rw [h0]
+    exact EuclideanDomain.dvd_lcm_left _ _
+  · set g := EuclideanDomain.gcd a b with hg_def
+    obtain ⟨α, hα⟩ := EuclideanDomain.gcd_dvd_left a b
+    obtain ⟨β, hβ⟩ := EuclideanDomain.gcd_dvd_right a b
+    have hcop_αβ : IsCoprime α β := by
+      refine ⟨EuclideanDomain.gcdA a b, EuclideanDomain.gcdB a b, ?_⟩
+      apply mul_left_cancel₀ hg
+      calc g * (EuclideanDomain.gcdA a b * α + EuclideanDomain.gcdB a b * β)
+          = g * α * EuclideanDomain.gcdA a b +
+            g * β * EuclideanDomain.gcdB a b := by ring
+        _ = a * EuclideanDomain.gcdA a b + b * EuclideanDomain.gcdB a b := by
+            rw [← hα, ← hβ]
+        _ = g := (EuclideanDomain.gcd_eq_gcd_ab a b).symm
+        _ = g * 1 := (mul_one _).symm
+    set d' := EuclideanDomain.gcd g c with hd'_def
+    have hd'_ne : d' ≠ 0 := by
+      intro h; apply hg
+      exact (zero_dvd_iff.mp (h ▸ EuclideanDomain.gcd_dvd_left g c))
+    obtain ⟨g', hg'⟩ := EuclideanDomain.gcd_dvd_left g c
+    obtain ⟨c', hc'⟩ := EuclideanDomain.gcd_dvd_right g c
+    have hcop_gc : IsCoprime g' c' := by
+      refine ⟨EuclideanDomain.gcdA g c, EuclideanDomain.gcdB g c, ?_⟩
+      apply mul_left_cancel₀ hd'_ne
+      calc d' * (EuclideanDomain.gcdA g c * g' + EuclideanDomain.gcdB g c * c')
+          = d' * g' * EuclideanDomain.gcdA g c +
+            d' * c' * EuclideanDomain.gcdB g c := by ring
+        _ = g * EuclideanDomain.gcdA g c + c * EuclideanDomain.gcdB g c := by
+            rw [← hg', ← hc']
+        _ = d' := (EuclideanDomain.gcd_eq_gcd_ab g c).symm
+        _ = d' * 1 := (mul_one _).symm
+    obtain ⟨k₁, hk₁⟩ := EuclideanDomain.dvd_lcm_left
+      (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c)
+    obtain ⟨k₂, hk₂⟩ := EuclideanDomain.dvd_lcm_right
+      (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c)
+    have hM1 : EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) =
+        (EuclideanDomain.gcdA a c * k₁) * a +
+        (EuclideanDomain.gcdB a c * k₁) * c := by
+      conv_lhs => rw [hk₁, EuclideanDomain.gcd_eq_gcd_ab a c]
+      ring
+    have hM2 : EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) =
+        (EuclideanDomain.gcdA b c * k₂) * b +
+        (EuclideanDomain.gcdB b c * k₂) * c := by
+      conv_lhs => rw [hk₂, EuclideanDomain.gcd_eq_gcd_ab b c]
+      ring
+    set r₁ := EuclideanDomain.gcdA a c * k₁
+    set s₁ := EuclideanDomain.gcdB a c * k₁
+    set r₂ := EuclideanDomain.gcdA b c * k₂
+    set s₂ := EuclideanDomain.gcdB b c * k₂
+    have hrab : r₁ * a - r₂ * b = (s₂ - s₁) * c := by
+      have heq := hM1.symm.trans hM2
+      calc r₁ * a - r₂ * b
+          = (r₁ * a + s₁ * c) - (r₂ * b + s₂ * c) + (s₂ - s₁) * c := by ring
+        _ = (r₂ * b + s₂ * c) - (r₂ * b + s₂ * c) + (s₂ - s₁) * c := by rw [heq]
+        _ = (s₂ - s₁) * c := by ring
+    have hgrab : g * (r₁ * α - r₂ * β) = (s₂ - s₁) * c := by
+      calc g * (r₁ * α - r₂ * β)
+          = r₁ * (g * α) - r₂ * (g * β) := by ring
+        _ = r₁ * a - r₂ * b := by rw [← hα, ← hβ]
+        _ = _ := hrab
+    have hgrab' : g' * (r₁ * α - r₂ * β) = (s₂ - s₁) * c' := by
+      apply mul_left_cancel₀ hd'_ne
+      have hlhs : d' * (g' * (r₁ * α - r₂ * β)) = (s₂ - s₁) * c := by
+        calc d' * (g' * (r₁ * α - r₂ * β))
+            = (d' * g') * (r₁ * α - r₂ * β) := by ring
+          _ = g * (r₁ * α - r₂ * β) := by rw [← hg']
+          _ = (s₂ - s₁) * c := hgrab
+      have hrhs : d' * ((s₂ - s₁) * c') = (s₂ - s₁) * c := by
+        calc d' * ((s₂ - s₁) * c') = (s₂ - s₁) * (d' * c') := by ring
+          _ = (s₂ - s₁) * c := by rw [← hc']
+      exact hlhs.trans hrhs.symm
+    have hc'_dvd : c' ∣ (r₁ * α - r₂ * β) := by
+      obtain ⟨u, v, huv⟩ := hcop_gc
+      obtain ⟨k, hk⟩ : c' ∣ g' * (r₁ * α - r₂ * β) := by
+        rw [hgrab']; exact dvd_mul_left c' _
+      exact ⟨u * k + v * (r₁ * α - r₂ * β), by
+        calc r₁ * α - r₂ * β
+            = (r₁ * α - r₂ * β) * (u * g' + v * c') := by rw [huv, mul_one]
+          _ = u * (g' * (r₁ * α - r₂ * β)) + v * c' * (r₁ * α - r₂ * β) := by ring
+          _ = u * (c' * k) + v * c' * (r₁ * α - r₂ * β) := by rw [hk]
+          _ = c' * (u * k + v * (r₁ * α - r₂ * β)) := by ring⟩
+    obtain ⟨w, hw⟩ := hc'_dvd
+    obtain ⟨p_b, q_b, hpq⟩ := hcop_αβ
+    have hβ_dvd : β ∣ (r₁ - p_b * (c' * w)) := by
+      have hr₁α : r₁ * α = r₂ * β + c' * w := by
+        calc r₁ * α = (r₁ * α - r₂ * β) + r₂ * β := by ring
+          _ = c' * w + r₂ * β := by rw [hw]
+          _ = r₂ * β + c' * w := by ring
+      have hqβ : q_b * β = 1 - p_b * α := by
+        calc q_b * β = (p_b * α + q_b * β) - p_b * α := by ring
+          _ = 1 - p_b * α := by rw [hpq]
+      have key : (r₁ - p_b * (c' * w)) * α = (r₂ + q_b * (c' * w)) * β := by
+        calc (r₁ - p_b * (c' * w)) * α
+            = r₁ * α - p_b * (c' * w) * α := by ring
+          _ = (r₂ * β + c' * w) - p_b * (c' * w) * α := by rw [hr₁α]
+          _ = r₂ * β + c' * w * (1 - p_b * α) := by ring
+          _ = r₂ * β + c' * w * (q_b * β) := by rw [← hqβ]
+          _ = (r₂ + q_b * (c' * w)) * β := by ring
+      exact ⟨p_b * (r₂ + q_b * (c' * w)) + q_b * (r₁ - p_b * (c' * w)), by
+        calc r₁ - p_b * (c' * w)
+            = (r₁ - p_b * (c' * w)) * (p_b * α + q_b * β) := by rw [hpq, mul_one]
+          _ = p_b * ((r₁ - p_b * (c' * w)) * α) +
+              q_b * (r₁ - p_b * (c' * w)) * β := by ring
+          _ = p_b * ((r₂ + q_b * (c' * w)) * β) +
+              q_b * (r₁ - p_b * (c' * w)) * β := by rw [key]
+          _ = β * (p_b * (r₂ + q_b * (c' * w)) + q_b * (r₁ - p_b * (c' * w))) := by ring⟩
+    obtain ⟨m, hm⟩ := hβ_dvd
+    have hr₁ : r₁ = m * β + p_b * (c' * w) := by
+      calc r₁ = (r₁ - p_b * (c' * w)) + p_b * (c' * w) := by ring
+        _ = β * m + p_b * (c' * w) := by rw [hm]
+        _ = m * β + p_b * (c' * w) := by ring
+    have hcg : c' * g = c * g' := by
+      calc c' * g = c' * (d' * g') := by rw [hg']
+        _ = (d' * c') * g' := by ring
+        _ = c * g' := by rw [← hc']
+    have hM_decomp :
+        EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c) =
+        m * (g * α * β) + (p_b * w * g' * α + s₁) * c := by
+      calc EuclideanDomain.lcm (EuclideanDomain.gcd a c) (EuclideanDomain.gcd b c)
+          = r₁ * a + s₁ * c := hM1
+        _ = r₁ * (g * α) + s₁ * c := by rw [hα]
+        _ = (m * β + p_b * (c' * w)) * (g * α) + s₁ * c := by rw [hr₁]
+        _ = m * (g * α * β) + p_b * w * α * (c' * g) + s₁ * c := by ring
+        _ = m * (g * α * β) + p_b * w * α * (c * g') + s₁ * c := by rw [hcg]
+        _ = m * (g * α * β) + (p_b * w * g' * α + s₁) * c := by ring
+    have hd_gab : EuclideanDomain.gcd (EuclideanDomain.lcm a b) c ∣ g * α * β := by
+      refine dvd_trans (EuclideanDomain.gcd_dvd_left _ _) ?_
+      refine EuclideanDomain.lcm_dvd ?_ ?_
+      · rw [hα]; exact dvd_mul_right _ _
+      · exact ⟨α, by calc g * α * β = g * β * α := by ring
+          _ = b * α := by rw [← hβ]⟩
+    rw [hM_decomp]
+    exact dvd_add
+      (hd_gab.mul_left m)
+      ((EuclideanDomain.gcd_dvd_right (EuclideanDomain.lcm a b) c).mul_left _)
+
+/-
+## Part I: lcm over a list of moduli
+-/
+
+/-- lcm of all elements of a list (empty list ↦ 1). -/
+def lcmList (l : List R) : R := l.foldr EuclideanDomain.lcm 1
+
+@[simp] theorem lcmList_nil : lcmList ([] : List R) = 1 := rfl
+
+@[simp] theorem lcmList_cons (m : R) (l : List R) :
+    lcmList (m :: l) = EuclideanDomain.lcm m (lcmList l) := rfl
+
+/-- Each element of the list divides the list lcm. -/
+theorem dvd_lcmList {z : R} : ∀ {l : List R}, z ∈ l → z ∣ lcmList l
+  | m :: rest, h => by
+      rcases List.mem_cons.mp h with rfl | h'
+      · exact EuclideanDomain.dvd_lcm_left _ _
+      · exact dvd_trans (dvd_lcmList h') (EuclideanDomain.dvd_lcm_right _ _)
+
+/-- If every element of the list divides `t`, so does the list lcm. -/
+theorem lcmList_dvd {l : List R} {t : R} (h : ∀ z ∈ l, z ∣ t) : lcmList l ∣ t := by
+  induction l with
+  | nil => exact one_dvd t
+  | cons m rest ih =>
+      rw [lcmList_cons]
+      exact EuclideanDomain.lcm_dvd (h m (List.mem_cons.mpr (Or.inl rfl)))
+        (ih (fun z hz => h z (List.mem_cons.mpr (Or.inr hz))))
+
+/-
+## Part II: Generalized GCD–LCM distributive law over a list
+
+`gcd (lcmList l) c` divides `lcmList (l.map (· gcd-with c))`, by a one-step
+induction from the binary `gcd_lcm_dvd_lcm_gcd`.
+-/
+theorem gcd_lcmList_dvd (c : R) (l : List R) :
+    EuclideanDomain.gcd (lcmList l) c ∣
+    lcmList (l.map (fun m => EuclideanDomain.gcd m c)) := by
+  induction l with
+  | nil =>
+      show EuclideanDomain.gcd (1 : R) c ∣ (1 : R)
+      exact EuclideanDomain.gcd_dvd_left 1 c
+  | cons m rest ih =>
+      rw [lcmList_cons, List.map_cons, lcmList_cons]
+      refine dvd_trans (gcd_lcm_dvd_lcm_gcd m (lcmList rest) c) ?_
+      exact EuclideanDomain.lcm_dvd (EuclideanDomain.dvd_lcm_left _ _)
+        (dvd_trans ih (EuclideanDomain.dvd_lcm_right _ _))
+
+/-
+## Part III: n-Moduli (list-indexed) Chinese Remainder Theorem
+
+A system is a list `l : List (R × R)` of (modulus, residue) pairs.
+-/
+
+/-- `x` solves the system: for each pair (m, a), m ∣ (x - a). -/
+def Solves (x : R) (l : List (R × R)) : Prop := ∀ p ∈ l, p.1 ∣ (x - p.2)
+
+/-- Pairwise compatibility: for every pair of entries, gcd(mᵢ, mⱼ) ∣ (aᵢ - aⱼ). -/
+def Compat (l : List (R × R)) : Prop :=
+  ∀ p ∈ l, ∀ q ∈ l, EuclideanDomain.gcd p.1 q.1 ∣ (p.2 - q.2)
+
+/-- Necessity: a solvable system is pairwise compatible. -/
+theorem crt_list_necessary {l : List (R × R)} (h : ∃ x, Solves x l) : Compat l := by
+  obtain ⟨x, hx⟩ := h
+  intro p hp q hq
+  have h1 : p.1 ∣ (x - p.2) := hx p hp
+  have h2 : q.1 ∣ (x - q.2) := hx q hq
+  have d1 : EuclideanDomain.gcd p.1 q.1 ∣ (x - p.2) :=
+    dvd_trans (EuclideanDomain.gcd_dvd_left _ _) h1
+  have d2 : EuclideanDomain.gcd p.1 q.1 ∣ (x - q.2) :=
+    dvd_trans (EuclideanDomain.gcd_dvd_right _ _) h2
+  have hsub : EuclideanDomain.gcd p.1 q.1 ∣ ((x - q.2) - (x - p.2)) := dvd_sub d2 d1
+  rwa [show (x - q.2) - (x - p.2) = p.2 - q.2 from by ring] at hsub
+
+/-- Sufficiency (hard direction): a pairwise-compatible system is solvable.
+    Proof by induction on the list. To combine the head modulus `m₀` with a
+    solution `x₀` of the tail (whose combined modulus is `M = lcm` of the tail
+    moduli), we show `gcd(M, m₀) ∣ (a₀ - x₀)`: each tail modulus `mᵢ` gives
+    `gcd(m₀, mᵢ) ∣ (a₀ - x₀)`, and the generalized distributive law upgrades
+    the lcm of those gcds — which divides `(a₀ - x₀)` — to `gcd(M, m₀)`. -/
+theorem crt_list_sufficient {l : List (R × R)} (h : Compat l) : ∃ x, Solves x l := by
+  induction l with
+  | nil => exact ⟨0, fun p hp => by simp at hp⟩
+  | cons p rest ih =>
+      have hcompat_rest : Compat rest := fun a ha b hb =>
+        h a (List.mem_cons.mpr (Or.inr ha)) b (List.mem_cons.mpr (Or.inr hb))
+      obtain ⟨x₀, hx₀⟩ := ih hcompat_rest
+      -- head is compatible with every tail entry
+      have hhead : ∀ q ∈ rest, EuclideanDomain.gcd p.1 q.1 ∣ (p.2 - q.2) :=
+        fun q hq => h p (List.mem_cons.mpr (Or.inl rfl)) q (List.mem_cons.mpr (Or.inr hq))
+      -- transfer through the tail solution: gcd(m₀, mᵢ) ∣ (a₀ - x₀)
+      have hpx0 : ∀ q ∈ rest, EuclideanDomain.gcd p.1 q.1 ∣ (p.2 - x₀) := by
+        intro q hq
+        have hq_sol : q.1 ∣ (x₀ - q.2) := hx₀ q hq
+        have hg2 : EuclideanDomain.gcd p.1 q.1 ∣ (x₀ - q.2) :=
+          dvd_trans (EuclideanDomain.gcd_dvd_right _ _) hq_sol
+        have hg1 : EuclideanDomain.gcd p.1 q.1 ∣ (p.2 - q.2) := hhead q hq
+        have hsub : EuclideanDomain.gcd p.1 q.1 ∣ ((p.2 - q.2) - (x₀ - q.2)) :=
+          dvd_sub hg1 hg2
+        rwa [show (p.2 - q.2) - (x₀ - q.2) = p.2 - x₀ from by ring] at hsub
+      -- distributive law: gcd(M, m₀) ∣ (a₀ - x₀), where M = lcm of tail moduli
+      have hgcdM : EuclideanDomain.gcd (lcmList (rest.map Prod.fst)) p.1 ∣ (p.2 - x₀) := by
+        refine dvd_trans (gcd_lcmList_dvd p.1 (rest.map Prod.fst)) ?_
+        apply lcmList_dvd
+        intro z hz
+        obtain ⟨w, hw_mem, rfl⟩ := List.mem_map.mp hz
+        obtain ⟨q, hq, rfl⟩ := List.mem_map.mp hw_mem
+        -- need gcd q.1 p.1 ∣ (p.2 - x₀); bridge gcd q.1 p.1 ∣ gcd p.1 q.1
+        have hbridge : EuclideanDomain.gcd q.1 p.1 ∣ EuclideanDomain.gcd p.1 q.1 :=
+          EuclideanDomain.dvd_gcd (EuclideanDomain.gcd_dvd_right _ _)
+            (EuclideanDomain.gcd_dvd_left _ _)
+        exact dvd_trans hbridge (hpx0 q hq)
+      -- orient for the 2-moduli solver (a₀ on the second slot)
+      have hgcdM' : EuclideanDomain.gcd (lcmList (rest.map Prod.fst)) p.1 ∣ (x₀ - p.2) := by
+        have h' := dvd_neg.mpr hgcdM
+        rwa [neg_sub] at h'
+      obtain ⟨x, hxM, hxp⟩ := ed_crt_sufficient hgcdM'
+      -- hxM : M ∣ (x - x₀), hxp : m₀ ∣ (x - a₀)
+      refine ⟨x, ?_⟩
+      intro s hs
+      rcases List.mem_cons.mp hs with rfl | hs'
+      · exact hxp
+      · have hs1_dvd_M : s.1 ∣ lcmList (rest.map Prod.fst) :=
+          dvd_lcmList (List.mem_map.mpr ⟨s, hs', rfl⟩)
+        have hs_xx0 : s.1 ∣ (x - x₀) := dvd_trans hs1_dvd_M hxM
+        have hs_x0 : s.1 ∣ (x₀ - s.2) := hx₀ s hs'
+        rw [show x - s.2 = (x - x₀) + (x₀ - s.2) from by ring]
+        exact dvd_add hs_xx0 hs_x0
+
+/-- The full iff for n moduli: solvability ↔ pairwise GCD compatibility. -/
+theorem crt_list_iff {l : List (R × R)} :
+    (∃ x, Solves x l) ↔ Compat l :=
+  ⟨crt_list_necessary, crt_list_sufficient⟩
+
+/-- Uniqueness: any two solutions agree modulo the lcm of all moduli. -/
+theorem crt_list_unique {l : List (R × R)} {x y : R}
+    (hx : Solves x l) (hy : Solves y l) :
+    lcmList (l.map Prod.fst) ∣ (x - y) := by
+  apply lcmList_dvd
+  intro z hz
+  obtain ⟨p, hp, rfl⟩ := List.mem_map.mp hz
+  have h1 : p.1 ∣ (x - p.2) := hx p hp
+  have h2 : p.1 ∣ (y - p.2) := hy p hp
+  have hsub : p.1 ∣ ((x - p.2) - (y - p.2)) := dvd_sub h1 h2
+  rwa [show (x - p.2) - (y - p.2) = x - y from by ring] at hsub
+
+/-
+## Summary
+
+### Theorems proved (0 axioms, 0 sorries):
+1. `ed_crt_sufficient`     — binary CRT sufficiency (from parent OQ-03)
+2. `gcd_lcm_dvd_lcm_gcd`   — binary GCD–LCM distributive law (from parent OQ-03)
+3. `dvd_lcmList`           — each modulus divides the list lcm
+4. `lcmList_dvd`           — list lcm divides any common multiple
+5. `gcd_lcmList_dvd`       — NEW: generalized GCD–LCM distributive law (n-fold)
+6. `crt_list_necessary`    — NEW: necessity for n moduli
+7. `crt_list_sufficient`   — NEW: sufficiency for n moduli (induction + distributive law)
+8. `crt_list_iff`          — NEW: full iff for n moduli
+9. `crt_list_unique`       — NEW: uniqueness modulo lcm of all moduli
+
+### Status: COMPLETE — answers OQ-03's first open question
+### Technique: induction on the modulus list; combine head with lcm of tail via
+### the generalized GCD–LCM distributive law (built from the binary case).
+-/
+
+end ChineseRemainderNonCoprimeOQ03OQ01

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-01/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "chinese-remainder-non-coprime-oq-03-oq-01",
+  "title": "Chinese Remainder Theorem for n Non-Coprime Moduli",
+  "slug": "chinese-remainder-non-coprime-oq-03-oq-01",
+  "description": "Generalizes the non-coprime CRT from a fixed number of moduli (2, 3) to an arbitrary finite family, organized as a list of (modulus, residue) pairs over any Euclidean domain. The system {x ≡ aᵢ [mod mᵢ]} is solvable iff gcd(mᵢ,mⱼ)∣(aᵢ−aⱼ) for every pair, and any two solutions agree modulo the lcm of all moduli. Sufficiency is proved by induction on the list, combining the head modulus with the lcm of the tail via a generalized GCD–LCM distributive law. 11 theorems, 3 definitions, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeOQ03OQ01.lean",
+    "tags": [
+      "number-theory",
+      "chinese-remainder-theorem",
+      "euclidean-domain",
+      "non-coprime",
+      "gcd-lcm",
+      "induction"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Fully machine-verified, 0 sorries, no native_decide. The binary GCD–LCM distributive law gcd_lcm_dvd_lcm_gcd and binary sufficiency ed_crt_sufficient are reproduced verbatim from the parent ChineseRemainderNonCoprimeOQ03 (verified there, 0 axioms) to keep this file self-contained.",
+    "lineCount": 380,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "originalContributions": [
+      "lcmList: lcm over a list of moduli (empty list ↦ 1), with the basic divisibility lemmas dvd_lcmList and lcmList_dvd",
+      "gcd_lcmList_dvd: NEW generalized GCD–LCM distributive law over a list — gcd(lcmList l, c) ∣ lcmList (l.map (gcd · c)) — obtained by a one-step induction from the binary distributive law",
+      "Solves / Compat: list-indexed formulation of an n-moduli congruence system and its pairwise GCD compatibility predicate",
+      "crt_list_necessary: necessity for n moduli — a solvable system is pairwise compatible",
+      "crt_list_sufficient: sufficiency for n moduli — induction on the modulus list, combining the head with the lcm of the tail via gcd_lcmList_dvd",
+      "crt_list_iff: full iff characterization for n-moduli non-coprime CRT",
+      "crt_list_unique: uniqueness — any two solutions agree modulo the lcm of all moduli"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classical Chinese Remainder Theorem for coprime moduli is ancient; its non-coprime refinement — a system of congruences x ≡ aᵢ (mod mᵢ) is solvable precisely when the residues are pairwise compatible, gcd(mᵢ,mⱼ)∣(aᵢ−aⱼ), with uniqueness modulo lcm(m₁,…,mₙ) — is the standard generalization stated in elementary number theory texts but rarely formalized in full generality. The parent gallery line verified the 2- and 3-moduli cases over arbitrary Euclidean domains, isolating the GCD–LCM distributive law gcd(lcm(a,b),c)=lcm(gcd(a,c),gcd(b,c)) (a defining identity of distributive lattices, Birkhoff 1935) as the essential algebraic engine. This entry closes the parent's first open question by lifting that machinery to an arbitrary finite family of moduli.",
+    "problemStatement": "In a Euclidean domain R, given a finite family of (modulus, residue) pairs (mᵢ, aᵢ), when does the system mᵢ∣(x−aᵢ) have a common solution x, and to what extent is it unique? Prove that solvability is equivalent to pairwise GCD compatibility for all pairs, and that solutions are unique modulo the lcm of all moduli.",
+    "text": "The family is modeled as a list l : List (R × R) of (modulus, residue) pairs. Solvability `∃ x, Solves x l` is characterized by `Compat l`, the all-pairs condition gcd(p.1,q.1)∣(p.2−q.2). Necessity is immediate: a common solution x makes gcd(mᵢ,mⱼ) divide both (x−aᵢ) and (x−aⱼ), hence their difference (aᵢ−aⱼ). Sufficiency is proved by induction on the list. Writing l = (m₀,a₀) :: rest, the inductive hypothesis gives a solution x₀ of the tail. To merge it with the head we must show gcd(M, m₀)∣(a₀−x₀), where M = lcmList of the tail moduli. Each tail modulus mᵢ yields gcd(m₀,mᵢ)∣(a₀−x₀) (combining head-vs-tail compatibility with mᵢ∣(x₀−aᵢ)), so the lcm of those pairwise gcds divides (a₀−x₀). The generalized distributive law gcd_lcmList_dvd upgrades gcd(M,m₀) to a divisor of that lcm, closing the gap. A final application of the binary 2-moduli solver merges (M, x₀) with (m₀, a₀); back-substitution recovers every original congruence. Uniqueness follows because every modulus divides x−y, hence so does their lcm.",
+    "proofStrategy": "List-indexed induction. Build lcmList (foldr lcm 1) with divisibility lemmas. Prove the generalized GCD–LCM distributive law gcd_lcmList_dvd by induction from the binary case. Reduce n-moduli sufficiency to the binary solver at each step. Necessity and uniqueness are direct divisibility arguments.",
+    "keyInsights": [
+      "Indexing the system by a list (rather than Fin n) makes the induction structural and avoids reindexing bookkeeping",
+      "The crux of the inductive step is gcd(lcm of tail moduli, head modulus) ∣ (head residue − tail solution), which needs the n-fold GCD–LCM distributive law",
+      "The n-fold distributive law gcd(lcmList l, c) ∣ lcmList (l.map (gcd · c)) is a clean one-step induction reusing the binary distributive law from the parent",
+      "Pairwise compatibility transfers to compatibility with the tail solution: gcd(m₀,mᵢ)∣(a₀−aᵢ) and mᵢ∣(x₀−aᵢ) give gcd(m₀,mᵢ)∣(a₀−x₀)",
+      "Uniqueness collapses from the product (coprime case) to the lcm (non-coprime case): the modulus of the solution set is exactly lcm(m₁,…,mₙ)",
+      "gcd is only commutative up to associatedness in a general Euclidean domain, so the proof bridges gcd q.1 p.1 ∣ gcd p.1 q.1 via dvd_gcd rather than rewriting"
+    ],
+    "prerequisites": [
+      "Euclidean domains: GCD, LCM, Bézout's identity",
+      "Non-coprime CRT for 2 and 3 moduli (ChineseRemainderNonCoprimeOQ03.lean)",
+      "GCD–LCM distributive law in the divisibility lattice",
+      "Structural induction over lists in Lean"
+    ]
+  },
+  "conclusion": {
+    "summary": "The non-coprime CRT is fully verified for an arbitrary finite family of moduli over any Euclidean domain: the list-indexed system is solvable iff all pairwise GCD conditions hold (crt_list_iff), and any two solutions agree modulo the lcm of all moduli (crt_list_unique). The engine is a generalized GCD–LCM distributive law over a list (gcd_lcmList_dvd), obtained by induction from the binary case. 11 theorems, 3 definitions, 380 lines, 0 axioms, 0 sorries.",
+    "implications": "This completes the non-coprime CRT hierarchy: the 2-, 3-, and now general n-moduli cases are all verified for arbitrary Euclidean domains. The list formulation applies uniformly to ℤ and to polynomial rings k[X] over a field, giving a non-coprime simultaneous-congruence solver for both. The generalized distributive law gcd_lcmList_dvd is independently reusable wherever an iterated GCD–LCM identity is needed.",
+    "openQuestions": [
+      "Recast the list-indexed result as a Fintype/Finset-indexed statement (family m : ι → R, a : ι → R over a Fintype ι), proving the solution set is invariant under permutation and duplication of moduli — i.e. it depends only on the underlying ideal-theoretic data",
+      "Sharpness of uniqueness: exhibit, for a concrete non-coprime family, two distinct solutions differing by exactly lcm(m₁,…,mₙ), confirming the lcm modulus cannot be improved (and contrast with the coprime case where it equals the product)"
+    ]
+  },
+  "leanFile": {
+    "namespace": "ChineseRemainderNonCoprimeOQ03OQ01",
+    "lineCount": 380,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3,
+    "path": "Proofs/ChineseRemainderNonCoprimeOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "proofId": "chinese-remainder-non-coprime-oq-03",
+      "relationship": "extends",
+      "description": "The 3-moduli non-coprime CRT over Euclidean domains. This file answers that entry's first open question by generalizing to an arbitrary finite family of moduli, and reuses its binary GCD–LCM distributive law gcd_lcm_dvd_lcm_gcd (reproduced verbatim) as the base case of the n-fold distributive law gcd_lcmList_dvd."
+    },
+    {
+      "proofId": "chinese-remainder-non-coprime-oq-02",
+      "relationship": "uses",
+      "description": "The 2-moduli non-coprime CRT. Its sufficiency construction (reproduced here as ed_crt_sufficient) is the merge step invoked once per inductive layer: at stage k it combines the running solution modulo lcm(m₁,…,m_{k-1}) with the new congruence modulo m_k."
+    },
+    {
+      "proofId": "chinese-remainder-constructive",
+      "relationship": "complementary",
+      "description": "The classical pairwise-coprime CRT: for coprime moduli the system is always solvable and unique modulo the product. This file is the opposite extreme generalized to n moduli — arbitrary (non-coprime) families, where solvability requires pairwise GCD compatibility and uniqueness drops from product to lcm."
+    },
+    {
+      "proofId": "bezout-identity",
+      "relationship": "uses",
+      "description": "Wiedijk #60. Bézout's identity underlies both the binary 2-moduli solver (which constructs x = a − m·(gcdA·q)) and the binary GCD–LCM distributive law that anchors the induction here."
+    },
+    {
+      "proofId": "fundamental-theorem-algebra",
+      "relationship": "context",
+      "description": "Polynomial rings k[X] over a field are Euclidean domains, so the n-moduli non-coprime CRT applies to simultaneous polynomial congruences pᵢ(X)∣(f(X)−rᵢ(X)) for arbitrary, not necessarily coprime, pᵢ."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring describing the n-moduli generalization, imports (Mathlib), and namespace setup. States the main results and clarifies that the binary infrastructure is reproduced from the parent for self-containedness."
+    },
+    {
+      "title": "Part 0: Binary CRT core and binary GCD–LCM distributive law",
+      "startLine": 46,
+      "endLine": 219,
+      "summary": "ed_crt_sufficient: binary CRT sufficiency via Bézout (from parent). gcd_lcm_dvd_lcm_gcd: the hard binary GCD–LCM distributive law gcd(lcm(a,b),c)∣lcm(gcd(a,c),gcd(b,c)), reproduced verbatim from ChineseRemainderNonCoprimeOQ03 — a Bézout decomposition with nested coprime factoring through gcd(a,b) and gcd(gcd(a,b),c)."
+    },
+    {
+      "title": "Part I: lcm over a list of moduli",
+      "startLine": 220,
+      "endLine": 247,
+      "summary": "lcmList (foldr EuclideanDomain.lcm 1) with simp lemmas lcmList_nil/lcmList_cons; dvd_lcmList (each element divides the list lcm) and lcmList_dvd (the list lcm divides any common multiple)."
+    },
+    {
+      "title": "Part II: Generalized GCD–LCM distributive law",
+      "startLine": 248,
+      "endLine": 268,
+      "summary": "gcd_lcmList_dvd: gcd(lcmList l, c) ∣ lcmList (l.map (gcd · c)), proved by induction on l. The cons step applies the binary distributive law gcd_lcm_dvd_lcm_gcd to the head and the lcm of the tail, then monotonicity of lcm with the inductive hypothesis."
+    },
+    {
+      "title": "Part III: n-Moduli list-indexed CRT",
+      "startLine": 269,
+      "endLine": 380,
+      "summary": "Solves and Compat predicates over List (R × R). crt_list_necessary (solvable ⟹ pairwise compatible). crt_list_sufficient (induction on the list; merge head with lcm of tail via gcd_lcmList_dvd and the binary solver). crt_list_iff (full characterization). crt_list_unique (lcm of all moduli divides the difference of any two solutions). Summary of the nine results."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `chinese-remainder-non-coprime-oq-03`: generalize the non-coprime Chinese Remainder Theorem from a fixed number of moduli (2, 3) to an **arbitrary finite family**, modeled as a list of (modulus, residue) pairs over any `EuclideanDomain`.

For `l : List (R × R)` of (modulus mᵢ, residue aᵢ) pairs:

- **`crt_list_iff`** — the system `{ x ≡ aᵢ [mod mᵢ] }` is solvable **⟺** `gcd(mᵢ, mⱼ) ∣ (aᵢ − aⱼ)` for every pair.
- **`crt_list_sufficient`** (hard direction) — by induction on the list. Combining the head modulus `m₀` with a solution `x₀` of the tail (combined modulus `M = lcm` of tail moduli) needs `gcd(M, m₀) ∣ (a₀ − x₀)`; each tail modulus gives `gcd(m₀, mᵢ) ∣ (a₀ − x₀)`, and the generalized distributive law upgrades the lcm of those gcds to `gcd(M, m₀)`.
- **`crt_list_necessary`** (easy direction).
- **`crt_list_unique`** — any two solutions agree modulo the lcm of all moduli.
- **`gcd_lcmList_dvd`** (NEW engine) — generalized GCD–LCM distributive law over a list, `gcd(lcmList l, c) ∣ lcmList (l.map (gcd · c))`, obtained by a one-step induction from the binary case.

## Verification

- **11 theorems, 3 definitions, 380 lines, 0 axioms, 0 sorries**, no `native_decide`.
- Built with Lean `v4.26.0`; `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (the standard foundational axioms — does **not** count as an assumption per the project's Axiom Integrity Policy).
- The binary `gcd_lcm_dvd_lcm_gcd` (170-line Bézout proof) and `ed_crt_sufficient` are reproduced verbatim from the parent `ChineseRemainderNonCoprimeOQ03` (verified there, 0 axioms) to keep this file self-contained; the genuinely new content is the n-fold generalization (`lcmList` infrastructure, `gcd_lcmList_dvd`, and the list-indexed CRT).

## Files

- `proofs/Proofs/ChineseRemainderNonCoprimeOQ03OQ01.lean` (new)
- `src/data/proofs/chinese-remainder-non-coprime-oq-03-oq-01/meta.json` (new)
- `proofs/Proofs.lean` (aggregator import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)