### PR TITLE
Enrich Erdős #1039 OQ-3: conformal inscribed-disc bound

### DIFF
--- a/src/data/proofs/erdos-1039-oq-03/index.ts
+++ b/src/data/proofs/erdos-1039-oq-03/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1039Conformal.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1039Oq03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1039Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1039Oq03Data: ProofData = {
+  proof: erdos1039Oq03Proof,
+  annotations: erdos1039Oq03Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-1039-oq-03` (the conformal/Cauchy–Schwarz route to bounding ρ(f), and its critical-point obstruction).

## Gaps closed
The entry had a rich `meta.json` but was missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" on the live site (no Vite glob discovery) and had zero inline annotations.

## Changes
- **`index.ts`** — added so the proof loads on the live site (imports meta, annotations, and raw Lean source `Erdos1039Conformal.lean`).
- **`annotations.json`** — 8 inline annotations spanning the full file:
  - the sublevel set (lemniscate interior)
  - the Cauchy/Schwarz derivative estimate (unit codomain)
  - the open→closed boundary bridge
  - the inscribed-disc derivative bound `|f'(c)| ≤ 1/r`
  - the radius form `r ≤ 1/|f'(c)|` (the "direct conformal estimate" of oq-03)
  - the monic-polynomial specialization (`rootPoly`, entirety via `fun_prop`)
  - the polynomial inscribed-radius bound
  - the critical-point obstruction (witness `f ≡ 0`, why KLR use the area approach)

  Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 8 annotations align to Lean constructs (0 misaligned for this entry). Axiom integrity unchanged: `verified` / `original` / 0 axioms / 0 sorries, consistent with the Lean source.

Branch named per-target to avoid collision with the shared agent branch.