### PR TITLE
research(derangements-convergence-oq-03-oq-01-oq-02): signed gap + sharp two-sided decay [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -828,6 +828,7 @@ import Proofs.DerangementsConvergenceOQ01
 import Proofs.DerangementsConvergenceOQ01OQ01
 import Proofs.DerangementsConvergenceOQ02
 import Proofs.DerangementsConvergenceOQ03
+import Proofs.DerangementsConvergenceOQ03OQ01OQ02
 import Proofs.DerangementsOQ02
 import Proofs.DerangementsOQ02OQ01
 import Proofs.DerangementsOQ02OQ02

--- a/proofs/Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean
@@ -1,0 +1,266 @@
+/-
+  Derangements: sign and sharp decay of the asymptotic gap  n!/e − D(n)
+  Open Question: derangements-convergence-oq-03-oq-01-oq-02
+
+  The grandparent entry (`DerangementsConvergence`) proved the convergence rate
+  `|D(n)/n! − e⁻¹| ≤ 1/(n+1)!`, and the parent (`...OQ03OQ01`) packaged the
+  resulting nearest-integer forms `D(n) = round(n!/e)` from the *absolute* bound
+  `|D(n) − n!/e| < 1/2`.
+
+  Both of those discard the **sign** of the error.  This entry recovers it.
+  Writing the signed gap
+
+      G(n)  :=  n!·e⁻¹ − D(n),
+
+  we show that `G(n)` is exactly `n!` times the alternating tail
+  `∑_{k≥n+1} (−1)ᵏ/k!`, hence
+
+    * **Sign (alternation).**  `G(n)` has the sign of `(−1)^{n+1}`:
+        - `n` even  ⟹  `D(n) > n!/e`   (`G(n) < 0`),
+        - `n` odd   ⟹  `D(n) < n!/e`   (`G(n) > 0`).
+      Equivalently `0 < (−1)^{n+1}·G(n)` for every `n`.  So the integers `D(n)`
+      straddle the real number `n!/e`, jumping above and below it alternately.
+
+    * **Sharp two-sided decay.**  For every `n`,
+        `1/(n+2) ≤ |G(n)| ≤ 1/(n+1)`.
+      The upper bound `1/(n+1)` is the grandparent rate scaled by `n!`; the lower
+      bound `1/(n+2)` is new and shows the gap does **not** decay faster than the
+      leading tail term — `|G(n)|` is squeezed between two consecutive unit
+      fractions, with `|G(n)|·(n+1) → 1`.
+
+  ## Main Results
+
+  `signed_gap_eq_factorial_mul_tail` : G(n) = n! · ∑'ₖ altFactTerm (n+1+k).
+  `gap_sign`                         : 0 < (−1)^{n+1} · G(n).
+  `gap_neg_of_even` / `gap_pos_of_odd` : the even/odd specialisations.
+  `abs_gap_le`                       : |G(n)| ≤ 1/(n+1).
+  `abs_gap_ge`                       : 1/(n+2) ≤ |G(n)|.
+  `abs_gap_bounds`                   : 1/(n+2) ≤ |G(n)| ≤ 1/(n+1).
+
+  ## Proof Strategy
+
+  Everything rests on the *signed* alternating-tail series
+      S(m) := ∑'ₖ (−1)ᵏ/(m+k)!     (here m = n+1).
+  The grandparent's helper lemmas `alt_partial_sum_nonneg`/`alt_partial_sum_le_first`
+  already give `0 ≤ S(m) ≤ 1/m!` (partial sums sandwiched, then `le_of_tendsto`).
+  Splitting off the first two terms,
+      S(m) = 1/m! − 1/(m+1)! + S(m+2),    S(m+2) ≥ 0,
+  upgrades the lower bound to the *sharp* `1/m! − 1/(m+1)! ≤ S(m)` (> 0).
+  Multiplying the sandwich `1/m! − 1/(m+1)! ≤ S(m) ≤ 1/m!` by `n!` and using
+  `n!/(n+1)! = 1/(n+1)`, `n!/(n+2)! = 1/((n+1)(n+2))` collapses the endpoints to
+  the consecutive unit fractions `1/(n+2)` and `1/(n+1)`.  The factor `(−1)^{n+1}`
+  pulled out of the tail (`altFactTerm (m+k) = (−1)ᵐ·(−1)ᵏ/(m+k)!`) supplies the
+  sign.
+
+  This is self-contained on top of the grandparent `DerangementsConvergence`; it
+  re-uses that file's alternating-series lemmas rather than re-proving them.
+-/
+
+import Mathlib
+import Proofs.DerangementsConvergence
+
+open Finset Nat Real BigOperators Filter Topology
+
+noncomputable section
+
+namespace DerangementsConvergenceOQ03OQ01OQ02
+
+/-- The signed alternating term `(−1)ᵏ/(m+k)!`.  This is `altFactTerm (m+k)` with
+the global sign `(−1)ᵐ` factored out, so it is termwise nonnegative-leading. -/
+def cTerm (m k : ℕ) : ℝ := (-1 : ℝ) ^ k / ((m + k).factorial : ℝ)
+
+lemma cTerm_zero (m : ℕ) : cTerm m 0 = 1 / (m.factorial : ℝ) := by
+  simp [cTerm]
+
+lemma cTerm_one (m : ℕ) : cTerm m 1 = -(1 / ((m + 1).factorial : ℝ)) := by
+  rw [cTerm, pow_one]; ring
+
+/-- `cTerm` shifted by two indices is `cTerm` of the shifted base: the `(−1)²`
+sign cancels. -/
+lemma cTerm_add_two (m k : ℕ) : cTerm m (k + 2) = cTerm (m + 2) k := by
+  unfold cTerm
+  rw [show m + (k + 2) = (m + 2) + k by ring, show (-1 : ℝ) ^ (k + 2) = (-1) ^ k by
+    rw [pow_add]; simp]
+
+/-- The signed alternating tail series `S(m) = ∑'ₖ (−1)ᵏ/(m+k)!` is summable.
+(Same comparison as the grandparent's `summable_altFactTerm`, reindexed.) -/
+lemma summable_cTerm (m : ℕ) : Summable (cTerm m) := by
+  have hbnd_summable : Summable (fun k => (1 : ℝ) / ((m + k).factorial : ℝ)) := by
+    have h1 : Summable (fun (k : ℕ) => (1 : ℝ) / (k.factorial : ℝ)) := by
+      simpa only [one_pow] using summable_pow_div_factorial (1 : ℝ)
+    exact h1.comp_injective (fun ⦃a b⦄ (h : m + a = m + b) => by omega)
+  refine Summable.of_norm_bounded_eventually hbnd_summable ?_
+  filter_upwards with k
+  apply le_of_eq
+  simp only [cTerm, norm_eq_abs, abs_div, abs_pow, abs_neg, abs_one, one_pow, Nat.abs_cast]
+
+/-- Lower envelope: `0 ≤ S(m)`.  Lifted from the grandparent's
+`alt_partial_sum_nonneg` via `le_of_tendsto`. -/
+lemma tsum_cTerm_nonneg (m : ℕ) : 0 ≤ ∑' k, cTerm m k := by
+  apply le_of_tendsto_of_tendsto tendsto_const_nhds
+    ((summable_cTerm m).hasSum.tendsto_sum_nat)
+  filter_upwards with N
+  exact alt_partial_sum_nonneg m N
+
+/-- Upper envelope: `S(m) ≤ 1/m!`.  Lifted from the grandparent's
+`alt_partial_sum_le_first` via `le_of_tendsto`. -/
+lemma tsum_cTerm_le_first (m : ℕ) : ∑' k, cTerm m k ≤ 1 / (m.factorial : ℝ) := by
+  apply le_of_tendsto ((summable_cTerm m).hasSum.tendsto_sum_nat)
+  filter_upwards with N
+  exact alt_partial_sum_le_first m N
+
+/-- **Sharp lower envelope.**  Peeling off the first two terms,
+`S(m) = 1/m! − 1/(m+1)! + S(m+2)` with `S(m+2) ≥ 0`, gives
+`1/m! − 1/(m+1)! ≤ S(m)`. -/
+lemma tsum_cTerm_ge_first_two (m : ℕ) :
+    1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ) ≤ ∑' k, cTerm m k := by
+  have hsplit := (summable_cTerm m).sum_add_tsum_nat_add 2
+  -- hsplit : (∑ k ∈ range 2, cTerm m k) + ∑' k, cTerm m (2 + k) = ∑' k, cTerm m k
+  have hhead : ∑ k ∈ range 2, cTerm m k =
+      1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ) := by
+    rw [Finset.sum_range_succ, Finset.sum_range_one, cTerm_zero, cTerm_one]; ring
+  have htail_nonneg : 0 ≤ ∑' k, cTerm m (k + 2) := by
+    have hcongr : ∑' k, cTerm m (k + 2) = ∑' k, cTerm (m + 2) k :=
+      tsum_congr fun k => cTerm_add_two m k
+    rw [hcongr]
+    exact tsum_cTerm_nonneg (m + 2)
+  rw [hhead] at hsplit
+  linarith [hsplit, htail_nonneg]
+end DerangementsConvergenceOQ03OQ01OQ02
+
+namespace DerangementsConvergenceOQ03OQ01OQ02
+
+/-- The grandparent's alternating tail, with the global sign factored out:
+`∑'ₖ altFactTerm (n+1+k) = (−1)^{n+1} · S(n+1)`. -/
+lemma tail_eq_sign_mul_cTerm (n : ℕ) :
+    ∑' k, altFactTerm (n + 1 + k) = (-1 : ℝ) ^ (n + 1) * ∑' k, cTerm (n + 1) k := by
+  rw [← tsum_mul_left]
+  refine tsum_congr fun k => ?_
+  simp only [altFactTerm, cTerm]
+  rw [show n + 1 + k = (n + 1) + k from rfl, pow_add, mul_div_assoc]
+
+/-- **Signed gap formula.**  The gap `G(n) = n!·e⁻¹ − D(n)` equals `n!` times the
+alternating tail `∑_{k≥n+1} (−1)ᵏ/k!`.  This is the exact (unsigned-bound-free)
+statement of the error. -/
+theorem signed_gap_eq_factorial_mul_tail (n : ℕ) :
+    (n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)
+      = (n.factorial : ℝ) * ∑' k, altFactTerm (n + 1 + k) := by
+  rw [numDerangements_eq_factorial_mul_altSum,
+    exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail n]
+  ring
+
+/-- The gap written as `(−1)^{n+1} · n! · S(n+1)` with `S(n+1) ≥ 0`. -/
+theorem signed_gap_eq_sign_form (n : ℕ) :
+    (n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)
+      = (-1 : ℝ) ^ (n + 1) * ((n.factorial : ℝ) * ∑' k, cTerm (n + 1) k) := by
+  rw [signed_gap_eq_factorial_mul_tail, tail_eq_sign_mul_cTerm]; ring
+
+/-- `n!/(m+1)! < n!/m!` packaged: the sharp lower envelope `S(m)` is strictly
+positive, since `1/m! − 1/(m+1)! > 0`. -/
+lemma tsum_cTerm_pos (n : ℕ) : 0 < ∑' k, cTerm (n + 1) k := by
+  have hlow := tsum_cTerm_ge_first_two (n + 1)
+  have hstrict : 0 < 1 / (((n + 1).factorial : ℝ)) - 1 / (((n + 1 + 1).factorial : ℝ)) := by
+    have h1 : (((n + 1).factorial : ℝ)) < (((n + 1 + 1).factorial : ℝ)) := by
+      have hnat : (n + 1).factorial < (n + 1 + 1).factorial := by
+        rw [Nat.factorial_lt (by omega : 0 < n + 1)]; omega
+      exact_mod_cast hnat
+    have hp1 := factorial_cast_pos' (n + 1)
+    have hp2 := factorial_cast_pos' (n + 1 + 1)
+    rw [sub_pos]
+    exact one_div_lt_one_div_of_lt hp1 h1
+  linarith
+
+/-- **Sign of the gap (alternation).**  For every `n`,
+`0 < (−1)^{n+1} · (n!·e⁻¹ − D(n))`.  Thus `D(n)` lies strictly on the side of
+`n!/e` dictated by the parity of `n`: the derangement counts straddle `n!/e`. -/
+theorem gap_sign (n : ℕ) :
+    0 < (-1 : ℝ) ^ (n + 1) * ((n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)) := by
+  rw [signed_gap_eq_sign_form]
+  have hsq : (-1 : ℝ) ^ (n + 1) * ((-1 : ℝ) ^ (n + 1) *
+      ((n.factorial : ℝ) * ∑' k, cTerm (n + 1) k))
+      = (n.factorial : ℝ) * ∑' k, cTerm (n + 1) k := by
+    rw [← mul_assoc, ← pow_add, ← two_mul, pow_mul]; simp
+  rw [hsq]
+  exact mul_pos (factorial_cast_pos' n) (tsum_cTerm_pos n)
+
+/-- For even `n`, the derangement count exceeds `n!/e`:  `D(n) > n!/e`. -/
+theorem gap_neg_of_even (n : ℕ) (hn : Even n) :
+    (n.factorial : ℝ) * rexp (-1) < (numDerangements n : ℝ) := by
+  have h := gap_sign n
+  have hsign : (-1 : ℝ) ^ (n + 1) = -1 := by
+    rw [pow_succ, hn.neg_one_pow]; ring
+  rw [hsign] at h
+  nlinarith [h]
+
+/-- For odd `n`, the derangement count is below `n!/e`:  `D(n) < n!/e`. -/
+theorem gap_pos_of_odd (n : ℕ) (hn : Odd n) :
+    (numDerangements n : ℝ) < (n.factorial : ℝ) * rexp (-1) := by
+  have h := gap_sign n
+  have hsign : (-1 : ℝ) ^ (n + 1) = 1 := by
+    rw [pow_succ, hn.neg_one_pow]; ring
+  rw [hsign] at h
+  nlinarith [h]
+
+/-- Helper: `n!/(n+1)! = 1/(n+1)` as reals. -/
+lemma factorial_ratio_succ (n : ℕ) :
+    (n.factorial : ℝ) / ((n + 1).factorial : ℝ) = 1 / (n + 1 : ℝ) := by
+  rw [Nat.factorial_succ]; push_cast
+  have hn : (n.factorial : ℝ) ≠ 0 := factorial_cast_ne_zero' n
+  have hn1 : (n + 1 : ℝ) ≠ 0 := by positivity
+  field_simp
+
+/-- Helper: `n!/(n+2)! = 1/((n+1)(n+2))` as reals. -/
+lemma factorial_ratio_succ_succ (n : ℕ) :
+    (n.factorial : ℝ) / ((n + 2).factorial : ℝ) = 1 / ((n + 1 : ℝ) * (n + 2 : ℝ)) := by
+  rw [show n + 2 = (n + 1) + 1 by ring, Nat.factorial_succ, Nat.factorial_succ]
+  push_cast
+  field_simp
+  ring
+
+/-- The absolute gap equals `n! · S(n+1)`. -/
+lemma abs_gap_eq (n : ℕ) :
+    |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)|
+      = (n.factorial : ℝ) * ∑' k, cTerm (n + 1) k := by
+  rw [signed_gap_eq_sign_form, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul,
+    abs_of_nonneg]
+  exact mul_nonneg (factorial_cast_pos' n).le (tsum_cTerm_nonneg (n + 1))
+
+/-- **Upper decay bound.**  `|n!·e⁻¹ − D(n)| ≤ 1/(n+1)` (the grandparent rate,
+scaled by `n!`). -/
+theorem abs_gap_le (n : ℕ) :
+    |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)| ≤ 1 / (n + 1 : ℝ) := by
+  rw [abs_gap_eq]
+  calc (n.factorial : ℝ) * ∑' k, cTerm (n + 1) k
+      ≤ (n.factorial : ℝ) * (1 / ((n + 1).factorial : ℝ)) :=
+        mul_le_mul_of_nonneg_left (tsum_cTerm_le_first (n + 1)) (factorial_cast_pos' n).le
+    _ = (n.factorial : ℝ) / ((n + 1).factorial : ℝ) := by rw [mul_one_div]
+    _ = 1 / (n + 1 : ℝ) := factorial_ratio_succ n
+
+/-- **Sharp lower decay bound.**  `1/(n+2) ≤ |n!·e⁻¹ − D(n)|`.  This is the new
+content: the gap does not decay faster than the leading tail term. -/
+theorem abs_gap_ge (n : ℕ) :
+    1 / (n + 2 : ℝ) ≤ |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)| := by
+  rw [abs_gap_eq]
+  have hkey : (n.factorial : ℝ) *
+      (1 / (((n + 1).factorial : ℝ)) - 1 / (((n + 1 + 1).factorial : ℝ)))
+      = 1 / (n + 2 : ℝ) := by
+    rw [mul_sub, mul_one_div, mul_one_div]
+    rw [show n + 1 + 1 = n + 2 by ring, factorial_ratio_succ n, factorial_ratio_succ_succ n]
+    have hn1 : (n + 1 : ℝ) ≠ 0 := by positivity
+    have hn2 : (n + 2 : ℝ) ≠ 0 := by positivity
+    field_simp
+    ring
+  calc 1 / (n + 2 : ℝ)
+      = (n.factorial : ℝ) *
+          (1 / (((n + 1).factorial : ℝ)) - 1 / (((n + 1 + 1).factorial : ℝ))) := hkey.symm
+    _ ≤ (n.factorial : ℝ) * ∑' k, cTerm (n + 1) k :=
+        mul_le_mul_of_nonneg_left (tsum_cTerm_ge_first_two (n + 1)) (factorial_cast_pos' n).le
+
+/-- **Sharp two-sided decay.**  The gap is squeezed between consecutive unit
+fractions:  `1/(n+2) ≤ |n!·e⁻¹ − D(n)| ≤ 1/(n+1)`. -/
+theorem abs_gap_bounds (n : ℕ) :
+    1 / (n + 2 : ℝ) ≤ |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)|
+      ∧ |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)| ≤ 1 / (n + 1 : ℝ) :=
+  ⟨abs_gap_ge n, abs_gap_le n⟩
+
+end DerangementsConvergenceOQ03OQ01OQ02

--- a/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "derangements-convergence-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 65
+    },
+    "type": "context",
+    "title": "Recovering the Sign and Sharp Rate of the Derangement Gap",
+    "content": "The grandparent proved $|D(n)/n! - e^{-1}| \\le 1/(n+1)!$ and the parent packaged $D(n) = \\mathrm{round}(n!/e)$ from $|D(n) - n!/e| < 1/2$ — both using the error only in absolute value. This entry studies the **signed** gap $G(n) = n!\\,e^{-1} - D(n)$ directly. The headline results: $G(n)$ has the sign of $(-1)^{n+1}$ (so $D(n)$ alternately exceeds and falls short of $n!/e$), and $1/(n+2) \\le |G(n)| \\le 1/(n+1)$ for every $n$. The lower bound is the genuinely new content; it answers the parent's own closing open question verbatim.",
+    "mathContext": "$G(n) = n!\\,e^{-1} - D(n) = n!\\sum_{k \\ge n+1} \\frac{(-1)^k}{k!}$, with $\\operatorname{sign} G(n) = (-1)^{n+1}$ and $\\frac{1}{n+2} \\le |G(n)| \\le \\frac{1}{n+1}$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "derangements",
+      "alternating series",
+      "asymptotic expansion",
+      "Euler's number"
+    ],
+    "prerequisites": [
+      "alternating series estimation",
+      "infinite sums (tsum)"
+    ]
+  },
+  {
+    "id": "ann-cterm-envelopes",
+    "proofId": "derangements-convergence-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 66,
+      "endLine": 131
+    },
+    "type": "technique",
+    "title": "The Sign-Factored Tail and Its Sharp Lower Envelope",
+    "content": "Writing $c_k = (-1)^k/(m+k)!$ (the tail term with the global sign $(-1)^m$ removed), the base entry's partial-sum lemmas $\\texttt{alt\\_partial\\_sum\\_nonneg}$ and $\\texttt{alt\\_partial\\_sum\\_le\\_first}$ give $0 \\le S(m) \\le 1/m!$ after $\\texttt{le\\_of\\_tendsto}$. The new ingredient is $\\texttt{tsum\\_cTerm\\_ge\\_first\\_two}$: peeling the first two terms via $\\texttt{Summable.sum\\_add\\_tsum\\_nat\\_add 2}$ writes $S(m) = 1/m! - 1/(m+1)! + S(m+2)$ with $S(m+2) \\ge 0$ (the same nonnegativity, reindexed by $\\texttt{cTerm\\_add\\_two}$), upgrading the lower bound to the sharp $1/m! - 1/(m+1)! \\le S(m)$.",
+    "mathContext": "$S(m) = \\sum_{k \\ge 0} \\frac{(-1)^k}{(m+k)!}$; Leibniz gives $a_0 - a_1 \\le S(m) \\le a_0$ with $a_k = 1/(m+k)!$, i.e. $\\frac{1}{m!} - \\frac{1}{(m+1)!} \\le S(m) \\le \\frac{1}{m!}$.",
+    "significance": "Sharp envelopes for an alternating tail, obtained by lifting the base entry's finite partial-sum bounds and peeling two terms — this is what makes both the strict sign and the lower decay bound possible.",
+    "relatedConcepts": [
+      "alternating series estimation",
+      "tail of a convergent series",
+      "Leibniz criterion"
+    ],
+    "prerequisites": [
+      "summability",
+      "le_of_tendsto"
+    ]
+  },
+  {
+    "id": "ann-gap-formula",
+    "proofId": "derangements-convergence-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 132,
+      "endLine": 161
+    },
+    "type": "key-step",
+    "title": "Signed Gap as a Scaled Alternating Tail",
+    "content": "Substituting $D(n) = n!\\cdot(\\text{partial sum})$ and $e^{-1} = (\\text{partial sum}) + (\\text{tail})$ (base lemmas $\\texttt{numDerangements\\_eq\\_factorial\\_mul\\_altSum}$, $\\texttt{exp\\_neg\\_one\\_eq\\_tsum\\_alt}$, $\\texttt{tsum\\_eq\\_partial\\_sum\\_add\\_tail}$) collapses the partial sums and leaves $G(n) = n!\\cdot\\sum_{k \\ge n+1}(-1)^k/k!$ exactly — $\\texttt{ring}$ closes it. Then $\\texttt{tail\\_eq\\_sign\\_mul\\_cTerm}$ factors $\\mathrm{altFactTerm}(n+1+k) = (-1)^{n+1}c_k$ and pulls $(-1)^{n+1}$ out via $\\texttt{tsum\\_mul\\_left}$, giving the sign form $G(n) = (-1)^{n+1}\\,n!\\,S(n+1)$ with $S(n+1) \\ge 0$.",
+    "mathContext": "$G(n) = n!\\sum_{k \\ge n+1}\\frac{(-1)^k}{k!} = (-1)^{n+1}\\,n!\\,S(n+1)$, $\\quad S(n+1) = \\sum_{k\\ge 0}\\frac{(-1)^k}{(n+1+k)!} \\ge 0$.",
+    "significance": "The exact signed identity for the gap — every downstream sign and bound is read off this single equation.",
+    "relatedConcepts": [
+      "tsum_mul_left",
+      "telescoping partial sums",
+      "Taylor remainder"
+    ],
+    "prerequisites": [
+      "infinite sums",
+      "factoring constants out of a sum"
+    ]
+  },
+  {
+    "id": "ann-sign",
+    "proofId": "derangements-convergence-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 162,
+      "endLine": 224
+    },
+    "type": "key-step",
+    "title": "The Counts Straddle n!/e",
+    "content": "Since $S(n+1) \\ge 1/(n+1)! - 1/(n+2)! > 0$ ($\\texttt{tsum\\_cTerm\\_pos}$) and $n! > 0$, multiplying the sign form by $(-1)^{n+1}$ kills the sign (the square $((-1)^{n+1})^2 = 1$) and leaves $(-1)^{n+1}G(n) = n!\\,S(n+1) > 0$ ($\\texttt{gap\\_sign}$). Specialising $(-1)^{n+1} = -1$ for even $n$ and $+1$ for odd $n$ gives $D(n) > n!/e$ (even, $\\texttt{gap\\_neg\\_of\\_even}$) and $D(n) < n!/e$ (odd, $\\texttt{gap\\_pos\\_of\\_odd}$): the integers $D(n)$ oscillate around $n!/e$.",
+    "mathContext": "$0 < (-1)^{n+1}G(n)$; even $n \\Rightarrow n!/e < D(n)$, odd $n \\Rightarrow D(n) < n!/e$.",
+    "significance": "The sign result: $D(n)$ does not approach $n!/e$ monotonically from one side — the discrete signature of the alternating series for $e^{-1}$.",
+    "relatedConcepts": [
+      "parity",
+      "alternating convergence",
+      "subfactorial"
+    ],
+    "prerequisites": [
+      "Even.neg_one_pow / Odd.neg_one_pow"
+    ]
+  },
+  {
+    "id": "ann-decay",
+    "proofId": "derangements-convergence-oq-03-oq-01-oq-02",
+    "range": {
+      "startLine": 225,
+      "endLine": 271
+    },
+    "type": "key-step",
+    "title": "Squeezed Between Consecutive Unit Fractions",
+    "content": "From $|G(n)| = n!\\,S(n+1)$ ($\\texttt{abs\\_gap\\_eq}$), multiply the envelope $1/m! - 1/(m+1)! \\le S(m) \\le 1/m!$ ($m = n+1$) by $n!$. Using $n!/(n+1)! = 1/(n+1)$ and $n!/(n+2)! = 1/((n+1)(n+2))$ the endpoints collapse: the upper bound is $1/(n+1)$ ($\\texttt{abs\\_gap\\_le}$) and the lower bound is $1/(n+1) - 1/((n+1)(n+2)) = 1/(n+2)$ ($\\texttt{abs\\_gap\\_ge}$). Hence $1/(n+2) \\le |G(n)| \\le 1/(n+1)$ ($\\texttt{abs\\_gap\\_bounds}$), so $|G(n)|\\cdot(n+1) \\to 1$ — the rate is sharp at the leading term.",
+    "mathContext": "$\\frac{1}{n+2} \\le |n!\\,e^{-1} - D(n)| \\le \\frac{1}{n+1}$, with $\\frac{1}{n+1} - \\frac{1}{(n+1)(n+2)} = \\frac{1}{n+2}$.",
+    "significance": "The new lower bound completes the parent's one-sided $< 1/2$ estimate into a sharp two-sided sandwich, showing no faster-than-$1/(n+1)$ decay is possible.",
+    "relatedConcepts": [
+      "factorial ratios",
+      "consecutive unit fractions",
+      "sharp rate of convergence"
+    ],
+    "prerequisites": [
+      "factorial identities",
+      "monotonicity of multiplication"
+    ]
+  }
+]

