### PR TITLE
Enrich Legendre Factorial Formula OQ-01: p-adic valuation of a factorial

### DIFF
--- a/src/data/proofs/legendre-factorial-formula-oq-01/annotations.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "legendre-fact-oq01-ann-header",
+    "proofId": "legendre-factorial-formula-oq-01",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "concept",
+    "title": "Two Classical Forms of Legendre's Formula",
+    "content": "Legendre's formula (1808) gives the exact exponent of a prime p in the factorization of n!, written vₚ(n!). It has two equivalent faces: the floor-sum form vₚ(n!) = ∑_{i≥1} ⌊n/pⁱ⌋, which counts at each level i how many of 1,…,n are divisible by pⁱ, and the digit-sum form (p−1)·vₚ(n!) = n − Sₚ(n), where Sₚ(n) is the sum of the base-p digits of n. Mathlib provides both plus the bound vₚ(n!) ≤ n; this file packages them and adds the solved form. The setup imports the p-adic valuation basics and uses the `Fact p.Prime` instance convention.",
+    "mathContext": "$v_p(n!) = \\sum_{i \\ge 1} \\left\\lfloor \\tfrac{n}{p^i} \\right\\rfloor = \\frac{n - S_p(n)}{p-1}.$",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "factorial", "base-p digit sum", "Kummer's theorem"],
+    "prerequisites": ["prime factorization", "floor function", "base-p expansions"]
+  },
+  {
+    "id": "legendre-fact-oq01-ann-floor-digit",
+    "proofId": "legendre-factorial-formula-oq-01",
+    "range": { "startLine": 32, "endLine": 45 },
+    "type": "theorem",
+    "title": "Floor-Sum and Digit-Sum Forms",
+    "content": "`padicValNat_factorial_eq_sum` re-exports Mathlib's `padicValNat_factorial`: for any truncation bound b strictly above log_p n, vₚ(n!) equals the finite sum ∑_{i∈[1,b)} ⌊n/pⁱ⌋ (finite because ⌊n/pⁱ⌋ = 0 once pⁱ > n). `sub_one_mul_padicValNat_factorial_eq` re-exports the digit-sum identity (p−1)·vₚ(n!) = n − Sₚ(n). Both are thin wrappers presenting the two classical statements side by side as a self-contained Legendre package.",
+    "mathContext": "$v_p(n!) = \\sum_{i \\in [1,b)} \\lfloor n/p^i \\rfloor \\quad (\\log_p n < b); \\qquad (p-1)\\,v_p(n!) = n - S_p(n).$",
+    "significance": "supporting",
+    "relatedConcepts": ["floor sum", "digit sum", "truncation bound", "Mathlib re-export"],
+    "prerequisites": ["padicValNat_factorial", "Nat.log"]
+  },
+  {
+    "id": "legendre-fact-oq01-ann-solved",
+    "proofId": "legendre-factorial-formula-oq-01",
+    "range": { "startLine": 47, "endLine": 56 },
+    "type": "theorem",
+    "title": "The Solved Form for the Valuation",
+    "content": "`padicValNat_factorial_eq_div` is the new content: it isolates vₚ(n!) itself rather than its (p−1)-multiple, giving vₚ(n!) = (n − Sₚ(n))/(p−1). Since p ≥ 2 gives 0 < p−1, and the digit-sum identity says the right-hand side n − Sₚ(n) is literally (p−1) times an integer, `Nat.mul_div_cancel_left` recovers the exact quotient with no rounding. This makes the formula directly usable when the valuation is needed as a value (binomial estimates, trailing zeros of n!).",
+    "mathContext": "$v_p(n!) = \\frac{n - S_p(n)}{p-1}, \\qquad (p-1) \\mid (n - S_p(n)).$",
+    "significance": "critical",
+    "relatedConcepts": ["exact division", "isolating a variable", "Nat.mul_div_cancel_left"],
+    "prerequisites": ["the digit-sum form", "natural-number division without remainder"]
+  },
+  {
+    "id": "legendre-fact-oq01-ann-bound-instance",
+    "proofId": "legendre-factorial-formula-oq-01",
+    "range": { "startLine": 58, "endLine": 71 },
+    "type": "theorem",
+    "title": "Bound and the v₂(10!) = 8 Instance",
+    "content": "`padicValNat_factorial_le` wraps Mathlib's bound vₚ(n!) ≤ n. The worked example v₂(10!) = 8 is verified through the floor-sum form rather than the digit/log form, with bound b = 4 (justified by `Nat.log_lt_of_lt_pow` since 10 < 2⁴): the goal reduces to ⌊10/2⌋ + ⌊10/4⌋ + ⌊10/8⌋ = 5 + 2 + 1 = 8, a plain Finset sum of divisions that `decide` reduces by the kernel. Routing through the floor sum (not Nat.digits / Nat.log, which are well-founded recursions that resist reduction) keeps the proof free of `native_decide` and hence of `Lean.ofReduceBool`.",
+    "mathContext": "$v_2(10!) = \\lfloor 10/2 \\rfloor + \\lfloor 10/4 \\rfloor + \\lfloor 10/8 \\rfloor = 5 + 2 + 1 = 8.$",
+    "significance": "supporting",
+    "relatedConcepts": ["valuation bound", "kernel decide", "well-founded recursion", "numerical verification"],
+    "prerequisites": ["padicValNat_factorial_le", "the floor-sum form", "Nat.log_lt_of_lt_pow"]
+  }
+]

