### PR TITLE
research(arsinh-log-formula-oq-01-oq-01): antiderivative of 1/√(1+x²) — arsinh calculus capstone via FTC [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -212,6 +212,7 @@ import Proofs.ArithmeticSeriesOQ04
 import Proofs.ArithmeticSeriesOQ04OQ01
 import Proofs.ArithmeticSeriesOQ04OQ03
 import Proofs.ArsinhLogFormulaOQ01
+import Proofs.ArsinhLogFormulaOQ01OQ01
 import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.AutomorphicNumberOQ01OQ02

--- a/proofs/Proofs/ArsinhLogFormulaOQ01OQ01.lean
+++ b/proofs/Proofs/ArsinhLogFormulaOQ01OQ01.lean
@@ -1,0 +1,135 @@
+/-
+# Antiderivative of `1/√(1 + x²)`: the `arsinh` calculus capstone
+
+Research: arsinh-log-formula-oq-01-oq-01
+Parent:   arsinh-log-formula-oq-01 (logarithmic form + addition law)
+
+This file answers the parent's first listed open question verbatim:
+
+  > Establish `∫ 1/√(1 + x²) dx = arsinh x + C` from `hasDerivAt_arsinh`.
+
+The parent established the *algebraic* theory of `arsinh` (its logarithmic
+closed form `arsinh x = log(x + √(1 + x²))`, the addition / subtraction /
+doubling laws, and concrete values such as `arsinh (4/3) = log 3`).  What was
+missing was the *calculus* side: that `arsinh` is an antiderivative of the
+integrand `1/√(1 + x²)`, and the resulting definite-integral evaluations.
+
+Here we supply that capstone, all `0`-axiom and machine-checked:
+
+* `hasDerivAt_arsinh'` — the antiderivative fact `(arsinh)' x = 1/√(1 + x²)`
+  in fractional form (Mathlib states it with an inverse), i.e. the precise
+  "`arsinh x + C`" content of the open question.
+* `deriv_arsinh_eq` — the same as a `deriv` equation.
+* `integral_one_div_sqrt_one_add_sq` — the Fundamental Theorem of Calculus
+  evaluation `∫_a^b 1/√(1 + t²) dt = arsinh b − arsinh a`.
+* `integral_eq_log_sub_log` — its logarithmic closed form.
+* `integral_zero_to` / `integral_zero_to_log` — the `∫_0^b` normalisation
+  (the genuine "`+ C` with `C = 0`" antiderivative).
+* `integral_symmetric` — the even-integrand identity
+  `∫_{-a}^a 1/√(1 + t²) dt = 2·arsinh a`.
+* `integral_zero_to_three_quarters`, `integral_zero_to_four_thirds` — concrete
+  evaluations `= log 2` and `= log 3`, tying the calculus back to the parent's
+  closed-form values.
+-/
+import Mathlib
+
+namespace ArsinhLogFormulaOQ01OQ01
+
+open Real intervalIntegral MeasureTheory
+
+/-- The denominator `√(1 + x²)` is strictly positive, so the integrand
+`1/√(1 + x²)` is well defined and continuous everywhere. -/
+theorem sqrt_one_add_sq_pos (x : ℝ) : 0 < Real.sqrt (1 + x ^ 2) :=
+  Real.sqrt_pos.mpr (by positivity)
+
+/-- **Antiderivative fact (the open question).** `arsinh` is an antiderivative of
+`1/√(1 + x²)`: `HasDerivAt arsinh (1/√(1 + x²)) x` at every real `x`.
+
+Mathlib's `Real.hasDerivAt_arsinh` records the derivative as `(√(1 + x²))⁻¹`;
+we restate it in the fractional form `1/√(1 + x²)` that matches the integrand. -/
+theorem hasDerivAt_arsinh' (x : ℝ) :
+    HasDerivAt arsinh (1 / Real.sqrt (1 + x ^ 2)) x := by
+  simpa [one_div] using Real.hasDerivAt_arsinh x
+
+/-- The `deriv` form of the antiderivative fact: `(arsinh)' x = 1/√(1 + x²)`. -/
+theorem deriv_arsinh_eq (x : ℝ) :
+    deriv arsinh x = 1 / Real.sqrt (1 + x ^ 2) :=
+  (hasDerivAt_arsinh' x).deriv
+
+/-- The integrand `x ↦ 1/√(1 + x²)` is continuous on all of `ℝ`. -/
+theorem continuous_integrand :
+    Continuous fun x : ℝ => 1 / Real.sqrt (1 + x ^ 2) :=
+  continuous_const.div
+    (Real.continuous_sqrt.comp (continuous_const.add (continuous_pow 2)))
+    (fun x => ne_of_gt (sqrt_one_add_sq_pos x))
+
+/-- Consequently the integrand is interval-integrable on every `[a, b]`. -/
+theorem intervalIntegrable_integrand (a b : ℝ) :
+    IntervalIntegrable (fun x => 1 / Real.sqrt (1 + x ^ 2)) volume a b :=
+  continuous_integrand.intervalIntegrable a b
+
+/-- **Fundamental Theorem of Calculus for `arsinh`.**
+`∫_a^b 1/√(1 + t²) dt = arsinh b − arsinh a`.
+
+This is the definite-integral incarnation of the antiderivative `arsinh`, and
+the precise meaning of "`∫ 1/√(1 + x²) dx = arsinh x + C`". -/
+theorem integral_one_div_sqrt_one_add_sq (a b : ℝ) :
+    ∫ x in a..b, 1 / Real.sqrt (1 + x ^ 2) = arsinh b - arsinh a := by
+  apply intervalIntegral.integral_eq_sub_of_hasDerivAt
+  · intro x _; exact hasDerivAt_arsinh' x
+  · exact intervalIntegrable_integrand a b
+
+/-- **Logarithmic closed form of the integral.**
+`∫_a^b 1/√(1 + t²) dt = log(b + √(1 + b²)) − log(a + √(1 + a²))`,
+obtained by unfolding `arsinh` to its parent logarithmic form. -/
+theorem integral_eq_log_sub_log (a b : ℝ) :
+    ∫ x in a..b, 1 / Real.sqrt (1 + x ^ 2) =
+      Real.log (b + Real.sqrt (1 + b ^ 2)) -
+        Real.log (a + Real.sqrt (1 + a ^ 2)) := by
+  rw [integral_one_div_sqrt_one_add_sq]
+  rfl
+
+/-- **Normalised antiderivative (`C = 0`).** Anchoring the lower limit at `0`,
+where `arsinh 0 = 0`, gives `∫_0^b 1/√(1 + t²) dt = arsinh b`. -/
+theorem integral_zero_to (b : ℝ) :
+    ∫ x in (0 : ℝ)..b, 1 / Real.sqrt (1 + x ^ 2) = arsinh b := by
+  rw [integral_one_div_sqrt_one_add_sq, arsinh_zero, sub_zero]
+
+/-- The normalised integral in logarithmic closed form:
+`∫_0^b 1/√(1 + t²) dt = log(b + √(1 + b²))`. -/
+theorem integral_zero_to_log (b : ℝ) :
+    ∫ x in (0 : ℝ)..b, 1 / Real.sqrt (1 + x ^ 2) =
+      Real.log (b + Real.sqrt (1 + b ^ 2)) := by
+  rw [integral_zero_to]
+  rfl
+
+/-- **Even integrand, symmetric interval.** Since the integrand is even and
+`arsinh` is odd, `∫_{-a}^a 1/√(1 + t²) dt = 2·arsinh a`. -/
+theorem integral_symmetric (a : ℝ) :
+    ∫ x in (-a)..a, 1 / Real.sqrt (1 + x ^ 2) = 2 * arsinh a := by
+  rw [integral_one_div_sqrt_one_add_sq, Real.arsinh_neg]
+  ring
+
+/-- Concrete evaluation `∫_0^{3/4} 1/√(1 + t²) dt = log 2`, since
+`arsinh (3/4) = log 2` (the parent's value `√(1 + (3/4)²) = 5/4`). -/
+theorem integral_zero_to_three_quarters :
+    ∫ x in (0 : ℝ)..(3 / 4), 1 / Real.sqrt (1 + x ^ 2) = Real.log 2 := by
+  rw [integral_zero_to]
+  have h : Real.sqrt (1 + (3 / 4 : ℝ) ^ 2) = 5 / 4 := by
+    rw [show (1 + (3 / 4 : ℝ) ^ 2) = (5 / 4) ^ 2 by norm_num]
+    exact Real.sqrt_sq (by norm_num)
+  show Real.log ((3 / 4 : ℝ) + Real.sqrt (1 + (3 / 4 : ℝ) ^ 2)) = Real.log 2
+  rw [h, show (3 / 4 + 5 / 4 : ℝ) = 2 by norm_num]
+
+/-- Concrete evaluation `∫_0^{4/3} 1/√(1 + t²) dt = log 3`, since
+`arsinh (4/3) = log 3` (the parent's value `√(1 + (4/3)²) = 5/3`). -/
+theorem integral_zero_to_four_thirds :
+    ∫ x in (0 : ℝ)..(4 / 3), 1 / Real.sqrt (1 + x ^ 2) = Real.log 3 := by
+  rw [integral_zero_to]
+  have h : Real.sqrt (1 + (4 / 3 : ℝ) ^ 2) = 5 / 3 := by
+    rw [show (1 + (4 / 3 : ℝ) ^ 2) = (5 / 3) ^ 2 by norm_num]
+    exact Real.sqrt_sq (by norm_num)
+  show Real.log ((4 / 3 : ℝ) + Real.sqrt (1 + (4 / 3 : ℝ) ^ 2)) = Real.log 3
+  rw [h, show (4 / 3 + 5 / 3 : ℝ) = 3 by norm_num]
+
+end ArsinhLogFormulaOQ01OQ01

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "arsinh-log-formula-oq-01-oq-01",
+  "slug": "arsinh-log-formula-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "intervalIntegral",
+      "MeasureTheory"
+    ],
+    "namespace": "ArsinhLogFormulaOQ01OQ01",
+    "lineCount": 135,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/ArsinhLogFormulaOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Antiderivative of 1/√(1 + x²): the arsinh Calculus Capstone",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ArsinhLogFormulaOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "hyperbolic-functions",
+      "inverse-hyperbolic",
+      "arsinh",
+      "integration",
+      "fundamental-theorem-of-calculus",
+      "antiderivative",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 135,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "integral_one_div_sqrt_one_add_sq: the Fundamental-Theorem-of-Calculus evaluation ∫_a^b 1/√(1 + t²) dt = arsinh b − arsinh a — the definite-integral incarnation of 'arsinh is an antiderivative of 1/√(1+x²)', which is the parent's first open question made precise. Mathlib records the derivative (Real.hasDerivAt_arsinh) but not this integral.",
+      "integral_eq_log_sub_log: the logarithmic closed form of the integral, ∫_a^b 1/√(1 + t²) dt = log(b + √(1+b²)) − log(a + √(1+a²)), obtained by unfolding arsinh to the parent's logarithmic form.",
+      "integral_zero_to / integral_zero_to_log: the normalised antiderivative (C = 0) ∫_0^b 1/√(1 + t²) dt = arsinh b = log(b + √(1+b²)), anchoring the constant of integration at arsinh 0 = 0.",
+      "integral_symmetric: the even-integrand identity ∫_{-a}^a 1/√(1 + t²) dt = 2·arsinh a, combining the FTC evaluation with the oddness of arsinh.",
+      "hasDerivAt_arsinh' / deriv_arsinh_eq: the antiderivative fact (arsinh)' x = 1/√(1 + x²) restated in fractional form (Mathlib states it as (√(1+x²))⁻¹), matching the integrand — this is the exact '∫ 1/√(1+x²) dx = arsinh x + C' content of the open question.",
+      "integral_zero_to_three_quarters / integral_zero_to_four_thirds: concrete evaluations ∫_0^{3/4} = log 2 and ∫_0^{4/3} = log 3, tying the calculus back to the parent's closed-form values via the (3,4,5) Pythagorean triple.",
+      "continuous_integrand / intervalIntegrable_integrand / sqrt_one_add_sq_pos: the supporting analytic API (the integrand is everywhere positive, continuous, and hence interval-integrable) needed to apply the FTC."
+    ],
+    "prerequisites": [
+      "Mathlib's derivative Real.hasDerivAt_arsinh : HasDerivAt arsinh (√(1 + x²))⁻¹ x",
+      "The Fundamental Theorem of Calculus intervalIntegral.integral_eq_sub_of_hasDerivAt",
+      "Continuity of √ (Real.continuous_sqrt) and Continuous.intervalIntegrable for interval integrability",
+      "The parent's logarithmic form arsinh x = log(x + √(1 + x²)) (Mathlib's definition) and Real.arsinh_zero, Real.arsinh_neg"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.hasDerivAt_arsinh",
+        "description": "HasDerivAt arsinh (√(1 + x²))⁻¹ x — the antiderivative fact from which the integral identity follows; restated here in fractional form 1/√(1+x²).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Arsinh"
+      },
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDerivAt",
+        "description": "The Fundamental Theorem of Calculus: if HasDerivAt f (f' x) x on the interval and f' is interval-integrable, then ∫_a^b f' = f b − f a. Applied with f = arsinh.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus"
+      },
+      {
+        "theorem": "Real.continuous_sqrt",
+        "description": "Continuity of √, composed with 1 + x² to give continuity (and hence interval integrability) of the integrand 1/√(1+x²).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.arsinh_zero / Real.arsinh_neg",
+        "description": "arsinh 0 = 0 (fixing C = 0 in the normalised integral) and arsinh(−x) = −arsinh x (driving the symmetric-interval doubling identity).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Arsinh"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral ∫ dx/√(1 + x²) = arsinh x + C = log(x + √(1 + x²)) + C is one of the standard entries in every integral table, and it is exactly what makes the inverse hyperbolic sine ubiquitous in calculus: it computes the arc length of the catenary y = cosh x (whose length element is √(1 + sinh²) = cosh, integrating to sinh, while the inverse substitution is governed by arsinh), and it is the prototype trigonometric-substitution integral handled by x = sinh u rather than x = tan u. The parent entry developed the algebraic theory of arsinh — its logarithmic closed form and its addition/subtraction/doubling calculus — but stopped short of the calculus identity that motivates the function in the first place. Mathlib supplies the derivative Real.hasDerivAt_arsinh; the present entry closes the loop by turning that derivative into the definite-integral evaluation via the Fundamental Theorem of Calculus, supplying the logarithmic closed form, the normalised (C = 0) antiderivative, the even-integrand symmetric-interval identity, and concrete logarithmic values.",
+    "problemStatement": "Establish ∫ 1/√(1 + x²) dx = arsinh x + C from Mathlib's hasDerivAt_arsinh, exhibiting arsinh as the antiderivative of the integrand. Concretely: prove the FTC evaluation ∫_a^b 1/√(1+t²) dt = arsinh b − arsinh a, its logarithmic closed form, the normalisation ∫_0^b = arsinh b = log(b + √(1+b²)), the symmetric-interval identity ∫_{-a}^a = 2·arsinh a, and concrete values ∫_0^{3/4} = log 2, ∫_0^{4/3} = log 3.",
+    "proofStrategy": "Restate Mathlib's Real.hasDerivAt_arsinh (derivative (√(1+x²))⁻¹) in fractional form 1/√(1+x²) via one_div, giving hasDerivAt_arsinh' — the precise antiderivative fact. The integrand is continuous everywhere (denominator √(1+x²) > 0 by positivity, composed continuity of √), hence interval-integrable. The Fundamental Theorem of Calculus intervalIntegral.integral_eq_sub_of_hasDerivAt then yields ∫_a^b 1/√(1+t²) dt = arsinh b − arsinh a directly. The logarithmic closed form is the parent's arsinh x = log(x + √(1+x²)) unfolded (rfl). Setting a = 0 and using arsinh_zero = 0 normalises the constant; the symmetric interval uses arsinh_neg to collapse arsinh a − arsinh(−a) to 2·arsinh a. Concrete values reuse the parent's (3,4,5)-triple computation: √(1+(3/4)²) = 5/4 makes the surd rational, so ∫_0^{3/4} = arsinh(3/4) = log(3/4 + 5/4) = log 2.",
+    "keyInsights": [
+      "The whole capstone is one application of the FTC to a single derivative fact: once arsinh is known to be an antiderivative of 1/√(1+x²), the definite integral over any interval is forced to be arsinh b − arsinh a. The only analytic content beyond Mathlib's derivative is interval-integrability, which follows from continuity.",
+      "Mathlib states the derivative with an inverse, (√(1+x²))⁻¹, while the integrand is naturally written 1/√(1+x²); the one-line one_div restatement is what makes the FTC apply syntactically — a small but necessary bridge.",
+      "Anchoring the lower limit at 0, where arsinh 0 = 0, is the honest way to pin the 'arbitrary constant C' to a concrete value: ∫_0^b 1/√(1+t²) dt = arsinh b, with no free constant left.",
+      "Because the integrand 1/√(1+t²) is even and arsinh is odd, the integral over a symmetric interval doubles cleanly: ∫_{-a}^a = arsinh a − arsinh(−a) = 2·arsinh a — a parity fact that needs no separate computation.",
+      "The (3,4,5) Pythagorean triple turns the surd rational and the integral into a clean logarithm: ∫_0^{3/4} 1/√(1+t²) dt = log 2. This links the calculus capstone directly to the parent's concrete closed-form values arsinh(3/4) = log 2 and arsinh(4/3) = log 3."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: the arsinh Antiderivative",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "States the open question (∫ 1/√(1+x²) dx = arsinh x + C from hasDerivAt_arsinh) and enumerates the theorems supplied: the antiderivative fact, the FTC evaluation, its logarithmic closed form, the normalised ∫_0^b, the symmetric-interval doubling, and the concrete logarithmic values.",
+      "mathContext": "$\\int \\frac{dx}{\\sqrt{1+x^2}} = \\operatorname{arsinh} x + C = \\log(x + \\sqrt{1+x^2}) + C$."
+    },
+    {
+      "id": "antiderivative-and-integrability",
+      "title": "Antiderivative Fact and Integrability",
+      "startLine": 38,
+      "endLine": 74,
+      "summary": "sqrt_one_add_sq_pos (denominator positivity), hasDerivAt_arsinh' (the derivative restated as 1/√(1+x²)), deriv_arsinh_eq (the deriv form), continuous_integrand and intervalIntegrable_integrand — the analytic API the FTC consumes.",
+      "mathContext": "$(\\operatorname{arsinh})'(x) = \\dfrac{1}{\\sqrt{1+x^2}}$, integrand continuous and interval-integrable."
+    },
+    {
+      "id": "ftc-evaluation",
+      "title": "The Fundamental Theorem of Calculus Evaluation",
+      "startLine": 76,
+      "endLine": 113,
+      "summary": "integral_one_div_sqrt_one_add_sq (∫_a^b = arsinh b − arsinh a), integral_eq_log_sub_log (logarithmic closed form), integral_zero_to and integral_zero_to_log (the normalised ∫_0^b = arsinh b = log(b + √(1+b²))), and integral_symmetric (∫_{-a}^a = 2·arsinh a).",
+      "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{1+t^2}} = \\operatorname{arsinh} b - \\operatorname{arsinh} a$; $\\int_{-a}^a = 2\\operatorname{arsinh} a$."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Logarithmic Evaluations",
+      "startLine": 115,
+      "endLine": 135,
+      "summary": "integral_zero_to_three_quarters (∫_0^{3/4} = log 2) and integral_zero_to_four_thirds (∫_0^{4/3} = log 3), using the (3,4,5) triple to rationalise √(1+x²) and reuse the parent's closed-form values.",
+      "mathContext": "$\\int_0^{3/4} \\frac{dt}{\\sqrt{1+t^2}} = \\log 2$, $\\int_0^{4/3} \\frac{dt}{\\sqrt{1+t^2}} = \\log 3$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "arsinh-log-formula-oq-01-oq-01-oq-01",
+      "question": "Derive the catenary arc-length formula: the length of y = cosh x over [0, b] equals sinh b, and re-express the arc-length integral of a general curve via the arsinh substitution to recover ∫_0^b √(1 + t²) dt = ½(b√(1+b²) + arsinh b).",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "arsinh-log-formula-oq-01",
+      "relationship": "parent",
+      "description": "The parent develops the algebraic theory of arsinh (logarithmic closed form, addition/subtraction/doubling laws, concrete values). This entry answers its first open question, supplying the calculus side: arsinh as the antiderivative of 1/√(1+x²) and the resulting definite-integral evaluations."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Arsinh",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.arsinh, its derivative Real.hasDerivAt_arsinh, and the inverse-pair / oddness lemmas."
+    },
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.IntervalIntegral.FundThmCalculus",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of intervalIntegral.integral_eq_sub_of_hasDerivAt, the Fundamental Theorem of Calculus used to turn the derivative fact into the integral evaluation."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Answers the parent's first open question: arsinh is exhibited as the antiderivative of 1/√(1 + x²). From Mathlib's Real.hasDerivAt_arsinh (restated in fractional form) and the continuity-driven interval-integrability of the integrand, the Fundamental Theorem of Calculus yields ∫_a^b 1/√(1+t²) dt = arsinh b − arsinh a, with its logarithmic closed form log(b+√(1+b²)) − log(a+√(1+a²)). The normalisation ∫_0^b = arsinh b pins the constant of integration (arsinh 0 = 0); the even integrand and the oddness of arsinh give ∫_{-a}^a = 2·arsinh a; and the (3,4,5) Pythagorean triple yields the concrete values ∫_0^{3/4} = log 2 and ∫_0^{4/3} = log 3. 135 lines, 12 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The derivative is Mathlib's and the FTC is a standard tool (hence the mathlib badge), but the integral identity, its logarithmic and normalised forms, the symmetric-interval doubling, and the concrete logarithmic evaluations are new to the gallery and complete the arsinh story begun by the parent — joining the algebraic addition calculus to the calculus identity that motivates the function. It also lays the groundwork for the catenary arc-length integral.",
+    "openQuestions": [
+      "Derive the catenary arc-length formula ∫_0^b √(1 + t²) dt = ½(b√(1+b²) + arsinh b) via the arsinh substitution."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent `arsinh-log-formula-oq-01` verbatim:

> Establish ∫ 1/√(1 + x²) dx = arsinh x + C from Mathlib's `hasDerivAt_arsinh`, exhibiting arsinh as the antiderivative underlying the catenary arc length.

The parent developed the *algebraic* theory of `arsinh` (logarithmic closed form, addition/subtraction/doubling laws). This entry supplies the *calculus* side: `arsinh` is the antiderivative of `1/√(1+x²)`, and the Fundamental Theorem of Calculus turns that into definite-integral evaluations.

## Results (12 theorems, 0 defs, 0 axioms, 0 sorries, 135 lines)

- `hasDerivAt_arsinh'` / `deriv_arsinh_eq` — the antiderivative fact `(arsinh)' x = 1/√(1+x²)`, restated in fractional form (Mathlib carries it as `(√(1+x²))⁻¹`). This is the precise "+ C" content of the question.
- `integral_one_div_sqrt_one_add_sq` — **FTC evaluation** `∫_a^b 1/√(1+t²) dt = arsinh b − arsinh a`.
- `integral_eq_log_sub_log` — logarithmic closed form `log(b+√(1+b²)) − log(a+√(1+a²))`.
- `integral_zero_to` / `integral_zero_to_log` — normalised antiderivative (C = 0): `∫_0^b = arsinh b = log(b+√(1+b²))`.
- `integral_symmetric` — even-integrand identity `∫_{-a}^a 1/√(1+t²) dt = 2·arsinh a`.
- `integral_zero_to_three_quarters` / `integral_zero_to_four_thirds` — concrete `∫_0^{3/4} = log 2`, `∫_0^{4/3} = log 3` via the (3,4,5) triple.
- Supporting analytic API: positivity, continuity, interval-integrability of the integrand.

## Verification

Typechecked with `lake env lean` against Mathlib (Lean v4.26.0). `#print axioms integral_one_div_sqrt_one_add_sq` reports only `[propext, Classical.choice, Quot.sound]` — **0-axiom verified**, no `sorry`, no `native_decide`.

Badge `mathlib`: the derivative is Mathlib's and the FTC is a standard tool, but the integral identity, its logarithmic/normalised forms, the symmetric-interval doubling, and the concrete logarithmic values are new to the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)