### PR TITLE
Enrich Fibonacci Shallow-Diagonal Sum (combinations-formula-oq-01-oq-01): annotations, index.ts, sections

### DIFF
--- a/src/data/proofs/combinations-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01/annotations.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "combinations-formula-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 22 },
+    "type": "context",
+    "title": "Shallow Diagonals of Pascal's Triangle Are Fibonacci",
+    "content": "One of the most celebrated hidden patterns in Pascal's triangle: summing the binomial coefficients along a **shallow (rising) diagonal** reproduces the Fibonacci numbers,\n$$\\sum_{j=0}^{n} \\binom{n-j}{j} = F_{n+1}.$$\nThe terms $\\binom{n}{0}, \\binom{n-1}{1}, \\binom{n-2}{2}, \\dots$ run up a diagonal of slope $2$ and vanish once $2j > n$, so the sum is finite. The parent entry recorded this only as `native_decide`-checked numeric examples and posed the general proof as its first open question; this file discharges it for all $n$, axiom-free, by recognizing the identity already living inside Mathlib's antidiagonal Fibonacci sum.",
+    "mathContext": "$\\sum_{j=0}^{n} \\binom{n-j}{j} = F_{n+1}$ — e.g. $n=4$: $\\binom40+\\binom31+\\binom22 = 1+3+1 = 5 = F_5$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Pascal's triangle",
+      "Fibonacci numbers",
+      "binomial coefficients",
+      "Lucas (rising diagonals)"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "the Fibonacci sequence"
+    ]
+  },
+  {
+    "id": "ann-mirror-form",
+    "proofId": "combinations-formula-oq-01-oq-01",
+    "range": { "startLine": 30, "endLine": 35 },
+    "type": "technique",
+    "title": "The Mirror Form From Mathlib's Antidiagonal Sum",
+    "content": "Mathlib already proves the Fibonacci sum over the antidiagonal: `Nat.fib_succ_eq_sum_choose` gives $F_{n+1} = \\sum_{p \\in \\mathrm{antidiagonal}\\,n} \\binom{p_1}{p_2}$, where the antidiagonal of $n$ is the set of pairs $(k, n-k)$. Rewriting it through `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` converts that pair-indexed sum into a plain range sum, yielding the *mirror form* $\\sum_{k=0}^{n} \\binom{k}{n-k} = F_{n+1}$ in a single `rw`. This is the load-bearing step: all the mathematics is already in the library; the work is choosing the right index presentation.",
+    "mathContext": "$\\sum_{k=0}^{n} \\binom{k}{n-k} = F_{n+1}$, from $F_{n+1} = \\sum_{(k,n-k)} \\binom{k}{n-k}$ over the antidiagonal.",
+    "significance": "key",
+    "relatedConcepts": [
+      "antidiagonal",
+      "Nat.fib_succ_eq_sum_choose",
+      "Finset range sums",
+      "reindexing"
+    ],
+    "prerequisites": [
+      "Finset antidiagonal and range sums",
+      "Nat.fib_succ_eq_sum_choose"
+    ]
+  },
+  {
+    "id": "ann-diagonal-form",
+    "proofId": "combinations-formula-oq-01-oq-01",
+    "range": { "startLine": 37, "endLine": 48 },
+    "type": "insight",
+    "title": "The Diagonal Form by Index Reflection",
+    "content": "The two index conventions $\\binom{k}{n-k}$ and $\\binom{n-j}{j}$ are related by the single reflection $j \\mapsto n - j$. The proof rewrites by the mirror form and `Finset.sum_range_reflect`, which sends $\\sum_{k} f(k) = \\sum_{j} f(n-j)$ over `range (n+1)`. What remains is pure natural-number subtraction bookkeeping: under the range bound $j \\le n$, the two equalities $n+1-1-j = n-j$ and $n-(n-j) = j$ — each closed instantly by `omega` — line the reflected summand up termwise with $\\binom{n-j}{j}$. `omega` is exactly the right tool here because truncated $\\mathbb{N}$-subtraction makes these identities false without the hypothesis $j \\le n$.",
+    "mathContext": "Reflection $j \\mapsto n-j$ on $\\mathrm{range}(n+1)$: $\\binom{k}{n-k} \\leadsto \\binom{n-j}{\\,n-(n-j)\\,} = \\binom{n-j}{j}$ when $j \\le n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_range_reflect",
+      "index reflection",
+      "truncated subtraction",
+      "omega"
+    ],
+    "prerequisites": [
+      "the mirror form above",
+      "natural-number subtraction",
+      "the omega tactic"
+    ]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01-oq-01/index.ts
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CombinationsFormulaOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const combinationsFormulaOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const combinationsFormulaOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const combinationsFormulaOQ01OQ01Data: ProofData = {
+  proof: combinationsFormulaOQ01OQ01Proof,
+  annotations: combinationsFormulaOQ01OQ01Annotations,
+}

--- a/src/data/proofs/combinations-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01-oq-01/meta.json
@@ -76,6 +76,12 @@
   ],
   "sections": [
     {
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "States the shallow-diagonal Fibonacci identity ∑_j C(n−j, j) = F(n+1), the parent's first open question (recorded there only via native_decide examples), and the strategy: reduce to Mathlib's antidiagonal form Nat.fib_succ_eq_sum_choose by reflecting the index. Imports Mathlib and opens Finset."
+    },
+    {
       "title": "Mirror form from the antidiagonal sum",
       "startLine": 29,
       "endLine": 37,


### PR DESCRIPTION
Enrichment pass for `combinations-formula-oq-01-oq-01` — the identity ∑_j C(n−j, j) = F(n+1) (shallow diagonals of Pascal's triangle are the Fibonacci numbers).

The entry shipped with only `meta.json`. This pass adds the missing files and completes section coverage:

**New `annotations.json`** — 3 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
- the shallow-diagonal/Fibonacci identity and its finiteness (terms vanish once 2j > n)
- the mirror form from Mathlib's antidiagonal sum `Nat.fib_succ_eq_sum_choose` via `Finset.Nat.sum_antidiagonal_eq_sum_range_succ`
- the diagonal form by the single index reflection j ↦ n−j (`Finset.sum_range_reflect`), with the two ℕ-subtraction identities discharged by `omega` under j ≤ n

**New `index.ts`** — was missing, so the page would show "proof not found" on the live site. Follows the sibling template (`combinationsFormulaOQ01OQ01`).

**`meta.json`** — added a 'Module header and context' section covering lines 1–28; previously only 29–50 were covered. All existing content preserved.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`, 0 axioms, 0 sorries — no `native_decide`; the proof reduces to a Mathlib lemma plus index reflection).