### PR TITLE
Fix amgm-inequality-oq-02-oq-01-oq-01 badge: original→mathlib

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-01/meta.json
@@ -124,7 +124,7 @@
     ]
   },
   "status": "verified",
-  "badge": "original",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib.RingTheory.MvPolynomial.Symmetric.NewtonIdentities",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: amgm-inequality-oq-02-oq-01-oq-01 ("The Full Newton–Girard Recurrence over Any Number of Variables")
**Problem**: Internal badge inconsistency — top-level `badge: "original"` contradicts the canonical `meta.badge: "mathlib"`.

## Evidence

The Lean file `AmgmInequalityOQ02OQ01OQ01.lean` has 4 theorems, all of which are direct Mathlib re-exports:

| Theorem | Proof body |
|---------|-----------|
| `newton_esymm_recurrence` | `mul_esymm_eq_sum σ R k` |
| `newton_psum_recurrence` | `psum_eq_mul_esymm_sub_sum σ R k hk` |
| `newton_sum_zero` | `sum_antidiagonal_card_esymm_psum_eq_zero σ R` |
| `psum_one_eq_esymm_one` | `by rw [psum_one, esymm_one]` |

This is a textbook **Tier-B mathlib bridge** (failure-mode #5: "0 sorries with hidden imports"). The core results are obtained entirely by calling deep Mathlib Newton-identities theorems; the file adds gallery-form statements only. The meta.json prose is already honest ("Mathlib proves the identities in full generality… This entry packages those", `originalContributions` describe "gallery-form statement of").

The canonical `meta.badge` field — the one the gallery renders (`listings.json` via `scripts/annotations/build.ts`, `ProofPage`/`ProofOverview` via `proof.meta.badge`) — already correctly reads `"mathlib"`. So there is **no public-facing overclaim**; this only corrects the stray top-level `badge` field so internal data is consistent. Most gallery proofs omit a top-level badge entirely; when present it should mirror `meta.badge`.

## Fix

Change top-level `"badge": "original"` → `"badge": "mathlib"`. `status` already correctly reads `"verified"` (0 sorries, 0 axioms confirmed). No Lean changes.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)