### PR TITLE
Enrich Solving the Infinite-Limit Recurrence (★∞) in Closed Form

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-infmoment-eq-eulerpoly",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 67, "endLine": 73 },
+    "type": "concept",
+    "title": "Closed-Form Solution of the Infinite Recurrence",
+    "content": "`infMoment_eq_eulerPoly` is the headline result: for |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ equals the Eulerian-polynomial closed form Eₘ(x)/(1 − x)^{m+1}. This identifies two independently developed gallery objects — the tsum-defined moment characterised in the parent only by the convolution recurrence (★∞), and the Frobenius/Eulerian closed form of the sibling line. The proof is a single line: the sibling file already proves the analytic HasSum statement, and `HasSum.tsum_eq` converts a HasSum into its tsum value, so `simpa only [infMoment] using (...).tsum_eq` closes the goal. The brevity is the point — all the analytic work lives upstream; this lemma is the bridge.",
+    "mathContext": "$\\mathrm{infMoment}\\,m\\,x = \\sum_{k=0}^{\\infty} k^m x^k = \\dfrac{E_m(x)}{(1-x)^{m+1}}$ for $|x| < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian polynomials", "infinite series", "tsum", "HasSum.tsum_eq", "Frobenius identity", "moments of geometric distribution"],
+    "prerequisites": ["infinite series", "Eulerian polynomials", "real analysis"]
+  },
+  {
+    "id": "ann-eulerpoly-recurrence",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 77, "endLine": 94 },
+    "type": "insight",
+    "title": "The Eulerian Polynomials Satisfy (★∞) as a Polynomial Identity",
+    "content": "`eulerPoly_recurrence` is the genuinely new content: the Eulerian polynomials themselves obey the (★∞) binomial-convolution recurrence as an exact identity in ℝ[X], (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}. This is the algebraic shadow of the analytic recurrence: clearing the denominators (1 − x)^{i+1} from the closed form converts the convergent-series convolution into a single homogeneous polynomial identity, linking the derivative-free Pascal recursion to the differential recurrence E_{m+1} = X(1−X)·E′ₘ + (m+1)·X·Eₘ that defines eulerPoly. No analogous statement exists in Mathlib.",
+    "mathContext": "$(1-X)E_m = 0^m(1-X)^{m+1} + X\\sum_{i<m}\\binom{m}{i}E_i(1-X)^{m-i}$ in $\\mathbb{R}[X]$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian polynomials", "binomial convolution", "Pascal's rule", "polynomial identity", "recurrence relations"],
+    "prerequisites": ["polynomial rings", "binomial coefficients", "recurrences"]
+  },
+  {
+    "id": "ann-eq-of-infinite-eval",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 95, "endLine": 120 },
+    "type": "technique",
+    "title": "Analytic-to-Algebraic Transfer via Polynomial Extensionality",
+    "content": "The polynomial identity is proved without touching a single coefficient. `eq_of_infinite_eval_eq` says two polynomials over an integral domain that agree on an infinite set of points are equal; `Set.Ioo_infinite` supplies the infinite set (−1,1). At each r in that interval the proof rewrites every eval Eᵢ(r) as infMoment i r · (1−r)^{i+1} (the closed form, via div_mul_cancel₀), pulls the common factor (1−r)^{m+1} out of the binomial sum (matching degrees with show m + 1 = (i+1) + (m−i); pow_add; ring), and then reduces to the parent's analytic recurrence (★∞) via `linear_combination (1 − r)^{m+1} * hrec`. This converts an analysis fact about convergent series into an exact algebraic identity in ℝ[X] — a transfer principle worth recognising on its own.",
+    "mathContext": "Agreement on the infinite set $(-1,1)$ forces equality in $\\mathbb{R}[X]$, an integral domain.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial extensionality", "eq_of_infinite_eval_eq", "integral domain", "linear_combination", "analytic continuation analogue"],
+    "prerequisites": ["polynomial rings", "integral domains", "real intervals"]
+  },
+  {
+    "id": "ann-infmoment-three",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 122, "endLine": 143 },
+    "type": "definition",
+    "title": "Low-Order Moments and the New Third Moment",
+    "content": "Specialising the headline closed form at small m recovers the known low moments and produces a new one. infMoment_one (= x/(1 − x)²) and infMoment_two (= (x + x²)/(1 − x)³) confirm consistency with the parent's directly-solved cases. infMoment_three gives the new explicit third moment ∑_{k} k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴, obtained for free by evaluating E₃ = X + 4X² + X³ — whose coefficients 1, 4, 1 are the Eulerian numbers ⟨3,0⟩, ⟨3,1⟩, ⟨3,2⟩ — over (1 − x)⁴. Each is a two-line rw of the closed form and the corresponding eulerPoly value.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} k^3 x^k = \\dfrac{x + 4x^2 + x^3}{(1-x)^4}$, with $1,4,1$ the Eulerian numbers $\\langle 3,j\\rangle$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eulerian numbers", "third moment", "geometric distribution", "specialisation"],
+    "prerequisites": ["Eulerian polynomials", "polynomial evaluation"]
+  },
+  {
+    "id": "ann-honest-scope",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 44, "endLine": 56 },
+    "type": "context",
+    "title": "Honest Scope: What Is Reused vs. New",
+    "content": "The file is explicit about provenance, a good model for research-entry framing. The headline closed form is NOT re-derived from scratch by strong induction on (★∞); it reuses the gallery's analytic Eulerian identity hasSum_pow_mul_geometric_eulerPoly, which itself rests on Frobenius' identity and the Stirling moment formula. The genuinely new deliverables are (1) the polynomial recurrence eulerPoly_recurrence — an explicit relation among the Eulerian polynomials and binomial weights not in Mathlib — and (2) the explicit third-moment closed form. The remaining open question asks for the harder analysis-free route: prove eulerPoly_recurrence by induction on m from the differential recurrence and Pascal's rule alone, yielding a derivation of the Eulerian closed form directly from (★∞).",
+    "mathContext": "New: $E_m$ satisfy (★∞) in $\\mathbb{R}[X]$, and $\\sum k^3 x^k$. Reused: the analytic Frobenius closed form.",
+    "significance": "context",
+    "relatedConcepts": ["proof provenance", "Frobenius identity", "Stirling numbers", "axiom integrity", "research framing"],
+    "prerequisites": ["mathematical exposition"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -20,6 +20,7 @@
     "sorries": 0
   },
   "title": "Solving the Infinite-Limit Recurrence (★∞) in Closed Form: infMoment m x = Eₘ(x)/(1 − x)^{m+1}",
