### PR TITLE
Enrich Erdős Problem #309: The Axiom-Free Upper Bound F(N) ≤ log N + 2

### DIFF
--- a/src/data/proofs/erdos-309-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-309-incomplete-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-309-incomplete-01",
+    "range": { "startLine": 43, "endLine": 64 },
+    "type": "definition",
+    "title": "The Representation Count F(N)",
+    "content": "A self-contained mirror of the parent file's definitions, needed because the parent no longer builds against Mathlib 4.26.0 (removed/relocated imports). `unitFraction n` is 1/n (and 0 at n = 0); `denominatorRange N` is {1,…,N} as range(N+1) \\ {0}; `harmonicNumber N` is the sum of unit fractions over that range; `IsRepresentable N k` says k = ∑_{d∈S} 1/d for some S ⊆ {1,…,N}; and `countRepresentable N` = F(N) counts the representable integers in {0,…,N}. The search is confined to {0,…,N} because, as proved below, every representable integer is bounded by H_N < N.",
+    "mathContext": "$H_N=\\sum_{d=1}^N \\tfrac1d$; $k$ representable $\\iff k=\\sum_{d\\in S}\\tfrac1d,\\ S\\subseteq\\{1,\\dots,N\\}$; $F(N)=|\\{k\\le N:\\ k\\text{ representable}\\}|$.",
+    "significance": "context",
+    "relatedConcepts": ["Egyptian fractions", "unit fractions", "harmonic number", "Erdős problems"],
+    "prerequisites": ["finite sums", "rational numbers", "Finset cardinality"]
+  },
+  {
+    "id": "ann-subset-sum-bound",
+    "proofId": "erdos-309-incomplete-01",
+    "range": { "startLine": 92, "endLine": 98 },
+    "type": "theorem",
+    "title": "Every Representable Integer Is at Most H_N",
+    "content": "`max_representable_le_harmonic`: if k is representable then (k:ℚ) ≤ H_N. The representing set S is a subset of the full denominator range {1,…,N}, and every unit fraction is nonnegative, so the subset sum ∑_{d∈S} 1/d is at most the full sum ∑_{d=1}^N 1/d = H_N (`Finset.sum_le_sum_of_subset_of_nonneg`). This is the entire arithmetic content of the upper bound: representable integers cannot exceed the harmonic number, which grows like log N.",
+    "mathContext": "$k$ representable $\\Rightarrow (k:\\mathbb{Q})=\\sum_{d\\in S}\\tfrac1d\\le\\sum_{d=1}^N\\tfrac1d=H_N$ (nonnegative subset sum).",
+    "significance": "key",
+    "relatedConcepts": ["subset sum", "monotonicity of sums", "nonnegative terms", "harmonic number"],
+    "prerequisites": ["Finset sums", "subset monotonicity"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "erdos-309-incomplete-01",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "technique",
+    "title": "Bridging to Mathlib's harmonic",
+    "content": "`harmonicNumber_eq_harmonic`: the file's custom `harmonicNumber N` equals Mathlib's `harmonic N`. The proof rewrites Mathlib's harmonic via `harmonic_eq_sum_Icc` (H_N = ∑_{d∈Icc 1 N} 1/d), identifies `denominatorRange N = Finset.Icc 1 N`, and checks termwise that `unitFraction d = 1/d` on that set. This bridge is the crux of the formalization: once the custom harmonic number is identified with the library's, all of Mathlib's analytic estimates — crucially `harmonic_le_one_add_log` — become available without re-deriving them.",
+    "mathContext": "$\\texttt{harmonicNumber}\\,N=\\texttt{harmonic}\\,N$, via $\\texttt{denominatorRange}\\,N=\\mathrm{Icc}\\,1\\,N$ and $\\texttt{unitFraction}\\,d=1/d$ there.",
+    "significance": "key",
+    "relatedConcepts": ["Mathlib bridge", "harmonic numbers", "Finset.Icc", "termwise equality"],
+    "prerequisites": ["Mathlib harmonic API", "Finset congruence"]
+  },
+  {
+    "id": "ann-floor-confine",
+    "proofId": "erdos-309-incomplete-01",
+    "range": { "startLine": 116, "endLine": 130 },
+    "type": "theorem",
+    "title": "Confining F(N) to ⌊H_N⌋ + 1 Values",
+    "content": "`countRepresentable_le_floor_harmonic`: F(N) ≤ ⌊H_N⌋ + 1. Since every representable k satisfies (k:ℚ) ≤ H_N, it satisfies k ≤ ⌊H_N⌋ as a natural number (`Nat.le_floor`), so the filtered finset of representable integers is contained in range(⌊H_N⌋ + 1). A cardinality comparison (`Finset.card_le_card`) gives the bound. This converts the analytic 'representable integers are small' into a finite-counting statement — F(N) is at most the number of integers in {0,…,⌊H_N⌋}.",
+    "mathContext": "$(k:\\mathbb{Q})\\le H_N\\Rightarrow k\\le\\lfloor H_N\\rfloor$, so $F(N)\\le\\lfloor H_N\\rfloor+1$ by counting $\\{0,\\dots,\\lfloor H_N\\rfloor\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.floor", "cardinality bound", "Finset.card_le_card", "counting argument"],
+    "prerequisites": ["floor function", "Finset cardinality"]
+  },
+  {
+    "id": "ann-upper-bound",
+    "proofId": "erdos-309-incomplete-01",
+    "range": { "startLine": 132, "endLine": 155 },
+    "type": "insight",
+    "title": "The Headline Bound F(N) ≤ log N + 2 (Axiom-Free)",
+    "content": "`countRepresentable_le_log_add_two`: F(N) ≤ log N + 2, fully machine-checked with zero axioms. The proof chains F(N) ≤ ⌊H_N⌋ + 1 ≤ H_N + 1 (floor under its argument) with the bridge harmonicNumber = harmonic and Mathlib's `harmonic_le_one_add_log` (H_N ≤ 1 + log N): F(N) ≤ (1 + log N) + 1 = log N + 2. This is the 'trivial upper bound' every source on Erdős #309 cites; the value here is that it is now formal and assumption-free, isolating the elementary half of a problem whose depth lies entirely in the lower bound.",
+    "mathContext": "$F(N)\\le\\lfloor H_N\\rfloor+1\\le H_N+1=\\texttt{harmonic}(N)+1\\le(1+\\log N)+1=\\log N+2$.",
+    "significance": "critical",
+    "relatedConcepts": ["trivial upper bound", "harmonic_le_one_add_log", "logarithmic growth", "axiom-free proof"],
+    "prerequisites": ["harmonic number bounds", "real logarithm", "floor inequalities"]
+  },
+  {
+    "id": "ann-lower-bracket",
+    "proofId": "erdos-309-incomplete-01",
+    "range": { "startLine": 159, "endLine": 180 },
+    "type": "theorem",
+    "title": "Trivial Lower Bound and the Final Bracket",
+    "content": "`two_le_countRepresentable`: for N ≥ 1 both 0 (empty sum) and 1 (the singleton {1}) are representable, so the filtered finset contains {0,1} and F(N) ≥ 2. `countRepresentable_bracket` assembles 2 ≤ F(N) ≤ log N + 2 for N ≥ 1. The upper bound is sharp up to the additive constant, but the matching log-ORDER lower bound F(N) ≥ log N − O(log log N) is the deep Yokota direction — axiomatized in the parent entry and deliberately not reproved here. The entry is thus honest about formalizing only the easy half of a solved problem.",
+    "mathContext": "$2\\le F(N)\\le\\log N+2$ for $N\\ge 1$; the deep $F(N)\\ge\\log N-O(\\log\\log N)$ (Yokota) is not reproved.",
+    "significance": "supporting",
+    "relatedConcepts": ["lower bound", "Yokota estimate", "Erdős #309", "asymptotic bracket"],
+    "prerequisites": ["Finset cardinality", "representability"]
+  }
+]

