### PR TITLE
Enrich Markov Equation OQ-04: pairwise coprimality of Markov triples

### DIFF
--- a/src/data/proofs/markov-equation-oq-04/annotations.json
+++ b/src/data/proofs/markov-equation-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "markov-oq04-ann-header",
+    "proofId": "markov-equation-oq-04",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "Coprimality as a Markov-Tree Invariant",
+    "content": "The Markov equation x² + y² + z² = 3xyz has every positive solution reachable from the root (1,1,1) by Vieta jumps z ↦ 3xy − z and coordinate transpositions (proved in the parent Proofs.MarkovEquation). This file shows the three coordinates of any positive Markov triple are pairwise coprime — not by a fresh descent, but as a property that holds at the root and is preserved by every generating move. The `Coprime3` predicate bundles the three `IsCoprime` statements on the product type ℤ × ℤ × ℤ so the induction lines up with the Step/Reachable infrastructure without higher-order unification trouble.",
+    "mathContext": "$x^2 + y^2 + z^2 = 3xyz; \\qquad \\mathrm{Coprime3}(x,y,z) := \\gcd(x,y) = \\gcd(y,z) = \\gcd(x,z) = 1.$",
+    "significance": "key",
+    "relatedConcepts": ["Markov equation", "Vieta jumping", "Markov tree", "pairwise coprimality"],
+    "prerequisites": ["Diophantine equations", "gcd / IsCoprime over ℤ", "reachability relations"]
+  },
+  {
+    "id": "markov-oq04-ann-vieta",
+    "proofId": "markov-equation-oq-04",
+    "range": { "startLine": 52, "endLine": 67 },
+    "type": "theorem",
+    "title": "The Vieta Jump Preserves Coprimality",
+    "content": "`coprime_fst_vieta` and `coprime_snd_vieta` are the entire arithmetic content: a Vieta jump z ↦ 3xy − z leaves coprimality with x and with y unchanged, because 3xy − z = −z + x·(3y) = −z + y·(3x) differs from −z by a multiple of x (resp. y). Each is proved by rewriting the expression and applying `IsCoprime.add_mul_left_right_iff` (adding a multiple of x to the right argument preserves IsCoprime x) and `IsCoprime.neg_right_iff` (negation preserves coprimality). Thus IsCoprime x (3xy−z) ↔ IsCoprime x z.",
+    "mathContext": "$\\gcd(x,\\,3xy - z) = \\gcd(x, z), \\qquad \\gcd(y,\\,3xy - z) = \\gcd(y, z).$",
+    "significance": "critical",
+    "relatedConcepts": ["Vieta involution", "IsCoprime.add_mul_left_right_iff", "congruence mod x", "invariance"],
+    "prerequisites": ["IsCoprime API", "ring normalization"]
+  },
+  {
+    "id": "markov-oq04-ann-invariant",
+    "proofId": "markov-equation-oq-04",
+    "range": { "startLine": 69, "endLine": 106 },
+    "type": "theorem",
+    "title": "Transporting Coprimality from the Root",
+    "content": "Three steps assemble the invariant. `coprime3_one`: the root (1,1,1) is pairwise coprime (gcd 1 1 = 1). `coprime3_of_step`: any single move preserves Coprime3 — transpositions merely permute the three coprimality statements, and the Vieta jump uses the two preservation lemmas; because every move is its own inverse, the backward direction needed for head-induction is available. `coprime3_of_isMarkov`: `markov_classification` (parent) gives a reachability path from any positive triple to the root, and `Relation.ReflTransGen.head_induction_on` pushes coprimality back one move at a time from (1,1,1) to the given triple.",
+    "mathContext": "$\\mathrm{Reachable}\\,(x,y,z)\\,(1,1,1) \\implies \\mathrm{Coprime3}(x,y,z).$",
+    "significance": "critical",
+    "relatedConcepts": ["head induction", "ReflTransGen", "involutive moves", "invariant propagation"],
+    "prerequisites": ["the Vieta preservation lemmas", "markov_classification", "Relation.ReflTransGen"]
+  },
+  {
+    "id": "markov-oq04-ann-headline",
+    "proofId": "markov-equation-oq-04",
+    "range": { "startLine": 108, "endLine": 165 },
+    "type": "theorem",
+    "title": "Headline Coprimality and the Parity Corollary",
+    "content": "`markov_coprime` states the headline (all three pairs coprime) with single-pair projections, and `markov_gcd_eq_one` restates it via `Int.gcd · · = 1`. The parity consequence follows from `not_two_dvd_both`: a coprime pair cannot share the factor 2, since `IsCoprime.isUnit_of_dvd'` would make 2 a unit in ℤ (ruled out by `Int.isUnit_iff`). Hence `markov_at_most_one_even` / `markov_not_both_even`: no two coordinates of a Markov triple are simultaneously even — matching (1,1,1), (1,1,2), (1,2,5), (2,5,29), … where even entries are isolated. Sanity checks confirm the small triples.",
+    "mathContext": "$\\mathrm{IsCoprime}\\,a\\,b \\implies \\lnot(2 \\mid a \\land 2 \\mid b); \\qquad \\text{at most one of } x,y,z \\text{ is even}.$",
+    "significance": "key",
+    "relatedConcepts": ["gcd = 1", "parity", "units of ℤ", "Lagrange spectrum normalization"],
+    "prerequisites": ["the coprimality theorem", "IsCoprime.isUnit_of_dvd'", "Int.isUnit_iff"]
+  }
+]

