### PR TITLE
Enrich Irreducibility of Φ_p via Eisenstein at Φ_p(X+1) (eisenstein-criterion-oq-01-oq-03-oq-02): add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-eis-cyclo-context",
+    "proofId": "eisenstein-criterion-oq-01-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "The Gauss argument: Eisenstein at the translate Φ_p(X+1)",
+    "content": "The p-th cyclotomic polynomial Φ_p(X) = 1 + X + ⋯ + X^(p−1) is not visibly Eisenstein at p, but its translate Φ_p(X+1) = ((X+1)^p − 1)/X = ∑_{k=1}^p C(p,k) X^(k−1) is: monic of degree p−1, every lower coefficient C(p,k) (1 ≤ k ≤ p−1) divisible by p, and constant term C(p,1) = p divisible by p but not p². Eisenstein makes Φ_p(X+1) irreducible over ℚ, and since X ↦ X+1 is a ring automorphism of ℚ[X], Φ_p itself is irreducible. This is the classical Gauss proof, here feeding the data into the parent's reproved criterion rather than invoking Mathlib's cyclotomic.irreducible_rat.",
+    "mathContext": "$\\Phi_p(X+1) = \\frac{(X+1)^p - 1}{X} = \\sum_{k=1}^p \\binom{p}{k} X^{k-1}$, Eisenstein at $p$ (constant term $\\binom{p}{1} = p$, $p\\nmid 1$, $p^2\\nmid p$).",
+    "significance": "context",
+    "relatedConcepts": ["cyclotomic polynomial", "Eisenstein's criterion", "translation automorphism", "Gauss's lemma", "irreducibility over ℚ"],
+    "prerequisites": ["cyclotomic polynomials", "Eisenstein's criterion", "binomial coefficients mod p"]
+  },
+  {
+    "id": "ann-eis-cyclo-shift",
+    "proofId": "eisenstein-criterion-oq-01-oq-03-oq-02",
+    "range": { "startLine": 42, "endLine": 52 },
+    "type": "definition",
+    "title": "The translate Φ_p(X+1) over ℤ, and its monicity",
+    "content": "shiftedCyclotomicInt p := (cyclotomic p ℤ).comp (X + 1) is the integer translate. shiftedCyclotomicInt_monic proves it is monic: composition of monics (cyclotomic.monic and X + 1 = X + C 1, monic of degree 1) is monic. The omit hp in marks that monicity needs no primality hypothesis. Monicity is one of the three Eisenstein inputs (the leading coefficient must be a unit / not in the prime ideal).",
+    "mathContext": "$\\Phi_p(X+1) = \\Phi_p\\circ(X+1)$ is monic, as a composition of monic polynomials.",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial.comp", "Monic.comp", "monic_X_add_C", "polynomial translation"],
+    "prerequisites": ["monic polynomials", "polynomial composition"]
+  },
+  {
+    "id": "ann-eis-cyclo-degree",
+    "proofId": "eisenstein-criterion-oq-01-oq-03-oq-02",
+    "range": { "startLine": 54, "endLine": 58 },
+    "type": "technique",
+    "title": "Degree p − 1",
+    "content": "shiftedCyclotomicInt_natDegree computes deg Φ_p(X+1) = p − 1, via natDegree_comp (degree of a composition multiplies), natDegree_cyclotomic giving φ(p) = p − 1 for prime p (Nat.totient_prime), and natDegree_X_add_C = 1 for the inner X + 1. The positive degree p − 1 > 0 (since p > 1) is the second Eisenstein input.",
+    "mathContext": "$\\deg\\Phi_p(X+1) = \\deg\\Phi_p\\cdot\\deg(X+1) = \\varphi(p)\\cdot 1 = p - 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["natDegree_comp", "Nat.totient_prime", "degree of cyclotomic polynomial"],
+    "prerequisites": ["polynomial degree", "Euler totient at a prime"]
+  },
+  {
+    "id": "ann-eis-cyclo-eisenstein",
+    "proofId": "eisenstein-criterion-oq-01-oq-03-oq-02",
+    "range": { "startLine": 60, "endLine": 86 },
+    "type": "insight",
+    "title": "Repackaging the Eisenstein data and applying the parent criterion",
+    "content": "cyclotomic_prime_irreducible_rat takes Mathlib's cyclotomic_comp_X_add_one_isEisensteinAt (the IsEisensteinAt witness for the ideal (p)) and unpacks it into the concrete divisibility hypotheses the parent's irreducible_rat_of_eisenstein expects: p ∣ every coefficient below the top (hEis.mem, via Ideal.mem_span_singleton) and p² ∤ the constant coefficient (hEis.notMem, via Ideal.span_singleton_pow). With monicity and positive degree, the parent criterion yields irreducibility of the ℚ-mapped translate — demonstrating the reproved criterion's reach beyond the Xⁿ + p·g family.",
+    "mathContext": "$\\text{IsEisensteinAt}\\,(p)$ unpacks to $p\\mid \\Phi_p(X+1).\\text{coeff}\\,k$ for $k<\\deg$ and $p^2\\nmid \\Phi_p(X+1).\\text{coeff}\\,0$, the divisibility form of Eisenstein.",
+    "significance": "key",
+    "relatedConcepts": ["IsEisensteinAt", "Ideal.mem_span_singleton", "Gauss's lemma", "reproved criterion reuse"],
+    "prerequisites": ["Eisenstein's criterion", "ideals in ℤ", "span of a singleton"]
+  },
+  {
+    "id": "ann-eis-cyclo-descent",
+    "proofId": "eisenstein-criterion-oq-01-oq-03-oq-02",
+    "range": { "startLine": 87, "endLine": 95 },
+    "type": "technique",
+    "title": "Descent from Φ_p(X+1) to Φ_p along the translation automorphism",
+    "content": "The integer translate maps to the ℚ translate (map_cyclotomic), so irreducibility of (cyclotomic p ℚ).comp (X+1) is established. The final descent uses the polynomial automorphism algEquivAevalXAddC (1) (substitution X ↦ X + 1), which sends Φ_p to Φ_p(X+1); since irreducibility is preserved by ring isomorphisms (MulEquiv.irreducible_iff), Φ_p itself is irreducible over ℚ. This re-derives cyclotomic.irreducible_rat for prime indices through the elementary Eisenstein route.",
+    "mathContext": "$X\\mapsto X+1$ is a ring automorphism of $\\mathbb{Q}[X]$ sending $\\Phi_p\\mapsto\\Phi_p(X+1)$; irreducibility transfers, so $\\Phi_p$ is irreducible.",
+    "significance": "key",
+    "relatedConcepts": ["algEquivAevalXAddC", "MulEquiv.irreducible_iff", "ring automorphism", "map_cyclotomic"],
+    "prerequisites": ["ring isomorphisms preserve irreducibility", "polynomial substitution automorphisms"]
+  }
+]

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03-oq-02/index.ts
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EisensteinCriterionOQ01OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eisensteinCriterionOQ01OQ03OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eisensteinCriterionOQ01OQ03OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eisensteinCriterionOQ01OQ03OQ02Data: ProofData = {
+  proof: eisensteinCriterionOQ01OQ03OQ02Proof,
+  annotations: eisensteinCriterionOQ01OQ03OQ02Annotations,
+}

