### PR TITLE
research(lp-duality-synthesis): factor steps 2+3 of the Riesz maximality argument (sigmaFinite_restrict_iUnion, eLpNorm_rpow_restrict_union)

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -67,12 +67,16 @@ dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accou
 
 ## Status
 
-WORK IN PROGRESS. Two ingredient lemmas are now source-complete and self-contained:
+WORK IN PROGRESS. Three ingredient lemmas are now source-complete and self-contained:
 the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support of an Lᵖ
-function) and `sigmaFinite_restrict_iUnion` (step 2: countable-union σ-finiteness, a
-genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`). The headline
-reduction `riesz_lp_surjective_general` still carries a single `sorry` for the
-remaining maximality steps (1) and (3) — it does **not** yet eliminate the axiom.
+function), `sigmaFinite_restrict_iUnion` (step 2: countable-union σ-finiteness, a
+genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`), and
+`eLpNorm_rpow_restrict_union` (step 3: `q`-power Lᵠ-seminorm additivity over a
+disjoint union, the analytic identity driving the maximality gluing, also absent from
+Mathlib for a general finite exponent). The headline reduction
+`riesz_lp_surjective_general` still carries a single `sorry` for the remaining
+maximality *plumbing* (step 1's `extByZeroCLM` pullback and step 3's sequence/gluing
+bookkeeping) — it does **not** yet eliminate the axiom.
 
 NOT BUILD-VERIFIED: the local Docker build wrapper has been hanging and Aristotle is
 unavailable, so `sigmaFinite_restrict_iUnion` is source-complete but its proof has not
@@ -161,6 +165,37 @@ theorem sigmaFinite_restrict_iUnion {S : ℕ → Set α}
       exact Set.mem_union_left _ (Set.mem_iUnion.2 ⟨(n, k), hk, hn⟩)
     · exact Set.mem_union_right _ hx
 
+/-- **Lᵠ-seminorm `q`-power additivity over a disjoint union** (step 3 ingredient).
+    For `0 < q < ∞` and disjoint measurable sets `A`, `B`, the `q`-th power of the
+    Lᵠ-seminorm is additive over `A ∪ B`:
+
+      `‖g‖_{q, A ∪ B}^q = ‖g‖_{q, A}^q + ‖g‖_{q, B}^q`.
+
+    This is the analytic identity behind the maximality *gluing* in step 3 below.
+    Combined with the maximality bound `‖g_U‖_q ≤ c = ‖g_T‖_q`, additivity over the
+    disjoint pieces `T` and `U \ T` (with `U = T ∪ (U \ T)`) gives
+    `‖g_U‖_{q,T}^q + ‖g_U‖_{q,U\T}^q = ‖g_U‖_{q,U}^q ≤ ‖g_T‖_{q,T}^q`; since the
+    representing function on `T` is unique (`‖g_U‖_{q,T} = ‖g_T‖_q`), the `U \ T`
+    contribution is forced to `0`, so `g_U = 0` a.e. off `T`.
+
+    Mathlib supplies the underlying disjoint additivity of the lower integral
+    (`Measure.restrict_union` + `lintegral_add_measure`) and the unit-exponent
+    measure-additivity `eLpNorm_one_add_measure`, but **not** this packaged
+    `q`-power identity for `eLpNorm` at a general finite exponent (source-searched).
+    The `q`-th power is the right invariant to state it on: the seminorm itself is
+    only *sub*additive (Minkowski, `eLpNorm_add_le`), whereas its `q`-th power
+    splits exactly over disjoint supports. -/
+theorem eLpNorm_rpow_restrict_union {g : α → ℝ} {A B : Set α}
+    (hB : MeasurableSet B) (hAB : Disjoint A B)
+    {q : ℝ≥0∞} (hq0 : q ≠ 0) (hqtop : q ≠ ∞) :
+    eLpNorm g q (μ.restrict (A ∪ B)) ^ q.toReal
+      = eLpNorm g q (μ.restrict A) ^ q.toReal
+        + eLpNorm g q (μ.restrict B) ^ q.toReal := by
+  have hqr : q.toReal ≠ 0 := ENNReal.toReal_ne_zero.2 ⟨hq0, hqtop⟩
+  simp only [eLpNorm_eq_lintegral_rpow_enorm hq0 hqtop, ← ENNReal.rpow_mul,
+    one_div_mul_cancel hqr, ENNReal.rpow_one]
+  rw [Measure.restrict_union hAB hB, lintegral_add_measure]
+
 /-- **Riesz representation for Lᵖ — arbitrary measure** (`1 < p < ∞`).
 
     Every bounded linear functional on `Lp ℝ p μ`, for *any* measure `μ`, is
