### PR TITLE
Enrich Cauchy-Schwarz OQ-06: equality case as linear dependence

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-06/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-06/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "cs-oq06-ann-header",
+    "proofId": "cauchy-schwarz-oq-06",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "concept",
+    "title": "The Symmetric, Unconditional Equality Case",
+    "content": "Cauchy-Schwarz gives ‖⟪x,y⟫‖ ≤ ‖x‖·‖y‖ in every inner-product space over 𝕜 ∈ {ℝ, ℂ}. Mathlib already characterizes equality, but its `norm_inner_eq_norm_iff` needs both vectors nonzero and states proportionality asymmetrically as `∃ r, y = r • x`. This file proves the textbook form `‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ¬ LinearIndependent 𝕜 ![x,y]`, which is symmetric in x and y and silently absorbs the degenerate cases x = 0 and y = 0. The setup fixes 𝕜 via the `RCLike` typeclass (the common abstraction of ℝ and ℂ) and E as an inner-product space over it.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| \\le \\|x\\|\\,\\|y\\|, \\qquad \\text{equality} \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y].$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "linear dependence", "inner product space", "RCLike"],
+    "prerequisites": ["inner product spaces over ℝ or ℂ", "linear independence of vectors"]
+  },
+  {
+    "id": "cs-oq06-ann-pair-iff",
+    "proofId": "cauchy-schwarz-oq-06",
+    "range": { "startLine": 44, "endLine": 65 },
+    "type": "theorem",
+    "title": "Linear Dependence as a Nontrivial Vanishing Combination",
+    "content": "`not_linearIndependent_pair_iff` restates `¬ LinearIndependent 𝕜 ![x,y]` in the workable form `∃ s t, (s ≠ 0 ∨ t ≠ 0) ∧ s•x + t•y = 0`. The forward direction pushes the negation through `LinearIndependent.pair_iff` (a `∀ s t, … → …` statement) by repeatedly applying `not_forall` and `not_imp`, then `not_and_or` to turn `¬(s = 0 ∧ t = 0)` into `s ≠ 0 ∨ t ≠ 0`. The reverse direction is a direct contradiction. This lemma is the linear-algebraic interface used by every result below.",
+    "mathContext": "$\\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y] \\iff \\exists s,t\\ (s \\ne 0 \\lor t \\ne 0) \\land s\\cdot x + t\\cdot y = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["linear independence", "negation of quantifiers", "de Morgan laws"],
+    "prerequisites": ["LinearIndependent.pair_iff", "propositional logic in Lean"]
+  },
+  {
+    "id": "cs-oq06-ann-equality",
+    "proofId": "cauchy-schwarz-oq-06",
+    "range": { "startLine": 71, "endLine": 103 },
+    "type": "theorem",
+    "title": "The Equality Case via Mathlib's TFAE",
+    "content": "`norm_inner_eq_norm_mul_iff_not_linearIndependent` is the central result. It pulls one entry out of Mathlib's `norm_inner_eq_norm_tfae` — `‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ x = 0 ∨ ∃ r, y = r•x` — and proves this right-hand side equivalent to the vanishing-combination form. Forward: `x = 0` is witnessed by `1•x + 0•y = 0`, and `y = r•x` by `r•x + (-1)•y = 0`. Reverse: case-split on the y-coefficient t — if t = 0 then s ≠ 0 forces x = 0; if t ≠ 0 then y = (-(t⁻¹s))•x by `inv_mul_cancel₀`. All inner-product analysis is delegated; the new content is purely the linear-algebra bridge.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| = \\|x\\|\\,\\|y\\| \\iff (x = 0 \\lor \\exists r,\\ y = r\\cdot x) \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y].$",
+    "significance": "critical",
+    "relatedConcepts": ["TFAE", "proportionality", "scalar inverse", "case analysis"],
+    "prerequisites": ["norm_inner_eq_norm_tfae", "field arithmetic in ℝ/ℂ"]
+  },
+  {
+    "id": "cs-oq06-ann-exists",
+    "proofId": "cauchy-schwarz-oq-06",
+    "range": { "startLine": 105, "endLine": 108 },
+    "type": "theorem",
+    "title": "Equality as an Explicit Witness",
+    "content": "`norm_inner_eq_norm_mul_iff_exists` reformulates the equality case so the witnessing coefficients are visible: `‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ∃ s t, (s ≠ 0 ∨ t ≠ 0) ∧ s•x + t•y = 0`. It is a one-line consequence — chain the headline equivalence with `not_linearIndependent_pair_iff`. This symmetric form is often more convenient downstream than the `¬ LinearIndependent` predicate.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| = \\|x\\|\\,\\|y\\| \\iff \\exists s,t\\ (s \\ne 0 \\lor t \\ne 0)\\land s\\cdot x + t\\cdot y = 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["explicit witnesses", "reformulation"],
+    "prerequisites": ["the headline equality case"]
+  },
+  {
+    "id": "cs-oq06-ann-sharp",
+    "proofId": "cauchy-schwarz-oq-06",
+    "range": { "startLine": 110, "endLine": 122 },
+    "type": "theorem",
+    "title": "Sharp Form: Strict Inequality ↔ Independence",
+    "content": "`norm_inner_lt_norm_mul_iff_linearIndependent` completes the dichotomy: `‖⟪x,y⟫‖ < ‖x‖·‖y‖ ↔ LinearIndependent 𝕜 ![x,y]`. Because Cauchy-Schwarz always supplies `≤`, strict inequality is exactly 'not equality'. The proof rewrites `<` as `≤ ∧ ≠` (`lt_iff_le_and_ne`), discharges the `≤` half with `norm_inner_le_norm`, and turns the `≠` half into the negated equality case, where `not_not` cancels the double negation back to `LinearIndependent`.",
+    "mathContext": "$\\|\\langle x,y\\rangle\\| < \\|x\\|\\,\\|y\\| \\iff \\mathrm{LinearIndependent}\\ \\mathbb{K}\\ [x,y].$",
+    "significance": "critical",
+    "relatedConcepts": ["strict inequality", "dichotomy", "lt_iff_le_and_ne", "Gram determinant positivity"],
+    "prerequisites": ["the equality case", "norm_inner_le_norm"]
+  },
+  {
+    "id": "cs-oq06-ann-real-corollaries",
+    "proofId": "cauchy-schwarz-oq-06",
+    "range": { "startLine": 124, "endLine": 166 },
+    "type": "theorem",
+    "title": "Real Specializations and Degenerate Corollaries",
+    "content": "Over a real inner-product space the inner product is real, so `Real.norm_eq_abs` lets `abs_real_inner_eq_norm_mul_iff_not_linearIndependent` and `abs_real_inner_lt_norm_mul_iff_linearIndependent` restate the results with `|⟪x,y⟫_ℝ|`. The sanity corollaries `norm_inner_eq_norm_mul_left_zero` (equality when x = 0) and `norm_inner_eq_norm_mul_of_smul` (equality when y = r•x) exhibit exactly the degenerate cases that Mathlib's nonzero-hypothesis form cannot even state — both proved by producing the dependence witness directly.",
+    "mathContext": "$|\\langle x,y\\rangle_{\\mathbb R}| = \\|x\\|\\,\\|y\\| \\iff \\neg\\,\\mathrm{LinearIndependent}\\ \\mathbb{R}\\ [x,y]; \\qquad \\|\\langle 0, y\\rangle\\| = \\|0\\|\\,\\|y\\|.$",
+    "significance": "supporting",
+    "relatedConcepts": ["real inner product", "absolute value", "degenerate cases", "Real.norm_eq_abs"],
+    "prerequisites": ["real vs complex inner products", "the general equality/sharp forms"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-06/index.ts
+++ b/src/data/proofs/cauchy-schwarz-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cauchySchwarzOQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cauchySchwarzOQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cauchySchwarzOQ06Data: ProofData = {
+  proof: cauchySchwarzOQ06Proof,
+  annotations: cauchySchwarzOQ06Annotations,
+}

--- a/src/data/proofs/cauchy-schwarz-oq-06/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-06/meta.json
@@ -75,6 +75,43 @@
       "Linear independence of a pair of vectors (LinearIndependent 𝕜 ![x, y])"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Statement and Setup",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Docstring contrasting Mathlib's nonzero-hypothesis equality case (norm_inner_eq_norm_iff, ∃ r, y = r • x) with the unconditional, symmetric goal ‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ¬ LinearIndependent 𝕜 ![x,y]. Imports Mathlib, opens InnerProductSpace notation, and fixes the variables 𝕜 (RCLike) and E (inner-product space)."
+    },
+    {
+      "id": "sec-dependence",
+      "title": "Part I — Linear Dependence in Explicit Form",
+      "startLine": 40,
+      "endLine": 65,
+      "summary": "not_linearIndependent_pair_iff: negates LinearIndependent.pair_iff into the convenient shape ∃ s t, (s ≠ 0 ∨ t ≠ 0) ∧ s•x + t•y = 0, pushing the negation through the universal quantifiers and the implication by hand."
+    },
+    {
+      "id": "sec-equality",
+      "title": "Part II — The Equality Case",
+      "startLine": 67,
+      "endLine": 108,
+      "summary": "The headline norm_inner_eq_norm_mul_iff_not_linearIndependent (bridging Mathlib's TFAE x = 0 ∨ ∃ r, y = r•x to linear dependence) and its explicit-witness reformulation norm_inner_eq_norm_mul_iff_exists. The reverse direction is the field computation y = (-(t⁻¹s)) • x when t ≠ 0."
+    },
+    {
+      "id": "sec-sharp",
+      "title": "Part III — The Sharp Boundary",
+      "startLine": 110,
+      "endLine": 122,
+      "summary": "norm_inner_lt_norm_mul_iff_linearIndependent: strict inequality ↔ linear independence, via lt_iff_le_and_ne with the Cauchy-Schwarz bound norm_inner_le_norm and the negated equality case."
+    },
+    {
+      "id": "sec-real-and-corollaries",
+      "title": "Parts IV–V — Real Form and Sanity Corollaries",
+      "startLine": 124,
+      "endLine": 166,
+      "summary": "Real absolute-value specializations (abs_real_inner_eq/lt via Real.norm_eq_abs) and degenerate-case corollaries (norm_inner_eq_norm_mul_left_zero, norm_inner_eq_norm_mul_of_smul) that the nonzero-hypothesis form cannot express."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "cauchy-schwarz",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-06` (the equality case `‖⟪x,y⟫‖ = ‖x‖·‖y‖ ↔ ¬ LinearIndependent 𝕜 ![x,y]`, unconditional and symmetric).

The meta.json was already rich (overview, mainTheorems, conclusion with open questions, references) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site), had no annotations, and had **no** `sections` array. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 6 annotations carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the header framing, `not_linearIndependent_pair_iff`, the headline equality case, the explicit-witness form, the sharp boundary, and the real/degenerate corollaries.
- **`sections`** — added 5 sections spanning the full 166-line file (the proof's Parts I-V).

Axiom integrity unchanged: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` — accurate (badge `mathlib` is appropriate since the analytic core is delegated to `norm_inner_eq_norm_tfae`; the contribution is the unconditional linear-dependence repackaging).

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)