### PR TITLE
Gallery integrity: arithmetic-series-oq-03 (ζ-regularization) badge verified→mathlib

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-03/meta.json
@@ -17,11 +17,11 @@
       "arithmetic-series",
       "divergent-series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 140,
-    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. All eight theorems depend only on the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted; `#print axioms` shows no `sorryAx` and no `Lean.ofReduceBool`. The analytic content — meromorphic continuation of ζ and its values at negative integers — is Mathlib's (`riemannZeta_neg_nat_eq_bernoulli`, `riemannZeta_neg_two_mul_nat_add_one`, `riemannZeta_zero`). The contribution here is the explicit closed-form evaluation of the classical regularized values, the trivial-zero family stated on the power index, and the rationality corollary. No new analysis is proved.",
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide`. All nine theorems depend only on the ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted; `#print axioms` shows no `sorryAx` and no `Lean.ofReduceBool`. The analytic content — meromorphic continuation of ζ and its values at negative integers — is Mathlib's (`riemannZeta_neg_nat_eq_bernoulli`, `riemannZeta_neg_two_mul_nat_add_one`, `riemannZeta_zero`). The contribution here is the explicit closed-form evaluation of the classical regularized values, the trivial-zero family stated on the power index, and the rationality corollary. No new analysis is proved.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -51,7 +51,7 @@
       }
     ],
     "dateAdded": "2026-06-21",
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1
   },
   "overview": {
@@ -149,7 +149,7 @@
     "namespace": "ZetaRegularization",
     "lineCount": 140,
     "axiomCount": 0,
-    "theoremCount": 8,
+    "theoremCount": 9,
     "definitionCount": 1,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Integrity Issue (MEDIUM)

**Proof**: arithmetic-series-oq-03 — *Zeta Regularization: 1 + 2 + 3 + ⋯ = -1/12*
**Problem**: Badge overstates a Tier-B Mathlib-delegated result; minor theorem-count mismatch.

## Evidence

**Lean source** (`proofs/Proofs/ZetaRegularization.lean`, 140L, 0 sorries, 0 axioms, no `native_decide` — all verified clean):
- The headline `riemannZeta_neg_one` (ζ(-1) = -1/12) is a one-line specialization of Mathlib's `riemannZeta_neg_nat_eq_bernoulli 1` + `norm_num [bernoulli_two]`.
- *Every* theorem is a 2–5 line delegation to Mathlib's value formula `ζ(-k) = (-1)^k B_{k+1}/(k+1)` (and `riemannZeta_neg_two_mul_nat_add_one`, `riemannZeta_zero`). No independent analysis is proved.
- This is the textbook Tier-B / failure-mode-#5 pattern: "0 sorries but obtains its main result by calling a deep Mathlib theorem → badge must be `mathlib`, not `verified`."

**meta.json claimed**: `badge: "verified"`, `theoremCount: 8`.
**Actual**: 9 theorems (the `bernoulli_four` helper was uncounted).

To the gallery's credit, the `description`, `assumptions`, and the file's own "Scope / honesty" docstring already disclose the Mathlib delegation exemplarily ("No new analysis is proved"). The only artifact in tension was the public badge token.

## Fix applied

- `meta.badge`: `verified` → `mathlib` (aligns with the 561 mathlib-badged Tier-B entries and prior audits of analogous "headline = Mathlib specialization" proofs).
- `theoremCount`: 8 → 9 (both `meta` and `leanFile` blocks); `assumptions` "All eight theorems" → "All nine theorems".
- `status` left `verified` (0 axioms, 0 sorries, machine-checked — status reflects machine-checking, badge reflects originality).

---
Discovered during gallery integrity audit.
🤖 Generated with [Claude Code](https://claude.com/claude-code)