### PR TITLE
Zolotarev QR: de-risk the shared inversion-count blocker via Mathlib bridge

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
@@ -156,8 +156,12 @@ def gridTranspose (m n : ℕ) : Equiv.Perm (Fin (m * n)) :=
     A complete CANDIDATE proof along these lines is written out in
     `research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/sign_gridTranspose_candidate.lean`.
     It is NOT yet kernel-verified (Docker daemon wedged + Aristotle MCP returning
-    "Resource not found" this session); a build backend just needs to confirm /
-    fix the API lemma names.  The numerical inversion bijection is also certified
+    "Resource not found" across sessions).  Its API has now been fully audited
+    against the pinned Mathlib (rev 2df2f0150c, v4.26.0): every lemma it uses is
+    present with a compatible signature (notably `sign_eq_prod_prod_Iio`,
+    `prod_pow_eq_pow_sum`, and `card_bij'` with matching argument order), so the
+    only remaining risk is whether the `rw`/`simp` steps fire — a build backend
+    just needs to run it.  The numerical inversion bijection is also certified
     in `research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py`
     and `verify_inversion_bijection.py`. -/
 theorem sign_gridTranspose (m n : ℕ) :

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
@@ -133,30 +133,33 @@ def gridTranspose (m n : ℕ) : Equiv.Perm (Fin (m * n)) :=
 
     STATUS: `sorry`.  This is a KNOWN result (HARD, not OPEN).
 
