### PR TITLE
research(conjugacy-class-equation-oq-01-oq-01): class equation in index form |G| = |Z(G)| + Σ [G : C_G(gᵢ)]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -766,6 +766,7 @@ import Proofs.CompositionCard2PowOQ01
 import Proofs.CompositionPartsChooseOQ01
 import Proofs.CompositionPartsChooseOQ01OQ01
 import Proofs.ConjugacyClassEquationOQ01
+import Proofs.ConjugacyClassEquationOQ01OQ01
 import Proofs.ConnectedSpaceOQ01
 import Proofs.ConnectedSpaceOQ01OQ01
 import Proofs.ContinuumHypothesis

--- a/proofs/Proofs/ConjugacyClassEquationOQ01OQ01.lean
+++ b/proofs/Proofs/ConjugacyClassEquationOQ01OQ01.lean
@@ -1,0 +1,89 @@
+import Mathlib
+
+/-!
+# The class equation in index form: `|G| = |Z(G)| + Σ [G : C_G(gᵢ)]`
+
+The parent file `ConjugacyClassEquationOQ01` proved the *per-class* form of the class
+equation via orbit–stabilizer for conjugation:
+
+* `|class(g)| = [G : C_G(g)]` — the size of the conjugacy class of `g` is the index of
+  its centralizer (`conjClass_card_eq_index_centralizer`).
+
+Mathlib supplies the *summed* class equation in cardinality form
+(`Group.nat_card_center_add_sum_card_noncenter_eq_card`):
+
+  `|Z(G)| + Σ_{noncentral classes K} |K| = |G|`.
+
+This file **assembles the standard textbook form** of the class equation by feeding the
+per-class index identity into Mathlib's summed equation, replacing each noncentral class
+size `|K|` by the centralizer index `[G : C_G(gᵢ)]` of a chosen representative `gᵢ`:
+
+  `|Z(G)| + Σ_{noncentral classes K} [G : C_G(g_K)] = |G|`.
+
+This is the arithmetic engine behind the classical corollaries (e.g. a nontrivial
+`p`-group has nontrivial center, since `p ∣ [G : C_G(gᵢ)]` for each noncentral `gᵢ`).
+Mathlib packages the cardinality form but not this index form.
+
+We work with `Nat.card` and the finitary sum `∑ᶠ`, so the only typeclass hypothesis is
+`[Finite G]`. Representatives are chosen with `ConjClasses.exists_rep`.
+-/
+
+open MulAction Subgroup ConjAct
+
+namespace ConjugacyClassEquationOQ01OQ01
+
+variable {G : Type*} [Group G]
+
+/-- **Per-class index identity** (re-derived from the parent file's
+`conjClass_card_eq_index_centralizer`). The size of the conjugacy class of `g`
+equals the index of its centralizer: `|class(g)| = [G : C_G(g)]`. -/
+theorem conjClass_card_eq_index_centralizer (g : G) :
+    Nat.card (ConjClasses.mk g).carrier =
+      (Subgroup.centralizer ({ConjAct.toConjAct g} : Set (ConjAct G))).index := by
+  have horbit : (ConjClasses.mk g).carrier = orbit (ConjAct G) g :=
+    (ConjAct.orbit_eq_carrier_conjClasses g).symm
+  rw [← ConjAct.stabilizer_eq_centralizer, horbit, Nat.card_coe_set_eq,
+    MulAction.index_stabilizer]
+
+/-- A chosen representative of a conjugacy class. -/
+noncomputable def classRep (x : ConjClasses G) : G := (ConjClasses.exists_rep x).choose
+
+@[simp] theorem mk_classRep (x : ConjClasses G) : ConjClasses.mk (classRep x) = x :=
+  (ConjClasses.exists_rep x).choose_spec
+
+/-- **Pointwise bridge.** The size of any conjugacy class `x` equals the index of the
+centralizer of its chosen representative: `|x| = [G : C_G(classRep x)]`. -/
+theorem card_carrier_eq_index_centralizer (x : ConjClasses G) :
+    Nat.card x.carrier =
+      (Subgroup.centralizer ({ConjAct.toConjAct (classRep x)} : Set (ConjAct G))).index := by
+  have h := conjClass_card_eq_index_centralizer (classRep x)
+  rw [mk_classRep] at h
+  exact h
+
+/-- **The class equation, index form.** For a finite group `G`,
+
+  `|Z(G)| + Σ_{noncentral classes x} [G : C_G(classRep x)] = |G|`.
+
+Obtained from Mathlib's summed class equation
+(`Group.nat_card_center_add_sum_card_noncenter_eq_card`) by replacing each noncentral
+class size with the index of the centralizer of a representative
+(`card_carrier_eq_index_centralizer`). -/
+theorem classEquation_centralizer_index_form [Finite G] :
+    Nat.card (Subgroup.center G) +
+        ∑ᶠ x ∈ ConjClasses.noncenter G,
+          (Subgroup.centralizer ({ConjAct.toConjAct (classRep x)} : Set (ConjAct G))).index =
+      Nat.card G := by
+  rw [← Group.nat_card_center_add_sum_card_noncenter_eq_card G]
+  congr 1
+  exact finsum_mem_congr rfl (fun x _ => (card_carrier_eq_index_centralizer x).symm)
+
+/-- **Corollary.** The sum of centralizer indices over the noncentral conjugacy classes
+accounts for exactly the noncentral elements: `Σ [G : C_G(gᵢ)] = |G| − |Z(G)|`. -/
+theorem sum_noncenter_index_eq_card_sub_center [Finite G] :
+    ∑ᶠ x ∈ ConjClasses.noncenter G,
+        (Subgroup.centralizer ({ConjAct.toConjAct (classRep x)} : Set (ConjAct G))).index =
+      Nat.card G - Nat.card (Subgroup.center G) := by
+  have h := classEquation_centralizer_index_form (G := G)
+  omega
+
+end ConjugacyClassEquationOQ01OQ01

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "conjclass-oq0101-ann-header",
+    "proofId": "conjugacy-class-equation-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 46 },
+    "type": "concept",
+    "title": "From cardinality form to index form — the open question answered",
+    "content": "The parent entry proves the per-class identity |class(g)| = [G : C_G(g)] and leaves as its first open question the assembly of the full numeric class equation |G| = |Z(G)| + Σ [G : C_G(gᵢ)] over representatives of the noncentral classes. Mathlib supplies the summed class equation only in cardinality form, Nat.card (center G) + ∑ᶠ x ∈ noncenter G, Nat.card x.carrier = Nat.card G. This file closes the gap by rewriting each summand |K| into a centralizer index [G : C_G(gᵢ)]. The header re-derives the per-class bridge conjClass_card_eq_index_centralizer (orbit_eq_carrier_conjClasses ▸ index_stabilizer ▸ stabilizer_eq_centralizer) so the file is self-contained.",
+    "mathContext": "$|G| = |Z(G)| + \\sum_i [G : C_G(g_i)].$",
+    "significance": "key",
+    "relatedConcepts": ["class equation", "centralizer index", "conjugacy class", "ConjAct"],
+    "prerequisites": ["orbit–stabilizer theorem", "per-class identity |class(g)| = [G : C_G(g)]"]
+  },
+  {
+    "id": "conjclass-oq0101-ann-classrep",
+    "proofId": "conjugacy-class-equation-oq-01-oq-01",
+    "range": { "startLine": 48, "endLine": 68 },
+    "type": "technique",
+    "title": "Choosing representatives and the pointwise bridge",
+    "content": "A conjugacy class x : ConjClasses G is a quotient with no canonical element, so the index [G : C_G(gᵢ)] only makes sense after choosing a representative. classRep x := (ConjClasses.exists_rep x).choose supplies one, with mk_classRep : ConjClasses.mk (classRep x) = x as the defining simp lemma. The pointwise bridge card_carrier_eq_index_centralizer then lifts the per-class identity to an arbitrary class: rewriting x as ConjClasses.mk (classRep x) inside Nat.card x.carrier (via mk_classRep at the hypothesis) turns the per-class identity into |x| = [G : C_G(classRep x)]. This is the equation that gets summed.",
+    "mathContext": "$|x| = [G : C_G(\\mathrm{classRep}\\,x)] \\quad\\text{for every class } x.$",
+    "significance": "key",
+    "relatedConcepts": ["ConjClasses.exists_rep", "Classical.choice", "representative selection"],
+    "prerequisites": ["quotient representatives", "centralizer index"]
+  },
+  {
+    "id": "conjclass-oq0101-ann-indexform",
+    "proofId": "conjugacy-class-equation-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 89 },
+    "type": "key-step",
+    "title": "One summand rewrite assembles the index form",
+    "content": "classEquation_centralizer_index_form starts from Mathlib's Group.nat_card_center_add_sum_card_noncenter_eq_card. After congr 1 isolates the two finitary sums (the center terms match by rfl), a single finsum_mem_congr rfl (fun x _ => (card_carrier_eq_index_centralizer x).symm) rewrites every summand from Nat.card x.carrier into the centralizer index [G : C_G(classRep x)], producing |Z(G)| + Σ_{noncentral classes} [G : C_G(classRep x)] = |G|. The corollary sum_noncenter_index_eq_card_sub_center then reads off Σ [G : C_G(gᵢ)] = |G| − |Z(G)| by omega. The whole conversion from Mathlib's combinatorial cardinality form to the textbook index form is thus one pointwise rewrite. Only [Finite G] is assumed.",
+    "mathContext": "$|Z(G)| + \\sum_{x \\in \\mathrm{noncenter}} [G : C_G(g_x)] = |G|; \\qquad \\sum_x [G : C_G(g_x)] = |G| - |Z(G)|.$",
+    "significance": "key",
+    "relatedConcepts": ["finsum_mem_congr", "class equation", "p-group center", "Sylow theory"],
+    "prerequisites": ["finitary sums ∑ᶠ", "summed class equation"]
+  }
+]

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/index.ts
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/ConjugacyClassEquationOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const conjugacyClassEquationOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const conjugacyClassEquationOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const conjugacyClassEquationOQ01OQ01Data: ProofData = {
+  proof: conjugacyClassEquationOQ01OQ01Proof,
+  annotations: conjugacyClassEquationOQ01OQ01Annotations,
+}

