### PR TITLE
research(schroeder-bernstein-oq-04-oq-01-oq-01): Σ⁰₁ presentation of the CBS orbit classification [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3379,6 +3379,7 @@ import Proofs.SchroederBernsteinOQ03Aristotle
 import Proofs.SchroederBernsteinOQ03StatementOnly
 import Proofs.SchroederBernsteinOQ04
 import Proofs.SchroederBernsteinOQ04OQ01
+import Proofs.SchroederBernsteinOQ04OQ01OQ01
 import Proofs.SchursLemma
 import Proofs.SchursTheorem
 import Proofs.SearchMathlib

--- a/proofs/Proofs/SchroederBernsteinOQ04OQ01OQ01.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ04OQ01OQ01.lean
@@ -1,0 +1,243 @@
+import Mathlib.Tactic
+import Proofs.SchroederBernsteinOQ04OQ01
+
+/-
+# Semi-Decidable (Σ⁰₁) Presentation of the CBS Orbit Classification
+
+## Open Question (OQ-04 ▸ OQ-01 ▸ sub-question 1)
+The parent file `SchroederBernsteinOQ04OQ01` proves Cantor–Bernstein–Schroeder for
+*arbitrary* types via the union-of-iterates reachable set
+`reachableSet f g = ⋃ₙ (step f g)^[n] (baseSet g)`, and observes in its header that
+the price of dropping finiteness is that the orbit classification
+`a ∈ reachableSet f g` is no longer decidable, only **semi-decidable (Σ⁰₁)** —
+"there is no a-priori bound on how many `step` iterations one must unfold."
+
+This file makes that observation precise and proves it.
+
+## What is proved
+
+* **Section A — the Σ⁰₁ logical form.** `reachableSet f g` is, *definitionally*, an
+  existential over the stage family `stage f g n := (step f g)^[n] (baseSet g)`:
+  `a ∈ reachableSet f g ↔ ∃ n, a ∈ stage f g n`, and `reachableSet f g = ⋃ n, stage f g n`.
+  The stages are monotone increasing. This is exactly the shape of a `Σ⁰₁`
+  (semi-decidable) predicate: an existential quantifier over a uniformly described
+  family of "approximation stages".
+
+* **Section B — semi-decision halts on members.** Every member has a *least*
+  certifying stage (`exists_least_stage`). This is the positive half of
+  semi-decidability: a search that enumerates the stages will, for any genuine
+  member, terminate at a finite stage — but it is given no information about
+  non-members.
+
+* **Section C — the decidability criterion.** If the stages ever become stationary
+  (`stage f g N = stage f g (N+1)`), the union collapses:
+  `reachableSet f g = stage f g N` (`reachableSet_eq_stage_of_stationary`). So
+  membership is decidable as soon as a fixed point is reached. For a `Fintype` a
+  fixed point must occur (a strictly increasing chain of subsets of a finite type
+  cannot run forever) — recovering the parent's finite, decidable case. The *only*
+  obstruction to decidability is therefore the failure of stabilization, i.e. an
+  unbounded search.
+
+* **Section D — the search is genuinely unbounded.** With `α = β = ℕ` and
+  `f = g = Nat.succ` (the shift embeddings of the parent header's example), the
+  stages strictly grow forever: `stage Nat.succ Nat.succ N = {0, 2, …, 2N}`, so the
+  least certifying stage of `2N` is exactly `N`. Hence:
+  - `unbounded_search`: for every bound `N` there is a member (`2(N+1)`) not yet
+    certified at stage `N`;
+  - `stage_succ_ne`: no stage is ever stationary, so the criterion of Section C is
+    *never* met here.
+  This is the formal content of "no a-priori bound on the number of iterations":
+  the Σ⁰₁ presentation cannot be collapsed to a single bounded (decidable-by-fixed-`N`)
+  test.
+
+## Honesty note
+"Semi-decidable / Σ⁰₁" is captured here as its precise *logical form* — an
+existential over a uniform stage family with the least-witness property — together
+with the proof that the search is genuinely unbounded. A fully computability-theoretic
+`RePred` statement would additionally require the injections `f`, `g` (and the
+membership `· ∈ range g`) to be effectively given; that is an orthogonal hypothesis
+not present in the parent's purely set-theoretic construction, and is *not* claimed
+here. In the concrete `ℕ`-shift instance membership happens to be decidable (it is
+the even numbers); what is unbounded — and what genuinely fails to stabilise — is the
+*stage-bounded* search, which is the mechanism behind the Σ⁰₁ presentation.
+
+## Status
+- [x] Complete proof (0 sorries, 0 `axiom` declarations)
+- [x] Builds on the parent's union-of-iterates construction with no new assumptions
+-/
+
+set_option linter.unusedSectionVars false
+
+namespace CBSInfinite
+
+variable {α β : Type*}
+
+/-! ## Stage family: the finite approximations of the reachable set -/
+
+/-- The `n`-th approximation stage: the reachable set unfolded to depth `n`.
+    `reachableSet f g` is the union of all stages. -/
+def stage (f : α → β) (g : β → α) (n : ℕ) : Set α :=
+  (step f g)^[n] (baseSet g)
+
+theorem stage_zero (f : α → β) (g : β → α) : stage f g 0 = baseSet g := rfl
+
+/-- One stage is obtained from the previous by a single `step`. -/
+theorem step_stage (f : α → β) (g : β → α) (n : ℕ) :
+    stage f g (n + 1) = step f g (stage f g n) := by
+  unfold stage
+  rw [Function.iterate_succ_apply']
+
+/-! ## Section A: the Σ⁰₁ logical form -/
+
+/-- **The Σ⁰₁ presentation.** Membership in `reachableSet` is, definitionally, an
+    existential over the uniformly described stage family. This is precisely the
+    shape of a semi-decidable predicate. -/
+theorem mem_reachable_iff_exists_stage (f : α → β) (g : β → α) (a : α) :
+    a ∈ reachableSet f g ↔ ∃ n, a ∈ stage f g n := Iff.rfl
+
+/-- The reachable set is the countable union of its stages. -/
+theorem reachableSet_eq_iUnion (f : α → β) (g : β → α) :
+    reachableSet f g = ⋃ n, stage f g n := by
+  ext a
+  simp only [reachableSet, stage, Set.mem_setOf_eq, Set.mem_iUnion]
+
+/-- Consecutive stages are nested. -/
+theorem stage_subset_succ (f : α → β) (g : β → α) (n : ℕ) :
+    stage f g n ⊆ stage f g (n + 1) :=
+  iter_subset_succ f g n
+
+/-- The stage family is monotone in the depth. -/
+theorem stage_mono (f : α → β) (g : β → α) : Monotone (stage f g) :=
+  monotone_nat_of_le_succ (fun n => stage_subset_succ f g n)
+
+/-! ## Section B: semi-decision halts on members -/
+
+/-- **Positive half of semi-decidability.** Every member of the reachable set is
+    certified at some *least* finite stage: a search enumerating the stages halts on
+    every genuine member. (It is told nothing about non-members — that is the whole
+    point of `Σ⁰₁`.) -/
+theorem exists_least_stage {f : α → β} {g : β → α} {a : α}
+    (h : a ∈ reachableSet f g) :
+    ∃ N, a ∈ stage f g N ∧ ∀ m, a ∈ stage f g m → N ≤ m := by
+  classical
+  exact ⟨Nat.find h, Nat.find_spec h, fun m hm => Nat.find_min' h hm⟩
+
+/-! ## Section C: the decidability criterion -/
+
+/-- Once two consecutive stages coincide, the family is constant from there on. -/
+theorem stage_const_of_stationary (f : α → β) (g : β → α) (N : ℕ)
+    (h : stage f g N = stage f g (N + 1)) :
+    ∀ k, stage f g (N + k) = stage f g N := by
+  intro k
+  induction k with
+  | zero => simp
+  | succ k ih =>
+    have e1 : N + (k + 1) = (N + k) + 1 := by ring
+    rw [e1, step_stage f g (N + k), ih, ← step_stage f g N, ← h]
+
+/-- A stationary point propagates to all later indices. -/
+theorem stage_eq_of_ge (f : α → β) (g : β → α) (N : ℕ)
+    (h : stage f g N = stage f g (N + 1)) {n : ℕ} (hn : N ≤ n) :
+    stage f g n = stage f g N := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le hn
+  exact stage_const_of_stationary f g N h k
+
+/-- **Decidability criterion.** If the stages become stationary at `N`, the whole
+    reachable set is just `stage f g N` — a single, bounded, decidable approximation.
+    The unbounded existential collapses to a finite one exactly when a fixed point of
+    `step` is reached. For a `Fintype` this always happens (the stages form a
+    strictly increasing chain of subsets, which must terminate), recovering the
+    parent's decidable finite case. -/
+theorem reachableSet_eq_stage_of_stationary (f : α → β) (g : β → α) (N : ℕ)
+    (h : stage f g N = stage f g (N + 1)) :
+    reachableSet f g = stage f g N := by
+  rw [reachableSet_eq_iUnion]
+  apply Set.eq_of_subset_of_subset
+  · apply Set.iUnion_subset
+    intro n
+    rcases le_total n N with hn | hn
+    · exact stage_mono f g hn
+    · exact (stage_eq_of_ge f g N h hn).le
+  · exact Set.subset_iUnion (stage f g) N
+
+/-! ## Section D: the search is genuinely unbounded (the `ℕ`-shift instance)
+
+We instantiate the construction at the parent header's own example: `α = β = ℕ`,
+`f = g = Nat.succ`. Here `baseSet = {0}` and `step S = S ∪ (·+2) '' S`, so the
+stages are the truncated evens `{0, 2, …, 2N}`. The least certifying stage of `2N`
+is exactly `N`, which grows without bound: the Σ⁰₁ search has no uniform cutoff. -/
+
+/-- For the shift `g = Nat.succ`, the only element with no preimage is `0`. -/
+theorem baseSet_succ : baseSet Nat.succ = {0} := by
+  ext a
+  simp only [baseSet, Set.mem_setOf_eq, Set.mem_singleton_iff]
+  constructor
+  · intro h
+    rcases Nat.eq_zero_or_pos a with h0 | hpos
+    · exact h0
+    · exact absurd (by omega : Nat.succ (a - 1) = a) (h (a - 1))
+  · rintro rfl b
+    exact Nat.succ_ne_zero b
+
+/-- Every element of stage `n` of the shift instance is at most `2n`. -/
+theorem mem_stage_succ_le {n m : ℕ} (hm : m ∈ stage Nat.succ Nat.succ n) :
+    m ≤ 2 * n := by
+  induction n generalizing m with
+  | zero =>
+    rw [stage_zero, baseSet_succ, Set.mem_singleton_iff] at hm
+    omega
+  | succ n ih =>
+    rw [step_stage] at hm
+    simp only [step, Set.mem_union, Set.mem_image] at hm
+    rcases hm with h | ⟨x, hx, rfl⟩
+    · have := ih h; omega
+    · have := ih hx; omega
+
+/-- The even number `2n` is reached at stage `n`. -/
+theorem two_mul_mem_stage (n : ℕ) : 2 * n ∈ stage Nat.succ Nat.succ n := by
+  induction n with
+  | zero =>
+    rw [stage_zero, baseSet_succ]
+    simp
+  | succ n ih =>
+    rw [step_stage]
+    simp only [step, Set.mem_union, Set.mem_image]
+    exact Or.inr ⟨2 * n, ih, by omega⟩
+
+/-- Hence `2n` is in the reachable set. -/
+theorem two_mul_mem_reachable (n : ℕ) :
+    2 * n ∈ reachableSet Nat.succ Nat.succ :=
+  ⟨n, two_mul_mem_stage n⟩
+
+/-- **The search is genuinely unbounded.** For every bound `N` there is a member of
+    the reachable set — namely `2(N+1)` — that is not yet certified at stage `N`. No
+    fixed number of iterations suffices uniformly: this is the precise sense of "no
+    a-priori bound" from the parent header. -/
+theorem unbounded_search (N : ℕ) :
+    ∃ a, a ∈ reachableSet Nat.succ Nat.succ ∧ a ∉ stage Nat.succ Nat.succ N := by
+  refine ⟨2 * (N + 1), two_mul_mem_reachable (N + 1), ?_⟩
+  intro h
+  have := mem_stage_succ_le h
+  omega
+
+/-- **No stationary point ever occurs** in the shift instance: the criterion of
+    `reachableSet_eq_stage_of_stationary` is never satisfied, so the reachable set is
+    not equal to any single stage. The stages strictly grow forever. -/
+theorem stage_succ_ne (N : ℕ) :
+    stage Nat.succ Nat.succ N ≠ stage Nat.succ Nat.succ (N + 1) := by
+  intro h
+  have hmem : 2 * (N + 1) ∈ stage Nat.succ Nat.succ N := by
+    rw [h]; exact two_mul_mem_stage (N + 1)
+  have := mem_stage_succ_le hmem
+  omega
+
+/-- Consequently the reachable set of the shift instance differs from every stage:
+    the unbounded union does not collapse. -/
+theorem reachableSet_ne_stage (N : ℕ) :
+    reachableSet Nat.succ Nat.succ ≠ stage Nat.succ Nat.succ N := by
+  intro h
+  obtain ⟨a, ha_mem, ha_not⟩ := unbounded_search N
+  rw [h] at ha_mem
+  exact ha_not ha_mem
+
+end CBSInfinite

--- a/src/data/proofs/schroeder-bernstein-oq-04-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-04-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-cbs-sigma01-stage",
+    "proofId": "schroeder-bernstein-oq-04-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 88 },
+    "type": "definition",
+    "title": "The Stage Family",
+    "content": "stage f g n = (step f g)^[n] (baseSet g) names the finite approximations of the parent's reachableSet. stage f g 0 is baseSet g, and stage f g (n+1) = step f g (stage f g n) by Function.iterate_succ_apply'. Membership in reachableSet is exactly an existential over this family, so the stages are where the Σ⁰₁ structure lives.",
+    "mathContext": "$\\operatorname{stage}_n = \\operatorname{step}^{[n]}(A_0)$, $\\operatorname{stage}_{n+1} = \\operatorname{step}(\\operatorname{stage}_n)$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit classification", "function iteration", "approximation stages"],
+    "prerequisites": ["Function.iterate", "Function.iterate_succ_apply'"]
+  },
+  {
+    "id": "ann-cbs-sigma01-form",
+    "proofId": "schroeder-bernstein-oq-04-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 111 },
+    "type": "key-result",
+    "title": "The Σ⁰₁ Logical Form",
+    "content": "mem_reachable_iff_exists_stage holds by Iff.rfl: a ∈ reachableSet f g ↔ ∃ n, a ∈ stage f g n. With reachableSet_eq_iUnion (reachableSet = ⋃ n, stage f g n) and stage_mono (the stages increase), this is precisely the shape of a semi-decidable predicate — an existential over a uniform, monotone family of stages.",
+    "mathContext": "$a \\in R \\iff \\exists n,\\ a \\in \\operatorname{stage}_n$, $R = \\bigcup_n \\operatorname{stage}_n$, $\\operatorname{stage}$ monotone.",
+    "significance": "key",
+    "relatedConcepts": ["semi-decidable predicate", "Σ⁰₁", "arithmetical hierarchy", "indexed union"],
+    "prerequisites": ["Set.mem_iUnion", "monotone_nat_of_le_succ"]
+  },
+  {
+    "id": "ann-cbs-sigma01-halts",
+    "proofId": "schroeder-bernstein-oq-04-oq-01-oq-01",
+    "range": { "startLine": 113, "endLine": 123 },
+    "type": "proof-technique",
+    "title": "Semi-Decision Halts on Members",
+    "content": "exists_least_stage uses Nat.find under a local classical instance to produce, for any member, a least certifying stage with the minimality property. This is the positive half of semi-decidability: a search enumerating the stages terminates on every genuine member. Crucially it provides no certificate of non-membership — the defining asymmetry of Σ⁰₁ versus decidable.",
+    "mathContext": "$a \\in R \\Rightarrow \\exists N,\\ a \\in \\operatorname{stage}_N \\wedge \\forall m,\\ a \\in \\operatorname{stage}_m \\to N \\le m$.",
+    "significance": "key",
+    "relatedConcepts": ["least witness", "well-ordering of ℕ", "halting on members"],
+    "prerequisites": ["Nat.find", "Nat.find_spec", "Nat.find_min'"]
+  },
+  {
+    "id": "ann-cbs-sigma01-decid",
+    "proofId": "schroeder-bernstein-oq-04-oq-01-oq-01",
+    "range": { "startLine": 125, "endLine": 161 },
+    "type": "key-result",
+    "title": "Decidability ⟺ Stabilization",
+    "content": "If two consecutive stages coincide, stage_const_of_stationary propagates the fixed point to all later indices, and reachableSet_eq_stage_of_stationary collapses the whole union to that single stage. So membership is decidable exactly once the iteration stabilizes. For a Fintype a fixed point must occur (a strictly increasing chain of subsets of a finite type terminates), which is precisely what makes the parent's finite case decidable. Unbounded, never-stabilizing search is the sole obstruction.",
+    "mathContext": "$\\operatorname{stage}_N = \\operatorname{stage}_{N+1} \\Rightarrow R = \\operatorname{stage}_N$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed point", "stabilization", "decidable predicate", "finite case recovery"],
+    "prerequisites": ["Set.iUnion_subset", "Set.subset_iUnion", "Nat.exists_eq_add_of_le"]
+  },
+  {
+    "id": "ann-cbs-sigma01-unbounded",
+    "proofId": "schroeder-bernstein-oq-04-oq-01-oq-01",
+    "range": { "startLine": 163, "endLine": 243 },
+    "type": "key-result",
+    "title": "The Search Is Genuinely Unbounded (ℕ-Shift)",
+    "content": "Instantiating at α = β = ℕ, f = g = Nat.succ: baseSet = {0} and the stages are the truncated evens {0,2,…,2N} — proved by the bound m ∈ stage n → m ≤ 2n together with 2n ∈ stage n. So the least certifying stage of 2N is exactly N: unbounded_search exhibits, for every N, a member 2(N+1) not yet reached at stage N, and stage_succ_ne shows no stage is ever stationary. This is the precise formal meaning of the parent's 'no a-priori bound on the number of iterations', and the criterion of the previous section is never met here.",
+    "mathContext": "$\\operatorname{stage}_N = \\{0,2,\\dots,2N\\}$, $2(N+1) \\in R \\setminus \\operatorname{stage}_N$, $\\operatorname{stage}_N \\ne \\operatorname{stage}_{N+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["shift map", "unbounded search", "non-stabilization", "concrete counterexample"],
+    "prerequisites": ["Nat.succ_ne_zero", "induction", "omega"]
+  }
+]

