### PR TITLE
research(gcd-algorithm-oq-04-oq-01): normalize on k[X] = monic representative [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/GcdAlgorithmOQ04OQ01.lean
+++ b/proofs/Proofs/GcdAlgorithmOQ04OQ01.lean
@@ -1,0 +1,175 @@
+import Mathlib
+
+/-
+# GCDMonoid Normalization on k[X] — the Monic Representative
+
+## Research Problem
+gcd-algorithm-oq-04-oq-01 (extension of gcd-algorithm-oq-04)
+
+## What This Proves
+
+Over a field `k`, the polynomial ring `k[X]` carries a canonical
+`NormalizationMonoid` structure. The abstract `normalize` map and its unit
+`normUnit` are not opaque: they are exactly "make it monic". Concretely, for a
+nonzero polynomial `p`:
+
+  * `normUnit p  = C (leadingCoeff p)⁻¹`              (a constant unit)
+  * `normalize p = C (leadingCoeff p)⁻¹ * p`          (the monic associate)
+  * `normalize p` is monic, and it is the **unique** monic polynomial
+    associated to `p`.
+
+As a consequence, the canonical gcd in `k[X]` — i.e. the *normalized* associate
+of the Euclidean-algorithm gcd — is monic (or `0`), which is exactly the monic
+gcd every textbook algorithm returns.
+
+The parent entry (`gcd-algorithm-oq-04`) established the coherence between the
+`EuclideanDomain` gcd and the `GCDMonoid` gcd and their normalization. This entry
+pins down the *concrete* form of that normalization on `k[X]`.
+
+## Key Mathlib Facts Used
+
+- `Polynomial.coe_normUnit_of_ne_zero` — over a field, `↑(normUnit p) = C (leadingCoeff p)⁻¹`.
+- `normalize_apply` — `normalize x = x * ↑(normUnit x)`.
+- `Polynomial.monic_normalize` — `normalize p` is monic for `p ≠ 0`.
+- `Polynomial.normalize_eq_self_iff_monic`, `Polynomial.Monic.normalize_eq_self`.
+- `normalize_eq_normalize_iff_associated`, `normalize_associated`.
+
+## Axiom Count
+0 axioms, 0 sorries.
+-/
+
+namespace GcdAlgorithmOQ04OQ01
+
+open Polynomial
+
+variable {k : Type*} [Field k] [DecidableEq k]
+
+/-! ## Part I: The normalization unit is the inverse leading coefficient
+
+In a `NormalizationMonoid`, `normUnit x` is the unit witnessing that
+`normalize x` is the canonical associate of `x`. For `k[X]` over a field, this
+unit is the *constant* polynomial whose value is the inverse leading coefficient.
+-/
+
+/-- The normalization unit of a nonzero polynomial over a field is the constant
+polynomial of the inverse leading coefficient. -/
+theorem normUnit_eq_C_inv_leadingCoeff {p : k[X]} (hp : p ≠ 0) :
+    (↑(normUnit p) : k[X]) = C (leadingCoeff p)⁻¹ :=
+  coe_normUnit_of_ne_zero hp
+
+/-! ## Part II: `normalize` is "divide by the leading coefficient"
+
+This is the headline identity: the abstract normalized associate of `p` is the
+explicit monic polynomial obtained by scaling `p` by `(leadingCoeff p)⁻¹`.
+-/
+
+/-- **Headline.** Over a field, the normalized associate of a nonzero polynomial
+is the monic polynomial `(leadingCoeff p)⁻¹ • p`, written with `C`. -/
+theorem normalize_eq_C_inv_leadingCoeff_mul {p : k[X]} (hp : p ≠ 0) :
+    normalize p = C (leadingCoeff p)⁻¹ * p := by
+  rw [normalize_apply, normUnit_eq_C_inv_leadingCoeff hp, mul_comm]
+
+/-- The `p = 0` convention: `normalize 0 = 0` (and `leadingCoeff 0 = 0`). -/
+theorem normalize_zero_poly : normalize (0 : k[X]) = 0 := normalize_zero
+
+/-! ## Part III: The normalized associate is monic -/
+
+/-- The normalized associate of a nonzero polynomial is monic. -/
+theorem monic_normalize_poly {p : k[X]} (hp : p ≠ 0) : (normalize p).Monic :=
+  monic_normalize hp
+
+/-- The leading coefficient of `normalize p` is `1` when `p ≠ 0`
+(an equivalent restatement of monicity). -/
+theorem leadingCoeff_normalize_eq_one {p : k[X]} (hp : p ≠ 0) :
+    leadingCoeff (normalize p) = 1 :=
+  monic_normalize_poly hp
+
+/-- `normalize p` is associated to `p`: it has the same divisors. -/
+theorem normalize_associated_poly (p : k[X]) : Associated (normalize p) p :=
+  normalize_associated p
+
+/-! ## Part IV: `normalize p` is the *unique* monic associate
+
+`normalize` selects the canonical representative of the associate class; over a
+field that representative is the unique monic one. We record both the
+characterization `normalize p = p ↔ p.Monic` and the uniqueness statement.
+-/
+
+/-- Characterization: a nonzero polynomial equals its own normalization iff it is
+already monic. -/
+theorem normalize_eq_self_iff {p : k[X]} (hp : p ≠ 0) :
+    normalize p = p ↔ p.Monic :=
+  normalize_eq_self_iff_monic hp
+
+/-- **Uniqueness.** Any monic polynomial associated to `p` is exactly `normalize p`.
+Combined with `monic_normalize_poly` and `normalize_associated_poly`, this says
+`normalize p` is *the* monic associate of `p`. -/
+theorem eq_normalize_of_monic_associated {p q : k[X]}
+    (hq : q.Monic) (h : Associated p q) : q = normalize p := by
+  have hpq : normalize p = normalize q := normalize_eq_normalize_iff_associated.2 h
+  rw [hpq, hq.normalize_eq_self]
+
+/-- Existence-and-uniqueness packaged: for `p ≠ 0` there is a unique monic
+polynomial associated to `p`, namely `normalize p`. -/
+theorem exists_unique_monic_associate {p : k[X]} (hp : p ≠ 0) :
+    ∃! m : k[X], m.Monic ∧ Associated m p := by
+  refine ⟨normalize p, ⟨monic_normalize_poly hp, normalize_associated_poly p⟩, ?_⟩
+  rintro m ⟨hm, hassoc⟩
+  exact eq_normalize_of_monic_associated hm (hassoc.symm)
+
+/-! ## Part V: The canonical gcd over a field is monic
+
+`EuclideanDomain.gcd` runs the Euclidean algorithm but need not return a monic
+result. The *canonical* gcd is its normalized associate, `normalize (gcd p q)`,
+which is the monic gcd. We work with the `GCDMonoid` coming from
+`EuclideanDomain.gcdMonoid` (a `def`, brought in via `letI`, exactly as in the
+parent entry), so that `GCDMonoid.gcd = EuclideanDomain.gcd`.
+-/
+
+/-- The normalized Euclidean gcd of two polynomials over a field is monic whenever
+it is nonzero — i.e. the canonical gcd is the monic gcd. -/
+theorem monic_normalize_gcd {p q : k[X]}
+    (hpq : EuclideanDomain.gcd p q ≠ 0) :
+    (normalize (EuclideanDomain.gcd p q)).Monic :=
+  monic_normalize hpq
+
+/-- Explicit monic form of the canonical gcd: it is `(leadingCoeff g)⁻¹ • g`
+where `g = EuclideanDomain.gcd p q`. -/
+theorem normalize_gcd_eq {p q : k[X]} (hpq : EuclideanDomain.gcd p q ≠ 0) :
+    normalize (EuclideanDomain.gcd p q)
+      = C (leadingCoeff (EuclideanDomain.gcd p q))⁻¹ * EuclideanDomain.gcd p q :=
+  normalize_eq_C_inv_leadingCoeff_mul hpq
+
+/-- The canonical (monic) gcd is associated to the Euclidean gcd, hence divides
+both arguments and is a true gcd. -/
+theorem normalize_gcd_dvd_left (p q : k[X]) :
+    normalize (EuclideanDomain.gcd p q) ∣ p :=
+  (normalize_associated_poly _).dvd.trans (EuclideanDomain.gcd_dvd_left p q)
+
+theorem normalize_gcd_dvd_right (p q : k[X]) :
+    normalize (EuclideanDomain.gcd p q) ∣ q :=
+  (normalize_associated_poly _).dvd.trans (EuclideanDomain.gcd_dvd_right p q)
+
+/-- Universal property of the canonical gcd: any common divisor divides it. -/
+theorem dvd_normalize_gcd {p q d : k[X]} (hp : d ∣ p) (hq : d ∣ q) :
+    d ∣ normalize (EuclideanDomain.gcd p q) :=
+  (EuclideanDomain.dvd_gcd hp hq).trans (associated_normalize _).dvd
+
+/-! ## Part VI: Worked examples over ℚ -/
+
+/-- A monic polynomial is its own normalization. -/
+example : normalize (X + C 1 : ℚ[X]) = X + C 1 :=
+  (monic_X_add_C (1 : ℚ)).normalize_eq_self
+
+/-- The scalar multiple `C 2 * X` normalizes to the monic `X`. -/
+example : normalize (C 2 * X : ℚ[X]) = X := by
+  have hp : (C 2 * X : ℚ[X]) ≠ 0 := by
+    apply mul_ne_zero
+    · simp
+    · exact X_ne_zero
+  rw [normalize_eq_C_inv_leadingCoeff_mul hp, leadingCoeff_mul, leadingCoeff_C,
+    leadingCoeff_X, ← mul_assoc, ← C_mul]
+  have h2 : ((2 : ℚ) * 1)⁻¹ * 2 = 1 := by norm_num
+  rw [h2, C_1, one_mul]
+
+end GcdAlgorithmOQ04OQ01

--- a/research/problems/gcd-algorithm-oq-04-oq-01/knowledge.md
+++ b/research/problems/gcd-algorithm-oq-04-oq-01/knowledge.md
@@ -1,0 +1,51 @@
+# Knowledge: gcd-algorithm-oq-04-oq-01
+
+GCDMonoid Normalization on k[X] — the Monic Representative.
+
+## Summary
+
+**Status**: COMPLETED (verified, 0 axioms, 0 sorries).
+
+The abstract `NormalizationMonoid` structure on `k[X]` over a field is concretely
+"make it monic by dividing by the leading coefficient". Proved
+`normUnit p = C (leadingCoeff p)⁻¹`, the headline
+`normalize p = C (leadingCoeff p)⁻¹ * p`, monicity and uniqueness of the monic
+associate (`∃!`), and the monic-gcd corollary (the normalized Euclidean gcd is
+monic, divides both arguments, and satisfies the universal property).
+
+## Session 2026-06-23 (Session 1) — FRESH
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Surveyed Mathlib's `Polynomial.FieldDivision` and `GCDMonoid.Basic`.
+- Found the entire result is assembled from existing Mathlib lemmas; no new
+  infrastructure needed.
+- Wrote `proofs/Proofs/GcdAlgorithmOQ04OQ01.lean` (14 theorems, 2 examples, 175 lines).
+- Kernel-verified via `lake env lean -Dexperimental.module=true`: 0 errors.
+- `#print axioms` on the headline / uniqueness / gcd theorems: all
+  `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `ofReduceBool`).
+- Created gallery entry `src/data/proofs/gcd-algorithm-oq-04-oq-01/`.
+
+### Key Findings / Mathlib lemmas used
+- `Polynomial.coe_normUnit_of_ne_zero` : `↑(normUnit p) = C (leadingCoeff p)⁻¹` over a field.
+- `normalize_apply` : `normalize x = x * ↑(normUnit x)`.
+- `Polynomial.monic_normalize`, `Polynomial.normalize_eq_self_iff_monic`,
+  `Polynomial.Monic.normalize_eq_self`.
+- `normalize_eq_normalize_iff_associated`, `normalize_associated`, `associated_normalize`.
+- The canonical gcd is `normalize (EuclideanDomain.gcd p q)`; `k[X]` over a field
+  has no global `NormalizedGCDMonoid` instance (gcdMonoid is a `def`), so the
+  monic gcd is expressed via `normalize` of the Euclidean gcd, with divisibility
+  transferred along the associate `normalize(gcd) ~ gcd`.
+
+### Files Modified
+- `proofs/Proofs/GcdAlgorithmOQ04OQ01.lean` (new)
+- `src/data/proofs/gcd-algorithm-oq-04-oq-01/meta.json` (new)
+- `src/data/proofs/gcd-algorithm-oq-04-oq-01/annotations.json` (new)
+
+### Next Steps (follow-up open questions)
+- Characterize normalization on `ℤ[X]` (UFD, non-field base) via content × primitive
+  part and Gauss's lemma.
+- Upgrade the monic-gcd identification to an algorithmic/definitional statement.
+- Canonical normalized gcd on `k[X1,...,Xn]` via a monomial order.

--- a/src/data/proofs/gcd-algorithm-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-04-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-gcd-oq0401-preamble",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 53 },
+    "type": "concept",
+    "title": "Normalization on k[X] is 'Make it Monic'",
+    "content": "The module docstring frames the goal: identify the abstract NormalizationMonoid structure on the polynomial ring k[X] over a field k with the concrete operation of dividing by the leading coefficient. In any NormalizationMonoid, every element x has a canonical associate normalize x = x * normUnit x, where normUnit x is a unit. The parent entry (gcd-algorithm-oq-04) studied the coherence between EuclideanDomain.gcd and GCDMonoid.gcd abstractly and asked, as an open question, whether the k[X] normalization (choosing a monic representative) has a canonical algebraic characterization. This entry answers yes: normUnit p = C (leadingCoeff p)⁻¹ and normalize p = C (leadingCoeff p)⁻¹ * p, so normalize selects the unique monic associate, and the canonical gcd is therefore the monic gcd.",
+    "mathContext": "For $p \\neq 0$ in $k[X]$: $\\operatorname{normUnit}(p) = C(\\operatorname{lc}(p)^{-1})$ and $\\operatorname{normalize}(p) = C(\\operatorname{lc}(p)^{-1}) \\cdot p$, the monic associate. The $p = 0$ case uses $\\operatorname{normalize}(0) = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["NormalizationMonoid", "normalize", "normUnit", "Polynomial.Monic", "leadingCoeff"],
+    "prerequisites": ["Lean 4 typeclass system", "NormalizationMonoid typeclass", "Polynomial API", "Mathlib import"]
+  },
+  {
+    "id": "ann-gcd-oq0401-normunit",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 54, "endLine": 70 },
+    "type": "insight",
+    "title": "Part I: The Normalization Unit is a Constant",
+    "content": "normUnit_eq_C_inv_leadingCoeff proves that for a nonzero polynomial p over a field, the normalization unit ↑(normUnit p) equals the constant polynomial C (leadingCoeff p)⁻¹. This is a thin wrapper over Mathlib's Polynomial.coe_normUnit_of_ne_zero. The key conceptual point: over a field, the unit group of k[X] is exactly the nonzero constants, so the only normalization available is rescaling by a scalar — it never changes the degree or the roots of p, only its leading coefficient.",
+    "mathContext": "$\\uparrow(\\operatorname{normUnit}(p)) = C(\\operatorname{lc}(p)^{-1})$. Units of $k[X]$ are $\\{C(c) : c \\in k^\\times\\}$, so normalization is multiplication by a constant.",
+    "significance": "key",
+    "relatedConcepts": ["normUnit", "units of k[X]", "leadingCoeff", "constant polynomial C"],
+    "prerequisites": ["normUnit in NormalizationMonoid", "Polynomial.coe_normUnit_of_ne_zero"]
+  },
+  {
+    "id": "ann-gcd-oq0401-normalize-formula",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 71, "endLine": 90 },
+    "type": "insight",
+    "title": "Part II: Headline — normalize p = C (leadingCoeff p)⁻¹ * p",
+    "content": "normalize_eq_C_inv_leadingCoeff_mul is the headline identity: the abstract normalized associate of a nonzero polynomial is the explicit monic polynomial obtained by dividing through by the leading coefficient. The proof rewrites normalize_apply (normalize p = p * normUnit p), substitutes the Part I form of normUnit, and commutes the product. normalize_zero_poly records the p = 0 convention normalize 0 = 0, which is forced because leadingCoeff 0 = 0 has no inverse.",
+    "mathContext": "$\\operatorname{normalize}(p) = p \\cdot \\operatorname{normUnit}(p) = p \\cdot C(\\operatorname{lc}(p)^{-1}) = C(\\operatorname{lc}(p)^{-1}) \\cdot p$. The monic associate divides $p$ by its leading coefficient, making the new leading coefficient $1$.",
+    "significance": "critical",
+    "relatedConcepts": ["normalize_apply", "monic associate", "leadingCoeff", "normalize 0 = 0"],
+    "prerequisites": ["normalize_apply", "Part I normUnit identity", "ring commutativity"]
+  },
+  {
+    "id": "ann-gcd-oq0401-monic",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 91, "endLine": 110 },
+    "type": "insight",
+    "title": "Part III: The Normalized Associate is Monic",
+    "content": "monic_normalize_poly establishes (normalize p).Monic for p ≠ 0 (via Mathlib's monic_normalize), and leadingCoeff_normalize_eq_one restates this as leadingCoeff (normalize p) = 1. normalize_associated_poly records that normalize p is associated to p, so it has exactly the same divisors. Together these say normalize p is a monic associate of p — the existence half of the characterization completed in Part IV.",
+    "mathContext": "$\\operatorname{normalize}(p)$ is monic and $\\operatorname{normalize}(p) \\sim p$ (associated). Monicity is the defining property of the canonical representative; association preserves divisibility behaviour.",
+    "significance": "key",
+    "relatedConcepts": ["Polynomial.Monic", "monic_normalize", "Associated", "normalize_associated"],
+    "prerequisites": ["Polynomial.monic_normalize", "normalize_associated"]
+  },
+  {
+    "id": "ann-gcd-oq0401-uniqueness",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 111, "endLine": 139 },
+    "type": "insight",
+    "title": "Part IV: normalize p is the Unique Monic Associate",
+    "content": "normalize_eq_self_iff characterizes nonzero fixed points of normalize as exactly the monic polynomials. eq_normalize_of_monic_associated proves uniqueness: any monic q associated to p must equal normalize p — the proof turns the association into normalize p = normalize q via normalize_eq_normalize_iff_associated, then uses Monic.normalize_eq_self to collapse normalize q to q. exists_unique_monic_associate packages existence (Part III) and uniqueness into a single ∃! statement: a nonzero polynomial has exactly one monic associate, namely normalize p.",
+    "mathContext": "For $p \\neq 0$: $\\operatorname{normalize}(p) = p \\iff p$ monic; and $\\exists!\\, m,\\ m\\text{ monic} \\wedge m \\sim p$, with $m = \\operatorname{normalize}(p)$. Uniqueness uses $\\operatorname{normalize}(x) = \\operatorname{normalize}(y) \\iff x \\sim y$.",
+    "significance": "critical",
+    "relatedConcepts": ["uniqueness up to associates", "normalize_eq_normalize_iff_associated", "Monic.normalize_eq_self", "ExistsUnique"],
+    "prerequisites": ["normalize_eq_normalize_iff_associated", "Monic.normalize_eq_self", "normalize_eq_self_iff_monic"]
+  },
+  {
+    "id": "ann-gcd-oq0401-monic-gcd",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 140, "endLine": 168 },
+    "type": "insight",
+    "title": "Part V: The Canonical gcd is Monic",
+    "content": "The Euclidean-algorithm gcd EuclideanDomain.gcd p q need not be monic, so the canonical gcd is its normalized associate normalize(EuclideanDomain.gcd p q). monic_normalize_gcd proves this is monic when nonzero; normalize_gcd_eq gives its explicit monic form C (leadingCoeff g)⁻¹ * g. The remaining theorems show it genuinely is a gcd: normalize_gcd_dvd_left/right transfer divisibility of p and q across the associate normalize(gcd) ~ gcd, and dvd_normalize_gcd proves the universal property (every common divisor of p and q divides the canonical gcd). This is exactly the monic gcd every textbook polynomial-gcd algorithm returns.",
+    "mathContext": "Canonical gcd $= \\operatorname{normalize}(\\gcd(p,q)) = C(\\operatorname{lc}(\\gcd)^{-1}) \\cdot \\gcd(p,q)$, monic and $\\sim \\gcd(p,q)$, hence divides $p$ and $q$ and absorbs every common divisor.",
+    "significance": "critical",
+    "relatedConcepts": ["EuclideanDomain.gcd", "monic gcd", "gcd universal property", "Associated.dvd"],
+    "prerequisites": ["EuclideanDomain.gcd_dvd_left/right", "EuclideanDomain.dvd_gcd", "Parts II–III"]
+  },
+  {
+    "id": "ann-gcd-oq0401-examples",
+    "proofId": "gcd-algorithm-oq-04-oq-01",
+    "range": { "startLine": 169, "endLine": 175 },
+    "type": "example",
+    "title": "Part VI: Worked Examples over ℚ",
+    "content": "Two concrete checks over ℚ. First, a monic polynomial X + C 1 is its own normalization (via Monic.normalize_eq_self with monic_X_add_C). Second, C 2 * X normalizes to the monic X: the headline identity gives C 2⁻¹ * (C 2 * X), and computing the leading coefficient (2 · 1 = 2) and simplifying the constant (2⁻¹ · 2 = 1) collapses it to X. These illustrate both the monic fixed-point case and a genuine rescaling.",
+    "mathContext": "$\\operatorname{normalize}(X + 1) = X + 1$ (already monic); $\\operatorname{normalize}(2X) = X$ (rescale by $\\tfrac12$).",
+    "significance": "supporting",
+    "relatedConcepts": ["monic_X_add_C", "leadingCoeff_mul", "worked example"],
+    "prerequisites": ["headline identity Part II", "Monic.normalize_eq_self"]
+  }
+]

--- a/src/data/proofs/gcd-algorithm-oq-04-oq-01/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-04-oq-01/meta.json
@@ -1,0 +1,185 @@
+{
+  "id": "gcd-algorithm-oq-04-oq-01",
+  "title": "GCDMonoid Normalization on k[X]: the Monic Representative",
+  "slug": "gcd-algorithm-oq-04-oq-01",
+  "description": "Pins down the abstract `NormalizationMonoid` structure on the polynomial ring k[X] over a field k as the familiar 'make it monic' operation. For nonzero p, proves normUnit p = C (leadingCoeff p)⁻¹ and the headline identity normalize p = C (leadingCoeff p)⁻¹ * p — the unique monic associate of p. Derives existence-and-uniqueness of the monic associate, and concludes that the canonical gcd in k[X] (the normalized associate of the Euclidean-algorithm gcd) is monic, divides both arguments, and satisfies the gcd universal property.",
+  "meta": {
+    "author": "Lean Genius (formalized in Lean 4)",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GcdAlgorithmOQ04OQ01.lean",
+    "tags": [
+      "algebra",
+      "gcd",
+      "gcd-monoid",
+      "euclidean-domain",
+      "polynomials",
+      "normalization",
+      "monic",
+      "typeclass-coherence",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. All results fully machine-verified; every theorem depends only on the standard foundational triple [propext, Classical.choice, Quot.sound].",
+    "lineCount": 175,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-23",
+    "originalContributions": [
+      "normalize_eq_C_inv_leadingCoeff_mul: headline identity normalize p = C (leadingCoeff p)⁻¹ * p over a field — the abstract normalization is concretely 'divide by the leading coefficient'",
+      "eq_normalize_of_monic_associated: any monic polynomial associated to p equals normalize p (uniqueness of the monic associate)",
+      "exists_unique_monic_associate: existence-and-uniqueness of the monic associate of a nonzero polynomial, packaged as ∃!",
+      "monic_normalize_gcd / normalize_gcd_eq: the canonical gcd in k[X] is monic with explicit form C (leadingCoeff g)⁻¹ * g",
+      "normalize_gcd_dvd_left/right and dvd_normalize_gcd: the canonical monic gcd genuinely is a gcd (divides both arguments and absorbs common divisors)"
+    ],
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "NormalizationMonoid typeclass: normalize and normUnit",
+      "Polynomial.leadingCoeff, Polynomial.Monic, Polynomial.C",
+      "EuclideanDomain.gcd and the Euclidean algorithm on k[X]",
+      "Associated elements; normalize_eq_normalize_iff_associated"
+    ]
+  },
+  "overview": {
+    "historicalContext": "When a textbook computes gcd(f, g) of two polynomials over a field, it always returns a *monic* polynomial — the leading coefficient is divided out so the answer is canonical. This convention is older than abstract algebra: it is what makes the polynomial gcd unique rather than defined only up to a nonzero scalar. Mathlib encodes the canonical-representative idea abstractly through the `NormalizationMonoid` typeclass, where every element x has a distinguished associate `normalize x` together with a unit `normUnit x` realizing it. For the polynomial ring k[X] over a field, Mathlib installs a `NormalizationMonoid` instance whose `normUnit` is the constant polynomial C(leadingCoeff⁻¹). The parent entry (gcd-algorithm-oq-04) studied the coherence between the Euclidean-domain gcd and the GCDMonoid gcd in the abstract; one of its open questions asked whether the normalization on k[X] — choosing a monic representative — admits a canonical algebraic characterization. This entry answers that affirmatively and concretely: the abstract `normalize` on k[X] is exactly 'make it monic by dividing by the leading coefficient', and the canonical gcd is therefore the monic gcd every algorithm returns.",
+    "problemStatement": "For a field k and the polynomial ring k[X], characterize the normalization map: prove that for nonzero p, normUnit p = C (leadingCoeff p)⁻¹ and normalize p = C (leadingCoeff p)⁻¹ * p, that normalize p is the unique monic polynomial associated to p, and conclude that the canonical gcd in k[X] is monic and satisfies the gcd universal property.",
+    "keyInsights": [
+      "Over a field, normUnit of a nonzero polynomial is the *constant* unit C(leadingCoeff⁻¹) — normalization rescales by a scalar, never changing degree or roots",
+      "normalize p = C (leadingCoeff p)⁻¹ * p makes the abstract normalized associate completely explicit: it is the monic polynomial obtained by dividing through by the leading coefficient",
+      "normalize p is the *unique* monic associate of p; uniqueness follows from normalize_eq_normalize_iff_associated together with Monic.normalize_eq_self",
+      "The canonical gcd of polynomials is normalize(EuclideanDomain.gcd p q) — monic when nonzero, associated to the raw Euclidean gcd, hence a genuine gcd satisfying the universal property",
+      "The p = 0 edge case is handled by the normalize 0 = 0 convention (leadingCoeff 0 = 0 has no inverse), so the monic identification is stated for p ≠ 0"
+    ],
+    "proofStrategy": "Six parts. (I) normUnit p = C (leadingCoeff p)⁻¹ via Mathlib's coe_normUnit_of_ne_zero. (II) headline normalize p = C (leadingCoeff p)⁻¹ * p by normalize_apply + the normUnit form + commutativity. (III) monicity of normalize p via monic_normalize. (IV) characterization normalize p = p ↔ Monic p and uniqueness of the monic associate via normalize_eq_normalize_iff_associated. (V) the canonical gcd: monicity, explicit form, divisibility of both arguments, and the universal property, all transferred across the associate normalize(gcd) ~ gcd. (VI) worked examples over ℚ."
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Overview: Normalization is 'Make it Monic'",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Module docstring explaining that the abstract NormalizationMonoid structure on k[X] is concretely 'divide by the leading coefficient', listing the Mathlib lemmas used. Imports Mathlib, opens Polynomial, fixes a field k with DecidableEq.",
+      "mathContext": "In any NormalizationMonoid each element has a canonical associate normalize x = x * normUnit x. For k[X] over a field, normUnit is the constant inverse-leading-coefficient unit, so normalize selects the monic associate. The module makes this identification explicit and derives the monic-gcd corollary."
+    },
+    {
+      "id": "normunit",
+      "title": "Part I: The Normalization Unit",
+      "startLine": 54,
+      "endLine": 70,
+      "summary": "normUnit p = C (leadingCoeff p)⁻¹ for nonzero p over a field — the normalization unit is a constant polynomial.",
+      "mathContext": "Direct application of Mathlib's Polynomial.coe_normUnit_of_ne_zero. Establishes that normalization rescales by the scalar (leadingCoeff p)⁻¹, embedded as a constant polynomial via C."
+    },
+    {
+      "id": "normalize-formula",
+      "title": "Part II: normalize is 'Divide by the Leading Coefficient'",
+      "startLine": 71,
+      "endLine": 90,
+      "summary": "Headline identity normalize p = C (leadingCoeff p)⁻¹ * p for p ≠ 0, plus the normalize 0 = 0 convention.",
+      "mathContext": "normalize_apply gives normalize p = p * normUnit p; substituting the Part I form and commuting yields the monic associate C (leadingCoeff p)⁻¹ * p. The zero case records the leadingCoeff-0-has-no-inverse convention."
+    },
+    {
+      "id": "monic",
+      "title": "Part III: The Normalized Associate is Monic",
+      "startLine": 91,
+      "endLine": 110,
+      "summary": "normalize p is monic for p ≠ 0; equivalently leadingCoeff (normalize p) = 1; and normalize p is associated to p.",
+      "mathContext": "Uses Polynomial.monic_normalize and normalize_associated. Monicity is the defining property of the canonical representative, and association guarantees the same divisibility behaviour as p."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Part IV: normalize p is the Unique Monic Associate",
+      "startLine": 111,
+      "endLine": 139,
+      "summary": "Characterization normalize p = p ↔ Monic p, uniqueness eq_normalize_of_monic_associated, and the packaged ∃! statement exists_unique_monic_associate.",
+      "mathContext": "normalize_eq_normalize_iff_associated reduces associate-equality to normalize-equality; combined with Monic.normalize_eq_self this forces any monic associate of p to coincide with normalize p, giving existence-and-uniqueness of the monic representative."
+    },
+    {
+      "id": "monic-gcd",
+      "title": "Part V: The Canonical gcd is Monic",
+      "startLine": 140,
+      "endLine": 168,
+      "summary": "The canonical gcd normalize(EuclideanDomain.gcd p q) is monic when nonzero, has explicit monic form, divides both p and q, and absorbs every common divisor (universal property).",
+      "mathContext": "EuclideanDomain.gcd need not be monic; its normalized associate is. Monicity from monic_normalize; divisibility transferred along the associate normalize(gcd) ~ gcd using normalize_associated and EuclideanDomain.gcd_dvd_left/right and dvd_gcd. This is the textbook monic gcd."
+    },
+    {
+      "id": "examples",
+      "title": "Part VI: Worked Examples over ℚ",
+      "startLine": 169,
+      "endLine": 175,
+      "summary": "A monic polynomial is its own normalization; C 2 * X normalizes to the monic X.",
+      "mathContext": "Concrete sanity checks of the headline identity over ℚ, illustrating both the monic-fixed-point case and a genuine rescaling."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gcd-algorithm-oq-04",
+      "relationship": "extends",
+      "description": "Parent proof: coherence of EuclideanDomain gcd vs GCDMonoid gcd and their normalization. This entry answers its open question about characterizing the k[X] normalization concretely as the monic representative."
+    },
+    {
+      "targetId": "gcd-algorithm",
+      "relationship": "related",
+      "description": "Euclidean algorithm for natural numbers — the foundational gcd algorithm whose polynomial analogue produces the monic gcd characterized here."
+    },
+    {
+      "targetId": "gcd-algorithm-oq-02",
+      "relationship": "related",
+      "description": "Binary GCD (Stein's algorithm) — alternative gcd algorithm raising the same normalization question of which canonical representative to return."
+    }
+  ],
+  "conclusion": {
+    "summary": "The abstract NormalizationMonoid structure on k[X] over a field is concretely 'make it monic': normUnit p = C (leadingCoeff p)⁻¹ and normalize p = C (leadingCoeff p)⁻¹ * p, the unique monic associate of p. Consequently the canonical gcd of polynomials — the normalized associate of the Euclidean-algorithm gcd — is monic and satisfies the gcd universal property, matching the textbook convention.",
+    "implications": "This removes the gap between the abstract typeclass normalization of the parent entry and the familiar monic-gcd convention. It gives a computable, degree-preserving description of the canonical representative on k[X], and shows the gcd Mathlib's GCDMonoid machinery should return (when normalized) is exactly the monic gcd.",
+    "openQuestions": [
+      "Over a non-field base such as ℤ[X] (a UFD but not a Euclidean domain), the normalization combines a content/unit factor with the primitive part; can the normalize map be characterized as (sign of leading coeff) × (content normalization) and tied cleanly to Gauss's lemma?",
+      "Can the monic-gcd identification be upgraded to an algorithmic statement: that the monic output of the polynomial Euclidean algorithm equals normalize(EuclideanDomain.gcd p q) definitionally, not just up to associates?",
+      "For k[X1,...,Xn] over a field (a UFD, not Euclidean for n ≥ 2), is there a canonical normalized gcd analogous to the monic representative, e.g. via a fixed monomial order making the gcd's leading monomial coefficient 1?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib4: Polynomial.FieldDivision",
+      "note": "coe_normUnit_of_ne_zero, monic_normalize, normalize_eq_self_iff_monic, Monic.normalize_eq_self for k[X]"
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "Mathlib4: GCDMonoid.Basic",
+      "note": "normalize, normUnit, normalize_apply, normalize_associated, normalize_eq_normalize_iff_associated"
+    }
+  ],
+  "leanFile": {
+    "imports": ["Mathlib"],
+    "opens": ["Polynomial"],
+    "namespace": "GcdAlgorithmOQ04OQ01",
+    "lineCount": 175,
+    "axiomCount": 0,
+    "theoremCount": 14,
+    "definitionCount": 0,
+    "path": "Proofs/GcdAlgorithmOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "normalize_eq_C_inv_leadingCoeff_mul",
+      "type": "core",
+      "description": "Over a field, the normalized associate of a nonzero polynomial is the monic polynomial C (leadingCoeff p)⁻¹ * p",
+      "leanType": "∀ {k : Type*} [Field k] [DecidableEq k] {p : k[X]}, p ≠ 0 → normalize p = C (leadingCoeff p)⁻¹ * p"
+    },
+    {
+      "name": "exists_unique_monic_associate",
+      "type": "core",
+      "description": "A nonzero polynomial over a field has a unique monic associate, namely normalize p",
+      "leanType": "∀ {k : Type*} [Field k] [DecidableEq k] {p : k[X]}, p ≠ 0 → ∃! m : k[X], m.Monic ∧ Associated m p"
+    },
+    {
+      "name": "monic_normalize_gcd",
+      "type": "core",
+      "description": "The canonical (normalized) gcd of two polynomials over a field is monic whenever it is nonzero",
+      "leanType": "∀ {k : Type*} [Field k] [DecidableEq k] {p q : k[X]}, EuclideanDomain.gcd p q ≠ 0 → (normalize (EuclideanDomain.gcd p q)).Monic"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extension of `gcd-algorithm-oq-04`. Pins down the abstract `NormalizationMonoid` structure on the polynomial ring `k[X]` over a field as the familiar **"make it monic"** operation, answering an open question of the parent entry.

For nonzero `p`:
- `normUnit p = C (leadingCoeff p)⁻¹` — the normalization unit is a constant.
- **Headline:** `normalize p = C (leadingCoeff p)⁻¹ * p` — the monic associate.
- `normalize p` is the **unique** monic polynomial associated to `p` (packaged as `∃!`).
- **Monic gcd corollary:** the canonical gcd `normalize (EuclideanDomain.gcd p q)` is monic when nonzero, divides both arguments, and satisfies the gcd universal property — the monic gcd every textbook algorithm returns.

## Verification

- 14 theorems, 2 examples, 0 definitions, **0 axioms, 0 sorries**, 175 lines.
- Kernel-verified with `lake env lean -Dexperimental.module=true` (Mathlib v4.26.0): 0 errors.
- `#print axioms` on the headline / uniqueness / monic-gcd theorems: all depend only on `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `Lean.ofReduceBool`).

## Files

- `proofs/Proofs/GcdAlgorithmOQ04OQ01.lean` (new)
- `src/data/proofs/gcd-algorithm-oq-04-oq-01/{meta,annotations}.json` (new gallery entry)
- `research/problems/gcd-algorithm-oq-04-oq-01/knowledge.md` (session notes)

## Method

Pure assembly of existing Mathlib lemmas (`Polynomial.coe_normUnit_of_ne_zero`, `normalize_apply`, `monic_normalize`, `normalize_eq_normalize_iff_associated`, `Monic.normalize_eq_self`) — no new infrastructure required. The divisibility of the monic gcd is transferred along the associate `normalize(gcd) ~ gcd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)