### PR TITLE
Enrich Roth/Szemerédi OQ-03-OQ-01-OQ-01 (multilinearity of Λ_k)

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "roth-oq030101-import-parent",
+    "proofId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+    "range": { "startLine": 31, "endLine": 37 },
+    "type": "concept",
+    "title": "Importing the parent operator Λ_k",
+    "content": "The file builds directly on `Proofs.RothTheoremOQ03OQ01`, which defines the k-AP counting operator `kAPCount` (written Λ_k) and the Gowers norm `gowersNorm`, and proves the constant/normalization/annihilation identities. No new definitions are introduced here (definitionCount = 0); the whole file is structural theorems about an object defined elsewhere. The section opens `Finset` and `BigOperators` so that `∏ i, …`, `univ`, and `erase` are in scope, and fixes `{N : ℕ} [NeZero N]` so that `ZMod N` is a nonzero ring throughout.",
+    "mathContext": "$\\Lambda_k(f_0,\\dots,f_{k-1}) = \\mathbb{E}_{x,d\\in\\mathbb{Z}/N\\mathbb{Z}}\\;\\prod_{i<k} f_i(x+i\\cdot d)$",
+    "significance": "supporting",
+    "prerequisites": ["finite products over Fin k", "ZMod N as a finite ring", "averaging operator E"],
+    "relatedConcepts": ["k-term arithmetic progression", "Gowers norm", "counting operator"]
+  },
+  {
+    "id": "roth-oq030101-engine",
+    "proofId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 52 },
+    "type": "theorem",
+    "title": "prod_update_factor — the factorization engine",
+    "content": "This is the single lemma that powers everything else. Replacing slot `j` of the tuple `f` by a function `v` (using `Function.update f j v`) lets you pull the j-th factor `v(x + j·d)` clean out of the k-AP product, leaving the product of the untouched factors over `univ.erase j`. Once a slot can be isolated this way, additivity and homogeneity become routine bookkeeping over the remaining product. Multilinearity properties of any indexed product are almost always reduced to exactly this 'isolate one coordinate' move.",
+    "mathContext": "$\\prod_{i<k} \\big(\\mathrm{update}\\,f\\,j\\,v\\big)_i(x+i d) = v(x+j d)\\cdot \\prod_{i\\neq j} f_i(x+i d)$",
+    "significance": "critical",
+    "prerequisites": ["Finset.mul_prod_erase", "Function.update", "products over a finite index"],
+    "relatedConcepts": ["multilinearity", "coordinate projection", "Function.update"]
+  },
+  {
+    "id": "roth-oq030101-mul-prod-erase",
+    "proofId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+    "range": { "startLine": 46, "endLine": 51 },
+    "type": "tactic",
+    "title": "Isolating the j-th factor with mul_prod_erase",
+    "content": "The proof rewrites the full product `∏ i ∈ univ` as `(j-th factor) * ∏ i ∈ univ.erase j` via `Finset.mul_prod_erase` (valid since `j ∈ univ`). It then splits into two `congr 1` goals: the isolated factor is evaluated with `Function.update_self` (which fires because the index *is* `j`), and the residual product is matched termwise with `Function.update_of_ne`, using `Finset.ne_of_mem_erase` to supply the proof that each surviving index differs from `j`. This is the canonical Lean idiom for 'peel one term off a Finset product'.",
+    "mathContext": "$f_a \\cdot \\prod_{i\\in s\\setminus\\{a\\}} f_i = \\prod_{i\\in s} f_i \\quad (a\\in s)$",
+    "significance": "key",
+    "prerequisites": ["Finset.erase", "Function.update_self / update_of_ne", "congr"],
+    "relatedConcepts": ["telescoping a product", "Finset.prod_congr"]
+  },
+  {
+    "id": "roth-oq030101-add-slot",
+    "proofId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+    "range": { "startLine": 53, "endLine": 65 },
+    "type": "theorem",
+    "title": "kAPCount_add_slot — additivity in one slot",
+    "content": "Λ_k is additive in its j-th argument: `Λ_k(…, a+b, …) = Λ_k(…,a,…) + Λ_k(…,b,…)`. After unfolding `kAPCount`, the engine `prod_update_factor` isolates the j-th factor; `Pi.add_apply` and `add_mul` split it as `a(x+j d)·P + b(x+j d)·P`. The double average `E_{x,d}` is then distributed over the sum with `Finset.sum_add_distrib` applied twice (once for the outer x-sum, once for the inner d-sum). This is one half of multilinearity.",
+    "mathContext": "$\\Lambda_k(\\dots,a+b,\\dots) = \\Lambda_k(\\dots,a,\\dots) + \\Lambda_k(\\dots,b,\\dots)$",
+    "significance": "critical",
+    "prerequisites": ["Finset.sum_add_distrib", "Pi.add_apply", "distributivity (add_mul)"],
+    "relatedConcepts": ["multilinear map", "generalized von Neumann inequality", "linearity in a coordinate"]
+  },
+  {
+    "id": "roth-oq030101-smul-slot",
+    "proofId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 80 },
+    "type": "theorem",
+    "title": "kAPCount_smul_slot — homogeneity in one slot",
+    "content": "Λ_k is homogeneous in its j-th argument: `Λ_k(…, c•a, …) = c · Λ_k(…,a,…)`. The same factorization engine isolates the j-th factor; `Pi.smul_apply` and `smul_eq_mul` turn it into `c · a(x+j d) · P`. The scalar `c` is then pulled out through both layers of the double average with `Finset.mul_sum` (twice), and `ring` closes the rearrangement `mul_left_comm`. Together with `kAPCount_add_slot` this establishes that Λ_k is multilinear — additive and homogeneous in each of its k slots separately.",
+    "mathContext": "$\\Lambda_k(\\dots,c\\cdot a,\\dots) = c\\cdot\\Lambda_k(\\dots,a,\\dots)$",
+    "significance": "critical",
+    "prerequisites": ["Finset.mul_sum", "Pi.smul_apply / smul_eq_mul", "ring"],
+    "relatedConcepts": ["scalar homogeneity", "multilinear map", "linearity in a coordinate"]
+  },
+  {
+    "id": "roth-oq030101-gowers-nonneg",
+    "proofId": "roth-theorem-k3-oq-03-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 86 },
+    "type": "theorem",
+    "title": "gowersNorm_nonneg — the Gowers norm is nonnegative",
+    "content": "The Gowers Uˢ norm is ≥ 0. Because `gowersNorm` is defined in the parent file as a genuine modulus `‖·‖`, nonnegativity is immediate from `norm_nonneg`. This is the first of the metric properties a quantity must satisfy to be used as a control on error terms: density- and energy-increment arguments bound the multilinear cross-terms of Λ_k by Gowers norms, so those bounds are only meaningful once the norm is known to be a nonnegative quantity.",
+    "mathContext": "$\\|f\\|_{U^s} \\ge 0$",
+    "significance": "supporting",
+    "prerequisites": ["norm_nonneg", "definition of the Gowers norm as a modulus"],
+    "relatedConcepts": ["Gowers uniformity norm", "seminorm axioms", "generalized von Neumann inequality"]
+  }
+]

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/index.ts
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/RothTheoremOQ03OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const rothTheoremK3OQ03OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const rothTheoremK3OQ03OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const rothTheoremK3OQ03OQ01OQ01Data: ProofData = {
+  proof: rothTheoremK3OQ03OQ01OQ01Proof,
+  annotations: rothTheoremK3OQ03OQ01OQ01Annotations,
+}

