### PR TITLE
Enrich Complete Trichotomy of (n−1)! mod n: add index.ts + annotations

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsTheoremOQ05OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const wilsonsTheoremOQ05OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const wilsonsTheoremOQ05OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const wilsonsTheoremOQ05OQ01Data: ProofData = {
+  proof: wilsonsTheoremOQ05OQ01Proof,
+  annotations: wilsonsTheoremOQ05OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01` (the complete classification of (n−1)! mod n: prime ⇒ n−1, n=4 ⇒ 2, composite ⇒ 0).

## Changes
- **Created `index.ts`** — the entry was missing it, so Vite's `import.meta.glob` could not discover the proof (page would not load on the live site).
- **Added `annotations.json`** (5 annotations, all with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  1. Header trichotomy + the ZMod-free, axiom-free framing vs sibling oq-01.
  2. `mul_dvd_factorial` — the distinct-factors-divide-m! engine.
  3. `dvd_factorial_pred_of_not_prime` — composite case via minFac split, with the (p,2p) substitute pair handling n=p² and the n=4 exception.
  4. `factorial_pred_mod_of_prime` — prime branch transported from Mathlib's ZMod Wilson.
  5. `factorial_pred_mod` + `factorial_pred_mod_eq_zero_iff` — the closed-form trichotomy (n=4 by kernel `decide`) and its sharp converse.

Recomputed quality 41 → 96. meta.json already rich (overview/conclusion/sections/crossReferences); status/badge/axiomCount unchanged (verified/original, 0 axioms — kernel `decide` for n=4, no `native_decide`).