### PR TITLE
Enrich Carnot's Theorem sine-sum uniqueness (oq-01-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CarnotTheoremOQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const carnotTheoremOq01Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const carnotTheoremOq01Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const carnotTheoremOq01Oq03Oq01Data: ProofData = {
+  proof: carnotTheoremOq01Oq03Oq01Proof,
+  annotations: carnotTheoremOq01Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `carnot-theorem-oq-01-oq-03-oq-01` (the equilateral triangle is the *unique* maximiser of sin A + sin B + sin C).

## Gaps closed
The entry had a rich `meta.json` but was missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" on the live site (no Vite glob discovery) and had zero inline annotations.

## Changes
- **`index.ts`** — added so the proof loads on the live site (imports meta, annotations, and raw Lean source `CarnotTheoremOQ01OQ03OQ01.lean`).
- **`annotations.json`** — 6 inline annotations spanning the full file:
  - the strict-Jensen equality lemma `sin_jensen_eq_imp_eq` (the uniqueness engine)
  - the uniqueness statement `sin A + sin B + sin C = 3√3/2 ↔ A=B=C=π/3`
  - the two ordinary Jensen steps reaching the barycentre π/3
  - the slack-balance tightness argument (saturation forces both steps tight)
  - decoding tightness to the equilateral angles via the lemma
  - the converse (evaluation at the equilateral triangle)

  Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 6 annotations align to Lean constructs (0 misaligned for this entry). Axiom integrity unchanged: `verified` / `original` / 0 axioms / 0 sorries, consistent with the Lean source.

Branch named per-target to avoid collision with concurrent agents on the shared branch.