--- a/src/data/proofs/markov-equation-oq-04/index.ts
+++ b/src/data/proofs/markov-equation-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MarkovCoprime.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const markovEquationOQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const markovEquationOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const markovEquationOQ04Data: ProofData = {
+  proof: markovEquationOQ04Proof,
+  annotations: markovEquationOQ04Annotations,
+}

--- a/src/data/proofs/markov-equation-oq-04/meta.json
+++ b/src/data/proofs/markov-equation-oq-04/meta.json
@@ -52,6 +52,36 @@
       "Stating the predicate on the product type ℤ × ℤ × ℤ (Coprime3) is what makes the induction line up cleanly with the Step/Reachable infrastructure, avoiding any higher-order unification trouble in the head-induction."
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview and the Coprime3 Predicate",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Docstring laying out the invariance strategy (coprimality at the root, preserved by each move, transported along reachability) and the key algebra 3xy − z = −z + x·(3y) = −z + y·(3x). Imports Mathlib and the parent Proofs.MarkovEquation, then defines Coprime3 on ℤ × ℤ × ℤ to line up with the Step/Reachable machinery."
+    },
+    {
+      "id": "sec-vieta",
+      "title": "The Vieta Jump Preserves Coprimality",
+      "startLine": 52,
+      "endLine": 67,
+      "summary": "coprime_fst_vieta and coprime_snd_vieta: IsCoprime x (3xy−z) ↔ IsCoprime x z (and likewise for y), proved by rewriting 3xy−z as −z + x·(3y) (resp. −z + y·(3x)) and applying IsCoprime.add_mul_left_right_iff and neg_right_iff. This is the entire arithmetic content."
+    },
+    {
+      "id": "sec-invariant",
+      "title": "Coprimality as a Tree Invariant",
+      "startLine": 69,
+      "endLine": 106,
+      "summary": "coprime3_one (root (1,1,1) is pairwise coprime), coprime3_of_step (each move — two transpositions and the Vieta jump, all involutions — preserves Coprime3, here in the backward direction), and coprime3_of_isMarkov (propagates coprimality from the root to any positive triple via ReflTransGen.head_induction_on on the markov_classification reachability path)."
+    },
+    {
+      "id": "sec-headline",
+      "title": "Headline Statements and Consequences",
+      "startLine": 108,
+      "endLine": 165,
+      "summary": "markov_coprime + the three projections, markov_gcd_eq_one (Int.gcd form), not_two_dvd_both (a coprime pair cannot share the non-unit factor 2), markov_at_most_one_even / markov_not_both_even (no two coordinates simultaneously even), and sanity checks on small triples like (2,5,29)."
+    }
+  ],
   "conclusion": {
     "summary": "A 0-axiom, 0-sorry formalization (165 lines, 13 theorems, 1 definition) proving that every positive Markov triple is pairwise coprime, together with the gcd-form and the parity corollary that at most one coordinate is even. The proof reuses the parent's verified tree classification and reduces the whole statement to the single observation that a Vieta jump shifts a coordinate by a multiple of the other two.",
     "implications": "Pairwise coprimality is a basic normalization used throughout Markov theory and the study of the Lagrange spectrum; isolating it as an invariant of the move relation shows how arithmetic properties of Markov triples can be read off the tree structure without re-running descent. The same template (verify at the root, check preservation under each move, transport along reachability) applies to other tree-invariant properties — e.g. parity patterns or congruence conditions of Markov numbers.",


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-04` (every positive Markov triple is pairwise coprime, proved as a tree invariant).

The meta.json was already rich (overview with key insights, conclusion with open questions, crossReferences) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site), had no annotations, and had **no** `sections` array. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 4 annotations carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the invariance framing + `Coprime3`, the Vieta-jump preservation lemmas, the root-to-tree transport via head induction, and the headline coprimality + parity corollary.
- **`sections`** — added 4 sections spanning the full 165-line file.

Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` — accurate (no `native_decide`; reuses the parent's verified `markov_classification`).

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)