### PR TITLE
Enrich Reparametrization Invariance of Arc Length and Signed Area

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-integrands",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 69 },
+    "type": "definition",
+    "title": "The Two Geometric Integrands",
+    "content": "`speedFn x y u = √(x'(u)² + y'(u)²)` is the arc-length (speed) integrand whose integral over one period is the curve's circumference; `areaFn x y u = x(u)·y'(u) − y(u)·x'(u)` is the Green's-theorem integrand whose integral over one period is twice the signed enclosed area. Both invariance theorems are stated directly about these two functions of the coordinate maps x, y, keeping the proof free of any curve structure so it can be reused as the analytic core of the parent's reparametrization axiom.",
+    "mathContext": "$\\text{speedFn} = \\sqrt{x'^2 + y'^2}$ (circumference integrand); $\\text{areaFn} = x\\,y' - y\\,x'$ (twice signed area).",
+    "significance": "context",
+    "relatedConcepts": ["arc length", "signed area", "Green's theorem", "curve integrals"],
+    "prerequisites": ["derivatives", "interval integrals", "plane curves"]
+  },
+  {
+    "id": "ann-periodic-deriv",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 104 },
+    "type": "technique",
+    "title": "The Derivative of a Periodic Function Is Periodic",
+    "content": "`periodic_deriv` proves that if f is T-periodic then deriv f is too — and remarkably, using ONLY deriv_comp_add_const and the period identity f(·+T) = f, with no differentiability hypothesis (if f isn't differentiable both sides are the junk value 0). `speedFn_periodic` and `areaFn_periodic` then lift periodicity of the coordinates x, y to the two integrands, since each is built from x, y and their derivatives. This periodicity is exactly what step 3 of each invariance proof needs to collapse a shifted one-period integral.",
+    "mathContext": "$f(\\cdot + T) = f \\Rightarrow (\\deriv f)(\\cdot + T) = \\deriv f$; hence speedFn, areaFn are $2\\pi$-periodic.",
+    "significance": "supporting",
+    "relatedConcepts": ["periodic function", "deriv_comp_add_const", "periodicity of derivative"],
+    "prerequisites": ["periodic functions", "derivatives"]
+  },
+  {
+    "id": "ann-chain-rule",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 112 },
+    "type": "technique",
+    "title": "Chain Rule Exposing the Jacobian Factor",
+    "content": "`deriv_coord_comp` packages the chain rule (x∘φ)'(t) = x'(φ t)·φ'(t) for C¹ data via deriv_comp and ContDiff.differentiable. This pointwise identity is the linchpin: substituting it into both integrands of the reparametrized curve γ∘φ factors out the Jacobian φ'(t), which is precisely the factor the change-of-variables theorem integral_comp_mul_deriv consumes.",
+    "mathContext": "$(x \\circ \\varphi)'(t) = x'(\\varphi(t)) \\cdot \\varphi'(t)$ for $C^1$ data.",
+    "significance": "supporting",
+    "relatedConcepts": ["chain rule", "deriv_comp", "ContDiff", "Jacobian"],
+    "prerequisites": ["chain rule", "differentiability"]
+  },
+  {
+    "id": "ann-arclength",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 114, "endLine": 154 },
+    "type": "insight",
+    "title": "Arc Length Invariance (Monotonicity Needed Under the Root)",
+    "content": "`arclength_reparam_invariant` runs the three-step pattern. Step 1: the speed of γ∘φ factors as √(φ'²·(speed∘φ)²) = φ'·(speed∘φ), where dropping the absolute value via Real.sqrt_sq REQUIRES φ' ≥ 0 — this is the one place the increasing hypothesis hmono is used (a decreasing φ would introduce |φ'| = −φ'). Step 2: integral_comp_mul_deriv substitutes u = φ(t), turning ∫₀²π into ∫_{φ0}^{φ(2π)}. Step 3: the period-commuting condition φ(2π) = φ0 + 2π makes this an integral over one full period, which speedFn_periodic + Function.Periodic.intervalIntegral_add_eq collapse back to ∫₀²π. So the circumference is unchanged.",
+    "mathContext": "$\\int_0^{2\\pi}\\!\\sqrt{(x\\circ\\varphi)'^2 + (y\\circ\\varphi)'^2} = \\int_0^{2\\pi}\\!\\sqrt{x'^2+y'^2}$, using $\\varphi' \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": ["arc length", "change of variables", "integral_comp_mul_deriv", "Real.sqrt_sq", "period shift"],
+    "prerequisites": ["change of variables", "square roots", "monotone reparametrization"]
+  },
+  {
+    "id": "ann-signed-area",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 156, "endLine": 194 },
+    "type": "insight",
+    "title": "Signed Area Invariance (No Monotonicity Required)",
+    "content": "`signed_area_reparam_invariant` follows the identical change-of-variables route, but with a telling difference: the Jacobian φ' enters the area integrand LINEARLY (no square root), so the algebra goes through for ANY C¹ period-commuting φ — no φ' ≥ 0 hypothesis. This reflects the geometry: signed area is sensitive to orientation, and a non-monotone reparametrization that locally reverses and re-traverses the curve cancels its own contributions, leaving the net signed area unchanged. Equality of the Green's-theorem integrals over a period gives equality of the signed areas of γ∘φ and γ.",
+    "mathContext": "$\\int_0^{2\\pi}\\!\\big((x\\circ\\varphi)(y\\circ\\varphi)' - (y\\circ\\varphi)(x\\circ\\varphi)'\\big) = \\int_0^{2\\pi}\\!(xy' - yx')$, for any $C^1$ $\\varphi$.",
+    "significance": "key",
+    "relatedConcepts": ["signed area", "orientation", "Green's theorem", "change of variables", "linearity in the Jacobian"],
+    "prerequisites": ["change of variables", "signed area", "orientation of curves"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ01OQ02OQ02OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ01OQ02OQ02OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ01OQ02OQ02OQ01OQ01Data: ProofData = {
+  proof: areaOfCircleOQ01OQ02OQ02OQ01OQ01Proof,
+  annotations: areaOfCircleOQ01OQ02OQ02OQ01OQ01Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -82,24 +82,51 @@
   },
   "sections": [
     {
+      "id": "integrands",
+      "title": "The Speed and Area Integrands",
+      "startLine": 61,
+      "endLine": 69,
+      "summary": "speedFn x y u = √(x'(u)² + y'(u)²) is the arc-length integrand (its integral over a period is the circumference); areaFn x y u = x(u)·y'(u) − y(u)·x'(u) is the Green's-theorem integrand (its integral over a period is twice the signed area). The two invariance theorems are stated about these."
+    },
+    {
       "id": "part-i",
-      "title": "Periodicity of the derivative",
-      "text": "`periodic_deriv` shows that if f is T-periodic then so is deriv f, using only `deriv_comp_add_const` and the period identity. `speedFn_periodic` and `areaFn_periodic` then lift periodicity of the coordinates to the arc-length and signed-area integrands."
+      "title": "Periodicity of the Derivative",
+      "startLine": 71,
+      "endLine": 104,
+      "summary": "periodic_deriv: if f is T-periodic then so is deriv f, using only deriv_comp_add_const and the period identity (no differentiability hypothesis). speedFn_periodic and areaFn_periodic lift periodicity of the coordinates to the two integrands — the property that lets the period-shift lemma close both integrals."
     },
     {
       "id": "part-ii",
-      "title": "Chain rule for coordinate compositions",
-      "text": "`deriv_coord_comp` packages the chain rule (x∘φ)'(t) = x'(φ t)·φ'(t) for C¹ data, the pointwise identity that exposes the Jacobian factor φ' in both integrands."
+      "title": "Chain Rule for Coordinate Compositions",
+      "startLine": 106,
+      "endLine": 112,
+      "summary": "deriv_coord_comp packages the chain rule (x∘φ)'(t) = x'(φ t)·φ'(t) for C¹ data, the pointwise identity that exposes the Jacobian factor φ' in both integrands."
     },
     {
       "id": "part-iii",
-      "title": "Arc length invariance",
-      "text": "`arclength_reparam_invariant`: factor the speed as φ'·(speed∘φ) (using φ' ≥ 0 to drop the absolute value under the square root), substitute u = φ(t), and collapse the resulting one-period integral with the period-shift lemma."
+      "title": "Arc Length Invariance",
+      "startLine": 114,
+      "endLine": 154,
+      "summary": "arclength_reparam_invariant: factor the speed of γ∘φ as φ'·(speed∘φ) — using φ' ≥ 0 to drop the absolute value under the square root (Real.sqrt_sq) — substitute u = φ(t) via integral_comp_mul_deriv, and collapse the resulting one-period integral [φ0, φ0+2π] back to [0,2π] with the period-shift lemma."
     },
     {
       "id": "part-iv",
-      "title": "Signed area invariance",
-      "text": "`signed_area_reparam_invariant`: the same substitution, but the φ' factor is linear so no monotonicity is required. Equality of the Green's-theorem integrals yields equality of the signed areas."
+      "title": "Signed Area Invariance",
+      "startLine": 156,
+      "endLine": 194,
+      "summary": "signed_area_reparam_invariant: the same change of variables, but the φ' factor enters linearly so NO monotonicity hypothesis on φ is needed. Equality of the Green's-theorem integrals over a period yields equality of the signed areas of γ∘φ and γ."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent isoperimetric entry whose central axiom exists_nice_reparam assumes a constant-speed reparametrization preserving circumference and area. This entry proves the change-of-variables heart of that axiom — that arc length and signed area are reparametrization invariants — as standalone 0-axiom theorems, removing the circularity the surveys flagged (the axiom only required the witness to SHARE γ's invariants, not to BE a reparametrization)."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "extended-by",
+      "description": "The capstone that assembles the fully axiom-free isoperimetric inequality for regular closed curves. It consumes the circumference/area-preservation supplied here (through the inverse-function-theorem reparametrization companion) to discharge exists_nice_reparam and feed the analytic bounds into the algebraic kernel."
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01`. Strong structured overview already present; this adds the missing annotations and conforms the sections.

## Changes
- **Created `annotations.json`** — 5 annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the two integrands, the periodicity-of-derivative lemma, the chain-rule Jacobian factor, and the two invariance theorems (highlighting why arc length needs φ' ≥ 0 under the square root while signed area does not).
- **Fixed the `sections`** to conform to `ProofSection` (`startLine`/`endLine`/`summary`; prior used a non-standard `text` field) and added an integrands section.
- **Added top-level `crossReferences`** to the parent `...-oq-02-oq-01` and the axiom-free capstone `...-oq-01-oq-02`.
- **Created `index.ts`** for consistency with sibling entries.

`pnpm build` passes (exit 0).