### PR TITLE
research(cayleys-theorem-oq-01-oq-01-oq-02-oq-02): centralizer of left-regular image = right-regular image, equal iff abelian [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -627,6 +627,7 @@ import Proofs.CayleyMengerHeronOQ05
 import Proofs.CayleysTheoremOQ01
 import Proofs.CayleysTheoremOQ01OQ01
 import Proofs.CayleysTheoremOQ01OQ01OQ02
+import Proofs.CayleysTheoremOQ01OQ01OQ02OQ02
 import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01

--- a/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean
@@ -1,0 +1,185 @@
+/-
+Proof: The centralizer of the left-regular image is the right-regular image,
+and the two regular representations have equal image iff the group is abelian.
+Research: cayleys-theorem-oq-01-oq-01-oq-02-oq-02
+
+Open question (from the `cayleys-theorem-oq-01-oq-01-oq-02` chain):
+  Cayley's theorem embeds a group `G` into `Equiv.Perm G` as the *left-regular*
+  representation `L g : x ↦ g * x`.  Identify the centralizer of `L(G)` inside
+  the full symmetric group `Equiv.Perm G`, and characterise exactly when the
+  left- and right-regular representations coincide.
+
+This file works directly over `Equiv.Perm G` for an arbitrary group `G` (no
+finiteness assumption — strictly more general than the parent's `Fin n` setting).
+We define the two regular representations as genuine group homomorphisms:
+
+* **Left regular** `leftReg G : G →* Equiv.Perm G`, `leftReg G g = Equiv.mulLeft g`,
+  i.e. `x ↦ g * x`.  Since `Equiv.mulLeft (a*b) = Equiv.mulLeft a * Equiv.mulLeft b`
+  this is a homomorphism on the nose.
+* **Right regular** `rightReg G : G →* Equiv.Perm G`, `rightReg G g = Equiv.mulRight g⁻¹`,
+  i.e. `x ↦ x * g⁻¹`.  The inverse is forced: plain right multiplication is an
+  *anti*-homomorphism (`mulRight (a*b) = mulRight b * mulRight a`), so inverting
+  the argument repairs the order and makes `rightReg` a homomorphism.
+
+Main results:
+
+* `centralizer_leftReg_range`:
+    `Subgroup.centralizer ↑(leftReg G).range = (rightReg G).range`.
+  A permutation commutes with every left translation iff it is a right
+  translation.  The forward direction is the classical "evaluate at `1`" trick:
+  if `σ` commutes with all `L g`, then `σ x = x * σ 1`, so `σ = mulRight (σ 1)`.
+* `centralizer_rightReg_range`: the mirror statement, with the roles swapped.
+* `leftReg_range_eq_rightReg_range_iff`:
+    `(leftReg G).range = (rightReg G).range ↔ ∀ x y : G, x * y = y * x`.
+  The two regular images coincide exactly when `G` is abelian.
+
+Together these say: the centralizer of the regular representation is the *other*
+regular representation (the structural fact underlying the holomorph of `G`),
+and the two only collapse onto each other in the commutative case.  We also
+record that both representations are faithful (`leftReg_injective`,
+`rightReg_injective`), so the abelian characterisation is genuinely about `G`.
+-/
+
+import Mathlib.GroupTheory.Subgroup.Centralizer
+import Mathlib.GroupTheory.Perm.Basic
+import Mathlib.Algebra.Group.End
+import Mathlib.Algebra.Group.Units.Equiv
+import Mathlib.Tactic
+
+namespace CayleyCentralizer
+
+variable {G : Type*} [Group G]
+
+/-- The **left-regular representation** `g ↦ (x ↦ g * x)` as a group
+homomorphism into the symmetric group on `G`.  It is a homomorphism because
+`Equiv.mulLeft` turns multiplication into composition. -/
+def leftReg (G : Type*) [Group G] : G →* Equiv.Perm G where
+  toFun := Equiv.mulLeft
+  map_one' := Equiv.mulLeft_one
+  map_mul' := Equiv.mulLeft_mul
+
+/-- The **right-regular representation** `g ↦ (x ↦ x * g⁻¹)` as a group
+homomorphism.  The inverse on the argument is what makes it a homomorphism:
+without it, `Equiv.mulRight` is an anti-homomorphism. -/
+def rightReg (G : Type*) [Group G] : G →* Equiv.Perm G where
+  toFun g := Equiv.mulRight g⁻¹
+  map_one' := by rw [inv_one, Equiv.mulRight_one]
+  map_mul' a b := by rw [mul_inv_rev, Equiv.mulRight_mul]
+
+@[simp] theorem leftReg_apply (g x : G) : leftReg G g x = g * x := rfl
+
+@[simp] theorem rightReg_apply (g x : G) : rightReg G g x = x * g⁻¹ := rfl
+
+/-- The left-regular representation is faithful. -/
+theorem leftReg_injective : Function.Injective (leftReg G) := by
+  intro a b hab
+  have h := DFunLike.congr_fun hab 1
+  rwa [leftReg_apply, leftReg_apply, mul_one, mul_one] at h
+
+/-- The right-regular representation is faithful. -/
+theorem rightReg_injective : Function.Injective (rightReg G) := by
+  intro a b hab
+  have h := DFunLike.congr_fun hab 1
+  rw [rightReg_apply, rightReg_apply, one_mul, one_mul] at h
+  exact inv_injective h
+
+/-- **Centralizer of the left-regular image.**  A permutation of `G` commutes
+with every left translation iff it is itself a right translation.  Hence the
+centralizer of `L(G)` inside `Equiv.Perm G` is exactly `R(G)`. -/
+theorem centralizer_leftReg_range :
+    Subgroup.centralizer (↑(leftReg G).range : Set (Equiv.Perm G)) = (rightReg G).range := by
+  apply le_antisymm
+  · -- A centralizing `σ` satisfies `σ x = x * σ 1`, so `σ = rightReg (σ 1)⁻¹`.
+    intro σ hσ
+    rw [Subgroup.mem_centralizer_iff] at hσ
+    refine ⟨(σ 1)⁻¹, ?_⟩
+    ext x
+    rw [rightReg_apply, inv_inv]
+    have hcomm := hσ (leftReg G x) ⟨x, rfl⟩
+    have h := DFunLike.congr_fun hcomm 1
+    rw [Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, leftReg_apply, leftReg_apply, mul_one] at h
+    exact h
+  · -- Right translations commute with left translations by associativity.
+    rintro σ ⟨g, rfl⟩
+    rw [Subgroup.mem_centralizer_iff]
+    rintro h ⟨g', rfl⟩
+    ext x
+    rw [Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, leftReg_apply, rightReg_apply,
+      rightReg_apply, leftReg_apply, mul_assoc]
+
+/-- **Centralizer of the right-regular image** — the mirror statement.  A
+permutation commutes with every right translation iff it is a left translation. -/
+theorem centralizer_rightReg_range :
+    Subgroup.centralizer (↑(rightReg G).range : Set (Equiv.Perm G)) = (leftReg G).range := by
+  apply le_antisymm
+  · -- A centralizing `σ` satisfies `σ x = σ 1 * x`, so `σ = leftReg (σ 1)`.
+    intro σ hσ
+    rw [Subgroup.mem_centralizer_iff] at hσ
+    refine ⟨σ 1, ?_⟩
+    ext x
+    rw [leftReg_apply]
+    have hcomm := hσ (rightReg G x⁻¹) ⟨x⁻¹, rfl⟩
+    have h := DFunLike.congr_fun hcomm 1
+    rw [Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, rightReg_apply, rightReg_apply,
+      inv_inv, one_mul] at h
+    exact h
+  · -- Left translations commute with right translations by associativity.
+    rintro σ ⟨g, rfl⟩
+    rw [Subgroup.mem_centralizer_iff]
+    rintro h ⟨g', rfl⟩
+    ext x
+    rw [Equiv.Perm.mul_apply, Equiv.Perm.mul_apply, rightReg_apply, leftReg_apply,
+      leftReg_apply, rightReg_apply, mul_assoc]
+
+/-- **Left and right regular images coincide iff the group is abelian.**  The
+two regular representations of `G` have the same image inside `Equiv.Perm G`
+exactly when `G` is commutative. -/
+theorem leftReg_range_eq_rightReg_range_iff :
+    (leftReg G).range = (rightReg G).range ↔ ∀ x y : G, x * y = y * x := by
+  constructor
+  · intro hEq x y
+    -- `leftReg x` lies in `rightReg`'s range, forcing `mulLeft x = mulRight x`.
+    have hmem : (leftReg G) x ∈ (rightReg G).range := by rw [← hEq]; exact ⟨x, rfl⟩
+    obtain ⟨z, hz⟩ := hmem
+    -- Evaluate at `1`: `z⁻¹ = x`, i.e. `z = x⁻¹`.
+    have h1 := DFunLike.congr_fun hz 1
+    rw [rightReg_apply, leftReg_apply, one_mul, mul_one] at h1
+    have hzx : z = x⁻¹ := by rw [← h1, inv_inv]
+    -- Evaluate at `y`: `y * x = x * y`.
+    have hy := DFunLike.congr_fun hz y
+    rw [rightReg_apply, leftReg_apply, hzx, inv_inv] at hy
+    exact hy.symm
+  · intro hcomm
+    apply le_antisymm
+    · rintro _ ⟨g, rfl⟩
+      refine ⟨g⁻¹, ?_⟩
+      ext x
+      rw [rightReg_apply, inv_inv, leftReg_apply]
+      exact (hcomm g x).symm
+    · rintro _ ⟨g, rfl⟩
+      refine ⟨g⁻¹, ?_⟩
+      ext x
+      rw [leftReg_apply, rightReg_apply]
+      exact hcomm g⁻¹ x
+
+/-- Consequence: the left-regular image is abelian (as a subgroup of `Equiv.Perm G`)
+iff `G` is abelian — it sits inside its own centralizer exactly when the two
+regular images coincide. -/
+theorem leftReg_range_le_centralizer_iff :
+    (leftReg G).range ≤ Subgroup.centralizer (↑(leftReg G).range : Set (Equiv.Perm G)) ↔
+      ∀ x y : G, x * y = y * x := by
+  rw [centralizer_leftReg_range]
+  constructor
+  · intro hle x y
+    have hmem : (leftReg G) x ∈ (rightReg G).range := hle ⟨x, rfl⟩
+    obtain ⟨z, hz⟩ := hmem
+    have h1 := DFunLike.congr_fun hz 1
+    rw [rightReg_apply, leftReg_apply, one_mul, mul_one] at h1
+    have hzx : z = x⁻¹ := by rw [← h1, inv_inv]
+    have hy := DFunLike.congr_fun hz y
+    rw [rightReg_apply, leftReg_apply, hzx, inv_inv] at hy
+    exact hy.symm
+  · intro hcomm
+    rw [(leftReg_range_eq_rightReg_range_iff).mpr hcomm]
+
+end CayleyCentralizer

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02",
+  "title": "The Centralizer of the Left-Regular Image is the Right-Regular Image (equal iff abelian)",
+  "slug": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02",
+  "description": "Cayley's theorem embeds a group G into Equiv.Perm G as its left-regular representation. This entry identifies the centralizer of that image inside the full symmetric group and characterises exactly when the left- and right-regular representations coincide, working over an arbitrary group G with no finiteness assumption (strictly more general than the parent's Fin n setting). The two regular representations are defined as honest group homomorphisms: leftReg G : G →* Equiv.Perm G with leftReg G g = Equiv.mulLeft g (x ↦ g * x), a homomorphism because Equiv.mulLeft (a*b) = Equiv.mulLeft a * Equiv.mulLeft b; and rightReg G : G →* Equiv.Perm G with rightReg G g = Equiv.mulRight g⁻¹ (x ↦ x * g⁻¹), where the inverse on the argument is forced — plain right multiplication is an anti-homomorphism (mulRight (a*b) = mulRight b * mulRight a), and inverting repairs the order. The main result centralizer_leftReg_range proves Subgroup.centralizer ↑(leftReg G).range = (rightReg G).range: a permutation commutes with every left translation iff it is a right translation. The forward inclusion is the classical evaluate-at-1 trick — if σ commutes with all leftReg g then σ x = x * σ 1, so σ = mulRight (σ 1); the reverse is associativity. The mirror statement centralizer_rightReg_range swaps the roles. Finally leftReg_range_eq_rightReg_range_iff shows (leftReg G).range = (rightReg G).range ↔ ∀ x y, x * y = y * x: the two regular images coincide exactly when G is abelian. Both representations are proved faithful (leftReg_injective, rightReg_injective), so the abelian characterisation is genuinely about G, and leftReg_range_le_centralizer_iff records that the left-regular image lies in its own centralizer iff G is abelian. Together these formalize the structural fact underlying the holomorph of G: the centralizer of the regular representation is the other regular representation.",
+  "meta": {
+    "author": "Classical (regular representations / holomorph); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Regular_representation",
+    "date": "1854",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "permutation-group",
+      "regular-representation",
+      "centralizer",
+      "holomorph",
+      "symmetric-group",
+      "abelian-group",
+      "group-homomorphism",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Subgroup.mem_centralizer_iff",
+        "description": "g ∈ Subgroup.centralizer s ↔ ∀ h ∈ s, h * g = g * h — the working characterisation of the centralizer of a set of permutations, used in both inclusions of the two centralizer theorems",
+        "module": "Mathlib.GroupTheory.Subgroup.Centralizer"
+      },
+      {
+        "theorem": "Equiv.mulLeft_mul",
+        "description": "Equiv.mulLeft (a * b) = Equiv.mulLeft a * Equiv.mulLeft b — turns left multiplication into composition, making leftReg a group homomorphism on the nose",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Equiv.mulRight_mul",
+        "description": "Equiv.mulRight (a * b) = Equiv.mulRight b * Equiv.mulRight a — the anti-homomorphism law for right multiplication; combined with mul_inv_rev it makes g ↦ mulRight g⁻¹ a homomorphism",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "Equiv.Perm.mul_apply",
+        "description": "(f * g) x = f (g x) for permutations — used after evaluating the commutativity equation at a single point to expose the left/right translation formulas",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "DFunLike.congr_fun",
+        "description": "evaluates an equality of permutations at a point — the 'evaluate at 1' (and at a general point) device that drives every forward inclusion",
+        "module": "Mathlib.Data.FunLike.Basic"
+      },
+      {
+        "theorem": "MonoidHom.mem_range",
+        "description": "σ ∈ f.range ↔ ∃ g, f g = σ — extracts and supplies the group element witnessing membership in a regular-representation range",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      }
+    ],
+    "originalContributions": [
+      "leftReg / rightReg: the left- and right-regular representations packaged as genuine group homomorphisms G →* Equiv.Perm G over an arbitrary group G, with rightReg g = Equiv.mulRight g⁻¹ chosen so right multiplication becomes a homomorphism rather than an anti-homomorphism",
+      "centralizer_leftReg_range: Subgroup.centralizer ↑(leftReg G).range = (rightReg G).range — a permutation commutes with every left translation iff it is a right translation (forward direction via σ x = x * σ 1, i.e. σ = mulRight (σ 1))",
+      "centralizer_rightReg_range: the mirror identity Subgroup.centralizer ↑(rightReg G).range = (leftReg G).range",
+      "leftReg_range_eq_rightReg_range_iff: (leftReg G).range = (rightReg G).range ↔ ∀ x y, x * y = y * x — the two regular images coincide exactly when G is abelian",
+      "leftReg_range_le_centralizer_iff: the left-regular image lies inside its own centralizer iff G is abelian, recovering 'self-centralizing ⟺ commutative' from the centralizer identity",
+      "leftReg_injective / rightReg_injective: both regular representations are faithful, so the abelian characterisation is a statement about G itself"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 185,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used. Holds for an arbitrary (possibly infinite) group G.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem realises an abstract group G as the left-regular permutation group L(G) ≤ Sym(G), acting on G by left multiplication. Sym(G) also carries the right-regular representation R(G), acting by right multiplication. A classical structural fact ties them together: inside the full symmetric group each is the centralizer of the other. This is the algebraic heart of the holomorph G ⋊ Aut(G): the normalizer of L(G) in Sym(G) is the holomorph, and its centralizer is R(G). Because left and right multiplication commute by associativity, R(G) ⊆ C(L(G)); the reverse — that nothing else commutes with all left translations — is exactly the evaluate-at-1 rigidity that pins a centralizing permutation down to a single right translation. The two regular images collapse onto each other precisely in the commutative case, where left and right multiplication agree.",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01-oq-01-oq-02, second follow-up)**: Relate the regular subgroup to its centralizer in the symmetric group — show the centralizer of the left-regular image is the right-regular image, and that the two coincide iff G is abelian.\n\n**Result**: centralizer_leftReg_range (centralizer of L(G) is R(G)), its mirror centralizer_rightReg_range, and leftReg_range_eq_rightReg_range_iff (equal images ⟺ G abelian), with both representations proved faithful.",
+    "text": "Let G be any group and embed it into Equiv.Perm G via the left-regular representation L g : x ↦ g * x and the right-regular representation R g : x ↦ x * g⁻¹ (the inverse making R a homomorphism). Then the centralizer of the image L(G) inside the symmetric group is exactly the image R(G), and symmetrically the centralizer of R(G) is L(G). The two images are equal as subgroups of Equiv.Perm G if and only if G is abelian.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The representations as homomorphisms. leftReg uses Equiv.mulLeft directly: mulLeft (a*b) = mulLeft a * mulLeft b. rightReg sends g ↦ mulRight g⁻¹; since mulRight is an anti-homomorphism, (a*b)⁻¹ = b⁻¹*a⁻¹ together with mulRight_mul gives mulRight (a*b)⁻¹ = mulRight a⁻¹ * mulRight b⁻¹, the homomorphism law.\n2. R(G) ⊆ C(L(G)) (and the analogous inclusions). For any g, g', the permutations mulLeft g' and mulRight g⁻¹ commute: applied at x both sides equal g' * x * g⁻¹ by associativity (mul_assoc).\n3. C(L(G)) ⊆ R(G). Let σ commute with every leftReg g. Evaluating the equation leftReg x * σ = σ * leftReg x at the point 1 (via DFunLike.congr_fun and Equiv.Perm.mul_apply) gives x * σ 1 = σ x for all x. Hence σ agrees pointwise with mulRight (σ 1), so σ = rightReg (σ 1)⁻¹ ∈ R(G).\n4. The mirror statement centralizer_rightReg_range is proved the same way, evaluating at 1 the commutativity with rightReg x⁻¹ to get σ x = σ 1 * x, so σ = leftReg (σ 1).\n5. Abelian characterisation. If the images are equal, leftReg x = rightReg z for some z; evaluating at 1 forces z = x⁻¹, and then evaluating at a general y gives y * x = x * y, so G is abelian. Conversely if G is abelian then mulLeft g = mulRight g, giving leftReg g = rightReg g⁻¹ and equal ranges. Faithfulness of both representations (evaluate at 1) makes this an honest statement about G.",
+    "keyInsights": [
+      "**The inverse in rightReg is not cosmetic.** Plain right multiplication is an anti-homomorphism, so the right-regular representation must use g ↦ mulRight g⁻¹ to be a genuine group homomorphism — the same reason the right-regular action is usually written with an inverse.",
+      "**Evaluate at the identity.** The entire forward content reduces to plugging the point 1 into a commutativity equation: σ commuting with all left translations forces σ x = x * σ 1, instantly identifying σ as a single right translation. No structure theory or finiteness is needed.",
+      "**Centralizer duality.** Left and right translations commute by associativity, so each regular image sits in the centralizer of the other; rigidity shows there is nothing more. This is the centralizer half of the holomorph picture (the normalizer being the larger G ⋊ Aut(G)).",
+      "**Collapse ⟺ commutativity.** The left- and right-regular images are literally the same subgroup of Sym(G) exactly when left and right multiplication agree — i.e. when G is abelian — turning a statement about permutation groups into the definition of commutativity."
+    ],
+    "prerequisites": [
+      "The regular representations as permutations: Equiv.mulLeft / Equiv.mulRight on a group, their composition laws (mulLeft_mul, mulRight_mul) and the resulting MonoidHom structure",
+      "Subgroups of Equiv.Perm G and the centralizer of a set: Subgroup.centralizer and Subgroup.mem_centralizer_iff",
+      "Evaluating equalities of permutations pointwise (DFunLike.congr_fun, Equiv.Perm.mul_apply) and elementary group manipulation (mul_assoc, mul_inv_rev, inv_inv)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring stating the centralizer/regular-representation duality and the abelian characterisation, imports (Subgroup.Centralizer, Perm.Basic, Algebra.Group.End and Units.Equiv for the mulLeft/mulRight API), and the namespace with an arbitrary group variable G.",
+      "mathContext": "$L(G), R(G) \\le \\mathrm{Sym}(G)$ for an arbitrary group $G$."
+    },
+    {
+      "id": "representations",
+      "title": "The Two Regular Representations",
+      "startLine": 52,
+      "endLine": 71,
+      "summary": "leftReg G : G →* Equiv.Perm G as Equiv.mulLeft (x ↦ g * x), a homomorphism via mulLeft_mul; rightReg G : G →* Equiv.Perm G as g ↦ Equiv.mulRight g⁻¹ (x ↦ x * g⁻¹), a homomorphism via mul_inv_rev and mulRight_mul; plus the definitional apply lemmas leftReg_apply and rightReg_apply.",
+      "mathContext": "$L(g): x \\mapsto gx,\\quad R(g): x \\mapsto x g^{-1}$."
+    },
+    {
+      "id": "faithful",
+      "title": "Faithfulness",
+      "startLine": 72,
+      "endLine": 85,
+      "summary": "leftReg_injective and rightReg_injective: both regular representations are faithful, proved by evaluating at the identity (leftReg a = leftReg b forces a = b via mul_one; rightReg via one_mul and inv_injective). This makes the abelian characterisation a statement about G itself.",
+      "mathContext": "$L$ and $R$ are injective — the regular representations are faithful."
+    },
+    {
+      "id": "centralizer-left",
+      "title": "Centralizer of the Left-Regular Image",
+      "startLine": 86,
+      "endLine": 109,
+      "summary": "centralizer_leftReg_range: Subgroup.centralizer ↑(leftReg G).range = (rightReg G).range. Forward inclusion evaluates the commutativity equation at 1 to get σ x = x * σ 1, identifying σ = rightReg (σ 1)⁻¹; reverse inclusion is associativity (mul_assoc).",
+      "mathContext": "$C_{\\mathrm{Sym}(G)}(L(G)) = R(G)$."
+    },
+    {
+      "id": "centralizer-right",
+      "title": "Centralizer of the Right-Regular Image",
+      "startLine": 110,
+      "endLine": 133,
+      "summary": "centralizer_rightReg_range: the mirror identity Subgroup.centralizer ↑(rightReg G).range = (leftReg G).range, proved by evaluating commutativity with rightReg x⁻¹ at 1 to get σ x = σ 1 * x, so σ = leftReg (σ 1).",
+      "mathContext": "$C_{\\mathrm{Sym}(G)}(R(G)) = L(G)$."
+    },
+    {
+      "id": "abelian-iff",
+      "title": "Equal Images iff Abelian",
+      "startLine": 134,
+      "endLine": 185,
+      "summary": "leftReg_range_eq_rightReg_range_iff: (leftReg G).range = (rightReg G).range ↔ ∀ x y, x * y = y * x. Forward: equality writes leftReg x as rightReg z, evaluation pins z = x⁻¹ and yields commutativity; reverse: abelianness gives leftReg g = rightReg g⁻¹. Closes with leftReg_range_le_centralizer_iff, deriving 'self-centralizing ⟺ abelian' from the centralizer identity.",
+      "mathContext": "$L(G) = R(G) \\iff G \\text{ abelian}$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: proves the image of the finite Cayley embedding is a regular (sharply transitive) subgroup of Sₙ and explicitly poses this entry's question — relate the regular subgroup to its centralizer, showing the centralizer of the left-regular image is the right-regular image, equal iff abelian. Here we answer it over an arbitrary group G via the two regular representations into Equiv.Perm G."
+    },
+    {
+      "targetId": "cayleys-theorem-oq-01",
+      "relationship": "builds-on",
+      "description": "Grandparent entry: the abstract left-regular representation G ↪ Sym(G). The centralizer duality proved here is the structural companion of that embedding — the centralizer of the left-regular image is the right-regular image, the centralizer half of the holomorph of G."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof that inside the full symmetric group Equiv.Perm G the centralizer of the left-regular image is exactly the right-regular image (centralizer_leftReg_range), with the mirror statement for the right-regular image (centralizer_rightReg_range), and that the two regular images coincide as subgroups if and only if G is abelian (leftReg_range_eq_rightReg_range_iff). Both representations are faithful (leftReg_injective, rightReg_injective), and the left-regular image is self-centralizing iff G is abelian (leftReg_range_le_centralizer_iff). The whole argument is the evaluate-at-1 rigidity plus associativity, and holds for arbitrary (possibly infinite) G.",
+    "implications": "Pins down the centralizer of Cayley's image precisely: not merely 'something commutes with it' but exactly the other regular representation — the centralizer half of the holomorph G ⋊ Aut(G). The commutative case is characterised cleanly: the left- and right-regular representations are the same subgroup of Sym(G) iff G is abelian, recovering 'self-centralizing ⟺ abelian'. The proof needs no finiteness, generalising the parent's Fin n regular-subgroup picture to all groups.",
+    "openQuestions": [
+      "Identify the normalizer of the left-regular image in Sym(G): the normalizer N_{Sym(G)}(L(G)) is the holomorph G ⋊ Aut(G), with the quotient N/L(G) ≅ Aut(G). Formalize this, extending the centralizer result of this entry to the full normalizer.",
+      "Strengthen the faithfulness/range statements to a bundled isomorphism: produce explicit MulEquiv G ≃* (leftReg G).range and G ≃* (rightReg G).range, and an order-reversing relationship between the two regular images (R(G) is the image of L under the opposite-group/inverse anti-automorphism)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Subgroup.Centralizer",
+      "Mathlib.GroupTheory.Perm.Basic",
+      "Mathlib.Algebra.Group.End",
+      "Mathlib.Algebra.Group.Units.Equiv",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "CayleyCentralizer",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "path": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement that every group is a group of permutations — the regular representation"
+    },
+    {
+      "authors": "Dixon, John D.; Mortimer, Brian",
+      "title": "Permutation Groups",
+      "year": "1996",
+      "venue": "Springer GTM 163",
+      "note": "Regular permutation groups, centralizers in the symmetric group, and the holomorph"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/cayleys-theorem-oq-01-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/cayleys-theorem-oq-01-oq-01-oq-02-oq-02.json
@@ -1,0 +1,115 @@
+{
+  "slug": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02",
+  "title": "Centralizer of the Left-Regular Image is the Right-Regular Image (Equal iff Abelian)",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "C_{\\mathrm{Sym}(G)}\\bigl(L(G)\\bigr) \\;=\\; R(G),\n\\qquad\\text{and}\\qquad L(G) = R(G) \\iff G \\text{ is abelian.}",
+    "plain": "Cayley's theorem embeds `G` into `Sym(G)` by left multiplication. The parent",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-23T07:22:21-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: centralizer of left-regular image = right-regular image, equal iff abelian — proved over arbitrary group G, 0 sorries / 0 axioms (PR pending).",
+    "builtItems": [
+      "leftReg/rightReg : G →* Equiv.Perm G — left/right regular reps as MonoidHoms (rightReg g = mulRight g⁻¹ to fix the anti-hom order) in Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean",
+      "centralizer_leftReg_range: Subgroup.centralizer ↑(leftReg G).range = (rightReg G).range",
+      "centralizer_rightReg_range: mirror identity centralizer of R(G) = L(G)",
+      "leftReg_range_eq_rightReg_range_iff: ranges equal ↔ ∀ x y, x*y=y*x (abelian)",
+      "leftReg_injective/rightReg_injective: both reps faithful; leftReg_range_le_centralizer_iff: self-centralizing ⟺ abelian"
+    ],
+    "insights": [
+      "Forward inclusion C(L(G))⊆R(G) is the evaluate-at-1 trick: σ commuting with all leftReg g gives σ x = x*σ1, so σ = mulRight(σ1). Reverse is associativity.",
+      "rightReg must use mulRight g⁻¹ since plain mulRight is an anti-hom (mulRight(a*b)=mulRight b*mulRight a); mul_inv_rev+mulRight_mul restore homomorphism law.",
+      "No finiteness needed — generalises parent Fin n regular-subgroup picture to arbitrary (possibly infinite) groups. This is the centralizer half of the holomorph G⋊Aut(G)."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Normalizer N_{Sym(G)}(L(G)) = holomorph G⋊Aut(G), quotient ≅ Aut(G) — extend centralizer to full normalizer.",
+      "Bundle faithfulness into MulEquiv G ≃* (leftReg G).range and relate R(G) to L via opposite-group anti-automorphism."
+    ],
+    "markdown": "# Knowledge Base: cayleys-theorem-oq-01-oq-01-oq-02-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "group-theory",
+    "regular-representation",
+    "centralizer"
+  ],
+  "relatedProofs": [
+    "cayleys-theorem-oq-01",
+    "cayleys-theorem-oq-01-oq-01",
+    "cayleys-theorem-oq-01-oq-01-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-23T14:39:14.520Z",
+  "lastUpdate": "2026-06-23",
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleysTheoremOQ01.lean",
+      "filename": "CayleysTheoremOQ01.lean",
+      "lineCount": 90,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleysTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleysTheoremOQ01OQ01.lean",
+      "filename": "CayleysTheoremOQ01OQ01.lean",
+      "lineCount": 108,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleysTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleysTheoremOQ01OQ01OQ02.lean",
+      "filename": "CayleysTheoremOQ01OQ01OQ02.lean",
+      "lineCount": 164,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean",
+      "filename": "CayleysTheoremOQ01OQ01OQ02OQ02.lean",
+      "lineCount": 186,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** posed verbatim by the parent entry `cayleys-theorem-oq-01-oq-01-oq-02` ("relate the regular subgroup to its centralizer in the symmetric group: the centralizer of the left-regular image is the right-regular image, and the two coincide iff G is abelian").

Works over an **arbitrary group `G`** (no finiteness — strictly more general than the parent's `Fin n` setting), inside `Equiv.Perm G`.

## Results (`Proofs/CayleysTheoremOQ01OQ01OQ02OQ02.lean`)

- **`leftReg` / `rightReg` : `G →* Equiv.Perm G`** — the two regular representations as genuine `MonoidHom`s. `rightReg g = Equiv.mulRight g⁻¹` because plain right multiplication is an *anti*-homomorphism; the inverse repairs the order.
- **`centralizer_leftReg_range`** : `Subgroup.centralizer ↑(leftReg G).range = (rightReg G).range`. Forward inclusion is the classical evaluate-at-`1` trick — a permutation commuting with every left translation satisfies `σ x = x * σ 1`, hence equals `mulRight (σ 1)`; the reverse is associativity.
- **`centralizer_rightReg_range`** : the mirror identity.
- **`leftReg_range_eq_rightReg_range_iff`** : `(leftReg G).range = (rightReg G).range ↔ ∀ x y, x*y = y*x` — the two regular images coincide exactly when `G` is abelian.
- **`leftReg_injective` / `rightReg_injective`** : both representations are faithful, so the abelian characterisation is a statement about `G` itself; **`leftReg_range_le_centralizer_iff`** recovers "self-centralizing ⟺ abelian".

This is the centralizer half of the holomorph `G ⋊ Aut(G)`.

## Verification

- **185 lines, 8 theorems / 2 definitions, 0 sorries, 0 axioms.**
- `#print axioms` lists only `propext`, `Classical.choice`, `Quot.sound`. No `decide` / `native_decide`.
- Built single-file with `lake env lean` against Mathlib 4.26.0 (Docker daemon unavailable this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)