### PR TITLE
research(fibonacci-identities-oq-01-oq-02): d'Ocagne's identity for Fibonacci numbers

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2718,6 +2718,7 @@ import Proofs.FeuerbachsTheoremOQ02Aristotle
 import Proofs.FeuerbachsTheoremOQ05
 import Proofs.FibonacciIdentities
 import Proofs.FibonacciIdentitiesOQ01
+import Proofs.FibonacciIdentitiesOQ01OQ02
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ03
 import Proofs.FibonacciIdentitiesOQ04

--- a/proofs/Proofs/FibonacciIdentitiesOQ01OQ02.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ01OQ02.lean
@@ -1,0 +1,119 @@
+import Mathlib.Data.Nat.Fib.Basic
+import Mathlib.Tactic
+
+/-
+# d'Ocagne's Identity for Fibonacci Numbers
+
+## What This Proves
+
+With `Fₙ = Nat.fib n` the Fibonacci sequence (`F₀ = 0, F₁ = 1, Fₙ₊₂ = Fₙ + Fₙ₊₁`),
+**d'Ocagne's identity** is the two-index relation
+
+    Fₘ · Fₙ₊₁ − Fₘ₊₁ · Fₙ = (−1)ⁿ · Fₘ₋ₙ      (over ℤ, for m ≥ n).
+
+It generalises Cassini's identity (`fibonacci-identities-oq-01`), which is the
+special case `m = n + 1`:  `Fₙ₊₁² − Fₙ₊₂·Fₙ = (−1)ⁿ·F₁ = (−1)ⁿ`.
+
+The natural-number subtraction `m − n` is the only obstruction to a fully
+two-sided statement, so the clean engine is the **gap-parameterised form**: with
+`k = m − n ≥ 0`,
+
+    F_{n+k} · Fₙ₊₁ − F_{n+k+1} · Fₙ = (−1)ⁿ · F_k.
+
+Here `k` is a genuine natural number and no subtraction appears.  The named
+identity above is recovered by writing `m = n + k`.
+
+For example (named form, `(−1)ⁿ·Fₘ₋ₙ`):
+- `m = 3, n = 1`: `F₃·F₂ − F₄·F₁ = 2·1 − 3·1 = −1 = (−1)¹·F₂ = −1`
+- `m = 5, n = 2`: `F₅·F₃ − F₆·F₂ = 5·2 − 8·1 =  2 = (−1)²·F₃ =  2`
+- `m = 4, n = 1`: `F₄·F₂ − F₅·F₁ = 3·1 − 5·1 = −2 = (−1)¹·F₃ = −2`
+
+## Approach
+
+Pure induction on `n` in the gap-parameterised form, cast to `ℤ`.  The crux is
+that the successor step simply **negates** the previous value:
+
+    F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ  =  −(F_{n+k+1}·Fₙ₊₂ − F_{n+k+2}·Fₙ₊₁),
+
+which is exactly `(−1)ⁿ·F_k → (−1)ⁿ⁺¹·F_k`.  After rewriting the two terms
+introduced at the successor step with the recurrence `Nat.fib_add_two` (cast to
+ℤ), a single `linear_combination (-1) * ih` closes the algebra — the same
+"one sign flip per step" mechanism that drives Cassini.  No closed form, Binet
+formula, or matrices are needed; the only input beyond base values is the
+recurrence.
+
+No `decide`/`native_decide` is used in the theorems, so the proofs are
+axiom-free (only Mathlib's foundational axioms).
+
+## Distinctness
+
+d'Ocagne's identity is **not** in Mathlib (`Mathlib.Data.Nat.Fib.Basic` has the
+recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, etc., but no two-index ±Fₖ
+determinant identity).  It is the second open question of
+`fibonacci-identities-oq-01` (Cassini) and properly generalises that parent:
+`fib_cassini_of_docagne` re-derives Cassini as the `m = n + 1` slice.
+
+## Status
+- [x] Complete proof, 0 sorries, 0 axioms (beyond Mathlib's foundational set)
+-/
+
+namespace FibonacciIdentitiesOQ01OQ02
+
+open Nat
+
+/-- **d'Ocagne's identity, gap-parameterised form.**  For every `n` and every
+gap `k`,
+
+    F_{n+k} · Fₙ₊₁ − F_{n+k+1} · Fₙ = (−1)ⁿ · F_k.
+
+This is the subtraction-free engine: `k` plays the role of `m − n`. -/
+theorem fib_docagne_gap (n k : ℕ) :
+    (Nat.fib (n + k) : ℤ) * Nat.fib (n + 1)
+      - (Nat.fib (n + k + 1) : ℤ) * Nat.fib n = (-1) ^ n * Nat.fib k := by
+  induction n with
+  | zero =>
+    -- F_k·F₁ − F_{k+1}·F₀ = F_k·1 − F_{k+1}·0 = F_k.
+    simp [Nat.fib_zero, Nat.fib_one]
+  | succ n ih =>
+    -- The only non-definitional index normalisation: `n+1+k = n+k+1`.
+    have i1 : n + 1 + k = n + k + 1 := by ring
+    rw [i1]
+    -- Remaining indices `n+k+1+1`, `n+1+1` are definitionally `n+k+2`, `n+2`.
+    show (Nat.fib (n + k + 1) : ℤ) * Nat.fib (n + 2)
+        - (Nat.fib (n + k + 2) : ℤ) * Nat.fib (n + 1) = (-1) ^ (n + 1) * Nat.fib k
+    -- Recurrences, cast to ℤ, for the two terms introduced at the successor step.
+    have e2 : (Nat.fib (n + 2) : ℤ) = (Nat.fib n : ℤ) + Nat.fib (n + 1) := by
+      exact_mod_cast Nat.fib_add_two (n := n)
+    have e4 : (Nat.fib (n + k + 2) : ℤ) = (Nat.fib (n + k) : ℤ) + Nat.fib (n + k + 1) := by
+      exact_mod_cast Nat.fib_add_two (n := n + k)
+    rw [e2, e4, pow_succ]
+    linear_combination (-1 : ℤ) * ih
+
+/-- **d'Ocagne's identity (named two-index form).**  For `m ≥ n`,
+
+    Fₘ · Fₙ₊₁ − Fₘ₊₁ · Fₙ = (−1)ⁿ · Fₘ₋ₙ. -/
+theorem fib_docagne (m n : ℕ) (h : n ≤ m) :
+    (Nat.fib m : ℤ) * Nat.fib (n + 1)
+      - (Nat.fib (m + 1) : ℤ) * Nat.fib n = (-1) ^ n * Nat.fib (m - n) := by
+  obtain ⟨k, rfl⟩ := Nat.exists_eq_add_of_le h
+  rw [Nat.add_sub_cancel_left]
+  exact fib_docagne_gap n k
+
+/-- **Cassini as a special case of d'Ocagne.**  Taking `m = n + 1` (gap `1`,
+`F₁ = 1`) recovers Cassini's identity in the form
+
+    Fₙ₊₁² − Fₙ₊₂ · Fₙ = (−1)ⁿ. -/
+theorem fib_cassini_of_docagne (n : ℕ) :
+    (Nat.fib (n + 1) : ℤ) ^ 2 - (Nat.fib (n + 2) : ℤ) * Nat.fib n = (-1) ^ n := by
+  have h := fib_docagne_gap n 1
+  -- F_{n+1}·F_{n+1} − F_{n+2}·F_n = (−1)ⁿ·F₁ = (−1)ⁿ.
+  simp only [Nat.fib_one, Nat.cast_one, mul_one] at h
+  linear_combination h
+
+/-! ## Concrete examples (named form `Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ`) -/
+
+example : (Nat.fib 3 : ℤ) * Nat.fib 2 - (Nat.fib 4 : ℤ) * Nat.fib 1 = -1 := by decide
+example : (Nat.fib 5 : ℤ) * Nat.fib 3 - (Nat.fib 6 : ℤ) * Nat.fib 2 = 2 := by decide
+example : (Nat.fib 4 : ℤ) * Nat.fib 2 - (Nat.fib 5 : ℤ) * Nat.fib 1 = -2 := by decide
+
+end FibonacciIdentitiesOQ01OQ02

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-fibdocagne-header",
+    "proofId": "fibonacci-identities-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 62 },
+    "type": "concept",
+    "title": "d'Ocagne's Identity and the Gap-Parameterisation Idea",
+    "content": "The docstring states d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ over ℤ (for m ≥ n) and frames it as the two-index companion of Cassini's identity (fibonacci-identities-oq-01), recovered as the m = n + 1 slice. The single obstruction to a fully two-sided statement is the natural-number subtraction m − n, so the file works through a subtraction-free engine: writing the index gap as an additive parameter k = m − n ≥ 0 gives F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = (−1)ⁿ·F_k, a clean statement in n and k. Worked numeric examples ((m,n) = (3,1), (5,2), (4,1)) anchor the sign and gap behaviour.",
+    "mathContext": "$F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$, engine $F_{n+k} F_{n+1} - F_{n+k+1} F_n = (-1)^n F_k$.",
+    "significance": "context",
+    "relatedConcepts": ["d'Ocagne's identity", "Cassini's identity", "Fibonacci recurrence", "index arithmetic", "alternating sign"],
+    "prerequisites": ["Fibonacci numbers", "natural-number subtraction", "casting ℕ → ℤ"]
+  },
+  {
+    "id": "ann-fibdocagne-gap",
+    "proofId": "fibonacci-identities-oq-01-oq-02",
+    "range": { "startLine": 64, "endLine": 90 },
+    "type": "theorem",
+    "title": "Gap-Parameterised Engine (single induction, one sign flip per step)",
+    "content": "fib_docagne_gap proves F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = (−1)ⁿ·F_k over ℤ by induction on n with k fixed. Base case n = 0 collapses to F_k·F₁ − F_{k+1}·F₀ = F_k under simp on fib_zero/fib_one. The successor step normalises the one non-definitional index (n+1+k = n+k+1) with a single rewrite, uses `show` to put the remaining indices in canonical n+2 / n+k+2 form (definitionally equal), casts the recurrence Nat.fib_add_two twice (e2 for fib(n+2), e4 for fib(n+k+2)), expands pow_succ, and closes with `linear_combination (-1)·ih`. The algebraic crux is that the left-hand side negates each step — F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = −(F_{n+k+1}·Fₙ₊₂ − F_{n+k+2}·Fₙ₊₁) — exactly matching (−1)ⁿ·F_k ↦ (−1)ⁿ⁺¹·F_k.",
+    "mathContext": "$F_{n+k} F_{n+1} - F_{n+k+1} F_n = (-1)^n F_k$ over $\\mathbb{Z}$, step negation $g(n+1) = -g(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.fib_add_two", "linear_combination", "induction on n", "pow_succ", "telescoping sign"],
+    "prerequisites": ["induction over ℕ", "the linear_combination tactic", "definitional index equality"]
+  },
+  {
+    "id": "ann-fibdocagne-named",
+    "proofId": "fibonacci-identities-oq-01-oq-02",
+    "range": { "startLine": 92, "endLine": 100 },
+    "type": "theorem",
+    "title": "Named Two-Index Form via Gap Substitution",
+    "content": "fib_docagne transports the gap engine to the classical statement Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ for m ≥ n. From the hypothesis n ≤ m it writes m = n + k (Nat.exists_eq_add_of_le, substituted by rfl), simplifies the index gap m − n = (n+k) − n = k (Nat.add_sub_cancel_left), and applies fib_docagne_gap. This is the only place the natural-number subtraction appears, and it is discharged cleanly by the additive decomposition.",
+    "mathContext": "$F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$ for $m \\ge n$, with $m = n + k$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.exists_eq_add_of_le", "Nat.add_sub_cancel_left", "natural-number subtraction"],
+    "prerequisites": ["eliminating ℕ-subtraction", "obtain/rfl destructuring"]
+  },
+  {
+    "id": "ann-fibdocagne-cassini",
+    "proofId": "fibonacci-identities-oq-01-oq-02",
+    "range": { "startLine": 102, "endLine": 111 },
+    "type": "theorem",
+    "title": "Cassini Recovered as the Gap-1 Special Case",
+    "content": "fib_cassini_of_docagne specialises the gap engine at k = 1 (F₁ = 1) to obtain Cassini's identity Fₙ₊₁² − Fₙ₊₂·Fₙ = (−1)ⁿ. After simp collapses the F₁ factor, a one-line linear_combination matches the squared middle term. This corollary certifies that d'Ocagne strictly generalises the parent fibonacci-identities-oq-01 rather than restating it.",
+    "mathContext": "$F_{n+1}^2 - F_{n+2} F_n = (-1)^n$ — Cassini, the $m = n+1$ slice.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cassini's identity", "specialisation", "generalisation witness"],
+    "prerequisites": ["Fibonacci base value F₁ = 1"]
+  },
+  {
+    "id": "ann-fibdocagne-examples",
+    "proofId": "fibonacci-identities-oq-01-oq-02",
+    "range": { "startLine": 113, "endLine": 119 },
+    "type": "concept",
+    "title": "Concrete Numeric Sanity Checks",
+    "content": "Three `decide` examples evaluate the named form Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ at (m,n) = (3,1), (5,2), (4,1), giving −1, 2, −2 respectively. These exercise both signs and a non-unit gap (Fₘ₋ₙ = F₃ = 2), and use decide only — they are not part of the universally quantified theorems, which remain axiom-free.",
+    "mathContext": "$F_5 F_3 - F_6 F_2 = 5\\cdot 2 - 8\\cdot 1 = 2 = (-1)^2 F_3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide", "numeric verification"],
+    "prerequisites": ["evaluating Nat.fib at small indices"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-01-oq-02/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "fibonacci-identities-oq-01-oq-02",
+  "title": "d'Ocagne's Identity for Fibonacci Numbers",
+  "slug": "fibonacci-identities-oq-01-oq-02",
+  "description": "d'Ocagne's identity: with Fₙ = Nat.fib n, the two-index determinant Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ over ℤ (for m ≥ n). It generalises Cassini's identity (fibonacci-identities-oq-01), recovered as the m = n + 1 slice. The natural-number subtraction m − n is the only obstruction to a two-sided statement, so the proof engine is the gap-parameterised form with k = m − n ≥ 0: F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = (−1)ⁿ·F_k, which has no subtraction. Proved by a single induction on n: casting to ℤ exposes the alternating sign, the recurrence Nat.fib_add_two rewrites the two terms introduced at the successor step, and one linear_combination against the induction hypothesis closes the algebra — the left-hand side simply negates at each step (the same 'one sign flip per step' mechanism as Cassini). The named form is recovered by writing m = n + k. d'Ocagne's identity is absent from Mathlib (which has the recurrence, fib_add, fib_two_mul, fib_gcd, but no two-index ±Fₖ determinant identity) and is the second open question of fibonacci-identities-oq-01.",
+  "meta": {
+    "author": "Maurice d'Ocagne; formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cassini_and_Catalan_identities",
+    "date": "1885",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "docagne",
+      "cassini",
+      "recurrence",
+      "induction",
+      "determinant",
+      "integer-sequences",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ01OQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the defining Fibonacci recurrence, cast to ℤ to rewrite the two terms introduced at the successor step",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_zero / Nat.fib_one",
+        "description": "fib 0 = 0, fib 1 = 1 — base values that collapse the n = 0 case (F_k·F₁ − F_{k+1}·F₀ = F_k) under simp",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.exists_eq_add_of_le / Nat.add_sub_cancel_left",
+        "description": "From n ≤ m obtain m = n + k and simplify m − n = k, transporting the gap-parameterised engine to the named two-index form",
+        "module": "Mathlib (Nat order/subtraction lemmas)"
+      }
+    ],
+    "originalContributions": [
+      "fib_docagne_gap: ∀ n k, (fib (n+k) : ℤ)·fib (n+1) − (fib (n+k+1) : ℤ)·fib n = (−1)ⁿ·fib k — the subtraction-free gap-parameterised engine for d'Ocagne, absent from Mathlib",
+      "fib_docagne: ∀ m n, n ≤ m → (fib m : ℤ)·fib (n+1) − (fib (m+1) : ℤ)·fib n = (−1)ⁿ·fib (m−n) — d'Ocagne's identity in its named two-index form",
+      "fib_cassini_of_docagne: ∀ n, (fib (n+1) : ℤ)² − (fib (n+2) : ℤ)·fib n = (−1)ⁿ — Cassini recovered as the m = n + 1 (gap-1) slice, witnessing that d'Ocagne properly generalises the parent"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 119,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). No decide/native_decide is used in the main theorems (only in the trailing numeric example sanity-checks).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 3,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "d'Ocagne's identity (after Maurice d'Ocagne, late 19th century) is the two-index companion of Cassini's and Catalan's identities. Where Cassini measures the determinant of three consecutive Fibonacci terms (always ±1) and Catalan symmetrises about a centre, d'Ocagne couples two independent indices m and n: Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ. Setting m = n + 1 collapses it to Cassini, while the matrix viewpoint M = [[1,1],[1,0]] makes it the (off-diagonal) entry comparison in Mᵐ = Mⁿ·Mᵐ⁻ⁿ. It is one of the standard 'index-arithmetic' Fibonacci identities used in fast doubling and in establishing the strong divisibility Fₘ | Fₘₖ.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-01, Q2)**: Prove d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ.\n\n**Result**: fib_docagne (for m ≥ n, the named two-index form over ℤ), driven by the subtraction-free engine fib_docagne_gap (k = m − n), with fib_cassini_of_docagne recovering the parent Cassini identity as the gap-1 special case.",
+    "text": "For all m ≥ n, working over ℤ, Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ, where Fₙ = Nat.fib n. The two-index cross-determinant of Fibonacci numbers equals, up to the alternating sign (−1)ⁿ, the Fibonacci number at the index gap m − n.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. Eliminate the natural-number subtraction up front by proving the gap-parameterised form fib_docagne_gap: with k playing the role of m − n, F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = (−1)ⁿ·F_k, an honest statement in n and k with no subtraction.\n2. Cast to ℤ and induct on n (k fixed). Base case n = 0: F_k·F₁ − F_{k+1}·F₀ = F_k·1 − F_{k+1}·0 = F_k = (−1)⁰·F_k, discharged by simp on fib_zero/fib_one.\n3. Successor step: normalise the one non-definitional index (n+1+k = n+k+1) by a single rewrite, then `show` the remaining indices in canonical n+k+2 / n+2 form (definitionally equal). Cast the recurrence twice — e2: fib (n+2) = fib n + fib (n+1), e4: fib (n+k+2) = fib (n+k) + fib (n+k+1) — rewrite both, expand pow_succ, and close with `linear_combination (-1) * ih`. The left-hand side is exactly the negation of the previous step, matching (−1)ⁿ → (−1)ⁿ⁺¹.\n4. Recover the named form fib_docagne: from n ≤ m write m = n + k (Nat.exists_eq_add_of_le), simplify m − n = k (Nat.add_sub_cancel_left), and apply fib_docagne_gap.\n5. Recover Cassini fib_cassini_of_docagne: specialise the gap engine at k = 1 (F₁ = 1).",
+    "keyInsights": [
+      "**Parameterise the gap, not the difference.** The only friction in d'Ocagne is the ℕ-subtraction m − n. Replacing it with an additive gap k = m − n yields a clean two-variable statement on which induction runs with no truncation, and the named form follows by a one-line substitution m = n + k.",
+      "**The step is a sign flip — exactly as in Cassini.** The cancellation F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = −(F_{n+k+1}·Fₙ₊₂ − F_{n+k+2}·Fₙ₊₁) means each value negates the next, precisely (−1)ⁿ·F_k ↦ (−1)ⁿ⁺¹·F_k, so a single linear_combination with coefficient −1 closes the algebra.",
+      "**Recurrence as the only input.** Beyond the base values, the proof uses nothing but Nat.fib_add_two cast to ℤ; no Catalan identity, closed form, Binet formula, or matrices are needed.",
+      "**A genuine generalisation of the parent.** fib_cassini_of_docagne re-derives Cassini's identity as the gap-1 slice, certifying that this entry strictly extends fibonacci-identities-oq-01 rather than restating it.",
+      "**Not in Mathlib.** Mathlib carries the recurrence, fib_add, fib_two_mul, and fib_gcd, but no two-index ±Fₖ determinant identity, so d'Ocagne (and its gap-parameterised engine) is an original contribution."
+    ],
+    "prerequisites": [
+      "The Fibonacci recurrence Nat.fib_add_two and base values",
+      "Induction over ℕ and casting ℕ → ℤ (exact_mod_cast)",
+      "Eliminating ℕ-subtraction via Nat.exists_eq_add_of_le and Nat.add_sub_cancel_left",
+      "The linear_combination tactic for closing polynomial identities against a hypothesis"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 62,
+      "summary": "Module docstring stating d'Ocagne's identity, its gap-parameterised engine, the relation to Cassini, and worked numerical examples; the Fibonacci/tactic imports, namespace, and open Nat.",
+      "mathContext": "$F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$, with $F_0=0, F_1=1, F_{n+2}=F_n+F_{n+1}$."
+    },
+    {
+      "id": "docagne-gap",
+      "title": "Gap-Parameterised Engine",
+      "startLine": 64,
+      "endLine": 90,
+      "summary": "fib_docagne_gap: the subtraction-free form F_{n+k}·Fₙ₊₁ − F_{n+k+1}·Fₙ = (−1)ⁿ·F_k, proved by induction on n — base case by simp, successor step by one index rewrite, casting the recurrence twice, and closing with linear_combination (-1)·ih.",
+      "mathContext": "$F_{n+k} F_{n+1} - F_{n+k+1} F_n = (-1)^n F_k$ over $\\mathbb{Z}$."
+    },
+    {
+      "id": "docagne-named",
+      "title": "Named Two-Index Form",
+      "startLine": 92,
+      "endLine": 100,
+      "summary": "fib_docagne: from n ≤ m write m = n + k and simplify m − n = k, transporting the gap engine to d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ.",
+      "mathContext": "$F_m F_{n+1} - F_{m+1} F_n = (-1)^n F_{m-n}$ for $m \\ge n$."
+    },
+    {
+      "id": "cassini-special",
+      "title": "Cassini as a Special Case",
+      "startLine": 102,
+      "endLine": 111,
+      "summary": "fib_cassini_of_docagne: specialising the gap engine at k = 1 (F₁ = 1) recovers Cassini's identity Fₙ₊₁² − Fₙ₊₂·Fₙ = (−1)ⁿ, witnessing that d'Ocagne generalises the parent.",
+      "mathContext": "$F_{n+1}^2 - F_{n+2} F_n = (-1)^n$."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Examples",
+      "startLine": 113,
+      "endLine": 119,
+      "summary": "Numeric sanity checks of the named form Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ at (m,n) = (3,1), (5,2), (4,1), each by decide.",
+      "mathContext": "e.g. $F_5 F_3 - F_6 F_2 = 5\\cdot2 - 8\\cdot1 = 2 = (-1)^2 F_3$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-01",
+      "relationship": "generalizes",
+      "description": "Cassini's identity is the m = n + 1 (gap-1) special case of d'Ocagne's identity proved here; fib_cassini_of_docagne re-derives it directly from the gap engine"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) proof of d'Ocagne's identity Fₘ·Fₙ₊₁ − Fₘ₊₁·Fₙ = (−1)ⁿ·Fₘ₋ₙ over ℤ (for m ≥ n), via a subtraction-free gap-parameterised engine proved by a single induction using only the Fibonacci recurrence. Cassini's identity is recovered as the gap-1 special case.",
+    "implications": "Supplies the two-index Fibonacci cross-determinant identity — the index-arithmetic identity underlying fast doubling and the strong divisibility Fₘ | Fₘₖ — as a universally quantified theorem absent from Mathlib, and certifies it as a strict generalisation of the gallery's Cassini entry.",
+    "openQuestions": [
+      "Prove Catalan's identity Fₙ₋ᵣ·Fₙ₊ᵣ − Fₙ² = (−1)ⁿ⁻ʳ·Fᵣ² (the symmetric companion), and unify it with d'Ocagne via a single two-parameter cross-determinant lemma.",
+      "Derive the strong divisibility Fₘ | Fₘₙ and fib_gcd-style consequences directly from the gap engine, isolating the role of the (−1)ⁿ sign."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Fib.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Nat"
+    ],
+    "namespace": "FibonacciIdentitiesOQ01OQ02",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vajda, S.",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section: Theory and Applications",
+      "year": "1989",
+      "venue": "Ellis Horwood / Dover",
+      "note": "d'Ocagne's, Catalan's, and Cassini's identities and their interrelations"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "d'Ocagne's identity and the index-arithmetic identities for Fibonacci numbers"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Proves **d'Ocagne's identity** for Fibonacci numbers — the second open question of the Cassini parent `fibonacci-identities-oq-01`:

