### PR TITLE
research(burnside-counting-oq-04-oq-02): general-n dihedral bracelet machinery + Burnside identity

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -484,6 +484,7 @@ import Proofs.BurnsideCountingOQ03Aristotle
 import Proofs.BurnsideCountingOQ03OQ03
 import Proofs.BurnsideCountingOQ04
 import Proofs.BurnsideCountingOQ04OQ01
+import Proofs.BurnsideCountingOQ04OQ02
 import Proofs.BurnsideCountingOQ05
 import Proofs.CantorDiagonalization
 import Proofs.CantorDiagonalizationOQ01

--- a/proofs/Proofs/BurnsideCountingOQ04OQ02.lean
+++ b/proofs/Proofs/BurnsideCountingOQ04OQ02.lean
@@ -1,0 +1,219 @@
+import Mathlib
+
+/-
+# Burnside Counting, OQ-04 → OQ-02: the general-`n` dihedral bracelet machinery
+
+## What this file provides
+
+The sibling entry `burnside-counting-oq-04-oq-01` (`BurnsideCountingOQ04OQ01.lean`) builds the
+concrete dihedral action of `D₄` on the `16` binary colourings of the `4`-cycle and reads off
+the unconditional bracelet count `|bracelets(4,2)| = 6`.  Its construction is, however,
+hard-wired to `n = 4`: the permutation representation, the `MulAction`, the decidability
+instances, and the Burnside step are all stated for `DihedralGroup 4`.
+
+This file **generalises that machinery to every `n`**.  For arbitrary `n` (with `NeZero n`) we
+build
+
+* the faithful permutation representation `ρ : DihedralGroup n →* Equiv.Perm (ZMod n)`,
+  `r i ↦ (x ↦ x + i)`, `sr i ↦ (x ↦ -i - x)`;
+* the induced left `MulAction` of `DihedralGroup n` on `Coloring n = ZMod n → Fin 2`;
+* the decidability / `Fintype` infrastructure that makes the orbit count (the *bracelet number*
+  `b(n)`) a well-defined natural number;
+
+and we prove, **for every `n`**, the Burnside bracelet identity
+
+      ∑_{g ∈ Dₙ} |Fix(g)|  =  b(n) · (2n)            (`bracelet_burnside`)
+
+(`2n = |Dₙ|`).  This is the orbit-counting engine behind the closed form
+`b(n) = (necklaces(n) + reflection-total(n)) / (2n)`: each fixed-point total
+`∑_{rotations} |Fix|` and `∑_{reflections} |Fix|` is one half of the right-hand sum.
+
+As concrete corollaries we discharge the general identity at several lengths by *kernel*
+`decide` on the fixed-point sum (no `native_decide`, so no `Lean.ofReduceBool`):
+
+      b(3) = 4,   b(5) = 8                          (OEIS A000029)
+
+matching the binary-bracelet sequence `2, 3, 4, 6, 8, 13, …`.  The sibling already records
+`b(4) = 6`; these add the next available lengths from the *general* construction rather than a
+length-specific one.
+
+## Honesty / scope
+
+The genuinely new content here is the **uniform-in-`n`** construction and Burnside identity
+(the sibling only had `n = 4`).  Burnside's lemma itself is Mathlib's
+(`MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`); `|Dₙ| = 2n` is
+`DihedralGroup.card`.  The fully *closed* form — evaluating `∑_{rotations} |Fix(r i)|` as the
+gcd-cycle sum `∑_i 2^{gcd(n,i)}` and `∑_{reflections} |Fix(sr i)|` by the parity of `n` — is
+left as documented follow-up; this file supplies the structural identity those evaluations plug
+into.  `#print axioms` on the headlines confirms only `propext, Classical.choice, Quot.sound`.
+-/
+
+namespace BurnsideCountingOQ04OQ02
+
+open Finset MulAction
+
+variable (n : ℕ)
+
+/-! ## Part I: positions, colourings, and the dihedral permutation representation -/
+
+/-- The `n` vertices of the regular `n`-gon, as `ZMod n` so that rotation is `+ i`. -/
+abbrev Pos : Type := ZMod n
+
+/-- A binary colouring of the `n` vertices. There are `2^n` of them. -/
+abbrev Coloring : Type := Pos n → Fin 2
+
+variable {n}
+
+/-- The faithful permutation representation of `DihedralGroup n` on the `n` vertices:
+rotations `r i` act by `x ↦ x + i`, reflections `sr i` act by `x ↦ -i - x`. The reflection
+form `-i - x` (rather than `i - x`) is what makes the assignment a *homomorphism* for Mathlib's
+dihedral multiplication convention `sr i * sr j = r (j - i)`. -/
+def posPerm : DihedralGroup n → Equiv.Perm (Pos n)
+  | .r i => Equiv.addRight i
+  | .sr i => Equiv.subLeft (-i)
+
+@[simp] theorem posPerm_r (i : ZMod n) : posPerm (.r i) = Equiv.addRight i := rfl
+@[simp] theorem posPerm_sr (i : ZMod n) : posPerm (.sr i) = Equiv.subLeft (-i) := rfl
+
+/-- `posPerm` sends the identity to the identity permutation. -/
+theorem posPerm_one : posPerm (1 : DihedralGroup n) = 1 := by
+  ext x
+  show (Equiv.addRight (0 : ZMod n)) x = x
+  simp
+
+/-- **`posPerm` is multiplicative.** Checked case-by-case against Mathlib's dihedral
+multiplication table; every case reduces to a `ZMod n` arithmetic identity after `ext`. -/
+theorem posPerm_mul (g h : DihedralGroup n) :
+    posPerm (g * h) = posPerm g * posPerm h := by
+  cases g with
+  | r i =>
+    cases h with
+    | r j => ext x; simp [DihedralGroup.r_mul_r, add_comm, add_left_comm]
+    | sr j => ext x; simp [DihedralGroup.r_mul_sr]; ring
+  | sr i =>
+    cases h with
+    | r j => ext x; simp [DihedralGroup.sr_mul_r]; ring
+    | sr j => ext x; simp [DihedralGroup.sr_mul_sr]; ring
+
+/-- The bundled homomorphism `ρ : DihedralGroup n →* Equiv.Perm (ZMod n)`. -/
+def ρ : DihedralGroup n →* Equiv.Perm (Pos n) where
+  toFun := posPerm
+  map_one' := posPerm_one
+  map_mul' := posPerm_mul
+
+/-! ## Part II: the induced action on colourings -/
+
+/-- The dihedral action on colourings: a symmetry `g` relabels positions by `ρ g`, sending the
+colouring `c` to `p ↦ c ((ρ g)⁻¹ p)`.  This is a genuine left `MulAction` because `ρ` is a
+homomorphism. -/
+instance : MulAction (DihedralGroup n) (Coloring n) where
+  smul g c := fun p => c ((ρ g).symm p)
+  one_smul c := by
+    funext p; show c ((ρ 1).symm p) = c p; rw [ρ.map_one]; rfl
+  mul_smul g h c := by
+    funext p
+    show c ((ρ (g * h)).symm p) = c ((ρ h).symm ((ρ g).symm p))
+    rw [ρ.map_mul]
+    rfl
+
+/-- Unfold the action pointwise (handy for the fixed-point computations). -/
+theorem smul_apply (g : DihedralGroup n) (c : Coloring n) (p : Pos n) :
+    (g • c) p = c ((ρ g).symm p) := rfl
+
+/-! ## Part III: Fintype instances for Burnside's lemma -/
+
+variable [NeZero n]
+
+instance decFixed (g : DihedralGroup n) :
+    DecidablePred (fun c : Coloring n => g • c = c) := fun c => decEq (g • c) c
+
+instance fintypeFixedBy (g : DihedralGroup n) : Fintype (fixedBy (Coloring n) g) :=
+  Subtype.fintype _
+
+/-- The orbit relation of the dihedral action is decidable: two colourings lie in the same
+orbit iff `∃ g, g • b = a`, decidable because `DihedralGroup n` is a `Fintype` and colourings
+have decidable equality. -/
+instance : DecidableRel (orbitRel (DihedralGroup n) (Coloring n)).r := fun a b =>
+  decidable_of_iff (∃ g : DihedralGroup n, g • b = a) MulAction.mem_orbit_iff.symm
+
+/-- The quotient of colourings by the dihedral action is a `Fintype`, so its cardinality — the
+bracelet count `b(n)` — is well-defined. -/
+noncomputable instance : Fintype (orbitRel.Quotient (DihedralGroup n) (Coloring n)) := by
+  letI s : Setoid (Coloring n) := orbitRel (DihedralGroup n) (Coloring n)
+  haveI : DecidableRel (α := Coloring n) (· ≈ ·) := fun a b =>
+    decidable_of_iff (∃ g : DihedralGroup n, g • b = a) MulAction.mem_orbit_iff.symm
+  exact Quotient.fintype _
+
+variable (n) in
+/-- The **bracelet number** `b(n)`: the number of binary colourings of the `n`-cycle up to the
+full dihedral symmetry group (rotations and reflections). -/
+noncomputable def braceletCard : ℕ :=
+  Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n))
+
+/-! ## Part IV: the general Burnside bracelet identity -/
+
+variable (n) in
+/-- **The general-`n` Burnside bracelet identity.**  For every `n`,
+
+      ∑_{g ∈ Dₙ} |Fix(g)|  =  b(n) · (2n).
+
+This is Burnside's lemma `sum_card_fixedBy_eq_card_orbits_mul_card_group` for the dihedral
+action built above, with `|Dₙ| = 2n` substituted via `DihedralGroup.card`.  It is the orbit-
+counting engine for the closed form `b(n) = (necklaces(n) + reflection-total(n))/(2n)`: the
+rotation part of the left sum is `necklaces(n)·n`-worth of fixed points and the reflection part
+is `reflection-total(n)`. -/
+theorem bracelet_burnside :
+    ∑ g : DihedralGroup n, Fintype.card (fixedBy (Coloring n) g) = braceletCard n * (2 * n) := by
+  have hburnside :
+      ∑ g : DihedralGroup n, Fintype.card (fixedBy (Coloring n) g)
+        = Fintype.card (orbitRel.Quotient (DihedralGroup n) (Coloring n))
+            * Fintype.card (DihedralGroup n) :=
+    MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (DihedralGroup n) (Coloring n)
+  rw [hburnside, DihedralGroup.card, braceletCard]
+
+/-! ## Part V: concrete bracelet counts from the general machinery
+
+We feed small `n` into the *general* identity.  The single computation in each case is the
+fixed-point sum, discharged by *kernel* `decide`; Burnside then pins down `b(n)`. -/
+
+/-- The Burnside fixed-point sum at `n = 3` is `24` (`8 + 2 + 2` rotations, `4·3` reflections),
+by kernel `decide`. -/
+theorem fixed_point_sum_three :
+    ∑ g : DihedralGroup 3, Fintype.card (fixedBy (Coloring 3) g) = 24 := by decide
+
+/-- **There are exactly `4` binary bracelets of length `3`**, from the general construction. -/
+theorem bracelet_three : braceletCard 3 = 4 := by
+  have h := bracelet_burnside 3
+  rw [fixed_point_sum_three] at h
+  omega
+
+/-- The Burnside fixed-point sum at `n = 5` is `80`, by kernel `decide`. -/
+theorem fixed_point_sum_five :
+    ∑ g : DihedralGroup 5, Fintype.card (fixedBy (Coloring 5) g) = 80 := by decide
+
+/-- **There are exactly `8` binary bracelets of length `5`**, from the general construction. -/
+theorem bracelet_five : braceletCard 5 = 8 := by
+  have h := bracelet_burnside 5
+  rw [fixed_point_sum_five] at h
+  omega
+
+/-- The Burnside fixed-point sum at `n = 6` is `156` (rotations `64+2+4+8+4+2 = 84`,
+reflections `16·3 + 8·3 = 72`), by kernel `decide`.  This is the largest length at which the
+kernel computation stays comfortably feasible. -/
+theorem fixed_point_sum_six :
+    ∑ g : DihedralGroup 6, Fintype.card (fixedBy (Coloring 6) g) = 156 := by decide
+
+/-- **There are exactly `13` binary bracelets of length `6`**, from the general construction. -/
+theorem bracelet_six : braceletCard 6 = 13 := by
+  have h := bracelet_burnside 6
+  rw [fixed_point_sum_six] at h
+  omega
+
+end BurnsideCountingOQ04OQ02
+
+-- Axiom audit: only the standard foundational axioms — no `Lean.ofReduceBool`
+-- (no `native_decide`) and no `sorryAx`.
+#print axioms BurnsideCountingOQ04OQ02.bracelet_burnside
+#print axioms BurnsideCountingOQ04OQ02.bracelet_three
+#print axioms BurnsideCountingOQ04OQ02.bracelet_five
+#print axioms BurnsideCountingOQ04OQ02.bracelet_six

