### PR TITLE
Enrich Erdős #1025 OQ-4 degenerate pair functions (erdos-1025-oq-04): add annotations

### DIFF
--- a/src/data/proofs/erdos-1025-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1025-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-erdos1025-overview",
+    "proofId": "erdos-1025-oq-04",
+    "range": { "startLine": 1, "endLine": 30 },
+    "type": "concept",
+    "title": "Relaxing the Validity Constraint of Pair Functions",
+    "content": "The docstring frames OQ-4 of Erdős #1025. The parent problem (Erdős–Hajnal 1958, Spencer 1972, Conlon–Fox–Sudakov 2016) studies valid pair functions — f sends each pair {x,y} to an element with f x y ∉ {x,y} — and asks for the largest independent set X (one with f x y ∉ X for x,y ∈ X), proving the guarantee g(n) = Θ(√n). OQ-4 asks what happens when the validity constraint is relaxed to allow degenerate values f x y ∈ {x,y}. The file gives two sharp elementary answers: unbounded degeneracy collapses the guarantee to a constant 1, while bounded degeneracy (≤ k degenerate pairs) recovers a genuinely valid sub-instance on ≥ n − 2k vertices — so the validity hypothesis is essential but robust to a sublinear violation budget.",
+    "mathContext": "Valid: $f(x,y) \\notin \\{x,y\\}$; $g(n) = \\Theta(\\sqrt n)$. Relaxed: degenerate $f(x,y) \\in \\{x,y\\}$ allowed — collapse to 1 vs recovery on $\\ge n-2k$ vertices.",
+    "significance": "context",
+    "relatedConcepts": ["pair functions", "set mappings", "Erdős–Hajnal", "independent sets", "extremal combinatorics"],
+    "prerequisites": ["set-mapping problem", "Finset cardinality"]
+  },
+  {
+    "id": "ann-erdos1025-defs",
+    "proofId": "erdos-1025-oq-04",
+    "range": { "startLine": 36, "endLine": 56 },
+    "type": "definition",
+    "title": "Relaxed Pair Functions, Validity, Independence",
+    "content": "Four definitions set up the relaxed framework on Fin n. RelaxedPairFunction n := Fin n → Fin n → Fin n is a two-argument function with NO constraint. Valid f := ∀ x y, x ≠ y → f x y ≠ x ∧ f x y ≠ y restores the original avoidance hypothesis. Independent f X := ∀ x,y ∈ X distinct, f x y ∉ X is the freeness condition. ValidOn f W localizes validity to pairs inside a subset W — the predicate the recovery theorem produces on the surviving vertex set. Stating f as an explicit two-argument function (rather than over unordered pairs) keeps the Finset bookkeeping elementary.",
+    "mathContext": "$\\mathrm{Valid}\\,f \\equiv \\forall x\\ne y,\\ f(x,y)\\notin\\{x,y\\}$; $\\mathrm{Independent}\\,f\\,X \\equiv \\forall x,y\\in X,\\ x\\ne y \\Rightarrow f(x,y)\\notin X$.",
+    "significance": "supporting",
+    "relatedConcepts": ["validity constraint", "freeness", "ValidOn", "two-argument formulation"],
+    "prerequisites": ["Lean predicates", "Finset membership"]
+  },
+  {
+    "id": "ann-erdos1025-floor",
+    "proofId": "erdos-1025-oq-04",
+    "range": { "startLine": 57, "endLine": 85 },
+    "type": "theorem",
+    "title": "The Free g(n) ≥ 2 Floor",
+    "content": "empty_independent and singleton_independent are trivial (no distinct pair exists). The substance is valid_pair_independent: for a valid f, every 2-element set {a,b} is independent. The proof is a four-way case split identifying {x,y} with {a,b}; in the two non-trivial cases the validity facts f x y ≠ x and f x y ≠ y are exactly what independence demands. A key insight surfaces here: independence of a pair IS the validity condition, so the lower bound g(n) ≥ 2 is automatic and content-free — all the hard Erdős–Hajnal/Spencer/CFS mathematics lives in pushing the guaranteed size from 2 up to Θ(√n).",
+    "mathContext": "$\\mathrm{Valid}\\,f,\\ a\\ne b \\Rightarrow \\mathrm{Independent}\\,f\\,\\{a,b\\}$ — the $g(n) \\ge 2$ floor is the validity condition itself.",
+    "significance": "key",
+    "relatedConcepts": ["independent pair", "case split", "trivial lower bound", "validity = independence"],
+    "prerequisites": ["the validity predicate"]
+  },
+  {
+    "id": "ann-erdos1025-collapse",
+    "proofId": "erdos-1025-oq-04",
+    "range": { "startLine": 86, "endLine": 118 },
+    "type": "theorem",
+    "title": "Part 1 — Collapse Under Unbounded Degeneracy",
+    "content": "The maximally degenerate witness fbad n := fun x _ => x always returns its first argument, so f x y = x ∈ {x,y} for every pair. fbad_not_valid confirms it violates validity for n ≥ 2. relaxed_collapse is the headline of Part 1: no set of size ≥ 2 is independent under fbad, because any two distinct a,b ∈ X give fbad a b = a ∈ X, violating independence (Finset.card_le_one). relaxed_g_eq_one packages the exact answer for n ≥ 2 — every independent set has size ≤ 1, and a singleton attains it — so the relaxed guarantee is exactly 1, the sharpest possible contrast with Θ(√n). This certifies the validity hypothesis is the entire source of the guarantee.",
+    "mathContext": "$f_{\\mathrm{bad}}(x,y) = x \\Rightarrow$ no independent set of size $\\ge 2$; relaxed guarantee $= 1$ vs $\\Theta(\\sqrt n)$.",
+    "significance": "critical",
+    "relatedConcepts": ["explicit witness", "Finset.card_le_one", "collapse", "sharp contrast", "essential hypothesis"],
+    "prerequisites": ["independence predicate", "card bounds"]
+  },
+  {
+    "id": "ann-erdos1025-recovery",
+    "proofId": "erdos-1025-oq-04",
+    "range": { "startLine": 119, "endLine": 189 },
+    "type": "theorem",
+    "title": "Part 2 — Recovery Under Bounded Degeneracy",
+    "content": "degenerateSet f filters the distinct ordered pairs (x,y) with f x y ∈ {x,y}; its cardinality measures degeneracy frequency. recovery is the structural reduction: if |degenerateSet f| ≤ k, the tainted-vertex set T = (image of fst) ∪ (image of snd) has |T| ≤ 2k (each coordinate-image has ≤ |D| ≤ k elements, Finset.card_union_le + card_image_le), so W = univ \\ T has |W| ≥ n − 2k (Finset.card_univ_diff) and f is genuinely valid on W by construction (any degenerate pair inside W would put an endpoint in T). validOn_pair_independent transfers the pair-independence argument to the local validity, and recovery_independent_pair extracts two distinct vertices from W when |W| ≥ 2 (Finset.one_lt_card), yielding a size-2 independent set. The upshot: a sublinear violation budget leaves a (1−o(1))-fraction of the ground set valid, so the asymptotic Θ(√n) guarantee is unaffected.",
+    "mathContext": "$|D| \\le k \\Rightarrow |T| \\le 2k \\Rightarrow |W| = n - |T| \\ge n - 2k$, with $f$ valid on $W$; independent pair survives when $n - 2k \\ge 2$.",
+    "significance": "critical",
+    "relatedConcepts": ["Finset.card_univ_diff", "Finset.card_union_le", "Finset.card_image_le", "Finset.one_lt_card", "vertex deletion"],
+    "prerequisites": ["Finset image/union/complement cardinality", "ValidOn"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1025-oq-04` (Degenerate Pair Functions — Collapse and Recovery).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage.

## What was added
5 line-range annotations over the full 189-line Lean file (mathContext/significance/relatedConcepts/prerequisites each):

1. **Docstring** — relaxing validity: collapse vs recovery.
2. **Definitions** — `RelaxedPairFunction`, `Valid`, `Independent`, `ValidOn`.
3. **Free floor** — `valid_pair_independent`: independence of a pair IS validity, so g(n)≥2 is free.
4. **Part 1 collapse** — `fbad`/`relaxed_collapse`/`relaxed_g_eq_one`: guarantee drops to exactly 1.
5. **Part 2 recovery** — `degenerateSet`/`recovery`/`recovery_independent_pair`: ≤2k taint deletion restores validity on ≥n−2k.

## Notes
- Consistent with the Lean source and existing `overview`/`sections`/`conclusion`.
- `status: verified`, `badge: original`, `axiomCount: 0` unchanged — accurate (no axioms/assumption structures; no native_decide).
- Dedicated branch to keep prior open enrichment PRs intact.