### PR TITLE
fix(arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02): repair non-compiling "verified" Vandermonde-convolution proof

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean
@@ -118,7 +118,6 @@ theorem ascPochhammer_eval_add {S : Type*} [CommSemiring S] (x y : S) (k : ℕ) 
     rw [Finset.sum_congr rfl hsplit, Finset.sum_add_distrib]
     -- RHS: expand the top sum via the Pascal step
     rw [Finset.sum_range_succ' (fun m => t (n + 1) m) (n + 1)]
-    dsimp only
     rw [h_first (n + 1),
         Finset.sum_congr rfl
           (fun i hi => h_middle n i (Finset.mem_range_succ_iff.mp hi)),
@@ -130,7 +129,6 @@ theorem ascPochhammer_eval_add {S : Type*} [CommSemiring S] (x y : S) (k : ℕ) 
             + (ascPochhammer S (n + 1)).eval y := by
       rw [Finset.sum_range_succ' (fun m => (y + ((n - m : ℕ) : S)) * t n m) n,
           Finset.sum_range_succ (fun i => (y + ((n - (i + 1) : ℕ) : S)) * t n (i + 1)) n]
-      dsimp only
       rw [h_last n, h_first n, hBy n, Nat.sub_zero]
       ring
     rw [hQ]; ring

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02/meta.json
@@ -26,7 +26,7 @@
     "lineCount": 222,
     "theoremCount": 8,
     "definitionCount": 0,
-    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (the three concrete checks use `decide`, so `#print axioms` lists only the ordinary foundational axioms propext / Classical.choice / Quot.sound, which are not counted). NOTE: local kernel verification via the Docker build wrapper was unavailable this session (the Docker daemon was unresponsive), so the proof is verified at the statement/lemma-signature level against Mathlib v4.26.0 and relies on the deployer build-gate for the final kernel check before merge.",
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, and no `native_decide` (the three concrete checks use `decide`, so `#print axioms` lists only the ordinary foundational axioms propext / Classical.choice / Quot.sound, which are not counted). Kernel-verified with `lake env lean` against Mathlib v4.26.0 (exit 0, `#print axioms` on the headline, the ℕ specialization, and a concrete check all return the standard triple).",
     "originalContributions": [
       "ascPochhammer_eval_add: (x+y)^{(k)} = Σ_{m∈range(k+1)} x^{(m)}·y^{(k-m)}·C(k,m) over any CommSemiring, via (ascPochhammer S _).eval — the rising-factorial Vandermonde convolution (sequence of binomial type). Mathlib has only the multiplicative composition law ascPochhammer_mul; this additive convolution is not in Mathlib.",
       "ascFactorial_add_vandermonde: the ℕ specialization with Nat.ascFactorial — (a+b).ascFactorial k = Σ a.ascFactorial m · b.ascFactorial (k-m) · C(k,m)",


### PR DESCRIPTION
## Gallery integrity repair

**Proof**: `arithmetic-series-oq-02-oq-04-oq-01-oq-01-oq-02` (Vandermonde Convolution for Rising Factorials)
**Severity**: HIGH — entry published `status: "verified"` but the Lean file did **not** compile on Mathlib v4.26.0.

### What was wrong
The entry's own `meta.json` admitted it was never kernel-checked:

> "local kernel verification via the Docker build wrapper was unavailable this session (the Docker daemon was unresponsive) ... relies on the deployer build-gate for the final kernel check before merge."

Kernel-verifying with `lake env lean` produced two deterministic errors:

```
ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean:121:4: error: `dsimp` made no progress
ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean:132:6: error: `dsimp` made no progress
```

Both bare `dsimp only` steps sit immediately after a `Finset.sum_range_succ'`
rewrite. On v4.26.0 the rewrite already leaves the summand fully beta-reduced,
so `dsimp only` has nothing to do and errors out.

### Fix
Remove both no-op `dsimp only` lines; the subsequent rewrites fire directly.

### Verification
- `lake env lean Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01OQ02.lean` → **exit 0**, no errors.
- `#print axioms` on `ascPochhammer_eval_add` (headline), `ascFactorial_add_vandermonde` (ℕ specialization), and `check_a1_b2_k3` (a `decide` check) → all `[propext, Classical.choice, Quot.sound]`. No `sorryAx`, no `Lean.ofReduceBool`.
- The three `decide` checks hand-verified: 6, 12, 60. ✓
- Counts confirmed: 8 theorems, 0 defs, 0 sorries, 0 `axiom` declarations — matches meta.

So the entry's `verified` / `original` / 0-axiom / 0-sorry claims are now **accurate** post-fix.

`meta.json` assumptions field updated to record the completed local kernel verification (replacing the "Docker unavailable / relies on deployer gate" disclaimer).

---
Discovered during gallery integrity audit. This is the latest in a recurring pattern of recently-added v4.26.0 entries published `verified` without an actual kernel build.