### PR TITLE
Enrich Sylvester's Sequence OQ-03 (doubly-exponential growth)

### DIFF
--- a/src/data/proofs/sylvester-sequence-oq-03/annotations.json
+++ b/src/data/proofs/sylvester-sequence-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "sylvester-sequence-oq-03",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Sylvester's Sequence and the Greedy Expansion of 1",
+    "content": "Sylvester's sequence 2, 3, 7, 43, 1807, … (a₀=2, a_{n+1}=aₙ²−aₙ+1) is the greedy Egyptian-fraction expansion of 1: each aₙ is the smallest integer keeping ∑ 1/aₖ below 1. The parent file SylvesterSequenceOQ01 supplies everything this file builds on — the definition syl, the exact partial-sum identity ∑_{k≤n} 1/aₖ = 1 − 1/(a_{n+1}−1), and the cast recurrence syl_cast_succ over ℤ. This entry adds the quantitative layer: exactly how fast the partial sums approach 1.",
+    "mathContext": "$a_0=2,\\ a_{n+1}=a_n^2-a_n+1$; OEIS A000058. Exact partial sum: $\\sum_{k=0}^{n} \\tfrac1{a_k} = 1 - \\tfrac1{a_{n+1}-1}$.",
+    "significance": "context",
+    "relatedConcepts": ["Egyptian fractions", "greedy algorithm", "Sylvester's sequence", "OEIS A000058", "reciprocal series"],
+    "prerequisites": ["recurrence relations", "Egyptian fractions"]
+  },
+  {
+    "id": "ann-gap-recurrence",
+    "proofId": "sylvester-sequence-oq-03",
+    "range": { "startLine": 40, "endLine": 44 },
+    "type": "insight",
+    "title": "The Gap Substitution: bₙ = aₙ − 1 Linearises the Constant Term",
+    "content": "This one-line lemma is the conceptual key to the whole file. Writing the recurrence in terms of the gap to 1, bₙ := aₙ − 1, the awkward aₙ²−aₙ+1 collapses to the pure quadratic map b_{n+1} = bₙ(bₙ+1) = bₙ²+bₙ. The +1 constant in the original recurrence is exactly absorbed by the shift, leaving a recurrence with no additive constant — which is what makes the squaring estimate b_{n+1} ≥ bₙ² clean. The Lean proof is just syl_cast_succ then ring over ℤ.",
+    "mathContext": "$a_{n+1}-1 = a_n(a_n-1)$, i.e. $b_{n+1} = b_n^2 + b_n$ with $b_n := a_n - 1$. Since $b_n \\ge 0$, $b_{n+1} \\ge b_n^2$.",
+    "significance": "key",
+    "relatedConcepts": ["change of variable", "quadratic map", "recurrence relations", "telescoping"],
+    "prerequisites": ["recurrence relations", "ring arithmetic"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "sylvester-sequence-oq-03",
+    "range": { "startLine": 46, "endLine": 71 },
+    "type": "technique",
+    "title": "Doubly-Exponential Lower Bound by Iterated Squaring",
+    "content": "two_pow_two_pow_le_syl_sub_one proves 2^(2ⁿ) ≤ a_{n+1}−1 by induction. The mechanism is iterated squaring: from b_{n+1} = bₙ(bₙ+1) ≥ bₙ² and the base value b₁ = 2, each step at least squares the previous bound, producing the tower 2, 4, 16, 256, …. The Lean proof abbreviates t = 2^(2^m), records t ≥ 2, lifts the inductive hypothesis to a_{m+1} ≥ t+1, rewrites via the gap recurrence, handles the exponent bookkeeping 2^(2^{m+1}) = (2^(2^m))² = t², and closes with nlinarith fed the product structure t·(t+1) ≥ t² = 2^(2^{m+1}).",
+    "mathContext": "$b_{n+1} \\ge b_n^2$ with $b_1 = 2 \\Rightarrow b_{n+1} \\ge 2^{2^n}$. Exponent step: $2^{2^{m+1}} = (2^{2^m})^2$.",
+    "significance": "key",
+    "relatedConcepts": ["iterated squaring", "doubly-exponential growth", "induction", "nlinarith"],
+    "prerequisites": ["mathematical induction", "exponent laws"]
+  },
+  {
+    "id": "ann-upper-bound",
+    "proofId": "sylvester-sequence-oq-03",
+    "range": { "startLine": 73, "endLine": 85 },
+    "type": "technique",
+    "title": "Matching Doubly-Exponential Upper Bound",
+    "content": "syl_le_two_pow_two_pow gives the other side of the sandwich, aₙ ≤ 2^(2ⁿ), by induction. The estimate a_{n+1} = aₙ²−aₙ+1 ≤ aₙ² (valid since aₙ ≥ 1) means each term is at most the square of the previous, and squaring the inductive bound 2^(2ⁿ) yields (2^(2ⁿ))² = 2^(2^{n+1}). Together with the lower bound this pins the growth rate to doubly-exponential from both sides, with no transcendental constant in sight.",
+    "mathContext": "$a_{n+1} = a_n^2 - a_n + 1 \\le a_n^2 \\le (2^{2^n})^2 = 2^{2^{n+1}}$, using $a_n \\ge 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["doubly-exponential growth", "induction", "two-sided bounds", "quadratic recurrence"],
+    "prerequisites": ["mathematical induction", "exponent laws"]
+  },
+  {
+    "id": "ann-convergence-rate",
+    "proofId": "sylvester-sequence-oq-03",
+    "range": { "startLine": 87, "endLine": 122 },
+    "type": "concept",
+    "title": "Sharp Convergence Rate and Strict Positivity of the Error",
+    "content": "Here the growth bound is converted into a convergence rate for the reciprocal series. The parent's exact identity rewrites the truncation error as 1 − Sₙ = 1/(a_{n+1}−1); feeding the doubly-exponential lower bound through one_div_le_one_div_of_le (with a cast from ℤ to ℚ) bounds it above by 1/2^(2ⁿ) (syl_error_le). Separately, positivity of the gap a_{n+1}−1 gives 1 − Sₙ > 0 (syl_error_pos), so every finite partial sum is strictly below 1. Growth and convergence are thus two readings of the same inequality.",
+    "mathContext": "$1 - S_n = \\dfrac{1}{a_{n+1}-1} \\le \\dfrac{1}{2^{2^n}}$, and $0 < 1 - S_n$ since $a_{n+1}-1 > 0$. Doubly-exponential decay of the error.",
+    "significance": "key",
+    "relatedConcepts": ["convergence rate", "truncation error", "reciprocal monotonicity", "Egyptian fractions"],
+    "prerequisites": ["telescoping sums", "rational inequalities", "limits"]
+  },
+  {
+    "id": "ann-capstone",
+    "proofId": "sylvester-sequence-oq-03",
+    "range": { "startLine": 124, "endLine": 137 },
+    "type": "concept",
+    "title": "Capstone: the Two-Sided Sandwich and Decay Rate",
+    "content": "sylvester_doubly_exponential packages the four results into a single conjunction: the lower bound 2^(2ⁿ) ≤ a_{n+1}−1, the upper bound aₙ ≤ 2^(2ⁿ), strict positivity 0 < 1−Sₙ, and the decay 1−Sₙ ≤ 1/2^(2ⁿ). This is the elementary, fully axiom-free shadow of the classical asymptotic aₙ ≈ E^(2^{n+1}) for Sylvester's constant E ≈ 1.2640… — the doubly-exponential shape captured without invoking E itself.",
+    "mathContext": "$2^{2^n} \\le a_{n+1}-1,\\quad a_n \\le 2^{2^n},\\quad 0 < 1-S_n \\le 2^{-2^n}$. Classical: $a_n \\approx E^{2^{n+1}}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Sylvester's constant", "doubly-exponential asymptotics", "two-sided bounds", "Egyptian fractions"],
+    "prerequisites": ["asymptotic analysis", "limits"]
+  }
+]

