### PR TITLE
research(erdos-128-wip-01-oq-01): triangle-freeness pulls back along graph homomorphisms; every C₅-blow-up is triangle-free

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1381,6 +1381,7 @@ import Proofs.Erdos125Problem
 import Proofs.Erdos126Problem
 import Proofs.Erdos127Problem
 import Proofs.Erdos128Problem
+import Proofs.Erdos128WIP01OQ01
 import Proofs.Erdos129Problem
 import Proofs.Erdos12Problem
 import Proofs.Erdos12ProblemAPNPartI

--- a/proofs/Proofs/Erdos128WIP01OQ01.lean
+++ b/proofs/Proofs/Erdos128WIP01OQ01.lean
@@ -1,0 +1,148 @@
+import Mathlib
+
+/-
+# Erdős #128 — triangle-freeness pulls back along graph homomorphisms
+# (erdos-128-wip-01-oq-01)
+
+## The Problem
+
+**Erdős Problem #128** ($250, OPEN). If every induced subgraph of an `n`-vertex
+graph `G` on `≥ ⌊n/2⌋` vertices has more than `n²/50` edges, must `G` contain a
+triangle? The constant `1/50` is conjectured optimal, witnessed by **blow-ups of
+`C₅`**: replace each vertex of the 5-cycle by an independent class and join two
+classes completely exactly when their `C₅`-vertices are adjacent. These blow-ups
+are triangle-free with induced-subgraph density `> 1/50` at every scale.
+
+The parent file `Erdos128WIP01.lean` proved that triangle-freeness is **hereditary**
+(passes to induced subgraphs) and that the edge count is monotone under induction.
+This file isolates the *structural reason the extremal witnesses are triangle-free*:
+triangle-freeness is preserved not only under induced subgraphs but under **arbitrary
+graph homomorphisms**, pulled back along the map. A blow-up is precisely the graph
+whose adjacency is the pullback of the base graph's adjacency along the class map,
+so triangle-freeness of `C₅` transfers to every one of its blow-ups, of every size.
+
+## Result
+
+Working in a self-contained re-declaration of the parent's `Graph` objects:
+
+1. `triangleFree_of_hom` — **triangle-freeness pulls back along homomorphisms.** If
+   there is a graph homomorphism `f : G → H` (adjacent vertices map to adjacent
+   vertices) and `H` is triangle-free, then `G` is triangle-free. (Irreflexivity of
+   `H` supplies the distinctness of the three image vertices, so a triangle of `G`
+   would force a genuine triangle of `H`.) This subsumes the parent's hereditary
+   property: an induced subgraph maps into its ambient graph by the identity.
+
+2. `blowup` / `blowup_isHom` — the **blow-up** of a base graph `H` along a class map
+   `c` is the graph on `Fin n` with `adj u v := H.adj (c u) (c v)`; the class map is
+   a homomorphism `blowup H c → H`.
+
+3. `blowup_triangleFree` — every blow-up of a triangle-free graph is triangle-free.
+
+4. `C5_triangleFree` — the concrete 5-cycle `C₅` is triangle-free (decision procedure).
+
+5. `blowup_C5_triangleFree` — **hence every blow-up of `C₅` is triangle-free**, at
+   every size `n` and for every class assignment `c : Fin n → Fin 5`. This is exactly
+   the triangle-freeness of the conjectured-optimal extremal construction.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos128WIP01OQ01
+
+/-- A simple graph on `n` vertices. -/
+structure Graph (n : ℕ) where
+  adj : Fin n → Fin n → Prop
+  symm : ∀ u v, adj u v → adj v u
+  irrefl : ∀ v, ¬ adj v v
+
+/-- `G` contains a triangle: three distinct, mutually adjacent vertices. -/
+def Graph.hasTriangle {n : ℕ} (G : Graph n) : Prop :=
+  ∃ u v w : Fin n, u ≠ v ∧ v ≠ w ∧ u ≠ w ∧
+    G.adj u v ∧ G.adj v w ∧ G.adj u w
+
+/-- `G` is triangle-free. -/
+def Graph.triangleFree {n : ℕ} (G : Graph n) : Prop := ¬ G.hasTriangle
+
+/-- A **graph homomorphism** `f : G → H`: it carries adjacent vertices to adjacent
+    vertices. (No injectivity or surjectivity is required.) -/
+def IsHom {n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k) : Prop :=
+  ∀ u v, G.adj u v → H.adj (f u) (f v)
+
+/-- **Triangle-freeness pulls back along graph homomorphisms.** If there is a
+    homomorphism `f : G → H` and `H` is triangle-free, then `G` is triangle-free.
+
+    The three image vertices of a `G`-triangle are automatically distinct: each edge
+    of `H` joins distinct endpoints because `H` is irreflexive, so the images form a
+    genuine `H`-triangle — contradicting `H`'s triangle-freeness. This generalises the
+    parent file's hereditary property (`triangleFree_induce`), which is the case where
+    `f` is the identity inclusion of an induced subgraph. -/
+theorem triangleFree_of_hom {n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k)
+    (hf : IsHom G H f) (hH : H.triangleFree) : G.triangleFree := by
+  rintro ⟨u, v, w, -, -, -, a1, a2, a3⟩
+  apply hH
+  have b1 := hf u v a1
+  have b2 := hf v w a2
+  have b3 := hf u w a3
+  refine ⟨f u, f v, f w, ?_, ?_, ?_, b1, b2, b3⟩
+  · intro h; rw [h] at b1; exact H.irrefl (f v) b1
+  · intro h; rw [h] at b2; exact H.irrefl (f w) b2
+  · intro h; rw [h] at b3; exact H.irrefl (f w) b3
+
+/-- The **blow-up** of a base graph `H` along a class map `c : Fin n → Fin k`: two
+    vertices are adjacent exactly when their classes are adjacent in `H`. This is the
+    formal extremal construction — `C₅`-blow-ups arise as `blowup C5 c`. -/
+def blowup {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) : Graph n where
+  adj u v := H.adj (c u) (c v)
+  symm u v h := H.symm (c u) (c v) h
+  irrefl v h := H.irrefl (c v) h
+
+/-- The class map of a blow-up is a graph homomorphism `blowup H c → H`. -/
+theorem blowup_isHom {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) :
+    IsHom (blowup H c) H c := fun u v h => h
+
+/-- **Every blow-up of a triangle-free graph is triangle-free.** A corollary of
+    `triangleFree_of_hom` applied to the class map. -/
+theorem blowup_triangleFree {n k : ℕ} (H : Graph k) (c : Fin n → Fin k)
+    (hH : H.triangleFree) : (blowup H c).triangleFree :=
+  triangleFree_of_hom (blowup H c) H c (blowup_isHom H c) hH
+
+/-- The **5-cycle `C₅`** on `Fin 5`: `i ~ j` iff they are one step apart around the
+    cycle (`i + 1 = j` or `j + 1 = i`, with addition modulo 5). -/
+def C5 : Graph 5 where
+  adj i j := i + 1 = j ∨ j + 1 = i
+  symm u v h := h.symm
+  irrefl := by decide
+
+/-- **`C₅` is triangle-free.** No three vertices of the 5-cycle are mutually adjacent;
+    verified by the decision procedure over `Fin 5` (not `native_decide`). -/
+theorem C5_triangleFree : C5.triangleFree := by
+  unfold Graph.triangleFree Graph.hasTriangle C5
+  decide
+
+/-- **Every blow-up of `C₅` is triangle-free**, for every size `n` and every class
+    assignment `c : Fin n → Fin 5`. This is precisely the triangle-freeness of the
+    conjectured-optimal extremal construction for Erdős #128: the `1/50` constant is
+    expected to be witnessed by `C₅`-blow-ups, and those witnesses are triangle-free
+    at every scale because triangle-freeness pulls back along the class map. -/
+theorem blowup_C5_triangleFree {n : ℕ} (c : Fin n → Fin 5) :
+    (blowup C5 c).triangleFree :=
+  blowup_triangleFree C5 c C5_triangleFree
+
+/-
+## Significance
+
+Erdős #128 asks whether density on every large induced subgraph forces a triangle.
+Its conjecturally optimal constant `1/50` is witnessed by blow-ups of `C₅`. The parent
+file showed triangle-freeness is hereditary; this file identifies the sharper
+structural fact underlying the extremal witnesses: triangle-freeness is preserved
+under **arbitrary graph homomorphisms** (`triangleFree_of_hom`), of which both induced
+subgraphs (identity map) and blow-ups (class map) are instances. Concretely, `C₅` is
+triangle-free (`C5_triangleFree`) and therefore so is every blow-up of it, at every
+size (`blowup_C5_triangleFree`). The remaining, genuinely hard analytic content — that
+these blow-ups achieve induced density `> 1/50`, and that this constant is optimal —
+stays open.
+-/
+
+end Erdos128WIP01OQ01

