### PR TITLE
research(catalan-numbers-oq-01-oq-03): scope Schröder holonomic recurrence as Mathlib-buildable

### DIFF
--- a/proofs/Proofs/SchroderLinearRecurrenceAristotle.lean
+++ b/proofs/Proofs/SchroderLinearRecurrenceAristotle.lean
@@ -34,6 +34,41 @@ recurrence is equivalent to
   `(n + 3) * Q (n+1) = (5n + 6) * Q n + (4n + 6) * L n`.
 
 Both statements below are over `ℕ` with no subtraction.
+
+## Buildable-in-Lean roadmap (Mathlib `PowerSeries` API — NOT yet executed)
+
+This recurrence is *not* a deep gap: every ingredient now exists in Mathlib, so it is BUILDABLE
+(~150–250 lines), not blocked.  Concrete plan, mirroring the Catalan precedent:
+
+1. **GF object.** Work over `ℤ` (the ODE needs subtraction).  Set
+   `f : ℤ⟦X⟧ := PowerSeries.mk (fun n => (largeSchroder n : ℤ))`, with
+   `coeff n f = largeSchroder n` and `constantCoeff f = 1`.
+
+2. **GF quadratic** `X * f^2 + (X - 1) * f + 1 = 0`  (equivalently `f = 1 + X*f + X*f^2`).
+   This is a *direct mirror* of Mathlib's
+   `PowerSeries.catalanSeries_sq_mul_X_add_one : catalanSeries ^ 2 * X + 1 = catalanSeries`
+   (file `Mathlib/RingTheory/PowerSeries/Catalan.lean`): `ext n; cases n`, then
+   `coeff_succ_mul_X`, `sq`, `coeff_mul`, and `largeSchroder_succ` in place of `catalan_succ'`.
+
+3. **Differentiate.** `PowerSeries.derivative` (`Mathlib/RingTheory/PowerSeries/Derivative.lean`)
+   is a `Derivation` (`d⁄dX`), giving `derivative_X = 1`, `derivative_C = 0`, additivity, and the
+   Leibniz rule `derivativeFun_mul`.  Differentiating the quadratic gives
+   `(2*X*f + (X-1)) * f' = -(f^2 + f)`.
+
+4. **Eliminate `f²` and the `f·f'` term.** The discriminant identity
+   `(2*X*f + (X-1))^2 = X^2 - 6*X + 1`  (which holds *on the solution*, since the RHS is the
+   discriminant of the quadratic and the cross term vanishes by step 2) rationalises the
+   denominator, yielding the linear ODE  `X*(X^2 - 6*X + 1) * f' = (3*X - 1)*f + (X + 1)`.
+
+5. **Extract the `xⁿ`-coefficient.** `PowerSeries.coeff_derivative`
+   (`coeff n (d⁄dX f) = coeff (n+1) f * (n+1)`) turns `f'`-coefficients into `(n+1)*L(n+1)`, and
+   `coeff_mul` / `coeff_X_mul` / `coeff_X_pow_mul` expand the polynomial coefficients.  Reading off
+   `coeff n` of the ODE in step 4 produces exactly `largeSchroder_holonomic`; the convolution-form
+   `largeSchroder_conv_holonomic` below follows the same way from step 2's coefficient identity.
+
+The single remaining `sorry` is therefore HARD-but-classical and fully scoped: it awaits either
+automated proof search or a manual session with a working Lean verifier (this session had neither
+Aristotle nor a responsive docker build available).
 -/
 
 namespace Nat

--- a/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-03/meta.json
@@ -51,7 +51,7 @@
     "additionalFiles": [
       {
         "path": "Proofs/SchroderLinearRecurrenceAristotle.lean",
-        "description": "Companion file (NOT part of the verified entry) stating the open order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) and its convolution reformulation, each as a `sorry`, for automated proof search. Contains 2 sorries; a full generating-function proof sketch is given in its docstring."
+        "description": "Companion file (NOT part of the verified entry) for the open order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1). The headline recurrence largeSchroder_holonomic is proved unconditionally from a single convolution lemma largeSchroder_conv_holonomic via a routine linear_combination, so there is now exactly 1 sorry — the convolution lemma — isolating all the hard generating-function content. Its docstring records a concrete five-step, Mathlib-supported buildability roadmap (PowerSeries.catalanSeries template + PowerSeries.derivative/coeff_derivative)."
       }
     ],
     "dateAdded": "2026-06-23",
@@ -70,7 +70,7 @@
       "**Positivity is a genuine gap.** Mathlib records evenness of the large Schröder numbers (Nat.even_largeSchroder) but not positivity; positivity is what licenses cancelling Schröder factors and is the base for every quantitative estimate.",
       "**Two boundary terms already force factor-3 growth.** The convolution sum ∑ i ≤ n+1, L i · L(n+1−i) contains the summands at i = 0 and i = n+1, each equal to L(n+1); together with the leading +L(n+1) in the convolution recurrence this gives L(n+2) ≥ 3·L(n+1) with no analysis of the interior terms.",
       "**The factor 3 is sharp as an integer ratio but loose asymptotically.** The true ratio L(n+1)/L n increases to 3 + 2√2 ≈ 5.83 (the dominant root of x² − 6x + 1, the discriminant of the Schröder generating-function equation); 3 is the best constant available from the two boundary terms alone.",
