### PR TITLE
research(cayleys-theorem-oq-01-oq-01-oq-02): Cayley image is a regular (sharply transitive) subgroup of Sₙ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -623,6 +623,7 @@ import Proofs.CayleyHamiltonReductionOQ02OQ01Aristotle
 import Proofs.CayleyMengerHeronOQ05
 import Proofs.CayleysTheoremOQ01
 import Proofs.CayleysTheoremOQ01OQ01
+import Proofs.CayleysTheoremOQ01OQ01OQ02
 import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01

--- a/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,163 @@
+/-
+Proof: The image of the finite Cayley embedding is a regular (sharply
+transitive) subgroup of Sₙ.
+Research: cayleys-theorem-oq-01-oq-01-oq-02
+
+Open question (from `cayleys-theorem-oq-01-oq-01`):
+  Show the image of `cayleyFinHom` is a *regular* (sharply transitive)
+  subgroup of `Sₙ` — a subgroup of order `n` acting freely and transitively
+  on the `n` points.
+
+The parent entry builds, for a relabelling `e : G ≃ Fin n`, the finite Cayley
+homomorphism `cayleyFinHom e : G →* Equiv.Perm (Fin n)` with
+`cayleyFinHom e g i = e (g * e.symm i)`, and proves it injective.  Here we study
+its *image* `H := (cayleyFinHom e).range` as a permutation group acting on the
+`n` points `Fin n`, and prove the three classical facts characterising a regular
+permutation group:
+
+* **Transitive.** For all `i j`, some `σ ∈ H` maps `i ↦ j`
+  (take `g = e.symm j * (e.symm i)⁻¹`).
+* **Free / semiregular.** Any `σ ∈ H` fixing even a single point is the
+  identity (the point stabilisers are trivial).
+* **Sharply transitive (simply transitive).** Combining the two: for all `i j`
+  there is a *unique* `σ ∈ H` with `σ i = j`.
+
+We also record that `H` has order `n` and package transitivity as a
+`MulAction.IsPretransitive` instance for the natural action of `H` on `Fin n`.
+A finite permutation group that is both transitive and free is exactly a regular
+representation, so these results identify `H` as the regular permutation group
+of degree `n` — the concrete content of "Cayley's theorem realises `G` as a
+regular subgroup of `Sₙ`".
+-/
+
+import Mathlib.GroupTheory.Perm.Basic
+import Mathlib.Algebra.Group.Action.Basic
+import Mathlib.Algebra.Group.Action.End
+import Mathlib.GroupTheory.GroupAction.Defs
+import Mathlib.GroupTheory.GroupAction.Basic
+import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Data.Fintype.Perm
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic
+import Proofs.CayleysTheoremOQ01OQ01
+
+namespace CayleyFinRegular
+
+open Equiv CayleyFin
+
+variable {G : Type*} [Group G] {n : ℕ} (e : G ≃ Fin n)
+
+/-- The regular permutation group: the image of the finite Cayley homomorphism,
+viewed as a subgroup of `Sₙ = Equiv.Perm (Fin n)`. -/
+abbrev regSubgroup : Subgroup (Equiv.Perm (Fin n)) := (cayleyFinHom e).range
+
+/-- Membership in the regular subgroup is witnessed by a group element. -/
+theorem mem_regSubgroup {σ : Equiv.Perm (Fin n)} :
+    σ ∈ regSubgroup e ↔ ∃ g : G, cayleyFinHom e g = σ :=
+  MonoidHom.mem_range
+
+/-- The Cayley permutation `cayleyFinHom e g` sends `i ↦ e (g * e.symm i)`.
+At the relabelled point `e x` it is simply left multiplication: `e x ↦ e (g*x)`. -/
+theorem cayleyFinHom_apply_relabel (g x : G) :
+    cayleyFinHom e g (e x) = e (g * x) := by
+  rw [cayleyFinHom_apply, Equiv.symm_apply_apply]
+
+/-! ### Transitivity -/
+
+/-- **Transitivity.** For any two points `i j : Fin n`, some element of the
+regular subgroup carries `i` to `j`.  The witness is the Cayley image of
+`g = e.symm j * (e.symm i)⁻¹`. -/
+theorem regSubgroup_transitive (i j : Fin n) :
+    ∃ σ ∈ regSubgroup e, σ i = j := by
+  refine ⟨cayleyFinHom e (e.symm j * (e.symm i)⁻¹), MonoidHom.mem_range.mpr ⟨_, rfl⟩, ?_⟩
+  rw [cayleyFinHom_apply, inv_mul_cancel_right, Equiv.apply_symm_apply]
+
+/-! ### Freeness (semiregularity) -/
+
+/-- **Freeness.** Any element of the regular subgroup that fixes even a single
+point of `Fin n` is the identity permutation.  Equivalently every point
+stabiliser is trivial, so the action is free (semiregular). -/
+theorem regSubgroup_free {σ : Equiv.Perm (Fin n)} (hσ : σ ∈ regSubgroup e)
+    {i : Fin n} (hfix : σ i = i) : σ = 1 := by
+  obtain ⟨g, rfl⟩ := MonoidHom.mem_range.mp hσ
+  -- `cayleyFinHom e g i = i` forces `g = 1`, hence the permutation is identity.
+  have hgx : g * e.symm i = e.symm i := by
+    apply e.injective
+    rw [Equiv.apply_symm_apply, ← cayleyFinHom_apply]
+    exact hfix
+  have hg : g = 1 := by
+    have := congrArg (· * (e.symm i)⁻¹) hgx
+    simpa [mul_inv_cancel_right] using this
+  rw [hg, map_one]
+
+/-- An element of the regular subgroup is determined by its value at any single
+point: two members agreeing at one point are equal. -/
+theorem regSubgroup_eq_of_apply_eq {σ τ : Equiv.Perm (Fin n)}
+    (hσ : σ ∈ regSubgroup e) (hτ : τ ∈ regSubgroup e) {i : Fin n}
+    (h : σ i = τ i) : σ = τ := by
+  have hmem : τ⁻¹ * σ ∈ regSubgroup e := mul_mem (inv_mem hτ) hσ
+  have hfix : (τ⁻¹ * σ) i = i := by
+    rw [Equiv.Perm.mul_apply, h, ← Equiv.Perm.mul_apply, inv_mul_cancel,
+      Equiv.Perm.one_apply]
+  -- `τ⁻¹ * σ = 1` gives `σ = τ`.
+  have hone : τ⁻¹ * σ = 1 := regSubgroup_free e hmem hfix
+  exact (inv_mul_eq_one.mp hone).symm
+
+/-! ### Sharp transitivity -/
+
+/-- **Sharp (simple) transitivity.** For any two points `i j : Fin n` there is a
+*unique* element of the regular subgroup carrying `i` to `j`.  This is the
+defining property of a regular permutation group. -/
+theorem regSubgroup_sharplyTransitive (i j : Fin n) :
+    ∃! σ : Equiv.Perm (Fin n), σ ∈ regSubgroup e ∧ σ i = j := by
+  obtain ⟨σ, hσmem, hσij⟩ := regSubgroup_transitive e i j
+  refine ⟨σ, ⟨hσmem, hσij⟩, ?_⟩
+  rintro τ ⟨hτmem, hτij⟩
+  exact regSubgroup_eq_of_apply_eq e hτmem hσmem (by rw [hτij, hσij])
+
+/-! ### Order of the regular subgroup -/
+
+/-- **Order.** The regular subgroup has exactly `n` elements: it is the
+isomorphic image of `G`, and `e : G ≃ Fin n` makes `G` an `n`-element group. -/
+theorem regSubgroup_card : Nat.card (regSubgroup e) = n := by
+  have h1 : Nat.card (regSubgroup e) = Nat.card G :=
+    Nat.card_congr (cayleyFinRangeEquiv e).toEquiv.symm
+  rw [h1, Nat.card_congr e, Nat.card_eq_fintype_card, Fintype.card_fin]
+
+/-! ### Action packaging -/
+
+/-- The natural action of the regular subgroup on the `n` points is transitive,
+recorded as a `MulAction.IsPretransitive` instance. -/
+instance regSubgroup_isPretransitive :
+    MulAction.IsPretransitive (regSubgroup e) (Fin n) := by
+  refine ⟨fun i j => ?_⟩
+  obtain ⟨σ, hσmem, hσij⟩ := regSubgroup_transitive e i j
+  exact ⟨⟨σ, hσmem⟩, hσij⟩
+
+/-- The action of the regular subgroup on `Fin n` is free: a group element
+fixing a point is the identity of the subgroup. -/
+theorem regSubgroup_smul_free (σ : regSubgroup e) (i : Fin n)
+    (h : σ • i = i) : σ = 1 := by
+  have h' : (σ : Equiv.Perm (Fin n)) i = i := h
+  have : (σ : Equiv.Perm (Fin n)) = 1 := regSubgroup_free e σ.2 h'
+  exact Subtype.ext this
+
+/-! ### Conclusion -/
+
+/-- **Cayley's theorem, regular form.** For a relabelling `e : G ≃ Fin n`, the
+image of the finite Cayley homomorphism is a subgroup of `Sₙ` of order `n` that
+acts freely and transitively on the `n` points — a regular (sharply transitive)
+permutation group of degree `n`. -/
+theorem cayley_regular_subgroup :
+    Nat.card (regSubgroup e) = n ∧
+    (∀ i j : Fin n, ∃! σ : Equiv.Perm (Fin n), σ ∈ regSubgroup e ∧ σ i = j) := by
+  exact ⟨regSubgroup_card e, regSubgroup_sharplyTransitive e⟩
+
+/-- Concrete instance: the left-regular image of the cyclic group of order `3`
+is a regular subgroup of `S₃` of order `3`. -/
+example :
+    Nat.card (regSubgroup (Fintype.equivFin (Multiplicative (ZMod 3)))) = 3 := by
+  rw [regSubgroup_card]
+  simp
+
+end CayleyFinRegular

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-01-oq-02",
+  "title": "Cayley's Image is a Regular (Sharply Transitive) Subgroup of Sₙ",
+  "slug": "cayleys-theorem-oq-01-oq-01-oq-02",
+  "description": "The image of the finite Cayley embedding cayleyFinHom e : G →* Equiv.Perm (Fin n) (from the parent cayleys-theorem-oq-01-oq-01) is a regular permutation group of degree n: a subgroup of Sₙ of order n that acts freely and transitively on the n points. Writing H := (cayleyFinHom e).range and recalling cayleyFinHom e g i = e (g * e.symm i), this entry proves the three classical facts characterising a regular (simply transitive) permutation group, answering the parent's second open question. (1) Transitivity: for any points i j : Fin n some σ ∈ H carries i ↦ j, with explicit witness the Cayley image of g = e.symm j * (e.symm i)⁻¹. (2) Freeness (semiregularity): any σ ∈ H fixing even a single point is the identity — equivalently every point stabiliser is trivial — because cayleyFinHom e g i = i forces g = 1. (3) Sharp transitivity: combining the two, for all i j there is a unique σ ∈ H with σ i = j (regSubgroup_sharplyTransitive), the defining property of a regular group. The order count Nat.card H = n follows from the parent's range isomorphism G ≃* H together with G ≃ Fin n. Transitivity is also packaged as a MulAction.IsPretransitive instance for the natural action of H on Fin n, and freeness is restated at the action level (a subgroup element fixing a point is 1).",
+  "meta": {
+    "author": "Arthur Cayley (1854); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Regular_representation",
+    "date": "1854",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "permutation-group",
+      "regular-representation",
+      "sharply-transitive",
+      "group-action",
+      "symmetric-group",
+      "transitive-action",
+      "free-action",
+      "finite-group",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MonoidHom.mem_range",
+        "description": "membership σ ∈ f.range ↔ ∃ g, f g = σ — used to extract the group element witnessing membership in the regular subgroup and to exhibit transitivity witnesses",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      },
+      {
+        "theorem": "MulAction.IsPretransitive",
+        "description": "the predicate that an action has a single orbit (∀ x y, ∃ g, g • x = y) — used to package transitivity of the regular subgroup acting on Fin n as a typeclass instance",
+        "module": "Mathlib.GroupTheory.GroupAction.Basic"
+      },
+      {
+        "theorem": "inv_mul_eq_one",
+        "description": "a⁻¹ * b = 1 ↔ a = b — converts the freeness conclusion τ⁻¹ * σ = 1 into the equality σ = τ underlying uniqueness in sharp transitivity",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "Nat.card_congr",
+        "description": "an equivalence of types preserves Nat.card — chains the parent's range isomorphism G ≃* H and the numbering G ≃ Fin n to compute the order |H| = n",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ],
+    "originalContributions": [
+      "regSubgroup_transitive: the image H = (cayleyFinHom e).range acts transitively on Fin n — for all i j some σ ∈ H sends i ↦ j, via the explicit witness g = e.symm j * (e.symm i)⁻¹",
+      "regSubgroup_free: H acts freely (semiregularly) — any σ ∈ H fixing a single point of Fin n is the identity, so every point stabiliser is trivial",
+      "regSubgroup_eq_of_apply_eq: an element of H is determined by its value at one point (two members agreeing anywhere are equal) — the rigidity behind uniqueness",
+      "regSubgroup_sharplyTransitive: H is sharply (simply) transitive — for all i j a unique σ ∈ H satisfies σ i = j, the defining property of a regular permutation group",
+      "regSubgroup_card: |H| = n, the order of the regular subgroup, from the parent's G ≃* H and the numbering G ≃ Fin n",
+      "regSubgroup_isPretransitive: transitivity packaged as a MulAction.IsPretransitive (cayleyFinHom e).range (Fin n) instance for the natural subgroup action",
+      "cayley_regular_subgroup: the combined statement — |H| = n and H is sharply transitive — identifying H as the regular permutation group of degree n"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 163,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem realises an abstract group of order n as a subgroup of the symmetric group Sₙ. The image is not an arbitrary subgroup: it is the left-regular representation, the prototype of a regular (or simply transitive) permutation group. A permutation group acting on a set is regular when it is both transitive (one orbit) and free (only the identity has a fixed point); equivalently it acts sharply transitively, with exactly one element carrying any chosen point to any other. Regular permutation groups are precisely the images of the left-regular representation, so order n ⟹ degree n with the action looking like the group acting on itself by left multiplication. This regularity is what makes Cayley's embedding canonical, and underlies the classification of transitive actions as coset actions (the regular action being the case of the trivial stabiliser).",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01-oq-01, second follow-up)**: Show the image of cayleyFinHom is a regular (sharply transitive) subgroup of Sₙ — a subgroup of order n acting freely and transitively on the n points.\n\n**Result**: regSubgroup_transitive (transitive), regSubgroup_free (free/semiregular), regSubgroup_sharplyTransitive (a unique element maps i ↦ j), regSubgroup_card (|H| = n), and the packaged MulAction.IsPretransitive instance — assembled in cayley_regular_subgroup.",
+    "text": "Let e : G ≃ Fin n number the elements of a finite group G, and let H = (cayleyFinHom e).range ≤ Sₙ be the image of the finite Cayley embedding, where cayleyFinHom e g i = e (g · e⁻¹ i). Then H has order n and acts on the n points Fin n freely and transitively: for any two points there is exactly one element of H carrying one to the other. Thus H is the regular permutation group of degree n.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Transitivity. Given points i, j, set g = e.symm j * (e.symm i)⁻¹. Then cayleyFinHom e g i = e (g * e.symm i) = e (e.symm j * (e.symm i)⁻¹ * e.symm i) = e (e.symm j) = j (using inv_mul_cancel_right and Equiv.apply_symm_apply). So the Cayley image of g lies in H and maps i ↦ j.\n2. Freeness. Suppose σ = cayleyFinHom e g ∈ H fixes a point i, i.e. e (g * e.symm i) = i. Applying e.symm gives g * e.symm i = e.symm i, hence g = 1 (cancel e.symm i on the right), so σ = cayleyFinHom e 1 = 1. Every point stabiliser is therefore trivial.\n3. Rigidity and sharp transitivity. If σ, τ ∈ H agree at one point i then τ⁻¹ * σ ∈ H fixes i, so by freeness τ⁻¹ * σ = 1 and σ = τ (inv_mul_eq_one). Combined with transitivity, for each i, j there is a unique σ ∈ H with σ i = j — sharp (simple) transitivity.\n4. Order. The parent supplies the isomorphism cayleyFinRangeEquiv : G ≃* H; with the numbering e : G ≃ Fin n, Nat.card_congr gives |H| = |G| = |Fin n| = n.\n5. Packaging. Transitivity is recorded as a MulAction.IsPretransitive (cayleyFinHom e).range (Fin n) instance, and freeness is restated for the subgroup action (σ • i = i ⟹ σ = 1). cayley_regular_subgroup bundles |H| = n with sharp transitivity.",
+    "keyInsights": [
+      "**Regular = transitive + free.** The two halves are independent and elementary here: transitivity is solved by an explicit group element (a 'translation' e.symm j * (e.symm i)⁻¹), while freeness reduces to the cancellativity of the group (a left-multiplication fixing a point must be the identity).",
+      "**Freeness is rigidity.** Because only the identity fixes a point, an element of the regular subgroup is pinned down by its value at a single point. This single fact yields uniqueness in sharp transitivity directly, with no orbit-counting.",
+      "**Order n from the parent's isomorphism.** No new cardinality argument is needed: the regular subgroup is isomorphic to G (parent's cayleyFinRangeEquiv) and G is numbered by Fin n, so |H| = n is a transport of cardinality.",
+      "**Sharp transitivity is the structural payoff.** 'Unique element mapping i ↦ j' is exactly the defining property of a regular permutation group and the reason the regular action is the universal free transitive action — every transitive action is a quotient of it."
+    ],
+    "prerequisites": [
+      "The finite Cayley embedding cayleyFinHom e : G →* Equiv.Perm (Fin n) and its range isomorphism cayleyFinRangeEquiv : G ≃* range (parent entry cayleys-theorem-oq-01-oq-01)",
+      "Group actions of permutation groups and subgroups: MulAction (Equiv.Perm (Fin n)) (Fin n), the restricted subgroup action, and MulAction.IsPretransitive",
+      "Elementary group cancellation (inv_mul_cancel_right, mul_inv_cancel_right, inv_mul_eq_one) and Nat.card transport along equivalences"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Module docstring stating the regular-subgroup result and the transitive + free = regular strategy, imports (including the parent module Proofs.CayleysTheoremOQ01OQ01 and Cardinal.Finite for Nat.card), and the namespace with the group variable G and numbering e : G ≃ Fin n.",
+      "mathContext": "$H = \\mathrm{im}(\\hat\\lambda) \\le S_n$ acting on the $n$ points $\\mathrm{Fin}\\,n$."
+    },
+    {
+      "id": "membership",
+      "title": "The Regular Subgroup and its Action Formula",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "regSubgroup e := (cayleyFinHom e).range as an abbreviation, the membership characterisation mem_regSubgroup (σ ∈ H ↔ ∃ g, cayleyFinHom e g = σ), and cayleyFinHom_apply_relabel (cayleyFinHom e g (e x) = e (g * x)) showing the action is left multiplication after relabelling.",
+      "mathContext": "$\\hat\\lambda(g)(e\\,x) = e(g\\,x)$ — left translation transported along $e$."
+    },
+    {
+      "id": "transitive",
+      "title": "Transitivity",
+      "startLine": 69,
+      "endLine": 78,
+      "summary": "regSubgroup_transitive: for any i j some σ ∈ H carries i ↦ j, with explicit witness the Cayley image of g = e.symm j * (e.symm i)⁻¹, closed by inv_mul_cancel_right and Equiv.apply_symm_apply.",
+      "mathContext": "$\\forall i\\,j,\\ \\exists \\sigma \\in H,\\ \\sigma(i) = j$ — single orbit."
+    },
+    {
+      "id": "free",
+      "title": "Freeness and Rigidity",
+      "startLine": 79,
+      "endLine": 108,
+      "summary": "regSubgroup_free: an element of H fixing a single point is the identity (cayleyFinHom e g i = i forces g = 1); regSubgroup_eq_of_apply_eq: members of H agreeing at one point are equal (τ⁻¹ * σ fixes the point, hence equals 1 by freeness).",
+      "mathContext": "$\\sigma(i)=i \\Rightarrow \\sigma = \\mathrm{id}$ — trivial point stabilisers."
+    },
+    {
+      "id": "sharp-and-order",
+      "title": "Sharp Transitivity and Order",
+      "startLine": 109,
+      "endLine": 129,
+      "summary": "regSubgroup_sharplyTransitive: for all i j a unique σ ∈ H satisfies σ i = j (existence from transitivity, uniqueness from rigidity); regSubgroup_card: |H| = n via the parent's range isomorphism G ≃* H and the numbering G ≃ Fin n.",
+      "mathContext": "$\\forall i\\,j,\\ \\exists! \\sigma \\in H,\\ \\sigma(i)=j$ and $|H| = n$."
+    },
+    {
+      "id": "action-packaging",
+      "title": "Action Packaging and Conclusion",
+      "startLine": 130,
+      "endLine": 163,
+      "summary": "regSubgroup_isPretransitive: the MulAction.IsPretransitive (cayleyFinHom e).range (Fin n) instance; regSubgroup_smul_free: freeness restated at the action level (σ • i = i ⟹ σ = 1); cayley_regular_subgroup: |H| = n with sharp transitivity bundled; plus a concrete S₃ example (order-3 regular subgroup).",
+      "mathContext": "$H$ is the regular permutation group of degree $n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: builds the finite Cayley embedding cayleyFinHom e : G →* Equiv.Perm (Fin n) and the range isomorphism cayleyFinRangeEquiv : G ≃* range. This entry studies that range as a permutation group and proves it is regular (sharply transitive) of order n, answering the parent's second open question."
+    },
+    {
+      "targetId": "cayleys-theorem-oq-01",
+      "relationship": "builds-on",
+      "description": "Grandparent entry: the abstract left-regular representation G ↪ Sym(G). The regularity proved here is the concrete-degree-n manifestation of the regular representation acting freely and transitively on G."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof that the image H of the finite Cayley embedding is a regular permutation group of degree n: H ≤ Sₙ has order n (regSubgroup_card) and acts freely (regSubgroup_free) and transitively (regSubgroup_transitive, packaged as MulAction.IsPretransitive) on the n points, equivalently sharply transitively — a unique element maps any point to any other (regSubgroup_sharplyTransitive). The combined statement is cayley_regular_subgroup.",
+    "implications": "Identifies the codomain of Cayley's theorem precisely: not just 'a subgroup of Sₙ' but the regular subgroup, the prototype of all transitive actions. Freeness reduces to group cancellation and transitivity to an explicit translation, while the order count is transported from the parent's range isomorphism — so the regularity is obtained with no orbit–stabiliser counting.",
+    "openQuestions": [
+      "Characterise abstractly: a subgroup of Sₙ that acts freely and transitively on n points has order n and is isomorphic to the abstract group whose regular representation it is (a converse to Cayley realising every regular subgroup as a left-regular image).",
+      "Relate the regular subgroup to its centraliser in Sₙ: the centraliser of the left-regular image is the right-regular image, and the two coincide iff G is abelian — formalize this normaliser/centraliser structure."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Perm.Basic",
+      "Mathlib.Algebra.Group.Action.Basic",
+      "Mathlib.Algebra.Group.Action.End",
+      "Mathlib.GroupTheory.GroupAction.Defs",
+      "Mathlib.GroupTheory.GroupAction.Basic",
+      "Mathlib.Logic.Equiv.Fin.Basic",
+      "Mathlib.Data.Fintype.Perm",
+      "Mathlib.SetTheory.Cardinal.Finite",
+      "Mathlib.Tactic",
+      "Proofs.CayleysTheoremOQ01OQ01"
+    ],
+    "opens": [
+      "Equiv",
+      "CayleyFin"
+    ],
+    "namespace": "CayleyFinRegular",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/CayleysTheoremOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement that every group is a group of permutations — the regular representation"
+    },
+    {
+      "authors": "Dixon, John D.; Mortimer, Brian",
+      "title": "Permutation Groups",
+      "year": "1996",
+      "venue": "Springer GTM 163",
+      "note": "Regular permutation groups, sharp/simple transitivity, and the structure of transitive actions"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the second open question of **cayleys-theorem-oq-01-oq-01**: the image `H = (cayleyFinHom e).range` of the finite Cayley embedding `cayleyFinHom e : G →* Equiv.Perm (Fin n)` is a **regular (sharply transitive) subgroup of Sₙ** — a subgroup of order `n` acting freely and transitively on the `n` points.

Recall `cayleyFinHom e g i = e (g * e.symm i)` (left translation transported along the numbering `e : G ≃ Fin n`).

## Results (163 lines, 10 theorems, 0 sorries, 0 axioms)

- **`regSubgroup_transitive`** — for all `i j`, some `σ ∈ H` sends `i ↦ j`; explicit witness the Cayley image of `g = e.symm j * (e.symm i)⁻¹`.
- **`regSubgroup_free`** — any `σ ∈ H` fixing a single point is the identity (point stabilisers are trivial), since `cayleyFinHom e g i = i` forces `g = 1`.
- **`regSubgroup_eq_of_apply_eq`** — a member of `H` is determined by its value at one point (rigidity).
- **`regSubgroup_sharplyTransitive`** — for all `i j` a **unique** `σ ∈ H` satisfies `σ i = j`, the defining property of a regular permutation group.
- **`regSubgroup_card`** — `|H| = n`, transported from the parent's `G ≃* H` and `G ≃ Fin n`.
- **`regSubgroup_isPretransitive`** — transitivity packaged as a `MulAction.IsPretransitive` instance for the natural subgroup action on `Fin n`.
- **`cayley_regular_subgroup`** — bundles `|H| = n` with sharp transitivity.

## Verification

- Builds against Mathlib (lean4 v4.26.0) importing the parent `Proofs.CayleysTheoremOQ01OQ01`.
- `#print axioms`: only `propext`, `Classical.choice`, `Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`). **0-axiom verified.**
- No `decide`/`native_decide`.

## Files
- `proofs/Proofs/CayleysTheoremOQ01OQ01OQ02.lean` (new)
- `src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02/meta.json` (new gallery entry)
- `proofs/Proofs.lean` (aggregator import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)