### PR TITLE
Enrich The Holomorph: normalizer of L(G) = L(G)·Aut(G)

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-left-regular",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 54, "endLine": 67 },
+    "type": "definition",
+    "title": "The Left-Regular Representation L(G)",
+    "content": "leftReg packages left multiplication g ↦ (x ↦ g·x) as a group homomorphism into the symmetric group Sym(G) = Equiv.Perm G. The bundling is free: Equiv.mulLeft already exists in Mathlib, and the homomorphism laws are exactly Equiv.mulLeft_one and Equiv.mulLeft_mul. leftReg_injective re-proves Cayley's theorem itself — faithfulness of the regular representation — by evaluating L_a = L_b at the identity to recover a = b.",
+    "mathContext": "$L : G \\to \\mathrm{Sym}(G),\\quad L_g(x) = g \\cdot x,\\qquad L_{gh} = L_g L_h,\\ L_1 = \\mathrm{id}$. Injectivity: $L_a = L_b \\Rightarrow a = a\\cdot 1 = L_a(1) = L_b(1) = b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cayley's theorem", "regular representation", "group homomorphism", "symmetric group", "faithful action"],
+    "prerequisites": ["group theory", "permutation groups"]
+  },
+  {
+    "id": "ann-aut-perm-hom",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 69, "endLine": 91 },
+    "type": "definition",
+    "title": "Realising Aut(G) Inside Sym(G): autPermHom",
+    "content": "autPerm φ = φ.toEquiv forgets the multiplicative structure of an automorphism and keeps only the underlying bijection of the set G. autPermHom bundles this as a monoid homomorphism MulAut G →* Equiv.Perm G, so that composition of automorphisms matches composition of permutations. autPermHom_injective then gives the holomorph embedding Aut(G) ↪ Sym(G): distinct automorphisms induce distinct permutations because they already differ as functions.",
+    "mathContext": "$\\mathrm{autPerm} : \\mathrm{Aut}(G) \\to \\mathrm{Sym}(G)$ is a monoid hom: $\\mathrm{autPerm}(\\varphi\\psi) = \\mathrm{autPerm}(\\varphi)\\,\\mathrm{autPerm}(\\psi)$ and $\\mathrm{autPerm}(\\mathrm{id}) = \\mathrm{id}$. It is injective, giving $\\mathrm{Aut}(G) \\hookrightarrow \\mathrm{Sym}(G)$.",
+    "significance": "key",
+    "relatedConcepts": ["automorphism group", "holomorph", "monoid homomorphism", "group embedding", "MulAut"],
+    "prerequisites": ["group theory", "automorphisms", "Mathlib MulAut API"]
+  },
+  {
+    "id": "ann-equivariance",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 93, "endLine": 104 },
+    "type": "insight",
+    "title": "Equivariance: Automorphisms Intertwine the Regular Representation",
+    "content": "This is the conceptual engine of the entire file. The single line proof of autPerm_mul_leftReg is nothing more than the homomorphism law map_mul read off at a point: φ(g·y) = φ(g)·φ(y). Re-interpreted as an equation of permutations, it says φ∘L_g = L_{φg}∘φ — the automorphism φ carries the left-translation-by-g to left-translation-by-φ(g). Conjugating (autPerm_conj_leftReg) gives φ L_g φ⁻¹ = L_{φg}, exhibiting φ as permuting the generators {L_g} of L(G) among themselves.",
+    "mathContext": "$\\varphi \\circ L_g = L_{\\varphi g} \\circ \\varphi \\iff \\varphi(g\\cdot y) = \\varphi(g)\\cdot\\varphi(y)$. Conjugated: $\\varphi\\, L_g\\, \\varphi^{-1} = L_{\\varphi g}$.",
+    "significance": "key",
+    "relatedConcepts": ["equivariance", "intertwiner", "conjugation", "group action", "representation theory"],
+    "prerequisites": ["group homomorphisms", "conjugation in groups"]
+  },
+  {
+    "id": "ann-aut-normalizes",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 106, "endLine": 125 },
+    "type": "technique",
+    "title": "Automorphisms Normalize L(G)",
+    "content": "autPerm_mem_normalizer feeds the conjugation lemma into Mathlib's Subgroup.mem_normalizer_iff. To show φ ∈ N(L(G)) one checks h ∈ L(G) ⟺ φ h φ⁻¹ ∈ L(G) for all h. The forward direction is immediate from autPerm_conj_leftReg; the backward direction conjugates by the inverse automorphism φ.symm, using map_mul and MulEquiv.symm_apply_apply. Since φ is a bijection of generators, the whole image subgroup L(G) is preserved set-wise.",
+    "mathContext": "$\\varphi \\in N_{\\mathrm{Sym}(G)}(L(G)) \\iff \\forall h,\\ h \\in L(G) \\Leftrightarrow \\varphi h \\varphi^{-1} \\in L(G)$. Each direction is supplied by $\\varphi L_g \\varphi^{-1} = L_{\\varphi g}$ (resp. with $\\varphi^{-1}$).",
+    "significance": "supporting",
+    "relatedConcepts": ["normalizer", "subgroup membership", "conjugation", "automorphism action"],
+    "prerequisites": ["normalizers", "Subgroup.mem_normalizer_iff"]
+  },
+  {
+    "id": "ann-evaluate-at-one",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 127, "endLine": 156 },
+    "type": "insight",
+    "title": "Aut(G) is the Identity-Stabiliser: the 'Evaluate at 1' Argument",
+    "content": "mem_normalizer_and_fixes_one_iff is the crux: a permutation σ that normalizes L(G) AND fixes 1 is forced to be an automorphism. The proof is the classical 'evaluate at a point' device. Normalising gives σ L_a σ⁻¹ = L_c for some c; rewriting to the inverse-free form L_c σ = σ L_a and evaluating at the point 1 pins down c = σ(a) (using σ(1)=1). Evaluating the same equation at a general point b then yields σ(a·b) = σ(a)·σ(b) — multiplicativity. Bundling σ as a monoid hom and applying MulEquiv.ofBijective to its known bijectivity recovers an honest automorphism. So Aut(G) sits inside the normalizer exactly as the stabiliser of the identity.",
+    "mathContext": "From $\\sigma L_a \\sigma^{-1} = L_c$, i.e. $L_c \\sigma = \\sigma L_a$: at $1$, $c = c\\cdot\\sigma(1) = \\sigma(a\\cdot 1) = \\sigma(a)$; at $b$, $\\sigma(a)\\cdot\\sigma(b) = c\\cdot\\sigma(b) = \\sigma(a\\cdot b)$. Hence $\\sigma \\in \\mathrm{Aut}(G)$.",
+    "significance": "key",
+    "relatedConcepts": ["normalizer", "automorphism", "MulEquiv.ofBijective", "evaluate at a point", "stabiliser"],
+    "prerequisites": ["normalizers", "group homomorphisms", "bijections"]
+  },
+  {
+    "id": "ann-holomorph-decomposition",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 158, "endLine": 178 },
+    "type": "concept",
+    "title": "The Holomorph Decomposition N(L(G)) = L(G)·Aut(G)",
+    "content": "mem_normalizer_iff_exists assembles the pieces into the holomorph identity: every normalizing permutation factors as a left translation followed by an automorphism. The trick is normalisation: given σ ∈ N(L(G)), the permutation L_{σ1}⁻¹∘σ is still in N(L(G)) (the normalizer is a subgroup and L(G) ≤ N(L(G)) by Subgroup.le_normalizer) and now fixes 1, so by the previous theorem it equals autPerm φ for some automorphism φ. Re-multiplying gives σ = L_{σ1}·autPerm φ. This is the set-level shadow of the semidirect product structure Hol(G) = L(G) ⋊ Aut(G).",
+    "mathContext": "$\\sigma \\in N(L(G)) \\iff \\exists\\, g\\,\\varphi,\\ \\sigma = L_g \\cdot \\mathrm{autPerm}\\,\\varphi$, with $g = \\sigma(1)$. The reduction: $L_{\\sigma 1}^{-1}\\sigma$ fixes $1$ since $(L_{\\sigma 1}^{-1}\\sigma)(1) = \\sigma(1)^{-1}\\cdot\\sigma(1) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["holomorph", "semidirect product", "normalizer", "regular representation", "group decomposition"],
+    "prerequisites": ["normalizers", "semidirect products", "cosets"]
+  },
+  {
+    "id": "ann-context-holomorph",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "The Holomorph and Its Place in Group Theory",
+    "content": "The holomorph Hol(G) = N_{Sym(G)}(L(G)) is the largest permutation group in which G (as L(G)) is normal and acted on by its full automorphism group. It packages G and Aut(G) into a single permutation group G ⋊ Aut(G). This file is a self-generated follow-up to the parent entry, which proved the companion fact that the centralizer of L(G) is the right-regular image R(G). Centralizer = R(G) and normalizer = L(G)·Aut(G) together give the complete picture of the symmetries of the regular representation. For the cyclic group Z/n the holomorph is the affine group {x ↦ a·x + b : a ∈ (Z/n)*, b ∈ Z/n}.",
+    "mathContext": "$\\mathrm{Hol}(G) = N_{\\mathrm{Sym}(G)}(L(G)) \\cong G \\rtimes \\mathrm{Aut}(G)$, while $C_{\\mathrm{Sym}(G)}(L(G)) = R(G)$. For $G = \\mathbb{Z}/n$: $\\mathrm{Hol}(\\mathbb{Z}/n) \\cong (\\mathbb{Z}/n) \\rtimes (\\mathbb{Z}/n)^\\times$, the affine maps $x \\mapsto ax+b$.",
+    "significance": "context",
+    "relatedConcepts": ["holomorph", "automorphism group", "regular representation", "centralizer", "affine group", "Burnside", "Miller"],
+    "prerequisites": ["group theory", "semidirect products", "permutation groups"]
+  }
+]

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/index.ts
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleysTheoremOq01Oq01Oq02Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleysTheoremOq01Oq01Oq02Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleysTheoremOq01Oq01Oq02Oq02Oq01Data: ProofData = {
+  proof: cayleysTheoremOq01Oq01Oq02Oq02Oq01Proof,
+  annotations: cayleysTheoremOq01Oq01Oq02Oq02Oq01Annotations,
+}

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -86,7 +86,19 @@
     "sorries": 0
   },
   "sorries": 0,
