### PR TITLE
research(compactness-finite-subcover-oq-01-oq-02-oq-01): Nested Closed Intervals Shrinking to a Point [0-axiom verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -732,6 +732,7 @@ import Proofs.CombinationsFormulaOQ09
 import Proofs.CompactnessFiniteSubcover
 import Proofs.CompactnessFiniteSubcoverOq01Oq01
 import Proofs.CompactnessFiniteSubcoverOq01Oq02
+import Proofs.CompactnessFiniteSubcoverOq01Oq02Oq01
 import Proofs.ComplexityCore
 import Proofs.CompositionCard2PowOQ01
 import Proofs.CompositionPartsChooseOQ01

--- a/proofs/Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean
+++ b/proofs/Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-!
+# Nested Closed Intervals Shrinking to a Point
+
+This file answers the **first** open question recorded on the parent entry
+`compactness-finite-subcover-oq-01-oq-02` ("The Finite-Intersection Dual and
+Cantor's Intersection Theorem").
+
+The parent's concrete real instance shows only that the nested intervals
+`[0, 1/(n+1)]` have **nonempty** intersection (a corollary of Cantor's
+intersection theorem).  Here we *pin the intersection exactly*:
+
+> **`nested_intervals_iInter_singleton`** — for a `Monotone` left endpoint `a`,
+> an `Antitone` right endpoint `b` with `a n ≤ b n` and lengths
+> `b n - a n → 0`, the intersection `⋂ n, [a n, b n]` is the **singleton**
+> `{⨆ n, a n}`.
+
+Cantor's theorem (the parent's content) supplies *nonemptiness*; the new content
+here is the **uniqueness** half — the shrinking-length hypothesis forces any two
+common points to coincide via the squeeze `|x - y| ≤ b n - a n → 0`.  Together
+they upgrade "nonempty" to "exactly one point", and that point is identified
+concretely as the supremum of the left endpoints (equivalently the infimum of
+the right endpoints).
+
+The concrete corollary `iInter_Icc_zero_one_div_eq_zero` then sharpens the
+parent's `[0, 1/(n+1)]` example from "nonempty" to the exact value `{0}`.
+-/
+
+open Set Filter Topology
+
+namespace CompactnessFiniteSubcoverOq01Oq02Oq01
+
+/-- **Nested closed intervals shrinking to a point.**
+
+Let `a` be a monotone (non-decreasing) sequence of left endpoints and `b` an
+antitone (non-increasing) sequence of right endpoints with `a n ≤ b n` for every
+`n`, and suppose the lengths `b n - a n` tend to `0`.  Then the intersection of
+the nested closed intervals `[a n, b n]` is the single point `⨆ n, a n`.
+
+The supremum exists because every `a m` lies below every `b n` (so `b 0` bounds
+the range of `a`); that same cross bound `a m ≤ b n` places the supremum inside
+every interval.  Uniqueness is the shrinking-length squeeze: any common point `x`
+satisfies `|x - (⨆ n, a n)| ≤ b n - a n` for all `n`, and the right side tends to
+`0`. -/
+theorem nested_intervals_iInter_singleton
+    (a b : ℕ → ℝ) (ha : Monotone a) (hb : Antitone b)
+    (hab : ∀ n, a n ≤ b n)
+    (hlen : Tendsto (fun n => b n - a n) atTop (𝓝 0)) :
+    ⋂ n, Icc (a n) (b n) = {⨆ n, a n} := by
+  -- Every left endpoint lies below every right endpoint.
+  have key : ∀ m n, a m ≤ b n := by
+    intro m n
+    rcases le_total m n with h | h
+    · exact (ha h).trans (hab n)
+    · exact (hab m).trans (hb h)
+  -- Hence the range of `a` is bounded above (by `b 0`), so the supremum exists.
+  have hbdd : BddAbove (Set.range a) := ⟨b 0, by rintro _ ⟨m, rfl⟩; exact key m 0⟩
+  have hac : ∀ n, a n ≤ ⨆ j, a j := fun n => le_ciSup hbdd n
+  have hcb : ∀ n, (⨆ j, a j) ≤ b n := fun n => ciSup_le (fun m => key m n)
+  apply Set.eq_singleton_iff_unique_mem.2
+  refine ⟨?_, ?_⟩
+  · -- The supremum belongs to every interval, hence to the intersection.
+    simp only [mem_iInter, mem_Icc]
+    exact fun n => ⟨hac n, hcb n⟩
+  · -- Any common point equals the supremum, by the shrinking-length squeeze.
+    intro x hx
+    simp only [mem_iInter, mem_Icc] at hx
+    have hbound : ∀ n, |x - ⨆ j, a j| ≤ b n - a n := by
+      intro n
+      rw [abs_le]
+      exact ⟨by linarith [(hx n).1, hcb n], by linarith [(hx n).2, hac n]⟩
+    have h0 : |x - ⨆ j, a j| ≤ 0 := ge_of_tendsto' hlen hbound
+    have : x - ⨆ j, a j = 0 := abs_nonpos_iff.1 h0
+    linarith
+
+/-- **Sharp value of the parent's concrete example.**
+
+The nested real intervals `[0, 1/(n+1)]` intersect in *exactly* `{0}` — the
+parent entry established only that this intersection is nonempty.  Specialising
+`nested_intervals_iInter_singleton` with constant left endpoint `0` and right
+endpoint `1/(n+1)` (antitone, with `1/(n+1) → 0`) yields the singleton; the
+supremum of the constant-`0` left endpoints is `0`. -/
+theorem iInter_Icc_zero_one_div_eq_zero :
+    ⋂ n : ℕ, Icc (0 : ℝ) (1 / (n + 1)) = {0} := by
+  have hanti : Antitone (fun n : ℕ => 1 / ((n : ℝ) + 1)) := by
+    intro m n hmn
+    have : (m : ℝ) ≤ n := by exact_mod_cast hmn
+    apply one_div_le_one_div_of_le <;> linarith
+  have hab : ∀ n : ℕ, (fun _ : ℕ => (0 : ℝ)) n ≤ (fun n : ℕ => 1 / ((n : ℝ) + 1)) n := by
+    intro n; positivity
+  have hlen : Tendsto (fun n : ℕ => (fun n => 1 / ((n : ℝ) + 1)) n - (fun _ => (0 : ℝ)) n)
+      atTop (𝓝 0) := by
+    simpa using (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ))
+  have h := nested_intervals_iInter_singleton (fun _ => (0 : ℝ))
+      (fun n => 1 / ((n : ℝ) + 1)) monotone_const hanti hab hlen
+  rw [show (⨆ _n : ℕ, (0 : ℝ)) = 0 from ciSup_const] at h
+  simpa using h
+
+end CompactnessFiniteSubcoverOq01Oq02Oq01

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,143 @@
+{
+  "id": "compactness-finite-subcover-oq-01-oq-02-oq-01",
+  "slug": "compactness-finite-subcover-oq-01-oq-02-oq-01",
+  "title": "Nested Closed Intervals Shrinking to a Point",
+  "status": "verified",
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Cantor's intersection theorem guarantees that a decreasing sequence of nonempty closed subsets of a compact space has nonempty intersection — but it says nothing about the size of that intersection. The classical refinement, the Nested Interval Theorem (the form Bolzano and Cantor used to construct real numbers and to prove the Bolzano–Weierstrass theorem), adds one hypothesis: if the lengths of a nested sequence of closed bounded intervals tend to 0, the intersection is not merely nonempty but a single point. This is the completeness of ℝ made geometric, and it is the engine of the bisection method, of binary expansions, and of the standard construction of the Cantor set as a nested intersection. The parent entry re-derived Cantor's theorem by hand from the finite-intersection dual and recorded, as a concrete instance, only that ⋂ₙ [0, 1/(n+1)] is nonempty. This entry supplies the missing uniqueness half and pins the intersection exactly.",
+    "problemStatement": "Answer the parent's first open question. (1) Abstract a 'nested intervals shrinking to a point' lemma: for a monotone left-endpoint sequence a, an antitone right-endpoint sequence b with a n ≤ b n, and lengths b n − a n → 0, prove the intersection ⋂ₙ [a n, b n] is the singleton {⨆ₙ a n}. (2) Sharpen the parent's concrete instance from 'nonempty' to the exact value ⋂ₙ [0, 1/(n+1)] = {0}.",
+    "proofStrategy": "Nonemptiness and uniqueness are separated. The cross bound a m ≤ b n for ALL m, n (proved by splitting on m ≤ n vs n ≤ m and using monotonicity/antitonicity through a n ≤ b n) does double duty: it bounds the range of a above by b 0 (so the supremum c = ⨆ₙ a n exists, via BddAbove), and ciSup_le gives c ≤ b n for every n while le_ciSup gives a n ≤ c. Hence c lies in every interval, so c ∈ ⋂ₙ [a n, b n]. For uniqueness, any common point x satisfies a n ≤ x ≤ b n and a n ≤ c ≤ b n, so |x − c| ≤ b n − a n for every n; since the right side tends to 0, ge_of_tendsto' forces |x − c| ≤ 0, hence x = c. Set.eq_singleton_iff_unique_mem packages membership + uniqueness into the singleton equality. The concrete corollary instantiates a ≡ 0 (monotone_const) and b n = 1/(n+1) (antitone via one_div_le_one_div_of_le, with 1/(n+1) → 0 by tendsto_one_div_add_atTop_nhds_zero_nat); the supremum of the constant-0 left endpoints is 0 by ciSup_const.",
+    "keyInsights": [
+      "Cantor's theorem gives nonemptiness; the shrinking-length hypothesis is exactly what upgrades it to a singleton. The new mathematical content over the parent is the uniqueness half, and it is a pure squeeze: two common points x, y both lie in [a n, b n], so |x − y| ≤ b n − a n → 0.",
+      "The single cross inequality a m ≤ b n (every left endpoint below every right endpoint, regardless of index order) is the whole engine. It simultaneously yields existence of the supremum (range of a bounded by b 0) and its membership in every interval (a n ≤ ⨆ a ≤ b n via le_ciSup / ciSup_le).",
+      "The common point is identified concretely as ⨆ₙ a n — the supremum of the left endpoints, equivalently the infimum of the right endpoints and the common limit of both. No appeal to convergence of a or b is needed: order completeness (ciSup) plus the length squeeze suffice, so the proof never constructs a limit explicitly.",
+      "The length hypothesis is essential, not cosmetic: without it the intersection can be a nondegenerate interval (e.g. constant a ≡ 0, b ≡ 1 gives ⋂ [0,1] = [0,1]). The theorem is sharp.",
+      "Specialising to a ≡ 0, b n = 1/(n+1) turns the parent's 'nonempty' into the exact {0}, completing the concrete example the parent left open."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: From Cantor's Theorem to a Single Point",
+      "startLine": 3,
+      "endLine": 28,
+      "summary": "Frames the entry as the uniqueness half the parent left open: Cantor's intersection theorem supplies nonemptiness, the shrinking-length hypothesis pins the intersection to one point, identified as the supremum of the left endpoints. Lists the general lemma and the sharpened concrete corollary.",
+      "mathContext": "$b_n-a_n\\to0\\Rightarrow\\bigcap_n[a_n,b_n]=\\{\\sup_n a_n\\}$."
+    },
+    {
+      "id": "general",
+      "title": "Nested Intervals Shrinking to a Point",
+      "startLine": 34,
+      "endLine": 75,
+      "summary": "nested_intervals_iInter_singleton: for monotone a, antitone b with a n ≤ b n and b n − a n → 0, the intersection ⋂ₙ [a n, b n] equals {⨆ₙ a n}. The cross bound a m ≤ b n gives BddAbove (range a), then le_ciSup and ciSup_le place the supremum in every interval (existence), while the squeeze |x − ⨆ a| ≤ b n − a n → 0 with ge_of_tendsto' gives uniqueness.",
+      "mathContext": "$a_m\\le b_n\\ \\forall m,n$; existence via $\\sup$, uniqueness via $|x-\\sup a|\\le b_n-a_n\\to0$."
+    },
+    {
+      "id": "instance",
+      "title": "Sharp Value of the Parent's Concrete Example",
+      "startLine": 77,
+      "endLine": 98,
+      "summary": "iInter_Icc_zero_one_div_eq_zero: ⋂ₙ [0, 1/(n+1)] = {0}, exactly. Instantiates the general lemma with constant left endpoint 0 (monotone_const) and right endpoint 1/(n+1) (antitone via one_div_le_one_div_of_le, tending to 0 by tendsto_one_div_add_atTop_nhds_zero_nat); the supremum of the constant-0 sequence is 0 by ciSup_const.",
+      "mathContext": "$\\bigcap_n[0,\\tfrac1{n+1}]=\\{0\\}$ in $\\mathbb{R}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The 'nested intervals shrinking to a point' lemma is established: for a monotone left-endpoint sequence a, an antitone right-endpoint sequence b with a n ≤ b n and lengths b n − a n → 0, the intersection ⋂ₙ [a n, b n] is exactly {⨆ₙ a n}. The cross bound a m ≤ b n for all indices yields both the existence of the supremum and its membership in every interval (le_ciSup, ciSup_le), while a length squeeze |x − ⨆ a| ≤ b n − a n → 0 closed by ge_of_tendsto' supplies uniqueness. The concrete corollary sharpens the parent entry's nested-interval example from 'nonempty' to the exact value ⋂ₙ [0, 1/(n+1)] = {0}. 100 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "This is the uniqueness refinement of Cantor's intersection theorem (the parent's content), i.e. the Nested Interval Theorem expressing the order-completeness of ℝ. The common point is identified concretely as the supremum of the left endpoints without constructing any limit, so the argument rests on order completeness (ciSup) plus a single squeeze. The hypothesis that lengths tend to 0 is sharp: dropping it allows a nondegenerate interval as intersection.",
+    "openQuestions": [
+      {
+        "id": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-01",
+        "question": "Prove the converse / generative form: every real number is the unique common point of some explicit nested sequence of closed intervals with rational endpoints and lengths → 0 (e.g. via binary or decimal bisection), exhibiting the Nested Interval Theorem as a representation of ℝ rather than only an intersection identity.",
+        "significance": "medium"
+      },
+      {
+        "id": "compactness-finite-subcover-oq-01-oq-02-oq-01-oq-02",
+        "question": "Generalise from ℝ to a complete metric space: a decreasing sequence of nonempty closed sets whose diameters tend to 0 has a singleton intersection, and show this property characterises completeness (Cantor's intersection theorem for complete metric spaces, the metric analogue of the order-completeness argument used here).",
+        "significance": "high"
+      }
+    ]
+  },
+  "references": [
+    {
+      "title": "Principles of Mathematical Analysis",
+      "author": "Rudin",
+      "year": "1976",
+      "venue": "McGraw-Hill",
+      "description": "The Nested Interval Theorem and the role of shrinking lengths in pinning the intersection to a single point (Theorem 3.10 and the construction of ℝ)."
+    },
+    {
+      "title": "Mathlib4: Order.Bounds, Topology.Algebra.Order, and Analysis.SpecificLimits.Basic",
+      "author": "Mathlib Community",
+      "year": "2026",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of le_ciSup / ciSup_le / ciSup_const (conditional suprema), ge_of_tendsto' (the limit squeeze), one_div_le_one_div_of_le, and tendsto_one_div_add_atTop_nhds_zero_nat (1/(n+1) → 0)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "compactness-finite-subcover-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: re-derives Cantor's intersection theorem by hand from the finite-intersection dual and records ⋂ₙ [0, 1/(n+1)] as merely nonempty. This entry answers its first open question — supplying the uniqueness half and pinning the intersection to the exact singleton {0}, with the general nested-intervals-shrinking-to-a-point lemma behind it."
+    },
+    {
+      "targetId": "compactness-finite-subcover-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling under the same parent answering the tube-lemma open question. Both turn a qualitative compactness statement into a sharp quantitative one."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean",
+    "tags": [
+      "topology",
+      "real-analysis",
+      "nested-intervals",
+      "cantor-intersection-theorem",
+      "order-completeness",
+      "supremum",
+      "squeeze-argument",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 100,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "nested_intervals_iInter_singleton: the 'nested intervals shrinking to a point' lemma. For monotone left endpoints a, antitone right endpoints b with a n ≤ b n and lengths b n − a n → 0, the intersection ⋂ₙ [a n, b n] equals the singleton {⨆ₙ a n}. Nonemptiness and uniqueness are separated: a single cross bound a m ≤ b n (all m, n, by case-splitting on index order through a n ≤ b n) bounds range a above by b 0 so the supremum exists, and le_ciSup / ciSup_le place that supremum inside every interval; uniqueness is the squeeze |x − ⨆ a| ≤ b n − a n with the right side → 0, closed by ge_of_tendsto' and abs_nonpos_iff. This is the uniqueness refinement of the parent's Cantor theorem — the Nested Interval Theorem — and the common point is identified as the supremum of the left endpoints without constructing any limit.",
+      "iInter_Icc_zero_one_div_eq_zero: sharpens the parent entry's concrete real instance from 'nonempty' to the exact value ⋂ₙ [0, 1/(n+1)] = {0}, by instantiating the general lemma with constant left endpoint 0 and right endpoint 1/(n+1) (antitone, tending to 0) and computing the supremum of the constant-0 left endpoints via ciSup_const."
+    ],
+    "prerequisites": [
+      "le_ciSup / ciSup_le: a conditional supremum dominates each term and is the least upper bound — used to place ⨆ₙ a n between a n and b n in every interval",
+      "ge_of_tendsto': if f → L and c ≤ f n eventually then c ≤ L — the limit squeeze forcing |x − ⨆ a| ≤ 0",
+      "Set.eq_singleton_iff_unique_mem: a set equals {a} iff a is a member and every member equals a — packages existence + uniqueness",
+      "one_div_le_one_div_of_le: antitonicity of x ↦ 1/x on the positives, for the concrete right endpoints",
+      "tendsto_one_div_add_atTop_nhds_zero_nat: 1/(n+1) → 0, the shrinking-length hypothesis of the concrete instance"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "le_ciSup",
+        "description": "For a family bounded above, each term is ≤ its conditional supremum. Gives a n ≤ ⨆ₙ a n.",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "ciSup_le",
+        "description": "If every term is ≤ c then the conditional supremum is ≤ c (nonempty index). Gives ⨆ₙ a n ≤ b n from the cross bound.",
+        "module": "Mathlib.Order.ConditionallyCompleteLattice.Basic"
+      },
+      {
+        "theorem": "ge_of_tendsto'",
+        "description": "If f tends to L and c ≤ f n for all n, then c ≤ L. The limit squeeze used for uniqueness.",
+        "module": "Mathlib.Topology.Order.Basic"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) tends to 0 as n → ∞. Supplies the shrinking-length hypothesis of the concrete instance.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ]
+  }
+}

