### PR TITLE
research(erdos-1040-oq-03-oq-02): monic normalization pins single-point lemniscate area to π

### DIFF
--- a/proofs/Proofs/Erdos1040OQ03OQ02.lean
+++ b/proofs/Proofs/Erdos1040OQ03OQ02.lean
@@ -1,0 +1,142 @@
+/-
+Erdős Problem #1040 — open question oq-03, follow-up oq-02:
+"What role does the *monic normalization* play in the lemniscate-area infimum
+   μ(F) = inf { area {|f| < 1} : f monic, roots ⊆ F } ?
+ For the single-point root set F = {c} the monic value is exactly π (oq-01); what
+ happens to the infimum if the leading-coefficient normalization is dropped?"
+
+Parent context.
+  * #1040 / oq-03 proved the elementary UPPER bounds  area {|f| < 1} ≤ degree·π.
+  * #1040 / oq-03 / oq-01 proved that for the *monic* pure power f(z) = (z - c)^n
+    the lemniscate is exactly the open unit disc B(c, 1), of area exactly π, for
+    every degree n ≥ 1 — hence μ({c}) ≤ π.
+
+This file isolates the role of the monic normalization. Rescaling the pure power
+by a positive real `R` (which rescales the leading coefficient),
+   f_R(z) = ((z - c) / R)^n = R^{-n} (z - c)^n        (R > 0),
+keeps the single root `c` of multiplicity `n` but changes the leading coefficient
+to `R^{-n}` (monic exactly when R = 1). Its lemniscate is the disc of radius `R`:
+   {z : |f_R(z)| < 1} = {z : |z - c| < R} = B(c, R),
+of area exactly `π R²`. Letting `R` range over `(0, ∞)`:
+
+  * **Monic ⇒ π.** Taking R = 1 (the monic pure power `(z - c)^n`) recovers area
+    exactly π, independent of n and c — the oq-01 value, re-derived self-containedly.
+
+  * **Without monicity the area is unconstrained.** The map `R ↦ π R²` is onto
+    `(0, ∞)`: every positive area is realised by some single-root degree-`n`
+    polynomial, and the areas become arbitrarily small. Hence the infimum of
+    lemniscate areas over *all* (not necessarily monic) single-root polynomials
+    is `0`.
+
+Conclusion: the monic normalization is *essential* to the finite positive value
+π in μ({c}); drop it and the infimum collapses to `0`. This explains why Erdős
+#1040 fixes the leading coefficient.
+
+Everything is axiom-free and self-contained: lemniscates are taken of bare
+functions `ℂ → ℂ`, so no polynomial-structure scaffolding is needed.
+-/
+
+import Mathlib
+
+open Complex MeasureTheory Metric
+
+namespace Erdos1040OQ03OQ02
+
+/-- The lemniscate (open sub-level set) of a function `f : ℂ → ℂ`. -/
+def lemOf (f : ℂ → ℂ) : Set ℂ := {z : ℂ | ‖f z‖ < 1}
+
+/-- The rescaled pure power `f_R(z) = ((z - c) / R)^n = R^{-n} (z - c)^n`: a degree-`n`
+polynomial with the single root `c` (multiplicity `n`) and leading coefficient
+`R^{-n}`. It is monic exactly when `R = 1`. -/
+noncomputable def scaledPure (R : ℝ) (c : ℂ) (n : ℕ) : ℂ → ℂ :=
+  fun z => ((z - c) / (R : ℂ)) ^ n
+
+@[simp] theorem scaledPure_apply (R : ℝ) (c : ℂ) (n : ℕ) (z : ℂ) :
+    scaledPure R c n z = ((z - c) / (R : ℂ)) ^ n := rfl
+
+/-- The monic case `R = 1` is the bare pure power `(z - c)^n`. -/
+theorem scaledPure_one (c : ℂ) (n : ℕ) (z : ℂ) :
+    scaledPure 1 c n z = (z - c) ^ n := by
+  simp [scaledPure]
+
+/-- **The rescaled-pure-power lemniscate is a disc of radius `R`.** For `R > 0` and
+`n ≥ 1`,  `{z : |f_R(z)| < 1} = B(c, R)`. -/
+theorem lemOf_scaledPure_eq_ball (R : ℝ) (hR : 0 < R) (c : ℂ) {n : ℕ} (hn : 0 < n) :
+    lemOf (scaledPure R c n) = Metric.ball c R := by
+  ext z
+  simp only [lemOf, scaledPure, Set.mem_setOf_eq, norm_pow, norm_div,
+    Complex.norm_real, Real.norm_eq_abs, Metric.mem_ball, dist_eq_norm]
+  rw [abs_of_pos hR,
+    pow_lt_one_iff_of_nonneg (div_nonneg (norm_nonneg _) hR.le) hn.ne']
+  exact div_lt_one hR
+
+/-- **Exact area `π R²`.** For `R > 0`, `n ≥ 1`, the rescaled-pure-power lemniscate
+has Lebesgue (area) measure exactly `π R²`. -/
+theorem volume_lemOf_scaledPure (R : ℝ) (hR : 0 < R) (c : ℂ) {n : ℕ} (hn : 0 < n) :
+    volume (lemOf (scaledPure R c n)) = ENNReal.ofReal (Real.pi * R ^ 2) := by
+  rw [lemOf_scaledPure_eq_ball R hR c hn, Complex.volume_ball]
+  have hpi : ((NNReal.pi : ℝ≥0∞)) = ENNReal.ofReal Real.pi := by
+    rw [← NNReal.coe_real_pi]; exact (ENNReal.ofReal_coe_nnreal).symm
+  rw [hpi, ← ENNReal.ofReal_pow hR.le,
+    ← ENNReal.ofReal_mul (show (0 : ℝ) ≤ R ^ 2 by positivity)]
+  congr 1
+  ring
+
+/-- **Monic ⇒ area `π`.** With `R = 1` (the monic pure power `(z - c)^n`) the area
+is exactly `π`, for every degree `n ≥ 1`. (Re-derives the oq-01 value, here as the
+single point `R = 1` of the area function `R ↦ π R²`.) -/
+theorem volume_lemOf_monic (c : ℂ) {n : ℕ} (hn : 0 < n) :
+    volume (lemOf (scaledPure 1 c n)) = ENNReal.ofReal Real.pi := by
+  rw [volume_lemOf_scaledPure 1 one_pos c hn]
+  congr 1
+  ring
+
+/-- The rescaled-pure-power lemniscate always has *positive* area, for every
+`R > 0`, `n ≥ 1`. -/
+theorem volume_lemOf_scaledPure_pos (R : ℝ) (hR : 0 < R) (c : ℂ) {n : ℕ}
+    (hn : 0 < n) : 0 < volume (lemOf (scaledPure R c n)) := by
+  rw [volume_lemOf_scaledPure R hR c hn, ENNReal.ofReal_pos]
+  positivity
+
+/-- **Every positive area is realised.** For any target area `A > 0` there is a
+single-root degree-`n` polynomial whose lemniscate has area exactly `A` — namely
+the rescaling at radius `R = √(A / π)`. -/
+theorem area_surjective (c : ℂ) {n : ℕ} (hn : 0 < n) {A : ℝ} (hA : 0 < A) :
+    ∃ R : ℝ, 0 < R ∧ volume (lemOf (scaledPure R c n)) = ENNReal.ofReal A := by
+  have hAπ : 0 < A / Real.pi := div_pos hA Real.pi_pos
+  refine ⟨Real.sqrt (A / Real.pi), Real.sqrt_pos.mpr hAπ, ?_⟩
+  rw [volume_lemOf_scaledPure _ (Real.sqrt_pos.mpr hAπ) c hn,
+    Real.sq_sqrt hAπ.le]
+  congr 1
+  rw [mul_comm]
+  exact div_mul_cancel₀ A Real.pi_ne_zero
+
+/-- **Areas are unbounded below.** Without the monic normalization the lemniscate
+area can be made smaller than any `ε > 0`; hence the infimum of areas over all
+single-root degree-`n` polynomials (not necessarily monic) is `0`. -/
+theorem area_arbitrarily_small (c : ℂ) {n : ℕ} (hn : 0 < n) {ε : ℝ} (hε : 0 < ε) :
+    ∃ R : ℝ, 0 < R ∧ volume (lemOf (scaledPure R c n)) < ENNReal.ofReal ε := by
+  obtain ⟨R, hRpos, hR⟩ := area_surjective c hn (half_pos hε)
+  refine ⟨R, hRpos, ?_⟩
+  rw [hR]
+  exact (ENNReal.ofReal_lt_ofReal_iff hε).mpr (by linarith)
+
+/-- **Capstone: the monic normalization is essential.**
+For the single-point root set `{c}`:
+* the *monic* representative `(z - c)^n` has lemniscate area exactly `π`,
+  independent of the degree `n ≥ 1`; yet
+* dropping the normalization, single-root degree-`n` lemniscate areas realise
+  *every* positive value and become *arbitrarily small*.
+Thus the finite positive infimum `μ({c}) = π` is a consequence of monicity:
+without it the infimum collapses to `0`. -/
+theorem monic_normalization_essential (c : ℂ) {n : ℕ} (hn : 0 < n) :
+    volume (lemOf (scaledPure 1 c n)) = ENNReal.ofReal Real.pi ∧
+    (∀ A : ℝ, 0 < A → ∃ R : ℝ, 0 < R ∧
+        volume (lemOf (scaledPure R c n)) = ENNReal.ofReal A) ∧
+    (∀ ε : ℝ, 0 < ε → ∃ R : ℝ, 0 < R ∧
+        volume (lemOf (scaledPure R c n)) < ENNReal.ofReal ε) :=
+  ⟨volume_lemOf_monic c hn,
+   fun _A hA => area_surjective c hn hA,
+   fun _ε hε => area_arbitrarily_small c hn hε⟩
+
+end Erdos1040OQ03OQ02

--- a/src/data/proofs/erdos-1040-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/erdos-1040-oq-03-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-erdos1040oq03oq02-header",
+    "proofId": "erdos-1040-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "concept",
+    "title": "What the Monic Normalization Buys in Erdős #1040",
+    "content": "Erdős #1040 studies μ(F), the infimum of lemniscate areas area{|f|<1} over MONIC polynomials with roots in F. The monic constraint is load-bearing: the lemniscate scales with the leading coefficient. This entry isolates that dependence for the single point F = {c}, complementing oq-01 (the monic π-witness) by showing the same family, un-normalized, has area infimum 0.",
+    "mathContext": "$\\mu(\\{c\\}) = \\inf\\{\\,|\\{|f|<1\\}| : f\\ \\text{monic, root} = c\\,\\} = \\pi$ — but $\\inf$ without monicity is $0$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial lemniscate", "leading coefficient", "normalization", "area infimum", "Pólya inequality"]
+  },
+  {
+    "id": "ann-erdos1040oq03oq02-setup",
+    "proofId": "erdos-1040-oq-03-oq-02",
+    "range": { "startLine": 44, "endLine": 61 },
+    "type": "technique",
+    "title": "The Bare Lemniscate and the Rescaled Pure Power",
+    "content": "lemOf f = {z : ‖f z‖ < 1} is the sub-level set of a bare function ℂ → ℂ — no polynomial scaffolding, so the entry is self-contained. scaledPure R c n = ((z - c)/R)^n = R^{-n}(z - c)^n is the pure power rescaled by R > 0; it keeps the single root c of multiplicity n but sets the leading coefficient to R^{-n}, monic exactly when R = 1.",
+    "mathContext": "$f_R(z) = ((z - c)/R)^n = R^{-n}(z - c)^n$.",
+    "significance": "standard",
+    "relatedConcepts": ["sublevel set", "leading coefficient", "root multiplicity", "monic polynomial"]
+  },
+  {
+    "id": "ann-erdos1040oq03oq02-disc",
+    "proofId": "erdos-1040-oq-03-oq-02",
+    "range": { "startLine": 62, "endLine": 73 },
+    "type": "key-step",
+    "title": "Lemniscate = Disc of Radius R",
+    "content": "The central identity. Since ‖((z-c)/R)^n‖ = (‖z-c‖/R)^n (norm_pow, norm_div, Complex.norm_real) and t^n < 1 ⟺ t < 1 for t ≥ 0, n > 0 (pow_lt_one_iff_of_nonneg), the condition |f_R(z)| < 1 reduces to ‖z-c‖/R < 1, i.e. ‖z-c‖ < R (div_lt_one). So the lemniscate is exactly the open disc B(c, R) — the unit disc of oq-01 dilated by R.",
+    "mathContext": "$\\{z : |f_R(z)| < 1\\} = \\{z : |z - c| < R\\} = B(c, R)$.",
+    "significance": "key",
+    "relatedConcepts": ["norm_pow", "pow_lt_one_iff_of_nonneg", "div_lt_one", "Metric.ball"]
+  },
+  {
+    "id": "ann-erdos1040oq03oq02-area",
+    "proofId": "erdos-1040-oq-03-oq-02",
+    "range": { "startLine": 74, "endLine": 100 },
+    "type": "key-step",
+    "title": "Exact Area π·R² and the Monic Value π",
+    "content": "Complex.volume_ball at radius R gives lemniscate area exactly π·R² (ENNReal.ofReal bookkeeping via ofReal_pow and ofReal_mul). The monic case R = 1 recovers area exactly π for every degree — the oq-01 value, here as the single point R = 1 of the area function R ↦ π·R². Every such area is strictly positive (ENNReal.ofReal_pos).",
+    "mathContext": "$|B(c, R)| = \\pi R^2$; at $R = 1$, area $= \\pi$ for all $n \\geq 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.volume_ball", "ENNReal.ofReal", "monic normalization"]
+  },
+  {
+    "id": "ann-erdos1040oq03oq02-normalization",
+    "proofId": "erdos-1040-oq-03-oq-02",
+    "range": { "startLine": 101, "endLine": 142 },
+    "type": "key-step",
+    "title": "Areas Span (0,∞): Monicity Is Essential",
+    "content": "The area map R ↦ π·R² is onto (0,∞): every target area A > 0 is realised at radius R = √(A/π) (Real.sq_sqrt, div_mul_cancel₀), and taking A = ε/2 makes the area smaller than any ε > 0 (ENNReal.ofReal_lt_ofReal_iff). So the infimum of single-root lemniscate areas over all non-monic polynomials is 0. The capstone packages monic ⇒ π against this surjectivity and unboundedness below: the finite positive value μ({c}) = π is a consequence of the monic normalization.",
+    "mathContext": "$R \\mapsto \\pi R^2$ onto $(0,\\infty)$; $\\inf$ over non-monic single-root polynomials $= 0$.",
+    "significance": "key",
+    "relatedConcepts": ["surjectivity", "Real.sqrt", "infimum", "normalization", "extremal problem"]
+  }
+]

