### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03): log-concavity of the unit-ball volume sequence

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -152,6 +152,7 @@ import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ01
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01
+import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01OQ03
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ02
 import Proofs.AreaOfCircleOQ01OQ02OQ01OQ03
 import Proofs.AreaOfCircleOQ01OQ02OQ02

--- a/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01OQ03.lean
+++ b/proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01OQ03.lean
@@ -1,0 +1,160 @@
+/-
+  Log-Concavity of the Unit-Ball Volume Sequence ω_n
+  Open Question: area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03
+
+  The ancestors study the *unimodality profile* of the unit n-ball volume
+  ω_n = π^(n/2) / Γ(n/2 + 1): the parent (…-oq-02-oq-01) proves strict
+  unimodality — ω rises strictly to a single peak at n = 5 and falls strictly
+  thereafter within each parity class.  Unimodality is a statement about the
+  *direction* of the increments; it says nothing about how the increments
+  themselves evolve.
+
+  This file proves the sharper *second-order* shape property: **log-concavity**
+  of the sequence,
+
+      ω_{n+1}² ≥ ω_n · ω_{n+2}      for every n,
+
+  equivalently, the ratios ω_{n+1}/ω_n are non-increasing.  Log-concavity is a
+  strictly stronger structural fact than unimodality (every log-concave positive
+  sequence is unimodal, but not conversely), and it is exactly the discrete
+  shadow of the analytic engine behind ω.
+
+  ## The mathematical content: π drops out, Γ log-convexity does the work
+
+  Writing x = n/2, the three relevant volumes are
+      ω_n     = π^x       / Γ(x+1),
+      ω_{n+1} = π^(x+1/2) / Γ(x+3/2),
+      ω_{n+2} = π^(x+1)   / Γ(x+2).
+  Then
+      ω_n · ω_{n+2} = π^(2x+1) / (Γ(x+1) Γ(x+2)),
+      ω_{n+1}²      = π^(2x+1) / Γ(x+3/2)².
+  The powers of π are *identical*, so log-concavity is equivalent to the pure
+  Gamma inequality
+
+      Γ(x + 3/2)² ≤ Γ(x+1) · Γ(x+2).
+
+  This is precisely midpoint log-convexity of Γ: with x+3/2 the midpoint of
+  x+1 and x+2, Mathlib's `Real.Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma`
+  (Hölder/Bohr–Mollerup) gives
+      Γ((x+1)/2 + (x+2)/2) ≤ Γ(x+1)^(1/2) · Γ(x+2)^(1/2),
+  and squaring yields the claim.  So the convexity that singles out Γ among all
+  interpolations of the factorial is exactly what makes the ball-volume sequence
+  log-concave.
+
+  Content (all 0 sorries, 0 axioms beyond Mathlib's foundational triple):
+  * `gamma_sq_le_mul`     — the engine: Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2) for x ≥ 0.
+  * `omega_log_concave`   — the headline: ω_n · ω_{n+2} ≤ ω_{n+1}² (all n).
+  * `omega_sq_ge`         — index form: ω_{n-1}·ω_{n+1} ≤ ω_n² for n ≥ 1.
+  * `omega_ratio_antitone`— the ratios ω_{n+1}/ω_n are non-increasing.
+
+  A *strict* log-concavity (ω_{n+1}² > ω_n·ω_{n+2}) would follow from strict
+  log-convexity of Γ, which Mathlib does not currently expose in midpoint form;
+  we record the non-strict statement, which is the standard "log-concave"
+  property and already implies unimodality.
+
+  References:
+  - AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01.lean (parent: strict unimodality)
+  - Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup (log-convexity of Γ)
+  - https://en.wikipedia.org/wiki/Volume_of_an_n-ball
+-/
+import Proofs.AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01
+
+open Real
+
+noncomputable section
+
+namespace MaxBallVolume
+
+/- ## The Gamma engine: midpoint log-convexity in squared form -/
+
+/-- **Midpoint log-convexity of Γ (squared form).**  For `x ≥ 0`,
+
+        Γ(x + 3/2)² ≤ Γ(x+1) · Γ(x+2).
+
+    Since `x + 3/2 = ½(x+1) + ½(x+2)` is the midpoint of `x+1` and `x+2`, this is
+    Mathlib's multiplicative log-convexity bound
+    `Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma` at weights `½, ½`, squared. -/
+theorem gamma_sq_le_mul {x : ℝ} (hx : 0 ≤ x) :
+    Gamma (x + 3 / 2) ^ 2 ≤ Gamma (x + 1) * Gamma (x + 2) := by
+  have hs : (0 : ℝ) < x + 1 := by linarith
+  have ht : (0 : ℝ) < x + 2 := by linarith
+  have hA : (0 : ℝ) < Gamma (x + 1) := Gamma_pos_of_pos hs
+  have hB : (0 : ℝ) < Gamma (x + 2) := Gamma_pos_of_pos ht
+  have hmid := Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma hs ht
+    (by norm_num : (0 : ℝ) < 1 / 2) (by norm_num : (0 : ℝ) < 1 / 2)
+    (by norm_num : (1 : ℝ) / 2 + 1 / 2 = 1)
+  -- normalise the midpoint argument `½(x+1) + ½(x+2) = x + 3/2`
+  rw [show (1 : ℝ) / 2 * (x + 1) + 1 / 2 * (x + 2) = x + 3 / 2 by ring] at hmid
+  -- square the inequality `Γ(x+3/2) ≤ Γ(x+1)^½ · Γ(x+2)^½`
+  have hmidpos : 0 ≤ Gamma (x + 3 / 2) := (Gamma_pos_of_pos (by linarith)).le
+  have hsq := mul_self_le_mul_self hmidpos hmid
+  -- expand the right-hand square: (A^½ B^½)² = A · B
+  have e1 : Gamma (x + 1) ^ (1 / 2 : ℝ) * Gamma (x + 1) ^ (1 / 2 : ℝ) = Gamma (x + 1) := by
+    rw [← Real.rpow_add hA, show (1 : ℝ) / 2 + 1 / 2 = 1 by norm_num, Real.rpow_one]
+  have e2 : Gamma (x + 2) ^ (1 / 2 : ℝ) * Gamma (x + 2) ^ (1 / 2 : ℝ) = Gamma (x + 2) := by
+    rw [← Real.rpow_add hB, show (1 : ℝ) / 2 + 1 / 2 = 1 by norm_num, Real.rpow_one]
+  have hexpand :
+      (Gamma (x + 1) ^ (1 / 2 : ℝ) * Gamma (x + 2) ^ (1 / 2 : ℝ)) *
+        (Gamma (x + 1) ^ (1 / 2 : ℝ) * Gamma (x + 2) ^ (1 / 2 : ℝ))
+        = Gamma (x + 1) * Gamma (x + 2) := by
+    rw [show (Gamma (x + 1) ^ (1 / 2 : ℝ) * Gamma (x + 2) ^ (1 / 2 : ℝ)) *
+          (Gamma (x + 1) ^ (1 / 2 : ℝ) * Gamma (x + 2) ^ (1 / 2 : ℝ))
+        = (Gamma (x + 1) ^ (1 / 2 : ℝ) * Gamma (x + 1) ^ (1 / 2 : ℝ)) *
+          (Gamma (x + 2) ^ (1 / 2 : ℝ) * Gamma (x + 2) ^ (1 / 2 : ℝ)) by ring,
+      e1, e2]
+  rw [pow_two, ← hexpand]
+  exact hsq
+
+/- ## Log-concavity of the volume sequence -/
+
+/-- **Log-concavity of the unit-ball volume sequence.**  For every `n`,
+
+        ω_n · ω_{n+2} ≤ ω_{n+1}².
+
+    The shared power `π^(2·(n/2)+1)` cancels between the two sides, reducing the
+    statement to `gamma_sq_le_mul` at `x = n/2`. -/
+theorem omega_log_concave (n : ℕ) : ω n * ω (n + 2) ≤ ω (n + 1) ^ 2 := by
+  have hpi : (0 : ℝ) < π := pi_pos
+  -- the shared π-power: π^(n/2) · π^(n/2+1) = (π^(n/2+1/2))²
+  have hP : π ^ ((n : ℝ) / 2) * π ^ ((n : ℝ) / 2 + 1)
+      = (π ^ ((n : ℝ) / 2 + 1 / 2)) ^ 2 := by
+    rw [pow_two, ← Real.rpow_add hpi, ← Real.rpow_add hpi]; congr 1; ring
+  have key := gamma_sq_le_mul (x := (n : ℝ) / 2) (by positivity)
+  unfold ω
+  -- rewrite the (n+1)- and (n+2)-arguments in terms of x = n/2
+  rw [show ((n + 2 : ℕ) : ℝ) / 2 + 1 = (n : ℝ) / 2 + 2 by push_cast; ring,
+      show ((n + 2 : ℕ) : ℝ) / 2 = (n : ℝ) / 2 + 1 by push_cast; ring,
+      show ((n + 1 : ℕ) : ℝ) / 2 + 1 = (n : ℝ) / 2 + 3 / 2 by push_cast; ring,
+      show ((n + 1 : ℕ) : ℝ) / 2 = (n : ℝ) / 2 + 1 / 2 by push_cast; ring]
+  rw [div_mul_div_comm, div_pow,
+      div_le_div_iff₀ (by positivity) (by positivity), hP]
+  exact mul_le_mul_of_nonneg_left key (by positivity)
+
+/-- **Log-concavity, index form.**  For `n ≥ 1`,
+
+        ω_{n-1} · ω_{n+1} ≤ ω_n².
+
+    The shift of `omega_log_concave` to a centred index. -/
+theorem omega_sq_ge {n : ℕ} (hn : 1 ≤ n) : ω (n - 1) * ω (n + 1) ≤ ω n ^ 2 := by
+  obtain ⟨m, rfl⟩ : ∃ m, n = m + 1 := ⟨n - 1, (Nat.succ_pred_eq_of_pos hn).symm⟩
+  simpa using omega_log_concave m
+
+/-- **Antitone volume ratios.**  Log-concavity expressed as monotonicity of the
+    successive ratios: for every `n`,
+
+        ω_{n+2} / ω_{n+1} ≤ ω_{n+1} / ω_n.
+
+    Each `ω` is positive, so this is `omega_log_concave` cross-multiplied. -/
+theorem omega_ratio_antitone (n : ℕ) : ω (n + 2) / ω (n + 1) ≤ ω (n + 1) / ω n := by
+  rw [div_le_div_iff₀ (omega_pos _) (omega_pos _)]
+  have h := omega_log_concave n
+  nlinarith [h, omega_pos n, omega_pos (n + 1), omega_pos (n + 2)]
+
+end MaxBallVolume
+
+end
+
+#check @MaxBallVolume.gamma_sq_le_mul
+#check @MaxBallVolume.omega_log_concave
+#check @MaxBallVolume.omega_sq_ge
+#check @MaxBallVolume.omega_ratio_antitone

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/annotations.json
@@ -1,0 +1,75 @@
+[
+ {
+  "id": "ann-intro",
+  "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "range": {
+   "startLine": 1,
+   "endLine": 71
+  },
+  "type": "concept",
+  "title": "From Unimodality to Log-Concavity",
+  "content": "The parent entry proves the unit n-ball volume ω_n = π^(n/2)/Γ(n/2+1) is strictly unimodal — it rises strictly to a single peak at n=5 and falls strictly afterwards. Unimodality only constrains the SIGN of the increments. This file proves the strictly stronger second-order property: LOG-CONCAVITY, ω_{n+1}² ≥ ω_n·ω_{n+2} for every n. Every positive log-concave sequence is unimodal, but not conversely, so this genuinely sharpens the parent. The crucial observation is that the powers of π are identical on both sides and cancel, leaving a pure statement about the Gamma function.",
+  "mathContext": "Log-concave: ω_n·ω_{n+2} ≤ ω_{n+1}² for all n. With x = n/2, both sides carry π^(2x+1), which cancels, reducing the claim to Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2).",
+  "significance": "Identifies the analytic source of the sequence's shape: log-concavity of ω_n IS midpoint log-convexity of Γ. The convexity that singles out Γ among interpolations of the factorial is exactly what makes the ball-volume sequence log-concave.",
+  "relatedConcepts": [
+   "log-concave sequence",
+   "log-convexity of Gamma",
+   "unimodality",
+   "Bohr–Mollerup theorem"
+  ]
+ },
+ {
+  "id": "ann-gamma-engine",
+  "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "range": {
+   "startLine": 80,
+   "endLine": 110
+  },
+  "type": "technique",
+  "title": "Squaring Mathlib's Log-Convexity Bound",
+  "content": "gamma_sq_le_mul is the whole engine. Mathlib's Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma (Hölder applied to Euler's integral) gives, at weights a=b=½ and points s=x+1, t=x+2, the midpoint bound Γ(x+3/2) ≤ Γ(x+1)^½·Γ(x+2)^½ — because ½(x+1)+½(x+2) = x+3/2. Both sides are nonnegative, so mul_self_le_mul_self squares it. The right-hand square is expanded with (A^½·B^½)² = (A^½·A^½)·(B^½·B^½), and each A^½·A^½ collapses to A via rpow_add (A^½·A^½ = A^(½+½) = A^1 = A), giving Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2).",
+  "mathContext": "x+3/2 is the midpoint of x+1 and x+2. Real.rpow_add (0<A) turns A^½·A^½ into A^(½+½) = A.",
+  "significance": "Reduces a second-order property of an entire integer sequence to one off-the-shelf convexity inequality, with the squaring handled by elementary rpow arithmetic.",
+  "relatedConcepts": [
+   "Hölder's inequality",
+   "real powers (rpow)",
+   "midpoint convexity"
+  ]
+ },
+ {
+  "id": "ann-pi-cancellation",
+  "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "range": {
+   "startLine": 112,
+   "endLine": 145
+  },
+  "type": "key-step",
+  "title": "The π-Power Cancels Exactly",
+  "content": "omega_log_concave lifts the Gamma inequality back to ω. After unfolding ω and normalising the half-integer arguments ((n+1)/2 = n/2+1/2, etc.), the left side ω_n·ω_{n+2} has numerator π^(n/2)·π^(n/2+1) and the right side ω_{n+1}² has numerator (π^(n/2+1/2))². The helper hP proves these are EQUAL (both π^(2·(n/2)+1)) by rpow_add. So once div_le_div_iff₀ clears the Gamma denominators, the entire π-contribution is a common positive factor removed by mul_le_mul_of_nonneg_left, and what remains is exactly gamma_sq_le_mul at x = n/2. No bound on π is used anywhere.",
+  "mathContext": "π^(n/2)·π^(n/2+1) = (π^(n/2+1/2))² = π^(n+1); this common factor cancels, leaving Γ(n/2+3/2)² ≤ Γ(n/2+1)·Γ(n/2+2).",
+  "significance": "Shows the inequality is purely about Γ: the transcendental constant π plays no role in log-concavity, only in the absolute values of the volumes.",
+  "relatedConcepts": [
+   "exponent arithmetic",
+   "clearing denominators",
+   "div_le_div_iff₀"
+  ]
+ },
+ {
+  "id": "ann-ratios",
+  "proofId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "range": {
+   "startLine": 147,
+   "endLine": 156
+  },
+  "type": "concept",
+  "title": "Antitone Volume Ratios",
+  "content": "omega_ratio_antitone restates log-concavity as the monotonicity of successive ratios: ω_{n+2}/ω_{n+1} ≤ ω_{n+1}/ω_n. This is the standard 'ratios non-increasing' characterisation of log-concavity for positive sequences. Since every ω_n > 0, cross-multiplying with div_le_div_iff₀ turns the ratio inequality into ω_n·ω_{n+2} ≤ ω_{n+1}², which is omega_log_concave. This one-step ratio control is information the parent's two-step parity descent did not provide.",
+  "mathContext": "For positive a,b,c: b/a ≥ c/b ⟺ b² ≥ a·c. Here a=ω_n, b=ω_{n+1}, c=ω_{n+2}.",
+  "significance": "Packages log-concavity in the form most useful for downstream monotonicity arguments and connects it back to the parent's unimodality programme.",
+  "relatedConcepts": [
+   "log-concave ⟺ antitone ratios",
+   "positivity",
+   "one-step monotonicity"
+  ]
+ }
+]

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "title": "Log-Concavity of the Unit Ball Volume Sequence",
+  "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01-oq-03",
+  "description": "Proves the second-order shape property of the unit n-ball volume ω_n = π^(n/2)/Γ(n/2+1): the sequence is log-concave, ω_{n+1}² ≥ ω_n·ω_{n+2} for every n. The shared power of π cancels exactly, reducing log-concavity to midpoint log-convexity of the Gamma function Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2) (Mathlib's Hölder/Bohr–Mollerup bound). Log-concavity is strictly stronger than the parent's unimodality and yields antitone volume ratios ω_{n+1}/ω_n.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Volume_of_an_n-ball",
+    "date": "2026-06-23",
+    "status": "verified",
+    "tags": [
+      "geometry",
+      "analysis",
+      "gamma-function",
+      "log-concavity",
+      "unit-ball",
+      "convexity",
+      "monotonicity"
+    ],
+    "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "lineCount": 160,
+    "assumptions": "None. Fully verified with 0 sorries and 0 axioms (only propext/Classical.choice/Quot.sound, the ordinary foundational triple — confirmed via #print axioms; no native_decide). The single nontrivial input is Mathlib's multiplicative log-convexity of Γ, Real.Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma (Hölder inequality / Bohr–Mollerup), specialised to weights ½,½. The π-powers cancel identically between the two sides, requiring no estimate on π.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma",
+        "description": "Multiplicative log-convexity of the Gamma function: Γ(a·s+b·t) ≤ Γ(s)^a·Γ(t)^b for positive weights a+b=1. Specialised to a=b=½, s=x+1, t=x+2 it gives the midpoint bound Γ(x+3/2) ≤ Γ(x+1)^½·Γ(x+2)^½, the engine of log-concavity.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.BohrMollerup"
+      },
+      {
+        "theorem": "Real.Gamma_pos_of_pos",
+        "description": "Positivity of Γ on the positive reals, used to square the midpoint inequality and to clear denominators (each ω_n > 0).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.rpow_add",
+        "description": "π^(y+z) = π^y·π^z, used to show the shared power π^(n/2)·π^(n/2+1) = (π^(n/2+1/2))² so it cancels between ω_n·ω_{n+2} and ω_{n+1}².",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "div_le_div_iff₀",
+        "description": "Cross-multiplication for the quotient form, turning the division inequality into the polynomial Gamma inequality.",
+        "module": "Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      }
+    ],
+    "definitionCount": 0
+  },
+  "parent": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01",
+  "openQuestion": "Is the integer sequence ω_n log-concave (ω_{n+1}² ≥ ω_n·ω_{n+2})? Log-concavity would give one-step unimodality directly and is the natural strengthening of the parent's unimodality.",
+  "overview": {
+    "historicalContext": "The unit n-ball volume ω_n = π^(n/2)/Γ(n/2+1) peaks at n=5; the parent entry established strict unimodality (strict rise to the peak, strict fall after). Unimodality constrains only the sign of the increments. The next natural structural question — explicitly raised as the parent's open question #3 — is whether the sequence is log-concave, ω_{n+1}² ≥ ω_n·ω_{n+2}. Log-concavity is a classical and strictly stronger shape property: every positive log-concave sequence is unimodal, but not conversely. Log-concave sequences enjoy strong combinatorial and analytic regularity (no internal zeros, unimodal, ratios monotone), so identifying ω_n as log-concave places it in this well-behaved class and pins its one-step decrease behaviour.",
+    "problemStatement": "Prove that the unit-ball volume sequence ω_n is log-concave: ω_n·ω_{n+2} ≤ ω_{n+1}² for every n ∈ ℕ, and deduce that the successive ratios ω_{n+1}/ω_n are non-increasing.",
+    "proofStrategy": "Write x = n/2. The three volumes are ω_n = π^x/Γ(x+1), ω_{n+1} = π^(x+1/2)/Γ(x+3/2), ω_{n+2} = π^(x+1)/Γ(x+2). Both ω_n·ω_{n+2} and ω_{n+1}² carry the identical power π^(2x+1), which cancels, so log-concavity is exactly equivalent to the pure Gamma inequality Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2). Since x+3/2 = ½(x+1)+½(x+2) is the midpoint of x+1 and x+2, this is midpoint log-convexity of Γ: Mathlib's Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma at weights ½,½ gives Γ(x+3/2) ≤ Γ(x+1)^½·Γ(x+2)^½, and squaring (both sides nonnegative, with (A^½)·(A^½)=A via rpow_add) yields the claim. Lifting back: unfold ω, normalise the half-integer arguments, cancel the π-power, and the antitone-ratio corollary follows by cross-multiplying with positivity of ω.",
+    "keyInsights": [
+      "The powers of π cancel exactly: ω_n·ω_{n+2} and ω_{n+1}² both equal (something)·π^(2x+1)/(Gamma factors), so log-concavity needs NO estimate on π whatsoever",
+      "Log-concavity of ω_n is precisely midpoint log-convexity of Γ at the half-integer x+3/2 — the analytic property that singles out Γ among interpolations of the factorial is exactly what makes the ball-volume sequence log-concave",
+      "Mathlib's multiplicative log-convexity bound (Hölder applied to Euler's integral) at weights ½,½ is the whole engine; squaring it via rpow_add gives Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2)",
+      "The result holds for every n ≥ 0 (including the boundary ω_1² ≥ ω_0·ω_2, i.e. 4 ≥ π) because the Gamma arguments x+1, x+2 stay positive for all x ≥ 0",
+      "Log-concavity is strictly stronger than the parent's unimodality and implies it; it also implies the successive ratios ω_{n+1}/ω_n are non-increasing (antitone), a one-step monotonicity the parent's two-step parity descent did not give"
+    ]
+  },
+  "sections": [
+    {
+      "id": "gamma-engine",
+      "title": "The Gamma Engine: Midpoint Log-Convexity",
+      "startLine": 73,
+      "endLine": 110,
+      "summary": "Proves gamma_sq_le_mul: Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2) for x ≥ 0, by squaring Mathlib's multiplicative log-convexity bound at weights ½,½.",
+      "mathContext": "Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma gives Γ(½(x+1)+½(x+2)) = Γ(x+3/2) ≤ Γ(x+1)^½·Γ(x+2)^½. Both sides are nonnegative, so mul_self_le_mul_self squares the inequality; the right square expands via (A^½·B^½)² = (A^½·A^½)·(B^½·B^½) = A·B using rpow_add."
+    },
+    {
+      "id": "log-concave",
+      "title": "Log-Concavity of the Volume Sequence",
+      "startLine": 112,
+      "endLine": 145,
+      "summary": "Proves omega_log_concave: ω_n·ω_{n+2} ≤ ω_{n+1}² for all n, by cancelling the shared π-power and applying the Gamma engine; plus the index-shifted form omega_sq_ge.",
+      "mathContext": "After unfolding ω and normalising the half-integer arguments, both sides share π^(2·(n/2)+1) = (π^(n/2+1/2))²; div_le_div_iff₀ clears denominators, the π-power cancels via mul_le_mul_of_nonneg_left, leaving exactly gamma_sq_le_mul at x = n/2."
+    },
+    {
+      "id": "ratios",
+      "title": "Antitone Volume Ratios",
+      "startLine": 147,
+      "endLine": 156,
+      "summary": "Proves omega_ratio_antitone: ω_{n+2}/ω_{n+1} ≤ ω_{n+1}/ω_n — the ratio reformulation of log-concavity.",
+      "mathContext": "Cross-multiplying with div_le_div_iff₀ (each ω_n > 0) reduces the ratio inequality to ω_n·ω_{n+2} ≤ ω_{n+1}², closed by nlinarith from omega_log_concave and positivity."
+    }
+  ],
+  "conclusion": {
+    "summary": "The unit-ball volume sequence ω_n = π^(n/2)/Γ(n/2+1) is log-concave: ω_n·ω_{n+2} ≤ ω_{n+1}² for every n, equivalently its successive ratios ω_{n+1}/ω_n are non-increasing. Proved with 0 sorries and 0 axioms, the entire content reducing to midpoint log-convexity of the Gamma function after the powers of π cancel.",
+    "implications": "This answers the parent entry's open question #3 and strengthens its unimodality result: log-concavity implies unimodality and additionally controls the one-step (not merely two-step parity) decrease behaviour via the antitone ratios. It identifies the precise analytic source of the shape — log-convexity of Γ — and slots ω_n into the well-behaved class of log-concave positive sequences.",
+    "openQuestions": [
+      "Is the log-concavity strict (ω_{n+1}² > ω_n·ω_{n+2})? This would follow from strict midpoint log-convexity of Γ, which Mathlib does not currently expose in a directly usable form; the Hölder bound is stated non-strictly.",
+      "Does the antitone-ratio bound combine with the half-integer Gamma ratio ω_{n+1}/ω_n = √π·Γ(n/2+1)/Γ(n/2+3/2) to give the full one-step strict decrease ω_{n+1} < ω_n for all n ≥ 5, closing the parent's remaining two-step gap?",
+      "Is the real-variable extension v(x) = π^(x/2)/Γ(x/2+1) log-concave on (0,∞) as a function (not just on integers), via log-convexity of Γ on the whole positive axis?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02-oq-01",
+      "relationship": "answers-open-question",
+      "description": "Answers the parent's open question #3 (log-concavity ω_{n+1}² ≥ ω_n·ω_{n+2}) and strengthens its strict-unimodality result, reusing the parent's ω definition and the positivity lemma omega_pos."
+    },
+    {
+      "targetId": "area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02",
+      "relationship": "related",
+      "description": "The grandparent argmax result (n=5 maximizes ω_n); log-concavity is the second-order strengthening of the monotonicity profile built atop it."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "omega_log_concave",
+      "type": "core",
+      "description": "Log-concavity of the unit-ball volume sequence: ω_n·ω_{n+2} ≤ ω_{n+1}² for every n",
+      "leanType": "∀ (n : ℕ), ω n * ω (n + 2) ≤ ω (n + 1) ^ 2"
+    },
+    {
+      "name": "gamma_sq_le_mul",
+      "type": "core",
+      "description": "Midpoint log-convexity of Γ (squared form), the engine: Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2) for x ≥ 0",
+      "leanType": "∀ {x : ℝ}, 0 ≤ x → Gamma (x + 3 / 2) ^ 2 ≤ Gamma (x + 1) * Gamma (x + 2)"
+    },
+    {
+      "name": "omega_ratio_antitone",
+      "type": "supporting",
+      "description": "Antitone successive volume ratios: ω_{n+2}/ω_{n+1} ≤ ω_{n+1}/ω_n",
+      "leanType": "∀ (n : ℕ), ω (n + 2) / ω (n + 1) ≤ ω (n + 1) / ω n"
+    },
+    {
+      "name": "omega_sq_ge",
+      "type": "supporting",
+      "description": "Index form of log-concavity: ω_{n-1}·ω_{n+1} ≤ ω_n² for n ≥ 1",
+      "leanType": "∀ {n : ℕ}, 1 ≤ n → ω (n - 1) * ω (n + 1) ≤ ω n ^ 2"
+    }
+  ],
+  "leanFile": {
+    "namespace": "MaxBallVolume",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02OQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's **open question #3**: the unit n-ball volume sequence ω_n = π^(n/2)/Γ(n/2+1) is **log-concave**,

  ω_{n+1}² ≥ ω_n · ω_{n+2}   for every n.

Log-concavity is strictly stronger than the parent's strict unimodality (every positive log-concave sequence is unimodal, but not conversely) and additionally controls the one-step ratio behaviour the parent's two-step parity descent did not.

## The mathematical content

Writing x = n/2, both ω_n·ω_{n+2} and ω_{n+1}² carry the **identical** power π^(2x+1), which cancels — so log-concavity is *equivalent* to the pure Gamma inequality

  Γ(x + 3/2)² ≤ Γ(x+1) · Γ(x+2).

Since x+3/2 = ½(x+1) + ½(x+2) is the midpoint, this is midpoint log-convexity of Γ: Mathlib's `Real.Gamma_mul_add_mul_le_rpow_Gamma_mul_rpow_Gamma` (Hölder / Bohr–Mollerup) at weights ½,½, squared. **No estimate on π is used anywhere.**

## Results (4 theorems, 0 defs)

- `gamma_sq_le_mul` — the engine: Γ(x+3/2)² ≤ Γ(x+1)·Γ(x+2) for x ≥ 0
- `omega_log_concave` — the headline: ω_n·ω_{n+2} ≤ ω_{n+1}² for all n
- `omega_sq_ge` — index form: ω_{n-1}·ω_{n+1} ≤ ω_n² for n ≥ 1
- `omega_ratio_antitone` — antitone ratios: ω_{n+1}/ω_n non-increasing

## Verification

- **0 sorries, 0 axioms** — `#print axioms` reports only `propext, Classical.choice, Quot.sound`; no `native_decide`.
- Kernel-verified via `lake env lean` (Docker build exited 144, the known infrastructure wedge; the host kernel check is authoritative). All four `#check`s elaborate.
- Status `verified`, badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)