### PR TITLE
research: two-coefficient closed form for quadratically-weighted partial alternating binomial sum (combinations-formula-oq-05-oq-01-oq-01-oq-01)

### DIFF
--- a/proofs/Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean
@@ -1,0 +1,163 @@
+import Mathlib
+
+/-
+# A Two-Coefficient Closed Form for the Quadratically-Weighted Partial Alternating Binomial Sum
+
+## Open Question OQ-05-OQ-01-OQ-01-OQ-01
+
+The parent (`CombinationsFormulaOQ05OQ01OQ01`) gives the sharp single-coefficient
+closed form for the **linearly weighted partial** alternating binomial sum,
+
+  ∑_{k=0}^{j} (-1)^k · k · C(n, k) = n · (-1)^j · C(n-2, j-1)      (n ≥ 2),
+
+and asks (its first open question): does the **quadratically weighted** partial
+sum admit an analogous closed form, obtained by absorbing `k² = k(k-1) + k` into
+two row shifts?
+
+This file answers that question.  The quadratic weight does **not** collapse to a
+single binomial — instead it produces a *two-coefficient* closed form, one
+binomial from each of the two row shifts:
+
+  ∑_{k=0}^{j} (-1)^k · k² · C(n, k)
+      = (-1)^j · n · ( (n-1) · C(n-3, j-2) + C(n-2, j-1) )      (n ≥ 3).      (★)
+
+The mechanism is the identity `k² = k(k-1) + k`.  The piece `k(k-1)·C(n,k) =
+n(n-1)·C(n-2,k-2)` shifts the row down by two, contributing the binomial
+`C(n-3, j-2)` (scaled by `n(n-1)`); the piece `k·C(n,k) = n·C(n-1,k-1)` shifts
+the row down by one, contributing `C(n-2, j-1)` (scaled by `n`), exactly the
+parent's single coefficient.  So one quadratic weight produces precisely **two**
+surviving binomials — the predicted two-coefficient form.
+
+Specialising `j` to the full row recovers the classical vanishing of the
+quadratically weighted alternating row sum `∑_{k=0}^{n} (-1)^k k² C(n,k) = 0`
+for `n ≥ 3` (a second finite difference of a constant sequence killing a degree
+`< n` polynomial weight).
+
+Equivalently, with no natural-number subtraction (the form actually proved by
+induction below),
+
+  ∑_{k=0}^{j+2} (-1)^k · k² · C(n+3, k)
+      = (-1)^j · (n+3) · ( (n+2) · C(n, j) + C(n+1, j+1) )     (all n, j).    (★')
+
+## Results
+
+1. `quad_weighted_partial_alternating_sum`            — (★') clean form, all `n, j`.
+2. `quad_weighted_partial_alternating_sum_sub`        — (★) literal `C(n-3,·)`,`C(n-2,·)` form, `n ≥ 3`.
+3. `quad_weighted_partial_alternating_sum_stabilizes` — the partial sums are `0` once `j ≥ n` (`n ≥ 3`).
+4. `quad_weighted_full_row_eq_zero`                   — recovers the anchor `∑_{k=0}^{n} (-1)^k k² C(n,k) = 0` (`n ≥ 3`).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ05OQ01OQ01OQ01
+
+open Finset
+
+/-- **Main identity (subtraction-free form).** For all `n, j`,
+    `∑_{k=0}^{j+2} (-1)^k · k² · C(n+3, k) = (n+3) · (-1)^j · ((n+2)·C(n,j) + C(n+1,j+1))`
+    in `ℤ`.
+
+    Proof by induction on `j`.  The inductive step rewrites the new weighted term
+    `(j+3)² · C(n+3, j+3)` via two applications of the binomial **absorption
+    identity** `(k+1)·C(m+1,k+1) = (m+1)·C(m,k)` (`Nat.add_one_mul_choose_eq`) into
+    `(n+3)·((n+2)·C(n+1,j+1) + C(n+2,j+2))` (lemma `key`), and then two uses of
+    Pascal's rule `C(m+1,k+1) = C(m,k) + C(m,k+1)` (`Nat.choose_succ_succ`)
+    telescope the two surviving coefficients down to row `n`.  All `(-1)`-power
+    bookkeeping and the scalars are discharged by `linear_combination` over `ring`. -/
+theorem quad_weighted_partial_alternating_sum (n j : ℕ) :
+    ∑ k ∈ range (j + 3), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * ((n + 3).choose k : ℤ))
+      = (-1 : ℤ) ^ j * (n + 3 : ℤ)
+          * (((n : ℤ) + 2) * (n.choose j : ℤ) + ((n + 1).choose (j + 1) : ℤ)) := by
+  induction j with
+  | zero =>
+    -- `∑_{k=0}^{2} = 0 - C(n+3,1) + 4·C(n+3,2)`; uses `2·C(n+3,2) = (n+3)(n+2)`.
+    have h := Nat.add_one_mul_choose_eq (n + 2) 1
+    have h2 := congrArg (Nat.cast (R := ℤ)) h
+    push_cast [Nat.choose_one_right] at h2
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero, zero_add,
+      Nat.choose_one_right, Nat.choose_zero_right]
+    push_cast
+    linear_combination -2 * h2
+  | succ j ih =>
+    rw [Finset.sum_range_succ, ih]
+    -- Absorption I: `(n+3)·C(n+2,j+2) = C(n+3,j+3)·(j+3)`.
+    have hI : ((n : ℤ) + 3) * ((n + 2).choose (j + 2) : ℤ)
+        = ((n + 3).choose (j + 3) : ℤ) * ((j : ℤ) + 3) := by
+      have h := Nat.add_one_mul_choose_eq (n + 2) (j + 2)
+      have h2 := congrArg (Nat.cast (R := ℤ)) h
+      push_cast at h2
+      linear_combination h2
+    -- Absorption II: `(n+2)·C(n+1,j+1) = C(n+2,j+2)·(j+2)`.
+    have hII : ((n : ℤ) + 2) * ((n + 1).choose (j + 1) : ℤ)
+        = ((n + 2).choose (j + 2) : ℤ) * ((j : ℤ) + 2) := by
+      have h := Nat.add_one_mul_choose_eq (n + 1) (j + 1)
+      have h2 := congrArg (Nat.cast (R := ℤ)) h
+      push_cast at h2
+      linear_combination h2
+    -- The new weighted term, rewritten by the two absorptions.
+    have key : ((j : ℤ) + 3) ^ 2 * ((n + 3).choose (j + 3) : ℤ)
+        = ((n : ℤ) + 3)
+            * (((n : ℤ) + 2) * ((n + 1).choose (j + 1) : ℤ)
+                + ((n + 2).choose (j + 2) : ℤ)) := by
+      linear_combination (-(j : ℤ) - 3) * hI + (-(n : ℤ) - 3) * hII
+    -- Pascal a: `C(n+1,j+1) = C(n,j) + C(n,j+1)`.
+    have pa : ((n + 1).choose (j + 1) : ℤ) = (n.choose j : ℤ) + (n.choose (j + 1) : ℤ) := by
+      rw [Nat.choose_succ_succ]; push_cast; ring
+    -- Pascal b: `C(n+2,j+2) = C(n+1,j+1) + C(n+1,j+2)`.
+    have pb : ((n + 2).choose (j + 2) : ℤ)
+        = ((n + 1).choose (j + 1) : ℤ) + ((n + 1).choose (j + 2) : ℤ) := by
+      rw [Nat.choose_succ_succ]; push_cast; ring
+    push_cast
+    linear_combination (-((-1 : ℤ) ^ j)) * key
+      + (-((-1 : ℤ) ^ j) * ((n : ℤ) + 3) * ((n : ℤ) + 2)) * pa
+      + (-((-1 : ℤ) ^ j) * ((n : ℤ) + 3)) * pb
+
+/-- **Two-coefficient closed form (literal subtraction form).** For `n ≥ 3` and any
+    `j`,
+    `∑_{k=0}^{j+2} (-1)^k · k² · C(n,k) = (-1)^j · n · ((n-1)·C(n-3,j) + C(n-2,j+1))`
+    in `ℤ`.
+
+    This is `(★)` with the cut-off written as `j+2`, exhibiting the two surviving
+    coefficients as binomials of rows `n-3` and `n-2`. -/
+theorem quad_weighted_partial_alternating_sum_sub {n : ℕ} (hn : 3 ≤ n) (j : ℕ) :
+    ∑ k ∈ range (j + 3), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (n.choose k : ℤ))
+      = (-1 : ℤ) ^ j * (n : ℤ)
+          * (((n : ℤ) - 1) * ((n - 3).choose j : ℤ) + ((n - 2).choose (j + 1) : ℤ)) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 3 := ⟨n - 3, by omega⟩
+  rw [show m + 3 - 3 = m from rfl, show m + 3 - 2 = m + 1 from rfl,
+    quad_weighted_partial_alternating_sum m j]
+  push_cast; ring
+
+/-- **Stabilisation.** Once the cut-off reaches the row length the quadratically
+    weighted partial sums are already `0`: for `n ≥ 3` and `j ≥ n`,
+    `∑_{k=0}^{j} (-1)^k · k² · C(n, k) = 0`.
+
+    Reason: both binomials in the closed form vanish, `C(n-3, j-2) = 0` and
+    `C(n-2, j-1) = 0`, since `j - 2 ≥ n - 2 > n - 3`. -/
+theorem quad_weighted_partial_alternating_sum_stabilizes {n : ℕ} (hn : 3 ≤ n) {j : ℕ}
+    (hj : n ≤ j) :
+    ∑ k ∈ range (j + 1), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (n.choose k : ℤ)) = 0 := by
+  obtain ⟨i, rfl⟩ : ∃ i, j = i + 2 := ⟨j - 2, by omega⟩
+  rw [show i + 2 + 1 = i + 3 from rfl, quad_weighted_partial_alternating_sum_sub hn i]
+  have h1 : (n - 3).choose i = 0 := Nat.choose_eq_zero_of_lt (by omega)
+  have h2 : (n - 2).choose (i + 1) = 0 := Nat.choose_eq_zero_of_lt (by omega)
+  rw [h1, h2]; simp
+
+/-- **Recovers the classical anchor.** The full quadratically weighted alternating
+    row sum vanishes for `n ≥ 3`, obtained as the special case `j = n` of the
+    closed form (both binomials are `0`). -/
+theorem quad_weighted_full_row_eq_zero {n : ℕ} (hn : 3 ≤ n) :
+    ∑ k ∈ range (n + 1), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (n.choose k : ℤ)) = 0 :=
+  quad_weighted_partial_alternating_sum_stabilizes hn (le_refl n)
+
+/-- Sanity check of the clean closed form at `n = 0, j = 0`:
+    LHS `= 0 - 1·C(3,1) + 4·C(3,2) = -3 + 12 = 9`; RHS `= 3·((2)·C(0,0) + C(1,1)) = 9`. -/
+example :
+    ∑ k ∈ range 3, ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (Nat.choose 3 k : ℤ)) = 9 := by decide
+
+/-- Sanity check of the full-row vanishing at `n = 4`:
+    `0 - 1·4 + 4·6 - 9·4 + 16·1 = -4 + 24 - 36 + 16 = 0`. -/
+example :
+    ∑ k ∈ range 5, ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (Nat.choose 4 k : ℤ)) = 0 := by decide
+
+end CombinationsFormulaOQ05OQ01OQ01OQ01

