### PR TITLE
research(cauchy-interlacing-theorem-oq-01-oq-02-oq-01): Ky Fan trace interlacing — weak majorization of a compression spectrum [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CauchyInterlacingKyFan.lean
+++ b/proofs/Proofs/CauchyInterlacingKyFan.lean
@@ -1,0 +1,116 @@
+import Mathlib
+import Proofs.CauchyInterlacingPoincare
+
+/-
+# Ky Fan trace interlacing for a compression — weak majorization from Poincaré separation
+
+`CauchyInterlacingPoincare.lean` (#27247) proves the **Poincaré separation
+theorem**: for a symmetric operator `T` on an `(n + m)`-dimensional inner product
+space `V` with descending eigenvalues `lam`, and a codimension-`m` subspace
+`H ≤ V` carrying a symmetric operator `TH` whose Rayleigh quotient agrees with
+`T`'s (the orthogonal compression), the descending eigenvalues `mu` of `TH`
+separate the eigenvalues of `T` *termwise*:
+
+  `lam ⟨k + m⟩ ≤ mu k ≤ lam ⟨k⟩`     for every `k : Fin n`.
+
+This file answers the natural follow-up: what do these termwise inequalities say
+about **sums** of eigenvalues — i.e. about the **trace** of the compression?
+
+Summing `mu k ≤ lam ⟨k⟩` over any index set `s ⊆ Fin n` gives
+
+  `∑_{k ∈ s} mu k ≤ ∑_{k ∈ s} lam ⟨k⟩`,
+
+and summing `lam ⟨k + m⟩ ≤ mu k` gives the matching lower bound.  Three readings:
+
+* **Weak majorization (Ky Fan).**  Taking `s = {0, 1, …, j-1}` (an initial
+  segment), every top-`j` partial sum of the compression spectrum is dominated by
+  the top-`j` partial sum of the spectrum of `T`:
+  `∑_{k < j} mu k ≤ ∑_{k < j} lam k`.  The descending eigenvalues of a compression
+  are *weakly majorized* by the largest eigenvalues of the full operator.
+
+* **Trace trapping.**  Taking `s = univ`, the trace of the compression — the sum
+  of all `n` of its eigenvalues — lies between the sum of the `n` *smallest* and
+  the sum of the `n` *largest* eigenvalues of `T`:
+  `∑_{j=m}^{n+m-1} lam j ≤ ∑_k mu k ≤ ∑_{j=0}^{n-1} lam j`.
+
+The proof is the monotonicity of finite sums applied to the termwise Poincaré
+bounds: no new spectral theory is used.  The mathematical content is entirely the
+Poincaré separation theorem; this file packages its summed (Ky Fan) consequences.
+
+Research file — intentionally NOT registered in `Proofs.lean`.
+-/
+
+open scoped InnerProductSpace BigOperators
+open CauchyInterlacing.Poincare
+
+namespace CauchyInterlacing.KyFan
+
+variable {𝕜 V : Type*} [RCLike 𝕜] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  [FiniteDimensional 𝕜 V] {n m : ℕ}
+  (T : V →ₗ[𝕜] V) (b : OrthonormalBasis (Fin (n + m)) 𝕜 V) (lam : Fin (n + m) → ℝ)
+  (hT : ∀ i, T (b i) = (lam i : 𝕜) • b i) (hlam : Antitone lam)
+  (H : Submodule 𝕜 V) (hHdim : Module.finrank 𝕜 H = n)
+  (TH : H →ₗ[𝕜] H) (bH : OrthonormalBasis (Fin n) 𝕜 H) (mu : Fin n → ℝ)
+  (hTH : ∀ i, TH (bH i) = (mu i : 𝕜) • bH i) (hmu : Antitone mu)
+  (hRayleigh : ∀ y : H, y ≠ 0 →
+    RCLike.re (@inner 𝕜 H _ (TH y) y) / ‖y‖ ^ 2
+      = RCLike.re (@inner 𝕜 V _ (T (y : V)) (y : V)) / ‖(y : V)‖ ^ 2)
+
+-- The Poincaré hypotheses are consumed only inside the proof bodies, so force
+-- their inclusion into every theorem below.
+include T b hT hlam hHdim TH bH hTH hmu hRayleigh
+
+/-- **Ky Fan upper sum bound (arbitrary index set).**  Summing the upper Poincaré
+inequality `mu k ≤ lam ⟨k⟩` over any `s : Finset (Fin n)`: the partial sum of the
+compression eigenvalues is at most the corresponding sum of the `lam ⟨k⟩`. -/
+theorem sum_mu_le_sum_top_lam (s : Finset (Fin n)) :
+    ∑ k ∈ s, mu k ≤ ∑ k ∈ s, lam ⟨(k : ℕ), by have := k.isLt; omega⟩ :=
+  Finset.sum_le_sum fun k _ =>
+    (poincare_separation T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh k).2
+
+/-- **Ky Fan lower sum bound (arbitrary index set).**  Summing the lower Poincaré
+inequality `lam ⟨k + m⟩ ≤ mu k` over any `s : Finset (Fin n)`. -/
+theorem sum_bot_lam_le_sum_mu (s : Finset (Fin n)) :
+    ∑ k ∈ s, lam ⟨(k : ℕ) + m, by have := k.isLt; omega⟩ ≤ ∑ k ∈ s, mu k :=
+  Finset.sum_le_sum fun k _ =>
+    (poincare_separation T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh k).1
+
+/-- **Weak majorization (top-`j` partial sums).**  For every `j : ℕ`, the sum of
+the compression eigenvalues with index `< j` is at most the sum of the
+corresponding `j` largest eigenvalues of `T`:
+
+  `∑_{k < j} mu k ≤ ∑_{k < j} lam k`.
+
+This is the Ky Fan weak-majorization statement: the descending spectrum of the
+compression is weakly majorized by the largest eigenvalues of the full
+operator. -/
+theorem partial_sum_mu_le_partial_sum_lam (j : ℕ) :
+    ∑ k ∈ Finset.univ.filter (fun k : Fin n => (k : ℕ) < j), mu k
+      ≤ ∑ k ∈ Finset.univ.filter (fun k : Fin n => (k : ℕ) < j),
+          lam ⟨(k : ℕ), by have := k.isLt; omega⟩ :=
+  sum_mu_le_sum_top_lam T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh _
+
+/-- **Trace upper bound.**  The trace of the compression (sum of all its
+eigenvalues) is at most the sum of the `n` largest eigenvalues of `T`. -/
+theorem trace_compress_le :
+    ∑ k : Fin n, mu k ≤ ∑ k : Fin n, lam ⟨(k : ℕ), by have := k.isLt; omega⟩ :=
+  sum_mu_le_sum_top_lam T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh _
+
+/-- **Trace lower bound.**  The trace of the compression is at least the sum of the
+`n` smallest eigenvalues of `T` (those with index `m, m+1, …, n+m-1`). -/
+theorem trace_compress_ge :
+    ∑ k : Fin n, lam ⟨(k : ℕ) + m, by have := k.isLt; omega⟩ ≤ ∑ k : Fin n, mu k :=
+  sum_bot_lam_le_sum_mu T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh _
+
+/-- **Trace interlacing (two-sided).**  The trace of the compression `TH` of `T`
+onto a codimension-`m` subspace is trapped between the sum of the `n` smallest and
+the sum of the `n` largest eigenvalues of `T`:
+
+  `∑_{j=m}^{n+m-1} lam j ≤ ∑_k mu k ≤ ∑_{j=0}^{n-1} lam j`. -/
+theorem trace_interlacing :
+    (∑ k : Fin n, lam ⟨(k : ℕ) + m, by have := k.isLt; omega⟩ ≤ ∑ k : Fin n, mu k)
+      ∧ (∑ k : Fin n, mu k ≤ ∑ k : Fin n, lam ⟨(k : ℕ), by have := k.isLt; omega⟩) :=
+  ⟨trace_compress_ge T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh,
+   trace_compress_le T b lam hT hlam H hHdim TH bH mu hTH hmu hRayleigh⟩
+
+end CauchyInterlacing.KyFan

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-arbitrary-index-set",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 63, "endLine": 76 },
+    "type": "insight",
+    "title": "Stating the Ky Fan Bounds over an Arbitrary Index Set",
+    "content": "`sum_mu_le_sum_top_lam` and `sum_bot_lam_le_sum_mu` are each a single `Finset.sum_le_sum` applied to one half of the parent's `poincare_separation`. The key design choice is to leave the index set `s : Finset (Fin n)` a free parameter rather than fixing it to `Finset.univ`. Because of this, the full-trace estimate (`s = univ`) and every top-`j` weak-majorization partial sum (`s` an initial segment) are immediate specialisations — no Fin-interval bookkeeping is ever needed.",
+    "mathContext": "From μ_k ≤ λ_⟨k⟩ for all k, ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩ for any finite s, by monotonicity of finite sums. Likewise λ_⟨k+m⟩ ≤ μ_k sums to ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k.",
+    "significance": "key",
+    "relatedConcepts": ["Ky Fan inequality", "monotonicity of finite sums", "Poincaré separation", "eigenvalue interlacing"],
+    "prerequisites": ["Finset.sum_le_sum", "termwise Poincaré separation bounds"]
+  },
+  {
+    "id": "ann-weak-majorization",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 78, "endLine": 91 },
+    "type": "insight",
+    "title": "Weak Majorization: the Compression Spectrum is Dominated by the Largest Eigenvalues",
+    "content": "`partial_sum_mu_le_partial_sum_lam` specialises the upper Ky Fan bound to the initial segment `{k : Fin n | (k : ℕ) < j}`, yielding ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every `j`. Since both μ and λ are listed in descending order, this is exactly the statement that the compression eigenvalues are *weakly majorized* by the largest eigenvalues of the full operator T — the eigenvalue-majorization backbone behind Schur–Horn and Ky Fan's maximum principle.",
+    "mathContext": "Two descending sequences satisfy μ ≺_w λ iff ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for all j; here it follows from the termwise μ_k ≤ λ_k by summing over each prefix.",
+    "significance": "high",
+    "relatedConcepts": ["weak majorization", "Ky Fan maximum principle", "Schur–Horn theorem", "descending eigenvalues"],
+    "prerequisites": ["majorization of descending sequences", "Finset.filter / initial segments"]
+  },
+  {
+    "id": "ann-trace-trapping",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 93, "endLine": 116 },
+    "type": "insight",
+    "title": "Trace Trapping: the Compression Trace Lies Between the Extreme Eigenvalue Sums",
+    "content": "Taking `s = Finset.univ`, `trace_compress_le` and `trace_compress_ge` give ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j and ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k; `trace_interlacing` bundles them. Since ∑_k μ_k is the trace of the compression and the index map k ↦ ⟨k⟩ / k ↦ ⟨k+m⟩ automatically selects the n largest / n smallest eigenvalues of T, the trace of any codimension-m orthogonal compression is trapped between the sum of the n smallest and the sum of the n largest eigenvalues of T.",
+    "mathContext": "trace(TH) = ∑ μ_k; summing m largest-side bounds gives the upper trap, m smallest-side bounds the lower trap. This is the trace form of Ky Fan's inequality for compressions.",
+    "significance": "high",
+    "relatedConcepts": ["trace inequality", "orthogonal compression", "extreme eigenvalue sums", "Ky Fan"],
+    "prerequisites": ["trace as the sum of eigenvalues", "Finset.univ summation"]
+  },
+  {
+    "id": "ann-include-directive",
+    "proofId": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 59, "endLine": 61 },
+    "type": "technique",
+    "title": "Threading the Poincaré Hypotheses with `include`",
+    "content": "The Poincaré data (`T, b, hT, hlam, hHdim, TH, bH, hTH, hmu, hRayleigh`) appears only inside the proof bodies — the *statements* of the Ky Fan theorems mention only `mu`, `lam`, and `s`. Lean's section-variable auto-binding therefore would not pull them in, so an explicit `include` directive forces their inclusion into every theorem below. Omitting it produces the misleading `unknown identifier T` error at each call site.",
+    "mathContext": "A purely Lean 4 elaboration point: section variables are auto-included only when referenced in the declared type, not when referenced solely in the proof term.",
+    "significance": "medium",
+    "relatedConcepts": ["Lean 4 section variables", "include directive", "auto-bound implicits"],
+    "prerequisites": ["Lean 4 variable/include semantics"]
+  }
+]

