### PR TITLE
Gallery integrity: legendre-factorial-formula-oq-01-oq-01 badge verified→mathlib (Tier B)

### DIFF
--- a/src/data/proofs/legendre-factorial-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/legendre-factorial-formula-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "central-binomial",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 115,


### PR DESCRIPTION
## Integrity Issue

**Proof**: legendre-factorial-formula-oq-01-oq-01 (Kummer's Carry-Count Theorem)
**Problem**: Tier-B Mathlib wrapper carries badge `verified` (should be `mathlib`).

## Evidence

The headline theorem obtains its result entirely from Mathlib's `Nat.factorization_choose`:

```lean
theorem padicValNat_choose_eq_carryCount [hp : Fact p.Prime] {n k b : ℕ}
    (hkn : k ≤ n) (hnb : Nat.log p n < b) :
    padicValNat p (n.choose k) = carryCount p k (n - k) b := by
  rw [← Nat.factorization_def _ hp.out, Nat.factorization_choose hp.out hkn hnb]
  rfl
```

`carryCount` is **definitionally** the RHS of `Nat.factorization_choose`, so `rfl`
closes the goal. The remaining 4 theorems are thin corollaries (`dvd_iff_one_le_factorization`
+ `omega`; the central-binomial theorem reruns the same bridge). The core mathematical
content (Kummer's theorem) is Mathlib's — this is auditor failure mode #5, "0 sorries
with hidden imports".

**Verified counts** (all meta fields EXACT): 115 lines, 5 theorems, 1 def, 0 axioms,
0 sorries, no `native_decide`. The lone `decide` (instance v₂(C(4,2))=1) is kernel
reduction on a concrete numeral, no `Lean.ofReduceBool`.

The meta prose is otherwise **exemplary**: `assumptions`, `proofStrategy`, `keyInsight #2`,
and `historicalContext` all explicitly credit `Nat.factorization_choose`. No delegation
opacity, no false novelty claim (no `originalContributions` field). Only the badge enum
was wrong.

**Consistency**: the parent `legendre-factorial-formula-oq-01` and child
`legendre-factorial-formula-oq-01-oq-01-oq-01` are both `verified/mathlib`. This entry
sits between them using the identical wrapper pattern but claimed `verified/verified`.

## Fix

`badge: "verified"` → `"mathlib"`. Status stays `verified` (fully machine-checked,
0 axioms/sorries), per the established convention for Tier-B fully-checked entries.

---
Discovered during gallery integrity audit.