### PR TITLE
Enrich Finite Arithmetico-Geometric Sum (∑ k·xᵏ): add index.ts, link child entry

### DIFF
--- a/src/data/proofs/geometric-series-oq-08-oq-01/index.ts
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ08OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ08OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ08OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ08OQ01Data: ProofData = {
+  proof: geometricSeriesOQ08OQ01Proof,
+  annotations: geometricSeriesOQ08OQ01Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01/meta.json
@@ -132,6 +132,11 @@
       "targetId": "geometric-series-oq-07",
       "relationship": "sibling",
       "description": "A sibling weighted extension: oq-07 computes the second moment ∑ n²·rⁿ of the INFINITE series, while this entry gives the FINITE first-moment closed form ∑_{k<n} k·xᵏ and recovers the infinite first moment x/(1 − x)² in the limit."
+    },
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Child entry answering this entry's open question. It promotes the first moment to the SECOND moment, giving the division-free closed form for ∑_{k<n} k²·xᵏ over any commutative ring, with field form over (1 − x)³ and infinite limit x(1 + x)/(1 − x)³ — the next member of the ∑ kᵐ·xᵏ hierarchy that raises the denominator order by one with each weight."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-08-oq-01`.

- **Created the missing `index.ts`** — without a Vite entry point the page rendered 'proof not found' on the live site despite appearing in the gallery listing.
- **Added an `extended-by` cross-reference** to `geometric-series-oq-08-oq-01-oq-01` (the ∑ k²·xᵏ child answering this entry's open question).

Existing overview, sections, conclusion, and 5 annotations preserved. `pnpm build` passes; JSON validated.