### PR TITLE
Enrich Open Mapping Theorem and its Banach-space consequences

### DIFF
--- a/src/data/proofs/open-mapping-theorem-oq-01/annotations.json
+++ b/src/data/proofs/open-mapping-theorem-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-setup",
+    "proofId": "open-mapping-theorem-oq-01",
+    "range": { "startLine": 33, "endLine": 36 },
+    "type": "context",
+    "title": "The Banach-space Setting",
+    "content": "Everything is stated over a nontrivially normed field 𝕜 and two Banach spaces E, F — `NormedAddCommGroup` + `NormedSpace 𝕜 _` + `CompleteSpace _`. The `CompleteSpace` assumptions on *both* spaces are not cosmetic: completeness is exactly what the entire theory turns on. A continuous linear bijection between incomplete normed spaces can fail to have a continuous inverse; the open mapping theorem is the statement of precisely what completeness, through the Baire category theorem, guarantees.",
+    "mathContext": "$E, F$ Banach spaces over a nontrivially normed field $\\mathbb{K}$; the bounded-linear-map type is $E \\to_L[\\mathbb{K}] F$.",
+    "significance": "context",
+    "relatedConcepts": ["Banach space", "completeness", "bounded linear map", "normed field"],
+    "prerequisites": ["normed vector spaces", "completeness", "functional analysis"]
+  },
+  {
+    "id": "ann-open-mapping",
+    "proofId": "open-mapping-theorem-oq-01",
+    "range": { "startLine": 39, "endLine": 53 },
+    "type": "concept",
+    "title": "The Open Mapping Theorem and Quotient Maps",
+    "content": "`open_mapping` re-exports `ContinuousLinearMap.isOpenMap`: a surjective bounded linear map between Banach spaces sends open sets to open sets. The standard proof runs through Baire category — the image of the unit ball is non-meagre, so contains a ball around 0 — followed by a completeness-powered iteration to drop the closure. `isOpen_image_of_surjective` is the pointwise form one applies in practice, and `quotient_map` records the sharper fact that such a surjection is a quotient map: the topology on F is exactly the one induced from E, with no extra information in F's norm beyond what f transports.",
+    "mathContext": "$f : E \\to_L F$ surjective $\\Rightarrow f$ is open, and $F$ carries the quotient topology induced by $f$.",
+    "significance": "key",
+    "relatedConcepts": ["open map", "quotient map", "Baire category theorem", "surjection", "induced topology"],
+    "prerequisites": ["open maps", "Baire category", "quotient topology"]
+  },
+  {
+    "id": "ann-bounded-inverse",
+    "proofId": "open-mapping-theorem-oq-01",
+    "range": { "startLine": 57, "endLine": 77 },
+    "type": "technique",
+    "title": "The Bounded Inverse Theorem",
+    "content": "Applied to a *bijection*, the open mapping theorem says the set-theoretic inverse is continuous — the bounded inverse theorem, the result that most sharply distinguishes Banach spaces from general normed spaces. `equivOfBijective` packages this as a continuous linear equivalence E ≃L[𝕜] F: take the algebraic `LinearEquiv.ofBijective` and upgrade it with `toContinuousLinearEquivOfContinuous f.continuous`, the inverse's continuity being supplied for free by the open mapping theorem. `exists_bounded_inverse` then reads off the bundled two-sided inverse g : F →L[𝕜] E as the equivalence's `symm`, with `symm_apply_apply` / `apply_symm_apply` discharging the two round-trip identities.",
+    "mathContext": "A continuous linear bijection $f : E \\to_L F$ between Banach spaces is a linear homeomorphism: $\\exists\\, g : F \\to_L E$ with $g \\circ f = \\mathrm{id}$, $f \\circ g = \\mathrm{id}$.",
+    "significance": "key",
+    "relatedConcepts": ["bounded inverse theorem", "continuous linear equivalence", "linear homeomorphism", "ContinuousLinearEquiv.ofBijective"],
+    "prerequisites": ["bijections", "continuous inverses", "linear equivalences"]
+  },
+  {
+    "id": "ann-norm-equiv",
+    "proofId": "open-mapping-theorem-oq-01",
+    "range": { "startLine": 81, "endLine": 103 },
+    "type": "insight",
+    "title": "Norm Equivalence: the Quantitative Corollary",
+    "content": "`norm_equiv_of_bijective` is the one result here assembled rather than re-exported: a continuous linear bijection gives constants 0 < c ≤ C with c‖x‖ ≤ ‖f x‖ ≤ C‖x‖, so the pullback norm x ↦ ‖f x‖ is equivalent to the original. The upper bound is mere continuity: C = ‖f‖ + 1 from `f.le_opNorm`. The lower bound is the genuine content of the open mapping theorem: with the bounded inverse g, ‖x‖ = ‖g(f x)‖ ≤ ‖g‖·‖f x‖, so c = 1/(‖g‖ + 1) works (the +1 keeps the denominator positive without a separate ‖g‖ ≠ 0 case). The two inequalities are closed by `nlinarith` from the operator-norm bounds and `norm_nonneg`. Morally c is 1/‖f⁻¹‖ — the constant the open mapping theorem produces but never names.",
+    "mathContext": "$\\exists\\, 0 < c \\le C,\\ \\forall x:\\ c\\lVert x\\rVert \\le \\lVert f x\\rVert \\le C\\lVert x\\rVert$; lower bound $c = 1/(\\lVert g\\rVert+1)$, upper bound $C = \\lVert f\\rVert + 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm equivalence", "operator norm", "le_opNorm", "graph norm", "nlinarith"],
+    "prerequisites": ["operator norms", "norm inequalities"]
+  },
+  {
+    "id": "ann-closed-graph",
+    "proofId": "open-mapping-theorem-oq-01",
+    "range": { "startLine": 107, "endLine": 131 },
+    "type": "concept",
+    "title": "The Closed Graph Theorem",
+    "content": "Equivalent to the open mapping theorem (it is the bounded inverse theorem applied to the projection from the graph), the closed graph theorem inverts the usual burden of proving an operator bounded: instead of producing an estimate ‖g x‖ ≤ M‖x‖, one checks only that the graph is closed. `closed_graph` re-exports `LinearMap.continuous_of_isClosed_graph` (topological form); `closed_graph_seq` gives the sequential criterion — continuity follows if uₙ → x and g uₙ → y force y = g x — which is usually the form actually verified; and `toContinuousOfClosedGraph` packages the upgrade as a bundled ContinuousLinearMap constructor `ContinuousLinearMap.ofIsClosedGraph`, with a simp lemma confirming it agrees with g pointwise.",
+    "mathContext": "A linear $g : E \\to F$ between Banach spaces with $\\mathrm{graph}(g)$ closed in $E \\times F$ is automatically continuous.",
+    "significance": "key",
+    "relatedConcepts": ["closed graph theorem", "graph of a linear map", "automatic continuity", "sequential continuity"],
+    "prerequisites": ["closed sets", "graphs of functions", "continuity criteria"]
+  },
+  {
+    "id": "ann-concrete-instances",
+    "proofId": "open-mapping-theorem-oq-01",
+    "range": { "startLine": 133, "endLine": 165 },
+    "type": "context",
+    "title": "Non-vacuous Witnesses",
+    "content": "Three examples instantiate the abstract hypotheses to guard against the theorems being formally true but never applicable. The identity of a Banach space is open (the trivial witness). The first-coordinate projection ℝ² → ℝ — `ContinuousLinearMap.fst` with `Prod.fst_surjective` — is a genuinely non-injective surjection that is open. And doubling x ↦ 2x on ℝ, realised as `(2 : ℝ) • ContinuousLinearMap.id`, is shown bijective by hand (injective via linarith, surjective with witness y/2) so that `norm_equiv_of_bijective` delivers concrete equivalence constants for ‖2x‖ versus ‖x‖.",
+    "mathContext": "Witnesses: $\\mathrm{id}_E$ open; $\\mathrm{Prod.fst} : \\mathbb{R}^2 \\to \\mathbb{R}$ open and non-injective; $x \\mapsto 2x$ a bijection with norm equivalent to the standard one.",
+    "significance": "context",
+    "relatedConcepts": ["coordinate projection", "identity map", "scalar multiplication", "concrete examples"],
+    "prerequisites": ["product spaces", "linear maps on ℝ"]
+  }
+]

