### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01): exact Stirling asymptotic of even unit-ball volumes ω_{2k} ~ (πe/k)^k/√(2πk) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -147,6 +147,7 @@ import Proofs.AreaOfCircle
 import Proofs.AreaOfCircleOQ01OQ02OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ01
+import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ03

--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,147 @@
+/-
+# The Exact Stirling Asymptotic of the Even Unit-Ball Volumes
+
+## Open Question: area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02
+
+**Question** (as posed): Prove the exact asymptotics
+`ω_n ~ √(2π/n) · (2πe/n)^(n/2)` from Stirling's formula in Mathlib.
+
+**What we prove (and a correction).** The ancestor file proved only that the
+unit `n`-ball volumes `ω_n = π^(n/2) / Γ(n/2+1)` tend to `0`. Here we pin the
+*exact decay rate* of the even subsequence using Mathlib's Stirling formula
+`Stirling.factorial_isEquivalent_stirling`:
+
+  `ω_{2k} ~[atTop] (π e / k)^k / √(2π k)`.
+
+Writing `n = 2k` (so `k = n/2`) this reads
+
+  `ω_n ~ (2π e / n)^(n/2) / √(π n)`,
+
+i.e. the universal leading constant is `1/√(π n)`, **not** `√(2π/n)` as the
+question literally states. From `Γ(n/2+1) ~ √(π n)·(n/(2e))^(n/2)` (Stirling),
+
+  `ω_n = π^(n/2)/Γ(n/2+1) ~ π^(n/2) / (√(π n)·(n/(2e))^(n/2))
+        = (2π e / n)^(n/2) / √(π n)`,
+
+and `1/√(π n) ≠ √(2π/n)` (they differ by the factor `√2·π`). So the proved
+constant `1/√(π n)` is the correct one; we record the discrepancy honestly.
+
+**Self-contained.** The committed ancestor `AreaOfCircleOQ01OQ02OQ01OQ01.lean`
+does not currently compile under Mathlib `v4.26.0` (an orphaned doc-comment plus
+a `Real.Gamma` rewrite that drifted). To keep this file independently
+machine-checkable we re-derive the minimal infrastructure it needs — the
+definition `ω`, the dimension-recurrence `ω_{n+2} = (2π/(n+2))·ω_n`, and the even
+closed form `ω_{2k} = π^k/k!` — directly, then prove the new asymptotic. The
+recurrence proof here is the drift-corrected version.
+
+## Mathlib ingredients
+- `Stirling.factorial_isEquivalent_stirling` — `n! ~ √(2π n)·(n/e)^n`.
+- `Real.Gamma_add_one`, `Real.Gamma_one`, `Real.Gamma_pos_of_pos` — Γ recurrence.
+- `Asymptotics.IsEquivalent.{mul,inv,congr_right}`, `isEquivalent_iff_tendsto_one`.
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Stirling
+import Mathlib.Analysis.SpecialFunctions.Gamma.Basic
+import Mathlib.Analysis.Asymptotics.AsymptoticEquivalent
+import Mathlib.Tactic
+
+open Real Filter Asymptotics Nat
+open scoped Topology
+
+namespace BallVolumeAsymptotic
+
+/-- The volume of the unit `n`-ball, `ω_n = π^(n/2) / Γ(n/2 + 1)`. -/
+noncomputable def ω (n : ℕ) : ℝ := π ^ ((n : ℝ) / 2) / Real.Gamma ((n : ℝ) / 2 + 1)
+
+/-- `ω_0 = 1` (the "volume" of a point). -/
+theorem omega_zero : ω 0 = 1 := by
+  simp [ω, Real.Gamma_one]
+
+/-- Positivity of the half-integer Gamma values appearing in `ω`. -/
+theorem gamma_half_pos (n : ℕ) : 0 < Real.Gamma ((n : ℝ) / 2 + 1) :=
+  Real.Gamma_pos_of_pos (by positivity)
+
+/-- **Dimension recurrence** `ω_{n+2} = (2π / (n+2)) · ω_n`.
+
+This is the drift-corrected proof: after `↑(n+2)/2 = ↑n/2 + 1`, the `Γ` argument
+becomes `(↑n/2 + 1) + 1` *definitionally*, so a single `Gamma_add_one` discharges
+it (no second cast rewrite, which is where the ancestor file broke). -/
+theorem omega_recurrence (n : ℕ) : ω (n + 2) = 2 * π / (↑n + 2) * ω n := by
+  unfold ω
+  have hcast1 : (↑(n + 2) : ℝ) / 2 = ↑n / 2 + 1 := by push_cast; ring
+  have hpos : (0 : ℝ) < ↑n / 2 + 1 := by positivity
+  have hΓ : 0 < Real.Gamma ((n : ℝ) / 2 + 1) := gamma_half_pos n
+  rw [hcast1, rpow_add pi_pos, rpow_one, Gamma_add_one hpos.ne']
+  have hn2 : (↑n : ℝ) + 2 ≠ 0 := by positivity
+  field_simp
+
+/-- **Even closed form** `ω_{2k} = π^k / k!`.
+
+Pure induction on the recurrence (no `Γ` manipulation), exactly as the classical
+even-subsequence identity. -/
+theorem omega_even_formula : ∀ k : ℕ, ω (2 * k) = π ^ k / (k ! : ℝ)
+  | 0 => by simp [omega_zero]
+  | k + 1 => by
+    rw [show 2 * (k + 1) = 2 * k + 2 from by ring, omega_recurrence (2 * k),
+        omega_even_formula k, Nat.factorial_succ]
+    have h1 : (2 * (↑k : ℝ) + 2) ≠ 0 := by positivity
+    have h2 : (↑(k !) : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (factorial_pos k).ne'
+    have h3 : (↑k : ℝ) + 1 ≠ 0 := by positivity
+    push_cast
+    field_simp
+    ring
+
+/-- **Exact even asymptotic.** The even unit-ball volumes satisfy
+
+  `ω_{2k} ~[atTop] (π·e / k)^k / √(2π k)`.
+
+This is the exact Stirling decay rate sharpening `ω_n → 0`: it identifies both
+the super-exponential shape `(πe/k)^k` and the precise polynomial prefactor
+`1/√(2πk)`. -/
+theorem omega_even_isEquivalent :
+    (fun k : ℕ => ω (2 * k)) ~[atTop]
+      (fun k : ℕ => (π * Real.exp 1 / (k : ℝ)) ^ k / Real.sqrt (2 * π * k)) := by
+  have hstir := Stirling.factorial_isEquivalent_stirling
+  -- `ω(2k) = π^k * (k!)⁻¹` pointwise.
+  have homega : (fun k : ℕ => ω (2 * k)) =ᶠ[atTop]
+      (fun k : ℕ => (π : ℝ) ^ k * ((k ! : ℝ))⁻¹) := by
+    filter_upwards with k
+    rw [omega_even_formula k, div_eq_mul_inv]
+  -- Transport Stirling through `π^k · (·)⁻¹`.
+  have hmul : (fun k : ℕ => (π : ℝ) ^ k * ((k ! : ℝ))⁻¹) ~[atTop]
+      (fun k : ℕ => (π : ℝ) ^ k *
+        (Real.sqrt (2 * k * π) * ((k : ℝ) / Real.exp 1) ^ k)⁻¹) :=
+    (IsEquivalent.refl).mul hstir.inv
+  -- The transported right-hand side equals the clean closed form (for `k ≥ 1`).
+  have hclean : (fun k : ℕ => (π : ℝ) ^ k *
+        (Real.sqrt (2 * k * π) * ((k : ℝ) / Real.exp 1) ^ k)⁻¹) =ᶠ[atTop]
+      (fun k : ℕ => (π * Real.exp 1 / (k : ℝ)) ^ k / Real.sqrt (2 * π * k)) := by
+    filter_upwards [eventually_gt_atTop 0] with k hk
+    have hsqrt : Real.sqrt (2 * (k : ℝ) * π) = Real.sqrt (2 * π * k) := by
+      rw [mul_right_comm]
+    have hpow : π ^ k * (Real.exp 1 / (k : ℝ)) ^ k = (π * Real.exp 1 / (k : ℝ)) ^ k := by
+      rw [← mul_pow, ← mul_div_assoc]
+    rw [hsqrt, mul_inv, ← inv_pow, inv_div,
+        show (π : ℝ) ^ k * ((Real.sqrt (2 * π * k))⁻¹ * (Real.exp 1 / (k : ℝ)) ^ k)
+          = (π ^ k * (Real.exp 1 / (k : ℝ)) ^ k) * (Real.sqrt (2 * π * k))⁻¹ from by ring,
+        hpow, div_eq_mul_inv ((π * Real.exp 1 / (k : ℝ)) ^ k)]
+  exact homega.isEquivalent.trans (hmul.congr_right hclean)
+
+/-- The exact even asymptotic restated as a limit of the normalised ratio:
+
+  `ω_{2k} / ((π·e/k)^k / √(2π k)) → 1`. -/
+theorem omega_even_ratio_tendsto_one :
+    Tendsto (fun k : ℕ => ω (2 * k) /
+        ((π * Real.exp 1 / (k : ℝ)) ^ k / Real.sqrt (2 * π * k)))
+      atTop (nhds 1) := by
+  have hne : ∀ᶠ k : ℕ in atTop,
+      (π * Real.exp 1 / (k : ℝ)) ^ k / Real.sqrt (2 * π * k) ≠ 0 := by
+    filter_upwards [eventually_gt_atTop 0] with k hk
+    have hk0 : (0 : ℝ) < k := by exact_mod_cast hk
+    have h1 : (0 : ℝ) < π * Real.exp 1 / k :=
+      div_pos (mul_pos pi_pos (Real.exp_pos 1)) hk0
+    have h2 : (0 : ℝ) < Real.sqrt (2 * π * k) := Real.sqrt_pos.mpr (by positivity)
+    exact (div_pos (pow_pos h1 k) h2).ne'
+  exact (isEquivalent_iff_tendsto_one hne).mp omega_even_isEquivalent
+
+end BallVolumeAsymptotic

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,87 @@
+{
+  "id": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+  "title": "The Exact Stirling Asymptotic of the Even Unit-Ball Volumes: ω_{2k} ~ (πe/k)^k/√(2πk)",
+  "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+  "description": "Sharpens the ancestor result ω_n → 0 to the exact decay rate of the even subsequence. From the exact even formula ω_{2k} = π^k/k! and Mathlib's Stirling formula n! ~ √(2πn)(n/e)^n, we prove ω_{2k} ~[atTop] (πe/k)^k/√(2πk). In terms of n = 2k this is ω_n ~ (2πe/n)^(n/2)/√(πn); we note that the universal constant is 1/√(πn), correcting the originally-posed √(2π/n) (off by a factor √2·π). Self-contained: re-derives ω, the dimension recurrence, and the even formula, since the committed ancestor file does not currently compile under Mathlib v4.26. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Classical asymptotic (Stirling); formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Volume_of_an_n-ball",
+    "date": "Classical",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "asymptotics",
+      "geometry",
+      "stirling",
+      "gamma-function",
+      "limits",
+      "research",
+      "open-problem"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Stirling.factorial_isEquivalent_stirling",
+        "description": "n! ~[atTop] √(2πn)·(n/e)^n (Stirling's formula as an IsEquivalent)",
+        "module": "Mathlib.Analysis.SpecialFunctions.Stirling"
+      },
+      {
+        "theorem": "Asymptotics.IsEquivalent.mul",
+        "description": "Asymptotic equivalence is compatible with multiplication",
+        "module": "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent"
+      },
+      {
+        "theorem": "Asymptotics.IsEquivalent.inv",
+        "description": "Asymptotic equivalence is compatible with inversion",
+        "module": "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent"
+      },
+      {
+        "theorem": "Asymptotics.isEquivalent_iff_tendsto_one",
+        "description": "f ~ g iff f/g → 1 when g is eventually nonzero",
+        "module": "Mathlib.Analysis.Asymptotics.AsymptoticEquivalent"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Γ(s+1) = s·Γ(s) for s ≠ 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      }
+    ],
+    "originalContributions": [
+      "omega_even_isEquivalent: the exact even-subsequence Stirling asymptotic ω_{2k} ~ (πe/k)^k/√(2πk) — sharpens the ancestor's mere ω_n → 0 to the precise super-exponential decay rate with exact prefactor",
+      "omega_even_ratio_tendsto_one: the same statement as a normalised-ratio limit → 1, via isEquivalent_iff_tendsto_one",
+      "Correction of the originally-posed constant: the universal coefficient is 1/√(πn), not √(2π/n) (they differ by the factor √2·π)",
+      "omega_recurrence: drift-corrected proof of ω_{n+2} = (2π/(n+2))·ω_n under Mathlib v4.26 (a single Gamma_add_one after the cast, avoiding the broken second-cast rewrite)",
+      "Self-contained re-derivation of ω, the recurrence, and the even formula ω_{2k} = π^k/k! (the committed ancestor AreaOfCircleOQ01OQ02OQ01OQ01.lean no longer compiles)"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 147,
+    "prerequisites": [
+      "Stirling's formula in IsEquivalent form (Mathlib)",
+      "Multiplicative calculus of asymptotic equivalence",
+      "Gamma function recurrence Γ(s+1) = s·Γ(s)",
+      "Even ball-volume closed form ω_{2k} = π^k/k!"
+    ],
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The unit n-ball volume ω_n = π^(n/2)/Γ(n/2+1) shrinks to 0 in high dimensions — the 'curse of dimensionality'. The ancestor entry proved only ω_n → 0. The sharper question is the exact rate. Stirling's formula resolves it: ω_n decays super-exponentially like (2πe/n)^(n/2) with a polynomial prefactor 1/√(πn). This file pins the exact even-subsequence asymptotic rigorously from Mathlib's Stirling lemma.",
+    "problemStatement": "**Question** (as posed): prove ω_n ~ √(2π/n)·(2πe/n)^(n/2) from Stirling.\n\n**Result**: For the even subsequence, ω_{2k} ~[atTop] (πe/k)^k/√(2πk). Equivalently, in terms of n = 2k, ω_n ~ (2πe/n)^(n/2)/√(πn). The correct universal constant is 1/√(πn); the posed √(2π/n) is off by a factor √2·π.",
+    "text": "The even unit-ball volumes satisfy the exact Stirling asymptotic ω_{2k} ~ (πe/k)^k/√(2πk), sharpening ω_n → 0 to its precise decay rate.",
+    "proofStrategy": "1. **Self-contained infrastructure**: define ω_n = π^(n/2)/Γ(n/2+1); prove ω_0 = 1, the recurrence ω_{n+2} = (2π/(n+2))·ω_n (drift-corrected for Mathlib v4.26), and by induction the even closed form ω_{2k} = π^k/k!.\n\n2. **Transport Stirling**: ω_{2k} = π^k·(k!)⁻¹. From k! ~ √(2πk)(k/e)^k (Stirling), IsEquivalent.inv gives (k!)⁻¹ ~ (√(2πk)(k/e)^k)⁻¹; multiply by the common factor π^k (IsEquivalent.mul with refl).\n\n3. **Clean closed form**: pointwise (for k ≥ 1) the transported RHS equals (πe/k)^k/√(2πk), via inv_pow/inv_div/mul_pow algebra; transport through IsEquivalent.congr_right.\n\n4. **Ratio form**: isEquivalent_iff_tendsto_one converts to ω_{2k}/((πe/k)^k/√(2πk)) → 1.",
+    "keyInsights": [
+      "**Exact even formula is the lever**: because ω_{2k} = π^k/k! is *exact*, the asymptotic reduces to Stirling for k! with no error analysis — the equivalence calculus (mul, inv, congr_right) does the rest.",
+      "**The posed constant is wrong**: Stirling gives ω_n ~ (2πe/n)^(n/2)/√(πn), i.e. coefficient 1/√(πn). The originally-stated √(2π/n) differs by the factor √2·π. We prove and record the correct constant.",
+      "**Super-exponential decay made precise**: the shape (πe/k)^k = (πe/k)^k vanishes faster than any geometric rate once k > πe, quantifying exactly how fast the ball 'empties'.",
+      "**Drift repair as a by-product**: the committed ancestor file no longer builds under Mathlib v4.26 (an orphaned doc-comment and a Gamma cast-rewrite that drifted). The recurrence is re-proved here correctly, keeping this entry independently machine-checkable."
+    ],
+    "prerequisites": [
+      "Stirling's formula (Mathlib, IsEquivalent form)",
+      "Asymptotic equivalence calculus",
+      "Gamma recurrence and ball-volume even formula"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02`: *prove the exact Stirling asymptotics of the unit n-ball volumes*. The ancestor entry proved only `ω_n → 0`; this file pins the **exact decay rate** of the even subsequence:

```
ω_{2k} ~[atTop] (π·e / k)^k / √(2π k)
```

In terms of `n = 2k` this reads `ω_n ~ (2πe/n)^(n/2) / √(πn)`.

### Correction to the posed constant
The question was posed as `ω_n ~ √(2π/n)·(2πe/n)^(n/2)`. From `Γ(n/2+1) ~ √(πn)·(n/(2e))^(n/2)` the correct universal coefficient is `1/√(πn)`, **not** `√(2π/n)` — they differ by the factor `√2·π`. The proved (correct) constant is `1/√(πn)`; this is documented in the file and meta.

### Proof
1. Self-contained infrastructure: `ω_n = π^(n/2)/Γ(n/2+1)`, `ω_0 = 1`, the dimension recurrence `ω_{n+2} = (2π/(n+2))·ω_n`, and by induction the exact even formula `ω_{2k} = π^k/k!`.
2. `ω_{2k} = π^k·(k!)⁻¹`; transport Stirling `k! ~ √(2πk)(k/e)^k` via `IsEquivalent.inv`/`.mul`, then `IsEquivalent.congr_right` to the clean closed form.
3. Ratio form via `isEquivalent_iff_tendsto_one`.

### Verification
- 5 theorems, 1 definition, **0 sorries, 0 axioms** (`#print axioms` → `propext, Classical.choice, Quot.sound` only — no `sorryAx`, no `Lean.ofReduceBool`).
- Builds standalone with `lake env lean` under Mathlib v4.26.0.

### ⚠️ Note for auditor/mechanic — broken ancestor
While building I found that the committed ancestor `proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean` (gallery `area-of-circle-oq-01-oq-02-oq-01-oq-01`, marked **verified**) **does not compile under Mathlib v4.26.0**:
- line ~97: an orphaned `/-- … -/` doc-comment with no following declaration (parse error);
- line ~83: a `Real.Gamma` cast `rw` that drifted (`↑(n+2)/2 + 1` pattern no longer present after the first cast rewrite).

This entry sidesteps it by re-deriving the needed infrastructure (with a drift-corrected recurrence proof), so this PR builds independently. The ancestor still needs a separate repair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)