### PR TITLE
Enrich Kempner–Smarandache Value S(p^k) for Prime Powers: add index.ts + annotations

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "wilson-oq05010101-ann-header",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 37 },
+    "type": "context",
+    "title": "The Kempner–Smarandache value S(p^k) via Legendre",
+    "content": "The parent entry located the Kempner threshold (when S(n) = min{m : n ∣ m!} drops below n) without computing S(n). This entry computes S(p^k) exactly for prime powers, purely from Legendre's formula for the p-adic valuation of a factorial. The headline results: S(p^k) lies in [p, p·k], is ALWAYS a multiple of p, and equals p·k exactly when k ≤ p (with S(p) = p as the k=1 base case). The whole development is driven by one Mathlib identity — Legendre at multiples, v_p((p·n)!) = v_p(n!) + n.",
+    "mathContext": "$S(m) = \\min\\{n : m \\mid n!\\}$; for prime $p$, $k\\ge1$: $p \\le S(p^k) \\le pk$, $p \\mid S(p^k)$, and $S(p^k)=pk \\iff k \\le p$.",
+    "significance": "context",
+    "relatedConcepts": ["Kempner function", "Smarandache function", "Legendre's formula", "p-adic valuation"],
+    "prerequisites": ["factorials and divisibility", "prime-power valuation of n!"]
+  },
+  {
+    "id": "wilson-oq05010101-ann-def",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+    "range": { "startLine": 43, "endLine": 55 },
+    "type": "definition",
+    "title": "The Kempner–Smarandache function via Nat.sInf",
+    "content": "S m := sInf {n | m ∣ n!}, the least n whose factorial is divisible by m. The specification is established by two lemmas: dvd_factorial_S (m ∣ (S m)! for m ≥ 1) shows S m is a genuine witness — the defining set is nonempty because m ∣ m! (Nat.dvd_factorial), so Nat.sInf_mem applies; and S_le (any n with m ∣ n! satisfies S m ≤ n) is the minimality, directly from Nat.sInf_le. Together they pin S as the least element of {n | m ∣ n!}.",
+    "mathContext": "$S(m) = \\inf\\{n \\in \\mathbb{N} \\mid m \\mid n!\\}$; nonempty since $m \\mid m!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sInf", "least-element operator", "Nat.dvd_factorial"],
+    "prerequisites": ["the infimum on ℕ and its membership/minimality lemmas"]
+  },
+  {
+    "id": "wilson-oq05010101-ann-legendre",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 91 },
+    "type": "technique",
+    "title": "Legendre's criterion and the [p, p·k] bounds",
+    "content": "pow_dvd_factorial_iff specializes Mathlib's Nat.Prime.pow_dvd_iff_le_factorization to n! : p^k ∣ n! ↔ k ≤ (n!).factorization p — the bridge from Kempner divisibility to the p-adic valuation. The upper bound S_prime_pow_le (≤ p·k) follows from prime_pow_dvd_factorial_mul: by Legendre at multiples (Nat.factorization_factorial_mul), (p·k)!.factorization p = (k!).factorization p + k ≥ k, so p^k ∣ (p·k)!. The lower bound prime_le_S_prime_pow (p ≤ S) uses Nat.Prime.dvd_factorial: since p ∣ p^k ∣ (S(p^k))!, the prime divides the factorial only when p ≤ S(p^k).",
+    "mathContext": "$p^k \\mid n! \\iff k \\le v_p(n!)$; $v_p((pk)!) = v_p(k!) + k \\ge k$ gives $S(p^k)\\le pk$; $p \\mid (S(p^k))!$ gives $p \\le S(p^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["Legendre's formula", "Nat.factorization_factorial_mul", "Nat.Prime.dvd_factorial", "valuation bounds"],
+    "prerequisites": ["the p-adic valuation of a factorial", "prime-power divisibility criterion"]
+  },
+  {
+    "id": "wilson-oq05010101-ann-multiple",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+    "range": { "startLine": 93, "endLine": 113 },
+    "type": "insight",
+    "title": "S(p^k) is always a multiple of p",
+    "content": "prime_dvd_S_prime_pow is the structural heart: p ∣ S(p^k). The p-adic valuation v_p(m!) is constant as m runs through a block between consecutive multiples of p and only jumps at multiples of p. Writing S(p^k) = t+1, minimality forces v_p(t!) < k while v_p((t+1)!) ≥ k; the multiplicative split factorization_factorial_succ_split — v_p((t+1)!) = v_p(t+1) + v_p(t!) — then forces v_p(t+1) ≥ 1, i.e. p ∣ S(p^k) (via Nat.dvd_of_factorization_pos). This is the precise sense in which 'the largest prime power controls S(n)': the least factorial-divisibility witness can only be a valuation jump point.",
+    "mathContext": "$v_p(m!)$ jumps only at multiples of $p$; the least $m$ with $v_p(m!)\\ge k$ is such a jump, so $p \\mid S(p^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["valuation jumps", "factorization_factorial_succ_split", "Nat.dvd_of_factorization_pos", "minimality argument"],
+    "prerequisites": ["the multiplicative split of a factorial's valuation", "minimality of sInf"]
+  },
+  {
+    "id": "wilson-oq05010101-ann-exact",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 166 },
+    "type": "insight",
+    "title": "The exact value: S(p^k) = p·k ⟺ k ≤ p",
+    "content": "S_prime_pow_eq_mul_iff pins the closed form on its sharp range. (⟸) For k ≤ p, write S(p^k) = p·t with t ≤ k (multiple-of-p + upper bound); were t < k then t < p, so v_p(t!) = 0 (Nat.factorization_factorial_eq_zero_of_lt), contradicting k ≤ v_p(t!) + t = t; hence t = k. (⟹, contrapositive) For k > p, p ∣ (k−1)! gives v_p((k−1)!) ≥ 1, so v_p((p·(k−1))!) = v_p((k−1)!) + (k−1) ≥ k, whence p^k ∣ (p·(k−1))! and S(p^k) ≤ p·(k−1) < p·k. The first failure is k = p+1 (e.g. S(2³)=4<6, S(3⁴)=9<12). S_prime recovers the classical S(p) = p as the k=1 corollary.",
+    "mathContext": "$S(p^k)=pk \\iff k\\le p$; first failure $k=p+1$, e.g. $S(2^3)=4$, $S(3^4)=9$.",
+    "significance": "key",
+    "relatedConcepts": ["sharp boundary", "Nat.factorization_factorial_eq_zero_of_lt", "closed-form value", "base case S(p)=p"],
+    "prerequisites": ["Legendre at multiples", "the multiple-of-p structure", "case analysis on t vs k"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/WilsonsTheoremOQ05OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const wilsonsTheoremOQ05OQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const wilsonsTheoremOQ05OQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const wilsonsTheoremOQ05OQ01OQ01OQ01Data: ProofData = {
+  proof: wilsonsTheoremOQ05OQ01OQ01OQ01Proof,
+  annotations: wilsonsTheoremOQ05OQ01OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01-oq-01-oq-01` (the exact Kempner–Smarandache value S(p^k) for prime powers via Legendre's formula).

## Changes
- **Created `index.ts`** (entry was missing it — page would not load on the live site).
- **Added `annotations.json`** (5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`):
  1. Header — the prime-power value, bounds, multiple-of-p, and k≤p boundary.
  2. `S` definition via `Nat.sInf` with its witness/minimality spec.
  3. `pow_dvd_factorial_iff` Legendre criterion and the [p, p·k] bounds.
  4. `prime_dvd_S_prime_pow` — S(p^k) is always a multiple of p (valuation jumps only at multiples of p).
  5. `S_prime_pow_eq_mul_iff` — S(p^k)=p·k ⟺ k≤p, the sharp boundary (e.g. S(2³)=4<6), plus S(p)=p.

Recomputed quality 41 → 96. meta.json already rich; status/badge/axiomCount unchanged (verified/original, 0 axioms, no native_decide).