### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-01-oq-01): Chebyshev's integral inequality — continuous correlation inequality for comonotone functions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -677,6 +677,7 @@ import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChebyshevPNTBridgeOQ03
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevSumMonotoneOQ01
+import Proofs.ChebyshevSumIntegralOQ01OQ01OQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive

--- a/proofs/Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean
@@ -1,0 +1,136 @@
+/-
+# Chebyshev's integral inequality (the continuous Chebyshev sum inequality)
+
+The gallery entry `chebyshev-sum-inequality-oq-01-oq-01` (weighted/discrete Chebyshev)
+proves the *finite* Chebyshev sum inequality with a nonnegative weight vector, and notes
+that the natural next step is the **continuous (integral) Chebyshev inequality**, where the
+weight becomes a measure/density.  This file supplies exactly that.
+
+For a finite measure `μ` and two bounded measurable functions `f, g` that are *comonotone*
+(similarly ordered: `(f x - f y) * (g x - g y) ≥ 0` for all `x, y`), one has
+
+  `(∫ f) * (∫ g) ≤ μ(univ) * ∫ f·g`.
+
+The proof is the classical comonotone (correlation) argument: the symmetric double integral
+`∫∫ (f x - f y)(g x - g y) dμx dμy` is nonnegative because its integrand is, and Fubini plus
+the product-integral identities expand it to `2·(μ(univ)·∫fg − (∫f)(∫g))`.
+
+Mathlib has only the discrete `Finset` Chebyshev inequality (`Mathlib/Algebra/Order/Chebyshev.lean`);
+the integral/measure-theoretic correlation inequality for comonotone functions is not present.
+
+Boundedness keeps every integrability obligation trivial on the finite (and finite product)
+measure, so the result is fully `0`-axiom verified.
+
+Corollaries:
+* `chebyshev_integral_ge_of_antitone`: the reversed inequality for oppositely ordered functions;
+* `chebyshev_integral_sq`: the second-moment / Cauchy–Schwarz bound `(∫f)² ≤ μ(univ)·∫f²`;
+* `chebyshev_integral_prob`: on a probability measure, `(∫f)(∫g) ≤ ∫fg` (covariance ≥ 0).
+-/
+import Mathlib
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace ChebyshevSumIntegral
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+/-- A bounded measurable real function is integrable with respect to a finite measure. -/
+theorem integrable_of_bounded [IsFiniteMeasure μ] {f : α → ℝ} (hf : Measurable f)
+    {C : ℝ} (hC : ∀ x, |f x| ≤ C) : Integrable f μ :=
+  (memLp_top_of_bound hf.aestronglyMeasurable C
+      (Filter.Eventually.of_forall fun x => by simpa [Real.norm_eq_abs] using hC x)).integrable le_top
+
+/-- **Chebyshev's integral inequality.**  For a finite measure `μ` and bounded measurable
+functions `f, g` that are *comonotone* (`(f x - f y)*(g x - g y) ≥ 0` for all `x, y`), the
+average of the product dominates the product of the averages:
+`(∫ f) * (∫ g) ≤ μ(univ) * ∫ f·g`. -/
+theorem chebyshev_integral_mul_le [IsFiniteMeasure μ]
+    {f g : α → ℝ} (hf : Measurable f) (hg : Measurable g)
+    {Cf Cg : ℝ} (hfb : ∀ x, |f x| ≤ Cf) (hgb : ∀ x, |g x| ≤ Cg)
+    (hmono : ∀ x y, 0 ≤ (f x - f y) * (g x - g y)) :
+    (∫ x, f x ∂μ) * (∫ x, g x ∂μ) ≤ μ.real Set.univ * ∫ x, f x * g x ∂μ := by
+  -- integrability of the basic functions on `μ`
+  have hfi : Integrable f μ := integrable_of_bounded hf hfb
+  have hgi : Integrable g μ := integrable_of_bounded hg hgb
+  have hfgi : Integrable (fun x => f x * g x) μ :=
+    integrable_of_bounded (hf.mul hg) (C := Cf * Cg) (fun x => by
+      rw [abs_mul]
+      exact mul_le_mul (hfb x) (hgb x) (abs_nonneg _) (le_trans (abs_nonneg (f x)) (hfb x)))
+  -- the double integral of the comonotone integrand is nonnegative
+  have hnn : 0 ≤ ∫ z, (f z.1 - f z.2) * (g z.1 - g z.2) ∂(μ.prod μ) :=
+    integral_nonneg (fun z => hmono z.1 z.2)
+  -- the four product integrals via Fubini / the product-integral identities
+  have hA : ∫ z, f z.1 * g z.1 ∂(μ.prod μ) = μ.real Set.univ * ∫ x, f x * g x ∂μ := by
+    have := integral_fun_fst (μ := μ) (ν := μ) (fun x => f x * g x)
+    simpa [smul_eq_mul] using this
+  have hD : ∫ z, f z.2 * g z.2 ∂(μ.prod μ) = μ.real Set.univ * ∫ x, f x * g x ∂μ := by
+    have := integral_fun_snd (μ := μ) (ν := μ) (fun x => f x * g x)
+    simpa [smul_eq_mul] using this
+  have hB : ∫ z, f z.1 * g z.2 ∂(μ.prod μ) = (∫ x, f x ∂μ) * ∫ x, g x ∂μ :=
+    integral_prod_mul f g
+  have hC : ∫ z, g z.1 * f z.2 ∂(μ.prod μ) = (∫ x, g x ∂μ) * ∫ x, f x ∂μ :=
+    integral_prod_mul g f
+  -- integrability of the four product functions on the (finite) product measure
+  have hAi : Integrable (fun z : α × α => f z.1 * g z.1) (μ.prod μ) :=
+    Integrable.comp_fst hfgi μ
+  have hDi : Integrable (fun z : α × α => f z.2 * g z.2) (μ.prod μ) :=
+    Integrable.comp_snd hfgi μ
+  have hBi : Integrable (fun z : α × α => f z.1 * g z.2) (μ.prod μ) := hfi.mul_prod hgi
+  have hCi : Integrable (fun z : α × α => g z.1 * f z.2) (μ.prod μ) := hgi.mul_prod hfi
+  have hABi : Integrable (fun z : α × α => f z.1 * g z.1 - f z.1 * g z.2) (μ.prod μ) :=
+    hAi.sub hBi
+  have hABCi : Integrable
+      (fun z : α × α => f z.1 * g z.1 - f z.1 * g z.2 - g z.1 * f z.2) (μ.prod μ) := hABi.sub hCi
+  -- expand the double integral by linearity
+  have hexp : ∫ z, (f z.1 - f z.2) * (g z.1 - g z.2) ∂(μ.prod μ)
+      = ((∫ z, f z.1 * g z.1 ∂(μ.prod μ)) - (∫ z, f z.1 * g z.2 ∂(μ.prod μ))
+          - (∫ z, g z.1 * f z.2 ∂(μ.prod μ))) + (∫ z, f z.2 * g z.2 ∂(μ.prod μ)) := by
+    calc ∫ z, (f z.1 - f z.2) * (g z.1 - g z.2) ∂(μ.prod μ)
+        = ∫ z, (f z.1 * g z.1 - f z.1 * g z.2 - g z.1 * f z.2 + f z.2 * g z.2) ∂(μ.prod μ) := by
+          apply integral_congr_ae; filter_upwards with z; ring
+      _ = ((∫ z, f z.1 * g z.1 ∂(μ.prod μ)) - (∫ z, f z.1 * g z.2 ∂(μ.prod μ))
+            - (∫ z, g z.1 * f z.2 ∂(μ.prod μ))) + (∫ z, f z.2 * g z.2 ∂(μ.prod μ)) := by
+          rw [integral_add hABCi hDi, integral_sub hABi hCi, integral_sub hAi hBi]
+  rw [hexp, hA, hB, hC, hD] at hnn
+  linarith [hnn, mul_comm (∫ x, f x ∂μ) (∫ x, g x ∂μ)]
+
+/-- The reversed Chebyshev integral inequality for *oppositely ordered* (anti-comonotone)
+functions: if `(f x - f y)*(g x - g y) ≤ 0` for all `x, y`, then
+`μ(univ) * ∫ f·g ≤ (∫ f) * (∫ g)`. -/
+theorem chebyshev_integral_ge_of_antitone [IsFiniteMeasure μ]
+    {f g : α → ℝ} (hf : Measurable f) (hg : Measurable g)
+    {Cf Cg : ℝ} (hfb : ∀ x, |f x| ≤ Cf) (hgb : ∀ x, |g x| ≤ Cg)
+    (hanti : ∀ x y, (f x - f y) * (g x - g y) ≤ 0) :
+    μ.real Set.univ * ∫ x, f x * g x ∂μ ≤ (∫ x, f x ∂μ) * ∫ x, g x ∂μ := by
+  have hgb' : ∀ x, |-(g x)| ≤ Cg := fun x => by rw [abs_neg]; exact hgb x
+  have hmono' : ∀ x y, 0 ≤ (f x - f y) * (-(g x) - -(g y)) := fun x y => by
+    nlinarith [hanti x y]
+  have key := chebyshev_integral_mul_le (μ := μ) hf hg.neg hfb hgb' hmono'
+  simp only [mul_neg, integral_neg] at key
+  nlinarith [key]
+
+/-- Second-moment / Cauchy–Schwarz bound: a bounded measurable function always satisfies
+`(∫ f)² ≤ μ(univ) * ∫ f²`.  (Comonotonicity is automatic when `g = f`.) -/
+theorem chebyshev_integral_sq [IsFiniteMeasure μ]
+    {f : α → ℝ} (hf : Measurable f) {C : ℝ} (hfb : ∀ x, |f x| ≤ C) :
+    (∫ x, f x ∂μ) ^ 2 ≤ μ.real Set.univ * ∫ x, f x ^ 2 ∂μ := by
+  have h := chebyshev_integral_mul_le (μ := μ) hf hf hfb hfb (fun x y => mul_self_nonneg _)
+  calc (∫ x, f x ∂μ) ^ 2 = (∫ x, f x ∂μ) * ∫ x, f x ∂μ := by ring
+    _ ≤ μ.real Set.univ * ∫ x, f x * f x ∂μ := h
+    _ = μ.real Set.univ * ∫ x, f x ^ 2 ∂μ := by simp_rw [← pow_two]
+
+/-- On a probability measure, the integral Chebyshev inequality is the statement that two
+comonotone (similarly ordered) random variables have nonnegative covariance:
+`(∫ f) * (∫ g) ≤ ∫ f·g`. -/
+theorem chebyshev_integral_prob [IsProbabilityMeasure μ]
+    {f g : α → ℝ} (hf : Measurable f) (hg : Measurable g)
+    {Cf Cg : ℝ} (hfb : ∀ x, |f x| ≤ Cf) (hgb : ∀ x, |g x| ≤ Cg)
+    (hmono : ∀ x y, 0 ≤ (f x - f y) * (g x - g y)) :
+    (∫ x, f x ∂μ) * (∫ x, g x ∂μ) ≤ ∫ x, f x * g x ∂μ := by
+  have h := chebyshev_integral_mul_le (μ := μ) hf hg hfb hgb hmono
+  have huniv : μ.real Set.univ = 1 := by simp [Measure.real, measure_univ]
+  rw [huniv, one_mul] at h
+  exact h
+
+end ChebyshevSumIntegral

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+  "title": "Chebyshev's Integral Inequality — the Continuous Chebyshev Sum Inequality",
+  "description": "Mathlib formalises only the discrete Finset Chebyshev sum inequality; the integral/measure-theoretic correlation inequality for comonotone functions is absent. We prove it: for a finite measure μ and bounded measurable f, g that are comonotone — (f x − f y)(g x − g y) ≥ 0 for all x, y — the average of the product dominates the product of the averages, (∫ f)(∫ g) ≤ μ(univ)·∫ f·g. The proof is the classical comonotone (correlation) argument: the symmetric double integral ∫∫ (f x − f y)(g x − g y) dμx dμy is nonnegative because its integrand is, and Fubini together with the product-integral identities expands it to 2(μ(univ)·∫fg − (∫f)(∫g)). We add the reversed inequality for anti-comonotone functions, the second-moment / Cauchy–Schwarz bound (∫f)² ≤ μ(univ)·∫f², and the probability-measure form (∫f)(∫g) ≤ ∫fg (nonnegative covariance of comonotone random variables). This answers the second open question of the discrete weighted companion (chebyshev-sum-inequality-oq-01-oq-01).",
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["MeasureTheory"],
+    "namespace": "ChebyshevSumIntegral",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Chebyshev's sum inequality (1880s) states that for two similarly sorted real sequences the average of their products dominates the product of their averages. Its continuous analogue, Chebyshev's integral inequality, replaces the finite sum by an integral against a measure: for monotone (more generally, comonotone) f, g on a probability space, the covariance ∫fg − ∫f·∫g is nonnegative. This is the measure-theoretic correlation inequality underlying the FKG / Chebyshev correlation phenomena. Mathlib formalises only the discrete Finset form (Mathlib.Algebra.Order.Chebyshev); the integral version for comonotone functions is missing. The discrete weighted companion of this entry explicitly named the continuous form as its next open question.",
+    "problemStatement": "Let $\\mu$ be a finite measure on a measurable space $\\alpha$ and let $f, g : \\alpha \\to \\mathbb{R}$ be bounded and measurable and *comonotone*, i.e. $(f(x) - f(y))(g(x) - g(y)) \\ge 0$ for all $x, y$. Then\n\n$$\\Big(\\int f \\, d\\mu\\Big)\\Big(\\int g \\, d\\mu\\Big) \\;\\le\\; \\mu(\\alpha) \\int f g \\, d\\mu.$$\n\nProve the reversed inequality for anti-comonotone $f, g$, the self-comonotone second-moment bound $(\\int f)^2 \\le \\mu(\\alpha) \\int f^2$, and the probability-measure specialisation $(\\int f)(\\int g) \\le \\int f g$ (nonnegative covariance).",
+    "proofStrategy": "The whole family rests on one nonnegative double integral and Fubini.\n\n1. Integrability bookkeeping (integrable_of_bounded): a bounded measurable function is integrable against a finite measure, via memLp_top_of_bound and MemLp.integrable. Boundedness makes every later integrability obligation — including those on the finite product measure μ.prod μ — immediate.\n\n2. Nonnegative integrand: comonotonicity says the pointwise product (f z.1 − f z.2)(g z.1 − g z.2) is ≥ 0 on α × α, so its integral against μ.prod μ is ≥ 0 by integral_nonneg.\n\n3. Fubini expansion: expand the integrand into four monomials f z.i · g z.j. The 'same-coordinate' terms integrate via integral_fun_fst / integral_fun_snd to μ(univ)·∫fg; the 'cross' terms integrate via the product-integral identity integral_prod_mul to (∫f)(∫g) and (∫g)(∫f). Linearity (integral_add / integral_sub, with the four product functions integrable on the finite product measure) assembles ∫∫ = 2(μ(univ)·∫fg − (∫f)(∫g)).\n\n4. Conclusion: nonnegativity of the double integral gives (∫f)(∫g) ≤ μ(univ)·∫fg. The anti-comonotone case applies the theorem to −g; the second-moment bound is the self-comonotone case g = f (whose hypothesis (f x − f y)² ≥ 0 is automatic); the probability case substitutes μ(univ) = 1.",
+    "keyInsights": [
+      "The covariance identity ∫∫ (f x − f y)(g x − g y) dμx dμy = 2(μ(univ)·∫fg − (∫f)(∫g)) is the continuous mirror of the discrete weighted monovariance identity: it holds for ALL bounded measurable data, so the inequality is purely the statement that the symmetric integrand has a fixed sign.",
+      "Comonotonicity — a single pointwise sign hypothesis (f x − f y)(g x − g y) ≥ 0 — is exactly what is needed; it is weaker than requiring f, g monotone and avoids any order structure on α.",
+      "Boundedness, not continuity or L² membership, is the cleanest route to integrability: a bounded measurable function on a finite measure is integrable, and the product (x,y) ↦ f x · g y is bounded measurable on the finite product measure, so Fubini applies with no extra hypotheses.",
+      "The self-comonotone instance g = f needs no hypothesis at all — (f x − f y)² ≥ 0 always — so it yields the second-moment bound (∫f)² ≤ μ(univ)·∫f² (Cauchy–Schwarz against the constant 1) for every bounded measurable f.",
+      "On a probability measure μ(univ) = 1, the inequality is precisely the statement that two comonotone random variables have nonnegative covariance."
+    ],
+    "prerequisites": [
+      "The Bochner integral, integral_nonneg, and linearity (integral_add / integral_sub)",
+      "Fubini's theorem on a product measure: integral_prod_mul, integral_fun_fst / integral_fun_snd",
+      "Integrability of bounded measurable functions on a finite measure (memLp_top_of_bound, MemLp.integrable)",
+      "The discrete Chebyshev sum inequality and its reading as nonnegative covariance"
+    ]
+  },
+  "conclusion": {
+    "summary": "We proved Chebyshev's integral inequality, the continuous correlation inequality that Mathlib omits: for a finite measure μ and bounded measurable comonotone f, g, (∫f)(∫g) ≤ μ(univ)·∫fg, together with the reversed inequality for anti-comonotone functions, the second-moment bound (∫f)² ≤ μ(univ)·∫f², and the probability-measure form (∫f)(∫g) ≤ ∫fg. The engine is the nonnegativity of the symmetric double integral ∫∫ (f x − f y)(g x − g y) dμx dμy, expanded by Fubini to 2(μ(univ)·∫fg − (∫f)(∫g)). All five results are fully machine-checked with 0 sorries and depend only on the foundational axioms.",
+    "implications": "This supplies the measure-theoretic interface to Chebyshev's inequality: a user with a finite measure or probability space obtains the correlation / nonnegative-covariance bound for comonotone observables directly, without re-deriving it, and the self-comonotone case gives the variance/second-moment bound for free. It answers the second open question of the discrete weighted companion (chebyshev-sum-inequality-oq-01-oq-01), completing the discrete → continuous arc of the Chebyshev sum inequality.",
+    "openQuestions": [
+      "Replace the boundedness hypothesis by L² (or L¹·L^∞) membership, obtaining the integral inequality for square-integrable comonotone functions on a finite measure.",
+      "Establish the equality case: (∫f)(∫g) = μ(univ)·∫fg iff f or g is μ-almost-everywhere constant.",
+      "Derive the continuous FKG / weighted power-mean chain by iterating the integral correlation bound against a density."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The discrete weighted Chebyshev sum inequality whose second open question — the continuous (integral) form — this entry answers"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01",
+      "relationship": "related",
+      "description": "The unweighted monotone-sequence Chebyshev sum inequality at the root of this lineage"
+    }
+  ],
+  "references": [
+    {
+      "text": "Hardy, G. H., Littlewood, J. E., Pólya, G. (1952). Inequalities, 2nd ed., Cambridge University Press (Chebyshev's integral inequality, §2.17).",
+      "url": "https://archive.org/details/Inequalities_201705"
+    },
+    {
+      "text": "Chebyshev's sum inequality (with the integral form).",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality"
+    },
+    {
+      "text": "Mathlib4: MeasureTheory.Integral.Prod (Fubini, integral_prod_mul) and Algebra.Order.Chebyshev (discrete form).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Integral/Prod.html"
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "summary": "Imports and an expository docstring contrasting Mathlib's discrete Finset Chebyshev inequality with the continuous integral form proved here, and recording that boundedness keeps every integrability obligation trivial.",
+      "startLine": 1,
+      "endLine": 36
+    },
+    {
+      "id": "integrable-of-bounded",
+      "title": "Bounded Measurable ⇒ Integrable",
+      "summary": "integrable_of_bounded: a bounded measurable real function is integrable against a finite measure, via memLp_top_of_bound and MemLp.integrable. This discharges every integrability side condition in the main argument, including on the finite product measure.",
+      "startLine": 38,
+      "endLine": 42
+    },
+    {
+      "id": "main-inequality",
+      "title": "Chebyshev's Integral Inequality",
+      "summary": "chebyshev_integral_mul_le: the core result (∫f)(∫g) ≤ μ(univ)·∫fg for comonotone bounded measurable f, g. The symmetric double integral of (f z.1 − f z.2)(g z.1 − g z.2) is nonnegative, and Fubini (integral_fun_fst/snd, integral_prod_mul) expands it to 2(μ(univ)·∫fg − (∫f)(∫g)).",
+      "startLine": 44,
+      "endLine": 96
+    },
+    {
+      "id": "antitone",
+      "title": "Reversed Inequality for Anti-Comonotone Functions",
+      "summary": "chebyshev_integral_ge_of_antitone: applying the main theorem to −g yields μ(univ)·∫fg ≤ (∫f)(∫g) when (f x − f y)(g x − g y) ≤ 0 for all x, y.",
+      "startLine": 98,
+      "endLine": 111
+    },
+    {
+      "id": "second-moment",
+      "title": "Second-Moment / Cauchy–Schwarz Bound and Probability Form",
+      "summary": "chebyshev_integral_sq: the self-comonotone case g = f gives (∫f)² ≤ μ(univ)·∫f² for any bounded measurable f. chebyshev_integral_prob: on a probability measure, the inequality reads (∫f)(∫g) ≤ ∫fg — nonnegative covariance of comonotone random variables.",
+      "startLine": 113,
+      "endLine": 134
+    }
+  ],
+  "meta": {
+    "status": "verified",
+    "badge": "original",
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "lineCount": 136,
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "inequalities",
+      "integration",
+      "chebyshev-sum-inequality",
+      "correlation",
+      "covariance",
+      "fubini",
+      "cauchy-schwarz"
+    ],
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean",
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_prod_mul",
+        "description": "∫ z, f z.1 * g z.2 ∂(μ.prod ν) = (∫ f)(∫ g) — Fubini's product-integral identity that evaluates the two cross terms of the expanded double integral",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "integral_fun_fst / integral_fun_snd",
+        "description": "∫ z, h z.1 ∂(μ.prod ν) = ν(univ) • ∫ h (and the symmetric snd form) — evaluates the two same-coordinate terms to μ(univ)·∫fg",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "integral_nonneg",
+        "description": "A pointwise-nonnegative function has nonnegative integral — applied to the comonotone integrand on the product measure",
+        "module": "Mathlib.MeasureTheory.Integral.Bochner.Basic"
+      },
+      {
+        "theorem": "Integrable.comp_fst / Integrable.comp_snd / Integrable.mul_prod",
+        "description": "Integrability of f∘fst, f∘snd, and (x,y) ↦ f x · g y on a finite product measure — the linearity side conditions for the Fubini expansion",
+        "module": "Mathlib.MeasureTheory.Integral.Prod"
+      },
+      {
+        "theorem": "memLp_top_of_bound / MemLp.integrable",
+        "description": "A bounded a.e.-strongly-measurable function lies in L^∞, hence is integrable on a finite measure — the integrable_of_bounded helper",
+        "module": "Mathlib.MeasureTheory.Function.LpSeminorm.Basic"
+      }
+    ],
+    "originalContributions": [
+      "chebyshev_integral_mul_le: Chebyshev's integral inequality (∫f)(∫g) ≤ μ(univ)·∫fg for bounded measurable comonotone f, g on a finite measure — the continuous correlation inequality absent from Mathlib, proved via the nonnegative symmetric double integral and Fubini",
+      "integrable_of_bounded: a bounded measurable function is integrable on a finite measure, the integrability engine that keeps the product-measure Fubini argument hypothesis-free",
+      "chebyshev_integral_ge_of_antitone: the reversed integral inequality μ(univ)·∫fg ≤ (∫f)(∫g) for anti-comonotone f, g, obtained by applying the main theorem to −g",
+      "chebyshev_integral_sq: the second-moment / Cauchy–Schwarz bound (∫f)² ≤ μ(univ)·∫f² for any bounded measurable f (the self-comonotone case)",
+      "chebyshev_integral_prob: the probability-measure form (∫f)(∫g) ≤ ∫fg — nonnegative covariance of comonotone random variables"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves **Chebyshev's integral inequality** — the continuous/measure-theoretic correlation inequality for comonotone functions — answering the **second open question** of the discrete weighted companion `chebyshev-sum-inequality-oq-01-oq-01` ("Extend the weighted bound to the continuous Chebyshev inequality ∫fg·μ(X) ≥ ∫f·∫g for a finite measure μ and monotone f, g").

For a finite measure `μ` and bounded measurable **comonotone** `f, g` (`(f x − f y)(g x − g y) ≥ 0` for all `x, y`):

> `(∫ f)(∫ g) ≤ μ(univ) · ∫ f·g`

**Proof.** The symmetric double integral `∫∫ (f x − f y)(g x − g y) dμx dμy` is nonnegative (pointwise nonneg integrand), and Fubini + the product-integral identities (`integral_prod_mul`, `integral_fun_fst`/`snd`) expand it to `2(μ(univ)·∫fg − (∫f)(∫g))`. Boundedness on the finite (and finite product) measure makes every integrability obligation immediate.

Mathlib has only the **discrete** `Finset` Chebyshev inequality (`Mathlib.Algebra.Order.Chebyshev`); the integral correlation inequality for comonotone functions is **not** present.

## Results (5 theorems, 0 defs, 0 sorries, 0 axioms)

| Theorem | Statement |
|---|---|
| `chebyshev_integral_mul_le` | main: `(∫f)(∫g) ≤ μ(univ)·∫fg` |
| `chebyshev_integral_ge_of_antitone` | reversed inequality for anti-comonotone `f, g` (apply to `−g`) |
| `chebyshev_integral_sq` | second-moment / Cauchy–Schwarz: `(∫f)² ≤ μ(univ)·∫f²` |
| `chebyshev_integral_prob` | probability measure: `(∫f)(∫g) ≤ ∫fg` (covariance ≥ 0) |
| `integrable_of_bounded` | helper: bounded measurable ⇒ integrable on a finite measure |

## Verification

- `lake env lean` clean compile (Lean v4.26.0 / Mathlib 4.26.0), no warnings.
- `#print axioms` for all four results: `[propext, Classical.choice, Quot.sound]` only — **0-axiom verified**.

## Files
- `proofs/Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean` (136 lines)
- `src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json`
- `proofs/Proofs.lean` (aggregator import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)