### PR TITLE
Enrich Newton–Girard k=5 closed form (amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ng5-overview",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 45 },
+    "type": "concept",
+    "title": "Newton–Girard k=5: the fifth rung of the closed-form chain",
+    "content": "The module docstring states the target identity p₅ = e₁⁵ − 5e₁³e₂ + 5e₁e₂² + 5e₁²e₃ − 5e₂e₃ − 5e₁e₄ + 5e₅ and situates it in a lineage (k=2 → recurrence → k=3 → k=4 → k=5). Newton's identities relate the power sums pₖ = Σxᵢᵏ to the elementary symmetric polynomials eₖ; this is the first rung where e₅ appears and where two distinct mixed monomials carry coefficient 5 (5e₁e₂² and 5e₂e₃). The file delivers two complementary forms — a universal MvPolynomial statement and a concrete Finset statement over an arbitrary CommRing — each 0-sorry, 0-axiom.",
+    "mathContext": "$p_5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$",
+    "significance": "context",
+    "prerequisites": ["elementary symmetric polynomials", "power sums", "the lower closed forms p₁..p₄"],
+    "relatedConcepts": ["Newton–Girard identities", "symmetric function theory", "Vieta's formulas"]
+  },
+  {
+    "id": "ng5-recurrence",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 65, "endLine": 89 },
+    "type": "theorem",
+    "title": "psum_five_recurrence — extracting the k=5 Newton recurrence",
+    "content": "Specialises Mathlib's general Newton identity `MvPolynomial.psum_eq_mul_esymm_sub_sum` at n=5 to get p₅ = e₁p₄ − e₂p₃ + e₃p₂ − e₄p₁ + 5e₅. The work is purely combinatorial: the antidiagonal filter {a : a.1+a.2=5, 0<a.1<5} is shown by `ext`+`omega` to equal {(1,4),(2,3),(3,2),(4,1)}, the four-term sum is unfolded with `Finset.sum_insert` (non-membership by `decide`) and `Finset.sum_singleton`, and `ring` evaluates the alternating (−1)ᵏ coefficients and the lead term (−1)⁶·5·e₅ = +5·e₅. This mirrors the k=2/3/4 derivations exactly.",
+    "mathContext": "$p_5 = e_1 p_4 - e_2 p_3 + e_3 p_2 - e_4 p_1 + 5 e_5$, with lead term $(-1)^{6}\\cdot 5\\, e_5$.",
+    "significance": "key",
+    "prerequisites": ["MvPolynomial.psum_eq_mul_esymm_sub_sum", "Finset.antidiagonal / sum_insert", "omega, decide, ring"],
+    "relatedConcepts": ["Newton recurrence", "antidiagonal", "alternating signs"]
+  },
+  {
+    "id": "ng5-closed",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 109 },
+    "type": "theorem",
+    "title": "psum_five_closed — the universal reduced closed form",
+    "content": "The headline universal identity in MvPolynomial σ R: substitute the proven lower closed forms — `psum_four_closed` (p₄), `psum_three_closed` (p₃), `psum_two_eq` (p₂ = e₁² − 2e₂), and `psum_one_eq_esymm_one` (p₁ = e₁) — into the recurrence and let `ring` normalise. The result expresses p₅ purely in e₁,…,e₅. Because it lives at the level of polynomial coefficients (before any evaluation), it holds in every commutative ring with no characteristic hypothesis.",
+    "mathContext": "$p_5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$ in $\\mathrm{MvPolynomial}\\,\\sigma\\,R$",
+    "significance": "critical",
+    "prerequisites": ["psum_five_recurrence", "the lower closed forms p₁..p₄", "ring"],
+    "relatedConcepts": ["closed form", "universal symmetric-function identity", "characteristic independence"]
+  },
+  {
+    "id": "ng5-defs",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 122, "endLine": 125 },
+    "type": "definition",
+    "title": "e₅ and p₅ over a concrete Finset",
+    "content": "The concrete-Finset versions: `e5 s f = Σ_{t ⊆ s, |t|=5} ∏_{i∈t} f i` is the fifth elementary symmetric sum via `powersetCard`, and `p5 s f = Σ_{i∈s} (f i)⁵` is the fifth power sum. These are the values the universal MvPolynomial identity is transported onto, with the index running over an arbitrary `Finset ι` and the values in any `CommRing R`.",
+    "mathContext": "$e_5(s,f) = \\sum_{t\\subseteq s,\\,|t|=5}\\prod_{i\\in t} f_i,\\qquad p_5(s,f) = \\sum_{i\\in s} f_i^5$",
+    "significance": "supporting",
+    "prerequisites": ["Finset.powersetCard", "finite products and sums"],
+    "relatedConcepts": ["elementary symmetric polynomial", "power sum", "concrete instantiation"]
+  },
+  {
+    "id": "ng5-bridge",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 128, "endLine": 139 },
+    "type": "theorem",
+    "title": "e5_bridge / p5_bridge — the degree-general aeval transport at n=5",
+    "content": "These two lemmas are the entire cost of the concrete form: `e5_bridge` and `p5_bridge` are just the degree-5 instances of the k=3 entry's n-general bridge lemmas `aeval_esymm_subtype` and `aeval_psum_subtype`, proved definitionally. They state that evaluating the universal symmetric polynomial / power sum via `aeval` on the membership subtype {x // x ∈ s} reproduces the concrete e₅ / p₅. This is the second confirmation (after k=4) that the k=3 aeval bridge is genuinely degree-uniform — no new transport machinery is ever needed.",
+    "mathContext": "$\\mathrm{aeval}\\,(\\mathrm{esymm}\\,5) = e_5,\\qquad \\mathrm{aeval}\\,(\\mathrm{psum}\\,5) = p_5$ on the subtype $\\{x \\mid x \\in s\\}$",
+    "significance": "key",
+    "prerequisites": ["aeval_esymm_subtype / aeval_psum_subtype (k=3 entry)", "MvPolynomial.aeval", "subtype evaluation"],
+    "relatedConcepts": ["evaluation homomorphism", "degree-uniform transport", "universal-to-concrete bridge"]
+  },
+  {
+    "id": "ng5-finset",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 142, "endLine": 156 },
+    "type": "theorem",
+    "title": "newton_girard_five_finset — the char-5-safe concrete identity",
+    "content": "The concrete Newton–Girard k=5 identity over an arbitrary CommRing, including characteristic 5. It is the `congrArg` image of `psum_five_closed` under `aeval (fun i ↦ f i.1)`, simplified by the ring-hom lemmas (`map_add`/`map_sub`/`map_mul`/`map_pow`/`map_ofNat`) and the six bridge lemmas (e₁..e₅, p₅). Because the universal identity transports at the coefficient level, no division by 5 ever occurs — over a characteristic-5 ring the +5e₅ term simply vanishes, with no obstruction to the identity itself.",
+    "mathContext": "Over any CommRing: $p_5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$",
+    "significance": "critical",
+    "prerequisites": ["psum_five_closed", "the e₁..e₅ / p₅ bridges", "congrArg + ring-hom map lemmas"],
+    "relatedConcepts": ["characteristic-independent identity", "transport along aeval", "concrete symmetric-function identity"]
+  },
+  {
+    "id": "ng5-explicit",
+    "proofId": "amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01",
+    "range": { "startLine": 166, "endLine": 187 },
+    "type": "theorem",
+    "title": "fifth_power_sum_five — the explicit 5-variable instance",
+    "content": "The smallest nondegenerate case spelled out in full: a⁵+b⁵+c⁵+d⁵+e⁵ equals the reduced expression in e₁ = a+b+c+d+e, e₂ = Σ pairs, e₃ = Σ triples, e₄ = Σ quadruples, e₅ = abcde. It is closed directly by `ring`, independent of the abstract development — a self-contained sanity check that the closed-form coefficients are exactly right. This is the n=5 Finset specialisation of `psum_five_closed`.",
+    "mathContext": "$a^5+b^5+c^5+d^5+e^5 = e_1^5 - 5 e_1^3 e_2 + 5 e_1 e_2^2 + 5 e_1^2 e_3 - 5 e_2 e_3 - 5 e_1 e_4 + 5 e_5$",
+    "significance": "supporting",
+    "prerequisites": ["the ring tactic", "elementary symmetric polynomials in 5 variables"],
+    "relatedConcepts": ["sum of fifth powers", "concrete verification", "Vieta's formulas"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-01-oq-03-oq-01-oq-01` — adds the missing annotations layer.

## Quality improvements
- Added `annotations.json` with **7 construct-aligned annotations** covering the whole Lean file: the module overview, `psum_five_recurrence` (extracting the k=5 Newton recurrence from Mathlib's general identity), `psum_five_closed` (the universal reduced closed form), the concrete `e5`/`p5` definitions, the `e5_bridge`/`p5_bridge` degree-general aeval transport, `newton_girard_five_finset` (the characteristic-5-safe concrete identity), and `fifth_power_sum_five` (the explicit 5-variable instance).
- Each annotation carries `mathContext` (LaTeX), `significance`, `prerequisites`, and `relatedConcepts`.

## Verification
- JSON parses cleanly.
- **Annotation alignment verified against the Lean source** with `scripts/annotations/resolver.ts validate`: **7 valid, 0 misaligned**.
- No `index.ts` added — proof loading is driven by `meta.json` presence via `scripts/annotations/build.ts` + `data-manifest.json` (issue #20993 Phase 2); per-proof index.ts shims are obsolete.
- Axiom integrity: `status: verified`, `badge: verified`, `axiomCount: 0` confirmed against the Lean source (only propext/Classical.choice/Quot.sound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)