### PR TITLE
Enrich Four-Square Distribution OQ-05: 2-adic structure of the symmetry multiplier

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-05/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-05/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "fsd-oq05-ann-header",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 1, "endLine": 57 },
+    "type": "concept",
+    "title": "Sign Symmetry and Jacobi's Factor of 8",
+    "content": "The header frames the contribution: the parent file decomposes r₄(n) by type t (a sorted tuple of absolute values) and assigns each type a symmetry multiplier `contribution(t) = permutations(t)·signFactor(t)`, where `signFactor(t) = 2^(nonzeroCount t)` counts the sign choices on the nonzero coordinates. This file isolates the 2-adic, sign-change half of the hyperoctahedral group B₄ = (ℤ/2)⁴ ⋊ S₄: the subgroup (ℤ/2)^(nonzeroCount) of order 2^(nonzeroCount) always divides the contribution. The honest-scope note records that the full `8 ∣ r₄(n)` additionally needs the permutation parity in the one- and two-nonzero cases, which is deliberately out of scope.",
+    "mathContext": "$\\mathrm{contribution}(t) = \\mathrm{permutations}(t)\\cdot 2^{\\mathrm{nonzeroCount}(t)}, \\qquad B_4 = (\\mathbb{Z}/2)^4 \\rtimes S_4, \\quad |B_4| = 2^4\\cdot 4! = 384.$",
+    "significance": "key",
+    "relatedConcepts": ["hyperoctahedral group", "Jacobi four-square theorem", "sign-change symmetry", "orbit-stabilizer"],
+    "prerequisites": ["sum of four squares", "semidirect products", "group actions on tuples"]
+  },
+  {
+    "id": "fsd-oq05-ann-one-le",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 59, "endLine": 62 },
+    "type": "lemma",
+    "title": "Positivity of the Sign Factor",
+    "content": "`one_le_signFactor` records that `signFactor t = 2^(nonzeroCount t) ≥ 1`. Unfolding the definition reduces it to `Nat.one_le_two_pow`, the statement that every power of two is at least one. This positivity guarantees the sign factor is a genuine (nonzero) divisor and underlies the later `simpa`-discharged corollaries.",
+    "mathContext": "$1 \\le 2^{\\mathrm{nonzeroCount}(t)}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "powers of two"],
+    "prerequisites": ["natural number exponentiation"]
+  },
+  {
+    "id": "fsd-oq05-ann-signfactor-dvd",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 64, "endLine": 67 },
+    "type": "theorem",
+    "title": "The Sign Factor Divides the Contribution",
+    "content": "`signFactor_dvd_contribution` is the structural heart of the file: since `contribution(t) = permutations(t)·signFactor(t)`, the sign factor is literally one of the multiplicative components. The divisibility is exhibited by the explicit anonymous-constructor witness `⟨t.permutations, …⟩` — i.e. the cofactor IS the permutation count — with `ring` closing the equation after unfolding `contribution`. No arithmetic about n is used; the divisibility is purely structural.",
+    "mathContext": "$\\mathrm{signFactor}(t) \\mid \\mathrm{contribution}(t), \\quad \\text{witness } \\mathrm{contribution}(t) = \\mathrm{signFactor}(t)\\cdot \\mathrm{permutations}(t).$",
+    "significance": "critical",
+    "relatedConcepts": ["divisibility", "factorization", "anonymous constructor witness"],
+    "prerequisites": ["Nat.dvd as existence of a cofactor", "ring tactic"]
+  },
+  {
+    "id": "fsd-oq05-ann-two-pow",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 69, "endLine": 75 },
+    "type": "theorem",
+    "title": "2^(nonzeroCount) Divides the Contribution",
+    "content": "`two_pow_nonzeroCount_dvd_contribution` is the headline result: `2^(nonzeroCount t) ∣ contribution t`. It is obtained from `signFactor_dvd_contribution` by unfolding `signFactor` to its definition `2^(nonzeroCount)` in the hypothesis. Group-theoretically this is the statement that the order of the sign-change subgroup (ℤ/2)^(nonzeroCount) divides the orbit size, an instance of Lagrange's theorem made concrete.",
+    "mathContext": "$2^{\\mathrm{nonzeroCount}(t)} \\mid \\mathrm{contribution}(t).$",
+    "significance": "critical",
+    "relatedConcepts": ["Lagrange's theorem", "subgroup order divides orbit", "2-adic valuation"],
+    "prerequisites": ["divisibility", "definitional unfolding"]
+  },
+  {
+    "id": "fsd-oq05-ann-tower",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 77, "endLine": 80 },
+    "type": "theorem",
+    "title": "The 2-adic Divisibility Tower",
+    "content": "`two_pow_dvd_contribution_of_le` generalizes the headline to every exponent below the threshold: for `k ≤ nonzeroCount t`, `2^k ∣ contribution t`. The proof chains `pow_dvd_pow 2 hk` (which gives `2^k ∣ 2^(nonzeroCount)`) with the headline divisibility via transitivity (`.trans`). This single lemma is the common parent of all the numeric corollaries that follow.",
+    "mathContext": "$k \\le \\mathrm{nonzeroCount}(t) \\implies 2^k \\mid \\mathrm{contribution}(t).$",
+    "significance": "key",
+    "relatedConcepts": ["transitivity of divisibility", "monotonicity of powers", "divisibility tower"],
+    "prerequisites": ["pow_dvd_pow", "Dvd.dvd.trans"]
+  },
+  {
+    "id": "fsd-oq05-ann-corollaries",
+    "proofId": "four-square-distribution-oq-05",
+    "range": { "startLine": 82, "endLine": 105 },
+    "type": "theorem",
+    "title": "Numeric Corollaries: 2, 4, 8, 16",
+    "content": "Four specializations instantiate the tower at small thresholds: `two_dvd_contribution_of_pos` (≥1 nonzero ⇒ 2 ∣), `four_dvd_contribution_of_two_le` (≥2 ⇒ 4 ∣), `eight_dvd_contribution_of_three_le` (≥3 ⇒ 8 ∣ — the per-type factor of 8), and `sixteen_dvd_contribution_of_four` (all four nonzero ⇒ 16 ∣). Each calls `two_pow_dvd_contribution_of_le` at the relevant k and lets `simpa` evaluate `2^k` to the literal (2, 4, 8, 16). The `eight_dvd` case is the cleanest appearance of Jacobi's factor of 8 attributable purely to sign symmetry.",
+    "mathContext": "$\\mathrm{nonzeroCount}(t) \\ge 3 \\implies 8 \\mid \\mathrm{contribution}(t); \\qquad \\mathrm{nonzeroCount}(t) = 4 \\implies 16 \\mid \\mathrm{contribution}(t).$",
+    "significance": "key",
+    "relatedConcepts": ["factor of 8", "specialization", "simp normalization of numerals"],
+    "prerequisites": ["two_pow_dvd_contribution_of_le", "simpa"]
+  }
+]

