### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01): automorphism equality |Aut_F(K)| = [K:F]_s for normal extensions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3191,6 +3191,7 @@ import Proofs.NarcissisticNumberOQ01
 import Proofs.NavierStokes
 import Proofs.NesbittInequalityOQ01
 import Proofs.NormEuclideanZsqrtdFamilyOQ03
+import Proofs.NormalAutFinSepDegreeEquality
 import Proofs.NewtonIndStep2
 import Proofs.NewtonInductiveStep
 import Proofs.NewtonInductiveStepOQ01

--- a/proofs/Proofs/NormalAutFinSepDegreeEquality.lean
+++ b/proofs/Proofs/NormalAutFinSepDegreeEquality.lean
@@ -1,0 +1,120 @@
+/-
+# The Automorphism Equality for Normal Extensions: |Aut_F(K)| = [K : F]_s
+
+This file answers the two open questions raised by
+`angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05`
+("The Automorphism Bound: |Aut_F(K)| ≤ [K : F]_s"), which proved the *inequality*
+`Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K` via a single injection
+
+  `toEmb : (K ≃ₐ[F] K) → Field.Emb F K`,
+  `toEmb e = (IsScalarTower.toAlgHom F K (AlgebraicClosure K)).comp e.toAlgHom`,
+
+and asked:
+
+> 1. Can the bound be sharpened to an equality criterion —
+>    `Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K` when `K / F` is normal —
+>    recovering the Galois characterisation `|Gal| = [K : F]` for normal separable
+>    extensions?
+> 2. Does the injection `toEmb` extend to a *bijection* onto the embeddings, giving
+>    `|Aut_F(K)|` equal to the number of `F`-embeddings of `K` for normal `K / F`?
+
+**The key observation.**  Mathlib packages `Normal.algHomEquivAut`, the equivalence
+
+  `(E →ₐ[F] K₁) ≃ (E ≃ₐ[F] E)`   for `[Normal F E]`,
+
+whose *inverse* sends `σ ↦ (IsScalarTower.toAlgHom F E K₁).comp σ.toAlgHom`.
+Taking `E = K` and `K₁ = AlgebraicClosure K`, this inverse is *definitionally* the
+parent's `toEmb`.  So for a normal extension the parent's injection is exactly one
+half of a Mathlib equivalence: it is automatically **bijective**, and counting both
+sides gives the equality `[K : F]_s = |Aut_F(K)|`.  This is the second branch of
+the open question answered head-on, and the equality of the first.
+
+**Why this is more than the Galois fact.**  Mathlib already has
+`IsGalois.card_aut_eq_finrank` (`|Aut| = [K : F]` for *Galois* = normal *and*
+separable extensions).  The equality proved here drops separability: for an
+arbitrary **normal** extension the automorphism count equals the *separable*
+degree `[K : F]_s`, which is `[K : F]` only when the extension is also separable.
+Indeed, among finite normal extensions, `|Aut_F(K)| = [K : F]` holds **iff** `K / F`
+is separable (`card_algEquiv_eq_finrank_iff_isSeparable` below); for a normal
+*purely inseparable* extension both `[K : F]_s` and `|Aut_F(K)|` collapse to `1`
+while `[K : F]` can be arbitrarily large.  So the automorphism group sees only the
+separable part of the degree — the equality isolates exactly that phenomenon.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+import Mathlib.FieldTheory.SeparableDegree
+import Mathlib.FieldTheory.Normal.Defs
+
+open Field
+
+variable (F K : Type*) [Field F] [Field K] [Algebra F K]
+
+namespace NormalAutEquality
+
+/-- The post-composition map from the parent entry: an `F`-algebra automorphism of
+`K` becomes an `F`-embedding of `K` into its algebraic closure by following it with
+the structure map `K → AlgebraicClosure K`. -/
+noncomputable def toEmb (e : K ≃ₐ[F] K) : Field.Emb F K :=
+  (IsScalarTower.toAlgHom F K (AlgebraicClosure K)).comp e.toAlgHom
+
+/-- For a normal extension, the parent's `toEmb` is *definitionally* the inverse of
+Mathlib's `Normal.algHomEquivAut` (specialised to embeddings into the algebraic
+closure): `Normal.algHomEquivAut` sends `σ` to `(toAlgHom F K _).comp σ.toAlgHom`,
+which is exactly `toEmb`. -/
+theorem toEmb_eq_symm_algHomEquivAut [Normal F K] :
+    toEmb F K = ⇑(Normal.algHomEquivAut F (AlgebraicClosure K) K).symm := rfl
+
+/-- The equivalence `Field.Emb F K ≃ (K ≃ₐ[F] K)` for a normal extension: every
+`F`-embedding of `K` into its algebraic closure restricts to an `F`-automorphism of
+`K`, and conversely. This is `Normal.algHomEquivAut` read through
+`Field.Emb F K = K →ₐ[F] AlgebraicClosure K`. -/
+noncomputable def embEquivAlgEquiv [Normal F K] :
+    Field.Emb F K ≃ (K ≃ₐ[F] K) :=
+  Normal.algHomEquivAut F (AlgebraicClosure K) K
+
+/-- **Answer to open question 2.**  For a normal extension `K / F`, the parent's
+injection `toEmb` is in fact a *bijection*: the `F`-automorphisms of `K` are in
+bijection with the `F`-embeddings of `K` into its algebraic closure. -/
+theorem toEmb_bijective [Normal F K] : Function.Bijective (toEmb F K) := by
+  rw [toEmb_eq_symm_algHomEquivAut]
+  exact (Normal.algHomEquivAut F (AlgebraicClosure K) K).symm.bijective
+
+/-- **Answer to open question 1 (the equality).**  For a normal extension `K / F`,
+the separable degree equals the number of `F`-algebra automorphisms of `K`:
+
+  `[K : F]_s = |Aut_F(K)|`.
+
+This sharpens the parent's inequality `|Aut_F(K)| ≤ [K : F]_s` to an equality
+whenever `K / F` is normal, by exhibiting the parent's injection as one half of
+`Normal.algHomEquivAut`. No finiteness hypothesis is needed: for an infinite normal
+extension both `Nat.card`s are `0`. -/
+theorem finSepDegree_eq_card_algEquiv [Normal F K] :
+    Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K) :=
+  Nat.card_congr (Normal.algHomEquivAut F (AlgebraicClosure K) K)
+
+/-- The same equality written with the automorphism count on the left, matching the
+shape of the parent's bound `Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K`. -/
+theorem card_algEquiv_eq_finSepDegree [Normal F K] :
+    Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K :=
+  (finSepDegree_eq_card_algEquiv F K).symm
+
+/-- **Sharp separability boundary.**  Among *finite normal* extensions, the
+automorphism count reaches the full degree `[K : F]` precisely when `K / F` is
+separable.  This is what distinguishes the equality above from the Galois fact
+`IsGalois.card_aut_eq_finrank`: the automorphism group always counts the separable
+degree, and that equals `[K : F]` exactly in the separable (hence Galois) case. -/
+theorem card_algEquiv_eq_finrank_iff_isSeparable
+    [FiniteDimensional F K] [Normal F K] :
+    Nat.card (K ≃ₐ[F] K) = Module.finrank F K ↔ Algebra.IsSeparable F K := by
+  rw [card_algEquiv_eq_finSepDegree, Field.finSepDegree_eq_finrank_iff]
+
+/-- **Galois corollary (recovering `IsGalois.card_aut_eq_finrank`).**  A finite
+normal *separable* extension — i.e. a finite Galois extension — has exactly
+`[K : F]` automorphisms.  Here it falls straight out of the normal equality plus
+`[K : F]_s = [K : F]` for separable extensions. -/
+theorem card_algEquiv_eq_finrank_of_normal_isSeparable
+    [FiniteDimensional F K] [Normal F K] [Algebra.IsSeparable F K] :
+    Nat.card (K ≃ₐ[F] K) = Module.finrank F K := by
+  rw [card_algEquiv_eq_finSepDegree, Field.finSepDegree_eq_finrank_of_isSeparable]
+
+end NormalAutEquality

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01",
+  "title": "The Automorphism Equality for Normal Extensions: |Aut_F(K)| = [K : F]_s",
+  "slug": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01",
+  "description": "Answers both open questions of the parent automorphism-bound entry. The parent proved the inequality |Aut_F(K)| ≤ [K:F]_s via an injection toEmb of automorphisms into embeddings of K into its algebraic closure. This entry observes that toEmb is *definitionally* the inverse half of Mathlib's Normal.algHomEquivAut, so for a normal extension it is a bijection — upgrading the parent's inequality to the equality [K:F]_s = |Aut_F(K)| (Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K)). Crucially this needs only normality, not separability: the automorphism count tracks the separable degree, equalling the full degree [K:F] exactly when K/F is also separable (Galois). Recovers IsGalois.card_aut_eq_finrank as a corollary.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NormalAutFinSepDegreeEquality.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "field-extensions",
+      "separability",
+      "separable-degree",
+      "normal-extension",
+      "automorphism-group"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlibDependencies": [
+      {
+        "theorem": "Normal.algHomEquivAut",
+        "description": "For a normal extension E/F inside a tower F → E → K₁, the equivalence (E →ₐ[F] K₁) ≃ (E ≃ₐ[F] E) restricting an embedding to an automorphism. With E = K and K₁ = AlgebraicClosure K this becomes Field.Emb F K ≃ (K ≃ₐ[F] K); its invFun σ ↦ (toAlgHom F E K₁).comp σ.toAlgHom is definitionally the parent's toEmb.",
+        "module": "Mathlib.FieldTheory.Normal.Defs"
+      },
+      {
+        "theorem": "Field.finSepDegree",
+        "description": "The separable degree [K:F]_s := Nat.card (Field.Emb F K) where Field.Emb F K := K →ₐ[F] AlgebraicClosure K. The equality is Nat.card of the two sides of Normal.algHomEquivAut.",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      },
+      {
+        "theorem": "Nat.card_congr",
+        "description": "An equivalence α ≃ β gives Nat.card α = Nat.card β; applied to Normal.algHomEquivAut to turn the type equivalence into the cardinality equality.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Field.finSepDegree_eq_finrank_iff",
+        "description": "[K:F]_s = [K:F] ↔ K/F is separable, for a finite extension; combined with the normal equality to characterise when |Aut_F(K)| reaches the full degree.",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      },
+      {
+        "theorem": "Field.finSepDegree_eq_finrank_of_isSeparable",
+        "description": "[K:F]_s = [K:F] for a separable extension; gives the Galois corollary |Aut| = [K:F] for normal separable (= Galois) extensions.",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      }
+    ],
+    "originalContributions": [
+      "finSepDegree_eq_card_algEquiv: for any normal extension K/F, Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K), i.e. [K:F]_s = |Aut_F(K)|. Mathlib v4.26 does NOT package this equality (it has IsGalois.card_aut_eq_finrank only for the stronger Galois hypothesis); it is obtained here by Nat.card_congr of Normal.algHomEquivAut specialised to embeddings into the algebraic closure. No finiteness hypothesis is required.",
+      "toEmb_eq_symm_algHomEquivAut: the parent entry's injection toEmb is *definitionally* (rfl) the inverse of Mathlib's Normal.algHomEquivAut. This is the structural insight that makes the equality free — the parent's hand-built map was already one half of a Mathlib equivalence.",
+      "toEmb_bijective: answers the parent's second open question — for a normal extension toEmb is a bijection, so |Aut_F(K)| equals the number of F-embeddings of K, recovered as (Normal.algHomEquivAut …).symm.bijective.",
+      "card_algEquiv_eq_finrank_iff_isSeparable: among finite NORMAL extensions, |Aut_F(K)| = [K:F] ↔ K/F is separable. This is the sharp boundary that distinguishes the normal equality from the Galois fact: the automorphism group counts the separable degree, which reaches the full degree exactly in the separable case. For a normal purely-inseparable extension both [K:F]_s and |Aut| collapse to 1 while [K:F] is arbitrary.",
+      "card_algEquiv_eq_finrank_of_normal_isSeparable: recovers Mathlib's IsGalois.card_aut_eq_finrank (|Aut| = [K:F] for finite Galois) as a one-line corollary of the normal equality plus [K:F]_s = [K:F] for separable extensions, showing the parent's framework subsumes the Galois fact."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked over Mathlib v4.26; #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no axiom declarations, no structure-encoded assumptions, no native_decide).",
+    "lineCount": 120,
+    "theoremCount": 6,
+    "definitionCount": 2
+  },
+  "leanFile": {
+    "path": "Proofs/NormalAutFinSepDegreeEquality.lean",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "lineCount": 120,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "For a finite extension K/F the chain of inequalities |Aut_F(K)| ≤ [K:F]_s ≤ [K:F] is classical (Artin, Galois Theory, 1942; Lang, Algebra, V §4, §6), with the first becoming an equality exactly when K/F is normal and the second exactly when K/F is separable — so both are equalities precisely in the Galois case, where |Gal(K/F)| = [K:F]. The parent entry formalised the first inequality (the automorphism bound) as the Mathlib-missing lemma Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K. The natural completion is to identify when it is sharp. Mathlib's field-theory library (2023–2024) packages the normality-side content abstractly as Normal.algHomEquivAut, the equivalence between F-embeddings of a normal subfield and its F-automorphisms, and the separability-side content as finSepDegree_eq_finrank_iff. It records IsGalois.card_aut_eq_finrank for the combined Galois hypothesis, but not the intermediate normal-only equality |Aut_F(K)| = [K:F]_s, which is what this entry supplies — and which makes visible that the automorphism group measures the separable degree, not the full degree.",
+    "problemStatement": "**Question** (parent entry, open questions 1 and 2): (1) Can the bound |Aut_F(K)| ≤ [K:F]_s be sharpened to an equality Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K when K/F is normal, recovering |Gal| = [K:F] for normal separable extensions? (2) Does the injection toEmb extend to a bijection onto the embeddings for normal K/F?\n\n**Answer**: Yes to both, and they are the same fact. Mathlib's Normal.algHomEquivAut : (K →ₐ[F] AlgebraicClosure K) ≃ (K ≃ₐ[F] K) has, as its inverse, exactly the parent's toEmb. So for normal K/F, toEmb is bijective (Q2), and counting both sides gives Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K) (Q1) — with no finiteness or separability hypothesis. The separability boundary is then isolated: |Aut_F(K)| = [K:F] iff K/F is separable, recovering the Galois case as a corollary.",
+    "keyInsights": [
+      "The parent's hand-built injection toEmb (automorphism ↦ post-compose with K → AlgebraicClosure K) is *definitionally equal* to the inverse function of Mathlib's Normal.algHomEquivAut. The equality of automorphism count and separable degree is therefore not a new construction but a recognition: the parent had already written down one half of a known equivalence.",
+      "Normality is exactly the hypothesis that turns the embedding-counting inequality into an equality: a normal extension is one all of whose F-embeddings into the algebraic closure land back in K, hence restrict to automorphisms. This is the content of Normal.algHomEquivAut.",
+      "Separability plays no role in the equality |Aut_F(K)| = [K:F]_s. The automorphism group counts the SEPARABLE degree. It equals the full degree [K:F] only when [K:F]_s = [K:F], i.e. when K/F is separable — so for normal extensions |Aut| = [K:F] ⟺ separable.",
+      "For a normal purely inseparable extension, [K:F]_s = 1 = |Aut_F(K)| (trivial automorphism group) while [K:F] = p^n can be arbitrarily large — the extreme case showing |Aut| tracks [K:F]_s and not [K:F].",
+      "Mathlib's IsGalois.card_aut_eq_finrank (|Aut| = [K:F] for Galois) is the special case normal + separable; here it drops out by composing the normal equality with finSepDegree_eq_finrank_of_isSeparable, so the normal equality is strictly more general."
+    ],
+    "proofStrategy": "1. Recall the parent's toEmb : (K ≃ₐ[F] K) → Field.Emb F K, e ↦ (IsScalarTower.toAlgHom F K (AlgebraicClosure K)).comp e.toAlgHom.\n2. toEmb_eq_symm_algHomEquivAut: observe toEmb = ⇑(Normal.algHomEquivAut F (AlgebraicClosure K) K).symm by rfl — the equivalence's invFun is literally toEmb.\n3. toEmb_bijective: rewrite by step 2 and use (…).symm.bijective.\n4. finSepDegree_eq_card_algEquiv: Field.finSepDegree F K = Nat.card (Field.Emb F K) definitionally, so Nat.card_congr (Normal.algHomEquivAut F (AlgebraicClosure K) K) gives = Nat.card (K ≃ₐ[F] K).\n5. card_algEquiv_eq_finSepDegree: the symmetric statement.\n6. card_algEquiv_eq_finrank_iff_isSeparable: rewrite by the equality, then Field.finSepDegree_eq_finrank_iff.\n7. card_algEquiv_eq_finrank_of_normal_isSeparable: rewrite by the equality, then Field.finSepDegree_eq_finrank_of_isSeparable.",
+    "prerequisites": [
+      "Separable degree [K:F]_s as the number of F-embeddings of K into an algebraic closure; Mathlib's Field.finSepDegree and Field.Emb",
+      "Normal extensions and the restriction of embeddings to automorphisms: Mathlib's Normal and Normal.algHomEquivAut",
+      "Algebra equivalences K ≃ₐ[F] K and the structure map via IsScalarTower.toAlgHom",
+      "Nat.card and Nat.card_congr (cardinality transported across an equivalence)",
+      "The separable-degree-equals-degree criterion finSepDegree_eq_finrank_iff and its separable instance"
+    ]
+  },
+  "sections": [
+    {
+      "id": "file-header",
+      "title": "File Header — The Two Open Questions",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "States the parent's two open questions, explains that Normal.algHomEquivAut packages exactly the needed equivalence with the parent's toEmb as its inverse, and emphasises that the equality needs only normality (not separability), distinguishing it from the Galois fact."
+    },
+    {
+      "id": "toemb-as-inverse",
+      "title": "The Parent's Injection as Half of an Equivalence",
+      "startLine": 56,
+      "endLine": 83,
+      "summary": "Reproduces toEmb, shows toEmb_eq_symm_algHomEquivAut (it is rfl-equal to the inverse of Normal.algHomEquivAut), packages the embEquivAlgEquiv equivalence, and concludes toEmb_bijective for normal extensions — answering open question 2."
+    },
+    {
+      "id": "main-equality",
+      "title": "The Separable-Degree Equality",
+      "startLine": 84,
+      "endLine": 103,
+      "summary": "finSepDegree_eq_card_algEquiv (the headline equality [K:F]_s = |Aut_F(K)| for normal K/F via Nat.card_congr) and its symmetric form card_algEquiv_eq_finSepDegree — answering open question 1."
+    },
+    {
+      "id": "separability-boundary",
+      "title": "Separability Boundary and the Galois Corollary",
+      "startLine": 104,
+      "endLine": 120,
+      "summary": "card_algEquiv_eq_finrank_iff_isSeparable (among finite normal extensions, |Aut| = [K:F] iff separable) and card_algEquiv_eq_finrank_of_normal_isSeparable (recovers IsGalois.card_aut_eq_finrank for finite Galois extensions)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+      "relationship": "extends",
+      "description": "Parent entry. Answers both of its open questions: the equality criterion Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K for normal K/F (Q1), and that its injection toEmb is a bijection onto the embeddings for normal K/F (Q2) — toEmb is definitionally the inverse of Normal.algHomEquivAut."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "context",
+      "description": "Galois-theoretic infrastructure consuming |Gal(f)| computations; the normal equality |Aut_F(K)| = [K:F]_s and its separability boundary are reusable building blocks for characteristic-p extensions of the Abel-Ruffini program."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "finSepDegree_eq_card_algEquiv",
+      "type": "theorem",
+      "statement": "For a normal extension K/F: Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K)",
+      "significance": "The headline result and answer to the parent's first open question: [K:F]_s = |Aut_F(K)| for any normal extension, sharpening the parent's inequality. More general than Mathlib's IsGalois.card_aut_eq_finrank because it does not assume separability — the automorphism count equals the separable degree.",
+      "description": "Obtained by Nat.card_congr of Normal.algHomEquivAut F (AlgebraicClosure K) K, using that Field.finSepDegree F K is definitionally Nat.card (Field.Emb F K) = Nat.card (K →ₐ[F] AlgebraicClosure K). No finiteness hypothesis."
+    },
+    {
+      "name": "toEmb_bijective",
+      "type": "theorem",
+      "statement": "For a normal extension K/F: Function.Bijective (toEmb F K)",
+      "significance": "Answers the parent's second open question: for normal K/F the parent's injection toEmb is a bijection, so |Aut_F(K)| equals the number of F-embeddings of K. The injection the parent built was already one half of a Mathlib equivalence.",
+      "description": "Proved by rewriting toEmb as the inverse of Normal.algHomEquivAut and invoking (…).symm.bijective."
+    },
+    {
+      "name": "card_algEquiv_eq_finrank_iff_isSeparable",
+      "type": "theorem",
+      "statement": "For a finite normal extension K/F: Nat.card (K ≃ₐ[F] K) = Module.finrank F K ↔ Algebra.IsSeparable F K",
+      "significance": "The sharp separability boundary distinguishing the normal equality from the Galois fact: among finite normal extensions, the automorphism count reaches the full degree exactly when K/F is separable. Shows |Aut| measures the separable degree, not the full degree.",
+      "description": "Rewrite by the normal equality, then Field.finSepDegree_eq_finrank_iff."
+    },
+    {
+      "name": "card_algEquiv_eq_finrank_of_normal_isSeparable",
+      "type": "theorem",
+      "statement": "For a finite normal separable extension K/F: Nat.card (K ≃ₐ[F] K) = Module.finrank F K",
+      "significance": "Recovers Mathlib's IsGalois.card_aut_eq_finrank (|Aut| = [K:F] for finite Galois extensions) as a one-line corollary of the normal equality plus [K:F]_s = [K:F] for separable extensions — demonstrating the normal equality subsumes the Galois fact.",
+      "description": "Rewrite by the normal equality, then Field.finSepDegree_eq_finrank_of_isSeparable."
+    },
+    {
+      "name": "toEmb_eq_symm_algHomEquivAut",
+      "type": "theorem",
+      "statement": "For normal K/F: toEmb F K = ⇑(Normal.algHomEquivAut F (AlgebraicClosure K) K).symm",
+      "significance": "The structural insight making the whole entry free: the parent's hand-built injection is definitionally (rfl) the inverse of a Mathlib equivalence.",
+      "description": "Holds by rfl — Normal.algHomEquivAut's invFun σ ↦ (toAlgHom F K _).comp σ.toAlgHom is exactly toEmb."
+    },
+    {
+      "name": "embEquivAlgEquiv",
+      "type": "definition",
+      "statement": "embEquivAlgEquiv [Normal F K] : Field.Emb F K ≃ (K ≃ₐ[F] K) := Normal.algHomEquivAut F (AlgebraicClosure K) K",
+      "significance": "Names the equivalence between F-embeddings of K into its algebraic closure and F-automorphisms of K for a normal extension; the source of the cardinality equality.",
+      "description": "Normal.algHomEquivAut read through Field.Emb F K = K →ₐ[F] AlgebraicClosure K."
+    }
+  ],
+  "references": [
+    {
+      "type": "textbook",
+      "citation": "Lang, S. (2002). Algebra (3rd ed.), Chapter V (Algebraic Extensions), §4 (Galois Theory) and §6 (Inseparable Extensions). Springer GTM 211.",
+      "relevance": "States |Aut_F(K)| ≤ [K:F]_s ≤ [K:F] with the first an equality iff K/F is normal and the second iff K/F is separable — the textbook source of the normal equality and its separability boundary."
+    },
+    {
+      "type": "textbook",
+      "citation": "Artin, E. (1942). Galois Theory. Notre Dame Mathematical Lectures.",
+      "relevance": "Linear independence of characters and the count of field automorphisms / embeddings underlying the automorphism equality."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.FieldTheory.Normal.Defs.\" (accessed 2026).",
+      "relevance": "Provides Normal.algHomEquivAut, the equivalence between embeddings and automorphisms of a normal extension that drives the equality."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.FieldTheory.SeparableDegree.\" (accessed 2026).",
+      "relevance": "Defines Field.finSepDegree / Field.Emb and proves finSepDegree_eq_finrank_iff and finSepDegree_eq_finrank_of_isSeparable, used for the separability boundary and Galois corollary."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a normal extension K/F the parent entry's automorphism bound is sharp: Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K), i.e. [K:F]_s = |Aut_F(K)|. The proof is a recognition rather than a construction — the parent's injection toEmb is definitionally the inverse of Mathlib's Normal.algHomEquivAut, so it is a bijection (answering open question 2) and counting both sides gives the equality (answering open question 1), with no finiteness or separability hypothesis. The equality isolates that the automorphism group counts the SEPARABLE degree: among finite normal extensions |Aut_F(K)| = [K:F] holds iff K/F is separable, and Mathlib's Galois fact IsGalois.card_aut_eq_finrank is the corollary obtained by adding separability. Fully verified, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Packages the normal-only equality |Aut_F(K)| = [K:F]_s that Mathlib v4.26 records only under the stronger Galois hypothesis — a clean upstream candidate for Mathlib.FieldTheory.SeparableDegree / Normal, sitting strictly between the abstract Normal.algHomEquivAut equivalence and the Galois cardinality lemma. It makes precise, and machine-checkable, the slogan that field automorphisms see only the separable part of the degree.",
+    "openQuestions": [
+      "Can the separability boundary be globalised to the infinite case, characterising when the (topological) automorphism group of an infinite normal extension has cardinality equal to the separable degree, in terms of the Krull topology?",
+      "Does the same toEmb = (Normal.algHomEquivAut).symm identification give a clean formula for |Aut_F(K)| over an intermediate normal subextension, i.e. a multiplicativity [K:F]_s = [K:E]_s · [E:F]_s reading of the automorphism counts in a normal tower?"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **both** open questions of the parent automorphism-bound entry (`angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05`, merged #28070), which proved the *inequality* `Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K` via an injection `toEmb` of automorphisms into embeddings of `K` into its algebraic closure.

**Key observation:** the parent's hand-built `toEmb` is *definitionally* (`rfl`) the inverse of Mathlib's `Normal.algHomEquivAut : (K →ₐ[F] AlgebraicClosure K) ≃ (K ≃ₐ[F] K)`. So for a normal extension:

- **Q2 (bijection):** `toEmb` is bijective — `(Normal.algHomEquivAut …).symm.bijective`.
- **Q1 (equality):** `Field.finSepDegree F K = Nat.card (K ≃ₐ[F] K)`, i.e. `[K:F]_s = |Aut_F(K)|`, via `Nat.card_congr`. No finiteness or separability hypothesis.

**Why more than the Galois fact.** Mathlib has `IsGalois.card_aut_eq_finrank` only for *Galois* (normal **and** separable) extensions. The equality here drops separability: the automorphism group counts the **separable** degree. Among finite normal extensions, `|Aut_F(K)| = [K:F]` holds **iff** `K/F` is separable (`card_algEquiv_eq_finrank_iff_isSeparable`); the Galois fact is recovered as a one-line corollary.

## Theorems (6 thm, 2 def)
- `finSepDegree_eq_card_algEquiv` — **main**: `[K:F]_s = |Aut_F(K)|` for normal K/F
- `toEmb_bijective` — parent's injection is a bijection for normal K/F
- `toEmb_eq_symm_algHomEquivAut` — toEmb = inverse of `Normal.algHomEquivAut` (`rfl`)
- `card_algEquiv_eq_finrank_iff_isSeparable` — sharp separability boundary
- `card_algEquiv_eq_finrank_of_normal_isSeparable` — recovers `IsGalois.card_aut_eq_finrank`

## Verification
- Builds against Mathlib v4.26 (`lake env lean`).
- `#print axioms` on all main results: only `propext`/`Classical.choice`/`Quot.sound`.
- **0 axioms, 0 sorries, no native_decide.** Status: verified / original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)