### PR TITLE
research(combinations-formula-oq-05-oq-01-oq-01-oq-01): two-coefficient closed form for the quadratically-weighted alternating binomial sum [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3758,3 +3758,4 @@ import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ03
 
 import Proofs.CombinationsFormulaOQ05OQ01OQ01
+import Proofs.CombinationsFormulaOQ05OQ01OQ01OQ01

--- a/proofs/Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean
@@ -1,0 +1,181 @@
+import Mathlib
+
+/-
+# Two-Coefficient Closed Form for the Quadratically-Weighted Alternating Binomial Sum
+
+## Open Question OQ-05-OQ-01-OQ-01-OQ-01
+
+The parent (`CombinationsFormulaOQ05OQ01OQ01`) proves the *single*-coefficient
+closed form for the **linearly** weighted partial alternating binomial sum,
+
+  ∑_{k=0}^{j} (-1)^k · k · C(n, k) = n · (-1)^j · C(n-2, j-1)      (n ≥ 2),
+
+obtained by one **absorption** step `k · C(n,k) = n · C(n-1, k-1)` followed by one
+telescoping.  Its first open question asks whether the **quadratically** weighted
+partial sum admits a closed form, obtained by absorbing `k² = k(k-1) + k` into two
+row shifts.
+
+This file answers that question.  The answer is a **two-coefficient** closed form
+— a fixed `ℤ`-linear combination of two single binomials, one from row `n-3` and
+one from row `n-2`:
+
+  ∑_{k=0}^{j} (-1)^k · k² · C(n, k)
+      = (-1)^j · ( n(n-1) · C(n-3, j-2) + n · C(n-2, j-1) )        (n ≥ 3).      (★)
+
+So the quadratic weight needs exactly two coefficients where the linear weight
+needed one: the `k(k-1)` part absorbs into the row *three below* (scaled by
+`n(n-1)`), and the leftover `k` part absorbs into the row *two below* (scaled by
+`n`), recovering the parent's term verbatim.
+
+## Mechanism
+
+The proof is a single induction on the cut-off, mirroring the parent.  The new
+term `(i+3)² · C(m+3, i+3)` is reduced by **two** applications of the absorption
+identity `(K+1)·C(N+1,K+1) = (N+1)·C(N,K)` (`Nat.add_one_mul_choose_eq`):
+
+  (i+3)² · C(m+3, i+3)
+    = (m+3)(m+2) · C(m+1, i+1) + (m+3) · C(m+2, i+2),
+
+after which two Pascal steps `C(N+1,K+1) = C(N,K) + C(N,K+1)`
+(`Nat.choose_succ_succ`) collapse the sum down to the two surviving coefficients.
+The `(-1)` powers and the scalars are bookkept by `linear_combination`.
+
+## Subtraction-free form
+
+To avoid natural-number subtraction the identity is proved in the shifted form
+(with `n = m+3`, `j = i+2`), valid for **all** `m, i`:
+
+  ∑_{k=0}^{i+2} (-1)^k · k² · C(m+3, k)
+      = (-1)^i · ( (m+3)(m+2) · C(m, i) + (m+3) · C(m+1, i+1) ).               (★')
+
+## Results
+
+1. `quad_weighted_partial_alternating_sum`      — (★') clean form, valid for all `m,i`.
+2. `quad_weighted_partial_alternating_sum_sub`  — (★) literal `C(n-3,·)`/`C(n-2,·)`
+   form, `n ≥ 3`.
+3. `quad_weighted_partial_alternating_sum_stabilizes` — the quadratically weighted
+   partial sums are `0` once `j ≥ n` (`n ≥ 3`).
+4. `quad_weighted_full_row_eq_zero`             — the full quadratically weighted
+   alternating row sum vanishes for `n ≥ 3`, the case `j = n` of (★).
+
+## Axioms: 0 | Sorries: 0
+-/
+
+namespace CombinationsFormulaOQ05OQ01OQ01OQ01
+
+open Finset
+
+/-- **Main identity (subtraction-free form).** For all `m, i`,
+    `∑_{k=0}^{i+2} (-1)^k · k² · C(m+3, k)
+       = (-1)^i · ( (m+3)(m+2) · C(m, i) + (m+3) · C(m+1, i+1) )` in `ℤ`.
+
+    Proof by induction on `i`.  The inductive step reduces the new weighted term
+    `(i+3)² · C(m+3, i+3)` by two absorptions and then telescopes with two Pascal
+    steps; `linear_combination` discharges the resulting polynomial identity. -/
+theorem quad_weighted_partial_alternating_sum (m i : ℕ) :
+    ∑ k ∈ range (i + 3), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * ((m + 3).choose k : ℤ))
+      = (-1 : ℤ) ^ i *
+          (((m : ℤ) + 3) * ((m : ℤ) + 2) * (m.choose i : ℤ)
+            + ((m : ℤ) + 3) * ((m + 1).choose (i + 1) : ℤ)) := by
+  induction i with
+  | zero =>
+    -- `range 3`: only `k = 1, 2` contribute.  Evaluate `C(m+3,2)` via one
+    -- absorption (`C(m+3,1)`, `C(m,0)`, `C(m+1,1)` fall to `simp`), then
+    -- `linear_combination`.
+    have h2 : (2 : ℤ) * ((m + 3).choose 2 : ℤ) = ((m : ℤ) + 3) * ((m : ℤ) + 2) := by
+      have hnat := Nat.add_one_mul_choose_eq (m + 2) 1
+      rw [Nat.choose_one_right, show m + 2 + 1 = m + 3 by omega,
+        show (1 : ℕ) + 1 = 2 by norm_num] at hnat
+      have hc := congrArg (Nat.cast (R := ℤ)) hnat
+      push_cast at hc
+      linear_combination -hc
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero]
+    push_cast [Nat.choose_zero_right, Nat.choose_one_right]
+    linear_combination (2 : ℤ) * h2
+  | succ i ih =>
+    rw [Finset.sum_range_succ, ih]
+    -- Absorption `a`: `(i+3)·C(m+3,i+3) = (m+3)·C(m+2,i+2)`.
+    have absorb_a : ((i : ℤ) + 3) * ((m + 3).choose (i + 3) : ℤ)
+        = ((m : ℤ) + 3) * ((m + 2).choose (i + 2) : ℤ) := by
+      have h := Nat.add_one_mul_choose_eq (m + 2) (i + 2)
+      have h2 := congrArg (Nat.cast (R := ℤ)) h
+      push_cast at h2
+      linear_combination -h2
+    -- Absorption `b`: `(i+2)·C(m+2,i+2) = (m+2)·C(m+1,i+1)`.
+    have absorb_b : ((i : ℤ) + 2) * ((m + 2).choose (i + 2) : ℤ)
+        = ((m : ℤ) + 2) * ((m + 1).choose (i + 1) : ℤ) := by
+      have h := Nat.add_one_mul_choose_eq (m + 1) (i + 1)
+      have h2 := congrArg (Nat.cast (R := ℤ)) h
+      push_cast at h2
+      linear_combination -h2
+    -- Double absorption: `(i+3)²·C(m+3,i+3) = (m+3)(m+2)·C(m+1,i+1) + (m+3)·C(m+2,i+2)`.
+    have absorbA : ((i : ℤ) + 3) ^ 2 * ((m + 3).choose (i + 3) : ℤ)
+        = ((m : ℤ) + 3) * ((m : ℤ) + 2) * ((m + 1).choose (i + 1) : ℤ)
+          + ((m : ℤ) + 3) * ((m + 2).choose (i + 2) : ℤ) := by
+      linear_combination ((i : ℤ) + 3) * absorb_a + ((m : ℤ) + 3) * absorb_b
+    -- Pascal `p1`: `C(m+1,i+1) = C(m,i) + C(m,i+1)`.
+    have pascal1 : ((m + 1).choose (i + 1) : ℤ)
+        = (m.choose i : ℤ) + (m.choose (i + 1) : ℤ) := by
+      rw [Nat.choose_succ_succ]; push_cast; ring
+    -- Pascal `p2`: `C(m+2,i+2) = C(m+1,i+1) + C(m+1,i+2)`.
+    have pascal2 : ((m + 2).choose (i + 2) : ℤ)
+        = ((m + 1).choose (i + 1) : ℤ) + ((m + 1).choose (i + 2) : ℤ) := by
+      rw [Nat.choose_succ_succ]; push_cast; ring
+    push_cast
+    linear_combination (-((-1 : ℤ) ^ i)) * absorbA
+      + (-((-1 : ℤ) ^ i) * (((m : ℤ) + 3) * ((m : ℤ) + 2))) * pascal1
+      + (-((-1 : ℤ) ^ i) * ((m : ℤ) + 3)) * pascal2
+
+/-- **Quadratically weighted partial sum (literal form).** For `n ≥ 3` and any `j`,
+    `∑_{k=0}^{j+2} (-1)^k · k² · C(n, k)
+       = (-1)^j · ( n(n-1)·C(n-3, j) + n·C(n-2, j+1) )` in `ℤ`.
+
+    This is `(★)` with the cut-off written as `j+2` (so that `j-2 = j` and
+    `j-1 = j+1` after the shift), exhibiting the two coefficients as binomials of
+    rows `n-3` and `n-2`. -/
+theorem quad_weighted_partial_alternating_sum_sub {n : ℕ} (hn : 3 ≤ n) (j : ℕ) :
+    ∑ k ∈ range (j + 3), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (n.choose k : ℤ))
+      = (-1 : ℤ) ^ j *
+          ((n : ℤ) * ((n : ℤ) - 1) * ((n - 3).choose j : ℤ)
+            + (n : ℤ) * ((n - 2).choose (j + 1) : ℤ)) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 3 := ⟨n - 3, by omega⟩
+  have e1 : (m + 3 - 3) = m := by omega
+  have e2 : (m + 3 - 2) = m + 1 := by omega
+  rw [quad_weighted_partial_alternating_sum m j, e1, e2]
+  push_cast
+  ring
+
+/-- **Stabilisation.** Once the cut-off reaches the row length the quadratically
+    weighted partial sums are already `0`: for `n ≥ 3` and `j ≥ n`,
+    `∑_{k=0}^{j} (-1)^k · k² · C(n, k) = 0`.
+
+    Reason: the closed form is `(-1)^j(n(n-1)·C(n-3,j-2) + n·C(n-2,j-1))`, and both
+    binomials vanish because `j - 2 ≥ n - 2 > n - 3` and `j - 1 ≥ n - 1 > n - 2`. -/
+theorem quad_weighted_partial_alternating_sum_stabilizes {n : ℕ} (hn : 3 ≤ n) {j : ℕ}
+    (hj : n ≤ j) :
+    ∑ k ∈ range (j + 1), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (n.choose k : ℤ)) = 0 := by
+  obtain ⟨i, rfl⟩ : ∃ i, j = i + 2 := ⟨j - 2, by omega⟩
+  rw [quad_weighted_partial_alternating_sum_sub hn i]
+  have h1 : (n - 3).choose i = 0 := Nat.choose_eq_zero_of_lt (by omega)
+  have h2 : (n - 2).choose (i + 1) = 0 := Nat.choose_eq_zero_of_lt (by omega)
+  rw [h1, h2]; simp
+
+/-- **Full quadratically weighted alternating row sum vanishes** for `n ≥ 3`,
+    obtained as the special case `j = n` of the partial closed form. -/
+theorem quad_weighted_full_row_eq_zero {n : ℕ} (hn : 3 ≤ n) :
+    ∑ k ∈ range (n + 1), ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (n.choose k : ℤ)) = 0 :=
+  quad_weighted_partial_alternating_sum_stabilizes hn (le_refl n)
+
+/-- Sanity check, row `n = 4`, cut-off `j = 2`:
+    `0 - 1·C(4,1) + 4·C(4,2) = -4 + 24 = 20`, and the closed form gives
+    `(+1)·(4·3·C(1,0) + 4·C(2,1)) = 12 + 8 = 20`. -/
+example :
+    ∑ k ∈ range 3, ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (Nat.choose 4 k : ℤ)) = 20 := by decide
+
+/-- Sanity check of the closed form at `n = 4, j = 3`:
+    LHS `= 0 - 4 + 24 - 9·C(4,3) = 20 - 36 = -16`;
+    RHS `= (-1)^3·(4·3·C(1,1) + 4·C(2,2)) = -(12 + 4) = -16`. -/
+example :
+    ∑ k ∈ range 4, ((-1 : ℤ) ^ k * (k : ℤ) ^ 2 * (Nat.choose 4 k : ℤ)) = -16 := by decide
+
+end CombinationsFormulaOQ05OQ01OQ01OQ01

