### PR TITLE
research(combinations-formula-oq-05-oq-01): telescoping partial alternating row sum — ∑(-1)ᵏC(n,k)=(-1)ʲC(n-1,j) [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -713,6 +713,7 @@ import Proofs.CombinationsFormulaOQ02Aristotle
 import Proofs.CombinationsFormulaOQ03
 import Proofs.CombinationsFormulaOQ03OQ06
 import Proofs.CombinationsFormulaOQ05
+import Proofs.CombinationsFormulaOQ05OQ01
 import Proofs.CombinationsFormulaOQ06
 import Proofs.CombinationsFormulaOQ07
 import Proofs.CombinationsFormulaOQ07OQ01

--- a/proofs/Proofs/CombinationsFormulaOQ05OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ05OQ01.lean
@@ -1,0 +1,98 @@
+import Mathlib
+
+/-
+# Telescoping the Alternating Row Sum: the Partial Sums of Pascal's Triangle
+
+## Open Question OQ-05-OQ-01
+
+The parent file `CombinationsFormulaOQ05` proves the *full*-row cancellation
+`∑_{k=0}^{n} (-1)^k C(n,k) = 0` (for `n ≥ 1`) and reads off the even/odd split.
+That identity is the endpoint of a sharper, telescoping phenomenon: the
+**partial** alternating sums collapse to a single binomial coefficient,
+
+  ∑_{k=0}^{j} (-1)^k · C(n, k) = (-1)^j · C(n-1, j) .
+
+This is the finite-difference / telescoping refinement requested by OQ-05-OQ-01.
+
+1. `partial_alternating_sum_choose_succ` — the base form on `m+1`, proved by a
+   one-line induction on `j` using Pascal's rule (`Nat.choose_succ_succ`).
+
+2. `partial_alternating_sum_choose` — the headline identity, stated with `n-1`
+   for `n ≥ 1`.
+
+3. `alternating_sum_choose_eq_zero` — the parent's full-row cancellation
+   recovered as the `j = n` instance: the partial sum lands on
+   `(-1)^n · C(n-1, n) = 0`, because `n > n-1`.
+
+4. `partial_alternating_sum_ne_zero` — the structural consequence: for every
+   `j < n` the partial sum is **nonzero**. The alternating row sum therefore
+   never cancels early — the single cancellation to `0` happens only when the
+   last term `k = n` is included. This is exactly what distinguishes the
+   telescoping identity from the bare endpoint statement.
+
+## Mathematical Context
+
+Writing `S_n(j) := ∑_{k≤j} (-1)^k C(n,k)`, Pascal's rule
+`C(n,k) = C(n-1,k-1) + C(n-1,k)` makes the alternating sum telescope:
+the `+C(n-1,k)` of one term cancels the `-C(n-1,k)` produced by the next, so
+only the last surviving boundary term `(-1)^j C(n-1,j)` remains. Setting
+`j = n` kills even that term, giving the classical vanishing. This is the
+discrete analogue of `∫_0^x f' = f(x) - f(0)` for the forward-difference
+operator on the row `k ↦ C(n,k)`.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ05OQ01
+
+open Finset
+
+/-- **Base form.** The partial alternating sum of row `m+1` of Pascal's triangle
+    telescopes to a single binomial coefficient of row `m`:
+        `∑_{k=0}^{j} (-1)^k C(m+1, k) = (-1)^j C(m, j)`.
+    Proved by induction on `j` with Pascal's rule. -/
+theorem partial_alternating_sum_choose_succ (m j : ℕ) :
+    ∑ k ∈ Finset.range (j + 1), ((-1) ^ k * ((m + 1).choose k) : ℤ)
+      = (-1) ^ j * (m.choose j) := by
+  induction j with
+  | zero => simp
+  | succ j ih =>
+    rw [Finset.sum_range_succ, ih]
+    have hp : (((m + 1).choose (j + 1) : ℤ)) = m.choose j + m.choose (j + 1) := by
+      exact_mod_cast Nat.choose_succ_succ m j
+    rw [hp]
+    ring
+
+/-- **Telescoping partial alternating sum** (headline identity). For `n ≥ 1`,
+        `∑_{k=0}^{j} (-1)^k C(n, k) = (-1)^j C(n-1, j)`. -/
+theorem partial_alternating_sum_choose {n : ℕ} (hn : n ≠ 0) (j : ℕ) :
+    ∑ k ∈ Finset.range (j + 1), ((-1) ^ k * (n.choose k) : ℤ)
+      = (-1) ^ j * ((n - 1).choose j) := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hn
+  simpa using partial_alternating_sum_choose_succ m j
+
+/-- **Full-row cancellation recovered.** The parent's vanishing alternating row
+    sum is the `j = n` instance of the telescoping identity: the partial sum
+    reaches `(-1)^n · C(n-1, n) = 0` because `n > n-1`. -/
+theorem alternating_sum_choose_eq_zero {n : ℕ} (hn : n ≠ 0) :
+    ∑ k ∈ Finset.range (n + 1), ((-1) ^ k * (n.choose k) : ℤ) = 0 := by
+  rw [partial_alternating_sum_choose hn n, Nat.choose_eq_zero_of_lt (by omega)]
+  simp
+
+/-- **No early cancellation.** For every `j < n` the partial alternating sum is
+    nonzero (it equals `±C(n-1, j)` with `0 < C(n-1, j)`). The alternating row
+    sum cancels to `0` only when the final term `k = n` is included. -/
+theorem partial_alternating_sum_ne_zero {n : ℕ} (hn : n ≠ 0) {j : ℕ} (hj : j < n) :
+    ∑ k ∈ Finset.range (j + 1), ((-1) ^ k * (n.choose k) : ℤ) ≠ 0 := by
+  rw [partial_alternating_sum_choose hn j]
+  apply mul_ne_zero
+  · exact pow_ne_zero j (by norm_num)
+  · have hpos : 0 < (n - 1).choose j := Nat.choose_pos (by omega)
+    exact_mod_cast hpos.ne'
+
+/-- Sanity check (row 4, `j = 2`): `1 - 4 + 6 = 3 = (-1)^2 · C(3,2) = 3`. -/
+example :
+    ∑ k ∈ Finset.range 3, ((-1) ^ k * (Nat.choose 4 k) : ℤ) = 3 := by
+  decide
+
+end CombinationsFormulaOQ05OQ01

--- a/src/data/proofs/combinations-formula-oq-05-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "combinations-formula-oq-05-oq-01",
+  "title": "Telescoping the Alternating Row Sum: Partial Sums of Pascal's Triangle",
+  "slug": "combinations-formula-oq-05-oq-01",
+  "description": "Refines the full-row cancellation ∑_{k=0}^{n} (-1)^k C(n,k) = 0 into the telescoping partial-sum identity ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j). The vanishing of the full row is recovered as the j = n case (C(n-1,n) = 0), and a sharp structural consequence is proved: every proper partial sum (j < n) is nonzero, so the alternating row sum cancels to 0 only when its very last term is included.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ05OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 98,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities are fully machine-checked for every n ≥ 1 and every j. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms). The sanity example uses decide (kernel reduction), not native_decide, so no Lean.ofReduceBool is incurred.",
+    "tags": [
+      "combinatorics",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "alternating-sum",
+      "telescoping",
+      "finite-differences",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-23",
+    "originalContributions": [
+      "partial_alternating_sum_choose_succ: the base form ∑_{k=0}^{j} (-1)^k C(m+1,k) = (-1)^j C(m,j), proved by a one-line induction on j using Pascal's rule Nat.choose_succ_succ and ring (formulating over m+1 avoids all ℕ subtraction)",
+      "partial_alternating_sum_choose: the headline telescoping identity ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) for n ≥ 1, obtained from the base form via Nat.exists_eq_succ_of_ne_zero",
+      "alternating_sum_choose_eq_zero: the parent's full-row cancellation recovered as the j = n instance, since C(n-1,n) = 0 by Nat.choose_eq_zero_of_lt",
+      "partial_alternating_sum_ne_zero: the structural sharpening — for every j < n the partial sum equals ±C(n-1,j) with C(n-1,j) > 0, hence is nonzero; the single cancellation to 0 happens only at k = n",
+      "Worked verification (row 4, j = 2): 1 - 4 + 6 = 3 = (-1)^2 C(3,2)"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ05OQ01.lean",
+    "namespace": "CombinationsFormulaOQ05OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 98,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The alternating row sum ∑ (-1)^k C(n,k) = 0 is the classical statement that a nonempty finite set has equally many even-sized and odd-sized subsets. But this endpoint identity is the terminal value of a sharper telescoping phenomenon already implicit in Pascal's rule: the partial alternating sums collapse to a single binomial coefficient. In the calculus of finite differences, the row k ↦ C(n,k) is the n-fold forward difference of the constant sequence, and the partial alternating sum is its discrete antiderivative — exactly analogous to the fundamental theorem of calculus ∫_0^x f' = f(x) - f(0).",
+    "problemStatement": "Open Question OQ-05-OQ-01 (posed by the parent entry combinations-formula-oq-05): formalize the partial alternating sums ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j), refining the full cancellation into a telescoping identity.",
+    "proofStrategy": "Work over ℤ to carry the signs and over n = m+1 to eliminate ℕ subtraction. The base lemma is a direct induction on j: the j = 0 case is C(m+1,0) = C(m,0) = 1; the step uses Finset.sum_range_succ to expose the new term (-1)^{j+1} C(m+1,j+1), rewrites C(m+1,j+1) = C(m,j) + C(m,j+1) by Pascal's rule (Nat.choose_succ_succ), and closes with ring — the +C(m,j) created by Pascal cancels the surviving (-1)^j C(m,j) of the inductive hypothesis, leaving (-1)^{j+1} C(m,j+1). The n ≥ 1 form follows by writing n = m+1. The full-row vanishing is the j = n specialization (C(n-1,n) = 0 since n-1 < n), and the no-early-cancellation result reads ±C(n-1,j) ≠ 0 off the identity using Nat.choose_pos for j < n.",
+    "keyInsights": [
+      "Pascal's rule makes the alternating sum telescope: the +C(n-1,k) term it produces cancels the -C(n-1,k) of the adjacent index, leaving only the boundary term (-1)^j C(n-1,j).",
+      "The classical full-row cancellation ∑_{k=0}^{n} (-1)^k C(n,k) = 0 is not a separate fact but the j = n endpoint of this telescoping, where the boundary term C(n-1,n) itself vanishes.",
+      "The partial sums are never zero before that endpoint: each equals ±C(n-1,j) with C(n-1,j) > 0 for j < n. The alternating row sum cancels exactly once, at the final term — a sharpening the bare endpoint statement cannot see.",
+      "Formulating the base case over m+1 rather than n with a hypothesis n ≥ 1 removes every ℕ-subtraction obstacle and lets a single ring call discharge the inductive step."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and Mathematical Context",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Header stating OQ-05-OQ-01: the telescoping refinement of the alternating row sum, its four results, and the finite-difference / fundamental-theorem-of-calculus analogy."
+    },
+    {
+      "id": "base-form",
+      "title": "Base Form on m+1 (Induction)",
+      "startLine": 56,
+      "endLine": 71,
+      "summary": "partial_alternating_sum_choose_succ: ∑_{k=0}^{j} (-1)^k C(m+1,k) = (-1)^j C(m,j) by induction on j, using Finset.sum_range_succ, Pascal's rule Nat.choose_succ_succ, and ring."
+    },
+    {
+      "id": "headline",
+      "title": "Telescoping Partial Alternating Sum",
+      "startLine": 73,
+      "endLine": 80,
+      "summary": "partial_alternating_sum_choose: the n ≥ 1 form ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j), obtained from the base form via Nat.exists_eq_succ_of_ne_zero."
+    },
+    {
+      "id": "endpoint",
+      "title": "Full-Row Cancellation Recovered",
+      "startLine": 82,
+      "endLine": 89,
+      "summary": "alternating_sum_choose_eq_zero: the parent's vanishing alternating sum is the j = n instance, where C(n-1,n) = 0 by Nat.choose_eq_zero_of_lt."
+    },
+    {
+      "id": "no-early-cancel",
+      "title": "No Early Cancellation",
+      "startLine": 91,
+      "endLine": 98,
+      "summary": "partial_alternating_sum_ne_zero: for j < n the partial sum equals ±C(n-1,j) with C(n-1,j) > 0, hence nonzero; plus a worked row-4 verification (1 - 4 + 6 = 3)."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. The alternating row sum is refined from a single endpoint identity into the telescoping family ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j), the full cancellation is recovered as its j = n case, and every proper partial sum is shown to be nonzero.",
+    "implications": "Directly answers the open question posed in combinations-formula-oq-05. The telescoping identity is the discrete fundamental theorem of calculus for the forward-difference operator on a Pascal row, and the no-early-cancellation result pins down exactly when the alternation cancels. The same induction-with-Pascal template extends to signed weighted sums ∑ (-1)^k p(k) C(n,k) for polynomial weights.",
+    "openQuestions": [
+      "Does the partial sum of the signed falling-factorial moment ∑_{k=0}^{j} (-1)^k k^{(r)} C(n,k) admit an analogous closed form in terms of C(n-1-r, j-r)?",
+      "Can the residue-class (m-way) partial sums of a Pascal row, evaluated via roots of unity, be telescoped in the same Pascal-rule manner?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-05",
+      "relationship": "parent — refines its full-row alternating cancellation into the telescoping partial-sum identity and recovers the cancellation as the endpoint case"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question posed by the parent entry **combinations-formula-oq-05**: refine the full-row cancellation `∑_{k=0}^{n} (-1)^k C(n,k) = 0` into the **telescoping partial-sum identity**
```
∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j)   (n ≥ 1, any j).
```

## Results (4 theorems, 0 sorries, 0 axioms)

1. `partial_alternating_sum_choose_succ` — base form on `m+1`, one-line induction on `j` via Pascal's rule (`Nat.choose_succ_succ`) + `ring` (formulating over `m+1` avoids all ℕ subtraction).
2. `partial_alternating_sum_choose` — headline identity `∑_{k≤j} (-1)^k C(n,k) = (-1)^j C(n-1,j)` for `n ≥ 1`.
3. `alternating_sum_choose_eq_zero` — the parent's full-row cancellation **recovered** as the `j = n` instance (`C(n-1,n) = 0`).
4. `partial_alternating_sum_ne_zero` — sharp structural consequence: every **proper** partial sum (`j < n`) is nonzero (equals `±C(n-1,j)`, `C(n-1,j) > 0`). The alternating row cancels to 0 **only** at the final term.

## Why it matters

The telescoping is the discrete fundamental theorem of calculus for the forward-difference operator on a Pascal row: Pascal's `+C(n-1,k)` cancels the adjacent `-C(n-1,k)`, leaving a single boundary term. The no-early-cancellation result pins down *exactly when* the alternation cancels — information the bare endpoint statement cannot see.

## Verification

`#print axioms` on all three main theorems: `[propext, Classical.choice, Quot.sound]` only. Sanity example uses `decide` (kernel), not `native_decide` — no `Lean.ofReduceBool`. Typechecks under Lean v4.26 / Mathlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)