### PR TITLE
Enrich Power-Mean Monotonicity (jensen-inequality-oq-01-oq-01-oq-01-oq-04): add annotations.json

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "powermean-oq04-header",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 3, "endLine": 49 },
+    "type": "context",
+    "title": "The power-mean inequality and the Jensen substitution",
+    "content": "The header states the classical power-mean inequality, a gap in Mathlib: the weighted power mean M_p(x) = (∑ wᵢxᵢ^p)^{1/p} is monotone non-decreasing in the exponent p > 0, so 0 < p ≤ q ⟹ M_p ≤ M_q. This single statement subsumes the comparison of the arithmetic mean M_1 with every higher power mean — in particular QM–AM (root-mean-square). It is the canonical consequence of Jensen's inequality for the convex map t ↦ t^r (r ≥ 1). Mathlib provides only the single-exponent Jensen building block `Real.rpow_arith_mean_le_arith_mean_rpow`; this file supplies the closed-form mean and its monotonicity. The strategy: to compare M_p, M_q, set r = q/p ≥ 1 and apply Jensen to the powered data xᵢ^p.",
+    "mathContext": "$0 < p \\le q \\implies \\left(\\sum_i w_i x_i^p\\right)^{1/p} \\le \\left(\\sum_i w_i x_i^q\\right)^{1/q}$",
+    "significance": "context",
+    "relatedConcepts": ["power-mean inequality", "Jensen's inequality", "convexity of t↦t^r", "QM–AM", "mean hierarchy"],
+    "prerequisites": ["weighted means", "convexity", "Jensen's inequality"]
+  },
+  {
+    "id": "powermean-oq04-definition",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 57, "endLine": 76 },
+    "type": "definition",
+    "title": "The weighted power mean and basic facts",
+    "content": "`powerMean s w x p = (∑ i ∈ s, wᵢ·xᵢ^p)^{1/p}` is the closed-form weighted power mean (noncomputable, over `Real.rpow`). Three structural facts accompany it: `sum_term_nonneg` (the inner sum is nonnegative for nonnegative weights and data), `powerMean_nonneg` (the mean itself is nonnegative), and `powerMean_one` (M_1 = ∑ wᵢxᵢ, the weighted arithmetic mean, by `rpow_one`/`div_one`). These are the basic packaging Mathlib does not provide.",
+    "mathContext": "$M_p(x) = \\left(\\sum_{i\\in s} w_i x_i^p\\right)^{1/p},\\qquad M_1(x) = \\sum_{i\\in s} w_i x_i$",
+    "significance": "supporting",
+    "relatedConcepts": ["weighted power mean", "Real.rpow", "weighted arithmetic mean"],
+    "prerequisites": ["real powers (rpow)", "Finset sums"]
+  },
+  {
+    "id": "powermean-oq04-monotonicity",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 78, "endLine": 113 },
+    "type": "theorem",
+    "title": "powerMean_le_powerMean: monotonicity in the exponent",
+    "content": "The main theorem: for nonnegative weights summing to 1, nonnegative data, and 0 < p ≤ q, M_p ≤ M_q. The proof applies `Real.rpow_arith_mean_le_arith_mean_rpow` with r = q/p ≥ 1 to the powered data xᵢ^p, giving (∑wᵢxᵢ^p)^{q/p} ≤ ∑wᵢxᵢ^q — the RHS rewrite uses (xᵢ^p)^{q/p} = xᵢ^q (`Real.rpow_mul`, p·(q/p) = q by `field_simp`). It then reduces M_p ≤ M_q to comparing the q-th powers via `Real.rpow_le_rpow_iff` (valid since q > 0, both means nonnegative): M_p^q = (∑wᵢxᵢ^p)^{q/p} and M_q^q = ∑wᵢxᵢ^q, so the goal is exactly the Jensen bound. Raising to the common power q is what linearizes the reciprocal exponents 1/p, 1/q.",
+    "mathContext": "$M_p^q = \\left(\\sum w_i x_i^p\\right)^{q/p} \\le \\sum w_i x_i^q = M_q^q \\implies M_p \\le M_q$",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow_arith_mean_le_arith_mean_rpow", "Real.rpow_le_rpow_iff", "Real.rpow_mul", "Jensen substitution"],
+    "prerequisites": ["the single-exponent Jensen bound", "rpow monotonicity and arithmetic"]
+  },
+  {
+    "id": "powermean-oq04-arith",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 115, "endLine": 121 },
+    "type": "theorem",
+    "title": "arith_mean_le_powerMean: AM is the smallest power mean (p ≥ 1)",
+    "content": "`arith_mean_le_powerMean`: for p ≥ 1, the weighted arithmetic mean ∑wᵢxᵢ ≤ M_p. It is the p = 1 slice of `powerMean_le_powerMean`, obtained by rewriting ∑wᵢxᵢ as M_1 (`powerMean_one`) and applying monotonicity from 1 to p. So the arithmetic mean sits at the bottom of the power-mean scale for exponents ≥ 1.",
+    "mathContext": "$\\sum_i w_i x_i = M_1 \\le M_p\\quad (p \\ge 1)$",
+    "significance": "supporting",
+    "relatedConcepts": ["arithmetic mean", "p = 1 specialization", "powerMean_one"],
+    "prerequisites": ["the monotonicity theorem"]
+  },
+  {
+    "id": "powermean-oq04-qmam",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04",
+    "range": { "startLine": 123, "endLine": 130 },
+    "type": "theorem",
+    "title": "qm_am_inequality: the root-mean-square inequality",
+    "content": "`qm_am_inequality`: the weighted arithmetic mean is at most the weighted quadratic mean, ∑wᵢxᵢ ≤ (∑wᵢxᵢ²)^{1/2}. It is the (p, q) = (1, 2) case of `arith_mean_le_powerMean`, with the exponent bound 1 ≤ 2 discharged by `norm_num`. This is the classical QM–AM (root-mean-square) inequality as an immediate corollary of power-mean monotonicity.",
+    "mathContext": "$\\sum_i w_i x_i \\le \\left(\\sum_i w_i x_i^2\\right)^{1/2}$",
+    "significance": "supporting",
+    "relatedConcepts": ["QM–AM inequality", "root mean square", "(1,2) specialization"],
+    "prerequisites": ["arith_mean_le_powerMean"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01-oq-04` (monotonicity of the weighted power mean in its exponent).

This entry had a rich `meta.json` but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **Power-mean framing** — M_p monotone in p via Jensen for t↦t^{q/p}.
- **powerMean definition** + nonnegativity and M_1 = arithmetic mean.
- **powerMean_le_powerMean** — the headline monotonicity, raising to the common power q.
- **arith_mean_le_powerMean** — AM is the smallest power mean for p ≥ 1.
- **qm_am_inequality** — the root-mean-square inequality, the (1,2) case.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)