### PR TITLE
Enrich Cassini's identity (fibonacci-identities-oq-01)

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "fib-oq01-ann-header",
+    "proofId": "fibonacci-identities-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Cassini's identity: the ±1 Fibonacci determinant",
+    "content": "The docstring states Cassini's identity $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$ over $\\mathbb{Z}$, equivalently the index-shifted $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$. It says the $2\\times 2$ determinant $\\begin{vmatrix} F_{n+1} & F_n \\\\ F_n & F_{n-1}\\end{vmatrix}$ of three consecutive Fibonacci numbers is always $\\pm 1$ — the product of the outer two differs from the middle's square by exactly one, with an alternating sign. Worked examples for $n=1,\\dots,4$ confirm the pattern. The identity is named after Giovanni Domenico Cassini (1680).",
+    "mathContext": "$F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$; \\; $\\det\\begin{psmallmatrix}1&1\\\\1&0\\end{psmallmatrix}^n = (-1)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Fibonacci numbers", "Cassini's identity", "determinant", "alternating sign"],
+    "prerequisites": ["Fibonacci recurrence", "integers"]
+  },
+  {
+    "id": "fib-oq01-ann-approach",
+    "proofId": "fibonacci-identities-oq-01",
+    "range": { "startLine": 25, "endLine": 51 },
+    "type": "technique",
+    "title": "Strategy: induction cast to ℤ, single linear_combination",
+    "content": "The proof is pure induction on $n$, cast to $\\mathbb{Z}$ so the alternating sign $(-1)^{n+1}$ makes sense. The recurrence `Nat.fib_add_two` ($F_{n+2}=F_n+F_{n+1}$), cast to $\\mathbb{Z}$, rewrites the three consecutive terms at the successor step, and a single `linear_combination` against the induction hypothesis closes the algebra. The structural heart: the determinant simply *negates* each step, $F_{n+2}F_n - F_{n+1}^2 = -(F_{n+3}F_{n+1} - F_{n+2}^2)$, which is exactly the sign flip $(-1)^{n+1}\\to(-1)^{n+2}$. No `decide`/`native_decide`, so the headline is axiom-free.",
+    "mathContext": "Sign flip per step: $D_{n+1} = -D_n$ where $D_n = F_{n+2}F_n - F_{n+1}^2$.",
+    "significance": "key",
+    "relatedConcepts": ["induction", "linear_combination", "telescoping sign"],
+    "prerequisites": ["mathematical induction", "Nat→ℤ casts"]
+  },
+  {
+    "id": "fib-oq01-ann-cassini",
+    "proofId": "fibonacci-identities-oq-01",
+    "range": { "startLine": 53, "endLine": 71 },
+    "type": "definition",
+    "title": "fib_cassini — the headline theorem and its inductive step",
+    "content": "`fib_cassini` proves $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$. The base case $n=0$ is `norm_num` on $F_0,F_1,F_2$. The successor step casts the recurrence twice (`e2` for $F_{k+2}$, `e3` for $F_{k+3}$), uses `show` to put the goal in $k+3 / k+2$ form (definitionally equal to $k+1$'s statement), rewrites the IH and goal via the recurrences and `pow_succ`, then discharges with `linear_combination (-1) * ih`. The coefficient $-1$ encodes the per-step sign flip.",
+    "mathContext": "$F_{(k+1)+2}F_{k+1} - F_{(k+1)+1}^2 = (-1)^{k+2} = -(-1)^{k+1}$",
+    "significance": "key",
+    "relatedConcepts": ["Fibonacci recurrence", "pow_succ", "induction hypothesis"],
+    "prerequisites": ["Nat.fib_add_two", "linear_combination tactic"]
+  },
+  {
+    "id": "fib-oq01-ann-shift",
+    "proofId": "fibonacci-identities-oq-01",
+    "range": { "startLine": 73, "endLine": 82 },
+    "type": "technique",
+    "title": "fib_cassini_shift — the index-shifted form",
+    "content": "`fib_cassini_shift` restates the identity as $F_n F_{n+2} - F_{n+1}^2 = (-1)^{n+1}$, the classical $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$ written on $n+1$ to avoid natural-number subtraction. It follows from `fib_cassini` by a one-line `linear_combination` (the two sides differ only by commuting the product $F_{n+2}F_n = F_n F_{n+2}$).",
+    "mathContext": "$F_n F_{n+2} - F_{n+1}^2 = (-1)^{n+1}$, i.e. $F_{n-1}F_{n+1} - F_n^2 = (-1)^n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["index shift", "ℕ subtraction avoidance"],
+    "prerequisites": ["commutativity of multiplication"]
+  },
+  {
+    "id": "fib-oq01-ann-abs",
+    "proofId": "fibonacci-identities-oq-01",
+    "range": { "startLine": 84, "endLine": 90 },
+    "type": "insight",
+    "title": "fib_cassini_abs — the unsigned ±1 statement",
+    "content": "`fib_cassini_abs` records the sign-free consequence $|F_{n+2}F_n - F_{n+1}^2| = 1$: consecutive Fibonacci determinants always have absolute value exactly 1. Proved by rewriting with `fib_cassini` then `abs_pow` and `simp` (since $|-1|=1$). This is the form most often quoted, and the source of the corollary that consecutive Fibonacci numbers are coprime.",
+    "mathContext": "$\\big|F_{n+2}F_n - F_{n+1}^2\\big| = |(-1)^{n+1}| = 1$",
+    "significance": "supporting",
+    "relatedConcepts": ["absolute value", "coprimality of consecutive Fibonacci numbers"],
+    "prerequisites": ["abs of powers"]
+  },
+  {
+    "id": "fib-oq01-ann-examples",
+    "proofId": "fibonacci-identities-oq-01",
+    "range": { "startLine": 91, "endLine": 98 },
+    "type": "context",
+    "title": "Concrete examples of the first determinants",
+    "content": "Four `decide`-checked examples instantiate the identity at $n=1,\\dots,4$, giving $1, -1, 1, -1$ — confirming both the $\\pm 1$ magnitude and the alternation. These are `example`s (not exported lemmas), serving as sanity checks; their `decide` use is local and does not affect the axiom status of the exported theorems.",
+    "mathContext": "$F_3F_1-F_2^2=1,\\ F_4F_2-F_3^2=-1,\\ F_5F_3-F_4^2=1,\\ F_6F_4-F_5^2=-1.$",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "decide"],
+    "prerequisites": ["Fibonacci values"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `fibonacci-identities-oq-01` (Cassini's identity $F_{n+2}F_n - F_{n+1}^2 = (-1)^{n+1}$).

## Gap addressed
Rich `meta.json` but **no `annotations.json`**.

## Changes
- Added `annotations.json` with **6 line-anchored annotations** spanning the file (header/determinant framing → induction strategy → `fib_cassini` → shifted form → absolute-value form → examples).
- Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- JSON validated; `pnpm build` passes. status/badge/axiomCount (verified/mathlib/0) unchanged.