### PR TITLE
Enrich cayley-hamilton-minpoly-oq-04-oq-01: add index.ts, overview, conclusion, cross-refs

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04-oq-01/meta.json
@@ -155,7 +155,48 @@
       "significance": "Convenience form combining the characterization with the constructive headline."
     }
   ],
+  "overview": {
+    "historicalContext": "The notion of a cyclic (or generating) vector and the equivalence 'nonderogatory ⟺ has a cyclic vector' are classical, going back to the theory of the rational canonical form developed by Frobenius and refined in Hoffman & Kunze's and Roman's textbooks (§7.1–7.2 and §10.4 respectively). A matrix is nonderogatory precisely when its minimal and characteristic polynomials coincide — equivalently, when its rational canonical form is a single companion block. The single nilpotent Jordan block Jₙ(0), whose minimal polynomial is Xⁿ, is the prototypical nonderogatory matrix; over any field a vector outside ker Nⁿ⁻¹ cyclically generates the whole space. This entry formalizes exactly that prototype, deliberately avoiding the genericity and factorization tools that the general converse needs.",
+    "problemStatement": "Over an arbitrary field K, prove the converse direction of the cyclic-vector characterization for maximal-nilpotent matrices: if N ∈ Mₙ(K) satisfies Nⁿ = 0 and Nⁿ⁻¹ ≠ 0 then N has a cyclic vector. Additionally characterize this class arithmetically by minpoly K N = Xⁿ and record natDegree(minpoly K N) = n.",
+    "proofStrategy": "Construct the cyclic vector explicitly. Since Nⁿ⁻¹ ≠ 0 there is a v with Nⁿ⁻¹v ≠ 0 (exists_mulVec_ne_zero). Its Krylov vectors {v, Nv, …, Nⁿ⁻¹v} are linearly independent: apply Nⁿ⁻¹⁻ʲ to any relation ∑ cₖ Nᵏv = 0; terms with exponent ≥ n vanish by Nⁿ = 0, terms below index j vanish by a descending strong induction, leaving cⱼ Nⁿ⁻¹v = 0 and hence cⱼ = 0. Independence of the full power basis upgrades to cyclicity via aeval_eq_sum_range'. The arithmetic side uses that Nⁿ = 0 forces minpoly K N ∣ Xⁿ; since X is prime, the minimal polynomial is a monic associate of some Xⁱ, hence equals Xⁱ, and i = n is forced because Nⁿ⁻¹ ≠ 0.",
+    "keyInsights": [
+      "The maximal-nilpotent case is the unique slice of the nonderogatory converse that is purely constructive: no infinite-field genericity and no rational-canonical-form factorization are needed, so it holds over finite fields that the infinite-field sibling cannot reach.",
+      "Linear independence of the Krylov vectors is proved by peeling: applying the descending powers Nⁿ⁻¹, Nⁿ⁻², … to a single relation isolates one coefficient at a time, with nilpotency killing the high-index tail and induction the low-index head.",
+      "Primality of X in K[X] does all the factorization work: minpoly ∣ Xⁿ plus prime_X plus equality of monic associates pins minpoly to Xⁱ, and Nⁿ⁻¹ ≠ 0 selects i = n — a one-line route to minpoly = Xⁿ that never mentions eigenvalues.",
+      "The equivalence minpoly K N = Xⁿ ⟺ (Nⁿ = 0 ∧ Nⁿ⁻¹ ≠ 0) is the polynomial signature of a single Jordan block at 0, translating a geometric/structural hypothesis into a clean arithmetic one and back.",
+      "Because natDegree(minpoly K N) = n = natDegree(charpoly N) here, the construction closes precisely the nonderogatory ⟹ cyclic gap that the parent entry had axiomatized — for this case, over every field."
+    ]
+  },
+  "conclusion": {
+    "summary": "A self-contained, 0-axiom, 0-sorry formalization (238 lines, 9 theorems, 1 definition) proving the constructive converse of the cyclic-vector characterization for maximal-nilpotent matrices N (Nⁿ = 0, Nⁿ⁻¹ ≠ 0) over an arbitrary field, including finite fields. It builds an explicit cyclic vector from the Krylov sequence of any v ∉ ker Nⁿ⁻¹, and characterizes the class arithmetically by minpoly K N = Xⁿ with natDegree(minpoly) = n.",
+    "implications": "This discharges the parent entry's axiomatized converse for the single-Jordan-block case without the infinite-field assumption or factorization machinery that the OQ04Backward sibling required (and which left that sibling with a `sorry`). The inline Krylov-independence helpers are reusable infrastructure for any cyclic-vector argument, and the minpoly = Xⁿ characterization is the base case from which a general nilpotent (multiple-block) or general nonderogatory converse could be assembled.",
+    "openQuestions": [
+      "General nonderogatory converse over any field: extend the construction from a single Jordan block to an arbitrary matrix whose minimal polynomial equals its characteristic polynomial, discharging the parent's full axiom without the infinite-field hypothesis.",
+      "Multiple nilpotent blocks: characterize and construct cyclic vectors (or prove their absence) for nilpotent matrices with minpoly Xᵐ but m < n, where no cyclic vector exists — making precise the boundary the maximal-nilpotent hypothesis sits on.",
+      "Repair vs. replace: determine whether the OQ04Backward sibling's `normalizedFactors`/`DecidableEq` import clash can be fixed against current Mathlib so the infinite-field and finite-field cases unify into one converse theorem."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-04",
+      "relationship": "extends",
+      "description": "The parent proves the easy direction (a cyclic vector ⟹ nonderogatory) and axiomatizes the converse nonderogatory_has_cyclic_vector. This entry discharges that converse constructively for the maximal-nilpotent case (minpoly = Xⁿ) over any field, and connects to the parent via natDegree(minpoly K N) = n."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "related",
+      "description": "Cayley–Hamilton (charpoly N annihilates N) underlies the nonderogatory notion: a matrix is nonderogatory exactly when its minimal polynomial reaches the full degree of the characteristic polynomial guaranteed by Cayley–Hamilton. Here that full degree n is realized by the single nilpotent block whose minpoly is Xⁿ."
+    }
+  ],
   "sections": [
+    {
+      "id": "header",
+      "title": "Overview, scope, and imports",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Docstring positioning the file against the parent (axiomatizes the converse) and the OQ04Backward sibling (infinite fields, with a `sorry`), and stating the maximal-nilpotent scope: Nⁿ = 0, Nⁿ⁻¹ ≠ 0 over an arbitrary field. Notes the inline Krylov helpers (the sibling's downstream assembly no longer compiles against Mathlib 4.26.0) and the arithmetic characterization minpoly = Xⁿ. Imports the Charpoly/Minpoly, LinearIndependent, Associated and RingDivision modules; opens Matrix and Polynomial.",
+      "mathContext": "Scope: a single nilpotent Jordan block $J_n(0)$, characterized by $N^n=0$ and $N^{n-1}\\ne 0$, over any field $K$ (finite or infinite)."
+    },
     {
       "id": "helpers",
       "title": "Part 0: Cyclic vectors and inlined Krylov-independence helpers",


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-04-oq-01` (Nonderogatory Converse: Cyclic Vectors for Maximal-Nilpotent Matrices over Any Field).

The entry had `meta.json` (with `mainTheorems` and `mathlibDependencies`) and 4 bare annotations, but was missing an `overview`, a `conclusion`, `crossReferences`, and a header section.

**Added:**
- **overview** — historicalContext (Frobenius / rational canonical form, Hoffman–Kunze, Roman), problemStatement, proofStrategy, 5 keyInsights.
- **conclusion** — summary, implications, 3 openQuestions.
- **crossReferences** — to the parent `cayley-hamilton-minpoly-oq-04` and `cayley-hamilton`.
- **annotations** — added `significance`, `relatedConcepts`, `prerequisites` to all; now 5 annotations (added an insight on the iff-characterization).
- **sections** — added the header section (lines 1–55) so sections cover the full 238-line file.

Axiom integrity unchanged and verified: `status: verified`, `badge: original`, `axiomCount: 0`, no `native_decide`. The assumptions field correctly states this discharges the converse only for the maximal-nilpotent case, not the parent's general axiom.

Note: per-proof `index.ts` is no longer used for loading (manifest-based since #20993), so none is added.

Verified with `pnpm build`.