### PR TITLE
Enrich erdos-124-complete-sequences-oq-02: add annotations

### DIFF
--- a/src/data/proofs/erdos-124-complete-sequences-oq-02/annotations.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "erdos124-oq02-ann-header",
+    "proofId": "erdos-124-complete-sequences-oq-02",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "context",
+    "title": "The Erdős 124 Boundary is Exactly an Egyptian Fraction",
+    "content": "The weak Erdős–Burr–Graham–Li problem #124 (AI-solved by Harmonic's Aristotle in 2025) says bases d₁,…,d_k ≥ 2 with ∑ 1/(dᵢ−1) ≥ 1 make every natural number a sum of base-dᵢ numbers with only digits 0,1. This file studies OQ-02 — the exact boundary ∑ 1/(dᵢ−1) = 1. The key observation: writing eᵢ = dᵢ − 1 ≥ 1, the boundary becomes ∑ 1/eᵢ = 1, so the boundary configurations are PRECISELY the Egyptian-fraction decompositions of 1. No new completeness machinery is needed (equality is a face of the parent's closed ≥ 1 region); the structure is the arithmetic of unit fractions.",
+    "mathContext": "$\\sum 1/(d_i-1) = 1 \\iff \\sum 1/e_i = 1$ with $e_i = d_i - 1$ — a unit-fraction decomposition of $1$",
+    "significance": "key",
+    "relatedConcepts": ["Egyptian fractions", "complete sequences", "Brown's criterion", "Sylvester sequence"],
+    "prerequisites": ["unit fractions", "Erdős 124 / complete sequences"]
+  },
+  {
+    "id": "erdos124-oq02-ann-bridge",
+    "proofId": "erdos-124-complete-sequences-oq-02",
+    "range": { "startLine": 54, "endLine": 93 },
+    "type": "definition",
+    "title": "Egyptian / Reciprocal Sums and the Bridge",
+    "content": "egyptSum e = ∑ 1/eᵢ and reciSum d = ∑ 1/(dᵢ−1) are defined as list-map-sums over ℚ, with cons/nil simp rules driving every induction. reciSum_eq_egyptSum is the structural bridge: reciSum d = egyptSum (d.map (·−1)) for bases ≥ 1. The cons step needs the cast ((a−1:ℕ):ℚ) = (a:ℚ)−1 (Nat.cast_sub, valid since a ≥ 1) so that natural subtraction matches rational subtraction. This single identity is the answer to OQ-02 — it reframes the opaque reciprocal boundary as classical Egyptian fractions.",
+    "mathContext": "$\\mathrm{reciSum}\\,d = \\mathrm{egyptSum}(d.\\mathrm{map}(\\cdot-1));\\quad ((a-1:\\mathbb{N}):\\mathbb{Q}) = (a:\\mathbb{Q})-1$ for $a\\ge 1$",
+    "significance": "key",
+    "relatedConcepts": ["List.map", "Nat.cast_sub", "reciprocal sum", "list induction"],
+    "prerequisites": ["List sums", "ℕ→ℚ casts"]
+  },
+  {
+    "id": "erdos124-oq02-ann-sylvester",
+    "proofId": "erdos-124-complete-sequences-oq-02",
+    "range": { "startLine": 95, "endLine": 202 },
+    "type": "theorem",
+    "title": "Sylvester Splitting: Boundary Configs of Every Size",
+    "content": "egyptSum_split is the Sylvester identity 1/e = 1/(e+1) + 1/(e(e+1)) (field_simp clears denominators for e ≥ 1) — the engine that trades one unit fraction for two. The recursive sylvester k construction repeatedly splits the head fraction; sylvester_egyptSum proves the sum stays 1, sylvester_length proves it has exactly k+1 denominators, sylvester_pos keeps them ≥ 1. exists_boundary_config maps the Sylvester denominators by (+1) to produce, for every k ≥ 1, a list of k bases ≥ 2 with reciSum = 1. So the number of bases at the boundary is completely unconstrained.",
+    "mathContext": "$1/e = 1/(e+1) + 1/(e(e+1))$; $\\mathrm{sylvester}\\,k$ has length $k+1$ and $\\mathrm{egyptSum} = 1$",
+    "significance": "key",
+    "relatedConcepts": ["Sylvester sequence", "unit fraction splitting", "field_simp", "explicit construction"],
+    "prerequisites": ["recursion on lists", "rational arithmetic"]
+  },
+  {
+    "id": "erdos124-oq02-ann-rigidity",
+    "proofId": "erdos-124-complete-sequences-oq-02",
+    "range": { "startLine": 204, "endLine": 291 },
+    "type": "insight",
+    "title": "Base-2 Rigidity: Binary is the Unique Single Base",
+    "content": "The unit fraction 1/1 = 1 saturates the entire budget. egyptSum_ge_one_of_mem_one shows that if the denominator 1 occurs, the sum is already ≥ 1; egypt_one_forces_singleton then proves any Egyptian decomposition of 1 containing 1 must be exactly [1] (any other positive term would overflow). Transported through the bridge, base_two_forces_singleton gives the rigidity: any boundary configuration using the base d = 2 is the singleton [2] — i.e. ordinary base-2 (binary) representation. This isolates precisely when the boundary degenerates.",
+    "mathContext": "$1 \\in l,\\ \\mathrm{egyptSum}\\,l = 1 \\Rightarrow l = [1]$; hence $2 \\in d,\\ \\mathrm{reciSum}\\,d = 1 \\Rightarrow d = [2]$",
+    "significance": "key",
+    "relatedConcepts": ["budget saturation", "rigidity", "binary representation", "positivity"],
+    "prerequisites": ["the bridge identity", "positivity of unit fractions"]
+  },
+  {
+    "id": "erdos124-oq02-ann-witnesses",
+    "proofId": "erdos-124-complete-sequences-oq-02",
+    "range": { "startLine": 293, "endLine": 316 },
+    "type": "context",
+    "title": "Concrete Boundary Witnesses",
+    "content": "Explicit Egyptian decompositions of 1 in base language: reciSum [2] = 1 (binary, 1/1), [3,3] (1/2+1/2), [3,4,7] (1/2+1/3+1/6), and [3,4,8,43] realizing Sylvester's sequence 2,3,7,43 (1/2+1/3+1/7+1/42). A decide-check confirms sylvester 3 = [4,12,6,2], a different length-4 decomposition (bases [5,13,7,3]). These ground the abstract existence results in computable instances.",
+    "mathContext": "$\\mathrm{reciSum}[3,4,8,43] = \\tfrac12+\\tfrac13+\\tfrac17+\\tfrac1{42} = 1$ (Sylvester)",
+    "significance": "supporting",
+    "relatedConcepts": ["Sylvester's sequence", "concrete witnesses", "norm_num"],
+    "prerequisites": ["unit-fraction arithmetic"]
+  }
+]

