### PR TITLE
Fix badge: area-of-circle-oq-07-oq-03-oq-01 is Tier-B (mathlib), not verified

### DIFF
--- a/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-07-oq-03-oq-01/meta.json
@@ -37,7 +37,8 @@
     "lineCount": 119,
     "theoremCount": 6,
     "definitionCount": 0,
-    "badge": "verified",
+    "badge": "mathlib",
+    "assumptions": "0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only propext / Classical.choice / Quot.sound. Tier B (core result via Mathlib bridge): the half-integer Gamma ladder closed form Γ(n+1/2) = (2n-1)‼·√π/2ⁿ (gammaLadder) is a direct re-export of Mathlib's Real.Gamma_nat_add_half, and the half-line moment evaluation is Mathlib's integral_rpow_mul_exp_neg_rpow. The file's independent contribution is the bridge — identifying the full-line even moment with Γ(n+1/2) by even-folding (integral_comp_abs) and the vanishing of odd moments (Measure.measurePreserving_neg) — not the analytic backbone, which is Mathlib's.",
     "originalContributions": [
       "evenGaussianMoment_eq_gamma: ∫_ℝ x^{2n} e^{-x²} dx = Γ(n+1/2) — every even Gaussian moment is exactly a half-integer Gamma value, proved by folding the line onto the half-line via evenness (integral_comp_abs) and evaluating the half-line integral with integral_rpow_mul_exp_neg_rpow at p=2, q=2n",
       "halfLine_evenMoment: ∫_{x>0} x^{2n} e^{-x²} = ½·Γ(n+1/2), the half-line evaluation converting natural powers to real powers (Real.rpow_natCast) so Mathlib's Gamma-integral lemma applies",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `area-of-circle-oq-07-oq-03-oq-01` — "The Half-Integer Gamma Ladder as the Tower of Even Gaussian Moments"
**Problem**: Badge `verified` overstates independence for a Tier-B Mathlib-bridge entry.

## Evidence

- `gammaLadder` is a literal one-line re-export of Mathlib's `Real.Gamma_nat_add_half`:
  ```lean
  theorem gammaLadder (n : ℕ) : Real.Gamma (n + 1 / 2) = (2 * n - 1)‼ * √π / 2 ^ n :=
    Real.Gamma_nat_add_half n
  ```
- The closed form `(2n-1)‼·√π/2ⁿ` comes entirely from that Mathlib lemma; the half-line moment is evaluated by Mathlib's `integral_rpow_mul_exp_neg_rpow`.
- This is *more* Mathlib-reliant than its **direct parent** `area-of-circle-oq-07-oq-03`, which correctly carries badge `mathlib`. The whole `area-of-circle-oq-07` family (`oq-07`, `oq-07-oq-01`, `oq-07-oq-02`, `oq-07-oq-03`) uses badge `mathlib`; only this child used `verified`.
- Auditor rubric failure mode #5: "0 sorries obtaining the main result via a deep Mathlib call → badge must be `mathlib`, not `verified`/`original`."

The genuine in-file contribution (even-folding the full-line moment onto the half-line via `integral_comp_abs`, and odd-moment vanishing) is real Tier-B bridge work — so `mathlib` is the correct tier, not a downgrade to wrapper.

## Fix

- `badge`: `verified` → `mathlib`
- Add `assumptions` field (previously absent) documenting the Mathlib reliance.

No prose was overstated — `originalContributions` and `conclusion` already disclose the re-export — so this is a badge-precision correction only. The sibling `oq-07-oq-03-oq-02` (independent Beta/FTC derivation) was also audited this pass and is correctly `original` (no change needed).

---
Discovered during gallery integrity audit.