### PR TITLE
research(bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02): ℤ[√d] PID/UFD for d∈{−1,−2} + prime-norm irreducibility

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3225,6 +3225,7 @@ import Proofs.NarcissisticNumberOQ01
 import Proofs.NavierStokes
 import Proofs.NesbittInequalityOQ01
 import Proofs.NormEuclideanZsqrtdFamilyOQ03
+import Proofs.NormEuclideanZsqrtdFamilyOQ03OQ02
 import Proofs.NormalAutFinSepDegreeEquality
 import Proofs.NewtonIndStep2
 import Proofs.NewtonInductiveStep

--- a/proofs/Proofs/NormEuclideanZsqrtdFamilyOQ03OQ02.lean
+++ b/proofs/Proofs/NormEuclideanZsqrtdFamilyOQ03OQ02.lean
@@ -1,0 +1,120 @@
+/-
+  # `ℤ[√d]` is a PID and a UFD for `d ∈ {-1, -2}` — and prime-norm irreducibility
+
+  Open question (`bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03`, the
+  Euclidean-`ℤ[√d]`-family entry):
+
+    > `ℤ[√d]` is a PID/UFD for `d ∈ {-1, -2}` from the uniform norm bound.
+
+  The parent file `NormEuclideanZsqrtdFamilyOQ03` packaged a *uniform*
+  nearest-lattice-point division making `ℤ[√d]` a **Euclidean domain** for every
+  `-2 ≤ d < 0` (`euclideanDomain`), specialising to the Gaussian integers
+  `ℤ[√-1]` and to `ℤ[√-2]`.  This file harvests the two standard structural
+  consequences and adds one piece of genuine arithmetic.
+
+  ## What we prove
+
+  * `isPrincipalIdealRing` / `uniqueFactorizationMonoid` — for every
+    `-2 ≤ d < 0`, the ring `ℤ[√d]` is a **principal ideal ring** and a
+    **unique factorization monoid**, obtained from the parent's Euclidean
+    structure via Mathlib's `EuclideanDomain.to_principal_ideal_domain` and
+    `PrincipalIdealRing.to_uniqueFactorizationMonoid`.
+  * Concrete corollaries for the two classical rings:
+    `gaussianInt_isPrincipalIdealRing`, `gaussianInt_uniqueFactorizationMonoid`
+    (`d = -1`) and `negTwo_isPrincipalIdealRing`,
+    `negTwo_uniqueFactorizationMonoid` (`d = -2`).
+  * `irreducible_of_prime_norm` — for **any** `d`, an element whose norm has
+    prime natural absolute value is irreducible.  This is the genuinely
+    arithmetic input (multiplicativity of the norm + `norm.natAbs = 1 ↔ unit`,
+    both unconditional in `d`), valid well beyond the Euclidean range.
+  * `prime_of_prime_norm` — combining the two, for `-2 ≤ d < 0` a prime-norm
+    element is actually **prime** (irreducible ⟺ prime in the UFD).
+
+  The PID/UFD step is pure Mathlib plumbing on top of the parent's Euclidean
+  structure; the mathematical substance new to this file is the prime-norm
+  irreducibility criterion and its UFD upgrade to primality.
+
+  Status: PROVED — 0 sorries, 0 axioms, no `native_decide`.
+  Tags: number-theory, quadratic-integers, euclidean-domain, pid, ufd
+-/
+import Proofs.NormEuclideanZsqrtdFamilyOQ03
+
+open Zsqrtd
+
+namespace NormEuclideanZsqrtdFamilyPIDUFD
+
+variable {d : ℤ}
+
+/-! ### Principal ideal ring and unique factorization, uniformly for `-2 ≤ d < 0` -/
+
+/-- **`ℤ[√d]` is a principal ideal ring for every `-2 ≤ d < 0`.** Immediate from
+the parent's Euclidean structure via `EuclideanDomain.to_principal_ideal_domain`. -/
+theorem isPrincipalIdealRing (hd : d < 0) (hd2 : -2 ≤ d) :
+    IsPrincipalIdealRing (ℤ√d) :=
+  letI := NormEuclideanZsqrtdFamily.euclideanDomain d hd hd2
+  inferInstance
+
+/-- **`ℤ[√d]` is a unique factorization monoid for every `-2 ≤ d < 0`.** A PID is
+a UFD: `PrincipalIdealRing.to_uniqueFactorizationMonoid`. -/
+theorem uniqueFactorizationMonoid (hd : d < 0) (hd2 : -2 ≤ d) :
+    letI := NormEuclideanZsqrtdFamily.euclideanDomain d hd hd2
+    UniqueFactorizationMonoid (ℤ√d) :=
+  letI := NormEuclideanZsqrtdFamily.euclideanDomain d hd hd2
+  inferInstance
+
+/-! ### The two classical rings -/
+
+/-- The Gaussian integers `ℤ[i] = ℤ[√-1]` form a principal ideal ring. -/
+theorem gaussianInt_isPrincipalIdealRing : IsPrincipalIdealRing (ℤ√(-1)) :=
+  isPrincipalIdealRing (by norm_num) (by norm_num)
+
+/-- The Gaussian integers `ℤ[i] = ℤ[√-1]` form a unique factorization monoid. -/
+theorem gaussianInt_uniqueFactorizationMonoid :
+    letI := NormEuclideanZsqrtdFamily.euclideanDomainNegOne
+    UniqueFactorizationMonoid (ℤ√(-1)) :=
+  letI := NormEuclideanZsqrtdFamily.euclideanDomainNegOne
+  inferInstance
+
+/-- `ℤ[√-2]` is a principal ideal ring. -/
+theorem negTwo_isPrincipalIdealRing : IsPrincipalIdealRing (ℤ√(-2)) :=
+  isPrincipalIdealRing (by norm_num) (by norm_num)
+
+/-- `ℤ[√-2]` is a unique factorization monoid. -/
+theorem negTwo_uniqueFactorizationMonoid :
+    letI := NormEuclideanZsqrtdFamily.euclideanDomainNegTwo
+    UniqueFactorizationMonoid (ℤ√(-2)) :=
+  letI := NormEuclideanZsqrtdFamily.euclideanDomainNegTwo
+  inferInstance
+
+/-! ### Prime norm ⟹ irreducible (and prime in the UFD) -/
+
+/-- **Prime-norm elements are irreducible.** For *any* `d`, if the natural
+absolute value of `N(z)` is a prime number, then `z` is irreducible in `ℤ[√d]`.
+
+The norm is multiplicative, so a factorisation `z = a * b` splits the prime
+`|N(z)| = |N(a)| · |N(b)|`, forcing one factor to have norm of absolute value `1`,
+i.e. to be a unit (`Zsqrtd.norm_eq_one_iff`, which is unconditional in `d`). This
+uses no hypothesis on `d` at all — in particular it holds far outside the
+Euclidean range `-2 ≤ d < 0`. -/
+theorem irreducible_of_prime_norm {z : ℤ√d}
+    (hz : Prime z.norm.natAbs) : Irreducible z := by
+  refine ⟨?_, ?_⟩
+  · -- `z` is not a unit, else `|N(z)| = 1`, contradicting primality.
+    intro hu
+    exact hz.ne_one (norm_eq_one_iff.mpr hu)
+  · -- A factorisation splits the prime norm.
+    intro a b hab
+    have hmn : z.norm.natAbs = a.norm.natAbs * b.norm.natAbs := by
+      rw [hab, norm_mul, Int.natAbs_mul]
+    rcases hz.irreducible.isUnit_or_isUnit hmn with h | h
+    · exact Or.inl (norm_eq_one_iff.mp (Nat.isUnit_iff.mp h))
+    · exact Or.inr (norm_eq_one_iff.mp (Nat.isUnit_iff.mp h))
+
+/-- **Prime-norm elements are prime** in `ℤ[√d]` for `-2 ≤ d < 0`. In the UFD,
+irreducible and prime coincide, so the criterion above upgrades to primality. -/
+theorem prime_of_prime_norm (hd : d < 0) (hd2 : -2 ≤ d) {z : ℤ√d}
+    (hz : Prime z.norm.natAbs) : Prime z := by
+  letI := NormEuclideanZsqrtdFamily.euclideanDomain d hd hd2
+  exact UniqueFactorizationMonoid.irreducible_iff_prime.mp (irreducible_of_prime_norm hz)
+
+end NormEuclideanZsqrtdFamilyPIDUFD

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02/meta.json
@@ -1,0 +1,102 @@
+{
+  "id": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+  "title": "ℤ[√d] is a PID and UFD for d ∈ {−1,−2}, and Prime-Norm Irreducibility",
+  "slug": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+  "description": "Answers the second open question of the uniform norm-Euclidean ℤ[√d] family: from the parent's single EuclideanDomain construction for −2 ≤ d < 0 we harvest the two standard structural consequences — ℤ[√d] is a principal ideal ring and a unique factorization monoid — specializing to the Gaussian integers ℤ[√-1] and to ℤ[√-2]. We add the genuinely arithmetic input the norm provides: for ANY d, an element whose norm has prime natural absolute value is irreducible (multiplicativity of the norm plus |N(·)| = 1 ⟺ unit, both unconditional in d), and in the UFD range −2 ≤ d < 0 such an element is therefore prime.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/NormEuclideanZsqrtdFamilyOQ03OQ02.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-integers",
+      "Euclidean-domain",
+      "PID",
+      "UFD",
+      "Zsqrtd"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Built on the parent's EuclideanDomain (ℤ√d) value (−2 ≤ d < 0) and Mathlib's EuclideanDomain.to_principal_ideal_domain, PrincipalIdealRing.to_uniqueFactorizationMonoid, and Zsqrtd.norm_mul / norm_eq_one_iff. Depends only on the standard foundational axioms (propext, Classical.choice, Quot.sound); no sorry, no native_decide.",
+    "lineCount": 120,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "originalContributions": [
+      "isPrincipalIdealRing / uniqueFactorizationMonoid: ℤ[√d] is a PID and a UFD for every −2 ≤ d < 0, derived uniformly from the parent's single EuclideanDomain value (no per-ring re-proof)",
+      "gaussianInt_/negTwo_ corollaries: the two classical rings ℤ[i] = ℤ[√-1] and ℤ[√-2] obtained as the d = −1 and d = −2 members",
+      "irreducible_of_prime_norm: for ANY d, |N(z)| prime ⟹ z irreducible — the genuinely arithmetic criterion from norm multiplicativity and |N(·)| = 1 ⟺ unit (Zsqrtd.norm_eq_one_iff is unconditional in d), valid well beyond the Euclidean range",
+      "prime_of_prime_norm: in the UFD range −2 ≤ d < 0, prime-norm elements are prime (irreducible ⟺ prime in a UFD)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Once a ring is shown to be a Euclidean domain, its principal-ideal and unique-factorization structure are formal consequences: EuclideanDomain ⟹ PID ⟹ UFD. For the imaginary quadratic rings ℤ[i] and ℤ[√-2] this is the classical route to unique factorization of Gaussian and Eisenstein-adjacent integers, underpinning sum-of-two-squares theorems and the arithmetic of norms. The accompanying prime-norm criterion — an element of prime norm is irreducible — is the standard first tool for locating irreducibles in quadratic integer rings.",
+    "problemStatement": "Does the uniform norm-Euclidean bound give a clean proof that ℤ[√d] is a PID/UFD for d ∈ {−1,−2}, and what arithmetic does the norm contribute to factorization?",
+    "text": "**Structural consequences.** The parent file packaged a single EuclideanDomain (ℤ√d) value for every −2 ≤ d < 0. Mathlib turns this into IsPrincipalIdealRing (ℤ√d) via EuclideanDomain.to_principal_ideal_domain, and then into UniqueFactorizationMonoid (ℤ√d) via PrincipalIdealRing.to_uniqueFactorizationMonoid. Both hold uniformly in d on the range −2 ≤ d < 0, and specialize to ℤ[i] = ℤ[√-1] and ℤ[√-2].\n\n**Prime-norm irreducibility.** The norm N: ℤ[√d] → ℤ is multiplicative, and for d < 0 it is nonnegative with |N(z)| = 1 ⟺ z a unit. Hence if |N(z)| is a prime number, any factorization z = a·b splits the prime |N(z)| = |N(a)|·|N(b)|, forcing one factor to be a unit: z is irreducible. This uses no hypothesis on d at all (Zsqrtd.norm_mul and Zsqrtd.norm_eq_one_iff are unconditional), so it holds far outside the Euclidean range. In the UFD range −2 ≤ d < 0, irreducible ⟺ prime, so prime-norm elements are prime.",
+    "proofStrategy": "1. Introduce the parent's euclideanDomain value as a local instance (letI) and let typeclass inference produce IsPrincipalIdealRing and UniqueFactorizationMonoid. 2. Specialize d = −1, −2 with norm_num side goals. 3. For irreducible_of_prime_norm: unfold Irreducible into (not a unit) and (every factorization has a unit factor); use Zsqrtd.norm_eq_one_iff (|N| = 1 ⟺ unit) for non-unit, and norm_mul + Int.natAbs_mul + Prime.irreducible.isUnit_or_isUnit to split the prime norm. 4. Upgrade to primality via UniqueFactorizationMonoid.irreducible_iff_prime.",
+    "keyInsights": [
+      "EuclideanDomain ⟹ PID ⟹ UFD is pure typeclass plumbing once the parent's Euclidean structure is available as a local instance; the uniform family means one derivation covers both classical rings.",
+      "The arithmetic content is the norm: multiplicativity converts a factorization in ℤ[√d] into a factorization of the integer |N(z)|, and |N(·)| = 1 ⟺ unit makes prime norm force irreducibility.",
+      "irreducible_of_prime_norm needs no hypothesis on d (the norm lemmas are unconditional), so it holds far outside the Euclidean range; it is the UFD structure (−2 ≤ d < 0) that upgrades irreducible to prime."
+    ],
+    "prerequisites": [
+      "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03: the uniform EuclideanDomain (ℤ√d) for −2 ≤ d < 0",
+      "Mathlib: EuclideanDomain.to_principal_ideal_domain, PrincipalIdealRing.to_uniqueFactorizationMonoid, UniqueFactorizationMonoid.irreducible_iff_prime, Zsqrtd.norm_mul, Zsqrtd.norm_eq_one_iff"
+    ]
+  },
+  "conclusion": {
+    "summary": "From the parent's single EuclideanDomain construction, ℤ[√d] is a principal ideal ring and a unique factorization monoid for every −2 ≤ d < 0, recovering ℤ[i] and ℤ[√-2]. The norm supplies the arithmetic: a prime-norm element is irreducible for any d, and prime in the UFD range.",
+    "implications": "The PID/UFD upgrade closes the structural picture of the uniform family, and the prime-norm criterion is the entry point to classifying irreducibles (and hence Gaussian/quadratic primes) by their norms.",
+    "openQuestions": [
+      "Classify the irreducibles of ℤ[i] and ℤ[√-2] by norm (rational primes that are inert, split, or ramified), merging the parent entries' inert-prime classifications into one norm/Legendre-symbol statement.",
+      "Establish a converse-flavored statement: characterize exactly which prime-norm-free elements remain irreducible, i.e. handle the units-times-rational-prime case."
+    ]
+  },
+  "leanFile": {
+    "namespace": "NormEuclideanZsqrtdFamilyPIDUFD",
+    "lineCount": 120,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 0,
+    "path": "Proofs/NormEuclideanZsqrtdFamilyOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+      "relationship": "extends",
+      "description": "Parent proof: the uniform EuclideanDomain (ℤ√d) for −2 ≤ d < 0. This entry answers its second open question by deriving PID/UFD and adding the prime-norm irreducibility criterion."
+    },
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+      "relationship": "thematic",
+      "description": "Grandparent: Gaussian integers ℤ[i] = ℤ[√-1] as a Euclidean domain, recovered here as the d = −1 PID/UFD member."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-pid-ufd",
+      "title": "PID and UFD, uniformly for −2 ≤ d < 0",
+      "startLine": 44,
+      "endLine": 64,
+      "summary": "isPrincipalIdealRing and uniqueFactorizationMonoid: the parent's EuclideanDomain value introduced as a local instance, with IsPrincipalIdealRing and UniqueFactorizationMonoid produced by typeclass inference. The UFD statements carry that instance in their type, since UniqueFactorizationMonoid (ℤ√d) requires the CancelCommMonoidWithZero structure the EuclideanDomain supplies."
+    },
+    {
+      "id": "sec-classical",
+      "title": "The two classical rings",
+      "startLine": 65,
+      "endLine": 88,
+      "summary": "gaussianInt_ and negTwo_ corollaries: ℤ[i] = ℤ[√-1] and ℤ[√-2] as the d = −1 and d = −2 members of the PID/UFD family, the UFD ones reusing the parent's euclideanDomainNegOne / euclideanDomainNegTwo specializations."
+    },
+    {
+      "id": "sec-prime-norm",
+      "title": "Prime norm ⟹ irreducible (and prime)",
+      "startLine": 89,
+      "endLine": 120,
+      "summary": "irreducible_of_prime_norm: |N(z)| prime ⟹ z irreducible for any d, via norm multiplicativity and |N(·)| = 1 ⟺ unit (both unconditional). prime_of_prime_norm upgrades to primality in the UFD range −2 ≤ d < 0 using irreducible_iff_prime."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **second open question** of the uniform norm-Euclidean ℤ[√d] family entry (`bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03`).

The parent file packaged a single `EuclideanDomain (ℤ√d)` value for every `−2 ≤ d < 0` (uniform nearest-lattice-point division). This entry harvests its standard structural consequences and adds one piece of genuine arithmetic.

### What we prove (8 theorems, 0 def, 0 sorries, 0 axioms)

- **`isPrincipalIdealRing` / `uniqueFactorizationMonoid`** — for every `−2 ≤ d < 0`, `ℤ[√d]` is a principal ideal ring and a unique factorization monoid, derived uniformly from the parent's Euclidean structure (`EuclideanDomain.to_principal_ideal_domain`, `PrincipalIdealRing.to_uniqueFactorizationMonoid`).
- **`gaussianInt_*` / `negTwo_*`** — the two classical rings ℤ[i] = ℤ[√-1] and ℤ[√-2] as the `d = −1` and `d = −2` members.
- **`irreducible_of_prime_norm`** — for **any** `d`, an element whose norm has prime natural absolute value is irreducible. Norm multiplicativity splits the prime `|N(z)| = |N(a)|·|N(b)|`, forcing a unit factor via `Zsqrtd.norm_eq_one_iff`. Both norm lemmas are unconditional in `d`, so this holds far outside the Euclidean range.
- **`prime_of_prime_norm`** — in the UFD range `−2 ≤ d < 0`, prime-norm elements are prime (irreducible ⟺ prime in a UFD).

### Verification

Kernel-verified with `lake env lean` (experimental modules) + `#print axioms`: all 8 theorems depend only on the standard foundational triple `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Status: `verified`.

### Note on the UFD statements

`UniqueFactorizationMonoid (ℤ√d)` is not a well-formed type without the `CancelCommMonoidWithZero (ℤ√d)` structure, which only the parent's `EuclideanDomain` supplies (`ℤ√d` has no global `IsDomain` instance for arbitrary `d`). The three UFD theorems therefore carry that instance in their return type via `letI`, reusing the parent's `euclideanDomain` / `euclideanDomainNegOne` / `euclideanDomainNegTwo` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)