### PR TITLE
research(denumerability-rationals-oq-05-oq-01-oq-01): multivariate polynomial & monoid algebras over a countable ring stay denumerable [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -810,6 +810,7 @@ import Proofs.DenumerabilityRationalsOQ03
 import Proofs.DenumerabilityRationalsOQ04
 import Proofs.DenumerabilityRationalsOQ05
 import Proofs.DenumerabilityRationalsOQ05OQ01
+import Proofs.DenumerabilityRationalsOQ05OQ01OQ01
 import Proofs.DenumerabilityRationalsOQ06
 import Proofs.DenumerabilityRationalsOQ07
 import Proofs.Derangements

--- a/proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean
@@ -1,0 +1,139 @@
+/-
+# Denumerability of the Rationals OQ-05-OQ-01-OQ-01:
+# countability and cardinality of multivariate polynomial and monoid algebras
+
+## Open Question
+The parent (`denumerability-rationals-oq-05-oq-01`) proved the `ℵ₀/𝔠` dichotomy for the
+univariate polynomial ring over any countably infinite commutative ring `R`:
+`#(R[X]) = ℵ₀` while `#(ℕ → R) = 𝔠`. Its first listed open question asks to
+**generalise the polynomial side** to
+
+  * several variables — `#(R[X₁, …, Xₙ]) = ℵ₀`, and
+  * monoid algebras — `#(MonoidAlgebra R M) = ℵ₀` for countable `R` and countable `M`.
+
+This entry settles both. The phenomenon is purely a statement about countable building
+blocks: as a *type*, both algebras are finitely supported families over countable index
+sets, so they are countable; combined with an evident infinitude they pin to exactly `ℵ₀`.
+
+## Approach
+Both algebras are, by definition, `Finsupp` types:
+
+  * `MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R)`, and
+  * `MonoidAlgebra R M = (M →₀ R)`.
+
+**Countability.** `Finsupp` of countable types over a countable codomain is countable
+(`Finsupp.instCountable`, the same engine the parent used for `ℕ →₀ R`). For the
+multivariate case this fires *twice*: `σ →₀ ℕ` is countable (countable `σ`, countable `ℕ`),
+hence `(σ →₀ ℕ) →₀ R` is countable.
+
+**Infinitude.** A coefficient embedding injects `R` (assumed infinite):
+`MvPolynomial.C : R → MvPolynomial σ R` is injective, and `r ↦ single m₀ r` injects `R`
+into `MonoidAlgebra R M` once `M` is nonempty.
+
+**Cardinality.** A countable infinite type has cardinality exactly `ℵ₀`
+(`Cardinal.mk_eq_aleph0`). So `#(MvPolynomial σ R) = ℵ₀ = #(MonoidAlgebra R M)`, and passing
+to either algebra leaves the cardinality unchanged: `= #R`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace DenumerabilityRationalsOQ05OQ01OQ01
+
+open Cardinal
+
+variable {R : Type} {σ : Type} {M : Type}
+
+/-! ### Multivariate polynomials -/
+
+/-- **`MvPolynomial σ R` is countable** whenever the coefficient ring `R` and the variable
+index `σ` are countable. Unfolding `MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ)
+= ((σ →₀ ℕ) →₀ R)`, the `Finsupp` countability instance fires twice: first to make the
+exponent space `σ →₀ ℕ` countable, then to make the coefficient family `(σ →₀ ℕ) →₀ R`
+countable. -/
+theorem countable_mvPolynomial [CommRing R] [Countable R] [Countable σ] :
+    Countable (MvPolynomial σ R) :=
+  inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))
+
+/-- **`MvPolynomial σ R` is infinite** when the coefficient ring `R` is infinite. The
+constant-polynomial embedding `MvPolynomial.C : R → MvPolynomial σ R` is injective, so it
+transports `Infinite R` to the polynomial algebra (valid for any variable set `σ`, even
+empty). -/
+theorem infinite_mvPolynomial [CommRing R] [Infinite R] :
+    Infinite (MvPolynomial σ R) :=
+  Infinite.of_injective _ (MvPolynomial.C_injective σ R)
+
+/-- **`#(MvPolynomial σ R) = ℵ₀`** for any countably infinite ring `R` and countable variable
+set `σ`. The algebra is countable and infinite, so `Cardinal.mk_eq_aleph0` pins its
+cardinality at exactly `ℵ₀`: adjoining countably many commuting indeterminates never leaves
+denumerability. This is the multivariate generalisation of the parent's `#(R[X]) = ℵ₀`. -/
+theorem mk_mvPolynomial [CommRing R] [Countable R] [Infinite R] [Countable σ] :
+    #(MvPolynomial σ R) = ℵ₀ := by
+  haveI : Countable (MvPolynomial σ R) := countable_mvPolynomial
+  haveI : Infinite (MvPolynomial σ R) := infinite_mvPolynomial
+  exact mk_eq_aleph0 _
+
+/-- **Passing to a polynomial algebra in countably many variables does not change the
+cardinality: `#(MvPolynomial σ R) = #R`.** Both sides equal `ℵ₀` (the right via
+`mk_eq_aleph0` on the countably infinite `R`). The algebra is a strictly larger ring but the
+same size set. -/
+theorem mk_mvPolynomial_eq_mk [CommRing R] [Countable R] [Infinite R] [Countable σ] :
+    #(MvPolynomial σ R) = #R := by
+  rw [mk_mvPolynomial, mk_eq_aleph0 R]
+
+/-! ### Monoid algebras -/
+
+/-- **`MonoidAlgebra R M` is countable** whenever the coefficient ring `R` and the monoid `M`
+are countable. By definition `MonoidAlgebra R M = (M →₀ R)`, a finitely supported family over
+countable types, so the same `Finsupp` countability engine applies. (Only the *type*
+structure is used, so no algebraic hypotheses on `M` are required.) -/
+theorem countable_monoidAlgebra [Semiring R] [Countable R] [Countable M] :
+    Countable (MonoidAlgebra R M) :=
+  inferInstanceAs (Countable (M →₀ R))
+
+/-- **`MonoidAlgebra R M` is infinite** when the coefficient ring `R` is infinite and the
+index `M` is nonempty. Fixing any point `m₀ : M`, the single-support embedding
+`r ↦ single m₀ r` injects `R` into `MonoidAlgebra R M`, transporting `Infinite R`. -/
+theorem infinite_monoidAlgebra [Semiring R] [Infinite R] [Nonempty M] :
+    Infinite (MonoidAlgebra R M) := by
+  obtain ⟨m₀⟩ := ‹Nonempty M›
+  have h : Infinite (M →₀ R) :=
+    Infinite.of_injective (fun r : R => Finsupp.single m₀ r)
+      (fun a b hab => by simpa using DFunLike.congr_fun hab m₀)
+  exact h
+
+/-- **`#(MonoidAlgebra R M) = ℵ₀`** for any countably infinite ring `R` and countable
+nonempty index `M`. Countable and infinite, hence exactly `ℵ₀` by `Cardinal.mk_eq_aleph0`:
+the monoid-algebra generalisation of the parent's `#(R[X]) = ℵ₀` (recovered at `M = ℕ`, where
+`MonoidAlgebra R ℕ = R[X]`). -/
+theorem mk_monoidAlgebra [Semiring R] [Countable R] [Infinite R] [Countable M] [Nonempty M] :
+    #(MonoidAlgebra R M) = ℵ₀ := by
+  haveI : Countable (MonoidAlgebra R M) := countable_monoidAlgebra
+  haveI : Infinite (MonoidAlgebra R M) := infinite_monoidAlgebra
+  exact mk_eq_aleph0 _
+
+/-- **`#(MonoidAlgebra R M) = #R`.** Both sides are `ℵ₀`. -/
+theorem mk_monoidAlgebra_eq_mk
+    [Semiring R] [Countable R] [Infinite R] [Countable M] [Nonempty M] :
+    #(MonoidAlgebra R M) = #R := by
+  rw [mk_monoidAlgebra, mk_eq_aleph0 R]
+
+/-! ### Concrete instances -/
+
+/-- **`#(MvPolynomial ℕ ℚ) = ℵ₀`.** Rational polynomials in countably many variables remain
+denumerable. -/
+theorem mk_mvPolynomial_nat_rat : #(MvPolynomial ℕ ℚ) = ℵ₀ :=
+  mk_mvPolynomial
+
+/-- **`#(MvPolynomial (Fin 3) ℤ) = ℵ₀`.** Integer polynomials in three variables are
+denumerable. -/
+theorem mk_mvPolynomial_fin_int : #(MvPolynomial (Fin 3) ℤ) = ℵ₀ :=
+  mk_mvPolynomial
+
+/-- **`#(MonoidAlgebra ℚ ℕ) = ℵ₀`.** The rational monoid algebra over `(ℕ, +)` — which *is*
+`ℚ[X]` — is denumerable, recovering the parent's univariate result through the monoid-algebra
+route. -/
+theorem mk_monoidAlgebra_nat_rat : #(MonoidAlgebra ℚ ℕ) = ℵ₀ :=
+  mk_monoidAlgebra
+
+end DenumerabilityRationalsOQ05OQ01OQ01

