### PR TITLE
Enrich Catalan 2-adic Valuation (v₂(Cₙ) = s₂(n+1)−1, oddness ⟺ n=2ᵏ−1)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "catalan-numbers-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "The Arithmetic of the Catalan Numbers",
+    "content": "The oddness of the Catalan numbers — Cₙ is odd precisely when n+1 is a power of two — is a classical gem combining Kummer's theorem (1852, the p-adic valuation of a binomial coefficient counts base-p carries) and Legendre's formula (v_p(m!) = (m − s_p(m))/(p−1)). For the central binomial coefficient the base-2 carry count is the binary digit sum s₂(n), and the factor n+1 dividing C(2n,n) (the Catalan denominator) supplies the correction term. Mathlib records the Catalan numbers and the central-binomial bridge but no divisibility/parity facts; this is the gallery's first entry on their arithmetic structure.",
+    "mathContext": "$v_2(C_n) = s_2(n) - v_2(n+1) = s_2(n+1) - 1$; $C_n$ odd $\\iff n+1 = 2^k$.",
+    "significance": "context",
+    "relatedConcepts": ["Catalan numbers", "Kummer's theorem", "Legendre's formula", "p-adic valuation", "binary digit sum"],
+    "prerequisites": ["p-adic valuation", "binomial coefficients"]
+  },
+  {
+    "id": "ann-digit-lemmas",
+    "proofId": "catalan-numbers-oq-01-oq-02",
+    "range": { "startLine": 35, "endLine": 86 },
+    "type": "technique",
+    "title": "Binary Digit-Sum Toolkit",
+    "content": "These elementary lemmas about the binary digit sum s₂ underpin everything. sum_digits_two_mul records the doubling invariance s₂(2n)=s₂(n) (a 0 bit is prepended). sum_digits_two_pos says s₂(n)>0 for n>0. The pair sum_digits_two_eq_one_imp/iff proves the crucial characterisation s₂(n)=1 ⟺ n is a power of two, by strong induction peeling the lowest bit: an even n reduces to n/2; an odd n with s₂=1 must have n/2=0, so n=1=2⁰. This single-bit characterisation is the only genuine digit recursion in the file — the carry identity later avoids digit induction entirely.",
+    "mathContext": "$s_2(2n) = s_2(n)$; $s_2(2^k) = 1$; $s_2(n) = 1 \\iff \\exists k,\\ n = 2^k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binary digit sum", "power of two", "strong induction", "Nat.digits"],
+    "prerequisites": ["base-b digit representations", "induction"]
+  },
+  {
+    "id": "ann-legendre-kummer",
+    "proofId": "catalan-numbers-oq-01-oq-02",
+    "range": { "startLine": 88, "endLine": 107 },
+    "type": "concept",
+    "title": "Legendre and Base-2 Kummer",
+    "content": "Two reusable valuation facts are specialised to p=2 from Mathlib's general theorems. padicValNat_two_factorial gives Legendre's formula v₂(m!) = m − s₂(m) (from sub_one_mul_padicValNat_factorial, with p−1=1). padicValNat_two_centralBinom gives the base-2 Kummer identity v₂(C(2n,n)) = s₂(n), instantiating Mathlib's digit-sum Kummer lemma at (2n,n): the carries cancel to leave s₂(n) + s₂(n) − s₂(2n) = s₂(n) since s₂(2n)=s₂(n). These are reused, not re-proved — the contribution is their Catalan-specific consequence.",
+    "mathContext": "$v_2(m!) = m - s_2(m)$ (Legendre); $v_2\\binom{2n}{n} = s_2(n)$ (base-2 Kummer).",
+    "significance": "key",
+    "relatedConcepts": ["Legendre's formula", "Kummer's theorem", "central binomial coefficient", "padicValNat"],
+    "prerequisites": ["p-adic valuation of factorials", "Kummer's theorem"]
+  },
+  {
+    "id": "ann-carry-identity",
+    "proofId": "catalan-numbers-oq-01-oq-02",
+    "range": { "startLine": 109, "endLine": 122 },
+    "type": "insight",
+    "title": "The Carry Identity Without Digit Bookkeeping",
+    "content": "Incrementing n in binary clears the v₂(n+1) trailing ones and sets one higher bit, so s₂(n) + 1 = s₂(n+1) + v₂(n+1). The elegant point is that this is proved with NO induction on the binary increment: apply Legendre's v₂(m!)=m−s₂(m) to both n and n+1, split v₂((n+1)!) = v₂(n+1) + v₂(n!) via valuation additivity on (n+1)! = (n+1)·n!, and feed the three resulting equations (with the digit-sum bounds s₂(m) ≤ m) to omega. The carry combinatorics that one would normally track by hand is fully absorbed into linear arithmetic over the factorial valuations.",
+    "mathContext": "$s_2(n) + 1 = s_2(n+1) + v_2(n+1)$, from $v_2(n!),\\,v_2((n+1)!)$ and $v_2((n+1)!) = v_2(n+1) + v_2(n!)$.",
+    "significance": "key",
+    "relatedConcepts": ["carry identity", "binary increment", "valuation additivity", "omega tactic"],
+    "prerequisites": ["Legendre's formula", "p-adic valuation additivity"]
+  },
+  {
+    "id": "ann-catalan-valuation",
+    "proofId": "catalan-numbers-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 151 },
+    "type": "concept",
+    "title": "The Valuation Formula v₂(Cₙ) = s₂(n+1) − 1",
+    "content": "The main result. Taking the 2-adic valuation across the Catalan bridge (n+1)·Cₙ = C(2n,n), additivity gives v₂(n+1) + v₂(Cₙ) = v₂(C(2n,n)) = s₂(n), so v₂(Cₙ) = s₂(n) − v₂(n+1) (padicValNat_two_catalan). The Catalan denominator n+1 is exactly the −v₂(n+1) correction to the central-binomial valuation. Combining with the carry identity then repackages this as the clean closed form v₂(Cₙ) = s₂(n+1) − 1 (padicValNat_two_catalan_eq), with catalan_ne_zero supplying the nonzero side condition the valuation additivity needs.",
+    "mathContext": "$v_2(C_n) = s_2(n) - v_2(n+1) = s_2(n+1) - 1$ (combining with the carry identity).",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "p-adic valuation", "central binomial bridge", "valuation additivity"],
+    "prerequisites": ["p-adic valuation", "Catalan-central binomial identity"]
+  },
+  {
+    "id": "ann-oddness",
+    "proofId": "catalan-numbers-oq-01-oq-02",
+    "range": { "startLine": 153, "endLine": 175 },
+    "type": "concept",
+    "title": "Oddness ⟺ n+1 a Power of Two",
+    "content": "The headline parity corollary. Cₙ is odd ⟺ ¬2∣Cₙ ⟺ v₂(Cₙ)=0 (via padicValNat_dvd_iff_le) ⟺ s₂(n+1)=1 (closed form) ⟺ n+1 is a power of two (sum_digits_two_eq_one_iff), i.e. n = 2ᵏ−1. So the odd Catalan numbers sit at indices 0,1,3,7,15,…. The concrete examples confirm C₀,C₁,C₃,C₇ odd (n+1 = 1,2,4,8) and C₂ = 2 even, the latter by kernel decide on ¬Odd 2 — no native_decide, keeping the file axiom-free.",
+    "mathContext": "$C_n$ odd $\\iff v_2(C_n) = 0 \\iff s_2(n+1) = 1 \\iff n+1 = 2^k \\iff n = 2^k - 1$. Odd indices: $0,1,3,7,15,\\dots$",
+    "significance": "key",
+    "relatedConcepts": ["parity", "power of two", "Mersenne-shifted indices", "padicValNat_dvd_iff_le"],
+    "prerequisites": ["p-adic valuation", "parity", "powers of two"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02/meta.json
@@ -110,16 +110,70 @@
   ],
   "crossReferences": [
     {
-      "id": "catalan-numbers-oq-01-oq-01",
-      "reason": "Sibling entry: the central-binomial reflection form catalan n = C(2n,n) − C(2n,n+1), also built on succ_mul_catalan_eq_centralBinom. This entry gives the arithmetic (2-adic) structure rather than the difference identity."
+      "proofId": "catalan-numbers-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling entry: the central-binomial reflection form catalan n = C(2n,n) − C(2n,n+1), also built on succ_mul_catalan_eq_centralBinom. This entry gives the arithmetic (2-adic) structure rather than the difference identity."
     },
     {
-      "id": "catalan-numbers-oq-01",
-      "reason": "Parent entry: the linear recurrence for the Catalan numbers from the central-binomial bridge."
+      "proofId": "catalan-numbers-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry: the linear recurrence for the Catalan numbers from the central-binomial bridge."
     },
     {
-      "id": "kummer-theorem-oq-04",
-      "reason": "Provides the base-2 central-binomial valuation v₂(C(2n,n)) = s₂(n) that this entry divides by the Catalan denominator n+1."
+      "proofId": "kummer-theorem-oq-04",
+      "relationship": "related",
+      "description": "Provides the base-2 central-binomial valuation v₂(C(2n,n)) = s₂(n) that this entry divides by the Catalan denominator n+1."
+    }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Overview: the 2-adic Valuation Program",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Imports Mathlib, opens Nat, and opens namespace CatalanTwoAdic. The docstring lays out the plan: from (n+1)·Cₙ = C(2n,n), the base-2 Kummer identity v₂(C(2n,n)) = s₂(n), and Legendre's formula v₂(m!) = m − s₂(m), derive v₂(Cₙ) = s₂(n) − v₂(n+1) = s₂(n+1) − 1 and the oddness characterisation Cₙ odd ⟺ n+1 a power of two. Flags the carry identity as Legendre-derived (no digit induction)."
+    },
+    {
+      "id": "digit-lemmas",
+      "title": "Elementary Binary Digit-Sum Lemmas",
+      "startLine": 35,
+      "endLine": 86,
+      "summary": "sum_digits_two_mul (s₂(2n)=s₂(n), doubling prepends a 0 bit), sum_digits_two_pos (s₂(n)>0 for n>0), sum_digits_two_pow (s₂(2ᵏ)=1), and sum_digits_two_eq_one_imp/iff (s₂(n)=1 ⟺ n a power of two) — the latter by strong induction peeling the lowest bit. This is the file's only genuine digit recursion."
+    },
+    {
+      "id": "legendre-kummer",
+      "title": "Legendre's Formula and the Central-Binomial Valuation",
+      "startLine": 88,
+      "endLine": 107,
+      "summary": "padicValNat_two_factorial: v₂(m!) = m − s₂(m), Legendre at p=2 (from Mathlib's sub_one_mul_padicValNat_factorial). padicValNat_two_centralBinom: v₂(C(2n,n)) = s₂(n), base-2 Kummer from Mathlib's digit-sum Kummer lemma at (2n,n) using 2n−n=n and s₂(2n)=s₂(n)."
+    },
+    {
+      "id": "carry-identity",
+      "title": "The Carry Identity, Without Digit Induction",
+      "startLine": 109,
+      "endLine": 122,
+      "summary": "sum_digits_two_succ: s₂(n) + 1 = s₂(n+1) + v₂(n+1). Rather than inducting on the binary increment, it applies Legendre's formula to n! and (n+1)! = (n+1)·n!, splits v₂((n+1)!) = v₂(n+1) + v₂(n!) by additivity, and lets omega combine the three valuation equations with the digit-sum bounds — an entirely carry-free derivation."
+    },
+    {
+      "id": "catalan-valuation",
+      "title": "The 2-adic Valuation of the Catalan Numbers",
+      "startLine": 123,
+      "endLine": 151,
+      "summary": "catalan_ne_zero (Cₙ ≠ 0, from positivity of C(2n,n)). padicValNat_two_catalan: v₂(Cₙ) = s₂(n) − v₂(n+1), taking v₂ across (n+1)·Cₙ = C(2n,n) with additivity and substituting v₂(C(2n,n)) = s₂(n). padicValNat_two_catalan_eq: the closed form v₂(Cₙ) = s₂(n+1) − 1, combining the previous with the carry identity by omega."
+    },
+    {
+      "id": "oddness",
+      "title": "Oddness ⟺ n+1 a Power of Two",
+      "startLine": 153,
+      "endLine": 162,
+      "summary": "odd_catalan_iff: Odd (catalan n) ↔ ∃ k, n+1 = 2ᵏ. Cₙ is odd ⟺ ¬2∣Cₙ ⟺ v₂(Cₙ)=0 (padicValNat_dvd_iff_le) ⟺ s₂(n+1)=1 (closed form) ⟺ n+1 a power of two (sum_digits_two_eq_one_iff) — the classical indices 0,1,3,7,15,…"
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Odd and Even Witnesses",
+      "startLine": 164,
+      "endLine": 175,
+      "summary": "C₀,C₁,C₃,C₇ are odd (indices 2ᵏ−1, exhibiting the power-of-two witness for n+1 = 1,2,4,8); C₂ = 2 is even via catalan_two then kernel decide on ¬Odd 2 — no native_decide, preserving the axiom-free claim."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-02` (quality 33, pass 0).

## What was added / fixed
- **No `annotations.json`** previously — created 6 inline annotations (`mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`) covering the arithmetic context, the binary digit-sum toolkit, Legendre/base-2 Kummer, the carry identity, the valuation formula, and the oddness corollary.
- **Empty `sections`** — added 7 conforming `ProofSection` entries (`startLine`/`endLine`/`summary`) mapped to the actual Lean line ranges.
- **Malformed `crossReferences`** — converted from non-schema `{id, reason}` to `{proofId, relationship, description}`. All three slugs (catalan-numbers-oq-01-oq-01, catalan-numbers-oq-01, kummer-theorem-oq-04) verified to exist.
- meta.json already had a rich `overview` and `conclusion` — left intact.

## Accuracy notes
- meta.json reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: mathlib` (accurate — reuses Mathlib's Kummer/Legendre, derives the Catalan-specific valuation + parity). Concrete checks use kernel `decide` only (no `native_decide`/Lean.ofReduceBool). No status/badge changes.
- Annotations match the actual declarations (padicValNat_two_catalan, padicValNat_two_catalan_eq, sum_digits_two_succ, odd_catalan_iff).
- No `index.ts` shim added (obsolete per issue #20993).

`pnpm build` passes.