### PR TITLE
Enrich Maclaurin/Newton-identities resolution (amgm-inequality-oq-02-oq-03-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const amgmInequalityOq02Oq03Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq02Oq03Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq02Oq03Oq03Oq01Data: ProofData = {
+  proof: amgmInequalityOq02Oq03Oq03Oq01Proof,
+  annotations: amgmInequalityOq02Oq03Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-03-oq-03-oq-01` (resolving whether Maclaurin's step follows from Mathlib's Newton identities — answer: No).

## Gaps closed
Rich `meta.json` but missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" on the live site and had zero inline annotations.

## Changes
- **`index.ts`** — added for live-site loading (imports meta, annotations, raw Lean source `AmgmInequalityOQ02OQ03OQ03OQ01.lean`).
- **`annotations.json`** — 5 inline annotations:
  - the Cauchy–Schwarz analytic engine `(Σxᵢ)² ≤ n·Σxᵢ²`
  - Newton's inequality at k=1 and why the (equality) identities can't supply it
  - the k=1 de-axiomatization of the parent's `maclaurin_step` axiom
  - the closed forms M₁ = (Σx)/n, M₂ = √(e₂/C(n,2))
  - the square-root-monotonicity reduction to the Cauchy–Schwarz bound

  Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 5 annotations align to Lean constructs. Axiom/badge integrity unchanged: `verified` / `mathlib` (Tier B, analytic engine imported from Mathlib) / 0 axioms / 0 sorries — consistent with the Lean source and the entry's honest assumptions note.

Branch named per-target to avoid collision with concurrent agents.