### PR TITLE
research(geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01): inverse Eulerian ⇆ Stirling pairing via binomial inversion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3771,6 +3771,7 @@ import Proofs.MellinPowerConvergenceOQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ04
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01
 
 import Proofs.ZetaRegularization
 import Proofs.CatalanNumbersOQ01OQ02

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01.lean
@@ -1,0 +1,190 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01-oq-06-oq-01:
+# The inverse Eulerian ⇆ Stirling pairing (binomial inversion)
+
+The parent entry `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06` proves the **forward**
+combinatorial Eulerian → Stirling identity (the per-coefficient dual of Worpitzky),
+
+  `eulerian_stirling` :  `i!·S(n,i) = ∑_{j<n} C(j, n−i)·⟨n,j⟩`   (`1 ≤ n`, `i ≤ n`),
+
+expressing the factorial-weighted Stirling row over the Eulerian row through the *plain*
+binomial weights `C(j, n−i)`.  This entry settles the open question `oq-01`: the **inverse
+pairing**, recovering the Eulerian numbers from the (factorial-weighted) Stirling row.  Together
+the two exhibit the Eulerian and Stirling rows as mutually inverse under the binomial triangle.
+
+## The corrected statement
+
+The open question proposed the inverse as `⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j, k−j)·j!·S(n,j)`.
+That formula is **incorrect**: e.g. for `n = 3, k = 0` it evaluates to `0`, whereas `⟨3,0⟩ = 1`
+(the only surviving term, `j = 0`, carries `0!·S(3,0) = 0`).  The correct binomial inverse — the
+genuine inversion of the forward identity above — is
+
+  **`eulerian_inverse`** :  `⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i, k)·i!·S(n,i)`   (`1 ≤ n`, `k ≤ n−1`).
+
+(Verified numerically for all rows `n ≤ 7`; the derivation below is the proof.)
+
+## Proof strategy
+
+The forward identity says `c_i := i!·S(n,i) = ∑_j C(j, n−i)·E_j` with `E_j := ⟨n,j⟩`.  Writing
+`m = n−i` this is `f(m) := c_{n−m} = ∑_j C(j, m)·E_j`, the *upper* binomial transform of the
+Eulerian row.  Its inverse is governed by the orthogonality of the binomial triangle under the
+alternating weight,
+
+  **`binom_ortho`** :  `∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j = k]`   (`j ≤ N`),
+
+proved from the subset-of-a-subset identity `C(j,m)·C(m,k) = C(j,k)·C(j−k, m−k)`
+(`Nat.choose_mul`) and the alternating row sum `∑_t (−1)^t·C(j−k, t) = [j = k]`
+(`Int.alternating_sum_range_choose`).  Substituting the forward identity into the claimed sum,
+swapping the order of summation, and reflecting the index `i ↦ n−i` reduces each inner sum to
+`binom_ortho`, collapsing the double sum to the single term `⟨n,k⟩`.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01
+
+open Finset Nat GeometricSeriesOQ07OQ01OQ01OQ01
+
+/-! ## Binomial orthogonality (the inversion kernel) -/
+
+/-- **Orthogonality of the binomial triangle under the alternating weight.**  For `j ≤ N`,
+`∑_{m ≤ N} (−1)^{m−k}·C(m,k)·C(j,m) = [j = k]`.  This is the inversion kernel: the matrices
+`(C(m,k))` and `((−1)^{m−k} C(m,k))` are mutually inverse, so it expresses that summing a binomial
+transform against the signed transform recovers a single coefficient. -/
+theorem binom_ortho (N j k : ℕ) (hjN : j ≤ N) :
+    ∑ m ∈ range (N + 1), (-1 : ℤ) ^ (m - k) * (m.choose k : ℤ) * (j.choose m : ℤ)
+      = if j = k then 1 else 0 := by
+  rcases lt_or_ge j k with hjk | hkj
+  · -- `j < k`: every term vanishes (`C(m,k)=0` for `m ≤ j`, `C(j,m)=0` for `m > j`)
+    rw [if_neg (by omega : ¬ j = k)]
+    apply Finset.sum_eq_zero
+    intro m _
+    rcases le_or_gt m j with hmj | hmj
+    · rw [Nat.choose_eq_zero_of_lt (by omega : m < k)]; ring
+    · rw [Nat.choose_eq_zero_of_lt hmj]; ring
+  · -- `k ≤ j`: split off the low terms `m < k`, reindex `m = k + t`, apply `Nat.choose_mul`
+    have hsplit : range (N + 1) = range k ∪ Ico k (N + 1) := by
+      rw [Finset.range_eq_Ico, Finset.Ico_union_Ico_eq_Ico (by omega) (by omega)]
+    rw [hsplit, Finset.sum_union (by
+      rw [Finset.range_eq_Ico]; exact Finset.Ico_disjoint_Ico_consecutive 0 k (N + 1))]
+    -- the `range k` part is zero
+    have hlow : ∑ m ∈ range k, (-1 : ℤ) ^ (m - k) * (m.choose k : ℤ) * (j.choose m : ℤ) = 0 := by
+      apply Finset.sum_eq_zero
+      intro m hm
+      rw [mem_range] at hm
+      rw [Nat.choose_eq_zero_of_lt hm]; ring
+    rw [hlow, zero_add]
+    -- reindex `Ico k (N+1)` as `m = k + t`, `t ∈ range (N+1-k)`
+    rw [Finset.sum_Ico_eq_sum_range]
+    have hN1 : N + 1 - k = (j - k) + 1 + (N - j) := by omega
+    -- rewrite each summand using the subset-of-subset identity
+    have hterm : ∀ t ∈ range (N + 1 - k),
+        (-1 : ℤ) ^ (k + t - k) * ((k + t).choose k : ℤ) * (j.choose (k + t) : ℤ)
+          = (j.choose k : ℤ) * ((-1 : ℤ) ^ t * ((j - k).choose t : ℤ)) := by
+      intro t _
+      have hcm : j.choose (k + t) * (k + t).choose k
+          = j.choose k * (j - k).choose ((k + t) - k) := Nat.choose_mul (by omega)
+      have hkt : (k + t) - k = t := by omega
+      rw [hkt] at hcm
+      have hexp : k + t - k = t := by omega
+      rw [hexp]
+      have hcast2 : ((k + t).choose k : ℤ) * (j.choose (k + t) : ℤ)
+          = (j.choose k : ℤ) * ((j - k).choose t : ℤ) := by
+        have h2 := congrArg (Nat.cast : ℕ → ℤ) hcm
+        push_cast at h2
+        linear_combination h2
+      linear_combination ((-1 : ℤ) ^ t) * hcast2
+    rw [Finset.sum_congr rfl hterm, ← Finset.mul_sum]
+    -- extend the alternating sum to the full row `range (j-k+1)` (extra terms vanish)
+    have hext : ∑ t ∈ range (N + 1 - k), (-1 : ℤ) ^ t * ((j - k).choose t : ℤ)
+        = ∑ t ∈ range ((j - k) + 1), (-1 : ℤ) ^ t * ((j - k).choose t : ℤ) := by
+      rw [hN1, ← Finset.sum_range_add_sum_Ico _ (by omega : (j - k) + 1 ≤ (j - k) + 1 + (N - j))]
+      have : ∑ t ∈ Ico ((j - k) + 1) ((j - k) + 1 + (N - j)),
+          (-1 : ℤ) ^ t * ((j - k).choose t : ℤ) = 0 := by
+        apply Finset.sum_eq_zero
+        intro t ht
+        rw [Finset.mem_Ico] at ht
+        rw [Nat.choose_eq_zero_of_lt (by omega : j - k < t)]; ring
+      rw [this, add_zero]
+    rw [hext, Int.alternating_sum_range_choose]
+    rcases eq_or_ne j k with hjk | hjk
+    · subst hjk; simp
+    · rw [if_neg (by omega : ¬ j - k = 0), if_neg (by omega : ¬ j = k), mul_zero]
+
+/-! ## The inverse pairing -/
+
+/-- **The inverse Eulerian ⇆ Stirling pairing.**  For `1 ≤ n` and `k ≤ n−1`,
+`⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i, k)·i!·S(n,i)`, where `⟨n,k⟩ = eulerian n k` is the
+combinatorial Eulerian number and `S(n,i) = stirlingSecond n i` the Stirling number of the second
+kind.  This is the binomial inverse of the forward identity `eulerian_stirling`; together they
+exhibit the two rows as mutually inverse under the binomial triangle. -/
+theorem eulerian_inverse (n k : ℕ) (hn : 1 ≤ n) (hk : k ≤ n - 1) :
+    (eulerian n k : ℤ)
+      = ∑ i ∈ range (n + 1),
+          (-1 : ℤ) ^ (n - i - k) * ((n - i).choose k : ℤ) * (i ! * stirlingSecond n i : ℤ) := by
+  symm
+  -- substitute the forward identity `i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩` (cast to ℤ)
+  have hsub : ∀ i ∈ range (n + 1),
+      (-1 : ℤ) ^ (n - i - k) * ((n - i).choose k : ℤ) * (i ! * stirlingSecond n i : ℤ)
+        = ∑ j ∈ range n,
+            (-1 : ℤ) ^ (n - i - k) * ((n - i).choose k : ℤ) * (j.choose (n - i) : ℤ)
+              * (eulerian n j : ℤ) := by
+    intro i hi
+    rw [mem_range] at hi
+    have hfwd := GeometricSeriesOQ07OQ01OQ01OQ01OQ06.eulerian_stirling n i hn (by omega)
+    have hcast : (i ! * stirlingSecond n i : ℤ)
+        = ∑ j ∈ range n, (j.choose (n - i) : ℤ) * (eulerian n j : ℤ) := by
+      have := congrArg (Nat.cast : ℕ → ℤ) hfwd
+      push_cast at this
+      exact this
+    rw [hcast, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro j _
+    ring
+  rw [Finset.sum_congr rfl hsub, Finset.sum_comm]
+  -- for each `j`, factor `⟨n,j⟩` out and reflect the index `i ↦ n − i`
+  have hinner : ∀ j ∈ range n,
+      ∑ i ∈ range (n + 1),
+          (-1 : ℤ) ^ (n - i - k) * ((n - i).choose k : ℤ) * (j.choose (n - i) : ℤ)
+            * (eulerian n j : ℤ)
+        = (eulerian n j : ℤ) * (if j = k then 1 else 0) := by
+    intro j hj
+    rw [mem_range] at hj
+    rw [← Finset.sum_mul, mul_comm]
+    congr 1
+    -- reflect: ∑_i g(n−i) = ∑_m g(m), with g(m) = (−1)^{m−k} C(m,k) C(j,m)
+    rw [← binom_ortho n j k (by omega)]
+    rw [← Finset.sum_range_reflect
+      (fun m => (-1 : ℤ) ^ (m - k) * (m.choose k : ℤ) * (j.choose m : ℤ)) (n + 1)]
+    apply Finset.sum_congr rfl
+    intro i hi
+    rw [mem_range] at hi
+    have : n + 1 - 1 - i = n - i := by omega
+    rw [this]
+  rw [Finset.sum_congr rfl hinner]
+  -- collapse: ∑_{j<n} ⟨n,j⟩·[j=k] = ⟨n,k⟩
+  simp only [mul_ite, mul_one, mul_zero]
+  rw [Finset.sum_ite_eq' (range n) k (fun j => (eulerian n j : ℤ)),
+    if_pos (mem_range.mpr (by omega))]
+
+/-! ## Corroboration on concrete rows -/
+
+-- `⟨3,1⟩ = 4 = ∑_{i≤3} (−1)^{3−i−1}·C(3−i,1)·i!·S(3,i)`.
+example : (eulerian 3 1 : ℤ)
+    = ∑ i ∈ range 4, (-1 : ℤ) ^ (3 - i - 1) * ((3 - i).choose 1 : ℤ)
+        * (i ! * stirlingSecond 3 i : ℤ) := by decide
+
+-- `⟨4,1⟩ = 11`.
+example : (eulerian 4 1 : ℤ)
+    = ∑ i ∈ range 5, (-1 : ℤ) ^ (4 - i - 1) * ((4 - i).choose 1 : ℤ)
+        * (i ! * stirlingSecond 4 i : ℤ) := by decide
+
+-- `⟨4,2⟩ = 11`.
+example : (eulerian 4 2 : ℤ)
+    = ∑ i ∈ range 5, (-1 : ℤ) ^ (4 - i - 2) * ((4 - i).choose 2 : ℤ)
+        * (i ! * stirlingSecond 4 i : ℤ) := by decide
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-docstring",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "context",
+    "title": "Problem Statement and the Corrected Inverse Formula",
+    "content": "The docstring states open question oq-06-oq-01: the binomial inverse of the parent's forward Eulerian → Stirling identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩. Crucially, it records that the open question's proposed inverse ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j) is incorrect — for n=3, k=0 every term but j=0 vanishes (negative lower binomial index) and the surviving term carries 0!·S(3,0) = 0, giving 0 ≠ ⟨3,0⟩ = 1. The corrected and proved statement is ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i), verified numerically for all rows n ≤ 7. The proof is previewed as binomial inversion driven by the orthogonality ∑_m (−1)^{m−k}·C(m,k)·C(j,m) = [j=k].",
+    "mathContext": "Forward: $i!\\,S(n,i) = \\sum_{j<n}\\binom{j}{n-i}\\langle n,j\\rangle$. Inverse (corrected): $\\langle n,k\\rangle = \\sum_{i\\le n}(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Eulerian numbers",
+      "Stirling numbers of the second kind",
+      "binomial inversion",
+      "Worpitzky's identity"
+    ],
+    "prerequisites": [
+      "combinatorics",
+      "binomial coefficients",
+      "binomial transforms"
+    ]
+  },
+  {
+    "id": "ann-binom-ortho",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+    "range": { "startLine": 58, "endLine": 121 },
+    "type": "technique",
+    "title": "Binomial Orthogonality: the Inversion Kernel",
+    "content": "binom_ortho proves ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] for j ≤ N — the statement that the binomial-triangle matrix (C(m,k)) and its signed transpose ((−1)^{m−k}·C(m,k)) are mutually inverse (the discrete analogue of Möbius inversion on the binomial lattice). The branch j<k is dispatched directly: every term vanishes (C(m,k)=0 for m≤j<k, C(j,m)=0 for m>j). For k≤j the sum over range(N+1) is split into range k (zero since C(m,k)=0 for m<k) and Ico k (N+1); the survivors are reindexed m = k+t (Finset.sum_Ico_eq_sum_range) and each term rewritten by the subset-of-a-subset identity C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t) (Nat.choose_mul). Factoring out C(j,k) leaves ∑_t (−1)^t·C(j−k,t), extended to the full row range(j−k+1) (the extra terms vanish) and evaluated to [j−k=0] by Int.alternating_sum_range_choose. Truncated ℕ subtraction in the exponent is harmless because C(m,k) already kills the m<k terms.",
+    "mathContext": "$\\sum_{m\\le N}(-1)^{m-k}\\binom{m}{k}\\binom{j}{m} = \\binom{j}{k}\\sum_{t}(-1)^t\\binom{j-k}{t} = \\binom{j}{k}(1-1)^{j-k} = [j=k]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "binomial inversion",
+      "subset-of-a-subset identity",
+      "alternating binomial sum",
+      "Möbius inversion"
+    ],
+    "prerequisites": [
+      "binomial coefficient identities",
+      "Finset reindexing",
+      "natural number subtraction in Lean"
+    ]
+  },
+  {
+    "id": "ann-eulerian-inverse",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+    "range": { "startLine": 123, "endLine": 184 },
+    "type": "key-step",
+    "title": "The Inverse Pairing by Binomial Inversion",
+    "content": "eulerian_inverse proves ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) for 1 ≤ n and k ≤ n−1. It substitutes the parent's forward identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩ (cast to ℤ via push_cast) into each summand (hsub), swaps the i- and j-summations with Finset.sum_comm, and for each fixed j factors ⟨n,j⟩ out and reflects the summation index i ↦ n−i with Finset.sum_range_reflect — turning the inner sum into the standard orthogonality form so binom_ortho evaluates it to [j=k] (hinner). The outer sum ∑_{j<n} ⟨n,j⟩·[j=k] then collapses to ⟨n,k⟩ via Finset.sum_ite_eq', using k ∈ range n (k ≤ n−1). The only substantive input is the forward identity; everything else is the inversion machinery.",
+    "mathContext": "$\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i) = \\sum_j\\langle n,j\\rangle\\!\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\binom{j}{n-i} = \\sum_j\\langle n,j\\rangle[j=k] = \\langle n,k\\rangle$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "binomial inversion",
+      "double sum interchange",
+      "index reflection",
+      "Eulerian–Stirling duality"
+    ],
+    "prerequisites": [
+      "Finset.sum_comm",
+      "Finset.sum_range_reflect",
+      "casting ℕ sums to ℤ"
+    ]
+  },
+  {
+    "id": "ann-concrete-rows",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+    "range": { "startLine": 186, "endLine": 190 },
+    "type": "context",
+    "title": "Corroboration on Concrete Rows",
+    "content": "Three kernel-decidable sanity checks confirm the inverse formula on small rows: ⟨3,1⟩ = 4, ⟨4,1⟩ = 11, and ⟨4,2⟩ = 11, each equated to its signed Stirling sum ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i). All use kernel decide rather than native_decide, so they add no axiom dependency (no Lean.ofReduceBool).",
+    "mathContext": "$\\langle 4,2\\rangle = 11 = \\sum_{i\\le 4}(-1)^{4-i-2}\\binom{4-i}{2}\\,i!\\,S(4,i)$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "decidable verification",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "Eulerian and Stirling number values"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/index.ts
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01Data: ProofData = {
+  proof: geometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01Proof,
+  annotations: geometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01Annotations,
+}

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01",
+  "description": "The inverse Eulerian ⇆ Stirling pairing: ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) (for 1 ≤ n, k ≤ n−1), the binomial inverse of the parent's forward identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩. Together the two exhibit the Eulerian and factorial-Stirling rows as mutually inverse under the binomial triangle. The open question's proposed formula ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j) is incorrect (it gives 0 for n=3,k=0 whereas ⟨3,0⟩=1); the corrected inverse is proved here via the binomial orthogonality ∑_m (−1)^{m−k}·C(m,k)·C(j,m) = [j=k]. 190 lines, 2 theorems, 0 axioms, 0 sorries.",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "GeometricSeriesOQ07OQ01OQ01OQ01"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01",
+    "lineCount": 190,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Inverse Eulerian ⇆ Stirling Pairing: ⟨n,k⟩ = ∑ᵢ (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "stirling-numbers",
+      "binomial-inversion",
+      "binomial-coefficients",
+      "worpitzky",
+      "orthogonality",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 190,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "eulerian_inverse: THE MAIN RESULT — the inverse Eulerian ⇆ Stirling pairing ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) for 1 ≤ n and k ≤ n−1, where ⟨n,k⟩ = eulerian n k is the parent's combinatorial Eulerian number and S(n,i) = Nat.stirlingSecond n i. This is the binomial inverse of the parent entry's forward identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩; together the two exhibit the Eulerian and factorial-weighted Stirling rows as mutually inverse under the binomial-coefficient triangle. The proof substitutes the forward identity into the claimed sum, swaps the order of summation, and reflects the index i ↦ n−i so that each inner sum reduces to the binomial orthogonality binom_ortho, collapsing the double sum to the single term ⟨n,k⟩.",
+      "CORRECTION of the open question: the question proposed the inverse as ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j). That formula is FALSE — e.g. for n=3, k=0 it evaluates to 0 (the only surviving term j=0 carries 0!·S(3,0)=0), whereas ⟨3,0⟩=1. The corrected and proved statement is the genuine binomial inverse ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i), verified numerically for all rows n ≤ 7 and then proved in general.",
+      "binom_ortho: the binomial orthogonality / inversion kernel ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] for j ≤ N — the statement that the binomial-triangle matrix (C(m,k)) and its signed transpose ((−1)^{m−k}·C(m,k)) are mutually inverse. Proved by splitting off the low terms m<k (where C(m,k)=0), reindexing the survivors m = k+t, applying the subset-of-a-subset identity C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t) (Nat.choose_mul), and evaluating the resulting alternating row sum ∑_t (−1)^t·C(j−k,t) = [j−k=0] via Int.alternating_sum_range_choose. The j<k branch is dispatched separately (every term vanishes)."
+    ],
+    "prerequisites": [
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06 — supplies the forward identity eulerian_stirling : i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩, which is substituted into the candidate sum and then inverted",
+      "Grandparent: geometric-series-oq-07-oq-01-oq-01-oq-01 — supplies the combinatorial Eulerian numbers eulerian n k and the diagonal-vanishing eulerian_eq_zero_of_lt",
+      "Mathlib's Nat.choose_mul (subset-of-a-subset / trinomial revision), Int.alternating_sum_range_choose (∑_m (−1)^m·C(n,m) = [n=0]), Nat.choose_eq_zero_of_lt, and Finset reindexing (Finset.sum_range_reflect, Finset.sum_Ico_eq_sum_range, Finset.sum_range_add_sum_Ico, Finset.sum_comm, Finset.sum_ite_eq')"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.choose_mul",
+        "description": "The subset-of-a-subset identity n.choose k · k.choose s = n.choose s · (n−s).choose (k−s) for s ≤ k. With n=j, k=k+t, s=k it gives C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t), the key factorization inside the orthogonality lemma.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Int.alternating_sum_range_choose",
+        "description": "The alternating row sum ∑_{m≤n} (−1)^m·C(n,m) = if n=0 then 1 else 0 (over ℤ). Evaluates ∑_t (−1)^t·C(j−k,t) to [j=k], completing the binomial orthogonality.",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑_{i<n} f(n−1−i) = ∑_{i<n} f i. Used to reflect the summation index i ↦ n−i, turning the inner sum ∑_i (−1)^{n−i−k}·C(n−i,k)·C(j,n−i) into the standard orthogonality form ∑_m (−1)^{m−k}·C(m,k)·C(j,m).",
+        "module": "Mathlib.Algebra.BigOperators.Intervals"
+      },
+      {
+        "theorem": "Finset.sum_comm",
+        "description": "Swaps the order of a double sum. After substituting the forward identity, exchanges the i- and j-summations so that ⟨n,j⟩ can be factored out and the inner i-sum handed to binom_ortho.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "GeometricSeriesOQ07OQ01OQ01OQ01OQ06.eulerian_stirling",
+        "description": "The forward Eulerian → Stirling identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩ from the parent entry. Substituted into the candidate inverse sum; the whole proof is the binomial inversion of this single hypothesis.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨n,k⟩ count permutations of {1,…,n} with k descents (Euler, Institutiones calculi differentialis, 1755); the Stirling numbers of the second kind S(n,i) count partitions of an n-set into i blocks (Stirling, Methodus Differentialis, 1730), and i!·S(n,i) counts surjections from an n-set onto an i-set. Worpitzky's identity (1883) links the two triangles via the binomial triangle, and the parent entry formalized one direction of this link — the forward pairing i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩. Pairs of triangles related through binomial weights are typically mutually invertible under the alternating-sign binomial transform (the discrete analogue of Möbius inversion on the binomial lattice). This entry formalizes the inverse direction, completing the mutual-inverse relationship and — in the course of doing so — correcting the inverse formula originally conjectured in the open question.",
+    "problemStatement": "Establish the binomial inverse of the parent's forward Eulerian → Stirling identity: express the combinatorial Eulerian numbers ⟨n,k⟩ as a signed binomial combination of the factorial-weighted Stirling numbers i!·S(n,i). The open question proposed ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j); determine the correct inverse and prove it.",
+    "text": "A 190-line, 0-axiom formalization with two public theorems. binom_ortho proves the binomial orthogonality ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] (for j ≤ N), the inversion kernel asserting that the binomial-triangle matrix and its signed transpose are mutually inverse. eulerian_inverse then proves ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) for 1 ≤ n and k ≤ n−1, by substituting the parent's forward identity, swapping the summation order, reflecting the index i ↦ n−i, and applying binom_ortho. Three concrete rows (⟨3,1⟩, ⟨4,1⟩, ⟨4,2⟩) are checked by kernel decide (not native_decide, so no Lean.ofReduceBool). The originally conjectured formula is shown to be false and the corrected one proved.",
+    "proofStrategy": "Binomial inversion. The forward identity reads c_i := i!·S(n,i) = ∑_j C(j,n−i)·E_j with E_j = ⟨n,j⟩. Writing m = n−i this is f(m) = ∑_j C(j,m)·E_j, the upper binomial transform of the Eulerian row. Substituting it into the claimed sum ∑_i (−1)^{n−i−k}·C(n−i,k)·c_i and swapping summations gives ∑_j E_j · (∑_i (−1)^{n−i−k}·C(n−i,k)·C(j,n−i)). Reflecting i ↦ n−i (Finset.sum_range_reflect) turns the inner sum into ∑_m (−1)^{m−k}·C(m,k)·C(j,m), which binom_ortho evaluates to [j=k]; the outer sum then collapses to E_k = ⟨n,k⟩ (Finset.sum_ite_eq'). The orthogonality kernel itself factors C(j,m)·C(m,k) by the subset-of-a-subset identity and reduces to the alternating binomial row sum (1−1)^{j−k}.",
+    "keyInsights": [
+      "The open question's proposed inverse formula ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j) is incorrect: for n=3, k=0 every term but j=0 vanishes (negative lower index) and the j=0 term carries 0!·S(3,0) = 0, giving 0 ≠ ⟨3,0⟩ = 1. The correct binomial inverse, verified for all rows n ≤ 7 and then proved, is ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i).",
+      "The inversion is governed by a single orthogonality identity: the binomial-triangle matrix M = (C(m,k)) and the signed matrix M⁻¹ = ((−1)^{m−k}·C(m,k)) are mutually inverse, ∑_m (−1)^{m−k}·C(m,k)·C(j,m) = [j=k]. This is the discrete analogue of Möbius inversion on the binomial lattice, and it is all that the inversion needs once the forward identity is taken as input.",
+      "The orthogonality reduces to two elementary facts: the subset-of-a-subset identity C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t) (Nat.choose_mul) pulls the constant C(j,k) out, and the alternating row sum ∑_t (−1)^t·C(j−k,t) = (1−1)^{j−k} = [j=k] (Int.alternating_sum_range_choose) finishes it. Truncated ℕ subtraction in the exponent (m−k) is harmless because the factor C(m,k) vanishes for m<k.",
+      "Reflecting the summation index i ↦ n−i (Finset.sum_range_reflect) is the bridge between the application form (where the sign and binomials are indexed by n−i, matching the forward identity's C(j,n−i)) and the orthogonality form (indexed by a free m), letting one general orthogonality lemma serve the inverse pairing.",
+      "Verification stays inside the kernel: the three concrete-row sanity checks use decide rather than native_decide, so the proof depends only on propext / Classical.choice / Quot.sound and incurs no Lean.ofReduceBool — honestly 0-axiom."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "eulerian_inverse",
+      "type": "core",
+      "description": "The inverse Eulerian ⇆ Stirling pairing: for 1 ≤ n and k ≤ n−1, ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i). The binomial inverse of the parent's forward identity; together they exhibit the two rows as mutually inverse under the binomial triangle.",
+      "leanType": "(eulerian n k : ℤ) = ∑ i ∈ range (n + 1), (-1) ^ (n - i - k) * ((n - i).choose k : ℤ) * (i ! * stirlingSecond n i : ℤ)"
+    },
+    {
+      "name": "binom_ortho",
+      "type": "core",
+      "description": "Binomial orthogonality / inversion kernel: for j ≤ N, ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k]. The binomial-triangle matrix and its signed transpose are mutually inverse.",
+      "leanType": "∑ m ∈ range (N + 1), (-1) ^ (m - k) * (m.choose k : ℤ) * (j.choose m : ℤ) = if j = k then 1 else 0"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Problem Statement and the Corrected Inverse",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "The docstring states oq-06-oq-01: the inverse of the parent's forward Eulerian → Stirling identity. It notes that the open question's proposed formula ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j) is incorrect (n=3, k=0 gives 0 ≠ ⟨3,0⟩=1) and records the corrected statement ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i), verified numerically for n ≤ 7. It previews the proof: binomial inversion driven by the orthogonality ∑_m (−1)^{m−k}·C(m,k)·C(j,m) = [j=k], itself from Nat.choose_mul plus Int.alternating_sum_range_choose. Followed by the imports of Mathlib, the grandparent and the parent.",
+      "mathContext": "Forward: $i!\\,S(n,i) = \\sum_{j<n}\\binom{j}{n-i}\\langle n,j\\rangle$. Inverse (corrected): $\\langle n,k\\rangle = \\sum_{i\\le n}(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i)$."
+    },
+    {
+      "id": "binom-ortho",
+      "title": "Binomial Orthogonality (the Inversion Kernel)",
+      "startLine": 58,
+      "endLine": 121,
+      "summary": "binom_ortho proves ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] for j ≤ N. The case j<k is handled directly (each term vanishes: C(m,k)=0 for m≤j<k, C(j,m)=0 for m>j). For k≤j, the sum over range(N+1) is split into range k (zero, since C(m,k)=0 for m<k) and Ico k (N+1); the latter is reindexed m = k+t and each term rewritten by the subset-of-a-subset identity C(j,k+t)·C(k+t,k) = C(j,k)·C(j−k,t) (Nat.choose_mul). Factoring out C(j,k) leaves ∑_t (−1)^t·C(j−k,t), extended to the full row range(j−k+1) (extra terms vanish) and evaluated by Int.alternating_sum_range_choose to [j−k=0] = [j=k].",
+      "mathContext": "$\\sum_{m\\le N}(-1)^{m-k}\\binom{m}{k}\\binom{j}{m} = \\binom{j}{k}\\sum_t (-1)^t\\binom{j-k}{t} = \\binom{j}{k}\\,(1-1)^{j-k} = [j=k]$."
+    },
+    {
+      "id": "eulerian-inverse",
+      "title": "The Inverse Pairing",
+      "startLine": 123,
+      "endLine": 184,
+      "summary": "eulerian_inverse proves ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i). It substitutes the parent's forward identity (cast to ℤ) into each summand (hsub), swaps the i- and j-summations with Finset.sum_comm, then for each j factors ⟨n,j⟩ out and reflects the index i ↦ n−i via Finset.sum_range_reflect so the inner sum matches binom_ortho, evaluating to [j=k] (hinner). The outer sum ∑_{j<n} ⟨n,j⟩·[j=k] collapses to ⟨n,k⟩ by Finset.sum_ite_eq' (k ∈ range n since k ≤ n−1).",
+      "mathContext": "$\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\,i!\\,S(n,i) = \\sum_j\\langle n,j\\rangle\\sum_i(-1)^{n-i-k}\\binom{n-i}{k}\\binom{j}{n-i} = \\sum_j\\langle n,j\\rangle[j=k] = \\langle n,k\\rangle$."
+    },
+    {
+      "id": "concrete-rows",
+      "title": "Corroboration on Concrete Rows",
+      "startLine": 186,
+      "endLine": 190,
+      "summary": "Three kernel-decidable sanity checks against small rows: ⟨3,1⟩ = 4, ⟨4,1⟩ = 11, and ⟨4,2⟩ = 11, each equated to the signed Stirling sum. All use kernel decide (not native_decide), so they add no axiom dependency.",
+      "mathContext": "e.g. $\\langle 4,2\\rangle = 11 = \\sum_{i\\le 4}(-1)^{4-i-2}\\binom{4-i}{2}\\,i!\\,S(4,i)$."
+    }
+  ],
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06",
+      "relationship": "extends",
+      "description": "Parent entry. The parent proves the forward Eulerian → Stirling identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩; this entry proves its binomial inverse ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i), so the two together exhibit the Eulerian and factorial-Stirling rows as mutually inverse under the binomial triangle. The forward identity is the sole substantive input to the inversion."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "uses",
+      "description": "Grandparent (the combinatorial Eulerian numbers). Supplies the triangle ⟨n,k⟩ = eulerian n k and the diagonal-vanishing eulerian_eq_zero_of_lt; the inverse pairing is stated and proved over these objects."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Sibling under the same grandparent. oq-03 proves Worpitzky's identity (the power basis over the Eulerian row in ascending binomials); the forward identity this entry inverts is its per-coefficient Stirling dual. Both are instances of the binomial-triangle change of basis between Eulerian, Stirling, and power data."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, Stirling numbers, binomial inversion)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian and Stirling triangles, the surjection interpretation i!·S(n,i), and the binomial-inversion / orthogonality machinery used here."
+    },
+    {
+      "title": "Mathlib4: Data.Nat.Choose.Basic and Data.Nat.Choose.Sum",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Nat.choose_mul (subset-of-a-subset identity) and Int.alternating_sum_range_choose (the alternating binomial row sum), the two facts the orthogonality kernel rests on."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "This entry proves the inverse Eulerian ⇆ Stirling pairing ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i) (for 1 ≤ n, k ≤ n−1), the binomial inverse of the parent entry's forward identity i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩. The two together exhibit the combinatorial Eulerian numbers and the factorial-weighted Stirling numbers as mutually inverse under the binomial-coefficient triangle. The proof rests on a single orthogonality lemma binom_ortho : ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k] (the binomial-triangle matrix and its signed transpose are inverse), itself reduced to the subset-of-a-subset identity (Nat.choose_mul) and the alternating binomial row sum (Int.alternating_sum_range_choose). Substituting the forward identity, swapping summations, and reflecting the index i ↦ n−i collapses the candidate double sum to ⟨n,k⟩. In the process the entry corrects the open question's conjectured formula ⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j), which is false (it gives 0 for n=3, k=0). 190 lines, 2 public theorems, 0 definitions, 0 axioms, 0 sorries; all results depend only on propext, Classical.choice, Quot.sound (the numeric checks use kernel decide, not native_decide, so no Lean.ofReduceBool).",
+    "implications": "Completing the inverse direction closes the mutual-invertibility of the Eulerian and Stirling rows under the binomial triangle, the discrete analogue of Möbius inversion on the binomial lattice. Combined with the parent (forward pairing) and the Worpitzky sibling (oq-03), the gallery now records the full change-of-basis triangle relating power, Eulerian, and (factorial-) Stirling data. The reusable byproduct is binom_ortho, a clean statement of binomial-transform orthogonality that any future binomial-inversion argument in the gallery can call.",
+    "openQuestions": []
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **oq-06-oq-01** of `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06`: the **binomial inverse** of that parent's forward Eulerian → Stirling identity `i!·S(n,i) = ∑_{j<n} C(j,n−i)·⟨n,j⟩`.

