### PR TITLE
Fix: stale 'the axiom' annotation in area-of-circle-oq-03-oq-02

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/annotations.json
@@ -98,7 +98,7 @@
     },
     "type": "insight",
     "title": "Traditional Formulations via norm_num",
-    "content": "Archimedes' bounds are often stated as $3 + 10/71 < \\pi < 3 + 1/7$ rather than as improper fractions. These theorems establish the equivalence using `norm_num` for the arithmetic identity ($3 + 10/71 = 223/71$) and `linarith` to chain with the axiom. This demonstrates Lean's strength at verified arithmetic: the equality $3 + 10/71 = 223/71$ is not merely claimed but machine-checked.",
+    "content": "Archimedes' bounds are often stated as $3 + 10/71 < \\pi < 3 + 1/7$ rather than as improper fractions. These theorems establish the equivalence using `norm_num` for the arithmetic identity ($3 + 10/71 = 223/71$) and `linarith` to chain with the proved bounds `archimedes_lower_bound`/`archimedes_upper_bound`. This demonstrates Lean's strength at verified arithmetic: the equality $3 + 10/71 = 223/71$ is not merely claimed but machine-checked.",
     "mathContext": "$3 + \\frac{10}{71} = \\frac{223}{71}$ and $3 + \\frac{1}{7} = \\frac{22}{7}$",
     "significance": "supporting",
     "relatedConcepts": [


### PR DESCRIPTION
## Fix

Correct an annotation that referred to a proved theorem as "the axiom" in a verified, 0-axiom entry.

## Evidence

`area-of-circle-oq-03-oq-02` is `status: verified`, `axiomCount: 0` — `proofs/Proofs/AreaOfCircleOQ03OQ02.lean` has zero `axiom` declarations (header explicitly: "Fully verified, 0 axioms, 0 sorries").

Annotation `ann-traditional-forms` ("Traditional Formulations via norm_num", range 50–58) said:

> ...and `linarith` to chain with **the axiom**.

But `archimedes_lower_traditional` / `archimedes_upper_traditional` close via `linarith [archimedes_lower_bound]` and `linarith [archimedes_upper_bound]` — both **theorems**, not axioms.

**Before**: "`linarith` to chain with the axiom."
**After**: "`linarith` to chain with the proved bounds `archimedes_lower_bound`/`archimedes_upper_bound`."

No other annotations in this entry reference axioms.

---
Automated fix by lean-mechanic agent.