### PR TITLE
research(area-of-circle-oq-07-oq-03-oq-02): Γ(1/2)²=π via Beta value B(1/2,1/2)=π and the arcsine density

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ03OQ02.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ03OQ02.lean
@@ -1,0 +1,184 @@
+import Mathlib
+
+/-
+# `Γ(1/2)² = π` via the Beta value `B(1/2,1/2) = π` and the arcsine density
+
+## What This Proves
+
+This file evaluates `Γ(1/2)` through the Euler Beta function rather than through the
+Gaussian integral. The two ingredients are:
+
+* **Beta–Gamma reflection at the centre.**  `Mathlib`'s
+  `Complex.Gamma_mul_Gamma_eq_betaIntegral` gives
+  `Γ(1/2)·Γ(1/2) = Γ(1)·B(1/2,1/2)`, and `Γ(1) = 1`, so `Γ(1/2)² = B(1/2,1/2)`.
+
+* **The arcsine integral.**  The Beta value is the total mass of the (unnormalised)
+  arcsine density,
+  `B(1/2,1/2) = ∫₀¹ x^{-1/2}(1-x)^{-1/2} dx = ∫₀¹ dx/√(x(1-x)) = π`,
+  evaluated by the fundamental theorem of calculus with antiderivative
+  `arcsin(2x-1)` (whose derivative is exactly the integrand on `(0,1)`).
+
+Combining them gives `Γ(1/2)² = π`, hence `Γ(1/2) = √π`, **without ever invoking the
+Gaussian integral** (which is how `Mathlib`'s own `Real.Gamma_one_half_eq` is proved).
+The proof is therefore an independent, genuinely Beta-function-based derivation, and it
+exhibits the classical fact that the arcsine probability density
+`1/(π√(x(1-x)))` integrates to one.
+
+## The Arithmetic of the Antiderivative
+
+On `(0,1)` we have `1-(2x-1)² = 4x(1-x)`, so
+
+  `d/dx arcsin(2x-1) = 2/√(1-(2x-1)²) = 2/√(4x(1-x)) = 1/√(x(1-x))
+                     = x^{-1/2}(1-x)^{-1/2}`,
+
+which is precisely the Beta integrand at `(1/2,1/2)`. The endpoint values
+`arcsin(±1) = ±π/2` give total integral `π/2-(-π/2) = π`. Singularities at the two
+endpoints are harmless: the FTC variant `integral_eq_sub_of_hasDeriv_right_of_le` only
+needs the derivative on the open interval together with continuity of the
+antiderivative and integrability of the integrand (the latter from
+`Complex.betaIntegral_convergent`).
+
+## Status: 0 sorries, 0 axioms
+-/
+
+open Real Complex MeasureTheory intervalIntegral Set
+
+namespace AreaOfCircleOQ07OQ03OQ02
+
+/-- The unnormalised arcsine density `x ↦ x^{-1/2}(1-x)^{-1/2}` on `[0,1]`. -/
+noncomputable def arcsineDensity (x : ℝ) : ℝ :=
+  x ^ (-(1 / 2) : ℝ) * (1 - x) ^ (-(1 / 2) : ℝ)
+
+/-! ## The antiderivative and its derivative -/
+
+/-- On the open interval `(0,1)`, `arcsin(2x-1)` has derivative equal to the arcsine
+density `x^{-1/2}(1-x)^{-1/2}`. This is the analytic heart: `1-(2x-1)² = 4x(1-x)`. -/
+theorem hasDerivAt_arcsin_affine {x : ℝ} (hx0 : 0 < x) (hx1 : x < 1) :
+    HasDerivAt (fun y => Real.arcsin (2 * y - 1)) (arcsineDensity x) x := by
+  have hne1 : 2 * x - 1 ≠ -1 := by nlinarith
+  have hne2 : 2 * x - 1 ≠ 1 := by nlinarith
+  -- derivative of the inner affine map `2x-1`
+  have hinner : HasDerivAt (fun y : ℝ => 2 * y - 1) 2 x := by
+    simpa using ((hasDerivAt_id x).const_mul 2).sub_const 1
+  -- chain rule with `arcsin`
+  have hchain : HasDerivAt (fun y => Real.arcsin (2 * y - 1))
+      (1 / Real.sqrt (1 - (2 * x - 1) ^ 2) * 2) x := by
+    have h := (Real.hasDerivAt_arcsin hne1 hne2).comp x hinner
+    simpa [Function.comp] using h
+  -- identify the derivative with the arcsine density
+  have hpos : 0 < x * (1 - x) := mul_pos hx0 (by linarith)
+  have hkey : 1 / Real.sqrt (1 - (2 * x - 1) ^ 2) * 2 = arcsineDensity x := by
+    have h4 : 1 - (2 * x - 1) ^ 2 = 4 * (x * (1 - x)) := by ring
+    have hsqrt4 : Real.sqrt (1 - (2 * x - 1) ^ 2)
+        = 2 * (Real.sqrt x * Real.sqrt (1 - x)) := by
+      rw [h4, show (4 : ℝ) = 2 ^ 2 by norm_num, Real.sqrt_mul (by positivity),
+        Real.sqrt_sq (by norm_num), Real.sqrt_mul hx0.le]
+    rw [hsqrt4]
+    have hsx : Real.sqrt x = x ^ ((1 : ℝ) / 2) := Real.sqrt_eq_rpow x
+    have hs1x : Real.sqrt (1 - x) = (1 - x) ^ ((1 : ℝ) / 2) := Real.sqrt_eq_rpow (1 - x)
+    have hsxpos : (0:ℝ) < x ^ ((1:ℝ)/2) := Real.rpow_pos_of_pos hx0 _
+    have hs1xpos : (0:ℝ) < (1 - x) ^ ((1:ℝ)/2) := Real.rpow_pos_of_pos (by linarith) _
+    rw [arcsineDensity, hsx, hs1x,
+      Real.rpow_neg hx0.le, Real.rpow_neg (by linarith : (0:ℝ) ≤ 1 - x)]
+    field_simp
+    ring
+  rw [← hkey]; exact hchain
+
+/-! ## Integrability of the integrand -/
+
+/-- The arcsine density is interval-integrable on `[0,1]`: its norm agrees with the
+norm of the convergent complex Beta integrand. -/
+theorem intervalIntegrable_arcsineDensity :
+    IntervalIntegrable arcsineDensity volume 0 1 := by
+  have hconv := Complex.betaIntegral_convergent (u := (1/2 : ℂ)) (v := (1/2 : ℂ))
+    (by norm_num) (by norm_num)
+  have hnorm := hconv.norm
+  refine hnorm.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr (ae_of_all _ ?_))
+  intro x hx
+  rw [uIoc_of_le (by norm_num : (0:ℝ) ≤ 1)] at hx
+  obtain ⟨hx0, hx1⟩ := hx
+  have hx0' : (0:ℝ) ≤ x := hx0.le
+  have hx1' : (0:ℝ) ≤ 1 - x := by linarith
+  -- both complex cpow factors are `ofReal` of nonnegative real rpows
+  have e1 : (x : ℂ) ^ ((1/2 : ℂ) - 1) = ((x ^ (-(1/2) : ℝ) : ℝ) : ℂ) := by
+    rw [Complex.ofReal_cpow hx0']; congr 1; push_cast; ring
+  have e2 : (1 - (x : ℂ)) ^ ((1/2 : ℂ) - 1) = (((1 - x) ^ (-(1/2) : ℝ) : ℝ) : ℂ) := by
+    rw [show (1 : ℂ) - (x : ℂ) = ((1 - x : ℝ) : ℂ) by push_cast; ring,
+      Complex.ofReal_cpow hx1']
+    congr 1; push_cast; ring
+  rw [e1, e2, ← Complex.ofReal_mul, Complex.norm_real, arcsineDensity]
+  rw [Real.norm_eq_abs,
+    abs_of_nonneg (mul_nonneg (Real.rpow_nonneg hx0' _) (Real.rpow_nonneg hx1' _))]
+
+/-! ## The arcsine integral equals `π` -/
+
+/-- **The arcsine integral.** `∫₀¹ x^{-1/2}(1-x)^{-1/2} dx = π`, by the FTC with
+antiderivative `arcsin(2x-1)`. -/
+theorem integral_arcsineDensity : ∫ x in (0:ℝ)..1, arcsineDensity x = π := by
+  have hcont : ContinuousOn (fun y => Real.arcsin (2 * y - 1)) (Icc 0 1) :=
+    (Real.continuous_arcsin.comp (by fun_prop)).continuousOn
+  have hderiv : ∀ x ∈ Ioo (0:ℝ) 1,
+      HasDerivWithinAt (fun y => Real.arcsin (2 * y - 1)) (arcsineDensity x) (Ioi x) x := by
+    intro x hx
+    exact (hasDerivAt_arcsin_affine hx.1 hx.2).hasDerivWithinAt
+  have hFTC := intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le
+    (by norm_num : (0:ℝ) ≤ 1) hcont hderiv intervalIntegrable_arcsineDensity
+  rw [hFTC, show (2 : ℝ) * 1 - 1 = 1 by norm_num, show (2 : ℝ) * 0 - 1 = -1 by norm_num,
+    Real.arcsin_one, Real.arcsin_neg_one]
+  ring
+
+/-! ## The Beta value and `Γ(1/2)² = π` -/
+
+/-- **The central Beta value.** `B(1/2,1/2) = π`. -/
+theorem betaIntegral_half_half : Complex.betaIntegral (1/2) (1/2) = (π : ℂ) := by
+  rw [Complex.betaIntegral]
+  have heq : ∀ᵐ x ∂(volume : Measure ℝ), x ∈ Set.uIoc (0:ℝ) 1 →
+      (x : ℂ) ^ ((1/2 : ℂ) - 1) * (1 - (x : ℂ)) ^ ((1/2 : ℂ) - 1)
+        = ((arcsineDensity x : ℝ) : ℂ) := by
+    refine ae_of_all _ (fun x hx => ?_)
+    rw [uIoc_of_le (by norm_num : (0:ℝ) ≤ 1)] at hx
+    obtain ⟨hx0, hx1⟩ := hx
+    have hx0' : (0:ℝ) ≤ x := hx0.le
+    have hx1' : (0:ℝ) ≤ 1 - x := by linarith
+    have e1 : (x : ℂ) ^ ((1/2 : ℂ) - 1) = ((x ^ (-(1/2) : ℝ) : ℝ) : ℂ) := by
+      rw [Complex.ofReal_cpow hx0']; congr 1; push_cast; ring
+    have e2 : (1 - (x : ℂ)) ^ ((1/2 : ℂ) - 1) = (((1 - x) ^ (-(1/2) : ℝ) : ℝ) : ℂ) := by
+      rw [show (1 : ℂ) - (x : ℂ) = ((1 - x : ℝ) : ℂ) by push_cast; ring,
+        Complex.ofReal_cpow hx1']
+      congr 1; push_cast; ring
+    rw [e1, e2, ← Complex.ofReal_mul, arcsineDensity]
+  rw [intervalIntegral.integral_congr_ae heq, intervalIntegral.integral_ofReal,
+    integral_arcsineDensity]
+
+/-- **`Γ(1/2)² = π` (complex).** Proved through the Beta value, not the Gaussian
+integral. -/
+theorem complex_Gamma_half_sq : Complex.Gamma (1/2) ^ 2 = (π : ℂ) := by
+  have h := Complex.Gamma_mul_Gamma_eq_betaIntegral (s := (1/2 : ℂ)) (t := (1/2 : ℂ))
+    (by norm_num) (by norm_num)
+  rw [show (1/2 : ℂ) + 1/2 = 1 by norm_num, Complex.Gamma_one, one_mul,
+    betaIntegral_half_half] at h
+  rw [sq]; exact h
+
+/-- **`Γ(1/2)² = π` (real).** -/
+theorem real_Gamma_half_sq : Real.Gamma (1/2) ^ 2 = π := by
+  have h := complex_Gamma_half_sq
+  rw [show (1/2 : ℂ) = ((1/2 : ℝ) : ℂ) by norm_num, Complex.Gamma_ofReal] at h
+  have : ((Real.Gamma (1/2) ^ 2 : ℝ) : ℂ) = ((π : ℝ) : ℂ) := by push_cast at h ⊢; linear_combination h
+  exact_mod_cast this
+
+/-- **`Γ(1/2) = √π`**, recovered through the Beta route. (`Mathlib`'s
+`Real.Gamma_one_half_eq` proves the same equality via the Gaussian integral; here it is
+a corollary of `B(1/2,1/2) = π`.) -/
+theorem real_Gamma_half : Real.Gamma (1/2) = Real.sqrt π := by
+  have hsq : Real.Gamma (1/2) ^ 2 = π := real_Gamma_half_sq
+  have hpos : 0 < Real.Gamma (1/2) := Real.Gamma_pos_of_pos (by norm_num)
+  rw [← hsq, Real.sqrt_sq hpos.le]
+
+/-- **Arcsine probability density normalisation.** The arcsine density
+`1/(π√(x(1-x)))` integrates to `1` over `[0,1]`. -/
+theorem arcsine_density_normalised :
+    ∫ x in (0:ℝ)..1, (π)⁻¹ * arcsineDensity x = 1 := by
+  rw [intervalIntegral.integral_const_mul, integral_arcsineDensity]
+  field_simp [Real.pi_ne_zero]
+
+end AreaOfCircleOQ07OQ03OQ02

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-02/meta.json
@@ -1,0 +1,178 @@
+{
+  "id": "area-of-circle-oq-07-oq-03-oq-02",
+  "slug": "area-of-circle-oq-07-oq-03-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Complex",
+      "MeasureTheory",
+      "intervalIntegral",
+      "Set"
+    ],
+    "namespace": "AreaOfCircleOQ07OQ03OQ02",
+    "lineCount": 185,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ07OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "title": "Γ(1/2)² = π via the Beta value B(1/2,1/2) = π and the arcsine density",
+  "description": "An independent, Beta-function-based derivation of Γ(1/2)² = π — not using the Gaussian integral (the route by which Mathlib's own Real.Gamma_one_half_eq is proved). Mathlib's Beta–Gamma relation Complex.Gamma_mul_Gamma_eq_betaIntegral gives Γ(1/2)·Γ(1/2) = Γ(1)·B(1/2,1/2) = B(1/2,1/2); the Beta value B(1/2,1/2) = ∫₀¹ x^{−1/2}(1−x)^{−1/2} dx = π is then computed from scratch by the fundamental theorem of calculus with antiderivative arcsin(2x−1), whose derivative on (0,1) is exactly the integrand because 1 − (2x−1)² = 4x(1−x). Combining gives Γ(1/2)² = π, hence Γ(1/2) = √π and the normalisation ∫₀¹ 1/(π√(x(1−x))) dx = 1 of the arcsine probability density. Answers the parent's open question oq-03-oq-02 verbatim.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ03OQ02.lean",
+    "tags": [
+      "analysis",
+      "gamma-function",
+      "beta-function",
+      "special-functions",
+      "arcsine-distribution",
+      "fundamental-theorem-of-calculus",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 185,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "integral_arcsineDensity: ∫₀¹ x^{−1/2}(1−x)^{−1/2} dx = π, evaluated independently by the FTC with antiderivative arcsin(2x−1) — the analytic heart, since 1 − (2x−1)² = 4x(1−x) makes the derivative of arcsin(2x−1) equal to the Beta integrand on (0,1)",
+      "betaIntegral_half_half: Complex.betaIntegral (1/2) (1/2) = π, obtained by reducing the complex Beta integrand to ofReal of the real arcsine density (via Complex.ofReal_cpow) and applying integral_arcsineDensity — not delegated to any Mathlib Beta special value",
+      "complex_Gamma_half_sq / real_Gamma_half_sq: Γ(1/2)² = π through the Beta value rather than the Gaussian integral, via Complex.Gamma_mul_Gamma_eq_betaIntegral and Γ(1) = 1",
+      "real_Gamma_half: Γ(1/2) = √π recovered as a corollary of B(1/2,1/2) = π (an independent proof of the equality Mathlib establishes through the Gaussian integral)",
+      "arcsine_density_normalised: ∫₀¹ 1/(π√(x(1−x))) dx = 1, the total-mass normalisation of the arcsine probability density on [0,1]"
+    ],
+    "prerequisites": [
+      "Euler Beta function Complex.betaIntegral and the Beta–Gamma relation Complex.Gamma_mul_Gamma_eq_betaIntegral",
+      "The fundamental theorem of calculus for an interval with endpoint singularities (intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le)",
+      "Real.arcsin and its derivative Real.hasDerivAt_arcsin; arcsin(±1) = ±π/2",
+      "Complex.ofReal_cpow to reduce the complex cpow integrand to a real rpow integrand",
+      "Parent: area-of-circle-oq-07-oq-03 (Γ(1/2) = √π, the Gaussian route)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.Gamma_mul_Gamma_eq_betaIntegral",
+        "description": "Γ(s)·Γ(t) = Γ(s+t)·B(s,t) for Re s, Re t > 0. Specialized at s = t = 1/2 (with Γ(1) = 1) to reduce Γ(1/2)² to the Beta value B(1/2,1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.betaIntegral_convergent",
+        "description": "Interval-integrability of the Beta integrand for positive real parts; used (via its norm) to supply integrability of the real arcsine density to the FTC.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Real.hasDerivAt_arcsin",
+        "description": "HasDerivAt arcsin (1/√(1−x²)) x for x ≠ ±1. Composed with the affine map x ↦ 2x−1 to produce the antiderivative of the Beta integrand on (0,1).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.InverseDeriv"
+      },
+      {
+        "theorem": "intervalIntegral.integral_eq_sub_of_hasDeriv_right_of_le",
+        "description": "FTC variant requiring the derivative only on the open interval, with continuity of the antiderivative and integrability of the integrand — exactly the hypotheses available for the singular arcsine density.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus"
+      },
+      {
+        "theorem": "Complex.ofReal_cpow",
+        "description": "(↑(x^y) : ℂ) = (↑x)^(↑y) for 0 ≤ x and real y. Reduces the complex Beta integrand to ofReal of the real arcsine density on (0,1).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's Beta function B(u,v) = ∫₀¹ t^{u−1}(1−t)^{v−1} dt and Gamma function Γ are linked by the reflection B(u,v) = Γ(u)Γ(v)/Γ(u+v). At the centre u = v = 1/2 this reads Γ(1/2)² = Γ(1)·B(1/2,1/2) = B(1/2,1/2), so the single number π appears two ways: as the square of the Gamma half-value and as the total mass of the (unnormalised) arcsine density 1/√(t(1−t)) on [0,1]. The arcsine distribution — Wigner's law for a 1-D random walk's fraction-of-time-positive, and the spectral density of a free Jacobi/Chebyshev ensemble — has density 1/(π√(t(1−t))); that the constant is exactly 1/π is the statement B(1/2,1/2) = π. The companion entry area-of-circle-oq-07-oq-03 obtains Γ(1/2) = √π from the Gaussian integral; this entry obtains the same π from the Beta side, closing the loop between the two classical evaluations.",
+    "problemStatement": "**Open Question (oq-03-oq-02)**: connect Γ(1/2)² = π to the Beta value B(1/2,1/2) = π via the Beta–Gamma relation, exhibiting the same π as the area under the arcsine density on [0,1]. Answer: Γ(1/2)² = Γ(1)·B(1/2,1/2) = B(1/2,1/2), and B(1/2,1/2) = ∫₀¹ dt/√(t(1−t)) = π by the FTC with antiderivative arcsin(2t−1).",
+    "proofStrategy": "(1) hasDerivAt_arcsin_affine: chain-rule arcsin with x ↦ 2x−1, then identify 2/√(1−(2x−1)²) with x^{−1/2}(1−x)^{−1/2} using 1−(2x−1)² = 4x(1−x) and √(4x(1−x)) = 2√x√(1−x). (2) intervalIntegrable_arcsineDensity: the real density equals the norm of Mathlib's convergent complex Beta integrand a.e. on (0,1), so it is interval-integrable. (3) integral_arcsineDensity: apply the open-interval FTC; endpoint values arcsin(±1) = ±π/2 give total π. (4) betaIntegral_half_half: rewrite the complex Beta integrand as ofReal of the real density (Complex.ofReal_cpow) and push ofReal through the integral. (5) complex_Gamma_half_sq / real_Gamma_half_sq / real_Gamma_half: feed the Beta value into the Beta–Gamma relation and cast. (6) arcsine_density_normalised divides by π.",
+    "keyInsights": [
+      "The derivative of arcsin(2x−1) IS the Beta(1/2,1/2) integrand: 1 − (2x−1)² = 4x(1−x), so 2/√(1−(2x−1)²) = 1/√(x(1−x)) = x^{−1/2}(1−x)^{−1/2}. The arcsine substitution is not auxiliary — it is the antiderivative.",
+      "The endpoint singularities of x^{−1/2}(1−x)^{−1/2} are handled by the FTC variant that needs the derivative only on the open interval; integrability is borrowed from Mathlib's complex Beta-convergence lemma via the norm.",
+      "Reducing the complex cpow Beta integrand to a real rpow integrand (Complex.ofReal_cpow on (0,1), where both bases are nonnegative reals) lets a single real FTC computation evaluate the complex Beta integral.",
+      "This is an independent derivation of Γ(1/2) = √π: it never calls Real.Gamma_one_half_eq, so the value is recomputed through the Beta/arcsine route rather than the Gaussian one, and the two appearances of π (Gamma-square and arcsine mass) are unified."
+    ]
+  },
+  "sections": [
+    {
+      "id": "antiderivative",
+      "title": "The Antiderivative arcsin(2x−1)",
+      "startLine": 64,
+      "endLine": 100,
+      "summary": "hasDerivAt_arcsin_affine: on (0,1), arcsin(2x−1) has derivative x^{−1/2}(1−x)^{−1/2}. The chain rule gives 2/√(1−(2x−1)²); the identity 1−(2x−1)² = 4x(1−x) and √-arithmetic identify it with the arcsine density."
+    },
+    {
+      "id": "integrability",
+      "title": "Integrability of the Density",
+      "startLine": 102,
+      "endLine": 132,
+      "summary": "intervalIntegrable_arcsineDensity: the real density is interval-integrable on [0,1] because it equals, a.e. on (0,1), the norm of Mathlib's convergent complex Beta integrand (Complex.betaIntegral_convergent)."
+    },
+    {
+      "id": "arcsine-integral",
+      "title": "The Arcsine Integral Equals π",
+      "startLine": 134,
+      "endLine": 150,
+      "summary": "integral_arcsineDensity: ∫₀¹ x^{−1/2}(1−x)^{−1/2} dx = π by the open-interval FTC with antiderivative arcsin(2x−1); arcsin(1) − arcsin(−1) = π/2 − (−π/2) = π."
+    },
+    {
+      "id": "beta-value",
+      "title": "The Beta Value B(1/2,1/2) = π",
+      "startLine": 152,
+      "endLine": 170,
+      "summary": "betaIntegral_half_half: Complex.betaIntegral (1/2) (1/2) = π, by reducing the complex integrand to ofReal of the real density (Complex.ofReal_cpow) and pushing ofReal through the interval integral."
+    },
+    {
+      "id": "gamma-square",
+      "title": "Γ(1/2)² = π and Γ(1/2) = √π",
+      "startLine": 172,
+      "endLine": 185,
+      "summary": "complex_Gamma_half_sq and real_Gamma_half_sq: Γ(1/2)² = π through Complex.Gamma_mul_Gamma_eq_betaIntegral and Γ(1) = 1; real_Gamma_half recovers Γ(1/2) = √π; arcsine_density_normalised gives ∫₀¹ 1/(π√(x(1−x))) = 1."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "area-of-circle-oq-07-oq-03-oq-02-oq-01",
+      "question": "Extend the Beta route to the general half-integer ladder: evaluate B(n+1/2, 1/2) by the same arcsine-substitution FTC (reducing ∫₀¹ x^{n−1/2}(1−x)^{−1/2} dx to a trigonometric moment via x = sin²θ), and identify Γ(n+1/2) = (2n−1)!!√π/2ⁿ as a product of these Beta values, an arcsine-density derivation parallel to the Gaussian-moment route of oq-03-oq-01.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-03",
+      "relationship": "extends",
+      "description": "Parent. The parent proves Γ(1/2) = √π via Mathlib's Gaussian-based Real.Gamma_one_half_eq; this entry re-derives Γ(1/2)² = π independently through the Beta value B(1/2,1/2) = π and the arcsine integral, answering the parent's open question oq-03-oq-02."
+    },
+    {
+      "targetId": "area-of-circle-oq-07",
+      "relationship": "related",
+      "description": "Grandparent. The Gaussian integral ∫_ℝ e^{−x²} = √π and the Beta value B(1/2,1/2) = π are two classical evaluations of the same π; this entry supplies the Beta/arcsine one."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.betaIntegral, Complex.Gamma_mul_Gamma_eq_betaIntegral, and Complex.betaIntegral_convergent."
+    },
+    {
+      "title": "Euler's Beta and Gamma functions",
+      "author": "Leonhard Euler",
+      "year": "1730",
+      "venue": "historical",
+      "description": "The Beta integral B(u,v) = ∫₀¹ t^{u−1}(1−t)^{v−1} dt and its relation to Γ; B(1/2,1/2) = π is the central value."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "Γ(1/2)² = π is derived independently of the Gaussian integral. Mathlib's Beta–Gamma relation reduces Γ(1/2)² to the Beta value B(1/2,1/2); that value is computed from scratch as ∫₀¹ x^{−1/2}(1−x)^{−1/2} dx = π by the fundamental theorem of calculus with antiderivative arcsin(2x−1) (whose derivative on (0,1) is exactly the integrand, since 1−(2x−1)² = 4x(1−x)). Corollaries: Γ(1/2) = √π and the arcsine density normalisation ∫₀¹ 1/(π√(x(1−x))) dx = 1. 185 lines, 8 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "Unlike the parent entry (which records Mathlib's Gaussian-based special value), this entry carries out the arcsine FTC computation itself, so it is an independent proof of Γ(1/2) = √π through the Beta function. It exhibits the single constant π simultaneously as Γ(1/2)² and as the total mass of the arcsine probability density on [0,1].",
+    "openQuestions": [
+      "Extend the Beta route to B(n+1/2, 1/2) via the arcsine substitution and recover the half-integer ladder Γ(n+1/2) = (2n−1)!!√π/2ⁿ as a product of Beta values."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **area-of-circle-oq-07-oq-03-oq-02** verbatim: *connect Γ(1/2)²=π to the Beta value B(1/2,1/2)=π via Mathlib's Beta–Gamma relation, exhibiting the same π as the area under the arcsine density on [0,1].*

This is an **independent, non-Gaussian** derivation of Γ(1/2)²=π. The parent entry (`area-of-circle-oq-07-oq-03`) records Mathlib's `Real.Gamma_one_half_eq`, which is proved via the Gaussian integral. This entry never calls that lemma; instead it computes the Beta value from scratch.

## The proof

1. **Beta–Gamma at the centre.** `Complex.Gamma_mul_Gamma_eq_betaIntegral` gives Γ(1/2)·Γ(1/2) = Γ(1)·B(1/2,1/2), and Γ(1)=1, so Γ(1/2)² = B(1/2,1/2).
2. **The arcsine integral.** B(1/2,1/2) = ∫₀¹ x^(−1/2)(1−x)^(−1/2) dx is evaluated by the fundamental theorem of calculus with antiderivative `arcsin(2x−1)`. The analytic heart: `1−(2x−1)² = 4x(1−x)`, so the derivative of `arcsin(2x−1)` on (0,1) is exactly `x^(−1/2)(1−x)^(−1/2)`. Endpoint values `arcsin(±1)=±π/2` give total **π**. Endpoint singularities are handled by the open-interval FTC variant; integrability is borrowed from `Complex.betaIntegral_convergent` via the norm.
3. **Conclusion.** Γ(1/2)² = π, hence Γ(1/2) = √π, plus the arcsine probability density normalisation ∫₀¹ 1/(π√(x(1−x))) dx = 1.

## Verification

- 185 lines, 8 theorems, 1 definition, **0 sorries, 0 axioms** (status `verified`, badge `original`).
- Compiles against Mathlib (`lake env lean`, clean — 0 errors/warnings).

## Notes

- Build performed via single-file `lake env lean` against the prebuilt Mathlib oleans: the Docker wrapper is currently failing on a `lean-mathlib-cache` volume permission error (`/root/.cache/mathlib/*.ltar: Permission denied`) affecting all docker builds on this host — an infra issue independent of this proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)