### PR TITLE
Enrich borsuk-ulam-oq-02-oq-01-oq-02: add annotations

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
@@ -90,24 +90,28 @@
   ],
   "sections": [
     {
+      "id": "nt-core",
       "title": "Number-theoretic core: prime localization of coprimality",
       "startLine": 53,
       "endLine": 71,
       "summary": "coprime_iff_forall_prime_dvd: gcd(a,n)=1 iff no prime divisor of n divides a, via Nat.dvd_gcd one way and Nat.exists_prime_and_dvd the other."
     },
     {
+      "id": "free-action-model",
       "title": "The free-action model",
       "startLine": 73,
       "endLine": 86,
       "summary": "IsFreeRep n a (every rotation weight is a unit mod n) and IsFreeAtPrime a p (no weight divisible by p), modelling free Z/n-actions and their restrictions to prime-order subgroups."
     },
     {
+      "id": "prime-localization",
       "title": "Prime localization of freeness (main theorem)",
       "startLine": 88,
       "endLine": 116,
       "summary": "isFreeRep_iff_forall_prime: Z/n acts freely iff every prime-order subgroup Z/p (p|n) acts freely; plus restrict_prime ('no exotic gain') and the converse isFreeRep_of_forall_prime."
     },
     {
+      "id": "prime-powers-witness",
       "title": "Prime powers, the standard representation, and a witness",
       "startLine": 118,
       "endLine": 144,


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq-02-oq-01-oq-02` (No Exotic Free Representations for Cyclic Groups).

## Problem found
Only meta.json (already rich: overview, conclusion, crossReferences) but no `annotations.json` (quality 39), and the `sections` lacked `id` fields.

## Changes
- **Created `annotations.json`** — 4 substantive annotations covering the 144-line file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`: the no-exotic-free-representation framing, the number-theoretic core (coprime_iff_forall_prime_dvd) and free-action model, the prime-localization main theorem (isFreeRep_iff_forall_prime), and the prime-power/standard-rep/sharp-witness results.
- **Added `id` fields** to the four `sections` (were missing).

## Verification
- `pnpm build` passes; both JSON files validate. status/badge/axiomCount (verified / verified / 0) consistent with the genuinely 0-axiom Lean source (small kernel `decide`s only, no native_decide) — note the entry is axiom-free unlike the parent's axiomatized buDim framework.

Pre-existing meta content preserved unchanged.