### PR TITLE
Add markov-equation index.ts so the proof page loads

### DIFF
--- a/src/data/proofs/markov-equation/index.ts
+++ b/src/data/proofs/markov-equation/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MarkovEquation.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const markovEquationProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const markovEquationAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const markovEquationData: ProofData = {
+  proof: markovEquationProof,
+  annotations: markovEquationAnnotations,
+}


### PR DESCRIPTION
PR #28240 enriched `markov-equation` with annotations and sections, but did **not** add `index.ts`. Without it, Vite's `import.meta.glob` cannot discover the proof, so the page renders "proof not found" on the live site even though the entry appears in the gallery listing.

This PR adds only the `index.ts` entry point, on top of the already-merged enrichment from #28240 (no changes to annotations.json or meta.json).

- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)