### PR TITLE
research: degree factorisation [K:F] = |Aut_F(K)|·[K:F]_i for normal extensions [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/NormalAutDegreeFormula.lean
+++ b/proofs/Proofs/NormalAutDegreeFormula.lean
@@ -1,0 +1,147 @@
+/-
+# The Degree Factorisation for Normal Extensions: [K : F] = |Aut_F(K)| · [K : F]ᵢ
+
+This file is a follow-up to
+`angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01`
+("The Automorphism Equality for Normal Extensions: |Aut_F(K)| = [K : F]ₛ",
+`Proofs/NormalAutFinSepDegreeEquality.lean`), which proved that for a normal
+extension `K / F` the automorphism count equals the **separable** degree
+
+  `Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K`.
+
+That equality answered "how big is `Aut_F(K)`?" in terms of the separable degree.
+The natural next question is how the automorphism count sits inside the *full*
+degree `[K : F]`, which for an inseparable extension is strictly larger than the
+separable degree.
+
+**The factorisation.**  Mathlib records the multiplicativity of the two halves of
+the degree, `Field.finSepDegree_mul_finInsepDegree`:
+
+  `[K : F]ₛ · [K : F]ᵢ = [K : F]`,
+
+where `[K : F]ᵢ = Field.finInsepDegree F K = finrank (separableClosure F K) K` is the
+inseparable degree.  Substituting the parent's `Nat.card (K ≃ₐ[F] K) = [K : F]ₛ`
+turns this into a statement *about the automorphism group*:
+
+  `[K : F] = |Aut_F(K)| · [K : F]ᵢ`            (`finrank_eq_card_algEquiv_mul_finInsepDegree`).
+
+This is the genuinely new content.  Mathlib's `finSepDegree_mul_finInsepDegree`
+speaks only of the separable degree; the bridge to the *automorphism count*
+requires normality and is supplied by the parent.  Three structural consequences
+fall out immediately:
+
+* **Divisibility** (`card_algEquiv_dvd_finrank`): for any normal `K / F`,
+  `|Aut_F(K)| ∣ [K : F]`, with cofactor exactly the inseparable degree.  This is
+  the inseparable refinement of the Galois fact `|Gal(K/F)| = [K : F]`: the
+  automorphism group never sees the inseparable part of the degree, but it always
+  divides it.
+
+* **The inseparable degree as a quotient** (`finInsepDegree_eq_finrank_div_card`):
+  `[K : F]ᵢ = [K : F] / |Aut_F(K)|` for a finite normal extension — the
+  automorphism count measures exactly the separable part, so the leftover quotient
+  *is* the inseparable degree.
+
+* **The separability boundary** (`card_algEquiv_eq_finrank_iff_isSeparable`): the
+  automorphism count reaches the full degree iff the inseparable degree is `1`, i.e.
+  iff `K / F` is separable — recovering, *through the factorisation*, the boundary
+  the parent proved directly, and the Galois corollary
+  `IsGalois.card_aut_eq_finrank`.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+import Mathlib.FieldTheory.Normal.Defs
+import Mathlib.FieldTheory.SeparableDegree
+import Mathlib.FieldTheory.PurelyInseparable.Basic
+
+open Field Module
+
+variable (F K : Type*) [Field F] [Field K] [Algebra F K]
+
+namespace NormalAutDegreeFormula
+
+/-- **Parent equality, recalled.**  For a normal extension `K / F` the number of
+`F`-algebra automorphisms of `K` equals the separable degree `[K : F]ₛ`.  This is the
+content of `NormalAutEquality.card_algEquiv_eq_finSepDegree`; we reprove it here in a
+single line — the parent's injection `toEmb` is one half of `Normal.algHomEquivAut`,
+so counting both sides of that equivalence gives the equality. -/
+theorem card_algEquiv_eq_finSepDegree [Normal F K] :
+    Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K :=
+  (Nat.card_congr (Normal.algHomEquivAut F (AlgebraicClosure K) K)).symm
+
+/-- **The degree factorisation.**  For a normal extension `K / F`, the field degree
+factors as the automorphism count times the inseparable degree:
+
+  `[K : F] = |Aut_F(K)| · [K : F]ᵢ`.
+
+No finiteness hypothesis is needed: for an infinite normal extension every term is
+`0` and the identity reads `0 = 0`.  This is the parent's separable-degree equality
+fed into Mathlib's `finSepDegree_mul_finInsepDegree`. -/
+theorem finrank_eq_card_algEquiv_mul_finInsepDegree [Normal F K] :
+    finrank F K = Nat.card (K ≃ₐ[F] K) * Field.finInsepDegree F K := by
+  rw [card_algEquiv_eq_finSepDegree]
+  exact (Field.finSepDegree_mul_finInsepDegree F K).symm
+
+/-- **Divisibility.**  For any normal extension `K / F`, the automorphism count
+divides the full degree: `|Aut_F(K)| ∣ [K : F]`.  The cofactor is exactly the
+inseparable degree `[K : F]ᵢ`.  For a Galois (normal *and* separable) extension the
+cofactor is `1` and this recovers `|Gal(K/F)| = [K : F]`; in general the
+automorphism group only ever divides the degree, never exceeds the separable part. -/
+theorem card_algEquiv_dvd_finrank [Normal F K] :
+    Nat.card (K ≃ₐ[F] K) ∣ finrank F K :=
+  ⟨Field.finInsepDegree F K, finrank_eq_card_algEquiv_mul_finInsepDegree F K⟩
+
+/-- The automorphism count of a finite normal extension is positive — it equals the
+separable degree, which is nonzero in the finite-dimensional case. -/
+theorem card_algEquiv_pos [Normal F K] [FiniteDimensional F K] :
+    0 < Nat.card (K ≃ₐ[F] K) := by
+  rw [card_algEquiv_eq_finSepDegree]
+  exact Nat.pos_of_ne_zero (NeZero.ne _)
+
+/-- **The inseparable degree as a quotient.**  For a finite normal extension, the
+inseparable degree is precisely the full degree divided by the automorphism count:
+
+  `[K : F]ᵢ = [K : F] / |Aut_F(K)|`.
+
+Since `|Aut_F(K)|` measures exactly the separable part of the degree, the remaining
+quotient is the inseparable degree. -/
+theorem finInsepDegree_eq_finrank_div_card [Normal F K] [FiniteDimensional F K] :
+    Field.finInsepDegree F K = finrank F K / Nat.card (K ≃ₐ[F] K) := by
+  rw [finrank_eq_card_algEquiv_mul_finInsepDegree,
+    Nat.mul_div_cancel_left _ (card_algEquiv_pos F K)]
+
+/-- **The separability boundary, via the factorisation.**  For a finite normal
+extension, the automorphism count reaches the full degree iff the inseparable degree
+collapses to `1`.  This is the factorisation `[K : F] = |Aut_F(K)| · [K : F]ᵢ` read as
+a cancellation: with `|Aut_F(K)| > 0`, equality `|Aut_F(K)| = [K : F]` forces the
+inseparable cofactor to be `1`. -/
+theorem card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one
+    [Normal F K] [FiniteDimensional F K] :
+    Nat.card (K ≃ₐ[F] K) = finrank F K ↔ Field.finInsepDegree F K = 1 := by
+  rw [finrank_eq_card_algEquiv_mul_finInsepDegree]
+  constructor
+  · intro h
+    have hmul : Nat.card (K ≃ₐ[F] K) * 1
+        = Nat.card (K ≃ₐ[F] K) * Field.finInsepDegree F K := by
+      rw [mul_one]; exact h
+    exact (Nat.eq_of_mul_eq_mul_left (card_algEquiv_pos F K) hmul).symm
+  · intro h; rw [h, mul_one]
+
+/-- **Separability boundary (intrinsic form).**  Recovering, through the
+factorisation, the parent's boundary: a finite normal extension has full
+automorphism count iff it is separable — i.e. iff it is Galois. -/
+theorem card_algEquiv_eq_finrank_iff_isSeparable
+    [Normal F K] [FiniteDimensional F K] :
+    Nat.card (K ≃ₐ[F] K) = finrank F K ↔ Algebra.IsSeparable F K := by
+  rw [card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one,
+    isSeparable_iff_finInsepDegree_eq_one]
+
+/-- **Galois corollary.**  A finite normal *separable* extension — i.e. a finite
+Galois extension — has exactly `[K : F]` automorphisms.  Here it drops out of the
+factorisation once the inseparable degree is `1`, recovering
+`IsGalois.card_aut_eq_finrank`. -/
+theorem card_algEquiv_eq_finrank_of_isSeparable
+    [Normal F K] [FiniteDimensional F K] [Algebra.IsSeparable F K] :
+    Nat.card (K ≃ₐ[F] K) = finrank F K :=
+  (card_algEquiv_eq_finrank_iff_isSeparable F K).mpr ‹_›
+
+end NormalAutDegreeFormula

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01/meta.json
@@ -1,0 +1,215 @@
+{
+  "id": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01",
+  "title": "The Degree Factorisation for Normal Extensions: [K : F] = |Aut_F(K)| · [K : F]_i",
+  "slug": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01",
+  "description": "Follow-up to the normal-extension automorphism equality |Aut_F(K)| = [K:F]_s. The parent located the automorphism count inside the SEPARABLE degree; this entry locates it inside the FULL degree by feeding the parent's equality into Mathlib's degree multiplicativity finSepDegree · finInsepDegree = finrank. The result is the factorisation [K:F] = |Aut_F(K)| · [K:F]_i for any normal extension, with three structural consequences: |Aut_F(K)| ∣ [K:F] (divisibility, the inseparable refinement of |Gal| = [K:F]); [K:F]_i = [K:F] / |Aut_F(K)| (the inseparable degree is exactly the cofactor); and |Aut_F(K)| = [K:F] ⟺ K/F separable ⟺ Galois (recovered through the factorisation, with IsGalois.card_aut_eq_finrank as corollary). Mathlib v4.26 packages the finSepDegree-finInsepDegree multiplicativity but not its automorphism-count reading, which requires normality.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NormalAutDegreeFormula.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "field-extensions",
+      "separability",
+      "separable-degree",
+      "inseparable-degree",
+      "normal-extension",
+      "automorphism-group",
+      "degree-formula"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlibDependencies": [
+      {
+        "theorem": "Field.finSepDegree_mul_finInsepDegree",
+        "description": "The degree multiplicativity [K:F]_s · [K:F]_i = [K:F], i.e. Field.finSepDegree F K * Field.finInsepDegree F K = Module.finrank F K, where finInsepDegree F K := finrank (separableClosure F K) K. This is the Mathlib half; substituting the parent's |Aut| = [K:F]_s turns it into the automorphism-count factorisation.",
+        "module": "Mathlib.FieldTheory.PurelyInseparable.Basic"
+      },
+      {
+        "theorem": "Normal.algHomEquivAut",
+        "description": "For a normal extension the equivalence (K →ₐ[F] AlgebraicClosure K) ≃ (K ≃ₐ[F] K); Nat.card_congr of it gives the parent's recalled equality Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K used as the bridge into the factorisation.",
+        "module": "Mathlib.FieldTheory.Normal.Defs"
+      },
+      {
+        "theorem": "Field.finInsepDegree",
+        "description": "The finite inseparable degree finInsepDegree F K := finrank (separableClosure F K) K; the cofactor in the factorisation and the quotient [K:F] / |Aut_F(K)|.",
+        "module": "Mathlib.FieldTheory.SeparableClosure"
+      },
+      {
+        "theorem": "isSeparable_iff_finInsepDegree_eq_one",
+        "description": "Algebra.IsSeparable F K ↔ finInsepDegree F K = 1; converts the factorisation's collapse of the inseparable cofactor to 1 into the separability boundary, recovering the Galois case.",
+        "module": "Mathlib.FieldTheory.PurelyInseparable.Basic"
+      },
+      {
+        "theorem": "Field.instNeZeroFinSepDegree",
+        "description": "NeZero (finSepDegree F K) for a finite-dimensional extension; gives positivity of the automorphism count (via the parent equality) needed to cancel it in the quotient and iff statements.",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      },
+      {
+        "theorem": "Nat.mul_div_cancel_left / Nat.eq_of_mul_eq_mul_left",
+        "description": "Natural-number cancellation by the positive automorphism count, turning the factorisation [K:F] = |Aut| · [K:F]_i into the quotient [K:F]_i = [K:F] / |Aut| and the cancellation underlying the separability iff.",
+        "module": "Mathlib.Algebra.Order.Group.Nat"
+      }
+    ],
+    "originalContributions": [
+      "finrank_eq_card_algEquiv_mul_finInsepDegree: for ANY normal extension K/F, Module.finrank F K = Nat.card (K ≃ₐ[F] K) * Field.finInsepDegree F K, i.e. [K:F] = |Aut_F(K)| · [K:F]_i. Mathlib v4.26 has the multiplicativity [K:F]_s · [K:F]_i = [K:F] but NOT its reading in terms of the automorphism count; the bridge requires normality (supplied by the parent equality |Aut| = [K:F]_s). No finiteness hypothesis is needed — for an infinite normal extension every factor is 0.",
+      "card_algEquiv_dvd_finrank: for any normal extension, |Aut_F(K)| ∣ [K:F], with cofactor exactly the inseparable degree. This is the inseparable refinement of the Galois fact |Gal(K/F)| = [K:F]: the automorphism group never exceeds the separable part of the degree but always divides the full degree.",
+      "finInsepDegree_eq_finrank_div_card: for a finite normal extension, [K:F]_i = [K:F] / |Aut_F(K)|. Since the automorphism count measures the separable part of the degree, the residual quotient IS the inseparable degree — an explicit formula for the inseparable degree in terms of automorphisms.",
+      "card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one: for a finite normal extension, |Aut_F(K)| = [K:F] ↔ [K:F]_i = 1, read off the factorisation as cancellation by the positive automorphism count. Phrases the separability boundary in terms of the inseparable degree rather than (as the parent did) the separable degree.",
+      "card_algEquiv_eq_finrank_iff_isSeparable / card_algEquiv_eq_finrank_of_isSeparable: recovers the parent's separability boundary and Mathlib's IsGalois.card_aut_eq_finrank THROUGH the factorisation — composing the inseparable-degree boundary with isSeparable_iff_finInsepDegree_eq_one — exhibiting the Galois case as the inseparable-cofactor-equals-1 specialisation of the degree formula."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked over Mathlib v4.26; no axiom declarations, no structure-encoded assumptions, no native_decide. Only the foundational propext / Classical.choice / Quot.sound underlie the build.",
+    "lineCount": 147,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "leanFile": {
+    "path": "Proofs/NormalAutDegreeFormula.lean",
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "lineCount": 147,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "For a finite extension K/F the degree factors canonically as [K:F] = [K:F]_s · [K:F]_i, the separable times the inseparable degree (Lang, Algebra, V §6; the inseparable degree is a power of the characteristic). Independently, the automorphism count satisfies |Aut_F(K)| ≤ [K:F]_s with equality for normal extensions (Artin). The parent entry formalised that normal equality, |Aut_F(K)| = [K:F]_s. Combining it with the degree factorisation — packaged in Mathlib (2023–2024) as Field.finSepDegree_mul_finInsepDegree — expresses the full degree directly through the automorphism group: [K:F] = |Aut_F(K)| · [K:F]_i. Mathlib records the separable-degree multiplicativity and, separately, the Galois cardinality |Gal| = [K:F], but not this intermediate factorisation that makes the inseparable degree the explicit cofactor of the automorphism count for an arbitrary normal extension.",
+    "problemStatement": "**Question** (follow-up to the parent normal-equality entry): the parent showed the automorphism count of a normal extension equals the separable degree, |Aut_F(K)| = [K:F]_s. How does |Aut_F(K)| sit inside the FULL degree [K:F], which for an inseparable extension is strictly larger? Concretely: is there a degree factorisation through the automorphism count, does |Aut_F(K)| divide [K:F], and what is the cofactor?\n\n**Answer**: Yes. Feeding the parent equality into Mathlib's finSepDegree · finInsepDegree = finrank gives [K:F] = |Aut_F(K)| · [K:F]_i for any normal K/F. Hence |Aut_F(K)| ∣ [K:F] with cofactor the inseparable degree; for a finite extension [K:F]_i = [K:F] / |Aut_F(K)|; and |Aut_F(K)| = [K:F] exactly when the inseparable cofactor is 1, i.e. when K/F is separable (Galois) — recovering the parent boundary and IsGalois.card_aut_eq_finrank.",
+    "keyInsights": [
+      "The parent equality |Aut_F(K)| = [K:F]_s is the only normality-dependent input; everything else is the purely formal degree multiplicativity [K:F]_s · [K:F]_i = [K:F]. Substituting one into the other immediately reads the full degree through the automorphism count.",
+      "Divisibility |Aut_F(K)| ∣ [K:F] holds for ALL normal extensions, not only Galois ones. For Galois (separable) extensions the cofactor [K:F]_i is 1 and this is the classical |Gal| = [K:F]; in the inseparable case the cofactor is the characteristic-power inseparable degree, and the automorphism group divides the degree with that quotient.",
+      "The inseparable degree acquires an automorphism-theoretic meaning: [K:F]_i = [K:F] / |Aut_F(K)| for finite normal K/F. The automorphism group measures exactly the separable part of the degree, so the leftover quotient is precisely the inseparable part.",
+      "Reading the separability boundary off the factorisation: |Aut_F(K)| = [K:F] ⟺ the inseparable cofactor is 1 ⟺ K/F separable. This re-derives the parent's boundary (which used the separable degree directly) via the complementary inseparable degree, and exhibits the Galois cardinality lemma as the [K:F]_i = 1 specialisation.",
+      "No finiteness is needed for the factorisation itself: in the infinite normal case finrank, finInsepDegree, and the automorphism count all vanish and the identity reads 0 = 0. Finiteness is used only for the quotient and the iff (to cancel the positive automorphism count)."
+    ],
+    "proofStrategy": "1. card_algEquiv_eq_finSepDegree: recall the parent equality Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K via Nat.card_congr (Normal.algHomEquivAut F (AlgebraicClosure K) K), reproved in one line so the file is self-contained.\n2. finrank_eq_card_algEquiv_mul_finInsepDegree: rewrite the automorphism count to the separable degree, then close with (Field.finSepDegree_mul_finInsepDegree F K).symm.\n3. card_algEquiv_dvd_finrank: read the factorisation as a Dvd witness ⟨finInsepDegree F K, ·⟩.\n4. card_algEquiv_pos: the automorphism count equals the separable degree, which is NeZero in the finite-dimensional case.\n5. finInsepDegree_eq_finrank_div_card: rewrite by the factorisation and cancel via Nat.mul_div_cancel_left using positivity.\n6. card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one: rewrite by the factorisation and cancel the positive automorphism count (Nat.eq_of_mul_eq_mul_left) to isolate the inseparable cofactor.\n7. card_algEquiv_eq_finrank_iff_isSeparable: compose step 6 with isSeparable_iff_finInsepDegree_eq_one.\n8. card_algEquiv_eq_finrank_of_isSeparable: the Galois corollary, the separable instance of step 7.",
+    "prerequisites": [
+      "The separable / inseparable degree factorisation [K:F]_s · [K:F]_i = [K:F]; Mathlib's Field.finSepDegree, Field.finInsepDegree and finSepDegree_mul_finInsepDegree",
+      "The parent normal-extension automorphism equality |Aut_F(K)| = [K:F]_s via Normal.algHomEquivAut and Nat.card_congr",
+      "The inseparable degree as the degree over the separable closure, and isSeparable_iff_finInsepDegree_eq_one",
+      "Natural-number divisibility and cancellation: Nat.mul_div_cancel_left, Nat.eq_of_mul_eq_mul_left",
+      "Positivity of the separable degree (NeZero) for finite-dimensional extensions"
+    ]
+  },
+  "sections": [
+    {
+      "id": "file-header",
+      "title": "File Header — From Separable Degree to Full Degree",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Recalls the parent equality |Aut_F(K)| = [K:F]_s, states that combining it with Mathlib's degree multiplicativity finSepDegree · finInsepDegree = finrank yields the factorisation [K:F] = |Aut_F(K)| · [K:F]_i, and previews the three consequences (divisibility, the inseparable-degree quotient, the separability boundary)."
+    },
+    {
+      "id": "parent-equality",
+      "title": "The Parent Equality, Recalled",
+      "startLine": 52,
+      "endLine": 77,
+      "summary": "card_algEquiv_eq_finSepDegree: reproves in one line that Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K for normal K/F, via Nat.card_congr of Normal.algHomEquivAut, keeping the file self-contained."
+    },
+    {
+      "id": "factorisation",
+      "title": "The Degree Factorisation and Divisibility",
+      "startLine": 78,
+      "endLine": 94,
+      "summary": "finrank_eq_card_algEquiv_mul_finInsepDegree (the headline factorisation [K:F] = |Aut_F(K)| · [K:F]_i for any normal extension) and card_algEquiv_dvd_finrank (|Aut_F(K)| ∣ [K:F] with the inseparable degree as cofactor)."
+    },
+    {
+      "id": "quotient-and-boundary",
+      "title": "The Inseparable Degree as Quotient, and the Separability Boundary",
+      "startLine": 95,
+      "endLine": 147,
+      "summary": "card_algEquiv_pos, finInsepDegree_eq_finrank_div_card ([K:F]_i = [K:F] / |Aut_F(K)|), card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one and card_algEquiv_eq_finrank_iff_isSeparable (the separability boundary read through the factorisation), and the Galois corollary card_algEquiv_eq_finrank_of_isSeparable."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry, which proved the normal-extension equality |Aut_F(K)| = [K:F]_s. This entry feeds that equality into the degree factorisation [K:F]_s · [K:F]_i = [K:F] to locate the automorphism count inside the full degree, yielding [K:F] = |Aut_F(K)| · [K:F]_i, divisibility, and the inseparable-degree quotient."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "context",
+      "description": "Galois-theoretic infrastructure; the divisibility |Aut_F(K)| ∣ [K:F] and the inseparable-degree factorisation are reusable for characteristic-p extensions where the inseparable degree is non-trivial."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "finrank_eq_card_algEquiv_mul_finInsepDegree",
+      "type": "theorem",
+      "statement": "For a normal extension K/F: Module.finrank F K = Nat.card (K ≃ₐ[F] K) * Field.finInsepDegree F K",
+      "significance": "The headline result: the full field degree factors as the automorphism count times the inseparable degree, [K:F] = |Aut_F(K)| · [K:F]_i, for any normal extension. Mathlib has the separable-degree multiplicativity but not this automorphism-count reading, which requires normality. No finiteness hypothesis.",
+      "description": "Rewrite the parent equality Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K, then close with (Field.finSepDegree_mul_finInsepDegree F K).symm."
+    },
+    {
+      "name": "card_algEquiv_dvd_finrank",
+      "type": "theorem",
+      "statement": "For a normal extension K/F: Nat.card (K ≃ₐ[F] K) ∣ Module.finrank F K",
+      "significance": "Divisibility: the automorphism count divides the full degree, with cofactor the inseparable degree. The inseparable refinement of the Galois fact |Gal(K/F)| = [K:F] — for Galois extensions the cofactor is 1, in general it is the inseparable degree.",
+      "description": "The factorisation read as a divisibility witness ⟨Field.finInsepDegree F K, finrank_eq_card_algEquiv_mul_finInsepDegree⟩."
+    },
+    {
+      "name": "finInsepDegree_eq_finrank_div_card",
+      "type": "theorem",
+      "statement": "For a finite normal extension K/F: Field.finInsepDegree F K = Module.finrank F K / Nat.card (K ≃ₐ[F] K)",
+      "significance": "An explicit automorphism-theoretic formula for the inseparable degree: it is the full degree divided by the automorphism count. The automorphism group measures exactly the separable part, so the residual quotient is the inseparable degree.",
+      "description": "Rewrite by the factorisation and cancel the positive automorphism count via Nat.mul_div_cancel_left."
+    },
+    {
+      "name": "card_algEquiv_eq_finrank_iff_isSeparable",
+      "type": "theorem",
+      "statement": "For a finite normal extension K/F: Nat.card (K ≃ₐ[F] K) = Module.finrank F K ↔ Algebra.IsSeparable F K",
+      "significance": "The separability boundary recovered THROUGH the factorisation: full automorphism count iff the inseparable cofactor collapses to 1 iff K/F separable (Galois). Re-derives the parent boundary via the complementary inseparable degree.",
+      "description": "Compose card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one with isSeparable_iff_finInsepDegree_eq_one."
+    },
+    {
+      "name": "card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one",
+      "type": "theorem",
+      "statement": "For a finite normal extension K/F: Nat.card (K ≃ₐ[F] K) = Module.finrank F K ↔ Field.finInsepDegree F K = 1",
+      "significance": "The factorisation read as cancellation: with the automorphism count positive, equality with the full degree forces the inseparable cofactor to be 1. Phrases the boundary in terms of the inseparable degree, complementary to the parent's separable-degree phrasing.",
+      "description": "Rewrite by the factorisation, then cancel the positive automorphism count with Nat.eq_of_mul_eq_mul_left."
+    },
+    {
+      "name": "card_algEquiv_eq_finrank_of_isSeparable",
+      "type": "theorem",
+      "statement": "For a finite normal separable (= Galois) extension K/F: Nat.card (K ≃ₐ[F] K) = Module.finrank F K",
+      "significance": "The Galois corollary, recovering Mathlib's IsGalois.card_aut_eq_finrank as the inseparable-cofactor-equals-1 specialisation of the degree factorisation.",
+      "description": "The separable instance of card_algEquiv_eq_finrank_iff_isSeparable."
+    }
+  ],
+  "references": [
+    {
+      "type": "textbook",
+      "citation": "Lang, S. (2002). Algebra (3rd ed.), Chapter V (Algebraic Extensions), §4 (Galois Theory) and §6 (Separable and Inseparable Extensions). Springer GTM 211.",
+      "relevance": "States the degree factorisation [K:F] = [K:F]_s · [K:F]_i and the automorphism bound with equality for normal extensions — the textbook source of the factorisation through the automorphism count."
+    },
+    {
+      "type": "textbook",
+      "citation": "Artin, E. (1942). Galois Theory. Notre Dame Mathematical Lectures.",
+      "relevance": "The count of field automorphisms / embeddings of a normal extension underlying |Aut_F(K)| = [K:F]_s."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.FieldTheory.PurelyInseparable.Basic.\" (accessed 2026).",
+      "relevance": "Provides Field.finSepDegree_mul_finInsepDegree and isSeparable_iff_finInsepDegree_eq_one, the degree multiplicativity and separability characterisation driving the factorisation."
+    },
+    {
+      "type": "library",
+      "citation": "The mathlib Community. \"Mathlib.FieldTheory.SeparableClosure.\" (accessed 2026).",
+      "relevance": "Defines Field.finInsepDegree as the degree over the separable closure — the cofactor and quotient in the factorisation."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a normal extension K/F the automorphism count factors the full degree: [K:F] = |Aut_F(K)| · [K:F]_i, obtained by feeding the parent's normal equality |Aut_F(K)| = [K:F]_s into Mathlib's degree multiplicativity [K:F]_s · [K:F]_i = [K:F]. Three structural consequences follow: |Aut_F(K)| ∣ [K:F] for any normal extension (the inseparable refinement of |Gal| = [K:F]); [K:F]_i = [K:F] / |Aut_F(K)| for a finite normal extension (the inseparable degree is exactly the cofactor of the automorphism count); and |Aut_F(K)| = [K:F] ⟺ [K:F]_i = 1 ⟺ K/F separable, recovering the parent's separability boundary and Mathlib's IsGalois.card_aut_eq_finrank through the factorisation. Fully verified, 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Packages the automorphism-count degree factorisation and divisibility |Aut_F(K)| ∣ [K:F] for arbitrary normal extensions — content Mathlib v4.26 records only for the separable degree (multiplicativity) or under the full Galois hypothesis (|Gal| = [K:F]). It gives the inseparable degree an automorphism-theoretic identity, [K:F]_i = [K:F] / |Aut_F(K)|, and is a natural upstream candidate sitting between Mathlib's finSepDegree_mul_finInsepDegree and IsGalois.card_aut_eq_finrank.",
+    "openQuestions": [
+      "Does the factorisation refine along a normal tower F ⊆ E ⊆ K to a multiplicative formula relating |Aut_F(K)|, |Aut_E(K)| and the inseparable degrees of the steps, paralleling the multiplicativity of separable and inseparable degrees?",
+      "Can the divisibility |Aut_F(K)| ∣ [K:F] be upgraded to a structural statement about the fixed field of Aut_F(K) — namely that it is the relative purely inseparable closure, with [K : Fix(Aut_F K)] = |Aut_F(K)| and [Fix(Aut_F K) : F] = [K:F]_i (Artin's theorem in the inseparable setting)?"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up to **#28093** ("The Automorphism Equality for Normal Extensions: |Aut_F(K)| = [K:F]ₛ", `NormalAutFinSepDegreeEquality.lean`), which located the automorphism count inside the **separable** degree. This entry locates it inside the **full** degree.

Feeding the parent equality `Nat.card (K ≃ₐ[F] K) = finSepDegree F K` into Mathlib's degree multiplicativity `Field.finSepDegree_mul_finInsepDegree` (`finSepDegree · finInsepDegree = finrank`) gives, for **any** normal extension `K/F`:

```
finrank F K = Nat.card (K ≃ₐ[F] K) * finInsepDegree F K       -- [K:F] = |Aut_F(K)| · [K:F]ᵢ
```

### Structural consequences
- **Divisibility** `card_algEquiv_dvd_finrank`: `|Aut_F(K)| ∣ [K:F]` for any normal extension — the inseparable refinement of the Galois fact `|Gal| = [K:F]`, with cofactor the inseparable degree.
- **Inseparable degree as quotient** `finInsepDegree_eq_finrank_div_card`: `[K:F]ᵢ = [K:F] / |Aut_F(K)|` for finite normal extensions — the automorphism count measures exactly the separable part, the residual quotient is the inseparable part.
- **Separability boundary** `card_algEquiv_eq_finrank_iff_isSeparable`: `|Aut_F(K)| = [K:F] ⟺ [K:F]ᵢ = 1 ⟺ K/F separable`, recovered *through the factorisation*; the Galois corollary `card_algEquiv_eq_finrank_of_isSeparable` recovers Mathlib's `IsGalois.card_aut_eq_finrank`.

### Why this is new
Mathlib v4.26 has the `finSepDegree`/`finInsepDegree` multiplicativity and, separately, the Galois cardinality `|Gal| = [K:F]`, but **not** the automorphism-count reading of the factorisation for an arbitrary normal (possibly inseparable) extension — the bridge requires normality, supplied by the parent. The factorisation needs no finiteness; finiteness is used only for the quotient and iff (to cancel the positive automorphism count).

## Verification
- `proofs/Proofs/NormalAutDegreeFormula.lean` — **8 theorems, 147 lines, 0 sorries, 0 axioms, no `native_decide`**.
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.NormalAutDegreeFormula`.
- Self-contained (imports only Mathlib); the parent equality is reproved in one line via `Normal.algHomEquivAut`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)