### PR TITLE
Enrich Genuine Coverage Kills the Minimal-Collision Witness: add index.ts + annotations

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "dissect-oq010101-ann-header",
+    "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 70 },
+    "type": "context",
+    "title": "Does the minimal-collision witness survive real coverage?",
+    "content": "The gallery result minimal_collision_achievable (OQ-01-01) builds a CubeDissection with exactly 2 colliding cubes, but its covers_unit_cube field is the placeholder True — the cubes do not actually fill the unit cube. This entry replaces that placeholder with a genuine volumetric coverage predicate ∑ c.side³ = 1 and asks whether the witness survives. It does not: the published example occupies under 7% of the unit cube. The predicate is shown satisfiable (the unit cube, 0 collisions), the known witness is shown to fail it, and a new cardinality bound proves any genuine minimal-collision dissection needs ≥ 3 cubes.",
+    "mathContext": "Replace placeholder $\\texttt{covers\\_unit\\_cube} : \\texttt{True}$ with the volumetric tiling condition $\\sum_{c} \\mathrm{side}(c)^3 = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["squaring the square", "cube dissection", "Wiedijk #82", "placeholder vs genuine coverage"],
+    "prerequisites": ["axis-aligned cube geometry", "the parent minimal-collision result"]
+  },
+  {
+    "id": "dissect-oq010101-ann-structure",
+    "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
+    "range": { "startLine": 71, "endLine": 97 },
+    "type": "definition",
+    "title": "GeoCubeDissection with volumetric coverage",
+    "content": "GeoCubeDissection keeps the combinatorial constraints of CubeDissection (all cubes contained in the unit cube, pairwise interior-disjoint) but replaces the True placeholder with the real coverage field volume_fills : ∑ c.size³ = 1. For pairwise interior-disjoint cubes inside [0,1]³ this is exactly the necessary condition for filling the unit cube, and is measure-sufficient. The forgetful map toCubeDissection discharges covers_unit_cube by trivial, letting the existing collidingCubes and HasMinimalCollision machinery be reused unchanged.",
+    "mathContext": "$\\texttt{volume\\_fills} : \\sum_{c \\in \\text{cubes}} c.\\mathrm{size}^3 = 1$, the necessary (measure-sufficient under disjointness) tiling condition.",
+    "significance": "key",
+    "relatedConcepts": ["volumetric coverage", "measure tiling", "forgetful map", "structure refinement"],
+    "prerequisites": ["Finset of cubes", "interior disjointness"]
+  },
+  {
+    "id": "dissect-oq010101-ann-satisfiable",
+    "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
+    "range": { "startLine": 98, "endLine": 145 },
+    "type": "technique",
+    "title": "The predicate is satisfiable — the unit cube",
+    "content": "unitGeoDissection is the single unit cube [0,1]³ as one tile: it satisfies volume_fills (sum over the singleton is 1³ = 1) and is therefore a genuine, non-vacuous witness that the coverage predicate is realizable. unitGeo_no_collision shows it has empty collidingCubes (a single tile has no second cube to share its size), and unitGeo_not_minimal concludes it does not have minimal collision (card ∅ = 0 ≠ 2). Satisfiability matters: it rules out the predicate being vacuously false, so the subsequent obstruction is real content, not an empty constraint.",
+    "mathContext": "$\\{[0,1]^3\\}$: $\\sum \\mathrm{side}^3 = 1^3 = 1$, $\\text{collidingCubes} = \\varnothing$.",
+    "significance": "supporting",
+    "relatedConcepts": ["satisfiability", "Finset.sum_singleton", "non-vacuous predicate"],
+    "prerequisites": ["singleton Finset sums", "the collidingCubes definition"]
+  },
+  {
+    "id": "dissect-oq010101-ann-fails",
+    "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
+    "range": { "startLine": 146, "endLine": 174 },
+    "type": "insight",
+    "title": "The minimal-collision witness fails genuine coverage",
+    "content": "exampleCubes_volume_ne_one computes the total volume of the OQ-01-01 minimal-collision set {cubeA, cubeB, cubeC} (sizes 1/4, 1/4, 1/3): peeling the 3-term Finset sum via Finset.sum_insert (using the existing distinctness lemmas cubeA_ne_cubeB etc.) and norm_num gives 2·(1/4)³ + (1/3)³ = 59/864 ≈ 0.068 ≠ 1. The headline no_geo_with_exampleCubes then concludes no GeoCubeDissection can have that cube set — its volume_fills field would contradict the computed volume. The combinatorial 2-collision witness is therefore NOT geometric: replacing True with real coverage destroys it.",
+    "mathContext": "$2\\cdot(1/4)^3 + (1/3)^3 = \\tfrac{59}{864} \\approx 0.068 \\ne 1$, so no $\\texttt{GeoCubeDissection}$ has this cube set.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_insert", "volume obstruction", "non-geometric witness"],
+    "prerequisites": ["the OQ-01-01 example cubes", "peeling a Finset sum"]
+  },
+  {
+    "id": "dissect-oq010101-ann-openq",
+    "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
+    "range": { "startLine": 176, "endLine": 203 },
+    "type": "context",
+    "title": "The open question, restated under genuine coverage",
+    "content": "Restates the surviving open problem: does there exist a genuine GeoCubeDissection that is nonempty and HasMinimalCollision (exactly 2 colliding cubes)? The parent ≥2 lower bound (at_least_two_colliding_cubes) transfers to GeoCubeDissection via toCubeDissection, so the only way minimal collision can fail for a genuine multi-cube tiling is by EXCEEDING two. Whether the geometry forces a strict excess — Littlewood's cascade heuristic — remains open. The ≥2 bound is referenced only in prose and deliberately not re-exported, because it depends on the two geometric axioms of DissectionOfCubes.lean, keeping every result in this file 0-axiom.",
+    "mathContext": "Open: $\\exists\\, g : \\texttt{GeoCubeDissection},\\ g.\\text{cubes}.\\text{Nonempty} \\wedge \\texttt{HasMinimalCollision}\\ g$?",
+    "significance": "context",
+    "relatedConcepts": ["Littlewood's cascade", "axiom hygiene", "open problem isolation"],
+    "prerequisites": ["the parent lower bound", "HasMinimalCollision"]
+  },
+  {
+    "id": "dissect-oq010101-ann-cardinality",
+    "proofId": "dissection-of-cubes-oq-01-oq-01-oq-01",
+    "range": { "startLine": 205, "endLine": 284 },
+    "type": "insight",
+    "title": "The colliding pair alone cannot fill: ≥ 3 cubes",
+    "content": "The new cardinality bound, from coverage alone. side_sum_le_one shows two interior-disjoint cubes in [0,1]³ have side sum a + b ≤ 1, by rcasing the 6-way separating-axis disjunction and linarith. two_disjoint_volume_lt_one then gives a³ + b³ = (a+b)³ − 3ab(a+b) < 1 strictly (the cross term 3ab(a+b) is positive, and (a+b)³ ≤ 1 by pow_le_one₀). Hence geo_card_ne_two: no GeoCubeDissection has exactly 2 cubes (Finset.card_eq_two + Finset.sum_pair would force a³+b³ = 1, contradicting <1). The headline minimal_collision_needs_three: collidingCubes ⊆ cubes gives card ≥ 2, geo_card_ne_two rules out =2, so any genuine minimal-collision dissection has ≥ 3 cubes — the colliding pair plus a third, distinct-sized cube.",
+    "mathContext": "Disjoint cubes in $[0,1]^3$: $a+b\\le1$, so $a^3+b^3 = (a+b)^3 - 3ab(a+b) < 1$; thus no 2-cube tiling, and minimal collision needs $\\ge 3$ cubes.",
+    "significance": "key",
+    "relatedConcepts": ["separating-axis disjunction", "pow_le_one₀", "Finset.card_eq_two", "cardinality lower bound"],
+    "prerequisites": ["interior disjointness case analysis", "the cubic identity a³+b³=(a+b)³−3ab(a+b)"]
+  }
+]

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DissectionOfCubesOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const dissectionOfCubesOQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const dissectionOfCubesOQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const dissectionOfCubesOQ01OQ01OQ01Data: ProofData = {
+  proof: dissectionOfCubesOQ01OQ01OQ01Proof,
+  annotations: dissectionOfCubesOQ01OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `dissection-of-cubes-oq-01-oq-01-oq-01` (replacing the True coverage placeholder with genuine volumetric coverage ∑ side³ = 1).

## Changes
- **Created `index.ts`** (entry was missing it — page would not load on the live site).
- **Added `annotations.json`** (6 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`): the header question; the `GeoCubeDissection` volumetric structure + forgetful map; the unit-cube satisfiability witness (0 collisions); the 59/864 volume obstruction killing the OQ-01-01 example; the restated open question with its axiom hygiene; and the new ≥3-cube cardinality bound (`side_sum_le_one`, `two_disjoint_volume_lt_one`, `geo_card_ne_two`, `minimal_collision_needs_three`).

Recomputed quality 42 → 97. meta.json already rich (crossReferences correct); status/badge/axiomCount unchanged (verified/original, 0 axioms).