### PR TITLE
research(inclusion-exclusion-oq-04-oq-01-oq-01): surjection count via the inclusion–exclusion sieve [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2919,6 +2919,7 @@ import Proofs.InclusionExclusionOQ01OQ03
 import Proofs.InclusionExclusionOQ03
 import Proofs.InclusionExclusionSieve
 import Proofs.InclusionExclusionSieveDerangements
+import Proofs.InclusionExclusionSieveSurjections
 import Proofs.InfinitudePrimes
 import Proofs.InfinitudePrimes3k2
 import Proofs.InfinitudePrimes4k1

--- a/proofs/Proofs/InclusionExclusionSieveSurjections.lean
+++ b/proofs/Proofs/InclusionExclusionSieveSurjections.lean
@@ -1,0 +1,183 @@
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Data.Fintype.Card
+import Mathlib.Data.Fintype.BigOperators
+import Mathlib.Data.Finset.Powerset
+import Mathlib.Tactic
+import Proofs.InclusionExclusionSieve
+
+/-
+# Surjection Counts as an Instance of the Inclusion–Exclusion Sieve
+
+## What This Proves
+This file answers the first open question of `InclusionExclusionSieveDerangements`
+("Derangements as an Instance of the Inclusion–Exclusion Sieve"):
+
+> Instantiate the same sieve to derive the surjection count
+> `#(surjections [n] ↠ [k]) = Σ_j (-1)^j C(k,j) (k-j)^n`,
+> taking the bad property `j` to be "value `j` is missed" — the crux count being
+> `|intersection over a j-set of missed values| = (k - |J|)^n`.
+
+We realise the set of **surjections** `Fin n → Fin k` as the "avoid" set of the sieve,
+taking the universe to be the function type `Fin n → Fin k` and the bad property `j`
+(for `j : Fin k`) to be "the value `j` is missed", i.e. no input maps to `j`. A function
+avoiding *every* bad property hits every value, so it is exactly a surjection. The general
+dual sieve `InclusionExclusionSieve.card_avoid_sieve` then yields the **closed sieve form**
+
+    #(surjections Fin n → Fin k)  =  Σ_{j=0}^k (-1)^j · C(k,j) · (k-j)^n.
+
+## Why This Is Not Already in the Gallery / Mathlib
+Mathlib does not record a closed form for the number of surjections between finite types,
+and the gallery's only sieve instance so far is the derangement count
+(`InclusionExclusionSieveDerangements`). This file adds the second classical application of
+the dual sieve — the surjection / "onto function" count, equivalently `k! · S(n,k)` with
+`S` the Stirling numbers of the second kind — obtained as a genuine instance of the reusable
+theorem `card_avoid_sieve`, exactly parallel to the derangement derivation.
+
+## Crux
+The one piece of real counting is:
+
+    #{ f : Fin n → Fin k : f misses every value in t }  =  (k - |t|)^n,
+
+because such an `f` is exactly a function into the `(k - |t|)`-element set `Fin k \ t`, and
+there are `(k - |t|)^n` functions from an `n`-element domain into a `(k - |t|)`-element
+codomain. We prove this by the explicit equivalence with `Fin n → {x : Fin k // x ∉ t}`.
+
+## Status
+- [x] Complete proof, no `sorry`, no `axiom`
+- [x] No `native_decide`; the worked example uses `decide`, so the file is axiom-free.
+
+## Mathlib / Gallery Dependencies
+- `InclusionExclusionSieve.card_avoid_sieve` : the general dual sieve (parent file)
+- `Fintype.card_fun`, `Fintype.card_subtype_compl` : function- and subtype-cardinalities
+- `Finset.powerset_card_disjiUnion`, `Finset.card_powersetCard` : grouping the powerset by size
+-/
+
+namespace InclusionExclusionSieveSurjections
+
+open Finset
+
+variable {k : ℕ}
+
+/-- The set of functions `Fin n → Fin k` that *miss* the value `j` (no input maps to `j`).
+This is the `j`-th "bad property" whose avoidance defines a surjection. -/
+def missSet (n : ℕ) (j : Fin k) : Finset (Fin n → Fin k) :=
+  univ.filter (fun f => ∀ i, f i ≠ j)
+
+@[simp] theorem mem_missSet (n : ℕ) (j : Fin k) (f : Fin n → Fin k) :
+    f ∈ missSet n j ↔ ∀ i, f i ≠ j := by simp [missSet]
+
+/-
+## Part I: The crux count — functions missing a prescribed set of values
+
+The intersection `t.inf (missSet n)` is the set of functions missing every value in `t`.
+We first identify it as a filter, then count it via the equivalence with functions into
+the complementary subtype.
+-/
+
+/-- The intersection of the "miss" sets over `t` is exactly the functions whose every value
+avoids `t`. -/
+theorem inf_missSet_eq_filter (n : ℕ) (t : Finset (Fin k)) :
+    t.inf (missSet n) = univ.filter (fun f : Fin n → Fin k => ∀ i, f i ∉ t) := by
+  ext f
+  simp only [Finset.mem_inf, mem_missSet, mem_filter, mem_univ, true_and]
+  constructor
+  · intro h i hi
+    exact h (f i) hi i rfl
+  · intro h j hj i hi
+    exact h i (hi ▸ hj)
+
+/-- **Crux count.** The number of functions `Fin n → Fin k` missing every value of a finite
+set `t` equals `(k - |t|)^n` — there are `k - |t|` allowed output values for each of the `n`
+inputs.
+
+Proved by the explicit equivalence with `Fin n → {x : Fin k // x ∉ t}`. -/
+theorem card_missesOn (n : ℕ) (t : Finset (Fin k)) :
+    (univ.filter (fun f : Fin n → Fin k => ∀ i, f i ∉ t)).card = (k - t.card) ^ n := by
+  -- equivalence: functions all of whose values avoid `t`  ≃  functions into `{x // x ∉ t}`
+  have e : {f : Fin n → Fin k // ∀ i, f i ∉ t} ≃ (Fin n → {x : Fin k // x ∉ t}) :=
+    { toFun := fun f i => ⟨f.1 i, f.2 i⟩
+      invFun := fun g => ⟨fun i => (g i).1, fun i => (g i).2⟩
+      left_inv := by rintro ⟨f, hf⟩; rfl
+      right_inv := by intro g; funext i; rfl }
+  -- the complementary subtype has `k - |t|` elements
+  have hcompl : Fintype.card {x : Fin k // x ∉ t} = k - t.card := by
+    have h := Fintype.card_subtype_compl (p := fun x : Fin k => x ∈ t)
+    simp only [Fintype.card_fin, Fintype.card_coe] at h
+    exact h
+  rw [← Fintype.card_subtype, Fintype.card_congr e, Fintype.card_fun, hcompl, Fintype.card_fin]
+
+/-
+## Part II: The avoid set is the set of surjections
+-/
+
+/-- The "avoid" set of the sieve — functions lying in *none* of the `missSet n j` — is the
+set of surjections `Fin n → Fin k`: missing no value means hitting every value. -/
+theorem avoid_eq_filter_surjective (n : ℕ) :
+    (univ.inf (fun j : Fin k => (missSet n j)ᶜ))
+      = univ.filter (fun f : Fin n → Fin k => Function.Surjective f) := by
+  ext f
+  simp only [Finset.mem_inf, mem_univ, mem_compl, mem_missSet, mem_filter, true_and,
+    Function.Surjective]
+  push_neg
+  tauto
+
+/-
+## Part III: The closed sieve form of the surjection count
+
+Applying `card_avoid_sieve` and grouping the powerset sum by cardinality `j` (there are
+`C(k,j)` subsets of size `j`, each contributing `(-1)^j (k-j)^n`) gives the binomial form.
+-/
+
+/-- **The sieve form of the surjection count.** Derived directly from the general
+inclusion–exclusion sieve `InclusionExclusionSieve.card_avoid_sieve`:
+
+    #(surjections Fin n → Fin k)  =  Σ_{j=0}^k (-1)^j · C(k,j) · (k-j)^n.
+
+This is the textbook inclusion–exclusion derivation of the surjection / onto-function count,
+exactly parallel to the derangement instance in the sibling file. -/
+theorem card_surjective_eq_sieve_sum (n k : ℕ) :
+    ((univ.filter (fun f : Fin n → Fin k => Function.Surjective f)).card : ℤ) =
+      ∑ j ∈ Finset.range (k + 1),
+        (-1 : ℤ) ^ j * (k.choose j : ℤ) * (((k - j) ^ n : ℕ) : ℤ) := by
+  have hsieve := InclusionExclusionSieve.card_avoid_sieve (univ : Finset (Fin k)) (missSet n)
+  rw [avoid_eq_filter_surjective n] at hsieve
+  rw [hsieve, Finset.powerset_card_disjiUnion, Finset.sum_disjiUnion]
+  -- now: Σ_{j ∈ range (univ.card + 1)} Σ_{t ∈ univ.powersetCard j} (-1)^|t| |⋂ missSet| = RHS
+  rw [Finset.card_univ, Fintype.card_fin]
+  apply Finset.sum_congr rfl
+  intro j _hj
+  have hconst : ∀ t ∈ (univ : Finset (Fin k)).powersetCard j,
+      (-1 : ℤ) ^ t.card * ((t.inf (missSet n)).card : ℤ)
+        = (-1 : ℤ) ^ j * (((k - j) ^ n : ℕ) : ℤ) := by
+    intro t ht
+    have htj : t.card = j := (Finset.mem_powersetCard.mp ht).2
+    rw [inf_missSet_eq_filter, card_missesOn, htj]
+  rw [Finset.sum_congr rfl hconst, Finset.sum_const, Finset.card_powersetCard,
+    Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  ring
+
+/-
+## Part IV: Concrete check (axiom-free)
+
+The number of surjections `[3] ↠ [2]` is `2^3 - 2 = 6`, verified against the sieve sum
+`Σ_{j=0}^2 (-1)^j C(2,j)(2-j)^3 = 8 - 2 + 0 = 6`, with `decide` (not `native_decide`).
+-/
+
+/-- The sieve form specialised to `n = 3`, `k = 2`. -/
+example :
+    ((univ.filter (fun f : Fin 3 → Fin 2 => Function.Surjective f)).card : ℤ) =
+      ∑ j ∈ Finset.range 3,
+        (-1 : ℤ) ^ j * (Nat.choose 2 j : ℤ) * (((2 - j) ^ 3 : ℕ) : ℤ) :=
+  card_surjective_eq_sieve_sum 3 2
+
+/-- The sieve sum evaluates to `6`, the number of surjections `[3] ↠ [2]`. -/
+example :
+    (∑ j ∈ Finset.range 3,
+      (-1 : ℤ) ^ j * (Nat.choose 2 j : ℤ) * (((2 - j) ^ 3 : ℕ) : ℤ)) = 6 := by
+  decide
+
+#check @card_surjective_eq_sieve_sum
+#check @card_missesOn
+#check @avoid_eq_filter_surjective
+
+end InclusionExclusionSieveSurjections

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,160 @@
+{
+  "id": "inclusion-exclusion-oq-04-oq-01-oq-01",
+  "slug": "inclusion-exclusion-oq-04-oq-01-oq-01",
+  "title": "Surjection Counts as an Instance of the Inclusion–Exclusion Sieve",
+  "description": "Answers the first open question of inclusion-exclusion-oq-04-oq-01 (Derangements as an Instance of the Inclusion–Exclusion Sieve): instantiate the same general dual sieve to derive the surjection count #(surjections Fin n → Fin k) = Σ_{j=0}^k (-1)^j C(k,j) (k-j)^n. Working over the universe of functions Fin n → Fin k, the bad property j (for j : Fin k) is 'the value j is missed' (missSet n j := {f | ∀ i, f i ≠ j}); a function avoiding all of them hits every value, hence is exactly a surjection. The parent's general sieve card_avoid_sieve then yields the closed sieve form Σ_{j=0}^k (-1)^j C(k,j) (k-j)^n. The single piece of real counting is the crux lemma card_missesOn: the functions missing every value of a prescribed set t number (k − |t|)^n, proved by the explicit equivalence {f // ∀ i, f i ∉ t} ≃ (Fin n → {x : Fin k // x ∉ t}) followed by Fintype.card_fun. This is the textbook inclusion–exclusion derivation of the surjection / onto-function count (equivalently k!·S(n,k) with S the Stirling numbers of the second kind), the second flagship application of the dual sieve after derangements. Verified, 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Lean Genius (Researcher)",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/InclusionExclusionSieveSurjections.lean",
+    "tags": [
+      "combinatorics",
+      "inclusion-exclusion",
+      "sieve",
+      "surjections",
+      "counting",
+      "stirling-numbers",
+      "functions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "InclusionExclusionSieve.card_avoid_sieve",
+        "description": "The parent file's general dual sieve: #(elements in none of the S_j) = Σ_{t⊆s} (-1)^|t| |⋂_{j∈t} S_j|. Applied with universe Fin n → Fin k, index set univ : Finset (Fin k), and S j = missSet n j = {f | ∀ i, f i ≠ j}, it is the engine that turns the surjection count into the alternating powerset sum.",
+        "module": "Proofs.InclusionExclusionSieve"
+      },
+      {
+        "theorem": "Fintype.card_fun",
+        "description": "Fintype.card (α → β) = (Fintype.card β) ^ (Fintype.card α). Supplies the (k − |t|)^n count once the functions missing every value of t are identified with the functions Fin n → {x : Fin k // x ∉ t} into the (k − |t|)-element complementary codomain.",
+        "module": "Mathlib.Data.Fintype.Pi"
+      },
+      {
+        "theorem": "Fintype.card_subtype_compl",
+        "description": "Fintype.card {x // ¬ p x} = Fintype.card α − Fintype.card {x // p x}. With p = (· ∈ t) over Fin k it gives Fintype.card {x : Fin k // x ∉ t} = k − |t|, the size of the allowed codomain in the crux count.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finset.powerset_card_disjiUnion",
+        "description": "s.powerset = (range (|s|+1)).disjiUnion (fun j => s.powersetCard j). Together with Finset.card_powersetCard (#(powersetCard j s) = C(|s|,j)) it groups the alternating powerset sum by subset size j, converting Σ_{t⊆univ} into Σ_{j=0}^k C(k,j)·(−1)^j(k−j)^n.",
+        "module": "Mathlib.Data.Finset.Powerset"
+      },
+      {
+        "theorem": "Finset.card_powersetCard",
+        "description": "#(s.powersetCard j) = C(|s|, j). Counts the C(k,j) subsets of size j of the value set Fin k, supplying the binomial coefficient on each sieve term once the inner sum over equal-size subsets is collapsed.",
+        "module": "Mathlib.Data.Finset.Powerset"
+      }
+    ],
+    "originalContributions": [
+      "card_surjective_eq_sieve_sum: the closed sieve form of the surjection count, #(surjections Fin n → Fin k) = Σ_{j=0}^k (-1)^j C(k,j) (k-j)^n, derived directly from the general inclusion-exclusion sieve card_avoid_sieve. Mathlib records no closed form for the number of surjections between finite types, so this binomial sieve sum is new to the gallery.",
+      "card_missesOn: the crux count — the functions Fin n → Fin k missing every value of a finite set t number exactly (k − |t|)^n. Proved by the explicit equivalence {f // ∀ i, f i ∉ t} ≃ (Fin n → {x : Fin k // x ∉ t}) composed with Fintype.card_fun and Fintype.card_subtype_compl; the bijection between value-avoiding functions and functions into the complementary codomain is built directly.",
+      "avoid_eq_filter_surjective: identifies the sieve's 'avoid' set univ.inf (fun j => (missSet n j)ᶜ) over Fin n → Fin k with the set of surjective functions, so its cardinality is the surjection count — the structural observation (missing no value = hitting every value = surjective) that makes the sieve applicable.",
+      "missSet n j := univ.filter (fun f => ∀ i, f i ≠ j): modeling 'the value j is missed' as the j-th bad property over the universe Fin n → Fin k, the reformulation that lets the parent's dual sieve be applied verbatim with the ground type instantiated to a function type."
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "inclusion-exclusion-oq-04-oq-01",
+        "relationship": "Answers open question oq-01. The parent entry instantiates the dual sieve to the derangement count and asks to 'instantiate the same sieve to derive the surjection count #(surjections [n]↠[k]) = Σ_j (-1)^j C(k,j)(k-j)^n, taking the bad property j to be value j is missed'. This entry does exactly that, importing card_avoid_sieve and instantiating its ground type with the function type Fin n → Fin k."
+      },
+      {
+        "id": "inclusion-exclusion-oq-04",
+        "relationship": "Grandchild of the dual-sieve entry. The surjection count is, with the derangement count, one of the two flagship applications of the sieve form of inclusion-exclusion proved in inclusion-exclusion-oq-04."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 183,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. n k : ℕ are arbitrary. #print axioms reports only the foundational propext, Classical.choice, Quot.sound for card_surjective_eq_sieve_sum and card_missesOn — no sorryAx, no Lean.ofReduceBool. The worked example (6 surjections [3]↠[2]) uses decide (kernel reduction), not native_decide, so the file remains axiom-free.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "proofRepoPath": null,
+  "leanFile": {
+    "path": "Proofs/InclusionExclusionSieveSurjections.lean",
+    "imports": [
+      "Mathlib.Data.Fintype.Pi",
+      "Mathlib.Data.Fintype.Card",
+      "Mathlib.Data.Fintype.BigOperators",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Tactic",
+      "Proofs.InclusionExclusionSieve"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "InclusionExclusionSieveSurjections",
+    "lineCount": 183,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 5,
+    "isAristotle": false,
+    "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionSieveSurjections.lean"
+  },
+  "overview": "A surjection from an n-element set onto a k-element set is an 'onto' function — every target value is hit at least once — and the count of such functions is the second classical application of inclusion–exclusion, after derangements. This entry realises that application formally as an instance of the same reusable sieve. Taking the ground set to be all functions Fin n → Fin k and the k 'bad properties' to be 'value j is missed', a function that avoids every bad property hits every value, so it is exactly a surjection; the parent file's dual sieve immediately expresses the surjection count as an alternating sum over subsets of the values. Grouping the subsets by size and counting the functions that miss a given set of values — the crux (k − |t|)^n count, since such a function maps into the complementary codomain — gives the binomial closed form Σ_j (-1)^j C(k,j)(k-j)^n. The whole derivation is an instance of a single general theorem, exactly as the open question requests.",
+  "sections": [
+    {
+      "id": "misssets-and-crux",
+      "title": "Miss Sets and the Crux Count",
+      "startLine": 60,
+      "endLine": 108,
+      "mathContext": "$\\text{missSet}(j) := \\{f \\mid \\forall i,\\ f(i)\\neq j\\}, \\qquad \\#\\{f : \\forall i,\\ f(i)\\notin t\\} = (k-|t|)^n$",
+      "summary": "missSet n j is the j-th bad property — functions that miss the value j. inf_missSet_eq_filter identifies the intersection over a value set t with the functions whose every output avoids t. card_missesOn is the one real count: those functions number (k − |t|)^n, proved by the explicit equivalence {f // ∀ i, f i ∉ t} ≃ (Fin n → {x : Fin k // x ∉ t}) with the complementary (k−|t|)-element codomain, then Fintype.card_fun."
+    },
+    {
+      "id": "avoid-is-surjections",
+      "title": "The Avoid Set Is the Surjections",
+      "startLine": 110,
+      "endLine": 124,
+      "mathContext": "$\\#\\bigl(\\textstyle\\bigsqcap_j \\text{missSet}(j)^{c}\\bigr) = \\#\\{f : \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,k \\mid f \\text{ surjective}\\}$",
+      "summary": "avoid_eq_filter_surjective identifies the sieve's 'avoid' set (functions in none of the missSet n j) with the set of surjective functions Fin n → Fin k: missing no value is exactly hitting every value. This is the structural step that makes the general sieve applicable to the surjection count."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Closed Sieve Form",
+      "startLine": 125,
+      "endLine": 182,
+      "mathContext": "$\\#(\\text{surjections } \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,k) = \\sum_{j=0}^k (-1)^j \\binom{k}{j}(k-j)^n$",
+      "summary": "card_surjective_eq_sieve_sum applies card_avoid_sieve and groups the powerset sum by subset size (C(k,j) subsets of size j, each contributing (-1)^j(k-j)^n) to give the binomial closed form. A concrete check confirms there are 6 = 2³ − 2 surjections [3]↠[2], matching the sieve sum 8 − 2 + 0, verified with decide (kernel reduction, not native_decide)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The surjection count is obtained as a genuine instance of the inclusion–exclusion sieve proved in the parent file. Over the universe of functions Fin n → Fin k, with bad property j being 'value j is missed', avoiding all bad properties means hitting every value, i.e. being surjective; the general sieve card_avoid_sieve then gives #(surjections Fin n → Fin k) = Σ_{j=0}^k (-1)^j C(k,j)(k-j)^n. The only nontrivial count is that the functions missing a prescribed set of m values number (k−m)^n. Verified, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "This is the textbook inclusion–exclusion derivation of the surjection / onto-function count, made formal as a one-line instantiation of a reusable theorem — the second flagship application of the dual sieve after derangements, demonstrating the same engine powers both classical enumerations. Mathlib records no closed form for the number of surjections between finite types, so the binomial sieve sum Σ_j (-1)^j C(k,j)(k-j)^n is new to the gallery; it is equivalently k!·S(n,k) with S the Stirling numbers of the second kind.",
+    "openQuestions": [
+      "Recover the Stirling-number form: prove #(surjections Fin n → Fin k) = k! · S(n,k) by relating the sieve sum to the Stirling numbers of the second kind, giving a closed form for S(n,k) itself as (1/k!)Σ_j (-1)^j C(k,j)(k-j)^n.",
+      "Specialise to k = n to obtain n! = Σ_{j=0}^n (-1)^j C(n,j)(n-j)^n (the surjections of an n-set onto itself are exactly its n! permutations), an identity of independent combinatorial interest."
+    ]
+  },
+  "references": [
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Section 2.2 derives the surjection count Σ_j (-1)^j C(k,j)(k-j)^n alongside the derangement count as canonical applications of the sieve form of inclusion-exclusion, exactly the derivation formalized here."
+    },
+    {
+      "authors": "van Lint, J. H.; Wilson, R. M.",
+      "title": "A Course in Combinatorics",
+      "year": "2001",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Chapter 10 presents the inclusion-exclusion sieve and obtains the derangement and surjection counts as its two flagship instances."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "inclusion-exclusion-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Answers open question oq-01 by instantiating the parent's general dual sieve card_avoid_sieve to the function-type universe Fin n → Fin k, deriving the surjection count as the 'avoid every missed-value set' instance — the companion to the parent's derangement instance."
+    },
+    {
+      "targetId": "inclusion-exclusion-oq-04",
+      "relationship": "related",
+      "description": "Grandchild of the dual-sieve entry: the surjection count is, with the derangement count, one of the two flagship applications of the sieve form of inclusion-exclusion proved there."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `inclusion-exclusion-oq-04-oq-01` (*Derangements as an Instance of the Inclusion–Exclusion Sieve*): instantiate the **same** general dual sieve `card_avoid_sieve` to derive the **surjection count**

$$\#(\text{surjections } \mathrm{Fin}\,n \to \mathrm{Fin}\,k) = \sum_{j=0}^k (-1)^j \binom{k}{j}(k-j)^n.$$

This is the second flagship application of the dual sieve, exactly parallel to the derangement instance, and literally what the open question asks for.

## Construction

- **Universe**: the function type `Fin n → Fin k`. **Bad property** `j` (for `j : Fin k`): *value `j` is missed*, `missSet n j := {f | ∀ i, f i ≠ j}`.
- **Avoid set = surjections** (`avoid_eq_filter_surjective`): missing no value ⟺ hitting every value ⟺ surjective.
- **Crux count** (`card_missesOn`): functions missing every value of a set `t` number `(k-|t|)^n`, via the explicit equivalence `{f // ∀ i, f i ∉ t} ≃ (Fin n → {x : Fin k // x ∉ t})` (functions into the complementary codomain) and `Fintype.card_fun`.
- **Main theorem** (`card_surjective_eq_sieve_sum`): apply `card_avoid_sieve`, group the powerset sum by subset size via `Finset.powerset_card_disjiUnion` / `Finset.card_powersetCard`.
- Concrete check: `6 = 2³ − 2` surjections `[3]↠[2]`, matching the sieve sum `8 − 2 + 0`, with `decide` (kernel reduction).

## Status

**Verified, 0 axioms, 0 sorries, no `native_decide`.** `#print axioms` reports only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). 183 lines, 5 theorems, 1 def. Mathlib records no closed form for surjection counts between finite types, so the binomial sieve sum is new to the gallery (equivalently `k!·S(n,k)` with `S` the Stirling numbers of the second kind).

## Files

- `proofs/Proofs/InclusionExclusionSieveSurjections.lean` (new)
- `src/data/proofs/inclusion-exclusion-oq-04-oq-01-oq-01/meta.json` (new)
- `proofs/Proofs.lean` (+1 import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)