### PR TITLE
Enrich Euler Totient OQ-09: the totient power law φ(nᵏ) = nᵏ⁻¹·φ(n)

### DIFF
--- a/src/data/proofs/euler-totient-oq-09/annotations.json
+++ b/src/data/proofs/euler-totient-oq-09/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "totient-oq09-ann-header",
+    "proofId": "euler-totient-oq-09",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "concept",
+    "title": "The Totient Under Powers, via Shared Prime Support",
+    "content": "Euler's totient φ(n) = |(ℤ/nℤ)ˣ| satisfies the product formula φ(n)/n = ∏_{p∣n}(1 − 1/p). Since n and nᵏ have exactly the same prime factors, that ratio is unchanged under powering, so φ(nᵏ) = nᵏ⁻¹·φ(n) — no induction on the exponent needed. Mathlib has the coprime law `Nat.totient_mul` and the prime-power values `Nat.totient_prime_pow`, but no general-base power law, and the coprime law cannot supply it (n and nᵏ are maximally non-coprime). This file fills the gap and, more usefully, isolates the mechanism as a reusable engine. Imports Totient/PrimeFin/Tactic and opens Nat so φ = Nat.totient.",
+    "mathContext": "$\\varphi(n^k) = n^{k-1}\\varphi(n) \\quad (k \\ge 1); \\qquad \\frac{\\varphi(n)}{n} = \\prod_{p \\mid n}\\left(1 - \\tfrac1p\\right).$",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "product formula", "prime support", "multiplicative functions"],
+    "prerequisites": ["totient function", "prime factorization", "unit group (ℤ/nℤ)ˣ"]
+  },
+  {
+    "id": "totient-oq09-ann-engine",
+    "proofId": "euler-totient-oq-09",
+    "range": { "startLine": 51, "endLine": 73 },
+    "type": "theorem",
+    "title": "The Engine: Prime-Saturated Scaling",
+    "content": "`totient_mul_of_primeFactors_subset` is the reusable export: φ(m·n) = m·φ(n) whenever every prime factor of m already divides n (m.primeFactors ⊆ n.primeFactors). This generalizes Mathlib's single-prime `Nat.totient_mul_of_prime_of_dvd` to an arbitrary prime-saturated multiplier. After dispatching the n = 0 and m = 0 cases by simp, the subset hypothesis with `Nat.primeFactors_mul` collapses (m·n).primeFactors onto n.primeFactors, so the two Euler products (via `totient_eq_mul_prod_factors`) coincide; casting to ℚ and `ring` finish, then `exact_mod_cast` returns to ℕ. The right level of generality is 'prime-saturated multiplier', not 'power'.",
+    "mathContext": "$m.\\mathrm{primeFactors} \\subseteq n.\\mathrm{primeFactors} \\implies \\varphi(mn) = m\\,\\varphi(n).$",
+    "significance": "critical",
+    "relatedConcepts": ["prime-saturated multiplier", "Euler product formula", "primeFactors_mul", "ℚ-cast"],
+    "prerequisites": ["totient_eq_mul_prod_factors", "Nat.primeFactors_mul", "ring over ℚ"]
+  },
+  {
+    "id": "totient-oq09-ann-power",
+    "proofId": "euler-totient-oq-09",
+    "range": { "startLine": 75, "endLine": 100 },
+    "type": "theorem",
+    "title": "Power Law, Recurrence, and Square Case",
+    "content": "Three corollaries of the engine. `totient_pow`: the headline φ(nᵏ) = nᵏ⁻¹·φ(n) for k ≥ 1, by writing nᵏ = nᵏ⁻¹·n and feeding the engine the subset (nᵏ⁻¹).primeFactors ⊆ n.primeFactors (from `Nat.primeFactors_pow`, or the empty-set inclusion when k = 1). `totient_pow_succ`: the recurrence φ(nᵏ⁺¹) = n·φ(nᵏ), exhibiting the constant ratio n between successive totient powers. `totient_sq`: the k = 2 specialization φ(n²) = n·φ(n). The identity holds for every base including 0, requiring only k ≥ 1.",
+    "mathContext": "$\\varphi(n^k) = n^{k-1}\\varphi(n), \\quad \\varphi(n^{k+1}) = n\\,\\varphi(n^k), \\quad \\varphi(n^2) = n\\,\\varphi(n).$",
+    "significance": "critical",
+    "relatedConcepts": ["power law", "recurrence", "primeFactors_pow", "general base"],
+    "prerequisites": ["the engine lemma", "exponent arithmetic"]
+  },
+  {
+    "id": "totient-oq09-ann-dvd-dichotomy",
+    "proofId": "euler-totient-oq-09",
+    "range": { "startLine": 101, "endLine": 121 },
+    "type": "theorem",
+    "title": "Divisibility and the n ↦ 2n Dichotomy",
+    "content": "Two divisibility facts read straight off the power law: `pow_pred_dvd_totient_pow` (nᵏ⁻¹ ∣ φ(nᵏ), the leading power factor survives) and `totient_dvd_totient_pow` (φ(n) ∣ φ(nᵏ)). The doubling dichotomy specializes the p = 2 prime-scaling lemmas: `totient_two_mul_of_even` (φ(2n) = 2φ(n) when 2 ∣ n, from `Nat.totient_mul_of_prime_of_dvd`) and `totient_two_mul_of_odd` (φ(2n) = φ(n) when n is odd, from `Nat.totient_mul_of_prime_of_not_dvd`). These refine how doubling interacts with the parity of φ.",
+    "mathContext": "$n^{k-1} \\mid \\varphi(n^k),\\ \\varphi(n) \\mid \\varphi(n^k); \\qquad \\varphi(2n) = \\begin{cases} 2\\varphi(n) & 2 \\mid n \\\\ \\varphi(n) & 2 \\nmid n \\end{cases}.$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility", "parity dichotomy", "totient_mul_of_prime_of_dvd", "doubling map"],
+    "prerequisites": ["the power law", "single-prime scaling lemmas"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-09/index.ts
+++ b/src/data/proofs/euler-totient-oq-09/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ09.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOQ09Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOQ09Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOQ09Data: ProofData = {
+  proof: eulerTotientOQ09Proof,
+  annotations: eulerTotientOQ09Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `euler-totient-oq-09` (the general-base power law φ(nᵏ) = nᵏ⁻¹·φ(n), via the prime-saturated scaling engine).

The meta.json was already rich (overview, sections, conclusion with open questions, related problems) but the entry was missing its `index.ts` (so it rendered "proof not found" on the live site) and had no annotations. Improvements:

- **`index.ts`** — created (entry was previously unloadable by Vite's `import.meta.glob`).
- **`annotations.json`** — created with 4 annotations carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the shared-prime-support framing, the `totient_mul_of_primeFactors_subset` engine, the power law / recurrence / square case, and the divisibility facts + n↦2n dichotomy.

Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` — accurate (no `native_decide`; rests on Euler's product formula `Nat.totient_eq_mul_prod_factors`).

`pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)