### PR TITLE
Enrich: Pell Brahmagupta composition & group structure (pell-equation-oq-06-oq-06)

### DIFF
--- a/src/data/proofs/pell-equation-oq-06-oq-06/index.ts
+++ b/src/data/proofs/pell-equation-oq-06-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ06OQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOQ06OQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOQ06OQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOQ06OQ06Data: ProofData = {
+  proof: pellEquationOQ06OQ06Proof,
+  annotations: pellEquationOQ06OQ06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-06-oq-06` (quality 30, pass 0). Verified against current main: only `meta.json` existed (no annotations.json/index.ts).

## What changed
- **Created `index.ts`** — was missing, so the page would 404 on the live site.
- **Created `annotations.json`** — 7 substantive annotations covering the header, the compose=multiplication-in-ℤ[√2] bridge, the Brahmagupta–Fibonacci identity (multiplicativity), the commutative-monoid laws, unit-group closure, the sign law (negative⊛negative=positive) + parent chain, and the kernel-decide sanity checks.
- **Added the missing `conclusion`** (summary, implications, 3 open questions).

## Verification
- `json.load` validates both JSON files; `tsc -b` passes; annotation build reports no errors for this entry (the 7 sections already present cover the full file).
- Axiom/status unchanged: verified / 0-axiom (kernel `decide`, no `native_decide`).