### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-01-oq-03): weighted power-mean monotonicity from the square bound

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -695,6 +695,7 @@ import Proofs.ChebyshevSumMonotoneOQ01
 import Proofs.ChebyshevSumIntegralOQ01OQ01OQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01
 import Proofs.ChebyshevSumWeightedOQ01OQ01OQ02
+import Proofs.ChebyshevSumWeightedOQ01OQ01OQ03
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ05

--- a/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01OQ03.lean
+++ b/proofs/Proofs/ChebyshevSumWeightedOQ01OQ01OQ03.lean
@@ -1,0 +1,162 @@
+import Mathlib
+import Proofs.ChebyshevSumWeightedOQ01OQ01
+
+/-
+# Weighted power-mean monotonicity from the weighted square bound
+
+The parent file `ChebyshevSumWeightedOQ01OQ01` derives, from the weighted
+Chebyshev sum inequality, the **weighted square bound** (a weighted
+Cauchy–Schwarz / power-mean estimate)
+
+  (∑ i ∈ s, w i * f i) ^ 2 ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * f i ^ 2,
+
+valid for nonnegative weights `w` and *any* real `f`.
+
+This file answers the open question: **derive the weighted power-mean /
+Cauchy–Schwarz "chain" (weighted Lᵖ monotonicity) from that square bound.**
+The square bound is exactly the `p = 1 ≤ 2` rung of the power-mean ladder;
+substituting `f i = a i ^ r` and iterating climbs it.
+
+## Contents
+
+* `pow_sum_sq_le` — the **Cauchy–Schwarz / Lyapunov chain** for natural-exponent
+  power sums `P m = ∑ wᵢ aᵢ^m`:
+    `P (m + t) ^ 2 ≤ P m * P (m + 2 t)`,
+  obtained by applying the square bound to weights `wᵢ aᵢ^m` and function `aᵢ^t`.
+  This is the discrete log-convexity (Lyapunov) inequality for power sums.
+
+* `pow_sum_log_convex` — the consecutive case `P (m+1)^2 ≤ P m * P (m+2)`.
+
+* `rpow_sum_sq_le` — the real-exponent form `(∑ wᵢ aᵢ^r)^2 ≤ W · ∑ wᵢ aᵢ^(2r)`
+  for nonnegative data, the square bound specialised to `f = a^r`.
+
+* `weightedPowerMean` and `weightedPowerMean_le_double` — the headline:
+  the **weighted power mean** `M r = (∑ wᵢ aᵢ^r / ∑ wᵢ)^(1/r)` satisfies
+  `M r ≤ M (2 r)` for `r > 0`. This is weighted Lᵖ monotonicity along the dyadic
+  ladder of exponents, exactly the reach of the square bound (the continuous
+  monotonicity `M p ≤ M q` for all `p ≤ q` needs Hölder, which is out of scope here).
+
+* `weightedPowerMean_le_pow_two_mul` — iterating gives `M r ≤ M (2^k r)`.
+
+All results are fully verified with no extra axioms.
+-/
+
+namespace ChebyshevSumWeightedPowerMean
+
+open Finset
+
+variable {ι : Type*}
+
+/-! ## Natural-exponent Lyapunov chain (no roots) -/
+
+/-- **Cauchy–Schwarz / Lyapunov chain for power sums.** For nonnegative data `a`
+and nonnegative weights `w`, the power sums `P m = ∑ wᵢ aᵢ^m` obey
+`P (m + t) ^ 2 ≤ P m * P (m + 2 t)`.
+
+This is the discrete log-convexity of the power-sum sequence, obtained by feeding
+the weighted square bound the weights `wᵢ aᵢ^m` and the function `aᵢ^t`. -/
+theorem pow_sum_sq_le (a w : ι → ℝ) (s : Finset ι)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hw : ∀ i ∈ s, 0 ≤ w i) (m t : ℕ) :
+    (∑ i ∈ s, w i * a i ^ (m + t)) ^ 2
+      ≤ (∑ i ∈ s, w i * a i ^ m) * ∑ i ∈ s, w i * a i ^ (m + 2 * t) := by
+  have hw' : ∀ i ∈ s, 0 ≤ w i * a i ^ m := fun i hi =>
+    mul_nonneg (hw i hi) (pow_nonneg (ha i hi) m)
+  have h := ChebyshevSumWeighted.weighted_sq_sum_le (fun i => w i * a i ^ m)
+    (fun i => a i ^ t) s hw'
+  have e1 : ∑ i ∈ s, (w i * a i ^ m) * a i ^ t = ∑ i ∈ s, w i * a i ^ (m + t) :=
+    Finset.sum_congr rfl fun i _ => by rw [mul_assoc, ← pow_add]
+  have e2 : ∑ i ∈ s, (w i * a i ^ m) * (a i ^ t) ^ 2 = ∑ i ∈ s, w i * a i ^ (m + 2 * t) :=
+    Finset.sum_congr rfl fun i _ => by
+      rw [← pow_mul, mul_assoc, ← pow_add, Nat.mul_comm t 2]
+  simpa only [e1, e2] using h
+
+/-- **Log-convexity of power sums** (consecutive case): `P (m+1)^2 ≤ P m · P (m+2)`. -/
+theorem pow_sum_log_convex (a w : ι → ℝ) (s : Finset ι)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hw : ∀ i ∈ s, 0 ≤ w i) (m : ℕ) :
+    (∑ i ∈ s, w i * a i ^ (m + 1)) ^ 2
+      ≤ (∑ i ∈ s, w i * a i ^ m) * ∑ i ∈ s, w i * a i ^ (m + 2) := by
+  simpa using pow_sum_sq_le a w s ha hw m 1
+
+/-! ## Real-exponent square bound -/
+
+/-- **Real-exponent square bound.** For nonnegative data and weights,
+`(∑ wᵢ aᵢ^r)^2 ≤ (∑ wᵢ) · ∑ wᵢ aᵢ^(2r)`. This is the parent's square bound applied
+to `f i = a i ^ r` (real `rpow`), the `r ↦ 2r` rung of the power-mean ladder. -/
+theorem rpow_sum_sq_le (a w : ι → ℝ) (s : Finset ι)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hw : ∀ i ∈ s, 0 ≤ w i) (r : ℝ) :
+    (∑ i ∈ s, w i * a i ^ r) ^ 2
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * a i ^ (2 * r) := by
+  have h := ChebyshevSumWeighted.weighted_sq_sum_le w (fun i => a i ^ r) s hw
+  have e : ∑ i ∈ s, w i * (a i ^ r) ^ 2 = ∑ i ∈ s, w i * a i ^ (2 * r) :=
+    Finset.sum_congr rfl fun i hi => by
+      rw [← Real.rpow_natCast (a i ^ r) 2, ← Real.rpow_mul (ha i hi),
+        show r * ((2 : ℕ) : ℝ) = 2 * r from by push_cast; ring]
+  simpa only [e] using h
+
+/-! ## The weighted power mean and its dyadic monotonicity -/
+
+/-- The **weighted power mean** of order `r` of data `a` with weights `w` on `s`:
+`M r = (∑ wᵢ aᵢ^r / ∑ wᵢ)^(1/r)`. -/
+noncomputable def weightedPowerMean (w a : ι → ℝ) (s : Finset ι) (r : ℝ) : ℝ :=
+  ((∑ i ∈ s, w i * a i ^ r) / (∑ i ∈ s, w i)) ^ (1 / r)
+
+/-- **Weighted power-mean monotonicity along the dyadic ladder.** For nonnegative
+data and weights with positive total mass, and any order `r > 0`,
+`M r ≤ M (2 r)`. This is weighted Lᵖ monotonicity, derived purely from the
+weighted square bound (the `r ↦ 2r` rung). -/
+theorem weightedPowerMean_le_double (w a : ι → ℝ) (s : Finset ι)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hW : 0 < ∑ i ∈ s, w i) {r : ℝ} (hr : 0 < r) :
+    weightedPowerMean w a s r ≤ weightedPowerMean w a s (2 * r) := by
+  have hrne : r ≠ 0 := hr.ne'
+  have hSr : 0 ≤ ∑ i ∈ s, w i * a i ^ r :=
+    Finset.sum_nonneg fun i hi => mul_nonneg (hw i hi) (Real.rpow_nonneg (ha i hi) r)
+  have hsq : (∑ i ∈ s, w i * a i ^ r) ^ 2
+      ≤ (∑ i ∈ s, w i) * ∑ i ∈ s, w i * a i ^ (2 * r) := rpow_sum_sq_le a w s ha hw r
+  simp only [weightedPowerMean]
+  set W := ∑ i ∈ s, w i with hWdef
+  set Sr := ∑ i ∈ s, w i * a i ^ r with hSrdef
+  set S2r := ∑ i ∈ s, w i * a i ^ (2 * r) with hS2rdef
+  have hNr : 0 ≤ Sr / W := div_nonneg hSr hW.le
+  have hW2 : (0 : ℝ) < W ^ 2 := by positivity
+  have hN : (Sr / W) ^ 2 ≤ S2r / W := by
+    rw [div_pow, div_le_div_iff₀ hW2 hW]
+    nlinarith [mul_le_mul_of_nonneg_right hsq hW.le]
+  have hexp : ((2 : ℕ) : ℝ) * (1 / (2 * r)) = 1 / r := by
+    rw [Nat.cast_ofNat, one_div, one_div, mul_inv, ← mul_assoc,
+      mul_inv_cancel₀ (two_ne_zero), one_mul]
+  calc (Sr / W) ^ (1 / r)
+      = ((Sr / W) ^ (2 : ℕ)) ^ (1 / (2 * r)) := by
+        rw [← Real.rpow_natCast (Sr / W) 2, ← Real.rpow_mul hNr, hexp]
+    _ ≤ (S2r / W) ^ (1 / (2 * r)) :=
+        Real.rpow_le_rpow (pow_nonneg hNr 2) hN (by positivity)
+
+/-- Iterating `weightedPowerMean_le_double`: `M r ≤ M (2^k r)` for every `k`. -/
+theorem weightedPowerMean_le_pow_two_mul (w a : ι → ℝ) (s : Finset ι)
+    (ha : ∀ i ∈ s, 0 ≤ a i) (hw : ∀ i ∈ s, 0 ≤ w i)
+    (hW : 0 < ∑ i ∈ s, w i) {r : ℝ} (hr : 0 < r) (k : ℕ) :
+    weightedPowerMean w a s r ≤ weightedPowerMean w a s (2 ^ k * r) := by
+  induction k with
+  | zero => simp
+  | succ n ih =>
+    have hrn : (0 : ℝ) < 2 ^ n * r := by positivity
+    have step := weightedPowerMean_le_double w a s ha hw hW hrn
+    calc weightedPowerMean w a s r
+        ≤ weightedPowerMean w a s (2 ^ n * r) := ih
+      _ ≤ weightedPowerMean w a s (2 * (2 ^ n * r)) := step
+      _ = weightedPowerMean w a s (2 ^ (n + 1) * r) := by
+            rw [show (2 : ℝ) * (2 ^ n * r) = 2 ^ (n + 1) * r from by ring]
+
+/-! ## Worked instance -/
+
+/-- A concrete dyadic power-mean comparison `M 1 ≤ M 2` for the data `0, 1, 2`
+with weights `1, 2, 3`, an instance of `weightedPowerMean_le_double`. -/
+example :
+    weightedPowerMean (fun i : ℕ => (i : ℝ) + 1) (fun i : ℕ => (i : ℝ)) (range 3) 1
+      ≤ weightedPowerMean (fun i : ℕ => (i : ℝ) + 1) (fun i : ℕ => (i : ℝ)) (range 3) 2 := by
+  have h := weightedPowerMean_le_double (fun i : ℕ => (i : ℝ) + 1) (fun i : ℕ => (i : ℝ))
+    (range 3) (fun i _ => by positivity) (fun i _ => by positivity)
+    (by norm_num [Finset.sum_range_succ]) (show (0 : ℝ) < 1 by norm_num)
+  simpa using h
+
+end ChebyshevSumWeightedPowerMean

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-01-oq-03/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+  "title": "Weighted Power-Mean Monotonicity from the Weighted Square Bound",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-01-oq-03",
+  "description": "The parent file derives, from the weighted Chebyshev sum inequality, the weighted Cauchy–Schwarz square bound (∑ wᵢfᵢ)² ≤ W·∑ wᵢfᵢ². This file answers its third open question: derive the weighted power-mean / Cauchy–Schwarz 'chain' (weighted Lᵖ monotonicity) from that square bound. Feeding the square bound the weights wᵢaᵢ^m and function aᵢ^t yields the discrete Lyapunov / log-convexity inequality for power sums P(m+t)² ≤ P(m)·P(m+2t); feeding it f = aᵢ^r (real rpow) gives (∑ wᵢaᵢ^r)² ≤ W·∑ wᵢaᵢ^(2r), the r ↦ 2r rung of the power-mean ladder. Iterating it proves the headline: the weighted power mean Mᵣ = (∑ wᵢaᵢ^r / W)^(1/r) satisfies Mᵣ ≤ M₂ᵣ for r > 0, hence Mᵣ ≤ M_(2^k r) for every k — weighted Lᵖ monotonicity along the dyadic ladder, exactly the elementary reach of a single square (Cauchy–Schwarz) bound.",
+  "meta": {
+    "author": "Lean Genius Researcher (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Generalized_mean",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "inequalities",
+      "order",
+      "chebyshev-sum-inequality",
+      "weighted",
+      "power-mean",
+      "cauchy-schwarz",
+      "log-convexity"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevSumWeightedOQ01OQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 162,
+    "mathlibDependencies": [
+      {
+        "theorem": "ChebyshevSumWeighted.weighted_sq_sum_le",
+        "description": "The parent file's weighted Cauchy–Schwarz square bound (∑ wᵢfᵢ)² ≤ (∑ wᵢ)·∑ wᵢfᵢ² for nonnegative weights and any real f — the sole engine; every result here is obtained by substituting a specific weight/function and simplifying",
+        "module": "Proofs.ChebyshevSumWeightedOQ01OQ01"
+      },
+      {
+        "theorem": "Real.rpow_natCast / Real.rpow_mul / Real.rpow_nonneg",
+        "description": "Real power (rpow) arithmetic: converting between natural and real exponents, (xʸ)ᶻ = x^(yz) for x ≥ 0, and nonnegativity of x^y — used to specialise the square bound to f = a^r and to manipulate the (1/r)-th root in the power mean",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of z ↦ x^z in the base for fixed nonnegative exponent: 0 ≤ x ≤ y, 0 ≤ z ⟹ xᶻ ≤ yᶻ — turns the squared-mean bound into the comparison of (1/(2r))-th roots that is the power-mean inequality",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "pow_add / pow_mul",
+        "description": "Exponent arithmetic aᵐ⁺ⁿ = aᵐaⁿ and a^(mn) = (aᵐ)ⁿ for natural exponents — collapses the substituted weight/function products in the discrete Lyapunov chain",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "pow_sum_sq_le: the discrete Cauchy–Schwarz / Lyapunov chain P(m+t)² ≤ P(m)·P(m+2t) for natural-exponent power sums P(m) = ∑ wᵢaᵢᵐ of nonnegative data, obtained by feeding the parent's square bound the weights wᵢaᵢᵐ and function aᵢᵗ — the log-convexity of the power-sum sequence",
+      "pow_sum_log_convex: the consecutive case P(m+1)² ≤ P(m)·P(m+2)",
+      "rpow_sum_sq_le: the real-exponent square bound (∑ wᵢaᵢ^r)² ≤ W·∑ wᵢaᵢ^(2r) for nonnegative data, the parent bound specialised to f = a^r",
+      "weightedPowerMean: the weighted power mean of order r, Mᵣ = (∑ wᵢaᵢ^r / ∑ wᵢ)^(1/r)",
+      "weightedPowerMean_le_double: the headline weighted Lᵖ monotonicity Mᵣ ≤ M₂ᵣ for r > 0, derived purely from the square bound (the r ↦ 2r rung)",
+      "weightedPowerMean_le_pow_two_mul: iterating the doubling gives Mᵣ ≤ M_(2^k r) for every k — the full dyadic power-mean ladder"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The power mean (or Hölder mean) Mᵣ of order r interpolates the classical means — harmonic (r = −1), geometric (r → 0), arithmetic (r = 1), quadratic (r = 2) — and the power-mean inequality states that Mᵣ is monotone increasing in r. Its weighted form, with a probability-like weight wᵢ ≥ 0, is the discrete heart of the Lᵖ-norm monotonicity on a finite measure space and of Lyapunov's inequality for the moments of a random variable. The cleanest elementary engine is a single Cauchy–Schwarz (square) bound: (∑ wᵢbᵢ)² ≤ W·∑ wᵢbᵢ². Substituting bᵢ = aᵢ^r turns one application of this bound into the r ↦ 2r rung of the ladder, and iterating climbs the dyadic exponents 1, 2, 4, 8, … — exactly how far an unaided square bound reaches before Hölder's inequality is needed for arbitrary intermediate exponents.",
+    "problemStatement": "Starting only from the parent's weighted square bound (∑_{i∈s} wᵢ fᵢ)² ≤ (∑_{i∈s} wᵢ)·∑_{i∈s} wᵢ fᵢ² (nonnegative weights, arbitrary real f), derive the weighted power-mean / Cauchy–Schwarz chain. Concretely: (i) the discrete log-convexity P(m+t)² ≤ P(m)·P(m+2t) of the power sums P(m) = ∑ wᵢ aᵢᵐ; (ii) the real-exponent bound (∑ wᵢ aᵢ^r)² ≤ W·∑ wᵢ aᵢ^(2r); and (iii) the weighted power-mean monotonicity Mᵣ ≤ M₂ᵣ along the dyadic ladder, where Mᵣ = (∑ wᵢ aᵢ^r / ∑ wᵢ)^(1/r) and r > 0.",
+    "proofStrategy": "Every result is one substitution into the parent's square bound, plus bookkeeping.\n\n1. Discrete Lyapunov chain (pow_sum_sq_le): apply the square bound with weights wᵢaᵢᵐ (nonnegative since aᵢ, wᵢ ≥ 0) and function aᵢᵗ. The left side becomes (∑ wᵢaᵢ^(m+t))², the multiplier stays ∑ wᵢaᵢᵐ, and ∑ (wᵢaᵢᵐ)(aᵢᵗ)² = ∑ wᵢaᵢ^(m+2t); exponent arithmetic via pow_add / pow_mul finishes it.\n\n2. Real-exponent bound (rpow_sum_sq_le): apply the square bound with f = aᵢ^r (real rpow). The only rewriting is (aᵢ^r)² = aᵢ^(2r), via rpow_natCast and rpow_mul (needs aᵢ ≥ 0).\n\n3. Dyadic power-mean monotonicity (weightedPowerMean_le_double): write Nᵣ = ∑ wᵢaᵢ^r / W. The real bound gives Nᵣ² ≤ N₂ᵣ. Since x ↦ x^(1/(2r)) is monotone on the nonnegatives, M₂ᵣ = N₂ᵣ^(1/(2r)) ≥ (Nᵣ²)^(1/(2r)) = Nᵣ^(1/r) = Mᵣ, using 2·(1/(2r)) = 1/r.\n\n4. The full ladder (weightedPowerMean_le_pow_two_mul): induct on k, doubling the exponent each step (2·(2ⁿr) = 2^(n+1)r).",
+    "keyInsights": [
+      "A single Cauchy–Schwarz (square) bound IS the r ↦ 2r rung of the power-mean ladder: substituting f = a^r converts (∑ wf)² ≤ W·∑ wf² into (∑ wa^r)² ≤ W·∑ wa^(2r) with no new analytic input.",
+      "The square bound only reaches dyadic exponents 1, 2, 4, 8, …; weighted Lᵖ monotonicity for ALL p ≤ q needs Hölder's inequality, which is intentionally out of scope — this file isolates exactly what the square bound alone yields.",
+      "With natural exponents the same substitution gives the log-convexity (Lyapunov) inequality P(m+t)² ≤ P(m)·P(m+2t) of the power-sum sequence, entirely root-free and hence purely algebraic.",
+      "Nonnegativity of the data is the only hypothesis the rpow step needs (so that a^r and the (1/r)-th root behave); the weight side reuses the parent bound verbatim.",
+      "The (1/r)-th root is handled by one monotonicity lemma (Real.rpow_le_rpow) plus the exponent identity 2·(1/(2r)) = 1/r — no inequality between means is assumed, only the squared-mean comparison."
+    ],
+    "prerequisites": [
+      "The parent's weighted Cauchy–Schwarz square bound (∑ wf)² ≤ W·∑ wf²",
+      "Real powers (rpow) and their arithmetic: rpow_natCast, rpow_mul, rpow_nonneg, rpow_le_rpow",
+      "Finite sums over Finset and nonnegativity of sums of nonnegative terms",
+      "The power mean / generalized mean and the statement of the power-mean inequality"
+    ]
+  },
+  "conclusion": {
+    "summary": "Building only on the parent's weighted square bound, we derived the weighted power-mean / Cauchy–Schwarz chain: the discrete log-convexity P(m+t)² ≤ P(m)·P(m+2t) of natural-exponent power sums, the real-exponent bound (∑ wa^r)² ≤ W·∑ wa^(2r), and the weighted power-mean monotonicity Mᵣ ≤ M₂ᵣ (hence Mᵣ ≤ M_(2^k r)) for nonnegative data with positive total weight. All five results are fully machine-checked with 0 sorries and depend only on the foundational axioms.",
+    "implications": "This exhibits the elementary mechanism behind weighted Lᵖ monotonicity: one Cauchy–Schwarz bound, substituted and iterated, climbs the dyadic power-mean ladder without any appeal to convexity machinery or Hölder's inequality. It answers the third open question of the weighted-Chebyshev companion and isolates the precise gap (intermediate non-dyadic exponents) that genuinely requires Hölder.",
+    "openQuestions": [
+      "Close the dyadic ladder to full continuous monotonicity Mₚ ≤ M_q for all 0 < p ≤ q, using Hölder's inequality (the step the square bound alone cannot supply).",
+      "Establish the equality case: Mᵣ = M₂ᵣ iff a is constant on the support {i ∈ s : wᵢ > 0}, sharpening the dyadic inequality to a rigidity statement.",
+      "Extend the discrete Lyapunov chain to the moment-generating / continuous setting, P(s)² ≤ P(s−t)·P(s+t) for the moments of a finite measure."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports (Mathlib plus the parent file), an expository docstring framing the square bound as the p = 1 ≤ 2 rung of the power-mean ladder, and namespace setup."
+    },
+    {
+      "id": "natural-lyapunov",
+      "title": "Natural-Exponent Lyapunov Chain",
+      "startLine": 57,
+      "endLine": 83,
+      "summary": "pow_sum_sq_le and pow_sum_log_convex: feeding the square bound the weights wᵢaᵢᵐ and function aᵢᵗ yields the discrete log-convexity P(m+t)² ≤ P(m)·P(m+2t) of the power sums, root-free."
+    },
+    {
+      "id": "rpow-square-bound",
+      "title": "Real-Exponent Square Bound",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "rpow_sum_sq_le: the parent bound specialised to f = aᵢ^r, giving (∑ wᵢaᵢ^r)² ≤ W·∑ wᵢaᵢ^(2r) for nonnegative data — the r ↦ 2r rung."
+    },
+    {
+      "id": "power-mean-monotonicity",
+      "title": "The Weighted Power Mean and Its Dyadic Monotonicity",
+      "startLine": 99,
+      "endLine": 152,
+      "summary": "weightedPowerMean defines Mᵣ = (∑ wᵢaᵢ^r / ∑ wᵢ)^(1/r); weightedPowerMean_le_double proves Mᵣ ≤ M₂ᵣ from Nᵣ² ≤ N₂ᵣ via rpow monotonicity; weightedPowerMean_le_pow_two_mul iterates to Mᵣ ≤ M_(2^k r)."
+    },
+    {
+      "id": "worked-instance",
+      "title": "Worked Instance",
+      "startLine": 153,
+      "endLine": 162,
+      "summary": "A concrete dyadic comparison M₁ ≤ M₂ for the data 0,1,2 with weights 1,2,3, an instance of weightedPowerMean_le_double."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The weighted Chebyshev companion whose weighted square bound (weighted_sq_sum_le) is the sole engine of this file; answers its third open question"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01",
+      "relationship": "related",
+      "description": "The unweighted monotone-sequence Chebyshev inequality at the root of this open-question chain"
+    }
+  ],
+  "references": [
+    {
+      "text": "Hardy, G. H., Littlewood, J. E., Pólya, G. (1952). Inequalities, 2nd ed., Cambridge University Press (power means and the power-mean inequality).",
+      "url": "https://archive.org/details/Inequalities_201705"
+    },
+    {
+      "text": "Generalized mean (power mean) and the power-mean inequality.",
+      "url": "https://en.wikipedia.org/wiki/Generalized_mean"
+    },
+    {
+      "text": "Lyapunov's inequality for moments (log-convexity of power sums).",
+      "url": "https://en.wikipedia.org/wiki/Lyapunov_inequality"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevSumWeightedOQ01OQ01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "ChebyshevSumWeightedPowerMean",
+    "lineCount": 162,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/ChebyshevSumWeightedOQ01OQ01OQ03.lean",
+    "theoremCount": 5,
+    "definitionCount": 1
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `chebyshev-sum-inequality-oq-01-oq-01` ("derive the weighted power-mean / Cauchy–Schwarz chain — weighted Lᵖ monotonicity — from the weighted square bound").

The parent file derives, from the weighted Chebyshev sum inequality, the **weighted square bound** `(∑ wᵢfᵢ)² ≤ W·∑ wᵢfᵢ²` (nonnegative weights, any real `f`). This file shows that single bound *is* the `r ↦ 2r` rung of the power-mean ladder, and iterating it climbs the dyadic exponents.

## Results (5 theorems, 1 definition, 162 lines)

- **`pow_sum_sq_le`** — discrete Lyapunov / log-convexity chain `P(m+t)² ≤ P(m)·P(m+2t)` for natural-exponent power sums `P(m) = ∑ wᵢaᵢᵐ`, by feeding the square bound the weights `wᵢaᵢᵐ` and function `aᵢᵗ` (root-free).
- **`pow_sum_log_convex`** — the consecutive case `P(m+1)² ≤ P(m)·P(m+2)`.
- **`rpow_sum_sq_le`** — real-exponent bound `(∑ wᵢaᵢ^r)² ≤ W·∑ wᵢaᵢ^(2r)` for nonnegative data.
- **`weightedPowerMean` + `weightedPowerMean_le_double`** — the weighted power mean `Mᵣ = (∑ wᵢaᵢ^r / W)^(1/r)` satisfies `Mᵣ ≤ M₂ᵣ` for `r > 0`.
- **`weightedPowerMean_le_pow_two_mul`** — iterating gives `Mᵣ ≤ M_(2^k r)`, the full dyadic ladder.

## Scope / honesty

The square bound alone reaches only **dyadic** exponents (1, 2, 4, 8, …). Full continuous monotonicity `Mₚ ≤ M_q` for all `0 < p ≤ q` requires Hölder's inequality and is intentionally **out of scope** — this PR isolates exactly what one Cauchy–Schwarz bound yields, and flags the Hölder gap as a follow-up open question.

## Verification

- **Kernel-verified** via `lake env lean` over cached Mathlib oleans (Docker is down). 0 errors.
- 0 sorries; `#print axioms` reports only `propext / Classical.choice / Quot.sound`.
- Status: `verified` / badge `original` / `axiomCount: 0`.
- Builds on `ChebyshevSumWeighted.weighted_sq_sum_le` from the parent file (imported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)