### PR TITLE
research(lp-duality-synthesis): docstring precision — source-complete vs build-verified

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -17,17 +17,28 @@ case to the already-proven σ-finite case**, which is the classical strategy of
 Folland, *Real Analysis* (2nd ed.), Theorem 6.16 (valid precisely because
 `1 < p < ∞`).
 
-## What is already verified (0 axioms, 0 sorries) in the dependency chain
+## State of the dependency chain (source-complete; not re-build-verified this session)
+
+The reduction in this file targets the σ-finite Riesz theorem. The chain below is
+**source-complete** — `grep` finds no `sorry` *tactic* and no `axiom` in any of these
+files (the only "sorry" tokens are historical notes in their docstrings). It has,
+however, **not** been re-verified under the Docker build wrapper this session (daemon
+hung), so "0 sorry / 0 axiom" is a static-source fact, not a fresh kernel check:
 
 * `RieszLpSurjectivity.riesz_lp_surjective_from_rn`  — finite-measure case
-  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean). Radon–Nikodým + Lᵖ machinery.
+  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean; 0 sorry / 0 axiom). Radon–Nikodým + Lᵖ.
 * `RieszSigmaFinite.riesz_lp_surjective_sigma_finite` — **σ-finite case**
-  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean), built from the finite case by
-  spanning-set localization (`localization_existence`) + an Lᵖ density extension.
-* `extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ` — the extension-by-zero
-  **isometry** (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean, currently
-  `private`; trivially re-exposable), together with the restriction isometry
+  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean; 0 sorry / 0 axiom), built from the
+  finite case by spanning-set localization (`localization_existence`) + an Lᵖ density
+  extension (both discharged; the docstring "HARD sorry" tags are historical).
+* `extByZeroCLM : Lp ℝ p (μ.restrict S) →L[ℝ] Lp ℝ p μ` — the extension-by-zero CLM
+  (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean; 0 sorry / 0 axiom;
+  currently `private`, trivially re-exposable), together with the restriction isometry
   `eLpNorm (S.indicator f) p μ = eLpNorm f p (μ.restrict S)`.
+
+So the remaining gap to eliminating the parent axiom is the maximality construction
+below (one `sorry`), plus re-exposing `extByZeroCLM`. Until that `sorry` is discharged
+*and* the whole chain rebuilds green, this file does **not** reduce the assumption count.
 
 ## The remaining mathematical content: a maximality argument
 
@@ -49,8 +60,9 @@ see `memLp_exists_sigmaFinite_support` below). The reduction goes:
    extended by `0` off `T`.
 
 The only non-mechanical step is this maximality construction
