### PR TITLE
Enrich Closure of ℵ₀ (Denumerability of Rationals OQ-05)

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-05/annotations.json
@@ -1,0 +1,84 @@
+[
+  {
+    "id": "ann-denum-oq05-engine",
+    "proofId": "denumerability-rationals-oq-05",
+    "range": { "startLine": 30, "endLine": 33 },
+    "type": "concept",
+    "title": "#ℚ = ℵ₀: The Engine",
+    "content": "mk_rat re-exports Cardinal.mk_eq_aleph0 for ℚ: since the rationals are countable and infinite, their cardinality is exactly ℵ₀. This single fact — Cantor's 1874 denumerability of ℚ — is the engine for every result in the file: each downstream cardinality reduces to ℵ₀-arithmetic once the rational factors are rewritten via mk_rat.",
+    "mathContext": "$$\\#\\mathbb{Q} = \\aleph_0 \\quad (\\mathbb{Q} \\text{ countable and infinite}).$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "denumerability",
+      "aleph-null",
+      "countable infinite types",
+      "Cantor's enumeration of ℚ"
+    ],
+    "prerequisites": [
+      "Cardinal.mk_eq_aleph0",
+      "countable vs infinite"
+    ]
+  },
+  {
+    "id": "ann-denum-oq05-product",
+    "proofId": "denumerability-rationals-oq-05",
+    "range": { "startLine": 35, "endLine": 48 },
+    "type": "insight",
+    "title": "Finite Products Preserve ℵ₀ — and a Bijection ℚ × ℚ ≃ ℚ",
+    "content": "mk_rat_prod shows #(ℚ × ℚ) = ℵ₀: mk_prod rewrites to #ℚ · #ℚ (lifts vanish via lift_id), mk_rat makes each factor ℵ₀, and aleph0_mul_aleph0 collapses ℵ₀ · ℵ₀ = ℵ₀ — the ℵ₀-analogue of the continuum law 𝔠 · 𝔠 = 𝔠. mk_rat_prod_eq_mk_rat restates this as #(ℚ × ℚ) = #ℚ, and nonempty_equiv_prod_rat unpacks the cardinal equality via Cardinal.eq into an actual bijection ℚ × ℚ ≃ ℚ — the rational pairing function, the ℵ₀ shadow of Cantor's line-plane bijection.",
+    "mathContext": "$$\\#(\\mathbb{Q}\\times\\mathbb{Q}) = \\aleph_0\\cdot\\aleph_0 = \\aleph_0 = \\#\\mathbb{Q}, \\qquad \\mathbb{Q}\\times\\mathbb{Q} \\simeq \\mathbb{Q}.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "aleph0_mul_aleph0",
+      "cardinal product",
+      "line-plane bijection",
+      "Cardinal.eq"
+    ],
+    "prerequisites": [
+      "mk_prod",
+      "aleph0_mul_aleph0",
+      "Cardinal.eq (cardinality ⟹ bijection)"
+    ]
+  },
+  {
+    "id": "ann-denum-oq05-list-finset",
+    "proofId": "denumerability-rationals-oq-05",
+    "range": { "startLine": 50, "endLine": 58 },
+    "type": "concept",
+    "title": "Finite Sequences and Finite Subsets Stay ℵ₀",
+    "content": "mk_list_rat gives #(List ℚ) = ℵ₀ directly from mk_list_eq_aleph0 (finite sequences of a countable nonempty type remain denumerable). mk_finset_rat gives #(Finset ℚ) = ℵ₀ via mk_finset_of_infinite (finite subsets of an infinite type match its cardinality), then mk_rat. Together with the product result they show ℵ₀ absorbs every FINITE operation — lists and finsets both bundle finitely much data, so they cannot escape ℵ₀.",
+    "mathContext": "$$\\#(\\mathrm{List}\\,\\mathbb{Q}) = \\aleph_0, \\qquad \\#(\\mathrm{Finset}\\,\\mathbb{Q}) = \\#\\mathbb{Q} = \\aleph_0.$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "finite sequences",
+      "finite subsets",
+      "mk_list_eq_aleph0",
+      "mk_finset_of_infinite"
+    ],
+    "prerequisites": [
+      "cardinality of List / Finset",
+      "mk_rat"
+    ]
+  },
+  {
+    "id": "ann-denum-oq05-boundary",
+    "proofId": "denumerability-rationals-oq-05",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "insight",
+    "title": "The Boundary: ℕ → ℚ Is the Continuum",
+    "content": "mk_seq_rat is where ℵ₀-absorption breaks: #(ℕ → ℚ) = 𝔠. mk_arrow rewrites the function-type cardinality to #ℚ ^ #ℕ = ℵ₀ ^ ℵ₀, which aleph0_power_aleph0 collapses to the continuum 𝔠 — a countably infinite POWER, unlike the finite operations above, escapes ℵ₀. not_countable_seq_rat then concludes ℕ → ℚ is uncountable: mk_le_aleph0_iff turns countability into #(ℕ → ℚ) ≤ ℵ₀, refuted by mk_seq_rat together with aleph0_lt_continuum (ℵ₀ < 𝔠). This makes Cantor's gap operational — an uncountable set built entirely from the rationals.",
+    "mathContext": "$$\\#(\\mathbb{N}\\to\\mathbb{Q}) = \\aleph_0^{\\aleph_0} = \\mathfrak{c} > \\aleph_0 \\;\\Rightarrow\\; \\mathbb{N}\\to\\mathbb{Q} \\text{ uncountable}.$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "aleph0_power_aleph0",
+      "continuum",
+      "Cantor's diagonal gap ℵ₀ < 𝔠",
+      "cardinal exponentiation"
+    ],
+    "prerequisites": [
+      "mk_arrow",
+      "aleph0_power_aleph0",
+      "aleph0_lt_continuum"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-05` (quality 39, pass 0).

## Gap addressed
Rich meta.json (4 keyInsights, 2 openQuestions, sections, crossRefs) but **no annotations.json**.

## Changes
- **Added `annotations.json` with 4 annotations** (`mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  - `mk_rat` — #ℚ = ℵ₀, the engine
  - `mk_rat_prod` + bijection — finite products preserve ℵ₀, with ℚ×ℚ ≃ ℚ
  - `mk_list_rat` / `mk_finset_rat` — finite sequences/subsets stay ℵ₀
  - `mk_seq_rat` / `not_countable_seq_rat` — the boundary: ℕ→ℚ has cardinality 𝔠

## Verification
- annotations.json is valid JSON; all range start lines anchor to `/--` docstring constructs (verified against source).
- Axiom integrity unchanged: `verified` / mathlib badge / 0 axioms.

_Note: full `pnpm annotations:build` skipped — host disk at 100%; ranges validated against the proven docstring-anchor pattern._