### PR TITLE
research(summation-by-parts-oq-01-oq-01-oq-01-oq-02): general discrete Abel transform over a commutative ring [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3537,6 +3537,7 @@ import Proofs.SumOfKthPowersOQ05OQ01OQ01
 import Proofs.SumOfOddsStatementOnly
 import Proofs.SummationByPartsOQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01
+import Proofs.SummationByPartsOQ01OQ01OQ01OQ02
 import Proofs.SylowTheorem
 import Proofs.SylowTheoremOQ01
 import Proofs.SylowTheoremOQ02

--- a/proofs/Proofs/SummationByPartsOQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/SummationByPartsOQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,126 @@
+import Mathlib.Algebra.BigOperators.Module
+import Mathlib.Tactic
+
+/-
+# The general discrete Abel transform (summation by parts) over a commutative ring
+
+## What This Proves
+
+For **any** commutative ring `R`, **any** two sequences `f, G : ℕ → R`, and
+**any** `n : ℕ`, with no side hypotheses whatsoever,
+
+    ∑_{k<n} f k · (G (k+1) − G k)
+      = f n · G n − f 0 · G 0 − ∑_{k<n} (f (k+1) − f k) · G (k+1).        (A)
+
+This is the **general discrete Abel summation by parts**.  Writing
+`Δh k = h (k+1) − h k` for the forward difference, identity (A) reads
+
+    ∑ f · ΔG = (boundary term `f·G`) − ∑ Δf · G(·+1),
+
+the exact discrete analogue of integration by parts `∫ f dG = fG − ∫ G df`.
+Here `G` plays the role of an *antidifference* (a discrete antiderivative) of the
+weight `g := ΔG`, so (A) transforms a sum weighted by `g = ΔG` into a sum
+weighted by the forward difference `Δf` of the other factor, plus an explicit
+boundary term.
+
+## Why This Is the Right Object
+
+The parent entry `SummationByPartsOQ01OQ01OQ01` proves the *geometric* special
+case — the hypothesis-free recursion
+
+    (r − 1) · ∑_{k<n} f k · rᵏ = f n · rⁿ − f 0 − ∑_{k<n} (f (k+1) − f k) · r^{k+1}.
+
+That parent recorded as an open question whether *"an analogous hypothesis-free
+recursion holds for a non-geometric base sequence … a general discrete Abel
+transform `∑ f·g = boundary − ∑ Δf·G(·+1)` packaged for reuse over a commutative
+ring."*  Identity (A) **is** that transform, and it is strictly more general: the
+geometric recursion is the single instance `G k = rᵏ`.  Indeed with `G k = rᵏ`,
+
+    G (k+1) − G k = r^{k+1} − rᵏ = rᵏ (r − 1),
+
+so the left side of (A) becomes `(r − 1) · ∑ f k · rᵏ` and (A) collapses to the
+parent identity verbatim (see `geom_weighted_recursion_of_abel`).  We also read
+off the pure telescoping identity `∑ ΔG = G n − G 0` as the `f ≡ 1` instance
+(`sum_diff_telescope`).
+
+## Relationship to Mathlib
+
+Mathlib has `Finset.sum_range_by_parts`, which is the same principle but stated
+with `g` primitive and `G j := ∑_{i<j} g i` its partial sum, using awkward `n−1`
+indexing.  Identity (A) is the cleaner *two-sequence* formulation requested by the
+open question: an **arbitrary** antidifference `G` with clean `n` indexing and a
+symmetric `f n G n − f 0 G 0` boundary.  It is proved here from scratch by a short
+induction, so the entry is self-contained and does not route through the Mathlib
+lemma.
+
+## Method
+
+Induction on `n`.  The base case `n = 0` is `simp`.  The step peels the top term
+off both finite sums with `Finset.sum_range_succ`, substitutes the induction
+hypothesis, and the remaining identity in the atoms `f m`, `f (m+1)`, `f 0`,
+`G m`, `G (m+1)`, `G 0` is polynomial and closed by `ring` (the leftover sum
+appears as a common opaque atom on both sides and cancels).
+
+## Tags
+
+summation-by-parts, abel-summation, abel-transform, finite-differences,
+discrete-integration-by-parts, telescoping, commutative-ring
+-/
+
+namespace SummationByPartsOQ01OQ01OQ01OQ02
+
+open Finset
+
+/-- **The general discrete Abel transform (A).**
+Over any commutative ring, for any sequences `f, G` and any `n`,
+`∑_{k<n} f k · (G (k+1) − G k) = f n · G n − f 0 · G 0 − ∑_{k<n} (f (k+1) − f k) · G (k+1)`.
+No hypotheses: both sides are polynomials in the sequence values. -/
+theorem abel_summation {R : Type*} [CommRing R] (f G : ℕ → R) (n : ℕ) :
+    ∑ k ∈ range n, f k * (G (k + 1) - G k)
+      = f n * G n - f 0 * G 0
+        - ∑ k ∈ range n, (f (k + 1) - f k) * G (k + 1) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [Finset.sum_range_succ (fun k => f k * (G (k + 1) - G k)), ih,
+        Finset.sum_range_succ (fun k => (f (k + 1) - f k) * G (k + 1))]
+      ring
+
+/-- **Order-swapped form.** Rearranging (A) isolates the difference-weighted sum:
+`∑_{k<n} (f (k+1) − f k) · G (k+1) = f n · G n − f 0 · G 0 − ∑_{k<n} f k · (G (k+1) − G k)`.
+This is the same identity read as "move the boundary term across", exhibiting the
+symmetry between differencing `f` and differencing `G`. -/
+theorem abel_summation_swap {R : Type*} [CommRing R] (f G : ℕ → R) (n : ℕ) :
+    ∑ k ∈ range n, (f (k + 1) - f k) * G (k + 1)
+      = f n * G n - f 0 * G 0
+        - ∑ k ∈ range n, f k * (G (k + 1) - G k) := by
+  have h := abel_summation f G n
+  linear_combination h
+
+/-- **Telescoping (bottom of the ladder).** Taking `f ≡ 1` makes every forward
+difference `Δf` vanish, so (A) collapses to the telescoping sum
+`∑_{k<n} (G (k+1) − G k) = G n − G 0`. -/
+theorem sum_diff_telescope {R : Type*} [CommRing R] (G : ℕ → R) (n : ℕ) :
+    ∑ k ∈ range n, (G (k + 1) - G k) = G n - G 0 := by
+  have h := abel_summation (fun _ => (1 : R)) G n
+  simpa using h
+
+/-- **Recovery of the parent's geometric recursion.** Specialising the
+antidifference to the geometric weight `G k = rᵏ` gives `G (k+1) − G k = rᵏ (r−1)`,
+so the general Abel transform (A) collapses to the parent entry's hypothesis-free
+identity `(r − 1)·∑_{k<n} f k · rᵏ = f n · rⁿ − f 0 − ∑_{k<n} (f (k+1) − f k)·r^{k+1}`.
+This exhibits the parent geometric recursion as the single instance `G = (· ↦ rᵏ)`
+of the general transform. -/
+theorem geom_weighted_recursion_of_abel {R : Type*} [CommRing R] (f : ℕ → R)
+    (r : R) (n : ℕ) :
+    (r - 1) * ∑ k ∈ range n, f k * r ^ k
+      = f n * r ^ n - f 0 - ∑ k ∈ range n, (f (k + 1) - f k) * r ^ (k + 1) := by
+  have h := abel_summation f (fun k => r ^ k) n
+  simp only [pow_zero, mul_one] at h
+  rw [Finset.mul_sum]
+  have e : ∀ k, (r - 1) * (f k * r ^ k) = f k * (r ^ (k + 1) - r ^ k) := by
+    intro k; rw [pow_succ]; ring
+  simp_rw [e]
+  rw [h]
+
+end SummationByPartsOQ01OQ01OQ01OQ02

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,135 @@
+{
+  "id": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+  "slug": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+  "title": "The General Discrete Abel Transform over a Commutative Ring",
+  "description": "Over any commutative ring R, for any two sequences f, G : ℕ → R and any n (no hypotheses): ∑_{k<n} f(k)·(G(k+1)−G(k)) = f(n)·G(n) − f(0)·G(0) − ∑_{k<n} (f(k+1)−f(k))·G(k+1). This is the general discrete Abel summation by parts — the exact analogue of ∫ f dG = fG − ∫ G df, with G a discrete antidifference of the weight g := ΔG. It strictly generalises the parent entry's geometric recursion, which is the single instance G(k) = rᵏ (where G(k+1)−G(k) = rᵏ(r−1)), and yields pure telescoping ∑ ΔG = G(n) − G(0) as the f ≡ 1 instance. Answers the parent entry's second open question.",
+  "overview": {
+    "historicalContext": "Abel's summation by parts is the discrete companion of integration by parts: it trades a sum weighted by a sequence $g$ for one weighted by the forward difference of the other factor, plus a boundary term. The parent entry `summation-by-parts-oq-01-oq-01-oq-01` proved the *geometric* incarnation — the hypothesis-free recursion $(r-1)\\sum f(k)r^k = f(n)r^n - f(0) - \\sum (\\Delta f)(k)\\,r^{k+1}$ — and recorded as an open question whether the same mechanism survives for a *non-geometric* base: a general discrete Abel transform $\\sum f\\cdot g = \\text{boundary} - \\sum \\Delta f\\cdot G(\\cdot+1)$, packaged for reuse over an arbitrary commutative ring. This entry supplies exactly that transform and shows the geometric recursion is its single specialisation $G(k)=r^k$.",
+    "problemStatement": "**Theorem (A).** For a commutative ring $R$, any $f, G : \\mathbb{N} \\to R$, and any $n \\in \\mathbb{N}$,\n$$\\sum_{k=0}^{n-1} f(k)\\,\\bigl(G(k+1)-G(k)\\bigr) \\;=\\; f(n)\\,G(n) - f(0)\\,G(0) \\;-\\; \\sum_{k=0}^{n-1} \\bigl(f(k+1)-f(k)\\bigr)\\,G(k+1).$$\nWriting $\\Delta h(k) = h(k+1)-h(k)$, this is $\\sum f\\cdot \\Delta G = \\bigl[f\\,G\\bigr]_0^n - \\sum \\Delta f \\cdot G(\\cdot+1)$, with $G$ a discrete antidifference of the weight $g := \\Delta G$. There are **no** side hypotheses — both sides are polynomials in the sequence values.",
+    "proofStrategy": "**Induction on $n$ (headline).** The base case $n=0$ is the empty sum on both sides. For the step, `Finset.sum_range_succ` peels the top term off both finite sums; substituting the induction hypothesis leaves an identity in the atoms $f(m), f(m+1), f(0), G(m), G(m+1), G(0)$ that is polynomial and closed by `ring` (the leftover sum appears as a common opaque atom and cancels). The proof routes through no summation-by-parts lemma, so the identity holds over an arbitrary commutative ring.\n\n**Specialisations read straight off (A).** Setting $G(k)=r^k$ gives $G(k+1)-G(k) = r^k(r-1)$, so the left side becomes $(r-1)\\sum f(k)r^k$ and (A) collapses verbatim to the parent's geometric recursion. Setting $f\\equiv 1$ kills every $\\Delta f$ and gives the pure telescoping identity $\\sum (G(k+1)-G(k)) = G(n)-G(0)$.",
+    "keyInsights": [
+      "**The geometric recursion is one instance.** With $G(k)=r^k$, $G(k+1)-G(k)=r^k(r-1)$, so $\\sum f(k)\\,\\Delta G(k) = (r-1)\\sum f(k)r^k$ and (A) becomes the parent's $(r-1)\\sum f(k)r^k = f(n)r^n - f(0) - \\sum \\Delta f(k)\\,r^{k+1}$ on the nose. The geometric weight was never essential — only that $r^k$ is a closed-form antidifference.",
+      "**Antidifference, not partial sum.** Mathlib's `Finset.sum_range_by_parts` states the same principle with the weight $g$ primitive and $G$ forced to be its partial sum $\\sum_{i<j} g(i)$, with awkward $n-1$ indexing. Taking $G$ as an *arbitrary* antidifference with $g=\\Delta G$ gives the cleaner two-sequence form, clean $n$ indexing, and the symmetric boundary $f(n)G(n)-f(0)G(0)$ — the formulation the open question requested.",
+      "**Discrete integration by parts.** (A) is the finite-sum shadow of $\\int u\\,dv = uv - \\int v\\,du$: $f$ is $u$, $\\Delta G$ is $dv$, $G$ is $v$, and $\\Delta f$ is $du$. The boundary cocycle $f(n)G(n)-f(0)G(0)$ is the evaluated $[uv]$ term, and the symmetry between differencing $f$ and differencing $G$ is the order-swapped form."
+    ]
+  },
+  "sections": [
+    {
+      "id": "general-abel-transform",
+      "title": "The General Discrete Abel Transform",
+      "startLine": 74,
+      "endLine": 98,
+      "summary": "abel_summation: ∑_{k<n} f(k)·(G(k+1)−G(k)) = f(n)·G(n) − f(0)·G(0) − ∑_{k<n} (f(k+1)−f(k))·G(k+1) for any f, G, n over any CommRing, by induction with sum_range_succ + ring. abel_summation_swap rearranges (A) to isolate the difference-weighted sum, exhibiting the f ↔ G symmetry.",
+      "mathContext": "The inductive step, after peeling the top term off both sums via Finset.sum_range_succ and substituting the IH, is a polynomial identity in f(m), f(m+1), f(0), G(m), G(m+1), G(0) closed by ring — no division and no hypotheses, so the identity lives over an arbitrary commutative ring. The swap form is a one-line linear_combination of (A), valid without any order on R."
+    },
+    {
+      "id": "telescoping",
+      "title": "Telescoping as the f ≡ 1 Instance",
+      "startLine": 100,
+      "endLine": 106,
+      "summary": "sum_diff_telescope: ∑_{k<n} (G(k+1)−G(k)) = G(n) − G(0), the bottom of the ladder where every forward difference Δf vanishes, obtained by specialising (A) at f ≡ 1.",
+      "mathContext": "With f ≡ 1 the correction sum ∑ Δf(k)·G(k+1) is identically zero and the boundary collapses to G(n) − G(0); simpa discharges the specialisation."
+    },
+    {
+      "id": "geometric-recovery",
+      "title": "Recovering the Parent's Geometric Recursion",
+      "startLine": 108,
+      "endLine": 125,
+      "summary": "geom_weighted_recursion_of_abel: specialising the antidifference to G(k) = rᵏ gives G(k+1)−G(k) = rᵏ(r−1), so (A) collapses to the parent entry's hypothesis-free identity (r−1)·∑_{k<n} f(k)·rᵏ = f(n)·rⁿ − f(0) − ∑_{k<n} (f(k+1)−f(k))·r^{k+1}. This exhibits the parent geometric recursion as the single instance G = (· ↦ rᵏ) of the general transform.",
+      "mathContext": "After mul_sum and rewriting (r−1)·(f(k)·rᵏ) = f(k)·(r^{k+1} − rᵏ) via pow_succ + ring, the goal matches (A) instantiated at G(k)=rᵏ with G(0)=r⁰=1; rw closes it."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves the general discrete Abel transform ∑_{k<n} f(k)·(G(k+1)−G(k)) = f(n)·G(n) − f(0)·G(0) − ∑_{k<n} (f(k+1)−f(k))·G(k+1), valid for any two sequences f, G over any commutative ring with no hypotheses, and reads off both pure telescoping (f ≡ 1) and the parent's geometric recursion (G(k) = rᵏ) as instances. It answers the parent entry's second open question: the hypothesis-free Abel mechanism is not special to a geometric base — it holds for an arbitrary antidifference G, packaged for reuse over a commutative ring.",
+    "implications": "The transform is the discrete, finite analogue of integration by parts ∫ f dG = fG − ∫ G df, and subsumes the parent's geometric recursion (hence the whole ∑ kᵐ rᵏ ladder) as the case G(k) = rᵏ. Because it carries no hypotheses and lives over any commutative ring with an arbitrary antidifference, it is reusable infrastructure for any future entry needing a closed form for a sum against a sequence with a known antidifference — q-analogues, falling-factorial weights, or any g = ΔG.",
+    "openQuestions": [
+      "Can (A) be iterated against a tower of antidifferences G₀ = f, G₁, G₂, … (repeated discrete integration by parts) to give a finite Taylor–Abel expansion ∑ f(k)·ΔG(k) = Σ boundary terms ± ∑ Δᵈf · G_d, the discrete analogue of the integration-by-parts series?",
+      "Does (A) extend, with the same induction, to a non-commutative ring or to a bimodule-valued pairing f(k) · (G(k+1) − G(k)) where f and G take values in different modules, provided the multiplication order is fixed?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "summation-by-parts-oq-01-oq-01-oq-01",
+      "relationship": "extension",
+      "description": "The parent entry proves the geometric recursion (r−1)·∑ f(k)·rᵏ = f(n)·rⁿ − f(0) − ∑ Δf(k)·r^{k+1}. This entry generalises it to an arbitrary antidifference G and recovers the parent identity verbatim as the instance G(k) = rᵏ (geom_weighted_recursion_of_abel). Answers the parent's second open question."
+    },
+    {
+      "targetId": "summation-by-parts-oq-01-oq-01",
+      "relationship": "extension",
+      "description": "The grandparent derives the closed form ∑_{k<n} k²·rᵏ by a hand summation-by-parts step. That step is the instance f(k)=k², G(k)=rᵏ of the general transform proved here."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "foundation",
+      "description": "The geometric series is the doubly-special case f ≡ 1, G(k) = rᵏ: telescoping (sum_diff_telescope) gives ∑ (r^{k+1} − rᵏ) = rⁿ − 1, the boundary content of (rⁿ−1)/(r−1)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Module",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SummationByPartsOQ01OQ01OQ01OQ02",
+    "lineCount": 126,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "sorries": 0,
+    "path": "Proofs/SummationByPartsOQ01OQ01OQ01OQ02.lean"
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Classical (Abel summation by parts); formalized for the lean-genius gallery",
+    "sourceUrl": "https://github.com/leanprover-community/mathlib4",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SummationByPartsOQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "finite-sums",
+      "summation-by-parts",
+      "abel-summation",
+      "abel-transform",
+      "finite-differences",
+      "discrete-integration-by-parts",
+      "telescoping",
+      "commutative-ring",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — the step driving the induction on both the weighted sum and the forward-difference sum",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.mul_sum",
+        "description": "Pulls the scalar (r−1) into the sum to match the Abel-transform left side when recovering the geometric recursion",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "pow_succ",
+        "description": "r^(k+1) = r^k * r — turns the geometric antidifference G(k+1)−G(k) into r^k(r−1) for the parent-recursion recovery",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The general discrete Abel transform ∑_{k<n} f(k)·(G(k+1)−G(k)) = f(n)·G(n) − f(0)·G(0) − ∑_{k<n} (f(k+1)−f(k))·G(k+1), valid for any two sequences f, G : ℕ → R over any commutative ring with no hypotheses, proved directly by induction (no summation-by-parts black box) — the two-sequence formulation with an arbitrary antidifference G requested by the parent's open question, cleaner than Mathlib's Finset.sum_range_by_parts (which forces G to be the partial sum of g and uses n−1 indexing)",
+      "Explicit recovery of the parent entry's geometric recursion as the single instance G(k) = rᵏ: since G(k+1)−G(k) = rᵏ(r−1), the transform collapses verbatim to (r−1)·∑ f(k)·rᵏ = f(n)·rⁿ − f(0) − ∑ Δf(k)·r^{k+1}, showing the geometric weight was never essential",
+      "The pure telescoping identity ∑_{k<n} (G(k+1)−G(k)) = G(n) − G(0) as the f ≡ 1 instance, and the order-swapped form isolating ∑ Δf(k)·G(k+1), exhibiting the f ↔ G symmetry of discrete integration by parts",
+      "Answers the second open question recorded by summation-by-parts-oq-01-oq-01-oq-01: the hypothesis-free Abel mechanism holds for a non-geometric base, packaged for reuse over a commutative ring with an arbitrary antidifference"
+    ],
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 126,
+    "theoremCount": 4,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound; no native_decide, no Lean.ofReduceBool).",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `summation-by-parts-oq-01-oq-01-oq-01`: whether the parent's hypothesis-free geometric recursion extends to a **non-geometric base** — a general discrete Abel transform packaged for reuse over a commutative ring.

**Theorem (A).** For any commutative ring `R`, any sequences `f, G : ℕ → R`, and any `n` (no hypotheses):
```
∑_{k<n} f(k)·(G(k+1) − G(k)) = f(n)·G(n) − f(0)·G(0) − ∑_{k<n} (f(k+1) − f(k))·G(k+1)
```
This is the general discrete Abel summation by parts — the finite analogue of `∫ f dG = fG − ∫ G df`, with `G` an arbitrary discrete antidifference of the weight `g := ΔG`.

## Why this is the right object
- **Recovers the parent verbatim.** Setting `G(k) = rᵏ` gives `G(k+1) − G(k) = rᵏ(r−1)`, so (A) collapses to the parent's `(r−1)·∑ f(k)·rᵏ = f(n)·rⁿ − f(0) − ∑ Δf(k)·r^{k+1}` (`geom_weighted_recursion_of_abel`). The geometric weight was never essential.
- **Telescoping** `∑ (G(k+1) − G(k)) = G(n) − G(0)` is the `f ≡ 1` instance (`sum_diff_telescope`).
- **Cleaner than Mathlib's `Finset.sum_range_by_parts`**, which forces `G` to be the partial sum of `g` with `n−1` indexing. The two-sequence formulation with an arbitrary antidifference and symmetric boundary `f(n)G(n) − f(0)G(0)` is exactly what the open question requested; proved from scratch by induction, so the entry is self-contained.

## Verification
- **4 theorems, 0 definitions, 0 sorries.**
- **0-axiom**: `#print axioms` lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Builds against Mathlib 4.26.0 (`lake env lean`, exit 0).
- Imports only `Mathlib.Algebra.BigOperators.Module` + `Mathlib.Tactic`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)