### PR TITLE
audit(erdos-1040-oq-03-oq-02): repair non-compiling ℝ≥0∞ scoped-notation use

### DIFF
--- a/proofs/Proofs/Erdos1040OQ03OQ02.lean
+++ b/proofs/Proofs/Erdos1040OQ03OQ02.lean
@@ -75,7 +75,7 @@ has Lebesgue (area) measure exactly `π R²`. -/
 theorem volume_lemOf_scaledPure (R : ℝ) (hR : 0 < R) (c : ℂ) {n : ℕ} (hn : 0 < n) :
     volume (lemOf (scaledPure R c n)) = ENNReal.ofReal (Real.pi * R ^ 2) := by
   rw [lemOf_scaledPure_eq_ball R hR c hn, Complex.volume_ball]
-  have hpi : ((NNReal.pi : ℝ≥0∞)) = ENNReal.ofReal Real.pi := by
+  have hpi : ((NNReal.pi : ENNReal)) = ENNReal.ofReal Real.pi := by
     rw [← NNReal.coe_real_pi]; exact (ENNReal.ofReal_coe_nnreal).symm
   rw [hpi, ← ENNReal.ofReal_pow hR.le,
     ← ENNReal.ofReal_mul (show (0 : ℝ) ≤ R ^ 2 by positivity)]


### PR DESCRIPTION
## Gallery Integrity Repair

**Proof**: `erdos-1040-oq-03-oq-02` (Monic normalization pins single-point lemniscate area to π)
**Severity**: HIGH — published `status: verified` / `badge: original` / 0 sorries, but the Lean file **did not compile** on Mathlib v4.26.0.

### Evidence

`meta.json` `assumptions` field self-admitted the risk:
> "Build NOT kernel-verified this session (Docker daemon unavailable, as in prior sessions); all Mathlib signatures ... were checked against Mathlib v4.26.0 source."

A signature check cannot catch a missing scoped-notation `open`. Kernel-verifying with `lake env lean` produced a parse error:

```
Proofs/Erdos1040OQ03OQ02.lean:78:30: error: expected token
Proofs/Erdos1040OQ03OQ02.lean:78:15: error: invalid binder name `NNReal.pi`, it must be atomic
... unsolved goals (volume_lemOf_scaledPure broken, cascading to all downstream theorems)
```

**Root cause**: line 78 uses the `ℝ≥0∞` notation for `ENNReal`, which is `scoped` under the `ENNReal` namespace. The file opens only `Complex MeasureTheory Metric`, so `ℝ≥0∞` is not in scope and fails to parse.

### Fix

One line — replace the scoped notation with a fully-qualified type ascription:

```lean
-  have hpi : ((NNReal.pi : ℝ≥0∞)) = ENNReal.ofReal Real.pi := by
+  have hpi : ((NNReal.pi : ENNReal)) = ENNReal.ofReal Real.pi := by
```

### Verification

- `lake env lean Proofs/Erdos1040OQ03OQ02.lean` → **EXIT 0**, zero errors.
- `#print axioms monic_normalization_essential` → `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- All meta.json claims now hold: `verified` / `original` / 0 axioms / 0 sorries / 9 theorems / 2 definitions.

No meta.json change needed — the claims were accurate; only the source failed to build.

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)