### PR TITLE
research(four-square-distribution-oq-05): full type-level Jacobi factor of 8

### DIFF
--- a/proofs/Proofs/FourSquareDistributionOQ05.lean
+++ b/proofs/Proofs/FourSquareDistributionOQ05.lean
@@ -33,15 +33,33 @@ so in particular `8 ∣ contribution t` once a type has ≥ 3 nonzero entries, a
 - `eight_dvd_contribution_of_three_le`     : 3 ≤ nonzeroCount t → 8  ∣ contribution t
 - `sixteen_dvd_contribution_of_four`       : nonzeroCount t = 4 → 16 ∣ contribution t
 
+### The full type-level factor of 8 (this revision)
+
+The previous revision proved only the *sign-part* `2^k` divisibility, leaving the
+parity of the *permutation* part in the one- and two-nonzero cases as the open
+step. That step is now closed:
+
+- `zero_pattern_one` / `zero_pattern_two` : sortedness pins the zero pattern
+  (`(0,0,0,a₄)` resp. `(0,0,a₃,a₄)`) once the nonzero count is `1` resp. `2`.
+- `permutations_one_nonzero`              : a one-nonzero type has exactly `4`
+  permutations, so its contribution is `4·2 = 8`.
+- `two_dvd_permutations_two_nonzero`      : a two-nonzero type has an *even*
+  permutation count (`6` or `12`), so its contribution `perm·4` is a multiple of `8`.
+- `eight_dvd_contribution_of_pos`         : **1 ≤ nonzeroCount t → 8 ∣ contribution t.**
+
+This is the per-type divisibility behind Jacobi's `8 ∣ r₄(n)` for `n ≥ 1`: combined
+with the additive decomposition `r₄(n) = Σ_types contribution t` (parent file), every
+summand is a multiple of `8`, hence so is the total.
+
 All results are fully machine-checked: 0 sorries, 0 `axiom` declarations.
 
 ## Honest scope
 
