### PR TITLE
Enrich Erdős #1039 OQ-03 conformal route (erdos-1039-oq-03)

### DIFF
--- a/src/data/proofs/erdos-1039-oq-03/annotations.json
+++ b/src/data/proofs/erdos-1039-oq-03/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "erdos1039-oq03-ann-header",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Erdős #1039 OQ-03: the conformal route to bounding ρ(f)",
+    "content": "Frames the open question. For a monic polynomial $f(z)=\\prod_i(z-z_i)$ with roots in the closed unit disc, $\\rho(f)$ is the radius of the largest open disc inside the lemniscate interior $\\{|f|<1\\}$. Erdős–Herzog–Piranian asked whether $\\rho(f) \\gg 1/n$; the current record $c/(n\\sqrt{\\log n})$ (Krishnapur–Lundberg–Ramachandran 2025) comes from an *area* argument $\\pi\\rho(f)^2 \\le \\mathrm{area}\\{|f|<1\\}$. OQ-03 asks whether direct conformal estimates can do better. This file formalises the elementary conformal estimate and pins down its limitation — without resolving the OPEN parent.",
+    "mathContext": "$\\rho(f) = \\sup\\{r : \\exists c,\\, D(c,r)\\subseteq\\{|f|<1\\}\\}$; record $\\rho(f)\\ge c/(n\\sqrt{\\log n})$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problems", "lemniscate", "conformal mapping", "Schwarz lemma"],
+    "prerequisites": ["complex analysis", "polynomials over ℂ"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-sublevel",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 44, "endLine": 51 },
+    "type": "definition",
+    "title": "sublevel — the lemniscate interior",
+    "content": "Imports all of Mathlib (gallery convention) and defines `sublevel f = {z : ‖f z‖ < 1}`, the open sublevel set whose inscribed discs measure $\\rho(f)$. The strict inequality makes it open (preimage of $[0,1)$ under the continuous $\\|f\\|$), which matters for the boundary-bridge argument below.",
+    "mathContext": "$\\mathrm{sublevel}(f) = \\{z \\in \\mathbb{C} : |f(z)| < 1\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["sublevel set", "lemniscate", "open set"],
+    "prerequisites": ["sets in Lean", "norm of complex numbers"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-cauchy",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 53, "endLine": 64 },
+    "type": "technique",
+    "title": "The Cauchy/Schwarz derivative estimate (unit codomain)",
+    "content": "`norm_deriv_le_inv_of_sphere_le_one` is the analytic core: a function holomorphic on $D(c,r)$, continuous up to the closure, and bounded by 1 on the boundary sphere satisfies $\\|f'(c)\\| \\le 1/r$. It is the $C=1$ specialisation of Mathlib's `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le` — the first Cauchy coefficient bound, equivalent to the Schwarz lemma for the disc. This single derivative bound, with no area content, is the form OQ-03 asks about.",
+    "mathContext": "$\\|f\\|\\le 1$ on $\\partial D(c,r) \\;\\Rightarrow\\; \\|f'(c)\\| \\le \\tfrac{1}{r}$",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy estimates", "Schwarz lemma", "holomorphic functions"],
+    "prerequisites": ["Cauchy's integral formula", "DiffContOnCl"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-bridge",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 66, "endLine": 82 },
+    "type": "technique",
+    "title": "Boundary bridge: open < 1 passes to closed ≤ 1",
+    "content": "`norm_le_one_on_closedBall` upgrades the strict bound on the open disc to the non-strict bound on the closed disc, supplying the boundary-sphere hypothesis the Cauchy estimate needs. Since $\\{w : \\|f w\\| \\le 1\\}$ is closed (preimage of $(-\\infty,1]$ under continuous $\\|f\\|$) and contains the open ball, it contains the ball's closure; `closure_ball` (valid as $r \\ne 0$) identifies that closure with the closed ball. A neat use of topological closedness to convert $<$ into $\\le$ on the boundary.",
+    "mathContext": "$D(c,r)\\subseteq\\{|f|<1\\} \\;\\Rightarrow\\; \\overline{D}(c,r)\\subseteq\\{|f|\\le 1\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["closure", "closed sets", "continuity", "boundary behaviour"],
+    "prerequisites": ["topology of metric spaces", "closure_ball"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-inscribed-deriv",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 84, "endLine": 94 },
+    "type": "concept",
+    "title": "Inscribed-disc estimate (derivative form)",
+    "content": "`inscribed_ball_norm_deriv_le` assembles the two previous lemmas: for entire $f$, if $D(c,r)$ is inscribed in $\\{|f|<1\\}$ then $\\|f'(c)\\| \\le 1/r$. Entirety gives `DiffContOnCl` on every ball, and the boundary bridge feeds `sphere_subset_closedBall` into the sphere hypothesis. This is the conformal estimate for a genuine inscribed disc.",
+    "mathContext": "$D(c,r)\\subseteq\\{|f|<1\\},\\ f \\text{ entire} \\;\\Rightarrow\\; \\|f'(c)\\| \\le \\tfrac1r$",
+    "significance": "key",
+    "relatedConcepts": ["entire functions", "inscribed disc", "derivative bound"],
+    "prerequisites": ["differentiability over ℂ"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-radius",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 96, "endLine": 113 },
+    "type": "insight",
+    "title": "Radius form: r ≤ 1/‖f'(c)‖ — the direct conformal estimate",
+    "content": "`inscribed_radius_le_inv_norm_deriv` inverts the derivative bound into a bound on the inscribed radius: when $f'(c) \\ne 0$, $r \\le 1/\\|f'(c)\\|$. The conversion uses `le_div_iff₀` (with $\\|f'(c)\\|>0$) and a short `calc`: $r\\|f'(c)\\| \\le r\\cdot(1/r) = 1$. This is the headline 'direct conformal mapping estimate' of OQ-03 — bounding the inscribed radius purely from the derivative, with no area input. The flip side: a large derivative at $c$ forbids a large inscribed disc centred there.",
+    "mathContext": "$f'(c)\\ne 0 \\;\\Rightarrow\\; r \\le \\dfrac{1}{\\|f'(c)\\|}$",
+    "significance": "key",
+    "relatedConcepts": ["inscribed radius", "reciprocal derivative bound", "division inequalities"],
+    "prerequisites": ["ordered field inequalities"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-rootpoly",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 115, "endLine": 141 },
+    "type": "technique",
+    "title": "Specialisation to a monic polynomial",
+    "content": "`rootPoly roots = z ↦ ∏ᵢ (z - rootsᵢ)` is the monic polynomial of the Erdős setting; `rootPoly_differentiable` shows it is entire via `fun_prop` (a finite product of differentiable factors). `polynomial_inscribed_radius_le_inv_norm_deriv` then specialises the radius bound verbatim to this $f$, since the general theorem only needed entirety. This connects the abstract estimate to the actual lemniscate of a root polynomial.",
+    "mathContext": "$f(z)=\\prod_{i}(z-z_i)$ entire $\\;\\Rightarrow\\; r \\le 1/\\|f'(c)\\|$ on inscribed discs.",
+    "significance": "supporting",
+    "relatedConcepts": ["monic polynomials", "fun_prop", "finite products"],
+    "prerequisites": ["polynomial functions", "differentiability of products"]
+  },
+  {
+    "id": "erdos1039-oq03-ann-obstruction",
+    "proofId": "erdos-1039-oq-03",
+    "range": { "startLine": 143, "endLine": 165 },
+    "type": "insight",
+    "title": "The critical-point obstruction — why the conformal route stalls",
+    "content": "`conformal_estimate_vacuous_at_critical_point` exhibits the limitation as a theorem. The witness $f \\equiv 0$ has sublevel set all of $\\mathbb{C}$ (every disc inscribed) yet $f' \\equiv 0$, so the radius bound becomes $r \\le 1/0 = 0$ (Lean junk value) — false for $r>0$. This certifies that the $f'(c)\\ne 0$ hypothesis is genuinely necessary. Because the extremal inscribed disc of a real lemniscate tends to sit near a critical point where $f$ is flat, the direct conformal estimate carries no information exactly where it is needed — the structural reason KLR fall back on the area approach. The degeneracy is *proved*, not informally argued.",
+    "mathContext": "$f\\equiv 0:\\ \\{|f|<1\\}=\\mathbb{C},\\ f'(c)=0 \\;\\Rightarrow\\; r \\le 1/0 = 0$ false.",
+    "significance": "key",
+    "relatedConcepts": ["critical points", "vacuous bounds", "counterexample witness", "junk values"],
+    "prerequisites": ["critical points of holomorphic maps"]
+  }
+]

--- a/src/data/proofs/erdos-1039-oq-03/meta.json
+++ b/src/data/proofs/erdos-1039-oq-03/meta.json
@@ -134,7 +134,8 @@
     "keyInsights": [
       "**The conformal estimate is the Cauchy/Schwarz derivative bound**: a disc inscribed in {|f| < 1} maps into the unit disc, so the first Cauchy coefficient gives |f'(c)| ≤ 1/r — a derivative bound with no area content, the form oq-03 asks about",
       "**Radius from derivative**: equivalently r ≤ 1/|f'(c)|, so large derivative at a point forbids a large inscribed disc centred there",
-      "**The obstruction is critical points**: the bound is vacuous wherever f'(c) = 0, and the extremal inscribed disc of a lemniscate tends to sit at a flat saddle of f — so the direct conformal estimate cannot by itself bound ρ(f), explaining why KLR resort to the area approach"
+      "**The obstruction is critical points**: the bound is vacuous wherever f'(c) = 0, and the extremal inscribed disc of a lemniscate tends to sit at a flat saddle of f — so the direct conformal estimate cannot by itself bound ρ(f), explaining why KLR resort to the area approach",
+      "**The degeneracy is witnessed, not merely asserted**: the constant f ≡ 0 has sublevel set all of ℂ (so discs of every radius are inscribed) yet f' ≡ 0, turning the bound into the false r ≤ 0 — a concrete certificate that the f'(c) ≠ 0 hypothesis is necessary and the conformal route carries no information at a critical centre, so the limitation of OQ-03's approach is proved rather than informally argued"
     ],
     "prerequisites": [
       "The lemniscate interior {z : |f(z)| < 1} and the inscribed-disc radius ρ(f)",


### PR DESCRIPTION
Enrichment pass for `erdos-1039-oq-03` (the conformal-mapping route to bounding $\rho(f)$; parent OPEN).

## Gaps addressed
- **No `annotations.json`** — added the full inline annotation layer.
- `keyInsights` had only 3 (target 4-5) — added a 4th.

## Changes
- Added `annotations.json` with **8 line-anchored annotations** across the whole file (header → `sublevel` → Cauchy/Schwarz core → boundary bridge → inscribed-disc derivative/radius forms → monic-polynomial specialisation → critical-point obstruction).
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Added a 4th `keyInsight`: the degeneracy at a critical centre is *witnessed* (by $f\equiv 0$), not merely asserted.

## Verification
- JSON validated; `pnpm build` passes.
- status/badge/axiomCount (verified/original/0) unchanged and consistent with the Lean source; the OPEN parent is not claimed resolved.