--- a/src/data/proofs/four-square-distribution-oq-05/index.ts
+++ b/src/data/proofs/four-square-distribution-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FourSquareDistributionOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fourSquareDistributionOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fourSquareDistributionOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fourSquareDistributionOQ05Data: ProofData = {
+  proof: fourSquareDistributionOQ05Proof,
+  annotations: fourSquareDistributionOQ05Annotations,
+}

--- a/src/data/proofs/four-square-distribution-oq-05/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-05/meta.json
@@ -98,7 +98,12 @@
   ],
   "conclusion": {
     "summary": "Machine-verified divisibility structure of the four-square symmetry multiplier: 2^(nonzeroCount t) ∣ contribution t for every type, hence 8 ∣ contribution t once a type has ≥ 3 nonzero entries and 16 ∣ contribution t when all four are nonzero. Zero sorries, zero axioms beyond the foundational ones.",
-    "implications": "Isolates the sign-change half of the hyperoctahedral symmetry behind Jacobi's factor of 8 at the per-type level, complementing the parent's upper bound. The full 8 ∣ r₄(n) refinement (needing the permutation parity in the one- and two-nonzero cases) is identified as the remaining step."
+    "implications": "Isolates the sign-change half of the hyperoctahedral symmetry behind Jacobi's factor of 8 at the per-type level, complementing the parent's upper bound. The full 8 ∣ r₄(n) refinement (needing the permutation parity in the one- and two-nonzero cases) is identified as the remaining step.",
+    "openQuestions": [
+      "Can the permutation parity in the one- and two-nonzero cases be supplied so that 8 ∣ contribution t holds for every type with ≥ 1 nonzero entry, yielding a fully type-local proof of Jacobi's 8 ∣ r₄(n) for n ≥ 1?",
+      "Does the same sign-part argument generalize to sums of 2k squares, giving 2^(nonzeroCount) ∣ contribution under the hyperoctahedral group B_{2k} = (ℤ/2)^{2k} ⋊ S_{2k}, and how does the resulting power of two compare with the known factor in r_{2k}(n)?",
+      "What is the exact 2-adic valuation v₂(contribution t) — i.e. when does the permutation count permutations(t) contribute additional factors of 2 beyond the sign part established here?"
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
Enrichment pass for `four-square-distribution-oq-05` (the 2-adic / sign-change divisibility of the four-square symmetry multiplier).

The meta.json was already rich (overview, sections, conclusion, crossReferences, references, mainTheorems) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site) and had no annotations. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 6 annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the header framing and all 8 theorems: `one_le_signFactor`, `signFactor_dvd_contribution`, `two_pow_nonzeroCount_dvd_contribution`, the divisibility tower `two_pow_dvd_contribution_of_le`, and the 2/4/8/16 numeric corollaries.
- **`conclusion.openQuestions`** — added 3 genuine open questions (type-local proof of Jacobi's `8 ∣ r₄(n)`, generalization to sums of `2k` squares under `B_{2k}`, and the exact 2-adic valuation `v₂(contribution t)`).

Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` — accurate against the Lean source (sign factor is literally a multiplicative component of the contribution; no number-theoretic input).

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)