--- a/src/data/proofs/compactness-finite-subcover-oq-01-oq-02/meta.json
+++ b/src/data/proofs/compactness-finite-subcover-oq-01-oq-02/meta.json
@@ -124,7 +124,8 @@
     {
       "id": "compactness-finite-subcover-oq-01-oq-02-oq-01",
       "question": "Strengthen the concrete instance to compute the intersection exactly: prove ⋂ n, [0, 1/(n+1)] = {0} (not merely nonempty), and abstract the pattern to a 'nested intervals shrinking to a point' lemma giving the unique common point of a decreasing sequence of closed intervals whose lengths tend to 0.",
-      "significance": "medium"
+      "significance": "medium",
+      "answeredBy": "compactness-finite-subcover-oq-01-oq-02-oq-01"
     },
     {
       "id": "compactness-finite-subcover-oq-01-oq-02-oq-02",


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `compactness-finite-subcover-oq-01-oq-02` (Cantor's intersection theorem / the finite-intersection dual): it asked to *strengthen the concrete instance to compute the intersection exactly* and to *abstract a 'nested intervals shrinking to a point' lemma*.

The parent established only that nested intervals have **nonempty** intersection (Cantor's theorem). This PR supplies the **uniqueness** half — the Nested Interval Theorem — and pins the intersection exactly.

## Results (`Proofs/CompactnessFiniteSubcoverOq01Oq02Oq01.lean`, 100 lines, 2 theorems, 0 defs, **0 axioms**, 0 sorries)

- **`nested_intervals_iInter_singleton`** — for a monotone left-endpoint sequence `a`, an antitone right-endpoint sequence `b` with `a n ≤ b n`, and lengths `b n − a n → 0`:
  ```
  ⋂ n, Icc (a n) (b n) = {⨆ n, a n}
  ```
  Existence and uniqueness are separated. A single cross bound `a m ≤ b n` (all indices, by case-split on `m ≤ n` / `n ≤ m`) bounds `range a` above by `b 0` so the supremum exists, and `le_ciSup` / `ciSup_le` place it inside every interval. Uniqueness is the squeeze `|x − ⨆ a| ≤ b n − a n → 0`, closed by `ge_of_tendsto'` + `abs_nonpos_iff`.

- **`iInter_Icc_zero_one_div_eq_zero`** — sharpens the parent's example from "nonempty" to the exact value:
  ```
  ⋂ n : ℕ, Icc (0 : ℝ) (1 / (n + 1)) = {0}
  ```

## Notes

- `#print axioms` on both theorems: only `propext`, `Classical.choice`, `Quot.sound` (the foundational three) — **0-axiom verified**, no `native_decide`, no `sorry`.
- The common point is identified as `⨆ₙ aₙ` via order-completeness alone; no limit of `a` or `b` is constructed.
- Hypothesis is sharp: dropping `bₙ−aₙ→0` allows a nondegenerate interval as intersection.
- Parent `openQuestions` entry annotated with `answeredBy`; aggregator import added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)