### PR TITLE
Enrich q-Fold Residue-Class Splitting of the Geometric Series

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-infmoment-eq-eulerpoly",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 67, "endLine": 73 },
+    "type": "concept",
+    "title": "Closed-Form Solution of the Infinite Recurrence",
+    "content": "`infMoment_eq_eulerPoly` is the headline result: for |x| < 1, the infinite m-th moment infMoment m x = ∑'_{k} kᵐ·xᵏ equals the Eulerian-polynomial closed form Eₘ(x)/(1 − x)^{m+1}. This identifies two independently developed gallery objects — the tsum-defined moment characterised in the parent only by the convolution recurrence (★∞), and the Frobenius/Eulerian closed form of the sibling line. The proof is a single line: the sibling file already proves the analytic HasSum statement, and `HasSum.tsum_eq` converts a HasSum into its tsum value, so `simpa only [infMoment] using (...).tsum_eq` closes the goal. The brevity is the point — all the analytic work lives upstream; this lemma is the bridge.",
+    "mathContext": "$\\mathrm{infMoment}\\,m\\,x = \\sum_{k=0}^{\\infty} k^m x^k = \\dfrac{E_m(x)}{(1-x)^{m+1}}$ for $|x| < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian polynomials", "infinite series", "tsum", "HasSum.tsum_eq", "Frobenius identity", "moments of geometric distribution"],
+    "prerequisites": ["infinite series", "Eulerian polynomials", "real analysis"]
+  },
+  {
+    "id": "ann-eulerpoly-recurrence",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 77, "endLine": 94 },
+    "type": "insight",
+    "title": "The Eulerian Polynomials Satisfy (★∞) as a Polynomial Identity",
+    "content": "`eulerPoly_recurrence` is the genuinely new content: the Eulerian polynomials themselves obey the (★∞) binomial-convolution recurrence as an exact identity in ℝ[X], (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}. This is the algebraic shadow of the analytic recurrence: clearing the denominators (1 − x)^{i+1} from the closed form converts the convergent-series convolution into a single homogeneous polynomial identity, linking the derivative-free Pascal recursion to the differential recurrence E_{m+1} = X(1−X)·E′ₘ + (m+1)·X·Eₘ that defines eulerPoly. No analogous statement exists in Mathlib.",
+    "mathContext": "$(1-X)E_m = 0^m(1-X)^{m+1} + X\\sum_{i<m}\\binom{m}{i}E_i(1-X)^{m-i}$ in $\\mathbb{R}[X]$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian polynomials", "binomial convolution", "Pascal's rule", "polynomial identity", "recurrence relations"],
+    "prerequisites": ["polynomial rings", "binomial coefficients", "recurrences"]
+  },
+  {
+    "id": "ann-eq-of-infinite-eval",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 95, "endLine": 120 },
+    "type": "technique",
+    "title": "Analytic-to-Algebraic Transfer via Polynomial Extensionality",
+    "content": "The polynomial identity is proved without touching a single coefficient. `eq_of_infinite_eval_eq` says two polynomials over an integral domain that agree on an infinite set of points are equal; `Set.Ioo_infinite` supplies the infinite set (−1,1). At each r in that interval the proof rewrites every eval Eᵢ(r) as infMoment i r · (1−r)^{i+1} (the closed form, via div_mul_cancel₀), pulls the common factor (1−r)^{m+1} out of the binomial sum (matching degrees with show m + 1 = (i+1) + (m−i); pow_add; ring), and then reduces to the parent's analytic recurrence (★∞) via `linear_combination (1 − r)^{m+1} * hrec`. This converts an analysis fact about convergent series into an exact algebraic identity in ℝ[X] — a transfer principle worth recognising on its own.",
+    "mathContext": "Agreement on the infinite set $(-1,1)$ forces equality in $\\mathbb{R}[X]$, an integral domain.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial extensionality", "eq_of_infinite_eval_eq", "integral domain", "linear_combination", "analytic continuation analogue"],
+    "prerequisites": ["polynomial rings", "integral domains", "real intervals"]
+  },
+  {
+    "id": "ann-infmoment-three",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 122, "endLine": 143 },
+    "type": "definition",
+    "title": "Low-Order Moments and the New Third Moment",
+    "content": "Specialising the headline closed form at small m recovers the known low moments and produces a new one. infMoment_one (= x/(1 − x)²) and infMoment_two (= (x + x²)/(1 − x)³) confirm consistency with the parent's directly-solved cases. infMoment_three gives the new explicit third moment ∑_{k} k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴, obtained for free by evaluating E₃ = X + 4X² + X³ — whose coefficients 1, 4, 1 are the Eulerian numbers ⟨3,0⟩, ⟨3,1⟩, ⟨3,2⟩ — over (1 − x)⁴. Each is a two-line rw of the closed form and the corresponding eulerPoly value.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} k^3 x^k = \\dfrac{x + 4x^2 + x^3}{(1-x)^4}$, with $1,4,1$ the Eulerian numbers $\\langle 3,j\\rangle$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Eulerian numbers", "third moment", "geometric distribution", "specialisation"],
+    "prerequisites": ["Eulerian polynomials", "polynomial evaluation"]
+  },
+  {
+    "id": "ann-honest-scope",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 44, "endLine": 56 },
+    "type": "context",
+    "title": "Honest Scope: What Is Reused vs. New",
+    "content": "The file is explicit about provenance, a good model for research-entry framing. The headline closed form is NOT re-derived from scratch by strong induction on (★∞); it reuses the gallery's analytic Eulerian identity hasSum_pow_mul_geometric_eulerPoly, which itself rests on Frobenius' identity and the Stirling moment formula. The genuinely new deliverables are (1) the polynomial recurrence eulerPoly_recurrence — an explicit relation among the Eulerian polynomials and binomial weights not in Mathlib — and (2) the explicit third-moment closed form. The remaining open question asks for the harder analysis-free route: prove eulerPoly_recurrence by induction on m from the differential recurrence and Pascal's rule alone, yielding a derivation of the Eulerian closed form directly from (★∞).",
+    "mathContext": "New: $E_m$ satisfy (★∞) in $\\mathbb{R}[X]$, and $\\sum k^3 x^k$. Reused: the analytic Frobenius closed form.",
+    "significance": "context",
+    "relatedConcepts": ["proof provenance", "Frobenius identity", "Stirling numbers", "axiom integrity", "research framing"],
+    "prerequisites": ["mathematical exposition"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -20,6 +20,7 @@
     "sorries": 0
   },
   "title": "Solving the Infinite-Limit Recurrence (★∞) in Closed Form: infMoment m x = Eₘ(x)/(1 − x)^{m+1}",
