### PR TITLE
audit(chebyshev-sum-inequality-oq-01-oq-01-oq-01): add missing meta.meta.sorries

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-01/meta.json
@@ -109,6 +109,7 @@
     "status": "verified",
     "badge": "original",
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 5,
     "definitionCount": 0,
     "lineCount": 136,


### PR DESCRIPTION
## Integrity Issue (schema-only)

**Proof**: chebyshev-sum-inequality-oq-01-oq-01-oq-01
**Problem**: `find-targets.ts` reports a phantom `sorry mismatch: claims -1, actual 0`.

## Root Cause

`find-targets.ts` reads `claimedSorries` from `meta.meta.sorries` (`?? meta.meta.sorryCount ?? -1`). This entry's `meta.meta` block had no `sorries` field, so it fell back to the `-1` sentinel and was flagged on every audit pass. The top-level `meta.sorries` and `leanFile.sorries` were already `0`.

## Verification

The Lean source `Proofs/ChebyshevSumIntegralOQ01OQ01OQ01.lean` is genuinely clean:
- 0 `sorry` / `admit` / `native_decide` (comments stripped)
- 0 `axiom` declarations
- 0 `True` stubs
- 5 theorems, matching the 5 `originalContributions` exactly (`integrable_of_bounded`, `chebyshev_integral_mul_le`, `chebyshev_integral_ge_of_antitone`, `chebyshev_integral_sq`, `chebyshev_integral_prob`)

`verified` / `original` badge is accurate — it proves the continuous Chebyshev integral (correlation) inequality absent from Mathlib, with honest `mathlibDependencies` disclosure.

## Fix

Add `"sorries": 0` to the `meta.meta` block. After the fix, `find-targets.ts --issues` reports 0 targets.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)