### PR TITLE
Fix stale axiom-based annotations on morleys-theorem (proof is axiom-free)

### DIFF
--- a/src/data/proofs/morleys-theorem/annotations.json
+++ b/src/data/proofs/morleys-theorem/annotations.json
@@ -3,13 +3,13 @@
     "id": "ann-intro",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 1,
-      "endLine": 58
+      "startLine": 9,
+      "endLine": 56
     },
     "type": "concept",
     "title": "Morley's Theorem: Wiedijk #84",
     "content": "**Morley's Trisector Theorem (1899)**: The three intersection points of **adjacent angle trisectors** of any triangle form an **equilateral triangle** (the Morley triangle). Given triangle $ABC$ with angles $\\alpha, \\beta, \\gamma$, trisect each angle into three equal parts. The adjacent trisectors (closest to each side) meet at three points that always form an equilateral triangle. Frank Morley discovered this in 1899 — despite millennia of triangle study, this elegant property remained hidden.",
-    "mathContext": "The formalization uses complex coordinates in $\\mathbb{C}$. Given a triangle with angles $\\alpha + \\beta + \\gamma = \\pi$, the trisected angles $\\alpha_3 = \\alpha/3$, $\\beta_3 = \\beta/3$, $\\gamma_3 = \\gamma/3$ satisfy $\\alpha_3 + \\beta_3 + \\gamma_3 = \\pi/3$. The Morley side length formula $s = 8R \\sin(\\alpha/3) \\sin(\\beta/3) \\sin(\\gamma/3)$ is symmetric in the trisected angles, immediately implying equilaterality.",
+    "mathContext": "This formalization proves the theorem by the **sine-rule / cosine-rule method** — coordinate geometry is avoided entirely. Given a triangle with angles $\\alpha + \\beta + \\gamma = \\pi$, the trisected angles $\\alpha_3 = \\alpha/3$, $\\beta_3 = \\beta/3$, $\\gamma_3 = \\gamma/3$ satisfy $\\alpha_3 + \\beta_3 + \\gamma_3 = \\pi/3$. Each Morley side, computed via the sine rule in the trisector sub-triangles and the cosine rule across a shared vertex, equals $8R \\sin(\\alpha/3) \\sin(\\beta/3) \\sin(\\gamma/3)$ — a formula **symmetric** in the three trisected angles, so all three sides are equal. The entire development is axiom-free.",
     "significance": "key",
     "relatedConcepts": [
       "angle-trisection",
@@ -28,8 +28,8 @@
     "id": "ann-triangle-angles",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 68,
-      "endLine": 92
+      "startLine": 69,
+      "endLine": 90
     },
     "type": "definition",
     "title": "Triangle Angles Structure and Trisection",
@@ -47,21 +47,21 @@
     ]
   },
   {
-    "id": "ann-backward-proof",
+    "id": "ann-equilateral-sides",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 115,
-      "endLine": 136
+      "startLine": 113,
+      "endLine": 160
     },
