### PR TITLE
Enrich Feuerbach orthocentric system (OQ-01-OQ-01-OQ-02): annotations

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-feuerbach-oq010102-header",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 66 },
+    "type": "context",
+    "title": "The open question: is {A,B,C,H} symmetric?",
+    "content": "The header poses the orthocentric-system question. Earlier files built H = A + B + C − 2O as a point attached to a fixed base triangle ABC. This file asks whether the four-point set {A,B,C,H} is symmetric — whether each point is the orthocenter of the triangle on the other three (A of BCH, B of CAH, C of ABH). The answer is yes, captured by three perpendicularities of opposite connectors, four orthocenter memberships, a uniqueness theorem, and the structural payoff of one shared nine-point circle.",
+    "mathContext": "Orthocentric system: $\\{A,B,C,H\\}$ with $H = A+B+C-2O$; each point is the orthocenter of the triangle on the other three.",
+    "significance": "context",
+    "relatedConcepts": ["orthocenter", "orthocentric system", "circumcenter", "nine-point circle"],
+    "prerequisites": ["Euclidean geometry", "triangle centers"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-perpbisector",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 76, "endLine": 122 },
+    "type": "technique",
+    "title": "Perpendicular-bisector relations for the circumcenter",
+    "content": "Part 0 reproves the circumcenter's defining equidistance relations, which the parent kept private. perp_bisector_AB and perp_bisector_AC state (B−A)⊥(B+A−2O) and (C−A)⊥(C+A−2O), proved by substituting the explicit circumcenter coordinates and clearing denominators (field_simp; ring) under the non-degeneracy hypothesis. perp_bisector_BC is their difference (equidistance is transitive). These are the linear facts every perpendicularity below reduces to.",
+    "mathContext": "$(B-A)\\cdot(B+A-2O)=0$ and $(C-A)\\cdot(C+A-2O)=0$; subtracting gives $(C-B)\\cdot(C+B-2O)=0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["circumcenter", "perpendicular bisector", "equidistance", "field_simp"],
+    "prerequisites": ["coordinate geometry", "dot product"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-coords",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 124, "endLine": 136 },
+    "type": "definition",
+    "title": "The orthocenter in coordinates",
+    "content": "orthocenter_fst and orthocenter_snd unfold the parent's definition componentwise: H = (A₁+B₁+C₁−2O₁, A₂+B₂+C₂−2O₂), both by rfl. This is the algebraic form H = A + B + C − 2O that makes every perpendicularity a linear substitution in O.",
+    "mathContext": "$H = A + B + C - 2O$, i.e. $H_1 = A_1+B_1+C_1-2O_1$, $H_2 = A_2+B_2+C_2-2O_2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthocenter", "Euler line", "circumcenter"],
+    "prerequisites": ["coordinate geometry"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-perps",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 138, "endLine": 181 },
+    "type": "insight",
+    "title": "The three perpendicularities are the orthocentric system",
+    "content": "Part 2 proves opposite connectors of {A,B,C,H} are perpendicular: (A−H)⊥(B−C), (B−H)⊥(C−A), (C−H)⊥(A−B). Each follows from one perpendicular-bisector relation after substituting H = A + B + C − 2O (a single linear_combination). These three statements ARE the orthocentric configuration; orthocentric_perpendicularities bundles them.",
+    "mathContext": "$(A-H)\\perp(B-C),\\ (B-H)\\perp(C-A),\\ (C-H)\\perp(A-B)$ — opposite connectors perpendicular.",
+    "significance": "key",
+    "relatedConcepts": ["perpendicularity", "altitudes", "orthocentric system", "linear_combination"],
+    "prerequisites": ["dot product", "the perpendicular-bisector relations"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-memberships",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 182, "endLine": 231 },
+    "type": "insight",
+    "title": "The orthocenter predicate and four memberships",
+    "content": "IsOrthocenterOf P X Y Z encodes 'P lies on all three altitudes of XYZ' as three perpendicularity equations. The four membership theorems then show H is the orthocenter of ABC and, symmetrically, A of BCH, B of CAH, C of ABH — each a re-permutation of the same three perpendicularities. orthocentric_system bundles all four, answering the open question affirmatively.",
+    "mathContext": "$H = \\operatorname{orth}(ABC),\\ A = \\operatorname{orth}(BCH),\\ B = \\operatorname{orth}(CAH),\\ C = \\operatorname{orth}(ABH)$.",
+    "significance": "key",
+    "relatedConcepts": ["orthocenter", "orthocentric system", "altitudes", "symmetry"],
+    "prerequisites": ["the three perpendicularities"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-uniqueness",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 232, "endLine": 286 },
+    "type": "technique",
+    "title": "Uniqueness via a 2×2 Cramer argument",
+    "content": "isOrthocenterOf_unique shows that for a non-degenerate triangle the perpendicularity characterization pins the orthocenter uniquely. Two altitude conditions, differenced, give a 2×2 linear system in P − P'; Cramer's rule multiplies through by the triangle's non-degeneracy determinant, forcing P.1 = P'.1 and P.2 = P'.2. orthocenter_of_BCH_unique specializes this so that on a non-degenerate BCH, A is THE orthocenter.",
+    "mathContext": "Two altitude equations in $P-P'$ have determinant $(Y_1-X_1)(Z_2-X_2)-(Z_1-X_1)(Y_2-X_2) \\ne 0$ (non-degeneracy), so $P = P'$.",
+    "significance": "key",
+    "relatedConcepts": ["Cramer's rule", "determinant", "uniqueness", "non-degeneracy"],
+    "prerequisites": ["linear systems", "the orthocenter predicate"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-ninepoint",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 287, "endLine": 305 },
+    "type": "concept",
+    "title": "One shared nine-point circle",
+    "content": "orthocentric_six_midpoints_concyclic repackages the parent's six nine-point membership theorems as a single statement about the orthocentric system: the midpoints of all six connectors of {A,B,C,H} — the three sides BC, CA, AB and the three cevian segments AH, BH, CH — lie on one circle (centre N, radius R/2). All four triangles of the system share this single nine-point circle, the structural hallmark of the configuration.",
+    "mathContext": "All six midpoints lie on the circle of centre $N$ and radius $R/2$; the four triangles of $\\{A,B,C,H\\}$ share one nine-point circle.",
+    "significance": "key",
+    "relatedConcepts": ["nine-point circle", "concyclicity", "midpoints", "orthocentric system"],
+    "prerequisites": ["nine-point circle theory"]
+  },
+  {
+    "id": "ann-feuerbach-oq010102-example",
+    "proofId": "feuerbachs-theorem-defs-oq-01-oq-01-oq-02",
+    "range": { "startLine": 306, "endLine": 344 },
+    "type": "context",
+    "title": "Worked example: an acute orthocentric system",
+    "content": "A concrete check on A=(0,0), B=(4,0), C=(1,2): circumcenter (2, 1/4), orthocenter H=(1, 3/2). The four points are verified pairwise distinct (an acute configuration, unlike the degenerate 3-4-5 right triangle where H collapses onto the right-angle vertex), and A is confirmed to be the orthocenter of BCH. All by norm_num — a genuine, non-collapsed instance of the system.",
+    "mathContext": "$A=(0,0), B=(4,0), C=(1,2) \\Rightarrow O=(2,\\tfrac14),\\ H=(1,\\tfrac32)$; four distinct points, $A = \\operatorname{orth}(BCH)$.",
+    "significance": "context",
+    "relatedConcepts": ["worked example", "acute triangle", "degenerate configuration", "norm_num"],
+    "prerequisites": ["coordinate geometry"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `feuerbachs-theorem-defs-oq-01-oq-01-oq-02` (the orthocentric system: each of A,B,C,H is the orthocenter of the triangle on the other three).

Entry had `sections` but no `annotations.json`. Quality score 35 (0 passes).

## Changes
- **annotations.json (new)**: 8 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, aligned to the existing 7 sections plus a header annotation: the open question, the perpendicular-bisector relations, the orthocenter coordinates, the three perpendicularities, the four orthocenter memberships, the Cramer uniqueness argument, the shared nine-point circle, and the worked acute example.

## Verification
Content checked against the Lean source; JSON validates. Axiom integrity preserved: `verified`/`original`, 0 axioms, 0 sorries.