### PR TITLE
Enrich Urysohn's Lemma and the Explicit Metric Urysohn Function

### DIFF
--- a/src/data/proofs/urysohns-lemma-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview-urysohn",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 3, "endLine": 34 },
+    "type": "context",
+    "title": "Urysohn's Lemma and Its Explicit Metric Witness",
+    "content": "Urysohn's lemma (Urysohn 1925) is the cornerstone separation theorem of point-set topology: in a normal space, normality (a set-theoretic condition) is equivalent to separation of disjoint closed sets by continuous functions (an analytic condition). It is the linchpin of the Urysohn metrization and Tietze extension theorems. Mathlib proves the abstract statement via dyadic interpolation; this entry re-exports it (hence the mathlib badge) and contributes the explicit metric witness f(x) = d(x,s)/(d(x,s)+d(x,t)) — a closed form that bypasses the abstract construction, not named in Mathlib.",
+    "mathContext": "Normal space $\\Leftrightarrow$ disjoint closed sets are functionally separated; metric witness $f=\\frac{d(\\cdot,s)}{d(\\cdot,s)+d(\\cdot,t)}$.",
+    "significance": "context",
+    "relatedConcepts": ["Urysohn's lemma", "normal space", "separation axioms", "functional separation"],
+    "prerequisites": ["point-set topology", "metric spaces"]
+  },
+  {
+    "id": "ann-abstract-normal",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 45, "endLine": 75 },
+    "type": "theorem",
+    "title": "The Abstract Urysohn Lemma (Re-exported)",
+    "content": "urysohn_normal re-exports Mathlib's exists_continuous_zero_one_of_isClosed: in a NormalSpace, disjoint closed s, t admit a continuous f : C(X,ℝ) with f = 0 on s, f = 1 on t, 0 ≤ f ≤ 1. urysohn_locallyCompact gives the locally-compact-Hausdorff form (compact set vs. disjoint closed set), the version behind partitions of unity and the Riesz representation theorem. urysohn_point_isClosed separates a point from a disjoint closed set in a normal T1 space by applying the lemma to the closed singleton {x₀} — the gateway to complete regularity.",
+    "mathContext": "Disjoint closed $s,t$ in normal $X$: $\\exists f\\in C(X,\\mathbb{R})$, $f|_s=0,\\ f|_t=1,\\ 0\\le f\\le 1$.",
+    "significance": "key",
+    "relatedConcepts": ["exists_continuous_zero_one_of_isClosed", "locally compact Hausdorff", "complete regularity", "T1 space"],
+    "prerequisites": ["normal spaces", "continuous maps"]
+  },
+  {
+    "id": "ann-denominator-pos",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 88, "endLine": 104 },
+    "type": "theorem",
+    "title": "Denominator Positivity (the Crux)",
+    "content": "`infDist_add_pos`: for disjoint nonempty closed s, t, the denominator d(x,s) + d(x,t) is strictly positive everywhere. Proof by cases on whether d(x,s) = 0: if so, x ∈ s (IsClosed.mem_iff_infDist_zero), hence x ∉ t (disjointness), hence d(x,t) > 0 (IsClosed.notMem_iff_infDist_pos); otherwise d(x,s) > 0 directly. A point where both distances vanish would lie in s ∩ t = ∅. This single fact powers continuity (no division by zero), the value 1 on t, and the [0,1] bound.",
+    "mathContext": "$d(x,s)+d(x,t)>0$ everywhere, since $d(x,s)=d(x,t)=0\\Rightarrow x\\in s\\cap t=\\varnothing$.",
+    "significance": "key",
+    "relatedConcepts": ["infDist", "IsClosed.mem_iff_infDist_zero", "disjointness", "denominator positivity"],
+    "prerequisites": ["distance to a set", "closed sets"]
+  },
+  {
+    "id": "ann-definition-continuity",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 77, "endLine": 114 },
+    "type": "definition",
+    "title": "The Explicit Function and Its Continuity",
+    "content": "`urysohnFn s t x = infDist x s / (infDist x s + infDist x t)`, the textbook metric Urysohn function. `continuous_urysohnFn` proves it continuous as Continuous.div of the continuous distance-to-a-set maps (continuous_infDist_pt) with the nowhere-vanishing denominator from infDist_add_pos — no appeal to the abstract Urysohn machinery. This is the closed-form witness Mathlib does not name.",
+    "mathContext": "$\\mathrm{urysohnFn}\\,s\\,t\\,x=\\dfrac{d(x,s)}{d(x,s)+d(x,t)}$, continuous via $\\mathrm{Continuous.div}$.",
+    "significance": "critical",
+    "relatedConcepts": ["urysohnFn", "Continuous.div", "continuous_infDist_pt", "explicit construction"],
+    "prerequisites": ["continuity", "distance to a set"]
+  },
+  {
+    "id": "ann-boundary-range",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 116, "endLine": 149 },
+    "type": "theorem",
+    "title": "Boundary Values and Range",
+    "content": "urysohnFn_eq_zero: = 0 on s (infDist_zero_of_mem makes the numerator vanish). urysohnFn_eq_one: = 1 on t (distance to t vanishes; distance to the closed nonempty s is positive off s, so numerator = denominator). urysohnFn_mem_Icc: valued in [0,1] (numerator nonnegative, bounded by the positive denominator). urysohn_metric bundles continuity + these into a C(X,ℝ) separator; urysohn_metric_of_normalSpace notes the abstract lemma also applies since every metric space is normal.",
+    "mathContext": "$f|_s=0$, $f|_t=1$, $f(x)\\in[0,1]$; bundled as $\\exists f\\in C(X,\\mathbb{R})$ separating $s,t$.",
+    "significance": "key",
+    "relatedConcepts": ["infDist_zero_of_mem", "boundary values", "bundled separator", "metric normality"],
+    "prerequisites": ["distance to a set", "continuous maps"]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "urysohns-lemma-oq-01",
+    "range": { "startLine": 160, "endLine": 169 },
+    "type": "technique",
+    "title": "Concrete Evaluation at the Midpoint",
+    "content": "`urysohnFn_half_at_midpoint`: on ℝ, the explicit function separating {0} and {1} takes the value 1/2 at the midpoint 1/2, as symmetry demands. Computed via infDist_singleton (distance to a singleton is the point distance) and Real.dist_eq, finished by norm_num. A concrete anchor confirming the abstract construction behaves as expected.",
+    "mathContext": "$f(\\tfrac12)=\\dfrac{|{\\tfrac12-0}|}{|{\\tfrac12-0}|+|{\\tfrac12-1}|}=\\dfrac{1/2}{1}=\\tfrac12$.",
+    "significance": "technical",
+    "relatedConcepts": ["concrete instance", "infDist_singleton", "symmetry"],
+    "prerequisites": ["arithmetic", "distance on ℝ"]
+  }
+]