+  "description": "Closes the loop between two gallery descriptions of the infinite geometric moments ∑'_{k} kᵐ·xᵏ: the parent's derivative-free binomial-convolution recurrence (★∞) and the sibling's differential Eulerian-polynomial closed form. Proves the headline identity infMoment m x = Eₘ(x)/(1 − x)^{m+1} for all m, a NEW polynomial recurrence showing the Eulerian polynomials themselves satisfy (★∞) over ℝ[X] (via polynomial extensionality on the infinite set (−1,1)), and the explicit third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -74,6 +75,41 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The rational closed forms ∑_{k≥0} kᵐ·xᵏ = Aₘ(x)/(1 − x)^{m+1} are classical: the numerators Aₘ are the Eulerian polynomials, whose coefficients ⟨m,j⟩ are the Eulerian numbers counting permutations of {1,…,m} with j descents. Leonhard Euler introduced these numbers in 1755 while summing exactly such series; Worpitzky's 1883 identity expands kᵐ in the binomial basis (k+j choose m) with Eulerian-number coefficients, the combinatorial root of the closed form. Two recurrences for the Eulerian polynomials coexist in the literature: a differential one, Aₘ₊₁ = x(1−x)A′ₘ + (1 + mx)Aₘ (here in the geometric normalisation Eₘ₊₁ = X(1−X)E′ₘ + (m+1)X·Eₘ), and a Pascal-style binomial-convolution one. This entry formalises the bridge between them inside Lean: the convolution recurrence (★∞), proved analytically for the tsum-defined moments, is shown to hold for the Eulerian polynomials themselves as an exact identity in ℝ[X].",
+    "problemStatement": "Let infMoment m x := $\\sum_{k=0}^{\\infty} k^m x^k$ for $|x| < 1$ (defined in the parent, where it is characterised only by the recurrence $(1-x)\\,\\mathrm{infMoment}\\,m\\,x = 0^m + x\\sum_{i<m}\\binom{m}{i}\\mathrm{infMoment}\\,i\\,x$, (★∞)). Solve (★∞) in closed form for all m, i.e. prove $\\mathrm{infMoment}\\,m\\,x = \\dfrac{E_m(x)}{(1-x)^{m+1}}$ with $E_m$ the Eulerian polynomial; show the $E_m$ satisfy (★∞) as a polynomial identity $(1-X)E_m = 0^m(1-X)^{m+1} + X\\sum_{i<m}\\binom{m}{i}E_i(1-X)^{m-i}$ in $\\mathbb{R}[X]$; and read off the explicit third moment.",
+    "proofStrategy": "Part 1 (infMoment_eq_eulerPoly) is a one-liner: the sibling file already proves the analytic Frobenius identity HasSum (kᵐ·rᵏ) (Eₘ(r)/(1−r)^{m+1}), and HasSum.tsum_eq converts it to the tsum value, identifying the two descriptions. Part 2 (eulerPoly_recurrence) is the genuinely new content and uses a polynomial-extensionality strategy: rather than manipulating polynomials directly, it shows both sides agree at every real r ∈ (−1,1) — there the closed form rewrites each eval Eᵢ(r) as infMoment i r · (1−r)^{i+1}, pulling a common (1−r)^{m+1} out of the binomial sum, after which the parent's analytic recurrence (★∞) closes the goal by linear_combination. Since (−1,1) is infinite (Set.Ioo_infinite) and ℝ[X] is over an integral domain, Polynomial.eq_of_infinite_eval_eq promotes pointwise equality to the polynomial identity. Part 3 specialises the headline closed form at m = 1, 2, 3 using the low-order Eulerian values, recovering x/(1−x)², (x+x²)/(1−x)³, and the new (x+4x²+x³)/(1−x)⁴.",
+    "keyInsights": [
+      "The same sequence of polynomials is pinned down by two structurally different recurrences — a differential one (defining eulerPoly in the sibling file) and a derivative-free binomial-convolution one (★∞) — and this entry proves they coincide. Establishing that two recurrences define the same object is exactly the kind of 'closing the loop' result that unifies a family.",
+      "The proof of the polynomial identity never touches a single polynomial coefficient: it evaluates both sides at infinitely many real points and invokes eq_of_infinite_eval_eq. This 'analytic-to-algebraic' transfer — agreement on an infinite set forces equality of polynomials over an integral domain — converts an analysis fact (the convergent series recurrence) into an exact algebraic one in ℝ[X].",
+      "Clearing the denominators (1 − x)^{i+1} from the closed form is what turns the analytic convolution recurrence (★∞) into a single homogeneous polynomial identity: each term contributes a power of (1 − X), and matching the total degree m + 1 across the sum is the algebraic heart of the rewrite (the show m + 1 = (i + 1) + (m − i); pow_add step).",
+      "The third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴ is obtained for free once the general closed form is in hand: it is just E₃ = X + 4X² + X³ over (1 − x)⁴, with the coefficients 1, 4, 1 being the Eulerian numbers ⟨3,0⟩, ⟨3,1⟩, ⟨3,2⟩ — no separate summation needed.",
+      "The entry is candid about scope: the headline closed form reuses the gallery's analytic Frobenius identity rather than re-deriving it by strong induction on (★∞). The genuinely original deliverables are the polynomial recurrence eulerPoly_recurrence (absent from Mathlib) and the explicit third-moment formula; the remaining open question asks for a purely algebraic, analysis-free derivation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "headline-closed-form",
+      "title": "Part 1: The Headline Closed Form",
+      "startLine": 65,
+      "endLine": 73,
+      "summary": "infMoment_eq_eulerPoly states the closed-form solution of (★∞): for |x| < 1, infMoment m x = Eₘ(x)/(1 − x)^{m+1}. The one-line proof applies HasSum.tsum_eq to the sibling file's analytic Frobenius identity hasSum_pow_mul_geometric_eulerPoly, identifying the tsum-defined moment with the Eulerian closed form."
+    },
+    {
+      "id": "eulerpoly-recurrence",
+      "title": "Part 2: The Eulerian Polynomials Satisfy (★∞)",
+      "startLine": 75,
+      "endLine": 120,
+      "summary": "eulerPoly_recurrence is the new polynomial identity (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i} in ℝ[X]. Proved by eq_of_infinite_eval_eq: both sides agree at every r ∈ (−1,1) (rewriting each Eᵢ(r) via the closed form, factoring out (1−r)^{m+1}, and closing with the parent's analytic (★∞) via linear_combination), and (−1,1) is infinite, so the polynomials are equal."
+    },
+    {
+      "id": "low-order-moments",
+      "title": "Part 3: Low-Order Closed Forms and the Third Moment",
+      "startLine": 122,
+      "endLine": 145,
+      "summary": "infMoment_one and infMoment_two recover x/(1 − x)² and (x + x²)/(1 − x)³ from the general closed form (consistency with the parent), and infMoment_three gives the new explicit third moment ∑ k³·xᵏ = (x + 4x² + x³)/(1 − x)⁴, read off the Eulerian polynomial E₃ = X + 4X² + X³."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-sq-arith-geom-mul",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 79 },
+    "type": "technique",
+    "title": "The Second-Moment Ring Identity by Induction",
+    "content": "`sq_arith_geom_mul` is the mathematical core: (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2}, valid over ANY commutative ring. The proof is induction on n, mirroring the linear (m = 1) parent: the base case is closed by simp; ring, and the successor step peels the top term k = n with `Finset.sum_range_succ`, rewrites the remaining sum by the induction hypothesis with `mul_add`, then discharges the polynomial identity with `push_cast; ring`. Keeping the (1 − x)³ factor on the left makes the statement ring-valid with no invertibility hypothesis — the field, integer, and analytic cases all specialise from this one lemma.",
+    "mathContext": "$(1-x)^3 \\sum_{k=0}^{n-1} k^2 x^k = x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}$ over any commutative ring.",
+    "significance": "key",
+    "relatedConcepts": ["second moment", "arithmetico-geometric series", "induction", "Finset.sum_range_succ", "Eulerian polynomials", "commutative ring"],
+    "prerequisites": ["mathematical induction", "polynomial identities", "Finset sums"]
+  },
+  {
+    "id": "ann-cast-well-definedness",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 73 },
+    "type": "insight",
+    "title": "Ring Casts Avoid the n = 0 Truncated-Subtraction Trap",
+    "content": "The numerator coefficients (n − 1)² and 2n² − 2n − 1 are written with explicit ring casts ((n : R) − 1, (n : R)) rather than as ℕ expressions. This matters: in ℕ, the subtraction n − 1 truncates to 0 at n = 0, so a naïve (n − 1)² would silently be 0 instead of the correct ring value 1 = (0 − 1)². By casting to R first and subtracting in the ring, the n = 0 instance is well-defined and the identity holds uniformly from n = 0 upward. This subtlety does not arise for the linear (m = 1) sum, whose coefficients are linear in n, but it is essential once squared coefficients appear at the second moment.",
+    "mathContext": "$((n:R) - 1)^2$ evaluated in $R$, not $(n-1)^2$ in $\\mathbb{N}$ where $n=0$ truncates $n-1$ to $0$.",
+    "significance": "technical",
+    "relatedConcepts": ["Nat subtraction", "truncated subtraction", "Nat.cast", "well-definedness"],
+    "prerequisites": ["natural-number subtraction", "type coercions in Lean"]
+  },
+  {
+    "id": "ann-sq-arith-geom-div",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 92 },
+    "type": "technique",
+    "title": "Clearing the (1 − x)³ Denominator",
+    "content": "`sq_arith_geom_div` upgrades the ring identity to the quotient form ∑_{k<n} k²·xᵏ = (numerator)/(1 − x)³ whenever x ≠ 1. The step is formal: 1 − x ≠ 0 follows from x ≠ 1 via `sub_ne_zero`, hence (1 − x)³ ≠ 0 by `pow_ne_zero`, and `eq_div_iff` converts the goal to the multiplied-through identity `sq_arith_geom_mul` already supplies (after `mul_comm` to align factor order). The cubic denominator (1 − x)³ — one power higher than the linear sum's (1 − x)² — is the visible signature of the quadratic weight k².",
+    "mathContext": "$\\sum_{k=0}^{n-1} k^2 x^k = \\dfrac{x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}}{(1-x)^3}$ for $x \\ne 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["field arithmetic", "eq_div_iff", "denominator clearing", "pow_ne_zero"],
+    "prerequisites": ["field theory", "fractions"]
+  },
+  {
+    "id": "ann-sq-arith-geom-two",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 126 },
+    "type": "insight",
+    "title": "The x = 2 Specialisation and Numerical Witnesses",
+    "content": "Substituting x = 2 gives ∑_{k<n} k²·2ᵏ = n²·2ⁿ − (2n² − 2n − 1)·2^{n+1} + (n−1)²·2^{n+2} − 6, where (1 − 2)³ = −1 flips the sign of the numerator (closed by field_simp; ring). As with the linear case, the geometric ratio 2 diverges yet the FINITE formula is exact — the identity is algebraic, not analytic. `sq_arith_geom_two_four` verifies n = 4: 0²·1 + 1²·2 + 2²·4 + 3²·8 = 0 + 2 + 16 + 72 = 90. `sq_arith_geom_three_three` checks x = 3, n = 3 directly from the field form: 0 + 1·3 + 4·9 = 39. Both are discharged by `norm_num`.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k^2 2^k$; e.g. $n=4$ gives $0+2+16+72 = 90$, and $x=3,n=3$ gives $3+36 = 39$.",
+    "significance": "supporting",
+    "relatedConcepts": ["second moment", "divergent ratio", "norm_num", "numerical verification"],
+    "prerequisites": ["powers of two", "arithmetic"]
+  },
+  {
+    "id": "ann-infinite-limit",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 137 },
+    "type": "context",
+    "title": "The Infinite Limit and the Eulerian Numerator",
+    "content": "This documentation section connects the finite closed form to its n → ∞ limit, the infinite second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1. As n grows, the three tail terms n²·xⁿ, (2n² − 2n − 1)·x^{n+1}, and (n − 1)²·x^{n+2} all vanish because geometric decay dominates polynomial growth, leaving the numerator x + x². That infinite value already lives in the gallery as geometric-series-oq-07 (tsum_sq_mul_geometric), so it is deliberately NOT reproved here — this entry supplies the missing finite companion. The limiting numerator x + x² = x·(1 + x) displays the Eulerian polynomial A₂(x) = 1 + x, the m = 2 case of the general structure ∑ kᵐ·xᵏ ~ x·Aₘ(x)/(1 − x)^{m+1}.",
+    "mathContext": "$\\sum_{k=0}^{\\infty} k^2 x^k = \\dfrac{x(1+x)}{(1-x)^3}$ for $\\lVert x \\rVert < 1$, with $1+x = A_2(x)$ the Eulerian polynomial.",
+    "significance": "context",
+    "relatedConcepts": ["infinite series", "tsum", "Eulerian polynomials", "moments of geometric distribution", "generating functions"],
+    "prerequisites": ["real analysis", "convergence of series", "limits"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01/meta.json
@@ -18,6 +18,7 @@
     "sorries": 0
   },
   "title": "Second-order Arithmetico-Geometric Sum: a Closed Form for ∑ k²·xᵏ",
