### PR TITLE
research(inclusion-exclusion-oq-04-oq-01): derangements as an instance of the inclusion–exclusion sieve [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2902,6 +2902,7 @@ import Proofs.InclusionExclusionOQ01
 import Proofs.InclusionExclusionOQ01OQ03
 import Proofs.InclusionExclusionOQ03
 import Proofs.InclusionExclusionSieve
+import Proofs.InclusionExclusionSieveDerangements
 import Proofs.InfinitudePrimes
 import Proofs.InfinitudePrimes3k2
 import Proofs.InfinitudePrimes4k1

--- a/proofs/Proofs/InclusionExclusionSieveDerangements.lean
+++ b/proofs/Proofs/InclusionExclusionSieveDerangements.lean
@@ -1,0 +1,222 @@
+import Mathlib.Combinatorics.Derangements.Finite
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Tactic
+import Proofs.InclusionExclusionSieve
+
+/-
+# Derangements as an Instance of the Inclusion–Exclusion Sieve
+
+## What This Proves
+This file answers the first open question of `InclusionExclusionSieve` ("The Sieve (Dual)
+Form of Inclusion–Exclusion"):
+
+> Instantiate the sieve to derive the derangement count
+> `D_n = n! · Σ_k (-1)^k / k!` directly as "permutations avoiding every fixed-point set".
+
+A **derangement** of `Fin n` is a permutation with no fixed point. We realise the set of
+derangements as the "avoid" set of the sieve, taking the universe to be `Equiv.Perm (Fin n)`
+and the bad property `i` to be "the permutation fixes the point `i`". The sieve
+`InclusionExclusionSieve.card_avoid_sieve` then yields the **closed sieve form**
+
+    D_n  =  Σ_{k=0}^n (-1)^k · C(n,k) · (n-k)!,
+
+and, dividing each binomial term, the classical exponential form
+
+    D_n  =  n! · Σ_{k=0}^n (-1)^k / k!.
+
+## Why This Is Not Already in the Gallery / Mathlib
+Mathlib's `numDerangements_sum` and the gallery file `DerangementsOQ03` both prove closed
+forms for `D_n`, but **via the recurrence** `D_{n+2} = (n+1)(D_n + D_{n+1})` and induction.
+The derivation here is conceptually different: it is the *textbook inclusion–exclusion*
+argument, obtained as a genuine instance of the general dual sieve proved in the parent file.
+The binomial sieve form `Σ_k (-1)^k C(n,k)(n-k)!` is, to our knowledge, not stated elsewhere
+in the gallery (which records the `ascFactorial` form and the `n!·Σ 1/k!` form).
+
+## Crux
+The one piece of real counting is:
+
+    #{ σ ∈ Perm (Fin n) : σ fixes every point of `t` }  =  (n - |t|)!,
+
+proved by the Mathlib equivalence `Equiv.Perm.subtypeEquivSubtypePerm`, which identifies
+permutations fixing the complement of a subtype with permutations of that subtype.
+
+## Status
+- [x] Complete proof, no `sorry`, no `axiom`
+- [x] No `native_decide`; the worked example uses `decide`, so the file is axiom-free.
+
+## Mathlib / Gallery Dependencies
+- `InclusionExclusionSieve.card_avoid_sieve` : the general dual sieve (parent file)
+- `Equiv.Perm.subtypeEquivSubtypePerm` : perms fixing the complement ≃ perms of the subtype
+- `card_derangements_eq_numDerangements`, `Fintype.card_perm`, `Finset.powerset_card_disjiUnion`
+-/
+
+namespace InclusionExclusionSieveDerangements
+
+open Equiv Finset
+
+variable {n : ℕ}
+
+/-- The set of permutations of `Fin n` that fix the point `i`. This is the `i`-th "bad
+property" whose avoidance defines a derangement. -/
+def fixSet (i : Fin n) : Finset (Perm (Fin n)) :=
+  univ.filter (fun σ => σ i = i)
+
+@[simp] theorem mem_fixSet (i : Fin n) (σ : Perm (Fin n)) : σ ∈ fixSet i ↔ σ i = i := by
+  simp [fixSet]
+
+/-
+## Part I: The crux count — permutations fixing a prescribed set pointwise
+
+The intersection `t.inf fixSet` is the set of permutations fixing every point of `t`. We
+first identify it as a filter, then count it via `subtypeEquivSubtypePerm`.
+-/
+
+/-- The intersection of the fixed-point sets over `t` is exactly the permutations fixing
+every point of `t`. -/
+theorem inf_fixSet_eq_filter (t : Finset (Fin n)) :
+    t.inf fixSet = univ.filter (fun σ : Perm (Fin n) => ∀ i ∈ t, σ i = i) := by
+  ext σ
+  simp [fixSet, Finset.mem_inf]
+
+/-- **Crux count.** The number of permutations of `Fin n` fixing every point of a finite set
+`t` equals `(n - |t|)!` — the number of ways to permute the remaining `n - |t|` points.
+
+Proved by the Mathlib equivalence `Equiv.Perm.subtypeEquivSubtypePerm`, which identifies the
+permutations fixing the complement of `{x // x ∉ t}` with permutations of that subtype. -/
+theorem card_fixesOn (t : Finset (Fin n)) :
+    (univ.filter (fun σ : Perm (Fin n) => ∀ i ∈ t, σ i = i)).card = (n - t.card).factorial := by
+  -- predicate-level equivalence:  (∀ a, ¬(a ∉ t) → σ a = a)  ↔  (∀ i ∈ t, σ i = i)
+  have hpred : ∀ σ : Perm (Fin n),
+      (∀ a, ¬(a ∉ t) → σ a = a) ↔ (∀ i ∈ t, σ i = i) := by
+    intro σ
+    constructor
+    · intro h i hi; exact h i (by simpa using hi)
+    · intro h a ha; exact h a (by simpa using ha)
+  -- card of the subtype of permutations fixing `t` pointwise
+  have key : Fintype.card {σ : Perm (Fin n) // ∀ i ∈ t, σ i = i} = (n - t.card).factorial := by
+    have e :
+        Perm {x : Fin n // x ∉ t} ≃ {σ : Perm (Fin n) // ∀ i ∈ t, σ i = i} :=
+      (Equiv.Perm.subtypeEquivSubtypePerm (fun x : Fin n => x ∉ t)).trans
+        (Equiv.subtypeEquivRight hpred)
+    have hcompl : Fintype.card {x : Fin n // x ∉ t} = n - t.card := by
+      have h := Fintype.card_subtype_compl (p := fun x : Fin n => x ∈ t)
+      simp only [Fintype.card_fin, Fintype.card_coe] at h
+      exact h
+    calc Fintype.card {σ : Perm (Fin n) // ∀ i ∈ t, σ i = i}
+        = Fintype.card (Perm {x : Fin n // x ∉ t}) := (Fintype.card_congr e).symm
+      _ = (Fintype.card {x : Fin n // x ∉ t}).factorial := Fintype.card_perm
+      _ = (n - t.card).factorial := by rw [hcompl]
+  rw [← key, Fintype.card_subtype]
+
+/-
+## Part II: The avoid set is the set of derangements
+-/
+
+/-- The "avoid" set of the sieve — permutations lying in *none* of the `fixSet i` — is the set
+of derangements, so it has cardinality `numDerangements n`. -/
+theorem card_avoid_eq_numDerangements :
+    (univ.inf (fun i : Fin n => (fixSet i)ᶜ)).card = numDerangements n := by
+  have h1 : univ.inf (fun i : Fin n => (fixSet i)ᶜ)
+      = univ.filter (fun σ : Perm (Fin n) => ∀ i, σ i ≠ i) := by
+    ext σ; simp [fixSet, Finset.mem_inf]
+  rw [h1, ← Fintype.card_subtype (fun σ : Perm (Fin n) => ∀ i, σ i ≠ i)]
+  have hd : Fintype.card (derangements (Fin n)) = numDerangements n := by
+    rw [card_derangements_eq_numDerangements, Fintype.card_fin]
+  rw [← hd]
+  exact Fintype.card_congr (Equiv.subtypeEquivRight (fun _ => Iff.rfl))
+
+/-
+## Part III: The closed sieve form of the derangement count
+
+Applying `card_avoid_sieve` and grouping the powerset sum by cardinality `k` (there are
+`C(n,k)` subsets of size `k`, each contributing `(-1)^k (n-k)!`) gives the binomial form.
+-/
+
+/-- **The sieve form of the derangement count.** Derived directly from the general
+inclusion–exclusion sieve `InclusionExclusionSieve.card_avoid_sieve`:
+
+    D_n = Σ_{k=0}^n (-1)^k · C(n,k) · (n-k)!.
+
+This is the textbook inclusion–exclusion derivation, independent of the recurrence-based
+proof of `numDerangements_sum`. -/
+theorem numDerangements_eq_sieve_sum (n : ℕ) :
+    (numDerangements n : ℤ) =
+      ∑ k ∈ Finset.range (n + 1),
+        (-1 : ℤ) ^ k * (n.choose k : ℤ) * ((n - k).factorial : ℤ) := by
+  have hsieve := InclusionExclusionSieve.card_avoid_sieve (univ : Finset (Fin n)) fixSet
+  rw [card_avoid_eq_numDerangements] at hsieve
+  rw [hsieve, Finset.powerset_card_disjiUnion, Finset.sum_disjiUnion]
+  -- now: Σ_{k ∈ range (univ.card + 1)} Σ_{t ∈ univ.powersetCard k} (-1)^|t| |⋂ fixSet| = RHS
+  rw [Finset.card_univ, Fintype.card_fin]
+  apply Finset.sum_congr rfl
+  intro k _hk
+  have hconst : ∀ t ∈ (univ : Finset (Fin n)).powersetCard k,
+      (-1 : ℤ) ^ t.card * ((t.inf fixSet).card : ℤ)
+        = (-1 : ℤ) ^ k * ((n - k).factorial : ℤ) := by
+    intro t ht
+    have htk : t.card = k := (Finset.mem_powersetCard.mp ht).2
+    rw [inf_fixSet_eq_filter, card_fixesOn, htk]
+  rw [Finset.sum_congr rfl hconst, Finset.sum_const, Finset.card_powersetCard,
+    Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  ring
+
+/-
+## Part IV: The exponential form, recovered from the sieve
+
+Each binomial term factors as `C(n,k)(n-k)! = n!/k!`, so the sieve sum collapses to the
+classical `n! · Σ (-1)^k / k!`. We derive this here from the sieve form above (not from the
+recurrence), literally answering the open question.
+-/
+
+/-- **The exponential closed form, derived from the sieve.**
+
+    D_n = n! · Σ_{k=0}^n (-1)^k / k!.
+
+Obtained from `numDerangements_eq_sieve_sum` by the identity `C(n,k)(n-k)! = n!/k!`. -/
+theorem numDerangements_eq_factorial_mul_altSum (n : ℕ) :
+    (numDerangements n : ℝ)
+      = (n.factorial : ℝ) * ∑ k ∈ Finset.range (n + 1), (-1 : ℝ) ^ k / (k.factorial : ℝ) := by
+  have hz := numDerangements_eq_sieve_sum n
+  have hr : (numDerangements n : ℝ)
+      = ∑ k ∈ Finset.range (n + 1),
+          (-1 : ℝ) ^ k * (n.choose k : ℝ) * ((n - k).factorial : ℝ) := by
+    have h := congrArg (Int.cast : ℤ → ℝ) hz
+    push_cast at h
+    exact h
+  rw [hr, Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k hk
+  have hkn : k ≤ n := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+  have hk0 : (k.factorial : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_pos k).ne'
+  have hfac : (n.choose k : ℝ) * (k.factorial : ℝ) * ((n - k).factorial : ℝ)
+      = (n.factorial : ℝ) := by
+    exact_mod_cast Nat.choose_mul_factorial_mul_factorial hkn
+  have hquot : (n.choose k : ℝ) * ((n - k).factorial : ℝ)
+      = (n.factorial : ℝ) / (k.factorial : ℝ) := by
+    rw [eq_div_iff hk0]; linear_combination hfac
+  rw [mul_assoc, hquot]
+  ring
+
+/-
+## Part V: Concrete check (axiom-free)
+
+`D_4 = 9`, verified against the sieve sum `Σ_{k=0}^4 (-1)^k C(4,k)(4-k)!
+= 24 - 24 + 12 - 4 + 1 = 9`, with `decide` (not `native_decide`).
+-/
+
+/-- The sieve form specialised to `n = 4`. -/
+example : (numDerangements 4 : ℤ) =
+    ∑ k ∈ Finset.range 5, (-1 : ℤ) ^ k * (Nat.choose 4 k : ℤ) * ((4 - k).factorial : ℤ) :=
+  numDerangements_eq_sieve_sum 4
+
+/-- The sieve sum evaluates to `9 = D_4`. -/
+example :
+    (∑ k ∈ Finset.range 5, (-1 : ℤ) ^ k * (Nat.choose 4 k : ℤ) * ((4 - k).factorial : ℤ)) = 9 := by
+  decide
+
+#check @numDerangements_eq_sieve_sum
+#check @numDerangements_eq_factorial_mul_altSum
+#check @card_fixesOn
+
+end InclusionExclusionSieveDerangements

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "inclusion-exclusion-oq-04-oq-01",
+  "slug": "inclusion-exclusion-oq-04-oq-01",
+  "title": "Derangements as an Instance of the Inclusion–Exclusion Sieve",
+  "description": "Answers the first open question of inclusion-exclusion-oq-04 (The Sieve/Dual Form of Inclusion–Exclusion): instantiate the general sieve to derive the derangement count D_n directly as 'permutations avoiding every fixed-point set'. Working over the universe Equiv.Perm (Fin n), the bad property i is 'the permutation fixes the point i' (fixSet i := {σ | σ i = i}); a permutation avoiding all of them is exactly a derangement. The parent's general sieve card_avoid_sieve then yields the closed sieve form D_n = Σ_{k=0}^n (-1)^k C(n,k) (n-k)!, and dividing each binomial term (C(n,k)(n-k)! = n!/k!) collapses it to the classical exponential form D_n = n! Σ_{k=0}^n (-1)^k/k!. The single piece of real counting is the crux lemma card_fixesOn: the permutations fixing a prescribed set t pointwise number (n − |t|)!, proved via Mathlib's Equiv.Perm.subtypeEquivSubtypePerm. This is the textbook inclusion–exclusion derivation of the derangement formula, conceptually distinct from the recurrence-based proofs of Mathlib's numDerangements_sum and the gallery's DerangementsOQ03 (which obtain closed forms from D_{n+2}=(n+1)(D_n+D_{n+1})). Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius (Researcher)",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InclusionExclusionSieveDerangements.lean",
+    "tags": [
+      "combinatorics",
+      "inclusion-exclusion",
+      "sieve",
+      "derangements",
+      "permutations",
+      "counting",
+      "factorial"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "InclusionExclusionSieve.card_avoid_sieve",
+        "description": "The parent file's general dual sieve: #(elements in none of the S_i) = Σ_{t⊆s} (-1)^|t| |⋂_{i∈t} S_i|. Applied with universe Equiv.Perm (Fin n), index set univ : Finset (Fin n), and S i = fixSet i = {σ | σ i = i}, it is the engine that turns the derangement count into the alternating powerset sum.",
+        "module": "Proofs.InclusionExclusionSieve"
+      },
+      {
+        "theorem": "Equiv.Perm.subtypeEquivSubtypePerm",
+        "description": "Perm (Subtype p) ≃ {f : Perm α // ∀ a, ¬p a → f a = a}: permutations of a subtype correspond to permutations of the whole type that fix the complement pointwise. With p = (· ∉ t) this is the crux of card_fixesOn — it identifies permutations fixing t pointwise with permutations of the (n − |t|)-element complement.",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Fintype.card_perm",
+        "description": "Fintype.card (Perm α) = (Fintype.card α)!. Supplies the (n − |t|)! count once the permutations fixing t are identified with the permutations of the complement.",
+        "module": "Mathlib.Data.Fintype.Perm"
+      },
+      {
+        "theorem": "card_derangements_eq_numDerangements",
+        "description": "Fintype.card (derangements α) = numDerangements (Fintype.card α). Identifies the cardinality of the sieve's 'avoid' set with the standard subfactorial numDerangements n, linking the inclusion-exclusion output to Mathlib's derangement counter.",
+        "module": "Mathlib.Combinatorics.Derangements.Finite"
+      },
+      {
+        "theorem": "Finset.powerset_card_disjiUnion",
+        "description": "s.powerset = (range (|s|+1)).disjiUnion (fun k => s.powersetCard k). Together with Finset.card_powersetCard (#(powersetCard k s) = C(|s|,k)) it groups the alternating powerset sum by subset size k, converting Σ_{t⊆univ} into Σ_{k=0}^n C(n,k)·(−1)^k(n−k)!.",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "C(n,k)·k!·(n−k)! = n! for k ≤ n. Used to rewrite each binomial sieve term C(n,k)(n−k)! as n!/k!, collapsing the closed sieve form into the exponential form n!·Σ(−1)^k/k!.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ],
+    "originalContributions": [
+      "numDerangements_eq_sieve_sum: the closed sieve form of the derangement count, D_n = Σ_{k=0}^n (-1)^k C(n,k) (n-k)!, derived directly from the general inclusion-exclusion sieve card_avoid_sieve rather than from the D_{n+2}=(n+1)(D_n+D_{n+1}) recurrence. This binomial-coefficient form is not otherwise recorded in the gallery (which has Mathlib's ascFactorial form and the n!·Σ1/k! form).",
+      "card_fixesOn: the crux count — the permutations of Fin n fixing every point of a finite set t number exactly (n − |t|)!. Proved by composing Mathlib's Equiv.Perm.subtypeEquivSubtypePerm (perms fixing the complement of a subtype ≃ perms of the subtype) with Fintype.card_perm and Fintype.card_subtype_compl; no explicit extension/restriction bijection is hand-built.",
+      "card_avoid_eq_numDerangements: identifies the sieve's 'avoid' set univ.inf (fun i => (fixSet i)ᶜ) over Perm (Fin n) with the set of derangements, so its cardinality is numDerangements n — the structural observation that makes the sieve applicable.",
+      "numDerangements_eq_factorial_mul_altSum: the classical exponential closed form D_n = n!·Σ_{k=0}^n (-1)^k/k!, recovered from the sieve form (not the recurrence) via the per-term identity C(n,k)(n-k)! = n!/k! — literally the formula the open question names.",
+      "fixSet i := univ.filter (fun σ => σ i = i): modeling 'the permutation fixes point i' as the i-th bad property over the universe Equiv.Perm (Fin n), the reformulation that lets the parent's dual sieve be applied verbatim with the ground type instantiated to permutations."
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "inclusion-exclusion-oq-04",
+        "relationship": "Answers open question oq-01. The parent entry proves the dual/sieve form of inclusion-exclusion (card_avoid_sieve) and asks to 'instantiate the sieve to derive the derangement count D_n = n!Σ(-1)^k/k! directly as permutations avoiding every fixed-point set'. This entry does exactly that, importing card_avoid_sieve and instantiating its ground type with Equiv.Perm (Fin n)."
+      },
+      {
+        "id": "derangements",
+        "relationship": "Provides a second, inclusion-exclusion-based proof of the derangement formula. The Derangements entry and DerangementsOQ03 obtain the closed forms from the two-step recurrence D_{n+2}=(n+1)(D_n+D_{n+1}); this entry obtains them from the sieve, the classical textbook route."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 222,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. n : ℕ is arbitrary. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for numDerangements_eq_sieve_sum, numDerangements_eq_factorial_mul_altSum, and card_fixesOn — no sorryAx, no Lean.ofReduceBool. The worked example D_4 = 9 uses decide (kernel reduction), not native_decide, so the file remains axiom-free.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "proofRepoPath": null,
+  "leanFile": {
+    "path": "Proofs/InclusionExclusionSieveDerangements.lean",
+    "imports": [
+      "Mathlib.Combinatorics.Derangements.Finite",
+      "Mathlib.Data.Fintype.Perm",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Tactic",
+      "Proofs.InclusionExclusionSieve"
+    ],
+    "opens": [
+      "Equiv",
+      "Finset"
+    ],
+    "namespace": "InclusionExclusionSieveDerangements",
+    "lineCount": 222,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 6,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionSieveDerangements.lean"
+  },
+  "overview": "A derangement of {1,…,n} is a permutation with no fixed point; the count D_n (the subfactorial !n) is the prototypical application of inclusion–exclusion. This entry realises that application formally. Taking the ground set to be all permutations of Fin n and the n 'bad properties' to be 'fixes point i', a permutation that avoids every bad property is exactly a derangement, so the parent file's dual sieve immediately expresses D_n as an alternating sum over subsets of the points. Grouping the subsets by size and counting permutations fixing a given subset pointwise — the crux (n − |t|)! count — gives the binomial closed form Σ_k (-1)^k C(n,k)(n-k)!, and one algebraic identity per term yields the famous n!·Σ(-1)^k/k!. The whole derivation is an instance of a single general theorem, exactly as the open question requests.",
+  "sections": [
+    {
+      "id": "fixsets-and-crux",
+      "title": "Fixed-Point Sets and the Crux Count",
+      "startLine": 53,
+      "endLine": 109,
+      "mathContext": "$\\text{fixSet}(i) := \\{\\sigma \\mid \\sigma(i)=i\\}, \\qquad \\#\\{\\sigma : \\forall i\\in t,\\ \\sigma(i)=i\\} = (n-|t|)!$",
+      "summary": "fixSet i is the i-th bad property — permutations fixing point i. inf_fixSet_eq_filter identifies the intersection over a set t with the permutations fixing every point of t. card_fixesOn is the one real count: those permutations number (n − |t|)!, proved by Equiv.Perm.subtypeEquivSubtypePerm identifying them with permutations of the (n−|t|)-element complement."
+    },
+    {
+      "id": "avoid-is-derangements",
+      "title": "The Avoid Set Is the Derangements",
+      "startLine": 110,
+      "endLine": 142,
+      "mathContext": "$\\#\\bigl(\\textstyle\\bigsqcap_i \\text{fixSet}(i)^{c}\\bigr) = \\#\\,\\text{derangements}(\\mathrm{Fin}\\,n) = D_n$",
+      "summary": "card_avoid_eq_numDerangements identifies the sieve's 'avoid' set (permutations in none of the fixSet i) with the set of derangements of Fin n, so its cardinality is numDerangements n. This is the structural step that makes the general sieve applicable to the derangement count."
+    },
+    {
+      "id": "closed-forms",
+      "title": "The Closed Sieve Form and the Exponential Form",
+      "startLine": 143,
+      "endLine": 207,
+      "mathContext": "$D_n = \\sum_{k=0}^n (-1)^k \\binom{n}{k}(n-k)! = n!\\sum_{k=0}^n \\frac{(-1)^k}{k!}$",
+      "summary": "numDerangements_eq_sieve_sum applies card_avoid_sieve and groups the powerset sum by subset size (C(n,k) subsets of size k, each contributing (-1)^k(n-k)!) to give the binomial closed form. numDerangements_eq_factorial_mul_altSum then rewrites each term via C(n,k)(n-k)! = n!/k! to recover the classical exponential form — both derived from the sieve, not the recurrence."
+    }
+  ],
+  "conclusion": {
+    "summary": "The derangement count is obtained as a genuine instance of the inclusion–exclusion sieve proved in the parent file. Over the universe of permutations of Fin n, with bad property i being 'fixes point i', avoiding all bad properties means being a derangement; the general sieve card_avoid_sieve then gives D_n = Σ_{k=0}^n (-1)^k C(n,k)(n-k)!, and the per-term identity C(n,k)(n-k)! = n!/k! collapses this to D_n = n!·Σ_{k=0}^n (-1)^k/k!. The only nontrivial count is that the permutations fixing a prescribed set of size m number (n−m)!. Verified, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "This is the textbook derivation of the derangement formula, made formal as a one-line instantiation of a reusable theorem — demonstrating that the gallery's dual sieve really does power the classical enumeration it was built for. It also adds the binomial-coefficient closed form Σ_k(-1)^k C(n,k)(n-k)! to the gallery (which previously had only Mathlib's ascFactorial form and the n!·Σ1/k! form, both via the recurrence), and gives an inclusion-exclusion-based proof of the exponential form independent of D_{n+2}=(n+1)(D_n+D_{n+1}).",
+    "openQuestions": [
+      "Instantiate the same sieve to derive the surjection count #(surjections [n]↠[k]) = Σ_j (-1)^j C(k,j)(k-j)^n, taking the bad property j to be 'value j is missed' — the crux count being |intersection over a j-set of missed values| = (k-|J|)^n.",
+      "Prove the Bonferroni inequalities for this instance: truncating the derangement sieve sum at an even (resp. odd) partial sum over-counts (resp. under-counts) D_n, a one-sided bound following from the alternating structure of the powerset sum."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Section 2.2 derives the derangement count D_n = n!Σ(-1)^k/k! as the canonical first application of the sieve form of inclusion-exclusion, exactly the derivation formalized here."
+    },
+    {
+      "authors": "van Lint, J. H.; Wilson, R. M.",
+      "title": "A Course in Combinatorics",
+      "year": "2001",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Chapter 10 presents the inclusion-exclusion sieve and obtains the derangement and surjection counts as its two flagship instances."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion-oq-04",
+      "relationship": "extends",
+      "description": "Answers open question oq-01 by instantiating the parent's general dual sieve card_avoid_sieve to the permutation universe, deriving the derangement count as the 'avoid every fixed-point set' instance."
+    },
+    {
+      "targetId": "derangements",
+      "relationship": "related",
+      "description": "Gives a second, inclusion-exclusion-based proof of the derangement closed forms, complementing the recurrence-based proofs in Derangements and DerangementsOQ03."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `inclusion-exclusion-oq-04` (*The Sieve / Dual Form of Inclusion–Exclusion*):

> Instantiate the sieve to derive the derangement count $D_n = n!\sum_k (-1)^k/k!$ directly as 'permutations avoiding every fixed-point set'.

Working over the universe `Equiv.Perm (Fin n)`, the $i$-th bad property is *'the permutation fixes the point $i$'* (`fixSet i := {σ | σ i = i}`). A permutation avoiding **all** of them is exactly a derangement, so the parent file's general dual sieve `card_avoid_sieve` expresses $D_n$ as an alternating sum over subsets of the points. Grouping by subset size gives the **closed sieve form**, and one algebraic identity per term collapses it to the classical exponential form.

$$D_n = \sum_{k=0}^n (-1)^k \binom{n}{k}(n-k)! = n!\sum_{k=0}^n \frac{(-1)^k}{k!}$$

## Why this is not a wrapper

Mathlib's `numDerangements_sum` and the gallery's `DerangementsOQ03` already prove closed forms for $D_n$ — but **via the recurrence** $D_{n+2}=(n+1)(D_n+D_{n+1})$ and induction. This entry gives the *textbook inclusion–exclusion* derivation instead, as a genuine instance of the parent's general sieve. The binomial-coefficient form $\sum_k(-1)^k\binom{n}{k}(n-k)!$ is new to the gallery (which previously had only the `ascFactorial` form and the $n!\sum 1/k!$ form).

## Key results

| Theorem | Statement |
|---|---|
| `card_fixesOn` | permutations fixing a set $t$ pointwise number $(n-|t|)!$ (crux; via `Equiv.Perm.subtypeEquivSubtypePerm`) |
| `card_avoid_eq_numDerangements` | the sieve's *avoid* set over `Perm (Fin n)` is the derangements, cardinality `numDerangements n` |
| `numDerangements_eq_sieve_sum` | $D_n = \sum_k (-1)^k\binom{n}{k}(n-k)!$, **derived from the sieve** |
| `numDerangements_eq_factorial_mul_altSum` | $D_n = n!\sum_k(-1)^k/k!$, recovered from the sieve via $\binom{n}{k}(n-k)!=n!/k!$ |

## Verification

- **222 lines, 6 theorems + 1 def, 0 sorries.**
- `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` for all three headline theorems — **no `Lean.ofReduceBool`, no `sorryAx`.**
- The worked example $D_4 = 9$ uses `decide` (kernel reduction), **not** `native_decide`, so the file stays axiom-free.
- Built against Mathlib 4.26.0 + the parent `Proofs.InclusionExclusionSieve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)