### PR TITLE
research(geometric-series-oq-09-oq-01): q-fold residue-class splitting of the geometric series — ∑ r^(qn+a)=r^a/(1−r^q) [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2792,6 +2792,7 @@ import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01
 import Proofs.GeometricSeriesOQ09
+import Proofs.GeometricSeriesOQ09OQ01
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01

--- a/proofs/Proofs/GeometricSeriesOQ09OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ09OQ01.lean
@@ -1,0 +1,154 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# q-Fold Residue-Class Splitting of the Geometric Series
+
+## What This Proves
+
+Fix an integer modulus `q ≥ 1` and a residue `a`.  For a ratio `r` in any
+complete normed field with `‖r‖ < 1`, the arithmetic-progression subseries with
+common difference `q` is itself a geometric series of ratio `r^q`:
+
+  ∑_{n=0}^{∞} r^(q·n + a)  =  r^a / (1 − r^q).
+
+Summing these `q` subseries over the residues `a = 0, 1, …, q−1` recombines into
+the full geometric series:
+
+  ∑_{a=0}^{q-1} ∑_{n=0}^{∞} r^(q·n + a)  =  ∑_{m=0}^{∞} r^m  =  1/(1 − r).
+
+This is the `q`-fold generalisation of the even/odd (`q = 2`) splitting recorded
+in `GeometricSeriesOQ09`, which is recovered here as the special case `q = 2`,
+`a ∈ {0, 1}`.
+
+## Why This Is Not Already in Mathlib
+
+Mathlib provides the plain geometric series `tsum_geometric_of_norm_lt_one`
+(`∑ rⁿ = (1−r)⁻¹`) but not the residue-class subsums.  The content is the
+reindexing `r^(q·n + a) = r^a · (r^q)ⁿ`, together with the bound
+`‖r^q‖ = ‖r‖^q < 1` (valid because `q ≥ 1`) which makes Mathlib's lemma
+applicable at the new ratio `r^q`, plus the recombination identity, which rests
+on the factorisation `1 − r^q = (1 − r)(1 + r + ⋯ + r^{q-1})`.
+
+## Proof Strategy
+
+1. **Key bound.** `‖r^q‖ = ‖r‖^q < 1` from `q ≠ 0` (`pow_lt_one₀`).
+2. **Residue subseries.** Rewrite `r^(q·n + a) = r^a · (r^q)ⁿ` and apply
+   `hasSum_geometric_of_norm_lt_one` at ratio `r^q`, scaled by `HasSum.mul_left`.
+3. **Recombination.** Sum the `q` closed forms `r^a · (1−r^q)⁻¹` over
+   `a : Fin q`.  Factor out `(1−r^q)⁻¹`, evaluate `∑_{a<q} r^a` with
+   `geom_sum_eq`, and simplify using `1 − r^q = (1 − r)(∑_{a<q} r^a)`.
+
+## Status: 0 sorries, 0 axioms (over any complete normed field)
+-/
+
+namespace GeometricSeriesOQ09OQ01
+
+-- Several supporting lemmas are purely algebraic and do not use completeness;
+-- `CompleteSpace` is only needed where the geometric series is summed.
+set_option linter.unusedSectionVars false
+
+variable {𝕜 : Type*} [NormedField 𝕜] [CompleteSpace 𝕜] {r : 𝕜}
+
+/-! ## Nonvanishing denominators -/
+
+/-- `r ≠ 1` whenever `‖r‖ < 1`. -/
+lemma ne_one (hr : ‖r‖ < 1) : r ≠ 1 := fun h => by simp [h] at hr
+
+/-- `1 - r ≠ 0` whenever `‖r‖ < 1`. -/
+lemma one_sub_ne_zero (hr : ‖r‖ < 1) : (1 : 𝕜) - r ≠ 0 :=
+  sub_ne_zero.mpr (ne_one hr).symm
+
+/-- `‖r^q‖ < 1` whenever `‖r‖ < 1` and `q ≠ 0`: the key bound that lets us apply
+the geometric-series lemma at the new ratio `r^q`. -/
+lemma norm_pow_lt_one (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) : ‖r ^ q‖ < 1 := by
+  rw [norm_pow]
+  exact pow_lt_one₀ (norm_nonneg r) hr hq
+
+/-- `1 - r^q ≠ 0` whenever `‖r‖ < 1` and `q ≠ 0`. -/
+lemma one_sub_pow_ne_zero (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) :
+    (1 : 𝕜) - r ^ q ≠ 0 :=
+  sub_ne_zero.mpr fun h => by simpa [← h] using norm_pow_lt_one hr hq
+
+/-! ## Residue-class subseries -/
+
+/-- **Residue subseries, `HasSum` form**: for `q ≠ 0` and any residue `a`,
+`∑_{n} r^(q·n + a) = r^a / (1 − r^q)`. -/
+theorem hasSum_geometric_residue (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    HasSum (fun n : ℕ => r ^ (q * n + a)) (r ^ a * (1 - r ^ q)⁻¹) := by
+  have h := hasSum_geometric_of_norm_lt_one (norm_pow_lt_one hr hq)
+  have key : (fun n : ℕ => r ^ (q * n + a)) = (fun n : ℕ => r ^ a * (r ^ q) ^ n) := by
+    funext n; rw [pow_add, pow_mul]; ring
+  rw [key]
+  exact h.mul_left (r ^ a)
+
+/-- **Residue subseries, `tsum` form**: `∑_{n} r^(q·n + a) = r^a / (1 − r^q)`. -/
+theorem tsum_geometric_residue (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    ∑' n : ℕ, r ^ (q * n + a) = r ^ a * (1 - r ^ q)⁻¹ :=
+  (hasSum_geometric_residue hr hq a).tsum_eq
+
+/-- Each residue subseries is summable. -/
+theorem summable_geometric_residue (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Summable (fun n : ℕ => r ^ (q * n + a)) :=
+  (hasSum_geometric_residue hr hq a).summable
+
+/-! ## Recombination: the q subseries reassemble the full series -/
+
+/-- The algebraic heart of the recombination: `1 − r^q` factors as
+`(1 − r) · (∑_{a<q} r^a)`. -/
+lemma one_sub_pow_eq (r : 𝕜) (q : ℕ) :
+    (1 : 𝕜) - r ^ q = (1 - r) * ∑ a ∈ Finset.range q, r ^ a := by
+  rw [Finset.mul_sum]
+  induction q with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ← ih, pow_succ]
+    ring
+
+/-- **Recombination, `tsum` form**: summing the `q` residue-class subseries over
+`a = 0, …, q−1` recovers the full geometric series
+`∑_{m} r^m = 1/(1 − r)`. -/
+theorem tsum_residues_eq_geometric (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) :
+    ∑ a ∈ Finset.range q, (∑' n : ℕ, r ^ (q * n + a)) = ∑' m : ℕ, r ^ m := by
+  have hfull : ∑' m : ℕ, r ^ m = (1 - r)⁻¹ := tsum_geometric_of_norm_lt_one hr
+  have hne : (1 : 𝕜) - r ≠ 0 := one_sub_ne_zero hr
+  have hqne : (1 : 𝕜) - r ^ q ≠ 0 := one_sub_pow_ne_zero hr hq
+  rw [hfull]
+  -- replace each subseries by its closed form and factor out (1 - r^q)⁻¹
+  simp_rw [tsum_geometric_residue hr hq]
+  rw [← Finset.sum_mul]
+  -- now: (∑_{a<q} r^a) * (1 - r^q)⁻¹ = (1 - r)⁻¹
+  have hsum : (1 - r) * ∑ a ∈ Finset.range q, r ^ a = 1 - r ^ q :=
+    (one_sub_pow_eq r q).symm
+  field_simp [hne, hqne]
+  linear_combination hsum
+
+/-! ## Connection to the even/odd (q = 2) case -/
+
+/-- Specialisation `q = 2, a = 0` recovers the even subseries
+`∑ r^(2n) = 1/(1 − r²)` of `GeometricSeriesOQ09`. -/
+theorem tsum_geometric_even (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ (2 * n) = (1 - r ^ 2)⁻¹ := by
+  have h := tsum_geometric_residue hr (q := 2) (by norm_num) 0
+  simpa using h
+
+/-- Specialisation `q = 2, a = 1` recovers the odd subseries
+`∑ r^(2n+1) = r/(1 − r²)` of `GeometricSeriesOQ09`. -/
+theorem tsum_geometric_odd (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ (2 * n + 1) = r * (1 - r ^ 2)⁻¹ := by
+  have h := tsum_geometric_residue hr (q := 2) (by norm_num) 1
+  simpa using h
+
+/-! ## Concrete values -/
+
+/-- Sanity check at `r = 1/2`, `q = 3`, `a = 0`: `∑ (1/2)^(3n) = ∑ (1/8)ⁿ = 8/7`. -/
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ (3 * n + 0) = 8 / 7 := by
+  rw [tsum_geometric_residue (by norm_num : ‖(1 / 2 : ℝ)‖ < 1) (by norm_num) 0]
+  norm_num
+
+/-- Sanity check at `r = 1/2`, `q = 3`, `a = 2`: `∑ (1/2)^(3n+2) = 2/7`. -/
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ (3 * n + 2) = 2 / 7 := by
+  rw [tsum_geometric_residue (by norm_num : ‖(1 / 2 : ℝ)‖ < 1) (by norm_num) 2]
+  norm_num
+
+end GeometricSeriesOQ09OQ01

--- a/src/data/proofs/geometric-series-oq-09-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "geometric-series-oq-09-oq-01",
+  "slug": "geometric-series-oq-09-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "GeometricSeriesOQ09OQ01",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ09OQ01.lean",
+    "sorries": 0
+  },
+  "title": "q-Fold Residue-Class Splitting of the Geometric Series: ∑ r^(qn+a) = r^a/(1−r^q)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ09OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "summability",
+      "normed-field",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 154,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_geometric_residue / tsum_geometric_residue: the closed form ∑_{n≥0} r^(q·n+a) = r^a/(1−r^q) for ‖r‖ < 1, q ≠ 0, and any residue a, over an arbitrary complete normed field 𝕜. This is the q-fold generalisation of the even/odd (q=2) splitting in geometric-series-oq-09; Mathlib records only the plain geometric series ∑ rⁿ = 1/(1−r).",
+      "tsum_residues_eq_geometric: the recombination ∑_{a=0}^{q-1} (∑_{n≥0} r^(q·n+a)) = ∑_{m≥0} r^m = 1/(1−r), proving that the q arithmetic-progression subseries partition and reassemble the full geometric series. Its closing step is the factorisation identity 1 − r^q = (1−r)·(∑_{a<q} r^a).",
+      "one_sub_pow_eq: the finite identity 1 − r^q = (1−r)·∑_{a<q} r^a over any commutative ring/field, proved by induction on q — the algebraic backbone of the recombination.",
+      "tsum_geometric_even / tsum_geometric_odd: explicit specialisations recovering the parent's ∑ r^(2n) = 1/(1−r²) and ∑ r^(2n+1) = r/(1−r²) as the cases q=2, a∈{0,1}.",
+      "Generality over an arbitrary complete normed field (covering ℝ and ℂ uniformly), the key bound ‖r^q‖ = ‖r‖^q < 1, the nonvanishing denominators 1−r ≠ 0 and 1−r^q ≠ 0, summability of each residue subseries, and concrete checks ∑ (1/2)^(3n) = 8/7, ∑ (1/2)^(3n+2) = 2/7."
+    ],
+    "prerequisites": [
+      "Mathlib's geometric series hasSum_geometric_of_norm_lt_one (∑ ξⁿ = (1−ξ)⁻¹ for ‖ξ‖ < 1 over a complete normed division ring), applied at the new ratio ξ = r^q",
+      "pow_add and pow_mul: r^(q·n+a) = r^a·(r^q)ⁿ, the reindexing that exhibits the residue-a subseries as a geometric series of ratio r^q",
+      "norm_pow and pow_lt_one₀: ‖r^q‖ = ‖r‖^q < 1 from ‖r‖ < 1 and q ≠ 0",
+      "geom_sum / induction for the factorisation 1 − r^q = (1−r)·∑_{a<q} r^a",
+      "HasSum arithmetic (HasSum.mul_left, HasSum.tsum_eq, HasSum.summable) and Finset.sum_mul",
+      "Parent: geometric-series-oq-09 (even/odd splitting), grandparent geometric-series (∑ rⁿ = 1/(1−r))"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "∑_n ξⁿ = (1−ξ)⁻¹ for ‖ξ‖ < 1 over a complete normed division ring. Applied at ξ = r^q to sum each residue subseries, then scaled by HasSum.mul_left (r^a).",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "pow_lt_one₀",
+        "description": "0 ≤ a → a < 1 → a^n < 1 (n ≠ 0). Combined with norm_pow to give ‖r^q‖ = ‖r‖^q < 1, the hypothesis Mathlib's geometric lemma needs at the ratio r^q.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Finset.sum_mul",
+        "description": "Factors the common (1−r^q)⁻¹ out of the finite sum over residues, reducing the recombination to the polynomial identity 1 − r^q = (1−r)·∑_{a<q} r^a.",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-09-oq-01-oq-01",
+      "question": "Promote the recombination to a genuine reindexing theorem: prove HasSum (fun (p : ℕ × Fin q) => r^(q·p.1 + p.2)) (1−r)⁻¹ directly via the bijection ℕ ≃ ℕ × Fin q (m ↦ (m / q, m % q)), so that the q-fold splitting is established as a Fubini/regrouping of the summation itself rather than via the closed forms of the parts.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-09",
+      "relationship": "extends",
+      "description": "Parent. The parent proves the even/odd (q=2) splitting ∑ r^(2n) = 1/(1−r²), ∑ r^(2n+1) = r/(1−r²). This entry generalises to arbitrary modulus q and residue a: ∑ r^(q·n+a) = r^a/(1−r^q), and proves the q-fold recombination ∑_{a<q} (subseries_a) = ∑ rⁿ = 1/(1−r). The parent's two closed forms are recovered here as the case q=2."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "Grandparent. The base entry proves ∑ rⁿ = 1/(1−r); this entry exhibits that full series as the disjoint union of q geometric subseries indexed by residue classes mod q, each of ratio r^q."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of hasSum_geometric_of_norm_lt_one, the geometric series lemma applied at the ratio r^q."
+    },
+    {
+      "title": "Concrete Mathematics (geometric series; multisection of power series)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the q-section (multisection) of a power series into q subseries indexed by residue classes mod q, of which the geometric q-fold splitting is the simplest instance."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For ‖r‖ < 1 over any complete normed field and any modulus q ≠ 0, the arithmetic-progression subseries with common difference q is itself geometric of ratio r^q: ∑_{n≥0} r^(q·n+a) = r^a/(1−r^q) for every residue a (hasSum_geometric_residue / tsum_geometric_residue). Summing these closed forms over a = 0,…,q−1 recombines into the full geometric series ∑_{m≥0} r^m = 1/(1−r) (tsum_residues_eq_geometric), with the closing step the factorisation 1 − r^q = (1−r)·∑_{a<q} r^a (one_sub_pow_eq, by induction). The residue subseries is summed by the reindexing r^(q·n+a) = r^a·(r^q)ⁿ together with the bound ‖r^q‖ = ‖r‖^q < 1 that lets Mathlib's hasSum_geometric_of_norm_lt_one apply at ratio r^q, scaled by HasSum.mul_left. Specialising to q=2 recovers the parent's even and odd subsums. 154 lines, 11 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This completes the open question posed by geometric-series-oq-09 (the q-fold splitting) and fills a small gap: Mathlib records the geometric series but not its residue-class multisections. The reusable move is that a subseries taken along any arithmetic progression of indices is again geometric, with ratio r^q, so summing it reduces to Mathlib's lemma at a new ratio plus the bound ‖r^q‖ < 1; the recombination is then pure algebra via 1 − r^q = (1−r)·(1+r+⋯+r^{q-1}). Working over a general complete normed field handles ℝ and ℂ uniformly.",
+    "openQuestions": [
+      "Promote the recombination to a direct reindexing HasSum statement over ℕ ≃ ℕ × Fin q, establishing the splitting as a regrouping of the summation rather than via the closed forms of the parts."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **geometric-series-oq-09** (even/odd splitting): the **q-fold generalisation** to an arbitrary residue class.

For a ratio `r` in **any complete normed field** (covering ℝ and ℂ) with `‖r‖ < 1`, and any modulus `q ≠ 0`, the arithmetic-progression subseries with common difference `q` is itself geometric of ratio `r^q`:

```
∑_{n≥0} r^(q·n + a)  =  r^a / (1 − r^q)        (any residue a)
```

and summing over residues `a = 0,…,q−1` recombines into the full series:

```
∑_{a=0}^{q-1} ∑_{n≥0} r^(q·n + a)  =  ∑_{m≥0} r^m  =  1/(1 − r).
```

The parent's even/odd case is recovered as `q = 2`, `a ∈ {0,1}`.

## Contents (154 lines, 11 theorems/lemmas, 0 defs)

- `hasSum_geometric_residue` / `tsum_geometric_residue` / `summable_geometric_residue` — the residue-class closed form, via the reindexing `r^(q·n+a) = r^a·(r^q)ⁿ` + the bound `‖r^q‖ = ‖r‖^q < 1` that lets Mathlib's `hasSum_geometric_of_norm_lt_one` apply at ratio `r^q`, scaled by `HasSum.mul_left`.
- `one_sub_pow_eq` — the factorisation `1 − r^q = (1−r)·∑_{a<q} r^a` (induction), the algebraic backbone.
- `tsum_residues_eq_geometric` — the q-fold recombination into the full geometric series.
- `tsum_geometric_even` / `tsum_geometric_odd` — explicit `q=2` specialisations recovering the parent.
- Nonvanishing-denominator lemmas + concrete checks `∑ (1/2)^(3n) = 8/7`, `∑ (1/2)^(3n+2) = 2/7`.

## Why not already in Mathlib

Mathlib records the plain geometric series `∑ rⁿ = 1/(1−r)` but not its residue-class multisections. The content is the reindexing at ratio `r^q` plus the recombination identity.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on the main results lists only `propext, Classical.choice, Quot.sound`.
- Compiled against Mathlib (lean4 v4.26.0).