### PR TITLE
Enrich mason-stothers-theorem-oq-01-oq-02: add index.ts, annotations, sections

### DIFF
--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "mason-oq0102-ann-header",
+    "proofId": "mason-stothers-theorem-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 52 },
+    "type": "context",
+    "title": "Davenport's Inequality as Function-Field Hall",
+    "content": "Davenport's inequality (1965) bounds how small the degree of f³ − g² can be relative to f: for coprime non-constant f, g over a characteristic-zero field with f³ ≠ g², deg(f³ − g²) ≥ ½·deg f + 1. It is the polynomial shadow of Hall's conjecture on the integer gap |x³ − y²|. Unlike the integer case, the polynomial bound is sharp and unconditional — it falls out of the Mason–Stothers theorem (the function-field abc). This file derives it as a 0-axiom corollary of the parent's mason_stothers_charZero, applied to the additive triple f³ + (−g²) = f³ − g².",
+    "mathContext": "$\\deg(f^3 - g^2) \\ge \\tfrac{1}{2}\\deg f + 1$, equivalently $\\deg f + 2 \\le 2\\deg(f^3-g^2)$",
+    "significance": "key",
+    "relatedConcepts": ["Mason–Stothers theorem", "abc conjecture", "Hall's conjecture", "function-field analogy"],
+    "prerequisites": ["polynomial degree", "radical of a polynomial"]
+  },
+  {
+    "id": "mason-oq0102-ann-radical-dvd",
+    "proofId": "mason-stothers-theorem-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 74 },
+    "type": "theorem",
+    "title": "Hypothesis-Free Radical Bound rad(f³g²c) ∣ fgc",
+    "content": "radical_cube_sq_mul_dvd is the combinatorial input to Davenport, and notably needs NO coprimality hypothesis. The radical (product of distinct prime factors) is insensitive to exponents — rad(pⁿ) = rad p — so a cube and a square contribute only deg f and deg g, not 3·deg f and 2·deg g, to the distinct-root count. The proof chains radical_mul_dvd (rad(ab) ∣ rad a · rad b, unconditional), radical_pow (collapse the powers), and radical_dvd_self (rad p ∣ p), giving rad(f³·g²·c) ∣ f·g·c and hence deg rad ≤ deg f + deg g + deg c.",
+    "mathContext": "$\\mathrm{rad}(f^3 g^2 c) \\mid f g c$ since $\\mathrm{rad}(p^n) = \\mathrm{rad}(p)$ and $\\mathrm{rad}(ab)\\mid\\mathrm{rad}(a)\\mathrm{rad}(b)$",
+    "significance": "key",
+    "relatedConcepts": ["radical (squarefree part)", "radical_mul_dvd", "radical_pow", "distinct roots"],
+    "prerequisites": ["unique factorization", "divisibility of polynomials"]
+  },
+  {
+    "id": "mason-oq0102-ann-triple",
+    "proofId": "mason-stothers-theorem-oq-01-oq-02",
+    "range": { "startLine": 85, "endLine": 102 },
+    "type": "insight",
+    "title": "Choosing the Mason–Stothers Triple (f³, −g², f³−g²)",
+    "content": "The heart of the derivation is the choice of additive triple a = f³, b = −g², c = f³ − g² with a + b = c. Coprimality of f, g lifts to IsCoprime f³ (−g²) (via IsCoprime.pow and neg_right), and f³ non-constant supplies the non-triviality disjunct that excludes Mason–Stothers' escape clause. Applying mason_stothers_charZero to this triple turns the abstract bound max{deg a, deg b} + 1 ≤ deg rad into two concrete lower bounds: 3·deg f + 1 ≤ deg rad and 2·deg g + 1 ≤ deg rad.",
+    "mathContext": "$a + b = c:\\quad f^3 + (-g^2) = f^3 - g^2,\\quad \\gcd(f,g)=1 \\Rightarrow \\gcd(f^3,-g^2)=1$",
+    "significance": "key",
+    "relatedConcepts": ["additive triple", "IsCoprime.pow", "non-triviality clause", "degree bound"],
+    "prerequisites": ["coprimality of polynomials", "Mason–Stothers statement"]
+  },
+  {
+    "id": "mason-oq0102-ann-radneg",
+    "proofId": "mason-stothers-theorem-oq-01-oq-02",
+    "range": { "startLine": 103, "endLine": 114 },
+    "type": "technique",
+    "title": "Aligning the Radical and Bounding Its Degree",
+    "content": "Mason–Stothers produces bounds on rad(f³·(−g²)·c), but the upper bound lemma is stated for rad(f³·g²·c). Since the two products differ only by the unit −1, radical_neg identifies their radicals (rad(−x) = rad x), letting the bounds be rewritten. Then natDegree_le_of_dvd converts the divisibility rad(f³·g²·c) ∣ f·g·c into deg rad ≤ deg f + deg g + deg c (expanding the product degree with natDegree_mul).",
+    "mathContext": "$\\mathrm{rad}(-x) = \\mathrm{rad}(x);\\quad p \\mid q,\\ q\\neq 0 \\Rightarrow \\deg p \\le \\deg q$",
+    "significance": "technical",
+    "relatedConcepts": ["radical_neg", "natDegree_le_of_dvd", "units", "natDegree_mul"],
+    "prerequisites": ["units in a ring", "degree of a product"]
+  },
+  {
+    "id": "mason-oq0102-ann-omega",
+    "proofId": "mason-stothers-theorem-oq-01-oq-02",
+    "range": { "startLine": 115, "endLine": 121 },
+    "type": "insight",
+    "title": "Sandwiching Two Lower Bounds Against One Upper Bound",
+    "content": "The finish is pure linear arithmetic (omega). With R = deg rad and C = deg(f³−g²), the two lower bounds 3·deg f + 1 ≤ R and 2·deg g + 1 ≤ R, plus the upper bound R ≤ deg f + deg g + C and the power degrees deg(f³) = 3·deg f, deg(g²) = 2·deg g, combine so the deg g terms cancel, leaving deg f + 2 ≤ 2C. This is Davenport's inequality, extracted with no further mathematical input.",
+    "mathContext": "$3F+1\\le R,\\ 2G+1\\le R,\\ R\\le F+G+C \\;\\Rightarrow\\; F+2\\le 2C$",
+    "significance": "key",
+    "relatedConcepts": ["linear arithmetic", "omega tactic", "natDegree_pow", "bound combination"],
+    "prerequisites": ["integer inequalities"]
+  },
+  {
+    "id": "mason-oq0102-ann-heightform",
+    "proofId": "mason-stothers-theorem-oq-01-oq-02",
+    "range": { "startLine": 123, "endLine": 132 },
+    "type": "concept",
+    "title": "Height Form: deg(f³ − g²) ≥ ½·deg f + 1",
+    "content": "natDegree_cube_sub_sq_ge restates davenport as a direct lower bound f.natDegree / 2 + 1 ≤ (f³ − g²).natDegree, the 'height form' most often quoted. Over ℕ the halving is integer division, faithful to the sharp ½·deg f + 1 since deg f + 2 ≤ 2·deg(f³−g²) rearranges to it. This convenience restatement follows from davenport by a single omega.",
+    "mathContext": "$\\lfloor \\deg f / 2\\rfloor + 1 \\le \\deg(f^3 - g^2)$",
+    "significance": "supporting",
+    "relatedConcepts": ["height of a polynomial", "integer division", "sharp bound"],
+    "prerequisites": ["natDegree", "omega tactic"]
+  }
+]

