### PR TITLE
Enrich Hilbert 10 OQ-04·OQ-03·OQ-01: Constructive Bézout Solver

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 29 },
+    "type": "concept",
+    "title": "Overview: From a Decision Procedure to a Constructive Solver",
+    "content": "The header states the upgrade this file performs. The parent (Hilbert10OQ04) records the *decidability* of linear Diophantine solvability — a₁x₁+…+aₙxₙ = c has an integer solution iff gcd(a₁,…,aₙ) ∣ c — but only existentially, via the principal coefficient ideal and an abstractly chosen generator (Classical.choice). This entry replaces 'a solution exists' with 'here is the solution': it produces an explicit, computable witness x : Fin n → ℤ whenever the gcd divides c. The mechanism is the classical extended Euclidean algorithm folded over the coefficient vector — read Bézout cofactors in the two-variable case, then recurse on the number of variables. The headline results are therefore theorems, not axioms, and the witness is genuinely computable.",
+    "mathContext": "A linear Diophantine equation $\\sum_{i} a_i x_i = c$ over $\\mathbb{Z}$ is solvable iff $\\gcd(a_1,\\dots,a_n) \\mid c$ (a multivariate Bézout criterion). The *forward* direction — existence of a solution — is what gets a constructive witness here, via the extended Euclidean cofactors $\\mathrm{gcdA}, \\mathrm{gcdB}$ satisfying $a\\,\\mathrm{gcdA} + b\\,\\mathrm{gcdB} = \\gcd(a,b)$.",
+    "significance": "key",
+    "prerequisites": ["Bézout's identity", "extended Euclidean algorithm", "linear Diophantine equations"],
+    "relatedConcepts": ["Hilbert's 10th problem", "constructive mathematics", "Int.gcdA / Int.gcdB", "decidability vs. construction"]
+  },
+  {
+    "id": "ann-defs-bezout",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01",
+    "range": { "startLine": 34, "endLine": 42 },
+    "type": "definition",
+    "title": "The Two-Variable Solution Components bezoutX, bezoutY",
+    "content": "`bezoutX a b c = Int.gcdA a b * (c / gcd a b)` and `bezoutY a b c = Int.gcdB a b * (c / gcd a b)` are the explicit, *computable* solution components of a·x + b·y = c. The idea is pure scaling: Mathlib's cofactors gcdA, gcdB already solve a·x + b·y = gcd a b exactly (Bézout's identity), so multiplying each by the integer factor k = c / gcd a b solves a·x + b·y = c — provided gcd a b ∣ c so that the division is exact. These are `def`s (not theorems), so they evaluate on concrete inputs, which is the whole point of a constructive solver.",
+    "mathContext": "From $a\\,\\mathrm{gcdA} + b\\,\\mathrm{gcdB} = \\gcd(a,b)$, scaling by $k = c/\\gcd(a,b)$ gives $a(\\mathrm{gcdA}\\,k) + b(\\mathrm{gcdB}\\,k) = \\gcd(a,b)\\cdot k = c$. The components $x = \\mathrm{gcdA}\\,k$, $y = \\mathrm{gcdB}\\,k$ are exactly bezoutX, bezoutY.",
+    "significance": "key",
+    "prerequisites": ["Bézout cofactors", "integer division"],
+    "relatedConcepts": ["Int.gcdA", "Int.gcdB", "scaling a Bézout solution", "computable definitions"]
+  },
+  {
+    "id": "ann-solve-spec",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01",
+    "range": { "startLine": 44, "endLine": 61 },
+    "type": "theorem",
+    "title": "Correctness of the Two-Variable Solver",
+    "content": "`bezout_solve_spec` proves that when gcd a b ∣ c, the pair (bezoutX, bezoutY) genuinely satisfies a·x + b·y = c. The proof unfolds the definitions, then `ring` factors the common scaling: a·(gcdA·k) + b·(gcdB·k) = (a·gcdA + b·gcdB)·k. Rewriting the parenthesized sum back to gcd a b via `Int.gcd_eq_gcd_ab` leaves gcd·(c/gcd), which `Int.mul_ediv_cancel' h` collapses to c — this is the single lemma that uses the divisibility hypothesis h to make the integer division exact. `bezout_two_exists` then repackages this as a pure ∃-statement.",
+    "mathContext": "$a\\cdot\\mathrm{bezoutX} + b\\cdot\\mathrm{bezoutY} = (a\\,\\mathrm{gcdA} + b\\,\\mathrm{gcdB})\\cdot\\tfrac{c}{\\gcd(a,b)} = \\gcd(a,b)\\cdot\\tfrac{c}{\\gcd(a,b)} = c$, the last equality being $\\mathrm{Int.mul\\_ediv\\_cancel'}$ under $\\gcd(a,b)\\mid c$.",
+    "significance": "critical",
+    "prerequisites": ["Bézout's identity (Int.gcd_eq_gcd_ab)", "exact integer division"],
+    "relatedConcepts": ["Int.gcd_eq_gcd_ab", "Int.mul_ediv_cancel'", "ring tactic", "Bézout correctness"]
+  },
+  {
+    "id": "ann-vecgcd",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 70 },
+    "type": "definition",
+    "title": "vecGcd: The Coefficient-Vector GCD as a Fold",
+    "content": "`vecGcd` computes the non-negative gcd of all entries of a : Fin n → ℤ by recursion matching the solver: vecGcd 0 _ = 0 (the empty gcd) and vecGcd (n+1) a = gcd (a 0) (vecGcd n (Fin.tail a)). Its recursive head/tail shape is deliberate — it lines up exactly with the n-variable solver, which peels the head coordinate a 0 and recurses on Fin.tail a. The base value 0 is the correct identity for gcd, and makes 'vecGcd 0 _ ∣ c' equivalent to 'c = 0' (since 0 ∣ c iff c = 0), driving the base case of the solver.",
+    "mathContext": "$\\mathrm{vecGcd}\\,n\\,a = \\gcd(a_0, \\gcd(a_1, \\dots, \\gcd(a_{n-1}, 0)))$, the iterated gcd with identity element $0$. A sibling entry proves $\\mathrm{vecGcd}\\,n\\,a = \\bigwedge_{i} a_i = \\mathrm{Finset.univ.gcd}\\,a$, reconciling it with the parent's Finset gcd.",
+    "significance": "supporting",
+    "prerequisites": ["gcd as a fold", "Fin.tail"],
+    "relatedConcepts": ["Int.gcd", "Fin.tail", "Finset.gcd", "empty gcd = 0"]
+  },
+  {
+    "id": "ann-exists-vec-combo",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01",
+    "range": { "startLine": 72, "endLine": 112 },
+    "type": "theorem",
+    "title": "Main Result: the n-Variable Constructive Solver",
+    "content": "`exists_vec_combo` is the heart of the file: by induction on n, it builds an explicit x : Fin n → ℤ with ∑ aᵢxᵢ = c whenever vecGcd n a ∣ c. Base case n = 0: the empty gcd is 0, so the hypothesis forces c = 0 (`zero_dvd_iff`), solved by the zero vector. Inductive step: let d = vecGcd of the tail. The hypothesis gives gcd(a₀, d) ∣ c, so the two-variable solver yields s, t with a₀·s + d·t = c (`bezout_solve_spec`). Since d ∣ d·t trivially (`dvd_mul_right`), the inductive hypothesis realizes the value d·t = d·bezoutY as a tail combination ∑ aᵢ₊₁·x'ᵢ. Prepending s with `Fin.cons` and splitting the sum with `Fin.sum_univ_succ` reassembles a₀·s + (tail sum) = a₀·s + d·t = c. The crucial defeq is that `Fin.tail a i = a i.succ`, so the inductive witness retypes directly. `linear_solvable_of_gcd_dvd` repackages this as the forward direction of the parent's criterion — now proved rather than assumed.",
+    "mathContext": "Recursion: $\\sum_{i<n+1} a_i x_i = a_0 x_0 + \\sum_{i<n} a_{i+1} x_{i+1}$. Solve $a_0 s + d\\,t = c$ with $d = \\gcd$ of the tail; recursively write $d\\,t = \\sum_{i<n} a_{i+1} x'_i$ (possible since $d \\mid d\\,t$ and $d$ is the tail gcd); then $x = (s, x')$ solves the full equation. This is the extended Euclidean algorithm lifted from 2 to $n$ variables.",
+    "significance": "critical",
+    "prerequisites": ["induction on ℕ", "the two-variable solver", "Fin.cons / Fin.sum_univ_succ"],
+    "relatedConcepts": ["Fin.sum_univ_succ", "Fin.cons", "dvd_mul_right", "constructive existence", "head/tail recursion"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01",
+    "range": { "startLine": 121, "endLine": 129 },
+    "type": "concept",
+    "title": "Worked Instances: the Solver Computes",
+    "content": "Two `example`s exercise the solver on concrete data: 3x + 5y = 1 (solvable since gcd 3 5 = 1 ∣ 1) and 6x + 4y = 10 (gcd 6 4 = 2 ∣ 10). Each is discharged by `bezout_two_exists … (by decide)` — `decide` checks the divisibility side condition, and the witness is then produced by the computable bezoutX/bezoutY. These confirm that the construction is not merely a proof of existence but an actual algorithm: for any instance meeting the gcd condition, evaluating the definitions yields an integer solution vector.",
+    "mathContext": "$\\gcd(3,5)=1 \\mid 1$ and $\\gcd(6,4)=2 \\mid 10$, so both equations are solvable and bezoutX/bezoutY return explicit witnesses (e.g. for $3x+5y=1$: $x = 2, y = -1$ up to the cofactor convention).",
+    "significance": "supporting",
+    "prerequisites": ["the two-variable solver", "decide tactic"],
+    "relatedConcepts": ["computability", "decide", "concrete witnesses"]
+  }
+]

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01/meta.json
@@ -90,6 +90,56 @@
     ],
     "text": "This entry closes the constructive gap left open by hilbert-10-oq-04-oq-03. That file decides solvability of a linear Diophantine equation by a single gcd-divisibility test, but its underlying existence proof is non-constructive. Here the witness is produced explicitly via the extended Euclidean algorithm: the two-variable case reads the solution off Int.gcdA / Int.gcdB and a scaling factor, and the general case folds that step over the coefficient vector by recursion. The result is a computable solver — given coefficients whose gcd divides the target, it returns an actual integer solution vector."
   },
