### PR TITLE
Enrich pythagorean-triples-oq-04-oq-01: add fermat-two-squares cross-reference

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-04-oq-01/meta.json
@@ -74,6 +74,11 @@
       "targetId": "pythagorean-triples-oq-04",
       "relationship": "extends",
       "description": "The parent entry proves Fermat's two-square theorem for primes and the two-factor Brahmagupta–Fibonacci identity. This entry runs those two ingredients through a strong induction to obtain the sufficiency direction of the full characterization, directly addressing the parent's first listed open question."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "Fermat's two-square theorem for primes (p = a²+b² iff p = 2 or p ≡ 1 mod 4) is the base case of this entry's induction, supplied here through Mathlib's Nat.Prime.sq_add_sq at the least prime factor."
     }
   ],
   "sections": [


### PR DESCRIPTION
Small follow-up enrichment on top of the just-merged #28322 (which added the annotations layer for this entry).

## What changed
Adds one `crossReference` to **`fermat-two-squares`** — the prime base case of this entry's strong induction (supplied via Mathlib's `Nat.Prime.sq_add_sq` at the least prime factor). The entry previously only linked to its parent `pythagorean-triples-oq-04`; this surfaces the direct relationship to the prime two-square theorem the induction bottoms out on.

## Note
I claimed and worked this target concurrently with #28322; its annotations.json (auto-generated, identical content) landed in main first, so this PR is scoped to the single remaining unique gap — the cross-reference. Data-only (meta.json), JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)