### PR TITLE
research(solution-of-cubic-oq-01-oq-02): discriminant of the general cubic

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3469,6 +3469,7 @@ import Proofs.SkolemNoetherMatrixAutAristotle
 import Proofs.SolutionOfCubic
 import Proofs.SolutionOfCubicOQ01
 import Proofs.SolutionOfCubicOQ01OQ01
+import Proofs.SolutionOfCubicOQ01OQ02
 import Proofs.SolutionOfCubicOQ03
 import Proofs.SolutionOfCubicOQ03OQ01
 import Proofs.SolutionOfCubicOQ03OQ02

--- a/proofs/Proofs/SolutionOfCubicOQ01OQ02.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ01OQ02.lean
@@ -1,0 +1,168 @@
+import Proofs.SolutionOfCubicOQ01
+
+/-!
+# The Discriminant of the General Cubic (Solution of Cubic, OQ-01-OQ-02)
+
+## What This Proves
+
+The parent file `SolutionOfCubicOQ01` reduced the general cubic `a x³ + b x² + c x + d`
+(`a ≠ 0`) to depressed form `a·(t³ + p t + q)` via the Tschirnhaus shift, with
+
+  `p = (3ac − b²)/(3a²)`,   `q = (2b³ − 9abc + 27a²d)/(27a³)`,
+
+and the parent's Cardano machinery measures solvability through the **depressed
+discriminant** `q²/4 + p³/27`. This file answers the parent's second open question:
+
+> *Formalize the discriminant of the general cubic in terms of `a, b, c, d` and relate it
+> to the depressed discriminant `q²/4 + p³/27` used by the parent.*
+
+The classical discriminant of `a x³ + b x² + c x + d` is
+
+  `Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`.
+
+## Original Contributions
+- `cubicDisc` — the classical discriminant as a polynomial in `a, b, c, d`.
+- `cubicDisc_eq_depressed` — the bridge: `Δ = −108 · a⁴ · (q²/4 + p³/27)`, i.e. the general
+  discriminant is, up to the universal factor `−108 a⁴`, exactly the depressed discriminant
+  the parent uses. This is the precise sense in which the Tschirnhaus shift preserves the
+  discriminant (it scales it by `a⁴` and changes sign convention by `−108`).
+- `cubicDisc_eq_zero_iff_depressed` — consequently `Δ = 0 ⟺ q²/4 + p³/27 = 0`, so the two
+  discriminants detect a repeated root *simultaneously*.
+- `cubicDisc_eq_of_roots` — the root form: if `a x³ + b x² + c x + d = a(x−r)(x−s)(x−t)`
+  (Vieta), then `Δ = a⁴·((r−s)(r−t)(s−t))²`, the textbook product-of-squared-differences.
+- `cubicDisc_roots_eq_zero_iff` — `Δ = 0 ⟺ two of the roots coincide`, the geometric meaning
+  of the discriminant.
+
+## Proof Techniques
+Pure field arithmetic (`field_simp` + `ring`) for the bridge; `ring` for the root identity;
+`mul_eq_zero` / `sq_eq_zero_iff` / `sub_eq_zero` for the vanishing criteria. Everything is
+over `ℂ`, matching the parent, and is `0`-axiom.
+-/
+
+namespace SolutionOfCubicOQ01OQ02
+
+open SolutionOfCubicOQ01
+
+/-! ## Part 1: The classical discriminant -/
+
+/-- **The discriminant of the general cubic** `a x³ + b x² + c x + d`:
+
+  `Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`.
+
+This is the standard symmetric polynomial whose vanishing detects a repeated root. -/
+def cubicDisc (a b c d : ℂ) : ℂ :=
+  18 * a * b * c * d - 4 * b ^ 3 * d + b ^ 2 * c ^ 2 - 4 * a * c ^ 3 - 27 * a ^ 2 * d ^ 2
+
+/-- **The depressed discriminant** `q²/4 + p³/27` used by the parent's Cardano formula.
+Its sign decides the number of real roots of the depressed cubic `t³ + p t + q`. -/
+noncomputable def depressedDisc (p q : ℂ) : ℂ := q ^ 2 / 4 + p ^ 3 / 27
+
+/-! ## Part 2: The bridge to the depressed discriminant
+
+Substituting the depressed parameters `p = depressedP a b c`, `q = depressedQ a b c d` into
+`q²/4 + p³/27` recovers the general discriminant up to the universal factor `−108 a⁴`. -/
+
+/-- **The discriminant bridge.** For `a ≠ 0`, the classical discriminant of the general
+cubic equals `−108 · a⁴` times the depressed discriminant `q²/4 + p³/27` of its Tschirnhaus
+reduction:
+
+  `Δ = −108 · a⁴ · ( q²/4 + p³/27 )`.
+
+Equivalently `q²/4 + p³/27 = −Δ / (108 a⁴)`. The factor `a⁴` is the expected scaling of a
+cubic discriminant under a leading coefficient, and `−108` is the conversion between the two
+standard sign conventions (`Δ = a⁴(−4p³ − 27q²)` versus `q²/4 + p³/27`). -/
+theorem cubicDisc_eq_depressed (a b c d : ℂ) (ha : a ≠ 0) :
+    cubicDisc a b c d
+      = -108 * a ^ 4 * depressedDisc (depressedP a b c) (depressedQ a b c d) := by
+  unfold cubicDisc depressedDisc depressedP depressedQ
+  field_simp
+  ring
+
+/-- **The two discriminants vanish together.** For `a ≠ 0`, the general cubic has a repeated
+root (`Δ = 0`) exactly when the depressed discriminant vanishes (`q²/4 + p³/27 = 0`). The
+Tschirnhaus shift therefore preserves the *repeated-root* locus, as it must, being a
+bijection on roots. -/
+theorem cubicDisc_eq_zero_iff_depressed (a b c d : ℂ) (ha : a ≠ 0) :
+    cubicDisc a b c d = 0
+      ↔ depressedDisc (depressedP a b c) (depressedQ a b c d) = 0 := by
+  rw [cubicDisc_eq_depressed a b c d ha]
+  have hfac : (-108 : ℂ) * a ^ 4 ≠ 0 := by
+    apply mul_ne_zero
+    · norm_num
+    · exact pow_ne_zero 4 ha
+  constructor
+  · intro h
+    exact (mul_eq_zero.mp h).resolve_left hfac
+  · intro h
+    rw [h, mul_zero]
+
+/-! ## Part 3: The root form and the geometric meaning
+
+Writing the cubic in factored form `a(x−r)(x−s)(x−t)` (Vieta), the discriminant becomes the
+classical product of squared root differences. -/
+
+/-- **Discriminant in terms of roots (Vieta).** If the general cubic factors as
+`a(x − r)(x − s)(x − t)`, so that by Vieta
+
+  `b = −a(r + s + t)`,  `c = a(rs + rt + st)`,  `d = −a·rst`,
+
+then its discriminant is `Δ = a⁴·((r−s)(r−t)(s−t))²` — the leading coefficient to the
+fourth power times the squared product of pairwise root differences. -/
+theorem cubicDisc_eq_of_roots (a r s t : ℂ) :
+    cubicDisc a (-(a * (r + s + t))) (a * (r * s + r * t + s * t)) (-(a * (r * s * t)))
+      = a ^ 4 * ((r - s) * (r - t) * (s - t)) ^ 2 := by
+  unfold cubicDisc
+  ring
+
+/-- **The discriminant detects a repeated root.** With `a ≠ 0` and the cubic in factored
+form `a(x − r)(x − s)(x − t)`, the discriminant vanishes precisely when two of the roots
+coincide:
+
+  `Δ = 0 ⟺ r = s ∨ r = t ∨ s = t`. -/
+theorem cubicDisc_roots_eq_zero_iff (a r s t : ℂ) (ha : a ≠ 0) :
+    cubicDisc a (-(a * (r + s + t))) (a * (r * s + r * t + s * t)) (-(a * (r * s * t))) = 0
+      ↔ r = s ∨ r = t ∨ s = t := by
+  rw [cubicDisc_eq_of_roots a r s t]
+  -- `a⁴ = 0` is impossible; what remains is the disjunction over the three differences.
+  have ha4 : a ^ 4 ≠ 0 := pow_ne_zero 4 ha
+  rw [mul_eq_zero, sq_eq_zero_iff, mul_eq_zero, mul_eq_zero,
+    sub_eq_zero, sub_eq_zero, sub_eq_zero]
+  -- The product rewrites yield a left-associated disjunction; `tauto` reconciles the
+  -- associativity and discharges the `a⁴ = 0` branch using `ha4`.
+  tauto
+
+/-! ## Part 4: Sanity checks -/
+
+/-- The depressed discriminant is the `a = 1, b = 0` specialization of the general one:
+for an already-depressed cubic `x³ + p x + q` (here `c = p`, `d = q`), the classical formula
+collapses to `−4p³ − 27q² = −108·(q²/4 + p³/27)`. -/
+example (p q : ℂ) : cubicDisc 1 0 p q = -4 * p ^ 3 - 27 * q ^ 2 := by
+  unfold cubicDisc; ring
+
+example (p q : ℂ) : cubicDisc 1 0 p q = -108 * depressedDisc p q := by
+  unfold cubicDisc depressedDisc; ring
+
+/-- `x³ − 3x + 2 = (x − 1)²(x + 2)` has a repeated root, so its discriminant is `0`.
+(`p = −3, q = 2`: `−4(−27) − 27·4 = 108 − 108 = 0`.) -/
+example : cubicDisc 1 0 (-3) 2 = 0 := by
+  unfold cubicDisc; norm_num
+
+/-- `x³ − x = x(x−1)(x+1)` has three distinct roots, so its discriminant is nonzero
+(`Δ = −4(−1)³ = 4`). -/
+example : cubicDisc 1 0 (-1) 0 = 4 := by
+  unfold cubicDisc; norm_num
+
+/-- The root form, checked against the distinct-roots example `r,s,t = 0,1,−1`
+(`a = 1`): `Δ = ((0−1)(0+1)(1+1))² = (−2)² = 4`. -/
+example : cubicDisc 1 (-(1 * ((0:ℂ) + 1 + -1))) (1 * (0 * 1 + 0 * -1 + 1 * -1))
+    (-(1 * (0 * 1 * -1))) = 4 := by
+  rw [cubicDisc_eq_of_roots]; norm_num
+
+end SolutionOfCubicOQ01OQ02
+
+-- Summary of key results
+#check SolutionOfCubicOQ01OQ02.cubicDisc
+#check SolutionOfCubicOQ01OQ02.cubicDisc_eq_depressed
+#check SolutionOfCubicOQ01OQ02.cubicDisc_eq_zero_iff_depressed
+#check SolutionOfCubicOQ01OQ02.cubicDisc_eq_of_roots
+#check SolutionOfCubicOQ01OQ02.cubicDisc_roots_eq_zero_iff

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "ann-soc-oq0102-disc",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 61
+    },
+    "type": "definition",
+    "title": "The Classical Cubic Discriminant",
+    "content": "cubicDisc a b c d = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² is the standard degree-4-in-coefficients symmetric polynomial whose vanishing detects a repeated root of ax³ + bx² + cx + d. depressedDisc p q = q²/4 + p³/27 is its Cardano-convention counterpart for the monic depressed cubic t³ + pt + q, exactly the quantity the parent's Cardano formula uses to decide solvability."
+  },
+  {
+    "id": "ann-soc-oq0102-bridge",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 64,
+      "endLine": 83
+    },
+    "type": "insight",
+    "title": "The Bridge: Δ = −108·a⁴·(q²/4 + p³/27)",
+    "content": "cubicDisc_eq_depressed substitutes the parent's depressed parameters p = (3ac − b²)/(3a²), q = (2b³ − 9abc + 27a²d)/(27a³) into q²/4 + p³/27 and shows the result is the general discriminant up to the universal factor −108·a⁴. The a⁴ is the expected scaling of a cubic discriminant by its leading coefficient; the −108 converts between the two standard sign conventions Δ = a⁴(−4p³ − 27q²) and the Cardano form q²/4 + p³/27. The proof is a single field_simp (clearing the a-denominators using a ≠ 0) followed by ring."
+  },
+  {
+    "id": "ann-soc-oq0102-simultaneous",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 85,
+      "endLine": 98
+    },
+    "type": "insight",
+    "title": "Both Discriminants Vanish Together",
+    "content": "Because the bridge factor −108·a⁴ is nonzero when a ≠ 0, cubicDisc_eq_zero_iff_depressed reads off that Δ = 0 ⟺ q²/4 + p³/27 = 0. So the general cubic has a repeated root exactly when its depressed reduction does — the Tschirnhaus shift preserves the repeated-root locus, consistent with the parent's theorem that the shift is a bijection on roots. The proof factors through mul_eq_zero and pow_ne_zero."
+  },
+  {
+    "id": "ann-soc-oq0102-vieta",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 120
+    },
+    "type": "insight",
+    "title": "The Vieta Root Form: Δ = a⁴·((r−s)(r−t)(s−t))²",
+    "content": "cubicDisc_eq_of_roots writes the cubic in factored form a(x−r)(x−s)(x−t) — equivalently, plugs the Vieta coefficients b = −a(r+s+t), c = a(rs+rt+st), d = −a·rst into cubicDisc — and proves the discriminant collapses to a⁴ times the square of the product of pairwise root differences. This is the textbook product-of-squared-differences identity, here a pure ring computation."
+  },
+  {
+    "id": "ann-soc-oq0102-repeated",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 122,
+      "endLine": 138
+    },
+    "type": "insight",
+    "title": "The Geometric Meaning: Δ = 0 ⟺ a Repeated Root",
+    "content": "cubicDisc_roots_eq_zero_iff combines the root form with a⁴ ≠ 0, sq_eq_zero_iff, and sub_eq_zero to conclude that the discriminant vanishes precisely when two of r, s, t coincide. This is the geometric content of the discriminant: it is the obstruction to the cubic having three distinct roots."
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/meta.json
@@ -1,0 +1,153 @@
+{
+  "id": "solution-of-cubic-oq-01-oq-02",
+  "title": "The Discriminant of the General Cubic",
+  "slug": "solution-of-cubic-oq-01-oq-02",
+  "description": "Formalizes the classical discriminant Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² of the general cubic ax³ + bx² + cx + d and proves it equals −108·a⁴ times the parent's depressed discriminant q²/4 + p³/27 under the Tschirnhaus reduction. Derives that the two discriminants vanish together (Δ = 0 ⟺ q²/4 + p³/27 = 0), expresses Δ in factored form as a⁴·((r−s)(r−t)(s−t))² via Vieta, and proves Δ = 0 exactly when two roots coincide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant#Degree_3",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "cubic-equations",
+      "discriminant",
+      "tschirnhaus-transformation",
+      "depressed-cubic",
+      "polynomial-arithmetic",
+      "vieta",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "cubicDisc: the classical cubic discriminant Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² as a polynomial in the coefficients",
+      "cubicDisc_eq_depressed: the bridge Δ = −108·a⁴·(q²/4 + p³/27) tying the general discriminant to the parent's depressed discriminant under the Tschirnhaus shift (a ≠ 0)",
+      "cubicDisc_eq_zero_iff_depressed: the two discriminants vanish simultaneously, so the shift preserves the repeated-root locus",
+      "cubicDisc_eq_of_roots: the factored / Vieta form Δ = a⁴·((r−s)(r−t)(s−t))², the textbook product of squared root differences",
+      "cubicDisc_roots_eq_zero_iff: Δ = 0 ⟺ two of the roots coincide (a ≠ 0), the geometric meaning of the discriminant"
+    ],
+    "dateAdded": "2026-06-23",
+    "prerequisites": [
+      "Tschirnhaus reduction of the general cubic (parent proof solution-of-cubic-oq-01)",
+      "Field arithmetic over the complex numbers",
+      "Vieta's formulas for a cubic"
+    ],
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic-oq-01",
+        "relationship": "Parent: Tschirnhaus reduction; this entry answers its second open question (formalize the discriminant and relate it to q²/4 + p³/27)"
+      },
+      {
+        "id": "solution-of-cubic",
+        "relationship": "Grandparent: Cardano's formula for the depressed cubic, whose q²/4 + p³/27 this discriminant generalizes"
+      },
+      {
+        "id": "solution-of-cubic-oq-03",
+        "relationship": "Sibling: Vieta's formulas for the Cardano roots of the depressed cubic"
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "None. All theorems fully proved from Mathlib with 0 axioms and 0 sorries. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, no Lean.ofReduceBool.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The discriminant of a polynomial — the quantity whose vanishing signals a repeated root — was developed in the 18th and 19th centuries as the theory of symmetric functions and resultants matured (Lagrange, Gauss, Sylvester, who coined the term 'discriminant' in 1851). For the cubic ax³ + bx² + cx + d the discriminant is Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d². Cardano's older analysis of the depressed cubic x³ + px + q already isolated the key quantity q²/4 + p³/27, whose sign distinguishes one real root (positive) from three real roots (negative) over the reals, and whose vanishing marks a repeated root. This entry makes precise the relationship between these two classical objects: they are the same invariant viewed through the Tschirnhaus shift of the parent file.",
+    "keyInsight": "The Tschirnhaus shift x = t − b/(3a) translates the roots without changing their pairwise differences, so it cannot change whether two roots coincide. Concretely, the discriminant Δ of the general cubic equals a⁴·((r−s)(r−t)(s−t))² in terms of the roots, while the monic depressed cubic obtained from the shift has the same root differences. The only changes are the universal scaling a⁴ (from the leading coefficient) and the sign-convention factor −108 between Δ = a⁴(−4p³ − 27q²) and the Cardano form q²/4 + p³/27. Hence Δ = −108·a⁴·(q²/4 + p³/27), and the two discriminants vanish together."
+  },
+  "sections": [
+    {
+      "id": "classical-discriminant",
+      "title": "Part 1: The Classical Discriminant",
+      "startLine": 49,
+      "endLine": 61,
+      "summary": "Defines cubicDisc a b c d = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d², the standard discriminant of the general cubic, and depressedDisc p q = q²/4 + p³/27, the depressed discriminant used by the parent's Cardano formula.",
+      "mathContext": "cubicDisc is the degree-4-in-coefficients symmetric polynomial that vanishes exactly on cubics with a repeated root; depressedDisc is its Cardano-convention counterpart for the monic depressed cubic t³ + pt + q."
+    },
+    {
+      "id": "discriminant-bridge",
+      "title": "Part 2: The Bridge to the Depressed Discriminant",
+      "startLine": 63,
+      "endLine": 108,
+      "summary": "Proves cubicDisc_eq_depressed: for a ≠ 0, Δ = −108·a⁴·(q²/4 + p³/27) with p, q the depressed parameters of the parent. Deduces cubicDisc_eq_zero_iff_depressed: the two discriminants vanish simultaneously.",
+      "mathContext": "The factor a⁴ is the expected scaling of a cubic discriminant by its leading coefficient; −108 is the conversion between the two standard sign conventions. The proof is pure field arithmetic (field_simp + ring)."
+    },
+    {
+      "id": "root-form",
+      "title": "Part 3: The Root Form and Geometric Meaning",
+      "startLine": 100,
+      "endLine": 138,
+      "summary": "Proves cubicDisc_eq_of_roots: with the cubic in factored form a(x−r)(x−s)(x−t) (Vieta), Δ = a⁴·((r−s)(r−t)(s−t))². Deduces cubicDisc_roots_eq_zero_iff: Δ = 0 ⟺ two roots coincide.",
+      "mathContext": "This is the textbook product-of-squared-differences description of the discriminant; the vanishing criterion is its geometric meaning — Δ detects a repeated root."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part 4: Sanity Checks",
+      "startLine": 140,
+      "endLine": 163,
+      "summary": "Specializes to already-depressed cubics (a = 1, b = 0): Δ = −4p³ − 27q² = −108·(q²/4 + p³/27). Checks x³ − 3x + 2 (repeated root, Δ = 0), x³ − x (distinct roots, Δ = 4), and the root form on r,s,t = 0,1,−1.",
+      "mathContext": "Concrete numerical confirmations that the abstract identities reproduce the classical discriminant values."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of the general cubic's discriminant Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d², its identity Δ = −108·a⁴·(q²/4 + p³/27) bridging to the parent's depressed discriminant, the consequent simultaneous-vanishing criterion, the Vieta root form Δ = a⁴·((r−s)(r−t)(s−t))², and the repeated-root criterion Δ = 0 ⟺ two roots coincide. 171 lines, 5 theorems, 2 definitions.",
+    "implications": "Completes the second open question of the parent Tschirnhaus-reduction entry, making explicit that the depressed discriminant the parent uses for solvability is, up to the universal factor −108·a⁴, the classical discriminant of the original cubic. Together with the parent's root bijection this confirms the Tschirnhaus shift preserves the repeated-root structure, and supplies the discriminant criterion needed to classify the cubic's root multiplicities."
+  },
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Proofs.SolutionOfCubicOQ01"
+    ],
+    "opens": [
+      "SolutionOfCubicOQ01"
+    ],
+    "namespace": "SolutionOfCubicOQ01OQ02",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 2,
+    "path": "Proofs/SolutionOfCubicOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-01",
+      "relationship": "extends",
+      "description": "Parent proof: the Tschirnhaus shift x = t − b/(3a) reducing the general cubic to depressed form a·(t³ + pt + q). This entry answers the parent's second open question by formalizing the general discriminant and proving Δ = −108·a⁴·(q²/4 + p³/27)."
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "complementary",
+      "description": "Grandparent: Cardano's formula for the depressed cubic, whose discriminant q²/4 + p³/27 is generalized here to the discriminant of an arbitrary cubic."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-03",
+      "relationship": "complementary",
+      "description": "Sibling: Vieta's formulas for the three Cardano roots; the discriminant's root form a⁴·((r−s)(r−t)(s−t))² is the symmetric function those roots determine."
+    }
+  ],
+  "references": [
+    {
+      "key": "Sy51",
+      "citation": "Sylvester, J.J., On a remarkable discovery in the theory of canonical forms and of hyperdeterminants, Philosophical Magazine (1851). (Origin of the term 'discriminant'.)",
+      "type": "article"
+    },
+    {
+      "key": "Wi-Disc",
+      "citation": "Discriminant — Degree 3, Wikipedia. https://en.wikipedia.org/wiki/Discriminant#Degree_3",
+      "type": "web"
+    },
+    {
+      "key": "Ti01",
+      "citation": "Tignol, J.-P., Galois' Theory of Algebraic Equations, World Scientific (2001), Chapters 3–5.",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the parent `solution-of-cubic-oq-01` (Tschirnhaus reduction): formalize the discriminant of the general cubic `a x³ + b x² + c x + d` and relate it to the depressed discriminant `q²/4 + p³/27` used by the parent's Cardano machinery.

## Results (`proofs/Proofs/SolutionOfCubicOQ01OQ02.lean`)

- **`cubicDisc`** — the classical discriminant `Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²`.
- **`cubicDisc_eq_depressed`** — the bridge `Δ = −108·a⁴·(q²/4 + p³/27)` (`a ≠ 0`): the general discriminant is the depressed one up to the universal factor `−108 a⁴`.
- **`cubicDisc_eq_zero_iff_depressed`** — both discriminants vanish simultaneously, so the Tschirnhaus shift preserves the repeated-root locus.
- **`cubicDisc_eq_of_roots`** — root form `Δ = a⁴·((r−s)(r−t)(s−t))²` (Vieta).
- **`cubicDisc_roots_eq_zero_iff`** — `Δ = 0 ⟺ two roots coincide` (`a ≠ 0`).

## Verification

5 theorems / 2 definitions, **0 sorries, 0 axioms**. Kernel-verified via `lake env lean`; `#print axioms` reports only `propext, Classical.choice, Quot.sound` for all four theorems — no `sorryAx`, no `Lean.ofReduceBool`. Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)