### PR TITLE
Enrich Erdős–Ginzburg–Ziv (erdos-ginzburg-ziv-oq-01)

### DIFF
--- a/src/data/proofs/erdos-ginzburg-ziv-oq-01/annotations.json
+++ b/src/data/proofs/erdos-ginzburg-ziv-oq-01/annotations.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "ann-egz-overview",
+    "proofId": "erdos-ginzburg-ziv-oq-01",
+    "range": { "startLine": 4, "endLine": 47 },
+    "type": "context",
+    "title": "Erdős–Ginzburg–Ziv and the Sharpness of 2n − 1",
+    "content": "The docstring states the theorem and the file's contribution. Erdős–Ginzburg–Ziv (1961) is a cornerstone of additive combinatorics: among any 2n − 1 integers, some n of them have a sum divisible by n; equivalently every length-(2n−1) sequence in ZMod n has a zero-sum subsequence of length exactly n. Mathlib proves the theorem (Int.erdos_ginzburg_ziv, ZMod.erdos_ginzburg_ziv, multiset variants). The genuinely new content here is the OPTIMALITY: the threshold 2n − 1 is best possible — Mathlib has no such sharpness lemma. EGZ is the value s(ℤ/nℤ) = 2n − 1 of the Davenport-constant / zero-sum theory and the gateway result of that subject.",
+    "mathContext": "Among any $2n-1$ integers, some $n$ sum to a multiple of $n$; the EGZ constant is $s(\\mathbb{Z}/n\\mathbb{Z}) = 2n - 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "additive combinatorics",
+      "zero-sum sequences",
+      "Davenport constant",
+      "pigeonhole principle"
+    ],
+    "prerequisites": [
+      "modular arithmetic (ZMod n)",
+      "subsequences and sums",
+      "Finset / Multiset"
+    ]
+  },
+  {
+    "id": "ann-egz-main",
+    "proofId": "erdos-ginzburg-ziv-oq-01",
+    "range": { "startLine": 55, "endLine": 79 },
+    "type": "definition",
+    "title": "The Mathlib Headlines Restated: ℤ, ZMod n, and Multiset Forms",
+    "content": "Four theorems restate the EGZ theorem as the file's baseline. egz_int: a family of ≥ 2n−1 integers has an n-subset with sum divisible by n (from Int.erdos_ginzburg_ziv). egz_zmod: the ZMod n version, n-subset summing to 0 (from ZMod.erdos_ginzburg_ziv). egz_int_multiset and egz_zmod_multiset give the multiset forms — the natural setting for 'a sequence with repetitions', since a subsequence is a submultiset. Each is a one-line re-export fixing the precise existential shapes that the sharpness theorem then proves cannot be improved.",
+    "mathContext": "$\\#s \\ge 2n-1 \\Rightarrow \\exists\\, t \\subseteq s,\\ \\#t = n \\wedge n \\mid \\sum_{i\\in t} a_i$ (and the $\\mathrm{ZMod}\\,n$ / multiset analogues).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Int.erdos_ginzburg_ziv",
+      "ZMod.erdos_ginzburg_ziv",
+      "multisets",
+      "re-export"
+    ],
+    "prerequisites": [
+      "Mathlib's EGZ file",
+      "Finset subsets",
+      "divisibility in ℤ"
+    ]
+  },
+  {
+    "id": "ann-egz-concrete",
+    "proofId": "erdos-ginzburg-ziv-oq-01",
+    "range": { "startLine": 81, "endLine": 87 },
+    "type": "context",
+    "title": "The n = 2 Case: Two of Any Three Integers Sum Evenly",
+    "content": "egz_three_integers makes the smallest nontrivial case explicit: among any three integers some two have an even sum. It is obtained by specialising Int.erdos_ginzburg_ziv at n = 2 (where 2·2 − 1 = 3) and simplifying. This is the historical toy case — a pigeonhole on parities (three integers, two parity classes, so two share a parity and sum to an even number) — read off from the general theorem rather than reproved.",
+    "mathContext": "$n=2$: $2 \\cdot 2 - 1 = 3$, so among any $3$ integers two have a sum divisible by $2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pigeonhole on parity",
+      "specialisation",
+      "base case n = 2"
+    ],
+    "prerequisites": [
+      "parity",
+      "the general EGZ theorem"
+    ]
+  },
+  {
+    "id": "ann-egz-sharp-construction",
+    "proofId": "erdos-ginzburg-ziv-oq-01",
+    "range": { "startLine": 89, "endLine": 110 },
+    "type": "insight",
+    "title": "Sharpness: The Extremal (n−1 zeros, n−1 ones) Witness",
+    "content": "egz_sharp is the new mathematical content: for every n ≥ 2 there is a length-(2n−2) sequence in ZMod n with NO zero-sum subsequence of length n, so the threshold 2n−1 cannot be lowered. The witness is the classical extremal configuration: on s = range (2n−2), set a i = 1 for i ≥ n−1 (the 'ones', n−1 of them) and a i = 0 otherwise (n−1 'zeros'). For any candidate n-subset t, the key reduction is hsum: ∑_{i∈t} a i = (k : ZMod n) where k = #{i ∈ t | n−1 ≤ i} is the number of chosen ones (proved by Finset.sum_boole). The whole problem thus reduces to bounding the natural number k.",
+    "mathContext": "Witness on $\\{0,\\dots,2n-3\\}$: $n-1$ ones and $n-1$ zeros; for an $n$-subset $t$, $\\sum_{i\\in t} a_i \\equiv k \\pmod n$ where $k$ counts the chosen ones.",
+    "significance": "key",
+    "relatedConcepts": [
+      "extremal configuration",
+      "Finset.sum_boole",
+      "indicator sums",
+      "optimality / lower-bound construction"
+    ],
+    "prerequisites": [
+      "Finset.range and filters",
+      "sums of indicator functions",
+      "casting ℕ → ZMod n"
+    ]
+  },
+  {
+    "id": "ann-egz-sharp-bounds",
+    "proofId": "erdos-ginzburg-ziv-oq-01",
+    "range": { "startLine": 111, "endLine": 138 },
+    "type": "technique",
+    "title": "Sharpness: Trapping the Count in [1, n−1] and Concluding",
+    "content": "The proof pins the count k of chosen ones strictly between 1 and n. Upper bound: the chosen ones live in Ico (n−1) (2n−2), which has exactly (2n−2)−(n−1) = n−1 elements, so k ≤ n−1 (card_le_card + Nat.card_Ico + omega). Lower bound: the chosen zeros lie in range (n−1), at most n−1 of them; since k + #zeros = #t = n (filter_card_add_filter_neg_card_eq_card), omega forces k ≥ 1. Finally a residue k with 1 ≤ k ≤ n−1 < n is nonzero in ZMod n: ZMod.natCast_eq_zero_iff turns the goal into ¬(n ∣ k), and n ∣ k with k > 0 would give n ≤ k by Nat.le_of_dvd, contradicting k ≤ n−1 (omega). Hence the sum is nonzero, completing the sharpness proof and pinning the EGZ constant at exactly 2n−1.",
+    "mathContext": "$1 \\le k \\le n-1 < n$, so $k \\not\\equiv 0 \\pmod n$ (else $n \\le k$). Thus no $n$-subset is zero-sum.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.card_Ico",
+      "filter_card_add_filter_neg_card_eq_card",
+      "ZMod.natCast_eq_zero_iff",
+      "Nat.le_of_dvd",
+      "omega"
+    ],
+    "prerequisites": [
+      "cardinality of intervals",
+      "splitting a Finset by a predicate",
+      "divisibility ⇒ size bound"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-ginzburg-ziv-oq-01` (the zero-sum theorem and the sharpness of its 2n−1 threshold).

## Gap addressed
Rich meta.json but **no annotations.json** (quality 41, 0 passes).

## Changes
- Created `annotations.json` with **5 substantive annotations**: overview, the Mathlib re-exports (ℤ / ZMod n / multiset), the explicit n=2 case, the sharpness witness (the extremal n−1 zeros / n−1 ones configuration with sum ≡ count k), and the counting bounds (1 ≤ k ≤ n−1 < n ⇒ nonzero residue) that establish optimality.
- Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- Complements the recently-enriched Chevalley–Warning entry (EGZ is its standard downstream application).

## Validation
JSON parses; all fields present; line ranges within the 140-line Lean file. No change to status/badge/axiomCount (verified / mathlib / 0 axioms).