### PR TITLE
research(geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01): analysis-free Eulerian recurrence via the Stirling binomial transform [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2818,6 +2818,7 @@ import Proofs.GeometricSeriesOQ08OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01
+import Proofs.GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01
 import Proofs.GeometricSeriesOQ08OQ03
 import Proofs.GeometricSeriesOQ08OQ03OQ01
 import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01.lean
@@ -1,0 +1,255 @@
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01
+
+/-
+# An analysis-free proof of the Eulerian (★∞) recurrence
+
+## What This Proves
+
+The parent `geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01` proves the
+**polynomial recurrence** satisfied by the Eulerian polynomials
+`Eₘ = eulerPoly m` (geometric normalisation):
+
+  (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}.   (★)
+
+The parent's proof is *analytic*: both sides are shown to agree at every point of
+the infinite set `(−1, 1)` (using the Frobenius closed form
+`∑ₙ nᵐ rⁿ = Eₘ(r)/(1−r)^{m+1}` and the analytic moment recurrence), hence agree
+as polynomials.  That route runs through real analysis (`tsum`, convergence of the
+geometric series and its derivatives).
+
+This entry answers the open question recorded on the parent: it gives a **purely
+algebraic, analysis-free** derivation of (★), valid over an *arbitrary commutative
+ring* `R`.  The proof rests on a new combinatorial identity about Stirling numbers
+of the second kind that is not in Mathlib.
+
+## The new content
+
+* `sum_choose_mul_stirlingSecond` — the **binomial transform of the second-kind
+  Stirling numbers**:
+
+    ∑_{i≤n} C(n,i)·S(i,j) = S(n+1, j+1).
+
+  Proved by induction on `n`, using only Pascal's rule and the Stirling recurrence
+  `S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k)`.  The inductive step closes because two
+  boundary terms vanish (`S(0,j+1)=0` and `C(n,n+1)=0`).  This identity is *not* in
+  Mathlib.
+
+* `sum_range_choose_mul_stirlingSecond` — the immediate corollary
+
+    ∑_{i<m} C(m,i)·S(i,j) = (j+1)·S(m, j+1).
+
+* `eulerPoly_recurrence_alg` — the headline: **(★) over any commutative ring**,
+  proved with no appeal to analysis.  The strategy substitutes the Stirling closed
+  form `Eₘ = ∑_{k≤m} S(m,k)·k!·Xᵏ·(1−X)^{m−k}` (`stirlingForm`, the Frobenius
+  identity `eulerPoly_eq_stirlingForm` from the sibling line) into both sides of
+  (★) and reduces the resulting polynomial identity, via a double-sum interchange,
+  to the binomial transform above.
+
+* `eulerPoly_recurrence` — the parent's exact `ℝ[X]` statement, re-derived here as a
+  specialisation of `eulerPoly_recurrence_alg`: the analytic theorem now has an
+  analysis-free proof (and is in fact a shadow of a ring-theoretic identity).
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+
+namespace GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01
+
+open Finset Nat Polynomial
+
+/-! ## Part 1: the binomial transform of the Stirling numbers (new)
+
+`∑_{i≤n} C(n,i)·S(i,j) = S(n+1, j+1)`, proved purely from Pascal's rule and the
+Stirling recurrence.  This is the combinatorial engine of the analysis-free proof.
+-/
+
+/-- **Binomial transform of Stirling numbers of the second kind.**
+`∑_{i≤n} C(n,i)·S(i,j) = S(n+1, j+1)`.  (Not in Mathlib.) -/
+theorem sum_choose_mul_stirlingSecond (n j : ℕ) :
+    ∑ i ∈ range (n + 1), n.choose i * Nat.stirlingSecond i j
+      = Nat.stirlingSecond (n + 1) (j + 1) := by
+  induction n generalizing j with
+  | zero =>
+    rw [Finset.sum_range_one, Nat.choose_self, one_mul,
+        Nat.stirlingSecond_succ_succ, Nat.stirlingSecond_zero_succ, mul_zero, zero_add]
+  | succ n ih =>
+    rcases j with _ | j'
+    · -- column `j = 0`: only the `i = 0` term survives and `S(n+1,1) = 1`.
+      rw [Nat.stirlingSecond_one_right, Finset.sum_eq_single 0]
+      · simp [Nat.stirlingSecond_zero]
+      · intro i _ hi0
+        obtain ⟨k, rfl⟩ := Nat.exists_eq_succ_of_ne_zero hi0
+        rw [Nat.stirlingSecond_succ_zero, mul_zero]
+      · intro h; simp at h
+    · -- the boundary-term shift lemma: `∑ g(i+1) = ∑ g i` since `g 0 = g(n+1) = 0`.
+      have hcollapse :
+          ∑ i ∈ range (n + 1), n.choose (i + 1) * Nat.stirlingSecond (i + 1) (j' + 1)
+            = ∑ i ∈ range (n + 1), n.choose i * Nat.stirlingSecond i (j' + 1) := by
+        have e1 := Finset.sum_range_succ'
+          (fun i => n.choose i * Nat.stirlingSecond i (j' + 1)) (n + 1)
+        have e2 := Finset.sum_range_succ
+          (fun i => n.choose i * Nat.stirlingSecond i (j' + 1)) (n + 1)
+        simp only [Nat.choose_zero_right, Nat.stirlingSecond_zero_succ, mul_zero,
+          Nat.choose_succ_self, zero_mul, add_zero] at e1 e2
+        omega
+      rw [Finset.sum_range_succ']
+      simp only [Nat.choose_zero_right, Nat.stirlingSecond_zero_succ, mul_zero, add_zero]
+      have hsplit : ∀ i ∈ range (n + 1),
+          (n + 1).choose (i + 1) * Nat.stirlingSecond (i + 1) (j' + 1)
+            = n.choose i * Nat.stirlingSecond (i + 1) (j' + 1)
+              + n.choose (i + 1) * Nat.stirlingSecond (i + 1) (j' + 1) := by
+        intro i _; rw [Nat.choose_succ_succ, add_mul]
+      rw [Finset.sum_congr rfl hsplit, Finset.sum_add_distrib, hcollapse]
+      have hP : ∀ i ∈ range (n + 1),
+          n.choose i * Nat.stirlingSecond (i + 1) (j' + 1)
+            = (j' + 1) * (n.choose i * Nat.stirlingSecond i (j' + 1))
+              + n.choose i * Nat.stirlingSecond i j' := by
+        intro i _; rw [Nat.stirlingSecond_succ_succ]; ring
+      rw [Finset.sum_congr rfl hP, Finset.sum_add_distrib, ← Finset.mul_sum,
+          ih (j' + 1), ih j']
+      conv_rhs => rw [Nat.stirlingSecond_succ_succ]
+      ring
+
+/-- The binomial transform over `range m` (the form used below):
+`∑_{i<m} C(m,i)·S(i,j) = (j+1)·S(m, j+1)`. -/
+theorem sum_range_choose_mul_stirlingSecond (m j : ℕ) :
+    ∑ i ∈ range m, m.choose i * Nat.stirlingSecond i j
+      = (j + 1) * Nat.stirlingSecond m (j + 1) := by
+  have hstd := sum_choose_mul_stirlingSecond m j
+  rw [Finset.sum_range_succ, Nat.choose_self, one_mul, Nat.stirlingSecond_succ_succ] at hstd
+  exact Nat.add_right_cancel hstd
+
+/-! ## Part 2: the polynomial reduction
+
+Both sides of (★) (after multiplying out the Stirling closed form) collapse to the
+same canonical sum
+`∑_j C((j+1)!·S(m'+1,j+1))·X^{j+1}·(1−X)^{m'+1−j}`. -/
+
+open GeometricSeriesOQ07OQ01OQ01
+
+variable {R : Type*} [CommRing R]
+
+/-- The canonical integrand of the convolution side, defined for all `(i, j)`. -/
+private noncomputable def gterm (m' i j : ℕ) : R[X] :=
+  ((m' + 1).choose i : R[X]) * C ((Nat.stirlingSecond i j * j ! : ℕ) : R)
+    * X ^ (j + 1) * (1 - X) ^ (m' + 1 - j)
+
+/-- The left-hand side of (★) in canonical form: multiplying the Stirling closed
+form `N_{m'+1}` by `(1 − X)` raises every power and drops the (vanishing) `k = 0`
+term, leaving `∑_j C((j+1)!·S(m'+1,j+1))·X^{j+1}·(1−X)^{m'+1−j}`. -/
+theorem one_sub_X_mul_stirlingForm (m' : ℕ) :
+    (1 - X) * (stirlingForm (m' + 1) : R[X])
+      = ∑ j ∈ range (m' + 1),
+          C (((j + 1)! * Nat.stirlingSecond (m' + 1) (j + 1) : ℕ) : R)
+            * X ^ (j + 1) * (1 - X) ^ (m' + 1 - j) := by
+  rw [stirlingForm, Finset.mul_sum, Finset.sum_range_succ']
+  simp only [Nat.stirlingSecond_succ_zero, Nat.cast_zero, map_zero, zero_mul, mul_zero, add_zero]
+  apply Finset.sum_congr rfl
+  intro k hk
+  have hk' : k ≤ m' := Nat.lt_succ_iff.mp (Finset.mem_range.mp hk)
+  have e1 : m' + 1 - (k + 1) = m' - k := by omega
+  have e2 : m' + 1 - k = (m' - k) + 1 := by omega
+  rw [e1, e2, Nat.mul_comm (Nat.stirlingSecond (m' + 1) (k + 1)) ((k + 1)!)]
+  ring
+
+/-- The right-hand (convolution) side of (★) in canonical form.  After substituting
+the Stirling closed form, interchanging the double sum, and applying the binomial
+transform `sum_range_choose_mul_stirlingSecond`, it reduces to exactly the same sum
+as `one_sub_X_mul_stirlingForm`. -/
+theorem X_mul_convolution_stirlingForm (m' : ℕ) :
+    X * ∑ i ∈ range (m' + 1),
+        ((m' + 1).choose i : R[X]) * stirlingForm i * (1 - X) ^ (m' + 1 - i)
+      = ∑ j ∈ range (m' + 1),
+          C (((j + 1)! * Nat.stirlingSecond (m' + 1) (j + 1) : ℕ) : R)
+            * X ^ (j + 1) * (1 - X) ^ (m' + 1 - j) := by
+  -- each `i`-slice becomes `∑_{j<m'+1} gterm m' i j` (extend the inner range; the
+  -- added `j > i` terms vanish because `S(i,j) = 0`).
+  rw [Finset.mul_sum]
+  have hslice : ∀ i ∈ range (m' + 1),
+      X * (((m' + 1).choose i : R[X]) * stirlingForm i * (1 - X) ^ (m' + 1 - i))
+        = ∑ j ∈ range (m' + 1), gterm (R := R) m' i j := by
+    intro i hi
+    have hi' : i ≤ m' := Nat.lt_succ_iff.mp (Finset.mem_range.mp hi)
+    rw [stirlingForm, Finset.mul_sum, Finset.sum_mul, Finset.mul_sum]
+    have hsub : range (i + 1) ⊆ range (m' + 1) := by
+      intro x hx; simp only [Finset.mem_range] at hx ⊢; omega
+    rw [← Finset.sum_subset hsub]
+    · apply Finset.sum_congr rfl
+      intro j hj
+      have hj' : j ≤ i := Nat.lt_succ_iff.mp (Finset.mem_range.mp hj)
+      have e1 : (i - j) + (m' + 1 - i) = m' + 1 - j := by omega
+      simp only [gterm]
+      rw [show m' + 1 - j = (i - j) + (m' + 1 - i) from e1.symm, pow_add]
+      ring
+    · intro j _ hj
+      have hij : i < j := by
+        simp only [Finset.mem_range, not_lt] at hj; omega
+      simp [gterm, Nat.stirlingSecond_eq_zero_of_lt hij]
+  rw [Finset.sum_congr rfl hslice, Finset.sum_comm]
+  -- the double sum is now over a square; evaluate each `j`-slice.
+  apply Finset.sum_congr rfl
+  intro j _
+  have hfac : ∑ i ∈ range (m' + 1), gterm (R := R) m' i j
+      = (∑ i ∈ range (m' + 1),
+          ((m' + 1).choose i : R[X]) * C ((Nat.stirlingSecond i j * j ! : ℕ) : R))
+        * (X ^ (j + 1) * (1 - X) ^ (m' + 1 - j)) := by
+    rw [Finset.sum_mul]
+    apply Finset.sum_congr rfl
+    intro i _; simp only [gterm]; ring
+  rw [hfac]
+  -- the scalar bracket collapses to one constant via the binomial transform.
+  have hnat : ∑ i ∈ range (m' + 1), (m' + 1).choose i * (Nat.stirlingSecond i j * j !)
+      = (j + 1)! * Nat.stirlingSecond (m' + 1) (j + 1) := by
+    have hpull : ∑ i ∈ range (m' + 1), (m' + 1).choose i * (Nat.stirlingSecond i j * j !)
+        = j ! * ∑ i ∈ range (m' + 1), (m' + 1).choose i * Nat.stirlingSecond i j := by
+      rw [Finset.mul_sum]; apply Finset.sum_congr rfl; intro i _; ring
+    rw [hpull, sum_range_choose_mul_stirlingSecond, Nat.factorial_succ]; ring
+  have hbracket : (∑ i ∈ range (m' + 1),
+        ((m' + 1).choose i : R[X]) * C ((Nat.stirlingSecond i j * j ! : ℕ) : R))
+      = C (((j + 1)! * Nat.stirlingSecond (m' + 1) (j + 1) : ℕ) : R) := by
+    rw [← hnat, Nat.cast_sum, map_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [← map_natCast (C : R →+* R[X]) ((m' + 1).choose i), ← map_mul]
+    congr 1
+    push_cast
+    ring
+  rw [hbracket, mul_assoc]
+
+/-! ## Part 3: the analysis-free Eulerian recurrence -/
+
+/-- **The Eulerian (★∞) recurrence, proved purely algebraically.**  For every `m`
+and over any commutative ring `R`,
+
+  `(1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}`   in `R[X]`,
+
+with no appeal to analysis.  For `m = 0` it is `(1 − X)·1 = (1 − X)`; for
+`m = m'+1` both sides collapse, via the Stirling closed form and the binomial
+transform `sum_choose_mul_stirlingSecond`, to the common canonical sum. -/
+theorem eulerPoly_recurrence_alg (m : ℕ) :
+    (1 - X) * (eulerPoly m : R[X])
+      = (0 : R[X]) ^ m * (1 - X) ^ (m + 1)
+        + X * ∑ i ∈ range m, (m.choose i : R[X]) * eulerPoly i * (1 - X) ^ (m - i) := by
+  rcases m with _ | m'
+  · simp [eulerPoly_zero]
+  · have h0 : (0 : R[X]) ^ (m' + 1) = 0 := by simp
+    rw [h0, zero_mul, zero_add, eulerPoly_eq_stirlingForm]
+    have hsum : (∑ i ∈ range (m' + 1),
+          ((m' + 1).choose i : R[X]) * eulerPoly i * (1 - X) ^ (m' + 1 - i))
+        = ∑ i ∈ range (m' + 1),
+          ((m' + 1).choose i : R[X]) * stirlingForm i * (1 - X) ^ (m' + 1 - i) := by
+      apply Finset.sum_congr rfl; intro i _; rw [eulerPoly_eq_stirlingForm]
+    rw [hsum, one_sub_X_mul_stirlingForm, X_mul_convolution_stirlingForm]
+
+/-- **The parent's `ℝ[X]` recurrence, re-derived analysis-free.**  This is verbatim
+the statement `geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01.eulerPoly_recurrence`,
+whose original proof goes through real analysis; here it is the `R = ℝ`
+specialisation of the ring-theoretic `eulerPoly_recurrence_alg`. -/
+theorem eulerPoly_recurrence (m : ℕ) :
+    (1 - X) * (eulerPoly m : ℝ[X])
+      = (0 : ℝ[X]) ^ m * (1 - X) ^ (m + 1)
+        + X * ∑ i ∈ range m, (m.choose i : ℝ[X]) * eulerPoly i * (1 - X) ^ (m - i) :=
+  eulerPoly_recurrence_alg m
+
+end GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-binomial-transform",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 114 },
+    "type": "insight",
+    "title": "The Binomial Transform of the Stirling Numbers (new)",
+    "content": "`sum_choose_mul_stirlingSecond` is the combinatorial engine of the whole entry: ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1), where S = Nat.stirlingSecond. It is proved by induction on n with the column j generalised, using only Pascal's rule (Nat.choose_succ_succ) and the Stirling recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k). Mathlib's Stirling file contains the defining recurrences and edge values but not this convolution identity, so it is genuinely new infrastructure. Combinatorially it expresses building a partition of an (n+1)-set into j+1 blocks by selecting which of the first n elements are partitioned apart from the last element's block.",
+    "mathContext": "$\\sum_{i=0}^{n}\\binom{n}{i}S(i,j) = S(n+1,j+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Stirling numbers of the second kind", "binomial transform", "Pascal's rule", "set partitions", "induction"],
+    "prerequisites": ["binomial coefficients", "Stirling numbers", "finite sums"]
+  },
+  {
+    "id": "ann-vanishing-boundary",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 96 },
+    "type": "technique",
+    "title": "The Vanishing-Boundary Shift Lemma",
+    "content": "The inductive step would not close were it not for `hcollapse`: ∑_{i<n+1} C(n,i+1)·S(i+1,j'+1) = ∑_{i<n+1} C(n,i)·S(i,j'+1). Writing g i = C(n,i)·S(i,j'+1), the two sides are ∑ g(i+1) and ∑ g(i); by Finset.sum_range_succ' and Finset.sum_range_succ they differ by exactly g(n+1) − g(0). Both ends vanish — g(0) carries S(0,j'+1)=0 and g(n+1) carries C(n,n+1)=0 — so the sums are equal and omega finishes. This boundary cancellation is what lets the four sub-sums produced by Pascal's rule and the Stirling recurrence recombine into the target via the induction hypothesis at the two columns j' and j'+1.",
+    "mathContext": "$\\sum_{i} g(i+1) - \\sum_i g(i) = g(n+1) - g(0) = 0$.",
+    "significance": "important",
+    "relatedConcepts": ["telescoping", "index shift", "Finset.sum_range_succ", "boundary terms"],
+    "prerequisites": ["finite sums", "Stirling numbers"]
+  },
+  {
+    "id": "ann-canonical-reduction",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 141, "endLine": 218 },
+    "type": "technique",
+    "title": "Both Sides Reduced to a Common Canonical Sum",
+    "content": "After substituting the Frobenius closed form Eₘ = stirlingForm m, both sides of (★∞) are driven to the same expression ∑_j C((j+1)!·S(m+1,j+1))·X^{j+1}·(1−X)^{m+1−j}. `one_sub_X_mul_stirlingForm` handles the left side: (1−X)·(1−X)^{m+1−k} = (1−X)^{m+2−k} raises every power and the k=0 term drops (S(m+1,0)=0). `X_mul_convolution_stirlingForm` handles the right (convolution) side: each inner Stirling sum is padded from range (i+1) up to the square range (m+1) — legitimate since the added j>i terms carry S(i,j)=0 — then Finset.sum_comm swaps the double sum, the common monomial X^{j+1}(1−X)^{m+1−j} is factored out, and the leftover scalar bracket ∑_i C(m+1,i)·S(i,j)·j! collapses to C((j+1)!·S(m+1,j+1)) by the binomial transform of Part 1.",
+    "mathContext": "Both sides $= \\sum_{j<m'+1} C((j+1)!\\,S(m'+1,j+1))\\,X^{j+1}(1-X)^{m'+1-j}$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_comm", "double-sum interchange", "Stirling closed form", "Frobenius identity", "factoring sums"],
+    "prerequisites": ["polynomial rings", "finite double sums", "Stirling numbers"]
+  },
+  {
+    "id": "ann-analysis-free",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 230, "endLine": 247 },
+    "type": "concept",
+    "title": "The Analysis-Free Recurrence Over Any Commutative Ring",
+    "content": "`eulerPoly_recurrence_alg` is the headline: (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i} over an ARBITRARY commutative ring R[X]. The parent proved the same identity only over ℝ[X], and only by Polynomial.eq_of_infinite_eval_eq — agreement at the infinitely many points of (−1,1). Here there is no evaluation, no convergence, no infinite set: m=0 is (1−X)·1=(1−X), and m=m'+1 simply chains the two canonical-form reductions. That the statement now holds over every commutative ring is the clearest evidence the proof is free of analysis.",
+    "mathContext": "$(1-X)E_m = 0^m(1-X)^{m+1} + X\\sum_{i<m}\\binom{m}{i}E_i(1-X)^{m-i}$ in $R[X]$, any commutative ring $R$.",
+    "significance": "key",
+    "relatedConcepts": ["Eulerian polynomials", "commutative rings", "polynomial identity", "binomial convolution", "analysis-free proof"],
+    "prerequisites": ["polynomial rings", "commutative rings", "recurrences"]
+  },
+  {
+    "id": "ann-real-specialisation",
+    "proofId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 249, "endLine": 253 },
+    "type": "concept",
+    "title": "Recovering the Parent's ℝ[X] Theorem",
+    "content": "`eulerPoly_recurrence` is verbatim the parent's statement over ℝ[X], obtained as the R = ℝ specialisation of eulerPoly_recurrence_alg. It exhibits the originally analytically-proved theorem as the shadow of a ring-theoretic identity: the analytic machinery of the parent is shown to be inessential to the result, only to one particular route to it.",
+    "mathContext": "The parent's $\\mathbb{R}[X]$ recurrence is the $R = \\mathbb{R}$ case of the general algebraic theorem.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialisation", "Eulerian polynomials", "real polynomials"],
+    "prerequisites": ["polynomial rings"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+  "slug": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "Polynomial"
+    ],
+    "namespace": "GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01",
+    "lineCount": 255,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "An Analysis-Free Proof of the Eulerian (★∞) Recurrence — via the Binomial Transform of Stirling Numbers",
+  "description": "Answers the parent's open question by giving a purely algebraic, analysis-free proof of the Eulerian binomial-convolution recurrence (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}, valid over an arbitrary commutative ring (the parent proved it only over ℝ[X], by evaluating both sides at infinitely many real points). The engine is a new combinatorial identity not in Mathlib — the binomial transform of the second-kind Stirling numbers ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1) — proved from Pascal's rule and the Stirling recurrence alone. Substituting the Stirling closed form for the Eulerian polynomials and interchanging a double sum reduces (★∞) to this identity.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ08OQ01OQ01OQ01OQ02OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "combinatorics",
+      "geometric-series",
+      "eulerian",
+      "eulerian-polynomial",
+      "stirling-numbers",
+      "binomial-transform",
+      "frobenius",
+      "polynomial-identity",
+      "recurrence",
+      "analysis-free",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 255,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "sum_choose_mul_stirlingSecond: the binomial transform of the Stirling numbers of the second kind, ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1). Proved by induction on n using only Pascal's rule (Nat.choose_succ_succ) and the Stirling recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k). The inductive step closes because two boundary terms vanish — S(0,j+1)=0 and C(n,n+1)=0 — so a shifted sum ∑ g(i+1) equals ∑ g(i). This identity is NOT present in Mathlib (whose Stirling file has only the defining recurrences and edge values).",
+      "sum_range_choose_mul_stirlingSecond: the half-open corollary ∑_{i<m} C(m,i)·S(i,j) = (j+1)·S(m,j+1), obtained from the transform by peeling the top term and the Stirling recurrence.",
+      "eulerPoly_recurrence_alg: the headline — the Eulerian (★∞) binomial-convolution recurrence (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i} proved over an ARBITRARY commutative ring R[X], with no appeal to analysis. The parent proved this only over ℝ[X] via Polynomial.eq_of_infinite_eval_eq (agreement at the infinitely many points of (−1,1)); this entry replaces that analytic step by a ring-theoretic computation. Both sides, after substituting the Stirling closed form Eₘ = ∑_{k≤m} S(m,k)·k!·Xᵏ·(1−X)^{m−k} (the sibling's Frobenius identity eulerPoly_eq_stirlingForm) and interchanging the resulting double sum, collapse to the common canonical form ∑_j C((j+1)!·S(m+1,j+1))·X^{j+1}·(1−X)^{m+1−j}; the scalar coefficients match exactly via the binomial transform.",
+      "one_sub_X_mul_stirlingForm / X_mul_convolution_stirlingForm: the two reduction lemmas putting each side of (★∞) into the shared canonical form — the left side by raising every power of (1−X) and dropping the vanishing k=0 term, the right side by extending each inner Stirling sum to a square, interchanging the double sum (Finset.sum_comm), factoring out X^{j+1}(1−X)^{m+1−j}, and collapsing the scalar bracket via the binomial transform.",
+      "eulerPoly_recurrence: the parent's exact ℝ[X] statement re-derived analysis-free, as the R = ℝ specialisation of eulerPoly_recurrence_alg — exhibiting the originally analytic theorem as the shadow of a ring-theoretic identity."
+    ],
+    "prerequisites": [
+      "GeometricSeriesOQ07OQ01OQ01.eulerPoly — the Eulerian polynomial defined by its differential recurrence E_{m+1} = X(1−X)·E'ₘ + (m+1)·X·Eₘ",
+      "GeometricSeriesOQ07OQ01OQ01.stirlingForm — the Stirling closed form Nₘ(X) = ∑_{k≤m} S(m,k)·k!·Xᵏ·(1−X)^{m−k}",
+      "GeometricSeriesOQ07OQ01OQ01.eulerPoly_eq_stirlingForm — Frobenius' identity eulerPoly m = stirlingForm m, itself proved (in the sibling) by induction on m from the differential recurrence; the bridge that lets the algebraic computation start from the Stirling closed form",
+      "Nat.stirlingSecond_succ_succ — the Stirling recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k), the only Stirling input to the binomial transform",
+      "Nat.choose_succ_succ — Pascal's rule, the binomial input to the transform",
+      "Finset.sum_comm — interchange of a finite double sum (over a square), the key step of the right-hand-side reduction"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "The defining recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k) for Stirling numbers of the second kind. The sole Stirling-number input to the new binomial transform identity and its corollary.",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ",
+        "description": "Pascal's rule (n+1).choose (k+1) = n.choose k + n.choose (k+1). Splits the binomial weight in the inductive step of the binomial transform.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Interchanges the order of a finite double sum over a product of finsets. After extending each inner Stirling sum to the full square range, this swaps the (i,j) summation so the binomial transform can be applied for each fixed column j.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_subset",
+        "description": "Equality of sums when extending the index set by terms that vanish. Used to extend each inner sum from range (i+1) to range (m+1), the added j>i terms being zero since S(i,j)=0.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Eulerian polynomials Eₘ — numerators of the rational closed forms ∑_{k≥0} kᵐ·xᵏ = Eₘ(x)/(1 − x)^{m+1} — satisfy two structurally different recurrences: a differential one, Eₘ₊₁ = X(1−X)E′ₘ + (m+1)X·Eₘ (which defines them in the gallery), and a Pascal-style binomial-convolution one, (★∞). The parent line proved that the Eulerian polynomials obey (★∞) as a polynomial identity, but only over ℝ[X], and only by an analytic device: evaluate both sides at the infinitely many points of (−1,1), where the convergent-series moment recurrence applies, then invoke polynomial extensionality. The parent's recorded open question asks for a derivation that never leaves the world of algebra. The bridge turns out to be a classical-but-unmechanised fact about Stirling numbers of the second kind: their binomial transform ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1). Stirling's S(n,k) count partitions of an n-set into k blocks; the transform reflects building a partition of an (n+1)-set by choosing which elements share the last element's block. Mathlib formalises the second-kind Stirling numbers and their basic recurrence, but not this convolution identity.",
+    "problemStatement": "The parent (geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01) proves, over ℝ[X] and through real analysis, that the Eulerian polynomials Eₘ = eulerPoly m satisfy $(1-X)E_m = 0^m(1-X)^{m+1} + X\\sum_{i<m}\\binom{m}{i}E_i(1-X)^{m-i}$ (★∞). Re-prove this purely algebraically — with no appeal to convergence, evaluation at points, or polynomial extensionality — and over an arbitrary commutative ring.",
+    "proofStrategy": "Reduce (★∞) to a combinatorial identity. Part 1 proves the engine: the binomial transform ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1), by induction on n. The j=0 column is immediate; for j=j'+1 the inductive step splits the binomial weight by Pascal's rule, rewrites S(i+1,j'+1) by the Stirling recurrence, and crucially observes that the shifted sum ∑_i C(n,i)·S(i+1,j'+1) equals ∑_i C(n,i)·S(i,j'+1) because the two boundary contributions S(0,j'+1) and C(n,n+1)·S(n+1,…) both vanish — collapsing four sub-sums to the target via the IH at two columns. The half-open corollary follows by peeling the top term. Part 2 substitutes the sibling's Frobenius closed form Eₘ = stirlingForm m into both sides of (★∞) and reduces each to the canonical sum ∑_j C((j+1)!·S(m+1,j+1))·X^{j+1}·(1−X)^{m+1−j}: the left side by (1−X)·(1−X)^{m+1−k} = (1−X)^{m+2−k} and dropping the k=0 term; the right side by extending each inner Stirling sum to a square (vanishing j>i terms), interchanging the double sum, factoring out the common monomial, and collapsing the scalar bracket via the binomial transform of Part 1. Part 3 assembles them: m=0 is (1−X)·1 = (1−X); m=m'+1 chains the two reductions. The ℝ[X] specialisation reproduces the parent's exact statement.",
+    "keyInsights": [
+      "The analytic step in the parent — agreement on the infinite set (−1,1) forces equality in ℝ[X] — is entirely eliminable. The same polynomial identity is a consequence of a finite combinatorial identity about Stirling numbers, so it holds verbatim over any commutative ring, not just over a field admitting infinitely many evaluation points. Generalising from ℝ[X] to arbitrary R[X] is the cleanest signal that no analysis is involved.",
+      "The right combinatorial lemma is the binomial transform of the second-kind Stirling numbers, ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1). It is exactly the bookkeeping needed when the Stirling closed forms of E_i are convolved against the binomial weights C(m,i): summing over i for a fixed power of X collapses to a single Stirling number of order m+1.",
+      "The inductive step of the binomial transform succeeds because of a vanishing-boundary phenomenon: the differential between ∑ g(i+1) and ∑ g(i) is g(n+1) − g(0), and both ends are zero (C(n,n+1)=0 and S(0,j+1)=0). This is what lets the column recurrence and Pascal's rule close without leftover terms.",
+      "The double-sum interchange is made painless by first padding each triangular inner sum ∑_{j≤i} up to the full square ∑_{j≤m} — legitimate because the added entries carry the factor S(i,j) with j>i, which is 0. Over a square, Finset.sum_comm swaps freely, after which each column j is a clean scalar multiple of the monomial X^{j+1}(1−X)^{m+1−j}.",
+      "The derivation is still grounded in the differential recurrence and Pascal's rule, as the open question asked: the differential recurrence enters through the sibling's Frobenius identity eulerPoly_eq_stirlingForm (proved by induction on m from E_{m+1} = X(1−X)E′ₘ + …), and Pascal's rule is the binomial input to the transform. What changes is that no analytic continuation, convergence, or point-evaluation is used anywhere."
+    ]
+  },
+  "sections": [
+    {
+      "id": "binomial-transform",
+      "title": "Part 1: The Binomial Transform of the Stirling Numbers",
+      "startLine": 61,
+      "endLine": 121,
+      "summary": "sum_choose_mul_stirlingSecond proves ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1) by induction on n, using only Pascal's rule and the Stirling recurrence; the inductive step hinges on a vanishing-boundary shift lemma (∑ g(i+1) = ∑ g(i) since g(0)=g(n+1)=0). sum_range_choose_mul_stirlingSecond is the half-open corollary ∑_{i<m} C(m,i)·S(i,j) = (j+1)·S(m,j+1). Neither identity is in Mathlib."
+    },
+    {
+      "id": "polynomial-reduction",
+      "title": "Part 2: Both Sides Collapse to a Common Canonical Sum",
+      "startLine": 123,
+      "endLine": 218,
+      "summary": "After substituting the Frobenius closed form Eₘ = stirlingForm m, one_sub_X_mul_stirlingForm rewrites the left side of (★∞) as ∑_j C((j+1)!·S(m+1,j+1))·X^{j+1}·(1−X)^{m+1−j}, and X_mul_convolution_stirlingForm rewrites the right (convolution) side to the same sum — by extending each inner range to a square, interchanging the double sum, factoring the common monomial, and collapsing the scalar bracket via the binomial transform."
+    },
+    {
+      "id": "analysis-free-recurrence",
+      "title": "Part 3: The Analysis-Free Eulerian Recurrence",
+      "startLine": 220,
+      "endLine": 254,
+      "summary": "eulerPoly_recurrence_alg assembles the two reductions into (★∞) over an arbitrary commutative ring (m=0 is (1−X)·1=(1−X); m=m'+1 chains the canonical forms). eulerPoly_recurrence specialises to ℝ[X], reproducing verbatim the parent's analytically-proved statement — now with an analysis-free proof."
+    }
+  ],
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent proves the Eulerian recurrence eulerPoly_recurrence over ℝ[X] analytically (agreement at the infinitely many points of (−1,1) via Polynomial.eq_of_infinite_eval_eq). This entry answers its recorded open question: a purely algebraic, analysis-free proof, valid over any commutative ring."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01",
+      "relationship": "uses",
+      "description": "Supplies the Eulerian polynomial eulerPoly (differential recurrence), the Stirling closed form stirlingForm, and Frobenius' identity eulerPoly_eq_stirlingForm. Substituting the closed form for the Eulerian polynomials is what reduces the recurrence to a Stirling-number identity; the Frobenius identity is itself proved there by induction from the differential recurrence."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Stirling numbers of the second kind, Eulerian numbers, ∑ kᵐ·xᵏ closed forms)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for second-kind Stirling numbers and their identities, the Eulerian polynomials, and the geometric moment sums."
+    },
+    {
+      "title": "Mathlib4: Combinatorics.Enumerative.Stirling",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides Nat.stirlingSecond and its defining recurrences and edge values; the binomial transform proved here is not among them."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Eulerian binomial-convolution recurrence (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}, proved in the parent only over ℝ[X] and only by an analytic device (agreement at the infinitely many points of (−1,1)), is re-established here purely algebraically and over an arbitrary commutative ring. The engine is a new combinatorial identity, the binomial transform of the second-kind Stirling numbers ∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1), proved from Pascal's rule and the Stirling recurrence alone — its inductive step closing through a vanishing-boundary shift. Substituting the Frobenius/Stirling closed form for the Eulerian polynomials and interchanging a (padded, square) double sum reduces both sides of the recurrence to the common canonical form ∑_j C((j+1)!·S(m+1,j+1))·X^{j+1}·(1−X)^{m+1−j}. 255 lines, 6 theorems, 1 definition, 0 axioms, 0 sorries; every result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Eliminating the analytic step shows that the Eulerian convolution recurrence is a ring-theoretic fact, not an analytic accident: it holds over every commutative ring, not just over fields with infinitely many evaluation points. The reusable by-product is the binomial transform of the second-kind Stirling numbers — a clean Mathlib-absent identity that future entries needing to convolve Stirling closed forms against binomial weights can call directly. Honest scope: the proof still rests on the sibling's Frobenius identity (and hence, transitively, on the differential recurrence proved there by induction) and on Pascal's rule, exactly the ingredients the open question named; the genuinely new content is the binomial transform and the analysis-free, ring-general assembly.",
+    "openQuestions": []
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent's recorded open question (`geometric-series-oq-08-oq-01-oq-01-oq-01-oq-02-oq-01`, openQuestions[0]) with a **purely algebraic, analysis-free** proof of the Eulerian binomial-convolution recurrence

> (1 − X)·Eₘ = 0ᵐ·(1 − X)^{m+1} + X·∑_{i<m} C(m,i)·Eᵢ·(1 − X)^{m−i}

now valid over an **arbitrary commutative ring** `R[X]`. The parent proved this only over ℝ[X], and only analytically — by showing both sides agree at the infinitely many points of (−1,1) and invoking `Polynomial.eq_of_infinite_eval_eq`. This entry removes all analysis.

## New content

- **`sum_choose_mul_stirlingSecond`** — the **binomial transform of the second-kind Stirling numbers**, `∑_{i≤n} C(n,i)·S(i,j) = S(n+1,j+1)`. Proved by induction on `n` using *only* Pascal's rule and the Stirling recurrence `S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k)`; the inductive step closes via a vanishing-boundary shift (`S(0,j+1)=0` and `C(n,n+1)=0`). **Not in Mathlib.**
- **`eulerPoly_recurrence_alg`** — the recurrence over any commutative ring. Substitutes the sibling's Frobenius/Stirling closed form `Eₘ = ∑_{k≤m} S(m,k)·k!·Xᵏ·(1−X)^{m−k}` into both sides, pads each inner sum to a square, interchanges the double sum (`Finset.sum_comm`), and collapses the scalar bracket via the binomial transform — both sides reduce to the common form `∑_j C((j+1)!·S(m+1,j+1))·X^{j+1}·(1−X)^{m+1−j}`.
- **`eulerPoly_recurrence`** — the parent's exact ℝ[X] statement, re-derived as the `R = ℝ` specialisation.

## Verification

- **0 sorries, 0 `axiom` declarations, 0 `native_decide`.**
- `#print axioms eulerPoly_recurrence_alg` → `[propext, Classical.choice, Quot.sound]`.
- 255 lines, 6 theorems, 1 (private) definition. Builds against Mathlib v4.26.0.

## Honest scope

Still grounded in exactly the ingredients the open question named: the differential recurrence (transitively, via the sibling's Frobenius identity `eulerPoly_eq_stirlingForm`, proved there by induction from `eulerPoly_succ`) and Pascal's rule (the binomial input to the transform). What is eliminated is every analytic step — no convergence, point-evaluation, or polynomial extensionality. The genuinely new, reusable artifact is the Stirling binomial transform.

Note: an abandoned, incomplete branch (`research/geom-oq08-eulerpoly-conv-recurrence-algebraic`) attacked the same OQ but left an auxiliary lemma `sorry`'d and pending Aristotle, with no PR. This proof is complete and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)