### PR TITLE
Enrich Finite Cayley's Theorem (cayleys-theorem-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleysTheoremOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleysTheoremOq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleysTheoremOq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleysTheoremOq01Oq01Data: ProofData = {
+  proof: cayleysTheoremOq01Oq01Proof,
+  annotations: cayleysTheoremOq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01-oq-01` (a finite group of order n embeds in Sₙ).

## Gaps closed
Rich `meta.json` but missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" live and had zero inline annotations.

## Changes
- **`index.ts`** — added for live-site loading (raw Lean source `CayleysTheoremOQ01OQ01.lean`).
- **`annotations.json`** — 6 inline annotations:
  - `permCongrMulEquiv` — conjugation σ ↦ e∘σ∘e⁻¹ as a MulEquiv of symmetric groups
  - `cayleyFinHom` — the regular representation transported to Sₙ
  - injectivity from composite of injective maps (faithfulness of the regular rep)
  - `cayley_fin` — the textbook G of order n ↪ Sₙ
  - the bundled embedding and subgroup-isomorphism packagings
  - the ℤ/3ℤ ↪ S₃ sanity check

  Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 6 annotations align to Lean constructs. Badge/axiom integrity unchanged: `verified` / `mathlib` (Tier B — injectivity rests on Mathlib's faithful regular rep) / 0 axioms / 0 sorries.

Branch named per-target to avoid collision with concurrent agents.