### PR TITLE
Enrich arsinh Calculus Capstone: antiderivative of 1/√(1+x²)

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01/annotations.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "arsinh-cap-ann-header",
+    "proofId": "arsinh-log-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 32
+    },
+    "type": "context",
+    "title": "The arsinh Antiderivative — Open Question and Plan",
+    "content": "States the open question — that arsinh is an antiderivative of 1/√(1+x²), so ∫ 1/√(1+x²) dx = arsinh x + C — and enumerates the capstone results: the antiderivative fact (from Mathlib's hasDerivAt_arsinh), the FTC evaluation ∫_a^b = arsinh b − arsinh a, its logarithmic closed form, the normalised ∫_0^b, the symmetric-interval doubling, and two concrete logarithmic values. The integrand 1/√(1+x²) is the standard one whose antiderivative is the inverse hyperbolic sine, the hyperbolic analogue of arctan for 1/(1+x²).",
+    "mathContext": "$\\int \\frac{dx}{\\sqrt{1+x^2}} = \\operatorname{arsinh} x + C = \\log\\!\\left(x + \\sqrt{1+x^2}\\right) + C$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "inverse hyperbolic sine",
+      "antiderivative",
+      "Real.arsinh",
+      "logarithmic form"
+    ],
+    "prerequisites": [
+      "differentiation",
+      "inverse hyperbolic functions"
+    ]
+  },
+  {
+    "id": "arsinh-cap-ann-antideriv",
+    "proofId": "arsinh-log-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 40,
+      "endLine": 70
+    },
+    "type": "technique",
+    "title": "The Antiderivative Fact and the Integrability API",
+    "content": "Builds the analytic API the FTC will consume. sqrt_one_add_sq_pos: the denominator √(1+x²) > 0 everywhere (so the integrand is well-defined and continuous). hasDerivAt_arsinh' restates Mathlib's hasDerivAt_arsinh in the form HasDerivAt arsinh (1/√(1+x²)) x — the antiderivative fact, and the literal answer to the open question. deriv_arsinh_eq is the deriv-form. continuous_integrand and intervalIntegrable_integrand establish continuity on ℝ and hence interval-integrability on every [a,b].",
+    "mathContext": "$\\operatorname{arsinh}'(x) = \\frac{1}{\\sqrt{1+x^2}}$, with $\\sqrt{1+x^2} > 0$ and the integrand continuous (hence interval-integrable) on $\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Real.hasDerivAt_arsinh",
+      "continuity",
+      "interval integrability",
+      "positivity of the denominator"
+    ],
+    "prerequisites": [
+      "derivative of arsinh",
+      "continuity implies interval-integrability"
+    ]
+  },
+  {
+    "id": "arsinh-cap-ann-ftc",
+    "proofId": "arsinh-log-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 71,
+      "endLine": 112
+    },
+    "type": "insight",
+    "title": "The FTC Evaluation and Its Logarithmic Form",
+    "content": "The capstone. integral_one_div_sqrt_one_add_sq applies the FTC with antiderivative arsinh: ∫_a^b 1/√(1+t²) dt = arsinh b − arsinh a. integral_eq_log_sub_log rewrites via the parent's logarithmic closed form arsinh x = log(x+√(1+x²)). integral_zero_to anchors the lower limit at 0 (so C = 0): ∫_0^b = arsinh b, and integral_zero_to_log gives = log(b+√(1+b²)). integral_symmetric exploits that the integrand is EVEN: ∫_{-a}^a = 2·arsinh a, the doubling identity.",
+    "mathContext": "$\\int_a^b \\frac{dt}{\\sqrt{1+t^2}} = \\operatorname{arsinh} b - \\operatorname{arsinh} a$; $\\int_0^b = \\log(b+\\sqrt{1+b^2})$; $\\int_{-a}^a = 2\\operatorname{arsinh} a$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "fundamental theorem of calculus",
+      "logarithmic closed form",
+      "even integrand",
+      "symmetric interval doubling"
+    ],
+    "prerequisites": [
+      "the antiderivative fact",
+      "arsinh = log(x+√(1+x²))"
+    ]
+  },
+  {
+    "id": "arsinh-cap-ann-concrete",
+    "proofId": "arsinh-log-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 135
+    },
+    "type": "context",
+    "title": "Concrete Logarithmic Evaluations via the (3,4,5) Triple",
+    "content": "Two clean closed-form values that exploit Pythagorean rationalisation of √(1+x²). integral_zero_to_three_quarters: ∫_0^{3/4} = log 2, since √(1+(3/4)²) = √(25/16) = 5/4 and 3/4 + 5/4 = 2. integral_zero_to_four_thirds: ∫_0^{4/3} = log 3, since √(1+(4/3)²) = 5/3 and 4/3 + 5/3 = 3. Both reuse integral_zero_to_log; the (3,4,5) triple is exactly what makes the surd rational and the logarithm a clean integer.",
+    "mathContext": "$\\int_0^{3/4}\\!\\frac{dt}{\\sqrt{1+t^2}} = \\log 2$ (since $\\tfrac34+\\tfrac54=2$); $\\int_0^{4/3} = \\log 3$ (since $\\tfrac43+\\tfrac53=3$).",
+    "significance": "context",
+    "relatedConcepts": [
+      "Pythagorean triple (3,4,5)",
+      "rationalising a surd",
+      "concrete evaluation",
+      "norm_num"
+    ],
+    "prerequisites": [
+      "the normalised logarithmic integral",
+      "Pythagorean triples"
+    ]
+  }
+]

--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-01/meta.json
@@ -161,5 +161,6 @@
     "openQuestions": [
       "Derive the catenary arc-length formula ∫_0^b √(1 + t²) dt = ½(b√(1+b²) + arsinh b) via the arsinh substitution."
     ]
-  }
+  },
+  "description": "The antiderivative of 1/√(1+x²) is the inverse hyperbolic sine: ∫ 1/√(1+x²) dx = arsinh x + C = log(x+√(1+x²)) + C. Starting from Mathlib's hasDerivAt_arsinh, this capstone supplies the antiderivative fact and integrability API, the FTC evaluation ∫_a^b = arsinh b − arsinh a, its logarithmic closed form, the normalised ∫_0^b = log(b+√(1+b²)), the symmetric-interval doubling ∫_{-a}^a = 2·arsinh a, and two concrete values (∫_0^{3/4} = log 2, ∫_0^{4/3} = log 3) that use the (3,4,5) triple to rationalise the surd. Fully verified, 0 axioms, 0 sorries."
 }


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-01` (quality 43, pass 0).

## Gaps addressed
Rich meta.json but **null `description`** and no `annotations.json`.

## Changes
- **Filled the null `description`** with the result summary.
- **Added `annotations.json`** — 4 annotations (mathContext/significance/relatedConcepts/prerequisites), aligned to Lean constructs (resolver: **4 valid, 0 misaligned**):
  1. The arsinh antiderivative — open question and plan
  2. The antiderivative fact + integrability API
  3. The FTC evaluation and its logarithmic form (+ symmetric doubling)
  4. Concrete values ∫_0^{3/4}=log 2, ∫_0^{4/3}=log 3 via the (3,4,5) triple

No `index.ts`: the gallery loader uses the build-generated `data-manifest.json` (issue #20992/#20993), not per-proof shims.

Verified: JSON parses; resolver alignment 4/4.