### PR TITLE
Enrich Pell Yₙ Divisibility Sequence (oq-06-oq-07): annotations, index.ts, conclusion

### DIFF
--- a/src/data/proofs/pell-equation-oq-06-oq-07/annotations.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-07/annotations.json
@@ -1,0 +1,158 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "context",
+    "title": "The Arithmetic Shadow of the Pell Chain",
+    "content": "The negative-Pell lineage `pell-equation-oq-06` and its children have described the solution chain of $x^2 - 2y^2 = \\pm 1$ analytically (best rational approximations of $\\sqrt2$), algebraically (powers of the fundamental unit, the Brahmagupta composition law, the linear recurrence), and via determinants (the Cassini constant). This entry records the one structural fact none of the siblings touch: a purely **arithmetic** (number-theoretic) property. Writing the positive-Pell unit $\\gamma = 3 + 2\\sqrt2$ and $\\gamma^n = X_n + Y_n\\sqrt2$, the second coordinates\n$$(Y_n) = 0,\\,2,\\,12,\\,70,\\,408,\\dots$$\nform a **divisibility sequence**: $m \\mid n \\Rightarrow Y_m \\mid Y_n$. The decisive point — mirroring the Fibonacci/Lucas case — is that this follows from the *addition law*, not from any closed form.",
+    "mathContext": "$\\gamma = 3 + 2\\sqrt2 = (1+\\sqrt2)^2 \\in \\mathbb{Z}[\\sqrt2]$ is the fundamental unit of norm $+1$; $\\gamma^n = X_n + Y_n\\sqrt2$ enumerates the positive solutions of $x^2 - 2y^2 = 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "divisibility sequence",
+      "Lucas sequence",
+      "Pell's equation",
+      "fundamental unit of a quadratic field"
+    ],
+    "prerequisites": [
+      "Pell's equation",
+      "quadratic integer rings",
+      "divisibility in the integers"
+    ]
+  },
+  {
+    "id": "ann-chain-definition",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 63, "endLine": 76 },
+    "type": "definition",
+    "title": "The Chain as Powers of the Fundamental Unit",
+    "content": "The entire chain is defined directly from a single quadratic integer: $\\gamma = \\langle 3, 2\\rangle : \\mathbb{Z}\\sqrt2$ in Mathlib's `Zsqrtd` model. The coordinate sequences are simply the real and imaginary parts of its powers, $X_n = (\\gamma^n)_{\\mathrm{re}}$ and $Y_n = (\\gamma^n)_{\\mathrm{im}}$. No recurrence is posited as an axiom; the recurrence and addition laws are *derived* below from the ring multiplication of $\\mathbb{Z}[\\sqrt2]$. The base values $X_0 = 1,\\ Y_0 = 0,\\ X_1 = 3,\\ Y_1 = 2$ are discharged by kernel `decide` on concrete integers.",
+    "mathContext": "$X_n = (\\gamma^n)_{\\mathrm{re}}$, $Y_n = (\\gamma^n)_{\\mathrm{im}}$, with $\\gamma^0 = 1$ giving $(X_0,Y_0) = (1,0)$ and $\\gamma^1 = \\gamma$ giving $(X_1,Y_1) = (3,2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Zsqrtd",
+      "ring of quadratic integers",
+      "real and imaginary parts"
+    ],
+    "prerequisites": [
+      "monoid powers",
+      "the ring Z[sqrt d]"
+    ]
+  },
+  {
+    "id": "ann-norm-pow",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 82, "endLine": 93 },
+    "type": "technique",
+    "title": "Multiplicativity of the Norm Across Powers",
+    "content": "The norm $N(a + b\\sqrt2) = a^2 - 2b^2$ is multiplicative ($N(zw) = N(z)N(w)$, Mathlib's `Zsqrtd.norm_mul`). `norm_pow` packages a clean one-line induction $N(z^k) = N(z)^k$ off that fact — a self-contained analogue of the missing power version. Since $N(\\gamma) = 3^2 - 2\\cdot 2^2 = 1$, every power keeps norm $1$: $N(\\gamma^n) = 1^n = 1$. This is the algebraic source of the Pell relation.",
+    "mathContext": "$N(z^k) = N(z)^k$; with $N(\\gamma)=1$, $N(\\gamma^n) = 1$ for all $n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicative norm",
+      "norm form of a quadratic field",
+      "induction on exponents"
+    ],
+    "prerequisites": [
+      "norm of a quadratic integer",
+      "mathematical induction"
+    ]
+  },
+  {
+    "id": "ann-pell-relation",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 95, "endLine": 100 },
+    "type": "concept",
+    "title": "The Pell Relation From the Norm",
+    "content": "Unfolding $N(\\gamma^n) = 1$ through `Zsqrtd.norm_def` gives exactly $X_n^2 - 2Y_n^2 = 1$ — every term of the chain is a genuine solution of Pell's equation. This is the bridge from algebra (the unit group of $\\mathbb{Z}[\\sqrt2]$) to Diophantine number theory: the powers of the fundamental unit *are* the positive solutions. The `linear_combination` tactic closes the gap between the unfolded norm and the stated quadratic identity.",
+    "mathContext": "$X_n^2 - 2Y_n^2 = 1$ for all $n \\ge 0$ — the norm-$+1$ form of $x^2 - 2y^2 = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Pell's equation",
+      "norm form",
+      "units of a real quadratic field"
+    ],
+    "prerequisites": [
+      "Pell's equation",
+      "quadratic norm forms"
+    ]
+  },
+  {
+    "id": "ann-addition-formulas",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 106, "endLine": 124 },
+    "type": "insight",
+    "title": "The Addition Formulas — The Engine",
+    "content": "The decomposition $\\gamma^{m+n} = \\gamma^m \\cdot \\gamma^n$, read coordinate-wise through `Zsqrtd.re_mul` and `im_mul`, yields the **addition formulas** for free:\n$$X_{m+n} = X_m X_n + 2 Y_m Y_n, \\qquad Y_{m+n} = X_m Y_n + Y_m X_n.$$\nThe second of these is the engine of the whole entry. Setting $n = 1$ specializes them to the **step recurrences** $X_{n+1} = 3X_n + 4Y_n$ and $Y_{n+1} = 2X_n + 3Y_n$ — exactly the parent lineage's form automorphism $(x,y) \\mapsto (3x+4y,\\,2x+3y)$, now revealed as nothing more than multiplication by $\\gamma$.",
+    "mathContext": "$Y_{m+n} = X_m Y_n + Y_m X_n = (\\gamma^m\\gamma^n)_{\\mathrm{im}}$; the case $n=1$ gives $Y_{n+1} = 2X_n + 3Y_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Brahmagupta composition law",
+      "addition formula",
+      "linear recurrence",
+      "group automorphism"
+    ],
+    "prerequisites": [
+      "multiplication in Z[sqrt d]",
+      "the law of exponents"
+    ]
+  },
+  {
+    "id": "ann-coprimality",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 138, "endLine": 141 },
+    "type": "technique",
+    "title": "Coprimality Is a Bézout Certificate",
+    "content": "Coprimality of $X_n$ and $Y_n$ is immediate from the Pell relation: rewriting $X_n^2 - 2Y_n^2 = 1$ as\n$$X_n \\cdot X_n + (-2Y_n)\\cdot Y_n = 1$$\nexhibits an explicit Bézout combination, so $\\gcd(X_n, Y_n) = 1$. The proof simply hands Lean the witnesses $(X_n,\\,-2Y_n)$ to the `IsCoprime` structure. This coprimality is the missing ingredient for the *strong* form $\\gcd(Y_m, Y_n) = Y_{\\gcd(m,n)}$, left here as future work.",
+    "mathContext": "$X_n\\cdot X_n + (-2Y_n)\\cdot Y_n = 1 \\Rightarrow \\gcd(X_n, Y_n) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "coprimality",
+      "strong divisibility sequence"
+    ],
+    "prerequisites": [
+      "Bézout's identity",
+      "greatest common divisor"
+    ]
+  },
+  {
+    "id": "ann-divisibility-core",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 147, "endLine": 161 },
+    "type": "insight",
+    "title": "The Divisibility Sequence by Induction on Multiples",
+    "content": "The headline result is reached in two moves. First the inductive core `Y_dvd_mul`: $Y_m \\mid Y_{k\\cdot m}$ by induction on $k$. Writing $(k+1)m = km + m$ and applying the addition formula gives\n$$Y_{(k+1)m} = X_{km}\\,Y_m + Y_{km}\\,X_m,$$\nwhose first summand carries $Y_m$ **directly** and whose second carries it **through the inductive hypothesis** $Y_m \\mid Y_{km}$. Reindexing $n = m\\cdot k$ then gives the full divisibility sequence $m \\mid n \\Rightarrow Y_m \\mid Y_n$. No closed form, no continued fractions — just the addition law and divisibility bookkeeping, exactly as in the Fibonacci proof that $F_m \\mid F_{km}$.",
+    "mathContext": "$Y_{(k+1)m} = X_{km}Y_m + Y_{km}X_m$; both summands are divisible by $Y_m$, so $Y_m \\mid Y_{km}$ for all $k$, hence $m \\mid n \\Rightarrow Y_m \\mid Y_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "divisibility sequence",
+      "Fibonacci divisibility theorem",
+      "Lucas sequences",
+      "induction"
+    ],
+    "prerequisites": [
+      "divisibility of integers",
+      "mathematical induction",
+      "the addition formula above"
+    ]
+  },
+  {
+    "id": "ann-two-dvd-and-checks",
+    "proofId": "pell-equation-oq-06-oq-07",
+    "range": { "startLine": 163, "endLine": 175 },
+    "type": "concept",
+    "title": "Every Yₙ Is Even, and Concrete Witnesses",
+    "content": "Because $Y_1 = 2$ and $1 \\mid n$ for every $n$, the divisibility sequence instantly gives $2 = Y_1 \\mid Y_n$: **every Pell $Y_n$ is even** — a one-line corollary illustrating how index divisibility propagates a concrete factor along the whole chain. The closing sanity checks confirm $X_2 = 17,\\ Y_2 = 12,\\ X_3 = 99,\\ Y_3 = 70$ and exhibit explicit instances $Y_2 \\mid Y_6$ (from $6 = 2\\cdot 3$) and $Y_3 \\mid Y_9$ (from $9 = 3\\cdot 3$) of the divisibility sequence.",
+    "mathContext": "$2 = Y_1 \\mid Y_n$ for all $n$; e.g. $Y_2 = 12 \\mid Y_6 = 23184$ and $Y_3 = 70 \\mid Y_9$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "parity",
+      "divisibility sequence",
+      "worked examples"
+    ],
+    "prerequisites": [
+      "divisibility of integers"
+    ]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-06-oq-07/index.ts
+++ b/src/data/proofs/pell-equation-oq-06-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PellEquationOQ06OQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pellEquationOQ06OQ07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pellEquationOQ06OQ07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pellEquationOQ06OQ07Data: ProofData = {
+  proof: pellEquationOQ06OQ07Proof,
+  annotations: pellEquationOQ06OQ07Annotations,
+}

