### PR TITLE
Fix: repair 4 Erdős Lean files for Mathlib v4.26.0 (build-verified)

### DIFF
--- a/proofs/Proofs/Erdos1001OQ02.lean
+++ b/proofs/Proofs/Erdos1001OQ02.lean
@@ -30,15 +30,7 @@ Neither has been proved in this gallery with explicit error bounds.
 **Status**: AXIOMATIZED (deep analytic number theory)
 -/
 
-import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
-import Mathlib.NumberTheory.Diophantine
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Order.Filter.AtTopBot.Basic
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Analysis.Asymptotics.Asymptotics
-import Mathlib.Topology.Instances.Real.Basic
-import Mathlib.NumberTheory.ArithmeticFunction
+import Mathlib
 
 open MeasureTheory Set Filter Real Asymptotics
 open scoped Topology
@@ -171,7 +163,7 @@ theorem convergence_faster_than_sqrtN (A c : ℝ) (hA : 0 < A) (hc : c > 1)
   -- log x / x^(1/2) → 0, so A * log N / √N → 0 on ℕ
   have hA_log_sqrt : Tendsto (fun n : ℕ => A * (Real.log ↑n / Real.sqrt ↑n)) atTop (nhds 0) := by
     have hlog12 : Tendsto (fun x : ℝ => Real.log x / x ^ ((1:ℝ)/2)) atTop (nhds 0) :=
-      Real.tendsto_log_div_rpow_atTop (1/2) (by norm_num)
+      (isLittleO_log_rpow_atTop (r := (1:ℝ)/2) (by norm_num)).tendsto_div_nhds_zero
     have h : Tendsto (fun n : ℕ => A * (Real.log ↑n / (↑n : ℝ) ^ ((1:ℝ)/2))) atTop (nhds 0) := by
       have := (hlog12.comp tendsto_natCast_atTop_atTop).const_mul A
       simpa [mul_zero] using this
@@ -186,22 +178,23 @@ theorem convergence_faster_than_sqrtN (A c : ℝ) (hA : 0 < A) (hc : c > 1)
   -- hN : |A * (log N / sqrt N)| < c'
   -- Derive: A * |log N| / sqrt N < c'
   have hN_abs : A * |Real.log ↑N| / Real.sqrt ↑N < c' := by
-    rwa [abs_mul, abs_div, abs_of_pos hA, abs_of_pos hsqrt_pos] at hN
+    rwa [abs_mul, abs_div, abs_of_pos hA, abs_of_pos hsqrt_pos, ← mul_div_assoc] at hN
   -- Multiply out: A * |log N| < c' * sqrt N
   -- Then: A * |log N| * sqrt N < c' * (sqrt N)² = c' * N
   have hkey : A * |Real.log ↑N| * Real.sqrt ↑N < c' * (Real.sqrt ↑N * Real.sqrt ↑N) := by
     have hmul : A * |Real.log ↑N| < c' * Real.sqrt ↑N := by
-      rwa [div_lt_iff hsqrt_pos] at hN_abs
+      rwa [div_lt_iff₀ hsqrt_pos] at hN_abs
     calc A * |Real.log ↑N| * Real.sqrt ↑N
         < c' * Real.sqrt ↑N * Real.sqrt ↑N := mul_lt_mul_of_pos_right hmul hsqrt_pos
       _ = c' * (Real.sqrt ↑N * Real.sqrt ↑N) := by ring
   -- Rewrite goal norms explicitly then use div_le_div_iff
   have h1 : ‖A * (Real.log ↑N / ↑N)‖ = A * |Real.log ↑N| / ↑N := by
-    rw [Real.norm_eq_abs, abs_mul, abs_of_pos hA, abs_div, abs_of_pos hNr]
+    rw [Real.norm_eq_abs, abs_mul, abs_of_pos hA, abs_div, abs_of_pos hNr, mul_div_assoc]
   have h2 : c' * ‖1 / Real.sqrt ↑N‖ = c' / Real.sqrt ↑N := by
     rw [Real.norm_eq_abs, abs_div, abs_one, abs_of_pos hsqrt_pos]; ring
   -- A * |log N| / N ≤ c' / sqrt N ↔ A * |log N| * sqrt N ≤ c' * N = c' * (sqrt N)²
-  rw [h1, h2, div_le_div_iff hNr hsqrt_pos, ← hsq]
+  rw [h1, h2, div_le_div_iff₀ hNr hsqrt_pos]
+  conv_rhs => rw [← hsq]
   linarith [hkey]
 
 /-- The rate is sharper than the a priori O(1) bound (trivially).
@@ -218,7 +211,7 @@ theorem rate_is_nontrivial (A c : ℝ) (hA : 0 < A) (hc : c > 1)
   simp only [div_one]
   -- log x / x → 0 on ℝ (from tendsto_log_div_rpow_atTop with p = 1)
   have hlogdiv : Tendsto (fun x : ℝ => Real.log x / x) atTop (nhds 0) := by
