### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-01): monotone integral-test sandwich — Stirling bounds for log n! + p-series criterion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -139,6 +139,7 @@ import Proofs.AngleTrisectionOQ05OQ01
 import Proofs.AngleTrisectionOQ05OQ02
 import Proofs.AngleTrisectionOQ05OQ03
 import Proofs.AngleTrisectionOQ05OQ04
+import Proofs.AntitoneIntegralSumComparisonOQ01OQ01
 import Proofs.ArchimedesMethodOfExhaustion
 import Proofs.AreaFromCircumferenceIntegral
 import Proofs.AreaOfCircle

--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean
@@ -1,0 +1,203 @@
+import Mathlib
+
+/-
+# The Monotone Integral–Sum Sandwich, Stirling-Type Bounds, and the p-Series Test
+
+This is the open-question companion to `AntitoneIntegralSumComparison`.  The parent
+packages the **antitone** integral-test sandwich
+
+  ∑_{i<a} f(x₀ + i + 1)  ≤  ∫_{x₀}^{x₀+a} f  ≤  ∑_{i<a} f(x₀ + i)
+
+and applies it to `1/x` to get the logarithmic bounds on the harmonic numbers.
+Here we develop the three pieces the open question asks for:
+
+* **Part I — the monotone companion sandwich.**  For `f` *monotone* (non-decreasing)
+  the two Riemann sums swap roles:
+
+    ∑_{i<a} f(x₀ + i)  ≤  ∫_{x₀}^{x₀+a} f  ≤  ∑_{i<a} f(x₀ + i + 1).
+
+* **Part II — Stirling-type bounds on `log n!`.**  Applying the monotone sandwich to
+  `log` (the natural increasing partner of the parent's decreasing `1/x`) and using
+  `∫₁^{1+n} log x dx = (1+n) log(1+n) − n` yields
+
+    log(n!)  ≤  (1+n) log(1+n) − n  ≤  log((n+1)!),
+
+  the elementary two-sided estimate underlying Stirling's approximation.
+
+* **Part III — the p-series criterion.**  The integral test applied to the antitone
+  `1/xᵖ` bounds the partial sums of `∑ 1/iᵖ` by the value `1/(p−1)` of the improper
+  integral `∫₁^∞ x^{−p} dx`, giving convergence for `p > 1` *directly from the
+  comparison*.  The full criterion `∑ 1/nᵖ` converges ⟺ `p > 1` is recorded via
+  Mathlib's `Real.summable_one_div_nat_rpow`.
+
+All results are fully machine-verified: 0 sorries, 0 axioms.
+-/
+
+namespace AntitoneIntegralSumComparisonOQ01OQ01
+
+open scoped BigOperators
+open Finset intervalIntegral
+
+/-! ## Part I — The monotone integral-test sandwich -/
+
+/-- **Monotone integral-test sandwich.**  For `f` monotone (non-decreasing) on
+`[x₀, x₀ + a]`, the integral lies between the left Riemann sum (lower bound) and the
+right Riemann sum (upper bound) — the mirror image of the parent's antitone
+comparison.  This is the companion two-sided bound underlying the integral test for
+increasing integrands. -/
+theorem monotone_integral_sandwich {f : ℝ → ℝ} {x₀ : ℝ} {a : ℕ}
+    (hf : MonotoneOn f (Set.Icc x₀ (x₀ + a))) :
+    (∑ i ∈ Finset.range a, f (x₀ + i)) ≤ (∫ x in x₀..x₀ + a, f x) ∧
+      (∫ x in x₀..x₀ + a, f x) ≤ ∑ i ∈ Finset.range a, f (x₀ + (i + 1 : ℕ)) :=
+  ⟨hf.sum_le_integral, hf.integral_le_sum⟩
+
+/-! ## Part II — Stirling-type bounds on the log-factorial -/
+
+/-- `log` is monotone on `[1, 1 + n]` (it lives on the positive reals). -/
+theorem log_monotoneOn (n : ℕ) :
+    MonotoneOn Real.log (Set.Icc (1 : ℝ) (1 + n)) := by
+  intro x hx y _ hxy
+  exact Real.log_le_log (lt_of_lt_of_le one_pos hx.1) hxy
+
+/-- `∫₁^{1+n} log x dx = (1 + n) · log(1 + n) − n`. -/
+theorem log_integral (n : ℕ) :
+    (∫ x in (1 : ℝ)..(1 + n), Real.log x) = (1 + n) * Real.log (1 + n) - n := by
+  rw [integral_log, Real.log_one]
+  ring
+
+/-- `∏_{i<n} (i + 2) = (n + 1)!` as naturals. -/
+theorem prod_range_add_two (n : ℕ) :
+    ∏ i ∈ Finset.range n, (i + 2) = (n + 1).factorial := by
+  induction n with
+  | zero => simp
+  | succ k ih => rw [Finset.prod_range_succ, ih, Nat.factorial_succ (k + 1)]; ring
+
+/-- The lower Riemann sum of `log` is `log(n!)`: `∑_{i<n} log(1 + i) = log(n!)`. -/
+theorem sum_log_eq_log_factorial (n : ℕ) :
+    ∑ i ∈ Finset.range n, Real.log (1 + (i : ℝ)) = Real.log (n.factorial : ℝ) := by
+  have hprod : ∏ i ∈ Finset.range n, (1 + (i : ℝ)) = (n.factorial : ℝ) := by
+    rw [← Finset.prod_range_add_one_eq_factorial, Nat.cast_prod]
+    exact Finset.prod_congr rfl (fun i _ => by push_cast; ring)
+  rw [← hprod, ← Real.log_prod]
+  intro i _
+  positivity
+
+/-- The upper Riemann sum of `log` is `log((n+1)!)`: `∑_{i<n} log(1 + (i+1)) = log((n+1)!)`. -/
+theorem sum_log_succ_eq (n : ℕ) :
+    ∑ i ∈ Finset.range n, Real.log (1 + ((i + 1 : ℕ) : ℝ)) = Real.log ((n + 1).factorial : ℝ) := by
+  have hprod : ∏ i ∈ Finset.range n, (1 + ((i + 1 : ℕ) : ℝ)) = ((n + 1).factorial : ℝ) := by
+    rw [← prod_range_add_two, Nat.cast_prod]
+    exact Finset.prod_congr rfl (fun i _ => by push_cast; ring)
+  rw [← hprod, ← Real.log_prod]
+  intro i _
+  positivity
+
+/-- **Stirling lower bound.** `log(n!) ≤ (1 + n) log(1 + n) − n`, from the monotone
+sandwich applied to `log`: the lower Riemann sum is at most the integral. -/
+theorem log_factorial_le (n : ℕ) :
+    Real.log (n.factorial : ℝ) ≤ (1 + n) * Real.log (1 + n) - n := by
+  have key : (∑ i ∈ Finset.range n, Real.log (1 + (i : ℝ))) ≤ ∫ x in (1 : ℝ)..(1 + n), Real.log x :=
+    (log_monotoneOn n).sum_le_integral
+  rw [log_integral, sum_log_eq_log_factorial] at key
+  exact key
+
+/-- **Stirling upper bound.** `(1 + n) log(1 + n) − n ≤ log((n+1)!)`, from the monotone
+sandwich applied to `log`: the integral is at most the right Riemann sum. -/
+theorem log_integral_le_log_factorial (n : ℕ) :
+    (1 + n) * Real.log (1 + n) - n ≤ Real.log ((n + 1).factorial : ℝ) := by
+  have key : (∫ x in (1 : ℝ)..(1 + n), Real.log x)
+      ≤ ∑ i ∈ Finset.range n, Real.log (1 + ((i + 1 : ℕ) : ℝ)) :=
+    (log_monotoneOn n).integral_le_sum
+  rw [log_integral, sum_log_succ_eq] at key
+  exact key
+
+/-- **Stirling-type sandwich for `log n!`.**  Combining the two bounds:
+`log(n!) ≤ (1 + n) log(1 + n) − n ≤ log((n+1)!)`. -/
+theorem log_factorial_sandwich (n : ℕ) :
+    Real.log (n.factorial : ℝ) ≤ (1 + n) * Real.log (1 + n) - n ∧
+      (1 + n) * Real.log (1 + n) - n ≤ Real.log ((n + 1).factorial : ℝ) :=
+  ⟨log_factorial_le n, log_integral_le_log_factorial n⟩
+
+/-! ## Part III — The p-series convergence test -/
+
+/-- **Integral-test bound for the p-series.**  For `p > 1`, every partial sum of
+`∑ 1/(i+2)ᵖ` is bounded by `1/(p−1)`, the value of the improper integral
+`∫₁^∞ x^{−p} dx`.  This is the antitone integral test applied to `1/xᵖ`. -/
+theorem pseries_partial_sum_le (p : ℝ) (hp : 1 < p) (n : ℕ) :
+    (∑ i ∈ Finset.range n, 1 / ((i : ℝ) + 2) ^ p) ≤ 1 / (p - 1) := by
+  have hp0 : (0 : ℝ) < p := by linarith
+  have hanti : AntitoneOn (fun x : ℝ => 1 / x ^ p) (Set.Icc (1 : ℝ) (1 + n)) := by
+    intro x hx y _ hxy
+    have hx0 : (0 : ℝ) < x := lt_of_lt_of_le one_pos hx.1
+    exact one_div_le_one_div_of_le (Real.rpow_pos_of_pos hx0 p)
+      (Real.rpow_le_rpow hx0.le hxy hp0.le)
+  have hcongr : (∫ x in (1 : ℝ)..(1 + n), 1 / x ^ p)
+      = ∫ x in (1 : ℝ)..(1 + n), x ^ (-p) := by
+    refine intervalIntegral.integral_congr (fun x hx => ?_)
+    rw [Set.uIcc_of_le (le_add_of_nonneg_right (by positivity))] at hx
+    have hx0 : (0 : ℝ) < x := lt_of_lt_of_le one_pos hx.1
+    rw [Real.rpow_neg hx0.le, one_div]
+  have hint : (∫ x in (1 : ℝ)..(1 + n), 1 / x ^ p)
+      = ((1 + (n : ℝ)) ^ (-p + 1) - 1) / (-p + 1) := by
+    rw [hcongr,
+      integral_rpow (Or.inr ⟨ne_of_lt (by linarith), Set.notMem_uIcc_of_lt one_pos (by positivity)⟩),
+      Real.one_rpow]
+  have key : (∑ i ∈ Finset.range n, 1 / ((1 : ℝ) + ((i + 1 : ℕ) : ℝ)) ^ p)
+      ≤ ∫ x in (1 : ℝ)..(1 + n), 1 / x ^ p :=
+    hanti.sum_le_integral
+  rw [hint] at key
+  have hsum : (∑ i ∈ Finset.range n, 1 / ((1 : ℝ) + ((i + 1 : ℕ) : ℝ)) ^ p)
+      = ∑ i ∈ Finset.range n, 1 / ((i : ℝ) + 2) ^ p := by
+    apply Finset.sum_congr rfl
+    intro i _
+    have : (1 : ℝ) + ((i + 1 : ℕ) : ℝ) = (i : ℝ) + 2 := by push_cast; ring
+    rw [this]
+  rw [hsum] at key
+  refine key.trans ?_
+  have hA : (0 : ℝ) ≤ (1 + (n : ℝ)) ^ (-p + 1) := Real.rpow_nonneg (by positivity) _
+  have hpm : (0 : ℝ) < p - 1 := by linarith
+  have h1 : (-p + 1) ≠ 0 := by linarith
+  have h2 : (p - 1) ≠ 0 := by linarith
+  have heq : ((1 + (n : ℝ)) ^ (-p + 1) - 1) / (-p + 1)
+      = (1 - (1 + (n : ℝ)) ^ (-p + 1)) * (1 / (p - 1)) := by
+    field_simp
+    ring
+  rw [heq, sub_mul, one_mul]
+  have hmul : (0 : ℝ) ≤ (1 + (n : ℝ)) ^ (-p + 1) * (1 / (p - 1)) :=
+    mul_nonneg hA (div_nonneg zero_le_one hpm.le)
+  linarith [hmul]
+
+/-- **p-series convergence (`p > 1`), via the integral test.**  Bounded partial sums of
+nonnegative terms are summable, so `∑ 1/(i+2)ᵖ` converges — derived from
+`pseries_partial_sum_le`, not from Mathlib's condensation test. -/
+theorem pseries_summable_of_one_lt (p : ℝ) (hp : 1 < p) :
+    Summable (fun i : ℕ => 1 / ((i : ℝ) + 2) ^ p) :=
+  summable_of_sum_range_le (fun i => by positivity) (fun n => pseries_partial_sum_le p hp n)
+
+/-- **The p-series criterion.**  `∑ 1/nᵖ` converges if and only if `p > 1`.  This is the
+headline corollary of the integral test; the full two-sided statement is Mathlib's
+`Real.summable_one_div_nat_rpow`. -/
+theorem pseries_summable_iff (p : ℝ) :
+    Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) ↔ 1 < p :=
+  Real.summable_one_div_nat_rpow
+
+/-! ## Part IV — Worked witnesses -/
+
+/-- The monotone sandwich specialised to `log` on `[1, 1 + n]`. -/
+example (n : ℕ) :
+    (∑ i ∈ Finset.range n, Real.log (1 + (i : ℕ))) ≤ (∫ x in (1 : ℝ)..(1 + n), Real.log x) ∧
+      (∫ x in (1 : ℝ)..(1 + n), Real.log x) ≤
+        ∑ i ∈ Finset.range n, Real.log (1 + (i + 1 : ℕ)) :=
+  monotone_integral_sandwich (log_monotoneOn n)
+
+/-- The Basel-exponent series `∑ 1/n²` converges (`p = 2 > 1`). -/
+example : Summable (fun n : ℕ => 1 / (n : ℝ) ^ (2 : ℝ)) :=
+  (pseries_summable_iff 2).mpr (by norm_num)
+
+/-- The harmonic series `∑ 1/n` diverges (`p = 1` is not `> 1`). -/
+example : ¬ Summable (fun n : ℕ => 1 / (n : ℝ) ^ (1 : ℝ)) := by
+  intro h
+  have := (pseries_summable_iff 1).mp h
+  linarith
+
+end AntitoneIntegralSumComparisonOQ01OQ01

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-isc-oq0101-monotone-sandwich",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01",
+    "range": { "startLine": 48, "endLine": 53 },
+    "type": "theorem",
+    "title": "The Monotone Integral-Test Sandwich",
+    "content": "monotone_integral_sandwich is the companion to the parent's antitone bound. For f monotone (non-decreasing) on [x₀, x₀+a] the staircase is ordered oppositely: the left Riemann sum ∑ f(x₀+i) underestimates the integral and the right Riemann sum ∑ f(x₀+i+1) overestimates it. The proof is the pair ⟨MonotoneOn.sum_le_integral, MonotoneOn.integral_le_sum⟩.",
+    "mathContext": "\\sum_{i<a} f(x_0+i) \\;\\le\\; \\int_{x_0}^{x_0+a} f \\;\\le\\; \\sum_{i<a} f(x_0+i+1)",
+    "significance": "key",
+    "relatedConcepts": ["integral test", "Riemann sums", "monotone functions", "convergence tests"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0101-log-integral",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 66 },
+    "type": "theorem",
+    "title": "The Exact Integral of log",
+    "content": "log_integral evaluates ∫₁^{1+n} log x dx = (1+n)log(1+n) − n. The antiderivative x log x − x is supplied by Mathlib's integral_log (b log b − a log a − b + a); at a = 1 the log term vanishes (log 1 = 0) and the constant terms collapse to −n. This exact value is what the monotone sandwich traps between the two log-factorial Riemann sums.",
+    "mathContext": "\\int_1^{1+n} \\log x \\, dx = (1+n)\\log(1+n) - n",
+    "significance": "standard",
+    "relatedConcepts": ["interval integral", "logarithm", "antiderivative"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0101-sum-log-factorial",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01",
+    "range": { "startLine": 76, "endLine": 94 },
+    "type": "theorem",
+    "title": "Riemann Sums of log are Log-Factorials",
+    "content": "sum_log_eq_log_factorial and sum_log_succ_eq identify the two Riemann sums of log with log(n!) and log((n+1)!). Each turns the sum of logs into the log of a product (Real.log_prod), then matches the real product against a cast natural-number product via the factorial identities ∏_{i<n}(i+1) = n! (Mathlib) and ∏_{i<n}(i+2) = (n+1)! (proved here by induction). This is the bridge that converts the integral test for log into a statement about factorials.",
+    "mathContext": "\\sum_{i<n} \\log(1+i) = \\log(n!), \\qquad \\sum_{i<n} \\log(i+2) = \\log((n+1)!)",
+    "significance": "key",
+    "relatedConcepts": ["logarithm of product", "factorial", "Finset product"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0101-stirling-sandwich",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01",
+    "range": { "startLine": 116, "endLine": 121 },
+    "type": "theorem",
+    "title": "Stirling-Type Bounds for log n!",
+    "content": "log_factorial_sandwich conjoins the two one-sided bounds into log(n!) ≤ (1+n)log(1+n) − n ≤ log((n+1)!) — the elementary two-sided estimate underlying Stirling's approximation log(n!) ≈ n log n − n. The lower bound comes from the monotone sandwich's left sum ≤ integral; the upper bound from integral ≤ right sum. No slack needs managing on either side.",
+    "mathContext": "\\log(n!) \\;\\le\\; (1+n)\\log(1+n) - n \\;\\le\\; \\log((n+1)!)",
+    "significance": "key",
+    "relatedConcepts": ["Stirling's approximation", "factorial growth", "integral test"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0101-pseries-bound",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01",
+    "range": { "startLine": 126, "endLine": 171 },
+    "type": "theorem",
+    "title": "Integral-Test Bound for the p-Series",
+    "content": "pseries_partial_sum_le bounds every partial sum of ∑ 1/(i+2)ᵖ by 1/(p−1) when p>1. The vehicle is the antitone comparison applied to 1/xᵖ (antitone via one_div_le_one_div_of_le and Real.rpow_le_rpow); the integral is computed by rewriting 1/xᵖ = x^{−p} pointwise on the interval (intervalIntegral.integral_congr) and applying integral_rpow, giving (1−(1+n)^{1−p})/(p−1). Since (1+n)^{1−p} ≥ 0 this is ≤ 1/(p−1), the value of the improper integral ∫₁^∞ x^{−p} dx.",
+    "mathContext": "\\sum_{i<n} \\frac{1}{(i+2)^p} \\;\\le\\; \\int_1^\\infty x^{-p}\\,dx = \\frac{1}{p-1} \\quad (p>1)",
+    "significance": "key",
+    "relatedConcepts": ["p-series", "improper integral", "real power", "integral test"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0101-pseries-criterion",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01",
+    "range": { "startLine": 173, "endLine": 182 },
+    "type": "theorem",
+    "title": "The p-Series Criterion",
+    "content": "pseries_summable_of_one_lt concludes convergence for p>1 by feeding the uniform partial-sum bound to summable_of_sum_range_le (bounded partial sums of nonnegative terms are summable) — an integral-test derivation independent of Mathlib's Cauchy-condensation proof. pseries_summable_iff then records the full two-sided criterion ∑ 1/nᵖ converges ⟺ p>1 via Mathlib's Real.summable_one_div_nat_rpow, completing the parent's requested corollary.",
+    "mathContext": "\\sum_{n} \\frac{1}{n^p} \\text{ converges} \\iff p > 1",
+    "significance": "key",
+    "relatedConcepts": ["p-series", "summability", "convergence test"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01/meta.json
@@ -1,0 +1,76 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-01",
+  "title": "The Monotone Integral Test: Stirling Bounds for log n! and the p-Series Criterion",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-01",
+  "description": "Answers the parent's open question by building the monotone (increasing) companion to its antitone integral-test sandwich and using the comparison framework on two showcase integrands. The monotone sandwich ∑_{i<a} f(x₀+i) ≤ ∫_{x₀}^{x₀+a} f ≤ ∑_{i<a} f(x₀+i+1) applied to log x gives the elementary Stirling-type bounds log(n!) ≤ (1+n)log(1+n) − n ≤ log((n+1)!); the antitone test applied to 1/xᵖ bounds the partial sums of ∑ 1/iᵖ by 1/(p−1) = ∫₁^∞ x^{−p} dx, yielding convergence for p>1 directly from the comparison. The full criterion ∑ 1/nᵖ converges ⟺ p>1 is recorded via Mathlib's Real.summable_one_div_nat_rpow. 12 theorems, 0 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Integral_test_for_convergence",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "p-series",
+      "stirling",
+      "log-factorial",
+      "riemann-sums",
+      "monotone",
+      "convergence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the foundational propext / Classical.choice / Quot.sound).",
+    "lineCount": 203,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "originalContributions": [
+      "monotone_integral_sandwich: the two-sided integral-test comparison for a monotone (non-decreasing) f on [x₀, x₀+a] — the mirror of the parent's antitone bound, bundling MonotoneOn.sum_le_integral and MonotoneOn.integral_le_sum",
+      "log_monotoneOn / log_integral: log is monotone on [1,1+n] and ∫₁^{1+n} log x dx = (1+n)log(1+n) − n (via integral_log)",
+      "sum_log_eq_log_factorial / sum_log_succ_eq: the two Riemann sums of log are log(n!) and log((n+1)!) (via Real.log_prod and the product identities ∏_{i<n}(i+1)=n!, ∏_{i<n}(i+2)=(n+1)!)",
+      "log_factorial_le / log_integral_le_log_factorial / log_factorial_sandwich: the Stirling-type sandwich log(n!) ≤ (1+n)log(1+n) − n ≤ log((n+1)!)",
+      "pseries_partial_sum_le: the integral-test bound ∑_{i<n} 1/(i+2)ᵖ ≤ 1/(p−1) for p>1, from the antitone comparison applied to 1/xᵖ and integral_rpow",
+      "pseries_summable_of_one_lt: p-series convergence for p>1 derived from bounded partial sums (summable_of_sum_range_le) — the integral-test route, not Mathlib's condensation test",
+      "pseries_summable_iff: the full criterion ∑ 1/nᵖ converges ⟺ p>1, recorded via Real.summable_one_div_nat_rpow"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral test compares a series ∑ f(n) with the integral ∫ f. The parent entry handled the decreasing case (1/x → harmonic numbers). Its natural partner is the increasing case: applying the same staircase comparison to a monotone integrand. The archetypal increasing application is log x, whose sum is log of a factorial — so the monotone integral test turns directly into the elementary form of Stirling's approximation, log(n!) ≈ n log n − n. The same comparison machinery, run on the decreasing 1/xᵖ, produces the p-series test, the cleanest classical criterion separating convergent from divergent series.",
+    "problemStatement": "Derive the monotone companion to the antitone integral-test sandwich, and use the comparison framework to obtain (a) Stirling-type bounds on log(n!) and (b) the p-series criterion ∑ 1/iᵖ converges iff p>1.",
+    "text": "For monotone (non-decreasing) f on [x₀,x₀+a] the staircase is ordered oppositely to the antitone case: on each subinterval the left value is the lower bound and the right value the upper, so ∑ f(x₀+i) ≤ ∫ f ≤ ∑ f(x₀+i+1). Mathlib provides both halves (MonotoneOn.sum_le_integral, MonotoneOn.integral_le_sum). Applied to log on [1,1+n], the integral is (1+n)log(1+n) − n (integral_log) and the two Riemann sums are exactly log(n!) and log((n+1)!), giving the Stirling sandwich. For the decreasing 1/xᵖ on [1,1+n] the antitone bound gives ∑_{i<n} 1/(i+2)ᵖ ≤ ∫₁^{1+n} x^{−p} dx = (1−(1+n)^{1−p})/(p−1) ≤ 1/(p−1); bounded partial sums of nonnegative terms are summable, so the p-series converges for p>1. The divergent direction completes the iff via Mathlib's p-series lemma.",
+    "proofStrategy": "Part I bundles the two Mathlib monotone one-sided bounds into monotone_integral_sandwich. Part II proves the log specialization: log_monotoneOn (Real.log_le_log on the positives), log_integral (integral_log with log 1 = 0), and the two sum-to-log-factorial identities sum_log_eq_log_factorial and sum_log_succ_eq (each via Real.log_prod after turning the real product into a cast natural product, ∏(i+1)=n! and ∏(i+2)=(n+1)!), then reads off log_factorial_le / log_integral_le_log_factorial and conjoins them as log_factorial_sandwich. Part III proves pseries_partial_sum_le: 1/xᵖ is antitone (one_div_le_one_div_of_le with Real.rpow_le_rpow), its integral is computed by rewriting 1/xᵖ = x^{−p} on the interval (intervalIntegral.integral_congr) and applying integral_rpow, and the resulting value is bounded by 1/(p−1) since (1+n)^{1−p} ≥ 0; pseries_summable_of_one_lt feeds this bound to summable_of_sum_range_le; pseries_summable_iff records the full criterion from Mathlib. Part IV gives worked witnesses (the log sandwich, ∑1/n² convergent, ∑1/n divergent).",
+    "keyInsights": [
+      "Monotonicity reverses the staircase order relative to the antitone case: for increasing f the left Riemann sum is the lower bound and the right sum the upper bound",
+      "The increasing partner of the parent's 1/x is log x — and the integral test then reads off as the elementary Stirling estimate, because ∑ log = log ∏ = log of a factorial",
+      "The exact integral ∫₁^{1+n} log x dx = (1+n)log(1+n) − n is sandwiched between log(n!) and log((n+1)!), with no slack to manage on either side",
+      "The same comparison run on the decreasing 1/xᵖ gives the integral test for the p-series; the improper integral's finite value 1/(p−1) is exactly the uniform bound on the partial sums",
+      "Convergence for p>1 follows from bounded partial sums of nonnegative terms — an integral-test derivation independent of Mathlib's Cauchy-condensation proof"
+    ],
+    "prerequisites": [
+      "Monotone / MonotoneOn functions and the monotone integral-sum bounds",
+      "Interval integrals: ∫ log x and ∫ xʳ (integral_log, integral_rpow)",
+      "Real powers (rpow), Real.log_prod, and factorial product identities",
+      "Summability from bounded partial sums (summable_of_sum_range_le) and the p-series criterion"
+    ]
+  },
+  "conclusion": {
+    "summary": "The monotone integral-test sandwich is established as the companion to the parent's antitone bound, and applied to log x to give the Stirling-type estimate log(n!) ≤ (1+n)log(1+n) − n ≤ log((n+1)!). The antitone test on 1/xᵖ bounds the p-series partial sums by 1/(p−1), giving convergence for p>1 directly from the comparison; the full criterion ∑ 1/nᵖ converges ⟺ p>1 is recorded via Mathlib. 12 theorems, 0 definitions, 203 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the integral-test infrastructure begun in the parent: both monotone directions are now packaged, and the two canonical applications (Stirling's log-factorial bounds; the p-series criterion) are demonstrated within the comparison framework. The monotone sandwich applies to any increasing summand, and the partial-sum bound technique generalizes to other comparison-test convergence proofs.",
+    "openQuestions": [
+      "Sharpen the Stirling bounds to the full asymptotic log(n!) = n log n − n + ½ log(2πn) + o(1) by adding the Euler–Maclaurin correction term",
+      "Derive the explicit error/remainder bound for the p-series tail ∑_{i≥N} 1/iᵖ ≤ N^{1−p}/(p−1) from the same integral comparison"
+    ]
+  },
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ01",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent `antitone-integral-sum-comparison-oq-01`:
> "Derive the analogous monotone sandwich and a p-series corollary (∑ 1/iᵖ convergent iff p > 1) from MonotoneOn.sum_le_integral / integral_le_sum."

### Part I — Monotone integral-test sandwich
The mirror of the parent's antitone bound. For `f` monotone (non-decreasing) on `[x₀, x₀+a]`:
```
∑_{i<a} f(x₀+i)  ≤  ∫_{x₀}^{x₀+a} f  ≤  ∑_{i<a} f(x₀+i+1)
```
bundling Mathlib's `MonotoneOn.sum_le_integral` and `MonotoneOn.integral_le_sum`.

### Part II — Stirling-type bounds on `log n!`
Applying the monotone sandwich to `log x` (the increasing partner of the parent's decreasing `1/x`) with `∫₁^{1+n} log x dx = (1+n)log(1+n) − n`:
```
log(n!)  ≤  (1+n) log(1+n) − n  ≤  log((n+1)!)
```
The Riemann sums of `log` are identified with log-factorials via `Real.log_prod` and the product identities `∏(i+1)=n!`, `∏(i+2)=(n+1)!`.

### Part III — The p-series criterion
The antitone test on `1/xᵖ` bounds the partial sums `∑ 1/(i+2)ᵖ ≤ 1/(p−1) = ∫₁^∞ x^{−p} dx` for `p>1` (via `integral_rpow`), giving convergence from `summable_of_sum_range_le` — an integral-test route independent of Mathlib's condensation proof. The full criterion `∑ 1/nᵖ` converges ⟺ `p>1` is recorded via `Real.summable_one_div_nat_rpow`.

## Verification
- **12 theorems, 0 definitions, 203 lines**
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`
- Typechecked against Mathlib (Lean v4.26.0)

Files: `proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01.lean`, gallery `meta.json` + `annotations.json`, `Proofs.lean` import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)