### PR TITLE
Enrich Subset Counting OQ-01 (Cantor's theorem, infinite analogue)

### DIFF
--- a/src/data/proofs/subset-count-oq-01/annotations.json
+++ b/src/data/proofs/subset-count-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "subset-count-oq-01",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "From Finite Subset Counting to Cantor's Theorem",
+    "content": "The parent entry counts the subsets of a finite set: an n-element set has exactly 2^n subsets. This file makes explicit the two facts hidden inside that formula: 2^n already strictly exceeds n (a finite set has strictly more subsets than elements), and this strict gap is not a finiteness artifact — it holds at every cardinality. That universal strict gap is Cantor's theorem (1891), the infinite analogue of subset counting and the source of the transfinite hierarchy of infinities.",
+    "mathContext": "Parent: $|\\mathcal P(S)| = 2^n$ for $|S| = n$. This entry: $|S| < |\\mathcal P(S)|$ for every set $S$ — Cantor's theorem.",
+    "significance": "context",
+    "relatedConcepts": ["Cantor's theorem", "power set", "cardinality", "diagonal argument", "transfinite hierarchy"],
+    "prerequisites": ["set theory", "cardinality"]
+  },
+  {
+    "id": "ann-diagonal-set",
+    "proofId": "subset-count-oq-01",
+    "range": { "startLine": 37, "endLine": 50 },
+    "type": "insight",
+    "title": "The Diagonal Set Escapes Every Enumeration",
+    "content": "diagonalSet f = {x | x ∉ f x} is the explicit witness of Cantor's argument: it collects exactly the elements that are NOT members of the set they are mapped to. The key lemma diagonalSet_not_mem_range shows it can never equal any f(a). If it did, then asking whether a ∈ f(a) gives a ∈ f(a) ↔ a ∈ diagonalSet f ↔ a ∉ f(a) — a direct contradiction (closed by tauto). A single set disagrees with every f(a) precisely at the point a, so it escapes the entire range. This is the whole diagonal argument in one self-contained step, with no appeal to Mathlib's Cantor lemmas.",
+    "mathContext": "$D := \\{x \\mid x \\notin f(x)\\}$. If $f(a) = D$ then $a \\in f(a) \\iff a \\notin f(a)$ — contradiction. So $D \\notin \\mathrm{range}\\,f$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal argument", "self-reference", "Russell's paradox", "range of a function"],
+    "prerequisites": ["sets", "functions", "proof by contradiction"]
+  },
+  {
+    "id": "ann-cantor-maps",
+    "proofId": "subset-count-oq-01",
+    "range": { "startLine": 52, "endLine": 61 },
+    "type": "concept",
+    "title": "Surjection and Injection Forms of Cantor's Theorem",
+    "content": "The diagonal lemma immediately yields Cantor in two dual forms. not_surjective_to_set: no f : α → Set α can be surjective, because surjectivity would force the diagonal set into the range, which it provably avoids. not_injective_from_set: no g : Set α → α can be injective — there is no way to label distinct subsets by distinct elements (re-exporting Mathlib's cantor_injective). Together they say the power set is unreachable both 'from below' (cannot enumerate it) and 'from above' (cannot embed it back).",
+    "mathContext": "No $f : \\alpha \\to \\mathcal P(\\alpha)$ is onto; no $g : \\mathcal P(\\alpha) \\to \\alpha$ is injective.",
+    "significance": "supporting",
+    "relatedConcepts": ["surjection", "injection", "Cantor's theorem", "cardinal comparison"],
+    "prerequisites": ["surjective and injective maps", "Cantor's theorem"]
+  },
+  {
+    "id": "ann-cardinal-form",
+    "proofId": "subset-count-oq-01",
+    "range": { "startLine": 63, "endLine": 74 },
+    "type": "concept",
+    "title": "The Cardinal Inequality #α < 2^#α",
+    "content": "On the cardinal side the result becomes the literal infinite analogue of the parent's count. mk_set_eq_two_pow records #(Set α) = 2^#α — exactly the parent's Fintype.card (Finset α) = 2^n promoted from natural numbers to arbitrary cardinals. mk_lt_mk_set then combines this with Mathlib's Cardinal.cantor to give the strict inequality #α < #(Set α), and mk_lt_two_pow_mk states it as #α < 2^#α. The exponential 2^κ is genuine cardinal exponentiation, so this is Cantor's theorem at full generality.",
+    "mathContext": "$\\#(\\mathrm{Set}\\,\\alpha) = 2^{\\#\\alpha}$ and $\\#\\alpha < 2^{\\#\\alpha}$ (Cardinal.cantor). The infinite analogue of $|\\mathcal P(S)| = 2^n > n$.",
+    "significance": "key",
+    "relatedConcepts": ["cardinal arithmetic", "cardinal exponentiation", "power set cardinality", "Cantor's theorem"],
+    "prerequisites": ["cardinal numbers", "cardinal exponentiation"]
+  },
+  {
+    "id": "ann-finite-shadow",
+    "proofId": "subset-count-oq-01",
+    "range": { "startLine": 76, "endLine": 90 },
+    "type": "concept",
+    "title": "The Finite Shadow: n < 2^n",
+    "content": "card_lt_card_finset closes the loop back to the parent. For a finite type, Fintype.card α < Fintype.card (Finset α), and since Fintype.card (Finset α) = 2^n (the parent's count), this unfolds to n < 2^n via Nat.lt_two_pow_self. card_lt_two_pow states the bare arithmetic fact n < 2^n. These show the parent's 2^n is not merely a count but a strict upper bound on n — the finite case of Cantor's theorem, exhibiting the same strict gap that the cardinal form generalises to every infinity.",
+    "mathContext": "$\\mathrm{card}\\,\\alpha < \\mathrm{card}(\\mathrm{Finset}\\,\\alpha) = 2^{\\mathrm{card}\\,\\alpha}$, i.e. $n < 2^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finite cardinality", "Finset", "n < 2^n", "finite Cantor"],
+    "prerequisites": ["finite types", "natural number inequalities"]
+  }
+]

