### PR TITLE
Enrich Closure and Path-Connectedness: add annotations layer

### DIFF
--- a/src/data/proofs/connected-space-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/connected-space-oq-01-oq-01/annotations.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 5,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "The Negative/Positive Dichotomy",
+    "content": "The module docstring frames the whole file as the path-connected analogue of the parent entry's closure-stability theorems. Because path-connectedness is strictly stronger than connectedness, closure cannot in general preserve it — the topologist's sine curve is the canonical witness. The split is therefore into a negative half (every parent theorem weakens by exactly one notch: the conclusion drops from path-connected to merely connected) and a positive half (local path-connectedness, which makes path components clopen, is precisely the extra hypothesis that restores closure-stability).",
+    "mathContext": "Path-connected $\\Rightarrow$ connected, but not conversely; closure $\\overline{(\\cdot)}$ preserves connectedness yet can destroy path-connectedness.",
+    "significance": "context",
+    "relatedConcepts": ["path-connectedness", "connectedness", "closure", "topologist's sine curve", "local path-connectedness"],
+    "prerequisites": ["topological spaces", "closure and dense subsets"]
+  },
+  {
+    "id": "ann-closure-pathconnected",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 61,
+      "endLine": 66
+    },
+    "type": "insight",
+    "title": "Closure of a Path-Connected Set Is Connected",
+    "content": "isConnected_closure_of_isPathConnected composes two robust facts: IsPathConnected.isConnected drops the hypothesis to connectedness, and IsConnected.closure then propagates connectedness across the closure. The conclusion is deliberately only IsConnected, not IsPathConnected — the closure may add points (like the limiting segment of the sine curve) reachable through limits but not through any continuous path. This is the first and sharpest instance of the 'weaken by one notch' principle.",
+    "mathContext": "If $s$ is path-connected then $\\overline{s}$ is connected; in general $\\overline{s}$ need not be path-connected, e.g. $S = \\{(x,\\sin(1/x)) : x>0\\}$ with $\\overline{S}$ adding $\\{0\\}\\times[-1,1]$.",
+    "significance": "key",
+    "relatedConcepts": ["path-connected set", "connected set", "closure", "topologist's sine curve"],
+    "prerequisites": ["path-connected and connected sets", "closure"]
+  },
+  {
+    "id": "ann-bark-tree",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 75
+    },
+    "type": "concept",
+    "title": "Bark and Tree, Path Version",
+    "content": "isConnected_of_isPathConnected_subset_closure is the sharp form: ANY set t wedged between a path-connected core s and its closure inherits connectedness, not just t = closure s. It is the honest path analogue of the parent's connected_of_subset_closure — 'honest' because the conclusion is weakened from path-connected to connected, faithfully reflecting that path-connectedness genuinely fails to survive. The full-closure theorem above is the special case t = closure s.",
+    "mathContext": "If $s$ is path-connected and $s \\subseteq t \\subseteq \\overline{s}$, then $t$ is connected.",
+    "significance": "supporting",
+    "relatedConcepts": ["sandwich principle", "closure", "preconnectedness"],
+    "prerequisites": ["closure", "subset relations"]
+  },
+  {
+    "id": "ann-dense",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 77,
+      "endLine": 85
+    },
+    "type": "insight",
+    "title": "Dense Path-Connected Subset ⟹ ConnectedSpace (Not PathConnectedSpace)",
+    "content": "connectedSpace_of_dense_isPathConnected reduces ConnectedSpace α to IsConnected univ via connectedSpace_iff_univ, rewrites univ as closure s using density (Dense.closure_eq), and finishes with IsConnected.closure on the path-connected set. The decisive point is the type of the conclusion: ConnectedSpace, never PathConnectedSpace. Density plus path-connectedness of a subset is not enough to path-connect the ambient space — the sine curve sits densely inside its own (only-connected) closure.",
+    "mathContext": "$s$ dense and path-connected $\\Rightarrow$ the space is connected ($\\overline{s} = \\text{univ}$), but the space need not be path-connected.",
+    "significance": "key",
+    "relatedConcepts": ["dense subset", "ConnectedSpace", "PathConnectedSpace", "closure"],
+    "prerequisites": ["dense subsets", "connected spaces"]
+  },
+  {
+    "id": "ann-locpathconnected",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 87,
+      "endLine": 89
+    },
+    "type": "definition",
+    "title": "Local Path-Connectedness: the Pivotal Hypothesis",
+    "content": "Adding the instance hypothesis [LocPathConnectedSpace α] is what turns every remaining result positive. In a locally path-connected space each point has a neighbourhood basis of path-connected open sets, which forces path components to be open — and since their complements are unions of other (open) path components, they are also closed, hence clopen. Clopenness is the exact ingredient missing in the negative half: a clopen set equals its own closure.",
+    "mathContext": "$\\alpha$ locally path-connected $\\Rightarrow$ each path component is clopen $\\Rightarrow$ each path component equals its closure.",
+    "significance": "context",
+    "relatedConcepts": ["locally path-connected space", "neighbourhood basis", "clopen set", "path components"],
+    "prerequisites": ["local path-connectedness", "clopen sets"]
+  },
+  {
+    "id": "ann-closure-pathcomponent",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "A Path Component Is Its Own Closure",
+    "content": "closure_pathComponent is the one-line crux of the positive half: IsClosed.pathComponent gives that the path component is closed in a locally path-connected space, and IsClosed.closure_eq turns closedness into closure (pathComponent x) = pathComponent x. This is precisely the setting where closure preserves path-connectedness, because it leaves the set unchanged.",
+    "mathContext": "In a locally path-connected space, $\\overline{\\mathrm{pathComponent}(x)} = \\mathrm{pathComponent}(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["path components", "closed sets", "closure", "clopen set"],
+    "prerequisites": ["path components", "closed sets and closure"]
+  },
+  {
+    "id": "ann-pathconnected-closure",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 103
+    },
+    "type": "insight",
+    "title": "Closure of a Path Component Is Path-Connected",
+    "content": "isPathConnected_closure_pathComponent rewrites the closure to the path component itself (closure_pathComponent) and then applies isPathConnected_pathComponent. This is the affirmative counterpoint to the negative half: here closure DOES preserve path-connectedness — not because of any new closure theorem, but because the closure operation is the identity on this clopen set.",
+    "mathContext": "$\\overline{\\mathrm{pathComponent}(x)}$ is path-connected, since it equals the path-connected set $\\mathrm{pathComponent}(x)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["path components", "path-connectedness", "closure", "clopen set"],
+    "prerequisites": ["path components", "path-connected sets"]
+  },
+  {
+    "id": "ann-pathcomponent-eq-connectedcomponent",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 110
+    },
+    "type": "insight",
+    "title": "Path Components Meet Connected Components",
+    "content": "closure_pathComponent_eq_connectedComponent chains closure_pathComponent with pathComponent_eq_connectedComponent (path and connected components coincide in a locally path-connected space). The closure of a path component is therefore the connected component — a reusable bridge tying the path-component and connected-component theories together precisely where they merge.",
+    "mathContext": "In a locally path-connected space, $\\overline{\\mathrm{pathComponent}(x)} = \\mathrm{connectedComponent}(x)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["path components", "connected components", "closure", "local path-connectedness"],
+    "prerequisites": ["path components", "connected components"]
+  },
+  {
+    "id": "ann-open-recovery",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 112,
+      "endLine": 118
+    },
+    "type": "technique",
+    "title": "Connected Open Sets Are Path-Connected",
+    "content": "isPathConnected_of_isConnected_of_isOpen records the standard local-to-global recovery: restricting to open sets, IsOpen.isConnected_iff_isPathConnected makes connectedness and path-connectedness equivalent. This does not contradict the negative half because the closure of an open connected set need not stay open, so the equivalence is not preserved by closure.",
+    "mathContext": "$U$ open and connected (in a locally path-connected space) $\\Rightarrow$ $U$ is path-connected.",
+    "significance": "supporting",
+    "relatedConcepts": ["open sets", "connected sets", "path-connectedness", "local-to-global"],
+    "prerequisites": ["open sets", "connected and path-connected sets"]
+  },
+  {
+    "id": "ann-global-recovery",
+    "proofId": "connected-space-oq-01-oq-01",
+    "range": {
+      "startLine": 120,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "Connected + Locally Path-Connected ⟹ Path-Connected",
+    "content": "pathConnectedSpace_of_connected is the global capstone via PathConnectedSpace.of_locPathConnectedSpace: a connected, locally path-connected space is path-connected. Combined with the negative half, it precisely delimits the gap between connectedness and path-connectedness — the two notions agree exactly when local path-connectedness is present, and diverge (with closure as the visible symptom) when it is absent.",
+    "mathContext": "$\\alpha$ connected and locally path-connected $\\Rightarrow$ $\\alpha$ is path-connected (ConnectedSpace $\\Rightarrow$ PathConnectedSpace).",
+    "significance": "key",
+    "relatedConcepts": ["ConnectedSpace", "PathConnectedSpace", "local path-connectedness"],
+    "prerequisites": ["connected spaces", "path-connected spaces", "local path-connectedness"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `connected-space-oq-01-oq-01` (quality 39, 0 prior passes).

## What changed
The entry had a rich `meta.json` but **no `annotations.json` at all**. Added a full annotations layer of 10 substantive annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Coverage
- **Overview** (module docstring): the negative/positive dichotomy framing.
- **Negative half** — `isConnected_closure_of_isPathConnected`, `isConnected_of_isPathConnected_subset_closure` (bark & tree), `connectedSpace_of_dense_isPathConnected`: closure preserves only connectedness; the topologist's sine curve as the witness; emphasis that the dense corollary yields `ConnectedSpace`, not `PathConnectedSpace`.
- **Pivotal hypothesis** — the `[LocPathConnectedSpace α]` variable and why clopen path components are the missing ingredient.
- **Positive half** — `closure_pathComponent`, `isPathConnected_closure_pathComponent`, `closure_pathComponent_eq_connectedComponent`, `isPathConnected_of_isConnected_of_isOpen`, `pathConnectedSpace_of_connected`: local path-connectedness restores closure-stability.

## Verification
- JSON validated; all annotation line ranges lie within the 126-line source.
- `pnpm annotations:build` / `research:build` / `research:enrich` run clean — the proof produces **zero** annotation-validation errors.
- Note: full `pnpm build` cannot complete in this worktree (`tsc`/node_modules absent + host disk pressure); the deployer performs the authoritative build. Change is data-only (JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)