### PR TITLE
research(cube-root-2-irrational-oq-05-oq-01-oq-01): rational radicands — q^(1/n)∈ℚ ⟺ num & den perfect n-th powers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -762,6 +762,7 @@ import Proofs.CubeRoot2IrrationalOQ01
 import Proofs.CubeRoot2IrrationalOQ03
 import Proofs.CubeRoot2IrrationalOQ05
 import Proofs.CubeRoot2IrrationalOQ05OQ01
+import Proofs.CubeRoot2IrrationalOQ05OQ01OQ01
 import Proofs.CubeRoot3Irrational
 import Proofs.CubeRoot3IrrationalOQ01
 import Proofs.CubeRoot3IrrationalOQ02

--- a/proofs/Proofs/CubeRoot2IrrationalOQ05OQ01OQ01.lean
+++ b/proofs/Proofs/CubeRoot2IrrationalOQ05OQ01OQ01.lean
@@ -1,0 +1,144 @@
+/-
+# Rational radicands: q^(1/n) ∈ ℚ ⟺ numerator and denominator are perfect n-th powers
+
+The parent entry (`cube-root-2-irrational-oq-05-oq-01`) proves, for a *natural* radicand,
+that `m^(1/n)` is rational iff `m` is a perfect `n`-th power. Its first open question asks to
+extend this to **rational** radicands:
+
+> *Extend the criterion to rational radicands: `q^(1/n)` for `q : ℚ⁺` is rational iff both
+> numerator and denominator of `q` (in lowest terms) are perfect n-th powers.*
+
+This file proves exactly that. For `q > 0` and `n ≥ 1`,
+
+  `q^(1/n)` is rational  ⟺  `q.num` and `q.den` are both perfect `n`-th powers.
+
+The key idea: `q^(1/n)` is rational iff `q = sⁿ` for some positive rational `s`. Writing
+`s = c/d` in lowest terms, `sⁿ = cⁿ/dⁿ` is *also* in lowest terms (coprimality is preserved by
+powers), so by uniqueness of the reduced representation `q.num = cⁿ` and `q.den = dⁿ`. This uses
+`Rat.num_pow`/`Rat.den_pow` (`(sⁿ).num = s.numⁿ`, `(sⁿ).den = s.denⁿ`), which already encode that
+uniqueness.
+
+The integer/natural criterion is recovered as the special case `q.den = 1` (a positive integer is
+a perfect `n`-th power as a rational iff it is as a natural number).
+
+## Main results
+
+* `rat_rpow_inv_pow`                 : `(q^(1/n))ⁿ = q` for `q ≥ 0`.
+* `rational_rpow_inv_iff_exists_rat` : `q^(1/n)` rational ⟺ `∃ s : ℚ, 0 < s ∧ sⁿ = q`.
+* `exists_rat_pow_iff_perfect`       : `∃ s, 0 < s ∧ sⁿ = q` ⟺ `q.num`, `q.den` perfect n-th powers.
+* `rational_rpow_inv_iff_rat`        : the criterion, assembled.
+* `irrational_rpow_inv_iff_rat`      : the negated (irrationality) form.
+-/
+
+import Mathlib
+
+namespace CubeRoot2IrrationalOQ05OQ01OQ01
+
+open Real
+
+/-- `m` is a perfect `n`-th power: there is a natural number `k` with `k ^ n = m`. -/
+def IsPerfectNthPow (m n : ℕ) : Prop := ∃ k : ℕ, k ^ n = m
+
+/-- The defining identity of the real `n`-th root for a rational radicand: for `q ≥ 0` and
+`n ≥ 1`, `(q^(1/n))ⁿ = q`. -/
+theorem rat_rpow_inv_pow {q : ℚ} (hq : 0 ≤ q) {n : ℕ} (hn : 0 < n) :
+    ((q : ℝ) ^ ((n : ℝ)⁻¹)) ^ n = (q : ℝ) := by
+  have hq0 : (0 : ℝ) ≤ (q : ℝ) := by exact_mod_cast hq
+  have hn0 : (n : ℝ) ≠ 0 := by positivity
+  rw [← Real.rpow_natCast ((q : ℝ) ^ ((n : ℝ)⁻¹)) n, ← Real.rpow_mul hq0,
+    inv_mul_cancel₀ hn0, Real.rpow_one]
+
+/-- **Bridge to rational `n`-th powers.** For `q > 0` and `n ≥ 1`, the real root `q^(1/n)` is
+rational (not irrational) iff `q` is the `n`-th power of a positive rational. -/
+theorem rational_rpow_inv_iff_exists_rat {q : ℚ} (hq : 0 < q) {n : ℕ} (hn : 0 < n) :
+    (¬ Irrational ((q : ℝ) ^ ((n : ℝ)⁻¹))) ↔ ∃ s : ℚ, 0 < s ∧ s ^ n = q := by
+  have hqR : (0 : ℝ) < (q : ℝ) := by exact_mod_cast hq
+  constructor
+  · intro hrat
+    obtain ⟨s, hs⟩ := not_not.mp hrat
+    refine ⟨s, ?_, ?_⟩
+    · have hpos : (0 : ℝ) < (s : ℝ) := by rw [hs]; exact Real.rpow_pos_of_pos hqR _
+      exact_mod_cast hpos
+    · have hpow : ((s : ℝ)) ^ n = (q : ℝ) := by rw [hs, rat_rpow_inv_pow hq.le hn]
+      have : ((s ^ n : ℚ) : ℝ) = ((q : ℚ) : ℝ) := by push_cast; exact hpow
+      exact_mod_cast this
+  · rintro ⟨s, hs0, hsn⟩
+    have hs0R : (0 : ℝ) < (s : ℝ) := by exact_mod_cast hs0
+    have hval : ((q : ℝ)) ^ ((n : ℝ)⁻¹) = (s : ℝ) := by
+      rw [← hsn]
+      push_cast
+      rw [← Real.rpow_natCast (s : ℝ) n, ← Real.rpow_mul hs0R.le,
+        mul_inv_cancel₀ (by positivity), Real.rpow_one]
+    rw [hval]
+    exact (s).not_irrational
+
+/-- **The arithmetic core.** For `q > 0` and `n ≥ 1`, `q` is the `n`-th power of a positive
+rational iff its numerator and denominator are both perfect `n`-th powers. -/
+theorem exists_rat_pow_iff_perfect {q : ℚ} (hq : 0 < q) {n : ℕ} (hn : 0 < n) :
+    (∃ s : ℚ, 0 < s ∧ s ^ n = q)
+      ↔ (IsPerfectNthPow q.num.toNat n ∧ IsPerfectNthPow q.den n) := by
+  have hnumpos : 0 < q.num := Rat.num_pos.mpr hq
+  constructor
+  · rintro ⟨s, hs0, hsn⟩
+    have hsnum0 : 0 ≤ s.num := (Rat.num_pos.mpr hs0).le
+    have hnum : q.num = s.num ^ n := by rw [← hsn, Rat.num_pow]
+    have hden : q.den = s.den ^ n := by rw [← hsn, Rat.den_pow]
+    refine ⟨⟨s.num.toNat, ?_⟩, ⟨s.den, ?_⟩⟩
+    · -- s.num.toNat ^ n = q.num.toNat
+      have key : ((s.num.toNat ^ n : ℕ) : ℤ) = s.num ^ n := by
+        push_cast
+        rw [Int.toNat_of_nonneg hsnum0]
+      rw [hnum, ← key, Int.toNat_natCast]
+    · rw [hden]
+  · rintro ⟨⟨c, hc⟩, ⟨d, hd⟩⟩
+    -- c ^ n = q.num.toNat, d ^ n = q.den
+    have hd0 : 0 < d := by
+      rcases Nat.eq_zero_or_pos d with rfl | h
+      · exfalso; rw [Nat.zero_pow hn] at hd; exact q.den_pos.ne' hd.symm
+      · exact h
+    have hc0 : 0 < c := by
+      rcases Nat.eq_zero_or_pos c with rfl | h
+      · exfalso; rw [Nat.zero_pow hn] at hc
+        rw [eq_comm, Int.toNat_eq_zero] at hc; omega
+      · exact h
+    have hqn0 : 0 ≤ q.num := hnumpos.le
+    have hqnum : (q.num : ℚ) = (c : ℚ) ^ n := by
+      have hz : q.num = ((c ^ n : ℕ) : ℤ) := by
+        rw [← Int.toNat_of_nonneg hqn0, hc]
+      rw [hz]; push_cast; ring
+    have hqden : (q.den : ℚ) = (d : ℚ) ^ n := by rw [← hd]; push_cast; ring
+    refine ⟨(c : ℚ) / (d : ℚ), by positivity, ?_⟩
+    rw [div_pow, ← hqnum, ← hqden, Rat.num_div_den]
+
+/-- **The rational-radicand criterion (OQ-05-OQ-01-OQ-01).** For `q > 0` and `n ≥ 1`, the real
+`n`-th root `q^(1/n)` is rational **iff** both the numerator and the denominator of `q` (in lowest
+terms) are perfect `n`-th powers. -/
+theorem rational_rpow_inv_iff_rat {q : ℚ} (hq : 0 < q) {n : ℕ} (hn : 0 < n) :
+    (¬ Irrational ((q : ℝ) ^ ((n : ℝ)⁻¹)))
+      ↔ (IsPerfectNthPow q.num.toNat n ∧ IsPerfectNthPow q.den n) :=
+  (rational_rpow_inv_iff_exists_rat hq hn).trans (exists_rat_pow_iff_perfect hq hn)
+
+/-- **The irrationality form.** `q^(1/n)` is irrational iff `q` fails to have both a perfect
+`n`-th power numerator and a perfect `n`-th power denominator. -/
+theorem irrational_rpow_inv_iff_rat {q : ℚ} (hq : 0 < q) {n : ℕ} (hn : 0 < n) :
+    Irrational ((q : ℝ) ^ ((n : ℝ)⁻¹))
+      ↔ ¬ (IsPerfectNthPow q.num.toNat n ∧ IsPerfectNthPow q.den n) := by
+  rw [← not_iff_not, not_not]
+  exact rational_rpow_inv_iff_rat hq hn
+
+/-- **Integer special case.** For a positive integer radicand (`q.den = 1`), the criterion reduces
+to the parent's natural-number criterion: `m^(1/n)` is rational iff `m` is a perfect `n`-th power.
+The denominator condition `IsPerfectNthPow 1 n` is automatic (`1 = 1ⁿ`). -/
+theorem rational_rpow_inv_iff_natCast {m n : ℕ} (hm : 0 < m) (hn : 0 < n) :
+    (¬ Irrational ((m : ℝ) ^ ((n : ℝ)⁻¹))) ↔ IsPerfectNthPow m n := by
+  have hmq : (0 : ℚ) < (m : ℚ) := by exact_mod_cast hm
+  have hcast : ((m : ℚ) : ℝ) = (m : ℝ) := by push_cast; ring
+  rw [← hcast, rational_rpow_inv_iff_rat hmq hn]
+  have hnum : ((m : ℚ)).num.toNat = m := by simp [Rat.num_natCast]
+  have hden : ((m : ℚ)).den = 1 := by simp [Rat.den_natCast]
+  rw [hnum, hden]
+  constructor
+  · exact fun h => h.1
+  · exact fun h => ⟨h, ⟨1, by simp⟩⟩
+
+end CubeRoot2IrrationalOQ05OQ01OQ01

