### PR TITLE
audit(arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02): repair non-compiling 'verified' proof (sorryAx via no-op dsimp)

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean
@@ -118,7 +118,6 @@ theorem ascPochhammer_eval_add {S : Type*} [CommSemiring S] (x y : S) (k : ℕ) 
     rw [Finset.sum_congr rfl hsplit, Finset.sum_add_distrib]
     -- RHS: expand the top sum via the Pascal step
     rw [Finset.sum_range_succ' (fun m => t (n + 1) m) (n + 1)]
-    dsimp only
     rw [h_first (n + 1),
         Finset.sum_congr rfl
           (fun i hi => h_middle n i (Finset.mem_range_succ_iff.mp hi)),
@@ -130,7 +129,6 @@ theorem ascPochhammer_eval_add {S : Type*} [CommSemiring S] (x y : S) (k : ℕ) 
             + (ascPochhammer S (n + 1)).eval y := by
       rw [Finset.sum_range_succ' (fun m => (y + ((n - m : ℕ) : S)) * t n m) n,
           Finset.sum_range_succ (fun i => (y + ((n - (i + 1) : ℕ) : S)) * t n (i + 1)) n]
-      dsimp only
       rw [h_last n, h_first n, hBy n, Nat.sub_zero]
       ring
     rw [hQ]; ring

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -23,10 +23,10 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
-    "lineCount": 222,
+    "lineCount": 220,
     "theoremCount": 8,
     "definitionCount": 0,
-    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (the three concrete checks use `decide`, so `#print axioms` lists only the ordinary foundational axioms propext / Classical.choice / Quot.sound, which are not counted). NOTE: local kernel verification via the Docker build wrapper was unavailable this session (the Docker daemon was unresponsive), so the proof is verified at the statement/lemma-signature level against Mathlib v4.26.0 and relies on the deployer build-gate for the final kernel check before merge.",
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (the three concrete checks use `decide`, so `#print axioms` lists only the ordinary foundational axioms propext / Classical.choice / Quot.sound, which are not counted). Kernel-verified against Mathlib v4.26.0 via `lake env lean`: all eight theorems compile with `#print axioms` reporting exactly [propext, Classical.choice, Quot.sound] (no sorryAx, no Lean.ofReduceBool).",
     "originalContributions": [
       "ascPochhammer_eval_add: (x+y)^{(k)} = Σ_{m∈range(k+1)} x^{(m)}·y^{(k-m)}·C(k,m) over any CommSemiring, via (ascPochhammer S _).eval — the rising-factorial Vandermonde convolution (sequence of binomial type). Mathlib has only the multiplicative composition law ascPochhammer_mul; this additive convolution is not in Mathlib.",
       "ascFactorial_add_vandermonde: the ℕ specialization with Nat.ascFactorial — (a+b).ascFactorial k = Σ a.ascFactorial m · b.ascFactorial (k-m) · C(k,m)",
@@ -61,28 +61,28 @@
       "title": "Part I: The Rising-Factorial Vandermonde Convolution (CommSemiring)",
       "summary": "ascPochhammer_eval_add: (x+y)^{(k)} = Σ C(k,m)·x^{(m)}·y^{(k-m)} over any commutative semiring, proved by induction mirroring Commute.add_pow with ascPochhammer_succ_eval as the analogue of pow_succ and a Pascal-rule middle lemma.",
       "startLine": 46,
-      "endLine": 137
+      "endLine": 135
     },
     {
       "id": "nat-specialization",
       "title": "Part II: ℕ Specialization — Chu–Vandermonde for Nat.ascFactorial",
       "summary": "ascFactorial_add_vandermonde and ascFactorial_add_vandermonde_prod: the headline evaluated at naturals, giving the multiset Vandermonde identity for Nat.ascFactorial and its explicit rising-product form.",
-      "startLine": 138,
-      "endLine": 164
+      "startLine": 136,
+      "endLine": 162
     },
     {
       "id": "corollaries",
       "title": "Part III: Structural Corollaries",
       "summary": "ascFactorial_add_vandermonde_zero_right (boundary collapse at b=0) and ascFactorial_add_vandermonde_symm (a↔b symmetry from commutativity of +).",
-      "startLine": 165,
-      "endLine": 183
+      "startLine": 163,
+      "endLine": 181
     },
     {
       "id": "concrete-checks",
       "title": "Part IV: Concrete Verification",
       "summary": "Three decide checks (no native_decide): a=b=1,k=2 (=6); a=2,b=1,k=2 (=12); a=1,b=2,k=3 (=60).",
-      "startLine": 184,
-      "endLine": 222
+      "startLine": 182,
+      "endLine": 220
     }
   ],
   "conclusion": {
@@ -140,7 +140,7 @@
   ],
   "leanFile": {
     "namespace": "ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02",
-    "lineCount": 222,
+    "lineCount": 220,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,


### PR DESCRIPTION
## Gallery Integrity Repair

**Proof**: arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02 (Vandermonde Convolution for Rising Factorials)
**Severity**: CRITICAL — published `status: verified`, `badge: original`, `sorries: 0`, but the Lean file did **not compile** and the capstone theorem depended on `sorryAx`.

### What was wrong

The inductive step of `ascPochhammer_eval_add` contained two bare `dsimp only` tactics (orig. lines 121, 133). On Mathlib v4.26.0 both error with **`dsimp made no progress`** — the preceding `rw` calls had already beta-reduced the goals. Lean's error recovery then injected `sorryAx` into `ascPochhammer_eval_add` and, transitively, into the four downstream theorems (`ascFactorial_add_vandermonde`, `..._prod`, `..._zero_right`, `..._symm`).

The `meta.json` `assumptions` field self-admitted the proof was never kernel-checked:
> "local kernel verification via the Docker build wrapper was unavailable this session (the Docker daemon was unresponsive) … relies on the deployer build-gate for the final kernel check before merge."

This is the exact red-flag pattern: a "verified" claim that was only signature-checked, not kernel-checked.

### Fix

Remove the two no-op `dsimp only` lines. Nothing else changes — the surrounding `rw`/`ring` already produce the reduced goals.

### Verification (`lake env lean`, Mathlib v4.26.0)

All 8 theorems compile; `#print axioms` for every one reports exactly:
```
[propext, Classical.choice, Quot.sound]
```
No `sorryAx`, no `Lean.ofReduceBool`. The entry's `verified` / `original` / 0-axiom / 0-sorry claims are now accurate.

### meta.json updates
- `lineCount`/`leanFile.lineCount`: 222 → 220
- section line anchors shifted by the two deletions
- replaced the "not kernel-verified / Docker down" `assumptions` note with the actual kernel-verification result

---
Discovered and repaired during gallery integrity audit.