### PR TITLE
Fix stale '(sorry)' title on szemeredi-counting Counting Lemma annotation

### DIFF
--- a/src/data/proofs/szemeredi-counting/annotations.json
+++ b/src/data/proofs/szemeredi-counting/annotations.json
@@ -57,7 +57,7 @@
       "startLine": 31,
       "endLine": 51
     },
-    "title": "Counting Lemma (sorry)",
+    "title": "Counting Lemma",
     "content": "The counting lemma: if $(A, B)$, $(A, C)$, and $(B, C)$ are all $\\varepsilon$-regular pairs with edge densities $\\geq \\varepsilon$, then the triangle count is at least $(d_{AB} - \\varepsilon)(d_{AC} - \\varepsilon)(d_{BC} - \\varepsilon)|A||B||C|$.\n\nThe proof idea: for a vertex $a \\in A$, its neighborhood in $B$ has size $\\approx d_{AB}|B|$ by regularity (for all but $\\varepsilon|A|$ vertices). Similarly for $C$. The number of edges between $N(a) \\cap B$ and $N(a) \\cap C$ is $\\approx d_{BC}|N(a) \\cap B||N(a) \\cap C|$ by regularity of $(B, C)$. Summing over $a$ and handling error terms gives the bound.",
     "mathContext": "$T(A,B,C) \\geq (d_{AB} - \\varepsilon)(d_{AC} - \\varepsilon)(d_{BC} - \\varepsilon)|A||B||C|$. The error bound is at most $3\\varepsilon|A||B||C|$ when densities are $\\Theta(1)$.",
     "significance": "key",


### PR DESCRIPTION
## Fix

The annotation for the Counting Lemma was titled "Counting Lemma (sorry)", but the theorem is fully proved.

## Evidence

**Before**: annotation `counting-lemma-thm` title = "Counting Lemma (sorry)".
**After**: "Counting Lemma".

- meta.json: `status: verified`, `sorries: 0`, `axiomCount: 0`.
- `SzemerediCounting.lean` contains 0 `sorry` (whole file).
- `theorem counting_lemma` (line 229) has a complete, substantive proof — a fully stated bound `triangleCount G A B C ≥ (1 - 2ε)(dAB - ε)(dAC - ε)(dBC - ε)·|A||B||C|`, with no `True` placeholder.

Scope note: the sibling "Triangle Removal Lemma (sorry)" annotation is intentionally left unchanged — that theorem genuinely uses a `True` placeholder for the edge-count bound, and its annotation content honestly discloses this, so the flag there signals real incompleteness.

---
Automated fix by lean-mechanic agent.