### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-01-oq-02): strict weighted Chebyshev sum inequality and its equality case [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -679,6 +679,7 @@ import Proofs.ChebyshevPNTBridgeOQ03
 import Proofs.ChebyshevPolynomialsOQ01
 import Proofs.ChebyshevSumMonotoneOQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01
+import Proofs.ChebyshevSumWeightedOQ01OQ01OQ02
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ05

--- a/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01OQ02.lean
@@ -1,0 +1,283 @@
+import Mathlib
+
+/-
+# Strict Weighted Chebyshev Sum Inequality and its Equality Case
+
+The parent entry `ChebyshevSumWeightedOQ01OQ01` proves the (non-strict) weighted
+Chebyshev sum inequality
+
+  (∑ᵢ wᵢfᵢ)(∑ᵢ wᵢgᵢ)  ≤  (∑ᵢ wᵢ)(∑ᵢ wᵢfᵢgᵢ)
+
+for nonnegative weights `w` and similarly sorted (`MonovaryOn`) data `f`, `g`.
+Its engine is the **weighted monovariance identity**
+
+  ∑ᵢ ∑ⱼ wᵢwⱼ(fᵢ − fⱼ)(gᵢ − gⱼ)
+    = 2[(∑ᵢ wᵢ)(∑ᵢ wᵢfᵢgᵢ) − (∑ᵢ wᵢfᵢ)(∑ᵢ wᵢgᵢ)],
+
+which writes the **Chebyshev defect** `D = (∑wᵢ)(∑wᵢfᵢgᵢ) − (∑wᵢfᵢ)(∑wᵢgᵢ)` as
+*half a sum of nonnegative cross terms* `wᵢwⱼ(fᵢ − fⱼ)(gᵢ − gⱼ) ≥ 0`.
+
+That representation does more than prove `D ≥ 0`; it pins down exactly *when the
+inequality is tight* and *when it is strict*:
+
+* **Equality** holds iff **every** cross term vanishes
+  (`weighted_chebyshev_eq_iff`).  A sum of nonnegative reals is zero iff each
+  summand is zero (`Finset.sum_eq_zero_iff_of_nonneg`).  With strictly positive
+  weights this simplifies to: there is no pair `i, j ∈ s` on which `f` and `g`
+  *both* strictly vary (`weighted_chebyshev_eq_iff_of_pos`).  In particular the
+  inequality degenerates to equality whenever `f` or `g` is constant on `s`.
+
+* **Strictness** holds as soon as a *single* positively weighted pair has a
+  strictly positive cross term (`weighted_chebyshev_strict`), e.g. two indices
+  `a, b ∈ s` with `wₐ, w_b > 0` at which `f` and `g` both genuinely differ
+  (`weighted_chebyshev_strict_of_ne`).  This uses `Finset.sum_pos'`: a sum of
+  nonnegative reals is positive once one summand is.
+
+Neither the equality characterisation nor the strict inequality is in Mathlib
+(whose Chebyshev file `Mathlib/Algebra/Order/Chebyshev.lean` records only the
+non-strict unweighted bound).  All results are over `ℝ`, fully verified, no
+`sorry`, no extra axioms.
+-/
+
+namespace ChebyshevSumWeightedStrict
+
+open Finset
+
+-- The algebraic identity needs no order structure; the sign and order facts use ℝ.
+set_option linter.unusedSectionVars false
+
+variable {ι : Type*} {s : Finset ι} {w f g : ι → ℝ}
+
+/-! ## Sign lemmas for monovarying pairs -/
+
+/-- If `f` and `g` monovary on `s`, the cross product `(fᵢ − fⱼ)(gᵢ − gⱼ)` is
+nonnegative for all `i, j ∈ s`: the two factors carry the same sign. -/
+theorem sub_mul_sub_nonneg_of_monovaryOn (hfg : MonovaryOn f g s) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) : 0 ≤ (f i - f j) * (g i - g j) := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · have hf : f i ≤ f j := hfg hi hj h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f j - f i)
+      (by linarith : (0 : ℝ) ≤ g j - g i)]
+  · have : g i - g j = 0 := by linarith
+    rw [this, mul_zero]
+  · have hf : f j ≤ f i := hfg hj hi h
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ f i - f j)
+      (by linarith : (0 : ℝ) ≤ g i - g j)]
+
+/-- If `f` and `g` monovary on `s` and **both** genuinely differ at `i, j ∈ s`
+(`f i ≠ f j` and `g i ≠ g j`), the cross product is *strictly* positive. -/
+theorem sub_mul_sub_pos_of_monovaryOn (hfg : MonovaryOn f g s) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) (hf : f i ≠ f j) (hg : g i ≠ g j) :
+    0 < (f i - f j) * (g i - g j) := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · have hfle : f i ≤ f j := hfg hi hj h
+    have hflt : f i < f j := lt_of_le_of_ne hfle hf
+    nlinarith [mul_pos (by linarith : (0 : ℝ) < f j - f i)
+      (by linarith : (0 : ℝ) < g j - g i)]
+  · exact absurd h hg
+  · have hfle : f j ≤ f i := hfg hj hi h
+    have hflt : f j < f i := lt_of_le_of_ne hfle (Ne.symm hf)
+    nlinarith [mul_pos (by linarith : (0 : ℝ) < f i - f j)
+      (by linarith : (0 : ℝ) < g i - g j)]
+
+/-- Each weighted cross term is nonnegative (nonnegative weights, monovariance). -/
+theorem term_nonneg (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 ≤ w i) {i j : ι}
+    (hi : i ∈ s) (hj : j ∈ s) : 0 ≤ w i * w j * ((f i - f j) * (g i - g j)) := by
+  have h := sub_mul_sub_nonneg_of_monovaryOn hfg hi hj
+  have hwi := hw i hi
+  have hwj := hw j hj
+  positivity
+
+/-! ## The weighted monovariance identity (defect = ½ the double sum) -/
+
+/-- **Weighted monovariance identity.** The symmetric double sum of
+`wᵢwⱼ(fᵢ − fⱼ)(gᵢ − gⱼ)` equals twice the Chebyshev defect. Holds for arbitrary
+real data — no sign or monotonicity hypothesis. -/
+theorem two_mul_chebyshev_defect_eq (w f g : ι → ℝ) (s : Finset ι) :
+    ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))
+      = 2 * ((∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i)
+        - 2 * ((∑ i ∈ s, w i * f i) * ∑ i ∈ s, w i * g i) := by
+  have h1 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g i)
+      = (∑ i ∈ s, w i * f i * g i) * ∑ j ∈ s, w j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h2 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g j)
+      = (∑ i ∈ s, w i) * ∑ j ∈ s, w j * f j * g j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h3 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g j)
+      = (∑ i ∈ s, w i * f i) * ∑ j ∈ s, w j * g j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have h4 : ∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g i)
+      = (∑ i ∈ s, w i * g i) * ∑ j ∈ s, w j * f j := by
+    rw [Finset.sum_mul_sum]
+    exact Finset.sum_congr rfl fun i _ => Finset.sum_congr rfl fun j _ => by ring
+  have hsplit : ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))
+      = (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g i))
+        - (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f i * g j))
+        - (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g i))
+        + (∑ i ∈ s, ∑ j ∈ s, w i * w j * (f j * g j)) := by
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [← Finset.sum_sub_distrib, ← Finset.sum_sub_distrib, ← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun j _ => by ring
+  rw [hsplit, h1, h2, h3, h4]
+  ring
+
+/-! ## The non-strict inequality (recalled, self-contained) -/
+
+/-- **Weighted Chebyshev sum inequality.** For nonnegative weights and monovarying
+`f`, `g`, the product of the weighted sums is at most total weight times the
+weighted sum of products. -/
+theorem weighted_sum_mul_sum_le (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i := by
+  have hD : 0 ≤ ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) :=
+    Finset.sum_nonneg fun i hi => Finset.sum_nonneg fun j hj => term_nonneg hfg hw hi hj
+  rw [two_mul_chebyshev_defect_eq] at hD
+  linarith
+
+/-! ## The equality case -/
+
+/-- **Equality case.** Under monovariance with nonnegative weights, the weighted
+Chebyshev inequality is an *equality* iff every weighted cross term vanishes. -/
+theorem weighted_chebyshev_eq_iff (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+        = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ↔ ∀ i ∈ s, ∀ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) = 0 := by
+  have key : (∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j))) = 0
+      ↔ ∀ i ∈ s, ∀ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) = 0 := by
+    rw [Finset.sum_eq_zero_iff_of_nonneg
+      (fun i hi => Finset.sum_nonneg fun j hj => term_nonneg hfg hw hi hj)]
+    apply forall_congr'; intro i
+    apply imp_congr_right; intro hi
+    exact Finset.sum_eq_zero_iff_of_nonneg fun j hj => term_nonneg hfg hw hi hj
+  rw [← key, two_mul_chebyshev_defect_eq]
+  constructor <;> intro h <;> linarith
+
+/-- **Equality case, strictly positive weights.** When all weights are positive,
+equality holds iff there is no pair `i, j ∈ s` on which `f` and `g` both strictly
+vary: `(fᵢ − fⱼ)(gᵢ − gⱼ) = 0` for all `i, j ∈ s`. -/
+theorem weighted_chebyshev_eq_iff_of_pos (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 < w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+        = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ↔ ∀ i ∈ s, ∀ j ∈ s, (f i - f j) * (g i - g j) = 0 := by
+  rw [weighted_chebyshev_eq_iff hfg (fun i hi => (hw i hi).le)]
+  apply forall_congr'; intro i; apply imp_congr_right; intro hi
+  apply forall_congr'; intro j; apply imp_congr_right; intro hj
+  constructor
+  · intro h
+    have hwij : w i * w j ≠ 0 := ne_of_gt (mul_pos (hw i hi) (hw j hj))
+    exact (mul_eq_zero.mp h).resolve_left hwij
+  · intro h; rw [h, mul_zero]
+
+/-- **Equality case, human-readable form.** With strictly positive weights, the
+weighted Chebyshev inequality is an *equality* iff `f` is constant on `s` **or**
+`g` is constant on `s`. This is the form recorded in the parent's open question:
+the termwise condition `(fᵢ − fⱼ)(gᵢ − gⱼ) = 0` for all `i, j ∈ s` is, under
+monovariance, equivalent to one of the two sequences being constant. -/
+theorem weighted_chebyshev_eq_iff_const (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 < w i) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+        = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i
+      ↔ (∀ i ∈ s, ∀ j ∈ s, f i = f j) ∨ (∀ i ∈ s, ∀ j ∈ s, g i = g j) := by
+  rw [weighted_chebyshev_eq_iff_of_pos hfg hw]
+  constructor
+  · intro H
+    -- From a vanishing cross product: distinct `f` forces equal `g`, and vice versa.
+    have hFG : ∀ p ∈ s, ∀ q ∈ s, f p ≠ f q → g p = g q := fun p hp q hq hpq => by
+      rcases mul_eq_zero.mp (H p hp q hq) with h | h
+      · exact absurd (sub_eq_zero.mp h) hpq
+      · exact sub_eq_zero.mp h
+    have hGF : ∀ p ∈ s, ∀ q ∈ s, g p ≠ g q → f p = f q := fun p hp q hq hpq => by
+      rcases mul_eq_zero.mp (H p hp q hq) with h | h
+      · exact sub_eq_zero.mp h
+      · exact absurd (sub_eq_zero.mp h) hpq
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨⟨a, ha, b, hb, hab⟩, ⟨c, hc, d, hd, hcd⟩⟩ := hcon
+    have hgab : g a = g b := hFG a ha b hb hab
+    by_cases hac : g a = g c
+    · have had : g a ≠ g d := by rw [hac]; exact hcd
+      have hfad : f a = f d := hGF a ha d hd had
+      have hbd : g b ≠ g d := by rw [← hgab, hac]; exact hcd
+      have hfbd : f b = f d := hGF b hb d hd hbd
+      exact hab (hfad.trans hfbd.symm)
+    · have hfac : f a = f c := hGF a ha c hc hac
+      have hbc : g b ≠ g c := by rw [← hgab]; exact hac
+      have hfbc : f b = f c := hGF b hb c hc hbc
+      exact hab (hfac.trans hfbc.symm)
+  · rintro (hf | hg) i hi j hj
+    · rw [hf i hi j hj]; ring
+    · rw [hg i hi j hj]; ring
+
+/-- If `f` is constant on `s`, the inequality degenerates to equality. -/
+theorem weighted_chebyshev_eq_of_const_left (hfg : MonovaryOn f g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hf : ∀ i ∈ s, ∀ j ∈ s, f i = f j) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i := by
+  rw [weighted_chebyshev_eq_iff hfg hw]
+  intro i hi j hj
+  rw [hf i hi j hj]; ring
+
+/-- If `g` is constant on `s`, the inequality degenerates to equality. -/
+theorem weighted_chebyshev_eq_of_const_right (hfg : MonovaryOn f g s)
+    (hw : ∀ i ∈ s, 0 ≤ w i) (hg : ∀ i ∈ s, ∀ j ∈ s, g i = g j) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i := by
+  rw [weighted_chebyshev_eq_iff hfg hw]
+  intro i hi j hj
+  rw [hg i hi j hj]; ring
+
+/-! ## The strict inequality -/
+
+/-- **Strict weighted Chebyshev sum inequality.** If two positively weighted
+indices `a, b ∈ s` have a strictly positive cross product, the inequality is
+strict. -/
+theorem weighted_chebyshev_strict (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 ≤ w i)
+    {a b : ι} (ha : a ∈ s) (hb : b ∈ s) (hwa : 0 < w a) (hwb : 0 < w b)
+    (hab : 0 < (f a - f b) * (g a - g b)) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      < (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i := by
+  have hDpos : 0 < ∑ i ∈ s, ∑ j ∈ s, w i * w j * ((f i - f j) * (g i - g j)) := by
+    refine Finset.sum_pos'
+      (fun i hi => Finset.sum_nonneg fun j hj => term_nonneg hfg hw hi hj) ⟨a, ha, ?_⟩
+    refine Finset.sum_pos' (fun j hj => term_nonneg hfg hw ha hj) ⟨b, hb, ?_⟩
+    exact mul_pos (mul_pos hwa hwb) hab
+  rw [two_mul_chebyshev_defect_eq] at hDpos
+  linarith
+
+/-- **Strict inequality from a genuinely varying positively weighted pair.** If
+`a, b ∈ s` have positive weights and `f`, `g` both differ there, the inequality is
+strict. -/
+theorem weighted_chebyshev_strict_of_ne (hfg : MonovaryOn f g s) (hw : ∀ i ∈ s, 0 ≤ w i)
+    {a b : ι} (ha : a ∈ s) (hb : b ∈ s) (hwa : 0 < w a) (hwb : 0 < w b)
+    (hf : f a ≠ f b) (hg : g a ≠ g b) :
+    (∑ i ∈ s, w i * f i) * (∑ i ∈ s, w i * g i)
+      < (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i * g i :=
+  weighted_chebyshev_strict hfg hw ha hb hwa hwb
+    (sub_mul_sub_pos_of_monovaryOn hfg ha hb hf hg)
+
+/-! ## Worked instances -/
+
+/- Concrete **strict** instance: unit weights on `{0, 1, 2}` with `f = g = id`.
+`(0+1+2)² = 9 < 3·(0²+1²+2²) = 3·5 = 15`, witnessed by the strict variation at
+`a = 0`, `b = 1`. -/
+set_option linter.unusedVariables false in
+example :
+    (∑ i ∈ range 3, (1 : ℝ) * (i : ℝ)) * (∑ i ∈ range 3, (1 : ℝ) * (i : ℝ))
+      < (∑ i ∈ range 3, (1 : ℝ)) * ∑ i ∈ range 3, (1 : ℝ) * (i : ℝ) * (i : ℝ) := by
+  exact weighted_chebyshev_strict_of_ne (w := fun _ => (1 : ℝ))
+    (f := fun i => (i : ℝ)) (g := fun i => (i : ℝ)) (s := Finset.range 3)
+    (monovaryOn_self _ _) (fun _ _ => by norm_num)
+    (a := 0) (b := 1) (by decide) (by decide) (by norm_num) (by norm_num)
+    (by norm_num) (by norm_num)
+
+/-- Concrete **equality** instance: with `f` constant the bound is tight. -/
+example (w g : ι → ℝ) (s : Finset ι) (hw : ∀ i ∈ s, 0 ≤ w i) :
+    (∑ i ∈ s, w i * (5 : ℝ)) * (∑ i ∈ s, w i * g i)
+      = (∑ i ∈ s, w i) * ∑ i ∈ s, w i * (5 : ℝ) * g i :=
+  weighted_chebyshev_eq_of_const_left
+    (f := fun _ => (5 : ℝ)) (fun _ _ _ _ _ => le_refl _) hw (fun _ _ _ _ => rfl)
+
+end ChebyshevSumWeightedStrict

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-01-oq-02",
+  "title": "Strict Weighted Chebyshev Sum Inequality and its Equality Case",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-01-oq-02",
+  "description": "The parent entry proves only the non-strict weighted Chebyshev sum inequality (∑ wᵢfᵢ)(∑ wᵢgᵢ) ≤ W·∑ wᵢfᵢgᵢ for nonnegative weights and monovarying f, g. We sharpen it to a strict/equality dichotomy. The parent's engine writes the Chebyshev defect as half a sum of nonnegative cross terms wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ); rerunning that identity through 'a sum of nonnegatives is zero iff each term is zero' (Finset.sum_eq_zero_iff_of_nonneg) and 'is positive once one term is' (Finset.sum_pos') yields: equality holds iff every cross term vanishes, and strict inequality holds as soon as one positively weighted pair has a strictly positive cross term. With strictly positive weights the equality condition simplifies to f or g being constant on s — the form recorded in the parent's open question.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "inequalities",
+      "order",
+      "chebyshev-sum-inequality",
+      "weighted",
+      "equality-case",
+      "strict-inequality",
+      "monovary"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevSumWeightedOQ01OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 283,
+    "mathlibDependencies": [
+      {
+        "theorem": "MonovaryOn",
+        "description": "The order-correlation predicate g i < g j → f i ≤ f j, supplying the sign (and, with genuine variation, strict sign) of each cross difference (f i − f j)(g i − g j)",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      },
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonneg",
+        "description": "A finite sum of nonnegative reals is zero iff every summand is zero — turns the vanishing of the defect double sum into the termwise equality condition",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_pos'",
+        "description": "A finite sum of nonnegative reals is strictly positive once a single summand is positive — drives the strict inequality from one positively weighted varying pair",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_mul_sum",
+        "description": "(∑ i, a i)(∑ j, b j) = ∑ i ∑ j a i · b j — collapses the four monomial double sums in the weighted monovariance identity",
+        "module": "Mathlib.Algebra.BigOperators.Ring"
+      },
+      {
+        "theorem": "monovaryOn_self",
+        "description": "Every function monovaries with itself — used in the concrete strict instance f = g = id",
+        "module": "Mathlib.Algebra.Order.Monovary"
+      }
+    ],
+    "originalContributions": [
+      "weighted_chebyshev_eq_iff: under monovariance with nonnegative weights, equality (∑ wf)(∑ wg) = W·∑ wfg holds iff every weighted cross term wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ) vanishes — the exact algebraic tightness condition, absent from Mathlib",
+      "weighted_chebyshev_eq_iff_of_pos: with strictly positive weights, equality iff no pair i, j ∈ s has both f and g strictly varying, i.e. (fᵢ−fⱼ)(gᵢ−gⱼ) = 0 for all i, j",
+      "weighted_chebyshev_eq_iff_const: the human-readable equality criterion recorded in the parent's open question — with positive weights, equality iff f is constant on s OR g is constant on s, via a finite case analysis showing the termwise condition forces one sequence constant",
+      "weighted_chebyshev_strict: strict inequality (∑ wf)(∑ wg) < W·∑ wfg whenever two positively weighted indices have a strictly positive cross product",
+      "weighted_chebyshev_strict_of_ne: the convenient sufficient form — strictness from a positively weighted pair on which f and g both genuinely differ",
+      "sub_mul_sub_pos_of_monovaryOn: under monovariance, the cross product is strictly positive when both f and g differ at the two indices (strict refinement of the parent's sign lemma)",
+      "weighted_chebyshev_eq_of_const_left / _right: the degenerate equalities when f resp. g is constant on s"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's sum inequality compares the product of the weighted means of two similarly sorted sequences with the weighted mean of their product; the gap between the two sides is exactly the (weighted) covariance of f and g. The non-strict inequality says this covariance is nonnegative. The natural companion question — when is the covariance exactly zero, and when is it strictly positive — is the rigidity (equality) analysis. For Chebyshev's inequality the classical answer is that equality holds precisely when one of the two sequences is constant; otherwise comonotone genuine variation forces a strictly positive correlation. Mathlib records neither the strict inequality nor this equality characterization, even in the unweighted case.",
+    "problemStatement": "Let $s$ be finite, $w_i \\ge 0$ on $s$, $W = \\sum_{i\\in s} w_i$, and let $f, g$ monovary on $s$. The parent gives $\\big(\\sum w_i f_i\\big)\\big(\\sum w_i g_i\\big) \\le W \\sum w_i f_i g_i$. Characterise the equality case and give a sufficient condition for strictness: show equality holds iff every cross term $w_i w_j (f_i - f_j)(g_i - g_j)$ vanishes — equivalently, for strictly positive weights, iff $f$ or $g$ is constant on $s$ — and that the inequality is strict as soon as some positively weighted pair $a, b$ has $(f_a - f_b)(g_a - g_b) > 0$.",
+    "proofStrategy": "Everything is read off the parent's weighted monovariance identity 2·D = ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ), where D = W·∑ wfg − (∑ wf)(∑ wg) is the Chebyshev defect and, under monovariance with nonnegative weights, every summand is ≥ 0.\n\n1. Equality (weighted_chebyshev_eq_iff): D = 0 iff the double sum is 0 iff each summand is 0 (Finset.sum_eq_zero_iff_of_nonneg applied to the outer then inner sum).\n\n2. Positive-weight simplification (weighted_chebyshev_eq_iff_of_pos): when wᵢ > 0 the factor wᵢwⱼ is invertible, so the termwise condition reduces to (fᵢ−fⱼ)(gᵢ−gⱼ) = 0.\n\n3. Constant criterion (weighted_chebyshev_eq_iff_const): the termwise condition (fᵢ−fⱼ)(gᵢ−gⱼ) = 0 means every pair agrees in f or in g; a short finite case analysis shows that if neither f nor g is constant one can exhibit a pair on which both vary, a contradiction. Hence equality iff f or g constant.\n\n4. Strictness (weighted_chebyshev_strict): if a positively weighted pair a, b has (f_a − f_b)(g_a − g_b) > 0, then the (a, b) summand is positive while all summands are ≥ 0, so the double sum is positive (Finset.sum_pos'), giving D > 0. Under monovariance, genuine variation of both f and g at a, b already forces the cross product positive (sub_mul_sub_pos_of_monovaryOn).",
+    "keyInsights": [
+      "The parent's identity does double duty: the same nonnegative double sum that proves D ≥ 0 also pins the equality case (sum of nonnegatives = 0 ⇔ each term = 0) and the strict case (one positive term ⇒ positive sum). No new algebra is needed — only the order lemmas Finset.sum_eq_zero_iff_of_nonneg and Finset.sum_pos'.",
+      "Equality is genuinely a statement about pairs: it holds iff there is NO pair on which f and g both strictly vary. The 'f or g constant' phrasing is the equivalent global form, recovered by a finite combinatorial argument.",
+      "Strictness needs only a single witnessing pair, so it is a local condition: two positively weighted indices where both sequences move.",
+      "With strictly positive weights the weight factors are invisible to the equality condition — exactly as for the inequality itself, the weights only rescale, they never change which pairs are tight."
+    ],
+    "prerequisites": [
+      "The parent weighted Chebyshev inequality and its weighted monovariance (covariance) identity",
+      "Finset.sum_eq_zero_iff_of_nonneg and Finset.sum_pos' for finite sums of nonnegative reals",
+      "The MonovaryOn order-correlation predicate and trichotomy sign reasoning",
+      "Basic ordered-field facts (mul_eq_zero, sub_eq_zero, sign of a product)"
+    ]
+  },
+  "conclusion": {
+    "summary": "We sharpened the weighted Chebyshev sum inequality to a full strict/equality dichotomy. Equality (∑ wf)(∑ wg) = W·∑ wfg holds iff every weighted cross term vanishes; with strictly positive weights this is exactly 'f or g constant on s'. The inequality is strict as soon as a single positively weighted pair has both sequences genuinely varying. All twelve results are machine-checked with 0 sorries and depend only on the foundational axioms; they reuse the parent's monovariance identity together with two standard order lemmas (sum of nonnegatives is zero iff termwise zero, positive once one term is).",
+    "implications": "This completes the rigidity analysis of the weighted Chebyshev / discrete covariance inequality: a user now knows not just that comonotone data has nonnegative weighted covariance but precisely when that covariance is zero (one sequence constant) versus strictly positive (some positively weighted pair varies in both). It directly answers the first open question of the parent and supplies the equality/strictness layer that the continuous (integral) companion will mirror.",
+    "openQuestions": [
+      "Transport the equality characterization to the continuous Chebyshev inequality: for a finite measure μ and monotone f, g, equality ∫ fg dμ · μ(X) = ∫ f dμ · ∫ g dμ iff f or g is μ-a.e. constant.",
+      "Give the equality case of the reverse (antivarying) weighted inequality, and of the weighted Cauchy–Schwarz square bound (∑ wf)² ≤ W·∑ wf², where equality should mean f is constant on the positive-weight support.",
+      "Quantify the defect: lower-bound D = W·∑ wfg − (∑ wf)(∑ wg) by an explicit positive multiple of the variation of f and g (a stability/quantitative-rigidity estimate)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports, an expository docstring laying out the strict/equality dichotomy and how it reads off the parent's monovariance identity, and namespace plus variable setup."
+    },
+    {
+      "id": "sign-lemmas",
+      "title": "Sign Lemmas for Monovarying Pairs",
+      "startLine": 51,
+      "endLine": 90,
+      "summary": "sub_mul_sub_nonneg_of_monovaryOn (the cross product is ≥ 0) and its strict refinement sub_mul_sub_pos_of_monovaryOn (the cross product is > 0 when both f and g genuinely differ), plus term_nonneg for the weighted summand."
+    },
+    {
+      "id": "identity",
+      "title": "The Weighted Monovariance Identity",
+      "startLine": 91,
+      "endLine": 127,
+      "summary": "two_mul_chebyshev_defect_eq: the symmetric double sum equals twice the Chebyshev defect, the algebraic engine reused from the parent, proved by expanding into four monomial double sums."
+    },
+    {
+      "id": "nonstrict",
+      "title": "The Non-Strict Inequality (Recalled)",
+      "startLine": 128,
+      "endLine": 140,
+      "summary": "weighted_sum_mul_sum_le: the baseline non-strict weighted Chebyshev inequality, included so the entry is self-contained."
+    },
+    {
+      "id": "equality-case",
+      "title": "The Equality Case",
+      "startLine": 141,
+      "endLine": 231,
+      "summary": "weighted_chebyshev_eq_iff (equality iff every cross term vanishes), weighted_chebyshev_eq_iff_of_pos (positive-weight simplification), weighted_chebyshev_eq_iff_const (equality iff f or g constant on s, via finite case analysis), and the degenerate corollaries for constant f or g."
+    },
+    {
+      "id": "strict-inequality",
+      "title": "The Strict Inequality",
+      "startLine": 232,
+      "endLine": 260,
+      "summary": "weighted_chebyshev_strict (strictness from one positively weighted positive cross term, via Finset.sum_pos') and weighted_chebyshev_strict_of_ne (the convenient form from a genuinely varying positively weighted pair)."
+    },
+    {
+      "id": "worked-instances",
+      "title": "Worked Instances",
+      "startLine": 261,
+      "endLine": 283,
+      "summary": "A concrete strict instance (unit weights on {0,1,2}, f = g = id, giving 9 < 15) and a concrete equality instance (constant f)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The non-strict weighted Chebyshev inequality whose first open question — the strict inequality and equality case — this answers, reusing its weighted monovariance identity"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "The continuous (integral) Chebyshev inequality, the sibling extension of the same parent; this entry supplies the discrete equality/strictness layer to be mirrored there"
+    },
+    {
+      "targetId": "rearrangement-inequality-oq-01",
+      "relationship": "related",
+      "description": "Equality/rigidity analysis of the unweighted Chebyshev sum inequality via the discrete covariance identity"
+    }
+  ],
+  "references": [
+    {
+      "text": "Hardy, G. H., Littlewood, J. E., Pólya, G. (1952). Inequalities, 2nd ed., Cambridge University Press (Chebyshev's inequality, equality conditions).",
+      "url": "https://archive.org/details/Inequalities_201705"
+    },
+    {
+      "text": "Chebyshev's sum inequality.",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality"
+    },
+    {
+      "text": "Mathlib4: Algebra.Order.Chebyshev and Algebra.Order.Monovary.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Order/Chebyshev.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ChebyshevSumWeightedStrict",
+    "lineCount": 283,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevSumWeightedOQ01OQ01OQ02.lean",
+    "theoremCount": 12,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `chebyshev-sum-inequality-oq-01-oq-01` (the non-strict weighted Chebyshev sum inequality): *establish the strict inequality and characterise the equality case.* New gallery entry `chebyshev-sum-inequality-oq-01-oq-01-oq-02` (the `-oq-01` slug is already taken by the merged integral companion #28032).

For nonnegative weights `w` with total mass `W = ∑ wᵢ` and `f, g` monovarying on a finite set `s`, the parent proves `(∑ wᵢfᵢ)(∑ wᵢgᵢ) ≤ W·∑ wᵢfᵢgᵢ`. This entry sharpens it to a full **strict / equality dichotomy**, read off the parent's weighted monovariance identity `2·D = ∑ᵢ∑ⱼ wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ)` (D = the Chebyshev defect):

- **Equality** `(∑ wf)(∑ wg) = W·∑ wfg` ⟺ every cross term `wᵢwⱼ(fᵢ−fⱼ)(gᵢ−gⱼ)` vanishes (a sum of nonnegatives is zero iff each term is — `Finset.sum_eq_zero_iff_of_nonneg`).
- With **strictly positive weights**, this simplifies to `f` or `g` constant on `s` (`weighted_chebyshev_eq_iff_const`) — the exact form recorded in the parent's open question, via a short finite case analysis.
- **Strict** inequality holds as soon as one positively-weighted pair `a, b` has `(fₐ−f_b)(gₐ−g_b) > 0` (`Finset.sum_pos'`); under monovariance, both `f` and `g` genuinely differing there already forces it.

## Theorems (12, all over ℝ)

`weighted_chebyshev_eq_iff`, `weighted_chebyshev_eq_iff_of_pos`, `weighted_chebyshev_eq_iff_const`, `weighted_chebyshev_strict`, `weighted_chebyshev_strict_of_ne`, plus the strict sign lemma `sub_mul_sub_pos_of_monovaryOn`, the constant-degeneracy corollaries, and the self-contained recall of the parent identity + non-strict bound. Two concrete worked instances (`9 < 15`; constant-`f` equality).

## Verification

- **0 sorries, 0 axioms** beyond `propext / Classical.choice / Quot.sound` (confirmed via `#print axioms`); no `native_decide`.
- Builds clean against Mathlib v4.26.0 (single-file `lake env lean`; Docker unavailable this session).
- Self-contained: imports only `Mathlib`, re-deriving the parent's defect identity as the engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)