### PR TITLE
Enrich Erdős #124 critical Brown sequence (OQ-02-OQ-01): annotations + sections

### DIFF
--- a/src/data/proofs/erdos-124-complete-sequences-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-erdos124oq0201-header",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "The critical case of Brown's criterion",
+    "content": "The header frames the entry as the sharp-boundary study behind Erdős #124. Brown's criterion (parent) says a sequence with f 0 = 1 and the small-gap property f(n+1) ≤ 1 + ∑_{i<n+1} f i is complete (every n is a subset sum). This file pins the tight-gap (equality) case: 2^n is the upper envelope of every Brown sequence, the tight gap forces f n = 2^n exactly, and on that binary sequence every n has a unique subset-sum representation — completeness with zero redundancy. The single base d = 2 has reciprocal sum 1/(2−1) = 1, the boundary value of ∑ 1/(dᵢ−1) ≥ 1.",
+    "mathContext": "Small-gap: $f(n+1) \\le 1 + \\sum_{i<n+1} f(i)$; tight gap (equality) $\\Rightarrow f(n) = 2^n$; $\\sum 1/(d_i-1) = 1$ at $d=2$.",
+    "significance": "context",
+    "relatedConcepts": ["Brown's criterion", "complete sequences", "binary representation", "Erdős problems"],
+    "prerequisites": ["subset sums", "number theory"]
+  },
+  {
+    "id": "ann-erdos124oq0201-geomsum",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 43, "endLine": 52 },
+    "type": "technique",
+    "title": "Geometric partial sum ∑ 2^i = 2^n − 1",
+    "content": "sum_range_two_pow: the identity ∑_{i<n} 2^i = 2^n − 1, proved by a one-step induction (pow_succ + omega over the bound 1 ≤ 2^n). This is the quantitative engine behind both the envelope bound and the rigidity step: it is exactly what makes 1 + ∑_{i<n+1} 2^i collapse to 2^{n+1}.",
+    "mathContext": "$\\sum_{i<n} 2^i = 2^n - 1$, so $1 + \\sum_{i<n+1} 2^i = 1 + (2^{n+1}-1) = 2^{n+1}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["geometric series", "powers of two", "induction"],
+    "prerequisites": ["finite sums"]
+  },
+  {
+    "id": "ann-erdos124oq0201-envelope",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 54, "endLine": 71 },
+    "type": "insight",
+    "title": "2^n is the upper envelope of every Brown sequence",
+    "content": "brown_le_pow2: any sequence with f 0 = 1 and the small-gap inequality satisfies f n ≤ 2^n for all n. Strong induction: assuming f i ≤ 2^i for i ≤ m, the gap gives f(m+1) ≤ 1 + ∑_{i<m+1} f i ≤ 1 + (2^{m+1}−1) = 2^{m+1}, using sum_le_sum termwise and the geometric identity. So the binary sequence is the pointwise ceiling no Brown sequence can exceed.",
+    "mathContext": "$f(0)=1, f(n+1)\\le 1+\\sum_{i<n+1} f(i) \\Rightarrow f(n) \\le 2^n$ for all $n$.",
+    "significance": "key",
+    "relatedConcepts": ["strong induction", "pointwise bound", "Brown sequences", "extremal envelope"],
+    "prerequisites": ["the geometric partial sum", "monotonicity of sums"]
+  },
+  {
+    "id": "ann-erdos124oq0201-rigidity",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 73, "endLine": 89 },
+    "type": "insight",
+    "title": "Rigidity: tight gap forces f n = 2^n",
+    "content": "critical_eq_pow2: replacing the gap inequality by equality, the same strong induction yields f n = 2^n exactly. With f i = 2^i for i ≤ m, the tight recursion f(m+1) = 1 + ∑_{i<m+1} 2^i = 1 + (2^{m+1}−1) = 2^{m+1}. The critical sequence is thus rigidly determined — there is no freedom once the gap is saturated.",
+    "mathContext": "$f(0)=1, f(n+1) = 1 + \\sum_{i<n+1} f(i) \\Rightarrow f(n) = 2^n$, the unique sequence saturating the Brown bound.",
+    "significance": "key",
+    "relatedConcepts": ["rigidity", "extremal sequence", "binary sequence", "saturation"],
+    "prerequisites": ["the envelope bound", "strong induction"]
+  },
+  {
+    "id": "ann-erdos124oq0201-injective",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 91, "endLine": 118 },
+    "type": "technique",
+    "title": "Injectivity of binary subset sums via bitIndices",
+    "content": "The uniqueness backbone. sum_eq_sortMap bridges a Finset sum to the sum over its sorted list; bitIndices_sum_two_pow then computes that the bit-indices of ∑_{i∈s} 2^i are exactly the sorted elements of s (via Mathlib's Nat.bitIndices_twoPowsum on a strictly-sorted list). Hence sum_two_pow_injective: the sum determines the index set, so s ↦ ∑_{i∈s} 2^i is injective on Finset ℕ.",
+    "mathContext": "$\\operatorname{bitIndices}\\big(\\sum_{i\\in s} 2^i\\big) = \\operatorname{sort}(s)$, so $s \\mapsto \\sum_{i\\in s} 2^i$ is injective.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.bitIndices", "injectivity", "binary expansion", "sorted Finset"],
+    "prerequisites": ["Finset sums", "Mathlib bitIndices API"]
+  },
+  {
+    "id": "ann-erdos124oq0201-unique",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 120, "endLine": 132 },
+    "type": "insight",
+    "title": "Unique representation: completeness with zero redundancy",
+    "content": "exists_sum_two_pow gives the existence half (binary expansion via Nat.twoPowSum_bitIndices over the nodup bit-index list), and unique_representation combines it with injectivity: every natural number is a binary subset sum in exactly one way. This is the hallmark of the boundary — strictly above the reciprocal-sum threshold a number can be a subset sum many ways, but on the critical sequence redundancy vanishes entirely.",
+    "mathContext": "$\\forall m,\\ \\exists!\\, s \\subseteq \\mathbb{N},\\ m = \\sum_{i\\in s} 2^i$ — the binary representation is unique.",
+    "significance": "key",
+    "relatedConcepts": ["unique representation", "binary expansion", "ExistsUnique", "redundancy"],
+    "prerequisites": ["injectivity", "existence of binary expansion"]
+  },
+  {
+    "id": "ann-erdos124oq0201-characterization",
+    "proofId": "erdos-124-complete-sequences-oq-02-oq-01",
+    "range": { "startLine": 134, "endLine": 149 },
+    "type": "concept",
+    "title": "The packaged characterisation and the d = 2 witness",
+    "content": "critical_sequence_characterization bundles rigidity and uniqueness: a sequence saturating the Brown gap is exactly n ↦ 2^n and on it every m has a unique subset-sum representation. The closing example 1/(2−1) = 1 records that the single base d = 2 sits exactly on the reciprocal-sum boundary ∑ 1/(dᵢ−1) = 1 and realises this extremal sequence — the honest scope being the abstract critical gap, not every boundary base multiset.",
+    "mathContext": "Tight Brown gap $\\Rightarrow (f = 2^n) \\wedge (\\forall m,\\, \\exists!\\, s,\\ m = \\sum_{i\\in s} f(i))$; $1/(2-1) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["characterisation", "reciprocal-sum boundary", "Egyptian fractions", "extremal base"],
+    "prerequisites": ["rigidity", "unique representation"]
+  }
+]

