### PR TITLE
Enrich erdos-1017-oq-02: add annotations + header section

### DIFF
--- a/src/data/proofs/erdos-1017-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1017-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "erdos1017oq02-ann-header",
+    "proofId": "erdos-1017-oq-02",
+    "range": { "startLine": 1, "endLine": 50 },
+    "type": "concept",
+    "title": "Why the Balanced Split is the EGP Extremal Graph",
+    "content": "Erdős Problem #1017 (Erdős–Goodman–Pósa, 1966) studies f(n,k), the minimum number of complete subgraphs needed to edge-partition every n-vertex k-edge graph, with bound f ≤ ⌊n²/4⌋. The bound is realized by the balanced complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉}, which is triangle-free (so each of its ⌊n²/4⌋ edges must be its own clique). The parent file proves K_{a,b} has a·b edges and is triangle-free; the sibling gives the closed forms of T(n). This entry supplies the missing quantitative fact: among all splits, a·(n−a) is maximized exactly at balance. turanBound n := n²/4 is re-declared for self-containment (the parent's two axioms are not imported here).",
+    "mathContext": "$T(n) = \\lfloor n^2/4 \\rfloor$; $K_{a,n-a}$ has $a(n-a)$ edges, maximized at $a = \\lfloor n/2\\rfloor$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Erdős–Goodman–Pósa theorem",
+      "Turán bound",
+      "complete bipartite graph",
+      "clique partition"
+    ],
+    "prerequisites": [
+      "extremal graph theory",
+      "Turán/Mantel theorems",
+      "floor function over ℕ"
+    ]
+  },
+  {
+    "id": "erdos1017oq02-ann-closedforms",
+    "proofId": "erdos-1017-oq-02",
+    "range": { "startLine": 52, "endLine": 61 },
+    "type": "definition",
+    "title": "Parity Closed Forms of the Turán Bound",
+    "content": "turanBound_two_mul and turanBound_two_mul_add_one re-derive the closed forms T(2m) = m² and T(2m+1) = m(m+1) locally (so the file does not depend on the sibling). The even case rewrites (2m)² = 4m² and cancels the 4; the odd case uses (2m+1)² = 4·m(m+1) + 1 and omega for the floor. These are the values the balanced split must hit, used in proving equality at balance.",
+    "mathContext": "$T(2m) = m^2,\\qquad T(2m+1) = m(m+1).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "quarter-square",
+      "floor of a square",
+      "parity split"
+    ],
+    "prerequisites": [
+      "natural-number division",
+      "omega tactic"
+    ]
+  },
+  {
+    "id": "erdos1017oq02-ann-amgm",
+    "proofId": "erdos-1017-oq-02",
+    "range": { "startLine": 63, "endLine": 82 },
+    "type": "technique",
+    "title": "The Integer AM–GM Kernel and Its Strict Form",
+    "content": "four_mul_mul_le_add_sq is the engine: 4ab ≤ (a+b)² over ℕ, whose gap is the perfect square (a−b)². Because truncated subtraction over ℕ is awkward, the gap is exposed by the case split a ≤ b / b ≤ a — writing the larger as smaller + d turns the goal into 0 ≤ d², discharged by nlinarith. four_mul_mul_lt_add_sq is the strict version for a ≠ b: there d ≥ 1, so the gap is ≥ 1 and the inequality is strict. This is the natural-number form of the quarter-square AM–GM at the heart of Mantel's and Turán's edge maxima.",
+    "mathContext": "$4ab \\le (a+b)^2$ with gap $(a-b)^2 \\ge 0$; strict ($\\ge 1$) when $a \\ne b$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "quarter-square identity",
+      "truncated subtraction",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "Nat.le.dest (write b as a + d)",
+      "perfect squares"
+    ]
+  },
+  {
+    "id": "erdos1017oq02-ann-upperbound",
+    "proofId": "erdos-1017-oq-02",
+    "range": { "startLine": 84, "endLine": 94 },
+    "type": "theorem",
+    "title": "The Universal Upper Bound a·(n−a) ≤ T(n)",
+    "content": "mul_compl_le_turanBound: for any split a ≤ n, the complete bipartite graph K_{a,n-a} has at most ⌊n²/4⌋ edges. The proof converts the floor bound via Nat.le_div_iff_mul_le (multiplying out by 4), then applies the AM–GM kernel to a and n−a using a + (n−a) = n to get 4·a·(n−a) ≤ (a + (n−a))² = n². So no complete bipartite graph on n vertices exceeds the Turán value.",
+    "mathContext": "$a \\le n \\Rightarrow a(n-a) \\le \\lfloor n^2/4\\rfloor$, via $4a(n-a) \\le n^2$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Nat.le_div_iff_mul_le",
+      "Turán bound",
+      "edge maximum",
+      "calc proof"
+    ],
+    "prerequisites": [
+      "the AM–GM kernel",
+      "floor division inequalities"
+    ]
+  },
+  {
+    "id": "erdos1017oq02-ann-equality-max",
+    "proofId": "erdos-1017-oq-02",
+    "range": { "startLine": 96, "endLine": 116 },
+    "type": "key-step",
+    "title": "Equality at Balance and T(n) as the Maximum",
+    "content": "balanced_mul_compl_eq_turanBound proves the balanced split a = ⌊n/2⌋ attains the bound: a parity split (Nat.even_or_odd) plus the local closed forms gives ⌊n/2⌋·(n − ⌊n/2⌋) = T(n) in both the even (m·m = m²) and odd (m·(m+1)) cases. Combining the universal upper bound with this equality, exists_balanced_max upgrades ⌊n²/4⌋ from 'an upper bound' to 'the exact maximum' of a·(n−a) over all splits, witnessed constructively by a = ⌊n/2⌋.",
+    "mathContext": "$\\lfloor n/2\\rfloor\\,(n-\\lfloor n/2\\rfloor) = T(n) = \\max_{a\\le n} a(n-a).$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "extremal witness",
+      "Nat.even_or_odd",
+      "maximum vs upper bound",
+      "balanced split"
+    ],
+    "prerequisites": [
+      "the upper bound theorem",
+      "parity case analysis"
+    ]
+  },
+  {
+    "id": "erdos1017oq02-ann-uniqueness",
+    "proofId": "erdos-1017-oq-02",
+    "range": { "startLine": 118, "endLine": 149 },
+    "type": "insight",
+    "title": "Uniqueness of the Maximiser for Even n",
+    "content": "even_unbalanced_lt: for n = 2m, every unequal split a ≠ m gives strictly fewer than m² = T(2m) edges, so K_{m,m} is the UNIQUE edge-maximiser. The proof applies the strict AM–GM kernel to a and 2m−a (which differ since a ≠ m), giving 4·a·(2m−a) < (2m)² = 4m², then cancels the factor 4 with Nat.lt_of_mul_lt_mul_left. For odd n the two near-balanced splits K_{m,m+1} tie, so uniqueness is genuinely an even-n phenomenon. This pins down the balanced complete bipartite graph as THE Erdős–Goodman–Pósa extremal example.",
+    "mathContext": "$n = 2m,\\ a \\ne m \\Rightarrow a(2m-a) < m^2 = T(2m)$; odd $n$ ties at $K_{m,m+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "uniqueness of extremiser",
+      "strict AM–GM",
+      "Nat.lt_of_mul_lt_mul_left",
+      "even vs odd n"
+    ],
+    "prerequisites": [
+      "the strict AM–GM kernel",
+      "cancellation of a positive factor"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-1017-oq-02/meta.json
+++ b/src/data/proofs/erdos-1017-oq-02/meta.json
@@ -59,10 +59,18 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Background, turanBound, and Closed Forms",
+      "summary": "Docstring framing Erdős #1017 (EGP bound f ≤ ⌊n²/4⌋, balanced K_{⌊n/2⌋,⌈n/2⌉} as the triangle-free extremal example) and the gap this file fills (why the balanced split attains T). Re-declares turanBound n = n²/4 for self-containment and proves the parity closed forms turanBound_two_mul (T(2m) = m²) and turanBound_two_mul_add_one (T(2m+1) = m(m+1)).",
+      "startLine": 1,
+      "endLine": 62,
+      "mathContext": "T(n) = ⌊n²/4⌋ with T(2m) = m², T(2m+1) = m(m+1); the balanced complete bipartite graph realizes the EGP bound."
+    },
+    {
       "id": "amgm-kernel",
       "title": "Integer AM-GM Kernel",
       "summary": "four_mul_mul_le_add_sq (4ab <= (a+b)^2) and its strict form four_mul_mul_lt_add_sq (a != b).",
-      "startLine": 60,
+      "startLine": 63,
       "endLine": 90,
       "mathContext": "The square gap (a-b)^2 is exposed by case-splitting a <= b / b <= a and writing the larger as smaller + d, reducing to 0 <= d^2 (resp. 1 <= d^2)."
     },


### PR DESCRIPTION
Enrichment pass for `erdos-1017-oq-02` (Erdős #1017: extremality of the balanced split in the Turán bound ⌊n²/4⌋).

The entry already had a structured overview, conclusion, and crossReferences, but **no annotations** and its `sections` started at line 60 (missing the header/closed-forms).

**Added:**
- **annotations.json** — 6 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: the EGP framing, the parity closed forms T(2m)=m² / T(2m+1)=m(m+1), the integer AM–GM kernel 4ab ≤ (a+b)² and its strict form, the universal upper bound a(n−a) ≤ T(n), equality at balance + T(n) as the maximum, and uniqueness of the maximiser for even n.
- **sections** — added a header section (lines 1–62) and shifted the kernel section start so the 2 → 3 sections span all 149 lines.

Axiom integrity unchanged and verified: `status: verified`, `badge: verified`, `axiomCount: 0`, no `native_decide`. The assumptions field correctly notes the file is self-contained and does NOT import the parent's two axioms (egp_theorem, k4free_partition_number); scope is the extremal-graph arithmetic, not the open clique-partition question.

Note: per-proof `index.ts` is no longer used for loading (manifest-based since #20993), so none is added.

Verified with `pnpm build`.