### PR TITLE
Enrich Lucas Theorem OQ-01: Glaisher's count of odd binomial coefficients

### DIFF
--- a/src/data/proofs/lucas-theorem-oq-01/annotations.json
+++ b/src/data/proofs/lucas-theorem-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "lucas-oq01-ann-defs",
+    "proofId": "lucas-theorem-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "definition",
+    "title": "Binary Digit Sum, Odd Row, and Odd Count",
+    "content": "The file targets Glaisher's 1899 specialization of Lucas' theorem to p = 2: the count of odd entries in row n of Pascal's triangle. Three definitions set the stage. `s2 n = (Nat.digits 2 n).sum` is the binary digit sum (popcount), valid because base-2 digits are 0 or 1. `oddRow n` is the Finset of columns k ≤ n with C(n,k) odd, and `oddCount n` is its cardinality. Reducing Pascal's triangle mod 2 yields the Sierpiński triangle, whose row populations 1,2,2,4,… are exactly 2^(popcount n).",
+    "mathContext": "$s_2(n) = \\sum (\\mathrm{digits}_2\\,n), \\qquad \\mathrm{oddCount}(n) = \\#\\{k \\le n : \\binom{n}{k}\\ \\text{odd}\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["binary digit sum", "popcount", "Sierpiński triangle", "Pascal's triangle mod 2"],
+    "prerequisites": ["binary expansions", "Finset cardinality", "binomial coefficients"]
+  },
+  {
+    "id": "lucas-oq01-ann-lucas",
+    "proofId": "lucas-theorem-oq-01",
+    "range": { "startLine": 49, "endLine": 63 },
+    "type": "theorem",
+    "title": "Lucas' Theorem and Its Base-2 Step",
+    "content": "`lucas_theorem` re-exports Mathlib's `Choose.lucas_theorem_nat`: for a prime p, C(n,k) ≡ ∏ᵢ C(nᵢ,kᵢ) (mod p) over the base-p digits. `lucas_mod_two` specializes the single recursive step to p = 2, namely C(n,k) ≡ C(n%2, k%2)·C(n/2, k/2) (mod 2), by registering the `Fact (Nat.Prime 2)` instance and invoking `choose_modEq_choose_mod_mul_choose_div_nat`. This one congruence is the entire engine for the pointwise parity laws below.",
+    "mathContext": "$\\binom{n}{k} \\equiv \\binom{n\\%2}{k\\%2}\\binom{n/2}{k/2} \\pmod 2.$",
+    "significance": "key",
+    "relatedConcepts": ["Lucas' theorem", "modular arithmetic", "base-p digits", "prime modulus"],
+    "prerequisites": ["modular congruences", "Mathlib Nat.Choose.Lucas"]
+  },
+  {
+    "id": "lucas-oq01-ann-pointwise",
+    "proofId": "lucas-theorem-oq-01",
+    "range": { "startLine": 64, "endLine": 92 },
+    "type": "theorem",
+    "title": "Pointwise Parity Laws",
+    "content": "Two laws read off the top binary digit. `odd_choose_two_mul`: C(2n,k) is odd iff k is even AND C(n,k/2) is odd — the top digit of 2n is 0, and C(0,1)=0 kills every odd-k case, creating the Sierpiński 'holes'. `odd_choose_two_mul_add_one`: C(2n+1,k) is odd iff C(n,k/2) is odd, for every k — the top digit of 2n+1 is 1 and C(1,0)=C(1,1)=1 imposes no constraint on k. Each is proved from `lucas_mod_two` by rewriting n%2, n/2 and casing on k%2 to evaluate the top-digit factor via `Nat.odd_iff`.",
+    "mathContext": "$\\binom{2n}{k}\\ \\text{odd} \\iff k\\ \\text{even} \\land \\binom{n}{k/2}\\ \\text{odd}; \\qquad \\binom{2n+1}{k}\\ \\text{odd} \\iff \\binom{n}{k/2}\\ \\text{odd}.$",
+    "significance": "critical",
+    "relatedConcepts": ["parity of binomial coefficients", "top binary digit", "Sierpiński holes", "case analysis"],
+    "prerequisites": ["lucas_mod_two", "Nat.odd_iff", "binomial coefficient base cases"]
+  },
+  {
+    "id": "lucas-oq01-ann-doubling",
+    "proofId": "lucas-theorem-oq-01",
+    "range": { "startLine": 94, "endLine": 154 },
+    "type": "theorem",
+    "title": "The Doubling Recursion",
+    "content": "The pointwise laws lift to a recursion on the row index without any explicit bit bookkeeping. `oddCount_two_mul`: every odd entry of row 2n sits in an even column, so oddRow(2n) is the image of oddRow n under j ↦ 2j and (injectivity ⇒) oddCount(2n) = oddCount n. `oddCount_two_mul_add_one`: oddRow(2n+1) is the disjoint union of its even part (image of j ↦ 2j) and odd part (image of j ↦ 2j+1), each a faithful copy of oddRow n, so the count doubles. The arguments stay entirely inside `Finset.card` algebra (`card_image_of_injective`, `card_union_of_disjoint`).",
+    "mathContext": "$\\mathrm{oddCount}(2n) = \\mathrm{oddCount}(n), \\qquad \\mathrm{oddCount}(2n+1) = 2\\,\\mathrm{oddCount}(n).$",
+    "significance": "critical",
+    "relatedConcepts": ["bijective reindexing", "disjoint union", "Finset cardinality", "recursion"],
+    "prerequisites": ["the pointwise parity laws", "injective image cardinality"]
+  },
+  {
+    "id": "lucas-oq01-ann-digitsum",
+    "proofId": "lucas-theorem-oq-01",
+    "range": { "startLine": 156, "endLine": 164 },
+    "type": "lemma",
+    "title": "The Matching Digit-Sum Recursion",
+    "content": "`s2_zero` and `s2_pos` give the binary-digit-sum recursion s₂ n = n%2 + s₂(n/2) for n > 0, obtained by unfolding `Nat.digits_def'` (digits 2 n = n%2 :: digits 2 (n/2)) and summing. This is the exact arithmetic shadow of the oddCount doubling recursion: s₂(2n) = s₂(n) matches oddCount(2n) = oddCount(n), and s₂(2n+1) = s₂(n)+1 matches the doubling.",
+    "mathContext": "$s_2(n) = n\\%2 + s_2(n/2) \\quad (n > 0); \\qquad s_2(2n) = s_2(n),\\ s_2(2n+1) = s_2(n)+1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["digit sum recursion", "Nat.digits", "binary expansion"],
+    "prerequisites": ["Nat.digits_def'", "list sum"]
+  },
+  {
+    "id": "lucas-oq01-ann-closed-form",
+    "proofId": "lucas-theorem-oq-01",
+    "range": { "startLine": 165, "endLine": 206 },
+    "type": "theorem",
+    "title": "Glaisher's Closed Form",
+    "content": "`oddCount_eq_two_pow_s2` proves oddCount n = 2^(s₂ n) by strong induction on n: the base case n = 0 is `decide`, and for n > 0 the proof cases on n % 2, in each branch chaining the matching oddCount and s₂ recursions (the even branch keeps the exponent, the odd branch adds one via `pow_succ`). The corollary `oddCount_isPowerOfTwo` records the qualitative Sierpiński fact (every row has a power-of-two odd count), and three concrete checks (rows 5, 4, 7) are verified by kernel `decide` — no `native_decide`, so the file stays free of `Lean.ofReduceBool`.",
+    "mathContext": "$\\mathrm{oddCount}(n) = 2^{s_2(n)}; \\qquad \\text{row } 5 = 101_2,\\ s_2 = 2,\\ \\mathrm{oddCount} = 4.$",
+    "significance": "critical",
+    "relatedConcepts": ["strong induction", "Glaisher's theorem", "closed form", "Sierpiński triangle dimension"],
+    "prerequisites": ["the two matching recursions", "strong induction", "pow_succ"]
+  }
+]

