### PR TITLE
research(cauchy-schwarz-integral-oq-02-oq-03-oq-01): equality case of reverse Minkowski

### DIFF
--- a/proofs/Proofs/CauchySchwarzIntegralOQ02OQ03OQ01.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralOQ02OQ03OQ01.lean
@@ -1,0 +1,169 @@
+import Mathlib.MeasureTheory.Function.L2Space
+import Mathlib.Analysis.InnerProductSpace.Basic
+import Mathlib.Analysis.MeanInequalities
+import Mathlib.Tactic
+
+/-
+# Equality Case of the Reverse Minkowski Inequality (cauchy-schwarz-integral-oq-02-oq-03-oq-01)
+
+## The Open Question (from cauchy-schwarz-integral-oq-02-oq-03)
+
+The parent file proved the **reverse Minkowski / reverse triangle inequality**
+`|‖f‖ − ‖g‖| ≤ ‖f + g‖`, deriving it (for `p = 2`) from the Cauchy–Schwarz *lower*
+bound `⟪f,g⟫ ≥ −‖f‖·‖g‖`, mirroring how the forward inequality uses the CS *upper*
+bound. The natural follow-up:
+
+> **When is the reverse Minkowski inequality an equality?** Characterise the pairs
+> `(f, g)` for which `|‖f‖ − ‖g‖| = ‖f + g‖`.
+
+## The Answer
+
+Equality holds **iff the two vectors are antiparallel** — one is a *nonpositive* real
+multiple of the other. The clean, division-free, zero-tolerant statement is
+
+```
+|‖u‖ − ‖v‖| = ‖u + v‖   ↔   ‖v‖ • u = −(‖u‖ • v).
+```
+
+### Why: the Cauchy–Schwarz lower bound must be *tight*
+
+For a real inner-product space, expanding `‖u+v‖²` and `(‖u‖−‖v‖)²` shows
+```
+|‖u‖ − ‖v‖| = ‖u + v‖   ⟺   ⟪u,v⟫ = −‖u‖·‖v‖,
+```
+i.e. equality in reverse Minkowski is *exactly* saturation of the CS lower bound
+`⟪u,v⟫ ≥ −‖u‖‖v‖`. By the equality case of Cauchy–Schwarz
+(`inner_eq_norm_mul_iff_real`, applied to `(u, −v)`), this is equivalent to
+`‖v‖ • u = −(‖u‖ • v)`, and for nonzero vectors to `v = r • u` for some `r < 0`.
+
+### The mirror picture
+
+This is the exact dual of the *forward* triangle equality
+`‖u + v‖ = ‖u‖ + ‖v‖ ↔ ‖v‖ • u = ‖u‖ • v` (vectors *parallel*, `r ≥ 0`,
+Mathlib's `norm_add_eq_iff_real`): the forward case saturates the CS *upper* bound,
+the reverse case saturates the CS *lower* bound.
+
+## Status (0 axioms, 0 sorries)
+-/
+
+noncomputable section
+
+open MeasureTheory
+open scoped InnerProductSpace
+
+namespace ReverseMinkowskiEqCase
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-!
+## Section I: Reduction to the Cauchy–Schwarz lower bound
+
+Equality `|‖u‖ − ‖v‖| = ‖u + v‖` is, after squaring both (nonnegative) sides and
+expanding via `norm_add_sq_real`, exactly the statement that the inner product attains
+its Cauchy–Schwarz *lower* bound: `⟪u,v⟫ = −‖u‖·‖v‖`.
+-/
+
+/-- **Equality in reverse Minkowski ⟺ the CS lower bound is tight.**
+`|‖u‖ − ‖v‖| = ‖u + v‖` holds iff `⟪u,v⟫ = −‖u‖·‖v‖`. -/
+theorem reverse_minkowski_eq_iff_inner (u v : E) :
+    |‖u‖ - ‖v‖| = ‖u + v‖ ↔ ⟪u, v⟫_ℝ = -(‖u‖ * ‖v‖) := by
+  rw [← pow_left_inj₀ (abs_nonneg _) (norm_nonneg _) (by norm_num : (2 : ℕ) ≠ 0),
+    sq_abs, norm_add_sq_real]
+  have expand : (‖u‖ - ‖v‖) ^ 2 = ‖u‖ ^ 2 + 2 * (-(‖u‖ * ‖v‖)) + ‖v‖ ^ 2 := by ring
+  constructor
+  · intro h; linarith [expand]
+  · intro h; rw [h]; ring
+
+/-!
+## Section II: The vector characterisation (antiparallel)
+
+Feeding the CS equality case `inner_eq_norm_mul_iff_real` the pair `(u, −v)` turns the
+inner-product condition into the clean vector identity `‖v‖ • u = −(‖u‖ • v)`.
+This form is symmetric, division-free, and handles the degenerate cases (`u = 0` or
+`v = 0`) automatically.
+-/
+
+/-- **Equality case of reverse Minkowski (vector form).**
+`|‖u‖ − ‖v‖| = ‖u + v‖ ↔ ‖v‖ • u = −(‖u‖ • v)` — the two vectors are *antiparallel*. -/
+theorem reverse_minkowski_eq_iff (u v : E) :
+    |‖u‖ - ‖v‖| = ‖u + v‖ ↔ ‖v‖ • u = -(‖u‖ • v) := by
+  rw [reverse_minkowski_eq_iff_inner]
+  have h := inner_eq_norm_mul_iff_real (x := u) (y := -v)
+  simp only [inner_neg_right, norm_neg, smul_neg] at h
+  rw [neg_eq_iff_eq_neg] at h
+  exact h
+
+/-- The reverse Minkowski inequality `|‖u‖ − ‖v‖| ≤ ‖u + v‖`, re-derived from the CS
+lower bound (kept private as a helper for the strict-inequality characterisation). -/
+private theorem reverse_minkowski_le (u v : E) : |‖u‖ - ‖v‖| ≤ ‖u + v‖ := by
+  have h_cs : |⟪u, v⟫_ℝ| ≤ ‖u‖ * ‖v‖ := abs_real_inner_le_norm u v
+  have h_ge : -(‖u‖ * ‖v‖) ≤ ⟪u, v⟫_ℝ := (abs_le.mp h_cs).1
+  have h_sq : (‖u‖ - ‖v‖) ^ 2 ≤ ‖u + v‖ ^ 2 := by rw [norm_add_sq_real]; nlinarith [h_ge]
+  have h_sqrt := Real.sqrt_le_sqrt h_sq
+  rwa [Real.sqrt_sq_eq_abs, Real.sqrt_sq (norm_nonneg _)] at h_sqrt
+
+/-- **Strict reverse Minkowski.** The inequality is *strict* exactly when the vectors
+are not antiparallel: `|‖u‖ − ‖v‖| < ‖u + v‖ ↔ ‖v‖ • u ≠ −(‖u‖ • v)`. -/
+theorem reverse_minkowski_lt_iff (u v : E) :
+    |‖u‖ - ‖v‖| < ‖u + v‖ ↔ ‖v‖ • u ≠ -(‖u‖ • v) := by
+  rw [← not_iff_not, not_lt, not_ne_iff, ← reverse_minkowski_eq_iff]
+  exact ⟨fun h => le_antisymm (reverse_minkowski_le u v) h, fun h => h.ge⟩
+
+/-!
+## Section III: Antiparallel = negative scalar multiple (nonzero vectors)
+
+For nonzero `u, v` the vector condition `‖v‖ • u = −(‖u‖ • v)` is precisely
+`v = r • u` for some `r < 0`: the vectors point in genuinely opposite directions.
+-/
+
+/-- **Equality case for nonzero vectors.** When `u ≠ 0` and `v ≠ 0`,
+`|‖u‖ − ‖v‖| = ‖u + v‖` iff `v` is a *negative* real multiple of `u`. -/
+theorem reverse_minkowski_eq_iff_neg_smul {u v : E} (hu : u ≠ 0) (hv : v ≠ 0) :
+    |‖u‖ - ‖v‖| = ‖u + v‖ ↔ ∃ r : ℝ, r < 0 ∧ v = r • u := by
+  have hne : ‖u‖ * ‖v‖ ≠ 0 := mul_ne_zero (norm_ne_zero_iff.2 hu) (norm_ne_zero_iff.2 hv)
+  rw [reverse_minkowski_eq_iff_inner]
+  have key := real_inner_div_norm_mul_norm_eq_neg_one_iff u v
+  rw [div_eq_iff hne, neg_one_mul] at key
+  rw [key]
+  exact and_iff_right hu
+
+/-!
+## Section IV: Difference form and the forward/reverse mirror
+
+Replacing `v` by `−v` converts the sum form into the difference form: equality in
+`|‖u‖ − ‖v‖| = ‖u − v‖` characterises *parallel* vectors `‖v‖ • u = ‖u‖ • v` — the same
+condition as the forward triangle equality `norm_add_eq_iff_real`.
+-/
+
+/-- **Difference form.** `|‖u‖ − ‖v‖| = ‖u − v‖ ↔ ‖v‖ • u = ‖u‖ • v` (vectors *parallel*),
+obtained from `reverse_minkowski_eq_iff` by `v ↦ −v`. -/
+theorem reverse_minkowski_sub_eq_iff (u v : E) :
+    |‖u‖ - ‖v‖| = ‖u - v‖ ↔ ‖v‖ • u = ‖u‖ • v := by
+  have h := reverse_minkowski_eq_iff u (-v)
+  simp only [norm_neg, smul_neg, neg_neg, ← sub_eq_add_neg] at h
+  exact h
+
+/-- **The forward/reverse mirror, made explicit.** Forward triangle equality
+(`‖u + v‖ = ‖u‖ + ‖v‖`, parallel) and reverse-with-difference equality
+(`|‖u‖ − ‖v‖| = ‖u − v‖`, also parallel) are governed by the *same* collinearity
+condition `‖v‖ • u = ‖u‖ • v`, hence are equivalent to each other. -/
+theorem forward_iff_reverse_sub (u v : E) :
+    ‖u + v‖ = ‖u‖ + ‖v‖ ↔ |‖u‖ - ‖v‖| = ‖u - v‖ := by
+  rw [norm_add_eq_iff_real, reverse_minkowski_sub_eq_iff]
+
+/-!
+## Section V: Specialisation to L²(μ)
+
+`Lp ℝ 2 μ` is a real inner-product space, so the equality case applies verbatim,
+answering the open question in the measure-theoretic setting that motivated it.
+-/
+
+variable {α : Type*} [MeasurableSpace α] {μ : Measure α}
+
+/-- **Equality case of reverse Minkowski in `L²(μ)`.** For `f, g ∈ L²(μ)`,
+`|‖f‖ − ‖g‖| = ‖f + g‖` iff `‖g‖ • f = −(‖f‖ • g)`. -/
+theorem reverse_minkowski_eq_iff_l2 (f g : Lp ℝ 2 μ) :
+    |‖f‖ - ‖g‖| = ‖f + g‖ ↔ ‖g‖ • f = -(‖f‖ • g) :=
+  reverse_minkowski_eq_iff f g
+
+end ReverseMinkowskiEqCase

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03-oq-01/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "ann-cs-lower-tight",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 75
+    },
+    "type": "insight",
+    "title": "Equality ⟺ the Cauchy-Schwarz LOWER Bound Is Saturated",
+    "content": "The reverse Minkowski inequality came from the CS lower bound ⟪u,v⟫ ≥ −‖u‖‖v‖; it is therefore an equality exactly when that bound is tight. The reduction is mechanical: |‖u‖−‖v‖| and ‖u+v‖ are both nonnegative, so pow_left_inj₀ and sq_abs replace the equation by the equality of squares (‖u‖−‖v‖)² = ‖u+v‖²; norm_add_sq_real expands the right to ‖u‖²+2⟪u,v⟫+‖v‖²; a one-line linarith against the ring identity (‖u‖−‖v‖)² = ‖u‖²+2(−‖u‖‖v‖)+‖v‖² isolates ⟪u,v⟫ = −(‖u‖·‖v‖). This mirrors the forward triangle equality, which saturates the CS UPPER bound.",
+    "mathContext": "$$\\|u+v\\|^2 = (\\|u\\|-\\|v\\|)^2 \\iff \\langle u,v\\rangle = -\\|u\\|\\,\\|v\\|$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy-Schwarz equality",
+      "norm_add_sq_real",
+      "pow_left_inj₀",
+      "sq_abs"
+    ],
+    "prerequisites": [
+      "inner-product norm-squared identity",
+      "equality of nonnegatives via squares"
+    ]
+  },
+  {
+    "id": "ann-substitute-neg-v",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 88,
+      "endLine": 94
+    },
+    "type": "technique",
+    "title": "The v ↦ −v Trick: Antiparallel from the Parallel CS Equality Case",
+    "content": "Mathlib's Cauchy-Schwarz equality case inner_eq_norm_mul_iff_real states ⟪x,y⟫ = ‖x‖‖y‖ ↔ ‖y‖•x = ‖x‖•y — the PARALLEL (nonnegative-multiple) case. We need the antiparallel condition ⟪u,v⟫ = −‖u‖‖v‖. Feeding the lemma the pair (u,−v) and simplifying (inner_neg_right, norm_neg, smul_neg) gives −⟪u,v⟫ = ‖u‖‖v‖ ↔ ‖v‖•u = −(‖u‖•v); neg_eq_iff_eq_neg flips the left side to ⟪u,v⟫ = −(‖u‖‖v‖). No bespoke 'negative CS equality' lemma is needed — the substitution turns the lower-bound saturation into the upper-bound one.",
+    "mathContext": "$$\\langle u,v\\rangle = -\\|u\\|\\|v\\| \\iff \\|v\\|\\cdot u = -(\\|u\\|\\cdot v)$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "inner_eq_norm_mul_iff_real",
+      "inner_neg_right",
+      "smul_neg",
+      "neg_eq_iff_eq_neg"
+    ],
+    "prerequisites": [
+      "Cauchy-Schwarz equality case",
+      "linearity of the inner product in the second slot"
+    ]
+  },
+  {
+    "id": "ann-strict-dichotomy",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 107,
+      "endLine": 110
+    },
+    "type": "insight",
+    "title": "Equality and Strict Inequality Form a Clean Dichotomy",
+    "content": "Because |‖u‖−‖v‖| ≤ ‖u+v‖ holds UNCONDITIONALLY (private reverse_minkowski_le, re-derived from the CS lower bound), the inequality is strict precisely when it is not an equality. not_iff_not over not_lt and not_ne_iff turns the goal |‖u‖−‖v‖| < ‖u+v‖ ↔ ‖v‖•u ≠ −(‖u‖•v) into ‖u+v‖ ≤ |‖u‖−‖v‖| ↔ |‖u‖−‖v‖| = ‖u+v‖, closed by le_antisymm against the unconditional bound. The qualitative question 'when is the reverse triangle inequality sharp' becomes the decidable algebraic test ‖v‖•u =? −(‖u‖•v).",
+    "mathContext": "$$\\big|\\|u\\|-\\|v\\|\\big| < \\|u+v\\| \\iff \\|v\\|\\cdot u \\ne -(\\|u\\|\\cdot v)$$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "not_iff_not",
+      "not_lt",
+      "le_antisymm",
+      "reverse triangle inequality"
+    ],
+    "prerequisites": [
+      "unconditional reverse Minkowski bound",
+      "antisymmetry of ≤"
+    ]
+  },
+  {
+    "id": "ann-forward-reverse-mirror",
+    "proofId": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+    "range": {
+      "startLine": 140,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "Forward and Reverse Equality Are Sign-Twinned Collinearity Conditions",
+    "content": "Substituting −v in the sum-form equality yields the difference form |‖u‖−‖v‖| = ‖u−v‖ ↔ ‖v‖•u = ‖u‖•v — now the PARALLEL condition (norm_neg, smul_neg, neg_neg, sub_eq_add_neg do the bookkeeping). Since Mathlib's forward triangle equality norm_add_eq_iff_real reads ‖u+v‖ = ‖u‖+‖v‖ ↔ ‖v‖•u = ‖u‖•v with the SAME right-hand side, the two equalities are equivalent: forward_iff_reverse_sub. The whole picture: ‖v‖•u = ‖u‖•v governs parallel cases (forward-sum, reverse-difference); ‖v‖•u = −(‖u‖•v) governs antiparallel cases (reverse-sum, forward-difference).",
+    "mathContext": "$$\\|u+v\\| = \\|u\\|+\\|v\\| \\iff \\big|\\|u\\|-\\|v\\|\\big| = \\|u-v\\|$$",
+    "significance": "key",
+    "relatedConcepts": [
+      "norm_add_eq_iff_real",
+      "smul_neg",
+      "sub_eq_add_neg",
+      "collinearity"
+    ],
+    "prerequisites": [
+      "forward triangle equality case",
+      "the v ↦ −v reflection"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-03-oq-01/meta.json
@@ -1,0 +1,233 @@
+{
+  "id": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+  "title": "Equality Case of the Reverse Minkowski Inequality",
+  "slug": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+  "description": "Answers the parent's open question (cauchy-schwarz-integral-oq-02-oq-03): when is the reverse Minkowski / reverse triangle inequality |‖f‖−‖g‖| ≤ ‖f+g‖ an equality? Equality holds iff the vectors are ANTIPARALLEL — one a nonpositive real multiple of the other. The clean, division-free, zero-tolerant characterization is |‖u‖−‖v‖| = ‖u+v‖ ↔ ‖v‖•u = −(‖u‖•v). The proof shows equality is exactly saturation of the Cauchy-Schwarz LOWER bound ⟪u,v⟫ = −‖u‖·‖v‖ (mirroring how the forward triangle equality saturates the CS upper bound), then converts that to the vector form via Mathlib's CS equality case inner_eq_norm_mul_iff_real applied to (u,−v). Includes the strict-inequality dichotomy, the nonzero-vector form (∃ r<0, v=r•u), the difference form (parallel vectors), the explicit forward/reverse mirror, and an L²(μ) specialization. 8 theorems, 0 axioms, 0 sorries; verified.",
+  "leanFile": {
+    "path": "Proofs/CauchySchwarzIntegralOQ02OQ03OQ01.lean",
+    "namespace": "ReverseMinkowskiEqCase",
+    "imports": [
+      "Mathlib.MeasureTheory.Function.L2Space",
+      "Mathlib.Analysis.InnerProductSpace.Basic",
+      "Mathlib.Analysis.MeanInequalities",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "InnerProductSpace (scoped)"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 169,
+    "theoremCount": 8,
+    "definitionCount": 0
+  },
+  "openQuestion": {
+    "id": "cauchy-schwarz-integral-oq-02-oq-03-oq-01",
+    "parentId": "cauchy-schwarz-integral-oq-02-oq-03",
+    "question": "Establish the equality case of the reverse Minkowski inequality: when is |‖f‖−‖g‖| = ‖f+g‖?",
+    "answer": "Equality holds iff the two vectors are antiparallel: ‖v‖•u = −(‖u‖•v), equivalently (for nonzero vectors) v = r•u for some r < 0. The mechanism is exact: squaring both nonnegative sides and expanding ‖u+v‖² = ‖u‖²+2⟪u,v⟫+‖v‖² shows |‖u‖−‖v‖| = ‖u+v‖ ⟺ ⟪u,v⟫ = −‖u‖·‖v‖, i.e. the reverse inequality is an equality exactly when the Cauchy-Schwarz LOWER bound ⟪u,v⟫ ≥ −‖u‖‖v‖ is tight. Feeding the CS equality case inner_eq_norm_mul_iff_real the pair (u,−v) turns this into the clean vector identity ‖v‖•u = −(‖u‖•v). This is the precise dual of the forward triangle equality ‖u+v‖ = ‖u‖+‖v‖ ↔ ‖v‖•u = ‖u‖•v (parallel, CS upper bound tight): forward = parallel, reverse = antiparallel. 8 theorems, 0 axioms, 0 sorries; verified."
+  },
+  "highlights": [
+    "Equality |‖u‖−‖v‖| = ‖u+v‖ ⟺ ‖v‖•u = −(‖u‖•v) (vectors ANTIPARALLEL)",
+    "Equality ⟺ the Cauchy-Schwarz LOWER bound ⟪u,v⟫ = −‖u‖·‖v‖ is saturated",
+    "Strict dichotomy: |‖u‖−‖v‖| < ‖u+v‖ ⟺ ‖v‖•u ≠ −(‖u‖•v)",
+    "Nonzero form: equality ⟺ v = r•u for some r < 0 (genuinely opposite directions)",
+    "Forward/reverse mirror: forward triangle equality ⟺ reverse-difference equality (both = parallel)",
+    "L²(μ) specialization plus an abstract real-inner-product-space version"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "|‖u‖−‖v‖| = ‖u+v‖ ↔ ‖v‖•u = −(‖u‖•v) in any real inner-product space",
+      "type": "theorem"
+    },
+    {
+      "statement": "|‖u‖−‖v‖| = ‖u+v‖ ↔ ⟪u,v⟫ = −‖u‖·‖v‖ (CS lower bound tight)",
+      "type": "theorem"
+    },
+    {
+      "statement": "For u,v ≠ 0: equality ↔ ∃ r < 0, v = r•u",
+      "type": "corollary"
+    },
+    {
+      "statement": "|‖u‖−‖v‖| < ‖u+v‖ ↔ ‖v‖•u ≠ −(‖u‖•v) (strict reverse Minkowski)",
+      "type": "corollary"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The reverse triangle inequality |‖f‖−‖g‖| ≤ ‖f+g‖ bounds how far below the difference of norms the norm of a sum can fall; the parent problem derived it from Cauchy-Schwarz, observing that the forward inequality uses the CS upper bound ⟪f,g⟫ ≤ ‖f‖‖g‖ while the reverse uses the lower bound ⟪f,g⟫ ≥ −‖f‖‖g‖, both fed through ‖f+g‖² = ‖f‖²+2⟪f,g⟫+‖g‖². The natural completion of that picture is the equality case: an inequality derived from a one-sided CS bound is tight exactly when that bound is tight, and the CS equality case is classical (the vectors are proportional). This file makes that completion precise.",
+    "problemStatement": "Characterize the pairs (f,g) in a real inner-product space (and in L²(μ)) for which the reverse Minkowski inequality |‖f‖−‖g‖| ≤ ‖f+g‖ holds with equality.",
+    "proofStrategy": "Square both nonnegative sides (pow_left_inj₀, sq_abs) and expand the right with norm_add_sq_real; a one-line linarith reduces |‖u‖−‖v‖| = ‖u+v‖ to the inner-product condition ⟪u,v⟫ = −(‖u‖·‖v‖). Apply Mathlib's Cauchy-Schwarz equality case inner_eq_norm_mul_iff_real to the pair (u,−v) (rewriting with inner_neg_right, norm_neg, smul_neg, neg_eq_iff_eq_neg) to obtain the vector form ‖v‖•u = −(‖u‖•v). The strict version follows from the always-valid ≤ bound by not_iff_not/not_lt/not_ne_iff; the nonzero form from real_inner_div_norm_mul_norm_eq_neg_one_iff; the difference form by substituting −v; and the forward/reverse mirror by chaining norm_add_eq_iff_real with the difference form.",
+    "keyInsights": [
+      "An inequality obtained from one side of |⟪u,v⟫| ≤ ‖u‖‖v‖ is an equality exactly when that side is tight: reverse Minkowski equality ⟺ ⟪u,v⟫ = −‖u‖‖v‖, the SATURATED CS lower bound — the mirror of forward-triangle equality, which saturates the upper bound.",
+      "The slick reduction is the substitution v ↦ −v: it converts the antiparallel condition for the sum into the parallel CS equality case inner_eq_norm_mul_iff_real, so no bespoke 'negative CS equality' lemma is needed.",
+      "The vector form ‖v‖•u = −(‖u‖•v) is superior to '∃ r<0, v=r•u' as the canonical statement: it is symmetric in u,v, division-free, and automatically correct in the degenerate cases u=0 or v=0 (where one norm vanishes and both sides are 0).",
+      "Forward and reverse equality are governed by sign-twinned collinearity conditions: ‖v‖•u = ‖u‖•v (parallel, forward) versus ‖v‖•u = −(‖u‖•v) (antiparallel, reverse). Substituting −v swaps them, making 'forward triangle equality ⟺ reverse-difference equality' a two-line corollary.",
+      "Equality and strict inequality form a clean dichotomy via not_iff_not on top of the unconditional ≤ bound, turning the qualitative 'when is it sharp' into a decidable algebraic test ‖v‖•u =? −(‖u‖•v)."
+    ],
+    "prerequisites": [
+      "Parent: cauchy-schwarz-integral-oq-02-oq-03 (reverse Minkowski from CS)",
+      "inner_eq_norm_mul_iff_real (Cauchy-Schwarz equality case) and norm_add_sq_real",
+      "real_inner_div_norm_mul_norm_eq_neg_one_iff (negative-multiple characterization)",
+      "norm_add_eq_iff_real (forward triangle equality) for the mirror",
+      "pow_left_inj₀, sq_abs to reduce equality of nonnegatives to equality of squares"
+    ]
+  },
+  "sections": [
+    {
+      "id": "cs-lower-tight",
+      "title": "Equality ⟺ the CS Lower Bound Is Tight",
+      "startLine": 58,
+      "endLine": 75,
+      "summary": "reverse_minkowski_eq_iff_inner: squaring both nonnegative sides (pow_left_inj₀, sq_abs) and expanding with norm_add_sq_real reduces |‖u‖−‖v‖| = ‖u+v‖ to ⟪u,v⟫ = −(‖u‖·‖v‖) by a one-line linarith.",
+      "mathContext": "‖u+v‖² = (‖u‖−‖v‖)² ⟺ ‖u‖²+2⟪u,v⟫+‖v‖² = ‖u‖²−2‖u‖‖v‖+‖v‖² ⟺ ⟪u,v⟫ = −‖u‖‖v‖."
+    },
+    {
+      "id": "vector-form",
+      "title": "The Antiparallel Vector Characterization",
+      "startLine": 77,
+      "endLine": 110,
+      "summary": "reverse_minkowski_eq_iff: applying inner_eq_norm_mul_iff_real to (u,−v) turns ⟪u,v⟫ = −‖u‖‖v‖ into ‖v‖•u = −(‖u‖•v). reverse_minkowski_lt_iff gives the strict dichotomy via not_iff_not on the unconditional ≤ bound (private reverse_minkowski_le).",
+      "mathContext": "inner_eq_norm_mul_iff_real at (u,−v): −⟪u,v⟫ = ‖u‖‖v‖ ⟺ ‖v‖•u = −(‖u‖•v)."
+    },
+    {
+      "id": "neg-smul",
+      "title": "Negative Scalar Multiple (Nonzero Vectors)",
+      "startLine": 112,
+      "endLine": 128,
+      "summary": "reverse_minkowski_eq_iff_neg_smul: for u,v ≠ 0, equality ⟺ ∃ r<0, v=r•u, via real_inner_div_norm_mul_norm_eq_neg_one_iff (the inner product divided by the product of norms equals −1).",
+      "mathContext": "⟪u,v⟫ = −‖u‖‖v‖ and ‖u‖‖v‖ > 0 ⟺ ⟪u,v⟫/(‖u‖‖v‖) = −1 ⟺ v = r•u, r < 0."
+    },
+    {
+      "id": "mirror",
+      "title": "Difference Form and the Forward/Reverse Mirror",
+      "startLine": 130,
+      "endLine": 152,
+      "summary": "reverse_minkowski_sub_eq_iff: |‖u‖−‖v‖| = ‖u−v‖ ⟺ ‖v‖•u = ‖u‖•v (parallel), by v ↦ −v. forward_iff_reverse_sub: chaining with norm_add_eq_iff_real shows forward triangle equality ⟺ reverse-difference equality, both governed by ‖v‖•u = ‖u‖•v.",
+      "mathContext": "Substituting −v swaps antiparallel ↔ parallel; both forward ‖u+v‖=‖u‖+‖v‖ and |‖u‖−‖v‖|=‖u−v‖ encode ‖v‖•u = ‖u‖•v."
+    },
+    {
+      "id": "l2",
+      "title": "Specialization to L²(μ)",
+      "startLine": 154,
+      "endLine": 169,
+      "summary": "reverse_minkowski_eq_iff_l2: the equality case applies verbatim in L²(μ), answering the open question in the measure-theoretic setting that motivated it.",
+      "mathContext": "Lp ℝ 2 μ is a real inner-product space, so |‖f‖−‖g‖| = ‖f+g‖ ⟺ ‖g‖•f = −(‖f‖•g)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The reverse Minkowski inequality |‖f‖−‖g‖| ≤ ‖f+g‖ is an equality exactly when f and g are antiparallel: ‖g‖•f = −(‖f‖•g), equivalently (nonzero) g = r•f with r < 0. Equality is precisely saturation of the Cauchy-Schwarz lower bound ⟪f,g⟫ = −‖f‖‖g‖, the mirror of the forward triangle equality (which saturates the CS upper bound and forces proportionality). The file also gives the strict-inequality dichotomy, the difference form, an explicit forward/reverse mirror theorem, and an L²(μ) specialization. 8 theorems, 0 axioms, 0 sorries.",
+    "implications": "This closes the loop on the parent's CS-based account of the Lᵖ triangle inequality: not only are both halves (forward and reverse) corollaries of the upper and lower CS bounds, but their equality cases are corollaries of the upper and lower CS EQUALITY cases — proportional vs. antiproportional. The strict version supplies a decidable sharpness test useful wherever the reverse triangle inequality is applied as a stability bound.",
+    "openQuestions": [
+      "Quantitative deficit: lower-bound ‖f+g‖ − |‖f‖−‖g‖| in terms of the angle between f and g (how the gap grows as the vectors leave antiparallel).",
+      "Equality case of the GENERAL Lᵖ reverse Minkowski (p ≠ 2), where strict convexity of the norm should force g = r•f a.e. with r ≤ 0 — but the inner-product proof is unavailable.",
+      "Complex L²: characterize equality |‖f‖−‖g‖| = ‖f+g‖ over ℂ, where ⟪f,g⟫ = −‖f‖‖g‖ requires a unit-modulus phase alignment rather than a real negative multiple."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-integral-oq-02-oq-03",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-02",
+      "relationship": "related"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral",
+      "relationship": "related"
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026-06-23",
+    "status": "verified",
+    "badge": "original",
+    "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ02OQ03OQ01.lean",
+    "tags": [
+      "functional-analysis",
+      "cauchy-schwarz",
+      "minkowski-inequality",
+      "reverse-triangle-inequality",
+      "equality-case",
+      "inner-product-spaces",
+      "lp-spaces"
+    ],
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 169,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "reverse_minkowski_eq_iff_inner: equality ⟺ the CS lower bound ⟪u,v⟫ = −‖u‖‖v‖ is tight",
+      "reverse_minkowski_eq_iff: the antiparallel vector characterization ‖v‖•u = −(‖u‖•v)",
+      "reverse_minkowski_lt_iff: strict reverse Minkowski as the negation of the antiparallel condition",
+      "reverse_minkowski_eq_iff_neg_smul: nonzero-vector form ∃ r<0, v=r•u",
+      "reverse_minkowski_sub_eq_iff and forward_iff_reverse_sub: difference form and the forward/reverse mirror",
+      "reverse_minkowski_eq_iff_l2: L²(μ) specialization"
+    ],
+    "proofStrategy": "Reduce equality of nonnegatives to equality of squares (pow_left_inj₀, sq_abs), expand with norm_add_sq_real, linarith to ⟪u,v⟫ = −‖u‖‖v‖; convert to the vector form by inner_eq_norm_mul_iff_real at (u,−v). Strict version by not_iff_not over the unconditional ≤; nonzero form by real_inner_div_norm_mul_norm_eq_neg_one_iff; difference form by v ↦ −v; mirror by norm_add_eq_iff_real.",
+    "openQuestions": [
+      "Quantitative deficit ‖f+g‖ − |‖f‖−‖g‖| via the angle between f and g",
+      "Equality case of general Lᵖ reverse Minkowski (p ≠ 2) via strict convexity",
+      "Complex L² equality case (phase alignment instead of negative real multiple)"
+    ],
+    "sections": [
+      {
+        "title": "Equality ⟺ CS Lower Bound Tight",
+        "content": "reverse_minkowski_eq_iff_inner.",
+        "startLine": 58,
+        "endLine": 75,
+        "theorems": [
+          "reverse_minkowski_eq_iff_inner"
+        ]
+      },
+      {
+        "title": "Antiparallel Vector Characterization",
+        "content": "reverse_minkowski_eq_iff, reverse_minkowski_lt_iff (private reverse_minkowski_le).",
+        "startLine": 77,
+        "endLine": 110,
+        "theorems": [
+          "reverse_minkowski_eq_iff",
+          "reverse_minkowski_lt_iff"
+        ]
+      },
+      {
+        "title": "Negative Scalar Multiple (Nonzero)",
+        "content": "reverse_minkowski_eq_iff_neg_smul.",
+        "startLine": 112,
+        "endLine": 128,
+        "theorems": [
+          "reverse_minkowski_eq_iff_neg_smul"
+        ]
+      },
+      {
+        "title": "Difference Form and Mirror",
+        "content": "reverse_minkowski_sub_eq_iff, forward_iff_reverse_sub.",
+        "startLine": 130,
+        "endLine": 152,
+        "theorems": [
+          "reverse_minkowski_sub_eq_iff",
+          "forward_iff_reverse_sub"
+        ]
+      },
+      {
+        "title": "L²(μ) Specialization",
+        "content": "reverse_minkowski_eq_iff_l2.",
+        "startLine": 154,
+        "endLine": 169,
+        "theorems": [
+          "reverse_minkowski_eq_iff_l2"
+        ]
+      }
+    ],
+    "mathContext": {
+      "field": "Functional Analysis / Inequalities",
+      "keyTheorem": "Reverse Minkowski equality case: |‖f‖−‖g‖| = ‖f+g‖ ⟺ ‖g‖•f = −(‖f‖•g) (antiparallel), i.e. the Cauchy-Schwarz lower bound ⟪f,g⟫ = −‖f‖‖g‖ is tight.",
+      "historicalBackground": "Equality cases of the triangle inequality (Minkowski) are classical: ‖f+g‖ = ‖f‖+‖g‖ forces nonnegative proportionality. The reverse triangle inequality's equality case is the antiproportional twin, and in inner-product spaces both are instances of the Cauchy-Schwarz equality case.",
+      "significance": "Completes the parent's symmetric CS picture at the level of equality cases: forward and reverse Minkowski saturate the upper and lower CS bounds, and they do so exactly when the vectors are proportional, respectively antiproportional."
+    }
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question posed by the parent **cauchy-schwarz-integral-oq-02-oq-03** (*Reverse Minkowski Inequality from Cauchy-Schwarz*):

> Establish the equality case of reverse Minkowski — when is `|‖f‖−‖g‖| = ‖f+g‖`?

**Answer: equality holds iff the vectors are antiparallel,**
```
|‖u‖ − ‖v‖| = ‖u + v‖   ↔   ‖v‖ • u = −(‖u‖ • v)
```
i.e. one is a *nonpositive* real multiple of the other (for nonzero vectors, `v = r•u` with `r < 0`).

## The mechanism

Equality in reverse Minkowski is *exactly* saturation of the Cauchy-Schwarz **lower** bound:
```
|‖u‖ − ‖v‖| = ‖u + v‖   ⟺   ⟪u,v⟫ = −‖u‖·‖v‖.
```
This is the precise dual of the forward triangle equality `‖u+v‖ = ‖u‖+‖v‖ ↔ ‖v‖•u = ‖u‖•v` (Mathlib's `norm_add_eq_iff_real`), which saturates the CS **upper** bound and forces *proportionality*. Forward = parallel; reverse = antiparallel. The antiparallel condition is obtained slickly by feeding Mathlib's CS equality case `inner_eq_norm_mul_iff_real` the pair `(u, −v)` — no bespoke "negative CS equality" lemma needed.

## Contents (8 theorems, 0 axioms, 0 sorries)

- `reverse_minkowski_eq_iff_inner` — equality ⟺ CS lower bound tight `⟪u,v⟫ = −‖u‖‖v‖`
- `reverse_minkowski_eq_iff` — the antiparallel vector form `‖v‖•u = −(‖u‖•v)`
- `reverse_minkowski_lt_iff` — strict dichotomy: `< ⟺ ‖v‖•u ≠ −(‖u‖•v)`
- `reverse_minkowski_eq_iff_neg_smul` — nonzero form `∃ r<0, v=r•u`
- `reverse_minkowski_sub_eq_iff` + `forward_iff_reverse_sub` — difference form & the explicit forward/reverse mirror
- `reverse_minkowski_eq_iff_l2` — L²(μ) specialization

## Verification

Kernel-verified with `lake env lean` (Lean 4 v4.26.0, Mathlib): 0 errors, 0 warnings, 0 sorries. `#print axioms` on the headline theorems lists only `propext, Classical.choice, Quot.sound` — **status `verified`, badge `original`, axiomCount 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)