### PR TITLE
Enrich Hall's Theorem for Balanced Bipartite Graphs: the One-Sided Condition Suffices

### DIFF
--- a/src/data/proofs/halls-theorem-oq-02/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-02/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-both-sides",
+    "proofId": "halls-theorem-oq-02",
+    "range": { "startLine": 44, "endLine": 89 },
+    "type": "theorem",
+    "title": "One-Sided Hall Saturates Both Sides (Balanced Case)",
+    "content": "`isMatching_saturating_both_of_balanced`: in a locally finite bipartite graph with balanced parts (p₁.ncard = p₂.ncard, p₂ finite), the ONE-SIDED Hall condition on p₁ yields a matching M with both p₁ ⊆ M.verts and p₂ ⊆ M.verts. The proof starts from a p₁-saturating matching given by the parent's hall_marriage, then defines the matched-partner map φ v = the unique M-neighbour of v and shows: (a) φ v ∈ p₂ — M.Adj v (φ v) ⟹ G.Adj v (φ v), and bipartiteness sends neighbours of p₁ into p₂ (IsBipartiteWith.mem_of_mem_adj); (b) φ v ∈ M.verts — a partner is a matched endpoint (Subgraph.Adj.snd_mem); (c) φ is injective on p₁ — equal partners force equal vertices in a matching (IsMatching.eq_of_adj_right). Hence φ '' p₁ ⊆ p₂ with (φ '' p₁).ncard = p₁.ncard = p₂.ncard, and since p₂ is finite Set.eq_of_subset_of_ncard_le gives φ '' p₁ = p₂, so p₂ ⊆ M.verts. Neither Mathlib nor the parent has this one-sided form.",
+    "mathContext": "$|p_1|=|p_2|$, $p_2$ finite, Hall on $p_1$ $\\Rightarrow\\exists M$ with $p_1,p_2\\subseteq M.\\mathrm{verts}$; the partner map $\\varphi$ injects $p_1\\hookrightarrow p_2$, and $|\\varphi(p_1)|=|p_2|$ forces $\\varphi(p_1)=p_2$.",
+    "significance": "critical",
+    "relatedConcepts": ["Hall's marriage theorem", "matched-partner map", "injection-to-bijection", "Set.ncard", "bipartite saturation"],
+    "prerequisites": ["bipartite matchings", "Hall's condition", "set cardinality"]
+  },
+  {
+    "id": "ann-perfect-matching",
+    "proofId": "halls-theorem-oq-02",
+    "range": { "startLine": 90, "endLine": 110 },
+    "type": "theorem",
+    "title": "The Balanced Perfect-Matching Criterion",
+    "content": "`exists_isPerfectMatching_of_balanced`: the practical bipartite perfect-matching criterion. Balanced parts (p₁.ncard = p₂.ncard, p₂ finite) that cover the vertex set (p₁ ∪ p₂ = univ) together with the one-sided Hall condition on p₁ give a genuine SimpleGraph perfect matching. It follows immediately from the both-sides-saturating matching: p₁ ⊆ M.verts and p₂ ⊆ M.verts give M.verts ⊇ p₁ ∪ p₂ = univ, so M is spanning (Subgraph.isSpanning_iff) and therefore a perfect matching. This replaces Mathlib's GLOBAL Hall condition (quantified over every s : Set V, which silently bundles balance and covering) with the explicit, checkable balance + covering + one-sided-Hall hypotheses.",
+    "mathContext": "balance $+$ $p_1\\cup p_2=V$ $+$ one-sided Hall $\\Rightarrow$ $M.\\mathrm{verts}=V$, a perfect matching; the global Hall condition is unbundled into its real components.",
+    "significance": "key",
+    "relatedConcepts": ["perfect matching", "spanning subgraph", "Subgraph.isSpanning_iff", "global vs one-sided condition"],
+    "prerequisites": ["perfect matchings", "spanning subgraphs", "bipartite covering"]
+  }
+]

