### PR TITLE
Enrich: Hall's marriage theorem / SDR (hall-marriage-theorem-oq-01)

### DIFF
--- a/src/data/proofs/hall-marriage-theorem-oq-01/annotations.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "hall-marriage-theorem-oq-01",
+    "range": { "startLine": 3, "endLine": 51 },
+    "type": "context",
+    "title": "Hall's Theorem and Its Two Practical Faces",
+    "content": "The docstring sets up the set-system (transversal) form of Hall's marriage theorem: for a family $t : \\iota \\to \\mathrm{Finset}\\,\\alpha$, a system of distinct representatives (SDR) — an injective $f$ with $f\\,i \\in t\\,i$ — exists iff Hall's condition $\\#s \\le \\#(s.\\mathrm{biUnion}\\,t)$ holds for every sub-family $s$. Mathlib proves only the biconditional (via Rado's compactness). This entry adds the two faces used in practice: the necessity direction proved *directly* by counting (no compactness, no finiteness of $\\iota$), and the deficiency obstruction certifying non-existence, plus concrete axiom-free witnesses.",
+    "mathContext": "SDR exists $\\iff \\forall s : \\mathrm{Finset}\\,\\iota,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t)$ (Hall's condition).",
+    "significance": "context",
+    "relatedConcepts": ["Hall's marriage theorem", "system of distinct representatives", "transversal", "bipartite matching"],
+    "prerequisites": ["combinatorics", "finite sets", "injections"]
+  },
+  {
+    "id": "ann-biconditional",
+    "proofId": "hall-marriage-theorem-oq-01",
+    "range": { "startLine": 57, "endLine": 73 },
+    "type": "theorem",
+    "title": "The Biconditional and Sufficiency Direction",
+    "content": "`hall_marriage_iff` re-exports Mathlib's `Finset.all_card_le_biUnion_card_iff_exists_injective` — the full Hall biconditional, foundation for the refinements. `exists_sdr_of_hall` extracts the substantive *sufficiency* half (Hall's condition $\\Rightarrow$ an SDR exists), which relies on Mathlib's Rado compactness argument over the finite case. These are the re-export layer; the genuine new content is the necessity direction and deficiency obstruction below.",
+    "mathContext": "$(\\forall s,\\ \\#s \\le \\#(s.\\mathrm{biUnion}\\,t)) \\Rightarrow \\exists f\\ \\text{injective},\\ \\forall x,\\ f\\,x \\in t\\,x.$",
+    "significance": "supporting",
+    "relatedConcepts": ["all_card_le_biUnion_card_iff_exists_injective", "Rado compactness", "re-export"],
+    "prerequisites": ["biconditional statements"]
+  },
+  {
+    "id": "ann-necessity",
+    "proofId": "hall-marriage-theorem-oq-01",
+    "range": { "startLine": 75, "endLine": 96 },
+    "type": "technique",
+    "title": "Necessity by Direct Counting — No Compactness",
+    "content": "`hall_condition_of_sdr` proves the easy direction *directly*, not by extracting it from the biconditional: an injective transversal $f$ forces $\\#s = \\#(s.\\mathrm{image}\\,f) \\le \\#(s.\\mathrm{biUnion}\\,t)$. The `calc` uses `card_image_of_injective` for the equality and `card_le_card` on the inclusion $s.\\mathrm{image}\\,f \\subseteq s.\\mathrm{biUnion}\\,t$ (each $f\\,x \\in t\\,x$, witnessed by `mem_biUnion`). Crucially this needs *only* injectivity and membership — no finiteness of $\\iota$, no compactness — so it holds for an arbitrary (possibly infinite) index type, unlike sufficiency. `hall_condition_of_exists_sdr` is the existential repackaging.",
+    "mathContext": "$f$ injective, $f\\,x \\in t\\,x \\Rightarrow \\#s = \\#(s.\\mathrm{image}\\,f) \\le \\#(s.\\mathrm{biUnion}\\,t).$",
+    "significance": "key",
+    "relatedConcepts": ["card_image_of_injective", "card_le_card", "mem_biUnion", "infinite index type"],
+    "prerequisites": ["cardinality of images", "subset cardinality"]
+  },
+  {
+    "id": "ann-deficiency",
+    "proofId": "hall-marriage-theorem-oq-01",
+    "range": { "startLine": 98, "endLine": 105 },
+    "type": "insight",
+    "title": "The Deficiency Obstruction: Certifying Impossibility",
+    "content": "`no_sdr_of_deficiency` is the workhorse for proving a matching impossible: a *deficient* sub-family — one with $\\#(s.\\mathrm{biUnion}\\,t) < \\#s$, more members than available representatives — rules out *any* SDR. It is the exact contrapositive of necessity: a transversal would force $\\#s \\le \\#(s.\\mathrm{biUnion}\\,t)$, contradicting the deficiency. In applications one rarely exhibits a transversal directly; one points to a deficient sub-family, and this lemma packages that reasoning. Mathlib does not isolate this form.",
+    "mathContext": "$\\#(s.\\mathrm{biUnion}\\,t) < \\#s \\Rightarrow \\neg\\,\\exists f\\ \\text{injective transversal}.$",
+    "significance": "key",
+    "relatedConcepts": ["deficiency version", "contrapositive", "certificate of impossibility", "pigeonhole"],
+    "prerequisites": ["contraposition", "Hall's condition"]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "hall-marriage-theorem-oq-01",
+    "range": { "startLine": 107, "endLine": 135 },
+    "type": "concept",
+    "title": "Concrete Axiom-Free Fin 3 Witnesses",
+    "content": "Three explicit instances confirm both directions by kernel `decide` (no `native_decide`, so axiom-free). `hall_satisfiable_example`: the family $\\{0,1\\},\\{1,2\\},\\{0,2\\}$ over $\\mathrm{Fin}\\,3$ admits the transversal $![0,1,2]$ (decide searches the $3^3$ maps). `hall_violating_deficiency`: for $t_0 = t_1 = t_2 = \\{0,1\\}$, $\\mathrm{univ}$ covers only $\\{0,1\\}$, so $\\#(\\mathrm{univ}.\\mathrm{biUnion}\\,t) = 2 < 3$. `hall_violating_example`: the same family has no SDR — established not by brute force but by feeding the deficient $\\mathrm{univ}$ to `no_sdr_of_deficiency`, exactly how Hall's theorem is used to rule out a matching. This is the smallest pigeonhole obstruction: three suitors, two values.",
+    "mathContext": "$\\{0,1\\},\\{1,2\\},\\{0,2\\} \\to$ SDR $![0,1,2]$; $\\{0,1\\}^{\\times 3} \\to$ deficient $\\mathrm{univ}$, no SDR.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "Matrix.cons (![…])", "pigeonhole obstruction", "axiom integrity"],
+    "prerequisites": ["decidability in Lean", "Fin n"]
+  }
+]

