### PR TITLE
Enrich Transcendental Numbers Exist (sqrt2-irrational-oq-02)

### DIFF
--- a/src/data/proofs/sqrt2-irrational-oq-02/annotations.json
+++ b/src/data/proofs/sqrt2-irrational-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-sqrt2oq02-context",
+    "proofId": "sqrt2-irrational-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 23
+    },
+    "type": "context",
+    "title": "From algebraic irrationals to transcendence",
+    "content": "The parent entry proves √n irrational for non-square n — but each such number is ALGEBRAIC, a root of x² − n. The natural follow-up: are there irrationals that are roots of NO polynomial? This file answers yes, concretely and axiom-free, via Mathlib's Liouville theory. Liouville's constant ∑_k 2^{-k!} is transcendental over ℤ — not a root of any nonzero integer polynomial — and in particular irrational, an irrational lying strictly beyond the algebraic numbers of the parent.",
+    "mathContext": "Algebraic: a root of some nonzero $p\\in\\mathbb{Z}[x]$. Transcendental $=\\neg$ algebraic. $\\sqrt n$ is irrational but algebraic; transcendence is strictly stronger.",
+    "significance": "context",
+    "relatedConcepts": ["algebraic number", "transcendental number", "irrationality", "Liouville number"],
+    "prerequisites": ["polynomials over ℤ", "irrational numbers"]
+  },
+  {
+    "id": "ann-sqrt2oq02-liouville-const",
+    "proofId": "sqrt2-irrational-oq-02",
+    "range": {
+      "startLine": 31,
+      "endLine": 45
+    },
+    "type": "definition",
+    "title": "Liouville's constant: a Liouville number, irrational and transcendental",
+    "content": "liouvilleConst := liouvilleNumber 2 = ∑_k 2^{-k!}, the canonical concrete transcendental. Three facts are read off Mathlib's Liouville theory: liouvilleConst_liouville (it is a Liouville number, liouville_liouvilleNumber), liouvilleConst_irrational (Liouville numbers are irrational, .irrational), and liouvilleConst_transcendental (transcendental over ℤ, transcendental_liouvilleNumber). The defining feature of a Liouville number is that it is approximable by rationals far better than any algebraic number can be — which forces transcendence.",
+    "mathContext": "$L=\\sum_{k\\ge 1} 2^{-k!}$. A Liouville number $x$ admits, for every $n$, a rational $p/q$ with $0<|x-p/q|<q^{-n}$ — impossible for an algebraic irrational by Liouville's inequality, hence $x$ is transcendental.",
+    "significance": "key",
+    "relatedConcepts": ["Liouville number", "liouvilleNumber", "rational approximation", "transcendence"],
+    "prerequisites": ["Liouville's theorem on approximation", "series"]
+  },
+  {
+    "id": "ann-sqrt2oq02-existence",
+    "proofId": "sqrt2-irrational-oq-02",
+    "range": {
+      "startLine": 47,
+      "endLine": 59
+    },
+    "type": "insight",
+    "title": "Answer to OQ-02: irrational transcendentals exist",
+    "content": "exists_irrational_transcendental bundles liouvilleConst with its irrationality and transcendence to witness ∃ x, Irrational x ∧ Transcendental ℤ x. not_forall_irrational_isAlgebraic restates this as ∃ x, Irrational x ∧ ¬IsAlgebraic ℤ x — using that Transcendental ℤ x is definitionally ¬IsAlgebraic ℤ x — so the algebraic irrationals (the parent's √n) do NOT exhaust the irrationals. A single explicit construction settles the existence question without invoking Cantor's counting argument.",
+    "mathContext": "$\\exists x\\in\\mathbb{R},\\ \\text{Irrational }x\\wedge\\neg\\text{IsAlgebraic}_{\\mathbb{Z}}x$. Transcendence is strictly stronger than irrationality.",
+    "significance": "key",
+    "relatedConcepts": ["existence statement", "Transcendental", "IsAlgebraic", "non-exhaustion"],
+    "prerequisites": ["existential statements", "algebraic vs transcendental"]
+  }
+]

--- a/src/data/proofs/sqrt2-irrational-oq-02/index.ts
+++ b/src/data/proofs/sqrt2-irrational-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Sqrt2IrrationalOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sqrt2IrrationalOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sqrt2IrrationalOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sqrt2IrrationalOQ02Data: ProofData = {
+  proof: sqrt2IrrationalOQ02Proof,
+  annotations: sqrt2IrrationalOQ02Annotations,
+}

--- a/src/data/proofs/sqrt2-irrational-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-irrational-oq-02/meta.json
@@ -71,18 +71,62 @@
       "description": "Parent: irrationality of √n (algebraic irrationals). This entry answers its open question by exhibiting irrational numbers that are not algebraic at all (transcendentals)."
     }
   ],
