### PR TITLE
Fix non-compiling erdos-1040-oq-03-oq-01 (mul_lt_mul orientation → sorryAx)

### DIFF
--- a/proofs/Proofs/Erdos1040OQ03OQ01.lean
+++ b/proofs/Proofs/Erdos1040OQ03OQ01.lean
@@ -116,7 +116,8 @@ theorem volume_lem_purePower_lt_degree_bound (c : ℂ) {n : ℕ} (hn : 2 ≤ n) 
   calc (NNReal.pi : ℝ≥0∞)
       = 1 * (NNReal.pi : ℝ≥0∞) := (one_mul _).symm
     _ < (n : ℝ≥0∞) * (NNReal.pi : ℝ≥0∞) :=
-        ENNReal.mul_lt_mul_right
+        -- `mul_lt_mul_left` keeps the RIGHT factor (π) fixed: `b * a < c * a` from `b < c`
+        ENNReal.mul_lt_mul_left
           (ENNReal.coe_ne_zero.mpr NNReal.pi_ne_zero) ENNReal.coe_ne_top hone
 
 /-- **Capstone.** The pure power `(z - c)^n` exhibits, simultaneously and for every


### PR DESCRIPTION
## Integrity Issue (CRITICAL — proof depended on sorryAx, claimed verified)

**Proof**: `erdos-1040-oq-03-oq-01` (The Pure-Power Lemniscate: a Sharp π-Area Witness)
**Problem**: Published as `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0` — but the Lean file **did not compile** on Mathlib v4.26.0, and the capstone theorem silently depended on **`sorryAx`**.

## Evidence

`lake env lean Proofs/Erdos1040OQ03OQ01.lean`:

```
Proofs/Erdos1040OQ03OQ01.lean:119:8: error: Type mismatch
  ENNReal.mul_lt_mul_right (…) ENNReal.coe_ne_top hone
has type      ↑NNReal.pi * 1 < ↑NNReal.pi * ↑n
but is expected to have type   1 * ↑NNReal.pi < ↑n * ↑NNReal.pi
```

In v4.26.0 the ENNReal lemmas are oriented opposite to their names:
- `ENNReal.mul_lt_mul_right (h0) (hinf) (b<c) : a * b < a * c`  *(fixes the **left** factor)*
- `ENNReal.mul_lt_mul_left  (h0) (hinf) (b<c) : b * a < c * a`  *(fixes the **right** factor)*

The calc goal `1 * π < n * π` keeps π fixed on the **right**, so it needs `mul_lt_mul_left`. With the wrong lemma the step fails to elaborate, and `#print axioms` confirmed the fallout:

```
purePower_sharp_witness depends on axioms: [propext, sorryAx, Classical.choice, Quot.sound]
```

`sorryAx` in a proof advertised as `verified` / `0 sorries` is the most serious class of integrity defect.

## Fix

One token: `ENNReal.mul_lt_mul_right` → `ENNReal.mul_lt_mul_left` (same hypotheses), plus a clarifying comment.

## Verification

`lake env lean` exit 0; `#print axioms` after the fix:

```
lem_purePower_eq_ball                  [propext, Classical.choice, Quot.sound]
volume_lem_purePower_lt_degree_bound   [propext, Classical.choice, Quot.sound]
purePower_sharp_witness                [propext, Classical.choice, Quot.sound]
```

No `sorryAx`. The `verified` / `original` / `0 sorries` claims are now accurate. The mathematical content and narrative (honest about the Pólya lower bound and the parent's axiomatized answers) are unchanged.

---
Discovered during gallery integrity audit.