### PR TITLE
audit(cramers-rule-oq-04-oq-01-oq-01): badge original → mathlib (Tier B bridge)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "linear-systems",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
@@ -127,7 +127,7 @@
     ]
   },
   "status": "verified",
-  "badge": "original",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Adjugate",


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `cramers-rule-oq-04-oq-01-oq-01` — "The Explicit Cramer Solution: xᵢ = det(Aᵢ)/det A"
**Problem**: Badge `original` overstates independence for a Tier B Mathlib bridge.

## Evidence

Every theorem in `CramersRuleOQ04OQ01OQ01.lean` is a 1–5 line rewrite over Mathlib's Cramer/adjugate lemmas:

- `det_smul_solution_eq_cramer` — one `rw` chain over `cramer_eq_adjugate_mulVec` + `adjugate_mul`
- `det_mul_solution_eq_det_updateCol` — `cramer_apply`
- `cramer_solution` (headline) — division step on top of the above
- `cramer_formula_isSolution` — `mulVec_cramer` + scalar cancel

The core mathematical content — the identification `cramer A b i = det(A.updateCol i b)` (Mathlib's `cramer_apply`) and the adjugate collapse `adj(A)·A = (det A)·I` (Mathlib's `adjugate_mul`) — comes entirely from Mathlib. The file's genuine contribution is the bridge/assembly, which is exactly Tier B.

Per the auditor tier rules: *"Core argument relies on a Mathlib theorem. Our file provides definitions, bridge, or infrastructure. Badge: `mathlib`."*

The prose is already honest and thorough about the reliance ("bridging through Mathlib's `Matrix.cramer`", "assembles ... from those primitives") — only the badge enum was inconsistent with that framing. Same pattern as prior fixes for mason-stothers, cayley, and Jordan–Chevalley–Dunford.

## Fix

- `meta.badge`: `original` → `mathlib`
- top-level `badge`: `original` → `mathlib`
- **`status` stays `verified`** — 0 axioms, 0 sorries, no `native_decide`; a legitimate fully-verified bridge.

All counts (6 theorems, 0 defs, 109 lines, 0 sorries, 0 axioms) are correct and unchanged.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)