+  "description": "The finite second-moment sum ∑_{k<n} k²·xᵏ — each geometric term xᵏ weighted by k² — has the division-free closed form (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring, the field form over (1 − x)³, and the n → ∞ limit x(1 + x)/(1 − x)³. The m = 2 member of the weighted-geometric family ∑ kᵐ·xᵏ, completing the m = 0, 1, 2 row in finite form.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -64,6 +65,48 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Sums of the form ∑ kᵐ·xᵏ — geometric series weighted by a polynomial in the index — are the higher 'moments' of the geometric distribution and were computed term by term well before a unified theory existed; Euler manipulated such weighted power series freely in the 18th century. The systematic device is the perturbation ('shift and subtract') method of Concrete Mathematics: each application of x·d/dx (or the discrete analogue) raises the moment order by one and the denominator power by one, so the second moment lands over (1 − x)³. The numerators that appear are, up to normalisation, the Eulerian polynomials Aₘ(x) — the m = 2 case here has numerator x + x² (= x·A₂(x) with A₂(x) = 1 + x in the standard convention) in its infinite limit. Mathlib formalises several infinite weighted series but not the finite truncations, which is exactly what computing a variance from a finite sample, or extracting a coefficient from a rational generating function, requires.",
+    "problemStatement": "For a length $n$ and a ratio $x$ in any commutative ring, evaluate the finite second-moment arithmetico-geometric sum $\\sum_{k=0}^{n-1} k^2\\,x^k$ in closed form. The target is the division-free identity $(1-x)^3 \\sum_{k=0}^{n-1} k^2 x^k = x + x^2 - n^2 x^n + (2n^2 - 2n - 1)x^{n+1} - (n-1)^2 x^{n+2}$ over every commutative ring, its field specialisation over $(1-x)^3$ for $x \\ne 1$, and the consistency that as $n \\to \\infty$ with $\\lVert x \\rVert < 1$ the value tends to $\\dfrac{x(1+x)}{(1-x)^3}$.",
+    "proofStrategy": "The core result sq_arith_geom_mul is the multiplied-through ring identity, proved by induction on n exactly as in the m = 1 parent. The successor step peels the top term k = n with Finset.sum_range_succ, applies the induction hypothesis via mul_add, and closes the polynomial identity with push_cast; ring. A subtlety specific to the second moment: the numerator's coefficients ((n − 1)², 2n² − 2n − 1) are written with ring casts ((n : R), (n : R) − 1) rather than ℕ subtraction, so the n = 0 instance is well-defined over any ring (no truncated-subtraction trap). The field form sq_arith_geom_div clears the nonzero (1 − x)³ with eq_div_iff. The x = 2 specialisation (where (1 − 2)³ = −1) and two norm_num numerical witnesses (n = 4 gives 90; x = 3, n = 3 gives 39) guard the sign pattern. The infinite limit is NOT reproved — it already exists in the gallery as geometric-series-oq-07 — and is cross-referenced as the n → ∞ specialisation.",
+    "keyInsights": [
+      "Each extra factor of k in the weight raises the denominator power by one: ∑ xᵏ lives over (1 − x), ∑ k·xᵏ over (1 − x)², and ∑ k²·xᵏ over (1 − x)³. This entry is the m = 2 rung of that ladder ∑ kᵐ·xᵏ over (1 − x)^{m+1}, the pattern the unifying open question asks to make explicit.",
+      "Writing the closed form in the multiplied-through shape (1 − x)³·∑ = … keeps it a polynomial identity valid over every commutative ring; the field form and the analytic limit are then mere specialisations of one inductive lemma, with no analysis used in the core proof.",
+      "The numerator coefficients are deliberately expressed as ring casts ((n : R) − 1)² rather than ℕ subtraction (n − 1)², so the n = 0 instance does not silently truncate to 0 in ℕ — a correctness subtlety that does not arise for the linear (m = 1) sum but bites at the second moment.",
+      "The finite identity strictly refines the infinite one: as n → ∞ with ‖x‖ < 1 the three tail terms n²·xⁿ, (2n² − 2n − 1)·x^{n+1}, (n − 1)²·x^{n+2} all vanish (geometric decay beats polynomial growth), leaving the numerator x + x² and recovering the gallery's infinite second moment x(1 + x)/(1 − x)³.",
+      "The numerator's limiting shape x + x² = x·(1 + x) exhibits the Eulerian polynomial A₂(x) = 1 + x; the general moment ∑ kᵐ·xᵏ has numerator x·Aₘ(x) with Aₘ the m-th Eulerian polynomial, the structural fact behind the unifying open question."
+    ]
+  },
+  "sections": [
+    {
+      "id": "ring-identity",
+      "title": "The Division-Free Ring Identity",
+      "startLine": 62,
+      "endLine": 79,
+      "summary": "sq_arith_geom_mul is the core result: (1 − x)³·∑_{k<n} k²·xᵏ = x + x² − n²·xⁿ + (2n² − 2n − 1)·x^{n+1} − (n−1)²·x^{n+2} over any commutative ring. Proved by induction on n; the successor step peels the top term with Finset.sum_range_succ, rewrites by the induction hypothesis, and closes the polynomial identity with push_cast; ring. Coefficients use ring casts so the n = 0 case is well-defined."
+    },
+    {
+      "id": "field-form",
+      "title": "The Field Closed Form and Base-Case Guard",
+      "startLine": 81,
+      "endLine": 98,
+      "summary": "sq_arith_geom_div divides the ring identity by the nonzero (1 − x)³ (from x ≠ 1, via eq_div_iff and pow_ne_zero) to give the quotient closed form for x ≠ 1. sq_arith_geom_mul_one checks both sides vanish at n = 1 (the only term 0²·x⁰ = 0), guarding the sign pattern against off-by-one errors."
+    },
+    {
+      "id": "specialisations",
+      "title": "Specialisations and Numerical Witnesses",
+      "startLine": 100,
+      "endLine": 126,
+      "summary": "sq_arith_geom_two derives the x = 2 formula (where (1 − 2)³ = −1, closed by field_simp; ring), with sq_arith_geom_two_four (∑_{k<4} k²·2ᵏ = 0 + 2 + 16 + 72 = 90) and sq_arith_geom_three_three (x = 3, n = 3: 0 + 3 + 36 = 39) as concrete norm_num checks of the closed form."
+    },
+    {
+      "id": "infinite-limit",
+      "title": "The Infinite Limit (Recorded Elsewhere)",
+      "startLine": 128,
+      "endLine": 137,
+      "summary": "A documentation section noting that the n → ∞ limit of the finite closed form is the infinite second moment ∑' k, k²·xᵏ = x(1 + x)/(1 − x)³ for ‖x‖ < 1, already in the gallery as geometric-series-oq-07 (tsum_sq_mul_geometric). It is deliberately not reproved here; this entry supplies the finite companion and cross-references oq-07 for the limit."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-01-oq-01-oq-01",

--- a/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-partialsum-dist",
+    "proofId": "geometric-series-oq-08-oq-03-oq-01",
+    "range": { "startLine": 76, "endLine": 94 },
+    "type": "technique",
+    "title": "The Distance Between Partial Sums Is a Slice",
+    "content": "`geometric_partialSum_dist` is the bridge that makes everything else metric: the distance between the partial sums Sₘ and Sₙ is exactly the middle block ∑_{k ∈ Ico m n} rᵏ. The proof rewrites the slice as Sₙ − Sₘ via `Finset.sum_Ico_eq_sub`, then `Real.dist_eq` and `abs_sub_comm` turn the difference into dist Sₘ Sₙ, which the slice bound caps at rᵐ/(1 − r). `geometric_partialSum_dist_le` symmetrises to dist Sₘ Sₙ ≤ r^{min m n}/(1 − r) for all m, n (by `le_total` and `dist_comm`), the order-free shape `Metric.cauchySeq_iff` quantifies over. Recognising dist(Sₘ,Sₙ) = |block| is the single insight converting the sibling's combinatorial estimate into metric-space language.",
+    "mathContext": "$\\mathrm{dist}(S_m, S_n) = \\left|\\sum_{k \\in [m,n)} r^k\\right| \\le \\dfrac{r^{\\min(m,n)}}{1-r}$.",
+    "significance": "key",
+    "relatedConcepts": ["metric space", "Finset.sum_Ico_eq_sub", "distance of partial sums", "Real.dist_eq"],
+    "prerequisites": ["metric spaces", "finite sums over intervals"]
+  },
+  {
+    "id": "ann-partialsum-cauchyseq",
+    "proofId": "geometric-series-oq-08-oq-03-oq-01",
+    "range": { "startLine": 96, "endLine": 113 },
+    "type": "concept",
+    "title": "The Partial Sums Form a CauchySeq",
+    "content": "`geometric_partialSum_cauchySeq` is the headline: the sequence n ↦ ∑_{k<n} rᵏ is a CauchySeq for 0 ≤ r < 1, proved directly from the slice/distance bound via `Metric.cauchySeq_iff` (∀ ε > 0 ∃ N ∀ m,n ≥ N, dist < ε). The threshold N is extracted from `exists_pow_lt_of_lt_one` applied to ε·(1 − r); for m, n ≥ N the proof chains the symmetric distance bound, the monotonicity r^{min m n} ≤ rᴺ (`pow_le_pow_of_le_one` with `le_min`), and `div_lt_iff₀` to clear the positive denominator. Crucially it never invokes hasSum_geometric — convergence is established from small tail blocks alone, exactly the Cauchy criterion in its abstract metric form.",
+    "mathContext": "$\\mathrm{CauchySeq}\\,(n \\mapsto \\sum_{k<n} r^k)$ from $\\mathrm{Metric.cauchySeq\\_iff}$.",
+    "significance": "key",
+    "relatedConcepts": ["CauchySeq", "Metric.cauchySeq_iff", "Cauchy criterion", "completeness", "exists_pow_lt_of_lt_one"],
+    "prerequisites": ["Cauchy sequences", "metric spaces", "epsilon-N convergence"]
+  },
+  {
+    "id": "ann-summable",
+    "proofId": "geometric-series-oq-08-oq-03-oq-01",
+    "range": { "startLine": 115, "endLine": 128 },
+    "type": "technique",
+    "title": "Summability from Bounded Partial Sums, Not the Closed Form",
+    "content": "`geometric_summable` recovers Summable (k ↦ rᵏ) elementarily, deliberately routing around hasSum_geometric. The ingredients are exactly the two hypotheses of `summable_of_sum_range_le`: nonnegativity of each term (pow_nonneg) and a uniform bound on the partial sums. The bound comes from `geometric_partialSum_le`, the m = 0 instance of the slice estimate (after range_eq_Ico): ∑_{k<n} rᵏ ≤ (1 − r)⁻¹ for all n. The philosophical point is that here (1 − r)⁻¹ functions only as a ceiling for the increasing partial sums; the fact that it is also the exact sum is a consequence of convergence, not an input to it.",
+    "mathContext": "$\\sum_{k<n} r^k \\le (1-r)^{-1}$ for all $n$, with terms $\\ge 0$, gives $\\mathrm{Summable}\\,(k \\mapsto r^k)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Summable", "summable_of_sum_range_le", "monotone bounded sequence", "comparison test"],
+    "prerequisites": ["summability", "bounded monotone convergence"]
+  },
+  {
+    "id": "ann-cauchyseq-finset",
+    "proofId": "geometric-series-oq-08-oq-03-oq-01",
+    "range": { "startLine": 130, "endLine": 135 },
+    "type": "concept",
+    "title": "The Finset-Net Cauchy Face of Summability",
+    "content": "`geometric_cauchySeq_finset` produces the other abstract face of convergence: the net s ↦ ∑_{k ∈ s} rᵏ indexed by the directed set of finite subsets of ℕ is a CauchySeq. Unlike the ℕ-indexed sequential partial sums, this is the unordered notion — it is the predicate that DEFINES Summable in a complete topological group, and the proof is simply `summable_iff_cauchySeq_finset.mp` applied to geometric_summable. Having both the sequential CauchySeq and the finset-net CauchySeq makes the geometric series usable with whichever of Mathlib's convergence theorems a downstream proof needs.",
+    "mathContext": "$\\mathrm{Summable}\\,f \\iff \\mathrm{CauchySeq}\\,(s \\mapsto \\sum_{k \\in s} f\\,k)$ over finsets.",
+    "significance": "supporting",
+    "relatedConcepts": ["unconditional convergence", "summable_iff_cauchySeq_finset", "directed set", "nets", "topological group"],
+    "prerequisites": ["summability", "directed sets", "topological groups"]
+  },
+  {
+    "id": "ann-route-around-hasSum",
+    "proofId": "geometric-series-oq-08-oq-03-oq-01",
+    "range": { "startLine": 38, "endLine": 57 },
+    "type": "insight",
+    "title": "Why Route Around hasSum_geometric",
+    "content": "The file is a deliberate translation layer with a conceptual agenda, worth understanding before the lemmas. The sibling entry answered 'is the tail block small?' with a bespoke inequality; Mathlib's convergence theorems instead speak CauchySeq / Summable / cauchySeq_finset. By rebuilding convergence in that vocabulary from bounded blocks and bounded monotone partial sums — never quoting the already-evaluated infinite sum — the entry demonstrates the more general convergence technique that applies to series with NO closed form (the comparison and ratio tests' actual setting). The closed form (1 − r)⁻¹ enters only as a partial-sum ceiling; completeness of ℝ then upgrades the Cauchy property to genuine convergence, with the value identified separately (the remaining open question).",
+    "mathContext": "Convergence from $\\mathrm{dist}(S_m,S_n)\\to 0$ and bounded $S_n$, with completeness supplying the limit — not from $\\sum r^k = (1-r)^{-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["Cauchy criterion", "completeness", "comparison test", "proof provenance", "abstraction layer"],
+    "prerequisites": ["mathematical exposition", "convergence theory"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03-oq-01/meta.json
@@ -21,6 +21,7 @@
     "sorries": 0
   },
   "title": "The Geometric Series as an Abstract Cauchy Sequence",
+  "description": "Promotes the sibling's hand-rolled ε–N slice criterion into Mathlib's convergence vocabulary. For 0 ≤ r < 1 it reads the Ico-slice bound metrically (dist between partial sums ≤ r^{min m n}/(1 − r)), feeds it to Metric.cauchySeq_iff to prove the partial sums form a CauchySeq, recovers Summable elementarily from bounded monotone partial sums, and derives the finset-net CauchySeq — all without invoking hasSum_geometric, so the closed form (1 − r)⁻¹ is a consequence of convergence, not its premise.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -91,6 +92,55 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The Cauchy criterion for series — a series converges iff its tail blocks become uniformly small — is, in a complete space like ℝ, both necessary and sufficient for convergence. Cantor's and Méray's 1870s constructions of the reals as equivalence classes of Cauchy sequences made completeness (every Cauchy sequence converges) the bedrock; the geometric series is the standard first application. There is a pedagogical fork in how convergence is established: one route evaluates the partial sums in closed form (1 − rⁿ)/(1 − r) and takes the limit; the other, more robust route — the one Rudin emphasises and that generalises to series with no closed form — shows only that the partial sums are Cauchy (or bounded and monotone) and lets completeness supply the limit. This entry takes the second route inside Lean, deliberately routing around hasSum_geometric so the closed-form value never enters the convergence argument, and lands the result in Mathlib's general predicates CauchySeq and Summable.",
+    "problemStatement": "For $0 \\le r < 1$, establish convergence of the geometric series $\\sum_k r^k$ in Mathlib's abstract vocabulary, using only block/partial-sum bounds and not the evaluated infinite sum. Concretely: read the slice bound as a metric estimate $\\mathrm{dist}(S_m, S_n) \\le \\frac{r^{\\min(m,n)}}{1-r}$ (with $S_n = \\sum_{k<n} r^k$); prove $S_n$ is a $\\mathrm{CauchySeq}$ via $\\mathrm{Metric.cauchySeq\\_iff}$; prove $\\mathrm{Summable}\\,(k \\mapsto r^k)$ from bounded nonnegative partial sums ($S_n \\le (1-r)^{-1}$); and obtain the finset-net $\\mathrm{CauchySeq}$ that defines summability.",
+    "proofStrategy": "The slice's absolute bound geometric_slice_abs_le (terms nonnegative, so abs is harmless) wraps geom_sum_Ico_le_of_lt_one. geometric_partialSum_dist reads it metrically: Finset.sum_Ico_eq_sub identifies the slice ∑_{k ∈ Ico m n} rᵏ with Sₙ − Sₘ, and Real.dist_eq + abs_sub_comm turn that into dist Sₘ Sₙ ≤ rᵐ/(1 − r). geometric_partialSum_dist_le symmetrises via le_total and dist_comm to the min-form Metric.cauchySeq_iff consumes. The headline geometric_partialSum_cauchySeq then extracts the threshold N from exists_pow_lt_of_lt_one (on ε·(1 − r)) and chains the distance bound, the monotonicity rᵐⁱⁿ ≤ rᴺ (pow_le_pow_of_le_one, le_min), and div_lt_iff₀. Separately, geometric_partialSum_le (m = 0 slice after range_eq_Ico) bounds every partial sum by (1 − r)⁻¹, which with nonnegativity feeds summable_of_sum_range_le to give geometric_summable; summable_iff_cauchySeq_finset then yields the finset-net CauchySeq. None of these touch hasSum_geometric.",
+    "keyInsights": [
+      "The distance between two partial sums IS a slice: dist Sₘ Sₙ = |∑_{k ∈ Ico m n} rᵏ| (via Finset.sum_Ico_eq_sub). This single identification is what converts the sibling's combinatorial block estimate into a metric statement, and it is the entire content of the bridge to Mathlib's metric-space machinery.",
+      "Convergence is established WITHOUT the closed form: the proof uses only that blocks are small (CauchySeq) and that partial sums are bounded and monotone (Summable). The value (1 − r)⁻¹ appears solely as the partial-sum bound, never as the limit fed in — so this is a genuinely independent convergence proof, not a repackaging of hasSum_geometric.",
+      "Two complementary abstract faces of convergence are produced: CauchySeq for the ℕ-indexed partial sums (sequential, order-dependent) and CauchySeq over the directed set of finsets (the unordered net that DEFINES Summable in a complete topological group). summable_iff_cauchySeq_finset is the hinge connecting them.",
+      "Symmetrising to the r^{min m n} form is the small but essential move that matches Metric.cauchySeq_iff, which quantifies over both m ≥ N and n ≥ N with no ordering — handled by le_total plus dist_comm rather than a hypothesis m ≤ n.",
+      "Completeness of ℝ is what makes the Cauchy route sufficient: the remaining open question asks to invoke cauchySeq_tendsto_of_complete to extract a limit L and then pin L = (1 − r)⁻¹ purely from the truncation defect rⁿ/(1 − r) → 0, recovering hasSum_geometric from first principles."
+    ]
+  },
+  "sections": [
+    {
+      "id": "metric-reading",
+      "title": "Metric Reading of the Slice",
+      "startLine": 68,
+      "endLine": 94,
+      "summary": "geometric_slice_abs_le restates the endpoint-free slice bound rᵐ/(1 − r). geometric_partialSum_dist identifies the distance between two partial sums with the middle block (via Finset.sum_Ico_eq_sub, Real.dist_eq, abs_sub_comm), bounding it by rᵐ/(1 − r); geometric_partialSum_dist_le symmetrises to the r^{min m n} form that Metric.cauchySeq_iff consumes."
+    },
+    {
+      "id": "cauchyseq-headline",
+      "title": "The Partial Sums Form a CauchySeq",
+      "startLine": 96,
+      "endLine": 113,
+      "summary": "geometric_partialSum_cauchySeq is the headline: n ↦ ∑_{k<n} rᵏ is a CauchySeq, proved straight from the distance bound via Metric.cauchySeq_iff. The threshold N comes from exists_pow_lt_of_lt_one (on ε·(1 − r)), chained with pow_le_pow_of_le_one and div_lt_iff₀ — no appeal to hasSum_geometric."
+    },
+    {
+      "id": "summability",
+      "title": "Bounded Partial Sums and Summability",
+      "startLine": 115,
+      "endLine": 128,
+      "summary": "geometric_partialSum_le bounds every partial sum by (1 − r)⁻¹ (the m = 0 slice instance after range_eq_Ico). geometric_summable then recovers Summable elementarily from nonnegativity and that bound via summable_of_sum_range_le — again without the closed-form value, which here is the bound rather than the premise."
+    },
+    {
+      "id": "finset-net",
+      "title": "The Finset-Net Cauchy Face",
+      "startLine": 130,
+      "endLine": 135,
+      "summary": "geometric_cauchySeq_finset gives the Mathlib-native predicate: the net s ↦ ∑_{k ∈ s} rᵏ over the directed set of finsets is a CauchySeq, obtained from geometric_summable via summable_iff_cauchySeq_finset. This is the unordered convergence notion that defines summability in a complete group."
+    },
+    {
+      "id": "concrete-instance",
+      "title": "Concrete Instance r = 1/2",
+      "startLine": 137,
+      "endLine": 152,
+      "summary": "Three examples instantiate the results at r = 1/2: the partial sums are a CauchySeq, the series is Summable, and every partial sum is bounded by (1 − 1/2)⁻¹ = 2, confirming the abstract predicates fire on a concrete ratio."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-03-oq-01-oq-01",

--- a/src/data/proofs/geometric-series-oq-08-oq-03/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-slice-eq-tail-sub",
+    "proofId": "geometric-series-oq-08-oq-03",
+    "range": { "startLine": 68, "endLine": 74 },
+    "type": "insight",
+    "title": "The Slice Is a Difference of Two Tails",
+    "content": "`geometric_slice_eq_tail_sub` is the structural bridge of the entry: for r < 1 and m ≤ n, a middle block equals the parent's m-tail minus its n-tail, ∑_{k ∈ Ico m n} rᵏ = rᵐ/(1 − r) − rⁿ/(1 − r). The proof is one line — rewrite by the slice closed form (rᵐ − rⁿ)/(1 − r), then `sub_div` distributes the division across the subtraction. This identity shows the two-sided slice estimate developed here and the parent's one-sided truncation defect rⁿ/(1 − r) are the same arithmetic seen from two ends, tying this entry back to GeometricSeriesOQ08.geometric_sum_tail.",
+    "mathContext": "$\\sum_{k \\in [m,n)} r^k = \\dfrac{r^m}{1-r} - \\dfrac{r^n}{1-r}$ for $r < 1,\\ m \\le n$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "tails of a series", "telescoping", "partial sums"],
+    "prerequisites": ["geometric series", "finite sums over intervals"]
+  },
+  {
+    "id": "ann-slice-factor",
+    "proofId": "geometric-series-oq-08-oq-03",
+    "range": { "startLine": 76, "endLine": 81 },
+    "type": "concept",
+    "title": "Self-Similarity of the Slice",
+    "content": "`geometric_slice_factor` records the scale invariance of the geometric series: a block starting at index m is rᵐ times a fresh partial sum, ∑_{k ∈ Ico m n} rᵏ = rᵐ·∑_{k < n−m} rᵏ. The proof reindexes the half-open interval to a range with `Finset.sum_Ico_eq_sum_range`, distributes the scalar with `Finset.mul_sum`, and matches terms via `pow_add` (r^{m+i} = rᵐ·rⁱ). Crucially it holds for ALL m, n with no ordering hypothesis — when n ≤ m both sides are 0 — which is the same robustness that lets the slice bound apply to arbitrary index pairs.",
+    "mathContext": "$\\sum_{k \\in [m,n)} r^k = r^m \\sum_{k < n-m} r^k$ for all $m, n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["self-similarity", "scale invariance", "reindexing", "Finset.sum_Ico_eq_sum_range"],
+    "prerequisites": ["finite sums", "index shifting"]
+  },
+  {
+    "id": "ann-slice-abs-le",
+    "proofId": "geometric-series-oq-08-oq-03",
+    "range": { "startLine": 83, "endLine": 104 },
+    "type": "technique",
+    "title": "The Endpoint-Free Cauchy Estimate",
+    "content": "`geometric_slice_abs_le` gives the bound the comparison and ratio tests actually use: |∑_{k ∈ Ico m n} rᵏ| ≤ rᵐ/(1 − r) for 0 ≤ r < 1. Because every term rᵏ is nonnegative, the sum is nonnegative and `abs_of_nonneg` removes the absolute value, reducing to the wrapped Mathlib bound geom_sum_Ico_le_of_lt_one. The decisive feature is what the bound omits: it does NOT depend on the right endpoint n. `geometric_slice_bound_tendsto` then shows this envelope rᵐ/(1 − r) → 0 as m → ∞ (geometric decay divided by the constant 1 − r), so late blocks are uniformly small regardless of how far they extend.",
+    "mathContext": "$\\left|\\sum_{k \\in [m,n)} r^k\\right| \\le \\dfrac{r^m}{1-r}$, independent of $n$, with $\\dfrac{r^m}{1-r} \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["comparison test", "ratio test", "geometric majorant", "uniform bound", "abs_of_nonneg"],
+    "prerequisites": ["absolute value", "monotone bounds", "limits"]
+  },
+  {
+    "id": "ann-slice-cauchy",
+    "proofId": "geometric-series-oq-08-oq-03",
+    "range": { "startLine": 106, "endLine": 123 },
+    "type": "technique",
+    "title": "The ε–N Cauchy Criterion",
+    "content": "`geometric_slice_cauchy` is the capstone, the explicit ε–N form of the Cauchy criterion: for 0 ≤ r < 1 and any ε > 0 there is an N such that every slice with left endpoint m ≥ N satisfies |∑_{k ∈ Ico m n} rᵏ| ≤ ε, uniformly in n. The threshold N comes from `exists_pow_lt_of_lt_one` applied to ε·(1 − r) (so rᴺ < ε·(1 − r)). For m ≥ N the proof chains three facts: the absolute slice bound, the monotonicity rᵐ ≤ rᴺ (`pow_le_pow_of_le_one`, since 0 ≤ r ≤ 1 and m ≥ N), and `div_le_iff₀` to clear the positive denominator 1 − r, closing with linarith. This is precisely the estimate exhibiting the geometric series as Cauchy and the template the comparison/ratio tests follow.",
+    "mathContext": "$\\forall \\varepsilon > 0\\ \\exists N\\ \\forall m \\ge N\\ \\forall n,\\ \\left|\\sum_{k \\in [m,n)} r^k\\right| \\le \\varepsilon$.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy criterion", "Cauchy sequence", "exists_pow_lt_of_lt_one", "ε–N definition", "convergence of series"],
+    "prerequisites": ["epsilon-N convergence", "Archimedean property", "real analysis"]
+  },
+  {
+    "id": "ann-concrete-instance",
+    "proofId": "geometric-series-oq-08-oq-03",
+    "range": { "startLine": 125, "endLine": 141 },
+    "type": "context",
+    "title": "Worked Instance at r = 1/2",
+    "content": "Three examples exercise the abstract lemmas on concrete numbers at r = 1/2, slice Ico 2 5. The block (1/2)² + (1/2)³ + (1/2)⁴ = 1/4 + 1/8 + 1/16 = 7/16 is computed directly by norm_num; it equals the tail difference (1/2)²/(1−1/2) − (1/2)⁵/(1−1/2) = 1/2 − 1/16 via geometric_slice_eq_tail_sub; and it is bounded by the endpoint-free envelope (1/2)²/(1−1/2) = 1/2 via geometric_slice_le. These ground the difference-of-tails identity and the slice bound, confirming the general results compute correctly.",
+    "mathContext": "$\\sum_{k=2}^{4} (1/2)^k = 7/16 = \\tfrac12 - \\tfrac1{16} \\le \\tfrac12$.",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "norm_num", "numerical verification"],
+    "prerequisites": ["arithmetic with fractions"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-03/meta.json
@@ -20,6 +20,7 @@
     "sorries": 0
   },
   "title": "The Ico-slice of a Geometric Series and the Cauchy Criterion",