+  "mainTheorems": [
+    {
+      "name": "exists_vec_combo",
+      "type": "main",
+      "description": "The constructive n-variable solver: if vecGcd n a ∣ c then ∑ aᵢxᵢ = c has an explicit integer solution, the witness built by recursion on n (solve a₀·x₀ + d·t = c at the head via the two-variable solver, then recurse to realise d·t over the tail). This upgrades the forward direction of the parent's criterion from a non-constructive ideal-generator existence proof to an explicit, computable witness.",
+      "leanType": "∀ (n : ℕ) (a : Fin n → ℤ) (c : ℤ), vecGcd n a ∣ c → ∃ x : Fin n → ℤ, ∑ i, a i * x i = c"
+    },
+    {
+      "name": "bezout_solve_spec",
+      "type": "core",
+      "description": "Correctness of the two-variable solver: whenever gcd a b ∣ c, the explicit pair (bezoutX, bezoutY) satisfies a·x + b·y = c. Proof: distribute the c/gcd scaling, fold via Int.gcd_eq_gcd_ab, cancel with Int.mul_ediv_cancel'.",
+      "leanType": "(a b c : ℤ) (h : (Int.gcd a b : ℤ) ∣ c) : a * bezoutX a b c + b * bezoutY a b c = c"
+    },
+    {
+      "name": "bezoutX",
+      "type": "definition",
+      "description": "The x-component of the explicit solution of a·x + b·y = c: the first Bézout cofactor Int.gcdA a b scaled by c / gcd a b. Computable.",
+      "leanType": "(a b c : ℤ) : ℤ"
+    },
+    {
+      "name": "bezoutY",
+      "type": "definition",
+      "description": "The y-component of the explicit solution of a·x + b·y = c: the second Bézout cofactor Int.gcdB a b scaled by c / gcd a b. Computable.",
+      "leanType": "(a b c : ℤ) : ℤ"
+    },
+    {
+      "name": "vecGcd",
+      "type": "definition",
+      "description": "The non-negative gcd of an n-coefficient vector as an explicit fold of Int.gcd over the coordinates: vecGcd 0 _ = 0, vecGcd (n+1) a = gcd (a 0) (vecGcd n (Fin.tail a)). Its head/tail shape matches the solver's recursion.",
+      "leanType": "(n : ℕ) → (Fin n → ℤ) → ℤ"
+    },
+    {
+      "name": "linear_solvable_of_gcd_dvd",
+      "type": "lemma",
+      "description": "Existence corollary packaging exists_vec_combo as a pure ∃-statement — the yes-instance half of the parent's linear_bezout_n, now proved rather than assumed.",
+      "leanType": "(n : ℕ) (a : Fin n → ℤ) (c : ℤ) (h : vecGcd n a ∣ c) : ∃ x : Fin n → ℤ, ∑ i, a i * x i = c"
+    }
+  ],
+  "conclusion": {
+    "summary": "The non-constructive linear-Diophantine decision procedure of the parent entries is upgraded into a fully constructive solver. In two variables the solution is read straight off the extended-Euclidean cofactors Int.gcdA / Int.gcdB scaled by c / gcd a b (bezout_solve_spec); in n variables it is built by head/tail recursion over the coefficient vector (exists_vec_combo). Every solution component is a closed-form, computable integer, so for any instance whose coefficient gcd divides the target the actual solution vector can be evaluated, not merely shown to exist.",
+    "implications": [
+      "Separates two genuinely different objects: an existence proof (the parent's solvable_iff_gcd_dvd, routed through the coefficient ideal and Classical.choice) versus a solver that exhibits the witness. The Bézout cofactors carry the witness explicitly and computably, closing the constructive gap the parent left open.",
+      "The whole two-variable step is scaling: gcdA, gcdB solve a·x + b·y = gcd a b exactly, so multiplying by c / gcd a b solves a·x + b·y = c, with Int.mul_ediv_cancel' the single lemma making the division exact under the divisibility hypothesis.",
+      "The n-variable solver is a short recursion: peel the head coordinate, solve a 2×2 Bézout problem against the gcd of the tail, recurse to express the leftover d·t. Fin.cons and Fin.sum_univ_succ align the witness bookkeeping with the induction, and it stays sorry-free and axiom-free."
+    ],
+    "openQuestions": [
+      "Reconcile vecGcd with Finset.univ.gcd so the constructive solver discharges the forward direction of the parent's solvable_iff_gcd_dvd verbatim — RESOLVED by the child hilbert-10-oq-04-oq-03-oq-01-oq-01 (vecGcd_eq_finset_gcd).",
+      "Extend the constructive solver to systems A·x = b over ℤ, returning an explicit solution via Smith normal form (Module.Basis.SmithNormalForm over the PID ℤ) — the sibling problem hilbert-10-oq-04-oq-03-oq-02."
+    ]
+  },
   "sections": [
     {
       "id": "two-variable-solver",


### PR DESCRIPTION
Enrichment pass for `hilbert-10-oq-04-oq-03-oq-01`.

This entry had a rich meta.json but no annotations, no `mainTheorems`, and no `conclusion`. Improvements:

**annotations.json (new, 6 annotations)** — each with `mathContext`, `significance`, `prerequisites`, `relatedConcepts`:
- Overview: decision procedure → constructive solver (the existence-vs-witness distinction)
- `bezoutX`/`bezoutY`: the scaling trick (gcdA/gcdB scaled by c/gcd)
- `bezout_solve_spec`: two-variable correctness via `Int.mul_ediv_cancel'`
- `vecGcd`: the coefficient-vector gcd fold matching the recursion
- `exists_vec_combo`: the n-variable head/tail recursion (main result)
- Worked instances (3x+5y=1, 6x+4y=10) showing the solver computes

**meta.json**:
- `mainTheorems` (6 entries with leanType signatures)
- `conclusion` (summary, 3 implications, 2 openQuestions — incl. the resolved vecGcd↔Finset.gcd child and the open Smith-normal-form sibling)

Build: `pnpm build` passes; JSON validated. (Note: build globally requires the `denumerability-rationals-oq-05-oq-01-oq-01` meta.json fix from PR #28074 — that file is committed corrupted on main, 8× concatenated.)

Pushed to a dedicated branch; PR #28067 is still open on `feature/enricher-1`.