### PR TITLE
Enrich Burnside-over-Finite (lagrange OQ-02-OQ-02-OQ-01-OQ-01): annotations + sections

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-lagrange-oq02020101-header",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 6, "endLine": 54 },
+    "type": "context",
+    "title": "Burnside off Fintype: the open question",
+    "content": "The header poses the parent's OQ-02: Mathlib's Burnside / Cauchy–Frobenius lemma sum_card_fixedBy_eq_card_orbits_mul_card_group is stated with Fintype hypotheses; does it generalise to the merely Finite setting with no constructive Fintype instances? The answer is yes, and the proof lifts essentially unchanged — because the orbit-counting content lives in a finiteness-free bijection. The generalisation replaces Fintype.card by the total, instance-free Nat.card and the finite sum by finsum (∑ᶠ), the canonical 'sum over a Finite type' idiom.",
+    "mathContext": "$\\sum^{f}_{g:G} \\#(\\operatorname{fixedBy} X\\,g) = \\#(X/G)\\cdot \\#G$ for $G,X$ merely $\\mathrm{Finite}$ (here $\\#$ is $\\mathrm{Nat.card}$).",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "Cauchy–Frobenius", "Nat.card vs Fintype.card", "Mathlib hygiene"],
+    "prerequisites": ["group actions", "orbit counting"]
+  },
+  {
+    "id": "ann-lagrange-oq02020101-setup",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 60 },
+    "type": "definition",
+    "title": "Setup: a group action with no finiteness yet",
+    "content": "namespace BurnsideFinite, open MulAction, and the ambient variables: an arbitrary group G acting on a type X (MulAction G X), with NO finiteness hypotheses on the variables themselves — those are added per theorem. Stating the action abstractly here is what lets the same fixedBy / orbitRel.Quotient vocabulary carry both the Finite generalisation and the Fintype recovery.",
+    "mathContext": "$G$ a group acting on $X$; $\\operatorname{fixedBy} X\\,g = \\{x : g\\cdot x = x\\}$, orbit quotient $X/G = \\operatorname{orbitRel.Quotient} G\\,X$.",
+    "significance": "supporting",
+    "relatedConcepts": ["MulAction", "fixed points", "orbit quotient"],
+    "prerequisites": ["group actions"]
+  },
+  {
+    "id": "ann-lagrange-oq02020101-finite",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 82 },
+    "type": "insight",
+    "title": "The Finite generalisation in four rewrites",
+    "content": "sum_card_fixedBy_eq_card_orbits_mul_card_group_of_finite [Finite G] [Finite X]: the headline. The proof is a four-step rewrite of the SAME finiteness-free bijection sigmaFixedByEquivOrbitsProdGroup : (Σ g, fixedBy X g) ≃ (X/G) × G. cases nonempty_fintype G extracts a non-constructive Fintype G (the only finiteness actually consumed); then finsum_eq_sum_of_fintype turns ∑ᶠ into a Finset sum, ← Nat.card_sigma folds it into the sigma cardinality, Nat.card_congr transports along the bijection, and Nat.card_prod splits the product — closing by rfl. No Fintype X, no Fintype on the fixed-point sets or the quotient is ever supplied.",
+    "mathContext": "$\\sum^{f}_g \\#(\\operatorname{fixedBy} X\\,g) = \\#\\big(\\Sigma_g\\,\\operatorname{fixedBy} X\\,g\\big) = \\#\\big((X/G)\\times G\\big) = \\#(X/G)\\cdot\\#G$.",
+    "significance": "key",
+    "relatedConcepts": ["sigmaFixedByEquivOrbitsProdGroup", "Nat.card_congr", "Nat.card_sigma", "finsum", "nonempty_fintype"],
+    "prerequisites": ["the orbit-counting bijection", "Nat.card transport lemmas"]
+  },
+  {
+    "id": "ann-lagrange-oq02020101-recovered",
+    "proofId": "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 104 },
+    "type": "concept",
+    "title": "Recovering Mathlib's Fintype form",
+    "content": "sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered shows the generalisation genuinely subsumes the original: supplying the Fintype instances and unfolding Nat.card to Fintype.card returns Mathlib's exact statement. Notably Finite X is DERIVED, not assumed — with Finite G each orbit is the image of a finite type (Set.finite_range), and there are finitely many orbits, so X ≃ Σ ω, orbit … is finite (selfEquivSigmaOrbits). Then finsum_eq_sum_of_fintype + simpa [Nat.card_eq_fintype_card] converts every cardinality. This certifies the Finite form is upstream-ready.",
+    "mathContext": "Supplying $\\mathrm{Fintype}$ instances and $\\mathrm{Nat.card} = \\mathrm{Fintype.card}$ recovers $\\sum_g \\mathrm{Fintype.card}(\\operatorname{fixedBy} X\\,g) = \\mathrm{Fintype.card}(X/G)\\cdot\\mathrm{Fintype.card}\\,G$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card_eq_fintype_card", "selfEquivSigmaOrbits", "subsumption", "Mathlib contribution"],
+    "prerequisites": ["the Finite generalisation", "Fintype/Finite bridging"]
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -90,6 +90,36 @@
       "**Finite vs Fintype** — `nonempty_fintype : Finite α → Nonempty (Fintype α)` and the `Subtype.finite` instance, which together let a `Finite` hypothesis discharge every `Fintype`/`Finite` obligation in the proof."
     ]
   },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Burnside off Fintype",
