### PR TITLE
Enrich Erdős #396: Wallis Integral Representation of C(2n,n)

### DIFF
--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 61 },
+    "type": "context",
+    "title": "Two Faces of the Wallis Product",
+    "content": "The parent entry derives the normalised central binomial coefficient as a finite combinatorial product C(2n,n)/4^n = ∏_{k<n}(2k+1)/(2k+2) = (2n−1)!!/(2n)!!, living entirely in ℚ-arithmetic of the recurrence and never touching an integral. This file supplies the analytic twin: John Wallis' seventeenth-century definite integrals of powers of sine over [0,π] evaluate to exactly the same closed products. Identifying the two makes a combinatorial number equal to an analytic quantity, with no Stirling estimate — the only combinatorial input is the imported recurrence.",
+    "mathContext": "$\\int_0^\\pi \\sin^{2n}x\\,dx = \\pi\\prod_{k<n}\\frac{2k+1}{2k+2}$ and $\\int_0^\\pi \\sin^{2n+1}x\\,dx = 2\\prod_{k<n}\\frac{2k+2}{2k+3}$.",
+    "significance": "context",
+    "relatedConcepts": ["Wallis product", "Wallis integrals", "central binomial coefficient", "analytic combinatorics", "double factorial"],
+    "prerequisites": ["definite integrals", "finite products"]
+  },
+  {
+    "id": "ann-odd-telescope",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 63, "endLine": 79 },
+    "type": "technique",
+    "title": "The Odd-Index Telescope",
+    "content": "prod_odd_telescope proves ∏_{k<n}(2k+1)/(2k+3) = 1/(2n+1), the elementary telescoping product (1/3)·(3/5)·(5/7)···((2n−1)/(2n+1)) where every interior factor cancels. The Lean proof is a one-line induction: Finset.prod_range_succ peels the last factor, then push_cast/field_simp/ring close it. This is the combinatorial fact that, against the parent's even product, pins down the odd Wallis product.",
+    "mathContext": "$\\prod_{k<n}\\frac{2k+1}{2k+3} = \\frac{1}{2n+1}$ (telescoping).",
+    "significance": "supporting",
+    "relatedConcepts": ["telescoping product", "induction", "Finset.prod_range_succ"],
+    "prerequisites": ["finite products", "induction"]
+  },
+  {
+    "id": "ann-integral-rep",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 100 },
+    "type": "insight",
+    "title": "The Central Binomial Coefficient as an Integral",
+    "content": "The headline result. integral_sin_pow_even_eq_centralBinom identifies Mathlib's even Wallis integral with the parent's product: ∫₀^π sin²ⁿx dx = π·C(2n,n)/4^n, by rewriting integral_sin_pow_even and then centralBinom_div_eq_wallis_prod backwards, closing with ring. The combinatorial and analytic Wallis products are literally equal. Inverting (centralBinom_eq_integral) writes the integer C(2n,n) = (4^n/π)·∫₀^π sin²ⁿx dx as a definite integral — the bridge that lets Wallis' analytic limit speak about the integer sequence.",
+    "mathContext": "$\\int_0^\\pi \\sin^{2n}x\\,dx = \\frac{\\pi\\,C(2n,n)}{4^n}$, equivalently $C(2n,n) = \\frac{4^n}{\\pi}\\int_0^\\pi \\sin^{2n}x\\,dx$.",
+    "significance": "key",
+    "relatedConcepts": ["Wallis integral", "central binomial coefficient", "integral representation", "analytic combinatorics"],
+    "prerequisites": ["definite integrals", "Wallis integrals"]
+  },
+  {
+    "id": "ann-odd-reciprocal",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 102, "endLine": 138 },
+    "type": "concept",
+    "title": "The Odd Integral Is the Reciprocal Central Binomial",
+    "content": "wallis_odd_prod_eq shows ∏(2k+2)/(2k+3) = 4^n/((2n+1)·C(2n,n)). The argument multiplies the even product A = ∏(2k+1)/(2k+2) and the odd product B = ∏(2k+2)/(2k+3): factorwise A·B = ∏(2k+1)/(2k+3) (Finset.prod_mul_distrib), which by the telescope is 1/(2n+1), so A·B·(2n+1) = 1. Substituting the parent's A = C(2n,n)/4^n and clearing denominators (eq_div_iff, linear_combination) gives the closed form, and integral_sin_pow_odd_eq_centralBinom reads off ∫₀^π sin²ⁿ⁺¹ = 2·4^n/((2n+1)·C(2n,n)). The (2k+2)/(2k+3) product is the reciprocal of the central binomial sequence.",
+    "mathContext": "$\\prod_{k<n}\\frac{2k+2}{2k+3} = \\frac{4^n}{(2n+1)C(2n,n)}$; $\\int_0^\\pi \\sin^{2n+1}x\\,dx = \\frac{2\\cdot 4^n}{(2n+1)C(2n,n)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Wallis product", "reciprocal central binomial", "Finset.prod_mul_distrib", "linear_combination"],
+    "prerequisites": ["finite products", "field arithmetic"]
+  },
+  {
+    "id": "ann-consequences",
+    "proofId": "erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 140, "endLine": 166 },
+    "type": "insight",
+    "title": "Multiplying Cancels the Combinatorics; Dividing Squares It",
+    "content": "Pairing the two consecutive Wallis integrals exposes the structure two ways. integral_even_mul_odd_eq: their product (∫sin²ⁿ)(∫sin²ⁿ⁺¹) = 2π/(2n+1) is entirely free of C(2n,n) — the central binomial coefficient cancels. integral_ratio_eq: their quotient (∫sin²ⁿ)/(∫sin²ⁿ⁺¹) = (π/2)(2n+1)(C(2n,n)/4^n)² is the square of the normalised central binomial sequence. Since Wallis' theorem forces this ratio to 1, the identity is the analytic source of the asymptotic C(2n,n)/4^n ∼ 1/√(πn) established in the sibling files — derived here without any Stirling estimate.",
+    "mathContext": "$(\\int\\sin^{2n})(\\int\\sin^{2n+1}) = \\frac{2\\pi}{2n+1}$; $\\frac{\\int\\sin^{2n}}{\\int\\sin^{2n+1}} = \\frac{\\pi}{2}(2n+1)\\left(\\frac{C(2n,n)}{4^n}\\right)^2 \\to 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Wallis' theorem", "central binomial asymptotic", "1/√(πn)", "integral squeeze"],
+    "prerequisites": ["limits", "Wallis product", "asymptotics"]
+  }
+]

