### PR TITLE
Enrich: Palindromicity of the Eulerian Polynomial (geometric-series oq-02)

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "Palindromicity of the Eulerian Polynomial",
+    "content": "The docstring states open question oq-02: prove the reflection symmetry ⟨m,k⟩ = ⟨m,m−1−k⟩ of the Eulerian numbers, equivalently Eₘ(X) = X^{m+1}·Eₘ(1/X) for m ≥ 1. The Eulerian polynomial Eₘ is inherited from the parent entry through its first-order differential recurrence E₀ = 1, E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ, with low rows E₁ = X, E₂ = X+X², E₃ = X+4X²+X³. The whole development works at the level of coefficients over an arbitrary commutative ring R (declared by the variable line), deliberately avoiding any combinatorial descent-statistic definition or bijection — Mathlib has none of these objects.",
+    "mathContext": "$\\langle m,k\\rangle = \\langle m,m-1-k\\rangle$, equivalently $E_m(X) = X^{m+1}E_m(1/X)$, from $E_{m+1} = X(1-X)E_m' + (m+1)X E_m$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Eulerian numbers",
+      "Eulerian polynomial",
+      "palindromic polynomial",
+      "reflection symmetry",
+      "differential recurrence"
+    ],
+    "prerequisites": [
+      "univariate polynomials",
+      "formal derivative",
+      "combinatorics"
+    ]
+  },
+  {
+    "id": "ann-coeff-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 112 },
+    "type": "technique",
+    "title": "Extracting the Coefficient Recurrence from the Differential Recurrence",
+    "content": "Part 1 converts the differential recurrence into a recurrence on coefficients — the engine of the whole file. natCast_add_one_eq_C rewrites the scalar (m+1) as a constant polynomial C(m+1). coeff_eulerPoly_succ_zero shows the constant term vanishes (every term carries a factor X), extended to m ≥ 1 by coeff_eulerPoly_zero_eq_zero; coeff_eulerPoly_succ_one is the index-1 boundary value. The centerpiece coeff_eulerPoly_succ_add_two splits X(1−X)E'ₘ into X·E'ₘ − X²·E'ₘ and reads off the coefficient at index j+2 using three Mathlib lemmas: coeff_X_mul (index shift −1), coeff_X_pow_mul (index shift −2), and coeff_derivative (which supplies the (n+1) weight of the formal derivative). The result is a clean three-term recurrence relating the (j+2), (j+1) coefficients of Eₘ to the (j+2) coefficient of E_{m+1}.",
+    "mathContext": "$\\mathrm{coeff}(E_{m+1}, j+2) = (j+2)\\,\\mathrm{coeff}(E_m, j+2) - (j+1)\\,\\mathrm{coeff}(E_m, j+1) + (m+1)\\,\\mathrm{coeff}(E_m, j+1)$, via $(\\mathrm{D}p).\\mathrm{coeff}\\,n = p.\\mathrm{coeff}(n+1)(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "coefficient extraction",
+      "Polynomial.coeff_derivative",
+      "coeff_X_mul / coeff_X_pow_mul index shifts",
+      "constant polynomial C"
+    ],
+    "prerequisites": [
+      "polynomial coefficient API",
+      "formal derivative of polynomials"
+    ]
+  },
+  {
+    "id": "ann-degree-bound",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+    "range": { "startLine": 114, "endLine": 127 },
+    "type": "technique",
+    "title": "Degree Bound deg Eₘ ≤ m",
+    "content": "coeff_eulerPoly_eq_zero proves coeff(Eₘ, j) = 0 for every j > m, i.e. the Eulerian polynomial has degree at most m. The induction is on m generalizing j: the base case uses E₀ = 1 (a constant, so all positive-index coefficients vanish), and the successor case writes j = j'+2 and applies the core recurrence coeff_eulerPoly_succ_add_two, both of whose surviving terms vanish by the induction hypothesis (the indices j'+2 and j'+1 both exceed the previous row's degree). This bound is the top-of-row boundary input that allows the symmetric induction to close at the high end of each row.",
+    "mathContext": "$j > m \\Rightarrow \\mathrm{coeff}(E_m, j) = 0$, so $\\deg E_m \\le m$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "degree of a polynomial",
+      "induction generalizing the index",
+      "vanishing coefficients"
+    ],
+    "prerequisites": [
+      "polynomial degree",
+      "induction in Lean"
+    ]
+  },
+  {
+    "id": "ann-palindrome",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+    "range": { "startLine": 129, "endLine": 187 },
+    "type": "insight",
+    "title": "The Palindromicity Induction",
+    "content": "eulerPoly_palindrome is the headline: for m ≥ 1, a+b = m+1 ⟹ coeff(Eₘ, a) = coeff(Eₘ, b), proved by Nat.le_induction. The base m=1 (E₁ = X) is a coeff_X case split. The step proves an ordered helper assuming a ≤ b, matching on the index pair: (0, n+2) has both sides vanishing (constant term via coeff_eulerPoly_succ_zero, top via the degree bound); (1, n+1) equates the two boundary values, routed through the inner induction hypothesis ih 1 (n'+1); the interior (a+2, b+2) applies the core recurrence to both sides and closes with a single linear_combination after ih pairs coeff(Eₙ, a+2)↔coeff(Eₙ, b+1) and coeff(Eₙ, a+1)↔coeff(Eₙ, b+2). The recurrence weights — which sum to n+2 across the paired coefficients — are exactly what makes the symmetric matching balance. The general (unordered) statement follows by le_total and .symm. eulerPoly_coeff_symm restates this as the reflection coeff(Eₘ, a) = coeff(Eₘ, m+1−a), with a > m+1 handled by both sides vanishing.",
+    "mathContext": "$a + b = m+1 \\Rightarrow \\mathrm{coeff}(E_m, a) = \\mathrm{coeff}(E_m, b)$; the interior case balances via $\\mathrm{linear\\_combination}$ over the paired recurrence weights summing to $n+2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.le_induction",
+      "structural induction on index pairs",
+      "linear_combination",
+      "reflection symmetry"
+    ],
+    "prerequisites": [
+      "induction in Lean",
+      "polynomial coefficients",
+      "the coefficient recurrence"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+    "range": { "startLine": 189, "endLine": 218 },
+    "type": "concept",
+    "title": "Corner Eulerian Numbers, Degree, and Monicity",
+    "content": "Part 4 reads off structural corollaries. eulerPoly_coeff_one proves the first Eulerian number ⟨m,0⟩ = 1 (coeff(Eₘ, 1) = 1) by an independent induction using the index-1 boundary value. eulerPoly_coeff_self then gets the leading number ⟨m,m−1⟩ = 1 (coeff(Eₘ, m) = 1) for FREE by reflecting index 1 onto index m via eulerPoly_coeff_symm — symmetry converting one computation into two. eulerPoly_natDegree computes the exact degree m over a [Nontrivial R] ring (the ≤ m bound from coeff_eulerPoly_eq_zero, the ≥ m bound from the leading coefficient 1 ≠ 0), and eulerPoly_monic concludes Eₘ is monic. The [Nontrivial R] hypothesis is needed only here, to know 1 ≠ 0.",
+    "mathContext": "$\\langle m,0\\rangle = \\langle m,m-1\\rangle = 1$; over a nontrivial ring $\\deg E_m = m$ and $E_m$ is monic (leading coefficient $\\langle m,m-1\\rangle = 1$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "extreme Eulerian numbers",
+      "leading coefficient",
+      "monic polynomial",
+      "Nontrivial ring hypothesis"
+    ],
+    "prerequisites": [
+      "polynomial degree and leading coefficient",
+      "Monic"
+    ]
+  },
+  {
+    "id": "ann-sanity-checks",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+    "range": { "startLine": 220, "endLine": 228 },
+    "type": "technique",
+    "title": "Low-Order Sanity Checks on the Symmetric Rows",
+    "content": "Two examples corroborate the theorem on the smallest palindromic rows: coeff(E₂, 1) = coeff(E₂, 2) (the row 1 1) and coeff(E₃, 1) = coeff(E₃, 3) (the row 1 4 1). Each is discharged by directly applying eulerPoly_palindrome with the trivial hypothesis (by norm_num for m ≥ 1 and rfl for the index sum) — NOT by decide or native_decide — so they exercise the proved theorem itself and add no axiom dependency, keeping the entry honestly 0-axiom (propext / Classical.choice / Quot.sound only).",
+    "mathContext": "$E_2 = X + X^2$ (row $1\\,1$); $E_3 = X + 4X^2 + X^3$ (row $1\\,4\\,1$) — palindromic by the theorem, not by kernel evaluation.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "sanity-check examples",
+      "axiom integrity",
+      "applying a proved theorem"
+    ],
+    "prerequisites": [
+      "Lean example declarations"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ07OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ07OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ07OQ01OQ01OQ02Data: ProofData = {
+  proof: geometricSeriesOQ07OQ01OQ01OQ02Proof,
+  annotations: geometricSeriesOQ07OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-02/meta.json
@@ -1,6 +1,7 @@
 {
   "id": "geometric-series-oq-07-oq-01-oq-01-oq-02",
   "slug": "geometric-series-oq-07-oq-01-oq-01-oq-02",
+  "description": "The Eulerian polynomial Eₘ (defined by the differential recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ) is palindromic for m ≥ 1: coeff(Eₘ, a) = coeff(Eₘ, m+1−a), i.e. the Eulerian numbers are symmetric ⟨m,k⟩ = ⟨m,m−1−k⟩. Proved over any commutative ring purely by coefficient extraction — no combinatorial descent-statistic definition. Corollaries: the extreme numbers ⟨m,0⟩ = ⟨m,m−1⟩ = 1, degree exactly m, and monicity. 228 lines, 11 theorems, 0 axioms, 0 sorries.",
   "leanFile": {
     "imports": [
       "Mathlib",
@@ -74,6 +75,120 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨m,k⟩ count permutations of {1,…,m} with exactly k descents, and the Eulerian polynomial A_m(t) = ∑_k ⟨m,k⟩ t^k arose in Leonhard Euler's 1755 Institutiones calculi differentialis as the numerator in summing ∑_{n≥0} n^m t^n = A_m(t)/(1−t)^{m+1}. The reflection symmetry ⟨m,k⟩ = ⟨m,m−1−k⟩ — equivalently the palindromicity of A_m(t) — is one of the oldest structural facts about these numbers: combinatorially it follows from the descent–ascent involution (reverse a permutation, sending k descents to m−1−k descents), but it can also be proved purely analytically from the polynomial's recurrence. This entry — open question oq-02 under the geometric-series Eulerian study — takes the analytic route: it works from the parent's first-order differential recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ over an arbitrary commutative ring, extracts a coefficient recurrence, and proves the symmetry by induction without ever invoking the descent statistic or any bijection. Mathlib contains neither the Eulerian numbers, the Eulerian polynomials, nor this symmetry.",
+    "problemStatement": "Prove the palindromic symmetry of the Eulerian polynomial: for m ≥ 1, coeff(Eₘ, a) = coeff(Eₘ, m+1−a) for every a — equivalently ⟨m,k⟩ = ⟨m,m−1−k⟩ — working over an arbitrary commutative ring directly from the differential recurrence defining Eₘ, and read off the resulting structural corollaries (the extreme coefficients equal 1, the degree, and monicity).",
+    "text": "A 228-line, 0-axiom development with 11 theorems. Part 1 extracts the coefficient recurrence coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1) + (m+1)·coeff(Eₘ, j+1) (coeff_eulerPoly_succ_add_two) plus the boundary values at indices 0 and 1, by feeding Polynomial.coeff_derivative / coeff_X_mul / coeff_X_pow_mul through the differential recurrence. Part 2 proves the degree bound coeff(Eₘ, j) = 0 for j > m. Part 3 is the headline: eulerPoly_palindrome (a+b = m+1 ⟹ coeff a = coeff b) by Nat.le_induction, with the reflection restatement eulerPoly_coeff_symm. Part 4 reads off the corollaries — the extreme Eulerian numbers ⟨m,0⟩ = ⟨m,m−1⟩ = 1 (eulerPoly_coeff_one / eulerPoly_coeff_self), the exact degree m, and monicity over a nontrivial ring. Part 5 checks the symmetric rows 1 and 1 4 1 against the theorem. Everything is over a general CommRing R.",
+    "proofStrategy": "The whole development is coefficient extraction. The differential recurrence is split into X·E'ₘ − X²·E'ₘ + (m+1)X·Eₘ; applying coeff at index j+2 and using coeff_X_mul (index −1), coeff_X_pow_mul (index −2) and coeff_derivative (the n+1 weight) yields the three-term coefficient recurrence. The degree bound is an easy induction killing both recurrence terms above index m. For palindromicity, Nat.le_induction on m: the base m=1 is E₁ = X (coeff_X case split); the step proves an ordered helper (assuming a ≤ b) by matching on the pair (a,b) — case (0, n+2) has both sides vanishing (constant term and above-degree), case (1, n+1) equates the two boundary values through the inner induction hypothesis ih 1 (n'+1), and the interior case (a+2, b+2) applies the core recurrence to both sides and closes with a single linear_combination once ih pairs coeff(Eₙ, a+2)↔coeff(Eₙ, b+1) and coeff(Eₙ, a+1)↔coeff(Eₙ, b+2) — the recurrence weights (summing to n+2) being exactly what makes the symmetric pairing balance. The general statement follows by le_total + .symm. Corollaries combine the degree bound with the non-vanishing leading coefficient.",
+    "keyInsights": [
+      "Palindromicity is derived analytically, not combinatorially: the symmetry ⟨m,k⟩ = ⟨m,m−1−k⟩ comes straight from the differential recurrence by coefficient extraction, with no descent-statistic definition and no descent↔ascent bijection — a genuinely different proof from the textbook one.",
+      "The single coefficient recurrence coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1) + (m+1)·coeff(Eₘ, j+1) is the engine of everything: the degree bound, the boundary corner values, AND the symmetry all fall out of it. Its weights at the j+1 and j+2 coefficients sum to m+2, which is precisely the bookkeeping that propagates the symmetry across a row.",
+      "The proof respects the index arithmetic by matching on coefficient-index shapes (0, 1, and _+2) rather than fighting subtraction: X shifts the index by 1 (coeff_X_mul), X² by 2 (coeff_X_pow_mul), and the formal derivative supplies the (n+1) weight (coeff_derivative) — so the natural recurrence lives at index j+2 and the boundary indices 0,1 are handled as separate lemmas.",
+      "Everything is over an ARBITRARY commutative ring R, not just ℤ or ℚ: the Eulerian numbers are integers, but the symmetry is a polynomial-coefficient identity that holds in any CommRing, and only the degree/monicity corollaries need [Nontrivial R] (to know the leading coefficient 1 ≠ 0).",
+      "The two corner Eulerian numbers are obtained with minimal work and illustrate the symmetry concretely: ⟨m,0⟩ = 1 is a direct induction (eulerPoly_coeff_one), and ⟨m,m−1⟩ = 1 is then FREE by palindromicity (eulerPoly_coeff_self reflects index 1 onto index m) — symmetry turns one computation into two.",
+      "Monicity and exact degree are corollaries of symmetry, not separate inductions: the degree bound gives ≤ m, and the leading coefficient is the reflected corner ⟨m,m−1⟩ = 1 ≠ 0, so deg Eₘ = m and Eₘ is monic — the leading coefficient being 1 is itself a manifestation of the palindrome pinning the top of each row to the bottom."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "eulerPoly_palindrome",
+      "type": "core",
+      "description": "Palindromicity (symmetric form): for m ≥ 1, a + b = m + 1 ⟹ coeff(Eₘ, a) = coeff(Eₘ, b). The Eulerian numbers are symmetric ⟨m,k⟩ = ⟨m,m−1−k⟩.",
+      "leanType": "∀ a b : ℕ, a + b = m + 1 → (eulerPoly m).coeff a = (eulerPoly m).coeff b"
+    },
+    {
+      "name": "eulerPoly_coeff_symm",
+      "type": "core",
+      "description": "Palindromicity (reflection form): for m ≥ 1, coeff(Eₘ, a) = coeff(Eₘ, m+1−a) for every a, including off-support indices where both vanish.",
+      "leanType": "(eulerPoly m).coeff a = (eulerPoly m).coeff (m + 1 - a)"
+    },
+    {
+      "name": "coeff_eulerPoly_succ_add_two",
+      "type": "core",
+      "description": "The core coefficient recurrence extracted from the differential recurrence: coeff(E_{m+1}, j+2) = (j+2)·coeff(Eₘ, j+2) − (j+1)·coeff(Eₘ, j+1) + (m+1)·coeff(Eₘ, j+1).",
+      "leanType": "(eulerPoly (m+1)).coeff (j+2) = (eulerPoly m).coeff (j+2) * (j+2) - (eulerPoly m).coeff (j+1) * (j+1) + (m+1) * (eulerPoly m).coeff (j+1)"
+    },
+    {
+      "name": "coeff_eulerPoly_eq_zero",
+      "type": "supporting",
+      "description": "Degree bound: coeff(Eₘ, j) = 0 for j > m, i.e. deg Eₘ ≤ m. The top-of-row boundary input for the symmetric induction.",
+      "leanType": "m < j → (eulerPoly m).coeff j = 0"
+    },
+    {
+      "name": "eulerPoly_coeff_one",
+      "type": "supporting",
+      "description": "The first Eulerian number ⟨m,0⟩ = 1: coeff(Eₘ, 1) = 1 for m ≥ 1, by induction.",
+      "leanType": "(eulerPoly m).coeff 1 = 1"
+    },
+    {
+      "name": "eulerPoly_coeff_self",
+      "type": "supporting",
+      "description": "The leading Eulerian number ⟨m,m−1⟩ = 1: coeff(Eₘ, m) = 1, read off from coeff 1 = 1 by palindromicity.",
+      "leanType": "(eulerPoly m).coeff m = 1"
+    },
+    {
+      "name": "eulerPoly_natDegree",
+      "type": "supporting",
+      "description": "Over a nontrivial ring, deg Eₘ = m for m ≥ 1 — the degree bound plus the non-vanishing leading coefficient.",
+      "leanType": "(eulerPoly m).natDegree = m"
+    },
+    {
+      "name": "eulerPoly_monic",
+      "type": "supporting",
+      "description": "Over a nontrivial ring, Eₘ is monic for m ≥ 1: the leading coefficient is ⟨m,m−1⟩ = 1.",
+      "leanType": "(eulerPoly m).Monic"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Problem Statement: Palindromicity of the Eulerian Polynomial",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "The docstring states oq-02: prove the palindromic symmetry ⟨m,k⟩ = ⟨m,m−1−k⟩ of the Eulerian numbers, equivalently Eₘ(X) = X^{m+1}·Eₘ(1/X) for m ≥ 1, where Eₘ is the parent's Eulerian polynomial defined by E₀ = 1, E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ (with E₁ = X, E₂ = X+X², E₃ = X+4X²+X³). It announces the strategy — extract a coefficient recurrence and induct — and the corollaries (extreme numbers, degree, monicity). Followed by imports of Mathlib and the parent, the namespace, the opens (Polynomial, Finset), the selective open of eulerPoly and its lemmas, and the variable declaration over an arbitrary CommRing R.",
+      "mathContext": "$\\langle m,k\\rangle = \\langle m,m-1-k\\rangle$, i.e. $E_m(X) = X^{m+1}E_m(1/X)$, with $E_{m+1} = X(1-X)E_m' + (m+1)X E_m$."
+    },
+    {
+      "id": "coefficient-recurrence",
+      "title": "Part 1: The Coefficient Recurrence",
+      "startLine": 55,
+      "endLine": 112,
+      "summary": "Coefficient extraction turns the differential recurrence into a recurrence on coefficients. natCast_add_one_eq_C rewrites (m+1 : R[X]) as C(m+1). coeff_eulerPoly_succ_zero gives the vanishing constant term (every term carries a factor X), and coeff_eulerPoly_zero_eq_zero extends it to m ≥ 1. coeff_eulerPoly_succ_one is the index-1 boundary value. The centerpiece coeff_eulerPoly_succ_add_two splits X(1−X)E'ₘ into X·E'ₘ − X²·E'ₘ and applies coeff_X_mul (shift 1), coeff_X_pow_mul (shift 2) and coeff_derivative (the n+1 weight) at index j+2, yielding the three-term recurrence.",
+      "mathContext": "$\\mathrm{coeff}(E_{m+1}, j+2) = (j+2)\\,\\mathrm{coeff}(E_m, j+2) - (j+1)\\,\\mathrm{coeff}(E_m, j+1) + (m+1)\\,\\mathrm{coeff}(E_m, j+1)$."
+    },
+    {
+      "id": "degree-bound",
+      "title": "Part 2: Degree Bound",
+      "startLine": 114,
+      "endLine": 127,
+      "summary": "coeff_eulerPoly_eq_zero proves coeff(Eₘ, j) = 0 whenever j > m, i.e. deg Eₘ ≤ m, by induction on m generalizing j: the base uses E₀ = 1, and the step writes j = j'+2 and applies the core recurrence, both of whose surviving terms vanish by the induction hypothesis. This is the top-of-row boundary that lets the symmetric induction close.",
+      "mathContext": "$j > m \\Rightarrow \\mathrm{coeff}(E_m, j) = 0$, so $\\deg E_m \\le m$."
+    },
+    {
+      "id": "palindromicity",
+      "title": "Part 3: Palindromicity",
+      "startLine": 129,
+      "endLine": 187,
+      "summary": "eulerPoly_palindrome proves a+b = m+1 ⟹ coeff(Eₘ, a) = coeff(Eₘ, b) for m ≥ 1 by Nat.le_induction. The base m=1 is E₁ = X by coeff_X case analysis. The step proves an ordered helper (a ≤ b) by matching on (a,b): the (0, n+2) case has both sides vanishing (constant term and above degree), the (1, n+1) case equates the two boundary values through the inner IH, and the interior (a+2, b+2) case applies the core recurrence to both sides and closes with one linear_combination once the IH pairs the inner coefficients — the recurrence weights making the symmetric pairing balance. The general statement follows by le_total and .symm. eulerPoly_coeff_symm restates it in reflection form coeff(Eₘ, a) = coeff(Eₘ, m+1−a), handling a > m+1 by both sides vanishing.",
+      "mathContext": "$a + b = m+1 \\Rightarrow \\mathrm{coeff}(E_m,a) = \\mathrm{coeff}(E_m,b)$; reflection: $\\mathrm{coeff}(E_m,a) = \\mathrm{coeff}(E_m, m+1-a)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part 4: Structural Corollaries",
+      "startLine": 189,
+      "endLine": 218,
+      "summary": "eulerPoly_coeff_one proves the first Eulerian number ⟨m,0⟩ = 1 (coeff(Eₘ, 1) = 1) by induction. eulerPoly_coeff_self gets the leading number ⟨m,m−1⟩ = 1 (coeff(Eₘ, m) = 1) FREE by reflecting index 1 onto index m via eulerPoly_coeff_symm. eulerPoly_natDegree computes the exact degree m over a nontrivial ring (degree bound ≤ m plus leading coefficient 1 ≠ 0), and eulerPoly_monic concludes monicity.",
+      "mathContext": "$\\langle m,0\\rangle = \\langle m,m-1\\rangle = 1$; $\\deg E_m = m$; $E_m$ monic (over a nontrivial ring)."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part 5: Low-Order Sanity Checks",
+      "startLine": 220,
+      "endLine": 228,
+      "summary": "Two examples confirm the symmetric rows against the theorem: coeff(E₂, 1) = coeff(E₂, 2) (the row 1 1) and coeff(E₃, 1) = coeff(E₃, 3) (the row 1 4 1), each discharged by applying eulerPoly_palindrome directly (not by decide), so they add no axiom dependency.",
+      "mathContext": "$E_2 = X + X^2$ (row $1\\,1$), $E_3 = X + 4X^2 + X^3$ (row $1\\,4\\,1$) — both palindromic."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-07-oq-01-oq-01-oq-02-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-02`.

Rich `meta.json` existed but the entry was **missing the required `index.ts`** (→ live-site 404) and had no `overview`, `sections`, `annotations.json`, or top-level `description`.

## Changes
- **Created `index.ts`** (REQUIRED) — fixes the live-site 404.
- **Added `annotations.json`** — 6 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering the docstring, the coefficient recurrence (Part 1), the degree bound (Part 2), the palindromicity induction (Part 3), the corner/degree/monicity corollaries (Part 4), and the sanity checks (Part 5).
- **Added `overview`** — `historicalContext` (Euler 1755, the descent-statistic symmetry), `problemStatement`, `text`, `proofStrategy`, 6 `keyInsights` (analytic vs combinatorial proof; the single coefficient recurrence as engine; index-shape matching; arbitrary CommRing generality; symmetry giving the second corner free; monicity from symmetry).
- **Added 6 `sections`** covering the full 228-line Lean file with `mathContext`.
- **Added `mainTheorems`** (8 entries) and a top-level `description`.

## Integrity
- `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` confirmed against the source: no `axiom`/`sorry`; the two sanity-check `example`s apply the proved `eulerPoly_palindrome` (no `decide`/`native_decide`), so there is no `Lean.ofReduceBool` dependency. Claims unchanged.
- Additive enrichment only; all pre-existing content preserved.

## Verification
- `tsc -b` ✓ (exit 0); JSON valid; all annotation ranges within the 228-line file.