### PR TITLE
research(de-moivre-oq-05-oq-01-oq-01-oq-01): normalised unitary DFT preserves the Euclidean norm [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -797,6 +797,7 @@ import Proofs.DeMoivreOQ04
 import Proofs.DeMoivreOQ05
 import Proofs.DeMoivreOQ05OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01
+import Proofs.DeMoivreOQ05OQ01OQ01OQ01
 import Proofs.DedekindFrobeniusBridge
 import Proofs.DenumerabilityRationals
 import Proofs.DenumerabilityRationalsOQ01

--- a/proofs/Proofs/DeMoivreOQ05OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ05OQ01OQ01OQ01.lean
@@ -1,0 +1,121 @@
+/-
+The normalised unitary discrete Fourier transform preserves the Euclidean norm
+
+Source: Open question from the de-moivre gallery family
+        (de-moivre-oq-05-oq-01-oq-01-oq-01)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent entry (de-moivre-oq-05-oq-01-oq-01) proved the **Plancherel / Parseval
+theorem** for the *unnormalised* discrete Fourier transform
+
+      x̂(j)  =  ∑_{k<n} x(k)·exp(2πi·jk/n),        ∑_{j<n} |x̂(j)|²  =  n · ∑_{k<n} |x(k)|²,
+
+so the bare DFT is `√n` times a unitary map.  This file performs the final
+normalisation step requested by the parent's first open question: package the
+**normalised** transform
+
+      (Ux)(j)  =  x̂(j) / √n        with kernel   U(j,k) = exp(2πi·jk/n) / √n
+
+and prove that it preserves the Euclidean energy *exactly* — no scale factor —
+
+      ∑_{j<n} |(Ux)(j)|²  =  ∑_{k<n} |x(k)|²,         √(∑_j |(Ux)(j)|²) = √(∑_k |x(k)|²),
+
+and, crucially, **exhibit `U` as a genuine element of the unitary group**: the
+`n × n` matrix `U(j,k) = exp(2πi·jk/n)/√n` satisfies `U · Uᴴ = 1`, i.e.
+`U ∈ Matrix.unitaryGroup (Fin n) ℂ`.
+
+Proof.  Energy preservation is the parent's Parseval divided by `n`: each
+normalised coefficient has `|(Ux)(j)|² = |x̂(j)|² / n`, so summing and using
+`∑_j |x̂(j)|² = n·∑_k |x(k)|²` cancels the `n`.  Matrix unitarity is the
+*column orthonormality* of the kernel: the `(j,l)` entry of `U·Uᴴ` is
+`(1/n)·∑_{k<n} char n j k · conj(char n l k)`, which the parent's character
+orthonormality `char_inner` evaluates to `(1/n)·(n·[j=l]) = [j=l]`, exactly the
+identity matrix.
+
+Theorems:
+1. `udft`                       — the normalised DFT `(Ux)(j) = x̂(j)/√n`
+2. `udft_parseval`              — exact energy law: ∑ |Ux|² = ∑ |x|²
+3. `udft_norm_preserving`       — the ℓ²-norm form ‖Ux‖ = ‖x‖
+4. `dftMatrix`                  — the normalised DFT matrix `U(j,k) = char/√n`
+5. `dftMatrix_mem_unitaryGroup` — `U ∈ Matrix.unitaryGroup (Fin n) ℂ`
+-/
+
+import Mathlib
+import Proofs.DeMoivreOQ05OQ01OQ01
+
+open Finset DeMoivreOQ05OQ01OQ01
+
+namespace DeMoivreOQ05OQ01OQ01OQ01
+
+/-- The **normalised discrete Fourier transform** of a sampled signal
+`x : ℕ → ℂ` of length `n`: `(Ux)(j) = x̂(j) / √n`.  Dividing the parent's
+`√n`-scaled unitary by `√n` turns the DFT into a genuine isometry. -/
+noncomputable def udft (n : ℕ) (x : ℕ → ℂ) (j : ℕ) : ℂ :=
+  dft n x j / (Real.sqrt n : ℂ)
+
+/-- **Parseval for the normalised DFT (energy form).**
+The normalised transform preserves the squared ℓ²-energy *exactly*:
+
+      ∑_{j<n} |(Ux)(j)|²  =  ∑_{k<n} |x(k)|².
+
+This is the parent's `dft_parseval_norm` (`∑|x̂|² = n·∑|x|²`) divided by the
+scale factor `n`. -/
+theorem udft_parseval (n : ℕ) (hn : 0 < n) (x : ℕ → ℂ) :
+    ∑ j ∈ range n, ‖udft n x j‖ ^ 2 = ∑ k ∈ range n, ‖x k‖ ^ 2 := by
+  have hn' : (0 : ℝ) < n := by exact_mod_cast hn
+  have hnz : (n : ℝ) ≠ 0 := hn'.ne'
+  have hden : ‖(Real.sqrt n : ℂ)‖ = Real.sqrt n := by
+    rw [Complex.norm_real, Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg _)]
+  have key : ∀ j, ‖udft n x j‖ ^ 2 = ‖dft n x j‖ ^ 2 / n := by
+    intro j
+    unfold udft
+    rw [norm_div, div_pow, hden, Real.sq_sqrt hn'.le]
+  simp only [key]
+  rw [← Finset.sum_div, dft_parseval_norm n hn x, mul_comm (n : ℝ),
+    mul_div_assoc, div_self hnz, mul_one]
+
+/-- **The normalised DFT preserves the Euclidean (ℓ²) norm.**
+Taking square roots in `udft_parseval`, the ℓ²-norm of `Ux` equals the ℓ²-norm
+of `x`: `‖Ux‖ = ‖x‖`. -/
+theorem udft_norm_preserving (n : ℕ) (hn : 0 < n) (x : ℕ → ℂ) :
+    Real.sqrt (∑ j ∈ range n, ‖udft n x j‖ ^ 2)
+      = Real.sqrt (∑ k ∈ range n, ‖x k‖ ^ 2) := by
+  rw [udft_parseval n hn x]
+
+/-- The **normalised DFT matrix** `U(j,k) = exp(2πi·jk/n) / √n`, an `n × n`
+complex matrix.  This is the operator implementing `udft` on `Fin n → ℂ`. -/
+noncomputable def dftMatrix (n : ℕ) : Matrix (Fin n) (Fin n) ℂ :=
+  fun j k => char n j k / (Real.sqrt n : ℂ)
+
+/-- **The normalised DFT matrix is unitary.**
+`U · Uᴴ = 1`, so `U ∈ Matrix.unitaryGroup (Fin n) ℂ`.  The `(j,l)` entry of
+`U·Uᴴ` is `(1/n)∑_{k<n} char n j k · conj(char n l k)`, which the parent's
+character orthonormality collapses to `[j=l]` — the identity matrix.  This is the
+precise sense in which the discrete Fourier transform "is a unitary map". -/
+theorem dftMatrix_mem_unitaryGroup (n : ℕ) (hn : 0 < n) :
+    dftMatrix n ∈ Matrix.unitaryGroup (Fin n) ℂ := by
+  have hn' : (0 : ℝ) < n := by exact_mod_cast hn
+  have hnz : (n : ℂ) ≠ 0 := by exact_mod_cast hn.ne'
+  rw [Matrix.mem_unitaryGroup_iff]
+  ext j l
+  rw [Matrix.mul_apply, Matrix.one_apply]
+  -- Rewrite each summand `U(j,k)·(Uᴴ)(k,l)` as a fraction over `n`.
+  have hterm : ∀ k : Fin n,
+      dftMatrix n j k * star (dftMatrix n) k l
+        = (char n j k * (starRingEnd ℂ) (char n l k)) / (n : ℂ) := by
+    intro k
+    rw [Matrix.star_eq_conjTranspose, Matrix.conjTranspose_apply]
+    simp only [dftMatrix]
+    rw [← starRingEnd_apply, map_div₀, Complex.conj_ofReal, div_mul_div_comm,
+      ← Complex.ofReal_mul, Real.mul_self_sqrt hn'.le, Complex.ofReal_natCast]
+  simp only [hterm]
+  rw [← Finset.sum_div,
+    Fin.sum_univ_eq_sum_range
+      (fun k => char n j k * (starRingEnd ℂ) (char n l k)) n,
+    char_inner hn j.isLt l.isLt]
+  by_cases h : j = l
+  · subst h
+    rw [if_pos rfl, if_pos rfl, div_self hnz]
+  · rw [if_neg (fun hc => h (Fin.val_injective hc)), if_neg h, zero_div]
+
+end DeMoivreOQ05OQ01OQ01OQ01

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,209 @@
+{
+  "id": "de-moivre-oq-05-oq-01-oq-01-oq-01",
+  "title": "De Moivre OQ-05-OQ-01-OQ-01-OQ-01: The Normalised Unitary DFT Preserves the Euclidean Norm",
+  "slug": "de-moivre-oq-05-oq-01-oq-01-oq-01",
+  "description": "The normalisation step closing the parent's Plancherel/Parseval law: package the transform U(j,k) = exp(2πi·jk/n)/√n and prove it preserves the Euclidean energy exactly, ∑_j |(Ux)(j)|² = ∑_k |x(k)|² (no scale factor), then exhibit U as a genuine element of the unitary group — the n×n matrix U satisfies U·Uᴴ = 1, i.e. U ∈ Matrix.unitaryGroup (Fin n) ℂ.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ05OQ01OQ01OQ01.lean",
+    "tags": [
+      "complex-analysis",
+      "discrete-fourier",
+      "plancherel",
+      "parseval",
+      "unitary-group",
+      "isometry",
+      "orthogonality",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.mem_unitaryGroup_iff",
+        "description": "A ∈ unitaryGroup n α ↔ A · star A = 1; reduces membership in the unitary group to the matrix identity U·Uᴴ = 1",
+        "module": "Mathlib.LinearAlgebra.UnitaryGroup"
+      },
+      {
+        "theorem": "Matrix.conjTranspose_apply",
+        "description": "(Aᴴ) i j = star (A j i); evaluates the Hermitian adjoint of the DFT matrix entrywise",
+        "module": "Mathlib.Data.Matrix.Basic"
+      },
+      {
+        "theorem": "Matrix.mul_apply",
+        "description": "(M·N) i k = ∑ j M i j · N j k; expands the (j,l) entry of U·Uᴴ as a sum over the time index",
+        "module": "Mathlib.Data.Matrix.Basic"
+      },
+      {
+        "theorem": "Fin.sum_univ_eq_sum_range",
+        "description": "∑ i : Fin n, f i = ∑ i ∈ range n, f i; converts the Fintype sum over Fin n into the range-n sum consumed by the parent's char_inner",
+        "module": "Mathlib.Algebra.BigOperators.Fin"
+      },
+      {
+        "theorem": "Real.mul_self_sqrt",
+        "description": "0 ≤ a → √a · √a = a; cancels the two 1/√n normalisation factors into a single 1/n",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Real.sq_sqrt",
+        "description": "0 ≤ a → (√a)² = a; turns ‖(√n:ℂ)‖² into n in the energy computation",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "Complex.conj_ofReal",
+        "description": "conj (↑r) = ↑r for real r; the conjugate of the real normalisation factor √n is itself",
+        "module": "Mathlib.Data.Complex.Basic"
+      },
+      {
+        "theorem": "DeMoivreOQ05OQ01OQ01.char_inner",
+        "description": "Parent result: orthonormality of the DFT kernel ∑_{k<n} char(a,k)·conj(char(b,k)) = n·[a=b] for a,b<n — the sole nontrivial input to the unitarity of U",
+        "module": "Proofs.DeMoivreOQ05OQ01OQ01"
+      },
+      {
+        "theorem": "DeMoivreOQ05OQ01OQ01.dft_parseval_norm",
+        "description": "Parent result: ∑_j ‖x̂(j)‖² = n·∑_k ‖x(k)‖²; dividing by n gives the exact (scale-free) energy law for the normalised transform",
+        "module": "Proofs.DeMoivreOQ05OQ01OQ01"
+      }
+    ],
+    "originalContributions": [
+      "udft: the normalised discrete Fourier transform (Ux)(j) = x̂(j)/√n, dividing the parent's √n-scaled isometry by √n to obtain a genuine isometry",
+      "udft_parseval: the exact energy law ∑_{j<n} |(Ux)(j)|² = ∑_{k<n} |x(k)|² with NO scale factor — the parent's ∑|x̂|² = n·∑|x|² divided by n",
+      "udft_norm_preserving: the ℓ²-norm form √(∑_j |(Ux)(j)|²) = √(∑_k |x(k)|²), i.e. ‖Ux‖ = ‖x‖",
+      "dftMatrix: the normalised DFT matrix U(j,k) = exp(2πi·jk/n)/√n as an explicit element of Matrix (Fin n) (Fin n) ℂ",
+      "dftMatrix_mem_unitaryGroup: U ∈ Matrix.unitaryGroup (Fin n) ℂ — the (j,l) entry of U·Uᴴ is (1/n)∑_{k<n} char(j,k)·conj(char(l,k)) = [j=l], so U·Uᴴ = 1, exhibiting the DFT as a genuine unitary operator"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 121,
+    "assumptions": "0 axioms, 0 sorries (proofs depend only on propext / Classical.choice / Quot.sound). The two nontrivial mathematical inputs are both parent results: the energy law dft_parseval_norm and the character orthonormality char_inner. The normalisation itself is √n·√n = n bookkeeping plus the standard Matrix.unitaryGroup membership criterion U·Uᴴ = 1.",
+    "theoremCount": 3,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The unitarity of the normalised discrete Fourier transform is the cornerstone of digital signal processing: it is what makes the DFT (and its fast algorithm, the FFT) an energy-preserving, perfectly invertible change of orthonormal basis on ℂ^n. Parseval (1799) and Plancherel (1910) supply the energy identity; recasting it as the membership U ∈ U(n) of an explicit matrix in the unitary group is the modern operator-theoretic statement. The parent entry proved the unnormalised energy law (the DFT is √n times a unitary); this entry performs the final normalisation and packages the result as a bona-fide unitary matrix.",
+    "problemStatement": "**Open Question** (parent de-moivre-oq-05-oq-01-oq-01): package the normalised transform $U(j,k) = e^{2\\pi i jk/n}/\\sqrt n$ and prove $\\lVert Ux\\rVert = \\lVert x\\rVert$ exactly, exhibiting $U$ as an element of the unitary group.\n\n**Answer**: Define $(Ux)(j) = \\hat x(j)/\\sqrt n$. Then $\\sum_{j<n}|(Ux)(j)|^2 = \\sum_{k<n}|x(k)|^2$ with no scale factor, and the $n\\times n$ matrix $U(j,k) = e^{2\\pi i jk/n}/\\sqrt n$ satisfies $U U^{\\mathsf H} = 1$, i.e. $U \\in \\mathrm{unitaryGroup}(\\mathrm{Fin}\\,n)\\,\\mathbb C$. The energy law is the parent's Parseval divided by $n$; the matrix unitarity is the parent's character orthonormality $\\sum_{k<n}\\chi_j(k)\\overline{\\chi_l(k)} = n[j=l]$ scaled by $1/n$.",
+    "text": "The normalised DFT $U = \\tfrac1{\\sqrt n}\\,\\mathrm{DFT}$ preserves the Euclidean norm exactly and is a genuine element of the unitary group, obtained from the parent's Plancherel/Parseval law and character orthonormality by the single normalisation $\\sqrt n\\cdot\\sqrt n = n$.",
+    "proofStrategy": "1. **Exact energy law** (`udft_parseval`): each normalised coefficient has $|(Ux)(j)|^2 = |\\hat x(j)|^2/n$ (since $\\lVert(\\sqrt n:\\mathbb C)\\rVert^2 = n$ via `Real.sq_sqrt`); summing and substituting the parent's $\\sum_j|\\hat x(j)|^2 = n\\sum_k|x(k)|^2$ cancels the $n$, leaving $\\sum_j|(Ux)(j)|^2 = \\sum_k|x(k)|^2$.\n2. **Norm form** (`udft_norm_preserving`): take $\\sqrt{\\cdot}$ of both sides to get the literal $\\lVert Ux\\rVert = \\lVert x\\rVert$.\n3. **The DFT matrix** (`dftMatrix`): define $U(j,k) = \\mathrm{char}(j,k)/\\sqrt n$ on $\\mathrm{Fin}\\,n$.\n4. **Unitarity** (`dftMatrix_mem_unitaryGroup`): by `Matrix.mem_unitaryGroup_iff` it suffices to show $U U^{\\mathsf H} = 1$. The $(j,l)$ entry is $\\sum_{k} U(j,k)\\overline{U(l,k)} = \\tfrac1n\\sum_{k<n}\\mathrm{char}(j,k)\\overline{\\mathrm{char}(l,k)}$ (using $\\overline{\\sqrt n} = \\sqrt n$ and $\\sqrt n\\cdot\\sqrt n = n$); the parent's orthonormality `char_inner` evaluates the sum to $n[j=l]$, giving $[j=l]$ — exactly the identity matrix."
+    ,
+    "keyInsights": [
+      "Unitarity is not new analysis — it is the parent's character orthonormality divided by n; the whole content beyond the parent is the cancellation √n·√n = n",
+      "Working with an explicit Matrix (Fin n) (Fin n) ℂ and Matrix.unitaryGroup gives the genuine operator-theoretic statement 'U is unitary' (U·Uᴴ = 1), strictly more than the scalar energy identity the parent supplied",
+      "The conjugate of the real normalisation factor is itself (conj √n = √n), so the two 1/√n factors in U(j,k)·conj(U(l,k)) combine cleanly into a single 1/n in front of the orthonormality sum",
+      "Fin.sum_univ_eq_sum_range is the quiet bridge: the unitary-group criterion sums over the Fintype Fin n, but the parent's char_inner is stated over Finset.range n — the two sums are definitionally matched once the index is reindexed",
+      "Exact (scale-free) norm preservation ‖Ux‖ = ‖x‖ is the right normalisation for signal processing: it makes U an isometry of ℂ^n, the property the FFT inherits"
+    ],
+    "prerequisites": [
+      "Plancherel / Parseval for the unnormalised DFT (parent de-moivre-oq-05-oq-01-oq-01)",
+      "Orthonormality of the discrete Fourier characters (char_inner)",
+      "The unitary group of matrices and the criterion U·Uᴴ = 1",
+      "Real square roots: √n·√n = n and (√n)² = n for n ≥ 0"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the normalisation of the parent's √n·unitary DFT into a genuine unitary, the exact energy law, and the unitary-group membership",
+      "startLine": 1,
+      "endLine": 51,
+      "mathContext": "**Goal**: $\\sum_j|(Ux)(j)|^2 = \\sum_k|x(k)|^2$ and $U \\in \\mathrm{unitaryGroup}(\\mathrm{Fin}\\,n)\\,\\mathbb C$ for $U(j,k) = e^{2\\pi i jk/n}/\\sqrt n$."
+    },
+    {
+      "id": "energy",
+      "title": "Part I: The Normalised Transform and Exact Energy Law",
+      "summary": "udft, udft_parseval, udft_norm_preserving: (Ux)(j) = x̂(j)/√n, the scale-free Parseval ∑|Ux|² = ∑|x|², and its ℓ²-norm form ‖Ux‖ = ‖x‖",
+      "startLine": 53,
+      "endLine": 85,
+      "mathContext": "$\\sum_{j<n}|(Ux)(j)|^2 = \\sum_{k<n}|x(k)|^2$ — the normalised DFT is an exact isometry of $\\ell^2$ energy."
+    },
+    {
+      "id": "unitary",
+      "title": "Part II: The DFT Matrix is Unitary",
+      "summary": "dftMatrix and dftMatrix_mem_unitaryGroup: the matrix U(j,k) = char(j,k)/√n and the proof U·Uᴴ = 1 via the parent's character orthonormality scaled by 1/n",
+      "startLine": 87,
+      "endLine": 121,
+      "mathContext": "$U U^{\\mathsf H} = 1$, i.e. $U \\in \\mathrm{unitaryGroup}(\\mathrm{Fin}\\,n)\\,\\mathbb C$ — the discrete Fourier transform is a genuine unitary operator."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization closes the parent entry's first open question: it normalises the discrete Fourier transform to U(j,k) = exp(2πi·jk/n)/√n, proves that U preserves the Euclidean ℓ²-energy exactly (∑_j |(Ux)(j)|² = ∑_k |x(k)|², hence ‖Ux‖ = ‖x‖), and exhibits U as a genuine element of the unitary group — the n×n matrix U satisfies U·Uᴴ = 1, i.e. U ∈ Matrix.unitaryGroup (Fin n) ℂ. The energy law is the parent's Parseval divided by n; the matrix unitarity is the parent's character orthonormality scaled by 1/n. All three theorems are fully proved with zero sorries and zero axioms.",
+    "implications": "Completes the de-moivre DFT family with the operator-theoretic statement of the Fourier transform: the normalised DFT is a unitary of ℂ^n. This is the exact form used in digital signal processing and the FFT — a perfectly invertible, energy-preserving orthonormal change of basis — and it places the explicit exponential DFT inside Mathlib's abstract Matrix.unitaryGroup machinery.",
+    "openQuestions": [
+      "DFT inversion as the adjoint: prove the explicit inverse x(k) = (1/n)∑_j x̂(j)·exp(-2πi·jk/n) and identify it with Uᴴ = U⁻¹ now that U is known unitary",
+      "Cyclic convolution theorem: (x ⋆ y)^(j) = x̂(j)·ŷ(j), the multiplicative companion to this additive energy law",
+      "Package U as a LinearIsometryEquiv on EuclideanSpace ℂ (Fin n), upgrading the matrix-level unitarity to an explicit isometric isomorphism"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05-oq-01-oq-01",
+      "relationship": "Parent: proves Plancherel/Parseval for the unnormalised DFT (∑|x̂|² = n·∑|x|²) and the character orthonormality char_inner; this entry answers its first open question by normalising to a genuine unitary U with U·Uᴴ = 1"
+    },
+    {
+      "id": "de-moivre-oq-05-oq-01",
+      "relationship": "Grandparent: proves the orthonormality of the discrete Fourier characters (sum_char_inner), the single nontrivial input behind the unitarity of U"
+    },
+    {
+      "id": "de-moivre-oq-05",
+      "relationship": "Great-grandparent: the roots-of-unity vanishing sum ∑ ζ^k = 0, the seed of the orthogonality this unitarity rests on"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DeMoivreOQ05OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "DeMoivreOQ05OQ01OQ01"
+    ],
+    "namespace": "DeMoivreOQ05OQ01OQ01OQ01",
+    "lineCount": 121,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 2,
+    "path": "Proofs/DeMoivreOQ05OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Marc-Antoine Parseval",
+      "title": "Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre",
+      "year": "1799",
+      "venue": "Mémoires présentés à l'Institut des Sciences"
+    },
+    {
+      "authors": "Michel Plancherel",
+      "title": "Contribution à l'étude de la représentation d'une fonction arbitraire par des intégrales définies",
+      "year": "1910",
+      "venue": "Rendiconti del Circolo Matematico di Palermo"
+    },
+    {
+      "authors": "James W. Cooley and John W. Tukey",
+      "title": "An Algorithm for the Machine Calculation of Complex Fourier Series",
+      "year": "1965",
+      "venue": "Mathematics of Computation"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent formalization (Plancherel/Parseval and character orthonormality); this entry normalises the √n·unitary DFT into a genuine unitary U and proves U·Uᴴ = 1, answering its first open question."
+    },
+    {
+      "targetId": "de-moivre-oq-05-oq-01",
+      "relationship": "foundational",
+      "description": "Grandparent character orthonormality sum_char_inner, the single nontrivial input behind the unitarity of the normalised DFT matrix."
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "foundational",
+      "description": "Euler's formula identifies the sampling characters exp(2πi·jk/n) whose normalisation this entry shows is unitary."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the first open question of the parent entry **de-moivre-oq-05-oq-01-oq-01** (Plancherel/Parseval for the DFT): *"package the transform U(j,k) = exp(2πi·jk/n)/√n and prove ‖Ux‖ = ‖x‖ exactly, exhibiting U as an element of the unitary group."*

The parent proved the **unnormalised** energy law ∑_j |x̂(j)|² = n·∑_k |x(k)|² — the DFT is √n times a unitary. This entry performs the final normalisation and packages the result as a genuine unitary operator.

## Results (`Proofs/DeMoivreOQ05OQ01OQ01OQ01.lean`)

- **`udft`** — the normalised transform (Ux)(j) = x̂(j)/√n
- **`udft_parseval`** — exact, scale-free energy law: ∑_{j<n} |(Ux)(j)|² = ∑_{k<n} |x(k)|²
- **`udft_norm_preserving`** — the ℓ²-norm form ‖Ux‖ = ‖x‖
- **`dftMatrix`** — the n×n matrix U(j,k) = exp(2πi·jk/n)/√n
- **`dftMatrix_mem_unitaryGroup`** — **U ∈ Matrix.unitaryGroup (Fin n) ℂ**, i.e. U·Uᴴ = 1

## Proof idea

Pure normalisation of parent results, with the cancellation √n·√n = n doing the work:
- **Energy law** = parent's `dft_parseval_norm` (∑|x̂|² = n·∑|x|²) divided by n.
- **Matrix unitarity**: the (j,l) entry of U·Uᴴ is (1/n)·∑_{k<n} char(j,k)·conj(char(l,k)), which the parent's character orthonormality `char_inner` evaluates to (1/n)·(n·[j=l]) = [j=l] — exactly the identity matrix.

## Verification

- **3 theorems, 2 definitions, 121 lines**
- **0 sorries, 0 axioms** — `#print axioms` lists only `propext / Classical.choice / Quot.sound`
- Lean 4.26.0 / Mathlib; gallery `meta.json` added; aggregator `Proofs.lean` import added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)