### PR TITLE
Enrich markov-equation: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/markov-equation/annotations.json
+++ b/src/data/proofs/markov-equation/annotations.json
@@ -1,0 +1,147 @@
+[
+  {
+    "id": "markov-ann-header",
+    "proofId": "markov-equation",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "concept",
+    "title": "The Markov Equation and the Markov Tree",
+    "content": "The Markov equation x² + y² + z² = 3xyz, introduced by A. A. Markov in 1879 while studying minima of indefinite binary quadratic forms, has positive integer solutions (Markov triples) that organize into an infinite ternary tree rooted at the singular solution (1,1,1): (1,1,1), (1,1,2), (1,2,5), (1,5,13), (2,5,29), …. The file defines IsMarkov x y z as the conjunction 0 < x ∧ 0 < y ∧ 0 < z ∧ x² + y² + z² = 3xyz and proves the root (1,1,1) is a solution. The whole development is elementary and axiom-free — the equation is not in Mathlib (Pell.Solution₁ only covers norm-+1 binary Pell), so the ternary descent is built from scratch.",
+    "mathContext": "$x^2 + y^2 + z^2 = 3xyz,\\qquad (x,y,z)\\in\\mathbb{Z}_{>0}^3.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Markov equation",
+      "Markov tree",
+      "Diophantine equations",
+      "Markov numbers"
+    ],
+    "prerequisites": [
+      "Diophantine equations",
+      "quadratic forms",
+      "positive integers over ℤ"
+    ]
+  },
+  {
+    "id": "markov-ann-symmetry",
+    "proofId": "markov-equation",
+    "range": { "startLine": 39, "endLine": 49 },
+    "type": "technique",
+    "title": "Symmetry: Coordinate Transpositions Preserve Solutions",
+    "content": "Because x² + y² + z² = 3xyz is symmetric in its three variables, any transposition of coordinates sends a Markov triple to a Markov triple. markov_swap12 and markov_swap23 record the two adjacent transpositions (which generate the full symmetric group S₃); each is a one-line linear_combination on the defining equation, carrying along the positivity conjuncts. These transpositions are later combined with the Vieta jump to form the move relation of the tree.",
+    "mathContext": "$\\mathrm{IsMarkov}(x,y,z)\\iff\\mathrm{IsMarkov}(y,x,z)\\iff\\mathrm{IsMarkov}(x,z,y).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric polynomials",
+      "transpositions",
+      "S₃ action",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "symmetry of polynomials",
+      "permutations"
+    ]
+  },
+  {
+    "id": "markov-ann-vieta",
+    "proofId": "markov-equation",
+    "range": { "startLine": 51, "endLine": 74 },
+    "type": "theorem",
+    "title": "Vieta Jumping: the Root-Swapping Involution",
+    "content": "Fixing x and y, the Markov equation is the monic quadratic t² − 3xy·t + (x²+y²) = 0 in the third coordinate. Its two roots z and z' = 3xy − z satisfy z·z' = x² + y² (markov_root_prod, by Vieta). markov_vieta shows the jump z ↦ 3xy − z again yields a Markov triple: solution-preservation is one linear_combination, and positivity of the new coordinate follows from z·z' = x² + y² > 0 with z > 0 (nlinarith). The jump is an involution (markov_vieta_involutive), so the move relation it generates is symmetric and produces a tree rather than a directed chain.",
+    "mathContext": "$z + z' = 3xy,\\qquad z\\,z' = x^2 + y^2,\\qquad z' = 3xy - z.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "root conjugation",
+      "involution",
+      "quadratic in one variable"
+    ],
+    "prerequisites": [
+      "Vieta's formulas",
+      "quadratic equations",
+      "positivity reasoning"
+    ]
+  },
+  {
+    "id": "markov-ann-descent",
+    "proofId": "markov-equation",
+    "range": { "startLine": 76, "endLine": 112 },
+    "type": "insight",
+    "title": "The Descent Inequality — the Arithmetic Heart",
+    "content": "For a sorted triple x ≤ y ≤ z with z ≥ 2, markov_top_strict shows the top coordinate is a strict maximum (y < z): a tie y = z would force x² = z²(3x−2), impossible for 1 ≤ x ≤ z. markov_vieta_lt then proves the jump strictly decreases the maximum: 3xy − z < z. The engine is the sign of the quadratic at t = y, g(y) = (y − z)(y − z') = x² + 2y² − 3xy² = x² + y²(2 − 3x) ≤ 0 (since x ≥ 1). With y < z this gives z' ≤ y, so z·z' = x²+y² ≤ z·y < z², which converts to 3xy < 2z, i.e. 3xy − z < z. So replacing the maximal coordinate strictly decreases the sum.",
+    "mathContext": "$g(y) = (y-z)(y-z') = x^2 + y^2(2-3x) \\le 0 \\ \\Rightarrow\\ 3xy - z < z.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "infinite descent",
+      "sign of a quadratic",
+      "monovariant",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "quadratic inequalities",
+      "ordered rings",
+      "case analysis"
+    ]
+  },
+  {
+    "id": "markov-ann-reachability",
+    "proofId": "markov-equation",
+    "range": { "startLine": 114, "endLine": 167 },
+    "type": "definition",
+    "title": "The Move Relation and Sorting",
+    "content": "Step is the inductive move relation with three constructors — the two transpositions and the Vieta jump — and Reachable is its reflexive-transitive closure (Relation.ReflTransGen). isMarkov_of_step confirms every single move preserves IsMarkov. sort_reachable handles the six orderings of a triple: any triple reaches a sorted representative a ≤ b ≤ c, with the same coordinate sum, by at most three transpositions. Encoding reachability via ReflTransGen lets the main descent be a single downward chain assembled with .head / .tail / .trans.",
+    "mathContext": "$\\mathrm{Reachable} = \\mathrm{ReflTransGen}\\,\\mathrm{Step},\\quad \\mathrm{Step} = \\{\\text{swap}_{12}, \\text{swap}_{23}, \\text{vieta}\\}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "reflexive-transitive closure",
+      "Relation.ReflTransGen",
+      "inductive relations",
+      "sorting networks"
+    ],
+    "prerequisites": [
+      "inductive predicates",
+      "transitive closure",
+      "case analysis on order"
+    ]
+  },
+  {
+    "id": "markov-ann-classification",
+    "proofId": "markov-equation",
+    "range": { "startLine": 169, "endLine": 207 },
+    "type": "theorem",
+    "title": "Classification by Strong Induction on the Sum",
+    "content": "markov_reachable_one is the main theorem: every positive Markov triple is reachable from (1,1,1). The proof is strong induction on the coordinate sum (as a ℕ via toNat). Sort the triple; if the top coordinate c = 1 then a = b = c = 1 and we are at the root; otherwise c ≥ 2, so the Vieta jump produces a genuine Markov triple with strictly smaller sum (markov_vieta_lt + Int.toNat_lt_toNat), and the induction hypothesis finishes. markov_classification is the clean corollary. The sum x + y + z is the monovariant that makes descent terminate.",
+    "mathContext": "$\\forall (x,y,z),\\ \\mathrm{IsMarkov}(x,y,z)\\ \\Rightarrow\\ \\mathrm{Reachable}((x,y,z),(1,1,1)).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "strong induction",
+      "infinite descent",
+      "monovariant",
+      "Int.toNat"
+    ],
+    "prerequisites": [
+      "well-founded induction",
+      "Nat.strong_induction_on",
+      "descent arguments"
+    ]
+  },
+  {
+    "id": "markov-ann-uniqueness",
+    "proofId": "markov-equation",
+    "range": { "startLine": 209, "endLine": 237 },
+    "type": "context",
+    "title": "Uniqueness of the Root and Small Triples",
+    "content": "markov_all_eq proves (t,t,t) is Markov iff t = 1: the equation collapses to t²(t−1) = 0, and positivity rules out t = 0. So (1,1,1) is the unique fixed triple of the descent — every other triple has a strict maximum to jump down. The file closes with concrete witnesses (1,1,2), (1,2,5), (2,5,29) and markov_step_root_to_112 exhibiting the first Vieta jump (1,1,1) ↦ (1,1,2), anchoring the abstract classification to the leading entries of the Markov tree.",
+    "mathContext": "$\\mathrm{IsMarkov}(t,t,t)\\iff t^2(t-1)=0 \\iff t = 1;\\quad (1,1,1)\\to(1,1,2)\\to(1,2,5)\\to\\cdots$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "fixed points",
+      "Markov triples",
+      "singular solution",
+      "tree leaves"
+    ],
+    "prerequisites": [
+      "factoring over ℤ",
+      "small-case verification"
+    ]
+  }
+]

