### PR TITLE
Enrich Finite Cayley's Theorem (cayleys-theorem-oq-01-oq-01): add annotations

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-cayleyfin-overview",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "From Abstract Sym(G) to the Concrete Sₙ",
+    "content": "The docstring frames the open question inherited from the parent entry (cayleys-theorem-oq-01), which proved the abstract Cayley theorem G ↪ Sym(G) — every group embeds into the symmetric group on its own underlying set, via the left-regular representation λ(g) = (x ↦ g·x). For a finite group of order n the classical textbook statement instead realises G inside the standard symmetric group Sₙ = Equiv.Perm (Fin n) on n labelled points. The key observation is that the two forms differ only by a relabelling: a numbering e : G ≃ Fin n of the group's elements converts permutations of G into permutations of {0,…,n−1}. The whole file is the bridge that turns the abstract embedding into the concrete one without re-proving any faithfulness.",
+    "mathContext": "$G \\hookrightarrow \\mathrm{Sym}(G) \\;\\xrightarrow{\\;e : G \\simeq \\mathrm{Fin}\\,n\\;}\\; G \\hookrightarrow S_n$, with $n = |G|$.",
+    "significance": "context",
+    "relatedConcepts": ["Cayley's theorem", "left-regular representation", "symmetric group", "group embedding", "relabelling"],
+    "prerequisites": ["group theory", "permutation groups"]
+  },
+  {
+    "id": "ann-permcongr-mulequiv",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 57 },
+    "type": "definition",
+    "title": "Conjugation as a Multiplicative Isomorphism",
+    "content": "permCongrMulEquiv e bundles the conjugation map σ ↦ e ∘ σ ∘ e⁻¹ as a multiplicative isomorphism Equiv.Perm α ≃* Equiv.Perm β. Its toEquiv is Mathlib's Equiv.permCongr e (the relabelling of permutations along e), and the crucial map_mul' obligation — that relabelling respects composition of permutations — is discharged by ext + simp with permCongr_apply and Perm.mul_apply. This is the algebraic engine: because conjugation by a fixed bijection is a group isomorphism of symmetric groups, composing the regular representation with it cannot break the homomorphism or injectivity. Mathlib already provides exactly this bundling as Equiv.permCongrHom; permCongrMulEquiv is a self-contained in-file re-derivation, so the entry's badge is 'mathlib' rather than 'original'.",
+    "mathContext": "$\\sigma \\mapsto e\\circ\\sigma\\circ e^{-1}$ satisfies $(e\\circ\\sigma\\tau\\circ e^{-1}) = (e\\circ\\sigma\\circ e^{-1})(e\\circ\\tau\\circ e^{-1})$, so $\\mathrm{Sym}(\\alpha)\\cong\\mathrm{Sym}(\\beta)$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugation", "MulEquiv", "Equiv.permCongr", "group isomorphism", "inner automorphism"],
+    "prerequisites": ["group homomorphisms", "Mathlib Equiv/MulEquiv API"]
+  },
+  {
+    "id": "ann-cayleyfin-hom",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "definition",
+    "title": "The Finite Cayley Homomorphism",
+    "content": "cayleyFinHom e composes the conjugation isomorphism with the regular representation: (permCongrMulEquiv e).toMonoidHom.comp (MulAction.toPermHom G G), a group homomorphism G →* Equiv.Perm (Fin n). MulAction.toPermHom G G is Mathlib's regular self-action g ↦ (x ↦ g·x) — the parent's abstract Cayley map. Conjugating it by the numbering e relabels the permuted set from G to Fin n. The apply lemma cayleyFinHom_apply spells out the action concretely: g sends index i to e(g · e⁻¹(i)) — decode i to a group element, left-multiply by g, re-encode — which holds by rfl, confirming the construction is definitionally the expected left-multiplication permutation transported through the numbering.",
+    "mathContext": "$\\hat\\lambda(g) = e\\circ\\lambda(g)\\circ e^{-1} : \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,n, \\quad \\hat\\lambda(g)(i) = e\\bigl(g\\cdot e^{-1}(i)\\bigr).$",
+    "significance": "critical",
+    "relatedConcepts": ["regular representation", "MulAction.toPermHom", "monoid homomorphism composition", "function transport"],
+    "prerequisites": ["group actions", "MonoidHom composition"]
+  },
+  {
+    "id": "ann-cayleyfin-injective",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 75 },
+    "type": "technique",
+    "title": "Injectivity from Faithfulness Plus a Bijection",
+    "content": "cayleyFinHom_injective shows the embedding is injective by factoring it as (injective regular representation) followed by (bijective relabelling). The faithfulness of the regular representation — the genuine mathematical content, that distinct group elements act as distinct permutations — is Mathlib's MulAction.toPerm_injective, which holds because a group acts freely on itself (g·x = x forces g = 1). The relabelling permCongrMulEquiv e is injective for free as a MulEquiv. The proof unfolds cayleyFinHom, peels off the relabelling with its injectivity (hcongr), then the regular representation's injectivity (hreg). This is exactly why the codomain refinement adds no new mathematical assumption beyond the parent.",
+    "mathContext": "$\\hat\\lambda = (\\text{permCongrMulEquiv } e)\\circ\\lambda$ with $\\lambda$ injective (free action: $g\\cdot x = x \\Rightarrow g = 1$) and the relabelling bijective $\\Rightarrow \\hat\\lambda$ injective.",
+    "significance": "key",
+    "relatedConcepts": ["faithful action", "MulAction.toPerm_injective", "free action", "composition of injections"],
+    "prerequisites": ["injective functions", "faithful group actions"]
+  },
+  {
+    "id": "ann-cayley-fin-packagings",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 93 },
+    "type": "theorem",
+    "title": "Finite Cayley's Theorem and Its Three Packagings",
+    "content": "Instantiating the relabelling at the canonical numbering e = Fintype.equivFin G : G ≃ Fin (Fintype.card G) produces the textbook statement in three equivalent forms. cayley_fin gives the existence of an injective f : G →* Equiv.Perm (Fin (Fintype.card G)) — 'a group of order n embeds in Sₙ'. cayleyFinEmbedding bundles the same data as a function-embedding G ↪ Sₙ. cayleyFinRangeEquiv upgrades injectivity to a multiplicative isomorphism G ≃* (cayleyFinHom e).range via MonoidHom.ofInjective — the 'G is isomorphic to a subgroup of Sₙ' form. All three are faces of the single injective homomorphism; MonoidHom.ofInjective is the converter from the existence form to the subgroup-isomorphism form.",
+    "mathContext": "$|G| = n \\Rightarrow \\exists$ injective $f : G \\to S_n$; equivalently $G \\hookrightarrow S_n$ and $G \\cong \\mathrm{im}(f) \\le S_n$.",
+    "significance": "critical",
+    "relatedConcepts": ["Fintype.equivFin", "MonoidHom.ofInjective", "subgroup", "group isomorphism", "embedding"],
+    "prerequisites": ["finite groups", "subgroups", "isomorphism theorems"]
+  },
+  {
+    "id": "ann-concrete-examples",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 107 },
+    "type": "context",
+    "title": "Sanity Checks: the General Form and ℤ/3 ↪ S₃",
+    "content": "Two examples confirm the statement type-checks as intended. The first re-derives the existence form for an arbitrary finite group, certifying that cayley_fin has the textbook signature. The second instantiates a concrete group — the cyclic group of order 3, modeled as Multiplicative (ZMod 3) — and exhibits its embedding into S₃ = Equiv.Perm (Fin 3), the smallest nontrivial Cayley picture (a 3-cycle subgroup of the 6-element symmetric group). These verify, by elaboration alone, that Fintype.card resolves correctly so the codomain is the symmetric group on exactly |G| points.",
+    "mathContext": "$\\mathbb{Z}/3\\mathbb{Z} \\hookrightarrow S_3$: the cyclic order-3 group sits inside the 6-element $S_3$ as a 3-cycle subgroup.",
+    "significance": "supporting",
+    "relatedConcepts": ["cyclic group", "ZMod", "S₃", "concrete instantiation", "type checking"],
+    "prerequisites": ["cyclic groups", "Lean elaboration"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01-oq-01` (Finite Cayley's Theorem: a Group of Order n Embeds in Sₙ).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage.

## What was added
6 line-range annotations covering the full 107-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

1. **Docstring** — the abstract Sym(G) → concrete Sₙ refinement as a relabelling `e : G ≃ Fin n`.
2. **`permCongrMulEquiv`** — conjugation `σ ↦ e∘σ∘e⁻¹` as a `MulEquiv`; notes Mathlib's `Equiv.permCongrHom` is the same bundling (justifies `badge: mathlib`).
3. **`cayleyFinHom`** — composing the relabelling with the regular representation; the `g·i ↦ e(g·e⁻¹ i)` apply lemma.
4. **`cayleyFinHom_injective`** — injectivity factored as faithful regular rep (`MulAction.toPerm_injective`, free self-action) ∘ bijection.
5. **Three packagings** — `cayley_fin`, `cayleyFinEmbedding`, `cayleyFinRangeEquiv` via `MonoidHom.ofInjective`.
6. **Concrete examples** — general form and `ℤ/3 ↪ S₃`.

## Notes
- Consistent with the Lean source and existing `overview`/`sections`/`conclusion`.
- `status: verified`, `badge: mathlib`, `axiomCount: 0` left unchanged — accurate (no axioms/assumption structures; no decide/native_decide).
- Pushed to a dedicated branch (not `feature/enricher-1`) to avoid clobbering open PR #28390.