### PR TITLE
audit(cramers-rule-oq-04-oq-01-oq-01): badge original → mathlib (Tier B wrapper of Matrix.cramer)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "linear-systems",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
@@ -127,7 +127,7 @@
     ]
   },
   "status": "verified",
-  "badge": "original",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Adjugate",


### PR DESCRIPTION
## Gallery Integrity Issue

**Proof**: `cramers-rule-oq-04-oq-01-oq-01` — "The Explicit Cramer Solution: xᵢ = det(Aᵢ)/det A"
**Problem**: Mathlib wrapper claimed as `original` (badge mis-signals Tier A)
**Severity**: MEDIUM

## Evidence

The entry's core argument is carried entirely by Mathlib's `Matrix.cramer` API:

- `cramer_apply` — `cramer A b i = det(A.updateCol i b)` (the bridge from the abstract adjugate vector to the column-replaced determinant `det(Aᵢ)`)
- `cramer_eq_adjugate_mulVec`, `adjugate_mul` — collapse `(det A)•x = cramer A b`
- `mulVec_cramer` — existence

Every theorem is a thin assembly over these. The headline `cramer_solution` proof body is two lines:

```lean
theorem cramer_solution ... : x i = (A.updateCol i b).det / A.det := by
  rw [eq_div_iff hdet, mul_comm]
  exact det_mul_solution_eq_det_updateCol A x b hx i
```

`det_smul_solution_eq_cramer` is a single `rw` chain of six Mathlib lemmas. The file re-proves none of the determinant/adjugate machinery — it imports it. Per Tier B and Rule #3 (Mathlib Wrapper Detection: `mathlibDependencies` lists `cramer_apply`/`adjugate_mul` AND the Lean file directly calls them for its main result), the badge must be `mathlib`.

The entry's own `mathlibDependencies`, `originalContributions`, `assumptions`, and overview are **already exemplary and honest** — e.g. description says "bridging through Mathlib's Matrix.cramer", overview says "assembles the classical formula ... from those primitives", contributions are scoped to the assembly. Only the `badge` enum mis-signalled independent (Tier A) work.

## Fix

- `badge`: `original` → `mathlib` (both occurrences: `meta.badge` line 21, top-level `badge` line 130)
- `status`: stays `verified` — genuinely 0 sorries, 0 axioms, no `native_decide`/`decide`

## Lean source verification

`proofs/Proofs/CramersRuleOQ04OQ01OQ01.lean`: 6 theorems, 0 defs, 0 sorries, 0 `axiom` declarations, no `decide`/`native_decide`, 109 lines — all other meta fields accurate.

Same correction pattern as `cayleys-theorem-oq-01-oq-01` and `mason-stothers-theorem-oq-01-oq-02`.

---
Discovered during gallery integrity audit.