### PR TITLE
Enrich Even/Odd Splitting of the Geometric Series: ∑ r^(2n) = 1/(1−r²)

### DIFF
--- a/src/data/proofs/geometric-series-oq-09/annotations.json
+++ b/src/data/proofs/geometric-series-oq-09/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview-bisection",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 4, "endLine": 43 },
+    "type": "context",
+    "title": "Bisecting the Geometric Series",
+    "content": "Splitting a power series into its even and odd parts is a standard generating-function technique (Concrete Mathematics). The geometric series is its simplest instance: the even-index subseries ∑ r^(2n) is itself geometric with ratio r², and likewise the odd part. Mathlib has the plain geometric series ∑ rⁿ = 1/(1−r) but not these index-parity subsums. The reusable move: a subseries along an arithmetic progression of indices is again geometric, with ratio r^q, so summing it reduces to Mathlib's lemma at a new ratio plus the bound ‖r^q‖ < 1.",
+    "mathContext": "$\\sum_n r^{2n}=\\frac{1}{1-r^2}$, $\\sum_n r^{2n+1}=\\frac{r}{1-r^2}$, recombining to $\\frac{1}{1-r}$.",
+    "significance": "context",
+    "relatedConcepts": ["generating functions", "series bisection", "geometric series", "subseries"],
+    "prerequisites": ["geometric series", "infinite sums"]
+  },
+  {
+    "id": "ann-norm-bound",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 49, "endLine": 63 },
+    "type": "technique",
+    "title": "The Key Bound ‖r²‖ < 1 and Nonvanishing Denominators",
+    "content": "`norm_sq_lt_one`: ‖r²‖ = ‖r‖² < 1 for ‖r‖ < 1, via norm_pow + pow_lt_one₀ — the one analytic fact that lets Mathlib's geometric-series lemma apply at the squared ratio r². The companions `one_sub_ne_zero` (1−r ≠ 0) and `one_sub_sq_ne_zero` (1−r² ≠ 0) supply the nonvanishing denominators the closed forms and the recombination need (both follow from r² < 1).",
+    "mathContext": "$\\|r^2\\|=\\|r\\|^2<1$; $1-r\\ne 0$ and $1-r^2\\ne 0$ for $\\|r\\|<1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm_pow", "pow_lt_one₀", "nonvanishing denominator", "squared ratio"],
+    "prerequisites": ["norms", "powers"]
+  },
+  {
+    "id": "ann-even",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 65, "endLine": 81 },
+    "type": "theorem",
+    "title": "The Even Subseries ∑ r^(2n) = 1/(1−r²)",
+    "content": "`hasSum_geometric_even`: ∑ r^(2n) = 1/(1−r²) for ‖r‖ < 1. The reindexing r^(2n) = (r²)ⁿ (pow_mul) exhibits the even subseries as a plain geometric series of ratio r², and hasSum_geometric_of_norm_lt_one applies because ‖r²‖ < 1. tsum_geometric_even and summable_geometric_even follow for free via HasSum.tsum_eq and HasSum.summable — proving the HasSum form once yields all three.",
+    "mathContext": "$\\sum_n r^{2n}=\\sum_n (r^2)^n=\\frac{1}{1-r^2}$, geometric of ratio $r^2$.",
+    "significance": "key",
+    "relatedConcepts": ["hasSum_geometric_of_norm_lt_one", "pow_mul", "reindexing", "HasSum.tsum_eq"],
+    "prerequisites": ["geometric series", "HasSum"]
+  },
+  {
+    "id": "ann-odd",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 83, "endLine": 101 },
+    "type": "theorem",
+    "title": "The Odd Subseries ∑ r^(2n+1) = r/(1−r²)",
+    "content": "`hasSum_geometric_odd`: ∑ r^(2n+1) = r/(1−r²). Obtained by the pure algebraic factor r^(2n+1) = r·r^(2n) (pow_succ, mul_comm) and HasSum.mul_left r applied to the even subseries — no fresh summation needed, the odd part inherits convergence and value from the even part scaled by r. tsum_geometric_odd and summable_geometric_odd follow for free.",
+    "mathContext": "$\\sum_n r^{2n+1}=r\\sum_n r^{2n}=\\frac{r}{1-r^2}$ via $\\mathrm{HasSum.mul\\_left}$.",
+    "significance": "key",
+    "relatedConcepts": ["HasSum.mul_left", "factorisation", "odd subseries", "inheritance"],
+    "prerequisites": ["HasSum arithmetic", "powers"]
+  },
+  {
+    "id": "ann-recombination",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 103, "endLine": 113 },
+    "type": "theorem",
+    "title": "Recombination Into the Full Series",
+    "content": "`tsum_even_add_odd`: ∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1−r). After substituting the three closed forms (via tsum_geometric_of_norm_lt_one for the full series), the identity 1/(1−r²) + r/(1−r²) = 1/(1−r) is closed by field_simp; ring — the analytic shadow of the factorisation 1−r² = (1−r)(1+r). This consistency check confirms the bisection loses nothing: the two parity subsums add back to the whole.",
+    "mathContext": "$\\frac{1}{1-r^2}+\\frac{r}{1-r^2}=\\frac{1+r}{1-r^2}=\\frac{1}{1-r}$, since $1-r^2=(1-r)(1+r)$.",
+    "significance": "critical",
+    "relatedConcepts": ["recombination", "factorisation", "field_simp", "consistency check"],
+    "prerequisites": ["field arithmetic", "infinite sums"]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 115, "endLine": 125 },
+    "type": "technique",
+    "title": "Concrete Values at r = 1/2",
+    "content": "Two sanity checks anchor the closed forms: ∑ (1/2)^(2n) = ∑ (1/4)ⁿ = 4/3 (even) and ∑ (1/2)^(2n+1) = 2/3 (odd). They instantiate tsum_geometric_even and tsum_geometric_odd and finish by norm_num, confirming the symbolic 1/(1−r²) and r/(1−r²) against arithmetic — and their sum 4/3 + 2/3 = 2 = 1/(1−1/2) reflects the recombination.",
+    "mathContext": "$\\sum_n(1/2)^{2n}=\\tfrac43$, $\\sum_n(1/2)^{2n+1}=\\tfrac23$, sum $=2$.",
+    "significance": "technical",
+    "relatedConcepts": ["concrete instance", "numerical verification", "norm_num"],
+    "prerequisites": ["arithmetic"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-09/meta.json
+++ b/src/data/proofs/geometric-series-oq-09/meta.json
@@ -16,6 +16,45 @@
     "sorries": 0
   },
   "title": "Even/Odd Splitting of the Geometric Series: ∑ r^(2n) = 1/(1−r²)",
