### PR TITLE
Enrich Finite Arithmetico-Geometric Sum (summation-by-parts-oq-01)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-sbp-oq01-context",
+    "proofId": "summation-by-parts-oq-01",
+    "range": {
+      "startLine": 4,
+      "endLine": 42
+    },
+    "type": "context",
+    "title": "The arithmetico-geometric sum and why it is a gap",
+    "content": "Multiplying each term of the geometric series by its index k yields the arithmetico-geometric sum ∑_{k<n} k·rᵏ — the discrete analogue of differentiating the geometric series. Its exact finite closed form (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² holds over any field for r ≠ 1, with the |r|<1 limit giving the textbook ∑ k·rᵏ = r/(1−r)². Mathlib has the geometric closed form geom_sum_eq and the triangular number sum_range_id separately, but NOT the weighted sum; the gallery's infinite GeometricSeriesOQ06 (a tsum over a normed field) silently assumes the finite identity this entry supplies.",
+    "mathContext": "$\\sum_{k=0}^{n-1} k\\,r^k = \\dfrac{r - n r^n + (n-1) r^{n+1}}{(r-1)^2}$, an exact polynomial-over-$(r-1)^2$ identity with no analytic hypothesis.",
+    "significance": "context",
+    "relatedConcepts": ["arithmetico-geometric series", "geometric series", "discrete calculus", "Abel summation"],
+    "prerequisites": ["finite sums", "geometric series"]
+  },
+  {
+    "id": "ann-sbp-oq01-closed-form",
+    "proofId": "summation-by-parts-oq-01",
+    "range": {
+      "startLine": 50,
+      "endLine": 63
+    },
+    "type": "technique",
+    "title": "The closed form by induction",
+    "content": "sum_range_mul_geom proves the identity by induction on n over an arbitrary field K (r ≠ 1 gives r − 1 ≠ 0). The base case is the empty sum (0 = 0/(r−1)²). The step uses Finset.sum_range_succ to add the new term m·rᵐ to the closed form at m; push_cast handles the ℕ→K casts of the index, field_simp clears the (r−1)² denominator (legal since r−1 ≠ 0), and ring discharges the resulting polynomial identity n·rⁿ(r−1)² = n·rⁿ⁺² − 2n·rⁿ⁺¹ + n·rⁿ.",
+    "mathContext": "Inductive step: $\\frac{r - m r^m + (m-1)r^{m+1}}{(r-1)^2} + m r^m = \\frac{r - (m{+}1)r^{m+1} + m\\,r^{m+2}}{(r-1)^2}$, reduced to a $\\texttt{ring}$ identity after clearing denominators.",
+    "significance": "key",
+    "relatedConcepts": ["mathematical induction", "Finset.sum_range_succ", "field_simp", "ring", "polynomial identity"],
+    "prerequisites": ["induction on ℕ", "field arithmetic"]
+  },
+  {
+    "id": "ann-sbp-oq01-by-parts",
+    "proofId": "summation-by-parts-oq-01",
+    "range": {
+      "startLine": 65,
+      "endLine": 81
+    },
+    "type": "insight",
+    "title": "Re-derivation via Abel's summation by parts",
+    "content": "sum_range_mul_geom_eq_byParts derives the same sum a second, structurally illuminating way. Specializing Finset.sum_range_by_parts to the arithmetic weight f(k) = k and geometric sequence g(k) = rᵏ rewrites ∑ k·rᵏ as the boundary term (n−1)·Gₙ minus a correction ∑_{i<n−1} G_{i+1}, where Gₘ = ∑_{j<m} rʲ is the geometric partial sum. The key structural fact: the forward differences f(k+1) − f(k) = 1 are CONSTANT, so the abstract Abel correction collapses to a plain sum of geometric partial sums — the discrete analogue of integration by parts, and the reason the closed form exists at all.",
+    "mathContext": "$\\sum_{k<n} k\\,r^k = (n-1)G_n - \\sum_{i<n-1} G_{i+1}$, with $G_m=\\sum_{j<m}r^j$; constant increments $f(k{+}1)-f(k)=1$ degenerate the correction.",
+    "significance": "key",
+    "relatedConcepts": ["Abel summation", "Finset.sum_range_by_parts", "integration by parts analogue", "forward differences"],
+    "prerequisites": ["summation by parts", "partial sums"]
+  }
+]

