### PR TITLE
Enrich Cyclic Invariance of the Trace and Eigenvalues of Similar Matrices: add index.ts + annotations

### DIFF
--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/index.ts
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SpectralTraceDetEigenvaluesOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const spectralTraceDetEigenvaluesOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const spectralTraceDetEigenvaluesOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const spectralTraceDetEigenvaluesOQ02Data: ProofData = {
+  proof: spectralTraceDetEigenvaluesOQ02Proof,
+  annotations: spectralTraceDetEigenvaluesOQ02Annotations,
+}

--- a/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
+++ b/src/data/proofs/spectral-trace-det-eigenvalues-oq-02/meta.json
@@ -114,8 +114,9 @@
   ],
   "crossReferences": [
     {
-      "id": "spectral-trace-det-eigenvalues-oq-01",
-      "relationship": "Companion entry establishing trace = Σλ and det = Πλ as the sum and product of the eigenvalues. This entry supplies the cyclic-invariance side: it shows conjugation preserves the entire eigenvalue multiset, so the oq-01 identities make trace and determinant similarity invariants."
+      "targetId": "spectral-trace-det-eigenvalues-oq-01",
+      "relationship": "related",
+      "description": "Companion entry establishing trace = Σλ and det = Πλ as the sum and product of the eigenvalues. This entry supplies the cyclic-invariance side: it shows conjugation preserves the entire eigenvalue multiset, so the oq-01 identities make trace and determinant similarity invariants."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `spectral-trace-det-eigenvalues-oq-02` (cyclic invariance of the trace, the commutator-trace identity, similarity invariance, and the eigenvalue-multiset bridge to oq-01).

## Changes
- **Created `index.ts`** — the entry was missing it, so Vite's `import.meta.glob` could not discover the proof (page would not load on the live site).
- **Added `annotations.json`** (6 annotations, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  1. The re-exported cyclic identities `trace_mul_comm` / `trace_mul_cycle` (rectangular case).
  2. `trace_commutator_eq_zero` — tr(A·B − B·A)=0 with honest subtraction; Jacobi's obstruction to AB−BA=I.
  3. `trace_conj_of_isUnit_det` / `trace_eq_of_conj` — similarity invariance in determinant form.
  4. `eigenvalues_units_conj` — similar matrices share the whole eigenvalue multiset (bridge to oq-01), with trace/det shadows.
  5. Cross-dimension ℤ witness (1×1 vs 2×2 products, both trace 11).
  6. Non-commuting pair (A·B≠B·A by `decide`) with equal product-traces 3 and commutator trace 0.
- **Fixed malformed `crossReferences` entry** in meta.json (`id`→`targetId`, moved the paragraph out of `relationship` into `description`).

Recomputed quality 41 → 96. Status/badge/axiomCount unchanged (verified/mathlib, 0 axioms — matches the Lean file: 0 sorries, no axiom decls, `decide` not `native_decide`).