--- a/src/data/proofs/cube-root-2-irrational-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cube-root-2-irrational-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,173 @@
+{
+  "id": "cube-root-2-irrational-oq-05-oq-01-oq-01",
+  "title": "Rational Radicands: q^(1/n) ∈ ℚ ⟺ Numerator and Denominator Are Perfect n-th Powers",
+  "slug": "cube-root-2-irrational-oq-05-oq-01-oq-01",
+  "description": "Extends the parent's natural-number rationality criterion to rational radicands. For q : ℚ with q > 0 and n ≥ 1, the real n-th root q^(1/n) is rational if and only if both the numerator and the denominator of q (in lowest terms) are perfect n-th powers. The proof reduces rationality of the root to q = sⁿ for a positive rational s, then uses uniqueness of the reduced fraction representation — encoded in Mathlib as Rat.num_pow / Rat.den_pow — to split the condition coordinatewise across q.num and q.den. The parent's natural-number criterion is recovered as the special case q.den = 1.",
+  "meta": {
+    "author": "classical (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Nth_root#Irrationality",
+    "date": "antiquity",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "irrationality",
+      "nth-root",
+      "perfect-power",
+      "rational",
+      "rational-radicand",
+      "real-analysis",
+      "rpow",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CubeRoot2IrrationalOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Rat.num_pow",
+        "description": "(q ^ n).num = q.num ^ n — the numerator of a rational power is the power of the numerator; encodes that cⁿ/dⁿ stays in lowest terms when c/d is",
+        "module": "Mathlib.Data.Rat.Defs"
+      },
+      {
+        "theorem": "Rat.den_pow",
+        "description": "(q ^ n).den = q.den ^ n — the denominator of a rational power is the power of the denominator",
+        "module": "Mathlib.Data.Rat.Defs"
+      },
+      {
+        "theorem": "Rat.num_div_den",
+        "description": "(q.num : ℚ) / (q.den : ℚ) = q — reconstructs q from its reduced numerator and denominator",
+        "module": "Mathlib.Algebra.Ring.Rat"
+      },
+      {
+        "theorem": "Real.rpow_mul",
+        "description": "0 ≤ x → x ^ (y * z) = (x ^ y) ^ z — collapses (q^(1/n))^n to q^(n⁻¹·n) = q, and (sⁿ)^(1/n) to s",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Rat.not_irrational",
+        "description": "(s : ℝ) is not irrational for s : ℚ — closes the ⟸ direction once the root simplifies to a rational s",
+        "module": "Mathlib.NumberTheory.Real.Irrational"
+      }
+    ],
+    "originalContributions": [
+      "rational_rpow_inv_iff_rat: the main criterion — ¬Irrational (q^(1/n)) ↔ (IsPerfectNthPow q.num.toNat n ∧ IsPerfectNthPow q.den n), for q > 0 and n ≥ 1",
+      "irrational_rpow_inv_iff_rat: the contrapositive form — q^(1/n) is irrational iff q lacks a perfect-n-th-power numerator or denominator",
+      "rational_rpow_inv_iff_exists_rat: the real-analytic bridge — q^(1/n) is rational iff q = sⁿ for some positive rational s",
+      "exists_rat_pow_iff_perfect: the arithmetic core — q = sⁿ iff q.num and q.den are perfect n-th powers, via uniqueness of the reduced fraction",
+      "rat_rpow_inv_pow: the root identity (q^(1/n))ⁿ = q for q ≥ 0, n ≥ 1",
+      "rational_rpow_inv_iff_natCast: the parent's natural-number criterion recovered as the special case q.den = 1"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 144,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on Lean's foundational propext / Classical.choice / Quot.sound). No native_decide.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The irrationality of n-th roots of non-perfect-power integers is the general form of the Greek discovery that √2 is irrational (Hardy & Wright, Theorem 44; Niven, Irrational Numbers). The rational-radicand version is the natural completion: a positive rational q = a/b in lowest terms has a rational n-th root iff a and b are separately perfect n-th powers, because coprimality is preserved by powers and reduced fractions are unique. The parent entry settled the integer case via integral closedness; this entry pushes the same idea one floor up to ℚ using the uniqueness already packaged in Mathlib's Rat.num_pow / Rat.den_pow.",
+    "problemStatement": "**Open Question (cube-root-2-irrational-oq-05-oq-01, first listed)**: Extend the criterion to rational radicands — q^(1/n) for q : ℚ⁺ is rational iff both numerator and denominator of q (in lowest terms) are perfect n-th powers.\n\n**Result**: rational_rpow_inv_iff_rat establishes ¬Irrational (q^(1/n)) ↔ (IsPerfectNthPow q.num.toNat n ∧ IsPerfectNthPow q.den n) for q > 0, n ≥ 1, with the irrationality form irrational_rpow_inv_iff_rat and the integer special case rational_rpow_inv_iff_natCast.",
+    "text": "For a positive rational q and n ≥ 1, the real n-th root q^(1/n) is rational exactly when the numerator and denominator of q (in lowest terms) are both perfect n-th powers.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Root identity.** rat_rpow_inv_pow: for q ≥ 0, n ≥ 1, (q^(1/n))ⁿ = q via Real.rpow_natCast and Real.rpow_mul (q^(n⁻¹·n) = q).\n2. **Bridge to a rational power.** rational_rpow_inv_iff_exists_rat: q^(1/n) is rational iff q = sⁿ for some s : ℚ, s > 0. (⇒) a rational value s of the root satisfies sⁿ = (q^(1/n))ⁿ = q after casting; (⇐) (sⁿ)^(1/n) = s by the same rpow law, and a rational is never irrational.\n3. **Arithmetic core via reduced fractions.** exists_rat_pow_iff_perfect: if q = sⁿ then q.num = s.numⁿ and q.den = s.denⁿ by Rat.num_pow / Rat.den_pow — exactly the statement that cⁿ/dⁿ is the reduced form of (c/d)ⁿ. Hence q.num.toNat = (s.num.toNat)ⁿ and q.den = s.denⁿ are perfect n-th powers. Conversely, given q.num.toNat = cⁿ and q.den = dⁿ, the rational s = c/d satisfies sⁿ = cⁿ/dⁿ = q.num/q.den = q (Rat.num_div_den).\n4. **Assembly.** rational_rpow_inv_iff_rat composes the two equivalences; irrational_rpow_inv_iff_rat negates it.\n5. **Integer special case.** rational_rpow_inv_iff_natCast: for q = (m : ℚ) the denominator is 1 (automatically a perfect power), so the criterion collapses to the parent's 'm is a perfect n-th power'."
+    ,
+    "keyInsights": [
+      "**Rationality of the root is rationality of an n-th power.** The real-analytic content is entirely in the one-line bridge q^(1/n) ∈ ℚ ⟺ q ∈ (ℚ⁺)ⁿ; everything afterward is pure arithmetic of fractions.",
+      "**Uniqueness of reduced fractions does all the work.** That cⁿ/dⁿ is automatically in lowest terms when c/d is — i.e. coprimality survives taking powers — is exactly what lets the single condition q = sⁿ split into two independent coordinate conditions. Mathlib's Rat.num_pow / Rat.den_pow are this fact in usable form.",
+      "**The numerator and denominator decouple.** Unlike the integer case (one condition), the rational case is a conjunction: a single non-perfect-power coordinate — numerator OR denominator — already forces irrationality.",
+      "**Strictly generalizes the parent.** Setting q.den = 1 recovers the natural-number criterion verbatim, so this entry subsumes cube-root-2-irrational-oq-05-oq-01 rather than merely paralleling it."
+    ],
+    "prerequisites": [
+      "Real power (rpow) arithmetic: rpow_mul, rpow_natCast for nonnegative base",
+      "Rational numbers in lowest terms: Rat.num, Rat.den, and the power lemmas Rat.num_pow / Rat.den_pow",
+      "Reconstruction of a rational from its reduced form: Rat.num_div_den"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header, Predicate, and Root Identity",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring stating the rational-radicand criterion, the IsPerfectNthPow predicate, and rat_rpow_inv_pow: (q^(1/n))ⁿ = q for q ≥ 0, n ≥ 1 via rpow composition.",
+      "mathContext": "$\\left(q^{1/n}\\right)^n = q$ for $q \\ge 0,\\ n \\ge 1$."
+    },
+    {
+      "id": "bridge",
+      "title": "Bridge to Rational n-th Powers",
+      "startLine": 51,
+      "endLine": 73,
+      "summary": "rational_rpow_inv_iff_exists_rat: ¬Irrational (q^(1/n)) ↔ ∃ s : ℚ, 0 < s ∧ sⁿ = q. Both directions use the root identity; the ⟸ direction closes with Rat.not_irrational.",
+      "mathContext": "$q^{1/n} \\in \\mathbb{Q} \\iff \\exists s \\in \\mathbb{Q}_{>0},\\ s^n = q$."
+    },
+    {
+      "id": "arithmetic-core",
+      "title": "The Arithmetic Core",
+      "startLine": 75,
+      "endLine": 111,
+      "summary": "exists_rat_pow_iff_perfect: q = sⁿ ⟺ q.num and q.den are perfect n-th powers, using Rat.num_pow / Rat.den_pow for ⇒ and constructing s = c/d for ⟸ via Rat.num_div_den.",
+      "mathContext": "$q \\in (\\mathbb{Q}_{>0})^n \\iff q.\\mathrm{num},\\ q.\\mathrm{den}$ are perfect $n$-th powers."
+    },
+    {
+      "id": "criterion-and-corollary",
+      "title": "Criterion, Irrationality Form, and Integer Special Case",
+      "startLine": 113,
+      "endLine": 144,
+      "summary": "rational_rpow_inv_iff_rat (the assembled criterion), irrational_rpow_inv_iff_rat (its contrapositive), and rational_rpow_inv_iff_natCast recovering the parent's natural-number criterion at q.den = 1.",
+      "mathContext": "$q^{1/n} \\in \\mathbb{Q} \\iff (\\exists k,\\ k^n = q.\\mathrm{num}) \\wedge (\\exists k,\\ k^n = q.\\mathrm{den})$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cube-root-2-irrational-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: lifts the natural-number criterion to rational radicands, recovering it as the special case q.den = 1 (rational_rpow_inv_iff_natCast)"
+    },
+    {
+      "targetId": "cube-root-2-irrational-oq-05",
+      "relationship": "related",
+      "description": "The grandparent prime-root result is subsumed twice over: a prime is a non-perfect-power integer, hence an integer radicand whose root is irrational"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the rational-radicand rationality criterion for n-th roots: q^(1/n) is rational iff the numerator and denominator of q are both perfect n-th powers. The real-analytic step is a one-line bridge to q = sⁿ; the substance is the coordinatewise split provided by uniqueness of reduced fractions (Rat.num_pow / Rat.den_pow).",
+    "implications": "Closes the rational-radicand line opened by the parent: rationality of every n-th root of every positive rational is now decided, with the integer criterion recovered as the q.den = 1 specialization. The decoupling of numerator and denominator conditions makes irrationality the generic case.",
+    "openQuestions": [
+      "Drop positivity: handle q < 0 and even/odd n uniformly (for odd n the real root of a negative rational is defined; for even n it is not real).",
+      "Quantify: for a rational q with a non-perfect-power numerator or denominator, give an effective irrationality measure for q^(1/n)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "CubeRoot2IrrationalOQ05OQ01OQ01",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/CubeRoot2IrrationalOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Hardy, G. H. and Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th ed.",
+      "note": "Theorem 44: a rational n-th root of an integer is an integer — the integer-case backbone the rational case builds on"
+    },
+    {
+      "authors": "Niven, Ivan",
+      "title": "Irrational Numbers",
+      "year": "1956",
+      "venue": "Carus Mathematical Monographs, MAA",
+      "note": "Classical treatment of irrationality of n-th roots via unique factorization"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `cube-root-2-irrational-oq-05-oq-01` (#27973): extend the n-th-root rationality criterion from **natural** to **rational** radicands.

For `q : ℚ` with `q > 0` and `n ≥ 1`:

> `¬ Irrational (q^(1/n))  ⟺  (q.num.toNat and q.den are both perfect n-th powers)`

A single non-perfect-power coordinate — numerator **or** denominator — forces irrationality.

## Method

1. **Bridge** (`rational_rpow_inv_iff_exists_rat`): `q^(1/n) ∈ ℚ ⟺ q = sⁿ` for some `s : ℚ`, `s > 0`, via the real rpow identity `(q^(1/n))ⁿ = q`.
2. **Arithmetic core** (`exists_rat_pow_iff_perfect`): uniqueness of the reduced fraction — encoded by `Rat.num_pow` / `Rat.den_pow` (`(sⁿ).num = s.numⁿ`, `(sⁿ).den = s.denⁿ`) — splits `q = sⁿ` coordinatewise into `q.num = s.numⁿ` and `q.den = s.denⁿ`. The `⟸` direction rebuilds `s = c/d` with `Rat.num_div_den`.
3. **Assembly**: `rational_rpow_inv_iff_rat` + the irrationality form `irrational_rpow_inv_iff_rat`.
4. **Integer special case** (`rational_rpow_inv_iff_natCast`): at `q.den = 1` this collapses to the parent's natural-number criterion, so the entry strictly subsumes #27973.

## Verification

- 144 lines, 6 theorems / 1 definition.
- **0 sorries, 0 axioms** — `#print axioms rational_rpow_inv_iff_rat` reports only `propext`, `Classical.choice`, `Quot.sound`. No `native_decide`.
- Builds against Mathlib 4.26.0.

## Files

- `proofs/Proofs/CubeRoot2IrrationalOQ05OQ01OQ01.lean` (new)
- `src/data/proofs/cube-root-2-irrational-oq-05-oq-01-oq-01/meta.json` (new)
- `proofs/Proofs.lean` (import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)