### PR TITLE
research(lp-duality-synthesis): scope general Lp-duality axiom elimination + bridge lemma

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -1,0 +1,117 @@
+/-
+# Synthesis: Eliminating the `riesz_lp_surjective` Axiom — Full Lᵖ Duality
+(cauchy-schwarz-integral-lp-duality-synthesis)
+
+## Goal
+
+The parent file `CauchySchwarzIntegralOQ01OQ01OQ02.lean` states the Lᵖ Riesz
+representation for an **arbitrary** measure `μ` (1 < p < ∞) as a single axiom:
+
+    axiom riesz_lp_surjective (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
+      (hpq : p.toReal.HolderConjugate q.toReal) :
+      ∀ φ : Lp ℝ p μ →L[ℝ] ℝ, ∃ g : α → ℝ, Memℒp g q μ ∧
+        ∀ f, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ
+
+This file works toward eliminating that axiom by **reducing the arbitrary-measure
+case to the already-proven σ-finite case**, which is the classical strategy of
+Folland, *Real Analysis* (2nd ed.), Theorem 6.16 (valid precisely because
+`1 < p < ∞`).
+
+## What is already verified (0 axioms, 0 sorries) in the dependency chain
+
+* `RieszLpSurjectivity.riesz_lp_surjective_from_rn`  — finite-measure case
+  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean). Radon–Nikodým + Lᵖ machinery.
+* `RieszSigmaFinite.riesz_lp_surjective_sigma_finite` — **σ-finite case**
+  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean), built from the finite case by
+  spanning-set localization (`localization_existence`) + an Lᵖ density extension.
+* `extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ` — the extension-by-zero
+  **isometry** (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean, currently
+  `private`; trivially re-exposable), together with the restriction isometry
+  `eLpNorm (S.indicator f) p μ = eLpNorm f p (μ.restrict S)`.
+
+## The remaining mathematical content: a maximality argument
+
+For an arbitrary measure `μ` and `1 < p < ∞`, every `f ∈ Lᵖ(μ)` is supported on a
+σ-finite set (Mathlib: `MemLp.aefinStronglyMeasurable` → `AEFinStronglyMeasurable`;
+see `memLp_exists_sigmaFinite_support` below). The reduction goes:
+
+1. For each measurable `S` with `μ.restrict S` σ-finite, pull `φ` back along
+   `extByZeroCLM` to a functional on `Lp ℝ p (μ.restrict S)`, and apply the σ-finite
+   Riesz theorem to obtain `g_S ∈ Lq(μ.restrict S)` with `‖g_S‖_q ≤ ‖φ‖`.
+2. Let `c = ⨆_S ‖g_S‖_q` (bounded above by `‖φ‖`, so finite). Pick σ-finite sets
+   `S_n` with `‖g_{S_n}‖_q → c`; set `T = ⋃ₙ S_n`. Then `μ.restrict T` is σ-finite
+   (countable union of σ-finite pieces) and, by uniqueness of the representing
+   function, `g_T` realizes the supremum: `‖g_T‖_q = c`.
+3. For arbitrary `f ∈ Lᵖ(μ)`, its support `Sf` is σ-finite; put `U = T ∪ Sf`. On `U`,
+   `g_U` represents `φ`. Lᵠ-norm additivity over the disjoint pieces `T` and `U \ T`
+   plus maximality `‖g_U‖_q ≤ c = ‖g_T‖_q` forces `g_U = g_T` a.e. on `T` and
+   `g_U = 0` a.e. on `U \ T`. Hence `φ f = ∫ f · g_U = ∫ f · g_T`, with `g_T`
+   extended by `0` off `T`.
+
+The only non-mechanical step is this maximality construction
+(`riesz_representing_function_maximal` below). All other ingredients are already in
+the verified chain or in Mathlib.
+
+## Status
+
+WORK IN PROGRESS. The bridge lemma `memLp_exists_sigmaFinite_support` is complete and
+self-contained. The headline reduction `riesz_lp_surjective_general` is stated with a
+single `sorry` for the maximality construction — it does **not** yet eliminate the
+axiom. Do not present this as verified until the `sorry` is discharged and the file
+builds under the Docker wrapper.
+
+## References
+
+* Folland, *Real Analysis* (2nd ed.), Theorem 6.16.
+* Rudin, *Real and Complex Analysis* (3rd ed.), Theorem 6.16.
+* Mathlib: `MeasureTheory.MemLp.aefinStronglyMeasurable`,
+  `MeasureTheory.AEFinStronglyMeasurable.{sigmaFiniteSet, ae_eq_zero_compl, sigmaFinite_restrict}`.
+-/
+
+import Mathlib
+
+noncomputable section
+
+open MeasureTheory ENNReal
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+namespace RieszLpDualitySynthesis
+
+/-- **Bridge lemma.** For `0 < p < ∞`, every `f ∈ Lᵖ(μ)` is a.e. supported on a
+    measurable set `S` whose restricted measure `μ.restrict S` is σ-finite: `f = 0`
+    a.e. on the complement of `S`.
+
+    This is the ingredient that reduces the *arbitrary-measure* Riesz representation
+    to the *σ-finite* case, and it resolves what the earlier sigma-finite file flagged
+    as a "Lean infrastructure gap": Mathlib already supplies it via
+    `MemLp.aefinStronglyMeasurable`. -/
+theorem memLp_exists_sigmaFinite_support
+    {f : α → ℝ} {p : ℝ≥0∞} (hf : MemLp f p μ) (hp0 : p ≠ 0) (hptop : p ≠ ∞) :
+    ∃ S : Set α, MeasurableSet S ∧ SigmaFinite (μ.restrict S) ∧ f =ᵐ[μ.restrict Sᶜ] 0 := by
+  have h := hf.aefinStronglyMeasurable hp0 hptop
+  exact ⟨h.sigmaFiniteSet, h.measurableSet, h.sigmaFinite_restrict, h.ae_eq_zero_compl⟩
+
+/-- **Riesz representation for Lᵖ — arbitrary measure** (`1 < p < ∞`).
+
+    Every bounded linear functional on `Lp ℝ p μ`, for *any* measure `μ`, is
+    represented by integration against some `g ∈ Lq(μ)`.
+
+    This is the statement of the parent file's `riesz_lp_surjective` axiom, here
+    presented as a theorem to be discharged from `riesz_lp_surjective_sigma_finite`
+    via the maximality argument documented at the top of this file.
+
+    REMAINING WORK: the `sorry` below is the maximality construction
+    (`riesz_representing_function_maximal`). It is HARD (classical, Folland 6.16),
+    not OPEN. All supporting infrastructure already exists in the verified chain. -/
+theorem riesz_lp_surjective_general
+    (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
+    (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)] :
+    ∀ φ : Lp ℝ p μ →L[ℝ] ℝ,
+    ∃ g : α → ℝ, MemLp g q μ ∧
+      ∀ f : Lp ℝ p μ, φ f = ∫ a, (f : α → ℝ) a * g a ∂μ := by
+  sorry
+
+end RieszLpDualitySynthesis
+
+end

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -182,3 +182,71 @@ removes the only open *mathematical* question that was gating the elimination pl
 - Per the project's "flag BLOCKED over PREP churn" rule, marking this **blocked**
   rather than writing a third ORIENT memo. Re-open the moment Docker/Aristotle return:
   build-check the σ-finite `Incomplete01` chain, then apply option (A) iff green.
