### PR TITLE
research(geometric-series-oq-09-oq-01-oq-01-oq-02): roots-of-unity multisection filter — ∑ f(qn+a) as a DFT average of rotated sums [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3781,3 +3781,4 @@ import Proofs.Erdos396OQ04OQ01OQ01OQ02OQ02OQ02OQ01OQ01
 import Proofs.BezoutIdentityOQ03OQ01OQ01OQ03
 
 import Proofs.CombinationsFormulaOQ05OQ01OQ01
+import Proofs.GeometricSeriesOQ09OQ01OQ01OQ02

--- a/proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ02.lean
@@ -1,0 +1,205 @@
+import Mathlib
+
+/-
+# The Roots-of-Unity Multisection Filter for an Absolutely Convergent Series
+
+## What This Proves
+
+Fix an integer modulus `q ≥ 1` and a primitive `q`-th root of unity `ω` in `ℂ`
+(canonically `ω = exp(2πi/q)`).  For an **absolutely convergent** complex series
+`∑_m f m` (i.e. `Summable (‖f ·‖)`) and a residue `a < q`, the residue subseries
+`∑_n f (q·n + a)` is recovered as a discrete-Fourier average of the `q` *rotated*
+full sums:
+
+  `∑'_n f (q·n + a)  =  q⁻¹ · ∑_{j<q} (ω^{j·a})⁻¹ · ∑'_m ω^{j·m} · f m`.
+
+This is the classical **roots-of-unity filter** (a.k.a. the multisection / series
+multisection formula): the inner sum `∑'_m ω^{j·m} f m` is the original series with
+its `m`-th term rotated by `ω^{j·m}`, and the outer DFT-weighted average over
+`j = 0, …, q-1` annihilates every residue class except `a`.
+
+## Relation to the Sibling (`…-oq-01`)
+
+The parent's open question has two genuinely different answers.  The combinatorial
+one (`geometric-series-oq-09-oq-01-oq-01-oq-01`) realises the multisection as a
+*partition / Fubini regrouping* `HasSum.prod_fiberwise` of the reindexing
+`ℕ ≃ ℕ × Fin q`; it holds for ANY summable family valued in a complete Hausdorff
+abelian group, with no roots of unity and no absolute convergence.  This file gives
+the *analytic / Fourier* answer: the same residue subseries expressed as a weighted
+average of rotated copies of the WHOLE series.  This genuinely needs the complex
+field (roots of unity) and **absolute** convergence — multiplying the conditionally
+convergent series by the bounded twist `ω^{j·m}` need not preserve plain
+summability, whereas it preserves absolute summability since `‖ω^{j·m}‖ = 1`.  The
+two results are complementary facets of the multisection, not variants.
+
+## Why This Is Not Already in Mathlib
+
+Mathlib has primitive roots (`Complex.isPrimitiveRoot_exp`), the finite geometric
+sum (`geom_sum_eq`), `pow_eq_pow_iff_modEq`, and the linearity/reindexing toolkit
+for `tsum`, but not their assembly into the series multisection filter.  The new
+content is the orthogonality computation `q⁻¹ ∑_{j<q} ((ω^a)⁻¹ ω^m)^j = ⟦m ≡ a⟧`
+(a `q`-fold geometric sum that collapses to the indicator of the residue class via
+`((ω^a)⁻¹ ω^m)^q = 1`), combined with the absolutely-convergent interchange of the
+finite DFT sum with the infinite series and the reindexing of the surviving
+indicator-weighted series onto the residue subseries.
+
+## Status: 0 sorries, 0 axioms.
+-/
+
+namespace GeometricSeriesOQ09OQ01OQ01OQ02
+
+open Complex Finset
+
+variable {f : ℕ → ℂ}
+
+/-- For `q ≠ 0` the residue map `n ↦ q·n + a` is injective `ℕ → ℕ`. -/
+theorem residue_injective {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Function.Injective (fun n : ℕ => q * n + a) := by
+  intro n m h
+  have : q * n = q * m := Nat.add_right_cancel h
+  exact Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero hq) this
+
+/-- The shift `q·n + a` lies in the residue class `a` modulo `q`. -/
+theorem residue_self_modEq {q : ℕ} (n a : ℕ) : (q * n + a) ≡ a [MOD q] := by
+  unfold Nat.ModEq
+  rw [Nat.add_comm, Nat.add_mul_mod_self_left]
+
+/-- For `a < q`, every element of the residue class `a` mod `q` is `q·n + a`. -/
+theorem residue_mem_range {q : ℕ} (a m : ℕ) (ha : a < q) (hcong : m ≡ a [MOD q]) :
+    m ∈ Set.range (fun n : ℕ => q * n + a) := by
+  refine ⟨m / q, ?_⟩
+  have hma : m % q = a := by
+    have h : m % q = a % q := hcong
+    rwa [Nat.mod_eq_of_lt ha] at h
+  show q * (m / q) + a = m
+  rw [← hma, Nat.div_add_mod]
+
+/-- **Roots-of-unity multisection filter.**  For an absolutely convergent complex
+series `f` and a primitive `q`-th root of unity `ω`, the residue subseries
+`∑'_n f (q·n + a)` (with `a < q`) equals the DFT-weighted average of the `q`
+twisted full sums `∑'_m ω^{j·m} f m`. -/
+theorem multisection_filter
+    (hf : Summable (fun m => ‖f m‖)) {q : ℕ} (hq : q ≠ 0)
+    {ω : ℂ} (hω : IsPrimitiveRoot ω q) {a : ℕ} (ha : a < q) :
+    ∑' n : ℕ, f (q * n + a)
+      = (q : ℂ)⁻¹ * ∑ j ∈ range q,
+          (ω ^ (j * a))⁻¹ * ∑' m : ℕ, ω ^ (j * m) * f m := by
+  -- Basic facts about ω.
+  have hω1 : ‖ω‖ = 1 := Complex.norm_eq_one_of_pow_eq_one hω.pow_eq_one hq
+  have hωne : ω ≠ 0 := by
+    intro h; rw [h, norm_zero] at hω1; exact one_ne_zero hω1.symm
+  have hfin : IsOfFinOrder ω :=
+    isOfFinOrder_iff_pow_eq_one.2 ⟨q, Nat.pos_of_ne_zero hq, hω.pow_eq_one⟩
+  have hord : orderOf ω = q := hω.eq_orderOf.symm
+  -- Each twisted series is (absolutely) summable: ‖ω^{j·m} f m‖ = ‖f m‖.
+  have htw : ∀ j : ℕ, Summable (fun m => ω ^ (j * m) * f m) := by
+    intro j
+    apply Summable.of_norm
+    have heq : (fun m => ‖ω ^ (j * m) * f m‖) = (fun m => ‖f m‖) := by
+      funext m; rw [norm_mul, norm_pow, hω1, one_pow, one_mul]
+    rw [heq]; exact hf
+  -- The residue subseries is summable.
+  have hres : Summable (fun n => f (q * n + a)) := by
+    apply Summable.of_norm
+    simpa [Function.comp_def] using hf.comp_injective (residue_injective hq a)
+  -- Orthogonality: q⁻¹ · ∑_{j<q} (ω^{ja})⁻¹ ω^{jm} = ⟦m ≡ a (mod q)⟧.
+  have hEm : ∀ m : ℕ,
+      (q : ℂ)⁻¹ * (∑ j ∈ range q, (ω ^ (j * a))⁻¹ * ω ^ (j * m))
+        = if m ≡ a [MOD q] then (1 : ℂ) else 0 := by
+    intro m
+    -- rewrite the j-th term as zʲ with z = (ω^a)⁻¹ · ω^m
+    have hterm : ∀ j, (ω ^ (j * a))⁻¹ * ω ^ (j * m) = ((ω ^ a)⁻¹ * ω ^ m) ^ j := by
+      intro j
+      rw [mul_comm j a, mul_comm j m, pow_mul, pow_mul, ← inv_pow, ← mul_pow]
+    have hsum_z : (∑ j ∈ range q, (ω ^ (j * a))⁻¹ * ω ^ (j * m))
+        = ∑ j ∈ range q, ((ω ^ a)⁻¹ * ω ^ m) ^ j :=
+      Finset.sum_congr rfl (fun j _ => hterm j)
+    have hmod : ω ^ m = ω ^ a ↔ m ≡ a [MOD q] := by
+      rw [hfin.pow_eq_pow_iff_modEq, hord]
+    have hzq : ((ω ^ a)⁻¹ * ω ^ m) ^ q = 1 := by
+      rw [mul_pow, inv_pow, ← pow_mul, ← pow_mul, mul_comm a q, mul_comm m q,
+        pow_mul, pow_mul]
+      simp only [hω.pow_eq_one, one_pow, inv_one, mul_one]
+    rw [hsum_z]
+    by_cases hcong : m ≡ a [MOD q]
+    · rw [if_pos hcong]
+      have hmeq : ω ^ m = ω ^ a := hmod.mpr hcong
+      have hz1 : (ω ^ a)⁻¹ * ω ^ m = 1 := by
+        rw [hmeq, inv_mul_cancel₀ (pow_ne_zero a hωne)]
+      rw [hz1]
+      simp only [one_pow, Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_one]
+      exact inv_mul_cancel₀ (by exact_mod_cast hq)
+    · rw [if_neg hcong]
+      have hzne : (ω ^ a)⁻¹ * ω ^ m ≠ 1 := by
+        intro h
+        apply hcong
+        have hmeq : ω ^ m = ω ^ a := by
+          have h2 : ω ^ a * ((ω ^ a)⁻¹ * ω ^ m) = ω ^ a * 1 := by rw [h]
+          rwa [← mul_assoc, mul_inv_cancel₀ (pow_ne_zero a hωne), one_mul, mul_one] at h2
+        exact hmod.mp hmeq
+      rw [geom_sum_eq hzne q, hzq]
+      simp
+  -- Rewrite the RHS into ∑'_m ⟦m ≡ a⟧ · f m.
+  have key :
+      (q : ℂ)⁻¹ * ∑ j ∈ range q, (ω ^ (j * a))⁻¹ * ∑' m : ℕ, ω ^ (j * m) * f m
+        = ∑' m : ℕ, (if m ≡ a [MOD q] then (1 : ℂ) else 0) * f m := by
+    -- pull the coefficient into each tsum
+    have step1 : ∀ j ∈ range q,
+        (ω ^ (j * a))⁻¹ * ∑' m, ω ^ (j * m) * f m
+          = ∑' m, (ω ^ (j * a))⁻¹ * (ω ^ (j * m) * f m) :=
+      fun j _ => (tsum_mul_left).symm
+    rw [Finset.sum_congr rfl step1]
+    -- swap the finite DFT sum with the infinite series
+    rw [← Summable.tsum_finsetSum (fun j _ => (htw j).mul_left ((ω ^ (j * a))⁻¹))]
+    rw [← tsum_mul_left]
+    apply tsum_congr
+    intro m
+    have hfactor : ∑ j ∈ range q, (ω ^ (j * a))⁻¹ * (ω ^ (j * m) * f m)
+        = (∑ j ∈ range q, (ω ^ (j * a))⁻¹ * ω ^ (j * m)) * f m := by
+      rw [Finset.sum_mul]
+      exact Finset.sum_congr rfl (fun j _ => by rw [mul_assoc])
+    rw [hfactor, ← mul_assoc, hEm m]
+  rw [key]
+  -- Reindex ∑'_m ⟦m ≡ a⟧ f m onto the residue subseries ∑'_n f (q·n+a).
+  symm
+  have hsupp : ∀ x, x ∉ Set.range (fun n : ℕ => q * n + a) →
+      (if x ≡ a [MOD q] then (1 : ℂ) else 0) * f x = 0 := by
+    intro x hx
+    rw [if_neg (fun hcong => hx (residue_mem_range a x ha hcong)), zero_mul]
+  have hFe : HasSum (fun m => (if m ≡ a [MOD q] then (1 : ℂ) else 0) * f m)
+      (∑' n, f (q * n + a)) := by
+    rw [← (residue_injective hq a).hasSum_iff hsupp]
+    have hcomp : ((fun m => (if m ≡ a [MOD q] then (1 : ℂ) else 0) * f m)
+          ∘ (fun n : ℕ => q * n + a))
+        = (fun n => f (q * n + a)) := by
+      funext n
+      simp only [Function.comp_apply]
+      rw [if_pos (residue_self_modEq n a), one_mul]
+    rw [hcomp]
+    exact hres.hasSum
+  exact hFe.tsum_eq
+
+/-- Specialisation to the canonical root `ω = exp(2πi/q)`. -/
+theorem multisection_filter_exp
+    (hf : Summable (fun m => ‖f m‖)) {q : ℕ} (hq : q ≠ 0) {a : ℕ} (ha : a < q) :
+    ∑' n : ℕ, f (q * n + a)
+      = (q : ℂ)⁻¹ * ∑ j ∈ range q,
+          (Complex.exp (2 * ↑Real.pi * Complex.I / q) ^ (j * a))⁻¹
+            * ∑' m : ℕ, Complex.exp (2 * ↑Real.pi * Complex.I / q) ^ (j * m) * f m :=
+  multisection_filter hf hq (Complex.isPrimitiveRoot_exp q hq) ha
+
+/-- **Even-part filter (`q = 2`).**  The even subseries of an absolutely convergent
+complex series is the half-sum of the series and its alternating twin, via the
+primitive square root of unity `ω = -1`:
+`∑'_n f (2n) = ½ (∑'_m f m + ∑'_m (-1)^m f m)`. -/
+theorem tsum_even_filter (hf : Summable (fun m => ‖f m‖)) :
+    ∑' n : ℕ, f (2 * n)
+      = (2 : ℂ)⁻¹ * (∑' m : ℕ, f m + ∑' m : ℕ, (-1 : ℂ) ^ m * f m) := by
+  have h := multisection_filter (f := f) (q := 2) (a := 0) hf (by norm_num)
+    (IsPrimitiveRoot.neg_one 0 (by norm_num)) (by norm_num)
+  simp only [Nat.add_zero, pow_zero, inv_one, one_mul,
+    Finset.sum_range_succ, Finset.sum_range_zero, zero_add, Nat.zero_mul,
+    mul_zero] at h
+  simpa using h
+
+end GeometricSeriesOQ09OQ01OQ01OQ02

--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+  "slug": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+  "title": "The Roots-of-Unity Multisection Filter for an Absolutely Convergent Series",
+  "description": "Extracts a single residue subseries of an absolutely convergent complex series as a discrete-Fourier average of rotated full sums: for a primitive q-th root of unity ω (canonically exp(2πi/q)), Summable (‖f ·‖), and residue a < q, ∑_n f(q·n+a) = q⁻¹ · ∑_{j<q} (ω^{j·a})⁻¹ · ∑_m ω^{j·m}·f(m). This is the classical roots-of-unity filter (series multisection): the inner sum is the original series with its m-th term rotated by ω^{j·m}, and the outer DFT-weighted average over j annihilates every residue class except a. The proof rests on the orthogonality collapse q⁻¹·∑_{j<q} ((ω^a)⁻¹ω^m)^j = ⟦m ≡ a (mod q)⟧ — a q-fold geometric sum that vanishes off the residue class because z := (ω^a)⁻¹ω^m satisfies z^q = 1 (geom_sum_eq) — combined with the absolutely-convergent interchange of the finite DFT sum with the infinite series (each twist ω^{j·m}·f(m) is absolutely summable since ‖ω^{j·m}‖ = 1) and the reindexing of the surviving indicator-weighted series onto the residue subseries. This is the analytic/Fourier counterpart to the sibling geometric-series-oq-09-oq-01-oq-01-oq-01, which realises the same multisection combinatorially as a Fubini regrouping; this version genuinely requires the complex field (roots of unity) and absolute convergence.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ09OQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "infinite-series",
+      "summability",
+      "multisection",
+      "roots-of-unity",
+      "discrete-fourier",
+      "absolute-convergence",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 205,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "multisection_filter: for Summable (‖f ·‖), q ≠ 0, a primitive q-th root of unity ω, and a < q, the identity ∑_n f(q·n+a) = q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·∑_m ω^{j·m}·f(m). Expresses a single residue subseries of an arbitrary absolutely convergent complex series as a DFT-weighted average of the q rotated full sums — the roots-of-unity filter, distinct from the combinatorial Fubini multisection of the sibling oq-01.",
+      "The orthogonality lemma (inline hEm): q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·ω^{j·m} = ⟦m ≡ a (mod q)⟧. Each term is z^j with z = (ω^a)⁻¹·ω^m; since z^q = 1 the q-fold geometric sum (geom_sum_eq) collapses to q·⟦z=1⟧, and z = 1 ⇔ ω^m = ω^a ⇔ m ≡ a (mod q) via IsOfFinOrder.pow_eq_pow_iff_modEq with orderOf ω = q.",
+      "The absolutely-convergent interchange: each twisted series m ↦ ω^{j·m}·f(m) is summable because ‖ω^{j·m}·f(m)‖ = ‖f(m)‖ (‖ω‖ = 1 from Complex.norm_eq_one_of_pow_eq_one), so the finite DFT sum commutes with the infinite series (Summable.tsum_finsetSum) — the step that genuinely needs absolute convergence rather than plain summability.",
+      "multisection_filter_exp: the canonical specialisation to ω = exp(2πi/q) via Complex.isPrimitiveRoot_exp.",
+      "tsum_even_filter: the q=2 even-part filter ∑_n f(2n) = ½·(∑_m f(m) + ∑_m (-1)^m·f(m)) via the primitive square root of unity ω = -1 (IsPrimitiveRoot.neg_one) — a concrete sanity instance of the master identity.",
+      "Supporting reindexing infrastructure: residue_injective (n ↦ q·n+a injective for q ≠ 0), residue_self_modEq (q·n+a ≡ a mod q), residue_mem_range (for a < q the residue class a is exactly {q·n+a}), used to transport the indicator-weighted series onto the residue subseries via Function.Injective.hasSum_iff."
+    ],
+    "prerequisites": [
+      "IsPrimitiveRoot ω q and Complex.isPrimitiveRoot_exp (n : ℕ) (h : n ≠ 0) : IsPrimitiveRoot (exp (2πi/n)) n",
+      "Complex.norm_eq_one_of_pow_eq_one: ζ^n = 1, n ≠ 0 ⟹ ‖ζ‖ = 1 (gives summability of the rotated series)",
+      "geom_sum_eq (x ≠ 1) : ∑_{i<n} x^i = (x^n−1)/(x−1) — the finite geometric sum that vanishes when x^n = 1, x ≠ 1",
+      "IsOfFinOrder.pow_eq_pow_iff_modEq : ω^n = ω^m ↔ n ≡ m [MOD orderOf ω], with orderOf ω = q from IsPrimitiveRoot.eq_orderOf",
+      "Summable.of_norm, Summable.tsum_finsetSum (finite sum commutes with tsum), tsum_mul_left, Function.Injective.hasSum_iff (reindex a series supported on the range of an injection)",
+      "Parent: geometric-series-oq-09-oq-01-oq-01 (reindexing of the geometric series as HasSum over ℕ × Fin q); sibling geometric-series-oq-09-oq-01-oq-01-oq-01 (the combinatorial Fubini multisection of an arbitrary summable family)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.isPrimitiveRoot_exp",
+        "description": "exp(2πi/n) is a primitive n-th root of unity for n ≠ 0. Supplies the canonical filter root in multisection_filter_exp; the abstract theorem takes any IsPrimitiveRoot ω q.",
+        "module": "Mathlib.RingTheory.RootsOfUnity.Complex"
+      },
+      {
+        "theorem": "geom_sum_eq",
+        "description": "∑_{i<n} x^i = (x^n − 1)/(x − 1) for x ≠ 1. Applied to x = (ω^a)⁻¹·ω^m off the residue class: since x^q = 1 the numerator vanishes, so the q-fold geometric sum is 0 — the orthogonality that filters out all residues except a.",
+        "module": "Mathlib.Algebra.Field.GeomSum"
+      },
+      {
+        "theorem": "IsOfFinOrder.pow_eq_pow_iff_modEq",
+        "description": "ω^n = ω^m ↔ n ≡ m [MOD orderOf ω] for ω of finite order. With orderOf ω = q (IsPrimitiveRoot.eq_orderOf) this identifies z = (ω^a)⁻¹ω^m = 1 with the residue congruence m ≡ a (mod q).",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "Summable.tsum_finsetSum",
+        "description": "∑'_b ∑_{i∈s} f i b = ∑_{i∈s} ∑'_b f i b when each fiber is summable. Interchanges the finite DFT sum over j with the infinite series over m; the summability hypothesis is met because ‖ω^{j·m}·f m‖ = ‖f m‖, i.e. absolute convergence is preserved by the bounded twist.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Function.Injective.hasSum_iff",
+        "description": "For injective g with f vanishing off range g, HasSum (f ∘ g) a ↔ HasSum f a. Reindexes the indicator-weighted series ∑_m ⟦m≡a⟧·f m onto the residue subseries ∑_n f(q·n+a) via g = (n ↦ q·n+a).",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Defs"
+      }
+    ]
+  },
+  "sorries": 0,
+  "references": [
+    {
+      "title": "Mathlib4: RingTheory.RootsOfUnity.Complex (isPrimitiveRoot_exp)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the canonical primitive root exp(2πi/n) used as the DFT filter kernel."
+    },
+    {
+      "title": "Mathlib4: Algebra.Field.GeomSum (geom_sum_eq) and GroupTheory.OrderOfElement (pow_eq_pow_iff_modEq)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Provide the finite geometric sum collapse and the order-of-element congruence characterisation underlying the roots-of-unity orthogonality."
+    },
+    {
+      "title": "Concrete Mathematics (multisection of power series / roots-of-unity filter)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the roots-of-unity filter extracting the residue-class subseries of a series via averages of rotated copies."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-09-oq-01-oq-01-oq-01",
+      "relationship": "complements",
+      "description": "Sibling. Both answer the parent's open question about the multisection of an arbitrary series, but via different mechanisms. The sibling realises the residue regrouping COMBINATORIALLY as a partition/Fubini (HasSum.prod_fiberwise) of the reindexing ℕ ≃ ℕ × Fin q, valid for any summable family in a complete Hausdorff abelian group with no roots of unity and no absolute convergence. This entry gives the ANALYTIC/Fourier answer: each residue subseries as a DFT-weighted average of rotated copies of the WHOLE series, which genuinely needs the complex field and absolute convergence (the bounded twist ω^{j·m} preserves absolute, not conditional, summability)."
+    },
+    {
+      "targetId": "geometric-series-oq-09-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent reindexes the GEOMETRIC series along Nat.divModEquiv and regroups by residue. This entry replaces the geometric closed forms with the roots-of-unity orthogonality, recovering an individual residue subseries of an arbitrary absolutely convergent series rather than only reassembling the geometric one."
+    },
+    {
+      "targetId": "geometric-series-oq-09-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent. The grandparent computed the geometric multisection ∑_n r^(q·n+a) = r^a/(1−r^q) from closed forms. The roots-of-unity filter here is the residue-selecting projection that, specialised to f(m) = r^m, reproduces that closed form — but applies to any absolutely convergent series, not only the geometric one."
+    }
+  ],
+  "conclusion": {
+    "summary": "For an absolutely convergent complex series (Summable (‖f ·‖)), a modulus q ≠ 0, a primitive q-th root of unity ω, and a residue a < q, the residue subseries is recovered as a discrete-Fourier average of rotated full sums: multisection_filter establishes ∑_n f(q·n+a) = q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·∑_m ω^{j·m}·f(m). The core is an orthogonality collapse — q⁻¹·∑_{j<q} ((ω^a)⁻¹ω^m)^j equals the indicator of m ≡ a (mod q) because z = (ω^a)⁻¹ω^m has z^q = 1, so the q-fold geometric sum (geom_sum_eq) is q when z = 1 and 0 otherwise, with z = 1 ⇔ m ≡ a via pow_eq_pow_iff_modEq. Absolute convergence enters exactly once, to commute the finite DFT sum with the infinite series (Summable.tsum_finsetSum), licensed by ‖ω^{j·m}·f m‖ = ‖f m‖. The surviving indicator-weighted series is reindexed onto the subseries via Function.Injective.hasSum_iff. The canonical root exp(2πi/q) (multisection_filter_exp) and the q=2 even-part filter ∑_n f(2n) = ½(∑_m f m + ∑_m (-1)^m f m) (tsum_even_filter, via ω = -1) specialise the master identity. 205 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Gives the analytic/Fourier facet of the series multisection complementary to the sibling's combinatorial Fubini facet: the same residue subseries that the sibling builds by partitioning ℕ = ⨆_a {q·n+a} is here projected out of the whole series by DFT-weighted rotation. The clean separation of hypotheses is informative — the combinatorial multisection needs only summability in a complete abelian group, while the roots-of-unity filter needs the complex field and absolute convergence, because the bounded multiplier ω^{j·m} preserves absolute but not conditional convergence. Specialised to f(m) = r^m it reproduces the grandparent's geometric closed form r^a/(1−r^q).",
+    "openQuestions": [
+      "Does the roots-of-unity filter extend to merely conditionally convergent series under a summation method (Abel/Cesàro) that the bounded twist ω^{j·m} respects, and over which complete normed ℂ-algebras (rather than ℂ) does the orthogonality argument survive?"
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-09-oq-01-oq-01-oq-02-oq-01",
+      "question": "Extend the roots-of-unity multisection filter beyond absolute convergence: does ∑_n f(q·n+a) = q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·∑_m ω^{j·m}·f(m) persist for conditionally convergent series under an Abel or Cesàro interpretation of the twisted sums, and what is the most general complete normed ℂ-algebra (in place of ℂ) for which the orthogonality collapse q⁻¹·∑_{j<q} z^j = ⟦m ≡ a⟧ and the interchange remain valid?",
+      "significance": "low"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the parent's open question (`geometric-series-oq-09-oq-01-oq-01`) on a **distinct facet** from the sibling `-oq-01` (PR #28108). For an **absolutely convergent** complex series `Summable (‖f ·‖)`, a modulus `q ≠ 0`, a primitive `q`-th root of unity `ω`, and a residue `a < q`:

```
∑'_n f(q·n + a) = q⁻¹ · ∑_{j<q} (ω^{j·a})⁻¹ · ∑'_m ω^{j·m} · f(m)
```

This is the classical **roots-of-unity filter** (series multisection): each residue subseries is a discrete-Fourier average of the `q` *rotated* full sums.

## Why this is not a duplicate of #28108

The sibling `-oq-01` realises the multisection **combinatorially** as a Fubini/`prod_fiberwise` regrouping of `ℕ ≃ ℕ × Fin q` — valid for any summable family in a complete Hausdorff abelian group, **no** roots of unity, **no** absolute convergence. This entry gives the **analytic/Fourier** answer: a single residue subseries projected out of the *whole* series by DFT-weighted rotation. It genuinely needs the complex field and **absolute** convergence, because the bounded twist `ω^{j·m}` preserves absolute but not conditional summability. Complementary facets, not variants.

## Proof skeleton

- **Orthogonality** (`hEm`): `q⁻¹·∑_{j<q} ((ω^a)⁻¹ω^m)^j = ⟦m ≡ a (mod q)⟧`. Each term is `z^j` with `z = (ω^a)⁻¹ω^m`; `z^q = 1`, so the `q`-fold geometric sum (`geom_sum_eq`) is `q` when `z=1` and `0` otherwise, with `z=1 ⇔ m ≡ a` via `IsOfFinOrder.pow_eq_pow_iff_modEq` (`orderOf ω = q`).
- **Interchange**: each twist `m ↦ ω^{j·m}·f(m)` is summable (`‖ω^{j·m}·f m‖ = ‖f m‖`), so the finite DFT sum commutes with the series (`Summable.tsum_finsetSum`).
- **Reindex**: the surviving indicator-weighted series maps onto the subseries via `Function.Injective.hasSum_iff`.

## Corollaries

- `multisection_filter_exp` — canonical root `ω = exp(2πi/q)`.
- `tsum_even_filter` — `q=2` even part `∑_n f(2n) = ½(∑_m f m + ∑_m (-1)^m f m)` via `ω = -1`.

## Verification

205 lines, 6 theorems, 0 definitions, **0 axioms, 0 sorries**. Built clean via `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ09OQ01OQ01OQ02` (no warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)