-    have h := Real.tendsto_log_div_rpow_atTop 1 one_pos
+    have h := (isLittleO_log_rpow_atTop (r := (1:ℝ)) one_pos).tendsto_div_nhds_zero
     simpa [Real.rpow_one] using h
   -- Pull back to ℕ via Nat.cast coercion
   have hlogdiv_nat : Tendsto (fun n : ℕ => Real.log ↑n / (↑n : ℝ)) atTop (nhds 0) :=
@@ -238,7 +231,7 @@ theorem convergence_effective (A c ε : ℝ) (hA : 0 < A) (hc : c > 1)
   -- From rate_is_nontrivial: |S N - f| = o(1)
   have ho := rate_is_nontrivial A c hA hc hregime
   rw [isLittleO_iff] at ho
-  have h_ev := ho (ε/2) (by linarith)
+  have h_ev := ho (show (0:ℝ) < ε / 2 by linarith)
   simp only [norm_one, mul_one] at h_ev
   rw [Filter.eventually_atTop] at h_ev
   obtain ⟨N₀, hN₀⟩ := h_ev

--- a/proofs/Proofs/Erdos1001Problem.lean
+++ b/proofs/Proofs/Erdos1001Problem.lean
@@ -17,13 +17,7 @@ for some N ≤ y ≤ cN with gcd(x,y) = 1.
 Reference: https://erdosproblems.com/1001
 -/
 
-import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
-import Mathlib.NumberTheory.Diophantine
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Nat.GCD.Basic
-import Mathlib.Order.Filter.AtTopBot.Basic
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Topology.Instances.Real.Basic
+import Mathlib
 
 open MeasureTheory Set Filter Real
 
@@ -173,7 +167,6 @@ def FareyFraction (n : ℕ) : Set ℚ :=
 theorem est_pi_squared_explanation :
     f 1 (Real.exp 1) = 12 / π^2 := by
   simp [f]
-  ring
 
 /-
 ## Outside the EST Regime (Open Question oq-01)

--- a/proofs/Proofs/Erdos1002Problem.lean
+++ b/proofs/Proofs/Erdos1002Problem.lean
@@ -16,13 +16,7 @@ Does f(α, n) have an asymptotic distribution function?
 Reference: https://erdosproblems.com/1002
 -/
 
-import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
-import Mathlib.Data.Real.Basic
-import Mathlib.Order.Filter.AtTopBot.Basic
-import Mathlib.Analysis.SpecialFunctions.Log.Basic
-import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
-import Mathlib.Topology.Instances.Real.Basic
-import Mathlib.Data.Int.Floor
+import Mathlib
 
 open MeasureTheory Set Filter Real Int
 
@@ -121,12 +115,12 @@ noncomputable def twoParamF (α β : ℝ) (n : ℕ) : ℝ :=
 noncomputable def cauchyDistribution (ρ : ℝ) (c : ℝ) : ℝ :=
   1 / π * Real.arctan (ρ * c) + 1 / 2
 
-/-- The Cauchy distribution function is a valid distribution function. -/
+/- The Cauchy distribution function is a valid distribution function. -/
 /-- Two-parameter level set. -/
 def twoParamLevelSet (n : ℕ) (c : ℝ) : Set (ℝ × ℝ) :=
   { p : ℝ × ℝ | p.1 ∈ Ioo 0 1 ∧ p.2 ∈ Ioo 0 1 ∧ twoParamF p.1 p.2 n ≤ c }
 
-/-- Kesten (1960): The two-parameter variant has Cauchy limit distribution.
+/- Kesten (1960): The two-parameter variant has Cauchy limit distribution.
     There exists ρ > 0 such that the level set measure converges to
     g(c) = (1/π) arctan(ρc) + 1/2. -/
 /-
@@ -147,8 +141,8 @@ theorem one_param_is_specialization (α : ℝ) (n : ℕ) :
 Fixing β = 0 destroys the ergodic independence Kesten used.
 -/
 
-/-- For fixed irrational α, f(α, n) is bounded (does not diverge). -/
-/-- The inner sum |S(α, n)| ≤ C · log n for irrational α,
+/- For fixed irrational α, f(α, n) is bounded (does not diverge). -/
+/- The inner sum |S(α, n)| ≤ C · log n for irrational α,
     where C depends on α's continued fraction expansion. -/
 /-
 ## Partial Results
@@ -157,9 +151,9 @@ Weyl equidistribution implies the sum S(α, n) grows sublinearly,
 justifying the log n normalization.
 -/
 
