### PR TITLE
research(spherical-law-of-cosines-oq-03-oq-01): hyperbolic dual law of cosines over a Lorentzian structure

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3532,6 +3532,7 @@ import Proofs.SpernerSimplicialInstanceOQ05Scarf1d
 import Proofs.SphericalLawOfCosines
 import Proofs.SphericalLawOfCosinesOQ03
 import Proofs.SphericalLawOfCosinesOQ03Bidual
+import Proofs.SphericalLawOfCosinesOQ03OQ01
 import Proofs.SphericalLawOfCosinesOQ03Primal
 import Proofs.SphericalLawOfCosinesOQ05
 import Proofs.SphericalLawOfSines

--- a/proofs/Proofs/SphericalLawOfCosinesOQ03OQ01.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ03OQ01.lean
@@ -1,0 +1,384 @@
+/-
+# Spherical Law of Cosines — OQ-03 · OQ-01: the Hyperbolic Dual Law of Cosines
+
+Research file for OQ-01 of the gallery entry `spherical-law-of-cosines-oq-03`
+(the dual / angles spherical law of cosines).
+
+## The OPEN question
+
+OQ-03's first open question asks:
+
+> Does the same clear-radicals-then-ring strategy yield the hyperbolic dual
+> law of cosines `cosh C = − cosh A · cosh B + sinh A · sinh B · cosh c`
+> over a Lorentzian (Minkowski) inner-product structure, with the cross
+> product replaced by its pseudo-Euclidean analogue?
+
+## Answer: yes — but the correct identity keeps the *angles* circular
+
+The strategy carries over essentially verbatim, with the Euclidean dot
+product on `ℝ³` replaced by the **Lorentzian inner product** of signature
+`(+, +, −)` and the cross product replaced by the **Lorentzian cross
+product** `mcross`. The result it produces, however, is the *standard*
+**second (dual) hyperbolic law of cosines**
+
+  `cos C = − cos A · cos B + sin A · sin B · cosh c`,
+
+NOT the literal formula quoted in the open question. The angle functions
+remain **circular** (`cos`, `sin`), only the included *side* becomes
+hyperbolic (`cos c ↦ cosh c`). This is forced by the geometry: a hyperbolic
+triangle's interior angles are ordinary Euclidean angles in `[0, π]`, and
+they are realised here as the angle between the two *spacelike* edge normals
+`u ⊠ v`, `u ⊠ w` at a vertex — whose Lorentzian inner product is
+`sinh b · sinh c · cos A` and whose Lorentzian norms are `sinh b`, `sinh c`,
+giving a genuine `cos A` with `|cos A| ≤ 1`. Replacing `cos A` by `cosh A`
+(as the quoted formula does) would require an unbounded angle and does not
+correspond to the algebra the Minkowski structure produces. So the honest
+answer is: *the strategy works, and the radical-free polynomial identity it
+yields is the second hyperbolic law of cosines with circular angle terms.*
+
+## Strategy: a radical-free, division-free formalisation (Minkowski)
+
+Work with vectors in `ℝ^{2,1}` as a 3-field structure `V`, with the
+Lorentzian inner product
+
+  `mdot u v = u.x·v.x + u.y·v.y − u.z·v.z`        (z-axis timelike)
+
+and the Lorentzian cross product `mcross u v`, the unique vector with
+`mdot (mcross u v) w = det(u, v, w)`. For three points `u, v, w` on the
+upper hyperboloid `{ mdot x x = −1, x.z > 0 }` (the model of `H²`), the side
+"cosines" are the *negative* hyperbolic cosines
+
+  `mdot v w = −cosh a`,  `mdot w u = −cosh b`,  `mdot u v = −cosh c`,
+
+(reverse Cauchy–Schwarz: two future timelike unit vectors have `mdot ≤ −1`).
+The Lorentzian Binet–Cauchy and Lagrange identities pick up a sign relative
+to the Euclidean ones:
+
+  `mdot (mcross a b) (mcross c d) = mdot a d · mdot b c − mdot a c · mdot b d`,
+  `mdot (mcross a b) (mcross a b) = (mdot a b)² − mdot a a · mdot b b`,
+
+so for hyperboloid points the edge normal `u ⊠ v` is **spacelike** with
+`mdot (mcross u v) (mcross u v) = (mdot u v)² − 1 = cosh²c − 1 = sinh²c ≥ 0`,
+and `[u v w]² = −Gram = 1 − ca² − cb² − cc² − 2·ca·cb·cc` (the cross term
+`−2·ca·cb·cc` flips sign relative to the spherical `+2`). Substituting the
+normal forms `cos A = (cb·cc + ca)/(sinh b·sinh c)`, `sin A = [u v w]/(sinh b·sinh c)`
+and clearing the radicals `sinh a, sinh b, sinh c` turns the dual law into a
+polynomial identity (`hyp_dual_poly`, by `ring`).
+
+## Contents
+
+* `mdot`, `mcross`, `mtriple`     — Lorentzian inner / cross / triple products
+* `binet_cauchy`, `lagrange_identity`, `triple_sq` — the (sign-flipped) Gram algebra
+* `dot_cross_left` / `dot_cross_right`             — `mcross u v ⊥ u, v`
+* `reverse_cauchy_schwarz`        — future unit timelike vectors: `mdot u v ≤ −1`
+* `sinhc_sq_nonneg`               — `sinh²c ≥ 0` for a hyperboloid edge
+* `hyp_dual_poly`                 — algebraic heart of the hyperbolic dual law   (ring)
+* `hyp_dual_law_cleared`          — cleared dual law for abstract normal-form data
+* `hyp_dual_law_minkowski_cleared`— cleared dual law for a hyperboloid triangle
+* `hyp_dual_law_trig`             — literal trig dual law `cos C = −cos A·cos B + sin A·sin B·cosh c`
+* `cosA_num` / `cosB_num` / `cosC_num` — angle-cosine numerators as Binet–Cauchy
+  inner products of edge normals
+* `sinha_sq` / `sinhb_sq` / `sinhc_sq` — side-sine squares as Lagrange self-inner-products
+* `hyp_dual_law_cross_product_form` — the dual law in pure Lorentzian cross-product form
+
+Axioms: 0.  Sorries: 0.
+
+NOTE (significance): this is a faithful Lorentzian port of the spherical
+`SphericalLawOfCosinesOQ03`. The mathematical news is the *correction* of the
+open question's tentative all-hyperbolic formula to the geometrically correct
+`cos C = −cos A·cos B + sin A·sin B·cosh c`, together with the explicit
+sign-flips of the Lorentzian Gram algebra (`−2·ca·cb·cc`, the spacelike
+edge-normal norm `(mdot u v)² − 1`) and the reverse Cauchy–Schwarz
+well-definedness of the side lengths.
+-/
+
+import Mathlib
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+
+namespace SphericalLawOfCosinesOQ03OQ01
+
+open Real
+
+/-! ## Part I: Minkowski 3-vectors, Lorentzian dot and cross products -/
+
+/-- A vector in `ℝ³`, carrying the Lorentzian form of signature `(+, +, −)`. -/
+structure V where
+  x : ℝ
+  y : ℝ
+  z : ℝ
+
+/-- Lorentzian (Minkowski) inner product of signature `(+, +, −)`; the
+`z`-axis is timelike. -/
+def mdot (u v : V) : ℝ := u.x * v.x + u.y * v.y - u.z * v.z
+
+/-- Lorentzian cross product on `ℝ^{2,1}`: the unique vector with
+`mdot (mcross u v) w = det(u, v, w)`. Compared with the Euclidean cross
+product, the timelike (`z`) component is negated. -/
+def mcross (u v : V) : V :=
+  ⟨u.y * v.z - u.z * v.y, u.z * v.x - u.x * v.z, -(u.x * v.y - u.y * v.x)⟩
+
+/-- Lorentzian scalar triple product `[u v w] = mdot u (mcross v w) = det(u, v, w)`. -/
+def mtriple (u v w : V) : ℝ := mdot u (mcross v w)
+
+theorem mdot_comm (u v : V) : mdot u v = mdot v u := by
+  obtain ⟨u1, u2, u3⟩ := u; obtain ⟨v1, v2, v3⟩ := v
+  simp only [mdot]; ring
+
+/-! ## Part II: Lorentzian Binet–Cauchy and Gram identities (pure `ring`)
+
+These are the pseudo-Euclidean analogues of the Euclidean identities; each
+carries an overall sign flip coming from the timelike direction. -/
+
+/-- **Lorentzian Binet–Cauchy identity**:
+    `mdot (a × b) (c × d) = mdot a d · mdot b c − mdot a c · mdot b d`.
+Note the swapped pairing relative to the Euclidean
+`⟨a,c⟩⟨b,d⟩ − ⟨a,d⟩⟨b,c⟩`: the Lorentzian signature flips the overall sign. -/
+theorem binet_cauchy (a b c d : V) :
+    mdot (mcross a b) (mcross c d) = mdot a d * mdot b c - mdot a c * mdot b d := by
+  obtain ⟨a1, a2, a3⟩ := a; obtain ⟨b1, b2, b3⟩ := b
+  obtain ⟨c1, c2, c3⟩ := c; obtain ⟨d1, d2, d3⟩ := d
+  simp only [mdot, mcross]; ring
+
+/-- **Lorentzian Lagrange identity**:
+    `mdot (a × b) (a × b) = (mdot a b)² − mdot a a · mdot b b`.
+The sign is flipped from the Euclidean `‖a‖²‖b‖² − ⟨a,b⟩²`; for two future
+timelike unit vectors this makes `a × b` spacelike. -/
+theorem lagrange_identity (a b : V) :
+    mdot (mcross a b) (mcross a b) = mdot a b ^ 2 - mdot a a * mdot b b := by
+  obtain ⟨a1, a2, a3⟩ := a; obtain ⟨b1, b2, b3⟩ := b
+  simp only [mdot, mcross]; ring
+
+/-- The Lorentzian cross product is `mdot`-orthogonal to its first factor. -/
+theorem dot_cross_left (a b : V) : mdot (mcross a b) a = 0 := by
+  obtain ⟨a1, a2, a3⟩ := a; obtain ⟨b1, b2, b3⟩ := b
+  simp only [mdot, mcross]; ring
+
+/-- The Lorentzian cross product is `mdot`-orthogonal to its second factor. -/
+theorem dot_cross_right (a b : V) : mdot (mcross a b) b = 0 := by
+  obtain ⟨a1, a2, a3⟩ := a; obtain ⟨b1, b2, b3⟩ := b
+  simp only [mdot, mcross]; ring
+
+/-- The squared Lorentzian triple product equals `− Gram(u, v, w)`. The leading
+minus sign (`det η = −1`) is the Lorentzian signature; the Gram polynomial is
+identical to the Euclidean one. -/
+theorem triple_sq (u v w : V) :
+    (mtriple u v w) ^ 2 =
+      -(mdot u u * mdot v v * mdot w w
+        + 2 * mdot u v * mdot v w * mdot w u
+        - mdot u u * mdot v w ^ 2
+        - mdot v v * mdot w u ^ 2
+        - mdot w w * mdot u v ^ 2) := by
+  obtain ⟨u1, u2, u3⟩ := u; obtain ⟨v1, v2, v3⟩ := v; obtain ⟨w1, w2, w3⟩ := w
+  simp only [mtriple, mdot, mcross]; ring
+
+/-! ## Part III: Reverse Cauchy–Schwarz and well-definedness of the sides
+
+On the upper hyperboloid `{ mdot x x = −1, x.z > 0 }` (the model of `H²`),
+two points have `mdot ≤ −1`, so `−mdot u v = cosh c ≥ 1` defines a genuine
+hyperbolic distance and the edge normals are spacelike (`sinh²c ≥ 0`). -/
+
+/-- **Reverse Cauchy–Schwarz** for the Minkowski form. Two future-directed
+unit timelike vectors (`mdot · · = −1`, positive timelike component) satisfy
+`mdot u v ≤ −1`, so `cosh c := −mdot u v ≥ 1`. The certificate is the sum of
+squares `(u.x − v.x)² + (u.y − v.y)² + (u.x·v.y − u.y·v.x)² ≥ 0`. -/
+theorem reverse_cauchy_schwarz (u v : V)
+    (hu : mdot u u = -1) (hv : mdot v v = -1)
+    (huz : 0 < u.z) (hvz : 0 < v.z) :
+    mdot u v ≤ -1 := by
+  simp only [mdot] at hu hv ⊢
+  nlinarith [sq_nonneg (u.x - v.x), sq_nonneg (u.y - v.y),
+    sq_nonneg (u.x * v.y - u.y * v.x), mul_pos huz hvz,
+    sq_nonneg (u.z * v.z - 1), sq_nonneg (u.x * v.x + u.y * v.y + 1),
+    mul_pos (mul_pos huz hvz) (mul_pos huz hvz)]
+
+/-- For a hyperboloid edge, the side-sine square `sinh²c = (mdot u v)² − 1` is
+nonnegative (the edge normal `u ⊠ v` is spacelike). -/
+theorem sinhc_sq_nonneg (u v : V)
+    (hu : mdot u u = -1) (hv : mdot v v = -1)
+    (huz : 0 < u.z) (hvz : 0 < v.z) :
+    0 ≤ mdot u v ^ 2 - 1 := by
+  have h := reverse_cauchy_schwarz u v hu hv huz hvz
+  nlinarith [h]
+
+/-! ## Part IV: The algebraic heart of the hyperbolic dual law -/
+
+/-- **Polynomial identity underlying the hyperbolic dual law of cosines.**
+
+For real side inner products `ca, cb, cc` (`= −cosh a, −cosh b, −cosh c`):
+
+  `(cc + ca·cb)(cc² − 1) = −(ca + cb·cc)(cb + ca·cc) − (1 − ca² − cb² − cc² − 2·ca·cb·cc)·cc`.
+
+The left factor `cc² − 1` is `sinh²c`, the last factor is the squared
+Lorentzian triple product `[u v w]²` (`= −Gram`), and the bracketed sums are
+the numerators of the normal-form angle cosines. Dividing through produces
+the dual law. Compared with the spherical `dual_poly`, the cross term inside
+the Gram is `−2·ca·cb·cc` and the included-side term carries an extra minus
+sign — exactly the Lorentzian signature. -/
+theorem hyp_dual_poly (ca cb cc : ℝ) :
+    (cc + ca * cb) * (cc ^ 2 - 1) =
+      -(ca + cb * cc) * (cb + ca * cc)
+        - (1 - ca ^ 2 - cb ^ 2 - cc ^ 2 - 2 * ca * cb * cc) * cc := by
+  ring
+
+/-- **Hyperbolic dual law of cosines (cleared, abstract form).**
+
+Given side inner products `ca, cb, cc`, the squared side sine `sc2 = cc² − 1`,
+and a squared triple product `tp2 = 1 − ca² − cb² − cc² − 2·ca·cb·cc`,
+
+  `(cc + ca·cb)·sc2 = −(ca + cb·cc)(cb + ca·cc) − tp2·cc`.
+
+Dividing both sides by `sinh a · sinh b · sinh² c` and using
+`cos A = (cb·cc + ca)/(sinh b · sinh c)`, `sin A = √tp2/(sinh b · sinh c)`,
+etc. gives the trig dual law `cos C = −cos A·cos B + sin A·sin B·cosh c`. -/
+theorem hyp_dual_law_cleared
+    (ca cb cc sc2 tp2 : ℝ)
+    (hsc : sc2 = cc ^ 2 - 1)
+    (htp : tp2 = 1 - ca ^ 2 - cb ^ 2 - cc ^ 2 - 2 * ca * cb * cc) :
+    (cc + ca * cb) * sc2 = -(ca + cb * cc) * (cb + ca * cc) - tp2 * cc := by
+  rw [hsc, htp]; ring
+
+/-! ## Part V: The geometric dual law for a hyperboloid triangle -/
+
+/-- **Hyperbolic dual law of cosines** for a triangle given by points
+`u, v, w` on the hyperboloid (`mdot u u = mdot v v = mdot w w = −1`), in
+cleared (radical-free, division-free) form.
+
+With side inner products `ca = mdot v w` (`= −cosh a`), `cb = mdot w u`,
+`cc = mdot u v`, and Lorentzian triple product `[u v w]`:
+
+  `(cc + ca·cb)·(cc² − 1) = −(ca + cb·cc)(cb + ca·cc) − [u v w]²·cc`.
+
+Here `cc² − 1 = sinh²c` and `[u v w]² = sinh²A · sinh²b · sinh²c = −Gram`, so
+dividing by `sinh a · sinh b · sinh² c` yields exactly
+
+  `cos C = −cos A · cos B + sin A · sin B · cosh c`. -/
+theorem hyp_dual_law_minkowski_cleared
+    (u v w : V) (hu : mdot u u = -1) (hv : mdot v v = -1) (hw : mdot w w = -1) :
+    (mdot u v + mdot v w * mdot w u) * (mdot u v ^ 2 - 1)
+      = -(mdot v w + mdot w u * mdot u v) * (mdot w u + mdot v w * mdot u v)
+        - (mtriple u v w) ^ 2 * mdot u v := by
+  have htp := triple_sq u v w
+  rw [hu, hv, hw] at htp
+  rw [htp]; ring
+
+/-! ## Part VI: The literal trigonometric dual law
+`cos C = −cos A·cos B + sin A·sin B·cosh c` -/
+
+/-- **Literal trigonometric hyperbolic dual law of cosines.**
+
+From the angle cos/sin defining relations taken in *cleared product form*
+(the first hyperbolic law of cosines solved for the angle, with denominators
+cleared) plus the side-Pythagorean identity `shc² = chc² − 1`, the second
+hyperbolic law of cosines holds as the literal equality
+
+  `cos C = −cos A · cos B + sin A · sin B · cosh c`,
+
+where `cha, chb, chc` are the side hyperbolic cosines, `sha, shb, shc` the side
+hyperbolic sines, and `cA, cB, cC, sA, sB` the **circular** cosines/sines of
+the interior angles.
+
+Division-free route (no `field_simp`): the angle relations are posited cleared,
+the common denominator `sha·shb·shc²` is removed once via `mul_right_cancel₀`,
+and the goal closes by a single `linear_combination` against the polynomial
+heart. The structure is identical to the spherical `dual_law_trig`; only the
+included side becomes `cosh c` and the Gram cross term becomes `+2·cha·chb·chc`. -/
+theorem hyp_dual_law_trig
+    (cha chb chc sha shb shc cA cB cC sA sB : ℝ)
+    (hsa : sha ≠ 0) (hsb : shb ≠ 0) (hsc : shc ≠ 0)
+    (hshc2 : shc ^ 2 = chc ^ 2 - 1)
+    (hcA : cA * (shb * shc) = chb * chc - cha)
+    (hcB : cB * (sha * shc) = cha * chc - chb)
+    (hcC : cC * (sha * shb) = cha * chb - chc)
+    (hsAsB : sA * sB * (sha * shb * shc ^ 2)
+        = 1 - cha ^ 2 - chb ^ 2 - chc ^ 2 + 2 * cha * chb * chc) :
+    cC = -cA * cB + sA * sB * chc := by
+  have hD : sha * shb * shc ^ 2 ≠ 0 :=
+    mul_ne_zero (mul_ne_zero hsa hsb) (pow_ne_zero 2 hsc)
+  have hAB : cA * cB * (sha * shb * shc ^ 2) = (chb * chc - cha) * (cha * chc - chb) := by
+    have h : cA * (shb * shc) * (cB * (sha * shc)) = (chb * chc - cha) * (cha * chc - chb) := by
+      rw [hcA, hcB]
+    linear_combination h
+  have key : (cha * chb - chc) * shc ^ 2
+      = -(chb * chc - cha) * (cha * chc - chb)
+        + (1 - cha ^ 2 - chb ^ 2 - chc ^ 2 + 2 * cha * chb * chc) * chc := by
+    rw [hshc2]; ring
+  apply mul_right_cancel₀ hD
+  linear_combination (shc ^ 2) * hcC + hAB - chc * hsAsB + key
+
+/-! ## Part VII: Fully geometric Lorentzian cross-product form
+
+Each angle-cosine numerator is a Lorentzian Binet–Cauchy inner product of two
+edge normals, and each side-sine square is a Lorentzian Lagrange
+self-inner-product. Substituting these recovers the dual law in **pure
+Lorentzian cross-product form** (`hyp_dual_law_cross_product_form`), grounding
+the posited normal forms of `hyp_dual_law_trig` in actual Minkowski geometry;
+all proofs remain `ring`/`rw`-only (no division, no radicals). -/
+
+/-- Angle `A` (at vertex `u`) numerator as a Lorentzian Binet–Cauchy inner
+product of the two edge normals at `u`:
+`mdot (u ⊠ v) (u ⊠ w) = mdot v w + mdot w u · mdot u v`
+(`= cosh b·cosh c − cosh a = sinh b·sinh c·cos A`). -/
+theorem cosA_num (u v w : V) (hu : mdot u u = -1) :
+    mdot (mcross u v) (mcross u w) = mdot v w + mdot w u * mdot u v := by
+  have h := binet_cauchy u v u w
+  rw [h, hu, mdot_comm u w, mdot_comm v u]; ring
+
+/-- Angle `B` (at vertex `v`) numerator as a Lorentzian Binet–Cauchy inner
+product of the two edge normals at `v`:
+`mdot (v ⊠ w) (v ⊠ u) = mdot w u + mdot v w · mdot u v`. -/
+theorem cosB_num (u v w : V) (hv : mdot v v = -1) :
+    mdot (mcross v w) (mcross v u) = mdot w u + mdot v w * mdot u v := by
+  have h := binet_cauchy v w v u
+  rw [h, hv, mdot_comm v u, mdot_comm w v]; ring
+
+/-- Angle `C` (at vertex `w`) numerator as a Lorentzian Binet–Cauchy inner
+product of the two edge normals at `w`:
+`mdot (w ⊠ u) (w ⊠ v) = mdot u v + mdot v w · mdot w u`. -/
+theorem cosC_num (u v w : V) (hw : mdot w w = -1) :
+    mdot (mcross w u) (mcross w v) = mdot u v + mdot v w * mdot w u := by
+  have h := binet_cauchy w u w v
+  rw [h, hw, mdot_comm w v, mdot_comm u w]; ring
+
+/-- Side `c` sine-square as a Lorentzian Lagrange self-inner-product:
+`mdot (u ⊠ v) (u ⊠ v) = (mdot u v)² − 1 = cosh²c − 1 = sinh²c`. -/
+theorem sinhc_sq (u v : V) (hu : mdot u u = -1) (hv : mdot v v = -1) :
+    mdot (mcross u v) (mcross u v) = mdot u v ^ 2 - 1 := by
+  rw [lagrange_identity u v, hu, hv]; ring
+
+/-- Side `b` sine-square: `mdot (w ⊠ u) (w ⊠ u) = (mdot w u)² − 1 = sinh²b`. -/
+theorem sinhb_sq (u w : V) (hw : mdot w w = -1) (hu : mdot u u = -1) :
+    mdot (mcross w u) (mcross w u) = mdot w u ^ 2 - 1 := by
+  rw [lagrange_identity w u, hw, hu]; ring
+
+/-- Side `a` sine-square: `mdot (v ⊠ w) (v ⊠ w) = (mdot v w)² − 1 = sinh²a`. -/
+theorem sinha_sq (v w : V) (hv : mdot v v = -1) (hw : mdot w w = -1) :
+    mdot (mcross v w) (mcross v w) = mdot v w ^ 2 - 1 := by
+  rw [lagrange_identity v w, hv, hw]; ring
+
+/-- **Hyperbolic dual law of cosines, pure Lorentzian cross-product form.**
+
+For a hyperboloid triangle `u, v, w`, the cleared dual law holds with every
+angle-cosine numerator and side-sine square replaced by its Lorentzian
+cross-product realisation:
+
+  `mdot (w⊠u) (w⊠v) · mdot (u⊠v) (u⊠v)
+     = −mdot (u⊠v) (u⊠w) · mdot (v⊠w) (v⊠u) − [u v w]² · mdot u v`.
+
+Reading off the geometric meaning (`mdot (w⊠u) (w⊠v) = sinh a sinh b cos C`,
+`mdot (u⊠v) (u⊠v) = sinh²c`, `[u v w]² = sinh²A sinh²b sinh²c`, etc.) and
+dividing by the positive product of side sines recovers
+`cos C = −cos A cos B + sin A sin B cosh c`. Proved by rewriting the four
+cross-product quantities to their side-inner-product normal forms
+(`cosC_num`/`sinhc_sq`/`cosA_num`/`cosB_num`) and invoking
+`hyp_dual_law_minkowski_cleared`. -/
+theorem hyp_dual_law_cross_product_form
+    (u v w : V) (hu : mdot u u = -1) (hv : mdot v v = -1) (hw : mdot w w = -1) :
+    mdot (mcross w u) (mcross w v) * mdot (mcross u v) (mcross u v)
+      = -(mdot (mcross u v) (mcross u w)) * mdot (mcross v w) (mcross v u)
+        - (mtriple u v w) ^ 2 * mdot u v := by
+  rw [cosC_num u v w hw, sinhc_sq u v hu hv, cosA_num u v w hu, cosB_num u v w hv]
+  exact hyp_dual_law_minkowski_cleared u v w hu hv hw
+
+end SphericalLawOfCosinesOQ03OQ01

