### PR TITLE
research(solution-of-cubic-oq-01-oq-02): sign of the real cubic discriminant classifies the root structure [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3469,6 +3469,7 @@ import Proofs.SkolemNoetherMatrixAutAristotle
 import Proofs.SolutionOfCubic
 import Proofs.SolutionOfCubicOQ01
 import Proofs.SolutionOfCubicOQ01OQ01
+import Proofs.SolutionOfCubicOQ01OQ02
 import Proofs.SolutionOfCubicOQ03
 import Proofs.SolutionOfCubicOQ03OQ01
 import Proofs.SolutionOfCubicOQ03OQ02

--- a/proofs/Proofs/SolutionOfCubicOQ01OQ02.lean
+++ b/proofs/Proofs/SolutionOfCubicOQ01OQ02.lean
@@ -1,0 +1,228 @@
+import Proofs.SolutionOfCubicOQ01OQ01
+
+/-!
+# The Sign of the Real Cubic Discriminant Classifies the Root Structure (Solution of Cubic, OQ-01-OQ-02)
+
+## What This Proves
+
+The sibling file `SolutionOfCubicOQ01OQ01` defines the general cubic discriminant
+`Δ(a,b,c,d) = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d²` over `ℂ`, proves its invariance under the
+Tschirnhaus shift, and gives the symmetric **root form** `Δ = a⁴·∏_{i<j}(xᵢ−xⱼ)²`. Over `ℂ` the
+discriminant is just an algebraic invariant: it vanishes iff two roots collide.
+
+Over `ℝ` the discriminant carries **strictly more** information — its **sign** classifies the
+root structure of a real cubic. This is the classical *discriminant test*:
+
+  * `Δ > 0`  ⟺  three **distinct real** roots;
+  * `Δ < 0`  ⟺  one real root and a **non-real complex-conjugate pair**;
+  * `Δ = 0`  ⟺  a **repeated** root (all roots then real).
+
+This file proves the three forward sign implications (the directions used in practice), which —
+because the three structural cases are exhaustive for a real cubic — give the full
+classification. None of this is in the sibling: the sibling is a characteristic-free algebraic
+identity over `ℂ`; here the content is the **order** structure of `ℝ`.
+
+## The key idea
+
+Both sign theorems come from the root form `Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²`:
+
+* **All-real roots.** The bracket is a real number, so `Δ = a⁴·(real)²  ≥ 0`, and `> 0` exactly
+  when the roots are distinct. (`realDiscriminant_pos_of_distinct_real_roots`.)
+
+* **Conjugate pair.** If the roots are `r` (real) and `w, w̄` with `w = m + n·i`, the Vieta
+  coefficients are real and a *single real polynomial identity* collapses the discriminant to
+
+    `Δ = −4·a⁴·n²·((r−m)² + n²)²`,
+
+  which is `< 0` precisely when `n ≠ 0` (a genuine non-real pair). The whole computation is a
+  `ring` identity in `a, r, m, n` — the complex root `(w − w̄)² = −4n²` is what flips the sign.
+  (`realDiscriminant_conj_pair`, `realDiscriminant_neg_of_conj_pair`.)
+
+To certify that the conjugate-pair *parametrization* really is the Vieta data of the complex
+roots `r, w, w̄`, `realDiscriminant_conj_pair_root_form` bridges back to the sibling's complex
+`generalDiscriminant_eq_root_form` via the real-to-complex cast.
+
+## Original Contributions
+- `realDiscriminant` — the real-valued cubic discriminant (so its sign is meaningful).
+- `realDiscriminant_eq_root_form` — real root form `Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²`.
+- `realDiscriminant_nonneg_of_real_roots` / `realDiscriminant_pos_of_distinct_real_roots` —
+  three real roots force `Δ ≥ 0`, strictly `> 0` when distinct.
+- `realDiscriminant_eq_zero_iff_repeated_real` — among real roots, `Δ = 0` ⟺ two coincide.
+- `realDiscriminant_conj_pair` — the headline real identity `Δ = −4a⁴n²((r−m)²+n²)²` for the
+  conjugate-pair Vieta data.
+- `realDiscriminant_neg_of_conj_pair` — `Δ < 0` for a real root plus a non-real conjugate pair.
+- `realDiscriminant_conj_pair_root_form` — certifies the parametrization is the complex root
+  form of `r, w, w̄` (`w = m + n·i`), bridging to the sibling's `generalDiscriminant`.
+
+## Proof Techniques
+Everything reduces to `ring` over `ℝ` plus `positivity`/`nlinarith` for the sign. The only
+complex-number work is the bridge, which proves three Vieta equalities componentwise
+(`Complex.ext`) — the algebraic core never leaves `ℝ`. `0`-axiom throughout.
+-/
+
+namespace SolutionOfCubicOQ01OQ02
+
+open SolutionOfCubicOQ01OQ01
+
+/-! ## Part 1: The real cubic discriminant -/
+
+/-- The discriminant of the **real** cubic `a x³ + b x² + c x + d`. Same polynomial as the
+sibling's complex `generalDiscriminant`, but valued in `ℝ` so that its **sign** is meaningful. -/
+def realDiscriminant (a b c d : ℝ) : ℝ :=
+  18 * a * b * c * d - 4 * b ^ 3 * d + b ^ 2 * c ^ 2 - 4 * a * c ^ 3 - 27 * a ^ 2 * d ^ 2
+
+/-- The real discriminant is the cast of the complex one: it agrees with the sibling's
+`generalDiscriminant` after `ℝ → ℂ`. -/
+theorem realDiscriminant_cast (a b c d : ℝ) :
+    (realDiscriminant a b c d : ℂ)
+      = generalDiscriminant (a : ℂ) (b : ℂ) (c : ℂ) (d : ℂ) := by
+  unfold realDiscriminant generalDiscriminant
+  push_cast
+  ring
+
+/-- A leading coefficient of a genuine cubic gives `a⁴ > 0`. -/
+private lemma pow4_pos {a : ℝ} (ha : a ≠ 0) : 0 < a ^ 4 := by positivity
+
+/-! ## Part 2: The all-real-roots case — `Δ ≥ 0`
+
+For three real roots the discriminant is `a⁴` times a real square, hence nonnegative, and
+strictly positive exactly when the roots are distinct. -/
+
+/-- **Real root form.** If `b, c, d` are the Vieta coefficients of three *real* roots
+`x₁, x₂, x₃` (so `a x³ + b x² + c x + d = a(x−x₁)(x−x₂)(x−x₃)`), then
+`Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²`. -/
+theorem realDiscriminant_eq_root_form (a x₁ x₂ x₃ b c d : ℝ)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    realDiscriminant a b c d = a ^ 4 * ((x₁ - x₂) * (x₁ - x₃) * (x₂ - x₃)) ^ 2 := by
+  subst hb hc hd
+  unfold realDiscriminant
+  ring
+
+/-- **Three real roots force `Δ ≥ 0`.** -/
+theorem realDiscriminant_nonneg_of_real_roots (a x₁ x₂ x₃ b c d : ℝ)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    0 ≤ realDiscriminant a b c d := by
+  rw [realDiscriminant_eq_root_form a x₁ x₂ x₃ b c d hb hc hd]
+  positivity
+
+/-- **Three distinct real roots force `Δ > 0`** — the first leg of the discriminant test. -/
+theorem realDiscriminant_pos_of_distinct_real_roots (a x₁ x₂ x₃ b c d : ℝ)
+    (ha : a ≠ 0) (h12 : x₁ ≠ x₂) (h13 : x₁ ≠ x₃) (h23 : x₂ ≠ x₃)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    0 < realDiscriminant a b c d := by
+  rw [realDiscriminant_eq_root_form a x₁ x₂ x₃ b c d hb hc hd]
+  have hprod : (x₁ - x₂) * (x₁ - x₃) * (x₂ - x₃) ≠ 0 :=
+    mul_ne_zero (mul_ne_zero (sub_ne_zero.mpr h12) (sub_ne_zero.mpr h13)) (sub_ne_zero.mpr h23)
+  positivity
+
+/-- **Repeated-root criterion over `ℝ`.** For real roots, `Δ = 0` iff two of them coincide —
+the boundary `Δ = 0` of the discriminant test. -/
+theorem realDiscriminant_eq_zero_iff_repeated_real (a x₁ x₂ x₃ b c d : ℝ) (ha : a ≠ 0)
+    (hb : b = -a * (x₁ + x₂ + x₃))
+    (hc : c = a * (x₁ * x₂ + x₁ * x₃ + x₂ * x₃))
+    (hd : d = -a * (x₁ * x₂ * x₃)) :
+    realDiscriminant a b c d = 0 ↔ (x₁ = x₂ ∨ x₁ = x₃ ∨ x₂ = x₃) := by
+  rw [realDiscriminant_eq_root_form a x₁ x₂ x₃ b c d hb hc hd, mul_eq_zero]
+  constructor
+  · rintro (h | h)
+    · exact absurd h (pow_ne_zero 4 ha)
+    · have hp : (x₁ - x₂) * (x₁ - x₃) * (x₂ - x₃) = 0 := pow_eq_zero_iff (by norm_num) |>.mp h
+      rcases mul_eq_zero.mp hp with h2 | h2
+      · rcases mul_eq_zero.mp h2 with h3 | h3
+        · exact Or.inl (sub_eq_zero.mp h3)
+        · exact Or.inr (Or.inl (sub_eq_zero.mp h3))
+      · exact Or.inr (Or.inr (sub_eq_zero.mp h2))
+  · intro h
+    refine Or.inr ?_
+    rcases h with h | h | h <;> subst h <;> ring
+
+/-! ## Part 3: The conjugate-pair case — `Δ < 0`
+
+If the roots are one real `r` and a non-real conjugate pair `m ± n·i`, the Vieta coefficients
+are real and the discriminant collapses to a manifestly nonpositive real form. -/
+
+/-- **The conjugate-pair discriminant identity.** A real cubic with roots `r` (real) and the
+conjugate pair `m ± n·i` has Vieta coefficients `b = −a(r+2m)`, `c = a(2rm + m²+n²)`,
+`d = −a·r(m²+n²)`, and its discriminant is the pure real expression
+
+  `Δ = −4·a⁴·n²·((r−m)² + n²)²`.
+
+The sign-flipping factor `−4n²` is exactly `(w − w̄)² = (2n·i)²`. -/
+theorem realDiscriminant_conj_pair (a r m n : ℝ) :
+    realDiscriminant a (-a * (r + 2 * m)) (a * (2 * r * m + (m ^ 2 + n ^ 2)))
+        (-a * (r * (m ^ 2 + n ^ 2)))
+      = -4 * a ^ 4 * n ^ 2 * ((r - m) ^ 2 + n ^ 2) ^ 2 := by
+  unfold realDiscriminant
+  ring
+
+/-- **A real root plus a non-real conjugate pair force `Δ < 0`** — the second leg of the
+discriminant test. The hypothesis `n ≠ 0` is exactly "the pair is genuinely non-real". -/
+theorem realDiscriminant_neg_of_conj_pair (a r m n : ℝ) (ha : a ≠ 0) (hn : n ≠ 0) :
+    realDiscriminant a (-a * (r + 2 * m)) (a * (2 * r * m + (m ^ 2 + n ^ 2)))
+        (-a * (r * (m ^ 2 + n ^ 2))) < 0 := by
+  rw [realDiscriminant_conj_pair]
+  have h1 : 0 < a ^ 4 := pow4_pos ha
+  have h2 : 0 < n ^ 2 := by positivity
+  have h3 : 0 < ((r - m) ^ 2 + n ^ 2) ^ 2 := by positivity
+  nlinarith [mul_pos (mul_pos h1 h2) h3]
+
+/-! ## Part 4: The bridge — the parametrization is the complex root form
+
+We certify that the conjugate-pair coefficients above are genuinely the Vieta data of the three
+complex roots `r, w, w̄` with `w = m + n·i`, by casting to `ℂ` and invoking the sibling's
+`generalDiscriminant_eq_root_form`. The three Vieta equalities are checked componentwise. -/
+
+set_option linter.unusedSimpArgs false in
+/-- **Bridge to complex conjugate roots.** With `w = m + n·i`, the real cubic of
+`realDiscriminant_conj_pair` is exactly the cubic with roots `r, w, w̄`: casting to `ℂ`, its
+discriminant equals the sibling's complex root form `a⁴·((r−w)(r−w̄)(w−w̄))²`. This shows the
+negativity is caused by the genuine non-real pair `w, w̄`. -/
+theorem realDiscriminant_conj_pair_root_form (a r m n : ℝ) :
+    (realDiscriminant a (-a * (r + 2 * m)) (a * (2 * r * m + (m ^ 2 + n ^ 2)))
+        (-a * (r * (m ^ 2 + n ^ 2))) : ℂ)
+      = (a : ℂ) ^ 4 *
+          (((r : ℂ) - ((m : ℂ) + (n : ℂ) * Complex.I)) *
+            ((r : ℂ) - (starRingEnd ℂ) ((m : ℂ) + (n : ℂ) * Complex.I)) *
+            (((m : ℂ) + (n : ℂ) * Complex.I) -
+              (starRingEnd ℂ) ((m : ℂ) + (n : ℂ) * Complex.I))) ^ 2 := by
+  rw [realDiscriminant_cast]
+  -- `apply` unifies the roots as `r, w, w̄` (`w = m + n·i`) from the right-hand side, leaving the
+  -- three Vieta equalities `b = -a·e₁`, `c = a·e₂`, `d = -a·e₃`. Each is checked componentwise
+  -- (`re`/`im` — keeping the real coefficients under the `ℝ → ℂ` cast) and closed by `ring`.
+  apply generalDiscriminant_eq_root_form <;>
+    (apply Complex.ext <;>
+      simp only [Complex.neg_re, Complex.neg_im, Complex.add_re, Complex.add_im, Complex.sub_re,
+        Complex.sub_im, Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im,
+        Complex.conj_re, Complex.conj_im, Complex.ofReal_re, Complex.ofReal_im] <;>
+      ring)
+
+/-! ## Part 5: Sanity checks — the discriminant test on worked cubics -/
+
+/-- `x³ − x = x(x−1)(x+1)`: three distinct real roots `0, 1, −1`, so `Δ = 4 > 0`. -/
+example : realDiscriminant 1 0 (-1) 0 = 4 := by unfold realDiscriminant; norm_num
+
+example : 0 < realDiscriminant 1 0 (-1) 0 := by unfold realDiscriminant; norm_num
+
+/-- `x³ + x = x(x²+1)`: real root `0` and the conjugate pair `±i`, so `Δ = −4 < 0`. This is the
+`r = 0, m = 0, n = 1` instance of `realDiscriminant_conj_pair`: `−4·1·1·(0+1)² = −4`. -/
+example : realDiscriminant 1 0 1 0 = -4 := by unfold realDiscriminant; norm_num
+
+example : realDiscriminant 1 0 1 0 < 0 := by unfold realDiscriminant; norm_num
+
+/-- `x³ − 3x + 2 = (x−1)²(x+2)`: a repeated real root, so `Δ = 0` (the boundary of the test). -/
+example : realDiscriminant 1 0 (-3) 2 = 0 := by unfold realDiscriminant; norm_num
+
+end SolutionOfCubicOQ01OQ02
+
+-- Summary of key results
+#check SolutionOfCubicOQ01OQ02.realDiscriminant_pos_of_distinct_real_roots
+#check SolutionOfCubicOQ01OQ02.realDiscriminant_neg_of_conj_pair
+#check SolutionOfCubicOQ01OQ02.realDiscriminant_eq_zero_iff_repeated_real
+#check SolutionOfCubicOQ01OQ02.realDiscriminant_conj_pair
+#check SolutionOfCubicOQ01OQ02.realDiscriminant_conj_pair_root_form

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-soc-oq0102-rootform",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 113,
+      "endLine": 124
+    },
+    "type": "insight",
+    "title": "Three Distinct Real Roots Force Δ > 0",
+    "body": "From the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))², the all-real case is pure positivity. For any real roots the bracket is a real number, so Δ = a⁴·(real)² ≥ 0; when the roots are distinct each difference is nonzero, the product is nonzero, its square is strictly positive, and a⁴ > 0 (since a ≠ 0), giving Δ > 0. This is the first leg of the classical discriminant test, and it is exactly where the order structure of ℝ — absent over ℂ — enters."
+  },
+  {
+    "id": "ann-soc-oq0102-conjpair",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 157,
+      "endLine": 174
+    },
+    "type": "insight",
+    "title": "The Conjugate-Pair Case is a Real Ring Identity",
+    "body": "For a real root r and a non-real conjugate pair m ± n·i, the Vieta coefficients b = −a(r+2m), c = a(2rm + m²+n²), d = −a·r(m²+n²) are all real, and the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², proved by one ring call with no complex arithmetic. The sign-flipping factor −4n² is precisely (w − w̄)² = (2n·i)². With n ≠ 0 (a genuine non-real pair), positivity reads off Δ < 0 — the second leg of the discriminant test."
+  },
+  {
+    "id": "ann-soc-oq0102-bridge",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 186,
+      "endLine": 204
+    },
+    "type": "technique",
+    "title": "Casting Back to Certify the Conjugate Pair",
+    "body": "realDiscriminant_conj_pair_root_form certifies that the chosen real parametrization really is the Vieta data of the complex roots r, w, w̄ with w = m + n·i. It casts realDiscriminant to ℂ (realDiscriminant_cast), applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, and discharges the three Vieta equalities componentwise via Complex.ext — keeping the real coefficients whole under the ℝ → ℂ cast so re/im reduce by ofReal_re/ofReal_im and ring closes. This guarantees the negativity is caused by an actual non-real conjugate pair, not an artifact of the parametrization."
+  },
+  {
+    "id": "ann-soc-oq0102-trichotomy",
+    "proofId": "solution-of-cubic-oq-01-oq-02",
+    "range": {
+      "startLine": 205,
+      "endLine": 219
+    },
+    "type": "insight",
+    "title": "One Cubic in Each Regime",
+    "body": "The three sanity checks instantiate the discriminant test: x³ − x = x(x−1)(x+1) has three distinct real roots and Δ = 4 > 0; x³ + x = x(x²+1) has the real root 0 and the conjugate pair ±i with Δ = −4 < 0 (the n = 1, m = r = 0 instance of the conjugate-pair identity); x³ − 3x + 2 = (x−1)²(x+2) has a repeated real root and Δ = 0. Together they sweep the full trichotomy Δ > 0 / Δ < 0 / Δ = 0."
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-01-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-01-oq-02/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "solution-of-cubic-oq-01-oq-02",
+  "title": "The Sign of the Real Cubic Discriminant Classifies the Root Structure",
+  "slug": "solution-of-cubic-oq-01-oq-02",
+  "description": "Over ℝ the cubic discriminant carries strictly more information than over ℂ: its sign classifies the root structure (the classical discriminant test). Δ > 0 for three distinct real roots, Δ < 0 for one real root and a non-real complex-conjugate pair, Δ = 0 for a repeated root. Both sign theorems flow from the root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²; the conjugate-pair case collapses to a single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)². Answers the sign-trichotomy open question raised by the sibling discriminant entry OQ-01-OQ-01.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Discriminant#Nature_of_the_roots",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ01OQ02.lean",
+    "tags": [
+      "algebra",
+      "cubic-equations",
+      "discriminant",
+      "real-roots",
+      "discriminant-test",
+      "complex-conjugate-roots",
+      "vieta",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [],
+    "originalContributions": [
+      "realDiscriminant: the real-valued cubic discriminant 18abcd − 4b³d + b²c² − 4ac³ − 27a²d², whose sign (unlike the complex version) is meaningful",
+      "realDiscriminant_eq_root_form: the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))² for Vieta coefficients of three real roots",
+      "realDiscriminant_pos_of_distinct_real_roots: three distinct real roots force Δ > 0 (first leg of the discriminant test), with realDiscriminant_nonneg_of_real_roots giving Δ ≥ 0 for any real roots",
+      "realDiscriminant_eq_zero_iff_repeated_real: among real roots, Δ = 0 ⟺ two of them coincide (the Δ = 0 boundary of the test)",
+      "realDiscriminant_conj_pair: the headline real identity Δ = −4a⁴n²((r−m)²+n²)² for a real root r and conjugate pair m ± n·i — a pure ring identity in a, r, m, n",
+      "realDiscriminant_neg_of_conj_pair: a real root plus a non-real conjugate pair (n ≠ 0) forces Δ < 0 (second leg of the discriminant test)",
+      "realDiscriminant_conj_pair_root_form: certifies the conjugate-pair parametrization is the genuine Vieta data of the complex roots r, w, w̄ (w = m + n·i), bridging back to the sibling's complex generalDiscriminant via the ℝ → ℂ cast"
+    ],
+    "dateAdded": "2026-06-23",
+    "prerequisites": [
+      "The general cubic discriminant and its symmetric root form (sibling proof, OQ-01-OQ-01)",
+      "Vieta's formulas; the conjugate-root theorem for real polynomials",
+      "Order properties of ℝ; basic complex arithmetic (re/im, conjugation)"
+    ],
+    "relatedProblems": [
+      {
+        "id": "solution-of-cubic-oq-01-oq-01",
+        "relationship": "Sibling: defines the general cubic discriminant and its complex root form. This entry answers its stated open question on the real sign trichotomy."
+      },
+      {
+        "id": "solution-of-cubic-oq-01",
+        "relationship": "Parent: the Tschirnhaus shift reducing the general cubic to depressed form."
+      },
+      {
+        "id": "solution-of-cubic-oq-03-oq-01",
+        "relationship": "Cousin: the depressed discriminant −4p³ − 27q² in root form over ℝ."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 228,
+    "assumptions": "None. All theorems fully proved from Mathlib with 0 axioms and 0 sorries. Depends only on the foundational axioms propext, Classical.choice, Quot.sound (verified via #print axioms); no native_decide, no Lean.ofReduceBool. The forward sign implications are proved unconditionally; the full ⟺ classification additionally uses that a real cubic's three roots are exhaustively either all real or one real plus a conjugate pair (the standard conjugate-root theorem), which is discussed in the docstring rather than re-formalized here.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "For a real cubic the discriminant Δ = 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² does more than detect repeated roots: its sign separates the three classical regimes. Δ > 0 gives three distinct real roots; Δ = 0 a repeated (hence all-real) root; Δ < 0 one real root and a non-real complex-conjugate pair. This sign test is the real-analytic counterpart of the purely algebraic discriminant of the sibling entry, which lives over ℂ where only Δ = 0 versus Δ ≠ 0 is visible. The trichotomy underlies the casus irreducibilis: exactly when Δ > 0 (three real roots) Cardano's formula is forced through non-real cube roots. The classification follows cleanly from the symmetric root form Δ = a⁴·∏(xᵢ−xⱼ)²: for three real roots the squared product is a nonnegative real, while for a conjugate pair m ± n·i the factor (w − w̄)² = (2n·i)² = −4n² flips the sign.",
+    "problemStatement": "Prove the sign classification of the real cubic discriminant: three distinct real roots ⟹ Δ > 0; one real root and a non-real conjugate pair ⟹ Δ < 0; a repeated real root ⟹ Δ = 0. Certify that the conjugate-pair parametrization is the genuine Vieta data of the complex roots r, w, w̄.",
+    "proofStrategy": "Define realDiscriminant over ℝ so its sign is meaningful, and prove the real root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))² by substituting Vieta and calling ring. The all-real case is then positivity: a⁴·(square) ≥ 0, strictly > 0 when the root differences are nonzero (distinct roots). The conjugate-pair case is the key simplification: writing the Vieta coefficients of r and m ± n·i as real expressions, the discriminant collapses to the single real polynomial identity Δ = −4a⁴n²((r−m)²+n²)² (one ring call), manifestly < 0 when n ≠ 0 — the complex root w − w̄ never has to be handled directly. Finally realDiscriminant_conj_pair_root_form casts to ℂ and applies the sibling's complex generalDiscriminant_eq_root_form with x₁ = r, x₂ = w, x₃ = w̄, discharging the three Vieta equalities componentwise (Complex.ext), so the parametrization is provably that of the conjugate pair.",
+    "keyInsights": [
+      "Over ℝ the discriminant's sign — not just its vanishing — is the invariant of interest: it is the order structure of ℝ, absent over ℂ, that makes the trichotomy possible.",
+      "Both signs come from one identity, the root form Δ = a⁴·∏(xᵢ−xⱼ)²: a real square is ≥ 0, and the conjugate-difference square (2n·i)² = −4n² is the lone source of negativity.",
+      "The conjugate-pair case never needs complex algebra: the Vieta coefficients of r, m ± n·i are real, and Δ = −4a⁴n²((r−m)²+n²)² is a pure ℝ-identity that ring verifies, with the sign read off by positivity.",
+      "The hypothesis n ≠ 0 is exactly the statement that the pair is genuinely non-real; setting n = 0 returns a (repeated) real root and Δ = 0, recovering the boundary of the test.",
+      "The three structural cases (three real, or one real plus a conjugate pair, with the repeated case at the Δ = 0 boundary) are exhaustive for a real cubic, so the forward sign implications give the full ⟺ classification."
+    ],
+    "prerequisites": [
+      "The sibling's general cubic discriminant generalDiscriminant and its complex root form generalDiscriminant_eq_root_form",
+      "Vieta's formulas and the conjugate-root theorem for real polynomials",
+      "The order field ℝ, positivity/nlinarith, and basic complex re/im arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "real-discriminant",
+      "title": "Part 1: The Real Cubic Discriminant",
+      "startLine": 67,
+      "endLine": 84,
+      "summary": "Defines realDiscriminant a b c d over ℝ (so its sign is meaningful) and realDiscriminant_cast, identifying it with the cast of the sibling's complex generalDiscriminant; a private a⁴ > 0 helper.",
+      "mathContext": "The same degree-4 polynomial as the complex discriminant, now valued in ℝ where order — and hence sign — is available."
+    },
+    {
+      "id": "all-real-case",
+      "title": "Part 2: The All-Real-Roots Case — Δ ≥ 0",
+      "startLine": 86,
+      "endLine": 144,
+      "summary": "realDiscriminant_eq_root_form (Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))² by ring), realDiscriminant_nonneg_of_real_roots (Δ ≥ 0), realDiscriminant_pos_of_distinct_real_roots (Δ > 0 when distinct), and realDiscriminant_eq_zero_iff_repeated_real (Δ = 0 ⟺ two coincide).",
+      "mathContext": "Three real roots make Δ a leading factor times a real square — nonnegative, and positive exactly when the roots are distinct."
+    },
+    {
+      "id": "conjugate-pair-case",
+      "title": "Part 3: The Conjugate-Pair Case — Δ < 0",
+      "startLine": 145,
+      "endLine": 174,
+      "summary": "realDiscriminant_conj_pair: the real identity Δ = −4a⁴n²((r−m)²+n²)² for the Vieta data of r and m ± n·i (one ring call); realDiscriminant_neg_of_conj_pair: Δ < 0 when n ≠ 0, by positivity.",
+      "mathContext": "A real root plus a genuine non-real conjugate pair forces Δ < 0; the factor −4n² = (w − w̄)² is the whole story."
+    },
+    {
+      "id": "complex-bridge",
+      "title": "Part 4: The Bridge to Complex Conjugate Roots",
+      "startLine": 175,
+      "endLine": 204,
+      "summary": "realDiscriminant_conj_pair_root_form: casting to ℂ, the conjugate-pair cubic equals the sibling's root form a⁴·((r−w)(r−w̄)(w−w̄))² with w = m + n·i — certifying the parametrization is the genuine Vieta data of r, w, w̄.",
+      "mathContext": "Ties the real identity back to actual complex roots so the negativity is provably caused by a real conjugate pair, not just a chosen parametrization."
+    },
+    {
+      "id": "sanity-checks",
+      "title": "Part 5: Sanity Checks",
+      "startLine": 205,
+      "endLine": 228,
+      "summary": "x³ − x = x(x−1)(x+1) has Δ = 4 > 0 (three distinct real roots); x³ + x = x(x²+1) has Δ = −4 < 0 (real root 0 and the pair ±i); x³ − 3x + 2 = (x−1)²(x+2) has Δ = 0 (repeated real root).",
+      "mathContext": "One worked cubic in each regime of the discriminant test."
+    }
+  ],
+  "conclusion": {
+    "summary": "Fully verified (0 sorries, 0 axioms) formalization of the real cubic discriminant test: three distinct real roots ⟹ Δ > 0, one real root and a non-real conjugate pair ⟹ Δ < 0, a repeated real root ⟹ Δ = 0. The all-real case is a positivity argument on the root form Δ = a⁴·∏(xᵢ−xⱼ)²; the conjugate-pair case collapses to the real polynomial identity Δ = −4a⁴n²((r−m)²+n²)², with a complex-root bridge certifying the parametrization. 228 lines, 8 theorems, 1 definition.",
+    "implications": "This answers the sign-trichotomy open question raised by the sibling discriminant entry OQ-01-OQ-01, completing the gallery's account of the cubic discriminant: the algebraic invariant over ℂ (sibling) and its real sign classification (here). It pins down the casus irreducibilis boundary (Δ > 0 ⟺ three real roots) at which Cardano's radicals are forced complex.",
+    "openQuestions": [
+      "Formalize the exhaustiveness step explicitly: every real cubic has either three real roots or one real root and a conjugate pair, upgrading the forward sign implications to a single decidable ⟺ classification.",
+      "Extend the sign analysis to the quartic, whose discriminant sign (together with auxiliary invariants P and D) distinguishes four real-root regimes."
+    ]
+  },
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "imports": [
+      "Proofs.SolutionOfCubicOQ01OQ01"
+    ],
+    "opens": [
+      "SolutionOfCubicOQ01OQ01"
+    ],
+    "namespace": "SolutionOfCubicOQ01OQ02",
+    "lineCount": 228,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/SolutionOfCubicOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Sibling entry defining the general cubic discriminant over ℂ and its symmetric root form. Its conclusion explicitly asked to prove the real sign trichotomy (Δ > 0 ⟺ three distinct real roots, Δ < 0 ⟺ one real and two conjugate complex roots); this entry does exactly that, reusing its generalDiscriminant and generalDiscriminant_eq_root_form via the ℝ → ℂ cast."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the Tschirnhaus shift reducing the general cubic to depressed form, on whose discriminant the sibling and this entry build."
+    },
+    {
+      "targetId": "solution-of-cubic-oq-03-oq-01",
+      "relationship": "complementary",
+      "description": "Cousin entry on the depressed discriminant −4p³ − 27q² in root form over ℝ; this entry supplies the general-cubic sign classification."
+    }
+  ],
+  "references": [
+    {
+      "key": "Ir90",
+      "citation": "Irving, R.S., Integers, Polynomials, and Rings, Springer (2004), Chapter on cubic and quartic equations and the discriminant.",
+      "type": "book"
+    },
+    {
+      "key": "Ti01",
+      "citation": "Tignol, J.-P., Galois' Theory of Algebraic Equations, World Scientific (2001), Chapters 3–6 (discriminant, real roots, casus irreducibilis).",
+      "type": "book"
+    },
+    {
+      "key": "Wiki-disc",
+      "citation": "Wikipedia, Discriminant — Nature of the roots (cubic), https://en.wikipedia.org/wiki/Discriminant#Nature_of_the_roots.",
+      "type": "web"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **sign-trichotomy open question** raised in the conclusion of sibling entry `solution-of-cubic-oq-01-oq-02`'s predecessor **OQ-01-OQ-01** ("Prove the sign trichotomy over ℝ: Δ > 0 ⟺ three distinct real roots, Δ < 0 ⟺ one real and two conjugate complex roots").

Over ℂ the cubic discriminant only distinguishes Δ = 0 from Δ ≠ 0. Over ℝ its **sign** classifies the root structure — the classical *discriminant test*:

| Roots | Discriminant |
|-------|--------------|
| three **distinct real** | Δ > 0 |
| one real + **non-real conjugate pair** | Δ < 0 |
| **repeated** real root | Δ = 0 |

## Key idea

Both sign theorems come from the symmetric root form Δ = a⁴·((x₁−x₂)(x₁−x₃)(x₂−x₃))²:

- **All real roots:** Δ = a⁴·(real)² ≥ 0, strictly > 0 when distinct (`positivity`).
- **Conjugate pair** r, m ± n·i: the Vieta coefficients are real and the discriminant collapses to a single **real polynomial identity**
  `Δ = −4·a⁴·n²·((r−m)² + n²)²`
  (one `ring` call, no complex algebra), manifestly < 0 when n ≠ 0. The sign flip is exactly (w − w̄)² = (2n·i)² = −4n².

A bridge theorem (`realDiscriminant_conj_pair_root_form`) casts to ℂ and applies the sibling's complex `generalDiscriminant_eq_root_form` to certify the parametrization is the genuine Vieta data of r, w, w̄.

## Verification

- **228 lines, 8 theorems, 1 definition, 0 sorries, 0 axioms.**
- Kernel-verified via `lake env lean` over cached Mathlib oleans (Docker wedged this session).
- `#print axioms` on all headline results: only `propext, Classical.choice, Quot.sound` — **no `sorryAx`, no `Lean.ofReduceBool`**. Status `verified` / badge `verified`.

## Honesty note

The forward sign implications are proved unconditionally. The full ⟺ classification additionally relies on the standard fact that a real cubic's roots are exhaustively either all real or one real plus a conjugate pair (conjugate-root theorem), which is discussed in the docstring rather than re-formalized; flagged as a follow-up open question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)