### PR TITLE
Gallery integrity: mason-stothers-oq-01-oq-02 badge original→mathlib

### DIFF
--- a/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/mason-stothers-theorem-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
       "number-theory",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Integrity Issue

**Proof**: mason-stothers-theorem-oq-01-oq-02 (Davenport's inequality)
**Problem**: Badge `original` overclaims attribution. Davenport's inequality is derived as a *one-line corollary* of Mason–Stothers, whose engine is Mathlib's `Polynomial.abc`. Per Tier B / Failure-mode #5, the badge should be `mathlib`.

## Evidence

- **meta.json claimed**: `badge: "original"`, `status: "verified"`.
- **Lean file** (`MasonStothersOQ01OQ02.lean`): `davenport` obtains its main result by calling `MasonStothersOQ01.mason_stothers_charZero` (line 102).
- **Parent** `mason-stothers-theorem-oq-01` is badged **`mathlib`** because `mason_stothers_charZero` is a wrapper of Mathlib's `Polynomial.abc` (parent docstring line 37: "Everything is a 0-axiom derivation from Mathlib's `Polynomial.abc`").
- This child's own docstring (line 47): "Everything is a 0-axiom derivation from Mathlib's `Polynomial.abc`."
- The entry itself calls Davenport "one of the classic one-line consequences of the Mason–Stothers theorem" — i.e. the deep theorem doing the core work is `Polynomial.abc`.

The in-file contributions (`radical_cube_sq_mul_dvd` + the omega sandwiching assembly) are genuine bridge/infrastructure, but a deep imported theorem does the core mathematical lifting → Tier B → badge `mathlib`, consistent with the parent.

## Fix

- `meta.badge`: `original` → `mathlib`.
- `status` unchanged (`verified`): the proof is fully kernel-checked, 0 axioms, 0 sorries, no `native_decide`. `verified` + `mathlib` is a valid combination.

## Verification (unchanged, accurate)

3 theorems, 0 defs, 0 sorries, 0 axioms, 132 lines — all match meta exactly. Prose disclosure was already exemplary (no delegation opacity); only the badge enum was inconsistent with the parent.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)