### PR TITLE
research(amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01): general Newton–Girard recurrence for arbitrary k [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -69,6 +69,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ02
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01Aristotle
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ01
+import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01
 import Proofs.AmgmInequalityOQ02OQ01OQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03
 import Proofs.AmgmInequalityOQ02OQ01OQ03Finset

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2829,6 +2829,7 @@ import Proofs.GeometricSeriesOQ09
 import Proofs.GeometricSeriesOQ09OQ01
 import Proofs.GeometricSeriesOQ09OQ01OQ01
 import Proofs.GeometricSeriesOQ09OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ09OQ01OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ10
 import Proofs.GnedenkoKolmogorov
 import Proofs.GodelFirstIncompletenessOQ01

--- a/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01.lean
@@ -1,0 +1,152 @@
+/-
+  General Newton–Girard Recurrence for arbitrary k
+
+  Open Question (amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01):
+  The parent proof established the Newton–Girard recurrence only for the
+  fixed degrees k = 4 and k = 5 (and the grandparent handled k = 1, 2, 3),
+  each by hand-expanding the antidiagonal of the corresponding degree.
+
+  This file proves the GENERAL recurrence for ARBITRARY k ≥ 1, in the
+  classical Newton–Girard shape
+
+      pₖ = ∑_{i=1}^{k-1} (-1)^(i+1) · eᵢ · pₖ₋ᵢ  +  (-1)^(k+1) · k · eₖ
+
+  i.e. (writing it out)
+
+      pₖ = e₁·pₖ₋₁ − e₂·pₖ₋₂ + e₃·pₖ₋₃ − ⋯ + (-1)^(k+1)·k·eₖ.
+
+  A single theorem here subsumes the parent's `psum_four_eq`, `psum_five_eq`
+  and the grandparent's k = 1, 2, 3 corollaries (and every other degree),
+  replacing the per-degree antidiagonal book-keeping by one reindexing of the
+  filtered antidiagonal occurring in Mathlib's
+  `MvPolynomial.psum_eq_mul_esymm_sub_sum`:
+
+      pₖ = (-1)^(k+1)·k·eₖ − ∑_{0<a<k} (-1)^a · eₐ · pₖ₋ₐ.
+
+  The only work is to rewrite the filtered antidiagonal sum
+  `∑ a ∈ antidiagonal k, a.1 ∈ Ioo 0 k` as a sum over the interval
+  `Ico 1 k` of the index `i = a.1` (with `a.2 = k - i`), and to fold the
+  outer minus sign into the alternating sign `(-1)^(i+1)`.
+
+  We also record the dual form (solving for `k · eₖ`) and verify, as a
+  sanity check, that specialising to k = 4 recovers the parent's statement
+  verbatim.
+
+  Status: PROVED — general k via antidiagonal reindexing + ring
+  Axioms: 0, Sorries: 0
+  Tags: algebra, symmetric-functions, newton-girard, power-sums, mv-polynomial
+-/
+
+import Mathlib
+
+namespace AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01
+
+open MvPolynomial Finset BigOperators Set
+
+variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]
+
+-- ============================================================
+-- General Newton–Girard recurrence (arbitrary k ≥ 1)
+-- ============================================================
+
+/-- **General Newton–Girard recurrence.** For every `k ≥ 1` the `k`-th power
+sum is determined by the lower power sums and the elementary symmetric
+polynomials through
+
+  `pₖ = ∑_{i=1}^{k-1} (-1)^(i+1) · eᵢ · pₖ₋ᵢ  +  (-1)^(k+1) · k · eₖ`.
+
+This is the classical Newton–Girard identity, valid over any `CommRing` and
+any finite collection of variables.  It subsumes the per-degree corollaries
+(k = 1, 2, 3, 4, 5, …) obtained in the ancestor entries.
+
+The proof reindexes the filtered antidiagonal sum that appears in Mathlib's
+`MvPolynomial.psum_eq_mul_esymm_sub_sum` as a sum over `Finset.Ico 1 k`. -/
+theorem psum_recurrence (k : ℕ) (hk : 0 < k) :
+    psum σ R k =
+      (∑ i ∈ Finset.Ico 1 k,
+        (-1 : MvPolynomial σ R) ^ (i + 1) * esymm σ R i * psum σ R (k - i))
+      + (-1 : MvPolynomial σ R) ^ (k + 1) * (k : MvPolynomial σ R) * esymm σ R k := by
+  -- The filter `i ∈ Ioo 0 k` over `range (k+1)` is exactly `Ico 1 k`.
+  have hfilt :
+      (Finset.range (k + 1)).filter (fun i => i ∈ Set.Ioo 0 k) = Finset.Ico 1 k := by
+    ext i
+    simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_Ico, Set.mem_Ioo]
+    omega
+  -- Reindex the Mathlib filtered-antidiagonal sum (index `a`) to the interval
+  -- `Ico 1 k` (index `i = a.1`, with `a.2 = k - i`).
+  have hS :
+      (∑ a ∈ (Finset.antidiagonal k).filter (fun a : ℕ × ℕ => a.1 ∈ Set.Ioo 0 k),
+          (-1 : MvPolynomial σ R) ^ a.fst * esymm σ R a.1 * psum σ R a.2)
+        = ∑ i ∈ Finset.Ico 1 k,
+            (-1 : MvPolynomial σ R) ^ i * esymm σ R i * psum σ R (k - i) := by
+    rw [← hfilt, Finset.sum_filter, Finset.sum_filter,
+        Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk
+          (fun a : ℕ × ℕ =>
+            if a.1 ∈ Set.Ioo 0 k then
+              (-1 : MvPolynomial σ R) ^ a.fst * esymm σ R a.1 * psum σ R a.2
+            else 0) k]
+  -- Apply Mathlib's identity and substitute the reindexed sum.
+  rw [MvPolynomial.psum_eq_mul_esymm_sub_sum σ R k hk, hS]
+  -- The alternating-sign sum and the `(-1)^i` sum are negatives of each other.
+  have hTU :
+      (∑ i ∈ Finset.Ico 1 k,
+          (-1 : MvPolynomial σ R) ^ (i + 1) * esymm σ R i * psum σ R (k - i))
+        + (∑ i ∈ Finset.Ico 1 k,
+            (-1 : MvPolynomial σ R) ^ i * esymm σ R i * psum σ R (k - i)) = 0 := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_eq_zero
+    intro i _
+    rw [pow_succ]
+    ring
+  linear_combination -hTU
+
+-- ============================================================
+-- Dual form: solving for k · eₖ
+-- ============================================================
+
+/-- **Dual Newton–Girard recurrence.** Rearranging `psum_recurrence` to isolate
+the top elementary symmetric polynomial:
+
+  `(-1)^(k+1) · k · eₖ = pₖ − ∑_{i=1}^{k-1} (-1)^(i+1) · eᵢ · pₖ₋ᵢ`.
+
+Multiplying through by `(-1)^(k+1)` (a unit) expresses `k · eₖ` purely in terms
+of power sums and lower elementary symmetric polynomials. -/
+theorem mul_esymm_recurrence (k : ℕ) (hk : 0 < k) :
+    (-1 : MvPolynomial σ R) ^ (k + 1) * (k : MvPolynomial σ R) * esymm σ R k =
+      psum σ R k
+        - ∑ i ∈ Finset.Ico 1 k,
+            (-1 : MvPolynomial σ R) ^ (i + 1) * esymm σ R i * psum σ R (k - i) := by
+  rw [psum_recurrence σ R k hk]
+  ring
+
+-- ============================================================
+-- Subsumption check: recover the parent's k = 4 corollary
+-- ============================================================
+
+/-- Specialising the general recurrence to `k = 4` reproduces the parent
+entry's `psum_four_eq` verbatim, confirming that the single general theorem
+subsumes the hand-expanded fixed-degree corollaries. -/
+example :
+    psum σ R 4 = esymm σ R 1 * psum σ R 3 - esymm σ R 2 * psum σ R 2 +
+                esymm σ R 3 * psum σ R 1 - 4 * esymm σ R 4 := by
+  have h : Finset.Ico 1 4 = ({1, 2, 3} : Finset ℕ) := by decide
+  rw [psum_recurrence σ R 4 (by norm_num), h,
+      Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_singleton]
+  norm_num
+  ring
+
+/-- Specialising the general recurrence to `k = 5` reproduces the parent
+entry's `psum_five_eq` verbatim. -/
+example :
+    psum σ R 5 = esymm σ R 1 * psum σ R 4 - esymm σ R 2 * psum σ R 3 +
+                esymm σ R 3 * psum σ R 2 - esymm σ R 4 * psum σ R 1 +
+                5 * esymm σ R 5 := by
+  have h : Finset.Ico 1 5 = ({1, 2, 3, 4} : Finset ℕ) := by decide
+  rw [psum_recurrence σ R 5 (by norm_num), h,
+      Finset.sum_insert (by decide), Finset.sum_insert (by decide),
+      Finset.sum_insert (by decide), Finset.sum_singleton]
+  norm_num
+  ring
+
+end AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01

