### PR TITLE
research(area-of-circle-oq-07-oq-03-oq-01): even Gaussian moments are the half-integer Gamma ladder

### DIFF
--- a/proofs/Proofs/AreaOfCircleOQ07OQ03OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ07OQ03OQ01.lean
@@ -1,0 +1,119 @@
+import Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral
+import Mathlib.MeasureTheory.Integral.Gamma
+import Mathlib.Tactic
+
+/-
+# The half-integer Gamma ladder as the tower of even Gaussian moments
+
+## Open Question (area-of-circle-oq-07-oq-03-oq-01)
+Formalize the half-integer ladder `Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ` and identify
+each value with the even Gaussian moment `∫_ℝ x^{2n} e^{-x²} dx`, extending the
+single `√π` of the parent entry (`Γ(1/2) = √π`, the `n = 0` rung) to the whole
+tower of half-integer Gamma values.
+
+## Answer: YES — the even moments *are* the half-integer Gamma values.
+
+The parent entry `area-of-circle-oq-07-oq-03` proves the bottom rung
+`Γ(1/2) = √π = ∫_ℝ e^{-x²}`.  Here we climb the whole ladder.
+
+The bridge is a single Mathlib evaluation, `integral_rpow_mul_exp_neg_rpow`,
+which gives over the half-line `∫_{x>0} x^q e^{-x^p} = (1/p)·Γ((q+1)/p)`.
+Specialising `p = 2`, `q = 2n` yields `∫_{x>0} x^{2n} e^{-x²} = ½·Γ(n + 1/2)`.
+The integrand `x^{2n} e^{-x²}` is **even** (the exponent `2n` is even and
+`e^{-x²}` depends only on `|x|`), so `integral_comp_abs` doubles the half-line
+integral to the full line:
+
+    ∫_ℝ x^{2n} e^{-x²} dx = 2 · ½ · Γ(n + 1/2) = Γ(n + 1/2).
+
+Combined with Mathlib's closed form `Real.Gamma_nat_add_half`
+(`Γ(k + 1/2) = (2k-1)‼ · √π / 2ᵏ`) this exhibits every even Gaussian moment as a
+double-factorial multiple of `√π`:
+
+    ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ.
+
+The companion odd moments vanish by oddness, so the *entire* moment sequence of
+the Gaussian weight `e^{-x²}` is pinned down.
+
+## Results
+* `evenGaussianMoment_eq_gamma` — `∫_ℝ x^{2n} e^{-x²} = Γ(n + 1/2)`;
+* `evenGaussianMoment_eq_doubleFactorial` — `∫_ℝ x^{2n} e^{-x²} = (2n-1)‼·√π/2ⁿ`;
+* `gammaLadder` — re-export of the half-integer ladder `Γ(n+1/2) = (2n-1)‼·√π/2ⁿ`;
+* `oddGaussianMoment_eq_zero` — `∫_ℝ x^{2n+1} e^{-x²} = 0`;
+* `evenGaussianMoment_zero` — the `n = 0` rung recovers the parent `∫_ℝ e^{-x²} = √π`.
+
+No new axioms: every step is a consequence of existing Mathlib results.
+-/
+
+open Real MeasureTheory Set
+open scoped Nat
+
+namespace AreaOfCircleOQ07OQ03OQ01
+
+/-- **Half-line even moment.** `∫_{x>0} x^{2n} e^{-x²} = ½·Γ(n + 1/2)`.
+The natural-power integrand is converted to the real-power form and evaluated by
+Mathlib's `integral_rpow_mul_exp_neg_rpow` at `p = 2`, `q = 2n`. -/
+private lemma halfLine_evenMoment (n : ℕ) :
+    ∫ x in Ioi (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2) = (1 / 2) * Real.Gamma (n + 1 / 2) := by
+  rw [show (∫ x in Ioi (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2))
+        = ∫ x in Ioi (0 : ℝ), x ^ (2 * (n : ℝ)) * Real.exp (-x ^ (2 : ℝ)) from
+      setIntegral_congr_fun measurableSet_Ioi (fun x _ => by
+        rw [← Real.rpow_natCast x (2 * n), ← Real.rpow_natCast x 2]
+        push_cast
+        ring_nf)]
+  rw [integral_rpow_mul_exp_neg_rpow (by norm_num : (0 : ℝ) < 2)
+      (by have h : (0 : ℝ) ≤ 2 * (n : ℝ) := by positivity
+          linarith)]
+  rw [show (2 * (n : ℝ) + 1) / 2 = (n : ℝ) + 1 / 2 by ring]
+
+/-- **Even Gaussian moment as a half-integer Gamma value.**
+The `2n`-th moment of the Gaussian weight `e^{-x²}` over the whole real line is
+exactly `Γ(n + 1/2)`.  The proof folds the line onto the half-line by evenness
+(`integral_comp_abs`) and evaluates the half-line integral via
+`halfLine_evenMoment`. -/
+theorem evenGaussianMoment_eq_gamma (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = Real.Gamma (n + 1 / 2) := by
+  have heq : (fun x : ℝ => x ^ (2 * n) * Real.exp (-x ^ 2))
+      = fun x : ℝ => (fun t : ℝ => t ^ (2 * n) * Real.exp (-t ^ 2)) |x| := by
+    funext x
+    simp only [sq_abs, (even_two_mul n).pow_abs]
+  rw [heq, integral_comp_abs (f := fun t : ℝ => t ^ (2 * n) * Real.exp (-t ^ 2))]
+  show 2 * (∫ x in Ioi (0 : ℝ), x ^ (2 * n) * Real.exp (-x ^ 2)) = Real.Gamma (n + 1 / 2)
+  rw [halfLine_evenMoment]
+  ring
+
+/-- **The even Gaussian moments are double-factorial multiples of `√π`.**
+`∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼ · √π / 2ⁿ`.  Combines the Gamma identification
+above with Mathlib's closed form `Real.Gamma_nat_add_half`. -/
+theorem evenGaussianMoment_eq_doubleFactorial (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n) * Real.exp (-x ^ 2) = (2 * n - 1)‼ * √π / 2 ^ n := by
+  rw [evenGaussianMoment_eq_gamma, Real.Gamma_nat_add_half]
+
+/-- **The half-integer Gamma ladder** (re-export of `Real.Gamma_nat_add_half`):
+`Γ(n + 1/2) = (2n-1)‼ · √π / 2ⁿ`.  The whole tower above the parent entry's
+`Γ(1/2) = √π` rung. -/
+theorem gammaLadder (n : ℕ) :
+    Real.Gamma (n + 1 / 2) = (2 * n - 1)‼ * √π / 2 ^ n :=
+  Real.Gamma_nat_add_half n
+
+/-- **The odd Gaussian moments vanish.**
+`∫_ℝ x^{2n+1} e^{-x²} dx = 0`, because the integrand is an odd function and the
+Lebesgue measure on `ℝ` is invariant under negation. -/
+theorem oddGaussianMoment_eq_zero (n : ℕ) :
+    ∫ x : ℝ, x ^ (2 * n + 1) * Real.exp (-x ^ 2) = 0 := by
+  have hmp := (Measure.measurePreserving_neg (volume : Measure ℝ)).integral_comp
+    measurableEmbedding_neg
+    (fun x : ℝ => x ^ (2 * n + 1) * Real.exp (-x ^ 2))
+  simp only [neg_sq, Odd.neg_pow (odd_two_mul_add_one n), neg_mul] at hmp
+  rw [integral_neg] at hmp
+  linarith
+
+/-- **Bottom rung = parent entry.**  The `n = 0` even moment recovers the parent
+entry's Gaussian integral `∫_ℝ e^{-x²} = √π` and the value `Γ(1/2)`. -/
+theorem evenGaussianMoment_zero :
+    ∫ x : ℝ, Real.exp (-x ^ 2) = √π := by
+  have h := evenGaussianMoment_eq_gamma 0
+  simp only [mul_zero, pow_zero, one_mul, Nat.cast_zero, zero_add] at h
+  rw [h]
+  exact Real.Gamma_one_half_eq
+
+end AreaOfCircleOQ07OQ03OQ01

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/annotations.json
@@ -1,0 +1,136 @@
+[
+  {
+    "id": "half-line-moment",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 52,
+      "endLine": 66
+    },
+    "type": "technique",
+    "title": "The Half-Line Even Moment = ½·Γ(n+1/2)",
+    "content": "`halfLine_evenMoment` evaluates ∫_{x>0} x^{2n} e^{-x²} = ½·Γ(n+1/2). The integrand is written with natural-number powers (`x ^ (2*n)`, `x ^ 2`), but Mathlib's evaluation lemma `integral_rpow_mul_exp_neg_rpow` is stated for real powers, so a `setIntegral_congr_fun` over Ioi 0 converts each `x ^ (k : ℕ)` to `x ^ (k : ℝ)` via `Real.rpow_natCast` (valid for x > 0). With p = 2 and q = 2n the lemma yields (1/p)·Γ((q+1)/p) = ½·Γ(n+1/2), since (2n+1)/2 = n+1/2.",
+    "mathContext": "$\\int_0^\\infty x^{2n}e^{-x^2}\\,dx = \\tfrac12\\,\\Gamma\\!\\left(n+\\tfrac12\\right)$, from $\\int_0^\\infty x^q e^{-x^p} = \\tfrac1p\\Gamma\\!\\left(\\tfrac{q+1}{p}\\right)$ at $p=2,\\,q=2n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gamma integral representation",
+      "rpow vs npow",
+      "Mellin-type substitution"
+    ],
+    "prerequisites": [
+      "Gamma function",
+      "set integrals",
+      "real powers"
+    ]
+  },
+  {
+    "id": "even-moment-gamma",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 82
+    },
+    "type": "insight",
+    "title": "Every Even Gaussian Moment IS a Half-Integer Gamma Value",
+    "content": "`evenGaussianMoment_eq_gamma` is the headline: ∫_ℝ x^{2n} e^{-x²} = Γ(n+1/2). The integrand x^{2n} e^{-x²} is even — the exponent 2n is even (`Even.pow_abs` gives |x|^{2n} = x^{2n}) and e^{-x²} depends only on |x| (`sq_abs`) — so it equals f(|x|) for f(t) = t^{2n} e^{-t²}. Mathlib's `integral_comp_abs` then folds the full line onto twice the half-line, and `halfLine_evenMoment` supplies ½·Γ(n+1/2), giving 2·½·Γ(n+1/2) = Γ(n+1/2). This is the structural advance: the parent's single √π = Γ(1/2) is just the n=0 rung of an infinite tower, and the whole tower is realized as Gaussian moments.",
+    "mathContext": "$\\int_{\\mathbb{R}} x^{2n}e^{-x^2}\\,dx = \\Gamma\\!\\left(n+\\tfrac12\\right)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "even functions",
+      "Gaussian moments",
+      "Gamma function",
+      "moment sequence"
+    ],
+    "prerequisites": [
+      "even/odd symmetry of integrals",
+      "Gamma function"
+    ]
+  },
+  {
+    "id": "double-factorial",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 89
+    },
+    "type": "concept",
+    "title": "Closed Form: (2n−1)‼·√π/2ⁿ",
+    "content": "`evenGaussianMoment_eq_doubleFactorial` composes the Gamma identification with Mathlib's closed form `Real.Gamma_nat_add_half` (Γ(k+1/2) = (2k−1)‼·√π/2ᵏ) to write each even Gaussian moment as a double-factorial multiple of √π: ∫_ℝ x^{2n} e^{-x²} = (2n−1)‼·√π/2ⁿ. For n = 1 this is √π/2 (the variance integral), for n = 2 it is 3√π/4, and so on — every value is a rational multiple of the same √π that the parent entry isolates at n = 0.",
+    "mathContext": "$\\int_{\\mathbb{R}} x^{2n}e^{-x^2}\\,dx = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "double factorial",
+      "closed form",
+      "moment generating function"
+    ],
+    "prerequisites": [
+      "double factorial",
+      "Gamma special values"
+    ]
+  },
+  {
+    "id": "gamma-ladder",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 96
+    },
+    "type": "concept",
+    "title": "The Half-Integer Gamma Ladder",
+    "content": "`gammaLadder` records the underlying special-value formula Γ(n+1/2) = (2n−1)‼·√π/2ⁿ, a direct re-export of Mathlib's `Real.Gamma_nat_add_half`. It is the analytic backbone of the entry: the functional equation Γ(s+1) = s·Γ(s) lifts the bottom rung Γ(1/2) = √π up the whole half-integer ladder, multiplying by (n−1/2)(n−3/2)···(1/2) = (2n−1)‼/2ⁿ. This entry's contribution is not this formula (Mathlib has it) but its identification with the Gaussian moments above.",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right) = \\dfrac{(2n-1)!!\\,\\sqrt{\\pi}}{2^{n}}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gamma functional equation",
+      "double factorial",
+      "half-integer values"
+    ],
+    "prerequisites": [
+      "Gamma function",
+      "recurrence relations"
+    ]
+  },
+  {
+    "id": "odd-moment",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 108
+    },
+    "type": "insight",
+    "title": "The Odd Moments Vanish",
+    "content": "`oddGaussianMoment_eq_zero` completes the moment picture: ∫_ℝ x^{2n+1} e^{-x²} = 0. The integrand is odd (`Odd.neg_pow` gives (−x)^{2n+1} = −x^{2n+1}, while e^{-x²} is even), and the Lebesgue measure on ℝ is invariant under negation (`Measure.measurePreserving_neg`). Pushing the integral through x ↦ −x therefore equals its own negative, forcing it to 0. Together with the even case, the entire moment sequence of the Gaussian weight e^{-x²} is pinned down: (2n−1)‼·√π/2ⁿ for even order, 0 for odd order.",
+    "mathContext": "$\\int_{\\mathbb{R}} x^{2n+1}e^{-x^2}\\,dx = 0$ by oddness.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "odd functions",
+      "negation-invariant measure",
+      "vanishing moments"
+    ],
+    "prerequisites": [
+      "odd/even symmetry",
+      "measure-preserving maps"
+    ]
+  },
+  {
+    "id": "bottom-rung",
+    "proofId": "area-of-circle-oq-07-oq-03-oq-01",
+    "range": {
+      "startLine": 110,
+      "endLine": 118
+    },
+    "type": "insight",
+    "title": "n = 0 Recovers the Parent Gaussian Integral",
+    "content": "`evenGaussianMoment_zero` closes the loop with the parent entry: specializing the even-moment formula at n = 0 gives ∫_ℝ e^{-x²} = √π = Γ(1/2). The double-factorial closed form degenerates correctly — (2·0−1)‼ = 0‼ = 1 and 2⁰ = 1 — so the whole tower's base rung is exactly the parent's √π. The infinite family of moments is thus a genuine extension of the single value area-of-circle-oq-07-oq-03 records.",
+    "mathContext": "$\\int_{\\mathbb{R}} e^{-x^2}\\,dx = \\sqrt{\\pi} = \\Gamma(1/2)$ (the $n=0$ rung).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Gaussian integral",
+      "base case",
+      "parent entry"
+    ],
+    "prerequisites": [
+      "Gaussian integral",
+      "Gamma special values"
+    ]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "area-of-circle-oq-07-oq-03-oq-01",
+  "slug": "area-of-circle-oq-07-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "Mathlib.MeasureTheory.Integral.Gamma",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Real", "MeasureTheory", "Set"],
+    "namespace": "AreaOfCircleOQ07OQ03OQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ07OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Integer Gamma Ladder as the Tower of Even Gaussian Moments",
+  "description": "The parent entry isolates a single value, Γ(1/2) = √π = ∫_ℝ e^{-x²}. This entry climbs the whole half-integer Gamma ladder and identifies each rung with an even Gaussian moment: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n+1/2) = (2n-1)‼·√π/2ⁿ. The substantive step proves the moment-to-Gamma identification — evenness folds the line onto the half-line (integral_comp_abs) where Mathlib's integral_rpow_mul_exp_neg_rpow evaluates the half-line moment as ½·Γ(n+1/2). The companion odd moments vanish (∫_ℝ x^{2n+1} e^{-x²} = 0) via negation-invariance of Lebesgue measure, so the entire moment sequence of the Gaussian weight is pinned down, with the parent's √π recovered as the n=0 rung.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ07OQ03OQ01.lean",
+    "tags": [
+      "analysis",
+      "gamma-function",
+      "gaussian-integral",
+      "gaussian-moments",
+      "double-factorial",
+      "special-functions",
+      "measure-theory",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 119,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "verified",
+    "originalContributions": [
+      "evenGaussianMoment_eq_gamma: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n+1/2) — every even Gaussian moment is exactly a half-integer Gamma value, proved by folding the line onto the half-line via evenness (integral_comp_abs) and evaluating the half-line integral with integral_rpow_mul_exp_neg_rpow at p=2, q=2n",
+      "halfLine_evenMoment: ∫_{x>0} x^{2n} e^{-x²} = ½·Γ(n+1/2), the half-line evaluation converting natural powers to real powers (Real.rpow_natCast) so Mathlib's Gamma-integral lemma applies",
+      "evenGaussianMoment_eq_doubleFactorial: ∫_ℝ x^{2n} e^{-x²} dx = (2n-1)‼·√π/2ⁿ, the even moments as double-factorial multiples of √π",
+      "oddGaussianMoment_eq_zero: ∫_ℝ x^{2n+1} e^{-x²} dx = 0, the odd moments vanish by oddness and negation-invariance of Lebesgue measure (Measure.measurePreserving_neg)",
+      "evenGaussianMoment_zero: ∫_ℝ e^{-x²} = √π, the n=0 rung recovering the parent entry's Gaussian integral",
+      "gammaLadder: Γ(n+1/2) = (2n-1)‼·√π/2ⁿ, a re-export of Mathlib's Real.Gamma_nat_add_half providing the analytic backbone"
+    ],
+    "prerequisites": [
+      "Euler Gamma function and its integral representation",
+      "Mathlib's integral_rpow_mul_exp_neg_rpow (half-line ∫ x^q e^{-x^p} = (1/p)Γ((q+1)/p))",
+      "Mathlib's Real.Gamma_nat_add_half (the half-integer ladder closed form)",
+      "integral_comp_abs (even-function integral folding) and Measure.measurePreserving_neg",
+      "Parent: area-of-circle-oq-07-oq-03 (Γ(1/2) = √π = ∫_ℝ e^{-x²})"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "integral_rpow_mul_exp_neg_rpow",
+        "description": "∫ x in Ioi 0, x ^ q * exp (-x ^ p) = (1 / p) * Gamma ((q + 1) / p) for 0 < p, -1 < q. Specialized at p = 2, q = 2n to evaluate the half-line even moment as ½·Γ(n+1/2).",
+        "module": "Mathlib.MeasureTheory.Integral.Gamma"
+      },
+      {
+        "theorem": "integral_comp_abs",
+        "description": "∫ x, f |x| = 2 * ∫ x in Ioi 0, f x. Folds the full-line even integrand x^{2n}e^{-x²} = f(|x|) onto twice the half-line integral.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Integral"
+      },
+      {
+        "theorem": "Real.Gamma_nat_add_half",
+        "description": "Gamma (k + 1/2) = (2k-1)‼ · √π / 2^k, the half-integer ladder closed form. Turns each Gamma value into a double-factorial multiple of √π.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Measure.measurePreserving_neg",
+        "description": "The Lebesgue measure on ℝ is preserved by negation. Combined with the oddness of x^{2n+1}e^{-x²}, forces the odd moments to vanish.",
+        "module": "Mathlib.MeasureTheory.Measure.Haar.OfBasis"
+      },
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "Real.Gamma (1/2) = √π. Identifies the n=0 even moment ∫_ℝ e^{-x²} with √π, recovering the parent entry.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's Gamma function Γ(s) = ∫₀^∞ u^{s−1}e^{−u}du interpolates the factorial, and its archetypal non-integer value Γ(1/2) = √π is the same number as the Gaussian normalization ∫_ℝ e^{−x²} = √π. But Γ(1/2) is only the bottom rung of an infinite ladder: the functional equation Γ(s+1) = s·Γ(s) propagates √π up through all half-integers, Γ(n+1/2) = (2n−1)‼·√π/2ⁿ. On the probability side these same numbers are the even moments of the Gaussian weight e^{−x²} — the quantities that determine the variance, kurtosis, and every higher even moment of a Gaussian. The double factorial counting of these moments (Wick's theorem / Isserlis' theorem in physics and statistics) is exactly the (2n−1)‼ appearing here. This entry, in the area-of-circle family because the Gaussian √π is a polar-coordinate cousin of the circle constant π, ties the analytic ladder to the probabilistic moment sequence.",
+    "problemStatement": "**Open Question (oq-01)**: extend the parent entry's single value Γ(1/2) = √π to the whole half-integer Gamma ladder Γ(n+1/2) = (2n−1)‼·√π/2ⁿ, and identify each value with the even Gaussian moment ∫_ℝ x^{2n} e^{−x²} dx. Answer: yes — ∫_ℝ x^{2n} e^{−x²} = Γ(n+1/2) = (2n−1)‼·√π/2ⁿ, the odd moments vanish, and n = 0 recovers the parent's √π.",
+    "proofStrategy": "The analytic ladder Γ(n+1/2) = (2n−1)‼·√π/2ⁿ is already in Mathlib (Real.Gamma_nat_add_half), so it is re-exported as gammaLadder; the entry's mathematical content is the moment identification. (1) halfLine_evenMoment evaluates the half-line moment: the natural-power integrand x^{2n}e^{−x²} is converted to real powers via Real.rpow_natCast on Ioi 0, then Mathlib's integral_rpow_mul_exp_neg_rpow at p=2, q=2n gives ½·Γ((2n+1)/2) = ½·Γ(n+1/2). (2) evenGaussianMoment_eq_gamma folds the full line onto the half-line: x^{2n}e^{−x²} = f(|x|) for f(t)=t^{2n}e^{−t²} (using Even.pow_abs for |x|^{2n}=x^{2n} and sq_abs for |x|²=x²), so integral_comp_abs doubles the half-line value to Γ(n+1/2). (3) evenGaussianMoment_eq_doubleFactorial composes with Real.Gamma_nat_add_half. (4) oddGaussianMoment_eq_zero uses negation-invariance (Measure.measurePreserving_neg) and Odd.neg_pow: the integral equals its own negative. (5) evenGaussianMoment_zero specializes n=0.",
+    "keyInsights": [
+      "The even Gaussian moments are not merely computable from Γ — they ARE the half-integer Gamma values: ∫_ℝ x^{2n}e^{−x²} = Γ(n+1/2) exactly, with no extra constants.",
+      "Evenness does the structural work: x^{2n}e^{−x²} = f(|x|), so integral_comp_abs reduces the full-line moment to twice a half-line Gamma integral that Mathlib evaluates in one lemma.",
+      "The double factorial (2n−1)‼ — the Wick/Isserlis pairing count — emerges as the closed form, exhibiting every even moment as a rational multiple of the parent's √π.",
+      "The odd moments vanish for a structural reason (negation-invariance of Lebesgue measure + oddness), so the entire moment sequence is determined; the parent's √π is exactly the n = 0 base rung.",
+      "The entry is honestly scoped: the ladder formula itself is Mathlib's (badge reflects the new content is the moment identification and the odd-moment vanishing, assembled from library lemmas)."
+    ]
+  },
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-07-oq-03",
+      "relationship": "extends",
+      "description": "Parent. The parent records the single value Γ(1/2) = √π = ∫_ℝ e^{−x²}; this entry extends it to the whole half-integer ladder Γ(n+1/2) = (2n−1)‼·√π/2ⁿ and identifies each rung with the even Gaussian moment ∫_ℝ x^{2n}e^{−x²}, recovering the parent as evenGaussianMoment_zero (n = 0)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.Gamma",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of integral_rpow_mul_exp_neg_rpow, the half-line evaluation ∫ x^q e^{-x^p} = (1/p)Γ((q+1)/p) that powers the moment identification."
+    },
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gaussian.GaussianIntegral",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_nat_add_half (the half-integer ladder closed form) and Real.Gamma_one_half_eq."
+    },
+    {
+      "title": "Wick's theorem and Gaussian moments",
+      "author": "Gian-Carlo Wick / Leon Isserlis",
+      "year": "1950",
+      "venue": "classical probability/physics",
+      "description": "The even moments of a Gaussian are counted by the double factorial (2n−1)‼, the pairing count appearing in the closed form here."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The even Gaussian moments are exactly the half-integer Gamma values: ∫_ℝ x^{2n}e^{−x²} dx = Γ(n+1/2) = (2n−1)‼·√π/2ⁿ (evenGaussianMoment_eq_gamma, evenGaussianMoment_eq_doubleFactorial), the odd moments vanish (oddGaussianMoment_eq_zero), and the n=0 rung recovers the parent's ∫_ℝ e^{−x²} = √π (evenGaussianMoment_zero). The half-integer ladder itself is re-exported from Mathlib (gammaLadder). 119 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "The contribution is the identification of the entire even-moment sequence of the Gaussian weight with the half-integer Gamma ladder, plus the vanishing of the odd moments — turning the parent's single √π into the base rung of a fully-determined moment tower. The analytic ladder formula is Mathlib's; the moment bridge (half-line evaluation + evenness folding) and the odd-moment vanishing are assembled here from library lemmas.",
+    "openQuestions": []
+  }
+}