--- a/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/meta.json
+++ b/src/data/proofs/conjugacy-class-equation-oq-01-oq-01/meta.json
@@ -1,0 +1,168 @@
+{
+  "id": "conjugacy-class-equation-oq-01-oq-01",
+  "title": "The Class Equation in Index Form: |G| = |Z(G)| + Σ [G : C_G(gᵢ)]",
+  "slug": "conjugacy-class-equation-oq-01-oq-01",
+  "description": "Assembles the standard textbook form of the class equation. Mathlib supplies the summed class equation in cardinality form, |Z(G)| + Σ_{noncentral classes K} |K| = |G| (Group.nat_card_center_add_sum_card_noncenter_eq_card), and the parent entry supplies the per-class identity |class(g)| = [G : C_G(g)]. Feeding the latter into the former replaces each noncentral class size with the index of the centralizer of a chosen representative, yielding |Z(G)| + Σ_{noncentral classes} [G : C_G(gᵢ)] = |G| — the form one actually cites in finite group theory (p-groups have nontrivial center, Sylow's theorem, Cauchy's theorem). Working with Nat.card and the finitary sum ∑ᶠ keeps the only typeclass hypothesis to [Finite G]; representatives are chosen with ConjClasses.exists_rep. A closing corollary records Σ [G : C_G(gᵢ)] = |G| − |Z(G)|.",
+  "meta": {
+    "author": "Classical group theory (Burnside, Frobenius); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Conjugacy_class#Conjugacy_class_equation",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "conjugacy-classes",
+      "class-equation",
+      "centralizer",
+      "conjact",
+      "finsum",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/ConjugacyClassEquationOQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Group.nat_card_center_add_sum_card_noncenter_eq_card",
+        "description": "Nat.card (center G) + ∑ᶠ x ∈ noncenter G, Nat.card x.carrier = Nat.card G — the class equation in cardinality form (the summed engine this entry rewrites into index form)",
+        "module": "Mathlib.GroupTheory.ClassEquation"
+      },
+      {
+        "theorem": "ConjClasses.exists_rep",
+        "description": "∃ a, ConjClasses.mk a = x — every conjugacy class has a representative; used to define classRep and choose the gᵢ in the index form",
+        "module": "Mathlib.Algebra.Group.Conj"
+      },
+      {
+        "theorem": "finsum_mem_congr",
+        "description": "Congruence for ∑ᶠ x ∈ s, … under a pointwise equality of summands; rewrites each class size into the centralizer index inside the finitary sum",
+        "module": "Mathlib.Algebra.BigOperators.Finprod"
+      },
+      {
+        "theorem": "ConjAct.orbit_eq_carrier_conjClasses",
+        "description": "orbit (ConjAct G) g = (ConjClasses.mk g).carrier — identifies the conjugation orbit with the conjugacy-class carrier (used to re-derive the per-class index bridge)",
+        "module": "Mathlib.GroupTheory.GroupAction.ConjAct"
+      },
+      {
+        "theorem": "ConjAct.stabilizer_eq_centralizer",
+        "description": "stabilizer (ConjAct G) g = centralizer {toConjAct g} — identifies the conjugation-stabilizer with the centralizer",
+        "module": "Mathlib.GroupTheory.GroupAction.ConjAct"
+      },
+      {
+        "theorem": "MulAction.index_stabilizer",
+        "description": "(stabilizer G x).index = (orbit G x).ncard — orbit–stabilizer in index form, giving the class size as the stabilizer index",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Nat.card_coe_set_eq",
+        "description": "Nat.card ↥s = s.ncard — bridges the subtype cardinality of the class carrier with its set cardinality",
+        "module": "Mathlib.SetTheory.Cardinal.Finite"
+      }
+    ],
+    "originalContributions": [
+      "classEquation_centralizer_index_form: |Z(G)| + Σ_{noncentral classes x} [G : C_G(classRep x)] = |G| — the class equation in centralizer-index form, obtained by rewriting Mathlib's cardinality-form summed equation summand-by-summand; this index form is not packaged in Mathlib",
+      "card_carrier_eq_index_centralizer: |x| = [G : C_G(classRep x)] for every conjugacy class x — the pointwise bridge powering the rewrite, lifting the per-class identity to an arbitrary class via its chosen representative",
+      "classRep / mk_classRep: a chosen representative of a conjugacy class (via ConjClasses.exists_rep) together with the simp lemma ConjClasses.mk (classRep x) = x",
+      "conjClass_card_eq_index_centralizer: |class(g)| = [G : C_G(g)] — the per-class index identity re-derived from the parent entry to keep the file self-contained",
+      "sum_noncenter_index_eq_card_sub_center: Σ_{noncentral classes} [G : C_G(gᵢ)] = |G| − |Z(G)| — the noncentral-element count as a corollary"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 89,
+    "assumptions": "None. Fully verified with 0 sorries and 0 axioms beyond Mathlib's foundational propext / Classical.choice / Quot.sound (which do not count; confirmed by #print axioms on both the main theorem and the corollary — only the standard triple appears, no sorryAx or Lean.ofReduceBool). The representative selection classRep is noncomputable (it uses Classical.choice via ConjClasses.exists_rep), which is immaterial to the verified equalities. The statements use Nat.card and ∑ᶠ, so [Finite G] is the only typeclass hypothesis; they recover the classical finite class equation.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The class equation |G| = |Z(G)| + Σ [G : C_G(gᵢ)], summing the index of the centralizer over representatives of the noncentral conjugacy classes, is one of the central counting tools of finite group theory. It is the form invoked to prove that a nontrivial p-group has nontrivial center (each noncentral index is divisible by p), in the first Sylow theorem, and in Cauchy's theorem. Mathlib records the equation in cardinality form — summing the sizes |K| of the nontrivial classes — but not in this index form, which is the one stated in every textbook because the divisibility p ∣ [G : C_G(gᵢ)] is exactly what the applications use.",
+    "problemStatement": "**Open Question (conjugacy-class-equation-oq-01-oq-01)**: Assemble the full numeric class equation |G| = |Z(G)| + Σ [G : C_G(gᵢ)] over representatives of the noncentral conjugacy classes, directly from the per-class identity |class(g)| = [G : C_G(g)] (conjClass_card_eq_index_centralizer), and relate it to Mathlib's summed class equation.\n\n**Result**: classEquation_centralizer_index_form proves |Z(G)| + Σ_{noncentral classes x} [G : C_G(classRep x)] = |G| for any finite G, obtained from Group.nat_card_center_add_sum_card_noncenter_eq_card by rewriting each class size into a centralizer index via the pointwise bridge card_carrier_eq_index_centralizer. The corollary sum_noncenter_index_eq_card_sub_center records Σ [G : C_G(gᵢ)] = |G| − |Z(G)|.",
+    "text": "Mathlib's class equation Nat.card (center G) + ∑ᶠ x ∈ noncenter G, Nat.card x.carrier = Nat.card G partitions G into its center and its nontrivial conjugacy classes, counted by size. The parent entry shows each class size equals the index of the centralizer of any of its elements. Selecting a representative classRep x = (ConjClasses.exists_rep x).choose for each class and lifting the per-class identity to card_carrier_eq_index_centralizer (|x| = [G : C_G(classRep x)]), a single finsum_mem_congr rewrites Mathlib's summand from a cardinality into a centralizer index, producing the textbook index form. The result holds for any finite group with [Finite G] the sole hypothesis.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Per-class bridge (re-derived).** conjClass_card_eq_index_centralizer: |class(g)| = [G : C_G(g)], proved by identifying the class with the conjugation orbit (orbit_eq_carrier_conjClasses), rewriting its size as the stabilizer index (index_stabilizer), and the stabilizer as the centralizer (stabilizer_eq_centralizer).\n\n2. **Choose representatives.** classRep x := (ConjClasses.exists_rep x).choose, with mk_classRep : ConjClasses.mk (classRep x) = x as a simp lemma.\n\n3. **Pointwise lift.** card_carrier_eq_index_centralizer: for an arbitrary class x, rewrite x as ConjClasses.mk (classRep x) via mk_classRep, then apply the per-class bridge to obtain |x| = [G : C_G(classRep x)].\n\n4. **Rewrite the sum.** Starting from Mathlib's Group.nat_card_center_add_sum_card_noncenter_eq_card, congr 1 isolates the two finitary sums; finsum_mem_congr rfl (fun x _ => (card_carrier_eq_index_centralizer x).symm) rewrites every summand from Nat.card x.carrier into [G : C_G(classRep x)], yielding the index form.\n\n5. **Corollary.** sum_noncenter_index_eq_card_sub_center follows from the index-form equation by omega.",
+    "keyInsights": [
+      "**Cardinality form ⟶ index form by a single summand rewrite.** Mathlib already does the hard combinatorial work (partitioning G into center and nontrivial classes); converting to the textbook index form is exactly one pointwise rewrite of the summand, |K| ↦ [G : C_G(gK)], under finsum_mem_congr.",
+      "**Representative selection makes the summand index meaningful.** A conjugacy class is a quotient with no canonical element, so the centralizer index [G : C_G(gᵢ)] requires choosing a representative; classRep via ConjClasses.exists_rep supplies one, and mk_classRep lets the per-class identity transfer to an arbitrary class.",
+      "**[Finite G] suffices.** Stating everything with Nat.card and ∑ᶠ avoids Fintype/Decidability bookkeeping: the only hypothesis is finiteness, inherited directly from Mathlib's nat_card form of the class equation.",
+      "**This is the form the applications use.** The index form is what powers p ∣ |Z(G)| for p-groups and the Sylow/Cauchy arguments, because each noncentral term [G : C_G(gᵢ)] is a proper divisor of |G| with the relevant arithmetic visible."
+    ],
+    "prerequisites": [
+      "The conjugation action ConjAct G ↷ G, ConjClasses, and the noncenter set (GroupAction/ConjAct.lean, Subgroup/Basic.lean)",
+      "The summed class equation in cardinality form (Group.nat_card_center_add_sum_card_noncenter_eq_card)",
+      "The per-class identity |class(g)| = [G : C_G(g)] (parent entry conjugacy-class-equation-oq-01)",
+      "Finitary sums ∑ᶠ and finsum_mem_congr (Algebra/BigOperators/Finprod.lean)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Module docstring explaining the assembly of the index form from Mathlib's cardinality-form class equation and the parent's per-class identity. Mathlib import, open MulAction Subgroup ConjAct, namespace, variable {G : Type*} [Group G], and the re-derived per-class bridge conjClass_card_eq_index_centralizer.",
+      "mathContext": "$|G| = |Z(G)| + \\sum_i [G : C_G(g_i)]$."
+    },
+    {
+      "id": "representatives",
+      "title": "Class Representatives and the Pointwise Bridge",
+      "startLine": 48,
+      "endLine": 68,
+      "summary": "classRep (chosen representative via ConjClasses.exists_rep) and mk_classRep (its defining simp lemma), then card_carrier_eq_index_centralizer: |x| = [G : C_G(classRep x)] for an arbitrary conjugacy class x, lifting the per-class identity through the chosen representative.",
+      "mathContext": "$|x| = [G : C_G(\\mathrm{classRep}\\,x)]$."
+    },
+    {
+      "id": "index-form",
+      "title": "The Class Equation in Index Form",
+      "startLine": 70,
+      "endLine": 89,
+      "summary": "classEquation_centralizer_index_form rewrites Mathlib's summed class equation summand-by-summand (congr 1 then finsum_mem_congr) into |Z(G)| + Σ_{noncentral classes} [G : C_G(classRep x)] = |G|; sum_noncenter_index_eq_card_sub_center derives Σ [G : C_G(gᵢ)] = |G| − |Z(G)| by omega.",
+      "mathContext": "$|Z(G)| + \\sum_{x} [G : C_G(g_x)] = |G|$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "conjugacy-class-equation-oq-01",
+      "relationship": "Parent entry: supplies the per-class identity |class(g)| = [G : C_G(g)] that is summed here into the index form."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) assembly of the textbook index form of the class equation, |Z(G)| + Σ_{noncentral classes} [G : C_G(gᵢ)] = |G|, obtained from Mathlib's cardinality-form summed class equation by a single summand rewrite through the per-class centralizer-index identity, with representatives chosen via ConjClasses.exists_rep.",
+    "implications": "Provides the precise index form of the class equation that finite group theory cites directly — the version behind p ∣ |Z(G)| for p-groups and the Sylow/Cauchy counting arguments — bridging Mathlib's cardinality-form summed equation and the parent's per-class identity. The pointwise lemma card_carrier_eq_index_centralizer and the classRep selection are reusable for any per-class-to-index argument.",
+    "openQuestions": [
+      "Deduce that a nontrivial finite p-group has nontrivial center directly from this index form: every noncentral term [G : C_G(gᵢ)] is divisible by p, so p ∣ |Z(G)|.",
+      "Specialize the index form to a concrete group (e.g. S₃ or the quaternion group Q₈) and evaluate the finitary sum to recover the familiar numeric class equation 6 = 1 + 2 + 3 (resp. 8 = 2 + 2 + 2 + 2)."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MulAction",
+      "Subgroup",
+      "ConjAct"
+    ],
+    "namespace": "ConjugacyClassEquationOQ01OQ01",
+    "lineCount": 89,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/ConjugacyClassEquationOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra (3rd ed.)",
+      "year": "2004",
+      "venue": "Wiley, §4.3 (The Class Equation)",
+      "note": "States the class equation in the centralizer-index form |G| = |Z(G)| + Σ [G : C_G(gᵢ)] assembled here"
+    },
+    {
+      "authors": "Isaacs, I. Martin",
+      "title": "Finite Group Theory",
+      "year": "2008",
+      "venue": "AMS Graduate Studies in Mathematics 92",
+      "note": "Class equation and its applications to p-groups and Sylow theory"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **conjugacy-class-equation-oq-01**: assemble the full numeric class equation `|G| = |Z(G)| + Σ [G : C_G(gᵢ)]` over representatives of the noncentral conjugacy classes.

Mathlib packages the summed class equation only in **cardinality form**
(`Group.nat_card_center_add_sum_card_noncenter_eq_card`):
`Nat.card (center G) + ∑ᶠ x ∈ noncenter G, Nat.card x.carrier = Nat.card G`.
The parent entry supplies the per-class identity `|class(g)| = [G : C_G(g)]`.
This file converts the former into the **textbook index form** by rewriting each
summand `|K|` into a centralizer index `[G : C_G(gᵢ)]`.

## Contributions (4 theorems, 1 def, 89 lines)

- `classRep` / `mk_classRep` — a chosen class representative via `ConjClasses.exists_rep`.
- `card_carrier_eq_index_centralizer` — pointwise bridge `|x| = [G : C_G(classRep x)]`.
- `classEquation_centralizer_index_form` — `|Z(G)| + Σ_{noncentral classes} [G : C_G(classRep x)] = |G|`, obtained by a single `finsum_mem_congr` summand rewrite; only `[Finite G]` is assumed.
- `sum_noncenter_index_eq_card_sub_center` — corollary `Σ [G : C_G(gᵢ)] = |G| − |Z(G)|`.
- `conjClass_card_eq_index_centralizer` — the per-class bridge re-derived to keep the file self-contained.

## Verification

Kernel-verified on **Mathlib v4.26.0** (`lake env lean`, exit 0).
`#print axioms` on both the main theorem and the corollary report only the
standard triple `{propext, Classical.choice, Quot.sound}` — **no `sorryAx`, no `Lean.ofReduceBool`**.

- Status: `verified`, badge `mathlib`, 0 sorries, 0 axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)