### PR TITLE
Enrich Chevalley-Warning nontrivial-zero corollary (chevalley-warning-theorem-oq-01): add annotations

### DIFF
--- a/src/data/proofs/chevalley-warning-theorem-oq-01/annotations.json
+++ b/src/data/proofs/chevalley-warning-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-cw-overview",
+    "proofId": "chevalley-warning-theorem-oq-01",
+    "range": { "startLine": 4, "endLine": 52 },
+    "type": "concept",
+    "title": "What Mathlib Proves and What It Omits",
+    "content": "The docstring states the Chevalley–Warning theorem (Chevalley & Warning, 1935): over a finite field K of characteristic p, a low-degree polynomial system — one whose total degrees sum to less than the number of variables — has a number of common zeros divisible by p. Mathlib formalizes the four divisibility forms but uses them only to prove Erdős–Ginzburg–Ziv; it never records the existence corollary Chevalley originally drew. That corollary — a low-degree system vanishing at the origin has a NONZERO common zero — is the genuinely new content here, together with two explicit 𝔽₂ witnesses. The corollary is the form actually invoked in applications (EGZ, Warning's second theorem, Ax–Katz).",
+    "mathContext": "$\\sum_i \\deg f_i < n \\Rightarrow p \\mid \\#\\{x : \\forall i,\\ f_i(x) = 0\\}$ over a finite field of characteristic $p$.",
+    "significance": "context",
+    "relatedConcepts": ["Chevalley–Warning theorem", "finite fields", "characteristic", "Erdős–Ginzburg–Ziv", "combinatorial nullstellensatz"],
+    "prerequisites": ["finite fields", "multivariate polynomials"]
+  },
+  {
+    "id": "ann-cw-divisibility",
+    "proofId": "chevalley-warning-theorem-oq-01",
+    "range": { "startLine": 58, "endLine": 98 },
+    "type": "theorem",
+    "title": "The Four Divisibility Forms (Mathlib Re-exports)",
+    "content": "chevalley_warning_dvd, _univ, _single, and _pair restate the four shapes of the divisibility theorem as the baseline: the Finset-indexed family (char_dvd_card_solutions_of_sum_lt), the full-Fintype-indexed family (char_dvd_card_solutions_of_fintype_sum_lt), a single polynomial (char_dvd_card_solutions), and two polynomials (char_dvd_card_solutions_of_add_lt). Each is a one-line direct re-export — they establish nothing new but provide the gallery-local statements the corollary builds on. The solution set is encoded as the subtype {x : σ → K // ∀ i ∈ s, eval x (f i) = 0}, whose Fintype.card is the count being divided.",
+    "mathContext": "$p \\mid \\#\\{x // \\forall i \\in s,\\ \\mathrm{eval}\\,x\\,(f_i) = 0\\}$ when $\\sum_{i\\in s}\\deg f_i < |\\sigma|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["char_dvd_card_solutions_of_sum_lt", "totalDegree", "subtype cardinality", "re-export"],
+    "prerequisites": ["Mathlib ChevalleyWarning API", "Fintype.card"]
+  },
+  {
+    "id": "ann-cw-nontrivial",
+    "proofId": "chevalley-warning-theorem-oq-01",
+    "range": { "startLine": 100, "endLine": 129 },
+    "type": "theorem",
+    "title": "Chevalley's Nontrivial-Solution Corollary",
+    "content": "chevalley_warning_nontrivial is the new content: if the degree condition holds and every f i vanishes at the origin (h0), then there is a nonzero common zero. The argument is pure cardinality, no algebraic geometry. (1) Chevalley–Warning gives p ∣ #S where S is the solution subtype. (2) The origin ⟨0, h0⟩ ∈ S, so #S ≥ 1 (Fintype.card_pos_iff). (3) With p prime, p.one_lt and Nat.le_of_dvd lift this to 1 < #S. (4) Fintype.exists_ne_of_one_lt_card produces y ∈ S with y ≠ ⟨0, h0⟩; y.val ≠ 0 follows by Subtype.ext, giving the nontrivial zero. Primality is essential — it is exactly what turns 'at least 1 solution' into 'at least p ≥ 2'.",
+    "mathContext": "Origin $\\Rightarrow \\#S \\ge 1$; $p\\mid\\#S$, $p$ prime $\\Rightarrow \\#S \\ge p \\ge 2 \\Rightarrow \\exists\\,y \\ne 0$ common zero.",
+    "significance": "critical",
+    "relatedConcepts": ["Fintype.card_pos_iff", "Fintype.exists_ne_of_one_lt_card", "Nat.le_of_dvd", "primality", "pigeonhole"],
+    "prerequisites": ["divisibility", "subtype cardinality", "Fact p.Prime"]
+  },
+  {
+    "id": "ann-cw-nontrivial-single",
+    "proofId": "chevalley-warning-theorem-oq-01",
+    "range": { "startLine": 131, "endLine": 148 },
+    "type": "theorem",
+    "title": "Single-Polynomial Form: Chevalley's Original Statement",
+    "content": "chevalley_warning_nontrivial_single runs the identical cardinality argument with the single-polynomial divisibility char_dvd_card_solutions in place of the family version. It is the classical statement Chevalley actually proved: a form of degree d < n in n variables with zero constant term has a nontrivial zero over a finite field. The structure mirrors the family corollary exactly — divisibility, origin gives ≥1, primality lifts to ≥2, extract a distinct (nonzero) witness.",
+    "mathContext": "$\\deg f < n$, $f(0) = 0 \\Rightarrow \\exists\\,x \\ne 0,\\ f(x) = 0$ over a finite field.",
+    "significance": "key",
+    "relatedConcepts": ["char_dvd_card_solutions", "homogeneous forms", "Artin's conjecture", "nontrivial zero"],
+    "prerequisites": ["single-polynomial divisibility"]
+  },
+  {
+    "id": "ann-cw-concrete",
+    "proofId": "chevalley-warning-theorem-oq-01",
+    "range": { "startLine": 150, "endLine": 172 },
+    "type": "context",
+    "title": "Explicit 𝔽₂ Witnesses",
+    "content": "Two concrete instances confirm the corollary numerically over ZMod 2. chevalley_linear_F2: the linear form X₀+X₁ (degree 1 < 2 variables) vanishes at (1,1) since 1+1=0 in 𝔽₂. chevalley_quadratic_F2: the quadratic form X₀·X₁+X₂² (total degree 2 < 3 variables) vanishes at (1,0,0) since 1·0+0²=0 — a genuine degree-2 witness, the typical shape Chevalley–Warning is applied in. Each proof discharges the nonzero-ness by evaluating a coordinate and the vanishing by simp + kernel decide. Note: this is kernel decide, not native_decide, so it introduces no Lean.ofReduceBool and the file remains axiom-free.",
+    "mathContext": "$X_0+X_1$ at $(1,1) = 0$; $X_0 X_1 + X_2^2$ at $(1,0,0) = 0$ over $\\mathbb{F}_2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod 2", "kernel decide", "MvPolynomial eval", "concrete witnesses"],
+    "prerequisites": ["finite field arithmetic", "decidable evaluation"]
+  }
+]