+      "startLine": 6,
+      "endLine": 54,
+      "summary": "Module docstring: poses the parent's OQ-02 (generalise Mathlib's Fintype-form Burnside lemma to Finite), states the finsum/Nat.card generalisation, and explains why the proof lifts unchanged — the orbit-counting content is the finiteness-free bijection sigmaFixedByEquivOrbitsProdGroup."
+    },
+    {
+      "id": "setup",
+      "title": "Setup",
+      "startLine": 56,
+      "endLine": 60,
+      "summary": "namespace BurnsideFinite, open MulAction, and an abstract group action G ↷ X with no finiteness on the variables (added per theorem)."
+    },
+    {
+      "id": "finite-form",
+      "title": "The Finite generalisation",
+      "startLine": 62,
+      "endLine": 82,
+      "summary": "sum_card_fixedBy_eq_card_orbits_mul_card_group_of_finite: ∑ᶠ g, Nat.card (fixedBy X g) = Nat.card (X/G) · Nat.card G, proved in four rewrites of the finiteness-free bijection (nonempty_fintype G, finsum_eq_sum_of_fintype, ← Nat.card_sigma, Nat.card_congr, Nat.card_prod)."
+    },
+    {
+      "id": "recovered",
+      "title": "Recovering the Fintype form",
+      "startLine": 84,
+      "endLine": 109,
+      "summary": "sum_card_fixedBy_eq_card_orbits_mul_card_group_recovered: recovers Mathlib's exact Fintype statement as a corollary (Finite X is derived via selfEquivSigmaOrbits, then Nat.card_eq_fintype_card converts), certifying the generalisation subsumes the original and is upstream-ready."
+    }
+  ],
   "leanFile": {
     "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean",
     "namespace": "BurnsideFinite",


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-02-oq-01-oq-01` (generalising Mathlib's Burnside/Cauchy–Frobenius orbit-counting lemma off `Fintype` to `Finite`).

Entry previously had only `meta.json` — no `annotations.json` and no `sections` array. Quality score 35 (0 passes).

## Changes
- **annotations.json (new)**: 4 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering the off-Fintype open question, the abstract group-action setup, the four-rewrite `Finite` generalisation (via the finiteness-free bijection `sigmaFixedByEquivOrbitsProdGroup`), and the recovery of Mathlib's exact `Fintype` form.
- **sections (new)**: 4 sections covering all 101 lines of `LagrangeTheoremOQ02OQ02OQ01OQ01.lean`.

## Verification
Content checked against the Lean source; JSON validates. Axiom integrity: `verified`/`mathlib`, 0 axioms, 0 sorries; `nonempty_fintype` uses only Classical.choice (foundational, not counted).