### PR TITLE
Enrich Erdős #978 OQ-01 local square obstruction (erdos-978-oq-01)

### DIFF
--- a/src/data/proofs/erdos-978-oq-01/annotations.json
+++ b/src/data/proofs/erdos-978-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "erdos978-oq01-ann-header",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Erdős #978 OQ-01: scope and why the conjecture is open",
+    "content": "Erdős asked whether $n^4 + 2$ takes infinitely many squarefree values — the $k=4$, $(k-2)$-power-free case of #978. This is OPEN: it lies below the range $k \\ge 9$ reached by Heath-Brown (2006) and Browning (2011), and a squarefree square-sieve for a quartic is beyond current technology (Hooley 1967 gives only the cubefree $k-1$ result). So the file does NOT target the conjecture; it formalises the two finite, self-contained local conditions the standard squarefree heuristic rests on — no global square obstruction, and the explicit dominant obstruction at $p=3$.",
+    "mathContext": "Local density heuristic: $C = \\prod_p \\big(1 - \\rho(p^2)/p^2\\big)$, $\\;\\rho(p^2) = \\#\\{n : p^2 \\mid n^4+2\\}$.",
+    "significance": "context",
+    "relatedConcepts": ["squarefree numbers", "Erdős problems", "square sieve", "local densities"],
+    "prerequisites": ["squarefree integers", "analytic number theory heuristics"]
+  },
+  {
+    "id": "erdos978-oq01-ann-def",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 39, "endLine": 47 },
+    "type": "definition",
+    "title": "Imports and the polynomial F",
+    "content": "Imports `Mathlib.Tactic` and `Mathlib.Data.ZMod.Basic` (the finite-ring machinery used for the mod-9 analysis), opens `Finset` for the cardinality counts, and defines $F(n) = n^4 + 2$ over $\\mathbb{Z}$. Everything downstream studies divisibility of $F$ by squares.",
+    "mathContext": "$F : \\mathbb{Z} \\to \\mathbb{Z}, \\quad F(n) = n^4 + 2$",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod", "integer polynomials"],
+    "prerequisites": ["Lean definitions", "Mathlib"]
+  },
+  {
+    "id": "erdos978-oq01-ann-fzero",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 49, "endLine": 57 },
+    "type": "technique",
+    "title": "The cheap witness F 0 = 2",
+    "content": "Part I rules out a *global* square obstruction. The key observation is the cheapest possible one: $F(0) = 2$, recorded as the `@[simp]` lemma `F_zero`. Since $2$ is squarefree, no square $> 1$ can divide every value — the witness $n=0$ already breaks any candidate.",
+    "mathContext": "$F(0) = 0^4 + 2 = 2$",
+    "significance": "supporting",
+    "relatedConcepts": ["squarefree witness", "simp lemmas"],
+    "prerequisites": ["evaluation"]
+  },
+  {
+    "id": "erdos978-oq01-ann-nofixedsquare",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 59, "endLine": 69 },
+    "type": "insight",
+    "title": "No fixed square divides every value",
+    "content": "`no_fixed_square_obstruction`: for any $m > 1$ there is an $n$ with $m^2 \\nmid F(n)$ — namely $n = 0$. If $m^2 \\mid 2$ then $m^2 \\le 2$ (by `Int.le_of_dvd`), but $m \\ge 2$ forces $m^2 \\ge 4$, a contradiction closed by `nlinarith` with $\\;(m-2)^2 \\ge 0$. This shuts the trivial 'answer is NO' route: there is no fixed square making $n^4+2$ never squarefree, so $\\rho(p^2) < p^2$ for every prime.",
+    "mathContext": "$\\forall m>1,\\ \\exists n:\\ m^2 \\nmid F(n)$; \\; $m^2 \\mid 2 \\Rightarrow m^2 \\le 2 < 4 \\le m^2$.",
+    "significance": "key",
+    "relatedConcepts": ["global obstruction", "divisibility bounds", "nlinarith"],
+    "prerequisites": ["divisibility in ℤ", "Int.le_of_dvd"]
+  },
+  {
+    "id": "erdos978-oq01-ann-zmod9",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 71, "endLine": 79 },
+    "type": "technique",
+    "title": "The mod-9 root structure, decided in the kernel",
+    "content": "Part II pins down the dominant local obstruction at $p=3$. Over the finite ring $\\mathbb{Z}/9\\mathbb{Z}$, `zmod_nine_root_iff` shows $n^4 + 2 = 0$ holds for exactly $n = 2$ and $n = 7$, proved by `decide +revert` — a finite kernel computation over the nine residues (no `native_decide`, so it stays axiom-free). $p=3$ is the smallest prime where $x^4 \\equiv -2 \\pmod 9$ is solvable and the leading term of the local density product.",
+    "mathContext": "$n^4 + 2 \\equiv 0 \\pmod 9 \\iff n \\equiv 2 \\text{ or } 7 \\pmod 9$",
+    "significance": "key",
+    "relatedConcepts": ["ZMod 9", "decide tactic", "quartic residues"],
+    "prerequisites": ["modular arithmetic", "decidable propositions"]
+  },
+  {
+    "id": "erdos978-oq01-ann-ninedvd",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 81, "endLine": 88 },
+    "type": "technique",
+    "title": "Lifting the obstruction from ZMod 9 to ℤ",
+    "content": "`nine_dvd_iff` transports the finite-ring fact to the integers: $9 \\mid F(n) \\iff (n : \\mathbb{Z}/9) = 2 \\lor (n:\\mathbb{Z}/9) = 7$. The bridge is `ZMod.intCast_zmod_eq_zero_iff_dvd` (an integer is divisible by 9 iff its image in $\\mathbb{Z}/9$ is zero), after `push_cast` aligns the polynomial casts, finished by `tauto`. This is the reusable pattern: decide a divisibility over the finite quotient, then lift.",
+    "mathContext": "$9 \\mid F(n) \\iff (n \\bmod 9) \\in \\{2, 7\\}$",
+    "significance": "supporting",
+    "relatedConcepts": ["intCast", "ZMod-to-ℤ lifting", "divisibility"],
+    "prerequisites": ["ring homomorphism ℤ → ZMod n"]
+  },
+  {
+    "id": "erdos978-oq01-ann-counts",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 90, "endLine": 103 },
+    "type": "insight",
+    "title": "ρ(9) = 2: two obstructed, seven safe residues",
+    "content": "The local density at $p=3$ is computed exactly: `obstructed_card` shows 2 of the 9 residues satisfy $n^4+2 \\equiv 0$, and `safe_card` shows the complementary 7 are 'safe' — both by `decide`. The positive proportion $7/9 > 0$ is precisely what the squarefree heuristic requires at $p=3$. `nine_dvd_F_two` ($F(2)=18=2\\cdot 3^2$) and `nine_dvd_F_seven` ($F(7)=2403=3^3\\cdot 89$) confirm the obstruction is non-vacuous on both classes.",
+    "mathContext": "$\\rho(9) = 2, \\quad 1 - \\rho(9)/9 = 7/9 > 0$",
+    "significance": "key",
+    "relatedConcepts": ["local density", "residue counting", "Finset.filter cardinality"],
+    "prerequisites": ["counting in ZMod", "decide"]
+  },
+  {
+    "id": "erdos978-oq01-ann-infinite",
+    "proofId": "erdos-978-oq-01",
+    "range": { "startLine": 105, "endLine": 123 },
+    "type": "insight",
+    "title": "Infinitely many values escape the p=3 square",
+    "content": "Part III turns the residue analysis into an infinitude statement. Since the obstructed classes are $2, 7 \\pmod 9$ and $0 \\notin \\{2,7\\}$, every multiple of 9 gives $9 \\nmid F(n)$. `infinitely_many_nine_safe`: for any bound $N$, the explicit $n = 9(|N|+1) > N$ has image $0$ in $\\mathbb{Z}/9$ (via `intCast_zmod_eq_zero_iff_dvd` and `dvd_mul_right`), so `nine_dvd_iff` plus a final `decide` (since $0 \\ne 2,7$) shows it escapes. Infinitely many $n$ avoid the dominant local square — a necessary condition for the heuristic, though not the full conjecture.",
+    "mathContext": "$\\forall N,\\ \\exists n>N:\\ 9 \\nmid F(n)$; \\; take $n = 9(|N|+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["infinitude", "explicit witness", "arithmetic progressions"],
+    "prerequisites": ["divisibility", "ZMod casts"]
+  }
+]