--- a/src/data/proofs/erdos-128-wip-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "erdos128-wip01oq01-ann-header",
+    "proofId": "erdos-128-wip-01-oq-01",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "context",
+    "title": "Why the extremal witnesses are triangle-free",
+    "content": "Erdős Problem #128 ($250, open) asks whether a uniform edge-density condition on all large induced subgraphs forces a triangle: if every induced subgraph on ≥ ⌊n/2⌋ vertices has more than n²/50 edges, must G contain a triangle? The constant 1/50 is conjectured optimal, witnessed by blow-ups of C₅. The parent entry proved triangle-freeness is hereditary under induced subgraphs; this file isolates the sharper structural fact underneath: triangle-freeness is preserved under arbitrary graph homomorphisms, pulled back along the map. A blow-up is exactly the pullback of adjacency along a class map, so C₅'s triangle-freeness transfers to every blow-up of it.",
+    "mathContext": "Conjectured optimal constant $1/50$; witnesses are blow-ups of $C_5$, triangle-free because triangle-freeness pulls back along the class map $c$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey–Turán theory", "triangle-free graphs", "graph homomorphism", "C₅ blow-up"],
+    "prerequisites": ["graph theory", "extremal combinatorics"]
+  },
+  {
+    "id": "erdos128-wip01oq01-ann-ishom",
+    "proofId": "erdos-128-wip-01-oq-01",
+    "range": { "startLine": 68, "endLine": 71 },
+    "type": "definition",
+    "title": "Graph homomorphism",
+    "content": "A graph homomorphism f : G → H is a vertex map carrying every edge of G to an edge of H (adjacent vertices to adjacent vertices). No injectivity or surjectivity is required. Two important examples are the identity inclusion of an induced subgraph into its ambient graph and the class map of a blow-up.",
+    "mathContext": "$f : G \\to H$ with $\\forall u\\,v,\\ G.\\mathrm{adj}\\,u\\,v \\Rightarrow H.\\mathrm{adj}\\,(f\\,u)\\,(f\\,v)$.",
+    "significance": "standard",
+    "relatedConcepts": ["graph homomorphism", "edge-preserving map"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01-ann-pullback",
+    "proofId": "erdos-128-wip-01-oq-01",
+    "range": { "startLine": 73, "endLine": 94 },
+    "type": "key-step",
+    "title": "Triangle-freeness pulls back along homomorphisms",
+    "content": "If there is a homomorphism f : G → H and H is triangle-free, then G is triangle-free. Given a triangle u,v,w of G, the images f u, f v, f w are mutually adjacent in H. They are automatically distinct: each H-edge joins distinct endpoints because H is irreflexive, so f u = f v would make H.adj (f v) (f v) hold, contradicting irreflexivity. Hence the images form a genuine H-triangle, contradicting H's triangle-freeness. This single theorem subsumes the parent's hereditary property — the identity inclusion of an induced subgraph is a homomorphism.",
+    "mathContext": "$f : G \\to H$ a homomorphism, $H$ triangle-free $\\Rightarrow$ $G$ triangle-free; distinctness of $f\\,u, f\\,v, f\\,w$ from irreflexivity of $H$.",
+    "significance": "key",
+    "relatedConcepts": ["graph homomorphism", "triangle-free graphs", "monotone graph property"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01-ann-blowup",
+    "proofId": "erdos-128-wip-01-oq-01",
+    "range": { "startLine": 96, "endLine": 110 },
+    "type": "definition",
+    "title": "Blow-up of a base graph",
+    "content": "The blow-up of a base graph H along a class map c : Fin n → Fin k joins two vertices exactly when their classes are adjacent in H (adj u v := H.adj (c u) (c v)). This is the pullback of H's adjacency along c, so the class map c is a graph homomorphism blowup H c → H. Consequently every blow-up of a triangle-free graph is triangle-free (blowup_triangleFree), directly from the pullback theorem.",
+    "mathContext": "$\\mathrm{blowup}\\,H\\,c$: $\\mathrm{adj}\\,u\\,v := H.\\mathrm{adj}\\,(c\\,u)\\,(c\\,v)$; the class map is a homomorphism into $H$.",
+    "significance": "important",
+    "relatedConcepts": ["graph blow-up", "C₅ blow-up", "graph homomorphism"],
+    "prerequisites": ["graph theory", "extremal combinatorics"]
+  },
+  {
+    "id": "erdos128-wip01oq01-ann-c5",
+    "proofId": "erdos-128-wip-01-oq-01",
+    "range": { "startLine": 113, "endLine": 133 },
+    "type": "key-step",
+    "title": "C₅ is triangle-free, hence so is every C₅-blow-up",
+    "content": "The 5-cycle C₅ on Fin 5 (i ~ j iff i+1=j or j+1=i mod 5) is triangle-free, checked by the ordinary kernel decision procedure over Fin 5 (decide, not native_decide — so no Lean.ofReduceBool axiom is incurred). Combining with blowup_triangleFree gives the capstone: every blow-up of C₅, at every size n and for every class assignment c : Fin n → Fin 5, is triangle-free (blowup_C5_triangleFree). This is exactly the triangle-freeness of the construction conjectured to witness the optimal constant 1/50 — established as a purely structural fact, independent of the open edge-density estimate.",
+    "mathContext": "$C_5$ triangle-free (finite $\\mathtt{decide}$); $\\forall c : \\mathrm{Fin}\\,n \\to \\mathrm{Fin}\\,5,\\ \\mathrm{blowup}\\,C_5\\,c$ triangle-free.",
+    "significance": "key",
+    "relatedConcepts": ["C₅ blow-up", "triangle-free graphs", "extremal construction", "decision procedure"],
+    "prerequisites": ["graph theory", "Fin arithmetic"]
+  }
+]

--- a/src/data/proofs/erdos-128-wip-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-128-wip-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos128WIP01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos128Wip01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos128Wip01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos128Wip01Oq01Data: ProofData = {
+  proof: erdos128Wip01Oq01Proof,
+  annotations: erdos128Wip01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-128-wip-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01/meta.json
@@ -1,0 +1,107 @@
+{
+  "id": "erdos-128-wip-01-oq-01",
+  "title": "Erdős #128: triangle-freeness pulls back along graph homomorphisms (and every C₅-blow-up is triangle-free)",
+  "slug": "erdos-128-wip-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos128WIP01OQ01",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos128WIP01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Identifies the structural reason the conjectured-optimal extremal witnesses for Erdős Problem #128 ($250, OPEN) are triangle-free. The parent entry erdos-128-wip-01 proved triangle-freeness is hereditary under induced subgraphs and the edge count is monotone. This entry proves the sharper fact those rest on: triangle-freeness is preserved under ARBITRARY graph homomorphisms, pulled back along the map (triangleFree_of_hom) -- if there is a homomorphism f : G -> H and H is triangle-free, then G is triangle-free, the three image vertices being forced distinct by H's irreflexivity. Induced subgraphs (identity inclusion) and blow-ups (class map) are both instances. The blow-up of a base graph H along a class map c is defined (blowup) and its class map is shown to be a homomorphism (blowup_isHom), giving blowup_triangleFree: every blow-up of a triangle-free graph is triangle-free. The concrete 5-cycle C5 on Fin 5 is shown triangle-free by the decision procedure (C5_triangleFree, not native_decide), and combining yields blowup_C5_triangleFree: every blow-up of C5, at every size n and for every class assignment c : Fin n -> Fin 5, is triangle-free -- exactly the triangle-freeness of the extremal construction conjectured to witness the optimal constant 1/50. 5 theorems, 5 definitions + 1 structure, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos128WIP01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "extremal-graph-theory",
+      "triangle-free",
+      "graph-homomorphism",
+      "ramsey-turan",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with `lake env lean Proofs/Erdos128WIP01OQ01.lean` (Lean v4.26.0, Mathlib pin): compiles with 0 errors. 0 sorries, 0 axiom declarations, no native_decide. #print axioms reports: triangleFree_of_hom depends on no axioms at all; C5_triangleFree and blowup_C5_triangleFree depend only on the standard foundational axioms [propext, Quot.sound] (the `decide` evaluation of C₅ over Fin 5 is the ordinary kernel decision procedure, NOT native_decide, so Lean.ofReduceBool is not used). Self-contained: the Graph objects are re-declared (the scaffold Erdos128Problem.lean does not build). Honest scope: the structural homomorphism-pullback fact and the triangle-freeness of the C₅-blow-up witnesses, NOT the open optimal-constant question (that these blow-ups achieve induced density > n²/50, and that 1/50 is optimal, remain open).",
+    "lineCount": 148,
+    "theoremCount": 5,
+    "definitionCount": 5,
+    "originalContributions": [
+      "triangleFree_of_hom: triangle-freeness pulls back along graph homomorphisms -- if f : G -> H is a homomorphism and H is triangle-free then G is triangle-free; the distinctness of the three image vertices is supplied by H's irreflexivity. Generalizes the parent's hereditary property (the identity inclusion of an induced subgraph is a homomorphism).",
+      "blowup / blowup_isHom: the blow-up of a base graph H along a class map c : Fin n -> Fin k (adj u v := H.adj (c u) (c v)); its class map is a graph homomorphism blowup H c -> H.",
+      "blowup_triangleFree: every blow-up of a triangle-free graph is triangle-free (corollary of triangleFree_of_hom applied to the class map).",
+      "C5_triangleFree: the concrete 5-cycle C₅ on Fin 5 (i ~ j iff i+1=j or j+1=i mod 5) is triangle-free, by the kernel decision procedure (not native_decide).",
+      "blowup_C5_triangleFree: hence every blow-up of C₅, at every size n and for every class assignment, is triangle-free -- the triangle-freeness of the conjectured-optimal extremal construction for the 1/50 constant."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #128 is a Ramsey–Turán-type question asking whether a uniform edge-density condition on all large induced subgraphs forces a triangle. The threshold constant 1/50 is conjectured optimal, witnessed by blow-ups of C₅ (and the Petersen graph), which are triangle-free yet have induced-subgraph density about 1/5 > 1/50. A long line of partial results (Erdős-Faudree-Rousseau-Schelp 1/16, Krivelevich, Razborov's flag-algebra 27/1024, Norin-Yepremyan) narrows the constant, but the exact 1/50 remains a $250 open problem. The triangle-freeness of the blow-up witnesses is, at root, the statement that triangle-freeness pulls back along graph homomorphisms.",
+    "problemStatement": "Erdős #128: if every induced subgraph of an n-vertex graph G on >= floor(n/2) vertices has more than n²/50 edges, must G contain a triangle? This entry formalizes why the conjectured extremal witnesses (C₅-blow-ups) are triangle-free: triangle-freeness is preserved under arbitrary graph homomorphisms.",
+    "proofStrategy": "Re-declare the scaffold's Graph/hasTriangle/triangleFree objects (the scaffold does not build). A graph homomorphism f : G -> H carries adjacent vertices to adjacent vertices. Given a triangle u,v,w of G, the images f u, f v, f w are mutually H-adjacent; they are also pairwise distinct because H is irreflexive (an H-edge cannot have equal endpoints), so they form an H-triangle, contradicting H's triangle-freeness (triangleFree_of_hom). A blow-up is the graph whose adjacency is the pullback of the base adjacency along the class map, so its class map is a homomorphism (blowup_isHom) and blowup_triangleFree follows. C₅ on Fin 5 is triangle-free by the finite decision procedure, and blowup_C5_triangleFree is the composition.",
+    "keyInsights": [
+      "Triangle-freeness is a homomorphism-monotone property: a homomorphism G -> H into a triangle-free H forces G triangle-free, because triangles are pulled back and irreflexivity keeps the images distinct.",
+      "Both induced subgraphs (identity inclusion map) and blow-ups (class map) are graph homomorphisms, so a single pullback theorem subsumes the parent's hereditary property and the extremal-witness triangle-freeness.",
+      "A blow-up is precisely a pullback of adjacency along a class map, which is why C₅-blow-ups inherit C₅'s triangle-freeness at every scale and every class assignment.",
+      "The triangle-freeness of the extremal construction is therefore independent of the (open) edge-density estimate; it is a purely structural fact, isolated and machine-checked here."
+    ]
+  },
+  "sections": [
+    {
+      "id": "objects",
+      "title": "Graphs, Triangles, and Homomorphisms (re-declared)",
+      "summary": "Graph, hasTriangle, triangleFree, and the graph-homomorphism predicate IsHom.",
+      "startLine": 55,
+      "endLine": 71,
+      "mathContext": "Self-contained re-declaration; a homomorphism carries adjacent vertices to adjacent vertices."
+    },
+    {
+      "id": "pullback",
+      "title": "Triangle-freeness pulls back along homomorphisms",
+      "summary": "triangleFree_of_hom: a homomorphism into a triangle-free graph forces triangle-freeness; image vertices are distinct by irreflexivity.",
+      "startLine": 73,
+      "endLine": 94,
+      "mathContext": "Generalizes the parent's hereditary property (induced inclusion is a homomorphism)."
+    },
+    {
+      "id": "blowup-c5",
+      "title": "Blow-ups and the C₅ witness",
+      "summary": "blowup, blowup_isHom, blowup_triangleFree, C5_triangleFree, blowup_C5_triangleFree.",
+      "startLine": 96,
+      "endLine": 133,
+      "mathContext": "A blow-up pulls adjacency back along a class map; C₅ is triangle-free, hence so is every blow-up of it."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #128 asks whether dense large induced subgraphs force a triangle, with conjectured-optimal constant 1/50 witnessed by C₅-blow-ups. This entry isolates the structural reason those witnesses are triangle-free: triangle-freeness pulls back along arbitrary graph homomorphisms (triangleFree_of_hom), of which induced subgraphs (identity map) and blow-ups (class map) are both instances. Concretely, C₅ is triangle-free (C5_triangleFree) and therefore so is every blow-up of it, at every size and class assignment (blowup_C5_triangleFree). Self-contained over Mathlib, verified with the ordinary kernel decision procedure (no native_decide), 0 sorries, 0 axioms.",
+    "implications": "Separating the triangle-freeness of the extremal construction from the (open) density estimate gives any formal attack on the optimal constant a verified, reusable foundation: the witness family is triangle-free by a one-line pullback argument, independent of how its edges are counted. The homomorphism-pullback framing also unifies this with the parent entry's hereditary property under a single theorem.",
+    "openQuestions": [
+      "Formalize the edge-density estimate for C₅-blow-ups: that a balanced blow-up has induced-subgraph density > n²/50 on every floor(n/2)-subgraph, completing the lower-bound witness for the 1/50 constant.",
+      "Prove (or formalize a partial result toward) the main question: does density > n²/50 on every floor(n/2)-subgraph force a triangle?",
+      "Generalize the pullback theorem to forbidden subgraphs beyond triangles (K_r-freeness pulls back along homomorphisms whenever the target is irreflexive)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-128-wip-01",
+      "relationship": "parent",
+      "description": "The parent entry proved triangle-freeness is hereditary under induced subgraphs and the edge count is monotone. This entry generalizes the hereditary property to arbitrary graph homomorphisms (the identity inclusion of an induced subgraph being one instance) and uses it to prove every C₅-blow-up is triangle-free."
+    },
+    {
+      "targetId": "erdos-128",
+      "relationship": "related",
+      "description": "The base Erdős #128 scaffold (Graph, edgeCount, induce, hasTriangle, triangleFree, denseSubgraphs and the prose partial results), whose conjectured-optimal extremal witnesses are the C₅-blow-ups shown triangle-free here."
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-128-wip-01.json
+++ b/src/data/research/problems/erdos-128-wip-01.json
@@ -11,25 +11,31 @@
     "whyMatters": []
   },
   "knowledge": {
-    "progressSummary": "Supplied the FIRST theorems for Erdős #128 ($250 open: dense large induced subgraphs force a triangle?). Scaffold Erdos128Problem.lean is prose-only AND fails to build (missing DecidablePred for edgeCount + trailing docstrings). Self-contained re-decl (Classical decidability): hasTriangle_induce (induced triangle => ambient), triangleFree_induce (HEREDITARY -- why C5-blow-ups are triangle-free), edgeCount_induce_le (MONOTONE), triangleFree_of_no_edges. 4 thm/4 def/1 struct, 0 sorries/0 axioms (Classical.choice doesn't count), builds green 7743 jobs.",
+    "progressSummary": "Follow-up entry erdos-128-wip-01-oq-01: proved triangle-freeness pulls back along ARBITRARY graph homomorphisms (triangleFree_of_hom), generalizing the parent hereditary property; defined blow-up as adjacency-pullback along a class map (blowup, blowup_isHom, blowup_triangleFree); proved C5 triangle-free (decide) and hence every C5-blow-up triangle-free at every scale (blowup_C5_triangleFree) -- the triangle-freeness of the conjectured-optimal extremal construction, isolated from the open density estimate. 5 thm/5 def/1 struct, 0 sorries, 0 axioms (propext/Quot.sound only, no native_decide). Kernel-verified via lake env lean.",
     "builtItems": [
       "hasTriangle_induce: induced triangle => ambient triangle",
       "triangleFree_induce: triangle-freeness hereditary",
       "edgeCount_induce_le: edge count monotone under induce",
-      "triangleFree_of_no_edges: empty graph triangle-free"
+      "triangleFree_of_no_edges: empty graph triangle-free",
+      "triangleFree_of_hom: triangle-freeness pulls back along graph homomorphisms (Erdos128WIP01OQ01.lean)",
+      "blowup + blowup_isHom + blowup_triangleFree: blow-up = pullback of adjacency along class map; class map is a homomorphism",
+      "C5_triangleFree + blowup_C5_triangleFree: C5 triangle-free (decide), hence every C5-blow-up triangle-free at every scale"
     ],
     "insights": [
       "Induced adjacency entails ambient adjacency => substructures lift.",
       "Triangle-freeness hereditary = 'no induced subgraph has a triangle' = why C5-blow-up extremal witnesses are triangle-free at every scale.",
-      "Edge-count monotonicity underlies the density hypothesis denseSubgraphs."
+      "Edge-count monotonicity underlies the density hypothesis denseSubgraphs.",
+      "Triangle-freeness is homomorphism-monotone: a homomorphism into a triangle-free graph forces triangle-freeness; the three image vertices are distinct because the target is irreflexive.",
+      "Induced subgraphs (identity map) and blow-ups (class map) are both graph homomorphisms, so one pullback theorem subsumes the parents hereditary property and the extremal-witness triangle-freeness.",
+      "The triangle-freeness of the C5-blow-up extremal construction is a purely structural fact, independent of the open edge-density estimate."
     ],
     "mathlibGaps": [
       "Scaffold Erdos128Problem.lean broken: missing DecidablePred instance for edgeCount filter (G.adj Prop not decidable) + trailing docstrings parse errors."
     ],
     "nextSteps": [
-      "Formalize a partial result toward optimal constant 1/50.",
-      "Formalize the C5-blow-up extremal construction using triangleFree_induce.",
-      "Repair the broken scaffold."
+      "Formalize the edge-density estimate for a balanced C5-blow-up: induced density > n^2/50 on every floor(n/2)-subgraph (the lower-bound witness).",
+      "Generalize triangleFree_of_hom to K_r-freeness pulls back along homomorphisms into irreflexive targets.",
+      "Prove or formalize a partial result toward the main question (density forces a triangle)."
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Follow-up research entry for **Erdős Problem #128** ($250, OPEN): if every induced subgraph of an `n`-vertex graph on `≥ ⌊n/2⌋` vertices has more than `n²/50` edges, must `G` contain a triangle? The conjectured-optimal constant `1/50` is witnessed by blow-ups of `C₅`.

The parent entry `erdos-128-wip-01` proved triangle-freeness is **hereditary** under induced subgraphs and the edge count is monotone. This entry isolates the sharper structural fact underneath — *why the extremal witnesses are triangle-free*: **triangle-freeness pulls back along arbitrary graph homomorphisms.**

## Results (`proofs/Proofs/Erdos128WIP01OQ01.lean`)

- **`triangleFree_of_hom`** — a graph homomorphism `f : G → H` into a triangle-free `H` forces `G` triangle-free. The three image vertices of a `G`-triangle are automatically distinct because `H` is irreflexive, so they form a genuine `H`-triangle. This *subsumes the parent's hereditary property* (an induced subgraph's identity inclusion is a homomorphism).
- **`blowup` / `blowup_isHom` / `blowup_triangleFree`** — the blow-up of `H` along a class map `c` is the pullback of adjacency (`adj u v := H.adj (c u) (c v)`); its class map is a homomorphism, so every blow-up of a triangle-free graph is triangle-free.
- **`C5_triangleFree`** — the concrete 5-cycle `C₅` on `Fin 5` is triangle-free (ordinary kernel `decide`, **not** `native_decide`).
- **`blowup_C5_triangleFree`** — hence **every blow-up of `C₅`**, at every size `n` and class assignment `c : Fin n → Fin 5`, is triangle-free: the triangle-freeness of the conjectured-optimal extremal construction, isolated from the (open) edge-density estimate.

## Verification

- 5 theorems, 5 definitions + 1 structure, **0 sorries, 0 axioms**.
- Kernel-verified with `lake env lean Proofs/Erdos128WIP01OQ01.lean` (Lean v4.26.0, Mathlib pin) — 0 errors.
- `#print axioms`: `triangleFree_of_hom` depends on **no axioms**; `C5_triangleFree` and `blowup_C5_triangleFree` depend only on `[propext, Quot.sound]`. No `sorryAx`, no `Lean.ofReduceBool` (decide is the ordinary kernel procedure).
- Self-contained over Mathlib (re-declares the `Graph` objects, as the scaffold `Erdos128Problem.lean` does not build).

## Files
- `proofs/Proofs/Erdos128WIP01OQ01.lean` (new, verified)
- `src/data/proofs/erdos-128-wip-01-oq-01/{meta.json,annotations.json,index.ts}` (new gallery entry)
- `src/data/research/problems/erdos-128-wip-01.json` (knowledge update)
- `proofs/Proofs.lean` (register the new module)

## Status
**Outcome**: completed (verified follow-up). **Open**: the edge-density estimate (`C₅`-blow-ups achieve induced density `> n²/50`) and the main question (density forces a triangle) remain open.

🤖 Generated by researcher-8