### PR TITLE
research(bernoulli-inequality-oq-01-oq-01): strict Bernoulli on Mathlib's full weak domain −2 ≤ a

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -281,6 +281,7 @@ import Proofs.BaselProblemOQ13
 import Proofs.BaselProblemOQ14
 import Proofs.BellNumbersOQ01
 import Proofs.BernoulliInequalityOQ01
+import Proofs.BernoulliInequalityOQ01OQ01
 import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04

--- a/proofs/Proofs/BernoulliInequalityOQ01OQ01.lean
+++ b/proofs/Proofs/BernoulliInequalityOQ01OQ01.lean
@@ -1,0 +1,136 @@
+import Mathlib
+
+/-
+# Strict Bernoulli over Mathlib's full weak domain `-2 ≤ a`
+
+**Open question (bernoulli-inequality-oq-01-oq-01).** Mathlib's weak Bernoulli
+inequality `one_add_mul_le_pow` holds on the full domain `-2 ≤ a` (not merely
+`a ≥ -1`).  The parent entry `bernoulli-inequality-oq-01`
+(`BernoulliInequalityOQ01.lean`) sharpens it to the *strict* form
+`1 + n·a < (1 + a)ⁿ` — but only over `a > -1`, where the elementary induction
+multiplies the inductive estimate by the *positive* factor `1 + a`.
+
+For `-2 ≤ a ≤ -1` that factor is `≤ 0`, so the induction collapses.  This file
+proves the strict inequality on the **entire weak domain** `-2 ≤ a`, matching the
+reach of `one_add_mul_le_pow`:
+
+* `one_add_mul_lt_pow_full` : for every `-2 ≤ a` with `a ≠ 0` and every `n ≥ 2`,
+  `1 + n·a < (1 + a)ⁿ`.  The hard new range is `-2 ≤ a ≤ -1`.
+* `one_add_mul_lt_pow_full_iff` : strictness holds **iff** `a ≠ 0 ∧ 2 ≤ n`.
+* `one_add_mul_eq_pow_full_iff` : equality holds **iff** `a = 0 ∨ n ≤ 1`.
+
+**The negative-tail argument.** For `-2 ≤ a ≤ -1` we have `|1 + a| ≤ 1`, hence
+`(1 + a)ⁿ ≥ -1`.  Meanwhile `a ≤ -1` forces `1 + n·a ≤ 1 - n`, which is `< -1`
+as soon as `n ≥ 3`; so the power already overshoots the line.  The single
+remaining value `n = 2` is the unconditional identity `(1+a)² - (1+2a) = a² > 0`.
+This is a genuinely different mechanism from the `a > -1` induction and is what
+extends the strict inequality past the sign change of `1 + a`.
+
+**Relation to Mathlib and the gallery.** Mathlib has the weak integer form
+`one_add_mul_le_pow` (domain `-2 ≤ a`) and an `rpow` strict form
+(`one_add_mul_self_lt_rpow_one_add`), but no strict *integer*-power Bernoulli on
+the negative range. The parent entry covers only `a > -1`; the contribution here
+is the extension to `-2 ≤ a` together with the two-sided characterizations on
+that full domain.
+-/
+
+namespace BernoulliInequalityOQ01OQ01
+
+variable {a : ℝ}
+
+/-- Strict Bernoulli on the *positive-factor* range `a > -1`, by the standard
+induction (the inductive estimate is multiplied by `1 + a > 0`).  This is the
+range already handled by the parent entry; we re-prove it here to keep the file
+self-contained. -/
+theorem one_add_mul_lt_pow_pos (ha : -1 < a) (ha0 : a ≠ 0) :
+    ∀ {n : ℕ}, 2 ≤ n → 1 + n * a < (1 + a) ^ n := by
+  have h1a : (0 : ℝ) < 1 + a := by linarith
+  have ha2 : (0 : ℝ) < a ^ 2 := by positivity
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base =>
+      push_cast
+      nlinarith [ha2]
+  | succ m hm ih =>
+      have hmpos : (1 : ℝ) ≤ (m : ℝ) := by exact_mod_cast Nat.one_le_of_lt hm
+      have step : (1 + (m : ℝ) * a) * (1 + a) < (1 + a) ^ m * (1 + a) :=
+        mul_lt_mul_of_pos_right ih h1a
+      have hexp : 1 + ((m : ℝ) + 1) * a < (1 + (m : ℝ) * a) * (1 + a) := by
+        nlinarith [ha2, hmpos]
+      push_cast
+      calc 1 + ((m : ℝ) + 1) * a
+            < (1 + (m : ℝ) * a) * (1 + a) := hexp
+        _ < (1 + a) ^ m * (1 + a) := step
+        _ = (1 + a) ^ (m + 1) := by ring
+
+/-- **Strict Bernoulli inequality on Mathlib's full weak domain.** For every real
+`-2 ≤ a` with `a ≠ 0` and every `n ≥ 2`, the binomial power strictly exceeds its
+first-order lower bound: `1 + n·a < (1 + a)ⁿ`.
+
+This extends the parent entry (which assumes `a > -1`) across the sign change of
+`1 + a` to the entire range on which `one_add_mul_le_pow` holds. -/
+theorem one_add_mul_lt_pow_full (ha : -2 ≤ a) (ha0 : a ≠ 0) :
+    ∀ {n : ℕ}, 2 ≤ n → 1 + n * a < (1 + a) ^ n := by
+  intro n hn
+  rcases le_or_gt a (-1) with hle | hgt
+  · -- `-2 ≤ a ≤ -1`: the factor `1 + a` is `≤ 0`, so the induction fails.
+    have ha2 : (0 : ℝ) < a ^ 2 := by positivity
+    obtain rfl | hn3 : n = 2 ∨ 3 ≤ n := by omega
+    · -- `n = 2`: unconditional identity `(1+a)² - (1+2a) = a² > 0`.
+      push_cast
+      nlinarith [ha2]
+    · -- `n ≥ 3`: `(1+a)ⁿ ≥ -1` while `1 + n·a ≤ 1 - n < -1`.
+      have hb : |1 + a| ≤ 1 := by rw [abs_le]; constructor <;> linarith
+      have hpw : |(1 + a) ^ n| ≤ 1 := by
+        rw [abs_pow]; exact pow_le_one₀ (abs_nonneg _) hb
+      have hpow : (-1 : ℝ) ≤ (1 + a) ^ n := (abs_le.mp hpw).1
+      have hn3' : (3 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn3
+      have hna : (n : ℝ) * a ≤ -(n : ℝ) := by
+        nlinarith [mul_le_mul_of_nonneg_left hle (Nat.cast_nonneg n : (0:ℝ) ≤ n)]
+      linarith
+  · -- `a > -1`: positive factor, use the induction.
+    exact one_add_mul_lt_pow_pos hgt ha0 hn
+
+/-- **Sharp strictness on the full domain.** For `-2 ≤ a`, Bernoulli's inequality
+is strict exactly when `a ≠ 0` and `n ≥ 2`. -/
+theorem one_add_mul_lt_pow_full_iff (ha : -2 ≤ a) {n : ℕ} :
+    1 + n * a < (1 + a) ^ n ↔ a ≠ 0 ∧ 2 ≤ n := by
+  constructor
+  · intro h
+    refine ⟨?_, ?_⟩
+    · rintro rfl; simp at h
+    · by_contra hn
+      push_neg at hn
+      interval_cases n <;> simp_all
+  · rintro ⟨ha0, hn⟩
+    exact one_add_mul_lt_pow_full ha ha0 hn
+
+/-- **Equality characterization on the full domain.** For `-2 ≤ a`, equality
+`1 + n·a = (1 + a)ⁿ` holds exactly when `a = 0` or `n ≤ 1`. -/
+theorem one_add_mul_eq_pow_full_iff (ha : -2 ≤ a) {n : ℕ} :
+    1 + n * a = (1 + a) ^ n ↔ a = 0 ∨ n ≤ 1 := by
+  constructor
+  · intro heq
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨ha0, hn⟩ := hcon
+    have hlt := one_add_mul_lt_pow_full ha ha0 (by omega : 2 ≤ n)
+    linarith
+  · rintro (rfl | hn)
+    · simp
+    · interval_cases n <;> simp
+
+/-- Concrete case in the new negative range `-2 ≤ a < -1`, outside the parent's
+`a > -1` domain: `1 + 3·(−3/2) = −7/2 < −1/8 = (1 − 3/2)³`. -/
+example : (1 : ℝ) + 3 * (-3 / 2) < (1 + (-3 / 2)) ^ 3 :=
+  one_add_mul_lt_pow_full (by norm_num) (by norm_num) (by norm_num)
+
+/-- Boundary value `a = -2`: `1 + 3·(−2) = −5 < −1 = (1 − 2)³`. -/
+example : (1 : ℝ) + 3 * (-2) < (1 + (-2)) ^ 3 :=
+  one_add_mul_lt_pow_full (by norm_num) (by norm_num) (by norm_num)
+
+/-- The `n = 2` case holds even at `a = -2`: `1 + 2·(−2) = −3 < 1 = (1−2)²`. -/
+example : (1 : ℝ) + 2 * (-2) < (1 + (-2)) ^ 2 :=
+  one_add_mul_lt_pow_full (by norm_num) (by norm_num) (by norm_num)
+
+end BernoulliInequalityOQ01OQ01

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "pos-range",
+    "proofId": "bernoulli-inequality-oq-01-oq-01",
+    "range": { "startLine": 45, "endLine": 64 },
+    "type": "insight",
+    "title": "Positive-Factor Range a > −1",
+    "content": "one_add_mul_lt_pow_pos re-establishes the strict inequality 1 + n·a < (1+a)ⁿ for a > −1 (a ≠ 0, n ≥ 2) by Nat.le_induction from n = 2 — the parent entry's mechanism, kept self-contained. The inductive step multiplies the estimate by the positive factor 1 + a (valid precisely because a > −1) and gains an extra m·a² > 0. This branch handles exactly the part of the domain where 1 + a > 0, leaving the negative tail to a separate argument.",
+    "mathContext": "$1 + na < (1+a)^n$ for $a > -1$, $a \\ne 0$, $n \\ge 2$; step gains $m a^2 > 0$, needing $1+a>0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bernoulli's inequality", "Nat.le_induction", "strict monotonicity"],
+    "prerequisites": ["induction", "ordered fields"]
+  },
+  {
+    "id": "full-domain",
+    "proofId": "bernoulli-inequality-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 92 },
+    "type": "insight",
+    "title": "Strict Inequality on the Full Weak Domain −2 ≤ a",
+    "content": "one_add_mul_lt_pow_full is the entry's central result: the strict inequality holds for EVERY −2 ≤ a with a ≠ 0 and n ≥ 2, matching the reach of Mathlib's weak one_add_mul_le_pow. The proof splits on the sign of 1 + a. For a > −1 it defers to the induction. For the new range −2 ≤ a ≤ −1 the factor 1 + a is non-positive, so the induction is unavailable; instead, |1 + a| ≤ 1 gives |(1+a)ⁿ| ≤ 1 (pow_le_one₀ on |1+a|, then abs_le), so (1+a)ⁿ ≥ −1, while a ≤ −1 forces n·a ≤ −n hence 1 + n·a ≤ 1 − n ≤ −2 < −1 for n ≥ 3. The lone case n = 2 is the unconditional identity (1+a)² − (1+2a) = a² > 0. The power is trapped in [−1,1] while the line escapes below it.",
+    "mathContext": "For $-2 \\le a \\le -1$, $n \\ge 3$: $(1+a)^n \\ge -1 > 1-n \\ge 1+na$; for $n=2$, gap is $a^2>0$.",
+    "significance": "key",
+    "relatedConcepts": ["sign change", "power bounds", "pow_le_one₀", "size argument", "case split"],
+    "prerequisites": ["the a > −1 inductive case", "|x| ≤ 1 power bounds"]
+  },
+  {
+    "id": "strict-iff",
+    "proofId": "bernoulli-inequality-oq-01-oq-01",
+    "range": { "startLine": 94, "endLine": 106 },
+    "type": "concept",
+    "title": "Strictness Characterization on −2 ≤ a",
+    "content": "one_add_mul_lt_pow_full_iff sharpens the inequality to an exact iff on the full domain: for −2 ≤ a, strictness 1 + n·a < (1+a)ⁿ holds iff a ≠ 0 ∧ 2 ≤ n. The backward direction is one_add_mul_lt_pow_full; the forward direction supplies the failure witnesses — a = 0 collapses both sides to 1, and n ≤ 1 is dispatched by interval_cases.",
+    "mathContext": "For $-2 \\le a$: $1 + na < (1+a)^n \\iff a \\ne 0 \\wedge 2 \\le n$.",
+    "significance": "key",
+    "relatedConcepts": ["sharp characterization", "iff statements", "interval_cases"],
+    "prerequisites": ["the full-domain strict inequality"]
+  },
+  {
+    "id": "eq-iff",
+    "proofId": "bernoulli-inequality-oq-01-oq-01",
+    "range": { "startLine": 108, "endLine": 121 },
+    "type": "concept",
+    "title": "Equality Characterization on −2 ≤ a",
+    "content": "one_add_mul_eq_pow_full_iff is the complementary classification on the full domain: for −2 ≤ a, equality 1 + n·a = (1+a)ⁿ holds iff a = 0 ∨ n ≤ 1. Forward: if a ≠ 0 and n ≥ 2, the full-domain strict inequality contradicts equality; backward: a = 0 gives 1 = 1 and n ≤ 1 is handled by interval_cases. Every (a, n) with −2 ≤ a is now exactly classified, with no a > −1 restriction.",
+    "mathContext": "For $-2 \\le a$: $1 + na = (1+a)^n \\iff a = 0 \\vee n \\le 1$.",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "two-sided characterization", "complementary classification"],
+    "prerequisites": ["the full-domain strict inequality"]
+  },
+  {
+    "id": "numeric",
+    "proofId": "bernoulli-inequality-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 134 },
+    "type": "example",
+    "title": "Numeric Witnesses in the New Range",
+    "content": "Concrete instances strictly inside the new negative tail, outside the parent's a > −1 domain: 1 + 3·(−3/2) = −7/2 < −1/8 = (1 − 3/2)³, the boundary value 1 + 3·(−2) = −5 < −1 = (1 − 2)³, and the n = 2 boundary 1 + 2·(−2) = −3 < 1 = (1 − 2)². Each is discharged by one_add_mul_lt_pow_full with norm_num side goals, demonstrating the inequality holds all the way to a = −2.",
+    "mathContext": "Witnesses at $a=-3/2$ and the endpoint $a=-2$, both outside $a>-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked examples", "boundary a = −2", "negative base"],
+    "prerequisites": ["the full-domain strict inequality"]
+  }
+]

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-01/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "bernoulli-inequality-oq-01-oq-01",
+  "title": "Strict Bernoulli on Mathlib's Full Weak Domain −2 ≤ a",
+  "slug": "bernoulli-inequality-oq-01-oq-01",
+  "description": "Mathlib's weak Bernoulli inequality one_add_mul_le_pow holds on the full domain −2 ≤ a, but the strict form 1 + n·a < (1 + a)ⁿ has only ever been proved for a > −1 (the parent entry), where the elementary induction multiplies by the positive factor 1 + a. This entry extends the strict inequality across the sign change of 1 + a to the entire weak domain −2 ≤ a (a ≠ 0, n ≥ 2), the genuinely harder range −2 ≤ a ≤ −1, and supplies the two-sided strictness and equality characterizations there.",
+  "meta": {
+    "author": "Jacob Bernoulli (1689); strict extension to Mathlib's one_add_mul_le_pow domain",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli%27s_inequality",
+    "date": "1689",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BernoulliInequalityOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "bernoulli-inequality",
+      "strict-inequality",
+      "equality-case",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "one_add_mul_le_pow",
+        "description": "Weak Bernoulli inequality for ℕ-powers: −2 ≤ a ⟹ 1 + n·a ≤ (1+a)ⁿ. Fixes the full domain −2 ≤ a that this entry strengthens to a strict inequality.",
+        "module": "Mathlib.Algebra.Order.Ring.Pow"
+      },
+      {
+        "theorem": "pow_le_one₀",
+        "description": "0 ≤ x ≤ 1 ⟹ xⁿ ≤ 1. Applied to |1 + a| ≤ 1 on the new range to bound |(1 + a)ⁿ| ≤ 1, hence (1 + a)ⁿ ≥ −1.",
+        "module": "Mathlib.Algebra.Order.Monoid.Lemmas"
+      },
+      {
+        "theorem": "Nat.le_induction",
+        "description": "Induction from a base value (here n = 2), used for the a > −1 sub-range.",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "mul_lt_mul_of_pos_right",
+        "description": "Strict monotonicity of multiplication by a positive constant; the inductive step for a > −1 multiplies the hypothesis by 1 + a > 0.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "originalContributions": [
+      "one_add_mul_lt_pow_full: the strict inequality 1 + n·a < (1+a)ⁿ on Mathlib's ENTIRE weak domain −2 ≤ a (a ≠ 0, n ≥ 2), extending the parent's a > −1 result across the sign change of 1 + a — the absent integer strict Bernoulli on the negative tail −2 ≤ a ≤ −1",
+      "A non-inductive mechanism for the new range −2 ≤ a ≤ −1: since |1 + a| ≤ 1 the power satisfies (1+a)ⁿ ≥ −1, while a ≤ −1 forces 1 + n·a ≤ 1 − n < −1 for n ≥ 3, with the single case n = 2 being the unconditional identity (1+a)² − (1+2a) = a² > 0",
+      "one_add_mul_lt_pow_full_iff: the sharp two-sided characterization on −2 ≤ a — strictness 1 + n·a < (1+a)ⁿ holds iff a ≠ 0 ∧ 2 ≤ n",
+      "one_add_mul_eq_pow_full_iff: the equality characterization on −2 ≤ a — equality 1 + n·a = (1+a)ⁿ holds iff a = 0 ∨ n ≤ 1",
+      "Numeric witnesses strictly inside the new range, including the boundary a = −2: 1 + 3·(−2) = −5 < −1 = (1−2)³"
+    ],
+    "dateAdded": "2026-06-23",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 136,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Bernoulli's inequality $1 + na \\le (1+a)^n$ is named for **Jacob Bernoulli** (1689). Mathlib's `one_add_mul_le_pow` proves the weak form on the comparatively large domain $-2 \\le a$, not merely $a \\ge -1$ — the extra slack to $-2$ comes from a sign-robust induction. The parent gallery entry sharpens it to the strict inequality, but only over $a > -1$, where the textbook induction multiplies by the positive factor $1 + a$. For $-2 \\le a \\le -1$ that factor is non-positive, so the induction collapses and a different argument is needed.",
+    "problemStatement": "**Open Question (OQ-01-OQ-01):** Mathlib's weak Bernoulli inequality holds for all $-2 \\le a$. Does the *strict* inequality $1 + na < (1+a)^n$ (for $a \\ne 0$, $n \\ge 2$) also extend to that full domain, across the sign change of $1 + a$ at $a = -1$, and can strictness and equality be characterized there?\n\n**Answer:** Yes. The strict inequality holds for every $-2 \\le a$ with $a \\ne 0$ and $n \\ge 2$; strictness holds iff $a \\ne 0 \\wedge n \\ge 2$, and equality holds iff $a = 0 \\vee n \\le 1$ — the same classification the parent gives on $a > -1$, now valid on the entire weak domain.",
+    "text": "Mathlib's weak Bernoulli inequality reaches down to a = −2, but the gallery's strict form stopped at a > −1 because its induction multiplies by 1 + a, which changes sign at a = −1. This entry closes that gap: on the negative tail −2 ≤ a ≤ −1 the bound |1 + a| ≤ 1 makes the power (1+a)ⁿ ≥ −1, while the line 1 + n·a drops below −1 for n ≥ 3, so the power overshoots the line outright; the lone case n = 2 is the identity a² > 0.",
+    "proofStrategy": "1. **Strict inequality** (`one_add_mul_lt_pow_full`): split on the sign of $1 + a$.\n   - For $a > -1$ (`one_add_mul_lt_pow_pos`): the standard `Nat.le_induction` from $n = 2$, multiplying the hypothesis by $1 + a > 0$ — exactly the parent's argument.\n   - For $-2 \\le a \\le -1$: the induction is unavailable. Split $n$ further. For $n = 2$ the goal is $(1+a)^2 - (1+2a) = a^2 > 0$, unconditional. For $n \\ge 3$: from $-2 \\le a \\le -1$ we get $|1+a| \\le 1$, hence $|(1+a)^n| \\le 1$ (via `pow_le_one₀` on $|1+a|$) and so $(1+a)^n \\ge -1$; meanwhile $a \\le -1$ gives $n\\,a \\le -n$, so $1 + n a \\le 1 - n \\le -2 < -1 \\le (1+a)^n$.\n2. **Strict iff** (`one_add_mul_lt_pow_full_iff`): the reverse direction supplies the witnesses where strictness fails — $a = 0$ collapses both sides to $1$, and $n \\le 1$ makes both sides equal.\n3. **Equality iff** (`one_add_mul_eq_pow_full_iff`): equality contradicts the strict inequality whenever $a \\ne 0$ and $n \\ge 2$; conversely $a = 0$ or $n \\le 1$ yield equality directly.",
+    "keyInsights": [
+      "**The sign change of $1 + a$ is the real obstruction, not the sign of $a$.** The parent's induction needs $1 + a > 0$; it has nothing to say once $a \\le -1$. The extension is therefore not a cosmetic widening — it requires a genuinely different argument on $-2 \\le a \\le -1$.",
+      "**On the negative tail the power is trapped in $[-1,1]$ while the line escapes.** Because $|1+a| \\le 1$, the power $(1+a)^n$ never leaves $[-1,1]$; but the linear lower bound $1 + na$ falls to $1 - n$, which is below $-1$ as soon as $n \\ge 3$. The inequality then holds for the blunt reason that the line has dropped beneath the entire range of the power.",
+      "**Only $n = 2$ resists the size argument, and it needs none.** At $n = 2$ the gap is exactly $a^2$, positive for every $a \\ne 0$ — so the boundary case is the most elementary one, valid even at $a = -2$.",
+      "**Matching Mathlib's reach.** The result now holds precisely on $-2 \\le a$, the domain of `one_add_mul_le_pow`, so the strict integer-power Bernoulli is available wherever the weak one is."
+    ],
+    "prerequisites": [
+      "The weak Bernoulli inequality one_add_mul_le_pow on −2 ≤ a",
+      "Induction starting from a base case (Nat.le_induction)",
+      "Monotonicity of multiplication by a positive constant",
+      "Power bounds for |x| ≤ 1 (pow_le_one₀, abs_pow)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "pos-range",
+      "title": "Positive-Factor Range a > −1",
+      "startLine": 45,
+      "endLine": 64,
+      "summary": "Re-proves the strict inequality for a > −1 by induction from n = 2, multiplying the hypothesis by 1 + a > 0 (the parent's mechanism), kept self-contained.",
+      "mathContext": "Strict 1 + n·a < (1+a)ⁿ for a > −1, a ≠ 0, n ≥ 2 via Nat.le_induction."
+    },
+    {
+      "id": "full-domain",
+      "title": "Strict Inequality on −2 ≤ a",
+      "startLine": 66,
+      "endLine": 92,
+      "summary": "Extends strictness to the full weak domain −2 ≤ a. The hard sub-range −2 ≤ a ≤ −1 uses (1+a)ⁿ ≥ −1 (from |1+a| ≤ 1) against 1 + n·a ≤ 1 − n < −1 for n ≥ 3, with n = 2 the identity a² > 0.",
+      "mathContext": "Strict 1 + n·a < (1+a)ⁿ for every −2 ≤ a with a ≠ 0 and n ≥ 2, including −2 ≤ a ≤ −1."
+    },
+    {
+      "id": "strict-iff",
+      "title": "Strictness Characterization",
+      "startLine": 94,
+      "endLine": 106,
+      "summary": "For −2 ≤ a, the inequality is strict iff a ≠ 0 and n ≥ 2.",
+      "mathContext": "For −2 ≤ a, strictness holds iff a ≠ 0 ∧ n ≥ 2."
+    },
+    {
+      "id": "eq-iff",
+      "title": "Equality Characterization",
+      "startLine": 108,
+      "endLine": 121,
+      "summary": "For −2 ≤ a, equality 1 + n·a = (1+a)ⁿ holds iff a = 0 or n ≤ 1.",
+      "mathContext": "For −2 ≤ a, equality holds iff a = 0 ∨ n ≤ 1."
+    },
+    {
+      "id": "numeric",
+      "title": "Numeric Witnesses",
+      "startLine": 123,
+      "endLine": 134,
+      "summary": "Concrete instances strictly inside the new range, including the boundary a = −2: 1 + 3·(−3/2) < (1 − 3/2)³, 1 + 3·(−2) < (1 − 2)³, and the n = 2 boundary 1 + 2·(−2) < (1 − 2)².",
+      "mathContext": "Witnesses in −2 ≤ a ≤ −1 outside the parent's a > −1 domain, including a = −2."
+    }
+  ],
+  "conclusion": {
+    "summary": "The strict integer-power Bernoulli inequality 1 + n·a < (1 + a)ⁿ (a ≠ 0, n ≥ 2) is established on Mathlib's entire weak domain −2 ≤ a, extending the parent's a > −1 result across the sign change of 1 + a; on the new range −2 ≤ a ≤ −1 the proof replaces the now-invalid induction with a size argument trapping (1+a)ⁿ in [−1,1] while 1 + n·a escapes below. Strictness holds iff a ≠ 0 ∧ n ≥ 2 and equality iff a = 0 ∨ n ≤ 1, on the full domain. Verified: 0 sorries, 0 axioms.",
+    "implications": "Mathlib provides the weak integer Bernoulli inequality on −2 ≤ a and a real-exponent strict form; the integer-power strict form is absent. The parent entry supplied it only for a > −1. This entry brings the strict form (and its two-sided characterizations) to the same domain −2 ≤ a as the weak one, removing the artificial a > −1 restriction and making the strict inequality a drop-in strengthening of one_add_mul_le_pow.",
+    "openQuestions": [
+      "Is −2 the true left endpoint of the strict inequality for fixed n, or does the admissible range depend on n (e.g. does some n admit a < −2)?",
+      "Can the size argument for −2 ≤ a ≤ −1 be packaged as a general 'line escapes a bounded power' lemma reusable for other truncated binomial bounds?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "bernoulli-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the strict inequality and its iff characterizations for a > −1; this entry extends them across the sign change of 1 + a to Mathlib's full weak domain −2 ≤ a"
+    },
+    {
+      "targetId": "binomial-theorem-oq-05",
+      "relationship": "extends",
+      "description": "binomial-theorem-oq-05 proves the strict Bernoulli inequality for a > 0; this entry reaches the opposite extreme, the negative tail −2 ≤ a ≤ −1"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "BernoulliInequalityOQ01OQ01",
+    "lineCount": 136,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/BernoulliInequalityOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Jacob Bernoulli",
+      "title": "Positiones Arithmeticae de Seriebus Infinitis",
+      "year": "1689",
+      "venue": "Basel",
+      "note": "Early use of the inequality 1 + nx ≤ (1+x)ⁿ in the study of infinite series"
+    },
+    {
+      "authors": "D. S. Mitrinović",
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Springer-Verlag",
+      "note": "Standard reference on Bernoulli's inequality, its strict forms, and the admissible domains"
+    }
+  ],
+  "sorries": 0
+}