--- a/src/data/proofs/erdos-978-oq-01/meta.json
+++ b/src/data/proofs/erdos-978-oq-01/meta.json
@@ -78,6 +78,14 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header, Imports, and the Polynomial F",
+      "summary": "Frames Erdős #978 OQ-01 (is n⁴+2 squarefree infinitely often?), explains why the conjecture is OPEN and out of reach, scopes the two finite local conditions actually formalized, imports Mathlib.Tactic and ZMod.Basic, and defines F n = n⁴ + 2.",
+      "startLine": 1,
+      "endLine": 47,
+      "mathContext": "F(n) = n⁴ + 2; the k=4 (k−2)-power-free case of Erdős #978, OPEN."
+    },
+    {
       "id": "no-fixed-square",
       "title": "No Fixed Square Obstruction",
       "summary": "For every m>1 some value n⁴+2 is not divisible by m² (witness n=0, value 2); ρ(p²)<p² for all primes p.",


### PR DESCRIPTION
Enrichment pass for `erdos-978-oq-01` (local square-obstruction structure of $n^4+2$; parent conjecture OPEN).

## Gaps addressed
- **No `annotations.json`** — added the full inline annotation layer.
- `sections` started at line 49, leaving the module header (1-47) uncovered — added a header section.

## Changes
- Added `annotations.json` with **8 line-anchored annotations** across the whole file (header → `F` def → `F_zero` witness → no-global-square → mod-9 `decide` root structure → ZMod→ℤ lift → $\rho(9)=2$ density counts → infinitude of safe values).
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- Added a `module-header` section so `sections` now cover lines 1-47.

## Verification
- JSON validated; `pnpm build` passes.
- status/badge/axiomCount (verified/verified/0) unchanged. Note: the file uses kernel `decide` over `ZMod 9` (not `native_decide`), so it is genuinely axiom-free; the OPEN parent conjecture is not claimed resolved.