### PR TITLE
research(chinese-remainder-constructive-oq-05-oq-01): axiom-free CRT on composite coprime moduli + three-modulus certificate

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -704,6 +704,7 @@ import Proofs.ChebyshevSumWeightedOQ01OQ01OQ03
 import Proofs.ChevalleyWarningTheoremOQ01
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ05
+import Proofs.ChineseRemainderConstructiveOQ05OQ01
 import Proofs.ChineseRemainderConstructiveOQ03
 import Proofs.ChineseRemainderConstructiveOQ03OQ01
 import Proofs.ChineseRemainderConstructiveOQ03OQ03

--- a/proofs/Proofs/ChineseRemainderConstructiveOQ05OQ01.lean
+++ b/proofs/Proofs/ChineseRemainderConstructiveOQ05OQ01.lean
@@ -1,0 +1,110 @@
+/-
+# Axiom-free CRT worked examples on composite coprime moduli (OQ-05-OQ-01)
+
+The sibling entry **chinese-remainder-constructive-oq-05** removed the root CRT
+entry's `native_decide` from its two headline worked examples (Sunzi `x = 23`
+mod `105` and the four-moduli `x = 53` mod `210`), packaging the argument into a
+reusable two-modulus certificate
+
+    `crt_pair_iff : Coprime m n → N < m*n → N % m = a → N % n = b →
+        ∀ x < m*n, (x % m = a ∧ x % n = b) ↔ x = N`
+
+whose only axioms are the ordinary foundational `propext / Classical.choice /
+Quot.sound`.  Every numeric check there is a kernel `decide` / `omega`, never the
+compiler-trusting `native_decide` (which would inject `Lean.ofReduceBool`).
+
+This entry continues that programme on the remaining advertised worked examples,
+which use **composite (non-prime) coprime moduli** — the regime where a careless
+`native_decide` is most tempting because `decide` on `Nat.Coprime` unfolds a `gcd`:
+
+* `crt_17_mod_20`   : over `0 ≤ x < 20 = 4·5`,   `x ≡ 1 (4) ∧ x ≡ 2 (5)  ↔ x = 17`.
+* `crt_135_mod_143` : over `0 ≤ x < 143 = 11·13`, `x ≡ 3 (11) ∧ x ≡ 5 (13) ↔ x = 135`.
+
+Both are one-line instances of `crt_pair_iff`, so they inherit its axiom profile.
+We also reprove the small `x = 8` mod `15` example that the list-based sibling
+`...OQ04OQ02` discharges with `native_decide`, here entirely kernel-checked.
+
+Finally we extend the certificate to **three pairwise-coprime moduli**
+
+    `crt_triple_iff : Coprime m n → Coprime m p → Coprime n p → N < m*n*p →
+        N % m = a → N % n = b → N % p = c →
+        ∀ x < m*n*p, (x % m = a ∧ x % n = b ∧ x % p = c) ↔ x = N`
+
+— the genuinely new infrastructure of this file (the sibling stopped at two
+moduli) — and exercise it on a fresh composite-modulus example `x = 11` mod `60`.
+
+`#print axioms` on every theorem below lists only `propext`, `Classical.choice`,
+`Quot.sound`: no `native_decide`, no `Lean.ofReduceBool`, no `sorry`, no `axiom`.
+-/
+import Mathlib
+import Proofs.ChineseRemainderConstructiveOQ05
+
+namespace ChineseRemainderConstructiveOQ05OQ01
+
+open ChineseRemainderConstructiveOQ05
+
+/- ## Composite-modulus worked examples via the two-modulus certificate -/
+
+/-- **`17` mod `20`, axiom-free.** The moduli `4` and `5` are coprime but not
+prime; over `0 ≤ x < 20` the congruences `x ≡ 1 (mod 4)` and `x ≡ 2 (mod 5)`
+hold *iff* `x = 17`.  A direct instance of `crt_pair_iff` — no `native_decide`. -/
+theorem crt_17_mod_20 (x : ℕ) (hx : x < 20) :
+    (x % 4 = 1 ∧ x % 5 = 2) ↔ x = 17 :=
+  crt_pair_iff (by decide) (by decide) (by decide) (by decide) x hx
+
+/-- **`135` mod `143`, axiom-free.** With the coprime composite range `143 = 11·13`,
+over `0 ≤ x < 143` the congruences `x ≡ 3 (mod 11)` and `x ≡ 5 (mod 13)` hold
+*iff* `x = 135`.  Again a single application of `crt_pair_iff`. -/
+theorem crt_135_mod_143 (x : ℕ) (hx : x < 143) :
+    (x % 11 = 3 ∧ x % 13 = 5) ↔ x = 135 :=
+  crt_pair_iff (by decide) (by decide) (by decide) (by decide) x hx
+
+/-- **`8` mod `15`, axiom-free.** The list-based sibling `...OQ04OQ02` proves the
+analogous `example_8_mod3_mod5` with `native_decide`; here the same fact is a
+kernel-checked instance of `crt_pair_iff` over `15 = 3·5`. -/
+theorem crt_8_mod_15 (x : ℕ) (hx : x < 15) :
+    (x % 3 = 2 ∧ x % 5 = 3) ↔ x = 8 :=
+  crt_pair_iff (by decide) (by decide) (by decide) (by decide) x hx
+
+/- ## A reusable axiom-free three-modulus certificate -/
+
+/-- **Three-modulus CRT certificate, axiom-free.** For pairwise coprime moduli
+`m, n, p` and a witness `N < m*n*p` matching all three residues, over the range
+`0 ≤ x < m*n*p` the three congruences hold *iff* `x = N`.
+
+This extends the sibling's two-modulus `crt_pair_iff` by folding in the third
+modulus with `Nat.modEq_and_modEq_iff_modEq_mul`, using `m·n` coprime to `p`
+(`Nat.Coprime.mul`).  Like the pair version it certifies existence and uniqueness
+in one `iff` and uses only kernel `omega`, never `native_decide`. -/
+theorem crt_triple_iff {m n p N : ℕ}
+    (hmn : Nat.Coprime m n) (hmp : Nat.Coprime m p) (hnp : Nat.Coprime n p)
+    (hN : N < m * n * p) {a b c : ℕ}
+    (ha : N % m = a) (hb : N % n = b) (hc : N % p = c)
+    (x : ℕ) (hx : x < m * n * p) :
+    (x % m = a ∧ x % n = b ∧ x % p = c) ↔ x = N := by
+  constructor
+  · rintro ⟨hxa, hxb, hxc⟩
+    have em : x ≡ N [MOD m] := by unfold Nat.ModEq; omega
+    have en : x ≡ N [MOD n] := by unfold Nat.ModEq; omega
+    have ep : x ≡ N [MOD p] := by unfold Nat.ModEq; omega
+    have emn : x ≡ N [MOD m * n] :=
+      (Nat.modEq_and_modEq_iff_modEq_mul hmn).mp ⟨em, en⟩
+    have hmnp : Nat.Coprime (m * n) p := hmp.mul_left hnp
+    have emnp : x ≡ N [MOD m * n * p] :=
+      (Nat.modEq_and_modEq_iff_modEq_mul hmnp).mp ⟨emn, ep⟩
+    have hxmod : x % (m * n * p) = N % (m * n * p) := emnp
+    rw [Nat.mod_eq_of_lt hx, Nat.mod_eq_of_lt hN] at hxmod
+    exact hxmod
+  · rintro rfl
+    exact ⟨ha, hb, hc⟩
+
+/-- **`11` mod `60`, axiom-free.** A fresh three-modulus example on the pairwise
+coprime composite range `60 = 3·4·5`: over `0 ≤ x < 60` the congruences
+`x ≡ 2 (mod 3)`, `x ≡ 3 (mod 4)`, `x ≡ 1 (mod 5)` hold *iff* `x = 11`.  A direct
+instance of `crt_triple_iff`. -/
+theorem crt_11_mod_60 (x : ℕ) (hx : x < 60) :
+    (x % 3 = 2 ∧ x % 4 = 3 ∧ x % 5 = 1) ↔ x = 11 :=
+  crt_triple_iff (by decide) (by decide) (by decide) (by decide)
+    (by decide) (by decide) (by decide) x hx
+
+end ChineseRemainderConstructiveOQ05OQ01

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-pair-examples",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-01",
+    "range": {
+      "startLine": 51,
+      "endLine": 68
+    },
+    "type": "insight",
+    "title": "Composite Coprime Moduli Without native_decide",
+    "content": "crt_17_mod_20 (4·5), crt_135_mod_143 (11·13), and crt_8_mod_15 (3·5) are each a single application of the sibling's crt_pair_iff. The four side conditions — Coprime of the two moduli, the witness below the product, and the two residue computations N % m = a, N % n = b — are kernel `decide` (the gcd and modular reductions are ordinary kernel computation, not native code), and the range hypothesis x < (product) is definitionally the required x < m·n. Because the proofs are instances of crt_pair_iff, they inherit its axiom profile {propext, Classical.choice, Quot.sound} for free — no Lean.ofReduceBool. crt_8_mod_15 is the kernel-checked counterpart of the native_decide example_8_mod3_mod5 in the list-based sibling ...OQ04OQ02."
+  },
+  {
+    "id": "ann-triple-certificate",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-01",
+    "range": {
+      "startLine": 79,
+      "endLine": 99
+    },
+    "type": "insight",
+    "title": "Folding in a Third Modulus",
+    "content": "crt_triple_iff extends crt_pair_iff by one fold. Forward: each residue equation x % mᵢ = aᵢ becomes a congruence x ≡ N [MOD mᵢ] (Nat.ModEq unfolds to x % mᵢ = N % mᵢ, closed by omega using the literal residue of N). Nat.modEq_and_modEq_iff_modEq_mul combines m and n into m·n; to fold in p one needs Coprime (m·n) p, supplied by Nat.Coprime.mul_left from Coprime m p and Coprime n p. A second application gives x ≡ N modulo m·n·p, and Nat.mod_eq_of_lt on both x and N (both below the product) collapses it to x = N. The reverse direction is just the three residues of N. Only kernel omega is used — no native_decide."
+  },
+  {
+    "id": "ann-triple-example",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-01",
+    "range": {
+      "startLine": 105,
+      "endLine": 108
+    },
+    "type": "concept",
+    "title": "Three Composite Moduli at Once",
+    "content": "crt_11_mod_60 instantiates crt_triple_iff on the pairwise-coprime composite range 60 = 3·4·5: over 0 ≤ x < 60, (x ≡ 2 mod 3 ∧ x ≡ 3 mod 4 ∧ x ≡ 1 mod 5) ↔ x = 11. The seven side conditions (three pairwise coprimalities, the witness bound, three residues) are all kernel decide. This is the three-modulus analogue of the sibling's pair examples and the next rung toward a fully list-indexed CRT certificate."
+  },
+  {
+    "id": "ann-axiom-free",
+    "proofId": "chinese-remainder-constructive-oq-05-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 44
+    },
+    "type": "concept",
+    "title": "Axiom Profile Confirmed",
+    "content": "#print axioms on all five theorems (crt_17_mod_20, crt_135_mod_143, crt_8_mod_15, crt_triple_iff, crt_11_mod_60) lists only propext, Classical.choice, Quot.sound. No Lean.ofReduceBool (which native_decide would inject), no sorryAx, no axiom declarations. The entry demonstrates that even composite-modulus residue and coprimality checks need no native_decide: kernel decide suffices and stays within the ordinary foundational axioms."
+  }
+]