+  "description": "Closes the loop between two gallery descriptions of the infinite geometric moments ∑'_{k} kᵐ·xᵏ: the parent's derivative-free binomial-convolution recurrence (★∞) and the sibling's differential Eulerian-polynomial closed form. Proves the headline identity infMoment m x = Eₘ(x)/(1 − x)^{m+1} for all m, a NEW polynomial recurrence showing the Eulerian polynomials themselves satisfy (★∞) over ℝ[X] (via polynomial extensionality on the infinite set (−1,1)), and the explicit third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -74,6 +75,41 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The rational closed forms ∑_{k≥0} kᵐ·xᵏ = Aₘ(x)/(1 − x)^{m+1} are classical: the numerators Aₘ are the Eulerian polynomials, whose coefficients ⟨m,j⟩ are the Eulerian numbers counting permutations of {1,…,m} with j descents. Leonhard Euler introduced these numbers in 1755 while summing exactly such series; Worpitzky's 1883 identity expands kᵐ in the binomial basis (k+j choose m) with Eulerian-number coefficients, the combinatorial root of the closed form. Two recurrences for the Eulerian polynomials coexist in the literature: a differential one, Aₘ₊₁ = x(1−x)A′ₘ + (1 + mx)Aₘ (here in the geometric normalisation Eₘ₊₁ = X(1−X)E′ₘ + (m+1)X·Eₘ), and a Pascal-style binomial-convolution one. This entry formalises the bridge between them inside Lean: the convolution recurrence (★∞), proved analytically for the tsum-defined moments, is shown to hold for the Eulerian polynomials themselves as an exact identity in ℝ[X].",
+    "problemStatement": "Let infMoment m x := $\\sum_{k=0}^{\\infty} k^m x^k$ for $|x| < 1$ (defined in the parent, where it is characterised only by the recurrence $(1-x)\\,\\mathrm{infMoment}\\,m\\,x = 0^m + x\\sum_{i<m}\\binom{m}{i}\\mathrm{infMoment}\\,i\\,x$, (★∞)). Solve (★∞) in closed form for all m, i.e. prove $\\mathrm{infMoment}\\,m\\,x = \\dfrac{E_m(x)}{(1-x)^{m+1}}$ with $E_m$ the Eulerian polynomial; show the $E_m$ satisfy (★∞) as a polynomial identity $(1-X)E_m = 0^m(1-X)^{m+1} + X\\sum_{i<m}\\binom{m}{i}E_i(1-X)^{m-i}$ in $\\mathbb{R}[X]$; and read off the explicit third moment.",
+    "proofStrategy": "Part 1 (infMoment_eq_eulerPoly) is a one-liner: the sibling file already proves the analytic Frobenius identity HasSum (kᵐ·rᵏ) (Eₘ(r)/(1−r)^{m+1}), and HasSum.tsum_eq converts it to the tsum value, identifying the two descriptions. Part 2 (eulerPoly_recurrence) is the genuinely new content and uses a polynomial-extensionality strategy: rather than manipulating polynomials directly, it shows both sides agree at every real r ∈ (−1,1) — there the closed form rewrites each eval Eᵢ(r) as infMoment i r · (1−r)^{i+1}, pulling a common (1−r)^{m+1} out of the binomial sum, after which the parent's analytic recurrence (★∞) closes the goal by linear_combination. Since (−1,1) is infinite (Set.Ioo_infinite) and ℝ[X] is over an integral domain, Polynomial.eq_of_infinite_eval_eq promotes pointwise equality to the polynomial identity. Part 3 specialises the headline closed form at m = 1, 2, 3 using the low-order Eulerian values, recovering x/(1−x)², (x+x²)/(1−x)³, and the new (x+4x²+x³)/(1−x)⁴.",
+    "keyInsights": [
+      "The same sequence of polynomials is pinned down by two structurally different recurrences — a differential one (defining eulerPoly in the sibling file) and a derivative-free binomial-convolution one (★∞) — and this entry proves they coincide. Establishing that two recurrences define the same object is exactly the kind of 'closing the loop' result that unifies a family.",
+      "The proof of the polynomial identity never touches a single polynomial coefficient: it evaluates both sides at infinitely many real points and invokes eq_of_infinite_eval_eq. This 'analytic-to-algebraic' transfer — agreement on an infinite set forces equality of polynomials over an integral domain — converts an analysis fact (the convergent series recurrence) into an exact algebraic one in ℝ[X].",
+      "Clearing the denominators (1 − x)^{i+1} from the closed form is what turns the analytic convolution recurrence (★∞) into a single homogeneous polynomial identity: each term contributes a power of (1 − X), and matching the total degree m + 1 across the sum is the algebraic heart of the rewrite (the show m + 1 = (i + 1) + (m − i); pow_add step).",
+      "The third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴ is obtained for free once the general closed form is in hand: it is just E₃ = X + 4X² + X³ over (1 − x)⁴, with the coefficients 1, 4, 1 being the Eulerian numbers ⟨3,0⟩, ⟨3,1⟩, ⟨3,2⟩ — no separate summation needed.",
+      "The entry is candid about scope: the headline closed form reuses the gallery's analytic Frobenius identity rather than re-deriving it by strong induction on (★∞). The genuinely original deliverables are the polynomial recurrence eulerPoly_recurrence (absent from Mathlib) and the explicit third-moment formula; the remaining open question asks for a purely algebraic, analysis-free derivation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "headline-closed-form",
+      "title": "Part 1: The Headline Closed Form",
+      "startLine": 65,
+      "endLine": 73,
+      "summary": "infMoment_eq_eulerPoly states the closed-form solution of (★∞): for |x| < 1, infMoment m x = Eₘ(x)/(1 − x)^{m+1}. The one-line proof applies HasSum.tsum_eq to the sibling file's analytic Frobenius identity hasSum_pow_mul_geometric_eulerPoly, identifying the tsum-defined moment with the Eulerian closed form."
+    },
+    {
+      "id": "eulerpoly-recurrence",
+      "title": "Part 2: The Eulerian Polynomials Satisfy (★∞)",
+      "startLine": 75,
+      "endLine": 120,
+      "summary": "eulerPoly_recurrence is the new polynomial identity (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i} in ℝ[X]. Proved by eq_of_infinite_eval_eq: both sides agree at every r ∈ (−1,1) (rewriting each Eᵢ(r) via the closed form, factoring out (1−r)^{m+1}, and closing with the parent's analytic (★∞) via linear_combination), and (−1,1) is infinite, so the polynomials are equal."
+    },
+    {
+      "id": "low-order-moments",
+      "title": "Part 3: Low-Order Closed Forms and the Third Moment",
+      "startLine": 122,
+      "endLine": 145,
+      "summary": "infMoment_one and infMoment_two recover x/(1 − x)² and (x + x²)/(1 − x)³ from the general closed form (consistency with the parent), and infMoment_three gives the new explicit third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴, read off the Eulerian polynomial E₃ = X + 4X² + X³."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sq-arith-geom-mul",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 79 },
+    "type": "technique",
+    "title": "The Second-Moment Ring Identity by Induction",
+    "content": "`sq_arith_geom_mul` is the mathematical core: (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}, valid over ANY commutative ring. The proof is induction on n, mirroring the linear (m = 1) parent: the base case is closed by simp; ring, and the successor step peels the top term k = n with `Finset.sum_range_succ`, rewrites the remaining sum by the induction hypothesis with `mul_add`, then discharges the polynomial identity with `push_cast; ring`. Keeping the (1 − x)³ factor on the left makes the statement ring-valid with no invertibility hypothesis — the field, integer, and analytic cases all specialise from this one lemma.",
+    "mathContext": "$(1-x)^3 \\sum_{k=0}^{n-1} k^2 x^k = x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}$ over any commutative ring.",
+    "significance": "key",
+    "relatedConcepts": ["second moment", "arithmetico-geometric series", "induction", "Finset.sum_range_succ", "Eulerian polynomials", "commutative ring"],
+    "prerequisites": ["mathematical induction", "polynomial identities", "Finset sums"]
+  },
+  {
+    "id": "ann-cast-well-definedness",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "insight",
+    "title": "Ring Casts Avoid the n = 0 Truncated-Subtraction Trap",
+    "content": "The numerator coefficients (n − 1)² and 2n² − 2n − 1 are written with explicit ring casts ((n : R) − 1, (n : R)) rather than as ℕ expressions. This matters: in ℕ, the subtraction n − 1 truncates to 0 at n = 0, so a naïve (n − 1)² would silently be 0 instead of the correct ring value 1 = (0 − 1)². By casting to R first and subtracting in the ring, the n = 0 instance is well-defined and the identity holds uniformly from n = 0 upward. This subtlety does not arise for the linear (m = 1) sum, whose coefficients are linear in n, but it is essential once squared coefficients appear at the second moment.",
+    "mathContext": "$((n:R) - 1)^2$ evaluated in $R$, not $(n-1)^2$ in $\\mathbb{N}$ where $n=0$ truncates $n-1$ to $0$.",
+    "significance": "technical",
+    "relatedConcepts": ["Nat subtraction", "truncated subtraction", "Nat.cast", "well-definedness"],
+    "prerequisites": ["natural-number subtraction", "type coercions in Lean"]
+  },
+  {
+    "id": "ann-sq-arith-geom-div",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 92 },
+    "type": "technique",
+    "title": "Clearing the (1 − x)³ Denominator",
+    "content": "`sq_arith_geom_div` upgrades the ring identity to the quotient form ∑_{k<n} k²·xᵏ = (numerator)/(1 − x)³ whenever x ≠ 1. The step is formal: 1 − x ≠ 0 follows from x ≠ 1 via `sub_ne_zero`, hence (1 − x)³ ≠ 0 by `pow_ne_zero`, and `eq_div_iff` converts the goal to the multiplied-through identity `sq_arith_geom_mul` already supplies (after `mul_comm` to align factor order). The cubic denominator (1 − x)³ — one power higher than the linear sum's (1 − x)² — is the visible signature of the quadratic weight k².",
+    "mathContext": "$\\sum_{k=0}^{n-1} k^2 x^k = \\dfrac{x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}}{(1-x)^3}$ for $x \\ne 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["field arithmetic", "eq_div_iff", "denominator clearing", "pow_ne_zero"],
+    "prerequisites": ["field theory", "fractions"]
+  },
+  {
+    "id": "ann-sq-arith-geom-two",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 126 },
+    "type": "insight",
+    "title": "The x = 2 Specialisation and Numerical Witnesses",
+    "content": "Substituting x = 2 gives ∑_{k<n} k²·2ᵏ = n²·2ⁿ − (2n² − 2n − 1)·2^{n+1} + (n−1)²·2^{n+2} − 6, where (1 − 2)³ = −1 flips the sign of the numerator (closed by field_simp; ring). As with the linear case, the geometric ratio 2 diverges yet the FINITE formula is exact — the identity is algebraic, not analytic. `sq_arith_geom_two_four` verifies n = 4: 0²·1 + 1²·2 + 2²·4 + 3²·8 = 0 + 2 + 16 + 72 = 90. `sq_arith_geom_three_three` checks x = 3, n = 3 directly from the field form: 0 + 1·3 + 4·9 = 39. Both are discharged by `norm_num`.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k^2 2^k$; e.g. $n=4$ gives $0+2+16+72 = 90$, and $x=3,n=3$ gives $3+36 = 39$.",
+    "significance": "supporting",
+    "relatedConcepts": ["second moment", "divergent ratio", "norm_num", "numerical verification"],
+    "prerequisites": ["powers of two", "arithmetic"]
+  },
+  {
+    "id": "ann-infinite-limit",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 137 },
+    "type": "context",
+    "title": "The Infinite Limit and the Eulerian Numerator",
+    "content": "This documentation section connects the finite closed form to its n → ∞ limit, the infinite second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1. As n grows, the three tail terms n²·xⁿ, (2n² − 2n − 1)·x^{n+1}, and (n − 1)²·x^{n+2} all vanish because geometric decay dominates polynomial growth, leaving the numerator x + x². That infinite value already lives in the gallery as geometric-series-oq-07 (tsum_sq_mul_geometric), so it is deliberately NOT reproved here — this entry supplies the missing finite companion. The limiting numerator x + x² = x·(1 + x) displays the Eulerian polynomial A₂(x) = 1 + x, the m = 2 case of the general structure ∑ kᵐ·xᵏ ~ x·Aₘ(x)/(1 − x)^{m+1}.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} k^2 x^k = \\dfrac{x(1+x)}{(1-x)^3}$ for $\\lVert x \\rVert < 1$, with $1+x = A_2(x)$ the Eulerian polynomial.",
+    "significance": "context",
+    "relatedConcepts": ["infinite series", "tsum", "Eulerian polynomials", "moments of geometric distribution", "generating functions"],
+    "prerequisites": ["real analysis", "convergence of series", "limits"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "Second-order Arithmetico-Geometric Sum: a Closed Form for ∑ k²·xᵏ",
+  "description": "The finite second-moment sum ∑_{k<n} k²·xᵏ — each geometric term xᵏ weighted by k² — has the division-free closed form (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring, the field form over (1 − x)³, and the n → ∞ limit x(1 + x)/(1 − x)³. The m = 2 member of the weighted-geometric family ∑ kᵐ·xᵏ, completing the m = 0, 1, 2 row in finite form.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -64,6 +65,48 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Sums of the form ∑ kᵐ·xᵏ — geometric series weighted by a polynomial in the index — are the higher 'moments' of the geometric distribution and were computed term by term well before a unified theory existed; Euler manipulated such weighted power series freely in the 18th century. The systematic device is the perturbation ('shift and subtract') method of Concrete Mathematics: each application of x·d/dx (or the discrete analogue) raises the moment order by one and the denominator power by one, so the second moment lands over (1 − x)³. The numerators that appear are, up to normalisation, the Eulerian polynomials Aₘ(x) — the m = 2 case here has numerator x + x² (= x·A₂(x) with A₂(x) = 1 + x in the standard convention) in its infinite limit. Mathlib formalises several infinite weighted series but not the finite truncations, which is exactly what computing a variance from a finite sample, or extracting a coefficient from a rational generating function, requires.",
+    "problemStatement": "For a length $n$ and a ratio $x$ in any commutative ring, evaluate the finite second-moment arithmetico-geometric sum $\\sum_{k=0}^{n-1} k^2\\,x^k$ in closed form. The target is the division-free identity $(1-x)^3 \\sum_{k=0}^{n-1} k^2 x^k = x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}$ over every commutative ring, its field specialisation over $(1-x)^3$ for $x \\ne 1$, and the consistency that as $n \\to \\infty$ with $\\lVert x \\rVert < 1$ the value tends to $\\dfrac{x(1+x)}{(1-x)^3}$.",
+    "proofStrategy": "The core result sq_arith_geom_mul is the multiplied-through ring identity, proved by induction on n exactly as in the m = 1 parent. The successor step peels the top term k = n with Finset.sum_range_succ, applies the induction hypothesis via mul_add, and closes the polynomial identity with push_cast; ring. A subtlety specific to the second moment: the numerator's coefficients ((n − 1)², 2n² − 2n − 1) are written with ring casts ((n : R), (n : R) − 1) rather than ℕ subtraction, so the n = 0 instance is well-defined over any ring (no truncated-subtraction trap). The field form sq_arith_geom_div clears the nonzero (1 − x)³ with eq_div_iff. The x = 2 specialisation (where (1 − 2)³ = −1) and two norm_num numerical witnesses (n = 4 gives 90; x = 3, n = 3 gives 39) guard the sign pattern. The infinite limit is NOT reproved — it already exists in the gallery as geometric-series-oq-07 — and is cross-referenced as the n → ∞ specialisation.",
+    "keyInsights": [
+      "Each extra factor of k in the weight raises the denominator power by one: ∑ xᵏ lives over (1 − x), ∑ k·xᵏ over (1 − x)², and ∑ k²·xᵏ over (1 − x)³. This entry is the m = 2 rung of that ladder ∑ kᵐ·xᵏ over (1 − x)^{m+1}, the pattern the unifying open question asks to make explicit.",
+      "Writing the closed form in the multiplied-through shape (1 − x)³·∑ = … keeps it a polynomial identity valid over every commutative ring; the field form and the analytic limit are then mere specialisations of one inductive lemma, with no analysis used in the core proof.",
+      "The numerator coefficients are deliberately expressed as ring casts ((n : R) − 1)² rather than ℕ subtraction (n − 1)², so the n = 0 instance does not silently truncate to 0 in ℕ — a correctness subtlety that does not arise for the linear (m = 1) sum but bites at the second moment.",
+      "The finite identity strictly refines the infinite one: as n → ∞ with ‖x‖ < 1 the three tail terms n²·xⁿ, (2n² − 2n − 1)·x^{n+1}, (n − 1)²·x^{n+2} all vanish (geometric decay beats polynomial growth), leaving the numerator x + x² and recovering the gallery's infinite second moment x(1 + x)/(1 − x)³.",
+      "The numerator's limiting shape x + x² = x·(1 + x) exhibits the Eulerian polynomial A₂(x) = 1 + x; the general moment ∑ kᵐ·xᵏ has numerator x·Aₘ(x) with Aₘ the m-th Eulerian polynomial, the structural fact behind the unifying open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "ring-identity",
+      "title": "The Division-Free Ring Identity",
+      "startLine": 62,
+      "endLine": 79,
+      "summary": "sq_arith_geom_mul is the core result: (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring. Proved by induction on n; the successor step peels the top term with Finset.sum_range_succ, rewrites by the induction hypothesis, and closes the polynomial identity with push_cast; ring. Coefficients use ring casts so the n = 0 case is well-defined."
+    },
+    {
+      "id": "field-form",
+      "title": "The Field Closed Form and Base-Case Guard",
+      "startLine": 81,
+      "endLine": 98,
+      "summary": "sq_arith_geom_div divides the ring identity by the nonzero (1 − x)³ (from x ≠ 1, via eq_div_iff and pow_ne_zero) to give the quotient closed form for x ≠ 1. sq_arith_geom_mul_one checks both sides vanish at n = 1 (the only term 0²·x⁰ = 0), guarding the sign pattern against off-by-one errors."
+    },
+    {
+      "id": "specialisations",
+      "title": "Specialisations and Numerical Witnesses",
+      "startLine": 100,
+      "endLine": 126,
+      "summary": "sq_arith_geom_two derives the x = 2 formula (where (1 − 2)³ = −1, closed by field_simp; ring), with sq_arith_geom_two_four (∑_{k<4} k²·2ᵏ = 0 + 2 + 16 + 72 = 90) and sq_arith_geom_three_three (x = 3, n = 3: 0 + 3 + 36 = 39) as concrete norm_num checks of the closed form."
+    },
+    {
+      "id": "infinite-limit",
+      "title": "The Infinite Limit (Recorded Elsewhere)",
+      "startLine": 128,
+      "endLine": 137,
+      "summary": "A documentation section noting that the n → ∞ limit of the finite closed form is the infinite second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1, already in the gallery as geometric-series-oq-07 (tsum_sq_mul_geometric). It is deliberately not reproved here; this entry supplies the finite companion and cross-references oq-07 for the limit."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01-oq-01-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01`.

This entry previously had only a bare `meta.json` (no description, overview, sections, or annotations). Added:

- **Top-level `description`** — was missing entirely.
- **`overview`** — `historicalContext` (Euler 1755, Eulerian numbers as descent counts, Worpitzky's identity, the differential vs. binomial-convolution recurrences), `problemStatement` (LaTeX), `proofStrategy`, and 5 `keyInsights` on unifying two recurrences, the analytic→algebraic transfer, denominator-clearing/degree-matching, the Eulerian-number third moment, and honest scope.
- **`sections`** — 3 sections covering all 145 lines (headline closed form, eulerPoly_recurrence, low-order moments).
- **`annotations.json`** — 5 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering `infMoment_eq_eulerPoly`, the new `eulerPoly_recurrence` polynomial identity, the `eq_of_infinite_eval_eq` polynomial-extensionality technique, `infMoment_three`, and the entry's honest-scope framing.

Axiom integrity: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean source (0 sorries, 0 axioms, 0 assumption-carrying structures). The entry is itself candid that the headline closed form reuses the gallery's analytic Frobenius identity; the new content is `eulerPoly_recurrence` and the explicit third moment.

Mathematical content verified against the Lean source.