### PR TITLE
Enrich Nonderogatory Converse nilpotent case (cayley-hamilton-minpoly-oq-04-oq-01)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "Isolating the case of the converse that needs no infinite field",
     "content": "A matrix M is nonderogatory when minpoly K M = charpoly M, equivalently when it has a cyclic vector. The parent entry proves the easy direction (cyclic ⟹ nonderogatory) and axiomatizes the converse. The OQ04Backward sibling proves the converse for infinite fields but its main assembly is a `sorry` (a normalizedFactors/DecidableEq import clash). This file handles the one case of the converse that needs neither an infinite field nor rational-canonical-form machinery: maximal-nilpotent matrices N with Nⁿ = 0 and Nⁿ⁻¹ ≠ 0, i.e. a single Jordan block at 0. For these we construct a cyclic vector EXPLICITLY over an arbitrary field, finite ones included.",
-    "mathContext": "Single nilpotent Jordan block: $N^n=0$, $N^{n-1}\\ne 0$. Cyclic vector exists over any field $K$."
+    "mathContext": "Single nilpotent Jordan block: $N^n=0$, $N^{n-1}\\ne 0$. Cyclic vector exists over any field $K$.",
+    "significance": "context",
+    "relatedConcepts": ["nonderogatory matrix", "cyclic vector", "minimal polynomial", "Jordan block", "nilpotent matrix"],
+    "prerequisites": ["minimal and characteristic polynomials", "linear algebra over a field"]
   },
   {
     "id": "ann-chminpolyoq04oq01-helpers",
@@ -15,24 +18,33 @@
     "type": "technique",
     "title": "Krylov-independence helpers, reproved inline",
     "content": "Three lemmas drive the construction. exists_mulVec_ne_zero: a nonzero matrix sends some standard basis vector outside its kernel. isCyclicVector_of_linearIndependent: if {v, Mv, …, Mⁿ⁻¹v} are linearly independent then no nonzero polynomial of degree < n annihilates v (uses aeval_eq_sum_range' to expand p(M) over the power basis, then Fintype.linearIndependent_iff). nilpotent_krylov_independent: for Nⁿ=0 and Nⁿ⁻¹v≠0, applying Nⁿ⁻¹⁻ʲ to a linear relation ∑cₖNᵏv=0 kills the high-degree terms by nilpotency and the low-degree terms by induction, leaving cⱼNⁿ⁻¹v=0 hence cⱼ=0 (descending strong induction). These are the proven helpers of the OQ04Backward sibling, reproduced here because that sibling's downstream assembly no longer compiles against Mathlib 4.26.0.",
-    "mathContext": "Apply $N^{\\,n-1-j}$ to $\\sum_k c_k N^k v = 0$: terms with $k>j$ vanish ($N^{\\ge n}=0$), terms with $k<j$ vanish by IH, leaving $c_j N^{n-1}v = 0$."
+    "mathContext": "Apply $N^{\\,n-1-j}$ to $\\sum_k c_k N^k v = 0$: terms with $k>j$ vanish ($N^{\\ge n}=0$), terms with $k<j$ vanish by IH, leaving $c_j N^{n-1}v = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Krylov subspace", "linear independence", "nilpotency", "descending induction", "power basis"],
+    "prerequisites": ["linear independence", "polynomial evaluation aeval", "nilpotent matrices"]
   },
   {
     "id": "ann-chminpolyoq04oq01-construction",
     "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
     "range": { "startLine": 161, "endLine": 174 },
-    "type": "key-step",
+    "type": "insight",
     "title": "The explicit cyclic vector",
     "content": "maximal_nilpotent_has_cyclic_vector is a three-line composition: since Nⁿ⁻¹ ≠ 0, exists_mulVec_ne_zero yields v with Nⁿ⁻¹v ≠ 0; nilpotent_krylov_independent makes its Krylov vectors linearly independent; isCyclicVector_of_linearIndependent upgrades that to cyclicity. No infinitude of K and no factorization are used, so this covers finite fields — exactly the gap left open by the infinite-field theorem.",
-    "mathContext": "Any $v\\notin\\ker N^{n-1}$ is cyclic: $\\{v,Nv,\\dots,N^{n-1}v\\}$ is a basis."
+    "mathContext": "Any $v\\notin\\ker N^{n-1}$ is cyclic: $\\{v,Nv,\\dots,N^{n-1}v\\}$ is a basis.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic vector", "constructive proof", "finite fields", "Krylov sequence"],
+    "prerequisites": ["cyclic vectors", "bases of vector spaces"]
   },
   {
     "id": "ann-chminpolyoq04oq01-minpoly",
     "proofId": "cayley-hamilton-minpoly-oq-04-oq-01",
     "range": { "startLine": 175, "endLine": 238 },
-    "type": "key-step",
+    "type": "insight",
     "title": "Minimal polynomial = Xⁿ, and the iff characterization",
     "content": "minpoly_eq_X_pow_of_maximal_nilpotent: Nⁿ = 0 gives aeval N (Xⁿ) = 0, so minpoly K N ∣ Xⁿ; since X is prime (prime_X), dvd_prime_pow gives minpoly associated to Xⁱ, and eq_of_monic_of_associated (both monic) makes minpoly = Xⁱ; then Nⁱ = 0, so i ≥ n (else Nⁿ⁻¹ = Nⁿ⁻¹⁻ⁱ·Nⁱ = 0), forcing i = n. The converse maximal_nilpotent_of_minpoly_eq_X_pow reads Nⁿ = 0 off aeval, and rules out Nⁿ⁻¹ = 0 by a degree comparison (minpoly would divide Xⁿ⁻¹). Together they give the iff and natDegree(minpoly) = n, linking the construction to the parent's degree-based nonderogatory characterization.",
-    "mathContext": "$\\mu\\mid X^n$, $X$ prime $\\Rightarrow \\mu = X^i$; $N^{n-1}\\ne 0\\Rightarrow i=n$, so $\\mu = X^n$ and $\\deg\\mu = n$."
+    "mathContext": "$\\mu\\mid X^n$, $X$ prime $\\Rightarrow \\mu = X^i$; $N^{n-1}\\ne 0\\Rightarrow i=n$, so $\\mu = X^n$ and $\\deg\\mu = n$.",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "prime element X", "dvd_prime_pow", "associated polynomials", "natDegree"],
+    "prerequisites": ["divisibility in polynomial rings", "prime elements", "monic polynomials"]
   }
 ]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/index.ts
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleyHamiltonMinpolyOQ04OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleyHamiltonMinpolyOQ04OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleyHamiltonMinpolyOQ04OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleyHamiltonMinpolyOQ04OQ01Data: ProofData = {
+  proof: cayleyHamiltonMinpolyOQ04OQ01Proof,
+  annotations: cayleyHamiltonMinpolyOQ04OQ01Annotations,
+}

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
@@ -59,6 +59,44 @@
     "dateAdded": "2026-06-21",
     "mathlib_version": "4.26.0"
   },
