### PR TITLE
Fix stale 'axiomatized' annotation on fourier-series Riemann-Lebesgue lemma

### DIFF
--- a/src/data/proofs/fourier-series/annotations.json
+++ b/src/data/proofs/fourier-series/annotations.json
@@ -360,7 +360,7 @@
     },
     "type": "concept",
     "title": "Riemann-Lebesgue Lemma",
-    "content": "States the **Riemann-Lebesgue lemma**: Fourier coefficients of $L^2$ functions decay to zero, $c_n \\to 0$ as $|n| \\to \\infty$. This is axiomatized since the proof requires showing that $\\sum|c_n|^2 < \\infty$ (Parseval) implies $c_n \\to 0$.",
+    "content": "States and **proves** the **Riemann-Lebesgue lemma**: Fourier coefficients of $L^2$ functions decay to zero, $c_n \\to 0$ as $|n| \\to \\infty$. The proof (`fourierCoeff_tendsto_zero`) is fully machine-checked — no axiom, no sorry: from Parseval, $\\sum|c_n|^2 < \\infty$, so $\\|c_n\\|^2 \\to 0$ along the `cofinite` filter (`summable_sq_fourierCoeff.tendsto_cofinite_zero`); converting the squared-norm bound to a norm bound via `nlinarith` then gives $c_n \\to 0$.",
     "mathContext": "Stated: `fourier_coeff_tendsto_zero_of_L2 (f : Lp ℂ 2 haarAddCircle) : Tendsto (fun n : ℤ => fourierCoeff (⇑f) n) cofinite (𝓝 0)`. The `cofinite` filter means convergence along $|n| \\to \\infty$: for any $\\varepsilon > 0$, only finitely many $n$ have $|c_n| \\geq \\varepsilon$. This follows from $\\sum|c_n|^2 < \\infty$.",
     "significance": "key",
     "relatedConcepts": [


### PR DESCRIPTION
## Fix

The `ann-fs-riemann-lebesgue` annotation on `fourier-series` claimed the Riemann-Lebesgue lemma "is axiomatized," contradicting both the meta status and the Lean source.

## Evidence

**meta.json**: `status: verified`, `axiomCount: 0`, `sorries: 0`.

**Source** (`Proofs/FourierSeries.lean`): `fourierCoeff_tendsto_zero` (and its alias `fourier_coeff_tendsto_zero_of_L2`) is fully proved — the docstring reads "Proved from Parseval: Σ|ĉ_n|² < ∞ implies |ĉ_n|² → 0, hence ĉ_n → 0", and the body discharges it via `summable_sq_fourierCoeff.tendsto_cofinite_zero` + `nlinarith`. There are 0 `axiom` declarations and 0 sorries in the file.

**Before**: "...This **is axiomatized** since the proof requires showing that Σ|c_n|² < ∞ (Parseval) implies c_n → 0."

**After**: "...States and **proves** the Riemann-Lebesgue lemma ... fully machine-checked — no axiom, no sorry ..." with the actual proof steps.

Single-entry, annotation-only change (1 field). JSON validated.

---
Automated fix by lean-mechanic agent.