### PR DESCRIPTION
## Summary

Answers open question **area-of-circle-oq-07-oq-03-oq-01**. The parent entry records the single value Γ(1/2) = √π = ∫_ℝ e^{-x²}. This entry climbs the whole **half-integer Gamma ladder** and identifies each rung with an **even Gaussian moment**:

$$\int_{\mathbb{R}} x^{2n} e^{-x^2}\,dx \;=\; \Gamma\!\left(n+\tfrac12\right) \;=\; \frac{(2n-1)!!\,\sqrt{\pi}}{2^{n}}.$$

## What is new (not in Mathlib)

Mathlib already has the *analytic* ladder `Real.Gamma_nat_add_half` and the half-line evaluation `integral_rpow_mul_exp_neg_rpow`, but **not** the full-line even Gaussian moment identity. The substantive content here is the bridge:

- **`evenGaussianMoment_eq_gamma`** — `∫_ℝ x^{2n} e^{-x²} = Γ(n+1/2)`. The integrand is even (`Even.pow_abs`, `sq_abs`), so `integral_comp_abs` folds the line onto twice the half-line, where `integral_rpow_mul_exp_neg_rpow` (p=2, q=2n) gives ½·Γ(n+1/2).
- **`halfLine_evenMoment`** — `∫_{x>0} x^{2n} e^{-x²} = ½·Γ(n+1/2)` (converts natural powers to real powers via `Real.rpow_natCast`).
- **`evenGaussianMoment_eq_doubleFactorial`** — `= (2n-1)‼·√π/2ⁿ` (composes with `Real.Gamma_nat_add_half`).
- **`oddGaussianMoment_eq_zero`** — `∫_ℝ x^{2n+1} e^{-x²} = 0`, via oddness + negation-invariance of Lebesgue measure (`Measure.measurePreserving_neg`).
- **`evenGaussianMoment_zero`** — the n=0 rung recovers the parent's `∫_ℝ e^{-x²} = √π`.
- **`gammaLadder`** — re-export of the Mathlib ladder formula (analytic backbone).

Together these pin down the *entire* moment sequence of the Gaussian weight `e^{-x²}`.

## Verification

- **119 lines, 6 theorems, 0 definitions, 0 sorries, 0 axioms.**
- `#print axioms` on every main theorem: depends only on `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).
- Badge: `verified` (machine-checked, no assumptions; honest provenance — the ladder formula is Mathlib's, the moment identification and odd-moment vanishing are new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)