### PR TITLE
Enrich Unifying the Weight Family: a Recurrence for the Finite m-th Moment ∑ kᵐ·xᵏ

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview-unification",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 69 },
+    "type": "context",
+    "title": "One Recurrence for the Whole Weight Family",
+    "content": "The gallery built the weighted-geometric family ∑_{k<n} kᵐ·xᵏ one moment at a time — m = 0 (geometric-series-oq-08), m = 1 (geometric-series-oq-08-oq-01), m = 2 (parent geometric-series-oq-08-oq-01-oq-01), each with its own closed form over (1−x)^{m+1}. This entry unifies them with a single division-free recurrence (★) valid for every m over every commutative ring. The honest scope of a fully general statement is a recurrence, not one explicit formula: the finite sum's boundary term nᵐ·xⁿ has no m-independent closed form, so (★) is the sharpest uniform identity.",
+    "mathContext": "$(1-x)\\,\\mathrm{momentSum}\\,m\\,n\\,x = 0^m - n^m x^n + x\\sum_{i<m}\\binom{m}{i}\\mathrm{momentSum}\\,i\\,n\\,x$.",
+    "significance": "context",
+    "relatedConcepts": ["arithmetico-geometric series", "moments", "Eulerian polynomial", "recurrence"],
+    "prerequisites": ["geometric series", "finite sums"]
+  },
+  {
+    "id": "ann-definition",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 79 },
+    "type": "definition",
+    "title": "The Finite m-th Moment Sum",
+    "content": "`momentSum m n x = ∑_{k ∈ range n} (k:R)ᵐ·xᵏ`, a single definition over any commutative ring R, uniform in the exponent m. Writing the index as a ring cast (k:R) keeps the definition well-defined for all m (including m = 0, where 0⁰ = 1 in the ring) and lets the same object stand for the unweighted geometric sum (m = 0), the linear arithmetico-geometric sum (m = 1), and all higher moments at once.",
+    "mathContext": "$\\mathrm{momentSum}\\,m\\,n\\,x=\\sum_{k\\in\\mathrm{range}\\,n}(k{:}R)^m x^k$ over any $\\mathrm{CommRing}\\,R$.",
+    "significance": "supporting",
+    "relatedConcepts": ["weighted sum", "uniform definition", "commutative ring"],
+    "prerequisites": ["Finset sums"]
+  },
+  {
+    "id": "ann-binomial-helper",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 90 },
+    "type": "theorem",
+    "title": "Binomial Helper: ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ",
+    "content": "`sum_choose_mul_pow`: the algebraic engine of the recurrence. The full binomial sum ∑_{i<m+1} C(m,i)·aⁱ·1^{m−i} = (a+1)ᵐ (from add_pow at y = 1); peeling its top term C(m,m)·aᵐ = aᵐ with Finset.sum_range_succ leaves ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ. This is exactly the shape needed to turn the telescoped increment (n+1)ᵐ − nᵐ into the coupling across lower moments in the induction step.",
+    "mathContext": "$\\sum_{i<m}\\binom{m}{i}a^i = (a+1)^m - a^m$, from $(a+1)^m=\\sum_{i\\le m}\\binom{m}{i}a^i$ minus the top term $a^m$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial theorem", "add_pow", "partial binomial sum", "telescoping"],
+    "prerequisites": ["binomial theorem", "Finset sums"]
+  },
+  {
+    "id": "ann-momentsum-succ",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 95 },
+    "type": "technique",
+    "title": "Top-Term Peel",
+    "content": "`momentSum_succ`: momentSum m (n+1) x = momentSum m n x + nᵐ·xⁿ, immediate from Finset.sum_range_succ. The inductive workhorse: every momentSum at length n+1 in the recurrence proof is rewritten by this lemma to expose the new top term nᵐ·xⁿ, which is precisely the boundary contribution the master recurrence tracks.",
+    "mathContext": "$\\mathrm{momentSum}\\,m\\,(n{+}1)\\,x = \\mathrm{momentSum}\\,m\\,n\\,x + n^m x^n$.",
+    "significance": "technical",
+    "relatedConcepts": ["Finset.sum_range_succ", "induction step", "boundary term"],
+    "prerequisites": ["finite sums"]
+  },
+  {
+    "id": "ann-master-recurrence",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 129 },
+    "type": "theorem",
+    "title": "The Master Recurrence (★)",
+    "content": "`momentSum_recurrence`: (1−x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x, over any commutative ring, uniform in m. Proved by induction on n. The step expands the interior sum at n+1 (hsig): each C(m,i)·momentSum i (n+1) x splits via momentSum_succ into the n-version plus C(m,i)·nⁱ·xⁿ, and Finset.sum_add_distrib + the binomial helper collapse ∑_{i<m} C(m,i)·nⁱ to (n+1)ᵐ − nᵐ. push_cast and linear_combination against the hypothesis close it. Reduces moment m to ALL lower moments because (k+1)ᵐ couples to every i < m via C(m,i).",
+    "mathContext": "$(1-x)\\,\\mathrm{momentSum}\\,m\\,n\\,x = 0^m - n^m x^n + x\\sum_{i<m}\\binom{m}{i}\\mathrm{momentSum}\\,i\\,n\\,x$; iterating clears $(1-x)^{m+1}$.",
+    "significance": "critical",
+    "relatedConcepts": ["induction", "linear_combination", "moment coupling", "division-free identity"],
+    "prerequisites": ["induction", "binomial coefficients", "Finset manipulation"]
+  },
+  {
+    "id": "ann-specialisations",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 131, "endLine": 155 },
+    "type": "theorem",
+    "title": "Specialisations m = 0, 1, 2",
+    "content": "Instantiating (★) recovers the gallery's known forms. `momentSum_recurrence_zero`: (1−x)·∑_{k<n} xᵏ = 1 − xⁿ (the plain finite geometric sum). `momentSum_recurrence_one`: (1−x)·∑_{k<n} k·xᵏ = −n·xⁿ + x·∑_{k<n} xᵏ. `momentSum_recurrence_two`: (1−x)·∑_{k<n} k²·xᵏ = −n²·xⁿ + x·(∑_{k<n} xᵏ + 2·∑_{k<n} k·xᵏ). Each evaluates the short binomial sum (Finset.sum_range_one, sum_range_succ) and finishes by ring. Multiplying the m = 1, 2 lines by (1−x), (1−x)² reproduces the parents' (1−x)², (1−x)³ closed forms.",
+    "mathContext": "$m{=}0{:}\\,(1{-}x)\\sum x^k=1{-}x^n$; $m{=}1{:}\\,-nx^n+x\\sum x^k$; $m{=}2{:}\\,-n^2x^n+x(\\sum x^k+2\\sum kx^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["specialisation", "geometric sum", "recovering ancestors", "(1-x)^{m+1}"],
+    "prerequisites": ["substitution", "finite sums"]
+  },
+  {
+    "id": "ann-numeric",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01",
+    "range": { "startLine": 157, "endLine": 161 },
+    "type": "technique",
+    "title": "Numerical Sanity Check",
+    "content": "An example over ℤ anchors the recurrence to arithmetic: ∑_{k<3} k·2ᵏ = 0 + 1·2 + 2·4 = 10, and the m = 1 recurrence gives (1−2)·10 = 0 − 3·8 + 2·(1+2+4) = −10 consistently. Closed by norm_num [momentSum, Finset.sum_range_succ]. A cheap guard that the uniform recurrence and the definition agree on a concrete instance.",
+    "mathContext": "$\\sum_{k<3}k\\cdot 2^k = 2+8 = 10$; the $m=1$ recurrence checks $(1-2)\\cdot 10=-10$.",
+    "significance": "technical",
+    "relatedConcepts": ["numerical verification", "norm_num", "consistency check"],
+    "prerequisites": ["arithmetic"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ08OQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ08OQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ08OQ01OQ01OQ01Data: ProofData = {
+  proof: geometricSeriesOQ08OQ01OQ01OQ01Proof,
+  annotations: geometricSeriesOQ08OQ01OQ01OQ01Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01/meta.json
@@ -18,6 +18,45 @@
     "sorries": 0
   },
   "title": "Unifying the Weight Family: a Recurrence for the Finite m-th Moment ∑ kᵐ·xᵏ",
+  "description": "A single division-free master recurrence, uniform in the exponent m and valid over any commutative ring, for the finite m-th moment weighted geometric sum momentSum m n x = ∑_{k<n} kᵐ·xᵏ: (1−x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x. It reduces the m-th finite moment to ALL lower moments in one step; iterating clears the denominator (1−x)^{m+1}, and its interior part is the Eulerian-polynomial recurrence in the n → ∞ limit. The m = 0, 1, 2 specialisations recover the gallery's (1−x), (1−x)², (1−x)³ closed forms. The honest scope of a fully general single statement is a recurrence — the finite sum's n-dependent boundary term nᵐ·xⁿ has no m-independent closed form.",
+  "overview": {
+    "historicalContext": "Weighted geometric sums ∑ kᵐ·xᵏ — the arithmetico-geometric family — are classical, with the perturbation and generating-function methods catalogued in Graham–Knuth–Patashnik's Concrete Mathematics and their numerators governed by the Eulerian numbers. The gallery had built the family one moment at a time: m = 0 (plain finite geometric sum, geometric-series-oq-08), m = 1 (linear, geometric-series-oq-08-oq-01), and m = 2 (the parent, geometric-series-oq-08-oq-01-oq-01), each with its own explicit closed form over (1−x)^{m+1}. The open question those entries left was whether the whole family could be captured uniformly. This entry answers it: a single recurrence valid for every m over every commutative ring. Mathlib records the infinite linear and binomial-weighted geometric series and the plain finite geometric sum geom_sum_eq, but no finite m-th moment sum and no recurrence linking the finite moments across m.",
+    "problemStatement": "Unify the finite weighted-geometric family ∑_{k<n} kᵐ·xᵏ into a single statement uniform in m. Define momentSum m n x = ∑_{k<n} kᵐ·xᵏ and prove the master recurrence (★) (1−x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x over an arbitrary commutative ring, then recover the m = 0, 1, 2 closed forms of the ancestors as specialisations.",
+    "proofStrategy": "Three ingredients. (1) The binomial helper sum_choose_mul_pow: ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ, from the binomial theorem add_pow at y = 1 with the top term C(m,m)·aᵐ = aᵐ peeled off by Finset.sum_range_succ. (2) momentSum_succ: peel the top term, momentSum m (n+1) x = momentSum m n x + nᵐ·xⁿ. (3) The recurrence (★) itself, by induction on n: the base case n = 0 is 0 = 0; the step rewrites every momentSum at n+1 via momentSum_succ, collapses the resulting ∑_{i<m} C(m,i)·nⁱ to (n+1)ᵐ − nᵐ using the helper, and closes with linear_combination against the hypothesis. All index bases are kept as ring casts so n = 0 is well-defined (no ℕ truncated subtraction). Specialisations instantiate m = 0, 1, 2 and simplify the short binomial sums.",
+    "keyInsights": [
+      "The single recurrence (★) reduces the m-th moment to ALL lower moments at once — not just the next one down — because the binomial expansion (k+1)ᵐ couples moment m to every moment i < m through the coefficient C(m,i). This is what makes one statement cover the entire family.",
+      "Iterating (★) clears exactly the denominator (1−x)^{m+1}: each application contributes one factor of (1−x), and the m nested moments unwind to the ancestors' known closed forms — recovering (1−x), (1−x)², (1−x)³ for m = 0, 1, 2.",
+      "The honest scope of a fully uniform statement is a recurrence, not one explicit Eulerian formula: the finite sum carries an n-dependent boundary term nᵐ·xⁿ whose expansion in n has no m-independent closed form, so (★) is the sharpest division-free identity that holds for all m simultaneously.",
+      "The interior part of (★) is precisely the Eulerian recurrence in the n → ∞ limit: as each momentSum i n x → Aᵢ(x)/(1−x)^{i+1}, the boundary term nᵐ·xⁿ vanishes and (★) becomes the recurrence for the infinite moment's Eulerian numerator (geometric-series-oq-07-oq-01).",
+      "The binomial helper ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ is the algebraic pivot: it is the binomial theorem with its top term removed, and it is exactly the shape needed to turn the telescoped (n+1)ᵐ − nᵐ increment into the coupling across lower moments."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition-helper",
+      "title": "The Moment Sum and the Binomial Helper",
+      "startLine": 77,
+      "endLine": 90,
+      "summary": "Defines momentSum m n x = ∑_{k<n} kᵐ·xᵏ, the finite m-th moment weighted geometric sum over any commutative ring. Proves the binomial helper sum_choose_mul_pow: ∑_{i<m} C(m,i)·aⁱ = (a+1)ᵐ − aᵐ, derived from add_pow at y = 1 by peeling the top term C(m,m)·aᵐ = aᵐ with Finset.sum_range_succ — the algebraic engine of the recurrence.",
+      "mathContext": "$\\mathrm{momentSum}\\,m\\,n\\,x=\\sum_{k<n}k^m x^k$; $\\sum_{i<m}\\binom{m}{i}a^i=(a+1)^m-a^m$."
+    },
+    {
+      "id": "master-recurrence",
+      "title": "The Master Recurrence (★)",
+      "startLine": 92,
+      "endLine": 129,
+      "summary": "momentSum_succ peels the top term (momentSum m (n+1) x = momentSum m n x + nᵐ·xⁿ). The headline momentSum_recurrence proves (★) (1−x)·momentSum m n x = 0ᵐ − nᵐ·xⁿ + x·∑_{i<m} C(m,i)·momentSum i n x by induction on n: the step expands the interior sum at n+1, collapses ∑_{i<m} C(m,i)·nⁱ to (n+1)ᵐ − nᵐ via the helper, and closes with linear_combination.",
+      "mathContext": "$(1-x)\\,\\mathrm{momentSum}\\,m\\,n\\,x = 0^m - n^m x^n + x\\sum_{i<m}\\binom{m}{i}\\mathrm{momentSum}\\,i\\,n\\,x$."
+    },
+    {
+      "id": "specialisations",
+      "title": "Specialisations m = 0, 1, 2 and a Numeric Check",
+      "startLine": 131,
+      "endLine": 161,
+      "summary": "momentSum_recurrence_zero: (1−x)·∑_{k<n} xᵏ = 1 − xⁿ. momentSum_recurrence_one: (1−x)·∑_{k<n} k·xᵏ = −n·xⁿ + x·∑_{k<n} xᵏ. momentSum_recurrence_two: (1−x)·∑_{k<n} k²·xᵏ = −n²·xⁿ + x·(∑_{k<n} xᵏ + 2·∑_{k<n} k·xᵏ). Each instantiates (★) and simplifies the short binomial sum. A numeric example over ℤ confirms ∑_{k<3} k·2ᵏ = 10.",
+      "mathContext": "$m{=}0{:}\\,1{-}x^n$; $m{=}1{:}\\,-nx^n{+}x\\!\\sum x^k$; $m{=}2{:}\\,-n^2x^n{+}x(\\sum x^k{+}2\\!\\sum kx^k)$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
## Summary

Enrichment pass for `geometric-series-oq-08-oq-01-oq-01-oq-01` (*Unifying the Weight Family: a Recurrence for the Finite m-th Moment ∑ kᵐ·xᵏ*). The entry previously had only `meta.json` (no overview, sections, annotations, or index.ts).

## Changes
- **description**: top-level summary of the uniform master recurrence (★) and why a recurrence (not one explicit formula) is the honest fully-general statement.
- **overview**: `historicalContext` (the family unification, the precise Mathlib gap), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (moment m couples to ALL lower moments via C(m,i); iterating clears (1−x)^{m+1}; the interior part is the Eulerian recurrence in the limit).
- **sections**: 3 sections covering the full Lean file (definition + binomial helper; master recurrence; specialisations m = 0,1,2 + numeric check).
- **annotations.json**: 7 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts**: created the missing Vite entry point (without it the page renders 'proof not found').

## Verification
- JSON validated for both files.
- Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 sorries, 0 axioms; propext/Classical.choice/Quot.sound only).