### PR TITLE
Enrich Sixty Divides the Product of a Pythagorean Triple's Sides: add index.ts + annotations

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-08/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-08/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "pyth-oq08-ann-residues",
+    "proofId": "pythagorean-triples-oq-08",
+    "range": { "startLine": 48, "endLine": 69 },
+    "type": "technique",
+    "title": "Three finite residue obstructions by decide",
+    "content": "Each factor of 60 = 4·3·5 comes from a complete finite check over ZMod n, discharged by ordinary kernel decide (NOT native_decide, so the proof stays at 0 axioms — no Lean.ofReduceBool). ab_zero_mod3: every solution of a²+b²=c² in ZMod 3 has a·b = 0 (squares are {0,1} mod 3, so two nonzero legs give c² ≡ 2, impossible). ab_quarter_mod8: every solution in ZMod 8 has a·b ∈ {0,4} — a leg is divisible by 4. abc_zero_mod5: every solution in ZMod 5 has a·b·c = 0 (no sum of two nonzero squares mod 5 is a nonzero square).",
+    "mathContext": "Squares are $\\{0,1\\}$ mod 3, $\\{0,1,4\\}$ mod 8, $\\{0,1,4\\}$ mod 5; $a^2+b^2=c^2$ forces $ab=0$ (mod 3), $ab\\in\\{0,4\\}$ (mod 8), $abc=0$ (mod 5).",
+    "significance": "key",
+    "relatedConcepts": ["ZMod residues", "decide tactic", "quadratic residues", "finite verification"],
+    "prerequisites": ["modular arithmetic", "squares modulo small n"]
+  },
+  {
+    "id": "pyth-oq08-ann-mod8",
+    "proofId": "pythagorean-triples-oq-08",
+    "range": { "startLine": 59, "endLine": 64 },
+    "type": "insight",
+    "title": "Why the factor of 4 needs mod 8, not mod 4",
+    "content": "The sharp point of the proof: divisibility by 4 cannot be seen modulo 4. In ZMod 4 the triple (a,b,c) = (2,1,1) satisfies a²+b²=c² (4+1=1 since 5≡1) yet a·b ≡ 2 — a spurious solution that defeats the naive mod-4 argument. The obstruction only becomes visible mod 8, where ab_quarter_mod8 verifies that every genuine solution has a·b ∈ {0,4}, both of which are divisible by 4. This mod-8 sharpening is the one nonobvious modular input in the whole result.",
+    "mathContext": "In $\\mathbb{Z}/4$, $(2,1,1)$ has $2^2+1^2=1^2$ but $2\\cdot1=2$; the factor of 4 only appears mod 8 where $ab\\in\\{0,4\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["spurious solutions", "modular sharpening", "lifting the modulus"],
+    "prerequisites": ["squares modulo 4 vs modulo 8"]
+  },
+  {
+    "id": "pyth-oq08-ann-cast",
+    "proofId": "pythagorean-triples-oq-08",
+    "range": { "startLine": 71, "endLine": 82 },
+    "type": "technique",
+    "title": "Casting the integer equation into ZMod n",
+    "content": "cast_eq is the bridge feeding the finite residue lemmas: the integer Pythagorean equation x·x+y·y=z·z, being the image of an equality under the ring homomorphism ℤ → ZMod n, reduces to (x̄)²+(ȳ)²=(z̄)² in any ZMod n (proved by push_cast on the cast of the hypothesis). Each integer-divisibility result instantiates this at n = 3, 8, 5 and applies the matching decide lemma.",
+    "mathContext": "$x^2+y^2=z^2$ in $\\mathbb{Z}$ $\\Rightarrow (\\bar x)^2+(\\bar y)^2=(\\bar z)^2$ in $\\mathbb{Z}/n$ for every $n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring homomorphism ℤ→ZMod n", "push_cast", "reduction modulo n"],
+    "prerequisites": ["the PythagoreanTriple predicate", "casting integers to ZMod"]
+  },
+  {
+    "id": "pyth-oq08-ann-divisibility",
+    "proofId": "pythagorean-triples-oq-08",
+    "range": { "startLine": 83, "endLine": 112 },
+    "type": "technique",
+    "title": "Transporting residues to integer divisibility",
+    "content": "three_dvd_legs (3 ∣ x·y), four_dvd_legs (4 ∣ x·y), and five_dvd_sides (5 ∣ x·y·z) transport each residue fact to ℤ via ZMod.intCast_zmod_eq_zero_iff_dvd. The mod-8 case is the only nontrivial one: ab_quarter_mod8 leaves two residues, so four_dvd_legs rcases on a·b ≡ 0 (giving 8 ∣ x·y) versus a·b ≡ 4 (giving 8 ∣ x·y−4), and omega concludes 4 ∣ x·y from either. Note 3 and 4 land on the LEGS x·y, while 5 may use the hypotenuse — only the full product x·y·z is guaranteed for the factor 5 (e.g. in (3,4,5) it is z that carries the 5).",
+    "mathContext": "$3\\mid xy,\\ 4\\mid xy,\\ 5\\mid xyz$; the mod-8 split $ab\\equiv0$ or $ab\\equiv4$ both yield $4\\mid xy$ by omega.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod.intCast_zmod_eq_zero_iff_dvd", "omega", "legs vs hypotenuse"],
+    "prerequisites": ["the residue lemmas", "integer divisibility from residue zero"]
+  },
+  {
+    "id": "pyth-oq08-ann-headline",
+    "proofId": "pythagorean-triples-oq-08",
+    "range": { "startLine": 114, "endLine": 146 },
+    "type": "insight",
+    "title": "Combining coprime factors into 60",
+    "content": "twelve_dvd_legs combines the coprime divisors 3 and 4 via IsCoprime.mul_dvd (coprimality checked by Int.isCoprime_iff_gcd_eq_one + decide) to get 12 ∣ x·y. sixty_dvd_product then lifts 12 ∣ x·y to 12 ∣ x·y·z (mul_right z) and combines it with 5 ∣ x·y·z, again via coprimality of 12 and 5, to get the headline 60 ∣ x·y·z — for EVERY triple, with no coprimality/primitivity hypothesis (scaling a primitive triple only multiplies the product). triple_345 records the tight instance: 3·4·5 = 60, exactly divisible by 60, so the bound 60 cannot be improved.",
+    "mathContext": "$\\gcd(3,4)=1 \\Rightarrow 12\\mid xy$; $\\gcd(12,5)=1 \\Rightarrow 60\\mid xyz$; tight at $(3,4,5)$ with product $60$.",
+    "significance": "key",
+    "relatedConcepts": ["IsCoprime.mul_dvd", "coprime factor combination", "tightness witness"],
+    "prerequisites": ["coprimality over ℤ", "the three divisibility lemmas"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-08/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-08/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ08.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOQ08Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOQ08Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOQ08Data: ProofData = {
+  proof: pythagoreanTriplesOQ08Proof,
+  annotations: pythagoreanTriplesOQ08Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-08` (60 ∣ x·y·z for every Pythagorean triple).

## Changes
- **Created `index.ts`** (entry was missing it — page would not load on the live site).
- **Added `annotations.json`** (5 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`): the three `decide` residue obstructions (mod 3/8/5); the why-mod-8-not-mod-4 sharpening (the spurious (2,1,1) solution); the `cast_eq` bridge into ZMod n; the transport to integer divisibility (with the mod-8 `omega` split); and the coprime-factor combination 3·4=12, 12·5=60 with the tight (3,4,5) witness.

Recomputed quality 42 → 97. meta.json already rich (crossReferences correct); status/badge/axiomCount unchanged (verified, 0 axioms — `decide` not `native_decide`).