### PR TITLE
Add missing index.ts for lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/index.ts
+++ b/src/data/proofs/lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lagrangeFourSquaresWaringG2OQ03OQ05OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lagrangeFourSquaresWaringG2OQ03OQ05OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lagrangeFourSquaresWaringG2OQ03OQ05OQ01Data: ProofData = {
+  proof: lagrangeFourSquaresWaringG2OQ03OQ05OQ01Proof,
+  annotations: lagrangeFourSquaresWaringG2OQ03OQ05OQ01Annotations,
+}


### PR DESCRIPTION
## Summary

The gallery entry `lagrange-four-squares-waring-g2-oq-03-oq-05-oq-01` (*The Non-Three-Square Density Error Is One-Sided and Genuinely Unbounded*) had its `meta.json` and `annotations.json` enriched on main, but the required **`index.ts` entry point was never created**.

Without `index.ts`, Vite's `import.meta.glob` cannot discover the proof, so the page renders **"proof not found"** on the live site even though the entry appears in the gallery listing.

This PR adds the standard `index.ts` wiring `meta.json`, `annotations.json`, and the Lean source (`Proofs/LagrangeFourSquaresWaringG2OQ03OQ05OQ01.lean`), following the established gallery convention.

## Notes
- No changes to `meta.json` / `annotations.json` — the on-main enrichment is already high quality.
- Verified the JSON keys referenced by `index.ts` (description, overview, sections, conclusion, crossReferences) all exist in the on-main `meta.json`.
- The relative import path matches the entry's `proofRepoPath`.