### PR TITLE
Fix sqrt2-irrational-oq-02 badge: verified → mathlib (Tier-B re-export)

### DIFF
--- a/src/data/proofs/sqrt2-irrational-oq-02/meta.json
+++ b/src/data/proofs/sqrt2-irrational-oq-02/meta.json
@@ -15,11 +15,11 @@
       "liouville-numbers",
       "algebraic-numbers"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
-    "assumptions": "None. #print axioms reports only propext, Classical.choice, Quot.sound. The transcendence and irrationality come from Mathlib's verified Liouville theory.",
+    "assumptions": "None (0 axioms, 0 sorries); core results via Mathlib bridge. #print axioms reports only propext, Classical.choice, Quot.sound. Irrationality and transcendence are direct Mathlib re-exports (Liouville.irrational, transcendental_liouvilleNumber); this file instantiates Liouville's constant at base 2 and packages the existence statements.",
     "lineCount": 61,
     "theoremCount": 5,
     "definitionCount": 1,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `sqrt2-irrational-oq-02` — "Beyond Irrationality: Transcendental Numbers Exist"
**Severity**: MEDIUM (Mathlib wrapper carrying a non-`mathlib` badge)

## Problem

The badge was `verified`, but every substantive result in the file is a **direct Mathlib re-export**. The file's entire contribution is instantiating Liouville's constant at base 2 and packaging existence statements:

```lean
noncomputable def liouvilleConst : ℝ := liouvilleNumber (2 : ℕ)
theorem liouvilleConst_liouville      : Liouville liouvilleConst := liouville_liouvilleNumber (by norm_num)
theorem liouvilleConst_irrational     : Irrational liouvilleConst := liouvilleConst_liouville.irrational
theorem liouvilleConst_transcendental : Transcendental ℤ liouvilleConst := transcendental_liouvilleNumber (by norm_num)
theorem exists_irrational_transcendental := ⟨liouvilleConst, …⟩
theorem not_forall_irrational_isAlgebraic := ⟨liouvilleConst, …⟩
```

This is a textbook **Tier-B** entry (core result via a Mathlib theorem) and matches auditor **failure mode #5** ("0 sorries with hidden imports"): technically sorry-free but presented with an independence-implying badge.

## Evidence

- Family convention: the **parent** `sqrt2-irrational` already uses badge `mathlib`. This thinner child (pure instantiate + package, zero independent math) was a **lone outlier** at `verified`.
- The disclosure prose was already honest (description: "Built axiom-free on Mathlib's Liouville theory"; assumptions credits Mathlib). Only the badge overclaimed.

## Fix

- `meta.badge`: `verified` → `mathlib`
- `status` unchanged (`verified` — fully machine-checked, 0 axioms / 0 sorries)
- Sharpened `assumptions` to note core results come via the Mathlib bridge

No Lean source changes; metadata only.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)