--- a/src/data/proofs/sylvester-sequence-oq-03/index.ts
+++ b/src/data/proofs/sylvester-sequence-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SylvesterSequenceOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sylvesterSequenceOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sylvesterSequenceOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sylvesterSequenceOq03Data: ProofData = {
+  proof: sylvesterSequenceOq03Proof,
+  annotations: sylvesterSequenceOq03Annotations,
+}

--- a/src/data/proofs/sylvester-sequence-oq-03/meta.json
+++ b/src/data/proofs/sylvester-sequence-oq-03/meta.json
@@ -5,8 +5,15 @@
   "description": "Sylvester's sequence a₀=2, a_{n+1}=aₙ²-aₙ+1 (2, 3, 7, 43, 1807, …) has reciprocals summing to 1; the base entries prove the exact partial sum ∑_{k≤n} 1/aₖ = 1 - 1/(a_{n+1}-1) (oq-01) and the qualitative limit ∑' 1/aₖ = 1 (oq-02), but neither quantifies how FAST. This entry supplies the missing quantitative layer: the gaps bₙ := aₙ-1 satisfy the exact recurrence b_{n+1} = bₙ(bₙ+1), which forces the doubly-exponential sandwich 2^(2ⁿ) ≤ a_{n+1}-1 (squaring the base b₁=2 into a tower) and aₙ ≤ 2^(2ⁿ). Combined with the exact error term this yields the convergence rate 0 < 1 - ∑_{k≤n} 1/aₖ ≤ 1/2^(2ⁿ) — doubly-exponential decay — and shows no finite partial sum ever reaches 1. Fully machine-checked with 0 sorries and 0 axioms.",
   "overview": {
     "historicalContext": "Sylvester's sequence (OEIS A000058), introduced by James Joseph Sylvester in 1880, is the greedy Egyptian-fraction expansion of 1: each term is the smallest denominator keeping the running reciprocal sum below 1. Its terms grow doubly exponentially — in fact aₙ = ⌊E^(2^{n+1}) + 1/2⌋ for Sylvester's constant E ≈ 1.26408… — which is exactly why the reciprocal series converges to 1 so explosively fast. The base gallery entries (oq-01, oq-02) establish the closed-form partial sums, pairwise coprimality, and the limit ∑' 1/aₖ = 1, but stop short of the quantitative growth and convergence rate that make the sequence remarkable.",
-    "keyInsight": "Track the gap to one, bₙ := aₙ - 1. The recurrence collapses to the clean quadratic map b_{n+1} = aₙ(aₙ-1) = bₙ(bₙ+1) = bₙ² + bₙ. Since bₙ ≥ 0 this gives b_{n+1} ≥ bₙ², so the single base value b₁ = 2 squares into the tower 2, 4, 16, 256, … i.e. 2^(2ⁿ) ≤ b_{n+1}. Symmetrically a_{n+1} = aₙ² - aₙ + 1 ≤ aₙ² gives aₙ ≤ 2^(2ⁿ). Plugging the lower bound into the parent's exact error identity 1 - Sₙ = 1/(a_{n+1}-1) turns the qualitative limit into the quantitative decay 1 - Sₙ ≤ 2^(-2ⁿ).",
-    "significance": "This is the quantitative companion to the base entries: oq-01 gives the exact error term, oq-02 proves it vanishes, and this entry pins down its size as doubly-exponentially small. The doubly-exponential growth bracket is the elementary, axiom-free shadow of the transcendental asymptotic aₙ ≈ E^(2^{n+1}), and the strict positivity of the error formalizes that 1 is approached only in the limit — the Egyptian-fraction expansion of 1 never terminates."
+    "problemStatement": "For Sylvester's sequence a₀=2, a_{n+1}=aₙ²−aₙ+1, prove the two-sided doubly-exponential growth bracket 2^(2ⁿ) ≤ a_{n+1}−1 and aₙ ≤ 2^(2ⁿ), and deduce the sharp convergence rate of its reciprocal series: the truncation error satisfies 0 < 1 − ∑_{k≤n} 1/aₖ ≤ 1/2^(2ⁿ). In particular every finite partial sum lies strictly below 1, so the Egyptian-fraction expansion of 1 never terminates.",
+    "proofStrategy": "Track the gap to one, bₙ := aₙ − 1. The recurrence collapses to the clean quadratic map b_{n+1} = aₙ(aₙ−1) = bₙ(bₙ+1) = bₙ² + bₙ (syl_sub_one_succ). Since bₙ ≥ 0 this gives b_{n+1} ≥ bₙ², so the single base value b₁ = 2 squares into the tower 2, 4, 16, 256, …, i.e. 2^(2ⁿ) ≤ b_{n+1} (two_pow_two_pow_le_syl_sub_one, by induction with exponent bookkeeping 2^(2^{m+1})=(2^(2^m))² and nlinarith). Symmetrically a_{n+1} = aₙ²−aₙ+1 ≤ aₙ² gives aₙ ≤ 2^(2ⁿ) (syl_le_two_pow_two_pow). Plugging the lower bound into the parent's exact error identity 1 − Sₙ = 1/(a_{n+1}−1) (via one_div_le_one_div_of_le) turns the qualitative limit into the quantitative decay 1 − Sₙ ≤ 2^(−2ⁿ) (syl_error_le), while positivity of the gap gives strict positivity of the error (syl_error_pos).",
+    "keyInsights": [
+      "The whole quantitative story is driven by one substitution: replacing aₙ with the gap bₙ = aₙ−1 turns the recurrence aₙ²−aₙ+1 into the pure quadratic map b_{n+1} = bₙ²+bₙ, with no constant term to obstruct the squaring estimate.",
+      "Because bₙ ≥ 0 forces b_{n+1} = bₙ(bₙ+1) ≥ bₙ², iterating squares the base b₁=2 into the tower 2^(2ⁿ) — doubly-exponential growth obtained from a single base value plus monotone squaring, no transcendental constant needed.",
+      "Growth and convergence are the same fact read two ways: the lower bound 2^(2ⁿ) ≤ a_{n+1}−1 is exactly what the parent's error identity 1−Sₙ = 1/(a_{n+1}−1) needs to become the decay 1−Sₙ ≤ 2^(−2ⁿ).",
+      "Strict positivity of every finite error (the gap a_{n+1}−1 is always positive) is the formal statement that 1 is reached only in the limit — the greedy Egyptian-fraction expansion of 1 never terminates.",
+      "The elementary 2^(2ⁿ) sandwich is the axiom-free shadow of the transcendental asymptotic aₙ ≈ E^(2^{n+1}) with Sylvester's constant E ≈ 1.2640…: the proof captures the doubly-exponential shape without ever invoking E."
+    ]
   },
   "mainTheorems": [
     {
@@ -41,16 +48,57 @@
     }
   ],
   "sections": [
-    "Imports and Module Docstring",
-    "Exact Gap Recurrence",
-    "Doubly-Exponential Lower Bound",
-    "Doubly-Exponential Upper Bound",
-    "Quantitative Convergence Rate and Strict Positivity",
-    "Capstone Sandwich"
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Module Docstring",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Imports Mathlib and the parent SylvesterSequenceOQ01 (which defines syl and proves the exact partial sum and the cast recurrence syl_cast_succ), then opens the SylvesterSequenceOQ01 namespace. The docstring frames the file as the missing quantitative layer above the base entries' exact identity and qualitative limit."
+    },
+    {
+      "id": "gap-recurrence",
+      "title": "Exact Gap Recurrence",
+      "startLine": 40,
+      "endLine": 44,
+      "summary": "syl_sub_one_succ: over ℤ, (a_{n+1})−1 = aₙ·(aₙ−1), proved by rewriting with the cast recurrence syl_cast_succ and ring. Equivalently b_{n+1} = bₙ²+bₙ for the gaps bₙ := aₙ−1 — the quadratic map that drives both growth bounds."
+    },
+    {
+      "id": "lower-bound",
+      "title": "Doubly-Exponential Lower Bound",
+      "startLine": 46,
+      "endLine": 71,
+      "summary": "two_pow_two_pow_le_syl_sub_one: 2^(2ⁿ) ≤ a_{n+1}−1, by induction. The base case b₁=2 gives equality; the step abbreviates t = 2^(2^m), uses the inductive bound a_{m+1} ≥ t+1, the gap recurrence, and the exponent identity 2^(2^{m+1}) = (2^(2^m))², closing with nlinarith on the product t·(t bound)."
+    },
+    {
+      "id": "upper-bound",
+      "title": "Doubly-Exponential Upper Bound",
+      "startLine": 73,
+      "endLine": 85,
+      "summary": "syl_le_two_pow_two_pow: aₙ ≤ 2^(2ⁿ), by induction from a_{n+1} = aₙ²−aₙ+1 ≤ aₙ² ≤ (2^(2ⁿ))² = 2^(2^{n+1}). Uses the cast recurrence, the lower bound aₙ ≥ 1 (two_le_syl), the squaring exponent identity, and nlinarith."
+    },
+    {
+      "id": "convergence-rate",
+      "title": "Quantitative Convergence Rate and Strict Positivity",
+      "startLine": 87,
+      "endLine": 122,
+      "summary": "syl_sub_one_pos_rat establishes the gap is a positive rational. syl_error_le bounds the truncation error 1 − ∑_{k≤n} 1/aₖ = 1/(a_{n+1}−1) (parent identity syl_partial_sum) above by 1/2^(2ⁿ) via one_div_le_one_div_of_le and the integer lower bound cast to ℚ. syl_error_pos gives strict positivity of the error, so no finite partial sum reaches 1."
+    },
+    {
+      "id": "capstone",
+      "title": "Capstone Sandwich",
+      "startLine": 124,
+      "endLine": 137,
+      "summary": "sylvester_doubly_exponential bundles the four results into one statement: 2^(2ⁿ) ≤ a_{n+1}−1, aₙ ≤ 2^(2ⁿ), 0 < 1−Sₙ, and 1−Sₙ ≤ 1/2^(2ⁿ) — the two-sided growth bracket together with the matching strictly-positive, doubly-exponentially-small convergence rate."
+    }
   ],
   "conclusion": {
-    "summary": "The gaps bₙ = aₙ - 1 obey the quadratic map b_{n+1} = bₙ(bₙ+1), which sandwiches the sequence between 2^(2ⁿ) and forces aₙ ≤ 2^(2ⁿ). The truncation error of the reciprocal series is therefore strictly positive and at most 2^(-2ⁿ) — doubly-exponentially small — quantifying the convergence the base entries leave qualitative.",
-    "takeaway": "A single quadratic recurrence on the gap to 1 turns Sylvester's sequence into a doubly-exponential tower, simultaneously bounding its growth from both sides and giving the sharp decay rate of its Egyptian-fraction approximation to 1."
+    "summary": "The gaps bₙ = aₙ − 1 obey the quadratic map b_{n+1} = bₙ(bₙ+1), which sandwiches the sequence between 2^(2ⁿ) and forces aₙ ≤ 2^(2ⁿ). The truncation error of the reciprocal series is therefore strictly positive and at most 2^(−2ⁿ) — doubly-exponentially small — quantifying the convergence the base entries leave qualitative. A single quadratic recurrence on the gap to 1 turns Sylvester's sequence into a doubly-exponential tower, simultaneously bounding its growth from both sides and giving the sharp decay rate of its Egyptian-fraction approximation to 1.",
+    "implications": "This is the quantitative companion to the base entries: oq-01 gives the exact error term, oq-02 proves it vanishes, and this entry pins down its size as doubly-exponentially small. The doubly-exponential growth bracket is the elementary, axiom-free shadow of the transcendental asymptotic aₙ ≈ E^(2^{n+1}), and the strict positivity of the error formalizes that 1 is approached only in the limit — the Egyptian-fraction expansion of 1 never terminates. The same gap-substitution technique applies to any sequence with a quadratic recurrence whose constant term is absorbed by the shift.",
+    "openQuestions": [
+      "Sharpen the bracket to the true asymptotic aₙ = ⌊E^(2^{n+1}) + 1/2⌋, formalizing the existence of Sylvester's constant E = lim aₙ^(1/2^{n+1}) and the doubly-exponential convergence of that limit — a genuinely transcendental refinement beyond the elementary 2^(2ⁿ) bounds proved here.",
+      "Extend the quantitative analysis to generalized Sylvester sequences a_{n+1} = aₙ²−aₙ+k or other greedy Egyptian-fraction expansions, identifying when the same gap-quadratic-map argument yields a doubly-exponential growth/convergence pair.",
+      "Relate the doubly-exponential denominator growth to the irrationality measure of the limit ∑ 1/aₖ for perturbed sequences (here the limit is the rational 1), connecting Sylvester-type growth to Diophantine approximation."
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Enrichment pass for `sylvester-sequence-oq-03` (quality 25, pass 0).

## What was missing
- **No `index.ts`** — the proof was unloadable on the live site. Created it from the template.
- **No `annotations.json`** — created with 6 inline annotations (each with `mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`) covering the context, the gap substitution bₙ=aₙ−1, both growth bounds, the convergence rate, and the capstone.
- **Non-conforming `sections`** — they were a plain array of strings; rewrote as `ProofSection` objects with `startLine`/`endLine`/`summary` mapped to the actual Lean line ranges.
- **`overview` was a non-standard shape** (`historicalContext`/`keyInsight`/`significance`) — rounded out to the full `ProofOverview` (`problemStatement`, `proofStrategy`, and a 5-element `keyInsights` array), preserving the existing content.
- **`conclusion`** — kept the summary, added `implications` and 3 `openQuestions` (Sylvester-constant asymptotic, generalized recurrences, irrationality measure).

## Accuracy notes
- meta.json reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: original`; confirmed against the Lean source (no `axiom`/`sorry`/structure-encoded assumptions; no `native_decide`). No status/badge changes.
- All annotations match the actual theorems (syl_sub_one_succ, two_pow_two_pow_le_syl_sub_one, syl_le_two_pow_two_pow, syl_error_le, syl_error_pos, sylvester_doubly_exponential). Cross-reference slugs (oq-01, oq-02, harmonic-divergence) verified to exist.

Note: pushed to a dedicated branch because the previous enrichment PR (#28157) is still open on `feature/enricher-1`.

`pnpm build` passes.