### PR TITLE
Enrich Fibonacci Summation Identities: add annotations.json

### DIFF
--- a/src/data/proofs/fibonacci-identities/annotations.json
+++ b/src/data/proofs/fibonacci-identities/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "fibid-ann-header",
+    "proofId": "fibonacci-identities",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Summation Identities Missing from Mathlib's fib Library",
+    "content": "The header explains the niche this entry fills: Mathlib's `Nat.fib` API is rich in *pointwise* identities — the recurrence `Nat.fib_add_two`, the addition formula `Nat.fib_add`, the doubling formulas, Cassini's identity, the gcd law `Nat.fib_gcd`, and the Pascal-diagonal sum — but it records none of the classical *summation* identities. This file supplies three: the sum of squares $\\sum F_i^2 = F_n F_{n+1}$, the odd-indexed sum $\\sum F_{2i-1} = F_{2n}$, and the even-indexed sum $\\sum F_{2i} + 1 = F_{2n+1}$. The strategy is uniform and minimal: every proof is a self-contained induction whose only Fibonacci input is the defining recurrence `Nat.fib_add_two`, the rest being `Finset.sum_range_succ` plus `ring`/`omega`. No axioms, no `native_decide`.",
+    "mathContext": "$F_0 = 0,\\ F_1 = 1,\\ F_{n+2} = F_{n+1} + F_n$. The three sums proved here are the textbook telescoping/parity identities, here machine-checked over $\\mathbb{N}$.",
+    "significance": "context",
+    "relatedConcepts": ["Fibonacci numbers", "Nat.fib", "summation identities", "telescoping sums"],
+    "prerequisites": ["Fibonacci recurrence", "finite sums over Finset.range"]
+  },
+  {
+    "id": "fibid-ann-sum-sq",
+    "proofId": "fibonacci-identities",
+    "range": { "startLine": 35, "endLine": 44 },
+    "type": "theorem",
+    "title": "Sum of Squares: ∑ Fᵢ² = Fₙ·Fₙ₊₁",
+    "content": "`fib_sum_sq` proves $F_0^2 + F_1^2 + \\cdots + F_n^2 = F_n F_{n+1}$ by induction. The base case is `simp`. In the step, `Finset.sum_range_succ` peels off $F_{k+1}^2$, the induction hypothesis rewrites the remaining sum as $F_k F_{k+1}$, `Nat.fib_add_two` expands $F_{k+2} = F_{k+1} + F_k$, and `ring` closes the identity $F_k F_{k+1} + F_{k+1}^2 = F_{k+1}(F_k + F_{k+1}) = F_{k+1} F_{k+2}$. Geometrically this is the classic dissection of an $F_n \\times F_{n+1}$ rectangle into squares of side $F_0, \\ldots, F_n$ — the spiral underlying the 'golden rectangle' picture.",
+    "mathContext": "Telescoping: $F_{n+1}F_{n+2} - F_n F_{n+1} = F_{n+1}(F_{n+2} - F_n) = F_{n+1}\\cdot F_{n+1} = F_{n+1}^2$, so partial sums of $F_i^2$ collapse to the single product $F_n F_{n+1}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping sum", "golden rectangle dissection", "Nat.fib_add_two", "Finset.sum_range_succ"],
+    "prerequisites": ["induction", "ring normalization"]
+  },
+  {
+    "id": "fibid-ann-odd",
+    "proofId": "fibonacci-identities",
+    "range": { "startLine": 46, "endLine": 54 },
+    "type": "theorem",
+    "title": "Odd-Indexed Sum: ∑ F₂ᵢ₊₁ = F₂ₙ",
+    "content": "`fib_sum_odd` proves $F_1 + F_3 + \\cdots + F_{2n-1} = F_{2n}$. The induction step adds $F_{2k+1}$ via `Finset.sum_range_succ`, uses the hypothesis $\\sum_{i<k} F_{2i+1} = F_{2k}$, and recognizes $2(k+1) = (2k+1)+1$ so that `Nat.fib_add_two` gives $F_{2k+2} = F_{2k+1} + F_{2k}$ — exactly the new sum. No `ring` is even needed; the recurrence closes it directly. This is the parity-sum companion to the even-indexed identity below.",
+    "mathContext": "$\\sum_{i<n} F_{2i+1} = F_{2n}$ because $F_{2k+2} = F_{2k+1} + F_{2k}$: each added odd-indexed term bridges from one even-indexed Fibonacci number to the next.",
+    "significance": "key",
+    "relatedConcepts": ["parity sums", "Fibonacci recurrence", "index arithmetic"],
+    "prerequisites": ["induction", "Nat.fib_add_two"]
+  },
+  {
+    "id": "fibid-ann-even",
+    "proofId": "fibonacci-identities",
+    "range": { "startLine": 56, "endLine": 70 },
+    "type": "theorem",
+    "title": "Even-Indexed Sum: (∑ F₂ᵢ₊₂) + 1 = F₂ₙ₊₁",
+    "content": "`fib_sum_even` proves $(F_2 + F_4 + \\cdots + F_{2n}) + 1 = F_{2n+1}$, stated additively (with the $+1$ on the left) to stay within $\\mathbb{N}$ and avoid subtraction. The step peels $F_{2k+2}$ off the sum and uses a local lemma $F_{2(k+1)+1} = F_{2k+1} + F_{2k+2}$ (two applications of index rewriting + `Nat.fib_add_two`); `omega` then discharges the linear-arithmetic bookkeeping that combines the hypothesis with the new term. The $+1$ correction reflects that the even-indexed partial sums fall exactly one short of the next odd-indexed Fibonacci number.",
+    "mathContext": "$\\sum_{i<n} F_{2i+2} + 1 = F_{2n+1}$; equivalently $\\sum_{i=1}^{n} F_{2i} = F_{2n+1} - 1$ over $\\mathbb{Z}$. The off-by-one is the Fibonacci analogue of $\\sum_{i\\le n} F_i = F_{n+2} - 1$.",
+    "significance": "key",
+    "relatedConcepts": ["parity sums", "ℕ subtraction avoidance", "omega", "off-by-one correction"],
+    "prerequisites": ["induction", "linear arithmetic over ℕ"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities` (Fibonacci Summation Identities).

## Gaps closed
- **Created `annotations.json`** — 4 annotations (none existed before) with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering the header (summation identities absent from Mathlib's pointwise `Nat.fib` API), the sum-of-squares telescoping identity ∑Fᵢ² = Fₙ·Fₙ₊₁ (with the golden-rectangle dissection), the odd-indexed sum ∑F₂ᵢ₊₁ = F₂ₙ, and the even-indexed off-by-one sum (∑F₂ᵢ₊₂)+1 = F₂ₙ₊₁.

## Notes
- The existing `overview`, `conclusion`, `crossReferences`, and `sections` (which already cover the full 70-line file with ids) were left intact.
- No `index.ts` added: site loading is via build-generated `listings.json`/`data-manifest.json` (entry confirmed present), not per-proof shims.
- Axiom integrity verified: `status: verified`, `badge: original`, `axiomCount: 0` match the Lean file (0 sorries, 0 axiom declarations, no `native_decide`; only `Nat.fib_add_two` + `Finset.sum_range_succ` + `ring`/`omega`).
- `pnpm build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)