### PR TITLE
Fix: remove stale '(still has 1 sorry)' in ballot-problem-oq-01 annotation

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01/annotations.json
@@ -122,7 +122,7 @@
     },
     "type": "concept",
     "title": "The Generalized Ballot Theorem Statement",
-    "content": "The main theorem statements: `generalized_ballot_count` asserts the counting formula via double counting (still has 1 sorry), while `generalized_ballot_prob` proves the probability $(a - kb)/(a + b) > 0$ when $a > kb$. Verified special cases include $(5, 2, 2) \\to 1/7$, $(10, 3, 3) \\to 1/13$, $(3, 1, 1) \\to 1/2$, and $(7, 2, 3) \\to 1/10$.",
+    "content": "The main theorem statements: `generalized_ballot_count` asserts the counting formula via double counting (fully proved), while `generalized_ballot_prob` proves the probability $(a - kb)/(a + b) > 0$ when $a > kb$. Verified special cases include $(5, 2, 2) \\to 1/7$, $(10, 3, 3) \\to 1/13$, $(3, 1, 1) \\to 1/2$, and $(7, 2, 3) \\to 1/10$.",
     "mathContext": "$$P(\\text{A leads throughout}) = \\frac{a - kb}{a + b} > 0 \\quad \\text{when } a > kb$$",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Fix

Remove the stale `(still has 1 sorry)` parenthetical from the `ballot-problem-oq-01` annotation describing `generalized_ballot_count`.

## Evidence

**Before**: annotations.json said `generalized_ballot_count` "asserts the counting formula via double counting (still has 1 sorry)".

**After**: "(fully proved)" — matching reality. `generalized_ballot_count` (`proofs/Proofs/BallotProblemOQ01.lean:226`) is proved with a complete `calc`-chain (ends L244, no `sorry`). The entry is `status: verified`, `sorries: 0`, and the whole file is 0-sorry (comment-stripped scan confirms).

Single-line annotation edit; no Lean or meta status changes.

---
Automated fix by lean-mechanic agent.