--- a/src/data/proofs/subset-count-oq-01/meta.json
+++ b/src/data/proofs/subset-count-oq-01/meta.json
@@ -66,6 +66,43 @@
       "description": "Both formalize Cantor's theorem; this entry approaches it from the subset-counting lineage (finite 2^n strictly dominates n, generalized to every cardinal) and supplies an explicit diagonal-set witness."
     }
   ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Lineage: from the finite count 2^n to Cantor's theorem",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring framing the file as the infinite analogue of the parent's finite subset count Fintype.card (Finset α) = 2^n. Two facts hide in 2^n: it already strictly exceeds n, and that strict gap persists at every cardinality — which is Cantor's theorem. Imports Mathlib, opens Function and scoped Cardinal, and opens the SubsetCountOQ01 namespace with universe-polymorphic α."
+    },
+    {
+      "id": "diagonal-set",
+      "title": "The Explicit Diagonal Set and the Diagonal Argument",
+      "startLine": 37,
+      "endLine": 50,
+      "summary": "diagonalSet f := {x | x ∉ f x} is the set of elements not contained in their own image under a candidate enumeration f : α → Set α. diagonalSet_not_mem_range proves it never lies in the range of f: if f a = diagonalSet f then a ∈ f a ↔ a ∉ f a, a contradiction discharged by tauto. This is the self-contained core of the whole file."
+    },
+    {
+      "id": "cantor-maps",
+      "title": "Cantor's Theorem: Surjection and Injection Forms",
+      "startLine": 52,
+      "endLine": 61,
+      "summary": "not_surjective_to_set: no f : α → Set α is surjective, since surjectivity would place the diagonal set in the range, contradicting diagonalSet_not_mem_range. not_injective_from_set: no g : Set α → α is injective, re-exporting Mathlib's cantor_injective — the dual labelling form."
+    },
+    {
+      "id": "cardinal-form",
+      "title": "The Cardinal Form #α < #(Set α) = 2^#α",
+      "startLine": 63,
+      "endLine": 74,
+      "summary": "mk_set_eq_two_pow records #(Set α) = 2^#α (Cardinal.mk_set) — the literal infinite analogue of the parent's 2^n. mk_lt_mk_set rewrites with it and applies Cardinal.cantor to give the strict inequality #α < #(Set α); mk_lt_two_pow_mk states the same in exponential form #α < 2^#α."
+    },
+    {
+      "id": "finite-shadow",
+      "title": "The Finite Shadow n < 2^n",
+      "startLine": 76,
+      "endLine": 90,
+      "summary": "card_lt_card_finset: Fintype.card α < Fintype.card (Finset α) for finite α, via Fintype.card_finset (= 2^n) and Nat.lt_two_pow_self — the parent's count already strictly dominates the element count. card_lt_two_pow states the arithmetic shadow n < 2^n directly. These are the finite case of Cantor, anchoring the infinite result to the parent's lineage."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
Enrichment pass for `subset-count-oq-01` (quality 32, pass 0).

## What was added
- **No `annotations.json`** previously — created with 5 inline annotations (each with `mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`) covering the finite→infinite lineage, the explicit diagonal set, the surjection/injection forms, the cardinal form #α < 2^#α, and the finite shadow n < 2^n.
- **Empty `sections`** — added 5 conforming `ProofSection` entries (`startLine`/`endLine`/`summary`) mapped to the actual Lean line ranges.
- meta.json already had a rich `overview`, `conclusion` (with implications + openQuestions), `crossReferences`, and `mainTheorems` — left intact.

## Accuracy notes
- meta.json reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: original`; confirmed against the Lean source (no `axiom`/`sorry`/structure-encoded assumptions; no `native_decide`). No status/badge changes.
- Annotations match the actual declarations (diagonalSet, diagonalSet_not_mem_range, not_surjective_to_set, not_injective_from_set, mk_lt_mk_set, card_lt_card_finset). Cross-reference slugs (subset-count, cantors-theorem) verified to exist.
- Did not add an `index.ts` shim: per issue #20993 the loader fetches build-generated data from `public/data/proofs/` and no longer imports per-proof index modules.

`pnpm build` passes.