### PR TITLE
Enrich intermediate-value-theorem-oq-02-oq-01: add index.ts, annotations

### DIFF
--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ivt-oq0201-ann-header",
+    "proofId": "intermediate-value-theorem-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "From Approximate Bisection to the Exact IVT",
+    "content": "The parent entry built the bisection algorithm and proved its approximate content (for every ε > 0, a point with |f(x)| < ε), explicitly leaving 'recover the exact zero via completeness of ℝ' as an open question. This file closes that loop: the endpoint sequences Lₙ, Rₙ are monotone, bounded in [a,b], with width Rₙ − Lₙ = (b−a)/2ⁿ → 0, so by monotone bounded convergence both converge to a common limit c, and continuity carries the sign invariant f(Lₙ) ≤ 0 ≤ f(Rₙ) to the limit, forcing f(c) = 0. This is the constructive-to-classical bridge for the IVT.",
+    "mathContext": "Bolzano (1817): the IVT rests on completeness of ℝ; bisection realizes it as the shared limit of two monotone endpoint sequences.",
+    "significance": "key",
+    "relatedConcepts": ["Intermediate Value Theorem", "Bolzano", "completeness of ℝ", "bisection method"],
+    "prerequisites": ["continuity", "limits of sequences"]
+  },
+  {
+    "id": "ivt-oq0201-ann-monotone",
+    "proofId": "intermediate-value-theorem-oq-02-oq-01",
+    "range": { "startLine": 38, "endLine": 54 },
+    "type": "theorem",
+    "title": "Endpoint Sequences are Monotone",
+    "content": "bisect_left_seq_mono and bisect_right_seq_anti promote the parent's per-step monotonicity (one bisectStep preserves order and moves an endpoint inward) to monotonicity of the whole sequences: the left endpoints Lₙ are non-decreasing and the right endpoints Rₙ are non-increasing. The proofs use monotone_nat_of_le_succ / antitone_nat_of_succ_le, unfolding one bisectStep and discharging both branches of the sign split with linarith against the parent's bisect_ordered invariant Lₙ ≤ Rₙ.",
+    "mathContext": "$L_n \\nearrow,\\ R_n \\searrow$, both confined to $[a,b]$ by $L_n \\le R_n$ (bisect_ordered)",
+    "significance": "supporting",
+    "relatedConcepts": ["monotone sequence", "antitone sequence", "monotone_nat_of_le_succ", "bisection invariants"],
+    "prerequisites": ["nested intervals", "order invariants"]
+  },
+  {
+    "id": "ivt-oq0201-ann-converge",
+    "proofId": "intermediate-value-theorem-oq-02-oq-01",
+    "range": { "startLine": 56, "endLine": 103 },
+    "type": "insight",
+    "title": "Convergence to a Common Limit via Completeness",
+    "content": "bisect_tendsto_root is the heart of the file. Both endpoint sequences lie in [a,b]; the left one, being monotone and bounded above by b, converges to its supremum c by tendsto_atTop_ciSup — this is the single use of completeness of ℝ. The interval width (b−a)/2ⁿ → 0 (from (1/2)ⁿ → 0), so the right endpoints Rₙ = Lₙ + width and the midpoints (Lₙ + Rₙ)/2 also converge to c, and c ∈ [a,b] by order-limit lemmas (le_of_tendsto / ge_of_tendsto). The vanishing width is precisely what collapses the three limits to one point.",
+    "mathContext": "$L_n \\to c = \\sup_n L_n$ (tendsto_atTop_ciSup); width $\\to 0 \\Rightarrow R_n \\to c$ and $\\mathrm{mid}_n \\to c$",
+    "significance": "key",
+    "relatedConcepts": ["monotone bounded convergence", "tendsto_atTop_ciSup", "nested interval theorem", "supremum"],
+    "prerequisites": ["completeness of ℝ", "limits of sums and quotients", "tendsto_pow_atTop_nhds_zero_of_lt_one"]
+  },
+  {
+    "id": "ivt-oq0201-ann-sign-limit",
+    "proofId": "intermediate-value-theorem-oq-02-oq-01",
+    "range": { "startLine": 104, "endLine": 117 },
+    "type": "technique",
+    "title": "Transporting the Sign Invariant Across the Limit",
+    "content": "Continuity is used exactly once. Since Lₙ → c and Rₙ → c within [a,b], ContinuousWithinAt gives f(Lₙ) → f(c) and f(Rₙ) → f(c) (composing the within-set tendsto with ContinuousOn). The parent's sign invariant f(Lₙ) ≤ 0 ≤ f(Rₙ) then passes to the limit by le_of_tendsto / ge_of_tendsto, yielding f(c) ≤ 0 and 0 ≤ f(c); le_antisymm forces f(c) = 0. Notably the parent's strict approximate bound |f| < ε is not needed for the exact statement.",
+    "mathContext": "$f(L_n)\\le 0 \\le f(R_n)$, $f(L_n)\\to f(c)$, $f(R_n)\\to f(c) \\Rightarrow f(c) \\le 0 \\le f(c) \\Rightarrow f(c)=0$",
+    "significance": "key",
+    "relatedConcepts": ["ContinuousWithinAt", "le_of_tendsto", "order limits", "le_antisymm"],
+    "prerequisites": ["continuity within a set", "order-closedness of limits"]
+  },
+  {
+    "id": "ivt-oq0201-ann-classical",
+    "proofId": "intermediate-value-theorem-oq-02-oq-01",
+    "range": { "startLine": 119, "endLine": 137 },
+    "type": "concept",
+    "title": "Recovering the Full Classical IVT",
+    "content": "exact_ivt_zero extracts the existence statement ∃ c ∈ [a,b], f c = 0 from the convergence result. exact_ivt then recovers the full classical IVT for an arbitrary intermediate value y between f(a) and f(b) by the standard shift: apply the zero version to g = f − y (continuous, with g(a) ≤ 0 ≤ g(b)), giving c with g(c) = 0, i.e. f(c) = y. This is a clean template for extracting classical existence theorems from convergent algorithms.",
+    "mathContext": "$g = f - y$, $g(a)\\le 0\\le g(b) \\Rightarrow \\exists c,\\ g(c)=0 \\Leftrightarrow f(c)=y$",
+    "significance": "supporting",
+    "relatedConcepts": ["classical IVT", "reduction by translation", "constructive existence"],
+    "prerequisites": ["ContinuousOn.sub", "the zero-version IVT"]
+  }
+]

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/IntermediateValueTheoremOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const intermediateValueTheoremOq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const intermediateValueTheoremOq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const intermediateValueTheoremOq02Oq01Data: ProofData = {
+  proof: intermediateValueTheoremOq02Oq01Proof,
+  annotations: intermediateValueTheoremOq02Oq01Annotations,
+}

