### PR TITLE
Enrich Farey adjacency criterion (erdos-1005-oq-03): add index.ts, mainTheorems

### DIFF
--- a/src/data/proofs/erdos-1005-oq-03/index.ts
+++ b/src/data/proofs/erdos-1005-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1005ProblemOQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1005OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1005OQ03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1005OQ03Data: ProofData = {
+  proof: erdos1005OQ03Proof,
+  annotations: erdos1005OQ03Annotations,
+}

--- a/src/data/proofs/erdos-1005-oq-03/meta.json
+++ b/src/data/proofs/erdos-1005-oq-03/meta.json
@@ -126,5 +126,37 @@
       "relationship": "extends",
       "description": "Supplies the adjacency criterion the parent's run problem presupposes. The parent proves the unimodular gap formula, mediant coprimality, and mediant betweenness; this entry uses those facts to determine exactly when two Farey fractions are neighbours (b + d > n) and to locate the order at which the mediant first appears."
     }
+  ],
+  "mainTheorems": [
+    {
+      "name": "farey_adjacency_iff",
+      "type": "headline",
+      "description": "The adjacency criterion: a unimodular pair a/b < c/d is adjacent in the Farey sequence F_n if and only if b + d > n. Packages sufficiency and sharpness into a single equivalence.",
+      "leanType": "∀ {n : ℕ} (f g : FareyFraction n), IsConsecutiveFarey f g → f.toRat < g.toRat → (adjacent in F_n ↔ f.q + g.q > n)"
+    },
+    {
+      "name": "intermediate_denom_ge",
+      "type": "core",
+      "description": "The engine: any fraction p/q strictly between two unimodular neighbours a/b < c/d (with bc − ad = 1) has denominator q ≥ b + d. Proved from the identity q·(bc − ad) = d·(pb − aq) + b·(cq − pd) collapsing under bc − ad = 1, with both bracketed integers ≥ 1.",
+      "leanType": "∀ {n : ℕ} (f g h : FareyFraction n), IsConsecutiveFarey f g → f.toRat < h.toRat → h.toRat < g.toRat → f.q + g.q ≤ h.q"
+    },
+    {
+      "name": "farey_adjacent_of_denom_sum_gt",
+      "type": "core",
+      "description": "Sufficiency: a unimodular pair a/b < c/d with b + d > n is adjacent in F_n, since any intermediate order-n fraction would need denominator ≥ b + d > n.",
+      "leanType": "∀ {n : ℕ} (f g : FareyFraction n), IsConsecutiveFarey f g → f.toRat < g.toRat → f.q + g.q > n → adjacent in F_n"
+    },
+    {
+      "name": "mediant_lt_n_not_adjacent",
+      "type": "core",
+      "description": "Sharpness: if b + d ≤ n the mediant (a+c)/(b+d) is a genuine order-n Farey fraction strictly between a/b and c/d, so the pair is NOT adjacent — equivalently the mediant first enters the Farey sequence at order exactly b + d (Stern–Brocot insertion order).",
+      "leanType": "∀ {n : ℕ} (f g : FareyFraction n), IsConsecutiveFarey f g → f.toRat < g.toRat → f.q + g.q ≤ n → ¬ adjacent in F_n"
+    },
+    {
+      "name": "toRat_lt_iff",
+      "type": "supporting",
+      "description": "Order bridge: two Farey fractions compare by cross-multiplication of their numerator/denominator pairs (f.p·g.q < g.p·f.q), the link between rational ordering and the integer arithmetic that drives every proof.",
+      "leanType": "∀ {n : ℕ} (f g : FareyFraction n), f.toRat < g.toRat ↔ f.p * g.q < g.p * f.q"
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-1005-oq-03` (the Farey adjacency criterion: a unimodular pair is adjacent in F_n iff b + d > n). The entry already had a rich meta.json (overview, conclusion, cross-reference) plus 8 sections and 8 fully-fielded annotations, but was **missing index.ts** and had no `mainTheorems` array.

## Changes
- **index.ts** (was absent): without it Vite's `import.meta.glob` cannot discover the proof, so the page renders 'proof not found' on the live site despite the entry appearing in the gallery listing. Added using the standard template (Lean source `Erdos1005ProblemOQ03.lean`).
- **mainTheorems** (was absent): 5 entries — farey_adjacency_iff (headline equivalence), intermediate_denom_ge (the q ≥ b+d engine), farey_adjacent_of_denom_sum_gt (sufficiency), mediant_lt_n_not_adjacent (sharpness), toRat_lt_iff (order bridge) — with statements derived from the Lean signatures.

## Verification
- meta.json validates as JSON; index.ts follows the established ProofData template.
- Cross-reference target (erdos-1005) exists in the gallery.
- Existing overview, conclusion, 8 sections, and 8 annotations left intact.
- No changes to status/badge/axiom claims — verified / original / 0 axioms / 0 sorries already accurate (no native_decide).