### PR TITLE
Enrich Sum of Stabilizer Sizes (lagrange-theorem-oq-02-oq-01-oq-02): add annotations.json

### DIFF
--- a/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "lagrange-oq020102-header",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 36 },
+    "type": "context",
+    "title": "The point-side counting identity, without Burnside",
+    "content": "The header frames the goal. For a finite group G acting on a finite set X, the incidence set {(g,x) : g·x = x} can be counted two ways: by group element, giving Σ_g |Fix(g)| (Burnside / Cauchy–Frobenius), or by point, giving Σ_x |Stab(x)|. Both equal |X/G|·|G|. The parent derives Burnside via the full double-counting chain; this child proves the point-side identity Σ_x |Stab(x)| = |X/G|·|G| *directly* from the orbit-stabilizer theorem, with no detour through Burnside. The mechanism: the disjoint union of stabilizers decomposes over orbits, and on each orbit it is orbit(rep) × Stab(rep) ≃ G, so summing the |X/G| orbits gives (X/G) × G.",
+    "mathContext": "$\\sum_{x \\in X} |\\mathrm{Stab}(x)| = |X/G| \\cdot |G|$",
+    "significance": "context",
+    "relatedConcepts": ["Burnside's lemma", "orbit-stabilizer theorem", "double counting", "group actions"],
+    "prerequisites": ["group actions", "orbits and stabilizers", "the orbit-stabilizer theorem"]
+  },
+  {
+    "id": "lagrange-oq020102-bijection",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 65 },
+    "type": "definition",
+    "title": "sigmaStabilizerEquivOrbitsProdGroup: the stabilizer half of the Burnside bijection",
+    "content": "The noncomputable equivalence (Σ b : β, stabilizer α b) ≃ Ω × α (Ω = X/G), built as a `calc` chain of Mathlib equivalences: (1) `selfEquivSigmaOrbits` decomposes X into its orbits; (2) `Equiv.sigmaAssoc` reassociates the nested sigma; (3) `stabilizerEquivStabilizerOfOrbitRel` replaces each point's stabilizer by that of the orbit representative ω.out (stabilizers in an orbit are conjugate); (4) `sigmaEquivProd` recombines each orbit's contribution as orbit × stabilizer; (5) `orbitProdStabilizerEquivGroup` collapses orbit(rep) × Stab(rep) to G; (6) a final `sigmaEquivProd` gives Ω × α. Mathlib only exposes the *combined* fixed-point/orbit bijection `sigmaFixedByEquivOrbitsProdGroup`; isolating the stabilizer half as a standalone equivalence is the file's contribution.",
+    "mathContext": "$\\left(\\textstyle\\Sigma_{b}\\ \\mathrm{Stab}(b)\\right) \\simeq \\Omega \\times \\alpha,\\quad \\mathrm{orbit}(\\omega) \\times \\mathrm{Stab}(\\omega) \\simeq G$",
+    "significance": "key",
+    "relatedConcepts": ["selfEquivSigmaOrbits", "orbitProdStabilizerEquivGroup", "stabilizerEquivStabilizerOfOrbitRel", "sigma/product equivalences"],
+    "prerequisites": ["orbit decomposition of a G-set", "the orbit-stabilizer equivalence", "sigma and product types"]
+  },
+  {
+    "id": "lagrange-oq020102-counting",
+    "proofId": "lagrange-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 74 },
+    "type": "theorem",
+    "title": "sum_card_stabilizer_eq_card_orbits_mul_card_group: taking cardinalities",
+    "content": "`sum_card_stabilizer_eq_card_orbits_mul_card_group` is the headline counting identity Σ_b |Stab(b)| = |Ω|·|α|. The proof is two rewrites: cardinality is multiplicative across the bijection, so `Fintype.card_prod`, `Fintype.card_sigma`, and `Fintype.card_congr sigmaStabilizerEquivOrbitsProdGroup` turn Σ_b |Stab(b)| into |(X/G) × G| = |X/G|·|G|. This is the stabilizer-side twin of Mathlib's `sum_card_fixedBy_eq_card_orbits_mul_card_group` (Burnside), obtained without circular dependence on Burnside.",
+    "mathContext": "$\\left|\\textstyle\\Sigma_b\\ \\mathrm{Stab}(b)\\right| = |(X/G) \\times G| = |X/G| \\cdot |G|$",
+    "significance": "key",
+    "relatedConcepts": ["Fintype.card_congr", "Fintype.card_sigma", "Fintype.card_prod", "Burnside twin identity"],
+    "prerequisites": ["cardinality of sigma and product types", "cardinality is a bijection invariant"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `lagrange-theorem-oq-02-oq-01-oq-02` (Σ_x |Stab(x)| = |X/G|·|G| directly from orbit-stabilizer).

This entry had a rich `meta.json` (with references) but no `annotations.json`. Added 3 inline annotations covering the full Lean file (2 declarations):

- **Without-Burnside framing** — counting the incidence set by point rather than by group element.
- **sigmaStabilizerEquivOrbitsProdGroup** — the stabilizer half of the Burnside bijection, as a calc chain of Mathlib equivalences.
- **sum_card_stabilizer_eq_card_orbits_mul_card_group** — taking cardinalities across the bijection.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **3 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)