### PR TITLE
Enrich Burnside to the Dihedral Group: add annotations layer

### DIFF
--- a/src/data/proofs/burnside-counting-oq-04/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-04/annotations.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 6,
+      "endLine": 50
+    },
+    "type": "context",
+    "title": "From Necklaces to Bracelets via an Index-2 Subgroup",
+    "content": "The module docstring frames the whole file: necklace counting is Burnside applied to the cyclic rotation group ℤ/nℤ, while bracelet counting is Burnside applied to the larger dihedral group D_n, which adjoins the n reflections. Because the rotations sit inside D_n as a subgroup of index 2 (|D_n| = 2n), 'adding reflections to Burnside' is, abstractly, nothing more than splitting the Burnside sum along that index-2 subgroup. The scope is stated honestly: the headline theorem is fully general and axiom-free, while the numeric length-4 instance takes the classical necklace count (6) and reflection total (24) as hypotheses rather than recomputing them.",
+    "mathContext": "$|D_n| = 2n = 2\\cdot|\\mathbb{Z}/n\\mathbb{Z}|$; bracelets $= \\tfrac{1}{2}\\bigl(\\text{necklaces} + \\tfrac{1}{n}\\sum_{\\text{reflections}}|\\mathrm{Fix}|\\bigr)$.",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "dihedral group", "necklaces", "bracelets", "index-2 subgroup"],
+    "prerequisites": ["group actions", "orbit-counting lemma"]
+  },
+  {
+    "id": "ann-folding-statement",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 58,
+      "endLine": 76
+    },
+    "type": "insight",
+    "title": "The Index-2 Orbit-Folding Theorem",
+    "content": "index_two_orbit_folding is the genuine contribution. For ANY finite group G acting on a finite set X and ANY subgroup H ≤ G, the Burnside count over G decomposes as the Burnside count over H plus the contribution of the elements outside H. The generality matters: the dihedral case is just the motivating instance obtained by taking H to be the rotation subgroup, where the complement sum ranges exactly over the reflections.",
+    "mathContext": "$|X/G|\\cdot|G| = |X/H|\\cdot|H| + \\sum_{g \\notin H} |\\mathrm{Fix}(g)|$.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's lemma", "subgroup", "orbit space", "fixed points"],
+    "prerequisites": ["group actions", "subgroups", "Burnside/Cauchy–Frobenius lemma"]
+  },
+  {
+    "id": "ann-burnside-G",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 77,
+      "endLine": 80
+    },
+    "type": "technique",
+    "title": "Burnside on the Full Group",
+    "content": "The proof opens by invoking Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group on G: the sum of fixed-point counts over all of G equals the number of orbits times |G|. This is the Cauchy–Frobenius (Burnside) lemma in its un-averaged form, and it is the engine applied twice — once to G, once to H — whose difference yields the folding identity.",
+    "mathContext": "$\\sum_{g \\in G} |\\mathrm{Fix}(g)| = |X/G|\\cdot|G|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Burnside's lemma", "fixed points", "orbit-counting"],
+    "prerequisites": ["group actions", "finite sums"]
+  },
+  {
+    "id": "ann-fintype-congr",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 81,
+      "endLine": 90
+    },
+    "type": "technique",
+    "title": "Reconciling the Restricted-Action Fintype Instances",
+    "content": "The only real subtlety: a point is fixed by h viewed in G iff it is fixed by h acting through the restricted H-action, so fixedBy X (h : G) and fixedBy X h are definitionally the SAME set — they merely carry different Fintype instances. Fintype.card_congr (Equiv.refl _) absorbs this mismatch term by term, after which Burnside's lemma for H lines up exactly. This is a characteristic Lean bookkeeping step with no mathematical content but essential for the formalization to typecheck.",
+    "mathContext": "$\\mathrm{Fix}_G(h) = \\mathrm{Fix}_H(h)$ as sets $\\Rightarrow$ $|\\mathrm{Fix}_G(h)| = |\\mathrm{Fix}_H(h)|$.",
+    "significance": "technical",
+    "relatedConcepts": ["restricted action", "Fintype instances", "definitional equality"],
+    "prerequisites": ["subgroup actions", "cardinality of finite types"]
+  },
+  {
+    "id": "ann-split-resum",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 91,
+      "endLine": 99
+    },
+    "type": "technique",
+    "title": "Splitting the Sum and Re-Indexing Over H",
+    "content": "The Burnside sum over G is split by membership in H via Finset.sum_filter_add_sum_filter_not, and the H-part is re-indexed as a sum over the subgroup via Finset.sum_subtype, identifying it with the subgroup Burnside sum. The final rewrite chain (← hG, ← hsplit, hrot, hH) leaves exactly the complement sum Σ_{g ∉ H} |Fix(g)| — the reflection contribution in the dihedral instance.",
+    "mathContext": "$\\sum_{g \\in G} = \\sum_{g \\in H} + \\sum_{g \\notin H}$, with $\\sum_{g \\in H}|\\mathrm{Fix}(g)| = |X/H|\\cdot|H|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sum over a subgroup", "filter", "re-indexing", "Finset"],
+    "prerequisites": ["finite sums", "subgroup membership predicates"]
+  },
+  {
+    "id": "ann-doubling",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 103,
+      "endLine": 121
+    },
+    "type": "insight",
+    "title": "The Dihedral Doubling Form",
+    "content": "dihedral_doubling specialises the folding theorem to the defining size relation |G| = 2|H|. Substituting and rearranging by ring turns the identity into 2·|X/G|·|H| = |X/H|·|H| + Σ_{g ∉ H} |Fix(g)| — read in the dihedral case as bracelets·2|H| = necklaces·|H| + (reflection fixed points), the classical 'bracelets = (necklaces + reflection total/n)/2' once divided through.",
+    "mathContext": "$|G| = 2|H| \\Rightarrow 2\\,|X/G|\\,|H| = |X/H|\\,|H| + \\sum_{g \\notin H}|\\mathrm{Fix}(g)|$.",
+    "significance": "key",
+    "relatedConcepts": ["index-2 subgroup", "dihedral group", "bracelets", "necklaces"],
+    "prerequisites": ["subgroup index", "the folding theorem"]
+  },
+  {
+    "id": "ann-dihedral-card",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 123,
+      "endLine": 127
+    },
+    "type": "context",
+    "title": "|DihedralGroup n| = 2n Anchors the Instance",
+    "content": "dihedralGroup_card re-exports Mathlib's DihedralGroup.card to record |D_n| = 2n explicitly. This is the order relation that places the rotation group ℤ/nℤ at index 2 inside D_n, supplying the |G| = 2|H| hypothesis of the doubling form for the dihedral specialisation.",
+    "mathContext": "$|\\mathrm{DihedralGroup}\\, n| = 2n$.",
+    "significance": "context",
+    "relatedConcepts": ["dihedral group", "group order", "index-2 subgroup"],
+    "prerequisites": ["dihedral groups", "finite group cardinality"]
+  },
+  {
+    "id": "ann-numeric-context",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 129,
+      "endLine": 141
+    },
+    "type": "context",
+    "title": "The Classical Length-4 Binary Data",
+    "content": "For the square (D_4, order 8) the four reflections fix 8, 8, 4, 4 colourings respectively — two axes through opposite vertices, two through opposite edge midpoints — for a reflection total of 24, while the parent establishes 6 binary necklaces. These two numbers are taken as hypotheses; the file derives the bracelet count from them algebraically rather than recomputing the concrete orbit quotients (which the parent itself only closes with native_decide).",
+    "mathContext": "Reflection fixed points $= 8+8+4+4 = 24$; necklaces $= 6$.",
+    "significance": "context",
+    "relatedConcepts": ["dihedral group D_4", "reflections", "fixed points", "binary colourings"],
+    "prerequisites": ["dihedral symmetry of the square", "necklace counting"]
+  },
+  {
+    "id": "ann-bracelet-count",
+    "proofId": "burnside-counting-oq-04",
+    "range": {
+      "startLine": 142,
+      "endLine": 155
+    },
+    "type": "insight",
+    "title": "Binary Length-4 Bracelets = 6",
+    "content": "binary_four_bracelet_count plugs |G| = 8, |H| = 4, necklaces = 6, and reflection total = 24 into index_two_orbit_folding, reducing the goal to |X/G|·8 = 6·4 + 24 = 48 and finishing by omega. The bracelet count is forced to be 6 — confirming that for length-4 binary strings the rotation-only and rotation-plus-reflection orbit counts coincide, a small numeric witness that the abstract folding theorem reproduces the classical bracelet number.",
+    "mathContext": "$|\\text{bracelets}|\\cdot 8 = 6\\cdot 4 + 24 = 48 \\Rightarrow |\\text{bracelets}| = 6$.",
+    "significance": "key",
+    "relatedConcepts": ["bracelets", "necklaces", "Burnside's lemma", "omega tactic"],
+    "prerequisites": ["the folding theorem", "linear arithmetic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-04` (quality 39, 0 prior passes).

## What changed
The entry had a rich `meta.json` but **no `annotations.json`**. Added a full annotations layer of 9 substantive annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Coverage
- **Overview**: necklaces→bracelets via the index-2 rotation subgroup; honest scope note.
- **`index_two_orbit_folding`**: the general theorem `|X/G|·|G| = |X/H|·|H| + Σ_{g∉H}|Fix(g)|`.
- **Burnside-twice engine**: `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` on G and H.
- **Restricted-action Fintype reconciliation**: `Fintype.card_congr (Equiv.refl _)` for `fixedBy X (h:G) = fixedBy X h`.
- **Split + re-index**: `sum_filter_add_sum_filter_not` and `sum_subtype`.
- **`dihedral_doubling`** and **`dihedralGroup_card`** (|D_n| = 2n).
- **Numeric instance**: length-4 binary, reflection total 24, `binary_four_bracelet_count` = 6.

## Verification
- JSON validated; all annotation line ranges lie within the 157-line source.
- `pnpm annotations:build` runs clean (exit 0); the proof produces no annotation-validation errors.
- Note: full `pnpm build` cannot complete in this worktree (`tsc`/node_modules absent + host disk pressure); the deployer performs the authoritative build. Change is data-only (JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)