### PR TITLE
research(cauchy-interlacing-theorem-oq-01-oq-02): Poincaré separation, self-contained via the explicit compression [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
+++ b/proofs/Proofs/CauchyInterlacingPoincareCompression.lean
@@ -1,0 +1,148 @@
+import Mathlib
+import Proofs.CauchyInterlacingCompression
+import Proofs.CauchyInterlacingPoincare
+
+/-
+# Poincaré separation, self-contained via the explicit orthogonal compression
+
+Two earlier research files leave a deliberate seam between them:
+
+* `CauchyInterlacingPoincare.lean` (#27247) proves the **abstract** Poincaré
+  separation theorem — for a codimension-`m` compression `dim V = n + m`,
+  `dim H = n`, the descending eigenvalues separate as
+  `lam ⟨k+m⟩ ≤ mu k ≤ lam ⟨k⟩` — but it takes the compression operator `TH` on
+  `H`, its spectral data, *and* the Rayleigh-agreement hypothesis as **inputs**.
+* `CauchyInterlacingCompression.lean` **builds** the orthogonal compression
+  `compress T H := P_H ∘ T ∘ ι_H` and discharges exactly that Rayleigh
+  hypothesis — but only assembles it into the **codimension-one** corollary.
+
+Crucially, `compress`, `isSymmetric_compress` and `rayleigh_compress_eq` are
+stated for an *arbitrary* submodule `H`: nothing in their proofs uses
+`codim H = 1`. So the abstract Poincaré theorem and the explicit compression
+construction fit together for **any** codimension with no new work.
+
+This file performs that join. Given only
+
+* a symmetric operator `T` on a finite-dimensional inner product space `V` of
+  dimension `n + m`, and
+* a subspace `H ≤ V` of dimension `n` (codimension `m`),
+
+we feed the explicit compression `compress T H` and its discharged Rayleigh
+identity straight into `poincare_separation`, yielding the textbook Poincaré
+separation theorem with **no Rayleigh side condition** and **no abstract `TH`**:
+
+  `λ_{k+m} ≤ μ_k ≤ λ_k`,
+
+where `μ` are the descending eigenvalues of the orthogonal compression of `T`
+onto `H`.  This is the arbitrary-codimension analogue of
+`cauchy_interlacing_compression` (the `m = 1` case, recovered below as a
+corollary), and the fully self-contained form of `poincare_separation`.
+
+A second corollary specialises `H` to the span of an arbitrary orthonormal
+`n`-frame `f : Fin n → V`, the "compression onto a `k`-dimensional subspace"
+picture: the dimension hypothesis is discharged automatically from
+`finrank_span_eq_card`.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace
+open CauchyInterlacing.Compression CauchyInterlacing.Poincare
+
+namespace CauchyInterlacing.PoincareCompression
+
+variable {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+/-- **Poincaré separation theorem (self-contained compression form).**
+
+Let `T` be a symmetric operator on an `(n + m)`-dimensional inner product space
+`V`, with descending eigenvalues `lam := hT.eigenvalues`.  Let `H ≤ V` be a
+subspace of dimension `n` (codimension `m`), and let `mu` be the descending
+eigenvalues of the orthogonal compression `compress T H` of `T` onto `H`.
+
+Then for every `k : Fin n`:
+
+  `lam ⟨k + m⟩ ≤ mu k`  and  `mu k ≤ lam ⟨k⟩`,
+
+i.e. `λ_{k+m} ≤ μ_k ≤ λ_k` (descending), the Poincaré separation theorem.  No
+Rayleigh hypothesis and no abstract compression operator are required: the
+compression is constructed explicitly and its Rayleigh quotient discharged
+internally from the orthogonal-projection adjoint identity. The
+codimension-one `cauchy_interlacing_compression` is the special case `m = 1`. -/
+theorem poincare_separation_compression
+    {T : V →ₗ[𝕜] V} (hT : T.IsSymmetric) {n m : ℕ}
+    (hVdim : Module.finrank 𝕜 V = n + m)
+    (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+    (k : Fin n) :
+    (hT.eigenvalues hVdim) ⟨(k : ℕ) + m, by have := k.isLt; omega⟩
+        ≤ (isSymmetric_compress hT H).eigenvalues hHdim k
+      ∧ (isSymmetric_compress hT H).eigenvalues hHdim k
+          ≤ (hT.eigenvalues hVdim) ⟨(k : ℕ), by have := k.isLt; omega⟩ := by
+  -- Spectral data for `T` on `V`.
+  set b := hT.eigenvectorBasis hVdim with hb_def
+  set lam := hT.eigenvalues hVdim with hlam_def
+  have hb : ∀ i, T (b i) = (lam i : 𝕜) • b i := hT.apply_eigenvectorBasis hVdim
+  have hlam : Antitone lam := hT.eigenvalues_antitone hVdim
+  -- Spectral data for the explicit compression `compress T H` on `H`.
+  set hTH := isSymmetric_compress hT H with hTH_def
+  set bH := hTH.eigenvectorBasis hHdim with hbH_def
+  set mu := hTH.eigenvalues hHdim with hmu_def
+  have hbH : ∀ i, compress T H (bH i) = (mu i : 𝕜) • bH i := hTH.apply_eigenvectorBasis hHdim
+  have hmu : Antitone mu := hTH.eigenvalues_antitone hHdim
+  -- Rayleigh agreement, in the exact shape `poincare_separation` wants.
+  have hRayleigh : ∀ y : H, y ≠ 0 →
+      RCLike.re (@inner 𝕜 H _ (compress T H y) y) / ‖y‖ ^ 2
+        = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2 :=
+    fun y _ => rayleigh_compress_eq T H y
+  exact poincare_separation T b lam hb hlam H hHdim (compress T H) bH mu hbH hmu hRayleigh k
+
+/-- **Cauchy interlacing (codimension one) recovered.**
+
+The `m = 1` case of `poincare_separation_compression`, in the parent entry's
+`succ`/`castSucc` notation: `lam k.succ ≤ mu k ≤ lam k.castSucc`.  This
+reproduces `cauchy_interlacing_compression`, confirming the arbitrary-codimension
+form is a faithful generalisation. -/
+theorem cauchy_interlacing_compression_of_poincare
+    {T : V →ₗ[𝕜] V} (hT : T.IsSymmetric) {n : ℕ}
+    (hVdim : Module.finrank 𝕜 V = n + 1)
+    (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+    (k : Fin n) :
+    (hT.eigenvalues hVdim) k.succ ≤ (isSymmetric_compress hT H).eigenvalues hHdim k
+      ∧ (isSymmetric_compress hT H).eigenvalues hHdim k
+          ≤ (hT.eigenvalues hVdim) k.castSucc := by
+  obtain ⟨hlo, hup⟩ := poincare_separation_compression hT hVdim H hHdim k
+  refine ⟨?_, ?_⟩
+  · have hk : k.succ = (⟨(k : ℕ) + 1, by have := k.isLt; omega⟩ : Fin (n + 1)) := by
+      apply Fin.ext; simp
+    rw [hk]; exact hlo
+  · have hk : k.castSucc = (⟨(k : ℕ), by have := k.isLt; omega⟩ : Fin (n + 1)) := by
+      apply Fin.ext; simp
+    rw [hk]; exact hup
+
+/-- **Compression onto the span of an orthonormal `n`-frame.**
+
+The "compression onto a `k`-dimensional subspace" picture: instead of a subspace
+`H` with a separately-supplied dimension hypothesis, take an arbitrary
+orthonormal family `f : Fin n → V` and compress onto `H := span (range f)`.  Its
+dimension is `n` automatically (`finrank_span_eq_card`), so Poincaré separation
+applies with `T` on `V` of dimension `n + m`:
+
+  `λ_{k+m} ≤ μ_k ≤ λ_k`,
+
+`μ` the descending eigenvalues of `compress T (span (range f))`. -/
+theorem poincare_separation_compression_span
+    {T : V →ₗ[𝕜] V} (hT : T.IsSymmetric) {n m : ℕ}
+    (hVdim : Module.finrank 𝕜 V = n + m)
+    (f : Fin n → V) (hf : Orthonormal 𝕜 f)
+    (k : Fin n) :
+    (hT.eigenvalues hVdim) ⟨(k : ℕ) + m, by have := k.isLt; omega⟩
+        ≤ (isSymmetric_compress hT (Submodule.span 𝕜 (Set.range f))).eigenvalues
+            ((finrank_span_eq_card hf.linearIndependent).trans (Fintype.card_fin n)) k
+      ∧ (isSymmetric_compress hT (Submodule.span 𝕜 (Set.range f))).eigenvalues
+            ((finrank_span_eq_card hf.linearIndependent).trans (Fintype.card_fin n)) k
+          ≤ (hT.eigenvalues hVdim) ⟨(k : ℕ), by have := k.isLt; omega⟩ :=
+  poincare_separation_compression hT hVdim (Submodule.span 𝕜 (Set.range f))
+    ((finrank_span_eq_card hf.linearIndependent).trans (Fintype.card_fin n)) k
+
+end CauchyInterlacing.PoincareCompression

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-poincare-separation-compression",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 104 },
+    "type": "theorem",
+    "title": "Self-Contained Poincaré Separation via the Explicit Compression",
+    "content": "`poincare_separation_compression` takes only a symmetric `T` on `V` with `finrank V = n + m` and a subspace `H` with `finrank H = n`. It sets the spectral data of `T` (eigenbasis `b`, antitone eigenvalues `lam`) and of the explicit orthogonal compression `compress T H` (symmetry from `isSymmetric_compress`, eigenbasis `bH`, antitone eigenvalues `mu`), supplies the Rayleigh-agreement hypothesis from `rayleigh_compress_eq`, and applies the gallery's abstract `poincare_separation`. The conclusion is `lam ⟨k+m⟩ ≤ mu k ∧ mu k ≤ lam ⟨k⟩` — the Poincaré separation theorem `λ_{k+m} ≤ μ_k ≤ λ_k` with NO Rayleigh side condition and NO abstract compression operator.",
+    "mathContext": "For T symmetric on an (n+m)-dimensional space and μ the descending eigenvalues of the compression of T onto any n-dimensional subspace, λ_{k+m} ≤ μ_k ≤ λ_k.",
+    "significance": "key",
+    "relatedConcepts": ["Poincaré separation", "orthogonal compression", "Courant–Fischer", "spectral theorem"],
+    "prerequisites": ["spectral theorem eigenbasis/eigenvalues", "Rayleigh quotient of a compression", "abstract Poincaré separation inequality"]
+  },
+  {
+    "id": "ann-recover-codim-one",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": { "startLine": 106, "endLine": 132 },
+    "type": "insight",
+    "title": "Recovering the Codimension-One Corollary (m = 1)",
+    "content": "`cauchy_interlacing_compression_of_poincare` specialises the main theorem to `m = 1` and re-expresses the index bounds `⟨k+1⟩` and `⟨k⟩` as `k.succ` and `k.castSucc` via `Fin.ext`, reproducing the merged codimension-one compression corollary `λ_{k+1} ≤ μ_k ≤ λ_k`. This certifies that the arbitrary-codimension form is a faithful generalisation rather than a divergent statement.",
+    "mathContext": "Cauchy interlacing for a hyperplane compression is exactly Poincaré separation at codimension m = 1.",
+    "significance": "standard",
+    "relatedConcepts": ["Cauchy interlacing", "Fin.succ", "Fin.castSucc", "proof irrelevance"],
+    "prerequisites": ["the main separation theorem"]
+  },
+  {
+    "id": "ann-compression-span-frame",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02",
+    "range": { "startLine": 134, "endLine": 147 },
+    "type": "construction",
+    "title": "Compression onto the Span of an Orthonormal Frame",
+    "content": "`poincare_separation_compression_span` replaces the explicit dimension hypothesis with an arbitrary orthonormal family `f : Fin n → V`, compressing onto `H = Submodule.span 𝕜 (Set.range f)`. The dimension `finrank H = n` is discharged inline by `finrank_span_eq_card hf.linearIndependent` composed with `Fintype.card_fin`. This is the literal 'eigenvalue interlacing under compression onto a k-dimensional subspace' phrasing, taking the subspace as the span of k orthonormal vectors.",
+    "mathContext": "An orthonormal k-frame spans a k-dimensional subspace; compressing onto it gives μ with λ_{k+m} ≤ μ_k ≤ λ_k.",
+    "significance": "standard",
+    "relatedConcepts": ["orthonormal family", "span", "finrank_span_eq_card", "k-dimensional subspace"],
+    "prerequisites": ["the main separation theorem", "linear independence of orthonormal families"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-02",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-02",
+  "title": "Poincaré Separation, Self-Contained via the Explicit Orthogonal Compression",
+  "description": "Joins two earlier research files to produce the Poincaré separation theorem with no side conditions. The abstract codimension-m Poincaré theorem (cauchy-interlacing-theorem-oq-02) takes the compression operator TH, its spectral data, and a Rayleigh-agreement hypothesis as inputs; the compression file (cauchy-interlacing-theorem-oq-01) builds the explicit orthogonal compression compress T H := P_H ∘ T ∘ ι_H and discharges that Rayleigh hypothesis, but only for codimension one. Because compress, isSymmetric_compress and rayleigh_compress_eq are stated for an ARBITRARY submodule (their proofs never use codim = 1), feeding the explicit compression into the abstract Poincaré theorem yields, for T symmetric on V of dimension n+m and H of dimension n, the fully self-contained separation λ_{k+m} ≤ μ_k ≤ λ_k where μ are the descending eigenvalues of the orthogonal compression of T onto H — no Rayleigh side condition and no abstract operator. The codimension-one compression corollary is recovered as the m=1 case, and a second corollary specialises H to the span of an arbitrary orthonormal n-frame. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Poincaré (separation); formalized for lean-genius",
+    "status": "verified",
+    "badge": "mathlib",
+    "proofRepoPath": "Proofs/CauchyInterlacingPoincareCompression.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "lineCount": 148,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "difficulty": "advanced",
+    "category": "linear-algebra",
+    "mathlibDependencies": [
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues",
+        "description": "the descending (antitone) eigenvalue family of a symmetric operator from the spectral theorem — supplies both T's and the compression's spectral data",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "LinearMap.IsSymmetric.eigenvalues_antitone",
+        "description": "the eigenvalue family is antitone (descending), the ordering Poincaré separation is stated against",
+        "module": "Mathlib.Analysis.InnerProductSpace.Spectrum"
+      },
+      {
+        "theorem": "finrank_span_eq_card",
+        "description": "finrank of the span of a linearly independent family equals its cardinality — discharges the dimension hypothesis for the orthonormal-frame corollary",
+        "module": "Mathlib.LinearAlgebra.Finrank"
+      }
+    ],
+    "originalContributions": [
+      "poincare_separation_compression: the fully self-contained Poincaré separation theorem — for T symmetric on V of dimension n+m and any subspace H of dimension n, the descending eigenvalues of the explicit orthogonal compression compress T H separate the eigenvalues of T as λ_{k+m} ≤ μ_k ≤ λ_k, with NO Rayleigh hypothesis and NO abstract compression operator",
+      "cauchy_interlacing_compression_of_poincare: the m=1 specialisation recovering the codimension-one compression corollary λ_{k+1} ≤ μ_k ≤ λ_k in succ/castSucc notation, confirming the arbitrary-codimension form is a faithful generalisation",
+      "poincare_separation_compression_span: compression onto the span of an arbitrary orthonormal n-frame f : Fin n → V, with the dimension hypothesis discharged automatically from finrank_span_eq_card — the literal 'compression onto a k-dimensional subspace' picture"
+    ],
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The variational keystone (bound-form Courant–Fischer) is supplied by the gallery's Poincaré entry (cauchy-interlacing-theorem-oq-02) and the explicit orthogonal compression with its discharged Rayleigh identity by cauchy-interlacing-theorem-oq-01; this entry is the assembly joining them for arbitrary codimension. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "tags": [
+      "Poincaré separation",
+      "Cauchy interlacing",
+      "eigenvalues",
+      "orthogonal compression",
+      "spectral theorem",
+      "inner product spaces",
+      "codimension"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingCompression",
+      "Proofs.CauchyInterlacingPoincare"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "CauchyInterlacing.Compression",
+      "CauchyInterlacing.Poincare"
+    ],
+    "namespace": "CauchyInterlacing.PoincareCompression",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingPoincareCompression.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 assembly of the Poincaré separation theorem in its fully self-contained form. Given a symmetric operator T on a finite-dimensional inner product space V with finrank V = n + m and a subspace H with finrank H = n, the orthogonal compression compress T H := P_H ∘ T ∘ ι_H is constructed explicitly, proved symmetric, and its Rayleigh quotient shown to agree with T's on H; feeding this into the gallery's abstract Poincaré separation theorem yields, for every k : Fin n, λ_{k+m} ≤ μ_k ≤ λ_k where λ and μ are the descending eigenvalues of T and of the compression. The result needs no Rayleigh side condition and no abstract compression operator. The m=1 case reproduces the codimension-one compression corollary, and a frame-based corollary takes H to be the span of an arbitrary orthonormal n-frame.",
+    "implications": "Closes the second open question of cauchy-interlacing-theorem-oq-01: extends the explicit-compression interlacing corollary from a single hyperplane (codimension one) to arbitrary codimension m. Where cauchy-interlacing-theorem-oq-02 proved the abstract Poincaré inequality but left the compression and its Rayleigh hypothesis as inputs, this entry supplies them, giving the textbook Poincaré separation theorem with hypotheses reduced to 'T symmetric, H a subspace of dimension n'. The key observation — that the compression construction and its Rayleigh discharge are codimension-agnostic — means the join required no new spectral theory.",
+    "openQuestions": [
+      "Specialise poincare_separation_compression to a Hermitian matrix and a multi-index coordinate subspace to obtain the literal matrix Poincaré separation λ_i ≤ μ_i ≤ λ_{i+m} for the principal submatrix obtained by deleting m rows and columns, via a coordinate isometry as in the single-deletion case (cauchy-interlacing-theorem-oq-01-oq-01-oq-02).",
+      "Derive eigenvalue majorization (the Schur–Horn direction) and the corollary that every compression of a positive semidefinite operator is positive semidefinite directly from the separation bound."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cauchy's interlacing theorem (1829) bounds the eigenvalues of a principal submatrix of a Hermitian matrix by those of the matrix. Poincaré's separation theorem is the general compression statement: if T is a symmetric operator on an (n+m)-dimensional space with descending eigenvalues λ₁ ≥ … ≥ λ_{n+m}, and μ₁ ≥ … ≥ μ_n are the descending eigenvalues of the compression of T onto any n-dimensional subspace, then λ_{k+m} ≤ μ_k ≤ λ_k for every k. The conceptual proof rests on the variational (Courant–Fischer) characterization of eigenvalues. The lean-genius gallery built this in stages: the codimension-one interlacing inequality and explicit compression (cauchy-interlacing-theorem-oq-01), then the abstract arbitrary-codimension Poincaré inequality with the compression supplied as input (cauchy-interlacing-theorem-oq-02). This entry joins the two so the compression no longer needs to be supplied or its Rayleigh quotient assumed.",
+    "problemStatement": "The compression file (cauchy-interlacing-theorem-oq-01) constructs compress T H := P_H ∘ T ∘ ι_H, proves it symmetric, and discharges the Rayleigh-agreement hypothesis from the orthogonal-projection adjoint identity — but assembles this only into the codimension-one corollary. Its second open question asks to extend the explicit-compression interlacing to compression onto an arbitrary k-dimensional subspace (the Poincaré separation theorem).\n\n**Answer.** The construction is already codimension-agnostic: compress, isSymmetric_compress and rayleigh_compress_eq are stated and proved for an arbitrary submodule H, with no use of codim H = 1. So one simply feeds compress T H, its spectral eigenbasis and eigenvalues, and rayleigh_compress_eq into the abstract Poincaré separation theorem (cauchy-interlacing-theorem-oq-02), obtaining λ_{k+m} ≤ μ_k ≤ λ_k for T on V of dimension n+m and H of dimension n, with no remaining side conditions.",
+    "text": "The explicit orthogonal compression of a symmetric operator and the discharge of its Rayleigh quotient are independent of the codimension; combining them with the abstract Poincaré separation inequality therefore yields the textbook Poincaré separation theorem for arbitrary codimension with no Rayleigh hypothesis.",
+    "proofStrategy": "Three theorems. (1) poincare_separation_compression mirrors the codimension-one cauchy_interlacing_compression line for line, but invokes poincare_separation (arbitrary codimension) instead of the codimension-one assembly: set the eigenbasis b and eigenvalues lam of T (with finrank V = n+m), the eigenbasis bH and eigenvalues mu of the symmetric compression (with finrank H = n), supply rayleigh_compress_eq as the Rayleigh-agreement hypothesis, and apply poincare_separation. The Fin index proofs differ only by proof-irrelevant omega witnesses, so the application is by exact. (2) cauchy_interlacing_compression_of_poincare instantiates m=1 and rewrites the index bounds ⟨k+1⟩, ⟨k⟩ to k.succ, k.castSucc via Fin.ext. (3) poincare_separation_compression_span takes an orthonormal family f : Fin n → V and applies the main theorem to H = span (range f), discharging finrank H = n inline by finrank_span_eq_card hf.linearIndependent composed with Fintype.card_fin.",
+    "keyInsights": [
+      "The explicit-compression construction is codimension-agnostic: nothing in compress, isSymmetric_compress, or rayleigh_compress_eq uses that H is a hyperplane, so the same machinery that yields the codimension-one corollary yields the arbitrary-codimension theorem with zero additional spectral work",
+      "Joining the abstract Poincaré inequality (which abstracts away the compression) with the explicit compression (which abstracts away the codimension) removes BOTH the Rayleigh hypothesis and the codimension restriction simultaneously",
+      "The main theorem differs from the merged codimension-one compression corollary only in calling poincare_separation rather than the codimension-one assembly — the surrounding spectral plumbing is identical, evidence the abstraction boundaries were drawn at the right place",
+      "Proof-irrelevance of the Fin.mk bounds lets the abstract theorem's ⟨k+m⟩ / ⟨k⟩ conclusion discharge the corollary's goal directly by exact, with no index-coercion rewriting in the main theorem"
+    ],
+    "prerequisites": [
+      "The spectral theorem: orthonormal eigenbases and antitone descending eigenvalue families for symmetric operators on finite-dimensional inner product spaces",
+      "Orthogonal compression of an operator to a subspace and its Rayleigh-quotient agreement via the orthogonal-projection adjoint identity",
+      "The Courant–Fischer max–min variational characterization of eigenvalues (supplied by the gallery's Poincaré entry)",
+      "Orthonormal families, the span of a linearly independent family, and finrank_span_eq_card"
+    ]
+  },
+  "sections": [
+    {
+      "title": "The Self-Contained Poincaré Separation Theorem",
+      "content": "poincare_separation_compression takes only a symmetric T on V (finrank V = n+m) and a subspace H (finrank H = n). It sets the spectral data of T (eigenbasis b, antitone eigenvalues lam) and of the explicit compression compress T H (symmetry from isSymmetric_compress, eigenbasis bH, antitone eigenvalues mu), supplies the Rayleigh-agreement hypothesis from rayleigh_compress_eq, and applies the gallery's abstract poincare_separation. The result is λ_{k+m} ≤ μ_k ≤ λ_k for every k : Fin n, with no Rayleigh side condition and no abstract compression operator."
+    },
+    {
+      "title": "Recovering Codimension One",
+      "content": "cauchy_interlacing_compression_of_poincare specialises to m=1 and re-expresses the index bounds ⟨k+1⟩ and ⟨k⟩ as k.succ and k.castSucc through Fin.ext, reproducing the codimension-one compression corollary λ_{k+1} ≤ μ_k ≤ λ_k. This confirms the arbitrary-codimension theorem is a faithful generalisation of the merged codimension-one entry."
+    },
+    {
+      "title": "Compression onto an Orthonormal Frame",
+      "content": "poincare_separation_compression_span replaces the explicit dimension hypothesis with an arbitrary orthonormal family f : Fin n → V, compressing onto H = span (range f). The dimension finrank H = n is discharged inline by finrank_span_eq_card hf.linearIndependent composed with Fintype.card_fin, giving the 'compression onto a k-dimensional subspace' form directly from an orthonormal frame."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Poincaré, H.",
+      "title": "Sur les équations aux dérivées partielles de la physique mathématique",
+      "year": "1890",
+      "note": "Separation (min-max) theorem for eigenvalues of compressions"
+    },
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "note": "Poincaré separation theorem and the Courant–Fischer characterization (Theorems 4.3.17, 4.2.6)"
+    },
+    {
+      "authors": "Bhatia, R.",
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "note": "Eigenvalue interlacing, separation, and majorization (Chapter III)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Closes its second open question: extends the explicit-compression interlacing corollary from a codimension-one hyperplane to arbitrary codimension m, the Poincaré separation theorem."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Supplies the explicit orthogonal compression and discharges the Rayleigh-agreement hypothesis that the abstract Poincaré separation theorem there takes as an input, yielding the self-contained form."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling that assembled the literal matrix principal-submatrix interlacing corollary for a single deleted row/column; the multi-index matrix specialisation of this entry's operator theorem is the natural next step."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of `cauchy-interlacing-theorem-oq-01`: extend the explicit-compression interlacing corollary from a single hyperplane (codimension one) to **arbitrary codimension** — the **Poincaré separation theorem**.

Two earlier research files leave a deliberate seam:
- **`cauchy-interlacing-theorem-oq-02`** (#27247) proves the *abstract* arbitrary-codimension Poincaré inequality `λ_{k+m} ≤ μ_k ≤ λ_k`, but takes the compression operator `TH`, its spectral data, *and* a Rayleigh-agreement hypothesis as **inputs**.
- **`cauchy-interlacing-theorem-oq-01`** *builds* the explicit orthogonal compression `compress T H := P_H ∘ T ∘ ι_H` and discharges that Rayleigh hypothesis — but only assembles the **codimension-one** corollary.

The key observation: `compress`, `isSymmetric_compress`, and `rayleigh_compress_eq` are stated for an **arbitrary** submodule — nothing in their proofs uses `codim H = 1`. So feeding the explicit compression straight into `poincare_separation` produces the textbook theorem with **no Rayleigh side condition** and **no abstract operator**.

## Results (`Proofs/CauchyInterlacingPoincareCompression.lean`)

- **`poincare_separation_compression`** — for `T` symmetric on `V` with `finrank V = n + m` and any `H` with `finrank H = n`, the descending eigenvalues `μ` of the orthogonal compression of `T` onto `H` satisfy `λ_{k+m} ≤ μ_k ≤ λ_k`. Self-contained.
- **`cauchy_interlacing_compression_of_poincare`** — the `m = 1` case in `succ`/`castSucc` notation, recovering the merged codimension-one corollary (faithful generalisation check).
- **`poincare_separation_compression_span`** — compression onto the span of an arbitrary orthonormal `n`-frame `f : Fin n → V`, with the dimension hypothesis discharged automatically via `finrank_span_eq_card`.

## Verification

- 148 lines, **3 theorems**, 0 definitions
- **0 sorries, 0 axioms** — `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`
- Builds against Mathlib 4.26.0 (`lake env lean`), reusing the two parent research files

🤖 Generated with [Claude Code](https://claude.com/claude-code)