### PR TITLE
Enrich The Automorphism Bound |Aut_F(K)| ≤ [K:F]_s: add index.ts + annotations

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/annotations.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "angtri-oq05-ann-header",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Reading the open question: which bound, and what is it called?",
+    "content": "The parent's fifth open question asks whether Mathlib packages |Aut_F(K)| ≤ [K:F]_s as Nat.card (K ≃ₐ[F] K) ≤ Module.finSepDegree F K. Two findings resolve it: Mathlib v4.26 does NOT record this automorphism-side bound as a named lemma, and the spelling Module.finSepDegree does not exist — the separable degree lives as Field.finSepDegree F K := Nat.card (Field.Emb F K). So the question's second branch applies: supply the lemma. The whole proof is one injection — an F-automorphism is an F-embedding into the algebraic closure once post-composed with the structure map — and the boundary case [K:F]_s = 1 recovers the parent's purely-inseparable triviality without any Frobenius computation.",
+    "mathContext": "Target: $|\\mathrm{Aut}_F(K)| = \\mathrm{Nat.card}(K\\simeq_F K) \\le [K:F]_s = \\texttt{Field.finSepDegree}\\,F\\,K$.",
+    "significance": "context",
+    "relatedConcepts": ["separable degree", "automorphism group", "Field.finSepDegree", "Mathlib API gaps"],
+    "prerequisites": ["field extensions", "F-algebra automorphisms"]
+  },
+  {
+    "id": "angtri-oq05-ann-toemb",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 49, "endLine": 70 },
+    "type": "technique",
+    "title": "The automorphism-to-embedding injection",
+    "content": "toEmb sends an F-automorphism e : K ≃ₐ[F] K to the F-embedding (IsScalarTower.toAlgHom F K (AlgebraicClosure K)).comp e.toAlgHom — i.e. follow e by the structure map K → AlgebraicClosure K. toEmb_injective is the one nontrivial step: if two automorphisms give equal composed embeddings then applying both sides to x gives algebraMap K (AlgClosure K) (e₁ x) = algebraMap (e₂ x), and the structure map is injective because any ring homomorphism out of a field into a nonzero ring is injective; AlgEquiv.ext finishes. This realizes Aut_F(K) as a subset of Emb_F(K) — the conceptual heart of the bound.",
+    "mathContext": "$\\mathrm{toEmb}(e) = (\\text{structure map}) \\circ e$; injective since $\\mathrm{algebraMap}\\,K\\,\\bar K$ is injective (field map).",
+    "significance": "key",
+    "relatedConcepts": ["Field.Emb", "IsScalarTower.toAlgHom", "injectivity of field homomorphisms", "AlgEquiv.ext"],
+    "prerequisites": ["algebra homomorphisms K →ₐ[F] L", "the algebraic closure structure map"]
+  },
+  {
+    "id": "angtri-oq05-ann-bound",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 71, "endLine": 86 },
+    "type": "insight",
+    "title": "The bound and the finrank corollary",
+    "content": "card_algEquiv_le_finSepDegree is the headline lemma: Nat.card (K ≃ₐ[F] K) ≤ Field.finSepDegree F K, literally Nat.card_le_card_of_injective applied to toEmb — the codomain Field.Emb F K is finite via minpoly.AlgHom.fintype, and Field.finSepDegree is definitionally its Nat.card, so no further work is needed. card_algEquiv_le_finrank composes this with Field.finSepDegree_le_finrank to recover the classical |Aut_F(K)| ≤ [K:F]. The separable degree, not the full degree, is what controls |Aut| — this is why the false 'insep_gal_trivial' axiom (with [K:F] on the right) fails on X⁴+X²+a, where [K:F]_s = 2 < 4 yet |Gal| = 2.",
+    "mathContext": "$\\mathrm{Nat.card}(K\\simeq_F K) \\le [K:F]_s \\le [K:F]$; equality on the left iff $K/F$ normal.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.card_le_card_of_injective", "Field.finSepDegree_le_finrank", "Artin's theorem on characters", "Galois bound"],
+    "prerequisites": ["counting under injections", "finiteness of hom-types for finite extensions"]
+  },
+  {
+    "id": "angtri-oq05-ann-inseparable",
+    "proofId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05",
+    "range": { "startLine": 87, "endLine": 105 },
+    "type": "insight",
+    "title": "Purely inseparable boundary case",
+    "content": "subsingleton_algEquiv_of_isPurelyInseparable specializes the bound at the boundary: a finite purely inseparable extension has [K:F]_s = 1 (IsPurelyInseparable.finSepDegree_eq_one), so Nat.card (K ≃ₐ[F] K) ≤ 1, which Finite.card_le_one_iff_subsingleton turns into Subsingleton (K ≃ₐ[F] K). card_algEquiv_eq_one_of_isPurelyInseparable states it as the equality Nat.card = 1 (subsingleton + the identity witness). This answers the parent's second open question (Mathlib has no direct Subsingleton theorem here) and replaces the parent's char-p Frobenius identity (σ(x)−x)^{pⁿ}=0 with a one-line consequence of a general, reusable degree bound.",
+    "mathContext": "$K/F$ purely inseparable $\\Rightarrow [K:F]_s = 1 \\Rightarrow \\mathrm{Nat.card}(K\\simeq_F K) \\le 1 \\Rightarrow$ Subsingleton, in fact $=1$.",
+    "significance": "key",
+    "relatedConcepts": ["IsPurelyInseparable.finSepDegree_eq_one", "Finite.card_le_one_iff_subsingleton", "purely inseparable extensions", "Frobenius-free argument"],
+    "prerequisites": ["the automorphism bound", "purely inseparable extensions have separable degree 1"]
+  }
+]

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/index.ts
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05Data: ProofData = {
+  proof: angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05Proof,
+  annotations: angleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05` (the separable-degree automorphism bound).

## Changes
- **Created `index.ts`** (entry was missing it — page would not load on the live site).
- **Added `annotations.json`** (4 annotations, all with `mathContext`/`significance`/`relatedConcepts`/`prerequisites`): the open-question reading (`Field.finSepDegree` vs the nonexistent `Module.finSepDegree`); the `toEmb` automorphism-to-embedding injection (injective via the field structure map); the headline `card_algEquiv_le_finSepDegree` + `card_algEquiv_le_finrank` corollary; and the purely-inseparable boundary case (`Subsingleton (K ≃ₐ[F] K)`, recovering the parent's conclusion Frobenius-free).

Recomputed quality 43 → 93. meta.json already rich (overview/conclusion/sections/mainTheorems/crossReferences); status/badge/axiomCount unchanged (verified/original, 0 axioms).