### PR TITLE
Enrich composite-modulus power-sum CRT (sum-of-kth-powers-oq-05-oq-01-oq-01): add annotations.json

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-sokp-oq050101-overview",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 4, "endLine": 32 },
+    "type": "concept",
+    "title": "From Prime to Composite Modulus via CRT",
+    "content": "The docstring frames the extension. The parent settled the power-sum dichotomy for a prime modulus: ∑_{i<p} iᵏ ≡ (if k≠0 ∧ (p−1)∣k then p−1 else 0) (mod p). This file lifts it to a composite modulus by combining two ideas. (1) A periodicity fact: modulo m the summand i ↦ iᵏ depends only on i mod m, and over a length-m·n range each residue class is hit n times, so ∑_{i<m·n} iᵏ ≡ n·∑_{i<m} iᵏ (mod m). (2) The Chinese Remainder Theorem: a congruence mod a·b for coprime a,b is the pair of congruences mod a and mod b. The replication lemma is the mathematical work; CRT is just the assembly.",
+    "mathContext": "$\\sum_{i<m\\cdot n} i^k \\equiv n\\sum_{i<m} i^k \\pmod m; \\qquad \\sum_{i<a\\cdot b} i^k \\bmod ab \\text{ from its factor residues.}$",
+    "significance": "context",
+    "relatedConcepts": ["Chinese Remainder Theorem", "power sums", "periodicity", "composite modulus", "Nat.ModEq"],
+    "prerequisites": ["modular arithmetic", "the parent prime dichotomy"]
+  },
+  {
+    "id": "ann-sokp-oq050101-zmod-periodicity",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 39, "endLine": 58 },
+    "type": "theorem",
+    "title": "Periodicity in ZMod m: the Replication Engine",
+    "content": "sum_pow_zmod_range_mul is the heart of the file. Working in the ring ZMod m, where the target congruence becomes an honest equality, it proves ∑_{i<m·n} (↑i)ᵏ = (↑n)·∑_{i<m} (↑i)ᵏ by induction on n. The base case is the empty range. The step splits range(m·(n+1)) = range(m·n + m) via Finset.sum_range_add into the first m·n terms (the induction hypothesis) plus a trailing block ∑_{x<m} (↑(m·n+x))ᵏ; the key identity (↑(m·n+x) : ZMod m) = ↑x (from ZMod.natCast_self, m ↦ 0) collapses that block to exactly one period ∑_{x<m}(↑x)ᵏ. Then (↑n + 1)·S = ↑n·S + S by ring. The whole congruence problem becomes a one-line induction once cast to ZMod m.",
+    "mathContext": "$\\sum_{i<m n} (\\overline i)^k = \\overline n \\sum_{i<m} (\\overline i)^k \\text{ in } \\mathbb{Z}/m, \\quad (\\overline{m n + x}) = \\overline x.$",
+    "significance": "key",
+    "relatedConcepts": ["ZMod m", "periodicity", "sum_range_add", "natCast_self", "induction"],
+    "prerequisites": ["ZMod ring", "Finset summation"]
+  },
+  {
+    "id": "ann-sokp-oq050101-cast-back",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 68 },
+    "type": "technique",
+    "title": "Casting the ZMod Equality Back to Nat.ModEq",
+    "content": "sum_pow_range_mul_modEq transports the ZMod m equality back to a natural-number congruence: ∑_{i<m·n} iᵏ ≡ n·∑_{i<m} iᵏ (mod m). ZMod.natCast_eq_natCast_iff turns the Nat.ModEq goal into the cast equality (↑a = ↑b in ZMod m), push_cast distributes the cast over the sum and the product, and the already-proved sum_pow_zmod_range_mul closes it. This is the reusable, primality-free replication lemma — it holds for ANY modulus and any periodic summand over a complete range.",
+    "mathContext": "$a \\equiv b \\pmod m \\iff (\\overline a = \\overline b \\text{ in } \\mathbb{Z}/m).$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.ModEq", "natCast_eq_natCast_iff", "push_cast"],
+    "prerequisites": ["ZMod ↔ ModEq bridge"]
+  },
+  {
+    "id": "ann-sokp-oq050101-factor-readings",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 79 },
+    "type": "technique",
+    "title": "Reading the Composite Sum Modulo Each Factor",
+    "content": "sum_pow_modEq_left and sum_pow_modEq_right read ∑_{i<a·b} iᵏ modulo each coprime factor. The left reading is the replication lemma at m=a, n=b: ∑_{i<a·b} iᵏ ≡ b·∑_{i<a} iᵏ (mod a). The right reading is the same lemma at m=b, n=a after Nat.mul_comm. Note the cofactor appears as a scalar: modulo a the sum is b copies of one period of length a — the multiplicity b counts how many periods fit in the range a·b.",
+    "mathContext": "$\\sum_{i<ab} i^k \\equiv b\\sum_{i<a} i^k \\pmod a, \\qquad \\sum_{i<ab} i^k \\equiv a\\sum_{i<b} i^k \\pmod b.$",
+    "significance": "supporting",
+    "relatedConcepts": ["coprime factors", "cofactor multiplicity", "mul_comm"],
+    "prerequisites": ["the replication lemma"]
+  },
+  {
+    "id": "ann-sokp-oq050101-crt",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 81, "endLine": 95 },
+    "type": "insight",
+    "title": "The CRT Characterisation",
+    "content": "sum_pow_crt is the assembly. For coprime a,b, it characterises when a natural x equals the composite residue: x ≡ ∑_{i<a·b} iᵏ (mod a·b) iff x matches both factor residues b·∑_{i<a} iᵏ (mod a) and a·∑_{i<b} iᵏ (mod b). Nat.modEq_and_modEq_iff_modEq_mul (the CRT for Nat.ModEq) rewrites the single mod-a·b congruence as the conjunction of the two factor congruences, and each side is transported along the two factor readings via Nat.ModEq.trans. The CRT does the structural reconstruction for free — the content was the replication lemma.",
+    "mathContext": "$x \\equiv \\textstyle\\sum_{i<ab} i^k \\!\\pmod{ab} \\iff x \\equiv b\\sum_{i<a} i^k \\!\\pmod a \\,\\wedge\\, x \\equiv a\\sum_{i<b} i^k \\!\\pmod b.$",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "modEq_and_modEq_iff_modEq_mul", "coprimality", "ModEq.trans"],
+    "prerequisites": ["CRT for Nat.ModEq"]
+  },
+  {
+    "id": "ann-sokp-oq050101-two-primes",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 97, "endLine": 114 },
+    "type": "theorem",
+    "title": "The Explicit Two-Primes Formula",
+    "content": "sum_pow_crt_two_primes is the fully explicit payoff for distinct primes p ≠ q. Coprimality is derived from Nat.coprime_primes; sum_pow_crt then reduces to the two factor readings, and each is composed (via Nat.ModEq.mul_left, supplying the cofactor scalar) with the parent's prime dichotomy sum_pow_modEq. The result: ∑_{i<p·q} iᵏ mod p·q is the unique residue whose factor residues are q·(p−1 or 0) mod p and p·(q−1 or 0) mod q, dictated by the (p−1)∣k and (q−1)∣k conditions. This is where primality finally enters — only at the last step.",
+    "mathContext": "$x \\equiv q\\,(\\text{if }(p-1)\\mid k\\text{ then }p-1\\text{ else }0)\\!\\pmod p \\,\\wedge\\, x \\equiv p\\,(\\text{if }(q-1)\\mid k\\text{ then }q-1\\text{ else }0)\\!\\pmod q.$",
+    "significance": "key",
+    "relatedConcepts": ["distinct primes", "coprime_primes", "ModEq.mul_left", "prime dichotomy"],
+    "prerequisites": ["the parent prime congruence", "CRT characterisation"]
+  },
+  {
+    "id": "ann-sokp-oq050101-instances",
+    "proofId": "sum-of-kth-powers-oq-05-oq-01-oq-01",
+    "range": { "startLine": 116, "endLine": 131 },
+    "type": "technique",
+    "title": "Concrete decide-Verified Instances",
+    "content": "Four worked instances illustrate the bridge on m = 6 = 2·3 and a three-period mod-4 replication. For k=2: ∑_{i<6} i² = 55 ≡ 1 (mod 6), recovered from its two factor readings (≡ 3·∑_{i<2} i² mod 2 and ≡ 2·∑_{i<3} i² mod 3, both ≡ 1) and the CRT-determined residue ≡ 1 (mod 6); the replication ∑_{i<12} i³ ≡ 3·∑_{i<4} i³ (mod 4) checks the n=3 case. Each is closed by kernel decide (not native_decide), so no Lean.ofReduceBool axiom is incurred and the file stays genuinely 0-axiom.",
+    "mathContext": "$\\sum_{i<6} i^2 = 55 \\equiv 1 \\pmod 6, \\quad \\sum_{i<12} i^3 \\equiv 3\\sum_{i<4} i^3 \\pmod 4.$",
+    "significance": "technical",
+    "relatedConcepts": ["decide", "kernel reduction", "axiom integrity", "worked examples"],
+    "prerequisites": ["decidable evaluation in Lean"]
+  }
+]


### PR DESCRIPTION
## Enrichment pass: sum-of-kth-powers-oq-05-oq-01-oq-01

This entry — extending the prime-modulus power-sum congruence to a composite modulus via periodicity + the Chinese Remainder Theorem — had a richly populated `meta.json` but **no `annotations.json`**. This pass adds the inline-annotation layer.

### Added
- **`annotations.json`** with 7 inline annotations covering the full Lean file, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Prime → composite / CRT overview
  2. The ZMod m periodicity replication engine (`sum_pow_zmod_range_mul`)
  3. Casting the ZMod equality back to `Nat.ModEq`
  4. The two coprime-factor readings
  5. The CRT characterisation (`modEq_and_modEq_iff_modEq_mul`)
  6. The explicit two-distinct-primes formula
  7. The `decide`-verified concrete instances (axiom-integrity: no `native_decide`)

### Verification
- `pnpm build` succeeds; entry not flagged.
- JSON validated; annotation line ranges align with the Lean source sections.
- No axiom/status claims altered — meta correctly reports `verified` / `original` / 0 axioms / 0 sorries.