--- a/src/data/proofs/open-mapping-theorem-oq-01/index.ts
+++ b/src/data/proofs/open-mapping-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/OpenMappingTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const openMappingTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const openMappingTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const openMappingTheoremOQ01Data: ProofData = {
+  proof: openMappingTheoremOQ01Proof,
+  annotations: openMappingTheoremOQ01Annotations,
+}

--- a/src/data/proofs/open-mapping-theorem-oq-01/meta.json
+++ b/src/data/proofs/open-mapping-theorem-oq-01/meta.json
@@ -17,6 +17,7 @@
     "sorries": 0
   },
   "title": "The Open Mapping Theorem and its Banach-space Consequences",
+  "description": "The Banach open mapping theorem — a surjective bounded linear map between Banach spaces is open — and the family of structural consequences flowing from it: the surjection is a quotient map; a continuous linear bijection has a bounded two-sided inverse (the bounded inverse theorem), packaged both as an explicit map and as a continuous linear equivalence E ≃L[𝕜] F; the two norms ‖x‖ and ‖f x‖ are equivalent (an explicit corollary not named in Mathlib); and a linear map with closed graph is automatically continuous (the closed graph theorem) in topological, sequential, and bundled forms. Three concrete witnesses (identity, the projection ℝ² → ℝ, doubling on ℝ) confirm the hypotheses are non-vacuous.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -84,6 +85,62 @@
       }
     ]
   },