-      "**The deeper holonomic recurrence needs generating functions.** The order-two recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) follows from the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1) satisfied by f = ∑ L n xⁿ; unlike the Catalan first-order recurrence (inherited from central binomials), it has no elementary central-coefficient bridge in Mathlib, so it is deferred to automated proof search."
+      "**The deeper holonomic recurrence needs generating functions, but is buildable in Mathlib.** The order-two recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) follows from the linear ODE x(x²−6x+1) f' = (3x−1) f + (x+1) satisfied by f = ∑ L n xⁿ. Unlike the Catalan first-order recurrence (inherited from central binomials) it has no central-coefficient shortcut, but it is not blocked: the formal-power-series route is fully supported by Mathlib (estimated ~150–250 lines). The GF quadratic X·f² + (x−1)·f + 1 = 0 is a direct mirror of PowerSeries.catalanSeries_sq_mul_X_add_one (Mathlib/RingTheory/PowerSeries/Catalan.lean), and the differentiation/coefficient-extraction step uses PowerSeries.derivative (a Derivation, d⁄dX) together with PowerSeries.coeff_derivative (Mathlib/RingTheory/PowerSeries/Derivative.lean). A concrete five-step lemma plan is recorded in the companion file's docstring; the single remaining sorry awaits automated proof search or a manual session with a working verifier."
     ],
     "prerequisites": [
       "The (large) Schröder numbers and their definition via the quadratic convolution recurrence",
@@ -122,7 +122,7 @@
     "summary": "Fully verified (0 sorries, 0 axioms) quantitative basics for Mathlib's large Schröder numbers: positivity 0 < L n, a convolution lower bound, the step growth 3·L(n+1) ≤ L(n+2), and the closed exponential lower bound 2·3ⁿ ≤ L(n+1).",
     "implications": "Supplies the positivity and geometric-growth facts that Mathlib's Schröder development lacks, enabling cancellation arguments and asymptotic estimates. It frames the Schröder analogue of the Catalan first-order recurrence: the order-two holonomic recurrence is stated with a full generating-function proof sketch in the companion file for automated proof search.",
     "openQuestions": [
-      "Prove the order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) — equivalently extract the xⁿ-coefficient of the ODE x(x²−6x+1) f' = (3x−1) f + (x+1) for the generating function f = ∑ L n xⁿ — completing the Schröder analogue of catalan-numbers-oq-01.",
+      "Prove the order-two holonomic recurrence (n+3)·L(n+2) + n·L n = 3·(2n+3)·L(n+1) — equivalently extract the xⁿ-coefficient of the ODE x(x²−6x+1) f' = (3x−1) f + (x+1) for the generating function f = ∑ L n xⁿ — completing the Schröder analogue of catalan-numbers-oq-01. This is now reduced (in the companion file) to the single convolution lemma largeSchroder_conv_holonomic, and scoped as BUILDABLE (~150–250 lines) via Mathlib's PowerSeries API: mirror PowerSeries.catalanSeries_sq_mul_X_add_one for the GF quadratic, then differentiate with PowerSeries.derivative and read off coefficients with PowerSeries.coeff_derivative (full plan in the companion docstring).",
       "Upgrade the growth bound to the sharp ratio: prove L(n+1)/L n → 3 + 2√2 over ℝ, the dominant root of x² − 6x + 1."
     ]
   },


### PR DESCRIPTION
## Summary

Follow-up to #28360 (merged), which reduced the large-Schröder order-two holonomic recurrence to a single convolution lemma `largeSchroder_conv_holonomic`. This PR is an **ORIENT-phase buildability finding**, not new live Lean.

The sole remaining `sorry` (the generating-function content) is **BUILDABLE (~150–250 lines), not blocked** — Mathlib supplies every ingredient:

- `PowerSeries.catalanSeries_sq_mul_X_add_one` (`Mathlib/RingTheory/PowerSeries/Catalan.lean`) is a **direct template** for the Schröder GF quadratic `X·f² + (X−1)·f + 1 = 0`.
- `PowerSeries.derivative` (a `Derivation`, `d⁄dX`) + `PowerSeries.coeff_derivative` (`Mathlib/RingTheory/PowerSeries/Derivative.lean`) supply the differentiation and coefficient extraction for the ODE `x(x²−6x+1) f' = (3x−1) f + (x+1)`.

## Changes

- **Companion docstring**: records a concrete five-step lemma plan (GF object → quadratic → differentiate → eliminate via the discriminant identity `(2Xf+X−1)² = X²−6X+1` → `coeff_derivative` extraction).
- **meta.json**: corrects keyInsight #4, the open question, and the additionalFiles description from *"no Mathlib bridge / deferred"* to *"buildable, scoped"*; fixes the stale **"2 sorries"** to the actual **single isolated sorry** (the headline `largeSchroder_holonomic` is now proved from the convolution lemma via `linear_combination`).

## Verification status

Documentation-only (docstring comments + meta.json); no change to compiled code, so no build risk. No verifier was available this session (Aristotle returns "Resource not found"; docker build hangs), which is why the actual GF proof is left for automated proof search / a future verified session rather than written blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)