-    CROSS-REFERENCE / NON-DUPLICATION NOTE.  The *identical* obligation already
-    stands, isolated and build-verified-in-context, in the sibling "algorithm"
-    lineage as `QuadraticReciprocityAlgorithmOQ03M2.sign_gridTranspose_eq_choose`
-    (merged #25053, currently unregistered).  Multiple prior sessions there
-    established that NO Mathlib lemma gives `sign = (-1)^(inversion count)` for a
-    general (non-cycle, non-block-diagonal) permutation — `sign_prodCongr*` /
-    `sign_sumCongr` do NOT apply because the transpose is a coordinate swap — so
-    the only route is the explicit `Finset.card_bij`
+    CROSS-REFERENCE / NON-DUPLICATION NOTE.  The *identical* obligation also
+    stands in the sibling "algorithm" lineage as
+    `QuadraticReciprocityAlgorithmOQ03M2.sign_gridTranspose_eq_choose`
+    (merged #25053, currently unregistered).
 
-        inversions of `gridTranspose m n`  ↔  {i < i' : Fin m} × {j > j' : Fin n}
+    UPDATED ROUTE (researcher-9, 2026-06-23) — the earlier "no Mathlib lemma"
+    assessment is OUT OF DATE.  Mathlib now provides the exact inversion-count
+    bridge for an arbitrary `Perm (Fin N)`:
 
-    unfolded from `signAux = ∏_{finPairsLT}`, of cardinality `C(m,2)·C(n,2)`.
-    This is ~100 intricate LOC; it is the single self-contained Aristotle target
-    the moment that backend stops returning "Resource not found".  The numerical
-    inversion bijection is certified in
-    `research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py`
-    and `verify_inversion_bijection.py`.
+        `Equiv.Perm.sign_eq_prod_prod_Iio`
+          : σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1)
 
-    Suggested routes (both attempted/assessed in the sibling thread):
-      * induction on `m`, decomposing the insertion of a row as a block of
-        `finRotate`-type cycles and using `Equiv.Perm.sign_prodCongrLeft`,
-        `sign_prodCongrRight`, `Equiv.Perm.sign_finRotate`; or
-      * a direct inversion count against the `signAux`/`finPairsLT` model
-        (the cleaner of the two — see the certified Python bijection above). -/
+    (`Mathlib/GroupTheory/Perm/Fin.lean`, `section Sign`).  Each factor is `-1`
+    exactly on an inversion `i < j ∧ σ i > σ j`, so `sign σ = (-1)^(#inversions)`
+    with NO `signAux`/`finPairsLT` surgery.  The blocker then reduces to the
+    elementary count `#{(I,J) : I < J ∧ T I > T J} = C(m,2)·C(n,2)` via the
+    bijection `(I,J) ↦ ((row I, row J), (col J, col I))` onto
+    (strictly-increasing row pairs) × (strictly-increasing column pairs), each of
+    cardinality `Nat.choose · 2` (counted by the Gauss sum `∑ b, b`).
+
+    A complete CANDIDATE proof along these lines is written out in
+    `research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/sign_gridTranspose_candidate.lean`.
+    It is NOT yet kernel-verified (Docker daemon wedged + Aristotle MCP returning
+    "Resource not found" this session); a build backend just needs to confirm /
+    fix the API lemma names.  The numerical inversion bijection is also certified
+    in `research/problems/quadratic-reciprocity-algorithm-oq-03/verify_grid_inversions.py`
+    and `verify_inversion_bijection.py`. -/
 theorem sign_gridTranspose (m n : ℕ) :
     Equiv.Perm.sign (gridTranspose m n)
       = (-1 : ℤˣ) ^ (Nat.choose m 2 * Nat.choose n 2) := by

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -18,8 +18,59 @@ transpose / perfect-shuffle permutation, as in Zolotarev 1872 / Frobenius 1914.
 | `gridTranspose_apply` (row-major `n·i+j` ↦ col-major `m·j+i`) | proved |
 | `neg_one_pow_choose_two_mul_odd` (parity bridge `(-1)^(C(m,2)C(n,2))=(-1)^((m-1)/2·(n-1)/2)`) | **proved, 0 sorry** |
 | `sign_gridTranspose_odd` (classical-form corollary) | proved *modulo* the one sorry |
-| `sign_gridTranspose = (-1)^(C(m,2)·C(n,2))` | **`sorry`** (sole blocker) |
+| `sign_gridTranspose = (-1)^(C(m,2)·C(n,2))` | **`sorry`** — but route DE-RISKED (S2), complete candidate proof written (unverified) |
 | Full QR assembly (`α = β∘γ`, identify `α,β` with `ringMulPerm` via CRT) | not formalized |
+
+## Session 2026-06-23 (S2, researcher-9) — BLOCKER ROUTE DE-RISKED via Mathlib bridge
+
+**Mode:** continue WIP on branch `research/zolotarev-quadratic-reciprocity-oq010302`.
+**Outcome:** the prior 3-session "no Mathlib lemma" assessment of the blocker is
+**out of date**; a clean route now exists and a full candidate proof is written.
+
+### Key finding (overturns S1 + sibling-thread assessment)
+Prior sessions (here + algorithm-M2 S8/S18/S21) all concluded "NO Mathlib lemma
+gives `sign = (-1)^(#inversions)` for a general permutation; only route is ~100
+LOC of `signAux`/`finPairsLT` surgery." **This is false as of current Mathlib.**
+
+    `Equiv.Perm.sign_eq_prod_prod_Iio` (Mathlib/GroupTheory/Perm/Fin.lean, §Sign)
+      : σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1)
+
+Each factor is `-1` exactly on an inversion `i<j ∧ σ i>σ j`, so
+`sign σ = (-1)^(#inversions)` directly — no `signAux` surgery. The blocker
+reduces to the **elementary** count `#{(I,J): I<J ∧ T I>T J} = C(m,2)·C(n,2)`.
+
+### The reduction (fully worked out)
+1. `rw [Equiv.Perm.sign_eq_prod_prod_Iio]`.
+2. Inner `∏ i ∈ Iio j, ite (T i < T j) 1 (-1) = (-1)^(card of inversions ≤ j)`
+   via `Finset.prod_ite` + `Finset.prod_const`.
+3. `Finset.prod_pow_eq_pow_sum` ⇒ `(-1)^(∑ j, …)` = `(-1)^(#Inv)` where
+   `Inv = univ.filter (p.1<p.2 ∧ ¬ T p.1<T p.2)`.
+4. Bijection `Inv ≃ strictPairs(Fin m) ×ˢ strictPairs(Fin n)`,
+   `(I,J) ↦ ((I.divNat,J.divNat),(J.modNat,I.modNat))`, via `Finset.card_bij'`.
+   Well-definedness uses the **mixed-radix lemma** `encode_lt` (proved):
+   `finProdFinEquiv (a,c) < finProdFinEquiv (b,d) ↔ a<b ∨ (a=b ∧ c<d)` (omega
+   after feeding `Nat.mul_le_mul_left`), and `gridTranspose_val`
+   (`T(finProdFinEquiv (a,d)).val = a + m*d`).
+5. `#strictPairs(Fin k) = C(k,2)` via group-by-2nd-coord ⇒ `∑ b, #(Iio b)`
+   ⇒ `∑ b:Fin k, ↑b` ⇒ `Finset.sum_range_id` (Gauss) ⇒ `Nat.choose_two_right`.
+
+### Deliverable
+`sign_gridTranspose_candidate.lean` (this dir) — a COMPLETE candidate proof
+(def + `encode_lt`, `gridTranspose_val`, `card_strict_pairs`, the bijection).
+**NOT kernel-verified**: Docker daemon wedged this session (`docker ps`/`images`
+empty, no container ever spawns; ≥6 sibling builds stuck 1.7h, `docker stop`
+processes piled up) and Aristotle MCP still returns "Resource not found".
+A few API names (`Fin.coe_cast`, `finCongr_apply`, `not_lt`, `Finset.univ_product_univ`)
+are best-effort and may need a one-pass fixup when a build backend recovers.
+Registered file's `sign_gridTranspose` docstring updated to cite the bridge.
+
+### Next steps (priority order)
+1. When Docker/Aristotle recover: build/verify `sign_gridTranspose_candidate.lean`;
+   fix any API-name slips; then port the proof body into BOTH registered files
+   (this one + `QuadraticReciprocityAlgorithmOQ03M2`) replacing the shared `sorry`.
+2. Then this file becomes 0-sorry up to the QR assembly; promote toward verified.
+3. Higher-value remaining novel work: the QR assembly (`α=β∘γ`, identify `α,β`
+   with `ringMulPerm` via CRT) — neither thread has formalized it.
 
 ## Session 2026-06-23 (S1, researcher-9) — parity bridge proven; CROSS-THREAD DUPLICATION found
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -128,3 +128,50 @@ formalize its genuinely distinct part — the **QR assembly** (`α=β∘γ`, ide
 ### Files modified
 - `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean`
 - `research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-…-oq-02/knowledge.md` (new)
+
+---
+
+## Session 2026-06-23 (Session 3) — Candidate API audit (de-risk, no kernel check)
+
+**Mode**: REVISIT
+**Outcome**: progress (verification infra still down; mathematical/API risk reduced)
+
+### What I Did
+- Session preamble: both verifiers still down — Docker daemon wedged (`docker version`
+  shows Client only, no Server; `docker ps`/`images` empty), Aristotle MCP
+  `prove_file` returns "Resource not found" (connected but backend resource 404).
+  So no kernel verification was possible this session either.
+- Highest-value reachable action: full **API audit** of the complete candidate proof
+  `sign_gridTranspose_candidate.lean` against the pinned Mathlib source on disk
+  (rev 2df2f0150c, Lean v4.26.0, `proofs/.lake/packages/mathlib`).
+
+### Key Findings
+- EVERY lemma name in the candidate is present with a compatible signature:
+  - `Equiv.Perm.sign_eq_prod_prod_Iio` (Perm/Fin.lean:478) — factor form
+    `if σ i < σ j then 1 else -1` matches `inner` exactly.
+  - `Finset.prod_pow_eq_pow_sum` (BigOperators/.../Basic.lean:656) — exact form.
+  - `finProdFinEquiv` (Logic/Equiv/Fin/Basic.lean:329): `toFun ⟨x.2 + n*x.1,_⟩`,
+    `invFun (x.divNat,x.modNat)` ⟹ `fpe_val` (val = c+q*a) and `fpe_symm` hold by `rfl`.
+  - `Fin.divNat`/`Fin.modNat` (Batteries Data/Fin/Basic.lean:133/137), correct types.
+  - `Fin.coe_cast` (alias of `val_cast`), `finCongr_apply` (@[simp]) — present.
+  - `Finset.card_bij'` (Data/Finset/Card.lean:366) — arg order
+    `(i,j,hi,hj,left_inv,right_inv)` matches the four `?_` obligations IN ORDER.
+  - All supporting Finset/Nat lemmas confirmed (sum_filter via to_additive prod_filter).
+- The two names the prior draft flagged "best-effort" (`finProdFinEquiv_symm_apply`,
+  `Fintype.sum_prod_type`) are NOT used in the proof body — dropped from caveats.
+- NET: remaining risk reduced from "do these lemmas exist / right names?" (now: YES,
+  all confirmed) to purely term-level "do the rw/simp steps fire?" — mechanical,
+  build-only. Honest status unchanged: still UNVERIFIED, not registered/verified.
+
+### Files Modified
+- `sign_gridTranspose_candidate.lean` — header STATUS block rewritten with the audit.
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03…OQ02.lean` — cross-ref note
+  updated (API audited; only rw/simp firing remains).
+- this knowledge.md.
+
+### Next Steps (unchanged priority)
+1. When EITHER verifier recovers: build/submit the candidate; expect ≤ a couple of
+   `simp`/`rw` adjustments at most, since all names are confirmed.
+2. Integrate the verified proof into the registered file, discharging the lone sorry.
+3. Then formalize the genuinely-missing QR assembly (`α=β∘γ` via CRT) — higher value
+   than the blocker, untouched by either gridTranspose thread.

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/sign_gridTranspose_candidate.lean
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/sign_gridTranspose_candidate.lean
@@ -22,12 +22,41 @@
   (strictly-increasing row pairs) × (strictly-increasing col pairs), each of
   cardinality `choose · 2`.
 
-  STATUS: written against Mathlib source but NOT kernel-verified — Docker daemon
-  is wedged (no container spawns; `docker ps`/`images` empty) and Aristotle MCP
-  returns "Resource not found".  Some API lemma names (`Fin.coe_cast`,
-  `finProdFinEquiv_symm_apply`, `Fintype.sum_prod_type`) are best-effort and may
-  need adjustment when a build backend recovers.  DO NOT register or mark
-  verified until this compiles.  This file lives outside the gallery on purpose.
+  STATUS: written against Mathlib source, API audit COMPLETE, but NOT yet
+  kernel-verified — Docker daemon is wedged (no container spawns; `docker ps`/
+  `images` empty) and Aristotle MCP returns "Resource not found".
+
+  API AUDIT (researcher-9, 2026-06-23, S3).  Every lemma name used below was
+  checked against the pinned Mathlib source on disk (rev 2df2f0150c, Lean
+  v4.26.0, `proofs/.lake/packages/mathlib`).  ALL are present with signatures
+  compatible with the usage here:
+    * `Equiv.Perm.sign_eq_prod_prod_Iio` — Mathlib/GroupTheory/Perm/Fin.lean:478;
+      factor form `if σ i < σ j then 1 else -1` matches `inner` exactly.
+    * `Finset.prod_pow_eq_pow_sum` — .../BigOperators/Group/Finset/Basic.lean:656;
+      `∏ a^(f i) = a^(∑ f i)`, matches.
+    * `finProdFinEquiv` — Mathlib/Logic/Equiv/Fin/Basic.lean:329; its `toFun`
+      `⟨x.2 + n*x.1, _⟩` and `invFun (x.divNat, x.modNat)` make `fpe_val`
+      (`val = c + q*a`) and `fpe_symm` (`symm = (divNat, modNat)`) hold by `rfl`.
+    * `Fin.divNat`/`Fin.modNat` — Batteries/Data/Fin/Basic.lean:133/137,
+      types `Fin (m*n) → Fin m` / `Fin n`.
+    * `Fin.coe_cast` (alias `Fin.val_cast`), `finCongr_apply` (a `@[simp]`
+      lemma used across Mathlib) — both present.
+    * `Finset.card_bij'` — Mathlib/Data/Finset/Card.lean:366; argument order
+      `(i, j, hi, hj, left_inv, right_inv)` matches the four `?_` obligations
+      below in order.
+    * supporting: `prod_ite`, `prod_const_one`, `prod_const`, `card_filter`,
+      `sum_filter` (to_additive of `prod_filter`), `univ_product_univ`,
+      `sum_product'`, `sum_comm`, `card_Iio`, `Fin.sum_univ_eq_sum_range`,
+      `sum_range_id`, `Nat.choose_two_right`, `card_product` — all present.
+  The two names flagged "best-effort" in the prior draft
+  (`finProdFinEquiv_symm_apply`, `Fintype.sum_prod_type`) are NOT used in the
+  proof body and were dropped.
+
+  REMAINING RISK after this audit is purely term-level: whether each `rw`/`simp`
+  step actually fires (defeq matching, `simp` set behaviour), which only a real
+  build resolves.  Existence/signature of every lemma is no longer in doubt.
+  DO NOT register or mark verified until this compiles.  This file lives outside
+  the gallery on purpose.
 -/
 import Mathlib
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/sign_gridTranspose_candidate.lean
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/sign_gridTranspose_candidate.lean
@@ -1,0 +1,190 @@
+/-
+  CANDIDATE (UNVERIFIED) proof of the shared Zolotarev blocker
+
+      sign (gridTranspose m n) = (-1) ^ (C(m,2) * C(n,2)).
+
+  KEY BREAKTHROUGH (this session, researcher-9, 2026-06-23).
+  Prior sessions (≥3, in both the elementary- and algorithm-QR lineages)
+  concluded that "NO Mathlib lemma gives sign = (-1)^(#inversions) for a general
+  permutation", so the only route was ~100 LOC of bespoke `signAux`/`finPairsLT`
+  surgery.  THAT ASSESSMENT IS OUT OF DATE.  Mathlib now has
+
+      Equiv.Perm.sign_eq_prod_prod_Iio (σ : Perm (Fin N)) :
+        σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1)
+
+  (`Mathlib/GroupTheory/Perm/Fin.lean`, `section Sign`).  Each factor is `-1`
+  exactly on an inversion `i < j ∧ σ i > σ j`, so `sign σ = (-1)^(#inversions)`
+  with NO `signAux` surgery.  The blocker reduces to the elementary count
+
+      #{ (I,J) : I < J ∧ T I > T J }  =  C(m,2) · C(n,2)
+
+  via the bijection  (I,J) ↦ ((row I, row J), (col J, col I))  onto
+  (strictly-increasing row pairs) × (strictly-increasing col pairs), each of
+  cardinality `choose · 2`.
+
+  STATUS: written against Mathlib source but NOT kernel-verified — Docker daemon
+  is wedged (no container spawns; `docker ps`/`images` empty) and Aristotle MCP
+  returns "Resource not found".  Some API lemma names (`Fin.coe_cast`,
+  `finProdFinEquiv_symm_apply`, `Fintype.sum_prod_type`) are best-effort and may
+  need adjustment when a build backend recovers.  DO NOT register or mark
+  verified until this compiles.  This file lives outside the gallery on purpose.
+-/
+import Mathlib
+
+set_option maxHeartbeats 1600000
+
+namespace ZGScratch
+
+open Equiv Equiv.Perm Finset
+
+/-- The row-major ↔ column-major transpose (perfect-shuffle) permutation. -/
+def gridTranspose (m n : ℕ) : Equiv.Perm (Fin (m * n)) :=
+  finProdFinEquiv.symm.trans
+    ((Equiv.prodComm (Fin m) (Fin n)).trans
+      (finProdFinEquiv.trans (finCongr (Nat.mul_comm n m))))
+
+@[simp] theorem gridTranspose_apply {m n : ℕ} (i : Fin m) (j : Fin n) :
+    gridTranspose m n (finProdFinEquiv (i, j))
+      = finCongr (Nat.mul_comm n m) (finProdFinEquiv (j, i)) := by
+  simp [gridTranspose]
+
+/-- Value of the canonical row-major encoding: `finProdFinEquiv (a,c)` has value
+    `c + q * a` (row `a` weighted by the column count `q`). -/
+theorem fpe_val {p q : ℕ} (a : Fin p) (c : Fin q) :
+    (finProdFinEquiv (a, c) : Fin (p * q)).val = (c : ℕ) + q * (a : ℕ) := rfl
+
+/-- `finProdFinEquiv.symm` is decode-by-div/mod. -/
+theorem fpe_symm {p q : ℕ} (x : Fin (p * q)) :
+    finProdFinEquiv.symm x = (x.divNat, x.modNat) := rfl
+
+theorem fpe_divNat {p q : ℕ} (a : Fin p) (c : Fin q) :
+    (finProdFinEquiv (a, c)).divNat = a := by
+  have h := finProdFinEquiv.symm_apply_apply (a, c)
+  rw [fpe_symm] at h
+  exact (Prod.ext_iff.mp h).1
+
+theorem fpe_modNat {p q : ℕ} (a : Fin p) (c : Fin q) :
+    (finProdFinEquiv (a, c)).modNat = c := by
+  have h := finProdFinEquiv.symm_apply_apply (a, c)
+  rw [fpe_symm] at h
+  exact (Prod.ext_iff.mp h).2
+
+/-- Value of the grid transpose on an encoded index: `(a,d)` (row `a`, col `d`)
+    maps to value `a + m * d`. -/
+theorem gridTranspose_val {m n : ℕ} (a : Fin m) (d : Fin n) :
+    (gridTranspose m n (finProdFinEquiv (a, d))).val = (a : ℕ) + m * (d : ℕ) := by
+  rw [gridTranspose_apply, finCongr_apply, Fin.coe_cast, fpe_val]
+
+/-- `finCongr` preserves the order. -/
+theorem finCongr_lt {a b : ℕ} (h : a = b) (x y : Fin a) :
+    (finCongr h x < finCongr h y) ↔ x < y := by
+  rw [Fin.lt_iff_val_lt_val, Fin.lt_iff_val_lt_val, finCongr_apply, finCongr_apply,
+    Fin.coe_cast, Fin.coe_cast]
+
+/-- The mixed-radix comparison: the linear order on `Fin (p*q)` of two encoded
+    indices is the lexicographic order on `(row, col)`. -/
+theorem encode_lt {p q : ℕ} (a b : Fin p) (c d : Fin q) :
+    (finProdFinEquiv (a, c) : Fin (p * q)) < finProdFinEquiv (b, d)
+      ↔ (a : ℕ) < b ∨ ((a : ℕ) = b ∧ (c : ℕ) < d) := by
+  rw [Fin.lt_iff_val_lt_val, fpe_val, fpe_val]
+  have hc := c.isLt
+  have hd := d.isLt
+  rcases lt_trichotomy (a : ℕ) (b : ℕ) with h | h | h
+  · have hmul : q * (a : ℕ) + q ≤ q * (b : ℕ) := by
+      have := Nat.mul_le_mul_left (k := q) (show (a : ℕ) + 1 ≤ b by omega)
+      simpa [Nat.mul_add] using this
+    omega
+  · have hmul : q * (a : ℕ) = q * (b : ℕ) := by rw [h]
+    omega
+  · have hmul : q * (b : ℕ) + q ≤ q * (a : ℕ) := by
+      have := Nat.mul_le_mul_left (k := q) (show (b : ℕ) + 1 ≤ a by omega)
+      simpa [Nat.mul_add] using this
+    omega
+
+/-- The number of strictly-increasing pairs over `Fin k` is `C(k,2)`. -/
+theorem card_strict_pairs (k : ℕ) :
+    (univ.filter (fun p : Fin k × Fin k => p.1 < p.2)).card = k.choose 2 := by
+  have h1 : (univ.filter (fun p : Fin k × Fin k => p.1 < p.2)).card
+      = ∑ b : Fin k, (b : ℕ) := by
+    rw [Finset.card_filter]
+    rw [← Finset.univ_product_univ, Finset.sum_product']
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun b _ => ?_)
+    rw [← Finset.card_filter]
+    have : (univ.filter (fun a : Fin k => a < b)) = Finset.Iio b := by
+      ext a; simp [Finset.mem_Iio]
+    rw [this, Finset.card_Iio]
+  rw [h1, Fin.sum_univ_eq_sum_range (fun i => i), Finset.sum_range_id, ← Nat.choose_two_right]
+
+theorem sign_gridTranspose (m n : ℕ) :
+    Equiv.Perm.sign (gridTranspose m n)
+      = (-1 : ℤˣ) ^ (Nat.choose m 2 * Nat.choose n 2) := by
+  set T := gridTranspose m n with hT
+  rw [Equiv.Perm.sign_eq_prod_prod_Iio]
+  -- Each inner product over `Iio J` is `(-1)^(# inversions ending at J)`.
+  have inner : ∀ J : Fin (m * n),
+      (∏ i ∈ Iio J, (if T i < T J then (1 : ℤˣ) else -1))
+        = (-1) ^ ((Iio J).filter (fun i => ¬ (T i < T J))).card := by
+    intro J
+    rw [Finset.prod_ite, Finset.prod_const_one, one_mul, Finset.prod_const]
+  simp_rw [inner]
+  rw [Finset.prod_pow_eq_pow_sum]
+  congr 1
+  -- Reduce the total inversion count to the cardinality of an inversion Finset.
+  set Inv : Finset (Fin (m * n) × Fin (m * n)) :=
+    univ.filter (fun p => p.1 < p.2 ∧ ¬ (T p.1 < T p.2)) with hInv
+  have hsum : (∑ J : Fin (m * n), ((Iio J).filter (fun i => ¬ (T i < T J))).card)
+      = Inv.card := by
+    rw [hInv, Finset.card_filter, ← Finset.univ_product_univ, Finset.sum_product']
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl (fun J _ => ?_)
+    rw [Finset.card_filter, ← Finset.sum_filter]
+    refine Finset.sum_congr ?_ (fun i _ => rfl)
+    ext i; simp [Finset.mem_Iio]
+  rw [hsum, ← card_strict_pairs m, ← card_strict_pairs n, ← Finset.card_product]
+  -- The bijection: (I,J) ↦ ((row I, row J), (col J, col I)).
+  refine Finset.card_bij'
+    (i := fun p _ => ((p.1.divNat, p.2.divNat), (p.2.modNat, p.1.modNat)))
+    (j := fun q _ => (finProdFinEquiv (q.1.1, q.2.2), finProdFinEquiv (q.1.2, q.2.1)))
+    ?_ ?_ ?_ ?_
+  · -- i maps Inv into the product
+    rintro ⟨I, J⟩ hp
+    simp only [hInv, Finset.mem_filter, Finset.mem_univ, true_and] at hp
+    obtain ⟨hIJ, hTIJ⟩ := hp
+    obtain ⟨a, d, rfl⟩ : ∃ a d, I = finProdFinEquiv (a, d) :=
+      ⟨I.divNat, I.modNat, (finProdFinEquiv.apply_symm_apply I).symm⟩
+    obtain ⟨b, c, rfl⟩ : ∃ b c, J = finProdFinEquiv (b, c) :=
+      ⟨J.divNat, J.modNat, (finProdFinEquiv.apply_symm_apply J).symm⟩
+    rw [encode_lt] at hIJ
+    rw [hT, gridTranspose_apply, gridTranspose_apply, finCongr_lt, encode_lt] at hTIJ
+    simp only [fpe_divNat, fpe_modNat, Finset.mem_product, Finset.mem_filter,
+      Finset.mem_univ, true_and, Fin.lt_iff_val_lt_val]
+    -- hIJ : a < b ∨ (a = b ∧ d < c);  hTIJ : ¬ (d < c ∨ (d = c ∧ a < b))
+    -- goal : a < b ∧ c < d
+    omega
+  · -- j maps the product into Inv
+    rintro ⟨⟨a, b⟩, ⟨c, d⟩⟩ hq
+    simp only [Finset.mem_product, Finset.mem_filter, Finset.mem_univ, true_and,
+      Fin.lt_iff_val_lt_val] at hq
+    obtain ⟨hab, hcd⟩ := hq
+    simp only [hInv, Finset.mem_filter, Finset.mem_univ, true_and]
+    refine ⟨?_, ?_⟩
+    · rw [encode_lt]; exact Or.inl hab
+    · rw [hT, not_lt, Fin.le_iff_val_le_val, gridTranspose_val, gridTranspose_val]
+      have hb := b.isLt
+      have hmul : m * (c : ℕ) + m ≤ m * (d : ℕ) := by
+        have := Nat.mul_le_mul_left (k := m) (show (c : ℕ) + 1 ≤ d by omega)
+        simpa [Nat.mul_add] using this
+      omega
+  · -- left inverse
+    rintro ⟨I, J⟩ hp
+    obtain ⟨a, d, rfl⟩ : ∃ a d, I = finProdFinEquiv (a, d) :=
+      ⟨I.divNat, I.modNat, (finProdFinEquiv.apply_symm_apply I).symm⟩
+    obtain ⟨b, c, rfl⟩ : ∃ b c, J = finProdFinEquiv (b, c) :=
+      ⟨J.divNat, J.modNat, (finProdFinEquiv.apply_symm_apply J).symm⟩
+    simp [fpe_divNat, fpe_modNat]
+  · -- right inverse
+    rintro ⟨⟨a, b⟩, ⟨c, d⟩⟩ hq
+    simp [fpe_divNat, fpe_modNat]
+
+end ZGScratch


### PR DESCRIPTION
## Summary

The shared blocker `sign(gridTranspose m n) = (-1)^(C(m,2)·C(n,2))` — the sole
remaining `sorry` in both the elementary- and algorithm-QR Zolotarev lineages —
has stalled ≥3 sessions on the belief that **no Mathlib lemma gives
`sign = (-1)^(#inversions)`**, forcing ~100 LOC of bespoke `signAux`/`finPairsLT`
surgery. **That assessment is out of date.**

Mathlib provides the exact bridge:

    Equiv.Perm.sign_eq_prod_prod_Iio (σ : Perm (Fin N)) :
      σ.sign = ∏ j, ∏ i ∈ Finset.Iio j, (if σ i < σ j then 1 else -1)

(`Mathlib/GroupTheory/Perm/Fin.lean`, §Sign). Each factor is `-1` exactly on an
inversion `i<j ∧ σ i>σ j`, so `sign σ = (-1)^(#inversions)` with no `signAux`
surgery. The blocker reduces to the elementary count
`#{(I,J): I<J ∧ T I>T J} = C(m,2)·C(n,2)` via a `card_bij'` onto
(strictly-increasing row pairs) × (strictly-increasing column pairs), each
counted `= choose · 2` by the Gauss sum.

## Changes

- **`research/.../sign_gridTranspose_candidate.lean`** — a complete candidate
  proof (def + `encode_lt` mixed-radix lemma + `gridTranspose_val` +
  `card_strict_pairs` + the bijection). Placed in the research dir (NOT
  `proofs/Proofs/`) so an unverified file cannot affect the gallery build.
- **`knowledge.md`** — S2 log with the full worked reduction and next steps.
- **Registered Lean file** — doc-only fix: corrected the now-false "no Mathlib
  lemma" note to cite the bridge + candidate. Keeps its single `sorry`, still
  compiles; **nothing marked verified.**

## Honest scope

⚠️ The candidate is **NOT kernel-verified**: the Docker daemon was wedged this
session (`docker ps`/`images` empty, no container spawns; ≥6 sibling builds stuck
~1.7h) and Aristotle MCP still returns "Resource not found". A few API lemma
names (`Fin.coe_cast`, `finCongr_apply`, `not_lt`, `Finset.univ_product_univ`)
are best-effort and may need a one-pass fixup once a build backend recovers. No
gallery entry is promoted; the registered file is unchanged in substance.