### PR TITLE
Enrich Mason-Stothers OQ-01: additive form and characteristic-zero degree bound

### DIFF
--- a/src/data/proofs/mason-stothers-theorem-oq-01/annotations.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "mason-oq01-ann-header",
+    "proofId": "mason-stothers-theorem-oq-01",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "Polynomial ABC and the Escape Clause",
+    "content": "Mason–Stothers is the function-field analogue of the abc conjecture: for a coprime relation a + b = c of polynomials, deg c is bounded by the number of distinct roots of a·b·c. Mathlib proves it as `Polynomial.abc` only in the homogeneous form a + b + c = 0, and with a derivative-vanishing escape clause that is genuinely necessary in positive characteristic — over 𝔽_p, Xᵖ + 1 = (X+1)ᵖ is coprime with huge degrees but a degree-1 radical, surviving only because every term is a p-th power with zero derivative. This file supplies the two repackagings Mathlib lacks: the textbook a + b = c form and the clean characteristic-zero bound. The setup fixes a field k with DecidableEq.",
+    "mathContext": "$a + b + c = 0,\\quad \\max\\{\\deg a, \\deg b, \\deg c\\} + 1 \\le \\deg(\\mathrm{rad}(abc)) \\ \\lor\\ a' = b' = c' = 0.$",
+    "significance": "key",
+    "relatedConcepts": ["abc conjecture", "radical of a polynomial", "Wronskian", "positive characteristic"],
+    "prerequisites": ["polynomials over a field", "formal derivative", "coprimality"]
+  },
+  {
+    "id": "mason-oq01-ann-add",
+    "proofId": "mason-stothers-theorem-oq-01",
+    "range": { "startLine": 46, "endLine": 75 },
+    "type": "theorem",
+    "title": "The Additive a + b = c Form",
+    "content": "`mason_stothers_add` restates Mason–Stothers in the inhomogeneous form in which it is almost always quoted. It applies `Polynomial.abc` to the triple (a, b, -c), which satisfies a + b + (-c) = 0, then translates the three quantities of -c back to c: the radical is unchanged because a·b·(-c) = -(a·b·c) and `radical_neg` makes radical unit-invariant; `natDegree_neg` handles the degree bound on -c; and `derivative_neg` with `neg_eq_zero` converts the escape clause derivative(-c) = 0 to derivative c = 0. The conclusion is the same dichotomy (degree bound OR all derivatives vanish).",
+    "mathContext": "$a + b = c \\implies \\big(\\deg + 1 \\le \\deg(\\mathrm{rad}(abc))\\ \\text{each}\\big)\\ \\lor\\ a' = b' = c' = 0.$",
+    "significance": "critical",
+    "relatedConcepts": ["homogeneous vs inhomogeneous form", "radical_neg", "unit invariance", "substitution"],
+    "prerequisites": ["Polynomial.abc", "radical / natDegree / derivative of a negation"]
+  },
+  {
+    "id": "mason-oq01-ann-charzero",
+    "proofId": "mason-stothers-theorem-oq-01",
+    "range": { "startLine": 77, "endLine": 99 },
+    "type": "theorem",
+    "title": "Eliminating the Escape Clause in Characteristic Zero",
+    "content": "`mason_stothers_charZero` shows the escape clause is vacuous over a CharZero field. It cases on `mason_stothers_add`: the degree-bound branch is the goal, while the escape branch (a' = b' = c' = 0) forces a.natDegree = b.natDegree = c.natDegree = 0 via `natDegree_eq_zero_of_derivative_eq_zero` (which holds because a CharZero field gives an additively torsion-free k[X]), contradicting the hypothesis that some factor is non-constant. The disjunction thus collapses to the unconditional degree bound — the form one actually wants.",
+    "mathContext": "$\\mathrm{char}\\,k = 0,\\ \\text{some factor non-constant} \\implies \\max\\{\\deg a, \\deg b, \\deg c\\} + 1 \\le \\deg(\\mathrm{rad}(abc)).$",
+    "significance": "critical",
+    "relatedConcepts": ["characteristic zero", "torsion-free ring", "derivative zero ⟺ constant", "case analysis"],
+    "prerequisites": ["mason_stothers_add", "natDegree_eq_zero_of_derivative_eq_zero", "CharZero"]
+  },
+  {
+    "id": "mason-oq01-ann-headline-rigidity",
+    "proofId": "mason-stothers-theorem-oq-01",
+    "range": { "startLine": 101, "endLine": 131 },
+    "type": "theorem",
+    "title": "Headline Inequality and Rigidity",
+    "content": "Two corollaries close the file. `natDegree_lt_radical_charZero`: for non-constant c, deg c < deg(rad(a·b·c)) — definitionally the c-component c.natDegree + 1 ≤ deg(rad) of the charZero bound (the polynomial shadow of the abc height inequality). `mason_stothers_rigidity` is the contrapositive: if the product has too few distinct roots (deg(rad(a·b·c)) ≤ deg c), then a, b, c must all be constant. Its proof cases on `mason_stothers_add` — the degree-bound branch yields the impossible c.natDegree + 1 ≤ deg(rad) ≤ c.natDegree (`omega`), so the escape branch holds and every factor is constant.",
+    "mathContext": "$\\deg c < \\deg(\\mathrm{rad}(abc)); \\qquad \\deg(\\mathrm{rad}(abc)) \\le \\deg c \\implies a, b, c\\ \\text{all constant}.$",
+    "significance": "key",
+    "relatedConcepts": ["abc inequality", "rigidity", "contrapositive", "distinct roots count"],
+    "prerequisites": ["mason_stothers_charZero", "mason_stothers_add", "omega"]
+  }
+]