--- a/src/data/proofs/erdos-124-complete-sequences-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02-oq-01/meta.json
@@ -71,6 +71,43 @@
       "Is there a clean characterisation of the greedy sequences that attain Brown's bound infinitely often versus only finitely often?"
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Background: the critical case",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Module docstring framing the entry as the tight-gap boundary of Brown's criterion: 2^n is the envelope, the tight gap forces the binary sequence, and representations on it are unique. Notes self-containment and the Nat.bitIndices backbone; the base d = 2 (reciprocal sum 1) realises the extremal sequence."
+    },
+    {
+      "id": "geomsum",
+      "title": "Geometric sum of powers of two",
+      "startLine": 43,
+      "endLine": 52,
+      "summary": "sum_range_two_pow: ∑_{i<n} 2^i = 2^n − 1, the quantitative engine of both the envelope bound and the rigidity step."
+    },
+    {
+      "id": "brown-bound",
+      "title": "The Brown bound and its critical case",
+      "startLine": 54,
+      "endLine": 89,
+      "summary": "brown_le_pow2 (2^n is the pointwise upper envelope of every Brown sequence with f 0 = 1) and critical_eq_pow2 (the tight gap forces f n = 2^n exactly) — both by strong induction over the gap and the geometric identity."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness of binary subset-sum representations",
+      "startLine": 91,
+      "endLine": 132,
+      "summary": "The Nat.bitIndices backbone: sum_eq_sortMap and bitIndices_sum_two_pow recover the sorted index set, giving sum_two_pow_injective; exists_sum_two_pow provides binary expansion; unique_representation combines them — every n has exactly one binary subset-sum representation."
+    },
+    {
+      "id": "characterization",
+      "title": "The critical sequence, characterised",
+      "startLine": 134,
+      "endLine": 151,
+      "summary": "critical_sequence_characterization packages rigidity (f = 2^n) with uniqueness; the closing example 1/(2−1) = 1 records that the single base d = 2 sits on the reciprocal-sum boundary and realises the extremal sequence."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "erdos-124-complete-sequences-oq-02",


### PR DESCRIPTION
Enrichment pass for `erdos-124-complete-sequences-oq-02-oq-01` (the tight-gap / critical case of Brown's criterion: the binary sequence 2^n with unique representation).

Entry previously had only `meta.json` — no `annotations.json` and no `sections` array. Quality score 35 (0 passes).

## Changes
- **annotations.json (new)**: 7 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering the header, the geometric partial sum, the Brown envelope + rigidity (2^n forced), the `Nat.bitIndices` injectivity backbone, unique binary representation, and the packaged characterisation with the d=2 boundary witness.
- **sections (new)**: 5 sections covering all 151 lines of `Erdos124CompleteSequencesOQ02OQ01.lean`.

## Verification
Content checked against the Lean source; JSON validates. Axiom integrity preserved: `verified`/`original`, 0 axioms, 0 sorries, no `native_decide`.