### PR TITLE
Fix stale sorry annotation in central-limit-theorem-oq-01-oq-02

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/annotations.json
@@ -32,7 +32,7 @@
     },
     "type": "concept",
     "title": "Gaussian Distribution as Infinitely Divisible",
-    "content": "Constructs the Gaussian characteristic exponent ψ(t) = iμt - σ²t²/2 and the Gaussian triplet (μ, σ², 0). The zero Lévy measure means no jumps — Gaussian distributions are the unique infinitely divisible laws with continuous sample paths. The construction proves ψ(0) = 0 and continuity via fun_prop, then packages everything into an InfDivisible instance. The gaussianExponent_zero sorry involves Complex.ofReal arithmetic that should be provable with ring-style tactics.",
+    "content": "Constructs the Gaussian characteristic exponent ψ(t) = iμt - σ²t²/2 and the Gaussian triplet (μ, σ², 0). The zero Lévy measure means no jumps — Gaussian distributions are the unique infinitely divisible laws with continuous sample paths. The construction proves ψ(0) = 0 and continuity via fun_prop, then packages everything into an InfDivisible instance. The normalization ψ(0) = 0 is proved as `gaussianExponent_zero` via `unfold` + `simp`.",
     "mathContext": "For $X \\sim N(\\mu, \\sigma^2)$: $\\varphi_X(t) = e^{i\\mu t - \\sigma^2 t^2/2}$, so $\\psi(t) = i\\mu t - \\sigma^2 t^2/2$. The triplet is $(\\mu, \\sigma^2, 0)$, with $\\nu = 0$ reflecting the absence of jumps.",
     "significance": "key",
     "relatedConcepts": [

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/annotations.json
@@ -104,7 +104,7 @@
     },
     "type": "insight",
     "title": "α-Stable Distributions and Scaling Property",
-    "content": "Defines the symmetric α-stable characteristic exponent ψ(t) = -c|t|^α and states its defining scaling property: n · ψ(t/n^{1/α}) = ψ(t). This means the n-fold convolution of an α-stable law with scale parameter c/n is the same α-stable law with scale c — the distribution is invariant under normalized summation. The case α = 2 gives the Gaussian (CLT attractor), while α < 2 gives heavy-tailed distributions that arise as limits when variance is infinite. The sorry on stable_scaling involves rpow arithmetic.",
+    "content": "Defines the symmetric α-stable characteristic exponent ψ(t) = -c|t|^α and states its defining scaling property: n · ψ(t/n^{1/α}) = ψ(t). This means the n-fold convolution of an α-stable law with scale parameter c/n is the same α-stable law with scale c — the distribution is invariant under normalized summation. The case α = 2 gives the Gaussian (CLT attractor), while α < 2 gives heavy-tailed distributions that arise as limits when variance is infinite. The scaling property is proved as `stable_scaling`, which reduces to the rpow identity `rpow_scaling_identity`.",
     "mathContext": "$\\psi(t) = -c|t|^\\alpha$ for $\\alpha \\in (0, 2]$, $c > 0$. Scaling property: $n \\cdot \\psi(t/n^{1/\\alpha}) = -cn|t/n^{1/\\alpha}|^\\alpha = -c|t|^\\alpha = \\psi(t)$, using $|t/n^{1/\\alpha}|^\\alpha = |t|^\\alpha/n$.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Fix

Two stale sorry annotations in `central-limit-theorem-oq-01-oq-02` that referenced sorries which no longer exist. The Lean source contains **0** sorry occurrences and meta.json is `verified` / 0 sorries / 0 axioms / badge `original`.

## Evidence

**1. `α-Stable Distributions and Scaling Property`**
- Before: _"The sorry on stable_scaling involves rpow arithmetic."_
- After: _"The scaling property is proved as `stable_scaling`, which reduces to the rpow identity `rpow_scaling_identity`."_
- `stable_scaling` (CentralLimitTheoremOQ01OQ02.lean:199) is proved via `rpow_scaling_identity` + `simp`.

**2. `Gaussian Distribution as Infinitely Divisible`**
- Before: _"The gaussianExponent_zero sorry involves Complex.ofReal arithmetic that should be provable with ring-style tactics."_
- After: _"The normalization ψ(0) = 0 is proved as `gaussianExponent_zero` via `unfold` + `simp`."_
- `gaussianExponent_zero` (CentralLimitTheoremOQ01OQ02.lean:86) is proved via `unfold` + `simp`.

---
Automated fix by lean-mechanic agent.