### PR TITLE
Enrich markov-equation-oq-03: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/markov-equation-oq-03/annotations.json
+++ b/src/data/proofs/markov-equation-oq-03/annotations.json
@@ -1,0 +1,162 @@
+[
+  {
+    "id": "markov-oq03-ann-header",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "Two Generalizations Sharing One Vieta Jump",
+    "content": "The classical Markov equation x² + y² + z² = 3xyz (parent Proofs.MarkovEquation) is the k = 0, n = 3, a = 3 member of two families: the parametric equation x² + y² + z² = 3xyz + k for a fixed integer k, and the n-variable Markov–Hurwitz equation ∑ xᵢ² = a·∏ xᵢ (Hurwitz 1907). The thesis of the file is that the Vieta jump — a solution-preserving involution with fixed root sum/product relations — survives both generalizations unchanged; only the *descent* (whether a jump strictly decreases a coordinate) is special to n = 3. Everything is elementary: the parametric identities are pure polynomial algebra and the n-variable facts are Finset manipulations, so the file is axiom-free.",
+    "mathContext": "$x^2+y^2+z^2 = 3xyz + k \\quad\\text{and}\\quad \\sum_{i} x_i^2 = a\\prod_i x_i.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Markov equation",
+      "Markov–Hurwitz equation",
+      "Vieta jumping",
+      "infinite descent"
+    ],
+    "prerequisites": [
+      "Diophantine equations",
+      "polynomial algebra over ℤ",
+      "Finset sums and products"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-genmarkov",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 45, "endLine": 75 },
+    "type": "theorem",
+    "title": "Parametric Vieta Jump: the Parameter k Cancels",
+    "content": "IsGenMarkov k x y z is the predicate x² + y² + z² = 3xyz + k. The jump z ↦ 3xy − z (genMarkov_vieta) preserves solutions for *every* k: substituting z' = 3xy − z into x² + y² + z'² − 3xyz' produces an expression in which k cancels identically, exactly as in the homogeneous case, so a single linear_combination h closes it. The root relations follow the same way: z + z' = 3xy (independent of k) and z·z' = x² + y² − k. Reading z as the unknown of the monic quadratic t² − 3xy·t + (x² + y² − k) = 0, the two roots are z and its jump partner, and these are Vieta's formulas for that quadratic.",
+    "mathContext": "$z' = 3xy - z,\\qquad z + z' = 3xy,\\qquad z\\,z' = x^2 + y^2 - k.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "solution-preserving involution",
+      "linear_combination tactic",
+      "quadratic root swap"
+    ],
+    "prerequisites": [
+      "polynomial identities",
+      "quadratic equations"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-foliation",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 77, "endLine": 86 },
+    "type": "insight",
+    "title": "The Parametric Family Foliates ℤ³",
+    "content": "genMarkov_param_unique observes that every integer triple (x, y, z) solves the parametric equation for exactly one value, k = x² + y² + z² − 3xyz. So the parametric family is a foliation of all of ℤ³ by level sets of the cubic form, and the classical Markov tree (k = 0, identified by genMarkov_zero_iff) is a single leaf of this one-parameter foliation. This reframes 'Markov triples' as the fibre over 0 of a globally defined invariant rather than an isolated object.",
+    "mathContext": "$k(x,y,z) = x^2 + y^2 + z^2 - 3xyz;\\quad \\mathbb{Z}^3 = \\bigsqcup_{k\\in\\mathbb{Z}} \\{(x,y,z): k(x,y,z)=k\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "foliation",
+      "level sets",
+      "invariants of cubic forms"
+    ],
+    "prerequisites": [
+      "cubic forms",
+      "fibres of a map"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-mh-defs",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 88, "endLine": 114 },
+    "type": "definition",
+    "title": "The n-Variable Jump as Function.update",
+    "content": "Part B indexes the variables by Fin n. IsMH a v is ∑ i, (v i)² = a·∏ i, v i. The Vieta partner at coordinate i is vietaVal a v i = a·(∏_{j ≠ i} vⱼ) − vᵢ, and vietaJump replaces just that coordinate via Function.update v i (vietaVal a v i). Encoding the move as a pointwise update is what makes the n-variable algebra tractable: vietaJump_self and vietaJump_of_ne record that the jump changes coordinate i and fixes every other coordinate, so any sum or product can later be split at i with the other factors untouched.",
+    "mathContext": "$\\mathrm{vietaVal}(a,v,i) = a\\!\\!\\prod_{j\\neq i}\\! v_j - v_i,\\qquad \\mathrm{vietaJump}(a,v,i) = v[i \\mapsto \\mathrm{vietaVal}(a,v,i)].$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Function.update",
+      "Fin n indexing",
+      "Finset.erase",
+      "coordinatewise jump"
+    ],
+    "prerequisites": [
+      "indexed families over Fin n",
+      "Finset products"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-dimensionfree",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 130, "endLine": 169 },
+    "type": "theorem",
+    "title": "Dimension-Free Preservation (isMH_vietaJump)",
+    "content": "The heart of the file: the Vieta jump preserves Markov–Hurwitz solutions in any number of variables and for any multiplier a. The proof splits the jumped tuple's sum of squares and product at coordinate i — the product over the other coordinates P = ∏_{j≠i} vⱼ is unchanged (prod_erase_vietaJump), and the sum of the other squares is unchanged (sum_erase_sq_vietaJump). Using the Vieta product relation vᵢ·(partner) = ∑_{j≠i} vⱼ² (vietaVal_mul), preservation reduces to the single polynomial identity (aP − vᵢ)² + vᵢ(aP − vᵢ) = a(aP − vᵢ)P, which holds for every n by ring. The same algebra that works in three variables works verbatim in n.",
+    "mathContext": "$(aP - v_i)^2 + v_i(aP - v_i) = a(aP - v_i)P,\\qquad P = \\prod_{j\\neq i} v_j.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Finset.add_sum_erase",
+      "Finset.mul_prod_erase",
+      "Vieta product relation",
+      "dimension-free algebra"
+    ],
+    "prerequisites": [
+      "Finset split lemmas",
+      "ring identities"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-positivity",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 184, "endLine": 205 },
+    "type": "theorem",
+    "title": "Positivity is Automatic, Not Assumed",
+    "content": "vietaVal_pos shows the partner of any coordinate of a positive solution is again positive when n ≥ 2, so the Vieta move never leaves the positive orthant and the descent tree is well-defined. The argument is short: vᵢ·(partner) = ∑_{j≠i} vⱼ², and with n ≥ 2 the erased index set is nonempty, so that sum of squares is strictly positive; dividing by vᵢ > 0 forces the partner positive. No positivity hypothesis on the partner is needed — it is a consequence of the product relation.",
+    "mathContext": "$v_i\\cdot\\mathrm{partner} = \\sum_{j\\neq i} v_j^2 > 0,\\ v_i>0 \\ \\Rightarrow\\ \\mathrm{partner} > 0.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "sum of squares positivity",
+      "Finset.sum_pos'",
+      "positive orthant",
+      "well-defined descent"
+    ],
+    "prerequisites": [
+      "ordered ring inequalities",
+      "nonempty Finset.erase"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-descent",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 207, "endLine": 221 },
+    "type": "insight",
+    "title": "The Descent Criterion and Why the Tree is Special to n = 3",
+    "content": "vietaVal_lt_iff is the exact criterion: with vᵢ > 0 the jump strictly decreases coordinate i iff that coordinate dominates the sum of the squares of the others, ∑_{j≠i} vⱼ² < vᵢ². This single inequality explains the dimensional boundary. For n = 3 the maximal coordinate of a sorted Markov triple always dominates the other two squares, so descent is guaranteed and the solutions organize into a tree. For n ≥ 4 the sum of the other squares can exceed the maximum, so no single global descent need exist — precisely the 'more delicate' behavior the parent's open question anticipated.",
+    "mathContext": "$\\mathrm{vietaVal}(a,v,i) < v_i \\iff \\sum_{j\\neq i} v_j^2 < v_i^2.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "infinite descent",
+      "dominance inequality",
+      "Markov tree",
+      "dimensional obstruction"
+    ],
+    "prerequisites": [
+      "strict monotonicity of multiplication",
+      "descent arguments"
+    ]
+  },
+  {
+    "id": "markov-oq03-ann-bridges",
+    "proofId": "markov-equation-oq-03",
+    "range": { "startLine": 223, "endLine": 263 },
+    "type": "context",
+    "title": "Bridges to the Classical Equation and Concrete Witnesses",
+    "content": "The final section identifies the generalizations' classical member and records concrete instances. isMH_three_iff writes out the three-variable equation coordinatewise via Fin.sum_univ_three / Fin.prod_univ_three, and isMH_three_markov specializes a = 3 to the classical Markov equation. Witnesses: isMH_ones (the singular triple (1,1,1) at a = 3), isMH_threes (the Hurwitz triple (3,3,3) of x²+y²+z² = xyz at a = 1), isMH_ones_four (an all-ones four-variable solution at a = 4), and vietaVal_ones_two, a worked jump showing (1,1,1) ↦ (1,1,2). These anchor the abstract Fin n machinery to checkable small cases.",
+    "mathContext": "$\\mathrm{IsMH}\\,3\\,(x,y,z)\\iff x^2+y^2+z^2 = 3xyz;\\quad (1,1,1)\\xrightarrow{\\text{jump } i=2}(1,1,2).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fin.sum_univ_three",
+      "Hurwitz triple",
+      "concrete witnesses",
+      "matrix literal ![·]"
+    ],
+    "prerequisites": [
+      "Fin.sum/prod_univ lemmas",
+      "matrix literal evaluation"
+    ]
+  }
+]

