### PR TITLE
Enrich Reflection-Fixed Colorings of an Odd Cycle (burnside-counting-oq-05)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-05/annotations.json
+++ b/src/data/proofs/burnside-counting-oq-05/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 3, "endLine": 31 },
+    "type": "context",
+    "title": "Colorings of an Odd Cycle Fixed by a Reflection",
+    "content": "For the dihedral group Dₙ acting on an n-cycle, this file counts the k-colorings fixed by a reflection, modeled as negation i ↦ −i on ZMod n. A coloring is fixed iff it is constant on each reflection orbit {i, −i}. For odd n = 2m+1 the only fixed point is 0, so the orbits are {0} plus m pairs — m+1 = (n+1)/2 orbits — giving the count k^((n+1)/2). This is the reflection counterpart to the rotation count k^gcd(n,r); both feed Burnside's lemma for the full dihedral necklace count.",
+    "mathContext": "Reflection-fixed $k$-colorings of an odd $n$-cycle: $k^{(n+1)/2}$ (one free color per reflection orbit; $(n+1)/2$ orbits).",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "dihedral group", "necklace counting", "reflection orbits", "fixed colorings"],
+    "prerequisites": ["group actions", "ZMod n", "orbit counting"]
+  },
+  {
+    "id": "ann-reflect",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 37, "endLine": 41 },
+    "type": "definition",
+    "title": "The Reflection as Negation (an Involution)",
+    "content": "The reflection of the n-cycle through position 0 is modeled as negation `reflect i = −i` on ZMod n, and `reflect_involutive` confirms it is an involution (applying it twice is the identity). Negation is the cleanest algebraic model of a reflection fixing position 0.",
+    "mathContext": "$\\mathrm{reflect}(i) = -i$; involutive: $-(-i) = i$.",
+    "significance": "key",
+    "relatedConcepts": ["reflection", "involution", "negation on ZMod n"],
+    "prerequisites": ["ZMod arithmetic", "involutions"]
+  },
+  {
+    "id": "ann-fixed-zero",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 43, "endLine": 59 },
+    "type": "theorem",
+    "title": "Odd n: the Reflection Fixes Only 0",
+    "content": "For n = 2m+1, reflect i = i ⟺ i = 0. From −i = i we get 2·i = 0; since 2 is coprime to the odd modulus 2m+1, it is a unit in ZMod(2m+1), so it can be cancelled, forcing i = 0. The oddness is exactly what makes 2 invertible — for even n the reflection has a second fixed point n/2, changing the orbit count.",
+    "mathContext": "$2$ is a unit mod $2m+1$ (coprime), so $2i = 0 \\implies i = 0$; only fixed point of $i\\mapsto -i$ is $0$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed points", "units of ZMod n", "coprimality of 2 and odd n", "parity dependence"],
+    "prerequisites": ["units in ZMod n", "ZMod.isUnit_iff_coprime"]
+  },
+  {
+    "id": "ann-fundamental-domain",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 61, "endLine": 99 },
+    "type": "definition",
+    "title": "The Fundamental Domain {0,…,m}: incl and fold",
+    "content": "`incl` includes the fundamental domain Fin(m+1) into the cycle; `fold` folds a position i to its representative min(i.val, n − i.val) in {0,…,m}. The lemmas establish the round-trip: `fold_incl` (fold undoes incl), `fold_neg` (fold is reflection-invariant: fold(−i) = fold(i)), and `incl_fold` (incl∘fold returns i or −i). Together these make {0,…,m} an exact set of orbit representatives.",
+    "mathContext": "$\\mathrm{fold}(i) = \\min(i, n-i)$ folds each orbit $\\{i,-i\\}$ to one representative in $\\{0,\\dots,m\\}$; $\\mathrm{fold}(-i)=\\mathrm{fold}(i)$.",
+    "significance": "key",
+    "relatedConcepts": ["fundamental domain", "orbit representatives", "folding map", "round-trip lemmas"],
+    "prerequisites": ["ZMod.val", "min on naturals", "orbit structure"]
+  },
+  {
+    "id": "ann-bijection",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 101, "endLine": 119 },
+    "type": "definition",
+    "title": "The Explicit Bijection with Domain Colorings",
+    "content": "`reflectionInvariantEquiv` is the explicit equivalence: a reflection-invariant coloring of ZMod(2m+1) is the same data as an arbitrary coloring of the fundamental domain Fin(m+1). Forward restricts along incl; inverse reconstructs by folding (well-defined because fold_neg makes it reflection-invariant). The two round-trip lemmas supply left_inv (via incl_fold + invariance) and right_inv (via fold_incl). Constructing an explicit Equiv, rather than just counting, makes the bijection computable.",
+    "mathContext": "$\\{c : \\mathbb{Z}/(2m{+}1)\\to\\mathrm{Fin}\\,k \\mid c(-i)=c(i)\\} \\simeq (\\mathrm{Fin}(m{+}1)\\to\\mathrm{Fin}\\,k).$",
+    "significance": "key",
+    "relatedConcepts": ["Equiv", "explicit bijection", "restriction to fundamental domain", "well-definedness"],
+    "prerequisites": ["the fold/incl round-trip lemmas", "Subtype / Equiv construction"]
+  },
+  {
+    "id": "ann-count",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 121, "endLine": 126 },
+    "type": "theorem",
+    "title": "Reflection-Fixed Count: k^(m+1)",
+    "content": "Transporting the cardinality across the bijection (`Fintype.card_congr`) and using card(Fin(m+1) → Fin k) = k^(m+1) (`Fintype.card_fun`) gives exactly k^(m+1) reflection-invariant colorings for n = 2m+1.",
+    "mathContext": "$\\#\\{c : c(-i)=c(i)\\} = \\#(\\mathrm{Fin}(m{+}1)\\to\\mathrm{Fin}\\,k) = k^{m+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["cardinality via bijection", "Fintype.card_fun", "function space count"],
+    "prerequisites": ["the explicit bijection", "card of a function type"]
+  },
+  {
+    "id": "ann-count-odd",
+    "proofId": "burnside-counting-oq-05",
+    "range": { "startLine": 128, "endLine": 135 },
+    "type": "theorem",
+    "title": "Reflection Count for Any Odd n: k^((n+1)/2)",
+    "content": "Restates the count for an arbitrary odd n: writing n = 2m+1, the count k^(m+1) becomes k^((n+1)/2) (the exponent identity m+1 = (n+1)/2 closed by `omega`). This is the form that plugs into Burnside's lemma alongside the rotation contributions.",
+    "mathContext": "$n$ odd $\\implies \\#\\{\\text{reflection-fixed }k\\text{-colorings}\\} = k^{(n+1)/2}.$",
+    "significance": "supporting",
+    "relatedConcepts": ["odd cycle", "Burnside's lemma input", "exponent rewriting"],
+    "prerequisites": ["the n=2m+1 count", "omega arithmetic"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `burnside-counting-oq-05`.

## What changed
The entry was missing `annotations.json`. Added 7 line-aligned annotations (validated 7/7, 0 misaligned via `resolver.ts validate`), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Coverage: the dihedral-necklace context; the reflection-as-negation involution; odd n fixes only 0 (2 invertible); the fundamental-domain fold/incl machinery with its round-trip lemmas; the explicit reflection-invariant ≃ domain-coloring bijection; and the counts k^(m+1) / k^((n+1)/2).

## Validation
- `resolver.ts validate`: 7 valid, 0 misaligned
- meta.json already met quality targets and was left intact.