### PR TITLE
research(de-moivre-oq-05-oq-01-oq-01): Plancherel/Parseval for the DFT [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -793,6 +793,7 @@ import Proofs.DeMoivreOQ03OQ01OQ01
 import Proofs.DeMoivreOQ04
 import Proofs.DeMoivreOQ05
 import Proofs.DeMoivreOQ05OQ01
+import Proofs.DeMoivreOQ05OQ01OQ01
 import Proofs.DedekindFrobeniusBridge
 import Proofs.DenumerabilityRationals
 import Proofs.DenumerabilityRationalsOQ01

--- a/proofs/Proofs/DeMoivreOQ05OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ05OQ01OQ01.lean
@@ -1,0 +1,184 @@
+/-
+Plancherel / Parseval for the discrete Fourier transform
+
+Source: Open question from the de-moivre gallery family
+        (de-moivre-oq-05-oq-01-oq-01)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent entry (de-moivre-oq-05-oq-01) established the full **orthogonality
+relation** of the `n`-th roots of unity and, as its sharpest corollary, the
+*orthonormality of the discrete Fourier characters*:
+
+      ∑_{k<n} exp(2πi·ak/n)·conj(exp(2πi·bk/n))  =  ⎧ n   if a = b
+                                                     ⎩ 0   if a ≠ b      (a,b < n).
+
+This file pushes that one structural step further to the **Plancherel /
+Parseval theorem**, the energy-preservation law of the DFT.  Define the
+(unnormalised) discrete Fourier transform of a sampled signal `x : ℕ → ℂ` by
+
+      x̂(j)  =  ∑_{k<n} x(k)·exp(2πi·jk/n).
+
+Then for any two signals `x, y` (Plancherel, complex bilinear form)
+
+      ∑_{j<n} x̂(j)·conj(ŷ(j))  =  n · ∑_{k<n} x(k)·conj(y(k)),
+
+and taking `y = x` gives **Parseval** in its energy form
+
+      ∑_{j<n} |x̂(j)|²  =  n · ∑_{k<n} |x(k)|².
+
+The transform therefore preserves the ℓ²-energy of a signal up to the scale
+factor `n`: the DFT is `√n` times a unitary map.  Mathlib has the unitarity of
+the *normalised* Fourier transform on `ZMod n` in the abstract `MeasureTheory`
+machinery, but not this elementary explicit-exponential Parseval identity built
+directly from roots-of-unity orthogonality, which we supply here.
+
+Proof.  Expand both transforms, exchange the order of summation so the
+frequency variable `j` runs innermost, and apply the character orthonormality
+`∑_{j<n} exp(2πi·jk/n)·conj(exp(2πi·jl/n)) = n·[k=l]` (which is the parent's
+`sum_char_inner` with the time/frequency roles swapped, valid because the kernel
+`exp(2πi·jk/n)` is symmetric in `j` and `k`).  The orthonormality collapses the
+double time-sum to its diagonal, leaving `n·∑_k x(k)·conj(y(k))`.
+
+Theorems:
+1. `char_symm`        — symmetry of the DFT kernel in time/frequency
+2. `char_inner`       — character orthonormality, restated for the kernel
+3. `freq_orthonormal` — orthonormality summed over the frequency index
+4. `dft_add`          — linearity of the discrete Fourier transform
+5. `dft_plancherel`   — Plancherel: ∑ x̂·conj ŷ = n·∑ x·conj y
+6. `dft_parseval`     — Parseval (energy form): ∑ |x̂|² = n·∑ |x|²
+7. `dft_parseval_norm`— Parseval in terms of the complex norm ‖·‖
+-/
+
+import Mathlib
+import Proofs.DeMoivreOQ05OQ01
+
+open Finset
+
+namespace DeMoivreOQ05OQ01OQ01
+
+/-- The DFT kernel: the sampled character `exp(2πi·jk/n)`.  This is exactly the
+summand appearing in the parent's `sum_char_inner`. -/
+noncomputable def char (n : ℕ) (j k : ℕ) : ℂ :=
+  Complex.exp (2 * ↑Real.pi * Complex.I * ↑j * ↑k / ↑n)
+
+/-- The (unnormalised) **discrete Fourier transform** of a sampled signal
+`x : ℕ → ℂ` of length `n`: `x̂(j) = ∑_{k<n} x(k)·exp(2πi·jk/n)`. -/
+noncomputable def dft (n : ℕ) (x : ℕ → ℂ) (j : ℕ) : ℂ :=
+  ∑ k ∈ range n, x k * char n j k
+
+/-- **Symmetry of the DFT kernel.**
+The kernel `exp(2πi·jk/n)` is symmetric in the time index `k` and the frequency
+index `j`, because the exponent `jk` is.  This is what lets us reuse the
+parent's character orthonormality (summed over the *time* index) for the sum
+over the *frequency* index. -/
+theorem char_symm (n j k : ℕ) : char n j k = char n k j := by
+  unfold char
+  congr 1
+  ring
+
+/-- **Character orthonormality, restated for the kernel.**
+Direct repackaging of the parent's `sum_char_inner`: for residues `a, b < n`
+the sampled characters `k ↦ char n a k` are orthonormal with squared norm `n`,
+`∑_{k<n} char n a k · conj (char n b k) = n·[a=b]`. -/
+theorem char_inner {n : ℕ} (hn : 0 < n) {a b : ℕ} (ha : a < n) (hb : b < n) :
+    ∑ k ∈ range n, char n a k * (starRingEnd ℂ) (char n b k)
+      = if a = b then (n : ℂ) else 0 := by
+  unfold char
+  exact DeMoivreOQ05OQ01.sum_char_inner hn ha hb
+
+/-- **Orthonormality over the frequency index.**
+The same dichotomy with the sum taken over the *frequency* index `j` and the two
+*time* indices `k, l` fixed: `∑_{j<n} char n j k · conj (char n j l) = n·[k=l]`.
+Obtained from `char_inner` by the kernel symmetry `char_symm`.  This is the form
+consumed by the Plancherel computation. -/
+theorem freq_orthonormal {n : ℕ} (hn : 0 < n) {k l : ℕ} (hk : k < n) (hl : l < n) :
+    ∑ j ∈ range n, char n j k * (starRingEnd ℂ) (char n j l)
+      = if k = l then (n : ℂ) else 0 := by
+  have hsymm : ∀ j, char n j k * (starRingEnd ℂ) (char n j l)
+      = char n k j * (starRingEnd ℂ) (char n l j) := by
+    intro j; rw [char_symm n j k, char_symm n j l]
+  simp only [hsymm]
+  exact char_inner hn hk hl
+
+/-- **Linearity of the DFT.**
+The discrete Fourier transform is additive: `(x+y)^ = x̂ + ŷ` pointwise in the
+frequency variable. -/
+theorem dft_add (n : ℕ) (x y : ℕ → ℂ) (j : ℕ) :
+    dft n (fun k => x k + y k) j = dft n x j + dft n y j := by
+  unfold dft
+  rw [← Finset.sum_add_distrib]
+  exact Finset.sum_congr rfl (fun k _ => by ring)
+
+/-- **Plancherel theorem for the DFT.**
+The discrete Fourier transform preserves the Hermitian inner product up to the
+scale factor `n`:
+
+      ∑_{j<n} x̂(j)·conj(ŷ(j))  =  n · ∑_{k<n} x(k)·conj(y(k)).
+
+Expand both transforms into time sums, push the frequency sum innermost, and the
+character orthonormality `freq_orthonormal` collapses the resulting double
+time-sum to its diagonal. -/
+theorem dft_plancherel (n : ℕ) (hn : 0 < n) (x y : ℕ → ℂ) :
+    ∑ j ∈ range n, dft n x j * (starRingEnd ℂ) (dft n y j)
+      = (n : ℂ) * ∑ k ∈ range n, x k * (starRingEnd ℂ) (y k) := by
+  -- Step 1: each frequency summand is a double sum over the time indices k, l.
+  have hterm : ∀ j ∈ range n,
+      dft n x j * (starRingEnd ℂ) (dft n y j)
+        = ∑ k ∈ range n, ∑ l ∈ range n,
+            (x k * (starRingEnd ℂ) (y l)) * (char n j k * (starRingEnd ℂ) (char n j l)) := by
+    intro j _
+    simp only [dft, map_sum, map_mul]
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl (fun k _ => Finset.sum_congr rfl (fun l _ => by ring))
+  rw [Finset.sum_congr rfl hterm]
+  -- Step 2: swap the outer frequency sum past the first time sum, so each `k`
+  -- block is `∑ j ∑ l (...)`.
+  rw [Finset.sum_comm]
+  -- Step 3: for each time index `k`, swap `∑ j ∑ l → ∑ l ∑ j`, pull the
+  -- (time-only) coefficient out of the frequency sum, apply the orthonormality
+  -- dichotomy, and collapse the inner diagonal.
+  have hcollapse : ∀ k ∈ range n,
+      (∑ j ∈ range n, ∑ l ∈ range n,
+        (x k * (starRingEnd ℂ) (y l)) * (char n j k * (starRingEnd ℂ) (char n j l)))
+        = (n : ℂ) * (x k * (starRingEnd ℂ) (y k)) := by
+    intro k hk
+    rw [mem_range] at hk
+    rw [Finset.sum_comm]
+    have hinner : ∀ l ∈ range n,
+        (∑ j ∈ range n,
+          (x k * (starRingEnd ℂ) (y l)) * (char n j k * (starRingEnd ℂ) (char n j l)))
+          = (x k * (starRingEnd ℂ) (y l)) * (if k = l then (n : ℂ) else 0) := by
+      intro l hl
+      rw [mem_range] at hl
+      rw [← Finset.mul_sum, freq_orthonormal hn hk hl]
+    rw [Finset.sum_congr rfl hinner, Finset.sum_eq_single k]
+    · rw [if_pos rfl]; ring
+    · intro l _ hlk
+      rw [if_neg (fun h => hlk h.symm), mul_zero]
+    · intro h; exact absurd (mem_range.mpr hk) h
+  rw [Finset.sum_congr rfl hcollapse, ← Finset.mul_sum]
+
+/-- **Parseval theorem (energy form).**
+Setting `y = x` in Plancherel gives the energy-preservation law: the DFT scales
+the squared ℓ²-norm by exactly `n`,
+
+      ∑_{j<n} |x̂(j)|²  =  n · ∑_{k<n} |x(k)|²,
+
+so the discrete Fourier transform is `√n` times a unitary map. -/
+theorem dft_parseval (n : ℕ) (hn : 0 < n) (x : ℕ → ℂ) :
+    ∑ j ∈ range n, Complex.normSq (dft n x j)
+      = (n : ℝ) * ∑ k ∈ range n, Complex.normSq (x k) := by
+  have h := dft_plancherel n hn x x
+  simp only [Complex.mul_conj] at h
+  exact_mod_cast h
+
+/-- **Parseval in terms of the complex norm.**
+The same identity written with the Euclidean norm `‖·‖` on `ℂ`, using
+`‖z‖² = normSq z`. -/
+theorem dft_parseval_norm (n : ℕ) (hn : 0 < n) (x : ℕ → ℂ) :
+    ∑ j ∈ range n, ‖dft n x j‖ ^ 2
+      = (n : ℝ) * ∑ k ∈ range n, ‖x k‖ ^ 2 := by
+  have h := dft_parseval n hn x
+  simpa only [Complex.normSq_eq_norm_sq] using h
+
+end DeMoivreOQ05OQ01OQ01

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,214 @@
+{
+  "id": "de-moivre-oq-05-oq-01-oq-01",
+  "title": "De Moivre OQ-05-OQ-01-OQ-01: Plancherel / Parseval for the Discrete Fourier Transform",
+  "slug": "de-moivre-oq-05-oq-01-oq-01",
+  "description": "The energy-preservation law of the DFT, derived from the parent's character orthonormality: for the unnormalised transform x̂(j) = ∑_{k<n} x(k)·exp(2πi·jk/n), the Plancherel identity ∑_j x̂(j)·conj(ŷ(j)) = n·∑_k x(k)·conj(y(k)) and its diagonal Parseval form ∑_j |x̂(j)|² = n·∑_k |x(k)|² — so the DFT is √n times a unitary map.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ05OQ01OQ01.lean",
+    "tags": [
+      "complex-analysis",
+      "discrete-fourier",
+      "plancherel",
+      "parseval",
+      "orthogonality",
+      "character-sums",
+      "energy-conservation",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_mul_sum",
+        "description": "Product of two finite sums as a double sum, (∑ f)·(∑ g) = ∑∑ f·g; expands x̂(j)·conj(ŷ(j)) into a double time-sum",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Interchange of the order of a double finite sum; reorders the time/frequency sums so the frequency index runs innermost",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "Distributing a constant factor through a finite sum; pulls the time-only coefficient out of the frequency sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_eq_single",
+        "description": "A finite sum collapses to a single term when all others vanish; extracts the diagonal of the orthonormality dichotomy",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Complex.mul_conj",
+        "description": "z·conj z = ↑(normSq z); converts the Hermitian Plancherel form into the real Parseval energy identity",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "Complex.normSq_eq_norm_sq",
+        "description": "normSq z = ‖z‖² on ℂ; restates Parseval in terms of the Euclidean norm",
+        "module": "Mathlib.Analysis.Complex.Norm"
+      },
+      {
+        "theorem": "DeMoivreOQ05OQ01.sum_char_inner",
+        "description": "Parent result: orthonormality of the DFT characters ∑_{k<n} exp(2πi·ak/n)·conj(exp(2πi·bk/n)) = n·[a=b] for a,b<n — the sole nontrivial input to Plancherel",
+        "module": "Proofs.DeMoivreOQ05OQ01"
+      }
+    ],
+    "originalContributions": [
+      "dft_plancherel: the Plancherel identity ∑_{j<n} x̂(j)·conj(ŷ(j)) = n·∑_{k<n} x(k)·conj(y(k)) for the unnormalised DFT, built directly from the parent's character orthonormality — not in Mathlib in this elementary explicit-exponential form",
+      "dft_parseval: the diagonal energy form ∑_{j<n} |x̂(j)|² = n·∑_{k<n} |x(k)|² (with normSq), exhibiting the DFT as √n times an isometry",
+      "dft_parseval_norm: the same energy identity phrased with the complex norm ‖·‖ via normSq_eq_norm_sq",
+      "freq_orthonormal: orthonormality summed over the frequency index, ∑_{j<n} char(j,k)·conj(char(j,l)) = n·[k=l], obtained from the parent's time-indexed orthonormality by the kernel symmetry char(j,k)=char(k,j)",
+      "char_symm: symmetry of the DFT kernel exp(2πi·jk/n) in time and frequency — the bridge that lets the parent's orthonormality apply along the frequency axis",
+      "dft_add: linearity of the discrete Fourier transform"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 184,
+    "assumptions": "0 axioms, 0 sorries (proofs depend only on propext / Classical.choice / Quot.sound). The single nontrivial mathematical input is the parent's character orthonormality DeMoivreOQ05OQ01.sum_char_inner; the rest is finite-sum bookkeeping (sum_mul_sum, sum_comm, mul_sum, sum_eq_single) and the standard z·conj z = normSq = ‖z‖² identities.",
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Parseval's theorem (1799) and Plancherel's theorem (1910) express that a Fourier transform preserves energy: the total squared magnitude of a signal equals (up to normalisation) that of its spectrum. For the finite/discrete Fourier transform on $\\mathbb{Z}/n\\mathbb{Z}$ this is the unitarity of the (normalised) DFT matrix, the bedrock of digital signal processing, the FFT, and the analysis of error-correcting codes. It is a one-line consequence of the orthonormality of the discrete exponential characters established in the parent entry.",
+    "problemStatement": "**Open Question** (parent de-moivre-oq-05-oq-01): derive Plancherel / Parseval for the DFT, $\\sum_k |f(k)|^2 = \\tfrac1n\\sum_j |\\hat f(j)|^2$, as a consequence of the character orthonormality `sum_char_inner`.\n\n**Answer**: For the unnormalised transform $\\hat x(j) = \\sum_{k<n} x(k)\\,e^{2\\pi i jk/n}$ and any signals $x,y$, $\\sum_{j<n}\\hat x(j)\\overline{\\hat y(j)} = n\\sum_{k<n} x(k)\\overline{y(k)}$, and with $y=x$, $\\sum_{j<n}|\\hat x(j)|^2 = n\\sum_{k<n}|x(k)|^2$. Expanding both transforms and exchanging the order of summation, the orthonormality $\\sum_{j<n} e^{2\\pi i jk/n}\\overline{e^{2\\pi i jl/n}} = n\\,[k=l]$ collapses the double time-sum to its diagonal.",
+    "text": "The Plancherel and Parseval energy identities for the discrete Fourier transform, obtained from the parent entry's orthonormality of the discrete Fourier characters by a single summation interchange.",
+    "proofStrategy": "1. **Kernel symmetry** (`char_symm`): the DFT kernel $e^{2\\pi i jk/n}$ is symmetric in $j$ and $k$ because the exponent $jk$ is. This lets the parent's orthonormality — summed over the time index — be reused along the frequency index.\n2. **Frequency orthonormality** (`freq_orthonormal`): rewrite each summand with `char_symm` and apply the parent's `sum_char_inner` to get $\\sum_{j<n}\\chi_k(j)\\overline{\\chi_l(j)} = n\\,[k=l]$ for $k,l<n$.\n3. **Plancherel** (`dft_plancherel`): expand $\\hat x(j)\\overline{\\hat y(j)}$ into a double time-sum via `sum_mul_sum`; sum over $j$ and interchange (`sum_comm`) so $j$ runs innermost; pull the time-only coefficient out (`mul_sum`) and apply `freq_orthonormal`; the inner diagonal (`sum_eq_single`) collapses to $n\\sum_k x(k)\\overline{y(k)}$.\n4. **Parseval** (`dft_parseval`, `dft_parseval_norm`): set $y=x$ and use $z\\overline z = \\mathrm{normSq}\\,z = \\lVert z\\rVert^2$ (`mul_conj`, `normSq_eq_norm_sq`) to land in $\\mathbb{R}$.",
+    "keyInsights": [
+      "Parseval is not an independent analytic fact — it is the *diagonal* of the character orthonormality already proved in the parent; the entire content is one summation interchange",
+      "The kernel symmetry $e^{2\\pi i jk/n} = e^{2\\pi i kj/n}$ is the quiet workhorse: it converts orthonormality of the DFT rows (sum over time) into orthonormality of the DFT columns (sum over frequency), which is the form the energy computation needs",
+      "Using the *unnormalised* transform makes the scale factor explicit: $\\sum_j|\\hat x(j)|^2 = n\\sum_k|x(k)|^2$, i.e. the DFT is exactly $\\sqrt n$ times a unitary map",
+      "The complex Plancherel form $\\sum_j \\hat x(j)\\overline{\\hat y(j)} = n\\sum_k x(k)\\overline{y(k)}$ is strictly stronger than Parseval and is what makes the DFT an inner-product (Hermitian) isometry; Parseval is the $y=x$ specialisation",
+      "Passing from the $\\mathbb{C}$ identity to the real energy statement is pure casting: $z\\overline z = \\mathrm{normSq}\\,z$ is real-valued, so `exact_mod_cast` bridges the two"
+    ],
+    "prerequisites": [
+      "Orthonormality of the discrete Fourier characters (parent de-moivre-oq-05-oq-01)",
+      "The discrete Fourier transform and its inversion",
+      "Interchange of finite double sums",
+      "Complex modulus: z·conj z = normSq z = ‖z‖²"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the Plancherel / Parseval identities, the role of the parent's character orthonormality, and the seven results proved",
+      "startLine": 1,
+      "endLine": 57,
+      "mathContext": "**Goal**: $\\sum_{j<n}\\hat x(j)\\overline{\\hat y(j)} = n\\sum_{k<n} x(k)\\overline{y(k)}$ and its energy form $\\sum_j|\\hat x(j)|^2 = n\\sum_k|x(k)|^2$."
+    },
+    {
+      "id": "definitions",
+      "title": "Part I: The DFT Kernel and Transform",
+      "summary": "char and dft: the sampled character exp(2πi·jk/n) and the unnormalised discrete Fourier transform x̂(j) = ∑_{k<n} x(k)·char(j,k)",
+      "startLine": 59,
+      "endLine": 67,
+      "mathContext": "$\\hat x(j) = \\sum_{k<n} x(k)\\,e^{2\\pi i jk/n}$, the length-$n$ unnormalised DFT."
+    },
+    {
+      "id": "orthonormality",
+      "title": "Part II: Kernel Symmetry and Frequency Orthonormality",
+      "summary": "char_symm and char_inner / freq_orthonormal: kernel symmetry in time/frequency and the orthonormality ∑_{j<n} char(j,k)·conj(char(j,l)) = n·[k=l]",
+      "startLine": 69,
+      "endLine": 101,
+      "mathContext": "$\\sum_{j<n} e^{2\\pi i jk/n}\\overline{e^{2\\pi i jl/n}} = n\\,[k=l]$ for $k,l<n$, from the parent's row orthonormality via $jk=kj$."
+    },
+    {
+      "id": "plancherel",
+      "title": "Part III: Linearity and the Plancherel Identity",
+      "summary": "dft_add and dft_plancherel: linearity of the DFT and the Hermitian Plancherel identity ∑_j x̂·conj(ŷ) = n·∑_k x·conj(y) by sum interchange + orthonormality collapse",
+      "startLine": 103,
+      "endLine": 159,
+      "mathContext": "$\\sum_{j<n}\\hat x(j)\\overline{\\hat y(j)} = n\\sum_{k<n} x(k)\\overline{y(k)}$ — the DFT is an inner-product isometry up to the factor $n$."
+    },
+    {
+      "id": "parseval",
+      "title": "Part IV: Parseval Energy Identities",
+      "summary": "dft_parseval and dft_parseval_norm: the y=x energy form ∑_j |x̂|² = n·∑_k |x|², in normSq and in the complex norm ‖·‖",
+      "startLine": 161,
+      "endLine": 184,
+      "mathContext": "$\\sum_{j<n}|\\hat x(j)|^2 = n\\sum_{k<n}|x(k)|^2$ — the DFT preserves $\\ell^2$-energy up to the scale $n$."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization proves the Plancherel and Parseval theorems for the discrete Fourier transform: for the unnormalised transform x̂(j) = ∑_{k<n} x(k)·exp(2πi·jk/n), the Hermitian identity ∑_{j<n} x̂(j)·conj(ŷ(j)) = n·∑_{k<n} x(k)·conj(y(k)) and its diagonal energy form ∑_{j<n} |x̂(j)|² = n·∑_{k<n} |x(k)|². It directly answers the parent entry's first open question, deriving energy preservation from the character orthonormality sum_char_inner by one summation interchange. All seven theorems are fully proved with zero sorries and zero axioms.",
+    "implications": "Completes the DFT-inversion package of the parent entry with its dual energy law: the discrete Fourier transform is √n times a unitary map, so it preserves ℓ²-energy exactly. This is the formal underpinning of Parseval-based spectral analysis, the L²-correctness of the FFT, and the weight/energy identities used for error-correcting codes and uncertainty principles on ℤ/nℤ.",
+    "openQuestions": [
+      "Normalised unitary DFT: package the transform U(j,k) = exp(2πi·jk/n)/√n and prove ‖Ux‖ = ‖x‖ exactly, exhibiting U as an element of the unitary group",
+      "DFT inversion as the adjoint: prove the explicit inverse x(k) = (1/n)∑_j x̂(j)·exp(-2πi·jk/n) and identify it with the Plancherel adjoint",
+      "Convolution theorem: (x ⋆ y)^(j) = x̂(j)·ŷ(j) for cyclic convolution, the multiplicative companion to this additive energy law"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05-oq-01",
+      "relationship": "Parent: proves the orthonormality of the discrete Fourier characters (sum_char_inner); this entry answers its first open question by deriving Plancherel / Parseval from it"
+    },
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "Grandparent: the roots-of-unity vanishing sum ∑ ζ^k = 0, the j=1 seed of the orthogonality these energy identities rest on"
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Base theorem: integer-exponent De Moivre, the origin of the sampling characters exp(2πi·jk/n)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DeMoivreOQ05OQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "DeMoivreOQ05OQ01OQ01",
+    "lineCount": 184,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2,
+    "path": "Proofs/DeMoivreOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Marc-Antoine Parseval",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficients constants",
+      "year": "1799",
+      "venue": "Mémoires présentés à l'Institut des Sciences"
+    },
+    {
+      "authors": "Michel Plancherel",
+      "title": "Contribution à l'étude de la représentation d'une fonction arbitraire par des intégrales définies",
+      "year": "1910",
+      "venue": "Rendiconti del Circolo Matematico di Palermo"
+    },
+    {
+      "authors": "James W. Cooley and John W. Tukey",
+      "title": "An Algorithm for the Machine Calculation of Complex Fourier Series",
+      "year": "1965",
+      "venue": "Mathematics of Computation"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Parent formalization (character orthonormality sum_char_inner); this entry derives the dual energy law Plancherel / Parseval from it, answering its first open question."
+    },
+    {
+      "targetId": "de-moivre-oq-05",
+      "relationship": "foundational",
+      "description": "Grandparent roots-of-unity vanishing sum; the orthogonality these energy identities rest on is its frequency-indexed generalisation."
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "Euler's formula identifies the sampling characters exp(2πi·jk/n) whose energy this entry shows the DFT preserves."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `de-moivre-oq-05-oq-01` (*Orthogonality of the Roots of Unity / DFT Inversion*, #27961): derive **Plancherel / Parseval** for the discrete Fourier transform from the character orthonormality `sum_char_inner`.

For the unnormalised transform `x̂(j) = ∑_{k<n} x(k)·exp(2πi·jk/n)`:

- **Plancherel** (`dft_plancherel`): `∑_{j<n} x̂(j)·conj(ŷ(j)) = n·∑_{k<n} x(k)·conj(y(k))`
- **Parseval** (`dft_parseval`, energy form): `∑_{j<n} |x̂(j)|² = n·∑_{k<n} |x(k)|²`
- **Parseval** (`dft_parseval_norm`): same identity in the complex norm `‖·‖`

so the DFT is exactly `√n` times a unitary map.

## Proof idea

The whole content is **one summation interchange**. The kernel `exp(2πi·jk/n)` is symmetric in time `k` and frequency `j` (`char_symm`), which turns the parent's row orthonormality (sum over time) into column orthonormality (sum over frequency, `freq_orthonormal`). Expanding `x̂(j)·conj(ŷ(j))` into a double time-sum, summing over `j`, and applying the orthonormality dichotomy `n·[k=l]` collapses the double sum to its diagonal `n·∑_k x(k)·conj(y(k))`. Parseval is the `y=x` specialisation via `z·conj z = normSq z = ‖z‖²`.

## Verification

- **7 theorems, 2 definitions, 184 lines**
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext / Classical.choice / Quot.sound`
- Builds against Mathlib v4.26.0; aggregator import added to `proofs/Proofs.lean`

## Files

- `proofs/Proofs/DeMoivreOQ05OQ01OQ01.lean` (new)
- `src/data/proofs/de-moivre-oq-05-oq-01-oq-01/meta.json` (new)
- `proofs/Proofs.lean` (import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)