### PR TITLE
research(denumerability-rationals-oq-05-oq-01-oq-01-oq-01): the fraction field of a countable ring stays denumerable — #(FractionRing R)=ℵ₀ and #ℚ=ℵ₀ as a localization [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -813,6 +813,7 @@ import Proofs.DenumerabilityRationalsOQ04
 import Proofs.DenumerabilityRationalsOQ05
 import Proofs.DenumerabilityRationalsOQ05OQ01
 import Proofs.DenumerabilityRationalsOQ05OQ01OQ01
+import Proofs.DenumerabilityRationalsOQ05OQ01OQ01OQ01
 import Proofs.DenumerabilityRationalsOQ06
 import Proofs.DenumerabilityRationalsOQ07
 import Proofs.Derangements

--- a/proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-
+# Denumerability of localizations — the fraction field of a countable ring is countable
+
+## What this proves
+
+The root of this problem family is the classical fact that the rationals `ℚ` are
+**denumerable** (countably infinite).  Earlier entries generalised the *polynomial*
+side — `#(R[X]) = ℵ₀`, and the multivariate / monoid-algebra variants over a countable
+ring.  This entry generalises the *rationals themselves*: `ℚ` is, by construction, the
+field of fractions of `ℤ`, and the operation "invert a multiplicative set" never escapes
+countability.
+
+* `countable_of_isLocalization` — **the headline.**  For a countable commutative
+  semiring `R`, a submonoid `M ≤ R`, and *any* localization `S` of `R` at `M`
+  (`[IsLocalization M S]`), the ring `S` is countable.  This is the denumerable
+  analogue of Mathlib's `IsLocalization.fintype'` (which Mathlib explicitly remarks
+  "cannot be an instance").  Proof: `IsLocalization.mk'_surjective` exhibits every
+  element of `S` as `mk' S r m` for some `(r, m) ∈ R × M`, and a surjective image of a
+  countable type is countable.
+
+* `Localization.instCountable` / `instCountableFractionRing` — the concrete localization
+  `Localization M` and the fraction field `FractionRing R` inherit countability as
+  honest instances.
+
+* `mk_fractionRing_eq_aleph0` — for an *infinite* countable integral domain the fraction
+  field is countably **infinite**: `#(FractionRing R) = ℵ₀`.
+
+* `mk_rat_eq_aleph0` — **the loop closes.**  Applying the general theorem to
+  `IsFractionRing ℤ ℚ` re-derives `#ℚ = ℵ₀`, the denumerability of the rationals, as a
+  special case of the localization principle.  The non-negative rationals `ℚ≥0`
+  (`IsFractionRing ℕ ℚ≥0`) follow for free in `mk_nnrat_eq_aleph0`.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+
+open Cardinal
+
+namespace DenumerabilityRationalsOQ05OQ01OQ01OQ01
+
+/-! ## Part 1: localizations preserve countability -/
+
+/-- **Localizations preserve countability.**  If `R` is a countable commutative semiring
+and `S` is any localization of `R` at a submonoid `M`, then `S` is countable.
+
+This is the denumerable analogue of `IsLocalization.fintype'`.  Every `z : S` is of the
+form `IsLocalization.mk' S r m` for some `(r, m) ∈ R × M` (`mk'_surjective`), so `S` is a
+surjective image of the countable type `R × M`. -/
+theorem countable_of_isLocalization {R : Type*} [CommSemiring R] (M : Submonoid R)
+    (S : Type*) [CommSemiring S] [Algebra R S] [IsLocalization M S] [Countable R] :
+    Countable S :=
+  (IsLocalization.mk'_surjective (S := S) M).countable
+
+/-- The concrete localization `Localization M` of a countable commutative semiring is
+countable. -/
+instance Localization.instCountable {R : Type*} [CommSemiring R] (M : Submonoid R)
+    [Countable R] : Countable (Localization M) :=
+  countable_of_isLocalization M (Localization M)
+
+/-- The field of fractions of a countable commutative ring is countable. -/
+instance instCountableFractionRing {R : Type*} [CommRing R] [Countable R] :
+    Countable (FractionRing R) :=
+  countable_of_isLocalization (nonZeroDivisors R) (FractionRing R)
+
+/-! ## Part 2: cardinality bounds -/
+
+/-- Any localization of a countable ring has cardinality at most `ℵ₀`. -/
+theorem mk_le_aleph0_of_isLocalization {R : Type*} [CommSemiring R] (M : Submonoid R)
+    (S : Type*) [CommSemiring S] [Algebra R S] [IsLocalization M S] [Countable R] :
+    #S ≤ ℵ₀ :=
+  have : Countable S := countable_of_isLocalization M S
+  mk_le_aleph0
+
+/-- **For an infinite countable integral domain the fraction field is denumerable.**
+`#(FractionRing R) = ℵ₀`.  Countability is `instCountableFractionRing`; infinitude comes
+from the injective `algebraMap R (FractionRing R)`. -/
+theorem mk_fractionRing_eq_aleph0 {R : Type*} [CommRing R] [IsDomain R] [Countable R]
+    [Infinite R] : #(FractionRing R) = ℵ₀ := by
+  have : Infinite (FractionRing R) :=
+    Infinite.of_injective _ (IsFractionRing.injective R (FractionRing R))
+  exact mk_eq_aleph0 _
+
+/-! ## Part 3: closing the loop — the rationals -/
+
+/-- **Closing the loop.**  `ℚ` is the field of fractions of `ℤ`
+(`Rat.isFractionRing : IsFractionRing ℤ ℚ`), so its denumerability `#ℚ = ℵ₀` is exactly
+the localization principle applied to `ℤ`. -/
+theorem mk_rat_eq_aleph0 : #ℚ = ℵ₀ := by
+  have : Countable ℚ := countable_of_isLocalization (nonZeroDivisors ℤ) ℚ
+  exact mk_eq_aleph0 _
+
+/-- The non-negative rationals `ℚ≥0` are the fraction object of `ℕ`
+(`NNRat.isFractionRing : IsFractionRing ℕ ℚ≥0`), hence also denumerable: `#ℚ≥0 = ℵ₀`. -/
+theorem mk_nnrat_eq_aleph0 : #ℚ≥0 = ℵ₀ := by
+  have : Countable ℚ≥0 := countable_of_isLocalization (nonZeroDivisors ℕ) ℚ≥0
+  exact mk_eq_aleph0 _
+
+end DenumerabilityRationalsOQ05OQ01OQ01OQ01

--- a/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
+  "title": "The Fraction Field of a Countable Ring Stays Denumerable: #(FractionRing R) = ℵ₀ and #ℚ = ℵ₀ as a Localization",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
+  "description": "The root of this family is the denumerability of ℚ. Earlier entries generalized the polynomial side (#(R[X]) = ℵ₀, multivariate and monoid-algebra variants). This entry generalizes the rationals themselves: ℚ is by construction the field of fractions of ℤ, and inverting a multiplicative set never escapes countability. The headline countable_of_isLocalization shows that for a countable commutative semiring R and ANY localization S of R at a submonoid M ([IsLocalization M S]), S is countable — the denumerable analogue of Mathlib's IsLocalization.fintype' (which Mathlib remarks 'cannot be an instance'). Proof: IsLocalization.mk'_surjective exhibits S as a surjective image of the countable type R × M. Corollaries: Localization M and FractionRing R inherit countability as instances; for an infinite countable integral domain #(FractionRing R) = ℵ₀; and applying the principle to IsFractionRing ℤ ℚ re-derives #ℚ = ℵ₀ (with #ℚ≥0 = ℵ₀ from IsFractionRing ℕ ℚ≥0), closing the loop back to the root problem.",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "denumerability",
+      "localization",
+      "fraction-field",
+      "ring-theory",
+      "cardinal-arithmetic",
+      "aleph-null",
+      "countable-ring",
+      "rational-numbers",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsLocalization.mk'_surjective",
+        "description": "Surjective (fun ((r, m) : R × M) ↦ mk' S r m) — every element of a localization S is mk' S r m for some (r, m) ∈ R × M; the surjection that carries countability from R × M onto S",
+        "module": "Mathlib.RingTheory.Localization.Defs"
+      },
+      {
+        "theorem": "Function.Surjective.countable",
+        "description": "[Countable α] → Surjective f → Countable β — a surjective image of a countable type is countable; applied to the mk' surjection",
+        "module": "Mathlib.Data.Countable.Defs"
+      },
+      {
+        "theorem": "Cardinal.mk_eq_aleph0",
+        "description": "[Countable α] [Infinite α] → #α = ℵ₀ — pins the fraction field / ℚ / ℚ≥0 cardinality at exactly ℵ₀ once countability and infinitude hold",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "IsFractionRing.injective",
+        "description": "Function.Injective (algebraMap R K) for a fraction ring — supplies Infinite (FractionRing R) from Infinite R via Infinite.of_injective",
+        "module": "Mathlib.RingTheory.Localization.FractionRing"
+      },
+      {
+        "theorem": "Rat.isFractionRing",
+        "description": "IsFractionRing ℤ ℚ (= IsLocalization (nonZeroDivisors ℤ) ℚ) — identifies ℚ as the localization of ℤ, so #ℚ = ℵ₀ is the general theorem specialized; NNRat.isFractionRing gives the ℚ≥0 analogue over ℕ",
+        "module": "Mathlib.RingTheory.Localization.FractionRing"
+      }
+    ],
+    "originalContributions": [
+      "countable_of_isLocalization: Countable S for any [IsLocalization M S] over a countable semiring R — the denumerable analogue of Mathlib's IsLocalization.fintype' (a Countable instance Mathlib does not provide), proved via IsLocalization.mk'_surjective",
+      "Localization.instCountable: Countable (Localization M) for countable R — the concrete localization is a countability instance",
+      "instCountableFractionRing: Countable (FractionRing R) for a countable commutative ring R",
+      "mk_le_aleph0_of_isLocalization: #S ≤ ℵ₀ for any localization of a countable ring",
+      "mk_fractionRing_eq_aleph0: #(FractionRing R) = ℵ₀ for an infinite countable integral domain — infinitude from the injective algebraMap into the fraction field",
+      "mk_rat_eq_aleph0: #ℚ = ℵ₀ re-derived as the localization principle applied to IsFractionRing ℤ ℚ — closing the loop to the root denumerability problem",
+      "mk_nnrat_eq_aleph0: #ℚ≥0 = ℵ₀ via IsFractionRing ℕ ℚ≥0"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 100,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The denumerability of ℚ — Cantor's observation that the rationals can be listed — is the root of this problem family. ℚ is, by construction, the field of fractions of ℤ: a rational is an equivalence class of pairs (numerator, nonzero denominator). The preceding entries kept the ℵ₀ side of OQ-05's dichotomy stable under enlarging the polynomial structure (univariate R[X], multivariate MvPolynomial σ R, monoid algebras). This entry turns to the construction that produces ℚ in the first place — localization — and shows it too preserves denumerability, so that #ℚ = ℵ₀ becomes a corollary of a general ring-theoretic principle rather than a hand-built bijection.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01-oq-01, structural direction)**: ℚ is the localization of ℤ at its nonzero elements. Does the denumerable side survive localization — is the fraction field (and, more generally, any localization) of a countable ring still countable, and does this recover #ℚ = ℵ₀?\n\n**Result**: countable_of_isLocalization (Countable S for any [IsLocalization M S] over countable R); instances Countable (Localization M) and Countable (FractionRing R); mk_fractionRing_eq_aleph0 (#(FractionRing R) = ℵ₀ for an infinite countable domain); and mk_rat_eq_aleph0 (#ℚ = ℵ₀), mk_nnrat_eq_aleph0 (#ℚ≥0 = ℵ₀) as specializations to IsFractionRing ℤ ℚ and IsFractionRing ℕ ℚ≥0.",
+    "text": "For a countable commutative semiring R and any localization S of R at a submonoid M, the ring S is countable. In particular the field of fractions of a countable commutative ring is countable, and for an infinite countable integral domain it is countably infinite: #(FractionRing R) = ℵ₀. Specializing to ℚ = Frac(ℤ) recovers #ℚ = ℵ₀.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `countable_of_isLocalization`: Mathlib's `IsLocalization.mk'_surjective` states that `fun ((r, m) : R × M) ↦ IsLocalization.mk' S r m` is surjective onto S. Since R is countable, the submonoid M (a subtype) is countable and so is the product R × M; `Function.Surjective.countable` then makes S countable. This is the exact denumerable mirror of Mathlib's `IsLocalization.fintype'`.\n2. `Localization.instCountable` / `instCountableFractionRing`: apply step 1 with S = Localization M (using the canonical `IsLocalization M (Localization M)`) and S = FractionRing R (using `IsFractionRing R (FractionRing R)` = `IsLocalization (nonZeroDivisors R) (FractionRing R)`).\n3. `mk_le_aleph0_of_isLocalization`: countability gives #S ≤ ℵ₀ via `Cardinal.mk_le_aleph0`.\n4. `mk_fractionRing_eq_aleph0`: the fraction field is infinite because `algebraMap R (FractionRing R)` is injective (`IsFractionRing.injective`) and R is infinite (`Infinite.of_injective`); together with countability, `Cardinal.mk_eq_aleph0` pins it at ℵ₀.\n5. `mk_rat_eq_aleph0` / `mk_nnrat_eq_aleph0`: ℚ carries `IsFractionRing ℤ ℚ` (`Rat.isFractionRing`) and ℚ≥0 carries `IsFractionRing ℕ ℚ≥0` (`NNRat.isFractionRing`), so both are countable by step 1 and infinite, hence ℵ₀ — recovering the root denumerability of the rationals.",
+    "keyInsights": [
+      "**Localization preserves denumerability.** The construction that builds ℚ from ℤ — inverting a multiplicative set — only ever forms a surjective image of R × M. Countability is therefore automatic; no fraction is ever 'new' from a cardinality standpoint.",
+      "**The denumerable analogue of a Fintype result Mathlib left open.** Mathlib has `IsLocalization.fintype'` with the note that it 'cannot be an instance'. The countable version `countable_of_isLocalization` is not in Mathlib; here it is supplied and, for the canonical `Localization M` and `FractionRing R`, packaged as honest instances.",
+      "**The loop closes on the root problem.** #ℚ = ℵ₀ is re-derived not by an explicit enumeration but as `IsFractionRing ℤ ℚ` plugged into the general principle — exhibiting Cantor's denumerability of the rationals as one instance of 'localizations of countable rings stay countable'.",
+      "**Only countability and injectivity are used.** The multiplicative structure of M and the ring axioms of S play no role in the count; the argument is purely the surjection R × M ↠ S plus, for infinitude, one injective coefficient map R ↪ FractionRing R."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_eq_aleph0 for countable infinite types, mk_le_aleph0)",
+      "Localization of a commutative ring: IsLocalization M S, mk', and the surjection mk'_surjective",
+      "Fraction fields: FractionRing R, IsFractionRing, and the canonical IsFractionRing ℤ ℚ / IsFractionRing ℕ ℚ≥0"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring framing localization as the construction behind ℚ and the denumerable analogue of IsLocalization.fintype', the Mathlib import, the Cardinal open, and the namespace.",
+      "mathContext": "$\\#(\\mathrm{FractionRing}\\,R) = \\aleph_0$ and $\\#\\mathbb{Q} = \\aleph_0$ as instances of localization preserving countability."
+    },
+    {
+      "id": "localization",
+      "title": "Localizations Preserve Countability",
+      "startLine": 43,
+      "endLine": 66,
+      "summary": "countable_of_isLocalization (Countable S for any [IsLocalization M S] over countable R, via mk'_surjective), and the instances Localization.instCountable and instCountableFractionRing.",
+      "mathContext": "$R \\times M \\twoheadrightarrow S$ via $\\mathrm{mk}'$, so $S$ is a surjective image of a countable type."
+    },
+    {
+      "id": "cardinality",
+      "title": "Cardinality Bounds",
+      "startLine": 67,
+      "endLine": 84,
+      "summary": "mk_le_aleph0_of_isLocalization (#S ≤ ℵ₀ for any localization of a countable ring) and mk_fractionRing_eq_aleph0 (#(FractionRing R) = ℵ₀ for an infinite countable integral domain).",
+      "mathContext": "$\\#(\\mathrm{FractionRing}\\,R) = \\aleph_0$ from countability plus the injective $R \\hookrightarrow \\mathrm{FractionRing}\\,R$."
+    },
+    {
+      "id": "rationals",
+      "title": "Closing the Loop: the Rationals",
+      "startLine": 85,
+      "endLine": 100,
+      "summary": "mk_rat_eq_aleph0 (#ℚ = ℵ₀ via IsFractionRing ℤ ℚ) and mk_nnrat_eq_aleph0 (#ℚ≥0 = ℵ₀ via IsFractionRing ℕ ℚ≥0).",
+      "mathContext": "$\\mathbb{Q} = \\mathrm{Frac}(\\mathbb{Z})$, so $\\#\\mathbb{Q} = \\aleph_0$ is the general principle specialized."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Continues the parent's program on which constructions preserve denumerability: where the parent enlarged the polynomial structure (MvPolynomial, MonoidAlgebra), this entry turns to localization — the construction that builds ℚ from ℤ — and shows it too keeps cardinality at ℵ₀"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Part of OQ-05's denumerability program over countable rings; here the ℵ₀ side is shown stable under passing to fraction fields and arbitrary localizations"
+    },
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "related",
+      "description": "Recovers the root result — the denumerability of ℚ, #ℚ = ℵ₀ — as the localization principle applied to IsFractionRing ℤ ℚ"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) extension of the denumerability program to localization: for a countable commutative semiring R, every localization S of R at a submonoid M is countable (countable_of_isLocalization, the denumerable analogue of Mathlib's IsLocalization.fintype'), so Localization M and FractionRing R are countable, #(FractionRing R) = ℵ₀ for an infinite countable integral domain, and #ℚ = ℵ₀, #ℚ≥0 = ℵ₀ follow by specializing to IsFractionRing ℤ ℚ and IsFractionRing ℕ ℚ≥0.",
+    "implications": "The denumerable side of OQ-05's dichotomy is robust under localization, the third major construction studied (after univariate and multivariate polynomial/monoid algebras). Most pointedly, the root fact #ℚ = ℵ₀ is recovered as a corollary of a general ring-theoretic principle rather than a bespoke enumeration of the rationals.",
+    "openQuestions": [
+      "Where does localization meet the continuum? For an uncountable ring R (e.g. #R = 𝔠), #(FractionRing R) = #R = 𝔠 is expected; is #(FractionRing R) = #R provable in general for infinite R, giving a localization analogue of the polynomial cardinality-preservation results?",
+      "Completion vs localization: the m-adic or valuation completion of a countable ring (e.g. ℤ_p over ℤ) reaches the continuum, contrasting with localization staying at ℵ₀ — can the ℵ₀/𝔠 boundary between these two 'enlarging' operations be made precise?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01OQ01",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ and the algebraic numbers; the ℵ₀ side recovered here as a localization"
+    },
+    {
+      "authors": "Atiyah, M. F. and Macdonald, I. G.",
+      "title": "Introduction to Commutative Algebra",
+      "year": "1969",
+      "venue": "Addison-Wesley",
+      "note": "Localization S⁻¹R and the construction of fraction fields; ℚ = Frac(ℤ)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers a structural open question of the parent **denumerability-rationals-oq-05-oq-01-oq-01** (#28056, merged): the parent enlarged the *polynomial* structure (MvPolynomial, MonoidAlgebra) while keeping cardinality at ℵ₀. This entry turns to **localization** — the construction that builds ℚ from ℤ — and shows it too preserves denumerability, recovering the root fact **#ℚ = ℵ₀** as a corollary of a general ring-theoretic principle.

## Results (`proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01.lean`, 100 lines, 7 decls)

- **`countable_of_isLocalization`** — for a countable commutative semiring `R` and *any* localization `S` of `R` at a submonoid `M` (`[IsLocalization M S]`), `S` is countable. This is the **denumerable analogue of Mathlib's `IsLocalization.fintype'`** (which Mathlib explicitly notes "cannot be an instance"). Proof: `IsLocalization.mk'_surjective` exhibits `S` as a surjective image of the countable type `R × M`.
- **`Localization.instCountable`**, **`instCountableFractionRing`** — the concrete localization and fraction field as countability instances.
- **`mk_le_aleph0_of_isLocalization`** — `#S ≤ ℵ₀`.
- **`mk_fractionRing_eq_aleph0`** — `#(FractionRing R) = ℵ₀` for an infinite countable integral domain (infinitude from the injective `algebraMap R (FractionRing R)`).
- **`mk_rat_eq_aleph0`** — `#ℚ = ℵ₀` re-derived via `IsFractionRing ℤ ℚ`, **closing the loop** to the root problem.
- **`mk_nnrat_eq_aleph0`** — `#ℚ≥0 = ℵ₀` via `IsFractionRing ℕ ℚ≥0`.

## Verification

- **0 sorries, 0 axioms** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound` for all theorems. No `sorryAx`, no `Lean.ofReduceBool`.
- Builds against Mathlib v4.26.0 (`lake env lean`, exit 0). Imports `Mathlib` only — self-contained.

## Gallery

- `src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01/meta.json` (status `verified`, badge `mathlib`, 0 axioms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)