### PR TITLE
Zolotarev QR: formalize & kernel-verify the Shurman three-transition assembly skeleton

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
@@ -573,6 +573,44 @@ theorem sign_affineLine_eq_legendreSym {p : ℕ} [hp : Fact p.Prime] (hp2 : p �
       ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd hodd a A hA,
       jacobiSym.legendreSym.to_jacobiSym]
 
+/-- **Collapse of the per-line signs over a residue array.**
+
+    Let `p` be an odd prime and `q` an odd number.  Consider a permutation of the
+    array `ZMod p × ZMod q` that acts *fiberwise over the `ZMod q` factor* as the
+    affine line map `x ↦ a·x + β k` on the `ZMod p` factor, i.e.
+
+        `prodCongrLeft (fun k : ZMod q => addLeft (β k) * ringMulPerm a)`.
+
+    Its total sign is the *single* per-line Legendre symbol `(A / p)`:
+    `sign_prodCongrLeft` turns the sign into the product of the `q` fiber signs;
+    each fiber sign is `(A/p)` (translation is even, `sign_affineLine_eq_legendreSym`);
+    and the `q`-fold product `(A/p)^q` collapses to `(A/p)` because `q` is odd and
+    the sign is a unit (`units_pow_odd`).
+
+    This is exactly the "`sign_prodCongrLeft` collapses the `q`-fold product" step
+    flagged at the end of the file header.  Together with the CRT identification of
+    each transition `τ_rd`, `τ_cd` as such a fiberwise-affine permutation, it
+    discharges the two hypotheses of `quadratic_reciprocity_of_transition_signs`;
+    the *only* remaining gap is that purely combinatorial identification. -/
+theorem sign_prodCongrLeft_affineLine {p q : ℕ} [hp : Fact p.Prime] [NeZero q]
+    (hp2 : p ≠ 2) (hq : Odd q) (a : (ZMod p)ˣ) (β : ZMod q → ZMod p)
+    (A : ℤ) (hA : (A : ZMod p) = (a : ZMod p)) :
+    (Equiv.Perm.sign (Equiv.prodCongrLeft
+        (fun k : ZMod q => Equiv.addLeft (β k) * ringMulPerm a)) : ℤ)
+      = legendreSym p A := by
+  haveI : NeZero p := ⟨hp.out.pos.ne'⟩
+  have hodd : Odd p := hp.out.odd_of_ne_two hp2
+  rw [Equiv.Perm.sign_prodCongrLeft]
+  -- every fiber sign collapses (translation is even) to `sign (ringMulPerm a)`.
+  have hfib : (fun k : ZMod q => Equiv.Perm.sign (Equiv.addLeft (β k) * ringMulPerm a))
+      = fun _ : ZMod q => Equiv.Perm.sign (ringMulPerm a) :=
+    funext fun k => sign_addLeft_mul hodd (β k) (ringMulPerm a)
+  rw [hfib, Finset.prod_const, Finset.card_univ, ZMod.card q,
+      ZolotarevCRT.units_pow_odd _ hq]
+  -- the surviving single line is the `b = 0` instance of the affine-line sign.
+  have h0 := sign_affineLine_eq_legendreSym hp2 a 0 A hA
+  rwa [sign_addLeft_mul hodd 0 (ringMulPerm a)] at h0
+
 end ZolotarevQR
 
 #check @ZolotarevQR.gridTranspose
@@ -586,3 +624,4 @@ end ZolotarevQR
 #check @ZolotarevQR.sign_addLeft_odd
 #check @ZolotarevQR.sign_addLeft_mul
 #check @ZolotarevQR.sign_affineLine_eq_legendreSym
+#check @ZolotarevQR.sign_prodCongrLeft_affineLine

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
@@ -112,9 +112,23 @@
   Discharging the two hypotheses `sign τ_cd = (p/q)`, `sign τ_rd = (q/p)` for the
   concrete CRT order `D` (Shurman §3): `D⁻¹∘C` fixes each row and acts on it by
   `y ↦ p·y + x mod q`, a multiplication-by-`p` permutation of `ℤ/q` up to an
-  even (odd-length-cycle) translation, whose sign is `(p/q)` by the already-proved
-  `ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd` (`= legendreSym` at a
-  prime).  This is the remaining number-theoretic step.
+  even (odd-length-cycle) translation, whose sign is `(p/q)`.
+
+  The *per-line number-theoretic step* is now PROVED in this file as
+  `sign_affineLine_eq_legendreSym` (§"Per-line Zolotarev sign" below): for an odd
+  prime `m` the sign of the affine permutation `x ↦ a·x + b` of `ℤ/m` is the
+  Legendre symbol `(a / m)`.  The translation summand `x ↦ x + b` is an *even*
+  permutation — it has odd order on the odd-order group `ℤ/m`, so its sign is `+1`
+  (`sign_addLeft_odd`, absent from Mathlib) — and the multiplication factor is
+  Zolotarev's lemma in Frobenius form
+  (`ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd = legendreSym` at a prime).
+
+  What is left is therefore PURELY COMBINATORIAL: identify each transition
+  `D⁻¹∘rowOrder` / `D⁻¹∘colOrder` with `prodCongrLeft` of the per-line affine maps
+  (transported across `Fin m ≃ ℤ/m`), apply `Equiv.Perm.sign_prodCongrLeft` to get
+  the `q`-fold (resp. `p`-fold) product of per-line signs, and collapse it via
+  `(q/p)^q = (q/p)` (an odd power of a `±1` Legendre symbol).  No further
+  Zolotarev/Jacobi input is needed.
 
   References:
   - Zolotarev (1872); Frobenius (1914); Lerch (1896).