--- a/src/data/proofs/hall-marriage-theorem-oq-01/index.ts
+++ b/src/data/proofs/hall-marriage-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HallMarriageTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hallMarriageTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hallMarriageTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hallMarriageTheoremOQ01Data: ProofData = {
+  proof: hallMarriageTheoremOQ01Proof,
+  annotations: hallMarriageTheoremOQ01Annotations,
+}

--- a/src/data/proofs/hall-marriage-theorem-oq-01/meta.json
+++ b/src/data/proofs/hall-marriage-theorem-oq-01/meta.json
@@ -95,8 +95,51 @@
   ],
   "crossReferences": [
     {
-      "id": "halls-theorem-oq-01",
-      "reason": "The bipartite-graph matching formulation of Hall's theorem (SimpleGraph.IsBipartiteWith / IsMatching). This entry gives the dual set-system / transversal (SDR) formulation over a Finset family — the original 'marriage' statement — on a different Mathlib backbone."
+      "targetId": "halls-theorem-oq-01",
+      "relationship": "related",
+      "description": "The bipartite-graph matching formulation of Hall's theorem (SimpleGraph.IsBipartiteWith / IsMatching). This entry gives the dual set-system / transversal (SDR) formulation over a Finset family — the original 'marriage' statement — on a different Mathlib backbone."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Setup: SDRs and Hall's Condition",
+      "startLine": 3,
+      "endLine": 51,
+      "summary": "Module docstring: the set-system (transversal) form of Hall's theorem, Mathlib's biconditional via Rado compactness, and the two practical faces this file adds (direct necessity, deficiency obstruction) plus axiom-free witnesses.",
+      "mathContext": "SDR exists ⟺ ∀ s, #s ≤ #(s.biUnion t)."
+    },
+    {
+      "id": "biconditional",
+      "title": "Biconditional and Sufficiency",
+      "startLine": 57,
+      "endLine": 73,
+      "summary": "hall_marriage_iff (re-export of Finset.all_card_le_biUnion_card_iff_exists_injective) and exists_sdr_of_hall (the sufficiency half, resting on Mathlib's compactness argument).",
+      "mathContext": "Hall's condition ⟹ an injective transversal exists."
+    },
+    {
+      "id": "necessity",
+      "title": "Necessity by Direct Counting",
+      "startLine": 75,
+      "endLine": 96,
+      "summary": "hall_condition_of_sdr proves the easy direction directly via #s = #(s.image f) ≤ #(s.biUnion t), using only injectivity — no finiteness of ι, no compactness; hall_condition_of_exists_sdr is the existential form.",
+      "mathContext": "Injective transversal ⟹ #s ≤ #(s.biUnion t) for every sub-family."
+    },
+    {
+      "id": "deficiency",
+      "title": "The Deficiency Obstruction",
+      "startLine": 98,
+      "endLine": 105,
+      "summary": "no_sdr_of_deficiency: a deficient sub-family (#(s.biUnion t) < #s) certifies that no SDR exists — the contrapositive of necessity and the form used to rule out matchings.",
+      "mathContext": "#(s.biUnion t) < #s ⟹ no transversal."
+    },
+    {
+      "id": "witnesses",
+      "title": "Concrete Fin 3 Witnesses",
+      "startLine": 107,
+      "endLine": 135,
+      "summary": "hall_satisfiable_example (the family {0,1},{1,2},{0,2} admits ![0,1,2]), hall_violating_deficiency (#(univ.biUnion t)=2<3 for {0,1}³), and hall_violating_example (no SDR, via the deficiency theorem) — all by kernel decide, axiom-free.",
+      "mathContext": "Smallest pigeonhole: three indices competing for two values."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `hall-marriage-theorem-oq-01` (quality 30, pass 0). Verified against current main: only `meta.json` existed (no annotations.json/index.ts).

## What changed
- **Created `index.ts`** — was missing, so the page would 404 on the live site.
- **Created `annotations.json`** — 5 substantive annotations covering the header, the biconditional + sufficiency re-export, the direct counting necessity proof (compactness-free), the deficiency obstruction (`no_sdr_of_deficiency`), and the axiom-free Fin 3 witnesses.
- **Added the missing `sections` array** — 5 sections spanning the full Lean file.
- **Fixed malformed `crossReferences`** — used `{id, reason}`, so `targetId` read `null` in the UI. Converted to canonical `{targetId, relationship, description}` for `halls-theorem-oq-01` (confirmed present; the distinct bipartite-graph formulation).

## Verification
- `json.load` validates both JSON files; `tsc -b` passes; annotation build reports no errors for this entry.
- Axiom/status unchanged: verified / mathlib / 0-axiom (kernel `decide`, no `native_decide`).