### PR TITLE
Enrich Derangements as an Instance of the Inclusion-Exclusion Sieve

### DIFF
--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-fixset",
+    "proofId": "inclusion-exclusion-oq-04-oq-01",
+    "range": { "startLine": 60, "endLine": 66 },
+    "type": "definition",
+    "title": "Modeling 'Fixes Point i' as the i-th Bad Property",
+    "content": "`fixSet i = univ.filter (fun σ => σ i = i)` is the set of permutations of Fin n that fix the point i — the i-th 'bad property' in the sieve. The whole derivation hinges on this reformulation: by taking the sieve's ground universe to be Equiv.Perm (Fin n) and its n bad properties to be the fixSet i, a permutation avoiding every bad property is precisely one with no fixed point, i.e. a derangement. This is what lets the parent's general dual sieve be applied verbatim with the ground type instantiated to permutations. The `mem_fixSet` simp lemma exposes the membership condition σ i = i.",
+    "mathContext": "$\\text{fixSet}(i) = \\{\\sigma \\in \\mathrm{Perm}(\\mathrm{Fin}\\,n) \\mid \\sigma(i) = i\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["derangement", "fixed point", "bad property", "inclusion-exclusion sieve", "permutation"],
+    "prerequisites": ["permutations", "Finset.filter", "fixed points"]
+  },
+  {
+    "id": "ann-crux-count",
+    "proofId": "inclusion-exclusion-oq-04-oq-01",
+    "range": { "startLine": 75, "endLine": 110 },
+    "type": "technique",
+    "title": "The Crux Count: Permutations Fixing a Set Pointwise Number (n − |t|)!",
+    "content": "The one genuinely combinatorial step. `inf_fixSet_eq_filter` first identifies the intersection ⋂_{i∈t} fixSet i with the permutations fixing every point of t. `card_fixesOn` then counts them: exactly (n − |t|)!. The proof is structural rather than hands-on — Mathlib's `Equiv.Perm.subtypeEquivSubtypePerm` (with predicate x ∉ t) identifies permutations fixing the complement of {x // x ∉ t} with permutations of that subtype, composed with `Equiv.subtypeEquivRight` to match the 'fixes t pointwise' predicate. Then `Fintype.card_perm` gives (card of complement)! and `Fintype.card_subtype_compl` evaluates the complement size as n − |t|. No explicit extension/restriction bijection is built by hand.",
+    "mathContext": "$\\#\\{\\sigma \\mid \\forall i \\in t,\\ \\sigma(i) = i\\} = (n - |t|)!$",
+    "significance": "key",
+    "relatedConcepts": ["subtypeEquivSubtypePerm", "Fintype.card_perm", "complement", "pointwise fixing", "bijective counting"],
+    "prerequisites": ["permutation groups", "subtypes", "Fintype cardinality"]
+  },
+  {
+    "id": "ann-avoid-derangements",
+    "proofId": "inclusion-exclusion-oq-04-oq-01",
+    "range": { "startLine": 112, "endLine": 127 },
+    "type": "insight",
+    "title": "The Avoid Set Is Exactly the Derangements",
+    "content": "`card_avoid_eq_numDerangements` is the structural observation that unlocks the sieve. The sieve's 'avoid' set — permutations lying in none of the fixSet i, i.e. ⋂_i (fixSet i)ᶜ — unfolds to {σ | ∀ i, σ i ≠ i}, which is the definition of a derangement. So its cardinality is numDerangements n (via `card_derangements_eq_numDerangements` linking Fintype.card (derangements α) to the subfactorial). Identifying 'avoids every fixed-point condition' with 'is a derangement' is precisely what makes the abstract sieve compute the quantity of interest.",
+    "mathContext": "$\\#\\bigl(\\bigsqcap_i \\text{fixSet}(i)^c\\bigr) = \\#\\{\\sigma \\mid \\forall i,\\ \\sigma(i) \\neq i\\} = D_n$.",
+    "significance": "key",
+    "relatedConcepts": ["derangement", "avoid set", "complement intersection", "numDerangements", "subfactorial"],
+    "prerequisites": ["derangements", "set complements"]
+  },
+  {
+    "id": "ann-sieve-form",
+    "proofId": "inclusion-exclusion-oq-04-oq-01",
+    "range": { "startLine": 129, "endLine": 162 },
+    "type": "concept",
+    "title": "The Binomial Sieve Form via Grouping by Subset Size",
+    "content": "`numDerangements_eq_sieve_sum` applies the parent's general dual sieve `card_avoid_sieve` to get D_n as a signed sum over all subsets t of the points, each weighted (−1)^|t|·|⋂_{i∈t} fixSet i|. The collapse to a binomial sum exploits that the crux count (n − |t|)! depends only on |t|: `Finset.powerset_card_disjiUnion` regroups the powerset by cardinality k, `Finset.card_powersetCard` counts C(n,k) subsets of size k, and each contributes the identical (−1)^k(n−k)!. The result, D_n = Σ_{k=0}^n (−1)^k C(n,k)(n−k)!, lives in ℤ — the alternating signs cannot survive in ℕ. This binomial form was not previously in the gallery.",
+    "mathContext": "$D_n = \\sum_{k=0}^n (-1)^k \\binom{n}{k}(n-k)!$ (over $\\mathbb{Z}$).",
+    "significance": "key",
+    "relatedConcepts": ["dual sieve", "card_avoid_sieve", "powerset_card_disjiUnion", "binomial coefficient", "alternating sum"],
+    "prerequisites": ["inclusion-exclusion", "powerset by cardinality", "signed sums"]
+  },
+  {
+    "id": "ann-exponential-form",
+    "proofId": "inclusion-exclusion-oq-04-oq-01",
+    "range": { "startLine": 164, "endLine": 199 },
+    "type": "insight",
+    "title": "Collapsing to the Classical Exponential Form",
+    "content": "`numDerangements_eq_factorial_mul_altSum` recovers the famous D_n = n!·Σ_{k=0}^n (−1)^k/k! directly from the sieve form (not the recurrence) — literally the formula the open question names. The single algebraic input is `Nat.choose_mul_factorial_mul_factorial`: C(n,k)·k!·(n−k)! = n!, rearranged to C(n,k)(n−k)! = n!/k!. Casting the ℤ-valued sieve identity through ℝ (push_cast) and applying this per term turns each (−1)^k C(n,k)(n−k)! into n!·(−1)^k/k!, exposing the partial sums of e⁻¹ that give the classical D_n/n! → 1/e.",
+    "mathContext": "$D_n = n!\\sum_{k=0}^n \\frac{(-1)^k}{k!}$, from $\\binom{n}{k}(n-k)! = \\dfrac{n!}{k!}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["exponential form", "subfactorial", "choose_mul_factorial_mul_factorial", "1/e limit", "push_cast"],
+    "prerequisites": ["factorials", "real number casts", "series for e"]
+  },
+  {
+    "id": "ann-concrete-check",
+    "proofId": "inclusion-exclusion-oq-04-oq-01",
+    "range": { "startLine": 201, "endLine": 222 },
+    "type": "context",
+    "title": "A Concrete, Axiom-Free Check at n = 4",
+    "content": "The file closes with D_4 = 9 verified against the sieve sum 24 − 24 + 12 − 4 + 1 = 9. Crucially the evaluation uses `decide` (kernel reduction), not `native_decide` (compiler reduction), so the file does not pick up the Lean.ofReduceBool axiom and remains genuinely axiom-free — #print axioms reports only propext, Classical.choice, Quot.sound for the main theorems. This is a deliberate axiom-integrity choice: the worked example confirms the formula numerically without compromising the verified, 0-axiom status.",
+    "mathContext": "$D_4 = \\sum_{k=0}^4 (-1)^k \\binom{4}{k}(4-k)! = 24 - 24 + 12 - 4 + 1 = 9$.",
+    "significance": "context",
+    "relatedConcepts": ["decide", "native_decide", "axiom integrity", "worked example"],
+    "prerequisites": ["kernel reduction", "small-case verification"]
+  }
+]

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01/index.ts
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/InclusionExclusionSieveDerangements.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const inclusionExclusionSieveDerangementsProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const inclusionExclusionSieveDerangementsAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const inclusionExclusionSieveDerangementsData: ProofData = {
+  proof: inclusionExclusionSieveDerangementsProof,
+  annotations: inclusionExclusionSieveDerangementsAnnotations,
+}

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-01/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-01/meta.json
@@ -99,7 +99,18 @@
     "isAristotle": false,
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InclusionExclusionSieveDerangements.lean"
   },
