### PR TITLE
Enrich Maclaurin Newton-identities resolution (amgm-inequality-oq-02-oq-03-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "amgm-oq02030301-ann-header",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 61 },
+    "type": "concept",
+    "title": "The question and its answer: identities vs. inequalities",
+    "content": "The docstring poses the parent's open question — can `maclaurin_step` ($M_k \\ge M_{k+1}$) be derived from Mathlib's `NewtonIdentities`? — and answers No. The Newton *identities* are ring equalities relating elementary symmetric polynomials $e_k$ and power sums $p_k$, valid over an arbitrary `CommRing`, so they carry no order information. The engine of `maclaurin_step` is Newton's *inequality* (log-concavity $e_k^2 \\ge e_{k-1}e_{k+1}$), a strictly stronger $\\mathbb{R}$-specific positivity fact requiring Cauchy–Schwarz. Equalities cannot imply a strict order fact.",
+    "mathContext": "Identities: $k\\,e_k = (-1)^{k+1}\\sum_a (-1)^a e_a p_b$ (any ring). Inequality: $e_k^2 \\ge e_{k-1}e_{k+1}$ (ordered field only).",
+    "significance": "key",
+    "relatedConcepts": ["Newton's identities", "Newton's inequalities", "log-concavity", "Cauchy-Schwarz", "symmetric functions"],
+    "prerequisites": ["elementary symmetric polynomials", "power sums"]
+  },
+  {
+    "id": "amgm-oq02030301-ann-imports",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 63, "endLine": 67 },
+    "type": "context",
+    "title": "Imports: only the parent's public API",
+    "content": "The file imports just `Proofs.AmgmInequalityOQ02` (the grandparent), which supplies `elemSymm`, `maclaurinMean`, the `maclaurin_step` axiom being chipped away at, and the proved bridge lemma `maclaurin_sq_m1_ge_m2_general`. Opening `Finset` and `Real` brings the summation and square-root API into scope. Working only from the parent's API keeps the resolution self-contained.",
+    "mathContext": "$M_k = (e_k / \\binom{n}{k})^{1/k}$, the normalized Maclaurin mean defined in the parent.",
+    "significance": "context",
+    "relatedConcepts": ["Maclaurin means", "elementary symmetric polynomials"],
+    "prerequisites": ["Lean 4 imports", "Mathlib"]
+  },
+  {
+    "id": "amgm-oq02030301-ann-cs-engine",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 69, "endLine": 81 },
+    "type": "technique",
+    "title": "cauchy_schwarz_engine — the analytic ingredient",
+    "content": "Restates Mathlib's `sq_sum_le_card_mul_sum_sq` (the $f=g$ case of Chebyshev's sum inequality, equivalently Cauchy–Schwarz against the all-ones vector) for `Fin n` data: $(\\sum_i x_i)^2 \\le n \\cdot \\sum_i x_i^2$. The proof is a one-line `simpa` rewriting `Finset.card_univ` and `Fintype.card_fin` to turn the cardinality `#univ` into `n`. This is exactly the order-theoretic fact the Newton identities cannot supply — the whole point of the resolution.",
+    "mathContext": "$\\left(\\sum_{i} x_i\\right)^2 \\le n \\sum_{i} x_i^2$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "Chebyshev sum inequality", "QM-AM"],
+    "prerequisites": ["Cauchy-Schwarz", "Finset summation"]
+  },
+  {
+    "id": "amgm-oq02030301-ann-newton-k1",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 83, "endLine": 93 },
+    "type": "definition",
+    "title": "newton_inequality_k1 — Newton's inequality at k=1",
+    "content": "States the cleared-denominator $k=1$ Newton inequality $\\binom{n}{2}(\\sum_i x_i)^2 \\ge n^2 e_2$, delegating to the parent's `maclaurin_sq_m1_ge_m2_general`. The crucial conceptual link: via the $k=2$ Newton identity $2e_2 = (\\sum x)^2 - \\sum x^2$ (the elementary-symmetric ↔ power-sum relation `mul_esymm_eq_sum` encodes), this inequality is *equivalent* to `cauchy_schwarz_engine` — the identity translates, but the inequality still needs Cauchy–Schwarz.",
+    "mathContext": "$\\binom{n}{2}\\left(\\sum_i x_i\\right)^2 \\ge n^2 e_2$, equivalently $(e_1/n)^2 \\ge e_2/\\binom{n}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["Newton's inequality", "log-concavity", "elementary symmetric polynomials"],
+    "prerequisites": ["Newton's inequalities", "binomial coefficients"]
+  },
+  {
+    "id": "amgm-oq02030301-ann-step-statement",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 95, "endLine": 106 },
+    "type": "definition",
+    "title": "maclaurin_step_one — de-axiomatising the k=1 step",
+    "content": "The headline: the $k=1$ case of the parent's `maclaurin_step` axiom is proved here as a theorem with 0 axioms — $M_1 \\ge M_2$ for non-negative inputs, i.e. $(\\sum x_i)/n \\ge \\sqrt{e_2/\\binom{n}{2}}$. The proof reduces the mean comparison to `newton_inequality_k1` (hence to Cauchy–Schwarz), with the remaining $1/2$-power step handled by `Real.sqrt` monotonicity — no appeal to Newton's identities.",
+    "mathContext": "$M_1 \\ge M_2 \\iff \\frac{\\sum x_i}{n} \\ge \\sqrt{\\frac{e_2}{\\binom{n}{2}}}$",
+    "significance": "key",
+    "relatedConcepts": ["Maclaurin's inequality", "de-axiomatisation", "AM-QM"],
+    "prerequisites": ["Maclaurin means", "square-root monotonicity"]
+  },
+  {
+    "id": "amgm-oq02030301-ann-mean-unfold",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 107, "endLine": 119 },
+    "type": "technique",
+    "title": "Unfolding the two means",
+    "content": "Positivity facts ($n>0$, $\\binom{n}{2}>0$, $\\sum x_i \\ge 0$) are discharged from $n \\ge 2$ and non-negativity of the inputs. Then the two Maclaurin means are unfolded concretely: $M_1 = (\\sum x_i)/n$ (using $e_1 = \\sum x_i$, $\\binom{n}{1}=n$, and $\\cdot^{1/1}$ trivial) and $M_2 = \\sqrt{e_2/\\binom{n}{2}}$ (rewriting the $1/2$ rpow as `Real.sqrt`). This puts both sides into elementary closed form for direct comparison.",
+    "mathContext": "$M_1 = \\frac{\\sum x_i}{n}, \\quad M_2 = \\sqrt{\\frac{e_2}{\\binom{n}{2}}}$",
+    "significance": "supporting",
+    "relatedConcepts": ["real power functions", "rpow", "elementary symmetric polynomials"],
+    "prerequisites": ["rpow and sqrt in Lean"]
+  },
+  {
+    "id": "amgm-oq02030301-ann-sqrt-reduction",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+    "range": { "startLine": 120, "endLine": 128 },
+    "type": "insight",
+    "title": "Comparing radicands closes the step",
+    "content": "The left side $(\\sum x_i)/n$ is rewritten as $\\sqrt{((\\sum x_i)/n)^2}$ (legal since it is non-negative), so by `Real.sqrt_le_sqrt` the comparison $M_2 \\le M_1$ reduces to comparing radicands: $e_2/\\binom{n}{2} \\le ((\\sum x_i)/n)^2$. Clearing denominators with `div_le_div_iff₀` turns this into $e_2 n^2 \\le (\\sum x_i)^2 \\binom{n}{2}$, which `nlinarith` discharges from `newton_inequality_k1`. Thus the entire $1/2$-power gap is pure square-root monotonicity over the Cauchy–Schwarz core.",
+    "mathContext": "$\\sqrt{a} \\le \\sqrt{b} \\iff a \\le b \\;(a,b\\ge 0)$, applied to $a = e_2/\\binom{n}{2}$, $b = ((\\sum x_i)/n)^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["square-root monotonicity", "nlinarith", "clearing denominators"],
+    "prerequisites": ["monotonicity of sqrt", "linear/nonlinear arithmetic tactics"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-02-oq-03-oq-03-oq-01` (resolves: can `maclaurin_step` be proved from Mathlib's `NewtonIdentities`? — **No**; engine is Cauchy–Schwarz).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — the inline annotation layer was missing.

## Changes
- Added `annotations.json` with **7 line-anchored annotations** covering the full Lean file (header → imports → `cauchy_schwarz_engine` → `newton_inequality_k1` → `maclaurin_step_one` and its sqrt-monotonicity reduction).
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Documents the identities-vs-inequalities crux (ring equalities carry no order content), the Cauchy–Schwarz engine `sq_sum_le_card_mul_sum_sq`, the role of the $k=2$ Newton identity $2e_2=(\sum x)^2-\sum x^2$ as a translator, and the 0-axiom de-axiomatisation of $M_1\ge M_2$.

## Verification
- JSON validated; `pnpm build` passes (data-gen + tsc + vite).
- No `meta.json` change; status/badge/axiomCount (verified/mathlib/0) consistent with the Lean source.