### PR TITLE
Enrich: Even Unit-Ball Volume Stirling Asymptotic (area-of-circle OQ-01·02·01·01·01·02)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "From ω_n → 0 to the Exact Decay Rate (and a Corrected Constant)",
+    "content": "The ancestor entry established only that the unit $n$-ball volumes $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ vanish in high dimension — the 'curse of dimensionality.' This file sharpens that to the *exact* even-subsequence asymptotic $\\omega_{2k} \\sim (\\pi e/k)^k/\\sqrt{2\\pi k}$ via Mathlib's Stirling formula. The header is also notable for an honest correction: written with $n = 2k$, the result is $\\omega_n \\sim (2\\pi e/n)^{n/2}/\\sqrt{\\pi n}$, so the universal constant is $1/\\sqrt{\\pi n}$ — not the $\\sqrt{2\\pi/n}$ the open question literally posed (they differ by a factor $\\sqrt2\\,\\pi$). The file is deliberately self-contained because the committed ancestor no longer compiles under Mathlib v4.26.",
+    "mathContext": "$\\omega_{2k} \\sim_{\\mathrm{atTop}} (\\pi e/k)^k/\\sqrt{2\\pi k}$; equivalently $\\omega_n \\sim (2\\pi e/n)^{n/2}/\\sqrt{\\pi n}$.",
+    "significance": "context",
+    "relatedConcepts": ["curse of dimensionality", "Stirling's formula", "asymptotic equivalence", "Gamma function"],
+    "prerequisites": ["asymptotic analysis", "Mathlib", "n-ball volume"]
+  },
+  {
+    "id": "ann-omega-def",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 58 },
+    "type": "definition",
+    "title": "The Unit n-Ball Volume ω_n",
+    "content": "The definition $\\omega_n = \\pi^{n/2}/\\Gamma(n/2+1)$ is the standard closed form for the Lebesgue volume of the unit ball in $\\mathbb{R}^n$, valid for all real (here natural) $n$ via the Gamma function interpolating the factorial. The companion `omega_zero` checks the base case $\\omega_0 = 1$ (the 'volume' of a point), which anchors the induction for the even formula. The definition is `noncomputable` because it rests on $\\Gamma$ and real powers.",
+    "mathContext": "$\\omega_n = \\dfrac{\\pi^{n/2}}{\\Gamma(n/2+1)}, \\qquad \\omega_0 = \\dfrac{\\pi^0}{\\Gamma(1)} = 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma function", "ball volume", "Real.rpow"],
+    "prerequisites": ["Gamma function", "real exponentiation"]
+  },
+  {
+    "id": "ann-omega-recurrence",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 76 },
+    "type": "technique",
+    "title": "The Dimension Recurrence (Drift-Corrected)",
+    "content": "The geometric heart of the infrastructure: $\\omega_{n+2} = \\frac{2\\pi}{n+2}\\,\\omega_n$, the classical fact that adding two dimensions multiplies the volume by $2\\pi/(n+2)$. The proof first rewrites $(n+2)/2 = n/2 + 1$, so the Gamma argument becomes $(n/2+1)+1$ *definitionally* — then a single `Real.Gamma_add_one` discharges the step, with `field_simp` clearing denominators. The annotation in the source emphasizes this is the 'drift-corrected' version: the ancestor file broke here by attempting a second cast-rewrite that no longer typechecks in Mathlib v4.26. `gamma_half_pos` supplies the positivity of $\\Gamma(n/2+1)$ needed to divide safely.",
+    "mathContext": "$\\omega_{n+2} = \\dfrac{2\\pi}{n+2}\\,\\omega_n$, using $\\Gamma(s+1) = s\\,\\Gamma(s)$ at $s = n/2+1$.",
+    "significance": "key",
+    "relatedConcepts": ["Gamma recurrence", "Real.Gamma_add_one", "field_simp", "Mathlib version drift"],
+    "prerequisites": ["Gamma functional equation", "Lean cast manipulation"]
+  },
+  {
+    "id": "ann-omega-even-formula",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 92 },
+    "type": "technique",
+    "title": "The Exact Even Closed Form ω_{2k} = π^k / k!",
+    "content": "Induction on $k$ over the recurrence yields the exact even-subsequence identity $\\omega_{2k} = \\pi^k/k!$ — no Gamma manipulation, just the multiplicative recurrence telescoping. This is the crucial lever for the asymptotics: because the formula is *exact*, the asymptotic estimate of $\\omega_{2k}$ reduces entirely to the asymptotics of $k!$ with zero error analysis. The successor step rewrites $2(k{+}1) = 2k+2$, applies the recurrence and the induction hypothesis, expands `Nat.factorial_succ`, and closes with `push_cast`/`field_simp`/`ring`.",
+    "mathContext": "$\\omega_{2k} = \\dfrac{\\pi^k}{k!}$, by induction: $\\omega_{2(k+1)} = \\dfrac{2\\pi}{2k+2}\\cdot\\dfrac{\\pi^k}{k!} = \\dfrac{\\pi^{k+1}}{(k+1)!}.$",
+    "significance": "key",
+    "relatedConcepts": ["mathematical induction", "factorial", "even subsequence", "telescoping recurrence"],
+    "prerequisites": ["induction", "factorial identities"]
+  },
+  {
+    "id": "ann-omega-even-isequivalent",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 94, "endLine": 128 },
+    "type": "insight",
+    "title": "The Exact Stirling Asymptotic",
+    "content": "The headline theorem: $\\omega_{2k} \\sim_{\\mathrm{atTop}} (\\pi e/k)^k/\\sqrt{2\\pi k}$. The proof is a clean exercise in the *calculus of asymptotic equivalence*. (1) Rewrite $\\omega_{2k} = \\pi^k\\cdot(k!)^{-1}$ pointwise (`homega`). (2) Feed Mathlib's $k! \\sim \\sqrt{2\\pi k}(k/e)^k$ through inversion and multiplication by the common factor $\\pi^k$: `(IsEquivalent.refl).mul hstir.inv` (`hmul`). (3) Show the transported right-hand side equals the clean closed form $(\\pi e/k)^k/\\sqrt{2\\pi k}$ for $k \\ge 1$ via `inv_pow`/`inv_div`/`mul_pow` algebra (`hclean`). (4) Chain with `trans` and `congr_right`. No epsilon-delta estimates appear — the exactness of $\\omega_{2k} = \\pi^k/k!$ makes the equivalence algebra carry the whole argument.",
+    "mathContext": "$\\omega_{2k} = \\pi^k(k!)^{-1} \\sim \\pi^k\\big(\\sqrt{2\\pi k}(k/e)^k\\big)^{-1} = \\dfrac{(\\pi e/k)^k}{\\sqrt{2\\pi k}}.$",
+    "significance": "key",
+    "relatedConcepts": ["IsEquivalent", "Stirling's formula", "asymptotic calculus", "super-exponential decay"],
+    "prerequisites": ["asymptotic equivalence", "Stirling's formula"]
+  },
+  {
+    "id": "ann-ratio-tendsto",
+    "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 130, "endLine": 147 },
+    "type": "concept",
+    "title": "Restatement as a Normalized Ratio Limit",
+    "content": "The equivalence is recast as the more familiar limit $\\omega_{2k}\\big/\\big((\\pi e/k)^k/\\sqrt{2\\pi k}\\big) \\to 1$, using `isEquivalent_iff_tendsto_one`. The conversion requires the normalizing denominator to be eventually nonzero, established by showing each factor is positive for $k \\ge 1$ (`div_pos`, `pow_pos`, `Real.sqrt_pos`). This is the reader-facing form: it literally says the even ball volumes track the Stirling estimate with relative error tending to zero.",
+    "mathContext": "$\\dfrac{\\omega_{2k}}{(\\pi e/k)^k/\\sqrt{2\\pi k}} \\to 1$ as $k \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["isEquivalent_iff_tendsto_one", "Tendsto", "relative error"],
+    "prerequisites": ["limits", "asymptotic equivalence"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02Data: ProofData = {
+  proof: areaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02Proof,
+  annotations: areaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -83,5 +83,52 @@
       "Asymptotic equivalence calculus",
       "Gamma recurrence and ball-volume even formula"
     ]
-  }
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Statement, Correction, Self-Containment",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Docstring framing the sharpening of ω_n → 0 to the exact even asymptotic, the honest correction of the posed constant (1/√(πn), not √(2π/n)), the self-contained re-derivation rationale (ancestor no longer builds under v4.26), imports, and the BallVolumeAsymptotic namespace.",
+      "mathContext": "$\\omega_{2k} \\sim (\\pi e/k)^k/\\sqrt{2\\pi k}$; constant $1/\\sqrt{\\pi n}$ vs posed $\\sqrt{2\\pi/n}$ (off by $\\sqrt2\\,\\pi$)."
+    },
+    {
+      "id": "infrastructure",
+      "title": "Ball-Volume Infrastructure",
+      "startLine": 53,
+      "endLine": 92,
+      "summary": "ω (definition π^(n/2)/Γ(n/2+1)), omega_zero (ω_0 = 1), gamma_half_pos (positivity), omega_recurrence (drift-corrected ω_{n+2} = (2π/(n+2))·ω_n), and omega_even_formula (the exact even closed form ω_{2k} = π^k/k! by induction).",
+      "mathContext": "$\\omega_{n+2} = \\tfrac{2\\pi}{n+2}\\omega_n \\Rightarrow \\omega_{2k} = \\pi^k/k!$ (exact)."
+    },
+    {
+      "id": "asymptotic",
+      "title": "The Exact Stirling Asymptotic",
+      "startLine": 94,
+      "endLine": 147,
+      "summary": "omega_even_isEquivalent (ω_{2k} ~ (πe/k)^k/√(2πk), proved by transporting Stirling for k! through inv/mul/congr_right) and omega_even_ratio_tendsto_one (the same as a normalized-ratio limit → 1 via isEquivalent_iff_tendsto_one).",
+      "mathContext": "$\\omega_{2k} = \\pi^k(k!)^{-1} \\sim (\\pi e/k)^k/\\sqrt{2\\pi k}$; ratio $\\to 1$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The exact even-subsequence asymptotic of the unit-ball volumes is established and machine-checked (0 sorries, 0 axioms): ω_{2k} ~[atTop] (πe/k)^k/√(2πk), equivalently ω_n ~ (2πe/n)^(n/2)/√(πn). The proof leverages the exact even closed form ω_{2k} = π^k/k! to reduce everything to Mathlib's Stirling formula for k!, then transports it through the calculus of asymptotic equivalence. Along the way the originally-posed leading constant √(2π/n) is corrected to the true 1/√(πn).",
+    "implications": "This pins the precise rate of the curse of dimensionality on the even subsequence: the ball volume decays super-exponentially like (πe/k)^k — faster than any geometric rate once k > πe — with polynomial prefactor 1/√(2πk). The work also demonstrates a robust formalization pattern (exact closed form + equivalence calculus) for converting a 'tends to 0' statement into a sharp asymptotic, and records a careful correction of a mis-stated constant rather than silently proving a different claim.",
+    "openQuestions": [
+      "Extend the exact asymptotic to the full (including odd) subsequence ω_n, where the half-integer Gamma values require the duplication formula or a direct Stirling estimate of Γ(n/2+1).",
+      "Quantify the second-order term: an asymptotic expansion ω_{2k} = (πe/k)^k/√(2πk)·(1 + c/k + O(1/k²)) from the refined Stirling series.",
+      "Determine the dimension k maximizing ω_{2k} (the volume peaks near n ≈ 5 and then decays) directly from the closed form π^k/k!."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sharpens the ancestor's ω_n → 0 to the exact even-subsequence decay rate ω_{2k} ~ (πe/k)^k/√(2πk), and re-derives its infrastructure in a form that compiles under Mathlib v4.26."
+    },
+    {
+      "targetId": "area-of-circle",
+      "relationship": "related",
+      "description": "Part of the area-of-circle / ball-volume lineage: the n-dimensional generalization of the circle-area computation, here analyzed asymptotically in high dimension."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01-oq-02` (quality 15, pass 0).

## What changed
- **Created `index.ts`** — was missing, so the page would 404 on the live site.
- **Created `annotations.json`** — 6 substantive annotations (mathContext/significance/relatedConcepts/prerequisites) covering: the header + corrected constant, the ω definition, the drift-corrected dimension recurrence ω_{n+2}=(2π/(n+2))·ω_n, the exact even formula ω_{2k}=π^k/k!, the Stirling asymptotic ω_{2k} ~ (πe/k)^k/√(2πk), and the ratio-limit restatement.
- **Expanded meta.json** — added `sections` (3, covering the full file), `conclusion` (summary, implications, 3 open questions), and `crossReferences` (verified ancestor `area-of-circle-oq-01-oq-02-oq-01-oq-01` and the `area-of-circle` lineage both exist).

## Verification
- `json.load` validates both JSON files; `tsc -b` passes; annotation build reports no errors for this entry.
- Cross-reference targets confirmed present in the gallery.
- Axiom/status unchanged: verified / original / 0-axiom, matching the sorry-free, axiom-free Lean source. The honest constant correction (1/√(πn) vs the posed √(2π/n)) noted in the source is preserved in the annotations and conclusion.