### PR TITLE
Enrich De Moivre DFT LinearIsometryEquiv (oq-05-oq-01-oq-01-oq-01-oq-03): annotations, index.ts, sections, conclusion

### DIFF
--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "context",
+    "title": "From Matrix Unitarity to a Hilbert-Space Isometry",
+    "content": "The operator-theoretic statement of the discrete Fourier transform is that it is a **unitary** of the finite-dimensional Hilbert space $\\mathbb{C}^n$: a perfectly invertible, energy-preserving change of orthonormal basis. The parent entry proved the matrix identity $U \\cdot U^{\\mathsf H} = 1$ for the normalised DFT matrix $U(j,k) = e^{2\\pi i jk/n}/\\sqrt n$, i.e. $U \\in \\mathrm{unitaryGroup}$. This file crosses from matrix algebra into Mathlib's *bundled* isometry hierarchy: it assembles $U$ into a `LinearIsometryEquiv` $\\mathbb{C}^n \\simeq_{\\ell i} \\mathbb{C}^n$ and identifies the inverse isometry with the conjugate-transpose operator $\\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$ — the inverse DFT.",
+    "mathContext": "$\\mathrm{dftLIE} : \\mathrm{EuclideanSpace}\\,\\mathbb{C}\\,(\\mathrm{Fin}\\,n) \\simeq_{\\ell i}[\\mathbb{C}] \\mathrm{EuclideanSpace}\\,\\mathbb{C}\\,(\\mathrm{Fin}\\,n)$, with $\\mathrm{dftLIE}^{-1} = \\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "discrete Fourier transform",
+      "unitary operator",
+      "LinearIsometryEquiv",
+      "Hilbert space isomorphism"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "unitary matrices",
+      "the discrete Fourier transform"
+    ]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 47, "endLine": 52 },
+    "type": "definition",
+    "title": "Setup: Importing the Parent's Unitary DFT Matrix",
+    "content": "The file imports the parent module `Proofs.DeMoivreOQ05OQ01OQ01OQ01` and opens its namespace, bringing into scope the DFT matrix `dftMatrix n` and the sole nontrivial input `dftMatrix_mem_unitaryGroup` ($U \\in \\mathrm{unitaryGroup}$). Everything proved here is the operator-theoretic *repackaging* of that one fact; no new analysis of the exponential entries is needed. Opening `Matrix` makes the matrix–vector and conjugate-transpose notation ($A^{\\mathsf H}$, $A \\ast_v v$) available.",
+    "mathContext": "Inputs: $\\mathrm{dftMatrix}\\,n$ and $\\mathrm{dftMatrix\\_mem\\_unitaryGroup} : U \\in \\mathrm{Matrix.unitaryGroup}\\,(\\mathrm{Fin}\\,n)\\,\\mathbb{C}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matrix.unitaryGroup",
+      "namespace import",
+      "proof reuse"
+    ],
+    "prerequisites": [
+      "Lean module imports"
+    ]
+  },
+  {
+    "id": "ann-two-sided-inverse",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 54, "endLine": 78 },
+    "type": "technique",
+    "title": "Uᴴ Is a Two-Sided Inverse as an Operator",
+    "content": "The two faces of unitary-group membership — `mem_unitaryGroup_iff'` ($U^{\\mathsf H} U = 1$) and `mem_unitaryGroup_iff` ($U U^{\\mathsf H} = 1$) — give the left and right inverse identities for the operators on $\\mathbb{C}^n$. Each proof injects into the underlying $\\ell^2$ vector via `WithLp.ofLp_injective`, then collapses the composed matrix–vector products with `Matrix.mulVec_mulVec` ($A *_v (B *_v v) = (AB) *_v v$); the matrix identity rewrites $AB$ to $1$ and `Matrix.one_mulVec` finishes. Together the two lemmas exhibit $\\mathrm{toEuclideanLin}\\,U$ as a bijection of $\\mathbb{C}^n$.",
+    "mathContext": "$\\mathrm{toEuclideanLin}\\,U^{\\mathsf H} \\circ \\mathrm{toEuclideanLin}\\,U = \\mathrm{id}$ and $\\mathrm{toEuclideanLin}\\,U \\circ \\mathrm{toEuclideanLin}\\,U^{\\mathsf H} = \\mathrm{id}$, from $U^{\\mathsf H} U = U U^{\\mathsf H} = 1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "matrix–vector product",
+      "two-sided inverse",
+      "Matrix.mulVec_mulVec",
+      "WithLp / EuclideanSpace"
+    ],
+    "prerequisites": [
+      "unitary group identities",
+      "matrix–vector multiplication"
+    ]
+  },
+  {
+    "id": "ann-inner-preservation",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 80, "endLine": 94 },
+    "type": "insight",
+    "title": "Inner-Product Preservation via Adjoint = Inverse",
+    "content": "The operator-theoretic heart of unitarity: $\\langle Ux, Uy\\rangle = \\langle x, y\\rangle$. The proof rewrites the left side through the adjoint, $\\langle Ux, Uy\\rangle = \\langle x, U^{\\ast}(Uy)\\rangle$ (`LinearMap.adjoint_inner_right`), then uses Mathlib's `toEuclideanLin_conjTranspose_eq_adjoint` to identify the operator adjoint $U^{\\ast}$ with $\\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$, which the left-inverse lemma collapses to give $U^{\\ast}(Uy) = y$. So unitarity = (adjoint equals inverse): the abstract version of \"the conjugate transpose is the inverse\".",
+    "mathContext": "$\\langle Ux, Uy\\rangle = \\langle x, U^{\\ast}Uy\\rangle = \\langle x, y\\rangle$, since $U^{\\ast} = \\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$ is a left inverse of $U$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "adjoint operator",
+      "inner-product preservation",
+      "Parseval/Plancherel",
+      "toEuclideanLin_conjTranspose_eq_adjoint"
+    ],
+    "prerequisites": [
+      "adjoint of a linear map",
+      "Hermitian inner product",
+      "the two-sided inverse above"
+    ]
+  },
+  {
+    "id": "ann-dftLIE",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 96, "endLine": 114 },
+    "type": "concept",
+    "title": "Assembling the LinearIsometryEquiv dftLIE",
+    "content": "With inner-product preservation in hand, `LinearMap.isometryOfInner` upgrades $\\mathrm{toEuclideanLin}\\,U$ to a `LinearIsometry`, and `LinearIsometryEquiv.ofSurjective` — fed the explicit right inverse $\\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$ as the surjectivity witness — promotes it to a full isometric *equivalence* `dftLIE`. The companion `dftLIE_apply` records the definitional fact that `dftLIE` acts as the original matrix operator, unwinding the `ofSurjective`/`isometryOfInner` wrappers by `rfl`-style rewriting.",
+    "mathContext": "$\\mathrm{dftLIE}\\,x = \\mathrm{toEuclideanLin}\\,U\\,x$; built from $\\mathrm{isometryOfInner}$ + $\\mathrm{ofSurjective}$ with right inverse $\\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "LinearIsometryEquiv.ofSurjective",
+      "isometryOfInner",
+      "bundled morphisms"
+    ],
+    "prerequisites": [
+      "linear isometries",
+      "surjective + isometry ⇒ equivalence"
+    ]
+  },
+  {
+    "id": "ann-properties-and-inverse",
+    "proofId": "de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03",
+    "range": { "startLine": 116, "endLine": 135 },
+    "type": "concept",
+    "title": "Energy Law, Inner-Product Law, and the Inverse DFT",
+    "content": "The bundled structure now yields the headline properties for free: `dftLIE_norm` ($\\lVert \\mathrm{dftLIE}\\,x\\rVert = \\lVert x\\rVert$) is the isometry's `norm_map` — the parent's $\\ell^2$-energy law as structure — and `dftLIE_inner` is `inner_map_map`. Finally `dftLIE_symm_apply` identifies the inverse isometry $(\\mathrm{dftLIE})^{-1}$ with $\\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$: applying `dftLIE` to both sides and using the right inverse shows it. Since $U^{\\mathsf H} = U^{-1}$ for a unitary, this is exactly the inverse discrete Fourier transform $x(k) = \\tfrac1n\\sum_j \\hat x(j)\\,e^{-2\\pi i jk/n}$.",
+    "mathContext": "$\\lVert \\mathrm{dftLIE}\\,x\\rVert = \\lVert x\\rVert$, $\\langle \\mathrm{dftLIE}\\,x, \\mathrm{dftLIE}\\,y\\rangle = \\langle x,y\\rangle$, $(\\mathrm{dftLIE})^{-1} = \\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "norm_map",
+      "inner_map_map",
+      "inverse DFT",
+      "Plancherel theorem"
+    ],
+    "prerequisites": [
+      "the dftLIE construction above",
+      "inverse of an isometric equivalence"
+    ]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/index.ts
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DeMoivreOQ05OQ01OQ01OQ01OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const deMoivreOQ05OQ01OQ01OQ01OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const deMoivreOQ05OQ01OQ01OQ01OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const deMoivreOQ05OQ01OQ01OQ01OQ03Data: ProofData = {
+  proof: deMoivreOQ05OQ01OQ01OQ01OQ03Proof,
+  annotations: deMoivreOQ05OQ01OQ01OQ01OQ03Annotations,
+}

