### PR TITLE
Enrich Hall's Theorem for Balanced Bipartite Graphs (one-sided condition)

### DIFF
--- a/src/data/proofs/halls-theorem-oq-02/index.ts
+++ b/src/data/proofs/halls-theorem-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HallsTheoremOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hallsTheoremOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hallsTheoremOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hallsTheoremOQ02Data: ProofData = {
+  proof: hallsTheoremOQ02Proof,
+  annotations: hallsTheoremOQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-02`. The entry already had a strong structured overview, but lacked annotations and its `sections` did not conform to the `ProofSection` schema.

## Changes
- **Created `annotations.json`** — 5 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the balanced one-sided statement, the imported `hall_marriage` matching + partner map, the injection of p₁ into p₂ ∩ M.verts, the cardinality upgrade to a bijection (the crux), and the perfect-matching corollary.
- **Fixed the `sections`** to conform to `ProofSection` (`startLine`/`endLine`/`summary`) — the prior entries used a non-standard `text` field with no line ranges — and added a setup section.
- **Added top-level `crossReferences`** to the parent `halls-theorem-oq-01` (the renderer consumes `crossReferences`, not the `meta.relatedProblems` that was present).
- **Created `index.ts`** for consistency with sibling entries.

`pnpm build` passes (exit 0); the entry regenerates under `public/data/proofs/`.