--- a/src/data/proofs/erdos-309-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-309-incomplete-01/meta.json
@@ -84,5 +84,54 @@
       "Subset sums of nonnegative rationals"
     ]
   },
-  "sections": []
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Self-Contained Definitions",
+      "startLine": 40,
+      "endLine": 64,
+      "summary": "A self-contained mirror of the parent file's definitions (the parent no longer builds against Mathlib 4.26.0). unitFraction n = 1/n (0 at n = 0); sumUnitFractions sums over a finite denominator set; denominatorRange N = range(N+1) \\ {0} = {1,…,N}; harmonicNumber N = sumUnitFractions (denominatorRange N); IsRepresentable N k means k = ∑_{d ∈ S} 1/d for some S ⊆ {1,…,N}; countRepresentable N = F(N) is the number of representable integers in {0,…,N}.",
+      "mathContext": "$H_N=\\sum_{d=1}^N 1/d$; $k$ representable iff $k=\\sum_{d\\in S}1/d$ for some $S\\subseteq\\{1,\\dots,N\\}$; $F(N)=|\\{k\\le N:\\ k\\text{ representable}\\}|$."
+    },
+    {
+      "id": "basic-facts",
+      "title": "Basic Facts and the Subset-Sum Bound",
+      "startLine": 66,
+      "endLine": 98,
+      "summary": "Membership in denominatorRange (mem_denominatorRange), nonnegativity of unit fractions and the harmonic number, and representability of 0 (empty set) and 1 (the singleton {1}, for N ≥ 1). The key inequality is max_representable_le_harmonic: every representable k satisfies (k:ℚ) ≤ H_N, because its representing set S ⊆ {1,…,N} and all unit fractions are nonnegative, so its subset sum is at most the full sum (Finset.sum_le_sum_of_subset_of_nonneg).",
+      "mathContext": "$k$ representable $\\Rightarrow (k:\\mathbb{Q})\\le H_N$ (subset sum of nonnegative unit fractions); $0,1$ representable for $N\\ge 1$."
+    },
+    {
+      "id": "bridge",
+      "title": "The Bridge to Mathlib's harmonic",
+      "startLine": 100,
+      "endLine": 112,
+      "summary": "harmonicNumber_eq_harmonic shows the file's custom harmonicNumber N equals Mathlib's harmonic N. Using harmonic_eq_sum_Icc (H_N = ∑_{d ∈ Icc 1 N} 1/d), the proof identifies denominatorRange N = Finset.Icc 1 N and checks unitFraction d = 1/d on that set. This bridge is what unlocks Mathlib's analytic estimate harmonic_le_one_add_log.",
+      "mathContext": "$\\texttt{harmonicNumber}\\,N=\\texttt{harmonic}\\,N$ via $H_N=\\sum_{d\\in[1,N]}1/d$ and $\\texttt{denominatorRange}\\,N=\\mathrm{Icc}\\,1\\,N$."
+    },
+    {
+      "id": "upper-bound",
+      "title": "The Axiom-Free Upper Bound F(N) ≤ log N + 2",
+      "startLine": 114,
+      "endLine": 155,
+      "summary": "countRepresentable_le_floor_harmonic confines the representable integers to {0,…,⌊H_N⌋} (via Nat.le_floor on the subset-sum bound), giving F(N) ≤ ⌊H_N⌋ + 1 by a cardinality comparison. countRepresentable_le_log_add_two — the headline result — chains F(N) ≤ ⌊H_N⌋ + 1 ≤ H_N + 1 with the bridge and Mathlib's harmonic_le_one_add_log (H_N ≤ 1 + log N) to conclude F(N) ≤ log N + 2, fully machine-checked and axiom-free.",
+      "mathContext": "$F(N)\\le\\lfloor H_N\\rfloor+1\\le H_N+1\\le(1+\\log N)+1=\\log N+2$."
+    },
+    {
+      "id": "lower-bound-bracket",
+      "title": "The Trivial Lower Bound and the Bracket",
+      "startLine": 157,
+      "endLine": 180,
+      "summary": "two_le_countRepresentable: since 0 and 1 are both representable for N ≥ 1, the filtered finset contains {0,1}, so F(N) ≥ 2. countRepresentable_bracket packages 2 ≤ F(N) ≤ log N + 2 for N ≥ 1. The upper bound is sharp up to the additive constant; the matching log-order lower bound F(N) ≥ log N − O(log log N) is the deep Yokota direction (axiomatized in the parent) and is NOT reproved here.",
+      "mathContext": "$2\\le F(N)\\le\\log N+2$ for $N\\ge 1$; lower bound from $0,1$ representable, upper bound from the harmonic estimate."
+    }
+  ],
+  "conclusion": {
+    "summary": "Working self-containedly (the parent Erdos309Problem.lean no longer builds against Mathlib 4.26.0), this file proves the elementary upper-bound half of Erdős #309: the count F(N) of integers representable as sums of distinct unit fractions with denominators in {1,…,N} satisfies F(N) ≤ log N + 2, with the matching trivial lower bound F(N) ≥ 2 for N ≥ 1. The argument confines the representable integers to {0,…,⌊H_N⌋} by a subset-sum bound, bridges the file's harmonic number to Mathlib's harmonic, and applies harmonic_le_one_add_log. 182 lines, 11 theorems, 6 definitions, 0 axioms, 0 sorries (verified with only propext, Classical.choice, Quot.sound; the single decide is kernel-level, not native_decide).",
+    "implications": "Erdős #309 is solved (F(N) = log N + γ + O((log log N)²/log N), Yokota/Croot), so F(N) = Θ(log N). The deep content is entirely in the lower bound; the upper bound is what the literature calls 'trivial', and this entry makes it fully machine-checked and axiom-free — an honest record of the easy half, explicitly leaving the Yokota lower bound to the (axiomatized) parent. The contribution is the careful Mathlib bridge harmonicNumber = harmonic, which turns a custom formalization into one that can invoke upstream analytic estimates.",
+    "openQuestions": [
+      "Reprove the deep Yokota lower bound F(N) ≥ log N − O(log log N) axiom-free, replacing the parent's axiom yokota_lower_bound_1997 and completing the F(N) = Θ(log N) result without assumptions.",
+      "Sharpen the additive constant: the truth is F(N) = log N + γ + o(1) (γ the Euler–Mascheroni constant); formalize the refined asymptotic, not merely the +2 bound."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `erdos-309-incomplete-01` (passes: 0).

The entry had a rich `description` and `overview`, but its `sections` array was **empty** and it had **no `annotations.json`** and no `conclusion`.

**Added to meta.json:**
- `sections`: 5 sections covering the full 182-line Lean file (self-contained definitions; basic facts & the subset-sum bound; the bridge to Mathlib's `harmonic`; the axiom-free upper bound; the trivial lower bound & bracket), each with `mathContext`.
- `conclusion`: `summary`, `implications`, and 2 `openQuestions` (axiom-free Yokota lower bound; the refined γ asymptotic).

**Created annotations.json:** 6 annotations (definitions, subset-sum bound, Mathlib bridge, floor-confinement, the headline F(N) ≤ log N + 2 [critical], lower bound & bracket), each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`.

**Axiom-integrity check:** confirmed the `verified`/`0-axiom`/`0-sorry` claim is accurate — the Lean file has no `axiom` or `sorry`, and its single `decide` (line 170, on `({0,1}:Finset ℕ).card = 2`) is kernel-level `decide`, not `native_decide`, so it adds no `Lean.ofReduceBool`. The 'incomplete' in the slug honestly reflects that only the elementary upper-bound half is proved (the deep Yokota lower bound stays axiomatized in the parent), and the entry states this throughout.

Verified: annotation line ranges validated by `annotations:build`; `tsc -b` clean; `vite build` succeeds; all JSON valid.