--- a/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -55,6 +55,43 @@
       "Does the half-interval refinement ∫₀^{π/2} sin²ⁿx dx = (π/2)·C(2n,n)/4^n (via the sin(π−x) symmetry) yield the Beta-function value B(n+1/2, 1/2) = π·C(2n,n)/4^n, connecting this thread to Mathlib's Gamma/Beta development?"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Combinatorial vs Analytic Wallis Product",
+      "startLine": 1,
+      "endLine": 61,
+      "summary": "Docstring contrasting the parent's combinatorial product C(2n,n)/4^n = ∏(2k+1)/(2k+2) (pure ℚ-arithmetic of the recurrence) with this file's analytic twin: Mathlib's Wallis integrals ∫₀^π sin²ⁿ = π·∏(2k+1)/(2k+2) and ∫₀^π sin²ⁿ⁺¹ = 2·∏(2k+2)/(2k+3) evaluate the same closed products. Imports Mathlib and the parent, opens Nat/Finset/Real/MeasureTheory/intervalIntegral, opens the namespace."
+    },
+    {
+      "id": "odd-telescope",
+      "title": "The Odd-Index Telescoping Product",
+      "startLine": 63,
+      "endLine": 79,
+      "summary": "prod_odd_telescope: ∏_{k<n} (2k+1)/(2k+3) = 1/(2n+1), the elementary telescope (1/3)(3/5)(5/7)···((2n−1)/(2n+1)). One-line induction via Finset.prod_range_succ, push_cast, field_simp, ring — the combinatorial input for the odd powers."
+    },
+    {
+      "id": "integral-rep",
+      "title": "The Integral Representation of C(2n,n)",
+      "startLine": 81,
+      "endLine": 100,
+      "summary": "integral_sin_pow_even_eq_centralBinom (headline): ∫₀^π sin²ⁿ = π·C(2n,n)/4^n, by rewriting Mathlib's integral_sin_pow_even and the parent's centralBinom_div_eq_wallis_prod backwards, closing by ring. centralBinom_eq_integral inverts it via field_simp: C(2n,n) = (4^n/π)·∫₀^π sin²ⁿ — an integer written as a definite integral."
+    },
+    {
+      "id": "odd-reciprocal",
+      "title": "The Odd Powers: the Reciprocal Central Binomial",
+      "startLine": 102,
+      "endLine": 138,
+      "summary": "wallis_odd_prod_eq: ∏(2k+2)/(2k+3) = 4^n/((2n+1)·C(2n,n)), by setting A = ∏(2k+1)/(2k+2), B = ∏(2k+2)/(2k+3), observing A·B = ∏(2k+1)/(2k+3) factorwise (Finset.prod_mul_distrib), substituting A = C/4^n and the telescope to get A·B·(2n+1) = 1, then clearing denominators (eq_div_iff, linear_combination). integral_sin_pow_odd_eq_centralBinom follows: ∫₀^π sin²ⁿ⁺¹ = 2·4^n/((2n+1)·C(2n,n))."
+    },
+    {
+      "id": "consequences",
+      "title": "Multiplying Cancels, Dividing Squares",
+      "startLine": 140,
+      "endLine": 166,
+      "summary": "integral_even_mul_odd_eq: the product (∫sin²ⁿ)(∫sin²ⁿ⁺¹) = 2π/(2n+1) — the central binomial coefficient cancels completely. integral_ratio_eq: the quotient (∫sin²ⁿ)/(∫sin²ⁿ⁺¹) = (π/2)(2n+1)(C(2n,n)/4^n)² — the square of the normalised central binomial sequence, whose Wallis-limit-to-1 is the analytic origin of C(2n,n)/4^n ∼ 1/√(πn). Both by field_simp after the two integral evaluations."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib",


### PR DESCRIPTION
Enrichment pass for `erdos-396-oq-04-oq-01-oq-01-oq-02-oq-02-oq-01-oq-01` (quality 33, pass 0).

## What was added
- **No `annotations.json`** previously — created 5 inline annotations (`mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`) covering the combinatorial/analytic contrast, the odd telescope, the headline integral representation ∫sin²ⁿ = π·C(2n,n)/4^n, the reciprocal odd integral, and the multiply-cancels/divide-squares consequences.
- **Empty `sections`** — added 5 conforming `ProofSection` entries (`startLine`/`endLine`/`summary`) mapped to the actual Lean line ranges.
- meta.json already had a rich `overview`, `conclusion`, and well-formed `crossReferences` (4 targets, all verified to exist) — left intact.

## Accuracy notes
- meta.json reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: verified`; confirmed against the Lean source (no `axiom`/`sorry`/structure-encoded assumptions; no `native_decide`). No status/badge changes.
- Annotations match the actual theorems (integral_sin_pow_even_eq_centralBinom, centralBinom_eq_integral, wallis_odd_prod_eq, integral_even_mul_odd_eq, integral_ratio_eq).
- No `index.ts` shim added (obsolete per issue #20993).

`pnpm build` passes.