### PR TITLE
research(geometric-series-oq-09-oq-01): q-fold geometric splitting ∑ r^(qn+a)=r^a/(1−r^q) over any complete normed field [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2792,6 +2792,7 @@ import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01
 import Proofs.GeometricSeriesOQ09
+import Proofs.GeometricSeriesOQ09OQ01
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01

--- a/proofs/Proofs/GeometricSeriesOQ09OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ09OQ01.lean
@@ -1,0 +1,154 @@
+import Mathlib.Analysis.SpecificLimits.Normed
+import Mathlib.Tactic
+
+/-
+# q-Fold Residue-Class Splitting of the Geometric Series
+
+## What This Proves
+
+Fix an integer modulus `q ≥ 1` and a residue `a`.  For a ratio `r` in any
+complete normed field with `‖r‖ < 1`, the arithmetic-progression subseries with
+common difference `q` is itself a geometric series of ratio `r^q`:
+
+  ∑_{n=0}^{∞} r^(q·n + a)  =  r^a / (1 − r^q).
+
+Summing these `q` subseries over the residues `a = 0, 1, …, q−1` recombines into
+the full geometric series:
+
+  ∑_{a=0}^{q-1} ∑_{n=0}^{∞} r^(q·n + a)  =  ∑_{m=0}^{∞} r^m  =  1/(1 − r).
+
+This is the `q`-fold generalisation of the even/odd (`q = 2`) splitting recorded
+in `GeometricSeriesOQ09`, which is recovered here as the special case `q = 2`,
+`a ∈ {0, 1}`.
+
+## Why This Is Not Already in Mathlib
+
+Mathlib provides the plain geometric series `tsum_geometric_of_norm_lt_one`
+(`∑ rⁿ = (1−r)⁻¹`) but not the residue-class subsums.  The content is the
+reindexing `r^(q·n + a) = r^a · (r^q)ⁿ`, together with the bound
+`‖r^q‖ = ‖r‖^q < 1` (valid because `q ≥ 1`) which makes Mathlib's lemma
+applicable at the new ratio `r^q`, plus the recombination identity, which rests
+on the factorisation `1 − r^q = (1 − r)(1 + r + ⋯ + r^{q-1})`.
+
+## Proof Strategy
+
+1. **Key bound.** `‖r^q‖ = ‖r‖^q < 1` from `q ≠ 0` (`pow_lt_one₀`).
+2. **Residue subseries.** Rewrite `r^(q·n + a) = r^a · (r^q)ⁿ` and apply
+   `hasSum_geometric_of_norm_lt_one` at ratio `r^q`, scaled by `HasSum.mul_left`.
+3. **Recombination.** Sum the `q` closed forms `r^a · (1−r^q)⁻¹` over
+   `a : Fin q`.  Factor out `(1−r^q)⁻¹`, evaluate `∑_{a<q} r^a` with
+   `geom_sum_eq`, and simplify using `1 − r^q = (1 − r)(∑_{a<q} r^a)`.
+
+## Status: 0 sorries, 0 axioms (over any complete normed field)
+-/
+
+namespace GeometricSeriesOQ09OQ01
+
+-- Several supporting lemmas are purely algebraic and do not use completeness;
+-- `CompleteSpace` is only needed where the geometric series is summed.
+set_option linter.unusedSectionVars false
+
+variable {𝕜 : Type*} [NormedField 𝕜] [CompleteSpace 𝕜] {r : 𝕜}
+
+/-! ## Nonvanishing denominators -/
+
+/-- `r ≠ 1` whenever `‖r‖ < 1`. -/
+lemma ne_one (hr : ‖r‖ < 1) : r ≠ 1 := fun h => by simp [h] at hr
+
+/-- `1 - r ≠ 0` whenever `‖r‖ < 1`. -/
+lemma one_sub_ne_zero (hr : ‖r‖ < 1) : (1 : 𝕜) - r ≠ 0 :=
+  sub_ne_zero.mpr (ne_one hr).symm
+
+/-- `‖r^q‖ < 1` whenever `‖r‖ < 1` and `q ≠ 0`: the key bound that lets us apply
+the geometric-series lemma at the new ratio `r^q`. -/
+lemma norm_pow_lt_one (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) : ‖r ^ q‖ < 1 := by
+  rw [norm_pow]
+  exact pow_lt_one₀ (norm_nonneg r) hr hq
+
+/-- `1 - r^q ≠ 0` whenever `‖r‖ < 1` and `q ≠ 0`. -/
+lemma one_sub_pow_ne_zero (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) :
+    (1 : 𝕜) - r ^ q ≠ 0 :=
+  sub_ne_zero.mpr fun h => by simpa [← h] using norm_pow_lt_one hr hq
+
+/-! ## Residue-class subseries -/
+
+/-- **Residue subseries, `HasSum` form**: for `q ≠ 0` and any residue `a`,
+`∑_{n} r^(q·n + a) = r^a / (1 − r^q)`. -/
+theorem hasSum_geometric_residue (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    HasSum (fun n : ℕ => r ^ (q * n + a)) (r ^ a * (1 - r ^ q)⁻¹) := by
+  have h := hasSum_geometric_of_norm_lt_one (norm_pow_lt_one hr hq)
+  have key : (fun n : ℕ => r ^ (q * n + a)) = (fun n : ℕ => r ^ a * (r ^ q) ^ n) := by
+    funext n; rw [pow_add, pow_mul]; ring
+  rw [key]
+  exact h.mul_left (r ^ a)
+
+/-- **Residue subseries, `tsum` form**: `∑_{n} r^(q·n + a) = r^a / (1 − r^q)`. -/
+theorem tsum_geometric_residue (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    ∑' n : ℕ, r ^ (q * n + a) = r ^ a * (1 - r ^ q)⁻¹ :=
+  (hasSum_geometric_residue hr hq a).tsum_eq
+
+/-- Each residue subseries is summable. -/
+theorem summable_geometric_residue (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Summable (fun n : ℕ => r ^ (q * n + a)) :=
+  (hasSum_geometric_residue hr hq a).summable
+
+/-! ## Recombination: the q subseries reassemble the full series -/
+
+/-- The algebraic heart of the recombination: `1 − r^q` factors as
+`(1 − r) · (∑_{a<q} r^a)`. -/
+lemma one_sub_pow_eq (r : 𝕜) (q : ℕ) :
+    (1 : 𝕜) - r ^ q = (1 - r) * ∑ a ∈ Finset.range q, r ^ a := by
+  rw [Finset.mul_sum]
+  induction q with
+  | zero => simp
+  | succ n ih =>
+    rw [Finset.sum_range_succ, ← ih, pow_succ]
+    ring
+
+/-- **Recombination, `tsum` form**: summing the `q` residue-class subseries over
+`a = 0, …, q−1` recovers the full geometric series
+`∑_{m} r^m = 1/(1 − r)`. -/
+theorem tsum_residues_eq_geometric (hr : ‖r‖ < 1) {q : ℕ} (hq : q ≠ 0) :
+    ∑ a ∈ Finset.range q, (∑' n : ℕ, r ^ (q * n + a)) = ∑' m : ℕ, r ^ m := by
+  have hfull : ∑' m : ℕ, r ^ m = (1 - r)⁻¹ := tsum_geometric_of_norm_lt_one hr
+  have hne : (1 : 𝕜) - r ≠ 0 := one_sub_ne_zero hr
+  have hqne : (1 : 𝕜) - r ^ q ≠ 0 := one_sub_pow_ne_zero hr hq
+  rw [hfull]
+  -- replace each subseries by its closed form and factor out (1 - r^q)⁻¹
+  simp_rw [tsum_geometric_residue hr hq]
+  rw [← Finset.sum_mul]
+  -- now: (∑_{a<q} r^a) * (1 - r^q)⁻¹ = (1 - r)⁻¹
+  have hsum : (1 - r) * ∑ a ∈ Finset.range q, r ^ a = 1 - r ^ q :=
+    (one_sub_pow_eq r q).symm
+  field_simp [hne, hqne]
+  linear_combination hsum
+
+/-! ## Connection to the even/odd (q = 2) case -/
+
+/-- Specialisation `q = 2, a = 0` recovers the even subseries
+`∑ r^(2n) = 1/(1 − r²)` of `GeometricSeriesOQ09`. -/
+theorem tsum_geometric_even (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ (2 * n) = (1 - r ^ 2)⁻¹ := by
+  have h := tsum_geometric_residue hr (q := 2) (by norm_num) 0
+  simpa using h
+
+/-- Specialisation `q = 2, a = 1` recovers the odd subseries
+`∑ r^(2n+1) = r/(1 − r²)` of `GeometricSeriesOQ09`. -/
+theorem tsum_geometric_odd (hr : ‖r‖ < 1) :
+    ∑' n : ℕ, r ^ (2 * n + 1) = r * (1 - r ^ 2)⁻¹ := by
+  have h := tsum_geometric_residue hr (q := 2) (by norm_num) 1
+  simpa using h
+
+/-! ## Concrete values -/
+
+/-- Sanity check at `r = 1/2`, `q = 3`, `a = 0`: `∑ (1/2)^(3n) = ∑ (1/8)ⁿ = 8/7`. -/
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ (3 * n + 0) = 8 / 7 := by
+  rw [tsum_geometric_residue (by norm_num : ‖(1 / 2 : ℝ)‖ < 1) (by norm_num) 0]
+  norm_num
+
+/-- Sanity check at `r = 1/2`, `q = 3`, `a = 2`: `∑ (1/2)^(3n+2) = 2/7`. -/
+example : ∑' n : ℕ, (1 / 2 : ℝ) ^ (3 * n + 2) = 2 / 7 := by
+  rw [tsum_geometric_residue (by norm_num : ‖(1 / 2 : ℝ)‖ < 1) (by norm_num) 2]
+  norm_num
+
+end GeometricSeriesOQ09OQ01

--- a/src/data/proofs/geometric-series-oq-09-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01/meta.json
@@ -1,0 +1,114 @@
+{
+  "id": "geometric-series-oq-09-oq-01",
+  "slug": "geometric-series-oq-09-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecificLimits.Normed",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "GeometricSeriesOQ09OQ01",
+    "lineCount": 154,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ09OQ01.lean",
+    "sorries": 0
+  },
+  "title": "q-Fold Splitting of the Geometric Series: ∑ r^(qn+a) = r^a/(1−r^q)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ09OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "infinite-series",
+      "power-series",
+      "summability",
+      "normed-field",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 154,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_geometric_residue / tsum_geometric_residue: the closed form ∑_{n≥0} r^(qn+a) = r^a/(1−r^q) for any modulus q ≠ 0, residue a, and ratio r with ‖r‖ < 1 in an arbitrary complete normed field. This is the q-fold generalisation of the parent's even/odd (q=2) splitting: the subseries indexed by the arithmetic progression a, a+q, a+2q, … is itself geometric of ratio r^q, scaled by the offset factor r^a. Mathlib records only the plain geometric series ∑ rⁿ = 1/(1−r), not its arithmetic-progression subsums",
+      "tsum_residues_eq_geometric: the recombination ∑_{a<q} (∑_{n≥0} r^(qn+a)) = ∑ rⁿ = 1/(1−r), expressing that the q residue classes a = 0,…,q−1 partition ℕ and reassemble the full geometric series. The proof rests on the factorisation 1 − r^q = (1−r)·∑_{a<q} r^a (one_sub_pow_eq), so the q closed forms r^a/(1−r^q) sum to (∑_{a<q} r^a)/(1−r^q) = 1/(1−r)",
+      "one_sub_pow_eq: the algebraic identity 1 − r^q = (1−r)·∑_{a<q} r^a over any commutative normed field, the finite-geometric-sum factorisation underlying the recombination, proved by induction on q",
+      "norm_pow_lt_one and one_sub_pow_ne_zero: the bound ‖r^q‖ = ‖r‖^q < 1 (q ≠ 0) that makes Mathlib's geometric-series lemma applicable at the new ratio r^q, together with the nonvanishing denominators 1−r ≠ 0 and 1−r^q ≠ 0",
+      "Generality beyond the parent: where geometric-series-oq-09 works over ℝ, this entry holds over any NormedField with CompleteSpace (ℝ, ℂ, ℚ_p, …); the parent even/odd forms tsum_geometric_even and tsum_geometric_odd are recovered as the q=2, a∈{0,1} specialisations, plus concrete checks ∑ (1/2)^(3n) = 8/7 and ∑ (1/2)^(3n+2) = 2/7"
+    ],
+    "prerequisites": [
+      "Mathlib's geometric series hasSum_geometric_of_norm_lt_one (∑ ξⁿ = (1−ξ)⁻¹ for ‖ξ‖ < 1 over a complete normed field), applied at the new ratio ξ = r^q",
+      "pow_add and pow_mul: r^(qn+a) = r^a·(r^q)ⁿ, the reindexing that exhibits the arithmetic-progression subseries as a geometric series of ratio r^q",
+      "norm_pow and pow_lt_one₀: ‖r^q‖ = ‖r‖^q < 1 from ‖r‖ < 1 and q ≠ 0",
+      "HasSum arithmetic (HasSum.mul_left, HasSum.tsum_eq, HasSum.summable)",
+      "Finset.sum_mul, Finset.sum_range_succ, field_simp, linear_combination for the recombination over a complete residue system",
+      "Parent: geometric-series-oq-09 (even/odd q=2 splitting), geometric-series (∑ rⁿ = 1/(1−r))"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "∑_n ξⁿ = (1−ξ)⁻¹ for ‖ξ‖ < 1 over a complete normed field. Applied at ξ = r^q to sum each arithmetic-progression subseries, then scaled by r^a via HasSum.mul_left.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "pow_lt_one₀",
+        "description": "0 ≤ a → a < 1 → a^n < 1 (n ≠ 0). Combined with norm_pow to give ‖r^q‖ = ‖r‖^q < 1, the hypothesis Mathlib's geometric lemma needs at the new ratio r^q.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "geom_sum_eq",
+        "description": "Closed form for finite geometric sums; the factorisation 1 − r^q = (1−r)·∑_{a<q} r^a (re-derived here as one_sub_pow_eq) is the discrete identity underneath the recombination of the q residue-class subseries.",
+        "module": "Mathlib.Algebra.GeomSum"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-09-oq-01-oq-01",
+      "question": "Promote the offset a to range over a complete residue system modulo q via Finset, and prove a weighted q-fold splitting ∑_{n≥0} c_{n mod q} r^n = (∑_{a<q} c_a r^a)/(1−r^q) for any q-periodic coefficient sequence c, recovering this entry at c ≡ 1 and exhibiting the rational generating function of an eventually-periodic sequence.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-09",
+      "relationship": "extends",
+      "description": "Parent. The parent splits the geometric series over its even/odd index subsequences (q=2). This entry generalises to an arbitrary modulus q: each residue class {qn+a : n ∈ ℕ} carries a geometric series of ratio r^q, giving ∑ r^(qn+a) = r^a/(1−r^q), and the q classes recombine to ∑ rⁿ = 1/(1−r). The parent's even (q=2,a=0) and odd (q=2,a=1) forms are recovered as specialisations, and the result is lifted from ℝ to any complete normed field."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "extends",
+      "description": "The base entry proves ∑ rⁿ = 1/(1−r). The recombination theorem here shows the q arithmetic-progression subseries partition that sum."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecificLimits.Normed",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of hasSum_geometric_of_norm_lt_one, the geometric series lemma applied at the new ratio r^q."
+    },
+    {
+      "title": "Concrete Mathematics (geometric series; bisection and m-section of power series)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the m-section of a power series into arithmetic-progression index classes, of which the q-fold geometric subsums are the simplest instance."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For ‖r‖ < 1 over any complete normed field and any modulus q ≠ 0, the geometric series splits over residue classes modulo q into q geometric series of ratio r^q: ∑_{n≥0} r^(qn+a) = r^a/(1−r^q) for each residue a (hasSum_geometric_residue / tsum_geometric_residue / summable_geometric_residue). The proof is the reindexing r^(qn+a) = r^a·(r^q)ⁿ together with the bound ‖r^q‖ = ‖r‖^q < 1 that lets Mathlib's hasSum_geometric_of_norm_lt_one apply at ratio r^q, scaled by r^a via HasSum.mul_left. The q subseries recombine into the full series: ∑_{a<q} (∑ r^(qn+a)) = ∑ rⁿ = 1/(1−r) (tsum_residues_eq_geometric), via the factorisation 1 − r^q = (1−r)·∑_{a<q} r^a (one_sub_pow_eq, by induction) closed with field_simp; linear_combination. The parent even (q=2,a=0) and odd (q=2,a=1) forms are recovered as specialisations, with concrete checks ∑ (1/2)^(3n) = 8/7 and ∑ (1/2)^(3n+2) = 2/7. 154 lines, 11 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This answers the parent's open question geometric-series-oq-09-oq-01 in full and beyond its ℝ framing: the q-fold splitting holds over any complete normed field. It records a reusable template — a subseries along an arithmetic progression of indices is again geometric, of ratio r^q, so summing it reduces to Mathlib's lemma at a new ratio plus the bound ‖r^q‖ < 1 — and exhibits the recombination as the analytic shadow of the finite identity 1 − r^q = (1−r)(1 + r + ⋯ + r^{q−1}). The natural next step is weighted/periodic coefficients, giving rational generating functions of eventually-periodic sequences.",
+    "openQuestions": [
+      "Prove a weighted q-fold splitting ∑ c_{n mod q} rⁿ = (∑_{a<q} c_a r^a)/(1−r^q) for a q-periodic coefficient sequence c."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question **geometric-series-oq-09-oq-01** in full and beyond its ℝ framing.

For `‖r‖ < 1` over **any complete normed field** and any modulus `q ≠ 0`, the geometric series splits over residue classes mod `q` into `q` geometric series of ratio `r^q`:

  ∑_{n≥0} r^(qn+a) = r^a / (1 − r^q)   (for each residue `a`)

and the `q` classes recombine into the full series:

  ∑_{a<q} ( ∑_{n} r^(qn+a) ) = ∑ rⁿ = 1/(1 − r).

This generalises the parent even/odd (`q=2`) splitting (`geometric-series-oq-09`) from ℝ to any `NormedField` + `CompleteSpace` (ℝ, ℂ, ℚ_p, …); the parent's even (`q=2,a=0`) and odd (`q=2,a=1`) forms are recovered as specialisations.

## Mathematical content
- **Reindexing:** `r^(qn+a) = r^a·(r^q)ⁿ`, exhibiting each arithmetic-progression subseries as geometric of ratio `r^q`.
- **New-ratio bound:** `‖r^q‖ = ‖r‖^q < 1` (for `q ≠ 0`) makes Mathlib's `hasSum_geometric_of_norm_lt_one` apply at `r^q`; scaled by `r^a` via `HasSum.mul_left`.
- **Recombination:** rests on the factorisation `1 − r^q = (1−r)·∑_{a<q} r^a` (`one_sub_pow_eq`, by induction), closed with `field_simp; linear_combination`.

Mathlib records only the plain geometric series `∑ rⁿ = 1/(1−r)`, not its arithmetic-progression subsums.

## Verification
- 154 lines, **11 theorems/lemmas, 0 definitions, 0 axioms, 0 sorries**.
- Typechecked under the project toolchain (Lean v4.26.0).
- `#print axioms` on the key results lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`.

## Files
- `proofs/Proofs/GeometricSeriesOQ09OQ01.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/geometric-series-oq-09-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)