### PR TITLE
research(buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02): exponent-swap reflection symmetry of the half-period trig integral

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -462,6 +462,7 @@ import Proofs.BuffonsNeedleOQ01OQ01OQ04
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01Beta
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01
+import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02
 import Proofs.BuffonsNeedleOQ01OQ02
 import Proofs.BuffonsNeedleOQ01OQ04
 import Proofs.BuffonsNeedleOQ02

--- a/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02.lean
@@ -1,0 +1,117 @@
+import Mathlib
+
+/-
+# Exponent-Swap Reflection Symmetry of the Half-Period Trigonometric Integral
+
+## Open Question: buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02
+
+The parent entry (`BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01`) proved a *single-power*
+instance of the reflection symmetry: under `θ ↦ π/2 − θ` the integral
+`∫_0^{π/2} sin θ · cosᵐ θ dθ` equals `∫_0^{π/2} cos θ · sinᵐ θ dθ`. It flagged as
+its **second open question** whether that reflection argument packages into one
+clean, reusable lemma — the statement that the half-period trigonometric integral
+is invariant under **swapping the two exponents**:
+
+  ∫_0^{π/2} sinᵃ θ · cosᵇ θ dθ = ∫_0^{π/2} sinᵇ θ · cosᵃ θ dθ.
+
+This file answers that affirmatively. The single mechanism is the reflection
+`θ ↦ π/2 − θ`, which fixes the interval `[0, π/2]` and exchanges `sin ↔ cos` by the
+*unconditional* identities `sin(π/2−θ) = cos θ` and `cos(π/2−θ) = sin θ`. No
+antiderivative, no integrability hypothesis, and no positivity assumption is
+needed — the swap is a pure change of variables, so it holds verbatim for both
+natural-number powers and arbitrary real (`rpow`) exponents.
+
+## Main results
+
+1. `integral_sin_pow_mul_cos_pow_swap`   — ℕ exponents: the headline reusable lemma.
+2. `integral_sin_rpow_mul_cos_rpow_swap` — real exponents (`Real.rpow`), strictly
+   more general; this is the form that meets the trigonometric Beta integral.
+3. `integral_beta_trig_symm`             — Euler Beta symmetry `B(x,y) = B(y,x)` in
+   its trigonometric guise, an immediate corollary of (2).
+4. `integral_sin_mul_cos_pow_eq_reflect` — the parent's single-power identity
+   recovered as the `a = 1` corollary of (1).
+
+The link to Mathlib's `Real.betaIntegral` / `Real.Gamma` (the half-angle
+substitution `t = sin²θ` and the Gamma recurrence) is the natural next boundary
+and is left to the Beta/Gamma API; this file isolates the *symmetry* content,
+which is purely the reflection and needs none of that machinery.
+
+**No axioms, no sorries.**
+-/
+
+open Real intervalIntegral MeasureTheory
+
+namespace BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02
+
+/-- **Exponent-swap reflection symmetry (natural-number powers).**
+
+    `∫_0^{π/2} sinᵃ θ · cosᵇ θ dθ = ∫_0^{π/2} sinᵇ θ · cosᵃ θ dθ`.
+
+    Proof: the reflection `θ ↦ π/2 − θ` (`intervalIntegral.integral_comp_sub_left`)
+    fixes the interval `[0, π/2]` and, by `sin(π/2−θ) = cos θ` and
+    `cos(π/2−θ) = sin θ`, turns the integrand `sinᵃ θ · cosᵇ θ` into
+    `cosᵃ θ · sinᵇ θ`. Both factors are simply transposed, so the value is
+    unchanged — no FTC, no integrability side condition. -/
+theorem integral_sin_pow_mul_cos_pow_swap (a b : ℕ) :
+    ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ a * Real.cos θ ^ b
+      = ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ b * Real.cos θ ^ a := by
+  have h := intervalIntegral.integral_comp_sub_left
+    (fun θ => Real.sin θ ^ a * Real.cos θ ^ b) (π / 2) (a := 0) (b := π / 2)
+  -- `h : ∫ θ in 0..π/2, cosᵃ θ · sinᵇ θ = ∫ θ in 0..π/2, sinᵃ θ · cosᵇ θ`
+  simp only [Real.sin_pi_div_two_sub, Real.cos_pi_div_two_sub, sub_zero, sub_self] at h
+  rw [← h]
+  exact intervalIntegral.integral_congr (fun θ _ => mul_comm _ _)
+
+/-- **Exponent-swap reflection symmetry (arbitrary real exponents).**
+
+    `∫_0^{π/2} sinᵃ θ · cosᵇ θ dθ = ∫_0^{π/2} sinᵇ θ · cosᵃ θ dθ` for `a b : ℝ`,
+    where the powers are `Real.rpow`.
+
+    The reflection `θ ↦ π/2 − θ` rewrites the *bases* via `sin(π/2−θ) = cos θ`,
+    `cos(π/2−θ) = sin θ`, so the argument is insensitive to whether the exponents
+    are natural numbers or reals — strictly generalizing the ℕ version, and the
+    form that meets the Euler Beta integral. -/
+theorem integral_sin_rpow_mul_cos_rpow_swap (a b : ℝ) :
+    ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ a * Real.cos θ ^ b
+      = ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ b * Real.cos θ ^ a := by
+  have h := intervalIntegral.integral_comp_sub_left
+    (fun θ => Real.sin θ ^ a * Real.cos θ ^ b) (π / 2) (a := 0) (b := π / 2)
+  simp only [Real.sin_pi_div_two_sub, Real.cos_pi_div_two_sub, sub_zero, sub_self] at h
+  rw [← h]
+  exact intervalIntegral.integral_congr (fun θ _ => mul_comm _ _)
+
+/-- **Euler Beta symmetry in trigonometric form.** With the classical trigonometric
+    representation `B(x, y) = 2 ∫_0^{π/2} sin^{2x−1}θ · cos^{2y−1}θ dθ`, the Beta
+    function's symmetry `B(x, y) = B(y, x)` is exactly the exponent swap
+
+      `∫_0^{π/2} sin^{2x−1}θ · cos^{2y−1}θ dθ = ∫_0^{π/2} sin^{2y−1}θ · cos^{2x−1}θ dθ`,
+
+    here obtained directly from the reflection, with no Gamma-function input. -/
+theorem integral_beta_trig_symm (x y : ℝ) :
+    ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ (2 * x - 1) * Real.cos θ ^ (2 * y - 1)
+      = ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ (2 * y - 1) * Real.cos θ ^ (2 * x - 1) :=
+  integral_sin_rpow_mul_cos_rpow_swap (2 * x - 1) (2 * y - 1)
+
+/-- **The parent's reflection identity, recovered as the `a = 1` corollary.**
+
+    The parent file proved `∫_0^{π/2} sin θ · cosᵐ θ = ∫_0^{π/2} cos θ · sinᵐ θ` by
+    a bespoke reflection. It is the special case `a = 1`, `b = m` of the general
+    swap lemma (using `sin θ ^ 1 = sin θ`, `cos θ ^ 1 = cos θ`), confirming the
+    headline lemma is a genuine generalization. -/
+theorem integral_sin_mul_cos_pow_eq_reflect (m : ℕ) :
+    ∫ θ in (0:ℝ)..(π/2), Real.sin θ * Real.cos θ ^ m
+      = ∫ θ in (0:ℝ)..(π/2), Real.cos θ * Real.sin θ ^ m := by
+  have h := integral_sin_pow_mul_cos_pow_swap 1 m
+  simp only [pow_one] at h
+  rw [h]
+  exact intervalIntegral.integral_congr (fun θ _ => mul_comm _ _)
+
+/-- Cross-check: the diagonal `a = b` is fixed by the swap (it relates the integral
+    to itself), so the symmetry is vacuous there — a sanity check that the lemma is
+    stated in the right direction. -/
+example (a : ℕ) :
+    (∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ a * Real.cos θ ^ a)
+      = ∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ a * Real.cos θ ^ a :=
+  integral_sin_pow_mul_cos_pow_swap a a
+
+end BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "ann-swap-overview",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 3, "endLine": 54 },
+    "type": "concept",
+    "title": "From a Single-Power Reflection to a Reusable Exponent-Swap Lemma",
+    "content": "The module docstring states the open question inherited from the parent (BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01): the parent proved only the single-power instance ∫_0^{π/2} sin θ · cosᵐ θ = ∫_0^{π/2} cos θ · sinᵐ θ and asked whether the reflection argument packages into one clean lemma. The answer is the two-parameter statement ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ. Its entire content is the reflection θ ↦ π/2 − θ, an involution of [0, π/2] that interchanges sin and cos. Crucially the argument touches only the bases of the powers, so it is indifferent to whether a, b are natural numbers or arbitrary reals — and it needs no positivity, integrability, or antiderivative.",
+    "mathContext": "$\\int_0^{\\pi/2}\\sin^{a}\\theta\\,\\cos^{b}\\theta\\,d\\theta = \\int_0^{\\pi/2}\\sin^{b}\\theta\\,\\cos^{a}\\theta\\,d\\theta$, via $\\theta\\mapsto \\tfrac{\\pi}{2}-\\theta$ with $\\sin(\\tfrac{\\pi}{2}-\\theta)=\\cos\\theta$, $\\cos(\\tfrac{\\pi}{2}-\\theta)=\\sin\\theta$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "reflection symmetry",
+      "change of variables",
+      "Beta function",
+      "complementary angle identities",
+      "trigonometric integrals"
+    ],
+    "prerequisites": ["interval integrals", "trigonometric identities"]
+  },
+  {
+    "id": "ann-nat-swap",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 73 },
+    "type": "technique",
+    "title": "The Headline Lemma: Exponent Swap for Natural-Number Powers",
+    "content": "integral_sin_pow_mul_cos_pow_swap is the three-line core. intervalIntegral.integral_comp_sub_left (fun θ => sinᵃθ cosᵇθ) (π/2) produces an equality whose left side is the integral of the reflected integrand sinᵃ(π/2−θ)cosᵇ(π/2−θ) over [π/2−π/2, π/2−0] = [0, π/2]. The simp set {Real.sin_pi_div_two_sub, Real.cos_pi_div_two_sub, sub_zero, sub_self} rewrites the bases to cosᵃθ sinᵇθ and normalizes the endpoints. The hypothesis h then reads ∫ cosᵃθ sinᵇθ = ∫ sinᵃθ cosᵇθ; `rw [← h]` turns the goal's left side into ∫ cosᵃθ sinᵇθ, and a single intervalIntegral.integral_congr with mul_comm transposes the two factors onto the swapped target sinᵇθ cosᵃθ.",
+    "mathContext": "After the reflection, $\\sin^{a}(\\tfrac{\\pi}{2}-\\theta)\\cos^{b}(\\tfrac{\\pi}{2}-\\theta)=\\cos^{a}\\theta\\,\\sin^{b}\\theta$; the only remaining step is the commutation $\\cos^{a}\\theta\\,\\sin^{b}\\theta=\\sin^{b}\\theta\\,\\cos^{a}\\theta$.",
+    "significance": "central",
+    "relatedConcepts": ["integral_comp_sub_left", "integral_congr", "mul_comm"],
+    "prerequisites": ["interval integrals"]
+  },
+  {
+    "id": "ann-rpow-swap",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 96 },
+    "type": "key-step",
+    "title": "Same Proof, Real Exponents: Reaching the Beta Function",
+    "content": "integral_sin_rpow_mul_cos_rpow_swap is the strictly more general statement with a, b : ℝ, where the powers are Real.rpow. The proof script is byte-for-byte the same as the natural-number version: integral_comp_sub_left, the same simp set, rw [← h], integral_congr with mul_comm. This works because the complementary-angle identities rewrite the bases sin(π/2−θ), cos(π/2−θ) regardless of how those bases are subsequently raised to a power, and mul_comm is exponent-agnostic. The real-exponent form is the one that meets the trigonometric Beta integral, where the exponents are 2x−1 and 2y−1.",
+    "mathContext": "For $a,b\\in\\mathbb{R}$, $\\int_0^{\\pi/2}\\sin^{a}\\theta\\cos^{b}\\theta\\,d\\theta=\\int_0^{\\pi/2}\\sin^{b}\\theta\\cos^{a}\\theta\\,d\\theta$ with $\\sin^{a}\\theta:=\\mathrm{rpow}(\\sin\\theta,a)$.",
+    "significance": "central",
+    "relatedConcepts": ["Real.rpow", "Beta function", "complementary angle identities"],
+    "prerequisites": ["real power function"]
+  },
+  {
+    "id": "ann-beta-symm",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 98, "endLine": 110 },
+    "type": "concept",
+    "title": "Euler Beta Symmetry Without the Gamma Function",
+    "content": "integral_beta_trig_symm instantiates the real-exponent lemma at exponents 2x−1 and 2y−1. In the classical trigonometric representation B(x,y) = 2∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ, this is precisely Euler's Beta symmetry B(x,y) = B(y,x). The standard route to that symmetry goes through B(x,y) = Γ(x)Γ(y)/Γ(x+y), where symmetry is visible from the commutativity of multiplication in the numerator; here the symmetry is obtained directly from the reflection, isolating it from the (harder, Gamma-dependent) evaluation of the Beta function.",
+    "mathContext": "$\\tfrac12 B(x,y)=\\int_0^{\\pi/2}\\sin^{2x-1}\\theta\\cos^{2y-1}\\theta\\,d\\theta$; the swap gives $B(x,y)=B(y,x)$ with no use of $\\Gamma$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Euler Beta function", "Gamma function", "Beta symmetry"],
+    "prerequisites": ["Beta function"]
+  },
+  {
+    "id": "ann-parent-recovery",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 126 },
+    "type": "concept",
+    "title": "The Parent's Identity as the a = 1 Corollary",
+    "content": "integral_sin_mul_cos_pow_eq_reflect re-proves the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ as the special case a = 1, b = m of the headline lemma (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ via pow_one, then one mul_comm). This confirms the new two-parameter statement is a genuine generalization of the parent rather than a cosmetic restatement, and that the bespoke reflection the parent performed by hand is subsumed by the reusable lemma the open question requested.",
+    "mathContext": "Setting $a=1$: $\\int_0^{\\pi/2}\\sin\\theta\\,\\cos^{m}\\theta\\,d\\theta=\\int_0^{\\pi/2}\\sin^{m}\\theta\\,\\cos\\theta\\,d\\theta=\\int_0^{\\pi/2}\\cos\\theta\\,\\sin^{m}\\theta\\,d\\theta$.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "pow_one"],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-scope-boundary",
+    "proofId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "range": { "startLine": 37, "endLine": 47 },
+    "type": "caveat",
+    "title": "Scope: Symmetry, Not Evaluation",
+    "content": "This file proves only the symmetry of the trigonometric power integral, not its value. The evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as Γ(x)Γ(y)/(2Γ(x+y)), and the bridge from this trigonometric form to Mathlib's Real.betaIntegral (∫_0^1 t^{x−1}(1−t)^{y−1} dt) via the half-angle substitution t = sin²θ, require the Gamma recurrence and lie outside the elementary reflection method. The open questions record connecting to Real.betaIntegral and deriving the Wallis recurrence as the natural next steps.",
+    "mathContext": "Symmetry is elementary (a reflection); evaluation needs $\\Gamma$ and the substitution $t=\\sin^2\\theta$ to reach $\\int_0^1 t^{x-1}(1-t)^{y-1}\\,dt$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.betaIntegral", "Gamma function", "Wallis recurrence"],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,113 @@
+{
+  "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "slug": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+  "title": "Exponent-Swap Reflection Symmetry of the Half-Period Trigonometric Integral",
+  "overview": {
+    "historicalContext": "The Cauchy–Crofton chain reduces the angular average on S^{n-1} to one-dimensional trigonometric power integrals of the form ∫_0^{π/2} sinᵃθ cosᵇθ dθ. The parent entry (BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01) proved a single-power instance of the reflection symmetry — ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ — and flagged as its second open question whether that bespoke reflection packages into one clean, reusable lemma: that the half-period trig integral is invariant under swapping its two exponents. This file resolves that question.",
+    "problemStatement": "Prove the exponent-swap symmetry $\\int_0^{\\pi/2} \\sin^{a}\\theta\\,\\cos^{b}\\theta\\,d\\theta = \\int_0^{\\pi/2} \\sin^{b}\\theta\\,\\cos^{a}\\theta\\,d\\theta$ as a single reusable lemma, for natural-number exponents $a,b$ and — strictly more generally — for arbitrary real exponents (Real.rpow), and identify the Euler Beta symmetry $B(x,y)=B(y,x)$ as the immediate corollary.",
+    "proofStrategy": "The whole content is the reflection θ ↦ π/2 − θ, applied via intervalIntegral.integral_comp_sub_left with center π/2 on the self-fixed interval [0, π/2] (endpoints π/2−π/2 = 0 and π/2−0 = π/2, closed by sub_self and sub_zero). The unconditional identities Real.sin_pi_div_two_sub (sin(π/2−θ)=cos θ) and Real.cos_pi_div_two_sub (cos(π/2−θ)=sin θ) rewrite the reflected integrand sinᵃ(π/2−θ)·cosᵇ(π/2−θ) into cosᵃθ·sinᵇθ; a single intervalIntegral.integral_congr with mul_comm transposes the two factors to land on the swapped integrand. Because the rewrite acts only on the bases of the powers, the identical script proves the natural-number version (the powers are Monoid.npow) and the real-exponent version (Real.rpow) with no positivity or integrability hypothesis. The Beta symmetry corollary is the real-exponent lemma instantiated at exponents 2x−1, 2y−1; the parent's single-power identity is the natural-number lemma at a = 1 (using pow_one).",
+    "keyInsights": [
+      "The reflection symmetry is not really about FTC or antiderivatives at all — it is a pure change of variables. Stripping the parent's single-power statement down to its mechanism reveals a two-parameter lemma whose proof is three tactic lines: integral_comp_sub_left, simp with the two complementary-angle identities, and integral_congr with mul_comm.",
+      "Because the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ are unconditional and act on the *bases* of the powers, the proof is completely insensitive to the exponent type. The natural-number and Real.rpow versions are literally the same script, so the general (real-exponent) lemma is obtained at no extra cost — and it is the form that meets the Euler Beta integral.",
+      "Euler's Beta symmetry B(x,y) = B(y,x), in the trigonometric representation B(x,y) = 2∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ, is exactly this exponent swap at exponents 2x−1, 2y−1. The reflection therefore gives a Gamma-free proof of Beta symmetry — the symmetry half of the Beta theory, cleanly separated from the (harder) evaluation half that needs the Gamma recurrence.",
+      "The parent's hand-rolled reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ is recovered verbatim as the a = 1 slice, confirming the new lemma is a genuine generalization rather than a restatement, and supplying the reusable bridge the open question asked for."
+    ]
+  },
+  "description": "Packages the parent's bespoke single-power reflection into one clean, reusable lemma: the half-period trigonometric integral ∫_0^{π/2} sinᵃθ cosᵇθ dθ is invariant under swapping the exponents a ↔ b. The proof is the single reflection θ ↦ π/2 − θ (intervalIntegral.integral_comp_sub_left) together with the complementary-angle identities sin(π/2−θ)=cos θ, cos(π/2−θ)=sin θ; because these act on the bases of the powers, the identical script proves both the natural-number-exponent and the Real.rpow versions, with no positivity or integrability side conditions. As corollaries it gives the Euler Beta symmetry B(x,y)=B(y,x) in trigonometric form (a Gamma-free derivation) and recovers the parent's single-power identity as the a = 1 case. Axiom-free, 0 sorries.",
+  "assumptions": [],
+  "conclusion": {
+    "summary": "Gives a complete axiom-free Lean formalization of the exponent-swap reflection symmetry of the half-period trigonometric integral, for both natural-number and arbitrary real (Real.rpow) exponents, from the single reflection θ ↦ π/2 − θ. Includes the Euler Beta symmetry B(x,y)=B(y,x) in trigonometric form and the parent's single-power identity as corollaries. All results are machine-checked with 0 sorries and 0 axioms.",
+    "implications": "Supplies the reusable 'symmetry of the half-period trig integral under exponent swap' lemma requested by the parent's open question, in a form usable across the gallery's trigonometric-integral entries and one that meets the Beta function directly. By isolating the symmetry content as a pure reflection — independent of exponent type, positivity, and integrability — it cleanly separates the (easy) symmetry half of Beta theory from the (Gamma-dependent) evaluation half.",
+    "openQuestions": [
+      "Can the trigonometric Beta integral ∫_0^{π/2} sin^{2x−1}θ cos^{2y−1}θ dθ be connected to Mathlib's Real.betaIntegral via the half-angle substitution t = sin²θ, turning this trigonometric symmetry into a proof of the symmetry of Real.betaIntegral itself?",
+      "Does the same reflection give the Wallis recurrence relating ∫ sinᵃθ cosᵇθ to ∫ sin^{a−2}θ cosᵇθ (integration by parts in the reflected variable), completing an elementary evaluation route alongside the symmetry?"
+    ]
+  },
+  "sorries": 0,
+  "openQuestion": {
+    "id": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01-oq-02",
+    "parentId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
+    "question": "Does the reflection-symmetry argument generalize to a clean Lean lemma 'symmetry of the half-period trig integral under exponent swap' usable across the gallery's trigonometric-integral entries?",
+    "answer": "Yes. The lemma integral_sin_pow_mul_cos_pow_swap states ∫_0^{π/2} sinᵃθ cosᵇθ dθ = ∫_0^{π/2} sinᵇθ cosᵃθ dθ for all a, b : ℕ, proved in three tactic steps from intervalIntegral.integral_comp_sub_left (the reflection θ ↦ π/2 − θ), the complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ, and a single integral_congr/mul_comm transposition. Because the identities act on the bases of the powers, the identical proof yields the strictly more general Real.rpow version integral_sin_rpow_mul_cos_rpow_swap for real exponents, with no positivity or integrability hypothesis. This real-exponent form instantiates to the Euler Beta symmetry B(x,y)=B(y,x) in its trigonometric guise (integral_beta_trig_symm), a Gamma-free derivation, and the natural-number form at a = 1 recovers the parent's single-power reflection identity (integral_sin_mul_cos_pow_eq_reflect). Connecting the trigonometric Beta integral to Mathlib's Real.betaIntegral via t = sin²θ remains the natural next step.",
+    "status": "answered"
+  },
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01",
+      "relationship": "Parent: proved the single-power reflection ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ and flagged the general exponent-swap lemma as its second open question; this file proves that general lemma and recovers the parent's identity as the a = 1 case"
+    },
+    {
+      "targetId": "buffons-needle-oq-01-oq-01-oq-04-oq-01",
+      "relationship": "Grandparent: defines the Cauchy–Crofton angular-average data whose trigonometric power integrals this symmetry governs"
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "Classical root: the Buffon needle crossing problem this integral-geometry chain formalizes"
+    }
+  ],
+  "highlights": [
+    {
+      "title": "One reflection, two exponent types",
+      "detail": "The reflection θ ↦ π/2 − θ rewrites the bases of the powers, so the same three-line proof covers natural-number and Real.rpow exponents alike — the general lemma costs nothing beyond the special case."
+    },
+    {
+      "title": "Beta symmetry without Gamma",
+      "detail": "Instantiated at exponents 2x−1, 2y−1, the lemma is Euler's Beta symmetry B(x,y)=B(y,x) in trigonometric form, derived purely from the reflection with no Gamma-function input."
+    },
+    {
+      "title": "No side conditions",
+      "detail": "The complementary-angle identities are unconditional, so the swap needs no positivity, no integrability, and no antiderivative — it is a pure change of variables."
+    },
+    {
+      "title": "Generalizes the parent verbatim",
+      "detail": "Setting a = 1 (using sin θ ^ 1 = sin θ) recovers the parent's hand-rolled reflection identity, confirming a genuine generalization."
+    },
+    {
+      "title": "Reusable across the gallery",
+      "detail": "Stated as a standalone two-parameter lemma, it is directly applicable to any half-period trigonometric power integral in the gallery, exactly as the open question requested."
+    }
+  ],
+  "sections": [
+    {
+      "title": "The exponent-swap lemma",
+      "content": "The headline lemma integral_sin_pow_mul_cos_pow_swap asserts ∫_0^{π/2} sinᵃθ cosᵇθ = ∫_0^{π/2} sinᵇθ cosᵃθ for a, b : ℕ. The proof applies intervalIntegral.integral_comp_sub_left with center π/2 and interval [0, π/2], which is fixed by the reflection (its endpoints map to π/2−π/2 = 0 and π/2−0 = π/2). The complementary-angle identities sin(π/2−θ)=cos θ and cos(π/2−θ)=sin θ rewrite the reflected integrand into cosᵃθ sinᵇθ, and one integral_congr with mul_comm transposes the factors onto the target."
+    },
+    {
+      "title": "Real exponents and the Beta function",
+      "content": "Because the reflection rewrites only the bases of the powers, the identical script proves integral_sin_rpow_mul_cos_rpow_swap for arbitrary real exponents (Real.rpow), with no positivity or integrability hypothesis. Instantiating the exponents at 2x−1 and 2y−1 yields integral_beta_trig_symm, the trigonometric form of Euler's Beta symmetry B(x,y)=B(y,x) — obtained without any Gamma-function machinery."
+    },
+    {
+      "title": "Recovering the parent",
+      "content": "The natural-number lemma at a = 1 (with sin θ ^ 1 = sin θ, cos θ ^ 1 = cos θ) is the parent's single-power reflection identity ∫ sin θ · cosᵐ θ = ∫ cos θ · sinᵐ θ, re-proved here as integral_sin_mul_cos_pow_eq_reflect. This confirms the new statement strictly generalizes the parent and supplies the reusable bridge the open question asked for."
+    },
+    {
+      "title": "Scope and boundary",
+      "content": "This file isolates the symmetry content of the trigonometric power integrals. The complementary half — the evaluation of ∫ sin^{2x−1}θ cos^{2y−1}θ as a ratio of Gamma values, and the bridge to Mathlib's Real.betaIntegral via t = sin²θ — needs the Gamma recurrence and is left to the Beta/Gamma API, marking the boundary of the elementary reflection method."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Beta_function",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01OQ04OQ01OQ01OQ01OQ02.lean",
+    "tags": [
+      "integral-geometry",
+      "beta-integral",
+      "buffon",
+      "cauchy-crofton",
+      "angular-averaging",
+      "trigonometric-integrals",
+      "reflection-symmetry",
+      "change-of-variables",
+      "rpow",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 117,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the **second open question** of the parent entry `buffons-needle-oq-01-oq-01-oq-04-oq-01-oq-01-oq-01`, which proved a single-power instance of the reflection symmetry and asked whether it packages into one clean, reusable lemma.

It does. The headline lemma states the half-period trigonometric integral is invariant under **swapping its two exponents**:

$$\int_0^{\pi/2} \sin^{a}\theta\,\cos^{b}\theta\,d\theta = \int_0^{\pi/2} \sin^{b}\theta\,\cos^{a}\theta\,d\theta.$$

The entire content is the reflection $\theta \mapsto \pi/2 - \theta$ (`intervalIntegral.integral_comp_sub_left`) on the self-fixed interval $[0,\pi/2]$, together with the unconditional complementary-angle identities $\sin(\pi/2-\theta)=\cos\theta$, $\cos(\pi/2-\theta)=\sin\theta$. Because these rewrite only the *bases* of the powers, the identical three-line script proves both the ℕ-exponent and the `Real.rpow` versions, with **no positivity or integrability side condition**.

## Results (4 theorems, 0 sorries, 0 axioms)

1. `integral_sin_pow_mul_cos_pow_swap` — ℕ exponents: the headline reusable lemma.
2. `integral_sin_rpow_mul_cos_rpow_swap` — arbitrary real exponents (`Real.rpow`); strictly more general, the form that meets the Beta integral.
3. `integral_beta_trig_symm` — Euler Beta symmetry $B(x,y)=B(y,x)$ in trigonometric form, a **Gamma-free** corollary (exponents $2x-1, 2y-1$).
4. `integral_sin_mul_cos_pow_eq_reflect` — the parent's single-power identity recovered as the $a=1$ case, confirming a genuine generalization.

## Verification

Kernel-verified via `lake env lean`; `#print axioms` on all four theorems lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`, badge `original`.

## Boundary / open questions

The bridge to Mathlib's `Real.betaIntegral` via the half-angle substitution $t=\sin^2\theta$, and the Wallis recurrence via integration by parts, are left as the natural next steps — they need the Gamma recurrence, beyond the elementary reflection method isolated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)