### PR TITLE
Enrich Reverse Minkowski Inequality (cauchy-schwarz-oq-03-oq-02-oq-01): add annotations

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-revmink-overview",
+    "proofId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 58 },
+    "type": "concept",
+    "title": "When the Triangle Inequality Runs Backwards",
+    "content": "The docstring frames the open question inherited from the parent (CauchySchwarzOQ03OQ02, forward Minkowski for p ≥ 1): for 0 < p < 1 the p-functional ‖v‖_p = (∑ vᵢ^p)^{1/p} is no longer a norm but a positively-homogeneous concave quasi-norm, so the triangle inequality reverses to superadditivity. The engine is the reverse Hölder inequality with negative conjugate exponent q = p/(p−1). Crucially, Mathlib has NO 0 < p < 1 Hölder or Minkowski lemma — every Hölder statement is gated on Real.HolderConjugate p q whose fields force p, q > 1 — so neither (RH) nor (RM) can be obtained by instantiating an existing lemma; both are built here from the forward p > 1 API by an exponent substitution that keeps the negative exponent out of every hypothesis. A durable Python certificate (verify_reverse_minkowski.py) cross-checks (RM), its equality locus, and the (RH) engine over 70 000 random trials.",
+    "mathContext": "$0<p<1$: $\\|\\cdot\\|_p$ concave $\\Rightarrow$ $\\big(\\sum(a_i+b_i)^p\\big)^{1/p} \\ge \\big(\\sum a_i^p\\big)^{1/p} + \\big(\\sum b_i^p\\big)^{1/p}$, the reverse of Minkowski.",
+    "significance": "context",
+    "relatedConcepts": ["Minkowski inequality", "Hölder inequality", "quasi-norm", "concavity", "Lp spaces"],
+    "prerequisites": ["real analysis", "Lp norms", "convexity/concavity"]
+  },
+  {
+    "id": "ann-reverse-holder-statement",
+    "proofId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+    "range": { "startLine": 66, "endLine": 88 },
+    "type": "theorem",
+    "title": "Reverse Hölder via Forward Hölder",
+    "content": "reverse_holder is the engine: for nonnegative u and strictly positive v with q = p/(p−1) < 0, (∑ uᵢ^p)^{1/p}·(∑ vᵢ^q)^{1/q} ≤ ∑ uᵢvᵢ. The key idea is to never let the negative exponent touch a hypothesis: instead, apply Mathlib's forward Hölder (NNReal.inner_le_Lp_mul_Lq) to the auxiliary positive conjugate pair P = 1/p > 1, P' = 1/(1−p) > 1 — which are Hölder conjugate by Real.HolderConjugate.inv_one_sub_inv — on the functions fᵢ = (uᵢvᵢ)^p and gᵢ = vᵢ^{−p}. The negative exponent q appears only in the conclusion, after unwinding fᵢgᵢ = uᵢ^p, fᵢ^P = uᵢvᵢ, gᵢ^{P'} = vᵢ^q.",
+    "mathContext": "$P = 1/p,\\ P' = 1/(1-p)$ are conjugate; apply forward Hölder to $f_i=(u_iv_i)^p,\\ g_i=v_i^{-p}$.",
+    "significance": "critical",
+    "relatedConcepts": ["NNReal.inner_le_Lp_mul_Lq", "Real.HolderConjugate.inv_one_sub_inv", "negative conjugate exponent", "exponent substitution"],
+    "prerequisites": ["Hölder's inequality", "conjugate exponents"]
+  },
+  {
+    "id": "ann-reverse-holder-unwind",
+    "proofId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+    "range": { "startLine": 89, "endLine": 131 },
+    "type": "technique",
+    "title": "Collapsing the Substitution and Raising to the Power p",
+    "content": "Three rpow-arithmetic lemmas unwind the forward-Hölder output into reverse Hölder. hLHS shows the inner product collapses: (uv)^p·v^{−p} = u^p, using v > 0 to cancel v^p·v^{−p} = v^0 = 1 (NNReal.rpow_add with add_neg_cancel). hR1 reduces the first L^P factor to (∑ uv)^p via ((uv)^p)^{1/p} = uv (rpow_mul, mul_inv_cancel₀). hR2 reduces the second L^{P'} factor to (∑ v^q)^{1−p}, where the exponent identity (−p)·(1−p)⁻¹ = p/(p−1) = q is the crux. Finally, with A = ∑u^p, B = ∑uv, C = ∑v^q (C > 0 by Finset.sum_pos), the goal is raised to the power p (NNReal.rpow_le_rpow_iff) so the fractional exponents 1/p and 1/q become 1 and p−1, and a short calc using C^{(1−p)+(p−1)} = C^0 = 1 closes it.",
+    "mathContext": "$\\sum u^p \\le (\\sum uv)^p(\\sum v^q)^{1-p}$; raise to power $p$: $A\\,C^{p-1} \\le B^p C^{1-p} C^{p-1} = B^p$.",
+    "significance": "key",
+    "relatedConcepts": ["NNReal.rpow_add", "NNReal.rpow_mul", "NNReal.rpow_le_rpow_iff", "gcongr", "Finset.sum_pos"],
+    "prerequisites": ["NNReal rpow arithmetic", "finite sums"]
+  },
+  {
+    "id": "ann-reverse-minkowski",
+    "proofId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+    "range": { "startLine": 133, "endLine": 187 },
+    "type": "theorem",
+    "title": "Reverse Minkowski by the Riesz Argument",
+    "content": "reverse_minkowski runs the classical Riesz Hölder⇒Minkowski deduction with reverse_holder in place of forward Hölder. The weight is w = (a+b)^{p−1} (positive since aᵢ+bᵢ > 0), chosen so that wᵢ^q = (aᵢ+bᵢ)^p, hence ∑ wᵢ^q = S := ∑(a+b)^p (hwq). Applying reverse Hölder to (a, w) and (b, w) bounds each of (∑a^p)^{1/p}·S^{1/q} and (∑b^p)^{1/p}·S^{1/q}; the split ∑(a+b)^p = ∑a·w + ∑b·w (hsplit, via (a+b)^p = (a+b)^1·(a+b)^{p−1}) reassembles their sum to exactly S. The final step divides through by the positive common factor S^{1/q} (le_of_mul_le_mul_right), and the conjugate relation 1/p + 1/q = 1 turns S^{1/q}·(missing factor) into the target exponent 1/p. The positivity hypothesis aᵢ+bᵢ > 0 is genuine because the weight exponent p−1 < 0 blows up at zero.",
+    "mathContext": "$w=(a+b)^{p-1},\\ w^q=(a+b)^p$; $(\\sum a^p)^{1/p}S^{1/q}+(\\sum b^p)^{1/p}S^{1/q} \\le \\sum aw + \\sum bw = S$, divide by $S^{1/q}$, use $\\tfrac1p+\\tfrac1q=1$.",
+    "significance": "critical",
+    "relatedConcepts": ["Riesz argument", "superadditivity", "le_of_mul_le_mul_right", "conjugate exponents", "Finset.sum_add_distrib"],
+    "prerequisites": ["Hölder's inequality", "Lp triangle inequality"]
+  },
+  {
+    "id": "ann-p-half",
+    "proofId": "cauchy-schwarz-oq-03-oq-02-oq-01",
+    "range": { "startLine": 189, "endLine": 199 },
+    "type": "context",
+    "title": "The p = 1/2 Instance",
+    "content": "reverse_minkowski_half specialises to p = 1/2, the representative quasi-norm exponent. Since 1/p = 2 and aᵢ^{1/2} = √aᵢ, the inequality becomes (∑√aᵢ)² + (∑√bᵢ)² ≤ (∑√(aᵢ+bᵢ))² — a clean, concrete reversal of the Cauchy–Schwarz-flavoured forward case. The proof simply feeds p = 1/2 to reverse_minkowski and rewrites 1/(1/2) = 2.",
+    "mathContext": "$p=\\tfrac12$: $\\big(\\sum\\sqrt{a_i}\\big)^2 + \\big(\\sum\\sqrt{b_i}\\big)^2 \\le \\big(\\sum\\sqrt{a_i+b_i}\\big)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["square root", "Cauchy–Schwarz", "concrete instance"],
+    "prerequisites": ["square roots", "specialization"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02-oq-01/meta.json
@@ -80,6 +80,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Docstring and Setup",
+      "summary": "States the open question from the parent forward-Minkowski entry, explains why 0 < p < 1 reverses the triangle inequality (the p-functional is a concave quasi-norm, hence superadditive), and records that Mathlib has no 0 < p < 1 Holder/Minkowski lemma (all gated on HolderConjugate forcing p, q > 1). Lists the three results and the durable Python numerical certificate. Imports Mathlib and opens Finset, NNReal under namespace ReverseMinkowski.",
+      "startLine": 1,
+      "endLine": 64,
+      "mathContext": "Engine is reverse Holder with negative conjugate $q = p/(p-1) < 0$; $1/p + 1/q = 1$."
+    },
+    {
       "id": "reverse-holder",
       "title": "Reverse Holder Inequality (0 < p < 1)",
       "summary": "reverse_holder: for nonnegative u and strictly positive v, (sum u^p)^(1/p) * (sum v^(p/(p-1)))^(1/(p/(p-1))) <= sum u*v. Derived from forward Holder applied to the conjugate pair P = 1/p, P' = 1/(1-p) on f = (uv)^p, g = v^(-p).",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-oq-03-oq-02-oq-01` (Reverse Minkowski Inequality for 0 < p < 1, from Reverse Hölder).

## Gaps addressed
Rich `meta.json` but **no `annotations.json`** (zero inline coverage), and the `sections` array omitted the module header (lines 1–64).

## What was added
- **5 line-range annotations** over the full 199-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  1. **Docstring** — why 0<p<1 reverses the triangle inequality; Mathlib's HolderConjugate gating that blocks direct instantiation.
  2. **`reverse_holder`** — the negative-conjugate trick: apply forward Hölder to the positive pair P=1/p, P'=1/(1−p).
  3. **Unwinding** — the rpow-arithmetic collapse and raising-to-power-p calc.
  4. **`reverse_minkowski`** — the Riesz argument with weight w=(a+b)^{p−1}, wᵢ^q=(aᵢ+bᵢ)^p, and the 1/p+1/q=1 division.
  5. **`reverse_minkowski_half`** — the p=1/2 instance (∑√a)²+(∑√b)² ≤ (∑√(a+b))².
- **Added a `header` section** to `meta.json` covering the previously-uncovered lines 1–64.

## Notes
- Consistent with the Lean source and existing `overview`/`conclusion`.
- `status: verified`, `badge: original`, `axiomCount: 0` left unchanged — accurate (no axioms/assumption structures; no decide/native_decide; strict-positivity hypotheses genuine, not encoding artefacts).
- Dedicated branch to keep prior open enrichment PRs intact.