-/-- Weyl equidistribution: The average deviation tends to zero.
+/- Weyl equidistribution: The average deviation tends to zero.
     This means (1/n) Σ (1/2 - {αk}) → 0 for irrational α. -/
-/-- For rational α = p/q, the sum S(α, n) is periodic with period q. -/
+/- For rational α = p/q, the sum S(α, n) is periodic with period q. -/
 /-
 ## Summary
 

--- a/proofs/Proofs/Erdos482Problem.lean
+++ b/proofs/Proofs/Erdos482Problem.lean
@@ -25,11 +25,7 @@ References:
 Tags: number-theory, binary-digits, algebraic-numbers, recurrence, solved
 -/
 
-import Mathlib.Data.Real.Basic
-import Mathlib.Data.Real.Sqrt
-import Mathlib.Data.Int.Floor
-import Mathlib.Data.Nat.Digits
-import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib
 
 open Real Int
 
@@ -43,7 +39,7 @@ noncomputable def grahamPollakSeq : ℕ → ℤ
   | 0 => 1
   | n + 1 => ⌊Real.sqrt 2 * (grahamPollakSeq n + 1/2)⌋
 
-/-- First few terms of the sequence.
+/- First few terms of the sequence.
 Axiomatized because computing floor(√2 · x) requires real arithmetic. -/
 /- ## Part 2: The Main Theorem
 -/
@@ -59,9 +55,9 @@ axiom graham_pollak_theorem :
 /- ## Part 3: Properties of the Recurrence
 -/
 
-/-- √2 ≈ 1.41421356...
+/- √2 ≈ 1.41421356...
 Axiomatized because Mathlib's norm_num cannot evaluate sqrt 2 directly. -/
-/-- The recurrence grows approximately by factor √2.
+/- The recurrence grows approximately by factor √2.
 Axiomatized because the convergence rate proof requires real analysis. -/
 /- ## Part 4: Generalization to √m
 -/
@@ -71,7 +67,7 @@ noncomputable def sqrtSeq (m : ℕ) : ℕ → ℤ
   | 0 => 1
   | n + 1 => ⌊Real.sqrt m * (sqrtSeq m n + 1/2)⌋
 
-/-- Stoll's generalization (2005): the digit-extraction method extends to
+/- Stoll's generalization (2005): the digit-extraction method extends to
 quadratic irrationals √m for square-free m.
 Axiomatized because the proof requires algebraic number theory. -/
 /-- Stoll (2005-2006): the method extends to all quadratic irrationals
@@ -85,7 +81,7 @@ axiom stoll_general :
 /- ## Part 5: Non-Periodicity
 -/
 
-/-- Non-periodicity of binary digits of √2.
+/- Non-periodicity of binary digits of √2.
 Since √2 is irrational, its binary expansion cannot be eventually periodic.
 Axiomatized because the proof requires irrationality of √2 combined with
 the characterization of eventually periodic binary expansions. -/


### PR DESCRIPTION
## Fix

Repairs the four Erdős gallery-backing Lean files that fail to compile on the pinned toolchain (Mathlib v4.26.0), restoring the aggregate `Proofs.lean`.

## Evidence

**Before**: `Erdos1002Problem`, `Erdos1001OQ02`, `Erdos1001Problem`, `Erdos482Problem` imported removed Mathlib modules; once imports were swapped, body-level breakage surfaced (renamed lemmas, a now-redundant `ring`, orphaned doc comments that are hard parse errors in this Lean).

**After**: all four elaborate cleanly. Verified individually with single-file `lake env lean` against the built Mathlib oleans (Docker daemon unavailable this session):

```
OK Erdos482Problem
OK Erdos1002Problem
OK Erdos1001Problem
OK Erdos1001OQ02
```

### Changes
- **Imports**: removed modules (`Topology.Instances.Real.Basic`, `Data.Int.Floor`, `NumberTheory.Diophantine`, `Analysis.Asymptotics.Asymptotics`, `Data.Nat.Digits`) → standard bare `import Mathlib`.
- **Erdos482 / Erdos1002**: orphaned `/-- … -/` doc comments (describing removed axioms) demoted to plain `/- … -/` block comments.
- **Erdos1001Problem**: dropped a redundant `ring` (`simp [f]` now closes the goal).
- **Erdos1001OQ02**: `Real.tendsto_log_div_rpow_atTop` → `(isLittleO_log_rpow_atTop _).tendsto_div_nhds_zero`; `div_lt_iff`/`div_le_div_iff` → `div_lt_iff₀`/`div_le_div_iff₀`; scoped a `← hsq` rewrite to the RHS with `conv_rhs`; adapted to `isLittleO_iff`'s strict-implicit positivity argument.

No mathematical content changed — all four remain `axiomatized`/`axiom` gallery entries.

Closes #28429

---
Automated fix by lean-mechanic agent.