-(`riesz_representing_function_maximal` below). All other ingredients are already in
-the verified chain or in Mathlib.
+(`riesz_representing_function_maximal` below). The remaining ingredients are *either*
+already in Mathlib (the bridge lemma's σ-finite-support fact) *or* source-complete in the
+dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accounting above.
 
 ## Status
 

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -250,3 +250,43 @@ theorem memLp_exists_sigmaFinite_support
 
 Full scaffold (with the maximality `sorry` and the reduction blueprint docstring) is in
 `proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean`.
+
+### 2026-06-23 (Session 5, researcher-7) — VERIFIER-BLOCKED (5th consecutive); docstring precision fix
+
+**Mode:** REVISIT. **Outcome:** minor integrity/precision improvement; no new verified math.
+
+- **Verifier blackout persists** — `docker info` exit 124 (daemon hung); Aristotle
+  `mcp__aristotle__prove` returns `Resource not found`. This is the 5th consecutive
+  session (S1–S5) blocked on the same wall. No Lean proof anywhere can be kernel-checked
+  right now, so switching problems would not help.
+- **Re-verified the chain's sorry status the right way.** A naive `grep -c '\bsorry\b'`
+  reports 11/10/1 sorries in the σ-finite/finite/Incomplete01 files — but **all** of those
+  tokens are in docstrings/comments (historical "[HARD sorry ~150 lines]" notes). There
+  are **zero `sorry` tactics** and zero `axiom`s in the chain: it is source-complete. The
+  S1 proof-tree map ("0 sorry / 0 axiom") was correct. GOTCHA recorded: never count chain
+  sorries with `grep -c` — these files document their own proof history in prose.
+- **Confirmed the bridge lemma is API-sound** against the on-disk Mathlib
+  (`proofs/.lake/packages/mathlib`): `MemLp.aefinStronglyMeasurable` (StronglyMeasurable/Lp.lean:59),
+  `AEFinStronglyMeasurable.sigmaFiniteSet` (AEStronglyMeasurable.lean:904), `.measurableSet`
+  (:907, protected — fine via dot-notation), `.ae_eq_zero_compl` (:911), and
+  `instance sigmaFinite_restrict` (:915) all exist with exactly the used signatures. High
+  confidence `memLp_exists_sigmaFinite_support` compiles.
+- **Docstring precision fix** to `CauchySchwarzIntegralLpDualitySynthesis.lean`: replaced
+  the bare "What is already verified (0 axioms, 0 sorries)" header — which overstated by
+  implying a fresh kernel check — with an accurate "source-complete; not re-build-verified
+  this session" accounting that distinguishes static-source 0-sorry from a green build.
+- **Why no new Lean code:** the only remaining content is the maximality construction
+  (Folland 6.16, ~100–150 lines of finicky measure theory: a supremum over σ-finite sets,
+  hull via countable union, Lq-additivity + uniqueness to pin the representer). Formalizing
+  this *requires* a verifier to get the signatures right; writing it blind would ship
+  unverifiable, near-certainly-broken code — worse than the current one clean `sorry` +
+  prose blueprint. Declined to churn.
+
+**Next session (verifier back) — concrete coding targets (in dependency order):**
+1. `sigmaFinite_restrict_iUnion : (∀ n, SigmaFinite (μ.restrict (S n))) → SigmaFinite (μ.restrict (⋃ n, S n))`
+   — step-2 hull lemma; not a Mathlib one-liner (checked); good Aristotle target.
+2. Re-expose `extByZeroCLM` (drop `private` in `…Incomplete01.lean`).
+3. The representer-with-norm-bound `g_S` from σ-finite Riesz via `extByZeroCLM`-pullback.
+4. The supremum `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` realized on the hull `T`; uniqueness ⇒ `g_U = g_T`.
+5. Assemble `riesz_lp_surjective_general`, build green, then swap the parent axiom and flip
+   meta `axiomatized → verified`.

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -41,12 +41,14 @@
   ],
   "phase": "ORIENT",
   "knowledge": {
-    "progressSummary": "ORIENT: Remaining work narrowed to a single maximality argument. Located the exact Mathlib infrastructure supplying the sigma-finite support of Lp functions (MemLp.aefinStronglyMeasurable), and confirmed the verified chain already provides the extension-by-zero isometry (extByZeroCLM) and restriction isometry. Bridge lemma written; scaffold file added with the general theorem reduced to one HARD (not OPEN) sorry. Not yet eliminated: no verifier available this session (Docker hung, Aristotle service returning Resource not found).",
+    "progressSummary": "VERIFIER-BLOCKED (5 consecutive sessions: docker exit124 + Aristotle Resource-not-found). Bridge lemma verified API-sound; chain confirmed source-complete; only the Folland-6.16 maximality construction (~150L, verifier-required) remains. S5: docstring precision fix (source-complete vs build-verified).",
     "insights": [
       "The previously-flagged Lean infrastructure gaps are RESOLVED. Mathlib supplies the sigma-finite support of any Lp function (0<p<inf) via MeasureTheory.MemLp.aefinStronglyMeasurable (Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean:59) -> AEFinStronglyMeasurable, whose .sigmaFiniteSet / .measurableSet / .ae_eq_zero_compl / sigmaFinite_restrict instance (StronglyMeasurable/AEStronglyMeasurable.lean:892-916) give a measurable set S with mu.restrict S sigma-finite and f=0 a.e. off S.",
       "The verified chain ALREADY contains the restriction/extension infrastructure once thought to be a ~150-line gap: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean proves eLpNorm (S.indicator f) p mu = eLpNorm f p (mu.restrict S) (line 246), MemLp f p (mu.restrict S) -> MemLp (S.indicator f) p mu (line 260), and the extension-by-zero ISOMETRY extByZeroCLM : Lp p (mu.restrict S) ->L Lp p mu (line 266, currently private).",
       "Therefore the ONLY remaining mathematical content for the general (arbitrary-measure) axiom is the maximality argument (Folland 6.16): c = sup over sigma-finite S of ||g_S||_q (bounded by ||phi||); realize c on a countable-union sigma-finite hull T; for arbitrary f, work on T union supp(f) and use Lq-norm additivity over disjoint pieces + maximality to force the representing function to coincide with g_T. Valid precisely for 1<p<inf.",
-      "Public entry point for the reduction is RieszSigmaFinite.riesz_lp_surjective_sigma_finite (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean:173), which is stated for a measure variable with [SigmaFinite mu] and so applies directly to mu.restrict S."
+      "Public entry point for the reduction is RieszSigmaFinite.riesz_lp_surjective_sigma_finite (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean:173), which is stated for a measure variable with [SigmaFinite mu] and so applies directly to mu.restrict S.",
+      "S5: chain is source-complete (0 sorry tactics / 0 axiom) — naive grep -c overcounts docstring \"sorry\" tokens; never count chain sorries with grep -c",
+      "S5: bridge lemma memLp_exists_sigmaFinite_support confirmed API-sound vs on-disk Mathlib (aefinStronglyMeasurable + sigmaFiniteSet/measurableSet/ae_eq_zero_compl/sigmaFinite_restrict all exist with used signatures)"
     ],
     "builtItems": [
       "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
@@ -54,13 +56,15 @@
     ],
     "mathlibGaps": [
       "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
-      "extByZeroCLM is declared private in Incomplete01.lean; a public re-export (or moving it to a shared location) is needed before the synthesis file can call it."
+      "extByZeroCLM is declared private in Incomplete01.lean; a public re-export (or moving it to a shared location) is needed before the synthesis file can call it.",
+      "sigmaFinite_restrict_iUnion (countable union of σ-finite restrictions is σ-finite-restricted) is NOT a Mathlib one-liner — needs building; step-2 hull ingredient"
     ],
     "nextSteps": [
-      "When a verifier is available (Docker wrapper or Aristotle), build memLp_exists_sigmaFinite_support to confirm the Mathlib API names, then formalize the maximality lemma riesz_representing_function_maximal.",
-      "Re-expose extByZeroCLM (drop private or add a public alias) and the two restriction lemmas so the synthesis file can reuse them instead of re-proving.",
-      "Submit the maximality reduction to Aristotle (HARD, not OPEN) once the service recovers; give it the chain files as context and the Folland-6.16 blueprint as a hint.",
-      "Only after the sorry is discharged and the file builds: replace axiom riesz_lp_surjective in CauchySchwarzIntegralOQ01OQ01OQ02.lean with the proven theorem and update the gallery meta from axiomatized->verified. Do NOT narrow the statement to [SigmaFinite mu] while keeping the Full-duality title (overclaim hazard already flagged)."
+      "[verifier-gated] Build sigmaFinite_restrict_iUnion (good Aristotle target)",
+      "[verifier-gated] Re-expose extByZeroCLM (drop private)",
+      "[verifier-gated] Representer g_S w/ norm bound via σ-finite Riesz + extByZeroCLM-pullback",
+      "[verifier-gated] Supremum c=⨆‖g_S‖_q realized on hull T; uniqueness ⇒ g_U=g_T",
+      "[verifier-gated] Assemble riesz_lp_surjective_general, build green, swap parent axiom, flip meta axiomatized→verified"
     ]
   }
 }


