### PR TITLE
research(catalan-numbers-oq-01-oq-03): reduce large-Schröder holonomic recurrence to single convolution lemma

### DIFF
--- a/proofs/Proofs/SchroderLinearRecurrenceAristotle.lean
+++ b/proofs/Proofs/SchroderLinearRecurrenceAristotle.lean
@@ -6,6 +6,11 @@ import Mathlib.Tactic
 
 This file isolates the HARD (but classical) result for automated proof search.
 
+The headline recurrence `largeSchroder_holonomic` is now proved *unconditionally on top of*
+the single convolution lemma `largeSchroder_conv_holonomic` (the reduction is a routine
+`linear_combination`, recorded below).  Hence the **only** remaining `sorry` — the sole piece
+needing generating-function / creative-telescoping machinery — is `largeSchroder_conv_holonomic`.
+
 The large Schröder numbers `L = Nat.largeSchroder` satisfy the order-two holonomic
 (P-recursive) linear recurrence
 
@@ -43,10 +48,26 @@ theorem largeSchroder_conv_holonomic (n : ℕ) :
   sorry
 
 /-- **Order-two holonomic recurrence for the large Schröder numbers.**
-`(n + 3) * L (n+2) + n * L n = 3 * (2n + 3) * L (n+1)`. -/
+`(n + 3) * L (n+2) + n * L n = 3 * (2n + 3) * L (n+1)`.
+
+This is a *mechanical consequence* of the convolution-form recurrence
+`largeSchroder_conv_holonomic` together with the defining quadratic recurrence
+`Nat.largeSchroder_succ` (which gives `L (n+1) = L n + Q n` and
+`L (n+2) = L (n+1) + Q (n+1)`).  Substituting both and eliminating the
+convolution sum `Q (n+1)` via the convolution form leaves a linear identity
+in `L n`, `Q n`, `Q (n+1)` that `linear_combination` discharges.  Thus the
+only genuinely hard content is `largeSchroder_conv_holonomic`. -/
 theorem largeSchroder_holonomic (n : ℕ) :
     (n + 3) * largeSchroder (n + 2) + n * largeSchroder n
       = 3 * (2 * n + 3) * largeSchroder (n + 1) := by
-  sorry
+  have hconv := largeSchroder_conv_holonomic n
+  rw [largeSchroder_succ (n + 1), largeSchroder_succ n]
+  -- After the two rewrites, both the goal and `hconv` are expressed in `largeSchroder n`
+  -- and the two convolution sums `Q n` and `Q (n+1)`; abstract the latter so the remaining
+  -- step is a pure linear identity.
+  set S := ∑ i ≤ n, largeSchroder i * largeSchroder (n - i)
+  set T := ∑ i ≤ n + 1, largeSchroder i * largeSchroder (n + 1 - i)
+  zify at hconv ⊢
+  linear_combination hconv
 
 end Nat

