### PR TITLE
Enrich Erdős #2 covering-system structural cost (OQ-03): annotations

### DIFF
--- a/src/data/proofs/erdos-2-oq-03/annotations.json
+++ b/src/data/proofs/erdos-2-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-erdos2oq03-header",
+    "proofId": "erdos-2-oq-03",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "Scope and honesty: structural cost, not the bound",
+    "content": "The header is explicit about scope. OQ-03 asks for a quantitative improvement to the 616,000 upper bound on the minimum modulus of a covering system (Balister–Bollobás–Morris–Sahasrabudhe–Tiba, 2022) — a wide-open problem NOT resolved here. What this file proves is the elementary structural arithmetic any such bound must respect, the counting consequences of the classical density inequality Σ 1/nᵢ ≥ 1. Crucially it does NOT use the parent's reciprocal-sum axiom: every theorem takes Σ 1/nᵢ ≥ 1 as an explicit hypothesis, so the file is axiom-free (0 axioms, 0 sorries, no native_decide). It is also self-contained because the parent fails to compile under Lean 4.26.0.",
+    "mathContext": "Reciprocal-sum bound $\\sum 1/n_i \\ge 1$ for any covering system; taken as an explicit hypothesis, not an axiom.",
+    "significance": "context",
+    "relatedConcepts": ["covering systems", "Erdős #2", "minimum modulus", "reciprocal-sum bound"],
+    "prerequisites": ["modular arithmetic", "number theory"]
+  },
+  {
+    "id": "ann-erdos2oq03-defs",
+    "proofId": "erdos-2-oq-03",
+    "range": { "startLine": 60, "endLine": 93 },
+    "type": "definition",
+    "title": "Self-contained covering-system definitions",
+    "content": "The minimal scaffold, re-declared so the file is independently verifiable: CongruenceClass (residue, modulus ≥ 2) with toSet its integer arithmetic progression; CoveringSystem (a nonempty list of classes covering all integers); and the derived notions moduli, hasDistinctModuli, hasMinModulusAtLeast m, and reciprocalSum = Σ 1/nᵢ. These are the objects every bound below quantifies over.",
+    "mathContext": "A covering system: finitely many classes $\\{r_i \\bmod n_i\\}$ with $\\bigcup_i (r_i \\bmod n_i) = \\mathbb{Z}$; $\\operatorname{reciprocalSum} = \\sum_i 1/n_i$.",
+    "significance": "supporting",
+    "relatedConcepts": ["congruence class", "covering system", "modulus", "reciprocal sum"],
+    "prerequisites": ["arithmetic progressions"]
+  },
+  {
+    "id": "ann-erdos2oq03-recipbound",
+    "proofId": "erdos-2-oq-03",
+    "range": { "startLine": 95, "endLine": 117 },
+    "type": "technique",
+    "title": "The reciprocal-sum upper bound Σ 1/nᵢ ≤ k/m",
+    "content": "reciprocalSum_le: if every modulus is ≥ m, then Σ 1/nᵢ ≤ k/m where k is the number of classes — the trivial half of the density picture, since each summand 1/nᵢ ≤ 1/m. Proved by bounding each term (one_div_le_one_div_of_le) and summing (List.sum_le_card_nsmul). This is the inequality that, combined with the density lower bound, forces many classes.",
+    "mathContext": "$n_i \\ge m \\Rightarrow \\sum_i 1/n_i \\le k/m$, since each $1/n_i \\le 1/m$.",
+    "significance": "supporting",
+    "relatedConcepts": ["reciprocal sum", "density bound", "termwise bound"],
+    "prerequisites": ["the covering-system definitions"]
+  },
+  {
+    "id": "ann-erdos2oq03-classcount",
+    "proofId": "erdos-2-oq-03",
+    "range": { "startLine": 118, "endLine": 137 },
+    "type": "insight",
+    "title": "Class-count bound: min modulus ≥ m ⟹ k ≥ m",
+    "content": "card_classes_ge: a covering system with minimum modulus ≥ m must contain at least m congruence classes. Chaining the density lower bound 1 ≤ Σ 1/nᵢ (hypothesis) with the upper bound Σ 1/nᵢ ≤ k/m gives 1 ≤ k/m, i.e. m ≤ k. This is the elementary engine behind every quantitative attack on Erdős #2: a large minimum modulus is unavoidably expensive in classes.",
+    "mathContext": "$1 \\le \\sum 1/n_i \\le k/m \\Rightarrow m \\le k$ — minimum modulus $\\ge m$ forces $\\ge m$ classes.",
+    "significance": "key",
+    "relatedConcepts": ["class count", "minimum modulus", "density inequality"],
+    "prerequisites": ["the reciprocal-sum upper bound"]
+  },
+  {
+    "id": "ann-erdos2oq03-spread",
+    "proofId": "erdos-2-oq-03",
+    "range": { "startLine": 138, "endLine": 184 },
+    "type": "insight",
+    "title": "Spread bound: the moduli span a factor-2 range",
+    "content": "maxModulus_ge: with distinct moduli all in [m, M], necessarily 2m ≤ M + 1 — equivalently the largest modulus is ≥ 2m − 1, so the moduli cannot be confined to a narrow window above the minimum. Proof: card_classes_ge forces ≥ m classes, while distinctness confines the moduli to Icc m M (which has M + 1 − m elements), so m ≤ M + 1 − m. improvement_cost packages the class-count and spread bounds into the combined structural price of a minimum modulus ≥ m.",
+    "mathContext": "Distinct moduli in $[m,M]$ with $k \\ge m$ and $|Icc(m,M)| = M+1-m \\Rightarrow 2m \\le M+1$, i.e. $\\max n_i \\ge 2m-1$.",
+    "significance": "key",
+    "relatedConcepts": ["distinct moduli", "interval cardinality", "spread", "structural cost"],
+    "prerequisites": ["the class-count bound", "Finset.Icc cardinality"]
+  },
+  {
+    "id": "ann-erdos2oq03-tight",
+    "proofId": "erdos-2-oq-03",
+    "range": { "startLine": 186, "endLine": 234 },
+    "type": "concept",
+    "title": "Tightness: the trivial mod-2 cover attains k = m",
+    "content": "card_bound_tight shows the class-count bound k ≥ m cannot be improved to k > m in general: the trivial cover {0 mod 2, 1 mod 2} has minimum modulus m = 2, exactly k = 2 classes, and reciprocal sum 1/2 + 1/2 = 1. even_odd_cover certifies it covers ℤ, trivialCover_reciprocalSum computes the density exactly. So m ≤ k is sharp at the boundary density 1.",
+    "mathContext": "$\\{0 \\bmod 2, 1 \\bmod 2\\}$: $m = 2$, $k = 2$, $\\sum 1/n_i = 1/2 + 1/2 = 1$ — the bound $k \\ge m$ is attained.",
+    "significance": "supporting",
+    "relatedConcepts": ["tightness", "trivial covering", "sharp bound", "parity"],
+    "prerequisites": ["the class-count bound"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-2-oq-03` (the structural-arithmetic constraints any covering system with a large minimum modulus must obey — the soft consequences of Σ 1/nᵢ ≥ 1 behind Erdős #2).

Entry had `sections` but no `annotations.json`. Quality score 35 (0 passes).

## Changes
- **annotations.json (new)**: 6 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, aligned to the existing 5 sections plus a header annotation: the scope/honesty framing, the self-contained covering-system definitions, the reciprocal-sum upper bound Σ 1/nᵢ ≤ k/m, the class-count bound (min modulus ≥ m ⟹ k ≥ m), the factor-2 spread bound, and tightness via the trivial mod-2 cover.

## Verification
Content checked against the Lean source; JSON validates. Axiom integrity preserved: `verified`, 0 axioms, 0 sorries — the reciprocal-sum bound is taken as an explicit hypothesis, not the parent's axiom.