### PR TITLE
Enrich Young's Inequality Equality Case (jensen-inequality-oq-01-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "young-oq0101-header",
+    "proofId": "jensen-inequality-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Young's inequality is weighted AM–GM in disguise",
+    "content": "The header frames the contribution. Young's inequality a·b ≤ aᵖ/p + bᵍ/q (Hölder-conjugate p, q, so 1/p + 1/q = 1, p,q > 1) is in Mathlib (`Real.young_inequality_of_nonneg`), but its *equality case* — equality iff aᵖ = bᵍ — is not. This file supplies it by recognizing the whole statement as the two-term weighted AM–GM inequality: with weights wₓ = 1/p, w_y = 1/q (which sum to 1) and data x = aᵖ, y = bᵍ, the weighted geometric mean (aᵖ)^{1/p}·(bᵍ)^{1/q} collapses to a·b and the weighted arithmetic mean is aᵖ/p + bᵍ/q. So both the inequality and its equality case descend from the parent's weighted AM–GM equality characterization.",
+    "mathContext": "$ab \\le \\frac{a^p}{p} + \\frac{b^q}{q},\\quad \\tfrac1p + \\tfrac1q = 1,\\quad (a^p)^{1/p}(b^q)^{1/q} = ab$",
+    "significance": "context",
+    "relatedConcepts": ["Young's inequality", "weighted AM–GM", "Hölder conjugate exponents", "equality case"],
+    "prerequisites": ["Hölder-conjugate exponents", "weighted arithmetic and geometric means"]
+  },
+  {
+    "id": "young-oq0101-amgm-two",
+    "proofId": "jensen-inequality-oq-01-oq-01",
+    "range": { "startLine": 35, "endLine": 58 },
+    "type": "theorem",
+    "title": "amgm_two_weighted_eq_iff: the two-variable AM–GM equality case",
+    "content": "`amgm_two_weighted_eq_iff` is the parent's general `weighted_amgm_eq_iff` specialized to a `Fin 2` index set: for positive weights wₓ, w_y summing to 1 and nonnegative x, y, the weighted geometric mean equals the weighted arithmetic mean iff x = y. The proof packages the two weights as `![wx, wy]` and data as `![x, y]`, discharges the positivity/sum/nonnegativity hypotheses by `fin_cases`, applies the parent lemma, and unfolds `Fin.prod_univ_two`/`Fin.sum_univ_two`. Reducing to the general statement over Fin 2 keeps this a one-shot specialization rather than a fresh convexity computation.",
+    "mathContext": "$x^{w_x} y^{w_y} = w_x x + w_y y \\iff x = y\\quad (w_x, w_y > 0,\\ w_x + w_y = 1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["weighted AM–GM equality case", "Fin 2 specialization", "Fin.prod_univ_two", "fin_cases"],
+    "prerequisites": ["the parent weighted_amgm_eq_iff", "finite products/sums over Fin 2"]
+  },
+  {
+    "id": "young-oq0101-young-le",
+    "proofId": "jensen-inequality-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 63 },
+    "type": "theorem",
+    "title": "young_le: Young's inequality (re-export)",
+    "content": "`young_le` records Young's inequality a·b ≤ aᵖ/p + bᵍ/q itself as a named companion, a thin re-export of Mathlib's `Real.young_inequality_of_nonneg`. Keeping the bare inequality alongside the new equality case lets the strict form be assembled cleanly as `lt_of_le_of_ne`.",
+    "mathContext": "$ab \\le \\frac{a^p}{p} + \\frac{b^q}{q}$",
+    "significance": "technical",
+    "relatedConcepts": ["Real.young_inequality_of_nonneg", "re-export"],
+    "prerequisites": ["Young's inequality (the bound)"]
+  },
+  {
+    "id": "young-oq0101-young-eq",
+    "proofId": "jensen-inequality-oq-01-oq-01",
+    "range": { "startLine": 65, "endLine": 83 },
+    "type": "theorem",
+    "title": "young_eq_iff: the equality case (the new content)",
+    "content": "`young_eq_iff` is the headline result Mathlib lacks: a·b = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ. The proof applies `amgm_two_weighted_eq_iff` with weights p⁻¹, q⁻¹ (positive, summing to 1 by Hölder conjugacy `holderConjugate_iff`) and data aᵖ, bᵍ. The exponent bookkeeping is the whole trick: (aᵖ)^{p⁻¹} = a^{p·p⁻¹} = a^1 = a via `Real.rpow_mul` + `mul_inv_cancel₀` (and likewise for b), so the weighted geometric mean telescopes to a·b. A `ring` rewrite matches aᵖ/p + bᵍ/q with p⁻¹·aᵖ + q⁻¹·bᵍ, and the AM–GM equality case delivers aᵖ = bᵍ. This is exactly what identifies the extremizers of Hölder's inequality.",
+    "mathContext": "$ab = \\frac{a^p}{p} + \\frac{b^q}{q} \\iff a^p = b^q,\\quad (a^p)^{1/p} = a^{p \\cdot p^{-1}} = a$",
+    "significance": "key",
+    "relatedConcepts": ["equality case of Young", "Real.rpow_mul", "Hölder extremizers", "rigidity"],
+    "prerequisites": ["the two-variable AM–GM equality case", "rpow arithmetic", "Hölder conjugacy"]
+  },
+  {
+    "id": "young-oq0101-young-lt",
+    "proofId": "jensen-inequality-oq-01-oq-01",
+    "range": { "startLine": 85, "endLine": 89 },
+    "type": "theorem",
+    "title": "young_lt_of_ne: the strict form",
+    "content": "`young_lt_of_ne` records the strict inequality a·b < aᵖ/p + bᵍ/q when aᵖ ≠ bᵍ, assembled as `lt_of_le_of_ne` from `young_le` and the contrapositive of `young_eq_iff`. Together with the equality case it gives the complete trichotomy-free picture: equality exactly on aᵖ = bᵍ, strict everywhere else.",
+    "mathContext": "$a^p \\ne b^q \\implies ab < \\frac{a^p}{p} + \\frac{b^q}{q}$",
+    "significance": "supporting",
+    "relatedConcepts": ["strict inequality", "lt_of_le_of_ne", "contrapositive"],
+    "prerequisites": ["the equality case", "lt_of_le_of_ne"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01` (the equality case of Young's inequality, via weighted AM–GM).

This entry had a rich `meta.json` but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **AM–GM-in-disguise framing** — Young = two-term weighted AM–GM with weights 1/p, 1/q on data aᵖ, bᵍ.
- **amgm_two_weighted_eq_iff** — the parent's equality case specialized to Fin 2.
- **young_le** — the inequality itself (re-export of Mathlib's lemma).
- **young_eq_iff** — the headline: ab = aᵖ/p + bᵍ/q ↔ aᵖ = bᵍ, with the (aᵖ)^{1/p}=a telescoping trick.
- **young_lt_of_ne** — the strict form when aᵖ ≠ bᵍ.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)