### PR TITLE
Fix erdos-124-complete-sequences-oq-02 integrity: theoremCount 15→19

### DIFF
--- a/src/data/proofs/erdos-124-complete-sequences-oq-02/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences-oq-02/meta.json
@@ -52,7 +52,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries, no native_decide (no Lean.ofReduceBool). Depends only on the foundational axioms propext, Classical.choice, Quot.sound via standard Mathlib lemmas. The deep ≥ 1 completeness theorem of Erdős 124 is the parent entry's contribution and is not reproved here.",
     "lineCount": 316,
-    "theoremCount": 15,
+    "theoremCount": 19,
     "definitionCount": 3
   },
   "overview": {
@@ -135,7 +135,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The exact boundary ∑ 1/(dᵢ−1) = 1 of Erdős 124 is shown to be precisely an Egyptian-fraction decomposition of 1 (eᵢ = dᵢ − 1), via the bridge reciSum_eq_egyptSum. The Sylvester splitting identity yields an explicit family of boundary configurations of every length (sylvester / exists_boundary_config), and the unit fraction 1/1 saturates the budget so that any boundary configuration using the base d = 2 is the singleton [2] (base_two_forces_singleton). 15 theorems, 3 definitions, 0 axioms, 0 sorries.",
+    "summary": "The exact boundary ∑ 1/(dᵢ−1) = 1 of Erdős 124 is shown to be precisely an Egyptian-fraction decomposition of 1 (eᵢ = dᵢ − 1), via the bridge reciSum_eq_egyptSum. The Sylvester splitting identity yields an explicit family of boundary configurations of every length (sylvester / exists_boundary_config), and the unit fraction 1/1 saturates the budget so that any boundary configuration using the base d = 2 is the singleton [2] (base_two_forces_singleton). 19 theorems, 3 definitions, 0 axioms, 0 sorries.",
     "implications": "Gives a clean structural answer to OQ-02: the boundary needs no new completeness machinery (it is a face of the parent's closed condition), but it carries the full combinatorial richness of Egyptian fractions — arbitrarily many bases, with binary as the unique degenerate single-base case.",
     "openQuestions": [
       "Which boundary configurations (Egyptian decompositions of 1) give the strong, gcd-restricted version of Erdős 124, where the digit-1 power is excluded?",
@@ -152,7 +152,7 @@
     "namespace": "Erdos124OQ02",
     "lineCount": 316,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 19,
     "definitionCount": 3,
     "path": "Proofs/Erdos124CompleteSequencesOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `erdos-124-complete-sequences-oq-02` — *Erdős 124 at the boundary: ∑ 1/(dᵢ−1) = 1 is exactly an Egyptian fraction*

**Problem**: `theoremCount` understated as **15** in three places; the Lean source actually has **19** `theorem` declarations.

## Evidence

```
$ grep -cE '^(@\[simp\] )?theorem ' proofs/Proofs/Erdos124CompleteSequencesOQ02.lean
19
```

The 4-theorem gap is exactly the `@[simp]` simp-rule lemmas that were excluded from the count (19 − 4 = 15):
`egyptSum_nil`, `egyptSum_cons`, `reciSum_nil`, `reciSum_cons`.

## Fix

`theoremCount: 15 → 19` in:
- `meta.theoremCount`
- `leanFile.theoremCount`
- `conclusion.summary` text ("15 theorems" → "19 theorems")

`definitionCount` (3), `lineCount` (316), `axiomCount` (0), `sorries` (0) all verified exact — unchanged.

## Everything else is exemplary (no other action)

- **Tier A, badge `original` — defensible.** The headline content (Egyptian-fraction bridge `reciSum_eq_egyptSum`, the explicit Sylvester construction, base-2 rigidity) is proved entirely in-file from elementary Mathlib infrastructure (`List` induction, `field_simp`, `Nat.cast_sub`, `positivity`, `omega`, `nlinarith`). No deep Mathlib theorem does the core work; this characterization is not in Mathlib.
- **`status: verified` correct.** 0 axioms, 0 sorries confirmed. No `native_decide` — the single `decide` (L314, `sylvester 3 = [4,12,6,2]`) is kernel decide on a tiny concrete list, so no `Lean.ofReduceBool`.
- **Scope honesty is strong.** Title is qualified ("at the boundary"); docstring (L46–47) and `assumptions` explicitly state the parent's deep ≥ 1 completeness theorem "is not reproved here." No axiom masking, no delegation opacity.
- **Math witnesses verified**: `1/2+1/3+1/7+1/42 = 1`; `sylvester 3 = [4,12,6,2]`.

The mismatch is an **undercount** (15 < 19), i.e. an understatement of work done, not an overclaim — corrected for metadata accuracy.

---
Discovered during gallery integrity audit.