### PR TITLE
research(fibonacci-identities-oq-01-oq-02): d'Ocagne's identity for Fibonacci numbers

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2718,6 +2718,7 @@ import Proofs.FeuerbachsTheoremOQ02Aristotle
 import Proofs.FeuerbachsTheoremOQ05
 import Proofs.FibonacciIdentities
 import Proofs.FibonacciIdentitiesOQ01
+import Proofs.FibonacciIdentitiesOQ01OQ02
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ03
 import Proofs.FibonacciIdentitiesOQ04

--- a/proofs/Proofs/FibonacciIdentitiesOQ01OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ01OQ02.lean
@@ -1,0 +1,114 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+
+/-
+# d'Ocagne's Identity for Fibonacci Numbers
+
+## What This Proves
+
+With `Fₙ = Nat.fib n` the Fibonacci sequence (`F₀ = 0, F₁ = 1, Fₙ₊₂ = Fₙ + Fₙ₊₁`),
+**d'Ocagne's identity** is the exact two-index relation
+
+    Fₘ · Fₙ₊₁ − Fₘ₊₁ · Fₙ = (−1)ⁿ · Fₘ₋ₙ      (m ≥ n, over ℤ).
+
+It expresses the `2×2` "cross determinant" of two windows of the Fibonacci
+sequence in terms of a single Fibonacci number `Fₘ₋ₙ`, with a sign that
+alternates with `n`.  It is the genuine two-parameter generalisation of
+Cassini's identity, which is the special case `m = n + 1`
+(`Fₙ₊₁² − Fₙ₊₂·Fₙ = (−1)ⁿ`, since `F₁ = 1`).
+
+To avoid natural-number subtraction, the headline lemma is phrased with the
+gap `d = m − n` made explicit, `m = n + d`:
+
+    F_{n+d} · F_{n+1} − F_{n+d+1} · F_n = (−1)ⁿ · F_d.
+
+For example (`n = 1`):
+- `d = 1`: `F₂·F₂ − F₃·F₁ = 1·1 − 2·1 = −1 = (−1)¹·F₁`
+- `d = 2`: `F₃·F₂ − F₄·F₁ = 2·1 − 3·1 = −1 = (−1)¹·F₂`
+- `d = 3`: `F₄·F₂ − F₅·F₁ = 3·1 − 5·1 = −2 = (−1)¹·F₃`
+
+## Approach
+
+Pure induction on `n` (with the gap `d` held fixed), cast to `ℤ` so the
+alternating sign `(−1)ⁿ` is available.  The base case `n = 0` is immediate
+(`F₀ = 0`, `F₁ = 1`).  In the successor step the recurrence
+`Nat.fib_add_two : Fₖ₊₂ = Fₖ + Fₖ₊₁` (cast to ℤ) rewrites the two terms
+introduced at `n = k+1` — both the inner index `k+2` and the shifted index
+`k+d+2` — and a single `linear_combination (-1) * ih` closes the algebra: each
+step negates the previous determinant, which is exactly `(−1)ᵏ → (−1)ᵏ⁺¹`.  The
+key cancellation is `F_{k+d+1}·F_{k+1} − F_{k+d}·F_{k+2}` collapsing (via the
+two recurrences) to `−(F_{k+d}·F_{k+1} − F_{k+d+1}·F_k)`.
+
+No `decide`/`native_decide` is used, so the proof is axiom-free (only Mathlib's
+foundational axioms).
+
+## Distinctness
+
+This is the second open question of the `fibonacci-identities-oq-01` (Cassini)
+entry.  Mathlib has the recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, etc.,
+but **no** d'Ocagne (cross-window determinant) identity, and the parent entry
+proves only Cassini (`m = n + 1`).  The sibling `oq-01-oq-01` covers Catalan's
+identity (`F_{n−r}·F_{n+r} − Fₙ²`), a *single*-window generalisation; d'Ocagne
+is the *two*-window cross identity, and the final theorem here shows Cassini is
+its `d = 1` specialisation.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (beyond Mathlib's foundational set)
+-/
+
+namespace FibonacciIdentitiesOQ01OQ02
+
+open Nat
+
+/-- **d'Ocagne's identity** (gap form, `m = n + d`).  For all `n d : ℕ`,
+
+    F_{n+d} · F_{n+1} − F_{n+d+1} · F_n = (−1)ⁿ · F_d. -/
+theorem fib_docagne (n d : ℕ) :
+    (Nat.fib (n + d) : ℤ) * Nat.fib (n + 1)
+      - (Nat.fib (n + d + 1) : ℤ) * Nat.fib n = (-1) ^ n * Nat.fib d := by
+  induction n with
+  | zero => simp [Nat.fib_zero, Nat.fib_one]
+  | succ k ih =>
+    -- Normalise the indices appearing at the successor step.
+    have idx3 : k + 1 + d + 1 = k + d + 2 := by omega
+    have idx1 : k + 1 + d = k + d + 1 := by omega
+    have idx2 : k + 1 + 1 = k + 2 := by omega
+    rw [idx3, idx1, idx2]
+    -- The two Fibonacci terms introduced at this step, via the recurrence.
+    have e1 : (Nat.fib (k + 2) : ℤ) = Nat.fib k + Nat.fib (k + 1) := by
+      exact_mod_cast Nat.fib_add_two (n := k)
+    have e2 : (Nat.fib (k + d + 2) : ℤ) = Nat.fib (k + d) + Nat.fib (k + d + 1) := by
+      exact_mod_cast Nat.fib_add_two (n := k + d)
+    rw [pow_succ, e1, e2]
+    linear_combination (-1 : ℤ) * ih
+
+/-- **d'Ocagne's identity** (classical form).  For `n ≤ m`,
+
+    Fₘ · Fₙ₊₁ − Fₘ₊₁ · Fₙ = (−1)ⁿ · F_{m−n}. -/
+theorem fib_docagne_le (m n : ℕ) (h : n ≤ m) :
+    (Nat.fib m : ℤ) * Nat.fib (n + 1)
+      - (Nat.fib (m + 1) : ℤ) * Nat.fib n = (-1) ^ n * Nat.fib (m - n) := by
+  obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le h
+  rw [Nat.add_sub_cancel_left]
+  exact fib_docagne n d
+
+/-- **Cassini is the `d = 1` case of d'Ocagne.**  Specialising the gap to `1`
+(`F₁ = 1`) recovers Cassini's identity `Fₙ₊₁² − Fₙ₊₂·Fₙ = (−1)ⁿ`. -/
+theorem fib_cassini_via_docagne (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - Nat.fib (n + 2) * Nat.fib n = (-1) ^ n := by
+  have h := fib_docagne n 1
+  rw [Nat.fib_one, Nat.cast_one, mul_one] at h
+  have e : (Nat.fib (n + 1 + 1) : ℤ) = Nat.fib (n + 2) := by rfl
+  rw [e] at h
+  linear_combination h
+
+/-! ## Concrete examples -/
+
+-- `n = 1, d = 1`: `F₂·F₂ − F₃·F₁ = −1`
+example : (Nat.fib 2 : ℤ) * Nat.fib 2 - (Nat.fib 3 : ℤ) * Nat.fib 1 = -1 := by decide
+-- `n = 1, d = 3`: `F₄·F₂ − F₅·F₁ = −F₃ = −2`
+example : (Nat.fib 4 : ℤ) * Nat.fib 2 - (Nat.fib 5 : ℤ) * Nat.fib 1 = -(Nat.fib 3 : ℤ) := by decide
+-- `n = 2, d = 2`: `F₄·F₃ − F₅·F₂ = F₂ = 1`
+example : (Nat.fib 4 : ℤ) * Nat.fib 3 - (Nat.fib 5 : ℤ) * Nat.fib 2 = (Nat.fib 2 : ℤ) := by decide
+
+end FibonacciIdentitiesOQ01OQ02

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-02/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "fibonacci-identities-oq-01-oq-02",
+  "title": "d'Ocagne's Identity for Fibonacci Numbers",
+  "slug": "fibonacci-identities-oq-01-oq-02",
+  "description": "d'Ocagne's identity: with Fₙ = Nat.fib n, the cross-window determinant of two Fibonacci windows is a single signed Fibonacci number — Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ over ℤ (m ≥ n). Answers the second open question of the Cassini entry (fibonacci-identities-oq-01). To avoid natural-number subtraction the headline lemma fixes the gap d = m − n: F_{n+d}·F_{n+1} − F_{n+d+1}·F_n = (−1)ⁿ·F_d, proved by a single induction on n (gap held fixed): casting to ℤ exposes the alternating sign, the recurrence Nat.fib_add_two rewrites the two terms (indices k+2 and k+d+2) introduced at the successor step, and one linear_combination (-1)·ih closes the algebra — each step negates the previous determinant. A classical-form corollary fib_docagne_le restores the m ≥ n / Fₘ₋ₙ statement, and fib_cassini_via_docagne recovers Cassini as the d = 1 specialisation (F₁ = 1). d'Ocagne's identity is absent from Mathlib (which has the recurrence, fib_add, fib_two_mul, fib_gcd, but no cross-window determinant identity); it is the two-window generalisation of Cassini, complementary to the single-window Catalan identity of sibling oq-01-oq-01.",
+  "meta": {
+    "author": "Maurice d'Ocagne (1885); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Other_identities",
+    "date": "1885",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "docagne",
+      "cassini",
+      "recurrence",
+      "induction",
+      "determinant",
+      "integer-sequences",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ01OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence, cast to ℤ to rewrite the two terms (indices k+2 and k+d+2) introduced at the successor step",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.exists_eq_add_of_le",
+        "description": "n ≤ m → ∃ d, m = n + d — reduces the classical m ≥ n form to the gap form by substituting m = n + d",
+        "module": "Mathlib.Algebra.Order.Sub"
+      },
+      {
+        "theorem": "Nat.add_sub_cancel_left",
+        "description": "(n + d) − n = d — recovers Fₘ₋ₙ = F_d after the gap substitution",
+        "module": "Mathlib.Algebra.Group.Basic"
+      },
+      {
+        "theorem": "Nat.fib_zero / Nat.fib_one",
+        "description": "fib 0 = 0, fib 1 = 1 — base values discharging the n = 0 case by simp",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fib_docagne: ∀ n d, (fib (n+d) : ℤ)·fib (n+1) − (fib (n+d+1) : ℤ)·fib n = (−1)ⁿ·fib d — d'Ocagne's identity in gap form (m = n + d), absent from Mathlib",
+      "fib_docagne_le: ∀ m n, n ≤ m → (fib m : ℤ)·fib (n+1) − (fib (m+1) : ℤ)·fib n = (−1)ⁿ·fib (m − n) — the classical m ≥ n / Fₘ₋ₙ statement",
+      "fib_cassini_via_docagne: ∀ n, (fib (n+1) : ℤ)² − fib (n+2)·fib n = (−1)ⁿ — Cassini recovered as the d = 1 specialisation of d'Ocagne, showing d'Ocagne strictly generalises the parent identity"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 114,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used in the universally-quantified theorems (the three trailing decide examples are concrete numeric checks only).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "d'Ocagne's identity, attributed to Maurice d'Ocagne (1885), is the two-index 'cross-window' companion to Cassini's identity. Where Cassini measures the determinant of three consecutive terms, d'Ocagne measures the cross determinant Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ of two windows starting at m and n, and collapses it to the single signed Fibonacci number (−1)ⁿ·Fₘ₋ₙ. It sits alongside Catalan's identity in the classical hierarchy of Fibonacci determinant identities, all of which specialise to Cassini.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-01, second question)**: Prove d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ.\n\n**Result**: fib_docagne (gap form F_{n+d}·F_{n+1} − F_{n+d+1}·F_n = (−1)ⁿ·F_d), the classical-form corollary fib_docagne_le for n ≤ m, and fib_cassini_via_docagne recovering Cassini as the case d = 1.",
+    "text": "For all n and d (with m = n + d), working over ℤ, F_{n+d}·F_{n+1} − F_{n+d+1}·F_n = (−1)ⁿ·F_d, where Fₙ = Nat.fib n. Equivalently, for n ≤ m, Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ: the cross determinant of two Fibonacci windows is a single signed Fibonacci number.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Cast to ℤ and phrase with the gap d = m − n explicit (m = n + d) to avoid natural-number subtraction; the alternating sign (−1)ⁿ then lives in ℤ.\n2. Induct on n with the gap d held fixed. Base case n = 0: F_d·F₁ − F_{d+1}·F₀ = F_d·1 − F_{d+1}·0 = F_d = (−1)⁰·F_d, closed by simp on fib_zero/fib_one.\n3. Successor step at k+1: normalise the three composite indices (k+1+d+1, k+1+d, k+1+1) to (k+d+2, k+d+1, k+2) by omega, cast the recurrence twice — e1: fib (k+2) = fib k + fib (k+1), e2: fib (k+d+2) = fib (k+d) + fib (k+d+1) — expand pow_succ, and close with `linear_combination (-1) * ih`. Algebraically the new cross determinant is exactly the negation of the previous one, matching (−1)ᵏ → (−1)ᵏ⁺¹.\n4. fib_docagne_le substitutes m = n + d via Nat.exists_eq_add_of_le and rewrites (n+d)−n = d. fib_cassini_via_docagne specialises d = 1 (F₁ = 1), recovering Cassini.",
+    "keyInsights": [
+      "**Fix the gap, induct on the offset.** Holding d = m − n fixed and inducting on n turns a two-index identity into a one-variable induction with the same sign-flip structure as Cassini — the gap appears only as a passive parameter in the recurrence rewrites.",
+      "**The step is again a sign flip.** As in Cassini, the successor cross determinant F_{k+d+1}·F_{k+1} − F_{k+d}·F_{k+2} collapses (via two recurrence substitutions) to the negation of the previous one, so a single linear_combination with coefficient −1 closes the algebra.",
+      "**Cassini is a corollary, not a cousin.** Setting d = 1 (F₁ = 1) turns d'Ocagne into Cassini, so this entry strictly generalises the parent — and the file proves that specialisation explicitly as fib_cassini_via_docagne.",
+      "**Not in Mathlib.** Mathlib carries the recurrence, fib_add, fib_two_mul, and fib_gcd, but no cross-window determinant identity, so d'Ocagne (in both gap and classical forms) is an original contribution."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two and base values fib_zero/fib_one",
+      "Induction over ℕ with a held parameter, and casting ℕ → ℤ (exact_mod_cast)",
+      "Nat.exists_eq_add_of_le and Nat.add_sub_cancel_left for the gap substitution",
+      "The linear_combination tactic for closing polynomial identities against a hypothesis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring stating d'Ocagne's identity in gap and classical forms with worked numerical examples, the Fibonacci/tactic imports, namespace, and open Nat.",
+      "mathContext": "$F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$, with $F_0=0, F_1=1, F_{n+2}=F_n+F_{n+1}$."
+    },
+    {
+      "id": "docagne",
+      "title": "d'Ocagne's Identity (gap form)",
+      "startLine": 64,
+      "endLine": 86,
+      "summary": "fib_docagne: the main theorem in the form F_{n+d}·F_{n+1} − F_{n+d+1}·F_n = (−1)ⁿ·F_d, proved by induction on n with the gap d fixed — base case by simp, successor step by normalising indices (omega), casting the recurrence twice, and closing with linear_combination (-1)·ih.",
+      "mathContext": "$F_{n+d} F_{n+1} - F_{n+d+1} F_n = (-1)^n F_d$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "docagne-le",
+      "title": "Classical Form (m ≥ n)",
+      "startLine": 88,
+      "endLine": 97,
+      "summary": "fib_docagne_le: the classical Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ statement for n ≤ m, obtained by substituting m = n + d (Nat.exists_eq_add_of_le) and rewriting (n+d)−n = d.",
+      "mathContext": "$F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$ for $n \\le m$."
+    },
+    {
+      "id": "cassini-recover",
+      "title": "Cassini as the d = 1 Case",
+      "startLine": 99,
+      "endLine": 112,
+      "summary": "fib_cassini_via_docagne: specialising the gap to d = 1 (F₁ = 1) recovers Cassini's identity Fₙ₊₁² − Fₙ₊₂·Fₙ = (−1)ⁿ, showing d'Ocagne strictly generalises the parent; followed by concrete numeric examples.",
+      "mathContext": "$F_{n+1}^2 - F_{n+2} F_n = (-1)^n$ (Cassini)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "parent",
+      "description": "Cassini's identity, the parent entry; d'Ocagne is its second open question and strictly generalises it (Cassini is the d = 1 case, proved here as fib_cassini_via_docagne)"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-01-oq-01",
+      "relationship": "sibling",
+      "description": "Catalan's identity (single-window generalisation Fₙ₋ᵣFₙ₊ᵣ − Fₙ²); d'Ocagne is the complementary two-window cross identity from the same parent"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ over ℤ, in both the gap form (m = n + d) and the classical m ≥ n form, by a single induction using only the Fibonacci recurrence; Cassini is recovered as the d = 1 specialisation.",
+    "implications": "Supplies the cross-window determinant identity for Fibonacci numbers — the two-index companion to Cassini and Catalan — as a universally quantified theorem absent from Mathlib, and exhibits Cassini explicitly as a corollary.",
+    "openQuestions": [
+      "Prove Catalan's identity Fₙ₋ᵣ·Fₙ₊ᵣ − Fₙ² = (−1)ⁿ⁻ʳ·Fᵣ² and exhibit both Cassini and a Catalan↔d'Ocagne bridge from a common addition-formula lemma.",
+      "Establish the Lucas-number d'Ocagne analogue Lₘ·Lₙ₊₁ − Lₘ₊₁·Lₙ = (−1)ⁿ·5·Fₘ₋ₙ (or the mixed Fibonacci–Lucas form) and compare signs."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FibonacciIdentitiesOQ01OQ02",
+    "lineCount": 114,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "d'Ocagne's, Catalan's, and Cassini's identities and their interrelations"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "d'Ocagne's identity and the family of Fibonacci determinant identities"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **d'Ocagne's identity** for Fibonacci numbers — the second open question of the Cassini entry (`fibonacci-identities-oq-01`):

$$F_m \cdot F_{n+1} - F_{m+1} \cdot F_n = (-1)^n \cdot F_{m-n} \quad (m \ge n, \text{ over } \mathbb{Z}).$$

This is the two-window **cross-determinant** companion to Cassini (single window, three consecutive terms) and to Catalan (single-window generalisation, sibling `oq-01-oq-01`). Absent from Mathlib.

## Theorems (3, 0 defs, 114 lines)

- **`fib_docagne`** — gap form $F_{n+d}\,F_{n+1} - F_{n+d+1}\,F_n = (-1)^n F_d$ (with $m = n+d$ to avoid ℕ subtraction). Single induction on $n$ with the gap $d$ held fixed: cast to ℤ exposes the alternating sign, `Nat.fib_add_two` rewrites the two terms introduced at the successor step (indices $k+2$, $k+d+2$), and `linear_combination (-1)·ih` closes the algebra — each step negates the previous determinant.
- **`fib_docagne_le`** — classical $n \le m$ / $F_{m-n}$ form via `Nat.exists_eq_add_of_le`.
- **`fib_cassini_via_docagne`** — recovers Cassini $F_{n+1}^2 - F_{n+2}F_n = (-1)^n$ as the $d=1$ case, showing d'Ocagne strictly generalises the parent.

## Verification

- **Status: `verified`** — 0 sorries, 0 axioms.
- `#print axioms` on all three theorems reports only `propext, Classical.choice, Quot.sound`. No `native_decide` / `Lean.ofReduceBool` in the universally-quantified theorems (trailing `decide` examples are concrete numeric checks only).
- Kernel-verified via `lake env lean` over cached Mathlib oleans (Docker build environment was wedged this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)