### PR TITLE
research(divisibility-by-3-oq-02-oq-01): alternating digit-sum rule for b+1 in every base [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -854,6 +854,7 @@ import Proofs.DissectionOfCubesOQ04
 import Proofs.DissectionOfCubesOQ04Aristotle
 import Proofs.DivisibilityBy3
 import Proofs.DivisibilityBy3OQ02
+import Proofs.DivisibilityBy3OQ02OQ01
 import Proofs.DivisibilityBy3OQ03
 import Proofs.DivisibilityBy3OQ03OQ02
 import Proofs.DivisibilityBy3OQ04

--- a/proofs/Proofs/DivisibilityBy3OQ02OQ01.lean
+++ b/proofs/Proofs/DivisibilityBy3OQ02OQ01.lean
@@ -1,0 +1,184 @@
+import Mathlib
+
+/-
+# The Alternating Digit-Sum Rule for b+1 (OQ-02-OQ-01)
+
+## What This Proves
+The companion of the base-b digit-sum rule. The parent OQ-02 file establishes the
+"sum of digits" test for `b - 1` (because `b ≡ 1 (mod b-1)`).  Here we establish the
+**alternating** sum of digits test for `b + 1`:
+
+  For every base `b` and every `n`,
+      n ≡ alternatingSum(digits b n)   (mod b+1),
+  hence
+      (b+1) ∣ n   ↔   (b+1) ∣ alternatingSum(digits b n).
+
+This is the universal principle behind the classical "divisibility by 11" test in
+base 10 (alternate adding and subtracting digits), and it works in *every* base:
+  * base 10 → divisibility by **11**  (recovers `Nat.eleven_dvd_iff`)
+  * base  2 → divisibility by **3**   (alternating bit sum)
+  * base  8 → divisibility by **9**
+  * base 16 → divisibility by **17**
+  * base 12 → divisibility by **13**, etc.
+
+## Key Mathematical Insight
+Since `b ≡ -1 (mod b+1)`, every power `b^k ≡ (-1)^k (mod b+1)`.  Therefore
+
+  n = ∑ dᵢ · bⁱ  ≡  ∑ dᵢ · (-1)ⁱ  =  alternating digit sum   (mod b+1).
+
+The alternating sum is taken in `ℤ` (it can be negative), so the congruences are
+stated with `[ZMOD (b+1)]` and `(b+1 : ℤ) ∣ …`.
+
+## Relation to Mathlib
+Mathlib proves the **base-10 specialization** only:
+  `Nat.modEq_eleven_digits_sum` and `Nat.eleven_dvd_iff` (theorem #85 of Freek's list).
+Both go through the generic facts
+  `Nat.zmodeq_ofDigits_digits`, `Nat.dvd_iff_dvd_ofDigits`, `Nat.ofDigits_neg_one`.
+We promote those generic facts to the full base-`b → (b+1)` family — the content the
+OQ asks for — and recover the base-10 rule as a corollary, plus new instances in other
+bases that Mathlib does not provide.
+
+## Status
+- [x] `b ≡ -1 (mod b+1)` (the driving congruence)
+- [x] General congruence  n ≡ alternatingSum [ZMOD b+1]
+- [x] General divisibility iff  (b+1) ∣ n ↔ (b+1) ∣ alternatingSum
+- [x] Recovers Mathlib's base-10 `eleven_dvd_iff`
+- [x] New base instances: binary→3, octal→9, hex→17, duodecimal→13
+- [x] Even-length palindrome ⟹ (b+1) ∣ n (generalizes `eleven_dvd_of_palindrome`)
+- [x] Numerical verifications
+-/
+
+namespace DivisibilityBy3OQ02OQ01
+
+open Nat
+
+/-- Convenience notation: the alternating sum of the base-`b` digits of `n`, taken in `ℤ`.
+    `altDigitSum b n = d₀ - d₁ + d₂ - d₃ + …` where `digits b n = [d₀, d₁, d₂, …]`. -/
+def altDigitSum (b n : ℕ) : ℤ :=
+  ((Nat.digits b n).map (fun k : ℕ => (k : ℤ))).alternatingSum
+
+-- ============================================================
+-- Part I: The Driving Congruence  b ≡ -1 (mod b+1)
+-- ============================================================
+
+/-- The base is congruent to `-1` modulo `b+1`. This is what makes alternating sums work:
+    `b ≡ -1` forces `b^k ≡ (-1)^k`. -/
+theorem base_zmodEq_neg_one (b : ℕ) : (b : ℤ) ≡ -1 [ZMOD (b + 1 : ℕ)] := by
+  -- `b ≡ -1 [ZMOD b+1]`  ↔  `(b+1) ∣ (-1 - b)`  and  `-1 - b = (b+1)·(-1)`.
+  rw [Int.modEq_iff_dvd]
+  push_cast
+  exact ⟨-1, by ring⟩
+
+-- ============================================================
+-- Part II: The General Alternating Digit-Sum Congruence
+-- ============================================================
+
+/-- **The (b+1) congruence.** In any base `b`, a number is congruent to the alternating
+    sum of its base-`b` digits modulo `b + 1`. -/
+theorem modEq_altDigitSum (b n : ℕ) :
+    (n : ℤ) ≡ altDigitSum b n [ZMOD (b + 1 : ℕ)] := by
+  have t := Nat.zmodeq_ofDigits_digits (b + 1) b (-1 : ℤ) (base_zmodEq_neg_one b) n
+  rwa [Nat.ofDigits_neg_one] at t
+
+/-- The alternating sum determines the residue of `n` modulo `b + 1`
+    (an `Int.emod` reformulation of `modEq_altDigitSum`). -/
+theorem emod_altDigitSum (b n : ℕ) :
+    (n : ℤ) % (b + 1 : ℕ) = altDigitSum b n % (b + 1 : ℕ) :=
+  modEq_altDigitSum b n
+
+-- ============================================================
+-- Part III: The General Divisibility Rule
+-- ============================================================
+
+/-- **The (b+1) divisibility rule.** In any base `b`, `b + 1` divides `n` iff `b + 1`
+    divides the alternating sum of the base-`b` digits of `n`. -/
+theorem succ_dvd_iff_altDigitSum (b n : ℕ) :
+    (b + 1) ∣ n ↔ ((b + 1 : ℕ) : ℤ) ∣ altDigitSum b n := by
+  have t := Nat.dvd_iff_dvd_ofDigits (b + 1) b (-1 : ℤ)
+    (by push_cast; exact ⟨1, by ring⟩) n
+  rwa [Nat.ofDigits_neg_one] at t
+
+/-- The same rule with the modulus written directly over `ℤ`. -/
+theorem succ_dvd_iff_altDigitSum' (b n : ℕ) :
+    (b + 1) ∣ n ↔ ((b : ℤ) + 1) ∣ altDigitSum b n := by
+  rw [succ_dvd_iff_altDigitSum]; push_cast; rfl
+
+-- ============================================================
+-- Part IV: Recovering Mathlib's Base-10 Rule (Consistency)
+-- ============================================================
+
+/-- Base 10 specialization of the congruence — definitionally Mathlib's
+    `Nat.modEq_eleven_digits_sum`. -/
+theorem modEq_eleven (n : ℕ) :
+    (n : ℤ) ≡ ((Nat.digits 10 n).map (fun k : ℕ => (k : ℤ))).alternatingSum [ZMOD 11] :=
+  modEq_altDigitSum 10 n
+
+/-- Base 10 specialization of the divisibility rule: this is Mathlib's
+    `Nat.eleven_dvd_iff`, recovered from the general theorem. -/
+theorem eleven_dvd_iff (n : ℕ) :
+    11 ∣ n ↔ (11 : ℤ) ∣ ((Nat.digits 10 n).map (fun k : ℕ => (k : ℤ))).alternatingSum :=
+  succ_dvd_iff_altDigitSum 10 n
+
+-- ============================================================
+-- Part V: New Base Instances (not in Mathlib)
+-- ============================================================
+
+/-- **Binary → 3**: `3 ∣ n` iff `3` divides the alternating sum of the *bits* of `n`. -/
+theorem three_dvd_iff_binary (n : ℕ) :
+    3 ∣ n ↔ (3 : ℤ) ∣ altDigitSum 2 n :=
+  succ_dvd_iff_altDigitSum 2 n
+
+/-- **Octal → 9**: `9 ∣ n` iff `9` divides the alternating sum of the base-8 digits. -/
+theorem nine_dvd_iff_octal (n : ℕ) :
+    9 ∣ n ↔ (9 : ℤ) ∣ altDigitSum 8 n :=
+  succ_dvd_iff_altDigitSum 8 n
+
+/-- **Hexadecimal → 17**: `17 ∣ n` iff `17` divides the alternating sum of the hex digits. -/
+theorem seventeen_dvd_iff_hex (n : ℕ) :
+    17 ∣ n ↔ (17 : ℤ) ∣ altDigitSum 16 n :=
+  succ_dvd_iff_altDigitSum 16 n
+
+/-- **Duodecimal → 13**: `13 ∣ n` iff `13` divides the alternating sum of the base-12 digits. -/
+theorem thirteen_dvd_iff_duodecimal (n : ℕ) :
+    13 ∣ n ↔ (13 : ℤ) ∣ altDigitSum 12 n :=
+  succ_dvd_iff_altDigitSum 12 n
+
+-- ============================================================
+-- Part VI: Even-Length Palindromes
+-- ============================================================
+
+/-- **Even-length palindromes are divisible by b+1.** If the base-`b` digit list of `n`
+    is a palindrome of even length, then `(b+1) ∣ n`. Generalizes Mathlib's
+    `Nat.eleven_dvd_of_palindrome` (the base-10 case) to every base. -/
+theorem succ_dvd_of_palindrome {b n : ℕ}
+    (p : (Nat.digits b n).Palindrome) (h : Even (Nat.digits b n).length) :
+    (b + 1) ∣ n := by
+  let dig := (Nat.digits b n).map (fun k : ℕ => (k : ℤ))
+  have hlen : Even dig.length := by rwa [List.length_map]
+  rw [succ_dvd_iff_altDigitSum]
+  refine ⟨0, (?_ : altDigitSum b n = 0)⟩
+  have hrev := dig.alternatingSum_reverse
+  rw [(p.map _).reverse_eq, _root_.pow_succ', hlen.neg_one_pow, mul_one, neg_one_zsmul] at hrev
+  exact eq_zero_of_neg_eq hrev.symm
+
+-- ============================================================
+-- Part VII: Numerical Verifications
+-- ============================================================
+
+/-- `121 = 11²`, base-10 digits `[1,2,1]`, alternating sum `1 - 2 + 1 = 0`, so `11 ∣ 121`. -/
+example : 11 ∣ 121 := by rw [eleven_dvd_iff]; native_decide
+
+/-- `132 = 11·12`, alternating digit sum `2 - 3 + 1 = 0`, so `11 ∣ 132`. -/
+example : 11 ∣ 132 := by rw [eleven_dvd_iff]; native_decide
+
+/-- `123` is **not** divisible by 11 (alternating sum `3 - 2 + 1 = 2`). -/
+example : ¬ (11 ∣ 123) := by rw [eleven_dvd_iff]; native_decide
+
+/-- Binary check: `9 = 0b1001`, bits `[1,0,0,1]`, alternating sum `1 - 0 + 0 - 1 = 0`,
+    so `3 ∣ 9`. -/
+example : 3 ∣ 9 := by rw [three_dvd_iff_binary]; native_decide
+
+/-- Hex check: `17 = 0x11`, hex digits `[1,1]`, alternating sum `1 - 1 = 0`, so `17 ∣ 17`. -/
+example : 17 ∣ 17 := by rw [seventeen_dvd_iff_hex]; native_decide
+
+end DivisibilityBy3OQ02OQ01

--- a/src/data/proofs/divisibility-by-3-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-02-oq-01/meta.json
@@ -1,0 +1,241 @@
+{
+  "id": "divisibility-by-3-oq-02-oq-01",
+  "slug": "divisibility-by-3-oq-02-oq-01",
+  "title": "The Alternating Digit-Sum Rule for b+1 (Divisibility by 11 in Every Base)",
+  "description": "The companion of the base-b digit-sum rule. Where the parent OQ-02 proves the 'sum of digits' test for b−1 (because b ≡ 1 mod b−1), this proves the alternating sum of digits test for b+1: for every base b and every n, n ≡ d₀ − d₁ + d₂ − ⋯ (mod b+1), hence (b+1) ∣ n ↔ (b+1) ∣ alternating digit sum. This is the universal principle behind the classical divisibility-by-11 test in base 10, and it holds in every base: base 2 → 3, base 8 → 9, base 10 → 11, base 16 → 17, base 12 → 13. Mathlib formalizes only the base-10/eleven specialization (theorem #85); this promotes the generic machinery to the full base-b → (b+1) family and recovers Nat.eleven_dvd_iff as a corollary.",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Nat"],
+    "namespace": "DivisibilityBy3OQ02OQ01",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "mainTheorems": [
+      {
+        "name": "modEq_altDigitSum",
+        "type": "original",
+        "description": "The (b+1) congruence: in any base b, n ≡ alternating digit sum (mod b+1)",
+        "leanType": "(b n : ℕ) → (n : ℤ) ≡ altDigitSum b n [ZMOD (b + 1 : ℕ)]"
+      },
+      {
+        "name": "succ_dvd_iff_altDigitSum",
+        "type": "original",
+        "description": "The (b+1) divisibility rule: (b+1) ∣ n ↔ (b+1) ∣ alternating sum of base-b digits",
+        "leanType": "(b n : ℕ) → (b + 1) ∣ n ↔ ((b + 1 : ℕ) : ℤ) ∣ altDigitSum b n"
+      },
+      {
+        "name": "base_zmodEq_neg_one",
+        "type": "original",
+        "description": "The driving congruence b ≡ −1 (mod b+1) that makes alternating sums work",
+        "leanType": "(b : ℕ) → (b : ℤ) ≡ -1 [ZMOD (b + 1 : ℕ)]"
+      },
+      {
+        "name": "eleven_dvd_iff",
+        "type": "application",
+        "description": "Base-10 specialization recovering Mathlib's Nat.eleven_dvd_iff from the general rule",
+        "leanType": "(n : ℕ) → 11 ∣ n ↔ (11 : ℤ) ∣ ((Nat.digits 10 n).map (fun k : ℕ => (k : ℤ))).alternatingSum"
+      },
+      {
+        "name": "succ_dvd_of_palindrome",
+        "type": "original",
+        "description": "Even-length base-b palindromes are divisible by b+1 (generalizes Nat.eleven_dvd_of_palindrome)",
+        "leanType": "{b n : ℕ} → (Nat.digits b n).Palindrome → Even (Nat.digits b n).length → (b + 1) ∣ n"
+      }
+    ],
+    "path": "Proofs/DivisibilityBy3OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Alternating digit-sum divisibility rule (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Divisibility_rule",
+    "date": "Ancient",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "divisibility",
+      "digit-sums",
+      "research",
+      "open-problem"
+    ],
+    "proofRepoPath": "Proofs/DivisibilityBy3OQ02OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "prerequisites": [
+      "modular arithmetic",
+      "digit representation",
+      "alternating sums"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.zmodeq_ofDigits_digits",
+        "description": "n ≡ ofDigits c (digits b' n) [ZMOD b] when (b' : ℤ) ≡ c [ZMOD b]",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Nat.dvd_iff_dvd_ofDigits",
+        "description": "b ∣ n ↔ (b : ℤ) ∣ ofDigits c (digits b' n) when (b : ℤ) ∣ (b' : ℤ) − c",
+        "module": "Mathlib.Data.Nat.Digits.Div"
+      },
+      {
+        "theorem": "Nat.ofDigits_neg_one",
+        "description": "ofDigits (−1) L = (L.map (↑·)).alternatingSum",
+        "module": "Mathlib.Data.Nat.Digits.Lemmas"
+      },
+      {
+        "theorem": "Int.modEq_iff_dvd",
+        "description": "a ≡ b [ZMOD n] ↔ n ∣ b − a",
+        "module": "Mathlib.Data.Int.GCD"
+      },
+      {
+        "theorem": "List.alternatingSum_reverse",
+        "description": "l.reverse.alternatingSum = (−1)^(l.length+1) • l.alternatingSum",
+        "module": "Mathlib.Algebra.BigOperators.Associated"
+      }
+    ],
+    "originalContributions": [
+      "base_zmodEq_neg_one: b ≡ −1 (mod b+1), the driving congruence behind alternating-sum tests",
+      "modEq_altDigitSum: the general congruence n ≡ alternating digit sum (mod b+1) for every base b",
+      "succ_dvd_iff_altDigitSum: the universal (b+1) divisibility rule for arbitrary base b",
+      "Recovers Mathlib's base-10 Nat.eleven_dvd_iff and Nat.modEq_eleven_digits_sum as corollaries",
+      "New base instances absent from Mathlib: binary→3, octal→9, hexadecimal→17, duodecimal→13",
+      "succ_dvd_of_palindrome: even-length base-b palindromes are divisible by b+1, generalizing Nat.eleven_dvd_of_palindrome from base 10 to every base"
+    ],
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 184,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "relatedProblems": [
+      {
+        "id": "divisibility-by-3-oq-02",
+        "relationship": "Parent: OQ-02 proves the (b−1) digit-sum rule via b ≡ 1 (mod b−1); this companion proves the (b+1) alternating-sum rule via b ≡ −1 (mod b+1)"
+      }
+    ],
+    "assumptions": "0 axioms, 0 sorries. The alternating-sum congruence is derived from Mathlib's generic Nat.zmodeq_ofDigits_digits, Nat.dvd_iff_dvd_ofDigits, and Nat.ofDigits_neg_one; Mathlib itself proves only the base-10 specialization (divisibility by 11). The five numerical checks use native_decide but appear only in anonymous examples, so no named theorem depends on Lean.ofReduceBool — all named results depend solely on propext/Classical.choice/Quot.sound.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The divisibility-by-11 test — alternately adding and subtracting the decimal digits — is classical, and appears as Theorem #85 on Freek Wiedijk's '100 theorems' list, where it is formalized in Mathlib for base 10. Its algebraic root is that 10 ≡ −1 (mod 11), the exact mirror of the casting-out-nines principle 10 ≡ 1 (mod 9) behind the parent digit-sum rule. The two tests are the two extreme residues b ≡ ±1: where b−1 collapses every power b^k to 1 (giving plain digit sums), b+1 collapses b^k to (−1)^k (giving alternating sums). This formalization promotes Mathlib's base-10 result to arbitrary bases, exhibiting divisibility by 11 as one instance of a universal phenomenon: in every base b, the alternating digit sum determines the residue modulo b+1.",
+    "problemStatement": "**The Alternating Digit-Sum Rule for b+1:**\n\nFor every base b and every n ∈ ℕ, writing the base-b digits of n as $d_0, d_1, d_2, \\dots$,\n$$n \\equiv d_0 - d_1 + d_2 - d_3 + \\cdots \\pmod{b+1}$$\nand consequently\n$$(b+1) \\mid n \\iff (b+1) \\mid \\sum_i (-1)^i d_i.$$\nIn base 10 this is the divisibility-by-11 test; in base 2 it tests divisibility by 3, in base 8 by 9, in base 16 by 17.",
+    "text": "A 184-line formalization answering the first open question of OQ-02: can the alternating digit-sum rule for b+1 be formalized? It can, and uniformly across all bases. The driving fact is `base_zmodEq_neg_one`: b ≡ −1 (mod b+1), proved in one step from `Int.modEq_iff_dvd` since −1 − b = (b+1)·(−1). Feeding this into Mathlib's generic `Nat.zmodeq_ofDigits_digits` and rewriting with `Nat.ofDigits_neg_one` yields `modEq_altDigitSum`: n ≡ alternating digit sum (mod b+1) for every base b. The same input through `Nat.dvd_iff_dvd_ofDigits` yields the divisibility iff `succ_dvd_iff_altDigitSum`. Specializing b = 10 recovers Mathlib's `Nat.eleven_dvd_iff` and `Nat.modEq_eleven_digits_sum` verbatim, confirming the general theory subsumes the library's base-10 result; specializing to b = 2, 8, 16, 12 gives divisibility tests by 3, 9, 17, 13 that Mathlib does not provide. Finally `succ_dvd_of_palindrome` generalizes Mathlib's `Nat.eleven_dvd_of_palindrome`: any number whose base-b digit list is an even-length palindrome is divisible by b+1, because the reversal symmetry forces the alternating sum to vanish. Five `native_decide` numerical checks (121, 132, 123 mod 11; 9 mod 3; 17 mod 17) confine all kernel-reduction trust to anonymous examples.",
+    "proofStrategy": "Both main theorems factor through one congruence b ≡ −1 (mod b+1). Since b ≡ −1, every power b^k ≡ (−1)^k, so n = Σ dᵢ·bⁱ ≡ Σ dᵢ·(−1)ⁱ = alternating digit sum (mod b+1). This is exactly Mathlib's `ofDigits` evaluated at −1, which `Nat.ofDigits_neg_one` identifies with `List.alternatingSum`. The generic transfer lemmas `Nat.zmodeq_ofDigits_digits` (congruence form) and `Nat.dvd_iff_dvd_ofDigits` (divisibility form) then give the two rules immediately; the only base-specific input is the trivial divisibility (b+1) ∣ (b+1).",
+    "keyInsights": [
+      "b ≡ −1 (mod b+1) is the universal principle behind every alternating digit-sum test, mirroring b ≡ 1 (mod b−1) for plain digit sums",
+      "Divisibility by 11 in base 10 is one instance of a family: base 2 → 3, base 8 → 9, base 16 → 17, base 12 → 13",
+      "The alternating sum lives in ℤ (it can be negative), so the natural statements use [ZMOD (b+1)] and (b+1 : ℤ) ∣ ·",
+      "Mathlib's base-10 eleven_dvd_iff and modEq_eleven_digits_sum fall out as one-line corollaries, confirming the generalization is faithful",
+      "Even-length palindromes are divisible by b+1 in every base: the reverse-symmetry of the digit list forces the alternating sum to zero"
+    ],
+    "prerequisites": [
+      "modular arithmetic",
+      "digit representation",
+      "alternating sums"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header, Imports, and the altDigitSum Definition",
+      "startLine": 1,
+      "endLine": 67,
+      "summary": "Imports Mathlib, documents the companion relationship to the parent (b−1) rule, lists the base instances covered, and defines altDigitSum b n as the ℤ-valued alternating sum of the base-b digits of n.",
+      "mathContext": "The universal principle: b ≡ −1 (mod b+1), so n = Σ dᵢ bⁱ ≡ Σ dᵢ (−1)ⁱ = alternating digit sum (mod b+1). This mirrors the parent's b ≡ 1 (mod b−1)."
+    },
+    {
+      "id": "driving-congruence",
+      "title": "Part I — The Driving Congruence b ≡ −1 (mod b+1)",
+      "startLine": 68,
+      "endLine": 80,
+      "summary": "Proves base_zmodEq_neg_one: (b : ℤ) ≡ −1 [ZMOD (b+1)], via Int.modEq_iff_dvd since −1 − b = (b+1)·(−1). This single fact drives both main theorems.",
+      "mathContext": "b ≡ −1 forces b^k ≡ (−1)^k, the algebraic reason alternating sums detect divisibility by b+1."
+    },
+    {
+      "id": "congruence",
+      "title": "Part II — The General Alternating Digit-Sum Congruence",
+      "startLine": 81,
+      "endLine": 97,
+      "summary": "Proves modEq_altDigitSum: n ≡ altDigitSum b n (mod b+1) for every base b, by feeding the driving congruence into Mathlib's Nat.zmodeq_ofDigits_digits and rewriting with Nat.ofDigits_neg_one. Adds an Int.emod reformulation.",
+      "mathContext": "n's residue mod b+1 equals the alternating digit sum's residue — the casting-out-elevens invariant, in every base."
+    },
+    {
+      "id": "divisibility",
+      "title": "Part III — The General Divisibility Rule",
+      "startLine": 98,
+      "endLine": 117,
+      "summary": "Proves succ_dvd_iff_altDigitSum (and an ℤ-modulus variant): (b+1) ∣ n ↔ (b+1) ∣ altDigitSum b n, via Nat.dvd_iff_dvd_ofDigits with the trivial input (b+1) ∣ (b+1).",
+      "mathContext": "The divisibility test proper: b+1 divides n exactly when it divides the alternating digit sum."
+    },
+    {
+      "id": "base-10",
+      "title": "Part IV — Recovering Mathlib's Base-10 Rule",
+      "startLine": 118,
+      "endLine": 134,
+      "summary": "Specializes b = 10 to recover Nat.modEq_eleven_digits_sum (modEq_eleven) and Nat.eleven_dvd_iff (eleven_dvd_iff), confirming the general theory faithfully reproduces Mathlib's base-10 divisibility-by-11 test.",
+      "mathContext": "Consistency check: the library's Theorem #85 is the b = 10 instance of the general family."
+    },
+    {
+      "id": "new-bases",
+      "title": "Part V — New Base Instances (not in Mathlib)",
+      "startLine": 135,
+      "endLine": 159,
+      "summary": "Derives divisibility tests Mathlib does not provide: three_dvd_iff_binary (base 2 → 3), nine_dvd_iff_octal (base 8 → 9), seventeen_dvd_iff_hex (base 16 → 17), thirteen_dvd_iff_duodecimal (base 12 → 13).",
+      "mathContext": "The same one-line specialization produces an unbounded family of divisibility tests."
+    },
+    {
+      "id": "palindromes",
+      "title": "Part VI — Even-Length Palindromes",
+      "startLine": 160,
+      "endLine": 172,
+      "summary": "Proves succ_dvd_of_palindrome: if the base-b digit list of n is an even-length palindrome then (b+1) ∣ n, generalizing Mathlib's Nat.eleven_dvd_of_palindrome from base 10 to every base via List.alternatingSum_reverse.",
+      "mathContext": "Reverse-symmetry of an even-length palindrome forces its alternating sum to vanish, hence b+1 divides n."
+    },
+    {
+      "id": "verifications",
+      "title": "Part VII — Numerical Verifications",
+      "startLine": 173,
+      "endLine": 184,
+      "summary": "Five native_decide sanity checks: 11 ∣ 121, 11 ∣ 132, 11 ∤ 123 (base 10); 3 ∣ 9 (binary); 17 ∣ 17 (hex). All are anonymous examples, so no named theorem depends on Lean.ofReduceBool.",
+      "mathContext": "Concrete instances bridging the abstract congruence with arithmetic the reader can check by hand."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete 0-axiom, 0-sorry formalization of the alternating digit-sum rule for b+1, answering the first open question of OQ-02. The universal principle b ≡ −1 (mod b+1) explains divisibility-by-11 in base 10 (recovering Mathlib's Theorem #85) and yields divisibility tests by b+1 in every base, plus an even-length-palindrome corollary.",
+    "implications": "Together with the parent (b−1) digit-sum rule, this completes the picture of the two extreme residues b ≡ ±1 (mod m): plain digit sums detect divisibility by b−1 and its factors, alternating digit sums detect divisibility by b+1. Every base b thus carries two free divisibility tests, one for b−1 and one for b+1, both computable from the digit list alone.",
+    "openQuestions": [
+      "Can the two rules be unified into a single weighted-digit framework handling arbitrary moduli m with b of small order mod m (e.g. divisibility by 7 in base 10, where 10 has order 6)?",
+      "Does the even-length-palindrome divisibility result have a converse or a characterization of which palindromic patterns force divisibility by b+1 versus b−1?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "divisibility-by-3-oq-02",
+      "relationship": "extends",
+      "description": "OQ-02 proves the (b−1) digit-sum rule via b ≡ 1 (mod b−1); this companion proves the (b+1) alternating-sum rule via b ≡ −1 (mod b+1), the mirror-image residue"
+    },
+    {
+      "targetId": "divisibility-by-3",
+      "relationship": "related",
+      "description": "The root proof formalizes the base-10 divisibility-by-3 rule (10 ≡ 1 mod 3); this generalizes the complementary 10 ≡ −1 mod 11 alternating-sum test to every base"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Wiedijk, Freek",
+      "title": "Formalizing 100 Theorems (Theorem #85: Divisibility by 11)",
+      "year": "2008",
+      "venue": "https://www.cs.ru.nl/~freek/100/",
+      "note": "The base-10 alternating digit-sum test for 11; formalized in Mathlib as Nat.eleven_dvd_iff, recovered here as the b = 10 instance of the general rule"
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Standard reference for positional notation and digit-based divisibility tests (casting out nines and elevens)"
+    }
+  ],
+  "sorries": []
+}


### PR DESCRIPTION
## Summary

Answers the **first open question of OQ-02** (Base-b Divisibility Rules): *"Can the alternating digit sum rule (for b+1) be formalized? E.g., 11 | n ↔ alternating digit sum divisible by 11."*

It can — and uniformly across **every** base. Where the parent OQ-02 proves the plain digit-sum test for `b−1` (because `b ≡ 1 mod b−1`), this companion proves the **alternating** digit-sum test for `b+1` (because `b ≡ −1 mod b+1`):

> For every base `b` and every `n`:  `n ≡ d₀ − d₁ + d₂ − ⋯  (mod b+1)`,  hence  `(b+1) ∣ n ↔ (b+1) ∣ alternating digit sum`.

## What's new vs Mathlib

Mathlib formalizes only the **base-10 / divisibility-by-11** specialization (`Nat.eleven_dvd_iff`, `Nat.modEq_eleven_digits_sum` — Theorem #85 of Freek's list). This promotes the generic machinery (`Nat.zmodeq_ofDigits_digits`, `Nat.dvd_iff_dvd_ofDigits`, `Nat.ofDigits_neg_one`) to the **full base-b → (b+1) family**:

- `base_zmodEq_neg_one` — the driving congruence `b ≡ −1 (mod b+1)`
- `modEq_altDigitSum` — `n ≡ alternating digit sum (mod b+1)` for every base `b`
- `succ_dvd_iff_altDigitSum` — the universal `(b+1)` divisibility rule
- `eleven_dvd_iff` / `modEq_eleven` — recovers Mathlib's base-10 result as a corollary (consistency check)
- New instances Mathlib lacks: **binary→3, octal→9, hexadecimal→17, duodecimal→13**
- `succ_dvd_of_palindrome` — even-length base-`b` palindromes are divisible by `b+1` (generalizes `Nat.eleven_dvd_of_palindrome`)

## Verification

- **184 lines, 12 theorems, 1 definition, 0 axioms, 0 sorries**
- Compiles clean under Lean 4.26.0 / Mathlib
- `#print axioms` on all named theorems: only `propext`, `Classical.choice`, `Quot.sound` (the foundational axioms that do not count). No `Lean.ofReduceBool`, no `sorryAx`.
- The five `native_decide` numerical checks appear only in anonymous `example`s, so no named theorem trusts kernel reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)