### PR TITLE
research(de-moivre-oq-05-oq-01): Orthogonality of the Roots of Unity (DFT Inversion) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -780,6 +780,7 @@ import Proofs.DeMoivreOQ03OQ01
 import Proofs.DeMoivreOQ03OQ01OQ01
 import Proofs.DeMoivreOQ04
 import Proofs.DeMoivreOQ05
+import Proofs.DeMoivreOQ05OQ01
 import Proofs.DedekindFrobeniusBridge
 import Proofs.DenumerabilityRationals
 import Proofs.DenumerabilityRationalsOQ01

--- a/proofs/Proofs/DeMoivreOQ05OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ05OQ01.lean
@@ -1,0 +1,198 @@
+/-
+Orthogonality of the n-th roots of unity (discrete-Fourier inversion)
+
+Source: Open question from the de-moivre gallery family (de-moivre-oq-05-oq-01)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent entry (de-moivre-oq-05) proves the single classical fact that for
+`n > 1` the `n` complex `n`-th roots of unity sum to zero, i.e.
+
+      ∑_{k=0}^{n-1} ζ^k = 0.
+
+This is exactly the `j = 1` slice of the full **orthogonality relation** that
+underlies the discrete Fourier transform.  If `ζ` is a primitive `n`-th root of
+unity then for every integer frequency `j`
+
+      ∑_{k=0}^{n-1} ζ^{jk}  =  ⎧ n   if n ∣ j        (all phases coincide)
+                               ⎨
+                               ⎩ 0   if n ∤ j        (geometric cancellation).
+
+This is the orthogonality / DFT-inversion identity: the columns of the DFT
+matrix are pairwise orthogonal, and a full period of any non-trivial sampling
+character sums to zero.  Mathlib records the `j = 1` geometric vanishing
+(`IsPrimitiveRoot.geom_sum_eq_zero`) but not the full frequency-indexed
+dichotomy; we supply it.
+
+Proof.  Write each term as `ζ^{jk} = (ζ^j)^k`, so the sum is the geometric
+series `∑_{k<n} w^k` with ratio `w = ζ^j`.
+
+* If `n ∣ j` then `w = ζ^j = 1` (primitivity), every term is `1`, and the sum
+  is `n`.
+* If `n ∤ j` then `w = ζ^j ≠ 1` (primitivity again), while `w^n = (ζ^n)^j = 1`.
+  The telescoping identity `(∑_{k<n} w^k)·(w − 1) = w^n − 1 = 0` together with
+  `w − 1 ≠ 0` in an integral domain forces the sum to vanish.
+
+We prove the relation over any integral domain possessing a primitive root,
+then specialise to `ℂ` and to the explicit de Moivre / DFT form
+`∑_{k<n} exp(2πi·jk/n)`, and finally recover the parent statement as the
+`j = 1` corollary.
+
+Theorems:
+1. `sum_pow_eq_ite`              — orthogonality over an integral domain
+2. `sum_pow_eq_zero_of_not_dvd`  — the cancellation (off-diagonal) case
+3. `sum_complex_pow_eq_ite`      — the ℂ specialisation
+4. `sum_exp_orthogonality`       — explicit de Moivre / DFT form
+5. `sum_complex_zpow_eq_ite`     — signed-frequency (j : ℤ) orthogonality over ℂ
+6. `sum_char_inner`             — orthonormality of the DFT characters (inversion)
+7. `sum_geom_eq_zero`            — parent recovery: ∑ ζ^k = 0 for n > 1
+-/
+
+import Mathlib
+
+open Finset
+
+namespace DeMoivreOQ05OQ01
+
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-- **Orthogonality of the roots of unity.**
+For a primitive `n`-th root of unity `ζ` (`n > 0`) and any frequency `j`, the
+power sum `∑_{k<n} ζ^{jk}` equals `n` when `n ∣ j` and `0` otherwise.  This is
+the frequency-indexed generalisation of the parent's `∑_{k<n} ζ^k = 0`: writing
+each term as `(ζ^j)^k` turns the sum into a geometric series with ratio `ζ^j`,
+which is `1` exactly when `n ∣ j` and otherwise a non-trivial `n`-th root, so the
+telescoping `(∑ w^k)(w − 1) = w^n − 1 = 0` collapses it to zero. -/
+theorem sum_pow_eq_ite {ζ : R} {n : ℕ} (hζ : IsPrimitiveRoot ζ n)
+    (j : ℕ) : ∑ k ∈ range n, ζ ^ (j * k) = if n ∣ j then (n : R) else 0 := by
+  have hsplit : ∀ k, ζ ^ (j * k) = (ζ ^ j) ^ k := fun k => by rw [← pow_mul]
+  simp only [hsplit]
+  split_ifs with h
+  · -- `n ∣ j` ⟹ `ζ^j = 1`, every term is `1`, the sum is `n`.
+    rw [(hζ.pow_eq_one_iff_dvd j).mpr h]
+    simp
+  · -- `n ∤ j` ⟹ `ζ^j ≠ 1`, geometric cancellation.
+    have hne : ζ ^ j - 1 ≠ 0 := by
+      rw [sub_ne_zero]
+      intro hh
+      exact h ((hζ.pow_eq_one_iff_dvd j).mp hh)
+    have hxn : (ζ ^ j) ^ n = 1 := by
+      rw [← pow_mul, mul_comm, pow_mul, hζ.pow_eq_one, one_pow]
+    have hgs := geom_sum_mul (ζ ^ j) n
+    rw [hxn, sub_self] at hgs
+    rcases mul_eq_zero.mp hgs with h1 | h2
+    · exact h1
+    · exact absurd h2 hne
+
+/-- **Off-diagonal cancellation.**
+When the frequency `j` is not a multiple of `n`, the orthogonality sum vanishes —
+the geometric-series form of the statement that distinct DFT modes are
+orthogonal. -/
+theorem sum_pow_eq_zero_of_not_dvd {ζ : R} {n : ℕ} (hζ : IsPrimitiveRoot ζ n)
+    {j : ℕ} (h : ¬ n ∣ j) : ∑ k ∈ range n, ζ ^ (j * k) = 0 := by
+  rw [sum_pow_eq_ite hζ j, if_neg h]
+
+/-- **The complex orthogonality relation.**
+Specialisation of `sum_pow_eq_ite` to `ℂ`, whose canonical primitive `n`-th root
+of unity is `exp(2πi/n)`. -/
+theorem sum_complex_pow_eq_ite {n : ℕ} (hn : 0 < n) (j : ℕ) :
+    ∑ k ∈ range n, (Complex.exp (2 * ↑Real.pi * Complex.I / ↑n)) ^ (j * k)
+      = if n ∣ j then (n : ℂ) else 0 :=
+  sum_pow_eq_ite (Complex.isPrimitiveRoot_exp n hn.ne') j
+
+/-- **Explicit de Moivre / discrete-Fourier form.**
+The `n` sampled phases `exp(2πi·jk/n)`, `k = 0, …, n-1`, of the integer frequency
+`j` sum to `n` when `j` is a multiple of `n` (all phases coincide) and to `0`
+otherwise (a full period cancels).  This is the identity behind DFT inversion;
+the parent's vanishing-sum is the `j = 1` instance. -/
+theorem sum_exp_orthogonality {n : ℕ} (hn : 0 < n) (j : ℕ) :
+    ∑ k ∈ range n, Complex.exp (2 * ↑Real.pi * Complex.I * ↑j * ↑k / ↑n)
+      = if n ∣ j then (n : ℂ) else 0 := by
+  rw [← sum_complex_pow_eq_ite hn j]
+  refine Finset.sum_congr rfl (fun k _ => ?_)
+  rw [← Complex.exp_nat_mul]
+  congr 1
+  push_cast
+  ring
+
+/-- **Integer-frequency orthogonality over ℂ.**
+The orthogonality relation extends to *signed* frequencies `j : ℤ` (negative
+modes), using the integer power `ζ^{jk}` of the primitive root `ζ = exp(2πi/n)`.
+The proof is the same geometric collapse, now with `IsPrimitiveRoot`'s integer
+divisibility criterion `ζ^j = 1 ↔ (n:ℤ) ∣ j`.  This signed form is what feeds
+the orthonormality of the Fourier characters. -/
+theorem sum_complex_zpow_eq_ite {n : ℕ} (hn : 0 < n) (j : ℤ) :
+    ∑ k ∈ range n, (Complex.exp (2 * ↑Real.pi * Complex.I / ↑n)) ^ (j * (k : ℤ))
+      = if (n : ℤ) ∣ j then (n : ℂ) else 0 := by
+  set ζ := Complex.exp (2 * ↑Real.pi * Complex.I / ↑n) with hζdef
+  have hprim := Complex.isPrimitiveRoot_exp n hn.ne'
+  have hsplit : ∀ k : ℕ, ζ ^ (j * (k : ℤ)) = (ζ ^ j) ^ k := by
+    intro k; rw [zpow_mul, zpow_natCast]
+  simp only [hsplit]
+  split_ifs with h
+  · rw [(hprim.zpow_eq_one_iff_dvd j).mpr h]
+    simp
+  · have hne : ζ ^ j - 1 ≠ 0 := by
+      rw [sub_ne_zero]; intro hh
+      exact h ((hprim.zpow_eq_one_iff_dvd j).mp hh)
+    have hxn : (ζ ^ j) ^ n = 1 := by
+      rw [← zpow_natCast (ζ ^ j) n, ← zpow_mul, mul_comm, zpow_mul, zpow_natCast,
+        hprim.pow_eq_one, one_zpow]
+    have hgs := geom_sum_mul (ζ ^ j) n
+    rw [hxn, sub_self] at hgs
+    rcases mul_eq_zero.mp hgs with h1 | h2
+    · exact h1
+    · exact absurd h2 hne
+
+/-- **Orthonormality of the discrete Fourier characters (DFT inversion).**
+For distinct residues `a, b < n` the sampled characters `k ↦ exp(2πi·ak/n)` and
+`k ↦ exp(2πi·bk/n)` are orthogonal, and each has squared norm `n`:
+
+      ∑_{k<n} exp(2πi·ak/n) · conj(exp(2πi·bk/n))  =  ⎧ n  if a = b
+                                                       ⎩ 0  if a ≠ b.
+
+This is the orthogonality of the rows of the DFT matrix — the identity that
+makes the inverse discrete Fourier transform recover Fourier coefficients.  The
+product of the two characters telescopes to `ζ^{(a−b)k}` for the signed
+frequency `a − b`, and integer-frequency orthogonality gives the dichotomy;
+since `|a − b| < n`, `n ∣ (a − b)` happens exactly when `a = b`. -/
+theorem sum_char_inner {n : ℕ} (hn : 0 < n) {a b : ℕ} (ha : a < n) (hb : b < n) :
+    ∑ k ∈ range n, Complex.exp (2 * ↑Real.pi * Complex.I * ↑a * ↑k / ↑n)
+        * (starRingEnd ℂ) (Complex.exp (2 * ↑Real.pi * Complex.I * ↑b * ↑k / ↑n))
+      = if a = b then (n : ℂ) else 0 := by
+  -- Each summand is the single signed mode `ζ^{(a−b)k}`.
+  have key : ∀ k : ℕ,
+      Complex.exp (2 * ↑Real.pi * Complex.I * ↑a * ↑k / ↑n)
+          * (starRingEnd ℂ) (Complex.exp (2 * ↑Real.pi * Complex.I * ↑b * ↑k / ↑n))
+        = (Complex.exp (2 * ↑Real.pi * Complex.I / ↑n)) ^ (((a : ℤ) - (b : ℤ)) * (k : ℤ)) := by
+    intro k
+    rw [← Complex.exp_conj, ← Complex.exp_add, ← Complex.exp_int_mul]
+    congr 1
+    simp only [map_div₀, map_mul, map_ofNat, Complex.conj_ofReal, Complex.conj_natCast,
+      Complex.conj_I]
+    push_cast
+    ring
+  rw [Finset.sum_congr rfl (fun k _ => key k), sum_complex_zpow_eq_ite hn]
+  -- `n ∣ (a − b)` with `|a − b| < n` happens exactly when `a = b`.
+  rcases eq_or_ne a b with hab | hab
+  · subst hab; simp
+  · rw [if_neg hab, if_neg]
+    rintro ⟨c, hc⟩
+    have hb1 : (n : ℤ) * c < n := by rw [← hc]; omega
+    have hb2 : -(n : ℤ) < (n : ℤ) * c := by rw [← hc]; omega
+    have hc1 : c < 1 := by nlinarith
+    have hc2 : -1 < c := by nlinarith
+    have : c = 0 := by omega
+    rw [this, mul_zero] at hc
+    omega
+
+/-- **Parent recovery.**
+For `n > 1` the `n`-th roots of unity sum to zero, `∑_{k<n} ζ^k = 0`: the `j = 1`
+case of orthogonality, since `n ∤ 1`.  This is exactly the parent statement
+`de-moivre-oq-05`. -/
+theorem sum_geom_eq_zero {ζ : R} {n : ℕ} (hζ : IsPrimitiveRoot ζ n) (hn : 1 < n) :
+    ∑ k ∈ range n, ζ ^ k = 0 := by
+  have h := sum_pow_eq_zero_of_not_dvd hζ (j := 1)
+    (by rw [Nat.dvd_one]; omega)
+  simpa using h
+
+end DeMoivreOQ05OQ01

--- a/src/data/proofs/de-moivre-oq-05-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01/meta.json
@@ -1,0 +1,211 @@
+{
+  "id": "de-moivre-oq-05-oq-01",
+  "title": "De Moivre OQ-05-OQ-01: Orthogonality of the Roots of Unity (DFT Inversion)",
+  "slug": "de-moivre-oq-05-oq-01",
+  "description": "The full orthogonality relation ∑_{k<n} ζ^(jk) = n·[n∣j] generalising the parent's vanishing sum (j=1) to every integer frequency, over any integral domain with a primitive root, with the ℂ / explicit-exp specialisations, a signed-frequency (j∈ℤ) form, and the orthonormality of the discrete Fourier characters — the identity behind DFT inversion.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ05OQ01.lean",
+    "tags": [
+      "complex-analysis",
+      "algebra",
+      "roots-of-unity",
+      "discrete-fourier",
+      "orthogonality",
+      "character-sums",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "geom_sum_mul",
+        "description": "Telescoping identity (∑ i ∈ range n, x^i)·(x − 1) = x^n − 1 over a commutative ring",
+        "module": "Mathlib.Algebra.GeomSum"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.pow_eq_one_iff_dvd",
+        "description": "For a primitive n-th root ζ, ζ^l = 1 ↔ n ∣ l (natural exponent)",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.zpow_eq_one_iff_dvd",
+        "description": "For a primitive n-th root ζ, ζ^l = 1 ↔ (n:ℤ) ∣ l (integer exponent)",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "Complex.isPrimitiveRoot_exp",
+        "description": "exp(2πi/n) is a primitive n-th root of unity for n ≠ 0",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Complex"
+      },
+      {
+        "theorem": "Complex.exp_conj",
+        "description": "exp(conj z) = conj(exp z); used to turn a conjugated character into a negative-frequency mode",
+        "module": "Mathlib.Analysis.SpecialFunctions.Complex.Circle"
+      },
+      {
+        "theorem": "Complex.exp_int_mul",
+        "description": "exp(↑m · z) = (exp z)^m for m : ℤ, identifying the product of two characters with a single signed mode",
+        "module": "Mathlib.Analysis.SpecialFunctions.Exp"
+      }
+    ],
+    "originalContributions": [
+      "sum_pow_eq_ite: the full orthogonality dichotomy ∑_{k<n} ζ^(jk) = (if n∣j then n else 0) over any integral domain possessing a primitive n-th root — the frequency-indexed generalisation of the parent's single j=1 vanishing sum; not recorded in Mathlib",
+      "sum_complex_zpow_eq_ite: the signed-frequency (j : ℤ) version over ℂ, covering negative Fourier modes via the integer-exponent primitive-root criterion",
+      "sum_exp_orthogonality: the explicit de Moivre / DFT form ∑_{k<n} exp(2πi·jk/n) = (if n∣j then n else 0)",
+      "sum_char_inner: orthonormality of the discrete Fourier characters ∑_{k<n} exp(2πi·ak/n)·conj(exp(2πi·bk/n)) = (if a=b then n else 0) for a,b<n — the row-orthogonality of the DFT matrix that powers the inverse transform",
+      "sum_geom_eq_zero: recovers the parent statement ∑_{k<n} ζ^k = 0 (n>1) as the j=1 corollary"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 198,
+    "assumptions": "0 axioms, 0 sorries (proofs depend only on propext / Classical.choice / Quot.sound). The geometric collapse uses Mathlib's geom_sum_mul and the primitive-root order criteria (pow_eq_one_iff_dvd / zpow_eq_one_iff_dvd); the orthogonality dichotomy, its signed-frequency form, and the DFT-character orthonormality are assembled here and are not individually in Mathlib.",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The vanishing of a full period of equally-spaced phases, $\\sum_{k=0}^{n-1} e^{2\\pi i k/n} = 0$, is the $j=1$ case of the **orthogonality relations** for the characters of the cyclic group $\\mathbb{Z}/n\\mathbb{Z}$. The general relation $\\sum_{k=0}^{n-1}\\zeta^{jk} = n$ if $n\\mid j$ and $0$ otherwise is the cornerstone of the discrete Fourier transform: it says the $n$ sampled exponentials $k\\mapsto\\zeta^{jk}$ form an orthogonal basis, so the inverse DFT recovers Fourier coefficients by a single inner product. The same orthogonality underlies Gauss sums, the analytic evaluation of Dirichlet $L$-functions at characters, and the FFT.",
+    "problemStatement": "**Open Question** (parent de-moivre-oq-05): generalise $\\sum_{k<n}\\zeta^k = 0$ to $\\sum_{k<n}\\zeta^{jk} = 0$ for $n\\nmid j$ — orthogonality of characters / DFT inversion.\n\n**Answer**: For a primitive $n$-th root $\\zeta$ and any frequency $j$, $\\sum_{k=0}^{n-1}\\zeta^{jk} = \\begin{cases} n & n\\mid j\\\\ 0 & n\\nmid j.\\end{cases}$ Writing $\\zeta^{jk} = (\\zeta^j)^k$, the sum is geometric with ratio $w=\\zeta^j$; $w=1$ exactly when $n\\mid j$ (giving $n$ equal terms), and otherwise $w\\neq 1$ with $w^n=1$, so $(\\sum_{k<n}w^k)(w-1) = w^n-1 = 0$ forces the sum to vanish. Over $\\mathbb{C}$ with $\\zeta=e^{2\\pi i/n}$ this is $\\sum_{k<n} e^{2\\pi i jk/n}$, and the conjugate-pair version gives the orthonormality $\\sum_{k<n} e^{2\\pi i ak/n}\\overline{e^{2\\pi i bk/n}} = n\\,[a=b]$ for $a,b<n$.",
+    "text": "The frequency-indexed orthogonality relation for the n-th roots of unity, generalising the parent's vanishing sum from j=1 to all integer frequencies, with the ℂ / explicit-exponential specialisations, a signed-frequency form, and the orthonormality of the DFT characters.",
+    "proofStrategy": "1. **Geometric collapse** (`sum_pow_eq_ite`): rewrite each term $\\zeta^{jk}=(\\zeta^j)^k$, so the sum is $\\sum_{k<n}w^k$ with $w=\\zeta^j$. If $n\\mid j$ then $w=1$ by `pow_eq_one_iff_dvd` and the sum is $n$. Otherwise $w\\neq 1$ while $w^n=(\\zeta^n)^j=1$; `geom_sum_mul` gives $(\\sum w^k)(w-1)=w^n-1=0$ and the integral-domain `mul_eq_zero` kills the sum.\n2. **Specialise to ℂ** (`sum_complex_pow_eq_ite`, `sum_exp_orthogonality`): instantiate with $\\zeta=e^{2\\pi i/n}$ and rewrite $e^{2\\pi i jk/n}=(e^{2\\pi i/n})^{jk}$ via `exp_nat_mul`.\n3. **Signed frequencies** (`sum_complex_zpow_eq_ite`): repeat the collapse with $j\\in\\mathbb{Z}$ using the integer order criterion `zpow_eq_one_iff_dvd`.\n4. **Character orthonormality** (`sum_char_inner`): $e^{2\\pi i ak/n}\\overline{e^{2\\pi i bk/n}} = \\zeta^{(a-b)k}$ via `exp_conj`/`exp_int_mul`; signed orthogonality then gives the dichotomy, and $|a-b|<n$ makes $n\\mid(a-b)$ equivalent to $a=b$.",
+    "keyInsights": [
+      "The parent's $\\sum_{k<n}\\zeta^k=0$ is precisely the $j=1$ slice of a two-valued dichotomy indexed by the frequency $j$; the on-diagonal value $n$ and the off-diagonal $0$ together are the orthogonality relation",
+      "The whole result is one geometric-series collapse: the only fact about $j$ that matters is whether $\\zeta^j=1$, i.e. whether $n\\mid j$ — supplied uniformly by `pow_eq_one_iff_dvd` (and its `zpow` analogue)",
+      "Working over an integral domain (not a field) avoids division entirely: `geom_sum_mul` plus `mul_eq_zero` replaces the textbook $(w^n-1)/(w-1)$",
+      "The conjugate of a sampling character is the negative-frequency mode, $\\overline{\\zeta^{bk}}=\\zeta^{-bk}$, so the inner product of two characters is a single signed orthogonality sum — this is why `sum_char_inner` reduces to `sum_complex_zpow_eq_ite`",
+      "Orthonormality $\\sum_k\\chi_a(k)\\overline{\\chi_b(k)} = n\\,[a=b]$ is exactly the statement that the inverse DFT recovers coefficients; the bound $|a-b|<n$ turns the divisibility test into an equality test"
+    ],
+    "prerequisites": [
+      "Complex roots of unity and primitive roots",
+      "Finite geometric series and telescoping",
+      "Characters of a cyclic group / discrete Fourier transform",
+      "Integral domains and the no-zero-divisors property"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the orthogonality dichotomy ∑ ζ^(jk) = n·[n∣j], the geometric-collapse argument, and the seven results proved",
+      "startLine": 1,
+      "endLine": 53,
+      "mathContext": "**Goal**: $\\sum_{k<n}\\zeta^{jk} = n$ if $n\\mid j$, else $0$ — the DFT orthogonality relation."
+    },
+    {
+      "id": "orthogonality",
+      "title": "Part I: Orthogonality over an Integral Domain",
+      "summary": "sum_pow_eq_ite and sum_pow_eq_zero_of_not_dvd: the frequency-indexed dichotomy via geom_sum_mul + mul_eq_zero, and the off-diagonal cancellation",
+      "startLine": 54,
+      "endLine": 92,
+      "mathContext": "$\\sum_{k<n}(\\zeta^j)^k$: equals $n$ when $\\zeta^j=1$ ($n\\mid j$), else $0$ since $(\\sum w^k)(w-1)=w^n-1=0$."
+    },
+    {
+      "id": "complex-exp",
+      "title": "Part II: Complex and Explicit Exponential Forms",
+      "summary": "sum_complex_pow_eq_ite and sum_exp_orthogonality: specialisation to ζ = exp(2πi/n) and the explicit ∑ exp(2πi·jk/n) form",
+      "startLine": 94,
+      "endLine": 115,
+      "mathContext": "$\\sum_{k<n} e^{2\\pi i jk/n} = n\\,[n\\mid j]$, recognising $e^{2\\pi i jk/n}=(e^{2\\pi i/n})^{jk}$."
+    },
+    {
+      "id": "signed-and-characters",
+      "title": "Part III: Signed Frequencies and DFT Character Orthonormality",
+      "summary": "sum_complex_zpow_eq_ite (j ∈ ℤ) and sum_char_inner: the negative-mode form and the orthonormality ∑ χ_a·conj(χ_b) = n·[a=b]",
+      "startLine": 117,
+      "endLine": 186,
+      "mathContext": "$\\sum_{k<n} e^{2\\pi i ak/n}\\overline{e^{2\\pi i bk/n}} = n\\,[a=b]$ for $a,b<n$ — orthonormal DFT rows."
+    },
+    {
+      "id": "parent-recovery",
+      "title": "Part IV: Parent Recovery",
+      "summary": "sum_geom_eq_zero: the parent's ∑ ζ^k = 0 (n>1) as the j=1 corollary of orthogonality",
+      "startLine": 188,
+      "endLine": 198,
+      "mathContext": "$\\sum_{k<n}\\zeta^k = 0$ for $n>1$, since $n\\nmid 1$ — exactly de-moivre-oq-05."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves the full orthogonality relation for the n-th roots of unity, ∑_{k<n} ζ^(jk) = n·[n∣j], over any integral domain possessing a primitive root, together with its complex and explicit-exponential specialisations, a signed-frequency (j∈ℤ) version, and the orthonormality of the discrete Fourier characters ∑ exp(2πi·ak/n)·conj(exp(2πi·bk/n)) = n·[a=b]. It directly answers the parent entry's first open question and recovers the parent's vanishing sum as the j=1 corollary. All seven theorems are fully proved with zero sorries and zero axioms.",
+    "implications": "Upgrades the single roots-of-unity vanishing sum to the complete character-orthogonality / DFT-inversion package: the discrete exponentials form an orthogonal (orthonormal up to the factor n) basis, so the inverse discrete Fourier transform recovers coefficients by one inner product. The same relations are the engine of Gauss sums, character-sum estimates, and the FFT.",
+    "openQuestions": [
+      "Plancherel / Parseval for the DFT: ∑_k |f(k)|² = (1/n)·∑_j |f̂(j)|² as a consequence of sum_char_inner",
+      "Gauss sums: evaluate ∑_k (k/p)·ζ^k for the Legendre symbol and prove |g|² = p via orthogonality",
+      "Orthogonality for a general finite abelian group's character table, with the cyclic case as the base"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "Parent: proves the j=1 vanishing sum ∑ ζ^k = 0; this entry answers its first open question (orthogonality / DFT inversion) and recovers it as a corollary"
+    },
+    {
+      "id": "de-moivre-oq-04",
+      "relationship": "OQ-04 exhibits the n-th roots as the powers of the trigonometric generator; orthogonality is the next structural fact about those powers"
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Base theorem: integer-exponent De Moivre, the source of the roots-of-unity description"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ05OQ01",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Abraham De Moivre",
+      "title": "Original theorem for integer exponents",
+      "year": "1707",
+      "venue": "Philosophical Transactions"
+    },
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae (cyclotomy, Gauss sums, character orthogonality)",
+      "year": "1801",
+      "venue": "Leipzig"
+    },
+    {
+      "authors": "James W. Cooley and John W. Tukey",
+      "title": "An Algorithm for the Machine Calculation of Complex Fourier Series",
+      "year": "1965",
+      "venue": "Mathematics of Computation"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05",
+      "relationship": "extends",
+      "description": "Parent formalization (∑ ζ^k = 0 for n>1); this entry generalises it to the full frequency-indexed orthogonality dichotomy and recovers the parent as the j=1 case."
+    },
+    {
+      "targetId": "de-moivre-oq-04",
+      "relationship": "sibling",
+      "description": "OQ-04 enumerates the n-th roots as the powers of a primitive root; orthogonality is the inner-product structure of that enumeration."
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "Euler's formula identifies the sampling characters exp(2πi·jk/n) whose orthogonality this entry proves."
+    },
+    {
+      "targetId": "primitive-roots",
+      "relationship": "related",
+      "description": "The whole argument turns on whether ζ^j = 1, governed by the primitive-root order criteria pow_eq_one_iff_dvd and zpow_eq_one_iff_dvd."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first listed open question** of the parent entry `de-moivre-oq-05` ("Generalise to ∑ ζ^(jk) = 0 for n ∤ j — orthogonality of characters / DFT inversion").

The parent proves only the `j = 1` slice, `∑_{k<n} ζ^k = 0`. This entry proves the full **orthogonality dichotomy**

```
∑_{k=0}^{n-1} ζ^(jk)  =  n   if n ∣ j
                         0   if n ∤ j
```

over any integral domain possessing a primitive `n`-th root, and packages the discrete-Fourier consequences.

## Theorems (7, 198 lines, 0 sorries, 0 axioms)

1. `sum_pow_eq_ite` — the orthogonality dichotomy over an integral domain
2. `sum_pow_eq_zero_of_not_dvd` — off-diagonal cancellation (`n ∤ j ⟹ 0`)
3. `sum_complex_pow_eq_ite` — the ℂ specialisation (`ζ = exp(2πi/n)`)
4. `sum_exp_orthogonality` — explicit de Moivre / DFT form `∑ exp(2πi·jk/n)`
5. `sum_complex_zpow_eq_ite` — signed-frequency (`j : ℤ`) orthogonality, covering negative modes
6. `sum_char_inner` — **orthonormality of the DFT characters** `∑ exp(2πi·ak/n)·conj(exp(2πi·bk/n)) = n·[a=b]` for `a,b<n` (the row-orthogonality behind inverse DFT)
7. `sum_geom_eq_zero` — recovers the parent's `∑ ζ^k = 0` (`n>1`) as the `j=1` corollary

## Proof technique

One geometric collapse: write `ζ^(jk) = (ζ^j)^k`, ratio `w = ζ^j`. `w = 1 ⇔ n ∣ j` (`IsPrimitiveRoot.pow_eq_one_iff_dvd` / `zpow_eq_one_iff_dvd`); otherwise `(∑ w^k)(w-1) = w^n - 1 = 0` (`geom_sum_mul`) and `mul_eq_zero` over the domain kills the sum — no division needed. The character inner product reduces to the signed form via `exp_conj` (`conj(ζ^(bk)) = ζ^(-bk)`).

## Verification

- `#print axioms` on all 7 theorems: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`) → **0-axiom verified**.
- Compiles against Mathlib v4.26.0; aggregator import added to `Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)