--- a/src/data/proofs/burnside-counting-oq-04-oq-02/meta.json
+++ b/src/data/proofs/burnside-counting-oq-04-oq-02/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "burnside-counting-oq-04-oq-02",
+  "title": "The General-n Dihedral Bracelet Machinery and its Burnside Identity",
+  "slug": "burnside-counting-oq-04-oq-02",
+  "description": "Generalises the concrete length-4 dihedral construction of the sibling burnside-counting-oq-04-oq-01 from D₄ to D_n for every n (with NeZero n). For arbitrary n we build the faithful permutation representation ρ : DihedralGroup n →* Equiv.Perm (ZMod n) sending r i to (x ↦ x + i) and sr i to (x ↦ -i - x) — the reflection form -i-x (not i-x) is exactly what makes ρ a homomorphism for Mathlib's dihedral convention sr i * sr j = r (j - i) — and lift it to the binary colourings Coloring n = ZMod n → Fin 2 by (g • c) p = c ((ρ g)⁻¹ p), a genuine MulAction because ρ is a hom. We then prove, uniformly in n, the Burnside bracelet identity Σ_{g ∈ Dₙ} |Fix(g)| = b(n)·(2n), where b(n) = braceletCard n is the orbit count and 2n = |Dₙ| = DihedralGroup.card. This is the orbit-counting engine the closed form b(n) = (necklaces(n) + reflection-total(n))/(2n) plugs into: the rotation part of the left sum is the necklace contribution and the reflection part is the reflection total. As corollaries we feed the GENERAL identity small lengths and discharge the single fixed-point sum by KERNEL decide (no native_decide), recovering b(3) = 4 (sum 24), b(5) = 8 (sum 80), and b(6) = 13 (sum 156, rotations 64+2+4+8+4+2 = 84, reflections 16·3 + 8·3 = 72) — the next binary-bracelet values (OEIS A000029) after the sibling's b(4) = 6, now from a single n-uniform construction rather than a length-specific one. This directly answers the first open question recorded in the sibling oq-04-oq-01. #print axioms on every headline confirms only propext / Classical.choice / Quot.sound — no Lean.ofReduceBool (no native_decide) and no sorryAx.",
+  "meta": {
+    "author": "Burnside / Pólya theory; formalized for lean-genius (researcher-2)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BurnsideCountingOQ04OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "group-action",
+      "burnside",
+      "dihedral-group",
+      "bracelets",
+      "necklaces",
+      "orbit-counting",
+      "kernel-decide",
+      "native-decide-free"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group",
+        "description": "Burnside's lemma: Σ_{g∈G} |Fix(g)| = |X/G|·|G|. Instantiated at the general dihedral colouring action to give the n-uniform identity Σ_{g∈Dₙ} |Fix(g)| = b(n)·(2n).",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "DihedralGroup.r_mul_r / r_mul_sr / sr_mul_r / sr_mul_sr",
+        "description": "The dihedral multiplication table (general n), against which posPerm_mul (the homomorphism property of ρ) is verified case by case.",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Dihedral"
+      },
+      {
+        "theorem": "DihedralGroup.card",
+        "description": "|DihedralGroup n| = 2n, substituted into Burnside to obtain b(n)·(2n).",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Dihedral"
+      },
+      {
+        "theorem": "Equiv.addRight / Equiv.subLeft",
+        "description": "The concrete permutations of ZMod n realising rotations (x ↦ x + i) and reflections (x ↦ -i - x); their kernel-reducible application lets decide evaluate the fixed-point counts at small n.",
+        "module": "Mathlib.Algebra.Group.Equiv.Basic"
+      },
+      {
+        "theorem": "Quotient.fintype",
+        "description": "Builds the Fintype on the orbit quotient from the finite colouring carrier and the decidable orbit relation, so the bracelet count braceletCard n = Fintype.card is well-defined.",
+        "module": "Mathlib.Data.Fintype.Quotient"
+      }
+    ],
+    "originalContributions": [
+      "posPerm / ρ generalised to all n: the faithful representation DihedralGroup n →* Equiv.Perm (ZMod n), r i ↦ (x ↦ x+i), sr i ↦ (x ↦ -i-x), with posPerm_mul proved case-by-case against the general dihedral multiplication table — the sibling oq-04-oq-01 had this only for n = 4",
+      "the induced MulAction (DihedralGroup n) (ZMod n → Fin 2) for arbitrary n, lifting the position permutation to colourings by (g • c) p = c ((ρ g)⁻¹ p), with one_smul / mul_smul discharged from ρ being a hom",
+      "bracelet_burnside: the n-uniform Burnside bracelet identity Σ_{g ∈ Dₙ} |Fix(g)| = braceletCard n · (2n) — the reusable orbit-counting engine for the closed-form bracelet numbers, valid for every n (the sibling proved only the single instance n = 4)",
+      "bracelet_three / bracelet_five / bracelet_six: b(3) = 4, b(5) = 8, b(6) = 13 obtained by feeding the GENERAL identity to small n and discharging the fixed-point sum (24 / 80 / 156) by KERNEL decide, with 0 axioms beyond propext / Classical.choice / Quot.sound — answering the sibling's open question of recovering b(5), b(6) from the general construction and charting kernel-decide feasibility (comfortable through n = 6)"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified, 0 axioms, 0 sorries, and no native_decide: the fixed-point sums are discharged by kernel decide, so every headline depends only on the standard foundational axioms propext, Classical.choice, Quot.sound (confirmed via #print axioms — in particular no Lean.ofReduceBool and no sorryAx).",
+    "lineCount": 219,
+    "theoremCount": 12,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Burnside's lemma counts the orbits of a finite group action as the average number of fixed points. For the cyclic rotation group ℤ/nℤ acting on the beads of an n-cycle it yields the necklace numbers; adjoining the n reflections gives the dihedral group D_n and the bracelet numbers (OEIS A000029: 2, 3, 4, 6, 8, 13, 18, 30, …). The parent burnside-counting-oq-04 proves the abstract index-2 folding identity but recovers the length-4 bracelet count only conditionally; the sibling oq-04-oq-01 builds a concrete D₄ action and makes that count unconditional, but hard-wired to n = 4. Its own first open question asks to generalise the construction to D_n and recover b(5), b(6) — which this entry does.",
+    "problemStatement": "Build the concrete dihedral action and Burnside orbit-counting identity uniformly in n (not just n = 4), and use the general identity to recover the next binary-bracelet numbers b(3) = 4, b(5) = 8, b(6) = 13 by axiom-free kernel computation — the structural step toward the closed form b(n) = (necklaces(n) + reflection-total(n))/(2n).",
+    "text": "With ρ : DihedralGroup n →* Equiv.Perm (ZMod n) the faithful representation r i ↦ (·+i), sr i ↦ (-i-·) and the colouring action (g • c) p = c ((ρ g)⁻¹ p), Burnside gives Σ_{g ∈ Dₙ} |Fix(g)| = b(n)·(2n) for every n. Evaluating the fixed-point sum by kernel decide at n = 3, 5, 6 yields 24, 80, 156, hence b(3) = 4, b(5) = 8, b(6) = 13.",
+    "proofStrategy": "Define posPerm n : DihedralGroup n → Equiv.Perm (ZMod n) with rotations acting by x ↦ x + i and reflections by x ↦ -i - x; the reflection form -i-x is dictated by Mathlib's convention sr i * sr j = r (j - i), and posPerm_mul checks the homomorphism property in all four (r/sr)×(r/sr) cases by ext + ZMod arithmetic — none of this needs NeZero n, so the representation is built before that hypothesis is introduced. Bundle it as ρ : DihedralGroup n →* Equiv.Perm (ZMod n) and lift to colourings via (g • c) p = c ((ρ g)⁻¹ p); one_smul and mul_smul follow from ρ.map_one and ρ.map_mul. Under NeZero n, register DecidablePred / Fintype instances for the fixed-point sets and a decidable orbit relation for the quotient Fintype, so braceletCard n is well-defined. Apply Burnside's lemma and rewrite |Dₙ| = 2n (DihedralGroup.card) to obtain the n-uniform identity bracelet_burnside. For each concrete length, evaluate the fixed-point sum by kernel decide (cheap: 2n symmetries × 2ⁿ colourings) and finish with omega; the orbit quotient itself is never enumerated, which keeps the computation within kernel reach through n = 6.",
+    "keyInsights": [
+      "The construction is genuinely n-uniform: the homomorphism property posPerm_mul and the MulAction laws hold for every n by ext + ZMod arithmetic against the dihedral multiplication table, so nothing about it is special to n = 4",
+      "The reflection must act as x ↦ -i - x, not the geometrically tempting x ↦ i - x: only the former is a homomorphism for Mathlib's convention sr i * sr j = r (j - i)",
+      "NeZero n is needed only from the Fintype layer onward (DihedralGroup n a Fintype, ZMod n a Fintype); the permutation representation and MulAction are built without it, keeping the scoping clean",
+      "Burnside lets one avoid enumerating the orbit quotient (the expensive step): only the fixed-point sum needs evaluation, light enough for kernel decide at n = 3, 5, 6 (sums 24, 80, 156) — beyond which kernel decide over 2n·2ⁿ Fin-data checks becomes the practical ceiling",
+      "bracelet_burnside is the reusable engine for the closed form: once Σ_{rotations} |Fix(r i)| is evaluated as Σ_i 2^{gcd(n,i)} and Σ_{reflections} |Fix(sr i)| by the parity of n, the closed form b(n) = (necklaces(n) + reflection-total(n))/(2n) follows by dividing this identity by 2n"
+    ],
+    "prerequisites": [
+      "Group actions, orbits, and the orbit-counting (Burnside/Cauchy–Frobenius) lemma",
+      "The dihedral group DihedralGroup n and its multiplication table",
+      "Decidable equality and Fintype enumeration for kernel decide"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Burnside, W.",
+      "title": "Theory of Groups of Finite Order",
+      "year": "1897",
+      "note": "The orbit-counting (Cauchy–Frobenius) lemma underlying necklace and bracelet enumeration"
+    },
+    {
+      "authors": "Pólya, G.",
+      "title": "Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen",
+      "year": "1937",
+      "note": "Enumeration under group actions; dihedral bracelet counts (OEIS A000029)"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "burnside-counting-oq-04-oq-01",
+      "relationship": "extends",
+      "description": "Generalises the sibling's concrete D₄ action and kernel-decided fixed-point sum to D_n for all n, and answers its first open question by recovering b(3) = 4, b(5) = 8, b(6) = 13 from the general construction."
+    },
+    {
+      "targetId": "burnside-counting-oq-04",
+      "relationship": "extends",
+      "description": "Supplies the n-uniform Burnside bracelet identity that the parent's conditional binary_four_bracelet_count only instantiated at n = 4."
+    }
+  ],
+  "conclusion": {
+    "summary": "Generalising the concrete dihedral action ρ : DihedralGroup n →* Equiv.Perm (ZMod n) to every n and lifting it to binary colourings yields the n-uniform Burnside bracelet identity Σ_{g ∈ Dₙ} |Fix(g)| = b(n)·(2n). Feeding the general identity small lengths and evaluating the fixed-point sum by kernel decide gives b(3) = 4, b(5) = 8, b(6) = 13 — axiom-free, no native_decide — directly answering the sibling oq-04-oq-01's first open question.",
+    "implications": "Provides the reusable orbit-counting engine for the binary bracelet numbers: any closed form b(n) = (necklaces(n) + reflection-total(n))/(2n) is obtained by evaluating the rotation and reflection halves of this identity's left-hand sum. The kernel-decide instances also chart where axiom-free per-n computation remains feasible (through n = 6).",
+    "openQuestions": [
+      "Evaluate the rotation half Σ_{i} |Fix(r i)| of bracelet_burnside as the gcd-cycle sum Σ_{i=0}^{n-1} 2^{gcd(n, i.val)} by proving |Fix(r i)| = 2^{gcd(n, i.val)} (a rotation by i has gcd(n,i) orbits, on each of which a fixed colouring is constant).",
+      "Evaluate the reflection half Σ_{i} |Fix(sr i)| by the parity of n (for odd n every reflection fixes 2^{(n+1)/2} colourings; for even n the two reflection classes fix 2^{n/2+1} and 2^{n/2}), and combine with the rotation half to prove the full closed form b(n) = (necklaces(n) + reflection-total(n))/(2n) without per-n computation."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "MulAction"
+    ],
+    "namespace": "BurnsideCountingOQ04OQ02",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 3,
+    "path": "Proofs/BurnsideCountingOQ04OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Generalises the concrete length-4 dihedral construction of the sibling **burnside-counting-oq-04-oq-01** (which was hard-wired to `D₄`) to **`D_n` for every `n`** (with `NeZero n`), and proves the orbit-counting identity uniformly in `n`.

This directly answers the **first open question recorded in oq-04-oq-01**:
> "Generalise the concrete action and kernel-decided fixed-point sum to `D_n` for small `n` (e.g. `n = 5, 6`), recovering `b(5) = 8` and `b(6) = 13` unconditionally, and chart where kernel decide stops being feasible."

## What it proves (`Proofs/BurnsideCountingOQ04OQ02.lean`)

- `ρ : DihedralGroup n →* Equiv.Perm (ZMod n)`, `r i ↦ (x ↦ x+i)`, `sr i ↦ (x ↦ -i-x)` — the reflection form `-i-x` (not `i-x`) is exactly what makes `ρ` a homomorphism for Mathlib's convention `sr i * sr j = r (j-i)`; `posPerm_mul` checks all four cases.
- the induced `MulAction (DihedralGroup n) (ZMod n → Fin 2)`, `(g • c) p = c ((ρ g)⁻¹ p)`.
- **`bracelet_burnside`** — the `n`-uniform Burnside bracelet identity `Σ_{g∈Dₙ} |Fix(g)| = braceletCard n · (2n)` (`2n = |Dₙ|`). This is the reusable engine the closed form `b(n) = (necklaces(n) + reflection-total(n))/(2n)` plugs into.
- **`b(3)=4`, `b(5)=8`, `b(6)=13`** obtained by feeding the *general* identity small lengths and discharging the fixed-point sum (`24 / 80 / 156`) by **kernel `decide`** (no `native_decide`). These are the next binary-bracelet values (OEIS A000029) after the sibling's `b(4)=6`.

## Verification

- 12 theorems / 3 defs, **0 sorries, 0 axioms**.
- Kernel-verified with `lake env lean` on Mathlib v4.26.0.
- `#print axioms` on every headline (`bracelet_burnside`, `bracelet_three/five/six`) = `[propext, Classical.choice, Quot.sound]` — no `Lean.ofReduceBool` (no `native_decide`), no `sorryAx`.

## Scope / follow-up

This supplies the structural identity; the *fully closed* form (evaluating the rotation half as `Σ_i 2^{gcd(n,i)}` and the reflection half by the parity of `n`) is documented as the entry's open questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)