### PR TITLE
research(cevas-theorem-oq-04-oq-04): angle bisectors, mass points, and the incenter [verified, 0-sorry]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -683,6 +683,7 @@ import Proofs.CevasTheoremOQ02OQ04
 import Proofs.CevasTheoremOQ02OQ04OQ01
 import Proofs.CevasTheoremOQ04
 import Proofs.CevasTheoremOQ04OQ01
+import Proofs.CevasTheoremOQ04OQ04
 import Proofs.CevasTheoremSinRatio
 import Proofs.ChebyshevBounds
 import Proofs.ChebyshevBoundsOQ03

--- a/proofs/Proofs/CevasTheoremOQ04OQ04.lean
+++ b/proofs/Proofs/CevasTheoremOQ04OQ04.lean
@@ -1,0 +1,208 @@
+import Proofs.CevasTheoremOQ04
+import Mathlib.Tactic
+import Mathlib.LinearAlgebra.AffineSpace.AffineMap
+
+/-
+# Angle Bisectors, Mass Points, and the Incenter (Ceva OQ-04-OQ-04)
+
+## Research Question (cevas-theorem-oq-04-oq-04)
+
+The parent file `CevasTheoremOQ04.lean` develops mass-point geometry as an
+algebraic certificate for concurrent cevians: positive masses mA, mB, mC at the
+vertices of a triangle induce cevian division points whose Ceva product is always
+1.  The centroid arises from *equal* masses (`centroid_example`).
+
+This file treats the **angle bisector** case.  Assign masses equal to the
+*opposite side lengths*, mA = a = |BC|, mB = b = |CA|, mC = c = |AB|.  We show:
+
+1. these masses realise exactly the angle-bisector division ratios — the
+   angle-bisector theorem ratios
+
+     BD/DC = c/b,   CE/EA = a/c,   AF/FB = b/a
+
+   (reusing the parent's `ratio_balance` family);
+2. hence the three angle bisectors are concurrent — their Ceva ratio product is 1
+   (reusing the parent's `ceva_ratio_product_one`);
+3. the point of concurrency is the **incenter**
+
+     I = (a·A + b·B + c·C) / (a + b + c),
+
+   proved *constructively* by exhibiting I as an affine combination of each vertex
+   with the opposite cevian foot.  Concretely I lies on all three angle bisectors
+   simultaneously, so the three lines meet at I.
+
+Item (3) is the substantive new content beyond the parent's ratio identity: a
+fully geometric concurrency witness in an *arbitrary real vector space*.  No
+triangle inequality is needed — only positivity of the three side lengths.
+
+## Mathematical Significance
+
+The barycentric coordinates of the incenter are (a : b : c): masses proportional
+to the opposite sides.  This is the canonical worked example of mass-point
+geometry for angle bisectors.  The affine-combination proof turns "the three
+bisectors meet at the incenter" into a checked theorem rather than a ratio
+coincidence: each bisector is an honest line in a vector space, and `incenter` is
+exhibited on each of them via `AffineMap.lineMap`.
+-/
+
+namespace MassPointCeva.AngleBisector
+
+open MassPointCeva
+
+/- ## The angle-bisector mass assignment -/
+
+/-- Masses equal to the opposite side lengths a = |BC|, b = |CA|, c = |AB|. -/
+def bisectorMass (a b c : ℝ) (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) : MassPoint :=
+  ⟨a, b, c, ha, hb, hc⟩
+
+@[simp] lemma bisectorMass_mA {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    (bisectorMass a b c ha hb hc).mA = a := rfl
+
+@[simp] lemma bisectorMass_mB {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    (bisectorMass a b c ha hb hc).mB = b := rfl
+
+@[simp] lemma bisectorMass_mC {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    (bisectorMass a b c ha hb hc).mC = c := rfl
+
+/- ## Angle-bisector division ratios
+
+The angle-bisector theorem says the internal bisector from a vertex divides the
+opposite side in the ratio of the two adjacent sides.  With masses = opposite
+sides, the parent's lever-arm identity `ratio_balance` reproduces exactly these
+ratios. -/
+
+/-- Bisector from `A`: `BD/DC = c/b` (= `|AB|/|AC|`). -/
+theorem bisector_ratio_BD_DC {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    rD (bisectorMass a b c ha hb hc) / (1 - rD (bisectorMass a b c ha hb hc)) = c / b :=
+  ratio_balance _
+
+/-- Bisector from `B`: `CE/EA = a/c` (= `|BC|/|BA|`). -/
+theorem bisector_ratio_CE_EA {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    rE (bisectorMass a b c ha hb hc) / (1 - rE (bisectorMass a b c ha hb hc)) = a / c :=
+  ratio_balance_E _
+
+/-- Bisector from `C`: `AF/FB = b/a` (= `|CA|/|CB|`). -/
+theorem bisector_ratio_AF_FB {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    rF (bisectorMass a b c ha hb hc) / (1 - rF (bisectorMass a b c ha hb hc)) = b / a :=
+  ratio_balance_F _
+
+/- ## Concurrency via Ceva (reusing the parent) -/
+
+/-- The three angle bisectors satisfy the Ceva concurrency criterion: the product
+of the directed division ratios is `1`. -/
+theorem bisectors_ceva_product {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    let m := bisectorMass a b c ha hb hc
+    (rD m / (1 - rD m)) * (rE m / (1 - rE m)) * (rF m / (1 - rF m)) = 1 :=
+  ceva_ratio_product_one _
+
+/-- The same Ceva product written explicitly in side-length ratios:
+`(c/b)·(a/c)·(b/a) = 1`. -/
+theorem bisectors_side_ratio_product {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    (c / b) * (a / c) * (b / a) = 1 := by
+  field_simp
+
+/- ## The incenter as the point of concurrency
+
+We now realise the cevians as honest lines in a real vector space and exhibit the
+incenter on each of them.  Points are vectors; the "feet" are the bisector
+division points, and `incenter` is the barycentric point `(a : b : c)`. -/
+
+section Affine
+
+variable {V : Type*} [AddCommGroup V] [Module ℝ V]
+
+/-- Foot of the `A`-bisector on side `BC`, dividing `BD:DC = c:b`. -/
+noncomputable def footD (b c : ℝ) (B C : V) : V :=
+  (b / (b + c)) • B + (c / (b + c)) • C
+
+/-- Foot of the `B`-bisector on side `CA`, dividing `CE:EA = a:c`. -/
+noncomputable def footE (c a : ℝ) (C A : V) : V :=
+  (c / (c + a)) • C + (a / (c + a)) • A
+
+/-- Foot of the `C`-bisector on side `AB`, dividing `AF:FB = b:a`. -/
+noncomputable def footF (a b : ℝ) (A B : V) : V :=
+  (a / (a + b)) • A + (b / (a + b)) • B
+
+/-- The **incenter**: barycentric coordinates `(a : b : c)`. -/
+noncomputable def incenter (a b c : ℝ) (A B C : V) : V :=
+  (a / (a + b + c)) • A + (b / (a + b + c)) • B + (c / (a + b + c)) • C
+
+/-- For the angle-bisector masses, `footD` is exactly the parent's division point
+`(1 - rD)·B + rD·C`, confirming it is the cevian foot of that mass assignment. -/
+theorem footD_eq_division {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) (B C : V) :
+    footD b c B C =
+      (1 - rD (bisectorMass a b c ha hb hc)) • B
+        + rD (bisectorMass a b c ha hb hc) • C := by
+  rw [one_sub_rD]
+  simp only [footD, rD, bisectorMass_mB, bisectorMass_mC]
+
+/-- **Incenter lies on the `A`-bisector.**  It is the affine combination of `A`
+and the foot `footD` with weights `a/(a+b+c)` and `(b+c)/(a+b+c)`. -/
+theorem incenter_on_bisector_A {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (A B C : V) :
+    incenter a b c A B C
+      = (a / (a + b + c)) • A + ((b + c) / (a + b + c)) • footD b c B C := by
+  have hbc : b + c ≠ 0 := by positivity
+  have habc : a + b + c ≠ 0 := by positivity
+  simp only [incenter, footD]
+  match_scalars <;> field_simp
+
+/-- **Incenter lies on the `B`-bisector.** -/
+theorem incenter_on_bisector_B {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (A B C : V) :
+    incenter a b c A B C
+      = (b / (a + b + c)) • B + ((c + a) / (a + b + c)) • footE c a C A := by
+  have hca : c + a ≠ 0 := by positivity
+  have habc : a + b + c ≠ 0 := by positivity
+  simp only [incenter, footE]
+  match_scalars <;> field_simp
+
+/-- **Incenter lies on the `C`-bisector.** -/
+theorem incenter_on_bisector_C {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (A B C : V) :
+    incenter a b c A B C
+      = (c / (a + b + c)) • C + ((a + b) / (a + b + c)) • footF a b A B := by
+  have hab : a + b ≠ 0 := by positivity
+  have habc : a + b + c ≠ 0 := by positivity
+  simp only [incenter, footF]
+  match_scalars <;> field_simp
+
+/- ### The affine weights are barycentric (sum to one)
+
+Each concurrency identity above is a genuine *affine* combination: the two weights
+sum to `1`, so `incenter` lies on the line through the vertex and the opposite
+foot. -/
+
+theorem weights_A_sum_one {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    a / (a + b + c) + (b + c) / (a + b + c) = 1 := by
+  have habc : a + b + c ≠ 0 := by positivity
+  field_simp; ring
+
+theorem weights_B_sum_one {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    b / (a + b + c) + (c + a) / (a + b + c) = 1 := by
+  have habc : a + b + c ≠ 0 := by positivity
+  field_simp; ring
+
+theorem weights_C_sum_one {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c) :
+    c / (a + b + c) + (a + b) / (a + b + c) = 1 := by
+  have habc : a + b + c ≠ 0 := by positivity
+  field_simp; ring
+
+/- ### Lines, via `AffineMap.lineMap`
+
+The cevian from a vertex to the opposite foot is the line `lineMap vertex foot`.
+The incenter is the point at parameter `t = (opposite-pair)/(a+b+c) ∈ (0,1)`. -/
+
+/-- The `A`-bisector as a line, with `incenter` at parameter `(b+c)/(a+b+c)`. -/
+theorem incenter_lineMap_A {a b c : ℝ} (ha : 0 < a) (hb : 0 < b) (hc : 0 < c)
+    (A B C : V) :
+    incenter a b c A B C
+      = AffineMap.lineMap A (footD b c B C) ((b + c) / (a + b + c) : ℝ) := by
+  have hbc : b + c ≠ 0 := by positivity
+  have habc : a + b + c ≠ 0 := by positivity
+  simp only [AffineMap.lineMap_apply, vsub_eq_sub, vadd_eq_add, incenter, footD]
+  match_scalars <;> field_simp <;> ring_nf
+
+end Affine
+
+end MassPointCeva.AngleBisector

--- a/src/data/proofs/cevas-theorem-oq-04-oq-04/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-04/annotations.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "ann-ctoq0404-00-header",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Module Overview: Angle Bisectors via Mass Points",
+    "content": "The parent entry cevas-theorem-oq-04 certifies cevian concurrency from positive vertex masses, with the centroid arising from equal masses. This file treats the angle-bisector case: masses equal to the opposite side lengths (a, b, c) reproduce the angle-bisector theorem ratios and make the three bisectors concurrent at the incenter.",
+    "mathContext": "Masses (mA, mB, mC) = (a, b, c); ratios BD/DC = c/b, CE/EA = a/c, AF/FB = b/a; incenter I = (a·A + b·B + c·C)/(a+b+c).",
+    "significance": "Turns the textbook 'the three angle bisectors meet at the incenter' into a checked theorem, with an explicit affine-combination witness in any real vector space."
+  },
+  {
+    "id": "ann-ctoq0404-01-bisectorMass",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 52, "endLine": 65 },
+    "type": "definition",
+    "title": "The Angle-Bisector Mass Assignment",
+    "content": "bisectorMass packages masses equal to the opposite side lengths a = |BC|, b = |CA|, c = |AB| as an instance of the parent's MassPoint structure. Positivity of the side lengths supplies the structure's positivity fields.",
+    "mathContext": "bisectorMass a b c : MassPoint with mA = a, mB = b, mC = c.",
+    "significance": "Choosing masses = opposite sides is precisely what the angle-bisector theorem dictates; everything else follows from the parent framework."
+  },
+  {
+    "id": "ann-ctoq0404-02-ratios",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 67, "endLine": 87 },
+    "type": "theorem",
+    "title": "Angle-Bisector Theorem Ratios",
+    "content": "The parent's lever-arm identity ratio_balance gives rD/(1-rD) = mC/mB, which for bisectorMass is c/b — exactly BD/DC for the internal bisector from A. The cyclic lemmas give CE/EA = a/c and AF/FB = b/a.",
+    "mathContext": "BD/DC = c/b, CE/EA = a/c, AF/FB = b/a.",
+    "significance": "Certifies that the side-length masses encode the angle-bisector theorem ratios, the bridge between the abstract masses and genuine bisectors."
+  },
+  {
+    "id": "ann-ctoq0404-03-ceva",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 89, "endLine": 102 },
+    "type": "theorem",
+    "title": "Concurrency via Ceva",
+    "content": "Reusing the parent's ceva_ratio_product_one, the three bisectors satisfy Ceva's concurrency criterion. The product of directed ratios telescopes: (c/b)·(a/c)·(b/a) = 1.",
+    "mathContext": "(rD/(1-rD))·(rE/(1-rE))·(rF/(1-rF)) = 1 = (c/b)·(a/c)·(b/a).",
+    "significance": "Establishes concurrency at the criterion level before pinning down the actual meeting point."
+  },
+  {
+    "id": "ann-ctoq0404-04-incenter-defs",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 104, "endLine": 139 },
+    "type": "definition",
+    "title": "Feet and Incenter in a Real Vector Space",
+    "content": "Working in an arbitrary real vector space V, footD/footE/footF are the bisector division points and incenter is the barycentric point (a·A + b·B + c·C)/(a+b+c). footD_eq_division confirms footD is the parent's rD division point for the bisector masses.",
+    "mathContext": "footD = (b/(b+c))·B + (c/(b+c))·C; incenter = Σ (side/perimeter)·vertex.",
+    "significance": "Realises the cevians as honest lines so that concurrency becomes a statement about a common point, not just a ratio identity."
+  },
+  {
+    "id": "ann-ctoq0404-05-concurrency",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 141, "endLine": 189 },
+    "type": "theorem",
+    "title": "The Incenter Lies on All Three Bisectors",
+    "content": "incenter_on_bisector_A/B/C prove (via match_scalars + field_simp) that the incenter equals the affine combination of each vertex with the opposite foot. The weights_*_sum_one lemmas show the two weights sum to 1, so each is a genuine affine combination and I lies on each bisector.",
+    "mathContext": "I = (a/(a+b+c))·A + ((b+c)/(a+b+c))·footD, with a/(a+b+c) + (b+c)/(a+b+c) = 1; cyclically for B, C.",
+    "significance": "The explicit geometric concurrency witness: a single point I incident to all three bisectors, with barycentric coordinates (a : b : c)."
+  },
+  {
+    "id": "ann-ctoq0404-06-linemap",
+    "proofId": "cevas-theorem-oq-04-oq-04",
+    "range": { "startLine": 191, "endLine": 208 },
+    "type": "theorem",
+    "title": "Bisector as an Affine Line",
+    "content": "incenter_lineMap_A recasts the A-bisector as AffineMap.lineMap A footD, locating the incenter at parameter (b+c)/(a+b+c) ∈ (0,1).",
+    "mathContext": "I = AffineMap.lineMap A footD ((b+c)/(a+b+c)).",
+    "significance": "Phrases incidence in Mathlib's canonical 'point on a line' vocabulary, ready to connect with the affine Ceva theory."
+  }
+]

--- a/src/data/proofs/cevas-theorem-oq-04-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04-oq-04/meta.json
@@ -1,0 +1,138 @@
+{
+  "id": "cevas-theorem-oq-04-oq-04",
+  "title": "Angle Bisectors, Mass Points, and the Incenter",
+  "slug": "cevas-theorem-oq-04-oq-04",
+  "description": "Specializes the parent's triangle mass-point framework to the angle-bisector case: assigning masses equal to the opposite side lengths (mA = a, mB = b, mC = c) reproduces the angle-bisector theorem ratios BD/DC = c/b, CE/EA = a/c, AF/FB = b/a, so the three bisectors satisfy Ceva's concurrency criterion. The point of concurrency is shown constructively to be the incenter I = (a·A + b·B + c·C)/(a+b+c): in an arbitrary real vector space, I is exhibited as an affine combination of each vertex with the opposite cevian foot (and as AffineMap.lineMap), proving I lies on all three bisectors simultaneously. The barycentric coordinates of the incenter are (a : b : c).",
+  "meta": {
+    "author": "researcher-6 (Lean Genius)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Incenter",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CevasTheoremOQ04OQ04.lean",
+    "tags": [
+      "geometry",
+      "cevas-theorem",
+      "mass-point-geometry",
+      "incenter",
+      "angle-bisector",
+      "barycentric-coordinates",
+      "affine-geometry",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "AffineMap.lineMap",
+        "description": "the affine line through two points, lineMap p q t = t·(q - p) + p, used to place the incenter on each cevian",
+        "module": "Mathlib.LinearAlgebra.AffineSpace.AffineMap"
+      },
+      {
+        "theorem": "Module.smul / match_scalars",
+        "description": "real-scalar module structure and the match_scalars tactic reducing a vector identity to coefficient equalities",
+        "module": "Mathlib.Tactic.Module"
+      }
+    ],
+    "originalContributions": [
+      "bisectorMass: the angle-bisector mass assignment (masses = opposite side lengths a, b, c) as an instance of the parent's MassPoint structure",
+      "bisector_ratio_BD_DC / CE_EA / AF_FB: these masses realise exactly the angle-bisector theorem ratios c/b, a/c, b/a via the parent's lever-arm identity ratio_balance",
+      "bisectors_ceva_product / bisectors_side_ratio_product: the three bisectors satisfy Ceva's concurrency criterion (product of directed ratios = 1)",
+      "footD / footE / footF: the bisector feet as honest division points in a real vector space V; footD_eq_division ties footD to the parent's rD division point",
+      "incenter: the barycentric point (a·A + b·B + c·C)/(a+b+c)",
+      "incenter_on_bisector_A / B / C: I is the affine combination of each vertex and the opposite foot, so I lies on all three bisectors — a fully geometric concurrency witness",
+      "weights_A/B/C_sum_one: each concurrency identity is a genuine affine (not merely linear) combination, the weights summing to 1",
+      "incenter_lineMap_A: the A-bisector as a line, with I at parameter (b+c)/(a+b+c)"
+    ],
+    "references": [
+      {
+        "authors": "Hausner, Melvin",
+        "title": "The Center of Mass and Affine Geometry",
+        "year": "1962",
+        "venue": "American Mathematical Monthly",
+        "note": "Foundational treatment of mass-point (barycentric) geometry"
+      },
+      {
+        "authors": "Coxeter, H.S.M. and Greitzer, S.L.",
+        "title": "Geometry Revisited",
+        "year": "1967",
+        "venue": "MAA",
+        "note": "Mass-point geometry, the angle-bisector theorem, and the incenter as the barycenter with weights equal to the opposite sides"
+      }
+    ],
+    "prerequisites": [
+      "Mass-point (barycentric) geometry of triangles (parent entry cevas-theorem-oq-04)",
+      "The angle-bisector theorem (the internal bisector divides the opposite side in the ratio of the adjacent sides)",
+      "Affine combinations and lines in a real vector space (AffineMap.lineMap)",
+      "Basic real arithmetic with field_simp / positivity and the match_scalars tactic"
+    ],
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 208,
+    "mathlib_version": "4.26.0",
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only the foundational propext / Classical.choice / Quot.sound). No triangle inequality is assumed; only positivity of the three side lengths.",
+    "theoremCount": 16,
+    "definitionCount": 5
+  },
+  "overview": {
+    "historicalContext": "Mass-point geometry assigns positive masses to the vertices of a triangle and reads off cevian concurrency from the balance of the center of mass. The parent entry cevas-theorem-oq-04 develops this as an algebraic certificate: any positive masses mA, mB, mC induce side-division ratios whose Ceva product is automatically 1, with the centroid arising from equal masses. The canonical next worked example is the angle bisector. By the angle-bisector theorem, the internal bisector from a vertex divides the opposite side in the ratio of the two adjacent sides; this is exactly the lever-arm balance produced by masses equal to the opposite side lengths. The common point of the three bisectors is the incenter, whose barycentric coordinates are (a : b : c).",
+    "problemStatement": "**Open Question (from parent proof cevas-theorem-oq-04)**: Establish the mass-point assignment for the three angle bisectors of a triangle — masses proportional to the opposite side lengths — and derive their concurrency (the incenter) from Ceva's theorem.\n\n**Resolution**: With masses (mA, mB, mC) = (a, b, c) the parent's lever-arm identity reproduces the angle-bisector ratios BD/DC = c/b, CE/EA = a/c, AF/FB = b/a, whose product is 1 (Ceva). The concurrency point is the incenter I = (a·A + b·B + c·C)/(a+b+c), proved by exhibiting I on each bisector as an affine combination of a vertex and the opposite foot.",
+    "text": "A 208-line, axiom-free development (5 definitions, 16 theorems/lemmas). bisectorMass packages the masses (a, b, c) as a parent MassPoint. The three ratio lemmas are one-line corollaries of the parent's ratio_balance family, certifying that these masses encode the angle-bisector theorem ratios. bisectors_ceva_product = ceva_ratio_product_one specialized; bisectors_side_ratio_product states (c/b)·(a/c)·(b/a) = 1 directly. The geometric core works in an arbitrary real vector space V: footD, footE, footF are the bisector feet, incenter is the barycentric point (a : b : c), and incenter_on_bisector_A/B/C prove (via match_scalars + field_simp) that I equals the affine combination of each vertex with the opposite foot. The companion weights_*_sum_one lemmas confirm these are affine combinations (weights sum to 1), so I genuinely lies on each line, and incenter_lineMap_A recasts the A-bisector as AffineMap.lineMap with I at parameter (b+c)/(a+b+c).",
+    "proofStrategy": "Ratio lemmas: ratio_balance / _E / _F give rD/(1-rD) = mC/mB etc., which for bisectorMass is c/b, a/c, b/a by definitional unfolding of the structure fields. Concurrency: reuse the parent's ceva_ratio_product_one; the explicit side-ratio product is field_simp. Incenter incidence: unfold incenter and the relevant foot, then match_scalars splits the vector equation into one scalar identity per vertex atom, each cleared by field_simp (using a+b+c ≠ 0 and the relevant pair sum ≠ 0 from positivity). The lineMap form additionally needs ring after field_simp. weights_*_sum_one are field_simp/ring on (x + y)/(a+b+c) = 1.",
+    "keyInsights": [
+      "Masses proportional to the opposite sides are forced by the angle-bisector theorem: BD/DC = c/b is the lever-arm balance mC/mB with mB = b, mC = c.",
+      "All three bisectors are realised by a single mass assignment (a, b, c), so their concurrency is the parent's universal Ceva identity, not a separate computation.",
+      "The concurrency point is pinned down explicitly: the incenter is the affine combination of any vertex with the opposite foot, with weights a/(a+b+c) and (b+c)/(a+b+c) summing to 1.",
+      "The barycentric coordinates of the incenter are (a : b : c) — the masses themselves, normalized.",
+      "Only positivity of the side lengths is used; the triangle inequality is unnecessary for the algebraic concurrency, which holds in any real vector space."
+    ],
+    "prerequisites": [
+      "Mass-point and barycentric geometry of triangles",
+      "The angle-bisector theorem",
+      "Affine combinations and lines in a vector space"
+    ]
+  },
+  "conclusion": {
+    "summary": "Assigning vertex masses equal to the opposite side lengths realises the three angle bisectors of a triangle within the parent's mass-point framework: the induced division ratios are exactly the angle-bisector theorem ratios c/b, a/c, b/a, whose Ceva product is 1. The bisectors are concurrent at the incenter I = (a·A + b·B + c·C)/(a+b+c), proved constructively by placing I on each bisector as an affine combination of a vertex and the opposite foot (and as AffineMap.lineMap). Fully verified, 0 axioms, 0 sorries.",
+    "implications": "This is the canonical angle-bisector / incenter worked example of mass-point geometry, made into a checked theorem. Beyond the parent's ratio identity it provides an explicit geometric concurrency witness (the incenter on all three cevians) valid in any real vector space, and identifies the incenter's barycentric coordinates as (a : b : c).",
+    "openQuestions": [
+      "Connect the side-length masses to actual Euclidean distances by proving the angle-bisector theorem BD/DC = |AB|/|AC| from the inner-product structure, closing the loop to genuine angle bisectors.",
+      "Give the analogous mass-point treatment of the excenters (signed masses) and the Gergonne/Nagel points, and locate each as a barycentric combination.",
+      "Verify the incenter is equidistant from the three sides, recovering the inradius from the barycentric weights."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cevas-theorem-oq-04",
+      "relationship": "extends",
+      "description": "Specializes the parent's triangle mass-point framework to the angle-bisector / incenter case"
+    },
+    {
+      "targetId": "cevas-theorem-oq-04-oq-01",
+      "relationship": "related",
+      "description": "Sibling generalization of the same mass-point framework to an n-dimensional simplex"
+    },
+    {
+      "targetId": "cevas-theorem",
+      "relationship": "related",
+      "description": "The classical Ceva concurrency theorem whose criterion the bisector ratios satisfy"
+    }
+  ],
+  "sorries": 0,
+  "leanFile": {
+    "imports": [
+      "Proofs.CevasTheoremOQ04",
+      "Mathlib.Tactic",
+      "Mathlib.LinearAlgebra.AffineSpace.AffineMap"
+    ],
+    "opens": [
+      "MassPointCeva"
+    ],
+    "namespace": "MassPointCeva.AngleBisector",
+    "lineCount": 208,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 5,
+    "sorries": 0,
+    "path": "Proofs/CevasTheoremOQ04OQ04.lean"
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the parent's open question (cevas-theorem-oq-04): **establish the mass-point assignment for the three angle bisectors of a triangle — masses proportional to the opposite side lengths — and derive their concurrency (the incenter) from Ceva's theorem.**

With masses equal to the opposite side lengths `(mA, mB, mC) = (a, b, c)`:

1. the parent's lever-arm identity `ratio_balance` reproduces exactly the **angle-bisector theorem ratios** `BD/DC = c/b`, `CE/EA = a/c`, `AF/FB = b/a`;
2. hence the three bisectors satisfy **Ceva's concurrency criterion** — product of directed ratios `= 1` (reusing the parent's `ceva_ratio_product_one`);
3. the point of concurrency is the **incenter** `I = (a·A + b·B + c·C)/(a+b+c)`, proved *constructively* in an arbitrary real vector space by exhibiting `I` on each bisector as an affine combination of a vertex with the opposite foot (`incenter_on_bisector_A/B/C`), with weights summing to 1, and as `AffineMap.lineMap` at parameter `(b+c)/(a+b+c)`.

Item (3) is the substantive new content beyond the parent's ratio identity: a fully geometric concurrency witness. No triangle inequality is needed — only positivity of the three side lengths. The incenter's barycentric coordinates `(a : b : c)` fall out as the normalized masses.

## Verification

- **16 theorems/lemmas, 5 definitions, 0 axioms, 0 sorries**
- Kernel-verified on Mathlib **v4.26.0** via `lake env lean`
- `#print axioms` on all headline results: only `propext`, `Classical.choice`, `Quot.sound`

## Files

- `proofs/Proofs/CevasTheoremOQ04OQ04.lean` (208 lines)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/cevas-theorem-oq-04-oq-04/{meta.json,annotations.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)