### PR TITLE
research: Taylor-coefficient factor theorem (X−a)ᵏ∣p ⟺ first k Taylor coeffs vanish [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/FactorRemainderTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ01OQ01.lean
@@ -1,0 +1,153 @@
+import Mathlib.Algebra.Polynomial.Taylor
+import Mathlib.Algebra.Polynomial.HasseDeriv
+import Mathlib.Tactic
+
+/-!
+# Factor–remainder theorem OQ-01-OQ-01: the Taylor-coefficient form
+
+The grandparent entry (`factor-remainder-theorem`) proves the Factor Theorem
+`(X − a) ∣ p ↔ p(a) = 0`. Its OQ-01 (`factor-remainder-theorem-oq-01`) gives the
+**multiplicity version** over a characteristic-zero field, phrased through iterated
+derivatives:
+
+> `(X − a)ᵏ ∣ p ↔ p(a) = p′(a) = ⋯ = p^{(k−1)}(a) = 0`.
+
+This entry answers OQ-01's first open question:
+
+> *Formalize the explicit Taylor-coefficient form: the order-`k` Taylor coefficient of `p`
+> at `a` is `p^{(k)}(a)/k!`, so `(X − a)ᵏ ∣ p` iff the first `k` Taylor coefficients vanish,
+> via `Polynomial.taylor`.*
+
+The Taylor coefficient `(taylor a p).coeff m` is defined directly through Hasse derivatives
+(`Polynomial.taylor_coeff : (taylor a p).coeff m = (hasseDeriv m p).eval a`) and so requires
+**no division**. Consequently the entire characterization holds over an **arbitrary
+commutative ring** — strictly more general than the parent's characteristic-zero field, and
+in particular valid in positive characteristic where ordinary derivatives fail to detect
+multiplicity. This simultaneously addresses the spirit of OQ-01's *second* open question
+(Hasse derivatives in positive characteristic).
+
+## Main results
+
+* `X_pow_dvd_taylor_iff` : `X^k ∣ taylor a p ↔ (X − a)^k ∣ p` — the substitution
+  `X ↦ X + a` (`Polynomial.taylorEquiv`, an algebra **equivalence**) reflects divisibility,
+  trading the shifted factor `(X − a)^k` for the monomial factor `X^k`.
+* `pow_dvd_iff_taylor_coeff_eq_zero` : **`(X − a)^k ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0`**
+  — the OQ's target, over any commutative ring, for any `k`.
+* `pow_dvd_iff_hasseDeriv_eval_eq_zero` : the same vanishing rephrased with Hasse derivatives,
+  `(X − a)^k ∣ p ↔ ∀ m < k, (hasseDeriv m p).eval a = 0` (the positive-characteristic form).
+* `factor_theorem_taylor` (`k = 1`) and `double_root_iff_taylor` (`k = 2`) : the low-order
+  specializations, recovering `p(a) = 0` and `p(a) = p′(a) = 0`.
+* `pow_dvd_iff_iterate_derivative_eval_eq_zero` : over a characteristic-zero field, the Taylor
+  form is *equivalent* to the parent's iterated-derivative form, since
+  `(derivative^[m] p).eval a = m! · (taylor a p).coeff m` and `m! ≠ 0`.
+
+`0` axioms.
+-/
+
+namespace FactorRemainderTheoremOQ01OQ01
+
+open Polynomial
+
+section CommRing
+
+variable {R : Type*} [CommRing R]
+
+/-- The substitution `X ↦ X + a` is an algebra **equivalence** of `R[X]`
+    (`Polynomial.taylorEquiv`), so it both preserves and reflects divisibility. Applied to the
+    factor `(X − a)^k` — which it sends to `X^k` — it shows that `X^k ∣ taylor a p` is
+    *equivalent* to `(X − a)^k ∣ p`. -/
+theorem X_pow_dvd_taylor_iff {p : R[X]} {a : R} {k : ℕ} :
+    X ^ k ∣ taylor a p ↔ (X - C a) ^ k ∣ p := by
+  -- `taylor a` carries the shifted factor `(X − a)^k` to the monomial `X^k`.
+  have hX : taylor a ((X - C a) ^ k) = X ^ k := by
+    have h1 : taylor a (X - C a) = X := by
+      rw [map_sub, taylor_X, taylor_C]; ring
+    rw [taylor_pow, h1]
+  -- Trade `X^k` for `taylor a ((X − a)^k)`, then reflect divisibility along the equivalence
+  -- `taylorEquiv a` (whose underlying map is `taylor a`, definitionally).
+  rw [← hX]
+  exact map_dvd_iff (taylorEquiv a)
+
+/-- **The Taylor-coefficient factor theorem.** Over any commutative ring, the factor
+    `(X − a)^k` divides `p` if and only if the first `k` Taylor coefficients of `p` at `a`
+    vanish:
+    `(X − a)^k ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0`.
+
+    No hypothesis on `p`, on `k`, or on the characteristic is needed. -/
+theorem pow_dvd_iff_taylor_coeff_eq_zero {p : R[X]} {a : R} {k : ℕ} :
+    (X - C a) ^ k ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0 := by
+  rw [← X_pow_dvd_taylor_iff, X_pow_dvd_iff]
+
+/-- **The Hasse-derivative form** (valid in positive characteristic). Since the Taylor
+    coefficient is `(taylor a p).coeff m = (hasseDeriv m p).eval a`, the divisibility
+    `(X − a)^k ∣ p` is equivalent to the vanishing of the first `k` Hasse derivatives of `p`
+    at `a`. Unlike ordinary derivatives, the divided-power (Hasse) derivatives correctly
+    characterize multiplicity over every commutative ring. -/
+theorem pow_dvd_iff_hasseDeriv_eval_eq_zero {p : R[X]} {a : R} {k : ℕ} :
+    (X - C a) ^ k ∣ p ↔ ∀ m < k, (hasseDeriv m p).eval a = 0 := by
+  simp_rw [pow_dvd_iff_taylor_coeff_eq_zero, taylor_coeff]
+
+/-- **Factor Theorem** (`k = 1`) recovered from the Taylor form: `(X − a) ∣ p ↔ p(a) = 0`,
+    because the `0`th Taylor coefficient is the evaluation `p(a)`. -/
+theorem factor_theorem_taylor {p : R[X]} {a : R} :
+    (X - C a) ∣ p ↔ p.eval a = 0 := by
+  rw [← pow_one (X - C a), pow_dvd_iff_taylor_coeff_eq_zero]
+  constructor
+  · intro h; simpa [taylor_coeff_zero] using h 0 Nat.zero_lt_one
+  · intro h m hm
+    interval_cases m
+    simpa [taylor_coeff_zero] using h
+
+/-- **Double-root criterion** (`k = 2`) recovered from the Taylor form:
+    `(X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0`. The `0`th and `1`st Taylor coefficients are
+    `p(a)` and `p′(a)`. -/
+theorem double_root_iff_taylor {p : R[X]} {a : R} :
+    (X - C a) ^ 2 ∣ p ↔ p.eval a = 0 ∧ (derivative p).eval a = 0 := by
+  rw [pow_dvd_iff_taylor_coeff_eq_zero]
+  constructor
+  · intro h
+    exact ⟨by simpa [taylor_coeff_zero] using h 0 (by norm_num),
+           by simpa [taylor_coeff_one] using h 1 (by norm_num)⟩
+  · rintro ⟨h0, h1⟩ m hm
+    interval_cases m
+    · simpa [taylor_coeff_zero] using h0
+    · simpa [taylor_coeff_one] using h1
+
+end CommRing
+
+section CharZero
+
+variable {K : Type*} [Field K] [CharZero K]
+
+omit [CharZero K] in
+/-- Over a characteristic-zero field, the iterated derivative recovers the Taylor coefficient
+    up to the factorial scalar: `(derivative^[m] p).eval a = m! · (taylor a p).coeff m`. This
+    is the polynomial form of Taylor's theorem `cₘ = p^{(m)}(a)/m!`. (No characteristic
+    hypothesis is needed for this identity; it holds over any commutative ring.) -/
+theorem iterate_derivative_eval_eq_factorial_smul_taylor_coeff
+    (p : K[X]) (a : K) (m : ℕ) :
+    (derivative^[m] p).eval a = (m.factorial : K) * (taylor a p).coeff m := by
+  have h := congrFun (factorial_smul_hasseDeriv (R := K) (k := m)) p
+  rw [taylor_coeff, ← h]
+  simp [nsmul_eq_mul]
+
+/-- **Consistency with the parent entry.** Over a characteristic-zero field the Taylor-form
+    factor theorem is *equivalent* to the parent's iterated-derivative form
+    (`factor-remainder-theorem-oq-01`): the first `k` Taylor coefficients of `p` at `a` vanish
+    iff the first `k` iterated derivatives of `p` vanish at `a`. The two characterizations of
+    multiplicity coincide because `m! ≠ 0`. -/
+theorem pow_dvd_iff_iterate_derivative_eval_eq_zero {p : K[X]} {a : K} {k : ℕ} :
+    (X - C a) ^ k ∣ p ↔ ∀ m < k, (derivative^[m] p).eval a = 0 := by
+  rw [pow_dvd_iff_taylor_coeff_eq_zero]
+  refine forall₂_congr fun m _ => ?_
+  rw [iterate_derivative_eval_eq_factorial_smul_taylor_coeff]
+  constructor
+  · intro h; rw [h, mul_zero]
+  · intro h
+    have hfac : (m.factorial : K) ≠ 0 := by
+      exact_mod_cast m.factorial_ne_zero
+    exact (mul_eq_zero.mp h).resolve_left hfac
+
+end CharZero
+
+end FactorRemainderTheoremOQ01OQ01

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-reflection",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 59,
+      "endLine": 74
+    },
+    "type": "insight",
+    "title": "Multiplicity Is Monomial Divisibility After Translating the Root to 0",
+    "content": "X_pow_dvd_taylor_iff is the geometric heart of the proof: Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p. The substitution X ↦ X + a is Mathlib's Polynomial.taylorEquiv, an algebra EQUIVALENCE of R[X]. It sends (X − a)ᵏ to Xᵏ (since taylor a (X − a) = (X + a) − a = X via taylor_X and taylor_C), and because it is an equivalence it both preserves AND reflects divisibility — map_dvd_iff turns taylor a ((X − a)ᵏ) ∣ taylor a p into the desired ‘iff’ with no separate converse. Conceptually: a root of multiplicity k at a becomes a root of multiplicity k at 0, where ‘(X − a)ᵏ divides’ is just ‘Xᵏ divides’, i.e. the first k coefficients vanish."
+  },
+  {
+    "id": "ann-main",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 90
+    },
+    "type": "insight",
+    "title": "The Taylor-Coefficient Form — and Why It Holds in Every Characteristic",
+    "content": "pow_dvd_iff_taylor_coeff_eq_zero is the open question's target: (X − a)ᵏ ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0. It is a one-line consequence of X_pow_dvd_taylor_iff followed by Mathlib's X_pow_dvd_iff (Xⁿ ∣ f ↔ ∀ d < n, f.coeff d = 0). The decisive point is that Mathlib defines the Taylor coefficient through Hasse derivatives, (taylor a p).coeff m = (hasseDeriv m p).eval a, with NO division by m!. So unlike the parent (which needed a characteristic-zero field to make factorials invertible), this statement — and its restatement pow_dvd_iff_hasseDeriv_eval_eq_zero — holds over an arbitrary commutative ring. In positive characteristic p the ordinary derivative of Xᵖ is 0, but the divided-power Hasse derivative still detects the multiplicity correctly."
+  },
+  {
+    "id": "ann-cases",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 114
+    },
+    "type": "insight",
+    "title": "Recovering the Factor Theorem and the Double-Root Criterion",
+    "content": "The classical low-order cases drop out of the Taylor form by reading the lowest coefficients. For k = 1, factor_theorem_taylor uses taylor_coeff_zero ((taylor a p).coeff 0 = p.eval a) to get (X − a) ∣ p ↔ p(a) = 0. For k = 2, double_root_iff_taylor adds taylor_coeff_one ((taylor a p).coeff 1 = p′.eval a) to get (X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0 — the repeated-root criterion used to detect discriminant vanishing or a common root of p and p′. Both proofs simply interval_cases over m < k and rewrite the corresponding coefficient lemma."
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "factor-remainder-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 126,
+      "endLine": 149
+    },
+    "type": "insight",
+    "title": "The New Form Generalizes the Parent, Not Replaces It",
+    "content": "Over a characteristic-zero field the two criteria coincide. iterate_derivative_eval_eq_factorial_smul_taylor_coeff proves the exact relation (derivative^[m] p).eval a = m! · (taylor a p).coeff m — the polynomial form of Taylor's theorem cₘ = p^{(m)}(a)/m! — using Mathlib's factorial_smul_hasseDeriv (m! • hasseDeriv m = derivative^[m]). Since m! ≠ 0 in characteristic zero, pow_dvd_iff_iterate_derivative_eval_eq_zero then shows the Taylor-coefficient form is EQUIVALENT to the parent's iterated-derivative form. This certifies that the more general statement specializes back to exactly the parent entry."
+  }
+]

