### PR TITLE
Enrich Second-order Arithmetico-Geometric Sum (∑ k²·xᵏ)

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sq-arith-geom-mul",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 79 },
+    "type": "technique",
+    "title": "The Second-Moment Ring Identity by Induction",
+    "content": "`sq_arith_geom_mul` is the mathematical core: (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}, valid over ANY commutative ring. The proof is induction on n, mirroring the linear (m = 1) parent: the base case is closed by simp; ring, and the successor step peels the top term k = n with `Finset.sum_range_succ`, rewrites the remaining sum by the induction hypothesis with `mul_add`, then discharges the polynomial identity with `push_cast; ring`. Keeping the (1 − x)³ factor on the left makes the statement ring-valid with no invertibility hypothesis — the field, integer, and analytic cases all specialise from this one lemma.",
+    "mathContext": "$(1-x)^3 \\sum_{k=0}^{n-1} k^2 x^k = x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}$ over any commutative ring.",
+    "significance": "key",
+    "relatedConcepts": ["second moment", "arithmetico-geometric series", "induction", "Finset.sum_range_succ", "Eulerian polynomials", "commutative ring"],
+    "prerequisites": ["mathematical induction", "polynomial identities", "Finset sums"]
+  },
+  {
+    "id": "ann-cast-well-definedness",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "insight",
+    "title": "Ring Casts Avoid the n = 0 Truncated-Subtraction Trap",
+    "content": "The numerator coefficients (n − 1)² and 2n² − 2n − 1 are written with explicit ring casts ((n : R) − 1, (n : R)) rather than as ℕ expressions. This matters: in ℕ, the subtraction n − 1 truncates to 0 at n = 0, so a naïve (n − 1)² would silently be 0 instead of the correct ring value 1 = (0 − 1)². By casting to R first and subtracting in the ring, the n = 0 instance is well-defined and the identity holds uniformly from n = 0 upward. This subtlety does not arise for the linear (m = 1) sum, whose coefficients are linear in n, but it is essential once squared coefficients appear at the second moment.",
+    "mathContext": "$((n:R) - 1)^2$ evaluated in $R$, not $(n-1)^2$ in $\\mathbb{N}$ where $n=0$ truncates $n-1$ to $0$.",
+    "significance": "technical",
+    "relatedConcepts": ["Nat subtraction", "truncated subtraction", "Nat.cast", "well-definedness"],
+    "prerequisites": ["natural-number subtraction", "type coercions in Lean"]
+  },
+  {
+    "id": "ann-sq-arith-geom-div",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 92 },
+    "type": "technique",
+    "title": "Clearing the (1 − x)³ Denominator",
+    "content": "`sq_arith_geom_div` upgrades the ring identity to the quotient form ∑_{k<n} k²·xᵏ = (numerator)/(1 − x)³ whenever x ≠ 1. The step is formal: 1 − x ≠ 0 follows from x ≠ 1 via `sub_ne_zero`, hence (1 − x)³ ≠ 0 by `pow_ne_zero`, and `eq_div_iff` converts the goal to the multiplied-through identity `sq_arith_geom_mul` already supplies (after `mul_comm` to align factor order). The cubic denominator (1 − x)³ — one power higher than the linear sum's (1 − x)² — is the visible signature of the quadratic weight k².",
+    "mathContext": "$\\sum_{k=0}^{n-1} k^2 x^k = \\dfrac{x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}}{(1-x)^3}$ for $x \\ne 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["field arithmetic", "eq_div_iff", "denominator clearing", "pow_ne_zero"],
+    "prerequisites": ["field theory", "fractions"]
+  },
+  {
+    "id": "ann-sq-arith-geom-two",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 126 },
+    "type": "insight",
+    "title": "The x = 2 Specialisation and Numerical Witnesses",
+    "content": "Substituting x = 2 gives ∑_{k<n} k²·2ᵏ = n²·2ⁿ − (2n² − 2n − 1)·2^{n+1} + (n−1)²·2^{n+2} − 6, where (1 − 2)³ = −1 flips the sign of the numerator (closed by field_simp; ring). As with the linear case, the geometric ratio 2 diverges yet the FINITE formula is exact — the identity is algebraic, not analytic. `sq_arith_geom_two_four` verifies n = 4: 0²·1 + 1²·2 + 2²·4 + 3²·8 = 0 + 2 + 16 + 72 = 90. `sq_arith_geom_three_three` checks x = 3, n = 3 directly from the field form: 0 + 1·3 + 4·9 = 39. Both are discharged by `norm_num`.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k^2 2^k$; e.g. $n=4$ gives $0+2+16+72 = 90$, and $x=3,n=3$ gives $3+36 = 39$.",
+    "significance": "supporting",
+    "relatedConcepts": ["second moment", "divergent ratio", "norm_num", "numerical verification"],
+    "prerequisites": ["powers of two", "arithmetic"]
+  },
+  {
+    "id": "ann-infinite-limit",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 137 },
+    "type": "context",
+    "title": "The Infinite Limit and the Eulerian Numerator",
+    "content": "This documentation section connects the finite closed form to its n → ∞ limit, the infinite second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1. As n grows, the three tail terms n²·xⁿ, (2n² − 2n − 1)·x^{n+1}, and (n − 1)²·x^{n+2} all vanish because geometric decay dominates polynomial growth, leaving the numerator x + x². That infinite value already lives in the gallery as geometric-series-oq-07 (tsum_sq_mul_geometric), so it is deliberately NOT reproved here — this entry supplies the missing finite companion. The limiting numerator x + x² = x·(1 + x) displays the Eulerian polynomial A₂(x) = 1 + x, the m = 2 case of the general structure ∑ kᵐ·xᵏ ~ x·Aₘ(x)/(1 − x)^{m+1}.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} k^2 x^k = \\dfrac{x(1+x)}{(1-x)^3}$ for $\\lVert x \\rVert < 1$, with $1+x = A_2(x)$ the Eulerian polynomial.",
+    "significance": "context",
+    "relatedConcepts": ["infinite series", "tsum", "Eulerian polynomials", "moments of geometric distribution", "generating functions"],
+    "prerequisites": ["real analysis", "convergence of series", "limits"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "Second-order Arithmetico-Geometric Sum: a Closed Form for ∑ k²·xᵏ",
+  "description": "The finite second-moment sum ∑_{k<n} k²·xᵏ — each geometric term xᵏ weighted by k² — has the division-free closed form (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring, the field form over (1 − x)³, and the n → ∞ limit x(1 + x)/(1 − x)³. The m = 2 member of the weighted-geometric family ∑ kᵐ·xᵏ, completing the m = 0, 1, 2 row in finite form.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -64,6 +65,48 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Sums of the form ∑ kᵐ·xᵏ — geometric series weighted by a polynomial in the index — are the higher 'moments' of the geometric distribution and were computed term by term well before a unified theory existed; Euler manipulated such weighted power series freely in the 18th century. The systematic device is the perturbation ('shift and subtract') method of Concrete Mathematics: each application of x·d/dx (or the discrete analogue) raises the moment order by one and the denominator power by one, so the second moment lands over (1 − x)³. The numerators that appear are, up to normalisation, the Eulerian polynomials Aₘ(x) — the m = 2 case here has numerator x + x² (= x·A₂(x) with A₂(x) = 1 + x in the standard convention) in its infinite limit. Mathlib formalises several infinite weighted series but not the finite truncations, which is exactly what computing a variance from a finite sample, or extracting a coefficient from a rational generating function, requires.",
+    "problemStatement": "For a length $n$ and a ratio $x$ in any commutative ring, evaluate the finite second-moment arithmetico-geometric sum $\\sum_{k=0}^{n-1} k^2\\,x^k$ in closed form. The target is the division-free identity $(1-x)^3 \\sum_{k=0}^{n-1} k^2 x^k = x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}$ over every commutative ring, its field specialisation over $(1-x)^3$ for $x \\ne 1$, and the consistency that as $n \\to \\infty$ with $\\lVert x \\rVert < 1$ the value tends to $\\dfrac{x(1+x)}{(1-x)^3}$.",
+    "proofStrategy": "The core result sq_arith_geom_mul is the multiplied-through ring identity, proved by induction on n exactly as in the m = 1 parent. The successor step peels the top term k = n with Finset.sum_range_succ, applies the induction hypothesis via mul_add, and closes the polynomial identity with push_cast; ring. A subtlety specific to the second moment: the numerator's coefficients ((n − 1)², 2n² − 2n − 1) are written with ring casts ((n : R), (n : R) − 1) rather than ℕ subtraction, so the n = 0 instance is well-defined over any ring (no truncated-subtraction trap). The field form sq_arith_geom_div clears the nonzero (1 − x)³ with eq_div_iff. The x = 2 specialisation (where (1 − 2)³ = −1) and two norm_num numerical witnesses (n = 4 gives 90; x = 3, n = 3 gives 39) guard the sign pattern. The infinite limit is NOT reproved — it already exists in the gallery as geometric-series-oq-07 — and is cross-referenced as the n → ∞ specialisation.",
+    "keyInsights": [
+      "Each extra factor of k in the weight raises the denominator power by one: ∑ xᵏ lives over (1 − x), ∑ k·xᵏ over (1 − x)², and ∑ k²·xᵏ over (1 − x)³. This entry is the m = 2 rung of that ladder ∑ kᵐ·xᵏ over (1 − x)^{m+1}, the pattern the unifying open question asks to make explicit.",
+      "Writing the closed form in the multiplied-through shape (1 − x)³·∑ = … keeps it a polynomial identity valid over every commutative ring; the field form and the analytic limit are then mere specialisations of one inductive lemma, with no analysis used in the core proof.",
+      "The numerator coefficients are deliberately expressed as ring casts ((n : R) − 1)² rather than ℕ subtraction (n − 1)², so the n = 0 instance does not silently truncate to 0 in ℕ — a correctness subtlety that does not arise for the linear (m = 1) sum but bites at the second moment.",
+      "The finite identity strictly refines the infinite one: as n → ∞ with ‖x‖ < 1 the three tail terms n²·xⁿ, (2n² − 2n − 1)·x^{n+1}, (n − 1)²·x^{n+2} all vanish (geometric decay beats polynomial growth), leaving the numerator x + x² and recovering the gallery's infinite second moment x(1 + x)/(1 − x)³.",
+      "The numerator's limiting shape x + x² = x·(1 + x) exhibits the Eulerian polynomial A₂(x) = 1 + x; the general moment ∑ kᵐ·xᵏ has numerator x·Aₘ(x) with Aₘ the m-th Eulerian polynomial, the structural fact behind the unifying open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "ring-identity",
+      "title": "The Division-Free Ring Identity",
+      "startLine": 62,
+      "endLine": 79,
+      "summary": "sq_arith_geom_mul is the core result: (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring. Proved by induction on n; the successor step peels the top term with Finset.sum_range_succ, rewrites by the induction hypothesis, and closes the polynomial identity with push_cast; ring. Coefficients use ring casts so the n = 0 case is well-defined."
+    },
+    {
+      "id": "field-form",
+      "title": "The Field Closed Form and Base-Case Guard",
+      "startLine": 81,
+      "endLine": 98,
+      "summary": "sq_arith_geom_div divides the ring identity by the nonzero (1 − x)³ (from x ≠ 1, via eq_div_iff and pow_ne_zero) to give the quotient closed form for x ≠ 1. sq_arith_geom_mul_one checks both sides vanish at n = 1 (the only term 0²·x⁰ = 0), guarding the sign pattern against off-by-one errors."
+    },
+    {
+      "id": "specialisations",
+      "title": "Specialisations and Numerical Witnesses",
+      "startLine": 100,
+      "endLine": 126,
+      "summary": "sq_arith_geom_two derives the x = 2 formula (where (1 − 2)³ = −1, closed by field_simp; ring), with sq_arith_geom_two_four (∑_{k<4} k²·2ᵏ = 0 + 2 + 16 + 72 = 90) and sq_arith_geom_three_three (x = 3, n = 3: 0 + 3 + 36 = 39) as concrete norm_num checks of the closed form."
+    },
+    {
+      "id": "infinite-limit",
+      "title": "The Infinite Limit (Recorded Elsewhere)",
+      "startLine": 128,
+      "endLine": 137,
+      "summary": "A documentation section noting that the n → ∞ limit of the finite closed form is the infinite second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1, already in the gallery as geometric-series-oq-07 (tsum_sq_mul_geometric). It is deliberately not reproved here; this entry supplies the finite companion and cross-references oq-07 for the limit."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08-oq-01-oq-01`.

This entry previously had only a bare `meta.json` (no description, overview, sections, or annotations). Added:

- **Top-level `description`** — was missing entirely.
- **`overview`** — `historicalContext` (higher moments of the geometric distribution, Eulerian polynomials, the perturbation method, variance/generating-function applications), `problemStatement` (LaTeX), `proofStrategy`, and 5 `keyInsights` on the (1−x)^{m+1} denominator ladder, ring-validity, the Nat-cast n=0 subtlety, the finite→infinite limit, and the Eulerian numerator.
- **`sections`** — 4 sections covering all 137 lines (ring identity, field form + base guard, specialisations, infinite limit).
- **`annotations.json`** — 5 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering `sq_arith_geom_mul`, the ring-cast well-definedness subtlety at n=0, `sq_arith_geom_div`, `sq_arith_geom_two`, and the Eulerian-numerator infinite limit.

Axiom integrity: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean source (0 sorries, 0 axioms, 0 assumption-carrying structures).

Mathematical content verified against the Lean source.