--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "split-two-shifts-context",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 55
+    },
+    "type": "concept",
+    "title": "Two Shifts from One Quadratic Weight",
+    "content": "The parent found that the linearly weighted partial sum ∑_{k=0}^{j} (-1)^k k C(n,k) collapses to a single binomial n (-1)^j C(n-2,j-1). This entry answers its first open question: what happens to the quadratic weight k²? The key is the split k² = k(k-1) + k. The piece k(k-1) C(n,k) = n(n-1) C(n-2,k-2) absorbs the weight into a shift of the row down by two, contributing a binomial of row n-3; the piece k C(n,k) = n C(n-1,k-1) shifts the row down by one, reproducing the parent's binomial of row n-2. Because the two pieces land on different rows, they cannot be merged — the answer is a genuine two-coefficient closed form (-1)^j n ((n-1) C(n-3,j-2) + C(n-2,j-1)).",
+    "mathContext": "With $a_k = (-1)^k k^2 \\binom{n}{k}$ and $k^2 = k(k-1) + k$, $\\sum_{k=0}^{j} a_k = n(n-1)\\sum_{k} (-1)^k \\binom{n-2}{k-2} + n\\sum_{k}(-1)^k\\binom{n-1}{k-1}$. Each inner partial sum telescopes (the parent's mechanism) to a single binomial, giving $(-1)^j\\,n\\bigl((n-1)\\binom{n-3}{j-2} + \\binom{n-2}{j-1}\\bigr)$. The full-row vanishing is the case $j = n$, where both $\\binom{n-3}{n-2}$ and $\\binom{n-2}{n-1}$ are $0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "falling-factorial split k² = k(k-1) + k",
+      "absorption identity k(k-1) C(n,k) = n(n-1) C(n-2,k-2)",
+      "telescoping sums",
+      "Stirling numbers of the second kind",
+      "weighted alternating binomial identities"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "absorption Nat.add_one_mul_choose_eq",
+      "Pascal's rule Nat.choose_succ_succ",
+      "induction over Finset.range"
+    ]
+  },
+  {
+    "id": "main-identity-induction",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 114
+    },
+    "type": "technique",
+    "title": "Subtraction-Free Induction with a Composed Absorption",
+    "content": "The clean form ∑_{k=0}^{j+2} (-1)^k k² C(n+3,k) = (n+3) (-1)^j ((n+2) C(n,j) + C(n+1,j+1)) is proved by induction on j, avoiding all natural-number subtraction. The crux is the helper lemma key, which rewrites the new term (j+3)² C(n+3,j+3) using the absorption identity twice: one factor of (j+3) is absorbed against row n+3 to give (n+3) C(n+2,j+2), and the residual (j+3) is split as (j+2)+1 so its (j+2) part absorbs against row n+2 to give (n+2) C(n+1,j+1). The net rewrite is (j+3)² C(n+3,j+3) = (n+3) ((n+2) C(n+1,j+1) + C(n+2,j+2)). Two Pascal steps then telescope both coefficients to row n.",
+    "mathContext": "Inductive step: the running sum gains $(-1)^{j+3}(j+3)^2\\binom{n+3}{j+3}$. Absorption $\\binom{m+1}{k+1}(k+1) = (m+1)\\binom{m}{k}$ applied at $(m,k) = (n+2,j+2)$ and $(n+1,j+1)$ yields $\\texttt{key}$; Pascal $\\binom{m+1}{k+1} = \\binom{m}{k} + \\binom{m}{k+1}$ at $(n,j)$ and $(n+1,j+1)$ telescopes. All signed-power bookkeeping is handed to one `linear_combination` over `ring`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "subtraction-free induction",
+      "composed absorption identities",
+      "linear_combination tactic",
+      "Pascal's rule telescoping"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ",
+      "Nat.add_one_mul_choose_eq",
+      "Nat.choose_succ_succ",
+      "linear_combination over ring"
+    ]
+  },
+  {
+    "id": "literal-form-note",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 115,
+      "endLine": 129
+    },
+    "type": "concept",
+    "title": "The Literal Two-Coefficient Form",
+    "content": "Writing n = m+3 turns the subtraction-free identity into the literal closed form ∑_{k=0}^{j+2} (-1)^k k² C(n,k) = (-1)^j n ((n-1) C(n-3,j) + C(n-2,j+1)) for n ≥ 3. The two binomials C(n-3,·) and C(n-2,·) are exactly the contributions of the two row shifts coming from k(k-1) and k respectively. The reduction is a single rw of the natural-number subtractions m+3-3 = m and m+3-2 = m+1 (both definitional), followed by push_cast and ring.",
+    "mathContext": "$\\sum_{k=0}^{j+2} (-1)^k k^2 \\binom{n}{k} = (-1)^j\\,n\\bigl((n-1)\\binom{n-3}{j} + \\binom{n-2}{j+1}\\bigr)$ for $n \\ge 3$. The factor $n(n-1)$ in front of $\\binom{n-3}{\\cdot}$ is the falling factorial $(n)_2$ from the double absorption of $k(k-1)$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "natural-number subtraction",
+      "definitional reduction",
+      "falling factorial (n)_2"
+    ],
+    "prerequisites": [
+      "Nat subtraction",
+      "push_cast",
+      "ring"
+    ]
+  },
+  {
+    "id": "stabilization-note",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 131,
+      "endLine": 151
+    },
+    "type": "concept",
+    "title": "Stabilisation and the Classical Full-Row Vanishing",
+    "content": "Once the cut-off j reaches the row length n, both binomials in the closed form vanish: C(n-3,j-2) = 0 and C(n-2,j-1) = 0 because j-2 ≥ n-2 > n-3. Hence the quadratically weighted partial sums are already 0 for j ≥ n. The special case j = n is the classical vanishing of the full quadratically weighted alternating row sum ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) — recovered here as a corollary, with both surviving coefficients explicitly shown to be 0.",
+    "mathContext": "For $j \\ge n$, $\\binom{n-3}{j-2} = 0$ since $j-2 > n-3$, and $\\binom{n-2}{j-1} = 0$ since $j-1 > n-2$. The degree-2 weight $k^2$ is annihilated by the $n$-fold alternating difference once $n > 2$, i.e. $n \\ge 3$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "finite differences",
+      "Nat.choose_eq_zero_of_lt",
+      "polynomial degree vs row length"
+    ],
+    "prerequisites": [
+      "Nat.choose_eq_zero_of_lt"
+    ]
+  },
+  {
+    "id": "verification-note",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 153,
+      "endLine": 163
+    },
+    "type": "concept",
+    "title": "Worked Verifications by Kernel Decide",
+    "content": "Two concrete checks confirm the formula and the vanishing. Row 3 cut at j = 2: 0 − 1·C(3,1) + 4·C(3,2) = −3 + 12 = 9, matching (n+3=3) 3 ((2) C(0,0) + C(1,1)) = 3·3 = 9. Full row 4: 0 − 1·4 + 4·6 − 9·4 + 16·1 = −4 + 24 − 36 + 16 = 0, the classical vanishing. Both are closed by kernel `decide`, so no Lean.ofReduceBool is involved and the entry remains 0-axiom.",
+    "mathContext": "At $n+3 = 3$ (so $n = 0$), $j = 0$: $\\sum_{k=0}^{2} (-1)^k k^2 \\binom{3}{k} = 0 - 3 + 12 = 9 = 3\\bigl(2\\binom{0}{0} + \\binom{1}{1}\\bigr)$. Full row $n = 4$: $\\sum_{k=0}^{4} (-1)^k k^2 \\binom{4}{k} = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide",
+      "concrete verification"
+    ],
+    "prerequisites": [
+      "Decidable equality on ℤ"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,116 @@
+{
+  "id": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+  "title": "A Two-Coefficient Closed Form for the Quadratically-Weighted Partial Alternating Binomial Sum",
+  "slug": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+  "description": "Answers the parent's first open question: the quadratically weighted partial alternating binomial sum admits a two-coefficient closed form ∑_{k=0}^{j} (-1)^k k² C(n,k) = (-1)^j n ((n-1) C(n-3,j-2) + C(n-2,j-1)) for n ≥ 3. The weight k² = k(k-1) + k splits into two row shifts: k(k-1) C(n,k) = n(n-1) C(n-2,k-2) contributes the binomial of row n-3, and k C(n,k) = n C(n-1,k-1) contributes the parent's single binomial of row n-2 — so one quadratic weight yields exactly two surviving coefficients. Specialising to the full row recovers the classical vanishing ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 for n ≥ 3.",
+  "meta": {
+    "author": "Lean Genius researcher-6",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 163,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities are fully machine-checked for every n and j. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); the two worked examples use kernel `decide`, so no Lean.ofReduceBool is involved.",
+    "tags": [
+      "combinatorics",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "alternating-sum",
+      "weighted-sum",
+      "absorption-identity",
+      "telescoping",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-23",
+    "originalContributions": [
+      "quad_weighted_partial_alternating_sum: the subtraction-free closed form ∑_{k=0}^{j+2} (-1)^k k² C(n+3,k) = (n+3) (-1)^j ((n+2) C(n,j) + C(n+1,j+1)), valid for all n, proved by induction on j with two applications of the absorption identity (Nat.add_one_mul_choose_eq) collected into the lemma key and two Pascal steps (Nat.choose_succ_succ), all discharged by linear_combination",
+      "quad_weighted_partial_alternating_sum_sub: the literal two-coefficient form ∑_{k=0}^{j+2} (-1)^k k² C(n,k) = (-1)^j n ((n-1) C(n-3,j) + C(n-2,j+1)) for n ≥ 3, obtained from the n+3 form by writing n = m+3",
+      "quad_weighted_partial_alternating_sum_stabilizes: the quadratically weighted partial sums are already 0 once j ≥ n (n ≥ 3), since both C(n-3,j-2) = 0 and C(n-2,j-1) = 0 there",
+      "quad_weighted_full_row_eq_zero: recovers the classical full-row vanishing ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) as the case j = n of the closed form",
+      "Worked verifications: row 3 cut at j=2 gives 0−3+12 = 9 = 3 ((2) C(0,0) + C(1,1)); full row 4 gives 0−4+24−36+16 = 0"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean",
+    "namespace": "CombinationsFormulaOQ05OQ01OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 163,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The classical vanishing of the quadratically weighted alternating row sum ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) is a second finite difference at x = 1 of the binomial theorem at x = -1: the weight k² is a degree-2 polynomial, killed by the n-fold alternating difference once n ≥ 3. The grandparent thread (CombinationsFormulaOQ05) handled the linear weight k and its full-row vanishing; the parent (CombinationsFormulaOQ05OQ01OQ01) found the single-binomial closed form n (-1)^j C(n-2,j-1) for the linearly weighted partial sums and asked whether the quadratic weight admits an analogue. It does — but the quadratic weight no longer collapses to one binomial: it produces two.",
+    "problemStatement": "Open Question OQ-05-OQ-01-OQ-01-OQ-01 (the first follow-up posed by the parent): does the quadratically weighted partial sum ∑_{k=0}^{j} (-1)^k k² C(n,k) admit a two-coefficient closed form, obtained by absorbing k² = k(k-1) + k into two row shifts?",
+    "proofStrategy": "Work in ℤ and prove the subtraction-free form ∑_{k=0}^{j+2} (-1)^k k² C(n+3,k) = (n+3) (-1)^j ((n+2) C(n,j) + C(n+1,j+1)) by induction on j. The base case j = 0 reduces to 0 − C(n+3,1) + 4 C(n+3,2), closed using 2 C(n+3,2) = (n+3)(n+2) (a cast of Nat.add_one_mul_choose_eq). The inductive step adds the term (-1)^{j+3} (j+3)² C(n+3,j+3); the helper lemma key applies the absorption identity twice — (j+3) C(n+3,j+3) = (n+3) C(n+2,j+2) and (j+2) C(n+2,j+2) = (n+2) C(n+1,j+1) — to rewrite it as (n+3) ((n+2) C(n+1,j+1) + C(n+2,j+2)), and two Pascal steps C(n+1,j+1) = C(n,j) + C(n,j+1), C(n+2,j+2) = C(n+1,j+1) + C(n+1,j+2) telescope both coefficients to row n; the signed-power algebra is closed by a single linear_combination. The literal C(n-3,·), C(n-2,·) form follows by writing n = m+3, and the full-row vanishing follows from both binomials being 0 for j ≥ n.",
+    "keyInsights": [
+      "The quadratic weight splits as k² = k(k-1) + k, and each summand is its own absorption: k(k-1) C(n,k) = n(n-1) C(n-2,k-2) shifts the row down by two, while k C(n,k) = n C(n-1,k-1) shifts it down by one. The two shifts land on different rows, so they cannot merge — the closed form has exactly two binomial coefficients, one per shift.",
+      "Stated with C(n+3,k) and cut-off j+2 the identity needs no natural-number subtraction and holds for all n, making the induction clean; the literal (n-1) C(n-3,j-2) + C(n-2,j-1) form is a one-line specialisation for n ≥ 3.",
+      "The inductive step's new term (j+3)² C(n+3,j+3) is reduced by composing two absorptions: (j+3)² = (j+3)·(j+3), one factor absorbed against row n+3 and the residual (j+3) split as (j+2) + 1 to absorb against row n+2. This is packaged as the lemma key and supplied to linear_combination as a single hypothesis.",
+      "The classical full-row vanishing is not assumed but derived: at j = n both coefficients C(n-3,n-2) and C(n-2,n-1) are 0, so this entry is strictly stronger than the bare anchor and exhibits exactly how the cancellation happens term by term."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Split k² = k(k-1) + k",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Header stating OQ-05-OQ-01-OQ-01-OQ-01: the quadratically weighted partial sums admit the two-coefficient closed form (-1)^j n ((n-1) C(n-3,j-2) + C(n-2,j-1)). Explains how k² = k(k-1) + k produces two independent row shifts and hence two surviving binomials."
+    },
+    {
+      "id": "main-identity",
+      "title": "Main Identity (Subtraction-Free Form)",
+      "startLine": 56,
+      "endLine": 114,
+      "summary": "quad_weighted_partial_alternating_sum: ∑_{k=0}^{j+2} (-1)^k k² C(n+3,k) = (n+3) (-1)^j ((n+2) C(n,j) + C(n+1,j+1)) for all n, by induction on j. The inductive step uses the helper lemma key (two absorption identities Nat.add_one_mul_choose_eq) and two Pascal steps Nat.choose_succ_succ, closed by linear_combination."
+    },
+    {
+      "id": "literal-form",
+      "title": "Two-Coefficient Literal Form",
+      "startLine": 115,
+      "endLine": 129,
+      "summary": "quad_weighted_partial_alternating_sum_sub: the literal ∑_{k=0}^{j+2} (-1)^k k² C(n,k) = (-1)^j n ((n-1) C(n-3,j) + C(n-2,j+1)) for n ≥ 3, obtained by writing n = m+3."
+    },
+    {
+      "id": "stabilization",
+      "title": "Stabilisation and Full-Row Recovery",
+      "startLine": 131,
+      "endLine": 151,
+      "summary": "quad_weighted_partial_alternating_sum_stabilizes: the partial sums are 0 once j ≥ n (both binomials vanish). quad_weighted_full_row_eq_zero: recovers the classical full quadratically weighted-row vanishing as the case j = n."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 153,
+      "endLine": 163,
+      "summary": "examples: row 3 cut at j=2 gives 0−3+12 = 9 = 3 ((2) C(0,0) + C(1,1)); full row 4 gives 0−4+24−36+16 = 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. Establishes the two-coefficient closed form ∑_{k=0}^{j} (-1)^k k² C(n,k) = (-1)^j n ((n-1) C(n-3,j-2) + C(n-2,j-1)) for every partial sum of a quadratically weighted alternating binomial row, and recovers the classical full-row vanishing as the special case j = n.",
+    "implications": "Confirms the parent's prediction: absorbing k² = k(k-1) + k yields a two-coefficient closed form, one binomial per row shift, generalising the parent's single-coefficient linear case. The absorb-then-telescope template scales with the polynomial degree of the weight — a degree-d weight ∑ (-1)^k k^d C(n,k) produces d surviving binomials from rows n-d, …, n-1 via the Stirling expansion k^d = ∑ S(d,r) (k)_r into falling factorials.",
+    "openQuestions": [
+      "Does the cubically weighted partial sum ∑_{k=0}^{j} (-1)^k k³ C(n,k) admit a three-coefficient closed form, via k³ = k(k-1)(k-2) + 3k(k-1) + k (Stirling numbers of the second kind)?",
+      "Is there a uniform degree-d statement ∑_{k=0}^{j} (-1)^k k^d C(n,k) = (-1)^j ∑_{r=1}^{d} S(d,r) (n)_r C(n-r-1, j-r) expressing the weighted partial sum as a Stirling-weighted sum of falling factorials times single binomials, of which d = 1 (parent) and d = 2 (this entry) are the first cases?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-05-oq-01-oq-01",
+      "relationship": "parent — answers its first open question by giving the quadratically weighted analogue of its single-coefficient linear closed form n (-1)^j C(n-2,j-1), now with two coefficients"
+    },
+    {
+      "targetId": "combinations-formula-oq-05-oq-01",
+      "relationship": "grandparent — extends its unweighted partial closed form (-1)^j C(n-1,j) to the quadratic weight, two row shifts below"
+    },
+    {
+      "targetId": "combinations-formula-oq-05",
+      "relationship": "great-grandparent — refines the weighted-row vanishing thread; reproves the quadratic full-row anchor ∑ (-1)^k k² C(n,k) = 0 (n ≥ 3) as the case j = n"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `combinations-formula-oq-05-oq-01-oq-01`: does the **quadratically weighted** partial alternating binomial sum admit a two-coefficient closed form, obtained by absorbing `k² = k(k-1) + k` into two row shifts?

It does — and the quadratic weight does **not** collapse to a single binomial (as the parent's linear weight did). It produces exactly two:

```
∑_{k=0}^{j} (-1)^k · k² · C(n,k) = (-1)^j · n · ( (n-1)·C(n-3, j-2) + C(n-2, j-1) )    (n ≥ 3).
```

The split `k² = k(k-1) + k` gives two independent absorptions: `k(k-1)·C(n,k) = n(n-1)·C(n-2,k-2)` shifts the row down by two (binomial of row `n-3`), and `k·C(n,k) = n·C(n-1,k-1)` shifts by one (the parent's binomial of row `n-2`). The two shifts land on different rows, so there are exactly two surviving coefficients — one per row shift.

## Results (`Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean`)

1. `quad_weighted_partial_alternating_sum` — subtraction-free clean form `∑_{k=0}^{j+2} (-1)^k k² C(n+3,k) = (n+3)(-1)^j((n+2)C(n,j) + C(n+1,j+1))`, all `n,j`.
2. `quad_weighted_partial_alternating_sum_sub` — literal `(n-1)C(n-3,·) + C(n-2,·)` form, `n ≥ 3`.
3. `quad_weighted_partial_alternating_sum_stabilizes` — partial sums are `0` once `j ≥ n` (both binomials vanish).
4. `quad_weighted_full_row_eq_zero` — recovers the classical full-row vanishing `∑_{k=0}^{n} (-1)^k k² C(n,k) = 0` (`n ≥ 3`) as the case `j = n`.

## Method

Subtraction-free induction on `j`. A helper lemma `key` composes the absorption identity (`Nat.add_one_mul_choose_eq`) twice to rewrite the new term `(j+3)² C(n+3,j+3) = (n+3)((n+2)C(n+1,j+1) + C(n+2,j+2))`; two Pascal steps (`Nat.choose_succ_succ`) then telescope both coefficients to row `n`, all discharged by a single `linear_combination` over `ring`.

## Verification

- **4 theorems, 0 sorries, 0 axioms.** `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound`.
- Two worked examples use kernel `decide` (no `Lean.ofReduceBool`).
- Built against Mathlib (lean v4.26.0).

Not registered in `Proofs.lean` (deployer regenerates the aggregator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)