-  "sections": [
+  "mainTheorems": [
     {
-      "title": "Liouville's constant: irrational and transcendental",
-      "startLine": 31,
-      "endLine": 50,
-      "summary": "liouvilleConst = liouvilleNumber 2, with its Liouville property, irrationality, and transcendence over ℤ from Mathlib."
+      "name": "exists_irrational_transcendental",
+      "type": "headline",
+      "description": "The answer to OQ-02: there exists an irrational real that is transcendental over ℤ — not a root of any nonzero integer polynomial. Witnessed by Liouville's constant.",
+      "leanType": "∃ x : ℝ, Irrational x ∧ Transcendental ℤ x"
     },
     {
+      "name": "not_forall_irrational_isAlgebraic",
+      "type": "core",
+      "description": "Transcendence is strictly stronger than irrationality: there is an irrational real that is NOT algebraic over ℤ, so the parent's algebraic irrationals √n do not exhaust the irrationals.",
+      "leanType": "∃ x : ℝ, Irrational x ∧ ¬ IsAlgebraic ℤ x"
+    },
+    {
+      "name": "liouvilleConst_transcendental",
+      "type": "core",
+      "description": "Liouville's constant ∑_k 2^{-k!} is transcendental over ℤ, via Mathlib's transcendental_liouvilleNumber.",
+      "leanType": "Transcendental ℤ liouvilleConst"
+    },
+    {
+      "name": "liouvilleConst_irrational",
+      "type": "supporting",
+      "description": "Liouville's constant is irrational (a Liouville number is irrational).",
+      "leanType": "Irrational liouvilleConst"
+    },
+    {
+      "name": "liouvilleConst_liouville",
+      "type": "supporting",
+      "description": "Liouville's constant is a Liouville number (liouville_liouvilleNumber at base 2) — the source of both irrationality and transcendence.",
+      "leanType": "Liouville liouvilleConst"
+    }
+  ],
+  "sections": [
+    {
+      "id": "context",
+      "title": "From algebraic irrationals to transcendence",
+      "startLine": 1,
+      "endLine": 29,
+      "summary": "Module docstring: the parent's √n are irrational but algebraic; OQ-02 asks for irrationals that are roots of no polynomial. This file answers concretely and axiom-free via Mathlib's Liouville theory.",
+      "mathContext": "Transcendental = not algebraic; transcendence is strictly stronger than irrationality."
+    },
+    {
+      "id": "liouville-const",
+      "title": "Liouville's constant: irrational and transcendental",
+      "startLine": 31,
+      "endLine": 45,
+      "summary": "liouvilleConst = liouvilleNumber 2, with its Liouville property (liouvilleConst_liouville), irrationality (liouvilleConst_irrational), and transcendence over ℤ (liouvilleConst_transcendental) from Mathlib.",
+      "mathContext": "$L=\\sum_k 2^{-k!}$; super-fast rational approximability forces transcendence."
+    },
+    {
+      "id": "existence",
       "title": "Existence and non-exhaustion",
-      "startLine": 52,
+      "startLine": 47,
       "endLine": 61,
-      "summary": "exists_irrational_transcendental and not_forall_irrational_isAlgebraic: irrational transcendentals exist, so algebraic irrationals do not exhaust the irrationals."
+      "summary": "exists_irrational_transcendental and not_forall_irrational_isAlgebraic: irrational transcendentals exist, so algebraic irrationals do not exhaust the irrationals.",
+      "mathContext": "$\\exists x,\\ \\text{Irrational }x\\wedge\\neg\\text{IsAlgebraic}_{\\mathbb Z}x$."
     }
   ],
   "sorries": []


### PR DESCRIPTION
Enrichment pass for `sqrt2-irrational-oq-02` (Liouville's constant as a concrete irrational transcendental). The entry had overview, conclusion, and a cross-reference but was **missing index.ts**, had no annotations, no `mainTheorems`, and incomplete section coverage.

## Changes
- **index.ts** (was absent): without it the page renders 'proof not found' on the live site. Added from the standard template (Lean source `Sqrt2IrrationalOQ02.lean`).
- **annotations.json** (was absent): 3 annotations (context: algebraic vs transcendental; Liouville's constant; the existence/non-exhaustion answer to OQ-02) with full fields.
- **mainTheorems** (was absent): 5 entries — exists_irrational_transcendental (headline), not_forall_irrational_isAlgebraic and liouvilleConst_transcendental (core), plus the two supporting Liouville facts.
- **sections**: expanded from 2 (no ids) to 3 with ids + a header section, now covering the full 61-line file.

## Verification
- meta.json and annotations.json validate as JSON; index.ts follows the established ProofData template.
- Cross-reference target (sqrt2-irrational) exists in the gallery.
- Annotation/section line ranges match the Lean source.
- No changes to status/badge/axiom claims — verified / 0 axioms / 0 sorries already accurate (transcendence/irrationality come from Mathlib's Liouville theory).