--- a/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03-oq-01-oq-01/meta.json
@@ -125,6 +125,11 @@
       "targetId": "roth-theorem-k3-oq-03",
       "relationship": "specializes",
       "description": "Grandparent: Gowers norms and the k-AP counting operator for Roth's theorem."
+    },
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "extends",
+      "description": "Root entry: Roth's theorem (Szemerédi k=3), the density result whose modern proof drives the density-increment expansions that multilinearity of Λ_k powers."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `roth-theorem-k3-oq-03-oq-01-oq-01`.

## Quality improvements

**Critical fix — proof was unreachable on the live site:**
- Created the missing `index.ts`. Without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered "proof not found". Structurally identical to the verified template; imports `Proofs/RothTheoremOQ03OQ01OQ01.lean?raw`.

**Annotation coverage (file had none):**
- Added `annotations.json` with 6 annotations spanning the whole Lean file: parent-operator import, the `prod_update_factor` factorization engine, the `Finset.mul_prod_erase` slot-isolation idiom, additivity (`kAPCount_add_slot`), homogeneity (`kAPCount_smul_slot`), and `gowersNorm_nonneg`.
- Each annotation carries `mathContext` (LaTeX), `significance`, `prerequisites`, and `relatedConcepts`.

**Cross-references:**
- Added a link to the root entry `roth-theorem-k3` alongside the existing grandparent link.

## Verification
- Both JSON files parse cleanly; the build's data-enrichment generation step processed the entry without error.
- `index.ts` is byte-for-byte structurally identical to a known-working gallery `index.ts` (verified by diff), with correct camelCase naming and a resolving Lean file path.
- Note: `tsc` typecheck could not run in the fresh worktree (the native `better-sqlite3` install fails under Node 26); this is a pre-existing environment constraint, not a content issue.
- Axiom integrity: `status: verified`, `badge: verified`, `axiomCount: 0` confirmed against the Lean source (only propext/Classical.choice/Quot.sound; no native_decide, no structure-encoded assumptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)