### PR TITLE
Enrich n-Variable Young Product Inequality (jensen-inequality-oq-01-oq-01-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "youngn-oq010101-header",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "context",
+    "title": "The n-variable Young product inequality",
+    "content": "The header generalizes the parent's two-term Young inequality to an arbitrary finite family of exponents. For pᵢ > 0 with ∑ 1/pᵢ = 1 (generalized Hölder conjugacy) and nonnegative data aᵢ, ∏ aᵢ ≤ ∑ aᵢ^{pᵢ}/pᵢ, with equality iff all aᵢ^{pᵢ} are equal. This stands to the parent exactly as the grandparent's general weighted AM–GM stands to its two-variable instance: take weights wᵢ = 1/pᵢ and data zᵢ = aᵢ^{pᵢ}, so the weighted geometric mean ∏(aᵢ^{pᵢ})^{1/pᵢ} collapses to ∏aᵢ and the weighted arithmetic mean is the Young sum. Mathlib has only the two-variable Young inequality and none of the equality cases; this file supplies the full n-variable form, answering the parent's listed open question.",
+    "mathContext": "$\\prod_i a_i \\le \\sum_i \\frac{a_i^{p_i}}{p_i},\\quad \\sum_i \\frac{1}{p_i} = 1$",
+    "significance": "context",
+    "relatedConcepts": ["Young's inequality", "weighted AM–GM", "generalized Hölder", "equality case"],
+    "prerequisites": ["the two-variable Young inequality", "weighted AM–GM over a Finset"]
+  },
+  {
+    "id": "youngn-oq010101-rpow-inv",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 41, "endLine": 45 },
+    "type": "theorem",
+    "title": "rpow_pow_inv: the telescoping identity (aᵖ)^{1/p} = a",
+    "content": "`rpow_pow_inv` proves (aᵖ)^{p⁻¹} = a for a ≥ 0, p ≠ 0, via `Real.rpow_mul` and `mul_inv_cancel₀` (p·p⁻¹ = 1, then `rpow_one`). This is the pointwise identity that turns the weighted geometric mean ∏(aᵢ^{pᵢ})^{1/pᵢ} into the plain product ∏aᵢ — the exponent bookkeeping at the heart of recognizing Young as AM–GM.",
+    "mathContext": "$(a^p)^{p^{-1}} = a^{p \\cdot p^{-1}} = a^1 = a$",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow_mul", "mul_inv_cancel₀", "telescoping geometric mean"],
+    "prerequisites": ["real power (rpow) arithmetic"]
+  },
+  {
+    "id": "youngn-oq010101-prod-le",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 67 },
+    "type": "theorem",
+    "title": "young_prod_le: the n-variable inequality",
+    "content": "`young_prod_le` specializes the grandparent's `weighted_amgm_le` with weights wᵢ = (pᵢ)⁻¹ and data zᵢ = aᵢ^{pᵢ}. Two `Finset.prod_congr`/`sum_congr` rewrites convert the abstract means into the concrete Young statement: the geometric mean ∏(aᵢ^{pᵢ})^{1/pᵢ} collapses to ∏aᵢ (via `rpow_pow_inv`), and the arithmetic mean ∑(pᵢ)⁻¹·aᵢ^{pᵢ} becomes ∑aᵢ^{pᵢ}/pᵢ (via `div_eq_inv_mul`). No new convexity argument is needed — the inequality descends wholesale from weighted AM–GM.",
+    "mathContext": "$\\prod_i a_i = \\prod_i (a_i^{p_i})^{1/p_i} \\le \\sum_i \\frac{1}{p_i} a_i^{p_i} = \\sum_i \\frac{a_i^{p_i}}{p_i}$",
+    "significance": "key",
+    "relatedConcepts": ["weighted_amgm_le", "Finset.prod_congr", "div_eq_inv_mul", "specialization"],
+    "prerequisites": ["the grandparent weighted AM–GM inequality", "Finset products and sums"]
+  },
+  {
+    "id": "youngn-oq010101-prod-eq",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 69, "endLine": 86 },
+    "type": "theorem",
+    "title": "young_prod_eq_iff: the equality case (the new content)",
+    "content": "`young_prod_eq_iff` is the headline: ∏aᵢ = ∑aᵢ^{pᵢ}/pᵢ ↔ ∀ j,k ∈ s, aⱼ^{pⱼ} = aₖ^{pₖ}. It applies the grandparent's `weighted_amgm_eq_iff` (geometric mean = arithmetic mean iff all data equal) with the same weights/data, then reuses the identical `hgeo`/`harith` rewrites. The equality case is the structurally informative content — it pins the extremizers of the generalized Hölder inequality (all aᵢ^{pᵢ} proportional). Specializing to a two-element index set with Hölder-conjugate p, q recovers the parent's `young_eq_iff`, exhibiting depth-over-breadth: one general statement subsumes the prior entry.",
+    "mathContext": "$\\prod_i a_i = \\sum_i \\frac{a_i^{p_i}}{p_i} \\iff \\forall j,k\\in s,\\ a_j^{p_j} = a_k^{p_k}$",
+    "significance": "key",
+    "relatedConcepts": ["weighted_amgm_eq_iff", "equality case", "Hölder extremizers", "rigidity"],
+    "prerequisites": ["the grandparent weighted AM–GM equality case", "the n-variable inequality"]
+  },
+  {
+    "id": "youngn-oq010101-prod-lt",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01",
+    "range": { "startLine": 88, "endLine": 95 },
+    "type": "theorem",
+    "title": "young_prod_lt_of_ne: the strict form",
+    "content": "`young_prod_lt_of_ne` gives the strict inequality ∏aᵢ < ∑aᵢ^{pᵢ}/pᵢ whenever two of the values aᵢ^{pᵢ} differ, assembled as `lt_of_le_of_ne` from `young_prod_le` and the contrapositive of `young_prod_eq_iff` (the witnessing pair j, k extracted from the `∃`). It completes the picture: equality exactly when all aᵢ^{pᵢ} coincide, strict otherwise.",
+    "mathContext": "$\\exists j,k\\ a_j^{p_j} \\ne a_k^{p_k} \\implies \\prod_i a_i < \\sum_i \\frac{a_i^{p_i}}{p_i}$",
+    "significance": "supporting",
+    "relatedConcepts": ["strict inequality", "lt_of_le_of_ne", "contrapositive of the equality case"],
+    "prerequisites": ["the equality case", "lt_of_le_of_ne"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01` (the general n-variable Young product inequality and its equality case).

This entry had a rich `meta.json` but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **n-variable framing** — ∏aᵢ ≤ ∑aᵢ^{pᵢ}/pᵢ as the general weighted AM–GM with weights 1/pᵢ.
- **rpow_pow_inv** — the (aᵖ)^{1/p}=a telescoping identity.
- **young_prod_le** — the inequality, from weighted_amgm_le.
- **young_prod_eq_iff** — the headline equality case: ∏aᵢ = Young sum ↔ all aᵢ^{pᵢ} equal.
- **young_prod_lt_of_ne** — the strict form.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)