--- a/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-02-oq-01/meta.json
@@ -81,18 +81,21 @@
   ],
   "sections": [
     {
+      "id": "endpoint-monotone",
       "title": "Endpoint sequences are monotone",
       "startLine": 44,
       "endLine": 64,
       "summary": "bisect_left_seq_mono and bisect_right_seq_anti promote the parent's per-step monotonicity to the full sequences of left/right endpoints."
     },
     {
+      "id": "convergence-exact-zero",
       "title": "Convergence to an exact zero",
       "startLine": 66,
       "endLine": 128,
       "summary": "bisect_tendsto_root: monotone bounded convergence gives the left limit c; the width (b−a)/2ⁿ → 0 forces the right endpoints and midpoints to c ∈ [a,b]; continuity transports the sign invariant to give f c = 0."
     },
     {
+      "id": "recovering-classical-ivt",
       "title": "Recovering the classical IVT",
       "startLine": 130,
       "endLine": 137,


### PR DESCRIPTION
Enrichment pass for `intermediate-value-theorem-oq-02-oq-01` (Bisection converges to an exact zero — recovering the classical IVT).

## Problem found
The entry had **only meta.json** — `index.ts` and `annotations.json` were missing (page rendered 'proof not found'), and the `sections` entries lacked `id` fields.

## Changes
- **Created `index.ts`** — the required Vite entry point (camelCase `intermediateValueTheoremOq02Oq01`, source `Proofs/IntermediateValueTheoremOQ02OQ01.lean`). Fixes the unloadable page.
- **Created `annotations.json`** — 5 substantive annotations covering the 137-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the approximate→exact bridge, the monotone/antitone endpoint sequences, convergence to a common limit via completeness (tendsto_atTop_ciSup), transporting the sign invariant across the limit by continuity, and recovering the full classical IVT via g = f − y.
- **Added `id` fields** to the three `sections` (were missing).

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite).
- Both JSON files validate; status/badge/axiomCount (verified / verified / 0) consistent with the 0-sorry, 0-axiom Lean source (#print axioms reports only propext / Classical.choice / Quot.sound; no native_decide).

Pre-existing overview, keyInsights, conclusion, and crossReferences were already strong and preserved unchanged.