$$F_m \cdot F_{n+1} - F_{m+1} \cdot F_n = (-1)^n \cdot F_{m-n} \qquad (m \ge n,\ \text{over } \mathbb{Z}).$$

It properly **generalises Cassini's identity** (the $m = n+1$ slice).

## Approach

The only obstruction to a two-sided statement is the ℕ-subtraction $m - n$, so the proof is driven by a subtraction-free **gap-parameterised engine** ($k = m - n$):

$$F_{n+k}\,F_{n+1} - F_{n+k+1}\,F_n = (-1)^n F_k.$$

- `fib_docagne_gap` — proved by a **single induction on $n$**. The successor step simply negates the previous value ($g(n+1) = -g(n)$), closed by `linear_combination (-1)·ih` after casting `Nat.fib_add_two` twice. Same "one sign flip per step" mechanism as Cassini; only input beyond base values is the recurrence.
- `fib_docagne` — the named two-index form, recovered by writing $m = n + k$ (`Nat.exists_eq_add_of_le` + `Nat.add_sub_cancel_left`).
- `fib_cassini_of_docagne` — recovers Cassini $F_{n+1}^2 - F_{n+2}F_n = (-1)^n$ as the gap-1 case, certifying a strict generalisation of the parent.

## Verification

- **3 theorems, 0 definitions, 0 axioms, 0 sorries, 119 lines** — `verified` / `original`.
- d'Ocagne's identity is **absent from Mathlib** (which has the recurrence, `fib_add`, `fib_two_mul`, `fib_gcd`, but no two-index ±Fₖ determinant identity).
- `#print axioms` on all three theorems: only `propext`, `Classical.choice`, `Quot.sound`. `decide` appears solely in trailing numeric sanity-checks, not the theorems.
- Kernel-verified via `lake env lean` over cached Mathlib oleans (Docker build infra currently down, exit 144).

## Files
- `proofs/Proofs/FibonacciIdentitiesOQ01OQ02.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/fibonacci-identities-oq-01-oq-02/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)