--- a/src/data/proofs/markov-equation/meta.json
+++ b/src/data/proofs/markov-equation/meta.json
@@ -36,6 +36,57 @@
     "theoremCount": 17,
     "definitionCount": 3
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "The Markov Equation and the Root (1,1,1)",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Docstring introducing the Markov equation x² + y² + z² = 3xyz, the Markov tree rooted at (1,1,1), and the descent strategy (sign of the quadratic g(t) = t² − 3xy·t + (x²+y²)). Notes that the ternary equation is not in Mathlib. Imports Mathlib, opens the MarkovEquation namespace, defines IsMarkov as positivity plus the equation, and proves markov_one that (1,1,1) is a solution."
+    },
+    {
+      "id": "sec-symmetry",
+      "title": "Symmetry of the Equation",
+      "startLine": 39,
+      "endLine": 49,
+      "summary": "markov_swap12 and markov_swap23: the two adjacent coordinate transpositions preserve Markov triples (the equation is fully symmetric), each a one-line linear_combination carrying the positivity hypotheses. These generate the S₃ action used in the move relation."
+    },
+    {
+      "id": "sec-vieta",
+      "title": "Vieta Jumping",
+      "startLine": 51,
+      "endLine": 74,
+      "summary": "markov_root_prod (the two z-roots multiply to x²+y²), markov_vieta (the jump z ↦ 3xy − z sends a Markov triple to a Markov triple, with positivity of the new coordinate from z·z' = x²+y² > 0 and z > 0), and markov_vieta_involutive (the jump is an involution). This is the root-swapping move of the tree."
+    },
+    {
+      "id": "sec-descent",
+      "title": "The Descent Inequality",
+      "startLine": 76,
+      "endLine": 112,
+      "summary": "markov_top_strict (a sorted triple with z ≥ 2 has a strict maximum y < z; a tie forces the impossible x² = z²(3x−2)) and markov_vieta_lt (the Vieta jump on the maximum strictly decreases it, 3xy − z < z), driven by the sign g(y) = (y−z)(y−z') = x² + y²(2−3x) ≤ 0 and the chain x²+y² = z·z' ≤ z·y < z². The engine of the descent."
+    },
+    {
+      "id": "sec-reachability",
+      "title": "Reachability in the Markov Tree",
+      "startLine": 114,
+      "endLine": 167,
+      "summary": "The inductive Step relation (two transpositions + Vieta jump), Reachable as its reflexive-transitive closure, isMarkov_of_step (each move preserves IsMarkov), and sort_reachable (any triple reaches a sorted representative with the same sum via ≤ 3 transpositions, covering all six orderings)."
+    },
+    {
+      "id": "sec-classification",
+      "title": "Main Classification Theorem",
+      "startLine": 169,
+      "endLine": 207,
+      "summary": "markov_reachable_one by strong induction on the coordinate sum (via Int.toNat): sort the triple, and if the top is ≥ 2, Vieta-jump it down to a strictly smaller sum and apply the induction hypothesis; otherwise it is (1,1,1). markov_classification packages this as: every positive Markov triple is reachable from the root."
+    },
+    {
+      "id": "sec-consequences",
+      "title": "Consequences and Small Triples",
+      "startLine": 209,
+      "endLine": 237,
+      "summary": "markov_all_eq (the root (1,1,1) is the unique all-equal triple, since (t,t,t) Markov ⟺ t²(t−1) = 0 ⟺ t = 1), the concrete witnesses (1,1,2), (1,2,5), (2,5,29), and markov_step_root_to_112 exhibiting the first Vieta jump (1,1,1) ↦ (1,1,2)."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "pell-equation",


### PR DESCRIPTION
Enrichment pass for the parent `markov-equation` (The Markov Equation: Complete Classification via Vieta Jumping).

The entry previously had `meta.json` with overview/conclusion/crossRefs but **no annotations** and **no `sections`** array.

**Added:**
- **annotations.json** — 7 annotations, each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`, covering: the equation and root, coordinate symmetry, Vieta jumping (`z·z' = x²+y²`), the descent inequality, the move relation / sorting, the classification by strong induction, and uniqueness with small triples.
- **sections** — 7 sections spanning all 237 lines of `MarkovEquation.lean`.

Axiom integrity unchanged: `status: verified`, `badge: verified`, `axiomCount: 0` — confirmed against the Lean source.

Note: per-proof `index.ts` is no longer used for loading (manifest-based since #20993), so none is added.

Verified with `pnpm build`.