--- a/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-05-oq-01/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "chinese-remainder-constructive-oq-05-oq-01",
+  "title": "Axiom-Free CRT on Composite Coprime Moduli + a Three-Modulus Certificate",
+  "slug": "chinese-remainder-constructive-oq-05-oq-01",
+  "description": "Continues the sibling entry chinese-remainder-constructive-oq-05 (which removed native_decide from the root CRT entry's Sunzi and four-moduli worked examples and packaged the argument into a reusable two-modulus certificate crt_pair_iff) onto the remaining advertised worked examples, which use COMPOSITE (non-prime) coprime moduli — the regime where a careless native_decide is most tempting because kernel decide on Nat.Coprime must unfold a gcd. It proves crt_17_mod_20 (over x < 20 = 4·5, x ≡ 1 (4) ∧ x ≡ 2 (5) ↔ x = 17) and crt_135_mod_143 (over x < 143 = 11·13, x ≡ 3 (11) ∧ x ≡ 5 (13) ↔ x = 135) as one-line instances of crt_pair_iff, and reproves the x = 8 mod 15 example that the list-based sibling ...OQ04OQ02 discharges with native_decide. It then extends the certificate to three pairwise-coprime moduli — the genuinely new crt_triple_iff (the sibling stopped at two) — and exercises it on a fresh composite example crt_11_mod_60 (over x < 60 = 3·4·5, x ≡ 2 (3) ∧ x ≡ 3 (4) ∧ x ≡ 1 (5) ↔ x = 11). #print axioms confirms every theorem depends only on propext, Classical.choice, Quot.sound — no native_decide, no Lean.ofReduceBool, no sorry, no axiom.",
+  "meta": {
+    "author": "Classical (Chinese Remainder Theorem); formalized in Lean 4",
+    "date": "400",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChineseRemainderConstructiveOQ05OQ01.lean",
+    "tags": [
+      "number-theory",
+      "chinese-remainder-theorem",
+      "modular-arithmetic",
+      "axiom-free",
+      "native-decide-removal",
+      "coprime-moduli",
+      "research"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 110,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "originalContributions": [
+      "crt_triple_iff: a reusable, axiom-free THREE-pairwise-coprime-modulus CRT certificate — for coprime m, n, p and an in-range witness N matching all three residues, over 0 ≤ x < m·n·p the three congruences hold iff x = N. Extends the sibling's two-modulus crt_pair_iff by folding the third modulus with Nat.modEq_and_modEq_iff_modEq_mul, using m·n coprime to p (Nat.Coprime.mul_left). Certifies existence and uniqueness in one iff with only kernel omega.",
+      "crt_17_mod_20: over 0 ≤ x < 20 = 4·5, (x ≡ 1 mod 4 ∧ x ≡ 2 mod 5) ↔ x = 17 — a composite-modulus worked example, axiom-free.",
+      "crt_135_mod_143: over 0 ≤ x < 143 = 11·13, (x ≡ 3 mod 11 ∧ x ≡ 5 mod 13) ↔ x = 135 — a larger composite-modulus example, axiom-free.",
+      "crt_8_mod_15: over 0 ≤ x < 15 = 3·5, (x ≡ 2 mod 3 ∧ x ≡ 3 mod 5) ↔ x = 8 — the kernel-checked counterpart of the sibling ...OQ04OQ02's native_decide example_8_mod3_mod5.",
+      "crt_11_mod_60: over 0 ≤ x < 60 = 3·4·5, (x ≡ 2 mod 3 ∧ x ≡ 3 mod 4 ∧ x ≡ 1 mod 5) ↔ x = 11 — a fresh three-modulus instance of crt_triple_iff.",
+      "All five theorems verified by #print axioms to depend only on propext, Classical.choice, Quot.sound — no Lean.ofReduceBool, demonstrating native_decide is unnecessary even for composite-modulus residue checks."
+    ],
+    "prerequisites": [
+      "Chinese Remainder Theorem for pairwise-coprime moduli",
+      "Nat.ModEq, Nat.modEq_and_modEq_iff_modEq_mul, Nat.Coprime.mul_left (Mathlib)",
+      "The reusable two-modulus certificate crt_pair_iff (sibling chinese-remainder-constructive-oq-05)",
+      "The distinction between kernel decide (axiom-free) and native_decide (uses Lean.ofReduceBool)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.modEq_and_modEq_iff_modEq_mul",
+        "description": "For coprime m, n: a ≡ b [MOD m] ∧ a ≡ b [MOD n] ↔ a ≡ b [MOD m*n] — the inductive heart of CRT, applied twice for three moduli.",
+        "module": "Mathlib.Data.Nat.ModEq"
+      },
+      {
+        "theorem": "Nat.Coprime.mul_left",
+        "description": "Coprime m k → Coprime n k → Coprime (m*n) k — lets the folded modulus m·n be combined with the third modulus p.",
+        "module": "Mathlib.Data.Nat.GCD.Basic"
+      },
+      {
+        "theorem": "Nat.mod_eq_of_lt",
+        "description": "x < n → x % n = x — turns a congruence modulo the product into an equality within the range.",
+        "module": "Mathlib.Data.Nat.Defs"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The Chinese Remainder Theorem, originating in Sunzi Suanjing (3rd–5th century CE), guarantees a unique solution modulo the product of pairwise-coprime moduli to a system of simultaneous congruences. The root gallery entry formalizes the general constructive CRT axiom-free, but verifies its concrete worked examples with native_decide; the sibling chinese-remainder-constructive-oq-05 de-axiomatized the Sunzi (23 mod 105) and four-moduli (53 mod 210) examples and abstracted the argument into a two-modulus certificate crt_pair_iff. This entry pushes that programme onto composite (non-prime) coprime moduli — 4·5, 11·13, 3·4·5 — precisely where native_decide is most tempting, since a kernel decide on Nat.Coprime must reduce a gcd.",
+    "problemStatement": "**Open Question (sibling chinese-remainder-constructive-oq-05)**: apply the same de-axiomatization to the remaining native_decide worked examples (composite-modulus instances such as 17 mod 20 and 135 mod 143), and generalize crt_pair_iff toward more moduli.\n\n**This entry**: proves the composite-modulus examples 17 mod 20 (= 4·5), 135 mod 143 (= 11·13), and 8 mod 15 (= 3·5) without native_decide as existence-and-uniqueness iffs; introduces a reusable axiom-free three-modulus certificate crt_triple_iff; and exercises it on 11 mod 60 (= 3·4·5). All confirmed axiom-free by #print axioms.",
+    "text": "A 110-line, fully verified file (0 sorries, 0 axioms, NO native_decide) importing Mathlib and the sibling crt_pair_iff. crt_17_mod_20, crt_135_mod_143, crt_8_mod_15 are one-line instances of crt_pair_iff on composite coprime moduli; crt_triple_iff is the new reusable three-modulus certificate; crt_11_mod_60 instantiates it. Every theorem's axiom dependency is exactly {propext, Classical.choice, Quot.sound}.",
+    "proofStrategy": "The two-modulus examples are direct applications of the sibling's crt_pair_iff: the four side conditions (coprimality of the moduli, the witness below the product, and the two residue computations) are each kernel decide, and the range hypothesis x < ∏ is definitionally the required x < m·n. crt_triple_iff repeats the sibling's pattern with one extra fold: the residue equations become congruences x ≡ N [MOD mᵢ] (each Nat.ModEq unfolds to x % mᵢ = N % mᵢ, closed by omega), then Nat.modEq_and_modEq_iff_modEq_mul combines m,n into m·n, and again — using Nat.Coprime.mul_left to certify Coprime (m·n) p — folds in p, giving x ≡ N modulo m·n·p; Nat.mod_eq_of_lt on both x and N collapses this to x = N. The reverse direction is the residues of N. crt_11_mod_60 is then a single instance.",
+    "keyInsights": [
+      "native_decide is unnecessary even for composite-modulus residue and coprimality checks: kernel decide reduces the underlying gcd and modular arithmetic and depends only on the ordinary foundational axioms, never Lean.ofReduceBool.",
+      "Reuse beats recomputation: the composite-modulus examples are one-line instances of the sibling's crt_pair_iff, so they inherit its axiom profile for free — no new tactic gymnastics per example.",
+      "Three moduli need only one extra fold: Nat.modEq_and_modEq_iff_modEq_mul applied twice, with Nat.Coprime.mul_left supplying coprimality of the partial product m·n to the next modulus p.",
+      "Stating each example as an iff (residues) ↔ (x = N) over the range packages existence and uniqueness into one axiom-free theorem, exactly as in the two-modulus sibling.",
+      "crt_triple_iff is the natural next rung toward a fully general list-indexed CRT certificate connecting to the oq-04 list thread."
+    ]
+  },
+  "sections": [
+    {
+      "id": "pair-examples",
+      "title": "Composite-Modulus Examples via crt_pair_iff",
+      "startLine": 48,
+      "endLine": 68,
+      "summary": "crt_17_mod_20 (4·5), crt_135_mod_143 (11·13), and crt_8_mod_15 (3·5) — composite coprime moduli as one-line instances of the sibling's two-modulus certificate, all kernel-checked.",
+      "mathContext": "The remaining worked examples de-axiomatized; crt_8_mod_15 mirrors the native_decide example_8_mod3_mod5 of sibling ...OQ04OQ02."
+    },
+    {
+      "id": "triple-certificate",
+      "title": "A Reusable Axiom-Free Three-Modulus Certificate",
+      "startLine": 71,
+      "endLine": 99,
+      "summary": "crt_triple_iff: for pairwise-coprime m, n, p and an in-range witness N, the three congruences hold iff x = N — extending crt_pair_iff by one fold via Nat.Coprime.mul_left.",
+      "mathContext": "The genuinely new infrastructure: the sibling stopped at two moduli."
+    },
+    {
+      "id": "triple-example",
+      "title": "A Fresh Three-Modulus Example",
+      "startLine": 101,
+      "endLine": 108,
+      "summary": "crt_11_mod_60: over x < 60 = 3·4·5, (x ≡ 2 mod 3 ∧ x ≡ 3 mod 4 ∧ x ≡ 1 mod 5) ↔ x = 11 — a single instance of crt_triple_iff.",
+      "mathContext": "Exercises the three-modulus certificate on composite coprime moduli."
+    }
+  ],
+  "conclusion": {
+    "summary": "Building on the sibling's two-modulus certificate, this entry de-axiomatizes the remaining composite-modulus CRT worked examples (17 mod 20, 135 mod 143, 8 mod 15) as existence-and-uniqueness iffs without native_decide, and adds a reusable axiom-free three-modulus certificate crt_triple_iff with a fresh instance (11 mod 60). #print axioms confirms dependence only on propext, Classical.choice, Quot.sound.",
+    "implications": "Composite coprime moduli are no obstacle to axiom-free CRT certificates: kernel decide settles the gcd and residue checks, and crt_pair_iff / crt_triple_iff let new numeric instances be obtained by one-line instantiation rather than per-example native_decide. crt_triple_iff is the next rung toward a fully list-indexed, axiom-free CRT certificate.",
+    "openQuestions": [
+      "Generalize crt_pair_iff / crt_triple_iff to an arbitrary list of pairwise-coprime moduli (an inductive, axiom-free CRT certificate), connecting to the oq-04 list thread and superseding its native_decide example checks.",
+      "Provide a tactic or elaborator that, given a list of (modulus, residue) pairs with pairwise-coprime moduli, emits an axiom-free CRT certificate and the unique in-range witness automatically.",
+      "Quantify the kernel cost of decide on Nat.Coprime for large composite moduli and identify the modulus size at which an explicit Bézout witness becomes preferable to gcd reduction."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chinese-remainder-constructive-oq-05",
+      "relationship": "extends",
+      "description": "Sibling/parent: removed native_decide from the Sunzi and four-moduli examples and introduced crt_pair_iff. This entry reuses crt_pair_iff on composite moduli and adds the three-modulus crt_triple_iff."
+    },
+    {
+      "targetId": "chinese-remainder-constructive-oq-04",
+      "relationship": "related",
+      "description": "The list/inductive CRT thread; crt_triple_iff is the three-modulus rung a fully list-indexed certificate would iterate, and crt_8_mod_15 is the kernel-checked counterpart of ...OQ04OQ02's native_decide example."
+    },
+    {
+      "targetId": "chinese-remainder-constructive",
+      "relationship": "related",
+      "description": "Root constructive-CRT entry whose worked examples use native_decide; this entry continues their de-axiomatization on composite coprime moduli."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChineseRemainderConstructiveOQ05"
+    ],
+    "opens": [
+      "ChineseRemainderConstructiveOQ05"
+    ],
+    "namespace": "ChineseRemainderConstructiveOQ05OQ01",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "crt_triple_iff",
+        "type": "core",
+        "description": "Reusable axiom-free three-pairwise-coprime-modulus CRT certificate: for coprime m, n, p and an in-range witness N matching all three residues, over x < m·n·p the three congruences hold iff x = N.",
+        "leanType": "{m n p N : ℕ} → m.Coprime n → m.Coprime p → n.Coprime p → N < m*n*p → {a b c : ℕ} → N % m = a → N % n = b → N % p = c → (x : ℕ) → x < m*n*p → ((x % m = a ∧ x % n = b ∧ x % p = c) ↔ x = N)"
+      },
+      {
+        "name": "crt_135_mod_143",
+        "type": "key",
+        "description": "Composite-modulus example: over x < 143 = 11·13, (x%11=3 ∧ x%13=5) ↔ x = 135, axiom-free.",
+        "leanType": "(x : ℕ) → x < 143 → ((x % 11 = 3 ∧ x % 13 = 5) ↔ x = 135)"
+      },
+      {
+        "name": "crt_11_mod_60",
+        "type": "key",
+        "description": "Three-modulus example: over x < 60 = 3·4·5, (x%3=2 ∧ x%4=3 ∧ x%5=1) ↔ x = 11.",
+        "leanType": "(x : ℕ) → x < 60 → ((x % 3 = 2 ∧ x % 4 = 3 ∧ x % 5 = 1) ↔ x = 11)"
+      }
+    ],
+    "path": "Proofs/ChineseRemainderConstructiveOQ05OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "crt_triple_iff",
+      "type": "core",
+      "description": "A reusable axiom-free CRT certificate for three pairwise-coprime moduli.",
+      "leanType": "{m n p N : ℕ} → m.Coprime n → m.Coprime p → n.Coprime p → N < m*n*p → {a b c : ℕ} → N % m = a → N % n = b → N % p = c → (x : ℕ) → x < m*n*p → ((x % m = a ∧ x % n = b ∧ x % p = c) ↔ x = N)"
+    },
+    {
+      "name": "crt_17_mod_20",
+      "type": "key",
+      "description": "Composite-modulus example 17 mod 20 (= 4·5), axiom-free, via crt_pair_iff.",
+      "leanType": "(x : ℕ) → x < 20 → ((x % 4 = 1 ∧ x % 5 = 2) ↔ x = 17)"
+    },
+    {
+      "name": "crt_135_mod_143",
+      "type": "supporting",
+      "description": "Composite-modulus example 135 mod 143 (= 11·13), axiom-free, via crt_pair_iff.",
+      "leanType": "(x : ℕ) → x < 143 → ((x % 11 = 3 ∧ x % 13 = 5) ↔ x = 135)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Sunzi",
+      "title": "Sunzi Suanjing (孫子算經)",
+      "year": "400",
+      "venue": "Classical Chinese mathematical text",
+      "note": "Original statement of the Chinese Remainder problem"
+    },
+    {
+      "authors": "Lean / Mathlib community",
+      "title": "native_decide and the Lean.ofReduceBool axiom",
+      "year": "2024",
+      "venue": "Lean 4 documentation",
+      "note": "native_decide trusts compiled kernel reduction; decide does not"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the open question of sibling **chinese-remainder-constructive-oq-05** — continue de-axiomatizing the CRT worked examples (composite-modulus instances like *17 mod 20* and *135 mod 143*) and push the reusable certificate toward more moduli.

The sibling removed `native_decide` from the root entry's Sunzi (23 mod 105) and four-moduli (53 mod 210) examples and packaged the argument into a two-modulus certificate `crt_pair_iff`. This entry takes it onto **composite (non-prime) coprime moduli** — the regime where `native_decide` is most tempting, because kernel `decide` on `Nat.Coprime` must reduce a gcd.

## New file: `Proofs/ChineseRemainderConstructiveOQ05OQ01.lean` (5 thm, 0 def, 110 L)

- **`crt_triple_iff`** — reusable axiom-free **three**-pairwise-coprime-modulus CRT certificate (the genuinely new infrastructure; the sibling stopped at two). Folds the third modulus with `Nat.modEq_and_modEq_iff_modEq_mul`, using `Nat.Coprime.mul_left` for `Coprime (m·n) p`. Certifies existence + uniqueness in one `iff`.
- **`crt_17_mod_20`** (4·5), **`crt_135_mod_143`** (11·13), **`crt_8_mod_15`** (3·5) — composite-modulus worked examples as one-line `crt_pair_iff` instances. `crt_8_mod_15` is the kernel-checked counterpart of the `native_decide` `example_8_mod3_mod5` in list-based sibling `...OQ04OQ02`.
- **`crt_11_mod_60`** (3·4·5) — fresh three-modulus instance of `crt_triple_iff`.

## Verification

`lake env lean` → exit 0. `#print axioms` on all five theorems lists only `propext, Classical.choice, Quot.sound` — **no `Lean.ofReduceBool`, no `native_decide`, no `sorry`, no `axiom`**.

Status: `verified`, badge `verified`, axiomCount 0, sorries 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)