### PR TITLE
Enrich No Greatest Cardinal (Cantor OQ-05)

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-05/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-05/annotations.json
@@ -1,0 +1,139 @@
+[
+  {
+    "id": "ann-cantor-oq05-engine",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 32, "endLine": 35 },
+    "type": "concept",
+    "title": "Cantor's Inequality as the Engine",
+    "content": "cantor_lt re-exports Mathlib's Cardinal.cantor: for every cardinal a, a < 2^a. This single strict inequality is the entire engine of the entry — everything downstream (unboundedness, the tower, injectivity) is a structural reading of repeatedly applying it. The diagonal argument that proves it lives in the base Cantor entry and OQ-03; here it is taken as given input.",
+    "mathContext": "$$a < 2^a \\quad \\text{for every cardinal } a.$$ Equivalently $|X| < |\\mathcal{P}(X)|$: there is no surjection $X \\twoheadrightarrow \\mathcal{P}(X)$ (Cantor's diagonal argument).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cantor's theorem",
+      "power set",
+      "diagonal argument",
+      "cardinal exponentiation"
+    ],
+    "prerequisites": [
+      "cardinality",
+      "power sets",
+      "strict order on cardinals"
+    ]
+  },
+  {
+    "id": "ann-cantor-oq05-exists-gt",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 37, "endLine": 39 },
+    "type": "concept",
+    "title": "Every Cardinal Is Exceeded",
+    "content": "exists_gt shows ∃ b, a < b by exhibiting the explicit witness b = 2^a. This is the constructive form of unboundedness: the proof does not merely assert that something larger exists, it hands you the power set cardinal. The whole tower built later is just this witness iterated.",
+    "mathContext": "$$\\forall a,\\ \\exists b,\\ a < b, \\qquad \\text{witness } b = 2^a.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "unbounded order",
+      "explicit witnesses",
+      "cofinality"
+    ],
+    "prerequisites": [
+      "existential witnesses",
+      "Cantor's inequality"
+    ]
+  },
+  {
+    "id": "ann-cantor-oq05-not-ismax",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 41, "endLine": 45 },
+    "type": "insight",
+    "title": "No Greatest Cardinal",
+    "content": "not_isMax proves ¬ IsMax a for every cardinal. The argument is a clean contradiction: if a were maximal, then applying maximality to a ≤ 2^a would force 2^a ≤ a, directly contradicting a < 2^a (cantor_lt). Thus the cardinals form an order with no top element — the order-theoretic heart of 'there is no largest set'.",
+    "mathContext": "$$\\neg\\,\\mathrm{IsMax}(a): \\quad \\text{maximality would give } a \\le 2^a \\Rightarrow 2^a \\le a, \\text{ contradicting } a < 2^a.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximal element",
+      "unbounded cardinals",
+      "proper class of cardinals",
+      "Cantor's paradox"
+    ],
+    "prerequisites": [
+      "IsMax in order theory",
+      "antisymmetry of <"
+    ]
+  },
+  {
+    "id": "ann-cantor-oq05-powtower-def",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 47, "endLine": 57 },
+    "type": "definition",
+    "title": "The Iterated-Powerset Tower",
+    "content": "powTower a n is defined as (c ↦ 2^c) iterated n times, starting from a — i.e. a, 2^a, 2^(2^a), …. powTower_zero (= a, by rfl) and powTower_succ (= 2^(powTower a n), via Function.iterate_succ_apply') pin down the recursion. Using Function.iterate rather than a hand-rolled recursor lets the whole monotonicity argument reduce to consecutive-rung comparisons.",
+    "mathContext": "$$\\mathrm{powTower}(a, n) = (2^{\\,\\cdot})^{[n]}(a), \\quad \\mathrm{powTower}(a,0)=a, \\quad \\mathrm{powTower}(a,n+1)=2^{\\mathrm{powTower}(a,n)}.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "function iteration",
+      "beth numbers",
+      "cumulative hierarchy",
+      "recursive sequences"
+    ],
+    "prerequisites": [
+      "Function.iterate",
+      "cardinal exponentiation"
+    ]
+  },
+  {
+    "id": "ann-cantor-oq05-strictmono",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 59, "endLine": 64 },
+    "type": "insight",
+    "title": "Tower Monotonicity Is Per-Rung Cantor, NOT Exponent Monotonicity",
+    "content": "powTower_strictMono is the subtle centerpiece. It proves StrictMono (powTower a) via strictMono_nat_of_lt_succ, which requires only the consecutive comparisons powTower a n < powTower a (n+1) = 2^(powTower a n) — each of which is cantor_lt applied freshly at the current rung. Crucially the proof makes NO use of monotonicity of c ↦ 2^c, i.e. the statement a < b → 2^a < 2^b, which is independent of ZFC (a GCH-adjacent question). The tower climbs because Cantor is re-applied at every level, not because exponentiation is order-preserving — a distinction that a careless proof would silently get wrong.",
+    "mathContext": "$$a < 2^a < 2^{2^a} < \\cdots, \\quad \\text{each step } x < 2^x \\text{ (Cantor at the rung } x=\\mathrm{powTower}(a,n)).$$ The global rule $a<b \\Rightarrow 2^a<2^b$ is NOT used and is in fact independent of ZFC.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict monotonicity from successor comparisons",
+      "generalized continuum hypothesis",
+      "independence from ZFC",
+      "cardinal exponentiation monotonicity"
+    ],
+    "prerequisites": [
+      "strictMono_nat_of_lt_succ",
+      "GCH and independence results",
+      "Cantor's inequality"
+    ]
+  },
+  {
+    "id": "ann-cantor-oq05-injective",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 66, "endLine": 70 },
+    "type": "concept",
+    "title": "All Rungs Are Distinct",
+    "content": "powTower_injective derives injectivity of the tower directly from strict monotonicity (StrictMono.injective). Combined with the ℕ-indexing, this exhibits infinitely many pairwise-distinct cardinals above a — concrete, constructive evidence for the abstract ¬ IsMax.",
+    "mathContext": "$$\\mathrm{StrictMono}(f) \\Rightarrow \\mathrm{Injective}(f): \\quad m \\ne n \\Rightarrow \\mathrm{powTower}(a,m) \\ne \\mathrm{powTower}(a,n).$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "injectivity from strict monotonicity",
+      "countably many distinct cardinals"
+    ],
+    "prerequisites": [
+      "StrictMono.injective",
+      "the tower's monotonicity"
+    ]
+  },
+  {
+    "id": "ann-cantor-oq05-lt-succ",
+    "proofId": "cantors-theorem-oq-05",
+    "range": { "startLine": 72, "endLine": 75 },
+    "type": "concept",
+    "title": "The Tower Escapes a Immediately",
+    "content": "lt_powTower_succ shows a < powTower a (n+1) for all n: every rung past the base strictly exceeds a. It follows by applying the tower's monotonicity to 0 < n+1 (with powTower a 0 = a). This confirms the tower not only rises but does so entirely above its starting cardinal — the witnesses for unboundedness all genuinely beat a.",
+    "mathContext": "$$a = \\mathrm{powTower}(a,0) < \\mathrm{powTower}(a,n+1) \\quad \\text{for all } n.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "strict monotonicity",
+      "explicit lower-bound escape"
+    ],
+    "prerequisites": [
+      "powTower_zero",
+      "the tower's monotonicity"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cantors-theorem-oq-05` (quality 39, pass 0).

## Gap addressed
The entry had a strong meta.json but **no annotations.json** — zero inline annotation coverage.

## Changes
- **Added `annotations.json` with 7 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering all 8 theorems and the `powTower` definition:
  - `cantor_lt` — Cantor's inequality as the engine
  - `exists_gt` — every cardinal is exceeded (witness 2^a)
  - `not_isMax` — no greatest cardinal
  - `powTower` (+ zero/succ) — the iterated-powerset tower
  - `powTower_strictMono` — the subtle centerpiece: monotonicity is per-rung Cantor, **not** the ZFC-independent monotonicity of c ↦ 2^c
  - `powTower_injective` — all rungs distinct
  - `lt_powTower_succ` — the tower escapes a immediately

## Verification
- `pnpm annotations:build` passes with **no warnings** for this proof (all ranges resolve).
- annotations.json is valid JSON.
- Axiom integrity unchanged: `verified` / mathlib badge / 0 axioms, consistent with the Lean source.