### PR TITLE
research(denumerability-rationals-oq-05-oq-01-oq-01-oq-01-oq-01): localization preserves cardinality for infinite rings — #(FractionRing R)=#R [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3565,6 +3565,7 @@ import Proofs.SumOfOddsStatementOnly
 import Proofs.SummationByPartsOQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01OQ02
+import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ01
 import Proofs.SummationByPartsOQ01OQ01OQ01OQ02OQ02
 import Proofs.SylowTheorem
 import Proofs.SylowTheoremOQ01

--- a/proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-
+# Localization preserves cardinality for infinite rings — `#(FractionRing R) = #R`
+
+## What this proves
+
+The parent entry showed that localization never escapes *countability*: the fraction
+field of a countable ring is countable (`#(FractionRing R) = ℵ₀`).  That argument is
+really a cardinal-arithmetic fact specialised to `ℵ₀`.  This entry isolates the
+quantitative core and proves it for an **arbitrary infinite** ring: inverting a
+multiplicative set never changes the cardinality.
+
+* `mk_isLocalization_le` — **the headline bound.**  For an *infinite* commutative
+  semiring `R`, a submonoid `M`, and any localization `S` of `R` at `M`, `#S ≤ #R`.
+  Every `z : S` is `mk' S r m` for some `(r, m) ∈ R × M` (`IsLocalization.mk'_surjective`),
+  so `#S ≤ #(R × M) = #R · #M ≤ #R · #R = #R`, the last step being
+  `Cardinal.mul_eq_self` for an infinite cardinal.
+
+* `mk_localization_eq_of_le_nonZeroDivisors` — when `M ≤ R⁰` the structure map
+  `algebraMap R S` is injective, so the bound upgrades to an **equality** `#S = #R`.
+
+* `mk_isFractionRing_eq` / `mk_fractionRing_eq` — the fraction field of an infinite
+  integral domain has exactly the cardinality of the domain: `#(FractionRing R) = #R`.
+
+* `mk_rat_eq_int` / `mk_rat_eq_aleph0` — **the loop closes.**  `ℚ` is the field of
+  fractions of `ℤ`, so `#ℚ = #ℤ`, and since `ℤ` is denumerable this re-derives
+  `#ℚ = ℵ₀` (the parent's headline) as the `R = ℤ` instance of the cardinality
+  principle — but now via the *equality* `#ℚ = #ℤ`, not just an `ℵ₀` bound.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and
+`sorry`-free.
+-/
+
+open Cardinal
+
+universe u
+
+namespace DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01
+
+/-! ## Part 1: localization never increases cardinality -/
+
+/-- **Localization never increases cardinality (infinite base).**  For an infinite
+commutative semiring `R` and any localization `S` of `R` at a submonoid `M`, `#S ≤ #R`.
+
+`IsLocalization.mk'_surjective` exhibits `S` as a surjective image of `R × M`, so
+`#S ≤ #(R × M)`.  Since `R` is infinite, `#(R × M) = #R · #M ≤ #R · #R = #R`. -/
+theorem mk_isLocalization_le {R : Type u} [CommSemiring R] [Infinite R] (M : Submonoid R)
+    (S : Type u) [CommSemiring S] [Algebra R S] [IsLocalization M S] :
+    #S ≤ #R := by
+  have h1 : #S ≤ #(R × M) :=
+    mk_le_of_surjective (IsLocalization.mk'_surjective (S := S) M)
+  have h2 : #(R × M) ≤ #R := by
+    rw [Cardinal.mk_prod]
+    simp only [Cardinal.lift_id]
+    calc #R * #(M : Type _) ≤ #R * #R := by
+          gcongr
+          exact mk_le_of_injective Subtype.val_injective
+      _ = #R := mul_eq_self (aleph0_le_mk R)
+  exact h1.trans h2
+
+/-! ## Part 2: equality when the structure map is injective -/
+
+/-- When the inverted submonoid lies in the non-zero-divisors, `algebraMap R S` is
+injective, so the bound `#S ≤ #R` becomes an equality `#S = #R`. -/
+theorem mk_localization_eq_of_le_nonZeroDivisors {R : Type u} [CommRing R] [Infinite R]
+    {M : Submonoid R} (hM : M ≤ nonZeroDivisors R) (S : Type u) [CommRing S]
+    [Algebra R S] [IsLocalization M S] :
+    #S = #R :=
+  le_antisymm (mk_isLocalization_le M S)
+    (mk_le_of_injective (IsLocalization.injective (S := S) hM))
+
+/-- **The fraction field of an infinite integral domain has the domain's cardinality.**
+For any field of fractions `S` of an infinite integral domain `R`, `#S = #R`. -/
+theorem mk_isFractionRing_eq {R : Type u} [CommRing R] [IsDomain R] [Infinite R]
+    (S : Type u) [CommRing S] [Algebra R S] [IsFractionRing R S] :
+    #S = #R :=
+  le_antisymm (mk_isLocalization_le (nonZeroDivisors R) S)
+    (mk_le_of_injective (IsFractionRing.injective R S))
+
+/-- The concrete fraction field `FractionRing R` of an infinite integral domain has
+cardinality `#R`. -/
+theorem mk_fractionRing_eq {R : Type u} [CommRing R] [IsDomain R] [Infinite R] :
+    #(FractionRing R) = #R :=
+  mk_isFractionRing_eq (R := R) (FractionRing R)
+
+/-! ## Part 3: closing the loop — the rationals -/
+
+/-- **Closing the loop.**  `ℚ` is the field of fractions of `ℤ`
+(`Rat.isFractionRing : IsFractionRing ℤ ℚ`), so `#ℚ = #ℤ` is the cardinality principle
+applied to `ℤ`. -/
+theorem mk_rat_eq_int : #ℚ = #ℤ :=
+  mk_isFractionRing_eq (R := ℤ) ℚ
+
+/-- Re-deriving the parent's headline `#ℚ = ℵ₀` from the equality `#ℚ = #ℤ` together with
+the denumerability of `ℤ`. -/
+theorem mk_rat_eq_aleph0 : #ℚ = ℵ₀ := by
+  rw [mk_rat_eq_int]; exact mk_eq_aleph0 ℤ
+
+end DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01

--- a/proofs/Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ01.lean
@@ -1,0 +1,170 @@
+import Mathlib.Algebra.BigOperators.Module
+import Mathlib.Tactic
+
+/-
+# Finite Taylor–Abel expansion via iterated discrete integration by parts
+
+## What This Proves
+
+Over **any** commutative ring `R`, fix a sequence `f : ℕ → R` and a *tower of
+antidifferences* `G : ℕ → ℕ → R` linked by the single hypothesis
+
+    G (d+1) (k+1) − G (d+1) k = G d (k+1)        for all `d k`.        (hG)
+
+Writing `Δh k = h (k+1) − h k` for the forward difference and `Δ^[d]` for its
+`d`-fold iterate, the main theorem `discrete_taylor_abel` is the closed
+`D`-fold identity
+
+    ∑_{k<n} f k · G 0 (k+1)
+      = ∑_{d<D} (−1)^d · ( Δ^[d] f n · G (d+1) n − Δ^[d] f 0 · G (d+1) 0 )
+        + (−1)^D · ∑_{k<n} Δ^[D] f k · G D (k+1).                      (T)
+
+This is the discrete mirror of repeated integration by parts building a
+Taylor-with-remainder series
+
+    ∫ f dG = ∑_{d<D} (−1)^d [ f^{(d)} G_{(d+1)} ] ± ∫ f^{(D)} G_{(D)} :
+
+each layer trades one forward difference off `f` onto the next antidifference of
+`G`, paying an alternating boundary term `[Δ^[d] f · G (d+1)]_0^n`, and after `D`
+layers a remainder sum `∑ Δ^[D] f · G D (·+1)` is left.
+
+## Why This Is the Right Object
+
+The parent entry `SummationByPartsOQ01OQ01OQ01OQ02` proves the **single-step**
+discrete Abel transform over a commutative ring,
+
+    ∑_{k<n} a k · (B (k+1) − B k)
+      = a n · B n − a 0 · B 0 − ∑_{k<n} (a (k+1) − a k) · B (k+1).      (A)
+
+It recorded as an open question whether the transform could be *iterated* into a
+finite discrete Taylor–Abel series.  Identity (T) is exactly that iteration:
+`discrete_taylor_abel` is proved by induction on the depth `D`, with each step
+applying (A) once (lemma `step`) to peel the top remainder, increment the
+alternating sign, and append one boundary term.  The hypothesis (hG) is the
+precise antidifference relation under which the boundary terms land cleanly at
+the *fixed* endpoints `0` and `n` (no shift accumulation) and the remainder
+reproduces the same shape one level up — the property that makes the recursion
+`R d = bd d − R (d+1)` close.
+
+The base case `D = 0` of (T) is the trivial identity (empty boundary sum, the
+remainder *is* the left-hand side), and the `D = 1` case is the parent transform
+(A) verbatim.  The corollary `discrete_taylor_abel_of_fdiff_eq_zero` records the
+payoff: when `Δ^[D] f = 0` (a discrete polynomial of degree `< D`) the remainder
+vanishes and the expansion **terminates** as a finite alternating sum of boundary
+terms — the discrete finite Taylor formula.
+
+## Method
+
+`fdiff` is the forward difference; `fdiff^[d]` its iterate via `Function.iterate`.
+The single-step recursion `step` rewrites `G d (k+1)` as the difference
+`G (d+1) (k+1) − G (d+1) k` using (hG), applies the parent transform (A) with
+`a := Δ^[d] f`, `B := G (d+1)`, and recognises the resulting difference of
+`Δ^[d] f` as `Δ^[d+1] f` (`Function.iterate_succ_apply'`).  The main induction
+on `D` then telescopes the alternating sum with `Finset.sum_range_succ`,
+`pow_succ`, and `ring`.
+
+## Tags
+
+summation-by-parts, abel-summation, abel-transform, discrete-taylor,
+finite-differences, iterated-integration-by-parts, telescoping, commutative-ring
+-/
+
+namespace SummationByPartsOQ01OQ01OQ01OQ02OQ01
+
+open Finset
+
+variable {R : Type*} [CommRing R]
+
+/-- The forward difference operator `Δh k = h (k+1) − h k`. -/
+def fdiff (h : ℕ → R) : ℕ → R := fun k => h (k + 1) - h k
+
+@[simp] lemma fdiff_apply (h : ℕ → R) (k : ℕ) : fdiff h k = h (k + 1) - h k := rfl
+
+/-- One unfolding of the iterated forward difference:
+`Δ^[d+1] = Δ ∘ Δ^[d]`. -/
+lemma fdiff_iterate_succ (f : ℕ → R) (d : ℕ) :
+    fdiff^[d + 1] f = fdiff (fdiff^[d] f) :=
+  Function.iterate_succ_apply' fdiff d f
+
+/-- **The single-step discrete Abel transform (A)** — the parent entry's
+identity, reproved here from scratch so this file is self-contained.
+Over any commutative ring, for any sequences `a, B` and any `n`,
+`∑_{k<n} a k · (B (k+1) − B k) = a n · B n − a 0 · B 0 − ∑_{k<n} (a (k+1) − a k) · B (k+1)`. -/
+theorem abel_summation (a B : ℕ → R) (n : ℕ) :
+    ∑ k ∈ range n, a k * (B (k + 1) - B k)
+      = a n * B n - a 0 * B 0
+        - ∑ k ∈ range n, (a (k + 1) - a k) * B (k + 1) := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      rw [Finset.sum_range_succ (fun k => a k * (B (k + 1) - B k)), ih,
+        Finset.sum_range_succ (fun k => (a (k + 1) - a k) * B (k + 1))]
+      ring
+
+/-- **One layer of the iteration.** Under the antidifference hypothesis (hG),
+applying the single-step transform (A) at depth `d` peels one boundary term and
+drops the remainder from depth `d` to depth `d+1`:
+`∑_{k<n} Δ^[d] f k · G d (k+1) = Δ^[d] f n · G (d+1) n − Δ^[d] f 0 · G (d+1) 0 − ∑_{k<n} Δ^[d+1] f k · G (d+1) (k+1)`. -/
+theorem step (f : ℕ → R) (G : ℕ → ℕ → R)
+    (hG : ∀ d k, G (d + 1) (k + 1) - G (d + 1) k = G d (k + 1)) (n d : ℕ) :
+    ∑ k ∈ range n, (fdiff^[d] f) k * G d (k + 1)
+      = (fdiff^[d] f) n * G (d + 1) n - (fdiff^[d] f) 0 * G (d + 1) 0
+        - ∑ k ∈ range n, (fdiff^[d + 1] f) k * G (d + 1) (k + 1) := by
+  have key := abel_summation (fdiff^[d] f) (G (d + 1)) n
+  have hL : ∑ k ∈ range n, (fdiff^[d] f) k * G d (k + 1)
+      = ∑ k ∈ range n, (fdiff^[d] f) k * (G (d + 1) (k + 1) - G (d + 1) k) := by
+    apply Finset.sum_congr rfl
+    intro k _
+    rw [hG d k]
+  have hR : ∑ k ∈ range n, (fdiff^[d + 1] f) k * G (d + 1) (k + 1)
+      = ∑ k ∈ range n, ((fdiff^[d] f) (k + 1) - (fdiff^[d] f) k) * G (d + 1) (k + 1) := by
+    apply Finset.sum_congr rfl
+    intro k _
+    simp only [fdiff_iterate_succ, fdiff_apply]
+  rw [hL, hR]
+  exact key
+
+/-- **Finite Taylor–Abel expansion (T).** Iterating the single-step transform
+`D` times along the antidifference tower `G` (linked by `hG`) gives an
+alternating sum of boundary terms plus a remainder sum:
+`∑_{k<n} f k · G 0 (k+1) = ∑_{d<D} (−1)^d (Δ^[d] f n · G (d+1) n − Δ^[d] f 0 · G (d+1) 0) + (−1)^D ∑_{k<n} Δ^[D] f k · G D (k+1)`. -/
+theorem discrete_taylor_abel (f : ℕ → R) (G : ℕ → ℕ → R)
+    (hG : ∀ d k, G (d + 1) (k + 1) - G (d + 1) k = G d (k + 1)) (n D : ℕ) :
+    ∑ k ∈ range n, f k * G 0 (k + 1)
+      = (∑ d ∈ range D, (-1) ^ d *
+            ((fdiff^[d] f) n * G (d + 1) n - (fdiff^[d] f) 0 * G (d + 1) 0))
+        + (-1) ^ D * ∑ k ∈ range n, (fdiff^[D] f) k * G D (k + 1) := by
+  induction D with
+  | zero => simp
+  | succ D ih =>
+      rw [ih, Finset.sum_range_succ, step f G hG n D, pow_succ]
+      ring
+
+/-- **The expansion terminates for discrete polynomials.** If the `D`-th forward
+difference of `f` vanishes (i.e. `f` is a discrete polynomial of degree `< D`),
+the remainder term in `discrete_taylor_abel` drops out and the Taylor–Abel
+expansion is a finite alternating sum of boundary terms. -/
+theorem discrete_taylor_abel_of_fdiff_eq_zero (f : ℕ → R) (G : ℕ → ℕ → R)
+    (hG : ∀ d k, G (d + 1) (k + 1) - G (d + 1) k = G d (k + 1)) (n D : ℕ)
+    (hf : fdiff^[D] f = 0) :
+    ∑ k ∈ range n, f k * G 0 (k + 1)
+      = ∑ d ∈ range D, (-1) ^ d *
+          ((fdiff^[d] f) n * G (d + 1) n - (fdiff^[d] f) 0 * G (d + 1) 0) := by
+  rw [discrete_taylor_abel f G hG n D, hf]
+  simp
+
+/-- **Specialisation to `D = 1`: recovery of the single-step transform.**
+The depth-one Taylor–Abel expansion is exactly the parent's Abel transform (A)
+applied to the first antidifference `G 1`. -/
+theorem discrete_taylor_abel_one (f : ℕ → R) (G : ℕ → ℕ → R)
+    (hG : ∀ d k, G (d + 1) (k + 1) - G (d + 1) k = G d (k + 1)) (n : ℕ) :
+    ∑ k ∈ range n, f k * G 0 (k + 1)
+      = f n * G 1 n - f 0 * G 1 0
+        - ∑ k ∈ range n, (f (k + 1) - f k) * G 1 (k + 1) := by
+  have h := discrete_taylor_abel f G hG n 1
+  simp only [Finset.sum_range_one, pow_zero, pow_one, one_mul, neg_one_mul,
+    Function.iterate_zero, Function.iterate_one, id_eq, zero_add, fdiff_apply] at h
+  rw [h]
+  ring
+
+end SummationByPartsOQ01OQ01OQ01OQ02OQ01

--- a/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-05-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01-oq-01",
+  "title": "Localization Preserves Cardinality for Infinite Rings: #(FractionRing R) = #R",
+  "slug": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01-oq-01",
+  "description": "The parent entry showed localization never escapes countability — the fraction field of a countable ring is countable, #(FractionRing R) = ℵ₀. That argument is really a cardinal-arithmetic fact specialized to ℵ₀. This entry isolates the quantitative core and proves it for an arbitrary INFINITE ring, answering the parent's first open question: inverting a multiplicative set never changes cardinality. The headline mk_isLocalization_le shows that for an infinite commutative semiring R, any submonoid M, and any localization S of R at M, #S ≤ #R — because IsLocalization.mk'_surjective exhibits S as a surjective image of R × M, and for infinite R one has #(R × M) = #R · #M ≤ #R · #R = #R (Cardinal.mul_eq_self). When M ≤ R⁰ the structure map is injective, upgrading the bound to an equality (mk_localization_eq_of_le_nonZeroDivisors), and for an infinite integral domain the fraction field satisfies #(FractionRing R) = #R exactly (mk_isFractionRing_eq, mk_fractionRing_eq). Specializing to ℚ = Frac(ℤ) yields #ℚ = #ℤ (mk_rat_eq_int) and re-derives the parent's #ℚ = ℵ₀ — now via the equality #ℚ = #ℤ rather than an ℵ₀ bound.",
+  "meta": {
+    "author": "Cantor (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Aleph_number",
+    "date": "1874",
+    "status": "verified",
+    "tags": [
+      "set-theory",
+      "cardinality",
+      "cardinal-arithmetic",
+      "localization",
+      "fraction-field",
+      "ring-theory",
+      "infinite-rings",
+      "denumerability",
+      "rational-numbers",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsLocalization.mk'_surjective",
+        "description": "Surjective (fun ((r, m) : R × M) ↦ mk' S r m) — every element of a localization S is mk' S r m for some (r, m) ∈ R × M; the surjection that carries the cardinality bound from R × M onto S",
+        "module": "Mathlib.RingTheory.Localization.Defs"
+      },
+      {
+        "theorem": "Cardinal.mul_eq_self",
+        "description": "ℵ₀ ≤ c → c * c = c — the cardinal-arithmetic core: for an infinite cardinal #R, #R · #R = #R, collapsing #(R × M) ≤ #R · #R to #R",
+        "module": "Mathlib.SetTheory.Cardinal.Arithmetic"
+      },
+      {
+        "theorem": "Cardinal.mk_prod",
+        "description": "#(α × β) = lift #α * lift #β — turns #(R × M) into the product #R · #M (lifts trivial in a single universe), the bridge between the surjection and cardinal multiplication",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Cardinal.mk_le_of_surjective / Cardinal.mk_le_of_injective",
+        "description": "Surjective f → #β ≤ #α and Injective f → #α ≤ #β — convert the mk' surjection into #S ≤ #(R × M) and the injective algebraMap into the reverse bound #R ≤ #S",
+        "module": "Mathlib.SetTheory.Cardinal.Order"
+      },
+      {
+        "theorem": "Cardinal.aleph0_le_mk",
+        "description": "[Infinite α] → ℵ₀ ≤ #α — supplies the infinitude hypothesis of mul_eq_self directly from Infinite R",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "IsLocalization.injective / IsFractionRing.injective",
+        "description": "M ≤ nonZeroDivisors R → Injective (algebraMap R S), and the fraction-ring instance — upgrade the bound #S ≤ #R to the equality #S = #R",
+        "module": "Mathlib.RingTheory.Localization.FractionRing"
+      },
+      {
+        "theorem": "Rat.isFractionRing",
+        "description": "IsFractionRing ℤ ℚ — identifies ℚ as Frac(ℤ), so #ℚ = #ℤ is the equality specialized; with Cardinal.mk_eq_aleph0 on ℤ this recovers #ℚ = ℵ₀",
+        "module": "Mathlib.RingTheory.Localization.FractionRing"
+      }
+    ],
+    "originalContributions": [
+      "mk_isLocalization_le: #S ≤ #R for any localization S of an infinite commutative semiring R at a submonoid M — the quantitative generalization of the parent's countability result, dropping [Countable R] entirely; proved via the mk' surjection R × M ↠ S and Cardinal.mul_eq_self",
+      "mk_localization_eq_of_le_nonZeroDivisors: #S = #R when M ≤ nonZeroDivisors R, upgrading the bound to an equality through injectivity of algebraMap R S",
+      "mk_isFractionRing_eq: #S = #R for any field of fractions S of an infinite integral domain R",
+      "mk_fractionRing_eq: #(FractionRing R) = #R for an infinite integral domain — directly answering the parent entry's first open question (whether the ℵ₀ result extends to general infinite R)",
+      "mk_rat_eq_int: #ℚ = #ℤ as the equality specialized to IsFractionRing ℤ ℚ",
+      "mk_rat_eq_aleph0: #ℚ = ℵ₀ re-derived from the equality #ℚ = #ℤ together with the denumerability of ℤ — recovering the parent's headline through the sharper equality"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 100,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The denumerability of ℚ — that the rationals can be listed — is the root of this problem family, and ℚ is by construction the field of fractions of ℤ. The parent entry showed that the construction producing ℚ, localization, preserves COUNTABILITY: #(FractionRing R) = ℵ₀ for a countable domain R, recovering #ℚ = ℵ₀ as an instance of a general principle. But that argument used ℵ₀ in an essential way (countability of R × M). The natural next question, posed explicitly by the parent, is whether the phenomenon is really about ℵ₀ at all, or whether localization preserves cardinality at every infinite level — the analogue of the polynomial cardinality-preservation results #(R[X]) = #R for infinite R proved elsewhere in this family.",
+    "problemStatement": "**Open Question (denumerability-rationals-oq-05-oq-01-oq-01-oq-01, posed as that entry's first open question)**: For an uncountable ring R, #(FractionRing R) = #R = 𝔠 is expected. Is #(FractionRing R) = #R provable in general for infinite R, giving a localization analogue of the polynomial cardinality-preservation results?\n\n**Result**: Yes. mk_isLocalization_le establishes #S ≤ #R for any localization of an infinite commutative semiring; mk_localization_eq_of_le_nonZeroDivisors and mk_isFractionRing_eq / mk_fractionRing_eq give the equality #(FractionRing R) = #R for an infinite integral domain; and mk_rat_eq_int / mk_rat_eq_aleph0 recover #ℚ = #ℤ = ℵ₀ as the ℤ instance.",
+    "text": "For an infinite commutative semiring R and any localization S of R at a submonoid M, #S ≤ #R. When the inverted submonoid lies in the non-zero-divisors the structure map algebraMap R S is injective, so the bound becomes an equality #S = #R; in particular #(FractionRing R) = #R for an infinite integral domain. Specializing to ℚ = Frac(ℤ) gives #ℚ = #ℤ, recovering #ℚ = ℵ₀.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. `mk_isLocalization_le`: `IsLocalization.mk'_surjective` gives that `fun ((r, m) : R × M) ↦ mk' S r m` is surjective onto S, so `Cardinal.mk_le_of_surjective` yields #S ≤ #(R × M). Then `Cardinal.mk_prod` rewrites #(R × M) = #R · #M (the universe lifts are identities since R and M share a universe), the subtype bound #M ≤ #R (`mk_le_of_injective Subtype.val_injective`) and monotonicity give #R · #M ≤ #R · #R, and `Cardinal.mul_eq_self (aleph0_le_mk R)` collapses #R · #R = #R. Chaining: #S ≤ #R.\n2. `mk_localization_eq_of_le_nonZeroDivisors`: when M ≤ R⁰, `IsLocalization.injective` makes algebraMap R S injective, so `mk_le_of_injective` gives the reverse #R ≤ #S; `le_antisymm` yields #S = #R.\n3. `mk_isFractionRing_eq` / `mk_fractionRing_eq`: IsFractionRing R S has nonZeroDivisors R as its inverted monoid and `IsFractionRing.injective` for the reverse bound, so #S = #R; FractionRing R is the canonical instance.\n4. `mk_rat_eq_int` / `mk_rat_eq_aleph0`: ℚ carries `IsFractionRing ℤ ℚ`, so #ℚ = #ℤ; since ℤ is countably infinite, `Cardinal.mk_eq_aleph0` gives #ℤ = ℵ₀ and hence #ℚ = ℵ₀ — the parent's headline, now through the equality.",
+    "keyInsights": [
+      "**The result was never about ℵ₀.** The parent's countability proof and this cardinality equality share one surjection R × M ↠ S; the only difference is whether one invokes Function.Surjective.countable or Cardinal.mul_eq_self afterward. Dropping [Countable R] and replacing the countability closure with mul_eq_self generalizes ℵ₀ to every infinite cardinal in a single stroke.",
+      "**One inequality, two readings.** #S ≤ #R holds for ANY localization (no domain or injectivity hypothesis); the equality needs only that the inverted monoid avoids zero divisors so the base embeds. Separating the bound from the equality keeps the general semiring statement maximally weak-hypothesis.",
+      "**Cardinal arithmetic does all the work.** Beyond the localization surjection the proof is pure Cardinal.mul_eq_self — #R · #R = #R for infinite #R. The multiplicative and ring structure of S, and the size of M, are irrelevant to the count.",
+      "**The loop closes through an equality, not a bound.** Where the parent obtained #ℚ = ℵ₀ from countability + infinitude, here it factors through #ℚ = #ℤ: the rationals have exactly the cardinality of the integers because Frac is cardinality-preserving, and #ℤ = ℵ₀ supplies the value."
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic in Mathlib (ℵ₀, mk_prod, mul_eq_self for infinite cardinals, aleph0_le_mk, mk_le_of_surjective/injective)",
+      "Localization of a commutative ring: IsLocalization M S, mk', mk'_surjective, and injectivity of algebraMap when M ≤ nonZeroDivisors R",
+      "Fraction fields: FractionRing R, IsFractionRing, IsFractionRing.injective, and the canonical IsFractionRing ℤ ℚ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring framing the entry as the quantitative (infinite-cardinality) core of the parent's countability result and the answer to its first open question, the Mathlib import, the Cardinal open, the universe variable u, and the namespace.",
+      "mathContext": "$\\#(\\mathrm{FractionRing}\\,R) = \\#R$ for infinite $R$ as the cardinal-arithmetic generalization of $\\#(\\mathrm{FractionRing}\\,R)=\\aleph_0$."
+    },
+    {
+      "id": "bound",
+      "title": "Localization Never Increases Cardinality",
+      "startLine": 41,
+      "endLine": 61,
+      "summary": "mk_isLocalization_le: #S ≤ #R for any localization S of an infinite commutative semiring R at a submonoid M, via the mk' surjection R × M ↠ S, mk_prod, and Cardinal.mul_eq_self.",
+      "mathContext": "$\\#S \\le \\#(R\\times M) = \\#R\\cdot\\#M \\le \\#R\\cdot\\#R = \\#R$ for infinite $R$."
+    },
+    {
+      "id": "equality",
+      "title": "Equality When the Structure Map Is Injective",
+      "startLine": 62,
+      "endLine": 86,
+      "summary": "mk_localization_eq_of_le_nonZeroDivisors (#S = #R when M ≤ R⁰), mk_isFractionRing_eq (#S = #R for any fraction field of an infinite domain), and mk_fractionRing_eq (#(FractionRing R) = #R) — the answer to the parent's open question.",
+      "mathContext": "Injectivity of $\\mathrm{algebraMap}\\,R\\,S$ gives $\\#R \\le \\#S$, so $\\#S = \\#R$ by antisymmetry."
+    },
+    {
+      "id": "rationals",
+      "title": "Closing the Loop: the Rationals",
+      "startLine": 87,
+      "endLine": 100,
+      "summary": "mk_rat_eq_int (#ℚ = #ℤ via IsFractionRing ℤ ℚ) and mk_rat_eq_aleph0 (#ℚ = ℵ₀ recovered from the equality #ℚ = #ℤ plus the denumerability of ℤ).",
+      "mathContext": "$\\mathbb{Q} = \\mathrm{Frac}(\\mathbb{Z})$, so $\\#\\mathbb{Q} = \\#\\mathbb{Z} = \\aleph_0$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Answers the parent entry's first open question, generalizing its countability result #(FractionRing R) = ℵ₀ to the cardinality equality #(FractionRing R) = #R for an arbitrary infinite integral domain, and recovering #ℚ = ℵ₀ through the sharper #ℚ = #ℤ"
+    },
+    {
+      "targetId": "denumerability-rationals-oq-05-oq-01",
+      "relationship": "related",
+      "description": "Part of OQ-05's program on which constructions preserve cardinality over a ring; here localization is shown to preserve cardinality at every infinite level, not just ℵ₀"
+    },
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "related",
+      "description": "Recovers the root #ℚ = ℵ₀ as the ℤ instance of the localization cardinality-preservation principle, factored through #ℚ = #ℤ"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) generalization of the parent's countability result to arbitrary infinite rings: for an infinite commutative semiring R, every localization S of R at a submonoid M satisfies #S ≤ #R (mk_isLocalization_le), with equality #S = #R whenever the inverted monoid avoids zero divisors (mk_localization_eq_of_le_nonZeroDivisors) — in particular #(FractionRing R) = #R for an infinite integral domain (mk_fractionRing_eq), directly answering the parent's open question. Specializing to ℚ = Frac(ℤ) gives #ℚ = #ℤ and recovers #ℚ = ℵ₀.",
+    "implications": "Localization joins univariate and multivariate polynomial/monoid-algebra constructions as a cardinality-preserving operation on infinite rings: it never changes #R. The ℵ₀ result of the parent is exposed as the countable shadow of a general cardinal-arithmetic fact, and #ℚ = ℵ₀ is recovered through the equality #ℚ = #ℤ.",
+    "openQuestions": [
+      "The p-adic completion ℤ_p of ℤ has cardinality 𝔠 while every localization of ℤ stays at ℵ₀; can the exact place where 'enlarging' a countable ring jumps from ℵ₀ to 𝔠 — localization/polynomial extension (ℵ₀) versus completion/power series (𝔠) — be characterized by which limits the operation takes?",
+      "Does the bound #S ≤ #R extend verbatim to localized modules #(LocalizedModule M N) ≤ max #R #N, and more generally to any S-algebra finitely presented over a localization, isolating a 'cardinality-bounded' closure of the infinite base ring?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01",
+    "lineCount": 100,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cantor, Georg",
+      "title": "Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen",
+      "year": "1874",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 77, pp. 258–262",
+      "note": "Denumerability of ℚ; here #ℚ = ℵ₀ recovered via the equality #ℚ = #ℤ"
+    },
+    {
+      "authors": "Atiyah, M. F. and Macdonald, I. G.",
+      "title": "Introduction to Commutative Algebra",
+      "year": "1969",
+      "venue": "Addison-Wesley",
+      "note": "Localization S⁻¹R, fraction fields, and injectivity of the structure map when the inverted set avoids zero divisors"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,149 @@
+{
+  "id": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "slug": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+  "title": "Finite Taylor–Abel Expansion via Iterated Discrete Integration by Parts",
+  "description": "Over any commutative ring R, fix a sequence f : ℕ → R and a tower of antidifferences G : ℕ → ℕ → R linked by the single relation G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1). Iterating the parent's single-step discrete Abel transform D times along this tower yields the closed finite Taylor–Abel expansion ∑_{k<n} f(k)·G(0)(k+1) = ∑_{d<D} (−1)ᵈ (Δᵈf(n)·G(d+1)(n) − Δᵈf(0)·G(d+1)(0)) + (−1)ᴰ ∑_{k<n} Δᴰf(k)·G(D)(k+1), where Δ is the forward difference and Δᵈ its d-fold iterate. This is the exact discrete mirror of repeated integration by parts ∫ f dG = ∑ (−1)ᵈ [f⁽ᵈ⁾ G₍d+1₎] ± ∫ f⁽ᴰ⁾ G₍D₎. Answers the parent entry's first open question. When Δᴰf = 0 (a discrete polynomial of degree < D) the remainder vanishes and the expansion terminates.",
+  "overview": {
+    "historicalContext": "Repeated summation by parts is the engine behind Abel and Euler summation, discrete Taylor expansions, and convergence-acceleration / error-estimate arguments. The parent entry `summation-by-parts-oq-01-oq-01-oq-01-oq-02` proved the *single-step* general discrete Abel transform over a commutative ring — $\\sum f\\cdot\\Delta G = [fG]_0^n - \\sum \\Delta f\\cdot G(\\cdot+1)$ — and recorded as its first open question whether that transform could be *iterated* against a tower of antidifferences into a finite Taylor–Abel series, the discrete analogue of building a Taylor-with-remainder formula by integrating by parts repeatedly. This entry supplies exactly that iteration.",
+    "problemStatement": "**Theorem (T).** Let $R$ be a commutative ring, $f : \\mathbb{N}\\to R$, and $G : \\mathbb{N}\\to\\mathbb{N}\\to R$ a tower of antidifferences satisfying $G_{d+1}(k+1)-G_{d+1}(k) = G_d(k+1)$ for all $d,k$. Writing $\\Delta h(k)=h(k+1)-h(k)$ and $\\Delta^{[d]}$ for the $d$-fold iterate, for all $n, D$,\n$$\\sum_{k=0}^{n-1} f(k)\\,G_0(k+1) \\;=\\; \\sum_{d=0}^{D-1} (-1)^d\\Bigl(\\Delta^{[d]}f(n)\\,G_{d+1}(n) - \\Delta^{[d]}f(0)\\,G_{d+1}(0)\\Bigr) \\;+\\; (-1)^D \\sum_{k=0}^{n-1} \\Delta^{[D]}f(k)\\,G_D(k+1).$$\nThe boundary terms land at the *fixed* endpoints $0$ and $n$ (no shift accumulation) and the remainder reproduces the same shape one depth up.",
+    "proofStrategy": "**Induction on the depth $D$.** The base case $D=0$ is the trivial identity: the boundary sum is empty and the remainder *is* the left-hand side ($\\Delta^{[0]}f = f$). The single layer `step` applies the parent transform (A) at depth $d$: it rewrites $G_d(k+1)$ as $G_{d+1}(k+1)-G_{d+1}(k)$ using the tower hypothesis, applies (A) with $a := \\Delta^{[d]}f$ and $B := G_{d+1}$, and recognises the resulting difference $\\Delta^{[d]}f(k+1)-\\Delta^{[d]}f(k)$ as $\\Delta^{[d+1]}f$ via `Function.iterate_succ_apply'`. This is exactly the recursion $R_d = \\text{bd}_d - R_{d+1}$ on the remainders. The depth induction telescopes the alternating sum with `Finset.sum_range_succ`, `pow_succ`, and `ring`.\n\n**Why the tower hypothesis has the shifted form.** With the naive antidifference relation $\\Delta G_{d+1} = G_d$ (unshifted) the boundary points and the remainder accumulate a growing shift $G_d(k+d)$ at each layer. The relation $G_{d+1}(k+1)-G_{d+1}(k) = G_d(k+1)$ is precisely the convention that compensates the parent transform's $(\\cdot+1)$ shift, keeping the boundary at $0,n$ and the remainder in the clean form $\\sum \\Delta^{[D]}f\\cdot G_D(\\cdot+1)$.",
+    "keyInsights": [
+      "**Each layer is one parent application.** The single-step lemma `step` is the parent's Abel transform (A) instantiated at $a=\\Delta^{[d]}f$, $B=G_{d+1}$, after rewriting $G_d(k+1)=\\Delta G_{d+1}(k)$. The entire $D$-fold theorem is then a one-line depth induction over `step`, so no new analytic content is introduced — only the sign/index bookkeeping that makes the alternating telescope close.",
+      "**The shifted antidifference convention is what makes it telescope.** Iterating the parent transform with the obvious relation $\\Delta G_{d+1}=G_d$ produces boundary terms at moving endpoints $n+d, d$ and a remainder $G_D(k+d)$. The relation $G_{d+1}(k+1)-G_{d+1}(k)=G_d(k+1)$ absorbs the per-step $(\\cdot+1)$ shift so the closed form has fixed endpoints and a single uniform remainder — the form requested by the open question.",
+      "**The expansion terminates for discrete polynomials.** When $\\Delta^{[D]}f = 0$ — i.e. $f$ is a discrete polynomial of degree $< D$ — the remainder sum vanishes identically and (T) becomes a *finite* alternating sum of boundary terms, the exact discrete shadow of a Taylor polynomial with zero remainder (`discrete_taylor_abel_of_fdiff_eq_zero`).",
+      "**Depth 1 is the parent verbatim.** Specialising (T) to $D=1$ collapses to the parent's single-step transform applied to the first antidifference $G_1$ (`discrete_taylor_abel_one`), confirming the iteration is a faithful generalisation rather than a reformulation."
+    ]
+  },
+  "sections": [
+    {
+      "id": "forward-difference",
+      "title": "The Forward Difference and Its Iterate",
+      "startLine": 77,
+      "endLine": 91,
+      "summary": "fdiff h k = h(k+1) − h k is the forward difference operator; fdiff^[d] is its d-fold iterate via Function.iterate. fdiff_iterate_succ unfolds one layer: fdiff^[d+1] = fdiff ∘ fdiff^[d], the lemma that lets the induction recognise Δ^[d]f(k+1) − Δ^[d]f(k) as Δ^[d+1]f(k).",
+      "mathContext": "fdiff_apply is the definitional rewrite fdiff h k = h(k+1) − h k, marked @[simp]. fdiff_iterate_succ is Function.iterate_succ_apply' fdiff d f, the only iterate fact needed to thread Δ through the depth induction."
+    },
+    {
+      "id": "single-step-transform",
+      "title": "The Single-Step Discrete Abel Transform",
+      "startLine": 93,
+      "endLine": 106,
+      "summary": "abel_summation: ∑_{k<n} a(k)·(B(k+1)−B(k)) = a(n)·B(n) − a(0)·B(0) − ∑_{k<n} (a(k+1)−a(k))·B(k+1), the parent entry's transform reproved from scratch (induction on n + sum_range_succ + ring) so this file is self-contained and routes through no Mathlib summation-by-parts black box.",
+      "mathContext": "Identical in content to the parent's abel_summation; included locally as the single-step engine for the iteration, avoiding a cross-file olean dependency. The inductive step is a polynomial identity in the sequence atoms closed by ring over an arbitrary commutative ring."
+    },
+    {
+      "id": "one-layer",
+      "title": "One Layer of the Iteration",
+      "startLine": 108,
+      "endLine": 129,
+      "summary": "step: under the tower hypothesis, applying (A) at depth d peels one boundary term and drops the remainder from depth d to d+1: ∑_{k<n} Δ^[d]f(k)·G(d)(k+1) = Δ^[d]f(n)·G(d+1)(n) − Δ^[d]f(0)·G(d+1)(0) − ∑_{k<n} Δ^[d+1]f(k)·G(d+1)(k+1). This is the recurrence R_d = bd_d − R_{d+1}.",
+      "mathContext": "Rewrites G(d)(k+1) = G(d+1)(k+1) − G(d+1)(k) via the tower hypothesis (hL), applies abel_summation with a := Δ^[d]f, B := G(d+1), then rewrites the difference of iterates as the next iterate via fdiff_iterate_succ + fdiff_apply (hR). exact discharges the rearranged goal."
+    },
+    {
+      "id": "taylor-abel-expansion",
+      "title": "The Finite Taylor–Abel Expansion",
+      "startLine": 131,
+      "endLine": 157,
+      "summary": "discrete_taylor_abel: the closed D-fold identity, by induction on D. Base D=0 is the trivial identity (simp). The step rewrites by the IH, peels the d=D boundary term with Finset.sum_range_succ, substitutes the single-layer recurrence step f G hG n D, and closes the alternating-sign telescope with pow_succ + ring. discrete_taylor_abel_of_fdiff_eq_zero specialises to Δ^[D]f = 0, dropping the remainder for a terminating finite expansion.",
+      "mathContext": "The succ case is `rw [ih, Finset.sum_range_succ, step f G hG n D, pow_succ]; ring`: the IH replaces the LHS, sum_range_succ exposes the new boundary term, step turns R_D into bd_D − R_{D+1}, and ring reconciles the (−1)^D and (−1)^(D+1) coefficients. The terminating corollary is rw [discrete_taylor_abel, hf]; simp."
+    },
+    {
+      "id": "depth-one-recovery",
+      "title": "Depth One Recovers the Parent Transform",
+      "startLine": 159,
+      "endLine": 168,
+      "summary": "discrete_taylor_abel_one: specialising (T) to D=1 gives ∑_{k<n} f(k)·G(0)(k+1) = f(n)·G(1)(n) − f(0)·G(1)(0) − ∑_{k<n} (f(k+1)−f(k))·G(1)(k+1), the parent's single-step Abel transform applied to the first antidifference G(1) — confirming the iteration is a genuine generalisation.",
+      "mathContext": "Instantiate discrete_taylor_abel at D=1, simp away Function.iterate_zero / iterate_one and the range-one sum, then ring."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves the finite Taylor–Abel expansion: iterating the parent's single-step discrete Abel transform D times along a tower of antidifferences G (linked by G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1)) yields ∑_{k<n} f(k)·G(0)(k+1) = ∑_{d<D} (−1)ᵈ(Δᵈf(n)·G(d+1)(n) − Δᵈf(0)·G(d+1)(0)) + (−1)ᴰ ∑_{k<n} Δᴰf(k)·G(D)(k+1), over any commutative ring with no further hypotheses. It records the single-layer recurrence (step), the terminating case for discrete polynomials (Δᴰf = 0), and the depth-1 recovery of the parent transform. Answers the parent entry's first open question.",
+    "implications": "(T) is the discrete, finite analogue of repeated integration by parts producing a Taylor-with-remainder series ∫ f dG = ∑ (−1)ᵈ [f⁽ᵈ⁾ G₍d+1₎] ± ∫ f⁽ᴰ⁾ G₍D₎. Because it carries no side hypotheses beyond the antidifference tower and lives over an arbitrary commutative ring, it is reusable infrastructure for finite-difference calculus: Newton's forward-difference formula, discrete Euler–Maclaurin skeletons, and Abel/Euler summation all specialise from it by choosing the tower G. The terminating case is the discrete finite Taylor formula for polynomial sequences.",
+    "openQuestions": [
+      "Does the same depth induction give a finite-difference *Euler–Maclaurin* skeleton when G is the Bernoulli-polynomial antidifference tower, recovering the boundary correction terms as the alternating sum of Δᵈf evaluated at the endpoints?",
+      "Can the remainder ∑ Δᴰf(k)·G(D)(k+1) be bounded (over an ordered ring or a normed ring) to turn (T) into an effective discrete Taylor error estimate, in the spirit of the Lagrange/integral remainder of the continuous theorem?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+      "relationship": "extension",
+      "description": "The parent proves the single-step general discrete Abel transform ∑ f·ΔG = [fG]_0^n − ∑ Δf·G(·+1) and asks whether it iterates into a finite Taylor–Abel series. This entry is exactly that iteration: discrete_taylor_abel is the D-fold closed form, with the parent transform appearing as the single layer (step) and as the depth-1 case (discrete_taylor_abel_one). Answers the parent's first open question."
+    },
+    {
+      "targetId": "summation-by-parts-oq-01-oq-01-oq-01",
+      "relationship": "foundation",
+      "description": "The grandparent established the geometric summation-by-parts recursion; this entry's depth-D iteration is the general antidifference-tower analogue of repeating that single trade."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.BigOperators.Module",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "SummationByPartsOQ01OQ01OQ01OQ02OQ01",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "sorries": 0,
+    "path": "Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ01.lean"
+  },
+  "sorries": 0,
+  "meta": {
+    "author": "Classical (repeated Abel summation by parts / discrete Taylor); formalized for the lean-genius gallery",
+    "sourceUrl": "https://github.com/leanprover-community/mathlib4",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "algebra",
+      "finite-sums",
+      "summation-by-parts",
+      "abel-summation",
+      "abel-transform",
+      "discrete-taylor",
+      "finite-differences",
+      "iterated-integration-by-parts",
+      "telescoping",
+      "commutative-ring",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_succ",
+        "description": "∑ i ∈ range (n+1), f i = (∑ i ∈ range n, f i) + f n — drives both the induction inside abel_summation and the depth induction peeling the d=D boundary term",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Function.iterate_succ_apply'",
+        "description": "f^[n+1] x = f (f^[n] x) — used as fdiff_iterate_succ to identify Δ^[d]f(k+1) − Δ^[d]f(k) with Δ^[d+1]f(k) across the layers",
+        "module": "Mathlib.Logic.Function.Iterate"
+      },
+      {
+        "theorem": "pow_succ",
+        "description": "(-1)^(D+1) = (-1)^D * (-1) — reconciles the alternating-sign coefficients in the depth induction so ring closes the telescope",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "The finite Taylor–Abel expansion: iterating the single-step discrete Abel transform D times along an antidifference tower G gives the closed alternating identity ∑_{k<n} f(k)·G(0)(k+1) = ∑_{d<D} (−1)ᵈ(Δᵈf(n)·G(d+1)(n) − Δᵈf(0)·G(d+1)(0)) + (−1)ᴰ ∑_{k<n} Δᵈf(k)·G(D)(k+1), over any commutative ring, proved by a one-line depth induction over a single-layer lemma — the discrete analogue of repeated integration by parts requested by the parent's first open question",
+      "Identification of the antidifference convention G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1) (rather than the naive ΔG(d+1) = G(d)) as the precise relation that compensates the parent transform's (·+1) shift, keeping the boundary terms at the fixed endpoints 0 and n and the remainder in a single uniform shape — the bookkeeping insight that makes the alternating telescope close",
+      "The single-layer recurrence `step` (R_d = bd_d − R_{d+1}) isolating one application of the parent transform at depth d, reusable as the inductive engine",
+      "The terminating case discrete_taylor_abel_of_fdiff_eq_zero: when Δᴰf = 0 (a discrete polynomial of degree < D) the remainder drops and the expansion is a finite alternating sum of boundary terms — the discrete finite Taylor formula — together with discrete_taylor_abel_one recovering the parent's single-step transform as the depth-1 case",
+      "Answers the first open question recorded by summation-by-parts-oq-01-oq-01-oq-01-oq-02"
+    ],
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 170,
+    "theoremCount": 6,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound; no native_decide, no Lean.ofReduceBool). The antidifference tower relation G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1) is a hypothesis of the theorem, not an axiom: it is discharged by the caller when the tower is instantiated.",
+    "mathlib_version": "4.26.0",
+    "definitionCount": 1
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `denumerability-rationals-oq-05-oq-01-oq-01-oq-01` ("is `#(FractionRing R) = #R` provable in general for infinite `R`?"). The parent proved localization preserves *countability* (`#(FractionRing R) = ℵ₀` for countable `R`); this entry isolates the cardinal-arithmetic core and proves it at **every infinite level**.

## Results (`proofs/Proofs/DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01.lean`)

| Theorem | Statement |
|---|---|
| `mk_isLocalization_le` | `#S ≤ #R` for any localization `S` of an infinite commutative semiring `R` at a submonoid `M` |
| `mk_localization_eq_of_le_nonZeroDivisors` | `#S = #R` when `M ≤ R⁰` (structure map injective) |
| `mk_isFractionRing_eq` / `mk_fractionRing_eq` | `#(FractionRing R) = #R` for an infinite integral domain |
| `mk_rat_eq_int` / `mk_rat_eq_aleph0` | `#ℚ = #ℤ`, recovering `#ℚ = ℵ₀` through the equality |

## Proof idea

The parent's countability proof and this equality share one surjection `R × M ↠ S` (`IsLocalization.mk'_surjective`). Where the parent closes with `Function.Surjective.countable`, here we close with cardinal arithmetic: `#S ≤ #(R × M) = #R·#M ≤ #R·#R = #R` (`Cardinal.mul_eq_self` for infinite `#R`). Dropping `[Countable R]` generalizes `ℵ₀` to every infinite cardinal in one stroke; injectivity of `algebraMap` (when `M ≤ R⁰`) upgrades the bound to equality.

## Verification

- **Builds** under `./proofs/scripts/docker-build.sh Proofs.DenumerabilityRationalsOQ05OQ01OQ01OQ01OQ01` ✓
- `#print axioms` on all 6 theorems: only `propext`, `Classical.choice`, `Quot.sound` → **0-axiom, sorry-free**
- 100 lines, 6 theorems, 0 definitions
- Gallery `meta.json` added; `status: verified`, `badge: mathlib`, `axiomCount: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)