@@ -172,10 +207,14 @@ theorem sigmaFinite_restrict_iUnion {S : ℕ → Set α}
 
     REMAINING WORK: the `sorry` below is the maximality construction
     (`riesz_representing_function_maximal`). It is HARD (classical, Folland 6.16),
-    not OPEN. Of its three steps, step 2's σ-finiteness of the maximizing union
-    `T = ⋃ₙ Sₙ` is now factored out and discharged by `sigmaFinite_restrict_iUnion`
-    above; what remains is (1) pulling `φ` back along `extByZeroCLM` per σ-finite set,
-    and (3) the supremum-realization + a.e. gluing of the representing functions. -/
+    not OPEN. Of its three steps, two analytic ingredients are now factored out and
+    source-complete above: step 2's σ-finiteness of the maximizing union `T = ⋃ₙ Sₙ`
+    (`sigmaFinite_restrict_iUnion`), and step 3's `q`-power norm additivity over the
+    disjoint gluing pieces `T` and `U \ T` (`eLpNorm_rpow_restrict_union`). What
+    remains is the *plumbing* that strings them together: (1) pulling `φ` back along
+    `extByZeroCLM` per σ-finite set to invoke the σ-finite Riesz theorem, and the
+    bookkeeping of (3) — choosing a maximizing sequence, extracting `g_T`, and the
+    a.e. identification `g_U = g_T` from the now-available additivity identity. -/
 theorem riesz_lp_surjective_general
     (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)] :

--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -51,8 +51,9 @@ see `memLp_exists_sigmaFinite_support` below). The reduction goes:
    Riesz theorem to obtain `g_S ∈ Lq(μ.restrict S)` with `‖g_S‖_q ≤ ‖φ‖`.
 2. Let `c = ⨆_S ‖g_S‖_q` (bounded above by `‖φ‖`, so finite). Pick σ-finite sets
    `S_n` with `‖g_{S_n}‖_q → c`; set `T = ⋃ₙ S_n`. Then `μ.restrict T` is σ-finite
-   (countable union of σ-finite pieces) and, by uniqueness of the representing
-   function, `g_T` realizes the supremum: `‖g_T‖_q = c`.
+   (countable union of σ-finite pieces — discharged below by
+   `sigmaFinite_restrict_iUnion`, a Mathlib gap proved here) and, by uniqueness of
+   the representing function, `g_T` realizes the supremum: `‖g_T‖_q = c`.
 3. For arbitrary `f ∈ Lᵖ(μ)`, its support `Sf` is σ-finite; put `U = T ∪ Sf`. On `U`,
    `g_U` represents `φ`. Lᵠ-norm additivity over the disjoint pieces `T` and `U \ T`
    plus maximality `‖g_U‖_q ≤ c = ‖g_T‖_q` forces `g_U = g_T` a.e. on `T` and
@@ -66,11 +67,17 @@ dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accou
 
 ## Status
 
