### PR TITLE
Enrich Hilbert 10 Constructive Bézout = Finset.gcd (oq-04-oq-03-oq-01-oq-01): annotations, index.ts, conclusion

### DIFF
--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-intro",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Two Vocabularies for the Same gcd",
+    "content": "The parent entry built an *explicit, computable* solver for the linear Diophantine equation $a_0x_0 + \\dots + a_{n-1}x_{n-1} = c$, whose solvability test is a hand-rolled fold `vecGcd n a = Int.gcd (a 0) (Int.gcd (a 1) (…))`, defined by structural recursion so the extended-Euclidean witness peels off one coordinate at a time. Mathlib instead packages the gcd of a family abstractly as `Finset.gcd`, the normalized gcd over a `NormalizedGCDMonoid` — the object of the structural theory of finitely generated ideals and invariant factors. This file **bridges** the two: it proves the bespoke fold equals the abstract `Finset.gcd`, then deduces that solvability is equivalent to the abstract gcd-divisibility criterion. Constructive content and structural content turn out to be one predicate.",
+    "mathContext": "$\\mathrm{vecGcd}\\,n\\,a = \\mathrm{Finset.univ.gcd}\\,a$, hence $(\\exists x,\\ \\sum_i a_i x_i = c) \\iff \\mathrm{Finset.univ.gcd}\\,a \\mid c$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Hilbert's 10th problem",
+      "linear Diophantine equations",
+      "Bézout's identity",
+      "normalized GCD monoid"
+    ],
+    "prerequisites": [
+      "greatest common divisor",
+      "linear Diophantine equations",
+      "structural recursion"
+    ]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+    "range": { "startLine": 44, "endLine": 69 },
+    "type": "insight",
+    "title": "The Bridge: vecGcd = Finset.gcd",
+    "content": "The core identity `vecGcd_eq_finset_gcd`: the parent's recursive fold equals Mathlib's normalized `Finset.univ.gcd a`, proved by induction on $n$. The inductive step is an exact lockstep of two head/tail decompositions: `Fin.univ_succ` rewrites the index set as `cons 0 (map Fin.succ univ)`, and `Finset.gcd_insert` peels the head, turning the abstract gcd into `GCDMonoid.gcd (a 0) ((map succ univ).gcd a)`. `Finset.map_eq_image` + `Finset.gcd_image` reindex the tail to `univ.gcd (a ∘ Fin.succ)` — definitionally `Fin.tail a` — while `Int.coe_gcd` identifies the cast `Int.gcd` of the fold with the abstract `GCDMonoid.gcd`. The two heads agree and the inductive hypothesis on `Fin.tail a` closes the goal.",
+    "mathContext": "Inductive step: $\\mathrm{GCDMonoid.gcd}(a_0, \\mathrm{vecGcd}\\,n\\,(\\mathrm{tail}\\,a)) = \\mathrm{GCDMonoid.gcd}(a_0, \\mathrm{univ.gcd}(a\\circ\\mathrm{succ}))$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Fin.univ_succ",
+      "Finset.gcd_insert",
+      "Int.coe_gcd",
+      "structural induction"
+    ],
+    "prerequisites": [
+      "induction on Fin (n+1)",
+      "Finset.gcd API",
+      "normalized vs concrete gcd"
+    ]
+  },
+  {
+    "id": "ann-equivalence",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 101 },
+    "type": "concept",
+    "title": "Solvability ⇔ gcd Divisibility",
+    "content": "With the bridge, the divisibility criterion `Finset.univ.gcd a ∣ c` becomes provably equivalent to solvability of $\\sum_i a_i x_i = c$. The **easy** direction `finset_gcd_dvd_of_solvable`: the gcd divides every coefficient (`Finset.gcd_dvd`), hence every summand, hence the sum (`Finset.dvd_sum`). The **hard** direction `solvable_of_finset_gcd_dvd` is discharged *verbatim* by the parent's constructive `exists_vec_combo`, with the hypothesis transported through the bridge `vecGcd_eq_finset_gcd`. The packaged biconditional `solvable_iff_finset_gcd_dvd` is a fully-proved iff whose forward implication carries an actual solution vector — no associate-juggling, because both gcds are normalized to be non-negative.",
+    "mathContext": "$(\\exists x,\\ \\sum_i a_i x_i = c) \\iff \\mathrm{Finset.univ.gcd}\\,a \\mid c$; hard direction reuses the explicit extended-Euclidean witness.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Bézout's identity",
+      "constructive witness",
+      "Finset.dvd_sum",
+      "decidable predicate"
+    ],
+    "prerequisites": [
+      "the bridge above",
+      "divisibility of sums",
+      "the parent's exists_vec_combo"
+    ]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "hilbert-10-oq-04-oq-03-oq-01-oq-01",
+    "range": { "startLine": 103, "endLine": 111 },
+    "type": "concept",
+    "title": "Worked Instances Through the Abstract Criterion",
+    "content": "Two concrete equations are solved by invoking the biconditional's reverse direction with a `decide`-checked divisibility: $3x + 5y = 1$ fires because $\\gcd\\{3,5\\} = 1 \\mid 1$, and $6x + 4y = 10$ because $\\gcd\\{6,4\\} = 2 \\mid 10$. These exercise the whole chain — the abstract `Finset.gcd` criterion produces an existence proof backed by the parent's constructive solver.",
+    "mathContext": "$\\gcd\\{3,5\\} = 1 \\mid 1$ and $\\gcd\\{6,4\\} = 2 \\mid 10$, both discharged by `decide`.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "worked examples",
+      "decide tactic"
+    ],
+    "prerequisites": [
+      "the biconditional above"
+    ]
+  }
+]

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/index.ts
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Hilbert10OQ04OQ03OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hilbert10OQ04OQ03OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hilbert10OQ04OQ03OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hilbert10OQ04OQ03OQ01OQ01Data: ProofData = {
+  proof: hilbert10OQ04OQ03OQ01OQ01Proof,
+  annotations: hilbert10OQ04OQ03OQ01OQ01Annotations,
+}