--- a/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/index.ts
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const derangementsConvergenceOQ03OQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const derangementsConvergenceOQ03OQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const derangementsConvergenceOQ03OQ01OQ02Data: ProofData = {
+  proof: derangementsConvergenceOQ03OQ01OQ02Proof,
+  annotations: derangementsConvergenceOQ03OQ01OQ02Annotations,
+}

--- a/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03-oq-01-oq-02/meta.json
@@ -1,0 +1,265 @@
+{
+  "id": "derangements-convergence-oq-03-oq-01-oq-02",
+  "title": "Sign and sharp decay of the gap n!/e − D(n)",
+  "slug": "derangements-convergence-oq-03-oq-01-oq-02",
+  "description": "Sharpens the absolute bound |D(n) − n!/e| < 1/2 (parent) into a signed, two-sided statement. The signed gap G(n) = n!·e⁻¹ − D(n) equals n! times the alternating tail ∑_{k≥n+1} (−1)^k/k!, so (i) it has the sign of (−1)^{n+1} — D(n) straddles n!/e, exceeding it for even n and falling short for odd n — and (ii) it is squeezed between consecutive unit fractions, 1/(n+2) ≤ |G(n)| ≤ 1/(n+1), for every n ≥ 0. The lower bound 1/(n+2) is new content: the gap does not decay faster than the leading tail term. Built self-containedly on the base entry's alternating-series lemmas.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "derangements",
+      "asymptotics",
+      "alternating-series",
+      "exponential",
+      "number-theory",
+      "analysis",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "No assumptions. Fully machine-checked, 0 axioms, 0 sorries. The file depends only on the base entry DerangementsConvergence.lean, re-using its alternating-series helper lemmas (alt_partial_sum_nonneg, alt_partial_sum_le_first) and the derangement/exponential series identities (numDerangements_eq_factorial_mul_altSum, exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail) rather than re-proving them. All bounds hold for every n ≥ 0 (no n ≥ 2 restriction).",
+    "dateAdded": "2026-06-23",
+    "lineCount": 266,
+    "theoremCount": 20,
+    "definitionCount": 1,
+    "originalContributions": [
+      "signed_gap_eq_factorial_mul_tail (PROVED): G(n) := n!·e⁻¹ − D(n) = n! · ∑'ₖ altFactTerm(n+1+k) — the exact signed-gap identity, the alternating tail with no absolute value taken",
+      "gap_sign (PROVED): 0 < (−1)^{n+1} · G(n) for every n — the derangement counts straddle n!/e, alternating which side they fall on",
+      "gap_neg_of_even (PROVED): for even n, n!·e⁻¹ < D(n) (D(n) overshoots n!/e)",
+      "gap_pos_of_odd (PROVED): for odd n, D(n) < n!·e⁻¹ (D(n) undershoots n!/e)",
+      "abs_gap_ge (PROVED): 1/(n+2) ≤ |G(n)| — the NEW sharp lower bound; the gap does not decay faster than the leading tail term, obtained from the peeled envelope S(n+1) ≥ 1/(n+1)! − 1/(n+2)!",
+      "abs_gap_le (PROVED): |G(n)| ≤ 1/(n+1) — the base rate bound 1/(n+1)! scaled by n!",
+      "abs_gap_bounds (PROVED): 1/(n+2) ≤ |G(n)| ≤ 1/(n+1) — the full two-sided sandwich between consecutive unit fractions",
+      "tsum_cTerm_ge_first_two (PROVED): sharp lower envelope 1/m! − 1/(m+1)! ≤ ∑'ₖ (−1)^k/(m+k)!, obtained by peeling the first two terms and using nonnegativity of the shifted tail S(m+2) ≥ 0",
+      "tsum_cTerm_pos (PROVED): strict positivity 0 < S(n+1) of the signed tail, which supplies the strict sign in gap_sign"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "numDerangements_eq_factorial_mul_altSum",
+        "description": "D(n) = n!·Σ_{k=0}^n (−1)^k/k! — the Montmort/Euler identity, from the base entry",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "exp_neg_one_eq_tsum_alt",
+        "description": "e⁻¹ = Σ_{k≥0} (−1)^k/k! — the exponential series at −1, from the base entry",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "tsum_eq_partial_sum_add_tail",
+        "description": "splits e⁻¹ into the n-th partial sum plus the tail Σ_{k≥n+1}, exposing G(n) = n!·(tail)",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "alt_partial_sum_nonneg",
+        "description": "partial sums of (−1)^k/(m+k)! are ≥ 0 — the lower envelope of the alternating series, from the base entry",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "alt_partial_sum_le_first",
+        "description": "partial sums of (−1)^k/(m+k)! are ≤ 1/m! — the upper envelope, from the base entry",
+        "module": "Proofs.DerangementsConvergence"
+      },
+      {
+        "theorem": "Summable.sum_add_tsum_nat_add",
+        "description": "Σ_{k<N} a_k + Σ'_k a_{N+k} = Σ'_k a_k — peels the first two terms to sharpen the lower envelope",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.NatInt"
+      },
+      {
+        "theorem": "tsum_mul_left",
+        "description": "Σ'_k (c · a_k) = c · Σ'_k a_k — pulls the global sign (−1)^{n+1} out of the tail",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Ring"
+      },
+      {
+        "theorem": "le_of_tendsto / le_of_tendsto_of_tendsto",
+        "description": "limit of a convergent net inherits ≤ bounds satisfied eventually — lifts the partial-sum envelopes to the tsum",
+        "module": "Mathlib.Order.Topology.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Montmort (1708) and Euler (1751) gave D(n) = n!·Σ_{k=0}^n (−1)^k/k!, whose alternating tail makes D(n)/n! → e⁻¹. The textbook strengthening D(n) = round(n!/e) (the grandparent open question OQ-03) and its floor/ceiling repackaging (the parent OQ-03-OQ-01) both rest on the absolute bound |D(n) − n!/e| < 1/2 — and both discard the sign of the error. The parent's own closing open question asked to 'quantify the gap n!/e − D(n) as n → ∞: it is the alternating tail ±1/(n+1) + …, so its sign and decay could be recorded.' This entry answers exactly that: it recovers the sign (−1)^{n+1} and sharpens the one-sided 1/2 estimate to a two-sided sandwich between consecutive unit fractions.",
+    "problemStatement": "**OQ-03-OQ-01-OQ-02 of derangements-convergence**\n\nDetermine the sign and the sharp rate of decay of the signed gap\n\n  G(n) := n!·e⁻¹ − D(n).\n\nShow G(n) is the alternating tail n!·Σ_{k≥n+1} (−1)^k/k!, deduce its sign alternates with parity of n, and bound |G(n)| above and below by consecutive unit fractions.",
+    "text": "For every n ≥ 0: 0 < (−1)^{n+1}·(n!·e⁻¹ − D(n)) and 1/(n+2) ≤ |n!·e⁻¹ − D(n)| ≤ 1/(n+1). Equivalently D(n) > n!/e for even n and D(n) < n!/e for odd n, with |n!/e − D(n)| trapped strictly between 1/(n+2) and 1/(n+1).",
+    "proofStrategy": "**Signed tail, then envelopes:**\n1. **Signed gap = scaled tail** (`signed_gap_eq_factorial_mul_tail`): substitute D(n) = n!·(partial sum) and e⁻¹ = partial sum + tail (base lemmas), so G(n) = n!·Σ_{k≥n+1} (−1)^k/k! with no absolute value.\n2. **Factor the sign** (`tail_eq_sign_mul_cTerm`): altFactTerm(n+1+k) = (−1)^{n+1}·cTerm(n+1,k) where cTerm(m,k) = (−1)^k/(m+k)!; `tsum_mul_left` pulls (−1)^{n+1} out, leaving the sign-stable series S(m) = Σ'ₖ cTerm(m,k).\n3. **Envelopes for S(m)**: the base helper lemmas give 0 ≤ S(m) ≤ 1/m! by `le_of_tendsto` on the partial sums. Peeling the first two terms (`Summable.sum_add_tsum_nat_add 2`) and using S(m+2) ≥ 0 sharpens this to 1/m! − 1/(m+1)! ≤ S(m), which is strictly positive.\n4. **Sign**: G(n) = (−1)^{n+1}·n!·S(n+1) with n!·S(n+1) > 0, so (−1)^{n+1}·G(n) = n!·S(n+1) > 0; even/odd specialisations follow from (−1)^{n+1} = ∓1.\n5. **Decay**: |G(n)| = n!·S(n+1); multiply the sandwich 1/m! − 1/(m+1)! ≤ S(m) ≤ 1/m! (m = n+1) by n! and simplify n!/(n+1)! = 1/(n+1), n!/(n+2)! = 1/((n+1)(n+2)) so the endpoints collapse to 1/(n+2) and 1/(n+1).",
+    "keyInsights": [
+      "The absolute bound |D(n) − n!/e| < 1/2 of the parent throws away two pieces of information that this entry recovers: the sign of the error and a matching lower bound. Both come from looking at the alternating tail signed rather than in absolute value.",
+      "The sign (−1)^{n+1} means the integer sequence D(n) does not approach n!/e monotonically from one side — it alternates above and below, overshooting for even n and undershooting for odd n. This is the discrete signature of an alternating series.",
+      "The sharp lower bound 1/(n+2) is obtained by the standard alternating-series trick of peeling two terms: S(m) ≥ a₀ − a₁ = 1/m! − 1/(m+1)!. Scaled by n! this is exactly 1/(n+1) − 1/((n+1)(n+2)) = 1/(n+2), so |G(n)| is trapped between two consecutive unit fractions and |G(n)|·(n+1) → 1.",
+      "Reuse over re-proof: the base entry already proved the two-sided partial-sum envelopes (alt_partial_sum_nonneg, alt_partial_sum_le_first) for the alternating series. This entry lifts them to the infinite sum with le_of_tendsto and adds only the two-term peel needed for the sharp lower bound — no new analysis from scratch.",
+      "Honest scope: this is a sharpening corollary of an existing convergence rate, not new mathematics about derangements. Its value is closing the parent's explicitly stated open question with the sign and a matched lower bound, all at 0 axioms."
+    ],
+    "prerequisites": [
+      "numDerangements_eq_factorial_mul_altSum, exp_neg_one_eq_tsum_alt, tsum_eq_partial_sum_add_tail, alt_partial_sum_nonneg, alt_partial_sum_le_first from DerangementsConvergence.lean",
+      "Summable.sum_add_tsum_nat_add, tsum_mul_left, le_of_tendsto from Mathlib",
+      "Alternating series estimation (Leibniz): partial sums sandwich the limit; peeling terms sharpens the bound",
+      "Basic factorial ratio identities n!/(n+1)! = 1/(n+1), n!/(n+2)! = 1/((n+1)(n+2))"
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 65,
+      "description": "Documents the signed-gap goal, states the sign (−1)^{n+1} and the two-sided sandwich 1/(n+2) ≤ |G(n)| ≤ 1/(n+1), and records the self-contained design over the base DerangementsConvergence entry."
+    },
+    {
+      "id": "sec-cterm",
+      "title": "The sign-factored alternating tail S(m)",
+      "startLine": 66,
+      "endLine": 131,
+      "description": "Defines cTerm(m,k) = (−1)^k/(m+k)! (the global sign factored out), proves summability and the two-sided envelopes 0 ≤ S(m) ≤ 1/m! (lifted from the base partial-sum lemmas), and the sharp lower envelope 1/m! − 1/(m+1)! ≤ S(m) by peeling the first two terms."
+    },
+    {
+      "id": "sec-gap-formula",
+      "title": "Signed gap as a scaled alternating tail",
+      "startLine": 132,
+      "endLine": 161,
+      "description": "tail_eq_sign_mul_cTerm pulls the sign (−1)^{n+1} out of the tail; signed_gap_eq_factorial_mul_tail and signed_gap_eq_sign_form express G(n) = n!·tail = (−1)^{n+1}·n!·S(n+1)."
+    },
+    {
+      "id": "sec-sign",
+      "title": "Sign of the gap (alternation)",
+      "startLine": 162,
+      "endLine": 224,
+      "description": "tsum_cTerm_pos (strict positivity of S(n+1)), gap_sign (0 < (−1)^{n+1}·G(n)), and the even/odd specialisations gap_neg_of_even (D(n) > n!/e) and gap_pos_of_odd (D(n) < n!/e)."
+    },
+    {
+      "id": "sec-decay",
+      "title": "Sharp two-sided decay",
+      "startLine": 225,
+      "endLine": 271,
+      "description": "Factorial ratio helpers, abs_gap_eq (|G(n)| = n!·S(n+1)), the upper bound abs_gap_le (≤ 1/(n+1)), the new lower bound abs_gap_ge (≥ 1/(n+2)), and the combined sandwich abs_gap_bounds."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "derangements-convergence-oq-03-oq-01",
+      "relationship": "extends",
+      "description": "Parent: proves the floor/ceiling/round forms from the absolute bound |D(n) − n!/e| < 1/2 and explicitly poses (as a closing open question) the quantification of the signed gap that this entry answers."
+    },
+    {
+      "targetId": "derangements-convergence",
+      "relationship": "depends-on",
+      "description": "Base entry: supplies the derangement/exponential series identities and the alternating-series partial-sum envelopes that this entry lifts to the infinite tail."
+    },
+    {
+      "targetId": "derangements-convergence-oq-03",
+      "relationship": "related",
+      "description": "Grandparent: the nearest-integer identity D(n) = round(n!/e); this entry records the signed error that the rounding discards."
+    }
+  ],
+  "conclusion": {
+    "summary": "The signed gap G(n) = n!·e⁻¹ − D(n) is exactly n! times the alternating tail Σ_{k≥n+1} (−1)^k/k!. Hence it has the sign of (−1)^{n+1} — the derangement counts straddle n!/e, overshooting for even n and undershooting for odd n — and its magnitude is squeezed between consecutive unit fractions, 1/(n+2) ≤ |G(n)| ≤ 1/(n+1), for every n ≥ 0. This recovers the sign and a matching lower bound that the parent's absolute estimate |D(n) − n!/e| < 1/2 discarded.",
+    "implications": [
+      "D(n) approaches n!/e by alternating around it, not from one side: the sign (−1)^{n+1} is the discrete fingerprint of the alternating Taylor series for e⁻¹.",
+      "The two-sided sandwich shows the convergence rate is sharp at the leading term: |G(n)|·(n+1) → 1, so no faster-than-1/(n+1) decay is possible and the parent's < 1/2 bound is far from tight for large n.",
+      "Methodologically, the entry demonstrates lifting partial-sum envelopes of an alternating series to the infinite tail (le_of_tendsto) and sharpening the lower bound by a two-term peel — a reusable pattern for any alternating-tail remainder estimate."
+    ],
+    "openQuestions": [
+      "Asymptotic expansion: refine 1/(n+2) ≤ |G(n)| ≤ 1/(n+1) to |G(n)| = 1/(n+1) − 1/((n+1)(n+2)) + O(1/n³), i.e. extract the full alternating expansion of the tail as a divergent asymptotic series in 1/n.",
+      "Transfer the signed-tail technique to the closely related count of partial derangements (rencontres numbers D(n,k)) and quantify the sign and rate of D(n,k) − n!/(k!·e)."
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "signed_gap_eq_factorial_mul_tail",
+      "type": "core",
+      "description": "The signed gap G(n) = n!·e⁻¹ − D(n) equals n! times the alternating tail Σ_{k≥n+1} (−1)^k/k! — the exact error with no absolute value taken.",
+      "leanType": "(n : ℕ) : (n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ) = (n.factorial : ℝ) * ∑' k, altFactTerm (n + 1 + k)"
+    },
+    {
+      "name": "gap_sign",
+      "type": "main",
+      "description": "The gap has the sign of (−1)^{n+1}: 0 < (−1)^{n+1}·(n!·e⁻¹ − D(n)) for every n. The derangement counts straddle n!/e.",
+      "leanType": "(n : ℕ) : 0 < (-1 : ℝ) ^ (n + 1) * ((n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ))"
+    },
+    {
+      "name": "gap_neg_of_even",
+      "type": "main",
+      "description": "For even n the derangement count overshoots n!/e: n!·e⁻¹ < D(n).",
+      "leanType": "(n : ℕ) (hn : Even n) : (n.factorial : ℝ) * rexp (-1) < (numDerangements n : ℝ)"
+    },
+    {
+      "name": "gap_pos_of_odd",
+      "type": "main",
+      "description": "For odd n the derangement count undershoots n!/e: D(n) < n!·e⁻¹.",
+      "leanType": "(n : ℕ) (hn : Odd n) : (numDerangements n : ℝ) < (n.factorial : ℝ) * rexp (-1)"
+    },
+    {
+      "name": "abs_gap_ge",
+      "type": "main",
+      "description": "Sharp lower decay bound (new content): 1/(n+2) ≤ |n!·e⁻¹ − D(n)|. The gap does not decay faster than the leading tail term.",
+      "leanType": "(n : ℕ) : 1 / (n + 2 : ℝ) ≤ |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)|"
+    },
+    {
+      "name": "abs_gap_le",
+      "type": "main",
+      "description": "Upper decay bound: |n!·e⁻¹ − D(n)| ≤ 1/(n+1) — the base rate 1/(n+1)! scaled by n!.",
+      "leanType": "(n : ℕ) : |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)| ≤ 1 / (n + 1 : ℝ)"
+    },
+    {
+      "name": "abs_gap_bounds",
+      "type": "main",
+      "description": "Full two-sided sandwich between consecutive unit fractions: 1/(n+2) ≤ |n!·e⁻¹ − D(n)| ≤ 1/(n+1).",
+      "leanType": "(n : ℕ) : 1 / (n + 2 : ℝ) ≤ |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)| ∧ |(n.factorial : ℝ) * rexp (-1) - (numDerangements n : ℝ)| ≤ 1 / (n + 1 : ℝ)"
+    },
+    {
+      "name": "tsum_cTerm_ge_first_two",
+      "type": "lemma",
+      "description": "Sharp lower envelope of the signed alternating tail: 1/m! − 1/(m+1)! ≤ Σ'ₖ (−1)^k/(m+k)!, by peeling the first two terms and using nonnegativity of the shifted tail.",
+      "leanType": "(m : ℕ) : 1 / (m.factorial : ℝ) - 1 / ((m + 1).factorial : ℝ) ≤ ∑' k, cTerm m k"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DerangementsConvergence"
+    ],
+    "opens": [
+      "Finset",
+      "Nat",
+      "Real",
+      "BigOperators",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "DerangementsConvergenceOQ03OQ01OQ02",
+    "lineCount": 266,
+    "axiomCount": 0,
+    "theoremCount": 20,
+    "substantiveTheoremCount": 8,
+    "duplicateTheorems": 0,
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsConvergenceOQ03OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Pierre de Montmort",
+      "title": "Essay d'analyse sur les jeux de hazard",
+      "year": "1708",
+      "venue": "Paris: Jacque Quillau (2nd ed. 1713)",
+      "note": "Derangement formula D(n) = n!·Σ_{k=0}^n (−1)^k/k!, whose alternating tail is exactly the signed gap quantified here."
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Calcul de la probabilité dans le jeu de rencontre",
+      "year": "1751",
+      "venue": "Mémoires de l'Académie de Berlin 7, pp. 255–270",
+      "note": "States D(n)/n! → e⁻¹; the rate and sign of this convergence are the subject of this entry."
+    },
+    {
+      "authors": "Gottfried Wilhelm Leibniz",
+      "title": "Alternating series test",
+      "year": "1682",
+      "venue": "letter to Jean Paul de la Roque",
+      "note": "Partial sums of an alternating series with decreasing terms sandwich the limit; peeling terms sharpens the bound — the engine behind the two-sided sandwich 1/(n+2) ≤ |G(n)| ≤ 1/(n+1)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers an open question of `derangements-convergence-oq-03-oq-01`: it **recovers the sign** that the parent's *absolute* bound `|D(n) − n!/e| < 1/2` discards.

Writing the signed gap `G(n) := n!·e⁻¹ − D(n)`, this entry proves:

- **Sign / alternation** — `0 < (−1)^{n+1}·G(n)` for every `n`. So `D(n)` straddles `n!/e`, landing above it for even `n` (`gap_neg_of_even`) and below for odd `n` (`gap_pos_of_odd`).
- **Sharp two-sided decay** — `1/(n+2) ≤ |G(n)| ≤ 1/(n+1)` (`abs_gap_bounds`). The upper bound is the grandparent rate scaled by `n!`; the lower bound `1/(n+2)` is new and shows the gap does **not** decay faster than the leading tail term — `|G(n)|·(n+1) → 1`.
- **Exact formula** — `G(n) = n!·∑_{k≥n+1} (−1)ᵏ/k!` (`signed_gap_eq_factorial_mul_tail`).

The argument peels the first two terms off the signed alternating tail `S(m)=∑'ₖ(−1)ᵏ/(m+k)!`, upgrading the grandparent's envelope `0 ≤ S(m) ≤ 1/m!` to the sharp `1/m! − 1/(m+1)! ≤ S(m) ≤ 1/m!`, then scales by `n!` to collapse the endpoints to consecutive unit fractions. Self-contained on top of the grandparent's alternating-series lemmas (no re-proving).

## Verification

- **Status:** verified / 0 axioms / 0 sorries — 266 lines, 20 thm + 1 def.
- Compiled on host with Lean v4.26.0 against the repo's Mathlib oleans (docker build wrapper was unavailable under concurrent swarm load — shared mathlib cache permission errors).
- `#print axioms` on all headline theorems (`abs_gap_bounds`, `gap_sign`, `signed_gap_eq_factorial_mul_tail`, `gap_neg_of_even`, `gap_pos_of_odd`) reports only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)