### PR TITLE
Enrich ℤ[√d] PID/UFD + prime-norm irreducibility (bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02): add annotations.json

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-zsqrtd-pidufd-overview",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "From Euclidean Domain to PID, UFD, and Prime Norms",
+    "content": "The docstring sets the agenda. The parent file made ℤ[√d] a Euclidean domain uniformly for every −2 ≤ d < 0 (a single nearest-lattice-point division). This file harvests the two standard structural consequences — principal ideal ring and unique factorization monoid — via the chain EuclideanDomain ⟹ PID ⟹ UFD, specialising to the Gaussian integers ℤ[√-1] and to ℤ[√-2]. It then adds the one piece of genuine arithmetic the norm contributes: an element of prime norm is irreducible (for ANY d), hence prime in the UFD range. The structural part is pure Mathlib typeclass plumbing; the prime-norm criterion is the new mathematical substance.",
+    "mathContext": "$\\text{EuclideanDomain} \\Rightarrow \\text{PID} \\Rightarrow \\text{UFD}; \\quad |N(z)| \\text{ prime} \\Rightarrow z \\text{ irreducible}.$",
+    "significance": "context",
+    "relatedConcepts": ["Euclidean domain", "principal ideal ring", "unique factorization", "quadratic integers", "Gaussian integers"],
+    "prerequisites": ["ring theory", "algebraic number theory"]
+  },
+  {
+    "id": "ann-zsqrtd-pidufd-structure",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 48, "endLine": 63 },
+    "type": "technique",
+    "title": "PID and UFD by Typeclass Inference",
+    "content": "isPrincipalIdealRing and uniqueFactorizationMonoid show ℤ[√d] is a PID and a UFD for every −2 ≤ d < 0. The mechanism is elegant: the parent's euclideanDomain d value is introduced as a local instance via letI, and then inferInstance lets Lean's typeclass resolution build IsPrincipalIdealRing (through EuclideanDomain.to_principal_ideal_domain) and UniqueFactorizationMonoid (through PrincipalIdealRing.to_uniqueFactorizationMonoid) automatically. The UFD statement must carry the letI instance in its very type, because UniqueFactorizationMonoid (ℤ√d) requires the CancelCommMonoidWithZero structure that the EuclideanDomain instance supplies. One derivation covers the whole family.",
+    "mathContext": "$-2 \\le d < 0 \\Rightarrow \\mathbb{Z}[\\sqrt d] \\text{ is a PID and a UFD}.$",
+    "significance": "key",
+    "relatedConcepts": ["typeclass inference", "letI local instance", "to_principal_ideal_domain", "to_uniqueFactorizationMonoid"],
+    "prerequisites": ["Lean typeclass resolution", "EuclideanDomain ⟹ PID ⟹ UFD"]
+  },
+  {
+    "id": "ann-zsqrtd-pidufd-classical",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 65, "endLine": 87 },
+    "type": "theorem",
+    "title": "The Two Classical Rings: ℤ[i] and ℤ[√-2]",
+    "content": "Four corollaries specialise the uniform family to its two named members. gaussianInt_isPrincipalIdealRing and gaussianInt_uniqueFactorizationMonoid give the Gaussian integers ℤ[i] = ℤ[√-1] (d = −1); negTwo_isPrincipalIdealRing and negTwo_uniqueFactorizationMonoid give ℤ[√-2] (d = −2). The PID statements just discharge the −2 ≤ d < 0 side goals with norm_num; the UFD statements reuse the parent's specialised euclideanDomainNegOne / euclideanDomainNegTwo instances. These are the classical rings underlying sum-of-two-squares (Gaussian) and the arithmetic of ℤ[√-2].",
+    "mathContext": "$\\mathbb{Z}[i] = \\mathbb{Z}[\\sqrt{-1}] \\text{ and } \\mathbb{Z}[\\sqrt{-2}] \\text{ are PIDs and UFDs.}$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gaussian integers", "sum of two squares", "norm_num", "specialisation"],
+    "prerequisites": ["quadratic integer rings"]
+  },
+  {
+    "id": "ann-zsqrtd-pidufd-prime-norm",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 89, "endLine": 111 },
+    "type": "insight",
+    "title": "Prime Norm ⟹ Irreducible, Unconditionally in d",
+    "content": "irreducible_of_prime_norm is the genuinely arithmetic contribution. If |N(z)| is a prime natural number, then z is irreducible in ℤ[√d] — for ANY d, with no Euclidean or sign hypothesis. The proof has two parts. (1) z is not a unit: a unit would give |N(z)| = 1 (Zsqrtd.norm_eq_one_iff), contradicting primality. (2) Any factorization z = a·b splits the prime: norm multiplicativity (Zsqrtd.norm_mul) and Int.natAbs_mul give |N(z)| = |N(a)|·|N(b)|, and Prime.irreducible.isUnit_or_isUnit forces one of |N(a)|, |N(b)| to be 1, i.e. that factor is a unit. Both norm lemmas are unconditional in d, so the criterion holds far outside the Euclidean range −2 ≤ d < 0.",
+    "mathContext": "$|N(z)| = |N(a)|\\cdot|N(b)| \\text{ prime} \\Rightarrow |N(a)| = 1 \\text{ or } |N(b)| = 1 \\Rightarrow a \\text{ or } b \\text{ a unit}.$",
+    "significance": "key",
+    "relatedConcepts": ["norm multiplicativity", "irreducibility", "norm_eq_one_iff", "prime splitting"],
+    "prerequisites": ["norm of quadratic integers", "irreducible elements"]
+  },
+  {
+    "id": "ann-zsqrtd-pidufd-prime",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02",
+    "range": { "startLine": 113, "endLine": 118 },
+    "type": "theorem",
+    "title": "Upgrading Irreducible to Prime in the UFD Range",
+    "content": "prime_of_prime_norm closes the loop: in the UFD range −2 ≤ d < 0, a prime-norm element is not merely irreducible but prime. The proof reinstates the parent's euclideanDomain instance (so ℤ[√d] is known to be a UFD), then applies UniqueFactorizationMonoid.irreducible_iff_prime — in a UFD, irreducible and prime coincide — to the previous theorem. This is exactly where the structural UFD result and the arithmetic prime-norm criterion combine: the unconditional irreducibility plus the conditional UFD structure yields primality.",
+    "mathContext": "$-2 \\le d < 0,\\ |N(z)| \\text{ prime} \\Rightarrow z \\text{ prime (since irreducible} \\Leftrightarrow \\text{prime in a UFD).}$",
+    "significance": "key",
+    "relatedConcepts": ["irreducible_iff_prime", "prime elements", "UFD", "unconditional vs conditional"],
+    "prerequisites": ["irreducible vs prime in a UFD"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass: bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03-oq-02

This entry — ℤ[√d] is a PID and UFD for −2 ≤ d < 0 (recovering ℤ[i] and ℤ[√-2]), plus the prime-norm irreducibility criterion — had a richly populated `meta.json` but **no `annotations.json`**. This pass adds the inline-annotation layer.

### Added
- **`annotations.json`** with 5 inline annotations covering the full Lean file, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Euclidean → PID → UFD → prime-norm overview
  2. PID and UFD by typeclass inference (`letI` + `inferInstance`)
  3. The two classical rings ℤ[i] and ℤ[√-2]
  4. Prime norm ⟹ irreducible, unconditional in d (norm multiplicativity + `norm_eq_one_iff`)
  5. Upgrading irreducible to prime in the UFD range (`irreducible_iff_prime`)

### Verification
- `pnpm build` succeeds; entry not flagged.
- JSON validated; annotation line ranges align with the Lean source sections.
- No axiom/status claims altered — meta correctly reports `verified` / 0 axioms / 0 sorries.