### PR TITLE
Enrich summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02: add annotations

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "sbp-oq02oq02-ann-header",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 3, "endLine": 63 },
+    "type": "context",
+    "title": "Biadditivity is the Only Hypothesis Abel Summation Needs",
+    "content": "The parent proved the discrete Abel transform ∑ f·ΔG = [fG] − ∑ Δf·G(·+1) over a commutative ring, closing the induction with the ring tactic. Its open question asked whether commutativity is essential. This file answers no in the sharpest form: the single algebraic fact the induction uses is biadditivity — additivity in each argument separately. Replacing the product by an arbitrary biadditive pairing p : A →+ B →+ M between three abelian groups, the master identity holds with no commutativity, associativity, or ring structure on the value group M. Only the fixed left-to-right order p(f·)(G·) matters.",
+    "mathContext": "$p : A \\to_+ B \\to_+ M$ biadditive $\\Rightarrow \\sum_{k<n} p(f k)(\\Delta G k) = p(f n)(G n) - p(f 0)(G 0) - \\sum_{k<n} p(\\Delta f k)(G(k{+}1))$",
+    "significance": "key",
+    "relatedConcepts": ["biadditivity", "Abel summation", "non-commutative ring", "abelian group"],
+    "prerequisites": ["additive group homomorphisms", "AddMonoidHom"]
+  },
+  {
+    "id": "sbp-oq02oq02-ann-master",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 69, "endLine": 91 },
+    "type": "theorem",
+    "title": "The Biadditive Abel Transform (A′)",
+    "content": "abel_summation_biadditive is the master identity, proved by the parent's induction shape with one crucial substitution. The step peels the top term off both sums via Finset.sum_range_succ and applies the IH; where the parent invoked ring, here the leftover identity lives in the abelian group M. Every p(a)(b₁−b₂) and p(a₁−a₂)(b) is expanded via map_sub (biadditivity) and AddMonoidHom.sub_apply into a ℤ-combination of the atoms p(f i)(G j), and abel closes the additive-group goal. Replacing ring by map_sub + abel is exactly what frees the identity from commutativity.",
+    "mathContext": "$\\mathtt{ring} \\rightsquigarrow \\mathtt{map\\_sub} + \\mathtt{abel}$: the inductive residue is an additive-group identity in atoms $p(f i)(G j)$, needing no multiplication on $M$",
+    "significance": "key",
+    "relatedConcepts": ["map_sub", "abel tactic", "Finset.sum_range_succ", "AddMonoidHom.sub_apply"],
+    "prerequisites": ["induction on ℕ", "additive group identities"]
+  },
+  {
+    "id": "sbp-oq02oq02-ann-swap",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 93, "endLine": 105 },
+    "type": "technique",
+    "title": "Order-Swapped Form in the Value Group",
+    "content": "abel_summation_swap_biadditive rearranges (A′) to isolate the difference-weighted sum ∑ p(Δf)(G(·+1)), obtained by rw [h]; abel on the master identity. It exhibits the f ↔ G symmetry of discrete integration by parts and — like everything here — needs no multiplication or order on the value group M, only its abelian-group structure.",
+    "mathContext": "$\\sum_{k<n} p(\\Delta f k)(G(k{+}1)) = p(f n)(G n) - p(f 0)(G 0) - \\sum_{k<n} p(f k)(\\Delta G k)$",
+    "significance": "supporting",
+    "relatedConcepts": ["abel tactic", "symmetry", "value group"],
+    "prerequisites": ["the master transform"]
+  },
+  {
+    "id": "sbp-oq02oq02-ann-ring",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 107, "endLine": 120 },
+    "type": "insight",
+    "title": "Abel Summation over an Arbitrary Ring (Commutativity Dropped)",
+    "content": "abel_summation_ring specialises p = AddMonoidHom.mul, which exists for any ring because multiplication distributes over addition on both sides (biadditive). The instance of (A′) at this pairing is the parent's identity ∑ f·ΔG = [fG] − ∑ Δf·G(·+1) over an ARBITRARY ring R — the parent's CommRing hypothesis was an artefact of closing the algebra with ring, not a real requirement. The conversion is simpa only [AddMonoidHom.mul_apply] (application is definitionally multiplication). This is a drop-in strengthening: future uses over a ring no longer need commutativity.",
+    "mathContext": "$p = \\mathrm{AddMonoidHom.mul} : R \\to_+ R \\to_+ R$; instance of (A′) $=$ parent identity with the product order $f * G$ fixed, no commutativity",
+    "significance": "key",
+    "relatedConcepts": ["AddMonoidHom.mul", "non-commutative ring", "specialisation", "hypothesis weakening"],
+    "prerequisites": ["the master transform", "ring distributivity"]
+  },
+  {
+    "id": "sbp-oq02oq02-ann-module",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02",
+    "range": { "startLine": 122, "endLine": 143 },
+    "type": "insight",
+    "title": "Module-Valued Abel Summation (the Bimodule Pairing)",
+    "content": "abel_summation_smul takes p to be the scalar action: f : ℕ → R ranges over a ring of multipliers and G : ℕ → M over a left R-module, so f and G live in genuinely different objects — exactly the 'different modules, fixed multiplication order' extension the open question requested. It is proved by the same induction with smul_sub and sub_smul replacing map_sub, then abel. This is the discrete Abel transform in its natural home for vector-, matrix-, or operator-valued series weighted by a scalar sequence.",
+    "mathContext": "$\\sum_{k<n} f k \\bullet (\\Delta G k) = f n \\bullet G n - f 0 \\bullet G 0 - \\sum_{k<n} (\\Delta f k)\\bullet G(k{+}1),\\ f : \\mathbb{N}\\to R,\\ G : \\mathbb{N}\\to M$",
+    "significance": "key",
+    "relatedConcepts": ["scalar action", "module-valued series", "smul_sub", "bimodule pairing"],
+    "prerequisites": ["modules over a ring", "the master transform"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02` (The Discrete Abel Transform is Biadditive).

## Problem found
The entry had only meta.json (already rich: overview, sections with ids, conclusion, crossReferences) but no `annotations.json` (quality 37).

## Changes
- **Created `annotations.json`** — 5 substantive annotations covering the 144-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: biadditivity as the sole hypothesis, the biadditive transform (A′) with the key ring→map_sub+abel proof substitution, the order-swapped form, Abel summation over an arbitrary ring (commutativity dropped via AddMonoidHom.mul), and the module-valued/bimodule pairing via the scalar action.

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite); annotations.json validates.
- status/badge/axiomCount (verified / original / 0) consistent with the 0-sorry, 0-axiom Lean source (only foundational propext / Classical.choice / Quot.sound; no native_decide).

(No `index.ts` created — obsolete per issue #20993; loader uses build-generated listings.json/data-manifest.json + public/data/proofs/.)

Pre-existing meta content was already strong and preserved unchanged.