### PR TITLE
Enrich Birthday k=3 Count at n=4 (oq-03-oq-01-oq-01-oq-05): annotations, index.ts, sections

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "context",
+    "title": "The k=3 Birthday Count and Its Closed-Form Sequence",
+    "content": "The classical birthday problem asks for the probability that two of $n$ people share a birthday. The **k=3** (triple-coincidence) variant instead counts the seatings that *avoid* any triple — configurations of $n$ labelled people on $d$ days with **at most two per day**. The parent entry built an $O(n^2)$ slot recurrence and read off the closed forms $\\mathrm{birthdayCount3}(1,d) = d$, $(2,d) = d^2$, $(3,d) = d^3 - d$. This file records the **next** term, $n = 4$:\n$$\\mathrm{birthdayCount3}(4,d) = d^4 - 4d^2 + 3d = d(d-1)(d^2+d-3).$$\nCrucially it is proved by *symbolic* unfolding of the recurrence rather than the parent's `native_decide` evaluation, so it is genuinely 0-axiom.",
+    "mathContext": "Closed-form sequence $d,\\ d^2,\\ d^3 - d,\\ d^4 - 4d^2 + 3d,\\dots$ for the number of at-most-two-per-day seatings of $n = 1,2,3,4$ people.",
+    "significance": "context",
+    "relatedConcepts": [
+      "birthday problem",
+      "generating functions",
+      "exponential generating function",
+      "enumerative combinatorics"
+    ],
+    "prerequisites": [
+      "birthday problem",
+      "combinatorial counting",
+      "polynomials"
+    ]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+    "range": { "startLine": 36, "endLine": 49 },
+    "type": "definition",
+    "title": "The Slot Recurrence R and the Base Lemma",
+    "content": "The recurrence $R$ threads a state $(e, s)$ = (number of still-empty days, number of days already holding one person) as people are seated one at a time:\n$$R(0,e,s) = 1, \\qquad R(n+1,e,s) = e\\cdot R(n,e-1,s+1) + s\\cdot R(n,e,s-1).$$\nSeating the next person on an empty day (one of $e$ choices) turns it into a single day ($e\\!-\\!1$, $s\\!+\\!1$); seating on a single day (one of $s$ choices) fills it ($s\\!-\\!1$) and forbids a third occupant. Then $\\mathrm{birthdayCount3}(n,d) = R(n,d,0)$. The definition is reproduced here (rather than imported) so the file compiles fast and self-contained. `R_one` proves the base case $R(1,e,s) = e + s$ — every level of the unfolding bottoms out here.",
+    "mathContext": "$R(n+1,e,s) = e\\,R(n,e-1,s+1) + s\\,R(n,e,s-1)$; $R(1,e,s) = e + s$; $\\mathrm{birthdayCount3}(n,d) = R(n,d,0)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "recurrence relation",
+      "state machine enumeration",
+      "occupancy problem",
+      "dynamic programming"
+    ],
+    "prerequisites": [
+      "recursive definitions",
+      "natural-number subtraction"
+    ]
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+    "range": { "startLine": 51, "endLine": 62 },
+    "type": "insight",
+    "title": "The n = 4 Closed Form by Symbolic Unfolding",
+    "content": "The headline `birthdayCount3_four` proves $\\mathrm{birthdayCount3}(4,d) = d^4 - 4d^2 + 3d$ over $\\mathbb{Z}$. The proof case-splits on $d$: the values $d = 0, 1, 2$ are closed by kernel `decide` on concrete numbers, and the generic case $d = e + 3$ unfolds $R$ four levels via its equation lemmas. The key trick is the reindexing $d = e + 3$: it makes every truncated natural subtraction ($d\\!-\\!1, d\\!-\\!2, d\\!-\\!3$) *exact*, so `simp` can normalize the unfolded expression and, after `push_cast` to $\\mathbb{Z}$, `ring` matches it against the target polynomial. Avoiding `native_decide` is what keeps the result axiom-free (no `Lean.ofReduceBool`).",
+    "mathContext": "$\\mathrm{birthdayCount3}(4,d) = d^4 - 4d^2 + 3d$; at $d = 4$ this is $256 - 64 + 12 = 204$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "recurrence unfolding",
+      "truncated subtraction",
+      "ring normalization",
+      "polynomial identities"
+    ],
+    "prerequisites": [
+      "the slot recurrence above",
+      "casting ℕ to ℤ",
+      "the ring tactic"
+    ]
+  },
+  {
+    "id": "ann-factored",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+    "range": { "startLine": 64, "endLine": 67 },
+    "type": "concept",
+    "title": "The Factored Form",
+    "content": "Re-expressing the closed form as $d(d-1)(d^2+d-3)$ exposes its combinatorial skeleton: the factor $d(d-1)$ is the number of ways to place the first pair of people on two ordered distinct days, and $d^2 + d - 3$ corrects for the constrained placement of the remaining two. The proof is a one-liner — rewrite by `birthdayCount3_four` and let `ring` confirm the factorization $d^4 - 4d^2 + 3d = d(d-1)(d^2+d-3)$.",
+    "mathContext": "$d^4 - 4d^2 + 3d = d(d-1)(d^2+d-3)$; the visible roots $d = 0$ and $d = 1$ reflect that $<2$ days cannot seat four people two-per-day with all four placed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "polynomial factorization",
+      "combinatorial interpretation"
+    ],
+    "prerequisites": [
+      "polynomial factorization"
+    ]
+  },
+  {
+    "id": "ann-nat-identity",
+    "proofId": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+    "range": { "startLine": 69, "endLine": 75 },
+    "type": "technique",
+    "title": "A Truncation-Free ℕ Identity",
+    "content": "Because $d^4 - 4d^2 + 3d$ can dip below the intermediate $4d^2$, stating the result directly over $\\mathbb{N}$ would risk truncated subtraction. The companion lemma sidesteps this by moving the negative term to the other side: $\\mathrm{birthdayCount3}(4,d) + 4d^2 = d^4 + 3d$ — an identity with no subtraction at all, valid for $d \\ge 1$. The proof `zify`s to $\\mathbb{Z}$ and finishes with `linarith` against the integer closed form. This illustrates the general discipline of proving polynomial count identities over $\\mathbb{Z}$ and transporting them back to $\\mathbb{N}$ only in subtraction-free form.",
+    "mathContext": "$\\mathrm{birthdayCount3}(4,d) + 4d^2 = d^4 + 3d$ for $d \\ge 1$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "natural-number subtraction",
+      "zify",
+      "linear arithmetic"
+    ],
+    "prerequisites": [
+      "natural vs. integer subtraction",
+      "the integer closed form above"
+    ]
+  }
+]

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/index.ts
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BirthdayProblemOQ03OQ01OQ01OQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const birthdayProblemOQ03OQ01OQ01OQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const birthdayProblemOQ03OQ01OQ01OQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const birthdayProblemOQ03OQ01OQ01OQ05Data: ProofData = {
+  proof: birthdayProblemOQ03OQ01OQ01OQ05Proof,
+  annotations: birthdayProblemOQ03OQ01OQ01OQ05Annotations,
+}

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01-oq-05/meta.json
@@ -73,6 +73,18 @@
   ],
   "sections": [
     {
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Recalls the parent's slot recurrence R and the closed forms for n = 1, 2, 3, and states the goal: the next term birthdayCount3 4 d = d⁴ − 4d² + 3d = d(d−1)(d²+d−3), proved 0-axiom by symbolic unfolding rather than native_decide."
+    },
+    {
+      "title": "The slot recurrence and base lemmas",
+      "startLine": 36,
+      "endLine": 49,
+      "summary": "Reproduces the recurrence R n e s (state = empty/single days) and birthdayCount3 n d = R n d 0 for a self-contained, fast-compiling file, with the simp lemmas R_zero, R_succ and the base identity R_one: R 1 e s = e + s."
+    },
+    {
       "title": "The n = 4 closed form",
       "startLine": 51,
       "endLine": 62,


### PR DESCRIPTION
Enrichment pass for `birthday-problem-oq-03-oq-01-oq-01-oq-05` — the closed form birthdayCount3 4 d = d⁴ − 4d² + 3d = d(d−1)(d²+d−3).

The entry shipped with only `meta.json`. This pass adds the missing files and completes section coverage:

**New `annotations.json`** — 5 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
- the k=3 birthday count and its closed-form sequence d, d², d³−d, d⁴−4d²+3d
- the slot recurrence R(n+1,e,s) = e·R(n,e−1,s+1) + s·R(n,e,s−1) and base lemma R 1 e s = e+s
- the n=4 closed form by symbolic unfolding (the reindex d = e+3 makes truncated subtractions exact, then push_cast + ring; no native_decide ⇒ axiom-free)
- the factored form d(d−1)(d²+d−3)
- the truncation-free ℕ identity birthdayCount3 4 d + 4d² = d⁴ + 3d for d ≥ 1

**New `index.ts`** — was missing, so the page would show "proof not found" on the live site. Follows the sibling template (`birthdayProblemOQ03OQ01OQ01OQ05`).

**`meta.json`** — extended `sections` to cover lines 1–50 (module header + recurrence/base lemmas); previously only 51–75 were covered. All existing content preserved.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`, 0 axioms, 0 sorries — confirmed against source: small cases by `decide`, generic case by recurrence unfolding, no `native_decide`).