### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-01-oq-02): explicit p-series tail remainder bound [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -140,6 +140,7 @@ import Proofs.AngleTrisectionOQ05OQ02
 import Proofs.AngleTrisectionOQ05OQ03
 import Proofs.AngleTrisectionOQ05OQ04
 import Proofs.AntitoneIntegralSumComparisonOQ01OQ01
+import Proofs.AntitoneIntegralSumComparisonOQ01OQ01OQ02
 import Proofs.ArchimedesMethodOfExhaustion
 import Proofs.AreaFromCircumferenceIntegral
 import Proofs.AreaOfCircle

--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02.lean
@@ -1,0 +1,161 @@
+import Mathlib
+
+/-
+# Explicit Remainder Bound for the p-Series Tail
+
+This is the open-question companion to `AntitoneIntegralSumComparisonOQ01OQ01`.  That
+parent file used the **antitone integral test** to show that every partial sum of the
+p-series `∑ 1/nᵖ` is bounded by `1/(p−1)`, the value of the improper integral
+`∫₁^∞ x^{−p} dx`, thereby proving convergence for `p > 1` *directly from the comparison*.
+
+The bound `1/(p−1)` is a single uniform constant; it says nothing about **how fast** the
+series converges.  The open question asks for the **explicit remainder** — a quantitative
+rate of convergence.  Running the very same integral test, but starting the comparison at
+`x = N` instead of `x = 1`, pins the tail down sharply:
+
+  ∑_{n > N} 1/nᵖ  ≤  ∫_N^∞ x^{−p} dx  =  N^{1−p}/(p−1)  =  1/((p−1) · N^{p−1}).
+
+Concretely, the development below proves, for `p > 1` and `N ≥ 1`:
+
+* **Tail partial-sum bound** (`pseries_tail_partial_le`): every finite tail
+  `∑_{i<m} 1/(N+1+i)ᵖ` is bounded by `N^{1−p}/(p−1)`, uniformly in `m`.
+* **Tail bound** (`pseries_tail_tsum_le`): passing to the limit,
+  `∑'_{i} 1/(N+1+i)ᵖ ≤ N^{1−p}/(p−1)`.
+* **Remainder bound** (`pseries_remainder_le`): identifying the tail with the genuine
+  truncation error, `(∑'_n 1/nᵖ) − (∑_{n ≤ N} 1/nᵖ) ≤ N^{1−p}/(p−1)`.
+* **Explicit form** (`pseries_tail_explicit`): the same bound written as the textbook
+  `1/((p−1) · N^{p−1})`, exhibiting the `O(N^{1−p})` decay of the remainder.
+
+The Basel exponent `p = 2` then gives the clean estimate `∑_{n>N} 1/n² ≤ 1/N`.
+
+All results are fully machine-verified: 0 sorries, 0 axioms.
+-/
+
+namespace AntitoneIntegralSumComparisonOQ01OQ01OQ02
+
+open scoped BigOperators
+open Finset intervalIntegral
+
+/-! ## The tail partial-sum bound -/
+
+/-- **Tail partial-sum bound.**  For `p > 1` and `N ≥ 1`, every finite tail
+`∑_{i<m} 1/(N+1+i)ᵖ` is bounded by `N^{1−p}/(p−1)`, the value of the improper integral
+`∫_N^∞ x^{−p} dx`.  This is the antitone integral test applied to `1/xᵖ` on `[N, N+m]`,
+the parent's `pseries_partial_sum_le` shifted to start at `N`. -/
+theorem pseries_tail_partial_le (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) (m : ℕ) :
+    (∑ i ∈ Finset.range m, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p) ≤ (N : ℝ) ^ (1 - p) / (p - 1) := by
+  have hp0 : (0 : ℝ) < p := by linarith
+  have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+  -- `1/xᵖ` is antitone on `[N, N+m]`.
+  have hanti : AntitoneOn (fun x : ℝ => 1 / x ^ p) (Set.Icc (N : ℝ) ((N : ℝ) + (m : ℝ))) := by
+    intro x hx y _ hxy
+    have hx0 : (0 : ℝ) < x := lt_of_lt_of_le hNpos hx.1
+    exact one_div_le_one_div_of_le (Real.rpow_pos_of_pos hx0 p)
+      (Real.rpow_le_rpow hx0.le hxy hp0.le)
+  -- Rewrite `1/xᵖ` as `x^{−p}` on the interval, to use `integral_rpow`.
+  have hcongr : (∫ x in (N : ℝ)..(N : ℝ) + (m : ℝ), 1 / x ^ p)
+      = ∫ x in (N : ℝ)..(N : ℝ) + (m : ℝ), x ^ (-p) := by
+    refine intervalIntegral.integral_congr (fun x hx => ?_)
+    rw [Set.uIcc_of_le (le_add_of_nonneg_right (by positivity))] at hx
+    have hx0 : (0 : ℝ) < x := lt_of_lt_of_le hNpos hx.1
+    rw [Real.rpow_neg hx0.le, one_div]
+  -- Evaluate the integral.
+  have hint : (∫ x in (N : ℝ)..(N : ℝ) + (m : ℝ), 1 / x ^ p)
+      = (((N : ℝ) + (m : ℝ)) ^ (-p + 1) - (N : ℝ) ^ (-p + 1)) / (-p + 1) := by
+    rw [hcongr, integral_rpow (Or.inr ⟨ne_of_lt (by linarith),
+      Set.notMem_uIcc_of_lt hNpos
+        (lt_of_lt_of_le hNpos (le_add_of_nonneg_right (by positivity)))⟩)]
+  -- The integral test: the right Riemann sum is below the integral.
+  have key : (∑ i ∈ Finset.range m, 1 / ((N : ℝ) + ((i + 1 : ℕ) : ℝ)) ^ p)
+      ≤ ∫ x in (N : ℝ)..(N : ℝ) + (m : ℝ), 1 / x ^ p :=
+    hanti.sum_le_integral
+  -- Reconcile the summation index `N + (i+1)` with `i + (N+1)`.
+  have hsum_eq : (∑ i ∈ Finset.range m, 1 / ((N : ℝ) + ((i + 1 : ℕ) : ℝ)) ^ p)
+      = ∑ i ∈ Finset.range m, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [show ((N : ℝ) + ((i + 1 : ℕ) : ℝ)) = (((i + (N + 1) : ℕ)) : ℝ) by push_cast; ring]
+  rw [hint] at key
+  rw [← hsum_eq]
+  refine le_trans key ?_
+  -- Bound the integral value `((N+m)^{1−p} − N^{1−p})/(1−p)` by `N^{1−p}/(p−1)`.
+  rw [show (-p + 1) = (1 - p) by ring]
+  have hA : (0 : ℝ) ≤ (N : ℝ) ^ (1 - p) := Real.rpow_nonneg hNpos.le _
+  have hB : (0 : ℝ) ≤ ((N : ℝ) + (m : ℝ)) ^ (1 - p) := Real.rpow_nonneg (by positivity) _
+  have hpm : (0 : ℝ) < p - 1 := by linarith
+  have hp1ne : (1 : ℝ) - p ≠ 0 := by linarith
+  have hpm_ne : (p : ℝ) - 1 ≠ 0 := by linarith
+  have hsplit : (((N : ℝ) + (m : ℝ)) ^ (1 - p) - (N : ℝ) ^ (1 - p)) / (1 - p)
+      = (N : ℝ) ^ (1 - p) / (p - 1) - ((N : ℝ) + (m : ℝ)) ^ (1 - p) / (p - 1) := by
+    field_simp
+    ring
+  rw [hsplit]
+  have hBnn : (0 : ℝ) ≤ ((N : ℝ) + (m : ℝ)) ^ (1 - p) / (p - 1) := div_nonneg hB hpm.le
+  linarith
+
+/-! ## The tail bound -/
+
+/-- **Tail bound for the p-series.**  For `p > 1` and `N ≥ 1`, the full tail
+`∑'_{i} 1/(N+1+i)ᵖ` is bounded by `N^{1−p}/(p−1)`.  Obtained from the uniform
+partial-sum bound by passing to the limit (`Real.tsum_le_of_sum_range_le`). -/
+theorem pseries_tail_tsum_le (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) :
+    (∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p) ≤ (N : ℝ) ^ (1 - p) / (p - 1) := by
+  apply Real.tsum_le_of_sum_range_le
+  · intro i; positivity
+  · intro m; exact pseries_tail_partial_le p hp N hN m
+
+/-! ## The genuine remainder bound -/
+
+/-- **Explicit remainder bound.**  For `p > 1` and `N ≥ 1`, the truncation error of the
+p-series after the first `N + 1` terms (indices `0, …, N`) is bounded by `N^{1−p}/(p−1)`.
+The remainder is identified with the tail via `Summable.sum_add_tsum_nat_add`. -/
+theorem pseries_remainder_le (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) :
+    (∑' n : ℕ, 1 / (n : ℝ) ^ p) - (∑ i ∈ Finset.range (N + 1), 1 / (i : ℝ) ^ p)
+      ≤ (N : ℝ) ^ (1 - p) / (p - 1) := by
+  have hsummable : Summable (fun n : ℕ => 1 / (n : ℝ) ^ p) :=
+    Real.summable_one_div_nat_rpow.mpr hp
+  -- `∑'_n = (∑_{i ≤ N}) + (tail)`, so `remainder = tail`.
+  have hrem : (∑' n : ℕ, 1 / (n : ℝ) ^ p)
+      = (∑ i ∈ Finset.range (N + 1), 1 / (i : ℝ) ^ p)
+        + ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p :=
+    (hsummable.sum_add_tsum_nat_add (N + 1)).symm
+  have hcancel : (∑ i ∈ Finset.range (N + 1), 1 / (i : ℝ) ^ p)
+        + (∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p)
+        - (∑ i ∈ Finset.range (N + 1), 1 / (i : ℝ) ^ p)
+      = ∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p := by ring
+  rw [hrem, hcancel]
+  exact pseries_tail_tsum_le p hp N hN
+
+/-! ## The explicit `1/((p−1)·N^{p−1})` form -/
+
+/-- **Explicit remainder, textbook form.**  Rewriting `N^{1−p}/(p−1)` as
+`1/((p−1)·N^{p−1})` exhibits the `O(N^{1−p})` decay of the p-series tail. -/
+theorem pseries_tail_explicit (p : ℝ) (hp : 1 < p) (N : ℕ) (hN : 1 ≤ N) :
+    (∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ p) ≤ 1 / ((p - 1) * (N : ℝ) ^ (p - 1)) := by
+  have h := pseries_tail_tsum_le p hp N hN
+  have hNpos : (0 : ℝ) < (N : ℝ) := by exact_mod_cast hN
+  have hpm_ne : (p : ℝ) - 1 ≠ 0 := by linarith
+  have hNp : (0 : ℝ) < (N : ℝ) ^ (p - 1) := Real.rpow_pos_of_pos hNpos _
+  have heq : (N : ℝ) ^ (1 - p) / (p - 1) = 1 / ((p - 1) * (N : ℝ) ^ (p - 1)) := by
+    rw [show (1 - p) = -(p - 1) by ring, Real.rpow_neg hNpos.le]
+    field_simp
+  rwa [heq] at h
+
+/-! ## Worked witnesses -/
+
+/-- **Basel-exponent rate.**  For `p = 2`, the explicit tail bound is the clean estimate
+`∑_{n>N} 1/n² ≤ 1/N`. -/
+example (N : ℕ) (hN : 1 ≤ N) :
+    (∑' i : ℕ, 1 / (((i + (N + 1) : ℕ)) : ℝ) ^ (2 : ℝ)) ≤ 1 / (N : ℝ) := by
+  have h := pseries_tail_explicit 2 (by norm_num) N hN
+  have heq : (1 : ℝ) / (((2 : ℝ) - 1) * (N : ℝ) ^ ((2 : ℝ) - 1)) = 1 / (N : ℝ) := by
+    rw [show ((2 : ℝ) - 1) = (1 : ℝ) by norm_num, Real.rpow_one]
+    norm_num
+  rwa [heq] at h
+
+/-- The remainder bound is genuinely a bound on the truncation error of `∑ 1/n²`. -/
+example : (∑' n : ℕ, 1 / (n : ℝ) ^ (2 : ℝ)) - (∑ i ∈ Finset.range 11, 1 / (i : ℝ) ^ (2 : ℝ))
+    ≤ (10 : ℝ) ^ (1 - 2 : ℝ) / ((2 : ℝ) - 1) :=
+  pseries_remainder_le 2 (by norm_num) 10 (by norm_num)
+
+end AntitoneIntegralSumComparisonOQ01OQ01OQ02

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-isc-oq010102-tail-partial",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+    "range": { "startLine": 45, "endLine": 99 },
+    "type": "theorem",
+    "title": "Tail Partial-Sum Bound via the Shifted Integral Test",
+    "content": "pseries_tail_partial_le runs the parent's integral-test argument with base point N instead of 1. Since 1/xᵖ is antitone on [N, N+m], AntitoneOn.sum_le_integral gives the right Riemann sum ∑_{i<m} 1/(N+1+i)ᵖ ≤ ∫_N^{N+m} x^{−p} dx. The integral is evaluated by integral_rpow (after rewriting 1/xᵖ = x^{−p}) to ((N+m)^{1−p} − N^{1−p})/(1−p), which rearranges to (N^{1−p} − (N+m)^{1−p})/(p−1) ≤ N^{1−p}/(p−1) because (N+m)^{1−p} ≥ 0. The bound is uniform in m — the only slack is dropping the far-endpoint value.",
+    "mathContext": "\\sum_{i<m} \\frac{1}{(N+1+i)^p} \\;\\le\\; \\int_N^{N+m} x^{-p}\\,dx \\;\\le\\; \\frac{N^{1-p}}{p-1}",
+    "significance": "key",
+    "relatedConcepts": ["integral test", "Riemann sums", "antitone functions", "integral_rpow"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010102-tail-tsum",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 109 },
+    "type": "theorem",
+    "title": "The Tail Bound in the Limit",
+    "content": "pseries_tail_tsum_le passes the uniform partial-sum bound to the limit. Real.tsum_le_of_sum_range_le states that if every partial sum of a nonnegative series is ≤ c, then the tsum is ≤ c. Feeding it pseries_tail_partial_le yields ∑'_{i} 1/(N+1+i)ᵖ ≤ N^{1−p}/(p−1) for the full infinite tail.",
+    "mathContext": "\\sum_{i=0}^{\\infty} \\frac{1}{(N+1+i)^p} \\;\\le\\; \\frac{N^{1-p}}{p-1}",
+    "significance": "standard",
+    "relatedConcepts": ["tsum", "infinite series", "monotone convergence"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010102-remainder",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 131 },
+    "type": "theorem",
+    "title": "The Tail IS the Truncation Error",
+    "content": "pseries_remainder_le makes the bound a genuine remainder estimate. Summable.sum_add_tsum_nat_add (using summability from Real.summable_one_div_nat_rpow for p>1) decomposes ∑'_n 1/nᵖ = (∑_{i<N+1} 1/iᵖ) + (∑'_i 1/(i+N+1)ᵖ). Subtracting the partial sum shows the truncation error (∑'_n) − (∑_{n≤N}) equals the shifted tail, which the previous theorem already bounds by N^{1−p}/(p−1).",
+    "mathContext": "\\Big(\\sum_{n=0}^{\\infty}\\tfrac{1}{n^p}\\Big) - \\Big(\\sum_{n=0}^{N}\\tfrac{1}{n^p}\\Big) \\;\\le\\; \\frac{N^{1-p}}{p-1}",
+    "significance": "key",
+    "relatedConcepts": ["truncation error", "series remainder", "tail decomposition", "summability"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq010102-explicit",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+    "range": { "startLine": 133, "endLine": 159 },
+    "type": "theorem",
+    "title": "The Textbook Form and the Basel Rate",
+    "content": "pseries_tail_explicit rewrites N^{1−p}/(p−1) as 1/((p−1)·N^{p−1}) using Real.rpow_neg (N^{1−p} = 1/N^{p−1}), exhibiting the O(N^{1−p}) decay of the remainder. The worked witness specializes to the Basel exponent p=2, where the bound collapses to the clean ∑_{n>N} 1/n² ≤ 1/N — the standard rate for truncating ζ(2).",
+    "mathContext": "\\sum_{n>N}\\frac{1}{n^p} \\le \\frac{1}{(p-1)\\,N^{p-1}}, \\qquad \\sum_{n>N}\\frac{1}{n^2} \\le \\frac{1}{N}",
+    "significance": "standard",
+    "relatedConcepts": ["rate of convergence", "rpow", "Basel problem", "zeta function"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,74 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+  "title": "Explicit Remainder Bound for the p-Series Tail",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-01-oq-02",
+  "description": "Answers the parent's second open question by turning the integral test into a quantitative rate of convergence. Running the same antitone comparison for 1/xᵖ, but starting at x = N instead of x = 1, sharply bounds the p-series tail: ∑_{n>N} 1/nᵖ ≤ ∫_N^∞ x^{−p} dx = N^{1−p}/(p−1) = 1/((p−1)·N^{p−1}). The tail is identified with the genuine truncation error (∑'_n − ∑_{n≤N}) via Summable.sum_add_tsum_nat_add, and the Basel exponent p=2 yields the clean estimate ∑_{n>N} 1/n² ≤ 1/N. 4 theorems, 2 worked witnesses, 0 definitions, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Integral_test_for_convergence",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "p-series",
+      "remainder-bound",
+      "rate-of-convergence",
+      "tail-estimate",
+      "tsum",
+      "convergence"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the foundational propext / Classical.choice / Quot.sound).",
+    "lineCount": 161,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "pseries_tail_partial_le: every finite tail ∑_{i<m} 1/(N+1+i)ᵖ is bounded by N^{1−p}/(p−1), uniformly in m — the antitone integral test (AntitoneOn.sum_le_integral) applied to 1/xᵖ on [N, N+m], with the integral computed by integral_rpow and bounded using (N+m)^{1−p} ≥ 0",
+      "pseries_tail_tsum_le: passing the uniform partial-sum bound to the limit via Real.tsum_le_of_sum_range_le gives ∑'_{i} 1/(N+1+i)ᵖ ≤ N^{1−p}/(p−1)",
+      "pseries_remainder_le: identifies the tail with the truncation error (∑'_n 1/nᵖ) − (∑_{n≤N} 1/nᵖ) via Summable.sum_add_tsum_nat_add, giving the genuine remainder bound",
+      "pseries_tail_explicit: rewrites the bound in the textbook form 1/((p−1)·N^{p−1}) (Real.rpow_neg), exhibiting the O(N^{1−p}) decay",
+      "Worked witnesses: the Basel-exponent rate ∑_{n>N} 1/n² ≤ 1/N for all N ≥ 1, and the concrete truncation-error statement for ∑ 1/n²"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The integral test certifies convergence but, in its bare form, only delivers a single uniform bound on the partial sums (the parent showed ∑ 1/nᵖ has partial sums ≤ 1/(p−1)). That constant says nothing about the speed of convergence. The quantitative refinement — bounding the tail ∑_{n>N} 1/nᵖ — is the classical 'integral remainder' estimate, the tool that makes the p-series a usable numerical object (it is exactly how one bounds the error when truncating ζ(p) = ∑ 1/nᵖ to N terms). The bound N^{1−p}/(p−1) is sharp in order: the tail decays like N^{1−p}, the same rate as the improper integral that majorizes it.",
+    "problemStatement": "From the antitone integral comparison, derive an explicit error/remainder bound for the p-series tail: for p > 1 and N ≥ 1, ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1) = 1/((p−1)·N^{p−1}).",
+    "text": "Apply the antitone integral test to f(x) = 1/xᵖ on the interval [N, N+m] instead of [1, 1+n]. The right Riemann sum underestimates the integral: ∑_{i<m} 1/(N+1+i)ᵖ ≤ ∫_N^{N+m} x^{−p} dx = (N^{1−p} − (N+m)^{1−p})/(p−1) ≤ N^{1−p}/(p−1), the last step because (N+m)^{1−p} ≥ 0. This bound is uniform in m, so the full tail tsum is bounded by N^{1−p}/(p−1). Finally, decomposing ∑'_n 1/nᵖ = (∑_{n≤N} 1/nᵖ) + (tail) shows the tail IS the truncation error, giving the remainder bound. The textbook form 1/((p−1)·N^{p−1}) follows from N^{1−p} = 1/N^{p−1}.",
+    "proofStrategy": "pseries_tail_partial_le runs the parent's pseries_partial_sum_le argument with base point N: 1/xᵖ is antitone on [N,N+m] (one_div_le_one_div_of_le with Real.rpow_le_rpow), AntitoneOn.sum_le_integral gives the right Riemann sum ≤ the integral, the integral is evaluated by rewriting 1/xᵖ = x^{−p} (intervalIntegral.integral_congr) and applying integral_rpow, and the value ((N+m)^{1−p} − N^{1−p})/(1−p) is rearranged (field_simp) and bounded by N^{1−p}/(p−1) using (N+m)^{1−p} ≥ 0. pseries_tail_tsum_le feeds this uniform bound to Real.tsum_le_of_sum_range_le. pseries_remainder_le uses Summable.sum_add_tsum_nat_add (with summability from Real.summable_one_div_nat_rpow) to identify the tail with the truncation error. pseries_tail_explicit rewrites N^{1−p}/(p−1) as 1/((p−1)·N^{p−1}) via Real.rpow_neg and field_simp. Two example witnesses specialize to the Basel exponent.",
+    "keyInsights": [
+      "Starting the integral comparison at N rather than 1 converts the parent's single uniform bound 1/(p−1) into the N-dependent tail estimate N^{1−p}/(p−1)",
+      "The right Riemann sum of a decreasing function underestimates the integral, so the tail partial sums are bounded by ∫_N^{N+m} x^{−p}, whose limit ∫_N^∞ x^{−p} = N^{1−p}/(p−1) is finite for p > 1",
+      "Slack only enters at the single step (N+m)^{1−p} ≥ 0 (dropping the value at the far endpoint); the resulting bound has the correct order N^{1−p}",
+      "Summable.sum_add_tsum_nat_add is the bridge from 'tail of a shifted series' to 'truncation error of the original series', making the bound a genuine remainder estimate",
+      "For p = 2 the bound collapses to ∑_{n>N} 1/n² ≤ 1/N — the textbook rate for truncating the Basel series"
+    ],
+    "prerequisites": [
+      "The antitone integral-test sandwich (AntitoneOn.sum_le_integral) from the parent entries",
+      "Interval integrals of real powers (integral_rpow) and real powers (rpow, Real.rpow_neg)",
+      "tsum bounds from uniform partial-sum bounds (Real.tsum_le_of_sum_range_le)",
+      "Series tail/truncation decomposition (Summable.sum_add_tsum_nat_add) and the p-series summability criterion"
+    ]
+  },
+  "conclusion": {
+    "summary": "The p-series tail is bounded explicitly: for p > 1 and N ≥ 1, ∑_{n>N} 1/nᵖ ≤ N^{1−p}/(p−1) = 1/((p−1)·N^{p−1}), obtained by the antitone integral test applied to 1/xᵖ on [N, N+m] and identified with the truncation error of ∑ 1/nᵖ via the shifted-tail decomposition. The Basel exponent gives ∑_{n>N} 1/n² ≤ 1/N. 4 theorems, 2 witnesses, 0 definitions, 161 lines, 0 sorries, 0 axioms.",
+    "implications": "Upgrades the parent's qualitative convergence proof to a quantitative O(N^{1−p}) rate, the estimate underlying numerical truncation of ζ(p) and any comparison against ∑ 1/nᵖ. The same base-shift technique (run the integral comparison from x = N) produces explicit tail bounds for any antitone summand whose integral can be evaluated.",
+    "openQuestions": [
+      "Combine the upper tail bound with the matching lower bound ∑_{n>N} 1/nᵖ ≥ (N+1)^{1−p}/(p−1) (from the left Riemann sum / integral_le_sum) to sandwich the remainder and pin its leading asymptotic N^{1−p}/(p−1)",
+      "Specialize at integer p to explicit rational error bounds for ζ(2), ζ(4), … and compare against the exact values π²/6, π⁴/90"
+    ]
+  },
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ01OQ02",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ01OQ02.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Explicit Remainder Bound for the p-Series Tail

Answers the parent's (`antitone-integral-sum-comparison-oq-01-oq-01`) **second open question** verbatim: *derive the explicit error/remainder bound for the p-series tail* `∑_{n≥N} 1/nᵖ ≤ N^{1−p}/(p−1)` *from the same integral comparison.*

### Result
For `p > 1` and `N ≥ 1`:
```
∑_{n>N} 1/nᵖ  ≤  ∫_N^∞ x^{−p} dx  =  N^{1−p}/(p−1)  =  1/((p−1)·N^{p−1})
```
turning the parent's qualitative convergence proof into a quantitative **O(N^{1−p}) rate of convergence**.

### Theorems (4 + 2 witnesses)
- `pseries_tail_partial_le` — uniform tail partial-sum bound, antitone integral test on `[N, N+m]` (`AntitoneOn.sum_le_integral` + `integral_rpow`), slack only at `(N+m)^{1−p} ≥ 0`.
- `pseries_tail_tsum_le` — passes to the limit via `Real.tsum_le_of_sum_range_le`.
- `pseries_remainder_le` — identifies the tail with the genuine truncation error `(∑'_n) − (∑_{n≤N})` via `Summable.sum_add_tsum_nat_add`.
- `pseries_tail_explicit` — textbook form `1/((p−1)·N^{p−1})` (`Real.rpow_neg`).
- Witnesses: Basel rate `∑_{n>N} 1/n² ≤ 1/N`; concrete truncation-error bound for `∑ 1/n²`.

### Verification
- 161 lines, 4 theorems, 0 definitions, **0 sorries, 0 axioms** (only foundational `propext`/`Classical.choice`/`Quot.sound`; no `native_decide`).
- `status: verified`, `badge: original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)