### PR TITLE
research(mason-stothers-oq-01-oq-02): Davenport's inequality from char-0 Mason–Stothers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/MasonStothersOQ01OQ02.lean
+++ b/proofs/Proofs/MasonStothersOQ01OQ02.lean
@@ -1,0 +1,132 @@
+import Mathlib
+import Proofs.MasonStothersOQ01
+
+/-
+# Davenport's inequality from Mason–Stothers (characteristic zero)
+
+Davenport's inequality is the classical statement that a polynomial of the shape
+`f³ - g²` cannot have too small a degree relative to `f`: if `f, g` are coprime
+non-constant polynomials over a characteristic-zero field with `f³ ≠ g²`, then
+
+  `deg f + 2 ≤ 2 · deg (f³ - g²)`,
+
+i.e. `deg (f³ - g²) ≥ ½ deg f + 1`.  It quantifies how close `f³` and `g²` can
+be, and is the polynomial shadow of Hall's conjecture on `|x³ - y²|` for integers.
+
+This file derives it as a direct `0`-axiom corollary of
+`MasonStothersOQ01.mason_stothers_charZero` (the characteristic-zero form of the
+polynomial ABC theorem proved in the parent entry).
+
+## Proof sketch
+
+Apply Mason–Stothers in the form `a + b = c` to the coprime triple
+
+  `a = f³,  b = -g²,  c = f³ - g²`.
+
+Coprimality of `f, g` gives coprimality of `f³, -g²`, and `a = f³` is non-constant,
+so the escape clause is excluded in characteristic zero and we get
+
+  `deg(f³) + 1 ≤ deg rad(a·b·c)`   and   `deg(g²) + 1 ≤ deg rad(a·b·c)`.
+
+The key combinatorial input is an *upper* bound on the radical's degree:
+
+  `rad(f³·g²·c) ∣ f·g·c`,
+
+obtained from `radical_mul_dvd` (which needs **no** coprimality), `radical_pow`
+(`rad(pⁿ) = rad p`) and `radical_dvd_self`.  Hence
+
+  `deg rad(a·b·c) ≤ deg f + deg g + deg c`.
+
+Feeding the two Mason–Stothers bounds and this upper bound to `omega`:
+
+  `3·deg f + 1 ≤ deg f + deg g + deg c`     (from `f³`)
+  `2·deg g + 1 ≤ deg f + deg g + deg c`     (from `g²`)
+
+add to give `deg f + 2 ≤ 2·deg c`, which is Davenport's inequality.
+
+Everything is a `0`-axiom derivation from Mathlib's `Polynomial.abc`.
+-/
+
+open Polynomial UniqueFactorizationMonoid UniqueFactorizationDomain
+
+namespace MasonStothersOQ01OQ02
+
+variable {k : Type*} [Field k] [DecidableEq k]
+
+/-- The radical of a product `f³ · g² · c` divides `f · g · c`, **without any
+coprimality hypotheses**.  This is the radical-degree input to Davenport's
+inequality: it bounds the number of distinct roots of `f³·g²·c` by
+`deg f + deg g + deg c`.  Proof: `radical_mul_dvd` splits the product, `radical_pow`
+collapses the powers (`rad(fⁿ) = rad f`), and `radical_dvd_self` returns to `f, g, c`. -/
+theorem radical_cube_sq_mul_dvd (f g c : k[X]) :
+    radical (f ^ 3 * g ^ 2 * c) ∣ f * g * c := by
+  have hrf : radical f ∣ f := radical_dvd_self
+  have hrg : radical g ∣ g := radical_dvd_self
+  have hrc : radical c ∣ c := radical_dvd_self
+  have h1 : radical (f ^ 3 * g ^ 2) ∣ f * g :=
+    calc radical (f ^ 3 * g ^ 2)
+          ∣ radical (f ^ 3) * radical (g ^ 2) := radical_mul_dvd
+      _ = radical f * radical g := by
+            rw [radical_pow f (by norm_num), radical_pow g (by norm_num)]
+      _ ∣ f * g := mul_dvd_mul hrf hrg
+  calc radical (f ^ 3 * g ^ 2 * c)
+        ∣ radical (f ^ 3 * g ^ 2) * radical c := radical_mul_dvd
+    _ ∣ (f * g) * c := mul_dvd_mul h1 hrc
+
+/-- **Davenport's inequality.**
+
+For coprime polynomials `f, g` over a characteristic-zero field with `f`
+non-constant, `g ≠ 0` and `f³ ≠ g²`,
+
+  `deg f + 2 ≤ 2 · deg (f³ - g²)`,
+
+equivalently `deg (f³ - g²) ≥ ½ deg f + 1`.  Derived directly from the
+characteristic-zero Mason–Stothers bound. -/
+theorem davenport [CharZero k] {f g : k[X]} (hf : f.natDegree ≠ 0) (hg : g ≠ 0)
+    (hcop : IsCoprime f g) (hne : f ^ 3 ≠ g ^ 2) :
+    f.natDegree + 2 ≤ 2 * (f ^ 3 - g ^ 2).natDegree := by
+  -- nonzeroness of the three terms `a = f³`, `b = -g²`, `c = f³ - g²`
+  have hf0 : f ≠ 0 := fun h => hf (by simp [h])
+  have ha : (f ^ 3) ≠ 0 := pow_ne_zero 3 hf0
+  have hb : (-g ^ 2) ≠ 0 := neg_ne_zero.mpr (pow_ne_zero 2 hg)
+  have hc : (f ^ 3 - g ^ 2) ≠ 0 := sub_ne_zero.mpr hne
+  -- coprimality `f³` ⟂ `-g²` and the additive relation `f³ + (-g²) = f³ - g²`
+  have hcop' : IsCoprime (f ^ 3) (-g ^ 2) := (hcop.pow).neg_right
+  have hsum : f ^ 3 + (-g ^ 2) = f ^ 3 - g ^ 2 := by ring
+  -- non-triviality: `f³` is non-constant since `f` is
+  have hnontriv : (f ^ 3).natDegree ≠ 0 ∨ (-g ^ 2).natDegree ≠ 0 ∨
+      (f ^ 3 - g ^ 2).natDegree ≠ 0 :=
+    Or.inl (by rw [Polynomial.natDegree_pow]; omega)
+  -- Mason–Stothers in characteristic zero
+  obtain ⟨b1, b2, _⟩ :=
+    MasonStothersOQ01.mason_stothers_charZero ha hb hc hcop' hsum hnontriv
+  -- rewrite `radical (f³ · (-g²) · c)` as `radical (f³ · g² · c)` (differ by the unit `-1`)
+  have hrad : radical (f ^ 3 * -g ^ 2 * (f ^ 3 - g ^ 2)) =
+      radical (f ^ 3 * g ^ 2 * (f ^ 3 - g ^ 2)) := by
+    rw [show f ^ 3 * -g ^ 2 * (f ^ 3 - g ^ 2)
+          = -(f ^ 3 * g ^ 2 * (f ^ 3 - g ^ 2)) by ring, radical_neg]
+  rw [hrad] at b1 b2
+  -- upper bound on the radical degree via `radical_cube_sq_mul_dvd`
+  have hfgc : f * g * (f ^ 3 - g ^ 2) ≠ 0 := mul_ne_zero (mul_ne_zero hf0 hg) hc
+  have hub : (radical (f ^ 3 * g ^ 2 * (f ^ 3 - g ^ 2))).natDegree ≤
+      f.natDegree + g.natDegree + (f ^ 3 - g ^ 2).natDegree := by
+    refine (natDegree_le_of_dvd (radical_cube_sq_mul_dvd f g (f ^ 3 - g ^ 2)) hfgc).trans_eq ?_
+    rw [natDegree_mul (mul_ne_zero hf0 hg) hc, natDegree_mul hf0 hg]
+  -- degrees of `f³` and `-g²`
+  have hdf3 : (f ^ 3).natDegree = 3 * f.natDegree := natDegree_pow f 3
+  have hdg2 : (-g ^ 2).natDegree = 2 * g.natDegree := by
+    rw [natDegree_neg, natDegree_pow]
+  rw [hdf3] at b1
+  rw [hdg2] at b2
+  omega
+
+/-- **Davenport, height form.**  Restated as a lower bound on the degree of
+`f³ - g²` directly: `deg (f³ - g²) ≥ ½ deg f + 1` rendered over `ℕ` as
+`2 ≤ 2·deg(f³-g²) - deg f`.  Equivalent to `davenport`; provided for convenience. -/
+theorem natDegree_cube_sub_sq_ge [CharZero k] {f g : k[X]} (hf : f.natDegree ≠ 0)
+    (hg : g ≠ 0) (hcop : IsCoprime f g) (hne : f ^ 3 ≠ g ^ 2) :
+    f.natDegree / 2 + 1 ≤ (f ^ 3 - g ^ 2).natDegree := by
+  have h := davenport hf hg hcop hne
+  omega
+
+end MasonStothersOQ01OQ02

