### PR TITLE
Enrich Weyl's Eigenvalue Inequalities (Cauchy Interlacing OQ-03)

### DIFF
--- a/src/data/proofs/cauchy-interlacing-theorem-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-interlacing-theorem-oq-03/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-weyl-oq03-grassmann",
+    "proofId": "cauchy-interlacing-theorem-oq-03",
+    "range": { "startLine": 49, "endLine": 61 },
+    "type": "technique",
+    "title": "Grassmann Lower Bound for an Intersection",
+    "content": "finrank_inf_lb is the reusable dimension-counting tool: finrank(P ⊓ Q) ≥ finrank P + finrank Q − finrank E. It drops straight out of the Grassmann identity finrank(P ⊔ Q) + finrank(P ⊓ Q) = finrank P + finrank Q together with finrank(P ⊔ Q) ≤ finrank E, closed by omega. Applied twice it produces the triple-intersection count that guarantees a common nonzero vector in Weyl's additive inequality.",
+    "mathContext": "$$\\dim(P \\cap Q) \\ge \\dim P + \\dim Q - \\dim E, \\quad \\text{from } \\dim(P+Q) + \\dim(P\\cap Q) = \\dim P + \\dim Q.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Grassmann dimension formula",
+      "subspace intersection",
+      "dimension counting",
+      "finrank"
+    ],
+    "prerequisites": [
+      "finite-dimensional vector spaces",
+      "Submodule.finrank_sup_add_finrank_inf_eq"
+    ]
+  },
+  {
+    "id": "ann-weyl-oq03-upper-eigenspan",
+    "proofId": "cauchy-interlacing-theorem-oq-03",
+    "range": { "startLine": 63, "endLine": 79 },
+    "type": "concept",
+    "title": "Upper-Tail Eigenspan Rayleigh Ceiling",
+    "content": "rayleigh_le_on_upper_eigenspan is the dual of the keystone's lower eigenspan bound: for antitone μ, every nonzero vector in the eigenspan span{b i, …, b (n-1)} (indices ≥ i) has Rayleigh quotient ≤ μ i. The ceiling is μ i because the supremum of an antitone μ over Finset.Ici i is attained at the left endpoint i (Finset.sup'_le). This is the eigenspan bound on which the additive inequality runs — restricting to the top-end eigenvectors caps the Rayleigh quotient.",
+    "mathContext": "$$x \\in \\mathrm{span}\\{b_i,\\dots,b_{n-1}\\},\\ x\\ne 0 \\;\\Rightarrow\\; \\frac{\\mathrm{re}\\langle Tx,x\\rangle}{\\|x\\|^2} \\le \\mu_i \\quad (\\mu \\text{ antitone}).$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Rayleigh quotient",
+      "eigenspan",
+      "antitone eigenvalue enumeration",
+      "Courant-Fischer keystone"
+    ],
+    "prerequisites": [
+      "Rayleigh quotients",
+      "spanning sets of eigenvectors",
+      "supremum over a finite set"
+    ]
+  },
+  {
+    "id": "ann-weyl-oq03-monotone",
+    "proofId": "cauchy-interlacing-theorem-oq-03",
+    "range": { "startLine": 81, "endLine": 112 },
+    "type": "insight",
+    "title": "Weyl Monotonicity: Lower-into-Upper Pairing",
+    "content": "weyl_monotone proves that eigenvalues are monotone in the Loewner order: if re⟪Tx,x⟫ ≤ re⟪Ux,x⟫ for all x (T ⪯ U) then μ k ≤ ν k for every descending index k. The proof is the cleanest possible Courant–Fischer corollary — a single pairing of the keystone's two halves on the same subspace: eigenvalue_maxmin_lower gives an optimal (k+1)-dimensional S on which μ k ≤ R_T; eigenvalue_maxmin_upper applied to U on that same S yields a nonzero witness x with R_U(x) ≤ ν k; and dividing the Loewner hypothesis by ‖x‖² > 0 gives R_T(x) ≤ R_U(x). Chaining: μ k ≤ R_T(x) ≤ R_U(x) ≤ ν k.",
+    "mathContext": "$$T \\preceq U \\;\\Rightarrow\\; \\mu_k \\le R_T(x) \\le R_U(x) \\le \\nu_k \\;\\Rightarrow\\; \\mu_k \\le \\nu_k.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Weyl monotonicity",
+      "Loewner order",
+      "Courant-Fischer min-max",
+      "Rayleigh comparison"
+    ],
+    "prerequisites": [
+      "eigenvalue_maxmin_lower / eigenvalue_maxmin_upper",
+      "the Loewner order",
+      "Rayleigh quotient division"
+    ]
+  },
+  {
+    "id": "ann-weyl-oq03-additive",
+    "proofId": "cauchy-interlacing-theorem-oq-03",
+    "range": { "startLine": 114, "endLine": 185 },
+    "type": "insight",
+    "title": "Weyl's Additive Inequality: A Double Grassmann Count",
+    "content": "weyl_add_le proves the classical λ_{i+j+1}(A+B) ≤ λ_{i+1}(A) + λ_{j+1}(B) in 0-based descending form: for i + j ≤ k, ρ k ≤ μ i + ν j. The optimal (k+1)-dimensional subspace S for T+U (lower keystone half) is intersected with the upper-tail eigenspans A = span{b i,…} (dim n−i) and B = span{c j,…} (dim n−j); applying finrank_inf_lb twice gives finrank(S ⊓ A ⊓ B) ≥ (k+1) − i − j ≥ 1, so the triple intersection contains a nonzero x. On it the one genuinely new ingredient over interlacing — Rayleigh additivity R_{T+U}(x) = R_T(x) + R_U(x) (LinearMap.add_apply + inner_add_left + map_add) — combines with the two eigenspan ceilings to give ρ k ≤ R_{T+U}(x) = R_T(x) + R_U(x) ≤ μ i + ν j.",
+    "mathContext": "$$\\dim(S \\cap A \\cap B) \\ge (k+1) - i - j \\ge 1, \\qquad \\rho_k \\le R_{T+U}(x) = R_T(x) + R_U(x) \\le \\mu_i + \\nu_j.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Weyl's inequality",
+      "eigenvalue perturbation",
+      "Rayleigh additivity",
+      "subspace intersection counting"
+    ],
+    "prerequisites": [
+      "finrank_inf_lb",
+      "upper-tail eigenspan bound",
+      "Rayleigh additivity",
+      "eigenvalue_maxmin_lower"
+    ]
+  },
+  {
+    "id": "ann-weyl-oq03-rayleigh-add",
+    "proofId": "cauchy-interlacing-theorem-oq-03",
+    "range": { "startLine": 174, "endLine": 185 },
+    "type": "technique",
+    "title": "Rayleigh Additivity: the One New Ingredient",
+    "content": "The algebraic heart distinguishing the additive inequality from plain interlacing: the Rayleigh quotient is additive over a sum of operators, R_{T+U}(x) = R_T(x) + R_U(x). It follows from LinearMap.add_apply ((T+U)x = Tx + Ux), inner_add_left (⟪Tx+Ux, x⟫ = ⟪Tx,x⟫ + ⟪Ux,x⟫), and additivity of RCLike.re (map_add), then dividing through by ‖x‖². This single fact, plus intersecting with two eigenspans instead of one, is the entire delta from Cauchy interlacing to Weyl's perturbation bound — no new spectral theory.",
+    "mathContext": "$$\\frac{\\mathrm{re}\\langle (T+U)x, x\\rangle}{\\|x\\|^2} = \\frac{\\mathrm{re}\\langle Tx,x\\rangle}{\\|x\\|^2} + \\frac{\\mathrm{re}\\langle Ux,x\\rangle}{\\|x\\|^2}.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Rayleigh quotient",
+      "sesquilinear additivity",
+      "inner_add_left",
+      "operator sum"
+    ],
+    "prerequisites": [
+      "inner product linearity",
+      "RCLike.re additivity"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cauchy-interlacing-theorem-oq-03` (quality 39, pass 0).

## Gap addressed
Strong meta.json (4 keyInsights, 2 openQuestions, crossRefs) but **no annotations.json** — zero inline coverage.

## Changes
- **Added `annotations.json` with 5 annotations** (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering:
  - `finrank_inf_lb` — the Grassmann intersection lower bound
  - `rayleigh_le_on_upper_eigenspan` — the upper-tail eigenspan Rayleigh ceiling
  - `weyl_monotone` — Weyl monotonicity as a single lower-into-upper keystone pairing
  - `weyl_add_le` — Weyl's additive inequality as a double Grassmann count
  - Rayleigh additivity — the one new ingredient over Cauchy interlacing

## Verification
- `pnpm annotations:build` passes with **no warnings** for this proof.
- annotations.json is valid JSON.
- Axiom integrity unchanged: `verified` / original badge / 0 axioms.