### PR TITLE
Enrich Axiom-Free Isoperimetric Inequality for Regular Closed Curves (Hurwitz Capstone)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 77 },
+    "type": "context",
+    "title": "Assembling the Three Discharged Companions",
+    "content": "The capstone imports the three companion files that individually eliminated the parent's analytic axioms, each 0-axiom: …Fourier (the Fourier decomposition, Wirtinger inequality, and wirtinger_sum_bound), …CauchySchwarz (integral_cauchy_schwarz_sq and area_cauchy_schwarz_bound_contDiff), and …IFT (exists_nice_reparam_for_regular, the inverse-function-theorem arc-length reparametrization on the RegularClosedCurve structure). This file contributes no new analysis — its job is to wire these proven theorems together into one end-to-end axiom-free result.",
+    "mathContext": "Hurwitz's program: Fourier $\\Rightarrow$ Wirtinger $\\Rightarrow$ Cauchy–Schwarz $\\Rightarrow$ IFT reparametrization $\\Rightarrow$ algebraic kernel.",
+    "significance": "context",
+    "relatedConcepts": ["isoperimetric inequality", "Hurwitz proof", "axiom discharge", "regular curve", "companion files"],
+    "prerequisites": ["Fourier analysis", "inverse function theorem", "Cauchy-Schwarz"]
+  },
+  {
+    "id": "ann-kernel",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 110 },
+    "type": "technique",
+    "title": "The Purely-Algebraic Kernel",
+    "content": "`isoperimetric_arithmetic_kernel` is the final algebraic step of Hurwitz's proof, stripped of all analysis. Given the assembled bounds 2A ≤ cS, S² ≤ 2π·Sxy, Sxy ≤ 2πc², and the speed identity L = 2πc, it chains them to 4πA ≤ L². The key move: S² ≤ 2π·Sxy ≤ 2π·(2πc²) = (2πc)², and since both sides are nonnegative, Real.sqrt_sq gives S ≤ 2πc; then 2A ≤ cS ≤ 2πc² and a final calc/nlinarith yields 4πA ≤ (2πc)² = L². It is re-proved locally (rather than imported from the parent) so the capstone builds even though the parent file has bit-rotted on the Mathlib v4.26.0 pin.",
+    "mathContext": "$2A \\le cS,\\ S^2 \\le 2\\pi S_{xy},\\ S_{xy} \\le 2\\pi c^2,\\ L = 2\\pi c \\;\\Rightarrow\\; 4\\pi A \\le L^2$.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic kernel", "Real.sqrt_sq", "nlinarith", "ordered field inequalities", "self-containment"],
+    "prerequisites": ["ordered fields", "square roots", "inequality chaining"]
+  },
+  {
+    "id": "ann-reparam",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 141 },
+    "type": "technique",
+    "title": "Constant-Speed Zero-Mean Reparametrization (the IFT Step)",
+    "content": "The proof of isoperimetric_inequality_regular opens by applying `RegularClosedCurve.exists_nice_reparam_for_regular` to obtain a regular curve ρ with the SAME circumference and area as γ, but constant speed c = L/(2π) and zero mean in each coordinate. This is the step that genuinely requires regularity: the arc-length map is strictly monotone only when the speed never vanishes, so the inverse function theorem yields a C¹ inverse exactly on regular curves — the axiom is false at stationary points. With ρ in hand, the integrals S = ∫√(ρ.x²+ρ.y²) and Sxy = ∫(ρ.x²+ρ.y²) are named, and S ≥ 0 follows from integral_nonneg.",
+    "mathContext": "$\\rho$ regular, constant speed $c = L/2\\pi$, zero mean, $\\rho.\\text{circumference} = \\gamma.\\text{circumference}$, $\\rho.\\text{area} = \\gamma.\\text{area}$.",
+    "significance": "key",
+    "relatedConcepts": ["arc-length reparametrization", "inverse function theorem", "regular curve", "constant speed", "zero mean"],
+    "prerequisites": ["inverse function theorem", "arc length", "change of variables"]
+  },
+  {
+    "id": "ann-analytic-bounds",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 142, "endLine": 159 },
+    "type": "insight",
+    "title": "The Three Analytic Bounds, Each from a 0-Axiom Companion",
+    "content": "On the reparametrized ρ, the three analytic ingredients are invoked, each a proven companion theorem: (1) `wirtinger_sum_bound` gives Sxy ≤ 2πc² (Wirtinger applied to each zero-mean coordinate, using the constant-speed hypothesis); (2) `integral_cauchy_schwarz_sq` gives the L² Cauchy–Schwarz S² ≤ 2π·Sxy; (3) `area_cauchy_schwarz_bound_contDiff` gives the pointwise 2-D Cauchy–Schwarz |∫(ρ.x·ρ.y' − ρ.y·ρ.x')| ≤ c·S. The crucial bridge h2area unfolds the Green's-theorem signed-area definition to show 2·ρ.area equals exactly that absolute value, converting the area bound into 2·ρ.area ≤ c·S — the form the kernel consumes.",
+    "mathContext": "$S_{xy} \\le 2\\pi c^2$ (Wirtinger); $S^2 \\le 2\\pi S_{xy}$ (L² CS); $2\\rho.\\text{area} = |\\!\\int(\\rho.x\\,\\rho.y' - \\rho.y\\,\\rho.x')| \\le cS$ (area CS).",
+    "significance": "key",
+    "relatedConcepts": ["Wirtinger's inequality", "Cauchy-Schwarz", "Green's theorem", "signed area", "Parseval"],
+    "prerequisites": ["Wirtinger inequality", "Cauchy-Schwarz", "Green's theorem"]
+  },
+  {
+    "id": "ann-transport",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+    "range": { "startLine": 160, "endLine": 165 },
+    "type": "concept",
+    "title": "Transporting the Bound Back to γ",
+    "content": "The final lines rewrite the goal 4π·γ.area ≤ γ.circumference² along the reparametrization's preservation equalities (← hρarea, ← hρcirc) so it becomes a statement about ρ, then discharge it with `isoperimetric_arithmetic_kernel` fed the five assembled facts. Because ρ shares γ's circumference and area exactly, the inequality proved for ρ is literally the inequality for γ. The result is 4πA ≤ L² for every regular closed curve with positive circumference, with #print axioms reporting only propext / Classical.choice / Quot.sound — the maximal honest 0-axiom endpoint of the Hurwitz program.",
+    "mathContext": "$\\rho.\\text{circumference} = \\gamma.\\text{circumference},\\ \\rho.\\text{area} = \\gamma.\\text{area} \\Rightarrow 4\\pi\\gamma.\\text{area} \\le \\gamma.\\text{circumference}^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["invariance under reparametrization", "axiom-free", "isoperimetric inequality", "regular locus"],
+    "prerequisites": ["reparametrization invariance", "goal rewriting"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02Data: ProofData = {
+  proof: areaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02Proof,
+  annotations: areaOfCircleOQ01OQ02OQ02OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -78,14 +78,32 @@
   },
   "sections": [
     {
+      "id": "setup",
+      "title": "Imports and the Discharged Companions",
+      "startLine": 67,
+      "endLine": 77,
+      "summary": "Opens the IsoperimetricCapstone namespace and imports the three 0-axiom companion files that discharged the parent's analytic axioms: the Fourier/Wirtinger bound (…Fourier), both Cauchy–Schwarz bounds (…CauchySchwarz), and the inverse-function-theorem arc-length reparametrization for regular curves (…IFT). This file's role is purely to assemble them."
+    },
+    {
       "id": "part-i",
-      "title": "The algebraic kernel",
-      "text": "`isoperimetric_arithmetic_kernel` reproves the parent's purely-algebraic step: from 2A ≤ cS, S² ≤ 2π·Sxy, Sxy ≤ 2πc², and L = 2πc it deduces 4πA ≤ L². No integrals or measures appear. It is re-proved here so the capstone is self-contained and independent of the bit-rotted parent file."
+      "title": "The Algebraic Kernel",
+      "startLine": 78,
+      "endLine": 110,
+      "summary": "isoperimetric_arithmetic_kernel reproves the parent's purely-algebraic step: from 2A ≤ cS, S² ≤ 2π·Sxy, Sxy ≤ 2πc², and L = 2πc it deduces 4πA ≤ L² (via S² ≤ (2πc)² ⟹ S ≤ 2πc by Real.sqrt_sq, then chaining with nlinarith). No integrals or measures appear; re-proved here so the capstone is self-contained and independent of the bit-rotted parent file."
     },
     {
       "id": "part-ii",
-      "title": "Assembling the axiom-free isoperimetric inequality",
-      "text": "`isoperimetric_inequality_regular` is the capstone. It applies exists_nice_reparam_for_regular (IFT, 0-axiom) to get a constant-speed zero-mean reparametrization ρ of γ, then invokes the Wirtinger sum bound and both Cauchy–Schwarz bounds (each 0-axiom) on ρ, bridges 2·ρ.area = |∫(ρ.x·ρ.y' − ρ.y·ρ.x')|, and feeds everything to the kernel. The circumference/area preservation of ρ transports the bound back to γ, giving 4πA ≤ L² with #print axioms reporting only the foundational propext / Classical.choice / Quot.sound."
+      "title": "Assembling the Axiom-Free Isoperimetric Inequality",
+      "startLine": 112,
+      "endLine": 165,
+      "summary": "isoperimetric_inequality_regular is the capstone. It applies exists_nice_reparam_for_regular (IFT, 0-axiom) to get a constant-speed (c = L/2π) zero-mean reparametrization ρ of γ, names S = ∫√(x²+y²) and Sxy = ∫(x²+y²), invokes the Wirtinger sum bound (Sxy ≤ 2πc²) and both Cauchy–Schwarz bounds (S² ≤ 2π·Sxy and |∫(x·y'−y·x')| ≤ c·S) on ρ, bridges 2·ρ.area = |∫(ρ.x·ρ.y' − ρ.y·ρ.x')|, and feeds everything to the kernel. ρ's circumference/area preservation transports the bound back to γ — 4πA ≤ L² with #print axioms reporting only propext / Classical.choice / Quot.sound."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent isoperimetric entry, which proved 4πA ≤ L² for smooth closed curves from five disclosed analytic axioms (Fourier decomposition, constant-speed reparametrization, the Wirtinger sum bound, and two Cauchy–Schwarz bounds). This capstone replaces every one of those axioms with its independently-discharged 0-axiom companion and assembles them into a fully axiom-free proof on the regular locus — the maximal honest endpoint, since the reparametrization axiom is genuinely false at stationary points."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02`. The entry had a strong structured overview but lacked annotations and its `sections` did not conform to the `ProofSection` schema.

## Changes
- **Created `annotations.json`** — 5 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the imported 0-axiom companions, the purely-algebraic kernel, the inverse-function-theorem reparametrization (the step that genuinely needs regularity), the three analytic bounds (Wirtinger + two Cauchy–Schwarz), and the transport back to γ.
- **Fixed the `sections`** to conform to `ProofSection` (`startLine`/`endLine`/`summary`; the prior sections used a non-standard `text` field with no line ranges) and added a setup section.
- **Added top-level `crossReferences`** to the parent `area-of-circle-oq-01-oq-02-oq-02-oq-01`.
- **Created `index.ts`** for consistency with sibling entries.

`pnpm build` passes (exit 0); the entry regenerates under `public/data/proofs/`.