--- a/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03/meta.json
@@ -7,7 +7,14 @@
     "problemStatement": "**Open Question** (parent de-moivre-oq-05-oq-01-oq-01-oq-01, third question): package the normalised DFT matrix U as a `LinearIsometryEquiv` on `EuclideanSpace ℂ (Fin n)`, upgrading the matrix-level unitarity `U·Uᴴ = 1` to an explicit isometric isomorphism.\n\n**Answer**: Let U act on ℂⁿ by the matrix–vector product, f = `toEuclideanLin U`. The adjoint of f is `toEuclideanLin Uᴴ` (Mathlib's `toEuclideanLin_conjTranspose_eq_adjoint`), and the two forms of `U ∈ unitaryGroup` (`Uᴴ·U = 1` and `U·Uᴴ = 1`) make `toEuclideanLin Uᴴ` a two-sided inverse of f. Hence f preserves the Hermitian inner product `⟪Ux,Uy⟫ = ⟪x,y⟫` and is bijective, so it assembles into `dftLIE : EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n)`. Its inverse `(dftLIE)⁻¹` acts as `toEuclideanLin Uᴴ` — exactly the inverse / conjugate-transpose discrete Fourier transform.",
     "historicalContext": "The operator-theoretic statement of the discrete Fourier transform is that it is a unitary of the finite-dimensional Hilbert space ℂⁿ: a perfectly invertible, energy-preserving change of orthonormal basis. The parent entry proved the underlying matrix identity U·Uᴴ = 1; this entry crosses from the matrix algebra into the bundled `≃ₗᵢ` (linear isometric equivalence) world, the form in which the DFT is used as a Hilbert-space isomorphism. Identifying the inverse isometry with the conjugate-transpose matrix is the abstract counterpart of the inverse-DFT formula x(k) = (1/n)∑_j x̂(j)·exp(−2πi·jk/n).",
     "significance": "Closes the parent entry's third open question. It places the explicit exponential DFT matrix inside Mathlib's bundled isometry hierarchy (`LinearIsometryEquiv`), making the energy law (`norm_map`) and inner-product preservation (`inner_map_map`) available as structure, and exhibits the inverse transform as the genuine inverse of the forward isometry.",
