### PR TITLE
research: Converse of Parseval — completeness characterization (cauchy-schwarz-oq-01-oq-04-oq-04)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -561,6 +561,7 @@ import Proofs.CauchySchwarzOQ01OQ01OQ02OQ01
 import Proofs.CauchySchwarzOQ01OQ02
 import Proofs.CauchySchwarzOQ01OQ03
 import Proofs.CauchySchwarzOQ01OQ04
+import Proofs.CauchySchwarzOQ01OQ04OQ04
 import Proofs.CauchySchwarzOQ02
 import Proofs.CauchySchwarzOQ02OQ01
 import Proofs.CauchySchwarzOQ02OQ02

--- a/proofs/Proofs/CauchySchwarzOQ01OQ04OQ04.lean
+++ b/proofs/Proofs/CauchySchwarzOQ01OQ04OQ04.lean
@@ -1,0 +1,156 @@
+import Mathlib.Analysis.InnerProductSpace.l2Space
+import Mathlib.Tactic
+
+/-!
+# The Converse of Parseval: Completeness from the Equality Case (Cauchy–Schwarz, OQ-01-OQ-04-OQ-04)
+
+## What This Proves
+
+The Bessel/Parseval entry `CauchySchwarzOQ01OQ04` establishes **Bessel's inequality**
+`∑' i, |⟨vᵢ, x⟩|² ≤ ‖x‖²` for every orthonormal family `v : ι → E`, and shows that when `v` is
+(the underlying family of) a `HilbertBasis`, Bessel becomes the **Parseval identity**
+`∑' i, |⟨vᵢ, x⟩|² = ‖x‖²`. That entry's docstring left as its fourth open question the
+*converse*:
+
+  *"Prove the converse: if `∑' i, ‖⟪vᵢ, x⟫‖² = ‖x‖²` for some orthonormal family, is it
+  necessarily a Hilbert basis? (This characterizes complete orthonormal systems.)"*
+
+This file answers exactly that, with a full **iff** characterization of completeness:
+
+  **An orthonormal family `v` in a Hilbert space satisfies Parseval for every vector `x`
+  if and only if `v` is the underlying family of a Hilbert basis.**
+
+The forward (converse-of-Parseval) direction is the substance: Parseval forces the orthogonal
+complement of `span v` to be trivial, so by `HilbertBasis.mkOfOrthogonalEqBot` the family
+completes to a Hilbert basis *without enlargement* — its underlying family is `v` itself. The
+backward direction reproduces the parent's `parseval_identity` (`parseval_of_hilbertBasis`).
+
+This entry is deliberately **self-contained** (it imports only Mathlib), so it stands
+independently of the parent file.
+
+## A small sharpening
+
+Triviality of the orthogonal complement — and hence density of the span — follows from the
+Parseval identity **alone**: orthonormality of `v` plays no role in `orthogonal_eq_bot_of_parseval`
+or `span_topologicalClosure_eq_top_of_parseval`. Indeed, if every Fourier coefficient
+`⟪vᵢ, y⟫` of `y` vanishes (i.e. `y ⟂ span v`), then `‖y‖² = ∑' i, 0 = 0`, so `y = 0`. The
+orthonormality hypothesis re-enters only when we *package* the total family as a genuine
+Hilbert basis via `mkOfOrthogonalEqBot`.
+
+## Original Contributions
+- `orthogonal_eq_bot_of_parseval` — the analytic core: Parseval-for-all-`x` ⟹
+  `(span 𝕜 (range v))ᗮ = ⊥`. Needs neither completeness nor orthonormality.
+- `hilbertBasisOfParseval` / `coe_hilbertBasisOfParseval` — the construction: a Hilbert basis
+  built from `v` and the Parseval hypothesis, whose underlying family is `v` itself.
+- `span_topologicalClosure_eq_top_of_parseval` — totality: Parseval ⟹ `span v` is dense.
+- `parseval_of_hilbertBasis` — the parent's forward Parseval identity, via the `ℓ²` isometry
+  `b.repr` (reproduced so the file is standalone).
+- `parseval_iff_isHilbertBasis` — the headline equivalence characterizing complete orthonormal
+  systems: Parseval-for-all-`x` ⟺ `v` is (the coe of) a Hilbert basis.
+
+## Proof Techniques
+The core is a one-line energy argument: membership in `(span v)ᗮ` (via `Submodule.mem_orthogonal`
+applied to each `vᵢ ∈ span v`) kills every Fourier coefficient `⟪vᵢ, y⟫`, so the Parseval sum
+collapses to `0`, forcing `‖y‖ = 0` (`pow_eq_zero_iff`, `norm_eq_zero`). The construction is
+`HilbertBasis.mkOfOrthogonalEqBot`; totality is `Submodule.orthogonal_orthogonal_eq_closure`
+together with `bot_orthogonal_eq_top`. The Parseval identity uses the `ℓ²`-norm formula
+`lp.norm_rpow_eq_tsum` and the isometry `b.repr.norm_map`. Everything is over an `RCLike`
+field and is `0`-axiom (`propext`, `Classical.choice`, `Quot.sound` only) / `0`-sorry.
+-/
+
+open scoped InnerProductSpace ENNReal
+
+namespace CauchySchwarzOQ01OQ04OQ04
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable {ι : Type*}
+
+/-! ## Part I: The analytic core — Parseval forces a trivial orthogonal complement
+
+If the Parseval identity holds for *every* vector, then no nonzero vector can be orthogonal
+to the whole family: such a vector would have all Fourier coefficients zero, hence Parseval
+energy `0`, hence norm `0`. This needs neither completeness nor orthonormality. -/
+
+/-- **Parseval ⟹ trivial orthogonal complement.** If `∑' i, ‖⟪vᵢ, x⟫‖² = ‖x‖²` for every `x`,
+then `(span 𝕜 (range v))ᗮ = ⊥`: the family is *total*. Orthonormality is not used. -/
+theorem orthogonal_eq_bot_of_parseval {v : ι → E}
+    (hpar : ∀ x : E, ∑' i, ‖⟪v i, x⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2) :
+    (Submodule.span 𝕜 (Set.range v))ᗮ = ⊥ := by
+  rw [Submodule.eq_bot_iff]
+  intro y hy
+  -- Every basis vector lies in the span, so `y ⟂ vᵢ` for all `i`.
+  have hzero : ∀ i, ⟪v i, y⟫_𝕜 = 0 := fun i =>
+    (Submodule.mem_orthogonal _ y).mp hy (v i) (Submodule.subset_span (Set.mem_range_self i))
+  -- Hence the Parseval sum is the sum of zeros.
+  have hsum : ∑' i, ‖⟪v i, y⟫_𝕜‖ ^ 2 = 0 := by
+    have hfun : (fun i => ‖⟪v i, y⟫_𝕜‖ ^ 2) = fun _ : ι => (0 : ℝ) := by
+      funext i; rw [hzero i, norm_zero]; ring
+    rw [hfun, tsum_zero]
+  -- Parseval then forces `‖y‖² = 0`, so `y = 0`.
+  have hy2 : ‖y‖ ^ 2 = 0 := by rw [← hpar y, hsum]
+  have hy0 : ‖y‖ = 0 := (pow_eq_zero_iff (by norm_num : (2 : ℕ) ≠ 0)).mp hy2
+  exact norm_eq_zero.mp hy0
+
+/-! ## Part II: The construction — completing to a Hilbert basis
+
+With the orthogonal complement trivial, `HilbertBasis.mkOfOrthogonalEqBot` turns the
+orthonormal family into a genuine Hilbert basis, *without* adding any vectors: the underlying
+family of the resulting basis is `v` itself. This requires `E` to be complete. -/
+
+/-- **Construction of the completing Hilbert basis.** An orthonormal family satisfying Parseval
+for every vector *is* a Hilbert basis (no enlargement needed). -/
+noncomputable def hilbertBasisOfParseval [CompleteSpace E] {v : ι → E} (hv : Orthonormal 𝕜 v)
+    (hpar : ∀ x : E, ∑' i, ‖⟪v i, x⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2) : HilbertBasis ι 𝕜 E :=
+  HilbertBasis.mkOfOrthogonalEqBot hv (orthogonal_eq_bot_of_parseval hpar)
+
+/-- The constructed Hilbert basis has `v` as its underlying family. -/
+@[simp]
+theorem coe_hilbertBasisOfParseval [CompleteSpace E] {v : ι → E} (hv : Orthonormal 𝕜 v)
+    (hpar : ∀ x : E, ∑' i, ‖⟪v i, x⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2) :
+    ⇑(hilbertBasisOfParseval hv hpar) = v :=
+  HilbertBasis.coe_mkOfOrthogonalEqBot hv _
+
+/-! ## Part III: Totality (density of the span)
+
+Triviality of the orthogonal complement is, in a Hilbert space, exactly density of the span.
+This is the classical "complete orthonormal system" picture, and again uses only Parseval. -/
+
+/-- **Totality.** Parseval-for-all-`x` makes the span of the family dense. -/
+theorem span_topologicalClosure_eq_top_of_parseval [CompleteSpace E] {v : ι → E}
+    (hpar : ∀ x : E, ∑' i, ‖⟪v i, x⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2) :
+    (Submodule.span 𝕜 (Set.range v)).topologicalClosure = ⊤ := by
+  rw [← Submodule.orthogonal_orthogonal_eq_closure,
+    orthogonal_eq_bot_of_parseval hpar, Submodule.bot_orthogonal_eq_top]
+
+/-! ## Part IV: The forward Parseval identity and the headline equivalence
+
+`parseval_of_hilbertBasis` reproduces the parent's Parseval identity through the `ℓ²` isometry
+`b.repr`; combined with Parts I–II it yields a clean characterization of completeness. -/
+
+/-- **Parseval's identity for a Hilbert basis.** Via the `ℓ²` isometry `b.repr`, the squared
+Fourier coefficients of `x` sum to `‖x‖²`. -/
+theorem parseval_of_hilbertBasis [CompleteSpace E] (b : HilbertBasis ι 𝕜 E) (x : E) :
+    ∑' i, ‖⟪b i, x⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2 := by
+  have hp : (0 : ℝ) < (2 : ℝ≥0∞).toReal := by norm_num
+  have key := lp.norm_rpow_eq_tsum hp (b.repr x)
+  rw [b.repr.norm_map] at key
+  have h2 : (2 : ℝ≥0∞).toReal = ((2 : ℕ) : ℝ) := by norm_num
+  rw [h2, Real.rpow_natCast] at key
+  rw [key]
+  refine tsum_congr (fun i => ?_)
+  rw [Real.rpow_natCast, b.repr_apply_apply]
+
+/-- **Completeness characterization.** For an orthonormal family `v` in a Hilbert space, the
+Parseval identity holds for *every* vector if and only if `v` is the underlying family of a
+Hilbert basis. This is the exact converse of `parseval_of_hilbertBasis`. -/
+theorem parseval_iff_isHilbertBasis [CompleteSpace E] {v : ι → E} (hv : Orthonormal 𝕜 v) :
+    (∀ x : E, ∑' i, ‖⟪v i, x⟫_𝕜‖ ^ 2 = ‖x‖ ^ 2) ↔ ∃ b : HilbertBasis ι 𝕜 E, ⇑b = v := by
+  constructor
+  · intro hpar
+    exact ⟨hilbertBasisOfParseval hv hpar, coe_hilbertBasisOfParseval hv hpar⟩
+  · rintro ⟨b, hb⟩ x
+    have h := parseval_of_hilbertBasis b x
+    simpa only [hb] using h
+
+end CauchySchwarzOQ01OQ04OQ04

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-04-oq-04/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-cs0404-header",
+    "proofId": "cauchy-schwarz-oq-01-oq-04-oq-04",
+    "range": { "startLine": 1, "endLine": 70 },
+    "type": "concept",
+    "title": "Module Header: The Converse of Parseval",
+    "content": "Imports Mathlib's InnerProductSpace.l2Space (HilbertBasis and the construction HilbertBasis.mkOfOrthogonalEqBot) and Tactic. The file is deliberately self-contained — it imports only Mathlib and reproduces the parent's forward Parseval identity as parseval_of_hilbertBasis. The docstring frames the parent's fourth open question (the converse of Parseval) and records a sharpening: triviality of the orthogonal complement, hence density of the span, follows from Parseval alone, with orthonormality re-entering only to package the total family as a Hilbert basis. Variables declare a complete inner product space $E$ over an RCLike field $\\mathbb{k}$ and a family $v : \\iota \\to E$.",
+    "mathContext": "Goal: for orthonormal $v$, characterize when $v$ is (the coercion of) a Hilbert basis. Answer: exactly when $\\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2$ for every $x$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Parseval's identity",
+      "Hilbert basis",
+      "orthogonal complement",
+      "complete orthonormal system"
+    ],
+    "prerequisites": [
+      "inner product spaces",
+      "orthonormality",
+      "Hilbert space completeness",
+      "Mathlib l2Space API"
+    ]
+  },
+  {
+    "id": "ann-cs0404-core",
+    "proofId": "cauchy-schwarz-oq-01-oq-04-oq-04",
+    "range": { "startLine": 78, "endLine": 100 },
+    "type": "technique",
+    "title": "The Analytic Core: Parseval ⟹ Trivial Orthogonal Complement",
+    "content": "orthogonal_eq_bot_of_parseval is the substance of the converse. Given that Parseval holds for every $x$, take any $y \\in (\\operatorname{span} v)^\\perp$. Each basis vector $v_i$ lies in the span (Submodule.subset_span ∘ Set.mem_range_self), so Submodule.mem_orthogonal gives $\\langle v_i, y\\rangle = 0$ for all $i$. The Parseval sum for $y$ is therefore $\\sum_i \\|0\\|^2 = 0$ (tsum_zero), and Parseval equates this to $\\|y\\|^2$; pow_eq_zero_iff and norm_eq_zero force $y = 0$. Notably this argument uses neither completeness nor orthonormality of $v$.",
+    "mathContext": "$y \\perp \\operatorname{span}(v) \\Rightarrow \\forall i,\\ \\langle v_i, y\\rangle = 0 \\Rightarrow \\|y\\|^2 = \\sum_i \\|\\langle v_i, y\\rangle\\|^2 = 0 \\Rightarrow y = 0$, i.e. $(\\operatorname{span} v)^\\perp = \\bot$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "orthogonal complement",
+      "Fourier coefficients",
+      "Submodule.mem_orthogonal",
+      "energy argument"
+    ],
+    "prerequisites": [
+      "orthogonal complements of submodules",
+      "tsum of a zero family",
+      "norm and pow_eq_zero_iff"
+    ]
+  },
+  {
+    "id": "ann-cs0404-construction",
+    "proofId": "cauchy-schwarz-oq-01-oq-04-oq-04",
+    "range": { "startLine": 108, "endLine": 122 },
+    "type": "technique",
+    "title": "Completing to a Hilbert Basis Without Enlargement",
+    "content": "hilbertBasisOfParseval feeds the trivial orthogonal complement into Mathlib's HilbertBasis.mkOfOrthogonalEqBot, producing a genuine Hilbert basis from the orthonormal family $v$ and the Parseval hypothesis. coe_hilbertBasisOfParseval records that the resulting basis coerces back to $v$ itself: completeness is achieved without adding a single vector. This step requires CompleteSpace $E$ and is where orthonormality of $v$ is finally used.",
+    "mathContext": "$(\\operatorname{span} v)^\\perp = \\bot$ together with orthonormality $\\Rightarrow v$ is a HilbertBasis with $\\lceil b\\rceil = v$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "HilbertBasis.mkOfOrthogonalEqBot",
+      "complete orthonormal system",
+      "total family"
+    ],
+    "prerequisites": [
+      "Hilbert bases",
+      "trivial orthogonal complement"
+    ]
+  },
+  {
+    "id": "ann-cs0404-totality",
+    "proofId": "cauchy-schwarz-oq-01-oq-04-oq-04",
+    "range": { "startLine": 128, "endLine": 134 },
+    "type": "concept",
+    "title": "Totality: Density of the Span",
+    "content": "span_topologicalClosure_eq_top_of_parseval translates the trivial orthogonal complement into density of the span. In a complete space, Submodule.orthogonal_orthogonal_eq_closure identifies the topological closure with the double orthogonal complement; since the (single) orthogonal complement is $\\bot$, bot_orthogonal_eq_top gives closure $= \\top$. Like Part I, this uses only Parseval, not orthonormality.",
+    "mathContext": "$\\overline{\\operatorname{span}(v)} = (\\operatorname{span} v)^{\\perp\\perp} = \\bot^\\perp = \\top$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "topological closure of a submodule",
+      "double orthogonal complement",
+      "density"
+    ],
+    "prerequisites": [
+      "orthogonal_orthogonal_eq_closure",
+      "completeness"
+    ]
+  },
+  {
+    "id": "ann-cs0404-iff",
+    "proofId": "cauchy-schwarz-oq-01-oq-04-oq-04",
+    "range": { "startLine": 140, "endLine": 156 },
+    "type": "key-step",
+    "title": "The Headline Equivalence",
+    "content": "parseval_of_hilbertBasis reproduces the forward Parseval identity through the $\\ell^2$ isometry b.repr: the squared coefficients sum to $\\|b.\\text{repr}\\,x\\|^2 = \\|x\\|^2$ via lp.norm_rpow_eq_tsum (with the $p = 2$ exponent normalized through Real.rpow_natCast) and b.repr.norm_map. parseval_iff_isHilbertBasis then assembles both directions into the characterization of complete orthonormal systems: Parseval holds for every vector if and only if $v$ is the underlying family of a Hilbert basis. The forward direction is Parts I-II; the backward direction is parseval_of_hilbertBasis after rewriting $b\\,i = v\\,i$.",
+    "mathContext": "$(\\forall x,\\ \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2) \\iff \\exists\\, b : \\text{HilbertBasis},\\ \\lceil b\\rceil = v$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Parseval's identity",
+      "ℓ² isometry b.repr",
+      "lp.norm_rpow_eq_tsum",
+      "completeness characterization"
+    ],
+    "prerequisites": [
+      "HilbertBasis.repr linear isometry",
+      "ℓ² norm formula",
+      "the converse direction (Parts I-II)"
+    ]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-04-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-04-oq-04/meta.json
@@ -1,0 +1,156 @@
+{
+  "id": "cauchy-schwarz-oq-01-oq-04-oq-04",
+  "title": "The Converse of Parseval: Completeness from the Equality Case",
+  "slug": "cauchy-schwarz-oq-01-oq-04-oq-04",
+  "description": "Proves the converse of Parseval's identity: an orthonormal family in a Hilbert space satisfies ∑' i, |⟨vᵢ,x⟩|² = ‖x‖² for every x if and only if it is the underlying family of a Hilbert basis. Parseval forces the orthogonal complement of the span to vanish, completing the family to a Hilbert basis without enlargement.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Parseval%27s_identity",
+    "date": "Classical (Parseval 1799, Hilbert 1904-1910); formalized 2026",
+    "status": "verified",
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ01OQ04OQ04.lean",
+    "tags": [
+      "functional-analysis",
+      "hilbert-spaces",
+      "inner-product-spaces",
+      "parseval-identity",
+      "orthonormal-systems",
+      "hilbert-basis",
+      "completeness"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean's standard foundational axioms (propext, Classical.choice, Quot.sound; verified via #print axioms). E is a complete inner product space over an RCLike field.",
+    "lineCount": 156,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "orthogonal_eq_bot_of_parseval: Parseval-for-all-x ⟹ (span 𝕜 (range v))ᗮ = ⊥. The analytic core, using neither completeness nor orthonormality — if every Fourier coefficient ⟪vᵢ,y⟫ vanishes then ‖y‖² = ∑' 0 = 0",
+      "hilbertBasisOfParseval: constructs a HilbertBasis from an orthonormal family satisfying Parseval, via HilbertBasis.mkOfOrthogonalEqBot (no enlargement)",
+      "coe_hilbertBasisOfParseval: the constructed Hilbert basis has v itself as its underlying family",
+      "span_topologicalClosure_eq_top_of_parseval: totality — Parseval ⟹ the span of v is dense (uses orthogonal_orthogonal_eq_closure and bot_orthogonal_eq_top)",
+      "parseval_of_hilbertBasis: the forward Parseval identity ∑' i, |⟨bᵢ,x⟩|² = ‖x‖² via the ℓ² isometry b.repr (reproduced so the file is self-contained)",
+      "parseval_iff_isHilbertBasis: the headline equivalence — Parseval-for-all-x ⟺ ∃ HilbertBasis b, ⇑b = v, characterizing complete orthonormal systems"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Marc-Antoine Parseval noted in 1799 that for a 'complete' trigonometric system the sum of squared Fourier coefficients equals the squared norm, $\\sum_n (a_n^2 + b_n^2) = \\frac{1}{\\pi}\\int_0^{2\\pi} f^2$. Bessel (1828) supplied the corresponding inequality for arbitrary orthonormal systems. The decisive question — exactly which orthonormal systems achieve equality — was answered by the abstract theory of Hilbert spaces developed by David Hilbert (1904-1910) and crystallized in the Riesz-Fischer theorem (1907): equality in Bessel's inequality for every vector is precisely the condition that the orthonormal system be *complete*, i.e. a Hilbert basis. The parent entry formalized Bessel's inequality and the forward Parseval identity (a Hilbert basis satisfies Parseval). This entry closes the loop with the converse: Parseval for every vector forces completeness.",
+    "problemStatement": "If an orthonormal family v in a Hilbert space satisfies ∑' i, ‖⟪vᵢ,x⟫‖² = ‖x‖² for every x, must v be (the underlying family of) a Hilbert basis?",
+    "text": "YES, and the equivalence is sharp. The key is that the Parseval identity, applied to a vector y orthogonal to the whole family, gives ‖y‖² = ∑' i, ‖⟪vᵢ,y⟫‖² = ∑' i, 0 = 0, so y = 0. Hence the orthogonal complement of span(v) is trivial, and Mathlib's HilbertBasis.mkOfOrthogonalEqBot packages v as a Hilbert basis whose underlying family is v itself — no vectors need to be added. The forward direction is the parent's Parseval identity, reproduced here through the ℓ² isometry b.repr so the file stands alone.",
+    "proofStrategy": "Part I (orthogonal_eq_bot_of_parseval) is the analytic core: by Submodule.mem_orthogonal each basis vector lies in the span, so membership in (span v)ᗮ kills every Fourier coefficient; the Parseval sum then collapses to 0 and pow_eq_zero_iff/norm_eq_zero force the vector to be 0. Part II builds the Hilbert basis via mkOfOrthogonalEqBot and records that its coercion is v. Part III derives density of the span from orthogonal_orthogonal_eq_closure and bot_orthogonal_eq_top. Part IV reproduces the forward Parseval identity via lp.norm_rpow_eq_tsum and b.repr.norm_map, and assembles the headline iff.",
+    "keyInsights": [
+      "Parseval for every x is equivalent to completeness of the orthonormal system",
+      "The converse needs only Parseval: triviality of (span v)ᗮ follows without re-invoking orthonormality — a vector orthogonal to all vᵢ has zero Parseval energy",
+      "Orthonormality re-enters only to *package* the total family as a genuine Hilbert basis (mkOfOrthogonalEqBot)",
+      "In a complete space, trivial orthogonal complement equals density of the span (orthogonal_orthogonal_eq_closure)",
+      "The completion adds no vectors: the resulting Hilbert basis has v itself as its underlying family"
+    ],
+    "prerequisites": [
+      "Inner product spaces, orthonormality, and orthogonal complements",
+      "Hilbert bases (complete orthonormal systems) and the ℓ² representation isometry",
+      "Bessel's inequality and the forward Parseval identity (parent entry)",
+      "Density / topological closure of submodules in a Hilbert space"
+    ]
+  },
+  "conclusion": {
+    "summary": "The converse of Parseval's identity is formalized in Lean 4: an orthonormal family satisfies Parseval for every vector if and only if it is the underlying family of a Hilbert basis. The substantive direction shows that Parseval forces the orthogonal complement of the span to vanish, so the family completes to a Hilbert basis without enlargement. This answers the parent entry's fourth open question affirmatively and sharpens it: the totality conclusion uses only Parseval, not orthonormality.",
+    "implications": "**Completes the Bessel/Parseval circle**: The parent entry proved Bessel's inequality and that a Hilbert basis satisfies Parseval; this entry supplies the converse, giving the exact characterization of complete orthonormal systems. Together they say: for an orthonormal family, equality in Bessel's inequality for every vector ⟺ completeness.\n\n**Density from energy**: The sharpening — that triviality of the orthogonal complement (hence density of the span) follows from Parseval alone — isolates exactly where orthonormality is needed. It is needed only to name the total family as a Hilbert basis, not to prove totality.\n\n**Fourier analysis**: This is the abstract form of the statement that a complete orthonormal system reconstructs every vector from its Fourier coefficients. Equality in Parseval is the 'no energy lost' condition underlying convergence of Fourier expansions.",
+    "openQuestions": [
+      "Promote the equivalence to the single-vector level: characterize, for a fixed x, equality ∑' i, ‖⟪vᵢ,x⟫‖² = ‖x‖² as membership of x in the closure of span(v) (the per-vector Bessel equality case).",
+      "Derive the Riesz-Fischer isometry as a corollary: combine this completeness characterization with the ℓ² representation to exhibit E ≃ₗᵢ ℓ²(ι,𝕜) explicitly when Parseval holds."
+    ]
+  },
+  "leanFile": {
+    "namespace": "CauchySchwarzOQ01OQ04OQ04",
+    "lineCount": 156,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/CauchySchwarzOQ01OQ04OQ04.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib.Analysis.InnerProductSpace.l2Space",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "scoped InnerProductSpace ENNReal"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-01-oq-04",
+      "relationship": "answers",
+      "description": "Answers the parent's fourth open question: the converse of Parseval, characterizing complete orthonormal systems as exactly those satisfying Parseval for every vector."
+    },
+    {
+      "targetId": "cauchy-schwarz-oq-01",
+      "relationship": "extends",
+      "description": "Continues the Cauchy-Schwarz / orthonormal-systems chain into the completeness characterization of Hilbert bases."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "foundational",
+      "description": "Root Cauchy-Schwarz proof; Bessel's inequality and its Parseval equality case are the Hilbert-space generalization."
+    }
+  ],
+  "references": [
+    {
+      "text": "Parseval, M.-A. (1806). Mémoire sur les séries et sur l'intégration complète d'une équation aux différences partielles linéaires du second ordre, à coefficiens constans.",
+      "url": "https://en.wikipedia.org/wiki/Parseval%27s_identity"
+    },
+    {
+      "text": "Riesz, F. (1907). Sur les systèmes orthogonaux de fonctions. C. R. Acad. Sci. Paris 144, 615-619.",
+      "url": "https://en.wikipedia.org/wiki/Riesz%E2%80%93Fischer_theorem"
+    },
+    {
+      "text": "Kreyszig, E. (1978). Introductory Functional Analysis with Applications. Wiley. Ch. 3.5-3.6 on Bessel, Parseval, and total orthonormal sets.",
+      "url": "https://en.wikipedia.org/wiki/Hilbert_space"
+    }
+  ],
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 70,
+      "summary": "Imports Mathlib's l2Space (HilbertBasis, mkOfOrthogonalEqBot) and Tactic. Docstring frames the open question — the converse of Parseval — and records the sharpening that totality needs only Parseval. Declares the inner product space E over an RCLike field 𝕜 and the family v : ι → E.",
+      "mathContext": "$E$ a complete inner product space over $\\mathbb{k}$ ($\\mathbb{R}$ or $\\mathbb{C}$); $v : \\iota \\to E$ orthonormal; goal: characterize when $v$ is a Hilbert basis."
+    },
+    {
+      "id": "analytic-core",
+      "title": "Part I: Parseval Forces a Trivial Orthogonal Complement",
+      "startLine": 71,
+      "endLine": 100,
+      "summary": "Proves orthogonal_eq_bot_of_parseval: if Parseval holds for every x then (span 𝕜 (range v))ᗮ = ⊥. A vector y in the orthogonal complement has every Fourier coefficient ⟪vᵢ,y⟫ = 0 (Submodule.mem_orthogonal), so the Parseval sum is 0 and ‖y‖ = 0. Uses neither completeness nor orthonormality.",
+      "mathContext": "$y \\perp \\operatorname{span}(v) \\Rightarrow \\|y\\|^2 = \\sum_i \\|\\langle v_i, y\\rangle\\|^2 = 0 \\Rightarrow y = 0$."
+    },
+    {
+      "id": "construction",
+      "title": "Part II: Completing to a Hilbert Basis",
+      "startLine": 101,
+      "endLine": 122,
+      "summary": "Defines hilbertBasisOfParseval via HilbertBasis.mkOfOrthogonalEqBot applied to the trivial orthogonal complement, and proves coe_hilbertBasisOfParseval: the constructed basis has v as its underlying family. Requires CompleteSpace E.",
+      "mathContext": "$(\\operatorname{span} v)^\\perp = \\bot \\Rightarrow v$ is a HilbertBasis with $\\lceil b \\rceil = v$."
+    },
+    {
+      "id": "totality",
+      "title": "Part III: Totality (Density of the Span)",
+      "startLine": 123,
+      "endLine": 134,
+      "summary": "Proves span_topologicalClosure_eq_top_of_parseval: Parseval makes the span dense. Uses Submodule.orthogonal_orthogonal_eq_closure and bot_orthogonal_eq_top.",
+      "mathContext": "$\\overline{\\operatorname{span}(v)} = (\\operatorname{span} v)^{\\perp\\perp} = \\bot^\\perp = \\top$."
+    },
+    {
+      "id": "headline-iff",
+      "title": "Part IV: Forward Parseval and the Headline Equivalence",
+      "startLine": 135,
+      "endLine": 156,
+      "summary": "Proves parseval_of_hilbertBasis (forward Parseval via the ℓ² isometry b.repr, lp.norm_rpow_eq_tsum) and assembles parseval_iff_isHilbertBasis: Parseval for every x ⟺ ∃ HilbertBasis b, ⇑b = v.",
+      "mathContext": "$(\\forall x,\\; \\sum_i \\|\\langle v_i, x\\rangle\\|^2 = \\|x\\|^2) \\iff \\exists\\, b : \\text{HilbertBasis},\\; \\lceil b \\rceil = v$."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent Bessel/Parseval entry's (`cauchy-schwarz-oq-01-oq-04`) **fourth open question** — the converse of Parseval:

> An orthonormal family `v` in a Hilbert space satisfies `∑' i, ‖⟪vᵢ,x⟫‖² = ‖x‖²` for **every** `x` **iff** `v` is the underlying family of a `HilbertBasis`.

This is the exact characterization of **complete orthonormal systems** and closes the Bessel/Parseval loop (parent proved Bessel + forward Parseval; this proves the converse).

## Mathematical content

- `orthogonal_eq_bot_of_parseval` — the analytic core: Parseval-for-all-`x` ⟹ `(span 𝕜 (range v))ᗮ = ⊥`. A vector orthogonal to all `vᵢ` has zero Parseval energy, hence zero norm. **Uses neither completeness nor orthonormality.**
- `hilbertBasisOfParseval` / `coe_hilbertBasisOfParseval` — completes `v` to a Hilbert basis via `HilbertBasis.mkOfOrthogonalEqBot`, *without enlargement* (the basis coerces back to `v`).
- `span_topologicalClosure_eq_top_of_parseval` — totality: Parseval ⟹ span is dense.
- `parseval_of_hilbertBasis` — forward Parseval via the `ℓ²` isometry `b.repr` (reproduced so the file is self-contained).
- `parseval_iff_isHilbertBasis` — the headline equivalence.

**Sharpening:** triviality of the orthogonal complement (hence density of the span) follows from Parseval *alone*; orthonormality re-enters only to package the total family as a Hilbert basis.

## Verification

- 5 theorems + 1 definition, 156 lines, **0 sorries / 0 axiom declarations**.
- Kernel-verified with `lake env lean Proofs/CauchySchwarzOQ01OQ04OQ04.lean` (Docker wrapper was wedged by a shared-cache race; verified directly over cached Mathlib oleans).
- `#print axioms parseval_iff_isHilbertBasis` → `[propext, Classical.choice, Quot.sound]` (standard foundational axioms only; status `verified`).

## Note for auditors / mechanic

This entry imports **only Mathlib** (not the parent file) on purpose. The parent `Proofs/CauchySchwarzOQ01OQ04.lean` **currently fails to elaborate against Mathlib 4.26.0**: `bessel_monotone`/`bessel_insert` use `Finset.sum_le_sum_of_subset`, which now requires `CanonicallyOrderedAdd ℝ` (false), so several downstream instances fail. That bit-rot is out of scope here but is worth a separate repair (likely `sum_le_sum_of_subset_of_nonneg` + `[DecidableEq ι]`). Making this entry self-contained sidesteps the broken import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)