### PR TITLE
Fix stale 'axiomatized' annotations on erdos-340-greedy-sidon

### DIFF
--- a/src/data/proofs/erdos-340-greedy-sidon/annotations.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/annotations.json
@@ -217,15 +217,15 @@
       "endLine": 386
     },
     "type": "concept",
-    "title": "Axiomatized Erdos-Turan Upper Bound",
-    "content": "Axiomatizes the tight Erdos-Turan upper bound: $|A| \\leq \\sqrt{N} + \\sqrt[4]{N} + 1$ for Sidon $A \\subseteq [1, N]$. The formalization uses `Nat.sqrt N + Nat.sqrt (Nat.sqrt N) + 1` as the Lean expression for $\\lfloor\\sqrt{N}\\rfloor + \\lfloor N^{1/4}\\rfloor + 1$.\n\nThis is axiomatized because the proof requires counting sums rather than differences. The idea: $|A + A| \\leq 2N$ (sums are at most $2N$) and $|A + A| \\geq \\binom{|A|+1}{2}$ (all sums distinct by Sidon), giving $|A|(|A|+1)/2 \\leq 2N$, hence $|A| \\leq \\sqrt{4N} = 2\\sqrt{N}$. The tighter $\\sqrt{N} + O(N^{1/4})$ requires a careful double-counting argument using modular arithmetic.",
-    "mathContext": "Axiom: $|A| \\leq \\lfloor\\sqrt{N}\\rfloor + \\lfloor N^{1/4}\\rfloor + 1$ for Sidon $A \\subseteq [1,N]$. Known result (Erdos-Turan, 1941), not yet formalized.",
+    "title": "Erdős–Turán Upper Bound — Axiom Retired",
+    "content": "This region documents that the sharp **Erdős–Turán upper bound** $|A| \\leq \\sqrt{N} + \\sqrt[4]{N} + O(1)$ for Sidon $A \\subseteq [1, N]$ is **no longer an axiom**. An earlier draft carried a single axiom `sidon_upper_bound`; it has been retired in favour of the verified, axiom-free bound `Erdos340.sidon_card_le_sqrt : |A| ≤ √N + ⁴√N + 2`, proved in `Erdos340SidonErdosTuran.lean` by optimising the master window inequality `sidon_window_key`. The weaker elementary difference bound $\\sqrt{2N} + 1$ is also proved in this file as `sidon_upper_bound_weak`. With the axiom gone, this file is entirely axiom-free.",
+    "mathContext": "Erdős–Turán (1941): $|A| \\leq \\sqrt{N} + N^{1/4} + O(1)$ for Sidon $A \\subseteq [1,N]$. Formalized axiom-free as `sidon_card_le_sqrt` (constant $+2$). The weak form $|A| \\leq \\sqrt{2N}+1$ (`sidon_upper_bound_weak`) follows by difference counting: the $\\binom{|A|}{2}$ distinct positive differences all lie in $[1, N-1]$, so $|A|(|A|-1)/2 \\leq N-1$.",
     "significance": "supporting",
     "relatedConcepts": [
-      "axiomatized result",
-      "Erdos-Turan bound",
-      "sum counting",
-      "modular arithmetic"
+      "Erdős–Turán bound",
+      "Sidon sets",
+      "difference counting",
+      "axiom-free formalization"
     ],
     "prerequisites": [
       "Sidon set theory",
@@ -240,21 +240,21 @@
       "endLine": 443
     },
     "type": "concept",
