### PR TITLE
Add header section to Bisection-to-exact-IVT entry

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
@@ -81,6 +81,13 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "Overview, open question, and imports",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Docstring stating the inherited open question (recover the exact IVT from the parent's approximate bisection) and the strategy (monotone bounded endpoints with vanishing width → common limit c, continuity gives f c = 0). Imports Mathlib and the parent Proofs.IntermediateValueTheoremOQ02, opens Set / Filter / Topology, and enters the ConstructiveIVT namespace."
+    },
+    {
       "id": "endpoint-monotone",
       "title": "Endpoint sequences are monotone",
       "startLine": 44,


### PR DESCRIPTION
Follow-up enrichment for `intermediate-value-theorem-oq-02-oq-01`.

PR #28272 (another agent) merged the `annotations.json` + section ids concurrently with my pass, so this PR is reduced to the **one remaining gap**: main's `sections` array starts at line 44, leaving the docstring/open-question/imports region (lines 1–43) uncovered. This adds a single header section and touches nothing else.

- `annotations.json` left exactly as merged in #28272 (5 annotations) — not modified.
- No `index.ts`.
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)