### PR TITLE
research(wilsons-theorem-oq-05-oq-01-oq-01-oq-01): exact Kempner–Smarandache value S(p^k) for prime powers via Legendre's formula [0-axiom verified]

### DIFF
--- a/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01.lean
@@ -1,0 +1,168 @@
+import Mathlib
+
+/-
+# The Kempner–Smarandache value `S(p^k)` for prime powers via Legendre's formula
+
+**Open Question (`wilsons-theorem-oq-05-oq-01-oq-01-oq-01`)**: the parent entry
+`wilsons-theorem-oq-05-oq-01-oq-01` proved the *Kempner threshold*
+`(∃ m < n, n ∣ m!) ↔ (¬ n.Prime ∧ n ≠ 4)`, i.e. it located *when* the
+Kempner–Smarandache function `S(n) = min {m : n ∣ m!}` drops strictly below `n`,
+but it did not compute `S(n)` itself for any composite `n`.  Its first registered
+open question asks to **determine the exact value `S(p^k)` for prime powers**,
+"and the role of the largest prime power dividing `n`", via Legendre's formula.
+
+This entry does exactly that.  The Kempner–Smarandache function is
+
+  `S m = sInf {n | m ∣ n !}`,
+
+the least `n` whose factorial is divisible by `m`.  For a prime `p` and `k ≥ 1`
+we prove, purely from Legendre's formula (the `p`-adic valuation of `n!`):
+
+* `pow_dvd_factorial_iff`     : `p^k ∣ n! ↔ k ≤ (n!).factorization p`  (Legendre).
+* `S_prime_pow_le`            : `S(p^k) ≤ p·k`.
+* `prime_le_S_prime_pow`      : `p ≤ S(p^k)`.
+* `prime_dvd_S_prime_pow`     : `p ∣ S(p^k)` — `S(p^k)` is *always a multiple of
+  `p`* (the new increment of the valuation can only happen at a multiple of `p`).
+* `S_prime_pow_eq_mul_iff`    : **`S(p^k) = p·k ↔ k ≤ p`** — the exact value on
+  the largest "linear" range, and the sharp boundary where the closed form `p·k`
+  first fails.
+* `S_prime`                   : `S(p) = p` (the classical base case).
+
+The engine is the Mathlib identity `Nat.factorization_factorial_mul`,
+`(p·n)!.factorization p = (n!).factorization p + n`, which is Legendre's formula
+read at multiples of `p`.  Combined with `factorization_factorial_eq_zero_of_lt`
+(no power of `p` divides `t!` for `t < p`) it pins `S(p^k) = p·k` exactly when
+`k ≤ p`, and shows `S(p^k) < p·k` for every `k > p` (the valuation of `(k-1)!`
+already contributes, so `(p·(k-1))!` is divisible by `p^k`).
+-/
+
+open Nat
+
+namespace WilsonsTheoremOQ05OQ01OQ01OQ01
+
+/-! ## The Kempner–Smarandache function -/
+
+/-- The **Kempner–Smarandache function**: the least `n` with `m ∣ n!`.
+For `m ≥ 1` this is well defined, since `m ∣ m!`. -/
+noncomputable def S (m : ℕ) : ℕ := sInf {n | m ∣ n !}
+
+/-- For `m ≥ 1`, `S m` is an actual witness: `m ∣ (S m)!`. -/
+theorem dvd_factorial_S {m : ℕ} (hm : 0 < m) : m ∣ (S m)! := by
+  have hne : Set.Nonempty {n | m ∣ n !} := ⟨m, Nat.dvd_factorial hm le_rfl⟩
+  exact Nat.sInf_mem hne
+
+/-- `S m` is the *least* witness: every `n` with `m ∣ n!` satisfies `S m ≤ n`. -/
+theorem S_le {m n : ℕ} (h : m ∣ n !) : S m ≤ n := Nat.sInf_le h
+
+/-! ## Legendre's formula and the prime-power value -/
+
+variable {p k : ℕ}
+
+/-- A factorial splits off its top factor multiplicatively, so the `p`-valuation
+of `(t+1)!` is that of `(t+1)` plus that of `t!`. -/
+theorem factorization_factorial_succ_split (t : ℕ) :
+    ((t + 1)!).factorization p
+      = (t + 1).factorization p + (t !).factorization p := by
+  rw [Nat.factorial_succ,
+      Nat.factorization_mul (Nat.succ_ne_zero t) (Nat.factorial_ne_zero t),
+      Finsupp.add_apply]
+
+/-- **Legendre's divisibility criterion.**  `p^k ∣ n!` exactly when `k` does not
+exceed the `p`-adic valuation `(n!).factorization p = ∑_{i≥1} ⌊n/p^i⌋`. -/
+theorem pow_dvd_factorial_iff (hp : p.Prime) {n : ℕ} :
+    p ^ k ∣ n ! ↔ k ≤ (n !).factorization p :=
+  Nat.Prime.pow_dvd_iff_le_factorization hp (Nat.factorial_ne_zero n)
+
+/-- `p^k ∣ (p·k)!`: by Legendre at multiples, `(p·k)!.factorization p
+= (k!).factorization p + k ≥ k`. -/
+theorem prime_pow_dvd_factorial_mul (hp : p.Prime) : p ^ k ∣ (p * k)! := by
+  rw [pow_dvd_factorial_iff hp, Nat.factorization_factorial_mul hp]
+  exact Nat.le_add_left k _
+
+/-- **Upper bound:** `S(p^k) ≤ p·k`. -/
+theorem S_prime_pow_le (hp : p.Prime) : S (p ^ k) ≤ p * k :=
+  S_le (prime_pow_dvd_factorial_mul hp)
+
+/-- **Lower bound:** `p ≤ S(p^k)` for `k ≥ 1`, since `p ∣ p^k ∣ (S(p^k))!`
+forces `p ≤ S(p^k)`. -/
+theorem prime_le_S_prime_pow (hp : p.Prime) (hk : 0 < k) : p ≤ S (p ^ k) := by
+  have hdvd : p ^ k ∣ (S (p ^ k))! := dvd_factorial_S (pow_pos hp.pos k)
+  have hp_dvd : p ∣ (S (p ^ k))! := dvd_trans (dvd_pow_self p hk.ne') hdvd
+  exact (Nat.Prime.dvd_factorial hp).mp hp_dvd
+
+/-- **Structural fact:** `S(p^k)` is always a multiple of `p`.  The minimal `n`
+with `p^k ∣ n!` must *strictly increase* the `p`-valuation of the factorial, and
+that valuation only ever increases at a multiple of `p`. -/
+theorem prime_dvd_S_prime_pow (hp : p.Prime) (hk : 0 < k) : p ∣ S (p ^ k) := by
+  have hpos : 0 < p ^ k := pow_pos hp.pos k
+  have hp2 : 2 ≤ p := hp.two_le
+  have hp_le : p ≤ S (p ^ k) := prime_le_S_prime_pow hp hk
+  obtain ⟨t, ht⟩ : ∃ t, S (p ^ k) = t + 1 := ⟨S (p ^ k) - 1, by omega⟩
+  have hmem : k ≤ ((t + 1)!).factorization p := by
+    have h := (pow_dvd_factorial_iff hp).mp (dvd_factorial_S hpos)
+    rwa [ht] at h
+  have hnot : ((t)!).factorization p < k := by
+    by_contra h
+    push_neg at h
+    have hd : p ^ k ∣ t ! := (pow_dvd_factorial_iff hp).mpr h
+    have := S_le hd
+    omega
+  have hsplit := factorization_factorial_succ_split (p := p) t
+  rw [ht]
+  apply Nat.dvd_of_factorization_pos
+  omega
+
+/-- **The exact value on the linear range.**  For a prime `p` and `k ≥ 1`,
+the Kempner–Smarandache value of `p^k` equals `p·k` *iff* `k ≤ p`.
+
+For `k ≤ p` the valuation of `(k-1)!` is `0`, so `(p·(k-1))!` is *not* divisible
+by `p^k` and the first multiple that works is `p·k`.  For `k > p` the valuation
+of `(k-1)!` is already positive, so `(p·(k-1))!` is divisible by `p^k` and
+`S(p^k) ≤ p·(k-1) < p·k`. -/
+theorem S_prime_pow_eq_mul_iff (hp : p.Prime) (hk : 0 < k) :
+    S (p ^ k) = p * k ↔ k ≤ p := by
+  constructor
+  · -- `S(p^k) = p·k → k ≤ p`, via the contrapositive.
+    intro hEq
+    by_contra hkp
+    push_neg at hkp                       -- `p < k`
+    have hpk1 : p ≤ k - 1 := by omega
+    have hdvd_fact : p ∣ (k - 1)! := (Nat.Prime.dvd_factorial hp).mpr hpk1
+    have hposf : 0 < ((k - 1)!).factorization p :=
+      hp.factorization_pos_of_dvd (Nat.factorial_ne_zero _) hdvd_fact
+    have hmul : ((p * (k - 1))!).factorization p
+        = ((k - 1)!).factorization p + (k - 1) :=
+      Nat.factorization_factorial_mul hp
+    have hge : k ≤ ((p * (k - 1))!).factorization p := by omega
+    have hdvd : p ^ k ∣ (p * (k - 1))! := (pow_dvd_factorial_iff hp).mpr hge
+    have hle : S (p ^ k) ≤ p * (k - 1) := S_le hdvd
+    have hcontra : p * k ≤ p * (k - 1) := hEq ▸ hle
+    have hlt2 : p * (k - 1) < p * k := mul_lt_mul_of_pos_left (by omega) hp.pos
+    omega
+  · -- `k ≤ p → S(p^k) = p·k`.
+    intro hkp
+    have hle : S (p ^ k) ≤ p * k := S_prime_pow_le hp
+    obtain ⟨t, ht⟩ := prime_dvd_S_prime_pow hp hk      -- `S(p^k) = p·t`
+    have htk : t ≤ k := by
+      have hmul : p * t ≤ p * k := ht ▸ hle
+      exact le_of_mul_le_mul_left hmul hp.pos
+    have hmem : p ^ k ∣ (p * t)! := by
+      rw [← ht]; exact dvd_factorial_S (pow_pos hp.pos k)
+    have hmemf : k ≤ ((p * t)!).factorization p := (pow_dvd_factorial_iff hp).mp hmem
+    rw [Nat.factorization_factorial_mul hp] at hmemf   -- `k ≤ (t!).factorization p + t`
+    rcases Nat.lt_or_ge t k with hlt | hge
+    · exfalso
+      have htp : t < p := by omega                     -- `t < k ≤ p`
+      have hz : ((t)!).factorization p = 0 :=
+        Nat.factorization_factorial_eq_zero_of_lt htp
+      rw [hz] at hmemf
+      omega
+    · have hteq : t = k := le_antisymm htk hge
+      rw [ht, hteq]
+
+/-- **Base case (classical):** `S(p) = p` for any prime `p`. -/
+theorem S_prime (hp : p.Prime) : S p = p := by
+  have h := (S_prime_pow_eq_mul_iff hp one_pos).mpr hp.one_lt.le
+  simpa using h
+
+end WilsonsTheoremOQ05OQ01OQ01OQ01

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+  "title": "The Kempner–Smarandache Value $S(p^k)$ for Prime Powers via Legendre's Formula",
+  "slug": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+  "description": "Answers the first registered open question of the parent entry `wilsons-theorem-oq-05-oq-01-oq-01`, which proved only the Kempner *threshold* (∃ m < n, n ∣ m!) ↔ (¬n.Prime ∧ n ≠ 4) — i.e. located when the Kempner–Smarandache function S(n) = min{m : n ∣ m!} drops below n, without computing S(n) for any composite n. This entry computes S(p^k) exactly for prime powers, directly from Legendre's formula. The function is defined as `S m = sInf {n | m ∣ n!}` (the least n whose factorial is divisible by m), with `dvd_factorial_S` (m ∣ (S m)! for m ≥ 1) and `S_le` (S m is the least such witness) establishing the spec. The Legendre criterion `pow_dvd_factorial_iff` reads p^k ∣ n! ↔ k ≤ (n!).factorization p (the p-adic valuation ∑⌊n/p^i⌋). From the Mathlib identity Nat.factorization_factorial_mul, (p·n)!.factorization p = (n!).factorization p + n, three results follow: the upper bound `S_prime_pow_le` (S(p^k) ≤ p·k); the lower bound `prime_le_S_prime_pow` (p ≤ S(p^k) for k ≥ 1); and the structural fact `prime_dvd_S_prime_pow` that S(p^k) is ALWAYS a multiple of p — because the minimal n must strictly increase the valuation of the factorial, and that valuation only increases at multiples of p. The headline `S_prime_pow_eq_mul_iff` pins the exact value on the linear range: S(p^k) = p·k ⟺ k ≤ p. For k ≤ p the valuation of (k-1)! is 0, so (p·(k-1))! is not divisible by p^k and the first multiple that works is p·k; for k > p the valuation of (k-1)! is already positive, so (p·(k-1))! is divisible by p^k and S(p^k) ≤ p·(k-1) < p·k — the sharp boundary where the closed form p·k first fails (e.g. S(2^3) = 4 < 6, since k = 3 > 2 = p). The classical base case S(p) = p (`S_prime`) is the corollary at k = 1. Fully machine-checked: 0 sorries, 0 axioms beyond the foundational propext, Classical.choice, Quot.sound; no native_decide.",
+  "meta": {
+    "author": "Kempner (1918) / Smarandache function S(n) = min{m : n ∣ m!}; Legendre's formula (1808); exact prime-power value S(p^k) formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Kempner_function",
+    "date": "1918",
+    "status": "verified",
+    "proofRepoPath": "Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "wilsons-theorem",
+      "kempner-function",
+      "smarandache-function",
+      "factorial",
+      "legendre-formula",
+      "p-adic-valuation",
+      "prime-powers",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 168,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The development rests on Mathlib's Legendre infrastructure: `Nat.Prime.pow_dvd_iff_le_factorization` (p^k ∣ n ↔ k ≤ n.factorization p for n ≠ 0), `Nat.factorization_factorial_mul` ((p·n)!.factorization p = (n!).factorization p + n, Legendre at multiples), `Nat.factorization_factorial_eq_zero_of_lt` (t < p ⟹ (t!).factorization p = 0), `Nat.Prime.factorization_pos_of_dvd`, `Nat.dvd_of_factorization_pos`, `Nat.Prime.dvd_factorial`, and `Nat.dvd_factorial`. The Kempner function is built on `Nat.sInf` (`Nat.sInf_mem`, `Nat.sInf_le`). No `decide` or `native_decide` is used; the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.factorization_factorial_mul",
+        "description": "`(p * n)!.factorization p = (n!).factorization p + n` for prime p — Legendre's formula read at multiples of p. The engine for every prime-power bound here: it converts the valuation of a factorial at a multiple of p into a valuation one 'level' down plus a linear term.",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "Nat.Prime.pow_dvd_iff_le_factorization",
+        "description": "`p^k ∣ n ↔ k ≤ n.factorization p` (for prime p, n ≠ 0). Specialized to n = m! it is exactly Legendre's divisibility criterion p^k ∣ m! ↔ k ≤ (m!).factorization p, converting the Kempner divisibility condition into an inequality on the p-adic valuation.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic"
+      },
+      {
+        "theorem": "Nat.factorization_factorial_eq_zero_of_lt",
+        "description": "`t < p → (t!).factorization p = 0`: no power of a prime p divides t! when t < p. This is the boundary input forcing S(p^k) = p·k exactly when k ≤ p (the valuation of (k-1)! vanishes).",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "Nat.Prime.factorization_pos_of_dvd / Nat.dvd_of_factorization_pos",
+        "description": "`p.Prime → n ≠ 0 → p ∣ n → 0 < n.factorization p` and its converse `n.factorization p ≠ 0 → p ∣ n`. Used to show S(p^k) is a multiple of p (positive valuation increment ⟹ p ∣ S) and that p ∣ (k-1)! gives a positive valuation for k > p.",
+        "module": "Mathlib.Data.Nat.Factorization.Basic / Defs"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_factorial",
+        "description": "`p.Prime → (p ∣ n! ↔ p ≤ n)`. Gives the lower bound p ≤ S(p^k): since p ∣ p^k ∣ (S(p^k))!, the prime p divides the factorial only when p ≤ S(p^k).",
+        "module": "Mathlib.Data.Nat.Prime.Factorial"
+      },
+      {
+        "theorem": "Nat.dvd_factorial / Nat.sInf_mem / Nat.sInf_le",
+        "description": "`0 < m → m ≤ n → m ∣ n!` makes m ∣ m! so the defining set {n | m ∣ n!} is nonempty; `Nat.sInf_mem` and `Nat.sInf_le` then give that S m = sInf{n | m ∣ n!} is a genuine least witness.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic / Mathlib.Data.Nat.Lattice"
+      }
+    ],
+    "originalContributions": [
+      "`S`: the Kempner–Smarandache function S m = sInf {n | m ∣ n!} (least n with m ∣ n!), with `dvd_factorial_S` (m ∣ (S m)! for m ≥ 1) and `S_le` (least-witness property) establishing its specification via Nat.sInf.",
+      "`pow_dvd_factorial_iff`: Legendre's divisibility criterion p^k ∣ n! ↔ k ≤ (n!).factorization p, the bridge from Kempner divisibility to the p-adic valuation.",
+      "`prime_pow_dvd_factorial_mul` and `S_prime_pow_le`: p^k ∣ (p·k)! and hence the upper bound S(p^k) ≤ p·k, via Legendre at multiples.",
+      "`prime_le_S_prime_pow`: the lower bound p ≤ S(p^k) for k ≥ 1.",
+      "`prime_dvd_S_prime_pow`: the structural fact that S(p^k) is ALWAYS a multiple of p — the minimal n increasing the p-valuation of the factorial must itself be a multiple of p (the valuation only jumps at multiples of p). This is the precise sense in which 'the largest prime power dividing n' controls S(n).",
+      "`S_prime_pow_eq_mul_iff`: the exact value on the linear range — S(p^k) = p·k ⟺ k ≤ p — with both the closed form and the sharp boundary k > p where it fails (then S(p^k) ≤ p·(k-1) < p·k, since the p-valuation of (k-1)! is already positive).",
+      "`S_prime`: the classical base case S(p) = p, recovered as the k = 1 corollary."
+    ],
+    "prerequisites": [
+      "The Kempner–Smarandache function S(n) = min {m : n ∣ m!}",
+      "Legendre's formula: the p-adic valuation of n! is ∑_{i≥1} ⌊n/p^i⌋ = (n!).factorization p",
+      "p-adic valuation `Nat.factorization` and prime-power divisibility",
+      "Factorials and divisibility (`Nat.dvd_factorial`, `Nat.Prime.dvd_factorial`)",
+      "The least-element operator `Nat.sInf` and its membership/minimality lemmas"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "wilsons-theorem-oq-05-oq-01-oq-01",
+        "relationship": "Parent: oq-05-oq-01-oq-01 proved the Kempner threshold (∃ m < n, n ∣ m!) ↔ (¬n.Prime ∧ n ≠ 4) — locating when S(n) < n but not computing S(n). Its first open question asks for the exact value S(p^k) for prime powers and the role of the largest prime power dividing n. This entry answers it via Legendre's formula: the exact value, the always-a-multiple-of-p structure, and the sharp boundary S(p^k) = p·k ⟺ k ≤ p."
+      },
+      {
+        "id": "wilsons-theorem-oq-03",
+        "relationship": "Sibling line: oq-03 computes the p-adic valuation ν_p((p-1)!) = 0 (a single Legendre evaluation); this entry uses the full Legendre identity at multiples of p to determine the Kempner value S(p^k)."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 168,
+    "path": "Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 1,
+    "theoremCount": 10
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "The Kempner–Smarandache function S(n) = min{m : n ∣ m!} (Kempner 1918, later rediscovered as the Smarandache function) is the inverse problem to the factorial: rather than asking which numbers divide n!, it asks for the smallest factorial divisible by n. For a prime p the answer is immediate — S(p) = p — but already for prime powers the value is subtle and is governed by Legendre's formula (1808) for the p-adic valuation of a factorial, v_p(m!) = ∑_{i≥1} ⌊m/p^i⌋. The parent gallery entry located the *threshold* S(n) < n (composite n ≠ 4) but stopped short of computing S(n). The natural next quantity is S(p^k), the building block from which S of a general n is assembled as the maximum over the prime powers in its factorization.",
+    "problemStatement": "**Open Question (wilsons-theorem-oq-05-oq-01-oq-01):** determine the exact Kempner–Smarandache value S(n) for composite n — in particular S(p^k) for prime powers, and the role of the largest prime power dividing n — via Legendre's formula. This entry computes S(p^k) for every prime p and k ≥ 1: it is always a multiple of p, lies in [p, p·k], and equals p·k exactly when k ≤ p.",
+    "text": "For a prime p and k ≥ 1, the least m with p^k ∣ m! satisfies p ≤ S(p^k) ≤ p·k, is always a multiple of p, and equals p·k iff k ≤ p; in particular S(p) = p.",
+    "proofStrategy": "Define S m = sInf {n | m ∣ n!}; m ∣ m! gives nonemptiness, so Nat.sInf_mem/Nat.sInf_le yield the membership m ∣ (S m)! and minimality S m ≤ n. Legendre's criterion pow_dvd_factorial_iff (Nat.Prime.pow_dvd_iff_le_factorization at n = m!) turns p^k ∣ m! into k ≤ (m!).factorization p. The upper bound uses Nat.factorization_factorial_mul: (p·k)!.factorization p = (k!).factorization p + k ≥ k, so p^k ∣ (p·k)! and S(p^k) ≤ p·k. The lower bound uses Nat.Prime.dvd_factorial: p ∣ p^k ∣ (S(p^k))! forces p ≤ S(p^k). For the multiple-of-p fact, write S(p^k) = t+1; minimality makes (t!).factorization p < k while ((t+1)!).factorization p ≥ k, and the multiplicative split ((t+1)!).factorization p = (t+1).factorization p + (t!).factorization p forces (t+1).factorization p ≥ 1, i.e. p ∣ S(p^k). For the exact value: (⟸) if k ≤ p then for S(p^k) = p·t with t ≤ k, were t < k we'd have t < p, so (t!).factorization p = 0 (factorization_factorial_eq_zero_of_lt), contradicting k ≤ (t!).factorization p + t = t; hence t = k. (⟹) contrapositive: if k > p then p ∣ (k-1)! gives ((k-1)!).factorization p ≥ 1, so (p·(k-1))!.factorization p = ((k-1)!).factorization p + (k-1) ≥ k, whence S(p^k) ≤ p·(k-1) < p·k.",
+    "keyInsights": [
+      "**S(p^k) is always a multiple of p.** The p-adic valuation v_p(m!) is constant as m runs through a block between consecutive multiples of p and only jumps at multiples of p. The least m with v_p(m!) ≥ k must be exactly such a jump point, so p ∣ S(p^k). This is the precise meaning of 'the largest prime power controls S(n).'",
+      "**Legendre at multiples is the whole engine.** The identity v_p((p·n)!) = v_p(n!) + n (Nat.factorization_factorial_mul) both gives the bound v_p((p·k)!) ≥ k (so S(p^k) ≤ p·k) and, run at n = k-1, detects exactly when a smaller multiple already works.",
+      "**The closed form p·k holds precisely for k ≤ p.** S(p^k) = p·k iff (k-1)! contributes no factor of p, i.e. k-1 < p. The first failure is k = p+1: then (k-1)! = p! already carries one p, so (p·(k-1))! is divisible by p^k and S(p^k) drops below p·k. Concretely S(2^3) = 4 (not 6), S(3^4) = 9 (not 12).",
+      "**Kempner refines the parent threshold into an exact value.** Where the parent only asserted S(n) < n for composite n ≠ 4, here for n = p^k the value is pinned to the interval [p, p·k] and to an exact multiple of p, with the equality region k ≤ p fully characterized."
+    ],
+    "prerequisites": [
+      "The Kempner–Smarandache function S(n) = min{m : n ∣ m!}",
+      "Legendre's formula for v_p(n!) and Nat.factorization",
+      "Prime-power divisibility p^k ∣ n ↔ k ≤ n.factorization p",
+      "Nat.Prime.dvd_factorial and Nat.dvd_factorial",
+      "The least-element operator Nat.sInf"
+    ]
+  },
+  "conclusion": {
+    "summary": "The parent's Kempner threshold (S(n) < n iff composite n ≠ 4) is refined into an exact value for prime powers: defining S m = sInf{n | m ∣ n!}, for prime p and k ≥ 1 we prove p ≤ S(p^k) ≤ p·k, that S(p^k) is always a multiple of p, and the sharp characterization S(p^k) = p·k ⟺ k ≤ p (with S(p) = p as the k = 1 case). The engine is Legendre's formula at multiples of p, v_p((p·n)!) = v_p(n!) + n. 10 theorems, 1 definition, 168 lines, 0 sorries, 0 axioms; no native_decide.",
+    "implications": "Provides the prime-power building block S(p^k) requested by the parent, with the structural insight (always a multiple of p) that explains why S(n) is governed by the prime powers in n's factorization. The next step — assembling S(n) = max over prime powers p^k ∥ n — now reduces to combining these per-prime values with the coprime CRT for factorials.",
+    "openQuestions": [
+      "Assemble the general value: prove S(n) = max over prime powers p^k ∥ n of S(p^k), i.e. that the Kempner function is determined by its values on the prime powers in the factorization of n.",
+      "Characterize S(p^k) exactly for k > p (where the closed form p·k fails) via the greedy base-p Kempner algorithm: S(p^k) = ∑ c_i p^{n_i} where k = ∑ c_i (p^{n_i} − 1)/(p − 1) is the generalized base-p expansion."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring stating the exact prime-power value S(p^k), the always-a-multiple-of-p structure, the bounds, and the sharp boundary S(p^k) = p·k ⟺ k ≤ p; imports Mathlib, opens Nat."
+    },
+    {
+      "id": "kempner-function",
+      "title": "The Kempner–Smarandache Function",
+      "startLine": 45,
+      "endLine": 60,
+      "summary": "Defines S m = sInf {n | m ∣ n!}; dvd_factorial_S (m ∣ (S m)! for m ≥ 1, via Nat.sInf_mem and m ∣ m!) and S_le (least-witness property, via Nat.sInf_le)."
+    },
+    {
+      "id": "legendre-bounds",
+      "title": "Legendre's Formula and the Prime-Power Value",
+      "startLine": 61,
+      "endLine": 120,
+      "summary": "factorization_factorial_succ_split (multiplicative split of the valuation), pow_dvd_factorial_iff (Legendre criterion), prime_pow_dvd_factorial_mul and S_prime_pow_le (upper bound p·k), prime_le_S_prime_pow (lower bound p), and prime_dvd_S_prime_pow (S(p^k) is a multiple of p)."
+    },
+    {
+      "id": "exact-value",
+      "title": "The Exact Value and Sharp Boundary",
+      "startLine": 121,
+      "endLine": 168,
+      "summary": "S_prime_pow_eq_mul_iff: S(p^k) = p·k ⟺ k ≤ p, via Legendre at multiples and factorization_factorial_eq_zero_of_lt; S_prime: S(p) = p as the k = 1 corollary."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "wilsons-theorem-oq-05-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent proved the Kempner threshold (∃ m < n, n ∣ m!) ↔ (¬n.Prime ∧ n ≠ 4), locating when S(n) < n. This entry answers its first open question by computing the exact value S(p^k) for prime powers via Legendre's formula: the bounds [p, p·k], the always-a-multiple-of-p structure, and S(p^k) = p·k ⟺ k ≤ p."
+    },
+    {
+      "targetId": "wilsons-theorem-oq-03",
+      "relationship": "sibling",
+      "description": "oq-03 computes a single Legendre evaluation ν_p((p-1)!) = 0; this entry uses the full Legendre identity at multiples of p to pin the Kempner value S(p^k)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first registered open question** of the parent `wilsons-theorem-oq-05-oq-01-oq-01`, which proved only the Kempner *threshold* (when `S(n) < n`) but computed `S(n)` for **no** composite `n`. This entry computes the Kempner–Smarandache value `S(p^k) = min{m : p^k ∣ m!}` **exactly** for prime powers, directly from **Legendre's formula**.

Defining `S m = sInf {n | m ∣ n!}`, for a prime `p` and `k ≥ 1`:

| Result | Statement |
|---|---|
| `S_prime_pow_le` | `S(p^k) ≤ p·k` |
| `prime_le_S_prime_pow` | `p ≤ S(p^k)` |
| `prime_dvd_S_prime_pow` | **`S(p^k)` is always a multiple of `p`** |
| `S_prime_pow_eq_mul_iff` | **`S(p^k) = p·k ⟺ k ≤ p`** (headline) |
| `S_prime` | `S(p) = p` (k = 1 corollary) |

## Key ideas

- **Legendre at multiples is the whole engine.** Mathlib's `Nat.factorization_factorial_mul` gives `v_p((p·n)!) = v_p(n!) + n`. Run at `n = k` it yields `S(p^k) ≤ p·k`; run at `n = k-1` it detects exactly when a smaller multiple already works.
- **`S(p^k)` is always a multiple of `p`**: the p-adic valuation `v_p(m!)` only jumps at multiples of `p`, so the minimal `m` reaching `k` must be such a jump point. This is the precise sense in which the largest prime power controls `S(n)`.
- **The closed form `p·k` holds precisely for `k ≤ p`**: `(k-1)!` carries a factor of `p` exactly when `k-1 ≥ p`. First failure `k = p+1`; e.g. `S(2³) = 4` (not 6), `S(3⁴) = 9` (not 12).

## Verification

- **0 sorries, 0 axioms** beyond foundational `propext`, `Classical.choice`, `Quot.sound` (verified via `#print axioms`). No `decide`/`native_decide`.
- 10 theorems, 1 definition, 168 lines. Builds against Mathlib 4.26.0.

## Files
- `proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01.lean`
- `src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/meta.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)