### PR TITLE
research(beta-integral-recurrence-oq-01-oq-02): half-integer Beta values B(1/2,1/2)=π and B(3/2,3/2)=π/8 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -277,6 +277,7 @@ import Proofs.BertrandsPostulateOQ03OQ04
 import Proofs.BertrandsPostulateOQ03OQ04Aristotle
 import Proofs.BertrandsPostulateOQ03OQ04OQ01
 import Proofs.BertrandsPostulateOQ03OQ04OQ03
+import Proofs.BetaIntegralHalfValue
 import Proofs.BetaIntegralRecurrence
 import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01

--- a/proofs/Proofs/BetaIntegralHalfValue.lean
+++ b/proofs/Proofs/BetaIntegralHalfValue.lean
@@ -1,0 +1,99 @@
+import Mathlib.Analysis.SpecialFunctions.Gamma.Beta
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.Tactic
+
+/-
+# The Beta Function at Half-Integer Arguments: `B(1/2, 1/2) = π`
+
+## What This Proves
+
+The Euler Beta integral `B(u, v) = ∫₀¹ t^(u-1) (1-t)^(v-1) dt` has the famous
+half-integer special value
+
+  **`betaIntegral_half_half`**:  `B(1/2, 1/2) = π`.
+
+This is the area capstone to the parent entry's integer closed form
+`B(m+1, n+1) = m!·n!/(m+n+1)!`: while the integer lattice is governed entirely
+by factorials, the half-integer lattice brings in `π` through the Gauss value
+`Γ(1/2) = √π`. Geometrically, `B(1/2,1/2) = ∫₀¹ dt/√(t(1-t)) = π` is the length
+of the substitution `t = sin²θ` sweeping `[0, π/2]` twice.
+
+We also push one step up the Beta recurrence to the next half-integer value
+
+  **`betaIntegral_three_half_three_half`**:  `B(3/2, 3/2) = π/8`,
+
+obtained from `Γ(3/2) = ½·Γ(1/2)` (the functional equation `Γ(s+1) = s·Γ(s)`)
+and `Γ(3) = 2! = 2`.
+
+## Relation to Mathlib
+
+Mathlib provides the Beta–Gamma division formula
+`Complex.betaIntegral_eq_Gamma_mul_div`, the Gauss value
+`Complex.Gamma_one_half_eq : Γ(1/2) = π^(1/2)`, the functional equation
+`Complex.Gamma_add_one`, and `Complex.Gamma_nat_eq_factorial`. It does **not**
+state the half-integer Beta values `B(1/2,1/2) = π` or `B(3/2,3/2) = π/8`; we
+assemble them here from those ingredients.
+
+## Approach
+
+`betaIntegral_half_half`: apply `betaIntegral_eq_Gamma_mul_div` (both real parts
+are `1/2 > 0`), rewrite `1/2 + 1/2 = 1`, collapse `Γ(1) = 1`, substitute
+`Γ(1/2) = π^(1/2)`, and recombine `π^(1/2) · π^(1/2) = π^(1/2 + 1/2) = π` via
+`cpow_add` (base `(π : ℂ) ≠ 0`) and `cpow_one`.
+
+`betaIntegral_three_half_three_half`: same Beta–Gamma split, then
+`Γ(3/2) = ½·Γ(1/2)` from `Gamma_add_one` and `Γ(3) = 2` from
+`Gamma_nat_eq_factorial`, finishing with `field_simp`/`ring` and the same
+`π^(1/2)` recombination.
+-/
+
+namespace BetaIntegralHalfValue
+
+open Complex
+
+/-- `(π : ℂ) ≠ 0`, the base nonvanishing needed to recombine `cpow` powers. -/
+private lemma piC_ne_zero : (Real.pi : ℂ) ≠ 0 := by
+  exact_mod_cast Real.pi_ne_zero
+
+/-- The square of the Gauss value: `π^(1/2) · π^(1/2) = π`. -/
+private lemma piC_half_sq :
+    (Real.pi : ℂ) ^ (1 / 2 : ℂ) * (Real.pi : ℂ) ^ (1 / 2 : ℂ) = (Real.pi : ℂ) := by
+  rw [← Complex.cpow_add _ _ piC_ne_zero, show (1 / 2 : ℂ) + 1 / 2 = 1 by ring,
+    Complex.cpow_one]
+
+/-- **`Γ(1/2) · Γ(1/2) = π`** — the squared Gauss value, recorded separately as
+the analytic heart of the half-integer Beta value. -/
+theorem gamma_half_sq : Gamma (1 / 2) * Gamma (1 / 2) = (Real.pi : ℂ) := by
+  rw [Gamma_one_half_eq, piC_half_sq]
+
+/-- **`B(1/2, 1/2) = π` (new).** The headline half-integer value of the Euler
+Beta function. -/
+theorem betaIntegral_half_half : betaIntegral (1 / 2) (1 / 2) = (Real.pi : ℂ) := by
+  have hre : (0 : ℝ) < ((1 / 2 : ℂ)).re := by norm_num
+  rw [betaIntegral_eq_Gamma_mul_div _ _ hre hre,
+    show (1 / 2 : ℂ) + 1 / 2 = 1 by ring, Gamma_one, div_one, gamma_half_sq]
+
+/-- `Γ(3/2) = ½ · Γ(1/2)`, the single recurrence step from the Gauss value. -/
+private lemma gamma_three_half : Gamma (3 / 2) = (1 / 2 : ℂ) * Gamma (1 / 2) := by
+  have h : Gamma ((1 / 2 : ℂ) + 1) = (1 / 2 : ℂ) * Gamma (1 / 2) :=
+    Gamma_add_one _ (by norm_num)
+  rwa [show (1 / 2 : ℂ) + 1 = 3 / 2 by ring] at h
+
+/-- **`B(3/2, 3/2) = π/8` (new).** The next half-integer Beta value, reached by
+one step of the Beta/Gamma recurrence above the headline value. -/
+theorem betaIntegral_three_half_three_half :
+    betaIntegral (3 / 2) (3 / 2) = (Real.pi : ℂ) / 8 := by
+  have hre : (0 : ℝ) < ((3 / 2 : ℂ)).re := by norm_num
+  have hsum : (3 / 2 : ℂ) + 3 / 2 = ((2 : ℕ) : ℂ) + 1 := by norm_num
+  rw [betaIntegral_eq_Gamma_mul_div _ _ hre hre, hsum, Gamma_nat_eq_factorial,
+    gamma_three_half, Gamma_one_half_eq]
+  -- goal: (1/2 · π^(1/2)) · (1/2 · π^(1/2)) / (2! : ℂ) = π / 8
+  have hpow := piC_half_sq
+  rw [show ((Nat.factorial 2 : ℂ)) = 2 by norm_num [Nat.factorial]]
+  rw [show (1 / 2 : ℂ) * (Real.pi : ℂ) ^ (1 / 2 : ℂ) *
+      ((1 / 2 : ℂ) * (Real.pi : ℂ) ^ (1 / 2 : ℂ))
+      = (1 / 4 : ℂ) * ((Real.pi : ℂ) ^ (1 / 2 : ℂ) * (Real.pi : ℂ) ^ (1 / 2 : ℂ)) by ring,
+    hpow]
+  ring
+
+end BetaIntegralHalfValue

