### PR TITLE
Enrich ℵ₀/𝔠 Dichotomy Over Countable Rings (denumerability-rationals-oq-05-oq-01): add annotations

### DIFF
--- a/src/data/proofs/denumerability-rationals-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/denumerability-rationals-oq-05-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-denum-overview",
+    "proofId": "denumerability-rationals-oq-05-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "The ℵ₀/𝔠 Boundary Is Structural, Not About ℚ",
+    "content": "The docstring frames the generalization. The parent OQ-05 located, for ℚ, where ℵ₀-closure breaks: finite products, finite subsets, and finite sequences stay denumerable, but the countably infinite power ℕ → ℚ already reaches the continuum 𝔠. This child shows ℚ was incidental — the dichotomy holds over ANY countably infinite commutative ring R. The polynomial ring R[X], a countable colimit ⋃_d {deg ≤ d} of finite-rank free modules, never leaves ℵ₀ (#(R[X]) = ℵ₀ = #R, with an explicit bijection R[X] ≃ R), while the countable power ℕ → R always lands on 𝔠. The whole file is driven by a single engine, #R = ℵ₀, plus two cardinal facts: a countable colimit stays ℵ₀, but a countable power escapes.",
+    "mathContext": "$\\#(R[X]) = \\aleph_0 = \\#R$ but $\\#(\\mathbb{N} \\to R) = \\mathfrak{c}$ for countably infinite $R$; the gap is $\\aleph_0 < \\mathfrak{c}$.",
+    "significance": "context",
+    "relatedConcepts": ["denumerability", "continuum", "Cantor's gap", "polynomial ring", "countable ring"],
+    "prerequisites": ["cardinal arithmetic", "countable/uncountable sets"]
+  },
+  {
+    "id": "ann-denum-sequence",
+    "proofId": "denumerability-rationals-oq-05-oq-01",
+    "range": { "startLine": 43, "endLine": 61 },
+    "type": "theorem",
+    "title": "The Sequence Space Escapes to the Continuum",
+    "content": "mk_eq_aleph0_of_countable_infinite is the engine: any countable infinite type has cardinality exactly ℵ₀ (Cardinal.mk_eq_aleph0). mk_seq computes #(ℕ → R) = 𝔠: Cardinal.mk_arrow rewrites the function space to #R ^ #ℕ, lift_uzero clears the universe lifts, both base and exponent reduce to ℵ₀, and aleph0_power_aleph0 collapses ℵ₀^ℵ₀ to 𝔠. not_countable_seq then turns countability into #(ℕ → R) ≤ ℵ₀ (mk_le_aleph0_iff) and refutes it via mk_seq + aleph0_lt_continuum. This is the operation — a countable power — that breaks ℵ₀-closure.",
+    "mathContext": "$\\#(\\mathbb{N} \\to R) = \\#R^{\\#\\mathbb{N}} = \\aleph_0^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$.",
+    "significance": "critical",
+    "relatedConcepts": ["Cardinal.mk_arrow", "aleph0_power_aleph0", "aleph0_lt_continuum", "mk_le_aleph0_iff"],
+    "prerequisites": ["cardinal exponentiation", "function spaces"]
+  },
+  {
+    "id": "ann-denum-polynomial",
+    "proofId": "denumerability-rationals-oq-05-oq-01",
+    "range": { "startLine": 61, "endLine": 84 },
+    "type": "theorem",
+    "title": "The Polynomial Ring Stays Denumerable",
+    "content": "countable_polynomial identifies R[X] = AddMonoidAlgebra R ℕ = (ℕ →₀ R), a finitely supported family over countable types (Finsupp.instCountable), and transports countability through the injective constructor Polynomial.toFinsupp_injective.countable. mk_polynomial then pins #(R[X]) = ℵ₀: R[X] is countable (above) and infinite (Polynomial.infinite, since Infinite R ⟹ Nontrivial R makes the monomials Xⁿ distinct), so mk_eq_aleph0 applies. mk_polynomial_eq_mk records #(R[X]) = #R (both sides ℵ₀) — a much larger ring but the same-size set — and nonempty_equiv_polynomial extracts an explicit bijection R[X] ≃ R from Cardinal.eq, the ℵ₀ analogue of a Hilbert-hotel repackaging.",
+    "mathContext": "$R[X] = \\mathbb{N} \\to_0 R$ countable + infinite $\\Rightarrow \\#(R[X]) = \\aleph_0 = \\#R$, with $R[X] \\simeq R$.",
+    "significance": "critical",
+    "relatedConcepts": ["Finsupp.instCountable", "Polynomial.toFinsupp_injective", "Polynomial.infinite", "Cardinal.eq", "AddMonoidAlgebra"],
+    "prerequisites": ["polynomial ring internals", "countable Finsupp"]
+  },
+  {
+    "id": "ann-denum-dichotomy",
+    "proofId": "denumerability-rationals-oq-05-oq-01",
+    "range": { "startLine": 86, "endLine": 92 },
+    "type": "insight",
+    "title": "The Dichotomy in One Inequality",
+    "content": "mk_polynomial_lt_mk_seq states the whole boundary as a single inequality: #(R[X]) < #(ℕ → R). Rewriting both sides (ℵ₀ and 𝔠) reduces it to aleph0_lt_continuum — Cantor's gap, now instantiated at the level of an arbitrary countable ring. The polynomial ring, algebraically far richer than R, stays at ℵ₀; the sequence space jumps to 𝔠. The contrast between a countable colimit and a countable power is exactly the ℵ₀ < 𝔠 boundary.",
+    "mathContext": "$\\#(R[X]) < \\#(\\mathbb{N} \\to R) \\iff \\aleph_0 < \\mathfrak{c}.$",
+    "significance": "key",
+    "relatedConcepts": ["aleph0_lt_continuum", "Cantor's diagonal", "colimit vs power"],
+    "prerequisites": ["cardinal inequalities"]
+  },
+  {
+    "id": "ann-denum-instances",
+    "proofId": "denumerability-rationals-oq-05-oq-01",
+    "range": { "startLine": 94, "endLine": 109 },
+    "type": "context",
+    "title": "Concrete Instances: ℚ and ℤ",
+    "content": "Three instances specialize the general theorems by direct application (the typeclass resolution supplies Countable and Infinite for ℚ and ℤ): mk_polynomial_rat (#(ℚ[X]) = ℵ₀), mk_polynomial_int (#(ℤ[X]) = ℵ₀), and mk_seq_int (#(ℕ → ℤ) = 𝔠). They confirm the abstract dichotomy holds verbatim for the rationals it was generalized from and for the integers, each proof a one-liner invoking the general result.",
+    "mathContext": "$\\#(\\mathbb{Q}[X]) = \\#(\\mathbb{Z}[X]) = \\aleph_0$, $\\#(\\mathbb{N} \\to \\mathbb{Z}) = \\mathfrak{c}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["concrete instantiation", "ℚ", "ℤ", "typeclass resolution"],
+    "prerequisites": ["specialization of general theorems"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `denumerability-rationals-oq-05-oq-01` (#(R[X]) = ℵ₀ but #(ℕ → R) = 𝔠 over any countable ring).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage.

## What was added
5 line-range annotations covering the full 109-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:

1. **Docstring** — the boundary is structural, not about ℚ; colimit vs power.
2. **Sequence space** — `mk_seq`/`not_countable_seq`: ℵ₀^ℵ₀ = 𝔠 via `mk_arrow` + `aleph0_power_aleph0`.
3. **Polynomial ring** — `countable_polynomial`/`mk_polynomial`/`mk_polynomial_eq_mk`/`nonempty_equiv_polynomial`: R[X]=ℕ→₀R stays ℵ₀=#R with R[X]≃R.
4. **Dichotomy** — `mk_polynomial_lt_mk_seq` = ℵ₀ < 𝔠.
5. **Instances** — ℚ[X], ℤ[X], ℕ→ℤ.

## Notes
- Consistent with the Lean source and existing `overview`/`sections`/`conclusion`.
- `status: verified`, `badge: mathlib`, `axiomCount: 0` unchanged — accurate (no axioms/assumption structures; no native_decide).
- Dedicated branch to keep prior open enrichment PRs intact.