### PR TITLE
Enrich Fixed-Target Dirichlet Selection and a Sharp Obstruction at n = 3

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/index.ts
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ07OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeFourSquaresWaringG2Oq03Oq07Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeFourSquaresWaringG2Oq03Oq07Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeFourSquaresWaringG2Oq03Oq07Oq01Data: ProofData = {
+  proof: lagrangeFourSquaresWaringG2Oq03Oq07Oq01Proof,
+  annotations: lagrangeFourSquaresWaringG2Oq03Oq07Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `lagrange-four-squares-waring-g2-oq-03-oq-07-oq-01`.

This entry had rich `meta`/`conclusion`/`openQuestions` but was missing the `index.ts` (so the proof page would show "proof not found" on the live site), an `annotations.json`, a top-level `description`, the `overview` block, and `sections`; its `crossReferences` were bare slug strings.

## Changes
- **index.ts** (REQUIRED): created so the proof loads on the site.
- **annotations.json**: 10 annotations covering every theorem/lemma (periodicity in the prime, residue-class transport, the unconditional supply and its assembled/non-vacuous forms, and the n = 3 obstruction chain). Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **overview**: `historicalContext` (Legendre 1798, Gauss 1801, Dirichlet 1837, genus theory), `problemStatement`, `proofStrategy`, and 6 `keyInsights`.
- **sections**: 4 sections (background, §1 periodicity, §2 supply, §3 obstruction) covering the full 244-line Lean file.
- **description**: top-level summary added.
- **crossReferences**: converted from bare slug strings to objects with `relationship` + `description` (depends-on parent `oq-03-oq-07`, related `oq-03`).

## Verification
- `pnpm build` succeeds (`tsc -b` clean, `vite build` OK; proof appears in generated `listings.json` and `public/data/proofs/`).
- Axiom integrity preserved: `status: verified`, `badge: original`, `axiomCount: 0`, no sorries; the Lean file has no axiom/sorry/native_decide (the n = 3 obstruction is kept 0-axiom via the reciprocity-based norm_num Jacobi evaluator) and no assumption-carrying structures — consistent with the metadata.