### PR TITLE
Enrich Sharpness of the Automorphism Bound (|Aut_F(K)|=[K:F]_s ⟺ K/F normal)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-autToAlgHom-def",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "definition",
+    "title": "From automorphism to embedding: e ↦ K.val ∘ e",
+    "content": "The map `autToAlgHom` sends an F-automorphism `e : K ≃ₐ[F] K` to the F-embedding `K →ₐ[F] L` obtained by post-composing with the canonical inclusion `K.val : K ↪ L`. This is the single map around which the whole sharpness argument turns: the parent entry showed it is injective (giving the inequality `|Aut| ≤ [K:F]_s`), and this entry shows equality of counts forces it to be surjective. The `@[simp]` lemma `autToAlgHom_apply` records the definitional fact that its value at `x` is just `↑(e x) : L`, the inclusion of `e x` into the ambient field.",
+    "mathContext": "$\\mathrm{autToAlgHom}(e) = \\iota_K \\circ e$, where $\\iota_K : K \\hookrightarrow L$ is the inclusion. As a map of sets $\\mathrm{Aut}_F(K) \\to \\mathrm{Hom}_F(K, L)$, it realises every automorphism of $K$ as an embedding of $K$ into $L$ that happens to land back inside $K$.",
+    "significance": "key",
+    "relatedConcepts": ["F-algebra homomorphism", "intermediate field inclusion", "automorphism group", "field embedding"],
+    "prerequisites": ["field extensions", "algebra homomorphisms", "intermediate fields"]
+  },
+  {
+    "id": "ann-autToAlgHom-injective",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 66, "endLine": 71 },
+    "type": "technique",
+    "title": "Injectivity from the injective inclusion",
+    "content": "`autToAlgHom` is injective because post-composition with the injective inclusion `K ↪ L` cannot identify distinct automorphisms: if `K.val ∘ e₁ = K.val ∘ e₂` then `e₁ x` and `e₂ x` have equal images in `L` for every `x`, and since `K ↪ L` is injective they are equal in `K`, so `e₁ = e₂`. The Lean proof is a one-liner: `ext x`, then `DFunLike.congr_fun h x` pushes the function equality down to a pointwise equality which `simp` discharges. This injection is precisely the content the parent entry used to obtain the bound `|Aut_F(K)| ≤ [K:F]_s`.",
+    "mathContext": "If $\\iota_K \\circ e_1 = \\iota_K \\circ e_2$ and $\\iota_K$ is injective, then $e_1 = e_2$. Equivalently, the cardinality bound $|\\mathrm{Aut}_F(K)| \\le |\\mathrm{Hom}_F(K,L)|$ follows from $\\mathrm{Nat.card\\_le\\_card\\_of\\_injective}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["injective function", "function extensionality", "cardinality bound", "DFunLike"],
+    "prerequisites": ["injectivity", "function extensionality"]
+  },
+  {
+    "id": "ann-fieldRange-le",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "insight",
+    "title": "Every automorphism's image stays inside K",
+    "content": "`autToAlgHom_fieldRange_le` records that the field range of `autToAlgHom K e` is contained in `K`. The proof destructures a range element `y` via `AlgHom.mem_fieldRange` to get `y = autToAlgHom K e x = ↑(e x)`, and then `SetLike.coe_mem (e x)` says `↑(e x)` is by construction a member of `K`. This is the pivotal observation that links automorphisms to normality: an automorphism, viewed as an embedding, never escapes `K`. The normality criterion demands *every* embedding has this property, so once surjectivity makes every embedding an automorphism, normality follows.",
+    "mathContext": "For an automorphism $e$, $\\mathrm{range}(\\iota_K \\circ e) = e(K) = K \\le K$. In fact equality holds, but only $\\le$ is needed: $\\sigma.\\mathrm{fieldRange} \\le K$ is exactly the hypothesis of $\\mathrm{normal\\_iff\\_forall\\_fieldRange\\_le}$.",
+    "significance": "key",
+    "relatedConcepts": ["field range", "normal extension", "Galois action stability", "conjugate subfields"],
+    "prerequisites": ["field range of an algebra homomorphism", "intermediate field membership"]
+  },
+  {
+    "id": "ann-main-biconditional",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 84, "endLine": 103 },
+    "type": "concept",
+    "title": "Main theorem: equal counts ⟺ normal (relative form)",
+    "content": "`normal_iff_card_aut_eq_card_algHom` is the heart of the entry: for a finite intermediate field `K` of a normal extension `L/F`, `Nat.card (K ≃ₐ[F] K) = Nat.card (K →ₐ[F] L)` if and only if `K/F` is normal. The genuinely new direction is `→`: from equal finite cardinalities and injectivity, `Nat.bijective_iff_injective_and_card` upgrades `autToAlgHom` to a bijection. Surjectivity means every embedding `σ` equals `autToAlgHom K e` for some automorphism `e`, hence `σ.fieldRange ≤ K`, and `normal_iff_forall_fieldRange_le` concludes normality — with no minimal-polynomial or splitting-field computation. The `←` direction is Mathlib's `Normal.algHomEquivAut`, counted by `Nat.card_congr`.",
+    "mathContext": "$|\\mathrm{Aut}_F(K)| = |\\mathrm{Hom}_F(K,L)| \\iff K/F \\text{ normal}$. The forward map is always an injection $\\mathrm{Aut}_F(K) \\hookrightarrow \\mathrm{Hom}_F(K,L)$; equal finite cardinality is exactly the condition for it to be a bijection, and a bijection means $K$ is stable under all embeddings, i.e. normal.",
+    "significance": "key",
+    "relatedConcepts": ["normal extension", "bijection from cardinality", "Artin's theorem", "Galois theory", "separable degree"],
+    "prerequisites": ["normal extensions", "finite cardinality counting", "Mathlib normality criteria"]
+  },
+  {
+    "id": "ann-finSepDegree-form",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 105, "endLine": 114 },
+    "type": "concept",
+    "title": "Separable-degree form: |Aut_F(K)| = [K:F]_s ⟺ normal",
+    "content": "`normal_iff_card_aut_eq_finSepDegree` is the headline statement. When the ambient `L` is algebraically closed, `Field.finSepDegree_eq_of_isAlgClosed` identifies the embedding count `Nat.card (K →ₐ[F] L)` with the separable degree `[K:F]_s := Field.finSepDegree F K`. Rewriting by this equation reduces the claim to the relative form, so the parent's bound `|Aut_F(K)| ≤ [K:F]_s` is now characterised: equality is attained exactly when `K/F` is normal. For separable extensions `[K:F]_s = [K:F]`, recovering the classical Galois criterion `|Aut_F(K)| = [K:F] ⟺ K/F Galois` as a special case.",
+    "mathContext": "$|\\mathrm{Aut}_F(K)| = [K:F]_s \\iff K/F \\text{ normal}$, where $[K:F]_s$ is the separable degree (number of F-embeddings into $\\bar F$). When $K/F$ is separable, $[K:F]_s = [K:F]$ and this becomes the classical statement that $K/F$ is Galois iff $|\\mathrm{Aut}_F(K)| = [K:F]$.",
+    "significance": "key",
+    "relatedConcepts": ["separable degree", "algebraically closed field", "Galois extension", "fundamental theorem of Galois theory"],
+    "prerequisites": ["separable degree", "algebraic closure", "Galois extensions"]
+  },
+  {
+    "id": "ann-strict-corollary",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 116, "endLine": 127 },
+    "type": "insight",
+    "title": "Quantitative sharpness: strict inequality off the normal locus",
+    "content": "`card_aut_lt_finSepDegree_of_not_normal` turns the biconditional into a quantitative statement: if `K/F` is *not* normal then `|Aut_F(K)| < [K:F]_s` strictly. The proof combines the parent inequality `≤` (from `Nat.card_le_card_of_injective` on `autToAlgHom`) with `≠` (the contrapositive of the equality characterisation) via `lt_of_le_of_ne`. So the automorphism group is strictly smaller than the separable degree precisely on non-normal extensions — the bound is never wastefully loose on the normal locus and never attained off it.",
+    "mathContext": "$K/F \\text{ not normal} \\implies |\\mathrm{Aut}_F(K)| < [K:F]_s$. The defect $[K:F]_s - |\\mathrm{Aut}_F(K)| > 0$ measures how far $K$ is from being closed under the Galois action; it vanishes exactly on normal extensions.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict inequality", "lt_of_le_of_ne", "normal closure", "defect of an extension"],
+    "prerequisites": ["strict vs non-strict inequalities", "contrapositive reasoning"]
+  },
+  {
+    "id": "ann-capstone-example",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02",
+    "range": { "startLine": 131, "endLine": 147 },
+    "type": "context",
+    "title": "Capstone: the clean form over an algebraic closure",
+    "content": "The final `example` specialises the ambient field to `L = AlgebraicClosure F`, which is simultaneously normal and algebraically closed over `F`. With these instances in scope, every finite intermediate field `K` satisfies the clean, quotable biconditional `Nat.card (K ≃ₐ[F] K) = Field.finSepDegree F K ↔ Normal F K` — no auxiliary ambient field need be named. This is the form a textbook states: a finite extension is normal exactly when its automorphism group has order equal to its separable degree.",
+    "mathContext": "Taking $L = \\overline{F}$: for any finite $K$ with $F \\le K \\le \\overline{F}$, $|\\mathrm{Aut}_F(K)| = [K:F]_s \\iff K/F \\text{ normal}$. This is the canonical sharpness statement decoupled from any choice of ambient normal field.",
+    "significance": "context",
+    "relatedConcepts": ["algebraic closure", "normal extension", "separable degree", "splitting field"],
+    "prerequisites": ["algebraic closure", "instance resolution in Lean"]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02Data: ProofData = {
+  proof: angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02Proof,
+  annotations: angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02` (quality 30, 0 prior passes).

## Changes
- **Added missing `index.ts`** — the proof had only `meta.json`, so it showed "proof not found" on the live site. Now wired up via the standard Vite `?raw` source import.
- **Added `annotations.json`** — 7 annotations covering the full Lean file (def `autToAlgHom`, injectivity, fieldRange ≤ K, the main biconditional, the separable-degree form, the strict-inequality corollary, and the algebraic-closure capstone). Every annotation has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **Added `sections` array** to meta.json (was absent) covering all five parts of the proof with accurate line ranges.

## Notes
- Verified against the Lean source: 6 theorems / 1 def, 0 sorries, 0 axiom declarations; `status: verified`, `badge: original`, `axiomCount: 0` all accurate (no `native_decide`, no structure-encoded assumptions).
- Cross-references to parent (…-oq-05) and sibling (…-oq-05-oq-01) preserved.
- JSON validated; build data-generation step passes (the `tsc not found` failure is a local env issue, not a data error).