### PR TITLE
research(chebyshev-bounds-oq-02-oq-01): Chebyshev's lower bound c₁·n ≤ ψ(n) via central binomial [verified, 0-sorry]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -687,6 +687,7 @@ import Proofs.CevasTheoremSinRatio
 import Proofs.ChebyshevBounds
 import Proofs.ChebyshevBoundsOQ03
 import Proofs.ChebyshevBoundsOQ02
+import Proofs.ChebyshevBoundsOQ02OQ01
 import Proofs.ChebyshevBoundsOQ04
 import Proofs.ChebyshevBoundsOQ04Aristotle
 import Proofs.ChebyshevBoundsOQ04OQ01

--- a/proofs/Proofs/ChebyshevBoundsOQ02OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ02OQ01.lean
@@ -1,0 +1,201 @@
+/-
+# Chebyshev's lower bound: explicit linear bounds c₁·n ≤ ψ(n) ≤ c₂·n (OQ-02-OQ-01)
+
+The parent file `ChebyshevBoundsOQ02` develops the second Chebyshev function
+`ψ(n) = ∑_{m ≤ n} Λ(m)` in von Mangoldt form and proves **Legendre's identity**
+`log(n!) = ∑_{d ≤ n} Λ(d)·⌊n/d⌋`, together with the easy estimate `ψ(n) ≤ log(n!)`
+(which is only `O(n log n)`).  Legendre's identity is the elementary engine behind the
+two-sided Chebyshev estimate `ψ(n) = Θ(n)`, but the parent stops short of the explicit
+linear bounds.
+
+This file proves the **lower bound** `c₁·n ≤ ψ(n)`, the harder half of Chebyshev's
+theorem and an explicit `TODO` in Mathlib's own `Mathlib/NumberTheory/Chebyshev.lean`
+("Prove Chebyshev's lower bound").  The argument is the classical one via the central
+binomial coefficient `C(n) = (2n choose n)`:
+
+* `log_centralBinom_eq_sum`:  `log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋)`, obtained by
+  applying Legendre's identity to `(2n)! = C(n)·(n!)²`.
+* `centralBinom_log_le_psi`:  `log C(n) ≤ ψ(2n)`.  Each Legendre coefficient
+  `⌊2n/d⌋ − 2⌊n/d⌋` lies in `{0,1}`, so each summand is at most `Λ(d)`.
+* Combined with Mathlib's `Nat.four_pow_le_two_mul_self_mul_centralBinom` (`4ⁿ ≤ 2n·C(n)`):
+  `psi_two_mul_ge_sub_log`:  `n·log 4 − log(2n) ≤ ψ(2n)`, and after absorbing the
+  logarithm (`2n ≤ 2ⁿ`):  `psi_two_mul_ge_linear`:  `n·log 2 ≤ ψ(2n)`.
+* `chebyshevPsi_lower_linear`:  for `m ≥ 2`,  `(log 2 / 3)·m ≤ ψ(m)`.
+
+Bridging the parent's `chebyshevPsi` to Mathlib's `Chebyshev.psi`
+(`chebyshevPsi_eq_psi`) imports the matching **upper** bound `ψ(n) ≤ (log 4 + 4)·n`
+(`Chebyshev.psi_le_const_mul_self`), giving the full two-sided explicit estimate
+`chebyshev_psi_bounds`:  `(log 2 / 3)·m ≤ ψ(m) ≤ (log 4 + 4)·m` for `m ≥ 2`.
+
+`#print axioms chebyshev_psi_bounds` lists only `propext`, `Classical.choice`, `Quot.sound`.
+-/
+import Mathlib
+import Proofs.ChebyshevBoundsOQ02
+
+open Finset ArithmeticFunction
+
+namespace ChebyshevBoundsOQ02OQ01
+
+open ChebyshevBoundsOQ02
+
+/-- **Floor identity** `⌊2n/d⌋ ≤ 2⌊n/d⌋ + 1` (natural-number division), the arithmetic
+core of the central-binomial argument: the Legendre coefficient `⌊2n/d⌋ − 2⌊n/d⌋` never
+exceeds `1`. -/
+theorem two_mul_div_le (n d : ℕ) : 2 * n / d ≤ 2 * (n / d) + 1 := by
+  rcases Nat.eq_zero_or_pos d with rfl | hd
+  · simp
+  · have hlt : 2 * n < d * (2 * (n / d) + 2) := by
+      have h := Nat.div_add_mod n d
+      have h2 := Nat.mod_lt n hd
+      nlinarith [h, h2]
+    have := Nat.div_lt_of_lt_mul hlt
+    omega
+
+/-- **Legendre expansion of the central binomial coefficient.**
+`log C(n) = ∑_{d=1}^{2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋)`, from `(2n)! = C(n)·(n!)²` and Legendre's
+identity for `log(2n)!` and `log(n!)`. -/
+theorem log_centralBinom_eq_sum (n : ℕ) :
+    Real.log (Nat.centralBinom n) =
+      ∑ d ∈ Finset.Icc 1 (2 * n),
+        Λ d * (((2 * n / d : ℕ) : ℝ) - 2 * ((n / d : ℕ) : ℝ)) := by
+  -- (2n)! = C(n) · n! · n!
+  have hfact : (Nat.centralBinom n : ℝ) * (Nat.factorial n : ℝ) * (Nat.factorial n : ℝ) =
+      (Nat.factorial (2 * n) : ℝ) := by
+    have hnat : Nat.centralBinom n * Nat.factorial n * Nat.factorial n = Nat.factorial (2 * n) := by
+      have h := Nat.choose_mul_factorial_mul_factorial (show n ≤ 2 * n by omega)
+      rw [show 2 * n - n = n by omega] at h
+      rw [Nat.centralBinom_eq_two_mul_choose]
+      exact h
+    exact_mod_cast hnat
+  -- log C(n) = log (2n)! − 2·log n!
+  have hlogcb : Real.log (Nat.centralBinom n) =
+      Real.log (Nat.factorial (2 * n) : ℝ) - 2 * Real.log (Nat.factorial n : ℝ) := by
+    have hpf : (0 : ℝ) < (Nat.factorial n : ℝ) := by exact_mod_cast Nat.factorial_pos n
+    have hpc : (0 : ℝ) < (Nat.centralBinom n : ℝ) := by exact_mod_cast Nat.centralBinom_pos n
+    rw [← hfact, Real.log_mul (by positivity) (by positivity),
+        Real.log_mul (by positivity) (by positivity)]
+    ring
+  rw [hlogcb, log_factorial_eq_sum (2 * n)]
+  -- extend Legendre for n! to the range Icc 1 (2n) (the extra terms vanish: n/d = 0)
+  have hLn : Real.log (Nat.factorial n : ℝ) =
+      ∑ d ∈ Finset.Icc 1 (2 * n), Λ d * ((n / d : ℕ) : ℝ) := by
+    rw [log_factorial_eq_sum n]
+    apply Finset.sum_subset
+    · intro x hx; rw [Finset.mem_Icc] at hx ⊢; omega
+    · intro x hx hx'
+      rw [Finset.mem_Icc] at hx
+      simp only [Finset.mem_Icc, not_and, not_le] at hx'
+      have hlt : n < x := hx' hx.1
+      rw [Nat.div_eq_of_lt hlt]; simp
+  rw [hLn, Finset.mul_sum, ← Finset.sum_sub_distrib]
+  refine Finset.sum_congr rfl fun d _ => ?_
+  ring
+
+/-- **Key inequality:** `log C(n) ≤ ψ(2n)`.  Every Legendre coefficient
+`⌊2n/d⌋ − 2⌊n/d⌋` is `0` or `1`, so each summand is at most `Λ(d)`, and the sum of `Λ(d)`
+over `d ≤ 2n` is exactly `ψ(2n)`. -/
+theorem centralBinom_log_le_psi (n : ℕ) :
+    Real.log (Nat.centralBinom n) ≤ chebyshevPsi (2 * n) := by
+  rw [log_centralBinom_eq_sum, chebyshevPsi]
+  refine Finset.sum_le_sum fun d _ => ?_
+  have hΛ : 0 ≤ Λ d := vonMangoldt_nonneg
+  have hcoeff : ((2 * n / d : ℕ) : ℝ) - 2 * ((n / d : ℕ) : ℝ) ≤ 1 := by
+    have hcast : ((2 * n / d : ℕ) : ℝ) ≤ 2 * ((n / d : ℕ) : ℝ) + 1 := by
+      exact_mod_cast two_mul_div_le n d
+    linarith
+  nlinarith [mul_nonneg hΛ
+    (by linarith : (0 : ℝ) ≤ 1 - (((2 * n / d : ℕ) : ℝ) - 2 * ((n / d : ℕ) : ℝ)))]
+
+/-- `n·log 4 − log(2n) ≤ ψ(2n)` for `n ≥ 1`, from `4ⁿ ≤ 2n·C(n)`. -/
+theorem psi_two_mul_ge_sub_log {n : ℕ} (hn : 0 < n) :
+    (n : ℝ) * Real.log 4 - Real.log (2 * n) ≤ chebyshevPsi (2 * n) := by
+  have hcb : (4 : ℝ) ^ n ≤ 2 * (n : ℝ) * (Nat.centralBinom n : ℝ) := by
+    exact_mod_cast Nat.four_pow_le_two_mul_self_mul_centralBinom n hn
+  have hn0 : (n : ℝ) ≠ 0 := by exact_mod_cast hn.ne'
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  have h2n0 : (2 * (n : ℝ)) ≠ 0 := by positivity
+  have hcb0 : (Nat.centralBinom n : ℝ) ≠ 0 := by
+    exact_mod_cast (Nat.centralBinom_pos n).ne'
+  have hpos2 : (0 : ℝ) < 2 * (n : ℝ) * (Nat.centralBinom n : ℝ) := by
+    have : (0 : ℝ) < (Nat.centralBinom n : ℝ) := by exact_mod_cast Nat.centralBinom_pos n
+    positivity
+  have hlog : Real.log ((4 : ℝ) ^ n) ≤ Real.log (2 * (n : ℝ) * (Nat.centralBinom n : ℝ)) :=
+    (Real.log_le_log_iff (by positivity) hpos2).mpr hcb
+  rw [Real.log_pow, Real.log_mul h2n0 hcb0] at hlog
+  have hcbpsi := centralBinom_log_le_psi n
+  linarith
+
+/-- Helper: `2m ≤ 2ᵐ` for `m ≥ 1`. -/
+theorem two_mul_le_two_pow {m : ℕ} (hm : 1 ≤ m) : 2 * m ≤ 2 ^ m := by
+  induction m with
+  | zero => omega
+  | succ k ih =>
+    rcases Nat.eq_zero_or_pos k with rfl | hk
+    · norm_num
+    · have hik := ih hk
+      have h2k : 2 ≤ 2 ^ k := by
+        calc (2 : ℕ) = 2 ^ 1 := (pow_one 2).symm
+          _ ≤ 2 ^ k := Nat.pow_le_pow_right (by norm_num) hk
+      rw [pow_succ]; omega
+
+/-- `log(2n) ≤ n·log 2` for `n ≥ 1` (since `2n ≤ 2ⁿ`). -/
+theorem log_two_mul_le {n : ℕ} (hn : 1 ≤ n) :
+    Real.log (2 * n) ≤ (n : ℝ) * Real.log 2 := by
+  have hnpos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast hn
+  have h : (2 * (n : ℝ)) ≤ (2 : ℝ) ^ n := by exact_mod_cast two_mul_le_two_pow hn
+  calc Real.log (2 * n) ≤ Real.log ((2 : ℝ) ^ n) :=
+        (Real.log_le_log_iff (mul_pos (by norm_num) hnpos) (by positivity)).mpr h
+    _ = (n : ℝ) * Real.log 2 := Real.log_pow 2 n
+
+/-- **Chebyshev's lower bound, even case:** `n·log 2 ≤ ψ(2n)` for `n ≥ 1`. -/
+theorem psi_two_mul_ge_linear {n : ℕ} (hn : 0 < n) :
+    (n : ℝ) * Real.log 2 ≤ chebyshevPsi (2 * n) := by
+  have h1 := psi_two_mul_ge_sub_log hn
+  have h2 := log_two_mul_le hn
+  have hlog4 : Real.log 4 = 2 * Real.log 2 := by
+    rw [show (4 : ℝ) = 2 ^ (2 : ℕ) by norm_num, Real.log_pow]; norm_num
+  have key : (n : ℝ) * Real.log 4 = 2 * ((n : ℝ) * Real.log 2) := by rw [hlog4]; ring
+  rw [key] at h1
+  linarith
+
+/-- **Chebyshev's lower bound:** `(log 2 / 3)·m ≤ ψ(m)` for `m ≥ 2`.  The constant
+`log 2 / 3 ≈ 0.231` is explicit; the odd/even split costs only the factor `3` in the
+denominator. -/
+theorem chebyshevPsi_lower_linear {m : ℕ} (hm : 2 ≤ m) :
+    Real.log 2 / 3 * (m : ℝ) ≤ chebyshevPsi m := by
+  have hmono : chebyshevPsi (2 * (m / 2)) ≤ chebyshevPsi m := chebyshevPsi_mono (by omega)
+  have hlin := psi_two_mul_ge_linear (n := m / 2) (by omega)
+  have hlog2 : 0 ≤ Real.log 2 := Real.log_nonneg (by norm_num)
+  have hm3 : (m : ℝ) ≤ 3 * ((m / 2 : ℕ) : ℝ) := by
+    have : m ≤ 3 * (m / 2) := by omega
+    exact_mod_cast this
+  have step : Real.log 2 / 3 * (m : ℝ) ≤ ((m / 2 : ℕ) : ℝ) * Real.log 2 := by
+    nlinarith [mul_nonneg hlog2 (by linarith : (0 : ℝ) ≤ 3 * ((m / 2 : ℕ) : ℝ) - m), hlog2, hm3]
+  linarith
+
+/-- Bridge: the parent's `chebyshevPsi n` equals Mathlib's `Chebyshev.psi n`. -/
+theorem chebyshevPsi_eq_psi (n : ℕ) : chebyshevPsi n = Chebyshev.psi (n : ℝ) := by
+  rw [Chebyshev.psi_eq_sum_Icc, Nat.floor_natCast, chebyshevPsi]
+  apply Finset.sum_subset
+  · intro x hx; rw [Finset.mem_Icc] at hx ⊢; omega
+  · intro x hx hx'
+    rw [Finset.mem_Icc] at hx
+    simp only [Finset.mem_Icc, not_and, not_le] at hx'
+    have : x = 0 := by omega
+    rw [this]; simp
+
+/-- **Chebyshev's upper bound** (imported from Mathlib): `ψ(n) ≤ (log 4 + 4)·n`. -/
+theorem chebyshevPsi_le_linear (n : ℕ) :
+    chebyshevPsi n ≤ (Real.log 4 + 4) * (n : ℝ) := by
+  rw [chebyshevPsi_eq_psi]
+  exact Chebyshev.psi_le_const_mul_self (by positivity)
+
+/-- **Two-sided explicit Chebyshev bounds:**
+`(log 2 / 3)·m ≤ ψ(m) ≤ (log 4 + 4)·m` for `m ≥ 2` — the elementary `ψ(m) = Θ(m)`, with
+both constants explicit. -/
+theorem chebyshev_psi_bounds {m : ℕ} (hm : 2 ≤ m) :
+    Real.log 2 / 3 * (m : ℝ) ≤ chebyshevPsi m ∧
+      chebyshevPsi m ≤ (Real.log 4 + 4) * (m : ℝ) :=
+  ⟨chebyshevPsi_lower_linear hm, chebyshevPsi_le_linear m⟩
+
+end ChebyshevBoundsOQ02OQ01

