### PR TITLE
Enrich exponent of a group of order p² (group-order-prime-squared-abelian-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json
+++ b/src/data/proofs/group-order-prime-squared-abelian-oq-01-oq-01/meta.json
@@ -82,6 +82,14 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 41,
+      "summary": "Docstring reframing the parent's cyclic/elementary-abelian dichotomy through the single invariant Monoid.exponent G, stating exponent = p² ⟺ cyclic and exponent = p ⟺ non-cyclic; imports Mathlib and the parent file, opens its namespace, and fixes a group variable G.",
+      "mathContext": "exponent G = p² ⟺ G ≅ ℤ/p²; exponent G = p ⟺ G ≅ (ℤ/p)²."
+    },
+    {
       "id": "helpers",
       "title": "Finiteness and Nontriviality",
       "startLine": 42,


### PR DESCRIPTION
Enrichment pass for `group-order-prime-squared-abelian-oq-01-oq-01` (the exponent as a sharp invariant: $\mathrm{exp}\,G=p^2 \iff$ cyclic, $=p \iff$ elementary abelian).

## Gaps addressed
- **No `annotations.json`** — added the full inline annotation layer.
- `sections` started at line 42 — added a module-header section (1-41).

## Changes
- Added `annotations.json` with **8 line-anchored annotations** (header → imports → finiteness/nontriviality helpers → order-exactly-p → cyclic exponent=p² → non-cyclic exponent=p → the p-or-p² dichotomy → the characterising biconditionals).
- Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- Added a `module-header` section.

## Verification
- JSON validated; `pnpm build` passes. status/badge/axiomCount (verified/original/0) unchanged.