### PR TITLE
research(stirling-second-kind-oq-01-oq-02): general finite-difference closed form k!·S(n,k)=∑(−1)ʲC(k,j)(k−j)ⁿ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3572,6 +3572,7 @@ import Proofs.StirlingFormulaOQ01OQ01
 import Proofs.StirlingFormulaOQ02
 import Proofs.StirlingFormulaOQ03
 import Proofs.StirlingSecondKindOQ01
+import Proofs.StirlingSecondKindOQ01OQ02
 import Proofs.SubsetCount
 import Proofs.SubsetCountMultisetOQ01
 import Proofs.SubsetCountOQ02

--- a/proofs/Proofs/StirlingSecondKindOQ01OQ02.lean
+++ b/proofs/Proofs/StirlingSecondKindOQ01OQ02.lean
@@ -1,0 +1,211 @@
+/-
+Stirling Numbers of the Second Kind — OQ-01-OQ-02:
+the general finite-difference (inclusion–exclusion) closed form
+
+  k! · S(n,k) = ∑_{j=0}^{k} (-1)^j · C(k,j) · (k-j)^n.
+
+Source: Open question OQ-02 of the gallery entry `stirling-second-kind-oq-01`
+(itself OQ-01 of the parent `stirling-second-kind`).
+
+## The open question
+
+The parent entry (`StirlingSecondKindOQ01.lean`) proved only the single two-block
+column `S(n,2) = 2^(n-1) − 1`. Mathlib
+(`Mathlib/Combinatorics/Enumerative/Stirling.lean`) defines
+`Nat.stirlingSecond n k` by the Pascal-style recurrence
+
+  S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k),     S(0,0)=1,  S(0,k+1)=0,  S(n+1,0)=0,
+
+together with the boundary columns, but it does **not** record the canonical
+closed form.  This file fills that gap.
+
+## Strategy — the surjection recurrence, factorial-cleared in ℤ
+
+Write the factorial-cleared finite-difference sum
+
+  T(n,k) := ∑_{j=0}^{k} (-1)^j · C(k,j) · (k-j)^n      (an integer; subtraction lives in ℤ).
+
+`T(n,k)` is exactly the number of surjections `[n] ↠ [k]` (inclusion–exclusion over
+the `k` "missed value" events), so the target is `k!·S(n,k) = T(n,k)`.  We prove it
+by induction on `n`, the heart being the **surjection recurrence**
+
+  T(n+1,k+1) = (k+1)·(T(n,k+1) + T(n,k)),
+
+which mirrors `S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k)` once each side is multiplied by
+the appropriate factorial.  The recurrence itself rests on two elementary binomial
+facts:
+
+* an **absorption** identity  (k+1−j)·C(k+1,j) = (k+1)·C(k,j), which turns one factor
+  of the base `(k+1−j)` into the multiplier `(k+1)` while lowering the upper index, and
+* **Pascal's rule** C(k+1,j+1) = C(k,j) + C(k,j+1),
+
+after which everything is bookkeeping with `Finset.sum_range_succ'`.
+
+As a sanity check we recover the parent's column `S(n,2) = 2^(n-1) − 1`.
+-/
+import Mathlib
+
+namespace StirlingSecondKindOQ01OQ02
+
+open Finset
+
+/-- The factorial-cleared finite-difference sum
+`T n k = ∑_{j=0}^{k} (-1)^j · C(k,j) · (k-j)^n`, an integer (the alternating signs and
+the base `k-j` both live in `ℤ`).  Combinatorially `T n k` is the number of surjections
+from an `n`-element set onto a `k`-element set. -/
+def T (n k : ℕ) : ℤ :=
+  ∑ j ∈ range (k + 1), (-1 : ℤ) ^ j * (k.choose j : ℤ) * ((k : ℤ) - (j : ℤ)) ^ n
+
+/-- **Absorption identity** (over `ℕ`): `(k+1)·C(k,j) = (k+1−j)·C(k+1,j)`.
+Both sides are `0` once `j > k+1`, so the statement is unconditional. -/
+theorem nat_absorb (k j : ℕ) :
+    (k + 1) * k.choose j = (k + 1 - j) * (k + 1).choose j := by
+  have h1 : (k + 1) * k.choose j = (k + 1).choose (j + 1) * (j + 1) :=
+    Nat.add_one_mul_choose_eq k j
+  have h2 : (k + 1).choose (j + 1) * (j + 1) = (k + 1).choose j * (k + 1 - j) :=
+    Nat.choose_succ_right_eq (k + 1) j
+  rw [h1, h2, Nat.mul_comm]
+
+/-- The absorption identity cast into `ℤ`, in the exact shape used inside the sum:
+for `j ≤ k+1`,  `((k:ℤ)+1 − j)·C(k+1,j) = ((k:ℤ)+1)·C(k,j)`. -/
+theorem absorbZ (k j : ℕ) (hj : j ≤ k + 1) :
+    ((k : ℤ) + 1 - (j : ℤ)) * ((k + 1).choose j : ℤ)
+      = ((k : ℤ) + 1) * (k.choose j : ℤ) := by
+  have hnat := nat_absorb k j
+  have hcast : (((k + 1 - j : ℕ)) : ℤ) = (k : ℤ) + 1 - (j : ℤ) := by
+    have : (j : ℤ) ≤ (k : ℤ) + 1 := by exact_mod_cast hj
+    push_cast [Nat.cast_sub hj]
+    ring
+  have : ((k : ℤ) + 1) * (k.choose j : ℤ)
+      = ((k + 1 - j : ℕ) : ℤ) * ((k + 1).choose j : ℤ) := by
+    exact_mod_cast hnat
+  rw [this, hcast]
+
+/-- **The surjection recurrence.**
+`T (n+1) (k+1) = (k+1) · (T n (k+1) + T n k)`. -/
+theorem rec_lemma (n k : ℕ) :
+    T (n + 1) (k + 1) = ((k : ℤ) + 1) * (T n (k + 1) + T n k) := by
+  -- Abbreviation for the "shifted" sum W that both sides funnel through.
+  set W : ℤ := ∑ j ∈ range (k + 2),
+      (-1 : ℤ) ^ j * (k.choose j : ℤ) * ((k : ℤ) + 1 - (j : ℤ)) ^ n with hW
+  -- STEP A:  T (n+1) (k+1) = ((k:ℤ)+1) * W   (via absorption).
+  have hA : T (n + 1) (k + 1) = ((k : ℤ) + 1) * W := by
+    rw [hW, T, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro j hj
+    have hjle : j ≤ k + 1 := by
+      have := Finset.mem_range.mp hj; omega
+    have habs := absorbZ k j hjle
+    have hbase : (((k + 1 : ℕ)) : ℤ) - (j : ℤ) = (k : ℤ) + 1 - (j : ℤ) := by push_cast; ring
+    rw [hbase, pow_succ]
+    -- goal: (-1)^j * C(k+1,j) * (b^n * b) = (k+1) * ((-1)^j * C(k,j) * b^n)
+    linear_combination ((-1 : ℤ) ^ j * ((k : ℤ) + 1 - (j : ℤ)) ^ n) * habs
+  -- STEP B:  T n (k+1) + T n k = W   (via Pascal, peeling the bottom index).
+  have hB : T n (k + 1) + T n k = W := by
+    -- Peel the j = 0 term of T n (k+1) and of W with `sum_range_succ'`.
+    have hTk1 : T n (k + 1)
+        = (∑ i ∈ range (k + 1),
+            (-1 : ℤ) ^ (i + 1) * ((k + 1).choose (i + 1) : ℤ) * ((k : ℤ) - (i : ℤ)) ^ n)
+          + ((k : ℤ) + 1) ^ n := by
+      rw [T, Finset.sum_range_succ']
+      congr 1
+      · apply Finset.sum_congr rfl
+        intro i _
+        have : (((k + 1 : ℕ)) : ℤ) - ((i + 1 : ℕ) : ℤ) = (k : ℤ) - (i : ℤ) := by push_cast; ring
+        rw [this]
+      · simp
+    have hWval : W
+        = (∑ i ∈ range (k + 1),
+            (-1 : ℤ) ^ (i + 1) * (k.choose (i + 1) : ℤ) * ((k : ℤ) - (i : ℤ)) ^ n)
+          + ((k : ℤ) + 1) ^ n := by
+      rw [hW, Finset.sum_range_succ']
+      congr 1
+      · apply Finset.sum_congr rfl
+        intro i _
+        have : (k : ℤ) + 1 - ((i + 1 : ℕ) : ℤ) = (k : ℤ) - (i : ℤ) := by push_cast; ring
+        rw [this]
+      · simp
+    rw [hTk1, hWval, T]
+    -- Now: (Σ_T + (k+1)^n) + Σ_{Tnk} = (Σ_W + (k+1)^n)
+    -- Cancel the boundary term and merge sums via `sum_range_succ'`-free Pascal per index.
+    have hmerge :
+        (∑ i ∈ range (k + 1),
+            (-1 : ℤ) ^ (i + 1) * ((k + 1).choose (i + 1) : ℤ) * ((k : ℤ) - (i : ℤ)) ^ n)
+          + (∑ i ∈ range (k + 1),
+              (-1 : ℤ) ^ i * (k.choose i : ℤ) * ((k : ℤ) - (i : ℤ)) ^ n)
+        = ∑ i ∈ range (k + 1),
+            (-1 : ℤ) ^ (i + 1) * (k.choose (i + 1) : ℤ) * ((k : ℤ) - (i : ℤ)) ^ n := by
+      rw [← Finset.sum_add_distrib]
+      apply Finset.sum_congr rfl
+      intro i _
+      have hp : (((k + 1).choose (i + 1) : ℕ) : ℤ)
+          = (k.choose i : ℤ) + (k.choose (i + 1) : ℤ) := by
+        have := Nat.choose_succ_succ' k i
+        exact_mod_cast this
+      rw [hp]; ring
+    linear_combination hmerge
+  rw [hA, hB]
+
+/-- **Main theorem — the finite-difference closed form (factorial-cleared, in ℤ).**
+
+For all `n k : ℕ`,
+
+  `k! · S(n,k) = ∑_{j=0}^{k} (-1)^j · C(k,j) · (k-j)^n`. -/
+theorem factorial_mul_stirlingSecond (n k : ℕ) :
+    (k.factorial : ℤ) * (Nat.stirlingSecond n k : ℤ) = T n k := by
+  induction n generalizing k with
+  | zero =>
+    -- T 0 k = ∑ (-1)^j C(k,j) = if k = 0 then 1 else 0 = S(0,k)
+    simp only [T, pow_zero, mul_one]
+    rw [Int.alternating_sum_range_choose]
+    cases k with
+    | zero => simp
+    | succ k => simp
+  | succ n ih =>
+    cases k with
+    | zero =>
+      -- S(n+1,0) = 0 and T (n+1) 0 = 0^(n+1) = 0
+      simp [T, Nat.stirlingSecond_succ_zero, zero_pow (Nat.succ_ne_zero n)]
+    | succ k =>
+      rw [rec_lemma, ← ih (k + 1), ← ih k, Nat.stirlingSecond_succ_succ]
+      push_cast [Nat.factorial_succ]
+      ring
+
+/-- The number of surjections `[n] ↠ [k]` is non-negative integer `T n k` and equals
+`k!·S(n,k)`; recorded here as the cleared form rearranged to expose `S`. -/
+theorem stirlingSecond_eq_finiteDifference (n k : ℕ) :
+    (Nat.stirlingSecond n k : ℤ) * (k.factorial : ℤ) = T n k := by
+  rw [mul_comm]; exact factorial_mul_stirlingSecond n k
+
+/-- Evaluation of the closed form at the two-block column: for `n ≥ 1`,
+`T n 2 = 2^n − 2`. -/
+theorem T_two {n : ℕ} (hn : n ≠ 0) : T n 2 = 2 ^ n - 2 := by
+  rw [T]
+  rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ,
+    Finset.sum_range_zero]
+  norm_num
+  rw [zero_pow hn]
+  ring
+
+/-- **Specialization recovering the parent column.**
+For `n ≥ 1`,  `2 · S(n,2) = 2^n − 2`. -/
+theorem two_mul_stirlingSecond_two {n : ℕ} (hn : n ≠ 0) :
+    (2 : ℤ) * (Nat.stirlingSecond n 2 : ℤ) = 2 ^ n - 2 := by
+  have h := factorial_mul_stirlingSecond n 2
+  rw [T_two hn] at h
+  norm_num at h
+  linarith [h]
+
+/-- **Parent's closed form, recovered.**  For `n ≥ 1`,
+`S(n,2) = 2^(n-1) − 1` (stated over `ℤ`). -/
+theorem stirlingSecond_two {n : ℕ} (hn : 1 ≤ n) :
+    (Nat.stirlingSecond n 2 : ℤ) = 2 ^ (n - 1) - 1 := by
+  have h := two_mul_stirlingSecond_two (by omega : n ≠ 0)
+  have hpow : (2 : ℤ) ^ n = 2 * 2 ^ (n - 1) := by
+    rw [← pow_succ']
+    congr 1
+    omega
+  rw [hpow] at h
+  linarith [h]
+
+end StirlingSecondKindOQ01OQ02

--- a/research/problems/stirling-second-kind-oq-01-oq-02/knowledge.md
+++ b/research/problems/stirling-second-kind-oq-01-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: stirling-second-kind-oq-01-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/stirling-second-kind-oq-01-oq-02/literature/README.md
+++ b/research/problems/stirling-second-kind-oq-01-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for stirling-second-kind-oq-01-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/stirling-second-kind-oq-01-oq-02/problem.md
+++ b/research/problems/stirling-second-kind-oq-01-oq-02/problem.md
@@ -1,0 +1,137 @@
+# Problem: The General Finite-Difference Formula for Stirling Numbers S(n,k)
+
+**Slug**: stirling-second-kind-oq-01-oq-02
+**Created**: 2026-06-23
+**Status**: Active
+**Source**: proof-suggestion
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+S(n,k) \;=\; \frac{1}{k!}\sum_{j=0}^{k} (-1)^j \binom{k}{j}\,(k-j)^n,
+$$
+
+equivalently the integer identity (clearing the factorial)
+
+$$
+k!\,S(n,k) \;=\; \sum_{j=0}^{k} (-1)^j \binom{k}{j}\,(k-j)^n,
+$$
+
+and the specialization recovering the parent's two-block column
+
+$$
+S(n,2) = 2^{n-1} - 1 \quad (n \ge 1).
+$$
+
+### Plain Language
+
+The Stirling number of the second kind $S(n,k)$ counts partitions of an
+$n$-element set into exactly $k$ non-empty blocks. The parent entry
+(`stirling-second-kind-oq-01`) proved the single column $S(n,2) = 2^{n-1} - 1$.
+We want the general closed form: an inclusion–exclusion (finite-difference) sum
+that gives $S(n,k)$ for all $k$, and we want to show it collapses to the parent's
+formula when $k = 2$.
+
+### Why This Matters
+
+The finite-difference formula is the canonical closed form for $S(n,k)$ and the
+standard bridge between the combinatorial definition (set partitions) and the
+analytic one (surjection counting). Formalizing it provides a reusable surjection-
+counting / inclusion–exclusion identity and validates the parent column as a true
+special case rather than an isolated computation.
+
+## Known Results
+
+### What's Already Proven
+
+- `stirling-second-kind-oq-01` (parent) — $S(n,2) = 2^{n-1} - 1$.
+- Mathlib `Nat.stirling` / `stirlingSecond` API (if present) or the surjection
+  count $k!\,S(n,k) = $ number of surjections $[n] \twoheadrightarrow [k]$.
+- Inclusion–exclusion over `Finset` and the binomial theorem
+  (`Finset.sum_range_choose_mul_pow`, `Int.alternating_sum_range_choose`).
+
+### What's Still Open
+
+- A Lean statement and proof of $k!\,S(n,k) = \sum_j (-1)^j \binom{k}{j}(k-j)^n$.
+- The reduction showing this recovers $S(n,2) = 2^{n-1} - 1$.
+
+### Our Goal
+
+Formalize the integer (factorial-cleared) finite-difference identity to avoid
+rational division, then derive the $k = 2$ column to reconnect with the parent.
+Decide whether to define $S(n,k)$ via surjection counts or via Mathlib's existing
+Stirling API, and prove the identity accordingly.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| stirling-second-kind-oq-01 | Parent; the $k=2$ column this generalizes | recurrence, induction |
+| binomial-theorem (and oq descendants) | Supplies the alternating binomial sum machinery | `Finset` binomial identities |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Surjection-count route**: Use $k!\,S(n,k) = |\text{Surj}([n],[k])|$ and prove
+   $|\text{Surj}([n],[k])| = \sum_j (-1)^j \binom{k}{j}(k-j)^n$ by inclusion–exclusion
+   over the $k$ "missed value" events. Risk: assembling the inclusion–exclusion sum
+   in Mathlib's `Finset` framework.
+
+2. **Direct induction on the recurrence** $S(n+1,k) = k\,S(n,k) + S(n,k-1)$, matching
+   it against the difference of the RHS sum. Risk: index shuffling in the sum.
+
+### Key Difficulties
+
+- Avoiding rational/`ℚ` division — work with the factorial-cleared integer form.
+- The $(k-j)^n$ term and the $k=0$ / $n=0$ boundary conventions.
+
+### What Would a Proof Need?
+
+- Key lemma 1: inclusion–exclusion surjection count, or the recurrence match.
+- Key lemma 2: $\sum_{j=0}^{2}(-1)^j\binom{2}{j}(2-j)^n = 2^n - 2 = 2(2^{n-1}-1)$.
+- Technical requirements: `Finset.sum`, `Nat.choose`, alternating-sign sums.
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Inclusion–exclusion and binomial sums are well supported in Mathlib.
+- The $k=2$ reduction is an elementary computation.
+- Main risk is plumbing the surjection inclusion–exclusion, not new mathematics.
+
+**Estimated Effort**:
+- Exploration: hours to a day
+- If tractable: 2–5 days
+- If hard: unknown (if the surjection count needs to be built from scratch)
+
+## References
+
+### Papers
+- Graham, Knuth, Patashnik, *Concrete Mathematics* — Stirling numbers and the finite-difference formula.
+
+### Online Resources
+- Standard inclusion–exclusion derivation of surjection counts.
+
+### Mathlib
+- `Mathlib.Combinatorics` Stirling/partition API and `Fintype.card` of surjections.
+- `Mathlib.Algebra.BigOperators` — `Finset.sum`, alternating binomial identities.
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - stirling-numbers
+  - set-partitions
+  - inclusion-exclusion
+related_proofs:
+  - stirling-second-kind-oq-01
+  - binomial-theorem
+difficulty: medium
+source: proof-suggestion
+created: 2026-06-23
+```

--- a/research/problems/stirling-second-kind-oq-01-oq-02/state.md
+++ b/research/problems/stirling-second-kind-oq-01-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: stirling-second-kind-oq-01-oq-02
+
+## Current State
+**Phase**: ACT
+**Path**: full
+**Since**: 2026-06-23T17:33:28-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-02/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-overview",
+    "proofId": "stirling-second-kind-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "concept",
+    "title": "The Finite-Difference Closed Form",
+    "content": "Mathlib defines Nat.stirlingSecond n k by its Pascal recurrence and records the boundary columns, but no closed form. This file proves the canonical one, k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n — the number of surjections from an n-set onto a k-set, counted by inclusion–exclusion over the k events 'value i is never hit'. The whole proof works with the factorial-cleared integer T(n,k), an induction on n whose only hard step is a single surjection recurrence.",
+    "mathContext": "$k!\\,S(n,k) = \\sum_{j=0}^{k} (-1)^j \\binom{k}{j}(k-j)^n$, the surjection count $[n]\\twoheadrightarrow[k]$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Stirling numbers of the second kind",
+      "inclusion-exclusion",
+      "surjection counting",
+      "finite differences"
+    ],
+    "prerequisites": [
+      "set partitions",
+      "binomial coefficients"
+    ]
+  },
+  {
+    "id": "ann-definition-T",
+    "proofId": "stirling-second-kind-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 59 },
+    "type": "definition",
+    "title": "The Factorial-Cleared Sum T(n,k)",
+    "content": "T n k = ∑_{j∈range(k+1)} (−1)^j C(k,j)(k−j)^n is defined over ℤ so that the alternating signs and the base k−j are integral — no rational division anywhere. Combinatorially T(n,k) is exactly k!·S(n,k), the surjection count; the file proves that equality.",
+    "mathContext": "$T(n,k) := \\sum_{j=0}^{k} (-1)^j \\binom{k}{j}(k-j)^n \\in \\mathbb{Z}$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "integer-valued sum",
+      "factorial clearing"
+    ],
+    "prerequisites": [
+      "Finset.range sums"
+    ]
+  },
+  {
+    "id": "ann-absorption",
+    "proofId": "stirling-second-kind-oq-01-oq-02",
+    "range": { "startLine": 61, "endLine": 84 },
+    "type": "technique",
+    "title": "The Absorption Identity",
+    "content": "nat_absorb proves (k+1)·C(k,j) = (k+1−j)·C(k+1,j) over ℕ — unconditional, since both sides vanish once j > k+1 — by chaining Nat.add_one_mul_choose_eq with Nat.choose_succ_right_eq. absorbZ casts it to ℤ in the precise shape ((k:ℤ)+1−j)·C(k+1,j) = ((k:ℤ)+1)·C(k,j) for j ≤ k+1 (using Nat.cast_sub). This is the lever that converts a base factor (k+1−j) into the leading multiplier (k+1) while lowering the binomial's upper index from k+1 to k.",
+    "mathContext": "$(k+1-j)\\binom{k+1}{j} = (k+1)\\binom{k}{j}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "binomial absorption",
+      "ℕ to ℤ casting"
+    ],
+    "prerequisites": [
+      "Pascal's triangle identities"
+    ]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "stirling-second-kind-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 152 },
+    "type": "key-step",
+    "title": "The Surjection Recurrence (heart of the proof)",
+    "content": "rec_lemma establishes T(n+1,k+1) = (k+1)(T(n,k+1)+T(n,k)). Step A writes (k+1−j)^{n+1} = (k+1−j)^n·(k+1−j) and applies absorption via linear_combination, collapsing T(n+1,k+1) to (k+1)·W where W = ∑_{j∈range(k+2)} (−1)^j C(k,j)(k+1−j)^n. Step B shows W = T(n,k+1)+T(n,k): peel the j=0 term of both T(n,k+1) and W with Finset.sum_range_succ' (so the troublesome j−1 in Pascal becomes i over ℕ), then Pascal's rule C(k+1,i+1)=C(k,i)+C(k,i+1) merges the shifted tails termwise, each index closed by ring.",
+    "mathContext": "$T(n+1,k+1) = (k+1)\\big(T(n,k+1)+T(n,k)\\big)$ — the cleared image of Pascal's rule for $S$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "surjection recurrence",
+      "Finset.sum_range_succ'",
+      "Pascal's rule",
+      "linear_combination"
+    ],
+    "prerequisites": [
+      "reindexing finite sums",
+      "induction"
+    ]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "stirling-second-kind-oq-01-oq-02",
+    "range": { "startLine": 154, "endLine": 180 },
+    "type": "key-step",
+    "title": "The Main Closed Form",
+    "content": "factorial_mul_stirlingSecond proves k!·S(n,k) = T(n,k) by induction on n, generalizing k. The base n=0 reduces (via pow_zero) to Int.alternating_sum_range_choose, which equals 1 if k=0 and 0 otherwise — exactly S(0,k). The step splits on k: the k=0 column gives 0^{n+1}=0=S(n+1,0) on both sides; for k+1, rewrite the goal with rec_lemma, apply the induction hypothesis at k+1 and k, expand the Pascal recurrence for S together with (k+1)! = (k+1)·k!, and finish with push_cast; ring.",
+    "mathContext": "$k!\\,S(n,k) = \\sum_{j=0}^{k} (-1)^j \\binom{k}{j}(k-j)^n$ for all $n,k$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "induction on n",
+      "Int.alternating_sum_range_choose",
+      "Nat.stirlingSecond_succ_succ"
+    ],
+    "prerequisites": [
+      "strong use of the induction hypothesis",
+      "factorial identities"
+    ]
+  },
+  {
+    "id": "ann-column-two",
+    "proofId": "stirling-second-kind-oq-01-oq-02",
+    "range": { "startLine": 182, "endLine": 211 },
+    "type": "key-step",
+    "title": "Recovering the Parent Column",
+    "content": "T_two evaluates the three-term sum T(n,2) = 2^n − 2 for n ≥ 1 (the j=2 term carries 0^n, killed by zero_pow). two_mul_stirlingSecond_two then reads off 2·S(n,2) = 2^n − 2, and stirlingSecond_two cancels the factor 2 using 2^n = 2·2^(n-1) to recover the parent entry's textbook result S(n,2) = 2^(n-1) − 1 — now a one-line corollary of the general law rather than an isolated computation.",
+    "mathContext": "$S(n,2) = 2^{n-1} - 1$, recovered from the general formula at $k=2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "specialization",
+      "geometric closed form"
+    ],
+    "prerequisites": [
+      "evaluating finite sums"
+    ]
+  }
+]

--- a/src/data/proofs/stirling-second-kind-oq-01-oq-02/meta.json
+++ b/src/data/proofs/stirling-second-kind-oq-01-oq-02/meta.json
@@ -1,0 +1,189 @@
+{
+  "id": "stirling-second-kind-oq-01-oq-02",
+  "title": "Stirling Numbers of the Second Kind: the general finite-difference closed form k!·S(n,k) = ∑(−1)ʲC(k,j)(k−j)ⁿ",
+  "slug": "stirling-second-kind-oq-01-oq-02",
+  "description": "The canonical inclusion–exclusion (finite-difference) closed form for every Stirling number of the second kind: k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n, the surjection count [n]↠[k]. Proved over ℤ (factorial-cleared, no rational division) by induction on n via the surjection recurrence T(n+1,k+1)=(k+1)(T(n,k+1)+T(n,k)), and shown to recover the parent's two-block column S(n,2)=2^(n-1)−1. Mathlib defines Nat.stirlingSecond by its Pascal recurrence but records no closed form.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "status": "verified",
+    "proofRepoPath": "Proofs/StirlingSecondKindOQ01OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "stirling-numbers",
+      "set-partitions",
+      "inclusion-exclusion",
+      "finite-differences",
+      "surjections",
+      "closed-form"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.stirlingSecond_succ_succ",
+        "description": "Pascal recurrence S(n+1,k+1) = (k+1)·S(n,k+1) + S(n,k), matched termwise against the surjection recurrence for the closed form",
+        "module": "Mathlib.Combinatorics.Enumerative.Stirling"
+      },
+      {
+        "theorem": "Nat.add_one_mul_choose_eq",
+        "description": "(k+1)·C(k,j) = C(k+1,j+1)·(j+1); one half of the absorption identity (k+1−j)·C(k+1,j) = (k+1)·C(k,j)",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_right_eq",
+        "description": "C(n,k+1)·(k+1) = C(n,k)·(n−k); the second half of the absorption identity",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Nat.choose_succ_succ'",
+        "description": "Pascal's rule C(k+1,j+1) = C(k,j) + C(k,j+1), used to merge the shifted sums in the recurrence step",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Int.alternating_sum_range_choose",
+        "description": "∑_{j} (−1)^j C(k,j) = if k=0 then 1 else 0, discharging the base case n=0 of the induction",
+        "module": "Mathlib.Data.Nat.Choose.Sum"
+      },
+      {
+        "theorem": "Finset.sum_range_succ'",
+        "description": "Peels the bottom index j=0 of a range sum and reindexes the rest as j=i+1, avoiding ℕ-subtraction when applying Pascal",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "factorial_mul_stirlingSecond: the general finite-difference closed form k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n, proved over ℤ by induction on n — absent from Mathlib",
+      "rec_lemma: the surjection recurrence T(n+1,k+1) = (k+1)(T(n,k+1) + T(n,k)) for the finite-difference sum, the combinatorial heart of the proof",
+      "nat_absorb / absorbZ: the absorption identity (k+1−j)·C(k+1,j) = (k+1)·C(k,j) that converts a base factor into the leading multiplier while lowering the binomial upper index",
+      "T_two and two_mul_stirlingSecond_two: evaluation T(n,2) = 2^n − 2 and the reduction 2·S(n,2) = 2^n − 2 reconnecting with the parent column",
+      "stirlingSecond_two: recovers the parent's textbook closed form S(n,2) = 2^(n-1) − 1 as a corollary of the general formula"
+    ],
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified: 0 axioms, 0 sorries. factorial_mul_stirlingSecond and stirlingSecond_two depend only on propext, Classical.choice, Quot.sound (no native_decide, hence no Lean.ofReduceBool). Kernel-verified on Mathlib 4.26.0.",
+    "lineCount": 211,
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Stirling number of the second kind S(n,k) counts partitions of an n-element set into k nonempty blocks; equivalently k!·S(n,k) counts surjections from an n-set onto a k-set. The identity k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n is the canonical closed form, obtained by inclusion–exclusion over the k events 'value i is missed' in counting surjections. It is the standard bridge between the combinatorial definition (set partitions) and the analytic one (finite differences of x^n at 0). The parent entry proved only the single column S(n,2) = 2^(n-1) − 1; this entry establishes the formula for all k and recovers that column as a special case.",
+    "problemStatement": "Prove in Lean the general finite-difference closed form for Stirling numbers of the second kind, k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n, working with the factorial-cleared integer form to avoid rational division, and derive the two-block column S(n,2) = 2^(n-1) − 1.",
+    "text": "Define T(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n over ℤ — the surjection count [n]↠[k]. The target k!·S(n,k) = T(n,k) follows by induction on n once T satisfies the surjection recurrence T(n+1,k+1) = (k+1)(T(n,k+1) + T(n,k)), which mirrors the Pascal recurrence for S after clearing factorials.",
+    "proofStrategy": "1. Define T(n,k) = ∑_{j∈[0,k]} (−1)^j C(k,j)(k−j)^n in ℤ (alternating signs and base both integral).\n2. Absorption (nat_absorb / absorbZ): chain Nat.add_one_mul_choose_eq and Nat.choose_succ_right_eq to get (k+1−j)·C(k+1,j) = (k+1)·C(k,j), unconditional over ℕ, cast to ℤ for j ≤ k+1.\n3. rec_lemma: prove T(n+1,k+1) = (k+1)(T(n,k+1)+T(n,k)). Step A factors one base (k+1−j) out of (k+1−j)^{n+1} and applies absorption to rewrite T(n+1,k+1) = (k+1)·W with W = ∑_{j∈[0,k+1]} (−1)^j C(k,j)(k+1−j)^n. Step B uses Finset.sum_range_succ' to peel the j=0 term of both T(n,k+1) and W, then Pascal's rule C(k+1,i+1)=C(k,i)+C(k,i+1) merges the shifted sums termwise (closed by ring), giving T(n,k+1)+T(n,k)=W.\n4. factorial_mul_stirlingSecond: induct on n (generalizing k). Base n=0 reduces via pow_zero to Int.alternating_sum_range_choose = [k=0] = S(0,k). Step: the k=0 column is 0^{n+1}=0=S(n+1,0); for k+1, rewrite with rec_lemma, apply the induction hypothesis at k+1 and k, expand the Pascal recurrence for S and the factorial (k+1)! = (k+1)·k!, and close with push_cast; ring.\n5. Specialization: T_two evaluates T(n,2)=2^n−2 (n≥1); two_mul_stirlingSecond_two gives 2·S(n,2)=2^n−2; stirlingSecond_two cancels the 2 to recover S(n,2)=2^(n-1)−1.",
+    "keyInsights": [
+      "**Clear the factorial, stay in ℤ.** Stating the identity as k!·S(n,k) = ∑(−1)^j C(k,j)(k−j)^n keeps everything integral: no rational division, and the alternating signs and the base k−j live naturally in ℤ. This is what makes the whole proof a clean induction rather than a fraction-clearing exercise.",
+      "**The surjection recurrence is the whole game.** Once T satisfies T(n+1,k+1) = (k+1)(T(n,k+1)+T(n,k)) — the factorial-cleared image of Pascal's rule for S — the main identity is a two-line induction. All the difficulty is concentrated in this one combinatorial lemma.",
+      "**Absorption turns a base into a multiplier.** The identity (k+1−j)·C(k+1,j) = (k+1)·C(k,j) is what lets one factor of the base (k+1−j) in (k+1−j)^{n+1} become the leading (k+1) while dropping the binomial's upper index from k+1 to k — converting T(n+1,k+1) into (k+1)·(a shifted T at exponent n).",
+      "**sum_range_succ' dodges ℕ-subtraction.** Pascal's rule C(k+1,j)=C(k,j)+C(k,j−1) has a j−1 that truncates badly at j=0 over ℕ. Peeling the bottom term and reindexing the tail as j=i+1 replaces j−1 by i, so Pascal applies cleanly as C(k+1,i+1)=C(k,i)+C(k,i+1) and the merge closes by ring.",
+      "**The parent column falls out.** Evaluating the formula at k=2 gives T(n,2)=2^n−2, hence 2·S(n,2)=2^n−2 and S(n,2)=2^(n-1)−1 — the parent's isolated computation is now a one-line corollary of the general law."
+    ],
+    "prerequisites": [
+      "Stirling numbers of the second kind and set partitions",
+      "Inclusion–exclusion / counting surjections",
+      "Binomial coefficients and Pascal's rule",
+      "Induction on the natural numbers",
+      "Finite sums over Finset.range"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Overview and Strategy",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "File docstring stating the closed form k!·S(n,k) = ∑(−1)^j C(k,j)(k−j)^n, the surjection interpretation of T(n,k), and the induction-via-surjection-recurrence plan resting on absorption and Pascal's rule.",
+      "mathContext": "k!·S(n,k) counts surjections [n]↠[k]; inclusion–exclusion over the 'missed value' events yields ∑(−1)^j C(k,j)(k−j)^n."
+    },
+    {
+      "id": "definition-T",
+      "title": "The Finite-Difference Sum T(n,k)",
+      "startLine": 56,
+      "endLine": 59,
+      "summary": "def T n k = ∑_{j∈range(k+1)} (−1)^j C(k,j)(k−j)^n over ℤ — the factorial-cleared closed form / surjection count.",
+      "mathContext": "T(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n ∈ ℤ."
+    },
+    {
+      "id": "absorption",
+      "title": "The Absorption Identity",
+      "startLine": 61,
+      "endLine": 84,
+      "summary": "nat_absorb: (k+1)·C(k,j) = (k+1−j)·C(k+1,j) over ℕ, unconditional, via Nat.add_one_mul_choose_eq and Nat.choose_succ_right_eq. absorbZ casts it into ℤ in the exact form ((k:ℤ)+1−j)·C(k+1,j) = ((k:ℤ)+1)·C(k,j) for j ≤ k+1.",
+      "mathContext": "(k+1−j)·C(k+1,j) = (k+1)·C(k,j): turn a base factor into the leading multiplier while lowering the upper index."
+    },
+    {
+      "id": "recurrence",
+      "title": "The Surjection Recurrence",
+      "startLine": 86,
+      "endLine": 152,
+      "summary": "rec_lemma: T(n+1,k+1) = (k+1)(T(n,k+1)+T(n,k)). Step A factors (k+1−j)^{n+1}=(k+1−j)^n·(k+1−j) and applies absorption (linear_combination) to get T(n+1,k+1)=(k+1)·W. Step B peels j=0 from T(n,k+1) and W with sum_range_succ', then Pascal's rule merges the shifted tails termwise (ring).",
+      "mathContext": "The factorial-cleared image of S(n+1,k+1)=(k+1)S(n,k+1)+S(n,k); the combinatorial heart of the proof."
+    },
+    {
+      "id": "main-theorem",
+      "title": "The Closed Form k!·S(n,k) = ∑(−1)ʲC(k,j)(k−j)ⁿ",
+      "startLine": 154,
+      "endLine": 180,
+      "summary": "factorial_mul_stirlingSecond: induction on n (generalizing k). Base n=0 collapses to Int.alternating_sum_range_choose = [k=0] = S(0,k). Step handles k=0 (both sides 0) and k+1 via rec_lemma + the induction hypothesis + the factorial identity, closed by push_cast; ring. A mul_comm variant is recorded.",
+      "mathContext": "k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n for all n,k."
+    },
+    {
+      "id": "column-two",
+      "title": "Recovering the Parent Column S(n,2) = 2ⁿ⁻¹ − 1",
+      "startLine": 182,
+      "endLine": 211,
+      "summary": "T_two: T(n,2) = 2^n − 2 for n ≥ 1 (expand the three-term sum, kill 0^n). two_mul_stirlingSecond_two: 2·S(n,2)=2^n−2. stirlingSecond_two: cancel the 2 using 2^n = 2·2^(n-1) to get S(n,2) = 2^(n-1) − 1, the parent's result.",
+      "mathContext": "Specialization k=2: S(n,2) = 2^(n-1) − 1, recovered as a corollary of the general law."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Stirling, James",
+      "title": "Methodus Differentialis",
+      "year": "1730",
+      "note": "Origin of the Stirling numbers; S(n,k) as finite-difference / connection coefficients"
+    },
+    {
+      "authors": "Graham, Knuth, Patashnik",
+      "title": "Concrete Mathematics",
+      "year": "1994",
+      "note": "Chapter 6: the finite-difference formula S(n,k) = (1/k!)∑(−1)^j C(k,j)(k−j)^n and the surjection interpretation"
+    },
+    {
+      "authors": "Stanley, Richard P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2011",
+      "note": "Inclusion–exclusion count of surjections, k!·S(n,k) = number of surjections [n]↠[k]"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "stirling-second-kind-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry; this generalizes its single column S(n,2)=2^(n-1)−1 to the full closed form for all k and recovers that column as a corollary"
+    }
+  ],
+  "conclusion": {
+    "summary": "Every Stirling number of the second kind satisfies the finite-difference closed form k!·S(n,k) = ∑_{j=0}^{k} (−1)^j C(k,j)(k−j)^n (factorial_mul_stirlingSecond), proved over ℤ by induction on n. The combinatorial heart is the surjection recurrence T(n+1,k+1)=(k+1)(T(n,k+1)+T(n,k)) (rec_lemma), itself resting on an absorption identity and Pascal's rule. The parent's two-block column S(n,2)=2^(n-1)−1 is recovered as a corollary. All theorems are verified with 0 axioms and 0 sorries.",
+    "implications": "Supplies the canonical, directly citable closed form for Stirling numbers of the second kind — the standard bridge between set-partition counting and finite differences of x^n — together with a reusable surjection-recurrence and binomial-absorption toolkit, complementing Mathlib's recurrence-only development.",
+    "openQuestions": [
+      "Does the dual relation x^n = ∑_k S(n,k)·x^{(k)} (ordinary powers in terms of falling factorials) admit an equally clean Lean proof from this closed form?",
+      "Can the surjection interpretation be made literal in Lean — proving T(n,k) = Fintype.card of the surjections (Fin n → Fin k) — to connect the analytic formula to an actual combinatorial cardinality?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "StirlingSecondKindOQ01OQ02",
+    "lineCount": 211,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/StirlingSecondKindOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/stirling-second-kind-oq-01-oq-02.json
+++ b/src/data/research/problems/stirling-second-kind-oq-01-oq-02.json
@@ -1,0 +1,85 @@
+{
+  "slug": "stirling-second-kind-oq-01-oq-02",
+  "title": "The General Finite-Difference Formula for Stirling Numbers S(n,k)",
+  "phase": "COMPLETED",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "S(n,k) \\;=\\; \\frac{1}{k!}\\sum_{j=0}^{k} (-1)^j \\binom{k}{j}\\,(k-j)^n,",
+    "plain": "The Stirling number of the second kind $S(n,k)$ counts partitions of an",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-23T17:33:28-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "COMPLETE: general finite-difference closed form verified (0 axioms, 0 sorries); parent column S(n,2)=2^(n-1)-1 recovered as corollary.",
+    "builtItems": [
+      "factorial_mul_stirlingSecond, rec_lemma, nat_absorb/absorbZ, T_two, two_mul_stirlingSecond_two, stirlingSecond_two in Proofs/StirlingSecondKindOQ01OQ02.lean (211L, 0 sorries, 0 axioms)"
+    ],
+    "insights": [
+      "k!*S(n,k) = sum (-1)^j C(k,j) (k-j)^n is provable cleanly over the integers (factorial-cleared) by induction on n; the only hard step is the surjection recurrence T(n+1,k+1) = (k+1)(T(n,k+1)+T(n,k)).",
+      "Absorption (k+1-j)*C(k+1,j) = (k+1)*C(k,j) is unconditional over Nat (both sides 0 for j>k+1); proven by chaining Nat.add_one_mul_choose_eq and Nat.choose_succ_right_eq.",
+      "Pascal C(k+1,j)=C(k,j)+C(k,j-1) has a Nat-subtraction trap at j=0; Finset.sum_range_succ' peels j=0 and reindexes the tail so Pascal applies as C(k+1,i+1)=C(k,i)+C(k,i+1) without truncation."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: stirling-second-kind-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "stirling-numbers",
+    "set-partitions",
+    "inclusion-exclusion"
+  ],
+  "relatedProofs": [
+    "stirling-second-kind-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-24T00:39:32.256Z",
+  "lastUpdate": "2026-06-24T00:39:32.292Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/StirlingSecondKindOQ01.lean",
+      "filename": "StirlingSecondKindOQ01.lean",
+      "lineCount": 81,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/StirlingSecondKindOQ01.lean"
+    },
+    {
+      "path": "Proofs/StirlingSecondKindOQ01OQ02.lean",
+      "filename": "StirlingSecondKindOQ01OQ02.lean",
+      "lineCount": 212,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/StirlingSecondKindOQ01OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Proves the **canonical finite-difference (inclusion–exclusion) closed form** for every Stirling number of the second kind:

$$k!\,S(n,k) = \sum_{j=0}^{k} (-1)^j \binom{k}{j}(k-j)^n,$$

the surjection count $[n]\twoheadrightarrow[k]$. Mathlib defines `Nat.stirlingSecond` by its Pascal recurrence and the boundary columns but records **no closed form**; this entry fills that gap. The parent (`stirling-second-kind-oq-01`) proved only the single column $S(n,2)=2^{n-1}-1$ and explicitly listed this formula as an open question.

## Approach

Everything is **factorial-cleared in ℤ** — no rational division. Define $T(n,k) = \sum_{j=0}^{k}(-1)^j\binom{k}{j}(k-j)^n$ and prove $k!\,S(n,k)=T(n,k)$ by induction on $n$. The crux is the **surjection recurrence**

$$T(n+1,k+1) = (k+1)\big(T(n,k+1)+T(n,k)\big),$$

the cleared image of Pascal's rule for $S$. It rests on:
- **Absorption** $(k+1-j)\binom{k+1}{j} = (k+1)\binom{k}{j}$ (unconditional over ℕ, via `Nat.add_one_mul_choose_eq` ∘ `Nat.choose_succ_right_eq`) — turns a base factor into the leading multiplier while lowering the upper index;
- **Pascal's rule** with `Finset.sum_range_succ'` peeling the $j=0$ term to dodge the ℕ-subtraction trap at $j-1$.

The base case $n=0$ collapses to `Int.alternating_sum_range_choose`. The parent column $S(n,2)=2^{n-1}-1$ is recovered as a one-line corollary (`stirlingSecond_two`).

## Verification

- **7 theorems, 1 definition, 211 lines, 0 sorries, 0 axioms.**
- Kernel-verified on Mathlib 4.26.0 (`lake env lean`); `#print axioms` of the main theorem and the column corollary returns exactly `[propext, Classical.choice, Quot.sound]` (no `native_decide`, no `Lean.ofReduceBool`).
- Registered in `Proofs.lean`; gallery `meta.json` + `annotations.json` added.

## Files
- `proofs/Proofs/StirlingSecondKindOQ01OQ02.lean` (new)
- `proofs/Proofs.lean` (import registration)
- `src/data/proofs/stirling-second-kind-oq-01-oq-02/{meta,annotations}.json` (new)
- `src/data/research/problems/stirling-second-kind-oq-01-oq-02.json`, `research/problems/...` (knowledge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)