### PR TITLE
research(cauchy-interlacing-theorem-oq-01-oq-01-oq-02): principal-submatrix eigenvalue interlacing corollary [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CauchyInterlacingOQ01OQ01OQ02.lean
@@ -1,0 +1,294 @@
+import Mathlib
+import Proofs.CauchyInterlacingOQ01OQ01
+import Proofs.CauchyInterlacingCompression
+
+/-
+# Cauchy interlacing for principal submatrices: the eigenvalue corollary
+
+`Proofs/CauchyInterlacingOQ01OQ01.lean` (`cauchy-interlacing-theorem-oq-01-oq-01`)
+proves the **geometric identification**: the orthogonal compression of
+`toEuclideanLin A` to the coordinate hyperplane
+`H = span {e_{j.succAbove i}}` has, on the natural basis `e_{j.succAbove i}`,
+*sesquilinear form exactly the principal submatrix*
+`A.submatrix j.succAbove j.succAbove`
+(`compress_inner_eq_principalSubmatrix`). It records as its first open question:
+
+> *Assemble the matrix-level eigenvalue corollary: show
+> `compress (toEuclideanLin A) H` is unitarily equivalent to
+> `toEuclideanLin (A.submatrix j.succAbove j.succAbove)` via the isometry
+> `e_{j.succAbove i} ↦ e_i`, so that the principal submatrix's eigenvalues
+> literally interlace `A`'s (`λ_{k+1} ≤ μ_k ≤ λ_k`).*
+
+This file answers it.  The bridge is the **coordinate isometry**
+`coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ[𝕜] H`, `e_i ↦ e_{j.succAbove i}`,
+under which the compression *is* `toEuclideanLin A'`:
+
+  `compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x)`
+      (`compress_intertwine`).
+
+Pushing `A'`'s spectral eigenbasis through `coordEquiv` gives an eigenbasis of
+the compression with the *same antitone eigenvalues* — no eigenvalue-uniqueness
+lemma is needed — which feeds the abstract `cauchy_interlacing` of
+`CauchyInterlacingAssembly`.
+
+## Main results
+
+* `compress_intertwine` — the compression and the submatrix operator are
+  intertwined by the coordinate isometry.
+* `principalSubmatrix_eigenvalues_interlacing` — operator-level statement:
+  the descending eigenvalues of `A` and of its principal submatrix `A'`
+  interlace, `lam k.succ ≤ mu k ≤ lam k.castSucc`.
+* `Matrix.IsHermitian.eigenvalues₀_principalSubmatrix_interlacing` — the literal
+  matrix statement in terms of `Matrix.IsHermitian.eigenvalues₀`.
+
+Over any `RCLike` field `𝕜` (so `ℝ` and `ℂ`). Absent from Mathlib.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open Matrix
+open CauchyInterlacingOQ01OQ01
+open CauchyInterlacing.Assembly
+
+namespace CauchyInterlacingOQ01OQ01OQ02
+
+set_option maxHeartbeats 4000000
+set_option synthInstance.maxHeartbeats 1000000
+
+variable {𝕜 : Type*} [RCLike 𝕜] {n : ℕ}
+
+/-! ## Eigenvalues are independent of the `finrank` proof (index bookkeeping) -/
+
+/-- `LinearMap.IsSymmetric.eigenvalues` depends on the dimension proof only through
+its right-hand side: two proofs of `finrank = m` and `finrank = m'` give the same
+eigenvalue list up to the (forced) equality `m = m'`. -/
+theorem eigenvalues_finrank_congr {E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E] {T : E →ₗ[𝕜] E}
+    (hT : T.IsSymmetric) {m m' : ℕ} (hm : Module.finrank 𝕜 E = m)
+    (hm' : Module.finrank 𝕜 E = m') (i : Fin m) :
+    hT.eigenvalues hm i = hT.eigenvalues hm' (Fin.cast (hm.symm.trans hm') i) := by
+  obtain rfl : m = m' := hm.symm.trans hm'
+  simp only [Fin.cast_eq_self]
+
+/-! ## The abstract transfer engine -/
+
+/-- **Cauchy interlacing transfers across an isometric intertwining.**
+
+Let `T` (with antitone eigendata `b, lam`) act on `V`, let `H ≤ V` be a
+codimension-one subspace, and let `T'` (with antitone eigendata `b', mu`) act on
+a model space `E`.  If an isometry `e : E ≃ₗᵢ H` intertwines a symmetric operator
+`TH` on `H` with `T'` (`TH (e x) = e (T' x)`) and `TH` satisfies the Rayleigh
+agreement of the orthogonal compression, then the eigenvalues interlace:
+`lam k.succ ≤ mu k ≤ lam k.castSucc`.
+
+Pushing `T'`'s eigenbasis `b'` through `e` produces an eigenbasis of `TH` with the
+*same* eigenvalues `mu` — so no eigenvalue-uniqueness lemma is needed — which is
+fed to the abstract `cauchy_interlacing`.  Stating it for abstract `V, E` keeps
+the heavy unification generic. -/
+theorem interlacing_of_intertwine {V E : Type*}
+    [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+    [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [FiniteDimensional 𝕜 E]
+    (T : V →ₗ[𝕜] V) (b : OrthonormalBasis (Fin (n + 1)) 𝕜 V) (lam : Fin (n + 1) → ℝ)
+    (hT : ∀ i, T (b i) = (lam i : 𝕜) • b i) (hlam : Antitone lam)
+    (Hs : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 Hs = n)
+    (TH : Hs →ₗ[𝕜] Hs)
+    (T' : E →ₗ[𝕜] E) (b' : OrthonormalBasis (Fin n) 𝕜 E) (mu : Fin n → ℝ)
+    (hT' : ∀ i, T' (b' i) = (mu i : 𝕜) • b' i) (hmu : Antitone mu)
+    (e : E ≃ₗᵢ[𝕜] Hs) (hinter : ∀ x : E, TH (e x) = e (T' x))
+    (hRay : ∀ y : Hs, y ≠ 0 →
+      RCLike.re (@inner 𝕜 Hs _ (TH y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2)
+    (k : Fin n) :
+    lam k.succ ≤ mu k ∧ mu k ≤ lam k.castSucc := by
+  set bH : OrthonormalBasis (Fin n) 𝕜 Hs := b'.map e with hbHdef
+  have hbH : ∀ i, bH i = e (b' i) := fun i => OrthonormalBasis.map_apply _ _ _
+  have hTH : ∀ i, TH (bH i) = (mu i : 𝕜) • bH i := by
+    intro i; rw [hbH, hinter, hT', map_smul]
+  exact CauchyInterlacing.Assembly.cauchy_interlacing T b lam hT hlam Hs hHdim TH bH mu
+    hTH hmu hRay k
+
+/-! ## The coordinate orthonormal basis and the coordinate isometry -/
+
+variable (j : Fin (n + 1))
+
+/-- The natural basis vectors of the coordinate hyperplane are orthonormal. -/
+theorem orthonormal_hyperplaneBasis :
+    Orthonormal 𝕜 (hyperplaneBasis (𝕜 := 𝕜) j) := by
+  have hbase : Orthonormal 𝕜 (fun i : Fin n => e (𝕜 := 𝕜) (j.succAbove i)) :=
+    (EuclideanSpace.orthonormal_single (𝕜 := 𝕜) (ι := Fin (n + 1))).comp _
+      (Fin.succAbove_right_injective (p := j))
+  rw [orthonormal_iff_ite] at hbase ⊢
+  intro i i'
+  rw [Submodule.coe_inner]
+  exact hbase i i'
+
+/-- The natural basis vectors span the coordinate hyperplane. -/
+theorem span_hyperplaneBasis_top :
+    (⊤ : Submodule 𝕜 (coordinateHyperplane (𝕜 := 𝕜) j)) ≤
+      Submodule.span 𝕜 (Set.range (hyperplaneBasis (𝕜 := 𝕜) j)) := by
+  rw [top_le_iff]
+  apply Submodule.map_injective_of_injective
+    (Submodule.subtype_injective (coordinateHyperplane (𝕜 := 𝕜) j))
+  rw [Submodule.map_subtype_top, Submodule.map_span]
+  have : (coordinateHyperplane (𝕜 := 𝕜) j).subtype '' Set.range (hyperplaneBasis (𝕜 := 𝕜) j)
+      = Set.range (fun i : Fin n => e (𝕜 := 𝕜) (j.succAbove i)) := by
+    rw [← Set.range_comp]; rfl
+  rw [this, coordinateHyperplane]
+
+/-- An orthonormal basis of the coordinate hyperplane: `coordBasis i = e_{j.succAbove i}`. -/
+noncomputable def coordBasis : OrthonormalBasis (Fin n) 𝕜 (coordinateHyperplane (𝕜 := 𝕜) j) :=
+  OrthonormalBasis.mk (orthonormal_hyperplaneBasis j) (span_hyperplaneBasis_top j)
+
+@[simp] theorem coordBasis_apply (i : Fin n) :
+    coordBasis (𝕜 := 𝕜) j i = hyperplaneBasis j i := by
+  rw [coordBasis, OrthonormalBasis.coe_mk]
+
+/-- The coordinate isometry `EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H`, `e_i ↦ e_{j.succAbove i}`. -/
+noncomputable def coordEquiv :
+    EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ[𝕜] coordinateHyperplane (𝕜 := 𝕜) j :=
+  (coordBasis (𝕜 := 𝕜) j).repr.symm
+
+theorem coordEquiv_eq_sum (x : EuclideanSpace 𝕜 (Fin n)) :
+    coordEquiv (𝕜 := 𝕜) j x = ∑ i, x i • coordBasis (𝕜 := 𝕜) j i := by
+  rw [coordEquiv, OrthonormalBasis.sum_repr_symm]
+
+/-- Reading off a coordinate of the isometry image against the basis returns the
+input coordinate: `⟪coordBasis i', coordEquiv x⟫ = x i'`. -/
+theorem coordBasis_inner_coordEquiv (x : EuclideanSpace 𝕜 (Fin n)) (i' : Fin n) :
+    @inner 𝕜 _ _ (coordBasis (𝕜 := 𝕜) j i') (coordEquiv (𝕜 := 𝕜) j x) = x i' := by
+  rw [← OrthonormalBasis.repr_apply_apply]
+  have h : (coordBasis (𝕜 := 𝕜) j).repr (coordEquiv (𝕜 := 𝕜) j x) = x :=
+    (coordBasis (𝕜 := 𝕜) j).repr.apply_symm_apply x
+  rw [h]
+
+/-! ## The intertwining: the compression is the submatrix operator -/
+
+variable (A : Matrix (Fin (n + 1)) (Fin (n + 1)) 𝕜)
+
+/-- Abbreviation for the principal submatrix obtained by deleting row/column `j`. -/
+local notation "A'" => A.submatrix j.succAbove j.succAbove
+
+/-- **The intertwining on a single coordinate basis vector.** This is the only
+place a submodule inner product is needed, and exactly one entry is read off via
+`compress_inner_eq_principalSubmatrix` — mirroring the parent file. -/
+theorem compress_coordBasis (i₀ : Fin n) :
+    compress (Matrix.toEuclideanLin A) (coordinateHyperplane j) (coordBasis (𝕜 := 𝕜) j i₀)
+      = coordEquiv (𝕜 := 𝕜) j (Matrix.toEuclideanLin A' (EuclideanSpace.single i₀ (1 : 𝕜))) := by
+  apply (coordBasis (𝕜 := 𝕜) j).repr.injective
+  ext i'
+  rw [OrthonormalBasis.repr_apply_apply, OrthonormalBasis.repr_apply_apply,
+    coordBasis_inner_coordEquiv, coordBasis_apply, coordBasis_apply,
+    compress_inner_eq_principalSubmatrix]
+  simp [Matrix.toEuclideanLin_apply, Matrix.mulVec_single, PiLp.toLp_apply,
+    EuclideanSpace.ofLp_single]
+
+/-- **The intertwining.** Under the coordinate isometry `coordEquiv`, the
+orthogonal compression of `toEuclideanLin A` to the coordinate hyperplane is the
+operator of the principal submatrix:
+
+  `compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x)`.
+
+Proved by expanding `x` in the standard basis of `EuclideanSpace 𝕜 (Fin n)` and
+pushing `compress`, `toEuclideanLin A'` and `coordEquiv` through the sum with
+`map_sum`/`map_smul` (purely rewrite-based, so the isometry is never unfolded),
+reducing each term to `compress_coordBasis`. -/
+theorem compress_intertwine (x : EuclideanSpace 𝕜 (Fin n)) :
+    compress (Matrix.toEuclideanLin A) (coordinateHyperplane j) (coordEquiv (𝕜 := 𝕜) j x)
+      = coordEquiv (𝕜 := 𝕜) j (Matrix.toEuclideanLin A' x) := by
+  have hx : x = ∑ i, x i • EuclideanSpace.single i (1 : 𝕜) := by
+    conv_lhs => rw [← (EuclideanSpace.basisFun (Fin n) 𝕜).sum_repr x]
+    simp_rw [EuclideanSpace.basisFun_repr, EuclideanSpace.basisFun_apply]
+  rw [coordEquiv_eq_sum, map_sum]
+  conv_rhs => rw [hx, map_sum]
+  simp_rw [map_smul, compress_coordBasis, map_sum, map_smul]
+
+/-! ## The eigenvalue interlacing corollary -/
+
+variable (hA : A.IsHermitian)
+
+/-- **Cauchy interlacing for a principal submatrix (operator-eigenvalue form).**
+
+For a Hermitian `(n+1) × (n+1)` matrix `A` and an index `j`, write
+`λ` for the descending eigenvalues of `toEuclideanLin A` and `μ` for those of the
+principal submatrix `A' = A.submatrix j.succAbove j.succAbove` (delete row/column
+`j`).  Then for every `k : Fin n`:
+
+  `λ k.succ ≤ μ k`   and   `μ k ≤ λ k.castSucc`,
+
+i.e. `λ_{k+1} ≤ μ_k ≤ λ_k`.  This is the assembly of the geometric identification
+`compress_inner_eq_principalSubmatrix` (the compression of `toEuclideanLin A` to
+the coordinate hyperplane *is* `toEuclideanLin A'`, via `compress_intertwine`)
+with the abstract Cauchy interlacing theorem. -/
+theorem principalSubmatrix_eigenvalues_interlacing (k : Fin n) :
+    (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin k.succ
+        ≤ (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).eigenvalues
+            finrank_euclideanSpace_fin k
+      ∧ (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).eigenvalues
+            finrank_euclideanSpace_fin k
+          ≤ (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues
+              finrank_euclideanSpace_fin k.castSucc := by
+  -- Rayleigh agreement of the orthogonal compression.
+  have hRay : ∀ y : coordinateHyperplane (𝕜 := 𝕜) j, y ≠ 0 →
+      RCLike.re (@inner 𝕜 _ _
+          (compress (Matrix.toEuclideanLin A) (coordinateHyperplane j) y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + 1))) _
+            (Matrix.toEuclideanLin A (y : EuclideanSpace 𝕜 (Fin (n + 1))))
+            (y : EuclideanSpace 𝕜 (Fin (n + 1)))) / ‖(y : EuclideanSpace 𝕜 (Fin (n + 1)))‖ ^ 2 := by
+    intro y _
+    have hi : @inner 𝕜 _ _ (compress (Matrix.toEuclideanLin A) (coordinateHyperplane j) y) y
+        = @inner 𝕜 (EuclideanSpace 𝕜 (Fin (n + 1))) _
+            (Matrix.toEuclideanLin A (y : EuclideanSpace 𝕜 (Fin (n + 1))))
+            (y : EuclideanSpace 𝕜 (Fin (n + 1))) := by
+      rw [compress_apply, Submodule.inner_orthogonalProjection_eq_of_mem_right]
+    rw [hi, Submodule.coe_norm]
+  exact interlacing_of_intertwine
+    (T := Matrix.toEuclideanLin A)
+    (b := (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvectorBasis finrank_euclideanSpace_fin)
+    (lam := (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin)
+    (hT := (Matrix.isHermitian_iff_isSymmetric.1 hA).apply_eigenvectorBasis _)
+    (hlam := (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues_antitone _)
+    (Hs := coordinateHyperplane j) (hHdim := finrank_coordinateHyperplane j)
+    (TH := compress (Matrix.toEuclideanLin A) (coordinateHyperplane j))
+    (T' := Matrix.toEuclideanLin (A.submatrix j.succAbove j.succAbove))
+    (b' := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).eigenvectorBasis
+      finrank_euclideanSpace_fin)
+    (mu := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).eigenvalues
+      finrank_euclideanSpace_fin)
+    (hT' := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).apply_eigenvectorBasis _)
+    (hmu := (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).eigenvalues_antitone _)
+    (e := coordEquiv j) (hinter := compress_intertwine (A := A) (j := j)) (hRay := hRay) (k := k)
+
+/-- **Cauchy interlacing for a principal submatrix (literal `eigenvalues₀` form).**
+
+The descending eigenvalues `Matrix.IsHermitian.eigenvalues₀` of a Hermitian
+`(n+1)×(n+1)` matrix `A` and of its principal submatrix
+`A' = A.submatrix j.succAbove j.succAbove` interlace:
+
+  `A.eigenvalues₀ (k+1) ≤ A'.eigenvalues₀ k ≤ A.eigenvalues₀ k`,
+
+read through the index identifications `Fin (n+1) ≃ Fin (card)` and
+`Fin n ≃ Fin (card)`.  This is the literal matrix statement requested by the
+parent entry's open question. -/
+theorem eigenvalues₀_principalSubmatrix_interlacing (k : Fin n) :
+    hA.eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm k.succ)
+        ≤ (hA.submatrix j.succAbove).eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm k)
+      ∧ (hA.submatrix j.succAbove).eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm k)
+          ≤ hA.eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm k.castSucc) := by
+  -- `eigenvalues₀` is `eigenvalues finrank_euclideanSpace`; bridge to the
+  -- `finrank_euclideanSpace_fin` indexing used in the operator statement.
+  have bridgeA : ∀ i : Fin (n + 1),
+      (Matrix.isHermitian_iff_isSymmetric.1 hA).eigenvalues finrank_euclideanSpace_fin i
+        = hA.eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm i) := fun i =>
+    eigenvalues_finrank_congr _ finrank_euclideanSpace_fin finrank_euclideanSpace i
+  have bridgeA' : ∀ i : Fin n,
+      (Matrix.isHermitian_iff_isSymmetric.1 (hA.submatrix j.succAbove)).eigenvalues
+          finrank_euclideanSpace_fin i
+        = (hA.submatrix j.succAbove).eigenvalues₀ (Fin.cast (Fintype.card_fin _).symm i) :=
+    fun i => eigenvalues_finrank_congr _ finrank_euclideanSpace_fin finrank_euclideanSpace i
+  obtain ⟨hlo, hup⟩ := principalSubmatrix_eigenvalues_interlacing j A hA k
+  rw [bridgeA, bridgeA'] at hlo
+  rw [bridgeA', bridgeA] at hup
+  exact ⟨hlo, hup⟩
+
+end CauchyInterlacingOQ01OQ01OQ02

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-interlacing-of-intertwine",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 87, "endLine": 111 },
+    "type": "insight",
+    "title": "Transfer Engine: Interlacing Across an Isometric Intertwining",
+    "content": "`interlacing_of_intertwine` is the reusable core. Given a symmetric operator `T` on `V` (antitone eigendata `b, lam`), a codimension-one `H ≤ V`, a model operator `T'` on `E` (antitone eigendata `b', mu`), an isometry `e : E ≃ₗᵢ H`, and the intertwining `TH (e x) = e (T' x)`, it concludes `lam k.succ ≤ mu k ≤ lam k.castSucc`. The proof simply maps `T'`'s eigenbasis through `e` (`b'.map e`) to obtain an eigenbasis of the compression with the SAME eigenvalues `mu`, then invokes the abstract `cauchy_interlacing`.",
+    "mathContext": "If S = e ∘ T' ∘ e⁻¹ and b' diagonalizes T', then e∘b' diagonalizes S with identical eigenvalues; unitary equivalence preserves the spectrum.",
+    "significance": "key",
+    "relatedConcepts": ["unitary equivalence", "spectral transport", "compression", "Cauchy interlacing"],
+    "prerequisites": ["orthonormal eigenbasis from the spectral theorem", "Rayleigh quotient of a compression"]
+  },
+  {
+    "id": "ann-coord-equiv",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 138, "endLine": 165 },
+    "type": "construction",
+    "title": "The Coordinate Isometry e_i ↦ e_{j.succAbove i}",
+    "content": "The orthonormal family of standard basis vectors other than `e_j` is packaged by `OrthonormalBasis.mk` into `coordBasis`, an orthonormal basis of the coordinate hyperplane. Its inverse representation `coordEquiv := coordBasis.repr.symm` is the linear isometry equivalence `EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H` sending `e_i` to `e_{j.succAbove i}`. The helper `coordBasis_inner_coordEquiv` records that reading a coordinate of `coordEquiv x` against `coordBasis i'` returns `x i'`.",
+    "mathContext": "An orthonormal basis B of an n-dimensional inner product space induces an isometry to EuclideanSpace 𝕜 (Fin n) via the coordinate representation B.repr.",
+    "significance": "important",
+    "relatedConcepts": ["orthonormal basis", "linear isometry equivalence", "coordinate hyperplane", "Fin.succAbove"],
+    "prerequisites": ["OrthonormalBasis.mk", "OrthonormalBasis.repr"]
+  },
+  {
+    "id": "ann-compress-intertwine",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 173, "endLine": 219 },
+    "type": "insight",
+    "title": "The Compression Is the Submatrix Operator",
+    "content": "`compress_coordBasis` checks the intertwining on a single coordinate vector: `coordBasis.repr.injective` reduces it to one submodule inner product, read off by the previous entry's `compress_inner_eq_principalSubmatrix` as an entry of `A' = A.submatrix j.succAbove j.succAbove`. `compress_intertwine` then extends to all `x` by expanding in the standard basis and pushing `compress`, `toEuclideanLin A'` and `coordEquiv` through the sum with `map_sum`/`map_smul`. Keeping these as rewrite lemmas (rather than linear-map-composition coercions) is essential: it leaves the `OrthonormalBasis.mk`-built isometry opaque, avoiding a definitional-unfolding blow-up.",
+    "mathContext": "The orthogonal compression P_H ∘ A ∘ ι_H, conjugated by the coordinate isometry, is exactly the principal submatrix operator on the smaller space.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonal compression", "principal submatrix", "intertwining", "map_sum"],
+    "prerequisites": ["compress_inner_eq_principalSubmatrix (parent entry)", "linearity of toEuclideanLin and isometries"]
+  },
+  {
+    "id": "ann-eigenvalues-corollary",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 221, "endLine": 292 },
+    "type": "result",
+    "title": "The Literal Matrix Cauchy Interlacing Theorem",
+    "content": "`principalSubmatrix_eigenvalues_interlacing` instantiates the transfer engine with the coordinate isometry, giving `λ_{k+1} ≤ μ_k ≤ λ_k` for the symmetric-operator eigenvalues of `A` and its principal submatrix. Because `Matrix.IsHermitian.eigenvalues₀` is by definition the operator's eigenvalues, the only remaining gap is the `Fin (card) ↔ Fin (n+1)` reindexing, discharged by `eigenvalues_finrank_congr` to yield the literal `eigenvalues₀`-level statement `eigenvalues₀_principalSubmatrix_interlacing`.",
+    "mathContext": "Cauchy interlacing: for Hermitian A (size n+1) and principal submatrix A' (delete row/col j), λ_{k+1}(A) ≤ λ_k(A') ≤ λ_k(A).",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy interlacing theorem", "Matrix.IsHermitian.eigenvalues₀", "principal submatrix"],
+    "prerequisites": ["the transfer engine", "eigenvalues₀ as operator eigenvalues"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+  "title": "Cauchy Interlacing for a Principal Submatrix: the Eigenvalue Corollary",
+  "description": "Assembles the literal matrix Cauchy interlacing theorem: the descending eigenvalues of a Hermitian (n+1)×(n+1) matrix and of any principal submatrix obtained by deleting one row and the matching column interlace, λ_{k+1} ≤ μ_k ≤ λ_k. The bridge is a coordinate isometry under which the orthogonal compression of the matrix operator IS the submatrix operator, so the submatrix's spectral eigenbasis transports to an eigenbasis of the compression with the same antitone eigenvalues, which feeds the gallery's abstract Cauchy interlacing theorem. 0 axioms, 0 sorries.",
+  "meta": {
+    "status": "verified",
+    "badge": "mathlib",
+    "axiomCount": 0,
+    "difficulty": "advanced",
+    "category": "linear-algebra",
+    "tags": [
+      "Cauchy interlacing",
+      "eigenvalues",
+      "Hermitian matrices",
+      "principal submatrix",
+      "orthogonal compression",
+      "spectral theorem",
+      "inner product spaces"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingOQ01OQ01",
+      "Proofs.CauchyInterlacingCompression"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "Matrix",
+      "CauchyInterlacingOQ01OQ01",
+      "CauchyInterlacing.Assembly"
+    ],
+    "namespace": "CauchyInterlacingOQ01OQ01OQ02",
+    "lineCount": 292,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "path": "Proofs/CauchyInterlacingOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 assembly of the literal matrix Cauchy interlacing theorem from the geometric identification of the previous entry. For a Hermitian A : Matrix (Fin (n+1)) (Fin (n+1)) 𝕜 and an index j, write λ for the descending eigenvalues (Matrix.IsHermitian.eigenvalues₀) of A and μ for those of the principal submatrix A' = A.submatrix j.succAbove j.succAbove. Then for every k : Fin n, λ_{k+1} ≤ μ_k ≤ λ_k. The file builds the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H onto the coordinate hyperplane, proves the intertwining compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x) (compress_intertwine), and packages a reusable transfer engine (interlacing_of_intertwine) that converts such an intertwining into interlacing without any eigenvalue-uniqueness lemma. The result is 0-axiom, 0-sorry; both an operator-eigenvalue form and the literal eigenvalues₀ form are provided.",
+    "implications": "Closes the first open question of cauchy-interlacing-theorem-oq-01-oq-01: the geometric fact that the compression's sesquilinear form is the principal submatrix (compress_inner_eq_principalSubmatrix) is upgraded to the spectral statement that the submatrix's eigenvalues literally interlace the parent's. Together with the parent chain this gives the full textbook Cauchy interlacing theorem for an arbitrary deleted row/column in Lean, a result still absent from Mathlib. The transfer engine interlacing_of_intertwine and the coordinate isometry coordEquiv are reusable for any unitary-equivalence transport of compression spectra.",
+    "openQuestions": [
+      "Iterate the single-deletion corollary to the Poincaré separation theorem for compression onto an arbitrary coordinate subspace of codimension m, λ_i ≤ μ_i ≤ λ_{i+m}, by composing the coordinate isometries (the abstract codimension-m statement is already proved as cauchy-interlacing-theorem-oq-02; the remaining step is the matrix-level identification for a multi-index deletion).",
+      "Derive the eigenvalue majorization and the interlacing-implies-positive-semidefiniteness corollaries (e.g. that every principal submatrix of a PSD matrix is PSD) directly from the eigenvalues₀ interlacing bound."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cauchy's interlacing theorem (1829) states that the eigenvalues of a principal submatrix of a Hermitian matrix interlace those of the matrix itself: if A is (n+1)×(n+1) Hermitian with descending eigenvalues λ₁ ≥ … ≥ λ_{n+1} and B is the n×n principal submatrix obtained by deleting one row and the matching column, with descending eigenvalues μ₁ ≥ … ≥ μ_n, then λ_{k+1} ≤ μ_k ≤ λ_k. The conceptual proof identifies B with the compression of A to a coordinate subspace and applies the variational (Courant–Fischer) characterization of eigenvalues. The lean-genius gallery first proved the abstract compression interlacing inequality (cauchy-interlacing-theorem-oq-01), then identified the compression's sesquilinear form with the principal submatrix (cauchy-interlacing-theorem-oq-01-oq-01). What remained — and is supplied here — was to pass from the form-level identification to the spectral-level conclusion, i.e. that the submatrix's eigenvalues themselves interlace.",
+    "problemStatement": "The previous entry proved that the orthogonal compression of toEuclideanLin A to the coordinate hyperplane H has, on the natural basis, sesquilinear form exactly the principal submatrix A' = A.submatrix j.succAbove j.succAbove. It left as its first open question: assemble the matrix-level eigenvalue corollary — exhibit a unitary equivalence of compress (toEuclideanLin A) H with toEuclideanLin A' so that the principal submatrix's eigenvalues literally interlace A's, λ_{k+1} ≤ μ_k ≤ λ_k.\n\n**Answer.** Build the coordinate isometry coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H sending e_i ↦ e_{j.succAbove i}. Under it the compression IS the submatrix operator: compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x). Transporting the submatrix's spectral eigenbasis through coordEquiv yields an eigenbasis of the compression with the same antitone eigenvalues, which the abstract Cauchy interlacing theorem turns into λ_{k+1} ≤ μ_k ≤ λ_k.",
+    "text": "Under the coordinate isometry that identifies a coordinate hyperplane with a smaller Euclidean space, the orthogonal compression of a Hermitian matrix operator is the principal-submatrix operator; transporting the submatrix's eigenbasis therefore makes the principal submatrix's eigenvalues interlace the parent matrix's.",
+    "proofStrategy": "Three pieces. (1) The coordinate isometry. The n vectors e_{j.succAbove i} (all standard basis vectors except e_j) are an orthonormal family; OrthonormalBasis.mk packages them as coordBasis, an orthonormal basis of the coordinate hyperplane H, and coordEquiv := coordBasis.repr.symm is the resulting isometry EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H, e_i ↦ e_{j.succAbove i}. (2) The intertwining (compress_intertwine). On a single coordinate vector, coordBasis.repr.injective reduces the goal to one submodule inner product, which the previous entry's compress_inner_eq_principalSubmatrix reads off as an entry of A' (compress_coordBasis); the general case follows by expanding x in the standard basis and pushing compress, toEuclideanLin A' and coordEquiv through the sum with map_sum/map_smul — purely rewrite-based, so the isometry is never definitionally unfolded. (3) The transfer engine (interlacing_of_intertwine). Given the intertwining compress T H (e x) = e (T' x), the image b'.map e of the submatrix's spectral eigenbasis b' is an eigenbasis of the compression with the same antitone eigenvalues; combined with the orthogonal compression's Rayleigh agreement, the gallery's abstract cauchy_interlacing produces λ_{k+1} ≤ μ_k ≤ λ_k. No eigenvalue-uniqueness lemma is required because the eigenvalues are carried along by the eigenbasis, not re-derived. A small bookkeeping lemma (eigenvalues_finrank_congr) bridges the operator eigenvalues used in the proof to Mathlib's Matrix.IsHermitian.eigenvalues₀ indexing.",
+    "keyInsights": [
+      "The eigenvalue corollary needs no eigenvalue-uniqueness theorem: pushing the submatrix's spectral eigenbasis through the coordinate isometry directly produces an eigenbasis of the compression with the SAME antitone eigenvalues, which the abstract interlacing theorem consumes as-is",
+      "The intertwining compress(A) ∘ e = e ∘ submatrix(A) is the precise spectral meaning of the previous entry's form-level identification, and it suffices to check it on a single coordinate vector before extending by linearity",
+      "Working through map_sum/map_smul rewrites rather than linear-map-composition coercions keeps the orthonormal-basis isometry opaque, avoiding the definitional-unfolding blow-up that the OrthonormalBasis.mk construction would otherwise trigger",
+      "Mathlib's Matrix.IsHermitian.eigenvalues₀ is by definition the symmetric operator's eigenvalues, so the only gap between the operator proof and the literal matrix statement is the Fin (card) ↔ Fin (n+1) reindexing, discharged once and for all by eigenvalues_finrank_congr"
+    ],
+    "prerequisites": [
+      "Hermitian matrices, their real eigenvalues, and Matrix.IsHermitian.eigenvalues₀",
+      "The spectral theorem: orthonormal eigenbases and antitone eigenvalue lists for symmetric operators",
+      "Orthogonal compression of an operator to a subspace and its Rayleigh-quotient agreement",
+      "Linear isometry equivalences, orthonormal bases (OrthonormalBasis.mk, repr), and EuclideanSpace ↔ matrix correspondence"
+    ]
+  },
+  "sections": [
+    {
+      "title": "The Coordinate Isometry",
+      "content": "The natural basis vectors e_{j.succAbove i} of the coordinate hyperplane are orthonormal (orthonormal_hyperplaneBasis) and span it (span_hyperplaneBasis_top), so OrthonormalBasis.mk assembles them into coordBasis : OrthonormalBasis (Fin n) 𝕜 H. Its inverse representation coordEquiv := coordBasis.repr.symm is the linear isometry equivalence EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H sending the standard basis vector e_i to e_{j.succAbove i}; reading any coordinate of an image against the basis returns the input coordinate (coordBasis_inner_coordEquiv)."
+    },
+    {
+      "title": "The Intertwining: Compression Is the Submatrix Operator",
+      "content": "On a single coordinate vector, coordBasis.repr.injective reduces the intertwining to one submodule inner product, evaluated by the previous entry's compress_inner_eq_principalSubmatrix as an entry of the principal submatrix (compress_coordBasis). Expanding a general x in the standard basis and pushing compress, toEuclideanLin A' and coordEquiv through the sum with map_sum/map_smul yields the full intertwining compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x) (compress_intertwine)."
+    },
+    {
+      "title": "The Transfer Engine and the Eigenvalue Corollary",
+      "content": "interlacing_of_intertwine is a reusable abstract theorem: an isometric intertwining of the compression with a symmetric operator T' transports T''s antitone eigenbasis onto an eigenbasis of the compression with the same eigenvalues, which — with the orthogonal compression's Rayleigh agreement — feeds the gallery's abstract cauchy_interlacing. Instantiating it with the coordinate isometry yields the operator form principalSubmatrix_eigenvalues_interlacing; the bookkeeping lemma eigenvalues_finrank_congr then re-expresses it in Mathlib's Matrix.IsHermitian.eigenvalues₀ indexing as eigenvalues₀_principalSubmatrix_interlacing: λ_{k+1} ≤ μ_k ≤ λ_k."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Cauchy, A.-L.",
+      "title": "Sur l'équation à l'aide de laquelle on détermine les inégalités séculaires des mouvements des planètes",
+      "year": "1829",
+      "note": "Original interlacing theorem"
+    },
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "note": "Cauchy interlacing and the compression/principal-submatrix correspondence (Theorem 4.3.17)"
+    },
+    {
+      "authors": "Bhatia, R.",
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "note": "Eigenvalue interlacing and majorization (Chapter III)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Closes its first open question: upgrades the form-level identification compress_inner_eq_principalSubmatrix to the spectral statement that the principal submatrix's eigenvalues interlace the parent matrix's."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry that proved the eigenvalue-uniqueness keystone (sorted eigenvalues determined by any orthonormal eigenbasis) and posed assembling the headline corollary λ_{k+1}(A) ≤ λ_k(A) ≤ λ_k(A) as its open question. This entry answers that question via an independent transfer-engine route that carries eigenvalues along the transported eigenbasis, so it never needs the uniqueness lemma."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01",
+      "relationship": "related",
+      "description": "Supplies the matrix-level eigenvalue corollary of the abstract compression interlacing inequality proved there."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-02",
+      "relationship": "related",
+      "description": "The abstract codimension-m Poincaré separation theorem, whose matrix-level identification for multi-index deletions is the natural next step."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Assembles the **literal matrix Cauchy interlacing theorem** for a principal submatrix — the capstone of the cauchy-interlacing-theorem-oq-01-oq-01 chain. For a Hermitian `A : Matrix (Fin (n+1)) (Fin (n+1)) 𝕜`, index `j`, and principal submatrix `A' = A.submatrix j.succAbove j.succAbove` (delete row/column `j`):

```
A.eigenvalues₀ (k+1) ≤ A'.eigenvalues₀ k ≤ A.eigenvalues₀ k       (descending, every k : Fin n)
```

This statement is absent from Mathlib and was left as the open question of both predecessors:
- **#27917** (`oq-01-oq-01`) proved the *form*-level identification (the compression's sesquilinear form on the natural basis is the principal submatrix) but not the spectral conclusion.
- **#27958** (`oq-01-oq-01-oq-01`, sibling) proved the eigenvalue-uniqueness *keystone* and explicitly posed "assemble the headline corollary `λ_{k+1}(A) ≤ λ_k(A') ≤ λ_k(A)`" as future work.

This entry delivers that corollary via an **independent route** (it imports #27917, not #27958).

## Approach

1. **Coordinate isometry** `coordEquiv : EuclideanSpace 𝕜 (Fin n) ≃ₗᵢ H`, `e_i ↦ e_{j.succAbove i}`, onto the coordinate hyperplane `H`.
2. **Intertwining** `compress (toEuclideanLin A) H (coordEquiv x) = coordEquiv (toEuclideanLin A' x)` — checked on one coordinate vector via #27917's `compress_inner_eq_principalSubmatrix`, extended by `map_sum`/`map_smul` (rewrite-based, keeping the `OrthonormalBasis.mk` isometry opaque to avoid a definitional blow-up).
3. **Transfer engine** `interlacing_of_intertwine` — transports `A'`'s antitone eigenbasis through the isometry onto an eigenbasis of the compression with the *same* eigenvalues, then feeds the gallery's abstract `cauchy_interlacing`. **No eigenvalue-uniqueness lemma needed** — eigenvalues ride along the eigenbasis.
4. `eigenvalues_finrank_congr` bridges operator eigenvalues to `Matrix.IsHermitian.eigenvalues₀`.

## Verification

- `0` sorries, `0` axioms (`#print axioms` → `propext, Classical.choice, Quot.sound` only).
- Compiles against Mathlib (lean4 v4.26.0). Research file, not registered in `Proofs.lean`.
- Gallery entry added under `src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)