-    "title": "Greedy Sidon Sequence Axiomatization",
-    "content": "Axiomatizes the greedy (Mian-Chowla) Sidon sequence and its key properties:\n\n- **`greedySidonSeq`**: The sequence function $\\mathbb{N} \\to \\mathbb{N}$.\n- **`greedySidonSeq_zero`**: $a_0 = 1$.\n- **`greedySidonSeq_strictMono`**: The sequence is strictly increasing.\n- **`greedySidonSeq_isSidon`**: The first $n+1$ terms always form a Sidon set.\n- **`greedySidonSeq_greedy`**: The greedy property — $a_{n+1}$ is the *smallest* value exceeding $a_n$ that maintains Sidon. No value between $a_n$ and $a_{n+1}$ could be added.\n- **Values** (`greedySidon_0` through `greedySidon_10`): First 11 terms: 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97 (OEIS A005282).\n\nThe axiomatization is necessary because defining the sequence constructively would require well-founded recursion on a complex predicate (minimality over the Sidon-preserving candidates). The values match the OEIS A005282 entry.\n\n**Why greedy is interesting:** Despite its simplicity, the greedy algorithm produces a remarkably dense Sidon set. The $n$-th term grows roughly as $n^3$ (based on the $N^{1/3}$ counting bound), but Erdos conjectured the true growth is nearly $n^2$ (from $N^{1/2-\\varepsilon}$).",
-    "mathContext": "Greedy Sidon sequence: $a_0 = 1$, $a_{n+1} = \\min\\{m > a_n : \\{a_0, \\ldots, a_n, m\\}$ is Sidon$\\}$. First terms: $1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97$.",
+    "title": "Greedy Sidon Sequence — Explicit Construction",
+    "content": "Builds the greedy (Mian–Chowla) Sidon sequence **explicitly and axiom-free** — what an earlier draft left as opaque existence axioms is now a genuine recursive definition with proved properties:\n\n- **`CanAddProp` / `instDecidableIsSidon`**: `IsSidon` is decidable (the four quantifiers are bounded by membership in `A`), which makes the greedy 'least valid extension' well-defined via `Nat.find`.\n- **`sidon_insert_of_large`**: if `m` exceeds every element of a Sidon set `A` and realises no collision `m + a = c + d`, then `insert m A` is Sidon.\n- **`sidon_exists_extension`**: every finite Sidon set extends, above any bound `B`, to a strictly larger Sidon set, with explicit witness `max (B+1) (2·(sup A)+1)`. This proves the greedy construction never gets stuck.\n\nThe greedy sequence is then defined as `greedySidonSeq n = (greedyPair n).1`, and its monotonicity and Sidon-ness are theorems (next annotation). The first 11 terms are 1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97 (OEIS A005282).",
+    "mathContext": "Greedy Sidon sequence: $a_0 = 1$, $a_{n+1} = \\min\\{m > a_n : \\{a_0, \\ldots, a_n, m\\}$ is Sidon$\\}$, well-defined because `sidon_exists_extension` guarantees a valid `m` always exists (witness $2\\cdot\\sup A + 1$). First terms: $1, 2, 4, 8, 13, 21, 31, 45, 66, 81, 97$.",
     "significance": "key",
     "relatedConcepts": [
       "greedy algorithm",
       "Mian-Chowla sequence",
       "OEIS A005282",
-      "well-founded recursion",
-      "axiomatization"
+      "decidable IsSidon",
+      "Nat.find"
     ],
     "prerequisites": [
       "IsSidon definition",
-      "greedy algorithms",
-      "strict monotonicity"
+      "Nat.find",
+      "Decidable instances"
     ]
   },
   {
@@ -265,22 +265,21 @@
       "endLine": 505
     },
     "type": "insight",