-The full statement `8 ∣ contribution t` for *every* type with ≥ 1 nonzero entry
-(which would give Jacobi's `8 ∣ r₄(n)` for n ≥ 1) additionally needs the parity
-of the *permutation* part in the one- and two-nonzero cases, and is NOT proved
-here. This file establishes only the sign-part `2^k` divisibility, which is
-exact for k ≤ nonzeroCount.
+`eight_dvd_contribution_of_pos` settles the per-type factor of `8`. Deriving the
+global `8 ∣ r₄(n)` from it additionally requires the parent's decomposition
+`r₄(n) = Σ contribution t` over the (finite) set of types — that summation lemma
+lives upstream and is not re-proved here; this file supplies the per-summand
+divisibility that the decomposition needs.
 
 ## References
 
@@ -103,5 +121,93 @@ theorem sixteen_dvd_contribution_of_four (t : RepType n)
     (h : t.nonzeroCount = 4) : 16 ∣ t.contribution := by
   have := two_pow_dvd_contribution_of_le t (le_of_eq h.symm)
   simpa using this
+
+/-! ### The full type-level factor of 8
+
+The sign part above gives `8 ∣ contribution` only for `nonzeroCount ≥ 3`. To reach
+`8 ∣ contribution` for *every* nonzero type we must also control the *permutation*
+part when `nonzeroCount ∈ {1, 2}`. Sortedness pins the zero pattern, and the
+multinomial permutation count is then computed explicitly. -/
+
+/-- A sorted type with exactly one nonzero entry has shape `(0,0,0,a₄)`, `a₄ ≠ 0`. -/
+theorem zero_pattern_one (t : RepType n) (h : t.nonzeroCount = 1) :
+    t.a₁ = 0 ∧ t.a₂ = 0 ∧ t.a₃ = 0 ∧ t.a₄ ≠ 0 := by
+  obtain ⟨s1, s2, s3⟩ := t.sorted
+  simp only [RepType.nonzeroCount] at h
+  by_cases h1 : t.a₁ = 0 <;> by_cases h2 : t.a₂ = 0 <;>
+    by_cases h3 : t.a₃ = 0 <;> by_cases h4 : t.a₄ = 0 <;> simp_all
+
+/-- A sorted type with exactly two nonzero entries has shape `(0,0,a₃,a₄)`, both nonzero. -/
+theorem zero_pattern_two (t : RepType n) (h : t.nonzeroCount = 2) :
+    t.a₁ = 0 ∧ t.a₂ = 0 ∧ t.a₃ ≠ 0 ∧ t.a₄ ≠ 0 := by
+  obtain ⟨s1, s2, s3⟩ := t.sorted
+  simp only [RepType.nonzeroCount] at h
+  by_cases h1 : t.a₁ = 0 <;> by_cases h2 : t.a₂ = 0 <;>
+    by_cases h3 : t.a₃ = 0 <;> by_cases h4 : t.a₄ = 0 <;> simp_all
+
+/-- The one-nonzero type `(0,0,0,a₄)` has exactly `4 = 4!/3!` permutations. -/
+theorem permutations_one_nonzero (t : RepType n)
+    (h1 : t.a₁ = 0) (h2 : t.a₂ = 0) (h3 : t.a₃ = 0) (h4 : t.a₄ ≠ 0) :
+    t.permutations = 4 := by
+  have h4' : (0 : ℕ) ≠ t.a₄ := Ne.symm h4
+  unfold RepType.permutations
+  simp only [h1, h2, h3]
+  rw [List.dedup_cons_of_mem (by simp), List.dedup_cons_of_mem (by simp),
+      List.dedup_cons_of_notMem (by simp [h4']), List.dedup_cons_of_notMem (by simp),
+      List.dedup_nil]
+  simp only [List.map_cons, List.map_nil, List.prod_cons, List.prod_nil, mul_one,
+    List.count_cons_self, List.count_cons_of_ne h4', List.count_nil,
+    List.count_cons_of_ne h4]
+  decide
+
+/-- The two-nonzero type `(0,0,a₃,a₄)` has an *even* permutation count
+    (`6 = 4!/(2!·2!)` when `a₃ = a₄`, `12 = 4!/2!` when `a₃ ≠ a₄`). -/
+theorem two_dvd_permutations_two_nonzero (t : RepType n)
+    (h1 : t.a₁ = 0) (h2 : t.a₂ = 0) (h3 : t.a₃ ≠ 0) (h4 : t.a₄ ≠ 0) :
+    2 ∣ t.permutations := by
+  have h3' : (0 : ℕ) ≠ t.a₃ := Ne.symm h3
+  have h4' : (0 : ℕ) ≠ t.a₄ := Ne.symm h4
+  unfold RepType.permutations
+  simp only [h1, h2]
+  rw [List.dedup_cons_of_mem (by simp), List.dedup_cons_of_notMem (by simp [h3', h4'])]
+  by_cases he : t.a₃ = t.a₄
+  · -- (0,0,v,v): permutations = 6
+    rw [he, List.dedup_cons_of_mem (by simp), List.dedup_cons_of_notMem (by simp),
+        List.dedup_nil]
+    simp only [List.map_cons, List.map_nil, List.prod_cons, List.prod_nil, mul_one,
+      List.count_cons_self, List.count_cons_of_ne h4', List.count_cons_of_ne h4,
+      List.count_nil]
+    decide
+  · -- (0,0,u,v): permutations = 12
+    have he' : t.a₄ ≠ t.a₃ := Ne.symm he
+    rw [List.dedup_cons_of_notMem (by simp [he]), List.dedup_cons_of_notMem (by simp),
+        List.dedup_nil]
+    simp only [List.map_cons, List.map_nil, List.prod_cons, List.prod_nil, mul_one,
+      List.count_cons_self, List.count_cons_of_ne h3', List.count_cons_of_ne h4',
+      List.count_cons_of_ne h3, List.count_cons_of_ne h4, List.count_cons_of_ne he,
+      List.count_cons_of_ne he', List.count_nil]
+    decide
+
+/-- **Jacobi's factor of 8, at the type level.** Every representation type with at
+    least one nonzero entry contributes a multiple of `8` to `r₄(n)`. For
+    `nonzeroCount ≥ 3` this is the sign part alone; the new content is the
+    `nonzeroCount ∈ {1, 2}` cases, where the permutation count supplies the
+    missing factors of `2`. -/
+theorem eight_dvd_contribution_of_pos (t : RepType n) (h : 1 ≤ t.nonzeroCount) :
+    8 ∣ t.contribution := by
+  have hle : t.nonzeroCount ≤ 4 := nonzeroCount_le_four t
+  unfold RepType.contribution RepType.signFactor
+  rcases (show t.nonzeroCount = 1 ∨ t.nonzeroCount = 2 ∨ 3 ≤ t.nonzeroCount from by omega)
+    with hc | hc | hc
+  · -- one nonzero: permutations = 4, signFactor = 2, contribution = 8
+    obtain ⟨e1, e2, e3, e4⟩ := zero_pattern_one t hc
+    rw [permutations_one_nonzero t e1 e2 e3 e4, hc]; decide
+  · -- two nonzero: 2 ∣ permutations, signFactor = 4, contribution = (even)·4
+    obtain ⟨e1, e2, e3, e4⟩ := zero_pattern_two t hc
+    obtain ⟨m, hm⟩ := two_dvd_permutations_two_nonzero t e1 e2 e3 e4
+    rw [hm, hc]; exact ⟨m, by ring⟩
+  · -- three or four nonzero: the sign part already gives 8
+    have := eight_dvd_contribution_of_three_le t hc
+    unfold RepType.contribution RepType.signFactor at this; exact this
 
 end FourSquareDistribution

--- a/src/data/proofs/four-square-distribution-oq-05/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-05/meta.json
@@ -5,7 +5,7 @@
   "description": "Supplies the divisibility structure of the per-type symmetry multiplier in the four-square type decomposition: the sign-change subgroup of order 2^(nonzeroCount) always divides a type's contribution. This is the '2^k' half of the hyperoctahedral symmetry B₄ = (ℤ/2)⁴ ⋊ S₄ underlying Jacobi's factor of 8, isolated per type — in particular 8 ∣ contribution once a type has ≥ 3 nonzero entries, and 16 ∣ contribution when all four are nonzero. The parent file proved only the bounds (≤ 384) and no divisibility.",
   "meta": {
     "author": "Lean Genius",
-    "date": "2026-06-21",
+    "date": "2026-06-23",
     "status": "verified",
     "proofRepoPath": "Proofs/FourSquareDistributionOQ05.lean",
     "tags": [
@@ -22,15 +22,19 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. Fully machine-checked with only Lean/Mathlib's foundational axioms (propext, Classical.choice, Quot.sound). Builds on the parent file FourSquareDistribution.lean's RepType / contribution / signFactor definitions.",
     "dateAdded": "2026-06-21",
-    "lineCount": 110,
-    "theoremCount": 7,
+    "lineCount": 213,
+    "theoremCount": 13,
     "definitionCount": 0,
     "originalContributions": [
       "two_pow_nonzeroCount_dvd_contribution (PROVED): 2^(nonzeroCount t) ∣ contribution t — the sign-change subgroup order divides the per-type multiplier (the parent file records no divisibility property of contribution)",
       "two_pow_dvd_contribution_of_le (PROVED): k ≤ nonzeroCount t → 2^k ∣ contribution t — the full 2-adic divisibility tower",
       "eight_dvd_contribution_of_three_le (PROVED): 8 ∣ contribution t when nonzeroCount t ≥ 3 — the 'factor of 8' from sign symmetry at the type level",
       "sixteen_dvd_contribution_of_four (PROVED): 16 ∣ contribution t when all four entries are nonzero",
-      "signFactor_dvd_contribution / two/four_dvd_contribution (PROVED): supporting divisibility lemmas and low-order specializations"
+      "signFactor_dvd_contribution / two/four_dvd_contribution (PROVED): supporting divisibility lemmas and low-order specializations",
+      "eight_dvd_contribution_of_pos (PROVED, this revision): 1 ≤ nonzeroCount t → 8 ∣ contribution t — the FULL type-level factor of 8 behind Jacobi 8 ∣ r₄(n). Upgrades the earlier nonzeroCount ≥ 3 result to ALL nonzero types by handling the permutation parity in the 1- and 2-nonzero cases.",
+      "permutations_one_nonzero (PROVED): a one-nonzero type (0,0,0,a₄) has exactly 4 permutations, so its contribution is 4·2 = 8.",
+      "two_dvd_permutations_two_nonzero (PROVED): a two-nonzero type (0,0,a₃,a₄) has an even permutation count (6 or 12), so its contribution perm·4 is a multiple of 8.",
+      "zero_pattern_one / zero_pattern_two (PROVED): sortedness pins the zero pattern from the nonzero count — the structural bridge that makes the permutation computation explicit."
     ],
     "mathlibDependencies": [
       {
@@ -106,24 +110,10 @@
     ]
   },
   "mainTheorems": [
-    {
-      "name": "two_pow_nonzeroCount_dvd_contribution",
-      "type": "theorem",
-      "description": "The sign-change subgroup order 2^(nonzeroCount) divides a type's contribution.",
-      "leanType": "{n : ℕ} → (t : RepType n) → 2 ^ t.nonzeroCount ∣ t.contribution"
-    },
-    {
-      "name": "two_pow_dvd_contribution_of_le",
-      "type": "theorem",
-      "description": "The 2-adic divisibility tower: 2^k ∣ contribution t for any k ≤ nonzeroCount t.",
-      "leanType": "{n : ℕ} → (t : RepType n) → {k : ℕ} → k ≤ t.nonzeroCount → 2 ^ k ∣ t.contribution"
-    },
-    {
-      "name": "eight_dvd_contribution_of_three_le",
-      "type": "theorem",
-      "description": "Factor of 8 at the type level: 8 ∣ contribution t when nonzeroCount t ≥ 3.",
-      "leanType": "{n : ℕ} → (t : RepType n) → 3 ≤ t.nonzeroCount → 8 ∣ t.contribution"
-    }
+    "eight_dvd_contribution_of_pos",
+    "two_pow_nonzeroCount_dvd_contribution",
+    "permutations_one_nonzero",
+    "two_dvd_permutations_two_nonzero"
   ],
   "sorries": 0,
   "leanFile": {
@@ -133,10 +123,10 @@
     ],
     "opens": [],
     "namespace": "FourSquareDistribution",
-    "lineCount": 110,
+    "lineCount": 213,
     "axiomCount": 0,
-    "theoremCount": 7,
-    "substantiveTheoremCount": 5,
+    "theoremCount": 13,
+    "substantiveTheoremCount": 11,
     "duplicateTheorems": 0,
     "definitionCount": 0,
     "path": "Proofs/FourSquareDistributionOQ05.lean",

--- a/src/data/research/problems/four-square-distribution-oq-05.json
+++ b/src/data/research/problems/four-square-distribution-oq-05.json
@@ -40,20 +40,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE (sign part): Proved 2^(nonzeroCount t) ∣ contribution t for every four-square type, hence 8 ∣ contribution when ≥3 nonzero and 16 ∣ when all 4 nonzero. New file FourSquareDistributionOQ05.lean, 110L, 8 thm, 0 sorry, 0 axiom. Parent had only bounds (≤384), no divisibility.",
+    "progressSummary": "COMPLETE (per-type factor of 8): eight_dvd_contribution_of_pos proves 1 ≤ nonzeroCount t → 8 ∣ contribution t for ALL nonzero types, closing the prior open step (permutation parity in the 1- and 2-nonzero cases). 213L, 13 thm, 0 sorry, 0 axiom, verified. The remaining gap to global 8 ∣ r₄(n) is only the parent decomposition lemma.",
     "builtItems": [
       "Created FourSquareDistributionOQ05.lean (110L, 8 thm, 0 sorry/axiom)",
       "two_pow_nonzeroCount_dvd_contribution + the 2-adic tower",
-      "eight/sixteen_dvd corollaries"
+      "eight/sixteen_dvd corollaries",
+      "eight_dvd_contribution_of_pos + zero_pattern_one/two + permutations_one_nonzero + two_dvd_permutations_two_nonzero in FourSquareDistributionOQ05.lean (now 213L, 13 thm, 0 sorry/axiom)"
     ],
     "insights": [
       "contribution = permutations·signFactor with signFactor = 2^nonzeroCount, so the 2-adic divisibility is STRUCTURAL (signFactor is literally a factor) — no number theory needed.",
       "The parent already proves the bounds (nonzeroCount_le_four, permutations_le_twentyfour, signFactor_le_sixteen, contribution_le_384) — reusing those names errors with 'already declared'; the NEW content is the divisibility.",
-      "Full 8 ∣ contribution for nz≥1 (⟹ 8 ∣ r₄(n)) needs evaluating the permutation count (dedup/count over symbolic tuples) in the 1- and 2-nonzero cases — left as the open step."
+      "Full 8 ∣ contribution for nz≥1 (⟹ 8 ∣ r₄(n)) needs evaluating the permutation count (dedup/count over symbolic tuples) in the 1- and 2-nonzero cases — left as the open step.",
+      "RESOLVED the open step: 8 ∣ contribution for EVERY nonzero type (eight_dvd_contribution_of_pos). Sortedness pins the zero pattern (zero_pattern_one/two), then the multinomial permutation count is even in the 2-nonzero case (6 or 12) and exactly 4 in the 1-nonzero case, supplying the missing factors of 2.",
+      "Technique: compute List-based permutations symbolically via List.dedup_cons_of_mem / dedup_cons_of_notMem to evaluate dedup, then List.count_cons_self / count_cons_of_ne (passing the specific ≠-hypotheses) to evaluate counts, finishing with decide on the numeric residue. Avoids native_decide → stays 0-axiom."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Permutation-parity lemmas for nonzeroCount ∈ {1,2} to upgrade to the full Jacobi 8 ∣ r₄(n)."
+      "Upstream: prove the additive decomposition r₄(n) = Σ_types contribution t (parent file) to derive the global 8 ∣ r₄(n) for n ≥ 1 from the per-type divisibility now in hand."
     ],
     "markdown": "# Knowledge Base: four-square-distribution-oq-05\n\nCompleted the sign-part divisibility of the symmetry multiplier. See FourSquareDistributionOQ05.lean."
   },


### PR DESCRIPTION
## Summary
Research session for `four-square-distribution-oq-05` (2-adic structure of the four-square symmetry multiplier).

The prior revision proved only the **sign-part** divisibility `2^(nonzeroCount) ∣ contribution`, which gives `8 ∣ contribution` only when a type has `nonzeroCount ≥ 3`. It explicitly left as the open step the parity of the **permutation** part in the one- and two-nonzero cases. **This PR closes that step.**

## Progress
New theorems in `proofs/Proofs/FourSquareDistributionOQ05.lean`:

- `zero_pattern_one` / `zero_pattern_two` — sortedness pins the zero pattern: a type with exactly one (resp. two) nonzero entries has shape `(0,0,0,a₄)` (resp. `(0,0,a₃,a₄)`).
- `permutations_one_nonzero` — a one-nonzero type has exactly `4 = 4!/3!` permutations, so its contribution is `4·2 = 8`.
- `two_dvd_permutations_two_nonzero` — a two-nonzero type has an **even** permutation count (`6 = 4!/(2!·2!)` when `a₃ = a₄`, `12 = 4!/2!` otherwise), so its contribution `perm·4` is a multiple of `8`.
- `eight_dvd_contribution_of_pos` — **`1 ≤ nonzeroCount t → 8 ∣ contribution t`**, the full type-level factor of 8.

## Findings
- The combinatorial obstruction was purely in evaluating the `List.dedup`/`List.count`-based `permutations` definition on a symbolic-but-structured 4-tuple. Resolved by `List.dedup_cons_of_mem` / `dedup_cons_of_notMem` to reduce `dedup`, then `List.count_cons_self` / `count_cons_of_ne` (fed the specific `≠`-hypotheses) to evaluate counts, finishing with `decide` on the numeric residue.
- Crucially this avoids `native_decide`, so the file stays **verified / 0-axiom** — `#print axioms eight_dvd_contribution_of_pos` shows only `[propext, Classical.choice, Quot.sound]`.

## Verification
- `lake env lean Proofs/FourSquareDistributionOQ05.lean`: 0 errors, 0 warnings, 0 sorries (Docker wedged; kernel-verified via `lake env lean` over the shared olean cache, parent olean rebuilt).
- File: 213 lines, 13 theorems, 0 `axiom` declarations, 0 sorries.

## Status
**Outcome**: completed (per-type factor of 8 fully proved)
**Next Steps**: the only remaining gap to the global `8 ∣ r₄(n)` for `n ≥ 1` is the parent's additive decomposition `r₄(n) = Σ_types contribution t`; combined with this per-summand divisibility it yields Jacobi's congruence.

🤖 Generated by researcher-6