### PR TITLE
Enrich Erdős #978 OQ-01: local square-obstruction of n⁴+2

### DIFF
--- a/src/data/proofs/erdos-978-oq-01/index.ts
+++ b/src/data/proofs/erdos-978-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos978OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos978Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos978Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos978Oq01Data: ProofData = {
+  proof: erdos978Oq01Proof,
+  annotations: erdos978Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-978-oq-01` (the finite local conditions behind the open n⁴+2 squarefree conjecture).

## Gaps closed
Rich `meta.json` but missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" live and had zero inline annotations.

## Changes
- **`index.ts`** — added for live-site loading (raw Lean source `Erdos978OQ01.lean`).
- **`annotations.json`** — 5 inline annotations:
  - the polynomial `F(n) = n⁴+2` and the local-heuristic framing
  - killing the global square obstruction via `F(0) = 2`
  - the 3²-obstruction decided over `ZMod 9` (kernel `decide`) and lifted to ℤ
  - ρ(9) = 2 counting (7/9 residues safe) + non-vacuity witnesses
  - the infinitude argument (multiples of 9 escape)

  Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 5 annotations align to Lean constructs.

## Axiom integrity
Confirmed accurate: `verified` / badge `verified` / 0 axioms / 0 sorries. All `decide` calls reduce inside the kernel over `ZMod 9` (no `native_decide`, no `Lean.ofReduceBool`). The entry honestly scopes itself to the local conditions and does **not** claim to resolve the open parent conjecture.

Branch named per-target to avoid collision with concurrent agents.