--- a/src/data/proofs/summation-by-parts-oq-01/index.ts
+++ b/src/data/proofs/summation-by-parts-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SummationByPartsOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const summationByPartsOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const summationByPartsOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const summationByPartsOQ01Data: ProofData = {
+  proof: summationByPartsOQ01Proof,
+  annotations: summationByPartsOQ01Annotations,
+}

--- a/src/data/proofs/summation-by-parts-oq-01/meta.json
+++ b/src/data/proofs/summation-by-parts-oq-01/meta.json
@@ -73,6 +73,20 @@
       "mathContext": "The weight f k = k has constant forward differences f(k+1)−f k = 1, so smul_eq_mul + push_cast + ring reduce the Abel transform to a sum of geometric partial sums."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "sum_range_mul_geom",
+      "type": "headline",
+      "description": "Closed form for the finite arithmetico-geometric sum: over any field, for r ≠ 1, ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)². Proved by induction with field_simp + ring on the step.",
+      "leanType": "∀ {K : Type*} [Field K] {r : K}, r ≠ 1 → ∀ (n : ℕ), ∑ k ∈ Finset.range n, (k : K) * r ^ k = (r - n * r ^ n + (n - 1) * r ^ (n + 1)) / (r - 1) ^ 2"
+    },
+    {
+      "name": "sum_range_mul_geom_eq_byParts",
+      "type": "core",
+      "description": "The same sum re-derived via Abel's summation by parts: ∑_{k<n} k·rᵏ = (n−1)·Gₙ − ∑_{i<n−1} G_{i+1} with Gₘ = ∑_{j<m} rʲ. The constant forward differences of the weight collapse the correction to a sum of geometric partial sums.",
+      "leanType": "∀ {K : Type*} [Field K] (r : K) (n : ℕ), ∑ k ∈ Finset.range n, (k : K) * r ^ k = (↑(n - 1) : K) * (∑ i ∈ Finset.range n, r ^ i) - ∑ i ∈ Finset.range (n - 1), (∑ j ∈ Finset.range (i + 1), r ^ j)"
+    }
+  ],
   "conclusion": {
     "summary": "This entry supplies the exact finite arithmetico-geometric identity ∑_{k<n} k·rᵏ = (r − n·rⁿ + (n−1)·rⁿ⁺¹)/(r−1)² over any field, both by induction and via Abel's summation by parts — the finite refinement underpinning the gallery's infinite ∑ k·rᵏ = r/(1−r)².",
     "implications": "The closed form is the workhorse of discrete calculus and generating-function manipulation; the summation-by-parts derivation exhibits the discrete analogue of integration by parts as the structural source of the formula.",


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01` (closed form of ∑ k·rᵏ over any field, by induction and via Abel summation). The entry had overview, conclusion, 2 sections, and 2 cross-references but was **missing index.ts**, had no annotations, and no `mainTheorems`.

## Changes
- **index.ts** (was absent): without it the page renders 'proof not found' on the live site. Added from the standard template (Lean source `SummationByPartsOQ01.lean`).
- **annotations.json** (was absent): 3 annotations (the arithmetico-geometric gap vs Mathlib/gallery, the closed form by induction, the Abel summation-by-parts re-derivation) with full fields.
- **mainTheorems** (was absent): 2 entries — sum_range_mul_geom (headline closed form) and sum_range_mul_geom_eq_byParts (the by-parts re-derivation) — with statements from the Lean signatures.

## Verification
- meta.json and annotations.json validate as JSON; index.ts follows the established ProofData template.
- Cross-reference targets (geometric-series-oq-06, geometric-series) exist in the gallery.
- Annotation line ranges match the Lean source.
- No changes to status/badge/axiom claims — verified / original / 0 axioms / 0 sorries already accurate.