--- a/src/data/proofs/factor-remainder-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,190 @@
+{
+  "id": "factor-remainder-theorem-oq-01-oq-01",
+  "title": "The Taylor-Coefficient Factor Theorem: (X − a)ᵏ ∣ p iff the First k Taylor Coefficients Vanish",
+  "slug": "factor-remainder-theorem-oq-01-oq-01",
+  "description": "Answers the first open question of factor-remainder-theorem-oq-01: recast the multiplicity factor theorem in terms of Taylor coefficients via Polynomial.taylor. The main result is (X − a)ᵏ ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0. Because the Taylor coefficient (taylor a p).coeff m = (hasseDeriv m p).eval a is defined through Hasse derivatives and needs no division, the characterization holds over an ARBITRARY commutative ring — strictly more general than the parent's characteristic-zero field, and valid in positive characteristic where ordinary derivatives fail (the spirit of OQ-01's second open question). Proof: the substitution X ↦ X + a is Mathlib's algebra equivalence Polynomial.taylorEquiv, so it reflects divisibility (map_dvd_iff), trading the shifted factor (X − a)ᵏ for the monomial Xᵏ, after which X_pow_dvd_iff reads off the vanishing of the first k coefficients. Includes the Hasse-derivative form, the k = 1 (Factor Theorem) and k = 2 (double root) cases, and a characteristic-zero bridge showing equivalence with the parent's iterated-derivative form. 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Taylor%27s_theorem",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorRemainderTheoremOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "factor-theorem",
+      "taylor-expansion",
+      "hasse-derivative",
+      "root-multiplicity",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.taylorEquiv",
+        "description": "The substitution X ↦ X + a as an algebra EQUIVALENCE R[X] ≃ₐ[R] R[X]; being a MulEquivClass it reflects divisibility",
+        "module": "Mathlib.Algebra.Polynomial.Taylor"
+      },
+      {
+        "theorem": "Polynomial.taylor_coeff",
+        "description": "(taylor a p).coeff m = (hasseDeriv m p).eval a — the Taylor coefficient is the evaluated Hasse derivative (no division)",
+        "module": "Mathlib.Algebra.Polynomial.Taylor"
+      },
+      {
+        "theorem": "Polynomial.X_pow_dvd_iff",
+        "description": "Xⁿ ∣ f ↔ ∀ d < n, f.coeff d = 0 — divisibility by a monomial power reads off low coefficients",
+        "module": "Mathlib.Algebra.Polynomial.Div"
+      },
+      {
+        "theorem": "map_dvd_iff",
+        "description": "For a MulEquivClass map f, f a ∣ f b ↔ a ∣ b — divisibility is reflected, not merely preserved",
+        "module": "Mathlib.Algebra.Ring.Divisibility.Basic"
+      },
+      {
+        "theorem": "Polynomial.factorial_smul_hasseDeriv",
+        "description": "m! • hasseDeriv m = derivative^[m] — relates Hasse derivatives to ordinary iterated derivatives (used only for the char-0 bridge)",
+        "module": "Mathlib.Algebra.Polynomial.HasseDeriv"
+      },
+      {
+        "theorem": "Polynomial.taylor_coeff_zero / Polynomial.taylor_coeff_one",
+        "description": "(taylor a p).coeff 0 = p.eval a and (taylor a p).coeff 1 = p'.eval a — the k = 1, 2 specializations",
+        "module": "Mathlib.Algebra.Polynomial.Taylor"
+      }
+    ],
+    "originalContributions": [
+      "pow_dvd_iff_taylor_coeff_eq_zero: the OQ's target — (X − a)ᵏ ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0, over an ARBITRARY commutative ring, for any k and any p (no nonzero/char hypotheses)",
+      "X_pow_dvd_taylor_iff: the structural lemma Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p, obtained by reflecting divisibility along the algebra equivalence taylorEquiv a (which sends (X − a)ᵏ to Xᵏ)",
+      "pow_dvd_iff_hasseDeriv_eval_eq_zero: the positive-characteristic form (X − a)ᵏ ∣ p ↔ ∀ m < k, (hasseDeriv m p).eval a = 0, where divided-power (Hasse) derivatives detect multiplicity even when ordinary derivatives vanish",
+      "factor_theorem_taylor and double_root_iff_taylor: the k = 1 and k = 2 cases recovered from the Taylor form via taylor_coeff_zero / taylor_coeff_one",
+      "iterate_derivative_eval_eq_factorial_smul_taylor_coeff and pow_dvd_iff_iterate_derivative_eval_eq_zero: over a characteristic-zero field, the explicit relation (derivative^[m] p).eval a = m! · (taylor a p).coeff m, proving the Taylor form is EQUIVALENT to the parent's iterated-derivative form"
+    ],
+    "axiomCount": 0,
+    "lineCount": 153,
+    "assumptions": "None. All theorems fully proved with 0 axioms and 0 sorries (no native_decide). The core results hold over an arbitrary commutative ring; only the final two theorems (the bridge to the iterated-derivative form) assume a characteristic-zero field, and there CharZero is used solely to conclude m! ≠ 0. #print axioms reports only [propext, Classical.choice, Quot.sound].",
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Polynomial divisibility and the Factor Theorem",
+      "The Taylor expansion of a polynomial (Polynomial.taylor) and its coefficients",
+      "Hasse (divided-power) derivatives",
+      "Root multiplicity in positive and zero characteristic"
+    ],
+    "relatedProblems": [
+      {
+        "id": "factor-remainder-theorem-oq-01",
+        "relationship": "Parent: the multiplicity factor theorem via iterated derivatives (over a char-0 field). This entry answers its first open question — the explicit Taylor-coefficient form — and generalizes it to any commutative ring."
+      },
+      {
+        "id": "factor-remainder-theorem",
+        "relationship": "Grandparent: the Factor and Remainder theorems. The k = 1 case factor_theorem_taylor recovers (X − a) ∣ p ↔ p(a) = 0."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The multiplicity factor theorem says (X − a)ᵏ ∣ p iff a is a root of p of multiplicity at least k. The parent entry (factor-remainder-theorem-oq-01) phrased this over a characteristic-zero field through iterated derivatives: p(a) = p′(a) = ⋯ = p^{(k−1)}(a) = 0. That formulation is exactly the statement that the Taylor expansion of p at a begins at order k. The parent left open the explicit Taylor-coefficient form — and the harder positive-characteristic case, where the derivative of Xᵖ vanishes and ordinary derivatives no longer track multiplicity.\n\nThe resolution is to use Hasse (divided-power) derivatives. Mathlib's Taylor coefficient is defined precisely this way: (taylor a p).coeff m = (hasseDeriv m p).eval a. This needs no division, so the entire characterization survives in arbitrary commutative rings. The geometric content is a change of variables: the algebra automorphism X ↦ X + a (Mathlib's Polynomial.taylorEquiv) carries the shifted factor (X − a)ᵏ to the monomial Xᵏ, converting a question about a root at a into a question about a root at 0 — where divisibility by Xᵏ is just the vanishing of the first k coefficients.",
+    "problemStatement": "Formalize the Taylor-coefficient form of the multiplicity factor theorem: (X − a)ᵏ ∣ p iff the first k Taylor coefficients of p at a vanish, via Polynomial.taylor. Make the characteristic hypothesis as weak as possible, and record the Hasse-derivative (positive-characteristic) form together with the k = 1 and k = 2 cases, plus the bridge back to the parent's iterated-derivative form over characteristic zero.",
+    "proofStrategy": "The keystone is X_pow_dvd_taylor_iff: Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p. Compute taylor a ((X − a)ᵏ) = (taylor a (X − a))ᵏ = Xᵏ (taylor a (X − a) = (X + a) − a = X, using taylor_X, taylor_C). Then reflect divisibility along the algebra EQUIVALENCE taylorEquiv a: since its underlying map is taylor a, map_dvd_iff gives taylor a ((X − a)ᵏ) ∣ taylor a p ↔ (X − a)ᵏ ∣ p, i.e. Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p. Chaining with Mathlib's X_pow_dvd_iff (Xⁿ ∣ f ↔ ∀ d < n, f.coeff d = 0) yields the main theorem pow_dvd_iff_taylor_coeff_eq_zero. The Hasse form is an application of taylor_coeff; the k = 1, 2 cases unfold taylor_coeff_zero / taylor_coeff_one; the char-0 bridge uses factorial_smul_hasseDeriv to get (derivative^[m] p).eval a = m! · (taylor a p).coeff m and cancels m! ≠ 0.",
+    "keyInsights": [
+      "The Taylor coefficient is a Hasse derivative, not a divided ordinary derivative: (taylor a p).coeff m = (hasseDeriv m p).eval a. This single fact removes every division and lets the whole theorem live over an arbitrary commutative ring.",
+      "Multiplicity is divisibility by a monomial after translation: the algebra equivalence X ↦ X + a moves the root from a to 0, turning (X − a)ᵏ ∣ p into Xᵏ ∣ taylor a p — and divisibility by Xᵏ is literally the vanishing of the first k coefficients.",
+      "Using an EQUIVALENCE (taylorEquiv) rather than just a homomorphism is what gives the ‘iff’: map_dvd_iff reflects divisibility in both directions, so no separate converse argument is needed.",
+      "The positive-characteristic obstruction of the parent disappears: pow_dvd_iff_hasseDeriv_eval_eq_zero holds in any characteristic because Hasse derivatives are the correct divided-power replacement for p^{(m)}/m!.",
+      "Consistency, not replacement: over characteristic zero (derivative^[m] p).eval a = m! · (taylor a p).coeff m, so the Taylor form and the parent's iterated-derivative form are equivalent — the new statement strictly generalizes the old."
+    ],
+    "prerequisites": [
+      "Polynomial divisibility and the Factor Theorem",
+      "Taylor expansion of polynomials and Taylor coefficients",
+      "Hasse (divided-power) derivatives",
+      "Algebra automorphisms of a polynomial ring"
+    ]
+  },
+  "sections": [
+    {
+      "id": "reflection",
+      "title": "Section I: The Substitution X ↦ X + a Reflects Divisibility",
+      "startLine": 59,
+      "endLine": 74,
+      "summary": "X_pow_dvd_taylor_iff: Xᵏ ∣ taylor a p ↔ (X − a)ᵏ ∣ p. Compute taylor a ((X − a)ᵏ) = Xᵏ, then reflect divisibility along the algebra equivalence taylorEquiv a via map_dvd_iff.",
+      "mathContext": "Translating the root from a to 0 trades the shifted factor (X − a)ᵏ for the monomial Xᵏ; an equivalence (not just a hom) reflects divisibility both ways."
+    },
+    {
+      "id": "main",
+      "title": "Section II: The Taylor-Coefficient Factor Theorem",
+      "startLine": 77,
+      "endLine": 90,
+      "summary": "pow_dvd_iff_taylor_coeff_eq_zero ((X − a)ᵏ ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0) over any commutative ring, and pow_dvd_iff_hasseDeriv_eval_eq_zero, the same vanishing rephrased with Hasse derivatives (the positive-characteristic form).",
+      "mathContext": "The OQ's target, plus the Hasse-derivative reading that remains valid where ordinary derivatives fail."
+    },
+    {
+      "id": "cases",
+      "title": "Section III: The k = 1 and k = 2 Cases",
+      "startLine": 92,
+      "endLine": 114,
+      "summary": "factor_theorem_taylor ((X − a) ∣ p ↔ p(a) = 0) and double_root_iff_taylor ((X − a)² ∣ p ↔ p(a) = 0 ∧ p′(a) = 0), recovered from the Taylor form via taylor_coeff_zero / taylor_coeff_one.",
+      "mathContext": "The classical Factor Theorem and the repeated-root criterion as low-order special cases."
+    },
+    {
+      "id": "bridge",
+      "title": "Section IV: Consistency with the Iterated-Derivative Form (char 0)",
+      "startLine": 126,
+      "endLine": 149,
+      "summary": "iterate_derivative_eval_eq_factorial_smul_taylor_coeff ((derivative^[m] p).eval a = m! · (taylor a p).coeff m) and pow_dvd_iff_iterate_derivative_eval_eq_zero, showing the Taylor form is equivalent to the parent's iterated-derivative form over a characteristic-zero field.",
+      "mathContext": "The new statement generalizes the parent: in characteristic zero the two multiplicity criteria coincide because m! is invertible."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) file of 153 lines and 7 theorems proving the Taylor-coefficient form of the multiplicity factor theorem: (X − a)ᵏ ∣ p iff the first k Taylor coefficients of p at a vanish. The argument reflects divisibility along the algebra equivalence taylorEquiv (X ↦ X + a), which sends (X − a)ᵏ to Xᵏ, and reads off coefficients via X_pow_dvd_iff. Because Taylor coefficients are Hasse derivatives, the result holds over an arbitrary commutative ring; the Hasse-derivative form, the k = 1 and k = 2 cases, and a characteristic-zero bridge to the parent's iterated-derivative form are included.",
+    "implications": "This answers the first open question of factor-remainder-theorem-oq-01 exactly as posed (the explicit Taylor-coefficient form via Polynomial.taylor) and, as a bonus, removes the parent's characteristic-zero restriction: the Taylor/Hasse form characterizes multiplicity in every characteristic, addressing the spirit of the second open question as well. The structural lemma X_pow_dvd_taylor_iff — multiplicity as monomial divisibility after translation — is a reusable tool for repeated-root and discriminant computations over general base rings.",
+    "openQuestions": [
+      "State the sharp positive-characteristic discrepancy explicitly: exhibit a polynomial over 𝔽ₚ for which the ordinary-derivative criterion fails but the Hasse/Taylor criterion succeeds, quantifying exactly where the parent's char-0 hypothesis is needed.",
+      "Derive the divided-difference/Newton-form consequence: relate (taylor a p).coeff m to finite differences and the Newton interpolation coefficients of p at a + ℤ, giving a combinatorial route to the same multiplicity test."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.Algebra.Polynomial.Taylor",
+      "Mathlib.Algebra.Polynomial.HasseDeriv",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "FactorRemainderTheoremOQ01OQ01",
+    "lineCount": 153,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/FactorRemainderTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "factor-remainder-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent: the multiplicity factor theorem via iterated derivatives over a char-0 field. This entry answers its first open question (the explicit Taylor-coefficient form via Polynomial.taylor) and generalizes it to any commutative ring."
+    },
+    {
+      "targetId": "factor-remainder-theorem",
+      "relationship": "extends",
+      "description": "Grandparent: the Factor and Remainder theorems. The k = 1 case factor_theorem_taylor recovers (X − a) ∣ p ↔ p(a) = 0."
+    }
+  ],
+  "references": [
+    {
+      "key": "DummitFoote",
+      "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004), §9.5 (multiplicities of roots).",
+      "type": "book"
+    },
+    {
+      "key": "HasseDeriv",
+      "citation": "Hasse, H., Theorie der höheren Differentiale in einem algebraischen Funktionenkörper mit vollkommenem Konstantenkörper bei beliebiger Charakteristik, J. Reine Angew. Math. 175 (1936), 50–54.",
+      "type": "article"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/factor-remainder-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/factor-remainder-theorem-oq-01-oq-01.json
@@ -1,0 +1,127 @@
+{
+  "slug": "factor-remainder-theorem-oq-01-oq-01",
+  "title": "Taylor-coefficient form of the multiplicity factor theorem",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{For } p \\in K[X],\\ a \\in K:\\quad (\\mathrm{taylor}\\ a\\ p).\\mathrm{coeff}\\ k = \\frac{p^{(k)}(a)}{k!}, \\qquad (X - C\\,a)^k \\mid p \\iff \\forall i < k,\\ (\\mathrm{taylor}\\ a\\ p).\\mathrm{coeff}\\ i = 0.",
+    "plain": "The parent entry proves that $(X-a)^k$ divides a polynomial $p$ exactly when $p$ and its first $k-1$ derivatives all vanish at $a$. This open question asks for the equivalent, more computational restatement in terms of the **Taylor expansion** of $p$ about $a$: the order-$k$ Taylor coefficient is $p^{(k)}(a)/k!$, so $(X-a)^k \\mid p$ iff the first $k$ Taylor coefficients of $p$ at $a$ vanish. The point is to route the criterion through Mathlib's `Polynomial.taylor` rather than iterated derivatives.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-06-23T09:30:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: Taylor-coefficient form proved over arbitrary CommRing (7 thms, 0 axioms, verified). Generalizes parent OQ-01 beyond char-0 and addresses spirit of its 2nd OQ (Hasse derivatives in positive characteristic). PR pending.",
+    "builtItems": [
+      "X_pow_dvd_taylor_iff (Proofs/FactorRemainderTheoremOQ01OQ01.lean:59): X^k ∣ taylor a p ↔ (X-a)^k ∣ p via taylorEquiv + map_dvd_iff",
+      "pow_dvd_iff_taylor_coeff_eq_zero (:77): MAIN — (X-a)^k ∣ p ↔ ∀ m<k, (taylor a p).coeff m = 0, over any CommRing",
+      "pow_dvd_iff_hasseDeriv_eval_eq_zero (:86): positive-characteristic Hasse form",
+      "factor_theorem_taylor (:92), double_root_iff_taylor (:104): k=1,2 cases",
+      "iterate_derivative_eval_eq_factorial_smul_taylor_coeff (:127) + pow_dvd_iff_iterate_derivative_eval_eq_zero (:139): char-0 bridge to parent (derivative^[m] p).eval a = m!·coeff"
+    ],
+    "insights": [
+      "The Taylor coefficient (taylor a p).coeff m is DEFINED as (hasseDeriv m p).eval a (no division), so the Taylor-coefficient multiplicity criterion holds over ANY commutative ring — strictly more general than the parent OQ-01 char-0 field.",
+      "Keystone: the substitution X ↦ X + a is Mathlib Polynomial.taylorEquiv, an ALGEBRA EQUIVALENCE; map_dvd_iff reflects divisibility, sending (X-a)^k ↦ X^k, reducing multiplicity to monomial divisibility X^k ∣ taylor a p.",
+      "X_pow_dvd_iff (X^n ∣ f ↔ ∀ d<n, f.coeff d = 0) then reads off the first k coefficients — making the main theorem a 2-rewrite proof."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Exhibit explicit F_p polynomial where ordinary-derivative criterion fails but Hasse/Taylor succeeds (quantify the char-0 gap).",
+      "Relate (taylor a p).coeff m to finite differences / Newton interpolation coefficients."
+    ],
+    "markdown": "# Knowledge Base: factor-remainder-theorem-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "algebra",
+    "polynomials",
+    "taylor-expansion"
+  ],
+  "relatedProofs": [
+    "factor-remainder-nullstellensatz",
+    "factor-remainder-theorem",
+    "factor-remainder-theorem-oq-01",
+    "factor-remainder-theorem-oq-05"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-23T16:32:41.646Z",
+  "lastUpdate": "2026-06-23T16:32:41.753Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/FactorRemainderTheorem.lean",
+      "filename": "FactorRemainderTheorem.lean",
+      "lineCount": 259,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheorem.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ01.lean",
+      "filename": "FactorRemainderTheoremOQ01.lean",
+      "lineCount": 72,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ02.lean",
+      "filename": "FactorRemainderTheoremOQ02.lean",
+      "lineCount": 103,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ03.lean",
+      "filename": "FactorRemainderTheoremOQ03.lean",
+      "lineCount": 287,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/FactorRemainderTheoremOQ05.lean",
+      "filename": "FactorRemainderTheoremOQ05.lean",
+      "lineCount": 124,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FactorRemainderTheoremOQ05.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `factor-remainder-theorem-oq-01` (the multiplicity factor theorem): the explicit **Taylor-coefficient form**, via `Polynomial.taylor`.

**Main result** — over an *arbitrary commutative ring* (strictly more general than the parent's characteristic-zero field):

```
pow_dvd_iff_taylor_coeff_eq_zero :
  (X − a)^k ∣ p ↔ ∀ m < k, (taylor a p).coeff m = 0
```

## How it works

- **Keystone** `X_pow_dvd_taylor_iff` : `X^k ∣ taylor a p ↔ (X − a)^k ∣ p`. The substitution `X ↦ X + a` is Mathlib's algebra **equivalence** `Polynomial.taylorEquiv`, so `map_dvd_iff` *reflects* divisibility, sending the shifted factor `(X − a)^k` to the monomial `X^k`. `Polynomial.X_pow_dvd_iff` then reads off the first `k` coefficients — making the main theorem a two-rewrite proof.
- **Every characteristic.** The Taylor coefficient `(taylor a p).coeff m = (hasseDeriv m p).eval a` is a *Hasse derivative* and needs **no division**, so the criterion survives in positive characteristic where ordinary derivatives fail. This is recorded as `pow_dvd_iff_hasseDeriv_eval_eq_zero`, addressing the spirit of OQ-01's *second* open question too.
- **Low-order cases** `factor_theorem_taylor` (`k = 1`) and `double_root_iff_taylor` (`k = 2`) recover `p(a) = 0` and `p(a) = p′(a) = 0`.
- **Consistency bridge** over a char-0 field: `(derivative^[m] p).eval a = m! · (taylor a p).coeff m`, proving the Taylor form is *equivalent* to the parent's iterated-derivative form (it generalizes, not replaces).

## Verification

- 7 theorems, 0 definitions, 153 lines; builds under `docker-build.sh` on Mathlib 4.26.0.
- `#print axioms` of the three headline theorems reports only `[propext, Classical.choice, Quot.sound]` — **no `native_decide`, no `Lean.ofReduceBool`, no `sorryAx`**. Status `verified`, 0 axioms.

## Files

- `proofs/Proofs/FactorRemainderTheoremOQ01OQ01.lean`
- `src/data/proofs/factor-remainder-theorem-oq-01-oq-01/{meta.json,annotations.json}`
- `src/data/research/problems/factor-remainder-theorem-oq-01-oq-01.json` (knowledge update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)