### PR TITLE
research(catalan-numbers-oq-01-oq-03): large Schröder positivity + exponential growth [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ01OQ02.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ01OQ02OQ01OQ02.lean
@@ -1,0 +1,90 @@
+/-
+Proof: Infinite converse to Cayley — a free transitive `H ≤ Sym(α)` has `#H = #α`.
+Research: cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02
+
+Open question (from `cayleys-theorem-oq-01-oq-01-oq-02-oq-01`):
+  The parent proves the *finite* converse to Cayley: a subgroup
+  `H ≤ Sₙ = Equiv.Perm α` acting **freely** and **transitively** on a finite
+  nonempty `α` is regular of order `n = |α|`, via the orbit bijection
+  `regularEquiv : H ≃ α`.  Its order statement is phrased with `Nat.card`, which
+  collapses to the vacuous `0 = 0` when `α` is infinite.  Here we record the
+  genuine infinite generalisation.
+
+The same orbit map `σ ↦ σ a` is a bijection `H ≃ α` for **arbitrary** nonempty
+`α` — the parent's `regularEquiv` is built without any finiteness hypothesis.
+Transporting cardinality across it gives the honest converse over any `α`:
+
+* **Cardinal equality.**  `#H = #α` as `Cardinal`s, for arbitrary nonempty `α`.
+  This subsumes the parent's finite order count and is non-vacuous when `α` is
+  infinite (where `Nat.card` says nothing).
+* **Infinitude transfer.**  `H` is infinite iff `α` is; in particular a free
+  transitive subgroup of `Sym(α)` over an infinite `α` is itself infinite, of
+  exactly the same cardinality.
+* **Sharp transitivity** carries over unchanged from the parent (it was already
+  proved for arbitrary `α`), so the full package — `#H = #α` together with
+  unique-transitivity — holds verbatim in the infinite setting.
+
+Everything reduces to one explicit bijection: no new mathematics beyond the
+parent, only the correct cardinal invariant.  We reuse the parent's
+`ActsTransitively` / `ActsFreely` / `IsRegular` predicates and its
+`regularEquiv`, so no construction is duplicated.
+-/
+
+import Proofs.CayleysTheoremOQ01OQ01OQ02OQ01
+
+namespace CayleyConverse
+
+open Equiv
+
+variable {α : Type*} {H : Subgroup (Equiv.Perm α)}
+
+/-- **Infinite converse to Cayley.**  A free transitive subgroup `H ≤ Sym(α)`
+over an arbitrary nonempty `α` has the *same cardinality* as `α`: `#H = #α`.
+
+This is the genuine infinite generalisation of the parent's order count.  The
+parent states `Nat.card H = Nat.card α`, which is the vacuous `0 = 0` when `α`
+is infinite; the cardinal equality below is non-vacuous in that case and
+specialises back to the finite count.  The proof transports cardinality across
+the parent's orbit bijection `regularEquiv : H ≃ α`. -/
+theorem cardinalMk_eq_of_free_transitive [Nonempty α]
+    (htrans : ActsTransitively H) (hfree : ActsFreely H) :
+    Cardinal.mk H = Cardinal.mk α :=
+  Cardinal.mk_congr (regularEquiv htrans hfree (Classical.arbitrary α))
+
+/-- **Infinitude transfer.**  For a free transitive subgroup, `H` is infinite
+exactly when the underlying point set `α` is.  Immediate from the orbit
+bijection `H ≃ α`. -/
+theorem infinite_iff_of_free_transitive [Nonempty α]
+    (htrans : ActsTransitively H) (hfree : ActsFreely H) :
+    Infinite H ↔ Infinite α :=
+  Equiv.infinite_iff (regularEquiv htrans hfree (Classical.arbitrary α))
+
+/-- **An infinite regular subgroup is infinite.**  A free transitive subgroup of
+`Sym(α)` over an infinite `α` is itself infinite (and, by
+`cardinalMk_eq_of_free_transitive`, of the same cardinality as `α`). -/
+theorem infinite_of_free_transitive [Infinite α]
+    (htrans : ActsTransitively H) (hfree : ActsFreely H) :
+    Infinite H :=
+  haveI : Nonempty α := inferInstance
+  (infinite_iff_of_free_transitive htrans hfree).mpr ‹Infinite α›
+
+/-- **Infinite converse to Cayley, packaged.**  A regular (free transitive)
+subgroup of `Sym(α)` over an *arbitrary* nonempty `α` has `#H = #α` and is
+sharply transitive.  This is the parent's `regular_iff_card_and_sharp` with the
+finite order count replaced by the cardinal equality that survives in the
+infinite setting; the sharp-transitivity half is reused verbatim. -/
+theorem regular_iff_cardinalMk_and_sharp [Nonempty α] (hreg : IsRegular H) :
+    Cardinal.mk H = Cardinal.mk α ∧
+      ∀ i j : α, ∃! σ : H, (σ : Equiv.Perm α) i = j :=
+  ⟨cardinalMk_eq_of_free_transitive hreg.1 hreg.2,
+    fun i j => existsUnique_of_free_transitive hreg.1 hreg.2 i j⟩
+
+/-- **Consistency with the finite parent.**  For finite nonempty `α` the cardinal
+equality `#H = #α` refines to the parent's `Nat.card H = Fintype.card α`, so the
+infinite statement genuinely extends the finite one rather than replacing it. -/
+theorem natCard_eq_of_cardinalMk [Fintype α] [Nonempty α]
+    (htrans : ActsTransitively H) (hfree : ActsFreely H) :
+    Nat.card H = Fintype.card α :=
+  fintypeCard_eq_of_free_transitive htrans hfree
+
+end CayleyConverse

--- a/proofs/Proofs/SchroderLinearRecurrence.lean
+++ b/proofs/Proofs/SchroderLinearRecurrence.lean
@@ -1,0 +1,95 @@
+import Mathlib.Combinatorics.Enumerative.Schroder
+import Mathlib.Tactic
+
+/-!
+# Positivity and exponential growth of the large Schröder numbers
+
+Mathlib's `Mathlib/Combinatorics/Enumerative/Schroder.lean` defines the large Schröder numbers
+`Nat.largeSchroder` via the quadratic (convolution / Segner-type) recurrence
+
+  `L (n+1) = L n + ∑ i ≤ n, L i * L (n - i)`        (`Nat.largeSchroder_succ`)
+
+and records only that they are *even* for `n ≠ 0` (`Nat.even_largeSchroder`).  It does not record
+two basic quantitative facts:
+
+* that the numbers are **positive**, and
+* the **growth rate**: the ratio `L (n+1) / L n` is at least `3` (in fact it tends to the
+  characteristic number `3 + 2√2 ≈ 5.83`, the larger root of `x² - 6x + 1`).
+
+This entry supplies both, working entirely with natural-number arithmetic and only the
+convolution recurrence as input.
+
+## Main results
+
+* `Nat.largeSchroder_pos` : `0 < largeSchroder n`.
+* `Nat.two_mul_largeSchroder_le_conv` : the convolution sum dominates `2 · L (n+1)` (the two
+  boundary terms `i = 0` and `i = n+1` already contribute `2 · L (n+1)`).
+* `Nat.largeSchroder_ge_three_mul` : `3 · L (n+1) ≤ L (n+2)` — each step grows by a factor `≥ 3`.
+* `Nat.largeSchroder_ge_two_mul_three_pow` : the closed exponential lower bound
+  `2 · 3 ^ n ≤ L (n+1)`, hence `L` grows at least geometrically with ratio `3`.
+
+## The deeper open question
+
+The *order-two holonomic* (P-recursive) linear recurrence
+
+  `(n + 3) · L (n+2) + n · L n = 3 · (2n + 3) · L (n+1)`,
+
+which computes `L (n+2)` from the **two** previous values in `O(1)` operations (the
+large-Schröder analogue of the Catalan first-order recurrence in `catalan-numbers-oq-01`), is
+stated and discussed in the companion file `SchroderLinearRecurrenceAristotle.lean`.  Its proof
+requires generating-function / creative-telescoping machinery (the GF `f = ∑ L n xⁿ` satisfies
+`x f² + (x-1) f + 1 = 0`, giving the linear ODE `x(x²-6x+1) f' = (3x-1) f + (x+1)`); it is left
+for automated proof search.
+-/
+
+namespace Nat
+
+open Finset
+
+/-- **Positivity of the large Schröder numbers.**  Mathlib records that `largeSchroder n` is
+even for `n ≠ 0` (`Nat.even_largeSchroder`) but not that it is positive. -/
+theorem largeSchroder_pos : ∀ n, 0 < largeSchroder n
+  | 0 => by simp
+  | n + 1 => by
+      rw [largeSchroder_succ]
+      have : 0 < largeSchroder n := largeSchroder_pos n
+      positivity
+
+/-- The convolution sum appearing in the quadratic recurrence is at least `2 * largeSchroder (n+1)`:
+the two boundary terms `i = 0` and `i = n+1` already contribute
+`L 0 * L (n+1) + L (n+1) * L 0 = 2 * L (n+1)`. -/
+theorem two_mul_largeSchroder_le_conv (n : ℕ) :
+    2 * largeSchroder (n + 1) ≤ ∑ i ≤ n + 1, largeSchroder i * largeSchroder (n + 1 - i) := by
+  have hsub : ({0, n + 1} : Finset ℕ) ⊆ Iic (n + 1) := by
+    intro x hx; simp only [mem_insert, mem_singleton] at hx
+    simp only [mem_Iic]; omega
+  have hpair : ∑ i ∈ ({0, n + 1} : Finset ℕ), largeSchroder i * largeSchroder (n + 1 - i)
+      = 2 * largeSchroder (n + 1) := by
+    rw [Finset.sum_pair (by omega)]
+    simp [largeSchroder_zero]
+    ring
+  calc 2 * largeSchroder (n + 1)
+      = ∑ i ∈ ({0, n + 1} : Finset ℕ), largeSchroder i * largeSchroder (n + 1 - i) := hpair.symm
+    _ ≤ ∑ i ≤ n + 1, largeSchroder i * largeSchroder (n + 1 - i) :=
+        Finset.sum_le_sum_of_subset hsub
+
+/-- **Growth lower bound:** `3 * L (n+1) ≤ L (n+2)`.  Each Schröder step grows by a factor of at
+least `3`. -/
+theorem largeSchroder_ge_three_mul (n : ℕ) :
+    3 * largeSchroder (n + 1) ≤ largeSchroder (n + 2) := by
+  rw [largeSchroder_succ (n + 1)]
+  have h := two_mul_largeSchroder_le_conv n
+  omega
+
+/-- **Exponential lower bound:** `2 * 3 ^ n ≤ L (n+1)`.  The large Schröder numbers grow at least
+geometrically with ratio `3` (the true ratio tends to `3 + 2√2 ≈ 5.83`). -/
+theorem largeSchroder_ge_two_mul_three_pow : ∀ n, 2 * 3 ^ n ≤ largeSchroder (n + 1)
+  | 0 => by norm_num [largeSchroder]
+  | n + 1 => by
+      calc 2 * 3 ^ (n + 1)
+          = 3 * (2 * 3 ^ n) := by ring
+        _ ≤ 3 * largeSchroder (n + 1) := by
+            have := largeSchroder_ge_two_mul_three_pow n; omega
+        _ ≤ largeSchroder (n + 2) := largeSchroder_ge_three_mul n
+
+end Nat

--- a/proofs/Proofs/SchroderLinearRecurrenceAristotle.lean
+++ b/proofs/Proofs/SchroderLinearRecurrenceAristotle.lean
@@ -1,0 +1,52 @@
+import Mathlib.Combinatorics.Enumerative.Schroder
+import Mathlib.Tactic
+
+/-
+# Companion file: the order-two holonomic recurrence for large Schröder numbers
+
+This file isolates the HARD (but classical) result for automated proof search.
+
+The large Schröder numbers `L = Nat.largeSchroder` satisfy the order-two holonomic
+(P-recursive) linear recurrence
+
+  `(n + 3) * L (n+2) + n * L n = 3 * (2n + 3) * L (n+1)`,
+
+equivalently `(n+1) * L n = 3 * (2n-1) * L (n-1) - (n-2) * L (n-2)` for `n ≥ 2`.
+Values: L 0 = 1, L 1 = 2, L 2 = 6, L 3 = 22, L 4 = 90, L 5 = 394.
+
+## Proof sketch (generating functions)
+
+Let `f = ∑ L n xⁿ`.  The convolution recurrence `Nat.largeSchroder_succ` translates to the
+algebraic equation `x * f^2 + (x - 1) * f + 1 = 0`.  Differentiating and eliminating `f^2`
+and `f * f'` gives the linear ODE `x * (x^2 - 6x + 1) * f' = (3x - 1) * f + (x + 1)`, whose
+`xⁿ`-coefficient is exactly the stated recurrence.
+
+## Equivalent convolution form (a useful intermediate)
+
+Writing `Q n = ∑ i ≤ n, L i * L (n - i)` for the convolution (so `L (n+1) = L n + Q n`), the
+recurrence is equivalent to
+
+  `(n + 3) * Q (n+1) = (5n + 6) * Q n + (4n + 6) * L n`.
+
+Both statements below are over `ℕ` with no subtraction.
+-/
+
+namespace Nat
+
+open Finset
+
+/-- Convolution-form reformulation of the holonomic recurrence (see module docstring). -/
+theorem largeSchroder_conv_holonomic (n : ℕ) :
+    (n + 3) * (∑ i ≤ n + 1, largeSchroder i * largeSchroder (n + 1 - i))
+      = (5 * n + 6) * (∑ i ≤ n, largeSchroder i * largeSchroder (n - i))
+        + (4 * n + 6) * largeSchroder n := by
+  sorry
+
+/-- **Order-two holonomic recurrence for the large Schröder numbers.**
+`(n + 3) * L (n+2) + n * L n = 3 * (2n + 3) * L (n+1)`. -/
+theorem largeSchroder_holonomic (n : ℕ) :
+    (n + 3) * largeSchroder (n + 2) + n * largeSchroder n
+      = 3 * (2 * n + 3) * largeSchroder (n + 1) := by
+  sorry
+
+end Nat

--- a/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "catalan-numbers-oq-01-oq-03",
+  "title": "Large Schröder Numbers: Positivity and Exponential Growth",
+  "slug": "catalan-numbers-oq-01-oq-03",
+  "description": "Quantitative basics for Mathlib's large Schröder numbers Nat.largeSchroder, which Mathlib (Combinatorics/Enumerative/Schroder.lean) defines only via the quadratic convolution recurrence L(n+1) = L n + ∑ i ≤ n, L i · L(n−i) and for which it records only evenness (Nat.even_largeSchroder). This entry adds positivity (0 < L n), a convolution lower bound (the i=0 and i=n+1 boundary terms already give 2·L(n+1)), the step growth 3·L(n+1) ≤ L(n+2), and the closed exponential lower bound 2·3ⁿ ≤ L(n+1), so the sequence grows at least geometrically with ratio 3 (the true ratio tends to 3+2√2 ≈ 5.83). All four results are fully verified over ℕ with 0 axioms, 0 sorries, no decide/native_decide, using only the convolution recurrence. This answers the boundary-rate portion of the catalan-numbers-oq-01 open question on holonomic combinatorial sequences (Catalan/Delannoy/Motzkin/Schröder). The deeper order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) is stated, with a full generating-function proof sketch, in the companion file SchroderLinearRecurrenceAristotle.lean and is left for automated proof search.",
+  "meta": {
+    "author": "Classical (Schröder / Hipparchus); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://oeis.org/A006318",
+    "date": "classical",
+    "status": "verified",
+    "tags": [
+      "combinatorics",
+      "schroder-numbers",
+      "enumerative-combinatorics",
+      "growth-bound",
+      "recurrence",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/SchroderLinearRecurrence.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.largeSchroder",
+        "description": "The large Schröder numbers, defined in Mathlib by the quadratic convolution recurrence L 0 = 1, L (n+1) = L n + ∑ i ≤ n, L i · L (n−i). This is the sole input to every result here.",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Nat.largeSchroder_succ",
+        "description": "The convolution (Segner-type) recurrence largeSchroder (n+1) = largeSchroder n + ∑ i ≤ n, largeSchroder i * largeSchroder (n−i), unfolded to drive positivity and the growth bounds.",
+        "module": "Mathlib.Combinatorics.Enumerative.Schroder"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset",
+        "description": "Monotonicity of a sum of naturals under enlarging the index set: used to bound the full convolution sum below by its two boundary terms over {0, n+1}.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_pair",
+        "description": "∑ over a two-element set {a,b} (a ≠ b) is f a + f b: evaluates the boundary contribution L 0 · L(n+1) + L(n+1) · L 0 = 2·L(n+1).",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "Nat.largeSchroder_pos: 0 < largeSchroder n — positivity, which Mathlib does not record (it states only Nat.even_largeSchroder for n ≠ 0)",
+      "Nat.two_mul_largeSchroder_le_conv: 2·L(n+1) ≤ ∑ i ≤ n+1, L i · L(n+1−i) — the convolution sum dominates twice the previous term via its two boundary summands",
+      "Nat.largeSchroder_ge_three_mul: 3·L(n+1) ≤ L(n+2) — each Schröder step grows by a factor of at least 3",
+      "Nat.largeSchroder_ge_two_mul_three_pow: 2·3ⁿ ≤ L(n+1) — the closed exponential lower bound, exhibiting geometric growth with ratio 3"
+    ],
+    "additionalFiles": [
+      {
+        "path": "Proofs/SchroderLinearRecurrenceAristotle.lean",
+        "description": "Companion file (NOT part of the verified entry) stating the open order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) and its convolution reformulation, each as a `sorry`, for automated proof search. Contains 2 sorries; a full generating-function proof sketch is given in its docstring."
+      }
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 95,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None for the four stated results. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, which do not count). No decide/native_decide is used. The deeper order-two holonomic recurrence is NOT proved here; it lives as a `sorry` in the companion file SchroderLinearRecurrenceAristotle.lean and is excluded from this entry's verified status.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The (large) Schröder numbers 1, 2, 6, 22, 90, 394, … (OEIS A006318) count, among many things, the lattice paths from (0,0) to (n,n) using steps →, ↑, ↗ that never rise above the diagonal, and the dissections of a convex polygon. They are the Schröder–Hipparchus relatives of the Catalan numbers: where the Catalan generating function satisfies x·C² − C + 1 = 0, the large Schröder generating function satisfies x·f² + (x−1)·f + 1 = 0, whose discriminant x²−6x+1 has roots 3 ± 2√2 — the asymptotic growth ratio of the sequence.",
+    "problemStatement": "**Open Question (catalan-numbers-oq-01, follow-up)**: catalan-numbers-oq-01 proved the first-order linear recurrence for the Catalan numbers and asked for the analogous holonomic structure of related combinatorial sequences (Delannoy, Motzkin, Schröder). Mathlib's large Schröder numbers come only with the quadratic convolution recurrence and an evenness lemma; even their positivity and growth rate are unrecorded.\n\n**Result**: positivity, a convolution lower bound, the step growth 3·L(n+1) ≤ L(n+2), and the closed exponential lower bound 2·3ⁿ ≤ L(n+1) — all fully verified. The order-two holonomic recurrence itself is set up (with proof sketch) for automated proof search in a companion file.",
+    "text": "For every natural number n the large Schröder number L n = Nat.largeSchroder n is positive, and the sequence grows at least geometrically: 3·L(n+1) ≤ L(n+2), hence 2·3ⁿ ≤ L(n+1). The growth factor 3 is the integer floor of the true asymptotic ratio 3 + 2√2 ≈ 5.83.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Positivity** (largeSchroder_pos): structural induction. L 0 = 1 > 0; for the successor, unfold largeSchroder_succ to L n + (convolution sum) and apply positivity to the L n summand (positivity tactic), the sum being a sum of naturals.\n\n2. **Convolution lower bound** (two_mul_largeSchroder_le_conv): the index set {0, n+1} ⊆ Iic (n+1); on it the summand is L 0 · L(n+1) + L(n+1) · L 0 = 2·L(n+1) (Finset.sum_pair, largeSchroder_zero), and the full sum dominates the partial one (Finset.sum_le_sum_of_subset).\n\n3. **Step growth** (largeSchroder_ge_three_mul): unfold largeSchroder_succ at n+1, so L(n+2) = L(n+1) + ∑ i ≤ n+1, …; combine with step 2 (the sum is ≥ 2·L(n+1)) via omega to get L(n+2) ≥ 3·L(n+1).\n\n4. **Exponential bound** (largeSchroder_ge_two_mul_three_pow): induction. Base 2·3⁰ = 2 = L 1; step 2·3^(n+1) = 3·(2·3ⁿ) ≤ 3·L(n+1) ≤ L(n+2) using the induction hypothesis and step 3.",
+    "keyInsights": [
+      "**Positivity is a genuine gap.** Mathlib records evenness of the large Schröder numbers (Nat.even_largeSchroder) but not positivity; positivity is what licenses cancelling Schröder factors and is the base for every quantitative estimate.",
+      "**Two boundary terms already force factor-3 growth.** The convolution sum ∑ i ≤ n+1, L i · L(n+1−i) contains the summands at i = 0 and i = n+1, each equal to L(n+1); together with the leading +L(n+1) in the convolution recurrence this gives L(n+2) ≥ 3·L(n+1) with no analysis of the interior terms.",
+      "**The factor 3 is sharp as an integer ratio but loose asymptotically.** The true ratio L(n+1)/L n increases to 3 + 2√2 ≈ 5.83 (the dominant root of x² − 6x + 1, the discriminant of the Schröder generating-function equation); 3 is the best constant available from the two boundary terms alone.",
+      "**The deeper holonomic recurrence needs generating functions.** The order-two recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) follows from the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1) satisfied by f = ∑ L n xⁿ; unlike the Catalan first-order recurrence (inherited from central binomials), it has no elementary central-coefficient bridge in Mathlib, so it is deferred to automated proof search."
+    ],
+    "prerequisites": [
+      "The (large) Schröder numbers and their definition via the quadratic convolution recurrence",
+      "Monotonicity of finite sums of naturals under enlarging the index set",
+      "Induction over ℕ and the positivity tactic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "Module docstring describing the Mathlib gap (only the convolution recurrence and evenness are recorded), the four results supplied here, and the deeper holonomic recurrence deferred to the companion file; imports of Mathlib's Schröder file and Tactic.",
+      "mathContext": "$L(n+1) = L(n) + \\sum_{i\\le n} L(i)\\,L(n-i)$; growth ratio $\\to 3 + 2\\sqrt2$."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity",
+      "startLine": 50,
+      "endLine": 59,
+      "summary": "largeSchroder_pos: 0 < largeSchroder n by structural induction, unfolding the convolution recurrence and using positivity of the leading term.",
+      "mathContext": "$0 < L(n)$."
+    },
+    {
+      "id": "convolution-bound",
+      "title": "Convolution Lower Bound",
+      "startLine": 60,
+      "endLine": 77,
+      "summary": "two_mul_largeSchroder_le_conv: the convolution sum is at least 2·L(n+1) via the two boundary terms over {0, n+1} (Finset.sum_pair, Finset.sum_le_sum_of_subset).",
+      "mathContext": "$2L(n+1) \\le \\sum_{i\\le n+1} L(i)\\,L(n+1-i)$."
+    },
+    {
+      "id": "growth",
+      "title": "Step Growth and Exponential Lower Bound",
+      "startLine": 78,
+      "endLine": 95,
+      "summary": "largeSchroder_ge_three_mul: 3·L(n+1) ≤ L(n+2) from the convolution recurrence and the boundary bound; largeSchroder_ge_two_mul_three_pow: 2·3ⁿ ≤ L(n+1) by induction on the step growth.",
+      "mathContext": "$3L(n+1)\\le L(n+2)$, hence $2\\cdot 3^n \\le L(n+1)$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "catalan-numbers-oq-01",
+      "relationship": "Parent open question: proved the first-order linear recurrence for the Catalan numbers and asked for the analogous holonomic structure of Delannoy/Motzkin/Schröder numbers; this entry addresses the Schröder growth rate and sets up the Schröder order-two recurrence."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) quantitative basics for Mathlib's large Schröder numbers: positivity 0 < L n, a convolution lower bound, the step growth 3·L(n+1) ≤ L(n+2), and the closed exponential lower bound 2·3ⁿ ≤ L(n+1).",
+    "implications": "Supplies the positivity and geometric-growth facts that Mathlib's Schröder development lacks, enabling cancellation arguments and asymptotic estimates. It frames the Schröder analogue of the Catalan first-order recurrence: the order-two holonomic recurrence is stated with a full generating-function proof sketch in the companion file for automated proof search.",
+    "openQuestions": [
+      "Prove the order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) — equivalently extract the xⁿ-coefficient of the ODE x(x²−6x+1) f' = (3x−1) f + (x+1) for the generating function f = ∑ L n xⁿ — completing the Schröder analogue of catalan-numbers-oq-01.",
+      "Upgrade the growth bound to the sharp ratio: prove L(n+1)/L n → 3 + 2√2 over ℝ, the dominant root of x² − 6x + 1."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Combinatorics.Enumerative.Schroder",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "Nat",
+    "lineCount": 95,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/SchroderLinearRecurrence.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume 2",
+      "year": "1999",
+      "venue": "Cambridge University Press",
+      "note": "Schröder numbers, their generating function x f² + (x−1) f + 1 = 0, and the holonomic recurrence"
+    },
+    {
+      "authors": "OEIS Foundation",
+      "title": "A006318: Large Schröder numbers",
+      "year": "2024",
+      "venue": "The On-Line Encyclopedia of Integer Sequences",
+      "note": "Values, generating function, and the order-two recurrence (n+1)a(n) = 3(2n−1)a(n−1) − (n−2)a(n−2)"
+    },
+    {
+      "authors": "leanprover-community",
+      "title": "Mathlib.Combinatorics.Enumerative.Schroder",
+      "year": "2025",
+      "venue": "Mathlib4",
+      "note": "Source of Nat.largeSchroder, the convolution recurrence largeSchroder_succ, and Nat.even_largeSchroder"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02/meta.json
@@ -1,0 +1,161 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+  "title": "Infinite converse to Cayley: a free transitive H ≤ Sym(α) has #H = #α",
+  "slug": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+  "description": "The parent entry (cayleys-theorem-oq-01-oq-01-oq-02-oq-01) proves the finite converse to Cayley: a subgroup H ≤ Sₙ = Equiv.Perm α acting freely and transitively on a finite nonempty α is regular of order n = |α|, via the orbit bijection regularEquiv : H ≃ α. Its order statement is phrased with Nat.card, which collapses to the vacuous 0 = 0 when α is infinite. This entry answers the parent's second open question by recording the genuine infinite generalisation. The same orbit map σ ↦ σ a is a bijection H ≃ α for ARBITRARY nonempty α — the parent's regularEquiv is built with no finiteness hypothesis — so transporting cardinality across it gives the honest converse over any α: (1) Cardinal equality #H = #α (Cardinal.mk H = Cardinal.mk α), non-vacuous precisely when α is infinite and specialising back to the finite count; (2) Infinitude transfer, H is infinite iff α is, so a free transitive subgroup of Sym(α) over an infinite α is itself infinite of the same cardinality; (3) Sharp transitivity carries over verbatim from the parent (already proved for arbitrary α). The packaged statement regular_iff_cardinalMk_and_sharp records cardinal equality plus unique transitivity, and natCard_eq_of_cardinalMk confirms consistency with the finite parent. Everything reduces to the parent's one explicit bijection — no new mathematics, only the correct cardinal invariant for the infinite regime.",
+  "meta": {
+    "author": "Arthur Cayley (1854); infinite converse formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Regular_representation",
+    "date": "1854",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "permutation-group",
+      "regular-representation",
+      "sharply-transitive",
+      "free-action",
+      "transitive-action",
+      "group-action",
+      "symmetric-group",
+      "cardinality",
+      "infinite-group",
+      "cardinal-arithmetic",
+      "converse",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Cardinal.mk_congr",
+        "description": "an equivalence of types preserves the cardinal Cardinal.mk — transports the parent's regular equivalence H ≃ α to the cardinal equality #H = #α, the engine of the infinite converse",
+        "module": "Mathlib.SetTheory.Cardinal.Defs"
+      },
+      {
+        "theorem": "Equiv.infinite_iff",
+        "description": "an equivalence α ≃ β yields Infinite α ↔ Infinite β — transfers infinitude across the orbit bijection so that H is infinite exactly when α is",
+        "module": "Mathlib.Data.Finite.Defs"
+      }
+    ],
+    "originalContributions": [
+      "cardinalMk_eq_of_free_transitive: the infinite converse to Cayley — Cardinal.mk H = Cardinal.mk α for a free transitive subgroup over arbitrary nonempty α, the non-vacuous generalisation of the parent's Nat.card order count",
+      "infinite_iff_of_free_transitive: infinitude transfer — H is infinite iff the underlying point set α is, via the orbit bijection",
+      "infinite_of_free_transitive: a free transitive subgroup of Sym(α) over an infinite α is itself infinite (and of the same cardinality)",
+      "regular_iff_cardinalMk_and_sharp: the packaged infinite converse — cardinal equality #H = #α together with sharp transitivity, valid over arbitrary nonempty α",
+      "natCard_eq_of_cardinalMk: consistency with the finite parent — the cardinal equality refines to Nat.card H = Fintype.card α for finite α, so the infinite statement extends rather than replaces the finite one"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 90,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound, the latter via Classical.arbitrary to pick a basepoint). No decide/native_decide is used. α is assumed nonempty (required: an empty α would give #H = 1 ≠ 0 = #α). The cardinal equality holds for arbitrary α, finite or infinite; the infinitude statements require α infinite as stated.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem (1854) realises an abstract group inside a symmetric group as the left-regular representation, whose image is a regular (simply transitive) permutation group: it acts transitively (one orbit) and freely (only the identity fixes a point). The parent entry proves the finite converse — a free transitive subgroup of Sₙ has order n and is sharply transitive — using the orbit map σ ↦ σ a as an explicit bijection H ≃ α. That argument never invokes finiteness; only the order statement, phrased with Nat.card, becomes vacuous for infinite α (where Nat.card returns 0). For infinite permutation groups the correct invariant is the cardinal #H, and the regular representation of an infinite group G acts freely and transitively on the set G with |G| elements. This entry records the honest infinite statement: a free transitive subgroup of Sym(α) has cardinality exactly #α, the abstract characterisation of regular permutation groups in the infinite setting.",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01-oq-01-oq-02-oq-01, second follow-up)**: Drop finiteness — for an infinite set α, a free transitive subgroup H ≤ Sym(α) is in bijection with α via the same orbit map (the parent's argument never used finiteness except to read |H| = n); record the cardinal equality #H = #α.\n\n**Result**: For any subgroup H ≤ Equiv.Perm α over an arbitrary nonempty type α, ActsTransitively H ∧ ActsFreely H implies Cardinal.mk H = Cardinal.mk α (cardinalMk_eq_of_free_transitive) and ∀ i j, ∃! σ ∈ H with σ i = j (reused from the parent), assembled in regular_iff_cardinalMk_and_sharp. Infinitude transfers: Infinite H ↔ Infinite α.",
+    "text": "Let α be an arbitrary nonempty type and H ≤ Equiv.Perm α a subgroup that is transitive (∀ i j, ∃ σ ∈ H with σ i = j) and free (any σ ∈ H fixing a single point is the identity). The parent's orbit map σ ↦ σ a is a bijection H ≃ α at any basepoint a — surjective by transitivity, injective by the freeness rigidity lemma — with no use of finiteness. Transporting cardinality along this equivalence with Cardinal.mk_congr gives #H = #α. When α is finite this recovers the parent's Nat.card H = Fintype.card α; when α is infinite it is the genuine content the Nat.card count cannot express. Infinitude transfers across the same equivalence via Equiv.infinite_iff, so H is infinite exactly when α is.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Reuse the parent's regularEquiv : H ≃ α — the orbit map σ ↦ σ a packaged as an equivalence via Equiv.ofBijective, built from rigidity (freeness pins an element down by one value) and transitivity (surjectivity), with no finiteness hypothesis.\n2. Cardinal equality (cardinalMk_eq_of_free_transitive). Apply Cardinal.mk_congr to regularEquiv at basepoint Classical.arbitrary α to get Cardinal.mk H = Cardinal.mk α. This is non-vacuous for infinite α, where the parent's Nat.card statement reads 0 = 0.\n3. Infinitude transfer (infinite_iff_of_free_transitive, infinite_of_free_transitive). Apply Equiv.infinite_iff to the same equivalence: Infinite H ↔ Infinite α, hence H is infinite whenever α is.\n4. Packaging (regular_iff_cardinalMk_and_sharp). IsRegular H = ActsTransitively H ∧ ActsFreely H yields the cardinal equality together with the parent's existsUnique_of_free_transitive (sharp transitivity, already proved for arbitrary α).\n5. Consistency (natCard_eq_of_cardinalMk). For finite α the result refines to the parent's Nat.card H = Fintype.card α, confirming the infinite statement extends the finite one.",
+    "keyInsights": [
+      "**Nat.card hides the infinite content.** The parent's order statement Nat.card H = Nat.card α is the vacuous 0 = 0 for infinite α, because Nat.card returns 0 on infinite types. The cardinal equality #H = #α is the same fact stated with the invariant that survives — and it specialises back to the finite count.",
+      "**The bijection was always finiteness-free.** The parent's regularEquiv : H ≃ α uses only rigidity (freeness) and transitivity, never that α is finite. So the entire infinite converse is just the correct cardinal transport of an equivalence the parent already built — no new construction.",
+      "**Regularity forces cardinality, even infinitely.** A free transitive subgroup of Sym(α) has exactly #α elements: order equals degree as cardinals. This is why the regular action of an infinite group G on its underlying set is the universal transitive G-set.",
+      "**Infinitude is an invariant of regularity.** H and α are infinite together; a free transitive permutation group on an infinite set is necessarily an infinite group of the same cardinality."
+    ],
+    "prerequisites": [
+      "The parent entry's orbit bijection regularEquiv : H ≃ α and its predicates ActsTransitively, ActsFreely, IsRegular (cayleys-theorem-oq-01-oq-01-oq-02-oq-01)",
+      "Cardinals and Cardinal.mk: Cardinal.mk_congr transporting #· along an equivalence; the fact that Nat.card vanishes on infinite types while Cardinal.mk does not",
+      "Infinitude transfer along equivalences: Equiv.infinite_iff (Infinite α ↔ Infinite β from α ≃ β)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring explaining that the parent's Nat.card order count is vacuous for infinite α and that the genuine generalisation is the cardinal equality #H = #α, obtained by transporting the parent's finiteness-free orbit bijection regularEquiv. Imports the parent file (Proofs.CayleysTheoremOQ01OQ01OQ02OQ01) and reopens the CayleyConverse namespace; reuses ActsTransitively, ActsFreely, IsRegular and regularEquiv.",
+      "mathContext": "Parent gives $H \\simeq \\alpha$ with no finiteness; restate $|H| = |\\alpha|$ as cardinals."
+    },
+    {
+      "id": "cardinal-equality",
+      "title": "Cardinal Equality #H = #α",
+      "startLine": 41,
+      "endLine": 53,
+      "summary": "cardinalMk_eq_of_free_transitive: for arbitrary nonempty α, a free transitive subgroup has Cardinal.mk H = Cardinal.mk α, via Cardinal.mk_congr applied to regularEquiv at basepoint Classical.arbitrary α. The non-vacuous infinite converse to Cayley.",
+      "mathContext": "$\\#H = \\#\\alpha$ — order equals degree as cardinals, for any $\\alpha$."
+    },
+    {
+      "id": "infinitude",
+      "title": "Infinitude Transfer",
+      "startLine": 54,
+      "endLine": 70,
+      "summary": "infinite_iff_of_free_transitive: Infinite H ↔ Infinite α via Equiv.infinite_iff on regularEquiv. infinite_of_free_transitive: for infinite α a free transitive subgroup H is itself infinite (and of the same cardinality).",
+      "mathContext": "$\\mathrm{Infinite}\\,H \\iff \\mathrm{Infinite}\\,\\alpha$."
+    },
+    {
+      "id": "conclusion",
+      "title": "Packaged Converse and Consistency",
+      "startLine": 71,
+      "endLine": 90,
+      "summary": "regular_iff_cardinalMk_and_sharp: from IsRegular H over arbitrary nonempty α, both #H = #α and sharp transitivity (parent's existsUnique_of_free_transitive). natCard_eq_of_cardinalMk: for finite α the result refines to the parent's Nat.card H = Fintype.card α, confirming the infinite statement extends the finite one.",
+      "mathContext": "Regular $H \\Rightarrow \\#H = \\#\\alpha \\wedge$ sharply transitive; refines to $|H| = n$ when finite."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: the finite converse to Cayley (a free transitive subgroup of Sₙ has order n and is sharply transitive), built on the orbit bijection regularEquiv : H ≃ α. This entry answers its second open question by dropping finiteness — the same bijection gives the cardinal equality #H = #α for arbitrary α, with the parent's sharp transitivity reused verbatim."
+    },
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01-oq-02",
+      "relationship": "builds-on",
+      "description": "Grandparent entry: the finite Cayley embedding and its regular range. The infinite converse here abstractly characterises regular subgroups of Sym(α) in the infinite setting, complementing the grandparent's construction."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of the infinite converse to Cayley: a subgroup H ≤ Sym(α) = Equiv.Perm α over an arbitrary nonempty type α that acts freely and transitively has Cardinal.mk H = Cardinal.mk α (cardinalMk_eq_of_free_transitive), is infinite exactly when α is (infinite_iff_of_free_transitive), and is sharply transitive — assembled in regular_iff_cardinalMk_and_sharp. The proof transports the parent's finiteness-free orbit bijection regularEquiv : H ≃ α across Cardinal.mk_congr and Equiv.infinite_iff; natCard_eq_of_cardinalMk confirms it refines to the parent's finite count.",
+    "implications": "Gives the honest order statement of the converse to Cayley in the infinite regime, where the parent's Nat.card count is the vacuous 0 = 0. A regular permutation group has cardinality exactly equal to the set it acts on, finite or infinite — the structural reason the regular action of any group is the universal transitive action. No new mathematics beyond the parent: only the correct cardinal invariant applied to an equivalence the parent already established.",
+    "openQuestions": [
+      "Make the regular representation explicit in the infinite setting: for a free transitive H ≤ Sym(α), construct a group isomorphism between H and the abstract group whose left-regular action on its own underlying set (of cardinality #α) recovers H, completing the structural classification beyond cardinality.",
+      "Compare #H with the ambient #Sym(α) = 2^#α: record that a regular subgroup is a proper subgroup of strictly smaller cardinality whenever α is infinite, quantifying how far the regular representation sits below the full symmetric group."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CayleysTheoremOQ01OQ01OQ02OQ01"
+    ],
+    "opens": [
+      "Equiv"
+    ],
+    "namespace": "CayleyConverse",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/CayleysTheoremOQ01OQ01OQ02OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement of the regular representation; the converse characterises its image"
+    },
+    {
+      "authors": "Dixon, John D.; Mortimer, Brian",
+      "title": "Permutation Groups",
+      "year": "1996",
+      "venue": "Springer GTM 163",
+      "note": "Regular permutation groups and simple transitivity, including the infinite case"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/catalan-numbers-oq-01-oq-03.json
+++ b/src/data/research/problems/catalan-numbers-oq-01-oq-03.json
@@ -1,0 +1,49 @@
+{
+  "slug": "catalan-numbers-oq-01-oq-03",
+  "title": "Large Schröder Numbers: Positivity, Growth, and the Order-Two Holonomic Recurrence",
+  "status": "in-progress",
+  "phase": "ACT",
+  "tier": "B",
+  "started": "2026-06-23",
+  "lastUpdate": "2026-06-23",
+  "path": "src/data/proofs/catalan-numbers-oq-01-oq-03",
+  "tags": ["combinatorics", "schroder-numbers", "recurrence", "holonomic", "growth-bound"],
+  "problemStatement": "Develop the large Schröder numbers Nat.largeSchroder (Mathlib provides only the quadratic convolution recurrence and evenness): prove positivity, growth bounds, and the order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1), the Schröder analogue of the Catalan first-order recurrence in catalan-numbers-oq-01.",
+  "currentState": "Positivity, convolution lower bound, step growth 3·L(n+1) ≤ L(n+2), and exponential bound 2·3ⁿ ≤ L(n+1) are proved and verified (0 axioms, 0 sorries) in Proofs/SchroderLinearRecurrence.lean. The order-two holonomic recurrence remains a sorry in the companion Proofs/SchroderLinearRecurrenceAristotle.lean, awaiting automated proof search (Aristotle service was unavailable this session).",
+  "knowledge": {
+    "progressSummary": "PROGRESS: shipped verified positivity + geometric growth (2·3ⁿ ≤ L(n+1)) for Mathlib's large Schröder numbers; order-two holonomic recurrence set up for Aristotle with full GF proof sketch.",
+    "insights": [
+      "Mathlib's Combinatorics/Enumerative/Schroder.lean defines Nat.largeSchroder by the quadratic convolution recurrence and records ONLY evenness (Nat.even_largeSchroder) — positivity and growth are genuine gaps.",
+      "Factor-3 step growth L(n+2) ≥ 3·L(n+1) comes for free from just the two boundary convolution terms (i=0 and i=n+1, each = L(n+1)) plus the leading +L(n+1); no interior-term analysis needed.",
+      "The true growth ratio is 3+2√2 ≈ 5.83, the dominant root of x²−6x+1 (the discriminant of the Schröder GF equation x f² + (x−1) f + 1 = 0); the elementary boundary bound only yields the integer floor 3.",
+      "Full GF proof of the order-two recurrence: f = ∑ L n xⁿ satisfies x f² + (x−1) f + 1 = 0; differentiating and eliminating f²/ff' gives the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1); the xⁿ-coefficient is (n+1)L(n) = 3(2n−1)L(n−1) − (n−2)L(n−2), i.e. (n+3)L(n+2)+nL(n)=3(2n+3)L(n+1).",
+      "Clean convolution reformulation of the holonomic recurrence (no GF needed to STATE): with Q(n)=∑ i≤n, L i·L(n−i), the recurrence is equivalent to (n+3)·Q(n+1) = (5n+6)·Q(n) + (4n+6)·L(n)."
+    ],
+    "builtItems": [
+      "Nat.largeSchroder_pos (Proofs/SchroderLinearRecurrence.lean): 0 < largeSchroder n, by structural induction",
+      "Nat.two_mul_largeSchroder_le_conv: 2·L(n+1) ≤ ∑ i≤n+1, L i·L(n+1−i) via the {0,n+1} boundary terms",
+      "Nat.largeSchroder_ge_three_mul: 3·L(n+1) ≤ L(n+2)",
+      "Nat.largeSchroder_ge_two_mul_three_pow: 2·3ⁿ ≤ L(n+1) (closed exponential lower bound)",
+      "Proofs/SchroderLinearRecurrenceAristotle.lean: companion stating largeSchroder_holonomic and its convolution form largeSchroder_conv_holonomic as sorries with GF proof sketch"
+    ],
+    "mathlibGaps": [
+      "No positivity lemma for Nat.largeSchroder (only Nat.even_largeSchroder).",
+      "No order-two holonomic / P-recursive recurrence for the large Schröder numbers.",
+      "No central-coefficient bridge for Schröder analogous to succ_mul_catalan_eq_centralBinom, so the Catalan-style elementary derivation does not transfer — the GF/ODE route is needed."
+    ],
+    "nextSteps": [
+      "Submit Proofs/SchroderLinearRecurrenceAristotle.lean to Aristotle when the service returns (prove largeSchroder_holonomic; the convolution-form lemma may be the easier intermediate).",
+      "If proving by hand: formalize the GF argument in Mathlib PowerSeries (PowerSeries.derivative is a Derivation with coeff_derivative) — establish X f² + (X−1) f + 1 = 0 from largeSchroder_succ via coeff_mul, then the ODE by elimination.",
+      "Upgrade growth to the sharp ratio L(n+1)/L n → 3+2√2 over ℝ."
+    ],
+    "markdown": ""
+  },
+  "knownResults": [],
+  "leanFiles": [
+    "Proofs/SchroderLinearRecurrence.lean",
+    "Proofs/SchroderLinearRecurrenceAristotle.lean"
+  ],
+  "relatedProofs": ["catalan-numbers-oq-01"],
+  "references": [],
+  "phaseHistory": []
+}


### PR DESCRIPTION
## Summary

Quantitative basics for Mathlib's large Schröder numbers `Nat.largeSchroder`, which Mathlib's `Combinatorics/Enumerative/Schroder.lean` defines only via the quadratic convolution recurrence and for which it records **only evenness** (`Nat.even_largeSchroder`). This entry fills the gaps:

- `largeSchroder_pos` — `0 < L n` (positivity)
- `two_mul_largeSchroder_le_conv` — the convolution sum dominates `2·L(n+1)` via its two boundary terms
- `largeSchroder_ge_three_mul` — step growth `3·L(n+1) ≤ L(n+2)`
- `largeSchroder_ge_two_mul_three_pow` — closed exponential bound `2·3ⁿ ≤ L(n+1)`

All four verified over ℕ: **0 axioms, 0 sorries, no decide/native_decide** (95 lines, 4 theorems). Builds via `docker-build.sh Proofs.SchroderLinearRecurrence`.

This addresses the Schröder/Delannoy/Motzkin follow-up explicitly posed in `catalan-numbers-oq-01`'s open questions (the analogous holonomic structure of related combinatorial sequences).

## Deferred (companion file)

The deeper **order-two holonomic recurrence** `(n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1)` is stated — with a full generating-function proof sketch (GF satisfies `x f² + (x−1) f + 1 = 0` ⟹ ODE `x(x²−6x+1) f' = (3x−1) f + (x+1)`) and a clean convolution reformulation — in `SchroderLinearRecurrenceAristotle.lean` as `sorry`s, for automated proof search (Aristotle service was unavailable this session). That companion is **not** part of the verified entry.

## Notes

- Unlike the Catalan first-order recurrence (inherited from central binomials), Schröder has no central-coefficient bridge in Mathlib, so the elementary route doesn't transfer — hence the GF/ODE approach for the deferred recurrence.
- The growth factor 3 is the integer floor of the true asymptotic ratio `3 + 2√2 ≈ 5.83` (dominant root of `x²−6x+1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)