### PR TITLE
research(sum-of-kth-powers-oq-05-oq-01): ℕ congruence ∑_{i<p} iᵏ ≡ −1 iff (p−1)∣k [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -672,6 +672,7 @@ import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChebyshevPNTBridgeOQ03
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevSumMonotoneOQ01
+import Proofs.ChebyshevSumWeightedOQ01OQ01
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ05

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3503,6 +3503,7 @@ import Proofs.SumOfKthPowersOQ03
 import Proofs.SumOfKthPowersOQ04
 import Proofs.SumOfKthPowersOQ04Aristotle
 import Proofs.SumOfKthPowersOQ05
+import Proofs.SumOfKthPowersOQ05OQ01
 import Proofs.SumOfOddsStatementOnly
 import Proofs.SummationByPartsOQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01

--- a/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01.lean
+++ b/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01.lean
@@ -1,0 +1,211 @@
+import Mathlib
+
+/-
+# Weighted Chebyshev sum inequality from a monovariance hypothesis
+
+The Mathlib Chebyshev file (`Mathlib/Algebra/Order/Chebyshev.lean`) proves the
+*unweighted* sum inequality
+
+  (∑ i ∈ s, f i) * (∑ i ∈ s, g i) ≤ #s * ∑ i ∈ s, f i * g i
+
+for `MonovaryOn f g s` (equivalently, similarly sorted sequences), and the reverse
+inequality for `AntivaryOn`. It has **no** weighted analogue.
+
+This file fills that gap. Given nonnegative weights `w : ι → ℝ` with total mass
+`W = ∑ i ∈ s, w i`, and `f`, `g` monovarying on `s`, we prove the
+**weighted Chebyshev sum inequality**
+
+  (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i) ≤ W * ∑ i ∈ s, w i * f i * g i,
+
+and the reverse for antivarying `f`, `g`. Taking `w ≡ 1` recovers the Mathlib `#s`
+form, so this is a strict generalization.
+
+The engine is the **weighted monovariance identity**
+
+  2 (W·∑ wᵢfᵢgᵢ − (∑ wᵢfᵢ)(∑ wᵢgᵢ))
+    = ∑ᵢ ∑ⱼ wᵢ wⱼ (fᵢ − fⱼ)(gᵢ − gⱼ),
+
+whose right-hand side is a sum of products of nonnegative factors (each
+`(fᵢ − fⱼ)(gᵢ − gⱼ) ≥ 0` because `f` and `g` monovary), hence `≥ 0`.
+
+All results are fully verified with no extra axioms.
+-/
+
+namespace ChebyshevSumWeighted
+
+open Finset
+
+variable {ι : Type*} {s : Finset ι} {w f g : ι → ℝ}
+
+/-! ## The sign lemmas for monovarying / antivarying pairs -/
+
+/-- If `f` and `g` monovary on `s`, then for any two indices `i, j ∈ s` the cross
+difference `(f i - f j) * (g i - g j)` is nonnegative: the two factors always carry the
+same sign. -/
+theorem sub_mul_sub_nonneg_of_monovaryOn (hfg : MonovaryOn f g s) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) : 0 ≤ (f i - f j) * (g i - g j) := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · -- `g i < g j` forces `f i ≤ f j`: both factors are `≤ 0`.
+    have hf : f i ≤ f j := hfg hi hj h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f j - f i)
+      (by linarith : (0 : ℝ) ≤ g j - g i)]
+  · -- equal `g`-values kill the second factor.
+    have : g i - g j = 0 := by linarith
+    rw [this, mul_zero]
+  · -- `g j < g i` forces `f j ≤ f i`: both factors are `≥ 0`.
+    have hf : f j ≤ f i := hfg hj hi h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f i - f j)
+      (by linarith : (0 : ℝ) ≤ g i - g j)]
+
+/-- If `f` and `g` antivary on `s`, then `(f i - f j) * (g i - g j) ≤ 0` for all
+`i, j ∈ s`: the two factors always carry opposite signs. -/
+theorem sub_mul_sub_nonpos_of_antivaryOn (hfg : AntivaryOn f g s) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) : (f i - f j) * (g i - g j) ≤ 0 := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · -- `g i < g j` forces `f j ≤ f i`: first factor `≥ 0`, second `≤ 0`.
+    have hf : f j ≤ f i := hfg hi hj h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f i - f j)
+      (by linarith : (0 : ℝ) ≤ g j - g i)]
+  · have : g i - g j = 0 := by linarith
+    rw [this, mul_zero]
+  · -- `g j < g i` forces `f i ≤ f j`: first factor `≤ 0`, second `≥ 0`.
+    have hf : f i ≤ f j := hfg hj hi h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f j - f i)
+      (by linarith : (0 : ℝ) ≤ g i - g j)]
+
+/-! ## The weighted monovariance identity -/
+
+/-- **Weighted monovariance identity.** The symmetric double sum of
+`wᵢ wⱼ (fᵢ − fⱼ)(gᵢ − gⱼ)` equals twice the Chebyshev defect
+`W·∑ wᵢfᵢgᵢ − (∑ wᵢfᵢ)(∑ wᵢgᵢ)`. This holds for arbitrary real data — no sign or
+monotonicity hypothesis is needed. -/
+theorem two_mul_chebyshev_defect_eq (w f g : ι → ℝ) (s : Finset ι) :
+    ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))
+      = 2 * ((∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i)
+        - 2 * ((∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i) := by
+  -- The four "monomial" double sums, each collapsing to a product of two single sums.
+  have h1 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g i)
+      = (∑ i ∈ s, w i * f i * g i) * ∑ j ∈ s, w j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h2 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g j)
+      = (∑ i ∈ s, w i) * ∑ j ∈ s, w j * f j * g j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h3 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g j)
+      = (∑ i ∈ s, w i * f i) * ∑ j ∈ s, w j * g j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h4 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g i)
+      = (∑ i ∈ s, w i * g i) * ∑ j ∈ s, w j * f j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  -- Expand the summand and split the double sum into the four monomial pieces.
+  have hsplit : ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))
+      = (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g i))
+        - (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g j))
+        - (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g i))
+        + (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g j)) := by
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun j _ => by ring
+  rw [hsplit, h1, h2, h3, h4]
+  ring
+
+/-! ## Weighted Chebyshev inequalities -/
+
+/-- **Weighted Chebyshev sum inequality** (similarly sorted data). For nonnegative
+weights `w` and functions `f`, `g` that monovary on `s`, the product of the weighted
+sums is at most the total weight times the weighted sum of products. With `w ≡ 1` this
+is the Mathlib lemma `MonovaryOn.sum_mul_sum_le_card_mul_sum`. -/
+theorem weighted_sum_mul_sum_le (hfg : MonovaryOn f g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i := by
+  have hD : 0 ≤ ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) := by
+    refine Finset.sum_nonneg fun i hi => Finset.sum_nonneg fun j hj => ?_
+    have := sub_mul_sub_nonneg_of_monovaryOn hfg hi hj
+    have hwi := hw i hi
+    have hwj := hw j hj
+    positivity
+  rw [two_mul_chebyshev_defect_eq] at hD
+  linarith
+
+/-- **Reverse weighted Chebyshev sum inequality** (oppositely sorted data). For
+nonnegative weights and `f`, `g` antivarying on `s`, the inequality reverses. With
+`w ≡ 1` this is `AntivaryOn.card_mul_sum_le_sum_mul_sum`. -/
+theorem weighted_antivary_le_sum_mul_sum (hfg : AntivaryOn f g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ≤ (∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i := by
+  have hD : ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) ≤ 0 := by
+    refine Finset.sum_nonpos fun i hi => Finset.sum_nonpos fun j hj => ?_
+    have hsign := sub_mul_sub_nonpos_of_antivaryOn hfg hi hj
+    have hwi := hw i hi
+    have hwj := hw j hj
+    have : 0 ≤ w i * w j := mul_nonneg hwi hwj
+    nlinarith [mul_nonneg this (neg_nonneg.mpr hsign)]
+  rw [two_mul_chebyshev_defect_eq] at hD
+  linarith
+
+/-! ## Monotone-sequence corollaries -/
+
+variable [LinearOrder ι]
+
+/-- **Weighted Chebyshev for monotone data.** If `f` and `g` are monotone on `s`, they
+monovary there, so the weighted Chebyshev inequality applies. This is the form named in
+the open question: a weighted inequality for similarly sorted (monotone) sequences. -/
+theorem weighted_chebyshev_monotoneOn (hf : MonotoneOn f s) (hg : MonotoneOn g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i :=
+  weighted_sum_mul_sum_le (hf.monovaryOn hg) hw
+
+/-- **Reverse weighted Chebyshev for oppositely monotone data.** If `f` is monotone and
+`g` is antitone on `s`, the weighted inequality reverses. -/
+theorem weighted_chebyshev_antitoneOn (hf : MonotoneOn f s) (hg : AntitoneOn g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ≤ (∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i :=
+  weighted_antivary_le_sum_mul_sum (hf.antivaryOn hg) hw
+
+/-! ## Weighted Cauchy–Schwarz corollary and unweighted recovery -/
+
+omit [LinearOrder ι] in
+/-- **Weighted Cauchy–Schwarz-type corollary.** The self-monovarying case `f = g` gives
+`(∑ wᵢfᵢ)² ≤ (∑ wᵢ)(∑ wᵢfᵢ²)`, a weighted power-mean / Cauchy–Schwarz bound, valid for
+*any* `f` (every function monovaries with itself). -/
+theorem weighted_sq_sum_le (w f : ι → ℝ) (s : Finset ι) (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) ^ 2 ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i ^ 2 := by
+  have h := weighted_sum_mul_sum_le (w := w) (monovaryOn_self f s) hw
+  rw [sq]
+  calc (∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * f i
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * f i := h
+    _ = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i ^ 2 := by
+          refine congrArg _ (Finset.sum_congr rfl fun i _ => ?_); ring
+
+omit [LinearOrder ι] in
+/-- Sanity check: with all weights equal to `1`, the weighted inequality collapses to the
+classical Mathlib `#s` form `(∑ f)(∑ g) ≤ #s · ∑ f g`. -/
+theorem unweighted_recovery (hfg : MonovaryOn f g s) :
+    (∑ i ∈ s, f i) * (∑ i ∈ s, g i) ≤ (#s : ℝ) * ∑ i ∈ s, f i * g i := by
+  have h := weighted_sum_mul_sum_le (w := fun _ => (1 : ℝ)) hfg (fun i _ => by norm_num)
+  simpa using h
+
+/-! ## Worked instance -/
+
+/-- A concrete weighted instance with weights `1, 2, 3` on the increasing sequence
+`0, 1, 2` (against itself), obtained from `weighted_sq_sum_le`. It evaluates to
+`(1·0 + 2·1 + 3·2)² = 64 ≤ 6 · (1·0² + 2·1² + 3·2²) = 6·14 = 84`. -/
+example :
+    (∑ i ∈ range 3, ((i : ℝ) + 1) * (i : ℝ)) ^ 2
+      ≤ (∑ i ∈ range 3, ((i : ℝ) + 1)) * ∑ i ∈ range 3, ((i : ℝ) + 1) * (i : ℝ) ^ 2 :=
+  weighted_sq_sum_le (fun i : ℕ => (i : ℝ) + 1) (fun i : ℕ => (i : ℝ)) (range 3)
+    fun i _ => by positivity
+
+/-- The instance above, with the sums evaluated: `64 ≤ 84`. -/
+example : ((0 : ℝ) + 2 * 1 + 3 * 2) ^ 2 ≤ (1 + 2 + 3) * (0 + 2 * 1 ^ 2 + 3 * 2 ^ 2) := by
+  norm_num
+
+end ChebyshevSumWeighted

--- a/proofs/Proofs/SumOfKthPowersOQ05OQ01.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ05OQ01.lean
@@ -1,0 +1,141 @@
+import Mathlib
+import Proofs.SumOfKthPowersOQ05
+
+/-
+# Power Sums mod `p`: the Natural-Number Congruence (Sum of k-th Powers, OQ-05-OQ-01)
+
+The parent entry (`SumOfKthPowersOQ05`) proves the complete power sum over a finite
+field, and its `ZMod p` specialisation
+
+  `∑_{x : ZMod p} x^k = -1`  if `k ≠ 0` and `(p-1) ∣ k`,   and `0` otherwise.
+
+That statement lives in the *ring* `ZMod p`.  The elementary number-theoretic face of the
+same fact — the form actually used to prove divisibilities like `p ∣ ∑_{i<p} i^k` — is a
+congruence between honest natural numbers:
+
+  `∑_{i=0}^{p-1} i^k ≡ (if k ≠ 0 and (p-1) ∣ k then p-1 else 0)  (mod p).`
+
+This entry carries the `ZMod p` dichotomy down to `ℕ`.  The bridge is a reindexing of the
+sum over the whole field by the residues `0, 1, …, p-1` (a bijection `range p ≃ ZMod p`
+via `Nat.cast` / `ZMod.val`), followed by the `Nat.cast`/`ModEq` correspondence
+`(↑a = ↑b in ZMod p) ↔ a ≡ b [MOD p]`.  The `-1` of the field becomes the residue `p-1`.
+
+Consequences:
+* `p ∣ ∑_{i<p} i^k` holds **exactly** when it is *not* the case that `k ≠ 0` and `(p-1)∣k`
+  (the divisibility criterion behind the standard "vanishing of low power sums").
+* the residues `0,1,…,p-1` sum to a multiple of `p` for every odd prime (`k = 1`).
+* an integer version `∑_{i<p} (i:ℤ)^k ≡ -1 (mod p)` recovering the field's `-1` directly.
+
+All results are `0`-axiom; the concrete examples use kernel `decide` (not the
+compiler-trusting `native_decide`), so no `Lean.ofReduceBool` dependency is incurred.
+-/
+
+namespace SumOfKthPowersOQ05OQ01
+
+open Finset
+open scoped BigOperators
+
+/-- **Reindexing bridge.** The cast to `ZMod p` of the natural-number power sum over
+`range p` equals the complete power sum over `ZMod p`.  The residues `0, 1, …, p-1`
+biject with `ZMod p` via `Nat.cast` (inverse `ZMod.val`). -/
+theorem sum_range_pow_cast (p : ℕ) [NeZero p] (k : ℕ) :
+    ((∑ i ∈ Finset.range p, i ^ k : ℕ) : ZMod p) = ∑ x : ZMod p, x ^ k := by
+  push_cast
+  symm
+  apply Finset.sum_bij' (fun (x : ZMod p) _ => ZMod.val x) (fun (i : ℕ) _ => (i : ZMod p))
+  · intro x _; exact Finset.mem_range.mpr (ZMod.val_lt x)
+  · intro i _; exact Finset.mem_univ _
+  · intro x _; exact ZMod.natCast_zmod_val x
+  · intro i hi; exact ZMod.val_natCast_of_lt (Finset.mem_range.mp hi)
+  · intro x _; rw [ZMod.natCast_zmod_val]
+
+/-- **Power-sum congruence mod `p`.** For a prime `p`,
+`∑_{i=0}^{p-1} i^k ≡ (if k ≠ 0 and (p-1) ∣ k then p-1 else 0)  (mod p)`.
+This is the natural-number form of the `ZMod p` dichotomy
+(`SumOfKthPowersOQ05.sum_pow_zmod`). -/
+theorem sum_range_pow_modEq (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    (∑ i ∈ Finset.range p, i ^ k)
+      ≡ (if k ≠ 0 ∧ (p - 1) ∣ k then p - 1 else 0) [MOD p] := by
+  rw [← ZMod.natCast_eq_natCast_iff, sum_range_pow_cast p k,
+    SumOfKthPowersOQ05.sum_pow_zmod p k]
+  split_ifs with h
+  · -- residue `p-1` casts to `-1` in `ZMod p`
+    have hp1 : 1 ≤ p := (Fact.out : p.Prime).one_lt.le
+    rw [Nat.cast_sub hp1, ZMod.natCast_self, Nat.cast_one, zero_sub]
+  · rw [Nat.cast_zero]
+
+/-- The `-1` face: when `k ≠ 0` and `(p-1) ∣ k`, the power sum is congruent to `p-1`
+(equivalently `-1`) mod `p`. -/
+theorem sum_range_pow_modEq_neg_one (p : ℕ) [Fact p.Prime] (k : ℕ)
+    (hk : k ≠ 0) (hdvd : (p - 1) ∣ k) :
+    (∑ i ∈ Finset.range p, i ^ k) ≡ p - 1 [MOD p] := by
+  have h := sum_range_pow_modEq p k
+  rwa [if_pos ⟨hk, hdvd⟩] at h
+
+/-- **Divisibility criterion.** `p` divides `∑_{i<p} i^k` precisely when it is *not*
+the case that `k ≠ 0` and `(p-1) ∣ k`. -/
+theorem dvd_sum_range_pow_iff (p : ℕ) [Fact p.Prime] (k : ℕ) :
+    p ∣ (∑ i ∈ Finset.range p, i ^ k) ↔ ¬ (k ≠ 0 ∧ (p - 1) ∣ k) := by
+  have h2 : 2 ≤ p := (Fact.out : p.Prime).two_le
+  rw [← Nat.modEq_zero_iff_dvd]
+  constructor
+  · intro h hcond
+    have hres : (p - 1 : ℕ) ≡ 0 [MOD p] :=
+      ((sum_range_pow_modEq_neg_one p k hcond.1 hcond.2).symm).trans h
+    have : p ∣ (p - 1) := (Nat.modEq_zero_iff_dvd).mp hres
+    have := Nat.le_of_dvd (by omega) this
+    omega
+  · intro hcond
+    have h := sum_range_pow_modEq p k
+    rwa [if_neg hcond] at h
+
+/-- **Sum of residues.** For an odd prime `p`, the residues `0, 1, …, p-1`
+sum to a multiple of `p` (the `k = 1` case, where `(p-1) ∤ 1` once `p > 2`). -/
+theorem sum_range_self_modEq_zero (p : ℕ) [Fact p.Prime] (hp : 2 < p) :
+    (∑ i ∈ Finset.range p, i) ≡ 0 [MOD p] := by
+  have h := sum_range_pow_modEq p 1
+  simp only [pow_one] at h
+  rw [if_neg] at h
+  · exact h
+  · rintro ⟨-, hdvd⟩
+    have := Nat.le_of_dvd one_pos hdvd
+    omega
+
+/-- **Integer form.** When `k ≠ 0` and `(p-1) ∣ k`, the integer power sum over the
+residues is congruent to `-1` mod `p`, recovering the `-1` of `FiniteField.sum_pow_units`
+directly (without rewriting `-1` as `p-1`). -/
+theorem sum_range_pow_intModEq_neg_one (p : ℕ) [Fact p.Prime] (k : ℕ)
+    (hk : k ≠ 0) (hdvd : (p - 1) ∣ k) :
+    (∑ i ∈ Finset.range p, (i : ℤ) ^ k) ≡ -1 [ZMOD p] := by
+  have hnat := sum_range_pow_modEq_neg_one p k hk hdvd
+  have hint : ((∑ i ∈ Finset.range p, i ^ k : ℕ) : ℤ) ≡ ((p - 1 : ℕ) : ℤ) [ZMOD p] :=
+    Int.natCast_modEq_iff.mpr hnat
+  have hcast : ((∑ i ∈ Finset.range p, i ^ k : ℕ) : ℤ)
+      = ∑ i ∈ Finset.range p, (i : ℤ) ^ k := by push_cast; ring
+  rw [hcast] at hint
+  refine hint.trans ?_
+  have hp1 : 1 ≤ p := (Fact.out : p.Prime).one_lt.le
+  rw [Int.modEq_iff_dvd]
+  refine ⟨-1, ?_⟩
+  have hsub : ((p - 1 : ℕ) : ℤ) = (p : ℤ) - 1 := by
+    rw [Nat.cast_sub hp1, Nat.cast_one]
+  rw [hsub]; ring
+
+/-! ### Concrete instances (verified by `decide`, hence `0`-axiom) -/
+
+/-- `∑_{i<5} i^4 = 354 ≡ 4 = 5-1 (mod 5)`, since `4 ≠ 0` and `(5-1) ∣ 4`. -/
+example : (∑ i ∈ Finset.range 5, i ^ 4) ≡ 4 [MOD 5] := by decide
+
+/-- `∑_{i<5} i^2 = 30 ≡ 0 (mod 5)`, since `(5-1) ∤ 2`. -/
+example : (∑ i ∈ Finset.range 5, i ^ 2) ≡ 0 [MOD 5] := by decide
+
+/-- `∑_{i<7} i^6 ≡ 6 = 7-1 (mod 7)`, since `(7-1) ∣ 6`. -/
+example : (∑ i ∈ Finset.range 7, i ^ 6) ≡ 6 [MOD 7] := by decide
+
+/-- `5 ∣ ∑_{i<5} i^2` (the divisibility criterion, since `(5-1) ∤ 2`). -/
+example : 5 ∣ (∑ i ∈ Finset.range 5, i ^ 2) := by decide
+
+/-- `5 ∤ ∑_{i<5} i^4` (since `(5-1) ∣ 4`, the sum is `≡ -1`). -/
+example : ¬ 5 ∣ (∑ i ∈ Finset.range 5, i ^ 4) := by decide
+
+end SumOfKthPowersOQ05OQ01

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-01",
+  "title": "Weighted Chebyshev Sum Inequality from a Monovariance Hypothesis",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-01",
+  "description": "Mathlib's Chebyshev sum inequality (MonovaryOn.sum_mul_sum_le_card_mul_sum) has no weighted analogue: it only multiplies the sum of products by the cardinality #s. We prove the weighted version. For nonnegative weights w with total mass W = ∑ wᵢ and functions f, g that monovary on s, (∑ wᵢfᵢ)(∑ wᵢgᵢ) ≤ W·∑ wᵢfᵢgᵢ, together with the reverse inequality for antivarying f, g, the monotone-sequence corollaries, a weighted Cauchy–Schwarz square bound (∑ wᵢfᵢ)² ≤ W·∑ wᵢfᵢ², and a w ≡ 1 recovery of the Mathlib #s form. The engine is the weighted monovariance identity 2(W·∑ wᵢfᵢgᵢ − (∑ wᵢfᵢ)(∑ wᵢgᵢ)) = ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ − fⱼ)(gᵢ − gⱼ), whose right side is a sum of products of like-signed factors, hence nonnegative.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "inequalities",
+      "order",
+      "chebyshev-sum-inequality",
+      "weighted",
+      "monotone",
+      "cauchy-schwarz"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevSumWeightedOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 211,
+    "mathlibDependencies": [
+      {
+        "theorem": "MonovaryOn / AntivaryOn",
+        "description": "The order-correlation predicates: g i < g j → f i ≤ f j (monovary) resp. f j ≤ f i (antivary), supplying the sign of each cross difference (f i − f j)(g i − g j)",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "monovaryOn_self",
+        "description": "Every function monovaries with itself on any set — drives the weighted Cauchy–Schwarz square corollary",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "MonotoneOn.monovaryOn / MonotoneOn.antivaryOn",
+        "description": "Bridges turning monotone (resp. monotone-vs-antitone) hypotheses on a finite set into MonovaryOn / AntivaryOn, used for the monotone-sequence corollaries",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "Finset.sum_mul_sum",
+        "description": "(∑ i, a i)(∑ j, b j) = ∑ i ∑ j a i · b j — collapses each of the four monomial double sums in the monovariance identity to a product of single sums",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      }
+    ],
+    "originalContributions": [
+      "two_mul_chebyshev_defect_eq: the weighted monovariance identity ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) = 2(W·∑ wfg − (∑ wf)(∑ wg)), valid for arbitrary real data with no sign hypothesis — the algebraic heart absent from Mathlib",
+      "sub_mul_sub_nonneg_of_monovaryOn / sub_mul_sub_nonpos_of_antivaryOn: each cross difference (fᵢ−fⱼ)(gᵢ−gⱼ) is ≥ 0 under monovariance and ≤ 0 under antivariance, by trichotomy on g",
+      "weighted_sum_mul_sum_le: the weighted Chebyshev sum inequality (∑ wf)(∑ wg) ≤ W·∑ wfg for nonnegative weights and monovarying f, g — the result Mathlib lacks",
+      "weighted_antivary_le_sum_mul_sum: the reverse weighted inequality for antivarying f, g",
+      "weighted_chebyshev_monotoneOn / weighted_chebyshev_antitoneOn: the monotone-sequence forms named in the open question, via the monotone ⇒ monovary bridges",
+      "weighted_sq_sum_le: the weighted Cauchy–Schwarz / power-mean corollary (∑ wf)² ≤ W·∑ wf², the self-monovarying case",
+      "unweighted_recovery: with w ≡ 1 the bound collapses to Mathlib's classical #s form, confirming the generalization"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's sum inequality (1880s) states that for two similarly sorted real sequences the average of their products dominates the product of their averages. The weighted form replaces uniform averaging by a probability-like weighting wᵢ ≥ 0: with total mass W = ∑ wᵢ one still has (∑ wᵢfᵢ)(∑ wᵢgᵢ) ≤ W·∑ wᵢfᵢgᵢ. This is the discrete statement that two comonotone random variables on a finite probability space have nonnegative covariance, and it underlies the FKG / Chebyshev correlation inequalities. Mathlib formalises only the unweighted version, where the multiplier is the cardinality #s; the weighted generalization — the one that specialises to covariance for a genuine weight/measure — is missing.",
+    "problemStatement": "Let $s$ be a finite index set, $w : \\iota \\to \\mathbb{R}$ with $w_i \\ge 0$ for $i \\in s$, and write $W = \\sum_{i\\in s} w_i$. If $f, g$ monovary on $s$ (e.g. both monotone) then\n\n$$\\Big(\\sum_{i\\in s} w_i f_i\\Big)\\Big(\\sum_{i\\in s} w_i g_i\\Big) \\;\\le\\; W \\sum_{i\\in s} w_i f_i g_i,$$\n\nwith the inequality reversing when $f, g$ antivary. Specialise to monotone sequences, derive the weighted square bound $(\\sum_i w_i f_i)^2 \\le W \\sum_i w_i f_i^2$, and recover Mathlib's $\\#s$ form at $w \\equiv 1$.",
+    "proofStrategy": "The whole family rests on one identity and one sign fact.\n\n1. Weighted monovariance identity (two_mul_chebyshev_defect_eq): expand the symmetric double sum ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) into four monomial double sums; each collapses via Finset.sum_mul_sum to a product of single sums, giving exactly 2(W·∑ wfg − (∑ wf)(∑ wg)). No hypothesis on the data is used.\n\n2. Sign of the cross difference (sub_mul_sub_nonneg_of_monovaryOn): by trichotomy on g i vs g j, monovariance forces f and g to move together, so (fᵢ−fⱼ)(gᵢ−gⱼ) ≥ 0; antivariance forces opposite motion, giving ≤ 0.\n\n3. Weighted Chebyshev (weighted_sum_mul_sum_le): with wᵢ, wⱼ ≥ 0 and the cross differences ≥ 0, every summand of the double sum is ≥ 0, so the double sum is ≥ 0; rewriting it by the identity and dividing by 2 yields (∑ wf)(∑ wg) ≤ W·∑ wfg. The antivary version is identical with the sign reversed.\n\n4. Corollaries: the monotone forms compose the monotone ⇒ monovary bridges; the square bound is the self-monovarying case f = g; the unweighted recovery substitutes w ≡ 1 and simplifies ∑ 1 = #s.",
+    "keyInsights": [
+      "The identity 2(W·∑ wfg − (∑ wf)(∑ wg)) = ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) is a weighted 'sum of products' (covariance) identity — it holds for ALL real data, so the inequality is purely a statement about the sign of the cross differences.",
+      "Mathlib's #s form is the w ≡ 1 special case; weighting is exactly what turns Chebyshev's inequality into the nonnegative-covariance statement for a finite measure.",
+      "The nonnegativity argument never touches the cardinality: replacing the constant weight 1 by an arbitrary nonnegative weight changes nothing in the proof, only in the multiplier W = ∑ wᵢ.",
+      "Each cross difference's sign is the single place monotonicity enters; everything else is a weighted algebraic rearrangement, which is why the antivary case is a one-line sign flip.",
+      "The self-monovarying instance f = g gives a weighted Cauchy–Schwarz / variance bound (∑ wf)² ≤ W·∑ wf² for free, valid for any f."
+    ],
+    "prerequisites": [
+      "Finite sums over Finset and the double-sum factorization Finset.sum_mul_sum",
+      "The MonovaryOn / AntivaryOn order-correlation predicates and the monotone ⇒ monovary bridges",
+      "Chebyshev's sum inequality and its interpretation as nonnegative covariance",
+      "Basic ordered-field reasoning (sign of a product, nonnegativity of a sum of nonnegative terms)"
+    ]
+  },
+  "conclusion": {
+    "summary": "We proved the weighted Chebyshev sum inequality that Mathlib omits: for nonnegative weights w with total mass W and monovarying f, g, (∑ wf)(∑ wg) ≤ W·∑ wfg, with the antivarying reverse, the monotone-sequence corollaries, a weighted Cauchy–Schwarz square bound, and a w ≡ 1 recovery of the classical #s form. The engine is a weighted monovariance (covariance) identity proved from scratch, combined with a trichotomy sign lemma for the cross differences. All nine results are fully machine-checked with 0 sorries and depend only on the foundational axioms.",
+    "implications": "This supplies the weighted/measure-theoretic interface to Chebyshev's inequality directly over a finite index set: a user with a nonnegative weight (a finite measure, a probability vector) gets the correlation bound without re-deriving it, and the same identity yields the weighted variance bound. It answers the first open question of the unweighted companion (chebyshev-sum-inequality-oq-01) and is the natural stepping stone toward the continuous (integral) Chebyshev inequality, where the weight becomes a density.",
+    "openQuestions": [
+      "Establish the strict weighted inequality with its equality case: (∑ wf)(∑ wg) = W·∑ wfg iff f or g is constant on the support {i ∈ s : w i > 0}.",
+      "Extend the weighted bound to the continuous Chebyshev inequality ∫ f g dμ · μ(X) ≥ ∫ f dμ · ∫ g dμ for a finite measure μ and monotone f, g.",
+      "Derive the weighted power-mean / Cauchy–Schwarz chain (weighted Lᵖ monotonicity) from the weighted square bound."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Imports, an expository docstring contrasting Mathlib's unweighted #s form with the weighted statement, and namespace plus variable setup."
+    },
+    {
+      "id": "sign-lemmas",
+      "title": "Sign of the Cross Differences",
+      "startLine": 40,
+      "endLine": 75,
+      "summary": "sub_mul_sub_nonneg_of_monovaryOn and sub_mul_sub_nonpos_of_antivaryOn: by trichotomy on g, each cross difference (f i − f j)(g i − g j) is ≥ 0 under monovariance and ≤ 0 under antivariance."
+    },
+    {
+      "id": "identity",
+      "title": "The Weighted Monovariance Identity",
+      "startLine": 76,
+      "endLine": 115,
+      "summary": "two_mul_chebyshev_defect_eq: the symmetric double sum equals twice the Chebyshev defect, proved by expanding into four monomial double sums and collapsing each via Finset.sum_mul_sum. Holds for arbitrary real data."
+    },
+    {
+      "id": "weighted-inequalities",
+      "title": "Weighted Chebyshev Inequalities",
+      "startLine": 116,
+      "endLine": 151,
+      "summary": "weighted_sum_mul_sum_le and weighted_antivary_le_sum_mul_sum: the double sum is nonnegative (resp. nonpositive) termwise, so the identity yields the weighted bound and its reverse."
+    },
+    {
+      "id": "monotone-corollaries",
+      "title": "Monotone-Sequence Corollaries",
+      "startLine": 152,
+      "endLine": 172,
+      "summary": "weighted_chebyshev_monotoneOn and weighted_chebyshev_antitoneOn: the forms named in the open question, obtained by composing the monotone ⇒ monovary / antivary bridges."
+    },
+    {
+      "id": "cauchy-schwarz-recovery",
+      "title": "Weighted Cauchy–Schwarz and Unweighted Recovery",
+      "startLine": 173,
+      "endLine": 195,
+      "summary": "weighted_sq_sum_le: the self-monovarying weighted square bound (∑ wf)² ≤ W·∑ wf². unweighted_recovery: substituting w ≡ 1 collapses the bound to Mathlib's classical #s form."
+    },
+    {
+      "id": "worked-instance",
+      "title": "Worked Instance",
+      "startLine": 196,
+      "endLine": 211,
+      "summary": "A concrete weighted instance with weights 1,2,3 against the sequence 0,1,2, evaluating to 64 ≤ 84, obtained from weighted_sq_sum_le."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The unweighted monotone-sequence Chebyshev inequality whose first open question (weighted form) this answers"
+    },
+    {
+      "targetId": "rearrangement-inequality-oq-01",
+      "relationship": "related",
+      "description": "Equality case of the unweighted Chebyshev sum inequality via the discrete covariance identity (rigidity companion)"
+    }
+  ],
+  "references": [
+    {
+      "text": "Hardy, G. H., Littlewood, J. E., Pólya, G. (1952). Inequalities, 2nd ed., Cambridge University Press (Chebyshev's inequality and weighted means).",
+      "url": "https://archive.org/details/Inequalities_201705"
+    },
+    {
+      "text": "Chebyshev's sum inequality.",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality"
+    },
+    {
+      "text": "Mathlib4: Algebra.Order.Chebyshev and Algebra.Order.Monovary.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Chebyshev.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ChebyshevSumWeighted",
+    "lineCount": 211,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevSumWeightedOQ01OQ01.lean",
+    "theoremCount": 9,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}

--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "sum-of-kth-powers-oq-05-oq-01",
+  "title": "Power Sums mod p: the Natural-Number Congruence ∑_{i<p} iᵏ ≡ −1 iff (p−1)∣k",
+  "slug": "sum-of-kth-powers-oq-05-oq-01",
+  "description": "Carries the parent's ZMod p power-sum dichotomy down to an honest natural-number congruence: ∑_{i=0}^{p-1} iᵏ ≡ (if k ≠ 0 and (p−1)∣k then p−1 else 0) (mod p). The bridge is a reindexing of the complete field sum by the residues 0,1,…,p−1 (a bijection range p ≃ ZMod p via Nat.cast / ZMod.val) composed with the Nat.cast/ModEq correspondence (↑a = ↑b in ZMod p) ↔ a ≡ b [MOD p]; the field's −1 becomes the residue p−1. Yields the exact divisibility criterion p ∣ ∑_{i<p} iᵏ ⟺ ¬(k ≠ 0 ∧ (p−1)∣k), the odd-prime residue sum 0+1+⋯+(p−1) ≡ 0 (mod p), and an integer form ∑_{i<p} (i:ℤ)ᵏ ≡ −1 (mod p) recovering FiniteField.sum_pow_units' −1 directly. This is the elementary form of the dichotomy actually used to prove power-sum divisibilities. Verified, 0 axioms.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fermat%27s_little_theorem",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "power-sums",
+      "modular-arithmetic",
+      "zmod",
+      "congruences",
+      "fermat-little-theorem",
+      "divisibility",
+      "finite-fields",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfKthPowersOQ05OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.natCast_eq_natCast_iff",
+        "description": "(↑a = ↑b in ZMod c) ↔ a ≡ b [MOD c] — the cast/ModEq correspondence that turns the ZMod p equation into a natural-number congruence",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Finset.sum_bij'",
+        "description": "reindexes the complete field sum ∑_{x : ZMod p} by the residues range p via the bijection x ↦ ZMod.val x with inverse Nat.cast",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "ZMod.val_natCast_of_lt / ZMod.natCast_zmod_val / ZMod.val_lt",
+        "description": "the two inverse identities making range p ≃ ZMod p a bijection: ((↑i).val = i for i < p) and (↑(x.val) = x), with val landing in range p",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Int.natCast_modEq_iff",
+        "description": "(↑a ≡ ↑b [ZMOD n]) ↔ a ≡ b [MOD n] — lifts the natural-number congruence to the integer form ∑ (i:ℤ)ᵏ ≡ −1",
+        "module": "Mathlib.Data.Int.ModEq"
+      },
+      {
+        "theorem": "Nat.modEq_zero_iff_dvd",
+        "description": "a ≡ 0 [MOD n] ↔ n ∣ a — converts the congruence into the divisibility criterion for p ∣ ∑_{i<p} iᵏ",
+        "module": "Mathlib.Data.Nat.ModEq"
+      }
+    ],
+    "originalContributions": [
+      "sum_range_pow_cast: the reindexing bridge ((∑_{i<p} iᵏ : ℕ) : ZMod p) = ∑_{x : ZMod p} xᵏ, identifying the residues range p with ZMod p via Finset.sum_bij' (ZMod.val ↔ Nat.cast)",
+      "sum_range_pow_modEq: the headline ℕ congruence ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p), the natural-number face of the parent's ZMod p dichotomy",
+      "sum_range_pow_modEq_neg_one: the −1 face, ∑_{i<p} iᵏ ≡ p−1 (mod p) when k ≠ 0 and (p−1)∣k",
+      "dvd_sum_range_pow_iff: the exact divisibility criterion p ∣ ∑_{i<p} iᵏ ⟺ ¬(k ≠ 0 ∧ (p−1)∣k)",
+      "sum_range_self_modEq_zero: 0+1+⋯+(p−1) ≡ 0 (mod p) for every odd prime (the k=1 instance)",
+      "sum_range_pow_intModEq_neg_one: the integer form ∑_{i<p} (i:ℤ)ᵏ ≡ −1 (mod p), recovering the −1 of FiniteField.sum_pow_units without rewriting it as p−1",
+      "Concrete decide-checked instances over ZMod 5 and ZMod 7 (0-axiom, no native_decide)"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 141,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only propext, Classical.choice, Quot.sound — the standard foundational axioms — appear in #print axioms). Concrete instances use kernel decide (not native_decide), so no Lean.ofReduceBool dependency. Builds on the parent entry SumOfKthPowersOQ05.sum_pow_zmod.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The mod-p evaluation of power sums is the arithmetic heart of Fermat's little theorem and the von Staudt–Clausen theorem. The parent entry (sum-of-kth-powers-oq-05) proved the dichotomy in the ring ZMod p: ∑_{x∈ZMod p} xᵏ = −1 when k ≠ 0 and (p−1)∣k, else 0. But the version a number theorist actually writes — and the version used to prove statements like 'p divides the sum of the k-th powers of the first p integers' — is a congruence between honest natural numbers: ∑_{i=0}^{p-1} iᵏ ≡ … (mod p). Translating between a ring equation in ZMod p and a ℕ/ℤ congruence is routine but not free: it requires reindexing the sum over the abstract field by the concrete residues 0,1,…,p−1 and invoking the Nat.cast/ModEq dictionary. This entry performs exactly that descent, and reads off the divisibility criterion, the classical residue-sum identity, and an integer form.",
+    "problemStatement": "**Open Question (sum-of-kth-powers-oq-05, follow-up #1)**: Derive the Nat-congruence corollary ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p) by casting the parent's ZMod p dichotomy back to ℕ via Nat.ModEq.\n\n**Result**: sum_range_pow_modEq — the natural-number congruence — together with the −1 face, the divisibility criterion dvd_sum_range_pow_iff, the odd-prime residue sum, and the integer form.",
+    "text": "For a prime p, the sum of the k-th powers of the residues 0,1,…,p−1 is congruent to p−1 (equivalently −1) modulo p exactly when k ≠ 0 and (p−1) divides k, and to 0 in every other case. Hence p divides ∑_{i<p} iᵏ precisely when that condition fails.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sum_range_pow_cast` is the bridge: after `push_cast` the goal is ∑_{i<p} (↑i)ᵏ = ∑_{x : ZMod p} xᵏ, proved by `Finset.sum_bij'` with the forward map x ↦ ZMod.val x (landing in range p by `ZMod.val_lt`) and inverse i ↦ (i : ZMod p); the two round-trip identities are `ZMod.natCast_zmod_val` and `ZMod.val_natCast_of_lt`.\n2. `sum_range_pow_modEq` rewrites the target congruence through `ZMod.natCast_eq_natCast_iff` (cast both sides to ZMod p), applies the bridge and the parent's `SumOfKthPowersOQ05.sum_pow_zmod`, then `split_ifs`: in the divisible case the residue p−1 casts to −1 via `Nat.cast_sub` and `ZMod.natCast_self`.\n3. `sum_range_pow_modEq_neg_one` is the `if_pos` specialization; `dvd_sum_range_pow_iff` turns the congruence into divisibility via `Nat.modEq_zero_iff_dvd`, using that p ∤ (p−1) to rule out the divisible case.\n4. `sum_range_self_modEq_zero` instantiates k = 1 (since (p−1)∤1 once p > 2).\n5. `sum_range_pow_intModEq_neg_one` lifts the ℕ statement to ℤ with `Int.natCast_modEq_iff` and identifies ↑(p−1) with −1 via `Int.modEq_iff_dvd`.",
+    "keyInsights": [
+      "**Ring equation → arithmetic congruence.** The parent lives in the ring ZMod p; this entry produces the ℕ statement ∑_{i<p} iᵏ ≡ … (mod p) used in elementary number theory. The translation is exactly the Nat.cast/ModEq correspondence `(↑a = ↑b) ↔ a ≡ b [MOD p]`.",
+      "**Residues are a bijective reindex of the field.** Summing over the abstract type ZMod p equals summing over the concrete residues range p; the bijection is Nat.cast with inverse ZMod.val, packaged by Finset.sum_bij'. This is the only non-formal ingredient.",
+      "**−1 becomes p−1.** In ℕ the field value −1 is the residue p−1; the cast `((p−1 : ℕ) : ZMod p) = −1` (via Nat.cast_sub and ZMod.natCast_self) is what makes the dichotomy land on a genuine natural number.",
+      "**A clean divisibility test.** p ∣ ∑_{i<p} iᵏ holds iff it is NOT the case that k ≠ 0 and (p−1)∣k — i.e. the low power sums (and the empty-exponent case) all vanish mod p, while the (p−1)∣k sums are ≡ −1."
+    ],
+    "prerequisites": [
+      "The parent dichotomy SumOfKthPowersOQ05.sum_pow_zmod over ZMod p",
+      "The Nat.cast/ModEq correspondence ZMod.natCast_eq_natCast_iff and Int.natCast_modEq_iff",
+      "Finset reindexing via sum_bij' and the ZMod.val ↔ Nat.cast bijection on range p"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "Module docstring framing the descent from the ZMod p dichotomy to a natural-number congruence, the Mathlib and parent imports, and the namespace.",
+      "mathContext": "$\\sum_{i=0}^{p-1} i^k \\pmod p$ from $\\sum_{x \\in \\mathbb{Z}/p} x^k$."
+    },
+    {
+      "id": "bridge",
+      "title": "Reindexing Bridge",
+      "startLine": 41,
+      "endLine": 54,
+      "summary": "sum_range_pow_cast: the cast of the ℕ power sum over range p equals the complete field sum over ZMod p, via Finset.sum_bij' with the ZMod.val ↔ Nat.cast bijection.",
+      "mathContext": "$\\left(\\textstyle\\sum_{i<p} i^k : \\mathbb{Z}/p\\right) = \\sum_{x : \\mathbb{Z}/p} x^k$"
+    },
+    {
+      "id": "main",
+      "title": "The Natural-Number Congruence",
+      "startLine": 56,
+      "endLine": 75,
+      "summary": "sum_range_pow_modEq (the headline ℕ dichotomy via natCast_eq_natCast_iff + the parent sum_pow_zmod) and sum_range_pow_modEq_neg_one (the −1 / p−1 face).",
+      "mathContext": "$\\sum_{i<p} i^k \\equiv \\begin{cases} p-1 & k \\neq 0,\\ (p-1)\\mid k \\\\ 0 & \\text{else}\\end{cases} \\pmod p$"
+    },
+    {
+      "id": "consequences",
+      "title": "Divisibility, Residue Sum, and Integer Form",
+      "startLine": 77,
+      "endLine": 122,
+      "summary": "dvd_sum_range_pow_iff (p ∣ ∑ ⟺ ¬(k≠0 ∧ (p−1)∣k)), sum_range_self_modEq_zero (residues sum to 0 for odd primes), and sum_range_pow_intModEq_neg_one (the integer −1 form).",
+      "mathContext": "$p \\mid \\sum_{i<p} i^k \\iff \\neg(k \\neq 0 \\wedge (p-1)\\mid k)$; $\\sum_{i<p} i \\equiv 0 \\pmod p$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances",
+      "startLine": 124,
+      "endLine": 141,
+      "summary": "decide-verified instances over ZMod 5 and ZMod 7, including both the congruence form and the divisibility criterion (0-axiom, no native_decide).",
+      "mathContext": "$\\sum_{i<5} i^4 \\equiv 4 \\pmod 5$; $5 \\mid \\sum_{i<5} i^2$; $5 \\nmid \\sum_{i<5} i^4$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-kth-powers-oq-05",
+      "relationship": "extends",
+      "description": "Parent entry: proves the ZMod p dichotomy ∑_{x∈ZMod p} xᵏ = −1 iff (p−1)∣k. This follow-up casts that ring equation down to the natural-number congruence ∑_{i<p} iᵏ ≡ … (mod p), exactly the parent's first listed open question."
+    },
+    {
+      "targetId": "sum-of-kth-powers-oq-04",
+      "relationship": "related",
+      "description": "OQ-04 gives Euler–Maclaurin asymptotics for integer power sums; this entry develops the orthogonal modular face as an explicit ℕ/ℤ congruence and divisibility criterion."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) descent of the parent's ZMod p power-sum dichotomy to a natural-number congruence: ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p), with the −1 face, the exact divisibility criterion, the odd-prime residue sum, and an integer form.",
+    "implications": "Provides the elementary, computation-ready form of the mod-p power-sum dichotomy — a congruence between natural numbers rather than an equation in the ring ZMod p — which is the version used to establish power-sum divisibilities and Bernoulli-number p-integrality.",
+    "openQuestions": [
+      "Use sum_range_pow_modEq to formalize the von Staudt–Clausen congruence on the p-integral part of Bernoulli numbers B_k for (p−1)∣k.",
+      "Generalize the reindexing bridge to ∑_{i<n} iᵏ (mod n) for composite n, where the units no longer fill all nonzero residues and the dichotomy is replaced by a CRT/totient-indexed sum."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SumOfKthPowersOQ05"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SumOfKthPowersOQ05OQ01",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfKthPowersOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Ireland, Kenneth and Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer Graduate Texts in Mathematics 84, 2nd ed.",
+      "note": "Chapter 4: sums of powers of residues mod p and their role in Bernoulli number congruences"
+    },
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Power sums and congruences modulo a prime; Fermat's little theorem"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first listed open question** of the parent entry `sum-of-kth-powers-oq-05`: cast the ZMod p power-sum dichotomy down to an honest natural-number congruence.

The parent proves `∑_{x∈ZMod p} xᵏ = −1 iff (p−1)∣k` as an equation in the **ring** `ZMod p`. This entry produces the form a number theorist actually writes and uses to prove power-sum divisibilities — a congruence between **natural numbers**:

```
∑_{i=0}^{p-1} iᵏ ≡ (if k ≠ 0 ∧ (p−1)∣k then p−1 else 0)  (mod p)
```

## Contributions (6 theorems, 0 defs, 141 lines)

- `sum_range_pow_cast` — the reindexing bridge `((∑_{i<p} iᵏ : ℕ) : ZMod p) = ∑_{x:ZMod p} xᵏ`, identifying the residues `range p` with `ZMod p` via `Finset.sum_bij'` (`ZMod.val` ↔ `Nat.cast`).
- `sum_range_pow_modEq` — the headline ℕ congruence (via `ZMod.natCast_eq_natCast_iff` + the parent's `sum_pow_zmod`).
- `sum_range_pow_modEq_neg_one` — the `−1` / `p−1` face for `k ≠ 0`, `(p−1)∣k`.
- `dvd_sum_range_pow_iff` — the exact criterion `p ∣ ∑_{i<p} iᵏ ⟺ ¬(k ≠ 0 ∧ (p−1)∣k)`.
- `sum_range_self_modEq_zero` — `0+1+⋯+(p−1) ≡ 0 (mod p)` for every odd prime (k=1).
- `sum_range_pow_intModEq_neg_one` — the integer form `∑_{i<p} (i:ℤ)ᵏ ≡ −1 (mod p)`, recovering `FiniteField.sum_pow_units`' `−1` directly.
- Concrete `decide`-checked instances over ZMod 5 / ZMod 7.

## Verification

- Builds against Mathlib (lean 4.26.0) via direct `lean` compile (Docker daemon down).
- `#print axioms` on all 6 theorems: only `propext`, `Classical.choice`, `Quot.sound` — **0 axioms** by policy. No `sorryAx`, no `Lean.ofReduceBool`.
- Concrete instances use **kernel `decide`** (not `native_decide`).

Builds on the parent `Proofs.SumOfKthPowersOQ05` (reuses its verified ZMod p dichotomy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)