--- a/src/data/proofs/urysohns-lemma-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01/meta.json
@@ -18,6 +18,45 @@
     "sorries": 0
   },
   "title": "Urysohn's Lemma and the Explicit Metric Urysohn Function",
+  "description": "Urysohn's lemma — the cornerstone separation theorem of point-set topology: in a normal space any two disjoint closed sets are functionally separated by a continuous [0,1]-valued function. This entry re-exports Mathlib's abstract statement (normal and locally-compact-Hausdorff forms, plus point-from-closed-set separation) and then supplies the content absent from Mathlib: the explicit metric Urysohn function f(x) = d(x,s)/(d(x,s)+d(x,t)) for disjoint nonempty closed sets, proved continuous, identically 0 on s and 1 on t, and [0,1]-valued — entirely from the Metric.infDist API, with no appeal to the abstract Urysohn machinery.",
+    "overview": {
+    "historicalContext": "Urysohn's lemma, proved by Pavel Urysohn in 1925, is the foundational functional-separation result of general topology: it shows that normality — a purely set-theoretic separation condition on closed sets — is equivalent to the ability to separate disjoint closed sets by continuous real functions. It is the linchpin of the Urysohn metrization theorem and the Tietze extension theorem, and its locally-compact-Hausdorff form underlies partitions of unity and the Riesz representation theorem. The abstract proof is delicate (a dyadic-rational interpolation of nested open sets), and Mathlib formalizes it as exists_continuous_zero_one_of_isClosed. In a metric space, however, the separating function has a famous closed form — the normalized distance d(x,s)/(d(x,s)+d(x,t)) — that bypasses the abstract construction entirely. This entry re-exports the abstract lemma (hence the mathlib badge) and contributes the explicit metric witness, which is not a named result in Mathlib.",
+    "problemStatement": "Present Urysohn's lemma and construct the explicit metric Urysohn function. Re-export Mathlib's abstract statement (normal-space and locally-compact-Hausdorff forms, and point-from-closed-set separation), and for disjoint nonempty closed sets s, t in a metric space define urysohnFn s t x = d(x,s)/(d(x,s)+d(x,t)) and prove it continuous, equal to 0 on s and 1 on t, and valued in [0,1], packaged as a bundled continuous separator.",
+    "proofStrategy": "Two parts. The abstract part is direct re-export: urysohn_normal and urysohn_locallyCompact wrap Mathlib's existence theorems, and urysohn_point_isClosed applies the normal-space form to the closed singleton {x₀}. The explicit metric part is built from the Metric.infDist API: infDist_add_pos shows the denominator d(x,s)+d(x,t) is strictly positive everywhere (a point with both distances zero would lie in s ∩ t, contradicting disjointness, via IsClosed.mem_iff_infDist_zero and notMem_iff_infDist_pos); continuous_urysohnFn is then Continuous.div of the continuous distance maps with this nowhere-vanishing denominator; urysohnFn_eq_zero/eq_one use infDist_zero_of_mem and closed-set distance positivity; urysohnFn_mem_Icc bounds the numerator by the positive denominator. urysohn_metric bundles these into a C(X,ℝ) separator.",
+    "keyInsights": [
+      "Urysohn's lemma is the equivalence between a set-theoretic separation property (normality) and an analytic one (separation by continuous functions) — it is what makes 'normal space' a useful hypothesis throughout topology and analysis.",
+      "In a metric space the separating function is explicit and constructive: f(x) = d(x,s)/(d(x,s)+d(x,t)) sidesteps the abstract dyadic-interpolation construction entirely, with continuity, boundary values, and range all read off the distance-to-a-set API.",
+      "Denominator positivity is the crux: d(x,s)+d(x,t) > 0 everywhere precisely because s and t are disjoint closed sets — a point where both distances vanish would lie in s ∩ t = ∅. This single fact powers continuity (no division by zero), the value 1 on t, and the [0,1] bound.",
+      "The boundary values invert the closed-set distance characterisation: infDist x s = 0 ⇔ x ∈ s for closed s, so the function is 0 exactly on s; and on t (disjoint from the closed s) the distance to s is positive, forcing the value 1.",
+      "The locally-compact-Hausdorff form (compact set vs. disjoint closed set) is the version that powers partitions of unity and the Riesz representation theorem — the same separation principle specialised to where measure theory needs it."
+    ]
+  },
+  "sections": [
+    {
+      "id": "abstract-lemma",
+      "title": "Part (a): The Abstract Lemma in a Normal Space",
+      "startLine": 40,
+      "endLine": 75,
+      "summary": "Direct re-exports of Mathlib's Urysohn lemma (the mathlib-badged content). urysohn_normal: disjoint closed sets in a NormalSpace are separated by a continuous [0,1]-valued f (exists_continuous_zero_one_of_isClosed). urysohn_locallyCompact: the LCH form separating a compact set from a disjoint closed set. urysohn_point_isClosed: a point outside a closed set is separated from it in a normal T1 space, by applying the lemma to the closed singleton {x₀}.",
+      "mathContext": "Normal space: disjoint closed $s,t$ $\\Rightarrow$ $\\exists f\\in C(X,\\mathbb{R})$, $f|_s=0$, $f|_t=1$, $0\\le f\\le 1$."
+    },
+    {
+      "id": "explicit-metric",
+      "title": "Part (b): The Explicit Metric Urysohn Function",
+      "startLine": 77,
+      "endLine": 158,
+      "summary": "Defines urysohnFn s t x = d(x,s)/(d(x,s)+d(x,t)) and proves, from the Metric.infDist API alone: infDist_add_pos (denominator > 0 everywhere, from disjointness), continuous_urysohnFn (Continuous.div with nowhere-vanishing denominator), urysohnFn_eq_zero (= 0 on s), urysohnFn_eq_one (= 1 on t), urysohnFn_mem_Icc ([0,1]-valued). urysohn_metric bundles these into a C(X,ℝ) separator; urysohn_metric_of_normalSpace notes the abstract lemma applies verbatim since every metric space is normal.",
+      "mathContext": "$f(x)=\\dfrac{d(x,s)}{d(x,s)+d(x,t)}$: continuous, $f|_s=0$, $f|_t=1$, $f(x)\\in[0,1]$, denominator $>0$."
+    },
+    {
+      "id": "concrete-evaluation",
+      "title": "Part (c): A Concrete Evaluation",
+      "startLine": 160,
+      "endLine": 169,
+      "summary": "urysohnFn_half_at_midpoint: on ℝ, the explicit function separating {0} and {1} takes the value 1/2 at the midpoint 1/2, as symmetry demands. Computed via infDist_singleton and Real.dist_eq, finished by norm_num — a concrete anchor for the abstract construction.",
+      "mathContext": "On $\\mathbb{R}$: $f(\\tfrac12)=\\dfrac{d(\\tfrac12,\\{0\\})}{d(\\tfrac12,\\{0\\})+d(\\tfrac12,\\{1\\})}=\\dfrac{1/2}{1/2+1/2}=\\tfrac12$."
+    }
+  ],
   "meta": {
     "author": "Lean Genius",
     "status": "verified",


### PR DESCRIPTION
## Summary

Enrichment pass for `urysohns-lemma-oq-01` (*Urysohn's Lemma and the Explicit Metric Urysohn Function*). The entry previously had only `meta.json` (no overview, sections, or annotations).

## Changes
- **description**: top-level summary of the abstract lemma re-export plus the explicit metric witness.
- **overview**: `historicalContext` (Urysohn 1925, the normality⇔functional-separation equivalence, Mathlib's role), `problemStatement`, `proofStrategy`, and 5 `keyInsights` (denominator positivity as the crux; the closed-form bypass; the LCH form's role in partitions of unity).
- **sections**: 3 sections covering the full Lean file (abstract lemma re-exports; explicit metric function; concrete evaluation).
- **annotations.json**: 6 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.
- No `index.ts`: the gallery loader uses the build-generated manifest; this entry is already registered.

## Axiom integrity
Badge `mathlib` (Tier B) preserved — the abstract Urysohn lemma is delegated to Mathlib (exists_continuous_zero_one_of_isClosed); the explicit metric Urysohn function is the new, self-contained content. status `verified`, axiomCount 0, consistent with the Lean file (0 sorries, 0 axioms).

## Verification
- JSON validated for both files.