--- a/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
+++ b/src/data/proofs/beta-integral-recurrence-oq-01-oq-02/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "beta-integral-recurrence-oq-01-oq-02",
+  "slug": "beta-integral-recurrence-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Complex"
+    ],
+    "namespace": "BetaIntegralHalfValue",
+    "lineCount": 99,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BetaIntegralHalfValue.lean",
+    "sorries": 0
+  },
+  "title": "The Beta Function at Half-Integers: B(1/2,1/2) = π",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BetaIntegralHalfValue.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "beta-function",
+      "gamma-function",
+      "pi",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 99,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "betaIntegral_half_half: the famous half-integer Beta value B(1/2,1/2) = π — NOT in Mathlib, which has the Beta–Gamma relation and the Gauss value Γ(1/2) = π^(1/2) but never assembles them into this evaluation. Obtained by applying betaIntegral_eq_Gamma_mul_div at u = v = 1/2, collapsing Γ(1/2+1/2) = Γ(1) = 1, and recombining π^(1/2)·π^(1/2) = π^(1/2+1/2) = π via Complex.cpow_add and Complex.cpow_one.",
+      "gamma_half_sq: the squared Gauss value Γ(1/2)·Γ(1/2) = π, recorded as the analytic heart of the half-integer Beta value, derived from Complex.Gamma_one_half_eq.",
+      "betaIntegral_three_half_three_half: the next half-integer Beta value B(3/2,3/2) = π/8, reached by one step of the functional equation Γ(3/2) = (1/2)·Γ(1/2) (Complex.Gamma_add_one) above the headline value, with Γ(3) = 2! from Complex.Gamma_nat_eq_factorial — demonstrating the half-integer lattice analogue of the parent's integer-lattice recurrence.",
+      "gamma_three_half: the single recurrence step Γ(3/2) = (1/2)·Γ(1/2) from the Gamma functional equation, isolating the mechanism that propagates the Gauss value up the half-integer lattice."
+    ],
+    "prerequisites": [
+      "Euler Beta integral Complex.betaIntegral u v = ∫₀¹ tᵘ⁻¹ (1−t)ᵛ⁻¹ dt",
+      "Beta–Gamma relation Complex.betaIntegral_eq_Gamma_mul_div: B(u,v) = Γu·Γv/Γ(u+v) for Re u, Re v > 0",
+      "Gauss value Complex.Gamma_one_half_eq: Γ(1/2) = π^(1/2)",
+      "Gamma functional equation Complex.Gamma_add_one: Γ(s+1) = s·Γ(s) for s ≠ 0",
+      "Complex.Gamma_one (Γ(1) = 1) and Complex.Gamma_nat_eq_factorial (Γ(n+1) = n!)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.betaIntegral_eq_Gamma_mul_div",
+        "description": "Beta–Gamma division formula B(u,v) = Γu·Γv/Γ(u+v) for Re u, Re v > 0, the bridge turning the half-integer Beta values into Gamma quotients.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.Gamma_one_half_eq",
+        "description": "The Gauss value Γ(1/2) = π^(1/2), the source of π in the half-integer Beta values (itself proved in Mathlib from the Gaussian integral).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Complex.Gamma_add_one",
+        "description": "Gamma functional equation Γ(s+1) = s·Γ(s) for s ≠ 0, used for the single step Γ(3/2) = (1/2)·Γ(1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Complex.Gamma_nat_eq_factorial",
+        "description": "Γ(n+1) = n! for n : ℕ, used to evaluate Γ(3) = 2! = 2 in the B(3/2,3/2) computation.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Euler Beta integral B(u,v) = ∫₀¹ t^(u−1)(1−t)^(v−1) dt is the 'Eulerian integral of the first kind'. While its integer values B(m+1,n+1) = m!·n!/(m+n+1)! are governed entirely by factorials (the subject of the parent entry), its half-integer values introduce the transcendental constant π through the Gauss value Γ(1/2) = √π, discovered by Euler and given its definitive form via the reflection formula and the Gaussian integral. The value B(1/2,1/2) = π is the total mass of the arcsine distribution: under the substitution t = sin²θ, B(1/2,1/2) = ∫₀¹ dt/√(t(1−t)) = 2∫₀^{π/2} dθ = π. This same half-integer Beta value computes the area of the unit disk and the volume of higher-dimensional balls, and B(3/2,3/2) = π/8 is the area under the semicircular density. Mathlib supplies the Beta–Gamma relation and the Gauss value Γ(1/2) = π^(1/2) separately, but never combines them into these evaluations; this entry does.",
+    "problemStatement": "Using Mathlib's Beta–Gamma relation B(u,v) = Γ(u)Γ(v)/Γ(u+v) and the Gauss value Γ(1/2) = π^(1/2), prove the half-integer Beta evaluations B(1/2,1/2) = π and B(3/2,3/2) = π/8, the latter via one step of the Gamma functional equation Γ(3/2) = (1/2)·Γ(1/2). This answers open question oq-02 of the parent entry.",
+    "proofStrategy": "betaIntegral_half_half applies betaIntegral_eq_Gamma_mul_div at u = v = 1/2 (real parts 1/2 > 0), rewrites 1/2 + 1/2 = 1 and Γ(1) = 1 (so the denominator vanishes from the quotient), and reduces to gamma_half_sq: Γ(1/2)·Γ(1/2) = π. The squared Gauss value is closed by substituting Γ(1/2) = π^(1/2) (Complex.Gamma_one_half_eq) and recombining π^(1/2)·π^(1/2) = π^(1/2+1/2) = π^1 = π through Complex.cpow_add (base (π:ℂ) ≠ 0) and Complex.cpow_one. betaIntegral_three_half_three_half repeats the Beta–Gamma split at u = v = 3/2, evaluates the denominator Γ(3) = 2! = 2 with Gamma_nat_eq_factorial, substitutes Γ(3/2) = (1/2)·Γ(1/2) (gamma_three_half, from Gamma_add_one), and finishes with the same π^(1/2) recombination and ring arithmetic giving π/8.",
+    "keyInsights": [
+      "The integer lattice of the Beta function is purely factorial (rational values); the half-integer lattice is purely π-driven. The crossover is the single Gauss value Γ(1/2) = √π — every transcendental Beta value is one power of √π in disguise.",
+      "B(1/2,1/2) = π squares the Gauss value: B(1/2,1/2) = Γ(1/2)²/Γ(1) = (√π)²/1 = π. No integration is performed — the Beta–Gamma relation and Γ(1/2) = √π do all the work, exactly as the parent's integer values come from Γ(n+1) = n!.",
+      "Geometrically B(1/2,1/2) = ∫₀¹ dt/√(t(1−t)) = π is the total mass of the arcsine density and the perimeter constant of the unit circle; the formal proof never touches this picture, buying the value algebraically through Gamma.",
+      "The half-integer recurrence mirrors the parent's integer recurrence: Γ(3/2) = (1/2)Γ(1/2) plays the role of (n+1)! = (n+1)·n!, so B(3/2,3/2) = π/8 is reached from B(1/2,1/2) = π by one functional-equation step, the half-integer analogue of climbing the factorial lattice.",
+      "The 'mathlib' badge is honest: the Beta–Gamma relation, the Gauss value, and the functional equation are imported deep theorems (Γ(1/2) = √π itself rests on the Gaussian integral); the original content is their assembly into the named half-integer Beta values, which Mathlib does not state."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Half-Integer Beta Values",
+      "startLine": 4,
+      "endLine": 51,
+      "summary": "States the Beta integral and announces the headline half-integer value B(1/2,1/2) = π as the π-driven companion to the parent's factorial integer closed form, together with the next value B(3/2,3/2) = π/8. Notes that Mathlib provides the Beta–Gamma relation, the Gauss value Γ(1/2) = π^(1/2), the functional equation, and Γ(n+1) = n! separately but never assembles them into these evaluations, and outlines the cpow recombination strategy.",
+      "mathContext": "$B(u,v) = \\int_0^1 t^{u-1}(1-t)^{v-1}\\,dt$; goal $B(1/2,1/2) = \\pi$, $B(3/2,3/2) = \\pi/8$."
+    },
+    {
+      "id": "gauss-value",
+      "title": "The Squared Gauss Value",
+      "startLine": 53,
+      "endLine": 69,
+      "summary": "Helper lemmas piC_ne_zero ((π:ℂ) ≠ 0) and piC_half_sq (π^(1/2)·π^(1/2) = π via cpow_add and cpow_one) feed gamma_half_sq: Γ(1/2)·Γ(1/2) = π, obtained by substituting the Gauss value Γ(1/2) = π^(1/2) and recombining the two half-powers.",
+      "mathContext": "$\\Gamma(1/2)^2 = (\\pi^{1/2})^2 = \\pi$."
+    },
+    {
+      "id": "half-half",
+      "title": "The Headline Value B(1/2,1/2) = π",
+      "startLine": 70,
+      "endLine": 75,
+      "summary": "betaIntegral_half_half applies the Beta–Gamma relation at u = v = 1/2, rewrites 1/2 + 1/2 = 1 and collapses Γ(1) = 1, then closes with the squared Gauss value gamma_half_sq.",
+      "mathContext": "$B(1/2,1/2) = \\Gamma(1/2)^2/\\Gamma(1) = \\pi$."
+    },
+    {
+      "id": "three-half",
+      "title": "One Recurrence Step: B(3/2,3/2) = π/8",
+      "startLine": 76,
+      "endLine": 99,
+      "summary": "gamma_three_half (Γ(3/2) = (1/2)·Γ(1/2) from Gamma_add_one) and betaIntegral_three_half_three_half: the Beta–Gamma split at u = v = 3/2 with Γ(3) = 2! = 2, substitution of Γ(3/2), and the same π^(1/2) recombination, finishing with ring arithmetic to π/8.",
+      "mathContext": "$B(3/2,3/2) = \\Gamma(3/2)^2/\\Gamma(3) = (\\sqrt\\pi/2)^2/2 = \\pi/8$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "beta-integral-recurrence-oq-01-oq-02-oq-01",
+      "question": "Establish the general half-integer closed form B(n+1/2, n+1/2) = π·(2n)!²/(4^(2n)·n!²·(2n)!) (equivalently in terms of double factorials), exhibiting the uniform π-dependence of the diagonal half-integer Beta values and connecting to the volume of the n-ball.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "beta-integral-recurrence-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry evaluates the Beta function on the integer lattice (B(m+1,n+1) = m!·n!/(m+n+1)!, purely factorial); this entry evaluates it on the half-integer lattice (B(1/2,1/2) = π, B(3/2,3/2) = π/8), where the Gauss value Γ(1/2) = √π introduces π. It answers the parent's open question oq-02 verbatim."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "related",
+      "description": "Both entries evaluate Gamma/Beta at rational arguments using Mathlib's Analysis.SpecialFunctions.Gamma theory. The reflection formula gives Γ(s)Γ(1−s) = π/sin(πs) (whose s = 1/2 case is Γ(1/2)² = π); here the Beta–Gamma relation turns that same squared Gauss value into B(1/2,1/2) = π."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta and Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.betaIntegral_eq_Gamma_mul_div, Complex.Gamma_one_half_eq (Γ(1/2) = π^(1/2)), Complex.Gamma_add_one, and Complex.Gamma_nat_eq_factorial."
+    },
+    {
+      "title": "Special Functions (Beta and Gamma functions)",
+      "author": "Andrews, Askey, Roy",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "description": "Standard reference for the Beta integral, the Beta–Gamma relation, the Gauss value Γ(1/2) = √π, and the half-integer Beta values."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The half-integer values of the Euler Beta function are evaluated from Mathlib's Beta–Gamma relation B(u,v) = Γu·Γv/Γ(u+v) and the Gauss value Γ(1/2) = π^(1/2). The centerpiece betaIntegral_half_half proves B(1/2,1/2) = π (via gamma_half_sq: Γ(1/2)² = π and Γ(1) = 1), and betaIntegral_three_half_three_half proves B(3/2,3/2) = π/8 by one step of the Gamma functional equation Γ(3/2) = (1/2)·Γ(1/2) with Γ(3) = 2. 99 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The Beta–Gamma relation, the Gauss value, and the functional equation are delegated to Mathlib (hence the mathlib badge); the genuine new content is their assembly into the named half-integer Beta evaluations B(1/2,1/2) = π and B(3/2,3/2) = π/8, which Mathlib does not state. Where the parent entry shows the integer lattice is factorial, this entry shows the half-integer lattice is π-driven, the crossover being the single value Γ(1/2) = √π.",
+    "openQuestions": [
+      "Establish the general diagonal half-integer closed form B(n+1/2, n+1/2) and connect it to the volume of the n-ball."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question **oq-02** of the parent entry `beta-integral-recurrence-oq-01` verbatim: *"Prove the half-integer evaluation B(1/2, 1/2) = π from Γ(1/2)² = π via the same Beta–Gamma relation."*

Where the parent entry shows the Beta function's **integer** lattice is purely factorial (`B(m+1,n+1) = m!·n!/(m+n+1)!`), this entry shows the **half-integer** lattice is **π-driven** — the crossover being the single Gauss value `Γ(1/2) = √π`.

## Results (`proofs/Proofs/BetaIntegralHalfValue.lean`)

| Theorem | Statement |
|---------|-----------|
| `gamma_half_sq` | `Γ(1/2)·Γ(1/2) = π` |
| `betaIntegral_half_half` | **`B(1/2,1/2) = π`** (headline) |
| `gamma_three_half` | `Γ(3/2) = (1/2)·Γ(1/2)` |
| `betaIntegral_three_half_three_half` | **`B(3/2,3/2) = π/8`** |

## Proof sketch

- `B(1/2,1/2) = Γ(1/2)²/Γ(1/2+1/2) = Γ(1/2)²/Γ(1) = π/1 = π`, applying Mathlib's `betaIntegral_eq_Gamma_mul_div` at `u = v = 1/2`.
- `Γ(1/2)² = π`: substitute `Γ(1/2) = π^(1/2)` (`Complex.Gamma_one_half_eq`) and recombine `π^(1/2)·π^(1/2) = π^(1/2+1/2) = π` via `Complex.cpow_add` (base `(π:ℂ) ≠ 0`) and `Complex.cpow_one`.
- `B(3/2,3/2) = π/8`: one step of the Gamma functional equation `Γ(3/2) = (1/2)·Γ(1/2)` (`Complex.Gamma_add_one`) with `Γ(3) = 2! = 2` (`Complex.Gamma_nat_eq_factorial`), then the same `π^(1/2)` recombination.

## Mathlib relationship

Mathlib provides the Beta–Gamma relation and the Gauss value `Γ(1/2) = π^(1/2)` (itself resting on the Gaussian integral) **separately**, but never assembles them into the named half-integer Beta values `B(1/2,1/2) = π` or `B(3/2,3/2) = π/8`. Badge: `mathlib` (deep theorems delegated; original content is the assembly).

## Verification

- 99 lines, **6 theorems, 0 definitions, 0 axioms, 0 sorries**
- Compiles against Mathlib (lean v4.26.0)
- Gallery entry added at `src/data/proofs/beta-integral-recurrence-oq-01-oq-02/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)