### PR TITLE
Enrich Catalan Reflection Form OQ-01 (C(n) = C(2n,n) − C(2n,n+1))

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "catalan-numbers-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "The Reflection Form and André's Reflection Principle",
+    "content": "The Catalan numbers count Dyck paths, balanced parenthesizations, polygon triangulations, and binary trees. The identity catalan n = C(2n,n) − C(2n,n+1) is the arithmetic shadow of André's reflection principle (1887) for the ballot problem: of the C(2n,n) monotone lattice paths from (0,0) to (n,n), the diagonal-crossing 'bad' paths are in bijection — by reflecting each path after its first bad step — with all C(2n,n+1) paths to the reflected endpoint, leaving exactly the catalan n Dyck paths. Mathlib records the division form catalan n = centralBinom n/(n+1) but not this difference form, which this file derives purely arithmetically over ℕ.",
+    "mathContext": "$\\mathrm{catalan}\\,n = \\binom{2n}{n} - \\binom{2n}{n+1}$ — the Dyck count after reflection removes the $\\binom{2n}{n+1}$ diagonal-crossing paths.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan numbers", "André's reflection principle", "ballot problem", "Dyck paths", "central binomial coefficient"],
+    "prerequisites": ["binomial coefficients", "lattice paths"]
+  },
+  {
+    "id": "ann-partition",
+    "proofId": "catalan-numbers-oq-01-oq-01",
+    "range": { "startLine": 35, "endLine": 62 },
+    "type": "insight",
+    "title": "Work Additively: the Near-Central Partition",
+    "content": "The key methodological move is to prove the ADDITIVE partition C(2n,n) = catalan n + C(2n,n+1) first, avoiding ℕ truncated subtraction entirely so the algebra stays honest. Two facts combine: the Catalan bridge (n+1)·catalan n = C(2n,n) (since centralBinom n is definitionally (2n).choose n), and the neighbour relation (n+1)·C(2n,n+1) = n·C(2n,n) extracted from Nat.choose_succ_right_eq at (2n,n) using 2n−n=n. Multiplying the target by n+1 gives (n+1)·C(2n,n) = (n+1)·catalan n + (n+1)·C(2n,n+1) = C(2n,n) + n·C(2n,n) = (n+1)·C(2n,n), and Nat.eq_of_mul_eq_mul_left cancels the positive factor n+1.",
+    "mathContext": "$(n+1)\\binom{2n}{n} = (n+1)\\,\\mathrm{catalan}\\,n + (n+1)\\binom{2n}{n+1} = \\binom{2n}{n} + n\\binom{2n}{n}$; cancel $n+1$ to get $\\binom{2n}{n} = \\mathrm{catalan}\\,n + \\binom{2n}{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial neighbour relation", "Nat.choose_succ_right_eq", "cancellation", "natural-number subtraction"],
+    "prerequisites": ["binomial identities", "natural-number arithmetic"]
+  },
+  {
+    "id": "ann-reflection-form",
+    "proofId": "catalan-numbers-oq-01-oq-01",
+    "range": { "startLine": 64, "endLine": 82 },
+    "type": "concept",
+    "title": "The Reflection Form, in Two Notations",
+    "content": "Once the additive partition is in hand, the headline difference form catalan n = C(2n,n) − C(2n,n+1) follows by omega (catalan_eq_centralBinom_sub_choose) — the ℕ subtraction is justified precisely because the partition exhibits C(2n,n) as catalan n plus the subtrahend. catalan_eq_centralBinom_sub then restates the identity using Mathlib's own Nat.centralBinom notation, bridging the bespoke (2n).choose n form to the library's centralBinom n by a single rfl rewrite.",
+    "mathContext": "$\\mathrm{catalan}\\,n = \\binom{2n}{n} - \\binom{2n}{n+1} = \\mathrm{centralBinom}\\,n - \\binom{2n}{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "omega tactic", "definitional equality"],
+    "prerequisites": ["binomial coefficients", "natural-number subtraction"]
+  },
+  {
+    "id": "ann-genuine-difference",
+    "proofId": "catalan-numbers-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 90 },
+    "type": "technique",
+    "title": "Certifying the Subtraction Is Not Truncated",
+    "content": "Over ℕ, subtraction is truncated: a − b = 0 whenever b ≥ a. A difference identity is only meaningful once the subtrahend is known not to exceed the minuend. choose_succ_le_centralBinom establishes C(2n,n+1) ≤ C(2n,n) — again read straight off the additive partition by omega — certifying the reflection form is a genuine difference everywhere, not vacuously 0. This is the kind of side condition that is easy to omit on paper but that a formal proof must discharge.",
+    "mathContext": "$\\binom{2n}{n+1} \\le \\binom{2n}{n}$, so $\\binom{2n}{n} - \\binom{2n}{n+1}$ is a true (non-truncated) ℕ difference.",
+    "significance": "supporting",
+    "relatedConcepts": ["truncated subtraction", "unimodality of binomial row", "side conditions", "formal rigor"],
+    "prerequisites": ["natural-number subtraction", "binomial coefficient monotonicity"]
+  },
+  {
+    "id": "ann-sanity",
+    "proofId": "catalan-numbers-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 101 },
+    "type": "technique",
+    "title": "Numerical Witnesses by Kernel decide",
+    "content": "Three example lemmas pin the identity to concrete numbers: catalan 3 = C(6,3) − C(6,4) as an instance of the general theorem, and the arithmetic facts C(6,3) − C(6,4) = 20 − 15 = 5 and C(8,4) − C(8,5) = 70 − 56 = 14 (= catalan 4) by kernel decide. Using decide (not native_decide) keeps the file axiom-free: kernel reduction introduces no Lean.ofReduceBool dependency, so the 'verified, 0 axioms' claim is honest.",
+    "mathContext": "$\\binom{6}{3}-\\binom{6}{4} = 20-15 = 5 = \\mathrm{catalan}\\,3$; $\\binom{8}{4}-\\binom{8}{5} = 70-56 = 14 = \\mathrm{catalan}\\,4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["kernel decide", "native_decide", "axiom-free verification", "numerical sanity check"],
+    "prerequisites": ["Lean decide tactic", "binomial coefficient evaluation"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01/meta.json
@@ -96,12 +96,51 @@
   ],
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01",
-      "reason": "The parent entry: the O(1) linear (holonomic) recurrence (n+2)*catalan(n+1) = 2(2n+1)*catalan n, also derived from the central-binomial bridge. This entry gives the closed difference form rather than the step recurrence."
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "parent",
+      "description": "The parent entry: the O(1) linear (holonomic) recurrence (n+2)*catalan(n+1) = 2(2n+1)*catalan n, also derived from the central-binomial bridge. This entry gives the closed difference form rather than the step recurrence."
     },
     {
-      "id": "dyck-catalan-count-oq-01",
-      "reason": "Counts Dyck paths by the Catalan numbers — the combinatorial objects whose enumeration the reflection identity C(2n,n) - C(2n,n+1) computes."
+      "proofId": "dyck-catalan-count-oq-01",
+      "relationship": "related",
+      "description": "Counts Dyck paths by the Catalan numbers — the combinatorial objects whose enumeration the reflection identity C(2n,n) - C(2n,n+1) computes."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "The Reflection Identity and Its Arithmetic Plan",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Imports Mathlib and frames the goal: Mathlib has the division form catalan n = centralBinom n / (n+1) and the bridge (n+1)*catalan n = centralBinom n, but not the reflection/ballot form catalan n = C(2n,n) − C(2n,n+1). Sketches the 0-axiom plan: with B = C(2n,n), R = C(2n,n+1), C = catalan n, combine (n+1)*C = B and (n+1)*R = n*B, multiply the target B = C + R by n+1, cancel the positive factor, and pass to ℕ subtraction via omega."
+    },
+    {
+      "id": "partition",
+      "title": "The Additive Near-Central Partition",
+      "startLine": 35,
+      "endLine": 62,
+      "summary": "centralBinom_eq_catalan_add_choose: C(2n,n) = catalan n + C(2n,n+1), the additive heart of the identity stated without ℕ truncated subtraction. Uses centralBinom n = (2n).choose n by rfl, the Catalan bridge succ_mul_catalan_eq_centralBinom for (n+1)*catalan n = C(2n,n), and the neighbour relation (n+1)*C(2n,n+1) = n*C(2n,n) derived from Nat.choose_succ_right_eq at (2n,n) with 2n−n=n; multiplying by n+1 and cancelling via Nat.eq_of_mul_eq_mul_left closes it."
+    },
+    {
+      "id": "reflection-form",
+      "title": "The Reflection / Ballot Form",
+      "startLine": 64,
+      "endLine": 82,
+      "summary": "catalan_eq_centralBinom_sub_choose: catalan n = C(2n,n) − C(2n,n+1), obtained from the additive partition by omega. catalan_eq_centralBinom_sub restates it against Mathlib's Nat.centralBinom (catalan n = centralBinom n − C(2n,n+1)) by rewriting centralBinom n = (2n).choose n via rfl — bridging the two notations."
+    },
+    {
+      "id": "genuine-difference",
+      "title": "Certifying the Difference Is Genuine",
+      "startLine": 84,
+      "endLine": 90,
+      "summary": "choose_succ_le_centralBinom: C(2n,n+1) ≤ C(2n,n), read off the additive partition by omega. This certifies the ℕ subtraction in the reflection form is a real difference and not silently truncated to 0 — without it the headline identity would be vacuous where the subtrahend exceeds the minuend."
+    },
+    {
+      "id": "sanity",
+      "title": "Numerical Witnesses via Kernel decide",
+      "startLine": 92,
+      "endLine": 101,
+      "summary": "Three examples confirm the identity on small values: catalan 3 = C(6,3) − C(6,4) (an instance of the general theorem), and the arithmetic checks C(6,3)−C(6,4)=20−15=5 and C(8,4)−C(8,5)=70−56=14 (= catalan 4) by kernel decide — no native_decide, so no Lean.ofReduceBool dependency."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-01` (quality 33, pass 0).

## What was added / fixed
- **No `annotations.json`** previously — created with 5 inline annotations (`mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`) covering the reflection-principle context, the additive partition strategy, the difference form, the genuine-difference certification, and the kernel-decide witnesses.
- **Empty `sections`** — added 5 conforming `ProofSection` entries (`startLine`/`endLine`/`summary`) mapped to the actual Lean line ranges.
- **Malformed `crossReferences`** — they used non-schema `{id, reason}` keys; converted to the `CrossReference` schema `{proofId, relationship, description}` so they render. Both slugs (catalan-numbers-oq-01, dyck-catalan-count-oq-01) verified to exist.
- meta.json already had a rich `overview` and `conclusion` — left intact.

## Accuracy notes
- meta.json reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: mathlib` (accurate — the result builds on Mathlib's central-binomial bridge but the difference form + neighbour cancellation are derived here). Concrete checks use kernel `decide` only (no `native_decide`/Lean.ofReduceBool). No status/badge changes.
- Annotations match the actual declarations (centralBinom_eq_catalan_add_choose, catalan_eq_centralBinom_sub_choose, catalan_eq_centralBinom_sub, choose_succ_le_centralBinom).
- No `index.ts` shim added (obsolete per issue #20993; loader fetches build-generated data).

`pnpm build` passes.