### PR TITLE
Add missing index.ts for sum-of-kth-powers-oq-05-oq-01-oq-01

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/index.ts
+++ b/src/data/proofs/sum-of-kth-powers-oq-05-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SumOfKthPowersOQ05OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const sumOfKthPowersOQ05OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const sumOfKthPowersOQ05OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const sumOfKthPowersOQ05OQ01OQ01Data: ProofData = {
+  proof: sumOfKthPowersOQ05OQ01OQ01Proof,
+  annotations: sumOfKthPowersOQ05OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Entry `sum-of-kth-powers-oq-05-oq-01-oq-01` was enriched with a 7-annotation `annotations.json` (#28519) and a rich `meta.json`, but its `index.ts` was never created. Without it, Vite's `import.meta.glob` cannot discover the proof and the page shows **'proof not found'** on the live site despite appearing in the gallery listing.

This PR adds the standard `index.ts` wiring (Lean source `SumOfKthPowersOQ05OQ01OQ01.lean`). No content changes to meta.json or annotations.json.

Verified: `tsc --noEmit` exit 0; Lean source path confirmed present.