### PR TITLE
Enrich Unconditional |bracelets(4,2)|=6 (Burnside OQ-04-OQ-01)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-01/annotations.json
@@ -1,0 +1,148 @@
+[
+  {
+    "id": "ann-burnside-oq0401-carrier",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 62, "endLine": 66 },
+    "type": "definition",
+    "title": "Positions as ZMod 4, Colourings as ZMod 4 → Fin 2",
+    "content": "The four vertices of the square are modelled as Pos = ZMod 4 (so rotation is literally addition + i) and a binary colouring as Coloring = Pos → Fin 2, of which there are 2^4 = 16. Keeping every object Fin-based is a deliberate design choice: it is exactly what lets kernel decide later evaluate the action and the fixed-point counts cheaply, avoiding native_decide.",
+    "mathContext": "$$\\text{Pos} = \\mathbb{Z}/4\\mathbb{Z}, \\qquad \\text{Coloring} = (\\mathbb{Z}/4\\mathbb{Z} \\to \\mathrm{Fin}\\,2), \\quad |\\text{Coloring}| = 2^4 = 16.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cyclic group ZMod n",
+      "binary colourings",
+      "decidable equality",
+      "Fintype enumeration"
+    ],
+    "prerequisites": [
+      "ZMod arithmetic",
+      "function types as finite carriers"
+    ]
+  },
+  {
+    "id": "ann-burnside-oq0401-posperm",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 68, "endLine": 77 },
+    "type": "definition",
+    "title": "The Dihedral Permutation Representation on Vertices",
+    "content": "posPerm sends each dihedral element to a permutation of the four vertices: a rotation r i acts by x ↦ x + i (Equiv.addRight i) and a reflection sr i by x ↦ -i - x (Equiv.subLeft (-i)). The choice of -i - x rather than the geometrically tempting i - x is forced — it is precisely the form that makes posPerm a homomorphism under Mathlib's dihedral convention sr i * sr j = r (j - i). This concrete action is exactly what the parent oq-04 leaves unbuilt.",
+    "mathContext": "$$\\rho(r_i)(x) = x + i, \\qquad \\rho(s r_i)(x) = -i - x.$$ The reflection form $-i-x$ matches Mathlib's $sr_i \\cdot sr_j = r_{j-i}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "permutation representation",
+      "dihedral group",
+      "Equiv.addRight / Equiv.subLeft",
+      "faithful action"
+    ],
+    "prerequisites": [
+      "dihedral multiplication convention",
+      "permutations of a finite set",
+      "ZMod arithmetic"
+    ]
+  },
+  {
+    "id": "ann-burnside-oq0401-hom",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 79, "endLine": 103 },
+    "type": "technique",
+    "title": "posPerm Is a Homomorphism (Case-by-Case)",
+    "content": "posPerm_one shows the identity maps to the identity permutation, and posPerm_mul establishes multiplicativity by splitting into the four (r/sr)×(r/sr) cases against Mathlib's dihedral multiplication table (r_mul_r, r_mul_sr, sr_mul_r, sr_mul_sr); each case reduces after ext to a ZMod 4 arithmetic identity closed by simp/ring. These two facts bundle posPerm into the monoid homomorphism ρ : DihedralGroup 4 →* Equiv.Perm Pos, which is what makes the induced action genuinely associative.",
+    "mathContext": "$$\\rho(1) = \\mathrm{id}, \\qquad \\rho(g \\cdot h) = \\rho(g) \\circ \\rho(h), \\quad \\text{verified on each of } \\{r,sr\\}^2.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "monoid homomorphism",
+      "MonoidHom bundling",
+      "dihedral multiplication table",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "MonoidHom structure",
+      "Equiv.ext",
+      "dihedral relations"
+    ]
+  },
+  {
+    "id": "ann-burnside-oq0401-action",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 105, "endLine": 122 },
+    "type": "concept",
+    "title": "The Induced MulAction on Colourings",
+    "content": "The dihedral symmetry g relabels positions by ρ g, acting on a colouring by (g • c) p = c ((ρ g)⁻¹ p) — pull back the colour along the inverse permutation, the standard contravariant lift. one_smul and mul_smul reduce directly to ρ.map_one and ρ.map_mul, so the MulAction laws hold on the nose precisely because ρ is a homomorphism. smul_apply records the pointwise unfolding for the fixed-point computations.",
+    "mathContext": "$$(g \\cdot c)(p) = c\\big((\\rho g)^{-1} p\\big), \\quad 1 \\cdot c = c, \\quad (gh)\\cdot c = g\\cdot(h\\cdot c).$$ The inverse makes it a *left* action.",
+    "significance": "key",
+    "relatedConcepts": [
+      "group action on functions",
+      "contravariant pullback",
+      "MulAction laws",
+      "permutation of coordinates"
+    ],
+    "prerequisites": [
+      "left group actions",
+      "inverse of a permutation",
+      "ρ as a homomorphism"
+    ]
+  },
+  {
+    "id": "ann-burnside-oq0401-instances",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 124, "endLine": 144 },
+    "type": "technique",
+    "title": "Decidability and Fintype Infrastructure",
+    "content": "Burnside's lemma needs the fixed-point sets and the orbit quotient to be finite and computable. decFixed makes 'g • c = c' decidable (colourings have decidable equality), fintypeFixedBy gives each fixedBy a Fintype, and a DecidableRel on the orbit relation is built from mem_orbit_iff plus the finiteness of DihedralGroup 4. Together with Quotient.fintype this puts a (noncomputable) Fintype on the orbit quotient, so the bracelet count Fintype.card is well-defined.",
+    "mathContext": "$$\\text{Fix}(g) = \\{c : g\\cdot c = c\\}, \\quad a \\sim b \\iff \\exists g,\\ g\\cdot b = a \\ \\text{(decidable)}.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "DecidablePred / DecidableRel",
+      "Fintype instances",
+      "orbit relation",
+      "quotient by a setoid"
+    ],
+    "prerequisites": [
+      "decidable equality",
+      "Setoid and Quotient",
+      "mem_orbit_iff"
+    ]
+  },
+  {
+    "id": "ann-burnside-oq0401-fixedsum",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 146, "endLine": 157 },
+    "type": "insight",
+    "title": "The Fixed-Point Sum = 48 by Kernel decide",
+    "content": "fixed_point_sum is the heart of the unconditional count: it tallies, over all eight dihedral symmetries, how many of the 16 colourings each fixes — 16+2+4+2 = 24 from the rotations and 8+8+4+4 = 24 from the reflections, total 48. Crucially it is discharged by kernel decide (8 × 16 light checks over Fin-based data), NOT native_decide, so it introduces no Lean.ofReduceBool axiom. This single sum subsumes both hypotheses the parent assumed — the necklace contribution and the reflection total.",
+    "mathContext": "$$\\sum_{g \\in D_4} |\\mathrm{Fix}(g)| = \\underbrace{16+2+4+2}_{\\text{rotations}=24} + \\underbrace{8+8+4+4}_{\\text{reflections}=24} = 48.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Burnside fixed-point sum",
+      "kernel decide vs native_decide",
+      "Lean.ofReduceBool",
+      "axiom-free computation"
+    ],
+    "prerequisites": [
+      "fixedBy and Fintype.card",
+      "kernel reduction",
+      "finite summation over a Fintype"
+    ]
+  },
+  {
+    "id": "ann-burnside-oq0401-count",
+    "proofId": "burnside-counting-oq-04-oq-01",
+    "range": { "startLine": 159, "endLine": 174 },
+    "type": "insight",
+    "title": "Unconditional |bracelets(4,2)| = 6 via Burnside",
+    "content": "binary_four_bracelet_unconditional is the headline. Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) equates the fixed-point sum with |bracelets| · |D₄|; rewriting with fixed_point_sum (= 48) and DihedralGroup.card (|D₄| = 8) gives 48 = |bracelets| · 8, which omega closes as |bracelets| = 6. No necklace count or reflection total is assumed — contrast the parent's binary_four_bracelet_count, which takes both as hypotheses. The orbit quotient is never enumerated; only the cheap fixed-point sum is, which keeps the whole proof within kernel reach and axiom-free (#print axioms shows only propext / Classical.choice / Quot.sound).",
+    "mathContext": "$$\\sum_{g \\in D_4} |\\mathrm{Fix}(g)| = |\\text{bracelets}| \\cdot |D_4| \\;\\Rightarrow\\; 48 = |\\text{bracelets}| \\cdot 8 \\;\\Rightarrow\\; |\\text{bracelets}| = 6.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Burnside's lemma (Cauchy-Frobenius)",
+      "bracelet numbers (OEIS A000029)",
+      "orbit counting",
+      "unconditional / axiom-free proof"
+    ],
+    "prerequisites": [
+      "Burnside's lemma",
+      "DihedralGroup.card",
+      "omega arithmetic"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04-oq-01` (quality 39, pass 0).

## Gap addressed
Strong meta.json but **no annotations.json** — zero inline annotation coverage.

## Changes
- **Added `annotations.json` with 7 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, covering:
  - Carrier types (Pos = ZMod 4, Coloring = ZMod 4 → Fin 2)
  - `posPerm` — the dihedral permutation representation (and why reflections are -i-x)
  - The homomorphism check (`posPerm_one`, `posPerm_mul`, bundled `ρ`)
  - The induced `MulAction` on colourings
  - Decidability / Fintype infrastructure for Burnside
  - `fixed_point_sum` — the kernel-`decide`d sum = 48 (no native_decide, no Lean.ofReduceBool)
  - `binary_four_bracelet_unconditional` — the unconditional |bracelets| = 6

## Verification
- `pnpm annotations:build` passes with **no warnings** for this proof.
- annotations.json is valid JSON.
- Axiom integrity unchanged: `verified` / 0 axioms / kernel-decide only, consistent with the Lean source.