--- a/proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,236 @@
+import Mathlib.Topology.Algebra.InfiniteSum.Basic
+import Mathlib.Topology.Algebra.InfiniteSum.Group
+import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Tactic
+
+/-
+# The Converse Multisection: Residue-Subseries Summability ⟺ Summability
+
+## What This Proves
+
+The parent (`GeometricSeriesOQ09OQ01OQ01OQ01`) proved the *forward* multisection of
+an arbitrary summable family `f : ℕ → M`: from `Summable f` one obtains, for every
+modulus `q ≥ 1`, the summability of each residue subseries `n ↦ f (q·n + a)`
+(`a < q`) and the regrouping identity
+
+  `∑_{a<q} ∑'_n f (q·n + a) = ∑'_m f m`.
+
+That direction relied on `M` being a **complete** Hausdorff uniform abelian group
+(completeness so that each residue subseries converges).
+
+This file answers its open question — the **converse** — and finds it both true and
+*structurally cheaper*:
+
+* **Converse (no completeness, no group).**  If each residue subseries
+  `n ↦ f (q·n + a)` has sum `S a`, then `f` has sum `∑_{a<q} S a` — over *any*
+  topological commutative additive monoid with continuous addition.
+* **Value identity over a mere Hausdorff monoid.**  When the residue subseries are
+  summable, `∑_{a<q} ∑'_n f (q·n + a) = ∑'_m f m` holds with **no completeness
+  hypothesis** — only `T2`.
+* **Equivalence (asymmetric hypotheses).**  The *forward* implication
+  `Summable f → Summable (residue)` is genuinely harder: extracting an infinite
+  subseries needs the Cauchy criterion, i.e. a *complete* uniform group.  Over such a
+  group the characterisation is two-sided:
+  `Summable f ↔ ∀ a : Fin q, Summable (fun n => f (q·n + a))`.
+
+## The Minimal Hypotheses (answering the open question)
+
+The open question asks for the minimal hypotheses under which residue-subseries
+summability is *equivalent* to summability of `f`, and whether the regrouping value
+identity survives the drop from complete to merely Hausdorff `M`.
+
+The answer is as clean as possible.  The **converse** direction
+(`hasSum_of_residues`) — the heart of the matter — needs only that `M` is a
+topological commutative additive *monoid* with `ContinuousAdd`: no group structure,
+no uniform/Cauchy structure, and crucially **no completeness**.  Because the number
+of residues `q` is *finite*, the converse is a finite combination of `HasSum`s
+(`hasSum_sum`), each obtained by viewing a residue subseries as a function on
+`ℕ × Fin q` supported on a single fiber.  Completeness was an artifact of the
+*forward* direction (proving each subseries converges); the converse takes that
+convergence as a hypothesis and so never needs it.
+
+For the two-sided *equivalence* one additionally needs the forward inclusion
+`Summable f → Summable (residue)`.  This direction is *not* free: a subseries of a
+convergent series converges only by the Cauchy criterion, so `Summable.comp_injective`
+requires a **complete** uniform abelian group.  Thus the two implications are
+genuinely asymmetric — the converse holds over a bare monoid, the forward needs
+completeness — and the equivalence holds over a complete uniform abelian group (the
+same setting as the parent's forward multisection).
+
+## Why This Is Not Already in Mathlib
+
+Mathlib has `Nat.divModEquiv`, `Equiv.hasSum_iff`, `Function.Injective.hasSum_iff`,
+`hasSum_sum`, and `Summable.comp_injective`, but not their assembly into the
+two-sided characterisation `Summable f ↔ residue-subseries summable` for a finite
+modulus, nor the observation that the converse regrouping holds over an arbitrary
+Hausdorff topological additive monoid.
+
+## Status: 0 sorries, 0 axioms
+-/
+
+namespace GeometricSeriesOQ09OQ01OQ01OQ01OQ01
+
+set_option linter.unusedSectionVars false
+
+/-! ## Injectivity of the residue map -/
+
+/-- For `q ≠ 0` the residue map `n ↦ q·n + a` is injective `ℕ → ℕ`. -/
+theorem residue_injective {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Function.Injective (fun n : ℕ => q * n + a) := by
+  intro n m h
+  simp only at h
+  exact Nat.eq_of_mul_eq_mul_left (Nat.pos_of_ne_zero hq) (Nat.add_right_cancel h)
+
+/-! ## The converse over a topological commutative additive monoid
+
+No completeness and no group structure: only `ContinuousAdd` (for the finite sum of
+`HasSum`s) and `T2` (for the value identity). -/
+
+section Monoid
+
+variable {M : Type*} [AddCommMonoid M] [TopologicalSpace M] {f : ℕ → M}
+
+/-- The residue subseries `a`, embedded into `ℕ × Fin q` supported on the fiber
+`p.2 = a`. -/
+private def fiber (f : ℕ → M) (q : ℕ) (a : Fin q) (p : ℕ × Fin q) : M :=
+  if p.2 = a then f (q * p.1 + (a : ℕ)) else 0
+
+/-- The single-fiber embedding `fiber f q a` has the same sum `S` as the residue
+subseries `n ↦ f (q·n + a)` itself: viewing the subseries as a function on
+`ℕ × Fin q` supported on one fiber leaves its `HasSum` unchanged. -/
+theorem hasSum_fiber {q : ℕ} (a : Fin q) {S : M}
+    (ha : HasSum (fun n : ℕ => f (q * n + (a : ℕ))) S) :
+    HasSum (fiber f q a) S := by
+  have hinj : Function.Injective (fun n : ℕ => (n, a)) := by
+    intro n m h; simpa using congrArg Prod.fst h
+  have hvanish : ∀ p : ℕ × Fin q, p ∉ Set.range (fun n : ℕ => (n, a)) →
+      fiber f q a p = 0 := by
+    intro p hp
+    have hp2 : p.2 ≠ a := fun h => hp ⟨p.1, by ext <;> simp [h]⟩
+    simp [fiber, hp2]
+  have hcomp : (fiber f q a) ∘ (fun n : ℕ => (n, a))
+      = fun n : ℕ => f (q * n + (a : ℕ)) := by funext n; simp [fiber]
+  exact (hinj.hasSum_iff hvanish).mp (by rw [hcomp]; exact ha)
+
+variable [ContinuousAdd M]
+
+/-- **Converse multisection (`HasSum` form).**  If each residue subseries
+`n ↦ f (q·n + a)` has sum `S a`, then `f` has sum `∑_{a<q} S a`.  Requires *no*
+completeness and *no* group structure: with `q` residues the total is a finite sum
+of `HasSum`s. -/
+theorem hasSum_of_residues {q : ℕ} [NeZero q] {S : Fin q → M}
+    (hS : ∀ a : Fin q, HasSum (fun n : ℕ => f (q * n + (a : ℕ))) (S a)) :
+    HasSum f (∑ a : Fin q, S a) := by
+  -- A finite sum of the `q` single-fiber embeddings.
+  have hsum : HasSum (fun p : ℕ × Fin q => ∑ a : Fin q, fiber f q a p)
+      (∑ a : Fin q, S a) :=
+    hasSum_sum fun a _ => hasSum_fiber a (hS a)
+  -- The fiberwise sum collapses to the reindexed term `f (q·p.1 + p.2)`.
+  have hpt : (fun p : ℕ × Fin q => ∑ a : Fin q, fiber f q a p)
+      = fun p : ℕ × Fin q => f (q * p.1 + (p.2 : ℕ)) := by
+    funext p
+    rw [show f (q * p.1 + (p.2 : ℕ)) = fiber f q p.2 p by simp [fiber]]
+    exact Finset.sum_eq_single p.2
+      (fun a _ ha => by simp [fiber, Ne.symm ha])
+      (fun h => absurd (Finset.mem_univ _) h)
+  rw [hpt] at hsum
+  -- Transport the two-dimensional `HasSum` back to `ℕ` along `(divModEquiv q).symm`.
+  have hcomp : (f ∘ (Nat.divModEquiv q).symm)
+      = fun p : ℕ × Fin q => f (q * p.1 + (p.2 : ℕ)) := by
+    funext p
+    rw [Function.comp_apply, Nat.divModEquiv_symm_apply, Nat.mul_comm p.1 q]
+  exact ((Nat.divModEquiv q).symm.hasSum_iff).mp (by rw [hcomp]; exact hsum)
+
+/-- **Converse multisection (`Summable` form).**  If each residue subseries is
+summable, so is `f`. -/
+theorem summable_of_residues {q : ℕ} [NeZero q]
+    (hS : ∀ a : Fin q, Summable (fun n : ℕ => f (q * n + (a : ℕ)))) :
+    Summable f :=
+  ⟨_, hasSum_of_residues fun a => (hS a).hasSum⟩
+
+/-- **Multisection value identity without completeness.**  When the residue
+subseries are summable, the regrouping `∑_{a<q} ∑'_n f (q·n + a) = ∑'_m f m` holds
+over any *Hausdorff* topological commutative additive monoid — the completeness
+hypothesis of the forward file is dropped. -/
+theorem tsum_multisection_of_residues [T2Space M] {q : ℕ} [NeZero q]
+    (hS : ∀ a : Fin q, Summable (fun n : ℕ => f (q * n + (a : ℕ)))) :
+    ∑ a : Fin q, (∑' n : ℕ, f (q * n + (a : ℕ))) = ∑' m : ℕ, f m :=
+  (hasSum_of_residues (S := fun a : Fin q => ∑' n : ℕ, f (q * n + (a : ℕ)))
+    fun a => (hS a).hasSum).tsum_eq.symm
+
+/-- `Finset.range` form of the value identity. -/
+theorem tsum_multisection_range_of_residues [T2Space M] {q : ℕ} [NeZero q]
+    (hS : ∀ a : Fin q, Summable (fun n : ℕ => f (q * n + (a : ℕ)))) :
+    ∑ a ∈ Finset.range q, (∑' n : ℕ, f (q * n + a)) = ∑' m : ℕ, f m := by
+  rw [← tsum_multisection_of_residues hS,
+    Fin.sum_univ_eq_sum_range (fun a => ∑' n : ℕ, f (q * n + a)) q]
+
+/-- **Even/odd converse.**  If the even-indexed and odd-indexed subseries are both
+summable, so is `f`. -/
+theorem summable_of_even_odd
+    (he : Summable (fun n : ℕ => f (2 * n))) (ho : Summable (fun n : ℕ => f (2 * n + 1))) :
+    Summable f := by
+  apply summable_of_residues (q := 2)
+  intro a; fin_cases a
+  · simpa using he
+  · simpa using ho
+
+/-- **Even/odd value identity over a Hausdorff monoid.**
+`∑'_n f (2n) + ∑'_n f (2n+1) = ∑'_m f m`, with no completeness assumption. -/
+theorem tsum_even_add_odd_of_residues [T2Space M]
+    (he : Summable (fun n : ℕ => f (2 * n))) (ho : Summable (fun n : ℕ => f (2 * n + 1))) :
+    (∑' n : ℕ, f (2 * n)) + (∑' n : ℕ, f (2 * n + 1)) = ∑' m : ℕ, f m := by
+  have h : ∀ a : Fin 2, Summable (fun n : ℕ => f (2 * n + (a : ℕ))) := by
+    intro a; fin_cases a
+    · simpa using he
+    · simpa using ho
+  simpa [Finset.sum_range_succ] using tsum_multisection_range_of_residues h
+
+end Monoid
+
+/-! ## The forward direction and the equivalence
+
+The forward inclusion `Summable f → Summable (residue)` is **not free**: extracting an
+infinite subseries from a convergent series requires the Cauchy criterion, hence a
+*complete* uniform group (`Summable.comp_injective`).  This is the asymmetry with the
+converse, which needs nothing.  Over a complete uniform group both directions hold and
+we obtain the two-sided characterisation. -/
+
+section Group
+
+variable {M : Type*} [AddCommGroup M] [UniformSpace M] [IsUniformAddGroup M]
+  [CompleteSpace M] {f : ℕ → M}
+
+/-- **Forward direction.**  Each residue subseries of a summable family is summable.
+Unlike the converse, this consumes completeness (`Summable.comp_injective` lives in
+the complete-uniform-group section): a subseries of a convergent series converges only
+because the ambient group is complete. -/
+theorem summable_residue (hf : Summable f) {q : ℕ} (hq : q ≠ 0) (a : ℕ) :
+    Summable (fun n : ℕ => f (q * n + a)) := by
+  simpa [Function.comp_def] using hf.comp_injective (residue_injective hq a)
+
+/-- **Equivalence (the two-sided characterisation).**  For any fixed modulus `q ≥ 1`,
+over a complete Hausdorff-free uniform abelian group, summability of `f` is equivalent
+to summability of all `q` residue subseries.  The forward implication needs the
+completeness; the converse (`summable_of_residues`) needs none of it. -/
+theorem summable_iff_residues {q : ℕ} [NeZero q] :
+    Summable f ↔ ∀ a : Fin q, Summable (fun n : ℕ => f (q * n + (a : ℕ))) :=
+  ⟨fun hf a => summable_residue hf (NeZero.ne q) (a : ℕ), summable_of_residues⟩
+
+end Group
+
+/-! ## Concrete check -/
+
+/-- Sanity check: the converse recovers summability of `n ↦ (1/2)^n` from the
+summability of its even and odd subseries, and the value identity holds — with no
+completeness invoked at the multisection step. -/
+example :
+    (∑' n : ℕ, (1 / 2 : ℝ) ^ (2 * n)) + (∑' n : ℕ, (1 / 2 : ℝ) ^ (2 * n + 1))
+      = ∑' m : ℕ, (1 / 2 : ℝ) ^ m := by
+  have hbase : Summable (fun m : ℕ => (1 / 2 : ℝ) ^ m) :=
+    summable_geometric_of_lt_one (by norm_num) (by norm_num)
+  apply tsum_even_add_odd_of_residues
+  · simpa using summable_residue hbase (by norm_num) 0
+  · simpa using summable_residue hbase (by norm_num) 1
+
+end GeometricSeriesOQ09OQ01OQ01OQ01OQ01

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-setup",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 46
+    },
+    "type": "concept",
+    "title": "Universal Setting: CommRing over Any Fintype",
+    "content": "The `open MvPolynomial Finset BigOperators Set` line and `variable (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]` fix the generality of the whole file.\n\n- **`σ : Type*` with `[Fintype σ]`** is the index type for the polynomial variables — any finite type, not just `Fin n`.\n- **`R : Type*` with `[CommRing R]`** is the coefficient ring — no ordering, no field, no characteristic assumption. The proof uses subtraction (the alternating `−` signs), so `CommSemiring` would not suffice.\n\nEvery theorem below is implicitly universally quantified over these parameters, so the general Newton–Girard recurrence holds simultaneously over $\\mathbb{Z}$, $\\mathbb{Q}$, $\\mathbb{F}_p$, polynomial rings, and any other commutative ring with a finite variable set.",
+    "mathContext": "Work happens in `MvPolynomial σ R`. The power sum is $p_k = \\sum_{i:\\sigma} X_i^k$ and the elementary symmetric polynomial is $e_k = \\sum_{S \\subseteq \\sigma, |S|=k} \\prod_{i \\in S} X_i$. The recurrence is an identity in this ring valid for every $(\\sigma, R)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "CommRing",
+      "Fintype",
+      "MvPolynomial σ R",
+      "power sum psum",
+      "elementary symmetric polynomial esymm"
+    ],
+    "prerequisites": [
+      "Lean 4 type class system",
+      "MvPolynomial definition",
+      "Finset.sum over Fintype"
+    ]
+  },
+  {
+    "id": "ann-psum-recurrence",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 105
+    },
+    "type": "theorem",
+    "title": "The General Recurrence and Why It Answers the Open Question",
+    "content": "`psum_recurrence` proves, for every $k \\ge 1$,\n$$p_k = \\sum_{i=1}^{k-1} (-1)^{i+1}\\, e_i\\, p_{k-i} \\;+\\; (-1)^{k+1}\\, k\\, e_k.$$\nThis is the textbook closed form of Newton's identity. The parent entry proved only the fixed degrees $k=4,5$ and listed, as its first open question, proving the recurrence for arbitrary $k$ 'without case-by-case antidiagonal computation', noting the obstacle: expressing the general filter $\\{(a,b) \\mid a+b=k,\\ 0<a<k\\}$ as a Finset that `ring` can close.\n\nThe resolution is a uniform reindexing rather than a per-degree expansion:\n1. **filter = interval** — `(range (k+1)).filter (· ∈ Ioo 0 k) = Ico 1 k`, proved by `ext` + `omega`;\n2. **reindex** — `Finset.sum_filter` turns Mathlib's filtered antidiagonal into an indicator sum, then `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` sends `a ↦ (i, k-i)`, after which step 1 collapses the indicator to a clean `Ico 1 k` sum of `(-1)^i e_i p_{k-i}` (the projections `(i,k-i).1 = i`, `.2 = k-i` reduce definitionally, so this is one `rw` chain).\n\nWith the sum in interval form, the whole identity becomes uniform in $k$ — no degree-specific bookkeeping survives.",
+    "mathContext": "Mathlib's `psum_eq_mul_esymm_sub_sum` states $p_k = (-1)^{k+1} k e_k - \\sum_{a \\in \\mathrm{antidiag}\\,k,\\ 0<a_1<k} (-1)^{a_1} e_{a_1} p_{a_2}$. The reindexing identifies the filtered antidiagonal with the interval $[1,k)$ under $i \\mapsto (i, k-i)$, giving $\\sum_{i=1}^{k-1} (-1)^i e_i p_{k-i}$.",
+    "significance": "fundamental",
+    "relatedConcepts": [
+      "Newton-Girard identity",
+      "filtered antidiagonal",
+      "Finset.Ico reindexing",
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+      "sum_antidiagonal_eq_sum_range_succ_mk"
+    ],
+    "prerequisites": [
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+      "Finset.sum_filter",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk"
+    ]
+  },
+  {
+    "id": "ann-sign-fold",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 101
+    },
+    "type": "technique",
+    "title": "Folding the Outer Minus into the Alternating Sign",
+    "content": "Mathlib's statement carries an outer minus sign in front of the antidiagonal sum, whereas the textbook form carries an internal alternating sign $(-1)^{i+1}$. Bridging them needs $-\\sum_i (-1)^i e_i p_{k-i} = \\sum_i (-1)^{i+1} e_i p_{k-i}$, i.e. the two sums are negatives of one another.\n\nRather than invoke a named 'negate-the-sum' lemma (whose exact name is brittle across Mathlib versions), the proof states the equivalent fact that the two sums **add to zero**:\n$$\\sum_{i \\in \\mathrm{Ico}\\,1\\,k}\\big((-1)^{i+1} + (-1)^{i}\\big) e_i p_{k-i} = 0,$$\nwhich is `Finset.sum_add_distrib` backwards, then `Finset.sum_eq_zero` with a termwise `pow_succ` + `ring` (since $(-1)^{i+1} + (-1)^i = 0$). The main goal then follows by `linear_combination -hTU`, letting `ring` treat each sum as an opaque atom.\n\nThis is a small but reusable robustness trick: proving `T + U = 0` is often cleaner and more version-stable than rewriting `T = -U` through a specific distributivity lemma.",
+    "mathContext": "$(-1)^{i+1} = (-1)\\cdot(-1)^i = -(-1)^i$, so each term of $T+U$ is $\\big((-1)^{i+1}+(-1)^i\\big)e_i p_{k-i} = 0$. Hence $T = -U$, converting the external minus of Mathlib's form into the internal alternating sign.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.sum_add_distrib",
+      "Finset.sum_eq_zero",
+      "pow_succ",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "alternating signs (-1)^n",
+      "Finset.sum manipulation"
+    ]
+  },
+  {
+    "id": "ann-dual-form",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 124
+    },
+    "type": "theorem",
+    "title": "Dual Form: Recovering k·eₖ from Power Sums",
+    "content": "`mul_esymm_recurrence` rearranges the main recurrence to isolate the top elementary symmetric polynomial:\n$$(-1)^{k+1}\\, k\\, e_k = p_k - \\sum_{i=1}^{k-1} (-1)^{i+1}\\, e_i\\, p_{k-i}.$$\nSince $(-1)^{k+1}$ is a unit in any `CommRing`, this determines $k\\, e_k$ — and hence $e_k$ whenever $k$ is invertible, i.e. when $\\operatorname{char}(R) \\nmid k$. That divisibility caveat is exactly why power sums determine the elementary symmetric polynomials over $\\mathbb{Q}, \\mathbb{R}, \\mathbb{C}$ but not, e.g., over $\\mathbb{F}_k$.\n\nThe proof is a single `ring` step after `rw [psum_recurrence …]`, illustrating that once the general recurrence is in closed form, its algebraic consequences are immediate.",
+    "mathContext": "Multiplying $(-1)^{k+1} k e_k = p_k - \\sum_{i=1}^{k-1}(-1)^{i+1} e_i p_{k-i}$ by the unit $(-1)^{k+1}$ gives $k e_k = (-1)^{k+1}\\big(p_k - \\sum \\cdots\\big)$; recovering $e_k$ requires $k$ invertible in $R$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "dual Newton-Girard",
+      "characteristic divisibility",
+      "units in a CommRing",
+      "elementary symmetric polynomials from power sums"
+    ],
+    "prerequisites": [
+      "ring tactic",
+      "units / invertibility"
+    ]
+  },
+  {
+    "id": "ann-subsumption",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 152
+    },
+    "type": "example",
+    "title": "Machine-Checked Subsumption of k=4 and k=5",
+    "content": "Two `example`s specialise the general theorem to $k=4$ and $k=5$ and prove the resulting statements match the parent entry's `psum_four_eq` and `psum_five_eq` **verbatim**:\n$$p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4 e_4, \\qquad p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5 e_5.$$\nEach proof expands the interval (`Ico 1 4 = {1,2,3}`, `Ico 1 5 = {1,2,3,4}`, both by `decide`), unfolds the sum via `sum_insert`/`sum_singleton`, and closes with `norm_num; ring` to evaluate the powers $(-1)^{i+1}$ and the natural-number subtractions $k-i$.\n\nThis is the formal content of 'subsumption': the fixed-degree corollaries of the ancestor entries are now *instances* of one theorem, verified by deriving them from it inside the same file. The `decide` calls are kernel-level Finset facts on small literals — no `native_decide`, so the file remains genuinely axiom-free.",
+    "mathContext": "Specialising $p_k = \\sum_{i=1}^{k-1}(-1)^{i+1} e_i p_{k-i} + (-1)^{k+1} k e_k$ at $k=4$ gives signs $+,-,+$ on $e_1 p_3, e_2 p_2, e_3 p_1$ and $-4e_4$; at $k=5$ the pattern continues to $+5e_5$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "subsumption",
+      "Finset.Ico expansion",
+      "kernel decide vs native_decide",
+      "psum_four_eq / psum_five_eq"
+    ],
+    "prerequisites": [
+      "Finset.sum_insert / sum_singleton",
+      "norm_num, ring",
+      "natural number subtraction"
+    ]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,188 @@
+{
+  "id": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+  "title": "General Newton–Girard Recurrence for Arbitrary k",
+  "slug": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01",
+  "description": "Proves the Newton–Girard recurrence for arbitrary k ≥ 1 as a single closed-form theorem — pₖ = Σ_{i=1}^{k-1} (-1)^(i+1)·eᵢ·pₖ₋ᵢ + (-1)^(k+1)·k·eₖ — directly answering the parent entry's open question of replacing per-degree antidiagonal computation by one general statement. The key step reindexes the filtered antidiagonal of Mathlib's psum_eq_mul_esymm_sub_sum as a sum over the interval Ico 1 k. A single theorem subsumes the parent's k=4,5 and the grandparent's k=1,2,3 corollaries (verified by reproducing the k=4 and k=5 statements verbatim). Also records the dual form solving for k·eₖ.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "symmetric-functions",
+      "newton-girard",
+      "power-sums",
+      "elementary-symmetric-polynomials",
+      "mv-polynomial"
+    ],
+    "badge": "mathlib",
+    "mathlibDependencies": [
+      {
+        "theorem": "MvPolynomial.psum_eq_mul_esymm_sub_sum",
+        "description": "Newton–Girard recurrence in filtered-antidiagonal form: pₖ = (-1)^(k+1)·k·eₖ − Σ_{a ∈ antidiagonal k, 0 < a.1 < k} (-1)^a.1·e_{a.1}·p_{a.2}",
+        "module": "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities"
+      },
+      {
+        "theorem": "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk",
+        "description": "Reindexes a sum over the nat antidiagonal of k as a sum over range (k+1): Σ_{ij ∈ antidiagonal k} f ij = Σ_{i ∈ range (k+1)} f (i, k-i). Used to convert the filtered antidiagonal to an interval sum.",
+        "module": "Mathlib.Algebra.BigOperators.NatAntidiagonal"
+      }
+    ],
+    "originalContributions": [
+      "psum_recurrence: the general Newton–Girard recurrence pₖ = Σ_{i ∈ Ico 1 k} (-1)^(i+1)·eᵢ·pₖ₋ᵢ + (-1)^(k+1)·k·eₖ for arbitrary k ≥ 1 over any CommRing and any Fintype index — a single theorem replacing the per-degree antidiagonal expansions of the ancestor entries",
+      "Reindexing technique: rewrites Mathlib's filtered antidiagonal {a ∈ antidiagonal k | 0 < a.1 < k} as the interval Ico 1 k via sum_filter + sum_antidiagonal_eq_sum_range_succ_mk, solving the parent's stated challenge of 'expressing the general antidiagonal filter as a Finset in a way that ring can close'",
+      "Sign-folding lemma: the alternating sum Σ (-1)^(i+1)·eᵢ·pₖ₋ᵢ and the raw sum Σ (-1)^i·eᵢ·pₖ₋ᵢ are termwise negatives, established by a Finset.sum_eq_zero argument (T + U = 0) that avoids any named neg-sum lemma",
+      "mul_esymm_recurrence: the dual form (-1)^(k+1)·k·eₖ = pₖ − Σ_{i ∈ Ico 1 k} (-1)^(i+1)·eᵢ·pₖ₋ᵢ, isolating the top elementary symmetric polynomial, valid over any CommRing",
+      "Subsumption checks: the k=4 and k=5 specialisations are derived from the general theorem and shown to match the parent's psum_four_eq and psum_five_eq statements verbatim"
+    ],
+    "dateAdded": "2026-06-23",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 152,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "assumptions": "Headline identity delegates to Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum; the new content is the reindexing of the filtered antidiagonal to a closed-form interval sum. 0 sorries, 0 axiom declarations, no native_decide (the `decide` calls are kernel-level Finset facts on small literals).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Newton's identities — also called Newton–Girard identities — relate the power sums $p_k = \\sum_i x_i^k$ to the elementary symmetric polynomials $e_k = \\sum_{i_1 < \\cdots < i_k} x_{i_1}\\cdots x_{i_k}$. Albert Girard recorded the low-degree cases in 1629; Newton stated the general recurrence in *Arithmetica Universalis* (1707); Waring and Lagrange later used them in the theory of polynomial resolvents.\n\nMathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum` proves the recurrence for all $k \\ge 1$ over any `CommRing` and any `Fintype` index, but it states it in a *filtered-antidiagonal* form: the lower-order terms appear as a sum over $\\{a \\in \\text{antidiagonal } k \\mid 0 < a_1 < k\\}$. The ancestor gallery entries (k=1,2,3 and k=4,5) each unfolded this filter by hand for one fixed degree.\n\nThis entry closes the loop by proving the recurrence once, for *arbitrary* $k$, in the familiar closed form $p_k = \\sum_{i=1}^{k-1}(-1)^{i+1} e_i p_{k-i} + (-1)^{k+1} k e_k$. It directly answers the first open question posed by the parent entry.",
+    "problemStatement": "**Open Question** (parent entry, first item): Prove the general Newton–Girard recurrence for arbitrary $k$ as a single theorem using Mathlib's `psum_eq_mul_esymm_sub_sum` directly, without case-by-case antidiagonal computation. The stated obstacle is expressing the general antidiagonal filter $\\{(a,b) \\mid a+b=k,\\ 0 < a < k\\}$ as a Finset in a way that `ring` can close.\n\n**Answer**: For every $k \\ge 1$,\n$$p_k = \\sum_{i=1}^{k-1} (-1)^{i+1}\\, e_i\\, p_{k-i} \\;+\\; (-1)^{k+1}\\, k\\, e_k$$\nover any `CommRing` and any `Fintype` index. The filter is handled uniformly: `Finset.sum_filter` turns it into an indicator sum, `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` reindexes the antidiagonal to `range (k+1)`, and the predicate `0 < i < k` over `range (k+1)` is exactly `Finset.Ico 1 k`.",
+    "text": "A single general theorem (psum_recurrence) for the Newton–Girard recurrence at arbitrary k, obtained by reindexing the filtered antidiagonal in Mathlib's psum_eq_mul_esymm_sub_sum to a sum over Ico 1 k. The parent's k=4 and k=5 corollaries are recovered verbatim as specialisations.",
+    "proofStrategy": "**Step 1 (filter = interval).** Show `(range (k+1)).filter (· ∈ Ioo 0 k) = Ico 1 k` by `ext` + `omega`.\n\n**Step 2 (reindex).** Rewrite Mathlib's filtered antidiagonal sum: `Finset.sum_filter` converts the filter to an `if … then … else 0` indicator, `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` reindexes `antidiagonal k` to `range (k+1)` (sending `a ↦ (i, k-i)`), and Step 1 collapses the indicator back to a clean sum over `Ico 1 k` of `(-1)^i · eᵢ · pₖ₋ᵢ`. The projections `(i, k-i).1 = i`, `.2 = k-i` reduce definitionally, so the whole reindex is a single `rw` chain.\n\n**Step 3 (fold the sign).** The outer minus sign in Mathlib's statement is absorbed into the alternating exponent: `Σ (-1)^(i+1) eᵢ pₖ₋ᵢ` and `Σ (-1)^i eᵢ pₖ₋ᵢ` sum to zero termwise (`pow_succ` + `ring` inside `Finset.sum_eq_zero`), and `linear_combination` finishes.\n\n**Step 4 (dual + subsumption).** `mul_esymm_recurrence` is one `ring` rearrangement. The k=4 and k=5 specialisations expand `Ico 1 4` / `Ico 1 5` via `sum_insert`/`sum_singleton` and close with `norm_num; ring`, matching the parent statements exactly.",
+    "keyInsights": [
+      "Mathlib already proves Newton–Girard for all k, but in a filtered-antidiagonal form; the genuine work is presentational — turning that filter into the textbook closed form so that downstream `ring`/`linear_combination` reasoning becomes uniform in k",
+      "The filter `{a ∈ antidiagonal k | 0 < a.1 < k}` is exactly the image of the interval `Ico 1 k` under `i ↦ (i, k-i)`; recognising this lets `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` do the reindexing in one rewrite, with the second coordinate `k - i` appearing automatically",
+      "Folding the outer minus sign into the alternating exponent `(-1)^(i+1) = -(-1)^i` is cleanest stated as 'the two sums add to zero' (`Finset.sum_eq_zero` after `pow_succ`), which sidesteps any dependence on the exact name of a negate-the-sum lemma",
+      "Because the proof is uniform in k, it strictly subsumes every fixed-degree corollary: instantiating at k=4 and k=5 and discharging with `norm_num; ring` reproduces the parent's psum_four_eq and psum_five_eq verbatim — a machine-checked demonstration that one theorem replaces the whole ladder",
+      "The recurrence holds over any CommRing with any Fintype index; the integer coefficient k in (-1)^(k+1)·k·eₖ means eₖ is recoverable from power sums only when char(R) ∤ k, exactly the obstruction that makes the dual form fail over 𝔽ₖ"
+    ],
+    "prerequisites": [
+      "MvPolynomial.psum_eq_mul_esymm_sub_sum — Newton–Girard in filtered-antidiagonal form (Mathlib)",
+      "Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk — antidiagonal-to-range reindexing (Mathlib)",
+      "Finset.sum_filter, Finset.sum_eq_zero, Finset.sum_add_distrib — finite-sum manipulation",
+      "Parent proof: AmgmInequalityOQ02OQ01OQ02OQ01OQ01 (k=4,5 corollaries)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: Statement of the General Recurrence",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "States the open question (replace per-degree antidiagonal work by one arbitrary-k theorem), the target closed form, and the reindexing plan. Records 0 sorries, 0 axioms.",
+      "mathContext": "Target: $p_k = \\sum_{i=1}^{k-1}(-1)^{i+1} e_i p_{k-i} + (-1)^{k+1} k e_k$ for all $k \\ge 1$, from Mathlib's filtered-antidiagonal form $p_k = (-1)^{k+1} k e_k - \\sum_{0<a<k}(-1)^a e_a p_{k-a}$."
+    },
+    {
+      "id": "setup",
+      "title": "Setup: Imports, Namespace, Opens, Variables",
+      "startLine": 51,
+      "endLine": 50,
+      "summary": "Imports Mathlib; opens MvPolynomial, Finset, BigOperators, Set; binds (σ : Type*) (R : Type*) [CommRing R] [Fintype σ]. Both theorems are universally quantified over these.",
+      "mathContext": "All results hold over an arbitrary `CommRing R` and arbitrary `Fintype` index `σ` — no ordering, field, or characteristic-zero assumptions."
+    },
+    {
+      "id": "psum-recurrence",
+      "title": "General Newton–Girard Recurrence (psum_recurrence)",
+      "startLine": 52,
+      "endLine": 105,
+      "summary": "The main theorem. Reindexes Mathlib's filtered antidiagonal to Ico 1 k (sum_filter + sum_antidiagonal_eq_sum_range_succ_mk + the filter=interval lemma), folds the outer minus into the alternating sign via a T+U=0 identity, and closes with linear_combination.",
+      "mathContext": "$p_k = \\sum_{i=1}^{k-1}(-1)^{i+1} e_i p_{k-i} + (-1)^{k+1} k e_k$ for $k \\ge 1$."
+    },
+    {
+      "id": "dual-form",
+      "title": "Dual Form: solving for k·eₖ (mul_esymm_recurrence)",
+      "startLine": 107,
+      "endLine": 124,
+      "summary": "Rearranges psum_recurrence to isolate (-1)^(k+1)·k·eₖ = pₖ − Σ_{i ∈ Ico 1 k} (-1)^(i+1)·eᵢ·pₖ₋ᵢ. One ring step.",
+      "mathContext": "$(-1)^{k+1} k e_k = p_k - \\sum_{i=1}^{k-1}(-1)^{i+1} e_i p_{k-i}$; multiplying by the unit $(-1)^{k+1}$ gives $k e_k$ in terms of power sums."
+    },
+    {
+      "id": "subsumption",
+      "title": "Subsumption Checks: recovering k=4 and k=5",
+      "startLine": 126,
+      "endLine": 152,
+      "summary": "Two examples specialise psum_recurrence to k=4 and k=5 and show the result matches the parent's psum_four_eq and psum_five_eq verbatim, by expanding Ico 1 4 / Ico 1 5 and closing with norm_num; ring.",
+      "mathContext": "$p_4 = e_1 p_3 - e_2 p_2 + e_3 p_1 - 4e_4$ and $p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5e_5$, now obtained as instances of the general theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves the Newton–Girard recurrence for arbitrary k ≥ 1 as one closed-form theorem (psum_recurrence), with 0 sorries and 0 axioms, plus its dual form. The key move reindexes the filtered antidiagonal of Mathlib's psum_eq_mul_esymm_sub_sum to an interval sum over Ico 1 k. The k=4 and k=5 specialisations reproduce the parent's corollaries verbatim, confirming subsumption.",
+    "implications": "**For the gallery's Newton–Girard chain**: a single arbitrary-k theorem now stands above the k=1,2,3 and k=4,5 fixed-degree entries, which become corollaries.\n\n**Methodologically**: the filter-to-interval reindexing (sum_filter → sum_antidiagonal_eq_sum_range_succ_mk → filter=Ico) is a reusable pattern for turning Mathlib's antidiagonal-form identities into closed forms amenable to ring/linear_combination.",
+    "openQuestions": [
+      "Derive the reverse direction as cleanly: a general closed form expressing eₖ as a polynomial in p₁,…,pₖ (Newton's identities solved for the elementary symmetric polynomials), via strong induction on k using mul_esymm_recurrence",
+      "Package psum_recurrence as a definitional recursion that computes pₖ from e₁,…,eₖ and lower power sums, yielding an executable Newton sum routine over any CommRing"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "Direct parent: proves Newton–Girard for k=4,5 by hand-expanding the antidiagonal. This entry answers its first open question by proving the arbitrary-k recurrence once, with k=4,5 recovered as instances."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02-oq-01-oq-02-oq-01",
+      "relationship": "ancestor",
+      "description": "Grandparent: Newton–Girard for k=1,2,3 — also subsumed by the general recurrence proved here."
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "ancestor",
+      "description": "Root of this sub-branch: Maclaurin inequalities via elementary symmetric polynomials."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "related",
+      "description": "Vieta's formulas express polynomial coefficients as elementary symmetric polynomials of the roots; combined with the general Newton–Girard recurrence here, all power sums pₖ become computable directly from the coefficients."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "related",
+      "description": "Newton–Girard identities supply the symmetric-function machinery for discriminant and resolvent computations underlying the Abel–Ruffini solvability boundary; the arbitrary-k form removes the per-degree ceiling of the fixed-degree entries."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "psum_recurrence",
+      "statement": "∀ (k : ℕ), 0 < k → psum σ R k = (∑ i ∈ Finset.Ico 1 k, (-1) ^ (i + 1) * esymm σ R i * psum σ R (k - i)) + (-1) ^ (k + 1) * (k : MvPolynomial σ R) * esymm σ R k",
+      "description": "General Newton–Girard recurrence for arbitrary k ≥ 1: the k-th power sum as a closed-form alternating combination of lower power sums and elementary symmetric polynomials, over any CommRing and any Fintype index. Subsumes the fixed-degree corollaries of the ancestor entries."
+    },
+    {
+      "name": "mul_esymm_recurrence",
+      "statement": "∀ (k : ℕ), 0 < k → (-1) ^ (k + 1) * (k : MvPolynomial σ R) * esymm σ R k = psum σ R k - ∑ i ∈ Finset.Ico 1 k, (-1) ^ (i + 1) * esymm σ R i * psum σ R (k - i)",
+      "description": "Dual form isolating the top elementary symmetric polynomial: (-1)^(k+1)·k·eₖ expressed via the k-th power sum and the lower-order alternating sum, over any CommRing."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Newton, Isaac",
+      "title": "Arithmetica Universalis",
+      "year": "1707",
+      "venue": "Cambridge",
+      "note": "States the general Newton–Girard recurrence (without proof); psum_recurrence is its machine-checked closed form for arbitrary k"
+    },
+    {
+      "authors": "Girard, Albert",
+      "title": "Invention nouvelle en l'algèbre",
+      "year": "1629",
+      "venue": "Amsterdam",
+      "note": "First written formulation of the identities for low-degree cases"
+    },
+    {
+      "authors": "Macdonald, I.G.",
+      "title": "Symmetric Functions and Hall Polynomials",
+      "year": "1995",
+      "venue": "Oxford University Press, 2nd edition",
+      "note": "Standard reference for Newton–Girard identities and power-sum symmetric functions"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01OQ01.lean",
+    "lineCount": 152,
+    "theoremCount": 2,
+    "definitionCount": 0,
+    "axiomCount": 0,
+    "sorries": 0
+  }
+}