--- a/src/data/proofs/chevalley-warning-theorem-oq-01/meta.json
+++ b/src/data/proofs/chevalley-warning-theorem-oq-01/meta.json
@@ -142,8 +142,9 @@
   ],
   "crossReferences": [
     {
-      "id": "erdos-ginzburg-ziv-oq-01",
-      "reason": "Erdős–Ginzburg–Ziv is the sole downstream consumer of Mathlib's Chevalley–Warning lemmas; its standard proof applies the nontrivial-solution corollary to a pair of power-sum forms over 𝔽_p"
+      "targetId": "erdos-ginzburg-ziv-oq-01",
+      "relationship": "related",
+      "description": "Erdős–Ginzburg–Ziv is the sole downstream consumer of Mathlib's Chevalley–Warning lemmas; its standard proof applies the nontrivial-solution corollary to a pair of power-sum forms over 𝔽_p"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `chevalley-warning-theorem-oq-01` (Chevalley–Warning: divisibility of the solution count and the nontrivial-zero corollary).

## Gaps addressed
Rich `meta.json` but **no `annotations.json`**; and the `crossReferences` entry used a non-standard `{id, reason}` shape that would not render.

## What was added
- **5 line-range annotations** over the full 172-line Lean file (mathContext/significance/relatedConcepts/prerequisites each):
  1. **Docstring** — what Mathlib proves (divisibility) vs omits (existence corollary).
  2. **Four divisibility re-exports** — Finset / full-Fintype / single / pair forms.
  3. **`chevalley_warning_nontrivial`** — the pure-cardinality argument: origin ⇒ ≥1, p prime ⇒ ≥2, extract a distinct nonzero zero.
  4. **`chevalley_warning_nontrivial_single`** — Chevalley's original single-form statement.
  5. **`chevalley_linear_F2` / `chevalley_quadratic_F2`** — explicit 𝔽₂ witnesses; notes kernel `decide` (not native_decide) keeps it axiom-free.
- **Fixed the `crossReferences` schema** to `{targetId, relationship, description}`.

## Notes
- Consistent with the Lean source and existing `overview`/`sections`/`conclusion`.
- `status: verified`, `badge: mathlib`, `axiomCount: 0` left unchanged — accurate (kernel decide only; no Lean.ofReduceBool).
- Dedicated branch to keep prior open enrichment PRs intact.