### PR TITLE
research(burnside-counting-oq-04-oq-01): kernel-verified |bracelets(4,2)|=6, no native_decide [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/BurnsideCountingOQ04OQ01.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ01.lean
@@ -1,0 +1,131 @@
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.GroupTheory.SpecificGroups.Dihedral
+import Mathlib.Data.Fintype.Card
+import Mathlib.Tactic
+
+/-
+# Burnside Counting, OQ-04-OQ-01: Axiom-free binary bracelets of length 4
+
+## What This Proves
+
+The parent entry `burnside-counting` and its dihedral extension `burnside-counting-oq-04`
+establish that there are exactly `6` binary **bracelets** of length 4 (orbits of the
+2-colourings of a square under the full dihedral symmetry group `D_4` of rotations *and*
+reflections).  Both close the final numeric count with `native_decide`, which trusts the
+Lean compiler and therefore depends on the `Lean.ofReduceBool` axiom.
+
+This file removes that dependency.  We build a *concrete* action of `DihedralGroup 4` on the
+positions `ZMod 4` of the square (rotation `r i : x ↦ x + i`, reflection `sr i : x ↦ -x - i`),
+lift it to the `16` colourings `Coloring = ZMod 4 → Fin 2` via the standard arrow action
+`(g • c) x = c (g⁻¹ • x)`, and count the orbits with Mathlib's Burnside lemma
+`MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`.
+
+The single computational step — the total number of colourings fixed across all `8` group
+elements equals `48` — is discharged by ordinary kernel `decide` (the carrier has only `16`
+elements, so the enumeration is small), **not** `native_decide`.  Burnside then forces the
+orbit count:
+
+  `48 = (#orbits) · 8`,  so  `#orbits = 6`.
+
+So `|bracelets(4,2)| = 6` is genuinely verified: `#print axioms bracelet_count_4_2`
+lists only `propext`, `Classical.choice`, `Quot.sound` — no `Lean.ofReduceBool`.
+
+## Why this matters
+
+It upgrades a headline combinatorial count from *axiomatized* (via `native_decide`) to
+*verified*, and it exhibits a reusable, fully kernel-checked pattern: define a concrete finite
+group action, lift it to colourings by the arrow action, and discharge Burnside's
+fixed-point side by `decide`.
+
+## Mathlib Dependencies
+- `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` : Burnside's lemma
+- `arrowAction` : the action of `G` on `A → B` induced by an action on `A`
+- `Mathlib.GroupTheory.SpecificGroups.Dihedral` : `DihedralGroup n`, `DihedralGroup.card`
+-/
+
+namespace BurnsideCountingOQ04OQ01
+
+open MulAction Finset
+
+/-- The `16` two-colourings of the four positions of a square.
+`ZMod 4` is definitionally `Fin 4`, so this is the parent's `Coloring 4 2 = Fin 4 → Fin 2`. -/
+abbrev Coloring := ZMod 4 → Fin 2
+
+/-! ## Part I: A concrete `D₄` action on the positions of the square -/
+
+/-- The geometric action of the dihedral group on the four positions `ZMod 4`:
+a rotation `r i` sends `x ↦ x + i`, a reflection `sr i` sends `x ↦ -x - i`.
+These formulas make the map `D₄ → (ZMod 4 → ZMod 4)` a genuine group homomorphism
+(verified by `decide` in `posMulAction`). -/
+def posAct : DihedralGroup 4 → ZMod 4 → ZMod 4
+  | .r i, x => x + i
+  | .sr i, x => -x - i
+
+/-- `DihedralGroup 4` acts on the positions `ZMod 4` by `posAct`.
+Both action laws are finite identities, discharged by kernel `decide`. -/
+instance posMulAction : MulAction (DihedralGroup 4) (ZMod 4) where
+  smul := posAct
+  one_smul := by decide
+  mul_smul := by decide
+
+@[simp] lemma posAct_r (i x : ZMod 4) : (DihedralGroup.r i) • x = x + i := rfl
+@[simp] lemma posAct_sr (i x : ZMod 4) : (DihedralGroup.sr i) • x = -x - i := rfl
+
+/-! ## Part II: Lift to colourings by the arrow action -/
+
+/-- The induced action of `D₄` on colourings: `(g • c) x = c (g⁻¹ • x)`.
+This is Mathlib's `arrowAction`, available because `D₄` is a group acting on `ZMod 4`. -/
+instance colMulAction : MulAction (DihedralGroup 4) Coloring := arrowAction
+
+/-- A colouring is fixed by `g` iff `g • c = c`; this is decidable because colourings have
+decidable equality, hence each fixed-point set is a `Fintype`. -/
+instance fixedByDecidablePred (g : DihedralGroup 4) :
+    DecidablePred (· ∈ fixedBy Coloring g) :=
+  fun c => decidable_of_iff (g • c = c) mem_fixedBy.symm
+
+/-- The orbit quotient of the (finite) colouring set is finite. We only need *some* `Fintype`
+instance for Burnside's lemma — the orbit count it computes is independent of the choice. -/
+noncomputable instance : Fintype (orbitRel.Quotient (DihedralGroup 4) Coloring) :=
+  Fintype.ofFinite _
+
+/-! ## Part III: The bracelet count via Burnside's lemma -/
+
+/-- The total number of `(g, c)` with `g • c = c`, summed over the eight elements of `D₄`,
+equals `48`.  Concretely the eight fixed-point counts are
+`16, 2, 4, 2` for the rotations `r 0, r 1, r 2, r 3` and `8, 4, 8, 4` for the reflections
+`sr 0, sr 1, sr 2, sr 3`, totalling `48`.  The carrier `ZMod 4 → Fin 2` has only `16`
+elements, so this finite enumeration is checked by ordinary kernel `decide`. -/
+theorem sum_fixedBy_eq :
+    (∑ g : DihedralGroup 4, Fintype.card (fixedBy Coloring g)) = 48 := by
+  decide
+
+/-- **Binary bracelets of length 4.**
+There are exactly `6` orbits of the `16` two-colourings of a square under the full dihedral
+group `D₄`.  Proved from Burnside's lemma and the kernel-checked fixed-point total `48`:
+`#orbits · |D₄| = 48` and `|D₄| = 8`, so `#orbits = 6`.
+
+Unlike the parent's `native_decide` count, this proof is `Lean.ofReduceBool`-free. -/
+theorem bracelet_count_4_2 :
+    Fintype.card (orbitRel.Quotient (DihedralGroup 4) Coloring) = 6 := by
+  have key := sum_card_fixedBy_eq_card_orbits_mul_card_group (DihedralGroup 4) Coloring
+  rw [sum_fixedBy_eq] at key
+  -- Burnside's lemma states its orbit side with the spelling `Quotient (orbitRel …)` and its own
+  -- synthesised `Fintype` instance, whereas the goal uses the API name `orbitRel.Quotient …`.
+  -- These are definitionally equal but *syntactically* distinct, so we move both sides to the
+  -- instance-independent `Nat.card` and reconcile the two spellings with a `rfl` bridge before
+  -- reading off the count.
+  simp only [← Nat.card_eq_fintype_card] at key ⊢
+  have hsp : Nat.card (orbitRel.Quotient (DihedralGroup 4) Coloring)
+           = Nat.card (Quotient (orbitRel (DihedralGroup 4) Coloring)) := rfl
+  have hG : Nat.card (DihedralGroup 4) = 8 := by
+    rw [Nat.card_eq_fintype_card]; exact DihedralGroup.card
+  rw [hsp]
+  rw [hG] at key
+  -- `key : 48 = Nat.card (Quotient (orbitRel …)) * 8`,  goal : `Nat.card (Quotient (orbitRel …)) = 6`
+  omega
+
+-- Axiom audit: confirms the count is `Lean.ofReduceBool`-free (kernel `decide`, not
+-- `native_decide`); only the standard foundational axioms appear.
+#print axioms bracelet_count_4_2
+
+end BurnsideCountingOQ04OQ01

--- a/research/problems/burnside-counting-oq-04-oq-01/knowledge.md
+++ b/research/problems/burnside-counting-oq-04-oq-01/knowledge.md
@@ -1,0 +1,41 @@
+# burnside-counting-oq-04-oq-01
+
+**Status**: COMPLETED (verified, 0 axioms, 0 sorries)
+**Answers**: parent burnside-counting-oq-04 open question #1
+
+## Summary
+
+Removes the `native_decide` (`Lean.ofReduceBool`) dependency from the headline count
+|bracelets(4,2)| = 6 by computing the Burnside fixed-point total with ordinary kernel `decide`.
+
+## Session 2026-06-23 (Session 1) — Completed
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Defined a concrete action `posAct`/`posMulAction` of `DihedralGroup 4` on positions `ZMod 4`
+  (rotations `x ↦ x + i`, reflections `x ↦ -x - i`); both `MulAction` laws by kernel `decide`.
+- Lifted to colourings `ZMod 4 → Fin 2` via Mathlib `arrowAction` (`colMulAction`), with a
+  computable `DecidablePred` instance so each `fixedBy` set is a kernel-computable `Fintype`.
+- `sum_fixedBy_eq`: total fixed colourings across the 8 group elements = 48, by kernel `decide`.
+- `bracelet_count_4_2`: Burnside's lemma + |D_4| = 8 forces 6 orbits.
+  `#print axioms` → only `propext, Classical.choice, Quot.sound` (no `Lean.ofReduceBool`).
+
+### Key Findings
+- **Atom-mismatch gotcha**: Burnside's lemma `sum_card_fixedBy_eq_card_orbits_mul_card_group`
+  states its orbit side as `Quotient (orbitRel α β)` (a `local notation Ω`) with its own
+  synthesised `Fintype` instance, while the goal uses the API name `orbitRel.Quotient α β`.
+  These are *definitionally* equal but *syntactically* distinct, so `omega` saw them as two
+  unrelated atoms and failed. Fix: route both through instance-independent `Nat.card`
+  (`simp only [← Nat.card_eq_fintype_card]`) and bridge the two spellings with a `rfl` lemma.
+- Kernel `decide` is entirely adequate here: carrier `k^n = 2^4 = 16` is tiny.
+
+### Files Modified
+- `proofs/Proofs/BurnsideCountingOQ04OQ01.lean` (131 lines, 2 thm / 2 def, verified)
+- `src/data/proofs/burnside-counting-oq-04-oq-01/meta.json`
+
+### Next Steps
+- Generalise to a parametric kernel-verified |bracelets(n,k)| for small (n,k).
+- Find the carrier-size threshold where kernel `decide` becomes infeasible and a structural
+  per-symmetry closed form is needed instead.

--- a/src/data/proofs/burnside-counting-oq-04-oq-01/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "burnside-counting-oq-04-oq-01",
+  "title": "Unconditional Binary Bracelets of Length 4: |bracelets(4,2)| = 6 Without native_decide",
+  "slug": "burnside-counting-oq-04-oq-01",
+  "description": "Removes the native_decide dependency from the headline dihedral bracelet count. The parent entries burnside-counting and burnside-counting-oq-04 establish that there are exactly 6 binary bracelets of length 4 (orbits of the 2-colourings of a square under the full dihedral group D_4 of rotations and reflections), but both close the final numeric count with native_decide, which trusts the Lean compiler's kernel reduction and therefore depends on the Lean.ofReduceBool axiom. This file builds a concrete action of DihedralGroup 4 on the positions ZMod 4 of the square (rotation r i : x ↦ x + i, reflection sr i : x ↦ -x - i), lifts it to the 16 colourings Coloring = ZMod 4 → Fin 2 via Mathlib's arrow action (g • c) x = c (g⁻¹ • x), and counts the orbits with Mathlib's Burnside lemma MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group. The single computational step — the total number of colourings fixed across all 8 group elements equals 48 — is discharged by ordinary kernel decide (the carrier has only 16 elements), not native_decide. Burnside then forces 48 = |orbits|·8, so |orbits| = 6. The result bracelet_count_4_2 is genuinely verified: #print axioms lists only propext, Classical.choice, Quot.sound — no Lean.ofReduceBool. This directly answers the first open question of burnside-counting-oq-04. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "bracelets",
+      "orbit-counting",
+      "group-theory",
+      "kernel-decide",
+      "native-decide-elimination"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
+        "description": "Burnside's lemma: Σ_{g∈G} |Fix(g)| = |X/G|·|G|. Supplies the orbit-counting engine; this file feeds it the kernel-checked fixed-point total 48 and the dihedral order 8 to extract the orbit count 6.",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "MulAction.arrowAction",
+        "description": "The action of G on the function space A → B induced by an action of G on A, via (g • f) a = f (g⁻¹ • a). Used to lift the concrete D_4 action on positions ZMod 4 to the colourings ZMod 4 → Fin 2.",
+        "module": "Mathlib.GroupTheory.GroupAction.Basic"
+      },
+      {
+        "theorem": "DihedralGroup.card",
+        "description": "|DihedralGroup n| = 2n, giving |D_4| = 8, the divisor Burnside's lemma uses to turn the fixed-point total 48 into the orbit count.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Dihedral"
+      },
+      {
+        "theorem": "Nat.card_eq_fintype_card",
+        "description": "Bridges Fintype.card and the instance-independent Nat.card. Used to reconcile the Fintype instance and orbit-quotient spelling synthesised inside Burnside's lemma (Quotient (orbitRel …)) with the API form orbitRel.Quotient … appearing in the goal.",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ],
+    "originalContributions": [
+      "posAct / posMulAction: a concrete geometric action of DihedralGroup 4 on the four positions ZMod 4 of a square (rotation r i : x ↦ x + i, reflection sr i : x ↦ -x - i), with both MulAction laws discharged by kernel decide on the 8-element group",
+      "colMulAction: the lift of that action to the 16 colourings Coloring = ZMod 4 → Fin 2 via Mathlib's arrowAction, together with a computable DecidablePred fixed-point instance so that each fixed-point set is a kernel-computable Fintype",
+      "sum_fixedBy_eq: the eight per-element fixed-point counts (16,2,4,2 for the rotations and 8,4,8,4 for the reflections) sum to 48, proved by ordinary kernel decide over the 16-element carrier — the step the parent entries close with native_decide",
+      "bracelet_count_4_2: combining sum_fixedBy_eq with Burnside's lemma and |D_4| = 8 forces the orbit count to be 6, with #print axioms confirming only propext / Classical.choice / Quot.sound (no Lean.ofReduceBool), upgrading the count from axiomatized (via native_decide) to verified"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The decisive enumeration uses ordinary kernel decide, not native_decide, so the result does NOT depend on Lean.ofReduceBool. #print axioms bracelet_count_4_2 lists only the standard foundational axioms propext, Classical.choice, Quot.sound.",
+    "lineCount": 131,
+    "theoremCount": 2,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Burnside's lemma counts the orbits of a finite group action as the average number of fixed points. For the dihedral group D_n acting on the n beads of a cycle (rotations together with reflections) it yields the bracelet numbers (OEIS A000029); for binary colourings of a square, D_4, the count is 6. In a formal setting the small finite count is tempting to discharge with native_decide, which compiles the decision procedure and runs it — but native_decide trusts the Lean compiler and so introduces the Lean.ofReduceBool axiom, leaving the result merely axiomatized rather than fully kernel-verified. The honest alternative is to keep the enumeration small enough that the trusted kernel can evaluate it directly with decide.",
+    "problemStatement": "Can the headline dihedral bracelet count |bracelets(4,2)| = 6 be established without native_decide, i.e. without depending on the Lean.ofReduceBool axiom?",
+    "text": "There are exactly 6 orbits of the 16 two-colourings of a square under the full dihedral group D_4. We prove this from Burnside's lemma with the fixed-point total computed by ordinary kernel decide rather than native_decide, so the result is Lean.ofReduceBool-free.",
+    "proofStrategy": "Define the concrete action posAct of DihedralGroup 4 on the positions ZMod 4 (rotations x ↦ x + i, reflections x ↦ -x - i) and verify the two MulAction laws by kernel decide on the eight group elements. Lift to colourings ZMod 4 → Fin 2 with Mathlib's arrowAction, and provide a computable DecidablePred instance for membership in each fixedBy set so the fixed-point Fintypes are kernel-computable. The carrier has only 16 elements, so sum_fixedBy_eq — the total number of (g, c) with g • c = c, summed over the 8 elements of D_4, equals 48 — is proved by ordinary decide. Burnside's lemma gives Σ_g |Fix(g)| = |orbits|·|D_4|; substituting the total 48 and |D_4| = 8 yields 48 = |orbits|·8, so |orbits| = 6 by omega. The one technical subtlety is that Burnside's lemma states its orbit side with the spelling Quotient (orbitRel α β) and its own synthesised Fintype instance, whereas the goal uses the API name orbitRel.Quotient α β; these are definitionally equal but syntactically distinct, so both sides are moved to the instance-independent Nat.card and the two spellings are reconciled with a rfl bridge before reading off the count.",
+    "keyInsights": [
+      "native_decide is unnecessary here: the carrier ZMod 4 → Fin 2 has only 16 elements, so the entire fixed-point enumeration (48 across 8 group elements) is small enough for the trusted kernel to evaluate with ordinary decide — keeping the result free of the Lean.ofReduceBool axiom",
+      "Making each fixed-point set kernel-computable only requires a DecidablePred instance for g • c = c, obtained via decidable_of_iff from decidable equality of colourings; this is what lets decide succeed without compilation",
+      "The reusable pattern is: define a concrete finite group action, lift it to colourings by the arrow action, and discharge Burnside's fixed-point side with decide — turning any small native_decide orbit count into a genuinely verified one",
+      "Burnside's lemma and the goal spell the orbit quotient differently (Quotient (orbitRel …) versus orbitRel.Quotient …) with distinct Fintype instances; routing both through Nat.card makes the kernel-checked total and the goal share a single atom"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
+      "The dihedral group DihedralGroup n and its action on a cycle by rotations and reflections",
+      "The arrow action of a group on a function space, and decidability/Fintype instances for fixed-point sets",
+      "The distinction between kernel decide and native_decide, and the Lean.ofReduceBool axiom the latter introduces"
+    ]
+  },
+  "sections": [
+    {
+      "id": "positions",
+      "title": "A Concrete D_4 Action on the Positions of the Square",
+      "startLine": 54,
+      "endLine": 72,
+      "summary": "posAct sends a rotation r i to x ↦ x + i and a reflection sr i to x ↦ -x - i on the positions ZMod 4; the two MulAction laws are finite identities discharged by kernel decide.",
+      "mathContext": "$r_i \\cdot x = x + i,\\qquad s_i \\cdot x = -x - i \\quad (x \\in \\mathbb{Z}/4\\mathbb{Z})$."
+    },
+    {
+      "id": "lift",
+      "title": "Lift to Colourings by the Arrow Action",
+      "startLine": 74,
+      "endLine": 89,
+      "summary": "The action on positions induces an action on the 16 colourings ZMod 4 → Fin 2 via Mathlib's arrowAction, (g • c) x = c (g⁻¹ • x); a DecidablePred instance makes each fixed-point set a kernel-computable Fintype.",
+      "mathContext": "$(g \\cdot c)(x) = c(g^{-1} \\cdot x),\\qquad c : \\mathbb{Z}/4\\mathbb{Z} \\to \\{0,1\\}$."
+    },
+    {
+      "id": "count",
+      "title": "The Bracelet Count via Burnside's Lemma",
+      "startLine": 91,
+      "endLine": 131,
+      "summary": "The fixed-point counts 16,2,4,2 (rotations) and 8,4,8,4 (reflections) sum to 48 by kernel decide; Burnside's lemma with |D_4| = 8 then forces 48 = |orbits|·8, so |bracelets(4,2)| = 6, with #print axioms confirming no Lean.ofReduceBool.",
+      "mathContext": "$\\sum_{g \\in D_4} |\\mathrm{Fix}(g)| = 48 = |\\text{orbits}| \\cdot 8 \\Rightarrow |\\text{bracelets}(4,2)| = 6$."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral bracelet counts"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-04",
+      "relationship": "extends",
+      "description": "Answers the first open question of oq-04: builds a concrete dihedral action on the colourings and discharges the bracelet count by kernel computation, yielding an unconditional |bracelets| = 6 where the parent closes the analogous cyclic count only with native_decide."
+    },
+    {
+      "targetId": "burnside-counting",
+      "relationship": "related",
+      "description": "Upgrades the base entry's dihedral bracelet count from axiomatized (via native_decide / Lean.ofReduceBool) to fully kernel-verified."
+    },
+    {
+      "targetId": "burnside-counting-oq-03",
+      "relationship": "related",
+      "description": "oq-03 supplies the rotation-fixed counts k^gcd(n,r); this entry computes the full dihedral fixed-point profile (rotations and reflections) concretely for n = 4, k = 2."
+    }
+  ],
+  "conclusion": {
+    "summary": "The headline dihedral bracelet count |bracelets(4,2)| = 6 is established without native_decide. A concrete action of DihedralGroup 4 on the positions ZMod 4 is lifted to the 16 colourings by the arrow action; the fixed-point total 48 is computed by ordinary kernel decide; and Burnside's lemma with |D_4| = 8 forces the orbit count 6. #print axioms confirms the result depends only on propext, Classical.choice, Quot.sound — no Lean.ofReduceBool.",
+    "implications": "Upgrades a headline combinatorial count from axiomatized (via native_decide) to verified, and exhibits a reusable, fully kernel-checked pattern: define a concrete finite group action, lift it to colourings by the arrow action, and discharge Burnside's fixed-point side by decide.",
+    "openQuestions": [
+      "Generalise the concrete construction to a parametric kernel-verified bracelet count |bracelets(n,k)| for a range of small (n,k), replacing the per-element decide with a uniform fixed-point computation over DihedralGroup n.",
+      "Identify the threshold at which the carrier k^n becomes too large for kernel decide and a structural (per-symmetry closed-form) computation is required instead of direct enumeration."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.SpecificGroups.Dihedral",
+      "Mathlib.Data.Fintype.Card",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MulAction",
+      "Finset"
+    ],
+    "namespace": "BurnsideCountingOQ04OQ01",
+    "lineCount": 131,
+    "axiomCount": 0,
+    "theoremCount": 2,
+    "definitionCount": 2,
+    "path": "Proofs/BurnsideCountingOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Removes the `native_decide` (`Lean.ofReduceBool`) dependency from the headline dihedral bracelet count **|bracelets(4,2)| = 6**, directly answering the first open question of `burnside-counting-oq-04`.

Both `burnside-counting` and `burnside-counting-oq-04` establish the count but close the final numeric step with `native_decide`, which trusts the Lean compiler's kernel reduction and so depends on the `Lean.ofReduceBool` axiom (status: *axiomatized*). This entry computes the same count with ordinary kernel `decide` and is therefore genuinely **verified**.

## Approach

- **Concrete D₄ action** (`posAct` / `posMulAction`): `DihedralGroup 4` acts on positions `ZMod 4` by rotations `x ↦ x + i` and reflections `x ↦ -x - i`; both `MulAction` laws are finite identities discharged by kernel `decide`.
- **Lift to colourings** (`colMulAction`): Mathlib's `arrowAction` lifts the action to the 16 colourings `ZMod 4 → Fin 2`, with a computable `DecidablePred` instance making each `fixedBy` set a kernel-computable `Fintype`.
- **Fixed-point total** (`sum_fixedBy_eq`): the eight per-element counts (16,2,4,2 rotations; 8,4,8,4 reflections) sum to **48**, proved by ordinary `decide` over the 16-element carrier.
- **Count** (`bracelet_count_4_2`): Burnside's lemma `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` with `|D₄| = 8` forces `48 = |orbits|·8`, so `|orbits| = 6`.

## Verification

```
#print axioms bracelet_count_4_2
-- 'bracelet_count_4_2' depends on axioms: [propext, Classical.choice, Quot.sound]
```

No `Lean.ofReduceBool`, no `sorryAx`. Docker build passes (`Build completed successfully (3062 jobs)`).

- **Status**: verified · **Axioms**: 0 · **Sorries**: 0 · 131 lines, 2 theorems / 2 definitions
- One technical note: Burnside's lemma spells the orbit quotient as `Quotient (orbitRel α β)` (with its own `Fintype` instance) while the goal uses the API form `orbitRel.Quotient α β` — defeq but syntactically distinct, so both are routed through instance-independent `Nat.card` and reconciled with a `rfl` bridge before `omega`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)