### PR TITLE
audit: record 4 entries clean — kernel-rebuilt v4.26.0 (algebraic-reals-meager cluster + alternating-series)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17767,6 +17767,12 @@
       "lastAudited": "2026-06-24T00:18:30Z",
       "result": "clean",
       "issues": []
+    },
+    "algebraic-reals-meager-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T00:21:19Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17773,6 +17773,12 @@
       "lastAudited": "2026-06-24T00:21:19Z",
       "result": "clean",
       "issues": []
+    },
+    "alternating-series-test-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T00:23:38Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17755,6 +17755,18 @@
       "lastAudited": "2026-06-23T03:36:20Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "algebraic-reals-meager-dense-gdelta": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T00:18:30Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-reals-meager-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T00:18:30Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — 4 entries CLEAN

All four entries were **kernel-rebuilt on current main (Mathlib v4.26.0)** via `lake env lean` (mathlib cache + parents + target); meta.json claims match the Lean source exactly. No issues found. Each headline theorem's `#print axioms` is the standard triple `[propext, Classical.choice, Quot.sound]`.

| Entry | Badge | Tally | Notes |
|-------|-------|-------|-------|
| `algebraic-reals-meager-dense-gdelta` | original | 9 thm, 0 sorry, 0 ax | Transcendentals as explicit dense Gδ + algebraic-reals-not-Gδ. Source byte-identical to research PR #27773. The one lemma coinciding with Mathlib's `Set.Countable.isGδ_compl` is honestly disclosed and re-proved. |
| `algebraic-reals-meager-oq-02` | mathlib | 8 thm, 0 sorry, 0 ax | Measure-vs-category synthesis; Liouville comeagre-yet-null ⇒ comeagre ⇏ conull. File states it is a synthesis of existing Mathlib results. |
| `algebraic-reals-meager-oq-03` | mathlib | 6 thm, 1 abbrev, 0 sorry, 0 ax | Oxtoby decomposition ℝ = A ⊔ B + both independence non-implications. Small abstract engine over Mathlib/sibling blocks. |
| `alternating-series-test-oq-01-oq-01` | mathlib | 10 thm, 0 sorry, 0 ax | Two-sided two-term Leibniz error trap + alternating-harmonic rate. Upper bound = Mathlib `Antitone.alternating` API; lower-bound sharpness is new content, explicitly scoped "absent from Mathlib". |

### Why this PR
Prior audit cycles recorded these completions only in the local working tree, which `git reset --hard origin/main` wiped each cycle — causing `find-targets --next` to loop indefinitely on these slugs. Committing the tracker entries breaks the loop.

---
Discovered during gallery integrity audit.