### PR TITLE
Enrich Power-Mean Monotonicity (jensen-inequality-oq-01-oq-01-oq-01-oq-04)

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/index.ts
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ04.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const jensenInequalityOq01Oq01Oq01Oq04Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const jensenInequalityOq01Oq01Oq01Oq04Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const jensenInequalityOq01Oq01Oq01Oq04Data: ProofData = {
+  proof: jensenInequalityOq01Oq01Oq01Oq04Proof,
+  annotations: jensenInequalityOq01Oq01Oq01Oq04Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01-oq-04` (monotonicity of the weighted power mean M_p in its exponent — the power-mean inequality).

## Gaps closed
Rich `meta.json` but missing both `annotations.json` and `index.ts` — so the proof page would show "proof not found" live and had zero inline annotations.

## Changes
- **`index.ts`** — added for live-site loading (raw Lean source `JensenInequalityOQ01OQ01OQ01OQ04.lean`).
- **`annotations.json`** — 5 inline annotations:
  - the `powerMean` definition + nonnegativity + `M₁` = weighted AM
  - the monotonicity headline `0 < p ≤ q ⟹ M_p ≤ M_q`
  - the Jensen-for-t↦tʳ substitution and exponent bookkeeping (the proof core)
  - the AM-is-smallest-power-mean corollary
  - the QM–AM (root-mean-square) corollary

  Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
`pnpm annotations:build` passes (exit 0); all 5 annotations align to Lean constructs. Badge/axiom integrity unchanged: `verified` / badge `verified` / 0 axioms / 0 sorries / no native_decide.

Branch named per-target to avoid collision with concurrent agents.