### Correction of the open question
The open question proposed the inverse as `⟨n,k⟩ = ∑_j (−1)^{k−j}·C(n−j,k−j)·j!·S(n,j)`. **This formula is false**: for `n=3, k=0` every term but `j=0` vanishes (negative lower binomial index) and the surviving term carries `0!·S(3,0)=0`, giving `0 ≠ ⟨3,0⟩=1`. The corrected statement (verified numerically for all rows `n ≤ 7`, then proved) is:

```
eulerian_inverse : ⟨n,k⟩ = ∑_{i≤n} (−1)^{n−i−k}·C(n−i,k)·i!·S(n,i)     (1 ≤ n, k ≤ n−1)
```

### Method — binomial inversion
Substitute the parent's forward identity into the candidate sum, swap the double sum (`Finset.sum_comm`), reflect the index `i ↦ n−i` (`Finset.sum_range_reflect`), and collapse via the orthogonality kernel

```
binom_ortho : ∑_{m≤N} (−1)^{m−k}·C(m,k)·C(j,m) = [j=k]     (j ≤ N)
```

itself proved from `Nat.choose_mul` (subset-of-a-subset / trinomial revision) and `Int.alternating_sum_range_choose`. Together with the parent, this exhibits the Eulerian and factorial-weighted Stirling rows as **mutually inverse** under the binomial triangle.

## Verification
- **190 lines, 2 theorems, 0 definitions, 0 axioms, 0 sorries**
- `#print axioms`: `eulerian_inverse` and `binom_ortho` depend only on `[propext, Classical.choice, Quot.sound]` — no `Lean.ofReduceBool` (numeric checks use kernel `decide`, not `native_decide`)
- Builds clean via `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01`

## Files
- `proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-06-oq-01/` (gallery meta/annotations/index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)