### PR TITLE
audit: add missing meta.sorries to chebyshev-sum-inequality-oq-01-oq-01-oq-01

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
@@ -109,6 +109,7 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 5,
     "definitionCount": 0,
     "lineCount": 136,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `chebyshev-sum-inequality-oq-01-oq-01-oq-01`
**Severity**: LOW (cosmetic metadata; no overclaim)

### Problem
The `meta` object in `meta.json` was missing a `sorries` field. The auditor's `find-targets.ts` reads `meta.meta.sorries` (line 340), falls back to `-1` when absent, and reports a phantom **"sorry mismatch: claims -1, actual 0"**.

### Verification
The Lean source `Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean` is genuinely:
- 0 sorries (comment-stripped)
- 0 `axiom` declarations
- 0 `native_decide`
- 0 `True` stubs
- 5 theorems

`leanFile.sorries` and the top-level `sorries` already record `0`; only the `meta` object lacked the field. Badge `original` is appropriate — the continuous comonotone Chebyshev correlation inequality is assembled from a symmetric double-integral + Fubini argument, not delegated to a Mathlib theorem stating the result (Mathlib only has the discrete Finset form).

### Fix
Added `"sorries": 0` to the `meta` object. Meta-only; no Lean source touched.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)