+  "description": "Turns the parent's one-sided truncation defect rⁿ/(1 − r) into the two-sided slice estimate that convergence proofs actually invoke. For 0 ≤ r < 1 an arbitrary middle block ∑_{k ∈ Ico m n} rᵏ equals the m-tail minus the n-tail and is bounded by the endpoint-free envelope rᵐ/(1 − r) → 0, packaged as the explicit ε–N Cauchy criterion uniform in the right endpoint — the reusable engine behind the comparison test, ratio-test remainder, and geometric-majorant dominated convergence.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -78,6 +79,55 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Augustin-Louis Cauchy's 1821 Cours d'analyse made the convergence of a series rest on the behaviour of its tail blocks: a series converges iff its partial sums form a Cauchy sequence, i.e. arbitrarily late finite blocks become arbitrarily small. The geometric series is the canonical worked example — Cauchy himself used the geometric majorant to formulate what became the comparison and ratio tests, where one dominates an unknown series' tail blocks by those of a convergent geometric series. This entry formalises exactly that block estimate. Where the classical statement bounds a tail block ∑_{k=m}^{n} rᵏ, the modern Lean formulation works with the half-open index set Ico m n (= {m, m+1, …, n−1}), so the empty-slice case n ≤ m is handled uniformly and the bound rᵐ/(1 − r) holds for all m, n with no ordering hypothesis — the form Mathlib's geom_sum_Ico_le_of_lt_one provides and the comparison/ratio tests consume.",
+    "problemStatement": "For $0 \\le r < 1$, control an arbitrary middle block of the geometric series, $\\sum_{k \\in [m, n)} r^k$, by a bound independent of the right endpoint $n$. Concretely: prove the difference-of-tails identity $\\sum_{k \\in [m,n)} r^k = \\frac{r^m}{1-r} - \\frac{r^n}{1-r}$, the self-similar factorisation $\\sum_{k \\in [m,n)} r^k = r^m \\sum_{k < n-m} r^k$, the endpoint-free estimate $\\left|\\sum_{k \\in [m,n)} r^k\\right| \\le \\frac{r^m}{1-r} \\to 0$, and package these as the $\\varepsilon$–$N$ Cauchy criterion: $\\forall \\varepsilon > 0\\ \\exists N\\ \\forall m \\ge N\\ \\forall n,\\ \\left|\\sum_{k \\in [m,n)} r^k\\right| \\le \\varepsilon$.",
+    "proofStrategy": "The closed form geometric_slice_closed wraps Mathlib's geom_sum_Ico'; sub_div then splits it into the difference of two parent tails (geometric_slice_eq_tail_sub). The self-similar factorisation geometric_slice_factor reindexes Ico m n to range (n − m) via Finset.sum_Ico_eq_sum_range and pulls out rᵐ with pow_add, needing no order hypothesis. The slice bound geometric_slice_le wraps Mathlib's geom_sum_Ico_le_of_lt_one (valid for all m, n since an empty slice is 0); geometric_slice_abs_le drops the absolute value because every term is nonnegative. The envelope rᵐ/(1 − r) → 0 follows from tendsto_pow_atTop_nhds_zero_of_lt_one divided by the constant 1 − r. The capstone geometric_slice_cauchy extracts the threshold N from exists_pow_lt_of_lt_one (applied to ε·(1 − r)), then for m ≥ N chains the absolute bound, the monotonicity rᵐ ≤ rᴺ (pow_le_pow_of_le_one), and div_le_iff₀ to reach ≤ ε — uniformly in n.",
+    "keyInsights": [
+      "The defining feature of the Cauchy criterion is that the block bound rᵐ/(1 − r) does NOT depend on the right endpoint n. This endpoint-uniformity is what lets the comparison and ratio tests dominate an unknown series' arbitrarily long tail blocks by a single geometric quantity that shrinks with the left endpoint alone.",
+      "The slice is literally the difference of two parent tails: ∑_{k ∈ Ico m n} rᵏ = rᵐ/(1 − r) − rⁿ/(1 − r). This difference-of-tails identity is the structural bridge from this two-sided estimate back to the parent entry's one-sided truncation defect, showing the two viewpoints are the same arithmetic.",
+      "Self-similarity ∑_{k ∈ Ico m n} rᵏ = rᵐ·∑_{k < n−m} rᵏ — a block starting at m is rᵐ times a fresh partial sum — is the geometric series' scale invariance, and it holds with NO ordering hypothesis on m, n (the empty-slice degeneracy is automatic), which is exactly why the bound extends to all index pairs.",
+      "Using the half-open interval Ico m n rather than a closed sum range is not cosmetic: it makes the n ≤ m case the empty sum 0, so geometric_slice_le and the Cauchy criterion need no m ≤ n hypothesis — a small formalisation choice that removes case splits throughout.",
+      "The entry deliberately bottoms out at the elementary ε–N statement rather than Mathlib's abstract CauchySeq predicate; the open question asks to bridge to cauchySeq_finset and thereby re-derive summability of the geometric series without invoking hasSum_geometric — an alternative, self-contained convergence proof."
+    ]
+  },
+  "sections": [
+    {
+      "id": "slice-closed-and-tails",
+      "title": "Slice Closed Form and Difference of Tails",
+      "startLine": 62,
+      "endLine": 74,
+      "summary": "geometric_slice_closed wraps Mathlib's geom_sum_Ico' to record the slice closed form (rᵐ − rⁿ)/(1 − r) for r ≠ 1, m ≤ n. geometric_slice_eq_tail_sub then splits it (via sub_div) into the parent's m-tail minus n-tail, rᵐ/(1 − r) − rⁿ/(1 − r) — the bridge back to GeometricSeriesOQ08.geometric_sum_tail."
+    },
+    {
+      "id": "self-similarity",
+      "title": "Self-Similar Factorisation",
+      "startLine": 76,
+      "endLine": 81,
+      "summary": "geometric_slice_factor proves ∑_{k ∈ Ico m n} rᵏ = rᵐ·∑_{k < n−m} rᵏ for all m, n (no order hypothesis), reindexing with Finset.sum_Ico_eq_sum_range and factoring out rᵐ via pow_add. A block starting at m is rᵐ times a fresh partial sum — the series' scale invariance."
+    },
+    {
+      "id": "slice-bounds",
+      "title": "Slice Bounds and Vanishing Envelope",
+      "startLine": 83,
+      "endLine": 104,
+      "summary": "geometric_slice_le (wrapping geom_sum_Ico_le_of_lt_one) bounds the block by rᵐ/(1 − r) for 0 ≤ r < 1, independently of n; geometric_slice_abs_le drops the absolute value since all terms are nonnegative. geometric_slice_bound_tendsto shows the envelope rᵐ/(1 − r) → 0 from tendsto_pow_atTop_nhds_zero_of_lt_one divided by 1 − r."
+    },
+    {
+      "id": "cauchy-criterion",
+      "title": "The ε–N Cauchy Criterion",
+      "startLine": 106,
+      "endLine": 123,
+      "summary": "geometric_slice_cauchy is the capstone: for 0 ≤ r < 1 and any ε > 0 there is an N past which every slice with left endpoint m ≥ N has |∑_{k ∈ Ico m n} rᵏ| ≤ ε, uniformly in n. The threshold comes from exists_pow_lt_of_lt_one (applied to ε·(1 − r)), chained with the monotonicity pow_le_pow_of_le_one and div_le_iff₀."
+    },
+    {
+      "id": "concrete-instance",
+      "title": "Concrete Instance r = 1/2",
+      "startLine": 125,
+      "endLine": 141,
+      "summary": "Worked example at r = 1/2, slice Ico 2 5: the block (1/2)² + (1/2)³ + (1/2)⁴ = 7/16 equals the tail difference 1/2 − 1/16 and is bounded by the endpoint-free envelope (1/2)²/(1−1/2) = 1/2, exercising the difference-of-tails identity and the slice bound on numbers."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-08-oq-03-oq-01",

--- a/src/data/proofs/geometric-series-oq-09-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-norm-pow-lt-one",
+    "proofId": "geometric-series-oq-09-oq-01",
+    "range": { "startLine": 62, "endLine": 71 },
+    "type": "technique",
+    "title": "The General Ratio Bound ‖r^q‖ < 1",
+    "content": "`norm_pow_lt_one` is the lone analytic ingredient, the q-fold generalisation of the parent's squared-ratio bound: ‖r^q‖ = ‖r‖^q < 1 whenever ‖r‖ < 1 and q ≠ 0. The proof rewrites ‖r^q‖ = ‖r‖^q with `norm_pow`, then `pow_lt_one₀` (0 ≤ a, a < 1, n ≠ 0 ⟹ aⁿ < 1) finishes — the hypothesis q ≠ 0 is exactly what pow_lt_one₀ needs. This is the only place convergence enters; once supplied, every residue subsum is immediate. one_sub_ne_zero and one_sub_pow_ne_zero record the nonvanishing denominators 1 − r ≠ 0 and 1 − r^q ≠ 0 used in the recombination.",
+    "mathContext": "$\\lVert r^q \\rVert = \\lVert r \\rVert^q < 1$ for $\\lVert r \\rVert < 1$, $q \\ne 0$.",
+    "significance": "key",
+    "relatedConcepts": ["normed field", "norm_pow", "pow_lt_one₀", "complete normed field"],
+    "prerequisites": ["normed fields", "powers and norms"]
+  },
+  {
+    "id": "ann-hasSum-residue",
+    "proofId": "geometric-series-oq-09-oq-01",
+    "range": { "startLine": 73, "endLine": 93 },
+    "type": "insight",
+    "title": "Every Residue Subseries Is Geometric of Ratio r^q",
+    "content": "`hasSum_geometric_residue` is the keystone: ∑ r^(qn+a) = r^a·(1 − r^q)⁻¹ for any modulus q ≠ 0 and residue a. The decisive reindexing r^(qn+a) = r^a·(r^q)ⁿ (pow_add then pow_mul, closed by ring) exhibits the residue-a subseries as r^a times a geometric series of ratio r^q. `hasSum_geometric_of_norm_lt_one` applies at ratio r^q (legal by norm_pow_lt_one), and `HasSum.mul_left (r^a)` scales it. This is the same self-similarity as the parent's even/odd case, now for arbitrary common difference q — raising the modulus only raises the power in the new ratio. tsum and Summable forms follow mechanically.",
+    "mathContext": "$\\sum_{n\\ge0} r^{qn+a} = r^a \\sum_{n\\ge0} (r^q)^n = \\dfrac{r^a}{1-r^q}$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "series multisection", "self-similarity", "pow_add", "HasSum.mul_left"],
+    "prerequisites": ["geometric series", "infinite series", "reindexing"]
+  },
+  {
+    "id": "ann-one-sub-pow-eq",
+    "proofId": "geometric-series-oq-09-oq-01",
+    "range": { "startLine": 97, "endLine": 106 },
+    "type": "technique",
+    "title": "The Factorisation 1 − r^q = (1 − r)·∑ r^a",
+    "content": "`one_sub_pow_eq` is the algebraic backbone of the recombination: 1 − r^q = (1 − r)·∑_{a<q} r^a over any commutative field, proved by induction on q. The base case q = 0 is 1 − 1 = 0 (simp); the successor step uses Finset.sum_range_succ, the induction hypothesis, and pow_succ, closed by ring. This is the finite geometric-sum identity in its product form, and it is exactly what makes the q residue closed forms r^a/(1 − r^q) telescope back to 1/(1 − r): the sum of numerators ∑ r^a is the cofactor that cancels (1 − r^q) down to (1 − r).",
+    "mathContext": "$1 - r^q = (1-r)\\sum_{a=0}^{q-1} r^a = (1-r)(1 + r + \\cdots + r^{q-1})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite geometric sum", "factorisation", "induction", "telescoping"],
+    "prerequisites": ["polynomial identities", "induction", "finite sums"]
+  },
+  {
+    "id": "ann-recombination",
+    "proofId": "geometric-series-oq-09-oq-01",
+    "range": { "startLine": 108, "endLine": 124 },
+    "type": "insight",
+    "title": "The q Subseries Reassemble the Full Series",
+    "content": "`tsum_residues_eq_geometric` proves the split is a faithful partition: ∑_{a<q} (∑ r^(qn+a)) = ∑ rᵐ = 1/(1 − r). After rewriting each subseries to its closed form r^a·(1 − r^q)⁻¹ (simp_rw) and factoring the common (1 − r^q)⁻¹ out of the finite sum with `Finset.sum_mul`, the goal becomes (∑_{a<q} r^a)·(1 − r^q)⁻¹ = (1 − r)⁻¹, closed by field_simp and `linear_combination` of the factorisation one_sub_pow_eq. This confirms the q arithmetic-progression subseries are disjoint and exhaustive — they partition ℕ by residue mod q and reassemble the whole geometric series.",
+    "mathContext": "$\\sum_{a=0}^{q-1} \\dfrac{r^a}{1-r^q} = \\dfrac{\\sum_{a<q} r^a}{1-r^q} = \\dfrac{1}{1-r}$.",
+    "significance": "key",
+    "relatedConcepts": ["series multisection", "partition of indices", "Finset.sum_mul", "linear_combination", "Fubini"],
+    "prerequisites": ["infinite series", "finite sums", "residue classes"]
+  },
+  {
+    "id": "ann-specialisation-generality",
+    "proofId": "geometric-series-oq-09-oq-01",
+    "range": { "startLine": 126, "endLine": 154 },
+    "type": "context",
+    "title": "q = 2 Recovery and Concrete Values",
+    "content": "The final sections anchor the general result to the parent and to numbers. tsum_geometric_even (q = 2, a = 0) and tsum_geometric_odd (q = 2, a = 1) recover GeometricSeriesOQ09's ∑ r^(2n) = 1/(1 − r²) and ∑ r^(2n+1) = r/(1 − r²) as one-line specialisations (simpa) of tsum_geometric_residue — confirming this entry strictly generalises the parent. The concrete checks at r = 1/2, q = 3 give ∑ (1/2)^(3n) = ∑ (1/8)ⁿ = 8/7 and ∑ (1/2)^(3n+2) = 2/7, exercising a modulus beyond even/odd. Note the whole file is generic over a complete normed field, so it applies to ℝ and ℂ alike.",
+    "mathContext": "$q=2$: $\\sum r^{2n} = \\tfrac{1}{1-r^2}$, $\\sum r^{2n+1} = \\tfrac{r}{1-r^2}$. $q=3, r=\\tfrac12$: $8/7$ and $2/7$.",
+    "significance": "context",
+    "relatedConcepts": ["specialisation", "complete normed field", "norm_num", "worked example"],
+    "prerequisites": ["arithmetic with fractions", "normed fields"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-09-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01/meta.json
@@ -16,6 +16,7 @@
     "sorries": 0
   },
   "title": "q-Fold Residue-Class Splitting of the Geometric Series: ∑ r^(qn+a) = r^a/(1−r^q)",
+  "description": "Generalises the even/odd splitting to arbitrary modulus q: for ‖r‖ < 1 over any complete normed field, the residue-a subseries ∑_{n≥0} r^(qn+a) = r^a/(1−r^q) is itself geometric of ratio r^q, and summing over a = 0,…,q−1 reassembles the full series ∑ rⁿ = 1/(1−r) via the factorisation 1 − r^q = (1−r)(1 + r + ⋯ + r^{q−1}). The q=2 case recovers the parent's even/odd subsums.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -68,6 +69,55 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Multisection (or q-section) of a power series — extracting the terms whose index lies in a fixed residue class mod q — is a classical generating-function technique. The general formula uses the discrete Fourier / roots-of-unity filter: for ω = e^{2πi/q}, ∑_{n ≡ a (q)} cₙxⁿ = (1/q)∑_{j<q} ω^{−ja} f(ωʲx), where f(x) = ∑ cₙxⁿ. Applied to the geometric series f(x) = 1/(1−x) it yields the residue subsums, but those subsums have a far simpler self-similar form than the general filter suggests: each is again geometric, of ratio r^q. The technique is catalogued in Concrete Mathematics and underlies, e.g., the closed forms for sums of binomial coefficients in fixed residue classes. This entry formalises the geometric case directly — without roots of unity — for every q ≥ 1 and over any complete normed field, so ℝ and ℂ are handled uniformly, generalising the q = 2 even/odd entry.",
+    "problemStatement": "Fix a modulus $q \\ge 1$ and residue $a$. For $r$ in a complete normed field with $\\lVert r \\rVert < 1$, sum the arithmetic-progression subseries with common difference $q$: prove $\\sum_{n=0}^{\\infty} r^{qn+a} = \\dfrac{r^a}{1-r^q}$, and prove the recombination $\\sum_{a=0}^{q-1}\\sum_{n=0}^{\\infty} r^{qn+a} = \\sum_{m=0}^{\\infty} r^m = \\dfrac{1}{1-r}$ — exhibiting the full geometric series as the disjoint union of $q$ geometric subseries indexed by residue classes mod $q$.",
+    "proofStrategy": "Each residue subseries is summed by the reindexing r^(qn+a) = r^a·(r^q)ⁿ (pow_add, pow_mul, ring), which exhibits it as r^a times a geometric series of ratio r^q; hasSum_geometric_of_norm_lt_one applies at ratio r^q because ‖r^q‖ = ‖r‖^q < 1 (norm_pow_lt_one, needing q ≠ 0), and HasSum.mul_left (r^a) supplies the value r^a·(1 − r^q)⁻¹ (hasSum_geometric_residue), with tsum and Summable forms following. The recombination tsum_residues_eq_geometric rewrites each subseries to closed form, factors (1 − r^q)⁻¹ out of the finite sum over residues (Finset.sum_mul), and closes via the algebraic backbone one_sub_pow_eq: 1 − r^q = (1 − r)·∑_{a<q} r^a, proved by induction on q. The whole development is generic over a complete normed field; the q = 2 specialisations recover the parent's even/odd subsums, and concrete checks at r = 1/2, q = 3 give 8/7 and 2/7.",
+    "keyInsights": [
+      "A subseries taken along ANY arithmetic progression of indices (common difference q) is again geometric — of ratio r^q. The even/odd case (q = 2) and this general q are the same phenomenon; raising the modulus only raises the power of r in the new ratio, so the proof is the q = 2 proof with 2 replaced by q.",
+      "The recombination's entire algebraic content is the factorisation 1 − r^q = (1 − r)(1 + r + ⋯ + r^{q−1}) (one_sub_pow_eq, by induction on q). This finite geometric-sum identity is what makes the q closed forms r^a/(1 − r^q) telescope back to 1/(1 − r): summing the numerators ∑ r^a produces exactly the cofactor that cancels (1 − r^q) down to (1 − r).",
+      "Only one analytic hypothesis is ever needed — ‖r^q‖ = ‖r‖^q < 1 — and it follows mechanically from ‖r‖ < 1 and q ≠ 0. Everything else (the reindexing, the factorisation, the recombination algebra) is formal, so the parity/residue structure adds no genuine convergence difficulty.",
+      "Working over an arbitrary complete normed field 𝕜 rather than ℝ covers ℝ and ℂ uniformly with one proof; set_option linter.unusedSectionVars false is used because the purely algebraic lemmas (one_sub_pow_eq, the nonvanishing denominators) do not invoke CompleteSpace, which is only required where the geometric series is actually summed.",
+      "The recombination is currently proved by adding the closed forms of the parts; the open question asks to instead establish it as a direct HasSum over the bijection ℕ ≃ ℕ × Fin q (m ↦ (m / q, m % q)) — a Fubini/regrouping of the summation itself, which would prove the splitting without first evaluating the pieces."
+    ]
+  },
+  "sections": [
+    {
+      "id": "nonvanishing-denominators",
+      "title": "Nonvanishing Denominators and the r^q Bound",
+      "startLine": 53,
+      "endLine": 71,
+      "summary": "Supporting lemmas over a general normed field: ne_one and one_sub_ne_zero (r ≠ 1, 1 − r ≠ 0 from ‖r‖ < 1), the keystone norm_pow_lt_one (‖r^q‖ = ‖r‖^q < 1 for q ≠ 0, via norm_pow and pow_lt_one₀) that licenses Mathlib's geometric lemma at ratio r^q, and one_sub_pow_ne_zero (1 − r^q ≠ 0)."
+    },
+    {
+      "id": "residue-subseries",
+      "title": "The Residue-Class Subseries",
+      "startLine": 73,
+      "endLine": 93,
+      "summary": "hasSum_geometric_residue proves ∑ r^(qn+a) = r^a·(1 − r^q)⁻¹ by reindexing r^(qn+a) = r^a·(r^q)ⁿ (pow_add, pow_mul, ring) and applying hasSum_geometric_of_norm_lt_one at ratio r^q scaled by HasSum.mul_left (r^a). tsum_geometric_residue and summable_geometric_residue give the tsum and Summable forms."
+    },
+    {
+      "id": "recombination",
+      "title": "Recombination of the q Subseries",
+      "startLine": 95,
+      "endLine": 124,
+      "summary": "one_sub_pow_eq is the algebraic backbone: 1 − r^q = (1 − r)·∑_{a<q} r^a, by induction on q. tsum_residues_eq_geometric then sums the q closed forms over residues, factors out (1 − r^q)⁻¹ via Finset.sum_mul, and closes ∑_{a<q} r^a · (1 − r^q)⁻¹ = (1 − r)⁻¹ with field_simp and linear_combination of the factorisation — recovering the full series 1/(1 − r)."
+    },
+    {
+      "id": "even-odd-specialisation",
+      "title": "Connection to the Even/Odd (q = 2) Case",
+      "startLine": 126,
+      "endLine": 140,
+      "summary": "tsum_geometric_even (q = 2, a = 0) and tsum_geometric_odd (q = 2, a = 1) recover the parent GeometricSeriesOQ09's closed forms ∑ r^(2n) = 1/(1 − r²) and ∑ r^(2n+1) = r/(1 − r²) as direct specialisations of tsum_geometric_residue, closed by simpa."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values at r = 1/2, q = 3",
+      "startLine": 142,
+      "endLine": 154,
+      "summary": "Two sanity checks at r = 1/2, q = 3: ∑ (1/2)^(3n) = ∑ (1/8)ⁿ = 8/7 (a = 0) and ∑ (1/2)^(3n+2) = 2/7 (a = 2), each via tsum_geometric_residue plus norm_num, exercising a modulus beyond the even/odd case."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-09-oq-01-oq-01",

--- a/src/data/proofs/geometric-series-oq-09/annotations.json
+++ b/src/data/proofs/geometric-series-oq-09/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-norm-sq-lt-one",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 55, "endLine": 63 },
+    "type": "technique",
+    "title": "The Squared-Ratio Bound ‖r²‖ < 1",
+    "content": "`norm_sq_lt_one` is the only genuinely new analytic ingredient: ‖r²‖ = ‖r‖² < 1 whenever ‖r‖ < 1. The proof rewrites ‖r²‖ = ‖r‖² with `norm_pow`, then `pow_lt_one₀` (0 ≤ a, a < 1, n ≠ 0 ⟹ aⁿ < 1) finishes. This bound is exactly the hypothesis Mathlib's geometric-series lemma needs at the new ratio r²; once it is in hand, summing the even subseries is immediate. The companions one_sub_ne_zero and one_sub_sq_ne_zero record 1 − r ≠ 0 and 1 − r² ≠ 0, the nonvanishing denominators the recombination step requires.",
+    "mathContext": "$\\lVert r^2 \\rVert = \\lVert r \\rVert^2 < 1$ when $\\lVert r \\rVert < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["normed field", "norm_pow", "pow_lt_one₀", "convergence radius"],
+    "prerequisites": ["normed fields", "powers and norms"]
+  },
+  {
+    "id": "ann-hasSum-even",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 65, "endLine": 81 },
+    "type": "insight",
+    "title": "The Even Subseries Is Geometric of Ratio r²",
+    "content": "`hasSum_geometric_even` is the keystone: ∑ r^(2n) = (1 − r²)⁻¹. The decisive move is the reindexing r^(2n) = (r²)ⁿ (`pow_mul`), which exhibits the even-index subseries as itself a geometric series — but of ratio r², not r. Then `hasSum_geometric_of_norm_lt_one` applies at ratio r² (legal because ‖r²‖ < 1), and `simpa only [pow_mul]` transports its conclusion back. This self-similarity — a subseries along an arithmetic index progression is again geometric, with the ratio raised to the step — is the reusable idea behind the whole entry. The tsum and Summable forms are mechanical projections via HasSum.tsum_eq and HasSum.summable.",
+    "mathContext": "$\\sum_{n\\ge0} r^{2n} = \\sum_{n\\ge0} (r^2)^n = \\dfrac{1}{1-r^2}$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "series bisection", "self-similarity", "pow_mul", "HasSum"],
+    "prerequisites": ["geometric series", "infinite series", "reindexing"]
+  },
+  {
+    "id": "ann-hasSum-odd",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 83, "endLine": 101 },
+    "type": "technique",
+    "title": "The Odd Subseries by Factoring Out r",
+    "content": "`hasSum_geometric_odd` sums ∑ r^(2n+1) = r·(1 − r²)⁻¹ not by reindexing from scratch but by transporting the even result. Factoring r^(2n+1) = r·r^(2n) (via pow_succ and mul_comm) writes the odd subseries as r times the even one, so `HasSum.mul_left r` applied to hasSum_geometric_even immediately yields the value. This keeps the odd value manifestly proportional to the even (odd = r·even) and is cheaper than an independent summation. Equivalently r/(1 − r²), the closed form.",
+    "mathContext": "$\\sum_{n\\ge0} r^{2n+1} = r\\sum_{n\\ge0} r^{2n} = \\dfrac{r}{1-r^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["HasSum.mul_left", "scalar multiple of a series", "factoring", "geometric series"],
+    "prerequisites": ["infinite series", "HasSum arithmetic"]
+  },
+  {
+    "id": "ann-recombination",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 103, "endLine": 113 },
+    "type": "insight",
+    "title": "Recombination and the Factorisation 1 − r² = (1−r)(1+r)",
+    "content": "`tsum_even_add_odd` verifies the split is faithful: ∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1 − r). After rewriting all three tsums to closed form, the goal (1 − r²)⁻¹ + r(1 − r²)⁻¹ = (1 − r)⁻¹ is closed by field_simp; ring, using 1 − r ≠ 0 and 1 − r² ≠ 0. The arithmetic is the analytic shadow of the factorisation 1 − r² = (1 − r)(1 + r): the combined numerator 1 + r cancels the (1 + r) factor in the denominator (1 − r)(1 + r), leaving 1/(1 − r). This consistency check confirms the even and odd parts partition the full series with no overlap or omission.",
+    "mathContext": "$\\dfrac{1}{1-r^2} + \\dfrac{r}{1-r^2} = \\dfrac{1+r}{(1-r)(1+r)} = \\dfrac{1}{1-r}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["difference of squares", "partial fractions", "series bisection", "field_simp"],
+    "prerequisites": ["algebraic identities", "infinite series"]
+  },
+  {
+    "id": "ann-concrete-values",
+    "proofId": "geometric-series-oq-09",
+    "range": { "startLine": 115, "endLine": 127 },
+    "type": "context",
+    "title": "Concrete Values at r = 1/2",
+    "content": "Two examples ground the closed forms at r = 1/2: ∑ (1/2)^(2n) = ∑ (1/4)ⁿ = 1/(1 − 1/4) = 4/3, and ∑ (1/2)^(2n+1) = (1/2)/(1 − 1/4) = 2/3. Each is proved by rewriting with the corresponding tsum closed form and finishing with norm_num. They also exercise the recombination on numbers: 4/3 + 2/3 = 2 = 1/(1 − 1/2), the full geometric sum at r = 1/2.",
+    "mathContext": "$\\sum (1/2)^{2n} = 4/3$, $\\sum (1/2)^{2n+1} = 2/3$, and $4/3 + 2/3 = 2 = 1/(1-1/2)$.",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "norm_num", "numerical verification"],
+    "prerequisites": ["arithmetic with fractions"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-09/meta.json
+++ b/src/data/proofs/geometric-series-oq-09/meta.json
@@ -16,6 +16,7 @@
     "sorries": 0
   },
   "title": "Even/Odd Splitting of the Geometric Series: ∑ r^(2n) = 1/(1−r²)",
