### PR TITLE
Enrich No Exotic Free Representations for Cyclic Groups

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-bu-oq020102-coprime-core",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 65 },
+    "type": "technique",
+    "title": "Prime localization of coprimality",
+    "content": "The number-theoretic heart of the file: a natural number $a$ is coprime to $n$ iff no prime divisor of $n$ divides $a$. The forward direction observes that a common prime $p$ would divide $\\gcd(a,n)=1$, contradicting $p>1$ (via Nat.dvd_gcd). The reverse direction is the contrapositive: if $\\gcd(a,n)\\neq 1$, then Nat.exists_prime_and_dvd extracts a prime $p \\mid \\gcd(a,n)$, which divides both $a$ and $n$, exhibiting the forbidden common prime divisor.",
+    "mathContext": "$\\gcd(a,n)=1 \\iff \\forall p\\text{ prime},\\ p \\mid n \\Rightarrow p \\nmid a$",
+    "significance": "key",
+    "relatedConcepts": ["greatest common divisor", "prime factorization", "coprimality", "fundamental theorem of arithmetic"],
+    "prerequisites": ["elementary number theory", "Nat.Coprime", "prime divisibility"]
+  },
+  {
+    "id": "ann-bu-oq020102-isfreerep-def",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 71 },
+    "type": "definition",
+    "title": "Free Z/n-action as coprimality of weights",
+    "content": "A complex $\\mathbb{Z}/n$-representation is recorded by its rotation weights $a : \\mathrm{Fin}\\,m \\to \\mathbb{N}$, where the generator acts on coordinate $i$ by $e^{2\\pi i\\, a_i / n}$. The unit vector on axis $i$ is fixed by $k \\in \\mathbb{Z}/n$ iff $k\\cdot a_i \\equiv 0 \\pmod n$; for the action to be free on the whole sphere every weight must be a unit mod $n$. Thus IsFreeRep is defined as $\\forall i,\\ \\gcd(a_i, n)=1$ — translating a topological freeness condition into pure arithmetic.",
+    "mathContext": "$\\mathrm{IsFreeRep}(n,a) \\;:=\\; \\forall i,\\ \\gcd(a_i, n)=1$",
+    "significance": "key",
+    "relatedConcepts": ["free group action", "representation sphere", "rotation weights", "stabilizer", "roots of unity"],
+    "prerequisites": ["cyclic group representations", "group actions on spheres", "complex representations"]
+  },
+  {
+    "id": "ann-bu-oq020102-isfreeatprime-def",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 76 },
+    "type": "definition",
+    "title": "Restriction to a prime-order subgroup",
+    "content": "Restricting the representation to the order-$p$ subgroup $\\mathbb{Z}/p \\le \\mathbb{Z}/n$ sends the weight $a_i$ to $a_i \\bmod p$. The generator of $\\mathbb{Z}/p$ acts on axis $i$ with that reduced weight, which is nonzero exactly when $p \\nmid a_i$. Hence the restricted action is free iff no weight is divisible by $p$, captured by IsFreeAtPrime $a\\ p := \\forall i,\\ p \\nmid a_i$.",
+    "mathContext": "$\\mathrm{IsFreeAtPrime}(a,p) \\;:=\\; \\forall i,\\ p \\nmid a_i$",
+    "significance": "supporting",
+    "relatedConcepts": ["subgroup restriction", "induced representation", "prime-order subgroup", "reduction mod p"],
+    "prerequisites": ["subgroups of cyclic groups", "modular arithmetic"]
+  },
+  {
+    "id": "ann-bu-oq020102-main-localization",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 93 },
+    "type": "insight",
+    "title": "Prime localization of freeness (main theorem)",
+    "content": "The central result: a $\\mathbb{Z}/n$-representation acts freely on its sphere iff its restriction to every prime-order subgroup $\\mathbb{Z}/p$ ($p \\mid n$) acts freely. After unfolding both definitions the statement becomes exactly coprime_iff_forall_prime_dvd transported across the index quantifier $\\forall i$ — the topology has been fully reduced to the arithmetic core. This is the precise sense in which composite cyclic groups gain no 'exotic' free representation: freeness is detected entirely on the primes dividing $n$.",
+    "mathContext": "$\\mathrm{IsFreeRep}(n,a) \\iff \\forall p\\text{ prime},\\ p\\mid n \\Rightarrow \\mathrm{IsFreeAtPrime}(a,p)$",
+    "significance": "key",
+    "relatedConcepts": ["P.A. Smith theory", "localization at primes", "equivariant Borsuk–Ulam", "free linear actions", "transformation groups"],
+    "prerequisites": ["equivariant topology", "cyclic group actions", "the coprimality core"]
+  },
+  {
+    "id": "ann-bu-oq020102-restrict-prime",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 95, "endLine": 99 },
+    "type": "concept",
+    "title": "No exotic gain (forward direction)",
+    "content": "The 'no exotic gain' direction packaged as a named lemma: every free $\\mathbb{Z}/n$-representation restricts to a free representation of each prime-order subgroup $\\mathbb{Z}/p$ with $p \\mid n$. This is the half of the equivalence with direct topological meaning — a free composite action can never hide a non-free prime restriction, so no free representation outruns what its prime subgroups already witness.",
+    "mathContext": "$\\mathrm{IsFreeRep}(n,a) \\Rightarrow \\forall p\\mid n\\ \\text{prime},\\ \\mathrm{IsFreeAtPrime}(a,p)$",
+    "significance": "supporting",
+    "relatedConcepts": ["restriction functor", "necessary conditions", "free actions"],
+    "prerequisites": ["the main localization theorem"]
+  },
+  {
+    "id": "ann-bu-oq020102-converse",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 101, "endLine": 105 },
+    "type": "concept",
+    "title": "Sufficiency of prime data (converse)",
+    "content": "The converse: prime-by-prime freeness assembles to freeness of the whole $\\mathbb{Z}/n$-action. The prime restrictions are not merely necessary but sufficient — once every prime-order subgroup acts freely, the full cyclic group does too. Together with restrict_prime this closes the equivalence, showing the prime data is a complete invariant for freeness.",
+    "mathContext": "$\\big(\\forall p\\mid n\\ \\text{prime},\\ \\mathrm{IsFreeAtPrime}(a,p)\\big) \\Rightarrow \\mathrm{IsFreeRep}(n,a)$",
+    "significance": "supporting",
+    "relatedConcepts": ["sufficient conditions", "local-global principle", "free actions"],
+    "prerequisites": ["the main localization theorem"]
+  },
+  {
+    "id": "ann-bu-oq020102-prime-pow",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 107, "endLine": 120 },
+    "type": "concept",
+    "title": "Prime powers collapse to one prime",
+    "content": "For a prime power $n = p^k$ ($k \\ge 1$) freeness is governed by the single prime $p$: a $\\mathbb{Z}/p^k$-representation is free iff its restriction to $\\mathbb{Z}/p$ is free. The proof specializes the main theorem and uses that $p$ is the only prime dividing $p^k$ (Nat.Prime.dvd_of_dvd_pow with prime_dvd_prime_iff_eq). Composite prime powers therefore behave exactly like the prime, the clearest case of the no-exotic-representation phenomenon.",
+    "mathContext": "$\\mathrm{IsFreeRep}(p^k, a) \\iff \\mathrm{IsFreeAtPrime}(a,p)\\quad (p\\text{ prime},\\ k\\ge 1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["prime powers", "p-groups", "Sylow theory", "single-prime localization"],
+    "prerequisites": ["prime power divisibility", "the main localization theorem"]
+  },
+  {
+    "id": "ann-bu-oq020102-const-one",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 122, "endLine": 126 },
+    "type": "concept",
+    "title": "The standard faithful representation is free",
+    "content": "The representation with all weights equal to $1$ is free for every $n$, since $\\gcd(1,n)=1$ always. This is the standard faithful rotation representation realising the classical Yang–Borsuk equivariant lower bound, and it is simultaneously free over every prime subgroup — the canonical positive example complementing the witness below.",
+    "mathContext": "$\\mathrm{IsFreeRep}(n, (1,\\dots,1))$ for all $n$, since $\\gcd(1,n)=1$",
+    "significance": "context",
+    "relatedConcepts": ["faithful representation", "Yang–Borsuk bound", "regular representation"],
+    "prerequisites": ["coprime_one_left"]
+  },
+  {
+    "id": "ann-bu-oq020102-witness",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-02",
+    "range": { "startLine": 128, "endLine": 142 },
+    "type": "insight",
+    "title": "Why the conjunction over all primes is necessary",
+    "content": "A concrete witness showing the all-primes conjunction cannot be weakened. For $\\mathbb{Z}/6$ the single-weight representation $a=(2)$ is free over $\\mathbb{Z}/3$ (since $3 \\nmid 2$) but not over $\\mathbb{Z}/2$ (since $2 \\mid 2$), hence not a free $\\mathbb{Z}/6$-representation. Freeness at one prime divisor is insufficient: the failure at $p=2$ propagates to the composite group. The three claims are discharged by decide on small concrete divisibilities.",
+    "mathContext": "$a=(2)$: free over $\\mathbb{Z}/3$, not over $\\mathbb{Z}/2$, hence $\\neg\\,\\mathrm{IsFreeRep}(6,a)$",
+    "significance": "key",
+    "relatedConcepts": ["counterexample", "necessity of hypotheses", "decidability", "concrete witness"],
+    "prerequisites": ["the main localization theorem", "decide tactic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq-02-oq-01-oq-02`.

The entry had a rich `meta.json` but **no `annotations.json`** (the inline annotation layer was entirely missing). This PR adds it.

## Changes
- **Added `annotations.json`** with 9 annotations covering the full 144-line Lean file:
  - `coprime_iff_forall_prime_dvd` — the number-theoretic core (prime localization of coprimality)
  - `IsFreeRep` / `IsFreeAtPrime` definitions (free Z/n-action ↔ coprime weights; restriction to Z/p)
  - `isFreeRep_iff_forall_prime` — the main prime-localization theorem
  - `restrict_prime` (no exotic gain) and the converse `isFreeRep_of_forall_prime`
  - `isFreeRep_prime_pow` (prime powers collapse to one prime)
  - `isFreeRep_const_one` (standard faithful representation)
  - `not_isFreeRep_example` (concrete Z/6 witness; conjunction over all primes is necessary)
- Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
- JSON validates; `pnpm annotations:build` resolves every annotation line range against a Lean construct with **no warnings** for this proof.
- No content removed; `index.ts` intentionally not added — proof discovery is now via the build-time `meta.json` scan (post-#20993), not per-proof shims.