--- a/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/meta.json
@@ -1,0 +1,145 @@
+{
+  "id": "spherical-law-of-cosines-oq-03-oq-01",
+  "title": "Hyperbolic Dual Law of Cosines (Lorentzian)",
+  "slug": "spherical-law-of-cosines-oq-03-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "SphericalLawOfCosinesOQ03OQ01",
+    "lineCount": 384,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 3,
+    "path": "Proofs/SphericalLawOfCosinesOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "description": "A radical-free, division-free Lean 4 formalization of the second (dual) hyperbolic law of cosines: cos C = −cos A·cos B + sin A·sin B·cosh c, ported from the spherical dual law spherical-law-of-cosines-oq-03 by replacing the Euclidean dot product on ℝ³ with the Lorentzian inner product of signature (+,+,−) and the cross product with its pseudo-Euclidean analogue. The entry answers — and corrects — OQ-01 of the parent: the clear-radicals-then-ring strategy does carry over to a Minkowski structure, but the geometrically correct identity keeps the interior angles circular (cos, sin), with only the included side becoming hyperbolic (cos c ↦ cosh c); the literal all-hyperbolic formula cosh C = −cosh A·cosh B + sinh A·sinh B·cosh c posed in the open question does not correspond to a real hyperbolic triangle. The Lorentzian Binet–Cauchy, Lagrange and Gram identities carry explicit sign flips (the spacelike edge-normal norm (mdot u v)²−1 and the Gram cross term −2·ca·cb·cc), and a reverse Cauchy–Schwarz lemma establishes well-definedness of the side lengths on the upper hyperboloid.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SphericalLawOfCosinesOQ03OQ01.lean",
+    "tags": [
+      "geometry",
+      "hyperbolic-geometry",
+      "minkowski-space",
+      "lorentzian",
+      "trigonometry",
+      "law-of-cosines",
+      "non-euclidean-geometry",
+      "duality",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 384,
+    "assumptions": "No axioms or sorries. The dual law is reduced to a polynomial identity (hyp_dual_poly, by ring) after clearing all radicals and denominators, so the cleared and cross-product forms need no non-degeneracy side conditions. The reverse Cauchy–Schwarz lemma reverse_cauchy_schwarz takes the hyperboloid constraints (mdot x x = −1) and future-direction (positive timelike component) as hypotheses on the input vectors. KERNEL-VERIFIED: lake env lean -Dexperimental.module=true compiles green (exit 0) on Mathlib v4.26.0; #print axioms reports the standard [propext, Classical.choice, Quot.sound] for hyp_dual_law_trig, hyp_dual_law_minkowski_cleared, hyp_dual_law_cross_product_form, and reverse_cauchy_schwarz (no sorryAx, no Lean.ofReduceBool).",
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Radical-free, division-free statement and proof of the second (dual) hyperbolic law of cosines cos C = −cos A·cos B + sin A·sin B·cosh c over an explicit Lorentzian inner-product structure",
+      "Correction of OQ-01's tentative all-hyperbolic formula: the Minkowski clear-radicals-then-ring strategy yields circular angle functions (cos, sin), not cosh of the angles — a hyperbolic triangle's angles are bounded Euclidean angles realised as the angle between spacelike edge normals",
+      "Lorentzian Binet–Cauchy and Lagrange identities with their sign flips (mdot (a⊠b)(c⊠d) = mdot a d·mdot b c − mdot a c·mdot b d; mdot (a⊠b)(a⊠b) = (mdot a b)² − mdot a a·mdot b b)",
+      "triple_sq: the squared Lorentzian triple product equals −Gram, giving the sign-flipped Gram determinant 1 − ca² − cb² − cc² − 2·ca·cb·cc (cross term negated relative to the spherical +2)",
+      "reverse_cauchy_schwarz: two future-directed unit timelike vectors satisfy mdot u v ≤ −1, so cosh c := −mdot u v ≥ 1 is a genuine hyperbolic distance and the edge normals are spacelike (sinh²c ≥ 0), proved by an explicit sum-of-squares certificate",
+      "hyp_dual_law_cross_product_form: the dual law expressed entirely via Lorentzian scalar triple products and spacelike cross-product norms"
+    ],
+    "theoremCount": 19,
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "The hyperbolic plane H² is modelled on the upper sheet of the two-sheeted hyperboloid {⟨x,x⟩ = −1} in Minkowski 3-space ℝ^{2,1}, where the Lorentzian inner product ⟨u,v⟩ = u₁v₁ + u₂v₂ − u₃v₃ plays the role the Euclidean dot product plays on the sphere S². Just as spherical trigonometry has a side law of cosines cos c = cos a·cos b + sin a·sin b·cos C and a dual (angles) law cos C = −cos A·cos B + sin A·sin B·cos c, hyperbolic trigonometry has a first law cosh c = cosh a·cosh b − sinh a·sinh b·cos C and a second (dual) law cos C = −cos A·cos B + sin A·sin B·cosh c. The two geometries are linked by the formal substitution a ↦ ia of the metric: cos(ia) = cosh a, sin(ia) = i·sinh a. This entry is OQ-01 of spherical-law-of-cosines-oq-03 (the spherical dual law), which explicitly asked whether the radical-free clearing strategy carries over to a Lorentzian structure. It does — and the derivation also pins down precisely which functions stay circular: the interior angles, which in hyperbolic geometry are ordinary Euclidean angles realised as the angle between the spacelike normals to the sides' geodesic planes.",
+    "problemStatement": "For a hyperbolic triangle with side lengths a, b, c and interior angles A, B, C (angle C opposite side c), prove the second (dual) law of cosines $\\cos C = -\\cos A\\,\\cos B + \\sin A\\,\\sin B\\,\\cosh c$. Working with three points u, v, w on the upper hyperboloid {mdot x x = −1, x.z > 0} in ℝ^{2,1} (so −cosh a = mdot v w, −cosh b = mdot w u, −cosh c = mdot u v), establish the cleared, radical-free polynomial form over the Lorentzian inner product and its Lorentzian cross-product realisation. Determine whether the all-hyperbolic formula cosh C = −cosh A·cosh B + sinh A·sinh B·cosh c proposed in OQ-01 is the correct dual law.",
+    "text": "Replaces the Euclidean dot/cross products of the spherical proof with the Lorentzian inner product of signature (+,+,−) and the Lorentzian cross product mcross u v (the unique vector with mdot (mcross u v) w = det(u,v,w)). The Binet–Cauchy and Lagrange identities pick up a sign flip; substituting the normal-form expressions for cos A, sin A (with sinh denominators) and multiplying by sinh a·sinh b·sinh²c turns the dual law into a polynomial identity closed by ring.",
+    "proofStrategy": "1. Lorentzian toolkit: a 3-field structure V with mdot (signature +,+,−), mcross, and mtriple = mdot u (mcross v w) = det(u,v,w), plus the sign-flipped Binet–Cauchy identity mdot (a⊠b)(c⊠d) = mdot a d·mdot b c − mdot a c·mdot b d, the Lagrange identity mdot (a⊠b)(a⊠b) = (mdot a b)² − mdot a a·mdot b b, and triple_sq (mtriple² = −Gram). 2. Well-definedness: reverse_cauchy_schwarz shows two future-directed unit timelike vectors have mdot ≤ −1, so cosh c = −mdot u v ≥ 1 and the edge normals are spacelike (sinh²c = (mdot u v)² − 1 ≥ 0). 3. Radical-free reduction: cos A = (cb·cc + ca)/(sinh b·sinh c), sin A = mtriple/(sinh b·sinh c); substituting and multiplying by sinh a·sinh b·sinh²c turns the dual law into hyp_dual_poly, closed by ring. 4. Geometric lift: hyp_dual_law_cleared and hyp_dual_law_minkowski_cleared state the cleared identity over hyperboloid vectors; hyp_dual_law_trig recovers the trigonometric form cos C = −cos A·cos B + sin A·sin B·cosh c. 5. Cross-product form: hyp_dual_law_cross_product_form re-expresses the law via Lorentzian triple products and spacelike cross-product norms (cosA_num/cosB_num/cosC_num, sinha_sq/sinhb_sq/sinhc_sq).",
+    "keyInsights": [
+      "The clear-radicals-then-ring strategy ports verbatim from S² to H²: replacing the Euclidean dot/cross products by the Lorentzian ones turns the second hyperbolic law of cosines into the single polynomial identity hyp_dual_poly, closed by ring, with no non-degeneracy side conditions in the cleared form.",
+      "The open question's literal formula cosh C = −cosh A·cosh B + sinh A·sinh B·cosh c is NOT the correct dual law: a hyperbolic triangle's interior angles are ordinary Euclidean angles in [0, π], realised here as the angle between the two spacelike edge normals u⊠v, u⊠w at a vertex, whose Lorentzian inner product sinh b·sinh c·cos A and norms sinh b, sinh c give a genuine cos A with |cos A| ≤ 1 — so the angle functions stay circular and only the included side becomes cosh c.",
+      "The Lorentzian signature shows up as two explicit sign flips relative to the spherical proof: the spacelike edge-normal norm mdot (u⊠v)(u⊠v) = (mdot u v)² − 1 (Lagrange flips sign), and the Gram cross term −2·ca·cb·cc in mtriple² = 1 − ca² − cb² − cc² − 2·ca·cb·cc (versus the spherical +2·ca·cb·cc).",
+      "Reverse Cauchy–Schwarz is what makes the side lengths well defined: for two future-directed unit timelike vectors, mdot u v ≤ −1, so cosh c := −mdot u v ≥ 1; the certificate is the sum of squares (u.x − v.x)² + (u.y − v.y)² + (u.x·v.y − u.y·v.x)² ≥ 0, the exact dual of the spherical Cauchy–Schwarz bound cos²c ≤ 1.",
+      "Phrasing everything over an explicit Lorentzian 3-field structure keeps the proof radical-free and division-free, so it is closed by ring / linear arithmetic rather than analytic estimates — the same template the spherical entry used, confirming its reusability across the sign of curvature."
+    ],
+    "prerequisites": [
+      "Spherical dual law of cosines: cos C = −cos A·cos B + sin A·sin B·cos c (parent entry spherical-law-of-cosines-oq-03)",
+      "Hyperboloid model of H²: points on {⟨x,x⟩ = −1, x.z > 0} in ℝ^{2,1}, with ⟨u,v⟩ = −cosh(d(u,v))",
+      "Minkowski inner product of signature (+,+,−) and the Lorentzian cross product",
+      "Lean 4 tactics: ring, linear_combination, nlinarith"
+    ]
+  },
+  "sections": [
+    {
+      "id": "part1-lorentzian-toolkit",
+      "title": "Part I: Minkowski Vector Toolkit",
+      "startLine": 95,
+      "endLine": 135,
+      "summary": "The 3-field structure V with the Lorentzian inner product mdot (signature +,+,−), the Lorentzian cross product mcross, and mtriple = mdot u (mcross v w) = det(u,v,w)."
+    },
+    {
+      "id": "part2-gram-algebra",
+      "title": "Part II: Sign-Flipped Binet–Cauchy and Gram Algebra",
+      "startLine": 136,
+      "endLine": 196,
+      "summary": "The Lorentzian Binet–Cauchy and Lagrange identities, the orthogonality of mcross to its factors, and triple_sq (mtriple² = −Gram) — each carrying the Lorentzian sign relative to the Euclidean version."
+    },
+    {
+      "id": "part3-reverse-cauchy-schwarz",
+      "title": "Part III: Reverse Cauchy–Schwarz and Well-Definedness",
+      "startLine": 197,
+      "endLine": 240,
+      "summary": "reverse_cauchy_schwarz: future-directed unit timelike vectors have mdot u v ≤ −1, so cosh c ≥ 1; sinhc_sq_nonneg: the edge normal is spacelike (sinh²c ≥ 0)."
+    },
+    {
+      "id": "part4-polynomial-heart",
+      "title": "Part IV: The Cleared Polynomial Identity",
+      "startLine": 241,
+      "endLine": 290,
+      "summary": "hyp_dual_poly — the hyperbolic dual law reduced to a polynomial identity in the side inner products (closed by ring) — and its abstract cleared form hyp_dual_law_cleared."
+    },
+    {
+      "id": "part5-minkowski-cleared",
+      "title": "Part V: Cleared Dual Law for a Hyperboloid Triangle",
+      "startLine": 291,
+      "endLine": 320,
+      "summary": "hyp_dual_law_minkowski_cleared: the cleared dual law for three points on the hyperboloid, via triple_sq with the −1 self-inner-products substituted."
+    },
+    {
+      "id": "part6-trig-form",
+      "title": "Part VI: Trigonometric Form",
+      "startLine": 321,
+      "endLine": 350,
+      "summary": "hyp_dual_law_trig recovers cos C = −cos A·cos B + sin A·sin B·cosh c from the cleared normal-form hypotheses, by a single linear_combination after mul_right_cancel₀."
+    },
+    {
+      "id": "part7-cross-product-form",
+      "title": "Part VII: Lorentzian Cross-Product Form",
+      "startLine": 351,
+      "endLine": 384,
+      "summary": "The angle-cosine numerators (cosA_num/cosB_num/cosC_num) and side-sine squares (sinha_sq/sinhb_sq/sinhc_sq) as Lorentzian inner products, and hyp_dual_law_cross_product_form expressing the dual law through scalar triple products and spacelike cross-product norms."
+    }
+  ],
+  "conclusion": {
+    "summary": "The second (dual) hyperbolic law of cosines $\\cos C = -\\cos A\\,\\cos B + \\sin A\\,\\sin B\\,\\cosh c$ is formalized radical-free and division-free over an explicit Lorentzian inner-product structure: after substituting the normal-form expressions for the angle cosines and sines and multiplying through by $\\sinh a\\,\\sinh b\\,\\sinh^2 c$, the law collapses to a single polynomial identity (hyp_dual_poly) closed by ring. This answers OQ-01 of the spherical dual entry affirmatively for the clearing strategy while correcting its tentative formula: the Minkowski algebra keeps the interior angles circular (cos, sin), turning only the included side hyperbolic.",
+    "implications": "The radical-free clearing template of the spherical dual law transfers across the sign of curvature with only sign changes in the Gram algebra: the Lagrange identity flips to (mdot u v)² − mdot u u·mdot v v (spacelike edge normals) and the Gram cross term flips to −2·ca·cb·cc. The reverse Cauchy–Schwarz lemma supplies the well-definedness of hyperbolic distance (cosh c ≥ 1) that the spherical Cauchy–Schwarz bound (cos²c ≤ 1) supplied on S². Together with the parent spherical entry, this exhibits the spherical and hyperbolic dual laws of cosines as the two specialisations of one polynomial identity, selected by the signature (+,+,+) versus (+,+,−) of the ambient bilinear form.",
+    "openQuestions": [
+      "Can the polar/dual construction be packaged so that the first hyperbolic law of cosines (cosh c = cosh a·cosh b − sinh a·sinh b·cos C) and this second law become one theorem applied to a hyperboloid triangle and to its de Sitter polar (the spacelike normals u⊠v, v⊠w, w⊠u), mirroring the spherical polar-triangle duality?",
+      "Does a single signature-parametrised structure (a bilinear form diag(1,1,ε) with ε = ±1) let the spherical entry's dual_law_trig and this hyp_dual_law_trig be derived as ε = +1 and ε = −1 instances of one ring identity, making curvature sign a parameter rather than a separate development?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "spherical-law-of-cosines-oq-03",
+      "relationship": "specializes",
+      "description": "The parent entry formalizes the spherical dual law cos C = −cos A·cos B + sin A·sin B·cos c over the Euclidean dot/cross products on S². This entry is OQ-01 of it: the same radical-free clearing strategy over the Lorentzian inner product of signature (+,+,−) yields the hyperbolic dual law cos C = −cos A·cos B + sin A·sin B·cosh c, with the cross term and edge-normal norm flipping sign."
+    },
+    {
+      "targetId": "spherical-law-of-cosines",
+      "relationship": "related",
+      "description": "The grandparent side law cos c = cos a·cos b + sin a·sin b·cos C on the sphere; the hyperbolic first law cosh c = cosh a·cosh b − sinh a·sinh b·cos C is its Lorentzian analogue, of which this entry formalizes the dual (angles) companion."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers **OQ-01** of `spherical-law-of-cosines-oq-03` (the spherical dual law of cosines): *does the clear-radicals-then-ring strategy yield a hyperbolic dual law over a Lorentzian/Minkowski inner-product structure?*

**Yes — and the entry corrects the open question's tentative formula.** Replacing the Euclidean dot/cross products on ℝ³ with the Lorentzian inner product of signature `(+,+,−)` and the Lorentzian cross product `mcross`, the strategy ports verbatim and produces the **standard second hyperbolic law of cosines**

> `cos C = −cos A·cos B + sin A·sin B·cosh c`

**not** the literal `cosh C = −cosh A·cosh B + sinh A·sinh B·cosh c` posed in OQ-01. A hyperbolic triangle's interior angles are ordinary Euclidean angles in `[0, π]` — realised here as the angle between the two **spacelike** edge normals `u ⊠ v`, `u ⊠ w` at a vertex (Lorentzian inner product `sinh b·sinh c·cos A`, norms `sinh b`, `sinh c`) — so the angle functions stay circular; only the included *side* goes hyperbolic.

## What's new (mathematical content)

- **Lorentzian Gram algebra with explicit sign flips**: the Lagrange identity gives the *spacelike* edge-normal norm `mdot (u⊠v)(u⊠v) = (mdot u v)² − mdot u u·mdot v v`, and `triple_sq` gives `mtriple² = −Gram` with cross term `−2·ca·cb·cc` (vs the spherical `+2`).
- **`reverse_cauchy_schwarz`**: two future-directed unit timelike vectors satisfy `mdot u v ≤ −1`, so `cosh c := −mdot u v ≥ 1` is a genuine hyperbolic distance — proved by the sum-of-squares certificate `(u.x−v.x)² + (u.y−v.y)² + (u.x·v.y−u.y·v.x)² ≥ 0`, the dual of the spherical Cauchy–Schwarz bound `cos²c ≤ 1`.
- **Full 7-part port** of the spherical entry: cleared polynomial heart (`hyp_dual_poly`, by `ring`), abstract/geometric cleared laws, the literal trig form (`hyp_dual_law_trig`), and the pure Lorentzian cross-product form.

## Verification

- **19 theorems, 3 defs, 0 sorries, 0 `axiom` declarations.**
- Kernel-verified via `lake env lean -Dexperimental.module=true` (exit 0) on Mathlib v4.26.0.
- `#print axioms` reports the standard `[propext, Classical.choice, Quot.sound]` for `hyp_dual_law_trig`, `hyp_dual_law_minkowski_cleared`, `hyp_dual_law_cross_product_form`, and `reverse_cauchy_schwarz` — no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`.

## Files

- `proofs/Proofs/SphericalLawOfCosinesOQ03OQ01.lean` (new, 384 lines)
- `proofs/Proofs.lean` (+1 import)
- `src/data/proofs/spherical-law-of-cosines-oq-03-oq-01/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)