### PR TITLE
Enrich The Non-Three-Square Density Error: cover the docstring exposition

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/annotations.json
@@ -1,5 +1,28 @@
 [
   {
+    "id": "residue-reduction",
+    "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 20,
+      "endLine": 50
+    },
+    "type": "insight",
+    "title": "The Residue Reduction: a Single mod-8 Increment Table",
+    "content": "The docstring records the conceptual heart of the file before any theorem. Starting from the parent's 4-descent recursion excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉, the error E(N) = 6·excludedCount N − N telescopes to E(N) = E(⌈N/4⌉) + δ(N), where the per-step increment δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) depends ONLY on N mod 8. Evaluating it on the eight residues 0..7 gives the table 0, 0, −1, −2, −3, −3, −4, −5. This single observation collapses a two-variable error analysis into eight numbers: the sign of every entry (all ≤ 0) settles one-sidedness, and the most negative SUSTAINABLE entry (−4, on residue 6) fixes the growth rate. Everything below is a corollary of reading this table.",
+    "mathContext": "$E(N) = E(\\lceil N/4\\rceil) + \\delta(N)$, $\\delta(N) = \\left\\lfloor\\tfrac{(N\\bmod 8)+3}{4}\\right\\rfloor - (N\\bmod 8) \\in \\{0,0,-1,-2,-3,-3,-4,-5\\}$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "telescoping recursion",
+      "residue reduction",
+      "2-adic self-similarity",
+      "error term"
+    ],
+    "prerequisites": [
+      "asymptotic density",
+      "floor and mod arithmetic"
+    ]
+  },
+  {
     "id": "one-sided",
     "proofId": "lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01",
     "range": {

--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/meta.json
@@ -17,6 +17,14 @@
   },
   "sections": [
     {
+      "id": "setup-section",
+      "title": "Setup: the telescoped error and the increment δ",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Docstring framing the open question oq-03-oq-05-oq-01 and recording the central reduction. The parent recursion excludedCount N = ⌊N/8⌋ + excludedCount ⌈N/4⌉ telescopes the error E(N) = 6·excludedCount N − N into E(N) = E(⌈N/4⌉) + δ(N), where the increment δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) depends ONLY on N mod 8 and takes the eight values 0,0,−1,−2,−3,−3,−4,−5. The sibling namespace LagrangeFourSquaresWaringG2OQ03OQ05 is opened so its recursion and zero-base facts are reused verbatim.",
+      "mathContext": "E(N) = E(⌈N/4⌉) + δ(N), δ(N) = ⌊(N mod 8 + 3)/4⌋ − (N mod 8) ∈ {0,0,−1,−2,−3,−3,−4,−5}."
+    },
+    {
       "id": "one-sided-section",
       "title": "One-Sided Sharpness",
       "startLine": 56,


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01`.

The entry was already richly enriched on main (full overview with 5 keyInsights, 3 sections, 6 annotations, 3 top-level openQuestions). This pass closes the **one remaining coverage gap**: neither sections nor annotations reached the docstring (lines 1–54), which carries the core mathematical exposition — the telescoped error `E(N) = E(⌈N/4⌉) + δ(N)` and the mod-8 increment table that drives the whole proof.

## Changes
- **`setup-section`** (lines 1–54): summarizes the central reduction (parent recursion → telescoped per-step increment δ(N) depending only on N mod 8, table {0,0,−1,−2,−3,−3,−4,−5}).
- **`residue-reduction`** annotation (lines 20–50): explains the single observation collapsing the two-variable error analysis to eight numbers — sign settles one-sidedness, most-sustainable entry fixes the Θ(log N) growth.

Sections and annotations now span the full 172-line file from line 1. No existing content removed; axiom/status metadata unchanged (verified, 0 axioms, 0 sorries — accurate).