### PR TITLE
Audit fix: correct false novelty claim in algebraic-reals-meager-dense-gdelta

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta/meta.json
@@ -66,7 +66,7 @@
       }
     ],
     "originalContributions": [
-      "isGδ_compl_of_countable: PROVED in any T1 space the complement of a countable set is a Gδ — realized as the countable intersection ⋂_{a ∈ s} {a}ᶜ of open singleton-complements (no such named lemma in Mathlib)",
+      "isGδ_compl_of_countable: in any T1 space the complement of a countable set is a Gδ — realized as the countable intersection ⋂_{a ∈ s} {a}ᶜ of open singleton-complements; re-proved in-file from IsGδ.biInter_of_isOpen rather than imported (Mathlib's Set.Countable.isGδ_compl states the same fact)",
       "dense_compl_of_countable: PROVED in a perfect T1 Baire space the complement of a countable set is dense (via meagreness of the countable set, reusing the parent's countable_isMeagre)",
       "isGδ_dense_compl_of_countable: PROVED the abstract dense-Gδ packaging — the complement of a countable set in a perfect T1 Baire space is a dense Gδ",
       "not_isGδ_of_dense_isMeagre: PROVED a dense meagre set in a nonempty Baire space is never a Gδ — the abstract mechanism behind 'ℚ is not a Gδ' (a dense Gδ would be residual, forcing both it and its complement meagre, hence univ meagre, contradiction)",
@@ -93,7 +93,7 @@
         "relationship": "Grandparent: the algebraic reals are countable (the countability input reused here)"
       }
     ],
-    "assumptions": "0 axioms (only propext, Classical.choice, Quot.sound — the standard Mathlib triple; no sorryAx, no native_decide). Relies on Mathlib's Gδ / Baire-category infrastructure, the perfect/T1/Baire structure of ℝ, and the countability and density of the algebraic reals.",
+    "assumptions": "0 axioms (only propext, Classical.choice, Quot.sound — the standard Mathlib triple; no sorryAx, no native_decide). Relies on Mathlib's Gδ / Baire-category infrastructure, the perfect/T1/Baire structure of ℝ, and the countability and density of the algebraic reals. Note: the abstract lemma isGδ_compl_of_countable coincides with Mathlib's existing Set.Countable.isGδ_compl (it is re-proved here from IsGδ.biInter_of_isOpen, not imported); the headline contribution is the concrete transcendental dense-Gδ result and the dual not-Gδ corollary for the algebraic reals, for which Mathlib provides only the irrational/rational analogue.",
     "theoremCount": 9,
     "definitionCount": 0,
     "additionalFiles": []


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: \`algebraic-reals-meager-dense-gdelta\`
**Severity**: MEDIUM (novelty overclaim in contributions text)

## Issue

The \`originalContributions\` entry for \`isGδ_compl_of_countable\` claimed it proves a fact with **"no such named lemma in Mathlib"**. This is false: Mathlib's [\`Set.Countable.isGδ_compl\`](Mathlib.Topology.Separation.GDelta) states the identical fact:

\`\`\`lean
theorem Set.Countable.isGδ_compl {s : Set X} [T1Space X] (hs : s.Countable) : IsGδ sᶜ
\`\`\`

vs. the file's

\`\`\`lean
theorem isGδ_compl_of_countable {X : Type*} [TopologicalSpace X] [T1Space X]
    {s : Set X} (hs : s.Countable) : IsGδ sᶜ
\`\`\`

The file **re-proves** the lemma in-file (from \`IsGδ.biInter_of_isOpen\`) rather than importing it, so the formalization work is genuine — but the *novelty* claim was inaccurate.

## Fix

- Reworded the contribution to acknowledge Mathlib's existing \`Set.Countable.isGδ_compl\`.
- Added a note to \`assumptions\` clarifying the abstract lemma duplicates the Mathlib lemma; the genuine gallery contribution is the **concrete transcendental dense-Gδ result** and the **dual not-Gδ corollary** for the algebraic reals (Mathlib has only the irrational/rational analogue — confirmed by grep over Mathlib's Topology tree).

## What was verified (otherwise clean)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| theoremCount | 9 | 9 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 (no \`axiom\`, no \`native_decide\`) | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 165 | 165 | ✓ |

- No True stubs. Parent dependencies (\`transcendentalReals_dense\`, \`countable_isMeagre\`, \`algebraicReals_isMeagre\`, \`algebraic_reals_countable\`) all exist in \`AlgebraicRealsMeager\`.
- Badge stays \`original\`: no deep Mathlib theorem does the core work; the headline transcendental dichotomy has no Mathlib analogue.
- Status stays \`verified\`.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)