### PR TITLE
research(de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03): normalised DFT as a linear isometric isomorphism of ℂⁿ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -805,6 +805,7 @@ import Proofs.DeMoivreOQ05
 import Proofs.DeMoivreOQ05OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01OQ01
+import Proofs.DeMoivreOQ05OQ01OQ01OQ01OQ03
 import Proofs.DedekindFrobeniusBridge
 import Proofs.DenumerabilityRationals
 import Proofs.DenumerabilityRationalsOQ01

--- a/proofs/Proofs/DeMoivreOQ05OQ01OQ01OQ01OQ03.lean
+++ b/proofs/Proofs/DeMoivreOQ05OQ01OQ01OQ01OQ03.lean
@@ -1,0 +1,137 @@
+/-
+The normalised DFT as an explicit linear isometric isomorphism of ℂⁿ
+
+Source: Open question from the de-moivre gallery family
+        (de-moivre-oq-05-oq-01-oq-01-oq-01, third open question)
+Status: VERIFIED (0 axioms, 0 sorries)
+
+The parent entry (de-moivre-oq-05-oq-01-oq-01-oq-01) packaged the normalised
+discrete Fourier transform `U(j,k) = exp(2πi·jk/n)/√n` as a *matrix* and proved
+
+      U · Uᴴ = 1,   i.e.   U ∈ Matrix.unitaryGroup (Fin n) ℂ,
+
+together with the ℓ²-energy law `‖Ux‖ = ‖x‖`.  Its third open question asks to
+upgrade this matrix-level unitarity to a genuine **isometric isomorphism** of the
+Euclidean space `ℂⁿ = EuclideanSpace ℂ (Fin n)`, i.e. an element of
+
+      EuclideanSpace ℂ (Fin n)  ≃ₗᵢ[ℂ]  EuclideanSpace ℂ (Fin n).
+
+This file does exactly that.  Acting on `EuclideanSpace ℂ (Fin n)` by the
+matrix–vector product, `U` becomes a linear map `toEuclideanLin U`; the parent's
+unitarity makes it inner-product preserving and two-sided invertible, so it
+assembles into a `LinearIsometryEquiv`, `dftLIE`.  We then record the three
+defining properties — it acts as `toEuclideanLin U`, preserves the norm and the
+inner product — and identify its inverse with `toEuclideanLin Uᴴ`, the **inverse
+discrete Fourier transform**.  Since `U` is unitary, `Uᴴ = U⁻¹`, so the inverse
+isometry is literally the conjugate-transpose / inverse-DFT operator.
+
+Proof.  Write `f = toEuclideanLin U`.  Mathlib's
+`toEuclideanLin_conjTranspose_eq_adjoint` gives `adjoint f = toEuclideanLin Uᴴ`,
+and the matrix identities `Uᴴ·U = 1` and `U·Uᴴ = 1` (both forms of
+`U ∈ unitaryGroup`) show `toEuclideanLin Uᴴ` is a two-sided inverse of `f`.  Hence
+`⟪f x, f y⟫ = ⟪x, adjoint f (f y)⟫ = ⟪x, y⟫`, so `f` preserves the inner product
+(`LinearMap.isometryOfInner`), and the right inverse makes it surjective
+(`LinearIsometryEquiv.ofSurjective`).
+
+Theorems / definitions:
+1. `dftMatrix_conjTranspose_toEuclideanLin_left_inverse`  — Uᴴ∘U = id on ℂⁿ
+2. `dftMatrix_toEuclideanLin_right_inverse`               — U∘Uᴴ = id on ℂⁿ
+3. `dftMatrix_toEuclideanLin_inner`                       — ⟪Ux,Uy⟫ = ⟪x,y⟫
+4. `dftLIE`                                               — the LinearIsometryEquiv
+5. `dftLIE_apply`                                         — dftLIE = toEuclideanLin U
+6. `dftLIE_norm`                                          — ‖dftLIE x‖ = ‖x‖
+7. `dftLIE_inner`                                         — ⟪dftLIE x, dftLIE y⟫ = ⟪x,y⟫
+8. `dftLIE_symm_apply`                                    — (dftLIE)⁻¹ = toEuclideanLin Uᴴ
+-/
+
+import Mathlib
+import Proofs.DeMoivreOQ05OQ01OQ01OQ01
+
+open Matrix DeMoivreOQ05OQ01OQ01OQ01
+
+namespace DeMoivreOQ05OQ01OQ01OQ01OQ03
+
+/-- **`Uᴴ` is a left inverse of `U` as operators on `ℂⁿ`.**
+On `EuclideanSpace ℂ (Fin n)`, applying `toEuclideanLin Uᴴ` after `toEuclideanLin U`
+is the identity, because the matrix identity `Uᴴ · U = 1` (the `star A * A = 1`
+form of `U ∈ unitaryGroup`) collapses the composed matrix–vector product. -/
+theorem dftMatrix_conjTranspose_toEuclideanLin_left_inverse (n : ℕ) (hn : 0 < n)
+    (z : EuclideanSpace ℂ (Fin n)) :
+    Matrix.toEuclideanLin (dftMatrix n)ᴴ (Matrix.toEuclideanLin (dftMatrix n) z) = z := by
+  have hAA : (dftMatrix n)ᴴ * dftMatrix n = 1 := by
+    have h := Matrix.mem_unitaryGroup_iff'.mp (dftMatrix_mem_unitaryGroup n hn)
+    rwa [Matrix.star_eq_conjTranspose] at h
+  apply WithLp.ofLp_injective 2
+  simp only [Matrix.ofLp_toEuclideanLin_apply, Matrix.mulVec_mulVec, hAA, Matrix.one_mulVec]
+
+/-- **`Uᴴ` is a right inverse of `U` as operators on `ℂⁿ`.**
+Symmetrically, applying `toEuclideanLin U` after `toEuclideanLin Uᴴ` is the
+identity, using the matrix identity `U · Uᴴ = 1`.  Together with the left-inverse
+lemma this exhibits `toEuclideanLin U` as a bijection of `ℂⁿ`. -/
+theorem dftMatrix_toEuclideanLin_right_inverse (n : ℕ) (hn : 0 < n)
+    (w : EuclideanSpace ℂ (Fin n)) :
+    Matrix.toEuclideanLin (dftMatrix n) (Matrix.toEuclideanLin (dftMatrix n)ᴴ w) = w := by
+  have hAA : dftMatrix n * (dftMatrix n)ᴴ = 1 := by
+    have h := Matrix.mem_unitaryGroup_iff.mp (dftMatrix_mem_unitaryGroup n hn)
+    rwa [Matrix.star_eq_conjTranspose] at h
+  apply WithLp.ofLp_injective 2
+  simp only [Matrix.ofLp_toEuclideanLin_apply, Matrix.mulVec_mulVec, hAA, Matrix.one_mulVec]
+
+/-- **The DFT operator preserves the Hermitian inner product.**
+For all `x, y ∈ ℂⁿ`, `⟪Ux, Uy⟫ = ⟪x, y⟫`.  This is the operator-theoretic core of
+unitarity: writing the left side via the adjoint, `⟪Ux, Uy⟫ = ⟪x, U*(Uy)⟫`, and the
+adjoint `U* = toEuclideanLin Uᴴ` is a left inverse of `U`, so `U*(Uy) = y`. -/
+theorem dftMatrix_toEuclideanLin_inner (n : ℕ) (hn : 0 < n)
+    (x y : EuclideanSpace ℂ (Fin n)) :
+    (inner ℂ (Matrix.toEuclideanLin (dftMatrix n) x)
+        (Matrix.toEuclideanLin (dftMatrix n) y) : ℂ) = inner ℂ x y := by
+  rw [show (inner ℂ (Matrix.toEuclideanLin (dftMatrix n) x)
+            (Matrix.toEuclideanLin (dftMatrix n) y) : ℂ)
+        = inner ℂ x (LinearMap.adjoint (Matrix.toEuclideanLin (dftMatrix n))
+            (Matrix.toEuclideanLin (dftMatrix n) y))
+      from (LinearMap.adjoint_inner_right _ _ _).symm,
+    ← Matrix.toEuclideanLin_conjTranspose_eq_adjoint,
+    dftMatrix_conjTranspose_toEuclideanLin_left_inverse n hn]
+
+/-- **The normalised DFT as a linear isometric isomorphism of `ℂⁿ`.**
+The operator `toEuclideanLin U` preserves the inner product and is surjective (its
+right inverse is `toEuclideanLin Uᴴ`), so it packages into an element of
+`EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n)` — the discrete Fourier
+transform as a genuine unitary of the Hilbert space `ℂⁿ`. -/
+noncomputable def dftLIE (n : ℕ) (hn : 0 < n) :
+    EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n) :=
+  LinearIsometryEquiv.ofSurjective
+    ((Matrix.toEuclideanLin (dftMatrix n)).isometryOfInner
+      (dftMatrix_toEuclideanLin_inner n hn))
+    (fun w => ⟨Matrix.toEuclideanLin (dftMatrix n)ᴴ w, by
+      simpa only [LinearMap.coe_isometryOfInner] using
+        dftMatrix_toEuclideanLin_right_inverse n hn w⟩)
+
+/-- `dftLIE` acts as the matrix operator `toEuclideanLin U`. -/
+@[simp]
+theorem dftLIE_apply (n : ℕ) (hn : 0 < n) (x : EuclideanSpace ℂ (Fin n)) :
+    dftLIE n hn x = Matrix.toEuclideanLin (dftMatrix n) x := by
+  rw [dftLIE, LinearIsometryEquiv.coe_ofSurjective, LinearMap.coe_isometryOfInner]
+
+/-- **`dftLIE` preserves the Euclidean norm:** `‖dftLIE x‖ = ‖x‖`.  This is the
+ℓ²-energy law of the parent entry, now packaged as the `norm_map` of an isometry. -/
+theorem dftLIE_norm (n : ℕ) (hn : 0 < n) (x : EuclideanSpace ℂ (Fin n)) :
+    ‖dftLIE n hn x‖ = ‖x‖ :=
+  (dftLIE n hn).norm_map x
+
+/-- **`dftLIE` preserves the Hermitian inner product:** `⟪dftLIE x, dftLIE y⟫ = ⟪x, y⟫`. -/
+theorem dftLIE_inner (n : ℕ) (hn : 0 < n) (x y : EuclideanSpace ℂ (Fin n)) :
+    (inner ℂ (dftLIE n hn x) (dftLIE n hn y) : ℂ) = inner ℂ x y :=
+  (dftLIE n hn).inner_map_map x y
+
+/-- **The inverse isometry is the inverse / conjugate-transpose DFT.**
+`(dftLIE)⁻¹` acts as `toEuclideanLin Uᴴ`.  Since `U` is unitary, `Uᴴ = U⁻¹`, so the
+inverse of the forward transform is exactly the inverse discrete Fourier transform
+`x(k) = (1/n)∑_j x̂(j)·exp(-2πi·jk/n)` realised by the conjugate-transpose matrix. -/
+theorem dftLIE_symm_apply (n : ℕ) (hn : 0 < n) (w : EuclideanSpace ℂ (Fin n)) :
+    (dftLIE n hn).symm w = Matrix.toEuclideanLin (dftMatrix n)ᴴ w := by
+  apply (dftLIE n hn).injective
+  rw [LinearIsometryEquiv.apply_symm_apply, dftLIE_apply]
+  exact (dftMatrix_toEuclideanLin_right_inverse n hn w).symm
+
+end DeMoivreOQ05OQ01OQ01OQ01OQ03

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+  "slug": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+  "title": "De Moivre OQ-05-OQ-01-OQ-01-OQ-01-OQ-03: The Normalised DFT as a Linear Isometric Isomorphism of ℂⁿ",
+  "description": "Upgrades the parent's matrix-level unitarity U·Uᴴ = 1 to a genuine isometric isomorphism dftLIE : EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n), and identifies its inverse with the conjugate-transpose / inverse-DFT operator toEuclideanLin Uᴴ.",
+  "overview": {
+    "problemStatement": "**Open Question** (parent de-moivre-oq-05-oq-01-oq-01-oq-01, third question): package the normalised DFT matrix U as a `LinearIsometryEquiv` on `EuclideanSpace ℂ (Fin n)`, upgrading the matrix-level unitarity `U·Uᴴ = 1` to an explicit isometric isomorphism.\n\n**Answer**: Let U act on ℂⁿ by the matrix–vector product, f = `toEuclideanLin U`. The adjoint of f is `toEuclideanLin Uᴴ` (Mathlib's `toEuclideanLin_conjTranspose_eq_adjoint`), and the two forms of `U ∈ unitaryGroup` (`Uᴴ·U = 1` and `U·Uᴴ = 1`) make `toEuclideanLin Uᴴ` a two-sided inverse of f. Hence f preserves the Hermitian inner product `⟪Ux,Uy⟫ = ⟪x,y⟫` and is bijective, so it assembles into `dftLIE : EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n)`. Its inverse `(dftLIE)⁻¹` acts as `toEuclideanLin Uᴴ` — exactly the inverse / conjugate-transpose discrete Fourier transform.",
+    "historicalContext": "The operator-theoretic statement of the discrete Fourier transform is that it is a unitary of the finite-dimensional Hilbert space ℂⁿ: a perfectly invertible, energy-preserving change of orthonormal basis. The parent entry proved the underlying matrix identity U·Uᴴ = 1; this entry crosses from the matrix algebra into the bundled `≃ₗᵢ` (linear isometric equivalence) world, the form in which the DFT is used as a Hilbert-space isomorphism. Identifying the inverse isometry with the conjugate-transpose matrix is the abstract counterpart of the inverse-DFT formula x(k) = (1/n)∑_j x̂(j)·exp(−2πi·jk/n).",
+    "significance": "Closes the parent entry's third open question. It places the explicit exponential DFT matrix inside Mathlib's bundled isometry hierarchy (`LinearIsometryEquiv`), making the energy law (`norm_map`) and inner-product preservation (`inner_map_map`) available as structure, and exhibits the inverse transform as the genuine inverse of the forward isometry.",
+    "keyInsight": "Unitarity is exactly two-sided invertibility of `toEuclideanLin U` together with adjoint = inverse. The adjoint of `toEuclideanLin U` is `toEuclideanLin Uᴴ` (Mathlib), and `Uᴴ·U = U·Uᴴ = 1` turns the matrix unitary group membership into a bona-fide isometric isomorphism whose inverse IS the conjugate-transpose operator."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DeMoivreOQ05OQ01OQ01OQ01"
+    ],
+    "opens": [
+      "Matrix",
+      "DeMoivreOQ05OQ01OQ01OQ01"
+    ],
+    "namespace": "DeMoivreOQ05OQ01OQ01OQ01OQ03",
+    "lineCount": 137,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/DeMoivreOQ05OQ01OQ01OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ05OQ01OQ01OQ01OQ03.lean",
+    "tags": [
+      "complex-analysis",
+      "discrete-fourier",
+      "unitary-group",
+      "isometry",
+      "linear-isometry-equiv",
+      "euclidean-space",
+      "adjoint",
+      "de-moivre"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Matrix.toEuclideanLin",
+        "description": "Realises a matrix as a linear map on EuclideanSpace 𝕜 (Fin n) via the matrix–vector product; the bridge from the matrix U to an operator on ℂⁿ",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Matrix.toEuclideanLin_conjTranspose_eq_adjoint",
+        "description": "Aᴴ.toEuclideanLin = A.toEuclideanLin.adjoint; identifies the operator adjoint of toEuclideanLin U with toEuclideanLin Uᴴ — the key step turning unitarity into inner-product preservation",
+        "module": "Mathlib.Analysis.InnerProductSpace.Adjoint"
+      },
+      {
+        "theorem": "Matrix.mem_unitaryGroup_iff",
+        "description": "A ∈ unitaryGroup ↔ A · star A = 1; the U·Uᴴ = 1 form, used for the right inverse / surjectivity",
+        "module": "Mathlib.LinearAlgebra.UnitaryGroup"
+      },
+      {
+        "theorem": "Matrix.mem_unitaryGroup_iff'",
+        "description": "A ∈ unitaryGroup ↔ star A · A = 1; the Uᴴ·U = 1 form, used for the left inverse / inner-product preservation",
+        "module": "Mathlib.LinearAlgebra.UnitaryGroup"
+      },
+      {
+        "theorem": "LinearMap.adjoint_inner_right",
+        "description": "⟪x, adjoint A y⟫ = ⟪A x, y⟫; rewrites ⟪Ux, Uy⟫ as ⟪x, U*(Uy)⟫ so the left-inverse identity finishes the inner-product preservation",
+        "module": "Mathlib.Analysis.InnerProductSpace.Adjoint"
+      },
+      {
+        "theorem": "LinearMap.isometryOfInner",
+        "description": "A linear map preserving the inner product is a linear isometry; packages toEuclideanLin U into a LinearIsometry",
+        "module": "Mathlib.Analysis.InnerProductSpace.LinearMap"
+      },
+      {
+        "theorem": "LinearIsometryEquiv.ofSurjective",
+        "description": "A surjective linear isometry is a linear isometric equivalence; with the right inverse this yields dftLIE",
+        "module": "Mathlib.Analysis.Normed.Operator.LinearIsometry"
+      },
+      {
+        "theorem": "Matrix.mulVec_mulVec",
+        "description": "A *ᵥ (B *ᵥ v) = (A · B) *ᵥ v; collapses the composed operator applications into a single matrix product so Uᴴ·U = 1 and U·Uᴴ = 1 apply",
+        "module": "Mathlib.Data.Matrix.Mul"
+      },
+      {
+        "theorem": "DeMoivreOQ05OQ01OQ01OQ01.dftMatrix_mem_unitaryGroup",
+        "description": "Parent result: U ∈ Matrix.unitaryGroup (Fin n) ℂ — the sole nontrivial input; everything here is its operator-theoretic repackaging",
+        "module": "Proofs.DeMoivreOQ05OQ01OQ01OQ01"
+      }
+    ],
+    "originalContributions": [
+      "dftMatrix_conjTranspose_toEuclideanLin_left_inverse: toEuclideanLin Uᴴ ∘ toEuclideanLin U = id on EuclideanSpace ℂ (Fin n), from the matrix identity Uᴴ·U = 1",
+      "dftMatrix_toEuclideanLin_right_inverse: toEuclideanLin U ∘ toEuclideanLin Uᴴ = id, from U·Uᴴ = 1 — together with the left inverse this gives bijectivity",
+      "dftMatrix_toEuclideanLin_inner: ⟪Ux, Uy⟫ = ⟪x, y⟫, inner-product preservation via adjoint = toEuclideanLin Uᴴ and the left-inverse identity",
+      "dftLIE: the normalised DFT as a LinearIsometryEquiv EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n), assembled from isometryOfInner + ofSurjective",
+      "dftLIE_apply / dftLIE_norm / dftLIE_inner: dftLIE acts as toEuclideanLin U, preserves the Euclidean norm, and preserves the Hermitian inner product",
+      "dftLIE_symm_apply: the inverse isometry (dftLIE)⁻¹ acts as toEuclideanLin Uᴴ — the inverse / conjugate-transpose discrete Fourier transform"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 137,
+    "assumptions": "0 axioms, 0 sorries (proofs depend only on propext / Classical.choice / Quot.sound). The single nontrivial mathematical input is the parent's dftMatrix_mem_unitaryGroup (U ∈ unitaryGroup); everything else is the standard repackaging of a unitary matrix as an isometric isomorphism via Mathlib's toEuclideanLin / adjoint / LinearIsometryEquiv machinery.",
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "sorries": 0,
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-05-oq-01-oq-01-oq-01",
+      "relationship": "Parent: packages the normalised DFT matrix U and proves U·Uᴴ = 1 (U ∈ unitaryGroup) plus the ℓ²-energy law; this entry answers its third open question by upgrading that matrix unitarity to a LinearIsometryEquiv on ℂⁿ with inverse toEuclideanLin Uᴴ"
+    },
+    {
+      "id": "de-moivre-oq-05-oq-01-oq-01",
+      "relationship": "Grandparent: Plancherel/Parseval for the unnormalised DFT and the character orthonormality char_inner underlying the unitarity"
+    },
+    {
+      "id": "de-moivre-oq-05-oq-01",
+      "relationship": "Great-grandparent: orthonormality of the discrete Fourier characters, the seed of the unitarity"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Michel Plancherel",
+      "title": "Contribution à l'étude de la représentation d'une fonction arbitraire par des intégrales définies",
+      "year": "1910",
+      "venue": "Rendiconti del Circolo Matematico di Palermo"
+    },
+    {
+      "authors": "James W. Cooley and John W. Tukey",
+      "title": "An Algorithm for the Machine Calculation of Complex Fourier Series",
+      "year": "1965",
+      "venue": "Mathematics of Computation"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-05-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent formalization (the unitary DFT matrix U with U·Uᴴ = 1); this entry packages U as a genuine LinearIsometryEquiv of EuclideanSpace ℂ (Fin n), answering its third open question and identifying the inverse isometry with the conjugate-transpose / inverse-DFT operator."
+    },
+    {
+      "targetId": "de-moivre-oq-05-oq-01-oq-01",
+      "relationship": "foundational",
+      "description": "Grandparent character orthonormality, the nontrivial input behind the unitarity that this entry lifts to an isometric isomorphism."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of the parent entry `de-moivre-oq-05-oq-01-oq-01-oq-01` (*"Package U as a LinearIsometryEquiv on EuclideanSpace ℂ (Fin n), upgrading the matrix-level unitarity to an explicit isometric isomorphism"*).

The parent proved the normalised DFT matrix `U(j,k) = exp(2πi·jk/n)/√n` satisfies `U·Uᴴ = 1`, i.e. `U ∈ Matrix.unitaryGroup (Fin n) ℂ`. This entry lifts that matrix identity into Mathlib's bundled isometry hierarchy:

```
dftLIE : EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n)
```

the discrete Fourier transform as a genuine **unitary of the Hilbert space ℂⁿ**, and identifies its inverse with the conjugate-transpose / inverse-DFT operator `toEuclideanLin Uᴴ`.

## Proof

Let `f = toEuclideanLin U` act on ℂⁿ by the matrix–vector product. Mathlib's `toEuclideanLin_conjTranspose_eq_adjoint` gives `adjoint f = toEuclideanLin Uᴴ`, and the two forms of `U ∈ unitaryGroup` (`Uᴴ·U = 1`, `U·Uᴴ = 1`) make `toEuclideanLin Uᴴ` a two-sided inverse of `f`. Hence `⟪f x, f y⟫ = ⟪x, adjoint f (f y)⟫ = ⟪x, y⟫` (inner-product preservation, `LinearMap.isometryOfInner`), and the right inverse gives surjectivity (`LinearIsometryEquiv.ofSurjective`).

## Contents (7 theorems, 1 definition)

- `dftMatrix_conjTranspose_toEuclideanLin_left_inverse` — Uᴴ∘U = id on ℂⁿ
- `dftMatrix_toEuclideanLin_right_inverse` — U∘Uᴴ = id on ℂⁿ
- `dftMatrix_toEuclideanLin_inner` — ⟪Ux, Uy⟫ = ⟪x, y⟫
- `dftLIE` — the LinearIsometryEquiv
- `dftLIE_apply` / `dftLIE_norm` / `dftLIE_inner` — acts as `toEuclideanLin U`, preserves norm and inner product
- `dftLIE_symm_apply` — `(dftLIE)⁻¹ = toEuclideanLin Uᴴ` (inverse DFT)

## Verification

- **0 sorries, 0 axiom declarations** — `#print axioms` lists only `propext / Classical.choice / Quot.sound`
- Compiles against Mathlib v4.26.0
- Sole nontrivial input is the parent's `dftMatrix_mem_unitaryGroup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)