### PR TITLE
Enrich finite-field power sums (sum-of-kth-powers-oq-05): add annotations.json

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-05/annotations.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-sokp-oq05-overview",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 3, "endLine": 26 },
+    "type": "concept",
+    "title": "The Modular Face of Power Sums",
+    "content": "The docstring positions this entry against the rest of the 'sum of k-th powers' family. Where the siblings give integer closed forms and asymptotics for ∑_{i<n} iᵏ (Faulhaber, Bernoulli, Nicomachus, Euler–Maclaurin), this one evaluates the complete power sum ∑_{x∈𝔽_q} xᵏ over an entire finite field — a congruence rather than a closed form. The answer is a clean dichotomy: −1 when k ≠ 0 and (q−1)∣k, and 0 otherwise. Mathlib stops at the sum over the units Kˣ; the work here is extending to the whole field, which surfaces the x=0 term and the k=0 collapse. This is the Fermat-little-theorem / von Staudt–Clausen mechanism behind Bernoulli-number congruences.",
+    "mathContext": "$\\sum_{x \\in \\mathbb{F}_q} x^k = \\begin{cases} -1 & k \\neq 0 \\text{ and } (q-1)\\mid k \\\\ 0 & \\text{otherwise}\\end{cases}$",
+    "significance": "context",
+    "relatedConcepts": ["finite fields", "Fermat's little theorem", "von Staudt–Clausen", "power sums", "character sums"],
+    "prerequisites": ["finite field theory", "modular arithmetic"]
+  },
+  {
+    "id": "ann-sokp-oq05-setup",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 28, "endLine": 33 },
+    "type": "context",
+    "title": "Finite-Field Setup",
+    "content": "The namespace opens Finset and the BigOperators scope for the ∑ notation, and fixes the ambient structure: K is an arbitrary finite field with decidable equality (Field K, Fintype K, DecidableEq K). Working over a general finite field rather than ZMod p keeps the headline theorem maximally reusable — the prime-field results are then obtained by specialisation. The cardinality q = Fintype.card K is the parameter governing the divisibility condition (q−1)∣k.",
+    "mathContext": "$K$ a finite field, $q = \\#K = p^m$; the multiplicative group $K^\\times$ is cyclic of order $q-1$.",
+    "significance": "technical",
+    "relatedConcepts": ["Fintype", "field typeclass", "cardinality"],
+    "prerequisites": ["Lean typeclasses"]
+  },
+  {
+    "id": "ann-sokp-oq05-main-k0",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 35, "endLine": 50 },
+    "type": "insight",
+    "title": "The k = 0 Collapse: Characteristic Enters",
+    "content": "sum_pow_eq is the headline theorem; its proof splits on whether k = 0. The k = 0 branch is where the field characteristic does its work: every summand is x⁰ = 1, so the sum is (card K)·1 = q. The decisive step is FiniteField.cast_card_eq_zero, which states (q : K) = 0 — the cardinality of a finite field vanishes in its own characteristic. So the sum is 0, matching the 'else' branch since the condition k ≠ 0 is false. This boundary case is precisely what the standard units-only lemma omits.",
+    "mathContext": "$\\sum_{x : K} x^0 = \\sum_{x : K} 1 = (\\#K)\\cdot 1 = q = 0 \\text{ in } K \\text{ (char } p).$",
+    "significance": "key",
+    "relatedConcepts": ["field characteristic", "cast_card_eq_zero", "case split", "empty product convention"],
+    "prerequisites": ["characteristic of a field", "Finset.sum_const"]
+  },
+  {
+    "id": "ann-sokp-oq05-main-units",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 51, "endLine": 63 },
+    "type": "technique",
+    "title": "k ≠ 0: Dropping x = 0 and Reducing to the Units",
+    "content": "For k ≠ 0 the x = 0 term is 0ᵏ = 0 and is removed via Finset.sum_sdiff (splitting univ into {0} and its complement) together with zero_pow hk. The remaining sum over univ \\ {0} is identified with the sum over the units Kˣ: the embedding φ : Kˣ ↪ K is injective (Units.val_injective), and isUnit_iff_ne_zero shows its image is exactly the nonzero elements, so univ.map φ = univ \\ {0}. FiniteField.sum_pow_units then evaluates the units sum to if (q−1)∣k then −1 else 0, and the conjunctive condition simplifies because k ≠ 0 holds.",
+    "mathContext": "$\\sum_{x : K} x^k = \\sum_{x \\in K\\setminus\\{0\\}} x^k = \\sum_{u : K^\\times} u^k = \\begin{cases}-1 & (q-1)\\mid k\\\\ 0 & \\text{else}\\end{cases}$",
+    "significance": "key",
+    "relatedConcepts": ["sum over units", "sum_pow_units", "injective embedding", "zero_pow", "sum_sdiff"],
+    "prerequisites": ["units of a field", "Finset.map and sums"]
+  },
+  {
+    "id": "ann-sokp-oq05-zmod",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 65, "endLine": 83 },
+    "type": "theorem",
+    "title": "Specialisation to ZMod p and the −1 Criterion",
+    "content": "sum_pow_zmod transports the general theorem to the prime field by substituting ZMod.card (Fintype.card (ZMod p) = p, so q = p), giving ∑_{x : ZMod p} xᵏ = if k ≠ 0 ∧ (p−1)∣k then −1 else 0. sum_pow_zmod_eq_neg_one_iff then reads off the precise congruence criterion: the sum equals −1 exactly when k ≠ 0 and (p−1)∣k. The forward direction uses that 0 ≠ −1 in the field ZMod p (a 0 = −1 contradiction forces 1 = 0, closed by linear_combination), so the 'else' branch can never accidentally equal −1.",
+    "mathContext": "$\\sum_{x : \\mathbb{Z}/p} x^k = -1 \\iff k \\neq 0 \\text{ and } (p-1)\\mid k.$",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod p", "ZMod.card", "congruence criterion", "prime fields"],
+    "prerequisites": ["ZMod API", "prime fields"]
+  },
+  {
+    "id": "ann-sokp-oq05-residues",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 85, "endLine": 94 },
+    "type": "theorem",
+    "title": "Residues Sum to Zero for Odd Primes",
+    "content": "sum_residues_eq_zero recovers the familiar fact 0 + 1 + ⋯ + (p−1) ≡ 0 (mod p) for odd primes p, as the k = 1 instance of the dichotomy. Instantiating sum_pow_zmod at k = 1, the condition (p−1)∣1 would force p−1 ≤ 1 (Nat.le_of_dvd), i.e. p ≤ 2, contradicting the hypothesis 2 < p; so the 'else' branch fires and the sum is 0. The oddness is exactly what makes (p−1) too large to divide 1.",
+    "mathContext": "$\\sum_{x : \\mathbb{Z}/p} x = 0 \\text{ for } p > 2, \\text{ since } (p-1)\\nmid 1.$",
+    "significance": "supporting",
+    "relatedConcepts": ["sum of residues", "k=1 case", "divisibility bound", "omega"],
+    "prerequisites": ["divisibility", "ZMod p"]
+  },
+  {
+    "id": "ann-sokp-oq05-instances",
+    "proofId": "sum-of-kth-powers-oq-05",
+    "range": { "startLine": 96, "endLine": 108 },
+    "type": "technique",
+    "title": "Concrete decide-Verified Instances",
+    "content": "Four worked instances confirm the dichotomy on small primes: ∑_{x:ZMod 5} x⁴ = 4 (= −1, since 4∣4), ∑_{x:ZMod 5} x² = 0 (since 4∤2), ∑_{x:ZMod 7} x⁶ = 6 (= −1, since 6∣6), and the residue sum over ZMod 5 = 0. Each is closed by decide — kernel reduction over the concrete finite type — not native_decide, so no Lean.ofReduceBool axiom is incurred and the entry stays genuinely 0-axiom. These serve as executable sanity checks against the universally-quantified theorems.",
+    "mathContext": "$\\sum_{x:\\mathbb{Z}/5} x^4 = 4 = -1,\\quad \\sum_{x:\\mathbb{Z}/5} x^2 = 0,\\quad \\sum_{x:\\mathbb{Z}/7} x^6 = 6 = -1.$",
+    "significance": "technical",
+    "relatedConcepts": ["decide", "kernel reduction", "axiom integrity", "worked examples"],
+    "prerequisites": ["decidable evaluation in Lean"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass: sum-of-kth-powers-oq-05

This entry — the complete power sum ∑_{x∈𝔽_q} xᵏ over a finite field (= −1 iff k ≠ 0 and (q−1)∣k, else 0), the modular face of the power-sum family — had a richly populated `meta.json` but **no `annotations.json`**. This pass adds the inline-annotation layer.

### Added
- **`annotations.json`** with 7 inline annotations covering the full Lean file, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. The modular-face overview (vs the family's integer closed forms)
  2. Finite-field setup
  3. The k=0 collapse where the field characteristic enters (`cast_card_eq_zero`)
  4. The k≠0 reduction: drop x=0, reduce to the units sum (`sum_pow_units`)
  5. The ZMod p specialisation and the −1 criterion
  6. Residues sum to zero for odd primes (the k=1 case)
  7. The `decide`-verified concrete instances (axiom-integrity note: no `native_decide`)

### Verification
- `pnpm build` succeeds; entry not flagged.
- JSON validated; annotation line ranges align with the Lean source sections.
- No axiom/status claims altered — meta correctly reports `verified` / `mathlib` / 0 axioms / 0 sorries.