--- a/src/data/research/problems/catalan-numbers-oq-01-oq-03.json
+++ b/src/data/research/problems/catalan-numbers-oq-01-oq-03.json
@@ -17,20 +17,23 @@
   "problemStatement": "Develop the large Schröder numbers Nat.largeSchroder (Mathlib provides only the quadratic convolution recurrence and evenness): prove positivity, growth bounds, and the order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1), the Schröder analogue of the Catalan first-order recurrence in catalan-numbers-oq-01.",
   "currentState": "Positivity, convolution lower bound, step growth 3·L(n+1) ≤ L(n+2), and exponential bound 2·3ⁿ ≤ L(n+1) are proved and verified (0 axioms, 0 sorries) in Proofs/SchroderLinearRecurrence.lean. The order-two holonomic recurrence remains a sorry in the companion Proofs/SchroderLinearRecurrenceAristotle.lean, awaiting automated proof search (Aristotle service was unavailable this session).",
   "knowledge": {
-    "progressSummary": "PROGRESS: shipped verified positivity + geometric growth (2·3ⁿ ≤ L(n+1)) for Mathlib's large Schröder numbers; order-two holonomic recurrence set up for Aristotle with full GF proof sketch.",
+    "progressSummary": "PROGRESS: holonomic recurrence reduced to (and proved from) the single convolution lemma largeSchroder_conv_holonomic; only that lemma remains as a sorry (needs GF/PowerSeries or Aristotle). Build pending docker recovery.",
     "insights": [
       "Mathlib's Combinatorics/Enumerative/Schroder.lean defines Nat.largeSchroder by the quadratic convolution recurrence and records ONLY evenness (Nat.even_largeSchroder) — positivity and growth are genuine gaps.",
       "Factor-3 step growth L(n+2) ≥ 3·L(n+1) comes for free from just the two boundary convolution terms (i=0 and i=n+1, each = L(n+1)) plus the leading +L(n+1); no interior-term analysis needed.",
       "The true growth ratio is 3+2√2 ≈ 5.83, the dominant root of x²−6x+1 (the discriminant of the Schröder GF equation x f² + (x−1) f + 1 = 0); the elementary boundary bound only yields the integer floor 3.",
       "Full GF proof of the order-two recurrence: f = ∑ L n xⁿ satisfies x f² + (x−1) f + 1 = 0; differentiating and eliminating f²/ff' gives the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1); the xⁿ-coefficient is (n+1)L(n) = 3(2n−1)L(n−1) − (n−2)L(n−2), i.e. (n+3)L(n+2)+nL(n)=3(2n+3)L(n+1).",
-      "Clean convolution reformulation of the holonomic recurrence (no GF needed to STATE): with Q(n)=∑ i≤n, L i·L(n−i), the recurrence is equivalent to (n+3)·Q(n+1) = (5n+6)·Q(n) + (4n+6)·L(n)."
+      "Clean convolution reformulation of the holonomic recurrence (no GF needed to STATE): with Q(n)=∑ i≤n, L i·L(n−i), the recurrence is equivalent to (n+3)·Q(n+1) = (5n+6)·Q(n) + (4n+6)·L(n).",
+      "The headline order-two holonomic recurrence is a MECHANICAL linear-combination corollary of the convolution form (n+3)Q(n+1)=(5n+6)Q(n)+(4n+6)L(n): substitute L(n+1)=L(n)+Q(n), L(n+2)=L(n+1)+Q(n+1) and eliminate (n+3)Q(n+1). So ALL difficulty is isolated in the single lemma largeSchroder_conv_holonomic.",
+      "GF elimination route for conv_holonomic: f=∑L(n)xⁿ satisfies X·f²+(X−1)f+1=0 (⟺ largeSchroder_succ). Differentiate: f²+f+(2Xf+X−1)f′=0. Multiply by X and subtract the algebraic eqn to kill X·f²: get X(2Xf+X−1)f′=1−f. Since [ℚ(x)(f):ℚ(x)]=2, f′=a(x)+b(x)f for rational a,b; clearing denominators by x(x²−6x+1) yields x(x²−6x+1)f′=(3x−1)f+(x+1), whose xⁿ-coefficient is the recurrence."
     ],
     "builtItems": [
       "Nat.largeSchroder_pos (Proofs/SchroderLinearRecurrence.lean): 0 < largeSchroder n, by structural induction",
       "Nat.two_mul_largeSchroder_le_conv: 2·L(n+1) ≤ ∑ i≤n+1, L i·L(n+1−i) via the {0,n+1} boundary terms",
       "Nat.largeSchroder_ge_three_mul: 3·L(n+1) ≤ L(n+2)",
       "Nat.largeSchroder_ge_two_mul_three_pow: 2·3ⁿ ≤ L(n+1) (closed exponential lower bound)",
-      "Proofs/SchroderLinearRecurrenceAristotle.lean: companion stating largeSchroder_holonomic and its convolution form largeSchroder_conv_holonomic as sorries with GF proof sketch"
+      "Proofs/SchroderLinearRecurrenceAristotle.lean: companion stating largeSchroder_holonomic and its convolution form largeSchroder_conv_holonomic as sorries with GF proof sketch",
+      "Nat.largeSchroder_holonomic (Proofs/SchroderLinearRecurrenceAristotle.lean): (n+3)·L(n+2)+n·L(n)=3(2n+3)·L(n+1) PROVED conditionally on largeSchroder_conv_holonomic — reduction is rw[largeSchroder_succ (n+1), largeSchroder_succ n] + set + zify + linear_combination (algebra hand-verified: goal_diff − hconv_diff = 0 over ℤ)"
     ],
     "mathlibGaps": [
       "No positivity lemma for Nat.largeSchroder (only Nat.even_largeSchroder).",
@@ -40,7 +43,8 @@
     "nextSteps": [
       "Submit Proofs/SchroderLinearRecurrenceAristotle.lean to Aristotle when the service returns (prove largeSchroder_holonomic; the convolution-form lemma may be the easier intermediate).",
       "If proving by hand: formalize the GF argument in Mathlib PowerSeries (PowerSeries.derivative is a Derivation with coeff_derivative) — establish X f² + (X−1) f + 1 = 0 from largeSchroder_succ via coeff_mul, then the ODE by elimination.",
-      "Upgrade growth to the sharp ratio L(n+1)/L n → 3+2√2 over ℝ."
+      "Upgrade growth to the sharp ratio L(n+1)/L n → 3+2√2 over ℝ.",
+      "Finish largeSchroder_conv_holonomic (the SOLE remaining sorry): either (a) Aristotle when service returns (currently \"Resource not found\"), or (b) hand GF proof in Mathlib PowerSeries — establish X·f²+(X−1)f+1=0 via coeff_mul from largeSchroder_succ, then derive the linear ODE and read off the xⁿ coefficient."
     ],
     "markdown": ""
   },


### PR DESCRIPTION
## Summary

Advances **catalan-numbers-oq-01-oq-03** (order-two holonomic recurrence for the large Schröder numbers `L = Nat.largeSchroder`).

Proves `Nat.largeSchroder_holonomic`:
$$(n+3)\,L(n+2) + n\,L(n) = 3(2n+3)\,L(n+1)$$
as a **mechanical consequence** of the convolution-form lemma `largeSchroder_conv_holonomic` plus Mathlib's defining quadratic recurrence `Nat.largeSchroder_succ`.

### The reduction
Writing `Q n = ∑ i ≤ n, L i · L (n-i)`, `largeSchroder_succ` gives `L(n+1)=L(n)+Q(n)` and `L(n+2)=L(n+1)+Q(n+1)`. Substituting both and eliminating `(n+3)·Q(n+1)` via the convolution form
$$(n+3)\,Q(n+1) = (5n+6)\,Q(n) + (4n+6)\,L(n)$$
leaves a pure linear identity in `L(n), Q(n), Q(n+1)`, discharged by `set` + `zify` + `linear_combination`. The algebra is hand-verified: `goal_diff − hconv_diff = 0` over ℤ.

### Impact
This **isolates all remaining difficulty** into the single lemma `largeSchroder_conv_holonomic` — now the sole `sorry` in the companion file (was 2). That lemma is the genuine generating-function content (`f = ∑ L(n)xⁿ` satisfies `X·f² + (X−1)f + 1 = 0`, giving the ODE `x(x²−6x+1)f′=(3x−1)f+(x+1)`); the full elimination derivation is documented in the file and in the problem's `knowledge.json` for Aristotle or a future PowerSeries proof.

### Status / verification
- The companion file remains an **Aristotle staging file** carrying one documented `sorry` (`largeSchroder_conv_holonomic`); the entry stays **in-progress**, not verified.
- **Build not yet kernel-verified locally**: Docker daemon hung (exit 124) and the Aristotle `prove` service is currently unreachable ("Resource not found"). The reduction mirrors the exact `rw [largeSchroder_succ (n+1)]`-against-`largeSchroder (n+2)` pattern already verified in the merged sibling `SchroderLinearRecurrence.lean`. The deployer build-gate will confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)