@@ -124,6 +138,9 @@
     "card trick" formulation used here).
 -/
 import Mathlib
+-- Zolotarev's lemma in Frobenius form (`sign(x ↦ a·x on ℤ/n) = J(A|n)`, n odd),
+-- used below to discharge the per-residue-line transition signs.
+import Proofs.ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01
 
 set_option maxHeartbeats 800000
 
@@ -494,6 +511,68 @@ theorem quadratic_reciprocity_of_transition_signs
     simpa using hcast
   rwa [hcd, hrd] at hZ
 
+/-! ### Per-line Zolotarev sign: discharging the transition-sign hypotheses
+
+The two hypotheses of `quadratic_reciprocity_of_transition_signs` are *per residue
+line* facts.  For the CRT order `D` (Shurman §3), the transition `D⁻¹∘rowOrder`
+fixes each column `j` and acts on the row index by the **affine** map
+`i ↦ q·i + j (mod p)`; dually `D⁻¹∘colOrder` acts per row by `j ↦ p·j + i (mod q)`.
+The sign of one such affine permutation of `ZMod p` is the Legendre symbol `(q/p)`:
+the translation summand is an *even* permutation — it has odd order on the
+odd-order group `ZMod p`, hence sign `+1` — and the multiplication factor is
+Zolotarev's lemma in Frobenius form
+(`ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd`).  These lemmas supply the
+remaining number-theoretic ingredient flagged in the file header; the only step
+left to make `quadratic_reciprocity_of_transition_signs` unconditional is the
+purely combinatorial identification of each transition with `prodCongrLeft` of
+these affine maps (`sign_prodCongrLeft` then collapses the `q`-fold product since
+`(q/p)^q = (q/p)`). -/
+
+open ZolotarevCRT (ringMulPerm)
+
+/-- `n • b = 0` in `ZMod n`: the additive group has exponent dividing `n`. -/
+private theorem nsmul_self_zmod {n : ℕ} (b : ZMod n) : n • b = 0 := by
+  rw [nsmul_eq_mul, ZMod.natCast_self, zero_mul]
+
+/-- **Translation is an even permutation on an odd-order group.**  For odd `n`,
+    the translation `x ↦ b + x` of `ZMod n` has sign `+1`: its order divides `n`
+    (because `n • b = 0`), so the order is odd, while `sign` lands in the
+    order-`2` group `ℤˣ`; thus an odd power of the sign equals the sign, and that
+    power is `sign 1 = 1`.  (Absent from Mathlib.) -/
+theorem sign_addLeft_odd {n : ℕ} [NeZero n] (hodd : Odd n) (b : ZMod n) :
+    Equiv.Perm.sign (Equiv.addLeft b) = 1 := by
+  set u : ℤˣ := Equiv.Perm.sign (Equiv.addLeft b) with hu
+  have hpow : (Equiv.addLeft b) ^ n = 1 := by
+    rw [pow_addLeft, nsmul_self_zmod, addLeft_zero]
+  have hun : u ^ n = 1 := by rw [hu, ← map_pow, hpow, map_one]
+  rw [← ZolotarevCRT.units_pow_odd u hodd]; exact hun
+
+/-- **Affine sign = multiplication sign on an odd-order group.**  Composing any
+    permutation `P` of `ZMod n` (odd `n`) with a translation leaves the sign
+    unchanged. -/
+theorem sign_addLeft_mul {n : ℕ} [NeZero n] (hodd : Odd n)
+    (b : ZMod n) (P : Equiv.Perm (ZMod n)) :
+    Equiv.Perm.sign (Equiv.addLeft b * P) = Equiv.Perm.sign P := by
+  rw [map_mul, sign_addLeft_odd hodd, one_mul]
+
+/-- **Per-line Zolotarev sign (prime modulus).**  For an odd prime `p`, a unit
+    `a : (ℤ/p)ˣ`, any translation `b`, and any integer representative `A ≡ a
+    (mod p)`, the sign of the affine permutation `x ↦ a·x + b` of `ℤ/p` is the
+    Legendre symbol `(A / p)`.  This combines the translation-parity lemma above
+    with Zolotarev's lemma in Frobenius form
+    (`ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd`), and is exactly the
+    sign of a single residue line of the CRT transition permutations `τ_rd`,
+    `τ_cd`.  It discharges the *per-line* content of the two hypotheses of
+    `quadratic_reciprocity_of_transition_signs`. -/
+theorem sign_affineLine_eq_legendreSym {p : ℕ} [hp : Fact p.Prime] (hp2 : p ≠ 2)
+    (a : (ZMod p)ˣ) (b : ZMod p) (A : ℤ) (hA : (A : ZMod p) = (a : ZMod p)) :
+    (Equiv.Perm.sign (Equiv.addLeft b * ringMulPerm a) : ℤ) = legendreSym p A := by
+  haveI : NeZero p := ⟨hp.out.pos.ne'⟩
+  have hodd : Odd p := hp.out.odd_of_ne_two hp2
+  rw [sign_addLeft_mul hodd b (ringMulPerm a),
+      ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd hodd a A hA,
+      jacobiSym.legendreSym.to_jacobiSym]
+
 end ZolotarevQR
 
 #check @ZolotarevQR.gridTranspose
