### PR TITLE
research(cayleys-theorem-oq-01-oq-01): finite Cayley — a group of order n embeds in Sₙ (verified, 0-axiom)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -617,6 +617,7 @@ import Proofs.CayleyHamiltonReductionOQ02OQ01
 import Proofs.CayleyHamiltonReductionOQ02OQ01Aristotle
 import Proofs.CayleyMengerHeronOQ05
 import Proofs.CayleysTheoremOQ01
+import Proofs.CayleysTheoremOQ01OQ01
 import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01

--- a/proofs/Proofs/CayleysTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ01.lean
@@ -1,0 +1,107 @@
+/-
+Proof: Finite Cayley's theorem — a group of order n embeds in Sₙ
+Research: cayleys-theorem-oq-01-oq-01
+
+Open question (from `cayleys-theorem-oq-01`): refine the abstract embedding
+`G ↪ Sym(G)` into the classical *finite* form `G ↪ Sₙ` for a group `G` of
+order `n`, by transporting the left-regular representation along a bijection
+`G ≃ Fin n`.
+
+Method: conjugate the regular representation `MulAction.toPermHom G G : G →*
+Equiv.Perm G` by a relabelling `e : G ≃ Fin n`.  Conjugation by a fixed
+bijection is a multiplicative isomorphism `Equiv.Perm G ≃* Equiv.Perm (Fin n)`,
+so the composite is again an injective group homomorphism — now landing in the
+concrete symmetric group `Sₙ = Equiv.Perm (Fin n)`.
+-/
+
+import Mathlib.GroupTheory.Perm.Basic
+import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.GroupTheory.GroupAction.Defs
+import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Tactic
+
+/-
+# Finite Cayley's theorem: `G` of order `n` embeds in `Sₙ`
+
+The parent entry proves the abstract Cayley theorem: the left-regular
+representation `λ : G →* Equiv.Perm G`, `λ(g) = (x ↦ g * x)`, is an injective
+group homomorphism, so every group embeds into the symmetric group on its own
+underlying set.
+
+For a *finite* group of order `n`, the classical statement instead realises `G`
+inside the standard symmetric group `Sₙ = Equiv.Perm (Fin n)`.  The two differ
+only by a relabelling of the points being permuted: any bijection
+`e : G ≃ Fin n` induces, by conjugation `σ ↦ e ∘ σ ∘ e⁻¹`, a multiplicative
+isomorphism `Equiv.Perm G ≃* Equiv.Perm (Fin n)`.  Composing the regular
+representation with this relabelling gives the finite Cayley embedding.
+-/
+
+namespace CayleyFin
+
+open Equiv
+
+variable {G : Type*} [Group G]
+
+/-- Conjugation by a fixed bijection `e : α ≃ β`, packaged as a multiplicative
+isomorphism `Equiv.Perm α ≃* Equiv.Perm β`.  On elements it is
+`σ ↦ e ∘ σ ∘ e⁻¹`, the relabelling of permutations along `e`. -/
+def permCongrMulEquiv {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+  toEquiv := Equiv.permCongr e
+  map_mul' x y := by
+    ext b
+    simp [Equiv.permCongr_apply, Equiv.Perm.mul_apply]
+
+@[simp] theorem permCongrMulEquiv_apply {α β : Type*} (e : α ≃ β) (σ : Equiv.Perm α)
+    (a : β) : permCongrMulEquiv e σ a = e (σ (e.symm a)) := rfl
+
+/-- The finite Cayley homomorphism induced by a relabelling `e : G ≃ Fin n`:
+conjugate the left-regular representation of `G` into `Sₙ = Equiv.Perm (Fin n)`. -/
+def cayleyFinHom {n : ℕ} (e : G ≃ Fin n) : G →* Equiv.Perm (Fin n) :=
+  (permCongrMulEquiv e).toMonoidHom.comp (MulAction.toPermHom G G)
+
+theorem cayleyFinHom_apply {n : ℕ} (e : G ≃ Fin n) (g : G) (i : Fin n) :
+    cayleyFinHom e g i = e (g * e.symm i) := rfl
+
+/-- The finite Cayley homomorphism is injective: it is the composite of the
+(injective) regular representation with a (bijective) relabelling. -/
+theorem cayleyFinHom_injective {n : ℕ} (e : G ≃ Fin n) :
+    Function.Injective (cayleyFinHom e) := by
+  have hreg : Function.Injective (MulAction.toPermHom G G) :=
+    MulAction.toPerm_injective
+  have hcongr : Function.Injective (permCongrMulEquiv e) := (permCongrMulEquiv e).injective
+  intro a b hab
+  exact hreg (hcongr (by simpa [cayleyFinHom] using hab))
+
+/-- **Finite Cayley's theorem.** Every finite group `G` of order `n` admits an
+injective group homomorphism into the standard symmetric group
+`Sₙ = Equiv.Perm (Fin n)`. -/
+theorem cayley_fin (G : Type*) [Group G] [Fintype G] :
+    ∃ f : G →* Equiv.Perm (Fin (Fintype.card G)), Function.Injective f :=
+  ⟨cayleyFinHom (Fintype.equivFin G), cayleyFinHom_injective _⟩
+
+/-- The finite Cayley embedding packaged as a bundled embedding `G ↪ Sₙ`. -/
+noncomputable def cayleyFinEmbedding (G : Type*) [Group G] [Fintype G] :
+    G ↪ Equiv.Perm (Fin (Fintype.card G)) :=
+  ⟨cayleyFinHom (Fintype.equivFin G), cayleyFinHom_injective _⟩
+
+/-- `G` is isomorphic to its image inside `Sₙ`: the finite form of "every group
+is isomorphic to a subgroup of a symmetric group". -/
+noncomputable def cayleyFinRangeEquiv {n : ℕ} (e : G ≃ Fin n) :
+    G ≃* (cayleyFinHom e).range :=
+  MonoidHom.ofInjective (cayleyFinHom_injective e)
+
+/-- Sanity check: the embedding really lands in the symmetric group on `n`
+points, with `n` the order of the group. -/
+example (G : Type*) [Group G] [Fintype G] :
+    ∃ f : G →* Equiv.Perm (Fin (Fintype.card G)), Function.Injective f :=
+  cayley_fin G
+
+/-- Concrete instance: the cyclic group of order 3 (`Multiplicative (ZMod 3)`)
+embeds in `S₃ = Equiv.Perm (Fin 3)`. -/
+example : ∃ f : Multiplicative (ZMod 3) →*
+    Equiv.Perm (Fin (Fintype.card (Multiplicative (ZMod 3)))), Function.Injective f :=
+  cayley_fin (Multiplicative (ZMod 3))
+
+end CayleyFin

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-01",
+  "title": "Finite Cayley's Theorem: a Group of Order n Embeds in Sₙ",
+  "slug": "cayleys-theorem-oq-01-oq-01",
+  "description": "The classical finite form of Cayley's theorem: a finite group G of order n admits an injective group homomorphism into the standard symmetric group Sₙ = Equiv.Perm (Fin n), so G ↪ Sₙ and G is isomorphic to a subgroup of Sₙ. The parent (cayleys-theorem-oq-01) proves only the abstract form G ↪ Sym(G), permuting G's own underlying set; this entry refines the codomain to the concrete n-point symmetric group, answering the parent's first listed open question. The construction transports the left-regular representation MulAction.toPermHom G G : G →* Equiv.Perm G along a relabelling e : G ≃ Fin n. Conjugation by a fixed bijection σ ↦ e ∘ σ ∘ e⁻¹ is a multiplicative isomorphism permCongrMulEquiv e : Equiv.Perm G ≃* Equiv.Perm (Fin n) (built here from Equiv.permCongr), and the composite cayleyFinHom e := (permCongrMulEquiv e).toMonoidHom.comp (MulAction.toPermHom G G) is again an injective group homomorphism, now landing in Sₙ. Injectivity follows from the regular representation's injectivity (MulAction.toPerm_injective, faithful self-action of a group) composed with the bijectivity of the relabelling. Instantiated at e = Fintype.equivFin G gives cayley_fin (G of order n ↪ Sₙ), a bundled embedding G ↪ Equiv.Perm (Fin n), and the range isomorphism G ≃* (cayleyFinHom e).range via MonoidHom.ofInjective.",
+  "meta": {
+    "author": "Arthur Cayley (1854); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cayley%27s_theorem",
+    "date": "1854",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "permutation-group",
+      "symmetric-group",
+      "regular-representation",
+      "group-action",
+      "embedding",
+      "finite-group",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.toPermHom",
+        "description": "G →* Equiv.Perm G for a group acting on a set — instantiated at the regular self-action (g • x = g * x) to give the left-regular representation being transported",
+        "module": "Mathlib.Algebra.Group.Action.End"
+      },
+      {
+        "theorem": "MulAction.toPerm_injective",
+        "description": "the underlying map of a faithful action is injective — supplies injectivity of the regular representation, which the relabelling preserves",
+        "module": "Mathlib.Algebra.Group.Action.Basic"
+      },
+      {
+        "theorem": "Equiv.permCongr",
+        "description": "the relabelling Perm α ≃ Perm β induced by e : α ≃ β (σ ↦ e ∘ σ ∘ e⁻¹) — promoted here to the multiplicative isomorphism permCongrMulEquiv",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Fintype.equivFin",
+        "description": "the canonical bijection G ≃ Fin (Fintype.card G) for a finite type — provides the relabelling that lands the embedding in the standard Sₙ",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "MonoidHom.ofInjective",
+        "description": "an injective group hom f : G →* N yields an isomorphism G ≃* f.range — upgrades the finite Cayley embedding to the subgroup form G ≃* range ≤ Sₙ",
+        "module": "Mathlib.Algebra.Group.Subgroup.Ker"
+      }
+    ],
+    "originalContributions": [
+      "permCongrMulEquiv: conjugation by a bijection e : α ≃ β packaged as a MulEquiv (Equiv.Perm α ≃* Equiv.Perm β) — Mathlib's Equiv.permCongr is only an Equiv; the multiplicative-isomorphism bundling is supplied here (map_mul' from permCongr_apply)",
+      "cayleyFinHom: the finite Cayley homomorphism G →* Equiv.Perm (Fin n) obtained by conjugating the regular representation along e : G ≃ Fin n, with cayleyFinHom_apply : cayleyFinHom e g i = e (g * e.symm i)",
+      "cayleyFinHom_injective: injectivity of the finite Cayley embedding, from injectivity of the regular representation composed with the bijective relabelling",
+      "cayley_fin: ∃ injective f : G →* Equiv.Perm (Fin (Fintype.card G)) — the textbook finite Cayley statement that a group of order n embeds in Sₙ",
+      "cayleyFinEmbedding: the embedding bundled as G ↪ Equiv.Perm (Fin n)",
+      "cayleyFinRangeEquiv: G ≃* (cayleyFinHom e).range — G is isomorphic to a subgroup of the concrete symmetric group Sₙ"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 107,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem (Arthur Cayley, 1854) shows every abstract group is concrete — a group of permutations. For a finite group of order n the sharpest classical statement places G inside the standard symmetric group Sₙ on n labelled points, the form in which Cayley's theorem is usually quoted and used (e.g. to bound a finite group's structure by that of Sₙ, or to reason about it via permutations of {1,…,n}). The passage from the abstract Sym(G) to the concrete Sₙ is a relabelling: any numbering of the group's elements turns permutations of G into permutations of {1,…,n}.",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01, first follow-up)**: Refine the codomain of Cayley's embedding — when G is finite of order n, exhibit the injective homomorphism into the finite symmetric group Equiv.Perm (Fin n) (G ↪ Sₙ).\n\n**Result**: cayley_fin (∃ injective f : G →* Equiv.Perm (Fin (Fintype.card G))), the bundled embedding cayleyFinEmbedding : G ↪ Equiv.Perm (Fin n), and the subgroup form cayleyFinRangeEquiv : G ≃* (cayleyFinHom e).range, all built from the conjugation isomorphism permCongrMulEquiv.",
+    "text": "For a finite group G of order n, numbering the elements by a bijection e : G ≃ Fin n turns the left-regular representation g ↦ (x ↦ g·x) into an injective homomorphism G →* Equiv.Perm (Fin n). Hence G embeds in the standard symmetric group Sₙ and is isomorphic to a subgroup of it.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Relabel permutations. A bijection e : α ≃ β induces the conjugation map Equiv.permCongr e : Perm α ≃ Perm β, σ ↦ e ∘ σ ∘ e⁻¹. Conjugation by a fixed bijection respects composition, so this is a *multiplicative* isomorphism; permCongrMulEquiv e bundles it as Equiv.Perm α ≃* Equiv.Perm β (map_mul' discharged by permCongr_apply + Perm.mul_apply).\n2. Transport the regular representation. The left-regular representation is Mathlib's regular self-action homomorphism MulAction.toPermHom G G : G →* Equiv.Perm G (the parent entry). Composing with the relabelling gives cayleyFinHom e := (permCongrMulEquiv e).toMonoidHom.comp (MulAction.toPermHom G G) : G →* Equiv.Perm (Fin n), with cayleyFinHom e g i = e (g * e.symm i).\n3. Injectivity. cayleyFinHom e is a composite of an injective map (the regular representation, injective by MulAction.toPerm_injective via the faithful self-action of a group) with a bijection (the relabelling permCongrMulEquiv e), hence injective.\n4. Specialise and package. Taking e = Fintype.equivFin G : G ≃ Fin (Fintype.card G) yields cayley_fin and the bundled embedding cayleyFinEmbedding; MonoidHom.ofInjective upgrades injectivity to the isomorphism cayleyFinRangeEquiv : G ≃* (cayleyFinHom e).range, the 'subgroup of Sₙ' form.",
+    "keyInsights": [
+      "**The codomain refinement is a relabelling, not new content.** The mathematical heart — faithfulness of the regular representation — is the parent's; the finite form is obtained purely by conjugating along a numbering G ≃ Fin n, which is an isomorphism of symmetric groups and therefore preserves injectivity.",
+      "**Conjugation is multiplicative.** Equiv.permCongr e is stated in Mathlib only as an Equiv; recognising that σ ↦ e ∘ σ ∘ e⁻¹ is a group isomorphism (permCongrMulEquiv) is what lets the regular representation be composed with it as a homomorphism, keeping the result a G →* Equiv.Perm (Fin n).",
+      "**Fintype.equivFin supplies the numbering.** Any finite group has a canonical bijection to Fin n with n = Fintype.card G; instantiating the general relabelled embedding there gives the textbook 'order n ⟹ embeds in Sₙ'.",
+      "**Three packagings.** Existence of an injective hom, a bundled embedding G ↪ Sₙ, and the isomorphism onto a subgroup G ≃* range are equivalent faces; MonoidHom.ofInjective converts the first into the last."
+    ],
+    "prerequisites": [
+      "Cayley's theorem in abstract form (the left-regular representation MulAction.toPermHom, parent entry cayleys-theorem-oq-01)",
+      "Relabelling of permutations Equiv.permCongr and conjugation as a group isomorphism",
+      "The canonical numbering Fintype.equivFin of a finite type, and MonoidHom.ofInjective for the subgroup form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Module docstring stating the finite form G ↪ Sₙ and the conjugation-of-the-regular-representation strategy, imports for permutations / group actions / Fintype.equivFin, and the namespace with the group variable G.",
+      "mathContext": "$G \\hookrightarrow S_n$ for $|G| = n$, via a numbering $e : G \\simeq \\mathrm{Fin}\\,n$."
+    },
+    {
+      "id": "perm-congr",
+      "title": "Conjugation as a Multiplicative Isomorphism",
+      "startLine": 50,
+      "endLine": 59,
+      "summary": "permCongrMulEquiv e : Equiv.Perm α ≃* Equiv.Perm β bundles Equiv.permCongr e (σ ↦ e ∘ σ ∘ e⁻¹) as a MulEquiv, with map_mul' proved from permCongr_apply and Perm.mul_apply, plus the apply lemma permCongrMulEquiv_apply.",
+      "mathContext": "$\\sigma \\mapsto e \\circ \\sigma \\circ e^{-1}$ is a group isomorphism $\\mathrm{Sym}(\\alpha) \\cong \\mathrm{Sym}(\\beta)$."
+    },
+    {
+      "id": "fin-hom",
+      "title": "The Finite Cayley Homomorphism",
+      "startLine": 61,
+      "endLine": 78,
+      "summary": "cayleyFinHom e := (permCongrMulEquiv e).toMonoidHom.comp (MulAction.toPermHom G G) : G →* Equiv.Perm (Fin n), with cayleyFinHom_apply : cayleyFinHom e g i = e (g * e.symm i) and cayleyFinHom_injective from injectivity of the regular representation composed with the relabelling.",
+      "mathContext": "$\\hat\\lambda(g) = e \\circ \\lambda(g) \\circ e^{-1}$, injective."
+    },
+    {
+      "id": "finite-cayley",
+      "title": "Finite Cayley's Theorem and Packagings",
+      "startLine": 80,
+      "endLine": 107,
+      "summary": "cayley_fin : ∃ injective f : G →* Equiv.Perm (Fin (Fintype.card G)); cayleyFinEmbedding : G ↪ Equiv.Perm (Fin n); cayleyFinRangeEquiv : G ≃* (cayleyFinHom e).range via MonoidHom.ofInjective; plus sanity examples (the existence form and the cyclic group of order 3 embedding in S₃).",
+      "mathContext": "$G \\cong \\mathrm{im} \\le S_n$ for $n = |G|$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: proves the abstract Cayley theorem G ↪ Sym(G) on the group's own underlying set. This entry refines the codomain to the concrete finite symmetric group Sₙ = Equiv.Perm (Fin n), answering its first open question."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of the finite form of Cayley's theorem: a finite group G of order n embeds in the standard symmetric group Sₙ = Equiv.Perm (Fin n) (cayley_fin, cayleyFinEmbedding), and is isomorphic to a subgroup of it (cayleyFinRangeEquiv). The embedding is the left-regular representation conjugated along a numbering e : G ≃ Fin n, using the multiplicative isomorphism permCongrMulEquiv built here.",
+    "implications": "Realises every finite group concretely as a permutation group on n = |G| labelled points — the form of Cayley's theorem used to study finite groups inside Sₙ. It isolates the codomain refinement as a pure relabelling (conjugation by Fintype.equivFin), reusing the parent's faithfulness content unchanged.",
+    "openQuestions": [
+      "Sharpen n: a group of order n with a subgroup of index k embeds in S_k (the coset action), often far smaller than S_n; formalize the minimal-degree faithful permutation representation for specific families.",
+      "Show the image of cayleyFinHom is a regular (sharply transitive) subgroup of Sₙ — a subgroup of order n acting freely and transitively on the n points."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Perm.Basic",
+      "Mathlib.Algebra.Group.Action.Basic",
+      "Mathlib.Algebra.Group.Action.End",
+      "Mathlib.GroupTheory.GroupAction.Defs",
+      "Mathlib.Logic.Equiv.Fin.Basic",
+      "Mathlib.Data.Fintype.Perm",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "CayleyFin",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 4,
+    "path": "Proofs/CayleysTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement that every group can be represented as a group of permutations"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley (3rd ed.)",
+      "note": "Cayley's theorem and the embedding of a finite group of order n into Sₙ"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **cayleys-theorem-oq-01**: refine Cayley's embedding from the abstract form `G ↪ Sym(G)` to the **classical finite form** `G ↪ Sₙ` for a finite group of order `n`, landing in the standard symmetric group `Sₙ = Equiv.Perm (Fin n)`.

## Mathematical content

The construction transports the left-regular representation along a numbering `e : G ≃ Fin n`:

- **`permCongrMulEquiv e : Equiv.Perm α ≃* Equiv.Perm β`** — conjugation `σ ↦ e ∘ σ ∘ e⁻¹` by a fixed bijection, bundled as a *multiplicative* isomorphism (Mathlib's `Equiv.permCongr` is only an `Equiv`; the `map_mul'` bundling is supplied here).
- **`cayleyFinHom e := (permCongrMulEquiv e).toMonoidHom.comp (MulAction.toPermHom G G) : G →* Equiv.Perm (Fin n)`**, with `cayleyFinHom e g i = e (g * e.symm i)`.
- **`cayleyFinHom_injective`** — injective, as the composite of the (injective) regular representation with the (bijective) relabelling.
- **`cayley_fin`** — `∃ injective f : G →* Equiv.Perm (Fin (Fintype.card G))`, the textbook statement.
- **`cayleyFinEmbedding : G ↪ Equiv.Perm (Fin n)`** and **`cayleyFinRangeEquiv : G ≃* (cayleyFinHom e).range`** (via `MonoidHom.ofInjective`).

The codomain refinement is a pure relabelling (conjugation by `Fintype.equivFin G`); the faithfulness content is the parent's, reused unchanged.

## Verification

- **0 sorries, 0 axioms** (only `propext` / `Classical.choice` / `Quot.sound`; no `decide`/`native_decide`).
- Typechecks against Mathlib on Lean v4.26.0.
- 4 theorems / 4 definitions, 107 lines.

Gallery entry: `src/data/proofs/cayleys-theorem-oq-01-oq-01/meta.json` (status `verified`, badge `original`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)