--- a/src/data/proofs/erdos-1040-oq-03-oq-02/meta.json
+++ b/src/data/proofs/erdos-1040-oq-03-oq-02/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "erdos-1040-oq-03-oq-02",
+  "title": "Why Erdős #1040 Fixes the Leading Coefficient: Monic Normalization Pins the Single-Point Lemniscate Area to π",
+  "slug": "erdos-1040-oq-03-oq-02",
+  "description": "Follow-up oq-02 to the elementary area-bounds companion of Erdős Problem #1040 (oq-03), and a complement to the monic π-witness oq-01. The infimum studied by Erdős #1040, μ(F) = inf of area{|f|<1} over MONIC polynomials with roots in F, depends crucially on the monic normalization. This entry isolates that dependence for the single-point root set F = {c}. Rescaling the pure power by a positive real R, f_R(z) = ((z - c)/R)^n = R^{-n}(z - c)^n, keeps the single root c of multiplicity n but changes the leading coefficient to R^{-n} (monic exactly when R = 1). Its lemniscate is exactly the disc of radius R: {z : |f_R(z)| < 1} = {z : |z - c| < R} = B(c, R), of area exactly π·R². Letting R range over (0, ∞): the monic case R = 1 gives area exactly π (the oq-01 value), while the area map R ↦ π·R² is ONTO (0, ∞), so dropping monicity every positive area is realised and the areas become arbitrarily small. Hence the infimum over all (not necessarily monic) single-root polynomials is 0, and the finite positive value π in μ({c}) is a consequence of the monic normalization. Axiom-free, self-contained, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1040OQ03OQ02.lean",
+    "tags": [
+      "complex-analysis",
+      "potential-theory",
+      "polynomials",
+      "lemniscates",
+      "measure-theory",
+      "geometry",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 142,
+    "assumptions": "None. All nine theorems are axiom-free and self-contained: lemniscates are taken of bare functions ℂ → ℂ (lemOf), so no polynomial-structure scaffolding and no dependence on the parent entry's open transfinite-diameter question. No native_decide is used (so no Lean.ofReduceBool). Build NOT kernel-verified this session (Docker daemon unavailable, as in prior sessions); all Mathlib signatures (Complex.volume_ball, norm_pow, norm_div, Complex.norm_real, Real.norm_eq_abs, pow_lt_one_iff_of_nonneg, div_lt_one, div_nonneg, norm_nonneg, abs_of_pos, ENNReal.ofReal_pow, ENNReal.ofReal_mul, ENNReal.ofReal_coe_nnreal, NNReal.coe_real_pi, ENNReal.ofReal_pos, ENNReal.ofReal_lt_ofReal_iff, Real.sqrt_pos, Real.sq_sqrt, div_mul_cancel₀, Real.pi_pos, Real.pi_ne_zero, div_pos, half_pos, dist_eq_norm, Metric.mem_ball) were checked against Mathlib v4.26.0 source. The deployer build-gate is the final check before merge.",
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "lemOf: the lemniscate (open sub-level set) {z : ‖f z‖ < 1} of a bare function f : ℂ → ℂ — no polynomial scaffolding, keeping the entry self-contained",
+      "scaledPure: the rescaled pure power f_R(z) = ((z - c)/R)^n = R^{-n}(z - c)^n, a single-root degree-n polynomial whose leading coefficient R^{-n} is the only thing varied (monic exactly when R = 1)",
+      "lemOf_scaledPure_eq_ball: the central identity — for R > 0, n ≥ 1 the rescaled-pure-power lemniscate equals the disc B(c, R) exactly, from ‖((z-c)/R)^n‖ = (‖z-c‖/R)^n and pow_lt_one_iff_of_nonneg then div_lt_one",
+      "volume_lemOf_scaledPure: the exact area π·R² for every R > 0, n ≥ 1 (Complex.volume_ball at radius R, with ENNReal.ofReal bookkeeping)",
+      "volume_lemOf_monic: the monic case R = 1 has area exactly π for every degree — the oq-01 value recovered as the single point R = 1 of the area function",
+      "volume_lemOf_scaledPure_pos: every rescaled-pure-power lemniscate has strictly positive area (the π·R² values fill (0,∞) from below by positivity)",
+      "area_surjective: SURJECTIVITY — every target area A > 0 is realised by a single-root degree-n polynomial, namely the rescaling at radius R = √(A/π)",
+      "area_arbitrarily_small: UNBOUNDEDNESS BELOW — without monicity the lemniscate area can be made smaller than any ε > 0, so the infimum over all single-root polynomials is 0",
+      "monic_normalization_essential: capstone — monic ⇒ exact area π, yet non-monic single-root areas realise every positive value and become arbitrarily small, so the finite positive μ({c}) = π is a consequence of the monic normalization"
+    ],
+    "theoremCount": 9,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1040 studies μ(F) = inf of the area |{z : |f(z)| < 1}| over MONIC polynomials f with roots in a closed set F ⊆ ℂ, asking whether μ(F) is governed by the transfinite diameter of F. The monic constraint is not incidental: the lemniscate {|f| < 1} = {|λf| < 1/|λ|} scales with the leading coefficient, so without normalization the area can be made anything. The companion oq-03 proved the elementary metric upper bounds area ≤ degree·π and area ≤ 4π, and oq-01 exhibited the monic pure power (z - c)^n as a sharp π-area witness with μ({c}) ≤ π. The natural structural question is what role the monic normalization itself plays in producing that finite positive value.",
+    "problemStatement": "Follow-up oq-02: for the single-point root set F = {c}, what happens to the lemniscate-area infimum if the monic normalization in Erdős #1040 is dropped? This entry shows that monicity is exactly what pins the value to π — without it the infimum is 0.",
+    "proofStrategy": "Vary only the leading coefficient. For f_R(z) = ((z - c)/R)^n with R > 0, compute ‖f_R(z)‖ = (‖z - c‖/R)^n (norm_pow, norm_div, Complex.norm_real), so |f_R(z)| < 1 ⟺ ‖z - c‖/R < 1 ⟺ ‖z - c‖ < R (pow_lt_one_iff_of_nonneg then div_lt_one). Hence the lemniscate is exactly B(c, R), and Complex.volume_ball gives area π·R² (ENNReal.ofReal bookkeeping via ofReal_pow / ofReal_mul). The monic case R = 1 yields π. For surjectivity onto (0,∞), choosing R = √(A/π) gives area A (Real.sq_sqrt, div_mul_cancel₀); taking A = ε/2 makes the area arbitrarily small (ENNReal.ofReal_lt_ofReal_iff), so the unconstrained single-root infimum is 0.",
+    "keyInsights": [
+      "The lemniscate of a polynomial scales with its leading coefficient: rescaling f(z) = (z - c)^n by R^{-n} dilates the unit disc B(c,1) to B(c,R), and the area π scales to π·R². So the single number that the monic normalization fixes is precisely the size of the lemniscate.",
+      "Monicity is the load-bearing hypothesis behind μ({c}) = π. Among single-root degree-n polynomials, ONLY the monic one (R = 1) is forced to area π; the rest realise every positive value, so the infimum over the un-normalized family collapses to 0.",
+      "The area function R ↦ π·R² is a bijection (0,∞) → (0,∞): single-root lemniscate areas are completely unconstrained once the leading coefficient is free, both arbitrarily large and arbitrarily small.",
+      "The phenomenon is purely metric — multiplicativity of the norm on powers and the area of a disc of radius R — so it is fully axiom-free and needs no polynomial-structure machinery, only the bare sub-level set lemOf."
+    ],
+    "prerequisites": [
+      "Lebesgue measure on ℂ: Complex.volume_ball (area of a metric ball of radius r is .ofReal r² · π)",
+      "Multiplicativity of the norm on powers and quotients (norm_pow, norm_div) and the norm of a real scalar (Complex.norm_real)",
+      "The order facts t^n < 1 ⟺ t < 1 for t ≥ 0, n ≠ 0 (pow_lt_one_iff_of_nonneg) and a/b < 1 ⟺ a < b for b > 0 (div_lt_one)",
+      "Real square roots (Real.sqrt_pos, Real.sq_sqrt) and ENNReal.ofReal arithmetic (ofReal_pow, ofReal_mul, ofReal_lt_ofReal_iff)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "§I: The Bare Lemniscate and the Rescaled Pure Power",
+      "startLine": 44,
+      "endLine": 61,
+      "summary": "Defines lemOf f = {z : ‖f z‖ < 1} for a bare function f : ℂ → ℂ, and scaledPure R c n = the rescaled pure power ((z - c)/R)^n with leading coefficient R^{-n}; the monic case R = 1 is the bare pure power (z - c)^n.",
+      "mathContext": "$f_R(z) = ((z - c)/R)^n = R^{-n}(z - c)^n$, monic iff $R = 1$."
+    },
+    {
+      "id": "disc-identity",
+      "title": "§II: Lemniscate = Disc of Radius R",
+      "startLine": 62,
+      "endLine": 73,
+      "summary": "The central identity: for R > 0 and n ≥ 1 the rescaled-pure-power lemniscate equals the open disc B(c, R) exactly, since ‖((z-c)/R)^n‖ = (‖z-c‖/R)^n < 1 ⟺ ‖z-c‖ < R.",
+      "mathContext": "$\\{z : |f_R(z)| < 1\\} = \\{z : |z - c| < R\\} = B(c, R)$."
+    },
+    {
+      "id": "exact-area",
+      "title": "§III: Exact Area π·R² and the Monic Value π",
+      "startLine": 74,
+      "endLine": 100,
+      "summary": "Area of the rescaled-pure-power lemniscate is exactly π·R² (Complex.volume_ball at radius R); the monic case R = 1 gives area exactly π for every degree, and every such area is strictly positive.",
+      "mathContext": "$|B(c, R)| = \\pi R^2$; at $R = 1$, area $= \\pi$ for all $n \\geq 1$."
+    },
+    {
+      "id": "normalization",
+      "title": "§IV: Areas Span (0,∞) and the Capstone",
+      "startLine": 101,
+      "endLine": 142,
+      "summary": "Every positive area A is realised at radius R = √(A/π) (surjectivity), and the areas become arbitrarily small, so the un-normalized single-root infimum is 0. The capstone packages monic ⇒ π against surjectivity and unboundedness below: monicity is essential to μ({c}) = π.",
+      "mathContext": "$R \\mapsto \\pi R^2$ is onto $(0,\\infty)$; $\\inf$ over non-monic single-root polynomials $= 0$."
+    }
+  ],
+  "conclusion": {
+    "summary": "For the single-point root set {c}, the monic representative (z - c)^n has lemniscate area exactly π (independent of degree), while dropping the leading-coefficient normalization the rescaled pure powers f_R(z) = ((z - c)/R)^n have lemniscate B(c, R) of area π·R², which realises every positive value and becomes arbitrarily small. Hence the infimum of single-root lemniscate areas over all (not necessarily monic) polynomials is 0, and the finite positive value π in Erdős #1040's μ({c}) is a consequence of the monic normalization. Axiom-free, self-contained, 0 sorries.",
+    "openQuestions": [
+      "Beyond the single-point case, does fixing the leading coefficient to 1 already determine a positive lower bound on area{|f| < 1} for every monic f — i.e. can Pólya's area ≥ π (the monic single-point lower bound) be formalized to upgrade μ({c}) ≤ π to equality?",
+      "For two distinct prescribed roots {a, b}, does an analogous scaling analysis combined with the exact Cassini/Bernoulli-lemniscate area of {|（z - a)(z - b)| < 1} pin down the monic two-point infimum?"
+    ],
+    "implications": "Explains a structural feature of Erdős #1040's definition: the monic normalization is not a cosmetic convention but the hypothesis that makes the area infimum finite and positive. It complements oq-01 (the monic π-witness) by showing that the same single-root family, un-normalized, has infimum 0, isolating exactly what the normalization buys."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1040-oq-03-oq-01",
+      "relationship": "sibling-followup",
+      "description": "The monic pure-power π-area witness — this entry varies its leading coefficient to show the value π is forced by monicity"
+    },
+    {
+      "targetId": "erdos-1040-oq-03",
+      "relationship": "parent-problem",
+      "description": "Elementary area bounds area ≤ degree·π and area ≤ 4π for polynomial lemniscates"
+    },
+    {
+      "targetId": "erdos-1040",
+      "relationship": "related-problem",
+      "description": "Erdős Problem #1040: transfinite diameter and the monic-polynomial area infimum μ(F) of lemniscates"
+    }
+  ],
+  "references": [
+    {
+      "author": "Pólya, G.",
+      "title": "Beitrag zur Verallgemeinerung des Verzerrungssatzes auf mehrfach zusammenhängende Gebiete",
+      "year": 1928,
+      "note": "Sharp inequality: the area of {z : |f(z)| ≤ 1} for MONIC degree-n f is at most π — the monic normalization is what makes such a bound possible"
+    },
+    {
+      "author": "Erdős, P., Herzog, F. and Piranian, G.",
+      "title": "Metric properties of polynomials",
+      "year": 1958,
+      "note": "Foundational study of lemniscate geometry"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1040OQ03OQ02",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1040OQ03OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Follow-up **oq-02** to the elementary area-bounds companion of Erdős Problem #1040 (oq-03), complementing the monic π-witness **oq-01** (PR #28418).

Erdős #1040 studies the infimum `μ(F) = inf { area{|f|<1} : f monic, roots ⊆ F }`, taken over **monic** polynomials. This entry isolates *why* the monic normalization matters, for the single-point root set `F = {c}`.

Rescaling the pure power by `R > 0`,
```
f_R(z) = ((z - c)/R)^n = R^{-n}(z - c)^n      (leading coefficient R^{-n})
```
keeps the single root `c` of multiplicity `n` but varies only the leading coefficient. Its lemniscate is exactly the disc of radius `R`:
```
{z : |f_R(z)| < 1} = {z : |z - c| < R} = B(c, R),   area = π·R².
```

**Consequences**
- **Monic ⇒ π.** `R = 1` (the monic pure power) gives area exactly π, every degree — the oq-01 value, recovered as the point `R = 1` of the area function `R ↦ π·R²`.
- **Without monicity, unconstrained.** The map `R ↦ π·R²` is *onto* `(0,∞)`: every positive area is realised (`area_surjective`, at `R = √(A/π)`) and the areas become arbitrarily small (`area_arbitrarily_small`). So the infimum over all (non-monic) single-root polynomials is **0**.

Hence the finite positive value π in `μ({c})` is a **consequence of the monic normalization** — not a cosmetic convention. This explains a structural feature of the problem's definition.

## Stats
- **9 theorems / 2 definitions / 142 lines**, **0 sorries**, **0 axioms**, self-contained.
- Lemniscates of bare functions `ℂ → ℂ` (`lemOf`); no dependence on the parent's open transfinite-diameter question.
- No `native_decide` (no `Lean.ofReduceBool`).

## Verification
Signature-verified against **Mathlib v4.26.0** source (`Complex.volume_ball`, `norm_pow`/`norm_div`/`Complex.norm_real`, `pow_lt_one_iff_of_nonneg`, `div_lt_one`, `ENNReal.ofReal_pow`/`ofReal_mul`/`ofReal_lt_ofReal_iff`, `Real.sq_sqrt`, `div_mul_cancel₀`, …). **Docker daemon unavailable this session**, so not kernel-checked locally — the deployer build-gate is the final check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)