--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,182 @@
+{
+  "id": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Topology.Algebra.InfiniteSum.Group",
+      "Mathlib.Logic.Equiv.Fin.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "GeometricSeriesOQ09OQ01OQ01OQ01OQ01",
+    "lineCount": 236,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/GeometricSeriesOQ09OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Converse Multisection: Residue-Subseries Summability ⟺ Summability, with Asymmetric Hypotheses",
+  "description": "Answers the parent's open question by establishing the CONVERSE of the residue multisection and pinning down the minimal hypotheses of each direction. The parent (geometric-series-oq-09-oq-01-oq-01-oq-01) proved the forward multisection of an arbitrary summable family f : ℕ → M over a COMPLETE Hausdorff uniform abelian group. This entry shows the converse is structurally cheaper: if each residue subseries n ↦ f(q·n+a) (a < q) has sum S a, then HasSum f (∑_{a<q} S a) — over ANY topological commutative additive monoid with continuous addition, with NO completeness and NO group structure. The proof embeds each residue subseries into ℕ × Fin q supported on a single fiber (Function.Injective.hasSum_iff), so the q subseries assemble as a finite sum of HasSums (hasSum_sum) which transports back along Nat.divModEquiv (Equiv.hasSum_iff). Consequently summable_of_residues (residue summability ⟹ Summable f) and the value identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m hold over a merely Hausdorff (T2) monoid — the completeness of the forward file is dropped. The forward inclusion is genuinely harder: extracting an infinite subseries from a convergent series needs the Cauchy criterion, so Summable.comp_injective requires a complete uniform group. Hence the two directions are ASYMMETRIC, and the two-sided equivalence Summable f ↔ ∀ a, Summable (n ↦ f(q·n+a)) holds over a complete uniform abelian group.",
+  "overview": {
+    "historicalContext": "The q-section (multisection) of a series ∑_m c_m extracts, for each residue a mod q, the subseries ∑_n c_{q·n+a}. The geometric ancestry built it analytically (closed forms r^a/(1−r^q)); the parent chain recast it as a reindexing of HasSum along the bijection ℕ ≃ ℕ × Fin q (Nat.divModEquiv), proving the FORWARD direction — summable f yields summable residue subseries and the regrouping identity — over a complete Hausdorff uniform abelian group. The completeness there is doing real work: it is what makes each infinite residue subseries converge (Summable.comp_injective). The natural next question, which this entry answers, is the two-sided refinement: is the converse true, and how much of that completeness is actually needed on each side?",
+    "problemStatement": "For f : ℕ → M and a modulus q ≠ 0 with the property that every residue subseries n ↦ f(q·n+a) (a : Fin q) is summable: (1) is f itself summable (a converse to the multisection)? (2) does ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m persist when M is only Hausdorff, not complete? (3) what are the minimal hypotheses making residue-subseries summability EQUIVALENT to summability of f?",
+    "proofStrategy": "Converse (no completeness): for each a : Fin q define fiber f q a : ℕ × Fin q → M sending p to f(q·p.1 + a) on the fiber {p.2 = a} and 0 elsewhere. The injection ℕ → ℕ × Fin q, n ↦ (n,a), has range exactly that fiber, so Function.Injective.hasSum_iff turns HasSum (residue a) (S a) into HasSum (fiber f q a) (S a). The pointwise sum ∑_{a:Fin q} fiber f q a p collapses (Finset.sum_eq_single) to the reindexed term f(q·p.1 + p.2); summing the q embeddings as a finite combination of HasSums (hasSum_sum) gives HasSum (fun p => f(q·p.1+p.2)) (∑_a S a), which transports back to HasSum f (∑_a S a) along (Nat.divModEquiv q).symm.hasSum_iff. This uses only AddCommMonoid + ContinuousAdd. summable_of_residues and (under T2) tsum_multisection_of_residues / its Finset.range form follow. Forward (completeness): summable_residue is hf.comp_injective along the injective residue map n ↦ q·n+a (residue_injective), which in Mathlib lives in the complete-uniform-group section — extracting an infinite subseries needs the Cauchy criterion. summable_iff_residues packages both directions over a complete uniform abelian group.",
+    "keyInsights": [
+      "The converse multisection needs NO completeness and NO group structure — only a topological commutative additive monoid with continuous addition. Because the number of residues q is finite, reconstructing f is a FINITE sum of HasSums (hasSum_sum), each a residue subseries embedded on a single fiber of ℕ × Fin q via Function.Injective.hasSum_iff. Completeness was an artifact of the forward direction, never the converse.",
+      "The two directions are genuinely ASYMMETRIC. Forward (Summable f ⟹ residue subseries summable) extracts an INFINITE subseries from a convergent series, which converges only by the Cauchy criterion — hence a complete uniform group (Summable.comp_injective). Converse (residue subseries summable ⟹ Summable f) reassembles f from FINITELY many given sums and needs nothing. So the difficulty lives entirely on the forward side.",
+      "The value identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m drops from a complete uniform group (parent) to a merely Hausdorff (T2) topological monoid: once the residue subseries are assumed summable, the identity is the tsum of the converse HasSum, and T2 only supplies uniqueness of the sum.",
+      "The single-fiber embedding is the technical heart: a residue subseries n ↦ f(q·n+a), viewed as a function on ℕ × Fin q supported on the fiber {p.2 = a}, has the SAME HasSum (Function.Injective.hasSum_iff), because the injection n ↦ (n,a) has that fiber as its range and the function vanishes off it.",
+      "The minimal-hypotheses answer: residue-subseries summability ⟺ summability of f holds over a complete Hausdorff uniform abelian group; the ⟸ direction (converse) alone holds over any ContinuousAdd monoid, and the value identity over any T2 such monoid."
+    ]
+  },
+  "sections": [
+    {
+      "id": "residue-injectivity",
+      "title": "Injectivity of the Residue Map",
+      "startLine": 76,
+      "endLine": 84,
+      "summary": "residue_injective: n ↦ q·n+a is injective ℕ → ℕ for q ≠ 0 (Nat.eq_of_mul_eq_mul_left after Nat.add_right_cancel). Shared by both the single-fiber embedding and the forward direction.",
+      "mathContext": "$n\\mapsto qn+a$ injective for $q\\neq0$."
+    },
+    {
+      "id": "converse-monoid",
+      "title": "The Converse over a Topological Commutative Additive Monoid",
+      "startLine": 89,
+      "endLine": 189,
+      "summary": "fiber/hasSum_fiber: a residue subseries embedded into ℕ × Fin q on the single fiber {p.2 = a} has the same HasSum (Function.Injective.hasSum_iff). hasSum_of_residues (main): if each residue subseries has sum S a then HasSum f (∑_{a<q} S a), a finite sum of fiber HasSums (hasSum_sum) collapsed by Finset.sum_eq_single and transported along (Nat.divModEquiv q).symm.hasSum_iff — NO completeness, NO group. summable_of_residues: residue summability ⟹ Summable f. tsum_multisection_of_residues / _range: the value identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m over a merely T2 monoid. summable_of_even_odd and tsum_even_add_odd_of_residues: the q=2 specialisations.",
+      "mathContext": "Each residue subseries summable $\\Rightarrow$ $\\mathrm{HasSum}\\,f\\,(\\sum_{a<q} S_a)$, over any $\\mathrm{ContinuousAdd}$ monoid; value identity over $T_2$."
+    },
+    {
+      "id": "forward-equivalence",
+      "title": "The Forward Direction and the Two-Sided Equivalence",
+      "startLine": 199,
+      "endLine": 220,
+      "summary": "summable_residue: each residue subseries of a summable f is summable, via Summable.comp_injective along the injective residue map — this consumes completeness (the lemma lives in the complete-uniform-group section). summable_iff_residues: the two-sided characterisation Summable f ↔ ∀ a : Fin q, Summable (n ↦ f(q·n+a)) over a complete Hausdorff uniform abelian group, the forward half needing completeness and the converse half needing none.",
+      "mathContext": "Forward needs completeness (Cauchy criterion); equivalence over a complete uniform abelian group."
+    },
+    {
+      "id": "concrete-check",
+      "title": "Concrete Check",
+      "startLine": 222,
+      "endLine": 236,
+      "summary": "A sanity check on n ↦ (1/2)^n: the converse recovers the value identity ∑_n (1/2)^(2n) + ∑_n (1/2)^(2n+1) = ∑_m (1/2)^m from the summability of the even and odd subseries, with no completeness invoked at the multisection step.",
+      "mathContext": "$\\sum_n (1/2)^{2n}+\\sum_n (1/2)^{2n+1}=\\sum_m (1/2)^m$."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ09OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "infinite-series",
+      "summability",
+      "multisection",
+      "converse",
+      "reindexing",
+      "topological-monoid",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 236,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "hasSum_of_residues: the CONVERSE multisection — if each residue subseries n ↦ f(q·n+a) has sum S a, then HasSum f (∑_{a<q} S a), over ANY topological commutative additive monoid with continuous addition, with no completeness and no group structure. This answers geometric-series-oq-09-oq-01-oq-01-oq-01's open question.",
+      "The single-fiber embedding fiber / hasSum_fiber: a residue subseries viewed as a function on ℕ × Fin q supported on one fiber has the same HasSum (Function.Injective.hasSum_iff), the technical device that makes the converse a finite sum of HasSums (hasSum_sum).",
+      "summable_of_residues: residue-subseries summability ⟹ Summable f, over a bare ContinuousAdd monoid — the converse to the forward file's summable_residue.",
+      "tsum_multisection_of_residues and its Finset.range form: the regrouping value identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m over a merely Hausdorff (T2) topological monoid, dropping the completeness hypothesis of the parent.",
+      "summable_iff_residues: the two-sided characterisation Summable f ↔ ∀ a : Fin q, Summable (n ↦ f(q·n+a)) over a complete Hausdorff uniform abelian group, exhibiting the ASYMMETRY — the forward implication consumes completeness (a subseries converges only by the Cauchy criterion), the converse needs none.",
+      "The q=2 specialisations summable_of_even_odd and tsum_even_add_odd_of_residues (∑_n f(2n)+∑_n f(2n+1)=∑_m f m without completeness), residue_injective, and a concrete check on n ↦ (1/2)^n."
+    ],
+    "prerequisites": [
+      "Function.Injective.hasSum_iff: HasSum (f ∘ g) a ↔ HasSum f a for injective g whose range contains the support of f — the single-fiber embedding device (monoid-level)",
+      "hasSum_sum: a finite sum of HasSums is a HasSum of the pointwise sum (needs ContinuousAdd)",
+      "Equiv.hasSum_iff and Nat.divModEquiv: transport HasSum along ℕ ≃ ℕ × Fin q, m ↦ (m/q, m%q)",
+      "Finset.sum_eq_single, Fin.sum_univ_eq_sum_range (collapsing the fiberwise sum and rewriting to Finset.range)",
+      "Summable.comp_injective (complete uniform group): summability descends along injections — the forward direction's completeness-consuming step",
+      "Parent: geometric-series-oq-09-oq-01-oq-01-oq-01 (the forward multisection of an arbitrary summable family)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Function.Injective.hasSum_iff",
+        "description": "For injective g with f vanishing off its range, HasSum (f ∘ g) a ↔ HasSum f a. Used (monoid-level) to identify a residue subseries with its single-fiber embedding into ℕ × Fin q.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Defs"
+      },
+      {
+        "theorem": "hasSum_sum",
+        "description": "A finite sum of HasSums has the pointwise sum as its sum (∑ i ∈ s, HasSum (f i) (a i) ⟹ HasSum (fun b => ∑ i ∈ s, f i b) (∑ i ∈ s, a i)). Assembles the q single-fiber embeddings into one HasSum; the only ContinuousAdd input of the converse.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Equiv.hasSum_iff",
+        "description": "HasSum (f ∘ e) a ↔ HasSum f a for an equivalence e. Applied with e = (Nat.divModEquiv q).symm to transport the two-dimensional HasSum on ℕ × Fin q back to f on ℕ.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Nat.divModEquiv",
+        "description": "The bijection ℕ ≃ ℕ × Fin n, a ↦ (a/n, a%n), with inverse (q,r) ↦ q·n + r. The index relabelling underlying the residue decomposition.",
+        "module": "Mathlib.Logic.Equiv.Fin.Basic"
+      },
+      {
+        "theorem": "Summable.comp_injective",
+        "description": "If f is summable and i injective then f ∘ i is summable; lives in the complete-uniform-group section. The forward direction's single, completeness-consuming step (a subseries of a convergent series converges by the Cauchy criterion).",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Group"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "question": "Is the completeness in the forward direction necessary, or merely sufficient? Construct an incomplete Hausdorff topological abelian group M and a family f : ℕ → M that is summable but with some residue subseries (q = 2) NOT summable — exhibiting a summable series with a non-summable even part — thereby showing Summable.comp_injective genuinely fails without completeness and that the equivalence summable_iff_residues cannot be stated over a bare topological group.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-09-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent. The parent proved the FORWARD multisection of an arbitrary summable family over a complete Hausdorff uniform abelian group: Summable f yields each residue subseries summable and ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m. This entry answers its open question with the CONVERSE — residue-subseries summability ⟹ Summable f and the same value identity — over a bare topological monoid (no completeness, no group), and isolates the asymmetry: only the forward direction needs completeness (the Cauchy criterion for extracting an infinite subseries)."
+    },
+    {
+      "targetId": "geometric-series-oq-09-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent. The grandparent recast the q-fold geometric splitting as a reindexing of the geometric HasSum along Nat.divModEquiv. The converse here uses the same bijection in reverse: it transports a finite assembly of residue-subseries HasSums (built on the fibers of ℕ × Fin q) back to f, reconstructing the whole series from its q residue parts."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.Algebra.InfiniteSum.Defs / Basic (Function.Injective.hasSum_iff, hasSum_sum, Equiv.hasSum_iff)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Monoid-level infinite-sum API: reindexing along injections and equivalences, and finite sums of HasSums — the engines of the completeness-free converse."
+    },
+    {
+      "title": "Mathlib4: Topology.Algebra.InfiniteSum.Group (Summable.comp_injective)",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Descent of summability along an injection in a complete uniform group — the completeness-consuming forward step, illustrating why the two directions are asymmetric."
+    },
+    {
+      "title": "Concrete Mathematics (multisection of power series)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the q-section of a power series into q subseries indexed by residue classes mod q."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The converse of the residue multisection is established and the minimal hypotheses of each direction are pinned down. If every residue subseries n ↦ f(q·n+a) (a : Fin q) has sum S a, then HasSum f (∑_{a<q} S a) — over ANY topological commutative additive monoid with continuous addition, via a finite sum (hasSum_sum) of single-fiber embeddings (Function.Injective.hasSum_iff) transported along Nat.divModEquiv. Hence summable_of_residues (residue summability ⟹ Summable f) and the value identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f m (tsum_multisection_of_residues) hold with NO completeness — only T2 for the identity. The forward inclusion (summable_residue) is genuinely harder, consuming completeness via Summable.comp_injective, so the two-sided equivalence summable_iff_residues holds over a complete Hausdorff uniform abelian group. 236 lines, 10 theorems, 1 definition, 0 axioms, 0 sorries; each result depends only on propext, Classical.choice, Quot.sound.",
+    "implications": "Answers geometric-series-oq-09-oq-01-oq-01-oq-01's open question two-sidedly and exhibits the asymmetry the question anticipated: residue-subseries summability is EQUIVALENT to summability of f over a complete uniform abelian group, but the converse implication alone is completeness-free (a finite reconstruction), while the forward implication necessarily extracts an infinite subseries and so depends on the Cauchy criterion. The value identity survives the drop from complete to merely Hausdorff. This sharpens the parent's 'completeness so each residue subseries converges' to 'completeness only for the forward direction'.",
+    "openQuestions": [
+      "Is completeness necessary (not just sufficient) for the forward direction? Exhibit an incomplete Hausdorff topological abelian group and a summable f whose even part is not summable, showing the equivalence cannot drop completeness."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves the **Newton–Girard recurrence for arbitrary k ≥ 1** as a single closed-form theorem, over any `CommRing` and any `Fintype` index:

$$p_k = \sum_{i=1}^{k-1} (-1)^{i+1}\, e_i\, p_{k-i} \;+\; (-1)^{k+1}\, k\, e_k.$$

This directly answers the **first open question** posed by the parent entry (`amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01`, "Newton-Girard for k=4 and k=5"):

> *Prove the general Newton-Girard recurrence for arbitrary k ... without case-by-case antidiagonal computation — the main challenge is expressing the general antidiagonal filter `{(a,b) | a+b=k, 0 < a < k}` as a Finset in a way that `ring` can close.*

The ancestor entries proved only the fixed degrees k=1,2,3 and k=4,5, each by hand-expanding the antidiagonal. A single theorem here subsumes them all.

## Approach

Mathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum` gives the recurrence in *filtered-antidiagonal* form. The work is to reindex that filter uniformly in k:

1. **filter = interval**: `(range (k+1)).filter (· ∈ Ioo 0 k) = Ico 1 k` by `ext` + `omega`.
2. **reindex**: `Finset.sum_filter` → indicator sum, `Finset.Nat.sum_antidiagonal_eq_sum_range_succ_mk` sends `a ↦ (i, k-i)`, then step 1 collapses to a clean `Ico 1 k` sum. The projections reduce definitionally → one `rw` chain.
3. **sign fold**: the outer minus is absorbed into `(-1)^(i+1)` via a termwise `T + U = 0` identity (`Finset.sum_eq_zero` + `pow_succ`), avoiding any brittle named negate-the-sum lemma; `linear_combination` finishes.

## Contents

- `psum_recurrence` — the general recurrence (arbitrary k ≥ 1).
- `mul_esymm_recurrence` — dual form isolating `(-1)^(k+1)·k·eₖ`.
- Two `example`s specialising to **k=4** and **k=5**, proving they match the parent's `psum_four_eq` / `psum_five_eq` **verbatim** (machine-checked subsumption).

## Verification

- 2 theorems + 2 subsumption examples, **0 sorries, 0 axioms**.
- No `native_decide` — the `decide` calls are kernel-level Finset facts on small literals, so the entry is genuinely axiom-free.
- Type-checks against Mathlib 4.26.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)