### PR TITLE
Enrich Positivity/Growth of Large Schröder Numbers (catalan-numbers-oq-01-oq-03)

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "catalan-numbers-oq-01-oq-03",
+    "range": { "startLine": 4, "endLine": 43 },
+    "type": "context",
+    "title": "Positivity and Exponential Growth of the Large Schröder Numbers",
+    "content": "Mathlib defines the large Schröder numbers via the quadratic (Segner-type convolution) recurrence L(n+1) = L n + ∑_{i≤n} L i·L(n−i) and records only that they are even. This entry adds two quantitative facts Mathlib omits — positivity and a growth rate (ratio ≥ 3, tending to 3+2√2 ≈ 5.83, the larger root of x²−6x+1) — using only natural-number arithmetic and the convolution recurrence. The deeper order-two holonomic recurrence (n+3)L(n+2)+nL n = 3(2n+3)L(n+1), needing generating-function machinery, is left to the Aristotle companion file.",
+    "mathContext": "$L(n{+}1) = L_n + \\sum_{i\\le n} L_i L_{n-i}$; growth ratio $\\to 3+2\\sqrt2$, the larger root of $x^2-6x+1$.",
+    "significance": "context",
+    "relatedConcepts": ["large Schröder numbers", "convolution recurrence", "Catalan numbers", "holonomic / P-recursive sequences", "generating functions"],
+    "prerequisites": ["the Schröder convolution recurrence", "natural-number induction"]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "catalan-numbers-oq-01-oq-03",
+    "range": { "startLine": 49, "endLine": 56 },
+    "type": "theorem",
+    "title": "Positivity: 0 < L n",
+    "content": "The large Schröder numbers are positive. By induction: L 0 = 1 > 0, and the successor case unfolds the recurrence and closes with `positivity` (a sum of products of positives plus a positive term). Mathlib records evenness for n ≠ 0 but not positivity — the basic fact every later bound rests on.",
+    "mathContext": "$0 < L_n$ for all $n$ (by induction on the convolution recurrence).",
+    "significance": "key",
+    "relatedConcepts": ["positivity", "induction", "Schröder recurrence"],
+    "prerequisites": ["the convolution recurrence", "positivity tactic"]
+  },
+  {
+    "id": "ann-conv-bound",
+    "proofId": "catalan-numbers-oq-01-oq-03",
+    "range": { "startLine": 58, "endLine": 74 },
+    "type": "theorem",
+    "title": "Boundary Terms Give 2·L(n+1)",
+    "content": "The convolution sum is at least 2·L(n+1): the two boundary terms i=0 and i=n+1 alone contribute L 0·L(n+1) + L(n+1)·L 0 = 2·L(n+1) (since L 0 = 1). The proof sums over the pair {0, n+1} ⊆ Iic(n+1) and uses monotonicity of sums over subsets (`sum_le_sum_of_subset`, valid since all terms are nonnegative naturals). This extracts the growth factor from the recurrence.",
+    "mathContext": "$2\\,L(n{+}1) = L_0 L(n{+}1) + L(n{+}1) L_0 \\le \\sum_{i\\le n+1} L_i L(n{+}1{-}i).$",
+    "significance": "key",
+    "relatedConcepts": ["boundary terms", "sum over a subset", "Finset.sum_pair", "monotonicity of sums"],
+    "prerequisites": ["L 0 = 1", "sum_le_sum_of_subset"]
+  },
+  {
+    "id": "ann-growth",
+    "proofId": "catalan-numbers-oq-01-oq-03",
+    "range": { "startLine": 76, "endLine": 82 },
+    "type": "theorem",
+    "title": "Step Growth: 3·L(n+1) ≤ L(n+2)",
+    "content": "Each Schröder step grows by a factor of at least 3. Unfolding L(n+2) = L(n+1) + (convolution sum) and using the boundary bound (convolution ≥ 2·L(n+1)) gives L(n+2) ≥ L(n+1) + 2·L(n+1) = 3·L(n+1) (closed by `omega`). The factor 3 is below the true asymptotic ratio 3+2√2 but suffices for an exponential bound.",
+    "mathContext": "$L(n{+}2) = L(n{+}1) + \\sum \\ge L(n{+}1) + 2L(n{+}1) = 3L(n{+}1).$",
+    "significance": "key",
+    "relatedConcepts": ["growth factor", "step ratio", "convolution recurrence"],
+    "prerequisites": ["the boundary-terms bound", "the recurrence"]
+  },
+  {
+    "id": "ann-exponential",
+    "proofId": "catalan-numbers-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 93 },
+    "type": "theorem",
+    "title": "Exponential Lower Bound: 2·3ⁿ ≤ L(n+1)",
+    "content": "Iterating the step-growth factor gives the closed exponential bound 2·3ⁿ ≤ L(n+1). By induction: the base L 1 = 2 = 2·3⁰; the step uses 2·3^(n+1) = 3·(2·3ⁿ) ≤ 3·L(n+1) ≤ L(n+2). So the large Schröder numbers grow at least geometrically with ratio 3 (the actual ratio tends to 3+2√2 ≈ 5.83).",
+    "mathContext": "$2\\cdot 3^n \\le L(n{+}1)$, so $L$ grows at least geometrically with ratio $3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["exponential lower bound", "geometric growth", "induction"],
+    "prerequisites": ["the step-growth bound", "L 1 = 2"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-03`.

## What changed
The entry was missing `annotations.json`. Added 5 line-aligned annotations (validated 5/5, 0 misaligned via `resolver.ts validate`), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

Coverage: the positivity/growth context (and the deeper holonomic recurrence left to the Aristotle companion); positivity 0<Lₙ; the boundary-terms bound (convolution ≥ 2·L(n+1)); step growth 3·L(n+1)≤L(n+2); and the exponential bound 2·3ⁿ≤L(n+1) with the true ratio 3+2√2.

## Validation
- `resolver.ts validate`: 5 valid, 0 misaligned
- meta.json already met quality targets and was left intact.