### PR TITLE
Enrich Roots-of-Unity Multisection Filter (geometric-series-oq-09-oq-01-oq-01-oq-02): annotations, index.ts, overview, sections

### DIFF
--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,121 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 47 },
+    "type": "context",
+    "title": "The Roots-of-Unity Filter (Series Multisection)",
+    "content": "The classical **roots-of-unity filter** extracts a single residue subseries of a series as a discrete-Fourier average of *rotated* copies of the whole series. For a primitive $q$-th root of unity $\\omega$ and residue $a < q$,\n$$\\sum_n f(qn+a) = \\frac1q \\sum_{j<q} (\\omega^{ja})^{-1} \\sum_m \\omega^{jm} f(m).$$\nThe inner sum is the original series with its $m$-th term rotated by $\\omega^{jm}$; the outer DFT-weighted average over $j$ annihilates every residue class except $a$. This is the **analytic/Fourier** counterpart to the sibling `…-oq-01`, which realises the same multisection **combinatorially** as a Fubini regrouping. The two are complementary: the combinatorial version holds for any summable family in a complete abelian group, while this one genuinely needs the complex field (roots of unity) and **absolute** convergence — the bounded twist $\\omega^{jm}$ preserves absolute but not conditional summability.",
+    "mathContext": "$\\sum_n f(qn+a) = q^{-1}\\sum_{j<q}(\\omega^{ja})^{-1}\\sum_m \\omega^{jm}f(m)$, $\\omega$ a primitive $q$-th root of unity.",
+    "significance": "context",
+    "relatedConcepts": [
+      "roots-of-unity filter",
+      "multisection of series",
+      "discrete Fourier transform",
+      "absolute convergence"
+    ],
+    "prerequisites": [
+      "infinite series and summability",
+      "roots of unity",
+      "residues modulo q"
+    ]
+  },
+  {
+    "id": "ann-reindexing",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 75 },
+    "type": "definition",
+    "title": "Residue-Class Reindexing Infrastructure",
+    "content": "Three small lemmas characterise the residue class $a$ modulo $q$ as exactly the image of $n \\mapsto qn+a$. `residue_injective` shows that map is injective (for $q \\ne 0$, by cancelling $q$); `residue_self_modEq` shows $qn+a \\equiv a \\pmod q$; and `residue_mem_range` shows that for $a < q$ every $m \\equiv a \\pmod q$ equals $q(m/q)+a$ (via `Nat.div_add_mod`). Together they let the final step transport the indicator-weighted series $\\sum_m [\\,m\\equiv a\\,] f(m)$ onto the subseries $\\sum_n f(qn+a)$.",
+    "mathContext": "$\\{m : m \\equiv a \\pmod q\\} = \\{qn+a : n \\in \\mathbb{N}\\}$ for $a < q$, with $n \\mapsto qn+a$ injective.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "residue classes",
+      "injective reindexing",
+      "modular arithmetic"
+    ],
+    "prerequisites": [
+      "natural-number division and modulo",
+      "Nat.ModEq"
+    ]
+  },
+  {
+    "id": "ann-orthogonality",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+    "range": { "startLine": 105, "endLine": 141 },
+    "type": "insight",
+    "title": "The Orthogonality Collapse",
+    "content": "The heart of the filter: the DFT-weighted average of the rotation coefficients is the **indicator** of the residue class,\n$$\\tfrac1q\\sum_{j<q}(\\omega^{ja})^{-1}\\omega^{jm} = [\\,m \\equiv a \\pmod q\\,].$$\nEach $j$-th term is $z^j$ with $z = (\\omega^a)^{-1}\\omega^m$, and $z^q = 1$ because $\\omega^q = 1$. So the $q$-fold geometric sum collapses: when $z = 1$ it is $q$ (giving $q^{-1}\\cdot q = 1$); when $z \\ne 1$, `geom_sum_eq` gives $(z^q-1)/(z-1) = 0$. The dichotomy $z = 1 \\iff \\omega^m = \\omega^a \\iff m \\equiv a \\pmod q$ uses `IsOfFinOrder.pow_eq_pow_iff_modEq` with $\\mathrm{orderOf}\\,\\omega = q$ — this is exactly where primitivity of $\\omega$ enters.",
+    "mathContext": "$z = (\\omega^a)^{-1}\\omega^m$, $z^q = 1$; $\\sum_{j<q} z^j = q\\,[z=1]$, and $z=1 \\iff m \\equiv a \\pmod q$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "orthogonality of characters",
+      "finite geometric sum",
+      "geom_sum_eq",
+      "order of a root of unity"
+    ],
+    "prerequisites": [
+      "finite geometric series",
+      "primitive roots of unity",
+      "order of a group element"
+    ]
+  },
+  {
+    "id": "ann-interchange",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+    "range": { "startLine": 142, "endLine": 180 },
+    "type": "technique",
+    "title": "Absolutely-Convergent Interchange and Reindexing",
+    "content": "With the orthogonality in hand, the right-hand side is rewritten as $\\sum_m [\\,m\\equiv a\\,]\\,f(m)$. This requires commuting the finite DFT sum over $j$ with the infinite sum over $m$ (`Summable.tsum_finsetSum`) — the **one place absolute convergence is essential**: each twisted series $m \\mapsto \\omega^{jm}f(m)$ is summable because $\\lVert \\omega^{jm}f(m)\\rVert = \\lVert f(m)\\rVert$ (as $\\lVert\\omega\\rVert = 1$ from `norm_eq_one_of_pow_eq_one`). After folding the indicator in, the surviving series $\\sum_m [\\,m\\equiv a\\,]f(m)$ is reindexed onto $\\sum_n f(qn+a)$ via `Function.Injective.hasSum_iff`: off the range of $n\\mapsto qn+a$ the indicator kills every term, and on the range `residue_self_modEq` makes the indicator $1$.",
+    "mathContext": "$q^{-1}\\sum_{j<q}(\\omega^{ja})^{-1}\\sum_m\\omega^{jm}f(m) = \\sum_m [\\,m\\equiv a\\,]f(m) = \\sum_n f(qn+a)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "interchange of summation",
+      "Summable.tsum_finsetSum",
+      "bounded multiplier",
+      "Function.Injective.hasSum_iff"
+    ],
+    "prerequisites": [
+      "absolute convergence",
+      "Fubini for tsum",
+      "reindexing infinite sums"
+    ]
+  },
+  {
+    "id": "ann-exp-specialization",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+    "range": { "startLine": 182, "endLine": 189 },
+    "type": "concept",
+    "title": "The Canonical Root exp(2πi/q)",
+    "content": "`multisection_filter_exp` specialises the abstract theorem to the canonical primitive root $\\omega = e^{2\\pi i/q}$, supplied by Mathlib's `Complex.isPrimitiveRoot_exp`. This is the form in which the filter is usually written in analysis — the DFT kernel made concrete — and a direct instantiation of the master identity with no extra work.",
+    "mathContext": "$\\omega = e^{2\\pi i/q}$: $\\sum_n f(qn+a) = q^{-1}\\sum_{j<q} e^{-2\\pi i ja/q}\\sum_m e^{2\\pi i jm/q} f(m)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Complex.isPrimitiveRoot_exp",
+      "DFT kernel",
+      "complex exponential"
+    ],
+    "prerequisites": [
+      "the complex exponential",
+      "the master filter above"
+    ]
+  },
+  {
+    "id": "ann-even-filter",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-02",
+    "range": { "startLine": 191, "endLine": 203 },
+    "type": "concept",
+    "title": "The q = 2 Even-Part Filter",
+    "content": "The simplest concrete instance: with $\\omega = -1$ (the primitive square root of unity) and $a = 0$, the filter says the even subseries is the half-sum of the series and its alternating twin,\n$$\\sum_n f(2n) = \\tfrac12\\Big(\\sum_m f(m) + \\sum_m (-1)^m f(m)\\Big).$$\nThis recovers the familiar even/odd decomposition of a series and serves as a sanity check on the master identity — the $j=0$ term contributes $\\sum_m f(m)$ and the $j=1$ term the alternating sum.",
+    "mathContext": "$\\sum_n f(2n) = \\tfrac12\\big(\\sum_m f(m) + \\sum_m (-1)^m f(m)\\big)$ via $\\omega = -1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "even/odd decomposition",
+      "alternating series",
+      "primitive square root of unity"
+    ],
+    "prerequisites": [
+      "the master filter above"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ09OQ01OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ09OQ01OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ09OQ01OQ01OQ02Data: ProofData = {
+  proof: geometricSeriesOQ09OQ01OQ01OQ02Proof,
+  annotations: geometricSeriesOQ09OQ01OQ01OQ02Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-02/meta.json
@@ -3,6 +3,17 @@
   "slug": "geometric-series-oq-09-oq-01-oq-01-oq-02",
   "title": "The Roots-of-Unity Multisection Filter for an Absolutely Convergent Series",
   "description": "Extracts a single residue subseries of an absolutely convergent complex series as a discrete-Fourier average of rotated full sums: for a primitive q-th root of unity ω (canonically exp(2πi/q)), Summable (‖f ·‖), and residue a < q, ∑_n f(q·n+a) = q⁻¹ · ∑_{j<q} (ω^{j·a})⁻¹ · ∑_m ω^{j·m}·f(m). This is the classical roots-of-unity filter (series multisection): the inner sum is the original series with its m-th term rotated by ω^{j·m}, and the outer DFT-weighted average over j annihilates every residue class except a. The proof rests on the orthogonality collapse q⁻¹·∑_{j<q} ((ω^a)⁻¹ω^m)^j = ⟦m ≡ a (mod q)⟧ — a q-fold geometric sum that vanishes off the residue class because z := (ω^a)⁻¹ω^m satisfies z^q = 1 (geom_sum_eq) — combined with the absolutely-convergent interchange of the finite DFT sum with the infinite series (each twist ω^{j·m}·f(m) is absolutely summable since ‖ω^{j·m}‖ = 1) and the reindexing of the surviving indicator-weighted series onto the residue subseries. This is the analytic/Fourier counterpart to the sibling geometric-series-oq-09-oq-01-oq-01-oq-01, which realises the same multisection combinatorially as a Fubini regrouping; this version genuinely requires the complex field (roots of unity) and absolute convergence.",
+  "overview": {
+    "historicalContext": "The roots-of-unity filter (series multisection) is a classical tool of generating-function combinatorics, treated as a staple in Graham–Knuth–Patashnik's Concrete Mathematics: to extract the terms of a power series whose index lies in a fixed residue class mod q, average the series against the q-th roots of unity. It is the discrete-Fourier analogue of extracting a Fourier coefficient by integrating against a character, and underlies countless evaluations of partial sums of binomial coefficients (∑_k C(n, qk+a)) and lacunary series. The mechanism is the orthogonality of the additive characters of ℤ/qℤ — the same orthogonality that powers the discrete Fourier transform. This entry isolates the analytic core of the filter for an arbitrary absolutely convergent complex series.",
+    "problemStatement": "The parent's open question asks how to express the residue subseries ∑_n f(q·n+a) of a series ∑_m f(m) in terms of the whole series. Can a single residue class be projected out of an arbitrary absolutely convergent complex series as a discrete-Fourier average of rotated copies of the entire series, and what convergence hypothesis does that genuinely require?\n\n**Answer:** Yes. For a primitive q-th root of unity ω and a < q, ∑_n f(q·n+a) = q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·∑_m ω^{j·m}·f(m). It needs the complex field (roots of unity) and absolute convergence — the bounded twist ω^{j·m} preserves absolute but not conditional summability.",
+    "proofStrategy": "(1) Reindexing infrastructure: residue_injective / residue_self_modEq / residue_mem_range identify the residue class a mod q with the image of n ↦ q·n+a (for a < q). (2) Orthogonality (inline hEm): rewrite the j-th DFT coefficient as zʲ with z = (ω^a)⁻¹ω^m; since z^q = 1, the q-fold geometric sum collapses — q when z = 1 and 0 otherwise (geom_sum_eq) — and z = 1 ⇔ m ≡ a (mod q) via IsOfFinOrder.pow_eq_pow_iff_modEq with orderOf ω = q. (3) Interchange: each twisted series ω^{j·m}·f(m) is absolutely summable (‖ω‖ = 1), so the finite DFT sum commutes with the infinite series (Summable.tsum_finsetSum), reducing the RHS to ∑_m ⟦m ≡ a⟧·f(m). (4) Reindex that indicator-weighted series onto ∑_n f(q·n+a) via Function.Injective.hasSum_iff. Specialise to ω = exp(2πi/q) and to q = 2 (ω = -1).",
+    "keyInsights": [
+      "The filter is character orthogonality in disguise: q⁻¹·∑_{j<q} ((ω^a)⁻¹ω^m)^j is the indicator ⟦m ≡ a (mod q)⟧ because the q-fold geometric sum of a q-th root of unity z is q when z = 1 and 0 otherwise — exactly the orthogonality relations of the additive characters of ℤ/qℤ.",
+      "Primitivity of ω is what makes the dichotomy sharp: z = (ω^a)⁻¹ω^m equals 1 iff ω^m = ω^a iff m ≡ a (mod q), which needs orderOf ω = q (IsPrimitiveRoot.eq_orderOf). A non-primitive root would collapse extra residue classes together.",
+      "Absolute convergence enters exactly once — to commute the finite DFT sum with the infinite series. The twist ω^{j·m} is a bounded multiplier (‖ω^{j·m}‖ = 1), so it preserves absolute but not conditional summability; this is precisely why the analytic filter needs more than the sibling's combinatorial Fubini, which works for any summable family.",
+      "Specialised to f(m) = r^m the identity reproduces the grandparent's geometric closed form ∑_n r^{q·n+a} = r^a/(1−r^q): the roots-of-unity filter is the residue-selecting projection of which the geometric multisection is one instance, and the q = 2 case is the familiar even/odd decomposition ∑_n f(2n) = ½(∑_m f(m) + ∑_m (−1)^m f(m))."
+    ]
+  },
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -106,6 +117,48 @@
       "targetId": "geometric-series-oq-09-oq-01",
       "relationship": "extends",
       "description": "Grandparent. The grandparent computed the geometric multisection ∑_n r^(q·n+a) = r^a/(1−r^q) from closed forms. The roots-of-unity filter here is the residue-selecting projection that, specialised to f(m) = r^m, reproduces that closed form — but applies to any absolutely convergent series, not only the geometric one."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module header and context",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "States the roots-of-unity filter ∑_n f(q·n+a) = q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·∑_m ω^{j·m}·f(m) for an absolutely convergent complex series, contrasts it with the sibling's combinatorial Fubini multisection (the analytic vs combinatorial facets), and explains the new content beyond Mathlib (the orthogonality assembly).",
+      "mathContext": "$\\sum_n f(qn+a) = q^{-1}\\sum_{j<q}(\\omega^{ja})^{-1}\\sum_m\\omega^{jm}f(m)$."
+    },
+    {
+      "id": "reindexing",
+      "title": "Residue-class reindexing lemmas",
+      "startLine": 49,
+      "endLine": 75,
+      "summary": "Opens the namespace and Complex/Finset; residue_injective (n ↦ q·n+a injective for q ≠ 0), residue_self_modEq (q·n+a ≡ a mod q), and residue_mem_range (for a < q the class a is exactly {q·n+a}) — the infrastructure for the final reindexing.",
+      "mathContext": "$\\{m \\equiv a \\pmod q\\} = \\{qn+a\\}$ for $a < q$."
+    },
+    {
+      "id": "orthogonality",
+      "title": "The orthogonality collapse (inside multisection_filter)",
+      "startLine": 77,
+      "endLine": 141,
+      "summary": "The main theorem multisection_filter begins by recording ‖ω‖ = 1, the finite order and orderOf ω = q, summability of each twisted series, and the orthogonality lemma hEm: q⁻¹·∑_{j<q} (ω^{ja})⁻¹ω^{jm} = ⟦m ≡ a⟧, via z = (ω^a)⁻¹ω^m with z^q = 1, geom_sum_eq, and pow_eq_pow_iff_modEq.",
+      "mathContext": "$q^{-1}\\sum_{j<q} z^j = [\\,m\\equiv a\\,]$, $z=(\\omega^a)^{-1}\\omega^m$, $z^q=1$."
+    },
+    {
+      "id": "interchange-reindex",
+      "title": "Interchange and reindexing onto the subseries",
+      "startLine": 142,
+      "endLine": 180,
+      "summary": "Rewrites the RHS as ∑_m ⟦m ≡ a⟧·f(m) by commuting the finite DFT sum with the infinite series (Summable.tsum_finsetSum, licensed by absolute convergence), then reindexes that indicator-weighted series onto ∑_n f(q·n+a) via Function.Injective.hasSum_iff, completing the proof.",
+      "mathContext": "RHS $= \\sum_m [\\,m\\equiv a\\,]f(m) = \\sum_n f(qn+a)$."
+    },
+    {
+      "id": "specializations",
+      "title": "Canonical root and the q = 2 even filter",
+      "startLine": 182,
+      "endLine": 205,
+      "summary": "multisection_filter_exp specialises to ω = exp(2πi/q) (Complex.isPrimitiveRoot_exp); tsum_even_filter is the q = 2 even-part filter ∑_n f(2n) = ½(∑_m f(m) + ∑_m (−1)^m f(m)) via ω = −1.",
+      "mathContext": "$\\sum_n f(2n) = \\tfrac12(\\sum_m f(m) + \\sum_m (-1)^m f(m))$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-09-oq-01-oq-01-oq-02` (quality score was 15) — the roots-of-unity filter ∑_n f(q·n+a) = q⁻¹·∑_{j<q} (ω^{j·a})⁻¹·∑_m ω^{j·m}·f(m).

The entry shipped with only `meta.json` and no `overview` block. This pass fills every gap:

**New `annotations.json`** — 6 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`): the filter framing vs the combinatorial sibling, the residue-reindexing lemmas, the orthogonality collapse (q-fold geometric sum → indicator via geom_sum_eq + pow_eq_pow_iff_modEq), the absolutely-convergent interchange + reindexing (Summable.tsum_finsetSum, Function.Injective.hasSum_iff), the exp(2πi/q) specialization, and the q=2 even-part filter.

**New `index.ts`** — was missing, so the page would show "proof not found" on the live site. Follows the sibling template (`geometricSeriesOQ09OQ01OQ01OQ02`).

**`meta.json`**:
- added the entire `overview` block (historicalContext on the Concrete-Mathematics filter, problemStatement, proofStrategy, 4 keyInsights) — the entry previously had no overview at all
- added a 5-entry `sections` array covering the whole file (lines 3–205; there were none). All existing content (description, conclusion, crossReferences, references, openQuestions) preserved.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`/badge `original`, 0 axioms, 0 sorries, no native_decide).