### PR TITLE
Audit: badge gcd-algorithm-oq-01-oq-01 (Binet closest-integer) verified→mathlib

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-01-oq-01/meta.json
@@ -16,9 +16,10 @@
       "euclidean-algorithm",
       "lame-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
+    "assumptions": "None beyond Mathlib. 0 sorries, 0 axioms, no native_decide (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The closed-form backbone is Mathlib's Real.coe_fib_eq (Binet's formula fib n = (φⁿ − ψⁿ)/√5); this entry's independent contribution is the closest-integer/rounding result on top of it (the <½ error bound and round(φⁿ/√5) = fib(n)). Badged mathlib accordingly.",
     "lineCount": 74,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Gallery integrity audit

**Proof**: gcd-algorithm-oq-01-oq-01 — "Binet's Closest-Integer Formula: fib(n) = round(φⁿ/√5)"

### Finding (badge accuracy, Rule #3 — Mathlib wrapper)

The entry was badged **`verified`** (Tier-A / independent formalization), but the closed-form backbone of its main result is Mathlib's `Real.coe_fib_eq` (Binet's formula `fib n = (φⁿ − ψⁿ)/√5`), invoked directly at the algebraic core:

```lean
have heq : (Nat.fib n : ℝ) - φ ^ n / √5 = -ψ ^ n / √5 := by
  rw [Real.coe_fib_eq n]; field_simp; ring
```

`mathlibDependencies` already lists `Real.coe_fib_eq`, and the main result `fib_eq_round_binet` depends on it transitively for its algebraic foundation. The genuinely independent in-file work is the `|ψⁿ/√5| < ½` error estimate and the rounding deduction — real, but built on Mathlib's Binet closed form. Per the auditor skill's **Rule #3 (Mathlib Wrapper Detection)** and **Failure Mode #5**, a result whose deep engine is a Mathlib theorem should carry badge **`mathlib`**, not `verified`.

The prose was already fully transparent (docstring: "from Mathlib's `Real.coe_fib_eq`"; overview credits Binet) — this is a badge-field accuracy fix, not an opacity fix.

### Changes
- `meta.badge`: `verified` → `mathlib`
- Added the missing `assumptions` field disclosing the Mathlib Binet bridge

### Verified unchanged / accurate
- 6 theorems, 0 defs, 74 lines, 0 sorries, 0 axioms — all match the Lean source exactly
- No `True` stubs, no `native_decide` (the one grep hit is a docstring mention)
- `originalContributions` honestly scoped to the error bound / rounding / sandwich
- `status` kept `verified` (it IS machine-checked, 0 axioms); `verified` status + `mathlib` badge is the gallery's standard Tier-B combination

---
Discovered during gallery integrity audit.