### PR TITLE
Enrich four-square-distribution-oq-06-oq-01: add annotations

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/four-square-distribution-oq-06-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "fsd-oq0601-ann-header",
+    "proofId": "four-square-distribution-oq-06-oq-01",
+    "range": { "startLine": 3, "endLine": 66 },
+    "type": "context",
+    "title": "Reducing Jacobi's σ* to the Classical Divisor Sum",
+    "content": "The parent OQ-06 computed Jacobi's modified divisor sum σ*(n) = ∑_{d|n, 4∤d} d only on prime powers. This entry gives a single closed form for every n, reducing σ* to the ordinary — and fully multiplicative — sum-of-divisors function σ. σ*(n) counts divisors not divisible by 4; sigmaStar and jacobiR4 = 8·σ* are re-declared standalone. Honest scope: jacobiR4 is DEFINED as 8·σ*, so these theorems compute the arithmetic prediction in closed form — they do not prove the open geometric identity r₄(n) = #{(a,b,c,d) : a²+b²+c²+d² = n} (which needs the q-expansion of jacobiTheta⁴).",
+    "mathContext": "$\\sigma^*(n) = \\sum_{d\\mid n,\\ 4\\nmid d} d,\\quad \\sigma(n) = \\sum_{d\\mid n} d,\\quad r_4(n) := 8\\sigma^*(n)$",
+    "significance": "key",
+    "relatedConcepts": ["sum of divisors", "Jacobi four-square theorem", "multiplicative functions", "modified divisor sum"],
+    "prerequisites": ["divisors of n", "Finset.sum"]
+  },
+  {
+    "id": "fsd-oq0601-ann-part1",
+    "proofId": "four-square-distribution-oq-06-oq-01",
+    "range": { "startLine": 68, "endLine": 83 },
+    "type": "theorem",
+    "title": "When 4 ∤ n, Nothing is Dropped: σ* = σ",
+    "content": "sigmaStar_eq_sigma_of_not_four_dvd: if 4 ∤ n then no divisor d of n can be divisible by 4 (else 4 | d | n), so the filter drops nothing and σ*(n) = σ(n). This is the SHARP form of the parent's 'odd ⇒ σ* = σ' — oddness is stronger than needed; 4 ∤ n is exactly the right hypothesis. The proof is a Finset.sum_congr replacing each if-branch by the divisor itself.",
+    "mathContext": "$4\\nmid n \\Rightarrow (d\\mid n \\Rightarrow 4\\nmid d) \\Rightarrow \\sigma^*(n) = \\sigma(n)$",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility transitivity", "Finset.sum_congr", "sharp hypothesis"],
+    "prerequisites": ["Nat.dvd_of_mem_divisors"]
+  },
+  {
+    "id": "fsd-oq0601-ann-part2",
+    "proofId": "four-square-distribution-oq-06-oq-01",
+    "range": { "startLine": 84, "endLine": 116 },
+    "type": "technique",
+    "title": "The Dropped Part is 4·σ(n/4) via the Bijection e ↦ 4e",
+    "content": "sum_filter_four_dvd: for 4 ∣ n, the divisors of n that ARE divisible by 4 are exactly {4e : e | (n/4)}, so their sum is 4·σ(n/4). The core is a set equality (Finset.image of e ↦ 4e equals the filtered divisors), proved by a membership ext argument in both directions using Nat.mul_div_cancel'. Finset.sum_image (with injectivity of e ↦ 4e) and Finset.mul_sum then extract the scalar 4. This identifies the discarded multiples-of-4 as a scaled copy of σ(n/4).",
+    "mathContext": "$\\{d\\mid n : 4\\mid d\\} = \\{4e : e\\mid n/4\\};\\quad \\sum_{d\\mid n,\\ 4\\mid d} d = 4\\sigma(n/4)$",
+    "significance": "key",
+    "relatedConcepts": ["bijective sum", "Finset.image", "Finset.sum_image", "scaled divisor sum"],
+    "prerequisites": ["Nat.mul_div_cancel'", "injective image sums"]
+  },
+  {
+    "id": "fsd-oq0601-ann-part3",
+    "proofId": "four-square-distribution-oq-06-oq-01",
+    "range": { "startLine": 117, "endLine": 142 },
+    "type": "insight",
+    "title": "Headline Identity: σ*(n) = σ(n) − 4·σ(n/4)",
+    "content": "Splitting σ(n) into its 4∤d and 4∣d parts, sigmaStar_add_eq gives the truncation-free additive form σ*(n) + 4·σ(n/4) = σ(n) for 4 ∣ n (each divisor's two if-branches sum to d). sigmaStar_eq_sigma_sub then states it subtractively σ*(n) = σ(n) − 4·σ(n/4) via omega. This is the structural bridge: Jacobi's σ* is fully determined by the classical multiplicative σ, so all of σ*'s arithmetic is inherited from σ.",
+    "mathContext": "$\\sigma^*(n) + 4\\sigma(n/4) = \\sigma(n) \\iff \\sigma^*(n) = \\sigma(n) - 4\\sigma(n/4)$ for $4\\mid n$",
+    "significance": "key",
+    "relatedConcepts": ["divisor sum splitting", "ℕ truncated subtraction", "omega", "multiplicativity transfer"],
+    "prerequisites": ["the parts 1–2 lemmas", "Finset.sum_add_distrib"]
+  },
+  {
+    "id": "fsd-oq0601-ann-part4",
+    "proofId": "four-square-distribution-oq-06-oq-01",
+    "range": { "startLine": 143, "endLine": 214 },
+    "type": "insight",
+    "title": "Odd-Part Capstone: σ*(2ᵃ·m) = 3·σ(m)",
+    "content": "sigmaStar_two_pow_mul_odd shows that for n = 2ᵃ·m with m odd and a ≥ 1, Jacobi's σ* depends ONLY on the odd part: σ*(2ᵃ·m) = 3·σ(m). The case a = 1 has 4 ∤ 2m so σ* = σ and σ(2m) = σ(2)·σ(m) = 3·σ(m) by multiplicativity (Coprime.sum_divisors_mul). For a ≥ 2, the headline identity with (2ᵃm)/4 = 2^{a−2}·m and the geometric σ(2ᵃ) = 2^{a+1}−1 (sigma_two_pow) reduces to a ℕ-arithmetic cancellation: writing 2^{b+1} = Q+1 clears all truncated subtractions and omega finishes. The factor 3 = σ(2) = 1+2 is what survives from every power of two.",
+    "mathContext": "$n = 2^a m,\\ m\\text{ odd},\\ a\\ge 1 \\Rightarrow \\sigma^*(n) = 3\\sigma(m);\\quad \\sigma(2^a) = 2^{a+1}-1$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicativity", "Coprime.sum_divisors_mul", "geometric divisor sum", "odd part"],
+    "prerequisites": ["the headline identity", "coprime factorization of σ"]
+  },
+  {
+    "id": "fsd-oq0601-ann-part56",
+    "proofId": "four-square-distribution-oq-06-oq-01",
+    "range": { "startLine": 215, "endLine": 249 },
+    "type": "context",
+    "title": "Jacobi's r₄ in Textbook Form, with Sanity Instances",
+    "content": "Translating σ* to jacobiR4 = 8·σ*: for 4 ∤ n, r₄(n) = 8·σ(n) (jacobiR4_of_not_four_dvd); for even n = 2ᵃm (m odd), r₄(2ᵃm) = 24·σ(m) (jacobiR4_two_pow_mul_odd) — the classical textbook statement that the number of representations as four squares depends only on the odd part. Sanity instances σ*(12) = 3·σ(3) = 12 and r₄(12) = 24·σ(3) = 96 are recovered symbolically, with the small σ(2)=3, σ(3)=4 facts by kernel decide (no native_decide, so no Lean.ofReduceBool).",
+    "mathContext": "$r_4(n) = 8\\sigma(n)\\ (4\\nmid n);\\quad r_4(2^a m) = 24\\sigma(m);\\quad r_4(12) = 24\\cdot 4 = 96$",
+    "significance": "supporting",
+    "relatedConcepts": ["Jacobi four-square theorem", "representations as sums of squares", "kernel decide"],
+    "prerequisites": ["the capstone", "the σ* = σ case"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `four-square-distribution-oq-06-oq-01` (σ*(n) = σ(n) − 4·σ(n/4)).

## Problem found
The entry had only meta.json (already rich: overview, 6 sections with ids, conclusion, crossReferences) but no `annotations.json` (quality 38).

## Changes
- **Created `annotations.json`** — 6 substantive annotations, one per section of the 249-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the σ*→σ reduction framing, the 4∤n case (σ* = σ), the e↦4e bijection identifying the dropped part as 4·σ(n/4), the headline identity σ*(n) = σ(n) − 4·σ(n/4), the odd-part capstone σ*(2ᵃm) = 3·σ(m), and the textbook r₄ closed forms with sanity instances.

## Verification
- `pnpm build` passes (data-enrichment + tsc + vite); annotations.json validates.
- status/badge/axiomCount (verified / 0) consistent with the 0-sorry, 0-axiom Lean source (the few `decide`s are small kernel checks — no native_decide, no Lean.ofReduceBool). Honest scope preserved: jacobiR4 is defined as 8·σ*, so this is the arithmetic side only (the geometric r₄ identity remains open).

Pre-existing meta content was already strong and preserved unchanged.