### PR TITLE
Enrich Strict Chebyshev Sum Inequality

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "cheb-strict-ann-header",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "From the Non-Strict Bound to the Strict Statement",
+    "content": "Mathlib records Chebyshev's sum inequality only as a non-strict bound (∑f)(∑g) ≤ #s·∑f·g for monovarying f, g, with no rigidity clause. The parent file RearrangementChebyshevEqOQ01 supplies the missing equality case (chebyshev_sum_eq_iff and its monotone corollary chebyshev_sum_eq_iff_const) from the discrete covariance identity. This file imports both and combines them into the textbook-quoted strict form: the inequality is strict unless one of the sequences is constant. The import of the parent companion file (Proofs.RearrangementChebyshevEqOQ01) and `open RearrangementChebyshevEq` make the parent's lemmas directly available.",
+    "mathContext": "Non-strict: $\\big(\\sum_i f_i\\big)\\big(\\sum_i g_i\\big) \\le \\#s\\sum_i f_i g_i$. Goal: the same with $<$ whenever neither sequence is constant.",
+    "significance": "context",
+    "relatedConcepts": ["Chebyshev's sum inequality", "rigidity / equality case", "discrete covariance", "MonovaryOn"],
+    "prerequisites": ["finite sums over a Finset", "order-correlation predicates"]
+  },
+  {
+    "id": "cheb-strict-ann-pair",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 53 },
+    "type": "technique",
+    "title": "Strictness from a Single Doubly-Varying Pair",
+    "content": "chebyshev_sum_strict_of_pair is the structural heart: under only MonovaryOn f g s, the existence of one pair a, b ∈ s with f a ≠ f b AND g a ≠ g b already forces strictness. The proof is lt_of_le_of_ne applied to the parent's ≤ bound (chebyshev_sum) and the negation of equality: assuming equality, chebyshev_sum_eq_iff forces f a = f b ∨ g a = g b on that pair, contradicting both hypotheses. This shows strictness is a *local* phenomenon — a single index pair varying in both coordinates suffices, no global monotonicity needed.",
+    "mathContext": "If $\\exists\\, a,b\\in s$ with $f_a\\neq f_b$ and $g_a\\neq g_b$, then $\\big(\\sum f\\big)\\big(\\sum g\\big) < \\#s\\sum f g$.",
+    "significance": "key",
+    "relatedConcepts": ["lt_of_le_of_ne", "MonovaryOn", "equality case negation", "local-to-global strictness"],
+    "prerequisites": ["chebyshev_sum_eq_iff", "the lt_of_le_of_ne pattern"]
+  },
+  {
+    "id": "cheb-strict-ann-monotone",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 68 },
+    "type": "insight",
+    "title": "The Textbook Monotone Form",
+    "content": "chebyshev_sum_strict is the statement people actually quote: for f, g monotone on a linearly ordered index, s nonempty, and neither f nor g constant on s, the inequality is strict. The monotone bridge (hf.monovary hg).monovaryOn s supplies the ≤ bound, and equality is excluded via chebyshev_sum_eq_iff_const — which says equality forces f or g constant on s, contradicting the non-constancy witnesses. Non-constancy is phrased as ∃ i j ∈ s, f i ≠ f j, the existence form that pairs naturally with the rigidity lemma.",
+    "mathContext": "$f,g$ monotone, $s\\neq\\varnothing$, neither constant on $s$ $\\;\\Rightarrow\\; \\big(\\sum f\\big)\\big(\\sum g\\big) < \\#s\\sum f g$.",
+    "significance": "key",
+    "relatedConcepts": ["Monotone.monovary", "chebyshev_sum_eq_iff_const", "non-constancy", "comonotone sequences"],
+    "prerequisites": ["monotone functions", "the equality-iff-constant characterisation"]
+  },
+  {
+    "id": "cheb-strict-ann-strictmono",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02",
+    "range": { "startLine": 70, "endLine": 83 },
+    "type": "insight",
+    "title": "The Strictly-Monotone Specialisation",
+    "content": "chebyshev_sum_strict_strictMono is the slickest sufficient condition: strictly monotone f, g with 1 < #s always give the strict inequality. Finset.one_lt_card extracts two distinct indices a ≠ b ∈ s, and StrictMono.injective upgrades a ≠ b into f a ≠ f b and g a ≠ g b automatically — so the doubly-varying pair is produced with no manual witness. The result then follows from chebyshev_sum_strict (equivalently the pair form). Injectivity is what removes any need to exhibit varying values by hand.",
+    "mathContext": "$f,g$ strictly monotone, $1 < \\#s$ $\\;\\Rightarrow\\;$ strict inequality, since injectivity makes $a\\neq b$ give $f_a\\neq f_b$ and $g_a\\neq g_b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["StrictMono.injective", "Finset.one_lt_card", "strict monotonicity"],
+    "prerequisites": ["strictly monotone functions", "injectivity of strictly monotone maps"]
+  }
+]

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02/index.ts
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/RearrangementChebyshevStrictOQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevSumInequalityOQ01OQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevSumInequalityOQ01OQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevSumInequalityOQ01OQ02Data: ProofData = {
+  proof: chebyshevSumInequalityOQ01OQ02Proof,
+  annotations: chebyshevSumInequalityOQ01OQ02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01-oq-02` (quality 41, pass 0).

## Gaps addressed
The entry had **only meta.json** — no `index.ts` (so the page would render 'proof not found' on the live site) and no `annotations.json`.

## Changes
- **Created `index.ts`** from the standard template (Lean source `RearrangementChebyshevStrictOQ01OQ02.lean`).
- **Added 4 annotations**, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Context: from Mathlib's non-strict bound to the strict statement via the parent equality case
  2. Technique: strictness from a single doubly-varying pair (`lt_of_le_of_ne` + negated `chebyshev_sum_eq_iff`)
  3. Insight: the textbook monotone form (strict unless one sequence is constant)
  4. Insight: the strictly-monotone specialisation (`StrictMono.injective` + `Finset.one_lt_card`)

Mathematical claims cross-checked against the Lean source. No existing content removed.

Verified: JSON parses, `tsc --noEmit` exit 0.