### PR TITLE
Enrich markov-equation-oq-03: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/markov-equation-oq-03/index.ts
+++ b/src/data/proofs/markov-equation-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MarkovHurwitz.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const markovEquationOq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const markovEquationOq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const markovEquationOq03Data: ProofData = {
+  proof: markovEquationOq03Proof,
+  annotations: markovEquationOq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `markov-equation-oq-03` (Generalizations of the Markov Equation).

## Problem found
The entry had **only meta.json** — both `index.ts` and `annotations.json` were missing, so the proof page rendered as 'proof not found' on the live site despite appearing in the gallery listing.

## Changes
- **Created `index.ts`** — the required Vite entry point (camelCase `markovEquationOq03`, source `Proofs/MarkovHurwitz.lean`). Fixes the unloadable page.
- **Created `annotations.json`** — 9 substantive annotations covering every section, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`: parametric definition, parameter-free Vieta jump, ℤ³ foliation, the n-variable equation, single-coordinate jump bookkeeping, dimension-free preservation, automatic positivity, the descent criterion, and the concrete-instance bridges.
- **Added `sections`** array to meta.json (4 sections) covering the full 263-line Lean file.

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite).
- Both JSON files validate; status/badge/axiomCount (verified / original / 0) confirmed consistent with the 0-sorry, 0-axiom Lean source.

The pre-existing overview, keyInsights, conclusion, and crossReferences were already strong and were preserved unchanged.