--- a/src/data/proofs/markov-equation-oq-03/meta.json
+++ b/src/data/proofs/markov-equation-oq-03/meta.json
@@ -56,6 +56,50 @@
       "The parametric family foliates all of ℤ³: every triple solves x² + y² + z² = 3xyz + k for exactly one k, so the Markov tree (k = 0) is one leaf of a one-parameter foliation."
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Overview: One Vieta Jump, Two Generalizations",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Docstring framing the classical Markov equation as the k = 0, n = 3, a = 3 member of the parametric family x² + y² + z² = 3xyz + k and the n-variable Markov–Hurwitz family ∑ xᵢ² = a·∏ xᵢ (Hurwitz 1907). States the thesis — the Vieta jump survives both generalizations as a solution-preserving involution with fixed root relations, while only the descent is special to n = 3 — and notes that the development is elementary and axiom-free. Imports Mathlib, opens the MarkovHurwitz namespace and Finset."
+    },
+    {
+      "id": "sec-parametric",
+      "title": "Part A — The Parametric Markov Equation",
+      "startLine": 39,
+      "endLine": 86,
+      "summary": "IsGenMarkov k x y z := x² + y² + z² = 3xyz + k, with coordinate swaps (genMarkov_swap12/23), the Vieta jump z ↦ 3xy − z preserving solutions for every k (genMarkov_vieta, by linear_combination), its involution, and the root sum z + z' = 3xy and product z·z' = x² + y² − k. genMarkov_zero_iff identifies k = 0 with the classical equation, and genMarkov_param_unique shows each triple solves the equation for the unique k = x² + y² + z² − 3xyz, foliating ℤ³."
+    },
+    {
+      "id": "sec-mh-defs",
+      "title": "Part B — The n-Variable Markov–Hurwitz Setup",
+      "startLine": 88,
+      "endLine": 114,
+      "summary": "Indexing variables by Fin n: IsMH a v := ∑ i, (v i)² = a·∏ i, v i, the Vieta partner vietaVal a v i = a·(∏_{j≠i} vⱼ) − vᵢ, and vietaJump as Function.update of coordinate i to its partner. vietaJump_self and vietaJump_of_ne record that the jump changes only coordinate i, enabling later sum/product splits at i."
+    },
+    {
+      "id": "sec-mh-invariance",
+      "title": "Dimension-Free Preservation and Involution",
+      "startLine": 116,
+      "endLine": 182,
+      "summary": "prod_erase_vietaJump and sum_erase_sq_vietaJump (the other coordinates are untouched), the Vieta relations vietaVal_add (partner + vᵢ = a·∏_{j≠i} vⱼ) and vietaVal_mul (vᵢ·partner = ∑_{j≠i} vⱼ²), the headline isMH_vietaJump — the jump preserves solutions in any n via the identity (aP − vᵢ)² + vᵢ(aP − vᵢ) = a(aP − vᵢ)P — and vietaJump_involutive."
+    },
+    {
+      "id": "sec-positivity-descent",
+      "title": "Positivity and the Descent Criterion",
+      "startLine": 184,
+      "endLine": 221,
+      "summary": "vietaVal_pos: on a positive solution with n ≥ 2 the partner is again positive (the jump stays in the positive orthant), because vᵢ·partner = ∑_{j≠i} vⱼ² > 0. vietaVal_lt_iff: the jump strictly decreases coordinate i iff ∑_{j≠i} vⱼ² < vᵢ² — the exact dominance inequality automatic at the maximal coordinate when n = 3 but able to fail for larger n."
+    },
+    {
+      "id": "sec-bridges",
+      "title": "Bridges to the Classical Equation and Witnesses",
+      "startLine": 223,
+      "endLine": 263,
+      "summary": "isMH_three_iff (coordinatewise three-variable form via Fin.sum/prod_univ_three) and isMH_three_markov (a = 3 is the classical Markov equation), plus concrete witnesses isMH_ones (1,1,1), isMH_threes the Hurwitz (3,3,3) of x²+y²+z²=xyz, isMH_ones_four an all-ones four-variable solution, and vietaVal_ones_two, a worked jump (1,1,1) ↦ (1,1,2)."
+    }
+  ],
   "conclusion": {
     "summary": "A self-contained, 0-axiom, 0-sorry formalization (263 lines, 23 theorems, 4 definitions) extending the Markov equation's Vieta-jump theory to the parametric equation x² + y² + z² = 3xyz + k and the n-variable Markov–Hurwitz equation ∑ xᵢ² = a·∏ xᵢ. The solution-preserving involution and root sum/product relations are proved in both families; for n variables the jump is shown to preserve positivity and the exact descent criterion (a coordinate descends iff it dominates the sum of the other squares) is established.",
     "implications": "The results answer the parent entry's third open question constructively: the part of Markov theory that generalizes is exactly the Vieta-jump algebra, and the descent criterion isolates why the full tree classification is a three-variable phenomenon. The dimension-free preservation lemma (isMH_vietaJump) is reusable infrastructure for formalizing any Markov–Hurwitz descent, and the foliation observation places the classical equation inside a one-parameter family.",


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-03` (Generalizations of the Markov Equation: Parametric and Markov–Hurwitz Vieta Jumping).

The entry previously had `meta.json` with overview/conclusion but **no annotations** and **no `sections`** array.

**Added:**
- **annotations.json** — 8 annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: the two-generalizations framing, the parametric Vieta jump (k cancels), the ℤ³ foliation, the n-variable `Function.update` setup, the dimension-free preservation identity, automatic positivity, the descent criterion and why the tree is special to n=3, and the classical bridges/witnesses.
- **sections** — 6 sections spanning all 263 lines of `MarkovHurwitz.lean`.

Axiom integrity unchanged: `status: verified`, `badge: original`, `axiomCount: 0` — confirmed against the Lean source (0 axioms, 0 sorries, no native_decide).

Note: per-proof `index.ts` is no longer used for loading (entries load via build-generated `listings.json` + `data-manifest.json` since #20993), so none is added.

Verified with `pnpm build`.