### PR TITLE
Enrich Power of a Point (ptolemys-theorem-oq-04)

### DIFF
--- a/src/data/proofs/ptolemys-theorem-oq-04/index.ts
+++ b/src/data/proofs/ptolemys-theorem-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PtolemysTheoremOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const ptolemysTheoremOq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const ptolemysTheoremOq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const ptolemysTheoremOq04Data: ProofData = {
+  proof: ptolemysTheoremOq04Proof,
+  annotations: ptolemysTheoremOq04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `ptolemys-theorem-oq-04` — the coordinate-free Power of a Point package.

This entry shipped with only `meta.json` (with a partial overview) — it was missing the `index.ts` (so the proof page would show "proof not found" on the live site), an `annotations.json`, `sections`, a `conclusion`, and the overview lacked `proofStrategy`/`keyInsights`.

## Changes
- **index.ts** (REQUIRED): created so the proof loads on the site.
- **annotations.json**: 10 annotations covering all 12 theorems/lemmas (intersecting chords/secants, the power invariant, line-independence, signed forms, tangent–secant, equal tangents, and the concrete ℂ witness). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **overview**: added `proofStrategy` and 5 `keyInsights` (entry previously had only historicalContext/problemStatement/text).
- **sections**: 5 sections covering the full 165-line Lean file.
- **conclusion**: summary, implications, and 3 openQuestions (radical axis/centre, inversive geometry, reusable perpendicular-diameter witness).
- **crossReferences**: links to `ptolemys-theorem` (additive relation), `product-of-segments-of-chords` (2D Vec2 proof), and `ptolemys-complex-proof`.

## Verification
- `pnpm build` succeeds (`tsc -b` clean, `vite build` OK; proof appears in generated `listings.json` and `public/data/proofs/`).
- Axiom integrity preserved: `status: verified`, `axiomCount: 0`, no sorries; the Lean file delegates to Mathlib's Sphere.power API with no axiom declarations or assumption-carrying structures — consistent with the metadata.