### PR TITLE
Enrich erdos-1023-oq-04: add annotations

### DIFF
--- a/src/data/proofs/erdos-1023-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1023-oq-04/annotations.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": "erdos1023oq04-ann-header",
+    "proofId": "erdos-1023-oq-04",
+    "range": { "startLine": 1, "endLine": 61 },
+    "type": "concept",
+    "title": "Elementary Growth Brackets, No Stirling",
+    "content": "F(n) is the maximum size of a union-free family of subsets of {1,…,n}. Erdős asked whether F(n) ~ c·2ⁿ/√n; the answer is yes, F(n) = C(n, ⌊n/2⌋) (middle layer optimal, Erdős–Kleitman), with the precise constant √(2/π) requiring Stirling. The parent obtains the exact asymptotic only through axioms. This sibling takes F(n) = C(n, ⌊n/2⌋) as the definition of unionFreeMax and proves — with ZERO axioms — the elementary growth: F(n) ≤ 2ⁿ, 2ⁿ ≤ (n+1)·F(n), the combined bracket, and divergence F(n) → ∞. This captures the QUALITATIVE content of the parent's Stirling axiom (order 2ⁿ up to a polynomial factor, unbounded) as a machine-checked statement, without the exact constant.",
+    "mathContext": "$F(n) = C(n,\\lfloor n/2\\rfloor)$; this file proves $\\dfrac{2^n}{n+1} \\le F(n) \\le 2^n$ and $F(n)\\to\\infty$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "union-free families",
+      "central binomial coefficient",
+      "Erdős–Kleitman theorem",
+      "Stirling's formula"
+    ],
+    "prerequisites": [
+      "binomial coefficients",
+      "Pascal's triangle",
+      "asymptotic notation"
+    ]
+  },
+  {
+    "id": "erdos1023oq04-ann-bracket",
+    "proofId": "erdos-1023-oq-04",
+    "range": { "startLine": 63, "endLine": 96 },
+    "type": "key-step",
+    "title": "The Two-Sided Bracket 2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ",
+    "content": "central_le_pow gives the trivial upper bound F(n) ≤ 2ⁿ (the central column is one term of the binomial sum, Nat.choose_le_two_pow). pow_le_succ_mul_central is the interesting direction: the binomial identity ∑_{m≤n} C(n,m) = 2ⁿ (Nat.sum_range_choose) and the maximality of the central column (Nat.choose_le_middle bounds every term) give 2ⁿ ≤ (n+1)·C(n,⌊n/2⌋) = (n+1)·F(n) in one Finset.sum_le_sum + sum_const. unionFreeMax_bracket packages both; pow_div_succ_le_central recasts the lower half over ℝ as 2ⁿ/(n+1) ≤ F(n) via div_le_iff₀. No Stirling estimate anywhere.",
+    "mathContext": "$2^n = \\sum_{m\\le n} C(n,m) \\le (n+1)\\,C(n,\\lfloor n/2\\rfloor) = (n+1)F(n);\\quad F(n) \\le 2^n.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "binomial row sum",
+      "Nat.choose_le_middle",
+      "averaging argument",
+      "polynomial factor"
+    ],
+    "prerequisites": [
+      "Nat.sum_range_choose",
+      "Finset.sum_le_sum",
+      "real division inequalities"
+    ]
+  },
+  {
+    "id": "erdos1023oq04-ann-even",
+    "proofId": "erdos-1023-oq-04",
+    "range": { "startLine": 98, "endLine": 108 },
+    "type": "theorem",
+    "title": "The Even Subsequence is the Central Binomial",
+    "content": "unionFreeMax_two_mul: F(2n) = C(2n, n) = centralBinom n (the floor ⌊2n/2⌋ = n is exact). two_mul_le_unionFreeMax_two_mul gives the clean linear lower bound 2n ≤ F(2n): centralBinom n ≥ C(2n, 1) = 2n by Nat.choose_le_centralBinom (the central column dominates every other column). This identifies the even-index subsequence with the well-studied central binomial coefficient and gives an explicit, Stirling-free growth handle.",
+    "mathContext": "$F(2n) = C(2n,n) = \\binom{2n}{n} \\ge \\binom{2n}{1} = 2n.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "central binomial coefficient",
+      "Nat.choose_le_centralBinom",
+      "even subsequence",
+      "column maximality"
+    ],
+    "prerequisites": [
+      "centralBinom definition",
+      "binomial column bounds"
+    ]
+  },
+  {
+    "id": "erdos1023oq04-ann-divergence",
+    "proofId": "erdos-1023-oq-04",
+    "range": { "startLine": 110, "endLine": 116 },
+    "type": "insight",
+    "title": "Divergence F(n) → ∞, Purely Combinatorially",
+    "content": "unionFreeMax_unbounded: ∀ M, ∃ n, M ≤ F(n) — the union-free maximum is unbounded. The proof is entirely over ℕ with no real analysis: take n = 2M; then F(2M) ≥ 2M ≥ M by the even-subsequence bound. This is the divergence content of the parent's Stirling-based asymptotic, recovered elementarily, and it shows the qualitative 'grows without bound' fact needs only column maximality, not the precise √(2/π)·2ⁿ/√n estimate.",
+    "mathContext": "$\\forall M,\\ F(2M) \\ge 2M \\ge M$, so $F(n)\\to\\infty$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "unboundedness",
+      "even subsequence bound",
+      "combinatorial divergence",
+      "no real analysis"
+    ],
+    "prerequisites": [
+      "the even-subsequence lower bound"
+    ]
+  },
+  {
+    "id": "erdos1023oq04-ann-concrete",
+    "proofId": "erdos-1023-oq-04",
+    "range": { "startLine": 118, "endLine": 133 },
+    "type": "context",
+    "title": "Concrete Values and a Bracket Sanity Check",
+    "content": "The closing examples evaluate F(0..6) = 1, 1, 2, 3, 6, 10, 20 by kernel `decide` (no native_decide, so no Lean.ofReduceBool), exhibiting the central-binomial sequence, and verify the lower bracket at n = 6: 2⁶ = 64 ≤ 7·20 = 140. These ground the abstract brackets in checkable small cases and confirm the (n+1)-factor in the lower bound is comfortably satisfied.",
+    "mathContext": "$F(0..6) = 1,1,2,3,6,10,20;\\quad 2^6 = 64 \\le 7\\cdot 20 = 140.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "concrete witnesses",
+      "kernel decide",
+      "central binomial sequence",
+      "sanity check"
+    ],
+    "prerequisites": [
+      "evaluating binomial coefficients"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1023-oq-04` (Erdős #1023: elementary growth brackets 2ⁿ/(n+1) ≤ F(n) ≤ 2ⁿ for the union-free maximum).

The entry already had a structured overview, conclusion, crossReferences, and full-file `sections`; the gap was **no annotations**.

**Added:**
- **annotations.json** — 5 annotations with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering: the no-Stirling growth framing, the two-sided bracket (averaging ∑C(n,m)=2ⁿ against the maximal central column), the even subsequence F(2n)=centralBinom n, the combinatorial divergence F(n)→∞, and the concrete values F(0..6).

Axiom integrity unchanged and verified: `status: verified`, `badge: verified`, `axiomCount: 0`. The concrete-value examples use kernel `decide` (not `native_decide`), so no `Lean.ofReduceBool` — correctly disclosed in the assumptions field. Scope is the elementary growth, not the exact √(2/π) constant or the Erdős–Kleitman optimality (both the parent's axiomatized inputs).

Note: per-proof `index.ts` is no longer used for loading (manifest-based since #20993), so none is added.

Verified with `pnpm build`.