### PR TITLE
Enrich Equality Case of the Weighted Power Mean Chain: add index.ts + annotations

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "wpme-ann-defs",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02",
+    "range": { "startLine": 52, "endLine": 67 },
+    "type": "definition",
+    "title": "The four weighted means",
+    "content": "Four noncomputable definitions mirror the parent file: the weighted harmonic mean WHM = (w₁/a + w₂/b)⁻¹, geometric mean WGM = a^w₁·b^w₂ (using Real.rpow for the real exponents), arithmetic mean WAM = w₁a + w₂b, and quadratic mean WQM = √(w₁a² + w₂b²). The parent established WHM ≤ WGM ≤ WAM ≤ WQM for positive a,b and weights w₁,w₂ > 0 with w₁ + w₂ = 1; this entry characterizes exactly when the chain collapses to a single value.",
+    "mathContext": "$\\mathrm{WHM} = (w_1/a + w_2/b)^{-1},\\ \\mathrm{WGM} = a^{w_1}b^{w_2},\\ \\mathrm{WAM} = w_1a+w_2b,\\ \\mathrm{WQM} = \\sqrt{w_1a^2+w_2b^2}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["power means", "weighted means", "Real.rpow"],
+    "prerequisites": ["real exponentiation rpow", "the parent power-mean chain"]
+  },
+  {
+    "id": "wpme-ann-collapse",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02",
+    "range": { "startLine": 68, "endLine": 95 },
+    "type": "technique",
+    "title": "Every mean collapses to a when a = b",
+    "content": "The backward direction's building blocks: whm/wgm/wam/wqm_eq_of_eq each show that at a = b the corresponding mean equals the common value a, using only the weight-sum constraint w₁ + w₂ = 1. The geometric case uses Real.rpow_add to combine a^w₁·a^w₂ = a^(w₁+w₂) = a^1 = a; the quadratic case uses √((w₁+w₂)a²) = √(a²) = a via Real.sqrt_sq. These supply the 'all four equal a' half of the headline iff.",
+    "mathContext": "At $a=b$: $a^{w_1}a^{w_2}=a^{w_1+w_2}=a$ and $\\sqrt{(w_1+w_2)a^2}=\\sqrt{a^2}=a$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.rpow_add", "Real.sqrt_sq", "weight normalization"],
+    "prerequisites": ["rpow arithmetic", "square root of a square"]
+  },
+  {
+    "id": "wpme-ann-variance",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02",
+    "range": { "startLine": 97, "endLine": 106 },
+    "type": "insight",
+    "title": "The weighted-variance identity",
+    "content": "weighted_variance_eq is the exact algebraic identity w₁a² + w₂b² − (w₁a + w₂b)² = w₁w₂(a−b)² for weights summing to 1 (substitute w₂ = 1 − w₁ and ring). Being an exact equality — not just ≥ 0 — its left side is the weighted variance and its right side vanishes iff a = b. This is the cleanest 'pinch' driving the entire collapse: with nothing beyond ring and Real.sqrt it forces a = b at the WAM = WQM link. Probabilistically it is 'variance = 0 iff the random variable is constant'.",
+    "mathContext": "$w_1a^2 + w_2b^2 - (w_1a+w_2b)^2 = w_1w_2(a-b)^2$, the weighted variance, $\\ge 0$ with equality iff $a=b$.",
+    "significance": "key",
+    "relatedConcepts": ["weighted variance", "Jensen equality case", "two-point distribution"],
+    "prerequisites": ["ring identities", "weight normalization w₁+w₂=1"]
+  },
+  {
+    "id": "wpme-ann-wam-wqm",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02",
+    "range": { "startLine": 108, "endLine": 164 },
+    "type": "insight",
+    "title": "WAM = WQM ⇔ a = b (the zero-variance link)",
+    "content": "wam_eq_wqm_iff is the central link. Forward: both means are nonnegative, so WAM = WQM squares to (w₁a + w₂b)² = w₁a² + w₂b² (via Real.sq_sqrt on the WQM side); the variance identity then gives w₁w₂(a−b)² = 0, and since w₁w₂ > 0 we get a = b. Backward is the collapse-value lemmas. The companion wam_lt_wqm_of_ne upgrades this to the strict gap WAM < WQM whenever a ≠ b — the quadratic mean strictly exceeds the arithmetic mean off the diagonal.",
+    "mathContext": "$w_1a + w_2b = \\sqrt{w_1a^2+w_2b^2} \\iff a=b$; squaring + the variance identity forces $w_1w_2(a-b)^2=0$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.sq_sqrt", "quadratic-arithmetic gap", "strict inequality"],
+    "prerequisites": ["the weighted-variance identity", "squaring a nonnegative equality"]
+  },
+  {
+    "id": "wpme-ann-wgm-wam",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02",
+    "range": { "startLine": 166, "endLine": 252 },
+    "type": "technique",
+    "title": "WGM = WAM and WHM = WGM via AM–GM equality and reciprocal duality",
+    "content": "wgm_eq_wam_iff is the two-variable weighted AM–GM equality case: it instantiates Mathlib's general-Finset Real.geom_mean_eq_arith_mean_weighted_iff' at Fin 2 with weights ![w₁,w₂] and values ![a,b]; equality means every value equals the common mean, i.e. a = b. whm_eq_wgm_iff then reduces the harmonic–geometric link to this one for free via reciprocal duality: WHM(a,b)⁻¹ = WAM(1/a,1/b) and WGM(a,b)⁻¹ = WGM(1/a,1/b) (using Real.div_rpow), so WHM = WGM at (a,b) iff WGM = WAM at (1/a,1/b), iff 1/a = 1/b, iff a = b.",
+    "mathContext": "$a^{w_1}b^{w_2} = w_1a+w_2b \\iff a=b$; and $\\mathrm{WHM}(a,b)^{-1} = \\mathrm{WAM}(1/a,1/b)$ folds the harmonic case into the geometric one.",
+    "significance": "key",
+    "relatedConcepts": ["weighted AM-GM equality", "Real.geom_mean_eq_arith_mean_weighted_iff'", "reciprocal duality", "Fin 2 packaging"],
+    "prerequisites": ["Mathlib's AM-GM equality condition", "Real.div_rpow"]
+  },
+  {
+    "id": "wpme-ann-headline",
+    "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02",
+    "range": { "startLine": 254, "endLine": 306 },
+    "type": "insight",
+    "title": "The chain collapse and the equal-weight specialization",
+    "content": "chain_eq_iff assembles the headline: WHM = WGM ∧ WGM = WAM ∧ WAM = WQM ⇔ a = b. The forward direction needs only the WAM = WQM link (the zero-variance pinch); the backward direction collapses every mean to a via the collapse-value lemmas. all_means_eq_iff packages the full equality. unweighted_chain_eq_iff specializes to w₁ = w₂ = 1/2, recovering the classical textbook statement HM = GM = AM = QM ⇔ a = b in explicit form: 2ab/(a+b) = √(ab) = (a+b)/2 = √((a²+b²)/2) ⟺ a = b.",
+    "mathContext": "$\\mathrm{WHM}=\\mathrm{WGM}=\\mathrm{WAM}=\\mathrm{WQM} \\iff a=b$; at $w_1=w_2=\\tfrac12$, $\\tfrac{2ab}{a+b}=\\sqrt{ab}=\\tfrac{a+b}{2}=\\sqrt{\\tfrac{a^2+b^2}{2}}\\iff a=b$.",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "classical means HM-GM-AM-QM", "chain collapse"],
+    "prerequisites": ["the three individual link characterizations"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/index.ts
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const weightedPowerMeanEqualityProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const weightedPowerMeanEqualityAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const weightedPowerMeanEqualityData: ProofData = {
+  proof: weightedPowerMeanEqualityProof,
+  annotations: weightedPowerMeanEqualityAnnotations,
+}

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02/meta.json
@@ -165,7 +165,7 @@
   ],
   "crossReferences": [
     {
-      "proofId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
       "relationship": "parent",
       "description": "Parent file proving the weighted power mean chain WHM ≤ WGM ≤ WAM ≤ WQM — this file answers its open question #2 on the equality case"
     }


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02` (WHM=WGM=WAM=WQM ⇔ a=b).

## Changes
- **Created `index.ts`** (entry was missing it — page would not load on the live site).
- **Added `annotations.json`** (6 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`): the four mean definitions; the a=b collapse values; the weighted-variance identity w₁a²+w₂b²−(w₁a+w₂b)²=w₁w₂(a−b)²; the WAM=WQM zero-variance link (+strict gap); the WGM=WAM (Mathlib AM-GM equality at Fin 2) and WHM=WGM (reciprocal duality) links; and the headline chain collapse + equal-weight HM=GM=AM=QM specialization.
- **Fixed malformed `crossReferences` entry** (`proofId`→`targetId`).

Recomputed quality 42 → 97. Status/badge/axiomCount unchanged (verified/original, 0 axioms).