### PR TITLE
Enrich Catalan Numbers: the O(1) Linear Recurrence

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-cat-oq01-statement",
+    "proofId": "catalan-numbers-oq-01",
+    "range": { "startLine": 26, "endLine": 32 },
+    "type": "insight",
+    "title": "The first-order (holonomic) recurrence",
+    "content": "The headline gap filled: $(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$. Mathlib provides only the quadratic Segner convolution $C_{n+1} = \\sum_i C_i C_{n-i}$ (\\(O(n)\\) work per term) and the closed form $C_n = \\binom{2n}{n}/(n+1)$, but not this first-order recurrence — the modern computational form that determines each Catalan number from its single predecessor in $O(1)$ operations and exhibits the sequence as holonomic (P-recursive) of order one.",
+    "mathContext": "$(n+2)\\,C_{n+1} = 2(2n+1)\\,C_n$ — first-order, versus Segner's quadratic $C_{n+1} = \\sum_{i=0}^{n} C_i\\,C_{n-i}$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "holonomic / P-recursive sequences", "Segner convolution recurrence", "enumerative combinatorics"],
+    "prerequisites": ["the Catalan numbers", "linear recurrence relations"]
+  },
+  {
+    "id": "ann-cat-oq01-bridge",
+    "proofId": "catalan-numbers-oq-01",
+    "range": { "startLine": 33, "endLine": 39 },
+    "type": "technique",
+    "title": "Bridge to central binomial coefficients",
+    "content": "No induction is needed: the recurrence is inherited from the central binomial coefficients via Mathlib's bridge $\\,(n+1)\\,C_n = B_n\\,$ (succ_mul_catalan_eq_centralBinom, where $B_n = \\binom{2n}{n}$). Instantiating it at $n+1$ gives $(n+2)\\,C_{n+1} = B_{n+1}$ (h1) and at $n$ gives $(n+1)\\,C_n = B_n$ (h3), while the central binomials carry their own first-order recurrence $(n+1)\\,B_{n+1} = 2(2n+1)\\,B_n$ (h2, Nat.succ_mul_centralBinom_succ) — the analytic heart the Catalan version is the image of.",
+    "mathContext": "$(n+1)\\,C_n = B_n,\\qquad (n+1)\\,B_{n+1} = 2(2n+1)\\,B_n,\\qquad B_n = \\binom{2n}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "Catalan–central-binomial identity", "recurrence inheritance"],
+    "prerequisites": ["succ_mul_catalan_eq_centralBinom", "Nat.succ_mul_centralBinom_succ"]
+  },
+  {
+    "id": "ann-cat-oq01-cancel",
+    "proofId": "catalan-numbers-oq-01",
+    "range": { "startLine": 40, "endLine": 48 },
+    "type": "technique",
+    "title": "Clear denominators over ℕ, then cancel",
+    "content": "The crux of keeping everything in $\\mathbb{N}$ (no cast to $\\mathbb{Q}$): linking the two indices of the bridge forces a spare factor $n+1$, so the goal is multiplied through by it. The calc chain rewrites $(n+1)(n+2)C_{n+1}$ to $(n+1)B_{n+1}$ (h1), to $2(2n+1)B_n$ (h2), to $2(2n+1)(n+1)C_n$ (h3), and finally reassociates to $(n+1)\\cdot 2(2n+1)C_n$ by ring. The common positive factor $n+1$ is then cancelled with Nat.eq_of_mul_eq_mul_left, yielding the recurrence exactly.",
+    "mathContext": "$(n+1)\\big[(n+2)C_{n+1}\\big] = (n+1)\\big[2(2n+1)C_n\\big] \\;\\xRightarrow{\\text{cancel } n+1}\\; (n+2)C_{n+1} = 2(2n+1)C_n$",
+    "significance": "supporting",
+    "relatedConcepts": ["left cancellation", "natural-number arithmetic", "calc proofs", "ring normalization"],
+    "prerequisites": ["Nat.eq_of_mul_eq_mul_left", "ring tactic"]
+  },
+  {
+    "id": "ann-cat-oq01-division",
+    "proofId": "catalan-numbers-oq-01",
+    "range": { "startLine": 50, "endLine": 56 },
+    "type": "concept",
+    "title": "Exact-division corollary (the O(1) step)",
+    "content": "The recurrence solved for the next term: $C_{n+1} = 2(2n+1)\\,C_n / (n+2)$ with truncating $\\mathbb{N}$ division. The division is provably exact — not assumed — because $n+2$ divides the numerator (which equals $(n+2)\\,C_{n+1}$ by the recurrence), certified by Nat.mul_div_cancel_left. This is the explicit constant-time step used to generate the sequence one term at a time.",
+    "mathContext": "$C_{n+1} = \\dfrac{2(2n+1)\\,C_n}{n+2}$ — exact over $\\mathbb{N}$ since $(n+2) \\mid 2(2n+1)C_n$",
+    "significance": "supporting",
+    "relatedConcepts": ["exact division", "truncating ℕ division", "computational generation"],
+    "prerequisites": ["Nat.mul_div_cancel_left", "the linear recurrence"]
+  },
+  {
+    "id": "ann-cat-oq01-check",
+    "proofId": "catalan-numbers-oq-01",
+    "range": { "startLine": 58, "endLine": 63 },
+    "type": "context",
+    "title": "Numeric sanity check, derived not decided",
+    "content": "A worked check that the recurrence reproduces $C_4 = 14$ from $C_3 = 5$ in one step: instantiate the recurrence at $n=3$, substitute catalan_three, and close with omega. Notably this is derived through the recurrence theorem rather than by kernel decide or native_decide, keeping the file free of the Lean.ofReduceBool axiom.",
+    "mathContext": "$(3+2)\\,C_4 = 2(2\\cdot 3 + 1)\\,C_3 \\Rightarrow 5\\,C_4 = 14\\cdot 5 \\Rightarrow C_4 = 14$",
+    "significance": "context",
+    "relatedConcepts": ["sanity check", "axiom-free numerics", "catalan_three"],
+    "prerequisites": ["the linear recurrence", "omega"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01`.

The entry had a rich `meta.json` but **no `annotations.json`**. This PR adds it.

## Changes
- **Added `annotations.json`** with 5 annotations covering the full 63-line Lean file:
  - the first-order recurrence statement $(n+2)C_{n+1}=2(2n+1)C_n$ and why it's a genuine gap vs Mathlib's Segner convolution / closed form
  - the central-binomial bridge (`succ_mul_catalan_eq_centralBinom`, `Nat.succ_mul_centralBinom_succ`) that supplies the recurrence with no induction
  - the multiply-by-$(n+1)$ / cancel derivation keeping everything in ℕ
  - the exact-division corollary `catalan_succ_eq_div`
  - the axiom-free numeric check ($C_4=14$ derived, not `decide`d)
- Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- JSON validates; `pnpm annotations:build` resolves every annotation line range against a Lean construct with **no warnings** for this proof.
- No content removed.