### PR TITLE
Enrich Transcendentals Dense Gδ / Algebraic Reals not Gδ (algebraic-numbers-countable-oq-02-oq-03-oq-02)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 10, "endLine": 51 },
+    "type": "context",
+    "title": "Transcendentals Are a Dense Gδ; Algebraic Reals Are Not Gδ",
+    "content": "The companion entry proves the transcendentals are residual (comeagre), but residuality (`mem_residual`) only says a set contains a dense Gδ. This entry sharpens to the Borel-hierarchy level: the transcendentals ARE a dense Gδ, and the algebraic reals are NOT Gδ. So the algebraic reals are Fσ but not Gδ, the transcendentals Gδ but not Fσ — strictly finer than 'meagre vs comeagre', which both sides' bare statements leave ambiguous.",
+    "mathContext": "Algebraic reals: $F_\\sigma$ (countable union of points) but not $G_\\delta$. Transcendentals: $G_\\delta$ but not $F_\\sigma$.",
+    "significance": "context",
+    "relatedConcepts": ["Gδ and Fσ sets", "Borel hierarchy", "Baire category", "residual sets", "descriptive set theory"],
+    "prerequisites": ["Gδ/Fσ sets", "Baire spaces", "algebraic vs transcendental reals"]
+  },
+  {
+    "id": "ann-compl-countable",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 59, "endLine": 69 },
+    "type": "theorem",
+    "title": "Abstract: Complement of a Countable Set Is a Dense Gδ",
+    "content": "In a perfect T1 Baire space, the complement of a countable set is a dense Gδ. Two facts combine: a countable set is Fσ (countable union of closed singletons) so its complement is Gδ (`Countable.isGδ_compl`); and a countable set is meagre in a perfect space, so its complement is residual hence dense (`dense_of_mem_residual`). This is the abstract form behind 'the transcendentals are a dense Gδ'.",
+    "mathContext": "Perfect $T_1$ Baire space, $s$ countable $\\implies s^c$ is $G_\\delta$ and dense.",
+    "significance": "key",
+    "relatedConcepts": ["countable set is Fσ", "Countable.isGδ_compl", "meagre / residual", "perfect space"],
+    "prerequisites": ["Gδ complement of countable", "residual ⟹ dense in Baire space"]
+  },
+  {
+    "id": "ann-disjoint-densegdelta",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 71, "endLine": 82 },
+    "type": "theorem",
+    "title": "Abstract Engine: No Two Disjoint Dense Gδ Sets",
+    "content": "In a nonempty Baire space, a dense set s that is Gδ cannot be disjoint from a dense Gδ set t: the intersection of two dense Gδ sets is dense (`Dense.inter_of_Gδ`), but s ∩ t = ∅ is not dense in a nonempty space — contradiction. This is the engine showing a dense set disjoint from a dense Gδ cannot itself be Gδ (the classical 'ℚ is not Gδ' argument).",
+    "mathContext": "$s,t$ dense $G_\\delta$, disjoint $\\implies$ False, since $s\\cap t$ is dense (Baire) but empty.",
+    "significance": "key",
+    "relatedConcepts": ["Dense.inter_of_Gδ", "Baire category theorem", "disjoint dense Gδ", "ℚ is not Gδ"],
+    "prerequisites": ["intersection of dense Gδ is dense", "nonempty space"]
+  },
+  {
+    "id": "ann-transcendental-gdelta",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 86, "endLine": 94 },
+    "type": "theorem",
+    "title": "The Transcendental Reals Are Gδ",
+    "content": "The algebraic reals are countable (`algebraic_reals_countable`); in the T1 space ℝ the complement of a countable set is Gδ. The complement of the algebraic reals is exactly the transcendentals, so they are Gδ. Concretizes the abstract complement-of-countable lemma at X = ℝ.",
+    "mathContext": "$\\{x\\in\\mathbb{R} : x \\text{ transcendental}\\} = \\{x : \\mathrm{IsAlgebraic}\\}^c$ is $G_\\delta$ (algebraic reals countable).",
+    "significance": "key",
+    "relatedConcepts": ["transcendental reals", "Gδ set", "countability of algebraic reals"],
+    "prerequisites": ["algebraic_reals_countable", "Gδ complement of countable"]
+  },
+  {
+    "id": "ann-transcendental-densegdelta",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 96, "endLine": 103 },
+    "type": "theorem",
+    "title": "The Transcendentals Are a Dense Gδ",
+    "content": "Combining density (from residuality, `transcendentalReals_dense`) with being Gδ. This is the upgrade of the `mem_residual` witness — which only says a residual set contains a dense Gδ — to the statement that the transcendentals themselves are a dense Gδ.",
+    "mathContext": "$\\{x : x\\text{ transcendental}\\}$ is $G_\\delta$ and dense in $\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["dense Gδ", "residuality ⟹ density", "transcendental reals"],
+    "prerequisites": ["transcendentals are Gδ", "transcendentals are dense"]
+  },
+  {
+    "id": "ann-algebraic-dense",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 105, "endLine": 112 },
+    "type": "theorem",
+    "title": "The Algebraic Reals Are Dense",
+    "content": "The algebraic reals contain ℚ (every rational is algebraic over ℚ, `isAlgebraic_rat`), and ℚ is dense in ℝ (`Rat.denseRange_cast`), so the algebraic reals are dense by monotonicity of density. This density is what makes the not-Gδ obstruction bite.",
+    "mathContext": "$\\mathbb{Q} \\subseteq \\{x : \\mathrm{IsAlgebraic}\\,\\mathbb{Q}\\,x\\}$ and $\\overline{\\mathbb{Q}} = \\mathbb{R}$, so the algebraic reals are dense.",
+    "significance": "supporting",
+    "relatedConcepts": ["density", "rationals dense in ℝ", "rationals are algebraic", "Dense.mono"],
+    "prerequisites": ["isAlgebraic_rat", "Rat.denseRange_cast"]
+  },
+  {
+    "id": "ann-algebraic-not-gdelta",
+    "proofId": "algebraic-numbers-countable-oq-02-oq-03-oq-02",
+    "range": { "startLine": 114, "endLine": 130 },
+    "type": "theorem",
+    "title": "The Algebraic Reals Are NOT Gδ (Headline)",
+    "content": "The classical Baire obstruction applied: the algebraic reals are dense, the transcendentals are a disjoint dense Gδ. If the algebraic reals were also Gδ, the abstract engine would force two disjoint dense Gδ sets to intersect densely — impossible. Hence the algebraic reals are Fσ but not Gδ, the transcendentals Gδ but not Fσ: countability pins their exact Borel-hierarchy location, not merely their Baire category.",
+    "mathContext": "$\\{x : \\mathrm{IsAlgebraic}\\,\\mathbb{Q}\\,x\\}$ is not $G_\\delta$: dense + disjoint from the dense $G_\\delta$ transcendentals.",
+    "significance": "key",
+    "relatedConcepts": ["not Gδ", "Fσ vs Gδ", "Baire obstruction", "Borel hierarchy location"],
+    "prerequisites": ["algebraic reals dense", "transcendentals dense Gδ", "the disjoint-dense-Gδ engine"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `algebraic-numbers-countable-oq-02-oq-03-oq-02`.

## What changed
The entry was missing `annotations.json`. Added 7 line-aligned annotations (validated 7/7, 0 misaligned via `resolver.ts validate`), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Coverage: the Borel-hierarchy refinement context (Fσ-not-Gδ vs Gδ-not-Fσ); the two abstract engines (complement of countable is dense Gδ; no two disjoint dense Gδ); the transcendentals are Gδ / dense Gδ; the algebraic reals are dense; and the headline — algebraic reals are not Gδ.

## Validation
- `resolver.ts validate`: 7 valid, 0 misaligned
- meta.json already met quality targets and was left intact.