### PR TITLE
research(cayley-hamilton-minpoly-oq-06-oq-01): RCF readout — minpoly + invariant factors [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -609,6 +609,7 @@ import Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05
 import Proofs.CayleyHamiltonMinpolyOQ05OQ02
 import Proofs.CayleyHamiltonMinpolyOQ05OQ02OQ03
 import Proofs.CayleyHamiltonMinpolyOQ06
+import Proofs.CayleyHamiltonMinpolyOQ06OQ01
 import Proofs.CayleyHamiltonOQ01
 import Proofs.CayleyHamiltonOQ01OQ01
 import Proofs.CayleyHamiltonOQ01OQ03

--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean
@@ -1,0 +1,161 @@
+import Mathlib
+
+/-
+# Rational Canonical Form readout: minimal polynomial plus invariant factors
+
+The rational canonical form (Frobenius normal form) writes every matrix over a
+field as a block-diagonal sum of companion matrices
+
+    C(f₁) ⊕ C(f₂) ⊕ … ⊕ C(f_k),     f₁ ∣ f₂ ∣ … ∣ f_k,
+
+whose blocks are the *invariant factors* `fᵢ`.  The standard "readout" of this
+form recovers the two distinguished polynomials of the matrix from its invariant
+factors:
+
+  * the **characteristic polynomial** is the *product* of the invariant factors,
+    `charpoly = ∏ᵢ fᵢ`; and
+  * the **minimal polynomial** is the *largest* invariant factor,
+    `minpoly = f_k`  (largest in the divisibility order, since the `fᵢ` form a
+    chain).
+
+This file proves the readout for the **two-invariant-factor case** (the
+inductive heart of the general statement; the `k`-block case requires a
+`Sigma`-indexed block matrix, since companion blocks of different degrees do not
+fit Mathlib's uniform `blockDiagonal`).  Crucially the statement is given for
+*arbitrary nonderogatory blocks* — a block `A` is nonderogatory when
+`minpoly A = charpoly A`, and that common value is its invariant factor — so it
+applies verbatim to companion matrices:
+`Matrix.charpoly_companionMatrix`/`Matrix.minpoly_companionMatrix` in
+`Proofs.CayleyHamiltonReductionOQ02OQ01` show `charpoly (C f) = minpoly (C f) = f`,
+exactly the nonderogatory hypothesis below.
+
+## What is new here
+
+Mathlib (v4.26.0) has `Matrix.charpoly_fromBlocks_zero₁₂` (the characteristic
+polynomial of a block-triangular matrix is the product of the diagonal blocks'
+characteristic polynomials) but **no** statement about the *minimal* polynomial
+of a block-diagonal matrix.  The core new results are:
+
+  * `aeval_fromBlocks` — polynomial evaluation distributes over a block-diagonal
+    matrix: `q(A ⊕ D) = q(A) ⊕ q(D)`;
+  * `minpoly_fromBlocks_of_dvd` — when the blocks' minimal polynomials form a
+    divisibility chain `minpoly A ∣ minpoly D`, the minimal polynomial of the
+    block-diagonal sum is the larger one, `minpoly D`.  (In general it is the
+    lcm; the chain hypothesis, automatic for invariant factors, collapses the
+    lcm to the larger element and avoids any normalisation bookkeeping.)
+
+Everything is sorry-free and axiom-free (`import Mathlib` only).
+
+## Open question addressed
+
+`cayley-hamilton-minpoly-oq-06-oq-01`: "Rational Canonical Form: Minimal
+Polynomial Plus Invariant Factors", a follow-up to
+`cayley-hamilton-minpoly-oq-06` ("similar matrices share a minimal polynomial").
+-/
+
+namespace CayleyHamiltonMinpolyOQ06OQ01
+
+open Matrix Polynomial BigOperators
+
+variable {F : Type*} [Field F]
+variable {m : Type*} [Fintype m] [DecidableEq m]
+variable {o : Type*} [Fintype o] [DecidableEq o]
+
+/-! ## Part 1: `algebraMap` and polynomial evaluation on a block-diagonal matrix -/
+
+/-- The scalar matrix `algebraMap F (Matrix (m ⊕ o)) a` is the block-diagonal sum
+of the two scalar blocks `algebraMap F (Matrix m) a` and
+`algebraMap F (Matrix o) a`. -/
+theorem algebraMap_fromBlocks (a : F) :
+    algebraMap F (Matrix (m ⊕ o) (m ⊕ o) F) a
+      = Matrix.fromBlocks (algebraMap F (Matrix m m F) a) 0 0
+          (algebraMap F (Matrix o o F) a) := by
+  rw [Algebra.algebraMap_eq_smul_one, Algebra.algebraMap_eq_smul_one,
+      Algebra.algebraMap_eq_smul_one, ← Matrix.fromBlocks_one,
+      Matrix.fromBlocks_smul]
+  simp
+
+/-- **Polynomial evaluation distributes over a block-diagonal matrix.**
+For any polynomial `q`, `q(A ⊕ D) = q(A) ⊕ q(D)`, where `A ⊕ D` is the
+block-diagonal matrix `fromBlocks A 0 0 D`. -/
+theorem aeval_fromBlocks (A : Matrix m m F) (D : Matrix o o F) (q : F[X]) :
+    aeval (Matrix.fromBlocks A 0 0 D) q
+      = Matrix.fromBlocks (aeval A q) 0 0 (aeval D q) := by
+  refine Polynomial.induction_on' q (fun p₁ p₂ ih₁ ih₂ => ?_) (fun n a => ?_)
+  · rw [map_add, map_add, map_add, ih₁, ih₂, Matrix.fromBlocks_add, add_zero, add_zero]
+  · simp only [aeval_monomial]
+    rw [Matrix.fromBlocks_diagonal_pow, algebraMap_fromBlocks,
+        Matrix.fromBlocks_multiply]
+    simp
+
+/-! ## Part 2: characteristic and minimal polynomials of a block-diagonal matrix -/
+
+/-- **Characteristic polynomial of a block-diagonal matrix** is the product of
+the blocks' characteristic polynomials.  (A direct restatement of Mathlib's
+`Matrix.charpoly_fromBlocks_zero₁₂`, recorded here for the RCF readout.) -/
+theorem charpoly_fromBlocks (A : Matrix m m F) (D : Matrix o o F) :
+    (Matrix.fromBlocks A 0 0 D).charpoly = A.charpoly * D.charpoly :=
+  Matrix.charpoly_fromBlocks_zero₁₂ A 0 D
+
+/-- **Minimal polynomial of a block-diagonal matrix, divisibility-chain case.**
+If the blocks' minimal polynomials form a divisibility chain
+`minpoly A ∣ minpoly D`, then the minimal polynomial of the block-diagonal sum
+`A ⊕ D` is the larger one, `minpoly D`.
+
+This is the minimal-polynomial counterpart of `charpoly_fromBlocks` and is the
+key fact missing from Mathlib.  The proof is a clean two-way divisibility:
+`minpoly D` annihilates `A ⊕ D` (it annihilates `D`, and divides—hence
+annihilates through—`minpoly A`), giving `minpoly (A ⊕ D) ∣ minpoly D`; and
+reading off the bottom-right block of `(minpoly (A ⊕ D))(A ⊕ D) = 0` shows
+`minpoly D ∣ minpoly (A ⊕ D)`.  Two monic associates are equal. -/
+theorem minpoly_fromBlocks_of_dvd (A : Matrix m m F) (D : Matrix o o F)
+    (hdvd : minpoly F A ∣ minpoly F D) :
+    minpoly F (Matrix.fromBlocks A 0 0 D) = minpoly F D := by
+  set B := Matrix.fromBlocks A 0 0 D with hB
+  have hDint : IsIntegral F D := Matrix.isIntegral D
+  have hBint : IsIntegral F B := Matrix.isIntegral B
+  -- `minpoly D` annihilates `A` as well (since `minpoly A ∣ minpoly D`).
+  have hAevalD : aeval A (minpoly F D) = 0 := by
+    obtain ⟨r, hr⟩ := hdvd
+    rw [hr, map_mul, minpoly.aeval, zero_mul]
+  -- Hence `minpoly D` annihilates the whole block-diagonal matrix.
+  have hannih : aeval B (minpoly F D) = 0 := by
+    rw [hB, aeval_fromBlocks, hAevalD, minpoly.aeval, Matrix.fromBlocks_zero]
+  have hdvd1 : minpoly F B ∣ minpoly F D := minpoly.dvd F B hannih
+  -- Conversely, `minpoly D ∣ minpoly B`: read off the bottom-right block of
+  -- `(minpoly B)(B) = 0`.
+  have hDaeval : aeval D (minpoly F B) = 0 := by
+    have hz : Matrix.fromBlocks (aeval A (minpoly F B)) 0 0 (aeval D (minpoly F B))
+        = 0 := by rw [← aeval_fromBlocks, ← hB]; exact minpoly.aeval F B
+    ext i j
+    have h := congr_fun (congr_fun hz (Sum.inr i)) (Sum.inr j)
+    rwa [Matrix.fromBlocks_apply₂₂, Matrix.zero_apply] at h
+  have hdvd2 : minpoly F D ∣ minpoly F B := minpoly.dvd F D hDaeval
+  exact Polynomial.eq_of_monic_of_associated (minpoly.monic hBint) (minpoly.monic hDint)
+    (associated_of_dvd_dvd hdvd1 hdvd2)
+
+/-! ## Part 3: the rational-canonical-form readout for two invariant factors -/
+
+/-- **Rational canonical form readout (two invariant factors).**
+
+Let `A`, `D` be two *nonderogatory* blocks: `A` has `minpoly A = charpoly A = f₁`
+and `D` has `minpoly D = charpoly D = f₂`, with the invariant factors forming a
+chain `f₁ ∣ f₂`.  (Companion matrices `C(f₁)`, `C(f₂)` are exactly such blocks.)
+
+Then the block-diagonal matrix `A ⊕ D` realises the two defining RCF relations:
+
+  * its **characteristic polynomial** is the *product* `f₁ · f₂` of the invariant
+    factors, and
+  * its **minimal polynomial** is the *largest* invariant factor `f₂`. -/
+theorem rcf_two_invariant_factors
+    (A : Matrix m m F) (D : Matrix o o F) (f₁ f₂ : F[X])
+    (hA_min : minpoly F A = f₁) (hA_char : A.charpoly = f₁)
+    (hD_min : minpoly F D = f₂) (hD_char : D.charpoly = f₂)
+    (hchain : f₁ ∣ f₂) :
+    (Matrix.fromBlocks A 0 0 D).charpoly = f₁ * f₂
+      ∧ minpoly F (Matrix.fromBlocks A 0 0 D) = f₂ := by
+  refine ⟨?_, ?_⟩
+  · rw [charpoly_fromBlocks, hA_char, hD_char]
+  · rw [minpoly_fromBlocks_of_dvd A D (by rw [hA_min, hD_min]; exact hchain), hD_min]
+
+end CayleyHamiltonMinpolyOQ06OQ01

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-06-oq-01",
+  "title": "Rational Canonical Form: Minimal Polynomial Plus Invariant Factors",
+  "slug": "cayley-hamilton-minpoly-oq-06-oq-01",
+  "description": "The rational-canonical-form readout for two invariant factors: for nonderogatory blocks A, D whose minimal polynomials form a divisibility chain (minpoly A ∣ minpoly D), the block-diagonal sum A ⊕ D has characteristic polynomial equal to the PRODUCT of the invariant factors and minimal polynomial equal to the LARGEST invariant factor. The key new ingredient — absent from Mathlib v4.26.0 — is the minimal polynomial of a block-diagonal matrix (minpoly_fromBlocks_of_dvd), the minpoly counterpart of Mathlib's charpoly_fromBlocks_zero₁₂.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "abstract-algebra",
+      "minimal-polynomial",
+      "characteristic-polynomial",
+      "rational-canonical-form",
+      "invariant-factors",
+      "block-matrix",
+      "research"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.charpoly_fromBlocks_zero₁₂",
+        "description": "The characteristic polynomial of a block-triangular matrix is the product of the diagonal blocks' characteristic polynomials",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic"
+      },
+      {
+        "theorem": "Matrix.fromBlocks_multiply",
+        "description": "Block matrices multiply blockwise; for block-diagonal matrices this collapses to (A ⊕ D)(A' ⊕ D') = AA' ⊕ DD'",
+        "module": "Mathlib.Data.Matrix.Block"
+      },
+      {
+        "theorem": "Matrix.fromBlocks_diagonal_pow",
+        "description": "Powers of a block-diagonal matrix are blockwise: (A ⊕ D)^k = A^k ⊕ D^k",
+        "module": "Mathlib.Data.Matrix.Block"
+      },
+      {
+        "theorem": "minpoly.dvd",
+        "description": "If a polynomial annihilates an element, the minimal polynomial divides it",
+        "module": "Mathlib.FieldTheory.Minpoly.Basic"
+      },
+      {
+        "theorem": "Polynomial.eq_of_monic_of_associated",
+        "description": "Two monic associates are equal — used to conclude equality from mutual divisibility of the two minimal polynomials",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Matrix.isIntegral",
+        "description": "Every matrix over a field is integral, so its minimal polynomial is monic",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly"
+      }
+    ],
+    "originalContributions": [
+      "aeval_fromBlocks: polynomial evaluation distributes over a block-diagonal matrix, q(A ⊕ D) = q(A) ⊕ q(D), proved by polynomial induction using a helper (algebraMap_fromBlocks) that splits the scalar matrix into block-diagonal scalar blocks",
+      "minpoly_fromBlocks_of_dvd: the minimal polynomial of a block-diagonal matrix A ⊕ D, when the blocks' minimal polynomials form a divisibility chain minpoly A ∣ minpoly D, equals the larger one minpoly D — the minimal-polynomial counterpart of Mathlib's charpoly_fromBlocks_zero₁₂, missing from Mathlib v4.26.0",
+      "rcf_two_invariant_factors: the rational-canonical-form readout for two invariant factors — for nonderogatory blocks (minpoly = charpoly = invariant factor) forming a chain f₁ ∣ f₂, the block-diagonal sum has charpoly = f₁·f₂ (product of invariant factors) and minpoly = f₂ (largest invariant factor)"
+    ],
+    "dateAdded": "2026-06-23",
+    "prerequisites": [
+      "Minimal and characteristic polynomials of matrices",
+      "Block matrices and the fromBlocks construction",
+      "Polynomial divisibility and monic associates",
+      "Rational canonical form / invariant factors (conceptual background)"
+    ],
+    "relatedProblems": [
+      {
+        "id": "cayley-hamilton-minpoly-oq-06",
+        "relationship": "Parent: similar matrices share a minimal polynomial; this answers its first open question on minpoly + invariant factors"
+      },
+      {
+        "id": "cayley-hamilton-reduction-oq-02-oq-01",
+        "relationship": "Companion: companion-matrix charpoly/minpoly identities (charpoly(C f) = minpoly(C f) = f), which instantiate the nonderogatory-block hypotheses here"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 161,
+    "assumptions": "0 axioms, 0 sorries. Depends only on propext, Classical.choice, Quot.sound (the standard Mathlib foundations). Proves the two-invariant-factor case of the rational-canonical-form readout; the general k-factor case requires a Sigma-indexed block matrix (companion blocks of differing degrees do not fit Mathlib's uniform blockDiagonal) and is left as future work.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The rational canonical form (Frobenius normal form) classifies square matrices over a field up to similarity: every matrix is similar to a unique block-diagonal sum of companion matrices C(f₁) ⊕ ⋯ ⊕ C(f_k) whose blocks are the invariant factors f₁ ∣ f₂ ∣ ⋯ ∣ f_k. The two distinguished polynomials of a matrix are recovered from these invariant factors: the characteristic polynomial is their product, and the minimal polynomial is the largest of them. This readout is the bridge between the structural decomposition (which exists by the structure theorem for finitely generated modules over the PID K[X]) and the elementary invariants studied in a first linear-algebra course.",
+    "problemStatement": "Establish the rational-canonical-form relations between the minimal polynomial, the characteristic polynomial, and the invariant factors. For the two-invariant-factor case: show that a block-diagonal sum of two nonderogatory blocks, whose invariant factors form a divisibility chain, has characteristic polynomial equal to the product of the invariant factors and minimal polynomial equal to the largest one.",
+    "text": "For two nonderogatory blocks A, D (each with minpoly = charpoly = its invariant factor) whose invariant factors satisfy f₁ ∣ f₂, the block-diagonal matrix A ⊕ D has charpoly = f₁·f₂ and minpoly = f₂.",
+    "proofStrategy": "The characteristic-polynomial half is Mathlib's charpoly_fromBlocks_zero₁₂ (block-triangular charpoly is the product of diagonal-block charpolys). The minimal-polynomial half is the new content: first prove that polynomial evaluation distributes over a block-diagonal matrix, aeval (A ⊕ D) q = (aeval A q) ⊕ (aeval D q), by polynomial induction (the monomial case uses that the scalar matrix algebraMap a is itself block-diagonal, and that powers of a block-diagonal matrix are blockwise). Then minpoly_fromBlocks_of_dvd follows by two-way divisibility: minpoly D annihilates A ⊕ D (it annihilates D, and divides — hence annihilates through — minpoly A), so minpoly(A ⊕ D) ∣ minpoly D; conversely, reading off the bottom-right block of (minpoly(A ⊕ D))(A ⊕ D) = 0 gives minpoly D ∣ minpoly(A ⊕ D). Two monic associates are equal. Finally rcf_two_invariant_factors packages the two halves for nonderogatory blocks.",
+    "keyInsights": [
+      "The minimal polynomial of a direct sum is the lcm of the summands' minimal polynomials; for invariant factors the divisibility chain collapses the lcm to the largest element, avoiding all normalisation bookkeeping",
+      "aeval distributes over block-diagonal matrices because (A, D) ↦ A ⊕ D is a ring homomorphism — captured here via polynomial induction with a scalar-splitting helper",
+      "Reading off a single diagonal block of the annihilation equation (minpoly(A ⊕ D))(A ⊕ D) = 0 yields the reverse divisibility cheaply, with no module theory",
+      "Stated for arbitrary nonderogatory blocks (minpoly = charpoly), the result applies verbatim to companion matrices C(f), whose charpoly and minpoly both equal f — exactly the blocks of the rational canonical form",
+      "This is the readout direction of RCF; the existence of the decomposition (the ~800-line PID module-structure theorem) is independent and remains the principal gap toward full RCF"
+    ],
+    "prerequisites": [
+      "Minimal and characteristic polynomials of matrices",
+      "Block matrices and the fromBlocks construction",
+      "Polynomial divisibility and monic associates",
+      "Rational canonical form / invariant factors (conceptual background)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Documentation and Setup",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Header explaining the rational-canonical-form readout, what is new relative to Mathlib, and the nonderogatory-block framing that subsumes companion matrices. Sets up a field F and two finite index types m, o for the two blocks.",
+      "mathContext": "RCF writes a matrix as C(f₁) ⊕ ⋯ ⊕ C(f_k) with f₁ ∣ ⋯ ∣ f_k the invariant factors; charpoly = ∏ fᵢ and minpoly = f_k. This file proves the two-block case for arbitrary nonderogatory blocks."
+    },
+    {
+      "id": "aeval-blockdiag",
+      "title": "Polynomial Evaluation on a Block-Diagonal Matrix",
+      "startLine": 64,
+      "endLine": 90,
+      "summary": "algebraMap_fromBlocks splits the scalar matrix algebraMap a into block-diagonal scalar blocks; aeval_fromBlocks then proves by polynomial induction that q(A ⊕ D) = q(A) ⊕ q(D).",
+      "mathContext": "Because (A, D) ↦ A ⊕ D is an F-algebra homomorphism, evaluating any polynomial on the block-diagonal matrix acts blockwise — the engine behind the minimal-polynomial computation."
+    },
+    {
+      "id": "charpoly-minpoly-blockdiag",
+      "title": "Characteristic and Minimal Polynomials of a Block-Diagonal Matrix",
+      "startLine": 91,
+      "endLine": 136,
+      "summary": "charpoly_fromBlocks records that charpoly(A ⊕ D) = charpoly A · charpoly D (from Mathlib). minpoly_fromBlocks_of_dvd proves the new result: when minpoly A ∣ minpoly D, minpoly(A ⊕ D) = minpoly D, via two-way divisibility plus block extraction.",
+      "mathContext": "These are the two RCF readout identities at the level of arbitrary blocks: charpoly multiplies, minpoly takes the larger element of the divisibility chain."
+    },
+    {
+      "id": "rcf-readout",
+      "title": "RCF Readout for Two Invariant Factors",
+      "startLine": 137,
+      "endLine": 161,
+      "summary": "rcf_two_invariant_factors: for nonderogatory blocks A, D with minpoly = charpoly = f₁ resp. f₂ and f₁ ∣ f₂, the block-diagonal sum has charpoly = f₁·f₂ and minpoly = f₂.",
+      "mathContext": "The textbook statement that the characteristic polynomial is the product of the invariant factors and the minimal polynomial is the largest invariant factor — proved here for two factors and instantiated by companion matrices."
+    }
+  ],
+  "conclusion": {
+    "summary": "For two nonderogatory blocks whose invariant factors form a divisibility chain f₁ ∣ f₂, the block-diagonal sum A ⊕ D has characteristic polynomial f₁·f₂ (product of the invariant factors) and minimal polynomial f₂ (the largest). The crux is minpoly_fromBlocks_of_dvd, the minimal polynomial of a block-diagonal matrix, which is missing from Mathlib v4.26.0 and is the minpoly counterpart of charpoly_fromBlocks_zero₁₂. All 5 theorems are fully verified with 0 sorries and 0 axioms.",
+    "implications": "This is the readout half of the rational canonical form: it shows precisely how the two classical similarity invariants are recovered from the invariant factors. Combined with the gallery's companion-matrix identities (charpoly(C f) = minpoly(C f) = f), it gives the RCF relations for the canonical two-block form. The general k-factor case and the existence of the decomposition (the PID module-structure theorem) remain open.",
+    "openQuestions": [
+      "Extend the readout to k invariant factors using a Sigma-indexed block matrix, since companion blocks of differing degrees do not fit Mathlib's uniform blockDiagonal.",
+      "Combine with the existence of the invariant-factor decomposition (structure theorem for f.g. modules over the PID K[X]) to obtain the full rational canonical form theorem."
+    ]
+  },
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial",
+      "BigOperators"
+    ],
+    "namespace": "CayleyHamiltonMinpolyOQ06OQ01",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-06",
+      "relationship": "extends",
+      "description": "Parent formalization; this answers its first open question — formalizing the minimal polynomial together with the invariant factors (rational canonical form)."
+    },
+    {
+      "targetId": "cayley-hamilton-reduction-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Companion: companion-matrix charpoly/minpoly identities charpoly(C f) = minpoly(C f) = f, which instantiate the nonderogatory-block hypotheses used here."
+    }
+  ],
+  "references": [
+    {
+      "key": "HJ13",
+      "citation": "Horn, R.A. and Johnson, C.R., Matrix Analysis, 2nd ed., Cambridge University Press (2013), Chapter 3: Canonical forms.",
+      "type": "book"
+    },
+    {
+      "key": "DF04",
+      "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004), Section 12.2: The Rational Canonical Form.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `cayley-hamilton-minpoly-oq-06` ("similar matrices share a minimal polynomial"): *formalize the minimal polynomial together with the invariant factors (rational canonical form).*

The rational canonical form writes a matrix as a block-diagonal sum of companion matrices `C(f₁) ⊕ ⋯ ⊕ C(f_k)` with invariant factors `f₁ ∣ ⋯ ∣ f_k`. The classical **readout** recovers the matrix's two distinguished polynomials: `charpoly = ∏ fᵢ` (product) and `minpoly = f_k` (largest). This PR proves the readout for the **two-invariant-factor case**, stated for arbitrary *nonderogatory* blocks (so it applies verbatim to companion matrices).

## New content (sorry-free, axiom-free)

`#print axioms` → only `propext, Classical.choice, Quot.sound`.

- **`aeval_fromBlocks`** — polynomial evaluation distributes over a block-diagonal matrix: `q(A ⊕ D) = q(A) ⊕ q(D)`, by polynomial induction (helper `algebraMap_fromBlocks` splits the scalar matrix into block-diagonal scalar blocks).
- **`minpoly_fromBlocks_of_dvd`** — when `minpoly A ∣ minpoly D`, `minpoly (A ⊕ D) = minpoly D`. This is the **minimal-polynomial counterpart of Mathlib's `charpoly_fromBlocks_zero₁₂`**, which is *missing from Mathlib v4.26.0*. Proved by two-way divisibility (annihilation + reading off the bottom-right block), no module theory or `lcm` bookkeeping.
- **`rcf_two_invariant_factors`** — for nonderogatory blocks (`minpoly = charpoly =` invariant factor) with `f₁ ∣ f₂`: `charpoly (A ⊕ D) = f₁·f₂` and `minpoly (A ⊕ D) = f₂`. The gallery's existing `charpoly(C f) = minpoly(C f) = f` (in `CayleyHamiltonReductionOQ02OQ01`) instantiates the hypotheses with companion matrices.

## Scope / honesty

This is the **readout** direction of RCF. The general `k`-factor case needs a `Sigma`-indexed block matrix (companion blocks of differing degrees do not fit Mathlib's uniform `blockDiagonal`), and the **existence** of the invariant-factor decomposition (the PID module-structure theorem, ~800 lines) is independent — both left as documented open questions.

## Files
- `proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean` (161 lines, 5 theorems, 0 defs)
- `proofs/Proofs.lean` (aggregator import)
- `src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/meta.json`

## Verification
Built against Mathlib v4.26.0 with `lake env lean`; 0 sorries, 0 `axiom` declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)