### PR TITLE
Enrich summation-by-parts-oq-01-oq-01-oq-01-oq-02: add annotations

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "sbp-oq010101oq02-ann-header",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 4, "endLine": 68 },
+    "type": "context",
+    "title": "Discrete Integration by Parts over a Commutative Ring",
+    "content": "Abel's summation by parts is the discrete companion of integration by parts ∫ f dG = fG − ∫ G df. Identity (A) — ∑ f·ΔG = [f·G] boundary − ∑ Δf·G(·+1) — holds for ANY two sequences f, G : ℕ → R over ANY commutative ring R with no side hypotheses, because both sides are polynomials in the sequence values. Here G is an arbitrary antidifference of the weight g := ΔG; this two-sequence formulation answers the parent's open question and is cleaner than Mathlib's Finset.sum_range_by_parts (which forces G to be the partial sum of g with n−1 indexing).",
+    "mathContext": "$\\sum_{k<n} f(k)\\,\\Delta G(k) = f(n)G(n) - f(0)G(0) - \\sum_{k<n} \\Delta f(k)\\,G(k{+}1),\\quad \\Delta h(k)=h(k{+}1)-h(k)$",
+    "significance": "key",
+    "relatedConcepts": ["Abel summation", "integration by parts", "finite differences", "antidifference"],
+    "prerequisites": ["finite sums", "commutative rings"]
+  },
+  {
+    "id": "sbp-oq010101oq02-ann-main",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 74, "endLine": 87 },
+    "type": "theorem",
+    "title": "The General Discrete Abel Transform (A)",
+    "content": "abel_summation is the headline identity, proved by a short induction on n with no summation-by-parts black box. The base case n = 0 is simp (empty sums). The step peels the top term off both finite sums via Finset.sum_range_succ, substitutes the induction hypothesis, and the remaining identity in the atoms f(m), f(m+1), f(0), G(m), G(m+1), G(0) is polynomial and closed by ring — the leftover sum appears as a common opaque atom on both sides and cancels. Because the proof routes through no division or hypothesis, the identity lives over an arbitrary commutative ring.",
+    "mathContext": "Induction step: $\\mathrm{sum\\_range\\_succ}$ peels the $m$-th term, IH substitutes, $\\mathtt{ring}$ closes a polynomial identity in six sequence-value atoms.",
+    "significance": "key",
+    "relatedConcepts": ["induction", "Finset.sum_range_succ", "ring tactic", "polynomial identity"],
+    "prerequisites": ["induction on ℕ", "Finset.sum manipulation"]
+  },
+  {
+    "id": "sbp-oq010101oq02-ann-swap",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 89, "endLine": 98 },
+    "type": "technique",
+    "title": "The Order-Swapped Form: f ↔ G Symmetry",
+    "content": "abel_summation_swap rearranges (A) to isolate the difference-weighted sum ∑ Δf(k)·G(k+1), obtained by a one-line linear_combination of the main identity. Reading the identity as 'move the boundary term across' exhibits the symmetry between differencing f and differencing G — the discrete echo of the order-swapped integration by parts ∫ G df = fG − ∫ f dG. The rearrangement needs no order on R.",
+    "mathContext": "$\\sum_{k<n}\\Delta f(k)\\,G(k{+}1) = f(n)G(n) - f(0)G(0) - \\sum_{k<n} f(k)\\,\\Delta G(k)$",
+    "significance": "supporting",
+    "relatedConcepts": ["linear_combination", "symmetry", "boundary term"],
+    "prerequisites": ["the main transform"]
+  },
+  {
+    "id": "sbp-oq010101oq02-ann-telescope",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 106 },
+    "type": "insight",
+    "title": "Telescoping as the f ≡ 1 Instance",
+    "content": "sum_diff_telescope is the bottom of the ladder: taking f ≡ 1 makes every forward difference Δf vanish, so the correction sum ∑ Δf(k)·G(k+1) is identically zero and the boundary collapses, giving the pure telescoping identity ∑_{k<n} (G(k+1) − G(k)) = G(n) − G(0). It follows by specialising (A) at the constant sequence and discharging with simpa — telescoping is a degenerate Abel transform.",
+    "mathContext": "$f\\equiv 1 \\Rightarrow \\Delta f \\equiv 0 \\Rightarrow \\sum_{k<n}(G(k{+}1)-G(k)) = G(n)-G(0)$",
+    "significance": "supporting",
+    "relatedConcepts": ["telescoping sum", "constant sequence", "degenerate case"],
+    "prerequisites": ["the main transform"]
+  },
+  {
+    "id": "sbp-oq010101oq02-ann-geometric",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 108, "endLine": 125 },
+    "type": "insight",
+    "title": "The Geometric Recursion is One Instance (G(k) = rᵏ)",
+    "content": "geom_weighted_recursion_of_abel recovers the parent entry's hypothesis-free geometric recursion as the single instance G(k) = rᵏ. Since the geometric antidifference satisfies G(k+1) − G(k) = r^{k+1} − rᵏ = rᵏ(r−1), the left side of (A) becomes (r−1)·∑ f(k)·rᵏ and the whole identity collapses verbatim to (r−1)·∑ f(k)rᵏ = f(n)rⁿ − f(0) − ∑ Δf(k)·r^{k+1}. The proof rewrites (r−1)·(f(k)·rᵏ) = f(k)·(r^{k+1} − rᵏ) via pow_succ and matches (A). This shows the geometric weight was never essential — only that rᵏ is a closed-form antidifference.",
+    "mathContext": "$G(k)=r^k,\\ \\Delta G(k)=r^k(r-1) \\Rightarrow (r-1)\\sum_{k<n} f(k)r^k = f(n)r^n - f(0) - \\sum_{k<n}\\Delta f(k)\\,r^{k+1}$",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "specialisation", "pow_succ", "antidifference"],
+    "prerequisites": ["the main transform", "geometric sums"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01-oq-01-oq-02` (The General Discrete Abel Transform over a Commutative Ring).

## Problem found
The entry had only meta.json (already rich: overview, sections with ids, conclusion, crossReferences) but no `annotations.json`, leaving inline annotation coverage empty (quality 37).

## Changes
- **Created `annotations.json`** — 5 substantive annotations covering the 126-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the discrete integration-by-parts framing, the general Abel transform (A) and its from-scratch induction, the order-swapped f↔G symmetry, telescoping as the f ≡ 1 instance, and recovery of the parent's geometric recursion as the single G(k)=rᵏ instance.

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite); annotations.json validates.
- status/badge/axiomCount (verified / original / 0) consistent with the 0-sorry, 0-axiom Lean source (only foundational propext / Classical.choice / Quot.sound; no native_decide).

(No `index.ts` created — per issue #20993 the loader uses build-generated listings.json/data-manifest.json + public/data/proofs/, and the per-proof index.ts shim is obsolete.)

Pre-existing meta content was already strong and preserved unchanged.