### PR TITLE
Enrich Infinite Converse to Cayley (cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02): add annotations

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-infconverse-overview",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "Why Nat.card Hides the Infinite Content",
+    "content": "The docstring motivates the whole file: the parent entry proved the finite converse to Cayley — a subgroup H ≤ Sym(α) = Equiv.Perm α acting freely and transitively on a finite nonempty α is regular of order n = |α| — through the orbit bijection regularEquiv : H ≃ α. Crucially that bijection used no finiteness; only the order statement, phrased with Nat.card, became the vacuous 0 = 0 for infinite α, because Nat.card returns 0 on infinite types. The correct invariant in the infinite regime is the cardinal #H = #α (Cardinal.mk), which is non-vacuous and still specialises back to the finite count. The file therefore adds no new mathematics: it transports the parent's existing equivalence across the right cardinality functor. It re-imports the parent and reuses its ActsTransitively / ActsFreely / IsRegular predicates and regularEquiv unchanged.",
+    "mathContext": "Parent: $H \\simeq \\alpha$ with no finiteness, but $\\mathrm{Nat.card}\\,H = \\mathrm{Nat.card}\\,\\alpha$ is $0 = 0$ for infinite $\\alpha$. Fix: state $\\#H = \\#\\alpha$ as cardinals.",
+    "significance": "context",
+    "relatedConcepts": ["converse to Cayley", "regular representation", "Nat.card vs Cardinal.mk", "free transitive action", "cardinality"],
+    "prerequisites": ["group actions", "cardinal arithmetic"]
+  },
+  {
+    "id": "ann-cardinal-equality",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 41, "endLine": 52 },
+    "type": "theorem",
+    "title": "Cardinal Equality #H = #α — the Infinite Converse",
+    "content": "cardinalMk_eq_of_free_transitive is the headline result: for arbitrary nonempty α, a free transitive subgroup H ≤ Sym(α) satisfies Cardinal.mk H = Cardinal.mk α. The proof is a single line — Cardinal.mk_congr applied to the parent's regularEquiv (the orbit map σ ↦ σ a, surjective by transitivity, injective by freeness-rigidity) at the basepoint Classical.arbitrary α. This is the entire mathematical payload of the entry: order equals degree as cardinals. For finite α it reduces to the parent's count; for infinite α it is the genuine statement the Nat.card phrasing could not express.",
+    "mathContext": "$\\#H = \\#\\alpha$ via $\\mathrm{Cardinal.mk\\_congr}$ on $\\mathrm{regularEquiv} : H \\simeq \\alpha$ at basepoint $a = \\text{Classical.arbitrary}\\,\\alpha$.",
+    "significance": "critical",
+    "relatedConcepts": ["Cardinal.mk_congr", "orbit bijection", "regular action", "cardinal transport"],
+    "prerequisites": ["cardinals", "equivalences of types"]
+  },
+  {
+    "id": "ann-infinitude-iff",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 54, "endLine": 60 },
+    "type": "theorem",
+    "title": "Infinitude Transfers Across the Orbit Bijection",
+    "content": "infinite_iff_of_free_transitive records that H is infinite exactly when α is, by Equiv.infinite_iff applied to the same regularEquiv. Where the cardinal equality is the quantitative statement, this is its qualitative shadow: the equivalence preserves the Infinite predicate in both directions. It is the natural companion fact making precise that 'a free transitive permutation group on an infinite set is an infinite group'.",
+    "mathContext": "$\\mathrm{Infinite}\\,H \\iff \\mathrm{Infinite}\\,\\alpha$ from $H \\simeq \\alpha$ via $\\mathrm{Equiv.infinite\\_iff}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Equiv.infinite_iff", "Infinite typeclass", "cardinality invariance"],
+    "prerequisites": ["finiteness/infinitude in type theory"]
+  },
+  {
+    "id": "ann-infinite-subgroup",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 62, "endLine": 69 },
+    "type": "theorem",
+    "title": "An Infinite Regular Subgroup Is Itself Infinite",
+    "content": "infinite_of_free_transitive specialises the iff to the forward direction under [Infinite α]: a free transitive subgroup of Sym(α) over an infinite α is infinite (and, with cardinalMk_eq_of_free_transitive, of the same cardinality #α). The proof derives the needed Nonempty α instance from Infinite α and feeds it through the .mpr of the iff. This is the concrete 'infinite Cayley' picture: an infinite group's regular representation acts on a set of equal cardinality.",
+    "mathContext": "$\\mathrm{Infinite}\\,\\alpha \\Rightarrow \\mathrm{Infinite}\\,H$, with $\\#H = \\#\\alpha$.",
+    "significance": "supporting",
+    "relatedConcepts": ["infinite groups", "regular representation", "instance derivation"],
+    "prerequisites": ["typeclass instances", "infinite types"]
+  },
+  {
+    "id": "ann-packaged-and-consistency",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02",
+    "range": { "startLine": 71, "endLine": 90 },
+    "type": "theorem",
+    "title": "Packaged Converse and Consistency with the Finite Parent",
+    "content": "Two closing results. regular_iff_cardinalMk_and_sharp packages the infinite converse from IsRegular H (= ActsTransitively ∧ ActsFreely) over arbitrary nonempty α: it returns both the cardinal equality #H = #α and sharp transitivity ∀ i j, ∃! σ ∈ H with σ i = j — the latter reused verbatim from the parent's existsUnique_of_free_transitive, which was already finiteness-free. natCard_eq_of_cardinalMk then certifies consistency: for finite α the cardinal equality refines to the parent's Nat.card H = Fintype.card α, so the infinite statement extends rather than replaces the finite one. Together they show the cardinal version is the single statement covering both regimes.",
+    "mathContext": "Regular $H \\Rightarrow \\#H = \\#\\alpha \\;\\wedge\\; \\forall i\\,j,\\ \\exists!\\,\\sigma\\in H,\\ \\sigma i = j$; and for finite $\\alpha$, $\\#H = \\#\\alpha$ refines to $|H| = |\\alpha|$.",
+    "significance": "key",
+    "relatedConcepts": ["sharply transitive action", "IsRegular", "Nat.card refinement", "existsUnique"],
+    "prerequisites": ["regular permutation groups", "finite cardinality"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01-oq-01-oq-02-oq-01-oq-02` (Infinite converse to Cayley: a free transitive H ≤ Sym(α) has #H = #α).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage.

## What was added
5 line-range annotations covering the full 90-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Docstring** — why `Nat.card` collapses to `0 = 0` on infinite α and `Cardinal.mk` is the surviving invariant.
2. **`cardinalMk_eq_of_free_transitive`** — the headline `#H = #α` via `Cardinal.mk_congr` on the parent's `regularEquiv`.
3. **`infinite_iff_of_free_transitive`** — infinitude transfer via `Equiv.infinite_iff`.
4. **`infinite_of_free_transitive`** — the infinite-subgroup corollary.
5. **`regular_iff_cardinalMk_and_sharp` + `natCard_eq_of_cardinalMk`** — packaged converse and refinement to the finite parent's count.

## Notes
- Consistent with the Lean source and existing `overview`/`sections`/`conclusion`.
- `status: verified`, `badge: original`, `axiomCount: 0` left unchanged — accurate (no axioms/assumption structures; no decide/native_decide; α assumed nonempty as stated).
- Pushed to a dedicated branch to keep prior open enrichment PRs intact.