### PR TITLE
research(legendre-factorial-formula-oq-01-oq-02): trailing zeros of n! in base 10 = v₅(n!) = (n−S₅(n))/4

### DIFF
--- a/proofs/Proofs/LegendreFactorialFormulaOQ01OQ02.lean
+++ b/proofs/Proofs/LegendreFactorialFormulaOQ01OQ02.lean
@@ -1,0 +1,128 @@
+/-
+# Trailing Zeros of `n!` in Base Ten
+
+The number of zeros that `n!` ends with in base `10` is the largest `k` with
+`10ᵏ ∣ n!`.  Since `10 = 2 · 5` and `2`, `5` are distinct primes, this count is
+
+  `min (v₂(n!)) (v₅(n!))`,
+
+where `vₚ` is the `p`-adic valuation.  The two-adic valuation of a factorial
+always dominates the five-adic one (there are at least as many factors of `2` as
+of `5`), so the minimum is realised by the five-adic side:
+
+  `#trailing zeros of n! = v₅(n!) = (n − S₅(n)) / 4`,
+
+with `S₅(n)` the base-`5` digit sum (Legendre's digit-sum form, specialised to
+`p = 5`).  This is the open question `oq-02` of the Legendre's-formula entry.
+
+We give the faithful order-theoretic statement: `v₅(n!)` is the **greatest** `k`
+with `10ᵏ ∣ n!` (`trailingZeros_isGreatest`), then read off the two defining
+properties (`10^{v₅} ∣ n!` and `¬ 10^{v₅+1} ∣ n!`), the `min` identity, and the
+closed digit-sum form.  Everything is fully verified with no `sorry` and no extra
+axioms.
+-/
+
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+
+open Nat Finset
+
+namespace LegendreFactorialFormulaOQ01OQ02
+
+/-- Dividing by a larger denominator gives a smaller quotient:
+`a ≤ b` and `0 < a` imply `n / b ≤ n / a`. -/
+private theorem div_le_div_of_denom_le {n a b : ℕ} (hab : a ≤ b) (ha : 0 < a) :
+    n / b ≤ n / a := by
+  rw [Nat.le_div_iff_mul_le ha]
+  exact le_trans (Nat.mul_le_mul (Nat.le_refl _) hab) (Nat.div_mul_le_self n b)
+
+/-- **The two-adic valuation of `n!` dominates the five-adic one.**
+Termwise, Legendre's floor sums satisfy `⌊n / 5ⁱ⌋ ≤ ⌊n / 2ⁱ⌋`, because `2ⁱ ≤ 5ⁱ`. -/
+theorem padicValNat_five_le_two (n : ℕ) :
+    padicValNat 5 (n !) ≤ padicValNat 2 (n !) := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  haveI : Fact (Nat.Prime 5) := ⟨by decide⟩
+  rw [padicValNat_factorial (p := 5) (n := n) (b := n + 1)
+        (Nat.lt_succ_of_le (Nat.log_le_self 5 n)),
+      padicValNat_factorial (p := 2) (n := n) (b := n + 1)
+        (Nat.lt_succ_of_le (Nat.log_le_self 2 n))]
+  apply Finset.sum_le_sum
+  intro i _
+  exact div_le_div_of_denom_le (Nat.pow_le_pow_left (by norm_num) i) (pow_pos (by norm_num) i)
+
+/-- **Main theorem.**  The five-adic valuation of `n!` is the greatest `k` for
+which `10ᵏ` divides `n!`; equivalently, it is the number of trailing zeros of
+`n!` in base ten.
+
+Membership uses `10^{v₅} = 2^{v₅} · 5^{v₅}` with both prime powers dividing `n!`
+(the `2`-power because `v₅ ≤ v₂`) and `2^{v₅}`, `5^{v₅}` coprime.  The upper
+bound is `5ᵏ ∣ 10ᵏ ∣ n! ⟹ k ≤ v₅`. -/
+theorem trailingZeros_isGreatest (n : ℕ) :
+    IsGreatest {k | 10 ^ k ∣ (n !)} (padicValNat 5 (n !)) := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  haveI : Fact (Nat.Prime 5) := ⟨by decide⟩
+  set Z := padicValNat 5 (n !) with hZ
+  constructor
+  · -- `10^Z ∣ n!`
+    show 10 ^ Z ∣ (n !)
+    have hv5 : (5 : ℕ) ^ Z ∣ (n !) := pow_padicValNat_dvd
+    have hv2 : (2 : ℕ) ^ Z ∣ (n !) :=
+      (padicValNat_dvd_iff_le (Nat.factorial_ne_zero n)).mpr (padicValNat_five_le_two n)
+    have hcop : Nat.Coprime (2 ^ Z) (5 ^ Z) := Nat.Coprime.pow _ _ (by decide)
+    have h10 : (10 : ℕ) = 2 * 5 := by norm_num
+    rw [h10, mul_pow]
+    exact Nat.Coprime.mul_dvd_of_dvd_of_dvd hcop hv2 hv5
+  · -- any `k` with `10^k ∣ n!` satisfies `k ≤ Z`
+    intro k hk
+    have h5 : (5 : ℕ) ^ k ∣ (n !) :=
+      dvd_trans (pow_dvd_pow_of_dvd (by norm_num) k) hk
+    exact (padicValNat_dvd_iff_le (Nat.factorial_ne_zero n)).mp h5
+
+/-- `10^{v₅(n!)}` divides `n!`: there are at least `v₅(n!)` trailing zeros. -/
+theorem ten_pow_v5_dvd_factorial (n : ℕ) :
+    10 ^ (padicValNat 5 (n !)) ∣ (n !) :=
+  (trailingZeros_isGreatest n).1
+
+/-- `10^{v₅(n!)+1}` does not divide `n!`: there are no more than `v₅(n!)` trailing
+zeros. -/
+theorem not_ten_pow_succ_dvd_factorial (n : ℕ) :
+    ¬ (10 ^ (padicValNat 5 (n !) + 1) ∣ (n !)) := by
+  intro h
+  have := (trailingZeros_isGreatest n).2 h
+  omega
+
+/-- **The trailing-zero count as a minimum of valuations.**
+`min (v₂(n!)) (v₅(n!)) = v₅(n!)`, since the five-adic valuation is the smaller. -/
+theorem trailingZeros_eq_min (n : ℕ) :
+    min (padicValNat 2 (n !)) (padicValNat 5 (n !)) = padicValNat 5 (n !) :=
+  min_eq_right (padicValNat_five_le_two n)
+
+/-- **Closed digit-sum form.**  The number of trailing zeros of `n!` equals
+`(n − S₅(n)) / 4`, where `S₅(n)` is the sum of the base-`5` digits of `n`. -/
+theorem trailingZeros_eq_digit_form (n : ℕ) :
+    min (padicValNat 2 (n !)) (padicValNat 5 (n !))
+      = (n - (Nat.digits 5 n).sum) / 4 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by decide⟩
+  rw [trailingZeros_eq_min]
+  have h := sub_one_mul_padicValNat_factorial (p := 5) n
+  rw [show (5 : ℕ) - 1 = 4 from rfl] at h
+  rw [← h, Nat.mul_div_cancel_left _ (by norm_num : 0 < 4)]
+
+/-- Worked instance: `10!` ends in exactly two zeros.
+`v₅(10!) = ⌊10/5⌋ = 2`, and indeed `10! = 3628800`. -/
+example : padicValNat 5 (10 !) = 2 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by decide⟩
+  rw [padicValNat_factorial (p := 5) (n := 10) (b := 2)
+    (Nat.log_lt_of_lt_pow (by norm_num) (by norm_num))]
+  decide
+
+/-- The greatest power of `10` dividing `10!` is `10² = 100`. -/
+example : IsGreatest {k | 10 ^ k ∣ (10 !)} 2 := by
+  haveI : Fact (Nat.Prime 5) := ⟨by decide⟩
+  have hv5 : padicValNat 5 (10 !) = 2 := by
+    rw [padicValNat_factorial (p := 5) (n := 10) (b := 2)
+      (Nat.log_lt_of_lt_pow (by norm_num) (by norm_num))]
+    decide
+  have := trailingZeros_isGreatest 10
+  rwa [hv5] at this
+
+end LegendreFactorialFormulaOQ01OQ02

