### PR TITLE
Enrich Finite Arithmetico-Geometric Sum (∑ k·xᵏ)

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-geom-sum-closed",
+    "proofId": "geometric-series-oq-08-oq-01",
+    "range": { "startLine": 71, "endLine": 77 },
+    "type": "context",
+    "title": "The Unweighted Building Block",
+    "content": "`geom_sum_closed` records the ordinary finite geometric sum ∑_{k<n} xᵏ = (1 − xⁿ)/(1 − x) for x ≠ 1. It is a thin wrapper of Mathlib's `geom_sum_eq`, which states the same fact in the (xⁿ − 1)/(x − 1) convention; the rewrite to the (1 − xⁿ)/(1 − x) form is closed by `field_simp; ring` after recording both x − 1 ≠ 0 and 1 − x ≠ 0. This is the k⁰-weighted case (k raised to the power 0 is 1) that the arithmetico-geometric sum refines by inserting the index weight k. Seeing it alongside the weighted sum makes the structural pattern visible: weight 1 gives a denominator (1 − x), weight k gives (1 − x)².",
+    "mathContext": "$\\sum_{k=0}^{n-1} x^k = \\dfrac{1 - x^n}{1 - x}$ for $x \\ne 1$.",
+    "significance": "context",
+    "relatedConcepts": ["finite geometric series", "geom_sum_eq", "telescoping"],
+    "prerequisites": ["geometric series", "field arithmetic"]
+  },
+  {
+    "id": "ann-arith-geom-mul",
+    "proofId": "geometric-series-oq-08-oq-01",
+    "range": { "startLine": 81, "endLine": 94 },
+    "type": "technique",
+    "title": "The Division-Free Ring Identity by Induction",
+    "content": "`arith_geom_mul` is the mathematical heart of the entry: (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x), valid over ANY commutative ring. Keeping the (1 − x)² factor on the left — rather than dividing — is exactly what makes the statement ring-valid with no invertibility hypothesis. The proof is induction on n: the base case is 0 = 0 (`simp`), and the successor step peels the top term k = n with `Finset.sum_range_succ`, rewrites the remaining sum by the induction hypothesis with `mul_add`, then discharges the polynomial identity f(n) + (1 − x)²·n·xⁿ = f(n+1) by `push_cast; ring`. This deliberately avoids the classical perturbation ('shift and subtract') derivation, which implicitly divides by (1 − x) and so would only work over a field.",
+    "mathContext": "$(1-x)^2 \\sum_{k=0}^{n-1} k\\,x^k = x(1-x^n) - n\\,x^n(1-x)$ over any commutative ring.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetico-geometric series", "induction", "Finset.sum_range_succ", "perturbation method", "commutative ring"],
+    "prerequisites": ["mathematical induction", "polynomial identities", "Finset sums"]
+  },
+  {
+    "id": "ann-arith-geom-div",
+    "proofId": "geometric-series-oq-08-oq-01",
+    "range": { "startLine": 96, "endLine": 104 },
+    "type": "technique",
+    "title": "Clearing the Denominator to the Field Form",
+    "content": "`arith_geom_div` upgrades the ring identity to the familiar quotient form ∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)² whenever x ≠ 1. The step is purely formal: 1 − x ≠ 0 follows from x ≠ 1 via `sub_ne_zero`, so (1 − x)² ≠ 0 by `pow_ne_zero`, and `eq_div_iff` converts the goal into the multiplied-through identity `arith_geom_mul` already supplies (after a `mul_comm` to align the factor order). The denominator (1 − x)² — one power higher than the unweighted (1 − x) — is the visible signature of the linear weight k.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k\\,x^k = \\dfrac{x(1-x^n) - n\\,x^n(1-x)}{(1-x)^2}$ for $x \\ne 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["field arithmetic", "eq_div_iff", "denominator clearing", "pow_ne_zero"],
+    "prerequisites": ["field theory", "fractions"]
+  },
+  {
+    "id": "ann-arith-geom-two",
+    "proofId": "geometric-series-oq-08-oq-01",
+    "range": { "startLine": 114, "endLine": 134 },
+    "type": "insight",
+    "title": "The Integer Specialisation ∑ k·2ᵏ = (n − 2)·2ⁿ + 2",
+    "content": "Substituting x = 2 yields ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2. What makes this case striking is that the geometric series with ratio 2 diverges, yet the FINITE closed form is perfectly clean: (1 − 2)² = 1 erases the denominator entirely, leaving a polynomial-in-2ⁿ expression over ℤ. This illustrates the entry's central point — the identity is algebraic, not analytic, so it holds regardless of convergence. `arith_geom_two_four` (= 34 at n = 4: 0·1 + 1·2 + 2·4 + 3·8) and `arith_geom_three_three` (x = 3, n = 3: 0 + 3 + 18 = 21, equivalently 84/4) are concrete `norm_num` witnesses guarding the sign conventions.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k\\,2^k = (n-2)\\,2^n + 2$; e.g. $n=4$ gives $0+2+8+24 = 34$.",
+    "significance": "supporting",
+    "relatedConcepts": ["arithmetico-geometric series", "divergent ratio", "norm_num", "integer identities"],
+    "prerequisites": ["powers of two", "arithmetic"]
+  },
+  {
+    "id": "ann-tsum-arith-geom",
+    "proofId": "geometric-series-oq-08-oq-01",
+    "range": { "startLine": 138, "endLine": 145 },
+    "type": "concept",
+    "title": "Recovering the Infinite Limit",
+    "content": "`tsum_arith_geom` records the infinite arithmetico-geometric sum ∑' k, k·xᵏ = x/(1 − x)² for |x| < 1 over ℝ, obtained directly from Mathlib's `tsum_coe_mul_geometric_of_norm_lt_one` (after converting |x| < 1 to ‖x‖ < 1). This closes the loop with the finite closed form: as n → ∞ the truncation tails xⁿ and n·xⁿ both tend to 0 (geometric decay dominates linear growth), so the finite numerator x·(1 − xⁿ) − n·xⁿ·(1 − x) → x and the finite value approaches x/(1 − x)². The finite identity is therefore strictly stronger — it carries the explicit truncation error that the analytic limit discards.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} k\\,x^k = \\dfrac{x}{(1-x)^2}$ for $\\lVert x \\rVert < 1$, the $n \\to \\infty$ limit of the finite form.",
+    "significance": "key",
+    "relatedConcepts": ["infinite series", "tsum", "convergence", "tsum_coe_mul_geometric_of_norm_lt_one", "truncation error"],
+    "prerequisites": ["real analysis", "convergence of series", "limits"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "Finite Arithmetico-Geometric Sum: a Closed Form for ∑ k·xᵏ",
+  "description": "The finite arithmetico-geometric sum ∑_{k<n} k·xᵏ — each geometric term xᵏ weighted by its index k — has the division-free closed form (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x) over any commutative ring, with the field form over (1 − x)², the specialisation ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2, and consistency with Mathlib's infinite weighted series x/(1 − x)² recovered as n → ∞.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -65,6 +66,55 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Arithmetico-geometric sequences — terms that are products of an arithmetic progression (here the index k) and a geometric one (here xᵏ) — were studied systematically in the 18th and 19th centuries; the closed form for ∑ k·xᵏ is the prototypical example and appears in the work of Euler on power series. The standard hand derivation is the perturbation (or 'shift and subtract') method popularised in Graham, Knuth & Patashnik's Concrete Mathematics: multiply the sum by x, subtract from the original, and the arithmetic weights collapse to a plain geometric series. The same identity is the engine behind the classical actuarial formulas for the present value of an increasing annuity (Fibonacci-era commercial arithmetic onward) and behind the mean of a geometric distribution. Mathlib formalises the analytic infinite version ∑' k, k·rᵏ = r/(1 − r)² but, until this entry, not the purely algebraic finite truncation that every application of a truncated weighted series actually needs.",
+    "problemStatement": "For a length $n$ and a ratio $x$ in any commutative ring, evaluate the finite arithmetico-geometric sum $\\sum_{k=0}^{n-1} k\\,x^k$ in closed form. The target is the division-free identity $(1-x)^2 \\sum_{k=0}^{n-1} k\\,x^k = x(1-x^n) - n\\,x^n(1-x)$, valid over every commutative ring, together with its field specialisation $\\sum_{k=0}^{n-1} k\\,x^k = \\dfrac{x(1-x^n) - n\\,x^n(1-x)}{(1-x)^2}$ for $x \\ne 1$, and the consistency check that as $n \\to \\infty$ with $\\lVert x \\rVert < 1$ the value tends to $\\dfrac{x}{(1-x)^2}$.",
+    "proofStrategy": "The heart of the proof is the ring identity arith_geom_mul, established by induction on n rather than by the perturbation trick (which divides). The inductive step peels the top term with Finset.sum_range_succ, applies the induction hypothesis, and then discharges the resulting polynomial identity f(n) + (1 − x)²·n·xⁿ = f(n+1) — where f(n) = x·(1 − xⁿ) − n·xⁿ·(1 − x) — by push_cast; ring. Keeping the identity in the multiplied-through form (1 − x)²·∑ = … is what makes it hold over an arbitrary commutative ring with no invertibility hypothesis. The field form arith_geom_div is then a one-line consequence: clear the nonzero denominator (1 − x)² with eq_div_iff. Specialisations substitute concrete x (x = 2 makes (1 − x)² = 1, eliminating the denominator) and the infinite limit quotes Mathlib's tsum_coe_mul_geometric_of_norm_lt_one.",
+    "keyInsights": [
+      "Inserting the linear weight k into the geometric sum ∑ xᵏ raises the order of the denominator from (1 − x) to (1 − x)²; each extra polynomial factor of k in the weight adds one more factor of (1 − x), so ∑ kᵐ·xᵏ lives over (1 − x)^{m+1}. This is the m = 1 member of that hierarchy.",
+      "Stating the result in the multiplied-through form (1 − x)²·∑ = x(1 − xⁿ) − n·xⁿ(1 − x) removes all division, so the identity becomes a polynomial fact valid over every commutative ring — not just fields — and the analytic, field, and integer cases all fall out as specialisations of one algebraic lemma.",
+      "Induction sidesteps the classical perturbation ('shift and subtract') derivation: the textbook method implicitly divides by (1 − x), whereas push_cast; ring on the peeled-off Finset.sum_range_succ term verifies the identity with no invertibility assumption at all.",
+      "The finite closed form contains the infinite one: as n → ∞ with ‖x‖ < 1 the tail terms xⁿ and n·xⁿ both vanish, leaving exactly the numerator x and recovering Mathlib's ∑' k, k·xᵏ = x/(1 − x)². The finite identity is therefore strictly more informative than the analytic limit, retaining the explicit O(n·xⁿ) truncation error.",
+      "The x = 2 case ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2 shows the formula survives where the geometric series diverges: the denominator (1 − 2)² = 1 disappears and the identity becomes a clean statement over ℤ, illustrating that the algebraic content is independent of any convergence."
+    ]
+  },
+  "sections": [
+    {
+      "id": "geom-sum-building-block",
+      "title": "The Plain Finite Geometric Sum (Building Block)",
+      "startLine": 65,
+      "endLine": 77,
+      "summary": "geom_sum_closed records the unweighted finite geometric sum ∑_{k<n} xᵏ = (1 − xⁿ)/(1 − x) for x ≠ 1, a thin wrapper of Mathlib's geom_sum_eq rewritten from the (xⁿ − 1)/(x − 1) convention via field_simp; ring. This is the k⁰-weighted case that the arithmetico-geometric sum refines by inserting the weight k."
+    },
+    {
+      "id": "ring-identity",
+      "title": "The Division-Free Ring Identity",
+      "startLine": 79,
+      "endLine": 94,
+      "summary": "arith_geom_mul is the core result: (1 − x)²·∑_{k<n} k·xᵏ = x·(1 − xⁿ) − n·xⁿ·(1 − x) over any commutative ring. Proved by induction on n; the successor step peels the top term with Finset.sum_range_succ, rewrites by the induction hypothesis, and closes the polynomial identity with push_cast; ring."
+    },
+    {
+      "id": "field-form",
+      "title": "The Field Closed Form",
+      "startLine": 96,
+      "endLine": 110,
+      "summary": "arith_geom_div divides the ring identity by the nonzero (1 − x)² (from x ≠ 1, via eq_div_iff and pow_ne_zero) to give ∑_{k<n} k·xᵏ = (x·(1 − xⁿ) − n·xⁿ·(1 − x))/(1 − x)². arith_geom_mul_one is a guard checking both sides vanish at n = 1, protecting against off-by-one sign errors."
+    },
+    {
+      "id": "specialisations",
+      "title": "Specialisations and Numerical Witnesses",
+      "startLine": 112,
+      "endLine": 134,
+      "summary": "arith_geom_two derives the integer formula ∑_{k<n} k·2ᵏ = (n − 2)·2ⁿ + 2 (where (1 − 2)² = 1 erases the denominator), with arith_geom_two_four (= 34 at n = 4) and arith_geom_three_three (x = 3, n = 3, = 21) as concrete numerical checks of the closed form."
+    },
+    {
+      "id": "infinite-limit",
+      "title": "The Infinite Limit (Consistency with Mathlib)",
+      "startLine": 136,
+      "endLine": 147,
+      "summary": "tsum_arith_geom records the infinite arithmetico-geometric sum ∑' k, k·xᵏ = x/(1 − x)² for |x| < 1 over ℝ, quoting Mathlib's tsum_coe_mul_geometric_of_norm_lt_one. The finite closed form recovers this as n → ∞ because xⁿ → 0 and n·xⁿ → 0, so the numerator tends to x."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08-oq-01`.

This entry previously had only a bare `meta.json` (no description, overview, sections, or annotations). Added:

- **Top-level `description`** — was missing entirely; the gallery page rendered without one.
- **`overview`** — `historicalContext` (arithmetico-geometric sequences, the perturbation/'shift-and-subtract' method from Concrete Mathematics, annuity & geometric-distribution applications), `problemStatement` (LaTeX), `proofStrategy`, and 5 `keyInsights` on the (1−x)^{m+1} denominator hierarchy, ring-validity of the multiplied-through form, induction vs. perturbation, and the finite→infinite limit.
- **`sections`** — 5 sections covering all 147 lines (building block, ring identity, field form, specialisations, infinite limit).
- **`annotations.json`** — 5 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering `geom_sum_closed`, `arith_geom_mul`, `arith_geom_div`, `arith_geom_two`, and `tsum_arith_geom`.

Axiom integrity: meta.json status `verified`, badge `original`, axiomCount 0 — consistent with the Lean source (0 sorries, 0 axioms, 0 assumption-carrying structures). No `index.ts` added: the gallery loader now uses fetch-by-slug via data-manifest (phase-2 build-perf fix, #20993), so per-proof `index.ts` shims are no longer used.

Mathematical content verified against the Lean source.