--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,115 @@
+[
+  {
+    "id": "double-absorb-context",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 63
+    },
+    "type": "concept",
+    "title": "Quadratic Weight: Absorb Twice, then Telescope",
+    "content": "The parent records the linearly weighted partial closed form ∑_{k=0}^{j} (-1)^k k C(n,k) = n (-1)^j C(n-2,j-1) — one absorption, one telescoping, one surviving binomial. Its first open question asks for the quadratic weight. The answer needs two coefficients: ∑_{k=0}^{j} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j-2) + n C(n-2,j-1) ). The mechanism is the splitting k² = k(k-1) + k. The falling factorial k(k-1) absorbs into a double row shift k(k-1) C(n,k) = n(n-1) C(n-2,k-2), telescoping to row n-3; the leftover k reproduces the parent's term on row n-2. Two pieces, two rows, two coefficients.",
+    "mathContext": "Write $a_k = (-1)^k k^2 \\binom{n}{k}$. Splitting $k^2 = k(k-1) + k$ gives $\\sum_{k=0}^{j} a_k = n(n-1)\\sum_{k}(-1)^k\\binom{n-2}{k-2} + n\\sum_{k}(-1)^k\\binom{n-1}{k-1}$. Each inner sum is an unweighted alternating partial sum of a shifted row, evaluated by the grandparent's telescoping to $(-1)^{j}\\binom{n-3}{j-2}$ and $(-1)^{j}\\binom{n-2}{j-1}$ respectively, yielding $\\sum_{k=0}^{j} a_k = (-1)^j\\big(n(n-1)\\binom{n-3}{j-2} + n\\binom{n-2}{j-1}\\big)$. The full-row vanishing is the case $j=n$, where both binomials are zero.",
+    "significance": "key",
+    "relatedConcepts": [
+      "absorption identity k C(n,k) = n C(n-1,k-1)",
+      "double absorption k(k-1) C(n,k) = n(n-1) C(n-2,k-2)",
+      "falling-factorial weight decomposition k^r = Σ S(r,j) (k)_j",
+      "Pascal's rule",
+      "telescoping sums"
+    ],
+    "prerequisites": [
+      "Nat.choose binomial coefficients",
+      "absorption Nat.add_one_mul_choose_eq",
+      "Pascal's rule Nat.choose_succ_succ",
+      "induction over Finset.range"
+    ]
+  },
+  {
+    "id": "main-identity-induction",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 134
+    },
+    "type": "proof-technique",
+    "title": "Subtraction-Free Induction with a Second-Order Step",
+    "content": "The main identity is proved in the shifted form ∑_{k=0}^{i+2} (-1)^k k² C(m+3,k) = (-1)^i ( (m+3)(m+2) C(m,i) + (m+3) C(m+1,i+1) ), which avoids all natural-number subtraction and holds for every m and i. The base case i = 0 is the range-3 sum −C(m+3,1) + 4 C(m+3,2), where 2 C(m+3,2) = (m+3)(m+2) is supplied by one absorption. The inductive step adds the term (-1)^{i+3} (i+3)² C(m+3,i+3); the key local lemma absorbA reduces it via two absorptions to (m+3)(m+2) C(m+1,i+1) + (m+3) C(m+2,i+2), and two Pascal steps then telescope the running sum down to the two surviving coefficients.",
+    "mathContext": "The induction reduces $(i+3)^2\\binom{m+3}{i+3}$ by absorbing twice: $(i+3)\\binom{m+3}{i+3} = (m+3)\\binom{m+2}{i+2}$, then $(i+2)\\binom{m+2}{i+2} = (m+2)\\binom{m+1}{i+1}$, giving $(i+3)^2\\binom{m+3}{i+3} = (m+3)(m+2)\\binom{m+1}{i+1} + (m+3)\\binom{m+2}{i+2}$. Pascal on $\\binom{m+1}{i+1}=\\binom{m}{i}+\\binom{m}{i+1}$ and $\\binom{m+2}{i+2}=\\binom{m+1}{i+1}+\\binom{m+1}{i+2}$ then cancels everything except the two target binomials.",
+    "significance": "key",
+    "relatedConcepts": [
+      "induction over a Finset.range cut-off",
+      "subtraction-free reformulation",
+      "binomial absorption chained twice"
+    ],
+    "prerequisites": [
+      "Finset.sum_range_succ",
+      "Nat.add_one_mul_choose_eq",
+      "Nat.choose_succ_succ"
+    ]
+  },
+  {
+    "id": "linear-combination-finisher",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 100,
+      "endLine": 134
+    },
+    "type": "proof-technique",
+    "title": "linear_combination over the Signed-Power Algebra",
+    "content": "The inductive step never rewrites under the (-1)^{i+3} factor — associativity makes that brittle. Instead the two absorption equalities and two Pascal equalities are supplied as linear hypotheses with explicit scalar coefficients, and linear_combination hands the entire signed-power polynomial identity to ring. The decisive coefficient is the double-absorption lemma absorbA, itself proved by linear_combination ((i:ℤ)+3) * absorb_a + ((m:ℤ)+3) * absorb_b: scaling the first absorption by (i+3) supplies the second factor of k², and scaling the second by (m+3) clears the leftover.",
+    "mathContext": "The step goal, after dividing by $(-1)^i$, is $\\big(P a + Q p\\big) - \\big(P p + Q r\\big) = -\\big(P b + Q q\\big)$ with $P=(m+3)(m+2)$, $Q=m+3$, $a=\\binom{m}{i}$, $b=\\binom{m}{i+1}$, $p=\\binom{m+1}{i+1}=a+b$, $q=\\binom{m+1}{i+2}$, $r=\\binom{m+2}{i+2}=p+q$. Substituting the two Pascal relations collapses the left side to $-Pb-Qq$, matching the right.",
+    "significance": "important",
+    "relatedConcepts": [
+      "linear_combination tactic",
+      "ring normalisation of signed powers",
+      "supplying rewrites as linear hypotheses"
+    ],
+    "prerequisites": [
+      "linear_combination",
+      "ring"
+    ]
+  },
+  {
+    "id": "literal-and-stabilization",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 136,
+      "endLine": 170
+    },
+    "type": "concept",
+    "title": "Literal Form, Stabilisation, and Full-Row Vanishing",
+    "content": "Writing n = m+3 turns the subtraction-free identity into the literal ∑_{k=0}^{j+2} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j) + n C(n-2,j+1) ) for n ≥ 3. Stabilisation is immediate: once j ≥ n both C(n-3,j-2) and C(n-2,j-1) have lower index exceeding their upper row, so each is 0 and the partial sum is already 0. The full-row vanishing ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) is the case j = n — derived here, not assumed, so the entry is strictly stronger than a bare statement of the quadratic cancellation.",
+    "mathContext": "For $j \\ge n$: $\\binom{n-3}{j-2} = 0$ because $j-2 \\ge n-2 > n-3$, and $\\binom{n-2}{j-1} = 0$ because $j-1 \\ge n-1 > n-2$. Hence $\\sum_{k=0}^{j}(-1)^k k^2\\binom{n}{k} = 0$ for all $j \\ge n \\ge 3$, recovering and refining the second-derivative binomial cancellation.",
+    "significance": "important",
+    "relatedConcepts": [
+      "Nat.choose_eq_zero_of_lt",
+      "stabilisation of partial sums",
+      "second-derivative binomial identity"
+    ],
+    "prerequisites": [
+      "Nat.choose_eq_zero_of_lt",
+      "natural-number subtraction bookkeeping"
+    ]
+  },
+  {
+    "id": "worked-verifications",
+    "proofId": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 171,
+      "endLine": 181
+    },
+    "type": "example",
+    "title": "Numerical Checks of the Two-Coefficient Form",
+    "content": "Two kernel-checked examples pin down the closed form. Row 4 cut at j = 2: 0 − 1·C(4,1) + 4·C(4,2) = −4 + 24 = 20, and the closed form gives (+1)·(4·3·C(1,0) + 4·C(2,1)) = 12 + 8 = 20. Row 4 cut at j = 3: the previous 20 plus −9·C(4,3) = −36 gives −16, and the closed form gives (−1)·(4·3·C(1,1) + 4·C(2,2)) = −(12 + 4) = −16. Both use kernel `decide`, so no Lean.ofReduceBool axiom is incurred.",
+    "mathContext": "At $n=4$: $n(n-1)=12$, so the closed form reads $(-1)^j\\big(12\\binom{1}{j-2} + 4\\binom{2}{j-1}\\big)$. For $j=2$ this is $12\\binom{1}{0}+4\\binom{2}{1}=12+8=20$; for $j=3$ it is $-(12\\binom{1}{1}+4\\binom{2}{2})=-(12+4)=-16$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "kernel decide vs native_decide",
+      "numerical verification of closed forms"
+    ],
+    "prerequisites": [
+      "Decidable evaluation of Finset sums"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,117 @@
+{
+  "id": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+  "title": "Two-Coefficient Closed Form for the Quadratically-Weighted Alternating Binomial Sum",
+  "slug": "combinations-formula-oq-05-oq-01-oq-01-oq-01",
+  "description": "Proves the two-coefficient closed form for the quadratically weighted partial alternating binomial sum: ∑_{k=0}^{j} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j-2) + n C(n-2,j-1) ) for n ≥ 3. This answers the parent's open question by absorbing k² = k(k-1) + k into two row shifts: the k(k-1) part lands on row n-3 scaled by n(n-1), and the leftover k part reproduces the parent's single coefficient on row n-2. Where the linearly weighted partial sum needed one binomial of the row two below, the quadratically weighted partial sum needs exactly two — one from row n-3, one from row n-2. The full quadratically weighted row vanishing ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) is recovered as the special case j = n.",
+  "meta": {
+    "author": "Lean Genius researcher-3",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 181,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. All identities are fully machine-checked for every n and j. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); the two worked examples use kernel `decide`, so no Lean.ofReduceBool is involved.",
+    "tags": [
+      "combinatorics",
+      "pascals-triangle",
+      "binomial-coefficients",
+      "alternating-sum",
+      "weighted-sum",
+      "absorption-identity",
+      "telescoping",
+      "finset-sums"
+    ],
+    "dateAdded": "2026-06-23",
+    "originalContributions": [
+      "quad_weighted_partial_alternating_sum: the subtraction-free two-coefficient closed form ∑_{k=0}^{i+2} (-1)^k k² C(m+3,k) = (-1)^i ( (m+3)(m+2) C(m,i) + (m+3) C(m+1,i+1) ), valid for all m and i, proved by induction on i; the new term (i+3)² C(m+3,i+3) is reduced by two applications of the absorption identity Nat.add_one_mul_choose_eq and two Pascal steps Nat.choose_succ_succ, all discharged by linear_combination",
+      "quad_weighted_partial_alternating_sum_sub: the literal form ∑_{k=0}^{j+2} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j) + n C(n-2,j+1) ) for n ≥ 3, obtained from the m+3 form by writing n = m+3",
+      "quad_weighted_partial_alternating_sum_stabilizes: the quadratically weighted partial sums are already 0 once j ≥ n (n ≥ 3), since both C(n-3,j-2) and C(n-2,j-1) vanish there",
+      "quad_weighted_full_row_eq_zero: the full quadratically weighted alternating row sum ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) recovered as the case j = n of the partial closed form",
+      "Worked verifications: row 4 cut at j=2 gives 0−4+24 = 20 = 4·3·C(1,0) + 4·C(2,1); row 4 cut at j=3 gives 0−4+24−36 = −16 = (−1)^3 ( 4·3·C(1,1) + 4·C(2,2) )"
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CombinationsFormulaOQ05OQ01OQ01OQ01.lean",
+    "namespace": "CombinationsFormulaOQ05OQ01OQ01OQ01",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 181,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The full quadratically weighted alternating row sum ∑_{k=0}^{n} (-1)^k k² C(n,k) = 0 (n ≥ 3) is the second-derivative-at-x=1 companion of the binomial theorem at x = -1: applying the operator (x d/dx)² to (1-x)^n and evaluating at x = 1 produces the doubly-weighted cancellation, which vanishes once the degree of the surviving differential operator drops below n. The grandparent (CombinationsFormulaOQ05) records the linear vanishing; the parent (CombinationsFormulaOQ05OQ01OQ01) records the linearly weighted partial closed form n (-1)^j C(n-2,j-1). What the truncated quadratically weighted sum equals — before it cancels — was the parent's first open question. The answer is no longer a single binomial: the weight k² splits as k(k-1) + k, and each piece absorbs into a different row shift, producing a fixed combination of two binomial coefficients.",
+    "problemStatement": "Open Question OQ-05-OQ-01-OQ-01-OQ-01 (the first follow-up posed by the parent): does the quadratically weighted partial sum ∑_{k=0}^{j} (-1)^k k² C(n,k) admit a closed form, obtained by absorbing k² = k(k-1) + k into two row shifts?",
+    "proofStrategy": "Work in ℤ and prove the subtraction-free form ∑_{k=0}^{i+2} (-1)^k k² C(m+3,k) = (-1)^i ( (m+3)(m+2) C(m,i) + (m+3) C(m+1,i+1) ) by induction on i. The base case i = 0 evaluates the range-3 sum −C(m+3,1) + 4 C(m+3,2), with 2 C(m+3,2) = (m+3)(m+2) supplied by one absorption. The inductive step adds the term (-1)^{i+3} (i+3)² C(m+3,i+3); applying the absorption identity (K+1) C(N+1,K+1) = (N+1) C(N,K) (Nat.add_one_mul_choose_eq) twice gives (i+3)² C(m+3,i+3) = (m+3)(m+2) C(m+1,i+1) + (m+3) C(m+2,i+2), and two Pascal steps C(N+1,K+1) = C(N,K) + C(N,K+1) (Nat.choose_succ_succ) telescope the sum down to the two surviving coefficients; all rewrites and the (-1)-power bookkeeping are discharged by a single linear_combination over ring. The literal C(n-3,·)/C(n-2,·) form follows by writing n = m+3, and the full-row vanishing follows from both binomials being 0 for j ≥ n.",
+    "keyInsights": [
+      "The quadratic weight splits cleanly as k² = k(k-1) + k, and each summand absorbs into its own row shift: k(k-1) C(n,k) = n(n-1) C(n-2,k-2) lands on row n-3 after telescoping, while k C(n,k) = n C(n-1,k-1) reproduces the parent's coefficient on row n-2 verbatim.",
+      "Two coefficients are necessary, not an artefact of the proof: the surviving combination n(n-1) C(n-3,j-2) + n C(n-2,j-1) cannot collapse to a single binomial because the two terms come from rows of different parity-shifted depth (n-3 and n-2).",
+      "Stated with C(m+3,k) and cut-off i+2 the identity needs no natural-number subtraction and holds for all m, making the induction clean; the literal n ≥ 3 form is a one-line specialisation.",
+      "linear_combination scales to the second-order step: the single new term needs two absorptions and two Pascals, but supplying them all as linear hypotheses lets ring handle the signed-power algebra without any rewriting under the (-1)^{i+3} factor.",
+      "The mechanism is uniform in the weight degree r: degree-1 needs one coefficient (parent), degree-2 needs two (this entry), and the falling-factorial expansion k^r = ∑ S(r,j) (k)_j predicts a closed form with r coefficients for the general weighted alternating partial sum."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Open Question and the Two-Coefficient Refinement",
+      "startLine": 1,
+      "endLine": 63,
+      "summary": "Header stating OQ-05-OQ-01-OQ-01-OQ-01: the quadratically weighted partial sums admit the two-coefficient closed form (-1)^j ( n(n-1) C(n-3,j-2) + n C(n-2,j-1) ), obtained by absorbing k² = k(k-1) + k into two row shifts. Explains the double-absorption-then-telescope mechanism."
+    },
+    {
+      "id": "main-identity",
+      "title": "Main Identity (Subtraction-Free Form)",
+      "startLine": 64,
+      "endLine": 134,
+      "summary": "quad_weighted_partial_alternating_sum: ∑_{k=0}^{i+2} (-1)^k k² C(m+3,k) = (-1)^i ( (m+3)(m+2) C(m,i) + (m+3) C(m+1,i+1) ) for all m, by induction on i. The inductive step reduces the new term via two absorptions (Nat.add_one_mul_choose_eq) and two Pascal steps (Nat.choose_succ_succ), closed by linear_combination."
+    },
+    {
+      "id": "literal-form",
+      "title": "Literal C(n-3,·) / C(n-2,·) Form",
+      "startLine": 136,
+      "endLine": 152,
+      "summary": "quad_weighted_partial_alternating_sum_sub: the literal ∑_{k=0}^{j+2} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j) + n C(n-2,j+1) ) for n ≥ 3, obtained by writing n = m+3."
+    },
+    {
+      "id": "stabilization",
+      "title": "Stabilisation and Full-Row Recovery",
+      "startLine": 154,
+      "endLine": 170,
+      "summary": "quad_weighted_partial_alternating_sum_stabilizes: the quadratically weighted partial sums are 0 once j ≥ n, since both C(n-3,j-2) and C(n-2,j-1) vanish. quad_weighted_full_row_eq_zero: the full quadratically weighted row sum vanishes for n ≥ 3 as the case j = n."
+    },
+    {
+      "id": "verification",
+      "title": "Worked Verifications",
+      "startLine": 171,
+      "endLine": 181,
+      "summary": "examples: row 4 cut at j=2 gives 0−4+24 = 20 = 4·3·C(1,0) + 4·C(2,1); row 4 cut at j=3 gives 0−4+24−36 = −16 = (−1)^3 ( 4·3·C(1,1) + 4·C(2,2) )."
+    }
+  ],
+  "conclusion": {
+    "summary": "4 theorems, 0 sorries, 0 axioms. Establishes the two-coefficient closed form ∑_{k=0}^{j} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j-2) + n C(n-2,j-1) ) for every partial sum of a quadratically weighted alternating binomial row (n ≥ 3), and recovers the full quadratically weighted row vanishing as the special case j = n.",
+    "implications": "Extends the OQ-05 weighted-sum thread one degree higher: the linearly weighted partial sum is one binomial of the row two below (parent), and the quadratically weighted partial sum is a fixed combination of two binomials, of rows three and two below. The absorb-then-telescope template scales by weight degree — degree r consumes r absorptions and produces an r-coefficient closed form — pointing directly at a uniform falling-factorial-weighted identity governed by Stirling numbers of the second kind.",
+    "openQuestions": [
+      "Does the falling-factorial-weighted partial sum ∑_{k=0}^{j} (-1)^k (k)_r C(n,k) equal (-1)^j (n)_r C(n-r-1, j-r) for every r, unifying the parent (r = 1) and the k(k-1) component of this entry (r = 2) under a single absorption-depth formula?",
+      "For the general power weight k^r, is the number of binomial coefficients in the closed form exactly the number of nonzero Stirling numbers S(r,j), and are their scalars the products (n)_j predicted by the falling-factorial decomposition k^r = ∑_j S(r,j) (k)_j?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "combinations-formula-oq-05-oq-01-oq-01",
+      "relationship": "parent — answers its first open question by giving the quadratically weighted analogue of its single-coefficient linearly weighted partial closed form n (-1)^j C(n-2,j-1)"
+    },
+    {
+      "targetId": "combinations-formula-oq-05-oq-01",
+      "relationship": "grandparent — the unweighted partial telescoping (-1)^j C(n-1,j) whose absorption-then-telescope mechanism is applied twice here"
+    },
+    {
+      "targetId": "combinations-formula-oq-05",
+      "relationship": "great-grandparent — the linear full-row vanishing anchor, here lifted to the quadratic full-row vanishing ∑ (-1)^k k² C(n,k) = 0 (n ≥ 3)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent's (`combinations-formula-oq-05-oq-01-oq-01`) first open question: a closed form for the **quadratically weighted** partial alternating binomial sum.

```
∑_{k=0}^{j} (-1)^k k² C(n,k) = (-1)^j ( n(n-1) C(n-3,j-2) + n C(n-2,j-1) )   (n ≥ 3)
```

Where the parent's linearly weighted sum needed **one** binomial of the row two below, the quadratically weighted sum needs exactly **two** — one from row n-3, one from row n-2. The mechanism is the split `k² = k(k-1) + k`: the falling factorial `k(k-1)` absorbs into a double row shift onto row n-3 (scaled by n(n-1)), while the leftover `k` reproduces the parent's coefficient on row n-2 verbatim.

## Results (4 theorems, 0 sorries, 0 axioms)

1. `quad_weighted_partial_alternating_sum` — subtraction-free form, valid for all m,i, by induction; the new term `(i+3)² C(m+3,i+3)` is reduced by two absorptions (`Nat.add_one_mul_choose_eq`) and two Pascal steps (`Nat.choose_succ_succ`), closed by `linear_combination`.
2. `quad_weighted_partial_alternating_sum_sub` — literal `C(n-3,·)`/`C(n-2,·)` form for n ≥ 3.
3. `quad_weighted_partial_alternating_sum_stabilizes` — the partial sums are 0 once j ≥ n.
4. `quad_weighted_full_row_eq_zero` — recovers the full quadratically weighted row vanishing ∑ (-1)^k k² C(n,k) = 0 (n ≥ 3) as the case j = n.

## Verification

- `#print axioms` on every theorem: `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. The two worked examples use kernel `decide`.
- Numerical checks: row 4 cut at j=2 → 20; row 4 cut at j=3 → −16; both match the closed form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)