### PR TITLE
research(divisibility-rules-oq-01-oq-02): universal power-of-10 divisibility rule for every modulus coprime to 10

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -913,6 +913,7 @@ import Proofs.DivisibilityByThreeOQ02
 import Proofs.DivisibilityByThreeOQ02OQ01
 import Proofs.DivisibilityRules
 import Proofs.DivisibilityRulesOQ01
+import Proofs.DivisibilityRulesOQ01OQ02
 import Proofs.DivisibilityRulesOQ01OQ01
 import Proofs.DivisibilityRulesOQ01OQ01OQ01
 import Proofs.DivisibilityRulesOQ02

--- a/proofs/Proofs/DivisibilityRulesOQ01OQ02.lean
+++ b/proofs/Proofs/DivisibilityRulesOQ01OQ02.lean
@@ -1,0 +1,244 @@
+/-
+Universal Digit-Sum / Alternating-Digit-Sum Divisibility Rules (OQ-01-OQ-02 Extension)
+
+Open question (extension of divisibility-rules-oq-01):
+  For every modulus d coprime to 10, exhibit a base B (a power of 10) such that
+  divisibility by d is detected either by the digit sum or by the alternating
+  digit sum of the base-B representation.
+
+Main result: the digit-sum branch ALWAYS succeeds. Concretely, taking
+B = 10^φ(d) (φ = Euler totient) gives 10^φ(d) ≡ 1 (mod d) by the Fermat–Euler
+theorem, so d ∣ n ↔ d ∣ (base-B digit sum of n). This proves the disjunction
+universally via its left branch.
+
+We additionally develop the alternating-digit-sum branch: whenever some power
+10^k ≡ -1 (mod d), divisibility by d is detected by the base-10^k alternating
+digit sum. This is genuinely realizable and often gives a SMALLER base than the
+universal φ(d) bound:
+  • d = 7  : 10^3 ≡ -1 (mod 7)  → alternating sum of three-digit groups
+  • d = 11 : 10   ≡ -1 (mod 11) → ordinary alternating digit sum
+  • d = 13 : 10^3 ≡ -1 (mod 13) → alternating sum of three-digit groups
+
+Tags: number-theory, modular-arithmetic, divisibility, euler-totient, extension
+-/
+
+import Mathlib.Data.Nat.Digits.Defs
+import Mathlib.Data.Nat.Digits.Lemmas
+import Mathlib.NumberTheory.PowModTotient
+import Mathlib.Tactic
+
+open Nat
+
+namespace DivisibilityRulesOQ01OQ02
+
+/-
+## Part I: The universal digit-sum rule
+
+For any modulus d > 1 coprime to 10, Euler's theorem gives 10^φ(d) ≡ 1 (mod d).
+With base B = 10^φ(d) we then have B ≡ 1 (mod d), and Mathlib's
+`Nat.modEq_digits_sum` reduces divisibility by d to divisibility of the base-B
+digit sum.
+-/
+
+/-- If the base `B` satisfies `B ≡ 1 (mod d)`, then `d ∣ n ↔ d ∣ (digit sum of n in base B)`.
+    This packages `Nat.modEq_digits_sum` into an `iff` on divisibility. -/
+theorem dvd_iff_dvd_digitSum (d B : ℕ) (hB : B % d = 1) (n : ℕ) :
+    d ∣ n ↔ d ∣ (Nat.digits B n).sum :=
+  Nat.ModEq.dvd_iff (Nat.modEq_digits_sum d B hB n) (dvd_refl d)
+
+/-- **Universal digit-sum divisibility rule.** For every modulus `d > 1` coprime
+    to `10`, the base `B = 10^φ(d)` is a power of `10` exceeding `1` and satisfies
+    `B % d = 1`, so divisibility by `d` is detected by the base-`B` digit sum.
+
+    This is the existence statement that the open question asks for, with the
+    explicit witness `k = φ(d)` coming from the Fermat–Euler theorem. -/
+theorem exists_base_digitSum_rule (d : ℕ) (hd : 1 < d) (hcop : Nat.Coprime 10 d) :
+    ∃ k : ℕ, 0 < k ∧ 1 < 10 ^ k ∧ (10 ^ k) % d = 1 ∧
+      ∀ n : ℕ, d ∣ n ↔ d ∣ (Nat.digits (10 ^ k) n).sum := by
+  have hφ : 0 < Nat.totient d := Nat.totient_pos.mpr (by omega)
+  have hmod : (10 ^ Nat.totient d) % d = 1 := Nat.pow_totient_mod_eq_one hd hcop
+  refine ⟨Nat.totient d, hφ, ?_, hmod, fun n => dvd_iff_dvd_digitSum d _ hmod n⟩
+  have h10 : (10 : ℕ) ^ 1 ≤ 10 ^ Nat.totient d := Nat.pow_le_pow_right (by norm_num) hφ
+  simp only [pow_one] at h10
+  omega
+
+/-
+## Part II: Alternating-digit-sum infrastructure
+
+When the base `b` satisfies `b ≡ -1 (mod d)`, the powers of `b` alternate sign
+modulo `d`, so `ofDigits b l ≡ (alternating sum of l) (mod d)`. We rebuild the
+small amount of machinery needed (self-contained, mirroring the OQ-01 parent).
+-/
+
+/-- Alternating sum of a list of digits, as an integer:
+    `[d₀, d₁, d₂, …] ↦ d₀ - d₁ + d₂ - d₃ + ⋯`. -/
+def alternatingDigitSum : List ℕ → ℤ
+  | [] => 0
+  | [d] => (d : ℤ)
+  | d₀ :: d₁ :: rest => (d₀ : ℤ) - (d₁ : ℤ) + alternatingDigitSum rest
+
+/-- Alternating digit sum of `n` written in base `b`. -/
+def altDigitSum (b n : ℕ) : ℤ := alternatingDigitSum (Nat.digits b n)
+
+/-- Cons recursion: `alternatingDigitSum (a :: rest) = a - alternatingDigitSum rest`. -/
+theorem alternatingDigitSum_cons (a : ℕ) (rest : List ℕ) :
+    alternatingDigitSum (a :: rest) = (a : ℤ) - alternatingDigitSum rest := by
+  induction rest generalizing a with
+  | nil => simp [alternatingDigitSum]
+  | cons b rest' ih =>
+    show (a : ℤ) - (b : ℤ) + alternatingDigitSum rest'
+        = (a : ℤ) - alternatingDigitSum (b :: rest')
+    rw [ih b]
+    ring
+
+/-- When `b ≡ -1 (mod d)`, `ofDigits b l ≡ alternatingDigitSum l (mod d)`. -/
+theorem ofDigits_modEq_alternatingDigitSum (d : ℕ) (hd : 0 < d)
+    (b : ℕ) (hb : b % d = d - 1) (l : List ℕ) :
+    ((Nat.ofDigits b l : ℕ) : ℤ) ≡ alternatingDigitSum l [ZMOD (d : ℤ)] := by
+  induction l with
+  | nil => simp [Nat.ofDigits, alternatingDigitSum, Int.ModEq]
+  | cons a rest ih =>
+    rw [alternatingDigitSum_cons, Nat.ofDigits_cons, Nat.cast_add, Nat.cast_mul]
+    have hb_neg : (b : ℤ) ≡ -1 [ZMOD (d : ℤ)] := by
+      -- from `b % d = d - 1` we get `d ∣ (b + 1)`, hence `b ≡ -1 (mod d)`
+      have hdm := Nat.div_add_mod b d       -- `d * (b / d) + b % d = b`
+      have hdvd : d ∣ (b + 1) := ⟨b / d + 1, by rw [Nat.mul_add, Nat.mul_one]; omega⟩
+      rw [Int.modEq_iff_dvd]
+      have hcast : (d : ℤ) ∣ ((b : ℤ) + 1) := by exact_mod_cast hdvd
+      have hrw : (-1 - (b : ℤ)) = -((b : ℤ) + 1) := by ring
+      rw [hrw]
+      exact dvd_neg.mpr hcast
+    calc (↑a + ↑b * (↑(Nat.ofDigits b rest) : ℤ))
+        ≡ ↑a + (-1) * alternatingDigitSum rest [ZMOD (d : ℤ)] :=
+          Int.ModEq.add (Int.ModEq.refl _) (Int.ModEq.mul hb_neg ih)
+      _ = ↑a - alternatingDigitSum rest := by ring
+
+/-- When `b ≡ -1 (mod d)`, `n ≡ altDigitSum b n (mod d)`. -/
+theorem modEq_altDigitSum (d b n : ℕ) (hd : 0 < d) (hb : b % d = d - 1) :
+    (n : ℤ) ≡ altDigitSum b n [ZMOD (d : ℤ)] := by
+  unfold altDigitSum
+  conv_lhs => rw [← Nat.ofDigits_digits b n]
+  exact_mod_cast ofDigits_modEq_alternatingDigitSum d hd b hb (Nat.digits b n)
+
+/-- If `b ≡ -1 (mod d)`, then `d ∣ n ↔ d ∣ (base-b alternating digit sum of n)`
+    (divisibility over `ℤ`, since the alternating sum may be negative). -/
+theorem dvd_iff_dvd_altDigitSum (d b n : ℕ) (hd : 0 < d) (hb : b % d = d - 1) :
+    d ∣ n ↔ (d : ℤ) ∣ altDigitSum b n := by
+  have hdvd : (d : ℤ) ∣ (altDigitSum b n - (n : ℤ)) :=
+    Int.modEq_iff_dvd.mp (modEq_altDigitSum d b n hd hb)
+  constructor
+  · intro hn
+    have hn' : (d : ℤ) ∣ (n : ℤ) := Int.natCast_dvd_natCast.mpr hn
+    have hrw : altDigitSum b n = (n : ℤ) + (altDigitSum b n - (n : ℤ)) := by ring
+    rw [hrw]; exact dvd_add hn' hdvd
+  · intro ha
+    have hrw : (n : ℤ) = altDigitSum b n - (altDigitSum b n - (n : ℤ)) := by ring
+    have hn' : (d : ℤ) ∣ (n : ℤ) := by rw [hrw]; exact dvd_sub ha hdvd
+    exact_mod_cast hn'
+
+/-
+## Part III: The alternating-sum branch is realizable
+
+Whenever some power `10^k ≡ -1 (mod d)`, divisibility by `d` is detected by the
+base-`10^k` alternating digit sum.
+-/
+
+/-- **Alternating-sum divisibility rule from a sign-reversing power.** If
+    `10^k ≡ -1 (mod d)` (i.e. `(10^k) % d = d - 1`) with `d > 1`, then the base
+    `10^k` detects divisibility by `d` through its alternating digit sum. -/
+theorem exists_base_altDigitSum_rule (d k : ℕ) (hd : 1 < d)
+    (hk : (10 ^ k) % d = d - 1) :
+    ∀ n : ℕ, d ∣ n ↔ (d : ℤ) ∣ altDigitSum (10 ^ k) n :=
+  fun n => dvd_iff_dvd_altDigitSum d (10 ^ k) n (by omega) hk
+
+/-
+## Part IV: The headline — every d coprime to 10 has a power-of-10 rule
+
+The disjunction the open question asks for, proved universally through the
+always-available digit-sum branch.
+-/
+
+/-- **Universal divisibility-rule existence.** For every modulus `d > 1` coprime
+    to `10`, there is a power `B = 10^k` of `10` (with `k ≥ 1`) such that
+    divisibility by `d` is detected either by the base-`B` digit sum **or** by
+    the base-`B` alternating digit sum.
+
+    The digit-sum branch always applies (take `k = φ(d)`); the alternating-sum
+    branch is recorded for moduli admitting a sign-reversing power of `10`. -/
+theorem exists_base_divisibility_rule (d : ℕ) (hd : 1 < d) (hcop : Nat.Coprime 10 d) :
+    ∃ k : ℕ, 0 < k ∧
+      ((∀ n : ℕ, d ∣ n ↔ d ∣ (Nat.digits (10 ^ k) n).sum)
+        ∨ (∀ n : ℕ, d ∣ n ↔ (d : ℤ) ∣ altDigitSum (10 ^ k) n)) := by
+  obtain ⟨k, hk0, _, _, hrule⟩ := exists_base_digitSum_rule d hd hcop
+  exact ⟨k, hk0, Or.inl hrule⟩
+
+/-
+## Part V: Worked instances
+
+Digit-sum branch (10^k ≡ 1):
+  d = 3   : 10  ≡ 1 (mod 3)
+  d = 9   : 10  ≡ 1 (mod 9)
+  d = 37  : 10^3 ≡ 1 (mod 37)
+  d = 101 : 10^4 ≡ 1 (mod 101)
+Alternating-sum branch (10^k ≡ -1):
+  d = 11  : 10   ≡ -1 (mod 11)
+  d = 7   : 10^3 ≡ -1 (mod 7)
+  d = 13  : 10^3 ≡ -1 (mod 13)
+-/
+
+/-- `3 ∣ n ↔ 3 ∣ digitSum₁₀(n)` (base `10^1`). -/
+theorem three_rule (n : ℕ) : 3 ∣ n ↔ 3 ∣ (Nat.digits (10 ^ 1) n).sum :=
+  dvd_iff_dvd_digitSum 3 (10 ^ 1) (by norm_num) n
+
+/-- `9 ∣ n ↔ 9 ∣ digitSum₁₀(n)` (base `10^1`). -/
+theorem nine_rule (n : ℕ) : 9 ∣ n ↔ 9 ∣ (Nat.digits (10 ^ 1) n).sum :=
+  dvd_iff_dvd_digitSum 9 (10 ^ 1) (by norm_num) n
+
+/-- `37 ∣ n ↔ 37 ∣ (sum of three-digit groups)` (base `10^3 = 1000`). -/
+theorem thirtyseven_rule (n : ℕ) : 37 ∣ n ↔ 37 ∣ (Nat.digits (10 ^ 3) n).sum :=
+  dvd_iff_dvd_digitSum 37 (10 ^ 3) (by norm_num) n
+
+/-- `101 ∣ n ↔ 101 ∣ (sum of four-digit groups)` (base `10^4 = 10000`). -/
+theorem onehundredone_rule (n : ℕ) : 101 ∣ n ↔ 101 ∣ (Nat.digits (10 ^ 4) n).sum :=
+  dvd_iff_dvd_digitSum 101 (10 ^ 4) (by norm_num) n
+
+/-- `11 ∣ n ↔ 11 ∣ altDigitSum₁₀(n)` (base `10^1`, since `10 ≡ -1 (mod 11)`). -/
+theorem eleven_rule (n : ℕ) : 11 ∣ n ↔ (11 : ℤ) ∣ altDigitSum (10 ^ 1) n :=
+  exists_base_altDigitSum_rule 11 1 (by norm_num) (by norm_num) n
+
+/-- `7 ∣ n ↔ 7 ∣ (alternating sum of three-digit groups)` (base `10^3`, since
+    `10^3 ≡ -1 (mod 7)`). -/
+theorem seven_rule (n : ℕ) : 7 ∣ n ↔ (7 : ℤ) ∣ altDigitSum (10 ^ 3) n :=
+  exists_base_altDigitSum_rule 7 3 (by norm_num) (by norm_num) n
+
+/-- `13 ∣ n ↔ 13 ∣ (alternating sum of three-digit groups)` (base `10^3`, since
+    `10^3 ≡ -1 (mod 13)`). -/
+theorem thirteen_rule (n : ℕ) : 13 ∣ n ↔ (13 : ℤ) ∣ altDigitSum (10 ^ 3) n :=
+  exists_base_altDigitSum_rule 13 3 (by norm_num) (by norm_num) n
+
+/-
+## Part VI: Kernel-checkable sanity checks
+
+We exercise the alternating-sum function on explicit digit lists (which the
+kernel reduces directly, with no `native_decide`), corresponding to:
+  • 1001 in base 10   = digits [1, 0, 0, 1], alternating sum 1 - 0 + 0 - 1 = 0
+  • 1233 in base 10   = digits [3, 3, 2, 1], alternating sum 3 - 3 + 2 - 1 = 1
+  • 1001 in base 1000 = digits [1, 1],       alternating sum 1 - 1 = 0
+-/
+
+example : alternatingDigitSum [1, 0, 0, 1] = 0 := by decide
+example : alternatingDigitSum [3, 3, 2, 1] = 1 := by decide
+example : alternatingDigitSum [1, 1] = 0 := by decide
+
+-- The divisibility verdicts the rules certify (over ℤ, kernel-checkable):
+example : (11 : ℤ) ∣ alternatingDigitSum [1, 0, 0, 1] := by decide
+example : (7 : ℤ) ∣ alternatingDigitSum [1, 1] := by decide
+example : (13 : ℤ) ∣ alternatingDigitSum [1, 1] := by decide
+example : ¬ (3 : ℤ) ∣ alternatingDigitSum [3, 3, 2, 1] := by decide
+
+#check @exists_base_divisibility_rule
+#check @exists_base_digitSum_rule
+#check @exists_base_altDigitSum_rule
+#check @dvd_iff_dvd_altDigitSum
+
+end DivisibilityRulesOQ01OQ02

--- a/src/data/proofs/divisibility-rules-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-02/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "divisibility-rules-oq-01-oq-02",
+  "title": "Divisibility Rules OQ-01-OQ-02: A Universal Power-of-10 Rule for Every Modulus Coprime to 10",
+  "slug": "divisibility-rules-oq-01-oq-02",
+  "description": "Resolves the second open question of divisibility-rules-oq-01: for every modulus d coprime to 10, there is a power B = 10^k of 10 such that divisibility by d is detected either by the base-B digit sum or by the base-B alternating digit sum. The digit-sum branch is shown to ALWAYS succeed — taking B = 10^φ(d) gives 10^φ(d) ≡ 1 (mod d) by the Fermat–Euler theorem, so d ∣ n ↔ d ∣ (base-B digit sum). The alternating-sum branch is developed as genuinely realizable infrastructure (whenever some 10^k ≡ -1 mod d), often yielding a smaller base than the universal φ(d) bound (e.g. base 1000 for d = 7 and d = 13). All 15 theorems are fully machine-checked with no axioms beyond Lean's standard foundational triple (propext, Classical.choice, Quot.sound) — no sorries, no native_decide, no structure-encoded assumptions.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DivisibilityRulesOQ01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "euler-totient",
+      "extensions"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None beyond Lean's standard foundational axioms. All four headline theorems (exists_base_divisibility_rule, exists_base_digitSum_rule, exists_base_altDigitSum_rule, dvd_iff_dvd_altDigitSum) verify with #print axioms = [propext, Classical.choice, Quot.sound]. Unlike the parent divisibility-rules-oq-01, this file uses NO native_decide: every base-side condition (e.g. 10^3 % 7 = 6) is discharged by norm_num, so the proof does not depend on Lean.ofReduceBool. The sanity-check examples evaluate the alternating-sum function on explicit digit lists, which the kernel reduces directly via `decide`.",
+    "lineCount": 244,
+    "theoremCount": 15,
+    "definitionCount": 2,
+    "originalContributions": [
+      "Universal existence theorem exists_base_divisibility_rule: for every d > 1 coprime to 10, a power of 10 detects divisibility by d via digit sum OR alternating digit sum — the exact open question resolved",
+      "exists_base_digitSum_rule: the digit-sum branch always works, with the explicit witness B = 10^φ(d) supplied by the Fermat–Euler theorem (Nat.pow_totient_mod_eq_one)",
+      "exists_base_altDigitSum_rule: the alternating-sum branch is realizable whenever 10^k ≡ -1 (mod d), often with a smaller base than 10^φ(d)",
+      "Self-contained, native_decide-free alternating-digit-sum framework (dvd_iff_dvd_altDigitSum) re-derived with a generalizing induction and an explicit d ∣ (b+1) construction (omega cannot reason about mod with a variable divisor)",
+      "Worked instances spanning both branches: digit-sum rules for 3, 9, 37, 101; alternating-sum rules for 11 (base 10), 7 and 13 (base 1000, since 10^3 ≡ -1 mod each)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classical schoolbook divisibility rules — casting out nines (3, 9), the alternating sum rule (11), and digit-group sums (37, 101) — are each special cases of a single congruence principle: choosing a base B that is a power of 10 with B ≡ ±1 (mod d). The parent gallery entry divisibility-rules-oq-01 collected many such rules one modulus at a time. The natural theoretical question, posed as its second open problem, is whether EVERY modulus coprime to 10 admits such a rule. The affirmative answer is a direct consequence of Euler's 1763 generalization of Fermat's little theorem: if gcd(a, n) = 1 then a^φ(n) ≡ 1 (mod n). Applied to a = 10, this guarantees a power of 10 congruent to 1 modulo d, hence a digit-sum rule in that base. The refinement to alternating sums (seeking 10^k ≡ -1) recovers the familiar base-10 rule for 11 and the elegant three-digit-block alternating rules for 7 and 13.",
+    "problemStatement": "Prove that for every modulus d coprime to 10, there exists a base B that is a power of 10 such that divisibility by d is detected either by the sum of the base-B digits of n or by the alternating sum of the base-B digits of n. Provide the explicit base, establish the always-available digit-sum branch via the Fermat–Euler theorem, develop the alternating-sum branch as realizable infrastructure, and exhibit concrete instances of both branches.",
+    "proofStrategy": "The digit-sum branch is the engine. Given d > 1 with gcd(10, d) = 1, Euler's theorem (Nat.pow_totient_mod_eq_one) gives (10^φ(d)) % d = 1, so the base B = 10^φ(d) satisfies B ≡ 1 (mod d). Mathlib's Nat.modEq_digits_sum then yields n ≡ (digits B n).sum (mod d), and Nat.ModEq.dvd_iff upgrades this to the iff d ∣ n ↔ d ∣ (digits B n).sum. The headline existence theorem packages this with the witness k = φ(d), and proves the disjunction through its left branch. For the alternating-sum branch, the file re-derives (self-contained) the fact that a base b ≡ -1 (mod d) makes powers of b alternate sign mod d, so ofDigits b l ≡ alternatingDigitSum l (mod d); this is proved by induction on the digit list, with the b ≡ -1 step obtained from an explicit construction of d ∣ (b + 1). The resulting dvd_iff_dvd_altDigitSum gives d ∣ n ↔ (d : ℤ) ∣ altDigitSum b n whenever (10^k) % d = d - 1.",
+    "keyInsights": [
+      "Euler's theorem is exactly the tool that makes the digit-sum rule universal: 10^φ(d) ≡ 1 (mod d) is the only ingredient needed, so the open question reduces to a one-line application of Nat.pow_totient_mod_eq_one.",
+      "The disjunction in the open question is logically settled by its left (digit-sum) branch alone, since that branch never fails for d coprime to 10; the alternating-sum branch is a practical refinement, not a logical necessity.",
+      "The alternating-sum branch can give a strictly smaller base than the universal φ(d) bound: for d = 7, φ(7) = 6 would demand base 10^6, but 10^3 ≡ -1 (mod 7) gives an alternating rule on three-digit blocks (base 1000); the same happens for d = 13.",
+      "omega cannot prove (b + 1) % d = 0 from b % d = d - 1 when d is a variable, because its modular reasoning is limited to constant divisors; the fix is to hand it the Euclidean identity Nat.div_add_mod and an explicit cofactor witness for d ∣ (b + 1).",
+      "Nat.ofDigits is polymorphic over a semiring, so the ascription (Nat.ofDigits b l : ℤ) silently coerces the base into ℤ; keeping the recursion in ℕ and casting afterwards (via Nat.cast_add / Nat.cast_mul rather than push_cast) avoids the coe_ofDigits normal form clashing with the inductive hypothesis."
+    ],
+    "prerequisites": [
+      "The Fermat–Euler totient theorem (Nat.pow_totient_mod_eq_one)",
+      "Nat.digits / Nat.ofDigits and Nat.modEq_digits_sum",
+      "Nat.ModEq and Int.ModEq, including Int.modEq_iff_dvd",
+      "Euler's totient function and Nat.totient_pos"
+    ]
+  },
+  "conclusion": {
+    "summary": "For every modulus d > 1 coprime to 10 there is a power of 10 whose digit sum (always) or alternating digit sum (when a sign-reversing power exists) detects divisibility by d. The universal digit-sum witness B = 10^φ(d) comes directly from the Fermat–Euler theorem, and the alternating-sum branch is realized for 11, 7, and 13. All 15 theorems are machine-checked with zero axioms beyond Lean's foundational triple — a strictly cleaner verification than the parent entry, which relied on native_decide.",
+    "implications": "This closes the gap between the parent's modulus-by-modulus catalogue and a single uniform existence theorem: the catalogue's separate rules are now seen as instances of one Euler-theoretic principle. The contrast with the parent — which discharges base-side conditions by native_decide and so carries Lean.ofReduceBool — shows that the universal statement is not only more general but also more honestly verified, since the totient witness eliminates the need for any compiler-trusting decision procedure.",
+    "openQuestions": [
+      "Characterize exactly which d coprime to 10 admit the alternating-sum branch (i.e. when -1 lies in the cyclic subgroup generated by 10 modulo d), and give the minimal base in each case in terms of the multiplicative order of 10.",
+      "Quantify how much smaller the alternating-sum base 10^k (with 10^k ≡ -1) can be than the digit-sum base 10^(ord_d(10)); equivalently, relate the two to the order and the index of ⟨100⟩ in ⟨10⟩ modulo d."
+    ]
+  },
+  "sections": [
+    {
+      "id": "sec-divOQ0102-digitsum",
+      "title": "Part I: The Universal Digit-Sum Rule",
+      "startLine": 34,
+      "endLine": 63,
+      "summary": "dvd_iff_dvd_digitSum packages Nat.modEq_digits_sum into an iff on divisibility for any base B with B % d = 1. exists_base_digitSum_rule is the universal theorem: for d > 1 coprime to 10, the base B = 10^φ(d) is a genuine base (> 1) with B % d = 1 (Fermat–Euler), so divisibility by d is detected by the base-B digit sum, with explicit witness k = φ(d)."
+    },
+    {
+      "id": "sec-divOQ0102-altsum-infra",
+      "title": "Part II: Alternating-Digit-Sum Infrastructure",
+      "startLine": 65,
+      "endLine": 138,
+      "summary": "Self-contained (native_decide-free) re-derivation of the alternating digit sum: the recursive function alternatingDigitSum, its cons recursion (proved by a generalizing induction), the congruence ofDigits_modEq_alternatingDigitSum for bases b ≡ -1 (mod d), and the divisibility iff dvd_iff_dvd_altDigitSum. The b ≡ -1 step is obtained from an explicit construction of d ∣ (b + 1), sidestepping omega's inability to reason about mod with a variable divisor."
+    },
+    {
+      "id": "sec-divOQ0102-altsum-realizable",
+      "title": "Part III: The Alternating-Sum Branch Is Realizable",
+      "startLine": 139,
+      "endLine": 153,
+      "summary": "exists_base_altDigitSum_rule: whenever (10^k) % d = d - 1 (i.e. 10^k ≡ -1 mod d) with d > 1, divisibility by d is detected by the base-10^k alternating digit sum."
+    },
+    {
+      "id": "sec-divOQ0102-headline",
+      "title": "Part IV: The Headline Existence Theorem",
+      "startLine": 154,
+      "endLine": 174,
+      "summary": "exists_base_divisibility_rule states the open question verbatim: for every d > 1 coprime to 10 there is a power 10^k (k ≥ 1) detecting divisibility by d via the digit sum OR the alternating digit sum. It is proved through the always-available digit-sum branch."
+    },
+    {
+      "id": "sec-divOQ0102-instances",
+      "title": "Part V: Worked Instances",
+      "startLine": 175,
+      "endLine": 218,
+      "summary": "Digit-sum branch: 3 and 9 (base 10), 37 (base 1000), 101 (base 10000). Alternating-sum branch: 11 (base 10, since 10 ≡ -1 mod 11), 7 and 13 (base 1000, since 10^3 ≡ -1 modulo each). Every base-side condition is discharged by norm_num."
+    },
+    {
+      "id": "sec-divOQ0102-sanity",
+      "title": "Part VI: Kernel-Checkable Sanity Checks",
+      "startLine": 219,
+      "endLine": 244,
+      "summary": "Sanity checks evaluate alternatingDigitSum on explicit digit lists ([1,0,0,1] for 1001 in base 10, [3,3,2,1] for 1233, [1,1] for 1001 in base 1000) and verify the corresponding ℤ-divisibility verdicts via decide — all kernel-reduced, with no native_decide."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "divisibility-rules-oq-01",
+      "relationship": "extends",
+      "description": "Resolves the second open question posed in the conclusion of divisibility-rules-oq-01, generalizing its modulus-by-modulus rules to a single universal existence theorem and removing the dependence on native_decide."
+    },
+    {
+      "targetId": "divisibility-rules",
+      "relationship": "related",
+      "description": "Provides the theoretical capstone to the base DivisibilityRules collection: every modulus coprime to 10 has a power-of-10 digit-sum rule."
+    }
+  ],
+  "leanFile": {
+    "lineCount": 244,
+    "path": "Proofs/DivisibilityRulesOQ01OQ02.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 2,
+    "theoremCount": 15
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **second open question** of `divisibility-rules-oq-01`:

> For every modulus `d` coprime to 10, there exists a base `B` (a power of 10) such that `d ∣ (sum of B-ary digits of n)` **or** `d ∣ (alternating sum of B-ary digits of n)`.

**The digit-sum branch always succeeds.** Taking `B = 10^φ(d)`, the Fermat–Euler theorem (`Nat.pow_totient_mod_eq_one`) gives `10^φ(d) ≡ 1 (mod d)`, so `d ∣ n ↔ d ∣ (base-B digit sum of n)` via `Nat.modEq_digits_sum`. The existence theorem is therefore proved through its left disjunct with the explicit witness `k = φ(d)`.

**The alternating-sum branch is developed as realizable infrastructure.** Whenever some `10^k ≡ -1 (mod d)`, divisibility by `d` is detected by the base-`10^k` alternating digit sum — often with a *smaller* base than `10^φ(d)`:
- `d = 11`: `10 ≡ -1 (mod 11)` → base 10
- `d = 7`:  `10³ ≡ -1 (mod 7)` → base 1000 (vs. `10^φ(7) = 10⁶`)
- `d = 13`: `10³ ≡ -1 (mod 13)` → base 1000

## Headline theorems

- `exists_base_divisibility_rule` — the open question, verbatim
- `exists_base_digitSum_rule` — universal digit-sum branch via Euler's theorem
- `exists_base_altDigitSum_rule` — alternating-sum branch from a sign-reversing power
- `dvd_iff_dvd_altDigitSum` — self-contained alternating-sum divisibility iff

## Verification

- **15 theorems, 2 definitions, 0 sorries, 0 `axiom` declarations**
- `#print axioms` on all four headline theorems = `[propext, Classical.choice, Quot.sound]`
- **No `native_decide`** — every base-side condition is discharged by `norm_num`, so (unlike the parent entry, which depends on `Lean.ofReduceBool`) this proof carries no compiler-trusting axiom. Status: `verified` / badge `original`.
- Kernel-verified with `lake env lean Proofs/DivisibilityRulesOQ01OQ02.lean` (0 errors).

## Files

- `proofs/Proofs/DivisibilityRulesOQ01OQ02.lean` (new, 244 lines)
- `proofs/Proofs.lean` (register module)
- `src/data/proofs/divisibility-rules-oq-01-oq-02/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)