### PR TITLE
Enrich: Measure–Category Orthogonality (algebraic-reals-meager-oq-03)

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-oq-03/annotations.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "algebraic-reals-meager-oq-03",
+    "range": { "startLine": 3, "endLine": 55 },
+    "type": "context",
+    "title": "Measure–Category Orthogonality and the Liouville Separator",
+    "content": "The docstring frames the open question. Lebesgue measure and Baire category give two *independent* notions of a 'small' subset of $\\mathbb{R}$: null (measure-small) and meagre (category-small). The parent proved the algebraic reals meagre; sibling oq-02 proved them null and exhibited a comeagre-yet-null set (the Liouville numbers), settling category-large $\\not\\Rightarrow$ measure-large. OQ-03 asks for the dual witness — a meagre set of *full* measure — and the sharpest structural form, Oxtoby's orthogonal decomposition $\\mathbb{R} = A \\sqcup B$ with $A$ meagre and $B$ null. The shorthand $\\mathcal{L} = \\{x : \\mathrm{Liouville}\\,x\\}$ is the separating set: $B = \\mathcal{L}$ and $A = \\mathcal{L}^c$.",
+    "mathContext": "Meagre = countable union of nowhere-dense sets; residual (comeagre) = complement of meagre; null = Lebesgue measure $0$. Meagre and null are distinct $\\sigma$-ideals on $\\mathbb{R}$.",
+    "significance": "context",
+    "relatedConcepts": ["Baire category", "Lebesgue measure", "Liouville numbers", "Oxtoby orthogonality", "sigma-ideal"],
+    "prerequisites": ["measure theory", "Baire category theorem", "real analysis"]
+  },
+  {
+    "id": "ann-engine",
+    "proofId": "algebraic-reals-meager-oq-03",
+    "range": { "startLine": 57, "endLine": 77 },
+    "type": "technique",
+    "title": "The Abstract Orthogonality Engine",
+    "content": "`meagre_conull_compl_of_residual_null` is the reusable core: if $S$ is residual and null, then $S^c$ is meagre, has full measure, and $S^c \\cup S = \\mathbb{R}$. Meagreness is immediate — $\\mathrm{IsMeagre}\\,S^c$ unfolds to $S^{cc} = S \\in \\mathrm{residual}$ (via `compl_compl`). The full-measure step is the elegant part: $\\mathrm{vol}(\\mathbb{R}) = \\mathrm{vol}(S^c \\cup S) \\le \\mathrm{vol}(S^c) + \\mathrm{vol}(S) = \\mathrm{vol}(S^c)$ by `measure_union_le` and $\\mathrm{vol}(S) = 0$, combined with $\\mathrm{vol}(S^c) \\le \\mathrm{vol}(\\mathbb{R})$ via antisymmetry. Crucially this uses only **countable subadditivity of the outer measure** — no measurability hypothesis on $S$ is needed, which is why the theorem applies to the (non-Borel-in-general) Liouville set directly.",
+    "mathContext": "$\\mathrm{vol}(\\mathrm{univ}) = \\mathrm{vol}(S^c \\cup S) \\le \\mathrm{vol}(S^c) + \\mathrm{vol}(S) = \\mathrm{vol}(S^c)$, and $\\mathrm{vol}(S^c) \\le \\mathrm{vol}(\\mathrm{univ})$, so equality.",
+    "significance": "key",
+    "relatedConcepts": ["countable subadditivity", "measure_union_le", "outer measure", "IsMeagre", "residual"],
+    "prerequisites": ["outer measure", "measure monotonicity"]
+  },
+  {
+    "id": "ann-decomposition",
+    "proofId": "algebraic-reals-meager-oq-03",
+    "range": { "startLine": 79, "endLine": 93 },
+    "type": "insight",
+    "title": "The Oxtoby Orthogonal Decomposition",
+    "content": "`real_meagre_null_decomposition` is the headline: $\\mathbb{R} = A \\sqcup B$ with $A = \\mathcal{L}^c$ meagre and $B = \\mathcal{L}$ null. It instantiates the engine at the Liouville numbers, supplying $A \\cup B = \\mathbb{R}$ (`compl_union_self`), disjointness (`disjoint_compl_left`), meagreness (engine output), and nullity (`liouville_null` from oq-02). This is Oxtoby's Theorem 1.6 — the sharpest expression of measure–category independence: a topologically small set and a measure-theoretically small set together tile the entire line, so neither $\\sigma$-ideal can contain the other.",
+    "mathContext": "$\\mathbb{R} = \\mathcal{L}^c \\sqcup \\mathcal{L}$, $\\mathcal{L}^c$ meagre, $\\mathcal{L}$ null.",
+    "significance": "key",
+    "relatedConcepts": ["Oxtoby theorem", "orthogonal decomposition", "disjoint union", "Liouville numbers"],
+    "prerequisites": ["complementation identities", "Baire category"]
+  },
+  {
+    "id": "ann-meagre-conull",
+    "proofId": "algebraic-reals-meager-oq-03",
+    "range": { "startLine": 95, "endLine": 102 },
+    "type": "concept",
+    "title": "The Requested Witness: a Meagre Set of Full Measure",
+    "content": "`exists_meagre_conull` produces exactly the object OQ-03 asks for: a meagre set $A = \\mathcal{L}^c$ with $\\mathrm{vol}(A^c) = 0$ and $\\mathrm{vol}(A) = \\mathrm{vol}(\\mathbb{R})$. It reads the meagreness and full-measure facts off the engine, and gets $\\mathrm{vol}(A^c) = \\mathrm{vol}(\\mathcal{L}) = 0$ after `compl_compl`. This is the dual of oq-02's comeagre null set: there, category-large + measure-small; here, category-small + measure-large.",
+    "mathContext": "$A = \\mathcal{L}^c$: $\\mathrm{IsMeagre}\\,A$, $\\mathrm{vol}(A^c) = 0$, $\\mathrm{vol}(A) = \\mathrm{vol}(\\mathrm{univ})$.",
+    "significance": "key",
+    "relatedConcepts": ["conull set", "full measure", "duality with oq-02"],
+    "prerequisites": ["complement measure"]
+  },
+  {
+    "id": "ann-non-implications",
+    "proofId": "algebraic-reals-meager-oq-03",
+    "range": { "startLine": 104, "endLine": 121 },
+    "type": "concept",
+    "title": "The Two Dual Non-Implications",
+    "content": "The independence is made literal by two theorems. `meagre_not_imp_null`: a meagre set with $\\mathrm{vol} \\ne 0$ — in fact $\\mathcal{L}^c$ has full *infinite* measure ($\\mathrm{vol}(\\mathrm{univ}) = \\infty$ by `Real.volume_univ`, $\\ne 0$ by `ENNReal.top_ne_zero`). `null_not_imp_meagre`: a null set that is not meagre — the Liouville numbers, which are residual and hence not meagre by `not_isMeagre_of_mem_residual` (a residual set in a Baire space cannot be meagre, else the whole space would be meagre). These are exact duals, witnessed by the complementary pair $(\\mathcal{L}^c, \\mathcal{L})$.",
+    "mathContext": "Category-small $\\not\\Rightarrow$ measure-small ($\\mathcal{L}^c$ meagre, $\\mathrm{vol} = \\infty$); measure-small $\\not\\Rightarrow$ category-small ($\\mathcal{L}$ null, not meagre).",
+    "significance": "supporting",
+    "relatedConcepts": ["not_isMeagre_of_mem_residual", "Real.volume_univ", "Baire space", "logical independence"],
+    "prerequisites": ["Baire category theorem", "extended nonnegative reals"]
+  },
+  {
+    "id": "ann-resolution",
+    "proofId": "algebraic-reals-meager-oq-03",
+    "range": { "startLine": 123, "endLine": 146 },
+    "type": "concept",
+    "title": "OQ-03 Resolution: Packaged Independence",
+    "content": "`oq03_resolution` bundles all three facts — the orthogonal decomposition plus both non-implications — into a single statement that measure-smallness and category-smallness are independent on $\\mathbb{R}$ in the sharpest form. The closing `#check`s confirm each theorem typechecks. The honest scope: the engine and packaging are the new content here, while the deep inputs (Liouville comeagre and null) are imported from the verified sibling oq-02 — a machine-checked synthesis rather than new analysis.",
+    "mathContext": "Independence $=$ (Oxtoby decomposition) $\\wedge$ (meagre $\\not\\Rightarrow$ null) $\\wedge$ (null $\\not\\Rightarrow$ meagre).",
+    "significance": "supporting",
+    "relatedConcepts": ["theorem packaging", "synthesis", "measure-category independence"],
+    "prerequisites": ["logical conjunction"]
+  }
+]

