### PR TITLE
Enrich Nesbitt's Inequality (nesbitt-inequality-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/nesbitt-inequality-oq-01/annotations.json
+++ b/src/data/proofs/nesbitt-inequality-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "nesbitt-oq01-header",
+    "proofId": "nesbitt-inequality-oq-01",
+    "range": { "startLine": 3, "endLine": 24 },
+    "type": "context",
+    "title": "Nesbitt's inequality via a sum-of-squares certificate",
+    "content": "The header states Nesbitt's inequality — for positive reals a, b, c, a/(b+c) + b/(c+a) + c/(a+b) ≥ 3/2 with equality iff a = b = c — and the proof's backbone: the sum-of-squares (SOS) identity Σ a/(b+c) − 3/2 = (a−b)²/(2(b+c)(c+a)) + (b−c)²/(2(c+a)(a+b)) + (c−a)²/(2(a+b)(b+c)). It is obtained by pairing each term with 1/2: a/(b+c) − 1/2 = ((a−b)+(a−c))/(2(b+c)). Each RHS summand is a nonnegative square over a positive denominator, so the defect is ≥ 0 (the bound) and vanishes exactly when all three squares vanish (the equality case). Nesbitt is the simplest nontrivial Shapiro cyclic sum and is absent from Mathlib as a named lemma.",
+    "mathContext": "$\\frac{a}{b+c} + \\frac{b}{c+a} + \\frac{c}{a+b} \\ge \\frac32,\\quad \\text{equality} \\iff a=b=c$",
+    "significance": "context",
+    "relatedConcepts": ["Nesbitt's inequality", "sum of squares", "cyclic sum", "Shapiro inequality"],
+    "prerequisites": ["real fractions", "SOS certificates", "ordered fields"]
+  },
+  {
+    "id": "nesbitt-oq01-sos",
+    "proofId": "nesbitt-inequality-oq-01",
+    "range": { "startLine": 28, "endLine": 39 },
+    "type": "theorem",
+    "title": "nesbitt_sub_eq: the sum-of-squares identity",
+    "content": "`nesbitt_sub_eq` is the algebraic heart: the defect Σ a/(b+c) − 3/2 equals the three-term SOS. The proof is a complete decision procedure once the denominators are known nonzero — `positivity` establishes b+c, c+a, a+b ≠ 0 from 0 < a,b,c, `field_simp` clears them, and `ring` closes the resulting polynomial identity. The only analytic input is the positivity of a, b, c; everything else is pure algebra.",
+    "mathContext": "$\\sum \\frac{a}{b+c} - \\frac32 = \\frac{(a-b)^2}{2(b+c)(c+a)} + \\frac{(b-c)^2}{2(c+a)(a+b)} + \\frac{(c-a)^2}{2(a+b)(b+c)}$",
+    "significance": "key",
+    "relatedConcepts": ["sum-of-squares identity", "field_simp", "ring", "positivity"],
+    "prerequisites": ["rational-function identities", "clearing denominators"]
+  },
+  {
+    "id": "nesbitt-oq01-ineq",
+    "proofId": "nesbitt-inequality-oq-01",
+    "range": { "startLine": 41, "endLine": 49 },
+    "type": "theorem",
+    "title": "nesbitt: the inequality itself",
+    "content": "`nesbitt` derives the bound 3/2 ≤ Σ a/(b+c) from the SOS identity. Each of the three summands is nonnegative — a square over a positive denominator, certified by `positivity` — so the defect is ≥ 0 and `linarith` against `nesbitt_sub_eq` concludes. The SOS identity converts a fractional cyclic inequality into manifestly nonnegative data; no rearrangement, Cauchy–Schwarz, or tangent-line trick is needed.",
+    "mathContext": "$\\text{each } \\frac{(\\cdot)^2}{2(\\cdot)(\\cdot)} \\ge 0 \\implies \\sum \\frac{a}{b+c} \\ge \\frac32$",
+    "significance": "key",
+    "relatedConcepts": ["nonnegativity of squares", "positivity", "linarith"],
+    "prerequisites": ["the SOS identity"]
+  },
+  {
+    "id": "nesbitt-oq01-eq",
+    "proofId": "nesbitt-inequality-oq-01",
+    "range": { "startLine": 51, "endLine": 85 },
+    "type": "theorem",
+    "title": "nesbitt_eq_iff: equality iff a = b = c",
+    "content": "`nesbitt_eq_iff`: equality holds iff a = b ∧ b = c. Forward: if the sum equals 3/2 the defect is 0; since each SOS term is nonnegative, `linarith` forces two of them to vanish, then `div_eq_zero_iff` (denominators nonzero by `positivity`) gives (a−b)² = (b−c)² = 0, and `pow_eq_zero_iff` + `sub_eq_zero` yield a = b and b = c. Reverse: substituting a = b = c makes every numerator square vanish, so the RHS is 0 and the sum is 3/2. The same identity that proves the bound pins the equality case — no separate optimisation argument.",
+    "mathContext": "$\\sum \\frac{a}{b+c} = \\frac32 \\iff (a-b)^2 = (b-c)^2 = 0 \\iff a = b = c$",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "div_eq_zero_iff", "pow_eq_zero_iff", "sub_eq_zero"],
+    "prerequisites": ["the SOS identity", "vanishing of squares"]
+  },
+  {
+    "id": "nesbitt-oq01-strict",
+    "proofId": "nesbitt-inequality-oq-01",
+    "range": { "startLine": 87, "endLine": 94 },
+    "type": "theorem",
+    "title": "nesbitt_lt: strict inequality off the diagonal",
+    "content": "`nesbitt_lt`: unless a = b = c, the bound is strict, 3/2 < Σ a/(b+c). It is packaged from the equality characterisation: `lt_or_eq_of_le` on `nesbitt` splits into the strict case (done) or equality, and equality would force a = b ∧ b = c via `nesbitt_eq_iff`, contradicting the hypothesis. Together with the equality case this gives the full picture: minimum 3/2 attained exactly on the diagonal.",
+    "mathContext": "$\\lnot(a = b \\wedge b = c) \\implies \\frac32 < \\sum \\frac{a}{b+c}$",
+    "significance": "supporting",
+    "relatedConcepts": ["strict inequality", "lt_or_eq_of_le", "contrapositive of the equality case"],
+    "prerequisites": ["the inequality and its equality case"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `nesbitt-inequality-oq-01` (a/(b+c)+b/(c+a)+c/(a+b) ≥ 3/2, equality iff a=b=c).

This entry had a rich `meta.json` (with references) but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **SOS-certificate framing** — the defect equals a sum of three squares over positive denominators.
- **nesbitt_sub_eq** — the SOS identity (field_simp + ring).
- **nesbitt** — the inequality, from nonnegativity of each term.
- **nesbitt_eq_iff** — equality iff a=b=c, forcing each square to vanish.
- **nesbitt_lt** — the strict form off the diagonal.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)