### PR TITLE
research: mean, second moment, and variance of the Eulerian descent statistic [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3776,6 +3776,7 @@ import Proofs.ZsqrtdNegTwoOQ03OQ01
 import Proofs.eTranscendental
 import Proofs.MellinPowerConvergenceOQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ04
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06
 import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ06OQ01

--- a/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01.lean
@@ -1,0 +1,212 @@
+/-
+# Geometric series, open question oq-07-oq-01-oq-01-oq-01-oq-01-oq-01:
+# The mean and variance of the descent statistic from the Eulerian numbers
+
+The combinatorial **Eulerian number** `⟨n,k⟩` (`eulerian n k`, built by the grandparent entry
+`geometric-series-oq-07-oq-01-oq-01-oq-01`) counts the permutations of `{1,…,n}` with exactly `k`
+descents.  The parent `…-oq-01` established the **row sum** `∑ₖ ⟨n,k⟩ = n!` (every permutation
+has between `0` and `n−1` descents) and the sibling `…-oq-05` the **palindromy**
+`⟨n,k⟩ = ⟨n,n−1−k⟩`.  Together these say the row `(⟨n,0⟩,…,⟨n,n−1⟩)` is the *distribution of the
+number of descents* of a uniformly random permutation of `{1,…,n}`.
+
+This entry computes the first two **moments** of that distribution — statements about the *shape*
+of the Eulerian row, not exact entry values, and so genuinely distinct from the identities already
+in the family:
+
+* `eulerian_first_moment`  : `2·∑ₖ k·⟨n,k⟩ = (n−1)·n!`           (mean number of descents `(n−1)/2`);
+* `eulerian_second_moment` : `12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4)`    (for `n ≥ 2`);
+* `eulerian_variance`      : `12·(M₂·n! − M₁²) = (n+1)·n!²`       (variance of descents `(n+1)/12`).
+
+For example, row `3` is `1,4,1`: `∑ k·⟨3,k⟩ = 0+4+2 = 6 = (3−1)·3!/2`, so the mean is `1`; and
+`∑ k²·⟨3,k⟩ = 0+4+4 = 8`, giving `E[X²] = 8/6 = 4/3` and variance `4/3 − 1 = 1/3 = (3+1)/12`.
+
+## Method
+
+The **mean** is read straight off the palindromy: reflecting `k ↦ n−1−k`
+(`Finset.sum_range_reflect`) pairs `k·⟨n,k⟩` with `(n−1−k)·⟨n,k⟩`, so twice the first moment is
+`∑ₖ (n−1)·⟨n,k⟩ = (n−1)·n!`.
+
+The **second moment** needs more than symmetry.  The engine is a single **moment-transfer lemma**
+(`moment_transfer`): for any integer weight `w`,
+
+  `∑_{k} w(k)·⟨n+1,k⟩ = ∑_{i} (w(i)·(i+1) + w(i+1)·(n−i))·⟨n,i⟩`,
+
+obtained from the triangle recurrence `⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩` by peeling the
+`k=0` term and reindexing the shifted sum.  Specialising `w(k) = k²` and simplifying the
+coefficient `i²(i+1)+(i+1)²(n−i) = (n−1)i² + (2n−1)i + n` turns it into the moment recurrence
+`M₂(n+1) = (n−1)·M₂(n) + (2n−1)·M₁(n) + n·M₀(n)`, which closes the closed form by induction on
+`n ≥ 2` (feeding in `M₀ = n!` and the mean `M₁`).  The **variance** is then pure algebra.
+
+Everything is `0`-axiom (`propext` / `Classical.choice` / `Quot.sound` only) and `sorry`-free.
+-/
+import Mathlib
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05
+
+namespace GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01
+
+open Nat Finset GeometricSeriesOQ07OQ01OQ01OQ01 GeometricSeriesOQ07OQ01OQ01OQ01OQ01
+  GeometricSeriesOQ07OQ01OQ01OQ01OQ05
+
+/-! ## The zeroth moment (row sum) -/
+
+/-- The `p = 0` "moment": the row sum `∑ₖ ⟨n,k⟩ = n!`, cast to `ℤ`. -/
+theorem eulerian_M0 (n : ℕ) : ∑ k ∈ range (n + 1), (eulerian n k : ℤ) = (n ! : ℤ) := by
+  have h := eulerian_row_sum n
+  exact_mod_cast h
+
+/-! ## The moment-transfer lemma -/
+
+/-- **Moment transfer.**  For an arbitrary integer weight `w`, the weighted row-`(n+1)` sum is a
+weighted row-`n` sum: `∑_{k} w(k)·⟨n+1,k⟩ = ∑_{i} (w(i)·(i+1) + w(i+1)·(n−i))·⟨n,i⟩`.  Proved by
+peeling the `k = 0` term, expanding the triangle recurrence, and reindexing the shifted sum
+`∑_j w(j+1)·(j+2)·⟨n,j+1⟩` back over `⟨n,i⟩`. -/
+theorem moment_transfer (w : ℕ → ℤ) (n : ℕ) :
+    ∑ k ∈ range (n + 2), w k * (eulerian (n + 1) k : ℤ)
+      = ∑ i ∈ range (n + 1),
+          (w i * ((i : ℤ) + 1) + w (i + 1) * ((n : ℤ) - i)) * (eulerian n i : ℤ) := by
+  -- Peel the `k = 0` term off the left sum (`⟨n+1,0⟩ = 1`).
+  have hL : ∑ k ∈ range (n + 2), w k * (eulerian (n + 1) k : ℤ)
+      = (∑ j ∈ range (n + 1), w (j + 1) * (eulerian (n + 1) (j + 1) : ℤ)) + w 0 := by
+    rw [Finset.sum_range_succ', eulerian_succ_zero]
+    push_cast; ring
+  -- Expand the triangle recurrence inside the shifted sum.
+  have hL2 : ∑ j ∈ range (n + 1), w (j + 1) * (eulerian (n + 1) (j + 1) : ℤ)
+      = (∑ j ∈ range (n + 1), w (j + 1) * ((j : ℤ) + 2) * (eulerian n (j + 1) : ℤ))
+        + (∑ j ∈ range (n + 1), w (j + 1) * ((n : ℤ) - j) * (eulerian n j : ℤ)) := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro j hj
+    rw [mem_range] at hj
+    rw [eulerian_succ_succ]
+    push_cast [Nat.cast_sub (by omega : j ≤ n)]
+    ring
+  -- Reindex the first shifted sum `∑_j w(j+1)·(j+2)·⟨n,j+1⟩` back over `⟨n,i⟩`.
+  have hA : ∑ j ∈ range (n + 1), w (j + 1) * ((j : ℤ) + 2) * (eulerian n (j + 1) : ℤ)
+      = (∑ i ∈ range (n + 1), w i * ((i : ℤ) + 1) * (eulerian n i : ℤ)) - w 0 := by
+    -- Align the bodies of the two `range n` sums (`↑(i+1)+1 = ↑i+2`).
+    have hbody : ∀ i ∈ range n,
+        w (i + 1) * (((i + 1 : ℕ) : ℤ) + 1) * (eulerian n (i + 1) : ℤ)
+          = w (i + 1) * ((i : ℤ) + 2) * (eulerian n (i + 1) : ℤ) := by
+      intro i _; push_cast; ring
+    -- Peel the boundary terms: the `i = 0` term of the right sum is `w 0`, and the
+    -- `j = n` term of the left sum vanishes (`⟨n,n+1⟩ = 0`).
+    rw [Finset.sum_range_succ' (fun i => w i * ((i : ℤ) + 1) * (eulerian n i : ℤ)) n,
+        eulerian_col_zero,
+        Finset.sum_range_succ
+          (fun j => w (j + 1) * ((j : ℤ) + 2) * (eulerian n (j + 1) : ℤ)) n,
+        eulerian_eq_zero_of_lt (Nat.lt_succ_self n),
+        Finset.sum_congr rfl hbody]
+    push_cast; ring
+  -- Assemble.
+  have target : ∑ i ∈ range (n + 1),
+        (w i * ((i : ℤ) + 1) + w (i + 1) * ((n : ℤ) - i)) * (eulerian n i : ℤ)
+      = (∑ i ∈ range (n + 1), w i * ((i : ℤ) + 1) * (eulerian n i : ℤ))
+        + ∑ i ∈ range (n + 1), w (i + 1) * ((n : ℤ) - i) * (eulerian n i : ℤ) := by
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro i _; ring
+  rw [hL, hL2, hA, target]
+  ring
+
+/-! ## The first moment: the mean number of descents is `(n−1)/2` -/
+
+/-- **First moment of the descent statistic.**  `2·∑ₖ k·⟨n,k⟩ = (n−1)·n!` for `n ≥ 1`: the
+expected number of descents of a uniformly random permutation of `{1,…,n}` is `(n−1)/2`.  Proved
+from palindromy — reflecting `k ↦ n−1−k` pairs `k·⟨n,k⟩` with `(n−1−k)·⟨n,k⟩`. -/
+theorem eulerian_first_moment (n : ℕ) (hn : 1 ≤ n) :
+    2 * ∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ) = ((n : ℤ) - 1) * (n ! : ℤ) := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, by omega⟩
+  -- The top term `k = m+1` vanishes, so the moment is a sum over `range (m+1)`.
+  have hdrop : ∑ k ∈ range (m + 1 + 1), (k : ℤ) * (eulerian (m + 1) k : ℤ)
+      = ∑ k ∈ range (m + 1), (k : ℤ) * (eulerian (m + 1) k : ℤ) := by
+    rw [Finset.sum_range_succ, eulerian_succ_self]
+    simp
+  -- The row sum over `range (m+1)`.
+  have hrow : ∑ k ∈ range (m + 1), (eulerian (m + 1) k : ℤ) = ((m + 1)! : ℤ) := by
+    have h := eulerian_M0 (m + 1)
+    rwa [Finset.sum_range_succ, eulerian_succ_self, Nat.cast_zero, add_zero] at h
+  -- Reflection identity for the weighted summand.
+  have hrefl :
+      ∑ k ∈ range (m + 1), ((m + 1 - 1 - k : ℕ) : ℤ) * (eulerian (m + 1) (m + 1 - 1 - k) : ℤ)
+        = ∑ k ∈ range (m + 1), (k : ℤ) * (eulerian (m + 1) k : ℤ) :=
+    Finset.sum_range_reflect (fun k => (k : ℤ) * (eulerian (m + 1) k : ℤ)) (m + 1)
+  -- Twice the moment = `m · rowsum` via the reflection.
+  have hsum2 : (∑ k ∈ range (m + 1), (k : ℤ) * (eulerian (m + 1) k : ℤ))
+        + (∑ k ∈ range (m + 1), (k : ℤ) * (eulerian (m + 1) k : ℤ))
+      = ∑ k ∈ range (m + 1), (m : ℤ) * (eulerian (m + 1) k : ℤ) := by
+    conv_lhs => lhs; rw [← hrefl]
+    rw [← Finset.sum_add_distrib]
+    apply Finset.sum_congr rfl
+    intro k hk
+    rw [mem_range] at hk
+    have hpal : eulerian (m + 1) (m + 1 - 1 - k) = eulerian (m + 1) k :=
+      (eulerian_palindrome' (by omega : 1 ≤ m + 1) (by omega : k < m + 1)).symm
+    rw [hpal]
+    have hcast : ((m + 1 - 1 - k : ℕ) : ℤ) = (m : ℤ) - (k : ℤ) := by
+      have h0 : (m + 1 - 1 - k : ℕ) = m - k := by omega
+      rw [h0, Nat.cast_sub (by omega : k ≤ m)]
+    rw [hcast]; ring
+  rw [hdrop, two_mul, hsum2, ← Finset.mul_sum, hrow]
+  push_cast; ring
+
+/-! ## The second moment via the moment recurrence -/
+
+/-- The second-moment recurrence, read off `moment_transfer` with weight `w(k) = k²`:
+`M₂(n+1) = (n−1)·M₂(n) + (2n−1)·M₁(n) + n·M₀(n)`. -/
+theorem eulerian_M2_succ (n : ℕ) :
+    ∑ k ∈ range (n + 2), (k : ℤ) ^ 2 * (eulerian (n + 1) k : ℤ)
+      = ((n : ℤ) - 1) * (∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * (eulerian n k : ℤ))
+        + (2 * (n : ℤ) - 1) * (∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ))
+        + (n : ℤ) * (∑ k ∈ range (n + 1), (eulerian n k : ℤ)) := by
+  rw [moment_transfer (fun k => (k : ℤ) ^ 2) n]
+  rw [Finset.mul_sum, Finset.mul_sum, Finset.mul_sum, ← Finset.sum_add_distrib,
+    ← Finset.sum_add_distrib]
+  apply Finset.sum_congr rfl
+  intro i _
+  push_cast
+  ring
+
+/-- **Second moment of the descent statistic.**  `12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4)` for `n ≥ 2`.
+Induction on `n` from the base row `n = 2`, stepping with `eulerian_M2_succ` and feeding in the
+row sum `M₀ = n!` and the first moment `M₁`. -/
+theorem eulerian_second_moment (n : ℕ) (hn : 2 ≤ n) :
+    12 * ∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * (eulerian n k : ℤ)
+      = (n ! : ℤ) * (3 * (n : ℤ) ^ 2 - 5 * n + 4) := by
+  induction n, hn using Nat.le_induction with
+  | base => decide
+  | succ n hn ih =>
+    have hM0 : ∑ k ∈ range (n + 1), (eulerian n k : ℤ) = (n ! : ℤ) := eulerian_M0 n
+    have hM1 : 2 * ∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ) = ((n : ℤ) - 1) * (n ! : ℤ) :=
+      eulerian_first_moment n (by omega)
+    rw [eulerian_M2_succ, hM0, Nat.factorial_succ]
+    push_cast
+    linear_combination ((n : ℤ) - 1) * ih + 6 * (2 * (n : ℤ) - 1) * hM1
+
+/-! ## The variance of the descent statistic is `(n+1)/12` -/
+
+/-- **Variance of the descent statistic.**  Writing `M₁ = ∑ₖ k·⟨n,k⟩` and `M₂ = ∑ₖ k²·⟨n,k⟩`, the
+variance `M₂/n! − (M₁/n!)²` of the number of descents equals `(n+1)/12` for `n ≥ 2`.  Stated cleared
+of denominators over `ℤ`: `12·(M₂·n! − M₁²) = (n+1)·n!²`.  Combines the first and second moments. -/
+theorem eulerian_variance (n : ℕ) (hn : 2 ≤ n) :
+    12 * ((∑ k ∈ range (n + 1), (k : ℤ) ^ 2 * (eulerian n k : ℤ)) * (n ! : ℤ)
+            - (∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ)) ^ 2)
+      = ((n : ℤ) + 1) * (n ! : ℤ) ^ 2 := by
+  have hA := eulerian_second_moment n hn
+  have hB := eulerian_first_moment n (by omega)
+  linear_combination (n ! : ℤ) * hA
+    - 3 * (2 * (∑ k ∈ range (n + 1), (k : ℤ) * (eulerian n k : ℤ)) + ((n : ℤ) - 1) * (n ! : ℤ)) * hB
+
+/-! ## Corroboration on concrete rows -/
+
+-- Mean of descents: row 3 `1,4,1` has `∑ k·⟨3,k⟩ = 6 = (3−1)·3!/2`.
+example : 2 * ∑ k ∈ range 4, (k : ℤ) * (eulerian 3 k : ℤ) = ((3 : ℤ) - 1) * (3 ! : ℤ) := by decide
+-- Second moment: row 3 has `∑ k²·⟨3,k⟩ = 8`, and `12·8 = 3!·(3·9−15+4) = 6·16`.
+example : 12 * ∑ k ∈ range 4, (k : ℤ) ^ 2 * (eulerian 3 k : ℤ)
+    = (3 ! : ℤ) * (3 * (3 : ℤ) ^ 2 - 5 * 3 + 4) := by decide
+-- Variance of row 4 (`1,11,11,1`): `12·(M₂·4! − M₁²) = (4+1)·(4!)²`.
+example : 12 * ((∑ k ∈ range 5, (k : ℤ) ^ 2 * (eulerian 4 k : ℤ)) * (4 ! : ℤ)
+      - (∑ k ∈ range 5, (k : ℤ) * (eulerian 4 k : ℤ)) ^ 2)
+    = ((4 : ℤ) + 1) * (4 ! : ℤ) ^ 2 := by decide
+
+end GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "moment-transfer",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 110
+    },
+    "type": "technique",
+    "title": "The moment-transfer engine",
+    "content": "`moment_transfer` is the heart of the file: it turns the Eulerian triangle recurrence into a transfer operator on weighted row sums. For an arbitrary integer weight $w$, $\\sum_k w(k)\\langle n{+}1,k\\rangle = \\sum_i \\big(w(i)(i{+}1) + w(i{+}1)(n{-}i)\\big)\\langle n,i\\rangle$. The proof peels the $k=0$ term (`Finset.sum_range_succ'`, using $\\langle n{+}1,0\\rangle = 1$), expands $\\langle n{+}1,k{+}1\\rangle = (k{+}2)\\langle n,k{+}1\\rangle + (n{-}k)\\langle n,k\\rangle$ (`eulerian_succ_succ`) inside the shifted sum, and reindexes $\\sum_j w(j{+}1)(j{+}2)\\langle n,j{+}1\\rangle$ back over $\\langle n,i\\rangle$. Specialising $w$ to $1$, $k$, $k^2$ reads off the recurrences for the zeroth, first, and second moments uniformly — only the combinatorial recurrence enters, everything else is linearity.",
+    "mathContext": "$\\sum_k w(k)\\langle n{+}1,k\\rangle = \\sum_i \\big(w(i)(i{+}1)+w(i{+}1)(n{-}i)\\big)\\langle n,i\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Eulerian triangle recurrence",
+      "transfer operator on moments",
+      "reindexing a shifted sum",
+      "linearity of finite sums"
+    ],
+    "prerequisites": [
+      "Eulerian numbers",
+      "triangle recurrence"
+    ]
+  },
+  {
+    "id": "first-moment",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 150
+    },
+    "type": "technique",
+    "title": "The mean (n−1)/2 from palindromy alone",
+    "content": "`eulerian_first_moment` proves $2\\sum_k k\\,\\langle n,k\\rangle = (n-1)\\,n!$ — the expected number of descents is $\\tfrac{n-1}{2}$ — without any recurrence. After dropping the vanishing top term, `Finset.sum_range_reflect` rewrites the moment with the index reflected to $n{-}1{-}k$; palindromy $\\langle n,k\\rangle = \\langle n,n{-}1{-}k\\rangle$ (`eulerian_palindrome'` from the sibling oq-05) then pairs the reflected summand $(n{-}1{-}k)\\langle n,k\\rangle$ with $k\\langle n,k\\rangle$, so adding the moment to its reflection gives $\\sum_k (n{-}1)\\langle n,k\\rangle = (n-1)\\,n!$ by the row sum. A symmetry argument: the descent distribution is symmetric about its mean $(n-1)/2$.",
+    "mathContext": "$2\\sum_{k} k\\,\\langle n,k\\rangle = (n-1)\\,n!$, so $\\mathbb{E}[X] = \\tfrac{n-1}{2}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "palindromy of the Eulerian row",
+      "index reflection",
+      "symmetry of the descent distribution",
+      "expected value"
+    ],
+    "prerequisites": [
+      "Eulerian numbers",
+      "Eulerian palindromy"
+    ]
+  },
+  {
+    "id": "second-moment",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 153,
+      "endLine": 183
+    },
+    "type": "technique",
+    "title": "The second moment by the moment recurrence",
+    "content": "`eulerian_M2_succ` specialises `moment_transfer` to $w(k)=k^2$ and simplifies the transferred coefficient $i^2(i{+}1)+(i{+}1)^2(n{-}i) = (n{-}1)i^2+(2n{-}1)i+n$ (a `ring` identity), giving the recurrence $M_2(n{+}1) = (n{-}1)M_2(n) + (2n{-}1)M_1(n) + n\\,M_0(n)$ that couples the second moment to the lower ones. `eulerian_second_moment` then proves the closed form $12\\sum_k k^2\\langle n,k\\rangle = n!\\,(3n^2-5n+4)$ for $n \\ge 2$ by `Nat.le_induction` from the base row $n=2$, feeding $M_0 = n!$ (`eulerian_M0`) and $M_1$ (the mean) into the step and closing with `linear_combination` over the recurrence.",
+    "mathContext": "$12\\sum_{k} k^2\\langle n,k\\rangle = n!\\,(3n^2-5n+4)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "moment recurrence",
+      "induction from a base case",
+      "linear_combination",
+      "second moment"
+    ],
+    "prerequisites": [
+      "moment-transfer lemma",
+      "row sum",
+      "first moment"
+    ]
+  },
+  {
+    "id": "variance",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 186,
+      "endLine": 198
+    },
+    "type": "insight",
+    "title": "The variance is (n+1)/12",
+    "content": "`eulerian_variance` assembles the variance from the first two moments. Cleared of denominators over $\\mathbb{Z}$ the statement is $12\\,(M_2\\,n! - M_1^2) = (n+1)\\,n!^2$, i.e. $\\mathrm{Var}(X) = \\tfrac{M_2}{n!} - \\big(\\tfrac{M_1}{n!}\\big)^2 = \\tfrac{n+1}{12}$. The proof is a single `linear_combination` of `eulerian_second_moment` and `eulerian_first_moment`: no new content, just algebra. With the mean $(n-1)/2$ this completes the second-order description of the descent statistic.",
+    "mathContext": "$12\\,(M_2\\,n! - M_1^2) = (n+1)\\,n!^2$, so $\\mathrm{Var}(X) = \\tfrac{n+1}{12}$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "variance",
+      "linear_combination",
+      "second-order description"
+    ],
+    "prerequisites": [
+      "first moment",
+      "second moment"
+    ]
+  },
+  {
+    "id": "checks",
+    "proofId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 200,
+      "endLine": 209
+    },
+    "type": "example",
+    "title": "Concrete-row sanity checks",
+    "content": "Row 3 of the Eulerian triangle is $1,4,1$: $\\sum_k k\\langle 3,k\\rangle = 0+4+2 = 6 = (3-1)\\cdot 3!/2$ (mean $1$) and $\\sum_k k^2\\langle 3,k\\rangle = 0+4+4 = 8$, so $\\mathbb{E}[X^2] = 8/6$ and variance $8/6 - 1 = 1/3 = (3+1)/12$. Row 4 is $1,11,11,1$ and satisfies the variance identity $12(M_2\\cdot 4! - M_1^2) = 5\\cdot(4!)^2$. All three are discharged by kernel `decide` (not `native_decide`), so the file stays axiom-free.",
+    "mathContext": "Row 3 ($1,4,1$): mean $1$, variance $\\tfrac{1}{3} = \\tfrac{3+1}{12}$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "Eulerian triangle rows 1,4,1 and 1,11,11,1",
+      "kernel decide"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,211 @@
+{
+  "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "slug": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01",
+  "title": "The Mean, Second Moment, and Variance of the Descent Statistic from the Eulerian Numbers",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01",
+      "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05"
+    ],
+    "opens": [
+      "Nat",
+      "Finset",
+      "GeometricSeriesOQ07OQ01OQ01OQ01",
+      "GeometricSeriesOQ07OQ01OQ01OQ01OQ01",
+      "GeometricSeriesOQ07OQ01OQ01OQ01OQ05"
+    ],
+    "namespace": "GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01",
+    "lineCount": 212,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "geometric-series",
+      "eulerian-numbers",
+      "descent-statistic",
+      "moments",
+      "variance",
+      "expected-value",
+      "factorial",
+      "recurrence",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 212,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "moment_transfer: THE ENGINE — for an arbitrary integer weight w, the weighted row-(n+1) sum ∑ₖ w(k)·⟨n+1,k⟩ equals the weighted row-n sum ∑ᵢ (w(i)·(i+1) + w(i+1)·(n−i))·⟨n,i⟩. This single lemma converts the triangle recurrence ⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩ into a transfer operator on the moment generating functional: any polynomial moment of the descent distribution at row n+1 is expressed through moments at row n. Proved by peeling the k=0 term, expanding the recurrence inside the shifted sum, and reindexing ∑ⱼ w(j+1)·(j+2)·⟨n,j+1⟩ back over ⟨n,i⟩. Not a Mathlib export; the descent statistic and its moments are not in Mathlib.",
+      "eulerian_first_moment: 2·∑ₖ k·⟨n,k⟩ = (n−1)·n! for n ≥ 1, i.e. the expected number of descents of a uniformly random permutation of {1,…,n} is exactly (n−1)/2. Proved purely from palindromy (the sibling oq-05): reflecting k ↦ n−1−k via Finset.sum_range_reflect pairs k·⟨n,k⟩ with (n−1−k)·⟨n,k⟩, so twice the first moment is ∑ₖ (n−1)·⟨n,k⟩ = (n−1)·n!. A symmetry argument requiring no recurrence.",
+      "eulerian_M2_succ: the second-moment recurrence M₂(n+1) = (n−1)·M₂(n) + (2n−1)·M₁(n) + n·M₀(n), obtained by specialising moment_transfer to the weight w(k) = k² and simplifying the transferred coefficient i²·(i+1) + (i+1)²·(n−i) = (n−1)·i² + (2n−1)·i + n. This exhibits the second moment as a linear combination of the lower moments at the previous row.",
+      "eulerian_second_moment: 12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4) for n ≥ 2, the closed form of the second moment. Proved by induction on n from the base row n = 2, stepping with eulerian_M2_succ and feeding in the zeroth moment M₀ = n! (eulerian_M0) and the first moment M₁ (eulerian_first_moment); the inductive step closes by linear_combination over the recurrence.",
+      "eulerian_variance: 12·(M₂·n! − M₁²) = (n+1)·n!² for n ≥ 2 — the variance of the number of descents is (n+1)/12. A pure-algebra consequence (linear_combination) of the first and second moments, cleared of denominators over ℤ. Together with the mean (n−1)/2 this is the full second-order description of the descent distribution.",
+      "eulerian_M0: the zeroth moment ∑ₖ ⟨n,k⟩ = n! cast to ℤ, repackaging the parent's row-sum identity (eulerian_row_sum) as the M₀ input to the moment recurrence."
+    ],
+    "prerequisites": [
+      "Grandparent: geometric-series-oq-07-oq-01-oq-01-oq-01 (the combinatorial Eulerian numbers ⟨n,k⟩) — supplies the eulerian triangle, the triangle recurrence eulerian_succ_succ, the boundary values eulerian_succ_zero / eulerian_col_zero / eulerian_succ_self, and eulerian_eq_zero_of_lt",
+      "Parent: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01 (the Eulerian row sum ∑ₖ ⟨n,k⟩ = n!) — supplies eulerian_row_sum, the zeroth moment M₀",
+      "Sibling: geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05 (palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩) — supplies eulerian_palindrome', the reflection symmetry from which the mean is read off",
+      "Mathlib: Finset.sum_range_reflect (index reflection), Finset.sum_range_succ' / Finset.sum_range_succ (peeling boundary terms), Finset.sum_add_distrib and Finset.mul_sum (linearity), Nat.le_induction (induction from a base), and linear_combination for the closing algebra"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_range_reflect",
+        "description": "∑ i in range n, f (n−1−i) = ∑ i in range n, f i. The reflection identity that, combined with palindromy of the Eulerian row, pairs k·⟨n,k⟩ with (n−1−k)·⟨n,k⟩ and yields the mean (n−1)/2 by symmetry alone.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "∑ i in range (n+1), f i = (∑ i in range n, f (i+1)) + f 0. Peels the k=0 term off the row-(n+1) sum in moment_transfer so the triangle recurrence (which is stated at k+1) can be applied to the shifted sum.",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      },
+      {
+        "theorem": "Nat.le_induction",
+        "description": "Induction starting from a base value (here n = 2). Drives the proof of the second-moment closed form, with eulerian_M2_succ as the inductive step.",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "eulerian_succ_succ",
+        "description": "The Eulerian triangle recurrence ⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩ from the grandparent entry. The sole combinatorial input to moment_transfer; everything downstream is linearity and algebra.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "eulerian_row_sum",
+        "description": "The Eulerian row sum ∑ₖ ⟨n,k⟩ = n! from the parent entry, repackaged here as the zeroth moment M₀ that feeds the second-moment recurrence.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01"
+      },
+      {
+        "theorem": "eulerian_palindrome'",
+        "description": "The palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ from the sibling oq-05. Combined with Finset.sum_range_reflect it gives the first moment (the mean number of descents) purely by symmetry.",
+        "module": "Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ05"
+      }
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent (the Eulerian row sum ∑ₖ ⟨n,k⟩ = n!). This entry reuses the row sum as the zeroth moment M₀ and goes beyond it to the first two moments and the variance of the descent distribution — statements about the shape of the Eulerian row rather than its total."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-05",
+      "relationship": "uses",
+      "description": "Sibling (palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩). The reflection symmetry is exactly what gives the mean number of descents (n−1)/2 without any recurrence: twice the first moment collapses to (n−1)·n! by pairing k with n−1−k."
+    },
+    {
+      "targetId": "geometric-series-oq-07-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Grandparent (the combinatorial Eulerian numbers ⟨n,k⟩). Supplies the triangle recurrence eulerian_succ_succ that the moment-transfer engine turns into a recurrence on the moments of the descent statistic."
+    }
+  ],
+  "references": [
+    {
+      "title": "Concrete Mathematics (Eulerian numbers, descent statistic)",
+      "author": "Graham, Knuth, Patashnik",
+      "year": "1994",
+      "venue": "Addison-Wesley",
+      "description": "Standard reference for the Eulerian numbers, the descent statistic of a random permutation, and the fact that its mean is (n−1)/2 and variance (n+1)/12."
+    },
+    {
+      "title": "Combinatorics of Permutations",
+      "author": "Miklós Bóna",
+      "year": "2012",
+      "venue": "CRC Press",
+      "description": "Develops the distribution of descents (and the asymptotic normality of the Eulerian distribution), for which the mean and variance computed here are the first two moments."
+    }
+  ],
+  "sorries": 0,
+  "openQuestions": [
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+      "question": "Use the moment-transfer engine to compute the third (and higher) moments of the descent statistic, or the centred moments, and verify the central-limit behaviour: that the standardised descent count (X − (n−1)/2)/√((n+1)/12) is asymptotically standard normal.",
+      "significance": "medium"
+    },
+    {
+      "id": "geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02",
+      "question": "Prove the moment generating / probability generating function of the descent statistic equals the (normalised) Eulerian polynomial Eₙ(t)/n!, recovering all moments at once as derivatives at t = 1, and compare with the moment-transfer recurrence used here.",
+      "significance": "low"
+    }
+  ],
+  "description": "Computes the first two moments and the variance of the number of descents of a uniformly random permutation of {1,…,n}, distributed as the Eulerian row (⟨n,0⟩,…,⟨n,n−1⟩). The mean is (n−1)/2 (2·∑ₖ k·⟨n,k⟩ = (n−1)·n!), read straight off the palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ by reflection. The second moment 12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4) and hence the variance (n+1)/12 (12·(M₂·n! − M₁²) = (n+1)·n!²) come from a single moment-transfer lemma: the triangle recurrence ⟨n+1,k+1⟩ = (k+2)·⟨n,k+1⟩ + (n−k)·⟨n,k⟩ is turned into ∑ₖ w(k)·⟨n+1,k⟩ = ∑ᵢ (w(i)·(i+1)+w(i+1)·(n−i))·⟨n,i⟩ for any weight w, which at w = k² gives the moment recurrence M₂(n+1) = (n−1)·M₂(n) + (2n−1)·M₁(n) + n·M₀(n) closing the closed form by induction. 0 axioms, 0 sorries.",
+  "overview": {
+    "historicalContext": "The Eulerian numbers ⟨n,k⟩ count the permutations of {1,…,n} with exactly k descents, so row n of Euler's 1755 triangle is the distribution of the descent statistic of a uniformly random permutation. Its first two moments are classical: the mean number of descents is (n−1)/2 and the variance is (n+1)/12 — the seed facts behind the asymptotic normality of the Eulerian distribution (a permutation of {1,…,n} has, to first order, (n−1)/2 ± √(n/12) descents). The mean is forced by the palindromic symmetry ⟨n,k⟩ = ⟨n,n−1−k⟩ alone; the variance needs the triangle recurrence. Mathlib has neither the combinatorial Eulerian numbers nor the descent statistic, so both the triangle (grandparent) and these moment computations are gallery-specific; only the linearity and reflection lemmas for finite sums and the induction principle are Mathlib's.",
+    "problemStatement": "For the combinatorial Eulerian numbers ⟨n,k⟩ of the grandparent entry, compute the first two moments of the descent statistic: prove 2·∑ₖ k·⟨n,k⟩ = (n−1)·n! (mean (n−1)/2), 12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4) (second moment), and 12·(M₂·n! − M₁²) = (n+1)·n!² (variance (n+1)/12), all over ℤ to avoid denominators.",
+    "proofStrategy": "(1) MEAN (eulerian_first_moment): drop the vanishing top term, then apply Finset.sum_range_reflect to ∑ₖ k·⟨n,k⟩; palindromy (eulerian_palindrome') turns the reflected summand (n−1−k)·⟨n,k⟩ into the partner of k·⟨n,k⟩, so twice the moment is ∑ₖ (n−1)·⟨n,k⟩ = (n−1)·n! by the row sum. No recurrence is used. (2) MOMENT TRANSFER (moment_transfer): for any weight w, peel the k=0 term of ∑ₖ w(k)·⟨n+1,k⟩ (Finset.sum_range_succ'), expand ⟨n+1,k+1⟩ by the triangle recurrence eulerian_succ_succ, and reindex the shifted binomial sum back over ⟨n,i⟩, obtaining ∑ᵢ (w(i)·(i+1)+w(i+1)·(n−i))·⟨n,i⟩. (3) SECOND-MOMENT RECURRENCE (eulerian_M2_succ): specialise w = k² and simplify i²·(i+1)+(i+1)²·(n−i) = (n−1)·i²+(2n−1)·i+n to get M₂(n+1) = (n−1)·M₂(n)+(2n−1)·M₁(n)+n·M₀(n). (4) CLOSED FORM (eulerian_second_moment): induct from n = 2, feeding M₀ = n! (eulerian_M0) and M₁ (the mean) into the recurrence and closing with linear_combination. (5) VARIANCE (eulerian_variance): combine the first and second moments by linear_combination.",
+    "keyInsights": [
+      "The mean is a pure symmetry fact: palindromy ⟨n,k⟩ = ⟨n,n−1−k⟩ pairs the k-th and (n−1−k)-th terms, so reflecting the index in ∑ₖ k·⟨n,k⟩ doubles it into ∑ₖ (n−1)·⟨n,k⟩. No recurrence, no induction — Finset.sum_range_reflect does all the work.",
+      "The whole second-order theory is generated by one lemma. moment_transfer converts the triangle recurrence into a transfer operator on weighted row sums: a moment at row n+1 with weight w is a moment at row n with the modified weight w(i)·(i+1)+w(i+1)·(n−i). Specialising the weight to 1, k, k² reads off the recurrences for the zeroth, first, and second moments uniformly.",
+      "The transferred coefficient for w = k² factors as i²·(i+1)+(i+1)²·(n−i) = (n−1)·i²+(2n−1)·i+n, a polynomial identity (ring), which is exactly why the second moment satisfies the linear recurrence M₂(n+1) = (n−1)·M₂(n)+(2n−1)·M₁(n)+n·M₀(n) coupling it to the lower moments.",
+      "Working over ℤ throughout (rather than ℚ) clears the denominators in (n−1)/2 and (n+1)/12, so the statements are exact integer identities (2·M₁ = (n−1)·n!, 12·M₂ = n!·(3n²−5n+4), 12·(M₂·n!−M₁²) = (n+1)·n!²) and the closing steps are linear_combination over the recurrence and the moments — no field inversion."
+    ]
+  },
+  "sections": [
+    {
+      "id": "zeroth-moment",
+      "title": "The Zeroth Moment (Row Sum)",
+      "startLine": 53,
+      "endLine": 56,
+      "summary": "eulerian_M0 recasts the parent's row sum ∑ₖ ⟨n,k⟩ = n! to ℤ as the M₀ input to the moment recurrence.",
+      "mathContext": "$\\sum_{k} \\langle n,k\\rangle = n!$."
+    },
+    {
+      "id": "moment-transfer",
+      "title": "The Moment-Transfer Lemma",
+      "startLine": 60,
+      "endLine": 110,
+      "summary": "moment_transfer turns the triangle recurrence into a transfer operator on weighted row sums: ∑ₖ w(k)·⟨n+1,k⟩ = ∑ᵢ (w(i)·(i+1)+w(i+1)·(n−i))·⟨n,i⟩ for any weight w. Proved by peeling k=0, expanding ⟨n+1,k+1⟩, and reindexing the shifted sum.",
+      "mathContext": "$\\sum_{k} w(k)\\langle n{+}1,k\\rangle = \\sum_{i}\\big(w(i)(i{+}1)+w(i{+}1)(n{-}i)\\big)\\langle n,i\\rangle$."
+    },
+    {
+      "id": "first-moment",
+      "title": "The First Moment: Mean (n−1)/2",
+      "startLine": 112,
+      "endLine": 150,
+      "summary": "eulerian_first_moment proves 2·∑ₖ k·⟨n,k⟩ = (n−1)·n! by reflecting k ↦ n−1−k (Finset.sum_range_reflect) and using palindromy to pair k·⟨n,k⟩ with (n−1−k)·⟨n,k⟩, so twice the moment is (n−1)·(row sum).",
+      "mathContext": "$2\\sum_{k} k\\,\\langle n,k\\rangle = (n-1)\\,n!$, i.e. $\\mathbb{E}[X]=\\tfrac{n-1}{2}$."
+    },
+    {
+      "id": "second-moment",
+      "title": "The Second Moment via the Moment Recurrence",
+      "startLine": 153,
+      "endLine": 183,
+      "summary": "eulerian_M2_succ reads the recurrence M₂(n+1) = (n−1)·M₂(n)+(2n−1)·M₁(n)+n·M₀(n) off moment_transfer at w = k²; eulerian_second_moment closes the closed form 12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4) by induction from n = 2, feeding in M₀ and M₁.",
+      "mathContext": "$12\\sum_{k} k^2\\langle n,k\\rangle = n!\\,(3n^2-5n+4)$."
+    },
+    {
+      "id": "variance",
+      "title": "The Variance of the Descent Statistic is (n+1)/12",
+      "startLine": 186,
+      "endLine": 198,
+      "summary": "eulerian_variance combines the first and second moments by linear_combination, giving 12·(M₂·n! − M₁²) = (n+1)·n!² — the variance of the number of descents is (n+1)/12.",
+      "mathContext": "$\\mathrm{Var}(X)=\\dfrac{M_2}{n!}-\\Big(\\dfrac{M_1}{n!}\\Big)^2=\\dfrac{n+1}{12}$."
+    },
+    {
+      "id": "checks",
+      "title": "Corroboration on Concrete Rows",
+      "startLine": 200,
+      "endLine": 209,
+      "summary": "Row 3 (1,4,1): ∑ k·⟨3,k⟩ = 6 = (3−1)·3!/2 and ∑ k²·⟨3,k⟩ = 8; row 4 (1,11,11,1): the variance identity 12·(M₂·4! − M₁²) = 5·(4!)². All discharged by kernel decide (not native_decide, so still axiom-free).",
+      "mathContext": "Row 3 gives mean $1$ and variance $\\tfrac{1}{3}=\\tfrac{3+1}{12}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "Computes the first two moments and the variance of the descent statistic of a uniformly random permutation of {1,…,n}, whose distribution is the Eulerian row. The mean (n−1)/2 falls out of palindromy by reflection; the second moment n!·(3n²−5n+4)/12 and the variance (n+1)/12 come from a single moment-transfer lemma that converts the Eulerian triangle recurrence into a recurrence M₂(n+1) = (n−1)·M₂(n)+(2n−1)·M₁(n)+n·M₀(n) on the moments, closed by induction from n = 2. 210 lines, 6 theorems, 0 definitions, 0 axioms, 0 sorries (depends only on propext, Classical.choice, Quot.sound; the concrete-row checks use kernel decide, not native_decide).",
+    "implications": "Together with the row sum (M₀ = n!), these give the complete first- and second-order description of the descent distribution: mean (n−1)/2, variance (n+1)/12. The moment-transfer lemma is reusable — specialising its weight to any monomial yields the recurrence for the corresponding moment — so the same engine reaches the higher moments and, ultimately, the central-limit behaviour of the descent count. The argument is entirely elementary (palindromy, one recurrence, linearity, and a single induction) and uses Mathlib only for finite-sum bookkeeping.",
+    "openQuestions": [
+      "Compute the third and higher moments with the same moment-transfer engine and establish the asymptotic normality of the standardised descent count.",
+      "Identify the moment/probability generating function of the descent statistic with the normalised Eulerian polynomial Eₙ(t)/n! and recover all moments as derivatives at t = 1."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `geometric-series-oq-07-oq-01-oq-01-oq-01-oq-01-oq-01`: the first two moments and the variance of the number of **descents** of a uniformly random permutation of `{1,…,n}`, whose distribution is the Eulerian row `(⟨n,0⟩,…,⟨n,n−1⟩)`.

- **`eulerian_first_moment`** — `2·∑ₖ k·⟨n,k⟩ = (n−1)·n!`, i.e. the mean number of descents is `(n−1)/2`. Read straight off the palindromy `⟨n,k⟩ = ⟨n,n−1−k⟩` (sibling oq-05) via `Finset.sum_range_reflect` — a pure symmetry argument, no recurrence.
- **`moment_transfer`** — the engine: for any integer weight `w`, `∑ₖ w(k)·⟨n+1,k⟩ = ∑ᵢ (w(i)(i+1)+w(i+1)(n−i))·⟨n,i⟩`, obtained from the triangle recurrence `⟨n+1,k+1⟩ = (k+2)⟨n,k+1⟩ + (n−k)⟨n,k⟩` by peeling `k=0`, expanding, and reindexing.
- **`eulerian_second_moment`** — `12·∑ₖ k²·⟨n,k⟩ = n!·(3n²−5n+4)` for `n ≥ 2`, by induction from `n=2` over the moment recurrence `M₂(n+1) = (n−1)M₂(n) + (2n−1)M₁(n) + n·M₀(n)`.
- **`eulerian_variance`** — `12·(M₂·n! − M₁²) = (n+1)·n!²`, i.e. the variance of the descent count is `(n+1)/12`.

Builds on the grandparent (combinatorial Eulerian numbers `⟨n,k⟩` and the triangle recurrence), the parent (row sum `∑ₖ ⟨n,k⟩ = n!`, the zeroth moment), and the sibling oq-05 (palindromy). Mathlib has neither the descent statistic nor these moments.

## Verification

- 212 lines, 6 theorems, 0 definitions, **0 axioms, 0 sorries**.
- No `native_decide`; the three concrete-row checks (rows `1,4,1` and `1,11,11,1`) use kernel `decide` only, so the file remains axiom-free (`propext`/`Classical.choice`/`Quot.sound`).
- Verified with `./proofs/scripts/docker-build.sh Proofs.GeometricSeriesOQ07OQ01OQ01OQ01OQ01OQ01` — `Built … (121s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)