### PR TITLE
research(bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03): uniform norm-Euclidean ℤ[√d] for d∈{-1,-2} [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3180,6 +3180,7 @@ import Proofs.NapoleonsTheoremOQ03
 import Proofs.NarcissisticNumberOQ01
 import Proofs.NavierStokes
 import Proofs.NesbittInequalityOQ01
+import Proofs.NormEuclideanZsqrtdFamilyOQ03
 import Proofs.NewtonIndStep2
 import Proofs.NewtonInductiveStep
 import Proofs.NewtonInductiveStepOQ01

--- a/proofs/Proofs/NormEuclideanZsqrtdFamilyOQ03.lean
+++ b/proofs/Proofs/NormEuclideanZsqrtdFamilyOQ03.lean
@@ -1,0 +1,229 @@
+/-
+  # Norm-Euclidean `ℤ[√d]` for the imaginary quadratic family — a uniform treatment
+
+  The parent gallery entries proved that the Gaussian integers `ℤ[i] = ℤ[√-1]` and
+  the ring `ℤ[√-2]` are Euclidean domains, each through an ad-hoc rounding bound
+  (`1/2` and `3/4` respectively). This file answers the third open question of the
+  `ℤ[√-2]` entry:
+
+    > Can the Euclidean-domain proof be generalised to a parameterised family
+    > `Zsqrtd d` for `d ∈ {-1,-2,-3,-7,-11}` with a *uniform* bound?
+
+  ## What we prove
+
+  For an arbitrary negative `d` we analyse the "nearest-lattice-point" division of
+  `Zsqrtd d`: given `x` and `y ≠ 0`, round each coordinate of `x · conj y / N(y)`
+  to the nearest integer. The remainder `r = x − y·q` then satisfies the *single
+  uniform inequality*
+
+      `4 · N(r) · N(y) ≤ (1 − d) · N(y)²`                        (`four_mul_norm_rem_le`)
+
+  for every negative `d`, i.e. `N(r) ≤ (1 − d)/4 · N(y)`. Hence whenever
+  `-2 ≤ d < 0` — that is, exactly `d ∈ {-1, -2}` — the factor is
+  `(1 − d)/4 ≤ 3/4 < 1`, so `N(r) < N(y)` (`norm_rem_lt`) and `ℤ[√d]` is
+  **norm-Euclidean with one uniform bound**. We package this as a value
+  `EuclideanDomain (ℤ√d)` depending only on the hypothesis `-2 ≤ d < 0`
+  (`euclideanDomain`), recovering both classical rings at once
+  (`euclideanDomainNegOne`, `euclideanDomainNegTwo`).
+
+  ## Why the family stops at `d = -2` (honest scope)
+
+  The open question lists `d ∈ {-1,-2,-3,-7,-11}`, but for `d = -3,-7,-11` the
+  object `Zsqrtd d` is the **wrong ring**: there the ring of integers of `ℚ(√d)`
+  is `ℤ[(1+√d)/2]`, not `ℤ[√d]`, and `ℤ[√-3]` is not even integrally closed (so
+  cannot be a PID, let alone a Euclidean domain). Correspondingly the
+  nearest-point factor `(1 − d)/4` is `≥ 1` precisely when `d ≤ -3`
+  (`nearest_point_factor_ge_one_of_le_neg_three`), so the uniform `Zsqrtd`
+  argument provably cannot extend. This is a genuine arithmetic obstruction, not a
+  weakness of the proof: the correct uniform family for all five discriminants
+  lives over the rings of integers `ℤ[ω]`, a different formalisation.
+
+  Everything is fully verified: 0 sorries, 0 axioms, no `native_decide`.
+-/
+import Mathlib
+
+open Zsqrtd
+
+namespace NormEuclideanZsqrtdFamily
+
+variable {d : ℤ}
+
+/-! ### A rational rounding bound
+
+The only analytic ingredient: rounding `m/k` to the nearest integer keeps the
+scaled error `m − q·k` within `±k/2`, equivalently `(2·(m − q·k))² ≤ k²`. -/
+
+/-- Rounding `m / k` (with `k > 0`) to the nearest integer `q := round (m/k)` gives
+`(2·(m − q·k))² ≤ k²`. -/
+theorem sq_two_mul_sub_round_le (m k : ℤ) (hk : 0 < k) :
+    (2 * (m - round ((m : ℚ) / (k : ℚ)) * k)) ^ 2 ≤ k ^ 2 := by
+  have hk' : (0 : ℚ) < (k : ℚ) := by exact_mod_cast hk
+  set q : ℤ := round ((m : ℚ) / (k : ℚ)) with hq
+  have hround : |(m : ℚ) / (k : ℚ) - q| ≤ 1 / 2 := abs_sub_round _
+  have hfac : (m : ℚ) - (q : ℚ) * k = (k : ℚ) * ((m : ℚ) / k - q) := by
+    field_simp
+  have herr : |(m : ℚ) - (q : ℚ) * k| ≤ (k : ℚ) / 2 := by
+    rw [hfac, abs_mul, abs_of_pos hk']
+    have hmul := mul_le_mul_of_nonneg_left hround hk'.le
+    calc (k : ℚ) * |(m : ℚ) / k - q| ≤ (k : ℚ) * (1 / 2) := hmul
+      _ = (k : ℚ) / 2 := by ring
+  -- the integer square inequality, obtained over ℚ then cast back
+  have hsq : ((2 * (m - q * k) : ℤ) : ℚ) ^ 2 ≤ ((k : ℤ) : ℚ) ^ 2 := by
+    push_cast
+    set X : ℚ := (m : ℚ) - (q : ℚ) * k with hX
+    have h2 : |2 * X| ≤ (k : ℚ) := by
+      rw [abs_mul, abs_two]; nlinarith [herr]
+    have hsqabs : (2 * X) ^ 2 ≤ (k : ℚ) ^ 2 := by
+      have hmm := mul_self_le_mul_self (abs_nonneg (2 * X)) h2
+      rw [← sq_abs (2 * X)]; nlinarith [hmm]
+    have hgoal : (2 * ((m : ℚ) - (q : ℚ) * k)) ^ 2 ≤ (k : ℚ) ^ 2 := by rw [← hX]; exact hsqabs
+    convert hgoal using 2
+  exact_mod_cast hsq
+
+/-! ### Nearest-lattice-point division -/
+
+variable (d) in
+/-- The nearest-lattice-point quotient: round each coordinate of `x · conj y / N(y)`
+to the nearest integer. (When `y = 0`, `N(y) = 0` and this is `0`, the convention
+required by `EuclideanDomain.quotient_zero`.) -/
+noncomputable def quo (x y : ℤ√d) : ℤ√d :=
+  ⟨round (((x * star y).re : ℚ) / (y.norm : ℚ)),
+   round (((x * star y).im : ℚ) / (y.norm : ℚ))⟩
+
+variable (d) in
+/-- The nearest-lattice-point remainder `r = x − y·q`. -/
+noncomputable def rem (x y : ℤ√d) : ℤ√d := x - y * quo d x y
+
+theorem quo_re (x y : ℤ√d) :
+    (quo d x y).re = round (((x * star y).re : ℚ) / (y.norm : ℚ)) := rfl
+
+theorem quo_im (x y : ℤ√d) :
+    (quo d x y).im = round (((x * star y).im : ℚ) / (y.norm : ℚ)) := rfl
+
+@[simp] theorem quotient_mul_add_remainder (x y : ℤ√d) :
+    y * quo d x y + rem d x y = x := by
+  simp [rem]
+
+theorem quo_zero (x : ℤ√d) : quo d x 0 = 0 := by
+  ext <;> simp [quo]
+
+/-- The real part of `(rem)·conj y` is the rounding error of the real coordinate. -/
+theorem rem_mul_star_re (x y : ℤ√d) :
+    (rem d x y * star y).re = (x * star y).re - (quo d x y).re * y.norm := by
+  have hy : (y : ℤ√d) * star y = (y.norm : ℤ√d) := (norm_eq_mul_conj y).symm
+  have key : rem d x y * star y = x * star y - quo d x y * (y.norm : ℤ√d) := by
+    rw [rem, sub_mul]
+    have hrw : (y * quo d x y) * star y = quo d x y * (y.norm : ℤ√d) := by
+      rw [mul_comm y, mul_assoc, hy]
+    rw [hrw]
+  rw [key]
+  simp only [re_sub, re_mul, re_intCast, im_intCast]
+  ring
+
+/-- The imaginary part of `(rem)·conj y` is the rounding error of the imag coordinate. -/
+theorem rem_mul_star_im (x y : ℤ√d) :
+    (rem d x y * star y).im = (x * star y).im - (quo d x y).im * y.norm := by
+  have hy : (y : ℤ√d) * star y = (y.norm : ℤ√d) := (norm_eq_mul_conj y).symm
+  have key : rem d x y * star y = x * star y - quo d x y * (y.norm : ℤ√d) := by
+    rw [rem, sub_mul]
+    have hrw : (y * quo d x y) * star y = quo d x y * (y.norm : ℤ√d) := by
+      rw [mul_comm y, mul_assoc, hy]
+    rw [hrw]
+  rw [key]
+  simp only [im_sub, im_mul, re_intCast, im_intCast]
+  ring
+
+/-! ### The uniform norm bound -/
+
+/-- **The uniform remainder bound.** For *every* negative `d`, the
+nearest-lattice-point remainder satisfies `4 · N(r) · N(y) ≤ (1 − d) · N(y)²`.
+The factor `(1 − d)/4` is the single uniform constant; it is `< 1` exactly when
+`-2 ≤ d`. -/
+theorem four_mul_norm_rem_le (hd : d < 0) (x y : ℤ√d) :
+    4 * ((rem d x y).norm * y.norm) ≤ (1 - d) * y.norm ^ 2 := by
+  rcases lt_or_eq_of_le (norm_nonneg hd.le y) with hpos | h0
+  · -- the generic case `0 < N(y)`
+    set R := rem d x y * star y with hR
+    have hRnorm : R.norm = (rem d x y).norm * y.norm := by rw [hR, norm_mul, norm_conj]
+    have hbre : (2 * R.re) ^ 2 ≤ y.norm ^ 2 := by
+      rw [hR, rem_mul_star_re, quo_re]; exact sq_two_mul_sub_round_le _ y.norm hpos
+    have hbim : (2 * R.im) ^ 2 ≤ y.norm ^ 2 := by
+      rw [hR, rem_mul_star_im, quo_im]; exact sq_two_mul_sub_round_le _ y.norm hpos
+    have hRdef : R.norm = R.re * R.re - d * R.im * R.im := norm_def R
+    have hfour : 4 * ((rem d x y).norm * y.norm) = (2 * R.re) ^ 2 - d * (2 * R.im) ^ 2 := by
+      rw [← hRnorm, hRdef]; ring
+    rw [hfour]
+    nlinarith [hbre, hbim, hd.le, sq_nonneg (2 * R.im)]
+  · -- degenerate case `N(y) = 0` (only when `y = 0`): both sides vanish
+    rw [← h0]; simp
+
+/-- **Uniform norm-Euclidean bound for `d ∈ {-1, -2}`.** When `-2 ≤ d < 0`, the
+nearest-lattice-point remainder has strictly smaller norm. -/
+theorem norm_rem_lt (hd : d < 0) (hd2 : -2 ≤ d) (x : ℤ√d) {y : ℤ√d} (hy : y ≠ 0) :
+    (rem d x y).norm < y.norm := by
+  have hpos : 0 < y.norm := by
+    rcases lt_or_eq_of_le (norm_nonneg hd.le y) with h | h
+    · exact h
+    · exact absurd ((norm_eq_zero_iff hd y).mp h.symm) hy
+  have hb := four_mul_norm_rem_le hd x y
+  have hrn := norm_nonneg hd.le (rem d x y)
+  nlinarith [hb, hpos, hrn, hd2, mul_pos hpos hpos]
+
+/-- The Euclidean division statement: existence of a quotient and remainder with
+strictly smaller norm. -/
+theorem exists_quotient_remainder (hd : d < 0) (hd2 : -2 ≤ d) (x : ℤ√d) {y : ℤ√d}
+    (hy : y ≠ 0) : ∃ q r : ℤ√d, x = y * q + r ∧ r.norm.natAbs < y.norm.natAbs := by
+  refine ⟨quo d x y, rem d x y, (quotient_mul_add_remainder x y).symm, ?_⟩
+  have h1 := norm_rem_lt hd hd2 x hy
+  have h2 := norm_nonneg hd.le (rem d x y)
+  have h3 := norm_nonneg hd.le y
+  omega
+
+/-! ### Packaging as a Euclidean domain -/
+
+variable (d) in
+/-- **`ℤ[√d]` is a Euclidean domain for every `-2 ≤ d < 0`**, with the *uniform*
+nearest-lattice-point division and the norm `|N(·)|` as Euclidean size. Specialising
+`d` to `-1` and `-2` recovers the Gaussian integers and `ℤ[√-2]` from a single proof. -/
+noncomputable def euclideanDomain (hd : d < 0) (hd2 : -2 ≤ d) : EuclideanDomain (ℤ√d) :=
+  { (inferInstance : CommRing (ℤ√d)), (inferInstance : Nontrivial (ℤ√d)) with
+    quotient := quo d
+    quotient_zero := quo_zero
+    remainder := rem d
+    quotient_mul_add_remainder_eq := fun a b => quotient_mul_add_remainder a b
+    r := fun a b => a.norm.natAbs < b.norm.natAbs
+    r_wellFounded := (measure fun z : ℤ√d => z.norm.natAbs).wf
+    remainder_lt := fun a {b} hb => by
+      have h1 := norm_rem_lt hd hd2 a hb
+      have h2 := norm_nonneg hd.le (rem d a b)
+      have h3 := norm_nonneg hd.le b
+      omega
+    mul_left_not_lt := fun a {b} hb => by
+      intro hlt
+      rw [norm_mul, Int.natAbs_mul] at hlt
+      have hb' : b.norm ≠ 0 := fun h => hb ((norm_eq_zero_iff hd b).mp h)
+      have hpos : 0 < b.norm.natAbs := by
+        rw [Int.natAbs_pos]; exact hb'
+      have hge : a.norm.natAbs ≤ a.norm.natAbs * b.norm.natAbs :=
+        Nat.le_mul_of_pos_right _ hpos
+      omega }
+
+/-- The Gaussian integers `ℤ[i] = ℤ[√-1]` as the `d = -1` member of the family. -/
+noncomputable def euclideanDomainNegOne : EuclideanDomain (ℤ√(-1)) :=
+  euclideanDomain (-1) (by norm_num) (by norm_num)
+
+/-- `ℤ[√-2]` as the `d = -2` member of the family. -/
+noncomputable def euclideanDomainNegTwo : EuclideanDomain (ℤ√(-2)) :=
+  euclideanDomain (-2) (by norm_num) (by norm_num)
+
+/-! ### The obstruction at `d ≤ -3` -/
+
+/-- **The uniform `Zsqrtd` argument provably stops at `d = -2`.** The
+nearest-point factor `(1 − d)/4` reaches `1` exactly at `d = -3` and exceeds it
+below, so the bound `N(r) < N(y)` is no longer forced. (Mathematically `ℤ[√d]` is
+not the ring of integers for `d ≤ -3` squarefree, and `ℤ[√-3]` is not even a
+Euclidean domain.) -/
+theorem nearest_point_factor_ge_one_of_le_neg_three (hd : d ≤ -3) : 4 ≤ 1 - d := by
+  omega
+
+end NormEuclideanZsqrtdFamily

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+  "title": "Norm-Euclidean ℤ[√d] for d ∈ {−1,−2}: A Uniform Family with One Bound",
+  "slug": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+  "description": "Answers the open question of whether the Euclidean-domain proofs for ℤ[i] and ℤ[√-2] can be unified into a parameterized family Zsqrtd(d) with a single uniform bound. We prove that for EVERY negative d the nearest-lattice-point remainder satisfies 4·N(r)·N(y) ≤ (1−d)·N(y)², so the uniform factor (1−d)/4 is < 1 exactly for d ∈ {−1,−2}, yielding a single EuclideanDomain construction specializing to both classical rings. We also prove the obstruction: (1−d)/4 ≥ 1 for d ≤ −3, so the naive Zsqrtd family provably cannot extend (the correct rings there are ℤ[ω]).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NormEuclideanZsqrtdFamilyOQ03.lean",
+    "tags": [
+      "number-theory",
+      "Euclidean-domain",
+      "Zsqrtd",
+      "imaginary-quadratic",
+      "norm-Euclidean"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Proved from first principles over Mathlib's Zsqrtd, EuclideanDomain, and round/abs_sub_round infrastructure. Depends only on the standard foundational axioms (propext, Classical.choice, Quot.sound); no sorry, no native_decide.",
+    "lineCount": 229,
+    "theoremCount": 11,
+    "definitionCount": 5,
+    "originalContributions": [
+      "sq_two_mul_sub_round_le: the single analytic input — rounding m/k keeps (2·(m−round(m/k)·k))² ≤ k², i.e. the coordinate error stays within ±k/2",
+      "four_mul_norm_rem_le: ONE uniform inequality 4·N(r)·N(y) ≤ (1−d)·N(y)² valid for EVERY negative d, factoring the d-dependence into the single constant (1−d)/4",
+      "norm_rem_lt / exists_quotient_remainder: the norm-Euclidean division property for the whole range −2 ≤ d < 0 at once",
+      "euclideanDomain: a single EuclideanDomain (ℤ√d) value parameterized by −2 ≤ d < 0, with euclideanDomainNegOne and euclideanDomainNegTwo recovering ℤ[i] and ℤ[√-2] from one proof",
+      "nearest_point_factor_ge_one_of_le_neg_three: the honest obstruction — the uniform factor (1−d)/4 reaches 1 at d=−3, so the Zsqrtd family provably stops at d=−2 (d=−3,−7,−11 need the ring of integers ℤ[ω])",
+      "A fully algebraic division proof using rational rounding (round on ℚ), avoiding the complex embedding ℂ used by the per-ring parent proofs"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Among imaginary quadratic fields ℚ(√d), exactly five discriminants d = −1,−2,−3,−7,−11 give norm-Euclidean rings of integers. For d = −1,−2 that ring is ℤ[√d] = Zsqrtd(d); for d = −3,−7,−11 it is ℤ[(1+√d)/2], strictly larger than ℤ[√d]. The classical norm-Euclidean proofs (Gauss for ℤ[i], Dedekind for the rest) all use the nearest-lattice-point division: round the rational/real quotient to the nearest lattice point and bound the remainder norm by the covering radius of the lattice. The parent gallery entries proved ℤ[i] and ℤ[√-2] separately, each via a complex embedding and an ad-hoc bound (1/2 and 3/4). This entry asks — and answers — whether the two proofs are instances of one uniform argument.",
+    "problemStatement": "Can the Euclidean-domain proof be generalized to a parameterized family Zsqrtd(d) for d ∈ {−1,−2,−3,−7,−11} with a uniform bound?",
+    "text": "**Answer**: Yes for d ∈ {−1,−2}, with a single uniform bound; and provably NO for d ≤ −3 over Zsqrtd(d), for a genuine arithmetic reason.\n\n**The uniform bound.** For any negative d and any x, y with y ≠ 0, set q = ⟨round(Re(x·ȳ)/N(y)), round(Im(x·ȳ)/N(y))⟩ and r = x − y·q. Multiplying r by ȳ turns each coordinate into a pure rounding error, and multiplicativity of the norm gives the single identity\n\n    4·N(r)·N(y) = (2·Re(r·ȳ))² − d·(2·Im(r·ȳ))² ≤ (1 − d)·N(y)².\n\nThe entire d-dependence is the constant (1 − d)/4. It is < 1 exactly when −2 ≤ d, i.e. d ∈ {−1,−2}, giving N(r) < N(y).\n\n**The obstruction.** For d ≤ −3 the factor (1 − d)/4 ≥ 1, so the covering-radius bound no longer forces a strict decrease — and indeed Zsqrtd(d) is the wrong ring there (ℤ[√−3] is not integrally closed, hence not a PID/Euclidean domain). The honest uniform family for all five discriminants must be built over ℤ[(1+√d)/2].",
+    "proofStrategy": "1. Prove the only analytic fact, sq_two_mul_sub_round_le, from Mathlib's abs_sub_round: |t − round t| ≤ 1/2 scaled by k. 2. Define the nearest-point quotient quo and remainder rem over ℚ-coordinates (no ℂ). 3. Show (rem·conj y) has coordinates equal to the rounding errors (rem_mul_star_re/im), using norm_eq_mul_conj. 4. Combine multiplicativity N(r·ȳ)=N(r)·N(y) (norm_mul, norm_conj) with the two squared error bounds to get the single inequality four_mul_norm_rem_le for all d<0. 5. Specialize to −2 ≤ d to get norm_rem_lt and assemble the EuclideanDomain value. 6. Record the d ≤ −3 obstruction.",
+    "keyInsights": [
+      "Working purely algebraically over ℚ (rational rounding) instead of embedding into ℂ makes the proof uniform in d: the factor √(−d) never appears, only the integer d as a coefficient.",
+      "Multiplying the remainder r by the conjugate ȳ is the key trick: (r·ȳ).re and (r·ȳ).im are exactly the scaled rounding errors, and N(r·ȳ) = N(r)·N(y) converts the coordinate bounds into a bound on N(r).",
+      "All of the d-dependence collapses into the single constant (1−d)/4 = (1+|d|)/4 — the squared covering radius of the rectangular lattice ℤ ⊕ √|d|·ℤ.",
+      "(1−d)/4 < 1 ⟺ |d| < 3, so d ∈ {−1,−2} is forced; the boundary case |d| = 3 (factor exactly 1) is precisely where Zsqrtd stops being the ring of integers.",
+      "The same statement four_mul_norm_rem_le holds for ALL negative d (even where the ring is not Euclidean): it is the bound that is uniform, and the conclusion that depends on d."
+    ],
+    "prerequisites": [
+      "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03: ℤ[√-2] as a Euclidean domain (3/4 bound)",
+      "Mathlib: Zsqrtd (norm, star, norm_mul, norm_conj, norm_eq_mul_conj), EuclideanDomain, round, abs_sub_round",
+      "The covering-radius / nearest-lattice-point view of norm-Euclidean rings"
+    ]
+  },
+  "conclusion": {
+    "summary": "There is a single uniform nearest-lattice-point bound 4·N(r)·N(y) ≤ (1−d)·N(y)² valid for every negative d. Its factor (1−d)/4 is < 1 exactly for d ∈ {−1,−2}, so one EuclideanDomain construction covers ℤ[i] and ℤ[√-2] simultaneously; for d ≤ −3 the factor is ≥ 1 and the Zsqrtd family provably cannot continue.",
+    "implications": "The uniform argument cleanly separates the geometric core (a single covering-radius inequality, uniform in d) from the arithmetic threshold (which d keep the factor below 1). It also identifies the precise reason the family stops at d = −2 over Zsqrtd: the boundary |d| = 3 is exactly where ℤ[√d] ceases to be the ring of integers. A genuinely complete five-discriminant family requires reformulating over the maximal orders ℤ[(1+√d)/2].",
+    "openQuestions": [
+      "Build the analogous uniform Euclidean-domain proof over the rings of integers ℤ[(1+√d)/2] for d ∈ {−3,−7,−11}, where the covering radius of the hexagonal/centered lattice gives the correct sub-1 bound.",
+      "Does the uniform bound four_mul_norm_rem_le give a clean uniform proof that ℤ[√d] is a PID/UFD for d ∈ {−1,−2}, and can the inert-prime classifications of the parent entries be merged into one Legendre-symbol statement over the family?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "NormEuclideanZsqrtdFamily",
+    "lineCount": 229,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 5,
+    "path": "Proofs/NormEuclideanZsqrtdFamilyOQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Parent proof: ℤ[√-2] as a Euclidean domain via the ad-hoc 3/4 bound and complex embedding. This entry answers its third open question by unifying it with the ℤ[i] case under one bound."
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Grandparent proof: Gaussian integers ℤ[i] = ℤ[√-1] as a Euclidean domain (1/2 bound). Recovered here as euclideanDomainNegOne, the d = −1 member of the uniform family."
+    },
+    {
+      "targetId": "quadratic-reciprocity",
+      "relationship": "thematic",
+      "description": "The arithmetic threshold separating norm-Euclidean discriminants ties to which d are squares mod p; the parent entries use quadratic reciprocity for their inert-prime classifications."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-rounding",
+      "title": "Part I: The Rational Rounding Bound",
+      "startLine": 50,
+      "endLine": 81,
+      "summary": "sq_two_mul_sub_round_le: the sole analytic input. From Mathlib's abs_sub_round (|t − round t| ≤ 1/2), scaling by k gives (2·(m − round(m/k)·k))² ≤ k², proved over ℚ and cast back to ℤ."
+    },
+    {
+      "id": "sec-division",
+      "title": "Part II: Nearest-Lattice-Point Division",
+      "startLine": 83,
+      "endLine": 139,
+      "summary": "quo and rem defined over ℚ-coordinates (no ℂ). quo_zero gives the y=0 convention. rem_mul_star_re/im show that r·conj y has the two scaled rounding errors as coordinates, via norm_eq_mul_conj."
+    },
+    {
+      "id": "sec-bound",
+      "title": "Part III: The Uniform Norm Bound",
+      "startLine": 141,
+      "endLine": 185,
+      "summary": "four_mul_norm_rem_le: 4·N(r)·N(y) ≤ (1−d)·N(y)² for all d<0, combining norm multiplicativity with the two coordinate bounds. norm_rem_lt and exists_quotient_remainder specialize to −2 ≤ d < 0."
+    },
+    {
+      "id": "sec-euclidean",
+      "title": "Part IV: One Euclidean Domain for the Family",
+      "startLine": 187,
+      "endLine": 218,
+      "summary": "euclideanDomain: a single EuclideanDomain (ℤ√d) value for any −2 ≤ d < 0, with euclideanDomainNegOne (ℤ[i]) and euclideanDomainNegTwo (ℤ[√-2]) as the two members."
+    },
+    {
+      "id": "sec-obstruction",
+      "title": "Part V: The Obstruction at d ≤ −3",
+      "startLine": 220,
+      "endLine": 229,
+      "summary": "nearest_point_factor_ge_one_of_le_neg_three: (1−d)/4 ≥ 1 exactly when d ≤ −3, so the uniform Zsqrtd argument provably stops at d = −2; the d = −3,−7,−11 rings require ℤ[ω]."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03` (ℤ[√-2] as a Euclidean domain):

> Can the Euclidean-domain proof be generalized to a parameterized family `Zsqrtd(d)` for `d ∈ {-1,-2,-3,-7,-11}` with a *uniform* bound?

**Answer: yes for `d ∈ {-1,-2}` with one bound, and provably no for `d ≤ -3` over `Zsqrtd(d)`** — for a genuine arithmetic reason, not a proof weakness.

## What is proved

For **every** negative `d`, the nearest-lattice-point remainder satisfies a single inequality
```
4 · N(r) · N(y) ≤ (1 − d) · N(y)²        (four_mul_norm_rem_le)
```
The whole `d`-dependence is the constant `(1 − d)/4` (the squared covering radius of the lattice `ℤ ⊕ √|d|·ℤ`). It is `< 1` **exactly** when `-2 ≤ d`, i.e. `d ∈ {-1,-2}`, giving `N(r) < N(y)` (`norm_rem_lt`) and one `EuclideanDomain (ℤ√d)` value (`euclideanDomain`) that specializes to:
- `euclideanDomainNegOne` — the Gaussian integers `ℤ[i] = ℤ[√-1]`,
- `euclideanDomainNegTwo` — `ℤ[√-2]`,

from a **single** proof.

The obstruction is recorded honestly: `nearest_point_factor_ge_one_of_le_neg_three` shows `(1 − d)/4 ≥ 1` for `d ≤ -3`, so the naive `Zsqrtd` family cannot continue — and indeed for `d = -3,-7,-11` the ring of integers is `ℤ[(1+√d)/2]`, not `ℤ[√d]` (`ℤ[√-3]` is not integrally closed).

## Technique

A fully **algebraic** division via rational rounding (`round` on ℚ, `abs_sub_round`), avoiding the complex embedding `ℂ` used per-ring by the parent entries — this is precisely what makes the argument uniform in `d` (the factor `√(-d)` never appears, only the integer `d` as a coefficient). Multiplying the remainder by the conjugate turns each coordinate into a scaled rounding error, and `norm_mul`/`norm_conj` convert the coordinate bounds into the norm bound.

## Verification

- 229 lines, 11 theorems, 5 defs
- **0 sorries, 0 `axiom` declarations, no `native_decide`**
- `#print axioms` for the main results lists only `propext`, `Classical.choice`, `Quot.sound`
- Builds against the pinned Mathlib via `lake env lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)