### PR TITLE
research(cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01): the holomorph — normalizer of L(G) is L(G)·Aut(G) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ02OQ01.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ02OQ01.lean
@@ -1,0 +1,178 @@
+/-
+Proof: The holomorph decomposition of the normalizer of the left-regular
+representation: `N_{Sym(G)}(L(G)) = L(G) · Aut(G)`, with the automorphisms
+recovered exactly as the normalizing permutations that fix the identity.
+
+Research: cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01
+
+Open question (self-generated follow-up to `cayleys-theorem-oq-01-oq-01-oq-02-oq-02`):
+  The parent file identifies the *centralizer* of the left-regular image `L(G)`
+  inside `Equiv.Perm G` as the right-regular image `R(G)`, and remarks that this
+  is "the structural fact underlying the holomorph of `G`".  The natural next
+  structural object is the **normalizer** of `L(G)`: the holomorph
+  `Hol(G) = N_{Sym(G)}(L(G))`.  Classical theory says `Hol(G) = L(G) ⋊ Aut(G)`,
+  so that `N_{Sym(G)}(L(G)) / L(G) ≅ Aut(G)`.  This file proves the underlying
+  set/subgroup identities over an *arbitrary* group `G` (no finiteness):
+
+  * every automorphism normalizes `L(G)` and fixes `1`;
+  * conversely a permutation that normalizes `L(G)` *and fixes `1`* is exactly an
+    automorphism — so `Aut(G)` is realised precisely as the stabiliser of `1`
+    inside the normalizer;
+  * the full normalizer decomposes as `L(G) · Aut(G)`: every normalizing
+    permutation is a left translation followed by (the permutation of) an
+    automorphism.
+
+The key computation is that an automorphism `φ` *intertwines* the left-regular
+representation: `φ ∘ L_g = L_{φ g} ∘ φ`, i.e. `autPerm φ * leftReg g =
+leftReg (φ g) * autPerm φ`.  Conjugating, `autPerm φ * leftReg g *
+(autPerm φ)⁻¹ = leftReg (φ g)`, which shows `Aut(G)` permutes the generators of
+`L(G)` and hence normalizes it.  The converse runs the classical "evaluate at
+`1`" argument: a normalizing `σ` fixing `1` satisfies `σ (a*b) = σ a * σ b`,
+so it *is* an automorphism.
+
+Main results:
+
+* `autPermHom`            : `MulAut G →* Equiv.Perm G`, the realisation of an
+                            automorphism as a permutation of the underlying set,
+                            with `autPermHom_injective` (the embedding `Aut(G) ↪
+                            Sym(G)` of the holomorph).
+* `autPerm_mem_normalizer`: every automorphism normalizes `L(G)`.
+* `mem_normalizer_and_fixes_one_iff`:
+    `σ ∈ N(L(G)) ∧ σ 1 = 1 ↔ ∃ φ : Aut(G), autPerm φ = σ`.
+  Aut(G) is exactly the normalizer's stabiliser of the identity.
+* `mem_normalizer_iff_exists`:
+    `σ ∈ N(L(G)) ↔ ∃ (g : G) (φ : Aut(G)), σ = leftReg g * autPerm φ`.
+  The holomorph decomposition `N(L(G)) = L(G) · Aut(G)`.
+-/
+
+import Mathlib
+
+namespace Holomorph
+
+variable {G : Type*} [Group G]
+
+/-- The **left-regular representation** `g ↦ (x ↦ g * x)` as a group homomorphism
+into the symmetric group on `G` (same construction as the parent file). -/
+def leftReg (G : Type*) [Group G] : G →* Equiv.Perm G where
+  toFun := Equiv.mulLeft
+  map_one' := Equiv.mulLeft_one
+  map_mul' := Equiv.mulLeft_mul
+
+@[simp] theorem leftReg_apply (g x : G) : leftReg G g x = g * x := rfl
+
+/-- The left-regular representation is faithful (Cayley's theorem). -/
+theorem leftReg_injective : Function.Injective (leftReg G) := by
+  intro a b hab
+  have h := DFunLike.congr_fun hab 1
+  rwa [leftReg_apply, leftReg_apply, mul_one, mul_one] at h
+
+/-- The permutation of the underlying set `G` induced by an automorphism `φ`. -/
+def autPerm (φ : MulAut G) : Equiv.Perm G := φ.toEquiv
+
+@[simp] theorem autPerm_apply (φ : MulAut G) (x : G) : autPerm φ x = φ x := rfl
+
+@[simp] theorem autPerm_symm_apply (φ : MulAut G) (x : G) :
+    (autPerm φ)⁻¹ x = φ.symm x := rfl
+
+/-- Realising an automorphism as a permutation is a group homomorphism
+`MulAut G →* Equiv.Perm G`. -/
+def autPermHom (G : Type*) [Group G] : MulAut G →* Equiv.Perm G where
+  toFun := autPerm
+  map_one' := by ext x; simp [autPerm_apply, MulAut.one_apply]
+  map_mul' φ ψ := by ext x; simp [autPerm_apply, MulAut.mul_apply, Equiv.Perm.mul_apply]
+
+@[simp] theorem autPermHom_apply (φ : MulAut G) : autPermHom G φ = autPerm φ := rfl
+
+/-- The holomorph embedding `Aut(G) ↪ Sym(G)` is injective. -/
+theorem autPermHom_injective : Function.Injective (autPermHom G) := by
+  intro φ ψ h
+  ext x
+  have := DFunLike.congr_fun h x
+  simpa [autPerm_apply] using this
+
+/-- **Equivariance.**  An automorphism intertwines the left-regular
+representation: `φ ∘ L_g = L_{φ g} ∘ φ`. -/
+theorem autPerm_mul_leftReg (φ : MulAut G) (g : G) :
+    autPerm φ * leftReg G g = leftReg G (φ g) * autPerm φ := by
+  ext y
+  simp [Equiv.Perm.mul_apply, leftReg_apply, autPerm_apply, map_mul]
+
+/-- **Conjugation of generators.**  Conjugating a left translation by an
+automorphism gives another left translation: `φ L_g φ⁻¹ = L_{φ g}`. -/
+theorem autPerm_conj_leftReg (φ : MulAut G) (g : G) :
+    autPerm φ * leftReg G g * (autPerm φ)⁻¹ = leftReg G (φ g) := by
+  rw [autPerm_mul_leftReg, mul_assoc, mul_inv_cancel, mul_one]
+
+/-- Every automorphism normalizes the left-regular image `L(G)`. -/
+theorem autPerm_mem_normalizer (φ : MulAut G) :
+    autPerm φ ∈ (leftReg G).range.normalizer := by
+  rw [Subgroup.mem_normalizer_iff]
+  intro h
+  constructor
+  · rintro ⟨a, rfl⟩
+    exact ⟨φ a, by rw [autPerm_conj_leftReg]⟩
+  · intro hmem
+    obtain ⟨b, hb⟩ := hmem
+    refine ⟨φ.symm b, ?_⟩
+    have key : (autPerm φ)⁻¹ * leftReg G b * autPerm φ = h := by rw [hb]; group
+    rw [← key]
+    ext y
+    simp [Equiv.Perm.mul_apply, leftReg_apply, autPerm_apply, autPerm_symm_apply,
+      map_mul, MulEquiv.symm_apply_apply]
+
+/-- An automorphism fixes the identity. -/
+@[simp] theorem autPerm_one_eq (φ : MulAut G) : autPerm φ 1 = 1 := by
+  simp [autPerm_apply]
+
+/-- **Aut(G) as the stabiliser of `1` in the normalizer.**  A permutation of `G`
+normalizes the left-regular image and fixes the identity **iff** it is the
+permutation underlying an automorphism of `G`. -/
+theorem mem_normalizer_and_fixes_one_iff (σ : Equiv.Perm G) :
+    (σ ∈ (leftReg G).range.normalizer ∧ σ 1 = 1) ↔ ∃ φ : MulAut G, autPerm φ = σ := by
+  constructor
+  · rintro ⟨hN, h1⟩
+    rw [Subgroup.mem_normalizer_iff] at hN
+    -- The classical "evaluate at `1`" argument: `σ` is multiplicative.  From
+    -- `σ L_a σ⁻¹ = L_c` we pass to the inverse-free form `L_c σ = σ L_a`, read
+    -- off `c = σ a` at `1`, and read off `σ (a*b) = σ a * σ b` at `b`.
+    have hmul : ∀ a b : G, σ (a * b) = σ a * σ b := by
+      intro a b
+      have hmemr : σ * leftReg G a * σ⁻¹ ∈ (leftReg G).range :=
+        (hN (leftReg G a)).mp ⟨a, rfl⟩
+      obtain ⟨c, hc⟩ := hmemr
+      have hc' : leftReg G c * σ = σ * leftReg G a := by rw [hc]; group
+      have hc1 := DFunLike.congr_fun hc' 1
+      simp only [Equiv.Perm.mul_apply, leftReg_apply, h1, mul_one] at hc1
+      have hcb := DFunLike.congr_fun hc' b
+      simp only [Equiv.Perm.mul_apply, leftReg_apply] at hcb
+      rw [hc1] at hcb
+      exact hcb.symm
+    -- Package `σ` as a monoid hom, then as an automorphism.
+    let f : G →* G := { toFun := σ, map_one' := h1, map_mul' := hmul }
+    refine ⟨MulEquiv.ofBijective f σ.bijective, ?_⟩
+    ext x
+    rfl
+  · rintro ⟨φ, rfl⟩
+    exact ⟨autPerm_mem_normalizer φ, autPerm_one_eq φ⟩
+
+/-- **The holomorph decomposition.**  A permutation normalizes the left-regular
+image **iff** it factors as a left translation composed with (the permutation of)
+an automorphism: `N_{Sym(G)}(L(G)) = L(G) · Aut(G)`. -/
+theorem mem_normalizer_iff_exists (σ : Equiv.Perm G) :
+    σ ∈ (leftReg G).range.normalizer ↔
+      ∃ (g : G) (φ : MulAut G), σ = leftReg G g * autPerm φ := by
+  constructor
+  · intro hN
+    have hgN : leftReg G (σ 1) ∈ (leftReg G).range.normalizer :=
+      Subgroup.le_normalizer ⟨σ 1, rfl⟩
+    have hτN : (leftReg G (σ 1))⁻¹ * σ ∈ (leftReg G).range.normalizer :=
+      Subgroup.mul_mem _ (Subgroup.inv_mem _ hgN) hN
+    have hτ1 : ((leftReg G (σ 1))⁻¹ * σ) 1 = 1 := by
+      rw [Equiv.Perm.mul_apply, ← map_inv, leftReg_apply, inv_mul_cancel]
+    obtain ⟨φ, hφ⟩ := (mem_normalizer_and_fixes_one_iff _).mp ⟨hτN, hτ1⟩
+    refine ⟨σ 1, φ, ?_⟩
+    rw [hφ, ← mul_assoc, mul_inv_cancel, one_mul]
+  · rintro ⟨g, φ, rfl⟩
+    exact Subgroup.mul_mem _ (Subgroup.le_normalizer ⟨g, rfl⟩) (autPerm_mem_normalizer φ)
+
+end Holomorph

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,112 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+  "slug": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+  "title": "The Holomorph: the Normalizer of the Left-Regular Image is L(G)·Aut(G)",
+  "description": "Over an arbitrary group G, the normalizer of the left-regular image L(G) inside the symmetric group Sym(G) — the holomorph of G — decomposes as L(G)·Aut(G): every normalizing permutation is a left translation followed by the permutation of an automorphism, and the automorphisms are recovered exactly as the normalizing permutations that fix the identity.",
+  "meta": {
+    "author": "Classical (holomorph of a group; Burnside, Miller); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Holomorph_(mathematics)",
+    "date": "1908",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "holomorph",
+      "permutation-group",
+      "regular-representation",
+      "normalizer",
+      "automorphism-group",
+      "symmetric-group",
+      "semidirect-product",
+      "group-homomorphism",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Subgroup.mem_normalizer_iff",
+        "description": "g ∈ H.normalizer ↔ ∀ h, h ∈ H ↔ g * h * g⁻¹ ∈ H — the working characterisation of the normalizer, used in both directions of the automorphism/normalizer correspondence",
+        "module": "Mathlib.Algebra.Group.Subgroup.Defs"
+      },
+      {
+        "theorem": "Subgroup.le_normalizer",
+        "description": "H ≤ H.normalizer — places left translations inside the normalizer, the L(G) factor of the holomorph decomposition",
+        "module": "Mathlib.GroupTheory.Subgroup.Basic"
+      },
+      {
+        "theorem": "MulEquiv.ofBijective",
+        "description": "promotes the bijective multiplicative map built from a normalizing permutation that fixes 1 into an honest automorphism (G ≃* G), closing the converse direction",
+        "module": "Mathlib.Algebra.Group.Equiv.Defs"
+      },
+      {
+        "theorem": "Equiv.mulLeft_mul",
+        "description": "Equiv.mulLeft (a * b) = Equiv.mulLeft a * Equiv.mulLeft b — makes leftReg a group homomorphism G →* Equiv.Perm G on the nose",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "MulAut.mul_apply",
+        "description": "(e₁ * e₂) m = e₁ (e₂ m) — the composition law for automorphisms, used to make autPermHom a monoid homomorphism MulAut G →* Equiv.Perm G",
+        "module": "Mathlib.Algebra.Group.End"
+      },
+      {
+        "theorem": "DFunLike.congr_fun",
+        "description": "evaluates an equality of permutations at a point — the 'evaluate at 1' / 'evaluate at b' device that extracts c = σ a and multiplicativity σ(a*b) = σ a · σ b",
+        "module": "Mathlib.Data.FunLike.Basic"
+      }
+    ],
+    "originalContributions": [
+      "autPerm / autPermHom: the realisation of an automorphism as a permutation of the underlying set packaged as a genuine monoid homomorphism MulAut G →* Equiv.Perm G, with autPermHom_injective giving the holomorph embedding Aut(G) ↪ Sym(G)",
+      "autPerm_mul_leftReg: an automorphism intertwines the left-regular representation, φ ∘ L_g = L_{φ g} ∘ φ (equivariance), and the conjugation corollary autPerm_conj_leftReg: φ L_g φ⁻¹ = L_{φ g}",
+      "autPerm_mem_normalizer: every automorphism normalizes L(G)",
+      "mem_normalizer_and_fixes_one_iff: σ ∈ N(L(G)) ∧ σ 1 = 1 ↔ ∃ φ : Aut(G), autPerm φ = σ — Aut(G) is realised exactly as the stabiliser of the identity inside the normalizer (the converse runs the classical 'evaluate at 1' multiplicativity argument)",
+      "mem_normalizer_iff_exists: σ ∈ N(L(G)) ↔ ∃ g φ, σ = leftReg g · autPerm φ — the holomorph decomposition N_{Sym(G)}(L(G)) = L(G)·Aut(G), proved by splitting off the left translation L_{σ 1} so the remainder fixes 1"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 178,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, confirmed via #print axioms). No decide/native_decide is used. Holds for an arbitrary (possibly infinite) group G.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Holomorph",
+    "lineCount": 178,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "path": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0,
+  "overview": "Cayley's theorem embeds a group G into its symmetric group Sym(G) = Equiv.Perm G as the left-regular representation L(G), L_g : x ↦ g·x. The parent entry identifies the centralizer of L(G) as the right-regular image R(G). This file takes the next structural step and identifies the normalizer of L(G) — the holomorph Hol(G) = N_{Sym(G)}(L(G)) — over an arbitrary group G.\n\nThe engine is a single equivariance computation: for an automorphism φ of G, φ(g·x) = φ(g)·φ(x) says precisely that φ (viewed as a permutation of G) intertwines left translations, φ ∘ L_g = L_{φ g} ∘ φ. Conjugating gives φ L_g φ⁻¹ = L_{φ g}, so φ permutes the generators of L(G) and therefore normalizes it. Conversely, a permutation σ that normalizes L(G) and fixes the identity must satisfy σ(a·b) = σ(a)·σ(b): writing σ L_a σ⁻¹ = L_c and reading the equation off at 1 forces c = σ(a), and reading it off at a general point forces multiplicativity, so σ is an automorphism. This proves Aut(G) is realised exactly as the stabiliser of 1 inside the normalizer.\n\nThe full holomorph decomposition N(L(G)) = L(G)·Aut(G) then follows by a one-line reduction: given any normalizing σ, the permutation L_{σ 1}⁻¹ ∘ σ still normalizes L(G) and now fixes 1, hence equals some automorphism φ, so σ = L_{σ 1} ∘ φ. Everything is proved over an arbitrary, possibly infinite group with 0 sorries and 0 axioms.",
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) 178-line file with 12 theorems and 3 definitions identifying the normalizer of the left-regular image L(G) inside Sym(G) — the holomorph of G — over an arbitrary group. The automorphisms are realised exactly as the normalizing permutations fixing the identity (mem_normalizer_and_fixes_one_iff), and the full normalizer decomposes as L(G)·Aut(G) (mem_normalizer_iff_exists). Built on Mathlib's normalizer API and MulEquiv.ofBijective, with the equivariance and 'evaluate at 1' arguments proved here.",
+    "implications": "This completes the structural picture begun by the parent entry: the centralizer of L(G) is R(G), and the normalizer of L(G) is L(G)·Aut(G). Together they exhibit the holomorph Hol(G) = N_{Sym(G)}(L(G)) ≅ G ⋊ Aut(G) at the level of the underlying subgroups, with Aut(G) embedded (autPermHom_injective) as the identity-stabiliser. The autPerm_mul_leftReg equivariance lemma — that an automorphism intertwines the regular representation — is a reusable building block for further work on the holomorph and its semidirect-product structure.",
+    "openQuestions": [
+      "Promote the set-level decomposition N(L(G)) = L(G)·Aut(G) to a group isomorphism N_{Sym(G)}(L(G)) ≅ G ⋊ Aut(G) (SemidirectProduct), exhibiting the splitting L(G) ◁ N and the Aut(G) complement explicitly and computing the quotient N/L(G) ≅ Aut(G).",
+      "Specialise to a finite group G to obtain the order formula |Hol(G)| = |G| · |Aut(G)|, and identify the holomorph of small concrete groups (e.g. Hol(C_n) as the group of affine maps x ↦ a·x + b on Z/n)."
+    ]
+  },
+  "references": [
+    {
+      "title": "Holomorph (mathematics)",
+      "url": "https://en.wikipedia.org/wiki/Holomorph_(mathematics)"
+    },
+    {
+      "title": "Regular representation",
+      "url": "https://en.wikipedia.org/wiki/Regular_representation"
+    }
+  ],
+  "crossReferences": [
+    "cayleys-theorem-oq-01-oq-01-oq-02-oq-02"
+  ],
+  "sections": []
+}