--- a/src/data/proofs/erdos-124-complete-sequences-oq-02/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02/meta.json
@@ -129,8 +129,9 @@
   ],
   "crossReferences": [
     {
-      "id": "erdos-124-complete-sequences",
-      "reason": "Direct parent: the AI-solved weak Erdős 124 entry whose reciprocal condition ∑ 1/(dᵢ−1) ≥ 1 this file analyzes at equality"
+      "targetId": "erdos-124-complete-sequences",
+      "relationship": "parent",
+      "description": "Direct parent: the AI-solved weak Erdős 124 entry whose reciprocal condition ∑ 1/(dᵢ−1) ≥ 1 this file analyzes at equality"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-124-complete-sequences-oq-02` (Erdős 124 boundary = Egyptian fraction).

## Problem found
The entry had only meta.json (already rich: overview, sections with ids, conclusion, references) but no `annotations.json` (quality 38), and its `crossReferences` used non-standard `{id, reason}` keys that don't match the CrossReference type.

## Changes
- **Created `annotations.json`** — 5 substantive annotations covering the 316-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the Egyptian-fraction boundary reframing, the reciSum↔egyptSum bridge (eᵢ = dᵢ−1), Sylvester splitting producing boundary configs of every size, base-2 rigidity (the unit fraction saturates the budget so d=2 forces [2]), and the concrete witnesses [2],[3,3],[3,4,7],[3,4,8,43].
- **Normalized `crossReferences`** to the canonical `{targetId, relationship, description}` schema.

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite); both JSON files validate.
- status/badge/axiomCount (verified / original / 0) consistent with the 0-sorry, 0-axiom Lean source (only foundational propext / Classical.choice / Quot.sound; no native_decide — the one decide is a small kernel check, no Lean.ofReduceBool).

Pre-existing meta content was already strong and preserved unchanged.