### PR TITLE
Enrich Second-order Arithmetico-Geometric Sum: a Closed Form for ∑ k²·xᵏ

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/index.ts
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ08OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ08OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ08OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ08OQ01OQ01Data: ProofData = {
+  proof: geometricSeriesOQ08OQ01OQ01Proof,
+  annotations: geometricSeriesOQ08OQ01OQ01Annotations,
+}


### PR DESCRIPTION
## Summary

Enrichment pass for `geometric-series-oq-08-oq-01-oq-01` (*Second-order Arithmetico-Geometric Sum: a Closed Form for ∑ k²·xᵏ*). The entry previously had only `meta.json` (no overview, sections, annotations, or index.ts).

## Changes
- **description**: top-level summary of the division-free closed form and its place in the ∑ kᵐ·xᵏ family.
- **overview**: `historicalContext` (Concrete Mathematics, the precise Mathlib gap), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (the ring-cast trick keeping n = 0 well-defined; the (1−x)^{m+1} denominator pattern; the finite form containing the infinite limit).
- **sections**: 3 sections covering the full Lean file (ring/field closed forms; specialisations + numeric witnesses; the infinite-limit note).
- **annotations.json**: 7 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts**: created the missing Vite entry point (without it the page renders 'proof not found').

## Verification
- JSON validated for both files.
- Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 sorries, 0 axioms; propext/Classical.choice/Quot.sound only).