### PR TITLE
research(euler-totient-oq-09-oq-01): gcd product formula + sharp iff φ(mn)=mφ(n) ⟺ m.primeFactors⊆n.primeFactors

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2675,6 +2675,7 @@ import Proofs.EulerTotientOQ05
 import Proofs.EulerTotientOQ06
 import Proofs.EulerTotientOQ07
 import Proofs.EulerTotientOQ09
+import Proofs.EulerTotientOQ09OQ01
 import Proofs.FactorRemainderNullstellensatzOQ01
 import Proofs.FactorRemainderNullstellensatzOQ02
 import Proofs.FactorRemainderTheorem

--- a/proofs/Proofs/EulerTotientOQ09OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ09OQ01.lean
@@ -1,0 +1,162 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Nat.PrimeFin
+import Mathlib.Tactic
+import Proofs.EulerTotientOQ09
+
+/-!
+# Totient of a product via `gcd`, and exactly when `φ(m·n) = m·φ(n)`
+
+**Open Question (`euler-totient-oq-09-oq-01`)**, an extension of
+`euler-totient-oq-09`.  Mathlib has the *coprime* multiplicative law
+`Nat.totient_mul` (`φ(mn) = φ(m)φ(n)` when `gcd(m,n) = 1`), and the parent entry
+`euler-totient-oq-09` proved the power law `φ(nᵏ) = nᵏ⁻¹·φ(n)` together with its
+engine
+
+  `totient_mul_of_primeFactors_subset` :
+      `m.primeFactors ⊆ n.primeFactors → φ(m·n) = m·φ(n)`.
+
+This file fills the gap between coprimality and the prime-power law in two ways.
+
+## Contents
+
+* `totient_mul_mul_totient_gcd` — the **general product formula**
+  `φ(m·n)·φ(gcd m n) = gcd(m,n)·φ(m)·φ(n)`, the exact non-coprime correction
+  factor (a commutative rearrangement of Mathlib's
+  `Nat.totient_gcd_mul_totient_mul`).  When `gcd(m,n) = 1` it collapses to
+  `Nat.totient_mul`.
+
+* `totient_mul_eq_iff_primeFactors_subset` — the **sharp characterisation**: for
+  `n ≠ 0`,
+  `φ(m·n) = m·φ(n) ↔ m.primeFactors ⊆ n.primeFactors`.
+  The `←` direction is precisely the parent's engine; the new content is the `→`
+  direction, which we obtain through Euler's rational product formula
+  `(φ n : ℚ) = n·∏_{p ∣ n}(1 − 1/p)`.  Writing `(m·n).primeFactors` as the union
+  `m.primeFactors ∪ n.primeFactors`, the identity forces
+  `∏_{p ∈ m.primeFactors ∖ n.primeFactors}(1 − 1/p) = 1`; but every such factor
+  lies strictly in `(0, 1)`, so a nonempty product would be `< 1`.  Hence the
+  index set is empty, i.e. `m.primeFactors ⊆ n.primeFactors`.
+
+* `totient_mul_eq_iff_primeFactors_subset'` — the symmetric statement
+  `φ(m·n) = n·φ(m) ↔ n.primeFactors ⊆ m.primeFactors` (for `m ≠ 0`).
+
+Fully machine-checked: `0` sorries, `0` axioms (only the foundational
+`propext`, `Classical.choice`, `Quot.sound`; no `native_decide`).
+-/
+
+namespace EulerTotientOQ09OQ01
+
+open Nat
+
+/-- A finite product of reals each strictly between `0` and `1`, over a nonempty
+index set, is strictly less than `1`.  (Stated over `ℚ` with the index type `ℕ`,
+which is all we need below.) -/
+private lemma prod_lt_one_aux :
+    ∀ (s : Finset ℕ) (f : ℕ → ℚ), s.Nonempty →
+      (∀ p ∈ s, 0 < f p) → (∀ p ∈ s, f p < 1) → ∏ p ∈ s, f p < 1 := by
+  intro s f
+  classical
+  induction s using Finset.induction with
+  | empty => intro hne; exact absurd hne (by simp)
+  | @insert a t ha ih =>
+    intro _ hpos hlt
+    rw [Finset.prod_insert ha]
+    have hfa0 : 0 < f a := hpos a (Finset.mem_insert_self a t)
+    have hfa1 : f a < 1 := hlt a (Finset.mem_insert_self a t)
+    rcases t.eq_empty_or_nonempty with rfl | ht
+    · simpa using hfa1
+    · have hpt : ∏ p ∈ t, f p < 1 :=
+        ih ht (fun p hp => hpos p (Finset.mem_insert_of_mem hp))
+          (fun p hp => hlt p (Finset.mem_insert_of_mem hp))
+      have hpt0 : 0 < ∏ p ∈ t, f p :=
+        Finset.prod_pos (fun p hp => hpos p (Finset.mem_insert_of_mem hp))
+      nlinarith [hfa0, hfa1, hpt, hpt0]
+
+/-- For a prime `p`, the Euler factor `1 - 1/p` is positive. -/
+private lemma one_sub_inv_pos {p : ℕ} (hp : p.Prime) : (0 : ℚ) < 1 - (p : ℚ)⁻¹ := by
+  have h2 : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp.two_le
+  have hp0 : (0 : ℚ) < (p : ℚ) := by linarith
+  have hpinv : (p : ℚ) * (p : ℚ)⁻¹ = 1 := mul_inv_cancel₀ (ne_of_gt hp0)
+  nlinarith [hpinv, h2, inv_pos.mpr hp0]
+
+/-- For a prime `p`, the Euler factor `1 - 1/p` is less than `1`. -/
+private lemma one_sub_inv_lt_one {p : ℕ} (hp : p.Prime) : (1 : ℚ) - (p : ℚ)⁻¹ < 1 := by
+  have h2 : (2 : ℚ) ≤ (p : ℚ) := by exact_mod_cast hp.two_le
+  have hp0 : (0 : ℚ) < (p : ℚ) := by linarith
+  have := inv_pos.mpr hp0
+  linarith
+
+/-- If the Euler product over `m.primeFactors ∖ n.primeFactors` equals `1`, that
+difference set is empty, i.e. `m.primeFactors ⊆ n.primeFactors`. -/
+private lemma primeFactors_subset_of_prod_eq_one {m n : ℕ}
+    (h : ∏ p ∈ m.primeFactors \ n.primeFactors, (1 - (p : ℚ)⁻¹) = 1) :
+    m.primeFactors ⊆ n.primeFactors := by
+  rw [← Finset.sdiff_eq_empty_iff_subset]
+  by_contra hne
+  have hne' : (m.primeFactors \ n.primeFactors).Nonempty :=
+    Finset.nonempty_iff_ne_empty.mpr hne
+  have hlt :=
+    prod_lt_one_aux (m.primeFactors \ n.primeFactors) (fun p => 1 - (p : ℚ)⁻¹) hne'
+      (fun p hp => one_sub_inv_pos (Nat.prime_of_mem_primeFactors (Finset.mem_sdiff.mp hp).1))
+      (fun p hp => one_sub_inv_lt_one (Nat.prime_of_mem_primeFactors (Finset.mem_sdiff.mp hp).1))
+  rw [h] at hlt
+  exact lt_irrefl 1 hlt
+
+/-- **General product formula for the totient.**  The non-coprime correction
+factor is governed by the `gcd`:
+`φ(m·n)·φ(gcd m n) = gcd(m,n)·φ(m)·φ(n)`.
+
+This is a commutative rearrangement of Mathlib's `Nat.totient_gcd_mul_totient_mul`.
+When `gcd(m,n) = 1` it reduces to the coprime law `Nat.totient_mul`. -/
+theorem totient_mul_mul_totient_gcd (m n : ℕ) :
+    φ (m * n) * φ (Nat.gcd m n) = Nat.gcd m n * φ m * φ n := by
+  calc φ (m * n) * φ (m.gcd n)
+      = φ (m.gcd n) * φ (m * n) := by ring
+    _ = φ m * φ n * m.gcd n := Nat.totient_gcd_mul_totient_mul m n
+    _ = m.gcd n * φ m * φ n := by ring
+
+/-- **Sharp characterisation.**  For `n ≠ 0`,
+`φ(m·n) = m·φ(n)` holds **iff** every prime dividing `m` already divides `n`,
+i.e. `m.primeFactors ⊆ n.primeFactors`.
+
+The `←` direction is the parent engine `totient_mul_of_primeFactors_subset`;
+the `→` direction goes through Euler's rational product formula. -/
+theorem totient_mul_eq_iff_primeFactors_subset {m n : ℕ} (hn : n ≠ 0) :
+    φ (m * n) = m * φ n ↔ m.primeFactors ⊆ n.primeFactors := by
+  constructor
+  · intro heq
+    rcases eq_or_ne m 0 with rfl | hm
+    · simp
+    -- Cast the totient identity to `ℚ` and expand via Euler's product formula.
+    have hQ : (φ (m * n) : ℚ) = (m : ℚ) * (φ n : ℚ) := by exact_mod_cast heq
+    rw [totient_eq_mul_prod_factors (m * n), totient_eq_mul_prod_factors n,
+      Nat.primeFactors_mul hm hn] at hQ
+    push_cast at hQ
+    apply primeFactors_subset_of_prod_eq_one
+    -- Notation: the `n`-product is positive (each prime factor is `> 1`).
+    have hm0 : (m : ℚ) ≠ 0 := by exact_mod_cast hm
+    have hn0 : (n : ℚ) ≠ 0 := by exact_mod_cast hn
+    have hQpos : (0 : ℚ) < ∏ p ∈ n.primeFactors, (1 - (p : ℚ)⁻¹) :=
+      Finset.prod_pos fun p hp => one_sub_inv_pos (Nat.prime_of_mem_primeFactors hp)
+    -- Split the union product `m.pf ∪ n.pf` as `(m.pf ∖ n.pf) · n.pf`.
+    rw [← Finset.prod_sdiff (Finset.subset_union_right (s₁ := m.primeFactors)
+        (s₂ := n.primeFactors)), Finset.union_sdiff_right] at hQ
+    -- Cancel the common nonzero factor `m·n·∏_{n.pf}` to isolate the difference product.
+    have hc0 : (m : ℚ) * n * (∏ p ∈ n.primeFactors, (1 - (p : ℚ)⁻¹)) ≠ 0 :=
+      mul_ne_zero (mul_ne_zero hm0 hn0) (ne_of_gt hQpos)
+    have hDc :
+        (∏ p ∈ m.primeFactors \ n.primeFactors, (1 - (p : ℚ)⁻¹))
+          * ((m : ℚ) * n * ∏ p ∈ n.primeFactors, (1 - (p : ℚ)⁻¹))
+        = 1 * ((m : ℚ) * n * ∏ p ∈ n.primeFactors, (1 - (p : ℚ)⁻¹)) := by
+      rw [one_mul]; linear_combination hQ
+    exact mul_right_cancel₀ hc0 hDc
+  · intro h
+    exact EulerTotientOQ09.totient_mul_of_primeFactors_subset h
+
+/-- The symmetric form of the characterisation: for `m ≠ 0`,
+`φ(m·n) = n·φ(m) ↔ n.primeFactors ⊆ m.primeFactors`. -/
+theorem totient_mul_eq_iff_primeFactors_subset' {m n : ℕ} (hm : m ≠ 0) :
+    φ (m * n) = n * φ m ↔ n.primeFactors ⊆ m.primeFactors := by
+  rw [mul_comm m n]
+  exact totient_mul_eq_iff_primeFactors_subset hm
+
+end EulerTotientOQ09OQ01

