### PR TITLE
Fix seeker replenishment: surrogate-safe title truncation in extract-problems.ts

### DIFF
--- a/.lean/scripts/extract-problems.ts
+++ b/.lean/scripts/extract-problems.ts
@@ -33,7 +33,8 @@ interface ProofMeta {
     millenniumProblem?: string;
   };
   conclusion?: {
-    openQuestions?: string[];
+    // Legacy entries are plain strings; enriched entries are {id, question, significance} objects.
+    openQuestions?: Array<string | { id?: string; question?: string; significance?: string }>;
   };
 }
 
@@ -112,8 +113,12 @@ function generateProblemId(proofId: string, index: number, type: string): string
 function extractTitle(question: string): string {
   // Take first sentence or first 80 chars
   const firstSentence = question.split(/[.?!]/)[0];
-  if (firstSentence.length <= 80) return firstSentence;
-  return firstSentence.substring(0, 77) + '...';
+  // Split on Unicode code points (not UTF-16 units) so astral-plane characters
+  // such as 𝔽 (U+1D53D = 𝔽) are never truncated mid-surrogate-pair,
+  // which would otherwise emit a lone surrogate and produce invalid JSON.
+  const chars = Array.from(firstSentence);
+  if (chars.length <= 80) return firstSentence;
+  return chars.slice(0, 77).join('') + '...';
 }
 
 // Main extraction function
@@ -135,7 +140,13 @@ function extractProblems(proofsDir: string): ExtractedProblem[] {
 
       // 1. Extract from openQuestions
       if (meta.conclusion?.openQuestions) {
-        meta.conclusion.openQuestions.forEach((question, index) => {
+        meta.conclusion.openQuestions.forEach((rawQuestion, index) => {
+          // openQuestions entries may be plain strings (legacy) or
+          // {id, question, significance} objects (enriched). Normalize to a string.
+          const question =
+            typeof rawQuestion === 'string'
+              ? rawQuestion
+              : (rawQuestion?.question ?? String(rawQuestion ?? ''));
           problems.push({
             id: generateProblemId(meta.id, index, 'oq'),
             title: extractTitle(question),


### PR DESCRIPTION
## Problem

The seeker agent's candidate-pool replenishment (`extract-problems.ts` → `.lean/research/problems.json` → `sync_pool.py`) has been a **no-op for 100+ consecutive cycles**. Each cycle regenerated an 8.8 MB reservoir that was **unparseable JSON**, so no new problems ever reached `candidate-pool.json`. The pool has been stuck at ~5 available, all hard open-ended generalization OQs.

## Root causes (both in `extractTitle` / openQuestions handling)

1. **Lone surrogate from `substring`.** `extractTitle` truncated titles with `String.prototype.substring(0, 77)`, which counts UTF-16 code units. When offset 77 fell between the high and low surrogate of an astral-plane math character (e.g. `𝔽` = U+1D53D), it severed the pair and emitted a lone `\ud835` high surrogate. A single such title made the **entire** reservoir unparseable (`jq: Invalid \uXXXX\uXXXX surrogate pair escape`).

2. **Object-shaped `openQuestions`.** Enriched `meta.json` now store open questions as `{id, question, significance}` objects rather than plain strings. `question.split(...)` threw `TypeError: ... is not a function`, silently dropping every problem from those proofs.

## Fix

1. Split on Unicode code points via `Array.from()` before slicing — never cuts mid-surrogate.
2. Normalize each `openQuestions` entry to its string `question` before use; legacy string entries still work.

## Verification

Before: `jq` fails at line 171436 (lone surrogate); `question.split is not a function` on ~dozen proofs.

After:
- `npx tsx .lean/scripts/extract-problems.ts --json` → **11830 problems**, exit 0
- `jq 'length'` parses cleanly (11830)
- `grep -c '\\ud8'` → **0** lone surrogates
- Astral math chars (ℝ, ℂ, 𝔽) preserved intact in titles
- Zero `is not a function` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)