### PR TITLE
Fix seeker reservoir corruption: remove spurious stdout redirect

### DIFF
--- a/.lean/roles/seeker.md
+++ b/.lean/roles/seeker.md
@@ -55,7 +55,7 @@ This creates `.lean/research/problems.json` with all 400+ open problems.
 
 Before selecting problems, refresh the candidate pool to include newly enriched gallery proofs:
 
-1. Extract problems from gallery: `npx tsx .lean/scripts/extract-problems.ts --json > .lean/research/problems.json`
+1. Extract problems from gallery: `npx tsx .lean/scripts/extract-problems.ts --json` (the script writes `.lean/research/problems.json` itself — do **not** add a `> .lean/research/problems.json` redirect, which clobbers the file and corrupts the reservoir)
 2. Sync to candidate pool: `python3 research/db/sync_pool.py`
 3. Proceed with selection from the refreshed pool
 

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -173,7 +173,11 @@ You are the **seeker** agent. Your mission is to keep the research pipeline fed 
 
 2. **Refresh candidate pool** (picks up newly enriched gallery proofs)
    \`\`\`bash
-   npx tsx .lean/scripts/extract-problems.ts --json > .lean/research/problems.json 2>/dev/null
+   # NOTE: --json mode writes .lean/research/problems.json itself. Do NOT add a
+   # shell redirect (> .lean/research/problems.json) — it clobbers the file the
+   # script writes, interleaving stdout progress lines into the JSON and
+   # corrupting the reservoir. (Caused 100+ no-op replenish cycles.)
+   npx tsx .lean/scripts/extract-problems.ts --json 2>/dev/null
    python3 research/db/sync_pool.py 2>/dev/null
    \`\`\`
 


### PR DESCRIPTION
## Problem

The seeker's pool-refresh step ran:

```bash
npx tsx .lean/scripts/extract-problems.ts --json > .lean/research/problems.json
```

But `extract-problems.ts` in `--json` mode **already writes** `.lean/research/problems.json` itself (`writeFileSync`, line 327). The shell redirect targets the **same path**, so the shell-truncated file and the script's `writeFileSync` race on one inode — interleaving stdout progress lines (`Wrote N problems to ...`) mid-token into the JSON:

```
"id": "cantors-theorem-oq-01-oq-0Wrote 11839 problems to ...
```

`jq` then fails with `Invalid string: control characters ...`, so the reservoir is unusable and replenishment is a no-op.

## Impact

This silently broke seeker replenishment for **100+ cycles**. The prior surrogate-pair fix (#28388) made `extract-problems` emit valid JSON, but the redirect kept corrupting the *output file* regardless — masking the fix.

## Fix

Drop the redirect; let the script write its own file. Verified locally:

```
$ npx tsx .lean/scripts/extract-problems.ts --json   # no redirect
Wrote 11840 problems to .../.lean/research/problems.json
$ jq 'length' .lean/research/problems.json
11840          # clean, parseable
```

Fixed in both tracked callers:
- `scripts/research/launch-seeker.sh` (generates the live seeker prompt)
- `.lean/roles/seeker.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)