### PR TITLE
Enrich Iterated Biadditive Abel Transform (finite Taylor–Abel expansion)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "sbp-taylorabel-fdiff-def",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 78, "endLine": 82 },
+    "type": "definition",
+    "title": "The forward difference operator Δf",
+    "content": "`fdiff f k = f(k+1) − f k` is the discrete derivative — the building block of the whole expansion. It is defined for any type with subtraction (`[Sub A]`), so it applies to the left sequence in any abelian group. The `@[simp] fdiff_apply` lemma exposes the defining equation to the simplifier. Iterating it, `fdiff^[j] f = Δʲf`, produces the discrete analogue of the j-th derivative that the Taylor–Abel expansion pairs against the antidifference tower.",
+    "mathContext": "$(\\Delta f)(k) = f(k+1) - f(k)$; the j-fold iterate $\\Delta^{j} f = \\mathrm{fdiff}^{[j]} f$ is the discrete j-th derivative.",
+    "significance": "key",
+    "prerequisites": ["finite differences", "the Sub typeclass", "function iteration f^[j]"],
+    "relatedConcepts": ["discrete derivative", "forward difference", "Taylor expansion"]
+  },
+  {
+    "id": "sbp-taylorabel-fdiff-iterate",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 84, "endLine": 89 },
+    "type": "lemma",
+    "title": "Unfolding one step of the iterated difference",
+    "content": "`fdiff_iterate_succ` proves Δ^{d+1}f k = Δᵈf(k+1) − Δᵈf k, i.e. one more difference of the d-th iterate. The single rewrite `Function.iterate_succ_apply'` turns `f^[d+1]` into `fdiff (f^[d])`, after which the goal is `rfl` by the definition of `fdiff`. This identity is precisely the left-tower hypothesis `hF` that the abstract theorem demands, so the iterated forward difference is a legitimate left difference tower.",
+    "mathContext": "$\\Delta^{d+1} f = \\Delta(\\Delta^{d} f)$, unfolded via $f^{[d+1]} = f \\circ f^{[d]}$.",
+    "significance": "supporting",
+    "prerequisites": ["Function.iterate_succ_apply'", "definitional unfolding (rfl)"],
+    "relatedConcepts": ["iterated forward difference", "left difference tower"]
+  },
+  {
+    "id": "sbp-taylorabel-single-step",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 93, "endLine": 114 },
+    "type": "theorem",
+    "title": "abel_summation_biadditive — the single-step transform (the engine)",
+    "content": "The parent entry's master identity, re-proved in-file for self-containedness: ∑_{k<n} p(f k)(G(k+1)−G k) = p(f n)(G n) − p(f 0)(G 0) − ∑_{k<n} p(f(k+1)−f k)(G(k+1)), for any biadditive pairing p between abelian groups. The proof inducts on n; `Finset.sum_range_succ` peels the top term off both sums, `map_sub` and `AddMonoidHom.sub_apply` expand the pairing in each slot, and `abel` discharges the abelian-group rearrangement. Crucially no commutativity, associativity, or ring structure is used — only that p is additive in each argument. This single lemma is the only analytic input the entire iteration consumes: applied once per order, it converts a remainder into one boundary term plus the next remainder.",
+    "mathContext": "$\\sum_{k<n} p(f_k)(G_{k+1}-G_k) = p(f_n)(G_n) - p(f_0)(G_0) - \\sum_{k<n} p(f_{k+1}-f_k)(G_{k+1})$",
+    "significance": "critical",
+    "prerequisites": ["biadditive pairing A →+ B →+ M", "Finset.sum_range_succ", "the abel tactic"],
+    "relatedConcepts": ["Abel summation by parts", "integration by parts", "biadditivity"]
+  },
+  {
+    "id": "sbp-taylorabel-master",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 118, "endLine": 145 },
+    "type": "theorem",
+    "title": "taylor_abel_biadditive — the finite Taylor–Abel expansion",
+    "content": "The headline result. For a left difference tower F (hF: F(j+1) k = F j(k+1) − F j k) and a right antidifference tower H (hH: H(j+1)(k+1) − H(j+1) k = H j(k+1)), the single biadditive sum expands into a finite alternating sum of D boundary terms plus an order-D remainder. The finite sum is the discrete Taylor polynomial; the trailing sum is the remainder, pairing the D-th left difference against the D-th right antidifference. The ℤ-coefficients (−1)ʲ act on the value group M by `zsmul`, which is well-defined on any abelian group — again no ring structure on M is needed.",
+    "mathContext": "$\\sum_{k<n} p(F_0 k)(H_0(k{+}1)) = \\sum_{j<D}(-1)^j\\big(p(F_j n)(H_{j+1} n) - p(F_j 0)(H_{j+1} 0)\\big) + (-1)^D\\!\\sum_{k<n} p(F_D k)(H_D(k{+}1))$",
+    "significance": "critical",
+    "prerequisites": ["the single-step transform", "induction on the order D", "difference / antidifference towers"],
+    "relatedConcepts": ["discrete Taylor formula", "iterated integration by parts", "finite-difference calculus"]
+  },
+  {
+    "id": "sbp-taylorabel-induction-step",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 146, "endLine": 164 },
+    "type": "insight",
+    "title": "Why the recursion closes: the shifted antidifference",
+    "content": "The inductive step is the heart of the proof. One application of `abel_summation_biadditive` to the order-d remainder ∑ p(F d k)(H(d+1)(k+1)) produces a boundary term and a new remainder; the two local lemmas `hL` and `hR` rewrite the difference relations that the engine exposes, using `hH d k` on the right and `hF d k` on the left. The decisive design choice is that H(j+1) antidifferences the *shifted* weight k↦H j(k+1) — this makes every Abel step emit a remainder of exactly the same shape ∑ p(·)(H·(k+1)) as the term it consumed, so the recursion closes on itself and the induction is a one-line peel-and-substitute. An unshifted antidifference would only iterate cleanly at the first step. The alternating sign is reconciled by `sum_range_succ`, `smul_sub`, `pow_succ`, `mul_smul`, `neg_one_smul`, then `abel`.",
+    "mathContext": "Tower relation $H_{j+1}(k{+}1) - H_{j+1}(k) = H_j(k{+}1)$ — antidifference of the *shifted* weight, the structural choice making each step self-similar.",
+    "significance": "critical",
+    "prerequisites": ["the abel tactic", "Finset.sum_congr", "pow_succ / smul rearrangement"],
+    "relatedConcepts": ["antidifference (discrete antiderivative)", "telescoping", "self-similar recursion"]
+  },
+  {
+    "id": "sbp-taylorabel-iterate",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 168, "endLine": 186 },
+    "type": "theorem",
+    "title": "taylor_abel_iterate — the genuine iterated-difference form",
+    "content": "Instantiates the abstract left tower to the concrete iterated forward difference F j = Δʲf = fdiff^[j] f. The tower hypothesis hF is supplied verbatim by `fdiff_iterate_succ`, and the result follows from the master theorem by `simpa`. This is the form one actually applies in practice: the left argument is a single sequence f and its successive differences, paired against an antidifference tower of weights.",
+    "mathContext": "$\\sum_{k<n} p(f_k)(H_0(k{+}1)) = \\sum_{j<D}(-1)^j\\big(p(\\Delta^j f\\,n)(H_{j+1} n) - p(\\Delta^j f\\,0)(H_{j+1} 0)\\big) + (-1)^D\\!\\sum_{k<n} p(\\Delta^D f\\,k)(H_D(k{+}1))$",
+    "significance": "key",
+    "prerequisites": ["fdiff_iterate_succ", "specialization of the abstract tower", "simpa"],
+    "relatedConcepts": ["iterated forward difference", "discrete Taylor polynomial"]
+  },
+  {
+    "id": "sbp-taylorabel-smul",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 190, "endLine": 210 },
+    "type": "theorem",
+    "title": "taylor_abel_smul — the module-valued form",
+    "content": "Takes the pairing to be the scalar action `smulAddHom R M : R →+ M →+ M`, giving the module-valued expansion: f is a sequence of scalars in a ring R, the weight tower H is valued in a left R-module M, and the sum ∑ f k • H 0(k+1) expands by the same formula. This is the 'different objects, fixed multiplication order' instance — the left multipliers and the right weights live in genuinely different types — which is exactly what biadditivity (as opposed to a symmetric bilinear form) buys. Proof: feed `smulAddHom R M` to `taylor_abel_iterate` and `simpa only [smulAddHom_apply]`.",
+    "mathContext": "$\\sum_{k<n} f_k \\cdot H_0(k{+}1) = \\sum_{j<D}(-1)^j\\big(\\Delta^j f\\,n\\cdot H_{j+1} n - \\Delta^j f\\,0\\cdot H_{j+1} 0\\big) + (-1)^D\\!\\sum_{k<n}\\Delta^D f\\,k\\cdot H_D(k{+}1)$",
+    "significance": "key",
+    "prerequisites": ["smulAddHom", "modules over a ring", "scalar action as a biadditive map"],
+    "relatedConcepts": ["module-valued summation", "bimodule pairing", "scalar action"]
+  },
+  {
+    "id": "sbp-taylorabel-order-two",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01",
+    "range": { "startLine": 231, "endLine": 252 },
+    "type": "theorem",
+    "title": "taylor_abel_order_two — the explicit second-order expansion",
+    "content": "Unfolds the master theorem at D=2 to the concrete identity ∑ p(f k)(H 0(k+1)) = (p(f n)(H 1 n) − p(f 0)(H 1 0)) − (p(Δf n)(H 2 n) − p(Δf 0)(H 2 0)) + ∑ p(Δ²f k)(H 2(k+1)). This is the discrete analogue of integrating by parts twice, ∫fg = [fG₁] − [Δf G₂] + ∫Δ²f G₂. The unfolding is mechanical: `sum_range_succ`/`sum_range_zero` expand the order sum, `pow_zero`/`pow_one`/`neg_one_sq` evaluate the signs, `iterate_one`/`iterate_zero` collapse the difference iterates, and `abel` finishes. The arbitrary-ring form `taylor_abel_ring` (via `AddMonoidHom.mul`, commutativity not required) is the analogous one-line specialization just above.",
+    "mathContext": "$\\sum_{k<n} p(f_k)(H_0(k{+}1)) = \\big[p(f)(H_1)\\big]_0^n - \\big[p(\\Delta f)(H_2)\\big]_0^n + \\sum_{k<n} p(\\Delta^2 f\\,k)(H_2(k{+}1))$",
+    "significance": "supporting",
+    "prerequisites": ["specialization at D = 2", "sum_range_succ / pow simplification", "integration by parts twice (analogy)"],
+    "relatedConcepts": ["second-order Taylor remainder", "iterated integration by parts", "arbitrary-ring form"]
+  }
+]

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01/index.ts
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const summationByPartsOQ01OQ01OQ01OQ02OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const summationByPartsOQ01OQ01OQ01OQ02OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const summationByPartsOQ01OQ01OQ01OQ02OQ02OQ01Data: ProofData = {
+  proof: summationByPartsOQ01OQ01OQ01OQ02OQ02OQ01Proof,
+  annotations: summationByPartsOQ01OQ01OQ01OQ02OQ02OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-02-oq-01`.

## Quality improvements

**Critical fix — proof was unreachable on the live site:**
- Created the missing `index.ts`. Without it Vite's `import.meta.glob` cannot discover the proof, so the page rendered "proof not found". Imports `Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ02OQ01.lean?raw`.

**Annotation coverage (file had none):**
- Added `annotations.json` with 8 annotations spanning the whole Lean file: the forward-difference operator `fdiff` and its iterate lemma, the single-step biadditive Abel engine `abel_summation_biadditive`, the master `taylor_abel_biadditive` expansion, the shifted-antidifference recursion insight (why the induction closes on itself), and the iterated-difference / module-valued / explicit second-order specializations.
- Each annotation carries `mathContext` (LaTeX), `significance`, `prerequisites`, and `relatedConcepts`.

## Verification
- Both JSON files parse cleanly.
- **Annotation alignment verified against the Lean source** with `scripts/annotations/resolver.ts validate`: **8 valid, 0 misaligned** — every annotation's line range lands on the correct Lean construct with a matching type.
- The build's data-enrichment step processed the entry with 0 errors.
- Note: the final `tsc` typecheck cannot run in a fresh worktree (native `better-sqlite3` install fails under Node 26) — a pre-existing environment constraint, not a content issue.
- Axiom integrity: `status: verified`, `badge: original`, `axiomCount: 0` confirmed against the Lean source (only propext/Classical.choice/Quot.sound; no native_decide; the single `def fdiff` carries no assumptions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)