### PR TITLE
Fix gallery integrity: missing meta.sorries in cauchy-interlacing-oq-01-oq-01-oq-02

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-01-oq-02/meta.json
@@ -7,6 +7,7 @@
     "status": "verified",
     "badge": "mathlib",
     "axiomCount": 0,
+    "sorries": 0,
     "difficulty": "advanced",
     "category": "linear-algebra",
     "tags": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: cauchy-interlacing-theorem-oq-01-oq-01-oq-02
**Problem**: The `sorries` field was missing from the `meta` sub-object.

The auditor (`scripts/auditor/find-targets.ts`) reads the claimed sorry count from `meta.meta.sorries` — the convention used by **all 3186 other** gallery entries. This entry was the lone exception: it declared `sorries: 0` only at the top level and in `leanFile`, but not inside the `meta` sub-object. So the auditor computed `claimedSorries = -1` (the `?? -1` fallback) and flagged a phantom **"sorry mismatch: claims -1, actual 0"**.

## Evidence

- `meta.meta.sorries` present in 3186 entries, absent in 1 (this one).
- Lean source `Proofs/CauchyInterlacingOQ01OQ01OQ02.lean` (comment-stripped): **0 code sorries, 0 axiom declarations, 0 True stubs, 0 native_decide**.
- `status: "verified"` / `badge: "mathlib"` are accurate (Tier B — builds on Mathlib + sibling gallery entries `CauchyInterlacingOQ01OQ01`, `CauchyInterlacingCompression`).

## Fix

Add `"sorries": 0` to the `meta` sub-object. Metadata-location only; no claim change. After the fix, `find-targets.ts --issues` reports 0 targets with issues.

---
Discovered during gallery integrity audit.