### PR TITLE
Enrich Algebraic Obstruction Behind No-Retraction (brouwer-fixed-point-oq-01-oq-02-oq-02)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 5, "endLine": 49 },
+    "type": "context",
+    "title": "The Algebraic Obstruction Behind No-Retraction",
+    "content": "The parent entry proves the No-Retraction Theorem by reducing it through homology to a purely algebraic fact: id : ℤ →+ ℤ cannot factor through the trivial group (Hₙ(Bⁿ)=0, Hₙ₋₁(Sⁿ⁻¹)=ℤ). This entry isolates the general obstruction — through which groups can id_ℤ fail to factor? — and shows the trivial group was a red herring: ℤ is not a retract of any finite, indeed any torsion, group. The homological proof never needed disc homology to be zero, only torsion.",
+    "mathContext": "$\\mathbb{Z}$ is a retract of $G$ iff $\\exists\\,\\varphi:\\mathbb{Z}\\to_{+} G,\\ \\psi:G\\to_{+}\\mathbb{Z}$ with $\\psi\\circ\\varphi = \\mathrm{id}$. Impossible when $G$ is torsion.",
+    "significance": "context",
+    "relatedConcepts": ["No-Retraction Theorem", "Brouwer fixed-point theorem", "singular homology", "retracts", "torsion groups"],
+    "prerequisites": ["additive group homomorphisms", "retraction / section", "homology of disc and sphere"]
+  },
+  {
+    "id": "ann-splitting",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 57, "endLine": 70 },
+    "type": "technique",
+    "title": "The Splitting Lemmas: φ Injective, ψ Surjective",
+    "content": "The retract relation ψ∘φ = id, evaluated pointwise as ψ(φ n) = n (`retract_apply`), makes ψ a left inverse of φ — so φ is injective (`injective_of_retract`) — and a right inverse of ψ from the other side — so ψ is surjective (`surjective_of_retract`). These are the standard section/retraction splitting facts, the foundation for everything downstream.",
+    "mathContext": "$\\psi(\\varphi\\,n) = n$, so $\\varphi$ is injective (left inverse $\\psi$) and $\\psi$ is surjective (right inverse $\\varphi$).",
+    "significance": "key",
+    "relatedConcepts": ["section and retraction", "left/right inverse", "injectivity", "surjectivity"],
+    "prerequisites": ["function inverses", "additive homomorphism composition"]
+  },
+  {
+    "id": "ann-infinite",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 72, "endLine": 76 },
+    "type": "theorem",
+    "title": "ℤ Retracts Only Onto Infinite Groups",
+    "content": "Since φ injectively embeds the infinite group ℤ into G (`Infinite.of_injective`), any G admitting ℤ as a retract must be infinite. This is the first cardinality consequence and the direct route to ruling out finite groups.",
+    "mathContext": "$\\varphi : \\mathbb{Z} \\hookrightarrow G$ injective $\\implies G$ is infinite.",
+    "significance": "key",
+    "relatedConcepts": ["infinite group", "injective embedding", "Infinite.of_injective"],
+    "prerequisites": ["the splitting lemmas", "cardinality of an injective image"]
+  },
+  {
+    "id": "ann-not-finite",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 78, "endLine": 93 },
+    "type": "theorem",
+    "title": "Not a Retract of Any Finite (or Trivial) Group",
+    "content": "ℤ is not a retract of any finite group: a retract would force G infinite, contradicting finiteness. The parent's trivial-group case is the instance G = PUnit (`not_retract_of_subsingleton`, via Finite.of_subsingleton) — exactly 'id_ℤ cannot factor through Unit'. This is the general form of the parent's hand-computed algebraic core.",
+    "mathContext": "$G$ finite $\\implies \\neg\\,\\exists\\,\\varphi,\\psi,\\ \\psi\\circ\\varphi=\\mathrm{id}$; trivial group is $G=\\mathrm{PUnit}$.",
+    "significance": "key",
+    "relatedConcepts": ["finite group", "trivial group PUnit", "subsingleton", "generalizing the parent"],
+    "prerequisites": ["infinite-of-retract", "finiteness vs infiniteness"]
+  },
+  {
+    "id": "ann-gen-infinite-order",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 95, "endLine": 104 },
+    "type": "theorem",
+    "title": "The Generator Maps to an Element of Infinite Order",
+    "content": "φ 1 has infinite additive order: if n • φ 1 = 0 with n > 0, applying ψ gives n = ψ(n • φ 1) = ψ(0) = 0 (via `map_nsmul` and `retract_apply`), a contradiction closed by `omega`. This sharpens 'G infinite' to 'G contains an element of infinite order' — the obstruction that defeats torsion groups.",
+    "mathContext": "$n\\bullet\\varphi(1)=0 \\Rightarrow n = \\psi(n\\bullet\\varphi(1)) = 0$, so $\\varphi(1)$ has infinite order.",
+    "significance": "key",
+    "relatedConcepts": ["order of an element", "IsOfFinAddOrder", "map_nsmul", "infinite order"],
+    "prerequisites": ["additive order", "the splitting relation"]
+  },
+  {
+    "id": "ann-not-torsion",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 106, "endLine": 118 },
+    "type": "theorem",
+    "title": "Not a Retract of Any Torsion Group (the Sharp Form)",
+    "content": "A torsion group has every element of finite order, but a retract of ℤ must contain φ 1 of infinite order — contradiction (`not_isTorsion_of_retract`, packaged as `not_retract_of_isTorsion`). This strictly generalizes the finite case (finite ⟹ torsion) and is the entry's sharpest statement: torsion-ness of the disc homology already suffices for the no-retraction contradiction.",
+    "mathContext": "$G$ torsion $\\implies \\neg\\,\\exists$ retract, since $\\varphi(1)$ would have infinite order in a group where all orders are finite.",
+    "significance": "key",
+    "relatedConcepts": ["torsion group", "AddMonoid.IsTorsion", "element of infinite order", "strict generalization"],
+    "prerequisites": ["the infinite-order generator", "definition of torsion"]
+  },
+  {
+    "id": "ann-significance",
+    "proofId": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+    "range": { "startLine": 120, "endLine": 140 },
+    "type": "context",
+    "title": "Significance: Torsion, Not Triviality, Is What Matters",
+    "content": "The homological No-Retraction proof splits id of Hₙ₋₁(Sⁿ⁻¹) ≅ ℤ through Hₙ₋₁(Bⁿ) = 0. This entry shows the trivial group was a red herring: id_ℤ cannot factor through any finite or torsion group, because a retract of ℤ must contain an element of infinite order. So the proof never needed disc homology to be zero — only torsion. The splitting and infinite-order lemmas are reusable facts about retracts of ℤ in abelian groups, independent of topology.",
+    "mathContext": "Any contractible-enough computation giving torsion disc-homology suffices: torsion $G$ cannot receive $\\mathrm{id}_\\mathbb{Z}$ as a retract.",
+    "significance": "context",
+    "relatedConcepts": ["singular homology", "retract obstruction", "reusable algebraic lemmas", "torsion vs trivial"],
+    "prerequisites": ["homological no-retraction argument"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-02-oq-02`.

## What changed
The entry was missing `annotations.json`. Added 7 line-aligned annotations (validated 7/7, 0 misaligned via `resolver.ts validate`), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Coverage: the algebraic-obstruction context; the splitting lemmas (φ injective, ψ surjective); ℤ retracts only onto infinite groups; not a retract of finite/trivial groups; the generator has infinite order; not a retract of any torsion group (sharp form); and the significance discussion (torsion, not triviality, is what the homology argument needs).

## Validation
- `resolver.ts validate`: 7 valid, 0 misaligned
- meta.json already met quality targets and was left intact.