### PR TITLE
Audit: fix badge original→mathlib for arithmetic-series-oq-02-oq-04-oq-01-oq-01

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "stars-and-bars",
       "arithmetic-series"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `arithmetic-series-oq-02-oq-04-oq-01-oq-01` (Multiset-Coefficient / Rising Factorial Identity)
**Severity**: MEDIUM — Mathlib wrapper badged as `original`

## Problem

The entry is badged **`original`** (Tier A), but its headline theorem is a verbatim composition of two Mathlib lemmas:

```lean
theorem multichoose_factorial (n k : ℕ) :
    Nat.choose (n + k - 1) k * k.factorial = ∏ i ∈ range k, (n + i) := by
  rw [Nat.mul_comm, ← Nat.ascFactorial_eq_factorial_mul_choose',
      Nat.ascFactorial_eq_prod_range]
```

`Nat.ascFactorial_eq_factorial_mul_choose'` already states the identity in the `C(n+k-1,k)` form — the imported Mathlib theorem does the core work. The entry's own `description`, `proofStrategy`, and `keyInsights` already acknowledge this ("reduces to two Mathlib lemmas", "near-trivial composition once the right lemma is located", "good Mathlib naming collapses a textbook derivation to a one-line rewrite").

The remaining 10 theorems are trivial corollaries of the Mathlib-derived headline (divisibility, multiset/ascending duality, k=1/2/3 specializations, `decide` checks).

This matches auditor **failure-mode #5** (0 sorries but main result obtained via a Mathlib theorem) and the **Mathlib Wrapper Detection** rule.

## Evidence

- Headline = direct `rw` by `Nat.ascFactorial_eq_factorial_mul_choose'` + `Nat.ascFactorial_eq_prod_range`, both listed in `mathlibDependencies`.
- No in-file original mathematical content beyond locating/packaging the Mathlib lemma.

## Other checks (all clean)

- 11 theorems, 0 sorries, 0 `axiom` declarations, no `native_decide` (the 3 textual matches are all in comments). ✓ matches meta.
- `multiset_ascending_duality` imports `simplicial_product` from the grandparent, but that is a pure rewrite (no axiom leak), so the `0 axioms` claim holds. ✓
- `status: verified` retained — `verified/mathlib` is the gallery's standard pairing for Mathlib-bridge proofs.

## Fix

`meta.badge`: `"original"` → `"mathlib"`. Narrative text already discloses the delegation, so no further wording changes needed.

---
Discovered during gallery integrity audit.