### PR TITLE
research(sum-of-kth-powers-oq-05-oq-01): Nat-congruence power-sum dichotomy mod p [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3502,6 +3502,7 @@ import Proofs.SumOfKthPowersOQ03
 import Proofs.SumOfKthPowersOQ04
 import Proofs.SumOfKthPowersOQ04Aristotle
 import Proofs.SumOfKthPowersOQ05
+import Proofs.SumOfKthPowersOQ05OQ01
 import Proofs.SumOfOddsStatementOnly
 import Proofs.SummationByPartsOQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01

--- a/proofs/Proofs/SumOfKthPowersOQ05OQ01.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ05OQ01.lean
@@ -1,0 +1,125 @@
+import Mathlib
+import Proofs.SumOfKthPowersOQ05
+
+/-
+# Nat-Congruence Power-Sum Dichotomy mod p (Sum of k-th Powers, OQ-05-OQ-01)
+
+The parent entry `SumOfKthPowersOQ05` proves the modular dichotomy for the complete
+power sum over a finite field, specialised to `ZMod p`:
+
+  `∑_{x : ZMod p} x^k = -1`  if `k ≠ 0` and `(p-1) ∣ k`,   and `0` otherwise.
+
+That statement lives in the ring `ZMod p`.  The natural number-theoretic reading is a
+congruence between honest natural numbers,
+
+  `∑_{i < p} i^k ≡ (if k ≠ 0 ∧ (p-1) ∣ k then p-1 else 0)  (mod p)`,
+
+where the sum is the ordinary sum of `k`-th powers of the residues `0, 1, …, p-1` taken in
+`ℕ`.  This file performs that cast.  The only mathematical content beyond the parent is the
+bookkeeping translation between the field-valued sum and the `ℕ`-valued sum:
+
+  * `Nat.cast` is a ring hom, so `(↑(∑ i<p, i^k) : ZMod p) = ∑ i<p, (↑i)^k`;
+  * the map `i ↦ (i : ZMod p)` restricted to `range p` is a bijection onto `ZMod p`
+    (`Finset.sum_nbij'` with inverse `ZMod.val`), so `∑ i<p, (↑i)^k = ∑ x:ZMod p, x^k`;
+  * `(↑(p-1) : ZMod p) = -1` (via `Nat.cast_pred` and `ZMod.natCast_self`), matching the
+    `-1` on the field side to the `p-1` on the `ℕ` side.
+
+Concrete instances (e.g. `∑_{i<5} i^4 ≡ 4`, `∑_{i<7} i^6 ≡ 6`) are checked by kernel
+`decide`, so they incur no `Lean.ofReduceBool` dependency.  All results are `0`-axiom.
+-/
+
+namespace SumOfKthPowersOQ05OQ01
+
+open Finset
+open scoped BigOperators
+
+/-- The residue cast `i ↦ (i : ZMod p)` restricted to `range p` is a bijection onto the
+whole of `ZMod p` (its inverse is `ZMod.val`); hence the `ℕ`-indexed sum of `k`-th powers
+over `range p` agrees with the field-indexed sum over `ZMod p`. -/
+theorem sum_range_cast_pow (p : ℕ) [NeZero p] (k : ℕ) :
+    (∑ i ∈ Finset.range p, (i : ZMod p) ^ k) = ∑ x : ZMod p, x ^ k :=
+  Finset.sum_nbij' (fun i => (i : ZMod p)) (fun x => x.val)
+    (fun _ _ => Finset.mem_univ _)
+    (fun x _ => Finset.mem_range.mpr (ZMod.val_lt x))
+    (fun _a ha => ZMod.val_natCast_of_lt (Finset.mem_range.mp ha))
+    (fun x _ => ZMod.natCast_zmod_val x)
+    (fun _ _ => rfl)
+
+/-- **Power-sum dichotomy as a natural-number congruence.**  For a prime `p`, the sum of
+`k`-th powers of the residues `0, 1, …, p-1` satisfies
+
+  `∑_{i < p} i^k ≡ (if k ≠ 0 ∧ (p-1) ∣ k then p-1 else 0)  (mod p)`.
+
+This is the `ℕ`-valued face of `SumOfKthPowersOQ05.sum_pow_zmod`. -/
+theorem sum_pow_modEq (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    (∑ i ∈ Finset.range p, i ^ k) ≡
+      (if k ≠ 0 ∧ (p - 1) ∣ k then p - 1 else 0) [MOD p] := by
+  haveI : NeZero p := ⟨(Fact.out : p.Prime).pos.ne'⟩
+  rw [← ZMod.natCast_eq_natCast_iff, Nat.cast_sum]
+  simp only [Nat.cast_pow]
+  rw [sum_range_cast_pow p k, SumOfKthPowersOQ05.sum_pow_zmod p k]
+  by_cases hcond : k ≠ 0 ∧ (p - 1) ∣ k
+  · rw [if_pos hcond, if_pos hcond, Nat.cast_pred (Fact.out : p.Prime).pos,
+      ZMod.natCast_self]
+    ring
+  · rw [if_neg hcond, if_neg hcond, Nat.cast_zero]
+
+/-- When `k ≠ 0` and `(p-1) ∣ k`, the power sum is congruent to `p-1 ≡ -1`. -/
+theorem sum_pow_modEq_pred (p : ℕ) [Fact p.Prime] {k : ℕ} (hk : k ≠ 0)
+    (hdvd : (p - 1) ∣ k) :
+    (∑ i ∈ Finset.range p, i ^ k) ≡ p - 1 [MOD p] := by
+  have h := sum_pow_modEq p k
+  rwa [if_pos ⟨hk, hdvd⟩] at h
+
+/-- Otherwise (either `k = 0`, or `(p-1) ∤ k`), the power sum is divisible by `p`. -/
+theorem sum_pow_modEq_zero (p : ℕ) [Fact p.Prime] {k : ℕ}
+    (hcond : ¬(k ≠ 0 ∧ (p - 1) ∣ k)) :
+    (∑ i ∈ Finset.range p, i ^ k) ≡ 0 [MOD p] := by
+  have h := sum_pow_modEq p k
+  rwa [if_neg hcond] at h
+
+/-- The power sum is divisible by `p` exactly when we are *not* in the `(p-1) ∣ k`
+nonzero-exponent regime. -/
+theorem p_dvd_sum_pow_iff (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    p ∣ (∑ i ∈ Finset.range p, i ^ k) ↔ ¬(k ≠ 0 ∧ (p - 1) ∣ k) := by
+  constructor
+  · intro hp
+    by_contra hcond
+    obtain ⟨hk, hdvd⟩ := hcond
+    have h := sum_pow_modEq_pred p hk hdvd
+    -- `∑ ≡ 0` and `∑ ≡ p-1` would force `p ∣ p-1`, impossible for a prime.
+    have h0 : (∑ i ∈ Finset.range p, i ^ k) ≡ 0 [MOD p] := (Nat.modEq_zero_iff_dvd).mpr hp
+    have : (0 : ℕ) ≡ p - 1 [MOD p] := h0.symm.trans h
+    have hpd : p ∣ (p - 1) := (Nat.modEq_zero_iff_dvd).mp this.symm
+    have hlt : p - 1 < p := Nat.sub_lt (Fact.out : p.Prime).pos one_pos
+    have hpos : 0 < p - 1 := by
+      have := (Fact.out : p.Prime).two_le; omega
+    exact absurd (Nat.le_of_dvd hpos hpd) (by omega)
+  · intro hcond
+    exact (Nat.modEq_zero_iff_dvd).mp (sum_pow_modEq_zero p hcond)
+
+/-- **Sum of residues.** For an odd prime `p`, the residues `0, 1, …, p-1` sum to a
+multiple of `p` (the `k = 1` case: `(p-1) ∤ 1` once `p > 2`). -/
+theorem sum_residues_modEq (p : ℕ) [Fact p.Prime] (hp : 2 < p) :
+    (∑ i ∈ Finset.range p, i) ≡ 0 [MOD p] := by
+  have h := sum_pow_modEq_zero (p := p) (k := 1) ?_
+  · simpa using h
+  · rintro ⟨-, hdvd⟩
+    have : p - 1 ≤ 1 := Nat.le_of_dvd one_pos hdvd
+    omega
+
+/-! ### Concrete instances (verified by kernel `decide`, hence `0`-axiom) -/
+
+/-- `∑_{i<5} i^4 = 354 ≡ 4 (mod 5)`, since `(5-1) ∣ 4`. -/
+example : (∑ i ∈ Finset.range 5, i ^ 4) ≡ 4 [MOD 5] := by decide
+
+/-- `∑_{i<5} i^2 = 30 ≡ 0 (mod 5)`, since `(5-1) ∤ 2`. -/
+example : (∑ i ∈ Finset.range 5, i ^ 2) ≡ 0 [MOD 5] := by decide
+
+/-- `∑_{i<7} i^6 = 67171 ≡ 6 (mod 7)`, since `(7-1) ∣ 6`. -/
+example : (∑ i ∈ Finset.range 7, i ^ 6) ≡ 6 [MOD 7] := by decide
+
+/-- Sum of residues of `ZMod 5` lifted to `ℕ`: `0+1+2+3+4 = 10 ≡ 0 (mod 5)`. -/
+example : (∑ i ∈ Finset.range 5, i) ≡ 0 [MOD 5] := by decide
+
+end SumOfKthPowersOQ05OQ01

--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01/meta.json
@@ -1,0 +1,179 @@
+{
+  "id": "sum-of-kth-powers-oq-05-oq-01",
+  "title": "Nat-Congruence Power-Sum Dichotomy mod p: ∑_{i<p} iᵏ ≡ (p−1 or 0)",
+  "slug": "sum-of-kth-powers-oq-05-oq-01",
+  "description": "The natural-number congruence face of the finite-field power-sum dichotomy. Casting the parent's ZMod p result ∑_{x:ZMod p} xᵏ = (−1 if k≠0 ∧ (p−1)∣k else 0) back to ℕ via Nat.ModEq gives ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p), a congruence between honest natural numbers. The cast hinges on a clean reindexing lemma: the residue map i ↦ (i:ZMod p) restricted to range p is a bijection onto ZMod p (inverse ZMod.val), so the ℕ-indexed sum agrees with the field-indexed sum. Includes the −1≡p−1 and divisibility corollaries, an iff characterizing exactly when p divides the power sum, the odd-prime residue-sum-≡0 case, and decide-checked instances. Verified, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_little_theorem",
+    "date": "2026-06-23",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "finite-fields",
+      "power-sums",
+      "fermat-little-theorem",
+      "modular-arithmetic",
+      "nat-modeq",
+      "zmod",
+      "congruences",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfKthPowersOQ05OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.natCast_eq_natCast_iff",
+        "description": "(↑a : ZMod c) = ↑b ↔ a ≡ b [MOD c] — the bridge converting the ℕ-valued congruence goal into an equality of casts in ZMod p",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_nbij'",
+        "description": "reindexes a finite sum along a bijection given with an explicit inverse; instantiated with i ↦ (i:ZMod p) and inverse ZMod.val to match ∑ over range p with ∑ over ZMod p",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "ZMod.val_natCast_of_lt",
+        "description": "(↑a : ZMod n).val = a when a < n — the left inverse of the residue cast on range p",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_zmod_val",
+        "description": "((a.val : ℕ) : ZMod n) = a for NeZero n — the right inverse, recovering every residue from its val",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.cast_pred",
+        "description": "(↑(n−1) : R) = ↑n − 1 for 0 < n — combined with ZMod.natCast_self gives (↑(p−1) : ZMod p) = −1, matching the field-side −1 to the ℕ-side p−1",
+        "module": "Mathlib.Data.Nat.Cast.Defs"
+      },
+      {
+        "theorem": "SumOfKthPowersOQ05.sum_pow_zmod",
+        "description": "the parent gallery result ∑_{x:ZMod p} xᵏ = if k≠0 ∧ (p−1)∣k then −1 else 0 — the field-valued dichotomy this entry casts to ℕ",
+        "module": "Proofs.SumOfKthPowersOQ05"
+      }
+    ],
+    "originalContributions": [
+      "sum_range_cast_pow: the residue cast i ↦ (i:ZMod p) restricted to range p is a bijection onto ZMod p, so ∑_{i<p} (↑i)ᵏ = ∑_{x:ZMod p} xᵏ (the reindexing engine, via Finset.sum_nbij' with inverse ZMod.val)",
+      "sum_pow_modEq: ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p) — the Nat-congruence face of the parent's ZMod p dichotomy",
+      "sum_pow_modEq_pred: when k≠0 and (p−1)∣k, ∑_{i<p} iᵏ ≡ p−1 (≡ −1) (mod p)",
+      "sum_pow_modEq_zero: otherwise ∑_{i<p} iᵏ ≡ 0 (mod p)",
+      "p_dvd_sum_pow_iff: p divides ∑_{i<p} iᵏ exactly when ¬(k≠0 ∧ (p−1)∣k) — a clean divisibility characterization",
+      "sum_residues_modEq: for an odd prime p, ∑_{i<p} i ≡ 0 (mod p) (the k=1 case lifted to ℕ)",
+      "Concrete decide-checked Nat.ModEq instances over mod 5 and mod 7 (0-axiom, no native_decide)"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 125,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Concrete instances use kernel decide (not native_decide), so no Lean.ofReduceBool dependency.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical congruence ∑_{i=1}^{p-1} iᵏ ≡ −1 (mod p) when (p−1)∣k, and ≡ 0 otherwise, is a staple of elementary number theory (Ireland–Rosen, Ch. 4) and the engine behind the von Staudt–Clausen analysis of Bernoulli-number denominators. It is most cleanly proved by working in the field ZMod p — which is exactly what the parent entry sum-of-kth-powers-oq-05 does. But the statement people quote is a congruence between ordinary integers/naturals, ∑_{i<p} iᵏ ≡ … (mod p). This entry closes that gap, transporting the field-valued theorem to a Nat.ModEq statement and recording the divisibility consequences directly usable in ℕ.",
+    "problemStatement": "**Open Question (sum-of-kth-powers-oq-05-oq-01)**: Derive the Nat-congruence corollary ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p) by casting the ZMod p power-sum dichotomy back to ℕ via Nat.ModEq.\n\n**Result**: sum_pow_modEq establishes exactly this congruence, with corollaries sum_pow_modEq_pred / sum_pow_modEq_zero, the divisibility iff p_dvd_sum_pow_iff, and the residue-sum case sum_residues_modEq.",
+    "text": "For a prime p, the sum of k-th powers of the residues 0,1,…,p−1 taken in ℕ is congruent mod p to p−1 when k ≠ 0 and (p−1) divides k, and to 0 in every other case.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sum_range_cast_pow` reindexes the ℕ-indexed sum onto ZMod p. The map i ↦ (i:ZMod p) on range p is a bijection with inverse ZMod.val: well-definedness is trivial (mem_univ), the inverse lands in range p by ZMod.val_lt, and the two round-trips are ZMod.val_natCast_of_lt (val of a small cast is itself) and ZMod.natCast_zmod_val (cast of a val recovers the element). Finset.sum_nbij' packages this into ∑_{i<p} (↑i)ᵏ = ∑_{x:ZMod p} xᵏ.\n2. `sum_pow_modEq` rewrites the goal a ≡ b [MOD p] as (↑a : ZMod p) = ↑b via ZMod.natCast_eq_natCast_iff, pushes the cast through the sum (Nat.cast_sum, Nat.cast_pow), applies the reindexing lemma and the parent's sum_pow_zmod, then matches the two if-branches: on the divisible branch (↑(p−1):ZMod p) = ↑p − 1 = −1 by Nat.cast_pred and ZMod.natCast_self; on the other branch both sides are 0.\n3. `sum_pow_modEq_pred` and `sum_pow_modEq_zero` specialize the two branches.\n4. `p_dvd_sum_pow_iff` converts the congruences to divisibility (Nat.modEq_zero_iff_dvd); the forward direction rules out the divisible branch because ∑ ≡ p−1 and ∑ ≡ 0 would force p ∣ (p−1), impossible since 0 < p−1 < p.\n5. `sum_residues_modEq` instantiates k = 1: (p−1)∣1 forces p−1 ≤ 1, contradicting p > 2.",
+    "keyInsights": [
+      "**Casting a field identity to a Nat congruence.** The parent theorem lives in the field ZMod p; the quotable statement lives in ℕ. The translation is exactly ZMod.natCast_eq_natCast_iff (a ≡ b [MOD p] ↔ casts agree) plus pushing Nat.cast through the finite sum — no new arithmetic, but the bookkeeping is the whole point of the entry.",
+      "**Reindexing range p ↔ ZMod p.** The crux is that i ↦ (i:ZMod p) is a bijection of range p onto the whole residue ring, with honest inverse ZMod.val. Stated as the standalone lemma sum_range_cast_pow, this is the reusable bridge between ℕ-sums over an initial segment and Fintype sums over ZMod p.",
+      "**−1 on the field side is p−1 on the ℕ side.** The dichotomy's −1 must become the natural number p−1 under the cast; Nat.cast_pred together with ZMod.natCast_self makes (↑(p−1):ZMod p) = −1 precise, the one place the value (not just the divisibility pattern) is matched.",
+      "**A divisibility test, not just a congruence.** p_dvd_sum_pow_iff turns the dichotomy into a crisp criterion: p ∣ ∑_{i<p} iᵏ ⟺ k = 0 or (p−1)∤k. The residue-sum fact 0+1+⋯+(p−1) ≡ 0 (mod p) for odd p is the headline k=1 instance."
+    ],
+    "prerequisites": [
+      "The parent finite-field power-sum dichotomy (sum-of-kth-powers-oq-05)",
+      "Nat.ModEq and its cast characterization ZMod.natCast_eq_natCast_iff",
+      "ZMod p ↔ range p reindexing via ZMod.val and the residue cast"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring explaining the cast from the field-valued parent result to a Nat.ModEq statement, the imports (Mathlib and the parent file), and the namespace.",
+      "mathContext": "$\\sum_{i<p} i^k \\pmod p$ obtained from $\\sum_{x:\\mathbb{Z}/p} x^k$."
+    },
+    {
+      "id": "reindex",
+      "title": "Residue-Cast Reindexing",
+      "startLine": 40,
+      "endLine": 55,
+      "summary": "sum_range_cast_pow: the bijection i ↦ (i:ZMod p) on range p (inverse ZMod.val) identifies ∑_{i<p} (↑i)ᵏ with ∑_{x:ZMod p} xᵏ, via Finset.sum_nbij'.",
+      "mathContext": "$\\sum_{i<p} (\\bar{i})^k = \\sum_{x:\\mathbb{Z}/p} x^k$."
+    },
+    {
+      "id": "main",
+      "title": "Nat-Congruence Dichotomy and Corollaries",
+      "startLine": 56,
+      "endLine": 110,
+      "summary": "sum_pow_modEq (the main congruence), sum_pow_modEq_pred / sum_pow_modEq_zero (the two branches), and p_dvd_sum_pow_iff (the divisibility criterion).",
+      "mathContext": "$\\sum_{i<p} i^k \\equiv \\begin{cases} p-1 & k \\neq 0,\\ (p-1)\\mid k \\\\ 0 & \\text{otherwise} \\end{cases} \\pmod p$"
+    },
+    {
+      "id": "residues",
+      "title": "Sum of Residues and Instances",
+      "startLine": 111,
+      "endLine": 125,
+      "summary": "sum_residues_modEq (∑_{i<p} i ≡ 0 for odd primes, the k=1 case) and concrete decide-verified Nat.ModEq instances mod 5 and mod 7.",
+      "mathContext": "$\\sum_{i<p} i \\equiv 0 \\pmod p$ for odd $p$; e.g. $\\sum_{i<5} i^4 = 354 \\equiv 4 \\pmod 5$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-kth-powers-oq-05",
+      "relationship": "extends",
+      "description": "Casts the parent's field-valued dichotomy ∑_{x:ZMod p} xᵏ = (−1 or 0) into the Nat.ModEq statement ∑_{i<p} iᵏ ≡ (p−1 or 0) (mod p), directly answering the parent's first listed open question"
+    },
+    {
+      "targetId": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Complements the base family's integer closed forms (Faulhaber/Nicomachus) with the mod-p congruence evaluation of the same power sum"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) transport of the finite-field power-sum dichotomy to a natural-number congruence: ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p), with branch corollaries, a divisibility iff, and the odd-prime residue-sum case, plus decide-checked instances.",
+    "implications": "Provides the quotable ℕ-congruence form of the power-sum dichotomy that the field-valued parent omits, packaged with a reusable range-p ↔ ZMod-p reindexing lemma (sum_range_cast_pow) and a divisibility criterion p ∣ ∑ iᵏ ⟺ ¬(k≠0 ∧ (p−1)∣k).",
+    "openQuestions": [
+      "Extend the Nat-congruence dichotomy to ∑_{i<n} iᵏ for composite n by combining the prime-power case with the Chinese Remainder Theorem.",
+      "Use sum_pow_modEq to give a finite-field derivation of the von Staudt–Clausen congruence on the p-integral part of Bernoulli numbers B_k for (p−1)∣k."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SumOfKthPowersOQ05"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SumOfKthPowersOQ05OQ01",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfKthPowersOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Ireland, Kenneth and Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer Graduate Texts in Mathematics 84, 2nd ed.",
+      "note": "Chapter 4: ∑ iᵏ mod p and its role in Bernoulli number congruences"
+    },
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Power residues and congruences for sums of powers mod p"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **sum-of-kth-powers-oq-05-oq-01** — the first open question listed by the parent entry `sum-of-kth-powers-oq-05`:

> Derive the Nat-congruence corollary `∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p)` by casting the ZMod p power-sum dichotomy back to ℕ via `Nat.ModEq`.

The parent proves the dichotomy in the field `ZMod p`:
`∑_{x:ZMod p} xᵏ = (−1 if k≠0 ∧ (p−1)∣k else 0)`. This entry transports it to a congruence between honest natural numbers.

## Results (`proofs/Proofs/SumOfKthPowersOQ05OQ01.lean`, 6 theorems, 125 lines)

- **`sum_range_cast_pow`** — reusable bridge: the residue cast `i ↦ (i:ZMod p)` on `range p` is a bijection onto `ZMod p` (inverse `ZMod.val`), so `∑_{i<p} (↑i)ᵏ = ∑_{x:ZMod p} xᵏ` (via `Finset.sum_nbij'`).
- **`sum_pow_modEq`** — the main congruence: `∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) [MOD p]`.
- **`sum_pow_modEq_pred` / `sum_pow_modEq_zero`** — the two branches (`≡ p−1 ≡ −1`, resp. `≡ 0`).
- **`p_dvd_sum_pow_iff`** — divisibility criterion: `p ∣ ∑_{i<p} iᵏ ⟺ ¬(k≠0 ∧ (p−1)∣k)`.
- **`sum_residues_modEq`** — odd-prime residue sum `0+1+⋯+(p−1) ≡ 0 (mod p)` (the `k=1` case).
- Concrete `Nat.ModEq` instances mod 5 and mod 7 by **kernel `decide`** (no `native_decide`).

## Verification

- **0 axioms** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` for all 6 theorems (no `sorryAx`, no `Lean.ofReduceBool`).
- **0 sorries.** Builds against Mathlib 4.26.0 and the parent `Proofs.SumOfKthPowersOQ05`.
- Added to the `Proofs.lean` aggregator; gallery entry at `src/data/proofs/sum-of-kth-powers-oq-05-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)