--- a/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "legendre-fact-oq01-oq02-ann-header",
+    "proofId": "legendre-factorial-formula-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "Trailing Zeros = Exponent of 10 = a Minimum of Valuations",
+    "content": "A trailing zero of a positive integer in base 10 is a factor of 10 = 2·5, so the number of terminal zeros of n! is the greatest k with 10ᵏ | n! — the exponent of 10 in n!. Because 2 and 5 are distinct primes, that exponent is min(v₂(n!), v₅(n!)), where vₚ is the p-adic valuation. The whole entry rests on one fact: v₂(n!) ≥ v₅(n!), so the minimum is always realised by the five-adic side, and the count equals v₅(n!) = (n − S₅(n))/4. This is the schoolbook rule 'to count trailing zeros of n!, count the factors of 5', proved.",
+    "mathContext": "$\\#\\{\\text{trailing zeros of } n!\\} = \\max\\{k : 10^k \\mid n!\\} = \\min(v_2(n!), v_5(n!)) = v_5(n!) = \\tfrac{n - S_5(n)}{4}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "factorial",
+      "trailing zeros",
+      "base-10 expansion"
+    ],
+    "prerequisites": [
+      "prime factorization",
+      "Legendre's formula"
+    ]
+  },
+  {
+    "id": "legendre-fact-oq01-oq02-ann-domination",
+    "proofId": "legendre-factorial-formula-oq-01-oq-02",
+    "range": {
+      "startLine": 32,
+      "endLine": 51
+    },
+    "type": "theorem",
+    "title": "The Two-Adic Valuation Dominates the Five-Adic",
+    "content": "`padicValNat_five_le_two` proves v₅(n!) ≤ v₂(n!) — the precise content of 'the fives run out first'. Both valuations are written as Legendre floor sums over the common truncation bound b = n+1 (legal since log_p n ≤ n < n+1, by Nat.log_le_self), and compared termwise: ⌊n/5ⁱ⌋ ≤ ⌊n/2ⁱ⌋ because 2ⁱ ≤ 5ⁱ — dividing by a larger denominator gives a smaller quotient. That termwise comparison is the private lemma `div_le_div_of_denom_le`, proved from Nat.le_div_iff_mul_le and Nat.div_mul_le_self.",
+    "mathContext": "$v_5(n!) = \\sum_{i \\in [1,n+1)} \\lfloor n/5^i \\rfloor \\le \\sum_{i \\in [1,n+1)} \\lfloor n/2^i \\rfloor = v_2(n!).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Legendre floor sum",
+      "termwise comparison",
+      "monotonicity of division"
+    ],
+    "prerequisites": [
+      "padicValNat_factorial",
+      "Nat.log_le_self"
+    ]
+  },
+  {
+    "id": "legendre-fact-oq01-oq02-ann-isgreatest",
+    "proofId": "legendre-factorial-formula-oq-01-oq-02",
+    "range": {
+      "startLine": 53,
+      "endLine": 91
+    },
+    "type": "theorem",
+    "title": "v₅(n!) is the Greatest k with 10ᵏ | n!",
+    "content": "`trailingZeros_isGreatest` is the main result: v₅(n!) is the greatest element of {k | 10ᵏ | n!}, the faithful order-theoretic statement of the trailing-zero count. Membership rewrites 10^{v₅} = 2^{v₅}·5^{v₅} (mul_pow) and supplies both prime-power divisors of n! — 5^{v₅} | n! from pow_padicValNat_dvd, 2^{v₅} | n! from v₅ ≤ v₂ via padicValNat_dvd_iff_le — combined with Nat.Coprime.mul_dvd_of_dvd_of_dvd since 2^{v₅}, 5^{v₅} are coprime. The upper bound sends 10ᵏ | n! to 5ᵏ | 10ᵏ | n! (pow_dvd_pow_of_dvd) and reads off k ≤ v₅. The corollaries `ten_pow_v5_dvd_factorial` (10^{v₅} | n!) and `not_ten_pow_succ_dvd_factorial` (¬ 10^{v₅+1} | n!) record the two defining properties.",
+    "mathContext": "$10^{v_5(n!)} \\mid n! \\quad\\text{and}\\quad 10^{v_5(n!)+1} \\nmid n!.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsGreatest",
+      "coprime divisibility",
+      "p-adic valuation"
+    ],
+    "prerequisites": [
+      "pow_padicValNat_dvd",
+      "padicValNat_dvd_iff_le",
+      "Nat.Coprime.mul_dvd_of_dvd_of_dvd"
+    ]
+  },
+  {
+    "id": "legendre-fact-oq01-oq02-ann-min-digit",
+    "proofId": "legendre-factorial-formula-oq-01-oq-02",
+    "range": {
+      "startLine": 92,
+      "endLine": 128
+    },
+    "type": "theorem",
+    "title": "Minimum Identity, Closed Digit-Sum Form, and Instance",
+    "content": "`trailingZeros_eq_min` records min(v₂(n!), v₅(n!)) = v₅(n!) as min_eq_right of the domination lemma. `trailingZeros_eq_digit_form` gives the closed expression (n − S₅(n))/4: starting from Legendre's digit-sum identity at p = 5, (5−1)·v₅(n!) = n − S₅(n), divide by 4 via Nat.mul_div_cancel_left (exact, no rounding). Two worked examples close the entry: v₅(10!) = 2 (via the floor-sum form, kernel decide — not native_decide, since Nat.digits/Nat.log resist reduction) and IsGreatest {k | 10ᵏ | 10!} 2, i.e. 10! = 3628800 ends in exactly two zeros.",
+    "mathContext": "$\\min(v_2(n!), v_5(n!)) = v_5(n!) = \\frac{n - S_5(n)}{4}; \\qquad v_5(10!) = \\lfloor 10/5 \\rfloor = 2.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "digit-sum form",
+      "min_eq_right",
+      "kernel decide"
+    ],
+    "prerequisites": [
+      "sub_one_mul_padicValNat_factorial",
+      "Nat.mul_div_cancel_left"
+    ]
+  }
+]