--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/index.ts
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MasonStothersOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const masonStothersTheoremOq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const masonStothersTheoremOq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const masonStothersTheoremOq01Oq02Data: ProofData = {
+  proof: masonStothersTheoremOq01Oq02Proof,
+  annotations: masonStothersTheoremOq01Oq02Annotations,
+}

--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/meta.json
@@ -88,6 +88,40 @@
       }
     ]
   },
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header: Davenport from Mason–Stothers",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Docstring stating Davenport's inequality deg f + 2 ≤ 2·deg(f³ − g²) and its proof sketch: apply mason_stothers_charZero to the coprime additive triple f³ + (−g²) = f³ − g², combine the two lower bounds on deg rad with the hypothesis-free radical-degree upper bound via omega. Imports Mathlib and the parent MasonStothersOQ01.",
+      "mathContext": "$\\deg f + 2 \\le 2\\deg(f^3 - g^2)$, the polynomial shadow of Hall's conjecture."
+    },
+    {
+      "id": "sec-radical-bound",
+      "title": "§1 Hypothesis-Free Radical Bound",
+      "startLine": 54,
+      "endLine": 74,
+      "summary": "radical_cube_sq_mul_dvd: rad(f³·g²·c) ∣ f·g·c with no coprimality hypothesis, via radical_mul_dvd, radical_pow (rad(pⁿ) = rad p) and radical_dvd_self. Bounds the distinct-root count of f³·g²·c by deg f + deg g + deg c.",
+      "mathContext": "$\\mathrm{rad}(f^3 g^2 c) \\mid fgc$ because the radical ignores exponents."
+    },
+    {
+      "id": "sec-davenport",
+      "title": "§2 Davenport's Inequality",
+      "startLine": 76,
+      "endLine": 121,
+      "summary": "davenport: applies mason_stothers_charZero to a = f³, b = −g², c = f³ − g²; uses IsCoprime.pow / neg_right for coprimality and f³ non-constant for non-triviality, radical_neg to align rad(f³·(−g²)·c) with rad(f³·g²·c), and the §1 bound, then omega to extract deg f + 2 ≤ 2·deg(f³ − g²).",
+      "mathContext": "$3\\deg f + 1 \\le R,\\ 2\\deg g + 1 \\le R,\\ R \\le \\deg f + \\deg g + \\deg c \\Rightarrow \\deg f + 2 \\le 2\\deg c$."
+    },
+    {
+      "id": "sec-height-form",
+      "title": "§3 Height Form",
+      "startLine": 123,
+      "endLine": 132,
+      "summary": "natDegree_cube_sub_sq_ge: the equivalent height-form lower bound f.natDegree / 2 + 1 ≤ (f³ − g²).natDegree, obtained from davenport by a single omega — the form most often quoted in the literature.",
+      "mathContext": "$\\lfloor \\deg f / 2 \\rfloor + 1 \\le \\deg(f^3 - g^2)$."
+    }
+  ],
   "references": [
     {
       "authors": "Davenport, H.",
@@ -116,8 +150,9 @@
   ],
   "crossReferences": [
     {
-      "slug": "mason-stothers-theorem-oq-01",
-      "relation": "Parent entry. Supplies mason_stothers_charZero, the characteristic-zero Mason–Stothers degree bound that this Davenport derivation rests on; this entry answers its second open question."
+      "targetId": "mason-stothers-theorem-oq-01",
+      "relationship": "parent",
+      "description": "Parent entry. Supplies mason_stothers_charZero, the characteristic-zero Mason–Stothers degree bound that this Davenport derivation rests on; this entry answers its second open question."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `mason-stothers-theorem-oq-01-oq-02` (Davenport's inequality from Mason–Stothers).

## Problem found
The entry had **only meta.json** — `index.ts` and `annotations.json` were missing (page rendered as 'proof not found'), and meta.json had no `sections` array.

## Changes
- **Created `index.ts`** — the required Vite entry point (camelCase `masonStothersTheoremOq01Oq02`, source `Proofs/MasonStothersOQ01OQ02.lean`). Fixes the unloadable page.
- **Created `annotations.json`** — 6 substantive annotations, one per logical unit, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the Davenport/Hall framing, the hypothesis-free radical bound rad(f³g²c) ∣ fgc, the Mason–Stothers triple (f³, −g², f³−g²), radical alignment via radical_neg, the omega sandwich, and the height form.
- **Added `sections`** array (4 sections) covering the full 132-line Lean file.
- **Normalized `crossReferences`** to the canonical `{targetId, relationship, description}` schema (the existing entry used non-standard `{slug, relation}` keys that don't match the CrossReference type and would render empty).

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite).
- Both JSON files validate; status/badge/axiomCount (verified / original / 0) confirmed consistent with the 0-sorry, 0-axiom Lean source (only foundational propext / Classical.choice / Quot.sound; no native_decide).

Pre-existing overview, keyInsights, exampleSections, references, and conclusion were already strong and preserved unchanged.