--- a/src/data/proofs/pell-equation-oq-06-oq-07/meta.json
+++ b/src/data/proofs/pell-equation-oq-06-oq-07/meta.json
@@ -130,5 +130,15 @@
       "summary": "Concrete values X₂=17, Y₂=12, X₃=99, Y₃=70 and instances of the divisibility sequence Y₂ ∣ Y₆, Y₃ ∣ Y₉.",
       "mathContext": "$Y_2=12\\mid Y_6$ and $Y_3=70\\mid Y_9$ — explicit witnesses from $6=2\\cdot3$, $9=3\\cdot3$."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "Building the positive-Pell chain γⁿ = Xₙ + Yₙ√2 directly from the fundamental unit γ = 3 + 2√2 ∈ ℤ[√2], the entry establishes the norm +1 Pell relation Xₙ² − 2Yₙ² = 1, the addition formulas Y_{m+n} = Xₘ·Yₙ + Yₘ·Xₙ and X_{m+n} = Xₘ·Xₙ + 2·Yₘ·Yₙ (multiplication in ℤ[√2] read through Zsqrtd.re_mul / im_mul), the step recurrences Xₙ₊₁ = 3Xₙ + 4Yₙ, Yₙ₊₁ = 2Xₙ + 3Yₙ, and coprimality of Xₙ and Yₙ. From the addition formula alone it derives the headline divisibility sequence m ∣ n ⟹ Yₘ ∣ Yₙ via the inductive core Yₘ ∣ Y_{k·m}, with the corollary that every Yₙ is even. All results are sorry-free and axiom-free (no native_decide).",
