### PR TITLE
Enrich Minimal Generators = dim Residue Space (nakayama-lemma-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/nakayama-lemma-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/nakayama-lemma-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 10, "endLine": 62 },
+    "type": "context",
+    "title": "Minimal Generators = dim of the Residue Space M/𝔪M",
+    "content": "Over a local ring (R, 𝔪) with residue field k = R/𝔪, a finitely generated module M has a minimal generator count μ(M), and it equals a single linear-algebra invariant: dim_k(M/𝔪M). Mathlib has Nakayama, the residue field, the k-vector-space structure on M/𝔪M, and the cotangent specialization 𝔪/𝔪², but states μ(M) = dim_k(M/𝔪M) for no module. This entry builds the two-sided count on the parent's lifting lemma.",
+    "mathContext": "$\\mu(M) = \\dim_k (M/\\mathfrak{m}M)$ for a finitely generated module $M$ over a local ring $(R,\\mathfrak{m})$, $k = R/\\mathfrak{m}$.",
+    "significance": "context",
+    "relatedConcepts": ["Nakayama's lemma", "local ring", "residue field", "minimal generators", "cotangent space"],
+    "prerequisites": ["local rings", "modules over a ring", "vector space dimension"]
+  },
+  {
+    "id": "ann-residue-space",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 90 },
+    "type": "definition",
+    "title": "The Residue Space M/𝔪M as a k-Vector Space",
+    "content": "`ResidueModule R M := M ⧸ 𝔪•⊤` is annihilated by 𝔪, hence a module over k = R/𝔪 = ResidueField R (Mathlib's quotient-module instance), with the IsScalarTower R k linking the actions. When M is R-finite it is a finite-dimensional k-vector space. `residueMap` is the quotient map M → M/𝔪M. This is the linear-algebra arena in which the generator count is computed.",
+    "mathContext": "$M/\\mathfrak{m}M$ is a $k$-vector space ($\\mathfrak{m}$ acts as $0$); finite-dimensional when $M$ is $R$-finite; quotient map $\\pi : M \\to M/\\mathfrak{m}M$.",
+    "significance": "key",
+    "relatedConcepts": ["quotient module", "residue field", "IsScalarTower", "finite-dimensional vector space"],
+    "prerequisites": ["quotient modules", "scalar restriction/extension", "ResidueField"]
+  },
+  {
+    "id": "ann-bridge",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 92, "endLine": 102 },
+    "type": "theorem",
+    "title": "Bridge Lemma: k-Span ⟺ R-Span Modulo 𝔪M",
+    "content": "The translation between pictures: a set t ⊆ M has image spanning M/𝔪M over k iff span_R(t) ⊔ 𝔪•⊤ = ⊤, i.e. t generates M modulo 𝔪M. Spans over R and over k coincide because R → k is surjective (`restrictScalars_span`), combined with `map_mkQ_eq_top` for surjective quotients. This lemma is the hinge linking the vector-space count to module generation.",
+    "mathContext": "$\\mathrm{span}_k(\\pi(t)) = \\top \\iff \\mathrm{span}_R(t) + \\mathfrak{m}M = M$ (since $R\\to k$ surjective).",
+    "significance": "key",
+    "relatedConcepts": ["span over base vs quotient", "restrictScalars_span", "surjective quotient map", "Submodule.map_mkQ_eq_top"],
+    "prerequisites": ["spans of submodules", "quotient surjectivity"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 104, "endLine": 123 },
+    "type": "theorem",
+    "title": "Lower Bound: Every Generating Set Has ≥ dim_k(M/𝔪M) Elements",
+    "content": "Any finite generating family of M maps to a spanning set of the residue space (bridge lemma), and a spanning set of a finite-dimensional vector space has at least dim-many elements (`finrank_le_of_span_eq_top`). The finset form `finrank_le_card_of_span_eq_top` repackages the family version via the subtype range. This is the easy half of the count.",
+    "mathContext": "$\\mathrm{span}_R(s) = \\top \\implies \\dim_k(M/\\mathfrak{m}M) \\le |s|.$",
+    "significance": "key",
+    "relatedConcepts": ["lower bound", "spanning set cardinality", "finrank_le_of_span_eq_top", "residue space image"],
+    "prerequisites": ["the bridge lemma", "dimension vs spanning-set size"]
+  },
+  {
+    "id": "ann-existence",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 125, "endLine": 159 },
+    "type": "theorem",
+    "title": "Upper Bound via Nakayama: a Generating Set of Size Exactly dim",
+    "content": "Lift a k-basis of M/𝔪M (size d = finrank) to elements g of M; their images are the basis, so they span the residue space, hence span M modulo 𝔪M. The parent's `nakayama_span_of_span_quotient` promotes 'spans mod 𝔪M' to 'spans M' — this is where Nakayama's lemma enters. The lift has ≤ d elements and the lower bound forces equality, giving a generating set of size exactly d.",
+    "mathContext": "Lift a basis of $M/\\mathfrak{m}M$; Nakayama promotes residue-spanning to $\\mathrm{span}_R = \\top$; size $= \\dim_k(M/\\mathfrak{m}M)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nakayama's lemma", "lifting a basis", "upper bound", "minimal generating set"],
+    "prerequisites": ["the bridge lemma", "the lower bound", "nakayama_span_of_span_quotient"]
+  },
+  {
+    "id": "ann-numgen-def",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 161, "endLine": 165 },
+    "type": "definition",
+    "title": "numGenerators: the Minimal Generator Count",
+    "content": "`numGenerators R M := sInf { n | ∃ s : Finset M, s.card = n ∧ span_R s = ⊤ }` — the least size of a finite generating set, defined as an infimum over generating-set cardinalities. This is the quantity the headline theorem identifies with the residue dimension.",
+    "mathContext": "$\\mu(M) = \\inf\\{\\,n : \\exists\\,s,\\ |s|=n \\land \\mathrm{span}_R(s)=\\top\\,\\}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["minimal generators", "infimum (sInf)", "generating set"],
+    "prerequisites": ["finite generating sets", "Nat.sInf"]
+  },
+  {
+    "id": "ann-headline",
+    "proofId": "nakayama-lemma-oq-01-oq-01",
+    "range": { "startLine": 167, "endLine": 183 },
+    "type": "theorem",
+    "title": "The Headline: μ(M) = dim_k(M/𝔪M)",
+    "content": "Antisymmetry combines the two bounds: existence shows d is attained so μ ≤ d (`Nat.sInf_le`); the lower bound applied to the actual minimizer (`Nat.sInf_mem`) gives μ ≥ d. Hence the minimal number of generators of M equals the k-dimension of its residue space — the clean invariant computing μ(M) by linear algebra.",
+    "mathContext": "$\\mu(M) = \\dim_k(M/\\mathfrak{m}M)$, by $\\mu \\le d$ (attained) and $\\mu \\ge d$ (lower bound on the minimizer).",
+    "significance": "key",
+    "relatedConcepts": ["minimal generators", "residue dimension", "le_antisymm", "Nat.sInf_le / sInf_mem"],
+    "prerequisites": ["the lower bound", "the existence theorem", "infimum characterization"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `nakayama-lemma-oq-01-oq-01`.

## What changed
The entry was missing `annotations.json`. Added 7 line-aligned annotations (validated 7/7, 0 misaligned via `resolver.ts validate`), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Coverage: the μ(M)=dim_k(M/𝔪M) context; the residue-space k-vector-space setup; the bridge lemma (k-span ⟺ R-span mod 𝔪M); the lower bound (every generating set ≥ dim); the Nakayama-powered upper bound (a generating set of size exactly dim); the `numGenerators` definition; and the headline equation via antisymmetry.

## Validation
- `resolver.ts validate`: 7 valid, 0 misaligned
- meta.json already met quality targets and was left intact.