### PR TITLE
research(geometric-series-oq-01-oq-03-oq-01): Abel's theorem regular direction at full strength [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ03OQ01.lean
@@ -1,0 +1,121 @@
+import Mathlib.Analysis.Complex.AbelLimit
+import Proofs.GeometricSeriesOQ01OQ03
+import Mathlib.Tactic
+
+/-
+# Abel's Theorem in the Regular Direction, at Full Strength
+
+## What This Proves
+The parent entry (`geometric-series-oq-01-oq-03`, *Abel Summability at the
+Boundary*) established the regularity of Abel summation only for the geometric
+family `aₙ = rⁿ` with `|r| < 1`: there `geom_abel_regular` shows the Abel sum
+`∑ₙ rⁿ xⁿ → 1/(1−r)` agrees with the ordinary sum.
+
+This entry answers the parent's open question `oq-01` by proving the regularity
+of Abel summation **for every convergent series**, not just geometric ones:
+
+> **Abel's theorem (regular direction).** If `∑ₙ aₙ` converges to `L`, then the
+> power series `A(x) = ∑ₙ aₙ xⁿ` converges for `x ∈ [0,1)` and `A(x) → L` as
+> `x → 1⁻`. Equivalently, every convergent series is *Abel summable* to its
+> ordinary sum.
+
+The geometric case studied by the parent is recovered here as a strict special
+case (`geom_abelSummableTo_of_general`), turning the parent's hand computation
+into a *consistency check* of the general theorem.
+
+## Approach
+The deep analytic core — the left-continuity of the Abel function at `1` — is
+**Mathlib's** `Real.tendsto_tsum_powerSeries_nhdsWithin_lt` (Abel's limit
+theorem, proved there via summation by parts on a Stolz sector). The work of
+this entry is to package that theorem against the parent's `AbelSummableTo`
+predicate, which additionally bundles the on-disk-of-convergence summability:
+
+1. **Summability on `[0,1)`** (`summable_mul_pow_of_summable`): a convergent
+   series has bounded terms (`aₙ → 0`), so for `0 ≤ x < 1` the power series is
+   dominated termwise by the geometric series `C·xⁿ` and converges by the
+   comparison test.
+2. **Regularity** (`abel_tendsto_of_tendsto_partial`): the left-limit at `1`,
+   directly from Mathlib's Abel limit theorem applied to the partial sums.
+3. **Synthesis** (`summable_abelSummableTo`, `hasSum_abelSummableTo`): combine
+   1 and 2 into the parent's `AbelSummableTo` predicate.
+4. **Consistency** (`geom_abelSummableTo_of_general`): specialise to `aₙ = rⁿ`,
+   `|r| < 1`, recovering the parent's geometric Abel sum `1/(1−r)`.
+
+## Honest Scope
+This is a *packaging* result: the hard theorem (left-continuity) is Mathlib's.
+The contribution is the general regularity statement in the parent's vocabulary,
+the dominated-convergence summability lemma, and the explicit reduction of the
+geometric boundary case to the general theorem.
+-/
+
+namespace GeometricSeriesOQ01OQ03OQ01
+
+open Filter Topology GeometricSeriesOQ01OQ03
+
+/-- The power series of a convergent real series converges on the open disc
+`[0,1)`. A convergent series has terms tending to `0`, hence bounded by some
+`C`; for `0 ≤ x < 1` the terms are then dominated by the geometric series
+`C·xⁿ`, and the comparison test gives summability. -/
+theorem summable_mul_pow_of_summable {a : ℕ → ℝ} (ha : Summable a) {x : ℝ}
+    (hx0 : 0 ≤ x) (hx1 : x < 1) : Summable (fun n => a n * x ^ n) := by
+  -- `aₙ → 0`, so `|aₙ| → 0` and the range of `|a|` is bounded above by some `C`.
+  have habs : Tendsto (fun n => |a n|) atTop (𝓝 0) := by
+    have h : Tendsto (fun n => |a n|) atTop (𝓝 |(0 : ℝ)|) :=
+      (continuous_abs.tendsto 0).comp ha.tendsto_atTop_zero
+    simpa [Function.comp] using h
+  obtain ⟨C, hC⟩ := habs.bddAbove_range
+  -- Dominating geometric series `C·xⁿ`.
+  have hgeom : Summable (fun n => C * x ^ n) :=
+    (summable_geometric_of_lt_one hx0 hx1).mul_left C
+  refine Summable.of_norm_bounded hgeom (fun n => ?_)
+  have hbound : |a n| ≤ C := hC (Set.mem_range_self n)
+  have hxn : (0 : ℝ) ≤ x ^ n := pow_nonneg hx0 n
+  calc ‖a n * x ^ n‖ = |a n| * x ^ n := by
+            rw [Real.norm_eq_abs, abs_mul, abs_pow, abs_of_nonneg hx0]
+    _ ≤ C * x ^ n := mul_le_mul_of_nonneg_right hbound hxn
+
+/-- **Abel's limit theorem, regular direction (left-limit form).** If the partial
+sums of `a` converge to `L`, then the Abel function `x ↦ ∑ₙ aₙ xⁿ` tends to `L`
+as `x → 1⁻`. This is `Real.tendsto_tsum_powerSeries_nhdsWithin_lt` from Mathlib,
+restated in the local notation. -/
+theorem abel_tendsto_of_tendsto_partial {a : ℕ → ℝ} {L : ℝ}
+    (h : Tendsto (fun n => ∑ i ∈ Finset.range n, a i) atTop (𝓝 L)) :
+    Tendsto (fun x => ∑' n, a n * x ^ n) (𝓝[<] (1 : ℝ)) (𝓝 L) :=
+  Real.tendsto_tsum_powerSeries_nhdsWithin_lt h
+
+/-- **Abel's theorem, regular direction (Summable form).** Every convergent real
+series `∑ₙ aₙ` is Abel summable to its ordinary sum `∑' n, aₙ`. This answers the
+parent open question `oq-01`: regularity of Abel summation for *every* convergent
+series, not only geometric ones. -/
+theorem summable_abelSummableTo {a : ℕ → ℝ} (ha : Summable a) :
+    AbelSummableTo a (∑' n, a n) := by
+  refine ⟨fun x hx0 hx1 => summable_mul_pow_of_summable ha hx0 hx1, ?_⟩
+  exact abel_tendsto_of_tendsto_partial ha.hasSum.tendsto_sum_nat
+
+/-- **Abel's theorem, regular direction (HasSum form).** If `a` sums to `L` then
+`a` is Abel summable to the same value `L`. -/
+theorem hasSum_abelSummableTo {a : ℕ → ℝ} {L : ℝ} (ha : HasSum a L) :
+    AbelSummableTo a L := by
+  have hL : L = ∑' n, a n := ha.tsum_eq.symm
+  rw [hL]
+  exact summable_abelSummableTo ha.summable
+
+/-- **Consistency check with the parent's geometric case.** For `|r| < 1` the
+geometric series `∑ rⁿ` converges to `1/(1−r)`, so by the general theorem it is
+Abel summable to `1/(1−r)` — recovering the parent's `geom_abelSummableTo`
+purely as a special case of Abel's theorem, with the boundary regularity no
+longer computed by hand but inherited from the general statement. -/
+theorem geom_abelSummableTo_of_general {r : ℝ} (hr : |r| < 1) :
+    AbelSummableTo (fun n => r ^ n) (1 / (1 - r)) := by
+  have hsum : HasSum (fun n => r ^ n) (1 - r)⁻¹ := hasSum_geometric_of_abs_lt_one hr
+  have h := hasSum_abelSummableTo hsum
+  simpa [one_div] using h
+
+/-- **The general theorem subsumes the parent.** The parent's geometric
+Abel-summability statement is definitionally the specialisation proved above;
+this records the agreement explicitly. -/
+theorem subsumes_parent_geom {r : ℝ} (hr : |r| < 1) :
+    AbelSummableTo (fun n => r ^ n) (1 / (1 - r)) :=
+  geom_abelSummableTo_of_general hr
+
+end GeometricSeriesOQ01OQ03OQ01

--- a/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": "ann-gsoq0301-summable-disc",
+    "proofId": "geometric-series-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 75
+    },
+    "type": "technique",
+    "title": "On-disc summability by domination against a geometric series",
+    "content": "summable_mul_pow_of_summable supplies the part of the parent's AbelSummableTo predicate that Mathlib's Abel theorem does not give: convergence of the power series ∑ₙ aₙ xⁿ for 0 ≤ x < 1. The argument is soft. A convergent series has terms tending to 0 (Summable.tendsto_atTop_zero), so |aₙ| → 0 and its range is bounded above by some C (Filter.Tendsto.bddAbove_range). For 0 ≤ x < 1 each term then satisfies ‖aₙ xⁿ‖ = |aₙ| xⁿ ≤ C xⁿ, and the geometric majorant C xⁿ is summable (summable_geometric_of_lt_one, scaled by C), so the comparison test Summable.of_norm_bounded closes it. The bound by C xⁿ rather than |aₙ| is essential: a conditionally convergent series (∑ (−1)ⁿ/n) is not absolutely summable, so |aₙ xⁿ| ≤ |aₙ| would not give a summable majorant.",
+    "mathContext": "$\\|a_n x^n\\| = |a_n|\\,x^n \\le C x^n$ for $0 \\le x < 1$, with $\\sum_n C x^n < \\infty$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "comparison test",
+      "geometric majorant",
+      "bounded sequence",
+      "conditional convergence",
+      "radius of convergence"
+    ],
+    "prerequisites": [
+      "summability",
+      "geometric series"
+    ]
+  },
+  {
+    "id": "ann-gsoq0301-abel-limit",
+    "proofId": "geometric-series-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 81,
+      "endLine": 84
+    },
+    "type": "key-step",
+    "title": "The deep core: Mathlib's Abel limit theorem",
+    "content": "abel_tendsto_of_tendsto_partial is a restatement of Mathlib's Real.tendsto_tsum_powerSeries_nhdsWithin_lt, and this is where all the analytic weight sits. For the geometric family aₙ = rⁿ the parent could compute the boundary limit by hand because the Abel function has the closed form 1/(1−rx); for an arbitrary convergent series there is no closed form, and left-continuity at 1 is the genuine summation-by-parts argument on a Stolz sector that Mathlib carries out upstream. This entry does not reprove it — it consumes it. The hypothesis is exactly 'the partial sums converge to L'; the conclusion is the radial limit on the left-neighborhood filter 𝓝[<] 1.",
+    "mathContext": "Mathlib: $\\big(\\textstyle\\sum_{i<n} a_i \\to L\\big) \\Rightarrow \\big(\\sum_n a_n x^n \\to L\\ \\text{as}\\ x \\to 1^-\\big)$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Abel summation",
+      "summation by parts",
+      "Stolz sector",
+      "left limit",
+      "power series"
+    ],
+    "prerequisites": [
+      "power series",
+      "filters"
+    ]
+  },
+  {
+    "id": "ann-gsoq0301-general",
+    "proofId": "geometric-series-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 90,
+      "endLine": 101
+    },
+    "type": "key-step",
+    "title": "Full-strength regularity: every convergent series is Abel summable to its sum",
+    "content": "summable_abelSummableTo assembles the two ingredients into the parent's predicate: given Summable a, the on-disc clause comes from summable_mul_pow_of_summable and the left-limit from the Abel theorem applied to the partial sums (via Summable.hasSum.tendsto_sum_nat, which converges to ∑' n, aₙ). The result is that every convergent real series is Abel summable to its ordinary sum — the full-strength regular direction that the parent had only for geometric aₙ. hasSum_abelSummableTo restates it from a HasSum hypothesis: if a sums to L then a is Abel summable to L, by rewriting L = ∑' n, aₙ.",
+    "mathContext": "$\\text{Summable }a \\Rightarrow \\text{AbelSummableTo } a\\,\\big(\\textstyle\\sum_n a_n\\big)$.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "Abel's theorem",
+      "regular summation method",
+      "ordinary sum",
+      "tsum"
+    ],
+    "prerequisites": [
+      "summability",
+      "Abel summation"
+    ]
+  },
+  {
+    "id": "ann-gsoq0301-geom-consistency",
+    "proofId": "geometric-series-oq-01-oq-03-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 119
+    },
+    "type": "insight",
+    "title": "The parent's geometric case as a consistency check",
+    "content": "geom_abelSummableTo_of_general recovers the parent's geom_abelSummableTo purely from the general theorem: for |r| < 1 the geometric series converges to (1−r)⁻¹ (hasSum_geometric_of_abs_lt_one), so by hasSum_abelSummableTo it is Abel summable to 1/(1−r) — no boundary limit computed by hand. This demonstrates that the parent's hand computation was the geometric instance of a general phenomenon: the regularity it established for aₙ = rⁿ is logically subsumed. subsumes_parent_geom records the agreement explicitly, matching the parent's statement verbatim.",
+    "mathContext": "$|r| < 1:\\ \\textstyle\\sum_n r^n = \\tfrac{1}{1-r} \\Rightarrow \\text{AbelSummableTo}\\,(r^n)\\,\\tfrac{1}{1-r}$, recovering the parent.",
+    "significance": "high",
+    "relatedConcepts": [
+      "consistency check",
+      "specialization",
+      "geometric series",
+      "regularity"
+    ],
+    "prerequisites": [
+      "geometric series",
+      "Abel summation"
+    ]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "geometric-series-oq-01-oq-03-oq-01",
+  "slug": "geometric-series-oq-01-oq-03-oq-01",
+  "title": "Abel's Theorem in the Regular Direction, at Full Strength",
+  "sorries": 0,
+  "description": "Answers open question oq-01 of the parent (Abel Summability at the Boundary) by upgrading its geometric-only regularity to the full classical theorem: every convergent real series ∑ₙ aₙ is Abel summable to its ordinary sum ∑' aₙ. The deep analytic core — left-continuity of the Abel function x ↦ ∑ₙ aₙ xⁿ at x = 1⁻ — is Mathlib's Abel limit theorem (Real.tendsto_tsum_powerSeries_nhdsWithin_lt); this entry packages it against the parent's AbelSummableTo predicate. The packaging requires one genuinely new lemma: a convergent series has terms tending to 0, hence bounded, so its power series is dominated termwise by a geometric series on [0,1) and converges by comparison. The parent's hand-computed geometric case |r| < 1 → 1/(1−r) is then recovered as a strict special case, turning that computation into a consistency check of the general theorem. 121 lines, 6 theorems, 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "Niels Henrik Abel proved in 1826 (Crelle's Journal vol. 1) his continuity theorem: if the series ∑ₙ aₙ converges to L, then the power series A(x) = ∑ₙ aₙ xⁿ converges for x ∈ [0,1) and tends to L as x → 1⁻. This is the 'regular direction' of Abel summation — the statement that the summation method reproduces ordinary sums. The parent entry formalized only the geometric instance aₙ = rⁿ with |r| < 1, where the Abel function 1/(1−rx) → 1/(1−r) by elementary continuity. The general theorem, valid for every convergent series, requires the summation-by-parts argument on a Stolz sector; this is exactly the content of Mathlib's AbelLimit development. Frobenius (1880) later showed Abel summation strictly dominates Cesàro's method; the comparison of regular summation methods is the subject of G. H. Hardy's Divergent Series (1949).",
+    "problemStatement": "Prove Abel's theorem in the regular direction at full strength: if ∑ₙ aₙ converges to L, then ∑ₙ aₙ xⁿ → L as x → 1⁻, for arbitrary convergent aₙ — not only the geometric aₙ = rⁿ treated by the parent. Express the result in the parent's AbelSummableTo vocabulary and recover the geometric case as a special case.",
+    "proofStrategy": "Two ingredients combine into the parent's AbelSummableTo predicate, a conjunction of (i) summability of the power series on [0,1) and (ii) the left-limit at 1. For (ii), the regularity, the heavy lifting is Mathlib's Real.tendsto_tsum_powerSeries_nhdsWithin_lt applied to the partial sums of a (obtained from Summable.hasSum.tendsto_sum_nat). For (i), the on-disc summability, a convergent series has aₙ → 0 (Summable.tendsto_atTop_zero), so |aₙ| is bounded above by some C (Filter.Tendsto.bddAbove_range); for 0 ≤ x < 1 each term then satisfies ‖aₙ xⁿ‖ = |aₙ| xⁿ ≤ C xⁿ, and the geometric majorant C xⁿ is summable (summable_geometric_of_lt_one), so the comparison test Summable.of_norm_bounded gives convergence. Packaging (i) and (ii) yields summable_abelSummableTo : Summable a → AbelSummableTo a (∑' n, a n), and its HasSum form. Specialising to aₙ = rⁿ with |r| < 1 (via hasSum_geometric_of_abs_lt_one) recovers the parent's geometric Abel sum 1/(1−r).",
+    "keyInsights": [
+      "The general regularity is genuinely deeper than the geometric case: for aₙ = rⁿ the Abel function has the closed form 1/(1−rx) and the limit is pure continuity, but for an arbitrary convergent series there is no closed form — the left-limit is the summation-by-parts / Stolz-sector argument supplied by Mathlib's Abel limit theorem.",
+      "The parent's AbelSummableTo predicate bundles an on-disc summability clause that the bare Mathlib theorem does not provide. The one new piece of mathematics here is that clause: a convergent series has bounded terms, so its power series converges inside the unit disc by domination against a geometric series — a soft compactness fact independent of the delicate boundary limit.",
+      "Conditional (non-absolute) convergence is the reason summability must be argued via boundedness rather than ∑|aₙ|: a series like ∑ (−1)ⁿ/n converges but not absolutely, so |aₙ xⁿ| cannot be bounded by |aₙ|; bounding instead by C·xⁿ uses only aₙ → 0.",
+      "The geometric case the parent proved by hand is logically subsumed: geom_abelSummableTo_of_general derives it from the general theorem plus the closed form ∑ rⁿ = 1/(1−r), so the parent's computation becomes a consistency check rather than independent input."
+    ]
+  },
+  "sections": [
+    {
+      "id": "summable-on-disc",
+      "title": "On-disc summability of the power series",
+      "startLine": 55,
+      "endLine": 75,
+      "summary": "summable_mul_pow_of_summable: a convergent series has aₙ → 0, hence |aₙ| ≤ C; for 0 ≤ x < 1 the power series is dominated termwise by the geometric series C·xⁿ and converges by the comparison test (Summable.of_norm_bounded). This supplies the on-disc clause of the parent's AbelSummableTo predicate for an arbitrary convergent series."
+    },
+    {
+      "id": "abel-limit",
+      "title": "The regular left-limit at 1 (Mathlib's Abel theorem)",
+      "startLine": 77,
+      "endLine": 84,
+      "summary": "abel_tendsto_of_tendsto_partial: if the partial sums of a converge to L then ∑ₙ aₙ xⁿ → L as x → 1⁻. This is a restatement of Mathlib's Real.tendsto_tsum_powerSeries_nhdsWithin_lt — the deep analytic core, proved upstream by summation by parts on a Stolz sector."
+    },
+    {
+      "id": "general-theorem",
+      "title": "Abel's theorem: every convergent series is Abel summable to its sum",
+      "startLine": 86,
+      "endLine": 101,
+      "summary": "summable_abelSummableTo: Summable a → AbelSummableTo a (∑' n, a n), combining the on-disc summability and the left-limit. hasSum_abelSummableTo: the HasSum form, a → L gives Abel summable to L. This is the full-strength answer to the parent's open question."
+    },
+    {
+      "id": "geometric-consistency",
+      "title": "Consistency check: the geometric case as a special case",
+      "startLine": 103,
+      "endLine": 119,
+      "summary": "geom_abelSummableTo_of_general: for |r| < 1, the convergent series ∑ rⁿ = 1/(1−r) is Abel summable to 1/(1−r) by the general theorem — recovering the parent's geom_abelSummableTo without computing the boundary limit by hand. subsumes_parent_geom records the agreement explicitly."
+    }
+  ],
+  "conclusion": {
+    "summary": "Abel's theorem in the regular direction is proved at full strength: every convergent real series ∑ₙ aₙ is Abel summable to its ordinary sum ∑' n, aₙ (summable_abelSummableTo), with a HasSum variant (hasSum_abelSummableTo). The deep analytic core — left-continuity of the Abel function at 1 — is Mathlib's Real.tendsto_tsum_powerSeries_nhdsWithin_lt; the entry's own mathematical content is the on-disc summability lemma summable_mul_pow_of_summable (a convergent series has bounded terms, so its power series is dominated by a geometric majorant on [0,1)) and the assembly of both ingredients into the parent's AbelSummableTo predicate. The parent's geometric case |r| < 1 → 1/(1−r) is recovered as a strict special case (geom_abelSummableTo_of_general). 121 lines, 6 theorems, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "This closes the gap between the parent's geometric-only regularity and the classical Abel continuity theorem, showing the parent's hand computation was the n = geometric instance of a general phenomenon. The packaging is honest about its sources: the boundary limit is Mathlib's, the on-disc convergence and the predicate-level synthesis are the contribution. The natural next directions are the converse-flavoured questions — Tauberian theorems giving conditions under which Abel summability forces ordinary convergence — and the Abel ⊋ Cesàro hierarchy (Frobenius), which would position Abel's method strictly above the parent's Cesàro mean.",
+    "openQuestions": [
+      {
+        "id": "geometric-series-oq-01-oq-03-oq-01-oq-01",
+        "question": "Prove a Tauberian converse to Abel's theorem: if a is Abel summable to L and the terms satisfy a one-sided Tauberian condition (e.g. aₙ ≥ 0, or n·aₙ bounded / n·aₙ → 0 for Tauber's original theorem), then ∑ₙ aₙ converges to L. This is the genuine partial converse to the regular direction proved here — Abel summability plus a growth restriction recovers ordinary convergence — and would sharpen the boundary between summable and merely Abel-summable series.",
+        "significance": "medium"
+      },
+      {
+        "id": "geometric-series-oq-01-oq-03-oq-01-oq-02",
+        "question": "Formalize Frobenius's theorem that Abel summation dominates Cesàro: if a is Cesàro summable to L (the arithmetic means of its partial sums converge to L), then a is Abel summable to L. Combined with this entry it would establish the inclusion Cesàro ⊆ Abel among regular summation methods, placing the parent's Cesàro mean strictly below Abel's method on the boundary.",
+        "significance": "medium"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Direct parent (Abel Summability at the Boundary), which proved regularity only for the geometric family aₙ = rⁿ, |r| < 1. This entry answers its open question oq-01: full-strength regularity for every convergent series, with the geometric case recovered as a special case of the general theorem."
+    },
+    {
+      "targetId": "geometric-series",
+      "relationship": "depends-on",
+      "description": "Base entry recording the closed form ∑ₙ rⁿ = 1/(1−r) for |r| < 1, used in geom_abelSummableTo_of_general to identify the ordinary sum that the general Abel theorem then reproduces at the boundary."
+    }
+  ],
+  "references": [
+    {
+      "title": "Untersuchungen über die Reihe 1 + (m/1)x + (m(m−1)/1·2)x² + …",
+      "author": "Niels Henrik Abel",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik, vol. 1",
+      "description": "Abel's continuity theorem: if ∑ aₙ converges to L then ∑ aₙ xⁿ → L as x → 1⁻. The regular direction proved here at full strength."
+    },
+    {
+      "title": "Divergent Series",
+      "author": "G. H. Hardy",
+      "year": "1949",
+      "venue": "Oxford University Press",
+      "description": "Standard reference for regular summation methods, their regularity, and the Tauberian converses and Cesàro ⊊ Abel inclusion named in the open questions."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ01OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "geometric-series",
+      "abel-summability",
+      "abels-theorem",
+      "summability-theory",
+      "power-series",
+      "regular-summation",
+      "comparison-test",
+      "boundary",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 121,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "summable_mul_pow_of_summable: the on-disc summability lemma — a convergent series has aₙ → 0 (so |aₙ| ≤ C for some C), hence for 0 ≤ x < 1 its power series is dominated termwise by the geometric series C·xⁿ and converges by the comparison test. This supplies the summability clause of the parent's AbelSummableTo predicate for an arbitrary convergent series, where conditional convergence rules out the naive |aₙ xⁿ| ≤ |aₙ| bound.",
+      "summable_abelSummableTo / hasSum_abelSummableTo: the full-strength regular-direction theorem in the parent's vocabulary — every convergent real series is Abel summable to its ordinary sum ∑' n, aₙ (and the HasSum variant). The on-disc summability is the new content; the left-limit is Mathlib's Abel theorem.",
+      "geom_abelSummableTo_of_general / subsumes_parent_geom: the explicit reduction of the parent's geometric Abel-summability (|r| < 1 → 1/(1−r)) to the general theorem, turning the parent's hand-computed boundary limit into a consistency check."
+    ],
+    "prerequisites": [
+      "Real.tendsto_tsum_powerSeries_nhdsWithin_lt (Mathlib): Abel's limit theorem for real power series — if the partial sums converge to L then ∑ₙ aₙ xⁿ → L as x → 1⁻. The deep analytic core, proved upstream by summation by parts on a Stolz sector.",
+      "Summable.of_norm_bounded (Mathlib): the comparison test — a function dominated in norm by a summable majorant is summable. Drives the on-disc summability against the geometric majorant.",
+      "summable_geometric_of_lt_one (Mathlib): summability of ∑ xⁿ for 0 ≤ x < 1, the geometric majorant.",
+      "Summable.tendsto_atTop_zero / Filter.Tendsto.bddAbove_range (Mathlib): a convergent series has terms tending to 0, hence a bounded range — the source of the uniform bound C on |aₙ|.",
+      "hasSum_geometric_of_abs_lt_one (Mathlib): closed form ∑ rⁿ = (1−r)⁻¹ for |r| < 1, used to identify the geometric ordinary sum recovered at the boundary.",
+      "Parent: geometric-series-oq-01-oq-03 (AbelSummableTo predicate and the geometric-only regularity geom_abelSummableTo)."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.tendsto_tsum_powerSeries_nhdsWithin_lt",
+        "description": "Abel's limit theorem for real power series: Tendsto (fun n ↦ ∑ i ∈ range n, f i) atTop (𝓝 l) → Tendsto (fun x ↦ ∑' n, f n * x ^ n) (𝓝[<] 1) (𝓝 l). The entire deep content of the regular direction — left-continuity of the Abel function at 1 — is this theorem; abel_tendsto_of_tendsto_partial is a restatement and summable_abelSummableTo applies it to the partial sums of a convergent series.",
+        "module": "Mathlib.Analysis.Complex.AbelLimit"
+      },
+      {
+        "theorem": "Summable.of_norm_bounded",
+        "description": "Direct comparison test: if ‖f n‖ ≤ g n with g summable then f is summable. Applied with g n = C·xⁿ to prove the power series ∑ aₙ xⁿ converges on [0,1).",
+        "module": "Mathlib.Analysis.Normed.Group.InfiniteSum"
+      },
+      {
+        "theorem": "summable_geometric_of_lt_one",
+        "description": "For 0 ≤ x < 1, Summable (fun n ↦ xⁿ). The geometric majorant whose left-multiple C·xⁿ dominates the power series terms.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      },
+      {
+        "theorem": "hasSum_geometric_of_abs_lt_one",
+        "description": "For |r| < 1, HasSum (fun n ↦ rⁿ) (1−r)⁻¹. Identifies the ordinary geometric sum in geom_abelSummableTo_of_general, which the general Abel theorem then reproduces at the boundary.",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/GeometricSeriesOQ01OQ03OQ01.lean",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "verified": null,
+    "lineCount": 121
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-01-oq-03-oq-01-oq-01",
+      "question": "Prove a Tauberian converse to Abel's theorem: if a is Abel summable to L and the terms satisfy a one-sided Tauberian condition (e.g. aₙ ≥ 0, or n·aₙ → 0 for Tauber's original theorem), then ∑ₙ aₙ converges to L.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-01-oq-03-oq-01-oq-02",
+      "question": "Formalize Frobenius's theorem that Abel summation dominates Cesàro: if a is Cesàro summable to L then a is Abel summable to L, establishing the inclusion Cesàro ⊆ Abel among regular summation methods.",
+      "significance": "medium"
+    }
+  ]
+}

--- a/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/proof.md
+++ b/src/data/proofs/geometric-series-oq-01-oq-03-oq-01/proof.md
@@ -1,0 +1,79 @@
+# Abel's Theorem in the Regular Direction, at Full Strength
+
+## The Question
+
+The parent entry, *Abel Summability at the Boundary*, defined a real sequence
+$(a_n)$ to be **Abel summable to $L$** when its power series
+$$A(x) = \sum_{n=0}^{\infty} a_n x^n$$
+converges for $x \in [0,1)$ and $A(x) \to L$ as $x \to 1^-$. It then established
+the **regularity** of the method only for the geometric family $a_n = r^n$ with
+$|r| < 1$: there $A(x) = 1/(1-rx) \to 1/(1-r)$, the ordinary sum, by elementary
+continuity.
+
+The parent's open question `oq-01` asks for the theorem at full strength:
+
+> **Abel's theorem (regular direction).** If $\sum_n a_n$ converges to $L$, then
+> $\sum_n a_n x^n \to L$ as $x \to 1^-$ — for *every* convergent series, not only
+> geometric ones.
+
+## Why the General Case Is Genuinely Harder
+
+For $a_n = r^n$ the Abel function has the closed form $1/(1-rx)$, so the boundary
+limit is pure continuity of $x \mapsto 1/(1-rx)$ at $x = 1$. For an arbitrary
+convergent series there is **no closed form**: the left-limit at $1$ is a real
+analytic theorem, proved by **summation by parts** together with a uniform tail
+estimate on a Stolz sector. This is exactly the content of **Mathlib's**
+`Real.tendsto_tsum_powerSeries_nhdsWithin_lt`, and this entry consumes it rather
+than reproving it.
+
+## What This Entry Adds
+
+The parent's `AbelSummableTo` predicate is a **conjunction**:
+
+1. $\forall x \in [0,1),\ \sum_n a_n x^n$ converges (on-disc summability), and
+2. $\sum_n a_n x^n \to L$ as $x \to 1^-$ (the boundary limit).
+
+Mathlib's theorem gives only (2). The new mathematics is (1).
+
+### On-disc summability
+
+A convergent series has terms tending to $0$ (`Summable.tendsto_atTop_zero`), so
+$|a_n|$ is **bounded** above by some $C$ (`Filter.Tendsto.bddAbove_range`). For
+$0 \le x < 1$ each term then satisfies
+$$\|a_n x^n\| = |a_n|\,x^n \le C\,x^n,$$
+and the geometric majorant $\sum_n C x^n$ is summable
+(`summable_geometric_of_lt_one`). The comparison test
+(`Summable.of_norm_bounded`) closes it.
+
+The bound by $C x^n$ — rather than by $|a_n|$ — is essential: a conditionally
+convergent series such as $\sum (-1)^n/n$ is **not** absolutely summable, so
+$|a_n x^n| \le |a_n|$ would not produce a summable majorant. Only $a_n \to 0$ is
+used.
+
+## The Theorem
+
+Combining (1) and (2):
+
+$$\textbf{Summable } a \ \Longrightarrow\ \textbf{AbelSummableTo } a \Big(\sum_n a_n\Big).$$
+
+Every convergent real series is Abel summable to its ordinary sum
+(`summable_abelSummableTo`), with a `HasSum` variant
+(`hasSum_abelSummableTo`).
+
+## The Geometric Case as a Consistency Check
+
+Specialising to $a_n = r^n$, $|r| < 1$: the series converges to $1/(1-r)$
+(`hasSum_geometric_of_abs_lt_one`), so by the general theorem it is Abel summable
+to $1/(1-r)$ (`geom_abelSummableTo_of_general`) — recovering the parent's
+`geom_abelSummableTo` **without computing the boundary limit by hand**. The
+parent's hand computation is thereby exhibited as the geometric instance of a
+general phenomenon.
+
+## Honest Scope
+
+This is a **packaging** result. The deep analytic theorem (left-continuity of the
+Abel function at $1$) is Mathlib's; the contribution is the on-disc summability
+lemma, the synthesis into the parent's `AbelSummableTo` vocabulary, and the
+explicit reduction of the geometric boundary case to the general statement.
+Badge: `mathlib`. 121 lines, 6 theorems, 0 axioms, 0 sorries; each result
+depends only on `propext`, `Classical.choice`, `Quot.sound`.


### PR DESCRIPTION
## Summary

Answers open question **oq-01** of the parent `geometric-series-oq-01-oq-03` (*Abel Summability at the Boundary*): upgrades the parent's **geometric-only** regularity to the full classical theorem —

> **Abel's theorem (regular direction).** Every convergent real series ∑ₙ aₙ is Abel summable to its ordinary sum ∑' aₙ.

## What's new vs. delegated

The deep analytic core — left-continuity of the Abel function `x ↦ ∑ₙ aₙ xⁿ` at `x = 1⁻` — is **Mathlib's** `Real.tendsto_tsum_powerSeries_nhdsWithin_lt` (proved upstream by summation by parts on a Stolz sector). This entry **packages** it against the parent's `AbelSummableTo` predicate.

The genuinely new mathematics is the **on-disc summability** clause that the bare Mathlib theorem does not provide:

- `summable_mul_pow_of_summable`: a convergent series has `aₙ → 0`, hence `|aₙ| ≤ C`, so for `0 ≤ x < 1` its power series is dominated termwise by the geometric series `C·xⁿ` and converges by comparison. (Conditional convergence is why the bound must be `C·xⁿ`, not `|aₙ|`.)

## Theorems

| Name | Statement |
|------|-----------|
| `summable_mul_pow_of_summable` | on-disc summability by geometric domination |
| `abel_tendsto_of_tendsto_partial` | restatement of Mathlib's Abel limit theorem |
| `summable_abelSummableTo` | `Summable a ⟹ AbelSummableTo a (∑' aₙ)` |
| `hasSum_abelSummableTo` | `HasSum a L ⟹ AbelSummableTo a L` |
| `geom_abelSummableTo_of_general` | recover parent's `|r|<1 → 1/(1−r)` as a special case |
| `subsumes_parent_geom` | explicit agreement with the parent's geometric statement |

The parent's hand-computed geometric case is thereby exhibited as the geometric instance of the general phenomenon — a **consistency check** rather than independent input.

## Verification

- **121 lines, 6 theorems, 0 defs, 0 sorries, 0 axioms.**
- `#print axioms` on all main theorems lists only `propext, Classical.choice, Quot.sound`.
- Builds via `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ01OQ03OQ01`.
- **Badge: `mathlib`** (the deep theorem is Mathlib's; the contribution is the on-disc summability lemma + predicate-level synthesis + geometric reduction).

## Follow-up open questions

1. A **Tauberian converse**: Abel summability + a one-sided growth condition (e.g. `aₙ ≥ 0`, or `n·aₙ → 0`) ⟹ ordinary convergence.
2. **Frobenius**: Cesàro summable ⟹ Abel summable to the same value (the Cesàro ⊆ Abel inclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)