### PR TITLE
research(lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01): orbit-counting index identity Nat.card(orbit)=[G:stab], two ways [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3049,6 +3049,7 @@ import Proofs.LagrangeTheoremOQ02OQ02
 import Proofs.LagrangeTheoremOQ02OQ02OQ01
 import Proofs.LagrangeTheoremOQ02OQ02OQ01OQ01
 import Proofs.LagrangeTheoremOQ02OQ02OQ01OQ01OQ01
+import Proofs.LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01
 import Proofs.LagrangeTheoremOQ02OQ02OQ01OQ02
 import Proofs.LagrangeTheoremOQ03
 import Proofs.LagrangeTheoremOQ05

--- a/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,124 @@
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.GroupTheory.Index
+import Mathlib.SetTheory.Cardinal.Finite
+import Mathlib.Tactic
+
+/-!
+# The Orbit-Counting Index Identity over `Nat.card`
+
+## What This Proves
+
+This file answers `oq-01` of the parent
+`lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01` (the orbit-stabilizer family over
+`Nat.card`).  The parent established, with **no** finiteness instance, the two
+finiteness-free orbit-counting identities
+
+  `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G`     (product form)
+  `Nat.card (orbit G x) = Nat.card (G ⧸ stabilizer G x)`              (quotient form)
+
+The open question asks to **combine the product form with Lagrange's theorem**
+`Nat.card (stabilizer G x) * [G : stabilizer G x] = Nat.card G` to derive the
+**orbit-counting index identity**
+
+  `Nat.card (orbit G x) = [G : stabilizer G x]`,
+
+phrased over `Subgroup.index` (= `Nat.card (G ⧸ ·)`), entirely over `Nat.card`.
+
+## The mathematical point: cancellation is *not* finiteness-free
+
+There are two genuinely different derivations, and they differ precisely in their
+finiteness needs.
+
+1. **The direct route** transports the bijection `orbitEquivQuotientStabilizer`
+   through `Nat.card` and unfolds `Subgroup.index`.  It is **unconditional** — it
+   needs no `Finite`/`Fintype` instance at all (`card_orbit_eq_index_stabilizer`).
+
+2. **The literal "combine and cancel" route** the OQ describes sets the two
+   products equal,
+
+     `Nat.card (orbit G x) * s = Nat.card G = [G : stabilizer G x] * s`,
+     `s := Nat.card (stabilizer G x)`,
+
+   and cancels the common factor `s`.  Right-cancellation in `ℕ` is valid **only
+   when `s ≠ 0`**, i.e. only when the stabilizer is finite.  Over the *total*
+   `Nat.card` (which is `0` on infinite types) this cancellation can fail for an
+   infinite stabilizer, so this derivation genuinely requires `Finite G`
+   (`card_orbit_eq_index_stabilizer_via_cancellation`).
+
+Both routes prove the *same* statement, but only the direct bijection achieves it
+in full generality.  This makes precise *why* Mathlib's orbit-stabilizer machinery
+is built from the bijection rather than from cardinal arithmetic: the bijection,
+not the cancellation, is what removes the finiteness hypothesis.
+
+## Status
+- [x] Orbit-counting index identity, unconditional — `0` sorries, `0` axioms
+- [x] Same identity via the OQ's product-and-cancel route (needs `Finite G`)
+- [x] Stabilizer-card positivity lemma underpinning the cancellation
+
+## Mathlib Dependencies
+- `Mathlib.GroupTheory.GroupAction.Quotient` : `orbitEquivQuotientStabilizer`,
+  `orbitProdStabilizerEquivGroup`
+- `Mathlib.GroupTheory.Index` : `Subgroup.index_eq_card`, `Subgroup.index_mul_card`
+- `Mathlib.SetTheory.Cardinal.Finite` : `Nat.card_congr`, `Nat.card_prod`,
+  `Nat.card_pos`
+-/
+
+namespace OrbitCountingIndex
+
+open MulAction
+
+variable (G : Type*) (X : Type*) [Group G] [MulAction G X]
+
+/-- **Orbit-stabilizer product over `Nat.card`** (the parent's product form,
+restated locally so this file is self-contained).  The content is the
+finiteness-free bijection `orbitProdStabilizerEquivGroup` transported through the
+total cardinal `Nat.card`; no `Finite`/`Fintype` instance is needed. -/
+theorem card_orbit_mul_card_stabilizer (x : X) :
+    Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G := by
+  rw [← Nat.card_prod, Nat.card_congr (orbitProdStabilizerEquivGroup G x)]
+
+/-- **Orbit-counting index identity, unconditional.**
+
+  `Nat.card (orbit G x) = [G : stabilizer G x]`.
+
+This is the orbit-counting half of Lagrange's theorem.  The proof unfolds
+`Subgroup.index` to `Nat.card (G ⧸ stabilizer G x)` and transports the
+finiteness-free bijection `orbitEquivQuotientStabilizer` through `Nat.card`, so it
+holds for **any** group action with no finiteness hypothesis whatsoever. -/
+theorem card_orbit_eq_index_stabilizer (x : X) :
+    Nat.card (orbit G x) = (stabilizer G x).index := by
+  rw [Subgroup.index_eq_card]
+  exact Nat.card_congr (orbitEquivQuotientStabilizer G x)
+
+/-- When `G` is finite the stabilizer is a finite, nonempty subgroup, so its
+`Nat.card` is strictly positive.  This is exactly the hypothesis that makes the
+right-cancellation in the OQ's "combine and cancel" derivation legitimate. -/
+theorem card_stabilizer_pos [Finite G] (x : X) :
+    0 < Nat.card (stabilizer G x) :=
+  Nat.card_pos
+
+/-- **Orbit-counting index identity via the OQ's product-and-cancel route.**
+
+Combine the orbit-stabilizer product `Nat.card (orbit G x) * s = Nat.card G` with
+Lagrange's theorem `[G : stabilizer G x] * s = Nat.card G` (where
+`s = Nat.card (stabilizer G x)`), then cancel the common factor `s`.  The
+cancellation needs `s ≠ 0`, which is supplied by `Finite G`; see
+`card_orbit_eq_index_stabilizer` for the unconditional bijection-based proof of the
+same statement. -/
+theorem card_orbit_eq_index_stabilizer_via_cancellation [Finite G] (x : X) :
+    Nat.card (orbit G x) = (stabilizer G x).index := by
+  have hprod : Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G :=
+    card_orbit_mul_card_stabilizer G X x
+  have hlag : (stabilizer G x).index * Nat.card (stabilizer G x) = Nat.card G :=
+    Subgroup.index_mul_card _
+  have hcancel :
+      Nat.card (orbit G x) * Nat.card (stabilizer G x)
+        = (stabilizer G x).index * Nat.card (stabilizer G x) := by
+    rw [hprod, hlag]
+  exact Nat.eq_of_mul_eq_mul_right (card_stabilizer_pos G X x) hcancel
+
+#check @card_orbit_mul_card_stabilizer
+#check @card_orbit_eq_index_stabilizer
+#check @card_orbit_eq_index_stabilizer_via_cancellation
+
+end OrbitCountingIndex

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-lag020201-context",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 6, "endLine": 64 },
+    "type": "concept",
+    "title": "Two Routes to the Index Identity — and Where Finiteness Hides",
+    "content": "The open question asks to derive the orbit-counting index identity `Nat.card (orbit G x) = [G : stabilizer G x]` by *combining* the parent's orbit-stabilizer product with Lagrange's theorem. This file delivers exactly that, but also points out a subtlety: there are two genuinely different derivations and they differ precisely in their finiteness needs. The direct bijection proves the identity unconditionally; the literal combine-and-cancel route needs `Finite G`, because cancelling the common stabilizer factor in `ℕ` is only valid when that factor is nonzero.",
+    "mathContext": "Orbit-stabilizer gives the bijection $\\mathrm{orbit}(x) \\cong G/\\mathrm{Stab}(x)$, hence $|\\mathrm{orbit}(x)| = [G : \\mathrm{Stab}(x)]$ directly. Alternatively, from $|\\mathrm{orbit}(x)|\\,|\\mathrm{Stab}(x)| = |G| = [G:\\mathrm{Stab}(x)]\\,|\\mathrm{Stab}(x)|$ one cancels $|\\mathrm{Stab}(x)|$. Over the total `Nat.card`, which is $0$ on infinite types, that cancellation can fail for an infinite stabilizer — so the cancellation route, unlike the bijection, is not finiteness-free.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orbit-stabilizer theorem",
+      "Lagrange's theorem",
+      "subgroup index",
+      "Nat.card totality",
+      "finiteness-free bijection"
+    ],
+    "prerequisites": [
+      "group action: orbit, stabilizer, orbit space",
+      "subgroup index [G : H] = Nat.card (G ⧸ H)",
+      "parent lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01 (orbit-stabilizer over Nat.card)"
+    ]
+  },
+  {
+    "id": "ann-lag020201-product",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 78 },
+    "type": "technique",
+    "title": "The Orbit-Stabilizer Product (Restated)",
+    "content": "`card_orbit_mul_card_stabilizer` restates the parent's product identity `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G` locally, so this file stands alone. The proof is the same two rewrites: `← Nat.card_prod` folds the product into `Nat.card (orbit × stabilizer)`, then `Nat.card_congr (orbitProdStabilizerEquivGroup G x)` rewrites along Mathlib's finiteness-free bijection. No `Finite`/`Fintype` instance appears.",
+    "mathContext": "This is one of the two products that get equated in the cancellation argument. It is itself unconditional, exactly because the bijection $\\mathrm{orbit}(x)\\times\\mathrm{Stab}(x)\\cong G$ requires no finiteness.",
+    "significance": "important",
+    "relatedConcepts": ["Nat.card_prod", "Nat.card_congr", "orbitProdStabilizerEquivGroup"],
+    "prerequisites": ["orbitProdStabilizerEquivGroup", "Nat.card transport lemmas"]
+  },
+  {
+    "id": "ann-lag020201-direct",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 80, "endLine": 91 },
+    "type": "technique",
+    "title": "The Unconditional Index Identity",
+    "content": "`card_orbit_eq_index_stabilizer` proves `Nat.card (orbit G x) = (stabilizer G x).index` directly: `Subgroup.index_eq_card` unfolds the index to `Nat.card (G ⧸ stabilizer G x)`, and `Nat.card_congr (orbitEquivQuotientStabilizer G x)` finishes via the orbit/coset bijection. No finiteness hypothesis is used — this is the strongest form of the result.",
+    "mathContext": "Reading the bijection $\\mathrm{orbit}(x) \\cong G/\\mathrm{Stab}(x)$ as an equality of cardinals gives $|\\mathrm{orbit}(x)| = [G : \\mathrm{Stab}(x)]$. Because `Subgroup.index` is *defined* as `Nat.card (G ⧸ H)`, the index notation and the quotient cardinal are interchangeable, and the identity holds for any group action whatsoever.",
+    "significance": "key",
+    "relatedConcepts": ["orbitEquivQuotientStabilizer", "Subgroup.index_eq_card", "stabilizer index"],
+    "prerequisites": ["orbitEquivQuotientStabilizer", "Subgroup.index_eq_card", "Nat.card_congr"]
+  },
+  {
+    "id": "ann-lag020201-pos",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 93, "endLine": 98 },
+    "type": "technique",
+    "title": "Positivity of the Stabilizer Card — Where Finiteness Enters",
+    "content": "`card_stabilizer_pos` records `0 < Nat.card (stabilizer G x)` under `Finite G`, discharged by `Nat.card_pos` (the stabilizer is a finite, nonempty subgroup). This single lemma isolates exactly the hypothesis the cancellation route depends on: it is the `c > 0` side condition of ℕ right-cancellation.",
+    "mathContext": "`Nat.card_pos` needs `[Nonempty α]` and `[Finite α]`. The stabilizer contains the identity (Nonempty) and is finite as a subtype of a finite group, so its cardinal is at least $1$. Without finiteness `Nat.card` could be $0$, and the cancellation below would be unjustified.",
+    "significance": "important",
+    "relatedConcepts": ["Nat.card_pos", "finite subgroup", "cancellation side condition"],
+    "prerequisites": ["Nat.card_pos", "Finite instances for subgroups"]
+  },
+  {
+    "id": "ann-lag020201-cancel",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 100, "endLine": 120 },
+    "type": "technique",
+    "title": "The Combine-and-Cancel Derivation (the OQ's Literal Route)",
+    "content": "`card_orbit_eq_index_stabilizer_via_cancellation` is the derivation the open question describes. It pairs the orbit-stabilizer product `Nat.card (orbit G x) * s = Nat.card G` with Lagrange's `Subgroup.index_mul_card`, `[G : stabilizer G x] * s = Nat.card G` (here `s = Nat.card (stabilizer G x)`), rewrites both to expose `Nat.card (orbit G x) * s = [G : stabilizer G x] * s`, and concludes by `Nat.eq_of_mul_eq_mul_right (card_stabilizer_pos …)`. The `Finite G` hypothesis is exactly what powers the positivity feeding that cancellation.",
+    "mathContext": "Right-cancellation $a c = b c \\Rightarrow a = b$ in $\\mathbb{N}$ holds iff $c > 0$. Both products equal $|G|$, so equating them and cancelling $|\\mathrm{Stab}(x)|$ yields $|\\mathrm{orbit}(x)| = [G:\\mathrm{Stab}(x)]$ — but only once $|\\mathrm{Stab}(x)| > 0$ is known. Contrast this with the bijection-based proof above, which needs no such hypothesis: the cancellation, not the statement, is what introduces finiteness.",
+    "significance": "key",
+    "relatedConcepts": ["Subgroup.index_mul_card", "Nat.eq_of_mul_eq_mul_right", "Lagrange's theorem", "cancellation"],
+    "prerequisites": ["Subgroup.index_mul_card", "Nat.eq_of_mul_eq_mul_right", "card_stabilizer_pos"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+  "slug": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.Index",
+      "Mathlib.SetTheory.Cardinal.Finite",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MulAction"
+    ],
+    "namespace": "OrbitCountingIndex",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Orbit-Counting Index Identity over Nat.card",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "group-theory",
+      "group-action",
+      "orbit-stabilizer",
+      "lagrange",
+      "subgroup-index",
+      "nat-card",
+      "finite",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 124,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "card_orbit_eq_index_stabilizer: Nat.card (orbit G x) = (stabilizer G x).index — the orbit-counting index identity, proved unconditionally by transporting orbitEquivQuotientStabilizer through Nat.card and unfolding Subgroup.index; no Finite/Fintype hypothesis",
+      "card_orbit_eq_index_stabilizer_via_cancellation: the same identity derived the way the open question literally asks — set the orbit-stabilizer product equal to Lagrange's product and right-cancel the common stabilizer factor; this route genuinely requires Finite G because ℕ-cancellation needs the stabilizer card to be nonzero",
+      "card_stabilizer_pos: 0 < Nat.card (stabilizer G x) for Finite G — the positivity fact that legitimises the cancellation, isolating exactly where finiteness enters",
+      "card_orbit_mul_card_stabilizer: the parent's orbit-stabilizer product over Nat.card, restated locally so the file is self-contained"
+    ],
+    "prerequisites": [
+      "Group actions: orbit, stabilizer, the orbit space G ⧸ stabilizer (MulAction)",
+      "Subgroup index as Nat.card (G ⧸ H) and Lagrange's theorem in card form (Subgroup.index_mul_card)",
+      "Mathlib's finiteness-free bijections orbitEquivQuotientStabilizer and orbitProdStabilizerEquivGroup",
+      "ℕ right-cancellation (Nat.eq_of_mul_eq_mul_right) and Nat.card_pos for finite nonempty types",
+      "Parent: lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01 (orbit-stabilizer family over Nat.card)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.orbitEquivQuotientStabilizer",
+        "description": "orbit G x ≃ G ⧸ stabilizer G x — the finiteness-free orbit/coset bijection. Transported through Nat.card it gives the index identity unconditionally.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "Subgroup.index_eq_card",
+        "description": "H.index = Nat.card (G ⧸ H) — unfolds the subgroup index to a quotient cardinal, the bridge between the orbit/coset bijection and the index notation [G : stabilizer G x].",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Subgroup.index_mul_card",
+        "description": "H.index * Nat.card H = Nat.card G — Lagrange's theorem over Nat.card; supplies the second product that, combined with the orbit-stabilizer product, yields the index identity by cancellation.",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Nat.eq_of_mul_eq_mul_right",
+        "description": "0 < c → a * c = b * c → a = b — the ℕ right-cancellation law that makes the combine-and-cancel derivation valid only when the stabilizer card is positive.",
+        "module": "Mathlib (Nat)"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "question": "Specialise the index identity to the conjugation action ConjAct G on G to obtain the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] over Nat.card, connecting it to the class equation Group.nat_card_center_add_sum_card_noncenter_eq_card.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. That entry proved the orbit-stabilizer product and quotient forms over Nat.card. This entry uses them to settle the index identity Nat.card (orbit G x) = [G : stabilizer G x], and makes precise that the direct bijection proves it unconditionally while the literal combine-and-cancel route needs Finite G."
+    },
+    {
+      "targetId": "lagrange-theorem",
+      "relationship": "related",
+      "description": "Grandparent family. The orbit-counting index identity is the orbit-theoretic form of Lagrange's theorem: an orbit is in bijection with the cosets of its stabilizer, so its size is the stabilizer's index."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: GroupTheory.Index",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Subgroup.index_eq_card and Subgroup.index_mul_card (Lagrange's theorem over Nat.card)."
+    },
+    {
+      "title": "Mathlib4: GroupTheory.GroupAction.Quotient",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of orbitEquivQuotientStabilizer and orbitProdStabilizerEquivGroup."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The orbit-counting index identity Nat.card (orbit G x) = [G : stabilizer G x] is proved two ways. The direct proof transports the finiteness-free bijection orbitEquivQuotientStabilizer through Nat.card and unfolds Subgroup.index, holding for any group action with no finiteness hypothesis. The combine-and-cancel proof — the literal route the open question describes — sets the orbit-stabilizer product equal to Lagrange's product and right-cancels the shared stabilizer factor; this needs Finite G, because ℕ-cancellation requires the stabilizer card to be nonzero. 124 lines, 4 theorems, 0 definitions, 0 axioms, 0 sorries; depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The two derivations pin down exactly where finiteness is and is not needed: the bijection, not the cardinal arithmetic, is what removes the finiteness hypothesis from orbit-stabilizer counting. This is why Mathlib builds orbit-stabilizer from equivalences rather than from cancellation — the cancellation step silently assumes the stabilizer is finite, whereas the equivalence is unconditional. The unconditional index identity supplies a total, instance-free statement of 'orbit size = stabilizer index' for downstream use.",
+    "openQuestions": [
+      "Specialise to the conjugation action to obtain the conjugacy-class size formula Nat.card (conjugacy class of g) = [G : centralizer g] and connect it to the class equation."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers `oq-01` of the parent **lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01** (the orbit-stabilizer family over `Nat.card`). The parent proved the orbit-stabilizer product and quotient forms over `Nat.card`; the open question asks to **combine the product with Lagrange's theorem** to derive the orbit-counting index identity

```
Nat.card (orbit G x) = [G : stabilizer G x]
```

over `Nat.card`. This entry settles it **two ways**, and the contrast between them is the real content.

### Theorems (`OrbitCountingIndex`)

| Theorem | Statement | Finiteness |
|---|---|---|
| `card_orbit_mul_card_stabilizer` | `Nat.card (orbit G x) * Nat.card (stabilizer G x) = Nat.card G` | none (parent's product, restated) |
| `card_orbit_eq_index_stabilizer` | `Nat.card (orbit G x) = (stabilizer G x).index` | **none** — direct bijection |
| `card_stabilizer_pos` | `0 < Nat.card (stabilizer G x)` | `Finite G` |
| `card_orbit_eq_index_stabilizer_via_cancellation` | same index identity | `Finite G` — combine-and-cancel |

### The mathematical point

- **Direct route** (`card_orbit_eq_index_stabilizer`): transport `orbitEquivQuotientStabilizer` through `Nat.card` and unfold `Subgroup.index_eq_card`. Holds for **any** group action, no finiteness instance.
- **Combine-and-cancel route** (the OQ's literal ask): equate the orbit-stabilizer product with Lagrange's `Subgroup.index_mul_card`, then right-cancel the shared stabilizer factor `s`. ℕ right-cancellation needs `s ≠ 0`, supplied by `Finite G` (`card_stabilizer_pos`).

So the cancellation, **not** the statement, is what introduces finiteness — which is exactly why Mathlib builds orbit-stabilizer from equivalences rather than from cardinal arithmetic.

## Verification

- 124 lines, 4 theorems, 0 definitions, **0 sorries, 0 axioms**
- `#print axioms` on all theorems: `[propext, Classical.choice, Quot.sound]` only
- Builds via single-file `lake env lean` against the pinned Mathlib

🤖 Generated with [Claude Code](https://claude.com/claude-code)