-  "overview": "A derangement of {1,…,n} is a permutation with no fixed point; the count D_n (the subfactorial !n) is the prototypical application of inclusion–exclusion. This entry realises that application formally. Taking the ground set to be all permutations of Fin n and the n 'bad properties' to be 'fixes point i', a permutation that avoids every bad property is exactly a derangement, so the parent file's dual sieve immediately expresses D_n as an alternating sum over subsets of the points. Grouping the subsets by size and counting permutations fixing a given subset pointwise — the crux (n − |t|)! count — gives the binomial closed form Σ_k (-1)^k C(n,k)(n-k)!, and one algebraic identity per term yields the famous n!·Σ(-1)^k/k!. The whole derivation is an instance of a single general theorem, exactly as the open question requests.",
+  "overview": {
+    "historicalContext": "The derangement count D_n — the number of permutations of n objects leaving nothing in its original place — is the historical birthplace of the inclusion–exclusion principle. Pierre Rémond de Montmort posed and solved the problem in 1708 in his Essay d'analyse sur les jeux de hazard, framed as the 'problème des rencontres' (the matching game / 'problème de treize'), and Nicholas Bernoulli and Euler returned to it repeatedly. The striking limiting fact D_n/n! → 1/e is the canonical first surprise of enumerative probability. The modern textbook derivation — count permutations avoiding every fixed-point condition by alternately adding and subtracting over the conditions — is the prototypical inclusion–exclusion argument, presented as such in Stanley's Enumerative Combinatorics and van Lint–Wilson. This entry formalizes exactly that route, realizing D_n as a genuine instance of the general dual sieve proved in the parent entry, in contrast to Mathlib's recurrence-based numDerangements_sum.",
+    "problemStatement": "A derangement of $\\mathrm{Fin}\\,n$ is a permutation with no fixed point; write $D_n$ for their number (the subfactorial $!n$). Answer the first open question of the parent sieve entry: by taking the ground set to be all permutations of $\\mathrm{Fin}\\,n$ and the $n$ bad properties to be 'the permutation fixes point $i$', derive both the binomial closed form $D_n = \\sum_{k=0}^n (-1)^k \\binom{n}{k}(n-k)!$ and the classical exponential form $D_n = n!\\sum_{k=0}^n \\frac{(-1)^k}{k!}$ purely as instances of the general inclusion–exclusion sieve, not from the recurrence $D_{n+2} = (n+1)(D_n + D_{n+1})$.",
+    "proofStrategy": "Model 'fixes point i' as fixSet i = {σ | σ i = i} over the universe Equiv.Perm (Fin n). The intersection over a set t of points is the permutations fixing t pointwise (inf_fixSet_eq_filter), and the crux count card_fixesOn shows these number (n − |t|)!, proved by composing Mathlib's Equiv.Perm.subtypeEquivSubtypePerm (permutations fixing the complement of a subtype ≃ permutations of the subtype) with Fintype.card_perm and Fintype.card_subtype_compl — no extension/restriction bijection is hand-built. The sieve's 'avoid' set (permutations in none of the fixSet i) is exactly the derangements (card_avoid_eq_numDerangements), so the parent's card_avoid_sieve expresses D_n as an alternating powerset sum. Grouping by subset size via Finset.powerset_card_disjiUnion (C(n,k) subsets of size k, each contributing (−1)^k(n−k)!) gives the binomial form numDerangements_eq_sieve_sum, and the per-term identity C(n,k)(n−k)! = n!/k! (Nat.choose_mul_factorial_mul_factorial) collapses it to the exponential form numDerangements_eq_factorial_mul_altSum. A decide-checked D_4 = 9 keeps the file axiom-free.",
+    "keyInsights": [
+      "Inclusion–exclusion is the historically correct proof of the derangement formula, and this entry recovers it as a one-line instantiation. Mathlib and the gallery's DerangementsOQ03 reach the closed forms through the recurrence D_{n+2}=(n+1)(D_n+D_{n+1}); here the formula falls out of the general dual sieve applied to the permutation universe, which is both the textbook route and a demonstration that the gallery's sieve powers the enumeration it was built for.",
+      "The entire combinatorial content is a single count: permutations fixing a prescribed t-element set number (n − |t|)!. Everything else is the abstract sieve plus bookkeeping. This count is obtained structurally — permutations fixing t pointwise correspond bijectively to permutations of the n − |t| free points — rather than by an explicit hand-built bijection.",
+      "Grouping the powerset sum by subset size is what converts the abstract Σ over all subsets into the familiar binomial sum. Because the crux count (n − |t|)! depends only on |t|, the C(n,k) subsets of each size k collapse to a single term (−1)^k C(n,k)(n−k)!, turning the 2^n-term sieve into an (n+1)-term formula.",
+      "The binomial form and the exponential form are the same identity at different granularities. The per-term factorization C(n,k)(n−k)! = n!/k! is the only algebra needed to pass from Σ(−1)^k C(n,k)(n−k)! to n!·Σ(−1)^k/k!, the latter exposing the D_n/n! → 1/e limit while the former is the raw sieve output.",
+      "Casting through ℤ then ℝ is essential because the sieve is signed. The alternating sum cannot live in ℕ (truncated subtraction would corrupt it), so numDerangements_eq_sieve_sum works over ℤ and the exponential form over ℝ — the signs are first-class, which is exactly the subtlety the dual sieve is designed to handle."
+    ]
+  },
   "sections": [
     {
       "id": "fixsets-and-crux",
@@ -160,6 +171,16 @@
       "targetId": "derangements",
       "relationship": "related",
       "description": "Gives a second, inclusion-exclusion-based proof of the derangement closed forms, complementing the recurrence-based proofs in Derangements and DerangementsOQ03."
+    },
+    {
+      "targetId": "inclusion-exclusion-oq-04-oq-01-oq-01",
+      "relationship": "extended-by",
+      "description": "Child answering this entry's first open question: it instantiates the same sieve to count surjections [n] ↠ [k] = Σ_j (-1)^j C(k,j)(k-j)^n, with bad property 'value j is missed' and crux count (k − |J|)^n — the second flagship application of the dual sieve."
+    },
+    {
+      "targetId": "inclusion-exclusion-oq-04-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "Child answering this entry's second open question: it proves the Bonferroni inequalities for the derangement sieve — truncating the alternating powerset sum at an even (resp. odd) partial sum over- (resp. under-) counts D_n, a one-sided bound from the sieve's alternating structure."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `inclusion-exclusion-oq-04-oq-01`. This research-authored entry had a rich meta.json but no annotations, a plain-string overview, and unlinked child entries.

## Changes
- **Created `annotations.json`** — 6 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering fixSet modeling, the (n − |t|)! crux count, the avoid-set = derangements step, the binomial sieve form, the exponential collapse, and the axiom-free n = 4 check.
- **Structured the `overview`** — converted the plain string into the `ProofOverview` object the type expects: `historicalContext` (Montmort 1708 / problème des rencontres), `problemStatement`, `proofStrategy`, 5 `keyInsights`.
- **Linked the children** — added `extended-by` cross-references to `inclusion-exclusion-oq-04-oq-01-oq-01` (surjection count) and `-oq-02` (Bonferroni), which answer this entry's two open questions.
- **Created `index.ts`** for consistency with sibling entries.

Verified the build regenerates `public/data/proofs/inclusion-exclusion-oq-04-oq-01/` from the updated meta/annotations. `pnpm build` passes (exit 0).