-  "overview": "Cayley's theorem embeds a group G into its symmetric group Sym(G) = Equiv.Perm G as the left-regular representation L(G), L_g : x ↦ g·x. The parent entry identifies the centralizer of L(G) as the right-regular image R(G). This file takes the next structural step and identifies the normalizer of L(G) — the holomorph Hol(G) = N_{Sym(G)}(L(G)) — over an arbitrary group G.\n\nThe engine is a single equivariance computation: for an automorphism φ of G, φ(g·x) = φ(g)·φ(x) says precisely that φ (viewed as a permutation of G) intertwines left translations, φ ∘ L_g = L_{φ g} ∘ φ. Conjugating gives φ L_g φ⁻¹ = L_{φ g}, so φ permutes the generators of L(G) and therefore normalizes it. Conversely, a permutation σ that normalizes L(G) and fixes the identity must satisfy σ(a·b) = σ(a)·σ(b): writing σ L_a σ⁻¹ = L_c and reading the equation off at 1 forces c = σ(a), and reading it off at a general point forces multiplicativity, so σ is an automorphism. This proves Aut(G) is realised exactly as the stabiliser of 1 inside the normalizer.\n\nThe full holomorph decomposition N(L(G)) = L(G)·Aut(G) then follows by a one-line reduction: given any normalizing σ, the permutation L_{σ 1}⁻¹ ∘ σ still normalizes L(G) and now fixes 1, hence equals some automorphism φ, so σ = L_{σ 1} ∘ φ. Everything is proved over an arbitrary, possibly infinite group with 0 sorries and 0 axioms.",
+  "overview": {
+    "historicalContext": "The holomorph of a group is a classical 19th–20th century construction, studied by Camille Jordan, William Burnside, and especially G. A. Miller around 1900–1910. Cayley's theorem (1854) realises any group $G$ as the left-regular permutation group $L(G) \\le \\mathrm{Sym}(G)$, acting by $L_g : x \\mapsto g \\cdot x$. The symmetric group $\\mathrm{Sym}(G)$ then contains two natural images of $G$: the left-regular $L(G)$ and the right-regular $R(G)$. The holomorph is defined as the normalizer $\\mathrm{Hol}(G) = N_{\\mathrm{Sym}(G)}(L(G))$, and the classical theorem (Burnside, *Theory of Groups of Finite Order*, 1897/1911; Miller) identifies it as the semidirect product $L(G) \\rtimes \\mathrm{Aut}(G)$. It is the smallest permutation group simultaneously containing $G$ (as $L(G)$) and acting on it through all of $\\mathrm{Aut}(G)$; for $G = \\mathbb{Z}/n$ it is exactly the group of affine maps $x \\mapsto ax+b$. This file is a self-generated follow-up to the parent entry, which identified the *centralizer* of $L(G)$ as $R(G)$; here the *normalizer* is identified, completing the structural picture.",
+    "problemStatement": "Work inside the symmetric group $\\mathrm{Sym}(G) = \\mathrm{Equiv.Perm}\\,G$ on the underlying set of an arbitrary (possibly infinite) group $G$. Let $L(G)$ be the left-regular image $\\{L_g : g \\in G\\}$, where $L_g(x) = g \\cdot x$. Identify the normalizer $N_{\\mathrm{Sym}(G)}(L(G))$ — the holomorph $\\mathrm{Hol}(G)$. Concretely: (1) show every automorphism $\\varphi \\in \\mathrm{Aut}(G)$, viewed as a permutation of $G$, normalizes $L(G)$ and fixes $1$; (2) show conversely that a permutation $\\sigma$ normalizing $L(G)$ with $\\sigma(1)=1$ is exactly an automorphism, so $\\mathrm{Aut}(G)$ is the stabiliser of the identity inside the normalizer; (3) deduce the holomorph decomposition $N_{\\mathrm{Sym}(G)}(L(G)) = L(G) \\cdot \\mathrm{Aut}(G)$.",
+    "proofStrategy": "The engine is a single equivariance computation: for $\\varphi \\in \\mathrm{Aut}(G)$, the homomorphism identity $\\varphi(g \\cdot x) = \\varphi(g) \\cdot \\varphi(x)$ says precisely that $\\varphi$ (as a permutation) intertwines left translations, $\\varphi \\circ L_g = L_{\\varphi g} \\circ \\varphi$. Conjugating yields $\\varphi\\, L_g\\, \\varphi^{-1} = L_{\\varphi g}$, so $\\varphi$ permutes the generators of $L(G)$ and hence normalizes it (autPerm_mem_normalizer). For the converse, a normalizing $\\sigma$ with $\\sigma(1)=1$ is shown multiplicative by the classical \\\"evaluate at $1$\\\" argument: from $\\sigma L_a \\sigma^{-1} = L_c$ pass to the inverse-free form $L_c \\sigma = \\sigma L_a$, read off $c = \\sigma(a)$ at the point $1$, then read off $\\sigma(a \\cdot b) = \\sigma(a) \\cdot \\sigma(b)$ at a general point $b$; bundling $\\sigma$ as a monoid hom and applying MulEquiv.ofBijective recovers an automorphism (mem_normalizer_and_fixes_one_iff). Finally the full decomposition follows by a one-line reduction: for any normalizing $\\sigma$, the permutation $L_{\\sigma 1}^{-1} \\circ \\sigma$ still normalizes $L(G)$ and now fixes $1$, hence equals some $\\mathrm{autPerm}\\,\\varphi$, giving $\\sigma = L_{\\sigma 1} \\circ \\mathrm{autPerm}\\,\\varphi$ (mem_normalizer_iff_exists).",
+    "keyInsights": [
+      "The holomorph is captured by a single equivariance identity: $\\varphi \\circ L_g = L_{\\varphi g} \\circ \\varphi$ is literally the homomorphism property $\\varphi(g \\cdot x) = \\varphi(g) \\cdot \\varphi(x)$ re-read as a statement about permutations — automorphisms intertwine the regular representation.",
+      "$\\mathrm{Aut}(G)$ is recovered without any group-theoretic machinery as the point stabiliser of $1$ inside the normalizer: the only extra datum needed to upgrade a normalizing permutation to an automorphism is that it fixes the identity.",
+      "The converse direction is the classical 'evaluate at a point' trick: the abstract relation $\\sigma L_a \\sigma^{-1} = L_c$ is collapsed to scalar facts by feeding it the inputs $1$ (which pins down $c = \\sigma a$) and $b$ (which yields multiplicativity) — turning an equation of permutations into the homomorphism law.",
+      "The whole decomposition $N(L(G)) = L(G) \\cdot \\mathrm{Aut}(G)$ reduces to a one-line normalisation: left-translating by $L_{\\sigma 1}^{-1}$ moves the identity back to a fixed point, separating the $L(G)$ factor from the $\\mathrm{Aut}(G)$ factor — the set-level shadow of the semidirect product $G \\rtimes \\mathrm{Aut}(G)$.",
+      "Everything is proved over an arbitrary, possibly infinite group with no finiteness, no decidability, and 0 axioms: the holomorph is a purely algebraic object, and Mathlib's normalizer API (Subgroup.mem_normalizer_iff, le_normalizer) plus MulEquiv.ofBijective suffice to formalise it cleanly.",
+      "Together with the parent entry's centralizer result $C_{\\mathrm{Sym}(G)}(L(G)) = R(G)$, this pins down both fundamental subgroups attached to the regular representation: the centralizer is the opposite regular image, the normalizer is the holomorph."
+    ]
+  },
   "conclusion": {
     "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) 178-line file with 12 theorems and 3 definitions identifying the normalizer of the left-regular image L(G) inside Sym(G) — the holomorph of G — over an arbitrary group. The automorphisms are realised exactly as the normalizing permutations fixing the identity (mem_normalizer_and_fixes_one_iff), and the full normalizer decomposes as L(G)·Aut(G) (mem_normalizer_iff_exists). Built on Mathlib's normalizer API and MulEquiv.ofBijective, with the equivariance and 'evaluate at 1' arguments proved here.",
     "implications": "This completes the structural picture begun by the parent entry: the centralizer of L(G) is R(G), and the normalizer of L(G) is L(G)·Aut(G). Together they exhibit the holomorph Hol(G) = N_{Sym(G)}(L(G)) ≅ G ⋊ Aut(G) at the level of the underlying subgroups, with Aut(G) embedded (autPermHom_injective) as the identity-stabiliser. The autPerm_mul_leftReg equivariance lemma — that an automorphism intertwines the regular representation — is a reusable building block for further work on the holomorph and its semidirect-product structure.",
@@ -108,5 +120,55 @@
   "crossReferences": [
     "cayleys-theorem-oq-01-oq-01-oq-02-oq-02"
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "header",
+      "title": "Problem Statement & Roadmap",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Docstring framing the holomorph as a self-generated follow-up to the parent centralizer result: the normalizer N_{Sym(G)}(L(G)) is to be identified as L(G)·Aut(G) over an arbitrary group, via the equivariance identity φ∘L_g = L_{φg}∘φ and the 'evaluate at 1' converse. Sets up the namespace Holomorph and the variable group G."
+    },
+    {
+      "id": "left-regular",
+      "title": "The Left-Regular Representation",
+      "startLine": 54,
+      "endLine": 67,
+      "summary": "Defines leftReg : G →* Equiv.Perm G sending g to the permutation Equiv.mulLeft g (x ↦ g·x), packaged as a group homomorphism via Equiv.mulLeft_one and Equiv.mulLeft_mul. leftReg_injective re-proves Cayley's theorem (faithfulness) by evaluating L_a = L_b at the identity."
+    },
+    {
+      "id": "aut-perm",
+      "title": "Automorphisms as Permutations: autPerm / autPermHom",
+      "startLine": 69,
+      "endLine": 91,
+      "summary": "Defines autPerm φ = φ.toEquiv, the permutation of the underlying set induced by an automorphism, and bundles it as a monoid homomorphism autPermHom : MulAut G →* Equiv.Perm G (using MulAut.mul_apply and Equiv.Perm.mul_apply). autPermHom_injective gives the holomorph embedding Aut(G) ↪ Sym(G)."
+    },
+    {
+      "id": "equivariance",
+      "title": "Equivariance and Conjugation of Generators",
+      "startLine": 93,
+      "endLine": 104,
+      "summary": "Proves the engine of the whole file: autPerm_mul_leftReg (autPerm φ · L_g = L_{φg} · autPerm φ), the equivariance φ∘L_g = L_{φg}∘φ which is just map_mul read off pointwise, and its conjugation corollary autPerm_conj_leftReg (φ L_g φ⁻¹ = L_{φg})."
+    },
+    {
+      "id": "aut-normalizes",
+      "title": "Every Automorphism Normalizes L(G)",
+      "startLine": 106,
+      "endLine": 125,
+      "summary": "autPerm_mem_normalizer shows each automorphism lies in (leftReg G).range.normalizer, checking both membership directions of Subgroup.mem_normalizer_iff using the conjugation lemma and the inverse φ.symm. autPerm_one_eq records that an automorphism fixes the identity 1."
+    },
+    {
+      "id": "aut-as-stabiliser",
+      "title": "Aut(G) as the Identity-Stabiliser in the Normalizer",
+      "startLine": 127,
+      "endLine": 156,
+      "summary": "mem_normalizer_and_fixes_one_iff: σ normalizes L(G) and fixes 1 ⟺ σ = autPerm φ for some automorphism φ. The forward direction runs the classical 'evaluate at 1' argument to prove σ(a·b)=σa·σb, then promotes σ to an automorphism via MulEquiv.ofBijective; the reverse direction is the two preceding lemmas."
+    },
+    {
+      "id": "holomorph-decomposition",
+      "title": "The Holomorph Decomposition N(L(G)) = L(G)·Aut(G)",
+      "startLine": 158,
+      "endLine": 178,
+      "summary": "mem_normalizer_iff_exists: σ ∈ N(L(G)) ⟺ σ = leftReg g · autPerm φ. Given a normalizing σ, left-translating by L_{σ1}⁻¹ produces a normalizing permutation fixing 1, which the previous theorem turns into an automorphism φ; the converse uses Subgroup.le_normalizer and the automorphism-normalizer lemma."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01-oq-01-oq-02-oq-02-oq-01` (quality 15, pass 0).

## What was missing
- **No `index.ts`** — the proof was unloadable on the live site ("proof not found"). Created it from the template.
- **No `annotations.json`** — created with 7 inline annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **`overview` was a plain string** — converted to the structured `ProofOverview` object (matching the parent entry) with `historicalContext`, `problemStatement`, `proofStrategy`, and 6 `keyInsights`.
- **Empty `sections` array** — populated with 7 sections covering the full 178-line Lean file (left-regular rep, autPermHom, equivariance, normalizer membership, identity-stabiliser, holomorph decomposition).

## Accuracy notes
- meta.json already reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: original`; confirmed against the Lean source (no `axiom`/`sorry`/structure-encoded assumptions; no `native_decide`). No status/badge changes needed.
- Annotations and overview match the actual theorems (autPerm_mul_leftReg, mem_normalizer_and_fixes_one_iff, mem_normalizer_iff_exists).

`pnpm build` passes.