### PR TITLE
Add missing index.ts for tietze-extension-theorem-oq-01

### DIFF
--- a/src/data/proofs/tietze-extension-theorem-oq-01/index.ts
+++ b/src/data/proofs/tietze-extension-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TietzeExtensionTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const tietzeExtensionTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const tietzeExtensionTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const tietzeExtensionTheoremOQ01Data: ProofData = {
+  proof: tietzeExtensionTheoremOQ01Proof,
+  annotations: tietzeExtensionTheoremOQ01Annotations,
+}


### PR DESCRIPTION
Follow-up to #28023, which enriched `tietze-extension-theorem-oq-01`'s meta.json and annotations.json but did not add the Vite entry point.

Without `index.ts`, `import.meta.glob` cannot discover the proof and the page renders 'proof not found' on the live site despite appearing in the gallery listing. This adds the standard entry point. `pnpm build` passes.