+  "overview": {
+    "historicalContext": "The open mapping theorem is one of the three pillars of linear functional analysis, standing beside the Hahn–Banach theorem and the Banach–Steinhaus uniform boundedness principle. All three were crystallised in Stefan Banach's 1932 monograph Théorie des opérations linéaires, the founding text of the field, building on the Baire category theorem (1899). The decisive role of completeness — the 'Banach' in Banach space — is most visible here: a continuous linear bijection between general normed spaces need not have a continuous inverse, but between complete spaces it always does. The standard proof uses Baire category to show the image of the unit ball contains a neighbourhood of the origin, then an iteration/series argument (requiring completeness of the domain) to remove the closure. The closed graph theorem, equivalent to the open mapping theorem, became the everyday tool for proving operators bounded without estimating them directly — one instead checks the often far easier condition that the graph is closed.",
+    "problemStatement": "Let $E$, $F$ be Banach spaces over a nontrivially normed field $\\mathbb{K}$ and $f : E \\to_L F$ a bounded linear map. Show: (i) if $f$ is surjective it is an open map and a quotient map; (ii) if $f$ is bijective it has a bounded linear two-sided inverse, so it is a linear homeomorphism $E \\simeq_L F$ and there exist $0 < c \\le C$ with $c\\lVert x\\rVert \\le \\lVert f x\\rVert \\le C\\lVert x\\rVert$; and (iii) any linear $g : E \\to F$ whose graph is closed in $E \\times F$ is automatically continuous.",
+    "proofStrategy": "Every result is sourced from Mathlib's Analysis.Normed.Operator.Banach and repackaged under textbook-faithful names. open_mapping and isOpen_image_of_surjective re-export ContinuousLinearMap.isOpenMap; quotient_map re-exports isQuotientMap. The bounded inverse theorem is obtained by building the continuous linear equivalence equivOfBijective from LinearEquiv.ofBijective upgraded via toContinuousLinearEquivOfContinuous, then reading off its symm as the bounded inverse g in exists_bounded_inverse. The only genuinely assembled result is norm_equiv_of_bijective: the upper bound c‖x‖ ≤ ‖f x‖ ≤ C‖x‖ takes C = ‖f‖ + 1 from f.le_opNorm, and the lower bound takes c = 1/(‖g‖ + 1) from ‖x‖ = ‖g(f x)‖ ≤ ‖g‖·‖f x‖, closed by nlinarith. The closed graph theorem is re-exported in topological (closed_graph), sequential (closed_graph_seq), and bundled-constructor (toContinuousOfClosedGraph) forms. Three examples instantiate the hypotheses concretely.",
+    "keyInsights": [
+      "Completeness is the entire content. A continuous linear bijection between incomplete normed spaces can have an unbounded inverse; it is exactly the completeness of both spaces (through Baire category) that forces the inverse to be bounded. The open mapping theorem is the precise statement of what completeness buys.",
+      "One theorem, four faces. Open mapping, quotient map, bounded inverse, and closed graph are not four results but one, viewed through different functorial lenses. The bounded inverse theorem is the open mapping theorem applied to a bijection; the closed graph theorem is the bounded inverse theorem applied to the projection from the graph. The entry makes this unity explicit by deriving them in sequence.",
+      "The norm-equivalence corollary is the quantitative shadow. Saying f is a linear homeomorphism is the same as saying the original norm and the pullback norm x ↦ ‖f x‖ are equivalent; the lower constant c is morally 1/‖f⁻¹‖, and it is precisely the constant the open mapping theorem produces but does not name.",
+      "The closed graph theorem inverts the usual burden of proof. To show an operator is bounded one would normally produce an estimate ‖g x‖ ≤ M‖x‖; the closed graph theorem replaces this with checking that the graph is closed — i.e. that uₙ → x and g uₙ → y force y = g x — which is frequently automatic and sidesteps any explicit constant.",
+      "Hypotheses are not vacuous. The projection ℝ² → ℝ is a genuinely non-injective surjection that is open, and doubling x ↦ 2x is a non-trivial bijection whose norm equivalence the abstract corollary delivers — guarding against the theorems being formally true but never instantiable."
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Setup: Banach Spaces over a Normed Field",
+      "startLine": 29,
+      "endLine": 36,
+      "summary": "Opens the OpenMappingTheoremOQ01 namespace and fixes the ambient data: a nontrivially normed field 𝕜 and two Banach spaces E, F over it (NormedAddCommGroup + NormedSpace + CompleteSpace). Completeness of both spaces is the hypothesis every result below depends on."
+    },
+    {
+      "id": "open-mapping",
+      "title": "The Open Mapping Theorem",
+      "startLine": 37,
+      "endLine": 53,
+      "summary": "open_mapping re-exports ContinuousLinearMap.isOpenMap: a surjective bounded linear map is open. isOpen_image_of_surjective is its pointwise form (open sets map to open sets), and quotient_map records that such a surjection is a quotient map, so F carries exactly the induced quotient topology."
+    },
+    {
+      "id": "bounded-inverse",
+      "title": "The Bounded Inverse Theorem",
+      "startLine": 55,
+      "endLine": 77,
+      "summary": "equivOfBijective upgrades a continuous linear bijection to a continuous linear equivalence E ≃L[𝕜] F via LinearEquiv.ofBijective + toContinuousLinearEquivOfContinuous, with a simp lemma fixing its action. exists_bounded_inverse then extracts the two-sided bounded inverse g : F →L[𝕜] E by reading off the equivalence's symm."
+    },
+    {
+      "id": "norm-equivalence",
+      "title": "Norm Equivalence",
+      "startLine": 79,
+      "endLine": 103,
+      "summary": "norm_equiv_of_bijective is the one assembled (not directly re-exported) result: a continuous linear bijection gives 0 < c ≤ C with c‖x‖ ≤ ‖f x‖ ≤ C‖x‖. Upper bound C = ‖f‖ + 1 from f.le_opNorm; lower bound c = 1/(‖g‖ + 1) from ‖x‖ = ‖g(f x)‖ ≤ ‖g‖·‖f x‖, discharged by nlinarith."
+    },
+    {
+      "id": "closed-graph",
+      "title": "The Closed Graph Theorem",
+      "startLine": 105,
+      "endLine": 131,
+      "summary": "closed_graph re-exports LinearMap.continuous_of_isClosed_graph (a linear map with closed graph is continuous); closed_graph_seq gives the sequential criterion (uₙ → x, g uₙ → y ⟹ y = g x); and toContinuousOfClosedGraph packages the upgrade as a bundled ContinuousLinearMap constructor with its defining simp lemma."
+    },
+    {
+      "id": "concrete-instances",
+      "title": "Concrete Instances",
+      "startLine": 133,
+      "endLine": 165,
+      "summary": "Three examples confirming the hypotheses are inhabited: the identity of a Banach space is open; the coordinate projection ℝ² → ℝ is an open non-injective surjection; and doubling x ↦ 2x on ℝ is a continuous linear bijection whose norm equivalence is delivered by norm_equiv_of_bijective."
+    }
+  ],
   "openQuestions": [
     {
       "id": "open-mapping-theorem-oq-01-oq-01",
@@ -96,7 +153,18 @@
       "significance": "low"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "baire-category-theorem-oq-01",
+      "relationship": "foundational",
+      "description": "The open mapping theorem rests directly on the Baire category theorem: Baire is what shows the image of the unit ball under a surjection is non-meagre, hence contains a neighbourhood of the origin. Without completeness (which powers Baire) the open mapping theorem fails."
+    },
+    {
+      "targetId": "banach-steinhaus-theorem-oq-01",
+      "relationship": "sibling",
+      "description": "The third cornerstone of linear functional analysis alongside this entry and Hahn–Banach. Banach–Steinhaus (uniform boundedness) is, like the open mapping theorem, a Baire-category consequence of completeness; together they form the structural backbone of the theory of bounded operators on Banach spaces."
+    }
+  ],
   "references": [
     {
       "title": "Mathlib4: Analysis.Normed.Operator.Banach",
@@ -115,7 +183,7 @@
   ],
   "sorries": 0,
   "conclusion": {
-    "summary": "The Banach open mapping theorem states that a surjective bounded linear map between Banach spaces is open. This entry re-exports it (open_mapping, with the pointwise isOpen_image_of_surjective) together with the family of structural consequences that flow from it: the surjection is a quotient map (quotient_map); a continuous linear bijection has a continuous two-sided inverse — the bounded inverse theorem — packaged both as an explicit g : F →L[𝕜] E (exists_bounded_inverse) and as a continuous linear equivalence E ≃L[𝕜] F (equivOfBijective); and a linear map between Banach spaces with closed graph is automatically continuous — the closed graph theorem — in topological (closed_graph), sequential (closed_graph_seq) and bundled (toContinuousOfClosedGraph) forms. The content not packaged as a single named Mathlib lemma is norm_equiv_of_bijective: a continuous linear bijection produces explicit constants 0 < c ≤ C with c‖x‖ ≤ ‖f x‖ ≤ C‖x‖, the upper bound from continuity and the lower bound from the inverse furnished by the open mapping theorem. Three concrete instances (identity, the projection ℝ² → ℝ, and doubling on ℝ) confirm the hypotheses are non-vacuous. 172 lines, 9 theorems, 2 definitions, 0 axioms, 0 sorries.",
+    "summary": "The Banach open mapping theorem states that a surjective bounded linear map between Banach spaces is open. This entry re-exports it (open_mapping, with the pointwise isOpen_image_of_surjective) together with the family of structural consequences that flow from it: the surjection is a quotient map (quotient_map); a continuous linear bijection has a continuous two-sided inverse — the bounded inverse theorem — packaged both as an explicit g : F →L[𝕜] E (exists_bounded_inverse) and as a continuous linear equivalence E ≃L[𝕜] F (equivOfBijective); and a linear map between Banach spaces with closed graph is automatically continuous — the closed graph theorem — in topological (closed_graph), sequential (closed_graph_seq) and bundled (toContinuousOfClosedGraph) forms. The content not packaged as a single named Mathlib lemma is norm_equiv_of_bijective: a continuous linear bijection produces explicit constants 0 < c ≤ C with c‖x‖ ≤ ‖f x‖ ≤ C‖x‖, the upper bound from continuity and the lower bound from the inverse furnished by the open mapping theorem. Three concrete instances (identity, the projection ℝ² → ℝ, and doubling on ℝ) confirm the hypotheses are non-vacuous. 165 lines, 9 theorems, 2 definitions, 0 axioms, 0 sorries.",
     "implications": "The open mapping theorem and its corollaries are delegated to Mathlib; the curation value is the uniform textbook-faithful packaging of the four linked consequences of completeness — open mapping, quotient map, bounded inverse, closed graph — under one roof, together with the explicit norm-equivalence corollary and concrete witnesses. This completes a functional-analysis trio in the gallery alongside the Banach–Steinhaus uniform boundedness principle and the Baire category theorem on which the open mapping theorem rests.",
     "openQuestions": [
       "Apply the closed graph theorem to obtain a Hellinger–Toeplitz boundedness result.",


### PR DESCRIPTION
Enrichment pass for `open-mapping-theorem-oq-01`. The entry previously had only metadata + a conclusion — no overview, sections, annotations, or Vite entry point.

## Changes
- **Created `index.ts`** — without it the page rendered 'proof not found' on the live site.
- **Created `annotations.json`** — 6 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) spanning the setup, open mapping + quotient map, bounded inverse theorem, the assembled norm-equivalence corollary, the closed graph theorem (3 forms), and the concrete witnesses.
- **Added `overview`** — `historicalContext` (Banach 1932, the three pillars, the decisive role of completeness), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **Added 6 `sections`** covering the full 165-line Lean file.
- **Added top-level `description`** and **cross-references** to `baire-category-theorem-oq-01` (foundational) and `banach-steinhaus-theorem-oq-01` (sibling cornerstone).
- **Fixed a line-count typo** in the conclusion (172 → 165).

Faithful to source: all theorems re-export Mathlib's Analysis.Normed.Operator.Banach (consistent with the `mathlib` badge); the only assembled result is `norm_equiv_of_bijective`. `pnpm build` passes; JSON validated.