### PR TITLE
Enrich Catalan p-adic valuation (catalan-numbers-oq-01-oq-02-oq-01): add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-catalan-padic-context",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "concept",
+    "title": "From the 2-adic special case to an arbitrary prime",
+    "content": "The sibling entry computed the 2-adic valuation v₂(Cₙ) = s₂(n+1) − 1, relying on the doubling-invariance of the binary digit sum (s₂(2n) = s₂(n)). At an odd prime that collapse fails, and the genuine quantity 2·s_p(n) − s_p(2n) — exactly (p−1) times Kummer's carry count for n + n in base p — must be carried. This file removes the restriction using only two general-in-p ingredients: Legendre's formula (p−1)·v_p(m!) = m − s_p(m) and the factorisation (2n)! = C(2n,n)·(n!)², bridged to the Catalan numbers by (n+1)·Cₙ = C(2n,n).",
+    "mathContext": "Kummer: $v_p\\binom{2n}{n} = \\dfrac{2s_p(n) - s_p(2n)}{p-1}$ (carry count of $n+n$ base $p$). The Catalan denominator $n+1$ subtracts $v_p(n+1)$.",
+    "significance": "context",
+    "relatedConcepts": ["Kummer's theorem", "Legendre's formula", "p-adic valuation", "digit sum", "Catalan numbers"],
+    "prerequisites": ["p-adic valuation", "base-p digit representation", "binomial coefficients"]
+  },
+  {
+    "id": "ann-catalan-padic-nonzero",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+    "range": { "startLine": 44, "endLine": 49 },
+    "type": "technique",
+    "title": "Catalan numbers are nonzero",
+    "content": "catalan_ne_zero records that catalan n ≠ 0, proved from (n+1)·catalan n = centralBinom n: if catalan n were 0 the right side centralBinom n would vanish, contradicting Nat.centralBinom_pos. This nonvanishing is the side condition required to split the p-adic valuation across products via padicValNat.mul (the valuation is only additive on nonzero factors).",
+    "mathContext": "$C_n \\neq 0$ for all $n$; needed so that $v_p$ is additive across $(n+1)\\cdot C_n$ and across $(2n)! = \\binom{2n}{n}(n!)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["central binomial coefficient", "valuation additivity", "nonvanishing"],
+    "prerequisites": ["Catalan numbers", "positivity of binomial coefficients"]
+  },
+  {
+    "id": "ann-catalan-padic-centralbinom",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+    "range": { "startLine": 51, "endLine": 80 },
+    "type": "insight",
+    "title": "Central-binomial valuation from Legendre alone",
+    "content": "sub_one_mul_padicValNat_centralBinom proves (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n) for any prime. The engine is Legendre's formula applied to (2n)! and n!, giving the exact additive equations (p−1)·v_p((2n)!) + s_p(2n) = 2n and (p−1)·v_p(n!) + s_p(n) = n — exact because digit_sum_le certifies no truncated subtraction. The factorisation (2n)! = C(2n,n)·n!·n! splits v_p((2n)!) = v_p(C) + 2·v_p(n!); a single ring step distributes (p−1) over the split, and omega closes the identity. No Kummer digit-sum lemma is invoked.",
+    "mathContext": "$(p-1)v_p\\binom{2n}{n} + s_p(2n) = 2s_p(n)$, from $(p-1)v_p((2n)!) + s_p(2n) = 2n$, $(p-1)v_p(n!) + s_p(n) = n$, and $v_p((2n)!) = v_p\\binom{2n}{n} + 2v_p(n!)$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre's formula", "central binomial coefficient", "digit_sum_le", "omega tactic", "valuation splitting"],
+    "prerequisites": ["Legendre's formula", "factorial valuation", "natural-number subtraction"]
+  },
+  {
+    "id": "ann-catalan-padic-catalan",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+    "range": { "startLine": 82, "endLine": 97 },
+    "type": "concept",
+    "title": "The p-adic valuation of the Catalan numbers",
+    "content": "sub_one_mul_padicValNat_catalan upgrades the central-binomial identity to the Catalan numbers: (p−1)·(v_p(Cₙ) + v_p(n+1)) + s_p(2n) = 2·s_p(n). The bridge is (n+1)·catalan n = centralBinom n, across which valuation additivity gives v_p(C(2n,n)) = v_p(n+1) + v_p(catalan n). A ring step distributes (p−1) over this split and omega substitutes it into the central-binomial identity. Equivalently v_p(Cₙ) = (2·s_p(n) − s_p(2n))/(p−1) − v_p(n+1).",
+    "mathContext": "$(p-1)(v_p(C_n) + v_p(n+1)) + s_p(2n) = 2s_p(n)$, i.e. $v_p(C_n) = \\dfrac{2s_p(n)-s_p(2n)}{p-1} - v_p(n+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "succ_mul_catalan_eq_centralBinom", "p-adic valuation", "valuation additivity"],
+    "prerequisites": ["central binomial valuation", "Catalan–central binomial identity"]
+  },
+  {
+    "id": "ann-catalan-padic-criterion",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+    "range": { "startLine": 99, "endLine": 129 },
+    "type": "insight",
+    "title": "The p-divisibility criterion",
+    "content": "not_dvd_catalan_iff: p ∤ catalan n ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n). Forward, p ∤ Cₙ means v_p(Cₙ) = 0 (padicValNat_dvd_iff_le), and substituting into the valuation identity drops the v_p(Cₙ) term. Backward, the identity forces (p−1)·v_p(Cₙ) = 0, and since p ≥ 2 makes p−1 ≠ 0, Nat.mul_eq_zero gives v_p(Cₙ) = 0, i.e. p ∤ Cₙ. For p = 2 the right side becomes v₂(n+1) = s₂(n), recovering the sibling's law Cₙ odd ⟺ n+1 a power of two.",
+    "mathContext": "$p \\nmid C_n \\iff (p-1)v_p(n+1) + s_p(2n) = 2s_p(n)$. At $p=2$: $v_2(n+1) = s_2(n) \\iff n+1 = 2^k$.",
+    "significance": "key",
+    "relatedConcepts": ["divisibility criterion", "padicValNat_dvd_iff_le", "Nat.mul_eq_zero", "parity law", "powers of two"],
+    "prerequisites": ["valuation–divisibility correspondence", "case analysis on products being zero"]
+  },
+  {
+    "id": "ann-catalan-padic-example",
+    "proofId": "catalan-numbers-oq-01-oq-02-oq-01",
+    "range": { "startLine": 131, "endLine": 135 },
+    "type": "context",
+    "title": "Concrete witness at p = 3",
+    "content": "The example 3 ∤ catalan 2 (C₂ = 2) is discharged by kernel decide after rewriting catalan_two — no native_decide, so the proof stays axiom-free (no Lean.ofReduceBool). It matches the criterion's right side: (3−1)·v₃(3) + s₃(4) = 2·1 + 2 = 4 = 2·s₃(2) = 2·2, confirming 3 ∤ C₂.",
+    "mathContext": "$C_2 = 2$, $3\\nmid 2$. Criterion: $(3-1)v_3(3) + s_3(4) = 2\\cdot 1 + 2 = 4 = 2 s_3(2)$.",
+    "significance": "context",
+    "relatedConcepts": ["kernel decide", "axiom-free verification", "worked example"],
+    "prerequisites": ["base-3 digit sums"]
+  }
+]

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CatalanNumbersOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const catalanNumbersOQ01OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const catalanNumbersOQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const catalanNumbersOQ01OQ02OQ01Data: ProofData = {
+  proof: catalanNumbersOQ01OQ02OQ01Proof,
+  annotations: catalanNumbersOQ01OQ02OQ01Annotations,
+}

