### PR TITLE
Enrich Exponent of a Group of Order p² (group-order-prime-squared-abelian-oq-01-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "grpexp-oq0101-header",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 32 },
+    "type": "context",
+    "title": "Reframing the order-p² dichotomy via the exponent",
+    "content": "The header explains the follow-up's angle. The parent classifies groups of order p² (p prime) into two abelian types via the exponent-p *predicate* '∀ g, gᵖ = 1': cyclic ℤ/p² OR elementary-abelian (ℤ/p)². This file recasts that split through the single numerical invariant `Monoid.exponent G` — the least n > 0 with gⁿ = 1 for all g — the standard discriminant between ℤ/p² and (ℤ/p)². It proves the exponent takes exactly the two values p and p², and that each value pins down the isomorphism type: exponent = p² ⟺ cyclic, exponent = p ⟺ not cyclic. The structural dichotomy itself is imported from the parent.",
+    "mathContext": "$\\exp(G) = p^2 \\iff G \\cong \\mathbb{Z}/p^2,\\qquad \\exp(G) = p \\iff G \\cong (\\mathbb{Z}/p)^2$",
+    "significance": "context",
+    "relatedConcepts": ["group exponent", "p-groups", "elementary abelian group", "cyclic group", "classification"],
+    "prerequisites": ["Monoid.exponent", "the parent order-p² dichotomy"]
+  },
+  {
+    "id": "grpexp-oq0101-helpers",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
+    "range": { "startLine": 42, "endLine": 54 },
+    "type": "context",
+    "title": "Finiteness and nontriviality from the cardinality",
+    "content": "Two private helpers extract the standing assumptions from `Nat.card G = p²`. `finite_of_card_eq_prime_sq` gives `Finite G` (the cardinality p² ≠ 0). `nontrivial_of_card_eq_prime_sq` gives `Nontrivial G` from p² ≥ 4 > 1 via `Finite.one_lt_card_iff_nontrivial` and `nlinarith [hp.two_le]`. Both are needed downstream: finiteness for the exponent/order divisibility API, nontriviality to exclude exponent = 1. They are not counted among the 6 substantive theorems.",
+    "mathContext": "$\\mathrm{Nat.card}\\,G = p^2 \\ge 4 > 1 \\implies G \\text{ finite and nontrivial}$",
+    "significance": "technical",
+    "relatedConcepts": ["Nat.card", "Finite", "Nontrivial", "p² ≥ 4"],
+    "prerequisites": ["finiteness from nonzero cardinality", "nlinarith"]
+  },
+  {
+    "id": "grpexp-oq0101-sharpening",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 69 },
+    "type": "theorem",
+    "title": "orderOf_eq_prime_of_not_isCyclic: order exactly p",
+    "content": "A sharpening of the parent's gᵖ = 1: in a non-cyclic group of order p², *every* g ≠ 1 has order *exactly* p. From `pow_prime_eq_one_of_not_isCyclic` (the parent) gᵖ = 1, so `orderOf g ∣ p` via `orderOf_dvd_iff_pow_eq_one`; by `Nat.dvd_prime` the order is 1 or p, and `orderOf_eq_one_iff` rules out 1 since g ≠ 1. This precise order statement — not merely gᵖ = 1 — is the input element-counting arguments need (an exponent-p group of order p² has p² − 1 elements of order p).",
+    "mathContext": "$g \\ne 1,\\ g^p = 1 \\implies \\mathrm{ord}(g) \\mid p,\\ \\mathrm{ord}(g) \\ne 1 \\implies \\mathrm{ord}(g) = p$",
+    "significance": "key",
+    "relatedConcepts": ["order of an element", "orderOf_dvd_iff_pow_eq_one", "Nat.dvd_prime", "element counting"],
+    "prerequisites": ["element orders", "divisors of a prime"]
+  },
+  {
+    "id": "grpexp-oq0101-exponent-values",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 104 },
+    "type": "theorem",
+    "title": "Computing the exponent in each case",
+    "content": "`exponent_eq_sq_of_isCyclic`: a cyclic group of order p² has exponent p². A generator (via `isCyclic_iff_exists_orderOf_eq_natCard`) has order p², so p² ∣ exponent (`Monoid.order_dvd_exponent`); every order divides p² so exponent ∣ p² (`Monoid.exponent_dvd_of_forall_pow_eq_one` + `orderOf_dvd_natCard`); `Nat.dvd_antisymm` closes it. `exponent_eq_prime_of_not_isCyclic`: a non-cyclic group has exponent p. Every gᵖ = 1 gives exponent ∣ p; nontriviality produces a g ≠ 1 whose order > 1 divides the exponent, excluding exponent = 1; primality leaves exponent = p. Both values are pure divisibility antisymmetries from the same exponent API.",
+    "mathContext": "$\\mathrm{cyclic}: p^2 \\mid \\exp(G) \\mid p^2;\\quad \\mathrm{non\\text{-}cyclic}: \\exp(G) \\mid p,\\ \\exp(G) \\ne 1$",
+    "significance": "key",
+    "relatedConcepts": ["Monoid.order_dvd_exponent", "Monoid.exponent_dvd_of_forall_pow_eq_one", "Lagrange's theorem", "divisibility antisymmetry"],
+    "prerequisites": ["exponent divisibility API", "generators of cyclic groups"]
+  },
+  {
+    "id": "grpexp-oq0101-sharp-invariant",
+    "proofId": "group-order-prime-squared-abelian-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 135 },
+    "type": "theorem",
+    "title": "The exponent is a complete invariant",
+    "content": "`exponent_eq_prime_or_sq` lists the two possible values (a `by_cases` on cyclicity over the two value lemmas). `exponent_eq_sq_iff_isCyclic` and `exponent_eq_prime_iff_not_isCyclic` then upgrade each value to a characterization of the isomorphism type: the reverse direction is the value lemma, the forward direction is the contrapositive using p < p² for p ≥ 2 (`nlinarith [hp.two_le]` rules out p = p²). Together they establish the exponent as a *complete* invariant — knowing whether it is p or p² is equivalent to knowing whether G is (ℤ/p)² or ℤ/p².",
+    "mathContext": "$\\exp(G) \\in \\{p, p^2\\},\\quad p < p^2\\ (p \\ge 2) \\implies \\text{the two values are distinct and characterizing}$",
+    "significance": "key",
+    "relatedConcepts": ["complete invariant", "contrapositive", "by_cases on cyclicity", "isomorphism type"],
+    "prerequisites": ["the two value lemmas", "p < p² for p ≥ 2"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `group-order-prime-squared-abelian-oq-01-oq-01` (the exponent as a sharp invariant for the order-p² dichotomy).

This entry had a rich `meta.json` (with references) but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **Exponent reframing** — recasting cyclic vs elementary-abelian via Monoid.exponent ∈ {p, p²}.
- **Finiteness/nontriviality helpers** — from Nat.card G = p² ≥ 4.
- **orderOf_eq_prime_of_not_isCyclic** — sharpening gᵖ=1 to order *exactly* p.
- **Exponent computation** — p² (cyclic) and p (non-cyclic) by divisibility antisymmetry.
- **Complete invariant** — each exponent value characterizes the isomorphism type.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)