### PR TITLE
Enrich Gauss Sum Generates a Quadratic Field (quadratic-gauss-sum-square-oq-04): add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/quadratic-gauss-sum-square-oq-04/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-qgss-oq04-context",
+    "proofId": "quadratic-gauss-sum-square-oq-04",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "concept",
+    "title": "From the square identity to a quadratic field",
+    "content": "The parent entry proves the algebraic square identity g² = p* := (−1)^((p−1)/2)·p for the quadratic Gauss sum g. This file reads that identity field-theoretically: since |p*| = p is prime, p* is not a rational square, so g is a quadratic irrational. The new results are its minimal polynomial over ℚ (X² − p*), the degree [ℚ(g):ℚ] = 2, and irrationality g ∉ ℚ. Equivalently the Gauss sum generates the unique quadratic subfield ℚ(√p*) of the cyclotomic field ℚ(ζ_p) — the field-theoretic foundation of the Gauss-sum proof of quadratic reciprocity.",
+    "mathContext": "$g^2 = p^* = (-1)^{(p-1)/2}p$, $|p^*| = p$ prime $\\Rightarrow$ $p^*$ not a square $\\Rightarrow$ $\\operatorname{minpoly}_\\mathbb{Q}(g) = X^2 - p^*$, $[\\mathbb{Q}(g):\\mathbb{Q}] = 2$, $g = \\sqrt{p^*}$ generating $\\mathbb{Q}(\\zeta_p)$'s quadratic subfield.",
+    "significance": "context",
+    "relatedConcepts": ["Gauss sum", "quadratic field", "cyclotomic field", "quadratic reciprocity", "minimal polynomial"],
+    "prerequisites": ["Gauss sums", "field extensions", "quadratic characters"]
+  },
+  {
+    "id": "ann-qgss-oq04-character",
+    "proofId": "quadratic-gauss-sum-square-oq-04",
+    "range": { "startLine": 40, "endLine": 63 },
+    "type": "definition",
+    "title": "The ℂ-valued quadratic character and χ(−1)",
+    "content": "chiC p is the ℂ-valued quadratic character, the integer-valued quadraticChar (ZMod p) composed with ℤ → ℂ. Its quadraticity and nontriviality transport from the integer character. chiC_neg_one evaluates χ(−1) = (−1)^((p−1)/2): via quadraticChar_neg_one and ZMod.χ₄_eq_neg_one_pow it equals (−1)^(p/2), and p/2 = (p−1)/2 for odd p. This sign is exactly what makes g² come out as p* with the correct ± in front.",
+    "mathContext": "$\\chi_\\mathbb{C} = \\iota\\circ\\operatorname{quadraticChar}(\\mathbb{Z}/p)$; $\\chi(-1) = (-1)^{(p-1)/2}$, the sign distinguishing $p\\equiv 1$ from $p\\equiv 3\\pmod 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["MulChar.ringHomComp", "quadraticChar_neg_one", "χ₄", "primitive character"],
+    "prerequisites": ["multiplicative characters", "quadratic character over ZMod p"]
+  },
+  {
+    "id": "ann-qgss-oq04-square",
+    "proofId": "quadratic-gauss-sum-square-oq-04",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "technique",
+    "title": "The square formula g² = p*, re-derived self-containedly",
+    "content": "pstar p := (−1)^((p−1)/2)·p packages the target value as an integer. gaussSum_sq_eq re-derives the parent's identity g² = (p* : ℂ) from Mathlib's generic gaussSum_sq, which gives g² = χ(−1)·#(ZMod p); substituting chiC_neg_one and ZMod.card and pushing casts yields exactly (pstar p : ℂ). Re-deriving it here (rather than importing the parent) keeps the file self-contained.",
+    "mathContext": "$g^2 = \\chi(-1)\\cdot|\\mathbb{Z}/p| = (-1)^{(p-1)/2}\\cdot p = p^*$.",
+    "significance": "key",
+    "relatedConcepts": ["gaussSum_sq", "ZMod.card", "p-star", "self-contained re-derivation"],
+    "prerequisites": ["Gauss sum square identity", "cardinality of ZMod p"]
+  },
+  {
+    "id": "ann-qgss-oq04-notsq",
+    "proofId": "quadratic-gauss-sum-square-oq-04",
+    "range": { "startLine": 80, "endLine": 103 },
+    "type": "insight",
+    "title": "p* is not a rational square",
+    "content": "pstar_not_sq is the single arithmetic fact that unlocks everything: no rational b has b² = p*. Since (−1)^((p−1)/2) is ±1, p* is p or −p. If p* = p, a rational b with b² = p makes √p = |b| rational, contradicting Nat.Prime.irrational_sqrt. If p* = −p < 0, then b² = −p contradicts sq_nonneg. Both p mod 4 classes are dispatched uniformly by the sign of p*. This is what separates X² − p* from a reducible quadratic and forces degree 2.",
+    "mathContext": "$\\forall b\\in\\mathbb{Q},\\ b^2 \\neq p^*$: for $p^*=p$, $\\sqrt p\\notin\\mathbb{Q}$ (prime); for $p^*=-p<0$, $b^2\\ge 0$ forbids it.",
+    "significance": "key",
+    "relatedConcepts": ["irrationality of √p", "Nat.Prime.irrational_sqrt", "sq_nonneg", "p mod 4"],
+    "prerequisites": ["irrationality of prime square roots", "sign of squares"]
+  },
+  {
+    "id": "ann-qgss-oq04-minpoly",
+    "proofId": "quadratic-gauss-sum-square-oq-04",
+    "range": { "startLine": 105, "endLine": 124 },
+    "type": "concept",
+    "title": "The minimal polynomial is X² − p*",
+    "content": "isIntegral_gaussSum exhibits g as a root of the monic X² − C(p*) (annihilation from g² = p*). minpoly_gaussSum then identifies this as the minimal polynomial: it is monic (monic_X_pow_sub_C), annihilates g, and is irreducible — X_pow_sub_C_irreducible_of_prime applied with the prime exponent 2 and the no-square-root hypothesis pstar_not_sq. Because the exponent 2 is itself prime, this Kummer-style irreducibility criterion applies directly, sidestepping the usual n = 2 awkwardness. minpoly.eq_of_irreducible_of_monic seals it.",
+    "mathContext": "$\\operatorname{minpoly}_\\mathbb{Q}(g) = X^2 - C(p^*)$: monic, $\\operatorname{aeval}_g = 0$, and irreducible since $X^2 - a$ is irreducible iff $a$ has no square root.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "X_pow_sub_C_irreducible_of_prime", "monic_X_pow_sub_C", "Kummer irreducibility"],
+    "prerequisites": ["minimal polynomials", "irreducibility of Xⁿ − a", "integral elements"]
+  },
+  {
+    "id": "ann-qgss-oq04-degree",
+    "proofId": "quadratic-gauss-sum-square-oq-04",
+    "range": { "startLine": 126, "endLine": 142 },
+    "type": "concept",
+    "title": "Degree 2 and irrationality",
+    "content": "finrank_adjoin_gaussSum reads [ℚ(g):ℚ] = 2 off the minimal polynomial via IntermediateField.adjoin.finrank and natDegree_X_pow_sub_C — so g generates the unique quadratic subfield ℚ(√p*) of ℚ(ζ_p). gaussSum_not_rational derives irrationality directly: if g were rational q then q² = p*, contradicting pstar_not_sq. Together these are the field-theoretic refinement of the parent's purely numerical square identity.",
+    "mathContext": "$[\\mathbb{Q}(g):\\mathbb{Q}] = \\deg(X^2 - p^*) = 2$, and $g\\notin\\operatorname{range}(\\mathbb{Q}\\to\\mathbb{C})$.",
+    "significance": "key",
+    "relatedConcepts": ["IntermediateField.adjoin.finrank", "degree of an extension", "quadratic subfield of ℚ(ζ_p)", "irrationality"],
+    "prerequisites": ["degree = natDegree of minpoly", "adjoining an algebraic element"]
+  }
+]

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-04/index.ts
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/QuadraticGaussSumSquareOQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const quadraticGaussSumSquareOQ04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const quadraticGaussSumSquareOQ04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const quadraticGaussSumSquareOQ04Data: ProofData = {
+  proof: quadraticGaussSumSquareOQ04Proof,
+  annotations: quadraticGaussSumSquareOQ04Annotations,
+}

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-04/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-04/meta.json
@@ -19,6 +19,43 @@
     "path": "Proofs/QuadraticGaussSumSquareOQ04.lean",
     "sorries": 0
   },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: from g² = p* to a quadratic field",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Module docstring: the parent's square identity g² = p* is interpreted field-theoretically — |p*| = p prime makes g a quadratic irrational with minpoly X² − p*, [ℚ(g):ℚ] = 2, generating the unique quadratic subfield ℚ(√p*) of ℚ(ζ_p)."
