### PR TITLE
Enrich cantor-diagonalization-oq-01-oq-01-oq-03: add annotations + sections

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "cantordiag010103-ann-header",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-oq-03",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "concept",
+    "title": "Easton's Three Constraints on the Continuum Function",
+    "content": "The parent entry formalized CH and stated König's constraint and Easton's theorem only at 2^{ℵ₀}, leaving open which patterns of the generalized continuum function α ↦ 2^{ℵ_α} are consistent with ZFC. Easton's theorem (1970) answers this for regular cardinals: the only ZFC constraints are monotonicity, Cantor's strict inequality ℵ_α < 2^{ℵ_α}, and König's cf(2^{ℵ_α}) > ℵ_α; subject to these any pattern is consistent. This file proves all three unconditionally and axiom-free from Mathlib's cardinal/cofinality API. contFn α := 2 ^ ℵ_α is the continuum function, and the helper two_ne_zero_card supplies (2 : Cardinal) ≠ 0 for the power-monotonicity lemma.",
+    "mathContext": "$\\mathrm{contFn}(\\alpha) = 2^{\\aleph_\\alpha}$; Easton constraints: monotone, $\\aleph_\\alpha < 2^{\\aleph_\\alpha}$, $\\operatorname{cf}(2^{\\aleph_\\alpha}) > \\aleph_\\alpha$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "generalized continuum hypothesis",
+      "Easton's theorem",
+      "continuum function",
+      "regular cardinals"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "the aleph hierarchy",
+      "ZFC independence (Gödel/Cohen)"
+    ]
+  },
+  {
+    "id": "cantordiag010103-ann-monotone",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-oq-03",
+    "range": { "startLine": 44, "endLine": 48 },
+    "type": "theorem",
+    "title": "Monotonicity (but not strict)",
+    "content": "contFn_monotone: α ≤ β ⟹ 2^{ℵ_α} ≤ 2^{ℵ_β}, proved by composing power_le_power_left (with base 2 ≠ 0) and aleph_le_aleph (monotonicity of the aleph indexing). Crucially this is only ≤, not <, between distinct indices: the continuum function is monotone but NOT strictly monotone, since 2^{ℵ_α} = 2^{ℵ_β} for α < β is consistent (e.g. 2^{ℵ₀} = 2^{ℵ₁} under Martin's Axiom). The strict inequality lives between an index and its own value, not between two indices.",
+    "mathContext": "$\\alpha \\le \\beta \\Rightarrow 2^{\\aleph_\\alpha} \\le 2^{\\aleph_\\beta}$; equality between distinct indices is consistent.",
+    "significance": "key",
+    "relatedConcepts": [
+      "monotone function",
+      "power_le_power_left",
+      "Martin's Axiom",
+      "aleph_le_aleph"
+    ],
+    "prerequisites": [
+      "cardinal exponentiation",
+      "monotonicity of aleph"
+    ]
+  },
+  {
+    "id": "cantordiag010103-ann-cantor",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-oq-03",
+    "range": { "startLine": 50, "endLine": 53 },
+    "type": "theorem",
+    "title": "Cantor's Constraint: ℵ_α < 2^{ℵ_α}",
+    "content": "aleph_lt_contFn is the second Easton constraint, an immediate instance of Cardinal.cantor (Cantor's theorem: every cardinal is strictly below its power set). It is the only strict inequality of the three that compares the function to its index, and it is the generalized-level form of the diagonal argument that gives the parent's ℵ₀ < 2^{ℵ₀}. Together with contFn_ne_aleph (the function has no fixed point) it records that 2^{ℵ_α} always strictly exceeds ℵ_α.",
+    "mathContext": "$\\aleph_\\alpha < 2^{\\aleph_\\alpha}$ for every ordinal $\\alpha$ (Cantor).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "diagonal argument",
+      "power set cardinality",
+      "no fixed point"
+    ],
+    "prerequisites": [
+      "Cantor's theorem (Cardinal.cantor)"
+    ]
+  },
+  {
+    "id": "cantordiag010103-ann-konig",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-oq-03",
+    "range": { "startLine": 55, "endLine": 65 },
+    "type": "key-step",
+    "title": "König's Constraint, Discharged from Mathlib",
+    "content": "aleph_lt_cof_contFn is the heart of the entry: cf(2^{ℵ_α}) > ℵ_α for all α, the consequence of König's theorem (1905) that — with monotonicity and Cantor — exhausts the ZFC constraints. Where the parent only STATED this as a Prop, here it is PROVED in one line from Cardinal.lt_cof_power (with base 2 > 1 and ℵ₀ ≤ ℵ_α). The classical case aleph0_lt_cof_continuum (cf(2^{ℵ₀}) > ℵ₀) follows by specializing α = 0 and rewriting ℵ_0 = ℵ₀, ruling out e.g. 2^{ℵ₀} = ℵ_ω (which has countable cofinality).",
+    "mathContext": "$\\operatorname{cf}(2^{\\aleph_\\alpha}) > \\aleph_\\alpha$; in particular $\\operatorname{cf}(2^{\\aleph_0}) > \\aleph_0$, so $2^{\\aleph_0} \\ne \\aleph_\\omega$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "König's theorem",
+      "cofinality",
+      "Cardinal.lt_cof_power",
+      "countable cofinality"
+    ],
+    "prerequisites": [
+      "cofinality of cardinals",
+      "König's theorem"
+    ]
+  },
+  {
+    "id": "cantordiag010103-ann-packaged",
+    "proofId": "cantor-diagonalization-oq-01-oq-01-oq-03",
+    "range": { "startLine": 71, "endLine": 79 },
+    "type": "insight",
+    "title": "The Three Constraints Packaged as Easton Admissibility",
+    "content": "contFn_constraints bundles the three results into a single statement: every value of the generalized continuum function simultaneously dominates ℵ_α, has cofinality above ℵ_α, and respects monotonicity. These are exactly the NECESSARY conditions in Easton's characterization; Easton's theorem asserts they are also SUFFICIENT for regular cardinals (any function on regular cardinals obeying them is consistent via forcing). So this packaged lemma is the faithful formal answer to the parent's open question 'which patterns of 2^{ℵ_α} are consistent?' — modulo the sufficiency half, which requires a forcing construction and is recorded as an open question.",
+    "mathContext": "$\\aleph_\\alpha < 2^{\\aleph_\\alpha} \\,\\wedge\\, \\aleph_\\alpha < \\operatorname{cf}(2^{\\aleph_\\alpha}) \\,\\wedge\\, (\\alpha \\le \\beta \\to 2^{\\aleph_\\alpha} \\le 2^{\\aleph_\\beta}).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Easton's theorem",
+      "admissibility conditions",
+      "necessary vs sufficient",
+      "forcing"
+    ],
+    "prerequisites": [
+      "Easton's theorem (background)",
+      "necessary conditions"
+    ]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-03/meta.json
@@ -83,10 +83,16 @@
   ],
   "sections": [
     {
-      "title": "The continuum function and monotonicity",
+      "title": "Overview, the continuum function, and the helper",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Docstring positioning the file against the parent (CH + König/Easton at 2^{ℵ₀}) and stating Easton's three constraints; imports Mathlib, opens Cardinal/Ordinal, defines contFn α = 2^{ℵ_α}, and proves the helper two_ne_zero_card ((2:Cardinal) ≠ 0) used by the monotonicity lemma."
+    },
+    {
+      "title": "Monotonicity",
       "startLine": 44,
-      "endLine": 59,
-      "summary": "contFn α = 2^{ℵ_α}, the helper (2:Cardinal) ≠ 0, and contFn_monotone (monotone in the index)."
+      "endLine": 49,
+      "summary": "contFn_monotone (monotone in the index, via power_le_power_left and aleph_le_aleph) — only ≤, not strict, between distinct indices."
     },
     {
       "title": "Cantor and König constraints",


### PR DESCRIPTION
Enrichment pass for `cantor-diagonalization-oq-01-oq-01-oq-03` (The Generalized Continuum Function: ZFC Constraints on 2^{ℵ_α}).

The entry already had a structured overview, conclusion, and crossReferences, but **no annotations** and its `sections` did not cover the file header.

**Added:**
- **annotations.json** — 5 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: Easton's three constraints, the (monotone-but-not-strict) monotonicity, Cantor's constraint ℵ_α < 2^{ℵ_α}, König's constraint cf(2^{ℵ_α}) > ℵ_α (discharged from `Cardinal.lt_cof_power`, where the parent only stated it), and the packaged admissibility lemma.
- **sections** — added a header section (lines 1–43) and split monotonicity so the 3 → 4 sections span all 79 lines.

Axiom integrity unchanged: `status: verified`, `badge: verified`, `axiomCount: 0` — confirmed against the Lean source (proved in ZFC from Mathlib, no added axioms, no native_decide).

Note: per-proof `index.ts` is no longer used for loading (manifest-based since #20993), so none is added.

Verified with `pnpm build`.