### PR TITLE
Enrich The Honest Continuity Hypothesis: On-Sphere Borsuk-Ulam and Ham Sandwich

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "hamsand-on-ann-header",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 10,
+      "endLine": 82
+    },
+    "type": "context",
+    "title": "From Global to On-Sphere Continuity — Closing the Honest-Hypothesis Gap",
+    "content": "The parent (OQ-01-OQ-03-OQ-01) reduced the Ham Sandwich theorem to a single analytic input — continuity of the parameterized slice-volume map — but its Part 9 proved that continuity is FALSE globally and only true on the sphere Sⁿ, flagging 'reformulate the chain to ContinuousOn (Sphere n)' as the real remaining work. The catch: the whole Borsuk-Ulam pipeline (SphereFun, no_continuous_odd_nonzero_on_sphere) is phrased with GLOBAL continuity, so the honest on-sphere hypothesis might be unusable. This entry removes the worry via radial extension, then re-derives the entire Ham Sandwich chain with the continuity hypothesis stated exactly as Part 9 demanded.",
+    "mathContext": "Goal: replace global $\\mathrm{Continuous}$ by the honest $\\mathrm{ContinuousOn}\\,(S^n)$ throughout the Borsuk-Ulam → Ham Sandwich chain.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Ham Sandwich theorem",
+      "Borsuk-Ulam",
+      "ContinuousOn vs Continuous",
+      "slice-volume continuity",
+      "radial extension"
+    ],
+    "prerequisites": [
+      "the parent Ham Sandwich reduction",
+      "continuity on a subset"
+    ]
+  },
+  {
+    "id": "hamsand-on-ann-radial",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 168
+    },
+    "type": "insight",
+    "title": "The Radial Extension and Its Global Continuity",
+    "content": "The crux construction. sphereExtend h x = ‖x‖·h(‖x‖⁻¹·x) extends a map defined on the sphere to all of ℝⁿ⁺¹: sphereExtend_zero (vanishes at 0), sphereExtend_eq_of_mem (reproduces h on the sphere, via normalize_mem_sphere), sphereExtend_odd (odd if h is). The key is sphereExtend_continuous: a ContinuousOn (Sphere n) map yields a GLOBALLY continuous extension — proved by a compact-sphere bound on h and the squeeze theorem at the origin (where the ‖x‖ factor kills the bounded h-values). This is exactly what turns the honest on-sphere hypothesis into something the global pipeline can consume.",
+    "mathContext": "$\\mathrm{sphereExtend}\\,h\\,(x) = \\|x\\|\\,h\\!\\left(\\|x\\|^{-1}x\\right)$: vanishes at $0$, equals $h$ on $S^n$, odd, and globally continuous from $\\mathrm{ContinuousOn}\\,(S^n)\\,h$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "radial extension",
+      "squeeze theorem at 0",
+      "compact-sphere bound",
+      "odd map",
+      "ContinuousOn ⇒ Continuous extension"
+    ],
+    "prerequisites": [
+      "continuity on a compact set",
+      "norm normalization onto the sphere"
+    ]
+  },
+  {
+    "id": "hamsand-on-ann-borsuk",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 172,
+      "endLine": 196
+    },
+    "type": "insight",
+    "title": "Borsuk-Ulam from On-Sphere Continuity",
+    "content": "borsuk_ulam_antipodal_collapse_on: an odd ContinuousOn (Sphere n) map has a zero on the sphere. The proof feeds the radial extension (globally continuous and odd by the previous section) to the parent's GLOBAL antipodal collapse, then restricts the resulting zero back to the sphere via sphereExtend_eq_of_mem. So the global Borsuk-Ulam axiom IMPLIES the on-sphere version — the global SphereFun collapse is recovered as the special case borsuk_ulam_antipodal_collapse_of_sphereFun.",
+    "mathContext": "Odd $h$ with $\\mathrm{ContinuousOn}\\,(S^n)\\,h \\Rightarrow \\exists x\\in S^n,\\ h(x)=0$ — global Borsuk-Ulam applied to the radial extension.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Borsuk-Ulam antipodal collapse",
+      "odd maps",
+      "global ⇒ on-sphere",
+      "no_continuous_odd_nonzero_on_sphere"
+    ],
+    "prerequisites": [
+      "the radial extension's continuity/oddness",
+      "the parent global collapse"
+    ]
+  },
+  {
+    "id": "hamsand-on-ann-chain",
+    "proofId": "brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01",
+    "range": {
+      "startLine": 200,
+      "endLine": 333
+    },
+    "type": "technique",
+    "title": "The Ham Sandwich Chain with On-Sphere Continuity",
+    "content": "Re-runs the parent's reduction on top of the on-sphere Borsuk-Ulam, replacing global Continuous by ContinuousOn (Sphere n) at every link: ham_sandwich_reduction_on (topological core), ham_sandwich_of_discrepancy_on (from a continuous-on-sphere discrepancy map), ham_sandwich_of_scalar_continuity_on (from scalar slice-volume continuity), and the headline ham_sandwich_standard_of_scalar_continuity_on (standard linear cut). The chain now uses the continuity hypothesis exactly as Part 9 of the parent demanded — the residual analytic input is finally stated honestly.",
+    "mathContext": "The full chain: on-sphere Borsuk-Ulam ⇒ reduction ⇒ discrepancy ⇒ scalar continuity ⇒ standard Ham Sandwich, all under $\\mathrm{ContinuousOn}\\,(S^n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ham Sandwich reduction",
+      "discrepancy map",
+      "slice-volume continuity",
+      "standard linear cut",
+      "honest hypothesis"
+    ],
+    "prerequisites": [
+      "the on-sphere Borsuk-Ulam collapse",
+      "the parent's Ham Sandwich reduction chain"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `brouwer-fixed-point-oq-01-oq-03-oq-01-oq-01` (quality 43, pass 0).

## Gap addressed
Rich meta.json but no `annotations.json`.

## Change
Adds `annotations.json` — 4 annotations (mathContext/significance/relatedConcepts/prerequisites), aligned to Lean constructs (resolver: **4 valid, 0 misaligned**):
1. From global to on-sphere continuity — closing the parent's Part-9 gap
2. The radial extension sphereExtend and its global continuity (the crux)
3. Borsuk-Ulam from on-sphere continuity (global axiom ⇒ on-sphere collapse)
4. The full Ham Sandwich chain re-derived under ContinuousOn (Sphere n)

No `index.ts`: the gallery loader uses the build-generated `data-manifest.json` (issue #20992/#20993), not per-proof shims.

Verified: JSON parses; resolver alignment 4/4.