### PR TITLE
research(angle-trisection-…-oq-05-oq-02): sharpness — |Aut_F(K)| = [K:F]_s ⟺ K/F normal [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean
@@ -1,0 +1,147 @@
+/-
+# Sharpness of the automorphism bound: |Aut_F(K)| = [K : F]_s ⟺ K/F normal
+
+The parent entry `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05` proved the
+*inequality*
+
+  `|Aut_F(K)| ≤ [K : F]_s`        (`Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K`)
+
+for a finite extension `K / F`, via a single injection of `K ≃ₐ[F] K` into the
+embeddings of `K`.  A sibling entry (`…-oq-05-oq-01`) proved that *equality holds
+for normal extensions*, recovering `IsGalois.card_aut_eq_finrank`.
+
+This file proves the **converse**, completing the picture into a sharp
+characterisation:
+
+  > For a finite extension, the automorphism bound is attained — i.e.
+  > `|Aut_F(K)| = [K : F]_s` — **if and only if** `K / F` is normal.
+
+So the automorphism group is "as large as the separable degree allows" exactly
+when the extension is normal; otherwise the inequality is strict.
+
+**Setting.**  We fix an ambient normal extension `L / F` (think: an algebraic
+closure) and view `K` as an intermediate field `F ≤ K ≤ L` with `K / F` finite.
+The relevant count is the number of `F`-embeddings `K →ₐ[F] L`; when `L` is
+algebraically closed this is exactly the separable degree `[K : F]_s`
+(`Field.finSepDegree_eq_of_isAlgClosed`).
+
+**The two directions.**
+
+* *(normal ⟹ equality)*  This is Mathlib's `Normal.algHomEquivAut`, the bijection
+  `(K →ₐ[F] L) ≃ (K ≃ₐ[F] K)` available whenever `K / F` is normal.  Counting both
+  sides gives the equality directly.
+
+* *(equality ⟹ normal)*  The map `autToAlgHom : (K ≃ₐ[F] K) → (K →ₐ[F] L)`,
+  `e ↦ K.val ∘ e`, is injective (post-composition with the injective inclusion
+  `K ↪ L`).  Equal finite cardinalities upgrade injectivity to **surjectivity**
+  (`Nat.bijective_iff_injective_and_card`): every embedding `σ : K →ₐ[F] L` is the
+  inclusion of an *automorphism*, so its image `σ.fieldRange` is `K` itself.
+  By Mathlib's normality criterion `normal_iff_forall_fieldRange_le`
+  (`Normal F K ↔ ∀ σ : K →ₐ[F] L, σ.fieldRange ≤ K`), `K / F` is normal.
+
+Combining the two yields the biconditional `normal_iff_card_aut_eq_card_algHom`,
+and the algebraically-closed specialisation `normal_iff_card_aut_eq_finSepDegree`
+states it with the separable degree `[K : F]_s` on the nose.
+
+No axioms, no `sorry`, no `native_decide`.
+-/
+import Mathlib.FieldTheory.SeparableDegree
+import Mathlib.FieldTheory.Normal.Closure
+
+open Field IntermediateField
+
+namespace AngleTrisectionAutSharp
+
+variable {F L : Type*} [Field F] [Field L] [Algebra F L] (K : IntermediateField F L)
+
+/-- An `F`-algebra automorphism of `K`, post-composed with the inclusion
+`K ↪ L`, is an `F`-embedding of `K` into the ambient field `L`. -/
+noncomputable def autToAlgHom (e : K ≃ₐ[F] K) : K →ₐ[F] L :=
+  K.val.comp e.toAlgHom
+
+@[simp]
+theorem autToAlgHom_apply (e : K ≃ₐ[F] K) (x : K) :
+    autToAlgHom K e x = (e x : L) := rfl
+
+/-- Post-composition with the injective inclusion `K ↪ L` is injective:
+distinct automorphisms give distinct embeddings. -/
+theorem autToAlgHom_injective : Function.Injective (autToAlgHom K) := by
+  intro e₁ e₂ h
+  ext x
+  simpa only [autToAlgHom_apply] using DFunLike.congr_fun h x
+
+/-- The image of an automorphism (followed by the inclusion) is contained in `K`:
+since each value `e x` already lies in `K`, the embedding `autToAlgHom K e` has
+field range `≤ K`.  (In fact it equals `K`, but `≤` is all the normality
+criterion needs.) -/
+theorem autToAlgHom_fieldRange_le (e : K ≃ₐ[F] K) :
+    (autToAlgHom K e).fieldRange ≤ K := by
+  rintro y hy
+  rw [AlgHom.mem_fieldRange] at hy
+  obtain ⟨x, rfl⟩ := hy
+  exact SetLike.coe_mem (e x)
+
+/-- **Sharp automorphism bound (relative form).**  For a finite intermediate
+field `K` of a normal extension `L / F`, the number of `F`-automorphisms of `K`
+equals the number of `F`-embeddings `K →ₐ[F] L` **iff** `K / F` is normal.
+
+The `←` direction is `Normal.algHomEquivAut`; the `→` direction promotes the
+injection `autToAlgHom` to a bijection by counting, then reads off normality from
+`normal_iff_forall_fieldRange_le`. -/
+theorem normal_iff_card_aut_eq_card_algHom [Normal F L] [FiniteDimensional F K] :
+    Nat.card (K ≃ₐ[F] K) = Nat.card (K →ₐ[F] L) ↔ Normal F K := by
+  constructor
+  · intro hcard
+    -- injective + equal finite cardinality ⟹ bijective
+    have hbij : Function.Bijective (autToAlgHom K) :=
+      (Nat.bijective_iff_injective_and_card _).mpr ⟨autToAlgHom_injective K, hcard⟩
+    -- every embedding has field range ≤ K, hence K/F is normal
+    refine normal_iff_forall_fieldRange_le.mpr fun σ => ?_
+    obtain ⟨e, rfl⟩ := hbij.surjective σ
+    exact autToAlgHom_fieldRange_le K e
+  · intro _
+    exact Nat.card_congr (Normal.algHomEquivAut F L K).symm
+
+/-- **Sharp automorphism bound (separable-degree form).**  For a finite extension
+`K / F` inside an algebraically closed normal extension `L`, the automorphism
+count attains the separable degree, `|Aut_F(K)| = [K : F]_s`, **iff** `K / F` is
+normal.  This is the parent inequality `|Aut_F(K)| ≤ [K : F]_s` sharpened to an
+equality characterisation. -/
+theorem normal_iff_card_aut_eq_finSepDegree
+    [Normal F L] [IsAlgClosed L] [FiniteDimensional F K] :
+    Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K ↔ Normal F K := by
+  rw [Field.finSepDegree_eq_of_isAlgClosed (K := L) F K]
+  exact normal_iff_card_aut_eq_card_algHom K
+
+/-- **Corollary (strict inequality off the normal locus).**  If `K / F` is *not*
+normal, the automorphism bound is strict: `|Aut_F(K)| < [K : F]_s`. -/
+theorem card_aut_lt_finSepDegree_of_not_normal
+    [Normal F L] [IsAlgClosed L] [FiniteDimensional F K] (hK : ¬ Normal F K) :
+    Nat.card (K ≃ₐ[F] K) < Field.finSepDegree F K := by
+  -- finiteness of the embedding count, then `≤` from the parent + `≠` from sharpness
+  have hbound : Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K := by
+    rw [Field.finSepDegree_eq_of_isAlgClosed (K := L) F K]
+    exact Nat.card_le_card_of_injective _ (autToAlgHom_injective K)
+  refine lt_of_le_of_ne hbound ?_
+  intro heq
+  exact hK ((normal_iff_card_aut_eq_finSepDegree K).mp heq)
+
+end AngleTrisectionAutSharp
+
+/-!
+### Capstone: the sharp characterisation over an algebraic closure
+
+Specialising the ambient field `L` to `AlgebraicClosure F` (which is normal and
+algebraically closed over `F`), every finite intermediate field `K` satisfies the
+clean biconditional below.  This is the form one usually quotes: a finite
+extension is normal exactly when its automorphism group has order equal to its
+separable degree.
+-/
+namespace AngleTrisectionAutSharp
+
+example (F : Type*) [Field F] (K : IntermediateField F (AlgebraicClosure F))
+    [FiniteDimensional F K] :
+    Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K ↔ Normal F K :=
+  normal_iff_card_aut_eq_finSepDegree K
+
+end AngleTrisectionAutSharp

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+  "title": "Sharpness of the Automorphism Bound: |Aut_F(K)| = [K : F]_s ⟺ K/F Normal",
+  "slug": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+  "description": "Completes the parent's automorphism-bound story into a sharp characterisation: for a finite extension K/F (inside a normal ambient field L), the count of F-automorphisms equals the number of F-embeddings K →ₐ[F] L — equivalently the separable degree [K:F]_s when L is algebraically closed — if and only if K/F is normal. The parent entry (…-oq-05) proved the inequality |Aut_F(K)| ≤ [K:F]_s; a sibling (…-oq-05-oq-01) proved equality for normal extensions. This entry proves the CONVERSE — equality forces normality — so the bound is attained exactly on the normal locus and is strict off it (card_aut_lt_finSepDegree_of_not_normal). The converse upgrades the parent's injection Aut ↪ Emb to a bijection by a cardinality count (Nat.bijective_iff_injective_and_card), then reads off normality from Mathlib's normal_iff_forall_fieldRange_le; the forward direction is Normal.algHomEquivAut.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean",
+    "tags": [
+      "algebra",
+      "galois-theory",
+      "field-extensions",
+      "normal-extension",
+      "separability",
+      "separable-degree",
+      "automorphism-group"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlibDependencies": [
+      {
+        "theorem": "normal_iff_forall_fieldRange_le",
+        "description": "Normal F K ↔ ∀ σ : K →ₐ[F] L, σ.fieldRange ≤ K, for an intermediate field K of a normal extension L/F. The criterion that converts surjectivity of the automorphism-to-embedding map into normality of K/F.",
+        "module": "Mathlib.FieldTheory.Normal.Closure"
+      },
+      {
+        "theorem": "Normal.algHomEquivAut",
+        "description": "For K/F normal, the bijection (K →ₐ[F] L) ≃ (K ≃ₐ[F] K) — every embedding into the ambient normal field is the inclusion of an automorphism. Supplies the forward (normal ⟹ equality) direction directly by Nat.card_congr.",
+        "module": "Mathlib.FieldTheory.Normal.Defs"
+      },
+      {
+        "theorem": "Nat.bijective_iff_injective_and_card",
+        "description": "For [Finite β], a map f : α → β is bijective iff it is injective and Nat.card α = Nat.card β. Upgrades the injection Aut ↪ Emb to a bijection from the cardinality hypothesis, giving surjectivity.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      },
+      {
+        "theorem": "Field.finSepDegree_eq_of_isAlgClosed",
+        "description": "For K/F algebraic and L algebraically closed, finSepDegree F K = Nat.card (K →ₐ[F] L). Identifies the embedding count with the separable degree [K:F]_s in the headline form.",
+        "module": "Mathlib.FieldTheory.SeparableDegree"
+      },
+      {
+        "theorem": "AlgHom.mem_fieldRange",
+        "description": "y ∈ f.fieldRange ↔ ∃ x, f x = y; used to destructure membership in an embedding's field range and exhibit the witness, whose value ↑(e x) lies in K by SetLike.coe_mem.",
+        "module": "Mathlib.FieldTheory.IntermediateField.Basic"
+      },
+      {
+        "theorem": "minpoly.AlgHom.fintype",
+        "description": "For a finite extension, the type K →ₐ[F] L of F-algebra homomorphisms is finite — the [Finite β] hypothesis of the bijectivity counting step.",
+        "module": "Mathlib.FieldTheory.Minpoly.Field"
+      }
+    ],
+    "originalContributions": [
+      "normal_iff_card_aut_eq_card_algHom: the biconditional Nat.card (K ≃ₐ[F] K) = Nat.card (K →ₐ[F] L) ↔ Normal F K, for a finite intermediate field K of a normal extension L/F. Mathlib has the forward map (Normal.algHomEquivAut) but not the characterisation that equal cardinality is EQUIVALENT to normality.",
+      "normal_iff_card_aut_eq_finSepDegree: the separable-degree headline Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K ↔ Normal F K (ambient L algebraically closed), exhibiting the parent's bound |Aut| ≤ [K:F]_s as an equality attained exactly when K/F is normal.",
+      "card_aut_lt_finSepDegree_of_not_normal: the strict-inequality corollary — off the normal locus the bound is strict, |Aut_F(K)| < [K:F]_s — the quantitative sharpness statement.",
+      "The converse direction (equality ⟹ normal) is the genuinely new content: the parent's injection Aut ↪ Emb becomes a bijection purely by counting (equal finite cardinalities), so every embedding K →ₐ[F] L is the inclusion of an automorphism, hence has field range K; normal_iff_forall_fieldRange_le then yields normality with no splitting-field computation."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-checked over Mathlib v4.26; #print axioms reports only the foundational propext / Classical.choice / Quot.sound (no axiom declarations, no structure-encoded assumptions, no native_decide).",
+    "lineCount": 147,
+    "theoremCount": 6,
+    "definitionCount": 1
+  },
+  "leanFile": {
+    "path": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean",
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "lineCount": 147,
+    "sorries": 0
+  },
+  "overview": {
+    "historicalContext": "The inequality |Aut_F(K)| ≤ [K:F]_s and its sharp case form the cardinality core of Artin's theorem (Artin, Galois Theory, 1942; Lang, Algebra, V §4–6): the F-automorphisms of K are exactly those F-embeddings K ↪ \\bar K whose image lands back in K, so equality between automorphisms and embeddings is precisely the statement that K is stable under the Galois action — i.e. normal. For separable extensions [K:F]_s = [K:F] and the equality |Aut| = [K:F] is the classical Galois criterion, so this entry's biconditional is the separable-degree refinement valid without a separability hypothesis. Mathlib packages the normal ⟹ equality direction as Normal.algHomEquivAut and the Galois corollary as IsGalois.card_aut_eq_finrank, and provides the normality criterion normal_iff_forall_fieldRange_le, but does not record the converse characterisation that attaining the automorphism bound forces normality.",
+    "problemStatement": "The parent entry proved |Aut_F(K)| ≤ [K:F]_s and a sibling proved equality when K/F is normal. Open question: is normality NECESSARY for equality — i.e. does |Aut_F(K)| = [K:F]_s imply K/F normal, making the bound a sharp characterisation? Answer: yes. We prove the biconditional Nat.card (K ≃ₐ[F] K) = Nat.card (K →ₐ[F] L) ↔ Normal F K (L a normal ambient field), specialise it to the separable degree when L is algebraically closed (Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K ↔ Normal F K), and record the strict-inequality consequence off the normal locus.",
+    "keyInsights": [
+      "Equality of the two finite counts upgrades the parent's INJECTION Aut ↪ Emb to a BIJECTION for free, via Nat.bijective_iff_injective_and_card — no new map is constructed, only counted.",
+      "Surjectivity means every embedding σ : K →ₐ[F] L is K.val ∘ e for an automorphism e, so every value σ x = ↑(e x) already lies in K and σ.fieldRange ≤ K (SetLike.coe_mem). Every embedding lands back in K — which is exactly the hypothesis of the normality criterion.",
+      "Mathlib's normal_iff_forall_fieldRange_le packages exactly 'every embedding's range ≤ K ⟺ K/F normal', so the converse needs no minimal-polynomial or splitting-field manipulation — it is a one-line consequence of the surjectivity.",
+      "The forward direction is not re-proved by hand: Normal.algHomEquivAut already gives the bijection (K →ₐ[F] L) ≃ (K ≃ₐ[F] K) for normal K/F, so Nat.card_congr closes it.",
+      "Sharpness has a quantitative face: lt_of_le_of_ne against the parent inequality yields |Aut_F(K)| < [K:F]_s whenever K/F is not normal."
+    ],
+    "proofStrategy": "1. Define autToAlgHom : (K ≃ₐ[F] K) → (K →ₐ[F] L), e ↦ K.val.comp e.toAlgHom, and prove it injective (K.val is injective).\n2. autToAlgHom_fieldRange_le: (autToAlgHom K e).fieldRange ≤ K, since each value autToAlgHom K e x = ↑(e x) lies in K (AlgHom.mem_fieldRange + SetLike.coe_mem).\n3. normal_iff_card_aut_eq_card_algHom (←): Nat.card_congr (Normal.algHomEquivAut F L K).symm. (→): from equal Nat.card and injectivity, Nat.bijective_iff_injective_and_card gives bijectivity; for any σ pick the automorphism e with autToAlgHom K e = σ, so σ.fieldRange ≤ K; conclude with normal_iff_forall_fieldRange_le.\n4. normal_iff_card_aut_eq_finSepDegree: rewrite finSepDegree F K = Nat.card (K →ₐ[F] L) by Field.finSepDegree_eq_of_isAlgClosed (L alg. closed) and apply step 3.\n5. card_aut_lt_finSepDegree_of_not_normal: the parent inequality (Nat.card_le_card_of_injective on autToAlgHom) plus ≠ from step 4 gives strict <.\n6. Capstone example with L = AlgebraicClosure F.",
+    "prerequisites": [
+      "Normal field extensions and Mathlib's criteria normal_iff_forall_fieldRange_le / Normal.algHomEquivAut",
+      "Separable degree [K:F]_s = number of F-embeddings into an algebraic closure (Field.finSepDegree, Field.finSepDegree_eq_of_isAlgClosed)",
+      "Intermediate fields, the inclusion K.val, AlgHom.fieldRange and AlgEquiv.fieldRange_eq_top",
+      "Counting under injections and the upgrade to bijection for finite types of equal cardinality (Nat.bijective_iff_injective_and_card)",
+      "The parent entry's automorphism-to-embedding injection and the bound |Aut_F(K)| ≤ [K:F]_s"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+      "description": "Parent entry: proves the inequality |Aut_F(K)| ≤ [K:F]_s via the injection Aut ↪ Emb. This entry sharpens it to an equality-iff-normal characterisation and a strict inequality off the normal locus."
+    },
+    {
+      "targetId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01",
+      "description": "Sibling entry: proves equality |Aut_F(K)| = [K:F]_s for normal extensions (recovering IsGalois.card_aut_eq_finrank). This entry adds the converse, so the two together give the biconditional."
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete, fully verified (0 sorries, 0 axioms) proof that the automorphism bound of the parent entry is SHARP: for a finite extension K/F inside a normal ambient field L, |Aut_F(K)| equals the number of F-embeddings K →ₐ[F] L (the separable degree [K:F]_s when L is algebraically closed) if and only if K/F is normal, and is strictly smaller otherwise. The forward direction is Mathlib's Normal.algHomEquivAut; the converse upgrades the parent's injection to a bijection by counting and reads off normality from normal_iff_forall_fieldRange_le.",
+    "openQuestions": [
+      "Quantify the defect [K:F]_s − |Aut_F(K)| for a non-normal K in terms of the normal closure: is it controlled by the index [normalClosure(K) : K] or by the number of distinct conjugate subfields of K?",
+      "State and prove the separable analogue purely in terms of fixed fields: for a finite group G ≤ Aut_F(K), |G| = [K : K^G] with K^G the fixed field, and relate the 'equality ⟹ normal' phenomenon here to Artin's theorem K/K^G is Galois."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Sharpens the parent entry's automorphism bound into a **sharp characterisation**.

- Parent `…-oq-05` (#28070): proved the inequality `|Aut_F(K)| ≤ [K:F]_s`.
- Sibling `…-oq-05-oq-01` (#28093): proved *equality for normal* extensions (recovers `IsGalois.card_aut_eq_finrank`).
- **This entry**: proves the **converse** — equality *forces* normality — so the bound is attained **exactly** on the normal locus, and is strict off it.

### Result

For a finite extension `K/F` inside a normal ambient field `L`:

```
Nat.card (K ≃ₐ[F] K) = Nat.card (K →ₐ[F] L)  ↔  Normal F K     -- normal_iff_card_aut_eq_card_algHom
```

and, with `L` algebraically closed (the separable-degree headline):

```
Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K  ↔  Normal F K   -- normal_iff_card_aut_eq_finSepDegree
```

plus the quantitative corollary `card_aut_lt_finSepDegree_of_not_normal`: off the normal locus, `|Aut_F(K)| < [K:F]_s`.

### Proof idea

- **normal ⟹ equality**: Mathlib's `Normal.algHomEquivAut` gives the bijection `(K →ₐ[F] L) ≃ (K ≃ₐ[F] K)`; count with `Nat.card_congr`.
- **equality ⟹ normal** *(new)*: the parent injection `autToAlgHom : Aut ↪ Emb` is upgraded to a **bijection** purely by counting (`Nat.bijective_iff_injective_and_card`, both sides finite). Surjectivity means every embedding `σ : K →ₐ[F] L` is the inclusion of an automorphism, so `σ.fieldRange ≤ K`; `normal_iff_forall_fieldRange_le` then yields `Normal F K` — no splitting-field or minimal-polynomial computation.

### Verification

- 6 theorems, 1 definition, 147 lines.
- **0 sorries, 0 axioms** — `#print axioms` reports only `propext / Classical.choice / Quot.sound` (no `native_decide`, no axiom declarations).
- Builds clean under the Docker wrapper against Mathlib v4.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)