### PR TITLE
Fix basel-problem-oq-03 meta: theoremCount 13→19

### DIFF
--- a/src/data/proofs/basel-problem-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-03/meta.json
@@ -66,7 +66,7 @@
     "lineCount": 177,
     "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries; no native_decide. The double zeta value ζ(2,2) is recorded via its stuffle-relation value (ζ(2)² − ζ(4))/2; the underlying stuffle identity ζ(2)² = ζ(4) + 2ζ(2,2) is stated as the motivation rather than proved from the double sum.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 19,
     "definitionCount": 0
   },
   "overview": {
@@ -151,7 +151,7 @@
     "namespace": "BaselProblemOQ03",
     "lineCount": 177,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 19,
     "definitionCount": 0,
     "path": "Proofs/BaselProblemOQ03.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: basel-problem-oq-03 (Multiple Zeta Values: Relationship to Single Zeta Values)

### Issue found
`theoremCount` understated as **13**; the Lean file `Proofs/BaselProblemOQ03.lean` actually contains **19** theorems.

```
$ grep -cE '^(private )?(theorem|lemma) ' proofs/Proofs/BaselProblemOQ03.lean
19
```

Corrected both `meta.theoremCount` and `leanFile.theoremCount` to 19.

### Everything else verified clean
- **0 sorries**, **0 axiom declarations**, **no native_decide** (the single `native_decide` grep hit is the line-45 docstring "no native_decide" — false positive)
- **Badge `mathlib` correct** (Tier B): closed forms ζ(2),ζ(4),ζ(6),ζ(8) come from Mathlib's `hasSum_zeta_nat`/`hasSum_zeta_two`/`hasSum_zeta_four`; B₆=1/42, B₈=−1/30 computed in-file from `bernoulli'_def`; product relations are honest one-line `ring` steps.
- **All claims numerically correct**: ζ(2)²=(5/2)ζ(4), ζ(2)·ζ(4)=(7/4)ζ(6), ζ(2)³=(35/8)ζ(6), ζ(4)²=(7/6)ζ(8), ζ(2)·ζ(6)=(5/3)ζ(8), and ζ(2,2)=(ζ(2)²−ζ(4))/2=π⁴/120=(3/4)ζ(4) all check out.
- **`assumptions` honest**: discloses ζ(2,2) is recorded via its stuffle-forced value, not derived from the double sum.

Severity: LOW (metadata count only; no credibility-affecting overclaim).

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)