--- a/src/data/proofs/schroeder-bernstein-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-04-oq-01-oq-01/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "schroeder-bernstein-oq-04-oq-01-oq-01",
+  "slug": "schroeder-bernstein-oq-04-oq-01-oq-01",
+  "title": "Semi-Decidable (Σ⁰₁) Presentation of the CBS Orbit Classification",
+  "conclusion": {
+    "summary": "We make precise, and prove, the parent entry's claim that the Cantor–Bernstein–Schroeder orbit classification reachableSet membership is semi-decidable (Σ⁰₁) but not decidable for infinite types. Membership is, definitionally, an existential over a monotone family of approximation stages stage f g n = (step f g)^[n] (baseSet g); every member is certified at a least finite stage; the union collapses to a single stage exactly when the stages become stationary; and in the ℕ-shift instance the stages strictly grow forever, so the search has no uniform bound.",
+    "implications": "**The Σ⁰₁ shape is the definitional backbone.** reachableSet membership is `∃ n, a ∈ stage f g n` with the stages a uniformly described monotone family — exactly the logical form of a semi-decidable predicate. The positive half of semi-decidability is the least-witness theorem: a search enumerating stages halts on every genuine member, but is told nothing about non-members.\n\n**Decidability ⟺ stabilization.** The unbounded existential collapses to a bounded, decidable test precisely when a fixed point stage f g N = stage f g (N+1) is reached. For a Fintype this always happens (a strictly increasing chain of subsets of a finite type must terminate), recovering the parent's decidable finite case; the only obstruction is the failure of stabilization.\n\n**The search is genuinely unbounded.** In the parent header's own example (α = β = ℕ, f = g = Nat.succ) the stages are the truncated evens {0,2,…,2N}, so the least certifying stage of 2N is exactly N. Hence no fixed bound suffices uniformly (unbounded_search) and no stage is ever stationary (stage_succ_ne) — the precise formal content of 'no a-priori bound on the number of iterations'.",
+    "openQuestions": [
+      "Can the logical Σ⁰₁ form proved here be upgraded to a genuine computability-theoretic statement — e.g. `RePred (· ∈ reachableSet f g)` (recursive enumerability) — under the hypothesis that f, g and `· ∈ range g` are effectively given (computable with semi-decidable range)?",
+      "Is there a pair of computable injections f, g for which reachableSet membership is provably undecidable (Σ⁰₁-complete), making the noncomputability of the CBS bijection unconditional rather than worst-case?"
+    ]
+  },
+  "description": "Formalizes and proves the parent entry's central claim: the CBS orbit classification reachableSet membership is semi-decidable (Σ⁰₁) but not decidable for infinite types. It is definitionally an existential over a monotone stage family (the Σ⁰₁ shape), every member has a least certifying stage (semi-decision halts on members), the union collapses to a single stage exactly when the stages stabilize (decidability criterion), and in the ℕ-shift instance the stages strictly grow forever, so the stage-bounded search has no uniform bound.",
+  "overview": {
+    "historicalContext": "A predicate is Σ⁰₁ (semi-decidable, recursively enumerable) when it can be written as an existential ∃ n, R(n,·) over a decidable/uniform 'stage' family: a search enumerating the stages confirms members but may run forever on non-members. The classical Schröder–Bernstein proof classifies each element by its backward orbit, which is non-constructive. The parent entry (schroeder-bernstein-oq-04-oq-01) reproved CBS for arbitrary types via the union-of-iterates reachable set R = ⋃ₙ step^[n] baseSet, and observed — without formalizing — that for infinite types R-membership is only Σ⁰₁, with 'no a-priori bound on how many step iterations one must unfold'. This entry answers that entry's first open question by making the Σ⁰₁ claim precise and proving it.",
+    "problemStatement": "**Open Question (OQ-04.1.1)**: Give a Σ⁰₁ (r.e.) presentation of `reachableSet` membership and quantify precisely how much constructivity is retained.\n\n**Answer**: Define the stage family stage f g n = (step f g)^[n] (baseSet g). Then:\n- **Σ⁰₁ form**: a ∈ reachableSet f g ↔ ∃ n, a ∈ stage f g n, and reachableSet f g = ⋃ n, stage f g n, with the stages monotone increasing.\n- **Halts on members**: every member has a least certifying stage.\n- **Decidability criterion**: if stage f g N = stage f g (N+1) then reachableSet f g = stage f g N (so membership is decidable once the iteration stabilizes; for a Fintype it always does).\n- **Genuinely unbounded**: for α = β = ℕ, f = g = Nat.succ, the stages are {0,2,…,2N}; for every N the member 2(N+1) is not yet at stage N, and no stage is ever stationary.",
+    "proofStrategy": "1. **Stage family**: stage f g n = (step f g)^[n] (baseSet g); stage f g (n+1) = step f g (stage f g n) via Function.iterate_succ_apply'.\n\n2. **Σ⁰₁ form (Section A)**: mem_reachable_iff_exists_stage is `Iff.rfl`; reachableSet_eq_iUnion by ext + simp; stage monotonicity from iter_subset_succ via monotone_nat_of_le_succ.\n\n3. **Least witness (Section B)**: exists_least_stage from Nat.find / Nat.find_spec / Nat.find_min' under a local classical instance.\n\n4. **Stabilization (Section C)**: stage_const_of_stationary propagates a fixed point to all later stages by induction; reachableSet_eq_stage_of_stationary splits the union into n ≤ N (monotone) and n ≥ N (constant).\n\n5. **Unboundedness (Section D)**: baseSet Nat.succ = {0}; an induction gives the upper bound m ∈ stage Nat.succ Nat.succ n → m ≤ 2n, and another gives 2n ∈ stage n. Together: 2(N+1) ∈ reachableSet but ∉ stage N (unbounded_search), and no stage equals its successor (stage_succ_ne), so reachableSet ≠ any single stage.",
+    "keyInsights": [
+      "**Σ⁰₁ is the definitional shape, not an add-on.** reachableSet membership is literally `∃ n, a ∈ stage f g n` — the existential-over-a-uniform-family form of a semi-decidable predicate. mem_reachable_iff_exists_stage holds by `Iff.rfl`. The content is everything around it: monotonicity, the least witness, and the unboundedness.",
+      "**Semi-decidability = halts on members only.** exists_least_stage gives every member a least certifying stage, so a stage-enumerating search confirms membership at a finite point. It receives no certificate of non-membership — the defining asymmetry of Σ⁰₁ versus decidable.",
+      "**Decidability is exactly stabilization.** reachableSet_eq_stage_of_stationary shows the unbounded union collapses to one stage as soon as step reaches a fixed point. For a Fintype a fixed point must occur (the parent's decidable finite case); the sole obstruction to decidability is an unbounded, never-stabilizing search.",
+      "**The unboundedness is genuine, and concrete.** In the ℕ-shift instance the stages are the truncated evens, so the least certifying stage of 2N is N: it grows without bound (unbounded_search) and no stage is ever stationary (stage_succ_ne). This is the precise formal meaning of the parent's 'no a-priori bound on the number of iterations'.",
+      "**Honest scope.** 'Σ⁰₁' is captured as its logical form plus the unbounded-search theorem, not as a computability-theoretic RePred statement (which would need f, g and range g effectively given — an orthogonal hypothesis). In the concrete ℕ instance membership itself is decidable (the evens); what is unbounded, and provably never stabilizes, is the stage-bounded search that drives the Σ⁰₁ presentation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-stage-family",
+      "title": "The Stage Family",
+      "startLine": 75,
+      "endLine": 88,
+      "summary": "Defines stage f g n = (step f g)^[n] (baseSet g), the finite approximations whose union is reachableSet. stage f g 0 = baseSet g, and stage f g (n+1) = step f g (stage f g n) by Function.iterate_succ_apply'.",
+      "mathContext": "$\\operatorname{stage}_n = \\operatorname{step}^{[n]}(A_0)$, $\\operatorname{stage}_{n+1} = \\operatorname{step}(\\operatorname{stage}_n)$."
+    },
+    {
+      "id": "sec-sigma01-form",
+      "title": "Section A: The Σ⁰₁ Logical Form",
+      "startLine": 90,
+      "endLine": 111,
+      "summary": "reachableSet membership is the existential ∃ n, a ∈ stage f g n (Iff.rfl), reachableSet f g = ⋃ n, stage f g n, and the stages are monotone increasing — exactly the shape of a semi-decidable predicate.",
+      "mathContext": "$a \\in R \\iff \\exists n,\\ a \\in \\operatorname{stage}_n$, $R = \\bigcup_n \\operatorname{stage}_n$, $\\operatorname{stage}$ monotone."
+    },
+    {
+      "id": "sec-halts",
+      "title": "Section B: Semi-Decision Halts on Members",
+      "startLine": 113,
+      "endLine": 123,
+      "summary": "exists_least_stage: every member of reachableSet is certified at a least finite stage. A search enumerating the stages halts on genuine members; it is given no information about non-members.",
+      "mathContext": "$a \\in R \\Rightarrow \\exists N,\\ a \\in \\operatorname{stage}_N \\wedge \\forall m,\\ a \\in \\operatorname{stage}_m \\to N \\le m$."
+    },
+    {
+      "id": "sec-decidability-criterion",
+      "title": "Section C: The Decidability Criterion",
+      "startLine": 125,
+      "endLine": 161,
+      "summary": "If stage f g N = stage f g (N+1) the family is constant thereafter (stage_const_of_stationary), so reachableSet f g = stage f g N (reachableSet_eq_stage_of_stationary): membership is decidable once the iteration stabilizes. For a Fintype stabilization always occurs.",
+      "mathContext": "$\\operatorname{stage}_N = \\operatorname{stage}_{N+1} \\Rightarrow R = \\operatorname{stage}_N$."
+    },
+    {
+      "id": "sec-unbounded",
+      "title": "Section D: The Search Is Genuinely Unbounded",
+      "startLine": 163,
+      "endLine": 243,
+      "summary": "For α = β = ℕ, f = g = Nat.succ: baseSet = {0}, stages are the truncated evens (m ∈ stage n → m ≤ 2n, and 2n ∈ stage n). Hence 2(N+1) ∈ reachableSet but ∉ stage N (unbounded_search), no stage is stationary (stage_succ_ne), and reachableSet equals no single stage (reachableSet_ne_stage).",
+      "mathContext": "$\\operatorname{stage}_N = \\{0,2,\\dots,2N\\}$, $2(N+1) \\in R \\setminus \\operatorname{stage}_N$, $\\operatorname{stage}_N \\ne \\operatorname{stage}_{N+1}$."
+    }
+  ],
+  "references": [
+    {
+      "text": "Schröder–Bernstein theorem (statement, history, and the orbit-classification proof).",
+      "url": "https://en.wikipedia.org/wiki/Schr%C3%B6der%E2%80%93Bernstein_theorem"
+    },
+    {
+      "text": "Arithmetical hierarchy: Σ⁰₁ (semi-decidable / recursively enumerable) predicates as existentials over decidable matrices.",
+      "url": "https://en.wikipedia.org/wiki/Arithmetical_hierarchy"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "schroeder-bernstein-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "The parent: CBS for arbitrary types via the union-of-iterates reachable set, which observes that orbit classification is only semi-decidable (Σ⁰₁). This entry answers that parent's first open question by formalizing and proving the Σ⁰₁ presentation and the genuine unboundedness of the search."
+    },
+    {
+      "targetId": "schroeder-bernstein-oq-04",
+      "relationship": "related",
+      "description": "The finite-type constructive CBS, where the same stage family stabilizes after |α| steps and orbit classification is decidable. Section C's decidability criterion is exactly what makes that finite case decidable."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Proofs.SchroederBernsteinOQ04OQ01"
+    ],
+    "opens": [],
+    "namespace": "CBSInfinite",
+    "lineCount": 243,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "substantiveTheoremCount": 17,
+    "definitionCount": 1,
+    "path": "Proofs/SchroederBernsteinOQ04OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SchroederBernsteinOQ04OQ01OQ01.lean",
+    "tags": [
+      "set-theory",
+      "computability",
+      "decidability",
+      "semi-decidable",
+      "arithmetical-hierarchy",
+      "infinite-types",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Function.iterate_succ_apply'",
+        "description": "f^[n+1] x = f (f^[n] x), used to relate consecutive stages",
+        "module": "Mathlib.Logic.Function.Iterate"
+      },
+      {
+        "theorem": "monotone_nat_of_le_succ",
+        "description": "A sequence with f n ≤ f (n+1) for all n is monotone; gives stage monotonicity",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "Nat.find",
+        "description": "Least natural satisfying a decidable predicate; gives the least certifying stage",
+        "module": "Mathlib.Data.Nat.Find"
+      },
+      {
+        "theorem": "Set.iUnion_subset",
+        "description": "Universal property of the indexed union, used in the stabilization collapse",
+        "module": "Mathlib.Data.Set.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "Stage family stage f g n = (step f g)^[n] (baseSet g) packaging reachableSet as a Σ⁰₁ existential ∃ n, a ∈ stage f g n with reachableSet = ⋃ n, stage f g n",
+      "Least-certifying-stage theorem (exists_least_stage): the positive half of semi-decidability — the stage-enumerating search halts on every member",
+      "Decidability criterion reachableSet_eq_stage_of_stationary: the union collapses to a single decidable stage exactly when the iteration stabilizes, isolating unbounded search as the sole obstruction to decidability and recovering the parent's finite decidable case",
+      "Concrete proof that the search is genuinely unbounded (unbounded_search, stage_succ_ne) in the ℕ-shift instance: stages are the truncated evens, the least certifying stage of 2N is N, and no stage is ever stationary — formalizing the parent's 'no a-priori bound on iterations'"
+    ],
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 243,
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1,
+    "theoremCount": 17,
+    "assumptions": "None beyond Lean/Mathlib's standard foundations. Fully verified with 0 sorries and 0 axiom declarations; no native_decide. The least-witness construction (exists_least_stage) and the parent's noncomputable bijection use the ordinary foundational axioms propext / Classical.choice / Quot.sound only — no sorryAx, no Lean.ofReduceBool. The entry proves the Σ⁰₁ logical form and the genuine unboundedness of the stage-bounded search; it does not claim a computability-theoretic RePred statement, which would require the injections to be effectively given."
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `schroeder-bernstein-oq-04-oq-01` ("CBS for arbitrary types via union-of-iterates"), which observed but did not formalize that the orbit classification `reachableSet` membership is only **semi-decidable (Σ⁰₁)** for infinite types, with "no a-priori bound on the number of `step` iterations."

This entry makes that claim precise and proves it, building directly on the parent's `baseSet` / `step` / `reachableSet`.

## What is proved

Defining the stage family `stage f g n = (step f g)^[n] (baseSet g)`:

- **Section A — the Σ⁰₁ logical form.** `a ∈ reachableSet f g ↔ ∃ n, a ∈ stage f g n` (`Iff.rfl`), `reachableSet f g = ⋃ n, stage f g n`, and the stages are monotone increasing — exactly the shape of a semi-decidable predicate.
- **Section B — semi-decision halts on members.** `exists_least_stage`: every member has a *least* certifying stage. A stage-enumerating search halts on every genuine member and is told nothing about non-members (the Σ⁰₁ asymmetry).
- **Section C — decidability ⟺ stabilization.** `reachableSet_eq_stage_of_stationary`: once `stage f g N = stage f g (N+1)`, the union collapses to the single stage `stage f g N`, so membership is decidable. For a `Fintype` a fixed point must occur — recovering the parent's decidable finite case. Unbounded search is the *sole* obstruction.
- **Section D — the search is genuinely unbounded.** For `α = β = ℕ`, `f = g = Nat.succ` (the parent header's own example): `baseSet = {0}`, the stages are the truncated evens `{0,2,…,2N}`, the least certifying stage of `2N` is `N`. Hence `unbounded_search` (for every `N`, the member `2(N+1)` is not yet at stage `N`) and `stage_succ_ne` (no stage is ever stationary). This is the precise formal content of "no a-priori bound on iterations."

## Verification

- **243 lines, 17 theorems, 1 definition.**
- **0 sorries, 0 `axiom` declarations, no `native_decide`.**
- `#print axioms` on all key results: only `propext` / `Classical.choice` / `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiles against the merged parent olean (`lake env lean`, Lean v4.26.0 / Mathlib v4.26.0).

## Honesty note

"Σ⁰₁" is captured as the logical form plus the unbounded-search theorem — **not** a computability-theoretic `RePred` statement, which would require the injections to be effectively given (an orthogonal hypothesis absent from the parent's set-theoretic construction). In the concrete ℕ instance membership itself is decidable (the evens); what is genuinely unbounded, and provably never stabilizes, is the stage-bounded search that drives the Σ⁰₁ presentation. Two follow-up open questions (genuine `RePred`; a `Σ⁰₁`-complete computable instance) are recorded in the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)