### PR TITLE
seeker: top up candidate pool with 5 fresh gallery-grounded problems

### DIFF
--- a/research/problems/combinations-formula-oq-05-oq-01/problem.md
+++ b/research/problems/combinations-formula-oq-05-oq-01/problem.md
@@ -1,0 +1,115 @@
+# Problem: Telescoping Partial Alternating Binomial Sums
+
+**Slug**: combinations-formula-oq-05-oq-01
+**Created**: 2026-06-23
+**Status**: Active
+**Source**: gallery-gap <!-- open question of verified parent combinations-formula-oq-05 (full alternating-row cancellation) -->
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\sum_{k=0}^{j} (-1)^k \binom{n}{k} \;=\; (-1)^j \binom{n-1}{j}, \qquad 0 \le j \le n .
+$$
+
+The parent entry establishes the *full-row* cancellation $\sum_{k=0}^{n} (-1)^k \binom{n}{k} = 0$ (for $n \ge 1$). This open question refines that vanishing into the **partial-sum** identity above: the alternating sum truncated at index $j$ collapses to a single signed binomial coefficient $(-1)^j\binom{n-1}{j}$. Setting $j = n$ recovers the parent (since $\binom{n-1}{n}=0$).
+
+### Plain Language
+
+If you walk along a row of Pascal's triangle and add the entries with alternating signs ($+,-,+,-,\dots$), the *whole* row cancels to zero. But what does the running total look like before you reach the end? The answer is surprisingly clean: after $j$ steps the partial total is exactly $\pm$ one entry of the row *above* — namely $(-1)^j\binom{n-1}{j}$. This problem asks to formalize that exact running-total formula in Lean, turning the "everything cancels" fact into a precise telescoping statement.
+
+### Why This Matters
+
+The partial-sum form is strictly more informative than the parent's full cancellation: it gives the exact value at every truncation point, exposes the identity as a telescoping consequence of Pascal's rule $\binom{n}{k} = \binom{n-1}{k} + \binom{n-1}{k-1}$, and is the discrete analogue of an antiderivative. It is a standard ingredient in inclusion–exclusion remainder bounds and in proofs of binomial transform inversion. Formalizing it exercises `Finset.sum_range_succ`, induction over the truncation index, and sign-bookkeeping with `(-1)^k` — a clean, reusable lemma for the gallery's combinatorics corpus.
+
+## Known Results
+
+### What's Already Proven
+
+- Full alternating-row identity $\sum_{k=0}^{n} (-1)^k \binom{n}{k} = 0$ — gallery entry `combinations-formula-oq-05` and Mathlib `Int.alternating_sum_range_choose`.
+- Pascal's rule `Nat.succ_sub_one`, `Nat.choose_succ_succ` (`Nat.choose_succ_succ : (n+1).choose (k+1) = n.choose k + n.choose (k+1)`) — Mathlib.
+- `Finset.sum_range_succ`, `Finset.sum_range_succ_comm`, and alternating-sum helpers — Mathlib `Mathlib.Algebra.BigOperators`.
+
+### What's Still Open (here)
+
+- The truncated identity $\sum_{k=0}^{j} (-1)^k \binom{n}{k} = (-1)^j \binom{n-1}{j}$ as a top-level theorem (over $\mathbb{Z}$, with the natural-number subtraction handled carefully when $n=0$).
+- A clean statement of the underlying telescoping step $(-1)^j\binom{n-1}{j} - (-1)^{j-1}\binom{n-1}{j-1} = (-1)^j\binom{n}{j}$.
+
+### Our Goal
+
+Deliver the partial-sum identity as a verified, 0-axiom theorem over $\mathbb{Z}$, proved by induction on $j$ using Pascal's rule, and re-derive the parent's full cancellation as a one-line corollary ($j=n$). Provide the telescoping step as a named lemma so downstream inversion/inclusion–exclusion entries can reuse it.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| combinations-formula-oq-05 | direct parent (full alternating-row cancellation) | `Int.alternating_sum_range_choose`, `Finset.sum` |
+| combinations-formula | base binomial-coefficient API | `Nat.choose`, Pascal's rule |
+| combinations-formula-oq-09 | sibling moment/peel-then-absorb identities | induction on a parameter, `Finset.sum_range_succ` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Induction on the truncation index `j`** (primary): Base $j=0$ gives $\binom{n}{0}=1=(-1)^0\binom{n-1}{0}$. Step uses `Finset.sum_range_succ` plus Pascal's rule to show the increment $(-1)^{j+1}\binom{n}{j+1}$ telescopes with the IH $(-1)^j\binom{n-1}{j}$ into $(-1)^{j+1}\binom{n-1}{j+1}$.
+   - Why it might work: Pascal's rule is *exactly* the algebraic identity the telescoping needs; Mathlib has it directly.
+   - Risk: sign management with `(-1)^k` and casting $\binom{}{}$ from $\mathbb{N}$ to $\mathbb{Z}$; resolved by working in $\mathbb{Z}$ throughout and using `push_cast`.
+
+2. **Telescoping via `Finset.sum_range_succ_sub`** (alternative): write each summand as a difference of consecutive $(-1)^k\binom{n-1}{k}$ terms and apply a telescoping-sum lemma.
+   - Why it might work: avoids explicit induction bookkeeping.
+   - Risk: requires phrasing the summand as an exact first difference; the edge term at $k=0$ needs care.
+
+### Key Difficulties
+
+- Natural-number subtraction: $\binom{n-1}{j}$ is ill-behaved at $n=0$; state over $n \ge 1$ or define via `Int` and handle $n=0$ separately.
+- Sign tracking through the inductive step (`pow_succ`, `neg_one_pow` lemmas).
+
+### What Would a Proof Need?
+
+- Key lemma 1: the one-step telescoping identity $(-1)^{j+1}\binom{n}{j+1} = (-1)^{j+1}\binom{n-1}{j+1} - (-1)^{j}\binom{n-1}{j}$ from Pascal's rule.
+- Key lemma 2: `Finset.sum_range_succ` to expose the last term.
+- Technical requirements: `push_cast`, `ring`/`linarith` for the sign algebra, `Nat.choose_succ_succ`.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The identity is a textbook telescoping consequence of Pascal's rule; the only Lean friction is sign/cast bookkeeping.
+- Numerous sibling gallery entries (combinations-formula-oq-09, -oq-06) ship analogous induction-on-a-parameter proofs.
+- Mathlib provides every needed primitive (`Nat.choose_succ_succ`, `Finset.sum_range_succ`, `Int.alternating_sum_range_choose`).
+
+**Estimated Effort**:
+- Exploration: 1–2 hours
+- If tractable: half a day to a day
+
+## References
+
+### Papers
+- Concrete Mathematics (Graham, Knuth, Patashnik), §5.1 — partial sums of alternating binomial coefficients.
+
+### Online Resources
+- The "hockey-stick" and alternating partial-sum identities are standard; see any treatment of the binomial transform.
+
+### Mathlib
+- `Mathlib.Combinatorics.Choose.Sum` — `Int.alternating_sum_range_choose` and related alternating sums.
+- `Mathlib.Algebra.BigOperators.Basic` — `Finset.sum_range_succ`.
+- `Mathlib.Data.Nat.Choose.Basic` — `Nat.choose_succ_succ` (Pascal's rule).
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - binomial-coefficients
+  - alternating-sum
+  - telescoping
+  - finset-sums
+related_proofs:
+  - combinations-formula-oq-05
+  - combinations-formula
+difficulty: low
+source: gallery-gap
+created: 2026-06-23
+```

--- a/research/problems/de-moivre-oq-05-oq-01/problem.md
+++ b/research/problems/de-moivre-oq-05-oq-01/problem.md
@@ -1,0 +1,126 @@
+# Problem: Orthogonality of Roots of Unity (DFT Inversion)
+
+**Slug**: de-moivre-oq-05-oq-01
+**Created**: 2026-06-23
+**Status**: Active
+**Source**: gallery-gap <!-- open question of verified parent de-moivre-oq-05 -->
+
+## Problem Statement
+
+### Formal Statement
+
+Let $\zeta$ be a primitive $n$-th root of unity (e.g. $\zeta = e^{2\pi i/n}$ in $\mathbb{C}$, or a primitive root in any field with one). For $j \in \mathbb{Z}$:
+
+$$
+\sum_{k=0}^{n-1} \zeta^{\,jk} \;=\;
+\begin{cases}
+n, & n \mid j,\\
+0, & n \nmid j.
+\end{cases}
+$$
+
+The parent `de-moivre-oq-05` handles the basic vanishing $\sum_{k=0}^{n-1}\zeta^{k} = 0$. This open question is the full **orthogonality relation**: the complete-character sum vanishes whenever the frequency $j$ is not a multiple of $n$, and equals $n$ when it is. This is precisely the discrete orthogonality of the additive characters $k \mapsto \zeta^{jk}$ and the kernel identity underlying **DFT inversion**.
+
+### Plain Language
+
+The $n$-th roots of unity are $n$ equally spaced points on the unit circle. If you add them all up you get $0$ — they cancel by symmetry. More generally, raise each to the $j$-th power first and then add: you *still* get $0$, unless $j$ is a multiple of $n$ (in which case every term becomes $1$ and the total is $n$). This clean "all-or-nothing" behavior is the mathematical heart of the discrete Fourier transform: it is exactly what lets you recover a signal from its frequency components. The problem asks to formalize this orthogonality relation in Lean.
+
+### Why This Matters
+
+Root-of-unity orthogonality is the single most-used identity in discrete harmonic analysis: it powers the DFT/inverse-DFT pair, roots-of-unity filters for series multisection, Gauss-sum evaluations, Newton's identities for cyclotomic polynomials, and character-sum estimates in analytic number theory. Promoting the parent's special case ($j=1$) to the full $j$-indexed dichotomy gives the gallery a genuinely reusable lemma. Formalizing it cleanly — ideally over a general field via `IsPrimitiveRoot` so it specializes to both $\mathbb{C}$ and finite fields — exercises the finite geometric-sum machinery exactly at its most important application.
+
+## Known Results
+
+### What's Already Proven
+
+- Basic vanishing $\sum_{k=0}^{n-1}\zeta^{k} = 0$ for a primitive $n$-th root ($n \ge 2$) — gallery parent `de-moivre-oq-05`.
+- `IsPrimitiveRoot` API: `IsPrimitiveRoot.geom_sum_eq_zero`, `IsPrimitiveRoot.pow_eq_one_iff_dvd`, `IsPrimitiveRoot.pow_ne_one_of_pos_of_lt` — Mathlib.
+- Finite geometric sums `geom_sum_eq` / `Finset.geom_sum_eq` and `mul_geom_sum`/`geom_sum_mul` (the $(x-1)\sum x^k = x^n - 1$ identity) — Mathlib `Mathlib.Algebra.GeomSum`.
+- DFT scaffolding (`AddChar`, `ZMod` character orthogonality) in `Mathlib.Analysis.SpecialFunctions` / `Mathlib.NumberTheory.LegendreSymbol.AddCharacter` — partial.
+
+### What's Still Open (here)
+
+- The two-case orthogonality $\sum_{k<n}\zeta^{jk} = $ ($n$ if $n\mid j$ else $0$), as a single theorem in $j$.
+- A statement phrased via `IsPrimitiveRoot` so it holds over any field containing a primitive $n$-th root (not just $\mathbb{C}$).
+
+### Our Goal
+
+Ship the full orthogonality dichotomy as a verified, 0-axiom theorem. Split on $n \mid j$: when $n \mid j$, each $\zeta^{jk} = (\zeta^n)^{(j/n)k} = 1$, so the sum is $n$; when $n \nmid j$, set $\omega := \zeta^j \ne 1$ (since $\zeta^j=1 \iff n\mid j$) and apply the finite geometric-sum vanishing $\sum_{k<n}\omega^k = \frac{\omega^n - 1}{\omega - 1} = 0$ (because $\omega^n = (\zeta^n)^j = 1$). State it over `IsPrimitiveRoot` for maximal reuse.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| de-moivre-oq-05 | direct parent (basic root-of-unity vanishing) | `IsPrimitiveRoot`, geometric sum |
+| de-moivre | base de Moivre / roots-of-unity API | `Complex.exp`, `IsPrimitiveRoot` |
+| de-moivre-oq-04 | sibling primitivity/totient-count question | `IsPrimitiveRoot.pow_eq_one_iff_dvd` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Case split on `n ∣ j` + finite geometric sum** (primary):
+   - `n ∣ j` branch: $\zeta^{jk} = (\zeta^n)^{mk} = 1$ where $j = nm$; sum of $n$ ones is $n$ (`Finset.sum_const`, `Finset.card_range`).
+   - `n ∤ j` branch: let $\omega = \zeta^j$. Then $\omega \ne 1$ (`IsPrimitiveRoot.pow_eq_one_iff_dvd`) and $\omega^n = 1$. Use `geom_sum_eq` (valid since $\omega \ne 1$): $\sum_{k<n}\omega^k = \frac{\omega^n - 1}{\omega - 1} = \frac{0}{\omega-1} = 0$.
+   - Why it might work: every sub-step is a named Mathlib lemma; `IsPrimitiveRoot.pow_eq_one_iff_dvd` cleanly decides $\omega = 1$.
+   - Risk: `geom_sum_eq` requires a field (division); for the general-field statement ensure the right typeclass; the $\omega - 1 \ne 0$ side condition.
+
+2. **`geom_sum_mul` (division-free)** (alternative): use $(\omega - 1)\sum_{k<n}\omega^k = \omega^n - 1 = 0$ and cancel $\omega - 1 \ne 0$ in an integral domain.
+   - Why it might work: avoids division, works in any integral domain with a primitive root.
+   - Risk: cancellation lemma bookkeeping (`mul_left_cancel₀`).
+
+### Key Difficulties
+
+- Deciding $\zeta^j = 1 \iff n \mid j$ (handled by `IsPrimitiveRoot.pow_eq_one_iff_dvd`).
+- Choosing the right generality (field vs. integral domain) so `geom_sum_eq`/`geom_sum_mul` applies.
+- Index/range conventions ($k$ over `Finset.range n`) and the $j \in \mathbb{Z}$ vs. $j \in \mathbb{N}$ statement.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `IsPrimitiveRoot.pow_eq_one_iff_dvd` to characterize when $\zeta^j = 1$.
+- Key lemma 2: `geom_sum_eq` (or `geom_sum_mul` + cancellation) for the vanishing branch.
+- Technical requirements: `Finset.sum_const`, `Finset.card_range`, `mul_left_cancel₀`.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The parent already proves the hardest geometric step for $j=1$; this generalizes by the same machinery with a case split.
+- `IsPrimitiveRoot.pow_eq_one_iff_dvd` exactly supplies the dichotomy condition.
+- Comparable root-of-unity sums are routinely formalized in Mathlib.
+
+**Estimated Effort**:
+- Exploration: 1–2 hours
+- If tractable: half a day to a day
+
+## References
+
+### Papers
+- Any standard text on the discrete Fourier transform (orthogonality of characters).
+- Ireland & Rosen, *A Classical Introduction to Modern Number Theory* — Gauss sums and character orthogonality.
+
+### Online Resources
+- Roots-of-unity filter / DFT inversion expositions.
+
+### Mathlib
+- `Mathlib.RingTheory.RootsOfUnity.Basic` — `IsPrimitiveRoot`, `IsPrimitiveRoot.pow_eq_one_iff_dvd`.
+- `Mathlib.Algebra.GeomSum` — `geom_sum_eq`, `geom_sum_mul`.
+- `Mathlib.NumberTheory.LegendreSymbol.AddCharacter` — additive-character orthogonality scaffolding.
+
+## Metadata
+
+```yaml
+tags:
+  - algebra
+  - complex-analysis
+  - roots-of-unity
+  - discrete-fourier
+  - geometric-sum
+related_proofs:
+  - de-moivre-oq-05
+  - de-moivre
+difficulty: low
+source: gallery-gap
+created: 2026-06-23
+```

--- a/research/problems/geometric-series-oq-09-oq-01/problem.md
+++ b/research/problems/geometric-series-oq-09-oq-01/problem.md
@@ -1,0 +1,119 @@
+# Problem: q-Fold Splitting of the Geometric Series
+
+**Slug**: geometric-series-oq-09-oq-01
+**Created**: 2026-06-23
+**Status**: Active
+**Source**: gallery-gap <!-- open question of verified parent geometric-series-oq-09 -->
+
+## Problem Statement
+
+### Formal Statement
+
+For a real (or complex) ratio $r$ with $|r| < 1$, a modulus $q \ge 1$, and a residue $a$ with $0 \le a < q$:
+
+$$
+\sum_{n=0}^{\infty} r^{\,q n + a} \;=\; \frac{r^{a}}{1 - r^{q}} .
+$$
+
+Equivalently, the full geometric series $\sum_{m\ge 0} r^m$ splits into $q$ residue subseries (indexed by $a = 0,1,\dots,q-1$), each itself geometric with ratio $r^q$ and leading term $r^a$, and the $q$ closed forms sum back to $\frac{1}{1-r}$ via $\sum_{a=0}^{q-1} r^a = \frac{1-r^q}{1-r}$.
+
+### Plain Language
+
+The geometric series $1 + r + r^2 + \cdots = \frac{1}{1-r}$ is one of the most familiar sums in mathematics. This problem asks what happens when you keep only every $q$-th term, starting from position $a$: $r^a + r^{a+q} + r^{a+2q} + \cdots$. Because the gaps are uniform, this thinned-out series is *again* geometric — with ratio $r^q$ — so it has the clean closed form $\frac{r^a}{1-r^q}$. Formalizing this makes precise the intuitive "split a series by residue class mod $q$" operation and confirms the pieces reassemble into the whole.
+
+### Why This Matters
+
+Residue-class (or "$q$-fold") splitting of geometric series is the engine behind generating-function manipulations: extracting even/odd parts ($q=2$), bisection/multisection of power series, roots-of-unity filters, and the term-by-term handling of Lambert and theta-type series. It is also the discrete shadow of partial-fraction decomposition over cyclotomic factors. A clean, reusable Lean lemma — "a geometric series re-indexed by $qn+a$ is geometric with ratio $r^q$" — supports many downstream analysis and number-theory entries (e.g. multisection identities, the $\sum n^k r^n$ family in sibling OQs).
+
+## Known Results
+
+### What's Already Proven
+
+- $\sum_{n} r^n = \frac{1}{1-r}$ for $|r|<1$ — Mathlib `tsum_geometric_of_lt_one` / `hasSum_geometric_of_lt_one` (real) and `tsum_geometric_of_norm_lt_one` (normed field).
+- Summability of geometric series under the norm bound — `summable_geometric_of_norm_lt_one`.
+- Reindexing / composition of `HasSum` along injective maps — `Function.Injective.hasSum_iff`, `HasSum.comp_injective`.
+- Finite geometric partial sums and $\sum_{a<q} r^a = \frac{1-r^q}{1-r}$ — `geom_sum_eq` / `Finset.geom_sum_eq`.
+
+### What's Still Open (here)
+
+- The thinned-subseries closed form $\sum_n r^{qn+a} = \frac{r^a}{1-r^q}$ as a `HasSum`/`tsum` statement (real and/or normed field).
+- The reassembly statement: the $q$ residue subseries sum to the full series (a `HasSum`-level partition over `Fin q`).
+
+### Our Goal
+
+Ship $\sum_n r^{qn+a} = \frac{r^a}{1-r^q}$ as a verified `tsum` (or `HasSum`) theorem for $\|r\|<1$, obtained by recognizing the subseries as geometric with ratio $r^q$ (note $\|r^q\| = \|r\|^q < 1$) and factoring the constant $r^a$. As a corollary, prove the $q$-fold reassembly $\sum_{a<q} \sum_n r^{qn+a} = \frac{1}{1-r}$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| geometric-series-oq-09 | direct parent | `tsum`, geometric closed form |
+| geometric-series | base closed-form/summability API | `hasSum_geometric_of_norm_lt_one` |
+| geometric-series-oq-07 / -oq-10 | sibling weighted/multisection variants | reindexing, `HasSum.mul_left` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Recognize-and-rescale** (primary): Write $r^{qn+a} = r^a \cdot (r^q)^n$. Apply `hasSum_geometric_of_norm_lt_one` to ratio $s := r^q$ (with $\|s\| = \|r\|^q < 1$ from `norm_pow` and `pow_lt_one`), then `HasSum.mul_left r^a` to pull out the constant. The closed form is $r^a \cdot \frac{1}{1-r^q}$.
+   - Why it might work: every step is a named Mathlib lemma; no genuine analysis is re-proved.
+   - Risk: the bound $\|r\|^q < 1$ needs $q \ge 1$ (handle $q=0$ as degenerate or exclude); minor `pow`/`norm` plumbing.
+
+2. **Reindex the full series along `n ↦ qn+a`** (alternative): use injectivity of $n\mapsto qn+a$ and a `HasSum.comp_injective`-style argument to extract the subseries from the full geometric `HasSum`.
+   - Why it might work: directly yields the reassembly/partition statement.
+   - Risk: assembling the disjoint-union-over-`Fin q` partition of $\mathbb{N}$ is fiddlier than approach 1.
+
+### Key Difficulties
+
+- Establishing $\|r^q\| < 1$ from $\|r\| < 1$ cleanly (`norm_pow`, `pow_lt_one_iff`/`pow_lt_one`).
+- Choosing real vs. normed-field generality; the normed-field version is more reusable.
+- Edge cases $q=0$ / $r=0$.
+
+### What Would a Proof Need?
+
+- Key lemma 1: `hasSum_geometric_of_norm_lt_one` applied to $r^q$.
+- Key lemma 2: `HasSum.mul_left` to factor $r^a$.
+- Technical requirements: `norm_pow`, `pow_lt_one`, `tsum_mul_left`, possibly `Finset.geom_sum_eq` for the reassembly corollary.
+
+## Tractability Assessment
+
+**Difficulty**: Low–Medium
+
+**Justification**:
+- The core is a recognize-and-rescale of an existing Mathlib closed form; no new analysis.
+- The only real work is the $\|r^q\|<1$ bound and constant-factoring, both standard.
+- Sibling geometric-series OQs already ship `HasSum`-level manipulations of this kind.
+
+**Estimated Effort**:
+- Exploration: 1–2 hours
+- If tractable: half a day to a day
+
+## References
+
+### Papers
+- Wilf, *generatingfunctionology* — multisection of power series via residue classes.
+
+### Online Resources
+- Standard treatments of series bisection / roots-of-unity filter.
+
+### Mathlib
+- `Mathlib.Analysis.SpecificLimits.Basic` — `hasSum_geometric_of_norm_lt_one`, `tsum_geometric_of_norm_lt_one`.
+- `Mathlib.Topology.Algebra.InfiniteSum.Basic` — `HasSum.mul_left`, `tsum_mul_left`.
+- `Mathlib.Algebra.GeomSum` — `geom_sum_eq` for the finite reassembly factor.
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - geometric-series
+  - infinite-series
+  - power-series
+  - summability
+related_proofs:
+  - geometric-series-oq-09
+  - geometric-series
+difficulty: low
+source: gallery-gap
+created: 2026-06-23
+```

--- a/research/problems/lagrange-theorem-oq-07-oq-02/problem.md
+++ b/research/problems/lagrange-theorem-oq-07-oq-02/problem.md
@@ -1,0 +1,119 @@
+# Problem: Additive Exponent — n·x = 0 in a Finite Abelian Group of Order n
+
+**Slug**: lagrange-theorem-oq-07-oq-02
+**Created**: 2026-06-23
+**Status**: Active
+**Source**: gallery-gap <!-- open question of verified parent lagrange-theorem-oq-07 (multiplicative exponent | order) -->
+
+## Problem Statement
+
+### Formal Statement
+
+Let $G$ be a finite **additive** abelian group with $|G| = n$. Then for every $x \in G$:
+
+$$
+n \cdot x \;=\; 0 .
+$$
+
+Equivalently, in multiplicative notation $g^{|G|} = 1$ for all $g$ — the additive transcription of the parent's exponent-divides-order result. The parent `lagrange-theorem-oq-07` establishes (multiplicatively) that the order of every element, and hence the exponent of the group, divides $|G|$, so $g^{|G|}=1$. This open question asks for the clean **additive** statement $n \bullet x = 0$, the form used in module theory and in additive number theory, recovering the additive analogues of Fermat/Euler.
+
+### Plain Language
+
+Lagrange's theorem says the size of any subgroup divides the size of the group. A direct corollary: if you take any element and "repeat" the group operation $|G|$ times, you return to the identity. In a group written additively (where the operation is $+$ and the identity is $0$), that statement reads $n \cdot x = 0$ — adding $x$ to itself $n$ times always gives zero, where $n$ is the number of elements. This problem asks to state and prove this additive version in Lean, the form that matches how finite abelian groups appear in module theory and number theory (e.g. "$n$ kills the group $\mathbb{Z}/n\mathbb{Z}$").
+
+### Why This Matters
+
+The additive corollary is the workhorse behind: the additive analogue of Fermat's little theorem ($n \cdot x = 0$ in $\mathbb{Z}/n$), the fact that a finite abelian group of order $n$ is a module over $\mathbb{Z}/n\mathbb{Z}$, torsion bounds in the structure theory of finite abelian groups, and elementary results in additive combinatorics. While Mathlib has the multiplicative `pow_card_eq_one` and `orderOf_dvd_card`, the explicitly *additive* `n • x = 0` phrasing (with $n = $ `Nat.card G` / `Fintype.card G`) is the directly citable statement for module-flavored downstream work. Shipping it bridges the parent's group-theoretic result to the additive/module setting.
+
+## Known Results
+
+### What's Already Proven
+
+- Multiplicative exponent-divides-order and `pow_card_eq_one : g ^ (Fintype.card G) = 1` — gallery parent `lagrange-theorem-oq-07` and Mathlib.
+- `orderOf_dvd_card`, `orderOf_dvd_of_pow_eq_one`, exponent API (`Monoid.exponent`, `Group.exponent_dvd_card`) — Mathlib.
+- Additive ↔ multiplicative bridging: `Multiplicative`/`Additive` type equivalences and `AddSubgroup`/`Subgroup` correspondence; `nsmul`/`pow` translation lemmas (`ofMul_pow`, `toMul_nsmul`, etc.) — Mathlib.
+- For the additive side directly: `AddMonoid.nsmul`, `addOrderOf`, `addOrderOf_dvd_card` (`addOrderOf_dvd_natCard`) — Mathlib.
+
+### What's Still Open (here)
+
+- The clean top-level additive theorem `∀ x : G, (Nat.card G) • x = 0` (equivalently with `Fintype.card`) for a finite `AddCommGroup` (or `AddGroup`) `G`.
+- The corollary instances: $n \cdot x = 0$ in `ZMod n` and in an arbitrary finite abelian group, framed as additive Fermat/Euler.
+
+### Our Goal
+
+Ship `(Nat.card G) • x = 0` for finite `G` as a verified, 0-axiom theorem — either by transporting the parent's `pow_card_eq_one` through the `Additive`/`Multiplicative` equivalence, or directly from `addOrderOf_dvd_natCard` + `addOrderOf_nsmul_eq_zero`-style lemmas. Provide the `ZMod n` specialization as a sanity corollary.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| lagrange-theorem-oq-07 | direct parent (multiplicative exponent | order) | `orderOf_dvd_card`, `pow_card_eq_one` |
+| lagrange-theorem | base Lagrange/coset API | subgroup index, `Subgroup.card_subgroup_dvd_card` |
+| euler-totient-oq-05 | sibling additive/Euler corollaries | `ZMod`, `nsmul` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Transport via `Additive`/`Multiplicative`** (primary): apply the parent/Mathlib `pow_card_eq_one` to `Multiplicative G`, then translate $g^{n} = 1$ back to $n \bullet x = 0$ using the `toMul`/`ofMul` and `pow`↔`nsmul` correspondence lemmas.
+   - Why it might work: reuses the already-proven multiplicative result verbatim; the equivalence lemmas are mechanical.
+   - Risk: friction in the `Additive`/`Multiplicative` cast lemma names (`ofMul_pow`, `Additive.forall`, etc.).
+
+2. **Direct additive proof** (alternative, cleaner): use `addOrderOf_dvd_natCard : addOrderOf x ∣ Nat.card G` together with `addOrderOf_nsmul_eq_zero`/`nsmul_eq_zero_of_dvd` to conclude `Nat.card G • x = 0` directly.
+   - Why it might work: avoids the multiplicative round-trip entirely; Mathlib already has the additive order API.
+   - Risk: confirming the exact additive lemma names (`addOrderOf_nsmul_eq_zero`, `nsmul_eq_zero_iff` analogues); none deep.
+
+### Key Difficulties
+
+- Locating the correct additive-order lemma names in current Mathlib (additive API sometimes lags the multiplicative one).
+- `Nat.card` vs. `Fintype.card` bookkeeping (state both or relate via `Nat.card_eq_fintype_card`).
+- Whether `AddCommGroup` is needed or `AddGroup` suffices (Lagrange does not require commutativity, though the headline targets abelian).
+
+### What Would a Proof Need?
+
+- Key lemma 1: `addOrderOf_dvd_natCard` (or `pow_card_eq_one` on `Multiplicative G`).
+- Key lemma 2: `nsmul_eq_zero_of_dvd` / `addOrderOf` vanishing under divisibility.
+- Technical requirements: `Nat.card_eq_fintype_card`, `Additive`/`Multiplicative` translation lemmas if using approach 1.
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**:
+- The mathematics is the parent result restated additively; Mathlib supplies both the multiplicative source and the additive order API.
+- This is primarily a transport/restatement exercise — the kind of clean corollary that ships quickly and 0-axiom.
+- Strong precedent in sibling Lagrange/Euler gallery entries.
+
+**Estimated Effort**:
+- Exploration: 1 hour
+- If tractable: a few hours to half a day
+
+## References
+
+### Papers
+- Any standard algebra text (Dummit & Foote, Ch. 3) — corollaries of Lagrange's theorem; additive analogue of Fermat/Euler.
+
+### Online Resources
+- Standard statement that a finite abelian group of order $n$ is annihilated by $n$ (is a $\mathbb{Z}/n$-module).
+
+### Mathlib
+- `Mathlib.GroupTheory.OrderOfElement` — `pow_card_eq_one`, `orderOf_dvd_card`, `addOrderOf_dvd_natCard`.
+- `Mathlib.Algebra.Group.TypeTags` — `Additive`/`Multiplicative` equivalences and `ofMul_pow` family.
+- `Mathlib.Data.ZMod.Basic` — for the `ZMod n` specialization corollary.
+
+## Metadata
+
+```yaml
+tags:
+  - group-theory
+  - finite-groups
+  - order-of-element
+  - lagrange-theorem
+  - module-theory
+related_proofs:
+  - lagrange-theorem-oq-07
+  - lagrange-theorem
+difficulty: low
+source: gallery-gap
+created: 2026-06-23
+```

--- a/research/problems/sum-of-kth-powers-oq-05-oq-01/problem.md
+++ b/research/problems/sum-of-kth-powers-oq-05-oq-01/problem.md
@@ -1,0 +1,132 @@
+# Problem: Nat-Congruence Power-Sum Dichotomy mod p
+
+**Slug**: sum-of-kth-powers-oq-05-oq-01
+**Created**: 2026-06-23
+**Status**: Active
+**Source**: gallery-gap <!-- open question of verified parent sum-of-kth-powers-oq-05 (ZMod p power-sum dichotomy) -->
+
+## Problem Statement
+
+### Formal Statement
+
+For a prime $p$ and an exponent $k \in \mathbb{N}$:
+
+$$
+\sum_{i=0}^{p-1} i^{\,k} \;\equiv\;
+\begin{cases}
+p - 1 \pmod{p}, & k \neq 0 \ \text{and}\ (p-1) \mid k,\\[2pt]
+0 \pmod{p}, & \text{otherwise,}
+\end{cases}
+$$
+
+as a congruence of **natural numbers** (`Nat.ModEq`). The parent entry `sum-of-kth-powers-oq-05` establishes the corresponding equality in $\mathbb{Z}/p\mathbb{Z}$:
+$$
+\sum_{i \in \mathbb{Z}/p\mathbb{Z}} i^{k} = \begin{cases} -1 & (p-1)\mid k,\ k\ne 0\\ 0 & \text{otherwise.}\end{cases}
+$$
+This open question asks to **cast that `ZMod p` dichotomy back to a congruence over $\mathbb{N}$** via `Nat.ModEq`, giving the elementary "sum of $k$-th powers mod $p$" statement (with $-1$ becoming $p-1$).
+
+### Plain Language
+
+Add up $0^k + 1^k + 2^k + \cdots + (p-1)^k$ and reduce mod a prime $p$. The result is almost always $0$ — *except* in the special case where the exponent $k$ is a nonzero multiple of $p-1$, when it is $-1 \equiv p-1$. (This is exactly why Fermat's little theorem makes $i^{p-1}\equiv 1$, so the sum becomes $p-1$ copies of $1$.) The parent proves this inside the finite field $\mathbb{Z}/p\mathbb{Z}$; here we want the same fact stated as an ordinary congruence about natural-number sums, which is the form most textbooks and applications use.
+
+### Why This Matters
+
+The $\mathbb{N}$-congruence form is the directly usable one for elementary number theory: it underlies the von Staudt–Clausen theorem (the $p$-integral part of Bernoulli numbers), Carlitz-style power-sum arguments, and the standard "$\sum i^{p-1} \equiv -1$" lemma used in primality and Wilson-type results. The translation from a `ZMod p` field identity to a `Nat.ModEq` statement is a recurring formalization pattern (cast the sum, push the field equality through `ZMod.natCast_self_eq_zero` / `ZMod.natCast_zmod_eq_zero_iff_dvd`), so doing it cleanly here yields a template reusable across the gallery's modular-arithmetic corpus.
+
+### Why This Matters (cont.)
+
+It also closes the loop on the parent: a field-level dichotomy is mathematically complete but pedagogically incomplete until it is expressed in the elementary language of integer congruences, which is where most readers and downstream proofs operate.
+
+## Known Results
+
+### What's Already Proven
+
+- The `ZMod p` power-sum dichotomy $\sum_{i:\mathbb{Z}/p} i^k \in \{0,-1\}$ — gallery parent `sum-of-kth-powers-oq-05`.
+- Fermat's little theorem / `ZMod.pow_card_sub_one_eq_one`, and the multiplicative-group structure of $(\mathbb{Z}/p)^\times$ — Mathlib.
+- Bridges between `Nat`/`Int` sums and `ZMod p`: `ZMod.natCast_self_eq_zero`, `ZMod.natCast_zmod_eq_zero_iff_dvd`, `Nat.cast_sum`, `ZMod.natCast_val` — Mathlib.
+- `Nat.ModEq` API (`Nat.modEq_iff_dvd'`, `Nat.ModEq.sub`, cast lemmas) — Mathlib.
+
+### What's Still Open (here)
+
+- The natural-number congruence statement $\sum_{i<p} i^k \equiv (\text{if } k\ne0 \wedge (p-1)\mid k \text{ then } p-1 \text{ else } 0) \pmod p$.
+- The careful handling of $-1 \mapsto p-1$ under the cast (and the $k=0$ edge case, where the sum is $p \equiv 0$).
+
+### Our Goal
+
+Ship the `Nat.ModEq` corollary as a verified theorem, derived from the parent's `ZMod p` equality by mapping the finite sum $\sum_{i<p} i^k$ over $\mathbb{N}$ into $\mathbb{Z}/p\mathbb{Z}$ (using the bijection `Finset.range p ↔ ZMod p`), invoking the parent dichotomy, and translating $-1$ and $0$ back to $p-1$ and $0$ in $\mathbb{N}$.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| sum-of-kth-powers-oq-05 | direct parent (ZMod p dichotomy) | `ZMod`, Fermat's little theorem, character sums |
+| sum-of-kth-powers | base Faulhaber/power-sum API | `Finset.sum`, induction |
+| wilsons-theorem-oq-05 | sibling ℕ-congruence-from-ZMod casting pattern | `ZMod.natCast_zmod_eq_zero_iff_dvd`, `Nat.ModEq` |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Cast-and-transport** (primary): Show $\big(\sum_{i<p} i^k : \mathbb{Z}/p\big) = \sum_{x:\mathbb{Z}/p} x^k$ by reindexing `Finset.range p` along the canonical bijection with `ZMod p` (`ZMod.natCast` is a bijection on residues), then substitute the parent equality. Finally convert "$=0$ in `ZMod p`" to "$p \mid \cdot$" via `ZMod.natCast_zmod_eq_zero_iff_dvd`, and "$=-1$" to "$\equiv p-1$" via `Nat.modEq_iff_dvd'`.
+   - Why it might work: it is a direct application of the parent plus standard cast lemmas.
+   - Risk: the reindexing bijection bookkeeping (`Finset.sum_bij` / `ZMod.sum_univ` style) and the $-1 \mapsto p-1$ congruence step need care.
+
+2. **Independent ℕ proof via Fermat** (fallback): split $i=0$ off, use $i^{p-1}\equiv1$ for $i\ne0$ when $(p-1)\mid k$, else pair terms via a primitive root to show cancellation — re-deriving rather than transporting.
+   - Why it might work: avoids the bijection plumbing.
+   - Risk: duplicates the parent's work; the non-divisible case needs the primitive-root cancellation argument.
+
+### Key Difficulties
+
+- The residue bijection `Finset.range p ≃ ZMod p` and matching the two sums.
+- Translating the field value $-1$ to the natural number $p-1$ as a `Nat.ModEq`.
+- $k=0$ edge case ($\sum_{i<p} 1 = p \equiv 0$, consistent with "otherwise" branch since the guard requires $k\ne0$).
+
+### What Would a Proof Need?
+
+- Key lemma 1: $\sum_{i<p}(i:\mathbb{Z}/p)^k = \sum_{x:\mathbb{Z}/p} x^k$ (sum reindex over the residue bijection).
+- Key lemma 2: parent dichotomy on $\sum_{x:\mathbb{Z}/p} x^k$.
+- Technical requirements: `ZMod.natCast_zmod_eq_zero_iff_dvd`, `Nat.modEq_iff_dvd'`, `Nat.cast_sum`, `Fact p.Prime`.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The mathematics is fully supplied by the parent; the work is a casting/transport exercise.
+- The `ZMod p` ↔ `Nat.ModEq` translation is a well-trodden pattern in sibling gallery entries (Wilson-family proofs).
+- The only nontrivial step is the residue-bijection reindexing of the sum.
+
+**Estimated Effort**:
+- Exploration: 2–3 hours
+- If tractable: one to two days
+
+## References
+
+### Papers
+- Ireland & Rosen, *A Classical Introduction to Modern Number Theory*, Ch. 4 — power sums mod p and Bernoulli congruences.
+- von Staudt–Clausen theorem (classical) — the $p$-integral part of Bernoulli numbers.
+
+### Online Resources
+- Standard "sum of k-th powers modulo a prime" lemma in elementary number theory notes.
+
+### Mathlib
+- `Mathlib.FieldTheory.Finite.Basic` — `ZMod.pow_card_sub_one_eq_one`, finite-field power-sum facts.
+- `Mathlib.Data.ZMod.Basic` — `ZMod.natCast_zmod_eq_zero_iff_dvd`, residue casts.
+- `Mathlib.Data.Nat.ModEq` — `Nat.ModEq`, `Nat.modEq_iff_dvd'`.
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - finite-fields
+  - power-sums
+  - modular-arithmetic
+  - zmod
+related_proofs:
+  - sum-of-kth-powers-oq-05
+  - sum-of-kth-powers
+difficulty: medium
+source: gallery-gap
+created: 2026-06-23
+```


### PR DESCRIPTION
## Seeker Pool Top-Up

The candidate pool was at the **15-problem threshold** with a very active research fleet (549 in-progress, 60+ live research worktrees) draining it. This registers **5 fresh, diverse, verified-clean** open questions extracted from the gallery, bringing operational availability from 15 → 20.

Each was cross-checked before selection: **not already in the db**, **no existing PR** (exact-slug `in:title` search), parent proof **verified**, and the statement is **crisp, Mathlib-supported, and tractable** (not an open conjecture in disguise).

| Slug | Domain | Statement |
|------|--------|-----------|
| `combinations-formula-oq-05-oq-01` | combinatorics | ∑_{k≤j} (−1)ᵏ C(n,k) = (−1)ʲ C(n−1,j) (telescoping partial alternating sum) |
| `geometric-series-oq-09-oq-01` | analysis | ∑ rⁿq⁺ᵃ = rᵃ/(1−rᵠ) (q-fold residue splitting) |
| `sum-of-kth-powers-oq-05-oq-01` | number theory | ∑_{i<p} iᵏ ≡ (p−1 if k≠0 ∧ (p−1)∣k else 0) (mod p) |
| `de-moivre-oq-05-oq-01` | algebra / DFT | ∑ ζʲᵏ = 0 for n∤j (=n for n∣j) — root-of-unity orthogonality |
| `lagrange-theorem-oq-07-oq-02` | group theory | n·x = 0 in a finite abelian group of order n (additive Lagrange/Euler) |

### Deployment
- Inserted into `research/db/knowledge.db` (source of truth) with `status='available'`.
- Patched the researcher-facing `.lean/state/candidate-pool.json` (operational pool: 15 → 20 available) so researchers discover them immediately.
- This PR adds the durable `problem.md` workspaces; all 5 pass `validate-seeker-stubs.ts` (no template placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)