-    "title": "Growth Rate Bounds and Erdos's Conjecture (#340)",
-    "content": "The climax of the module: the growth rate of the greedy Sidon sequence.\n\n**`greedySidon_growth_third`** (axiomatized): The greedy sequence contains $\\Omega(N^{1/3})$ elements up to $N$. This 'trivial' bound follows from the worst-case analysis: at step $n$, the greedy element is at most $\\sim n^3/6$ (since $n(n-1)/2$ differences use up values), so inverting gives $n \\geq \\Omega(N^{1/3})$.\n\n**`erdos_340`** (axiomatized, OPEN): Erdos's conjecture that for all $\\varepsilon > 0$, the greedy sequence contains $\\Omega(N^{1/2-\\varepsilon})$ elements up to $N$. Both are stated using `Filter.atTop` for the 'eventually for all large $N$' quantification.\n\nThe documentation outlines five potential research approaches: improving the $N^{1/3}$ bound, structural analysis of the difference set, probabilistic comparison with random Sidon sets, local-to-global arguments on intervals $[N, 2N]$, and density increment strategies analogous to Roth's theorem.\n\n**The 80-year gap:** Between the $N^{1/3}$ lower bound (trivial) and the conjectured $N^{1/2-\\varepsilon}$ lies one of the most persistent open problems in additive combinatorics. Any improvement beyond $1/3$ in the exponent would be publishable and significant.",
-    "mathContext": "Known: $|A \\cap [1,N]| \\geq \\Omega(N^{1/3})$. Conjectured (Erdos #340): $\\forall \\varepsilon > 0$, $|A \\cap [1,N]| \\geq \\Omega(N^{1/2-\\varepsilon})$. STATUS: OPEN. The exponent gap $1/3 \\to 1/2$ is unresolved since the 1940s.",
+    "title": "Greedy Recursion and Erdős's Open Growth Conjecture (#340)",
+    "content": "The greedy recursion itself, plus context on the open problem. `nextSidon S b` is the least `m > b` keeping `insert m S` Sidon (via `Nat.find`, with a junk fallback `b+1` that `nextSidon_spec` shows never triggers for Sidon `S`); `greedyPair` threads `(aₙ, {a₀,…,aₙ})` from the seed `(1, {1})`; and `greedySidonSeq n = (greedyPair n).1`. From `nextSidon_spec` the sequence is **proved** strictly increasing (`greedySidonSeq_strictMono`) and every initial segment is **proved** Sidon (`greedySeqSet_isSidon`). All of this is axiom-free.\n\n**The open conjecture (Erdős #340) — discussed, not formalized as a theorem:** the trivial counting bound gives $|A \\cap [1,N]| \\gg N^{1/3}$ (at step $n$ the greedy term is $\\lesssim n^3$, since $\\binom{n}{2}$ differences are used up), whereas Erdős conjectured $|A \\cap [1,N]| \\gg N^{1/2-\\varepsilon}$. This $1/3 \\to 1/2$ exponent gap has been open since the 1940s. Neither growth bound is stated as a Lean theorem in this file — only the construction and its proved Sidon/monotonicity properties are.",
+    "mathContext": "Greedy recursion: `nextSidon S b = if ∃ m > b, IsSidon (insert m S) then Nat.find _ else b+1`. Proved here: `greedySidonSeq_strictMono`, `greedySeqSet_isSidon`. OPEN (Erdős #340, not formalized in this file): $|A \\cap [1,N]| \\gg N^{1/2-\\varepsilon}$ versus the trivial $\\gg N^{1/3}$; the exponent gap is unresolved since the 1940s.",
     "significance": "key",
     "relatedConcepts": [
+      "greedy recursion",
+      "Nat.find",
       "open conjecture",
       "growth rate",
-      "Filter.atTop",
-      "asymptotic bounds",
-      "density increment",
-      "Roth's theorem analogy"
+      "asymptotic bounds"
     ],
     "prerequisites": [
       "greedy Sidon sequence",
-      "asymptotic analysis",
-      "Filter.atTop"
+      "Nat.find",
+      "strict monotonicity"
     ]
   }
 ]


### PR DESCRIPTION
## Fix

Three annotations on `erdos-340-greedy-sidon` described the entry as containing axioms and two **axiomatized** theorems, contradicting the meta status and the current Lean source.

## Evidence

**meta.json**: `status: verified`, `axiomCount: 0`, `sorries: 0`.

**Source** (`Proofs/Erdos340GreedySidon.lean`, 648 lines, 0 axioms / 0 sorries): the file was rewritten to be entirely axiom-free.
- The Erdős–Turán upper-bound axiom was retired — the source docstring reads *"Erdős–Turán upper bound (no longer an axiom)"* and routes through the verified `sidon_card_le_sqrt`; `sidon_upper_bound_weak` is proved here.
- The greedy sequence is now **explicitly constructed** (`greedyPair`, `nextSidon`, `greedySidonSeq`) with proved `greedySidonSeq_strictMono` and `greedySeqSet_isSidon` — the docstring notes *"This **defines** — rather than axiomatizes — the sequence"* and *"Was `axiom greedySidonSeq_strictMono`; now a theorem"*.
- The theorems `erdos_340` and `greedySidon_growth_third` referenced by the annotations **no longer exist** in the file.

**Before**: titles "**Axiomatized** Erdos-Turan Upper Bound", "Greedy Sidon Sequence **Axiomatization**"; content "Axiomatizes…", "This is axiomatized…", "`erdos_340` (axiomatized, OPEN)", "`greedySidon_growth_third` (axiomatized)".

**After**: titles "Erdős–Turán Upper Bound — Axiom Retired", "Greedy Sidon Sequence — Explicit Construction", "Greedy Recursion and Erdős's Open Growth Conjecture (#340)"; content describes the actual axiom-free construction and proved theorems, and frames the open #340 conjecture as discussed but not formalized as a theorem.

Single-entry, annotation-only change (3 annotations). 0 residual "axiomatiz" mentions; JSON validated.

---
Automated fix by lean-mechanic agent.