--- a/src/data/proofs/algebraic-reals-meager-oq-03/index.ts
+++ b/src/data/proofs/algebraic-reals-meager-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AlgebraicRealsMeagerOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const algebraicRealsMeagerOQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const algebraicRealsMeagerOQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const algebraicRealsMeagerOQ03Data: ProofData = {
+  proof: algebraicRealsMeagerOQ03Proof,
+  annotations: algebraicRealsMeagerOQ03Annotations,
+}

--- a/src/data/proofs/algebraic-reals-meager-oq-03/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-oq-03/meta.json
@@ -157,7 +157,18 @@
       "url": "https://en.wikipedia.org/wiki/Meagre_set"
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "targetId": "algebraic-reals-meager-oq-02",
+      "relationship": "extends",
+      "description": "Supplies the dual missing half: oq-02 proves comeagre ⇏ conull (Liouville numbers comeagre yet null); this entry proves meagre ⇏ null (a meagre set of full measure) and combines both into the Oxtoby decomposition, reusing oq-02's verified liouville_residual and liouville_null."
+    },
+    {
+      "targetId": "algebraic-reals-meager",
+      "relationship": "related",
+      "description": "The parent proves the topological (Baire-category) smallness of the algebraic reals; this entry shows category-smallness and measure-smallness are logically independent, so the parent's meagreness and the measure-zero fact are genuinely distinct theorems."
+    }
+  ],
   "conclusion": "Measure-smallness and category-smallness are independent on ℝ. Dual to oq-02's comeagre null set, the complement of the Liouville numbers is a meagre set of full Lebesgue measure, and the two combine into the Oxtoby decomposition ℝ = A ⊔ B with A meagre and B null. So neither notion of smallness implies the other, and the algebraic reals being both meagre and Lebesgue-null is a conjunction of two genuinely separate facts — all formalized with zero axioms on top of the verified Liouville infrastructure.",
   "sorries": []
 }


### PR DESCRIPTION
Enrichment pass for `algebraic-reals-meager-oq-03` (quality 30, pass 0). Verified against current main: only `meta.json` existed (no annotations.json/index.ts).

## What changed
- **Created `index.ts`** — was missing, so the page would 404 on the live site.
- **Created `annotations.json`** — 6 substantive annotations (mathContext/significance/relatedConcepts/prerequisites) covering the overview, the abstract orthogonality engine (`meagre_conull_compl_of_residual_null`), the Oxtoby decomposition, the meagre-conull witness, the two dual non-implications, and the packaged `oq03_resolution`.
- **Populated `crossReferences`** (was an empty array) — sibling `algebraic-reals-meager-oq-02` and parent `algebraic-reals-meager`, both confirmed present.

## Verification
- `json.load` validates both JSON files; `tsc -b` passes; annotation build reports no errors for this entry.
- Axiom/status unchanged: verified / mathlib / 0-axiom, matching the sorry-free, axiom-free Lean source (built on verified oq-02 Liouville infrastructure).