--- a/src/data/proofs/euler-totient-oq-09-oq-01/annotations.json
+++ b/src/data/proofs/euler-totient-oq-09-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "totient-oq0901-ann-header",
+    "proofId": "euler-totient-oq-09-oq-01",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "concept",
+    "title": "Totient on Non-Coprime Products: gcd Correction and the Sharp iff",
+    "content": "Euler's totient is multiplicative only on coprime arguments; on a general product the failure is governed by gcd(m,n). This file answers the first open question of the parent oq-09 with two results: the isolated-gcd product formula φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n), and the characterization φ(m·n) = m·φ(n) ⟺ m.primeFactors ⊆ n.primeFactors (for n ≠ 0). The proof rests on the product formula φ(n)/n = ∏_{p∣n}(1 − 1/p), which depends only on the prime support of n. Imports Totient/PrimeFin/Tactic plus the parent module (whose engine is reused for the ⟸ direction); opens Nat so φ = Nat.totient.",
+    "mathContext": "$\\varphi(mn)\\,\\varphi(\\gcd(m,n)) = \\gcd(m,n)\\,\\varphi(m)\\,\\varphi(n); \\qquad \\varphi(mn) = m\\,\\varphi(n) \\iff m.\\mathrm{primeFactors} \\subseteq n.\\mathrm{primeFactors}.$",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "product formula", "gcd correction factor", "prime support"],
+    "prerequisites": ["totient function", "prime factorization", "gcd"]
+  },
+  {
+    "id": "totient-oq0901-ann-strict-product",
+    "proofId": "euler-totient-oq-09-oq-01",
+    "range": { "startLine": 52, "endLine": 106 },
+    "type": "lemma",
+    "title": "Strict ℚ-Product Helpers for Necessity",
+    "content": "The necessity (⟹) direction needs that a nonempty finite product of Euler factors, each strictly in (0,1), is < 1. Mathlib's `Finset.prod_lt_one` is stated for ordered multiplicative groups (ℚ under multiplication is not one), so `prod_lt_one_aux` proves it directly by induction on the Finset, closing the step with `nlinarith` from positivity and the per-factor bounds. `one_sub_inv_pos`/`one_sub_inv_lt_one` certify 0 < 1 − 1/p < 1 for prime p (using p ≥ 2 and p·p⁻¹ = 1). `primeFactors_subset_of_prod_eq_one` then concludes: if the product over m.primeFactors ∖ n.primeFactors equals 1, that difference set is empty — else the strict bound contradicts it — hence m.primeFactors ⊆ n.primeFactors via `Finset.sdiff_eq_empty_iff_subset`.",
+    "mathContext": "$\\prod_{p \\in S}\\left(1 - \\tfrac1p\\right) = 1 \\text{ with } S \\subseteq \\text{primes} \\implies S = \\varnothing.$",
+    "significance": "critical",
+    "relatedConcepts": ["strict finite product", "Euler factor", "Finset induction", "sdiff_eq_empty_iff_subset"],
+    "prerequisites": ["Finset.prod_pos", "nlinarith", "prime p ≥ 2"]
+  },
+  {
+    "id": "totient-oq0901-ann-gcd-formula",
+    "proofId": "euler-totient-oq-09-oq-01",
+    "range": { "startLine": 107, "endLine": 121 },
+    "type": "theorem",
+    "title": "The General Product Formula via gcd",
+    "content": "`totient_mul_mul_totient_gcd`: φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n), holding for all m, n. The proof is a three-step `calc` that commutes the factors of Mathlib's `Nat.totient_gcd_mul_totient_mul` (φ(gcd)·φ(m·n) = φ(m)·φ(n)·gcd), with `ring` over ℕ discharging the rearrangements. This is the exact non-coprime correction to multiplicativity: when gcd(m,n) = 1 it collapses (φ(1) = 1) to the coprime law `Nat.totient_mul`, and it is stated in the symmetric isolated-gcd form requested by the parent's open question.",
+    "mathContext": "$\\varphi(mn)\\,\\varphi(\\gcd(m,n)) = \\gcd(m,n)\\,\\varphi(m)\\,\\varphi(n).$",
+    "significance": "key",
+    "relatedConcepts": ["non-coprime correction", "totient_gcd_mul_totient_mul", "coprime multiplicativity"],
+    "prerequisites": ["Nat.totient_gcd_mul_totient_mul", "ring over ℕ"]
+  },
+  {
+    "id": "totient-oq0901-ann-iff",
+    "proofId": "euler-totient-oq-09-oq-01",
+    "range": { "startLine": 122, "endLine": 156 },
+    "type": "theorem",
+    "title": "The Sharp Characterization φ(m·n) = m·φ(n)",
+    "content": "`totient_mul_eq_iff_primeFactors_subset` (n ≠ 0): φ(m·n) = m·φ(n) ⟺ m.primeFactors ⊆ n.primeFactors. The ⟸ direction is the parent engine `EulerTotientOQ09.totient_mul_of_primeFactors_subset` applied verbatim. For ⟹, after the m = 0 case, cast the identity to ℚ and expand both totients via `Nat.totient_eq_mul_prod_factors`; `Nat.primeFactors_mul` rewrites (m·n).primeFactors as m.primeFactors ∪ n.primeFactors, and `Finset.prod_sdiff` with `Finset.union_sdiff_right` factors the union product as (∏ over m.primeFactors ∖ n.primeFactors)·(∏ over n.primeFactors). Cancelling the common nonzero m·n·(∏ over n.primeFactors) via `linear_combination`/`mul_right_cancel₀` forces the difference product to 1, and the helper finishes.",
+    "mathContext": "$n \\neq 0 \\implies \\big(\\varphi(mn) = m\\,\\varphi(n) \\iff m.\\mathrm{primeFactors} \\subseteq n.\\mathrm{primeFactors}\\big).$",
+    "significance": "critical",
+    "relatedConcepts": ["iff characterization", "Euler product formula", "primeFactors_mul", "prod_sdiff", "ℚ-cast cancellation"],
+    "prerequisites": ["totient_mul_of_primeFactors_subset", "Nat.totient_eq_mul_prod_factors", "Finset.prod_sdiff"]
+  },
+  {
+    "id": "totient-oq0901-ann-symmetric",
+    "proofId": "euler-totient-oq-09-oq-01",
+    "range": { "startLine": 157, "endLine": 162 },
+    "type": "theorem",
+    "title": "The Symmetric Form",
+    "content": "`totient_mul_eq_iff_primeFactors_subset'` (m ≠ 0): φ(m·n) = n·φ(m) ⟺ n.primeFactors ⊆ m.primeFactors. Immediate from the main characterization by `mul_comm m n`, recording that the roles of the two factors are interchangeable.",
+    "mathContext": "$m \\neq 0 \\implies \\big(\\varphi(mn) = n\\,\\varphi(m) \\iff n.\\mathrm{primeFactors} \\subseteq m.\\mathrm{primeFactors}\\big).$",
+    "significance": "supporting",
+    "relatedConcepts": ["symmetry", "mul_comm"],
+    "prerequisites": ["the main characterization"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-09-oq-01/index.ts
+++ b/src/data/proofs/euler-totient-oq-09-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ09OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOQ09OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOQ09OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOQ09OQ01Data: ProofData = {
+  proof: eulerTotientOQ09OQ01Proof,
+  annotations: eulerTotientOQ09OQ01Annotations,
+}

--- a/src/data/proofs/euler-totient-oq-09-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-09-oq-01/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "euler-totient-oq-09-oq-01",
+  "title": "Totient of a Product via $\\gcd$, and Exactly When $\\varphi(mn) = m\\,\\varphi(n)$",
+  "slug": "euler-totient-oq-09-oq-01",
+  "description": "Settles the first open question of `euler-totient-oq-09`: pin down how Euler's totient behaves on a *general* (non-coprime) product, and characterize precisely when the clean scaling identity holds. Two results. First, the general product formula φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n) — the exact non-coprime correction factor, a commutative rearrangement of Mathlib's `Nat.totient_gcd_mul_totient_mul` that collapses to the coprime law `Nat.totient_mul` when gcd(m,n) = 1. Second, and the real content, the sharp characterization: for n ≠ 0, φ(m·n) = m·φ(n) ⟺ m.primeFactors ⊆ n.primeFactors (every prime dividing m already divides n). The ⟸ direction is exactly the parent's reusable engine `totient_mul_of_primeFactors_subset`; the new ⟹ direction is obtained through Euler's rational product formula φ(n) = n·∏_{p∣n}(1−1/p): writing (m·n).primeFactors as the union m.primeFactors ∪ n.primeFactors, the identity forces ∏_{p ∈ m.primeFactors ∖ n.primeFactors}(1−1/p) = 1, but each such Euler factor lies strictly in (0,1), so a nonempty product would be < 1 — hence the difference set is empty. A symmetric form φ(m·n) = n·φ(m) ⟺ n.primeFactors ⊆ m.primeFactors follows by commutativity. Fully machine-checked: 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Classical (Euler); gcd product formula and the prime-support characterization formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function",
+    "date": "1763",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ09OQ01.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "prime-factorization",
+      "product-formula",
+      "gcd",
+      "multiplicative-functions",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 162,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (no native_decide). The gcd product formula is a rearrangement of Mathlib's `Nat.totient_gcd_mul_totient_mul`; the forward characterization rests on Euler's product formula `Nat.totient_eq_mul_prod_factors` and `Nat.primeFactors_mul`, with a short self-contained `ℚ`-product argument (each Euler factor 1 − 1/p lies in (0,1)); the reverse direction reuses the parent engine `EulerTotientOQ09.totient_mul_of_primeFactors_subset`. The only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_gcd_mul_totient_mul",
+        "description": "`φ(gcd(a,b))·φ(a·b) = φ(a)·φ(b)·gcd(a,b)`. A commutative rearrangement gives the entry's general product formula isolating the non-coprime correction factor.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.totient_eq_mul_prod_factors",
+        "description": "Euler's product formula over ℚ: `(φ n : ℚ) = n · ∏ p ∈ n.primeFactors, (1 − p⁻¹)`. Expanding both sides of φ(m·n) = m·φ(n) reduces the forward characterization to a statement about the Euler product over the prime-factor difference set.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Nat.primeFactors_mul",
+        "description": "`a ≠ 0 → b ≠ 0 → (a·b).primeFactors = a.primeFactors ∪ b.primeFactors`. Splits the product's prime support into the union, after which `Finset.prod_sdiff` isolates the m-only primes.",
+        "module": "Mathlib.Data.Nat.PrimeFin"
+      },
+      {
+        "theorem": "Finset.prod_sdiff",
+        "description": "`s₁ ⊆ s₂ → (∏ x ∈ s₂ ∖ s₁, f x)·(∏ x ∈ s₁, f x) = ∏ x ∈ s₂, f x`. Factors the union Euler product as (difference product)·(n-product), enabling cancellation of the common nonzero n-product.",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      },
+      {
+        "theorem": "EulerTotientOQ09.totient_mul_of_primeFactors_subset",
+        "description": "The parent engine `m.primeFactors ⊆ n.primeFactors → φ(m·n) = m·φ(n)`, reused verbatim as the ⟸ direction of the characterization.",
+        "module": "Proofs.EulerTotientOQ09"
+      }
+    ],
+    "originalContributions": [
+      "`totient_mul_mul_totient_gcd`: the general product formula φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n) for all m, n — the explicit non-coprime correction factor, stated in the symmetric isolated-`gcd` form the parent's open question requested.",
+      "`totient_mul_eq_iff_primeFactors_subset`: the sharp characterization that, for n ≠ 0, φ(m·n) = m·φ(n) holds exactly when m.primeFactors ⊆ n.primeFactors — upgrading the parent's one-directional engine to an iff by supplying the forward (necessity) direction.",
+      "`totient_mul_eq_iff_primeFactors_subset'`: the symmetric form φ(m·n) = n·φ(m) ⟺ n.primeFactors ⊆ m.primeFactors (for m ≠ 0), by commutativity of the product.",
+      "A short self-contained ℚ-product lemma `prod_lt_one_aux` (a nonempty finite product of factors each strictly in (0,1) is < 1) plus `one_sub_inv_pos`/`one_sub_inv_lt_one` (the Euler factor 1 − 1/p lies in (0,1) for prime p), which drive the necessity argument — Mathlib's strict-product lemmas are stated for ordered groups and do not directly apply over ℚ."
+    ],
+    "prerequisites": [
+      "Euler's totient function φ(n) = |(ℤ/nℤ)ˣ|",
+      "Euler's product formula φ(n) = n·∏_{p∣n}(1 − 1/p)",
+      "Greatest common divisor and the prime-factor sets primeFactors, primeFactors of a product",
+      "Finite products over Finsets: prod_sdiff, prod_union, positivity of products"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "euler-totient-oq-09",
+        "relationship": "Parent: oq-09 proved the power law φ(n^k) = n^(k−1)·φ(n) through the engine φ(m·n) = m·φ(n) for m.primeFactors ⊆ n.primeFactors, and explicitly posed as its first open question the general-product / iff statement this entry now settles."
+      },
+      {
+        "id": "euler-totient",
+        "relationship": "Ancestor: the gallery family on Euler's totient and his generalization of Fermat's little theorem; this entry adds the non-coprime product law and its sharp equality characterization."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 162,
+    "path": "Proofs/EulerTotientOQ09OQ01.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 7
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Euler's totient φ(n) = |(ℤ/nℤ)ˣ| is multiplicative on coprime arguments — φ(mn) = φ(m)φ(n) when gcd(m,n) = 1 — but not in general: the doubly-counted shared primes introduce a correction factor governed by gcd(m,n). The classical product formula φ(n) = n·∏_{p∣n}(1 − 1/p) shows that the ratio φ(n)/n depends only on the *set* of primes dividing n (its radical), which is precisely the lens that makes the non-coprime case transparent. Mathlib provides the coprime law `Nat.totient_mul` and the bilinear gcd identity `Nat.totient_gcd_mul_totient_mul`, and the parent entry oq-09 proved a one-directional scaling engine; what was missing — and what oq-09 listed as its first open question — was the explicit isolated-gcd product formula together with the exact characterization of when the clean identity φ(mn) = m·φ(n) holds.",
+    "problemStatement": "**Open Question (euler-totient-oq-09-oq-01):** express φ(m·n) for general m, n in terms of φ(m), φ(n), and gcd(m,n), and characterize exactly when φ(m·n) = m·φ(n) holds.",
+    "text": "For all m, n: φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n). And for n ≠ 0: φ(m·n) = m·φ(n) if and only if m.primeFactors ⊆ n.primeFactors — every prime dividing m already divides n.",
+    "proofStrategy": "The product formula `totient_mul_mul_totient_gcd` is a three-step `calc` rearrangement of Mathlib's `Nat.totient_gcd_mul_totient_mul` using only commutativity (`ring` over ℕ). The characterization `totient_mul_eq_iff_primeFactors_subset` is an iff: the ⟸ direction is the parent engine `EulerTotientOQ09.totient_mul_of_primeFactors_subset` applied verbatim. For ⟹, after the m = 0 case, cast φ(m·n) = m·φ(n) to ℚ and expand both totients via `Nat.totient_eq_mul_prod_factors`; `Nat.primeFactors_mul` rewrites (m·n).primeFactors as m.primeFactors ∪ n.primeFactors, and `Finset.prod_sdiff` + `Finset.union_sdiff_right` factor the union Euler product as (∏ over m.primeFactors ∖ n.primeFactors)·(∏ over n.primeFactors). Cancelling the common nonzero factor m·n·(∏ over n.primeFactors) — positivity from `Finset.prod_pos` since each 1 − 1/p > 0 — forces ∏_{p ∈ m.primeFactors ∖ n.primeFactors}(1 − 1/p) = 1. A short induction (`prod_lt_one_aux`) shows a nonempty product of factors each in (0,1) is strictly < 1, so the difference set must be empty, i.e. m.primeFactors ⊆ n.primeFactors via `Finset.sdiff_eq_empty_iff_subset`. The symmetric form follows from `mul_comm`.",
+    "keyInsights": [
+      "**The gcd is the exact correction factor.** Multiplicativity fails on non-coprime arguments by precisely φ(gcd(m,n))/gcd(m,n): rearranging Mathlib's bilinear identity isolates this and recovers `Nat.totient_mul` the instant gcd(m,n) = 1.",
+      "**φ(n)/n is a function of the prime support alone.** Because φ(n)/n = ∏_{p∣n}(1 − 1/p), the clean identity φ(mn) = m·φ(n) is equivalent to the products over (m·n).primeFactors and n.primeFactors agreeing — which happens exactly when m contributes no new primes.",
+      "**Necessity is a strict-product phenomenon.** Each Euler factor 1 − 1/p sits strictly inside (0,1); a single extra prime in m ∖ n drops the product strictly below 1, so equality forces the difference set empty. Mathlib's `Finset.prod_lt_one` is stated for ordered groups (ℚ under multiplication is not one), so the (0,1)-strict-product step is proved here by a short induction.",
+      "**This is the parent's open question, answered as an iff.** oq-09 supplied φ(mn) = m·φ(n) ⟸ subset; this entry adds the converse, turning a sufficient condition into a complete characterization, and packages the non-coprime product law alongside it."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the unit group (ℤ/nℤ)ˣ",
+      "Euler's product formula φ(n) = n·∏_{p∣n}(1 − 1/p) and its Mathlib ℚ form",
+      "gcd and prime-factor sets; primeFactors of a product is the union",
+      "Finite products over Finsets and their positivity / cancellation"
+    ]
+  },
+  "conclusion": {
+    "summary": "For all m, n, φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n), the explicit non-coprime correction to multiplicativity; and for n ≠ 0, φ(m·n) = m·φ(n) holds exactly when m.primeFactors ⊆ n.primeFactors, with the symmetric statement following by commutativity. The reverse implication is the parent's scaling engine; the new forward implication runs through Euler's rational product formula and a short strict-product argument over ℚ. 7 theorems/lemmas, 162 lines, 0 sorries, 0 axioms (no native_decide).",
+    "implications": "The iff characterization is the precise dividing line between the coprime law and the prime-power law: it tells you the totient scales linearly under multiplication by m exactly when m is 'prime-saturated' relative to n, and otherwise must drop. Together with the isolated-gcd product formula it gives a complete account of φ on products — recovering φ(mn) = φ(m)φ(n) (coprime), φ(n^k) = n^{k−1}φ(n) (m a power of the radical), and the general correction in between — useful wherever totients of composite or repeated moduli appear.",
+    "openQuestions": [
+      "Make the inequality quantitative: φ(m·n) ≤ m·φ(n) always, with deficit m·φ(n) − φ(m·n) controlled by ∏_{p ∈ m.primeFactors ∖ n.primeFactors}(1 − 1/p); derive sharp bounds on φ(m·n)/(m·φ(n)).",
+      "Characterize the dual identity φ(m·n) = φ(m)·n (rather than m·φ(n)) and, more generally, classify all pairs (m,n) with φ(m·n) = c·φ(n) for a given natural c.",
+      "Lift the gcd correction factor to other multiplicative arithmetic functions (σ, the number-of-divisors function) and identify which admit an analogous clean prime-support characterization of their 'scaling' identities."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Module docstring framing the two goals — the general gcd product formula and the sharp iff for φ(m·n) = m·φ(n) — and recalling the parent engine it builds on. Imports `Mathlib.Data.Nat.Totient`, `Mathlib.Data.Nat.PrimeFin`, `Mathlib.Tactic`, and `Proofs.EulerTotientOQ09`; opens namespace `EulerTotientOQ09OQ01` and `Nat` so `φ` denotes `Nat.totient`."
+    },
+    {
+      "id": "strict-product-helpers",
+      "title": "ℚ-Product Helpers for the Necessity Direction",
+      "startLine": 52,
+      "endLine": 106,
+      "summary": "`prod_lt_one_aux`: a nonempty finite product of ℚ-factors each strictly in (0,1) is < 1 (induction on the Finset, closing the inductive step with `nlinarith`). `one_sub_inv_pos` and `one_sub_inv_lt_one`: for a prime p the Euler factor 1 − 1/p lies in (0,1). `primeFactors_subset_of_prod_eq_one`: if the Euler product over m.primeFactors ∖ n.primeFactors equals 1 then that difference set is empty (contradicting the strict bound otherwise), hence m.primeFactors ⊆ n.primeFactors."
+    },
+    {
+      "id": "gcd-product-formula",
+      "title": "The General Product Formula via gcd",
+      "startLine": 107,
+      "endLine": 121,
+      "summary": "`totient_mul_mul_totient_gcd`: φ(m·n)·φ(gcd(m,n)) = gcd(m,n)·φ(m)·φ(n), a three-step `calc` rearrangement of Mathlib's `Nat.totient_gcd_mul_totient_mul` using commutativity (`ring` over ℕ). Collapses to the coprime law `Nat.totient_mul` when gcd(m,n) = 1."
+    },
+    {
+      "id": "characterization",
+      "title": "The Sharp Characterization and Its Symmetric Form",
+      "startLine": 122,
+      "endLine": 162,
+      "summary": "`totient_mul_eq_iff_primeFactors_subset` (n ≠ 0): φ(m·n) = m·φ(n) ⟺ m.primeFactors ⊆ n.primeFactors. The ⟸ direction is the parent engine; the ⟹ direction casts to ℚ, expands via `Nat.totient_eq_mul_prod_factors`, splits (m·n).primeFactors with `Nat.primeFactors_mul`, factors the union product with `Finset.prod_sdiff`/`Finset.union_sdiff_right`, cancels the common nonzero factor, and applies the helper. `totient_mul_eq_iff_primeFactors_subset'` gives the symmetric φ(m·n) = n·φ(m) ⟺ n.primeFactors ⊆ m.primeFactors via `mul_comm`."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-09",
+      "relationship": "parent",
+      "description": "oq-09 proved the power law φ(n^k) = n^(k−1)·φ(n) via the one-directional engine φ(m·n) = m·φ(n) for m.primeFactors ⊆ n.primeFactors, and posed the general-product / iff statement as its first open question. This entry reuses that engine as the ⟸ direction and supplies the converse, settling the question."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "The ancestor gallery family develops Euler's totient and his generalization of Fermat's little theorem; this entry contributes the non-coprime product law and the exact prime-support condition for clean scaling."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Settles the **first open question** of `euler-totient-oq-09`: how Euler's totient behaves on a general (non-coprime) product, and exactly when the clean scaling identity holds.

New file `proofs/Proofs/EulerTotientOQ09OQ01.lean` + gallery entry `euler-totient-oq-09-oq-01`.

### Results
- **`totient_mul_mul_totient_gcd`** — the general product formula
  `φ(m·n)·φ(gcd m n) = gcd(m,n)·φ(m)·φ(n)`, the exact non-coprime correction factor (a rearrangement of Mathlib's `Nat.totient_gcd_mul_totient_mul`; collapses to the coprime law `Nat.totient_mul` when `gcd = 1`).
- **`totient_mul_eq_iff_primeFactors_subset`** (`n ≠ 0`) — the sharp characterization
  `φ(m·n) = m·φ(n) ⟺ m.primeFactors ⊆ n.primeFactors`. The `⟸` direction reuses the parent engine `EulerTotientOQ09.totient_mul_of_primeFactors_subset`; the new `⟹` direction goes through Euler's ℚ product formula, reducing the identity to `∏_{p ∈ m.primeFactors ∖ n.primeFactors}(1 − 1/p) = 1` — and since each Euler factor lies strictly in `(0,1)`, a nonempty product would be `< 1`, forcing the difference set empty.
- **`totient_mul_eq_iff_primeFactors_subset'`** — the symmetric form `φ(m·n) = n·φ(m) ⟺ n.primeFactors ⊆ m.primeFactors`, by `mul_comm`.

### Verification
- 162 lines, 7 theorem/lemma decls (3 public + 4 private helpers), 0 definitions.
- **0 sorries, 0 axioms** — `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for all three public theorems. No `native_decide`.
- Kernel-verified on Mathlib v4.26.0 (`lake env lean`).
- Status `verified`, badge `original`.

Note: Mathlib's `Finset.prod_lt_one` is stated for ordered *multiplicative groups* (ℚ under multiplication is not one), so the strict-product step is proved here by a short self-contained Finset induction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)