--- a/src/data/proofs/eisenstein-criterion-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/eisenstein-criterion-oq-01-oq-03-oq-02/meta.json
@@ -101,6 +101,29 @@
     "path": "Proofs/EisensteinCriterionOQ01OQ03OQ02.lean",
     "sorries": 0
   },
+  "sections": [
+    {
+      "id": "overview-header",
+      "title": "Overview: the Gauss argument",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module docstring: Φ_p is not visibly Eisenstein, but its translate Φ_p(X+1) = ∑ C(p,k) X^(k−1) is (Eisenstein at p); since X ↦ X+1 is a ring automorphism, Φ_p is irreducible over ℚ. The Eisenstein data feeds the parent's reproved criterion, re-deriving cyclotomic.irreducible_rat for prime indices elementarily."
+    },
+    {
+      "id": "translate-properties",
+      "title": "The translate Φ_p(X+1) and its basic properties",
+      "startLine": 42,
+      "endLine": 58,
+      "summary": "shiftedCyclotomicInt p := (cyclotomic p ℤ).comp (X+1); shiftedCyclotomicInt_monic (composition of monics, no primality needed) and shiftedCyclotomicInt_natDegree = p − 1 (natDegree_comp + Nat.totient_prime) — the monicity and positive-degree Eisenstein inputs."
+    },
+    {
+      "id": "irreducibility-and-descent",
+      "title": "Irreducibility via Eisenstein and descent to Φ_p",
+      "startLine": 60,
+      "endLine": 95,
+      "summary": "cyclotomic_prime_irreducible_rat: unpack Mathlib's cyclotomic_comp_X_add_one_isEisensteinAt into the divisibility hypotheses of the parent's irreducible_rat_of_eisenstein (p ∣ lower coeffs, p² ∤ constant), get irreducibility of the ℚ translate, then descend to Φ_p along algEquivAevalXAddC (1) via MulEquiv.irreducible_iff."
+    }
+  ],
   "mainTheorems": [
     {
       "name": "cyclotomic_prime_irreducible_rat",


### PR DESCRIPTION
Enrichment pass for `eisenstein-criterion-oq-01-oq-03-oq-02` (irreducibility of the p-th cyclotomic polynomial via Eisenstein at the translate; quality 35, 0 prior passes).

## Changes
- **Added missing `index.ts`** — the entry had only `meta.json` (showed "proof not found" live). Wired up via the standard Vite `?raw` import of `Proofs/EisensteinCriterionOQ01OQ03OQ02.lean`.
- **Added `annotations.json`** — 5 annotations covering the full file: the classical Gauss-argument framing, the translate Φ_p(X+1) and its monicity, the degree p−1, the Eisenstein-data repackaging feeding the parent's reproved criterion, and the descent to Φ_p along the translation automorphism. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **Added `sections`** array covering all three parts (the `overview`/`conclusion`/`crossReferences`/`mainTheorems` were already rich).

## Notes
- Verified against the Lean source: 4 theorems / 1 def, 0 sorries, 0 axioms, no `native_decide`. `status: verified`, `badge: mathlib`, `axiomCount: 0` accurate.
- All annotation start lines resolve to Lean constructs via `scripts/annotations/lean-parser.ts`; JSON validated.