### PR TITLE
Add missing index.ts for cauchy-group-theorem-oq-01

### DIFF
--- a/src/data/proofs/cauchy-group-theorem-oq-01/index.ts
+++ b/src/data/proofs/cauchy-group-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchyGroupTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchyGroupTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchyGroupTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchyGroupTheoremOQ01Data: ProofData = {
+  proof: cauchyGroupTheoremOQ01Proof,
+  annotations: cauchyGroupTheoremOQ01Annotations,
+}


### PR DESCRIPTION
The entry's `meta.json` and `annotations.json` were enriched in #28083, but **no `index.ts` was added** — so the proof page renders 'proof not found' on the live site (Vite's `import.meta.glob` cannot discover the proof without it). This PR adds the standard entry point wiring meta + annotations + Lean source.

Rebased onto current main; index.ts-only, no conflict with #28083's content.

## Verification
- `tsc -b` passes; follows the standard gallery index.ts template.