### PR TITLE
Enrich Picard–Lindelöf via Contraction Mapping (banach-fixed-point-oq-01-oq-01): annotations, index.ts, sections

### DIFF
--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01/annotations.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "banach-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 29 },
+    "type": "context",
+    "title": "Picard–Lindelöf as a Fixed-Point Theorem",
+    "content": "The Picard–Lindelöf (Cauchy–Lipschitz) theorem is the prototypical application of the **Banach contraction mapping principle**. The autonomous initial value problem $y'(t) = f(y(t))$, $y(t_0) = x_0$ is recast as the fixed-point equation $y = Py$ for the **Picard integral operator**\n$$(Py)(t) = x_0 + \\int_{t_0}^{t} f(y(s))\\,ds.$$\nWhen $f$ is Lipschitz, $P$ is a contraction on a complete space of continuous curves over a short time interval, so Banach's theorem produces a unique fixed point — the local solution. Mathlib performs this construction internally (`IsPicardLindelof`, the `FunSpace` contraction, `ODE_solution_unique` via Grönwall) but exposes no clean autonomous existence-and-uniqueness statement; this entry packages exactly that.",
+    "mathContext": "$y = Py$, $(Py)(t) = x_0 + \\int_{t_0}^{t} f(y(s))\\,ds$ — a contraction whose unique fixed point solves $y' = f(y)$, $y(t_0)=x_0$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Banach fixed-point theorem",
+      "Picard iteration",
+      "contraction mapping",
+      "initial value problem"
+    ],
+    "prerequisites": [
+      "ordinary differential equations",
+      "the contraction mapping principle",
+      "complete metric spaces"
+    ]
+  },
+  {
+    "id": "ann-setup",
+    "proofId": "banach-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 31, "endLine": 35 },
+    "type": "definition",
+    "title": "Setup: An Autonomous Field on a Normed Space",
+    "content": "The development works over a general real normed vector space $E$ (`NormedAddCommGroup E`, `NormedSpace ℝ E`), with completeness `CompleteSpace E` added where existence requires it. The vector field $f : E \\to E$ is **autonomous** — time-independent — which is the case where the Mathlib uniqueness lemma collapses most cleanly (see the uniqueness theorem). Opening `Set` and `Metric` brings the open interval `Ioo`, `closedBall`, and `EqOn` notation into scope.",
+    "mathContext": "$E$ a real Banach space (when complete); $f : E \\to E$ time-independent, $y' = f(y)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "normed vector space",
+      "autonomous ODE",
+      "complete space"
+    ],
+    "prerequisites": [
+      "normed and Banach spaces"
+    ]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "banach-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 37, "endLine": 53 },
+    "type": "insight",
+    "title": "Existence From the Contraction Fixed Point",
+    "content": "`exists_local_solution`: a $C^1$ vector field near $x_0$ yields a solution $\\alpha$ on a genuine open interval $(t_0-\\varepsilon, t_0+\\varepsilon)$ with $\\alpha(t_0) = x_0$. The work is delegated to Mathlib's `ContDiffAt.exists_forall_mem_closedBall_exists_eq_forall_mem_Ioo_hasDerivAt`, which internally manufactures the `IsPicardLindelof` data from the $C^1$ hypothesis (via `IsPicardLindelof.of_contDiffAt_one`) and solves it by the `FunSpace` contraction — i.e. this is exactly where the Banach fixed point lives. The proof then instantiates the family of curves at the centre $x_0$, which lies in the closed ball since $r > 0$ (`mem_closedBall_self`).",
+    "mathContext": "$f \\in C^1$ near $x_0 \\Rightarrow \\exists\\,\\varepsilon>0,\\ \\alpha$ with $\\alpha(t_0)=x_0$ and $\\alpha'(t) = f(\\alpha(t))$ on $(t_0-\\varepsilon, t_0+\\varepsilon)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsPicardLindelof",
+      "FunSpace contraction",
+      "C¹ vector field",
+      "local flow"
+    ],
+    "prerequisites": [
+      "continuous differentiability",
+      "the contraction mapping principle"
+    ]
+  },
+  {
+    "id": "ann-uniqueness",
+    "proofId": "banach-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 71 },
+    "type": "insight",
+    "title": "Uniqueness From Grönwall's Inequality",
+    "content": "`solution_unique`: for a Lipschitz field, any two solutions on $(a,b)$ agreeing at one interior point $t_0$ coincide on all of $(a,b)$. Unlike existence, uniqueness does **not** come from the contraction — it comes from **Grönwall's inequality** (`ODE_solution_unique_of_mem_Ioo`), a comparison estimate bounding the growth of the gap between two solutions. The autonomous case is obtained by specializing the general lemma's time-dependent field to $v(t) := f$ and its constraint set to $s(t) := \\mathrm{univ}$; the Lipschitz-on-`univ` hypothesis comes from `LipschitzWith.lipschitzOnWith` and membership in `univ` is trivial.",
+    "mathContext": "$f$ Lipschitz, $\\alpha(t_0)=\\beta(t_0)$, both solving $y'=f(y)$ on $(a,b)$ $\\Rightarrow \\alpha = \\beta$ on $(a,b)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Grönwall's inequality",
+      "Lipschitz continuity",
+      "ODE_solution_unique_of_mem_Ioo",
+      "comparison estimate"
+    ],
+    "prerequisites": [
+      "Lipschitz functions",
+      "Grönwall's inequality"
+    ]
+  },
+  {
+    "id": "ann-combined",
+    "proofId": "banach-fixed-point-oq-01-oq-01",
+    "range": { "startLine": 73, "endLine": 89 },
+    "type": "concept",
+    "title": "The Combined Cauchy–Lipschitz Theorem",
+    "content": "`exists_unique_local_solution` assembles the two halves into the single statement the contraction mapping principle is famous for: a $C^1$, globally Lipschitz field admits a local solution that is unique among all solutions on that interval sharing the initial value. The proof takes the solution from `exists_local_solution`, observes $t_0 \\in (t_0-\\varepsilon, t_0+\\varepsilon)$ (a one-line `linarith`), and feeds any competitor $\\beta$ with $\\beta(t_0)=x_0$ into `solution_unique`. The two distinct hypotheses — $C^1$ for existence, Lipschitz for uniqueness — are exactly the two engines combined.",
+    "mathContext": "$f \\in C^1$ near $x_0$ and Lipschitz $\\Rightarrow \\exists!$ local solution of $y'=f(y)$, $y(t_0)=x_0$ on $(t_0-\\varepsilon, t_0+\\varepsilon)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy–Lipschitz theorem",
+      "existence and uniqueness",
+      "well-posedness"
+    ],
+    "prerequisites": [
+      "the existence and uniqueness halves above"
+    ]
+  }
+]

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01/index.ts
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PicardLindelofOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const banachFixedPointOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const banachFixedPointOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const banachFixedPointOQ01OQ01Data: ProofData = {
+  proof: banachFixedPointOQ01OQ01Proof,
+  annotations: banachFixedPointOQ01OQ01Annotations,
+}