--- a/src/data/proofs/mason-stothers-theorem-oq-01/index.ts
+++ b/src/data/proofs/mason-stothers-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MasonStothersOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const masonStothersOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const masonStothersOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const masonStothersOQ01Data: ProofData = {
+  proof: masonStothersOQ01Proof,
+  annotations: masonStothersOQ01Annotations,
+}

--- a/src/data/proofs/mason-stothers-theorem-oq-01/meta.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01/meta.json
@@ -110,6 +110,36 @@
     }
   ],
   "crossReferences": [],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Docstring contrasting Mathlib's homogeneous Polynomial.abc (with its char-p derivative-vanishing escape clause, illustrated by Xᵖ+1 = (X+1)ᵖ over 𝔽_p) with the two repackagings this file provides. Imports Mathlib, opens Polynomial / UFM / UFD, and fixes a field k with DecidableEq."
+    },
+    {
+      "id": "sec-add",
+      "title": "The Additive a + b = c Form",
+      "startLine": 46,
+      "endLine": 75,
+      "summary": "mason_stothers_add: the textbook inhomogeneous statement, derived by applying Polynomial.abc to the triple (a, b, -c) with a + b + (-c) = 0 and translating radical (radical_neg, since a·b·(-c) = -(a·b·c)), natDegree (natDegree_neg) and derivative (derivative_neg + neg_eq_zero) of -c back to c."
+    },
+    {
+      "id": "sec-charzero",
+      "title": "The Characteristic-Zero Bound",
+      "startLine": 77,
+      "endLine": 99,
+      "summary": "mason_stothers_charZero: over a CharZero field the escape clause is impossible for a non-constant factor (natDegree_eq_zero_of_derivative_eq_zero), so the disjunction collapses to the unconditional degree bound max{deg a, deg b, deg c} + 1 ≤ deg(rad(a·b·c)) given any non-constant factor."
+    },
+    {
+      "id": "sec-headline-rigidity",
+      "title": "Headline Inequality and Rigidity",
+      "startLine": 101,
+      "endLine": 131,
+      "summary": "natDegree_lt_radical_charZero (deg c < deg(rad(a·b·c)) for non-constant c, definitionally the c-component of the charZero bound) and mason_stothers_rigidity (the contrapositive: deg(rad(a·b·c)) ≤ deg c forces a, b, c all constant, via the impossible c.natDegree + 1 ≤ deg rad ≤ c.natDegree)."
+    }
+  ],
   "conclusion": {
     "summary": "Mathlib's polynomial ABC theorem Polynomial.abc (homogeneous form a + b + c = 0, with a derivative-vanishing escape clause) is repackaged into the classical inhomogeneous form a + b = c (mason_stothers_add) and sharpened over characteristic-zero fields, where the escape clause is eliminated: a non-constant coprime triple obeys the unconditional degree bound max{deg a, deg b, deg c} + 1 ≤ deg(rad(a·b·c)) (mason_stothers_charZero), with headline inequality deg c < deg(rad(a·b·c)) (natDegree_lt_radical_charZero) and rigidity corollary (mason_stothers_rigidity). All results are verified with 0 axioms and 0 sorries.",
     "implications": "Provides the textbook a + b = c statement of Mason–Stothers and a clean characteristic-zero degree bound — the polynomial analogue of the abc inequality — as reusable lemmas, complementing Mathlib's homogeneous formulation and its downstream polynomial Fermat theorem.",


### PR DESCRIPTION
Enrichment pass for `mason-stothers-theorem-oq-01` (the polynomial ABC theorem in `a + b = c` form, sharpened over characteristic-zero fields).

The meta.json was already rich (overview with key insights, conclusion with open questions, references) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site), had no annotations, and had **no** `sections` array. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 4 annotations carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the polynomial-ABC/escape-clause framing, the additive `a + b = c` form, the characteristic-zero collapse of the escape clause, and the headline inequality + rigidity corollaries.
- **`sections`** — added 4 sections spanning the full 131-line file.

Axiom integrity unchanged: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` — accurate (a 0-axiom derivation from Mathlib's `Polynomial.abc`; the `[CharZero k]` instance is a mathematical hypothesis, not an unproved assumption).

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)