### PR TITLE
Enrich No Exotic Free Representations for Cyclic Groups

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-02/meta.json
@@ -42,7 +42,9 @@
     "keyInsights": [
       "Freeness of a cyclic linear action on the sphere is exactly coprimality of every rotation weight to the group order — a number-theoretic, not topological, condition once the weights are recorded.",
       "Coprimality localizes at primes: gcd(a,n)=1 iff a avoids every prime divisor of n, which is precisely the statement that freeness is detected on prime-order subgroups.",
-      "For prime powers the criterion collapses to a single prime, making the 'no exotic representation' phenomenon transparent."
+      "For prime powers the criterion collapses to a single prime, making the 'no exotic representation' phenomenon transparent.",
+      "The biconditional splits into a 'no exotic gain' direction (every free Z/n-rep restricts to a free Z/p-rep) and a converse assembly (prime-level freeness rebuilds Z/n-freeness), so the prime data is a complete invariant for the existence of free representations — not merely a necessary condition.",
+      "Necessity of the all-primes conjunction is sharp: the Z/6 weight a = (2) is free over Z/3 but not Z/2, so a failure at a single prime propagates to the composite group — the localization cannot be weakened to 'some prime'."
     ],
     "prerequisites": [
       "Cyclic group representations and rotation weights",


### PR DESCRIPTION
Enrichment pass for `borsuk-ulam-oq-02-oq-01-oq-02` (quality 39, pass 0).

## Gap addressed
The entry had a strong meta.json but **no annotations.json** — zero inline annotation coverage, the single biggest quality gap. (`index.ts` is not needed: the gallery loader reads meta.json + annotations.json at build time and only ~87/3246 legacy dirs still carry a per-proof shim.)

## Changes
- **Added `annotations.json` with 8 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  - Prime localization of coprimality (`coprime_iff_forall_prime_dvd`)
  - `IsFreeRep` — freeness as coprimality of rotation weights
  - `IsFreeAtPrime` — restriction to a prime-order subgroup
  - `isFreeRep_iff_forall_prime` — the main localization theorem
  - `restrict_prime` / `isFreeRep_of_forall_prime` — no-exotic-gain + converse assembly
  - `isFreeRep_prime_pow` — prime powers collapse to one prime
  - `isFreeRep_const_one` — the standard faithful rep is always free
  - `not_isFreeRep_example` — the Z/6 witness showing the all-primes conjunction is necessary
- **Deepened `overview.keyInsights`** from 3 to 5 (complete-invariant framing; sharpness of the all-primes conjunction).

## Verification
- `pnpm annotations:build` passes with **no warnings** for this proof (all annotation ranges resolve cleanly).
- meta.json and annotations.json are valid JSON.
- Axiom integrity unchanged: still `verified` / 0 axioms, consistent with the Lean source.