--- a/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-04-oq-03-oq-01-oq-01/meta.json
@@ -101,6 +101,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module header and context",
+      "startLine": 1,
+      "endLine": 46,
+      "summary": "Recalls the parent's computable solver and its hand-rolled fold vecGcd, contrasts it with Mathlib's abstract normalized Finset.gcd, and states the goal: prove vecGcd = Finset.univ.gcd and deduce solvability ⇔ Finset.gcd divisibility. Imports Mathlib and the parent module.",
+      "mathContext": "vecGcd n a (recursive Int.gcd fold) vs Finset.univ.gcd a (normalized GCDMonoid gcd)."
+    },
+    {
       "id": "vecgcd-bridge",
       "title": "vecGcd Equals the Abstract Finset.gcd",
       "startLine": 47,
@@ -144,5 +152,14 @@
       "relationship": "extends",
       "description": "Recasts the grandparent's gcd-divisibility decision criterion as an explicit biconditional against Mathlib's abstract Finset.gcd."
     }
-  ]
+  ],
+  "conclusion": {
+    "summary": "The parent's hand-rolled recursive fold vecGcd is proved equal to Mathlib's normalized Finset.univ.gcd (vecGcd_eq_finset_gcd, by induction matching Fin.univ_succ against the recursion clause and Int.coe_gcd identifying the cast Int.gcd with the abstract GCDMonoid.gcd). The bridge yields the biconditional solvable_iff_finset_gcd_dvd: ∑ᵢ aᵢxᵢ = c is solvable ⇔ Finset.univ.gcd a ∣ c — the easy direction from Finset.gcd_dvd + Finset.dvd_sum, the hard direction discharged verbatim by the parent's constructive exists_vec_combo. 4 theorems, 0 axioms, 0 sorries.",
+    "implications": "Unifies two presentations of the same decidable predicate: the project's explicit-Bézout-witness solver (constructive content — an actual solution vector) and Mathlib's abstract Finset.gcd divisibility criterion (structural content — ideal / invariant-factor divisibility). Because both gcds are normalized to be non-negative they are equal on the nose, not merely associated, so the constructive witness transfers with no associate-juggling. This is the single-equation base case of the invariant-factor (Smith normal form) divisibility criterion for systems A·x = b.",
+    "openQuestions": [
+      "Does the equivalence extend to systems A·x = b over ℤ, identifying solvability with divisibility of b by the invariant factors (Smith normal form) of A, with Module.Basis.SmithNormalForm supplying the constructive witness? (The sibling direction hilbert-10-oq-04-oq-03-oq-02.)",
+      "Can the bridge vecGcd = Finset.gcd be generalized from ℤ to an arbitrary Euclidean domain (or Bézout domain), recovering both the explicit witness and the abstract criterion uniformly?",
+      "What is the bit-complexity of the constructive solver relative to computing Finset.gcd, and does the normalized identification suggest a fused algorithm that returns both the gcd and the Bézout vector in one pass?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `hilbert-10-oq-04-oq-03-oq-01-oq-01` — the bridge vecGcd = Finset.univ.gcd and the equivalence (∃ x, ∑ aᵢxᵢ = c) ↔ Finset.univ.gcd a ∣ c.

The entry shipped with only `meta.json`. This pass adds the missing files, header section coverage, and a conclusion:

**New `annotations.json`** — 4 fully-fielded annotations (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`): the two-vocabularies framing (computable fold vs abstract normalized gcd), the vecGcd = Finset.gcd bridge (Fin.univ_succ + Finset.gcd_insert/gcd_image + Int.coe_gcd induction), the solvability ⇔ gcd-divisibility equivalence (easy via dvd_sum, hard via the parent's constructive exists_vec_combo), and the worked instances.

**New `index.ts`** — was missing, so the page would show "proof not found" on the live site. Follows the sibling template (`hilbert10OQ04OQ03OQ01OQ01`).

**`meta.json`**:
- added a 'Module header and context' section covering lines 1–46 (sections previously started at line 47)
- added a `conclusion` (summary, implications, 3 open questions: systems/Smith normal form, generalization to Euclidean/Bézout domains, fused gcd+witness algorithm). All existing content (overview, sections, openQuestions, crossReferences) preserved.

Verified: `pnpm build` passes; JSON validates. Axiom integrity unchanged (status `verified`/badge `original`, 0 axioms, 0 sorries; the hard direction inherits the parent's fully constructive witness).