### PR TITLE
research(lucas-theorem-oq-01-oq-01): Fine's theorem — ∏(nᵢ+1) entries not divisible by prime p [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3142,6 +3142,7 @@ import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle
 import Proofs.LucasLehmerTestOQ01
 import Proofs.LucasTheoremOQ01
+import Proofs.LucasTheoremOQ01OQ01
 import Proofs.LucasTheoremOQ01OQ02
 import Proofs.LucasTheoremOQ01OQ02OQ01
 import Proofs.MachinFromAddition

--- a/proofs/Proofs/LucasTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/LucasTheoremOQ01OQ01.lean
@@ -1,0 +1,211 @@
+import Mathlib
+import Proofs.LucasTheoremOQ01
+
+/-!
+# Fine's Theorem: the digit-product count of binomials not divisible by a prime
+
+For a prime `p`, write `n` in base `p` as `n = (nₐ … n₁ n₀)_p`.  **Fine's theorem**
+(1947) counts the entries of row `n` of Pascal's triangle that are *not* divisible
+by `p`:
+
+> the number of `k ∈ {0, …, n}` with `p ∤ C(n, k)` equals `∏ᵢ (nᵢ + 1)`,
+
+the product over the base-`p` digits `nᵢ` of `n`.
+
+This generalises the prime-`2` special case proved in `LucasTheoremOQ01`
+(`oddCount n = 2 ^ s₂(n)`): when `p = 2` every digit is `0` or `1`, so each factor
+`nᵢ + 1` is `1` or `2` and the product is `2` raised to the number of `1`-digits,
+i.e. `2 ^ s₂(n)`.
+
+## The proof
+
+The engine is the single base-`p` step of Lucas' theorem,
+`C(p·n + r, k) ≡ C(r, k mod p) · C(n, k div p) (mod p)` for `0 ≤ r < p`.  Since
+`r < p`, the digit-wise factor `C(r, s)` is coprime to `p` exactly when `s ≤ r`
+(when `s > r` it vanishes; when `s ≤ r` the factorial identity forces `vₚ = 0`).
+This yields the pointwise characterisation
+
+* `not_dvd_choose_step` : `p ∤ C(p·n + r, k) ↔ k mod p ≤ r ∧ p ∤ C(n, k div p)`,
+
+generalising `odd_choose_two_mul` / `odd_choose_two_mul_add_one`.  Partitioning row
+`p·n + r` by the last base-`p` digit `s = k mod p` turns the row into the image of
+`(fineRow p n) ×ˢ {0, …, r}` under `(j, s) ↦ p·j + s`, giving the multiplicative
+recursion
+
+* `fineCount_recursion` : `fineCount p (p·n + r) = (r + 1) · fineCount p n`,
+
+mirroring `oddCount_two_mul` and `oddCount_two_mul_add_one`.  A strong induction
+on `n`, run alongside the base-`p` digit recursion `Nat.digits_def'`, then gives the
+closed form
+
+* `fine_theorem` : `fineCount p n = ∏ over (digits p n) of (digit + 1)`.
+
+All results are fully machine-checked: `0` `sorry`, `0` `axiom`, no `native_decide`.
+-/
+
+open Nat Finset
+
+namespace FineTheorem
+
+/-- The set of column indices `k ≤ n` for which `p ∤ C(n, k)`. -/
+def fineRow (p n : ℕ) : Finset ℕ := (range (n + 1)).filter (fun k => ¬ p ∣ n.choose k)
+
+/-- The number of entries in row `n` of Pascal's triangle not divisible by `p`. -/
+def fineCount (p n : ℕ) : ℕ := (fineRow p n).card
+
+/-! ## A small-row binomial is coprime to `p` iff the column fits -/
+
+/-- For a prime `p` and `r < p`, the binomial `C(r, s)` is coprime to `p` exactly when
+`s ≤ r`: if `s > r` the coefficient vanishes (and `p ∣ 0`), while if `s ≤ r` the
+factorial identity `C(r,s)·s!·(r−s)! = r!` together with `p ∤ r!` (as `r < p`) forces
+`vₚ(C(r,s)) = 0`. -/
+theorem choose_not_dvd_iff {p : ℕ} (hp : p.Prime) {r : ℕ} (hr : r < p) (s : ℕ) :
+    ¬ p ∣ r.choose s ↔ s ≤ r := by
+  rcases le_or_gt s r with hs | hs
+  · simp only [hs, iff_true]
+    intro hdvd
+    have hfac : r.choose s * s ! * (r - s)! = r ! :=
+      Nat.choose_mul_factorial_mul_factorial hs
+    have hpr : p ∣ r ! := by
+      rw [← hfac]; exact (hdvd.mul_right _).mul_right _
+    rw [hp.dvd_factorial] at hpr
+    omega
+  · rw [Nat.choose_eq_zero_of_lt hs]
+    simp only [dvd_zero, not_true_eq_false, false_iff, not_le]
+    exact hs
+
+/-! ## The pointwise non-divisibility characterisation (single base-`p` step) -/
+
+/-- **Pointwise step.** For a prime `p` and last digit `r < p`,
+`p ∤ C(p·n + r, k)` iff the last base-`p` digit `k mod p` of `k` is `≤ r` and
+`p ∤ C(n, k div p)`.  This is the general-`p` analogue of `odd_choose_two_mul`
+(`r = 0`) and `odd_choose_two_mul_add_one` (`r = 1`). -/
+theorem not_dvd_choose_step {p : ℕ} (hp : p.Prime) {r : ℕ} (hr : r < p) (n k : ℕ) :
+    ¬ p ∣ (p * n + r).choose k ↔ k % p ≤ r ∧ ¬ p ∣ n.choose (k / p) := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  have h : (p * n + r).choose k
+      ≡ ((p * n + r) % p).choose (k % p) * ((p * n + r) / p).choose (k / p) [MOD p] :=
+    Choose.choose_modEq_choose_mod_mul_choose_div_nat
+  have e1 : (p * n + r) % p = r := by
+    rw [Nat.mul_add_mod]; exact Nat.mod_eq_of_lt hr
+  have e2 : (p * n + r) / p = n := by
+    rw [Nat.mul_add_div hp.pos]; simp [Nat.div_eq_of_lt hr]
+  rw [e1, e2] at h
+  have hiff : p ∣ (p * n + r).choose k ↔ p ∣ r.choose (k % p) * n.choose (k / p) := by
+    rw [← Nat.modEq_zero_iff_dvd, ← Nat.modEq_zero_iff_dvd]
+    exact ⟨fun ha => h.symm.trans ha, fun hb => h.trans hb⟩
+  rw [hiff, hp.dvd_mul, not_or, choose_not_dvd_iff hp hr]
+
+/-! ## The multiplicative recursion for `fineCount` -/
+
+/-- **Multiplicative recursion.** For a prime `p` and last digit `r < p`,
+`fineCount p (p·n + r) = (r + 1) · fineCount p n`.  Row `p·n + r` is the image of
+`fineRow p n ×ˢ {0, …, r}` under `(j, s) ↦ p·j + s` (split off the last base-`p`
+digit), and that map is injective on the product, so the cardinalities multiply.
+Generalises `oddCount_two_mul` (`r = 0`) and `oddCount_two_mul_add_one` (`r = 1`). -/
+theorem fineCount_recursion {p : ℕ} (hp : p.Prime) {r : ℕ} (hr : r < p) (n : ℕ) :
+    fineCount p (p * n + r) = (r + 1) * fineCount p n := by
+  have himg : fineRow p (p * n + r)
+      = (fineRow p n ×ˢ range (r + 1)).image (fun x : ℕ × ℕ => p * x.1 + x.2) := by
+    ext k
+    simp only [fineRow, Finset.mem_filter, Finset.mem_range, Finset.mem_image,
+      Finset.mem_product, Nat.lt_succ_iff, Prod.exists]
+    constructor
+    · rintro ⟨hk, hnd⟩
+      rw [not_dvd_choose_step hp hr] at hnd
+      obtain ⟨hs, hndj⟩ := hnd
+      have hjn : k / p ≤ n := by
+        by_contra hcon
+        push_neg at hcon
+        exact hndj (by rw [Nat.choose_eq_zero_of_lt hcon]; exact dvd_zero p)
+      refine ⟨k / p, k % p, ⟨⟨hjn, hndj⟩, hs⟩, ?_⟩
+      exact Nat.div_add_mod k p
+    · rintro ⟨j, s, ⟨⟨hjn, hndj⟩, hs⟩, rfl⟩
+      have hsp : s < p := lt_of_le_of_lt hs hr
+      have hmod : (p * j + s) % p = s := by
+        rw [Nat.mul_add_mod]; exact Nat.mod_eq_of_lt hsp
+      have hdiv : (p * j + s) / p = j := by
+        rw [Nat.mul_add_div hp.pos]; simp [Nat.div_eq_of_lt hsp]
+      have hpj : p * j ≤ p * n := by gcongr
+      refine ⟨by omega, ?_⟩
+      rw [not_dvd_choose_step hp hr, hmod, hdiv]
+      exact ⟨hs, hndj⟩
+  have hinj : Set.InjOn (fun x : ℕ × ℕ => p * x.1 + x.2)
+      (↑(fineRow p n ×ˢ range (r + 1)) : Set (ℕ × ℕ)) := by
+    intro a ha b hb hab
+    simp only [Finset.coe_product, Set.mem_prod, Finset.mem_coe, Finset.mem_range] at ha hb
+    have hap : a.2 < p := lt_of_lt_of_le ha.2 (by omega)
+    have hbp : b.2 < p := lt_of_lt_of_le hb.2 (by omega)
+    have key : p * a.1 + a.2 = p * b.1 + b.2 := hab
+    have h1 : a.1 = b.1 := by
+      have e1 : (p * a.1 + a.2) / p = a.1 := by
+        rw [Nat.mul_add_div hp.pos, Nat.div_eq_of_lt hap, add_zero]
+      have e2 : (p * b.1 + b.2) / p = b.1 := by
+        rw [Nat.mul_add_div hp.pos, Nat.div_eq_of_lt hbp, add_zero]
+      rw [← e1, ← e2, key]
+    have h2 : a.2 = b.2 := by rw [h1] at key; exact Nat.add_left_cancel key
+    exact Prod.ext h1 h2
+  have hcard : (fineRow p (p * n + r)).card
+      = (fineRow p n ×ˢ range (r + 1)).card := by
+    rw [himg]; exact Finset.card_image_of_injOn hinj
+  unfold fineCount
+  rw [hcard, Finset.card_product, Finset.card_range]
+  ring
+
+/-- Base case: `p ∤ C(0, 0) = 1`, so row `0` has a single surviving entry. -/
+theorem fineCount_zero {p : ℕ} (hp : p.Prime) : fineCount p 0 = 1 := by
+  have h : fineRow p 0 = {0} := by
+    ext k
+    simp only [fineRow, Finset.mem_filter, Finset.mem_range, Finset.mem_singleton]
+    constructor
+    · rintro ⟨hk, _⟩; omega
+    · rintro rfl
+      refine ⟨by omega, ?_⟩
+      rw [Nat.choose_self]
+      exact Nat.dvd_one.not.mpr hp.ne_one
+  unfold fineCount
+  rw [h, Finset.card_singleton]
+
+/-! ## Fine's theorem -/
+
+/-- **Fine's theorem.** For a prime `p`, the number of entries in row `n` of Pascal's
+triangle that are *not* divisible by `p` equals the product `∏ᵢ (nᵢ + 1)` over the
+base-`p` digits `nᵢ` of `n`.
+
+Specialising to `p = 2` recovers Glaisher's `oddCount n = 2 ^ s₂(n)` from
+`LucasTheoremOQ01`. -/
+theorem fine_theorem {p : ℕ} (hp : p.Prime) (n : ℕ) :
+    fineCount p n = ((Nat.digits p n).map (· + 1)).prod := by
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · rw [fineCount_zero hp]; simp
+    · have hp1 : 1 < p := hp.one_lt
+      have hsplit : p * (n / p) + n % p = n := Nat.div_add_mod n p
+      have hlt : n / p < n := Nat.div_lt_self hn hp1
+      have hr : n % p < p := Nat.mod_lt _ hp.pos
+      calc fineCount p n
+          = fineCount p (p * (n / p) + n % p) := by rw [hsplit]
+        _ = (n % p + 1) * fineCount p (n / p) := fineCount_recursion hp hr _
+        _ = (n % p + 1) * ((Nat.digits p (n / p)).map (· + 1)).prod := by rw [ih _ hlt]
+        _ = ((Nat.digits p n).map (· + 1)).prod := by
+              rw [Nat.digits_def' hp1 hn, List.map_cons, List.prod_cons]
+
+/-! ## Sanity checks -/
+
+/-- Row `5` mod `2`: digits of `5` are `1, 0, 1` (`5 = 101₂`), product
+`(1+1)(0+1)(1+1) = 4`, matching `oddCount 5 = 4`. -/
+example : fineCount 2 5 = 4 := by decide
+
+/-- Row `7` mod `3`: `7 = 21₃` has digits `1, 2`, product `(1+1)(2+1) = 6`. -/
+example : fineCount 3 7 = 6 := by decide
+
+/-- Row `10` mod `3`: `10 = 101₃` has digits `1, 0, 1`, product
+`(1+1)(0+1)(1+1) = 4`. -/
+example : fineCount 3 10 = 4 := by decide
+
+/-- The closed form holds for `p = 3`, `n = 7`. -/
+example : fineCount 3 7 = ((Nat.digits 3 7).map (· + 1)).prod :=
+  fine_theorem (by norm_num) 7
+
+end FineTheorem

--- a/src/data/proofs/lucas-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "fine-oq0101-ann-defs",
+    "proofId": "lucas-theorem-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 54 },
+    "type": "definition",
+    "title": "Non-Divisible Row and Count (fineRow, fineCount)",
+    "content": "Two definitions generalise the parent's p = 2 setup to an arbitrary prime p. `fineRow p n` is the Finset of columns k ∈ {0,…,n} for which p ∤ C(n,k), and `fineCount p n` is its cardinality — the number of entries in row n of Pascal's triangle not divisible by p. For p = 2 these are exactly the parent's `oddRow` / `oddCount`. The target is Fine's closed form fineCount p n = ∏ᵢ (nᵢ+1) over the base-p digits nᵢ of n.",
+    "mathContext": "$\\mathrm{fineCount}(p,n) = \\#\\{k \\le n : p \\nmid \\binom{n}{k}\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Pascal's triangle mod p",
+      "Lucas' theorem",
+      "base-p digits",
+      "Finset cardinality"
+    ],
+    "prerequisites": [
+      "base-p expansions",
+      "binomial coefficients",
+      "prime divisibility"
+    ]
+  },
+  {
+    "id": "fine-oq0101-ann-coprime",
+    "proofId": "lucas-theorem-oq-01-oq-01",
+    "range": { "startLine": 62, "endLine": 75 },
+    "type": "theorem",
+    "title": "Digit-wise Coprimality: C(r,s) coprime to p ⟺ s ≤ r",
+    "content": "For a prime p and a digit value r < p, the small binomial C(r,s) is coprime to p exactly when s ≤ r. The s > r branch is immediate: C(r,s) = 0 and p ∣ 0. For s ≤ r, the factorial identity C(r,s)·s!·(r−s)! = r! shows any prime dividing C(r,s) would divide r!; but p ∤ r! since r < p (Nat.Prime.dvd_factorial gives p ∣ r! ⟺ p ≤ r). This is the survival criterion for a single base-p digit, and the engine that turns Lucas mod p into a counting recursion.",
+    "mathContext": "$r < p \\implies \\bigl(p \\nmid \\tbinom{r}{s} \\iff s \\le r\\bigr).$",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "p-adic valuation",
+      "factorial identity",
+      "prime not dividing small factorial"
+    ],
+    "prerequisites": [
+      "Nat.choose_mul_factorial_mul_factorial",
+      "Nat.Prime.dvd_factorial"
+    ]
+  },
+  {
+    "id": "fine-oq0101-ann-pointwise",
+    "proofId": "lucas-theorem-oq-01-oq-01",
+    "range": { "startLine": 83, "endLine": 97 },
+    "type": "theorem",
+    "title": "Pointwise Non-Divisibility via Lucas mod p",
+    "content": "Writing the row index as p·n+r with last base-p digit r < p, the single step of Lucas' theorem (Mathlib's choose_modEq_choose_mod_mul_choose_div_nat, with (p·n+r)%p = r and (p·n+r)/p = n) gives C(p·n+r, k) ≡ C(r, k%p)·C(n, k/p) (mod p). As p is prime it divides the product iff a factor, and C(r, k%p) is coprime to p exactly when k%p ≤ r (previous lemma). Hence p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p) — the general-p analogue of the parent's odd_choose_two_mul (r = 0) and odd_choose_two_mul_add_one (r = 1).",
+    "mathContext": "$p \\nmid \\tbinom{pn+r}{k} \\iff k \\bmod p \\le r \\ \\wedge\\ p \\nmid \\tbinom{n}{\\lfloor k/p\\rfloor}.$",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "Lucas' theorem single step",
+      "modular arithmetic of binomials",
+      "digit-wise divisibility"
+    ],
+    "prerequisites": [
+      "Nat.Choose.choose_modEq_choose_mod_mul_choose_div_nat",
+      "Nat.Prime.dvd_mul"
+    ]
+  },
+  {
+    "id": "fine-oq0101-ann-recursion",
+    "proofId": "lucas-theorem-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 151 },
+    "type": "theorem",
+    "title": "The Multiplicative Recursion fineCount p (p·n+r) = (r+1)·fineCount p n",
+    "content": "Partition row p·n+r by the last base-p digit s = k%p. The pointwise law identifies the surviving columns with the image of the product fineRow p n ×ˢ {0,…,r} under the map (j,s) ↦ p·j+s. That map is injective on the product (s < p recovers s = k%p and j = k/p by div/mod), so Finset.card_image_of_injOn and Finset.card_product give fineCount p (p·n+r) = fineCount p n · (r+1). This is the (r+1)-branch generalisation of the parent's even/odd split j ↦ 2j and j ↦ 2j+1, and the combinatorial mirror of the base-p digit recursion digits p (p·n+r) = r :: digits p n.",
+    "mathContext": "$\\mathrm{fineCount}(p,\\,pn+r) = (r+1)\\,\\mathrm{fineCount}(p,n), \\qquad 0 \\le r < p.$",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "image of a Finset product",
+      "injective reindexing",
+      "base-p digit recursion"
+    ],
+    "prerequisites": [
+      "Finset.card_image_of_injOn",
+      "Finset.card_product",
+      "Nat.mul_add_div / Nat.mul_add_mod"
+    ]
+  },
+  {
+    "id": "fine-oq0101-ann-finetheorem",
+    "proofId": "lucas-theorem-oq-01-oq-01",
+    "range": { "startLine": 174, "endLine": 189 },
+    "type": "theorem",
+    "title": "Fine's Theorem: fineCount p n = ∏ᵢ (nᵢ+1)",
+    "content": "A strong induction on n closes the closed form. The base case fineCount p 0 = 1 (only C(0,0) = 1, coprime to p) matches the empty digit product. For n > 0, peel the last base-p digit with Nat.digits_def' (digits p n = n%p :: digits p (n/p)) and apply the multiplicative recursion at the decomposition n = p·(n/p) + n%p, so fineCount p n = (n%p + 1)·fineCount p (n/p), which by induction equals (n%p + 1)·∏(digits p (n/p) + 1) = ∏(digits p n + 1). Specialising to p = 2 — where every digit nᵢ ∈ {0,1} so nᵢ+1 ∈ {1,2} — recovers Glaisher's oddCount n = 2^(s₂ n) from the parent entry.",
+    "mathContext": "$\\mathrm{fineCount}(p,n) = \\prod_{i} (n_i + 1), \\qquad n = (n_a\\dots n_1 n_0)_p.$",
+    "significance": "main-result",
+    "relatedConcepts": [
+      "Fine's theorem",
+      "base-p digit product",
+      "Sierpiński/Lucas fractal",
+      "strong induction"
+    ],
+    "prerequisites": [
+      "Nat.digits_def'",
+      "Nat.strong_induction_on",
+      "List.prod_cons"
+    ]
+  }
+]