--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/meta.json
@@ -1,0 +1,150 @@
+{
+  "id": "mason-stothers-theorem-oq-01-oq-02",
+  "title": "Davenport's inequality as a 0-axiom corollary of Mason–Stothers (characteristic zero)",
+  "slug": "mason-stothers-theorem-oq-01-oq-02",
+  "description": "Davenport's inequality bounds how small the degree of f³ − g² can be relative to f: for coprime polynomials f, g over a characteristic-zero field with f non-constant and f³ ≠ g², deg f + 2 ≤ 2·deg(f³ − g²), i.e. deg(f³ − g²) ≥ ½·deg f + 1. It is the polynomial shadow of Hall's conjecture on |x³ − y²| for integers. This entry answers the second open question of the parent (mason-stothers-theorem-oq-01): derive Davenport directly from mason_stothers_charZero. The proof applies Mason–Stothers in the additive form a + b = c to the coprime triple a = f³, b = −g², c = f³ − g², extracting the two lower bounds 3·deg f + 1 ≤ deg(rad(a·b·c)) and 2·deg g + 1 ≤ deg(rad(a·b·c)). The combinatorial input is an upper bound on the radical degree proved here as radical_cube_sq_mul_dvd: rad(f³·g²·c) ∣ f·g·c with no coprimality hypothesis, via radical_mul_dvd, radical_pow (rad(pⁿ) = rad p) and radical_dvd_self, giving deg rad ≤ deg f + deg g + deg c. Feeding the two lower bounds and this upper bound to omega yields deg f + 2 ≤ 2·deg(f³ − g²). Everything is a 0-axiom derivation from the parent entry's mason_stothers_charZero.",
+  "meta": {
+    "author": "H. Davenport (1965, classical); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/MasonStothersOQ01OQ02.lean",
+    "tags": [
+      "polynomials",
+      "mason-stothers",
+      "davenport-inequality",
+      "abc-conjecture",
+      "radical",
+      "degree-bound",
+      "characteristic-zero",
+      "hall-conjecture",
+      "number-theory",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "radical_mul_dvd",
+        "description": "radical (a * b) ∣ radical a * radical b, with NO coprimality hypothesis. Splits radical (f³·g²·c) across the product; the key tool for the radical-degree upper bound.",
+        "module": "Mathlib.RingTheory.Radical"
+      },
+      {
+        "theorem": "radical_pow",
+        "description": "radical (a ^ n) = radical a for n ≠ 0. Collapses the powers rad(f³) = rad f and rad(g²) = rad g, so the radical loses no information about exponents.",
+        "module": "Mathlib.RingTheory.Radical"
+      },
+      {
+        "theorem": "radical_dvd_self",
+        "description": "radical a ∣ a. Returns from rad f, rad g, rad c to f, g, c, completing rad(f³·g²·c) ∣ f·g·c.",
+        "module": "Mathlib.RingTheory.Radical"
+      },
+      {
+        "theorem": "radical_neg",
+        "description": "radical (-a) = radical a. Identifies rad(f³·(−g²)·c) with rad(f³·g²·c) (they differ by the unit −1), so the upper bound applies to the product appearing in Mason–Stothers.",
+        "module": "Mathlib.RingTheory.Radical"
+      },
+      {
+        "theorem": "Polynomial.natDegree_le_of_dvd",
+        "description": "p ∣ q and q ≠ 0 ⟹ natDegree p ≤ natDegree q. Converts the divisibility rad(f³·g²·c) ∣ f·g·c into the degree inequality deg rad ≤ deg f + deg g + deg c.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Lemmas"
+      },
+      {
+        "theorem": "Polynomial.natDegree_pow",
+        "description": "natDegree (p ^ n) = n * natDegree p. Supplies deg(f³) = 3·deg f and deg(g²) = 2·deg g for the final omega step.",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
+      }
+    ],
+    "originalContributions": [
+      "radical_cube_sq_mul_dvd: the hypothesis-free divisibility rad(f³·g²·c) ∣ f·g·c over a field, bounding the number of distinct roots of f³·g²·c by deg f + deg g + deg c. The radical-degree input to Davenport, proved from radical_mul_dvd / radical_pow / radical_dvd_self without any coprimality assumption.",
+      "davenport: Davenport's inequality deg f + 2 ≤ 2·deg(f³ − g²) for coprime f, g over a characteristic-zero field with f non-constant and f³ ≠ g², assembled in-file from the parent's mason_stothers_charZero (applied to the triple f³ − g² = f³ + (−g²)) and the radical-degree upper bound. Not a Mathlib export.",
+      "natDegree_cube_sub_sq_ge: the height form deg(f³ − g²) ≥ ½·deg f + 1, rendered over ℕ as f.natDegree / 2 + 1 ≤ (f³ − g²).natDegree."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (hence no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas and the parent entry's mason_stothers_charZero (itself 0-axiom). The [CharZero k] field instance and the coprimality / non-constancy / f³ ≠ g² hypotheses are mathematical hypotheses of Davenport's statement, not assumptions about unproved facts.",
+    "lineCount": 132,
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Davenport's inequality (H. Davenport, 1965, 'On f³(t) − g²(t)') is the polynomial analogue of Hall's conjecture, which asks how small |x³ − y²| can be for integers x, y. In the polynomial setting Davenport proved the sharp lower bound deg(f³ − g²) ≥ ½·deg f + 1 for coprime non-constant f, g — there is no epsilon and no exceptional set, in contrast to the still-open integer Hall conjecture. The inequality is one of the classic one-line consequences of the Mason–Stothers theorem (the function-field abc), alongside the polynomial Fermat theorem.",
+    "problemStatement": "The parent entry proves the characteristic-zero Mason–Stothers degree bound mason_stothers_charZero. Its second open question asks: can Davenport's inequality deg(f³ − g²) ≥ ½·deg f + 1 be derived directly as a 0-axiom corollary?\n\n**Answer:** Yes. Apply mason_stothers_charZero to the coprime additive triple f³ + (−g²) = f³ − g². The two lower bounds on deg(rad) coming from the f³ and g² terms, combined with the hypothesis-free upper bound rad(f³·g²·c) ∣ f·g·c, give deg f + 2 ≤ 2·deg(f³ − g²) by linear arithmetic.",
+    "text": "Davenport's inequality deg f + 2 ≤ 2·deg(f³ − g²) for coprime non-constant f, g in characteristic zero, obtained as a direct 0-axiom corollary of the parent's Mason–Stothers degree bound and a hypothesis-free upper bound on the radical degree.",
+    "proofStrategy": "1. radical_cube_sq_mul_dvd: rad(f³·g²·c) ∣ f·g·c. Split rad(f³·g²) ∣ rad(f³)·rad(g²) = rad f · rad g (radical_mul_dvd, radical_pow), then rad f ∣ f, rad g ∣ g, rad c ∣ c (radical_dvd_self) and combine with one more radical_mul_dvd and mul_dvd_mul.\n2. davenport: set a = f³, b = −g², c = f³ − g². Verify a, b, c ≠ 0; IsCoprime f g ⟹ IsCoprime f³ (−g²) (IsCoprime.pow, neg_right); a + b = c by ring; f³ non-constant supplies the Mason–Stothers non-triviality disjunct. mason_stothers_charZero gives 3·deg f + 1 ≤ deg(rad(f³·(−g²)·c)) and 2·deg g + 1 ≤ same. Rewrite rad(f³·(−g²)·c) = rad(f³·g²·c) (radical_neg, since the product differs from f³·g²·c by −1). Bound deg(rad(f³·g²·c)) ≤ deg f + deg g + deg c via radical_cube_sq_mul_dvd and natDegree_le_of_dvd / natDegree_mul. Feed the two lower bounds, the upper bound, deg(f³) = 3·deg f and deg(g²) = 2·deg g to omega.\n3. natDegree_cube_sub_sq_ge: omega from davenport.",
+    "keyInsights": [
+      "**Davenport is Mason–Stothers for the triple (f³, −g², f³ − g²).** Choosing this coprime additive triple turns the abstract degree bound max{deg a, deg b} + 1 ≤ deg rad into two concrete inequalities 3·deg f + 1 ≤ R and 2·deg g + 1 ≤ R.",
+      "**The radical upper bound needs no coprimality.** rad(f³·g²·c) ∣ f·g·c holds because the radical is insensitive to exponents (rad(pⁿ) = rad p) and rad(ab) ∣ rad a · rad b unconditionally; the cube and the square contribute only deg f and deg g, not 3·deg f and 2·deg g, to the distinct-root count.",
+      "**Sandwiching two lower bounds against one upper bound.** Adding 3F + 1 ≤ R and 2G + 1 ≤ R and using 2R ≤ 2(F + G + C) cancels the G terms and gives F + 2 ≤ 2C — Davenport's inequality — purely by omega.",
+      "**Characteristic zero is inherited from the parent.** mason_stothers_charZero already eliminated the derivative-vanishing escape clause; over 𝔽_p the inequality can fail (e.g. f, g built from p-th powers), so the [CharZero k] hypothesis is essential and is carried straight through."
+    ],
+    "exampleSections": [
+      {
+        "title": "Sharpness: the bound deg(f³ − g²) ≥ ½·deg f + 1 is attained",
+        "mathContext": "Davenport's inequality is sharp: there exist coprime f, g with deg(f³ − g²) exactly ½·deg f + 1 (the classical 'Davenport pairs', related to Belyi maps and dessins d'enfants). The omega step here proves the inequality; equality cases are the subject of a separate study of extremal triples."
+      },
+      {
+        "title": "Why the integer Hall conjecture stays open",
+        "mathContext": "The integer analogue — that |x³ − y²| ≥ c·√x for some constant c (Hall's conjecture) — has no known unconditional proof, and the radical-degree argument has no integer counterpart because there is no 'derivative' lowering degrees. Davenport's polynomial inequality is the cautionary success story: the function-field abc (Mason–Stothers) is a theorem, while integer abc / Hall remain conjectural."
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Davenport, H.",
+      "title": "On f³(t) − g²(t)",
+      "year": "1965",
+      "note": "Norske Vid. Selsk. Forh. (Trondheim) 38, 86–87 — the original proof of the polynomial inequality deg(f³ − g²) ≥ ½·deg f + 1."
+    },
+    {
+      "authors": "Stothers, W. W.",
+      "title": "Polynomial identities and Hauptmoduln",
+      "year": "1981",
+      "note": "Quart. J. Math. Oxford 32, 349–370 — the Mason–Stothers theorem from which Davenport follows."
+    },
+    {
+      "authors": "Hall, Marshall",
+      "title": "The Diophantine equation x³ − y² = k",
+      "year": "1971",
+      "note": "Computers in Number Theory, 173–198 — the integer conjecture that Davenport's polynomial inequality models."
+    },
+    {
+      "authors": "Zannier, Umberto",
+      "title": "On Davenport's bound for the degree of f³ − g² and Riemann's existence theorem",
+      "year": "1995",
+      "note": "Acta Arith. 71, 107–137 — sharpness and the connection to Belyi maps / dessins d'enfants."
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "mason-stothers-theorem-oq-01",
+      "relation": "Parent entry. Supplies mason_stothers_charZero, the characteristic-zero Mason–Stothers degree bound that this Davenport derivation rests on; this entry answers its second open question."
+    }
+  ],
+  "conclusion": {
+    "summary": "Davenport's inequality deg f + 2 ≤ 2·deg(f³ − g²) (equivalently deg(f³ − g²) ≥ ½·deg f + 1) for coprime non-constant f, g over a characteristic-zero field with f³ ≠ g² is derived as a 0-axiom corollary of the parent's mason_stothers_charZero. The proof applies Mason–Stothers to the coprime triple f³ + (−g²) = f³ − g² and feeds the resulting lower bounds, together with the hypothesis-free radical-degree upper bound rad(f³·g²·c) ∣ f·g·c (radical_cube_sq_mul_dvd), to omega. Verified with 0 axioms, 0 sorries, no native_decide.",
+    "implications": "Closes the second open question of mason-stothers-theorem-oq-01 and packages the textbook Davenport inequality — the polynomial shadow of Hall's conjecture — as a reusable 0-axiom lemma built directly on the gallery's Mason–Stothers infrastructure.",
+    "openQuestions": [
+      "Characterise the extremal (Davenport) pairs attaining deg(f³ − g²) = ½·deg f + 1, connecting them to Belyi maps and the count of distinct roots of f³ − g².",
+      "Generalise to deg(fᵐ − gⁿ) for coprime f, g with 1/m + 1/n < 1, recovering the Davenport–Zannier bound (1 − 1/m − 1/n)·deg(fᵐ) + 1 from the same Mason–Stothers input."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.MasonStothersOQ01"
+    ],
+    "opens": [
+      "Polynomial",
+      "UniqueFactorizationMonoid",
+      "UniqueFactorizationDomain"
+    ],
+    "namespace": "MasonStothersOQ01OQ02",
+    "lineCount": 132,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/MasonStothersOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds **Davenport's inequality** as a verified, **0-axiom** corollary of the characteristic-zero Mason–Stothers (polynomial ABC) theorem proved in the parent entry `mason-stothers-theorem-oq-01`.

For coprime polynomials `f, g` over a characteristic-zero field with `f` non-constant, `g ≠ 0`, and `f³ ≠ g²`:

  **deg f + 2 ≤ 2·deg(f³ − g²)**,  equivalently  deg(f³ − g²) ≥ ½·deg f + 1.

This is the polynomial shadow of Hall's conjecture on `|x³ − y²|`.

## Proof
Apply Mason–Stothers to the coprime triple `a = f³, b = −g², c = f³ − g²`. The escape clause is excluded in char 0 since `f³` is non-constant, yielding lower bounds `deg(f³)+1, deg(g²)+1 ≤ deg rad(abc)`. The key combinatorial input is an **upper** bound `rad(f³·g²·c) ∣ f·g·c` (no coprimality needed) via `radical_mul_dvd`, `radical_pow`, `radical_dvd_self`, giving `deg rad(abc) ≤ deg f + deg g + deg c`. Combining via `omega`:
- `3·deg f + 1 ≤ deg f + deg g + deg c`
- `2·deg g + 1 ≤ deg f + deg g + deg c`

add to give `deg f + 2 ≤ 2·deg c`.

## Verification
- `./proofs/scripts/docker-build.sh Proofs.MasonStothersOQ01OQ02` ✅ builds (7744 jobs)
- 3 theorems, 0 sorries, 0 `axiom` declarations, no `native_decide`
- status: `verified`, badge: `original`, axiomCount: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)