-    "type": "definition",
-    "title": "Backward Proof: Equilateral Triangle Construction",
-    "content": "Conway's **backward proof** strategy: instead of starting with triangle $ABC$ and proving the trisector intersections are equilateral (computationally hard), start with the equilateral triangle and reconstruct $ABC$ around it. The unit equilateral triangle vertices are defined as $P = e^{0}$, $Q = e^{i \\cdot 2\\pi/3}$, $R = e^{i \\cdot 4\\pi/3}$ in complex coordinates. The axiom `equilateral_side_length_axiom` asserts $|Q - P| = |R - Q| = |P - R|$.",
-    "mathContext": "The vertices $\\{e^{i \\cdot 2\\pi k/3}\\}_{k=0}^{2}$ are the cube roots of unity, placing an equilateral triangle inscribed in the unit circle. The complex exponential $e^{i\\theta} = \\cos\\theta + i\\sin\\theta$ provides coordinates: $P = 1$, $Q = -1/2 + i\\sqrt{3}/2$, $R = -1/2 - i\\sqrt{3}/2$. Each side has length $|e^{i \\cdot 2\\pi/3} - 1| = \\sqrt{3}$. The axiom captures the equal-side property without computing $|Q - P|$ explicitly.",
+    "type": "theorem",
+    "title": "Equilateral Triangle Has Equal Sides (Proved)",
+    "content": "A unit equilateral triangle is placed at the cube roots of unity: $P = e^{0} = 1$, $Q = e^{i \\cdot 2\\pi/3}$, $R = e^{i \\cdot 4\\pi/3}$ via `equilateralVertex k = exp(i · 2πk/3)`. The theorem `equilateral_side_length` **proves** (no axiom) that $|Q - P| = |R - Q| = |P - R|$. The proof observes $R = Q^2$, $Q^3 = 1$, and $|Q| = 1$, so $R - Q = Q(Q - P)$ and $P - R = Q^2(Q - P)$; multiplying by a unit-modulus factor preserves length.",
+    "mathContext": "The vertices $\\{e^{i \\cdot 2\\pi k/3}\\}_{k=0}^{2}$ are the cube roots of unity, an equilateral triangle inscribed in the unit circle: $P = 1$, $Q = -1/2 + i\\sqrt{3}/2$, $R = -1/2 - i\\sqrt{3}/2$. The proof is fully constructive in Lean: `hP : P = 1` by `simp`, `hR : R = Q^2` via `Complex.exp_add`, `hQ_abs : |Q| = 1` from `map_exp_ofReal_mul_I_re`, and `hQ3 : Q^3 = 1` from `Complex.exp_two_pi_mul_I`. Then `map_mul` and `Complex.abs_pow` collapse each side length to $|Q - P|$.",
     "significance": "key",
     "relatedConcepts": [
       "Complex.exp",
       "roots-of-unity",
-      "Conway-backward-proof",
+      "cube-roots-of-unity",
       "equilateral-triangle"
     ],
     "prerequisites": [
@@ -74,107 +74,106 @@
     "id": "ann-trig-identity",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 150,
-      "endLine": 158
+      "startLine": 176,
+      "endLine": 229
     },