+  "description": "Splits the geometric series over index parity into two geometric series of ratio r²: ∑_{n≥0} r^(2n) = 1/(1−r²) and ∑_{n≥0} r^(2n+1) = r/(1−r²) for ‖r‖ < 1, which recombine to ∑ rⁿ = 1/(1−r) via 1 − r² = (1−r)(1+r). The reusable move — a subseries along an arithmetic index progression is again geometric, of ratio r^q — reduces each subsum to Mathlib's geometric lemma at the squared ratio plus the bound ‖r²‖ < 1.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -66,6 +67,55 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "Splitting a power series ∑ aₙxⁿ into its even part ∑ a₂ₙx^{2n} and odd part ∑ a₂ₙ₊₁x^{2n+1} is the classical 'bisection' (or 'multisection') of series, a standard generating-function technique catalogued in Concrete Mathematics and traceable to Euler's manipulations of power series. The general multisection extracts the residue class n ≡ a (mod q) using q-th roots of unity: ∑_{n ≡ a (q)} aₙxⁿ = (1/q)∑_{j<q} ω^{−ja} f(ωˣ) with ω = e^{2πi/q}. For the geometric series f(x) = 1/(1−x) the even/odd parts have an especially clean self-similar structure — each is itself geometric — because the indicator of an arithmetic progression of indices, summed against a geometric weight, just rescales the ratio. This entry formalises the q = 2 instance and its recombination, the simplest nontrivial multisection.",
+    "problemStatement": "For a real ratio $r$ with $\\lVert r \\rVert < 1$, sum the even- and odd-indexed subseries of $\\sum_n r^n$ in closed form and verify they recombine. Concretely: prove $\\sum_{n=0}^{\\infty} r^{2n} = \\frac{1}{1-r^2}$ and $\\sum_{n=0}^{\\infty} r^{2n+1} = \\frac{r}{1-r^2}$, and that their sum equals the full series $\\sum_n r^n = \\frac{1}{1-r}$ — the analytic identity $\\frac{1}{1-r^2} + \\frac{r}{1-r^2} = \\frac{1}{1-r}$ underneath the factorisation $1 - r^2 = (1-r)(1+r)$.",
+    "proofStrategy": "The keystone is the observation that the even subseries is itself geometric of ratio r²: rewriting r^(2n) = (r²)ⁿ with pow_mul turns ∑ r^(2n) into Mathlib's geometric series at ratio r², which applies because ‖r²‖ = ‖r‖² < 1 (norm_sq_lt_one, from norm_pow and pow_lt_one₀). That gives hasSum_geometric_even with value (1 − r²)⁻¹. The odd subseries is transported from the even one: factor r^(2n+1) = r·r^(2n) and apply HasSum.mul_left r, yielding value r·(1 − r²)⁻¹. Each result is exposed in HasSum, tsum (via HasSum.tsum_eq), and Summable (via HasSum.summable) forms. The recombination tsum_even_add_odd rewrites all three tsums to their closed forms and closes (1 − r²)⁻¹ + r(1 − r²)⁻¹ = (1 − r)⁻¹ with field_simp; ring, using the nonvanishing denominators 1 − r ≠ 0 and 1 − r² ≠ 0. Concrete checks at r = 1/2 give 4/3 and 2/3.",
+    "keyInsights": [
+      "A subseries of a geometric series taken along an arithmetic progression of indices is again geometric — with ratio r^q, not r. The whole proof rests on this self-similarity: summing the even part is just Mathlib's geometric lemma re-applied at the new ratio r².",
+      "The only genuinely new analytic ingredient is the bound ‖r²‖ = ‖r‖² < 1, which licenses Mathlib's lemma at the squared ratio. Once that hypothesis is supplied, the closed form is immediate — the parity structure adds no convergence difficulty.",
+      "The odd subseries is not summed independently but factored out of the even one: r^(2n+1) = r·r^(2n), so HasSum.mul_left r transports the even result. This is cheaper and more robust than reindexing, and it keeps the two subseries' values manifestly proportional (odd = r·even).",
+      "The recombination 1/(1−r²) + r/(1−r²) = 1/(1−r) is the analytic shadow of the algebraic factorisation 1 − r² = (1−r)(1+r): the numerator 1 + r cancels the (1 + r) factor of the denominator, leaving 1/(1−r). The field_simp; ring proof is the formal record of that cancellation.",
+      "This is the q = 2 case of series multisection; the general q-fold splitting ∑ r^(qn+a) = r^a/(1−r^q) (the medium-significance open question) follows the identical template — reindex to ratio r^q, bound ‖r^q‖ < 1, factor out r^a — and connects, over ℂ, to roots-of-unity filters and generating functions of arithmetic-progression indicators."
+    ]
+  },
+  "sections": [
+    {
+      "id": "nonvanishing-denominators",
+      "title": "Nonvanishing Denominators and the Squared-Ratio Bound",
+      "startLine": 49,
+      "endLine": 63,
+      "summary": "Three supporting lemmas: one_sub_ne_zero (1 − r ≠ 0 from ‖r‖ < 1), the keystone norm_sq_lt_one (‖r²‖ = ‖r‖² < 1, via norm_pow and pow_lt_one₀) that lets Mathlib's geometric lemma apply at the squared ratio, and one_sub_sq_ne_zero (1 − r² ≠ 0) for the recombination's denominators."
+    },
+    {
+      "id": "even-subseries",
+      "title": "The Even-Power Subseries",
+      "startLine": 65,
+      "endLine": 81,
+      "summary": "hasSum_geometric_even proves ∑ r^(2n) = (1 − r²)⁻¹ by rewriting r^(2n) = (r²)ⁿ (pow_mul) and applying hasSum_geometric_of_norm_lt_one at ratio r² (valid by norm_sq_lt_one). tsum_geometric_even and summable_geometric_even expose the tsum and Summable forms via HasSum.tsum_eq / HasSum.summable."
+    },
+    {
+      "id": "odd-subseries",
+      "title": "The Odd-Power Subseries",
+      "startLine": 83,
+      "endLine": 101,
+      "summary": "hasSum_geometric_odd proves ∑ r^(2n+1) = r·(1 − r²)⁻¹ by factoring r^(2n+1) = r·r^(2n) (pow_succ, mul_comm) and applying HasSum.mul_left r to the even subseries, so the odd value is manifestly r times the even one. tsum and Summable forms follow."
+    },
+    {
+      "id": "recombination",
+      "title": "Recombination into the Full Series",
+      "startLine": 103,
+      "endLine": 113,
+      "summary": "tsum_even_add_odd shows ∑ r^(2n) + ∑ r^(2n+1) = ∑ rⁿ = 1/(1 − r): rewrite all three to closed form, then field_simp; ring closes (1 − r²)⁻¹ + r(1 − r²)⁻¹ = (1 − r)⁻¹ using the nonvanishing denominators — the analytic shadow of 1 − r² = (1 − r)(1 + r)."
+    },
+    {
+      "id": "concrete-values",
+      "title": "Concrete Values at r = 1/2",
+      "startLine": 115,
+      "endLine": 127,
+      "summary": "Two sanity checks at r = 1/2: ∑ (1/2)^(2n) = ∑ (1/4)ⁿ = 4/3 and ∑ (1/2)^(2n+1) = 2/3, each via the corresponding tsum closed form plus norm_num, confirming the subsums compute and recombine (4/3 + 2/3 = 2 = 1/(1−1/2))."
+    }
+  ],
   "openQuestions": [
     {
       "id": "geometric-series-oq-09-oq-01",


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-09-oq-01`.

This entry previously had only a bare `meta.json` (no description, overview, sections, or annotations). Added:

- **Top-level `description`** — was missing entirely.
- **`overview`** — `historicalContext` (series multisection / q-section, the roots-of-unity filter, Concrete Mathematics), `problemStatement` (LaTeX), `proofStrategy`, and 5 `keyInsights` on the self-similar residue subseries, the 1−r^q factorisation backbone, the single analytic hypothesis, the complete-normed-field generality, and the open reindexing question.
- **`sections`** — 5 sections covering all 154 lines (denominators + r^q bound, residue subseries, recombination, q=2 specialisation, concrete values).
- **`annotations.json`** — 5 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering `norm_pow_lt_one`, `hasSum_geometric_residue`, the `one_sub_pow_eq` factorisation, `tsum_residues_eq_geometric`, and the q=2 recovery + concrete values.

Axiom integrity: status `verified`, badge `original`, axiomCount 0 — consistent with the Lean source (0 sorries, 0 axioms, 0 assumption-carrying structures); generic over a complete normed field, so applies to ℝ and ℂ.

Mathematical content verified against the Lean source.