### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-01): weighted Chebyshev sum inequality from a monovariance hypothesis [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -672,6 +672,7 @@ import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChebyshevPNTBridgeOQ03
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevSumMonotoneOQ01
+import Proofs.ChebyshevSumWeightedOQ01OQ01
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ05

--- a/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01.lean
+++ b/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01.lean
@@ -1,0 +1,211 @@
+import Mathlib
+
+/-
+# Weighted Chebyshev sum inequality from a monovariance hypothesis
+
+The Mathlib Chebyshev file (`Mathlib/Algebra/Order/Chebyshev.lean`) proves the
+*unweighted* sum inequality
+
+  (∑ i ∈ s, f i) * (∑ i ∈ s, g i) ≤ #s * ∑ i ∈ s, f i * g i
+
+for `MonovaryOn f g s` (equivalently, similarly sorted sequences), and the reverse
+inequality for `AntivaryOn`. It has **no** weighted analogue.
+
+This file fills that gap. Given nonnegative weights `w : ι → ℝ` with total mass
+`W = ∑ i ∈ s, w i`, and `f`, `g` monovarying on `s`, we prove the
+**weighted Chebyshev sum inequality**
+
+  (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i) ≤ W * ∑ i ∈ s, w i * f i * g i,
+
+and the reverse for antivarying `f`, `g`. Taking `w ≡ 1` recovers the Mathlib `#s`
+form, so this is a strict generalization.
+
+The engine is the **weighted monovariance identity**
+
+  2 (W·∑ wᵢfᵢgᵢ − (∑ wᵢfᵢ)(∑ wᵢgᵢ))
+    = ∑ᵢ ∑ⱼ wᵢ wⱼ (fᵢ − fⱼ)(gᵢ − gⱼ),
+
+whose right-hand side is a sum of products of nonnegative factors (each
+`(fᵢ − fⱼ)(gᵢ − gⱼ) ≥ 0` because `f` and `g` monovary), hence `≥ 0`.
+
+All results are fully verified with no extra axioms.
+-/
+
+namespace ChebyshevSumWeighted
+
+open Finset
+
+variable {ι : Type*} {s : Finset ι} {w f g : ι → ℝ}
+
+/-! ## The sign lemmas for monovarying / antivarying pairs -/
+
+/-- If `f` and `g` monovary on `s`, then for any two indices `i, j ∈ s` the cross
+difference `(f i - f j) * (g i - g j)` is nonnegative: the two factors always carry the
+same sign. -/
+theorem sub_mul_sub_nonneg_of_monovaryOn (hfg : MonovaryOn f g s) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) : 0 ≤ (f i - f j) * (g i - g j) := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · -- `g i < g j` forces `f i ≤ f j`: both factors are `≤ 0`.
+    have hf : f i ≤ f j := hfg hi hj h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f j - f i)
+      (by linarith : (0 : ℝ) ≤ g j - g i)]
+  · -- equal `g`-values kill the second factor.
+    have : g i - g j = 0 := by linarith
+    rw [this, mul_zero]
+  · -- `g j < g i` forces `f j ≤ f i`: both factors are `≥ 0`.
+    have hf : f j ≤ f i := hfg hj hi h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f i - f j)
+      (by linarith : (0 : ℝ) ≤ g i - g j)]
+
+/-- If `f` and `g` antivary on `s`, then `(f i - f j) * (g i - g j) ≤ 0` for all
+`i, j ∈ s`: the two factors always carry opposite signs. -/
+theorem sub_mul_sub_nonpos_of_antivaryOn (hfg : AntivaryOn f g s) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) : (f i - f j) * (g i - g j) ≤ 0 := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · -- `g i < g j` forces `f j ≤ f i`: first factor `≥ 0`, second `≤ 0`.
+    have hf : f j ≤ f i := hfg hi hj h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f i - f j)
+      (by linarith : (0 : ℝ) ≤ g j - g i)]
+  · have : g i - g j = 0 := by linarith
+    rw [this, mul_zero]
+  · -- `g j < g i` forces `f i ≤ f j`: first factor `≤ 0`, second `≥ 0`.
+    have hf : f i ≤ f j := hfg hj hi h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f j - f i)
+      (by linarith : (0 : ℝ) ≤ g i - g j)]
+
+/-! ## The weighted monovariance identity -/
+
+/-- **Weighted monovariance identity.** The symmetric double sum of
+`wᵢ wⱼ (fᵢ − fⱼ)(gᵢ − gⱼ)` equals twice the Chebyshev defect
+`W·∑ wᵢfᵢgᵢ − (∑ wᵢfᵢ)(∑ wᵢgᵢ)`. This holds for arbitrary real data — no sign or
+monotonicity hypothesis is needed. -/
+theorem two_mul_chebyshev_defect_eq (w f g : ι → ℝ) (s : Finset ι) :
+    ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))
+      = 2 * ((∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i)
+        - 2 * ((∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i) := by
+  -- The four "monomial" double sums, each collapsing to a product of two single sums.
+  have h1 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g i)
+      = (∑ i ∈ s, w i * f i * g i) * ∑ j ∈ s, w j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h2 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g j)
+      = (∑ i ∈ s, w i) * ∑ j ∈ s, w j * f j * g j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h3 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g j)
+      = (∑ i ∈ s, w i * f i) * ∑ j ∈ s, w j * g j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h4 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g i)
+      = (∑ i ∈ s, w i * g i) * ∑ j ∈ s, w j * f j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  -- Expand the summand and split the double sum into the four monomial pieces.
+  have hsplit : ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))
+      = (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g i))
+        - (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g j))
+        - (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g i))
+        + (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g j)) := by
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun j _ => by ring
+  rw [hsplit, h1, h2, h3, h4]
+  ring
+
+/-! ## Weighted Chebyshev inequalities -/
+
+/-- **Weighted Chebyshev sum inequality** (similarly sorted data). For nonnegative
+weights `w` and functions `f`, `g` that monovary on `s`, the product of the weighted
+sums is at most the total weight times the weighted sum of products. With `w ≡ 1` this
+is the Mathlib lemma `MonovaryOn.sum_mul_sum_le_card_mul_sum`. -/
+theorem weighted_sum_mul_sum_le (hfg : MonovaryOn f g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i := by
+  have hD : 0 ≤ ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) := by
+    refine Finset.sum_nonneg fun i hi => Finset.sum_nonneg fun j hj => ?_
+    have := sub_mul_sub_nonneg_of_monovaryOn hfg hi hj
+    have hwi := hw i hi
+    have hwj := hw j hj
+    positivity
+  rw [two_mul_chebyshev_defect_eq] at hD
+  linarith
+
+/-- **Reverse weighted Chebyshev sum inequality** (oppositely sorted data). For
+nonnegative weights and `f`, `g` antivarying on `s`, the inequality reverses. With
+`w ≡ 1` this is `AntivaryOn.card_mul_sum_le_sum_mul_sum`. -/
+theorem weighted_antivary_le_sum_mul_sum (hfg : AntivaryOn f g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ≤ (∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i := by
+  have hD : ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) ≤ 0 := by
+    refine Finset.sum_nonpos fun i hi => Finset.sum_nonpos fun j hj => ?_
+    have hsign := sub_mul_sub_nonpos_of_antivaryOn hfg hi hj
+    have hwi := hw i hi
+    have hwj := hw j hj
+    have : 0 ≤ w i * w j := mul_nonneg hwi hwj
+    nlinarith [mul_nonneg this (neg_nonneg.mpr hsign)]
+  rw [two_mul_chebyshev_defect_eq] at hD
+  linarith
+
+/-! ## Monotone-sequence corollaries -/
+
+variable [LinearOrder ι]
+
+/-- **Weighted Chebyshev for monotone data.** If `f` and `g` are monotone on `s`, they
+monovary there, so the weighted Chebyshev inequality applies. This is the form named in
+the open question: a weighted inequality for similarly sorted (monotone) sequences. -/
+theorem weighted_chebyshev_monotoneOn (hf : MonotoneOn f s) (hg : MonotoneOn g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i :=
+  weighted_sum_mul_sum_le (hf.monovaryOn hg) hw
+
+/-- **Reverse weighted Chebyshev for oppositely monotone data.** If `f` is monotone and
+`g` is antitone on `s`, the weighted inequality reverses. -/
+theorem weighted_chebyshev_antitoneOn (hf : MonotoneOn f s) (hg : AntitoneOn g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ≤ (∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i :=
+  weighted_antivary_le_sum_mul_sum (hf.antivaryOn hg) hw
+
+/-! ## Weighted Cauchy–Schwarz corollary and unweighted recovery -/
+
+omit [LinearOrder ι] in
+/-- **Weighted Cauchy–Schwarz-type corollary.** The self-monovarying case `f = g` gives
+`(∑ wᵢfᵢ)² ≤ (∑ wᵢ)(∑ wᵢfᵢ²)`, a weighted power-mean / Cauchy–Schwarz bound, valid for
+*any* `f` (every function monovaries with itself). -/
+theorem weighted_sq_sum_le (w f : ι → ℝ) (s : Finset ι) (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) ^ 2 ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i ^ 2 := by
+  have h := weighted_sum_mul_sum_le (w := w) (monovaryOn_self f s) hw
+  rw [sq]
+  calc (∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * f i
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * f i := h
+    _ = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i ^ 2 := by
+          refine congrArg _ (Finset.sum_congr rfl fun i _ => ?_); ring
+
+omit [LinearOrder ι] in
+/-- Sanity check: with all weights equal to `1`, the weighted inequality collapses to the
+classical Mathlib `#s` form `(∑ f)(∑ g) ≤ #s · ∑ f g`. -/
+theorem unweighted_recovery (hfg : MonovaryOn f g s) :
+    (∑ i ∈ s, f i) * (∑ i ∈ s, g i) ≤ (#s : ℝ) * ∑ i ∈ s, f i * g i := by
+  have h := weighted_sum_mul_sum_le (w := fun _ => (1 : ℝ)) hfg (fun i _ => by norm_num)
+  simpa using h
+
+/-! ## Worked instance -/
+
+/-- A concrete weighted instance with weights `1, 2, 3` on the increasing sequence
+`0, 1, 2` (against itself), obtained from `weighted_sq_sum_le`. It evaluates to
+`(1·0 + 2·1 + 3·2)² = 64 ≤ 6 · (1·0² + 2·1² + 3·2²) = 6·14 = 84`. -/
+example :
+    (∑ i ∈ range 3, ((i : ℝ) + 1) * (i : ℝ)) ^ 2
+      ≤ (∑ i ∈ range 3, ((i : ℝ) + 1)) * ∑ i ∈ range 3, ((i : ℝ) + 1) * (i : ℝ) ^ 2 :=
+  weighted_sq_sum_le (fun i : ℕ => (i : ℝ) + 1) (fun i : ℕ => (i : ℝ)) (range 3)
+    fun i _ => by positivity
+
+/-- The instance above, with the sums evaluated: `64 ≤ 84`. -/
+example : ((0 : ℝ) + 2 * 1 + 3 * 2) ^ 2 ≤ (1 + 2 + 3) * (0 + 2 * 1 ^ 2 + 3 * 2 ^ 2) := by
+  norm_num
+
+end ChebyshevSumWeighted

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-01",
+  "title": "Weighted Chebyshev Sum Inequality from a Monovariance Hypothesis",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-01",
+  "description": "Mathlib's Chebyshev sum inequality (MonovaryOn.sum_mul_sum_le_card_mul_sum) has no weighted analogue: it only multiplies the sum of products by the cardinality #s. We prove the weighted version. For nonnegative weights w with total mass W = ∑ wᵢ and functions f, g that monovary on s, (∑ wᵢfᵢ)(∑ wᵢgᵢ) ≤ W·∑ wᵢfᵢgᵢ, together with the reverse inequality for antivarying f, g, the monotone-sequence corollaries, a weighted Cauchy–Schwarz square bound (∑ wᵢfᵢ)² ≤ W·∑ wᵢfᵢ², and a w ≡ 1 recovery of the Mathlib #s form. The engine is the weighted monovariance identity 2(W·∑ wᵢfᵢgᵢ − (∑ wᵢfᵢ)(∑ wᵢgᵢ)) = ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ − fⱼ)(gᵢ − gⱼ), whose right side is a sum of products of like-signed factors, hence nonnegative.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "inequalities",
+      "order",
+      "chebyshev-sum-inequality",
+      "weighted",
+      "monotone",
+      "cauchy-schwarz"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevSumWeightedOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 211,
+    "mathlibDependencies": [
+      {
+        "theorem": "MonovaryOn / AntivaryOn",
+        "description": "The order-correlation predicates: g i < g j → f i ≤ f j (monovary) resp. f j ≤ f i (antivary), supplying the sign of each cross difference (f i − f j)(g i − g j)",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "monovaryOn_self",
+        "description": "Every function monovaries with itself on any set — drives the weighted Cauchy–Schwarz square corollary",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "MonotoneOn.monovaryOn / MonotoneOn.antivaryOn",
+        "description": "Bridges turning monotone (resp. monotone-vs-antitone) hypotheses on a finite set into MonovaryOn / AntivaryOn, used for the monotone-sequence corollaries",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "Finset.sum_mul_sum",
+        "description": "(∑ i, a i)(∑ j, b j) = ∑ i ∑ j a i · b j — collapses each of the four monomial double sums in the monovariance identity to a product of single sums",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      }
+    ],
+    "originalContributions": [
+      "two_mul_chebyshev_defect_eq: the weighted monovariance identity ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) = 2(W·∑ wfg − (∑ wf)(∑ wg)), valid for arbitrary real data with no sign hypothesis — the algebraic heart absent from Mathlib",
+      "sub_mul_sub_nonneg_of_monovaryOn / sub_mul_sub_nonpos_of_antivaryOn: each cross difference (fᵢ−fⱼ)(gᵢ−gⱼ) is ≥ 0 under monovariance and ≤ 0 under antivariance, by trichotomy on g",
+      "weighted_sum_mul_sum_le: the weighted Chebyshev sum inequality (∑ wf)(∑ wg) ≤ W·∑ wfg for nonnegative weights and monovarying f, g — the result Mathlib lacks",
+      "weighted_antivary_le_sum_mul_sum: the reverse weighted inequality for antivarying f, g",
+      "weighted_chebyshev_monotoneOn / weighted_chebyshev_antitoneOn: the monotone-sequence forms named in the open question, via the monotone ⇒ monovary bridges",
+      "weighted_sq_sum_le: the weighted Cauchy–Schwarz / power-mean corollary (∑ wf)² ≤ W·∑ wf², the self-monovarying case",
+      "unweighted_recovery: with w ≡ 1 the bound collapses to Mathlib's classical #s form, confirming the generalization"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's sum inequality (1880s) states that for two similarly sorted real sequences the average of their products dominates the product of their averages. The weighted form replaces uniform averaging by a probability-like weighting wᵢ ≥ 0: with total mass W = ∑ wᵢ one still has (∑ wᵢfᵢ)(∑ wᵢgᵢ) ≤ W·∑ wᵢfᵢgᵢ. This is the discrete statement that two comonotone random variables on a finite probability space have nonnegative covariance, and it underlies the FKG / Chebyshev correlation inequalities. Mathlib formalises only the unweighted version, where the multiplier is the cardinality #s; the weighted generalization — the one that specialises to covariance for a genuine weight/measure — is missing.",
+    "problemStatement": "Let $s$ be a finite index set, $w : \\iota \\to \\mathbb{R}$ with $w_i \\ge 0$ for $i \\in s$, and write $W = \\sum_{i\\in s} w_i$. If $f, g$ monovary on $s$ (e.g. both monotone) then\n\n$$\\Big(\\sum_{i\\in s} w_i f_i\\Big)\\Big(\\sum_{i\\in s} w_i g_i\\Big) \\;\\le\\; W \\sum_{i\\in s} w_i f_i g_i,$$\n\nwith the inequality reversing when $f, g$ antivary. Specialise to monotone sequences, derive the weighted square bound $(\\sum_i w_i f_i)^2 \\le W \\sum_i w_i f_i^2$, and recover Mathlib's $\\#s$ form at $w \\equiv 1$.",
+    "proofStrategy": "The whole family rests on one identity and one sign fact.\n\n1. Weighted monovariance identity (two_mul_chebyshev_defect_eq): expand the symmetric double sum ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) into four monomial double sums; each collapses via Finset.sum_mul_sum to a product of single sums, giving exactly 2(W·∑ wfg − (∑ wf)(∑ wg)). No hypothesis on the data is used.\n\n2. Sign of the cross difference (sub_mul_sub_nonneg_of_monovaryOn): by trichotomy on g i vs g j, monovariance forces f and g to move together, so (fᵢ−fⱼ)(gᵢ−gⱼ) ≥ 0; antivariance forces opposite motion, giving ≤ 0.\n\n3. Weighted Chebyshev (weighted_sum_mul_sum_le): with wᵢ, wⱼ ≥ 0 and the cross differences ≥ 0, every summand of the double sum is ≥ 0, so the double sum is ≥ 0; rewriting it by the identity and dividing by 2 yields (∑ wf)(∑ wg) ≤ W·∑ wfg. The antivary version is identical with the sign reversed.\n\n4. Corollaries: the monotone forms compose the monotone ⇒ monovary bridges; the square bound is the self-monovarying case f = g; the unweighted recovery substitutes w ≡ 1 and simplifies ∑ 1 = #s.",
+    "keyInsights": [
+      "The identity 2(W·∑ wfg − (∑ wf)(∑ wg)) = ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) is a weighted 'sum of products' (covariance) identity — it holds for ALL real data, so the inequality is purely a statement about the sign of the cross differences.",
+      "Mathlib's #s form is the w ≡ 1 special case; weighting is exactly what turns Chebyshev's inequality into the nonnegative-covariance statement for a finite measure.",
+      "The nonnegativity argument never touches the cardinality: replacing the constant weight 1 by an arbitrary nonnegative weight changes nothing in the proof, only in the multiplier W = ∑ wᵢ.",
+      "Each cross difference's sign is the single place monotonicity enters; everything else is a weighted algebraic rearrangement, which is why the antivary case is a one-line sign flip.",
+      "The self-monovarying instance f = g gives a weighted Cauchy–Schwarz / variance bound (∑ wf)² ≤ W·∑ wf² for free, valid for any f."
+    ],
+    "prerequisites": [
+      "Finite sums over Finset and the double-sum factorization Finset.sum_mul_sum",
+      "The MonovaryOn / AntivaryOn order-correlation predicates and the monotone ⇒ monovary bridges",
+      "Chebyshev's sum inequality and its interpretation as nonnegative covariance",
+      "Basic ordered-field reasoning (sign of a product, nonnegativity of a sum of nonnegative terms)"
+    ]
+  },
+  "conclusion": {
+    "summary": "We proved the weighted Chebyshev sum inequality that Mathlib omits: for nonnegative weights w with total mass W and monovarying f, g, (∑ wf)(∑ wg) ≤ W·∑ wfg, with the antivarying reverse, the monotone-sequence corollaries, a weighted Cauchy–Schwarz square bound, and a w ≡ 1 recovery of the classical #s form. The engine is a weighted monovariance (covariance) identity proved from scratch, combined with a trichotomy sign lemma for the cross differences. All nine results are fully machine-checked with 0 sorries and depend only on the foundational axioms.",
+    "implications": "This supplies the weighted/measure-theoretic interface to Chebyshev's inequality directly over a finite index set: a user with a nonnegative weight (a finite measure, a probability vector) gets the correlation bound without re-deriving it, and the same identity yields the weighted variance bound. It answers the first open question of the unweighted companion (chebyshev-sum-inequality-oq-01) and is the natural stepping stone toward the continuous (integral) Chebyshev inequality, where the weight becomes a density.",
+    "openQuestions": [
+      "Establish the strict weighted inequality with its equality case: (∑ wf)(∑ wg) = W·∑ wfg iff f or g is constant on the support {i ∈ s : w i > 0}.",
+      "Extend the weighted bound to the continuous Chebyshev inequality ∫ f g dμ · μ(X) ≥ ∫ f dμ · ∫ g dμ for a finite measure μ and monotone f, g.",
+      "Derive the weighted power-mean / Cauchy–Schwarz chain (weighted Lᵖ monotonicity) from the weighted square bound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Imports, an expository docstring contrasting Mathlib's unweighted #s form with the weighted statement, and namespace plus variable setup."
+    },
+    {
+      "id": "sign-lemmas",
+      "title": "Sign of the Cross Differences",
+      "startLine": 40,
+      "endLine": 75,
+      "summary": "sub_mul_sub_nonneg_of_monovaryOn and sub_mul_sub_nonpos_of_antivaryOn: by trichotomy on g, each cross difference (f i − f j)(g i − g j) is ≥ 0 under monovariance and ≤ 0 under antivariance."
+    },
+    {
+      "id": "identity",
+      "title": "The Weighted Monovariance Identity",
+      "startLine": 76,
+      "endLine": 115,
+      "summary": "two_mul_chebyshev_defect_eq: the symmetric double sum equals twice the Chebyshev defect, proved by expanding into four monomial double sums and collapsing each via Finset.sum_mul_sum. Holds for arbitrary real data."
+    },
+    {
+      "id": "weighted-inequalities",
+      "title": "Weighted Chebyshev Inequalities",
+      "startLine": 116,
+      "endLine": 151,
+      "summary": "weighted_sum_mul_sum_le and weighted_antivary_le_sum_mul_sum: the double sum is nonnegative (resp. nonpositive) termwise, so the identity yields the weighted bound and its reverse."
+    },
+    {
+      "id": "monotone-corollaries",
+      "title": "Monotone-Sequence Corollaries",
+      "startLine": 152,
+      "endLine": 172,
+      "summary": "weighted_chebyshev_monotoneOn and weighted_chebyshev_antitoneOn: the forms named in the open question, obtained by composing the monotone ⇒ monovary / antivary bridges."
+    },
+    {
+      "id": "cauchy-schwarz-recovery",
+      "title": "Weighted Cauchy–Schwarz and Unweighted Recovery",
+      "startLine": 173,
+      "endLine": 195,
+      "summary": "weighted_sq_sum_le: the self-monovarying weighted square bound (∑ wf)² ≤ W·∑ wf². unweighted_recovery: substituting w ≡ 1 collapses the bound to Mathlib's classical #s form."
+    },
+    {
+      "id": "worked-instance",
+      "title": "Worked Instance",
+      "startLine": 196,
+      "endLine": 211,
+      "summary": "A concrete weighted instance with weights 1,2,3 against the sequence 0,1,2, evaluating to 64 ≤ 84, obtained from weighted_sq_sum_le."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The unweighted monotone-sequence Chebyshev inequality whose first open question (weighted form) this answers"
+    },
+    {
+      "targetId": "rearrangement-inequality-oq-01",
+      "relationship": "related",
+      "description": "Equality case of the unweighted Chebyshev sum inequality via the discrete covariance identity (rigidity companion)"
+    }
+  ],
+  "references": [
+    {
+      "text": "Hardy, G. H., Littlewood, J. E., Pólya, G. (1952). Inequalities, 2nd ed., Cambridge University Press (Chebyshev's inequality and weighted means).",
+      "url": "https://archive.org/details/Inequalities_201705"
+    },
+    {
+      "text": "Chebyshev's sum inequality.",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality"
+    },
+    {
+      "text": "Mathlib4: Algebra.Order.Chebyshev and Algebra.Order.Monovary.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Chebyshev.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ChebyshevSumWeighted",
+    "lineCount": 211,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevSumWeightedOQ01OQ01.lean",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `chebyshev-sum-inequality-oq-01`: *derive the weighted Chebyshev sum inequality for monotone sequences from a weighted monovariance hypothesis.*

Mathlib's Chebyshev sum inequality (`MonovaryOn.sum_mul_sum_le_card_mul_sum`) only ever multiplies the sum of products by the **cardinality** `#s` — it has **no weighted analogue**. This PR fills that gap. For nonnegative weights `w` with total mass `W = ∑ wᵢ` and `f, g` monovarying on `s`:

$$\Big(\sum_{i} w_i f_i\Big)\Big(\sum_{i} w_i g_i\Big) \le W \sum_{i} w_i f_i g_i,$$

with the reverse for antivarying `f, g`. Taking `w ≡ 1` recovers Mathlib's `#s` form, so this is a strict generalization (the weighted version is the one that specialises to *nonnegative covariance for a finite measure*).

## Engine

The **weighted monovariance (covariance) identity**, proved from scratch for arbitrary real data:

$$2\Big(W\!\cdot\!\textstyle\sum w f g - (\sum w f)(\sum w g)\Big) = \sum_i \sum_j w_i w_j (f_i - f_j)(g_i - g_j),$$

whose right-hand side is a sum of products of **like-signed** factors (each `(fᵢ−fⱼ)(gᵢ−gⱼ) ≥ 0` under monovariance, by trichotomy on `g`), hence `≥ 0`. The four monomial double sums each collapse via `Finset.sum_mul_sum`.

## Contents (9 theorems, 0 definitions, 211 lines)

- `two_mul_chebyshev_defect_eq` — the weighted monovariance identity (no sign hypothesis)
- `sub_mul_sub_nonneg_of_monovaryOn` / `sub_mul_sub_nonpos_of_antivaryOn` — sign of the cross differences
- `weighted_sum_mul_sum_le` — **the weighted Chebyshev inequality** (the missing result)
- `weighted_antivary_le_sum_mul_sum` — the reverse for antivarying data
- `weighted_chebyshev_monotoneOn` / `weighted_chebyshev_antitoneOn` — monotone-sequence forms named in the OQ
- `weighted_sq_sum_le` — weighted Cauchy–Schwarz / variance bound `(∑ wf)² ≤ W·∑ wf²`
- `unweighted_recovery` — `w ≡ 1` collapses to Mathlib's classical `#s` form

## Verification

- **0 sorries, 0 axioms** (`#print axioms` shows only `propext`, `Classical.choice`, `Quot.sound`)
- Builds against Mathlib **v4.26.0**
- `status: verified`, `badge: original` (the weighted inequality and its covariance identity are genuinely new, not in Mathlib)

🤖 Generated with [Claude Code](https://claude.com/claude-code)