### PR TITLE
Fix stale 'remains as an axiom' annotation on amgm-inequality-oq-03-oq-01

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/annotations.json
@@ -103,7 +103,7 @@
     },
     "type": "concept",
     "title": "The Power Mean Interpolation Chain: Status Summary",
-    "content": "A documentation theorem summarizing the full power mean chain $\\min(z) \\leq \\cdots \\leq \\text{HM} \\leq \\text{GM} \\leq \\text{AM} \\leq M_2 \\leq \\cdots \\leq \\max(z)$, marking which links are proved. Seven results are marked [✓]: GM ≤ AM (from Mathlib), AM ≤ M_p for p ≥ 1 (Mathlib), GM ≤ M_p for p ≥ 1, Jensen's inequality, HM ≤ GM (proved here), positive monotonicity (proved here), and negative monotonicity (proved here via duality). Only the mixed-sign crossing (r < 0 < s, requiring the r → 0 limit) remains as an axiom.",
+    "content": "A summary comment block documenting the full power mean chain $\\min(z) \\leq \\cdots \\leq \\text{HM} \\leq \\text{GM} \\leq \\text{AM} \\leq M_2 \\leq \\cdots \\leq \\max(z)$, marking which links are proved. Seven results are established: GM ≤ AM (from Mathlib), AM ≤ M_p for p ≥ 1 (Mathlib), GM ≤ M_p for p ≥ 1, Jensen's inequality, HM ≤ GM (proved here), positive monotonicity (proved here), and negative monotonicity (proved here via duality). Only the mixed-sign crossing (r < 0 < s, crossing the geometric-mean limit at r = 0) is left out of scope: it is not formalized in this file. The file contains no axioms — this case is simply omitted, not assumed.",
     "mathContext": "$\\min(z) \\leq \\cdots \\leq M_{-1} = \\text{HM} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM} \\leq M_2 \\leq \\cdots \\leq \\max(z)$. Proved: $M_r \\leq M_s$ for $0 < r \\leq s$ and for $r \\leq s < 0$. Remaining: $r < 0 < s$ (mixed sign).",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
## Fix

The "Power Mean Interpolation Chain: Status Summary" annotation on `amgm-inequality-oq-03-oq-01` claimed the mixed-sign power-mean case (r < 0 < s) "remains as an axiom." This is false — the entry is verified/0-axiom/0-sorry.

## Evidence

**Before**: annotation said "Only the mixed-sign crossing (r < 0 < s, requiring the r → 0 limit) remains as an axiom." It also described the target (a comment block at lines 358–374) as "A documentation theorem."

**After**: annotation states the mixed-sign case is "left out of scope: it is not formalized in this file. The file contains no axioms — this case is simply omitted, not assumed." Mislabel "documentation theorem" → "summary comment block."

Source check (`proofs/Proofs/AmgmInequalityOQ03.lean`):
- `grep "^axiom"` → 0 declarations, `grep "sorry"` → 0 hits
- Line 34 / 373: "Mixed-sign case (r < 0 < s …) — not formalized in this file"
- Line 349: "the inequality itself is proved **without using** the power mean axiom"
- `meta.json`: status `verified`, axiomCount 0, sorries 0

---
Automated fix by lean-mechanic agent.