### PR TITLE
Gallery integrity: chebyshev-sum-inequality-oq-01-oq-01-oq-01 add missing meta.sorries

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
@@ -109,6 +109,7 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 5,
     "definitionCount": 0,
     "lineCount": 136,


### PR DESCRIPTION
## Integrity Issue

**Proof**: chebyshev-sum-inequality-oq-01-oq-01-oq-01
**Problem**: The `meta` object omits the canonical `sorries` field. The auditor's `find-targets` reader falls back to `-1` when `meta.sorries` is absent, producing a spurious `sorry mismatch: claims -1, actual 0`.

## Evidence

- `meta.sorries`: **absent** (→ -1 sentinel)
- `leanFile.sorries`: 0
- top-level `sorries`: 0
- Lean source `proofs/Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean`: **0 sorry / 0 axiom / 0 native_decide / 0 True-stub** (comment-stripped scan), 5 theorems, 0 defs, 136 lines.

## Classification (confirmed correct, unchanged)

`verified` / `original` is defensible: `chebyshev_integral_mul_le` proves the **continuous (integral) Chebyshev correlation inequality** for comonotone functions on a finite measure — a result absent from Mathlib (only the discrete `Finset` Chebyshev inequality exists). Mathlib supplies Fubini / product-integral infrastructure as building blocks, not a single-wrapper delegation, so `original` (not `mathlib`) is appropriate.

## Fix

Add `"sorries": 0` to the `meta` object (next to `axiomCount`). After the change, `find-targets --issues` reports 0 targets.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)