### PR TITLE
Enrich Quadratic Residue Equidistribution (residues = non-residues = (p−1)/2)

### DIFF
--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02/annotations.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-context",
+    "proofId": "quadratic-gauss-sum-square-oq-02",
+    "range": { "startLine": 1, "endLine": 36 },
+    "type": "context",
+    "title": "Equidistribution as the Orthogonality Side of Gauss Sums",
+    "content": "That exactly half the nonzero residues mod an odd prime are squares is among the oldest facts in number theory (classically via pairing a with −a, or the two-to-one squaring map on (ℤ/p)×). The quadratic character χ packages it: +1 on residues, −1 on non-residues, 0 at zero. Its vanishing total sum ∑ χ(a) = 0 is the simplest instance of character orthogonality — the same orthogonality behind Gauss-sum evaluation and Dirichlet L-function functional equations. This entry isolates the counting content of that vanishing sum, separate from the parent's algebraic square identity g² = (−1)^((p−1)/2)·p.",
+    "mathContext": "$\\chi = \\operatorname{quadraticChar}(\\mathbb{Z}/p)$, $\\sum_{a} \\chi(a) = 0$; residues and non-residues each number $(p-1)/2$.",
+    "significance": "context",
+    "relatedConcepts": ["quadratic character", "Legendre symbol", "character orthogonality", "quadratic residues", "Gauss sums"],
+    "prerequisites": ["modular arithmetic", "quadratic residues"]
+  },
+  {
+    "id": "ann-vanishing-sum",
+    "proofId": "quadratic-gauss-sum-square-oq-02",
+    "range": { "startLine": 38, "endLine": 45 },
+    "type": "technique",
+    "title": "The Vanishing Character Sum",
+    "content": "quadraticChar_sum_eq_zero specialises Mathlib's general quadraticChar_sum_zero to ZMod p. The only work is discharging the characteristic hypothesis ringChar (ZMod p) ≠ 2, which follows from p ≠ 2 via ZMod.ringChar_zmod_n (the ring characteristic of ZMod n is n). This single orthogonality fact ∑ χ(a) = 0 is the entire analytic input; everything else is counting.",
+    "mathContext": "$\\sum_{a \\in \\mathbb{Z}/p} \\chi(a) = 0$, requiring $\\operatorname{ringChar}(\\mathbb{Z}/p) = p \\ne 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["character orthogonality", "ring characteristic", "quadraticChar_sum_zero"],
+    "prerequisites": ["finite fields", "ring characteristic"]
+  },
+  {
+    "id": "ann-filters-split",
+    "proofId": "quadratic-gauss-sum-square-oq-02",
+    "range": { "startLine": 47, "endLine": 76 },
+    "type": "insight",
+    "title": "The Character Sum Is a Signed Count",
+    "content": "The crux: the vanishing sum is literally a signed count. Because quadraticChar_isQuadratic says χ(a) ∈ {0, 1, −1}, each summand χ(a) can be rewritten as the difference of Boolean indicators [χ(a)=1] − [χ(a)=−1]. Distributing the sum and applying Finset.sum_boole (which converts an indicator sum to a filter cardinality) turns ∑ χ(a) into #residues − #nonresidues. Equidistribution is therefore not an extra theorem but a direct reading of orthogonality: residues contribute +1, non-residues −1, zero contributes 0.",
+    "mathContext": "$\\chi(a) = [\\chi(a)=1] - [\\chi(a)=-1]$, so $\\sum_a \\chi(a) = \\#\\{\\chi=1\\} - \\#\\{\\chi=-1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Boolean indicators", "Finset.sum_boole", "signed counting", "quadraticity"],
+    "prerequisites": ["finite sums", "indicator functions"]
+  },
+  {
+    "id": "ann-equidistribution",
+    "proofId": "quadratic-gauss-sum-square-oq-02",
+    "range": { "startLine": 78, "endLine": 116 },
+    "type": "concept",
+    "title": "Equidistribution and the Partition",
+    "content": "card_residues_eq_card_nonresidues combines the two facts: ∑ χ(a) = 0 and ∑ χ(a) = #residues − #nonresidues force the two counts to be equal. card_residues_add_card_nonresidues then shows the two filters partition the nonzero elements: they are disjoint (χ(a) cannot be both 1 and −1) and their union is exactly {a ≠ 0} (since χ(a)=0 ⟺ a=0 via quadraticChar_eq_zero_iff, the only excluded element is 0), whose cardinality is p−1 by rewriting to univ.erase 0 and ZMod.card. So the two equal classes together account for all p−1 nonzero residues.",
+    "mathContext": "$\\#\\text{residues} = \\#\\text{nonresidues}$ and $\\#\\text{residues} + \\#\\text{nonresidues} = p-1$ (disjoint union exhausting $\\{a \\ne 0\\}$).",
+    "significance": "key",
+    "relatedConcepts": ["equidistribution", "partition", "disjoint union", "quadraticChar_eq_zero_iff"],
+    "prerequisites": ["finite cardinality", "set partitions"]
+  },
+  {
+    "id": "ann-counts",
+    "proofId": "quadratic-gauss-sum-square-oq-02",
+    "range": { "startLine": 118, "endLine": 134 },
+    "type": "concept",
+    "title": "Each Class Has (p−1)/2 Elements",
+    "content": "card_residues_eq and card_nonresidues_eq deliver the headline: two equal halves summing to p−1 each equal (p−1)/2, closed by omega. For every odd prime p exactly (p−1)/2 of the elements of ZMod p are nonzero squares and (p−1)/2 are non-squares. This is the elementary counting companion to the Gauss-sum family — derived purely from orthogonality, independent of the algebraic square identity studied in the parent entry.",
+    "mathContext": "$\\#\\text{residues} = \\#\\text{nonresidues} = \\frac{p-1}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residues", "(p−1)/2 count", "Legendre symbol", "omega tactic"],
+    "prerequisites": ["modular arithmetic", "natural-number arithmetic"]
+  }
+]