-    "type": "concept",
-    "title": "Key Trigonometric Identities",
-    "content": "Two expansion identities for $\\pi/3$-shifted angles: $\\sin(\\pi/3 + \\theta) = (\\sqrt{3}/2)\\cos\\theta + (1/2)\\sin\\theta$ and $\\cos(\\pi/3 + \\theta) = (1/2)\\cos\\theta - (\\sqrt{3}/2)\\sin\\theta$. Both are proved by `simp` using `sin_add`/`cos_add` with the known values $\\sin(\\pi/3) = \\sqrt{3}/2$ and $\\cos(\\pi/3) = 1/2$. These connect trisected angles to the equilateral triangle's $60°$ geometry.",
-    "mathContext": "The identities follow from the addition formulas: $\\sin(a + b) = \\sin a \\cos b + \\cos a \\sin b$ and $\\cos(a + b) = \\cos a \\cos b - \\sin a \\sin b$. With $a = \\pi/3$, we substitute $\\sin(\\pi/3) = \\sqrt{3}/2$ and $\\cos(\\pi/3) = 1/2$. These are the only theorems in the file proved without axioms — the `simp` tactic closes them from Mathlib's `sin_add`, `cos_add`, `sin_pi_div_three`, and `cos_pi_div_three`.",
+    "type": "theorem",
+    "title": "Key Trigonometric Identities (Proved)",
+    "content": "Four identities for $\\pi/3$-shifted angles, all proved from Mathlib: $\\sin(\\pi/3 + \\theta) = (\\sqrt{3}/2)\\cos\\theta + (1/2)\\sin\\theta$ and $\\cos(\\pi/3 + \\theta) = (1/2)\\cos\\theta - (\\sqrt{3}/2)\\sin\\theta$ (by `simp` with `sin_add`/`cos_add`), the supplement identity $\\sin(2\\pi/3 + x) = \\sin(\\pi/3 - x)$, and the **triple sine product** $\\sin(3x) = 4\\sin(x)\\sin(\\pi/3 + x)\\sin(\\pi/3 - x)$. The last is the key identity that simplifies the sine-rule arm lengths in the trisector sub-triangles.",
+    "mathContext": "The expansions follow from $\\sin(a + b) = \\sin a \\cos b + \\cos a \\sin b$ and $\\cos(a + b) = \\cos a \\cos b - \\sin a \\sin b$ with $\\sin(\\pi/3) = \\sqrt{3}/2$, $\\cos(\\pi/3) = 1/2$. The triple product `sin_triple_product` is derived from Mathlib's `sin_three_mul` and the product-to-sum law `two_mul_sin_mul_sin`, using $\\cos(2\\pi/3) = -1/2$ and $\\cos(2x) = 1 - 2\\sin^2 x$ to reach $3\\sin x - 4\\sin^3 x = \\sin(3x)$. Every identity here is a fully checked theorem, not an axiom.",
     "significance": "key",
     "relatedConcepts": [
       "sin_add",
       "cos_add",
-      "sin_pi_div_three",
-      "cos_pi_div_three"
+      "triple-angle-formula",
+      "product-to-sum"
     ],
     "prerequisites": [
       "Real.sin",
       "Real.cos",
       "Real.sqrt",
-      "sin_add",
-      "cos_add"
+      "sin_three_mul"
     ]
   },
   {
-    "id": "ann-vertex-construction",
+    "id": "ann-cosine-rule-identity",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 174,
-      "endLine": 198
-    },
-    "type": "definition",
-    "title": "Original Triangle Vertex Construction",
-    "content": "Defines `Point := ℂ` and `direction θ := e^{iθ}` for angle-based construction. The vertices $A$, $B$, $C$ of the original triangle are reconstructed from the Morley triangle using the trisected angles: `vertexA t = R + direction(π - β₃)`, `vertexB t = P + direction(π + π/3 - γ₃)`, `vertexC t = Q + direction(π + 2π/3 - α₃)`. Each vertex lies at the intersection of lines from two Morley vertices at angles determined by the trisected angles.",
-    "mathContext": "The construction uses the complex plane as the Euclidean plane. The direction vector $e^{i\\theta}$ points at angle $\\theta$ from the positive real axis. Vertex $A$ is found by extending a ray from Morley vertex $R$ at angle $\\pi - \\beta_3$, vertex $B$ from $P$ at angle $\\pi + \\pi/3 - \\gamma_3$, and vertex $C$ from $Q$ at angle $\\pi + 2\\pi/3 - \\alpha_3$. The angles involve offsets of $0$, $\\pi/3$, and $2\\pi/3$ reflecting the equilateral triangle's rotational symmetry.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Complex.exp",
-      "direction-vector",
-      "backward-construction",
-      "complex-plane-geometry"
-    ],
-    "prerequisites": [
-      "Complex.exp",
-      "Complex.I",
-      "TriangleAngles"
-    ]
-  },
-  {
-    "id": "ann-morley-side",
-    "proofId": "morleys-theorem",
-    "range": {
-      "startLine": 217,
-      "endLine": 230
+      "startLine": 253,
+      "endLine": 276
     },
     "type": "theorem",
-    "title": "Morley Side Length Formula",
-    "content": "The `MorleyTriangle t` structure holds three complex points $M_1, M_2, M_3$ (the trisector intersections near sides $BC$, $CA$, $AB$ respectively). The remarkable **Morley side length formula** $s = 8R \\cdot \\sin(\\alpha/3) \\cdot \\sin(\\beta/3) \\cdot \\sin(\\gamma/3)$ (where $R$ is the circumradius) shows equilaterality immediately: the formula is **symmetric** in the three trisected angles, so all three sides are equal.",
-    "mathContext": "The formula $s = 8R \\sin(\\alpha_3) \\sin(\\beta_3) \\sin(\\gamma_3)$ can be derived from the law of sines applied to the sub-triangles formed by the Morley points and the original vertices. Since $\\sin(\\alpha_3)$, $\\sin(\\beta_3)$, $\\sin(\\gamma_3)$ appear symmetrically as a product, the formula yields the same value regardless of which pair of Morley points we measure — hence equilateral. For an equilateral original triangle ($\\alpha = \\beta = \\gamma = \\pi/3$), this gives $s = 8R \\sin^3(\\pi/9)$.",
+    "title": "The Cosine Rule Identity (Algebraic Heart)",
+    "content": "The theorem `cosine_rule_identity` proves the algebraic core of Morley's theorem: for any angles with $p + q + c = \\pi$, $$\\sin^2 p + \\sin^2 q - 2\\sin p \\sin q \\cos c = \\sin^2 c.$$ This is the law of cosines for a triangle inscribed in a unit-diameter circle (sides $\\sin p$, $\\sin q$, $\\sin c$). Applied with $p = \\pi/3 + \\alpha_3$, $q = \\pi/3 + \\beta_3$, $c = \\gamma_3$ (which sum to $\\pi$), it converts the cosine-rule distance computation into the symmetric Morley side-length formula.",
+    "mathContext": "The proof substitutes $c = \\pi - (p + q)$, uses $\\sin(\\pi - x) = \\sin x$ and $\\cos(\\pi - x) = -\\cos x$, expands $\\sin(p+q)$ and $\\cos(p+q)$ by the addition formulas, and closes the resulting polynomial identity with `nlinarith` supplied the Pythagorean relations $\\sin^2 + \\cos^2 = 1$ for both $p$ and $q$ together with the square-nonnegativity hints. No axiom is used.",
     "significance": "key",
     "relatedConcepts": [
-      "circumradius",
-      "law-of-sines",
-      "symmetric-formula",
-      "equilateral-triangle"
+      "law-of-cosines",
+      "trigonometric-identity",
+      "nlinarith",
+      "Pythagorean-identity"
     ],
     "prerequisites": [
       "Real.sin",
-      "TriangleAngles",
-      "MorleyTriangle"
+      "Real.cos",
+      "sin_pi_sub",
+      "cos_pi_sub"
+    ]
+  },
+  {
+    "id": "ann-morley-arm",
+    "proofId": "morleys-theorem",
+    "range": {
+      "startLine": 308,
+      "endLine": 332
+    },
+    "type": "theorem",
+    "title": "Core Computational Lemma: Cosine Side from Two Arms",
+    "content": "The def `cosineSideSq arm₁ arm₂ angle = arm₁² + arm₂² - 2·arm₁·arm₂·cos(angle)` packages the squared side produced by the cosine rule from two arm lengths and the included angle. The **core lemma** `morley_arm_cosine_rule` proves: when the arms are $k\\sin(\\pi/3 + a)$ and $k\\sin(\\pi/3 + b)$ and the included trisected angle is $c$ with $a + b + c = \\pi/3$, then the opposite Morley side squared equals $k^2 \\sin^2 c$.",
+    "mathContext": "This is where the sine-rule arms and the cosine rule meet. Since $a + b + c = \\pi/3$, the shifted angles satisfy $(\\pi/3 + a) + (\\pi/3 + b) + c = \\pi$, so `cosine_rule_identity` applies. The proof factors $k^2$ out of `cosineSideSq` by `ring`, then rewrites with the identity to land on $k^2 \\sin^2 c$. This single lemma, instantiated cyclically at each vertex, drives the whole side-length computation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "law-of-cosines",
+      "sine-rule",
+      "trisector-sub-triangle",
+      "symmetric-formula"
+    ],
+    "prerequisites": [
+      "cosine_rule_identity",
+      "Real.sin",
+      "Real.cos"
     ]
   },
   {
     "id": "ann-main-theorem",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 255,
-      "endLine": 270
+      "startLine": 361,
+      "endLine": 428
     },
