### PR TITLE
Enrich Schur's Lemma scalar form (schur-lemma-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/schur-lemma-oq-01/annotations.json
+++ b/src/data/proofs/schur-lemma-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "schur-oq01-header",
+    "proofId": "schur-lemma-oq-01",
+    "range": { "startLine": 6, "endLine": 48 },
+    "type": "context",
+    "title": "Three layers of Schur's Lemma, and the gap this fills",
+    "content": "Schur's Lemma (Schur, 1905) is the rigidity cornerstone of representation theory, in three classical layers: (1) the **dichotomy** — a homomorphism between simple modules is an isomorphism or zero; (2) the **division ring** structure on a simple module's endomorphism ring; and (3) the **scalar form** — over an algebraically closed field, every endomorphism of a finite-dimensional irreducible representation is multiplication by a scalar. Mathlib has (1) and (2) (`LinearMap.bijective_or_eq_zero`, `Module.End.instDivisionRing`) and proves (3) only abstractly in the 𝕜-linear category setting and for `FDRep`. This entry derives the concrete module-language scalar form used in character theory, assembled from Mathlib's eigenvalue theory plus the dichotomy.",
+    "mathContext": "$f \\in \\mathrm{End}_A(M),\\ k \\text{ alg. closed} \\implies \\exists c \\in k,\\ f = c\\cdot\\mathrm{id}$",
+    "significance": "context",
+    "relatedConcepts": ["Schur's Lemma", "irreducible representations", "simple modules", "character theory"],
+    "prerequisites": ["modules and simple modules", "algebraically closed fields", "eigenvalues"]
+  },
+  {
+    "id": "schur-oq01-dichotomy",
+    "proofId": "schur-lemma-oq-01",
+    "range": { "startLine": 54, "endLine": 87 },
+    "type": "theorem",
+    "title": "Layers 1 & 2: dichotomy, iso-upgrade, orthogonality, division ring",
+    "content": "The module-theoretic half of Schur's lemma, valid over any ring, re-exported so the full picture is in one file. `hom_bijective_or_zero`: a hom between simples is bijective or zero (Mathlib's `bijective_or_eq_zero`). `homEquivOfNeZero`: a nonzero hom upgrades to a linear isomorphism M ≃ₗ N. `hom_eq_zero_of_not_linearEquiv`: between non-isomorphic simples the only hom is zero (the orthogonality form). `endDivisionRing`: End(M) of a simple module is a division ring.",
+    "mathContext": "$f : M \\to N \\text{ simples} \\implies f \\text{ bijective} \\vee f = 0;\\quad \\mathrm{End}_R(M) \\text{ a division ring}$",
+    "significance": "supporting",
+    "relatedConcepts": ["LinearMap.bijective_or_eq_zero", "division ring", "orthogonality", "simple modules"],
+    "prerequisites": ["simple modules over a ring"]
+  },
+  {
+    "id": "schur-oq01-scalar",
+    "proofId": "schur-lemma-oq-01",
+    "range": { "startLine": 90, "endLine": 128 },
+    "type": "theorem",
+    "title": "schur_endomorphism_scalar: the eigenvalue argument",
+    "content": "The headline (the genuinely new content): over an algebraically closed field k, every A-linear endomorphism f of a finite-dimensional simple A-module M is multiplication by a scalar, ∃ c, ∀ m, f m = c • m. The classical eigenvalue proof: view f as a k-linear map g = `f.restrictScalars k`; since k is algebraically closed, M finite-dimensional and nonzero (`IsSimpleModule.nontrivial`), `Module.End.exists_eigenvalue` gives an eigenvalue c with eigenvector v ≠ 0 (g v = c • v). Then h = f − c•id is A-linear and kills v, so it is *not injective*; by the dichotomy (`bijective_or_eq_zero`) a non-injective endomorphism of a simple module is 0, hence f m = c • m. Algebraic closure enters exactly once — as the eigenvalue — which is precisely why the scalar form fails over ℝ.",
+    "mathContext": "$g v = c\\cdot v,\\ v \\ne 0 \\implies (f - c\\cdot\\mathrm{id}) \\text{ not injective} \\implies f - c\\cdot\\mathrm{id} = 0$",
+    "significance": "key",
+    "relatedConcepts": ["Module.End.exists_eigenvalue", "restrictScalars", "eigenvectors", "Schur dichotomy"],
+    "prerequisites": ["existence of an eigenvalue over an algebraically closed field", "restriction of scalars", "the dichotomy"]
+  },
+  {
+    "id": "schur-oq01-eqsmul",
+    "proofId": "schur-lemma-oq-01",
+    "range": { "startLine": 130, "endLine": 139 },
+    "type": "theorem",
+    "title": "schur_endomorphism_eq_smul_id: absolute simplicity",
+    "content": "`schur_endomorphism_eq_smul_id` repackages the scalar form as an equality of linear maps, f = c • LinearMap.id (by `ext` + `simpa` on `schur_endomorphism_scalar`). This is the 'absolute simplicity' statement: the endomorphism algebra of M is exactly k·id ≅ k. Over an algebraically closed field every simple module is therefore absolutely simple — the fact that makes the centre of a group algebra act by scalars on each irreducible.",
+    "mathContext": "$\\mathrm{End}_A(M) = k\\cdot\\mathrm{id} \\cong k$",
+    "significance": "key",
+    "relatedConcepts": ["absolute simplicity", "endomorphism algebra", "centre of a group algebra"],
+    "prerequisites": ["the scalar form headline"]
+  },
+  {
+    "id": "schur-oq01-categorical",
+    "proofId": "schur-lemma-oq-01",
+    "range": { "startLine": 141, "endLine": 185 },
+    "type": "theorem",
+    "title": "Categorical and FDRep forms",
+    "content": "For completeness the abstract packagings are re-exported. `categorical_endomorphism_scalar`: in a 𝕜-linear category with finite-dimensional hom-spaces over an algebraically closed field, every endomorphism of a simple object is a scalar multiple of the identity (`endomorphism_simple_eq_smul_id`). `fdRep_finrank_hom_simple_simple`: over an algebraically closed field, dim Hom(V,W) between irreducible finite-dimensional representations is 1 if V ≅ W and 0 otherwise — the hom-space dimension count behind the orthogonality relations.",
+    "mathContext": "$\\dim_k \\mathrm{Hom}(V, W) = \\begin{cases}1 & V \\cong W\\\\ 0 & \\text{else}\\end{cases}$",
+    "significance": "supporting",
+    "relatedConcepts": ["CategoryTheory.endomorphism_simple_eq_smul_id", "FDRep", "hom-space dimension", "orthogonality relations"],
+    "prerequisites": ["𝕜-linear categories", "finite-dimensional representations"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `schur-lemma-oq-01` (the module-language scalar form of Schur's Lemma).

This entry had a rich `meta.json` (with references) but no `annotations.json`. Added 5 inline annotations covering the full Lean file:

- **Three-layers framing** — dichotomy, division ring, scalar form; the gap Mathlib leaves.
- **Dichotomy & division ring** — re-exports of the over-any-ring half.
- **schur_endomorphism_scalar** — the eigenvalue argument (alg. closure enters once).
- **schur_endomorphism_eq_smul_id** — absolute simplicity, End(M) ≅ k.
- **Categorical & FDRep forms** — re-exports of the abstract packagings.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`. Line-annotation resolver: **5 valid, 0 misaligned**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)