### PR TITLE
Enrich Nakayama's Lemma local forms (nakayama-lemma-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/nakayama-lemma-oq-01/annotations.json
+++ b/src/data/proofs/nakayama-lemma-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "nakayama-oq01-header",
+    "proofId": "nakayama-lemma-oq-01",
+    "range": { "startLine": 5, "endLine": 56 },
+    "type": "context",
+    "title": "From Mathlib's Jacobson forms to the textbook local-ring forms",
+    "content": "Nakayama's lemma is the workhorse of commutative algebra. Mathlib proves only the general *Jacobson-radical* statements (Stacks 00DV (2), (4), (8)) for an arbitrary ring; it states none of them for the maximal ideal 𝔪 of a local ring — the form every course actually quotes — and offers no 'generators lift from M/𝔪M' corollary. This file derives the textbook forms: N ≤ 𝔪N ⟹ N = 0; 𝔪M = M ⟹ M = 0 (and the nonvanishing dual); generators modulo 𝔪N generate N; and a set spanning M/𝔪M spans M. The unifying device is a single inclusion, 𝔪 ≤ jacobson ⊥ in a local ring, which specializes each Jacobson statement to its local counterpart. All 0-axiom.",
+    "mathContext": "$\\mathfrak{m} \\cdot M = M \\implies M = 0;\\quad \\mathfrak{m} \\le \\mathrm{jacobson}(\\bot)$",
+    "significance": "context",
+    "relatedConcepts": ["Nakayama's lemma", "Jacobson radical", "local ring", "minimal generators"],
+    "prerequisites": ["modules and submodules", "local rings and maximal ideals", "the Jacobson radical"]
+  },
+  {
+    "id": "nakayama-oq01-jacobson",
+    "proofId": "nakayama-lemma-oq-01",
+    "range": { "startLine": 64, "endLine": 70 },
+    "type": "theorem",
+    "title": "nakayama_jacobson: the Jacobson-form baseline",
+    "content": "`nakayama_jacobson` restates Mathlib's `Submodule.eq_bot_of_le_smul_of_le_jacobson_bot` (Stacks 00DV (2)): a finitely generated submodule N with N ≤ I•N and I ≤ jacobson ⊥ is the zero submodule. This is the general-ring engine; every local-ring form below is this statement composed with the inclusion 𝔪 ≤ jacobson ⊥, so the mathematical content lives here and the contribution is exhibiting the textbook forms as specializations.",
+    "mathContext": "$N \\text{ f.g.},\\ N \\le I \\cdot N,\\ I \\le \\mathrm{jacobson}(\\bot) \\implies N = \\bot$",
+    "significance": "supporting",
+    "relatedConcepts": ["Submodule.eq_bot_of_le_smul_of_le_jacobson_bot", "Stacks 00DV", "finitely generated submodule"],
+    "prerequisites": ["the Jacobson radical", "finitely generated submodules"]
+  },
+  {
+    "id": "nakayama-oq01-local-forms",
+    "proofId": "nakayama-lemma-oq-01",
+    "range": { "startLine": 74, "endLine": 97 },
+    "type": "theorem",
+    "title": "The local-ring forms (vanishing and nonvanishing)",
+    "content": "Under `[IsLocalRing R]`: `nakayama_local` is the single most-cited statement — a finitely generated N with N ≤ 𝔪•N vanishes — obtained by applying `nakayama_jacobson` with I = 𝔪 and discharging I ≤ jacobson ⊥ by `IsLocalRing.maximalIdeal_le_jacobson ⊥`. `nakayama_local_top` upgrades this to the type level: a finite module M with 𝔪•M = M is `Subsingleton`, bridging the submodule equation ⊤ = ⊥ to a triviality (membership in ⊥ pins every element to 0). `nakayama_local_top_ne` is the contrapositive — a nonzero finite M has 𝔪•M ≠ M, so the cotangent space M/𝔪M is itself nonzero — closed via `not_subsingleton`.",
+    "mathContext": "$\\mathfrak{m} \\cdot M = M \\implies M \\cong 0;\\quad M \\ne 0 \\implies \\mathfrak{m} \\cdot M \\ne M$",
+    "significance": "key",
+    "relatedConcepts": ["IsLocalRing.maximalIdeal_le_jacobson", "Subsingleton", "cotangent space M/𝔪M", "Module.Finite.fg_top"],
+    "prerequisites": ["the Jacobson baseline", "the inclusion 𝔪 ≤ jacobson ⊥", "submodule ⊥ membership"]
+  },
+  {
+    "id": "nakayama-oq01-generators",
+    "proofId": "nakayama-lemma-oq-01",
+    "range": { "startLine": 99, "endLine": 105 },
+    "type": "theorem",
+    "title": "nakayama_generators: generators modulo 𝔪N generate N",
+    "content": "`nakayama_generators`: over a local ring, if a finitely generated N satisfies N ≤ span t ⊔ 𝔪•N, then already N ≤ span t. It is governed by statement (4), `Submodule.le_of_le_smul_of_le_jacobson_bot` (the sup/comparison form), with the candidate submodule taken to be span t — statement (2) alone does not see the generating set. This is the precise sense in which elements generating N modulo 𝔪N already generate N.",
+    "mathContext": "$N \\le \\mathrm{span}(t) \\sqcup \\mathfrak{m} \\cdot N \\implies N \\le \\mathrm{span}(t)$",
+    "significance": "key",
+    "relatedConcepts": ["Submodule.le_of_le_smul_of_le_jacobson_bot", "Stacks 00DV (4)", "span of a generating set"],
+    "prerequisites": ["the Jacobson statement (4)", "spans of submodules"]
+  },
+  {
+    "id": "nakayama-oq01-lifting",
+    "proofId": "nakayama-lemma-oq-01",
+    "range": { "startLine": 107, "endLine": 113 },
+    "type": "theorem",
+    "title": "nakayama_span_of_span_quotient: lifting a residue-field basis",
+    "content": "`nakayama_span_of_span_quotient` specializes the generators corollary to N = ⊤ (for finite M) and reads span t = ⊤ off `top_le_iff`: a set t spanning M modulo 𝔪M spans M itself. This is exactly the statement used to lift a basis of the R/𝔪-vector space M/𝔪M to a generating set of M — the source of 'minimal number of generators = dim_{R/𝔪} M/𝔪M'.",
+    "mathContext": "$t \\text{ spans } M/\\mathfrak{m}M \\implies t \\text{ spans } M;\\quad \\#\\text{min gens} = \\dim_{R/\\mathfrak{m}} M/\\mathfrak{m}M$",
+    "significance": "key",
+    "relatedConcepts": ["residue field R/𝔪", "minimal generators", "top_le_iff", "Nakayama lifting"],
+    "prerequisites": ["the generators corollary", "quotient modules M/𝔪M"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `nakayama-lemma-oq-01` (the local-ring forms of Nakayama's lemma and lifting of generators).

This entry had a rich `meta.json` (with references) but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **Jacobson → local framing** — Mathlib has the Jacobson-radical forms; this derives the textbook local ones via 𝔪 ≤ jacobson ⊥.
- **nakayama_jacobson** — the general-ring baseline (Stacks 00DV (2)).
- **Local-ring forms** — vanishing (𝔪M=M ⟹ M=0) and nonvanishing (M/𝔪M ≠ 0).
- **nakayama_generators** — generators modulo 𝔪N generate N (statement (4)).
- **nakayama_span_of_span_quotient** — lifting a residue-field basis to a generating set.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)