--- a/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/index.ts
+++ b/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LegendreFactorialFormulaOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const legendreFactorialFormulaOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const legendreFactorialFormulaOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const legendreFactorialFormulaOQ01OQ02Data: ProofData = {
+  proof: legendreFactorialFormulaOQ01OQ02Proof,
+  annotations: legendreFactorialFormulaOQ01OQ02Annotations,
+}

--- a/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01-oq-02/meta.json
@@ -1,0 +1,128 @@
+{
+  "id": "legendre-factorial-formula-oq-01-oq-02",
+  "title": "Trailing Zeros of n! in Base Ten",
+  "slug": "legendre-factorial-formula-oq-01-oq-02",
+  "description": "The number of zeros that n! ends with in base 10 is the largest k with 10ᵏ | n!. Since 10 = 2·5 with 2, 5 distinct primes, that count is min(v₂(n!), v₅(n!)), and the two-adic valuation of a factorial always dominates the five-adic one, so the minimum is v₅(n!). Hence the trailing-zero count equals v₅(n!) = (n − S₅(n))/4, the base-5 digit-sum form of Legendre's solved formula. The entry gives the order-theoretic statement that v₅(n!) is the greatest k with 10ᵏ | n!, the two defining divisibilities, the min identity, and the closed digit-sum form. This is open question oq-02 of the Legendre's-formula entry.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Trailing_zero",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LegendreFactorialFormulaOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "p-adic-valuation",
+      "factorial",
+      "legendre-formula",
+      "trailing-zeros",
+      "digit-sum",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 128,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Fully machine-checked from Mathlib with 0 sorries and 0 axioms beyond Lean's foundational propext / Classical.choice / Quot.sound (confirmed by #print axioms on the main theorems: no sorryAx, no Lean.ofReduceBool). The five-adic / two-adic comparison reduces both valuations to Legendre floor sums over a common bound n+1 and compares them termwise (⌊n/5ⁱ⌋ ≤ ⌊n/2ⁱ⌋ since 2ⁱ ≤ 5ⁱ); membership 10^{v₅} | n! uses 10^{v₅} = 2^{v₅}·5^{v₅} with the two coprime prime powers dividing n!; the upper bound is 5ᵏ | 10ᵏ | n! ⟹ k ≤ v₅ via padicValNat_dvd_iff_le. The digit-sum form reuses Mathlib's sub_one_mul_padicValNat_factorial. The numeric instance v₅(10!) = 2 is closed by decide on a finite floor sum (kernel reduction, not native_decide).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Counting the trailing zeros of n! is the classic first application of Legendre's formula (Adrien-Marie Legendre, 1808). A trailing zero in base 10 is a factor of 10 = 2·5, so the number of terminal zeros of n! is the exponent of 10 in n!, i.e. the largest k with 10ᵏ | n!. Because 2 and 5 are distinct primes, this exponent is min(v₂(n!), v₅(n!)). The familiar schoolbook shortcut — 'just count the factors of 5' — is precisely the observation that v₂(n!) ≥ v₅(n!): among 1,…,n there are always at least as many multiples of each power of 2 as of the corresponding power of 5, so the supply of 2s never runs out before the supply of 5s. The count therefore collapses to v₅(n!), which Legendre's digit-sum form evaluates in closed form as (n − S₅(n))/4. This entry is the oq-02 follow-up to the gallery's Legendre's-formula entry, which supplied the floor-sum, digit-sum, and solved forms used here.",
+    "problemStatement": "Show that the number of trailing zeros of n! in base 10 — the greatest k with 10ᵏ | n! — equals v₅(n!). Concretely: (1) v₅(n!) ≤ v₂(n!); (2) v₅(n!) is the greatest k with 10ᵏ | n! (so 10^{v₅} | n! and ¬ 10^{v₅+1} | n!); (3) min(v₂(n!), v₅(n!)) = v₅(n!); (4) the count has the closed form (n − S₅(n))/4, where S₅(n) is the base-5 digit sum. Verify the instance v₅(10!) = 2.",
+    "text": "The trailing-zero count of n! in base 10 is the greatest k with 10ᵏ | n!, which equals min(v₂(n!), v₅(n!)) = v₅(n!) = (n − S₅(n))/4.",
+    "proofStrategy": "The keystone is padicValNat_five_le_two: v₅(n!) ≤ v₂(n!). Both valuations are written as Legendre floor sums over the common bound b = n+1 (legal since log_p n ≤ n < n+1 by Nat.log_le_self), and compared termwise — ⌊n/5ⁱ⌋ ≤ ⌊n/2ⁱ⌋ because 2ⁱ ≤ 5ⁱ (a small div-antitone-in-denominator lemma, proved from Nat.le_div_iff_mul_le and Nat.div_mul_le_self). The main theorem trailingZeros_isGreatest packages the trailing-zero count as IsGreatest {k | 10ᵏ | n!} (v₅(n!)): membership rewrites 10^{v₅} = 2^{v₅}·5^{v₅} (mul_pow) and supplies both prime-power divisors of n! — 5^{v₅} | n! from pow_padicValNat_dvd, 2^{v₅} | n! from v₅ ≤ v₂ and padicValNat_dvd_iff_le — combined via Nat.Coprime.mul_dvd_of_dvd_of_dvd; the upper bound sends 10ᵏ | n! to 5ᵏ | 10ᵏ | n! (pow_dvd_pow_of_dvd) and reads off k ≤ v₅ from padicValNat_dvd_iff_le. The two divisibility corollaries and the not-divisible statement fall out of IsGreatest. The min identity is min_eq_right of v₅ ≤ v₂, and the closed digit-sum form rewrites v₅(n!) using Mathlib's sub_one_mul_padicValNat_factorial at p = 5 and Nat.mul_div_cancel_left (5−1 = 4).",
+    "keyInsights": [
+      "**Trailing zeros = exponent of 10 = min of prime valuations.** A terminal zero in base 10 is one factor of 2·5, so the number of trailing zeros of any positive integer m is the greatest k with 10ᵏ | m, and for the prime factorization 10 = 2·5 this is min(v₂(m), v₅(m)). The IsGreatest formulation states this faithfully without inventing a bespoke 'trailing zeros' function.",
+      "**The supply of 2s never runs out before the 5s.** v₅(n!) ≤ v₂(n!) is the precise content of the schoolbook rule 'just count the fives'. Termwise the Legendre floor sums obey ⌊n/5ⁱ⌋ ≤ ⌊n/2ⁱ⌋ because 2ⁱ ≤ 5ⁱ — fewer numbers are divisible by the larger power. Hence the minimum is always realised by the five-adic side.",
+      "**Coprimality turns two prime-power divisibilities into a 10-power one.** Knowing 2^{v₅} | n! and 5^{v₅} | n! separately is not enough; 10^{v₅} = 2^{v₅}·5^{v₅} divides n! because the two factors are coprime (Nat.Coprime.mul_dvd_of_dvd_of_dvd). The matching non-divisibility 10^{v₅+1} ∤ n! follows because already 5^{v₅+1} ∤ n!.",
+      "**Closed form for free from the parent entry.** Once the count is pinned to v₅(n!), Legendre's digit-sum form (p−1)·v₅(n!) = n − S₅(n) at p = 5 gives the exact value (n − S₅(n))/4 with no rounding, since 4 genuinely divides n − S₅(n).",
+      "**Digit/log functions resist kernel evaluation; the floor sum does not.** Nat.digits and Nat.log use well-founded recursion and do not reduce under decide, so the instance v₅(10!) = 2 is checked through the floor-sum form (a plain Finset sum of divisions) where decide reduces cleanly — keeping the proof axiom-free (no native_decide)."
+    ],
+    "prerequisites": [
+      "Legendre's formula (parent entry): floor-sum form padicValNat_factorial, digit-sum form sub_one_mul_padicValNat_factorial",
+      "p-adic valuation API: pow_padicValNat_dvd, padicValNat_dvd_iff_le, and the Fact p.Prime convention",
+      "Coprime divisibility: Nat.Coprime.pow and Nat.Coprime.mul_dvd_of_dvd_of_dvd",
+      "Order-theoretic extremum: IsGreatest and upperBounds",
+      "Natural-number division facts: Nat.le_div_iff_mul_le, Nat.div_mul_le_self, Nat.mul_div_cancel_left, Nat.log_le_self"
+    ]
+  },
+  "conclusion": {
+    "summary": "The trailing-zero count of n! in base 10 is identified as v₅(n!): trailingZeros_isGreatest states that v₅(n!) is the greatest k with 10ᵏ | n!, with the two defining divisibilities 10^{v₅} | n! and ¬ 10^{v₅+1} | n! as corollaries. The min identity min(v₂(n!), v₅(n!)) = v₅(n!) and the closed digit-sum form (n − S₅(n))/4 complete the picture. All 7 theorems are fully verified with 0 axioms and 0 sorries; the instance v₅(10!) = 2 (10! ends in two zeros) is checked by kernel reduction.",
+    "implications": "This is the canonical worked application of Legendre's formula: the answer 'count the fives' is now a verified theorem rather than folklore. The keystone v₅(n!) ≤ v₂(n!) and the IsGreatest packaging are reusable for the general statement that the exponent of a squarefree base b = p₁⋯pᵣ in n! is min_i v_{pᵢ}(n!), realised by the largest prime.",
+    "openQuestions": [
+      "Generalize to an arbitrary base b ≥ 2: the exponent of b in n! is min over the prime powers pᵉ ‖ b of ⌊v_p(n!)/e⌋, and identify exactly when (as for b = 10) a single prime realises the minimum for all n.",
+      "Prove the asymptotic trailing-zero count: the number of terminal zeros of n! is n/4 + O(log n), since v₅(n!) = (n − S₅(n))/4 and S₅(n) = O(log n)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "legendre-factorial-formula-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. Supplies the Legendre floor-sum and digit-sum forms used here; this entry answers its open question oq-02 by computing the trailing-zero count of n! as v₅(n!) = (n − S₅(n))/4."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview and Setup",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Docstring explaining trailing zeros as the greatest k with 10ᵏ | n!, equal to min(v₂(n!), v₅(n!)) = v₅(n!) = (n − S₅(n))/4. Imports the p-adic valuation basics and opens Nat / Finset."
+    },
+    {
+      "id": "sec-domination",
+      "title": "Five-Adic ≤ Two-Adic",
+      "startLine": 32,
+      "endLine": 51,
+      "summary": "A private div-antitone-in-denominator lemma (a ≤ b, 0 < a ⟹ n/b ≤ n/a) and padicValNat_five_le_two: writing both valuations as Legendre floor sums over the common bound n+1 and comparing termwise (⌊n/5ⁱ⌋ ≤ ⌊n/2ⁱ⌋ since 2ⁱ ≤ 5ⁱ)."
+    },
+    {
+      "id": "sec-isgreatest",
+      "title": "Trailing Zeros as a Greatest Element",
+      "startLine": 53,
+      "endLine": 91,
+      "summary": "trailingZeros_isGreatest: v₅(n!) is the greatest k with 10ᵏ | n!. Membership rewrites 10^{v₅} = 2^{v₅}·5^{v₅} and combines the two coprime prime-power divisors of n!; the upper bound uses 5ᵏ | 10ᵏ | n!. Corollaries ten_pow_v5_dvd_factorial and not_ten_pow_succ_dvd_factorial record the two defining properties."
+    },
+    {
+      "id": "sec-min-digit",
+      "title": "Minimum Identity, Digit-Sum Form, and Instance",
+      "startLine": 92,
+      "endLine": 128,
+      "summary": "trailingZeros_eq_min (min(v₂, v₅) = v₅ via min_eq_right) and trailingZeros_eq_digit_form (the closed form (n − S₅(n))/4 from Legendre's digit-sum identity at p = 5). Two worked examples: v₅(10!) = 2 and IsGreatest {k | 10ᵏ | 10!} 2 — 10! ends in exactly two zeros."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "LegendreFactorialFormulaOQ01OQ02",
+    "lineCount": 128,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/LegendreFactorialFormulaOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Legendre, Adrien-Marie",
+      "title": "Essai sur la théorie des nombres",
+      "year": "1808",
+      "venue": "Courcier, Paris (2nd edition)",
+      "note": "Original source of the formula for the exponent of a prime in n!, of which the trailing-zero count is the standard application."
+    },
+    {
+      "authors": "Hardy, G. H.; Wright, E. M.",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "2008",
+      "venue": "Oxford University Press, 6th edition",
+      "note": "Standard reference for Legendre's formula and base-p digit-sum identities (§6)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **open question oq-02** of [`legendre-factorial-formula-oq-01`](../tree/main/src/data/proofs/legendre-factorial-formula-oq-01): *derive the trailing-zero count of n! in base 10 as min(v₂(n!), v₅(n!)) = v₅(n!) and express it via the digit-sum form.*

A trailing zero of `n!` in base 10 is a factor of `10 = 2·5`, so the number of terminal zeros is the greatest `k` with `10ᵏ ∣ n!`. Since `2` and `5` are distinct primes this is `min(v₂(n!), v₅(n!))`, and the two-adic valuation of a factorial always dominates the five-adic one, so the count collapses to

```
#trailing zeros of n! = v₅(n!) = (n − S₅(n)) / 4
```

the base-5 digit-sum form of Legendre's solved formula. This is the schoolbook rule *"to count trailing zeros of n!, count the fives"*, proved.

## What's proved (7 theorems, 0 sorries, 0 axioms)

- `padicValNat_five_le_two` — **keystone**: `v₅(n!) ≤ v₂(n!)`, via termwise comparison of Legendre floor sums over the common bound `n+1` (`⌊n/5ⁱ⌋ ≤ ⌊n/2ⁱ⌋` since `2ⁱ ≤ 5ⁱ`).
- `trailingZeros_isGreatest` — **main theorem**: `v₅(n!)` is the *greatest* `k` with `10ᵏ ∣ n!` (`IsGreatest`). Membership uses `10^{v₅} = 2^{v₅}·5^{v₅}` with both coprime prime powers dividing `n!`; the upper bound is `5ᵏ ∣ 10ᵏ ∣ n! ⟹ k ≤ v₅`.
- `ten_pow_v5_dvd_factorial`, `not_ten_pow_succ_dvd_factorial` — the two defining divisibilities.
- `trailingZeros_eq_min` — `min(v₂(n!), v₅(n!)) = v₅(n!)`.
- `trailingZeros_eq_digit_form` — the closed form `(n − S₅(n))/4`.
- Worked instance: `v₅(10!) = 2` (10! = 3628800 ends in two zeros).

## Verification

- Builds against Mathlib 4.26.0 via `./proofs/scripts/docker-build.sh Proofs.LegendreFactorialFormulaOQ01OQ02`.
- `#print axioms` on the main theorems lists only `propext`, `Classical.choice`, `Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`** (the numeric instance uses kernel `decide`, not `native_decide`).
- Status: **verified**, badge **verified**, axiomCount **0**.

Gallery entry added under `src/data/proofs/legendre-factorial-formula-oq-01-oq-02/` (meta, 4 annotations, index.ts), cross-referenced to the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)