+
+### 2026-06-23 (Session 4, researcher-7) — PROGRESS (option B de-risked; verifier blackout continues)
+
+**Mode:** REVISIT. **Outcome:** progress (no verified code — Docker hung `docker version` exit 124, Aristotle backend returns `Resource not found`).
+
+**Headline:** the general→σ-finite reduction (option B), which Session 2 dropped from
+the critical path as too hard, is now **fully scoped and de-risked**. The one piece
+prior sessions treated as a vague "Lean infrastructure gap" — the σ-finite support of
+an arbitrary Lᵖ function — **is already in Mathlib**, and the verified chain already
+contains the restriction/extension isometries. The only remaining mathematical content
+is a single maximality argument.
+
+**Why option B (not option A):** Session 2 favored option A (add `[SigmaFinite μ]` to
+the axiom and discharge with `riesz_lp_surjective_sigma_finite`). But that silently
+narrows the published *Full* Lᵖ-duality claim to σ-finite measures — the exact overclaim
+hazard recorded in `surveyFindings`. Option B keeps the unqualified statement and is now
+tractable, so it is the right path.
+
+**What I located (static source read):**
+- `MeasureTheory.MemLp.aefinStronglyMeasurable` (`Mathlib/.../StronglyMeasurable/Lp.lean:59`):
+  `MemLp f p μ → p ≠ 0 → p ≠ ∞ → AEFinStronglyMeasurable f μ`.
+- `AEFinStronglyMeasurable.{sigmaFiniteSet, measurableSet, ae_eq_zero_compl}` +
+  `instance sigmaFinite_restrict` (`StronglyMeasurable/AEStronglyMeasurable.lean:892–916`):
+  yield a measurable `S` with `μ.restrict S` σ-finite and `f =ᵐ[μ.restrict Sᶜ] 0`.
+- Chain already proves (in `…Incomplete01.lean`): `eLpNorm (S.indicator f) p μ =
+  eLpNorm f p (μ.restrict S)` (l.246), `MemLp f p (μ.restrict S) → MemLp (S.indicator f) p μ`
+  (l.260), and the extension-by-zero **isometry** `extByZeroCLM` (l.266, `private`).
+- Mathlib has **no** general Lᵖ duality (`grep` found no `*Dual*` Lp file) — genuine gap
+  the chain fills.
+
+**What I wrote (UNVERIFIED — no build available):**
+- `proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean`:
+  - `memLp_exists_sigmaFinite_support` — the bridge lemma, proven with the confirmed
+    Mathlib API above (high confidence, but not kernel-checked).
+  - `riesz_lp_surjective_general` — the parent axiom restated as a theorem, reduced to a
+    single documented `sorry` for the maximality construction (HARD, not OPEN). File
+    docstring carries the full Folland-6.16 blueprint. **This does not yet eliminate the
+    axiom.**
+
+**Maximality blueprint (the only remaining content):** `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` over
+σ-finite `S` (each `g_S` from σ-finite Riesz on `μ.restrict S` via `extByZeroCLM`-pullback);
+realize `c` on a countable-union hull `T`; for arbitrary `f`, work on `T ∪ supp f` and use
+Lᵠ-norm additivity over disjoint pieces + maximality to pin the representing function to
+`g_T`. Valid exactly for `1 < p < ∞`.
+
+**Next session (verifier back):** build `memLp_exists_sigmaFinite_support`; re-expose
+`extByZeroCLM`; formalize the maximality lemma (or hand it to Aristotle with the chain as
+context + the blueprint as hint); then swap the axiom and flip meta `axiomatized→verified`
+iff green.
+
+#### Bridge lemma source (for preservation; UNVERIFIED)
+
+```lean
+import Mathlib
+open MeasureTheory ENNReal
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+/-- For 0 < p < ∞, every f ∈ Lᵖ(μ) is a.e. supported on a measurable S with
+    μ.restrict S σ-finite. Reduces general Riesz representation to the σ-finite case. -/
+theorem memLp_exists_sigmaFinite_support
+    {f : α → ℝ} {p : ℝ≥0∞} (hf : MemLp f p μ) (hp0 : p ≠ 0) (hptop : p ≠ ∞) :
+    ∃ S : Set α, MeasurableSet S ∧ SigmaFinite (μ.restrict S) ∧ f =ᵐ[μ.restrict Sᶜ] 0 := by
+  have h := hf.aefinStronglyMeasurable hp0 hptop
+  exact ⟨h.sigmaFiniteSet, h.measurableSet, h.sigmaFinite_restrict, h.ae_eq_zero_compl⟩
+```
+
+Full scaffold (with the maximality `sorry` and the reduction blueprint docstring) is in
+`proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean`.

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -38,5 +38,29 @@
   "relatedProofs": [
     "cauchy-schwarz",
     "cauchy-schwarz-integral"
-  ]
+  ],
+  "phase": "ORIENT",
+  "knowledge": {
+    "progressSummary": "ORIENT: Remaining work narrowed to a single maximality argument. Located the exact Mathlib infrastructure supplying the sigma-finite support of Lp functions (MemLp.aefinStronglyMeasurable), and confirmed the verified chain already provides the extension-by-zero isometry (extByZeroCLM) and restriction isometry. Bridge lemma written; scaffold file added with the general theorem reduced to one HARD (not OPEN) sorry. Not yet eliminated: no verifier available this session (Docker hung, Aristotle service returning Resource not found).",
+    "insights": [
+      "The previously-flagged Lean infrastructure gaps are RESOLVED. Mathlib supplies the sigma-finite support of any Lp function (0<p<inf) via MeasureTheory.MemLp.aefinStronglyMeasurable (Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean:59) -> AEFinStronglyMeasurable, whose .sigmaFiniteSet / .measurableSet / .ae_eq_zero_compl / sigmaFinite_restrict instance (StronglyMeasurable/AEStronglyMeasurable.lean:892-916) give a measurable set S with mu.restrict S sigma-finite and f=0 a.e. off S.",
+      "The verified chain ALREADY contains the restriction/extension infrastructure once thought to be a ~150-line gap: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean proves eLpNorm (S.indicator f) p mu = eLpNorm f p (mu.restrict S) (line 246), MemLp f p (mu.restrict S) -> MemLp (S.indicator f) p mu (line 260), and the extension-by-zero ISOMETRY extByZeroCLM : Lp p (mu.restrict S) ->L Lp p mu (line 266, currently private).",
+      "Therefore the ONLY remaining mathematical content for the general (arbitrary-measure) axiom is the maximality argument (Folland 6.16): c = sup over sigma-finite S of ||g_S||_q (bounded by ||phi||); realize c on a countable-union sigma-finite hull T; for arbitrary f, work on T union supp(f) and use Lq-norm additivity over disjoint pieces + maximality to force the representing function to coincide with g_T. Valid precisely for 1<p<inf.",
+      "Public entry point for the reduction is RieszSigmaFinite.riesz_lp_surjective_sigma_finite (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean:173), which is stated for a measure variable with [SigmaFinite mu] and so applies directly to mu.restrict S."
+    ],
+    "builtItems": [
+      "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
+      "Scaffold proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean: states riesz_lp_surjective_general (= the parent axiom as a theorem) reduced to one documented HARD sorry (the maximality construction), with the full reduction blueprint in the file docstring."
+    ],
+    "mathlibGaps": [
+      "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
+      "extByZeroCLM is declared private in Incomplete01.lean; a public re-export (or moving it to a shared location) is needed before the synthesis file can call it."
+    ],
+    "nextSteps": [
+      "When a verifier is available (Docker wrapper or Aristotle), build memLp_exists_sigmaFinite_support to confirm the Mathlib API names, then formalize the maximality lemma riesz_representing_function_maximal.",
+      "Re-expose extByZeroCLM (drop private or add a public alias) and the two restriction lemmas so the synthesis file can reuse them instead of re-proving.",
+      "Submit the maximality reduction to Aristotle (HARD, not OPEN) once the service recovers; give it the chain files as context and the Folland-6.16 blueprint as a hint.",
+      "Only after the sorry is discharged and the file builds: replace axiom riesz_lp_surjective in CauchySchwarzIntegralOQ01OQ01OQ02.lean with the proven theorem and update the gallery meta from axiomatized->verified. Do NOT narrow the statement to [SigmaFinite mu] while keeping the Full-duality title (overclaim hazard already flagged)."
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Research progress on **cauchy-schwarz-integral-lp-duality-synthesis** (Tier A, sig 8) — eliminating the `riesz_lp_surjective` axiom in `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean` (arbitrary-measure Lᵖ Riesz representation, 1 < p < ∞).

This session **scoped and de-risked** the general→σ-finite reduction (Folland 6.16) that prior sessions had dropped as too hard:

- **Located the missing ingredient in Mathlib.** The σ-finite support of an arbitrary Lᵖ function — previously flagged only as a vague "Lean infrastructure gap" — is `MemLp.aefinStronglyMeasurable` → `AEFinStronglyMeasurable.{sigmaFiniteSet, ae_eq_zero_compl, sigmaFinite_restrict}`.
- **Confirmed the verified chain already has the rest.** The restriction isometry and the extension-by-zero isometry `extByZeroCLM` are already proven in `…Incomplete01.lean` (the latter is `private`, needs re-exposing).
- **Conclusion:** the only remaining mathematical content is a single maximality argument (the sup-of-representing-norms / σ-finite-hull construction).

## What's added

- `memLp_exists_sigmaFinite_support` — the **bridge lemma**, proven from the confirmed Mathlib API.
- `riesz_lp_surjective_general` — the parent axiom restated as a theorem, reduced to **one documented `sorry`** for the maximality construction (HARD, not OPEN), with the full reduction blueprint in the file docstring.
- `knowledge.md` / problem `json` — session-4 findings, insights, mathlib gaps, next steps.

## Honesty / status

⚠️ **Not verified, axiom NOT yet eliminated.** No verifier was available this session — the Docker build wrapper hung (`docker version` exit 124) and the Aristotle backend returned `Resource not found`. The bridge lemma uses only confirmed API names (high confidence) but is **not kernel-checked**; the scaffold carries a `sorry`. This is an ORIENT-phase WIP contribution, not a completed proof. The next session with a working verifier should build the bridge lemma, formalize/Aristotle the maximality lemma, then swap the axiom and flip the gallery meta `axiomatized → verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)