-    "keyInsight": "Unitarity is exactly two-sided invertibility of `toEuclideanLin U` together with adjoint = inverse. The adjoint of `toEuclideanLin U` is `toEuclideanLin Uᴴ` (Mathlib), and `Uᴴ·U = U·Uᴴ = 1` turns the matrix unitary group membership into a bona-fide isometric isomorphism whose inverse IS the conjugate-transpose operator."
+    "keyInsight": "Unitarity is exactly two-sided invertibility of `toEuclideanLin U` together with adjoint = inverse. The adjoint of `toEuclideanLin U` is `toEuclideanLin Uᴴ` (Mathlib), and `Uᴴ·U = U·Uᴴ = 1` turns the matrix unitary group membership into a bona-fide isometric isomorphism whose inverse IS the conjugate-transpose operator.",
+    "proofStrategy": "Write f = toEuclideanLin U on EuclideanSpace ℂ (Fin n). (1) Read off the two matrix identities Uᴴ·U = 1 and U·Uᴴ = 1 from the two forms of U ∈ unitaryGroup, and turn each into an operator identity (toEuclideanLin Uᴴ is a two-sided inverse of f) by injecting through WithLp.ofLp and collapsing the composition with Matrix.mulVec_mulVec. (2) Identify the operator adjoint of f with toEuclideanLin Uᴴ (toEuclideanLin_conjTranspose_eq_adjoint) and combine with the left-inverse identity to get inner-product preservation ⟪f x, f y⟫ = ⟪x, y⟫ via adjoint_inner_right. (3) Feed inner-preservation to isometryOfInner and the explicit right inverse to LinearIsometryEquiv.ofSurjective to obtain dftLIE. (4) Derive dftLIE_apply / dftLIE_norm / dftLIE_inner from the bundled structure and identify (dftLIE).symm with toEuclideanLin Uᴴ.",
+    "keyInsights": [
+      "Unitarity of a matrix is exactly two-sided invertibility of the induced operator toEuclideanLin U together with the fact that its adjoint equals its inverse — the abstract content of 'the conjugate transpose is the inverse'.",
+      "Mathlib's toEuclideanLin_conjTranspose_eq_adjoint is the bridge from matrix algebra to operator theory: it makes the operator adjoint of toEuclideanLin U literally toEuclideanLin Uᴴ, so the parent's matrix identities become statements about f and its adjoint.",
+      "The two forms of unitary-group membership (Uᴴ·U = 1 and U·Uᴴ = 1) supply the left and right inverses separately; the left inverse gives inner-product preservation and the right inverse gives surjectivity, the two hypotheses LinearIsometryEquiv.ofSurjective needs.",
+      "Once bundled, the parent's ℓ²-energy law ‖Ux‖ = ‖x‖ and the inner-product law are no longer separate theorems but the norm_map and inner_map_map of a single isometry, and the inverse DFT is literally the inverse morphism (dftLIE).symm = toEuclideanLin Uᴴ."
+    ]
   },
   "leanFile": {
     "imports": [
@@ -146,5 +153,65 @@
       "relationship": "foundational",
       "description": "Grandparent character orthonormality, the nontrivial input behind the unitarity that this entry lifts to an isometric isomorphism."
     }
-  ]
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and open question",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "States the parent's matrix unitarity U·Uᴴ = 1 for the normalised DFT U(j,k) = exp(2πi·jk/n)/√n and the third open question — upgrade it to an isometric isomorphism of ℂⁿ — then sketches the plan (adjoint = toEuclideanLin Uᴴ, two-sided inverse, isometryOfInner + ofSurjective) and lists the eight results.",
+      "mathContext": "Goal: $\\mathrm{dftLIE} : \\mathbb{C}^n \\simeq_{\\ell i}[\\mathbb{C}] \\mathbb{C}^n$ from $U \\in \\mathrm{unitaryGroup}$."
+    },
+    {
+      "id": "setup",
+      "title": "Imports and namespace",
+      "startLine": 47,
+      "endLine": 52,
+      "summary": "Imports the parent module (bringing dftMatrix and dftMatrix_mem_unitaryGroup into scope), opens Matrix and the parent namespace, and opens namespace DeMoivreOQ05OQ01OQ01OQ01OQ03.",
+      "mathContext": "Sole nontrivial input: $\\mathrm{dftMatrix\\_mem\\_unitaryGroup} : U \\in \\mathrm{unitaryGroup}\\,(\\mathrm{Fin}\\,n)\\,\\mathbb{C}$."
+    },
+    {
+      "id": "two-sided-inverse",
+      "title": "Uᴴ as a two-sided operator inverse",
+      "startLine": 54,
+      "endLine": 78,
+      "summary": "dftMatrix_conjTranspose_toEuclideanLin_left_inverse (from Uᴴ·U = 1) and dftMatrix_toEuclideanLin_right_inverse (from U·Uᴴ = 1): toEuclideanLin Uᴴ is a two-sided inverse of toEuclideanLin U on ℂⁿ, proved by WithLp.ofLp_injective + Matrix.mulVec_mulVec.",
+      "mathContext": "$\\mathrm{toEuclideanLin}\\,U^{\\mathsf H} \\circ \\mathrm{toEuclideanLin}\\,U = \\mathrm{id} = \\mathrm{toEuclideanLin}\\,U \\circ \\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$."
+    },
+    {
+      "id": "inner-preservation",
+      "title": "Inner-product preservation",
+      "startLine": 80,
+      "endLine": 94,
+      "summary": "dftMatrix_toEuclideanLin_inner: ⟪Ux, Uy⟫ = ⟪x, y⟫, via adjoint_inner_right + toEuclideanLin_conjTranspose_eq_adjoint and the left-inverse identity (adjoint = inverse).",
+      "mathContext": "$\\langle Ux, Uy\\rangle = \\langle x, U^{\\ast}Uy\\rangle = \\langle x, y\\rangle$."
+    },
+    {
+      "id": "dftlie",
+      "title": "Assembling dftLIE",
+      "startLine": 96,
+      "endLine": 114,
+      "summary": "dftLIE: the normalised DFT as a LinearIsometryEquiv, built from isometryOfInner (inner preservation) + LinearIsometryEquiv.ofSurjective (right inverse as the surjectivity witness); dftLIE_apply records that it acts as toEuclideanLin U.",
+      "mathContext": "$\\mathrm{dftLIE}\\,x = \\mathrm{toEuclideanLin}\\,U\\,x$."
+    },
+    {
+      "id": "properties",
+      "title": "Norm/inner laws and the inverse DFT",
+      "startLine": 116,
+      "endLine": 137,
+      "summary": "dftLIE_norm (‖dftLIE x‖ = ‖x‖, the norm_map), dftLIE_inner (the inner_map_map), and dftLIE_symm_apply: (dftLIE).symm acts as toEuclideanLin Uᴴ — the inverse / conjugate-transpose discrete Fourier transform.",
+      "mathContext": "$(\\mathrm{dftLIE})^{-1} = \\mathrm{toEuclideanLin}\\,U^{\\mathsf H}$, i.e. $x(k) = \\tfrac1n\\sum_j \\hat x(j)\\,e^{-2\\pi i jk/n}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The normalised discrete Fourier transform is packaged as an explicit linear isometric isomorphism dftLIE : EuclideanSpace ℂ (Fin n) ≃ₗᵢ[ℂ] EuclideanSpace ℂ (Fin n), upgrading the parent's matrix unitarity U·Uᴴ = 1 to Mathlib's bundled ≃ₗᵢ world. Its forward action is toEuclideanLin U, it preserves the Euclidean norm and the Hermitian inner product, and its inverse (dftLIE).symm is toEuclideanLin Uᴴ — the inverse / conjugate-transpose DFT. 7 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "Realises the DFT in the form actually used in functional analysis and signal processing: a unitary of the finite-dimensional Hilbert space ℂⁿ. As a LinearIsometryEquiv it carries the energy law and inner-product law as structural lemmas (norm_map, inner_map_map) rather than ad-hoc identities, and the inverse transform is the genuine inverse morphism. This is the discrete, finite-dimensional shadow of the Plancherel theorem, with the inverse isometry making the conjugate-transpose = inverse-DFT identification explicit.",
+    "openQuestions": [
+      "Express dftLIE in Mathlib's orthonormal-basis framework: exhibit the DFT as the change-of-basis isometry between the standard basis and the Fourier (character) basis of ℂⁿ.",
+      "Connect dftLIE to Mathlib's abstract Fourier transform on finite abelian groups (the characters of ℤ/nℤ), recovering this concrete matrix as a special case.",
+      "Quantify the spectrum of dftLIE: its eigenvalues are fourth roots of unity (U⁴ = 1), with multiplicities given by the classical Gauss-sum / McClellan–Parks analysis — formalize the eigenvalue multiplicities.",
+      "Derive the convolution theorem in this bundled setting: dftLIE intertwines cyclic convolution with pointwise multiplication."
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-05-oq-01-oq-01-oq-01-oq-03` (quality score was 10, the lowest) — the normalised DFT packaged as an isometric isomorphism dftLIE : ℂⁿ ≃ₗᵢ[ℂ] ℂⁿ.

The entry shipped with only `meta.json` and a non-standard overview. This pass fills every gap:

**New `annotations.json`** — 6 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`): the matrix-unitarity→Hilbert-isometry framing, the parent-import setup, Uᴴ as a two-sided operator inverse (WithLp.ofLp_injective + Matrix.mulVec_mulVec), inner-product preservation via adjoint = inverse, assembling dftLIE (isometryOfInner + ofSurjective), and the norm/inner laws + the inverse DFT (dftLIE).symm = toEuclideanLin Uᴴ.

**New `index.ts`** — was missing, so the page would show "proof not found" on the live site. Follows the sibling template (`deMoivreOQ05OQ01OQ01OQ01OQ03`).

**`meta.json`**:
- added a 6-entry `sections` array covering the whole file (lines 1–137; there were none)
- added a `conclusion` (summary, implications, 4 open questions: orthonormal-basis framing, finite-abelian-group Fourier transform, eigenvalue multiplicities U⁴=1, convolution theorem)
- added the schema-standard `overview.keyInsights` array (4) and `proofStrategy`; the entry previously had only a singular non-standard `keyInsight` string (preserved). All existing content kept.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`/badge `original`, 0 axioms, 0 sorries; the single nontrivial input is the parent's dftMatrix_mem_unitaryGroup, repackaged via Mathlib's toEuclideanLin/adjoint/LinearIsometryEquiv machinery).