### PR TITLE
Enrich Cassini's Identity (fibonacci-identities-oq-01)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-01/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOq01Data: ProofData = {
+  proof: fibonacciIdentitiesOq01Proof,
+  annotations: fibonacciIdentitiesOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-01` (Cassini's identity Fₙ₊₂·Fₙ − Fₙ₊₁² = (−1)ⁿ⁺¹).

## Gaps closed
Rich `meta.json` but missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" live and had zero inline annotations.

## Changes
- **`index.ts`** — added for live-site loading (raw Lean source `FibonacciIdentitiesOQ01.lean`).
- **`annotations.json`** — 5 inline annotations:
  - the identity statement + the "cast to ℤ before inducting" idea (base case)
  - the sign-flip successor step (recurrence cast twice + `linear_combination (-1)·ih`)
  - the index-shifted form (avoiding ℕ-subtraction)
  - the unsigned |·| = 1 form (missing-square paradox)
  - the concrete small-n determinants

  Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 5 annotations align to Lean constructs. Badge/axiom integrity unchanged: `verified` / `mathlib` (Cassini absent from Mathlib) / 0 axioms / 0 sorries.

Branch named per-target to avoid collision with concurrent agents.