### PR TITLE
Add missing index.ts for automorphic-number-oq-01-oq-03

### DIFF
--- a/src/data/proofs/automorphic-number-oq-01-oq-03/index.ts
+++ b/src/data/proofs/automorphic-number-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AutomorphicNumberOQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const automorphicNumberOQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const automorphicNumberOQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const automorphicNumberOQ01OQ03Data: ProofData = {
+  proof: automorphicNumberOQ01OQ03Proof,
+  annotations: automorphicNumberOQ01OQ03Annotations,
+}


### PR DESCRIPTION
The entry's `meta.json` and `annotations.json` are already present and enriched, but **no `index.ts` was added** — so the proof page renders 'proof not found' on the live site (Vite's `import.meta.glob` cannot discover the proof without it). This PR adds the standard entry point.

index.ts-only, no conflict with existing content.

## Verification
- `tsc -b` passes; follows the standard gallery index.ts template.