### PR TITLE
fix(erdos-1042-oq-03): repair non-compiling lemniscate confinement proof

### DIFF
--- a/proofs/Proofs/Erdos1042OQ03.lean
+++ b/proofs/Proofs/Erdos1042OQ03.lean
@@ -78,7 +78,9 @@ theorem lem_near_root (p : RootedPoly) {z : ℂ} (hz : z ∈ lem p) :
   have h1 : (1 : ℝ) ≤ ‖p.eval z‖ := by
     unfold RootedPoly.eval
     rw [norm_prod]
-    exact Finset.one_le_prod' fun i _ => h i
+    calc (1 : ℝ) = ∏ _i : Fin p.degree, (1 : ℝ) := Finset.prod_const_one.symm
+      _ ≤ ∏ i : Fin p.degree, ‖z - p.roots i‖ :=
+          Finset.prod_le_prod (fun i _ => zero_le_one) (fun i _ => h i)
   have hz' : ‖p.eval z‖ < 1 := hz
   exact absurd hz' (not_lt.mpr h1)
 
@@ -97,7 +99,7 @@ theorem lem_subset_iUnion_ball (p : RootedPoly) :
 /-- The lemniscate is bounded: it sits inside a finite union of unit balls. -/
 theorem isBounded_lem (p : RootedPoly) : Bornology.IsBounded (lem p) := by
   have hb : Bornology.IsBounded (⋃ i : Fin p.degree, Metric.ball (p.roots i) 1) :=
-    isBounded_iUnion.mpr fun _ => Metric.isBounded_ball
+    Bornology.isBounded_iUnion.mpr fun _ => Metric.isBounded_ball
   exact hb.subset (lem_subset_iUnion_ball p)
 
 /-- **Capstone.** Every polynomial lemniscate is an open, bounded subset of ℂ

--- a/src/data/proofs/erdos-1042-oq-03/meta.json
+++ b/src/data/proofs/erdos-1042-oq-03/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 113,
-    "assumptions": "None. All eight theorems are axiom-free and self-contained: the polynomial/lemniscate structures are re-declared locally so that nothing depends on the parent entry's axioms (transfiniteDiameter, ghosh_ramachandran_small_diameter, ghosh_ramachandran_diameter_one_examples). No native_decide is used. Build NOT kernel-verified this session (Docker daemon unavailable); all Mathlib v4.26.0 signatures (continuous_finset_prod, norm_prod, Finset.prod_eq_zero, Finset.one_le_prod', Continuous.norm, dist_eq_norm, isBounded_iUnion, Metric.isBounded_ball) were checked against Mathlib source. Uses the modern norm ‖·‖ throughout (Complex.abs was removed in v4.26.0). The deployer build-gate is the final check.",
+    "assumptions": "None. All eight theorems are axiom-free and self-contained: the polynomial/lemniscate structures are re-declared locally so that nothing depends on the parent entry's axioms (transfiniteDiameter, ghosh_ramachandran_small_diameter, ghosh_ramachandran_diameter_one_examples). No native_decide is used. Kernel-verified against Mathlib v4.26.0 (`lake env lean`, exit 0); `#print axioms geometric_confinement` reports only `[propext, Classical.choice, Quot.sound]`. Mathlib lemmas used: continuous_finset_prod, norm_prod, Finset.prod_eq_zero, Finset.prod_le_prod, Finset.prod_const_one, Continuous.norm, dist_eq_norm, Bornology.isBounded_iUnion, Metric.isBounded_ball. Uses the modern norm ‖·‖ throughout (Complex.abs was removed in v4.26.0).",
     "dateAdded": "2026-06-23",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -49,7 +49,7 @@
       "Re-declaring the structures locally keeps the contribution axiom-free, in contrast to the parent entry whose Ghosh–Ramachandran results are axiomatized."
     ],
     "prerequisites": [
-      "Finite products over Finset (norm_prod, Finset.prod_eq_zero, Finset.one_le_prod')",
+      "Finite products over Finset (norm_prod, Finset.prod_eq_zero, Finset.prod_le_prod, Finset.prod_const_one)",
       "Continuity of finite products (continuous_finset_prod) and of the norm (Continuous.norm)",
       "Open preimages of continuous maps; metric balls, dist_eq_norm, and boundedness of finite unions of balls"
     ]


### PR DESCRIPTION
## Gallery integrity repair (auditor finding)

**Proof**: \`erdos-1042-oq-03\` — *Polynomial Lemniscates Are Confined to Unit Balls About Their Roots*

The entry was published as **status=verified / badge=original / 0 sorries / 0 axioms**, but the Lean file **did not compile** against its stated Mathlib v4.26.0. Two real elaboration errors (kernel-verified by the auditor via \`lake env lean\`):

### Error 1 — \`lem_near_root\` (line 81)
\`\`\`
error: failed to synthesize MulLeftMono ℝ
\`\`\`
\`Finset.one_le_prod'\` requires \`[MulLeftMono N]\` over an \`OrderedCommMonoid\`. ℝ under multiplication is **not** an ordered comm monoid, so the lemma cannot apply to a product of real norms \`∏ᵢ ‖z - rootᵢ‖\`.

**Fix**: bound below by the constant-1 product instead:
\`\`\`lean
calc (1 : ℝ) = ∏ _i : Fin p.degree, (1 : ℝ) := Finset.prod_const_one.symm
  _ ≤ ∏ i : Fin p.degree, ‖z - p.roots i‖ :=
      Finset.prod_le_prod (fun i _ => zero_le_one) (fun i _ => h i)
\`\`\`
(\`Finset.prod_le_prod\` holds for ℝ via \`CommMonoidWithZero\`/\`PosMulMono\`/\`ZeroLEOneClass\`.)

### Error 2 — \`isBounded_lem\` (line 100)
\`\`\`
error: Unknown identifier `isBounded_iUnion`
\`\`\`
The lemma lives in the \`Bornology\` namespace; the file only opens \`Complex\`/\`BigOperators\`/\`Metric\`.

**Fix**: qualify as \`Bornology.isBounded_iUnion.mpr\`.

## Verification
- \`lake env lean Proofs/Erdos1042OQ03.lean\` → **exit 0** (Mathlib v4.26.0)
- \`#print axioms Erdos1042OQ03.geometric_confinement\` → \`[propext, Classical.choice, Quot.sound]\` only

So **verified / original / 0 sorries / 0 axioms is now accurate**. No mathematical content changed — only the two broken tactic invocations. \`meta.json\` \`assumptions\` field updated to record the kernel verification and corrected lemma names.

---
Discovered and fixed during gallery integrity audit.