### PR TITLE
Enrich erdos-100-oq-01-incomplete-01: add index.ts, annotations

### DIFF
--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "erdos100-oq01inc01-ann-header",
+    "proofId": "erdos-100-oq-01-incomplete-01",
+    "range": { "startLine": 3, "endLine": 38 },
+    "type": "context",
+    "title": "Erdős #100 and the Integer-Distance Bridge",
+    "content": "Erdős Problem #100 (open) asks whether an n-point planar set with all pairwise distances positive integers must have diameter ≫ n. The current best lower bound, diam ≥ c·n/log n, combines the Guth–Katz distinct-distances theorem with an elementary observation linking #100 to Erdős #89: integer distances confine the distinct distances to {1,…,⌊diam⌋}. This file proves exactly that bridge — #distinct distances ≤ diameter — cleanly and unconditionally, leaving the parent scaffold's hard Piepmeyer explicit-witness sorry untouched.",
+    "mathContext": "Integer distances $\\Rightarrow$ distinct distances $\\subseteq \\{1,\\dots,\\lfloor\\mathrm{diam}\\rfloor\\}\\Rightarrow \\#\\text{distinct} \\le \\mathrm{diam}$",
+    "significance": "key",
+    "relatedConcepts": ["Erdős distinct distances", "Guth–Katz theorem", "integer-distance sets", "diameter lower bound"],
+    "prerequisites": ["discrete geometry", "Finset cardinality"]
+  },
+  {
+    "id": "erdos100-oq01inc01-ann-floor-core",
+    "proofId": "erdos-100-oq-01-incomplete-01",
+    "range": { "startLine": 46, "endLine": 72 },
+    "type": "theorem",
+    "title": "Counting Positive Integers in a Bounded Range",
+    "content": "card_le_floor_of_pos_int_le is the combinatorial core: a finite set S of reals, each a positive integer and each ≤ D, has |S| ≤ ⌊D⌋₊. The proof maps each x ∈ S to its natural-number floor ⌊x⌋₊. This map lands in Finset.Icc 1 ⌊D⌋₊ (positivity gives ≥ 1, x ≤ D gives ⌊x⌋₊ ≤ ⌊D⌋₊ by Nat.floor_le_floor) and is injective on S (distinct integer reals have distinct floors). Then Finset.card_le_card_of_injOn and Nat.card_Icc (|Icc 1 m| = m) finish it.",
+    "mathContext": "$x \\mapsto \\lfloor x\\rfloor_+$ injects $S \\hookrightarrow \\{1,\\dots,\\lfloor D\\rfloor_+\\}$, so $|S| \\le \\lfloor D\\rfloor_+$",
+    "significance": "key",
+    "relatedConcepts": ["injection counting", "Finset.card_le_card_of_injOn", "Nat.floor", "Nat.card_Icc"],
+    "prerequisites": ["Finset.Icc", "injective maps on finite sets", "Nat.floor_le_floor"]
+  },
+  {
+    "id": "erdos100-oq01inc01-ann-real-bound",
+    "proofId": "erdos-100-oq-01-incomplete-01",
+    "range": { "startLine": 74, "endLine": 83 },
+    "type": "theorem",
+    "title": "Bound Stated Directly Against D",
+    "content": "card_le_of_pos_int_le restates the bound against the real D rather than ⌊D⌋₊: for D ≥ 0, |S| ≤ D. It follows from the floor version by chaining (S.card : ℝ) ≤ (⌊D⌋₊ : ℝ) ≤ D, the last step being Nat.floor_le (⌊D⌋₊ ≤ D when D ≥ 0). This is the form consumed by the bridge theorem, where D is a diameter.",
+    "mathContext": "$|S| \\le \\lfloor D\\rfloor_+ \\le D$ for $D \\ge 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.floor_le", "cast monotonicity", "real bounds"],
+    "prerequisites": ["Nat.floor_le", "ℕ → ℝ casts"]
+  },
+  {
+    "id": "erdos100-oq01inc01-ann-bridge",
+    "proofId": "erdos-100-oq-01-incomplete-01",
+    "range": { "startLine": 85, "endLine": 98 },
+    "type": "insight",
+    "title": "The Integer-Distance Bridge (Erdős #100 ↔ #89)",
+    "content": "distinct_distances_le_diam is the named result: if the distinct pairwise distances of an integer-distance configuration form a finite set bounded by the diameter D ≥ 0, then their count is ≤ D. It is an immediate specialization of card_le_of_pos_int_le to the distance set. This single inequality is precisely what upgrades the Guth–Katz distinct-distances lower bound (#distinct ≥ c·n/log n) into a diameter lower bound diam ≥ c·n/log n — making the dependence explicit and machine-checked, independent of any explicit construction.",
+    "mathContext": "$\\#\\{\\text{distinct integer distances}\\} \\le \\mathrm{diam};\\ \\text{with } \\#\\text{distinct} \\ge \\tfrac{cn}{\\log n}\\Rightarrow \\mathrm{diam}\\ge \\tfrac{cn}{\\log n}$",
+    "significance": "key",
+    "relatedConcepts": ["Erdős #89", "Guth–Katz bound", "distinct distances", "diameter"],
+    "prerequisites": ["the counting lemma above"]
+  },
+  {
+    "id": "erdos100-oq01inc01-ann-significance",
+    "proofId": "erdos-100-oq-01-incomplete-01",
+    "range": { "startLine": 100, "endLine": 118 },
+    "type": "context",
+    "title": "Scope and Significance",
+    "content": "The closing commentary frames what is and is not proved. The bridge isolates the exact combinatorial step that transfers a distinct-distances lower bound to a diameter lower bound; the counting lemma (|S| ≤ ⌊D⌋₊ for a bounded set of positive integers) is a reusable discrete-geometry primitive. The hard, open parts — discharging the parent's Piepmeyer 9-point witness, formalizing Guth–Katz, and the diameter conjecture diam ≫ n itself — remain untouched and are flagged honestly.",
+    "mathContext": "Honest scope: the bridge is unconditional; the open conjecture $\\mathrm{diam} \\gg n$ is not claimed.",
+    "significance": "context",
+    "relatedConcepts": ["honest scope", "reusable primitive", "open conjecture"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/erdos-100-oq-01-incomplete-01/index.ts
+++ b/src/data/proofs/erdos-100-oq-01-incomplete-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos100OQ01Incomplete01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos100Oq01Incomplete01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos100Oq01Incomplete01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos100Oq01Incomplete01Data: ProofData = {
+  proof: erdos100Oq01Incomplete01Proof,
+  annotations: erdos100Oq01Incomplete01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-100-oq-01-incomplete-01` (the Erdős #100 integer-distance bridge).

## Problem found
The entry had **only meta.json** — `index.ts` and `annotations.json` were missing, so the proof page rendered as 'proof not found' on the live site.

## Changes
- **Created `index.ts`** — the required Vite entry point (camelCase `erdos100Oq01Incomplete01`, source `Proofs/Erdos100OQ01Incomplete01.lean`). Fixes the unloadable page.
- **Created `annotations.json`** — 5 substantive annotations covering every part of the 118-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the #100↔#89 / Guth–Katz framing, the floor-injection counting core (card_le_floor_of_pos_int_le), the real-valued restatement, the named bridge distinct_distances_le_diam, and the honest-scope significance note.

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite).
- Both JSON files validate; status/badge/axiomCount (verified / verified / 0) confirmed consistent with the 0-sorry, 0-axiom Lean source (no native_decide; only foundational axioms).

Pre-existing overview, keyInsights, sections, conclusion, and crossReferences were already strong and preserved unchanged.