### PR TITLE
research: multisection of an arbitrary summable family via Nat.divModEquiv (geometric-series-oq-09-oq-01-oq-01-oq-01)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2824,6 +2824,7 @@ import Proofs.GeometricSeriesOQ08OQ03OQ01OQ01
 import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ09OQ01
 import Proofs.GeometricSeriesOQ09OQ01OQ01
+import Proofs.GeometricSeriesOQ09OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01

--- a/proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ01.lean
@@ -1,0 +1,163 @@
+import Mathlib.Topology.Algebra.InfiniteSum.Group
+import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Tactic
+
+/-
+# Multisection of an Arbitrary Summable Family as a Reindexing via `Nat.divModEquiv`
+
+## What This Proves
+
+The parent (`GeometricSeriesOQ09OQ01OQ01`) obtained the `q`-fold splitting of the
+*geometric* series `∑_m r^m` as a genuine reindexing of the summation along the
+bijection
+
+  `ℕ  ≃  ℕ × Fin q,    m ↦ (m / q, m % q),    (n, a) ↦ q·n + a`
+
+(`Nat.divModEquiv`).  This file answers its open question: the same viewpoint
+applies to **any** summable family `f : ℕ → M` valued in a complete Hausdorff
+uniform abelian group, with *no* algebraic closed form required.  Concretely, fix a
+modulus `q ≥ 1`; then for every `HasSum f S`:
+
+* **Reindexing.**  `HasSum (fun (p : ℕ × Fin q) => f (q·p.1 + p.2)) S` — the
+  one-dimensional sum, transported verbatim onto `ℕ × Fin q`.
+* **Block regrouping.**  `HasSum (fun n => ∑_{a<q} f (q·n + a)) S` — grouping the
+  reindexed series by the block index `n` (finite inner sums); this needs no
+  hypothesis beyond `HasSum f S` because the fibers `Fin q` are finite.
+* **Residue multisection.**  `HasSum (fun a : Fin q => ∑'_n f (q·n + a)) S`, hence
+  `∑_{a<q} ∑'_n f (q·n + a) = ∑'_m f m`.  This is the genuine *multisection*: the
+  series is split into `q` residue subseries indexed by `a`, each summed over its
+  own block index `n`.
+
+## The Characterisation (answering the open question)
+
+The open question asks to *characterise when* the residue regrouping
+`∑_{a<q} ∑'_n f (q·n + a) = S` holds.  The answer is clean: **it holds for every
+summable `f`, unconditionally** — it is a pure Fubini/`HasSum.prod_fiberwise`
+consequence of summability.  The only nontrivial input is that each residue
+subseries `n ↦ f (q·n + a)` is itself summable; this is automatic because
+`n ↦ q·n + a` is injective, so summability descends along it
+(`Summable.comp_injective`).  No absolute convergence beyond plain `Summable`,
+no normed/Banach structure is required — only that `M` is a complete Hausdorff
+uniform abelian group (completeness so that each residue subseries converges,
+Hausdorffness so that infinite sums are unique, and the topological-group
+structure so that the regular-space fiberwise-summation lemma applies).
+
+## Why This Is Not Already in Mathlib
+
+Mathlib has `Nat.divModEquiv`, `Equiv.hasSum_iff`, `HasSum.prod_fiberwise`, and
+`Summable.comp_injective`, but not their assembly into the residue-indexed
+multisection of an arbitrary summable family.  The new content is the
+identification of `f ∘ (Nat.divModEquiv q).symm` with `p ↦ f (q·p.1 + p.2)` and
+the observation that, once each residue subseries is seen to be summable via the
+injectivity of `n ↦ q·n + a`, the full multisection drops out of fiberwise
+summation with no further structure.
+
+## Status: 0 sorries, 0 axioms (over any complete Hausdorff uniform abelian group)
+-/
+
+namespace GeometricSeriesOQ09OQ01OQ01OQ01
+
+set_option linter.unusedSectionVars false
+
+variable {M : Type*} [AddCommGroup M] [UniformSpace M] [IsUniformAddGroup M]
+  [CompleteSpace M] [T2Space M] {f : ℕ → M} {S : M}
+
+/-! ## Injectivity of the residue map and summability of residue subseries -/
+
+/-- For `q ≠ 0` the residue map `n ↦ q·n + a` is injective `ℕ → ℕ`. -/
+theorem residue_injective {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Function.Injective (fun n : ℕ => q * n + a) := by
+  intro n m h
+  simp only at h
+  exact Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero hq) (Nat.add_right_cancel h)
+
+/-- Each residue subseries `n ↦ f (q·n + a)` is summable whenever `f` is and
+`q ≠ 0`.  This is the only place summability is used, and it follows purely from
+the injectivity of the residue map (`Summable.comp_injective`). -/
+theorem summable_residue (hf : Summable f) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Summable (fun n : ℕ => f (q * n + a)) := by
+  simpa [Function.comp_def] using hf.comp_injective (residue_injective hq a)
+
+/-! ## The reindexing theorem -/
+
+/-- **Reindexing.**  Transporting `HasSum f S` along the bijection
+`ℕ ≃ ℕ × Fin q`, `m ↦ (m / q, m % q)` yields the two-dimensional series with term
+`f (q·n + a)` at `(n, a)`, summing to the same `S`. -/
+theorem hasSum_reindex (hf : HasSum f S) (q : ℕ) [NeZero q] :
+    HasSum (fun p : ℕ × Fin q => f (q * p.1 + (p.2 : ℕ))) S := by
+  have h := (Nat.divModEquiv q).symm.hasSum_iff.mpr hf
+  simp only [Function.comp_def, Nat.divModEquiv_symm_apply] at h
+  -- `h : HasSum (fun p => f (p.1 * q + ↑p.2)) S`
+  have heq : (fun p : ℕ × Fin q => f (p.1 * q + (p.2 : ℕ)))
+      = (fun p : ℕ × Fin q => f (q * p.1 + (p.2 : ℕ))) := by
+    funext p; rw [Nat.mul_comm]
+  rwa [heq] at h
+
+/-- `tsum` form of the reindexing. -/
+theorem tsum_reindex (hf : Summable f) (q : ℕ) [NeZero q] :
+    ∑' p : ℕ × Fin q, f (q * p.1 + (p.2 : ℕ)) = ∑' m : ℕ, f m := by
+  rw [(hasSum_reindex hf.hasSum q).tsum_eq, hf.hasSum.tsum_eq]
+
+/-- The reindexed two-dimensional series is summable. -/
+theorem summable_reindex (hf : Summable f) (q : ℕ) [NeZero q] :
+    Summable (fun p : ℕ × Fin q => f (q * p.1 + (p.2 : ℕ))) :=
+  (hasSum_reindex hf.hasSum q).summable
+
+/-! ## Block regrouping: finite inner sums over the `q` residues -/
+
+/-- **Block regrouping.**  Grouping the reindexed series by the block index
+`n : ℕ` (each block the *finite* sum over the `q` residues) recovers `S`.  No
+hypothesis beyond `HasSum f S` is needed because the fibers `Fin q` are finite. -/
+theorem hasSum_block (hf : HasSum f S) (q : ℕ) [NeZero q] :
+    HasSum (fun n : ℕ => ∑ a : Fin q, f (q * n + (a : ℕ))) S :=
+  (hasSum_reindex hf q).prod_fiberwise fun _ => hasSum_fintype _
+
+/-! ## Residue multisection: the Fubini consequence of summability -/
+
+/-- **Residue multisection.**  Grouping the reindexed series by the residue
+`a : Fin q` (each group the *infinite* subseries over the block index `n`)
+recovers `S`.  This is the multisection of an arbitrary `HasSum`, valid for every
+summable `f` as a fiberwise-summation (Fubini) consequence. -/
+theorem hasSum_multisection (hf : HasSum f S) (q : ℕ) [NeZero q] :
+    HasSum (fun a : Fin q => ∑' n : ℕ, f (q * n + (a : ℕ))) S := by
+  have h2 : HasSum (fun p : Fin q × ℕ => f (q * p.2 + (p.1 : ℕ))) S := by
+    rw [← (Equiv.prodComm ℕ (Fin q)).hasSum_iff]
+    simpa [Function.comp_def] using hasSum_reindex hf q
+  exact h2.prod_fiberwise fun a =>
+    (summable_residue hf.summable (NeZero.ne q) (a : ℕ)).hasSum
+
+/-- **Multisection identity (answering the open question).**  For every summable
+`f` the residue regrouping holds unconditionally:
+`∑_{a<q} ∑'_n f (q·n + a) = ∑'_m f m`. -/
+theorem tsum_multisection (hf : Summable f) (q : ℕ) [NeZero q] :
+    ∑ a ∈ Finset.range q, (∑' n : ℕ, f (q * n + a)) = ∑' m : ℕ, f m := by
+  have hfin : (∑ a : Fin q, ∑' n : ℕ, f (q * n + (a : ℕ))) = ∑' m : ℕ, f m :=
+    (hasSum_fintype (fun a : Fin q => ∑' n : ℕ, f (q * n + (a : ℕ)))).unique
+      (hasSum_multisection hf.hasSum q)
+  rw [← hfin, Fin.sum_univ_eq_sum_range (fun a => ∑' n : ℕ, f (q * n + a)) q]
+
+/-! ## Specialisations -/
+
+/-- The `q = 2` even/odd splitting of an arbitrary summable family:
+`HasSum f S → HasSum (fun a : Fin 2 => ∑'_n f (2·n + a)) S`. -/
+theorem hasSum_multisection_two (hf : HasSum f S) :
+    HasSum (fun a : Fin 2 => ∑' n : ℕ, f (2 * n + (a : ℕ))) S :=
+  hasSum_multisection hf 2
+
+/-- Even/odd decomposition of a summable real (or any-group) family:
+`∑'_n f (2n) + ∑'_n f (2n+1) = ∑'_m f m`. -/
+theorem tsum_even_add_odd (hf : Summable f) :
+    (∑' n : ℕ, f (2 * n)) + (∑' n : ℕ, f (2 * n + 1)) = ∑' m : ℕ, f m := by
+  have h := tsum_multisection hf 2
+  simpa [Finset.sum_range_succ] using h
+
+/-! ## Concrete check -/
+
+/-- Sanity check: the even/odd multisection of the summable family `n ↦ (1/2)^n`
+recombines to its total `∑'_m (1/2)^m = 2`. -/
+example :
+    (∑' n : ℕ, (1 / 2 : ℝ) ^ (2 * n)) + (∑' n : ℕ, (1 / 2 : ℝ) ^ (2 * n + 1))
+      = ∑' m : ℕ, (1 / 2 : ℝ) ^ m :=
+  tsum_even_add_odd (summable_geometric_of_lt_one (by norm_num) (by norm_num))
+
+end GeometricSeriesOQ09OQ01OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,176 @@
+{
+  "id": "geometric-series-oq-09-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-09-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Topology.Algebra.InfiniteSum.Group",
+      "Mathlib.Logic.Equiv.Fin.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "GeometricSeriesOQ09OQ01OQ01OQ01",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ09OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Multisection of an Arbitrary Summable Family as a Reindexing via Nat.divModEquiv",
+  "description": "Generalises the parent's q-fold reindexing of the geometric series to an arbitrary summable family f : ℕ → M valued in a complete Hausdorff uniform abelian group, answering its open question. For any HasSum f S and modulus q ≠ 0, transporting the series along the bijection ℕ ≃ ℕ × Fin q (m ↦ (m/q, m%q), Nat.divModEquiv) yields HasSum (fun (p : ℕ × Fin q) => f(q·p.1 + p.2)) S via Equiv.hasSum_iff. Two fiberwise regroupings (HasSum.prod_fiberwise) follow: the block regrouping HasSum (fun n => ∑_{a<q} f(q·n+a)) S, which needs no hypothesis beyond HasSum f S because the Fin q fibers are finite; and the residue multisection HasSum (fun a : Fin q => ∑_n f(q·n+a)) S, hence ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m. The characterisation answering the open question: the residue regrouping holds for EVERY summable f unconditionally, the only nontrivial input being that each residue subseries n ↦ f(q·n+a) is summable — automatic from the injectivity of n ↦ q·n+a via Summable.comp_injective. No normed/Banach or closed-form structure is used.",
+  "overview": {
+    "historicalContext": "The q-section (multisection) of a series ∑_m c_m extracts, for each residue a mod q, the subseries ∑_n c_{q·n+a}. The geometric ancestry of this entry built the multisection analytically: geometric-series-oq-09-oq-01 computed the q residue closed forms r^a/(1−r^q) and reassembled them via 1−r^q = (1−r)·∑_{a<q} r^a, and its child geometric-series-oq-09-oq-01-oq-01 recast that splitting as a reindexing of the geometric HasSum along Nat.divModEquiv. The open question those raised was whether the reindexing viewpoint is intrinsic to summability rather than to the geometric closed forms. It is: the decomposition ℕ = ⨆_{a<q} {q·n+a : n} is the bijection ℕ ≃ ℕ × Fin q, so ANY HasSum f S transports along it, and the multisection drops out of fiberwise (discrete-Fubini) summation. This is the abstract form of the same reindex-then-regroup mechanism Mathlib uses for the even/odd parts of the cos/sin Taylor series (Nat.divModEquiv 2).",
+    "problemStatement": "Let M be a complete Hausdorff uniform abelian group and f : ℕ → M with HasSum f S. For any modulus q ≠ 0, prove HasSum (fun (p : ℕ × Fin q) => f(q·p.1 + p.2)) S by transporting f along ℕ ≃ ℕ × Fin q, m ↦ (m/q, m%q). Then derive, by fiberwise summation, the block regrouping HasSum (fun n => ∑_{a<q} f(q·n+a)) S and the residue multisection HasSum (fun a : Fin q => ∑_n f(q·n+a)) S, and characterise when the multisection identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m holds.",
+    "proofStrategy": "(1) Reindexing: apply (Nat.divModEquiv q).symm.hasSum_iff.mpr to HasSum f S; since (Nat.divModEquiv q).symm (n,a) = n·q + a, simp [Function.comp_def, Nat.divModEquiv_symm_apply] gives fun p => f(p.1·q + p.2), and one mul_comm normalises to the q·p.1 form (hasSum_reindex). tsum and summability corollaries follow. (2) Block regrouping: HasSum.prod_fiberwise with the finite fibers over Fin q (hasSum_fintype) gives HasSum (fun n => ∑_{a:Fin q} f(q·n+a)) S — no extra hypothesis. (3) Residue summability: n ↦ q·n+a is injective for q ≠ 0 (residue_injective, from Nat.eq_of_mul_eq_mul_left + Nat.add_right_cancel), so Summable.comp_injective makes each subseries n ↦ f(q·n+a) summable (summable_residue). (4) Residue multisection: reindex by Equiv.prodComm to Fin q × ℕ, then HasSum.prod_fiberwise over the ℕ fibers (each summable by summable_residue) yields HasSum (fun a : Fin q => ∑_n f(q·n+a)) S; HasSum.unique against hasSum_fintype + Fin.sum_univ_eq_sum_range gives ∑_{a∈range q} ∑_n f(q·n+a) = ∑_m f m (tsum_multisection). The characterisation is that this holds for every summable f.",
+    "keyInsights": [
+      "The multisection of an arbitrary summable family is not an analytic computation but a relabelling: ℕ = ⨆_{a<q} {q·n+a} IS the bijection ℕ ≃ ℕ × Fin q (Nat.divModEquiv), so ANY HasSum f S transports along it verbatim via Equiv.hasSum_iff — the geometric closed forms used by the ancestors play no role.",
+      "The open question asked to characterise WHEN the residue regrouping ∑_{a<q} ∑_n f(q·n+a) = S holds. The answer is unconditional: it holds for every summable f, as a pure HasSum.prod_fiberwise (discrete Fubini) consequence. There is no convergence side-condition to impose beyond plain Summable f.",
+      "The single nontrivial input is summability of each residue subseries n ↦ f(q·n+a). This is automatic, not assumed: n ↦ q·n+a is injective (q ≠ 0), and summability descends along injections (Summable.comp_injective). So the whole multisection is powered by one counting fact plus fiberwise summation.",
+      "The block regrouping HasSum (fun n => ∑_{a<q} f(q·n+a)) S requires NO hypothesis beyond HasSum f S, because the fibers Fin q are finite (hasSum_fintype) — finite inner sums never raise a convergence question. Only the residue (infinite-fiber) regrouping needs the comp_injective summability step.",
+      "The natural home is a complete Hausdorff uniform abelian group: completeness so each residue subseries converges (Summable.comp_injective lives in the complete-uniform-group section), Hausdorffness for uniqueness of sums, and the topological-group structure supplies the RegularSpace instance HasSum.prod_fiberwise needs. No norm, no Banach, no absolute convergence beyond Summable."
+    ]
+  },
+  "sections": [
+    {
+      "id": "residue-summability",
+      "title": "Residue Map Injectivity and Subseries Summability",
+      "startLine": 65,
+      "endLine": 80,
+      "summary": "residue_injective: n ↦ q·n+a is injective ℕ → ℕ for q ≠ 0 (Nat.eq_of_mul_eq_mul_left after Nat.add_right_cancel). summable_residue: each residue subseries n ↦ f(q·n+a) is summable whenever f is, via Summable.comp_injective — the only place summability is consumed, and it follows purely from injectivity of the residue map, with no normed structure.",
+      "mathContext": "$n\\mapsto qn+a$ injective for $q\\neq0$; summability descends along injections, so $\\sum_n f(qn+a)$ converges."
+    },
+    {
+      "id": "reindexing",
+      "title": "The Reindexing Theorem",
+      "startLine": 81,
+      "endLine": 105,
+      "summary": "hasSum_reindex (main): HasSum (fun p : ℕ × Fin q => f(q·p.1 + p.2)) S, obtained by transporting HasSum f S along (Nat.divModEquiv q).symm.hasSum_iff. The transported map sends (n,a) ↦ f(n·q + a) (simp with Nat.divModEquiv_symm_apply), normalised to q·n via mul_comm. tsum_reindex and summable_reindex are the tsum and summability corollaries.",
+      "mathContext": "$\\mathbb{N}\\simeq\\mathbb{N}\\times\\mathrm{Fin}\\,q,\\ m\\mapsto(m/q,m\\%q)$; $\\sum_{(n,a)} f(qn+a)=S$."
+    },
+    {
+      "id": "regrouping",
+      "title": "Block Regrouping and Residue Multisection",
+      "startLine": 106,
+      "endLine": 138,
+      "summary": "hasSum_block: grouping by block index n (finite inner sums over Fin q) gives HasSum (fun n => ∑_{a:Fin q} f(q·n+a)) S via HasSum.prod_fiberwise + hasSum_fintype, with no hypothesis beyond HasSum f S. hasSum_multisection: grouping by residue a (after Equiv.prodComm) gives HasSum (fun a => ∑_n f(q·n+a)) S, fibers summed by summable_residue. tsum_multisection: the multisection identity ∑_{a∈range q} ∑_n f(q·n+a) = ∑_m f m, for EVERY summable f, via HasSum.unique + Fin.sum_univ_eq_sum_range.",
+      "mathContext": "$\\sum_{a<q}\\sum_n f(qn+a)=\\sum_m f(m)$ by fiberwise (discrete-Fubini) summation, unconditionally for summable $f$."
+    },
+    {
+      "id": "specialisations",
+      "title": "Even/Odd Specialisation and Concrete Check",
+      "startLine": 139,
+      "endLine": 162,
+      "summary": "hasSum_multisection_two: the q=2 even/odd split HasSum (fun a : Fin 2 => ∑_n f(2·n+a)) S. tsum_even_add_odd: ∑_n f(2n) + ∑_n f(2n+1) = ∑_m f m for any summable family (Finset.sum_range_succ). A concrete check on n ↦ (1/2)^n recombines the even and odd parts to the total ∑_m (1/2)^m, exhibiting the abstract theorem on the geometric family of the ancestors.",
+      "mathContext": "$\\sum_n f(2n)+\\sum_n f(2n+1)=\\sum_m f(m)$; sanity check on $(1/2)^n$."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ09OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "infinite-series",
+      "summability",
+      "multisection",
+      "reindexing",
+      "fubini",
+      "topological-group",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 163,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_reindex: HasSum (fun (p : ℕ × Fin q) => f(q·p.1 + p.2)) S for any HasSum f S in a complete Hausdorff uniform abelian group and q ≠ 0, by transporting along Nat.divModEquiv via Equiv.hasSum_iff. This is the parent's reindexing generalised from the geometric series to an arbitrary summable family, answering geometric-series-oq-09-oq-01-oq-01's open question.",
+      "hasSum_multisection: HasSum (fun a : Fin q => ∑_n f(q·n+a)) S, the residue multisection of an arbitrary summable family as a discrete-Fubini (HasSum.prod_fiberwise) consequence — valid for EVERY summable f, the characterisation the open question requested.",
+      "tsum_multisection: the unconditional multisection identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m for every summable f, derived from hasSum_multisection via HasSum.unique and Fin.sum_univ_eq_sum_range.",
+      "summable_residue: each residue subseries n ↦ f(q·n+a) is summable whenever f is, reduced to the injectivity of the residue map n ↦ q·n+a (residue_injective) via Summable.comp_injective — isolating the single nontrivial input of the multisection.",
+      "hasSum_block: the complementary block regrouping HasSum (fun n => ∑_{a:Fin q} f(q·n+a)) S, requiring no hypothesis beyond HasSum f S (finite Fin q fibers, hasSum_fintype).",
+      "tsum_reindex, summable_reindex, residue_injective, the q=2 even/odd specialisation hasSum_multisection_two and tsum_even_add_odd (∑_n f(2n)+∑_n f(2n+1)=∑_m f m), plus a concrete check recombining the even/odd parts of n ↦ (1/2)^n."
+    ],
+    "prerequisites": [
+      "Nat.divModEquiv (n : ℕ) [NeZero n] : ℕ ≃ ℕ × Fin n, the bijection a ↦ (a/n, a%n) with inverse (q,r) ↦ q·n + r",
+      "Equiv.hasSum_iff: a series transported along an equivalence has the same sum (HasSum (f ∘ e) a ↔ HasSum f a)",
+      "HasSum.prod_fiberwise: a HasSum on β × γ regroups to a HasSum on β whose terms are the fiber sums (needs RegularSpace, supplied by the topological-group structure)",
+      "Summable.comp_injective: summability descends along an injective reindexing (needs a complete uniform group)",
+      "hasSum_fintype (finite fibers), Equiv.prodComm (coordinate swap), Fin.sum_univ_eq_sum_range, HasSum.unique (needs T2Space)",
+      "Parent: geometric-series-oq-09-oq-01-oq-01 (reindexing of the geometric series); grandparent geometric-series-oq-09-oq-01 (geometric multisection via closed forms)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.divModEquiv",
+        "description": "The bijection ℕ ≃ ℕ × Fin n, a ↦ (a/n, a%n), with inverse (q,r) ↦ q·n + r (left/right inverses from Nat.div_add_mod). The index relabelling along which an arbitrary summable family is transported.",
+        "module": "Mathlib.Logic.Equiv.Fin.Basic"
+      },
+      {
+        "theorem": "Equiv.hasSum_iff",
+        "description": "HasSum (f ∘ e) a ↔ HasSum f a for an equivalence e: a series and its reindexing have the same sum. The engine of the reindexing theorem, applied with e = (Nat.divModEquiv q).symm and e = Equiv.prodComm.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Group"
+      },
+      {
+        "theorem": "HasSum.prod_fiberwise",
+        "description": "If f : β × γ → α has sum a and each fiber {b}×γ sums to g b, then g has sum a. Used twice: finite fibers over Fin q (block regrouping) and ℕ fibers after Equiv.prodComm (residue multisection).",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Constructions"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "If f is summable and i is injective then f ∘ i is summable. Reduces the summability of each residue subseries n ↦ f(q·n+a) to the injectivity of n ↦ q·n+a; lives in the complete-uniform-group section.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Group"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+      "question": "Quantify the multisection two-sidedly: for f : ℕ → M with all q residue subseries n ↦ f(q·n+a) summable, is f itself necessarily summable (a converse to the multisection), and does ∑_{a<q} ∑_n f(q·n+a) then equal ∑_m f m even when M is only Hausdorff (not complete)? Identify the minimal hypotheses under which residue-subseries summability is equivalent to summability of f.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-09-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent reindexes the GEOMETRIC series ∑ r^m along Nat.divModEquiv (over a complete normed field), recovering the q-fold splitting and the recombination as Fubini regroupings of that specific two-dimensional series. This entry answers the parent's open question by removing the geometric closed forms entirely: the same reindexing and fiberwise multisection hold for an ARBITRARY summable family f : ℕ → M in a complete Hausdorff uniform abelian group, with residue-subseries summability supplied by injectivity (Summable.comp_injective) rather than by a geometric formula."
+    },
+    {
+      "targetId": "geometric-series-oq-09-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent. The grandparent computed the geometric multisection ∑_n r^(q·n+a) = r^a/(1−r^q) and the recombination ∑_{a<q}(subseries_a) = 1/(1−r) from closed forms and the factorisation 1−r^q = (1−r)·∑_{a<q} r^a. This entry shows that recombination is the q=anything, f=arbitrary case of a single Fubini identity, with no factorisation or closed form involved."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Logic.Equiv.Fin.Basic (Nat.divModEquiv)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the bijection ℕ ≃ ℕ × Fin n, a ↦ (a/n, a%n), along which an arbitrary summable family is transported."
+    },
+    {
+      "title": "Mathlib4: Topology.Algebra.InfiniteSum.Group (Summable.comp_injective, Equiv.hasSum_iff)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provides reindexing of HasSum along equivalences and the descent of summability along injections in a complete uniform group — the two engines of the abstract multisection."
+    },
+    {
+      "title": "Concrete Mathematics (multisection of power series)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the q-section of a power series into q subseries indexed by residue classes mod q."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For any summable family f : ℕ → M valued in a complete Hausdorff uniform abelian group and modulus q ≠ 0, the q-fold residue multisection is established as a genuine reindexing-plus-Fubini, with no geometric closed forms: transporting HasSum f S along ℕ ≃ ℕ × Fin q (Nat.divModEquiv) gives hasSum_reindex: HasSum (fun (p : ℕ × Fin q) => f(q·p.1 + p.2)) S. Fiberwise summation (HasSum.prod_fiberwise) regroups two ways — by block index n (finite inner sums, hasSum_block, hypothesis-free) and by residue a (infinite subseries, hasSum_multisection, with each subseries summable via Summable.comp_injective on the injective n ↦ q·n+a). The multisection identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m (tsum_multisection) then holds for EVERY summable f — the characterisation the parent's open question requested. 163 lines, 10 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Answers geometric-series-oq-09-oq-01-oq-01's open question: the multisection viewpoint is intrinsic to summability, not to the geometric closed forms. The analytic content reduces to the counting bijection q·(m/q)+m%q = m plus the injectivity of n ↦ q·n+a, after which discrete Fubini does all the work. The block regrouping needs no hypothesis at all (finite fibers); only the infinite-fiber residue regrouping consumes summability, and that minimally. This is the abstract form of the even/odd Nat.divModEquiv 2 mechanism Mathlib uses for the cos/sin Taylor series.",
+    "openQuestions": [
+      "Establish a two-sided multisection: when all q residue subseries are summable, is f summable (converse), and what are the minimal separation/completeness hypotheses for ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m?"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question of **geometric-series-oq-09-oq-01-oq-01**: extend the `Nat.divModEquiv` reindexing viewpoint from the *geometric* series to an **arbitrary summable family** `f : ℕ → M`, and characterise when the residue multisection holds.

For any `HasSum f S` in a complete Hausdorff uniform abelian group `M` and modulus `q ≠ 0`:

- **Reindexing** (`hasSum_reindex`): `HasSum (fun p : ℕ × Fin q => f (q·p.1 + p.2)) S`, by transporting along `ℕ ≃ ℕ × Fin q`, `m ↦ (m/q, m%q)` via `Equiv.hasSum_iff`.
- **Block regrouping** (`hasSum_block`): `HasSum (fun n => ∑_{a<q} f (q·n+a)) S` — **no hypothesis** beyond `HasSum f S` (finite `Fin q` fibers).
- **Residue multisection** (`hasSum_multisection`, `tsum_multisection`): `∑_{a<q} ∑_n f (q·n+a) = ∑_m f m`, holding **unconditionally for every summable `f`** as a discrete-Fubini (`HasSum.prod_fiberwise`) consequence.

**The characterisation** the open question asked for: the residue regrouping holds for *every* summable `f`. The only nontrivial input — summability of each residue subseries `n ↦ f (q·n+a)` — is automatic, since `n ↦ q·n+a` is injective and summability descends along injections (`Summable.comp_injective`). No normed/Banach or closed-form structure is used; this strictly generalises the parent's normed-field geometric case.

Includes the `q=2` even/odd specialisation (`tsum_even_add_odd`: `∑_n f(2n) + ∑_n f(2n+1) = ∑_m f m`) and a concrete check on `(1/2)^n`.

## Verification

- `proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ01.lean` — 163 lines, 10 theorems, 0 definitions
- **0 sorries, 0 axioms** (`#print axioms`: only `propext`, `Classical.choice`, `Quot.sound`)
- Compiles cleanly via `lake env lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)