+  "description": "Splitting the geometric series over index parity into two geometric series of ratio r². For ‖r‖ < 1 over ℝ: the even-index subseries ∑_{n≥0} r^(2n) = 1/(1−r²) and the odd-index subseries ∑_{n≥0} r^(2n+1) = r/(1−r²), and these recombine into the full series ∑ rⁿ = 1/(1−r) via 1/(1−r²) + r/(1−r²) = 1/(1−r) under 1−r² = (1−r)(1+r). The reusable move: a subseries along an arithmetic progression of indices is again geometric, with ratio r^q — so summing it reduces to Mathlib's geometric lemma at a new ratio plus the bound ‖r^q‖ < 1. Mathlib has the plain geometric series but not its index-parity subsums.",
+  "overview": {
+    "historicalContext": "Bisecting a power series into its even and odd parts — f(x) = f_even(x) + f_odd(x) with f_even(x) = (f(x)+f(−x))/2 — is a standard generating-function technique (Graham–Knuth–Patashnik, Concrete Mathematics), used to extract subsequences and to derive identities for alternating and parity-restricted sums. The geometric series is its simplest instance: its even-index subseries ∑ r^(2n) is itself geometric with ratio r², and likewise the odd part. Mathlib formalizes the plain geometric series ∑ rⁿ = 1/(1−r) (hasSum_geometric_of_norm_lt_one) but not these index-parity subsums. This entry fills that small gap and, more usefully, exhibits the reusable template — a subseries taken along an arithmetic progression of indices is again geometric, with ratio r^q — that powers the general q-fold splitting posed as the open question.",
+    "problemStatement": "For ‖r‖ < 1 over ℝ, sum the geometric series along its even and odd index subsequences. Prove ∑_{n≥0} r^(2n) = 1/(1−r²) and ∑_{n≥0} r^(2n+1) = r/(1−r²) (in HasSum, tsum, and summability forms), and verify the recombination ∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1−r).",
+    "proofStrategy": "Reduce each subseries to Mathlib's geometric lemma at a new ratio. (1) Even subseries: rewrite r^(2n) = (r²)ⁿ (pow_mul) and apply hasSum_geometric_of_norm_lt_one at ratio r², valid because ‖r²‖ = ‖r‖² < 1 (norm_sq_lt_one, from norm_pow + pow_lt_one₀). (2) Odd subseries: factor r^(2n+1) = r·r^(2n) and apply HasSum.mul_left r to the even subseries, giving value r·(1−r²)⁻¹. (3) Recombination: add the two tsum values and simplify (1−r²)⁻¹ + r(1−r²)⁻¹ = (1−r)⁻¹ with field_simp; ring, using the nonvanishing denominators 1−r ≠ 0 and 1−r² ≠ 0 (both from r² < 1). Concrete checks at r = 1/2 give 4/3 and 2/3.",
+    "keyInsights": [
+      "A subseries along an arithmetic progression of indices is again geometric: the even subseries ∑ r^(2n) = ∑ (r²)ⁿ has ratio r², not r — the single reindexing r^(2n) = (r²)ⁿ reduces it to the known geometric series at a new ratio.",
+      "The only analytic content is the norm bound ‖r²‖ = ‖r‖² < 1: once that lets Mathlib's lemma apply at ratio r², the even subseries is immediate and the odd subseries follows by a pure algebraic factor r^(2n+1) = r·r^(2n) plus HasSum.mul_left.",
+      "The recombination 1/(1−r²) + r/(1−r²) = 1/(1−r) is the analytic shadow of the factorisation 1−r² = (1−r)(1+r): the two parity subsums add back to the whole, a consistency check that the bisection loses nothing.",
+      "The template generalises verbatim to a q-fold splitting ∑ r^(qn+a) = r^a/(1−r^q) (0 ≤ a < q): q geometric subseries of ratio r^q, each summed by the lemma at ratio r^q with the bound ‖r^q‖ < 1 — the even/odd case is q = 2.",
+      "HasSum is the right primitive: proving the HasSum form first yields tsum (HasSum.tsum_eq) and summability (HasSum.summable) for free, and lets the odd subseries inherit from the even one by a single HasSum.mul_left rather than a fresh summation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "denominators",
+      "title": "Nonvanishing Denominators and the Key Bound",
+      "startLine": 49,
+      "endLine": 63,
+      "summary": "one_sub_ne_zero: 1−r ≠ 0 for ‖r‖ < 1. norm_sq_lt_one: the key bound ‖r²‖ = ‖r‖² < 1 (norm_pow + pow_lt_one₀) that lets Mathlib's geometric lemma apply at the squared ratio r². one_sub_sq_ne_zero: 1−r² ≠ 0, needed for the recombination's field arithmetic.",
+      "mathContext": "$\\|r^2\\|=\\|r\\|^2<1$, and $1-r\\ne 0$, $1-r^2\\ne 0$ for $\\|r\\|<1$."
+    },
+    {
+      "id": "even-odd-subseries",
+      "title": "The Even and Odd Subseries",
+      "startLine": 65,
+      "endLine": 101,
+      "summary": "Even subseries (hasSum/tsum/summable_geometric_even): ∑ r^(2n) = 1/(1−r²), via r^(2n) = (r²)ⁿ (pow_mul) and hasSum_geometric_of_norm_lt_one at ratio r². Odd subseries (hasSum/tsum/summable_geometric_odd): ∑ r^(2n+1) = r/(1−r²), by factoring r^(2n+1) = r·r^(2n) and HasSum.mul_left r on the even subseries.",
+      "mathContext": "$\\sum_n r^{2n}=\\frac{1}{1-r^2}$, $\\;\\sum_n r^{2n+1}=\\frac{r}{1-r^2}$, each geometric of ratio $r^2$."
+    },
+    {
+      "id": "recombination",
+      "title": "Recombination and Concrete Values",
+      "startLine": 103,
+      "endLine": 125,
+      "summary": "tsum_even_add_odd: ∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1−r), the identity 1/(1−r²) + r/(1−r²) = 1/(1−r) closed by field_simp; ring under 1−r² = (1−r)(1+r). Concrete checks at r = 1/2 confirm ∑ (1/2)^(2n) = 4/3 and ∑ (1/2)^(2n+1) = 2/3.",
+      "mathContext": "$\\frac{1}{1-r^2}+\\frac{r}{1-r^2}=\\frac{1}{1-r}$; e.g. $r=\\tfrac12$: $\\tfrac43+\\tfrac23=2$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
## Summary

Enrichment pass for `geometric-series-oq-09` (*Even/Odd Splitting of the Geometric Series*). The entry previously had only `meta.json` (no overview, sections, or annotations).

## Changes
- **description**: top-level summary of the even/odd parity splitting into two geometric series of ratio r² and the reusable subseries-at-r^q template.
- **overview**: `historicalContext` (series bisection, generating functions, the Mathlib gap), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (subseries is geometric at a new ratio; the only analytic content is ‖r²‖ < 1; the q-fold generalisation).
- **sections**: 3 sections covering the full Lean file (denominators + key bound; even/odd subseries; recombination + concrete values).
- **annotations.json**: 6 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- No `index.ts`: the gallery loader uses the build-generated manifest; this entry is already registered.

## Verification
- JSON validated for both files.
- Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 sorries, 0 axioms; propext/Classical.choice/Quot.sound only).