### PR TITLE
Enrich The Third Moment of the Geometric Series: ∑ n³ rⁿ

### DIFF
--- a/src/data/proofs/geometric-series-oq-10/annotations.json
+++ b/src/data/proofs/geometric-series-oq-10/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview-moments",
+    "proofId": "geometric-series-oq-10",
+    "range": { "startLine": 5, "endLine": 64 },
+    "type": "context",
+    "title": "The Moment Family and the Rising-Binomial Technique",
+    "content": "The weighted geometric sums ∑ nᵏ·rⁿ are the moments of the geometric distribution, arising from repeatedly applying r·d/dr to ∑ rⁿ = 1/(1−r), with Eulerian-polynomial numerators. Mathlib has only the zeroth and first moments; the sibling geometric-series-oq-07 added the second via a degree-2 rising-binomial identity, and this entry takes the next step to the third. The technique: every nᵏ lies in the finite span of {(n+j choose j) : j ≤ k} that Mathlib already sums, so each moment is a finite linear combination of known HasSum facts rather than a fresh convergence proof.",
+    "mathContext": "$\\sum r^n,\\ \\sum n r^n=\\frac{r}{(1-r)^2},\\ \\sum n^2 r^n=\\frac{r(1+r)}{(1-r)^3},\\ \\sum n^3 r^n=\\frac{r(1+4r+r^2)}{(1-r)^4}$.",
+    "significance": "context",
+    "relatedConcepts": ["moments", "Eulerian polynomials", "rising-binomial basis", "geometric distribution"],
+    "prerequisites": ["geometric series", "infinite sums"]
+  },
+  {
+    "id": "ann-cast-choose-three",
+    "proofId": "geometric-series-oq-10",
+    "range": { "startLine": 72, "endLine": 90 },
+    "type": "theorem",
+    "title": "The Column-3 Binomial Cast",
+    "content": "`cast_choose_three`: (n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6. Mathlib supplies cast lemmas only up to column 2 (Nat.cast_choose_two), so this is derived from Nat.cast_choose (the factorial form b!/(a!(b−a)!)) together with the factorial expansion (n+3)! = (n+1)(n+2)(n+3)·n! (three applications of Nat.factorial_succ), then field_simp. This is the one genuinely new piece of infrastructure the degree-3 moment needs.",
+    "mathContext": "$\\binom{n+3}{3}=\\frac{(n+3)!}{3!\\,n!}=\\frac{(n+1)(n+2)(n+3)}{6}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.cast_choose", "Nat.factorial_succ", "binomial coefficient", "column-3 cast"],
+    "prerequisites": ["binomial coefficients", "factorials"]
+  },
+  {
+    "id": "ann-cube-eq",
+    "proofId": "geometric-series-oq-10",
+    "range": { "startLine": 92, "endLine": 99 },
+    "type": "theorem",
+    "title": "The Cube Identity in the Rising-Binomial Basis",
+    "content": "`cube_eq`: n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1, cast to ℝ. Substituting cast_choose_three, Nat.cast_choose_two, and Nat.choose_one_right and closing by push_cast; ring. The coefficients (6,−12,7,−1) are Newton's forward-difference (binomial) transform of the cube sequence — expanding n³ against the rising-binomial basis is exactly finite-difference calculus, with Stirling-number-weighted coefficients.",
+    "mathContext": "$n^3=6\\binom{n+3}{3}-12\\binom{n+2}{2}+7\\binom{n+1}{1}-1$; coefficients $=$ forward-difference transform.",
+    "significance": "key",
+    "relatedConcepts": ["forward differences", "binomial transform", "Stirling numbers", "basis expansion"],
+    "prerequisites": ["binomial coefficients", "finite differences"]
+  },
+  {
+    "id": "ann-low-moments",
+    "proofId": "geometric-series-oq-10",
+    "range": { "startLine": 101, "endLine": 112 },
+    "type": "context",
+    "title": "The Zeroth and First Moments",
+    "content": "tsum_geometric (∑ rⁿ = 1/(1−r), the geometric series itself) and tsum_mul_geometric (∑ n·rⁿ = r/(1−r)², restating Mathlib's tsum_coe_mul_geometric_of_norm_lt_one) are displayed to show the full low-order moment family. They are the k = 0 and k = 1 cases; the sibling oq-07 gives k = 2 and this entry adds k = 3.",
+    "mathContext": "$\\sum_n r^n=\\frac{1}{1-r}$ (zeroth), $\\sum_n n r^n=\\frac{r}{(1-r)^2}$ (first).",
+    "significance": "supporting",
+    "relatedConcepts": ["zeroth moment", "first moment", "moment family"],
+    "prerequisites": ["geometric series"]
+  },
+  {
+    "id": "ann-third-moment",
+    "proofId": "geometric-series-oq-10",
+    "range": { "startLine": 114, "endLine": 159 },
+    "type": "theorem",
+    "title": "The Third Moment ∑ n³·rⁿ = r(1+4r+r²)/(1−r)⁴",
+    "content": "`hasSum_cube_mul_geometric`: the headline. Takes the four rising-binomial HasSum facts hasSum_choose_mul_geometric_of_norm_lt_one at k = 3,2,1,0 (values 1/(1−r)^{k+1}) and forms the linear combination 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ via HasSum.mul_left/add/sub. By cube_eq the summand equals n³·rⁿ, and the value 6/(1−r)⁴ − 12/(1−r)³ + 7/(1−r)² − 1/(1−r) collapses to r(1+4r+r²)/(1−r)⁴ by field_simp; ring (core: 6 − 12(1−r) + 7(1−r)² − (1−r)³ = r(1+4r+r²)). tsum and summability forms follow via HasSum.tsum_eq/summable.",
+    "mathContext": "$\\sum_n n^3 r^n = 6\\cdot\\frac{1}{(1-r)^4}-12\\cdot\\frac{1}{(1-r)^3}+7\\cdot\\frac{1}{(1-r)^2}-\\frac{1}{1-r}=\\frac{r(1+4r+r^2)}{(1-r)^4}$.",
+    "significance": "critical",
+    "relatedConcepts": ["hasSum_choose_mul_geometric_of_norm_lt_one", "HasSum.mul_left", "linear combination", "field_simp"],
+    "prerequisites": ["HasSum arithmetic", "field arithmetic"]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "geometric-series-oq-10",
+    "range": { "startLine": 161, "endLine": 167 },
+    "type": "technique",
+    "title": "Concrete Value ∑ n³/2ⁿ = 26",
+    "content": "A sanity check at r = 1/2: ∑ n³·(1/2)ⁿ = 26, since r(1+4r+r²)/(1−r)⁴ = (1/2)(13/4)/(1/16) = 26. Instantiates tsum_cube_mul_geometric and finishes by norm_num, anchoring the symbolic closed form to a verifiable numerical value.",
+    "mathContext": "$\\sum_n n^3/2^n=\\frac{(1/2)(1+2+1/4)}{(1/2)^4}=\\frac{(1/2)(13/4)}{1/16}=26$.",
+    "significance": "technical",
+    "relatedConcepts": ["concrete instance", "numerical verification", "norm_num"],
+    "prerequisites": ["arithmetic"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-10/meta.json
+++ b/src/data/proofs/geometric-series-oq-10/meta.json
@@ -20,6 +20,45 @@
     "sorries": 0
   },
   "title": "The Third Moment of the Geometric Series: ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴",
+  "description": "The third moment of the geometric series, ∑_{n≥0} n³·rⁿ = r(1+4r+r²)/(1−r)⁴ for ‖r‖ < 1 over ℝ — the next term beyond the second-moment sibling, completing the low-order family ∑ rⁿ, ∑ n·rⁿ, ∑ n²·rⁿ, ∑ n³·rⁿ. Mathlib has only the zeroth and first moments. The proof assembles the third moment as a linear combination 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ of four Mathlib rising-binomial HasSum facts, using the basis identity n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1; the only new infrastructure is the column-3 binomial cast (n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6, which Mathlib supplies only to column 2.",
+  "overview": {
+    "historicalContext": "The weighted geometric sums ∑ nᵏ·rⁿ — the moments of the geometric distribution — arise from repeatedly applying the derivative operator r·d/dr to ∑ rⁿ = 1/(1−r), and their numerators are the Eulerian polynomials (Graham–Knuth–Patashnik, Concrete Mathematics). Mathlib formalizes the zeroth moment (the geometric series) and the first moment ∑ n·rⁿ = r/(1−r)², but stops there: no n² or n³ sum. The sibling geometric-series-oq-07 added the second moment via a degree-2 rising-binomial identity; this entry takes the next step to the third moment, demonstrating that the rising-binomial assembly technique scales to any degree. The coefficient pattern of the numerators (1, r, r(1+r), r(1+4r+r²)) is the sequence of Eulerian polynomials, pointing to the general-moment formula posed as the open question.",
+    "problemStatement": "Prove the closed form for the third moment of the geometric series: ∑_{n≥0} n³·rⁿ = r(1+4r+r²)/(1−r)⁴ for ‖r‖ < 1 over ℝ, in HasSum, tsum, and summability forms, and supply the column-3 binomial cast that Mathlib lacks. Verify the concrete value ∑ n³/2ⁿ = 26.",
+    "proofStrategy": "Express n³ in the rising-binomial basis Mathlib already sums, then take a linear combination. (1) cast_choose_three derives the column-3 cast (n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6 from Nat.cast_choose and the factorial expansion (n+3)! = (n+1)(n+2)(n+3)·n! (Mathlib provides casts only to column 2). (2) cube_eq establishes n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1 (push_cast; ring), the coefficients (6,−12,7,−1) being Newton's forward-difference transform of n³. (3) hasSum_cube_mul_geometric takes the four rising-binomial HasSum facts hasSum_choose_mul_geometric_of_norm_lt_one at k = 3,2,1,0 (values 1/(1−r)^{k+1}) and forms 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ via HasSum.mul_left/add/sub; the summand becomes n³·rⁿ by cube_eq, and the value 6/(1−r)⁴ − 12/(1−r)³ + 7/(1−r)² − 1/(1−r) collapses to r(1+4r+r²)/(1−r)⁴ by field_simp; ring.",
+    "keyInsights": [
+      "Every monomial nᵏ lies in the finite span of the rising-binomial functions {(n+j choose j) : j ≤ k} that Mathlib already sums, so each moment is a FINITE linear combination of known HasSum facts — not a fresh convergence argument.",
+      "The coefficients (6,−12,7,−1) are Newton's forward-difference (binomial) transform of the cube sequence: expanding n³ against the rising-binomial basis is exactly the finite-difference calculus, and these are the Stirling-number-weighted coefficients.",
+      "HasSum is closed under the linear operations used: HasSum.mul_left, HasSum.add, HasSum.sub let four convergent series be combined term-by-term into the n³·rⁿ series with no re-proof of summability.",
+      "The only genuinely new infrastructure at degree 3 is the column-3 binomial cast (n+3 choose 3) = (n+1)(n+2)(n+3)/6; Mathlib stops at column 2 (Nat.cast_choose_two), and this is derived in a few lines from the factorial form.",
+      "The numerator sequence 1, r, r(1+r), r(1+4r+r²) is the sequence of Eulerian polynomials Aₖ(r): the general moment is ∑ nᵏ·rⁿ = Aₖ(r)/(1−r)^{k+1}, the natural induction the open question proposes."
+    ]
+  },
+  "sections": [
+    {
+      "id": "casts-and-identity",
+      "title": "Rising-Binomial Casts and the Cube Identity",
+      "startLine": 72,
+      "endLine": 99,
+      "summary": "cast_choose_three supplies the column-3 binomial cast (n+3 choose 3 : ℝ) = (n+1)(n+2)(n+3)/6, derived from Nat.cast_choose and the factorial expansion (n+3)! = (n+1)(n+2)(n+3)·n! (Mathlib stops at column 2). cube_eq establishes the basis identity n³ = 6·(n+3 choose 3) − 12·(n+2 choose 2) + 7·(n+1 choose 1) − 1 (push_cast; ring), the coefficients being the forward-difference transform of n³.",
+      "mathContext": "$\\binom{n+3}{3}=\\frac{(n+1)(n+2)(n+3)}{6}$; $n^3=6\\binom{n+3}{3}-12\\binom{n+2}{2}+7\\binom{n+1}{1}-1$."
+    },
+    {
+      "id": "moment-family",
+      "title": "The Low-Order Moment Family",
+      "startLine": 101,
+      "endLine": 112,
+      "summary": "Displays the existing low-order moments for context: tsum_geometric (∑ rⁿ = 1/(1−r), the zeroth moment) and tsum_mul_geometric (∑ n·rⁿ = r/(1−r)², the first moment, restating Mathlib's tsum_coe_mul_geometric_of_norm_lt_one). Together with the sibling's second moment and the new third moment, these complete the family ∑ nᵏ·rⁿ for k = 0,1,2,3.",
+      "mathContext": "$\\sum r^n=\\frac{1}{1-r}$, $\\sum n r^n=\\frac{r}{(1-r)^2}$ (Mathlib's zeroth/first moments)."
+    },
+    {
+      "id": "third-moment",
+      "title": "The Third Moment (New Result)",
+      "startLine": 114,
+      "endLine": 167,
+      "summary": "hasSum_cube_mul_geometric: ∑ n³·rⁿ = r(1+4r+r²)/(1−r)⁴. Takes the four rising-binomial HasSum facts at k = 3,2,1,0 and forms 6·h₃ − 12·h₂ + 7·h₁ − 1·h₀ (HasSum.mul_left/add/sub); the summand becomes n³·rⁿ by cube_eq, and the value collapses via field_simp; ring (algebraic core 6 − 12(1−r) + 7(1−r)² − (1−r)³ = r(1+4r+r²)). tsum and summability forms follow; a concrete check confirms ∑ n³/2ⁿ = 26.",
+      "mathContext": "$\\sum_n n^3 r^n = \\dfrac{r(1+4r+r^2)}{(1-r)^4}$; e.g. $\\sum_n n^3/2^n = 26$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
## Summary

Enrichment pass for `geometric-series-oq-10` (*The Third Moment of the Geometric Series: ∑ n³ rⁿ = r(1+4r+r²)/(1-r)⁴*). The entry previously had only `meta.json` (no overview, sections, or annotations).

## Changes
- **description**: top-level summary of the third moment and the rising-binomial assembly technique.
- **overview**: `historicalContext` (moments / Eulerian polynomials / the Mathlib gap), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (nᵏ in the finite span of rising binomials; forward-difference coefficients; HasSum closed under the linear ops; the column-3 cast; the Eulerian-polynomial numerator pattern).
- **sections**: 3 sections covering the full Lean file (casts + cube identity; low-order moment family; third moment + concrete value).
- **annotations.json**: 6 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- No `index.ts`: the gallery loader uses the build-generated manifest; this entry is already registered.

## Verification
- JSON validated for both files.
- Axiom integrity unchanged: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean file (0 sorries, 0 axioms; propext/Classical.choice/Quot.sound only).