### PR TITLE
fix(deployer): don't crash merge loop when a PR branch is checked out elsewhere

### DIFF
--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -376,7 +376,19 @@ merge_prs() {
             # which is shared across all worktrees and serialized via a single
             # lockfile. With ~60 worktrees doing concurrent rebases this lock
             # is the dominant failure mode ("could not lock config file").
-            (cd "$worktree_path" && git checkout --no-track -B "$branch" "origin/$branch")
+            #
+            # The checkout fails fatally ("branch is already used by worktree")
+            # when this branch is checked out in an active agent worktree that
+            # our find-worktree scan missed (e.g. a race, or a detached state at
+            # scan time). Under `set -e` that would crash the whole merge loop
+            # before build/deploy, so guard it: clean up the temp worktree, mark
+            # the PR failed, and continue with the rest.
+            if ! (cd "$worktree_path" && git checkout --no-track -B "$branch" "origin/$branch") 2>/dev/null; then
+                print_warning "Branch $branch is checked out elsewhere; skipping rebase for #$pr"
+                git worktree remove "$worktree_path" --force 2>/dev/null || true
+                ((++failed))
+                continue
+            fi
             temp_worktree=true
         fi
 


### PR DESCRIPTION
## Problem

The deployer's conflict-rebase phase in `sync-and-deploy.sh` creates a temporary worktree and runs `git checkout -B <branch>` in it. When `<branch>` is already checked out in an active agent worktree that the find-worktree scan missed (a race, or the worktree was in a detached state at scan time), this checkout fails fatally:

```
fatal: 'feature/enricher-2' is already used by worktree at '.loom/worktrees/enricher-2'
```

Under `set -euo pipefail` this aborted the **entire merge loop before build and deploy ever ran**. Observed this cycle crashing on `feature/enricher-2` (#28119), leaving a leaked `temp-rebase-*` worktree and skipping all remaining clean PRs + build + deploy.

## Fix

Guard the checkout: on failure, clean up the temp worktree, count the PR as `failed`, and `continue` to the next PR — exactly how the adjacent `git worktree add` failure is already handled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)