### PR TITLE
Enrich The Infinite-Limit Recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview-limit",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 5, "endLine": 73 },
+    "type": "context",
+    "title": "From the Finite Algebra to the Infinite Analysis",
+    "content": "The parent (geometric-series-oq-08-oq-01-oq-01-oq-01) proved a uniform FINITE recurrence (★) for the partial sums momentSum m n x over any commutative ring. This entry passes it to the analytic limit |x| < 1: the partial sums converge to the infinite moment infMoment m x = ∑'_{k} kᵐ·xᵏ, and the finite recurrence's boundary term nᵐ·xⁿ — the general term of a convergent series — washes out, leaving the clean infinite convolution recurrence (★∞). It is the cleanest bridge from the finite theory to the gallery's two one-shot closed forms (Stirling and Frobenius/Eulerian).",
+    "mathContext": "$(1-x)\\,\\mathrm{infMoment}\\,m\\,x = 0^m + x\\sum_{i<m}\\binom{m}{i}\\mathrm{infMoment}\\,i\\,x$, the $n\\to\\infty$ limit of (★).",
+    "significance": "context",
+    "relatedConcepts": ["infinite series", "limit of identities", "moments", "Eulerian polynomial"],
+    "prerequisites": ["infinite series", "convergence"]
+  },
+  {
+    "id": "ann-definition",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 80, "endLine": 82 },
+    "type": "definition",
+    "title": "The Infinite m-th Moment",
+    "content": "`infMoment m x = ∑' k, (k:ℝ)ᵐ·xᵏ`, the convergent weighted geometric series, defined as a tsum over ℝ. It is the infinite companion of the parent's finite momentSum: where momentSum sums over range n, infMoment sums over all of ℕ. Marked noncomputable because tsum depends on classical choice for its value when not summable (here it is always summable for |x| < 1).",
+    "mathContext": "$\\mathrm{infMoment}\\,m\\,x = \\sum'_{k} (k{:}\\mathbb{R})^m x^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["tsum", "infinite series", "weighted geometric series"],
+    "prerequisites": ["infinite sums"]
+  },
+  {
+    "id": "ann-summability",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 84, "endLine": 93 },
+    "type": "theorem",
+    "title": "Summability and Convergence of Partial Sums",
+    "content": "`summable_moment`: ∑ kᵐ·xᵏ is summable for |x| < 1, from Mathlib's summable_pow_mul_geometric_of_norm_lt_one (a polynomial times a decaying geometric is summable). `tendsto_momentSum`: the partial sums momentSum m n x → infMoment m x as n → ∞, via HasSum.tendsto_sum_nat — the precise sense in which the finite theory approaches the infinite one. This is the bridge that lets the finite recurrence be passed to the limit.",
+    "mathContext": "$\\sum_k k^m x^k$ summable for $|x|<1$; $\\mathrm{momentSum}\\,m\\,n\\,x\\to\\mathrm{infMoment}\\,m\\,x$ as $n\\to\\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["summability", "HasSum.tendsto_sum_nat", "partial sums", "convergence"],
+    "prerequisites": ["summability", "limits of sequences"]
+  },
+  {
+    "id": "ann-boundary",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 95, "endLine": 99 },
+    "type": "insight",
+    "title": "The Boundary Term Vanishes Structurally",
+    "content": "`tendsto_boundary`: nᵐ·xⁿ → 0 as n → ∞, proved as Summable.tendsto_atTop_zero — NOT via a separate polynomial-times-geometric decay estimate. The key insight: nᵐ·xⁿ is precisely the general (n-th) term of the summable series ∑ kᵐ·xᵏ from summable_moment, and the general term of any summable series tends to 0. This is the term the finite recurrence had to carry and the infinite one drops, so its vanishing is what makes (★∞) cleaner than (★).",
+    "mathContext": "$n^m x^n\\to 0$ since it is the general term of the summable series $\\sum_k k^m x^k$.",
+    "significance": "key",
+    "relatedConcepts": ["Summable.tendsto_atTop_zero", "general term", "boundary term", "structural proof"],
+    "prerequisites": ["summability", "divergence test"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 134 },
+    "type": "theorem",
+    "title": "The Master Infinite Recurrence (★∞)",
+    "content": "`infMoment_recurrence`: (1−x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x for |x| < 1. Proved by passing the parent's finite recurrence (true for every n) to the limit: the LHS (1−x)·momentSum m n x → (1−x)·infMoment m x by Tendsto.const_mul; the inner finite sum converges term-by-term by tendsto_finset_sum; the boundary term vanishes (tendsto_boundary). Since both sides are the SAME sequence in n, tendsto_nhds_unique (uniqueness of limits in a Hausdorff space) equates their limits to give (★∞).",
+    "mathContext": "$(1-x)\\,\\mathrm{infMoment}\\,m\\,x = 0^m + x\\sum_{i<m}\\binom{m}{i}\\mathrm{infMoment}\\,i\\,x$ via $\\lim$ of the finite identity.",
+    "significance": "critical",
+    "relatedConcepts": ["tendsto_nhds_unique", "limit of an identity", "binomial convolution", "tendsto_finset_sum"],
+    "prerequisites": ["uniqueness of limits", "continuity", "finite sums"]
+  },
+  {
+    "id": "ann-recurrence-succ",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 136, "endLine": 142 },
+    "type": "theorem",
+    "title": "The Pure Convolution Form (m ≥ 1)",
+    "content": "`infMoment_recurrence_succ`: for m ≥ 1 the constant 0ᵐ = 0 drops, leaving (1−x)·infMoment (m+1) x = x·∑_{i≤m} C(m+1,i)·infMoment i x. This is the recurrence in its cleanest convolution form — every higher moment is a Pascal-weighted combination of the lower ones, scaled by x/(1−x). Immediate from infMoment_recurrence by simp.",
+    "mathContext": "$(1-x)\\,\\mathrm{infMoment}\\,(m{+}1)\\,x = x\\sum_{i\\le m}\\binom{m+1}{i}\\mathrm{infMoment}\\,i\\,x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["convolution recurrence", "Pascal weights", "moment hierarchy"],
+    "prerequisites": ["binomial coefficients"]
+  },
+  {
+    "id": "ann-specialisations",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 144, "endLine": 186 },
+    "type": "theorem",
+    "title": "Solving (★∞): the Gallery's Closed Forms",
+    "content": "Solving the recurrence recursively recovers the gallery's explicit sums. `infMoment_zero`: 1/(1−x), the plain geometric series (from the 0⁰ = 1 constant term). `infMoment_one`: x/(1−x)², the infinite arithmetico-geometric sum ∑ k·xᵏ (gallery geometric-series-oq-08-oq-01), feeding in infMoment_zero. `infMoment_two`: x(1+x)/(1−x)³, the infinite second moment ∑ k²·xᵏ (gallery geometric-series-oq-08-oq-01-oq-01), feeding in both lower moments. Each clears (1−x) ≠ 0 (from x < 1) with field_simp and closes by ring_nf / linarith.",
+    "mathContext": "$\\mathrm{infMoment}\\,0=\\frac{1}{1-x}$, $\\mathrm{infMoment}\\,1=\\frac{x}{(1-x)^2}$, $\\mathrm{infMoment}\\,2=\\frac{x(1+x)}{(1-x)^3}$.",
+    "significance": "critical",
+    "relatedConcepts": ["closed form", "geometric series", "second moment", "field_simp"],
+    "prerequisites": ["field arithmetic", "recursion"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ08OQ01OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ08OQ01OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ08OQ01OQ01OQ01OQ02Data: ProofData = {
+  proof: geometricSeriesOQ08OQ01OQ01OQ01OQ02Proof,
+  annotations: geometricSeriesOQ08OQ01OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -21,6 +21,45 @@
     "sorries": 0
   },
   "title": "The Infinite-Limit Recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1",
+  "description": "The infinite-series companion of the parent's finite moment recurrence. For a real ratio x with |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ satisfies the clean binomial-convolution recurrence (★∞) (1−x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x — a first-order-in-m recursion through ALL lower moments with Pascal weights, no derivatives, no special functions. It is the n → ∞ limit of the finite master recurrence (★): the partial sums converge to infMoment, and the boundary term nᵐ·xⁿ — the general term of a convergent series — washes out. Solving (★∞) at m = 0, 1, 2 recovers the gallery's closed forms 1/(1−x), x/(1−x)², x(1+x)/(1−x)³.",
+  "overview": {
+    "historicalContext": "The weighted geometric series ∑ kᵐ·xᵏ and their rational closed forms (with Eulerian-polynomial numerators) are classical, going back to Euler and catalogued in Graham–Knuth–Patashnik's Concrete Mathematics. The gallery had reached this point along the geometric-series lineage: the parent (geometric-series-oq-08-oq-01-oq-01-oq-01) proved a uniform FINITE recurrence (★) for the partial sums momentSum m n x over any commutative ring, and two sibling entries give the infinite moments in explicit one-shot closed form (the Stirling form geometric-series-oq-07-oq-01 and the Frobenius/Eulerian form geometric-series-oq-07-oq-01-oq-01). This entry supplies the missing piece: passing the finite recurrence to the analytic limit |x| < 1 to obtain the INFINITE recurrence (★∞), the cleanest bridge from the finite algebra to the infinite analysis. Mathlib has summability of ∑ kᵐ·xᵏ but neither the moment as a named object nor any recurrence across m.",
+    "problemStatement": "For real x with |x| < 1, define infMoment m x = ∑'_{k} kᵐ·xᵏ and prove the infinite-limit recurrence (★∞) (1−x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x as the n → ∞ limit of the parent's finite recurrence, then solve it at m = 0, 1, 2 to recover 1/(1−x), x/(1−x)², and x(1+x)/(1−x)³.",
+    "proofStrategy": "Pass the finite recurrence (★) to the limit in five steps. (1) Summability: summable_pow_mul_geometric_of_norm_lt_one gives Summable (k ↦ kᵐ·xᵏ) for every m. (2) Convergence of partial sums: HasSum.tendsto_sum_nat turns summability into momentSum m n x → infMoment m x (the partial sums ARE the parent's momentSum). (3) The boundary vanishes: Summable.tendsto_atTop_zero gives nᵐ·xⁿ → 0 structurally — it is the general term of the summable series, requiring no separate polynomial-times-geometric decay estimate. (4) Pass to the limit: both sides of (★) are sequences in n; the LHS converges by continuity of (1−x)·•, the RHS by linearity of limits over the finite inner sum (tendsto_finset_sum), and tendsto_nhds_unique equates the two limits to give (★∞). (5) Specialisations solve (★∞) at m = 0, 1, 2 via field_simp and linarith, each feeding the lower-moment values into the next.",
+    "keyInsights": [
+      "The boundary term's vanishing is structural, not estimated: nᵐ·xⁿ → 0 because it is the general term of the SAME summable series whose partial sums define infMoment — Summable.tendsto_atTop_zero gives it directly, with no polynomial-times-geometric decay bound needed.",
+      "Taking n → ∞ genuinely simplifies the recurrence: the finite (★) carries an n-dependent correction nᵐ·xⁿ that the infinite (★∞) does not, so the infinite recursion is strictly cleaner than its finite parent — the analysis removes a term the algebra had to track.",
+      "(★∞) is a binomial CONVOLUTION recurrence: it expresses the m-th infinite moment through ALL lower moments using only the Pascal weights C(m,i), with no derivatives and no special functions — complementary to the gallery's two one-shot closed forms (Stirling and Frobenius/Eulerian).",
+      "The proof is a textbook limit-of-an-identity argument made rigorous: an identity true for every n, each side a convergent sequence, passed to the limit by uniqueness in a Hausdorff space (tendsto_nhds_unique) — the inner finite sum commutes with the limit because it has finitely many terms (tendsto_finset_sum).",
+      "Solving (★∞) recursively recovers exactly the gallery's closed forms: m = 0 gives 1/(1−x), m = 1 feeds that in to give x/(1−x)², and m = 2 uses both to give x(1+x)/(1−x)³ — so the convolution recurrence is a complete, derivative-free generator of the rational moment formulas."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definition-limits",
+      "title": "The Infinite Moment and Its Limit Infrastructure",
+      "startLine": 80,
+      "endLine": 99,
+      "summary": "Defines infMoment m x = ∑'_{k} kᵐ·xᵏ (a tsum), the convergent companion of the parent's finite momentSum. summable_moment gives summability of ∑ kᵐ·xᵏ for |x| < 1 from summable_pow_mul_geometric_of_norm_lt_one. tendsto_momentSum: the partial sums converge, momentSum m n x → infMoment m x (HasSum.tendsto_sum_nat). tendsto_boundary: nᵐ·xⁿ → 0 structurally as the general term of the summable series.",
+      "mathContext": "$\\mathrm{infMoment}\\,m\\,x=\\sum'_k k^m x^k$; partial sums $\\to$ it, and $n^m x^n\\to 0$ as the summable series' general term."
+    },
+    {
+      "id": "infinite-recurrence",
+      "title": "The Master Infinite Recurrence (★∞)",
+      "startLine": 101,
+      "endLine": 142,
+      "summary": "infMoment_recurrence proves (★∞) (1−x)·infMoment m x = 0ᵐ + x·∑_{i<m} C(m,i)·infMoment i x by passing the finite recurrence to the limit: the LHS converges by const_mul, the inner finite sum by tendsto_finset_sum, the boundary term vanishes, and tendsto_nhds_unique equates the two limits. infMoment_recurrence_succ drops the 0ᵐ term for m ≥ 1, giving the pure convolution form.",
+      "mathContext": "$(1-x)\\,\\mathrm{infMoment}\\,m\\,x = 0^m + x\\sum_{i<m}\\binom{m}{i}\\mathrm{infMoment}\\,i\\,x$ for $|x|<1$."
+    },
+    {
+      "id": "specialisations",
+      "title": "Solving (★∞) at m = 0, 1, 2",
+      "startLine": 144,
+      "endLine": 186,
+      "summary": "Recursively recovers the gallery's closed forms. infMoment_zero: 1/(1−x) (from the 0⁰ = 1 constant term). infMoment_one: x/(1−x)², the infinite arithmetico-geometric sum, using infMoment_zero. infMoment_two: x(1+x)/(1−x)³, the infinite second moment, using infMoment_zero and infMoment_one. Each clears the (1−x) ≠ 0 denominator with field_simp and finishes by ring_nf / linarith.",
+      "mathContext": "$\\mathrm{infMoment}\\,0=\\frac{1}{1-x}$, $\\mathrm{infMoment}\\,1=\\frac{x}{(1-x)^2}$, $\\mathrm{infMoment}\\,2=\\frac{x(1+x)}{(1-x)^3}$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
## Summary

Enrichment pass for `geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02` (*The Infinite-Limit Recurrence: ∑_{k≥0} kᵐ·xᵏ for |x| < 1*). The entry previously had only `meta.json` (no overview, sections, annotations, or index.ts).

## Changes
- **description**: top-level summary of the infinite convolution recurrence (★∞) as the n → ∞ limit of the parent's finite recurrence.
- **overview**: `historicalContext` (the finite→infinite bridge, the precise Mathlib gap), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (the boundary term vanishes structurally as a summable series' general term; the limit genuinely simplifies the recurrence; the limit-of-an-identity argument via tendsto_nhds_unique).
- **sections**: 3 sections covering the full Lean file (definition + limit infrastructure; master infinite recurrence; specialisations m = 0,1,2).
- **annotations.json**: 7 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- **index.ts**: created the missing Vite entry point (without it the page renders 'proof not found').

## Verification
- JSON validated for both files.
- Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 sorries, 0 axioms; propext/Classical.choice/Quot.sound only).