### PR TITLE
Enrich The Multiplier–QR Reduction for Three-Square Sufficiency

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/index.ts
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeFourSquaresWaringG2Oq03Oq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeFourSquaresWaringG2Oq03Oq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeFourSquaresWaringG2Oq03Oq07Data: ProofData = {
+  proof: lagrangeFourSquaresWaringG2Oq03Oq07Proof,
+  annotations: lagrangeFourSquaresWaringG2Oq03Oq07Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-07`.

This entry shipped with only a `meta.json` — it was missing the `index.ts` (so the proof page would show "proof not found" on the live site), an `annotations.json`, a top-level `description`, and the `overview`/`sections` blocks.

## Changes
- **index.ts** (REQUIRED): created so the proof loads on the site.
- **annotations.json**: 7 annotations covering every theorem and lemma (`natCast_mul_eq_one`, `legendreSym_neg_multiplier_eq`, the product-square argument, the selection criteria, `coprime_pred_self`, `exists_multiplier_prime`, `exists_multiplier_prime_qr_reduces`). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **overview**: `historicalContext` (Legendre 1798, Gauss 1801, Dirichlet 1850, and the Mathlib PrimesInAP dependency), `problemStatement`, `proofStrategy`, and 5 `keyInsights`.
- **sections**: 6 sections covering the full 171-line Lean file.
- **description**: top-level summary added.

## Verification
- `pnpm build` succeeds (`tsc -b` clean, `vite build` OK; proof appears in generated `listings.json` and `public/data/proofs/`).
- Axiom integrity preserved: `status: verified`, `badge: original`, `axiomCount: 0` — the Lean file has no `axiom`/`sorry`/`native_decide` and no assumption-carrying structures, consistent with the metadata.