@@ -504,3 +583,6 @@ end ZolotarevQR
 #check @ZolotarevQR.gridTranspose_eq
 #check @ZolotarevQR.sign_transRC
 #check @ZolotarevQR.quadratic_reciprocity_of_transition_signs
+#check @ZolotarevQR.sign_addLeft_odd
+#check @ZolotarevQR.sign_addLeft_mul
+#check @ZolotarevQR.sign_affineLine_eq_legendreSym

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean
@@ -84,12 +84,44 @@
     `sign (gridTranspose m n) = (-1)^(((m-1)/2)·((n-1)/2))` for odd `m, n`,
     obtained by feeding the parity bridge into `sign_gridTranspose`; now fully
     proved (0 sorry).
-  * The full QR assembly (`α = β ∘ γ`, identifying `α, β` with `ringMulPerm`
-    through the CRT isomorphism) is documented above but not yet formalized.
+  * **QR assembly skeleton (NEW, this file, §"Assembly" below).**  Following the
+    "proof from the book" reworking of Zolotarev's argument (J. Shurman, after
+    Baker 2013), QR is the single relation `sign τ_cd · sign τ_rd = sign τ_rc`
+    among the three *order-transition* permutations of the `p × q` array
+    (row-major `R`, column-major `C`, diagonal/CRT `D`):
+
+        τ_rd = D⁻¹∘R,   τ_cd = D⁻¹∘C,   τ_rc = C⁻¹∘R,     with τ_cd⁻¹∘τ_rd = τ_rc.
+
+    Shurman's signs are `sign τ_cd = (p/q)`, `sign τ_rd = (q/p)` (Zolotarev's
+    lemma applied per residue line) and `sign τ_rc = (-1)^((p-1)/2·(q-1)/2)`
+    (the inversion count — which is exactly `sign_gridTranspose` above, since
+    `τ_rc` IS `gridTranspose p q` transported across `R`).  Substituting yields
+    `(p/q)·(q/p) = (-1)^((p-1)/2·(q-1)/2)`.
+
+    `quadratic_reciprocity_of_transition_signs` below formalizes this skeleton
+    with **0 sorries**: the tautological composition `τ_cd⁻¹∘τ_rd = τ_rc`, the
+    sign-product reduction, and the identification `sign τ_rc = sign gridTranspose`
+    (`sign_transRC`) — reducing QR to the two per-line Zolotarev sign facts,
+    supplied here as hypotheses.  (The PREVIOUS plan above mis-stated the assembly
+    as "α = β∘γ identifying α,β with `ringMulPerm` via the CRT isomorphism"; the
+    correct objects are the three transition permutations, and α,β are NOT
+    `ringMulPerm` on `ℤ/pq` but per-line multiplication maps on `ℤ/q` resp `ℤ/p`.)
+
+  ## What remains
+
+  Discharging the two hypotheses `sign τ_cd = (p/q)`, `sign τ_rd = (q/p)` for the
+  concrete CRT order `D` (Shurman §3): `D⁻¹∘C` fixes each row and acts on it by
+  `y ↦ p·y + x mod q`, a multiplication-by-`p` permutation of `ℤ/q` up to an
+  even (odd-length-cycle) translation, whose sign is `(p/q)` by the already-proved
+  `ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd` (`= legendreSym` at a
+  prime).  This is the remaining number-theoretic step.
 
   References:
   - Zolotarev (1872); Frobenius (1914); Lerch (1896).
   - Cartier; Baker, "Quadratic reciprocity and Zolotarev's Lemma" (2013).
+  - J. Shurman, "Zolotarev's proof of quadratic reciprocity",
+    https://people.reed.edu/~jerry/361/lectures/qrz.pdf (the three-transition
+    "card trick" formulation used here).
 -/
 import Mathlib
 
@@ -373,6 +405,95 @@ theorem sign_gridTranspose_odd {m n : ℕ} (hm : Odd m) (hn : Odd n) :
       = (-1 : ℤˣ) ^ (((m - 1) / 2) * ((n - 1) / 2)) := by
   rw [sign_gridTranspose, neg_one_pow_choose_two_mul_odd hm hn]
 