-    "type": "concept",
-    "title": "Morley's Theorem (Wiedijk #84)",
-    "content": "**Morley's Theorem**: For any triangle with angles $\\alpha, \\beta, \\gamma$, the three intersection points $M_1, M_2, M_3$ of adjacent angle trisectors satisfy $|M_1 M_2| = |M_2 M_3| = |M_3 M_1|$. The main theorem `morleys_theorem` follows directly from `morleys_theorem_axiom`. The alternative formulation `morley_triangle_equilateral` adds a trivial `True` conjunct. The axiom encodes the deep geometric fact that the symmetric side length formula guarantees equilateral geometry.",
-    "mathContext": "The theorem asserts $|M_2 - M_1| = |M_3 - M_2|$ and $|M_3 - M_2| = |M_1 - M_3|$ using `Complex.abs` for Euclidean distance in the complex plane. The axiom `morleys_theorem_axiom` is the only axiom used for the main result (besides `equilateral_side_length_axiom` for the construction). A full proof would require showing that the backward construction produces valid trisectors, which involves substantial trigonometric computation.",
+    "type": "theorem",
+    "title": "Morley's Theorem — Equilateral Property (Proved, Wiedijk #84)",
+    "content": "The Morley side length is defined as `morleySideLength t R = 8R · sin(α₃) · sin(β₃) · sin(γ₃)`. The theorem `morleys_theorem_side_formula` **proves** that all three cosine-rule-computed sides equal $(\\text{morleySideLength})^2$, by applying `morley_arm_cosine_rule` at each of the three vertices (angle $\\gamma_3$ at $C$, $\\alpha_3$ at $A$, $\\beta_3$ at $B$) and closing each with `ring`. Its corollary `morleys_theorem_equilateral` then proves $M_1M_2 = M_2M_3 = M_3M_1$ directly by `linarith`. There are **no axioms** — both are fully machine-checked.",
+    "mathContext": "Each side, via the sine rule in the trisector sub-triangles and the cosine rule across the shared vertex, equals $(8R \\sin\\alpha_3 \\sin\\beta_3 \\sin\\gamma_3)^2$. Because this value is **symmetric** in $\\alpha_3, \\beta_3, \\gamma_3$, the three sides squared are identical, so the sides are equal. `morleys_theorem_side_formula` establishes the three equalities to the common symmetric value; `morleys_theorem_equilateral` derives pairwise equality of the sides as the equilateral conclusion.",
     "significance": "key",
     "relatedConcepts": [
       "equilateral-triangle",
-      "Complex.abs",
+      "symmetric-formula",
       "Wiedijk-100-theorems",
-      "axiom-based-proof"
+      "law-of-cosines"
     ],
     "prerequisites": [
-      "morleys_theorem_axiom",
-      "MorleyTriangle",
-      "TriangleAngles",
-      "Complex.abs"
+      "morley_arm_cosine_rule",
+      "morleySideLength",
+      "TriangleAngles"
     ]
   },
   {
     "id": "ann-special-cases",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 283,
-      "endLine": 311
+      "startLine": 434,
+      "endLine": 469
     },
     "type": "definition",
     "title": "Special Cases: Equilateral and Right Isosceles",