--- a/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,1432 @@
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "title": "Multivariate Polynomial and Monoid Algebras Over a Countable Ring Stay Denumerable: #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01",
+  "description": "The parent located the ℵ₀/𝔠 boundary for the univariate polynomial ring over any countably infinite ring R: #(R[X]) = ℵ₀. Its first open question asks to generalize the polynomial side to several variables and to monoid algebras. This entry settles both: for countable R and countable index σ (resp. countable nonempty M), #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀. As types both are finitely supported families over countable index sets — MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) (Finsupp countability applied twice) and MonoidAlgebra R M = (M →₀ R) — hence countable; a coefficient embedding (MvPolynomial.C, resp. r ↦ single m₀ r) supplies infinitude, and mk_eq_aleph0 pins the cardinality at exactly ℵ₀. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "polynomial-ring",
+      "monoid-algebra",
+      "multivariate-polynomial",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "finsupp",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins both algebras' cardinality at ℵ₀ once countability and infinitude are established",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Finsupp.instCountable",
+        "description": "[Countable α] [Countable β] [Zero β] → Countable (α →₀ β) — the countability engine; fires twice for MvPolynomial = ((σ →₀ ℕ) →₀ R) and once for MonoidAlgebra = (M →₀ R)",
+        "module": "Mathlib.Data.Finsupp.Encodable"
+      },
+      {
+        "theorem": "MvPolynomial.C_injective",
+        "description": "Function.Injective (C : R → MvPolynomial σ R) — the constant embedding transports Infinite R to the polynomial algebra",
+        "module": "Mathlib.Algebra.MvPolynomial.Basic"
+      },
+      {
+        "theorem": "Infinite.of_injective",
+        "description": "an injection from an infinite type forces the codomain infinite — supplies Infinite (MvPolynomial σ R) and Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Logic.Equiv.Basic"
+      },
+      {
+        "theorem": "Finsupp.single_eq_same",
+        "description": "(single a b) a = b — closes injectivity of r ↦ single m₀ r used for Infinite (MonoidAlgebra R M)",
+        "module": "Mathlib.Data.Finsupp.Single"
+      }
+    ],
+    "originalContributions": [
+      "countable_mvPolynomial: Countable (MvPolynomial σ R) for countable R, σ — Finsupp countability applied to ((σ →₀ ℕ) →₀ R)",
+      "infinite_mvPolynomial: Infinite (MvPolynomial σ R) for infinite R, via the injective constant embedding MvPolynomial.C",
+      "mk_mvPolynomial: #(MvPolynomial σ R) = ℵ₀ — polynomial algebras in countably many variables stay denumerable",
+      "mk_mvPolynomial_eq_mk: #(MvPolynomial σ R) = #R, adjoining countably many commuting indeterminates does not change cardinality",
+      "countable_monoidAlgebra: Countable (MonoidAlgebra R M) for countable R, M — Finsupp countability on (M →₀ R)",
+      "infinite_monoidAlgebra: Infinite (MonoidAlgebra R M) for infinite R and nonempty M, via r ↦ single m₀ r",
+      "mk_monoidAlgebra: #(MonoidAlgebra R M) = ℵ₀ — monoid algebras over a countably infinite ring stay denumerable",
+      "mk_monoidAlgebra_eq_mk: #(MonoidAlgebra R M) = #R",
+      "mk_mvPolynomial_nat_rat: #(MvPolynomial ℕ ℚ) = ℵ₀, concrete instance (countably many variables over ℚ)",
+      "mk_mvPolynomial_fin_int: #(MvPolynomial (Fin 3) ℤ) = ℵ₀, concrete instance (three variables over ℤ)",
+      "mk_monoidAlgebra_nat_rat: #(MonoidAlgebra ℚ ℕ) = ℵ₀, concrete instance — MonoidAlgebra ℚ ℕ is ℚ[X], recovering the parent's univariate result"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 139,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The parent entry generalized OQ-05's ℵ₀/𝔠 dichotomy off ℚ: over any countably infinite commutative ring R the univariate polynomial ring R[X] stays denumerable (#(R[X]) = ℵ₀) while the sequence space ℕ → R reaches the continuum. The natural next question — listed as the parent's first open question — is whether the denumerable side survives richer algebraic constructions. It does: adjoining countably many commuting indeterminates (MvPolynomial σ R, the free commutative R-algebra on σ) or passing to an arbitrary monoid algebra MonoidAlgebra R M over a countable monoid keeps cardinality at exactly ℵ₀. The reason is structural: each is, by definition, a finitely supported family over a countable index set, i.e. a Finsupp of countable types, and the polynomial/monoid-algebra structure only enlarges the ring, never the underlying set's cardinality.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01, first sub-question)**: Generalize the polynomial side to several variables and to monoid algebras — show #(MvPolynomial σ R) = ℵ₀ and #(MonoidAlgebra R M) = ℵ₀ for countable R and countable M.\n\n**Result**: mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀, with mk_mvPolynomial_eq_mk: = #R) for countable R, σ and infinite R; mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀, with mk_monoidAlgebra_eq_mk) for countable R, M, infinite R, nonempty M. Concrete instances over ℚ and ℤ, including MonoidAlgebra ℚ ℕ = ℚ[X].",
+    "text": "For a countably infinite ring R and a countable variable set σ, the multivariate polynomial ring MvPolynomial σ R is denumerable: #(MvPolynomial σ R) = ℵ₀ = #R. The same holds for any monoid algebra MonoidAlgebra R M over a countable nonempty index M: #(MonoidAlgebra R M) = ℵ₀ = #R.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_mvPolynomial`: MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R). The Finsupp countability instance fires twice — first making the exponent space σ →₀ ℕ countable (countable σ, countable ℕ), then the coefficient family (σ →₀ ℕ) →₀ R countable. Delivered by `inferInstanceAs (Countable ((σ →₀ ℕ) →₀ R))`.\n2. `infinite_mvPolynomial`: the constant embedding MvPolynomial.C is injective (`MvPolynomial.C_injective`), so `Infinite.of_injective` transports Infinite R to the algebra.\n3. `mk_mvPolynomial`: countable (step 1) and infinite (step 2), so `Cardinal.mk_eq_aleph0` gives #(MvPolynomial σ R) = ℵ₀; `mk_mvPolynomial_eq_mk` rewrites #R = ℵ₀ for equality.\n4. `countable_monoidAlgebra`: MonoidAlgebra R M = (M →₀ R) is countable by the same Finsupp instance, `inferInstanceAs (Countable (M →₀ R))`.\n5. `infinite_monoidAlgebra`: fixing m₀ : M (from Nonempty M), r ↦ Finsupp.single m₀ r is injective (apply at m₀, `Finsupp.single_eq_same`), so `Infinite.of_injective` gives infinitude.\n6. `mk_monoidAlgebra`: countable + infinite ⟹ #(MonoidAlgebra R M) = ℵ₀; `mk_monoidAlgebra_eq_mk` for the equality with #R.\n7. Instances `mk_mvPolynomial_nat_rat`, `mk_mvPolynomial_fin_int`, `mk_monoidAlgebra_nat_rat` specialize to ℚ and ℤ.",
+    "keyInsights": [
+      "**Denumerability survives richer algebra.** The parent kept R[X] at ℵ₀; this entry shows countably many variables (MvPolynomial) and arbitrary countable monoid algebras stay at ℵ₀ too. Only 'countable' and 'infinite' are used — the multiplicative structure of σ, M, or R never enters the cardinality count.",
+      "**Everything is a Finsupp.** MvPolynomial σ R = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) are, definitionally, finitely supported families. The single Mathlib engine `Finsupp.instCountable` does all the work, nested twice for the multivariate exponent space σ →₀ ℕ.",
+      "**Infinitude comes from one injected coefficient line.** The constant embedding MvPolynomial.C (resp. r ↦ single m₀ r) injects the infinite ring R, so the algebra is infinite for the cheapest possible reason — no need to count monomials.",
+      "**MonoidAlgebra ℚ ℕ is ℚ[X].** The monoid-algebra route recovers the parent's univariate polynomial result as the special case M = (ℕ, +), confirming the generalization is faithful."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types)",
+      "MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R) and MonoidAlgebra R M = (M →₀ R) as Finsupp types",
+      "Finsupp countability (Finsupp.instCountable) and coefficient embeddings (MvPolynomial.C_injective, Finsupp.single)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Module docstring framing the multivariate / monoid-algebra generalization of the parent's #(R[X]) = ℵ₀, the Mathlib import, namespace, Cardinal open, and the variables R, σ, M.",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0$ for countable building blocks."
+    },
+    {
+      "id": "mvpolynomial",
+      "title": "Multivariate Polynomials Stay Denumerable",
+      "startLine": 47,
+      "endLine": 83,
+      "summary": "countable_mvPolynomial (Countable (MvPolynomial σ R) via the doubly-nested Finsupp), infinite_mvPolynomial (Infinite via MvPolynomial.C_injective), mk_mvPolynomial (#(MvPolynomial σ R) = ℵ₀) and mk_mvPolynomial_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MvPolynomial}\\,\\sigma\\,R = ((\\sigma \\to_0 \\mathbb{N}) \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MvPolynomial}\\,\\sigma\\,R) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "monoidalgebra",
+      "title": "Monoid Algebras Stay Denumerable",
+      "startLine": 84,
+      "endLine": 120,
+      "summary": "countable_monoidAlgebra (Countable (MonoidAlgebra R M)), infinite_monoidAlgebra (Infinite via r ↦ single m₀ r), mk_monoidAlgebra (#(MonoidAlgebra R M) = ℵ₀) and mk_monoidAlgebra_eq_mk (= #R).",
+      "mathContext": "$\\mathrm{MonoidAlgebra}\\,R\\,M = (M \\to_0 R)$ is countable and infinite, so $\\#(\\mathrm{MonoidAlgebra}\\,R\\,M) = \\aleph_0 = \\#R$."
+    },
+    {
+      "id": "instances",
+      "title": "Concrete Instances: ℚ and ℤ",
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "mk_mvPolynomial_nat_rat (#(MvPolynomial ℕ ℚ) = ℵ₀), mk_mvPolynomial_fin_int (#(MvPolynomial (Fin 3) ℤ) = ℵ₀), mk_monoidAlgebra_nat_rat (#(MonoidAlgebra ℚ ℕ) = ℵ₀, i.e. ℚ[X]).",
+      "mathContext": "$\\#(\\mathrm{MvPolynomial}\\,\\mathbb{N}\\,\\mathbb{Q}) = \\#(\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,3)\\,\\mathbb{Z}) = \\#(\\mathrm{MonoidAlgebra}\\,\\mathbb{Q}\\,\\mathbb{N}) = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent's first open question: generalizes #(R[X]) = ℵ₀ to multivariate polynomial algebras MvPolynomial σ R and monoid algebras MonoidAlgebra R M over countable building blocks"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05",
+      "relationship": "related",
+      "description": "Continues OQ-05's program on which set-forming operations preserve denumerability: adjoining countably many indeterminates and forming countable monoid algebras both keep cardinality at ℵ₀"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's #(R[X]) = ℵ₀: for a countably infinite ring R, the multivariate polynomial algebra MvPolynomial σ R (countable σ) and any monoid algebra MonoidAlgebra R M (countable nonempty M) stay denumerable, #(MvPolynomial σ R) = #(MonoidAlgebra R M) = ℵ₀ = #R. Both reduce to nested Finsupp countability plus a one-line coefficient embedding for infinitude.",
+    "implications": "The ℵ₀-denumerable side of the dichotomy is robust under the standard ways of building bigger algebras: countably many commuting variables, or an arbitrary countable monoid algebra. Concrete over ℚ and ℤ, with MonoidAlgebra ℚ ℕ = ℚ[X] recovering the univariate case.",
+    "openQuestions": [
+      "Push to the continuum side: for a countably infinite ring R, is #(MvPolynomial σ R) = 𝔠 once σ is uncountable, and where exactly does the transition happen as the variable set grows?",
+      "Cardinality of formal power series: #(PowerSeries R) and #(MvPowerSeries σ R) — the completed analogues should reach 𝔠 (= #(ℕ → R)), sharpening the polynomial/power-series contrast."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01",
+    "lineCount": 139,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side of the dichotomy"
+    },
+    {
+      "authors": "Jech, Thomas",
+      "title": "Set Theory",
+      "year": "2003",
+      "venue": "Springer Monographs in Mathematics, 3rd ed.",
+      "note": "Cardinal arithmetic: countable unions/colimits of countable sets stay ℵ₀"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `denumerability-rationals-oq-05-oq-01` (PR #27939): generalize the parent's `#(R[X]) = ℵ₀` from the univariate polynomial ring to **several variables** and to **monoid algebras**.

For a countably infinite (commutative) ring `R`:
- `#(MvPolynomial σ R) = ℵ₀ = #R` for any countable variable set `σ`;
- `#(MonoidAlgebra R M) = ℵ₀ = #R` for any countable nonempty index `M`.

## Mathematical content

Both algebras are, by definition, finitely supported families over countable index sets:
- `MvPolynomial σ R = AddMonoidAlgebra R (σ →₀ ℕ) = ((σ →₀ ℕ) →₀ R)` — `Finsupp` countability fires **twice** (exponent space `σ →₀ ℕ`, then coefficients);
- `MonoidAlgebra R M = (M →₀ R)` — `Finsupp` countability once.

Infinitude comes from a single injected coefficient line: `MvPolynomial.C` (constant embedding, injective) for the polynomial side, and `r ↦ Finsupp.single m₀ r` for the monoid algebra. `Cardinal.mk_eq_aleph0` then pins each cardinality at exactly `ℵ₀`.

The phenomenon is structural: only *countable* + *infinite* are used; the algebraic structure enlarges the ring, never the underlying set's cardinality. `MonoidAlgebra ℚ ℕ = ℚ[X]` recovers the parent's univariate result.

## Theorems (11, 0 definitions)

- `countable_mvPolynomial`, `infinite_mvPolynomial`, `mk_mvPolynomial` (`= ℵ₀`), `mk_mvPolynomial_eq_mk` (`= #R`)
- `countable_monoidAlgebra`, `infinite_monoidAlgebra`, `mk_monoidAlgebra` (`= ℵ₀`), `mk_monoidAlgebra_eq_mk` (`= #R`)
- Concrete: `mk_mvPolynomial_nat_rat` (`#(MvPolynomial ℕ ℚ) = ℵ₀`), `mk_mvPolynomial_fin_int` (`#(MvPolynomial (Fin 3) ℤ) = ℵ₀`), `mk_monoidAlgebra_nat_rat` (`#(MonoidAlgebra ℚ ℕ) = ℵ₀`)

## Verification

- **0 sorries, 0 axioms** beyond `propext` / `Classical.choice` / `Quot.sound` (confirmed via `#print axioms`).
- Built with `lake env lean`, Lean **v4.26.0** / Mathlib.
- Status `verified`, badge `mathlib`.

## Files
- `proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01.lean` (139 lines)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)