### PR TITLE
Gallery integrity: JCD decomposition badge verified→mathlib (Tier B wrapper)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01-oq-02/meta.json
@@ -17,11 +17,11 @@
       "nilpotent",
       "perfect-field"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-21",
     "axiomCount": 0,
-    "assumptions": "None. The results are fully machine-checked over an arbitrary perfect field K and a finite-dimensional K-vector space V; #print axioms reports only propext, Classical.choice, Quot.sound.",
+    "assumptions": "None beyond Mathlib. The results are fully machine-checked over an arbitrary perfect field K and a finite-dimensional K-vector space V; #print axioms reports only propext, Classical.choice, Quot.sound. The existence half (the decomposition itself) is obtained via Mathlib's Newton-iteration theorem Module.End.exists_isNilpotent_isSemisimple, and uniqueness is assembled from Mathlib's IsSemisimple.sub_of_commute and eq_zero_of_isNilpotent_isSemisimple; this file contributes the explicit polynomial-in-f witnesses, the commutation lemmas, and the packaged ExistsUnique statement (which Mathlib leaves as a TODO).",
     "lineCount": 129,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Integrity Issue

**Proof**: cayley-hamilton-minpoly-oq-01-oq-02 (The Jordan–Chevalley–Dunford Decomposition)
**Problem**: Tier B proof carries badge `verified`, overstating independence.

## Evidence

**meta.json claimed**: `badge: "verified"` — presents the result as independent verification.

**Lean source shows** (`Proofs/CayleyHamiltonMinpolyOQ01OQ02.lean`):
- The headline existence theorem `jordan_chevalley_decomposition` is a **direct wrapper** of Mathlib's `Module.End.exists_isNilpotent_isSemisimple` (the Newton-iteration JordanChevalley theorem) — the file only extracts polynomial-in-`f` witnesses.
- Uniqueness is assembled from Mathlib's `IsSemisimple.sub_of_commute` + `eq_zero_of_isNilpotent_isSemisimple`.
- This is the classic **Tier B** pattern (core argument relies on a Mathlib theorem; our file provides bridge/packaging). Per the auditor wrapper rule #5, the badge must be `mathlib`, not `verified`.

## Fix

- `badge`: `verified` → `mathlib`
- `assumptions`: noted the Mathlib bridge dependency (existence via `exists_isNilpotent_isSemisimple`, uniqueness via `IsSemisimple.sub_of_commute`) and what this file genuinely contributes (explicit witnesses, commutation lemmas, the `ExistsUnique` packaging that Mathlib leaves as a TODO).
- `status` stays `verified` (machine-checked, 0 axioms, 0 sorries).

## Counts verified exact
5 theorems / 0 defs / 0 sorries / 0 axioms / 129 lines / native_decide=0 (so `Lean.ofReduceBool`-free → 0-axiom claim credible).

The narrative (description/overview/proofStrategy/keyInsights) already credits Mathlib exemplarily — there is **no delegation opacity**. This PR only corrects the public badge label.

---
Discovered during gallery integrity audit.