### PR TITLE
Enrich Erdős #1040 oq-03 EHP convex extension (erdos-1040-oq-03): add annotations

### DIFF
--- a/src/data/proofs/erdos-1040-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1040-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-erdos1040-overview",
+    "proofId": "erdos-1040-oq-03",
+    "range": { "startLine": 1, "endLine": 44 },
+    "type": "concept",
+    "title": "Framing the EHP-to-Convex-Sets Question",
+    "content": "The docstring frames open question oq-03 of Erdős #1040. The EHP quantity is μ(F) = inf over monic polynomials f with roots in a closed infinite F ⊆ ℂ of the planar Lebesgue measure of the lemniscatic sublevel set {z : |f(z)| < 1}; the open conjecture asks whether μ(F) is governed by the transfinite diameter of F. Erdős–Herzog–Piranian (1958) answered YES for line segments and discs; oq-03 asks about general convex F. This file does not resolve that — it isolates two elementary fully-verified facts any extension must reckon with: (1) the degree-1 base case, where the linear sublevel set is the unit disc (convex, measure π, giving μ(F) ≤ π); and (2) the degree-2 obstruction, where even roots in the convex segment [−1,1] produce a non-convex sublevel set. The two facts are the easy upper side and the first nonlinear obstacle of the program.",
+    "mathContext": "$\\mu(F) = \\inf_f \\mathrm{vol}\\{z : |f(z)| < 1\\}$; degree-1 gives $\\mu(F) \\le \\pi$, degree-2 breaks sublevel-set convexity.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős–Herzog–Piranian", "lemniscates", "transfinite diameter", "convexity", "logarithmic capacity"],
+    "prerequisites": ["complex analysis", "Lebesgue measure", "convex sets"]
+  },
+  {
+    "id": "ann-erdos1040-defs",
+    "proofId": "erdos-1040-oq-03",
+    "range": { "startLine": 41, "endLine": 71 },
+    "type": "definition",
+    "title": "The Minimal EHP Objects",
+    "content": "Self-contained copies of the EHP definitions (the base file is imported only for reference). PolynomialInF F is a structure carrying a degree, its roots Fin degree → ℂ, and a proof all roots lie in F; its eval is ∏ᵢ (z − rᵢ). sublevelSet p = {z : ‖p.eval z‖ < 1} is the lemniscate interior, sublevelMeasure its volume, and muPosDeg F = ⨅ over polynomials of degree ≥ 1 of sublevelMeasure — the degree-≥1-corrected infimum (degree-0 gives the empty sublevel set, so it must be excluded for the right μ).",
+    "mathContext": "$p.\\mathrm{eval}(z) = \\prod_i (z - r_i)$; $\\mathrm{muPosDeg}(F) = \\inf_{\\deg p \\ge 1} \\mathrm{vol}\\{z : \\|p.\\mathrm{eval}(z)\\| < 1\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["polynomial lemniscate", "sublevel set", "infimum over polynomials", "monic polynomial"],
+    "prerequisites": ["structures in Lean", "Finset products"]
+  },
+  {
+    "id": "ann-erdos1040-degree1",
+    "proofId": "erdos-1040-oq-03",
+    "range": { "startLine": 73, "endLine": 113 },
+    "type": "theorem",
+    "title": "Degree-1 Base Case: the Sublevel Set Is a Unit Disc",
+    "content": "linPoly F a ha is the linear polynomial with single root a. linPoly_eval collapses the Fin 1 product to z − a (Fin.prod_univ_one). linPoly_sublevelSet identifies {z : ‖z − a‖ < 1} with Metric.ball a 1 via dist_eq_norm — the sublevel set is exactly the open unit disc. linPoly_sublevelSet_convex deduces convexity from convex_ball (this is the only degree at which the sublevel set is guaranteed convex), and linPoly_measure computes its Lebesgue measure as exactly π via Complex.volume_ball at radius 1 (ENNReal.ofReal 1² · π = π).",
+    "mathContext": "$\\{z : |z - a| < 1\\} = B(a,1)$: convex, $\\mathrm{vol} = \\pi$.",
+    "significance": "key",
+    "relatedConcepts": ["Metric.ball", "Complex.volume_ball", "convex_ball", "dist_eq_norm", "Fin.prod_univ_one"],
+    "prerequisites": ["metric balls", "volume of a disc"]
+  },
+  {
+    "id": "ann-erdos1040-bound",
+    "proofId": "erdos-1040-oq-03",
+    "range": { "startLine": 114, "endLine": 126 },
+    "type": "theorem",
+    "title": "The Universal Upper Bound μ(F) ≤ π",
+    "content": "muPosDeg_le_pi: for any nonempty F, μ(F) ≤ π. Choosing any root a ∈ F, the degree-1 polynomial linPoly F a ha is a valid degree-≥1 witness in the infimum, so iInf₂_le bounds muPosDeg F below its measure, which linPoly_measure evaluates to π. Hence μ(F) is always finite, independent of the transfinite diameter — the elementary upper counterpart to the genuinely open lower-bound behaviour (μ(F) = 0 when capacity ≥ 1).",
+    "mathContext": "$\\mu(F) \\le \\mathrm{sublevelMeasure}(z - a) = \\pi$ for any $a \\in F$.",
+    "significance": "key",
+    "relatedConcepts": ["iInf₂_le", "infimum witness", "finiteness of μ", "transfinite diameter independence"],
+    "prerequisites": ["infima in ℝ≥0∞", "the degree-1 measure"]
+  },
+  {
+    "id": "ann-erdos1040-degree2",
+    "proofId": "erdos-1040-oq-03",
+    "range": { "startLine": 123, "endLine": 184 },
+    "type": "theorem",
+    "title": "Degree-2 Obstruction: Convex Roots, Non-Convex Lemniscate",
+    "content": "quadPoly is (z−1)(z+1) = z² − 1 with roots ±1, which lie in the convex segment [−1,1] (left_/right_mem_segment). quad_eval computes the product (Fin.prod_univ_two). one_mem_quad_sublevel and negOne_mem_quad_sublevel place ±1 in the sublevel set (eval = 0), while zero_not_mem_quad_sublevel excludes the midpoint 0 (eval = −1, norm 1 ≥ 1). quad_sublevelSet_not_convex concludes non-convexity: convexity would force the midpoint (1/2)·1 + (1/2)·(−1) = 0 (computed via Complex.real_smul) into the set, contradicting its exclusion. The two lobes around ±1 pinch at the saddle 0. This shows the natural hope behind oq-03 — that convex root sets keep lemniscates convex — fails already at degree 2, so any EHP-to-convex extension must use capacity/area machinery, not sublevel-set convexity.",
+    "mathContext": "Roots $\\pm 1 \\in [-1,1]$ in the sublevel set, but midpoint $0 \\notin$ it ($|0^2-1| = 1$) — the lemniscate is non-convex.",
+    "significance": "critical",
+    "relatedConcepts": ["left_mem_segment", "right_mem_segment", "Complex.real_smul", "non-convexity", "lemniscate lobes", "convex obstruction"],
+    "prerequisites": ["convex segments", "midpoint convexity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `erdos-1040-oq-03` (Extending EHP to convex sets — the degree-1 base case and the degree-2 non-convexity obstruction).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — zero inline annotation coverage.

## What was added
5 line-range annotations over the full 184-line Lean file (mathContext/significance/relatedConcepts/prerequisites each):

1. **Docstring** — framing oq-03; easy upper side vs first nonlinear obstacle.
2. **Definitions** — `PolynomialInF`, `eval`, `sublevelSet`, `muPosDeg`.
3. **Degree-1** — sublevel set = `Metric.ball a 1`, convex, measure π via `Complex.volume_ball`.
4. **Universal bound** — `muPosDeg_le_pi` via `iInf₂_le`.
5. **Degree-2 obstruction** — convex roots ±1 but midpoint 0 ∉ set, so the lemniscate is non-convex.

## Notes
- Consistent with the Lean source and existing `overview`/`sections`/`conclusion`.
- `status: verified`, `badge: original`, `axiomCount: 0` unchanged — accurate (no axioms/assumption structures; no native_decide). meta `assumptions` honestly discloses Docker build was unavailable this session (deployer-gated).
- Dedicated branch to keep prior open enrichment PRs intact.