--- a/src/data/proofs/lucas-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LucasTheoremOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const lucasTheoremOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const lucasTheoremOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const lucasTheoremOQ01OQ01Data: ProofData = {
+  proof: lucasTheoremOQ01OQ01Proof,
+  annotations: lucasTheoremOQ01OQ01Annotations,
+}

--- a/src/data/proofs/lucas-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lucas-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,142 @@
+{
+  "id": "lucas-theorem-oq-01-oq-01",
+  "slug": "lucas-theorem-oq-01-oq-01",
+  "title": "Fine's Theorem: row n of Pascal's triangle has ∏(nᵢ+1) entries not divisible by a prime p",
+  "description": "Fine's theorem (1947) counts the entries of row n of Pascal's triangle that are NOT divisible by a prime p: writing n in base p as n = (nₐ…n₁n₀)_p, the number of k ∈ {0,…,n} with p ∤ C(n,k) equals the digit product ∏ᵢ (nᵢ + 1). This generalises the prime-2 special case proved in the parent entry (Glaisher's oddCount n = 2^(s₂ n)): when p = 2 every base-2 digit is 0 or 1, so each factor nᵢ+1 is 1 or 2 and the product collapses to 2^(number of 1-digits) = 2^(s₂ n). The engine is the single base-p step of Lucas' theorem, C(p·n+r, k) ≡ C(r, k%p)·C(n, k/p) (mod p) for the last digit r < p. Because r < p, the digit-wise factor C(r, s) is coprime to p exactly when s ≤ r — when s > r it vanishes, and when s ≤ r the factorial identity C(r,s)·s!·(r−s)! = r! together with p ∤ r! (as r < p) forces vₚ(C(r,s)) = 0. This yields the pointwise characterisation p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p), the general-p analogue of the parent's two parity laws (r = 0 and r = 1). Splitting row p·n+r by its last base-p digit s = k%p exhibits the surviving columns as the image of (fineRow p n) ×ˢ {0,…,r} under (j,s) ↦ p·j+s, an injection, giving the multiplicative recursion fineCount p (p·n+r) = (r+1)·fineCount p n. A strong induction run alongside the base-p digit recursion digits_def' then yields the closed form. Verified with 0 axioms, 0 sorries, no native_decide (the concrete row checks use kernel decide).",
+  "leanFile": {
+    "imports": ["Mathlib", "Proofs.LucasTheoremOQ01"],
+    "opens": ["Nat", "Finset"],
+    "namespace": "FineTheorem",
+    "lineCount": 211,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/LucasTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "overview": {
+    "text": "By the single base-p step of Lucas' theorem the non-divisibility of C(n,k) by p is determined digit-by-digit: p ∤ C(n,k) iff every base-p digit of k is ≤ the corresponding digit of n. Counting such k over the d base-p digits of n gives ∏ᵢ (nᵢ+1) independent choices, one factor 0,1,…,nᵢ per digit. The formalization routes this through a multiplicative recursion on the row index — peel the last base-p digit r, and the row splits into (r+1) reindexed copies of the smaller row — mirroring the base-p digit recursion of Nat.digits, and avoiding any explicit digit-tuple bijection."
+  },
+  "meta": {
+    "author": "Classical (Lucas 1878; Fine 1947 for the digit-product count of non-divisible binomials); Lean formalization original",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LucasTheoremOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "prime",
+      "binomial-coefficients",
+      "lucas-theorem",
+      "fines-theorem",
+      "pascals-triangle",
+      "base-p-digits",
+      "divisibility",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Choose.choose_modEq_choose_mod_mul_choose_div_nat",
+        "description": "The single recursive step of Lucas' theorem: for a prime p, C(m,k) ≡ C(m%p, k%p)·C(m/p, k/p) (mod p). Specialised to the last digit m = p·n+r (so m%p = r, m/p = n) it is the entire engine for the pointwise non-divisibility law not_dvd_choose_step.",
+        "module": "Mathlib.Data.Nat.Choose.Lucas"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "C(r,s)·s!·(r−s)! = r! for s ≤ r. Combined with p ∤ r! (when r < p) this forces vₚ(C(r,s)) = 0, proving the small-row coprimality C(r,s) coprime to p ⟺ s ≤ r (choose_not_dvd_iff).",
+        "module": "Mathlib.Data.Nat.Choose.Factorization"
+      },
+      {
+        "theorem": "Nat.Prime.dvd_factorial",
+        "description": "p ∣ r! ⟺ p ≤ r for a prime p. The r < p direction gives p ∤ r!, the source of the digit-wise coprimality that makes a base-p digit s ≤ r the exact survival condition.",
+        "module": "Mathlib.Data.Nat.Factorial.Prime"
+      },
+      {
+        "theorem": "Nat.digits_def'",
+        "description": "1 < b → 0 < n → digits b n = n % b :: digits b (n/b). The base-p digit recursion that aligns the strong induction in fine_theorem with the multiplicative recursion fineCount p (p·n+r) = (r+1)·fineCount p n.",
+        "module": "Mathlib.Data.Nat.Digits.Defs"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "Set.InjOn f ↑s → (s.image f).card = s.card. Counts the reindexing (j,s) ↦ p·j+s of the product fineRow p n ×ˢ range (r+1), giving the (r+1)-fold recursion (the p-branch generalisation of the parent's even/odd j ↦ 2j, 2j+1 split).",
+        "module": "Mathlib.Data.Finset.Card"
+      },
+      {
+        "theorem": "Finset.card_product",
+        "description": "(s ×ˢ t).card = s.card · t.card. Turns the cardinality of the split row fineRow p n ×ˢ range (r+1) into fineCount p n · (r+1).",
+        "module": "Mathlib.Data.Finset.Prod"
+      }
+    ],
+    "originalContributions": [
+      "fine_theorem (Fine 1947): for a prime p, the number of entries in row n of Pascal's triangle not divisible by p equals ∏ᵢ (nᵢ+1) over the base-p digits nᵢ of n, formalized as fineCount p n = ((Nat.digits p n).map (· + 1)).prod. Proved by strong induction on the multiplicative recursion, with the base-p digit-product structure supplied by digits_def'. Generalises the parent's Glaisher count oddCount n = 2^(s₂ n) from p = 2 (where every nᵢ+1 ∈ {1,2}) to arbitrary p. Not present in Mathlib.",
+      "not_dvd_choose_step: the pointwise non-divisibility law p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p) for the last base-p digit r < p, from the single Lucas step with C(r, k%p) coprime to p exactly when k%p ≤ r. The general-p analogue of the parent's odd_choose_two_mul (r = 0) and odd_choose_two_mul_add_one (r = 1).",
+      "choose_not_dvd_iff: for a prime p and r < p, C(r,s) is coprime to p ⟺ s ≤ r — the digit-wise survival criterion. Proved from the factorial identity and p ∤ r! (as r < p), with the vanishing C(r,s) = 0 handling the s > r branch.",
+      "fineCount_recursion: the multiplicative recursion fineCount p (p·n+r) = (r+1)·fineCount p n, obtained by exhibiting row p·n+r as the injective image of fineRow p n ×ˢ {0,…,r} under (j,s) ↦ p·j+s — the combinatorial mirror of the base-p digit recursion digits p (p·n+r) = r :: digits p n.",
+      "fineRow / fineCount: the set and count of columns k ≤ n with p ∤ C(n,k), the general-p generalisation of the parent's oddRow / oddCount."
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries. The headline Fine's theorem is assembled in-file from the single-step Lucas recursion (Nat.Choose.choose_modEq_choose_mod_mul_choose_div_nat) and standard Finset/factorial infrastructure, all credited in mathlibDependencies; Fine's digit-product count itself is not in Mathlib. No native_decide — the concrete row checks (fineCount 2 5 = 4, fineCount 3 7 = 6, fineCount 3 10 = 4) use kernel `decide`, so no Lean.ofReduceBool. Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas.",
+    "lineCount": 211,
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "sections": [
+    {
+      "title": "Overview and Definitions",
+      "text": "fineRow p n is the finset of columns k ∈ {0,…,n} with p ∤ C(n,k); fineCount p n is its cardinality — the number of entries in row n not divisible by p. These generalise the parent's oddRow / oddCount (the p = 2 case counting odd entries). The goal is the closed form fineCount p n = ∏ᵢ (nᵢ+1) over the base-p digits of n."
+    },
+    {
+      "title": "Digit-wise Coprimality (choose_not_dvd_iff)",
+      "text": "For a prime p and a digit value r < p, the small binomial C(r,s) is coprime to p exactly when s ≤ r. If s > r then C(r,s) = 0 and p ∣ 0. If s ≤ r, the factorial identity C(r,s)·s!·(r−s)! = r! together with p ∤ r! (which holds because r < p, via Nat.Prime.dvd_factorial) forces p ∤ C(r,s). This is the survival criterion for a single base-p digit."
+    },
+    {
+      "title": "Pointwise Non-Divisibility via Lucas (not_dvd_choose_step)",
+      "text": "Writing the row index as p·n+r with last digit r < p, the single base-p step of Lucas' theorem gives C(p·n+r, k) ≡ C(r, k%p)·C(n, k/p) (mod p). Since p is prime it divides the product iff it divides a factor; with C(r, k%p) coprime to p ⟺ k%p ≤ r, this yields p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p) — the general-p analogue of the parent's two parity laws."
+    },
+    {
+      "title": "The Multiplicative Recursion (fineCount_recursion)",
+      "text": "Partition row p·n+r by the last base-p digit s = k%p. The pointwise law identifies the surviving columns with the image of fineRow p n ×ˢ {0,…,r} under the injection (j,s) ↦ p·j+s (injective because s < p pins down s = k%p and j = k/p). Counting the product gives fineCount p (p·n+r) = (r+1)·fineCount p n — the (r+1)-branch generalisation of the parent's even/odd j ↦ 2j, 2j+1 reindexing."
+    },
+    {
+      "title": "Fine's Closed Form (fine_theorem)",
+      "text": "A strong induction on n, peeling the last base-p digit via Nat.digits_def' (digits p n = n%p :: digits p (n/p)) and applying the multiplicative recursion at each step, assembles fineCount p n = ((Nat.digits p n).map (· + 1)).prod = ∏ᵢ (nᵢ+1). Specialising to p = 2 recovers Glaisher's oddCount n = 2^(s₂ n) from the parent entry."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "lucas-theorem-oq-01",
+      "relationship": "specializes",
+      "description": "The parent proves the prime-2 case (Glaisher: oddCount n = 2^(s₂ n)); this entry generalises it to an arbitrary prime p via the same Lucas-step engine and image/product reindexing, with the (r+1)-branch recursion replacing the even/odd 2-branch split. Reuses Proofs.LucasTheoremOQ01 as an import."
+    },
+    {
+      "targetId": "catalan-numbers-oq-01-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Shares the Lucas/Kummer arithmetic of binomial coefficients modulo a prime; there for the p-adic valuation of Catalan numbers, here for the digit-product count of non-divisible binomials."
+    }
+  ],
+  "references": [
+    {
+      "title": "Binomial coefficients and the ring of p-adic integers (Fine's theorem on N(n,p))",
+      "author": "N. J. Fine",
+      "year": 1947,
+      "note": "Fine, 'Binomial coefficients modulo a prime', American Mathematical Monthly 54 (1947), 589–592: the number of k with p ∤ C(n,k) is ∏(nᵢ+1)."
+    },
+    {
+      "title": "Sur les congruences des nombres eulériens et des coefficients différentiels...",
+      "author": "É. Lucas",
+      "year": 1878,
+      "note": "Original source of Lucas' theorem on binomial coefficients modulo a prime."
+    }
+  ],
+  "sorries": [],
+  "conclusion": {
+    "summary": "Generalising the parent's prime-2 Glaisher count, this entry proves Fine's theorem: the number of entries in row n of Pascal's triangle not divisible by a prime p equals the base-p digit product ∏ᵢ (nᵢ+1). The proof reduces the single base-p step of Lucas' theorem to a digit-wise coprimality criterion (C(r,s) coprime to p ⟺ s ≤ r for r < p), lifts it to a pointwise non-divisibility law, packages that into the multiplicative recursion fineCount p (p·n+r) = (r+1)·fineCount p n via an injective product reindexing, and closes by strong induction along the base-p digit recursion — all with 0 axioms and no native_decide.",
+    "implications": "Fine's count is the multiplicity backbone of Pascal's triangle modulo p (the p-ary Sierpiński/Lucas fractal): row n carries exactly ∏(nᵢ+1) units mod p. The p = 2 face is the parent's odd-entry count 2^(s₂ n). The recursion fineCount p (p·n+r) = (r+1)·fineCount p n is the per-row engine behind the row-sum asymptotics ∑_{n < pᵐ} fineCount p n = (p(p+1)/2)ᵐ, the arithmetic of the mod-p fractal's box dimension.",
+    "openQuestions": [
+      "Row-sum / fractal dimension: prove ∑_{n < pᵐ} fineCount p n = (p(p+1)/2)ᵐ, generalising the p = 2 total 3ᵐ; it follows from fine_theorem by summing the digit-product over all m-digit base-p strings (∑_{d<p} (d+1) = p(p+1)/2 per digit), giving the Sierpiński-gasket box dimension log_p(p(p+1)/2).",
+      "Exact divisibility refinement (Kummer): strengthen 'p ∤ C(n,k)' to the full p-adic valuation vₚ(C(n,k)) = number of carries when adding k and n−k in base p, recovering fine_theorem as the zero-carry (vₚ = 0) stratum."
+    ]
+  }
+}

--- a/src/data/research/problems/lucas-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/lucas-theorem-oq-01-oq-01.json
@@ -1,0 +1,117 @@
+{
+  "slug": "lucas-theorem-oq-01-oq-01",
+  "title": "Fine's Theorem: Digit-Product Count of Non-Divisible Binomials",
+  "phase": "ACT",
+  "status": "completed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\#\\{\\,k\\le n : p\\nmid\\binom{n}{k}\\,\\} = \\prod_i (n_i+1),\\ \\text{ where } n=\\sum_i n_i p^i",
+    "plain": "Generalizing the parent's base-2 odd-count formula (2^(number of 1-bits)), Fine's theorem counts the entries in row n of Pascal's triangle that are NOT divisible by a prime p: the count is the product over the base-p digits n_i of n of (n_i + 1). By Lucas' theorem a binomial is nonzero mod p exactly when each digit k_i <= n_i, giving n_i+1 choices per digit.",
+    "whyMatters": [
+      "Fine's theorem is the canonical generalization of the Sierpinski-triangle odd-count formula to every prime.",
+      "It packages a clean application of Lucas' theorem to a counting problem, completing the parent's first open question."
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": "Define notDivCount p n = card of {k <= n : not p | C(n,k)} and prove it equals the product over base-p digits of (n_i+1), via a per-digit Lucas recursion notDivCount p (p*m+r) = (r+1)*notDivCount p m (or the digit-tuple bijection)."
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-23T08:51:48-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Fine theorem proved & verified (0 axioms, 0 sorries, no native_decide). fineCount p n = prod(n_i+1) over base-p digits. Docker build 7744 jobs OK; shipped as PR #28255.",
+    "builtItems": [
+      "fine_theorem: fineCount p n = ((digits p n).map (+1)).prod (LucasTheoremOQ01OQ01.lean:174)",
+      "not_dvd_choose_step (LucasTheoremOQ01OQ01.lean:83)",
+      "fineCount_recursion (LucasTheoremOQ01OQ01.lean:106)",
+      "choose_not_dvd_iff (LucasTheoremOQ01OQ01.lean:62)"
+    ],
+    "insights": [
+      "Reflection (k->n-k), the parent oq-07-oq-03 trick, does NOT generalize; engine is the single base-p Lucas step C(p*n+r,k) = C(r,k%p)*C(n,k/p) mod p, mirroring the parent oq-01 p=2 doubling recursion.",
+      "Digit-wise survival: for r<p, C(r,s) coprime to p iff s<=r. From C(r,s)*s!*(r-s)!=r! and p does not divide r! (r<p).",
+      "Multiplicative recursion fineCount p (p*n+r)=(r+1)*fineCount p n is the (r+1)-branch generalization of the parent even/odd 2-branch split.",
+      "Injectivity of (j,s)->p*j+s needs div/mod recovery (Nat.mul_add_div), not omega (nonlinear p*j)."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks Fine digit-product count of non-divisible binomials; assembled in-file from single-step Lucas."
+    ],
+    "nextSteps": [
+      "Row-sum sum_{n<p^m} fineCount p n = (p(p+1)/2)^m (Sierpinski box dim).",
+      "Kummer carry-count vp(C(n,k))=#carries refinement.",
+      "Follow-ups (future entries): row-sum identity sum_{n<p^m} fineCount p n = (p(p+1)/2)^m (Sierpinski box dimension log_p(p(p+1)/2)); Kummer refinement to full v_p(C(n,k)) = base-p carry count."
+    ],
+    "markdown": "# Knowledge Base: lucas-theorem-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory",
+    "lucas-theorem",
+    "digit-sums",
+    "binomial-coefficients",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "kummer-theorem-oq-01",
+    "lucas-theorem",
+    "lucas-theorem-oq-01",
+    "lucas-theorem-oq-01-oq-01",
+    "lucas-theorem-oq-01-oq-02",
+    "lucas-theorem-oq-01-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-23T08:51:48-07:00",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/LucasTheoremOQ01.lean",
+      "filename": "LucasTheoremOQ01.lean",
+      "lineCount": 207,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LucasTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/LucasTheoremOQ01OQ02.lean",
+      "filename": "LucasTheoremOQ01OQ02.lean",
+      "lineCount": 116,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LucasTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LucasTheoremOQ01OQ02OQ01.lean",
+      "filename": "LucasTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 219,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LucasTheoremOQ01OQ02OQ01.lean"
+    }
+  ],
+  "lastUpdate": "2026-06-23"
+}


