### PR TITLE
Enrich Finite Cayley's theorem (cayleys-theorem-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "cayley-oq0101-ann-header",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "From abstract Sym(G) to the concrete Sₙ",
+    "content": "The docstring states the goal: refine the parent's abstract Cayley embedding $G \\hookrightarrow \\mathrm{Sym}(G)$ into the classical finite form $G \\hookrightarrow S_n$ for $|G| = n$. The only difference is a relabelling of the permuted points: a numbering $e : G \\simeq \\mathrm{Fin}\\,n$ turns permutations of $G$ into permutations of $\\{0,\\dots,n-1\\}$ by conjugation $\\sigma \\mapsto e \\circ \\sigma \\circ e^{-1}$, which is a group isomorphism of symmetric groups. Composing the left-regular representation with it lands the embedding in $S_n$.",
+    "mathContext": "$G \\hookrightarrow S_n$, \\; $S_n = \\mathrm{Equiv.Perm}(\\mathrm{Fin}\\,n)$, via $e : G \\simeq \\mathrm{Fin}\\,n$.",
+    "significance": "key",
+    "relatedConcepts": ["Cayley's theorem", "regular representation", "symmetric group", "relabelling"],
+    "prerequisites": ["group homomorphisms", "permutations"]
+  },
+  {
+    "id": "cayley-oq0101-ann-imports",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 17, "endLine": 45 },
+    "type": "context",
+    "title": "Imports and setup",
+    "content": "Imports bring in permutation groups (`Perm.Basic`), the group-action-to-permutation homomorphism (`Action.End`, `Action.Basic`), the canonical numbering of a finite type (`Equiv.Fin.Basic`, `Fintype.Perm`), and the tactic library. The `CayleyFin` namespace opens `Equiv` and fixes a group variable `G`. Note this gallery file uses `import Mathlib.Tactic` and several targeted Mathlib imports — standard gallery convention, not the stricter mathlib-submission style.",
+    "mathContext": "Working over an arbitrary `[Group G]`, later specialised to `[Fintype G]`.",
+    "significance": "context",
+    "relatedConcepts": ["group actions", "Fintype"],
+    "prerequisites": ["Lean 4 imports", "Mathlib"]
+  },
+  {
+    "id": "cayley-oq0101-ann-permcongr",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 47, "endLine": 54 },
+    "type": "definition",
+    "title": "permCongrMulEquiv — conjugation as a multiplicative isomorphism",
+    "content": "Packages conjugation by a fixed bijection $e : \\alpha \\simeq \\beta$ as a `MulEquiv` $\\mathrm{Perm}\\,\\alpha \\simeq^* \\mathrm{Perm}\\,\\beta$. The underlying equivalence is Mathlib's `Equiv.permCongr e` ($\\sigma \\mapsto e \\circ \\sigma \\circ e^{-1}$); the new content is `map_mul'`, proved by `ext` + `simp` with `permCongr_apply` and `Perm.mul_apply` — i.e. conjugation respects composition. (Mathlib already provides this exact bundling as `Equiv.permCongrHom`; this is an in-file re-derivation, honestly noted in the meta.)",
+    "mathContext": "$\\phi_e(\\sigma) = e\\,\\sigma\\,e^{-1}$, \\; $\\phi_e(\\sigma\\tau) = \\phi_e(\\sigma)\\,\\phi_e(\\tau)$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugation", "MulEquiv", "permutation relabelling", "inner automorphism"],
+    "prerequisites": ["multiplicative isomorphisms", "Equiv.permCongr"]
+  },
+  {
+    "id": "cayley-oq0101-ann-permcongr-apply",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 56, "endLine": 57 },
+    "type": "technique",
+    "title": "Computation lemma for the conjugation map",
+    "content": "`permCongrMulEquiv_apply` records that the relabelled permutation acts by $(\\phi_e\\,\\sigma)(a) = e(\\sigma(e^{-1}(a)))$, true by `rfl`. Tagged `@[simp]` so downstream `simp` calls can unfold conjugation pointwise, which is what makes the injectivity and apply lemmas one-liners.",
+    "mathContext": "$(\\phi_e\\,\\sigma)(a) = e\\big(\\sigma(e^{-1}(a))\\big)$",
+    "significance": "technical",
+    "relatedConcepts": ["definitional equality", "simp lemmas"],
+    "prerequisites": ["Lean rfl-lemmas"]
+  },
+  {
+    "id": "cayley-oq0101-ann-finhom",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "definition",
+    "title": "cayleyFinHom — the finite Cayley homomorphism",
+    "content": "Defines the finite Cayley map by composing the relabelling with the left-regular representation: $\\hat\\lambda = \\phi_e \\circ \\lambda$, where $\\lambda = $ `MulAction.toPermHom G G` is $g \\mapsto (x \\mapsto g x)$. The result is a monoid hom $G \\to^* \\mathrm{Perm}(\\mathrm{Fin}\\,n)$. The companion `cayleyFinHom_apply` computes its action: $\\hat\\lambda(g)(i) = e(g \\cdot e^{-1}(i))$ — i.e. left-multiply by $g$ after decoding the index, then re-encode.",
+    "mathContext": "$\\hat\\lambda(g)(i) = e\\big(g \\cdot e^{-1}(i)\\big)$",
+    "significance": "key",
+    "relatedConcepts": ["left-regular representation", "monoid homomorphism", "function composition"],
+    "prerequisites": ["MulAction.toPermHom", "monoid hom composition"]
+  },
+  {
+    "id": "cayley-oq0101-ann-injective",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 67, "endLine": 75 },
+    "type": "insight",
+    "title": "Injectivity from faithfulness ∘ bijection",
+    "content": "The embedding is injective because it is the composite of an injective map and a bijection. The regular representation is injective by `MulAction.toPerm_injective` (the self-action of a group is faithful — the mathematical heart, inherited from the parent), and the relabelling `permCongrMulEquiv e` is bijective (`.injective`). Given $\\hat\\lambda(a) = \\hat\\lambda(b)$, peel off the bijective relabelling, then apply faithfulness to conclude $a = b$.",
+    "mathContext": "$\\lambda$ injective $\\;\\wedge\\;$ $\\phi_e$ bijective $\\;\\Rightarrow\\;$ $\\phi_e \\circ \\lambda$ injective.",
+    "significance": "key",
+    "relatedConcepts": ["faithful action", "injective composition", "regular representation"],
+    "prerequisites": ["injectivity", "faithful group action"]
+  },
+  {
+    "id": "cayley-oq0101-ann-cayleyfin",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 87 },
+    "type": "definition",
+    "title": "cayley_fin — the textbook finite statement",
+    "content": "Specialising the numbering to $e = $ `Fintype.equivFin G` ($G \\simeq \\mathrm{Fin}(|G|)$) gives `cayley_fin`: there exists an injective hom $G \\to^* \\mathrm{Perm}(\\mathrm{Fin}(|G|))$ — the standard 'a group of order $n$ embeds in $S_n$'. `cayleyFinEmbedding` repackages the same data as a bundled embedding $G \\hookrightarrow S_n$ (noncomputable, since `Fintype.equivFin` chooses an arbitrary numbering).",
+    "mathContext": "$\\exists\\, f : G \\to^* S_{|G|}, \\; f \\text{ injective}; \\quad G \\hookrightarrow S_{|G|}.$",
+    "significance": "key",
+    "relatedConcepts": ["finite groups", "Fintype.equivFin", "embeddings"],
+    "prerequisites": ["finite types", "canonical numbering"]
+  },
+  {
+    "id": "cayley-oq0101-ann-rangeequiv",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 93 },
+    "type": "technique",
+    "title": "cayleyFinRangeEquiv — isomorphism onto a subgroup of Sₙ",
+    "content": "`MonoidHom.ofInjective` upgrades the injective Cayley hom to a multiplicative isomorphism $G \\simeq^* (\\hat\\lambda)\\!.\\mathrm{range}$, the 'every finite group is isomorphic to a subgroup of $S_n$' form. This is the strongest packaging: not just an embedding but a concrete realisation of $G$ as a permutation subgroup.",
+    "mathContext": "$G \\simeq^* \\mathrm{im}(\\hat\\lambda) \\le S_n$",
+    "significance": "supporting",
+    "relatedConcepts": ["subgroup", "MonoidHom.ofInjective", "first isomorphism theorem"],
+    "prerequisites": ["range of a homomorphism", "group isomorphisms"]
+  },
+  {
+    "id": "cayley-oq0101-ann-examples",
+    "proofId": "cayleys-theorem-oq-01-oq-01",
+    "range": { "startLine": 95, "endLine": 107 },
+    "type": "context",
+    "title": "Sanity checks and a concrete instance",
+    "content": "Two `example`s validate the API: the first restates the existence form, the second instantiates it at the cyclic group of order 3, `Multiplicative (ZMod 3)`, embedding it in $S_3 = \\mathrm{Perm}(\\mathrm{Fin}\\,3)$. These confirm that the abstract construction specialises cleanly to a named finite group, with the codomain's point count matching $|G|$.",
+    "mathContext": "$\\mathbb{Z}/3\\mathbb{Z} \\hookrightarrow S_3$",
+    "significance": "context",
+    "relatedConcepts": ["cyclic groups", "ZMod", "worked example"],
+    "prerequisites": ["cyclic groups"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01-oq-01` (finite form: a group of order $n$ embeds in $S_n$).

## Gap addressed
Rich `meta.json` but **no `annotations.json`** — the inline annotation layer was missing.

## Changes
- Added `annotations.json` with **9 line-anchored annotations** spanning the full file (docstring → imports → `permCongrMulEquiv` → `cayleyFinHom` → injectivity → `cayley_fin`/embedding → range iso → examples).
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Documents the codomain refinement as conjugation by a numbering $e: G \simeq \mathrm{Fin}\,n$, injectivity = faithfulness ∘ bijection, and the three equivalent packagings, plus the $\mathbb{Z}/3 \hookrightarrow S_3$ instance.

## Verification
- JSON validated; `pnpm build` passes (data-gen + tsc + vite).
- No `meta.json` change; status/badge/axiomCount (verified/mathlib/0) consistent with the Lean source.