### PR TITLE
research(combinations-formula-oq-05-oq-01): telescoping partial sums of an alternating binomial row [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -713,6 +713,7 @@ import Proofs.CombinationsFormulaOQ02Aristotle
 import Proofs.CombinationsFormulaOQ03
 import Proofs.CombinationsFormulaOQ03OQ06
 import Proofs.CombinationsFormulaOQ05
+import Proofs.CombinationsFormulaOQ05OQ01
 import Proofs.CombinationsFormulaOQ06
 import Proofs.CombinationsFormulaOQ07
 import Proofs.CombinationsFormulaOQ07OQ01

--- a/proofs/Proofs/CombinationsFormulaOQ05OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ05OQ01.lean
@@ -1,0 +1,109 @@
+import Mathlib
+
+/-
+# Telescoping Partial Sums of an Alternating Binomial Row
+
+## Open Question OQ-05-OQ-01
+
+The parent (`CombinationsFormulaOQ05`) records the *full* alternating row sum of
+Pascal's triangle, `∑_{k=0}^{n} (-1)^k C(n,k) = 0` for `n ≥ 1`
+(`Int.alternating_sum_range_choose_of_ne`).  That identity says the complete
+alternating row cancels, but it is silent about the **partial** sums
+`∑_{k=0}^{j} (-1)^k C(n,k)` for `j < n`.
+
+This file proves the sharp closed form for every partial sum:
+
+  ∑_{k=0}^{j} (-1)^k · C(n, k) = (-1)^j · C(n-1, j)            (n ≥ 1).             (★)
+
+Equivalently, with no natural-number subtraction,
+
+  ∑_{k=0}^{j} (-1)^k · C(n+1, k) = (-1)^j · C(n, j)            (all n).             (★')
+
+Mathlib has only the full-row vanishing (`Int.alternating_sum_range_choose`,
+`Int.alternating_sum_range_choose_of_ne`).  The partial closed form (★) is not in
+Mathlib; it is a genuine refinement — the full-row identity falls out of (★) by
+taking `j = n` and using `C(n-1, n) = 0`.
+
+## Why a closed form at all?
+
+Write `aₖ := (-1)^k C(n,k)`.  Pascal's rule `C(n,j+1) = C(n-1,j) + C(n-1,j+1)`
+makes the running sum **telescope**: the `j`-th partial sum is, up to sign, a
+single binomial coefficient of the *previous* row.  Concretely, the sequence of
+partial sums is exactly the alternating row of `C(n-1, ·)` read off term by term.
+This is the discrete analogue of the fact that `(1-x)^n` has antiderivative-like
+partial sums governed by `(1-x)^{n-1}`; it is the binomial-coefficient form of
+the finite-difference operator `Δ⁻¹`.
+
+## Results
+
+1. `partial_alternating_sum`        — (★') clean form, valid for all `n`.
+2. `partial_alternating_sum_pred`   — (★) literal `C(n-1,j)` form, `n ≥ 1`.
+3. `partial_alternating_sum_stabilizes` — partial sums are `0` once `j ≥ n` (`n ≥ 1`).
+4. `full_alternating_row_eq_zero`   — recovers the parent anchor from (★') alone.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ05OQ01
+
+open Finset
+
+/-- **Main identity (subtraction-free form).** For all `n, j`,
+    `∑_{k=0}^{j} (-1)^k C(n+1, k) = (-1)^j C(n, j)` in `ℤ`.
+
+    Proof by induction on `j`; the inductive step is precisely Pascal's rule
+    `C(n+1, j+1) = C(n, j) + C(n, j+1)`, which is what makes the partial sums
+    telescope down to a single binomial coefficient of row `n`. -/
+theorem partial_alternating_sum (n j : ℕ) :
+    ∑ k ∈ range (j + 1), ((-1 : ℤ) ^ k * ((n + 1).choose k : ℤ))
+      = (-1 : ℤ) ^ j * (n.choose j : ℤ) := by
+  induction j with
+  | zero => simp
+  | succ j ih =>
+    rw [Finset.sum_range_succ, ih]
+    -- Pascal's rule, cast to ℤ.
+    have pascal : ((n + 1).choose (j + 1) : ℤ)
+        = (n.choose j : ℤ) + (n.choose (j + 1) : ℤ) := by
+      rw [Nat.choose_succ_succ]; push_cast; ring
+    rw [pascal, pow_succ]
+    ring
+
+/-- **Telescoping partial sum (literal form).** For `n ≥ 1` and any `j`,
+    `∑_{k=0}^{j} (-1)^k C(n, k) = (-1)^j C(n-1, j)` in `ℤ`. -/
+theorem partial_alternating_sum_pred {n : ℕ} (hn : n ≠ 0) (j : ℕ) :
+    ∑ k ∈ range (j + 1), ((-1 : ℤ) ^ k * (n.choose k : ℤ))
+      = (-1 : ℤ) ^ j * ((n - 1).choose j : ℤ) := by
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hn
+  simpa using partial_alternating_sum m j
+
+/-- **Stabilisation.** Once the cut-off reaches the row length the partial sums
+    are already `0`: for `n ≥ 1` and `j ≥ n`,
+    `∑_{k=0}^{j} (-1)^k C(n, k) = 0`.  (The tail terms `C(n, k)` with `k > n` are
+    zero, so all partial sums past the row coincide with the full row sum.) -/
+theorem partial_alternating_sum_stabilizes {n : ℕ} (hn : n ≠ 0) {j : ℕ}
+    (hj : n ≤ j) :
+    ∑ k ∈ range (j + 1), ((-1 : ℤ) ^ k * (n.choose k : ℤ)) = 0 := by
+  rw [partial_alternating_sum_pred hn j]
+  -- `C(n-1, j) = 0` because `j ≥ n > n - 1`.
+  have : (n - 1).choose j = 0 := Nat.choose_eq_zero_of_lt (by omega)
+  rw [this]; simp
+
+/-- **Recovers the parent anchor.** The full alternating row sum vanishes for
+    `n ≥ 1`.  This is `Int.alternating_sum_range_choose_of_ne`, here obtained as
+    the special case `j = n` of the partial closed form (with `C(n-1, n) = 0`). -/
+theorem full_alternating_row_eq_zero {n : ℕ} (hn : n ≠ 0) :
+    ∑ k ∈ range (n + 1), ((-1 : ℤ) ^ k * (n.choose k : ℤ)) = 0 :=
+  partial_alternating_sum_stabilizes hn (le_refl n)
+
+/-- Sanity check, row `n = 4`, cut-off `j = 2`:
+    `C(4,0) - C(4,1) + C(4,2) = 1 - 4 + 6 = 3 = (+1)·C(3,2) = 3`. -/
+example :
+    ∑ k ∈ range 3, ((-1 : ℤ) ^ k * (Nat.choose 4 k : ℤ)) = 3 := by decide
+
+/-- Sanity check of the closed form at `n = 5, j = 3`:
+    LHS `= 1 - 5 + 10 - 10 = -4`; RHS `= (-1)^3 · C(4,3) = -4`. -/
+example :
+    ∑ k ∈ range 4, ((-1 : ℤ) ^ k * (Nat.choose 5 k : ℤ))
+      = (-1 : ℤ) ^ 3 * (Nat.choose 4 3 : ℤ) := by decide
+
+end CombinationsFormulaOQ05OQ01

--- a/src/data/proofs/combinations-formula-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "telescoping-context",
+    "proofId": "combinations-formula-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "From Full-Row Cancellation to a Telescoping Partial Sum",
+    "content": "The parent entry records that the complete alternating row sum ∑_{k=0}^{n} (-1)^k C(n,k) vanishes for n ≥ 1. That says nothing about a truncated sum stopping at j < n. This entry proves the sharp closed form ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j): every partial sum is, up to sign, a single binomial coefficient of the previous row. Summing an alternating binomial row is therefore the discrete inverse of the finite-difference operation that Pascal's rule encodes.",
+    "mathContext": "Writing $a_k = (-1)^k \\binom{n}{k}$, the partial sum $S_j = \\sum_{k=0}^{j} a_k$ satisfies $S_j = (-1)^j \\binom{n-1}{j}$. Pascal's rule $\\binom{n}{j+1} = \\binom{n-1}{j} + \\binom{n-1}{j+1}$ makes $S_{j+1} = S_j + a_{j+1}$ collapse to a single term, the binomial-coefficient analogue of $\\Delta^{-1}$. The full-row identity is the case $j = n$, where $\\binom{n-1}{n} = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pascal's rule",
+      "finite differences",
+      "binomial transform",
+      "telescoping sums",
+      "alternating binomial identities"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "Pascal's rule Nat.choose_succ_succ",
+      "induction over Finset.range"
+    ]
+  },
+  {
+    "id": "main-identity-theorem",
+    "proofId": "combinations-formula-oq-05-oq-01",
+    "range": { "startLine": 57, "endLine": 71 },
+    "type": "theorem",
+    "title": "Main Identity (Subtraction-Free Form)",
+    "content": "partial_alternating_sum: ∑_{k=0}^{j} (-1)^k C(n+1,k) = (-1)^j C(n,j) over ℤ, for all n and j. Proved by induction on j. The base case is C(n+1,0) = C(n,0) = 1. The inductive step rewrites with Finset.sum_range_succ, applies the hypothesis, and uses Pascal's rule C(n+1,j+1) = C(n,j) + C(n,j+1) (Nat.choose_succ_succ cast to ℤ); the (-1)^j C(n,j) carried by the hypothesis cancels one Pascal summand, leaving (-1)^{j+1} C(n,j+1). The C(n+1,k) phrasing avoids natural-number subtraction so the statement holds even at n = 0.",
+    "mathContext": "Inductive step: $S_{j+1} = (-1)^j\\binom{n}{j} + (-1)^{j+1}\\binom{n+1}{j+1} = (-1)^j\\binom{n}{j} + (-1)^{j+1}\\big(\\binom{n}{j}+\\binom{n}{j+1}\\big) = (-1)^{j+1}\\binom{n}{j+1}$, since $(-1)^{j+1} = -(-1)^j$ cancels the $\\binom{n}{j}$ terms.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_succ_succ",
+      "Finset.sum_range_succ",
+      "induction on the cut-off"
+    ],
+    "prerequisites": [
+      "Pascal's rule",
+      "alternating sums over Finset.range"
+    ]
+  },
+  {
+    "id": "literal-form-theorem",
+    "proofId": "combinations-formula-oq-05-oq-01",
+    "range": { "startLine": 73, "endLine": 80 },
+    "type": "theorem",
+    "title": "Literal C(n-1,j) Form",
+    "content": "partial_alternating_sum_pred: for n ≥ 1, ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j). This is the identity as classically stated. It follows from the subtraction-free form by writing n = m+1 via Nat.exists_eq_succ_of_ne_zero, so that n-1 = m and the n+1-form applies verbatim.",
+    "mathContext": "For $n \\ge 1$, $\\sum_{k=0}^{j} (-1)^k \\binom{n}{k} = (-1)^j \\binom{n-1}{j}$. The restriction $n \\ge 1$ is essential: at $n = 0$ the right side $(-1)^j\\binom{0-1}{j}$ would involve truncated subtraction and the identity fails for $j \\ge 1$ (LHS $= 1$, RHS $= 0$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.exists_eq_succ_of_ne_zero",
+      "natural-number subtraction caveats"
+    ],
+    "prerequisites": [
+      "the subtraction-free main identity"
+    ]
+  },
+  {
+    "id": "stabilization-recovery",
+    "proofId": "combinations-formula-oq-05-oq-01",
+    "range": { "startLine": 83, "endLine": 98 },
+    "type": "theorem",
+    "title": "Stabilisation and Recovery of the Full-Row Identity",
+    "content": "partial_alternating_sum_stabilizes: for n ≥ 1 and j ≥ n, the partial sum is already 0, because C(n-1,j) = 0 once j > n-1 (Nat.choose_eq_zero_of_lt). full_alternating_row_eq_zero: the parent's full-row vanishing ∑_{k=0}^{n} (-1)^k C(n,k) = 0 (Mathlib's Int.alternating_sum_range_choose_of_ne) is recovered as the j = n instance. The partial closed form is therefore strictly stronger than — and reproves — the anchor.",
+    "mathContext": "Since $\\binom{n-1}{j} = 0$ for $j \\ge n$, the running partial sums reach $0$ exactly at $j = n$ and stay there (the remaining terms $\\binom{n}{k}$ with $k > n$ vanish). The full row sum is the $j = n$ value, $(-1)^n\\binom{n-1}{n} = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.choose_eq_zero_of_lt",
+      "Int.alternating_sum_range_choose_of_ne",
+      "strengthening the parent anchor"
+    ],
+    "prerequisites": [
+      "the literal C(n-1,j) form",
+      "vanishing of out-of-range binomial coefficients"
+    ]
+  },
+  {
+    "id": "worked-verifications",
+    "proofId": "combinations-formula-oq-05-oq-01",
+    "range": { "startLine": 100, "endLine": 109 },
+    "type": "example",
+    "title": "Worked Verifications",
+    "content": "Two kernel-`decide` sanity checks of the closed form. Row 4 cut at j = 2: C(4,0) − C(4,1) + C(4,2) = 1 − 4 + 6 = 3 = (+1)·C(3,2). Row 5 cut at j = 3: 1 − 5 + 10 − 10 = −4 = (−1)^3·C(4,3). Both use kernel decide, so they introduce no Lean.ofReduceBool dependency.",
+    "mathContext": "$\\sum_{k=0}^{2}(-1)^k\\binom{4}{k} = 3 = \\binom{3}{2}$ and $\\sum_{k=0}^{3}(-1)^k\\binom{5}{k} = -4 = -\\binom{4}{3}$, matching $(-1)^j\\binom{n-1}{j}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide",
+      "numerical verification"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-05-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "combinations-formula-oq-05-oq-01",
+  "title": "Telescoping Partial Sums of an Alternating Binomial Row",
+  "slug": "combinations-formula-oq-05-oq-01",
+  "description": "Proves the sharp closed form for every partial sum of an alternating binomial row: ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) for n ≥ 1. This refines the parent's full-row vanishing (∑_{k=0}^{n} (-1)^k C(n,k) = 0) into a telescoping identity — each partial sum is, up to sign, a single binomial coefficient of the previous row. Mathlib has only the complete-row cancellation; the partial closed form is new, and the full-row identity is recovered as the special case j = n via C(n-1,n) = 0.",
+  "meta": {
+    "author": "Lean Genius researcher-2",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ05OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 109,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities are fully machine-checked for every n and j. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); the two worked examples use kernel `decide`, so no Lean.ofReduceBool is involved.",
+    "tags": [
+      "combinatorics",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "alternating-sum",
+      "telescoping",
+      "finite-differences",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-23",
+    "originalContributions": [
+      "partial_alternating_sum: the subtraction-free closed form ∑_{k=0}^{j} (-1)^k C(n+1,k) = (-1)^j C(n,j), valid for all n, proved by induction on j with Pascal's rule (Nat.choose_succ_succ) as the inductive step",
+      "partial_alternating_sum_pred: the literal C(n-1,j) form ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) for n ≥ 1, obtained from the n+1 form by Nat.exists_eq_succ_of_ne_zero",
+      "partial_alternating_sum_stabilizes: the partial sums are already 0 once j ≥ n (n ≥ 1), since C(n-1,j) = 0 there",
+      "full_alternating_row_eq_zero: recovers the parent's full-row vanishing ∑_{k=0}^{n} (-1)^k C(n,k) = 0 (= Int.alternating_sum_range_choose_of_ne) as the case j = n of the partial closed form",
+      "Worked verifications: row 4 cut at j=2 gives 1−4+6 = 3 = C(3,2); row 5 cut at j=3 gives 1−5+10−10 = −4 = (−1)^3 C(4,3)"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ05OQ01.lean",
+    "namespace": "CombinationsFormulaOQ05OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 109,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The full alternating row sum ∑_{k=0}^{n} (-1)^k C(n,k) = 0 (n ≥ 1) is the evaluation of the binomial theorem at x = -1 and is one of the oldest combinatorial identities. Far less often stated is what happens when the sum is truncated at j < n: the running partial sums do not merely approach 0, they are each exactly a single signed binomial coefficient of row n-1. This is the binomial-coefficient form of the discrete antidifference operator Δ⁻¹: summing the alternating sequence (-1)^k C(n,k) is the inverse of the finite-difference operation that Pascal's rule encodes.",
+    "problemStatement": "Open Question OQ-05-OQ-01 (the first follow-up posed by the parent OQ-05): formalize the partial alternating sums ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j), refining the full-row cancellation into a telescoping identity.",
+    "proofStrategy": "Work in ℤ and prove the subtraction-free form ∑_{k=0}^{j} (-1)^k C(n+1,k) = (-1)^j C(n,j) by induction on j. The base case j = 0 is C(n+1,0) = C(n,0) = 1. The inductive step adds the term (-1)^{j+1} C(n+1,j+1) and applies Pascal's rule C(n+1,j+1) = C(n,j) + C(n,j+1) (Nat.choose_succ_succ, cast to ℤ); the (-1)^j C(n,j) from the hypothesis cancels against one Pascal summand, leaving exactly (-1)^{j+1} C(n,j+1) — the telescoping. The literal C(n-1,j) form follows by writing n = m+1 (Nat.exists_eq_succ_of_ne_zero). Stabilisation and the full-row corollary then follow from C(n-1,j) = 0 for j ≥ n.",
+    "keyInsights": [
+      "Pascal's rule is exactly the telescoping mechanism: it lets the (j+1)-th partial sum absorb the new term and collapse back to one binomial coefficient of the previous row.",
+      "Stated with C(n+1,k) instead of C(n,k) the identity needs no natural-number subtraction and holds for all n (including n = 0), making the induction clean; the literal C(n-1,j) form is then a one-line specialisation for n ≥ 1.",
+      "The full-row identity is not assumed — it is derived: taking j = n makes the right side (-1)^n C(n-1,n) = 0, so this entry is strictly stronger than the parent anchor and reproves Int.alternating_sum_range_choose_of_ne.",
+      "The partial sums stabilise at 0 the moment j reaches n, because the trailing binomial coefficients C(n,k) with k > n vanish; equivalently the right-hand binomial C(n-1,j) is supported on j < n."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Telescoping Refinement",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Header stating OQ-05-OQ-01: the partial alternating sums admit the closed form (-1)^j C(n-1,j), refining the parent's full-row vanishing. Explains the telescoping/finite-difference interpretation and that Mathlib has only the complete-row identity."
+    },
+    {
+      "id": "main-identity",
+      "title": "Main Identity (Subtraction-Free Form)",
+      "startLine": 57,
+      "endLine": 71,
+      "summary": "partial_alternating_sum: ∑_{k=0}^{j} (-1)^k C(n+1,k) = (-1)^j C(n,j) for all n, by induction on j with Pascal's rule (Nat.choose_succ_succ) driving the inductive step."
+    },
+    {
+      "id": "literal-form",
+      "title": "Literal C(n-1,j) Form",
+      "startLine": 73,
+      "endLine": 80,
+      "summary": "partial_alternating_sum_pred: the literal ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) for n ≥ 1, obtained by writing n = m+1 via Nat.exists_eq_succ_of_ne_zero."
+    },
+    {
+      "id": "stabilization",
+      "title": "Stabilisation and Full-Row Recovery",
+      "startLine": 83,
+      "endLine": 98,
+      "summary": "partial_alternating_sum_stabilizes: the partial sums are 0 once j ≥ n (C(n-1,j) = 0). full_alternating_row_eq_zero: recovers the parent's full-row vanishing as the case j = n."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 100,
+      "endLine": 109,
+      "summary": "examples: row 4 cut at j=2 gives 1−4+6 = 3 = C(3,2); row 5 cut at j=3 gives 1−5+10−10 = −4 = (−1)^3 C(4,3)."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. Establishes the sharp closed form ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j) for every partial sum of an alternating binomial row, and recovers the parent's full-row vanishing as the special case j = n.",
+    "implications": "Converts the parent's complete-row cancellation into the finer telescoping statement that each partial sum is a single signed binomial coefficient of the previous row — the binomial form of the discrete antidifference. The inductive Pascal's-rule template extends directly to other signed binomial partial-sum identities.",
+    "openQuestions": [
+      "Does the weighted partial sum ∑_{k=0}^{j} (-1)^k k C(n,k) admit an analogous single-coefficient closed form, refining the vanishing of the full weighted alternating sum?",
+      "Can the partial sums of the alternating sum of squares ∑_{k=0}^{j} (-1)^k C(n,k)^2 (whose full sum is treated in CombinationsFormulaOQ07OQ05) be put in closed form, or do they genuinely require two coefficients?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-05",
+      "relationship": "parent — refines its full-row alternating sum ∑ (-1)^k C(n,k) = 0 into the telescoping partial closed form, and reproves that anchor as the case j = n"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves the sharp closed form for **every partial sum** of an alternating binomial row:

$$\sum_{k=0}^{j} (-1)^k \binom{n}{k} = (-1)^j \binom{n-1}{j} \qquad (n \ge 1).$$

This is the **#1 follow-up question** the parent entry `combinations-formula-oq-05` explicitly posed in its `openQuestions`. It refines the parent's *full-row* vanishing $\sum_{k=0}^{n}(-1)^k\binom{n}{k}=0$ into a **telescoping** identity: each partial sum is, up to sign, a single binomial coefficient of the *previous* row. Pascal's rule $\binom{n}{j+1}=\binom{n-1}{j}+\binom{n-1}{j+1}$ is exactly the telescoping mechanism — the binomial form of the discrete antidifference $\Delta^{-1}$.

Mathlib has only the complete-row cancellation (`Int.alternating_sum_range_choose_of_ne`); the partial closed form is new. The full-row identity is **recovered, not assumed**: it is the $j=n$ case (where $\binom{n-1}{n}=0$), so this entry is strictly stronger than the parent anchor and reproves it.

## Theorems (4, 0 sorries, 0 axioms)

- `partial_alternating_sum` — subtraction-free form $\sum_{k=0}^{j}(-1)^k\binom{n+1}{k}=(-1)^j\binom{n}{j}$, all $n$, by induction on $j$ with `Nat.choose_succ_succ`.
- `partial_alternating_sum_pred` — the literal $\binom{n-1}{j}$ form for $n\ge 1$.
- `partial_alternating_sum_stabilizes` — the partial sums are $0$ once $j\ge n$.
- `full_alternating_row_eq_zero` — recovers the parent's full-row vanishing as $j=n$.

Plus two kernel-`decide` worked verifications (rows 4 and 5).

## Verification

- Built with Lean v4.26.0 against the repo's Mathlib (Docker daemon was down; built directly via `lean` + `LEAN_PATH`).
- `#print axioms` on all four theorems: only `propext`, `Classical.choice`, `Quot.sound` — **0-axiom**. The examples use kernel `decide`, so no `Lean.ofReduceBool`.

Gallery: `src/data/proofs/combinations-formula-oq-05-oq-01/` (meta + annotations), aggregator import added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)