@@ -198,8 +197,8 @@
     "id": "ann-history",
     "proofId": "morleys-theorem",
     "range": {
-      "startLine": 317,
-      "endLine": 352
+      "startLine": 475,
+      "endLine": 524
     },
     "type": "concept",
     "title": "Historical Significance and Generalizations",
@@ -213,7 +212,7 @@
       "compass-straightedge"
     ],
     "prerequisites": [
-      "morleys_theorem",
+      "morleys_theorem_equilateral",
       "angle-trisection"
     ]
   }


### PR DESCRIPTION
## Fix

The `morleys-theorem` annotations described a long-gone axiom-based version of the file; re-authored all 9 to match the current axiom-free, fully-proved source.

## Evidence

**Before**: Annotations referenced constructs absent from `proofs/Proofs/MorleysTheorem.lean`:
- `equilateral_side_length_axiom` and `morleys_theorem_axiom` (stated as the main result's axioms)
- a `MorleyTriangle` structure with `M₁,M₂,M₃`, plus `vertexA/B/C`, `Point := ℂ`, `direction θ`
- `morley_triangle_equilateral` ("trivial `True` conjunct"), tag `axiom-based-proof`
- ann-trig-identity falsely claimed those two were "the only theorems in the file proved without axioms"
- all line ranges were misaligned to the source

**After**: `MorleysTheorem.lean` is `status: verified`, `axiomCount: 0`, `sorries: 0` (`grep -cE '^\s*axiom ' = 0`). It proves Morley's theorem via the sine-rule / cosine-rule method. Annotations now describe the actual theorems — `equilateral_side_length`, `sin_pi_third_add`/`cos_pi_third_add`/`sin_two_thirds_pi_add`/`sin_triple_product`, `cosine_rule_identity`, `cosineSideSq`/`morley_arm_cosine_rule`, `morleySideLength`, `morleys_theorem_side_formula`, `morleys_theorem_equilateral` — all proved, with every line range realigned.

Metadata was already correct (verified / 0 axioms / 0 sorries); only the annotations were stale. PR #23616 realigned sections earlier but left the axiom-based annotation text in place.

---
Automated fix by lean-mechanic agent.