--- a/src/data/proofs/banach-fixed-point-oq-01-oq-01/meta.json
+++ b/src/data/proofs/banach-fixed-point-oq-01-oq-01/meta.json
@@ -96,8 +96,9 @@
   ],
   "crossReferences": [
     {
-      "id": "banach-fixed-point-oq-01",
-      "reason": "The parent entry: the Banach contraction mapping theorem (existence and uniqueness of a fixed point for a contraction on a complete space), of which Picard–Lindelöf is the canonical application."
+      "targetId": "banach-fixed-point-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry: the Banach contraction mapping theorem (existence and uniqueness of a fixed point for a contraction on a complete space), of which Picard–Lindelöf is the canonical application. This entry packages that application as clean local existence/uniqueness theorems for y' = f(y)."
     }
   ],
   "conclusion": {
@@ -109,6 +110,48 @@
       "Quantify the interval of existence ε in terms of the Lipschitz constant and the bound on f, recovering the classical estimate ε ≥ min(a/L, 1/K)."
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and context",
+      "startLine": 3,
+      "endLine": 29,
+      "summary": "Frames Picard–Lindelöf as the prototypical contraction-mapping application: the IVP y' = f(y), y(t₀) = x₀ recast as the fixed point of the Picard integral operator (P y)(t) = x₀ + ∫ f(y), and notes that Mathlib does the contraction internally (IsPicardLindelof, FunSpace, Grönwall) without exposing a clean autonomous statement.",
+      "mathContext": "$(Py)(t) = x_0 + \\int_{t_0}^t f(y(s))\\,ds$; $y = Py$."
+    },
+    {
+      "id": "setup",
+      "title": "Setup: autonomous field on a normed space",
+      "startLine": 31,
+      "endLine": 35,
+      "summary": "Opens Set and Metric, declares namespace PicardLindelofOQ01, and fixes a real normed space E (completeness added per-theorem) carrying the autonomous vector field f : E → E.",
+      "mathContext": "$E$ a real normed space, $f : E \\to E$ time-independent."
+    },
+    {
+      "id": "existence",
+      "title": "Local existence (exists_local_solution)",
+      "startLine": 37,
+      "endLine": 53,
+      "summary": "exists_local_solution: a C¹ field near x₀ gives a solution α on (t₀-ε, t₀+ε) with α t₀ = x₀, by delegating to Mathlib's contraction-based local-flow theorem and instantiating the curve family at the centre x₀ (in the closed ball since r > 0).",
+      "mathContext": "$f \\in C^1$ near $x_0 \\Rightarrow \\exists\\,\\varepsilon>0,\\ \\alpha,\\ \\alpha(t_0)=x_0,\\ \\alpha'=f\\circ\\alpha$ on $(t_0-\\varepsilon,t_0+\\varepsilon)$."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Local uniqueness (solution_unique)",
+      "startLine": 55,
+      "endLine": 71,
+      "summary": "solution_unique: for a Lipschitz field, two solutions on (a,b) agreeing at an interior point coincide on (a,b), via Grönwall's ODE_solution_unique_of_mem_Ioo specialized to the time-independent field v t := f and set s t := univ (Lipschitz-on-univ from LipschitzWith.lipschitzOnWith).",
+      "mathContext": "$f$ Lipschitz, $\\alpha(t_0)=\\beta(t_0) \\Rightarrow \\alpha = \\beta$ on $(a,b)$."
+    },
+    {
+      "id": "combined",
+      "title": "Combined existence and uniqueness (exists_unique_local_solution)",
+      "startLine": 73,
+      "endLine": 89,
+      "summary": "exists_unique_local_solution: a C¹ and globally Lipschitz field admits a local solution unique among all solutions on the interval with the same initial value — built by taking the existence solution, noting t₀ ∈ (t₀-ε, t₀+ε), and feeding competitors into solution_unique.",
+      "mathContext": "$f \\in C^1$ near $x_0$ and Lipschitz $\\Rightarrow \\exists!$ local solution of $y'=f(y),\\,y(t_0)=x_0$."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
Enrichment pass for `banach-fixed-point-oq-01-oq-01` — Picard–Lindelöf local existence and uniqueness as the headline application of the Banach contraction mapping principle.

The entry shipped with only `meta.json`. This pass adds the missing files, full section coverage, and a schema fix:

**New `annotations.json`** — 5 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`): the Picard-operator/fixed-point framing, the autonomous-field setup, existence from the contraction fixed point (Mathlib's IsPicardLindelof + FunSpace), uniqueness from Grönwall (ODE_solution_unique_of_mem_Ioo specialized to v t := f, s t := univ), and the combined Cauchy–Lipschitz theorem.

**New `index.ts`** — was missing, so the page would show "proof not found" on the live site. Follows the sibling template (`banachFixedPointOQ01OQ01`, source `PicardLindelofOQ01.lean`).

**`meta.json`**:
- added a 5-entry `sections` array covering the whole file (lines 3–89; there were none)
- fixed `crossReferences` from the non-standard `{id, reason}` shape to the renderer's `{targetId, relationship, description}` so the parent link (banach-fixed-point-oq-01) actually resolves on the page. All existing content preserved.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`/badge `mathlib`, 0 axioms, 0 sorries; existence delegates to Mathlib's contraction-based local flow, uniqueness to Grönwall — both standard Mathlib lemmas, accurately reflected by the `mathlib` badge).