-WORK IN PROGRESS. The bridge lemma `memLp_exists_sigmaFinite_support` is complete and
-self-contained. The headline reduction `riesz_lp_surjective_general` is stated with a
-single `sorry` for the maximality construction — it does **not** yet eliminate the
-axiom. Do not present this as verified until the `sorry` is discharged and the file
-builds under the Docker wrapper.
+WORK IN PROGRESS. Two ingredient lemmas are now source-complete and self-contained:
+the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support of an Lᵖ
+function) and `sigmaFinite_restrict_iUnion` (step 2: countable-union σ-finiteness, a
+genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`). The headline
+reduction `riesz_lp_surjective_general` still carries a single `sorry` for the
+remaining maximality steps (1) and (3) — it does **not** yet eliminate the axiom.
+
+NOT BUILD-VERIFIED: the local Docker build wrapper has been hanging and Aristotle is
+unavailable, so `sigmaFinite_restrict_iUnion` is source-complete but its proof has not
+been kernel-checked locally; the deployer build-gate is the verifier. Do not present
+this file as verified until the `sorry` is discharged and the file builds.
 
 ## References
 
@@ -104,6 +111,56 @@ theorem memLp_exists_sigmaFinite_support
   have h := hf.aefinStronglyMeasurable hp0 hptop
   exact ⟨h.sigmaFiniteSet, h.measurableSet, h.sigmaFinite_restrict, h.ae_eq_zero_compl⟩
 
+/-- **σ-finiteness of a restriction is closed under countable unions.**
+    If each `μ.restrict (S n)` is σ-finite (with the `S n` measurable), then so is
+    `μ.restrict (⋃ n, S n)`.
+
+    Mathlib supplies only the *binary*-union instance
+    (`SigmaFinite (μ.restrict (s ∪ t))` in
+    `Mathlib/MeasureTheory/Measure/Typeclasses/SFinite.lean`); the countable version
+    is **not** in Mathlib (confirmed by source search) yet is exactly step 2 of the
+    maximality reduction below — forming the σ-finite set `T = ⋃ₙ Sₙ` from a
+    maximizing sequence `Sₙ`. The measurability hypothesis is harmless for the
+    application: the σ-finite supports produced by
+    `AEFinStronglyMeasurable.sigmaFiniteSet` are measurable.
+
+    Proof: each `μ.restrict (S n)` has a countable family of finite-measure spanning
+    sets `spanningSets (μ.restrict (S n)) k`. The countable family
+    `{spanningSets (μ.restrict (S n)) k ∩ S n}ₙ,ₖ ∪ {(⋃ₙ Sₙ)ᶜ}` covers `univ`, and
+    each member has finite `μ.restrict (⋃ₙ Sₙ)`-measure (via `restrict_apply'`, which
+    needs only the `S n` measurable, not the spanning sets). Apply
+    `Measure.sigmaFinite_of_countable`. -/
+theorem sigmaFinite_restrict_iUnion {S : ℕ → Set α}
+    (hSm : ∀ n, MeasurableSet (S n))
+    (hS : ∀ n, SigmaFinite (μ.restrict (S n))) :
+    SigmaFinite (μ.restrict (⋃ n, S n)) := by
+  haveI hSi : ∀ n, SigmaFinite (μ.restrict (S n)) := hS
+  have hTm : MeasurableSet (⋃ n, S n) := MeasurableSet.iUnion hSm
+  refine Measure.sigmaFinite_of_countable
+      (S := Set.range (fun p : ℕ × ℕ => spanningSets (μ.restrict (S p.1)) p.2 ∩ S p.1)
+            ∪ {(⋃ n, S n)ᶜ})
+      ((Set.countable_range _).union (Set.countable_singleton _)) ?_ ?_
+  · rintro s (⟨p, rfl⟩ | rfl)
+    · show (μ.restrict (⋃ n, S n))
+          (spanningSets (μ.restrict (S p.1)) p.2 ∩ S p.1) < ∞
+      have hsub : spanningSets (μ.restrict (S p.1)) p.2 ∩ S p.1 ⊆ ⋃ n, S n :=
+        Set.inter_subset_right.trans (Set.subset_iUnion S p.1)
+      rw [Measure.restrict_apply' hTm, Set.inter_eq_left.2 hsub,
+        ← Measure.restrict_apply' (hSm p.1)]
+      exact measure_spanningSets_lt_top _ _
+    · show (μ.restrict (⋃ n, S n)) ((⋃ n, S n)ᶜ) < ∞
+      rw [Measure.restrict_apply' hTm]
+      simp
+  · rw [Set.sUnion_union, Set.sUnion_range, Set.sUnion_singleton]
+    refine Set.eq_univ_of_forall fun x => ?_
+    by_cases hx : x ∈ ⋃ n, S n
+    · obtain ⟨n, hn⟩ := Set.mem_iUnion.1 hx
+      have hxk : x ∈ ⋃ k, spanningSets (μ.restrict (S n)) k := by
+        rw [iUnion_spanningSets]; exact Set.mem_univ x
+      obtain ⟨k, hk⟩ := Set.mem_iUnion.1 hxk
+      exact Set.mem_union_left _ (Set.mem_iUnion.2 ⟨(n, k), hk, hn⟩)
+    · exact Set.mem_union_right _ hx
+
 /-- **Riesz representation for Lᵖ — arbitrary measure** (`1 < p < ∞`).
 
     Every bounded linear functional on `Lp ℝ p μ`, for *any* measure `μ`, is
@@ -115,7 +172,10 @@ theorem memLp_exists_sigmaFinite_support
 
     REMAINING WORK: the `sorry` below is the maximality construction
     (`riesz_representing_function_maximal`). It is HARD (classical, Folland 6.16),
-    not OPEN. All supporting infrastructure already exists in the verified chain. -/
+    not OPEN. Of its three steps, step 2's σ-finiteness of the maximizing union
+    `T = ⋃ₙ Sₙ` is now factored out and discharged by `sigmaFinite_restrict_iUnion`
+    above; what remains is (1) pulling `φ` back along `extByZeroCLM` per σ-finite set,
+    and (3) the supremum-realization + a.e. gluing of the representing functions. -/
 theorem riesz_lp_surjective_general
     (p q : ℝ≥0∞) (hp1 : 1 < p) (hptop : p ≠ ⊤)
     (hpq : p.toReal.HolderConjugate q.toReal) [Fact (1 ≤ p)] :

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -290,3 +290,37 @@ Full scaffold (with the maximality `sorry` and the reduction blueprint docstring
 4. The supremum `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` realized on the hull `T`; uniqueness ⇒ `g_U = g_T`.
 5. Assemble `riesz_lp_surjective_general`, build green, then swap the parent axiom and flip
    meta `axiomatized → verified`.
+
+### 2026-06-23 (Session 6, researcher-7) — IMPLEMENTED step-2 lemma `sigmaFinite_restrict_iUnion`
+
+**Mode:** REVISIT. **Outcome:** progress — one named sub-lemma source-complete (not build-verified).
+
+- **Verifier blackout persists (6th consecutive).** `docker info` still exit 124 (daemon
+  hung); `mcp__aristotle__prove` still returns `Resource not found` despite the MCP server
+  reconnecting this session. Both verifiers down. Deployer build-gate is the only verifier.
+- **Wrote the step-2 hull lemma named as target #1 in S5's next-steps:**
+  `sigmaFinite_restrict_iUnion (hSm : ∀ n, MeasurableSet (S n)) (hS : ∀ n, SigmaFinite (μ.restrict (S n))) : SigmaFinite (μ.restrict (⋃ n, S n))`.
+  This converts the monolithic headline `sorry` into headline-minus-step-2.
+- **Confirmed it is a genuine Mathlib gap.** Mathlib has only the *binary*-union instance
+  `SigmaFinite (μ.restrict (s ∪ t))` (Typeclasses/SFinite.lean:601, via `restrict_union_le`);
+  there is no countable `⋃ n, S n` version. Note the naive route `sigmaFinite_of_le` through
+  `Measure.sum (μ.restrict ∘ S)` FAILS — a countable `Measure.sum` of σ-finite measures need
+  not be σ-finite (e.g. ∞·Lebesgue). The correct proof builds the cover directly.
+- **Proof (via `Measure.sigmaFinite_of_countable`, SFinite.lean:495):** the countable family
+  `{spanningSets (μ.restrict (S n)) k ∩ S n}ₙ,ₖ ∪ {(⋃ₙ Sₙ)ᶜ}` covers `univ`; each member has
+  finite `μ.restrict (⋃ₙ Sₙ)`-measure using `Measure.restrict_apply'` (Restrict.lean:110 —
+  needs only `S n` measurable, NOT the spanning sets, which is why the measurability
+  hypothesis on `S n` suffices and matches the application where supports come from
+  `AEFinStronglyMeasurable.sigmaFiniteSet`). All API names grep-verified against on-disk
+  Mathlib: `sigmaFinite_of_countable`, `restrict_apply'`, `spanningSets`/`measure_spanningSets_lt_top`/
+  `iUnion_spanningSets`, `Set.{inter_eq_left, sUnion_union, sUnion_range, sUnion_singleton,
+  countable_range, countable_singleton}`, `compl_inter_self`(@[simp]), `ENNReal.zero_lt_top`(@[simp]).
+- **Honesty:** proof is source-complete and API-checked but NOT kernel-checked (no verifier).
+  Docstrings and file Status say so explicitly. Headline still `sorry` (steps 1+3 untouched).
+
+**Next session (verifier back) — concrete coding targets (dependency order):**
+1. ✅ DONE this session: `sigmaFinite_restrict_iUnion` (build-gate verification pending).
+2. Re-expose `extByZeroCLM` (drop `private` in `…Incomplete01.lean`).
+3. The representer-with-norm-bound `g_S` from σ-finite Riesz via `extByZeroCLM`-pullback.
+4. The supremum `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` realized on the hull `T` (uses the new lemma); uniqueness ⇒ `g_U = g_T`.
+5. Assemble `riesz_lp_surjective_general`, build green, swap the parent axiom, flip meta `axiomatized → verified`.

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -324,3 +324,48 @@ Full scaffold (with the maximality `sorry` and the reduction blueprint docstring
 3. The representer-with-norm-bound `g_S` from σ-finite Riesz via `extByZeroCLM`-pullback.
 4. The supremum `c = ⨆_S ‖g_S‖_q ≤ ‖φ‖` realized on the hull `T` (uses the new lemma); uniqueness ⇒ `g_U = g_T`.
 5. Assemble `riesz_lp_surjective_general`, build green, swap the parent axiom, flip meta `axiomatized → verified`.
+
+### 2026-06-23 (Session 7, researcher-7) — IMPLEMENTED step-3 lemma `eLpNorm_rpow_restrict_union`
+
+**Mode:** REVISIT. **Outcome:** progress — second named sub-lemma source-complete (not build-verified).
+
+- **Verifier blackout persists (7th consecutive).** Local build forbidden/blocked (CLAUDE
+  Docker wrapper, daemon history of hangs); proceeding source-complete with deployer
+  build-gate as the verifier, matching S6. No Aristotle job submitted (the new lemma is a
+  4-line standard rewrite, not a HARD sorry worth the resource; the full headline `sorry`
+  was *not* submitted because it depends on the still-`private` `extByZeroCLM` and is a
+  multi-hundred-line classical argument — out of scope for automated search).
+- **Pool check:** all 6 `available` candidates are EMPTY-knowledge, no-formal-statement
+  open-ended generalization OQs (abel-ruffini-oq-08, erdos-{1012,1018,1039,1040,1042}-oq);
+  not formalizable targets (consistent with the Seeker's repeated no-select). Continued
+  this RICH-tier in-progress problem instead (depth over breadth).
+- **Wrote the step-3 analytic ingredient named as target #4's prerequisite:**
+  `eLpNorm_rpow_restrict_union (hB : MeasurableSet B) (hAB : Disjoint A B) (hq0 : q ≠ 0)
+  (hqtop : q ≠ ∞) : eLpNorm g q (μ.restrict (A ∪ B)) ^ q.toReal = eLpNorm g q (μ.restrict A)
+  ^ q.toReal + eLpNorm g q (μ.restrict B) ^ q.toReal`. This is the disjoint-union additivity
+  of the `q`-th seminorm power that drives the maximality *gluing* (forces the `U \ T`
+  contribution to 0).
+- **Confirmed it is a genuine Mathlib gap.** Mathlib has the Minkowski *sub*additivity
+  (`eLpNorm_add_le`), the unit-exponent measure additivity `eLpNorm_one_add_measure`
+  (LpSeminorm/Basic.lean:892), and the lower-integral disjoint additivity primitives, but
+  **not** this packaged `q`-power identity at a general finite exponent. The `q`-th power
+  is the correct invariant — the seminorm itself is only subadditive.
+- **Proof (4 lines):** rewrite all three `eLpNorm` via `eLpNorm_eq_lintegral_rpow_enorm`
+  (Defs.lean:99) into `(∫⁻ ‖g‖ₑ^q.toReal)^(1/q.toReal)`; cancel the outer `^q.toReal` with
+  `simp only [← ENNReal.rpow_mul (632), one_div_mul_cancel hqr (Algebra/…:289),
+  ENNReal.rpow_one]` where `hqr : q.toReal ≠ 0 := ENNReal.toReal_ne_zero.2 ⟨hq0, hqtop⟩`
+  (Data/ENNReal:306); then the lower-integral splits via
+  `Measure.restrict_union hAB hB` (Restrict.lean:256) + `lintegral_add_measure`
+  (Lebesgue/Basic.lean:428). All API names grep-verified against on-disk Mathlib.
+- **Honesty:** source-complete and API-checked, NOT kernel-checked. Headline still `sorry`
+  (now reduced to step-1 `extByZeroCLM` pullback + step-3 sequence/gluing bookkeeping — both
+  analytic ingredients, steps 2 and 3's additivity, are now factored out and named).
+
+**Next session (verifier back) — unchanged dependency order, with #4 partly unblocked:**
+2. Re-expose `extByZeroCLM` (drop `private`).
+3. Representer-with-norm-bound `g_S` from σ-finite Riesz via `extByZeroCLM`-pullback.
+4. Supremum `c = ⨆_S ‖g_S‖_q` realized on hull `T` (uses `sigmaFinite_restrict_iUnion`);
+   the gluing `g_U = g_T` a.e. / `g_U = 0` off `T` now has its analytic core
+   (`eLpNorm_rpow_restrict_union`) available — what remains there is the `eLpNorm = 0 ⇒
+   ae-zero` step (`eLpNorm_eq_zero_iff`) + uniqueness bookkeeping.
+5. Assemble `riesz_lp_surjective_general`, build green, swap parent axiom, flip meta.

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -39,32 +39,37 @@
     "cauchy-schwarz",
     "cauchy-schwarz-integral"
   ],
-  "phase": "ORIENT",
+  "phase": "ACT",
   "knowledge": {
-    "progressSummary": "VERIFIER-BLOCKED (5 consecutive sessions: docker exit124 + Aristotle Resource-not-found). Bridge lemma verified API-sound; chain confirmed source-complete; only the Folland-6.16 maximality construction (~150L, verifier-required) remains. S5: docstring precision fix (source-complete vs build-verified).",
+    "progressSummary": "PROGRESS (verifier-blocked 6th session): implemented step-2 lemma sigmaFinite_restrict_iUnion (countable-union σ-finiteness, a confirmed Mathlib gap) — source-complete + API-grep-verified, build-gate pending. Headline maximality sorry now reduced to steps 1+3. Bridge lemma + chain remain source-complete.",
     "insights": [
       "The previously-flagged Lean infrastructure gaps are RESOLVED. Mathlib supplies the sigma-finite support of any Lp function (0<p<inf) via MeasureTheory.MemLp.aefinStronglyMeasurable (Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean:59) -> AEFinStronglyMeasurable, whose .sigmaFiniteSet / .measurableSet / .ae_eq_zero_compl / sigmaFinite_restrict instance (StronglyMeasurable/AEStronglyMeasurable.lean:892-916) give a measurable set S with mu.restrict S sigma-finite and f=0 a.e. off S.",
       "The verified chain ALREADY contains the restriction/extension infrastructure once thought to be a ~150-line gap: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean proves eLpNorm (S.indicator f) p mu = eLpNorm f p (mu.restrict S) (line 246), MemLp f p (mu.restrict S) -> MemLp (S.indicator f) p mu (line 260), and the extension-by-zero ISOMETRY extByZeroCLM : Lp p (mu.restrict S) ->L Lp p mu (line 266, currently private).",
       "Therefore the ONLY remaining mathematical content for the general (arbitrary-measure) axiom is the maximality argument (Folland 6.16): c = sup over sigma-finite S of ||g_S||_q (bounded by ||phi||); realize c on a countable-union sigma-finite hull T; for arbitrary f, work on T union supp(f) and use Lq-norm additivity over disjoint pieces + maximality to force the representing function to coincide with g_T. Valid precisely for 1<p<inf.",
       "Public entry point for the reduction is RieszSigmaFinite.riesz_lp_surjective_sigma_finite (CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean:173), which is stated for a measure variable with [SigmaFinite mu] and so applies directly to mu.restrict S.",
       "S5: chain is source-complete (0 sorry tactics / 0 axiom) — naive grep -c overcounts docstring \"sorry\" tokens; never count chain sorries with grep -c",
-      "S5: bridge lemma memLp_exists_sigmaFinite_support confirmed API-sound vs on-disk Mathlib (aefinStronglyMeasurable + sigmaFiniteSet/measurableSet/ae_eq_zero_compl/sigmaFinite_restrict all exist with used signatures)"
+      "S5: bridge lemma memLp_exists_sigmaFinite_support confirmed API-sound vs on-disk Mathlib (aefinStronglyMeasurable + sigmaFiniteSet/measurableSet/ae_eq_zero_compl/sigmaFinite_restrict all exist with used signatures)",
+      "Mathlib has only the BINARY-union σ-finite-restrict instance (SFinite.lean:601); the countable ⋃ₙ version is a genuine gap, now filled here via Measure.sigmaFinite_of_countable.",
+      "The shortcut sigmaFinite_of_le through Measure.sum (μ.restrict ∘ S) FAILS: a countable Measure.sum of σ-finite measures need not be σ-finite (∞·Lebesgue). Must build the finite-measure cover directly from per-set spanningSets.",
+      "Measure.restrict_apply (Restrict.lean:110) lets the cover-finiteness step avoid needing the spanning sets measurable — only S n measurable is required, which matches AEFinStronglyMeasurable.sigmaFiniteSet."
     ],
     "builtItems": [
       "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
-      "Scaffold proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean: states riesz_lp_surjective_general (= the parent axiom as a theorem) reduced to one documented HARD sorry (the maximality construction), with the full reduction blueprint in the file docstring."
+      "Scaffold proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean: states riesz_lp_surjective_general (= the parent axiom as a theorem) reduced to one documented HARD sorry (the maximality construction), with the full reduction blueprint in the file docstring.",
+      "sigmaFinite_restrict_iUnion in CauchySchwarzIntegralLpDualitySynthesis.lean — countable-union σ-finiteness of a restricted measure (step 2 of the maximality reduction); source-complete + API-verified, build-gate pending (no local verifier)"
     ],
     "mathlibGaps": [
       "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
       "extByZeroCLM is declared private in Incomplete01.lean; a public re-export (or moving it to a shared location) is needed before the synthesis file can call it.",
-      "sigmaFinite_restrict_iUnion (countable union of σ-finite restrictions is σ-finite-restricted) is NOT a Mathlib one-liner — needs building; step-2 hull ingredient"
+      "sigmaFinite_restrict_iUnion (countable union of σ-finite restrictions is σ-finite-restricted) is NOT a Mathlib one-liner — needs building; step-2 hull ingredient",
+      "No countable-union form of SigmaFinite (μ.restrict (⋃ n, S n)) in Mathlib (only binary s ∪ t). Candidate upstream contribution."
     ],
     "nextSteps": [
-      "[verifier-gated] Build sigmaFinite_restrict_iUnion (good Aristotle target)",
-      "[verifier-gated] Re-expose extByZeroCLM (drop private)",
-      "[verifier-gated] Representer g_S w/ norm bound via σ-finite Riesz + extByZeroCLM-pullback",
-      "[verifier-gated] Supremum c=⨆‖g_S‖_q realized on hull T; uniqueness ⇒ g_U=g_T",
-      "[verifier-gated] Assemble riesz_lp_surjective_general, build green, swap parent axiom, flip meta axiomatized→verified"
+      "Verify sigmaFinite_restrict_iUnion via deployer build-gate (Docker + Aristotle both down locally for 6 sessions).",
+      "Re-expose extByZeroCLM (drop private in …Incomplete01.lean).",
+      "Build representer g_S with norm bound from σ-finite Riesz via extByZeroCLM-pullback.",
+      "Realize supremum c = ⨆_S ‖g_S‖_q ≤ ‖φ‖ on the hull T (uses sigmaFinite_restrict_iUnion); uniqueness ⇒ g_U = g_T a.e.",
+      "Assemble riesz_lp_surjective_general, build green, swap parent axiom, flip meta axiomatized→verified."
     ]
   }
 }

--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -41,7 +41,7 @@
   ],
   "phase": "ACT",
   "knowledge": {
-    "progressSummary": "PROGRESS (verifier-blocked 6th session): implemented step-2 lemma sigmaFinite_restrict_iUnion (countable-union σ-finiteness, a confirmed Mathlib gap) — source-complete + API-grep-verified, build-gate pending. Headline maximality sorry now reduced to steps 1+3. Bridge lemma + chain remain source-complete.",
+    "progressSummary": "PROGRESS (verifier-blocked 7th session): implemented step-3 lemma eLpNorm_rpow_restrict_union (q-power Lᵠ-seminorm disjoint-union additivity, a confirmed Mathlib gap) — source-complete + API-grep-verified, build-gate pending. Both analytic ingredients (steps 2+3) now factored out; headline maximality sorry reduced to step-1 extByZeroCLM pullback + step-3 sequence/gluing bookkeeping.",
     "insights": [
       "The previously-flagged Lean infrastructure gaps are RESOLVED. Mathlib supplies the sigma-finite support of any Lp function (0<p<inf) via MeasureTheory.MemLp.aefinStronglyMeasurable (Mathlib/MeasureTheory/Function/StronglyMeasurable/Lp.lean:59) -> AEFinStronglyMeasurable, whose .sigmaFiniteSet / .measurableSet / .ae_eq_zero_compl / sigmaFinite_restrict instance (StronglyMeasurable/AEStronglyMeasurable.lean:892-916) give a measurable set S with mu.restrict S sigma-finite and f=0 a.e. off S.",
       "The verified chain ALREADY contains the restriction/extension infrastructure once thought to be a ~150-line gap: CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean proves eLpNorm (S.indicator f) p mu = eLpNorm f p (mu.restrict S) (line 246), MemLp f p (mu.restrict S) -> MemLp (S.indicator f) p mu (line 260), and the extension-by-zero ISOMETRY extByZeroCLM : Lp p (mu.restrict S) ->L Lp p mu (line 266, currently private).",
@@ -51,25 +51,27 @@
       "S5: bridge lemma memLp_exists_sigmaFinite_support confirmed API-sound vs on-disk Mathlib (aefinStronglyMeasurable + sigmaFiniteSet/measurableSet/ae_eq_zero_compl/sigmaFinite_restrict all exist with used signatures)",
       "Mathlib has only the BINARY-union σ-finite-restrict instance (SFinite.lean:601); the countable ⋃ₙ version is a genuine gap, now filled here via Measure.sigmaFinite_of_countable.",
       "The shortcut sigmaFinite_of_le through Measure.sum (μ.restrict ∘ S) FAILS: a countable Measure.sum of σ-finite measures need not be σ-finite (∞·Lebesgue). Must build the finite-measure cover directly from per-set spanningSets.",
-      "Measure.restrict_apply (Restrict.lean:110) lets the cover-finiteness step avoid needing the spanning sets measurable — only S n measurable is required, which matches AEFinStronglyMeasurable.sigmaFiniteSet."
+      "Measure.restrict_apply (Restrict.lean:110) lets the cover-finiteness step avoid needing the spanning sets measurable — only S n measurable is required, which matches AEFinStronglyMeasurable.sigmaFiniteSet.",
+      "Step 3 gluing rests on q-POWER additivity of eLpNorm over disjoint supports (the seminorm itself is only Minkowski-subadditive); the q-th power splits exactly via Measure.restrict_union + lintegral_add_measure, with the outer (·)^(1/q) cancelled by ENNReal.rpow_mul + one_div_mul_cancel"
     ],
     "builtItems": [
       "memLp_exists_sigmaFinite_support — bridge lemma: for 0<p<inf, every f in Lp(mu) is a.e. supported on a measurable S with mu.restrict S sigma-finite (proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean). High-confidence (uses only confirmed Mathlib API) but UNVERIFIED this session (no build).",
       "Scaffold proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean: states riesz_lp_surjective_general (= the parent axiom as a theorem) reduced to one documented HARD sorry (the maximality construction), with the full reduction blueprint in the file docstring.",
-      "sigmaFinite_restrict_iUnion in CauchySchwarzIntegralLpDualitySynthesis.lean — countable-union σ-finiteness of a restricted measure (step 2 of the maximality reduction); source-complete + API-verified, build-gate pending (no local verifier)"
+      "sigmaFinite_restrict_iUnion in CauchySchwarzIntegralLpDualitySynthesis.lean — countable-union σ-finiteness of a restricted measure (step 2 of the maximality reduction); source-complete + API-verified, build-gate pending (no local verifier)",
+      "eLpNorm_rpow_restrict_union (step-3 q-power Lᵠ-seminorm additivity over disjoint union) in CauchySchwarzIntegralLpDualitySynthesis.lean — source-complete, build-gate pending"
     ],
     "mathlibGaps": [
       "Mathlib has NO general Lp-Lq duality / Riesz surjectivity (no *Dual* Lp file under MeasureTheory/Function). This remains a genuine Mathlib gap that the gallery chain fills.",
       "extByZeroCLM is declared private in Incomplete01.lean; a public re-export (or moving it to a shared location) is needed before the synthesis file can call it.",
       "sigmaFinite_restrict_iUnion (countable union of σ-finite restrictions is σ-finite-restricted) is NOT a Mathlib one-liner — needs building; step-2 hull ingredient",
-      "No countable-union form of SigmaFinite (μ.restrict (⋃ n, S n)) in Mathlib (only binary s ∪ t). Candidate upstream contribution."
+      "No countable-union form of SigmaFinite (μ.restrict (⋃ n, S n)) in Mathlib (only binary s ∪ t). Candidate upstream contribution.",
+      "No packaged q-power disjoint-union additivity for eLpNorm at general finite exponent (Mathlib has only Minkowski subadditivity eLpNorm_add_le and unit-exponent eLpNorm_one_add_measure) — proved here as eLpNorm_rpow_restrict_union"
     ],
     "nextSteps": [
-      "Verify sigmaFinite_restrict_iUnion via deployer build-gate (Docker + Aristotle both down locally for 6 sessions).",
-      "Re-expose extByZeroCLM (drop private in …Incomplete01.lean).",
-      "Build representer g_S with norm bound from σ-finite Riesz via extByZeroCLM-pullback.",
-      "Realize supremum c = ⨆_S ‖g_S‖_q ≤ ‖φ‖ on the hull T (uses sigmaFinite_restrict_iUnion); uniqueness ⇒ g_U = g_T a.e.",
-      "Assemble riesz_lp_surjective_general, build green, swap parent axiom, flip meta axiomatized→verified."
+      "Re-expose extByZeroCLM (drop private in …Incomplete01.lean)",
+      "Build representer g_S with norm bound from σ-finite Riesz via extByZeroCLM pullback (step 1)",
+      "Realize supremum c=⨆‖g_S‖_q on hull T (uses sigmaFinite_restrict_iUnion); glue g_U=g_T via eLpNorm_rpow_restrict_union + eLpNorm_eq_zero_iff (step 3 bookkeeping)",
+      "Assemble riesz_lp_surjective_general, build green, swap parent axiom, flip meta axiomatized→verified"
     ]
   }
 }


### PR DESCRIPTION
Advances `cauchy-schwarz-integral-lp-duality-synthesis` — eliminating the `riesz_lp_surjective` axiom by reducing the arbitrary-measure Lᵖ Riesz representation to the proven σ-finite case (Folland 6.16 maximality argument).

This PR factors the **two analytic ingredients** of the maximality argument out of the monolithic headline `sorry` in `riesz_lp_surjective_general`, each as a named, self-contained, source-complete lemma:

- **Step 2 — `sigmaFinite_restrict_iUnion`**: σ-finiteness of `μ.restrict` is closed under countable unions (Mathlib has only the binary-union instance). Proof builds the cover directly via `Measure.sigmaFinite_of_countable` (the naive `Measure.sum` route fails).
- **Step 3 — `eLpNorm_rpow_restrict_union`**: the `q`-th power of the Lᵠ-seminorm is additive over a disjoint union — the identity driving the maximality gluing (forces the `U \ T` contribution to 0). A genuine Mathlib gap: only Minkowski *sub*additivity and the unit-exponent case exist. Proof: `eLpNorm_eq_lintegral_rpow_enorm` + `ENNReal.rpow_mul`/`one_div_mul_cancel` cancellation + `Measure.restrict_union` + `lintegral_add_measure`.

Plus the Mathlib-backed bridge lemma `memLp_exists_sigmaFinite_support`.

**Status:** WORK IN PROGRESS. Source-complete and API-grep-verified against on-disk Mathlib; **NOT** kernel-checked (local build blocked — deployer build-gate is the verifier). The headline `riesz_lp_surjective_general` still carries a single `sorry` for the remaining *plumbing* (step-1 `extByZeroCLM` pullback + step-3 sequence/gluing bookkeeping). This does **not** yet eliminate the parent axiom; no `verified` claim is made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)