### PR TITLE
research(combinations-formula-oq-05-oq-01-oq-01): weighted partial alternating binomial sum closed form [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3752,3 +3752,5 @@ import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ01
 import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01
 
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ03
+
+import Proofs.CombinationsFormulaOQ05OQ01OQ01

--- a/proofs/Proofs/CombinationsFormulaOQ05OQ01OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ05OQ01OQ01.lean
@@ -1,0 +1,135 @@
+import Mathlib
+
+/-
+# Closed Form for the Weighted Partial Alternating Binomial Sum
+
+## Open Question OQ-05-OQ-01-OQ-01
+
+The grandparent (`CombinationsFormulaOQ05`) records the vanishing of the *full*
+**weighted** alternating row sum, `∑_{k=0}^{n} (-1)^k · k · C(n,k) = 0` for
+`n ≥ 2`.  The parent (`CombinationsFormulaOQ05OQ01`) gives the closed form for
+the *unweighted* **partial** sums, `∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j)`.
+
+This file answers the parent's open question by combining both refinements:
+it gives the sharp single-coefficient closed form for the **weighted partial**
+sum, valid for every cut-off `j`:
+
+  ∑_{k=0}^{j} (-1)^k · k · C(n, k) = n · (-1)^j · C(n-2, j-1)      (n ≥ 2).      (★)
+
+So, just like the unweighted partial sum is a single binomial of the *previous*
+row, the weighted partial sum is a single binomial of the row *two below*,
+scaled by `n` — and it stabilises to `0` exactly when `j ≥ n`, recovering the
+grandparent's full-row vanishing as the special case `j = n`.
+
+## Why a closed form at all?
+
+Two mechanisms combine.  First, the **absorption identity**
+`k · C(n,k) = n · C(n-1, k-1)` turns the weight `k` into a shift of the row,
+converting the weighted sum on row `n` into `n` times an *unweighted* partial
+sum on row `n-1`.  Second, that unweighted partial sum telescopes to a single
+binomial of row `n-2` (the parent's mechanism).  The net effect is one
+absorption followed by one telescoping, producing the single coefficient
+`n · (-1)^j · C(n-2, j-1)`.
+
+Equivalently, with no natural-number subtraction (the form actually proved by
+induction below),
+
+  ∑_{k=0}^{j+1} (-1)^k · k · C(n+2, k) = (n+2) · (-1)^{j+1} · C(n, j)   (all n,j).  (★')
+
+## Results
+
+1. `weighted_partial_alternating_sum`       — (★') clean form, valid for all `n,j`.
+2. `weighted_partial_alternating_sum_sub`    — (★) literal `C(n-2,j-1)` form, `n ≥ 2`.
+3. `weighted_partial_alternating_sum_stabilizes` — the weighted partial sums are
+   `0` once `j ≥ n` (`n ≥ 2`).
+4. `weighted_full_row_eq_zero`               — recovers the grandparent anchor
+   `∑_{k=0}^{n} (-1)^k k C(n,k) = 0` (`n ≥ 2`) from (★') alone.
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ05OQ01OQ01
+
+open Finset
+
+/-- **Main identity (subtraction-free form).** For all `n, j`,
+    `∑_{k=0}^{j+1} (-1)^k · k · C(n+2, k) = (n+2) · (-1)^{j+1} · C(n, j)` in `ℤ`.
+
+    Proof by induction on `j`.  The inductive step uses the binomial **absorption
+    identity** `(k+1)·C(n+1,k+1) = (n+1)·C(n,k)` (`Nat.succ_mul_choose_eq`) to
+    rewrite the new weighted term as a binomial of row `n+1`, followed by Pascal's
+    rule `C(n+1,j+1) = C(n,j) + C(n,j+1)` to telescope down to a single binomial of
+    row `n`. -/
+theorem weighted_partial_alternating_sum (n j : ℕ) :
+    ∑ k ∈ range (j + 2), ((-1 : ℤ) ^ k * (k : ℤ) * ((n + 2).choose k : ℤ))
+      = (n + 2 : ℤ) * (-1 : ℤ) ^ (j + 1) * (n.choose j : ℤ) := by
+  induction j with
+  | zero =>
+    -- `∑_{k=0}^{1} = 0 - C(n+2,1) = -(n+2)`, and `(n+2)·(-1)·C(n,0) = -(n+2)`.
+    simp [Finset.sum_range_succ, Nat.choose_one_right]
+  | succ j ih =>
+    rw [Finset.sum_range_succ, ih]
+    -- Absorption: `(j+2)·C(n+2,j+2) = (n+2)·C(n+1,j+1)` (cast of `Nat.add_one_mul_choose_eq`).
+    have absorb : ((j : ℤ) + 2) * ((n + 2).choose (j + 2) : ℤ)
+        = ((n : ℤ) + 2) * ((n + 1).choose (j + 1) : ℤ) := by
+      -- `h : (n+2) * (n+1).choose (j+1) = (n+2).choose (j+2) * (j+2)`
+      have h := Nat.add_one_mul_choose_eq (n + 1) (j + 1)
+      have h2 := congrArg (Nat.cast (R := ℤ)) h
+      push_cast at h2
+      linear_combination -h2
+    -- Pascal: `C(n+1,j+1) = C(n,j) + C(n,j+1)`.
+    have pascal : ((n + 1).choose (j + 1) : ℤ)
+        = (n.choose j : ℤ) + (n.choose (j + 1) : ℤ) := by
+      rw [Nat.choose_succ_succ]; push_cast; ring
+    -- Combine via one absorption and one Pascal step; the `(-1)` powers and the
+    -- scalar `n+2` are bookkept by `ring` inside `linear_combination`.
+    push_cast
+    linear_combination (-((-1 : ℤ) ^ (j + 1))) * absorb
+      + (-((-1 : ℤ) ^ (j + 1)) * ((n : ℤ) + 2)) * pascal
+
+/-- **Telescoping weighted partial sum (literal form).** For `n ≥ 2` and any `j`,
+    `∑_{k=0}^{j+1} (-1)^k · k · C(n, k) = n · (-1)^{j+1} · C(n-2, j)` in `ℤ`.
+
+    This is `(★)` with the cut-off written as `j+1` (so that `j-1 = j` after the
+    shift), exhibiting the single coefficient as a binomial of row `n-2`. -/
+theorem weighted_partial_alternating_sum_sub {n : ℕ} (hn : 2 ≤ n) (j : ℕ) :
+    ∑ k ∈ range (j + 2), ((-1 : ℤ) ^ k * (k : ℤ) * (n.choose k : ℤ))
+      = (n : ℤ) * (-1 : ℤ) ^ (j + 1) * ((n - 2).choose j : ℤ) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 2 := ⟨n - 2, by omega⟩
+  simpa using weighted_partial_alternating_sum m j
+
+/-- **Stabilisation.** Once the cut-off reaches the row length the weighted partial
+    sums are already `0`: for `n ≥ 2` and `j ≥ n`,
+    `∑_{k=0}^{j} (-1)^k · k · C(n, k) = 0`.
+
+    Reason: the closed form is `n·(-1)^j·C(n-2, j-1)`, and `C(n-2, j-1) = 0` because
+    `j - 1 ≥ n - 1 > n - 2`. -/
+theorem weighted_partial_alternating_sum_stabilizes {n : ℕ} (hn : 2 ≤ n) {j : ℕ}
+    (hj : n ≤ j) :
+    ∑ k ∈ range (j + 1), ((-1 : ℤ) ^ k * (k : ℤ) * (n.choose k : ℤ)) = 0 := by
+  obtain ⟨i, rfl⟩ : ∃ i, j = i + 1 := ⟨j - 1, by omega⟩
+  rw [weighted_partial_alternating_sum_sub hn i]
+  -- `C(n-2, i) = 0` since `i ≥ n - 1 > n - 2`.
+  have : (n - 2).choose i = 0 := Nat.choose_eq_zero_of_lt (by omega)
+  rw [this]; simp
+
+/-- **Recovers the grandparent anchor.** The full weighted alternating row sum
+    vanishes for `n ≥ 2`.  This is the content of `CombinationsFormulaOQ05`, here
+    obtained as the special case `j = n` of the weighted partial closed form
+    (with `C(n-2, n-1) = 0`). -/
+theorem weighted_full_row_eq_zero {n : ℕ} (hn : 2 ≤ n) :
+    ∑ k ∈ range (n + 1), ((-1 : ℤ) ^ k * (k : ℤ) * (n.choose k : ℤ)) = 0 :=
+  weighted_partial_alternating_sum_stabilizes hn (le_refl n)
+
+/-- Sanity check, row `n = 4`, cut-off `j = 2`:
+    `0 - 1·C(4,1) + 2·C(4,2) = -4 + 12 = 8 = 4·(+1)·C(2,1) = 8`. -/
+example :
+    ∑ k ∈ range 3, ((-1 : ℤ) ^ k * (k : ℤ) * (Nat.choose 4 k : ℤ)) = 8 := by decide
+
+/-- Sanity check of the closed form at `n = 5, j = 3`:
+    LHS `= 0 - 5 + 2·10 - 3·10 = -15`; RHS `= 5·(-1)^3·C(3,2) = -15`. -/
+example :
+    ∑ k ∈ range 4, ((-1 : ℤ) ^ k * (k : ℤ) * (Nat.choose 5 k : ℤ))
+      = (5 : ℤ) * (-1 : ℤ) ^ 3 * (Nat.choose 3 2 : ℤ) := by decide
+
+end CombinationsFormulaOQ05OQ01OQ01

--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "absorb-telescope-context",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Weighting the Alternating Row: Absorb, then Telescope",
+    "content": "The grandparent records that the full weighted alternating row sum ∑_{k=0}^{n} (-1)^k k C(n,k) vanishes for n ≥ 2; the parent records the unweighted partial closed form ∑_{k=0}^{j} (-1)^k C(n,k) = (-1)^j C(n-1,j). This entry answers the question they leave open: the weighted partial sum ∑_{k=0}^{j} (-1)^k k C(n,k) = n (-1)^j C(n-2,j-1). The extra factor k is removed by the absorption identity k C(n,k) = n C(n-1,k-1), which converts the weighted row-n sum into n copies of an unweighted row-(n-1) sum; the parent's telescoping then collapses that to a single binomial of row n-2.",
+    "mathContext": "With $a_k = (-1)^k k \\binom{n}{k}$, the partial sum is $\\sum_{k=0}^{j} a_k = n(-1)^j\\binom{n-2}{j-1}$. Absorption $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ gives $\\sum_{k=0}^{j} a_k = n\\sum_{i=0}^{j-1}(-1)^{i+1}\\binom{n-1}{i} = -n\\sum_{i=0}^{j-1}(-1)^{i}\\binom{n-1}{i}$, and the parent's identity evaluates the inner sum to $(-1)^{j-1}\\binom{n-2}{j-1}$. The full-row vanishing is the case $j = n$, where $\\binom{n-2}{n-1} = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absorption identity k C(n,k) = n C(n-1,k-1)",
+      "Pascal's rule",
+      "telescoping sums",
+      "binomial transform",
+      "weighted alternating binomial identities"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "absorption Nat.add_one_mul_choose_eq",
+      "Pascal's rule Nat.choose_succ_succ",
+      "induction over Finset.range"
+    ]
+  },
+  {
+    "id": "main-identity-theorem",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 96 },
+    "type": "theorem",
+    "title": "Main Identity (Subtraction-Free Form)",
+    "content": "weighted_partial_alternating_sum: ∑_{k=0}^{j+1} (-1)^k k C(n+2,k) = (n+2) (-1)^{j+1} C(n,j) over ℤ, for all n and j. Proved by induction on j. The base case j = 0 leaves only the term −C(n+2,1) = −(n+2). The inductive step rewrites with Finset.sum_range_succ and the hypothesis, then supplies two equalities — the absorption identity (j+2) C(n+2,j+2) = (n+2) C(n+1,j+1) (cast of Nat.add_one_mul_choose_eq) and Pascal's rule C(n+1,j+1) = C(n,j) + C(n,j+1) (Nat.choose_succ_succ) — to a single linear_combination, which lets ring handle the signed-power algebra and the scalar n+2.",
+    "mathContext": "Inductive step: the new term is $(-1)^{j+2}(j+2)\\binom{n+2}{j+2}$. Absorption rewrites $(j+2)\\binom{n+2}{j+2} = (n+2)\\binom{n+1}{j+1}$, and Pascal gives $\\binom{n+1}{j+1} = \\binom{n}{j} + \\binom{n}{j+1}$. With $(-1)^{j+2} = -(-1)^{j+1}$, the carried $(n+2)(-1)^{j+1}\\binom{n}{j}$ cancels the $\\binom{n}{j}$ contribution, leaving $(n+2)(-1)^{j+2}\\binom{n}{j+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.add_one_mul_choose_eq",
+      "Nat.choose_succ_succ",
+      "Finset.sum_range_succ",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "absorption and Pascal's rule",
+      "weighted alternating sums over Finset.range"
+    ]
+  },
+  {
+    "id": "literal-subtraction-form",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01",
+    "range": { "startLine": 98, "endLine": 110 },
+    "type": "theorem",
+    "title": "Literal C(n-2,j-1) Form",
+    "content": "weighted_partial_alternating_sum_sub: for n ≥ 2, ∑_{k=0}^{j+1} (-1)^k k C(n,k) = n (-1)^{j+1} C(n-2,j). This is the headline form (★) with the cut-off written as j+1 so the single coefficient appears as a binomial of row n-2. It is obtained from the subtraction-free statement by writing n = m+2 (so n-2 = m) and simplifying.",
+    "mathContext": "Substituting $n = m+2$ turns $(m+2)(-1)^{j+1}\\binom{m}{j}$ into $n(-1)^{j+1}\\binom{n-2}{j}$, the literal closed form $n(-1)^{J}\\binom{n-2}{J-1}$ at $J = j+1$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "natural-number subtraction",
+      "specialisation of a subtraction-free identity"
+    ],
+    "prerequisites": [
+      "weighted_partial_alternating_sum",
+      "existence of a predecessor n = m+2"
+    ]
+  },
+  {
+    "id": "stabilization-and-full-row",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01",
+    "range": { "startLine": 112, "endLine": 131 },
+    "type": "theorem",
+    "title": "Stabilisation and Full-Row Recovery",
+    "content": "weighted_partial_alternating_sum_stabilizes: for n ≥ 2 and j ≥ n, the weighted partial sum ∑_{k=0}^{j} (-1)^k k C(n,k) = 0, because the closed-form coefficient C(n-2,j-1) vanishes once j-1 > n-2. weighted_full_row_eq_zero: the full weighted row sum ∑_{k=0}^{n} (-1)^k k C(n,k) = 0 for n ≥ 2, recovered as the special case j = n — exactly the grandparent (CombinationsFormulaOQ05) anchor, so this entry is strictly stronger.",
+    "mathContext": "$\\binom{n-2}{j-1} = 0$ for $j - 1 \\ge n - 1 > n - 2$, so every partial sum from $j = n$ onward is $0$. At $j = n$ this reproduces the derivative-at-$x=1$ vanishing $\\sum_{k} (-1)^k k \\binom{n}{k} = 0$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.choose_eq_zero_of_lt",
+      "support of a binomial row",
+      "recovering an anchor as a special case"
+    ],
+    "prerequisites": [
+      "weighted_partial_alternating_sum_sub",
+      "vanishing of out-of-range binomial coefficients"
+    ]
+  },
+  {
+    "id": "worked-verifications",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01",
+    "range": { "startLine": 133, "endLine": 135 },
+    "type": "example",
+    "title": "Worked Verifications",
+    "content": "Two kernel-checked instances of the closed form. Row 4 cut at j=2: 0·1 − 1·C(4,1) + 2·C(4,2) = 0 − 4 + 12 = 8 = 4·C(2,1). Row 5 cut at j=3: 0 − 1·C(5,1) + 2·C(5,2) − 3·C(5,3) = 0 − 5 + 20 − 30 = −15 = 5·(−1)^3·C(3,2). Both are discharged by decide.",
+    "mathContext": "These confirm $n(-1)^j\\binom{n-2}{j-1}$ at $(n,j) = (4,2)$ giving $+8$ and at $(n,j) = (5,3)$ giving $-15$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "decide",
+      "concrete binomial computations"
+    ],
+    "prerequisites": [
+      "the closed-form identity"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "combinations-formula-oq-05-oq-01-oq-01",
+  "title": "Closed Form for the Weighted Partial Alternating Binomial Sum",
+  "slug": "combinations-formula-oq-05-oq-01-oq-01",
+  "description": "Proves the sharp single-coefficient closed form for the weighted partial alternating binomial sum: ∑_{k=0}^{j} (-1)^k k C(n,k) = n (-1)^j C(n-2,j-1) for n ≥ 2. This answers the parent's open question by combining its two refinements at once — where the unweighted partial sum is a single binomial of the previous row, the weighted partial sum is n times a single binomial of the row two below. The mechanism is one absorption step k C(n,k) = n C(n-1,k-1) followed by one telescoping. The grandparent's full weighted-row vanishing ∑_{k=0}^{n} (-1)^k k C(n,k) = 0 is recovered as the special case j = n.",
+  "meta": {
+    "author": "Lean Genius researcher-9",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ05OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities are fully machine-checked for every n and j. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); the two worked examples use kernel `decide`, so no Lean.ofReduceBool is involved.",
+    "tags": [
+      "combinatorics",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "alternating-sum",
+      "weighted-sum",
+      "absorption-identity",
+      "telescoping",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-23",
+    "originalContributions": [
+      "weighted_partial_alternating_sum: the subtraction-free closed form ∑_{k=0}^{j+1} (-1)^k k C(n+2,k) = (n+2) (-1)^{j+1} C(n,j), valid for all n, proved by induction on j with the absorption identity (Nat.add_one_mul_choose_eq) and Pascal's rule (Nat.choose_succ_succ) discharged together by linear_combination",
+      "weighted_partial_alternating_sum_sub: the literal C(n-2,j-1) form ∑_{k=0}^{j+1} (-1)^k k C(n,k) = n (-1)^{j+1} C(n-2,j) for n ≥ 2, obtained from the n+2 form by writing n = m+2",
+      "weighted_partial_alternating_sum_stabilizes: the weighted partial sums are already 0 once j ≥ n (n ≥ 2), since C(n-2,j-1) = 0 there",
+      "weighted_full_row_eq_zero: recovers the grandparent's full weighted-row vanishing ∑_{k=0}^{n} (-1)^k k C(n,k) = 0 (CombinationsFormulaOQ05) as the case j = n of the weighted partial closed form",
+      "Worked verifications: row 4 cut at j=2 gives 0−4+12 = 8 = 4 C(2,1); row 5 cut at j=3 gives 0−5+20−30 = −15 = 5 (−1)^3 C(3,2)"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ05OQ01OQ01.lean",
+    "namespace": "CombinationsFormulaOQ05OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The full weighted alternating row sum ∑_{k=0}^{n} (-1)^k k C(n,k) = 0 (n ≥ 2) is the derivative-at-x=1 companion of the binomial theorem at x = -1: differentiating (1-x)^n and evaluating produces the weighted cancellation. The grandparent entry (CombinationsFormulaOQ05) records that vanishing; the parent (CombinationsFormulaOQ05OQ01) records the unweighted partial closed form (-1)^j C(n-1,j). What the truncated weighted sum equals — before it cancels — was left open. The answer is again a single binomial coefficient, now of the row two below, because the weight k is absorbed into a row shift before the same telescoping that governs the unweighted case takes over.",
+    "problemStatement": "Open Question OQ-05-OQ-01-OQ-01 (the first follow-up posed by the parent): does the weighted partial sum ∑_{k=0}^{j} (-1)^k k C(n,k) admit an analogous single-coefficient closed form, refining the vanishing of the full weighted alternating sum?",
+    "proofStrategy": "Work in ℤ and prove the subtraction-free form ∑_{k=0}^{j+1} (-1)^k k C(n+2,k) = (n+2) (-1)^{j+1} C(n,j) by induction on j. The base case j = 0 is the single surviving term −C(n+2,1) = −(n+2). The inductive step adds the term (-1)^{j+2} (j+2) C(n+2,j+2); the absorption identity (j+2) C(n+2,j+2) = (n+2) C(n+1,j+1) (Nat.add_one_mul_choose_eq) converts the weight into a binomial of row n+1, and Pascal's rule C(n+1,j+1) = C(n,j) + C(n,j+1) (Nat.choose_succ_succ) telescopes it down to a single binomial of row n; both rewrites and the (-1)-power bookkeeping are discharged by a single linear_combination over ring. The literal C(n-2,j-1) form follows by writing n = m+2, and the full-row vanishing follows from C(n-2,j-1) = 0 for j ≥ n.",
+    "keyInsights": [
+      "Two classical one-step mechanisms compose exactly: absorption k C(n,k) = n C(n-1,k-1) turns the weighted row-n sum into n times an unweighted row-(n-1) sum, and the parent's telescoping then collapses that to a single binomial of row n-2.",
+      "Stated with C(n+2,k) and cut-off j+1 the identity needs no natural-number subtraction and holds for all n, making the induction clean; the literal n (-1)^j C(n-2,j-1) form is a one-line specialisation for n ≥ 2.",
+      "linear_combination is the right finisher for the inductive step: rather than rewriting under the (-1)^{j+2} factor (which fails on associativity), the absorption and Pascal equalities are supplied as linear hypotheses and ring handles the signed-power algebra.",
+      "The grandparent's full weighted-row vanishing is not assumed but derived: at j = n the coefficient C(n-2,n-1) = 0, so this entry is strictly stronger than the CombinationsFormulaOQ05 anchor."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Absorb-then-Telescope Refinement",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Header stating OQ-05-OQ-01-OQ-01: the weighted partial sums admit the closed form n (-1)^j C(n-2,j-1), combining the grandparent's weighted full-row vanishing with the parent's partial telescoping. Explains the absorption-then-telescoping mechanism."
+    },
+    {
+      "id": "main-identity",
+      "title": "Main Identity (Subtraction-Free Form)",
+      "startLine": 57,
+      "endLine": 96,
+      "summary": "weighted_partial_alternating_sum: ∑_{k=0}^{j+1} (-1)^k k C(n+2,k) = (n+2) (-1)^{j+1} C(n,j) for all n, by induction on j. The inductive step uses the absorption identity Nat.add_one_mul_choose_eq and Pascal's rule Nat.choose_succ_succ, closed by linear_combination."
+    },
+    {
+      "id": "literal-form",
+      "title": "Literal C(n-2,j-1) Form",
+      "startLine": 98,
+      "endLine": 110,
+      "summary": "weighted_partial_alternating_sum_sub: the literal ∑_{k=0}^{j+1} (-1)^k k C(n,k) = n (-1)^{j+1} C(n-2,j) for n ≥ 2, obtained by writing n = m+2."
+    },
+    {
+      "id": "stabilization",
+      "title": "Stabilisation and Full-Row Recovery",
+      "startLine": 112,
+      "endLine": 131,
+      "summary": "weighted_partial_alternating_sum_stabilizes: the weighted partial sums are 0 once j ≥ n (C(n-2,j-1) = 0). weighted_full_row_eq_zero: recovers the grandparent's full weighted-row vanishing as the case j = n."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 133,
+      "endLine": 135,
+      "summary": "examples: row 4 cut at j=2 gives 0−4+12 = 8 = 4 C(2,1); row 5 cut at j=3 gives 0−5+20−30 = −15 = 5 (−1)^3 C(3,2)."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. Establishes the sharp single-coefficient closed form ∑_{k=0}^{j} (-1)^k k C(n,k) = n (-1)^j C(n-2,j-1) for every partial sum of a weighted alternating binomial row, and recovers the grandparent's full weighted-row vanishing as the special case j = n.",
+    "implications": "Completes the OQ-05 thread: the unweighted partial sum is a single binomial of the previous row (parent), and the weighted partial sum is n times a single binomial of the row two below. The absorb-then-telescope template — one absorption identity to clear the weight, one Pascal step to collapse the sum, finished by linear_combination — applies to higher-weight variants ∑ (-1)^k k^2 C(n,k) and to falling-factorial-weighted alternating sums.",
+    "openQuestions": [
+      "Does the quadratically weighted partial sum ∑_{k=0}^{j} (-1)^k k^2 C(n,k) admit a two-coefficient closed form, obtained by absorbing k^2 = k(k-1) + k into two row shifts?",
+      "Is there a uniform closed form for the falling-factorial-weighted partial sum ∑_{k=0}^{j} (-1)^k (k)_r C(n,k) = (n)_r (-1)^? C(n-r-1, j-r) for general r, of which r = 1 is this entry?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-05-oq-01",
+      "relationship": "parent — answers its open question by giving the weighted analogue of its unweighted partial closed form (-1)^j C(n-1,j)"
+    },
+    {
+      "targetId": "combinations-formula-oq-05",
+      "relationship": "grandparent — refines its full weighted-row vanishing ∑ (-1)^k k C(n,k) = 0 into the weighted partial closed form, and reproves that anchor as the case j = n"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question posed by the parent **combinations-formula-oq-05-oq-01**: the *weighted* partial alternating binomial sum has a single-coefficient closed form,

$$\sum_{k=0}^{j} (-1)^k\, k\, \binom{n}{k} \;=\; n\,(-1)^j \binom{n-2}{j-1}\qquad (n \ge 2).$$

Where the parent showed the *unweighted* partial sum is a single binomial of the **previous** row $\big((-1)^j\binom{n-1}{j}\big)$, the weighted partial sum is $n$ times a single binomial of the row **two below**.

## Mechanism (absorb, then telescope)

1. **Absorption** $k\binom{n}{k} = n\binom{n-1}{k-1}$ (`Nat.add_one_mul_choose_eq`) clears the weight, turning the weighted row-$n$ sum into $n$ copies of an unweighted row-$(n-1)$ sum.
2. The parent's **telescoping** (Pascal's rule, `Nat.choose_succ_succ`) collapses that to a single binomial of row $n-2$.

The inductive step is discharged by a single `linear_combination` over the absorption and Pascal equalities, letting `ring` handle the signed-power algebra.

## Results (4 theorems, 0 sorries, 0 axioms)

- `weighted_partial_alternating_sum` — subtraction-free form, all `n, j`.
- `weighted_partial_alternating_sum_sub` — literal $n(-1)^{j+1}\binom{n-2}{j}$ form, `n ≥ 2`.
- `weighted_partial_alternating_sum_stabilizes` — sums vanish once `j ≥ n`.
- `weighted_full_row_eq_zero` — **recovers the grandparent** (`CombinationsFormulaOQ05`) full weighted-row vanishing $\sum_{k} (-1)^k k\binom{n}{k} = 0$ as the case `j = n`, so this entry is strictly stronger.

Verified with `#print axioms`: depends only on `propext`, `Classical.choice`, `Quot.sound`. The two worked examples use kernel `decide` (no `Lean.ofReduceBool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)