### PR TITLE
research(gcd-algorithm-oq-04-oq-01): register missing Proofs.lean import

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2827,6 +2827,7 @@ import Proofs.GaussWilsonNonCyclicOQ01B
 import Proofs.GaussWilsonNonCyclicOQ03
 import Proofs.GcdAlgorithmOQ02
 import Proofs.GcdAlgorithmOQ04
+import Proofs.GcdAlgorithmOQ04OQ01
 import Proofs.GelfondSchneider
 import Proofs.GeneralQuartic
 import Proofs.GeneralQuarticAxiomsDischarge


### PR DESCRIPTION
## Summary

PR #28562 shipped the verified entry **gcd-algorithm-oq-04-oq-01** ("Normalization on k[X] is the monic representative") — adding `proofs/Proofs/GcdAlgorithmOQ04OQ01.lean`, the gallery `meta.json`, and `research/problems/.../knowledge.md` — but **did not add the module import to `proofs/Proofs.lean`**.

As a result the proof is orphaned from the aggregate build graph: it is never compiled by the gallery build, has no olean, and is not covered by CI verification despite being presented as `verified`.

This one-line PR registers the import:

```lean
import Proofs.GcdAlgorithmOQ04OQ01
```

## Verification

The proof file itself is unchanged. It was independently kernel-verified on Mathlib v4.26.0 (`lake env lean`, exit 0, no errors/warnings). Spot-checked axiom profiles of the headline theorems:

- `normalize_eq_C_inv_leadingCoeff_mul`
- `exists_unique_monic_associate`
- `monic_normalize_gcd`
- `dvd_normalize_gcd`

each depend only on `[propext, Classical.choice, Quot.sound]` — 0 axioms, 0 sorries.

## Labels

research / integrity fix. No `loom:review-requested` (math-agent PR, deployer merges directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)