### PR TITLE
Enrich Mean and Variance of the Descent Statistic via the Eulerian Polynomial

### DIFF
--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview-moments",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Descent Moments as Derivatives of the Eulerian Polynomial",
+    "content": "The Eulerian polynomial Eₘ(X) = ∑ₖ ⟨m,k−1⟩ Xᵏ is the descent generating function of Sₘ: the coefficient of Xᵏ counts permutations of {1,…,m} with k−1 descents. So the moments of the descent statistic are derivatives of Eₘ at X = 1: E'ₘ(1) = ∑ₖ k·⟨m,k−1⟩ is the first factorial moment of k = des+1, and E''ₘ(1) = ∑ₖ k(k−1)·⟨m,k−1⟩ the second. The whole file is the observation that the parent's analytic recurrence makes computing these a mechanical derivative-and-evaluate, because the factor X(1−X) vanishes at X = 1.",
+    "mathContext": "$E_m(X)=\\sum_k \\langle m,k{-}1\\rangle X^k$; $E'_m(1)=\\sum_k k\\langle m,k{-}1\\rangle$, $E''_m(1)=\\sum_k k(k{-}1)\\langle m,k{-}1\\rangle$.",
+    "significance": "context",
+    "relatedConcepts": ["Eulerian numbers", "descent statistic", "generating functions", "factorial moments"],
+    "prerequisites": ["permutation statistics", "generating functions"]
+  },
+  {
+    "id": "ann-first-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 60, "endLine": 70 },
+    "type": "theorem",
+    "title": "First Moment Recurrence",
+    "content": "`deriv_eulerPoly_eval_one_succ`: E'_{m+1}(1) = (m+1)·Eₘ(1) + m·E'ₘ(1). Obtained by differentiating the recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ once and evaluating at X = 1. The product-rule expansion of (X(1−X)E'ₘ)' contains a term X(1−X)·E''ₘ that would reference the second derivative — but X(1−X) = 0 at X = 1, so it drops out, leaving a clean first-order recurrence. Mathlib's derivative_mul/derivative_sub/eval_* simp set normalizes the expression and ring finishes.",
+    "mathContext": "$E'_{m+1}(1)=(m{+}1)E_m(1)+mE'_m(1)$; the $X(1{-}X)E''_m$ term vanishes since $X(1{-}X)|_{X=1}=0$.",
+    "significance": "key",
+    "relatedConcepts": ["formal derivative", "product rule", "linear recurrence", "vanishing factor"],
+    "prerequisites": ["polynomial derivatives", "evaluation"]
+  },
+  {
+    "id": "ann-second-recurrence",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 72, "endLine": 82 },
+    "type": "theorem",
+    "title": "Second Moment Recurrence",
+    "content": "`deriv2_eulerPoly_eval_one_succ`: E''_{m+1}(1) = 2m·E'ₘ(1) + (m−1)·E''ₘ(1). Differentiate the recurrence twice and evaluate at X = 1. Differentiating X(1−X)E'ₘ twice produces a term X(1−X)·E'''ₘ which again vanishes at X = 1 (the same structural factor), so the recurrence closes at second order and never references the third derivative. This self-limiting order is exactly what lets the analytic definition compute combinatorial moments.",
+    "mathContext": "$E''_{m+1}(1)=2mE'_m(1)+(m{-}1)E''_m(1)$; the $X(1{-}X)E'''_m$ term again vanishes at $X=1$.",
+    "significance": "key",
+    "relatedConcepts": ["second derivative", "closed recurrence", "moment hierarchy"],
+    "prerequisites": ["higher derivatives", "polynomial evaluation"]
+  },
+  {
+    "id": "ann-first-moment",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 103 },
+    "type": "theorem",
+    "title": "First Factorial Moment: 2·E'ₘ(1) = (m+1)!",
+    "content": "`two_mul_deriv_eulerPoly_eval_one`: for m ≥ 1, 2·E'ₘ(1) = (m+1)!, over an arbitrary commutative ring. Equivalently ∑ₖ k·⟨m,k−1⟩ = (m+1)!/2, so the mean of k = des+1 is (m+1)/2 and the mean number of descents is (m−1)/2. Proved by Nat.le_induction from m = 1 (E₁ = X, E'₁(1) = 1, 2·1 = 2!) using the first-moment recurrence and the row sum Eₘ(1) = m!; the inductive step is one linear_combination after factorial algebra.",
+    "mathContext": "$2E'_m(1)=(m{+}1)!$ for $m\\ge 1$; mean of $k=\\mathrm{des}{+}1$ is $\\frac{m+1}{2}$, mean descents $\\frac{m-1}{2}$.",
+    "significance": "critical",
+    "relatedConcepts": ["factorial moment", "Nat.le_induction", "mean", "denominator-free identity"],
+    "prerequisites": ["induction", "factorials", "commutative rings"]
+  },
+  {
+    "id": "ann-second-moment",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 105, "endLine": 127 },
+    "type": "theorem",
+    "title": "Second Factorial Moment: 12·E''ₘ(1) = (3m−2)(m+1)!",
+    "content": "`twelve_mul_deriv2_eulerPoly_eval_one`: for m ≥ 2, 12·E''ₘ(1) = (3m−2)(m+1)!, over any commutative ring. Here E''ₘ(1) = ∑ₖ k(k−1)·⟨m,k−1⟩ is the second falling-factorial moment of k = des+1; with the first moment it pins the variance. Proved by Nat.le_induction from m = 2 (E₂ = X + X², E''₂(1) = 2, 12·2 = 24 = 4·3!), the step combining the second-moment recurrence with the first-moment identity via linear_combination.",
+    "mathContext": "$12E''_m(1)=(3m{-}2)(m{+}1)!$ for $m\\ge 2$; $E''_m(1)=\\sum_k k(k{-}1)\\langle m,k{-}1\\rangle$ is the 2nd falling-factorial moment.",
+    "significance": "critical",
+    "relatedConcepts": ["second factorial moment", "falling factorial", "induction", "variance input"],
+    "prerequisites": ["induction", "factorials"]
+  },
+  {
+    "id": "ann-mean",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 129, "endLine": 148 },
+    "type": "theorem",
+    "title": "Mean of the Descent Statistic Over ℚ",
+    "content": "`mean_descents_succ`: over ℚ, E'ₘ(1)/Eₘ(1) = (m+1)/2 for m ≥ 1. Dividing the first-moment identity 2·E'ₘ(1) = (m+1)! by the row sum Eₘ(1) = m! gives the average value of k = des+1, hence the mean number of descents of a uniformly random permutation of {1,…,m} is (m−1)/2. The division is justified by m! ≠ 0; div_eq_div_iff and linear_combination close it.",
+    "mathContext": "$\\dfrac{E'_m(1)}{E_m(1)}=\\dfrac{m+1}{2}$, so $E[\\mathrm{des}]=\\dfrac{m-1}{2}$ over $S_m$.",
+    "significance": "critical",
+    "relatedConcepts": ["expected value", "uniform permutation", "natural density", "field arithmetic"],
+    "prerequisites": ["rational arithmetic", "expectation"]
+  },
+  {
+    "id": "ann-variance",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-03",
+    "range": { "startLine": 150, "endLine": 175 },
+    "type": "theorem",
+    "title": "Variance of the Descent Statistic Over ℚ",
+    "content": "`variance_descents_succ`: over ℚ for m ≥ 2, E''ₘ(1)/Eₘ(1) + E'ₘ(1)/Eₘ(1) − (E'ₘ(1)/Eₘ(1))² = (m+1)/12. The left side is E[k(k−1)] + E[k] − E[k]² = E[k²] − E[k]² = Var(k) for k = des+1 (whose variance equals that of the descent count), recovering the classical variance (m+1)/12. Assembled from the two moment identities and Eₘ(1) = m!, then closed by field_simp and ring.",
+    "mathContext": "$\\mathrm{Var}(k)=E[k(k{-}1)]+E[k]-E[k]^2=\\dfrac{m+1}{12}$ for $k=\\mathrm{des}{+}1$; the descent count has the same variance.",
+    "significance": "critical",
+    "relatedConcepts": ["variance", "falling-factorial identity", "second moment", "asymptotic normality"],
+    "prerequisites": ["variance", "expectation", "field arithmetic"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ07OQ01OQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ07OQ01OQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ07OQ01OQ01OQ03Data: ProofData = {
+  proof: geometricSeriesOQ07OQ01OQ01OQ03Proof,
+  annotations: geometricSeriesOQ07OQ01OQ01OQ03Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-03/meta.json
@@ -19,6 +19,45 @@
     "sorries": 0
   },
   "title": "Mean and Variance of the Descent Statistic via the Eulerian Polynomial",
+  "description": "The classical facts that a uniformly random permutation of {1,…,m} has mean number of descents (m−1)/2 and variance (m+1)/12, derived NOT from the combinatorial definition of the Eulerian numbers but mechanically from the analytic differential recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ defining the Eulerian polynomial. Because the factor X(1−X) vanishes at X = 1, differentiating the recurrence once or twice and evaluating at 1 collapses to clean linear recurrences for the moments E'ₘ(1) and E''ₘ(1), giving the denominator-free integral identities 2·E'ₘ(1) = (m+1)! and 12·E''ₘ(1) = (3m−2)(m+1)! over any commutative ring; dividing by the row sum Eₘ(1) = m! recovers the mean and variance over ℚ.",
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨m,k⟩ — the number of permutations of {1,…,m} with exactly k descents — were introduced by Leonhard Euler in his 1755 study of the series ∑ nᵐ rⁿ, the same geometric-moment lineage this entry's grandparent formalizes. Their generating polynomial Eₘ(X) = ∑ₖ ⟨m,k⟩ Xᵏ is the descent generating function of the symmetric group Sₘ, and the moments of the descent statistic — mean (m−1)/2, variance (m+1)/12 — are textbook results (Graham–Knuth–Patashnik, Bóna) underpinning the classical theorem that the number of descents is asymptotically normal. Standard derivations argue combinatorially from the descent-counting definition or manipulate the closed-form generating function. The contribution here is methodological: working purely from the parent entry's analytic differential-recurrence definition of Eₘ, the moments fall out by formal differentiation, with no bijective or combinatorial input. Mathlib formalizes neither the Eulerian numbers nor these moments.",
+    "problemStatement": "Given the Eulerian polynomial Eₘ defined by E₀ = 1, E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ (parent entry) with row sum Eₘ(1) = m!, compute the first two moments of the descent statistic on Sₘ. Prove the integral identities 2·E'ₘ(1) = (m+1)! (m ≥ 1) and 12·E''ₘ(1) = (3m−2)(m+1)! (m ≥ 2) over an arbitrary commutative ring, and deduce over ℚ that the descent count has mean (m−1)/2 and variance (m+1)/12.",
+    "proofStrategy": "Differentiate-and-evaluate. The descent moments are derivatives of Eₘ at X = 1: E'ₘ(1) = ∑ₖ k·⟨m,k−1⟩ is the first factorial moment of k = des+1, and E''ₘ(1) = ∑ₖ k(k−1)·⟨m,k−1⟩ the second. Differentiating the recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ once (resp. twice) and evaluating at X = 1 — where X(1−X) = 0 kills the unwanted higher-derivative term — yields the linear recurrences E'_{m+1}(1) = (m+1)Eₘ(1) + m·E'ₘ(1) and E''_{m+1}(1) = 2m·E'ₘ(1) + (m−1)·E''ₘ(1). Nat.le_induction lifts these to the closed forms 2·E'ₘ(1) = (m+1)! and 12·E''ₘ(1) = (3m−2)(m+1)!, each inductive step closed by linear_combination. Specializing to ℚ and dividing by Eₘ(1) = m! gives the mean (m+1)/2 of k = des+1 and, via E[k²] − E[k]² = E[k(k−1)] + E[k] − E[k]², the variance (m+1)/12.",
+    "keyInsights": [
+      "The vanishing of the structural factor X(1−X) at X = 1 is the entire mechanism: it makes each differentiated recurrence close in low order, so the n-th moment recurrence never references derivatives above order n. This is why an analytic definition can compute combinatorial moments with no combinatorics.",
+      "The moments are read off as formal derivatives evaluated at a point: E'ₘ(1) and E''ₘ(1) are exactly the first and second falling-factorial moments of k = des+1, so differentiation of the generating function literally computes the statistics.",
+      "The integral identities 2·E'ₘ(1) = (m+1)! and 12·E''ₘ(1) = (3m−2)(m+1)! hold over ANY commutative ring — they are denominator-free statements about the Eulerian polynomial's derivatives, with the rational mean/variance only a specialization obtained after dividing by m!.",
+      "Variance is recovered through the falling-factorial bridge E[k²] − E[k]² = E[k(k−1)] + E[k] − E[k]²: the second factorial moment plus the first, minus the square of the first, equals the ordinary variance — and the variance of k = des+1 equals the variance of the descent count itself.",
+      "The mean (m−1)/2 is the symmetry center of the Eulerian distribution: the palindromicity ⟨m,k⟩ = ⟨m,m−1−k⟩ (sibling entry) forces the descent distribution to be symmetric about (m−1)/2, consistent with the mean computed here directly."
+    ]
+  },
+  "sections": [
+    {
+      "id": "moment-recurrences",
+      "title": "Part 1: The One-Step Moment Recurrences",
+      "startLine": 53,
+      "endLine": 82,
+      "summary": "Differentiates the Eulerian differential recurrence E_{m+1} = X(1−X)E'ₘ + (m+1)X·Eₘ once (deriv_eulerPoly_eval_one_succ: E'_{m+1}(1) = (m+1)Eₘ(1) + m·E'ₘ(1)) and twice (deriv2_eulerPoly_eval_one_succ: E''_{m+1}(1) = 2m·E'ₘ(1) + (m−1)E''ₘ(1)), evaluating at X = 1. The factor X(1−X) = 0 at X = 1 drops the unwanted higher-derivative term; Mathlib's derivative/eval simp set plus ring close each.",
+      "mathContext": "$E'_{m+1}(1)=(m{+}1)E_m(1)+mE'_m(1)$ and $E''_{m+1}(1)=2mE'_m(1)+(m{-}1)E''_m(1)$, from $\\frac{d}{dX}\\bigl[X(1{-}X)\\bigr]\\big|_{X=1}$ killing higher terms."
+    },
+    {
+      "id": "closed-forms",
+      "title": "Part 2: Closed Forms (Denominator-Free, Any Ring)",
+      "startLine": 84,
+      "endLine": 127,
+      "summary": "Lifts the one-step recurrences to closed form by Nat.le_induction over a commutative ring: two_mul_deriv_eulerPoly_eval_one gives 2·E'ₘ(1) = (m+1)! for m ≥ 1, and twelve_mul_deriv2_eulerPoly_eval_one gives 12·E''ₘ(1) = (3m−2)(m+1)! for m ≥ 2 (the latter using the first-moment identity in its step). Factorial algebra via Nat.factorial_succ; each step closed by linear_combination.",
+      "mathContext": "$2E'_m(1)=(m{+}1)!\\ (m\\ge 1)$ and $12E''_m(1)=(3m{-}2)(m{+}1)!\\ (m\\ge 2)$ — integral identities over any commutative ring."
+    },
+    {
+      "id": "mean-variance",
+      "title": "Part 3: Mean and Variance Over ℚ",
+      "startLine": 129,
+      "endLine": 175,
+      "summary": "Specializes to ℚ and divides by the row sum Eₘ(1) = m!. mean_descents_succ: E'ₘ(1)/Eₘ(1) = (m+1)/2, so the mean number of descents is (m−1)/2. variance_descents_succ: E''ₘ(1)/Eₘ(1) + E'ₘ(1)/Eₘ(1) − (E'ₘ(1)/Eₘ(1))² = (m+1)/12, the variance via the falling-factorial identity E[k²] − E[k]² = E[k(k−1)] + E[k] − E[k]². Closed by field_simp and ring.",
+      "mathContext": "Mean of descents $=\\frac{m-1}{2}$, variance $=\\frac{m+1}{12}$, via $\\mathrm{Var}(k)=E[k(k{-}1)]+E[k]-E[k]^2$ for $k=\\mathrm{des}+1$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
## Summary

Enrichment pass for `geometric-series-oq-07-oq-01-oq-01-oq-03` (*Mean and Variance of the Descent Statistic via the Eulerian Polynomial*). The entry previously had only a `meta.json` (no overview, sections, annotations, or index.ts).

## Changes
- **description**: added a top-level summary of the differentiate-and-evaluate derivation of mean (m−1)/2 and variance (m+1)/12.
- **overview**: added `historicalContext` (Euler 1755, descent statistic, Graham–Knuth–Patashnik / Bóna), `problemStatement`, `proofStrategy`, and 5 `keyInsights` centered on the X(1−X) vanishing mechanism that makes each differentiated recurrence self-limiting in order.
- **sections**: 3 sections covering the full Lean file (one-step moment recurrences; denominator-free closed forms; mean/variance over ℚ).
- **annotations.json**: 7 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **index.ts**: created the missing Vite entry point so the page loads on the live site (without it the page renders 'proof not found').

## Verification
- JSON validated for both `meta.json` and `annotations.json`.
- Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 sorries, 0 axioms, depends only on propext/Classical.choice/Quot.sound).