### PR TITLE
Enrich Order of 1+p·a mod Odd Prime Power (order-one-add-mul-prime-oq-01)

### DIFF
--- a/src/data/proofs/order-one-add-mul-prime-oq-01/annotations.json
+++ b/src/data/proofs/order-one-add-mul-prime-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 3, "endLine": 32 },
+    "type": "context",
+    "title": "Principal Units and the Structure of (ℤ/pⁿℤ)ˣ",
+    "content": "For an odd prime p and p ∤ a, the element 1 + p·a has multiplicative order exactly pⁿ in ZMod(p^(n+1)). This is the arithmetic engine behind the cyclicity of (ℤ/pᵏℤ)ˣ: the principal units 1 + p·ℤ form a cyclic p-group of order pⁿ, which combines with the order-(p−1) cyclic group from reduction mod p to make the full unit group cyclic for odd prime powers. Mathlib has the order computation but not the structural corollaries this file packages.",
+    "mathContext": "$\\mathrm{ord}_{(\\mathbb{Z}/p^{n+1})^\\times}(1+pa) = p^n$ for odd prime $p$, $p\\nmid a$. The principal units $1+p\\mathbb{Z}$ are a cyclic $p$-group of order $p^n$.",
+    "significance": "context",
+    "relatedConcepts": ["multiplicative order", "unit group of ℤ/pⁿℤ", "principal units", "cyclic p-group"],
+    "prerequisites": ["modular arithmetic", "order of a group element", "prime powers"]
+  },
+  {
+    "id": "ann-core-order",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 36, "endLine": 42 },
+    "type": "theorem",
+    "title": "Core Order Computation (Mathlib Re-Export)",
+    "content": "The deep fact, re-exported from Mathlib's `ZMod.orderOf_one_add_mul_prime`: for odd prime p, p ∤ a, the order of 1 + p·a modulo p^(n+1) is pⁿ. Requiring p ≠ 2 is essential — the order behaves differently for the prime 2 (the 2-adic units are not cyclic). Everything else in the file is derived from this single result.",
+    "mathContext": "$p$ odd prime, $p\\nmid a \\implies \\mathrm{orderOf}(1+pa : \\mathbb{Z}/p^{n+1}) = p^n.$",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "odd prime power", "ZMod", "lifting the exponent"],
+    "prerequisites": ["order of an element", "ZMod arithmetic"]
+  },
+  {
+    "id": "ann-independent-of-a",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 44, "endLine": 49 },
+    "type": "theorem",
+    "title": "The Order Is Independent of the Residue a",
+    "content": "Any two integers a, b coprime to p give elements 1 + p·a and 1 + p·b of the same order pⁿ. The proof simply rewrites both sides via the core computation. This uniformity is what lets one treat 'the' order of a principal unit without tracking which admissible a was chosen.",
+    "mathContext": "$p\\nmid a,\\ p\\nmid b \\implies \\mathrm{orderOf}(1+pa) = \\mathrm{orderOf}(1+pb) = p^n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["order independence", "principal units", "coprimality"],
+    "prerequisites": ["multiplicative order", "the core computation"]
+  },
+  {
+    "id": "ann-p-element",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 51, "endLine": 55 },
+    "type": "theorem",
+    "title": "1 + p·a Is a p-Element",
+    "content": "Existence form: the order is a power of p (witnessed by exponent n), so 1 + p·a lies in the p-Sylow part of the unit group. This is the statement that feeds into Sylow/structure arguments about (ℤ/pᵏℤ)ˣ.",
+    "mathContext": "$\\exists k,\\ \\mathrm{orderOf}(1+pa) = p^k$ — the principal unit is a $p$-element.",
+    "significance": "supporting",
+    "relatedConcepts": ["p-element", "Sylow subgroup", "order a power of p"],
+    "prerequisites": ["p-groups", "multiplicative order"]
+  },
+  {
+    "id": "ann-a-eq-one",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 57, "endLine": 61 },
+    "type": "theorem",
+    "title": "Textbook Specialization a = 1",
+    "content": "The classical case 1 + p: its order modulo p^(n+1) is pⁿ, re-exported from `ZMod.orderOf_one_add_prime`. This is the form most textbooks state, exhibiting 1 + p as a canonical generator of the principal-unit p-group.",
+    "mathContext": "$\\mathrm{orderOf}(1+p : \\mathbb{Z}/p^{n+1}) = p^n.$",
+    "significance": "supporting",
+    "relatedConcepts": ["canonical generator", "principal units", "multiplicative order"],
+    "prerequisites": ["the core computation"]
+  },
+  {
+    "id": "ann-order-one-iff",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 63, "endLine": 74 },
+    "type": "theorem",
+    "title": "Order 1 ⟺ n = 0 (the mod-p Boundary Case)",
+    "content": "The order equals 1 exactly when n = 0, i.e. modulo p itself, where 1 + p·a ≡ 1. The proof rewrites to pⁿ = 1 and argues: if n ≠ 0 then p ≤ pⁿ (with p ≥ 2), contradicting pⁿ = 1 via `omega`; conversely n = 0 gives p⁰ = 1. This pins down the degenerate case of the order formula.",
+    "mathContext": "$\\mathrm{orderOf}(1+pa : \\mathbb{Z}/p^{n+1}) = 1 \\iff n = 0$ (since $p^n = 1 \\iff n = 0$ for $p\\ge 2$).",
+    "significance": "supporting",
+    "relatedConcepts": ["trivial order", "boundary case", "prime power equals one"],
+    "prerequisites": ["order = 1 means identity", "omega"]
+  },
+  {
+    "id": "ann-concrete-instances",
+    "proofId": "order-one-add-mul-prime-oq-01",
+    "range": { "startLine": 78, "endLine": 100 },
+    "type": "theorem",
+    "title": "Concrete Instances (Derived, Not Decided)",
+    "content": "Three numeric witnesses obtained from the theorem rather than by kernel evaluation: ord(4) = 3 mod 9 (=3²), ord(4) = 9 mod 27 (=3³), ord(6) = 5 mod 25 (=5²). Each instantiates the core lemma at specific p, a, n and rewrites 1 + p·a to the concrete unit via `push_cast; ring`. Deriving rather than `decide`-ing keeps the file axiom-free (no `Lean.ofReduceBool`).",
+    "mathContext": "$\\mathrm{ord}_9(4)=3,\\ \\mathrm{ord}_{27}(4)=9,\\ \\mathrm{ord}_{25}(6)=5$ — instances of $\\mathrm{orderOf}(1+pa)=p^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "axiom-free derivation", "multiplicative order"],
+    "prerequisites": ["instantiating a general theorem", "push_cast / ring"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `order-one-add-mul-prime-oq-01`.

## What changed
The entry was missing `annotations.json`. Added 7 line-aligned annotations (validated 7/7, 0 misaligned via `resolver.ts validate`), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Coverage: the principal-units / cyclicity context, the core Mathlib order computation `orderOf(1+pa)=pⁿ` (and why p≠2 matters), residue-independence, the p-element existence form, the a=1 textbook specialization, the order-1 ⟺ n=0 boundary case, and the three axiom-free concrete instances (ord 4 mod 9/27, ord 6 mod 25).

## Validation
- `resolver.ts validate`: 7 valid, 0 misaligned
- meta.json already met quality targets and was left intact.