### PR DESCRIPTION
## Summary

Adds a fully verified gallery entry proving **Fine's theorem** (1947): for a prime `p`, the number of entries in row `n` of Pascal's triangle that are **not** divisible by `p` equals the base-`p` digit product `∏ᵢ (nᵢ+1)`, formalized as `fineCount p n = ((Nat.digits p n).map (·+1)).prod`.

This generalises the parent `lucas-theorem-oq-01` (Glaisher's prime-2 count `oddCount n = 2^(s₂ n)`) to an arbitrary prime. It answers the open question posed in the parent entry.

## Proof architecture
- `choose_not_dvd_iff`: for `r < p`, `C(r,s)` is coprime to `p` ⟺ `s ≤ r` (digit-wise survival).
- `not_dvd_choose_step`: pointwise law `p ∤ C(p·n+r, k) ⟺ k%p ≤ r ∧ p ∤ C(n, k/p)`, from the single base-`p` Lucas step (`Nat.Choose.choose_modEq_choose_mod_mul_choose_div_nat`). General-`p` analogue of the parent's two parity laws.
- `fineCount_recursion`: multiplicative recursion `fineCount p (p·n+r) = (r+1)·fineCount p n`, via an injective product reindexing `(j,s) ↦ p·j+s` of `fineRow p n ×ˢ {0,…,r}`.
- `fine_theorem`: strong induction along `Nat.digits_def'` closes the form.

## Verification
- **5 theorems, 2 definitions, 211 lines.**
- **0 axioms, 0 sorries, no `native_decide`** (concrete row sanity checks use kernel `decide`).
- Builds via Docker: `✔ [7744/7744] Built Proofs.LucasTheoremOQ01OQ01`.
- Status `verified`, badge `original` — the headline digit-product count is not in Mathlib and is assembled in-file; only the single Lucas step + standard Finset/factorial infrastructure are borrowed (all credited in `mathlibDependencies`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)