--- a/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-02-oq-01/meta.json
@@ -148,5 +148,49 @@
     "path": "Proofs/CatalanNumbersOQ01OQ02OQ01.lean",
     "sorries": 0
   },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: from p = 2 to an arbitrary prime",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Module docstring framing the generalisation of the sibling's 2-adic result to a general prime p, identifying the two general-in-p ingredients (Legendre's formula and (2n)! = C(2n,n)·(n!)²) and the Kummer carry-count interpretation of 2·s_p(n) − s_p(2n)."
+    },
+    {
+      "id": "setup-nonzero",
+      "title": "Setup: Catalan numbers are nonzero",
+      "startLine": 38,
+      "endLine": 49,
+      "summary": "Opens namespace CatalanPAdic; catalan_ne_zero proves catalan n ≠ 0 from (n+1)·catalan n = centralBinom n > 0 — the side condition for splitting the p-adic valuation across products."
+    },
+    {
+      "id": "central-binomial-valuation",
+      "title": "Central-binomial valuation at a general prime",
+      "startLine": 51,
+      "endLine": 80,
+      "summary": "sub_one_mul_padicValNat_centralBinom: (p−1)·v_p(C(2n,n)) + s_p(2n) = 2·s_p(n), proved from Legendre's formula on (2n)! and n! (made exact by digit_sum_le) plus the factorisation (2n)! = C(2n,n)·n!·n!; one ring step distributes (p−1) and omega closes it."
+    },
+    {
+      "id": "catalan-valuation",
+      "title": "The p-adic valuation of the Catalan numbers",
+      "startLine": 82,
+      "endLine": 97,
+      "summary": "sub_one_mul_padicValNat_catalan: (p−1)·(v_p(Cₙ) + v_p(n+1)) + s_p(2n) = 2·s_p(n), obtained by splitting v_p across (n+1)·catalan n = C(2n,n) and substituting into the central-binomial identity."
+    },
+    {
+      "id": "divisibility-criterion",
+      "title": "The p-divisibility criterion",
+      "startLine": 99,
+      "endLine": 129,
+      "summary": "not_dvd_catalan_iff: p ∤ catalan n ⟺ (p−1)·v_p(n+1) + s_p(2n) = 2·s_p(n), via padicValNat_dvd_iff_le and Nat.mul_eq_zero (using p ≥ 2). Generalises the sibling's parity law (p = 2 ⇒ v₂(n+1) = s₂(n) ⟺ n+1 a power of two)."
+    },
+    {
+      "id": "concrete-example",
+      "title": "Concrete example at p = 3",
+      "startLine": 131,
+      "endLine": 135,
+      "summary": "example : ¬ 3 ∣ catalan 2, discharged by kernel decide (no native_decide), matching the criterion's arithmetic (2·1 + s₃(4) = 4 = 2·s₃(2))."
+    }
+  ],
   "sorries": 0
 }


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-02-oq-01` (p-adic valuation of Catalan numbers at an arbitrary prime; quality 33, 0 prior passes).

## Changes
- **Added missing `index.ts`** — the entry had only `meta.json`, so it showed "proof not found" on the live site. Wired up via the standard Vite `?raw` import of `Proofs/CatalanNumbersOQ01OQ02OQ01.lean`.
- **Added `annotations.json`** — 6 annotations covering the full file: the p=2→general-p framing, `catalan_ne_zero`, the central-binomial valuation from Legendre, the Catalan valuation, the p-divisibility criterion, and the p=3 worked example. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **Added `sections`** array covering all six parts (the `overview`/`conclusion`/`crossReferences`/`references` were already rich).

## Notes
- Verified against the Lean source: 4 theorems / 0 defs, 0 sorries, 0 axioms, no `native_decide` (the lone example uses kernel `decide` on ¬ 3 ∣ 2). `status: verified`, `badge: mathlib`, `axiomCount: 0` accurate.
- All annotation start lines resolve to Lean constructs via `scripts/annotations/lean-parser.ts`; JSON validated.