+    },
+    {
+      "id": "character-and-square",
+      "title": "The character and the square formula",
+      "startLine": 38,
+      "endLine": 76,
+      "summary": "chiC p (ℂ-valued quadratic character) with its quadraticity/nontriviality and the evaluation χ(−1) = (−1)^((p−1)/2); pstar p := (−1)^((p−1)/2)·p; gaussSum_sq_eq re-derives g² = (p* : ℂ) from Mathlib's gaussSum_sq, keeping the file self-contained."
+    },
+    {
+      "id": "pstar-not-square",
+      "title": "p* is not a rational square",
+      "startLine": 78,
+      "endLine": 103,
+      "summary": "pstar_not_sq: no rational b has b² = p*. p* = ±p; p* = p contradicts irrationality of √p (prime), p* = −p < 0 contradicts sq_nonneg. Uniform across p mod 4 — the fact that forces degree 2."
+    },
+    {
+      "id": "minimal-polynomial",
+      "title": "The minimal polynomial X² − p*",
+      "startLine": 105,
+      "endLine": 124,
+      "summary": "isIntegral_gaussSum (g is a root of the monic X² − C(p*)); minpoly_gaussSum identifies minpoly ℚ g = X² − C(p*) via monicity, annihilation, and irreducibility (X_pow_sub_C_irreducible_of_prime with prime exponent 2 + pstar_not_sq)."
+    },
+    {
+      "id": "degree-irrationality",
+      "title": "Degree 2 and irrationality",
+      "startLine": 126,
+      "endLine": 142,
+      "summary": "finrank_adjoin_gaussSum: [ℚ(g):ℚ] = 2 (from natDegree of the minimal polynomial); gaussSum_not_rational: g ∉ ℚ, since g = q would give q² = p* against pstar_not_sq."
+    }
+  ],
   "description": "The parent entry proves the classical square identity g² = (−1)^((p−1)/2)·p = p* for the quadratic Gauss sum g = gaussSum(χ, ψ) of an odd prime p and a primitive additive character ψ : ZMod p → ℂ. This entry pushes that one structural step further into field theory: it identifies the minimal polynomial of g over ℚ and the degree of the field it generates. The key arithmetic input is that |p*| = p is prime, so p* is not the square of any rational (when p ≡ 1 mod 4, p* = p is prime hence not a perfect square; when p ≡ 3 mod 4, p* = −p < 0 is not a real square). Combined with g² = p*, this makes g a quadratic irrational: its minimal polynomial over ℚ is exactly X² − p* (irreducible because the prime-exponent Kummer criterion X² − a is irreducible iff a has no square root), so [ℚ(g) : ℚ] = 2 and g ∉ ℚ. Concretely, the quadratic Gauss sum generates the unique quadratic subfield ℚ(√p*) of the p-th cyclotomic field ℚ(ζ_p) — the classical bridge from Gauss sums to quadratic fields. The square identity gaussSum_sq_eq is re-derived in-file from Mathlib's generic gaussSum_sq so the file is self-contained; the minimal-polynomial, degree, and irrationality results (minpoly_gaussSum, finrank_adjoin_gaussSum, gaussSum_not_rational) are the new content. Fully machine-verified with no axioms and no sorries.",
   "meta": {
     "author": "Lean Genius",


### PR DESCRIPTION
Enrichment pass for `quadratic-gauss-sum-square-oq-04` (g is a quadratic irrational with minpoly X²−p*; quality 33, 0 prior passes).

## Changes
- **Added missing `index.ts`** — the entry had only `meta.json` (showed "proof not found" live). Wired up via the standard Vite `?raw` import of `Proofs/QuadraticGaussSumSquareOQ04.lean`.
- **Added `annotations.json`** — 6 annotations covering the full file: the field-theoretic framing, the ℂ-valued character and χ(−1), the re-derived square formula g²=p*, the no-rational-square fact, the minimal polynomial X²−p*, and degree 2 + irrationality. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **Added `sections`** array covering all five parts (the `overview`/`conclusion`/`crossReferences` were already rich).

## Notes
- Verified against the Lean source: 9 theorems / 2 defs, 0 sorries, 0 axioms. `status: verified`, `badge: original`, `axiomCount: 0` accurate.
- All annotation start lines resolve to Lean constructs via `scripts/annotations/lean-parser.ts`; JSON validated.