### PR DESCRIPTION
## Summary

Self-generated follow-up to **#28112** (centralizer of the regular representation). The parent identifies the *centralizer* of the left-regular image `L(G)` inside `Sym(G)` as the right-regular image `R(G)`, and flags "the holomorph of `G`" as the natural next object. This PR identifies the **normalizer** of `L(G)` — the holomorph `Hol(G) = N_{Sym(G)}(L(G))` — over an **arbitrary** group `G` (no finiteness).

## Results (`Holomorph` namespace, 178 lines, 12 theorems, 3 defs)

- `autPermHom : MulAut G →* Equiv.Perm G` — automorphisms realised as permutations, a monoid hom, with `autPermHom_injective` giving the holomorph embedding `Aut(G) ↪ Sym(G)`.
- `autPerm_mul_leftReg` — **equivariance**: an automorphism intertwines the left-regular representation, `φ ∘ L_g = L_{φ g} ∘ φ` (the engine of the whole file); conjugation corollary `autPerm_conj_leftReg : φ L_g φ⁻¹ = L_{φ g}`.
- `autPerm_mem_normalizer` — every automorphism normalizes `L(G)`.
- `mem_normalizer_and_fixes_one_iff` — `σ ∈ N(L(G)) ∧ σ 1 = 1 ↔ ∃ φ : Aut(G), autPerm φ = σ`. **Aut(G) is exactly the normalizer's stabiliser of the identity**; the converse runs the classical "evaluate at `1`" multiplicativity argument and promotes `σ` to an automorphism via `MulEquiv.ofBijective`.
- `mem_normalizer_iff_exists` — `σ ∈ N(L(G)) ↔ ∃ g φ, σ = L_g · autPerm φ`. **The holomorph decomposition `N_{Sym(G)}(L(G)) = L(G)·Aut(G)`**, by splitting off the left translation `L_{σ 1}` so the remainder fixes `1`.

Together with the parent: the **centralizer** of `L(G)` is `R(G)` and the **normalizer** of `L(G)` is `L(G)·Aut(G)`, exhibiting `Hol(G) ≅ G ⋊ Aut(G)` at the level of underlying subgroups.

## Verification

- Compiles cleanly (`lake env lean`, EXIT=0, 0 errors, 0 warnings).
- **0 sorries, 0 axioms.** `#print axioms` on all three main theorems lists only `propext, Classical.choice, Quot.sound` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- Holds for an arbitrary, possibly infinite group `G`.

Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)