--- a/src/data/proofs/lucas-theorem-oq-01/index.ts
+++ b/src/data/proofs/lucas-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LucasTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lucasTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lucasTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lucasTheoremOQ01Data: ProofData = {
+  proof: lucasTheoremOQ01Proof,
+  annotations: lucasTheoremOQ01Annotations,
+}

--- a/src/data/proofs/lucas-theorem-oq-01/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01/meta.json
@@ -104,12 +104,58 @@
   ],
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01-oq-02",
-      "reason": "Uses the same binary-digit-sum s₂ and its doubling-invariance s₂(2n)=s₂(n); there for the 2-adic valuation of Catalan numbers, here for the odd-entry count."
+      "targetId": "catalan-numbers-oq-01-oq-02",
+      "relationship": "related",
+      "description": "Uses the same binary-digit-sum s₂ and its doubling-invariance s₂(2n)=s₂(n); there for the 2-adic valuation of Catalan numbers, here for the odd-entry count."
     },
     {
-      "id": "catalan-numbers-oq-01-oq-02-oq-01",
-      "reason": "Generalises the same Lucas/Kummer arithmetic of binomial coefficients to an arbitrary prime via Legendre's formula; this entry is the parity (p = 2) face of that family."
+      "targetId": "catalan-numbers-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Generalises the same Lucas/Kummer arithmetic of binomial coefficients to an arbitrary prime via Legendre's formula; this entry is the parity (p = 2) face of that family."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview and Definitions",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring framing Lucas mod 2 and Glaisher's count, then the three definitions: s2 (binary digit sum (digits 2 n).sum), oddRow (the columns k ≤ n with C(n,k) odd), and oddCount (its cardinality)."
+    },
+    {
+      "id": "sec-lucas",
+      "title": "Lucas' Theorem (Mathlib Re-export)",
+      "startLine": 49,
+      "endLine": 63,
+      "summary": "lucas_theorem re-exports Mathlib's digit-product congruence verbatim; lucas_mod_two specializes the single recursive step to p = 2 (supplying the Fact (Nat.Prime 2) instance), the engine for everything below."
+    },
+    {
+      "id": "sec-pointwise",
+      "title": "Pointwise Parity via Lucas mod 2",
+      "startLine": 64,
+      "endLine": 92,
+      "summary": "odd_choose_two_mul (C(2n,k) odd ⟺ k even ∧ C(n,k/2) odd — top digit 0, C(0,1)=0) and odd_choose_two_mul_add_one (C(2n+1,k) odd ⟺ C(n,k/2) odd — top digit 1, C(1,0)=C(1,1)=1), each by casing on k % 2 and evaluating the top-digit factor."
+    },
+    {
+      "id": "sec-doubling",
+      "title": "The Doubling Recursion for oddCount",
+      "startLine": 94,
+      "endLine": 154,
+      "summary": "oddCount_two_mul (oddRow(2n) = image (j↦2j) oddRow n, so card preserved) and oddCount_two_mul_add_one (oddRow(2n+1) splits as the disjoint union of even part j↦2j and odd part j↦2j+1, each a copy of oddRow n), via Finset.card_image_of_injective and card_union_of_disjoint."
+    },
+    {
+      "id": "sec-digitsum",
+      "title": "The Binary Digit Sum Recursion",
+      "startLine": 156,
+      "endLine": 164,
+      "summary": "s2_zero (s₂ 0 = 0) and s2_pos (s₂ n = n%2 + s₂(n/2) for n > 0, from Nat.digits_def') — the arithmetic recursion that the oddCount doubling recursion mirrors."
+    },
+    {
+      "id": "sec-closed-form",
+      "title": "Glaisher's Closed Form and Corollary",
+      "startLine": 165,
+      "endLine": 206,
+      "summary": "oddCount_eq_two_pow_s2 (oddCount n = 2^(s₂ n), strong induction casing on n % 2 and matching the two recursions), the corollary oddCount_isPowerOfTwo, and three concrete row checks (oddCount 5/4/7) by kernel decide."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `lucas-theorem-oq-01` (Glaisher's theorem: row n of Pascal's triangle has 2^(s₂ n) odd entries).

The meta.json was already rich (overview with key insights, conclusion with open questions, references) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site), had no annotations, and had **no** `sections` array; its `crossReferences` also used non-standard `id`/`reason` keys. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 6 annotations carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: definitions, Lucas re-export + `lucas_mod_two`, the two pointwise parity laws, the doubling recursion, the digit-sum recursion, and Glaisher's closed form.
- **`sections`** — added 6 sections spanning the full 206-line file.
- **`crossReferences`** — normalized from `{id, reason}` to the schema `{targetId, relationship, description}`.

Axiom integrity unchanged: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` — accurate; uses kernel `decide` (not `native_decide`) for the three concrete row checks, so no `Lean.ofReduceBool`.

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)