### PR TITLE
research(cube-root-2-irrational-oq-05-oq-01): full rationality criterion m^(1/n) ∈ ℚ ⟺ m is a perfect n-th power [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -750,6 +750,7 @@ import Proofs.CubeRoot2Irrational
 import Proofs.CubeRoot2IrrationalOQ01
 import Proofs.CubeRoot2IrrationalOQ03
 import Proofs.CubeRoot2IrrationalOQ05
+import Proofs.CubeRoot2IrrationalOQ05OQ01
 import Proofs.CubeRoot3Irrational
 import Proofs.CubeRoot3IrrationalOQ01
 import Proofs.CubeRoot3IrrationalOQ02

--- a/proofs/Proofs/CubeRoot2IrrationalOQ05OQ01.lean
+++ b/proofs/Proofs/CubeRoot2IrrationalOQ05OQ01.lean
@@ -1,0 +1,126 @@
+/-
+# Cube Root of 2 OQ-05-OQ-01: the full rationality criterion for n-th roots
+
+## Open Question (parent OQ-05, first listed)
+State and prove the full criterion: for `m, n ≥ 1`, the real n-th root `m ^ (1/n)` is
+**rational iff m is a perfect n-th power** (`∃ k : ℕ, k ^ n = m`).
+
+The parent OQ-05 proves only one direction for prime bases — a prime is never a perfect
+power, so its n-th root is irrational. This entry proves the complete two-way
+characterization for an arbitrary natural number `m`, and recovers the prime case as a
+corollary.
+
+## Approach
+Write `x = (m : ℝ) ^ (n : ℝ)⁻¹`. Note `x ≥ 0` and `x ^ n = m` (rpow composition,
+`m ≥ 0`).
+* (⇐) If `m = k ^ n` then `x = ((k : ℝ) ^ n) ^ n⁻¹ = (k : ℝ) ^ (n · n⁻¹) = k`, rational.
+* (⇒) If `x` is rational then `x ^ n = m` (an integer) with `0 < n`, so Mathlib's
+  `irrational_nrt_of_notint_nrt` (contrapositive) forces `x = (y : ℤ)`. Since `x ≥ 0`,
+  `y ≥ 0`, hence `y = (k : ℕ)` and `k ^ n = m`.
+
+The prime corollary then needs only the elementary fact that a prime is not a perfect
+`n`-th power for `n ≥ 2`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace CubeRoot2IrrationalOQ05OQ01
+
+open Real
+
+/-- `m` is a perfect `n`-th power: there is a natural number `k` with `k ^ n = m`. -/
+def IsPerfectNthPow (m n : ℕ) : Prop := ∃ k : ℕ, k ^ n = m
+
+/-- The defining identity of the real `n`-th root: for `n ≥ 1`,
+`(m ^ (1/n)) ^ n = m`. -/
+theorem rpow_inv_pow {m n : ℕ} (hn : 0 < n) :
+    ((m : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = (m : ℝ) := by
+  have hm0 : (0 : ℝ) ≤ (m : ℝ) := by positivity
+  have hn0 : (n : ℝ) ≠ 0 := by positivity
+  rw [← Real.rpow_natCast ((m : ℝ) ^ ((n : ℝ)⁻¹)) n, ← Real.rpow_mul hm0,
+    inv_mul_cancel₀ hn0, Real.rpow_one]
+
+/-- **The rationality criterion.** For `m, n ≥ 1`, the real `n`-th root `m ^ (1/n)` is
+rational (i.e. *not* irrational) **iff** `m` is a perfect `n`-th power. -/
+theorem rational_rpow_inv_iff {m n : ℕ} (hn : 0 < n) :
+    (¬ Irrational ((m : ℝ) ^ ((n : ℝ)⁻¹))) ↔ IsPerfectNthPow m n := by
+  constructor
+  · -- rational ⟹ perfect power
+    intro hrat
+    have hxr : ((m : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = ((m : ℤ) : ℝ) := by
+      rw [rpow_inv_pow hn]; push_cast; ring
+    -- the integral-closedness lemma: a rational `n`-th root of an integer is an integer
+    have hint : ∃ y : ℤ, (m : ℝ) ^ ((n : ℝ)⁻¹) = (y : ℝ) := by
+      by_contra h
+      exact hrat (irrational_nrt_of_notint_nrt n (m : ℤ) hxr h hn)
+    obtain ⟨y, hy⟩ := hint
+    have hx0 : (0 : ℝ) ≤ (m : ℝ) ^ ((n : ℝ)⁻¹) := by positivity
+    rw [hy] at hx0
+    have hy0 : 0 ≤ y := by exact_mod_cast hx0
+    lift y to ℕ using hy0 with k
+    refine ⟨k, ?_⟩
+    have h2 : ((m : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = (m : ℝ) := rpow_inv_pow hn
+    rw [hy] at h2
+    exact_mod_cast h2
+  · -- perfect power ⟹ rational
+    rintro ⟨k, rfl⟩
+    have hk0 : (0 : ℝ) ≤ (k : ℝ) := by positivity
+    have hn0 : (n : ℝ) ≠ 0 := by positivity
+    have hval : ((↑(k ^ n) : ℝ)) ^ ((n : ℝ)⁻¹) = (k : ℝ) := by
+      rw [Nat.cast_pow, ← Real.rpow_natCast (k : ℝ) n, ← Real.rpow_mul hk0,
+        mul_inv_cancel₀ hn0, Real.rpow_one]
+    rw [hval]
+    exact Nat.not_irrational k
+
+/-- **The irrationality criterion** (negated form). For `m, n ≥ 1`, the real `n`-th root
+`m ^ (1/n)` is irrational **iff** `m` is not a perfect `n`-th power. -/
+theorem irrational_rpow_inv_iff {m n : ℕ} (hn : 0 < n) :
+    Irrational ((m : ℝ) ^ ((n : ℝ)⁻¹)) ↔ ¬ IsPerfectNthPow m n := by
+  rw [← not_iff_not, not_not]
+  exact rational_rpow_inv_iff hn
+
+/-- A prime is never a perfect `n`-th power for `n ≥ 2`. -/
+theorem not_isPerfectNthPow_prime {p n : ℕ} (hp : p.Prime) (hn : 2 ≤ n) :
+    ¬ IsPerfectNthPow p n := by
+  rintro ⟨k, hk⟩
+  have hdvd : k ∣ p := by
+    rw [← hk]; exact dvd_pow_self k (by omega)
+  rcases (hp.eq_one_or_self_of_dvd k hdvd) with h1 | hpk
+  · subst h1; rw [one_pow] at hk; exact hp.ne_one hk.symm
+  · subst hpk
+    have h1 : k ^ n = k ^ 1 := by rw [pow_one]; exact hk
+    have hk2 : 2 ≤ k := hp.two_le
+    have := Nat.pow_right_injective hk2 h1
+    omega
+
+/-- **The n-th root of a prime is irrational** — the parent OQ-05 result recovered as a
+corollary of the general criterion. -/
+theorem irrational_rpow_inv_prime {p n : ℕ} (hp : p.Prime) (hn : 2 ≤ n) :
+    Irrational ((p : ℝ) ^ ((n : ℝ)⁻¹)) :=
+  (irrational_rpow_inv_iff (by omega)).mpr (not_isPerfectNthPow_prime hp hn)
+
+/-- **∛2 is irrational** — the base entry, recovered from the prime corollary. -/
+theorem irrational_cbrt_two : Irrational ((2 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+  have := irrational_rpow_inv_prime (p := 2) (n := 3) (by norm_num) (by norm_num)
+  simpa using this
+
+/-- **∛8 is rational** (= 2): `8 = 2³` is a perfect cube, so the criterion's rational
+branch fires. Demonstrates the converse direction on a genuine perfect power. -/
+theorem rational_cbrt_eight : ¬ Irrational ((8 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+  have := (rational_rpow_inv_iff (m := 8) (n := 3) (by norm_num)).mpr ⟨2, by norm_num⟩
+  simpa using this
+
+/-- **∛6 is irrational**, although `6` is *not prime*: the criterion handles composite
+non-perfect-powers that the prime corollary cannot reach. -/
+theorem irrational_cbrt_six : Irrational ((6 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+  have key : Irrational ((6 : ℝ) ^ ((3 : ℝ)⁻¹)) := by
+    refine (irrational_rpow_inv_iff (m := 6) (n := 3) (by norm_num)).mpr ?_
+    rintro ⟨k, hk⟩
+    rcases Nat.lt_or_ge k 2 with h | h
+    · interval_cases k <;> omega
+    · have : 2 ^ 3 ≤ k ^ 3 := Nat.pow_le_pow_left h 3
+      omega
+  simpa using key
+
+end CubeRoot2IrrationalOQ05OQ01

--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "cube-root-2-irrational-oq-05-oq-01",
+  "title": "Rationality Criterion for n-th Roots: m^(1/n) ∈ ℚ ⟺ m Is a Perfect n-th Power",
+  "slug": "cube-root-2-irrational-oq-05-oq-01",
+  "description": "The full two-way criterion: for m, n ≥ 1 the real n-th root m^(1/n) is rational if and only if m is a perfect n-th power (∃ k, kⁿ = m). The parent OQ-05 proves only the irrationality direction for prime bases; this entry settles the complete characterization for arbitrary natural m and recovers the prime case — and ∛2 — as corollaries. The non-trivial direction routes through Mathlib's integral-closedness lemma irrational_nrt_of_notint_nrt: a rational n-th root of an integer must be an integer.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Nth_root#Irrationality",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "nth-root",
+      "perfect-power",
+      "rational",
+      "real-analysis",
+      "rpow",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CubeRoot2IrrationalOQ05OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "irrational_nrt_of_notint_nrt",
+        "description": "If x^n is an integer (n > 0) and x is not itself an integer, then x is irrational — contrapositive gives integral closedness: a rational n-th root of an integer is an integer",
+        "module": "Mathlib.NumberTheory.Real.Irrational"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "0 ≤ x → x ^ (y * z) = (x ^ y) ^ z — collapses (m^(1/n))^n to m^(n⁻¹·n) = m^1 = m, and (kⁿ)^(1/n) to k",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_natCast",
+        "description": "x ^ (n : ℝ) = x ^ n — bridges the monoid power x^n and the real power x^(n:ℝ)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Nat.not_irrational",
+        "description": "(k : ℝ) is not irrational for k : ℕ — closes the perfect-power direction once the root simplifies to k",
+        "module": "Mathlib.NumberTheory.Real.Irrational"
+      },
+      {
+        "theorem": "Nat.pow_right_injective",
+        "description": "For 2 ≤ k, the map n ↦ kⁿ is injective — used to show a prime cannot equal kⁿ for n ≥ 2",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "rational_rpow_inv_iff: the main criterion — ¬Irrational (m^(1/n)) ↔ ∃ k, kⁿ = m, for m, n ≥ 1 (both directions)",
+      "irrational_rpow_inv_iff: the contrapositive form — m^(1/n) is irrational ↔ m is not a perfect n-th power",
+      "IsPerfectNthPow: predicate ∃ k : ℕ, kⁿ = m packaging the perfect-power condition",
+      "not_isPerfectNthPow_prime: a prime is never a perfect n-th power for n ≥ 2 (the elementary obstruction)",
+      "irrational_rpow_inv_prime: the parent OQ-05 result (p^(1/n) irrational for prime p, n ≥ 2) recovered as a one-line corollary",
+      "rational_cbrt_eight: ∛8 is rational (= 2) — the converse direction firing on a genuine perfect cube",
+      "irrational_cbrt_six: ∛6 is irrational although 6 is composite — a case the prime corollary cannot reach"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 126,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on Lean's foundational propext / Classical.choice / Quot.sound). No native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "That a non-perfect-power has an irrational root is the general form of the Greek discovery that √2 is irrational. The classical statement — m^(1/n) is rational only when m is itself an n-th power — appears in Hardy & Wright (Theorem 44) and Niven's Irrational Numbers as the prototypical application of unique factorization. The parent entry proves the easy half (primes are never perfect powers, so their roots are irrational); the full equivalence additionally requires the converse — that a rational n-th root forces an exact power — which is the content of integral closedness of ℤ in ℚ. Mathlib packages exactly this as irrational_nrt_of_notint_nrt.",
+    "problemStatement": "**Open Question (cube-root-2-irrational-oq-05, first listed)**: State and prove the full criterion — for m, n ≥ 1, m^(1/n) is rational iff m is a perfect n-th power.\n\n**Result**: rational_rpow_inv_iff establishes ¬Irrational (m^(1/n)) ↔ ∃ k, kⁿ = m, with the irrationality form irrational_rpow_inv_iff, the prime corollary irrational_rpow_inv_prime, and worked instances ∛2 (irrational), ∛8 (rational), ∛6 (irrational, composite).",
+    "text": "For natural numbers m, n ≥ 1, the real n-th root m^(1/n) is rational exactly when m is a perfect n-th power — completing the parent's one-directional prime result to a full equivalence.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Set x = m^(1/n) (real rpow, n ≥ 1). The defining identity xⁿ = m (`rpow_inv_pow`) follows from Real.rpow_natCast and Real.rpow_mul: x^n = m^(n⁻¹·n) = m^1 = m, using m ≥ 0.\n2. **(⇒) rational ⟹ perfect power.** If x is rational then xⁿ = m is an integer with n > 0, so the contrapositive of `irrational_nrt_of_notint_nrt` forces x = (y : ℤ) for some integer y. Since x ≥ 0, y ≥ 0, so y = (k : ℕ); substituting into xⁿ = m gives kⁿ = m.\n3. **(⇐) perfect power ⟹ rational.** If m = kⁿ then (kⁿ)^(1/n) = k^(n·n⁻¹) = k (again Real.rpow_mul, k ≥ 0), and a natural number is not irrational (`Nat.not_irrational`).\n4. **Prime corollary.** `not_isPerfectNthPow_prime`: if p = kⁿ with n ≥ 2 then k ∣ p, so k = 1 (gives p = 1, impossible) or k = p (gives kⁿ = k¹, so n = 1 by `Nat.pow_right_injective`, contradiction). Feeding this into irrational_rpow_inv_iff recovers the parent's irrational_rpow_inv_prime and hence ∛2.\n5. **Worked instances.** ∛8 rational via the witness k = 2; ∛6 irrational by ruling out k = 0, 1 (interval_cases) and k ≥ 2 (2³ ≤ k³ already exceeds 6)."
+    ,
+    "keyInsights": [
+      "**The criterion is an integral-closedness statement.** The hard direction is precisely that ℤ is integrally closed in ℚ specialised to xⁿ - m: a rational root of a monic integer polynomial is an integer. Mathlib's irrational_nrt_of_notint_nrt is this fact in n-th-root clothing.",
+      "**Primality was never essential — only 'not a perfect power' is.** The parent used primes because a prime is the cleanest non-perfect-power. The general criterion exposes the real obstruction and is strictly stronger: it decides composite radicands like 6 and 8 that the prime corollary cannot.",
+      "**rpow turns the radical into an exponent identity.** Writing the n-th root as m^(n⁻¹) reduces both directions to the single homomorphism law Real.rpow_mul for nonnegative base; the only arithmetic is n⁻¹·n = 1.",
+      "**Sharp at n = 1.** The hypothesis n ≥ 1 is exactly right: at n = 1 every m is (trivially) a perfect 1st power and m^(1/1) = m is rational, so the equivalence still holds and degenerates correctly."
+    ],
+    "prerequisites": [
+      "Integral closedness of ℤ in ℚ via the n-th-root criterion irrational_nrt_of_notint_nrt",
+      "Real power (rpow) arithmetic: rpow_mul, rpow_natCast for nonnegative base",
+      "Elementary divisibility: a prime is not a perfect n-th power for n ≥ 2 (Nat.pow_right_injective)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header, Predicate, and Root Identity",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring stating the full criterion, the IsPerfectNthPow predicate, and rpow_inv_pow: (m^(1/n))^n = m for n ≥ 1 via rpow composition.",
+      "mathContext": "$\\left(m^{1/n}\\right)^n = m$ for $m \\ge 0,\\ n \\ge 1$."
+    },
+    {
+      "id": "criterion",
+      "title": "The Rationality Criterion",
+      "startLine": 44,
+      "endLine": 81,
+      "summary": "rational_rpow_inv_iff: ¬Irrational (m^(1/n)) ↔ ∃ k, kⁿ = m, and its contrapositive irrational_rpow_inv_iff. The (⇒) direction uses irrational_nrt_of_notint_nrt to force an integer root; (⇐) simplifies (kⁿ)^(1/n) to k.",
+      "mathContext": "$m^{1/n} \\in \\mathbb{Q} \\iff \\exists k,\\ k^n = m$."
+    },
+    {
+      "id": "prime-and-instances",
+      "title": "Prime Corollary and Worked Instances",
+      "startLine": 83,
+      "endLine": 126,
+      "summary": "not_isPerfectNthPow_prime (a prime is never a perfect n-th power, n ≥ 2), irrational_rpow_inv_prime (parent result recovered), and instances irrational_cbrt_two, rational_cbrt_eight (= 2), irrational_cbrt_six (composite).",
+      "mathContext": "$\\sqrt[3]{2},\\sqrt[3]{6} \\notin \\mathbb{Q}$ but $\\sqrt[3]{8} = 2 \\in \\mathbb{Q}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-2-irrational-oq-05",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: upgrades the one-directional 'prime ⟹ irrational' result to the full two-way criterion for arbitrary m, and recovers irrational_rpow_inv_prime as a corollary"
+    },
+    {
+      "targetId": "cube-root-2-irrational",
+      "relationship": "related",
+      "description": "∛2 irrational (the base entry) is recovered here as irrational_cbrt_two, an instance of the prime corollary"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the rationality criterion for n-th roots: m^(1/n) is rational iff m is a perfect n-th power. The converse direction — the genuinely new content over the parent — comes from integral closedness (irrational_nrt_of_notint_nrt), and the prime case, ∛2, ∛8, and ∛6 all fall out as instances.",
+    "implications": "Settles the natural completion of the ∛2 / prime-root line: the criterion decides rationality of every n-th root of every natural number, including composites that the prime obstruction cannot reach. It also isolates the exact hypothesis — 'not a perfect power' — replacing the stronger 'prime' used by the parent.",
+    "openQuestions": [
+      "Extend the criterion to rational radicands: q^(1/n) for q : ℚ⁺ is rational iff both numerator and denominator of q (in lowest terms) are perfect n-th powers.",
+      "Quantify the irrationality: for non-perfect-power m, give an effective irrationality measure / denominator bound for m^(1/n)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CubeRoot2IrrationalOQ05OQ01",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/CubeRoot2IrrationalOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Theorem 44: a rational n-th root of an integer is an integer — the integral-closedness fact underlying the converse direction"
+    },
+    {
+      "authors": "Niven, Ivan",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs, MAA",
+      "note": "Classical treatment of irrationality of n-th roots of integers that are not perfect powers"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `cube-root-2-irrational-oq-05` ("State and prove the full criterion: m^(1/n) is rational iff m is a perfect n-th power, for m, n ≥ 1").

The parent proves only the one-directional result for **prime** bases (a prime is never a perfect power, so its n-th root is irrational). This entry settles the complete **two-way** characterization for an arbitrary natural number `m`:

```
rational_rpow_inv_iff : ∀ {m n : ℕ}, 0 < n → (¬ Irrational ((m:ℝ) ^ (n:ℝ)⁻¹) ↔ ∃ k : ℕ, k ^ n = m)
```

## What's new over the parent

- **Both directions.** The genuinely new content is the converse (`rational ⟹ perfect power`), which is integral closedness of ℤ in ℚ specialised to `xⁿ - m`. Routed through Mathlib's `irrational_nrt_of_notint_nrt` (a rational n-th root of an integer must be an integer).
- **Replaces "prime" with the real obstruction, "not a perfect power".** Strictly stronger than the parent: it decides composite radicands the prime corollary cannot — e.g. `∛8 = 2` is rational (witness k=2), `∛6` is irrational (composite, not a cube).
- **Recovers the parent.** `irrational_rpow_inv_prime` (p^(1/n) irrational for prime p, n ≥ 2) and `∛2` drop out as one-line corollaries via `not_isPerfectNthPow_prime`.

## Contents

8 theorems + 1 definition (`IsPerfectNthPow`), 126 lines:
`rpow_inv_pow`, `rational_rpow_inv_iff` (main), `irrational_rpow_inv_iff`, `not_isPerfectNthPow_prime`, `irrational_rpow_inv_prime`, `irrational_cbrt_two`, `rational_cbrt_eight`, `irrational_cbrt_six`.

## Verification

- **0 sorries, 0 axioms.** `#print axioms` on the main results lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Verified by single-file `lean` typecheck against Mathlib v4.26.0 (Docker build wrapper down this session).

Files: `proofs/Proofs/CubeRoot2IrrationalOQ05OQ01.lean`, `proofs/Proofs.lean` (aggregator import), `src/data/proofs/cube-root-2-irrational-oq-05-oq-01/meta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)