+  "overview": {
+    "historicalContext": "A square matrix is nonderogatory when its minimal and characteristic polynomials coincide, equivalently (Frobenius) when it admits a cyclic vector — a single vector whose iterated images under the matrix span the whole space. This is the linear-algebra backbone of rational canonical form. The easy direction (a cyclic vector forces minpoly = charpoly) is elementary; the converse — every nonderogatory matrix has a cyclic vector — is classically proved via the structure theorem for modules over a PID or rational canonical form, machinery that is heavy to formalize and, in some routes, implicitly assumes an infinite field. This entry isolates the one case where the converse is fully constructive and field-agnostic: the single nilpotent Jordan block N with Nⁿ = 0 and Nⁿ⁻¹ ≠ 0.",
+    "problemStatement": "Prove the converse of the cyclic-vector / nonderogatory equivalence for the maximal-nilpotent case over an ARBITRARY field: if N satisfies Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has a cyclic vector. Also characterize this hypothesis arithmetically as minpoly K N = Xⁿ.",
+    "proofStrategy": "Constructive. Since Nⁿ⁻¹ ≠ 0, some standard basis vector v has Nⁿ⁻¹v ≠ 0 (exists_mulVec_ne_zero). The Krylov vectors {v, Nv, …, Nⁿ⁻¹v} are then linearly independent: apply Nⁿ⁻¹⁻ʲ to a vanishing linear combination — terms above degree j die by nilpotency, terms below by descending induction — leaving cⱼ Nⁿ⁻¹v = 0, hence cⱼ = 0 (nilpotent_krylov_independent). Linear independence of the power orbit is exactly cyclicity (isCyclicVector_of_linearIndependent, via aeval_eq_sum_range'). Separately, minpoly K N = Xⁿ is obtained from Nⁿ = 0 (so minpoly ∣ Xⁿ), primeness of X (minpoly = Xⁱ), and Nⁿ⁻¹ ≠ 0 (forcing i = n).",
+    "keyInsights": [
+      "**The nilpotent case needs no infinite field.** The general converse routes through rational canonical form or PID module theory; for a single Jordan block the cyclic vector is built by hand, so the result holds over finite fields too — exactly the gap the infinite-field sibling cannot cover.",
+      "**Cyclicity = Krylov linear independence.** A vector is cyclic iff its power orbit {v, Nv, …, Nⁿ⁻¹v} is linearly independent; the proof expands p(N)v over this power basis (aeval_eq_sum_range') so that no nonzero low-degree polynomial annihilates v.",
+      "**Nilpotency peels coefficients one at a time.** Applying the right power of N to a linear relation kills high-degree terms outright and, with descending induction, isolates each coefficient against the nonzero Nⁿ⁻¹v — an elementary substitute for module-theoretic generators.",
+      "**minpoly = Xⁿ is the clean restatement.** The maximal-nilpotent hypothesis Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0 is exactly minpoly K N = Xⁿ (X prime ⟹ minpoly is a power of X; the nonvanishing pins the exponent), tying the construction to the degree-n (nonderogatory) framing of the parent.",
+      "**Honest scope.** This discharges the parent's axiomatized converse only for the maximal-nilpotent case; the general nonderogatory converse remains axiomatized, and the infinite-field sibling's full assembly still carries a `sorry`."
+    ],
+    "prerequisites": [
+      "Minimal and characteristic polynomials; nonderogatory matrices and cyclic vectors",
+      "Krylov / power-orbit linear independence and aeval over a power basis",
+      "Nilpotent matrices and the single Jordan block; primeness of X in K[X]"
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (238 lines, 9 theorems, 1 definition) of the constructive converse of the cyclic-vector / nonderogatory equivalence for maximal-nilpotent matrices over an arbitrary field: if Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has an explicit cyclic vector. It also gives the arithmetic characterization minpoly K N = Xⁿ ⟺ (Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0) and natDegree(minpoly K N) = n.",
+    "implications": "Discharges the parent entry's axiomatized converse for the nilpotent single-Jordan-block case — and crucially over finite fields, which the infinite-field sibling cannot reach — by an explicit Krylov construction needing no rational-canonical-form or PID machinery. The reproved Krylov-independence helpers are reusable infrastructure for cyclic-vector arguments elsewhere in the Cayley–Hamilton / minimal-polynomial family.",
+    "openQuestions": [
+      "Extend the constructive converse from a single nilpotent Jordan block to a general nilpotent matrix (direct sum of blocks), and then to arbitrary nonderogatory matrices over any field, fully discharging the parent's axiom.",
+      "Repair the infinite-field sibling (CayleyHamiltonMinpolyOQ04Backward) whose downstream assembly carries a `sorry` and a bit-rotted `ring` step under Mathlib 4.26.0.",
+      "Connect the explicit cyclic vector to a constructive rational canonical form over finite fields, where genericity arguments are unavailable."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: proves cyclic ⟹ nonderogatory and axiomatizes the converse. This entry discharges the converse for the maximal-nilpotent (single Jordan block) case over an arbitrary field, by an explicit cyclic-vector construction."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+      "relationship": "complements",
+      "description": "Sibling that proves the converse for infinite fields but leaves its main assembly as a `sorry`. This entry handles the orthogonal case that needs neither an infinite field nor factorization machinery (finite fields included), reproving the shared Krylov-independence helpers inline."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-04-oq-01` (constructive cyclic vector for maximal-nilpotent matrices over any field). The entry already had annotations, 3 sections, and 5 mainTheorems but was **missing index.ts**, had no overview, no conclusion, and no cross-references; its annotations also lacked the depth fields.

## Changes
- **index.ts** (was absent): without it the page renders 'proof not found' on the live site. Added from the standard template (Lean source `CayleyHamiltonMinpolyOQ04OQ01.lean`).
- **overview** (was absent): historicalContext (nonderogatory ⟺ cyclic vector, rational canonical form), problemStatement, proofStrategy (Krylov construction + minpoly = Xⁿ), and 5 keyInsights.
- **conclusion** (was absent): summary, implications, and 3 openQuestions.
- **crossReferences** (was absent): parent `cayley-hamilton-minpoly-oq-04` and the infinite-field sibling `cayley-hamilton-minpoly-oq-04-backward-incomplete-01`.
- **annotations**: enriched all 4 with `significance`/`relatedConcepts`/`prerequisites` and normalized the non-standard `key-step` type to `insight`.

## Verification
- meta.json and annotations.json validate as JSON; index.ts follows the established ProofData template.
- Cross-reference targets exist in the gallery.
- Existing sections (3) and mainTheorems (5) left intact.
- No changes to status/badge/axiom claims — verified / original / 0 axioms / 0 sorries already accurate (no native_decide); scope (nilpotent case only, parent's general axiom not discharged) preserved.