--- a/src/data/proofs/chebyshev-bounds-oq-02-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-02-oq-01/meta.json
@@ -1,0 +1,224 @@
+{
+  "id": "chebyshev-bounds-oq-02-oq-01",
+  "title": "Chebyshev's Lower Bound: Explicit Linear Bounds (log 2/3)·n ≤ ψ(n) ≤ (log 4 + 4)·n",
+  "slug": "chebyshev-bounds-oq-02-oq-01",
+  "description": "Proves the explicit two-sided Chebyshev estimate (log 2/3)·n ≤ ψ(n) ≤ (log 4 + 4)·n for the second Chebyshev function ψ. The lower bound — the harder half of Chebyshev's theorem and an explicit TODO in Mathlib's own NumberTheory/Chebyshev.lean ('Prove Chebyshev's lower bound') — is obtained via the central binomial coefficient C(n) = (2n choose n): applying the parent's Legendre identity to (2n)! = C(n)·(n!)² gives log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋); since every coefficient ⌊2n/d⌋ − 2⌊n/d⌋ lies in {0,1}, log C(n) ≤ ψ(2n), and Mathlib's bound 4ⁿ ≤ 2n·C(n) then forces ψ(2n) ≥ n·log 4 − log(2n) ≥ n·log 2. Bridging the parent's chebyshevPsi to Mathlib's Chebyshev.psi imports the matching upper bound. Answers the parent chebyshev-bounds-oq-02's first open question.",
+  "meta": {
+    "author": "Pafnuty Chebyshev (1852); formalized in Lean 4",
+    "date": "1852",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ChebyshevBoundsOQ02OQ01.lean",
+    "tags": [
+      "number-theory",
+      "primes",
+      "chebyshev",
+      "von-mangoldt",
+      "prime-counting",
+      "central-binomial",
+      "analytic-number-theory"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 201,
+    "assumptions": "0 literal `axiom` declarations, 0 sorries, no `native_decide`. `#print axioms` on chebyshev_psi_bounds, centralBinom_log_le_psi, and chebyshevPsi_lower_linear reports only the three ordinary foundational axioms (propext, Classical.choice, Quot.sound), which are not counted under the project's axiom-integrity policy. Builds on the parent ChebyshevBoundsOQ02 (Legendre's identity) and Mathlib's central-binomial and Chebyshev developments; all results are fully machine-checked.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.four_pow_le_two_mul_self_mul_centralBinom",
+        "description": "4ⁿ ≤ 2n·C(n) — the exponential lower bound on the central binomial coefficient that drives ψ's lower bound",
+        "module": "Mathlib.Data.Nat.Choose.Central"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "C(2n,n)·n!·(2n−n)! = (2n)! — identifies (2n)! = C(n)·(n!)² so log C(n) = log(2n)! − 2 log(n!)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Chebyshev.psi_le_const_mul_self",
+        "description": "ψ(x) ≤ (log 4 + 4)·x — Mathlib's explicit Chebyshev upper bound, imported across the chebyshevPsi ↔ Chebyshev.psi bridge",
+        "module": "Mathlib.NumberTheory.Chebyshev"
+      },
+      {
+        "theorem": "ArithmeticFunction.vonMangoldt_nonneg",
+        "description": "0 ≤ Λ(d) — needed to bound each Legendre summand Λ(d)·(coefficient) by Λ(d)",
+        "module": "Mathlib.NumberTheory.ArithmeticFunction.VonMangoldt"
+      },
+      {
+        "theorem": "Real.log_le_log_iff",
+        "description": "monotonicity of log on positive reals, applied to 4ⁿ ≤ 2n·C(n) and 2n ≤ 2ⁿ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-23",
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's 1852 theorem — that ψ(x) = ∑_{p^k ≤ x} log p satisfies c₁·x ≤ ψ(x) ≤ c₂·x — was the first unconditional progress toward the Prime Number Theorem, giving π(x) ≍ x/log x and (via Bertrand's postulate) a prime in every interval (n, 2n]. Both bounds rest on the central binomial coefficient C(n) = (2n choose n). The upper bound comes from C(n) ≤ 4ⁿ together with the fact that every prime in (n, 2n] divides C(n); the lower bound from 4ⁿ/(2n) ≤ C(n) together with log C(n) ≤ ψ(2n), the latter because the exponent of each prime power p^k ≤ 2n in C(n) = (2n)!/(n!)² is ⌊2n/p^k⌋ − 2⌊n/p^k⌋ ∈ {0,1}. The parent file ChebyshevBoundsOQ02 proved the underlying Legendre identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋; this file completes the bound. Notably, Mathlib's own NumberTheory/Chebyshev.lean carries the explicit TODO 'Prove Chebyshev's lower bound' — it supplies the upper bound (psi_le_const_mul_self) but not the lower, so the lower half formalized here fills a gap Mathlib itself flags.",
+    "problemStatement": "**Open Question (parent chebyshev-bounds-oq-02, first open direction)**: Derive the explicit Chebyshev bounds c₁·n ≤ ψ(n) ≤ c₂·n by telescoping Legendre's identity against the central binomial coefficient.\n\n**Result**: For all m ≥ 2, (log 2 / 3)·m ≤ ψ(m) ≤ (log 4 + 4)·m, with both constants explicit. The lower bound is proved from scratch via the central binomial coefficient; the upper bound is imported from Mathlib across a bridge identifying the parent's chebyshevPsi with Mathlib's Chebyshev.psi.",
+    "text": "A 201-line, fully verified (0 sorries, 0 axioms, no native_decide) file. The headline chebyshev_psi_bounds gives (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for m ≥ 2. The lower half is the new mathematical content; the upper half is a one-line corollary of Mathlib once the definitions are bridged.",
+    "proofStrategy": "The lower bound is built in four steps. (1) log_centralBinom_eq_sum writes log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋): from (2n)! = C(n)·(n!)² (Nat.choose_mul_factorial_mul_factorial) one gets log C(n) = log(2n)! − 2 log(n!), and applying the parent's Legendre identity to both factorials (extending the n! sum harmlessly to the range [1,2n], where the extra terms ⌊n/d⌋ = 0 vanish) combines the two sums termwise. (2) centralBinom_log_le_psi bounds log C(n) ≤ ψ(2n): the floor identity two_mul_div_le shows ⌊2n/d⌋ ≤ 2⌊n/d⌋ + 1, so each coefficient is ≤ 1, and since Λ(d) ≥ 0 each summand Λ(d)·(coefficient) ≤ Λ(d); summing gives ψ(2n). (3) psi_two_mul_ge_sub_log feeds in Mathlib's 4ⁿ ≤ 2n·C(n): taking logs, n·log 4 ≤ log(2n) + log C(n) ≤ log(2n) + ψ(2n). (4) psi_two_mul_ge_linear absorbs the logarithm via 2n ≤ 2ⁿ (two_mul_le_two_pow), giving log(2n) ≤ n·log 2 and hence n·log 2 ≤ ψ(2n); chebyshevPsi_lower_linear then extends to all m ≥ 2 by monotonicity (ψ(m) ≥ ψ(2⌊m/2⌋)) with the constant log 2/3 absorbing the odd/even split. The upper bound (chebyshevPsi_le_linear) is Chebyshev.psi_le_const_mul_self transported across chebyshevPsi_eq_psi.",
+    "keyInsights": [
+      "The central binomial coefficient is the bridge: log C(n) = log(2n)! − 2 log(n!), and Legendre's identity turns this into ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋).",
+      "Each Legendre coefficient ⌊2n/d⌋ − 2⌊n/d⌋ lies in {0,1} (the arithmetic core two_mul_div_le: ⌊2n/d⌋ ≤ 2⌊n/d⌋ + 1), so log C(n) ≤ ∑_{d≤2n} Λ(d) = ψ(2n) — no prime factorization of C(n) is needed, only the floor inequality and Λ ≥ 0.",
+      "Mathlib's 4ⁿ ≤ 2n·C(n) converts the combinatorial bound log C(n) ≤ ψ(2n) into the analytic ψ(2n) ≥ n·log 4 − log(2n).",
+      "The logarithmic error term log(2n) is absorbed cleanly by the elementary 2n ≤ 2ⁿ, yielding the clean linear bound n·log 2 ≤ ψ(2n) with no asymptotic hand-waving and an explicit constant.",
+      "Mathlib's NumberTheory/Chebyshev.lean explicitly lists 'Prove Chebyshev's lower bound' as an open TODO; this file supplies exactly that, while reusing Mathlib's upper bound by bridging the parent's chebyshevPsi to Chebyshev.psi."
+    ],
+    "prerequisites": [
+      "The second Chebyshev function ψ and Legendre's identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ (parent chebyshev-bounds-oq-02)",
+      "The central binomial coefficient C(n) = (2n choose n) and its exponential bounds 4ⁿ/(2n) ≤ C(n) ≤ 4ⁿ",
+      "The von Mangoldt function Λ and elementary properties of Real.log on positive reals"
+    ]
+  },
+  "sections": [
+    {
+      "id": "floor-core",
+      "title": "Floor Identity",
+      "startLine": 44,
+      "endLine": 52,
+      "summary": "two_mul_div_le: ⌊2n/d⌋ ≤ 2⌊n/d⌋ + 1, so every Legendre coefficient ⌊2n/d⌋ − 2⌊n/d⌋ is 0 or 1.",
+      "mathContext": "The arithmetic engine bounding the central-binomial Legendre coefficients."
+    },
+    {
+      "id": "legendre-expansion",
+      "title": "Legendre Expansion of C(n)",
+      "startLine": 57,
+      "endLine": 95,
+      "summary": "log_centralBinom_eq_sum: log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋), from (2n)! = C(n)·(n!)² and the parent's Legendre identity.",
+      "mathContext": "Turns the central binomial coefficient into a von Mangoldt sum."
+    },
+    {
+      "id": "key-inequality",
+      "title": "log C(n) ≤ ψ(2n)",
+      "startLine": 97,
+      "endLine": 108,
+      "summary": "centralBinom_log_le_psi: each coefficient ≤ 1 and Λ ≥ 0, so each summand ≤ Λ(d), giving the sum ψ(2n).",
+      "mathContext": "The combinatorial core of Chebyshev's lower bound."
+    },
+    {
+      "id": "analytic-lower",
+      "title": "Analytic Lower Bound",
+      "startLine": 110,
+      "endLine": 162,
+      "summary": "psi_two_mul_ge_sub_log: n·log 4 − log(2n) ≤ ψ(2n) from 4ⁿ ≤ 2n·C(n); psi_two_mul_ge_linear: n·log 2 ≤ ψ(2n) after absorbing log(2n) via 2n ≤ 2ⁿ.",
+      "mathContext": "Converts the combinatorial bound into an explicit linear estimate."
+    },
+    {
+      "id": "two-sided",
+      "title": "Two-Sided Bounds",
+      "startLine": 164,
+      "endLine": 200,
+      "summary": "chebyshevPsi_lower_linear: (log 2/3)·m ≤ ψ(m) for m ≥ 2; chebyshevPsi_eq_psi bridges to Mathlib's Chebyshev.psi to import the upper bound chebyshevPsi_le_linear; chebyshev_psi_bounds packages both.",
+      "mathContext": "The explicit two-sided ψ(m) = Θ(m), with both constants exhibited."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file proves the explicit two-sided Chebyshev estimate (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for m ≥ 2. The lower bound — the harder half of Chebyshev's theorem and an explicit TODO in Mathlib — is derived from the central binomial coefficient: log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋) with every coefficient in {0,1}, giving log C(n) ≤ ψ(2n), then Mathlib's 4ⁿ ≤ 2n·C(n) forces ψ(2n) ≥ n·log 2. The upper bound is imported from Mathlib across a definitional bridge.",
+    "implications": "ψ(x) = Θ(x) is equivalent (by partial summation) to π(x) = Θ(x/log x), Chebyshev's celebrated approximation to the Prime Number Theorem, and is the form in which PNT reads ψ(x) ∼ x. The lower bound also underlies Bertrand's postulate. Formalizing the lower half completes the elementary two-sided Chebyshev estimate flagged as open in Mathlib's own source and connects the gallery's Chebyshev thread to the PNT bridge.",
+    "openQuestions": [
+      "Sharpen the constants toward the optimal Chebyshev values (lower ≈ log 2 ≈ 0.693, upper ≈ 2 log 2 ≈ 1.386) by refining the central-binomial estimates.",
+      "Transfer the bounds to θ(n) = ∑_{p≤n} log p using ψ(n) − θ(n) = O(√n log² n), giving θ(n) = Θ(n).",
+      "Combine with partial summation to derive explicit Chebyshev bounds c₁·n/log n ≤ π(n) ≤ c₂·n/log n."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-bounds-oq-02",
+      "relationship": "extends",
+      "description": "Parent: the second Chebyshev function ψ and Legendre's identity log(n!) = ∑ Λ(d)⌊n/d⌋. This entry answers its first open question — the explicit linear bounds on ψ."
+    },
+    {
+      "targetId": "chebyshev-bounds",
+      "relationship": "related",
+      "description": "Grandparent: explicit Chebyshev bounds on π(n) and θ(n) via central binomial coefficients."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "related",
+      "description": "ψ(x) = Θ(x) is the natural form of the Prime Number Theorem this thread works toward."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevBoundsOQ02"
+    ],
+    "opens": [
+      "Finset",
+      "ArithmeticFunction"
+    ],
+    "namespace": "ChebyshevBoundsOQ02OQ01",
+    "lineCount": 201,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "chebyshev_psi_bounds",
+        "type": "core",
+        "description": "Two-sided explicit Chebyshev bounds (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for m ≥ 2",
+        "leanType": "{m : ℕ} → 2 ≤ m → Real.log 2 / 3 * (m : ℝ) ≤ chebyshevPsi m ∧ chebyshevPsi m ≤ (Real.log 4 + 4) * (m : ℝ)"
+      },
+      {
+        "name": "centralBinom_log_le_psi",
+        "type": "key",
+        "description": "log C(n) ≤ ψ(2n): each Legendre coefficient ⌊2n/d⌋ − 2⌊n/d⌋ ∈ {0,1}",
+        "leanType": "(n : ℕ) → Real.log (Nat.centralBinom n) ≤ chebyshevPsi (2 * n)"
+      },
+      {
+        "name": "chebyshevPsi_lower_linear",
+        "type": "key",
+        "description": "Chebyshev's lower bound (log 2/3)·m ≤ ψ(m) for m ≥ 2",
+        "leanType": "{m : ℕ} → 2 ≤ m → Real.log 2 / 3 * (m : ℝ) ≤ chebyshevPsi m"
+      }
+    ],
+    "path": "Proofs/ChebyshevBoundsOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "chebyshev_psi_bounds",
+      "type": "core",
+      "description": "Two-sided explicit Chebyshev bounds (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for m ≥ 2",
+      "leanType": "{m : ℕ} → 2 ≤ m → Real.log 2 / 3 * (m : ℝ) ≤ chebyshevPsi m ∧ chebyshevPsi m ≤ (Real.log 4 + 4) * (m : ℝ)"
+    },
+    {
+      "name": "log_centralBinom_eq_sum",
+      "type": "key",
+      "description": "log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋), the Legendre expansion of the central binomial coefficient",
+      "leanType": "(n : ℕ) → Real.log (Nat.centralBinom n) = ∑ d ∈ Finset.Icc 1 (2 * n), Λ d * (((2 * n / d : ℕ) : ℝ) - 2 * ((n / d : ℕ) : ℝ))"
+    },
+    {
+      "name": "centralBinom_log_le_psi",
+      "type": "key",
+      "description": "log C(n) ≤ ψ(2n) — the combinatorial core of Chebyshev's lower bound",
+      "leanType": "(n : ℕ) → Real.log (Nat.centralBinom n) ≤ chebyshevPsi (2 * n)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Chebyshev, Pafnuty L.",
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "venue": "Journal de mathématiques pures et appliquées 17, 366–390",
+      "note": "The original two-sided bounds c₁·x ≤ ψ(x) ≤ c₂·x via factorials and the central binomial coefficient"
+    },
+    {
+      "authors": "Apostol, Tom M.",
+      "title": "Introduction to Analytic Number Theory",
+      "year": "1976",
+      "venue": "Springer UTM",
+      "note": "Chapter 4: the Chebyshev functions ψ, θ and their Θ(x) bounds via the central binomial coefficient"
+    },
+    {
+      "authors": "Nair, M.",
+      "title": "On Chebyshev-Type Inequalities for Primes",
+      "year": "1982",
+      "venue": "American Mathematical Monthly 89(2), 126–129",
+      "note": "An elegant elementary derivation of ψ(n) = Θ(n) from the central binomial coefficient"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/chebyshev-bounds-oq-02-oq-01.json
+++ b/src/data/research/problems/chebyshev-bounds-oq-02-oq-01.json
@@ -1,0 +1,57 @@
+{
+  "slug": "chebyshev-bounds-oq-02-oq-01",
+  "title": "Chebyshev's Lower Bound: explicit linear bounds c₁·n ≤ ψ(n) ≤ c₂·n",
+  "problemStatement": "Derive the explicit Chebyshev bounds c₁·n ≤ ψ(n) ≤ c₂·n for the second Chebyshev function ψ, by telescoping the parent's Legendre identity log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋ against the central binomial coefficient C(n) = (2n choose n).",
+  "phase": "COMPLETED",
+  "status": "completed",
+  "tier": "B",
+  "significance": 6,
+  "tractability": 6,
+  "tags": [
+    "number-theory",
+    "primes",
+    "chebyshev",
+    "von-mangoldt",
+    "central-binomial",
+    "analytic-number-theory"
+  ],
+  "path": "Proofs/ChebyshevBoundsOQ02OQ01.lean",
+  "leanFiles": [
+    "Proofs/ChebyshevBoundsOQ02OQ01.lean"
+  ],
+  "started": "2026-06-23",
+  "lastUpdate": "2026-06-23",
+  "currentState": "SOLVED. Proved the two-sided explicit Chebyshev estimate (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for m ≥ 2, fully verified (0 sorries, 0 axioms beyond the foundational triple). The lower bound is new content; the upper bound is imported from Mathlib across a chebyshevPsi ↔ Chebyshev.psi bridge.",
+  "knowledge": {
+    "insights": [
+      "Chebyshev's lower bound reduces to log C(n) ≤ ψ(2n): applying the parent's Legendre identity to (2n)! = C(n)·(n!)² gives log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋), and every coefficient ⌊2n/d⌋ − 2⌊n/d⌋ lies in {0,1}.",
+      "No prime factorization of C(n) is needed — only the floor inequality ⌊2n/d⌋ ≤ 2⌊n/d⌋ + 1 and Λ(d) ≥ 0.",
+      "Mathlib's Nat.four_pow_le_two_mul_self_mul_centralBinom (4ⁿ ≤ 2n·C(n)) converts the combinatorial bound into ψ(2n) ≥ n·log 4 − log(2n).",
+      "The log(2n) error term is absorbed by the elementary 2n ≤ 2ⁿ, giving the clean n·log 2 ≤ ψ(2n) with explicit constant.",
+      "Mathlib's NumberTheory/Chebyshev.lean lists 'Prove Chebyshev's lower bound' as an explicit TODO; it provides the upper bound (psi_le_const_mul_self) but not the lower — this file fills exactly that gap."
+    ],
+    "builtItems": [
+      "two_mul_div_le (floor identity ⌊2n/d⌋ ≤ 2⌊n/d⌋+1) — ChebyshevBoundsOQ02OQ01.lean:44",
+      "log_centralBinom_eq_sum (Legendre expansion of C(n)) — ChebyshevBoundsOQ02OQ01.lean:57",
+      "centralBinom_log_le_psi (log C(n) ≤ ψ(2n)) — ChebyshevBoundsOQ02OQ01.lean:97",
+      "psi_two_mul_ge_sub_log / psi_two_mul_ge_linear (n·log 2 ≤ ψ(2n)) — ChebyshevBoundsOQ02OQ01.lean:110,151",
+      "chebyshevPsi_lower_linear ((log 2/3)·m ≤ ψ(m)) and chebyshev_psi_bounds (two-sided) — ChebyshevBoundsOQ02OQ01.lean:164,196"
+    ],
+    "mathlibGaps": [
+      "Mathlib has the Chebyshev upper bound (Chebyshev.psi_le_const_mul_self) but not the lower bound; its source explicitly flags 'Prove Chebyshev's lower bound' as a TODO."
+    ],
+    "nextSteps": [
+      "Sharpen constants toward the optimal Chebyshev values (lower ≈ log 2, upper ≈ 2 log 2).",
+      "Transfer to θ(n) via ψ(n) − θ(n) = O(√n log² n).",
+      "Combine with partial summation for explicit π(n) = Θ(n/log n)."
+    ],
+    "progressSummary": "COMPLETE: two-sided explicit Chebyshev bounds (log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m for m ≥ 2, verified 0-sorry 0-axiom."
+  },
+  "knownResults": [],
+  "references": [],
+  "relatedProofs": [
+    "chebyshev-bounds-oq-02",
+    "chebyshev-bounds",
+    "chebyshev-pnt-bridge"
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **explicit two-sided Chebyshev estimate** `(log 2/3)·m ≤ ψ(m) ≤ (log 4 + 4)·m` for `m ≥ 2` — the elementary `ψ(m) = Θ(m)`, with both constants exhibited.

The **lower bound** is the harder half of Chebyshev's theorem and an explicit `TODO` in Mathlib's own `Mathlib/NumberTheory/Chebyshev.lean` (line: *"Prove Chebyshev's lower bound"*). Mathlib supplies the upper bound (`psi_le_const_mul_self`) but not the lower — this file fills exactly that gap.

Answers the **first open question** of the parent `chebyshev-bounds-oq-02` (which proved Legendre's identity `log(n!) = ∑_{d≤n} Λ(d)·⌊n/d⌋`).

## Proof (lower bound, via the central binomial coefficient `C(n) = (2n choose n)`)

1. **`log_centralBinom_eq_sum`** — from `(2n)! = C(n)·(n!)²`, the parent's Legendre identity gives `log C(n) = ∑_{d≤2n} Λ(d)·(⌊2n/d⌋ − 2⌊n/d⌋)`.
2. **`centralBinom_log_le_psi`** — every coefficient `⌊2n/d⌋ − 2⌊n/d⌋ ∈ {0,1}` (floor identity `two_mul_div_le`) and `Λ ≥ 0`, so each summand `≤ Λ(d)`, hence `log C(n) ≤ ψ(2n)`. No prime factorization of `C(n)` needed.
3. **`psi_two_mul_ge_linear`** — Mathlib's `4ⁿ ≤ 2n·C(n)` forces `ψ(2n) ≥ n·log 4 − log(2n) ≥ n·log 2` (the `log(2n)` term absorbed via `2n ≤ 2ⁿ`).
4. **`chebyshevPsi_lower_linear`** — `(log 2/3)·m ≤ ψ(m)` for `m ≥ 2`.

The **upper bound** is imported from Mathlib (`Chebyshev.psi_le_const_mul_self`) across the `chebyshevPsi ↔ Chebyshev.psi` bridge (`chebyshevPsi_eq_psi`).

## Verification

- **11 theorems, 0 definitions, 201 lines.**
- 0 sorries, 0 `axiom` declarations, no `native_decide`.
- `#print axioms chebyshev_psi_bounds` → `[propext, Classical.choice, Quot.sound]` only.
- Kernel-verified via `lake env lean Proofs/ChebyshevBoundsOQ02OQ01.lean` (0 errors).

## Files

- `proofs/Proofs/ChebyshevBoundsOQ02OQ01.lean` (new)
- `proofs/Proofs.lean` (registered import)
- `src/data/proofs/chebyshev-bounds-oq-02-oq-01/meta.json` (new gallery entry)
- `src/data/research/problems/chebyshev-bounds-oq-02-oq-01.json` (new)