+/-! ## Assembly: quadratic reciprocity from the three transition signs
+
+The Zolotarev/Shurman "card-trick" skeleton.  The three linear orders on the
+`p × q` array are realized as bijections `Fin p × Fin q ≃ Fin (p*q)`: row-major
+`rowOrder`, column-major `colOrder`, and the diagonal/CRT order (an abstract
+parameter `D` below).  The transition permutations of the array are then
+`τ_rd = D⁻¹∘rowOrder`, `τ_cd = D⁻¹∘colOrder`, `τ_rc = colOrder⁻¹∘rowOrder`, and
+the tautology `τ_cd⁻¹∘τ_rd = τ_rc` is quadratic reciprocity once the three signs
+are known. -/
+
+/-- Row-major order on the `p × q` array: `(i, j) ↦ q·i + j`.  This is the same
+    `finProdFinEquiv` underlying `gridTranspose`. -/
+def rowOrder (p q : ℕ) : Fin p × Fin q ≃ Fin (p * q) := finProdFinEquiv
+
+/-- Column-major order on the `p × q` array: `(i, j) ↦ i + p·j`.  This is exactly
+    the codomain factor of `gridTranspose`, so `gridTranspose = rowOrder⁻¹ ∘ colOrder`
+    holds definitionally (`gridTranspose_eq`). -/
+def colOrder (p q : ℕ) : Fin p × Fin q ≃ Fin (p * q) :=
+  (Equiv.prodComm (Fin p) (Fin q)).trans
+    (finProdFinEquiv.trans (finCongr (Nat.mul_comm q p)))
+
+/-- `gridTranspose p q` is the row→column transition read on linear indices. -/
+theorem gridTranspose_eq (p q : ℕ) :
+    gridTranspose p q = (rowOrder p q).symm.trans (colOrder p q) := rfl
+
+/-- The **row→column transition** permutation of the array, `colOrder⁻¹ ∘ rowOrder`. -/
+def transRC (p q : ℕ) : Equiv.Perm (Fin p × Fin q) :=
+  (rowOrder p q).trans (colOrder p q).symm
+
+/-- The array transition `transRC` and the linear-index shuffle `gridTranspose`
+    are conjugate via `rowOrder`, hence share their sign. -/
+theorem sign_transRC (p q : ℕ) :
+    Equiv.Perm.sign (transRC p q) = Equiv.Perm.sign (gridTranspose p q) := by
+  have h : ∀ x, (rowOrder p q) (transRC p q x)
+      = (gridTranspose p q)⁻¹ ((rowOrder p q) x) := by
+    intro x
+    rw [gridTranspose_eq]
+    simp only [transRC, Equiv.Perm.inv_def, Equiv.trans_apply, Equiv.symm_trans_apply,
+      Equiv.symm_symm]
+  rw [Equiv.Perm.sign_eq_sign_of_equiv (transRC p q) (gridTranspose p q)⁻¹ (rowOrder p q) h,
+    map_inv]
+  rcases Int.units_eq_one_or (Equiv.Perm.sign (gridTranspose p q)) with h2 | h2 <;> simp [h2]
+
+/-- **Quadratic reciprocity via the Zolotarev/Shurman transition skeleton.**
+
+    Let `p, q` be odd primes and `D : Fin p × Fin q ≃ Fin (p*q)` the diagonal
+    (CRT) ordering of the array.  If the row→diagonal and column→diagonal
+    transitions carry the Zolotarev signs `(q/p)` and `(p/q)` (Shurman §3 — each
+    restricts to multiplication permutations on a single residue line, whose sign
+    is a Legendre symbol by Zolotarev's lemma), then the quadratic reciprocity law
+
+        `(p/q)·(q/p) = (-1)^((p-1)/2·(q-1)/2)`
+
+    follows.  The proof is the tautological composition `τ_cd⁻¹∘τ_rd = τ_rc`, the
+    sign-product reduction, the identification `sign τ_rc = sign (gridTranspose)`
+    (`sign_transRC`), and the proven `sign_gridTranspose_odd`.  This reduces QR to
+    the two per-line Zolotarev sign facts, supplied here as hypotheses. -/
+theorem quadratic_reciprocity_of_transition_signs
+    {p q : ℕ} [Fact p.Prime] [Fact q.Prime] (hp : Odd p) (hq : Odd q)
+    (D : Fin p × Fin q ≃ Fin (p * q))
+    (hrd : (Equiv.Perm.sign ((rowOrder p q).trans D.symm) : ℤ) = legendreSym p (q : ℤ))
+    (hcd : (Equiv.Perm.sign ((colOrder p q).trans D.symm) : ℤ) = legendreSym q (p : ℤ)) :
+    legendreSym q (p : ℤ) * legendreSym p (q : ℤ)
+      = (-1 : ℤ) ^ (((p - 1) / 2) * ((q - 1) / 2)) := by
+  set τrd : Equiv.Perm (Fin p × Fin q) := (rowOrder p q).trans D.symm with hτrd
+  set τcd : Equiv.Perm (Fin p × Fin q) := (colOrder p q).trans D.symm with hτcd
+  -- Tautological composition: τ_cd⁻¹ ∘ τ_rd = τ_rc (the `D⁻¹`s cancel).
+  have hcomp : τcd⁻¹ * τrd = transRC p q := by
+    refine Equiv.ext fun z => ?_
+    simp only [hτcd, hτrd, transRC, Equiv.Perm.coe_mul, Function.comp_apply,
+      Equiv.Perm.inv_def, Equiv.symm_trans_apply, Equiv.symm_symm, Equiv.trans_apply,
+      Equiv.apply_symm_apply]
+  -- Sign is multiplicative and `ℤˣ` has exponent 2, so signs multiply.
+  have hsign : Equiv.Perm.sign τcd * Equiv.Perm.sign τrd
+      = Equiv.Perm.sign (transRC p q) := by
+    rw [← hcomp, map_mul, map_inv]
+    have hself : (Equiv.Perm.sign τcd)⁻¹ = Equiv.Perm.sign τcd := by
+      rcases Int.units_eq_one_or (Equiv.Perm.sign τcd) with h | h <;> simp [h]
+    rw [hself]
+  -- Evaluate `sign τ_rc` through `gridTranspose`.
+  rw [sign_transRC, sign_gridTranspose_odd hp hq] at hsign
+  -- Cast the `ℤˣ` identity to `ℤ` and substitute the two Zolotarev signs.
+  have hZ : (Equiv.Perm.sign τcd : ℤ) * (Equiv.Perm.sign τrd : ℤ)
+      = (-1 : ℤ) ^ (((p - 1) / 2) * ((q - 1) / 2)) := by
+    have hcast := congrArg (fun u : ℤˣ => (u : ℤ)) hsign
+    push_cast at hcast
+    simpa using hcast
+  rwa [hcd, hrd] at hZ
+
 end ZolotarevQR
 
 #check @ZolotarevQR.gridTranspose
@@ -380,3 +501,6 @@ end ZolotarevQR
 #check @ZolotarevQR.sign_gridTranspose
 #check @ZolotarevQR.neg_one_pow_choose_two_mul_odd
 #check @ZolotarevQR.sign_gridTranspose_odd
+#check @ZolotarevQR.gridTranspose_eq
+#check @ZolotarevQR.sign_transRC
+#check @ZolotarevQR.quadratic_reciprocity_of_transition_signs

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -272,3 +272,56 @@ formalize its genuinely distinct part — the **QR assembly** (`α=β∘γ`, ide
 2. Integrate the verified proof into the registered file, discharging the lone sorry.
 3. Then formalize the genuinely-missing QR assembly (`α=β∘γ` via CRT) — higher value
    than the blocker, untouched by either gridTranspose thread.
+
+## Session 2026-06-23 (researcher-9, S6) — Per-line affine→Legendre Zolotarev sign PROVED
+
+**Mode**: REVISIT (continuing the assembly skeleton thread)
+**Outcome**: progress — the per-residue-line number-theoretic step is now a
+kernel-verified lemma (0 sorry, axioms `[propext, Classical.choice, Quot.sound]`).
+
+### What I Did
+- Added to the registered file `…OQ02.lean` (now 588L, builds clean) three new
+  theorems discharging the *per-line* content of the two transition-sign
+  hypotheses of `quadratic_reciprocity_of_transition_signs`:
+  - `sign_addLeft_odd {n}[NeZero n] (Odd n) (b) : sign (Equiv.addLeft b) = 1` —
+    **translation is an even permutation on an odd-order group** (absent from
+    Mathlib). Proof: `(addLeft b)^n = addLeft (n•b) = addLeft 0 = 1` (since
+    `n•b=0` in `ZMod n`); `sign` lands in order-2 `ℤˣ`, so an odd power of it
+    equals it, and that power is `sign 1 = 1`. Uses `pow_addLeft`, `addLeft_zero`,
+    parent `ZolotarevCRT.units_pow_odd`.
+  - `sign_addLeft_mul (Odd n)(b)(P) : sign (addLeft b * P) = sign P` — corollary,
+    `map_mul` + the above.
+  - `sign_affineLine_eq_legendreSym {p}[Fact p.Prime](p≠2)(a)(b)(A)(A≡a) :
+    (sign (addLeft b * ringMulPerm a) : ℤ) = legendreSym p A` — **the per-line
+    Zolotarev sign**: affine `x ↦ a·x+b` on `ℤ/p` has sign `(A/p)`. Combines the
+    translation-parity lemma with the parent's Zolotarev–Frobenius identity
+    `ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd` and `jacobiSym.legendreSym.to_jacobiSym`.
+
+### Key Findings
+- The correct per-line model is **affine**, not pure multiplication: `D⁻¹∘rowOrder`
+  acts per column `j` by `i ↦ q·i + j (mod p)` (a translation by `j` after
+  mult-by-`q`). The translation is exactly the part that needed the new even-perm
+  lemma; mult-by-`q` is the parent's already-proven Zolotarev sign.
+- Mathlib has NO translation-sign lemma; the odd-order/odd-power argument is clean
+  (`pow_addLeft` + `units_pow_odd`).
+- `legendreSym.to_jacobiSym` is declared INSIDE `namespace jacobiSym`, so its real
+  name is `jacobiSym.legendreSym.to_jacobiSym` (the bare name is unknown-constant).
+
+### Files Modified
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean`
+  (added per-line section + imports parent `…OQ01OQ01OQ01OQ01OQ01`; header
+  "What remains" updated). Kernel-verified via `lake env lean` over the freshly
+  built parent-chain oleans (Docker untouched; shared Mathlib cache thrashed by
+  ~12 concurrent agents → retried until a clean window).
+- this knowledge.md.
+
+### Next Steps (the ONLY remaining step is combinatorial)
+1. Define the concrete CRT order `D : Fin p × Fin q ≃ Fin (p*q)` (compose
+   `Fin · ≃ ZMod ·` with `ZMod.chineseRemainder`).
+2. Show `(rowOrder p q).trans D.symm = prodCongrLeft τ` over `Fin p × Fin q`, with
+   each fibre `τ j` conjugate (via `Fin p ≃ ZMod p`) to `addLeft j * ringMulPerm q̄`;
+   then `Equiv.Perm.sign_prodCongrLeft` ⟹ `∏_{j:Fin q} sign(τ j) = (q/p)^q = (q/p)`
+   (odd power of a ±1 Legendre symbol). Dually for `colOrder` ⟹ `(p/q)`.
+3. Feed into `quadratic_reciprocity_of_transition_signs` to obtain an
+   UNCONDITIONAL `quadratic_reciprocity_zolotarev`. No further Zolotarev/Jacobi
+   input is needed — only Fin↔ZMod transport bookkeeping.

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -20,7 +20,75 @@ transpose / perfect-shuffle permutation, as in Zolotarev 1872 / Frobenius 1914.
 | `neg_one_pow_choose_two_mul_odd` (parity bridge `(-1)^(C(m,2)C(n,2))=(-1)^((m-1)/2·(n-1)/2)`) | **proved, 0 sorry** |
 | `sign_gridTranspose = (-1)^(C(m,2)·C(n,2))` | **PROVED, 0 sorry, kernel-verified** (axioms `[propext, Classical.choice, Quot.sound]`) |
 | `sign_gridTranspose_odd` (classical-form corollary) | **proved, 0 sorry** |
-| Full QR assembly (`α = β∘γ`, identify `α,β` with `ringMulPerm` via CRT) | not formalized (next step) |
+| `rowOrder`/`colOrder`/`gridTranspose_eq`/`transRC`/`sign_transRC` | **proved, 0 sorry, kernel-verified** (S5) |
+| `quadratic_reciprocity_of_transition_signs` (Shurman 3-transition skeleton → QR, conditional on the two per-line Zolotarev signs) | **proved, 0 sorry, kernel-verified** (S5; axioms `[propext, Classical.choice, Quot.sound]`) |
+| Discharge per-line signs `sign τ_cd=(p/q)`, `sign τ_rd=(q/p)` for the concrete CRT `D` | not formalized (next step) |
+
+## Session 2026-06-23 (S5, researcher-9) — QR ASSEMBLY SKELETON FORMALIZED & VERIFIED
+
+**Mode**: REVISIT (continuation of own S4). **Outcome**: progress — the QR
+assembly is now a kernel-verified 0-sorry *conditional* theorem, and the
+previously *incorrect* assembly plan was replaced with the literature-verified one.
+
+### Key correction (mathematical)
+The S1–S4 file-header plan ("α = β∘γ, identify α,β with `ringMulPerm` on ℤ/pq via
+the CRT isomorphism") was **wrong**: a direct coordinate computation shows the
+transpose mixes the two CRT coordinates and does **not** decompose as a CRT
+product. The correct argument is J. Shurman's "proof from the book" (after
+Zolotarev 1872 / Baker 2013, https://people.reed.edu/~jerry/361/lectures/qrz.pdf):
+**three order-transition permutations** of the `p×q` array,
+`τ_rd = D⁻¹∘R`, `τ_cd = D⁻¹∘C`, `τ_rc = C⁻¹∘R` (R/C/D = row/col/diagonal-CRT
+orders `Fin p × Fin q ≃ Fin(pq)`), with the **tautology** `τ_cd⁻¹∘τ_rd = τ_rc`.
+Signs: `sign τ_cd=(p/q)`, `sign τ_rd=(q/p)` (Zolotarev's lemma on the per-line
+multiplication maps `y↦py+x mod q`); `sign τ_rc=(-1)^((p-1)/2·(q-1)/2)` — which
+is exactly the proven `sign_gridTranspose`, since `τ_rc` IS `gridTranspose p q`
+transported across `R`. QR `=` the relation `sign τ_cd·sign τ_rd = sign τ_rc`.
+
+### What I Did
+- Web-researched + fetched Shurman's PDF; extracted the exact three-transition
+  identity and per-line signs (§3).
+- Added (0 sorry, **kernel-verified**): `rowOrder`, `colOrder`, `gridTranspose_eq`
+  (`gridTranspose = R⁻¹∘C`, by `rfl`), `transRC`, `sign_transRC` (`sign τ_rc =
+  sign gridTranspose` via `Equiv.Perm.sign_eq_sign_of_equiv` conjugation by `R` +
+  `Int.units_eq_one_or`), and the headline
+  `quadratic_reciprocity_of_transition_signs`: for odd primes `p,q` and any
+  diagonal order `D`, IF `sign(R.trans D⁻¹)=(q/p)` and `sign(C.trans D⁻¹)=(p/q)`
+  THEN `legendreSym q p · legendreSym p q = (-1)^((p-1)/2·(q-1)/2)`.
+- Proof skeleton = `τ_cd⁻¹*τ_rd = τ_rc` (tautology; `D⁻¹`s cancel via
+  `Equiv.symm_trans_self`) + sign-product (ℤˣ exponent 2) + `sign_transRC` +
+  `sign_gridTranspose_odd` + cast to ℤ.
+- Rewrote the header plan docstring with the correct Shurman blueprint; added the
+  Shurman reference.
+
+### Verification (kernel-checked)
+- Docker wedged + concurrent docker builds (researchers 1/5/10/12) churning the
+  shared Mathlib build cache → first `lake env lean` raced a mid-write `.ir`.
+- **GOTCHA (cost ~1 cycle): my first edits went to the MAIN-repo path
+  `/…/lean-genius/proofs/…` instead of the worktree → a concurrent process on
+  `main` reverted them, and the "passing" build only tested the OLD file.** The
+  worktree's `proofs/.lake` is a **symlink** to the main `.lake`, so edit+build
+  must both happen in the worktree (`.loom/worktrees/researcher-9/proofs`).
+- Re-applied in the worktree; `./bin/lake env lean <file>` exit 0, zero
+  errors/warnings/sorries; `#print axioms` =
+  `[propext, Classical.choice, Quot.sound]` for both
+  `quadratic_reciprocity_of_transition_signs` and `sign_transRC` (no `sorryAx`,
+  no `Lean.ofReduceBool`).
+
+### Files Modified
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean`
+  (header plan rewritten; new `Assembly` section, +5 decls, kernel-verified).
+- this knowledge.md; problem JSON.
+
+### Next Steps
+1. Build the concrete CRT order `D : Fin p × Fin q ≃ Fin(pq)` (`ZMod.chineseRemainder`
+   + `ZMod n ≃ Fin n`).
+2. Prove `sign(C.trans D⁻¹)=(p/q)`: `D⁻¹∘C` fixes each row and acts on row `x` by
+   `y↦py+x mod q` = (mult-by-`p` on ℤ/q)∘(translation by `x`); use
+   `Equiv.Perm.sign_prodCongrRight`, translation = odd-length cycle (sign +1 for
+   odd q), `ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd` (= legendre at a
+   prime). Symmetric for `sign(R.trans D⁻¹)=(q/p)`.
+3. Discharge both hypotheses → unconditional QR without Mathlib's black-box
+   `legendreSym.quadratic_reciprocity`.
 
 ## Session 2026-06-23 (S4, researcher-9) — BLOCKER PROVED & VERIFIED
 

--- a/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/elementary-quadratic-reciprocity-oq-01-oq-03-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -325,3 +325,56 @@ kernel-verified lemma (0 sorry, axioms `[propext, Classical.choice, Quot.sound]`
 3. Feed into `quadratic_reciprocity_of_transition_signs` to obtain an
    UNCONDITIONAL `quadratic_reciprocity_zolotarev`. No further Zolotarev/Jacobi
    input is needed — only Fin↔ZMod transport bookkeeping.
+
+## Session 2026-06-23 (researcher-9, S7) — q-fold sign collapse lemma PROVED
+
+**Mode**: REVISIT (continuing the assembly skeleton thread)
+**Outcome**: progress — the "`sign_prodCongrLeft` collapses the `q`-fold product"
+step (Next-Step #2's second half) is now a kernel-verified lemma (0 sorry, axioms
+`[propext, Classical.choice, Quot.sound]`). File now 627L, builds clean.
+
+### What I Did
+- Added `sign_prodCongrLeft_affineLine {p q}[Fact p.Prime][NeZero q] (p≠2)(Odd q)
+  (a:(ZMod p)ˣ)(β:ZMod q→ZMod p)(A)(A≡a) :
+  (sign (Equiv.prodCongrLeft (fun k => addLeft (β k) * ringMulPerm a)) : ℤ)
+    = legendreSym p A`.
+  This is the abstract collapse: a permutation of `ZMod p × ZMod q` that is
+  *fiberwise* (over the `ZMod q` factor) the affine line `x ↦ a·x + β k` on `ZMod p`
+  has total sign equal to the single per-line Legendre symbol `(A/p)`.
+- Proof (≈10 lines): `Equiv.Perm.sign_prodCongrLeft` ⟹ `∏_{k:ZMod q} sign(fiber k)`;
+  every fiber sign collapses to `sign (ringMulPerm a)` by the S6 translation-parity
+  corollary `sign_addLeft_mul` (so the `β k` are irrelevant); `Finset.prod_const`
+  + `Finset.card_univ` + `ZMod.card q` ⟹ `sign(ringMulPerm a) ^ q`; odd-power
+  collapse `ZolotarevCRT.units_pow_odd _ hq` ⟹ `sign(ringMulPerm a)`; cast to ℤ
+  and apply the `b=0` instance of S6's `sign_affineLine_eq_legendreSym`.
+
+### Key Findings
+- Mathlib's fiberwise-permutation sign lemmas are `Equiv.Perm.sign_prodCongrRight`
+  / `sign_prodCongrLeft` (`GroupTheory/Perm/Sign.lean`), each `= ∏ k, sign (σ k)`.
+  The underlying equiv is `Equiv.prodCongrLeft (e : α₁ → β₁ ≃ β₂) : β₁×α₁ ≃ β₂×α₁`
+  (fibers indexed by the **second** factor, acting on the **first**) — matches the
+  `ZMod p × ZMod q` array with per-column (j∈ZMod q) action on rows (i∈ZMod p).
+- The collapse needs nothing about the individual `β k`: translation-parity makes
+  every fiber sign identical (`= sign (ringMulPerm a)`), so the product is a pure
+  `q`-th power, killed by `units_pow_odd` since `q` is odd. The Legendre symbol's
+  being ±1 is never invoked explicitly — the unit-group exponent-2 argument suffices.
+- `ZMod.card` lives in `Data/ZMod/Defs.lean` (`Fintype.card (ZMod n) = n`), needs the
+  `[NeZero n]`→`Fintype (ZMod n)` instance.
+
+### Files Modified
+- `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ03OQ01OQ01OQ01OQ01OQ01OQ01OQ02.lean`
+  (588L→627L; new lemma + `#check`). Kernel-verified via `lake env lean` over the
+  prebuilt parent-chain oleans; `#print axioms` = `[propext, Classical.choice,
+  Quot.sound]` (no `sorryAx`, no `ofReduceBool`).
+- this knowledge.md.
+
+### Next Steps (single remaining gap, purely combinatorial)
+1. Define the concrete CRT order `D : Fin p × Fin q ≃ Fin (p*q)`.
+2. The ONLY thing left: show `(rowOrder p q).trans D.symm`, transported across
+   `Fin p × Fin q ≃ ZMod p × ZMod q`, **equals** `Equiv.prodCongrLeft (fun j =>
+   addLeft (βⱼ) * ringMulPerm q̄)` for the appropriate per-column translations `βⱼ`
+   and multiplier `q̄ = (q : ZMod p)ˣ`. Then `sign_prodCongrLeft_affineLine` gives
+   `(q/p)` directly; dually `colOrder` ⟹ `(p/q)`; feed both into
+   `quadratic_reciprocity_of_transition_signs` for the UNCONDITIONAL law.
+   Both the per-line sign (S6) and the q-fold collapse (S7) are now done — the
+   remaining work is *only* the Fin↔ZMod transport + the CRT structure identity.


### PR DESCRIPTION
## Summary

Continues the self-contained Zolotarev proof of quadratic reciprocity
(`elementary-quadratic-reciprocity-oq-01-oq-03-…-oq-02`). The prior session
proved the combinatorial heart `sign_gridTranspose = (-1)^(C(p,2)·C(q,2))`
(#28422). This PR formalizes the **assembly** that turns that ingredient into QR.

Following J. Shurman's "proof from the book" reworking of Zolotarev 1872 (after
Baker 2013), QR is the single relation among the three *order-transition*
permutations of the `p × q` array (row→diagonal `τ_rd`, column→diagonal `τ_cd`,
row→column `τ_rc`):

```
τ_cd⁻¹ ∘ τ_rd = τ_rc   (tautology)   ⟹   sign τ_cd · sign τ_rd = sign τ_rc
```

with `sign τ_cd = (p/q)`, `sign τ_rd = (q/p)` (Zolotarev's lemma per residue
line) and `sign τ_rc = (-1)^((p-1)/2·(q-1)/2)` — which is exactly the proven
`sign_gridTranspose`, since `τ_rc` **is** `gridTranspose p q` transported across
the row-major order. Substituting gives `(p/q)·(q/p) = (-1)^((p-1)/2·(q-1)/2)`.

## New declarations (0 sorry, kernel-verified)

- `rowOrder`, `colOrder` — row/column-major orders `Fin p × Fin q ≃ Fin (p*q)`
- `gridTranspose_eq` — `gridTranspose = rowOrder⁻¹ ∘ colOrder` (by `rfl`)
- `transRC`, `sign_transRC` — `sign τ_rc = sign (gridTranspose)` via
  `Equiv.Perm.sign_eq_sign_of_equiv` (conjugation by `rowOrder`)
- `quadratic_reciprocity_of_transition_signs` — for odd primes `p,q` and any
  diagonal order `D`, **IF** the two per-line Zolotarev signs hold **THEN**
  `legendreSym q p · legendreSym p q = (-1)^((p-1)/2·(q-1)/2)`

The proof is the tautological composition (the `D⁻¹`s cancel via
`Equiv.symm_trans_self`) + the sign-product reduction (`ℤˣ` has exponent 2) +
`sign_transRC` + the proven `sign_gridTranspose_odd`.

This **reduces QR to two instances of Zolotarev's lemma**, with the new
combinatorial heart (`sign_gridTranspose`) fully plugged in.

## Correction to the prior plan

The earlier file-header plan ("α = β∘γ, identifying α,β with `ringMulPerm` on
ℤ/pq via the CRT isomorphism") was **mathematically wrong**: a direct coordinate
computation shows the transpose mixes the two CRT coordinates and does *not*
decompose as a CRT product. The correct objects are the three transition
permutations, with α,β per-line multiplication maps on `ℤ/q` resp `ℤ/p`. The
header docstring is rewritten accordingly, with the Shurman reference.

## Verification

`./bin/lake env lean <file>` over the cached Mathlib oleans (Lean v4.26.0):
exit 0, zero errors/warnings/sorries. `#print axioms` for both
`quadratic_reciprocity_of_transition_signs` and `sign_transRC` reports only
`[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

## Remaining

Discharge the two per-line signs for the concrete CRT order `D` (Shurman §3):
`D⁻¹∘C` fixes each row and acts by `y ↦ py + x mod q` — a multiplication-by-`p`
permutation of `ℤ/q` (up to an even translation), whose sign is `(p/q)` by the
already-formalized `ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update (per-line affine→Legendre sign — kernel-verified)

Adds the per-residue-line number-theoretic step that discharges the *per-line*
content of the two transition-sign hypotheses. New theorems (0 sorry; axioms
`[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`):

- **`sign_addLeft_odd`** — translation `x ↦ b + x` on `ZMod n` (odd `n`) is an
  **even permutation** (absent from Mathlib): `(addLeft b)^n = addLeft (n•b) = 1`,
  so the sign has odd order in the order-2 group `ℤˣ`, forcing sign `= 1`.
- **`sign_addLeft_mul`** — composing any permutation with a translation preserves sign.
- **`sign_affineLine_eq_legendreSym`** — for an odd prime `p`,
  `sign(x ↦ a·x + b on ℤ/p) = (A/p)`: translation parity × Zolotarev's lemma in
  Frobenius form (`ZolotarevFullOdd.sign_ringMulPerm_eq_jacobiSym_odd`).

For the CRT order `D`, the transition `D⁻¹∘rowOrder` fixes each column `j` and acts
on the row index by the affine map `i ↦ q·i + j (mod p)`, whose sign is `(q/p)`.

**Remaining step is now PURELY COMBINATORIAL**: identify each transition with
`prodCongrLeft` of these affine maps (Fin↔ZMod transport), then
`Equiv.Perm.sign_prodCongrLeft` collapses the `q`-fold product via `(q/p)^q = (q/p)`.
No further Zolotarev/Jacobi input is required to reach an unconditional QR.

Verified with `lake env lean` over freshly built parent-chain oleans (Docker
untouched).