### PR TITLE
Enrich Non-Crossing Partitions: the Combinatorial Target of the Ballot/Dyck Bijection

### DIFF
--- a/src/data/proofs/ballot-problem-oq-04/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-04/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ballot-nc-ann-header",
+    "proofId": "ballot-problem-oq-04",
+    "range": {
+      "startLine": 1,
+      "endLine": 68
+    },
+    "type": "context",
+    "title": "The Missing Non-Crossing Side of the Catalan Bijection",
+    "content": "Ballot sequences (Dyck words) and non-crossing partitions of an n-element ordered set are both counted by the Catalan numbers, and OQ-04 asks for the bijection between them. Mathlib supplies the ballot/Dyck side in full (DyckWord, card_dyckWord_semilength_eq_catalan) but has NO non-crossing partitions. This file introduces that missing combinatorial object: a partition of Fin n is modelled by its 'same block' equivalence relation (a Setoid), setting up the codomain of the bijection.",
+    "mathContext": "Both sides are Catalan-counted: $\\#\\{$Dyck words of semilength $n\\} = \\#\\{$non-crossing partitions of $[n]\\} = C_n$. This file builds the non-crossing-partition side.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Catalan numbers",
+      "Dyck words / ballot sequences",
+      "non-crossing partitions",
+      "Setoid model of a partition",
+      "bijective combinatorics"
+    ],
+    "prerequisites": [
+      "equivalence relations as partitions",
+      "the Catalan numbers"
+    ]
+  },
+  {
+    "id": "ballot-nc-ann-def",
+    "proofId": "ballot-problem-oq-04",
+    "range": {
+      "startLine": 72,
+      "endLine": 109
+    },
+    "type": "definition",
+    "title": "Non-Crossing Defined, and the Small/Extreme Partitions",
+    "content": "IsNonCrossing s holds for a Setoid (Fin n) when no four indices a<b<c<d have a~c and b~d while lying in distinct blocks (no two blocks 'interleave'). Three first facts: the one-block partition ⊤ and the all-singletons partition ⊥ are both non-crossing (isNonCrossing_top / isNonCrossing_bot — trivially, since one has a single block and the other no pair related), and every partition of a set with at most three elements is non-crossing (isNonCrossing_of_n_le_three) because a crossing needs four points.",
+    "mathContext": "$\\mathrm{IsNonCrossing}(s)$: no $a<b<c<d$ with $a\\sim c$, $b\\sim d$ in different blocks. $\\top,\\bot$ non-crossing; all partitions of $[n]$, $n\\le 3$, non-crossing.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsNonCrossing",
+      "Setoid ⊤/⊥",
+      "crossing needs four points",
+      "interleaving blocks"
+    ],
+    "prerequisites": [
+      "Setoid (Fin n)",
+      "the order on Fin n"
+    ]
+  },
+  {
+    "id": "ballot-nc-ann-structure",
+    "proofId": "ballot-problem-oq-04",
+    "range": {
+      "startLine": 113,
+      "endLine": 153
+    },
+    "type": "insight",
+    "title": "The Structural Meaning of Non-Crossing",
+    "content": "The core lemmas. all_related: in a non-crossing partition, an interleaving configuration (a~c and b~d with a<b<c<d) forces ALL four indices into one block — so two distinct blocks can only 'meet' by coinciding. outer_related is the corollary that the two endpoints a~d are related, collapsing the whole interval. isNonCrossing_iff gives the standard 'no genuine crossing' reformulation: there is no pair of distinct blocks with interleaving representatives. The first genuine crossing is {{0,2},{1,3}} on Fin 4 — which is exactly why C₄ = 14 = Bell B₄ (15) minus that single crossing partition.",
+    "mathContext": "Non-crossing $\\Rightarrow$ an interleaving $a\\sim c,\\ b\\sim d$ ($a<b<c<d$) forces $a\\sim b\\sim c\\sim d$; first crossing $\\{\\{0,2\\},\\{1,3\\}\\}$ on $[4]$, $C_4=14=B_4-1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "all_related lemma",
+      "blocks meet only by coinciding",
+      "no-genuine-crossing reformulation",
+      "Catalan vs Bell numbers"
+    ],
+    "prerequisites": [
+      "the IsNonCrossing definition",
+      "transitivity of the block relation"
+    ]
+  },
+  {
+    "id": "ballot-nc-ann-dyck",
+    "proofId": "ballot-problem-oq-04",
+    "range": {
+      "startLine": 157,
+      "endLine": 192
+    },
+    "type": "context",
+    "title": "The Ballot/Dyck Side Is Catalan-Counted",
+    "content": "dyck_side_card re-exposes Mathlib's card_dyckWord_semilength_eq_catalan: the number of Dyck words of semilength n is catalan n. This is the domain of the OQ-04 bijection, now paired with the freshly-formalized non-crossing-partition codomain — both sides Catalan-counted, setting up the bijection whose construction is the remaining open work.",
+    "mathContext": "$\\#\\{$Dyck words of semilength $n\\} = C_n$ (Mathlib), the Catalan-counted domain matched to the non-crossing-partition codomain built here.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "DyckWord",
+      "card_dyckWord_semilength_eq_catalan",
+      "Catalan-counted domain",
+      "bijection setup"
+    ],
+    "prerequisites": [
+      "Mathlib's DyckWord API",
+      "the Catalan count of Dyck words"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `ballot-problem-oq-04` (quality 43, pass 0).

## Gap addressed
Rich meta.json but no `annotations.json`.

## Change
Adds `annotations.json` — 4 annotations (mathContext/significance/relatedConcepts/prerequisites), aligned to Lean constructs (resolver: **4 valid, 0 misaligned**):
1. The missing non-crossing side of the Catalan bijection (Mathlib has Dyck, not non-crossing partitions)
2. IsNonCrossing defined + the ⊤/⊥ and ≤3-point partitions
3. The structural lemmas (all_related, no-genuine-crossing reformulation, first crossing on Fin 4, C₄=B₄−1)
4. The Catalan-counted Dyck side of the bijection

No `index.ts`: the gallery loader uses the build-generated `data-manifest.json` (issue #20992/#20993), not per-proof shims.

Verified: JSON parses; resolver alignment 4/4.