--- a/src/data/proofs/legendre-factorial-formula-oq-01/index.ts
+++ b/src/data/proofs/legendre-factorial-formula-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LegendreFactorialFormulaOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const legendreFactorialFormulaOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const legendreFactorialFormulaOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const legendreFactorialFormulaOQ01Data: ProofData = {
+  proof: legendreFactorialFormulaOQ01Proof,
+  annotations: legendreFactorialFormulaOQ01Annotations,
+}

--- a/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01/meta.json
@@ -60,6 +60,36 @@
       "description": "Shares Legendre's name but is mathematically unrelated: 'legendre-partial' concerns the Legendre conjecture (a prime between consecutive squares), whereas this entry is Legendre's factorial formula for p-adic valuations."
     }
   ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Docstring stating Legendre's formula in its two classical forms (floor-sum and digit-sum) and announcing the new solved form vₚ(n!) = (n − Sₚ(n))/(p−1). Imports the p-adic valuation basics, opens Nat / Finset, and fixes a prime p (via the Fact p.Prime convention on each theorem)."
+    },
+    {
+      "id": "sec-floor-digit",
+      "title": "Floor-Sum and Digit-Sum Forms",
+      "startLine": 32,
+      "endLine": 45,
+      "summary": "padicValNat_factorial_eq_sum wraps Mathlib's padicValNat_factorial (vₚ(n!) = ∑_{i∈[1,b)} ⌊n/pⁱ⌋ for any bound b above log_p n) and sub_one_mul_padicValNat_factorial_eq wraps sub_one_mul_padicValNat_factorial ((p−1)·vₚ(n!) = n − Sₚ(n))."
+    },
+    {
+      "id": "sec-solved",
+      "title": "The Solved Form",
+      "startLine": 47,
+      "endLine": 56,
+      "summary": "padicValNat_factorial_eq_div: the value-add. Starting from (p−1)·vₚ(n!) = n − Sₚ(n) with 0 < p−1, divide both sides by p−1 via Nat.mul_div_cancel_left to isolate vₚ(n!) = (n − Sₚ(n))/(p−1) as an exact (remainder-free) natural quotient."
+    },
+    {
+      "id": "sec-bound-instance",
+      "title": "Bound and Worked Instance",
+      "startLine": 58,
+      "endLine": 71,
+      "summary": "padicValNat_factorial_le wraps Mathlib's bound vₚ(n!) ≤ n, and a worked example checks v₂(10!) = 8 through the floor-sum form (bound b = 4 justified by log₂ 10 < 4), reducing to ⌊10/2⌋ + ⌊10/4⌋ + ⌊10/8⌋ = 8 closed by kernel decide."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.NumberTheory.Padics.PadicVal.Basic"


### PR DESCRIPTION
Enrichment pass for `legendre-factorial-formula-oq-01` (Legendre's formula for vₚ(n!), with the solved form vₚ(n!) = (n − Sₚ(n))/(p−1)).

The meta.json was already rich (overview with key insights, conclusion with open questions, references) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site), had no annotations, and had **no** `sections` array. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 4 annotations carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the two classical forms, the floor/digit-sum re-exports, the solved form, and the bound + `v₂(10!) = 8` instance.
- **`sections`** — added 4 sections spanning the full 71-line file.

Axiom integrity unchanged: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` — accurate; the numerical instance uses kernel `decide` on the floor sum (not `native_decide`), so no `Lean.ofReduceBool`.

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)