--- a/src/data/research/problems/bernoulli-inequality-oq-01-oq-01.json
+++ b/src/data/research/problems/bernoulli-inequality-oq-01-oq-01.json
@@ -1,0 +1,68 @@
+{
+  "slug": "bernoulli-inequality-oq-01-oq-01",
+  "title": "Strict Bernoulli on Mathlib's full weak domain −2 ≤ a",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "tractability": 8,
+  "significance": 5,
+  "path": "fast",
+  "problemStatement": "Mathlib's weak Bernoulli inequality one_add_mul_le_pow holds for all −2 ≤ a, but the strict form 1 + n·a < (1+a)ⁿ (a ≠ 0, n ≥ 2) had only been proved for a > −1. Extend strictness across the sign change of 1 + a to the entire weak domain −2 ≤ a, and characterize strictness and equality there.",
+  "leanFiles": [
+    {
+      "path": "Proofs/BernoulliInequalityOQ01OQ01.lean",
+      "filename": "BernoulliInequalityOQ01OQ01.lean",
+      "lineCount": 136,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BernoulliInequalityOQ01OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "bernoulli-inequality-oq-01",
+    "bernoulli-inequality-oq-01-oq-01",
+    "binomial-theorem-oq-05"
+  ],
+  "knowledge": {
+    "insights": [
+      "The obstruction to extending strict Bernoulli below a = −1 is the sign change of the factor 1 + a, not the sign of a: the parent's Nat.le_induction multiplies the estimate by 1 + a and needs 1 + a > 0, i.e. a > −1.",
+      "On the negative tail −2 ≤ a ≤ −1 the power is trapped: |1 + a| ≤ 1 gives |(1+a)ⁿ| ≤ 1, so (1+a)ⁿ ≥ −1. Meanwhile a ≤ −1 forces 1 + n·a ≤ 1 − n, which is < −1 for n ≥ 3, so the line escapes below the entire range of the power.",
+      "The only value resisting the size argument is n = 2, where the gap is exactly a² > 0 — unconditional and valid even at the endpoint a = −2.",
+      "−2 is exactly the left endpoint of Mathlib's weak one_add_mul_le_pow, so the strict form now matches the weak form's domain and is a drop-in strengthening."
+    ],
+    "builtItems": [
+      "one_add_mul_lt_pow_full (BernoulliInequalityOQ01OQ01.lean:72): strict 1 + n·a < (1+a)ⁿ for all −2 ≤ a, a ≠ 0, n ≥ 2",
+      "one_add_mul_lt_pow_pos (BernoulliInequalityOQ01OQ01.lean:45): self-contained a > −1 inductive case",
+      "one_add_mul_lt_pow_full_iff (BernoulliInequalityOQ01OQ01.lean:96): strictness ⇔ a ≠ 0 ∧ 2 ≤ n on −2 ≤ a",
+      "one_add_mul_eq_pow_full_iff (BernoulliInequalityOQ01OQ01.lean:110): equality ⇔ a = 0 ∨ n ≤ 1 on −2 ≤ a"
+    ],
+    "mathlibGaps": [
+      "Mathlib has no strict integer-power Bernoulli inequality (only weak one_add_mul_le_pow and the rpow strict form one_add_mul_self_lt_rpow_one_add); the negative-range strict integer form proved here is absent."
+    ],
+    "nextSteps": [
+      "Investigate whether −2 is the true left endpoint for every fixed n, or whether some n admit a < −2 (the size argument suggests larger n tolerate more, but |1+a| ≤ 1 is essential).",
+      "Package the −2 ≤ a ≤ −1 mechanism as a reusable 'line escapes a bounded power' lemma for other truncated binomial bounds."
+    ],
+    "progressSummary": "COMPLETE: strict Bernoulli extended to Mathlib's full weak domain −2 ≤ a (4 theorems, 0 sorries, 0 axioms), verified [propext, Classical.choice, Quot.sound]."
+  },
+  "knownResults": [],
+  "references": [
+    "Mathlib one_add_mul_le_pow (weak Bernoulli, −2 ≤ a)",
+    "D. S. Mitrinović, Analytic Inequalities (1970)"
+  ],
+  "tags": [
+    "analysis",
+    "inequality",
+    "bernoulli-inequality",
+    "strict-inequality",
+    "research"
+  ],
+  "tractability_notes": "Single-session; the negative tail needed a non-inductive size argument but no new infrastructure.",
+  "currentState": "Completed and verified; PR opened.",
+  "path_meta": "Proofs/BernoulliInequalityOQ01OQ01.lean",
+  "lastUpdate": "2026-06-24T01:02:09.000Z",
+  "started": "2026-06-24T01:02:09.000Z"
+}


### PR DESCRIPTION
## Summary

Mathlib's weak Bernoulli inequality `one_add_mul_le_pow` holds on the **full domain `−2 ≤ a`**, but the *strict* form `1 + n·a < (1 + a)ⁿ` (for `a ≠ 0`, `n ≥ 2`) had only ever been proved for `a > −1` — the parent entry `bernoulli-inequality-oq-01`, where the elementary `Nat.le_induction` multiplies the estimate by the **positive** factor `1 + a`. For `−2 ≤ a ≤ −1` that factor is non-positive and the induction collapses.

This entry extends the strict inequality across the sign change of `1 + a` to the **entire weak domain `−2 ≤ a`**, matching the reach of `one_add_mul_le_pow`, and supplies the two-sided characterizations there.

## Results (`Proofs/BernoulliInequalityOQ01OQ01.lean`)

- **`one_add_mul_lt_pow_full`** — strict `1 + n·a < (1 + a)ⁿ` for every `−2 ≤ a` with `a ≠ 0` and `n ≥ 2` (the new range is `−2 ≤ a ≤ −1`).
- **`one_add_mul_lt_pow_full_iff`** — strictness holds **iff** `a ≠ 0 ∧ 2 ≤ n`.
- **`one_add_mul_eq_pow_full_iff`** — equality holds **iff** `a = 0 ∨ n ≤ 1`.

## The negative-tail argument

The parent's induction is unavailable once `1 + a ≤ 0`. On `−2 ≤ a ≤ −1`:

- `|1 + a| ≤ 1` ⟹ `|(1 + a)ⁿ| ≤ 1` (`pow_le_one₀`), so `(1 + a)ⁿ ≥ −1`;
- `a ≤ −1` ⟹ `1 + n·a ≤ 1 − n`, which is `< −1` as soon as `n ≥ 3`.

So the line `1 + n·a` drops below the entire range `[−1, 1]` of the power. The single remaining value `n = 2` is the unconditional identity `(1+a)² − (1+2a) = a² > 0`, valid even at the endpoint `a = −2`.

## Verification

- 4 theorems, **0 sorries, 0 axioms**.
- Kernel-verified on Mathlib **v4.26.0**: all three headline theorems depend only on `[propext, Classical.choice, Quot.sound]`.
- Numeric witnesses inside the new range, including the boundary `a = −2`: `1 + 3·(−2) = −5 < −1 = (1 − 2)³`.

## Relation to existing work

- **Extends** `bernoulli-inequality-oq-01` (strict + iffs for `a > −1`) to `−2 ≤ a`.
- **Complements** `binomial-theorem-oq-05` (strict for `a > 0`) at the opposite extreme.
- Strict integer-power Bernoulli on the negative range is **absent from Mathlib** (which has only the weak integer form and an `rpow` strict form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)