### PR TITLE
research(solution-of-cubic-oq-03-oq-05-oq-01): Vieta's formulas for degree-n polynomials [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3424,6 +3424,7 @@ import Proofs.SolutionOfCubicOQ03OQ01
 import Proofs.SolutionOfCubicOQ03OQ02
 import Proofs.SolutionOfCubicOQ03OQ03
 import Proofs.SolutionOfCubicOQ03OQ05
+import Proofs.VietaGeneralOQ030505OQ01
 import Proofs.SolutionOfCubicOQ05
 import Proofs.SophieGermain
 import Proofs.SophieGermainOQ01

--- a/proofs/Proofs/VietaGeneralOQ030505OQ01.lean
+++ b/proofs/Proofs/VietaGeneralOQ030505OQ01.lean
@@ -1,0 +1,187 @@
+/-
+  Vieta's Formulas for Degree-n Polynomials (General Case)
+
+  This entry answers the first open question of `solution-of-cubic-oq-03-oq-05`
+  ("Vieta's Formulas for the General Cubic"):
+
+    "Can Vieta's formulas for degree-n polynomials be proved in generality in Lean
+     using Mathlib's `Polynomial.roots` and `Multiset` infrastructure?"
+    "Do Mathlib's `Polynomial.Vieta` lemmas cover the general case?"
+
+  Answer: yes, in full generality. The cornerstone is Mathlib's
+  `Polynomial.coeff_eq_esymm_roots_of_card`, which expresses every coefficient of a
+  polynomial that *splits* (its root multiset has cardinality equal to its degree)
+  as an elementary symmetric function of its roots:
+
+      coeff k = leadingCoeff · (-1)^(n-k) · e_{n-k}(roots).
+
+  From this single formula we assemble the classical named relations for an arbitrary
+  degree `n`, generalizing the cubic case of the parent entry:
+
+    * sum of the roots          (the X^{n-1} coefficient),
+    * second symmetric function (the X^{n-2} coefficient),
+    * product of the roots      (the constant coefficient),
+
+  together with the field (non-monic) versions, the symmetric-function form for an
+  explicit product of linear factors `∏ (X - rᵢ)`, and a concrete recovery of the
+  cubic Vieta relations as the cardinality-3 special case.
+
+  Everything is `0`-sorry, `0`-axiom, building only on Mathlib.
+-/
+import Mathlib
+
+open Polynomial Multiset
+
+set_option linter.unusedSectionVars false
+
+namespace VietaGeneral
+
+/-! ## Section I: Elementary symmetric helper -/
+
+variable {R : Type*} [CommRing R] [IsDomain R]
+
+/-- The first elementary symmetric function of a multiset is its sum:
+`e₁(s) = ∑ s`. -/
+theorem esymm_one_eq_sum (s : Multiset R) : s.esymm 1 = s.sum := by
+  simp [Multiset.esymm, Multiset.powersetCard_one]
+
+/-! ## Section II: The general Vieta coefficient formula
+
+The whole theory follows from one Mathlib lemma. -/
+
+/-- **Vieta's formula, general degree-n form.** For a polynomial `p` over an integral
+domain whose root multiset has cardinality equal to its degree (i.e. `p` splits), the
+`k`-th coefficient equals `leadingCoeff · (-1)^(n-k) · e_{n-k}(roots)`. -/
+theorem vieta_coeff (p : R[X]) (hcard : Multiset.card p.roots = p.natDegree)
+    {k : ℕ} (hk : k ≤ p.natDegree) :
+    p.coeff k =
+      p.leadingCoeff * (-1) ^ (p.natDegree - k) * p.roots.esymm (p.natDegree - k) :=
+  Polynomial.coeff_eq_esymm_roots_of_card hcard hk
+
+/-! ## Section III: The classical named relations (monic case)
+
+For a monic polynomial these collapse to the textbook Vieta formulas. -/
+
+/-- **Sum of the roots.** For a monic, split polynomial of degree `≥ 1`, the
+next-to-leading coefficient is minus the sum of the roots:
+`coeff (n-1) = -∑ roots`. -/
+theorem sum_of_roots (p : R[X]) (hm : p.Monic)
+    (hcard : Multiset.card p.roots = p.natDegree) (hdeg : 1 ≤ p.natDegree) :
+    p.coeff (p.natDegree - 1) = - p.roots.sum := by
+  have hk : p.natDegree - 1 ≤ p.natDegree := Nat.sub_le _ _
+  have h := vieta_coeff p hcard hk
+  have hsub : p.natDegree - (p.natDegree - 1) = 1 := by omega
+  rw [hsub, esymm_one_eq_sum, hm.leadingCoeff] at h
+  rw [h]; ring
+
+/-- **Second elementary symmetric function.** For a monic, split polynomial of degree
+`≥ 2`, the `X^{n-2}` coefficient is the second elementary symmetric function of the
+roots (the sum of products of pairs): `coeff (n-2) = e₂(roots)`. -/
+theorem coeff_sub_two_eq_esymm_two (p : R[X]) (hm : p.Monic)
+    (hcard : Multiset.card p.roots = p.natDegree) (hdeg : 2 ≤ p.natDegree) :
+    p.coeff (p.natDegree - 2) = p.roots.esymm 2 := by
+  have hk : p.natDegree - 2 ≤ p.natDegree := Nat.sub_le _ _
+  have h := vieta_coeff p hcard hk
+  have hsub : p.natDegree - (p.natDegree - 2) = 2 := by omega
+  rw [hsub, hm.leadingCoeff] at h
+  rw [h]; ring
+
+/-- **Product of the roots.** For a monic, split polynomial, the constant coefficient
+is `(-1)^n` times the product of the roots: `coeff 0 = (-1)^n · ∏ roots`. -/
+theorem prod_of_roots (p : R[X]) (hm : p.Monic)
+    (hcard : Multiset.card p.roots = p.natDegree) :
+    p.coeff 0 = (-1) ^ p.natDegree * p.roots.prod :=
+  (splits_iff_card_roots.mpr hcard).coeff_zero_eq_prod_roots_of_monic hm
+
+/-! ## Section IV: Field (non-monic) versions
+
+Over a field we may divide by the leading coefficient and recover the familiar
+"`-a_{n-1}/a_n`" and "`(-1)^n a_0/a_n`" statements. -/
+
+section Field
+
+variable {F : Type*} [Field F]
+
+/-- Over a field, a split polynomial of degree `≥ 1` has leading coefficient nonzero. -/
+private theorem leadingCoeff_ne_zero_of_deg (p : F[X]) (hdeg : 1 ≤ p.natDegree) :
+    p.leadingCoeff ≠ 0 := by
+  intro h
+  rw [Polynomial.leadingCoeff_eq_zero] at h
+  rw [h] at hdeg
+  simp at hdeg
+
+/-- **Sum of the roots, field form.** `a_{n-1} / a_n = -∑ roots`. -/
+theorem sum_of_roots_field (p : F[X]) (hcard : Multiset.card p.roots = p.natDegree)
+    (hdeg : 1 ≤ p.natDegree) :
+    p.coeff (p.natDegree - 1) / p.leadingCoeff = - p.roots.sum := by
+  have hlc := leadingCoeff_ne_zero_of_deg p hdeg
+  have hk : p.natDegree - 1 ≤ p.natDegree := Nat.sub_le _ _
+  have h := vieta_coeff p hcard hk
+  have hsub : p.natDegree - (p.natDegree - 1) = 1 := by omega
+  rw [hsub, esymm_one_eq_sum] at h
+  rw [div_eq_iff hlc, h]
+  ring
+
+/-- **Product of the roots, field form.** `a_0 / a_n = (-1)^n · ∏ roots`. -/
+theorem prod_of_roots_field (p : F[X]) (hcard : Multiset.card p.roots = p.natDegree)
+    (hdeg : 1 ≤ p.natDegree) :
+    p.coeff 0 / p.leadingCoeff = (-1) ^ p.natDegree * p.roots.prod := by
+  have hlc := leadingCoeff_ne_zero_of_deg p hdeg
+  have h := (splits_iff_card_roots.mpr hcard).coeff_zero_eq_leadingCoeff_mul_prod_roots
+  -- h : p.coeff 0 = (-1)^n * p.leadingCoeff * p.roots.prod
+  rw [div_eq_iff hlc, h]
+  ring
+
+end Field
+
+/-! ## Section V: Symmetric-function form for `∏ (X - rᵢ)`
+
+The same content, phrased for a polynomial *presented* as a product of linear factors,
+using the `Multiset` infrastructure directly (no `roots`/splits hypotheses needed). -/
+
+/-- **Vieta in product form.** The `k`-th coefficient of `∏ (X - rᵢ)` is
+`(-1)^(m-k) · e_{m-k}(rᵢ)` where `m` is the number of factors. -/
+theorem prod_linear_coeff (s : Multiset R) {k : ℕ} (hk : k ≤ Multiset.card s) :
+    (s.map fun r => X - C r).prod.coeff k =
+      (-1) ^ (Multiset.card s - k) * s.esymm (Multiset.card s - k) :=
+  Multiset.prod_X_sub_C_coeff s hk
+
+/-- The next-to-leading coefficient of `∏ (X - rᵢ)` is `-(∑ rᵢ)`. -/
+theorem prod_linear_sub_one (s : Multiset R) (hs : 1 ≤ Multiset.card s) :
+    (s.map fun r => X - C r).prod.coeff (Multiset.card s - 1) = - s.sum := by
+  have hk : Multiset.card s - 1 ≤ Multiset.card s := Nat.sub_le _ _
+  have h := prod_linear_coeff s hk
+  have hsub : Multiset.card s - (Multiset.card s - 1) = 1 := by omega
+  rw [hsub, esymm_one_eq_sum] at h
+  rw [h]; ring
+
+/-! ## Section VI: Recovering the cubic (parent OQ-03-OQ-05)
+
+The general degree-`n` machinery specializes, at cardinality 3, to the classical Vieta
+relations for `(X - r₁)(X - r₂)(X - r₃)` proved in the parent entry. -/
+
+/-- The `X²` coefficient of `(X - r₁)(X - r₂)(X - r₃)` is `-(r₁ + r₂ + r₃)`,
+as the cardinality-3 instance of `prod_linear_sub_one`. -/
+theorem cubic_coeff_two (r₁ r₂ r₃ : R) :
+    (({r₁, r₂, r₃} : Multiset R).map fun r => X - C r).prod.coeff 2
+      = -(r₁ + r₂ + r₃) := by
+  have hcard : Multiset.card ({r₁, r₂, r₃} : Multiset R) = 3 := by simp
+  have h := prod_linear_sub_one ({r₁, r₂, r₃} : Multiset R) (by rw [hcard]; norm_num)
+  rw [hcard] at h
+  rw [show (3 - 1 : ℕ) = 2 from rfl] at h
+  rw [h]
+  simp only [Multiset.insert_eq_cons, Multiset.sum_cons, Multiset.sum_singleton]
+  ring
+
+/-- The constant coefficient of `(X - r₁)(X - r₂)(X - r₃)` is `-(r₁ r₂ r₃)`.
+Here we read it off directly via `coeff 0 = eval 0`, complementing `cubic_coeff_two`. -/
+theorem cubic_coeff_zero (r₁ r₂ r₃ : R) :
+    (({r₁, r₂, r₃} : Multiset R).map fun r => X - C r).prod.coeff 0
+      = -(r₁ * r₂ * r₃) := by
+  rw [Polynomial.coeff_zero_eq_eval_zero]
+  simp only [Multiset.insert_eq_cons, Multiset.map_cons, Multiset.map_singleton,
+    Multiset.prod_cons, Multiset.prod_singleton, Polynomial.eval_mul, Polynomial.eval_sub,
+    Polynomial.eval_X, Polynomial.eval_C]
+  ring
+
+end VietaGeneral

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/annotations.json
@@ -1,0 +1,134 @@
+[
+  {
+    "id": "ann-esymm-helper",
+    "proofId": "solution-of-cubic-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 36,
+      "endLine": 47
+    },
+    "type": "lemma",
+    "title": "First Symmetric Function Equals the Sum",
+    "content": "`esymm_one_eq_sum (s : Multiset R) : s.esymm 1 = s.sum`. The elementary symmetric function `Multiset.esymm s 1` is defined as the sum, over all 1-element sub-multisets of `s`, of their products. `Multiset.powersetCard_one` identifies those 1-element subsets with the singletons of `s`, so each product is just the element itself and the total is `∑ s`. This tiny lemma is what converts the abstract `e₁(roots)` appearing in the coefficient formula into the concrete sum of the roots used by `sum_of_roots`.",
+    "mathContext": "$e_1(r_1,\\ldots,r_n) = \\sum_i r_i$. In Mathlib, `esymm s k = ((s.powersetCard k).map Multiset.prod).sum`; the `k = 1` case collapses by `powersetCard_one`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "elementary symmetric polynomial",
+      "Multiset.esymm",
+      "powersetCard"
+    ],
+    "prerequisites": [
+      "multisets",
+      "elementary symmetric functions"
+    ]
+  },
+  {
+    "id": "ann-vieta-coeff",
+    "proofId": "solution-of-cubic-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 63
+    },
+    "type": "theorem",
+    "title": "The General Vieta Coefficient Formula",
+    "content": "`vieta_coeff (p : R[X]) (hcard : card p.roots = p.natDegree) (hk : k ≤ p.natDegree) : p.coeff k = p.leadingCoeff * (-1)^(n-k) * p.roots.esymm (n-k)`. This is the heart of degree-n Vieta and is a direct restatement of Mathlib's `Polynomial.coeff_eq_esymm_roots_of_card`. The same lemma already underlies the gallery's `vietas-formulas` entry (as `vieta_polynomial_coeff`); it is included here as the foundation from which the named relations below are derived. The hypothesis `card p.roots = p.natDegree` says p has 'as many roots as its degree', i.e. p splits.",
+    "mathContext": "$[x^k]\\,p = \\operatorname{lc}(p)\\,(-1)^{n-k}\\,e_{n-k}(\\text{roots})$. Every Vieta relation is a specialization of this in $k$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "Polynomial.roots",
+      "coeff_eq_esymm_roots_of_card",
+      "splitting field"
+    ],
+    "prerequisites": [
+      "polynomial roots with multiplicity",
+      "elementary symmetric functions"
+    ]
+  },
+  {
+    "id": "ann-named-monic",
+    "proofId": "solution-of-cubic-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 103
+    },
+    "type": "theorem",
+    "title": "Sum, Product, and Second Symmetric Function of the Roots",
+    "content": "For a monic split polynomial: `sum_of_roots` gives `coeff (n-1) = -∑ roots`, `coeff_sub_two_eq_esymm_two` gives `coeff (n-2) = e₂(roots)`, and `prod_of_roots` gives `coeff 0 = (-1)^n ∏ roots`. The first two are `vieta_coeff` specialized at `k = n-1` and `k = n-2`, with the natural-number identities `n-(n-1)=1` and `n-(n-2)=2` discharged by `omega` and `e₁` rewritten to the sum via `esymm_one_eq_sum`. `prod_of_roots` instead converts the cardinality hypothesis to a `Splits` predicate (`splits_iff_card_roots`) and applies Mathlib's `Splits.coeff_zero_eq_prod_roots_of_monic`. These explicit named relations are the new content not present in `vietas-formulas`.",
+    "mathContext": "Sum of roots $= -a_{n-1}$, product $= (-1)^n a_0$, and the $x^{n-2}$ coefficient is the second elementary symmetric function $e_2 = \\sum_{i<j} r_i r_j$ — for monic polynomials.",
+    "significance": "central",
+    "relatedConcepts": [
+      "sum of roots",
+      "product of roots",
+      "second symmetric function",
+      "Splits.coeff_zero_eq_prod_roots_of_monic"
+    ],
+    "prerequisites": [
+      "monic polynomials",
+      "natural-number subtraction (omega)"
+    ]
+  },
+  {
+    "id": "ann-field",
+    "proofId": "solution-of-cubic-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 104,
+      "endLine": 145
+    },
+    "type": "theorem",
+    "title": "Field Forms: Dividing by the Leading Coefficient",
+    "content": "Over a field, `sum_of_roots_field` gives `a_{n-1}/a_n = -∑ roots` and `prod_of_roots_field` gives `a_0/a_n = (-1)^n ∏ roots`. A private helper shows the leading coefficient is nonzero whenever `natDegree ≥ 1` (a degree-0 polynomial would contradict the hypothesis). The denominator is then cleared by `div_eq_iff` and the goal closed by `ring`. Stating the relations as the ratio `a_{n-k}/a_n` keeps the sign clean — no spurious `(-1)^(2n)` appears.",
+    "mathContext": "The textbook forms $-a_{n-1}/a_n = \\sum r_i$ and $(-1)^n a_0/a_n = \\prod r_i$, valid for any polynomial over a field that splits.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "field",
+      "leading coefficient",
+      "div_eq_iff"
+    ],
+    "prerequisites": [
+      "fields",
+      "division in Lean"
+    ]
+  },
+  {
+    "id": "ann-product-form",
+    "proofId": "solution-of-cubic-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 146,
+      "endLine": 167
+    },
+    "type": "theorem",
+    "title": "Vieta for an Explicit Product of Linear Factors",
+    "content": "`prod_linear_coeff` states that the k-th coefficient of `∏ (X - C rᵢ)` equals `(-1)^(m-k) · e_{m-k}(rᵢ)` (Mathlib's `Multiset.prod_X_sub_C_coeff`), and `prod_linear_sub_one` reads off the next-to-leading coefficient as `-(∑ rᵢ)`. These need no `roots` or `Splits` hypotheses — they apply to a polynomial presented directly as a product of linear factors, using exactly the `Multiset` infrastructure the parent's open question asked about.",
+    "mathContext": "For $\\prod_{i} (x - r_i)$ with $m$ factors, $[x^k] = (-1)^{m-k} e_{m-k}(r)$; the $x^{m-1}$ coefficient is $-\\sum r_i$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "product of linear factors",
+      "Multiset.prod_X_sub_C_coeff",
+      "elementary symmetric functions"
+    ],
+    "prerequisites": [
+      "multiset products of polynomials"
+    ]
+  },
+  {
+    "id": "ann-cubic-recovery",
+    "proofId": "solution-of-cubic-oq-03-oq-05-oq-01",
+    "range": {
+      "startLine": 168,
+      "endLine": 187
+    },
+    "type": "example",
+    "title": "Recovering the Parent Cubic",
+    "content": "`cubic_coeff_two` and `cubic_coeff_zero` instantiate the general theorems at the 3-element root multiset `{r₁, r₂, r₃}`: the `x²` coefficient is `-(r₁+r₂+r₃)` (via `prod_linear_sub_one` at cardinality 3) and the constant term is `-(r₁r₂r₃)` (read off as `coeff 0 = eval 0`). These reproduce the relations of the parent entry `solution-of-cubic-oq-03-oq-05`, demonstrating that the degree-n machinery subsumes the hand-expanded cubic case.",
+    "mathContext": "At $n = 3$: $a = -(r_1+r_2+r_3)$ and $c = -r_1 r_2 r_3$ — the classical cubic Vieta relations, now derived from the general degree-n theorems.",
+    "significance": "illustrative",
+    "relatedConcepts": [
+      "cubic equation",
+      "specialization",
+      "Vieta's formulas"
+    ],
+    "prerequisites": [
+      "the general theorems above"
+    ]
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/meta.json
@@ -1,0 +1,157 @@
+{
+  "id": "solution-of-cubic-oq-03-oq-05-oq-01",
+  "title": "Vieta's Formulas for Degree-n Polynomials",
+  "slug": "solution-of-cubic-oq-03-oq-05-oq-01",
+  "description": "Answers the open question of solution-of-cubic-oq-03-oq-05: yes, Vieta's formulas hold for arbitrary degree n via Mathlib's Polynomial.roots / Multiset.esymm infrastructure. From the single coefficient formula coeff k = leadingCoeff·(-1)^(n-k)·e_{n-k}(roots) we extract the classical named relations — sum of roots, product of roots, and the second symmetric function — in both monic and field (division) forms, plus the product-of-linear-factors form, and recover the cubic case as the cardinality-3 special case.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vieta%27s_formulas",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VietaGeneralOQ030505OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "vieta-formulas",
+      "symmetric-polynomials",
+      "elementary-symmetric",
+      "roots",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 187,
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic-oq-03-oq-05",
+        "relationship": "Parent: Vieta's formulas for the general cubic; this entry answers its first open question (degree-n generality)"
+      },
+      {
+        "id": "vietas-formulas",
+        "relationship": "Provides the core coefficient formula vieta_polynomial_coeff that this entry builds on"
+      },
+      {
+        "id": "solution-of-cubic-oq-03",
+        "relationship": "Ancestor: Vieta's for the depressed cubic"
+      }
+    ],
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "François Viète (1540–1603) discovered the relationship between the roots and coefficients of a polynomial. For a degree-$n$ polynomial $p(x) = a_n x^n + \\cdots + a_0$ that factors completely as $a_n \\prod_{i=1}^n (x - r_i)$, Vieta's formulas express every coefficient as an elementary symmetric function of the roots:\n$$\\frac{a_{n-k}}{a_n} = (-1)^k\\, e_k(r_1, \\ldots, r_n), \\qquad e_k = \\sum_{i_1 < \\cdots < i_k} r_{i_1}\\cdots r_{i_k}.$$\nIn particular the two extreme cases are the most familiar: the sum of the roots is $-a_{n-1}/a_n$ and the product of the roots is $(-1)^n a_0/a_n$. These relations are the gateway to the theory of symmetric polynomials and to Galois theory, where the coefficients are exactly the symmetric (Galois-invariant) functions of the roots.\n\nThe parent entry proved the cubic case by direct `ring` expansion of $(x-r_1)(x-r_2)(x-r_3)$ and asked whether the degree-$n$ case could be established in Lean through Mathlib's `Polynomial.roots` and `Multiset` machinery. This entry answers that question affirmatively and assembles the classical named relations for general $n$.",
+    "problemStatement": "Let $p$ be a polynomial over an integral domain $R$ whose root multiset (counted with multiplicity) has cardinality equal to $\\deg p = n$ — equivalently, $p$ splits. Then for every $k \\le n$,\n$$[x^k]\\,p = \\operatorname{lc}(p)\\,(-1)^{n-k}\\, e_{n-k}(\\text{roots}).$$\nSpecialized: for monic $p$ of degree $\\ge 1$ the coefficient of $x^{n-1}$ is $-\\sum r_i$; the coefficient of $x^{n-2}$ is $e_2(\\text{roots})$; the constant term is $(-1)^n \\prod r_i$. Over a field the leading coefficient may be divided out to give $a_{n-1}/a_n = -\\sum r_i$ and $a_0/a_n = (-1)^n \\prod r_i$.",
+    "proofStrategy": "The cornerstone is Mathlib's `Polynomial.coeff_eq_esymm_roots_of_card`, restated here as `vieta_coeff`; this same lemma already underlies the gallery's `vietas-formulas` entry. The new content is the systematic extraction of the individually-named classical relations. `sum_of_roots` and `coeff_sub_two_eq_esymm_two` specialize `vieta_coeff` at $k = n-1$ and $k = n-2$, using the helper `esymm_one_eq_sum` (which proves $e_1(s) = \\sum s$ from `powersetCard_one`) and `omega` to evaluate the natural-number subtraction $n - (n-1) = 1$. `prod_of_roots` invokes Mathlib's `Splits.coeff_zero_eq_prod_roots_of_monic` after converting the cardinality hypothesis to a `Splits` predicate via `splits_iff_card_roots`. The field versions `sum_of_roots_field` / `prod_of_roots_field` clear the denominator with `div_eq_iff` and finish by `ring`. `prod_linear_coeff` / `prod_linear_sub_one` give the same content phrased directly for an explicit product $\\prod (X - C r_i)$ via `Multiset.prod_X_sub_C_coeff`. Finally `cubic_coeff_two` and `cubic_coeff_zero` instantiate the general machinery at cardinality 3, recovering the parent's cubic relations.",
+    "keyInsights": [
+      "**One formula governs all coefficients.** Every Vieta relation is a specialization of `coeff_eq_esymm_roots_of_card`: choosing $k = n-1$ gives the sum of the roots, $k = n-2$ the second symmetric function, and $k = 0$ the product. The natural-number subtraction $n-k$ in the exponent and the `esymm` index is handled uniformly by `omega`.",
+      "**The named relations are the new content.** Mathlib (and the existing `vietas-formulas` entry) state the raw coefficient formula, but the explicit, individually-named relations — `coeff (n-1) = -∑ roots`, `coeff 0 = (-1)^n ∏ roots`, and the field-division forms `a_{n-1}/a_n = -∑ roots`, `a_0/a_n = (-1)^n ∏ roots` — are assembled here for arbitrary degree.",
+      "**First symmetric function = sum.** The helper `esymm_one_eq_sum` (proved from `Multiset.powersetCard_one`, which says the singletons of `s` are its 1-element subsets) is what turns the abstract `e_1(roots)` appearing in the coefficient formula into the concrete sum of the roots.",
+      "**Cardinality-of-roots is the splitting hypothesis.** The clean hypothesis `Multiset.card p.roots = p.natDegree` is equivalent (via `splits_iff_card_roots`) to `p` splitting into linear factors. This is exactly the condition under which a degree-$n$ polynomial has 'as many roots as its degree' and Vieta's formulas apply.",
+      "**Recovering the cubic.** `cubic_coeff_two` and `cubic_coeff_zero` show the general degree-$n$ theorems specialize, at a 3-element root multiset, to the $x^2$ and constant coefficients $-(r_1+r_2+r_3)$ and $-(r_1 r_2 r_3)$ of the parent entry — the general machinery subsumes the hand-expanded cubic case."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-03-oq-05",
+      "relationship": "answers",
+      "description": "This entry resolves the first open question of solution-of-cubic-oq-03-oq-05 — that Vieta's formulas can be proved for degree-n polynomials in Lean using Mathlib's Polynomial.roots and Multiset infrastructure — and recovers that entry's cubic relations as the cardinality-3 special case."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "extends",
+      "description": "vietas-formulas already states the general coefficient formula (vieta_polynomial_coeff, identical to vieta_coeff here, both citing Mathlib's coeff_eq_esymm_roots_of_card). This entry extends that base by extracting the explicit named relations — sum of roots, product of roots, second symmetric function, and their field-division forms — which vietas-formulas does not state."
+    },
+    {
+      "targetId": "vietas-formulas-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Generalized Newton's identities express power sums of the roots in terms of elementary symmetric functions; together with Vieta's formulas (this entry) they express the coefficients via power sums."
+    }
+  ],
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Polynomial",
+      "Multiset"
+    ],
+    "namespace": "VietaGeneral",
+    "lineCount": 187,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/VietaGeneralOQ030505OQ01.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Documentation header stating the open question being answered and summarizing the degree-n Vieta formulas. Imports Mathlib, opens Polynomial and Multiset, works over an integral domain R.",
+      "mathContext": "The hypothesis throughout is that the root multiset of p has cardinality equal to deg p, i.e. p splits into linear factors over R."
+    },
+    {
+      "id": "sec-esymm-helper",
+      "title": "Elementary Symmetric Helper",
+      "startLine": 36,
+      "endLine": 47,
+      "summary": "esymm_one_eq_sum: the first elementary symmetric function of a multiset equals its sum, e₁(s) = ∑ s. Proved from Multiset.powersetCard_one.",
+      "mathContext": "`Multiset.esymm s 1 = ((s.powersetCard 1).map Multiset.prod).sum`; `powersetCard_one` identifies the 1-element sub-multisets with the singletons of s, so the products collapse to the elements and the sum is ∑ s."
+    },
+    {
+      "id": "sec-coeff",
+      "title": "General Vieta Coefficient Formula",
+      "startLine": 48,
+      "endLine": 63,
+      "summary": "vieta_coeff: for p over an integral domain with card roots = natDegree, coeff k = leadingCoeff·(-1)^(n-k)·e_{n-k}(roots). This restates Mathlib's coeff_eq_esymm_roots_of_card and matches vietas-formulas' vieta_polynomial_coeff.",
+      "mathContext": "`Polynomial.coeff_eq_esymm_roots_of_card (hroots) (hk)` is the single Mathlib lemma from which all named relations below are derived."
+    },
+    {
+      "id": "sec-named-monic",
+      "title": "Classical Named Relations (Monic Case)",
+      "startLine": 64,
+      "endLine": 103,
+      "summary": "sum_of_roots (coeff (n-1) = -∑ roots), coeff_sub_two_eq_esymm_two (coeff (n-2) = e₂(roots)), and prod_of_roots (coeff 0 = (-1)^n ∏ roots), for monic split polynomials. The first two specialize vieta_coeff at k = n-1, n-2; the third cites Splits.coeff_zero_eq_prod_roots_of_monic.",
+      "mathContext": "These are the individually-named Vieta relations. natDegree subtraction is discharged by omega; esymm_one_eq_sum converts e₁ to the sum; splits_iff_card_roots converts the cardinality hypothesis to a Splits predicate for the product formula."
+    },
+    {
+      "id": "sec-field",
+      "title": "Field (Non-Monic) Versions",
+      "startLine": 104,
+      "endLine": 145,
+      "summary": "Over a field: sum_of_roots_field (a_{n-1}/a_n = -∑ roots) and prod_of_roots_field (a_0/a_n = (-1)^n ∏ roots). A private lemma establishes leadingCoeff ≠ 0 from degree ≥ 1; the division is cleared by div_eq_iff and closed by ring.",
+      "mathContext": "These are the textbook 'divide by the leading coefficient' forms valid for any split polynomial over a field, recovering -a_{n-1}/a_n and (-1)^n a_0/a_n."
+    },
+    {
+      "id": "sec-product-form",
+      "title": "Symmetric-Function Form for a Product of Linear Factors",
+      "startLine": 146,
+      "endLine": 167,
+      "summary": "prod_linear_coeff: the k-th coefficient of ∏(X - C rᵢ) is (-1)^(m-k)·e_{m-k}(rᵢ) (Mathlib's Multiset.prod_X_sub_C_coeff). prod_linear_sub_one: its next-to-leading coefficient is -(∑ rᵢ). No roots/splits hypotheses needed.",
+      "mathContext": "This phrases Vieta directly for a polynomial presented as a product of linear factors, using the Multiset infrastructure the open question asked about."
+    },
+    {
+      "id": "sec-cubic-recovery",
+      "title": "Recovering the Cubic (Parent OQ-03-OQ-05)",
+      "startLine": 168,
+      "endLine": 187,
+      "summary": "cubic_coeff_two and cubic_coeff_zero: instantiating the general theorems at the 3-element multiset {r₁,r₂,r₃} gives the x² coefficient -(r₁+r₂+r₃) and constant term -(r₁r₂r₃) of the parent cubic entry.",
+      "mathContext": "cubic_coeff_two applies prod_linear_sub_one at cardinality 3; cubic_coeff_zero reads off the constant term via coeff 0 = eval 0. Together they show the general degree-n machinery subsumes the hand-expanded cubic Vieta of the parent."
+    }
+  ],
+  "conclusion": {
+    "summary": "Vieta's formulas are established for arbitrary degree n over any integral domain (and field), with 0 sorries and 0 axioms. The classical named relations — sum of roots, product of roots, second symmetric function, and their field-division forms — are extracted from the single Mathlib coefficient formula, and the parent's cubic relations are recovered as the cardinality-3 instance. This affirmatively answers the parent's open question: Mathlib's Polynomial.roots / Multiset.esymm machinery fully covers the general case.",
+    "implications": "The named relations provide ready-to-use lemmas for any argument relating a split polynomial's coefficients to symmetric functions of its roots — trace and determinant of a matrix from its characteristic polynomial, Newton's identities, discriminants, and the Galois-theoretic fact that coefficients are the symmetric (invariant) functions of the roots.",
+    "openQuestions": [
+      "Extract the general k-th relation coeff (n-k) = e_k(roots) for monic split polynomials as a single uniform theorem (the entry states k = 0, 1, 2 explicitly).",
+      "Combine these Vieta relations with the gallery's generalized Newton identities to express the power sums ∑ rᵢ^m of the roots directly in terms of the polynomial's coefficients."
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `solution-of-cubic-oq-03-oq-05` ("Vieta's Formulas for the General Cubic"):

> Can Vieta's formulas for degree-n polynomials be proved in generality in Lean using Mathlib's `Polynomial.roots` and `Multiset` infrastructure? Do Mathlib's `Polynomial.Vieta` lemmas cover the general case?

**Yes.** From the single coefficient formula `coeff k = leadingCoeff·(-1)^(n-k)·e_{n-k}(roots)` (Mathlib's `coeff_eq_esymm_roots_of_card`) the entry extracts the classical **named** root–coefficient relations for arbitrary degree:

- `sum_of_roots` — `coeff (n-1) = -∑ roots` (monic)
- `coeff_sub_two_eq_esymm_two` — `coeff (n-2) = e₂(roots)` (monic)
- `prod_of_roots` — `coeff 0 = (-1)^n ∏ roots` (monic)
- `sum_of_roots_field` / `prod_of_roots_field` — the field `a_{n-k}/a_n` forms
- `prod_linear_coeff` / `prod_linear_sub_one` — the product-of-linear-factors form via `Multiset.prod_X_sub_C_coeff`
- `cubic_coeff_two` / `cubic_coeff_zero` — recover the parent cubic relations at cardinality 3

## Verification
- **12 theorems, 187 lines, 0 sorries, 0 axioms** (`#print axioms` shows only `propext`/`Classical.choice`/`Quot.sound` for every theorem).
- Builds against Mathlib (toolchain v4.26.0).

## Honest scope note
The base coefficient formula `vieta_coeff` is identical to `vieta_polynomial_coeff` in the existing **`vietas-formulas`** gallery entry (both cite the same Mathlib lemma); it is included here as the foundation and **credited in the meta/cross-references**. The genuinely new content is the set of explicit **named** relations (sum/product/second-symmetric of roots, field-division forms, general product form) which `vietas-formulas` does not state, plus the concrete recovery of the parent cubic.

## Files
- `proofs/Proofs/VietaGeneralOQ030505OQ01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/solution-of-cubic-oq-03-oq-05-oq-01/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)