### PR TITLE
research(compactness-finite-subcover-oq-01-oq-02): finite-intersection dual + Cantor's intersection theorem [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -731,6 +731,7 @@ import Proofs.CombinationsFormulaOQ08
 import Proofs.CombinationsFormulaOQ09
 import Proofs.CompactnessFiniteSubcover
 import Proofs.CompactnessFiniteSubcoverOq01Oq01
+import Proofs.CompactnessFiniteSubcoverOq01Oq02
 import Proofs.ComplexityCore
 import Proofs.CompositionCard2PowOQ01
 import Proofs.CompositionPartsChooseOQ01

--- a/proofs/Proofs/CompactnessFiniteSubcoverOq01Oq02.lean
+++ b/proofs/Proofs/CompactnessFiniteSubcoverOq01Oq02.lean
@@ -1,0 +1,133 @@
+import Mathlib
+
+/-
+# The Finite-Intersection Dual and Cantor's Intersection Theorem
+
+## What This Proves
+
+This file answers the **second** open question recorded on the parent entry
+*"Compactness via Finite Subcovers: the Heine–Borel Characterization"*:
+
+> Prove the finite-intersection-property dual and Cantor's intersection theorem
+> for nested compacts.
+
+The parent's headline is the open-cover characterization of compactness
+(`every open cover admits a finite subcover`).  Taking complements turns covers
+into families of closed sets, and the statement dualises to the **finite
+intersection property (FIP)**:
+
+> a set is compact **iff** every family of closed sets, every finite subfamily
+> of which meets the set, has its *whole* intersection meeting the set.
+
+The headline result here is that FIP characterisation, and its main payoff is
+**Cantor's intersection theorem**: a decreasing sequence of nonempty closed
+subsets of a compact set has nonempty intersection.
+
+* `compact_iff_finite_subfamily_closed` — the FIP characterisation, recorded as
+  the closed-set dual of the parent's `compact_iff_finite_subcover`
+  (a `Mathlib` re-export of `isCompact_iff_finite_subfamily_closed`).
+* `compact_inter_iInter_nonempty` — the everyday nonempty form: to meet the
+  intersection of a closed family it suffices to meet every *finite* subfamily
+  (`Mathlib`'s `IsCompact.inter_iInter_nonempty`, recorded as the FIP dual).
+* `cantor_inter_of_isCompact` — **Cantor's intersection theorem** for a compact
+  ambient set, proved **by hand** from the FIP dual: every finite subfamily of a
+  decreasing sequence is pinned below by its largest-index term, which is a
+  nonempty subset of the compact set, so the finite intersection property holds
+  and the full intersection is nonempty.
+* `cantor_inter` — the `[CompactSpace X]` corollary.
+* a concrete `ℝ` instance: the nested intervals `[0, 1/(n+1)]`.
+
+## Why This Is a Non-Wrapper
+
+`Mathlib` already carries `nonempty_iInter_of_sequence_nonempty_isCompact_isClosed`,
+its ready-made Cantor theorem.  That lemma is **never invoked**.  Instead Cantor
+is rebuilt from the finite-intersection dual exactly as the parent rebuilds
+compactness consequences from the finite-subcover characterization: the genuine
+content is the antitone bookkeeping that shows every finite subfamily intersection
+contains the largest-index term, which is nonempty.  That hand derivation, the
+`CompactSpace` corollary, and the concrete nested-interval instance are the
+mathematical substance; the two FIP statements are recorded as the explicit
+closed-set dual of the parent's open-cover headline.
+-/
+
+open Set
+
+universe u
+
+variable {X : Type u} [TopologicalSpace X]
+
+/-! ## The finite-intersection-property dual of compactness -/
+
+/-- **The finite-intersection characterisation of compactness.**  A set `s` is
+compact iff, for every family of closed sets whose total intersection avoids `s`,
+already some *finite* subfamily intersection avoids `s`.  This is the closed-set
+dual of the parent entry's `compact_iff_finite_subcover`, obtained by
+complementing covers into closed families (`Mathlib`'s
+`isCompact_iff_finite_subfamily_closed`). -/
+theorem compact_iff_finite_subfamily_closed {s : Set X} :
+    IsCompact s ↔ ∀ {ι : Type u} (t : ι → Set X),
+      (∀ i, IsClosed (t i)) → (s ∩ ⋂ i, t i) = ∅ →
+        ∃ u : Finset ι, (s ∩ ⋂ i ∈ u, t i) = ∅ :=
+  isCompact_iff_finite_subfamily_closed
+
+/-- **The finite-intersection property (nonempty form).**  To meet the
+intersection of a family of closed sets, a compact set need only meet every
+*finite* subfamily.  This is the form Cantor's theorem is built from; it is
+`Mathlib`'s `IsCompact.inter_iInter_nonempty`, recorded as the FIP dual. -/
+theorem compact_inter_iInter_nonempty {ι : Type*} {s : Set X} (hs : IsCompact s)
+    (t : ι → Set X) (htc : ∀ i, IsClosed (t i))
+    (hfip : ∀ v : Finset ι, (s ∩ ⋂ i ∈ v, t i).Nonempty) :
+    (s ∩ ⋂ i, t i).Nonempty :=
+  hs.inter_iInter_nonempty t htc hfip
+
+/-! ## Cantor's intersection theorem, re-derived from the FIP dual -/
+
+/-- **Cantor's intersection theorem (compact-set form).**  A decreasing sequence
+of nonempty closed subsets of a compact set `s` has nonempty intersection.
+
+Proved by hand from the finite-intersection dual `compact_inter_iInter_nonempty`,
+not from `Mathlib`'s ready-made `nonempty_iInter_of_sequence_…`.  The content is
+the antitone bookkeeping: for a finite set `v` of indices, every term `t i`
+(`i ∈ v`) contains the largest-index term `t (v.max')`, so
+`⋂_{i ∈ v} t i ⊇ t (v.max')`, which is a nonempty subset of `s`.  Hence every
+finite subfamily meets `s`, and the FIP dual returns a point in `s ∩ ⋂ t`; since
+`⋂ t ⊆ t 0 ⊆ s`, that point lies in `⋂ t`. -/
+theorem cantor_inter_of_isCompact {s : Set X} (hs : IsCompact s) (t : ℕ → Set X)
+    (hsub : ∀ n, t n ⊆ s) (hanti : Antitone t) (hcl : ∀ n, IsClosed (t n))
+    (hne : ∀ n, (t n).Nonempty) : (⋂ n, t n).Nonempty := by
+  -- Every finite subfamily already meets `s`.
+  have key : ∀ v : Finset ℕ, (s ∩ ⋂ i ∈ v, t i).Nonempty := by
+    intro v
+    rcases v.eq_empty_or_nonempty with rfl | hv
+    · simpa using (hne 0).mono (hsub 0)
+    · refine (hne (v.max' hv)).mono ?_
+      refine subset_inter (hsub _) (subset_iInter₂ fun i hi => ?_)
+      exact hanti (v.le_max' i hi)
+  -- The FIP dual yields a point of `s ∩ ⋂ t`; as `⋂ t ⊆ s`, it lies in `⋂ t`.
+  have hmeet := compact_inter_iInter_nonempty hs t hcl key
+  rwa [inter_eq_right.mpr ((iInter_subset t 0).trans (hsub 0))] at hmeet
+
+/-- **Cantor's intersection theorem (compact-space form).**  In a compact space, a
+decreasing sequence of nonempty closed sets has nonempty intersection. -/
+theorem cantor_inter [CompactSpace X] (t : ℕ → Set X) (hanti : Antitone t)
+    (hcl : ∀ n, IsClosed (t n)) (hne : ∀ n, (t n).Nonempty) :
+    (⋂ n, t n).Nonempty :=
+  cantor_inter_of_isCompact isCompact_univ t (fun _ => subset_univ _) hanti hcl hne
+
+/-! ## A concrete instance over `ℝ` -/
+
+/-- **Concrete Cantor instance over `ℝ`.**  The nested closed intervals
+`[0, 1/(n+1)]` form a decreasing sequence of nonempty compacts, so their
+intersection is nonempty (it is in fact `{0}`). -/
+example : (⋂ n : ℕ, Set.Icc (0 : ℝ) (1 / (n + 1))).Nonempty := by
+  have hanti : Antitone (fun n : ℕ => Set.Icc (0 : ℝ) (1 / (n + 1))) := by
+    intro n m hnm
+    refine Set.Icc_subset_Icc_right ?_
+    gcongr
+  refine cantor_inter_of_isCompact (s := Set.Icc (0 : ℝ) 1) isCompact_Icc
+    (fun n => Set.Icc (0 : ℝ) (1 / (n + 1))) (fun n => ?_) hanti
+    (fun _ => isClosed_Icc) (fun n => ⟨0, Set.mem_Icc.mpr ⟨le_refl 0, by positivity⟩⟩)
+  refine Set.Icc_subset_Icc_right ?_
+  rw [div_le_one (by positivity)]
+  have : (0 : ℝ) ≤ n := Nat.cast_nonneg n
+  linarith

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "compactness-finite-subcover-oq-01-oq-02",
+  "slug": "compactness-finite-subcover-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set"
+    ],
+    "namespace": "",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/CompactnessFiniteSubcoverOq01Oq02.lean",
+    "sorries": 0
+  },
+  "title": "The Finite-Intersection Dual and Cantor's Intersection Theorem",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompactnessFiniteSubcoverOq01Oq02.lean",
+    "tags": [
+      "topology",
+      "compactness",
+      "finite-intersection-property",
+      "cantor-intersection-theorem",
+      "finite-subcover",
+      "nested-compacts",
+      "general-topology",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 133,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "cantor_inter_of_isCompact: Cantor's intersection theorem re-derived BY HAND from the finite-intersection dual, NOT from Mathlib's ready-made nonempty_iInter_of_sequence_nonempty_isCompact_isClosed. For a decreasing sequence of nonempty closed subsets of a compact set s, the proof shows every finite subfamily already meets s — for a finite index set v the intersection ⋂_{i ∈ v} t i contains the largest-index term t (v.max') by antitonicity (subset_iInter₂ + Finset.le_max'), and that term is a nonempty subset of s — then feeds this finite-intersection property into the FIP dual to obtain a point of s ∩ ⋂ t, which lies in ⋂ t because ⋂ t ⊆ t 0 ⊆ s. The antitone bookkeeping pinning each finite subfamily below by its largest index is the genuine content, the closed-set dual of the parent entry's by-hand finite-subcover arguments.",
+      "cantor_inter: the CompactSpace corollary — in a compact space a decreasing sequence of nonempty closed sets has nonempty intersection — obtained from the compact-set form with s = univ via isCompact_univ.",
+      "compact_iff_finite_subfamily_closed: the finite-intersection characterisation of compactness recorded as the explicit closed-set dual of the parent entry's compact_iff_finite_subcover (a re-export of Mathlib's isCompact_iff_finite_subfamily_closed, the complement-image of the open-cover characterization).",
+      "compact_inter_iInter_nonempty: the everyday nonempty form of the FIP dual — to meet the intersection of a closed family it suffices to meet every finite subfamily — the lemma Cantor's theorem is built from (a re-export of Mathlib's IsCompact.inter_iInter_nonempty).",
+      "Concrete ℝ instance: the nested closed intervals [0, 1/(n+1)] form a decreasing sequence of nonempty compacts, so their intersection is nonempty (in fact {0}); instantiates cantor_inter_of_isCompact at the compact ambient Icc 0 1 with antitonicity discharged by gcongr."
+    ],
+    "prerequisites": [
+      "IsCompact.inter_iInter_nonempty: to meet the intersection of a closed family, a compact set need only meet every finite subfamily — the finite-intersection dual that powers Cantor's theorem",
+      "isCompact_iff_finite_subfamily_closed: the FIP characterisation of compactness, the closed-set dual of the finite-subcover characterization re-exported by the parent entry",
+      "Finset.le_max' / Finset.max': the largest index of a nonempty finite set, used to pin a finite subfamily intersection below by a single sequence term",
+      "isCompact_univ: the whole space of a CompactSpace is compact — specializes the compact-set Cantor theorem to the compact-space corollary",
+      "isCompact_Icc: closed real intervals are compact — drives the concrete nested-interval instance over ℝ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCompact.inter_iInter_nonempty",
+        "description": "If a compact set s meets s ∩ ⋂_{i ∈ u} t i for every finite u (the finite intersection property), then it meets s ∩ ⋂ i, t i. The dual of finite subcover; the engine of Cantor's theorem.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "isCompact_iff_finite_subfamily_closed",
+        "description": "IsCompact s ↔ for every family of closed sets whose intersection avoids s, some finite subfamily intersection already avoids s. The closed-set dual of isCompact_iff_finite_subcover.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "isCompact_univ",
+        "description": "In a CompactSpace, the universal set is compact. Specializes the compact-set Cantor theorem to the compact-space corollary.",
+        "module": "Mathlib.Topology.Compactness.Compact"
+      },
+      {
+        "theorem": "isCompact_Icc",
+        "description": "A closed bounded real interval [a,b] is compact. Drives the concrete nested-interval instance over ℝ.",
+        "module": "Mathlib.Topology.Order.Compact"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The open-cover definition of compactness has a perfectly dual face obtained by complementing every open set: covers become families of closed sets, 'admits a finite subcover' becomes 'some finite subfamily already has empty intersection with the set', and the contrapositive is the finite intersection property (FIP) — if every finite subfamily of a closed family meets the compact set, so does the whole family. This dual is the engine behind a chain of classical results: the nonemptiness of inverse limits of compacts, the existence of cluster points, and most famously Cantor's intersection theorem (Cantor, 1879), the statement that a decreasing sequence of nonempty closed subsets of a compact space (paradigmatically a nested sequence of closed bounded intervals or a nested sequence of nonempty compact sets in ℝⁿ) has nonempty intersection. Cantor's theorem is the compactness heart of the Baire category theorem on complete spaces and of the construction of the Cantor set itself. Mathlib packages Cantor's theorem directly through a directed-family argument (nonempty_iInter_of_sequence_nonempty_isCompact_isClosed); this entry instead derives it from the FIP dual by hand, in the by-hand spirit of the parent entry, which re-derives compactness consequences directly from the Heine–Borel finite-subcover definition rather than citing ready-made lemmas.",
+    "problemStatement": "Answer the parent's second open question: prove the finite-intersection-property dual of compactness and Cantor's intersection theorem for nested compacts. Concretely, record the FIP characterisation IsCompact s ↔ (every closed family with empty total intersection with s has a finite subfamily with empty intersection with s) as the closed-set dual of the parent's compact_iff_finite_subcover, expose its nonempty form (meeting every finite subfamily forces meeting the whole intersection), and use it — without citing Mathlib's ready-made Cantor lemma — to prove that a decreasing sequence of nonempty closed subsets of a compact set has nonempty intersection. Supply the compact-space corollary and a concrete ℝ instance.",
+    "proofStrategy": "cantor_inter_of_isCompact is the substance. Given a decreasing sequence t of nonempty closed subsets of a compact s, we verify the finite intersection property: for any finite index set v, the intersection s ∩ ⋂_{i ∈ v} t i is nonempty. If v is empty the intersection is s, nonempty because t 0 ⊆ s is nonempty; otherwise let m = v.max'. By antitonicity t m ⊆ t i for every i ∈ v (Finset.le_max'), so t m ⊆ ⋂_{i ∈ v} t i (subset_iInter₂), and t m ⊆ s (hypothesis); thus the nonempty t m sits inside s ∩ ⋂_{i ∈ v} t i. Feeding this into compact_inter_iInter_nonempty (Mathlib's IsCompact.inter_iInter_nonempty) yields a point of s ∩ ⋂ i, t i; since ⋂ i, t i ⊆ t 0 ⊆ s, rewriting inter_eq_right places that point in ⋂ i, t i. cantor_inter specializes to a CompactSpace with s = univ via isCompact_univ. compact_iff_finite_subfamily_closed and compact_inter_iInter_nonempty record the FIP characterisation and its nonempty form (Mathlib re-exports, the explicit duals of the parent's headline). The concrete ℝ instance instantiates at Icc 0 1: antitonicity of [0, 1/(n+1)] is Set.Icc_subset_Icc_right discharged by gcongr, closedness is isClosed_Icc, and 0 witnesses each interval's nonemptiness.",
+    "keyInsights": [
+      "The finite intersection property is literally the open-cover characterization read through complements: 'every open cover has a finite subcover' becomes 'every closed family whose finite subfamilies all meet the set has its whole intersection meet the set'. Recording this dual makes the parent's headline and Cantor's theorem two sides of one definition.",
+      "Cantor's theorem is the FIP applied to a decreasing sequence, where the finite-subfamily check is trivial: a finite set of indices is dominated by its maximum, and antitonicity collapses ⋂_{i ∈ v} t i down to (a superset of) the single largest-index term t (v.max'). The whole proof is this bookkeeping plus one appeal to the dual.",
+      "Compactness enters exactly once, through the FIP dual; nestedness and nonemptiness of the terms supply the finite intersection property for free. Without compactness the conclusion fails — the nested open-ended sets [n, ∞) in ℝ are closed, nonempty, and decreasing, yet their intersection is empty.",
+      "Working with a compact ambient set s rather than a compact space is strictly more flexible and specializes to the space version instantly with s = univ; it also lets the empty-index and single-point cases fall out of the same argument with no separate handling.",
+      "The 'mathlib' badge reflects an honest split: the two FIP statements are re-exports recorded as the explicit closed-set dual of the parent's open-cover headline, while Cantor's theorem is the genuine by-hand re-derivation — Mathlib's ready-made nonempty_iInter_of_sequence_… is deliberately not cited, mirroring the parent's refusal to cite IsCompact.union."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The FIP Dual and Cantor's Theorem",
+      "startLine": 3,
+      "endLine": 51,
+      "summary": "States the finite-intersection-property dual of the open-cover characterization, contrasts the by-hand Cantor derivation with Mathlib's ready-made nonempty_iInter_of_sequence_…, and lists the five results: the FIP characterisation, its nonempty form, the compact-set and compact-space Cantor theorems, and a concrete ℝ instance.",
+      "mathContext": "Compact $s$, decreasing nonempty closed $t_n\\subseteq s$ $\\Rightarrow\\bigcap_n t_n\\neq\\varnothing$."
+    },
+    {
+      "id": "fip-dual",
+      "title": "The Finite-Intersection Dual of Compactness",
+      "startLine": 59,
+      "endLine": 81,
+      "summary": "compact_iff_finite_subfamily_closed records the FIP characterisation IsCompact s ↔ (every closed family with empty total intersection with s has a finite subfamily intersection already avoiding s), the closed-set dual of the parent's compact_iff_finite_subcover. compact_inter_iInter_nonempty exposes the nonempty form: meeting every finite subfamily forces meeting the whole intersection.",
+      "mathContext": "$\\text{IsCompact }s\\iff\\forall\\text{ closed }t,\\ s\\cap\\bigcap_i t_i=\\varnothing\\Rightarrow\\exists\\text{ finite }u,\\ s\\cap\\bigcap_{i\\in u}t_i=\\varnothing$."
+    },
+    {
+      "id": "cantor",
+      "title": "Cantor's Intersection Theorem, by Hand from the FIP Dual",
+      "startLine": 83,
+      "endLine": 115,
+      "summary": "cantor_inter_of_isCompact: for a decreasing sequence of nonempty closed subsets of a compact s, every finite subfamily intersection contains the largest-index term t (v.max') (subset_iInter₂ + Finset.le_max'), which is a nonempty subset of s; the FIP dual then delivers a point of s ∩ ⋂ t, and ⋂ t ⊆ t 0 ⊆ s places it in ⋂ t. cantor_inter is the CompactSpace corollary via isCompact_univ.",
+      "mathContext": "$v$ finite $\\Rightarrow t_{\\max v}\\subseteq\\bigcap_{i\\in v}t_i$; FIP $\\Rightarrow\\bigcap_n t_n\\neq\\varnothing$."
+    },
+    {
+      "id": "instance",
+      "title": "Concrete Instance over ℝ",
+      "startLine": 117,
+      "endLine": 133,
+      "summary": "The nested closed intervals [0, 1/(n+1)] are a decreasing sequence of nonempty compacts inside Icc 0 1, so by cantor_inter_of_isCompact their intersection is nonempty (it is {0}). Antitonicity is Set.Icc_subset_Icc_right discharged by gcongr; nonemptiness uses 0 ∈ [0, 1/(n+1)].",
+      "mathContext": "$\\bigcap_n[0,\\tfrac1{n+1}]=\\{0\\}\\neq\\varnothing$ in $\\mathbb{R}$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "compactness-finite-subcover-oq-01-oq-02-oq-01",
+      "question": "Strengthen the concrete instance to compute the intersection exactly: prove ⋂ n, [0, 1/(n+1)] = {0} (not merely nonempty), and abstract the pattern to a 'nested intervals shrinking to a point' lemma giving the unique common point of a decreasing sequence of closed intervals whose lengths tend to 0.",
+      "significance": "medium"
+    },
+    {
+      "id": "compactness-finite-subcover-oq-01-oq-02-oq-02",
+      "question": "Derive the cluster-point form of compactness from the FIP dual: every net (or filter) on a compact set has a cluster point, by applying the finite intersection property to the closures of the net's tails, again without citing Mathlib's filter-based compactness lemmas.",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "compactness-finite-subcover-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: re-derives compactness-propagation results by hand from the finite-subcover characterization. This entry answers its second open question by recording the closed-set (finite-intersection) dual and re-deriving Cantor's intersection theorem in the same by-hand style."
+    },
+    {
+      "targetId": "compactness-finite-subcover-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling answering the parent's first open question (the tube lemma from finite subcovers). Together the two children realise both faces of the Heine–Borel characterization: the open-cover face (tube lemma) and the closed-family face (finite intersection property / Cantor)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Topology",
+      "author": "Munkres",
+      "year": "2000",
+      "venue": "Prentice Hall",
+      "description": "Finite intersection property characterisation of compactness (§26) and Cantor's intersection theorem for nested compacts."
+    },
+    {
+      "title": "Mathlib4: Topology.Compactness.Compact and Topology.Order.Compact",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of IsCompact.inter_iInter_nonempty, isCompact_iff_finite_subfamily_closed, isCompact_univ, and isCompact_Icc; also carries nonempty_iInter_of_sequence_nonempty_isCompact_isClosed, the ready-made Cantor theorem deliberately not cited here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The finite-intersection-property dual of compactness and Cantor's intersection theorem are established from the finite-subcover characterization. compact_iff_finite_subfamily_closed records the FIP characterisation (IsCompact s iff every closed family whose intersection avoids s has a finite subfamily avoiding s), the closed-set dual of the parent's compact_iff_finite_subcover, and compact_inter_iInter_nonempty its nonempty form. cantor_inter_of_isCompact then proves BY HAND that a decreasing sequence of nonempty closed subsets of a compact s has nonempty intersection: every finite subfamily intersection contains the largest-index term t (v.max'), a nonempty subset of s, so the FIP dual returns a point of s ∩ ⋂ t, which lies in ⋂ t since ⋂ t ⊆ t 0 ⊆ s. cantor_inter is the CompactSpace corollary; a concrete ℝ instance gives the nested intervals [0, 1/(n+1)]. 133 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Mathlib's ready-made nonempty_iInter_of_sequence_nonempty_isCompact_isClosed is deliberately not cited; Cantor's theorem is rebuilt from the finite-intersection dual exactly as the parent rebuilds compactness consequences from finite subcovers (badge 'mathlib': the two FIP statements re-export Mathlib, the Cantor derivation is the by-hand contribution). The FIP dual is the engine of inverse-limit nonemptiness and of the cluster-point form of compactness, flagged as the next by-hand derivations.",
+    "openQuestions": [
+      "Compute ⋂ n, [0, 1/(n+1)] = {0} exactly and abstract a nested-intervals-shrinking-to-a-point lemma.",
+      "Derive the cluster-point form of compactness from the FIP dual, without citing Mathlib's filter-based compactness lemmas."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second** open question of the parent entry *Compactness via Finite Subcovers: the Heine–Borel Characterization* — *"Prove the finite-intersection-property dual and Cantor's intersection theorem for nested compacts."* (The first open question, the tube lemma, was answered by #27979.)

Taking complements turns the parent's open-cover headline into its closed-set dual, the **finite intersection property**; its main payoff is **Cantor's intersection theorem**, re-derived here *by hand* from the FIP dual rather than from Mathlib's ready-made sequence lemma — matching the parent's "re-derive, don't cite" style.

## Results (`Proofs/CompactnessFiniteSubcoverOq01Oq02.lean`, 133 L, 4 theorems)

- `compact_iff_finite_subfamily_closed` — the FIP characterisation, the closed-set dual of the parent's `compact_iff_finite_subcover` (re-export of `isCompact_iff_finite_subfamily_closed`).
- `compact_inter_iInter_nonempty` — nonempty form: to meet `⋂ tᵢ` a compact set need only meet every finite subfamily (re-export of `IsCompact.inter_iInter_nonempty`).
- `cantor_inter_of_isCompact` — **Cantor's intersection theorem, by hand**: for a decreasing sequence of nonempty closed subsets of a compact `s`, each finite subfamily intersection `⋂_{i∈v} tᵢ` contains the largest-index term `t (v.max')`, a nonempty subset of `s`; the FIP dual then returns a point of `s ∩ ⋂ t`, which lies in `⋂ t` since `⋂ t ⊆ t 0 ⊆ s`. Mathlib's `nonempty_iInter_of_sequence_nonempty_isCompact_isClosed` is **not** cited.
- `cantor_inter` — `CompactSpace` corollary via `isCompact_univ`.
- Concrete ℝ instance: the nested intervals `[0, 1/(n+1)]` have nonempty intersection.

## Verification

- 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions.
- `#print axioms` on all four theorems lists only `propext`, `Classical.choice`, `Quot.sound`.
- Typechecks against the pinned Mathlib (Lean v4.26.0); imported in `Proofs.lean`.
- `status: verified`, `badge: mathlib` — honest split: the two FIP statements re-export Mathlib; the by-hand Cantor derivation is the contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)