--- a/src/data/proofs/quadratic-gauss-sum-square-oq-02/meta.json
+++ b/src/data/proofs/quadratic-gauss-sum-square-oq-02/meta.json
@@ -76,5 +76,49 @@
       "relationship": "related",
       "description": "Equidistribution of residues and non-residues is part of the elementary theory of the Legendre symbol that underlies quadratic reciprocity."
     }
+  ],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Equidistribution from Character Orthogonality",
+      "startLine": 1,
+      "endLine": 36,
+      "summary": "Docstring framing the result: the quadratic character χ = quadraticChar (ZMod p) has vanishing total sum ∑ χ(a) = 0 (Mathlib's quadraticChar_sum_zero), and this file reads off the counting consequence that nonzero residues and non-residues are equinumerous with (p−1)/2 elements each. Notes the logical independence from the parent's square identity g² = (−1)^((p−1)/2)·p. Imports Mathlib, opens BigOperators/Finset, opens the namespace with a Fact p.Prime variable."
+    },
+    {
+      "id": "vanishing-sum",
+      "title": "The Vanishing Character Sum",
+      "startLine": 38,
+      "endLine": 45,
+      "summary": "quadraticChar_sum_eq_zero specialises Mathlib's quadraticChar_sum_zero to ZMod p, discharging the characteristic hypothesis ringChar ≠ 2 from p ≠ 2 via ZMod.ringChar_zmod_n. This is the orthogonality input the whole count rests on."
+    },
+    {
+      "id": "filters-split",
+      "title": "Splitting the Sum into Filter Cardinalities",
+      "startLine": 47,
+      "endLine": 76,
+      "summary": "Defines the residues filter {a : χ(a) = 1} and nonresidues filter {a : χ(a) = −1}. sum_eq_card_sub_card rewrites each summand χ(a) as the difference of Boolean indicators [χ(a)=1] − [χ(a)=−1] — valid because quadraticChar_isQuadratic says χ(a) ∈ {0,1,−1} — and applies Finset.sum_boole to turn the two indicator sums into the filter cardinalities, giving ∑ χ(a) = #residues − #nonresidues."
+    },
+    {
+      "id": "equidistribution",
+      "title": "Equidistribution: #residues = #nonresidues",
+      "startLine": 78,
+      "endLine": 85,
+      "summary": "card_residues_eq_card_nonresidues combines the two previous results: substituting ∑ χ(a) = 0 into ∑ χ(a) = #residues − #nonresidues forces the two counts to agree (via linarith and a ℤ cast). Equidistribution is a direct reading of orthogonality, not a separate theorem."
+    },
+    {
+      "id": "partition",
+      "title": "The Two Classes Exhaust the Nonzero Elements",
+      "startLine": 87,
+      "endLine": 116,
+      "summary": "card_residues_add_card_nonresidues: #residues + #nonresidues = p − 1. The filters are disjoint (χ(a) cannot be both 1 and −1) and their union is exactly the nonzero elements (using χ(a)=0 ⟺ a=0 via quadraticChar_eq_zero_iff), whose count is p−1 by rewriting to univ.erase 0 and ZMod.card."
+    },
+    {
+      "id": "counts",
+      "title": "Each Class Has Exactly (p−1)/2 Elements",
+      "startLine": 118,
+      "endLine": 134,
+      "summary": "card_residues_eq and card_nonresidues_eq: two equal halves summing to p−1 give (p−1)/2 each, discharged by omega. The headline counts of quadratic residues and non-residues mod an odd prime."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `quadratic-gauss-sum-square-oq-02` (quality 33, pass 0).

## What was added
- **No `annotations.json`** previously — created 5 inline annotations (`mathContext` LaTeX, `significance`, `relatedConcepts`, `prerequisites`) covering the orthogonality context, the vanishing character sum, the signed-count split, the equidistribution+partition, and the (p−1)/2 counts.
- **Empty `sections`** — added 6 conforming `ProofSection` entries (`startLine`/`endLine`/`summary`) mapped to the actual Lean line ranges.
- meta.json already had a rich `overview`, `conclusion`, and well-formed `crossReferences` (3 targets, all verified to exist) — left intact.

## Accuracy notes
- meta.json reports `status: verified`, `axiomCount: 0`, `sorries: 0`, `badge: mathlib` (accurate — reads the count off Mathlib's quadraticChar_sum_zero plus quadraticity). No `native_decide`. No status/badge changes.
- Annotations match the actual declarations (quadraticChar_sum_eq_zero, sum_eq_card_sub_card, card_residues_eq_card_nonresidues, card_residues_eq).
- No `index.ts` shim added (obsolete per issue #20993).

`pnpm build` passes.