### PR TITLE
research(sum-of-kth-powers-oq-05-oq-01-oq-01): power-sum congruence for composite modulus via CRT [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3522,6 +3522,7 @@ import Proofs.SumOfKthPowersOQ04
 import Proofs.SumOfKthPowersOQ04Aristotle
 import Proofs.SumOfKthPowersOQ05
 import Proofs.SumOfKthPowersOQ05OQ01
+import Proofs.SumOfKthPowersOQ05OQ01OQ01
 import Proofs.SumOfOddsStatementOnly
 import Proofs.SummationByPartsOQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01

--- a/proofs/Proofs/SumOfKthPowersOQ05OQ01OQ01.lean
+++ b/proofs/Proofs/SumOfKthPowersOQ05OQ01OQ01.lean
@@ -1,0 +1,133 @@
+import Mathlib
+import Proofs.SumOfKthPowersOQ05OQ01
+
+/-
+# Power-Sum Congruence for Composite Modulus via CRT (Sum of k-th Powers, OQ-05-OQ-01-OQ-01)
+
+The parent entry `SumOfKthPowersOQ05OQ01` settles the natural-number power-sum dichotomy for a
+*prime* modulus:
+
+  `∑_{i < p} i^k ≡ (if k ≠ 0 ∧ (p-1) ∣ k then p-1 else 0)  (mod p)`.
+
+This file answers its first open question: *extend the congruence to a composite modulus by
+combining the prime-power case with the Chinese Remainder Theorem.*
+
+The bridge is a single periodicity fact.  Modulo `m`, the summand `i ↦ i^k` depends only on
+`i mod m`, and as `i` ranges over `0, 1, …, m·n - 1` each residue class is hit exactly `n`
+times.  Hence
+
+  `∑_{i < m·n} i^k ≡ n · ∑_{i < m} i^k   (mod m)`.                    (`sum_pow_range_mul_modEq`)
+
+We prove this by casting to `ZMod m`, where the congruence becomes the equality
+`∑_{i < m·n} (i : ZMod m)^k = n · ∑_{i < m} (i : ZMod m)^k`, established by induction on `n`
+using `Finset.sum_range_add` and the period-`m` identity `(↑(m·n + x) : ZMod m) = ↑x`.
+
+Applying this with the two coprime factors of a composite modulus and feeding the results into
+Mathlib's `Nat.modEq_and_modEq_iff_modEq_mul` (the CRT for `Nat.ModEq`) gives a complete
+characterisation of `∑_{i < a·b} i^k` modulo `a·b` from its two factor residues
+(`sum_pow_crt`).  Specialising the factors to distinct primes and inserting the parent's
+dichotomy yields the fully explicit composite formula `sum_pow_crt_two_primes`.
+
+All results are `0`-axiom; concrete instances are kernel-`decide` checked.
+-/
+
+namespace SumOfKthPowersOQ05OQ01OQ01
+
+open Finset
+open scoped BigOperators
+
+/-- **Periodicity in `ZMod m`.**  Over the field/ring `ZMod m`, the sum of `k`-th powers of the
+residues `0, …, m·n - 1` is exactly `n` copies of the sum over a single period `0, …, m - 1`,
+because `i ↦ (i : ZMod m)^k` has period `m`. -/
+theorem sum_pow_zmod_range_mul (m n k : ℕ) :
+    (∑ i ∈ Finset.range (m * n), (i : ZMod m) ^ k)
+      = (n : ZMod m) * (∑ i ∈ Finset.range m, (i : ZMod m) ^ k) := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [Nat.mul_succ, Finset.sum_range_add, ih]
+    -- the trailing block `∑_{x < m} (m·n + x)^k` collapses to `∑_{x < m} x^k` modulo `m`
+    have hsec : (∑ x ∈ Finset.range m, ((m * n + x : ℕ) : ZMod m) ^ k)
+        = ∑ x ∈ Finset.range m, ((x : ℕ) : ZMod m) ^ k := by
+      refine Finset.sum_congr rfl (fun x _ => ?_)
+      congr 1
+      push_cast
+      simp
+    rw [hsec]
+    push_cast
+    ring
+
+/-- **Replication congruence.**  For any modulus `m`, the natural-number power sum over a range
+of length `m·n` is congruent to `n` copies of the power sum over one period:
+
+  `∑_{i < m·n} i^k ≡ n · ∑_{i < m} i^k   (mod m)`. -/
+theorem sum_pow_range_mul_modEq (m n k : ℕ) :
+    (∑ i ∈ Finset.range (m * n), i ^ k) ≡ n * (∑ i ∈ Finset.range m, i ^ k) [MOD m] := by
+  rw [← ZMod.natCast_eq_natCast_iff]
+  push_cast
+  rw [sum_pow_zmod_range_mul m n k]
+
+/-- Reading the composite sum modulo the **left** factor `a`. -/
+theorem sum_pow_modEq_left (a b k : ℕ) :
+    (∑ i ∈ Finset.range (a * b), i ^ k) ≡ b * (∑ i ∈ Finset.range a, i ^ k) [MOD a] :=
+  sum_pow_range_mul_modEq a b k
+
+/-- Reading the composite sum modulo the **right** factor `b`. -/
+theorem sum_pow_modEq_right (a b k : ℕ) :
+    (∑ i ∈ Finset.range (a * b), i ^ k) ≡ a * (∑ i ∈ Finset.range b, i ^ k) [MOD b] := by
+  rw [Nat.mul_comm a b]
+  exact sum_pow_range_mul_modEq b a k
+
+/-- **CRT characterisation for a composite modulus.**  For coprime `a, b`, a natural number `x`
+is congruent to the composite power sum `∑_{i < a·b} i^k` modulo `a·b` **iff** it matches the two
+factor residues `b · ∑_{i < a} i^k (mod a)` and `a · ∑_{i < b} i^k (mod b)`.  This pins down the
+residue of the composite power sum from the two factor sums, exactly as the Chinese Remainder
+Theorem prescribes. -/
+theorem sum_pow_crt (a b k : ℕ) (hab : Nat.Coprime a b) (x : ℕ) :
+    x ≡ (∑ i ∈ Finset.range (a * b), i ^ k) [MOD a * b]
+      ↔ (x ≡ b * (∑ i ∈ Finset.range a, i ^ k) [MOD a]
+          ∧ x ≡ a * (∑ i ∈ Finset.range b, i ^ k) [MOD b]) := by
+  rw [← Nat.modEq_and_modEq_iff_modEq_mul hab]
+  constructor
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1.trans (sum_pow_modEq_left a b k), h2.trans (sum_pow_modEq_right a b k)⟩
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1.trans (sum_pow_modEq_left a b k).symm, h2.trans (sum_pow_modEq_right a b k).symm⟩
+
+/-- **Fully explicit composite formula for two distinct primes.**  Combining the CRT bridge with
+the parent's prime dichotomy, for distinct primes `p ≠ q` the composite power sum is the unique
+residue modulo `p·q` whose two factor residues are dictated by the `(p-1) ∣ k` and `(q-1) ∣ k`
+conditions. -/
+theorem sum_pow_crt_two_primes (p q k : ℕ) [Fact p.Prime] [Fact q.Prime] (hpq : p ≠ q)
+    (x : ℕ) :
+    x ≡ (∑ i ∈ Finset.range (p * q), i ^ k) [MOD p * q]
+      ↔ (x ≡ q * (if k ≠ 0 ∧ (p - 1) ∣ k then p - 1 else 0) [MOD p]
+          ∧ x ≡ p * (if k ≠ 0 ∧ (q - 1) ∣ k then q - 1 else 0) [MOD q]) := by
+  have hcop : Nat.Coprime p q := (Nat.coprime_primes Fact.out Fact.out).mpr hpq
+  rw [sum_pow_crt p q k hcop x]
+  constructor
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1.trans ((_root_.SumOfKthPowersOQ05OQ01.sum_pow_modEq p k).mul_left q),
+           h2.trans ((_root_.SumOfKthPowersOQ05OQ01.sum_pow_modEq q k).mul_left p)⟩
+  · rintro ⟨h1, h2⟩
+    exact ⟨h1.trans ((_root_.SumOfKthPowersOQ05OQ01.sum_pow_modEq p k).mul_left q).symm,
+           h2.trans ((_root_.SumOfKthPowersOQ05OQ01.sum_pow_modEq q k).mul_left p).symm⟩
+
+/-! ### Concrete instances (verified by kernel `decide`, hence `0`-axiom)
+
+For `m = 6 = 2 · 3` and `k = 2`: `∑_{i<6} i^2 = 0+1+4+9+16+25 = 55 ≡ 1 (mod 6)`.
+The two factor residues recover this via CRT. -/
+
+/-- Left factor `a = 2`, `b = 3`: `∑_{i<6} i^2 ≡ 3 · ∑_{i<2} i^2 = 3 (mod 2)`, both `≡ 1`. -/
+example : (∑ i ∈ Finset.range 6, i ^ 2) ≡ 3 * (∑ i ∈ Finset.range 2, i ^ 2) [MOD 2] := by decide
+
+/-- Right factor `b = 3`, `a = 2`: `∑_{i<6} i^2 ≡ 2 · ∑_{i<3} i^2 = 10 (mod 3)`, both `≡ 1`. -/
+example : (∑ i ∈ Finset.range 6, i ^ 2) ≡ 2 * (∑ i ∈ Finset.range 3, i ^ 2) [MOD 3] := by decide
+
+/-- The CRT-determined residue: `∑_{i<6} i^2 = 55 ≡ 1 (mod 6)`. -/
+example : (∑ i ∈ Finset.range 6, i ^ 2) ≡ 1 [MOD 6] := by decide
+
+/-- Replication over three periods of length `4`: `∑_{i<12} i^3 ≡ 3 · ∑_{i<4} i^3 (mod 4)`. -/
+example : (∑ i ∈ Finset.range 12, i ^ 3) ≡ 3 * (∑ i ∈ Finset.range 4, i ^ 3) [MOD 4] := by decide
+
+end SumOfKthPowersOQ05OQ01OQ01

--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+  "title": "Power-Sum Congruence for Composite Modulus via CRT: ∑_{i<a·b} iᵏ from its factor residues",
+  "slug": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+  "description": "Extends the parent's prime-modulus power-sum congruence to a composite modulus using the Chinese Remainder Theorem. The bridge is a single periodicity fact: modulo m the summand i ↦ iᵏ depends only on i mod m, and as i ranges over 0,…,m·n−1 each residue class is hit exactly n times, so ∑_{i<m·n} iᵏ ≡ n·∑_{i<m} iᵏ (mod m). Proved by casting to ZMod m, where the congruence becomes an equality established by induction on n via Finset.sum_range_add and (↑(m·n+x):ZMod m)=↑x. Reading the composite sum modulo each coprime factor and feeding the two residues into Mathlib's Nat.modEq_and_modEq_iff_modEq_mul gives a complete CRT characterization of ∑_{i<a·b} iᵏ mod a·b; specializing the factors to distinct primes and inserting the parent's dichotomy yields the fully explicit composite formula. Verified, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chinese_remainder_theorem",
+    "date": "2026-06-23",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "power-sums",
+      "modular-arithmetic",
+      "chinese-remainder-theorem",
+      "nat-modeq",
+      "zmod",
+      "congruences",
+      "periodicity",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SumOfKthPowersOQ05OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_add",
+        "description": "∑_{x<n+m} f x = ∑_{x<n} f x + ∑_{x<m} f (n+x) — splits range (m·n+m) into the first m·n terms plus a trailing block of length m, the inductive step of the periodicity lemma",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_self",
+        "description": "(↑m : ZMod m) = 0 — collapses (↑(m·n+x):ZMod m) to ↑x, the period-m identity making each trailing block equal to one period",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_natCast_iff",
+        "description": "(↑a : ZMod c) = ↑b ↔ a ≡ b [MOD c] — converts the ℕ-valued replication congruence into the ZMod m equality proved by induction",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.modEq_and_modEq_iff_modEq_mul",
+        "description": "for coprime a, b: (x ≡ y [MOD a] ∧ x ≡ y [MOD b]) ↔ x ≡ y [MOD a·b] — the CRT for Nat.ModEq, which assembles the two factor residues into the residue mod a·b",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Nat.coprime_primes",
+        "description": "for primes p, q: Nat.Coprime p q ↔ p ≠ q — supplies the coprimality hypothesis in the two-distinct-primes specialization",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "SumOfKthPowersOQ05OQ01.sum_pow_modEq",
+        "description": "the parent gallery result ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p) — the prime dichotomy fed into the CRT bridge to produce the explicit two-primes formula",
+        "module": "Proofs.SumOfKthPowersOQ05OQ01"
+      }
+    ],
+    "originalContributions": [
+      "sum_pow_zmod_range_mul: in ZMod m, ∑_{i<m·n} (↑i)ᵏ = (↑n)·∑_{i<m} (↑i)ᵏ — the periodicity engine, proved by induction on n with Finset.sum_range_add and the period-m identity (↑(m·n+x):ZMod m)=↑x",
+      "sum_pow_range_mul_modEq: the replication congruence ∑_{i<m·n} iᵏ ≡ n·∑_{i<m} iᵏ (mod m) for an arbitrary modulus m, obtained by casting the ZMod m equality back to Nat.ModEq",
+      "sum_pow_modEq_left / sum_pow_modEq_right: reading the composite sum ∑_{i<a·b} iᵏ modulo the left factor a (≡ b·∑_{i<a} iᵏ) and the right factor b (≡ a·∑_{i<b} iᵏ)",
+      "sum_pow_crt: the full CRT characterization — for coprime a,b, x ≡ ∑_{i<a·b} iᵏ (mod a·b) iff x matches both factor residues; pins the composite residue down from the two factor sums",
+      "sum_pow_crt_two_primes: the fully explicit composite formula for distinct primes p≠q, combining the CRT bridge with the parent's prime dichotomy",
+      "Concrete decide-checked Nat.ModEq instances over mod 6 = 2·3 and a three-period mod-4 replication (0-axiom, no native_decide)"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 133,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Concrete instances use kernel decide (not native_decide), so no Lean.ofReduceBool dependency.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The prime-modulus congruence for ∑ iᵏ is classical (Ireland–Rosen, Ch. 4). Moving to a composite modulus is exactly where the Chinese Remainder Theorem earns its keep: a congruence modulo a product of coprime factors is equivalent to the pair of congruences modulo each factor. The remaining ingredient is purely combinatorial — over a complete range of length m·n the summand i ↦ iᵏ is periodic mod m with period m, so the long sum is n copies of one period. Together these reduce the composite power sum, modulo each factor, to a scalar multiple of a shorter power sum, and for prime factors to the parent's explicit dichotomy.",
+    "problemStatement": "**Open Question (sum-of-kth-powers-oq-05-oq-01-oq-01)**: Extend the Nat-congruence power-sum dichotomy from a prime modulus to a composite modulus n by combining the prime case with the Chinese Remainder Theorem.\n\n**Result**: The replication congruence sum_pow_range_mul_modEq reduces ∑_{i<m·n} iᵏ mod m to n·∑_{i<m} iᵏ; sum_pow_crt assembles the two coprime-factor readings into a complete characterization of ∑_{i<a·b} iᵏ mod a·b; sum_pow_crt_two_primes specializes to distinct primes with the parent's explicit values.",
+    "text": "For any modulus m, the sum of k-th powers over a range whose length is a multiple m·n is congruent mod m to n times the sum over a single period of length m. Consequently, for coprime factors a and b the residue of ∑_{i<a·b} iᵏ modulo a·b is exactly the value the Chinese Remainder Theorem builds from the two factor residues b·∑_{i<a} iᵏ (mod a) and a·∑_{i<b} iᵏ (mod b); for distinct primes these residues are given by the parent's (p−1)∣k dichotomy.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `sum_pow_zmod_range_mul` works in the ring ZMod m, where the target congruence becomes the equality ∑_{i<m·n} (↑i)ᵏ = (↑n)·∑_{i<m} (↑i)ᵏ. Induct on n. Base: range 0 is empty. Step: split range (m·n+m) with Finset.sum_range_add into the first m·n terms (the induction hypothesis) plus a trailing block ∑_{x<m} (↑(m·n+x))ᵏ; since (↑(m·n+x):ZMod m) = ↑x by ZMod.natCast_self, the block equals one full period ∑_{x<m} (↑x)ᵏ, and (↑n + 1)·S = ↑n·S + S closes by ring.\n2. `sum_pow_range_mul_modEq` casts step 1 back to ℕ: ZMod.natCast_eq_natCast_iff turns the Nat.ModEq goal into the cast equality, push_cast distributes over the sum and the product n·∑, and the ZMod identity finishes it.\n3. `sum_pow_modEq_left` is the lemma at m=a, n=b; `sum_pow_modEq_right` is the lemma at m=b, n=a after Nat.mul_comm.\n4. `sum_pow_crt` rewrites x ≡ ∑ [MOD a·b] as the conjunction of the two factor congruences (Nat.modEq_and_modEq_iff_modEq_mul) and transports each side along the two readings from step 3.\n5. `sum_pow_crt_two_primes` derives coprimality of distinct primes (Nat.coprime_primes), applies sum_pow_crt, and composes each factor reading with the parent's sum_pow_modEq via Nat.ModEq.mul_left.",
+    "keyInsights": [
+      "**Periodicity is the whole content.** Modulo m the summand i ↦ iᵏ has period m, so summing over a length-m·n range is literally n repetitions of one period. Casting to ZMod m turns this from a congruence-bookkeeping problem into a one-line induction, with (↑(m·n+x):ZMod m)=↑x (ZMod.natCast_self) as the only arithmetic input.",
+      "**CRT is the assembly, not the work.** Once the composite sum is understood modulo each coprime factor, Nat.modEq_and_modEq_iff_modEq_mul reconstructs the residue mod a·b for free. The mathematical step is the replication lemma; the CRT step is purely structural.",
+      "**The factor residues carry a scalar.** Reading ∑_{i<a·b} iᵏ modulo a gives b·∑_{i<a} iᵏ, not ∑_{i<a} iᵏ: the cofactor b counts how many periods fit. This multiplicity is exactly what the explicit two-primes formula records.",
+      "**Generic modulus, prime payoff.** The replication lemma holds for every modulus m (it never uses primality), so the framework applies to prime powers and arbitrary composites alike; primality enters only at the last step, where the parent's dichotomy supplies the closed-form factor residues."
+    ],
+    "prerequisites": [
+      "The parent prime-modulus power-sum congruence (sum-of-kth-powers-oq-05-oq-01)",
+      "Nat.ModEq, its cast characterization ZMod.natCast_eq_natCast_iff, and the CRT form Nat.modEq_and_modEq_iff_modEq_mul",
+      "Summation over an initial segment of ℕ and Finset.sum_range_add"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Module docstring laying out the periodicity-plus-CRT strategy, the imports (Mathlib and the parent file), and the namespace.",
+      "mathContext": "$\\sum_{i<a\\cdot b} i^k \\pmod{a\\cdot b}$ from its factor residues."
+    },
+    {
+      "id": "periodicity",
+      "title": "Periodicity in ZMod m and the Replication Congruence",
+      "startLine": 42,
+      "endLine": 69,
+      "summary": "sum_pow_zmod_range_mul (the ZMod m equality ∑_{i<m·n}(↑i)ᵏ = ↑n·∑_{i<m}(↑i)ᵏ by induction on n) and sum_pow_range_mul_modEq (its Nat.ModEq cast).",
+      "mathContext": "$\\sum_{i<m\\cdot n} i^k \\equiv n\\,\\sum_{i<m} i^k \\pmod m$."
+    },
+    {
+      "id": "crt",
+      "title": "Factor Readings and the CRT Characterization",
+      "startLine": 70,
+      "endLine": 114,
+      "summary": "sum_pow_modEq_left / sum_pow_modEq_right (the two factor readings) and sum_pow_crt (the complete CRT characterization for coprime a,b), plus sum_pow_crt_two_primes (the explicit distinct-primes formula via the parent dichotomy).",
+      "mathContext": "$x \\equiv \\sum_{i<a b} i^k \\pmod{ab} \\iff x \\equiv b\\sum_{i<a} i^k \\pmod a \\wedge x \\equiv a\\sum_{i<b} i^k \\pmod b$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances",
+      "startLine": 115,
+      "endLine": 133,
+      "summary": "decide-verified Nat.ModEq instances for mod 6 = 2·3 (∑_{i<6} i² = 55 ≡ 1, recovered from both factor residues) and a three-period mod-4 replication.",
+      "mathContext": "$\\sum_{i<6} i^2 = 55 \\equiv 1 \\pmod 6$, consistent with the factor residues mod 2 and mod 3."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sum-of-kth-powers-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Extends the parent's prime-modulus congruence ∑_{i<p} iᵏ ≡ (p−1 or 0) (mod p) to a composite modulus via CRT, directly answering the parent's first listed open question; the parent's sum_pow_modEq supplies the explicit factor residues in the two-primes formula"
+    },
+    {
+      "targetId": "sum-of-kth-powers",
+      "relationship": "related",
+      "description": "Complements the base family's integer closed forms with the composite-modulus congruence evaluation of the same power sum"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) extension of the power-sum congruence from prime to composite modulus. The replication lemma ∑_{i<m·n} iᵏ ≡ n·∑_{i<m} iᵏ (mod m) holds for every modulus; the CRT bridge sum_pow_crt assembles the two coprime-factor readings into the residue mod a·b; and sum_pow_crt_two_primes gives the fully explicit value for distinct primes by inserting the parent dichotomy.",
+    "implications": "Reduces any composite power-sum residue to shorter power sums modulo the coprime factors, and to the explicit (p−1)∣k dichotomy when the factors are prime. The periodicity lemma sum_pow_range_mul_modEq is reusable for any periodic summand over a complete range, independent of primality.",
+    "openQuestions": [
+      "Iterate the replication lemma over a prime factorization n = ∏ pᵢ^{eᵢ} to obtain a single explicit closed form for ∑_{i<n} iᵏ mod n in terms of the prime-power power sums.",
+      "Evaluate the prime-power factor residue ∑_{i<p^e} iᵏ mod p^e directly (lifting the exponent), completing the composite formula for non-squarefree moduli."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.SumOfKthPowersOQ05OQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SumOfKthPowersOQ05OQ01OQ01",
+    "lineCount": 133,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/SumOfKthPowersOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Ireland, Kenneth and Rosen, Michael",
+      "title": "A Classical Introduction to Modern Number Theory",
+      "year": "1990",
+      "venue": "Springer Graduate Texts in Mathematics 84, 2nd ed.",
+      "note": "Chapter 4: ∑ iᵏ mod p; the Chinese Remainder Theorem for congruences"
+    },
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "The Chinese Remainder Theorem and congruences modulo composite moduli"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `sum-of-kth-powers-oq-05-oq-01`: **extend the prime-modulus power-sum congruence to a composite modulus via the Chinese Remainder Theorem.**

The crux is a single periodicity fact. Modulo `m`, the summand `i ↦ iᵏ` depends only on `i mod m`, and over a complete range of length `m·n` each residue class is hit exactly `n` times, so

```
∑_{i<m·n} iᵏ ≡ n · ∑_{i<m} iᵏ   (mod m)        -- sum_pow_range_mul_modEq
```

proved by casting to `ZMod m` (where it becomes an equality) and inducting on `n` with `Finset.sum_range_add` and the period-`m` identity `(↑(m·n+x):ZMod m) = ↑x`. Reading the composite sum modulo each coprime factor and assembling the two residues via Mathlib's `Nat.modEq_and_modEq_iff_modEq_mul` gives the full CRT characterization `sum_pow_crt`; specializing the factors to distinct primes and inserting the parent's dichotomy yields the explicit formula `sum_pow_crt_two_primes`.

## Results (6 theorems, 0 definitions)

- `sum_pow_zmod_range_mul` — periodicity in `ZMod m`: `∑_{i<m·n} (↑i)ᵏ = (↑n)·∑_{i<m} (↑i)ᵏ`
- `sum_pow_range_mul_modEq` — the replication congruence over an arbitrary modulus `m`
- `sum_pow_modEq_left` / `sum_pow_modEq_right` — the two coprime-factor readings of `∑_{i<a·b} iᵏ`
- `sum_pow_crt` — CRT characterization: for coprime `a,b`, `x ≡ ∑_{i<a·b} iᵏ [MOD a·b]` iff it matches both factor residues
- `sum_pow_crt_two_primes` — fully explicit composite formula for distinct primes via the parent dichotomy

Plus `decide`-checked instances (mod 6 = 2·3, three-period mod 4).

## Verification

- 0 sorries, 0 `axiom` declarations
- `#print axioms` for all theorems: `{propext, Classical.choice, Quot.sound}` only — concrete instances use kernel `decide` (not `native_decide`), so **no `Lean.ofReduceBool`**
- Builds against current Mathlib (v4.26.0); `status: verified`, `badge: original`

🤖 Generated with [Claude Code](https://claude.com/claude-code)