+    "implications": "The entry isolates the arithmetic core of the Pell chain that its analytic, algebraic, and determinantal siblings leave untouched, and frames it as the exact Pell analogue of the classical Fibonacci/Lucas divisibility-sequence theorem (Lucas 1878): in both settings the divisibility structure is a shadow of the addition law, not of any closed form. It also pins down the parent lineage's defining automorphism (x,y) ↦ (3x+4y, 2x+3y) as the n+1 case of the addition formula — i.e. multiplication by γ — unifying the recurrence, the composition law, and the divisibility structure under a single ring operation in ℤ[√2]. The explicit Bézout certificate behind coprimality is precisely the lever needed to upgrade to the strong (gcd) form.",
+    "openQuestions": [
+      "Strong divisibility sequence: does gcd(Yₘ, Yₙ) = Y_{gcd(m,n)} hold, and can it be formalized via Nat.gcd.induction using the coprimality isCoprime_X_Y proved here? (Left as future work in the source.)",
+      "What is the rank of apparition — the least index n with d ∣ Yₙ for a given divisor d — and does it satisfy the Lucas-sequence law that d ∣ Yₙ iff (rank of d) ∣ n?",
+      "Do the analogous divisibility-sequence and strong-divisibility results hold for the coordinate sequences of the general Pell equation x² − Dy² = 1 over ℤ[√D] for arbitrary non-square D, with the same addition-formula proof?",
+      "Which primes p divide some Yₙ, and how does the 2-adic (and p-adic) valuation of Yₙ grow with n — i.e. the analogue of the lifting-the-exponent / Carmichael theory for Lucas sequences?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `pell-equation-oq-06-oq-07` — the Pell analogue of the Fibonacci/Lucas divisibility-sequence theorem (m ∣ n ⟹ Yₘ ∣ Yₙ).

The entry shipped with only `meta.json`. This pass adds the two missing files the page needs and a conclusion:

**New `annotations.json`** — 8 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering:
- the arithmetic framing vs. the analytic/algebraic/determinantal siblings
- the chain as powers of the fundamental unit γ = 3 + 2√2 in `Zsqrtd 2`
- norm multiplicativity N(zᵏ) = N(z)ᵏ and the Pell relation Xₙ² − 2Yₙ² = 1
- the addition formulas / step recurrence as multiplication by γ (the engine)
- coprimality as an explicit Bézout certificate
- the inductive divisibility core Yₘ ∣ Y_{k·m} and the evenness corollary

**New `index.ts`** — the entry was missing it, so the page would show "proof not found" on the live site. Added following the sibling template (`pellEquationOQ06OQ07`, source `PellEquationOQ06OQ07.lean`).

**`meta.json`** — added a `conclusion` (summary, implications, 4 open questions: strong gcd-divisibility form, rank of apparition, general D, p-adic valuations). All existing content preserved.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`, 0 axioms, 0 sorries — confirmed against the source: only `decide` on concrete integers, no `native_decide`).