--- a/src/data/proofs/halls-theorem-oq-02/meta.json
+++ b/src/data/proofs/halls-theorem-oq-02/meta.json
@@ -80,13 +80,27 @@
   "sections": [
     {
       "id": "part-i",
-      "title": "Balanced one-sided Hall saturates both sides",
-      "text": "`isMatching_saturating_both_of_balanced`: from hall_marriage's p₁-saturating matching, the matched-partner map φ injects p₁ into p₂ and into M.verts; balance (p₁.ncard = p₂.ncard) with p₂ finite upgrades the injection to φ '' p₁ = p₂ (Set.eq_of_subset_of_ncard_le), so p₂ ⊆ M.verts. The matching saturates both sides."
+      "title": "Part I: Balanced One-Sided Hall Saturates Both Sides",
+      "startLine": 40,
+      "endLine": 89,
+      "summary": "isMatching_saturating_both_of_balanced: from hall_marriage's p₁-saturating matching, the matched-partner map φ injects p₁ into p₂ (bipartiteness) and into M.verts (partners are matched endpoints); injectivity comes from IsMatching.eq_of_adj_right. Balance (p₁.ncard = p₂.ncard) with p₂ finite upgrades the injection to φ '' p₁ = p₂ (Set.eq_of_subset_of_ncard_le), so p₂ ⊆ M.verts and the matching saturates both sides.",
+      "mathContext": "$\\varphi:p_1\\hookrightarrow p_2$ with $|\\varphi(p_1)|=|p_1|=|p_2|$ and $p_2$ finite $\\Rightarrow\\varphi(p_1)=p_2$, so $p_2\\subseteq M.\\mathrm{verts}$."
     },
     {
       "id": "part-ii",
-      "title": "The balanced perfect-matching criterion",
-      "text": "`exists_isPerfectMatching_of_balanced`: adding p₁ ∪ p₂ = univ to the balanced one-sided hypotheses makes the both-sides-saturating matching spanning (Subgraph.isSpanning_iff), hence a perfect matching — the practical bipartite criterion in its natural one-sided form."
+      "title": "Part II: The Balanced Perfect-Matching Criterion",
+      "startLine": 90,
+      "endLine": 110,
+      "summary": "exists_isPerfectMatching_of_balanced: adding p₁ ∪ p₂ = univ to the balanced one-sided hypotheses makes the both-sides-saturating matching spanning (its vertex set ⊇ p₁ ∪ p₂ = univ, via Subgraph.isSpanning_iff), hence a SimpleGraph perfect matching — the practical bipartite criterion in its natural one-sided form, with the global Hall condition replaced by balance + covering + one-sided Hall.",
+      "mathContext": "$p_1\\subseteq M.\\mathrm{verts}\\wedge p_2\\subseteq M.\\mathrm{verts}\\wedge p_1\\cup p_2=V\\Rightarrow M.\\mathrm{verts}=V$, i.e. $M$ is a perfect matching."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "An axiom-free strengthening of Hall's marriage theorem for the balanced bipartite case: in a locally finite bipartite graph with balanced parts (p₁.ncard = p₂.ncard, p₂ finite), the ONE-SIDED Hall condition on p₁ already produces a matching saturating BOTH sides (isMatching_saturating_both_of_balanced), and — when the parts cover the vertex set — a genuine perfect matching (exists_isPerfectMatching_of_balanced). The argument layers a clean counting step on top of the parent's hall_marriage: the matched-partner map injects p₁ into p₂, and balance plus finiteness upgrade the injection to a bijection. 110 lines, 2 theorems, 0 axioms, 0 sorries (#print axioms reports only propext / Classical.choice / Quot.sound).",
+    "implications": "Mathlib's perfect-matching theorem and the parent's hall_perfect both require the GLOBAL Hall condition quantified over every set s : Set V, which silently bundles balance and covering. This entry isolates the textbook balanced criterion — check Hall on one side, get both — which is what one actually verifies in practice. No new hard combinatorics is introduced: the strengthening rides entirely on the parent's necessity direction plus elementary ncard bookkeeping, demonstrating how cardinality balance converts one-sided saturation into two-sided. Separating the matching (verts ⊇ p₁ ∪ p₂) from the covering (p₁ ∪ p₂ = univ) makes the perfect-matching corollary a one-line consequence.",
+    "openQuestions": [
+      "Drop the explicit p₂-finiteness hypothesis where it follows from local finiteness and balance, or extend the criterion to the case where only p₁.ncard ≤ p₂.ncard (one-sided saturation without forcing a bijection).",
+      "Derive the defect/deficiency version: when the one-sided Hall condition fails by at most d, the maximum matching saturates all but d vertices of p₁ (the König–Ore defect form), again from hall_marriage plus counting."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-02` (passes: 0).

The entry had a rich structured `overview` and `description`, but **(1) its 2 `sections` used a non-schema `text` field with no line ranges (the `ProofSection` type requires `startLine`/`endLine`/`summary`), (2) it had no `conclusion`, and (3) no `annotations.json`**.

**Fixed sections:** converted both to `startLine`/`endLine`/`summary`/`mathContext` so they render and link to the Lean source.

**Added conclusion:** `summary`, `implications` (Mathlib/parent use the global Hall condition that bundles balance + covering; this isolates the textbook one-sided criterion), and 2 `openQuestions` (dropping p₂-finiteness / one-sided saturation; the König–Ore defect version).

**Created annotations.json:** 2 annotations — one-sided Hall saturating both sides via the matched-partner map + injection-to-bijection counting, and the balanced perfect-matching criterion — each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. (A 2-theorem entry, so 2 substantive annotations rather than padding.)

**Axiom-integrity check:** verified/original/0-axiom/0-sorry confirmed (no `axiom`/`sorry`/`native_decide`).

Verified: annotation line ranges validated by `annotations:build`; `tsc -b` clean; `vite build` succeeds; all JSON valid.