### PR DESCRIPTION
Follow-up to merged #28352. That PR landed the synthesis file with a docstring header reading **"What is already verified (0 axioms, 0 sorries) in the dependency chain."** That phrasing overstates the verification status: the finite/σ-finite Riesz files and `extByZeroCLM` are **source-complete** (0 `sorry` tactics, 0 `axiom`) but were **not** re-checked under the Docker build wrapper — the daemon has been hung (exit 124) and the Aristotle backend returns `Resource not found` for 5 consecutive sessions.

### Changes
- **`CauchySchwarzIntegralLpDualitySynthesis.lean`** — replace the "already verified" header with an accurate "source-complete; not re-build-verified this session" accounting that distinguishes static-source 0-sorry from a fresh kernel check. Fix one downstream paragraph likewise.
- **knowledge.md / problem JSON** — Session-5 log: chain confirmed source-complete (naive `grep -c '\bsorry\b'` overcounts docstring "sorry" tokens — GOTCHA recorded); bridge lemma `memLp_exists_sigmaFinite_support` re-confirmed API-sound vs on-disk Mathlib; concrete dependency-ordered coding targets for the remaining Folland-6.16 maximality construction.

### Honest status
No new verified mathematics — the verifier blackout precludes it, and the remaining maximality argument (~150 lines of measure theory) requires a verifier to formalize correctly. This PR is an **integrity/precision correction** to documentation already on `main`, aligning the file with the Axiom Integrity Policy (do not claim "verified" without a build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)