--- a/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,141 @@
+{
+  "id": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+  "slug": "cauchy-interlacing-theorem-oq-01-oq-02-oq-01",
+  "title": "Ky Fan Trace Interlacing: Weak Majorization of a Compression Spectrum",
+  "description": "Sums the termwise Poincaré separation bounds λ_{k+m} ≤ μ_k ≤ λ_k over an arbitrary index set to obtain the Ky Fan trace inequalities for an orthogonal compression. For any s ⊆ Fin n, ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_k and ∑_{k∈s} λ_{k+m} ≤ ∑_{k∈s} μ_k. Reading s as an initial segment gives weak majorization (every top-j partial sum of the compression eigenvalues is dominated by the j largest eigenvalues of the full operator); reading s as the whole index set traps the trace of the compression between the sum of the n smallest and the sum of the n largest eigenvalues of T. 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Ky Fan (1949); formalized for lean-genius",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/CauchyInterlacingKyFan.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "lineCount": 116,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "difficulty": "advanced",
+    "category": "linear-algebra",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_le_sum",
+        "description": "monotonicity of a finite sum under a termwise ≤ — the single engine that turns each Poincaré bound into its summed (Ky Fan) form",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "sum_mu_le_sum_top_lam: for every s : Finset (Fin n), ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩ — the upper Ky Fan bound over an arbitrary index set, subsuming both the trace and every partial sum",
+      "sum_bot_lam_le_sum_mu: the matching lower bound ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k",
+      "partial_sum_mu_le_partial_sum_lam: the weak-majorization statement ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every j, exhibiting the compression spectrum as weakly majorized by the largest eigenvalues of T",
+      "trace_compress_le / trace_compress_ge: the s = univ specialisations — the trace of the compression is at most the sum of the n largest, and at least the sum of the n smallest, eigenvalues of T",
+      "trace_interlacing: the two-sided trace trapping ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j"
+    ],
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The mathematical content is the Poincaré separation theorem of the parent entry (cauchy-interlacing-theorem-oq-01-oq-02, the explicit-compression form of CauchyInterlacingPoincare); this entry adds only the summation of its termwise bounds via Finset.sum_le_sum. Depends only on the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "tags": [
+      "Cauchy interlacing",
+      "Poincaré separation",
+      "Ky Fan inequality",
+      "weak majorization",
+      "eigenvalues",
+      "trace",
+      "orthogonal compression",
+      "inner product spaces"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CauchyInterlacingPoincare"
+    ],
+    "opens": [
+      "InnerProductSpace",
+      "BigOperators",
+      "CauchyInterlacing.Poincare"
+    ],
+    "namespace": "CauchyInterlacing.KyFan",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/CauchyInterlacingKyFan.lean",
+    "sorries": 0
+  },
+  "conclusion": {
+    "summary": "A machine-checked Lean 4 derivation of the Ky Fan trace inequalities for an orthogonal compression, obtained by summing the termwise Poincaré separation bounds. Let T be a symmetric operator on an (n+m)-dimensional inner product space V with descending eigenvalues λ, and let TH be the orthogonal compression of T onto a codimension-m subspace H, with descending eigenvalues μ (the abstract hypotheses of poincare_separation). The parent theorem gives, for each k : Fin n, λ_⟨k+m⟩ ≤ μ_k ≤ λ_⟨k⟩. Monotonicity of finite sums (Finset.sum_le_sum) lifts this to: for every s : Finset (Fin n), ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩ and ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k. Specialising s yields the weak-majorization partial sums (s an initial segment) and the two-sided trace trapping (s = univ). 0 axioms, 0 sorries.",
+    "implications": "Packages the summed (Ky Fan) consequences of Poincaré separation: the descending eigenvalues of a compression are weakly majorized by the largest eigenvalues of the full operator, and the trace of any codimension-m orthogonal compression is sandwiched between the sums of the n smallest and the n largest eigenvalues of T. Because the upper and lower bounds are stated over an arbitrary index set, a single pair of theorems covers the trace bound and all top-j partial sums uniformly; the arbitrary-finset form is directly reusable for further majorization-type corollaries (Schur–Horn, Ky Fan's maximum principle).",
+    "openQuestions": [
+      "Identify ∑_k μ_k with LinearMap.trace 𝕜 H TH (the matrix trace in the eigenbasis bH is diagonal with entries μ), turning trace_interlacing into a literal statement about the operator trace rather than the eigenvalue sum.",
+      "Derive the full (two-sided) majorization μ ≺ λ including the lower partial sums ∑_{k≥j} μ_k ≥ ∑ of the corresponding smallest λ, and connect to Mathlib's developing majorization API where available."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Cauchy's interlacing theorem (1829) and its codimension-m generalisation, the Poincaré separation theorem, control individual eigenvalues of a compression. Summing these termwise inequalities produces the trace and partial-sum estimates studied by Ky Fan (1949), whose maximum principle expresses the sum of the k largest eigenvalues of a Hermitian operator as a maximum of traces over k-dimensional compressions. The resulting statement — that the descending spectrum of a compression is weakly majorized by the largest eigenvalues of the full operator — is the eigenvalue-majorization backbone behind the Schur–Horn theorem and many trace inequalities in matrix analysis.",
+    "problemStatement": "The parent entry proves the termwise Poincaré separation λ_{k+m} ≤ μ_k ≤ λ_k for the eigenvalues μ of the orthogonal compression of a symmetric operator T onto a codimension-m subspace. What do these say about sums of eigenvalues — equivalently about the trace of the compression? Sum the inequalities over an index set and read off (a) the weak-majorization partial sums and (b) the two-sided trapping of the trace.",
+    "text": "Summing the termwise Poincaré separation bounds over any index set yields the Ky Fan inequalities: the descending eigenvalues of an orthogonal compression are weakly majorized by the largest eigenvalues of the full operator, and the trace of the compression lies between the sums of the n smallest and the n largest eigenvalues.",
+    "proofStrategy": "Each theorem is one application of Finset.sum_le_sum to a termwise bound supplied by the parent theorem poincare_separation. For the upper Ky Fan bound, the termwise input is (poincare_separation … k).2 : μ_k ≤ λ_⟨k⟩; for the lower bound it is (poincare_separation … k).1 : λ_⟨k+m⟩ ≤ μ_k. Stating the two core theorems over an arbitrary s : Finset (Fin n) makes the trace forms (s = Finset.univ) and the weak-majorization partial sums (s = the initial segment {k : k < j}) immediate corollaries — no Fin-segment arithmetic is needed because the summation index set is a free parameter. The Poincaré hypotheses are threaded into every theorem with an explicit include directive, since they appear only in the proof bodies.",
+    "keyInsights": [
+      "Stating the Ky Fan bounds over an arbitrary index set s : Finset (Fin n) — rather than only over Finset.univ — lets a single pair of theorems subsume both the trace estimate and every top-j partial sum, so the weak-majorization statement is a one-line specialisation with no Fin-interval bookkeeping",
+      "The full mathematical weight sits in the parent Poincaré separation theorem; the Ky Fan content is exactly the monotonicity of finite sums, which is honest to record as a Finset.sum_le_sum wrapper rather than dressed up as new spectral theory",
+      "Because the eigenvalues are carried as the free functions λ and μ with the index map k ↦ ⟨k+m⟩ / k ↦ ⟨k⟩, the lower bound automatically references the n SMALLEST eigenvalues of T (indices m … n+m-1) and the upper bound the n LARGEST (indices 0 … n-1), making the trace trapping read off directly"
+    ],
+    "prerequisites": [
+      "The Poincaré separation theorem (cauchy-interlacing-theorem-oq-01-oq-02 / CauchyInterlacingPoincare): termwise interlacing of compression eigenvalues",
+      "Descending (antitone) eigenvalue lists and orthonormal eigenbases for symmetric operators",
+      "Monotonicity of finite sums (Finset.sum_le_sum) and basic Finset manipulation",
+      "Weak majorization: domination of top-j partial sums of two descending sequences"
+    ]
+  },
+  "sections": [
+    {
+      "title": "The Ky Fan Sum Bounds over an Arbitrary Index Set",
+      "content": "sum_mu_le_sum_top_lam and sum_bot_lam_le_sum_mu apply Finset.sum_le_sum to the two halves of the parent's Poincaré separation theorem. For any s : Finset (Fin n), the upper half μ_k ≤ λ_⟨k⟩ sums to ∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩, and the lower half λ_⟨k+m⟩ ≤ μ_k sums to ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k. Leaving s free is the design choice that makes every later corollary a specialisation."
+    },
+    {
+      "title": "Weak Majorization: Top-j Partial Sums",
+      "content": "partial_sum_mu_le_partial_sum_lam specialises s to the initial segment {k : Fin n | (k : ℕ) < j}, giving ∑_{k<j} μ_k ≤ ∑_{k<j} λ_k for every j : ℕ. This is the Ky Fan weak-majorization statement: the descending spectrum of the compression is weakly majorized by the largest eigenvalues of the full operator."
+    },
+    {
+      "title": "Trace Trapping",
+      "content": "trace_compress_le and trace_compress_ge specialise s to Finset.univ: the trace of the compression (the sum of all n of its eigenvalues) is at most the sum of the n largest eigenvalues of T and at least the sum of the n smallest (those with index m … n+m-1). trace_interlacing bundles the two as ∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Fan, K.",
+      "title": "On a theorem of Weyl concerning eigenvalues of linear transformations I",
+      "year": "1949",
+      "note": "Proceedings of the National Academy of Sciences 35(11): 652–655 — the maximum principle and trace/partial-sum eigenvalue inequalities"
+    },
+    {
+      "authors": "Bhatia, R.",
+      "title": "Matrix Analysis",
+      "year": "1997",
+      "note": "Eigenvalue interlacing, majorization, and Ky Fan's maximum principle (Chapters II–III)"
+    },
+    {
+      "authors": "Horn, R. A. and Johnson, C. R.",
+      "title": "Matrix Analysis",
+      "year": "2013",
+      "note": "Cauchy interlacing, Poincaré separation, and majorization of compression spectra"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Sums the termwise Poincaré separation bounds λ_{k+m} ≤ μ_k ≤ λ_k of the parent into their Ky Fan (trace and partial-sum) forms."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-02",
+      "relationship": "related",
+      "description": "The abstract codimension-m Poincaré separation theorem whose summed consequences are formalized here."
+    },
+    {
+      "targetId": "cauchy-interlacing-theorem-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Sibling entry assembling the matrix-level eigenvalue corollary of Cauchy interlacing; this entry instead derives the majorization/trace consequences of the abstract separation theorem."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **#28084** (Poincaré separation, cauchy-interlacing-theorem-oq-01-oq-02). The parent proves the *termwise* separation bounds for an orthogonal compression:

```
λ_⟨k+m⟩ ≤ μ_k ≤ λ_⟨k⟩    (for every k : Fin n)
```

This entry sums those bounds over an **arbitrary index set** `s : Finset (Fin n)` to obtain the **Ky Fan trace inequalities**:

```
∑_{k∈s} μ_k ≤ ∑_{k∈s} λ_⟨k⟩      and      ∑_{k∈s} λ_⟨k+m⟩ ≤ ∑_{k∈s} μ_k
```

Specialising `s` gives two readings:

- **Weak majorization** (`s` = initial segment): `∑_{k<j} μ_k ≤ ∑_{k<j} λ_k` for every j — the descending spectrum of the compression is weakly majorized by the largest eigenvalues of the full operator.
- **Trace trapping** (`s = univ`): `∑_{j=m}^{n+m-1} λ_j ≤ ∑_k μ_k ≤ ∑_{j=0}^{n-1} λ_j` — the trace of any codimension-m orthogonal compression lies between the sums of the n smallest and the n largest eigenvalues of T.

## Theorems (6, 0 defs)

| name | statement |
|------|-----------|
| `sum_mu_le_sum_top_lam` | upper Ky Fan bound over arbitrary s |
| `sum_bot_lam_le_sum_mu` | lower Ky Fan bound over arbitrary s |
| `partial_sum_mu_le_partial_sum_lam` | weak-majorization top-j partial sums |
| `trace_compress_le` / `trace_compress_ge` | trace ≤ sum of n largest / ≥ sum of n smallest |
| `trace_interlacing` | two-sided trace trapping |

## Verification

- **116 lines, 0 sorries, 0 axioms** — `#print axioms` shows only `propext, Classical.choice, Quot.sound`.
- Built single-file with `lake env lean` against the main-branch oleans for `Proofs.CauchyInterlacingPoincare` (the abstract `poincare_separation`, already on main). Independent of the still-open parent PR #28084.
- Research file, intentionally **not** registered in `Proofs.lean`.

## Honesty note

The mathematical weight sits entirely in the parent's Poincaré separation theorem; the Ky Fan content here is exactly the monotonicity of finite sums (`Finset.sum_le_sum`). The contribution is the clean packaging — stating the bounds over an arbitrary index set so that weak majorization and trace trapping are uniform one-line specialisations — not new spectral theory. The docstrings and meta record this plainly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)