### PR TITLE
Enrich Cayley's Theorem (cayleys-theorem-oq-01)

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01/annotations.json
@@ -1,0 +1,87 @@
+[
+  {
+    "id": "ann-cayley-overview",
+    "proofId": "cayleys-theorem-oq-01",
+    "range": { "startLine": 6, "endLine": 49 },
+    "type": "context",
+    "title": "Cayley's Theorem: Every Group Is a Permutation Group",
+    "content": "The module docstring frames the theorem. Cayley's theorem (Cayley, 1854) says every abstract group G is 'concrete' — it can be realised as a group of permutations. The vehicle is the left-regular representation λ : G → Equiv.Perm G, λ(g) = (x ↦ g·x): each element g acts on the underlying set of G by left multiplication, a bijection with inverse left-multiplication by g⁻¹. The map respects the group law (λ(g·h) = λ(g) ∘ λ(h)) and is injective because λ(g) = λ(h) evaluated at the identity gives g·1 = h·1, i.e. g = h. Hence G is isomorphic to its image, a subgroup of the symmetric group Sym(G) = Equiv.Perm G. The docstring also flags the common confusion: this is NOT Cayley–Hamilton (the matrix identity); the group-theoretic Cayley theorem was absent from the gallery.",
+    "mathContext": "$\\lambda : G \\to \\operatorname{Sym}(G),\\ \\lambda(g)(x) = g x$ is an injective group homomorphism, so $G \\cong \\operatorname{im}(\\lambda) \\le \\operatorname{Sym}(G)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "group action",
+      "symmetric group",
+      "regular representation",
+      "representation theorem"
+    ],
+    "prerequisites": [
+      "groups and group homomorphisms",
+      "permutations and Equiv.Perm",
+      "injective maps"
+    ]
+  },
+  {
+    "id": "ann-cayley-leftregular",
+    "proofId": "cayleys-theorem-oq-01",
+    "range": { "startLine": 55, "endLine": 62 },
+    "type": "definition",
+    "title": "The Left-Regular Representation as a Bundled Homomorphism",
+    "content": "`leftRegular G := MulAction.toPermHom G G` is the left-regular representation packaged as a bundled group homomorphism G →* Equiv.Perm G. The key economy here is reuse: rather than hand-construct the map and separately verify map_one and map_mul, the proof instantiates Mathlib's regular self-action — where g • x = g * x comes from `Mul.toSMul` — and inherits the homomorphism structure for free (map_one = one_smul, map_mul = mul_smul). The lemma `leftRegular_apply : leftRegular G g x = g * x` holds definitionally (`rfl`), pinning the abstract bundled object down to the concrete 'multiply on the left by g' permutation.",
+    "mathContext": "$\\lambda(g)(x) = g \\cdot x$; bundled, $\\lambda(g \\cdot h) = \\lambda(g) \\circ \\lambda(h)$ and $\\lambda(1) = \\mathrm{id}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MulAction.toPermHom",
+      "regular self-action",
+      "Mul.toSMul",
+      "bundled morphisms"
+    ],
+    "prerequisites": [
+      "group actions (MulAction)",
+      "monoid homomorphisms (G →* H)",
+      "definitional equality / rfl"
+    ]
+  },
+  {
+    "id": "ann-cayley-injective",
+    "proofId": "cayleys-theorem-oq-01",
+    "range": { "startLine": 64, "endLine": 69 },
+    "type": "insight",
+    "title": "leftRegular_injective: Faithfulness Is the Whole Content",
+    "content": "This is the heart of Cayley's theorem and the only place where group structure (beyond being a homomorphism) is used. Injectivity of the left-regular representation reduces to a single fact: the regular self-action of a group is *faithful*. Concretely, λ(g) = λ(h) evaluated at the identity gives g·1 = h·1, so g = h by right cancellation. Mathlib supplies the underlying-map injectivity for any faithful action via `MulAction.toPerm_injective`, and the faithfulness instance `FaithfulSMul G G` is found automatically by typeclass resolution through `RightCancelMonoid.faithfulSMul` (a group is right-cancellative). After rewriting the bundled-hom coercion with `MulAction.coe_toPermHom`, a single `simpa` closes the goal. No `decide`/`native_decide` is used, keeping the proof axiom-free.",
+    "mathContext": "$\\lambda(g) = \\lambda(h) \\Rightarrow \\lambda(g)(1) = \\lambda(h)(1) \\Rightarrow g \\cdot 1 = h \\cdot 1 \\Rightarrow g = h$ (right cancellation).",
+    "significance": "key",
+    "relatedConcepts": [
+      "faithful group action",
+      "FaithfulSMul",
+      "right cancellation",
+      "MulAction.toPerm_injective",
+      "typeclass resolution"
+    ],
+    "prerequisites": [
+      "faithful actions and FaithfulSMul",
+      "cancellation in groups",
+      "Function.Injective"
+    ]
+  },
+  {
+    "id": "ann-cayley-embedding",
+    "proofId": "cayleys-theorem-oq-01",
+    "range": { "startLine": 71, "endLine": 87 },
+    "type": "insight",
+    "title": "Three Faces: Existence and the Subgroup-Embedding Isomorphism",
+    "content": "The final block records the theorem in its standard packagings. `cayley : ∃ f : G →* Equiv.Perm G, Function.Injective f` is the textbook existence form, assembled trivially as ⟨leftRegular G, leftRegular_injective G⟩. `cayleyEquivRange : G ≃* (leftRegular G).range` is the subgroup-embedding form — 'G is isomorphic to a subgroup of Sym(G)' — obtained by feeding the injective hom to `MonoidHom.ofInjective` (the multiplicative analogue of the first isomorphism theorem packaging: an injective hom yields an isomorphism onto its range). `cayleyEquivRange_apply` confirms the isomorphism still acts as g ↦ leftRegular g on elements. Injectivity, existence of an embedding, and isomorphism-onto-a-subgroup are three equivalent ways to state one theorem; the file makes the conversions explicit.",
+    "mathContext": "$\\exists\\, f : G \\to^* \\operatorname{Sym}(G)$ injective; equivalently $G \\cong \\operatorname{im}(\\lambda) \\le \\operatorname{Sym}(G)$ via $\\texttt{MonoidHom.ofInjective}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MonoidHom.ofInjective",
+      "first isomorphism theorem",
+      "subgroup embedding",
+      "MulEquiv (≃*)"
+    ],
+    "prerequisites": [
+      "injective hom ↦ isomorphism onto range",
+      "subgroups and ranges of homomorphisms",
+      "existential packaging in Lean"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01` (the group-theoretic Cayley theorem: every group is a permutation group).

## Gap addressed
Rich, complete meta.json but **no annotations.json** (quality 41, 0 passes).

## Changes
- Created `annotations.json` with **4 substantive annotations** covering every section:
  1. Overview — the left-regular representation and the embedding into Sym(G)
  2. `leftRegular` / `leftRegular_apply` — reusing Mathlib's regular self-action as a bundled hom
  3. `leftRegular_injective` — faithfulness of the regular self-action is the whole content
  4. `cayley` / `cayleyEquivRange` — existence and subgroup-embedding packagings via `MonoidHom.ofInjective`
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Validation
- JSON parses; all required fields present; all line ranges within the 89-line Lean file; `proofId` consistent.

No changes to the Lean proof or to status/badge/axiomCount (remains verified / mathlib / 0 axioms).