### PR TITLE
research(baire-category-theorem-oq-01-oq-01): Banach–Steinhaus from Baire [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -226,6 +226,8 @@ import Proofs.AutomorphicNumberOQ01
 import Proofs.AutomorphicNumberOQ01OQ01
 import Proofs.AutomorphicNumberOQ01OQ02
 import Proofs.AutomorphicNumberOQ01OQ03
+import Proofs.BaireCategoryTheoremOQ01
+import Proofs.BaireCategoryTheoremOQ01OQ01
 import Proofs.BallotProblem
 import Proofs.BallotProblemOQ01
 import Proofs.BallotProblemOQ01OQ01

--- a/proofs/Proofs/BaireCategoryTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/BaireCategoryTheoremOQ01OQ01.lean
@@ -1,0 +1,119 @@
+import Mathlib
+import Proofs.BaireCategoryTheoremOQ01
+
+/-!
+# The Uniform Boundedness Principle from Baire's theorem
+
+This file derives the **Banach–Steinhaus theorem** (the *Uniform Boundedness Principle*)
+directly from the gallery Baire category theorem
+(`BaireCategoryTheoremOQ01.baire_nonempty_interior`), rather than invoking Mathlib's
+packaged `banach_steinhaus`.
+
+The statement: if `g : ι → E →L[𝕜] F` is a family of bounded linear operators from a
+**Banach** space `E` into a normed space `F` that is *pointwise bounded*
+(`∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C`), then the operator norms are *uniformly bounded*
+(`∃ C', ∀ i, ‖g i‖ ≤ C'`).
+
+## The classical Baire argument
+
+This is the textbook proof, and it is genuinely distinct from current Mathlib, whose
+`banach_steinhaus` is deduced from the barrelled-space / equicontinuity framework
+(`WithSeminorms.banach_steinhaus`). Here we run the original closed-set exhaustion:
+
+* For each `n : ℕ` form the closed "sublevel" set `e n = ⋂ i, {x | ‖g i x‖ ≤ n}`.
+* Pointwise boundedness makes `⋃ n, e n` the whole space.
+* The **gallery Baire theorem** (category form) hands us an `m` with `interior (e m) ≠ ∅`,
+  i.e. a ball `ball x ε` on which *every* `g i` is bounded by `m`.
+* A translation-and-scaling (shell) estimate turns this local bound into the uniform
+  operator-norm bound `‖g i‖ ≤ 2m / (ε/‖c‖)`.
+
+## Main results
+
+* `uniform_boundedness` — the Uniform Boundedness Principle.
+* `uniform_boundedness_with_const` — the same with an explicit `‖g i x‖ ≤ C' * ‖x‖`
+  equicontinuity-style bound.
+* `exists_resonance_of_not_uniformly_bounded` — the contrapositive **resonance**
+  statement: a family with unbounded operator norms must have a point of resonance,
+  a single `x` at which `sup_i ‖g i x‖ = ∞`.
+
+All results are fully machine-checked, no `sorry`, no extra axioms.
+-/
+
+namespace BaireCategoryTheoremOQ01OQ01
+
+open Set Metric BaireCategoryTheoremOQ01
+
+variable {𝕜 E F : Type*} [NontriviallyNormedField 𝕜]
+  [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- **Uniform Boundedness Principle (Banach–Steinhaus).** A pointwise-bounded family of
+bounded linear operators from a Banach space into a normed space is uniformly bounded in
+operator norm. Proved from the gallery Baire category theorem. -/
+theorem uniform_boundedness {ι : Type*} {g : ι → E →L[𝕜] F}
+    (h : ∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C) : ∃ C', ∀ i, ‖g i‖ ≤ C' := by
+  haveI : Nonempty E := ⟨0⟩
+  -- The closed sublevel sets `e n = ⋂ i, {x | ‖g i x‖ ≤ n}`.
+  set e : ℕ → Set E := fun n => ⋂ i : ι, {x : E | ‖g i x‖ ≤ n} with he
+  have hc : ∀ n : ℕ, IsClosed (e n) := fun n =>
+    isClosed_iInter fun i => isClosed_le (g i).cont.norm continuous_const
+  -- Pointwise boundedness exhausts the whole space.
+  have hU : (⋃ n : ℕ, e n) = univ := by
+    refine eq_univ_of_forall fun x => ?_
+    obtain ⟨C, hC⟩ := h x
+    obtain ⟨m, hm⟩ := exists_nat_ge C
+    exact mem_iUnion.2 ⟨m, mem_iInter.2 fun i => (hC i).trans hm⟩
+  -- Baire: some `e m` has nonempty interior, hence contains a ball.
+  obtain ⟨m, hmne⟩ := baire_nonempty_interior hc hU
+  obtain ⟨x, hx⟩ := hmne
+  obtain ⟨ε, ε_pos, hε⟩ := Metric.isOpen_iff.mp isOpen_interior x hx
+  obtain ⟨c, hc1⟩ := NormedField.exists_one_lt_norm 𝕜
+  have hcpos : (0 : ℝ) < ‖c‖ := zero_lt_one.trans hc1
+  have εc_pos : 0 < ε / ‖c‖ := div_pos ε_pos hcpos
+  -- Every operator is bounded by `m` on the ball.
+  have ball_le : ∀ z ∈ ball x ε, ∀ i, ‖g i z‖ ≤ (m : ℝ) := by
+    intro z hz i
+    have hzm : z ∈ e m := interior_subset (hε hz)
+    exact mem_iInter.1 hzm i
+  -- The uniform constant.
+  refine ⟨(m + m : ℝ) / (ε / ‖c‖), fun i => ?_⟩
+  refine ContinuousLinearMap.opNorm_le_of_shell ε_pos ?_ hc1 ?_
+  · exact div_nonneg (by positivity) εc_pos.le
+  · intro y le_y y_lt
+    -- `y` and `y + x` both lie in the ball, so `g i y = g i (y+x) - g i x` is small.
+    have hyx : y + x ∈ ball x ε := by
+      rw [mem_ball, dist_eq_norm, add_sub_cancel_right]; exact y_lt
+    have hx0 : x ∈ ball x ε := mem_ball_self ε_pos
+    have hmap : g i y = g i (y + x) - g i x := by rw [map_add]; abel
+    have key : ‖g i y‖ ≤ (m + m : ℝ) := by
+      rw [hmap]
+      calc ‖g i (y + x) - g i x‖
+          ≤ ‖g i (y + x)‖ + ‖g i x‖ := norm_sub_le _ _
+        _ ≤ (m : ℝ) + m := add_le_add (ball_le _ hyx i) (ball_le _ hx0 i)
+    -- The shell hypothesis `ε/‖c‖ ≤ ‖y‖` upgrades the flat bound to a proportional one.
+    have step : (m + m : ℝ) ≤ (m + m : ℝ) / (ε / ‖c‖) * ‖y‖ := by
+      rw [div_mul_eq_mul_div, le_div_iff₀ εc_pos]
+      exact mul_le_mul_of_nonneg_left le_y (by positivity)
+    exact key.trans step
+
+/-- The Uniform Boundedness Principle in *equicontinuity* form: there is a single constant
+`C'` with `‖g i x‖ ≤ C' * ‖x‖` for every operator `i` and every point `x`. -/
+theorem uniform_boundedness_with_const {ι : Type*} {g : ι → E →L[𝕜] F}
+    (h : ∀ x, ∃ C, ∀ i, ‖g i x‖ ≤ C) : ∃ C', 0 ≤ C' ∧ ∀ i, ∀ x, ‖g i x‖ ≤ C' * ‖x‖ := by
+  obtain ⟨C', hC'⟩ := uniform_boundedness h
+  refine ⟨max C' 0, le_max_right _ _, fun i x => ?_⟩
+  calc ‖g i x‖ ≤ ‖g i‖ * ‖x‖ := (g i).le_opNorm x
+    _ ≤ max C' 0 * ‖x‖ :=
+        mul_le_mul_of_nonneg_right ((hC' i).trans (le_max_left _ _)) (norm_nonneg _)
+
+/-- **Resonance (contrapositive of Banach–Steinhaus).** If the operator norms of a family
+are *not* uniformly bounded, then the family cannot be pointwise bounded: there exists a
+single point `x` of resonance at which `sup_i ‖g i x‖` is infinite (no finite `C` bounds
+`‖g i x‖` over all `i`). -/
+theorem exists_resonance_of_not_uniformly_bounded {ι : Type*} {g : ι → E →L[𝕜] F}
+    (h : ¬ ∃ C', ∀ i, ‖g i‖ ≤ C') : ∃ x, ¬ ∃ C, ∀ i, ‖g i x‖ ≤ C := by
+  by_contra hcon
+  push_neg at hcon
+  exact h (uniform_boundedness hcon)
+
+end BaireCategoryTheoremOQ01OQ01

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "ann-baire-oq0101-docstring",
+    "proofId": "baire-category-theorem-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 40 },
+    "type": "context",
+    "title": "Banach–Steinhaus from Baire — Goal and Plan",
+    "content": "The docstring fixes the objective: derive the Uniform Boundedness Principle (Banach–Steinhaus) directly from the gallery Baire category theorem (BaireCategoryTheoremOQ01.baire_nonempty_interior), NOT by invoking Mathlib's packaged banach_steinhaus. It previews the classical textbook argument — closed sublevel sets, their union exhausting the space, Baire producing a ball of local uniform boundedness, and a shell estimate promoting that to a uniform operator-norm bound — and notes this is genuinely distinct from Mathlib's current proof, which goes through the barrelled-space / equicontinuity framework. Three results: the principle, an equicontinuity-form restatement, and the contrapositive resonance principle.",
+    "mathContext": "If $\\{g_i\\}$ are bounded operators on a Banach space with $\\sup_i \\|g_i x\\| < \\infty$ for each $x$, then $\\sup_i \\|g_i\\| < \\infty$.",
+    "significance": "context",
+    "relatedConcepts": ["Banach–Steinhaus theorem", "uniform boundedness principle", "Baire category theorem", "operator norm", "functional analysis"],
+    "prerequisites": ["normed and Banach spaces", "bounded linear operators", "operator norm"]
+  },
+  {
+    "id": "ann-baire-oq0101-ubp",
+    "proofId": "baire-category-theorem-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 97 },
+    "type": "theorem",
+    "title": "The Uniform Boundedness Principle",
+    "content": "uniform_boundedness is the heart of the entry. Define the sublevel sets e n = ⋂ i, {x | ‖g i x‖ ≤ n}; each is closed because x ↦ ‖g i x‖ is continuous (isClosed_le applied to the intersection). Pointwise boundedness — every x has a finite bound C, dominated by some natural m — gives ⋃ n e n = univ. Completeness makes E a Baire space, so the gallery category form baire_nonempty_interior returns an m with interior (e m) nonempty: a ball ball x ε on which every ‖g i ·‖ ≤ m. The off-center bound is homogenized by the shell trick: for ε/‖c‖ ≤ ‖y‖ < ε, write g i y = g i (y+x) − g i x (both arguments in the ball) to get ‖g i y‖ ≤ 2m, then ‖g i y‖ ≤ (2m/(ε/‖c‖))·‖y‖. ContinuousLinearMap.opNorm_le_of_shell converts this into ‖g i‖ ≤ 2m/(ε/‖c‖), a bound independent of i.",
+    "mathContext": "Baire gives a ball where all $\\|g_i\\cdot\\| \\le m$; translation $g_i y = g_i(y+x) - g_i x$ yields $\\|g_i y\\| \\le 2m$ on the shell, so $\\|g_i\\| \\le 2m/(\\varepsilon/\\|c\\|)$.",
+    "significance": "key",
+    "relatedConcepts": ["baire_nonempty_interior", "isClosed_le", "opNorm_le_of_shell", "sublevel set", "shell estimate"],
+    "prerequisites": ["Baire category theorem", "operator norm", "continuity of the norm", "completeness ⇒ Baire space"]
+  },
+  {
+    "id": "ann-baire-oq0101-consequences",
+    "proofId": "baire-category-theorem-oq-01-oq-01",
+    "range": { "startLine": 99, "endLine": 117 },
+    "type": "theorem",
+    "title": "Equicontinuity and Resonance Restatements",
+    "content": "Two application-facing forms. uniform_boundedness_with_const repackages the uniform operator-norm bound as a single nonnegative constant C' with ‖g i x‖ ≤ C'·‖x‖ for all i and x, obtained by chaining le_opNorm with the uniform bound — the homogeneous (equicontinuity) inequality used in convergence-of-operators arguments. exists_resonance_of_not_uniformly_bounded is the contrapositive resonance principle: if the operator norms are NOT uniformly bounded, then the pointwise-boundedness hypothesis must fail somewhere, so there is a single point x of resonance at which no finite C bounds ‖g i x‖ over all i. Its proof is a clean by_contra / push_neg reduction to uniform_boundedness. This is the lever behind classical condensation-of-singularities constructions.",
+    "mathContext": "Equicontinuity: $\\|g_i x\\| \\le C'\\|x\\|$. Resonance: $\\neg(\\exists C', \\forall i, \\|g_i\\| \\le C') \\Rightarrow \\exists x,\\ \\sup_i \\|g_i x\\| = \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["le_opNorm", "equicontinuity", "resonance", "condensation of singularities", "contrapositive"],
+    "prerequisites": ["operator norm bound", "proof by contradiction", "push_neg"]
+  }
+]

--- a/src/data/proofs/baire-category-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/baire-category-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "baire-category-theorem-oq-01-oq-01",
+  "slug": "baire-category-theorem-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BaireCategoryTheoremOQ01"
+    ],
+    "opens": [
+      "Set",
+      "Metric",
+      "BaireCategoryTheoremOQ01"
+    ],
+    "namespace": "BaireCategoryTheoremOQ01OQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "path": "Proofs/BaireCategoryTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Uniform Boundedness Principle from Baire's Theorem",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BaireCategoryTheoremOQ01OQ01.lean",
+    "tags": [
+      "functional-analysis",
+      "banach-steinhaus",
+      "uniform-boundedness",
+      "baire-category",
+      "operator-norm",
+      "banach-space",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 119,
+    "theoremCount": 3,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "uniform_boundedness: the Banach–Steinhaus theorem (Uniform Boundedness Principle) — a pointwise-bounded family g : ι → E →L[𝕜] F of bounded linear operators from a Banach space E into a normed space F has uniformly bounded operator norms. Proved by the classical closed-set exhaustion argument built ON TOP of the gallery Baire category theorem (BaireCategoryTheoremOQ01.baire_nonempty_interior), NOT by invoking Mathlib's banach_steinhaus.",
+      "The derivation is genuinely distinct from current Mathlib: Mathlib's banach_steinhaus is now deduced from the barrelled-space / equicontinuity framework (WithSeminorms.banach_steinhaus via the equicontinuous TFAE), whereas this entry runs the original Baire argument — closed sublevel sets e n = ⋂ i {x | ‖g i x‖ ≤ n}, their union exhausting the space, Baire producing a ball of uniform local boundedness, and a translation-and-scaling (shell) estimate (opNorm_le_of_shell) converting the local bound ‖g i‖ ≤ 2m/(ε/‖c‖).",
+      "uniform_boundedness_with_const: the equicontinuity-form restatement — a single nonnegative constant C' with ‖g i x‖ ≤ C' · ‖x‖ for every operator i and every point x, the bound actually used in convergence arguments.",
+      "exists_resonance_of_not_uniformly_bounded: the contrapositive resonance principle — a family whose operator norms are NOT uniformly bounded must admit a point of resonance, a single x at which no finite C bounds ‖g i x‖ over all i (sup_i ‖g i x‖ = ∞). This is the form invoked in the standard constructions of divergent Fourier series and other resonance phenomena."
+    ],
+    "prerequisites": [
+      "The gallery Baire category theorem in category form (BaireCategoryTheoremOQ01.baire_nonempty_interior): a countable closed cover of a nonempty Baire space has a member with nonempty interior.",
+      "CompleteSpace E ⇒ BaireSpace E for a normed space (Mathlib instance), supplying the Baire hypothesis from completeness.",
+      "Continuous-linear-map operator-norm API: ContinuousLinearMap.opNorm_le_of_shell (shell estimate), le_opNorm, and continuity of x ↦ ‖g i x‖.",
+      "NormedField.exists_one_lt_norm: a nontrivially normed field contains an element of norm > 1, the scalar used in the shell rescaling."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ContinuousLinearMap.opNorm_le_of_shell",
+        "description": "If ‖f x‖ ≤ C·‖x‖ holds on the shell ε/‖c‖ ≤ ‖x‖ < ε (for some scalar c with 1 < ‖c‖), then ‖f‖ ≤ C. Converts the local ball bound from Baire into the uniform operator-norm bound.",
+        "module": "Mathlib.Analysis.Normed.Operator.Basic"
+      },
+      {
+        "theorem": "NormedField.exists_one_lt_norm",
+        "description": "A nontrivially normed field has an element of norm strictly greater than 1; supplies the rescaling scalar c for the shell argument.",
+        "module": "Mathlib.Analysis.Normed.Field.Basic"
+      },
+      {
+        "theorem": "isClosed_le",
+        "description": "The set {x | f x ≤ g x} is closed when f, g are continuous; used to show each sublevel set {x | ‖g i x‖ ≤ n} (and their intersection e n) is closed.",
+        "module": "Mathlib.Topology.Order.IsLUB"
+      },
+      {
+        "theorem": "ContinuousLinearMap.le_opNorm",
+        "description": "‖f x‖ ≤ ‖f‖ · ‖x‖ for a continuous linear map; turns the uniform operator-norm bound into the equicontinuity-form pointwise bound in uniform_boundedness_with_const.",
+        "module": "Mathlib.Analysis.Normed.Operator.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "baire-category-theorem-oq-01-oq-01-oq-01",
+      "question": "Derive the open mapping theorem (and hence the closed graph theorem) for Banach spaces from the same gallery Baire category theorem, completing the trio of Baire-powered cornerstones of functional analysis.",
+      "significance": "high"
+    },
+    {
+      "id": "baire-category-theorem-oq-01-oq-01-oq-02",
+      "question": "Construct an explicit resonance witness for a concrete unbounded family (e.g. the partial-sum operators of Fourier series at a point) using exists_resonance_of_not_uniformly_bounded, formalizing the existence of a continuous function with divergent Fourier series.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "slug": "baire-category-theorem-oq-01",
+      "relationship": "Parent entry providing the Baire category theorem (baire_nonempty_interior) that this derivation is built on; this resolves its lead open question."
+    }
+  ],
+  "references": [
+    {
+      "title": "Stefan Banach and Hugo Steinhaus, Sur le principe de la condensation de singularités",
+      "author": "S. Banach, H. Steinhaus",
+      "year": "1927",
+      "venue": "Fundamenta Mathematicae",
+      "description": "Original statement of the uniform boundedness principle and the condensation-of-singularities (resonance) phenomenon."
+    },
+    {
+      "title": "Walter Rudin, Functional Analysis",
+      "author": "W. Rudin",
+      "year": "1991",
+      "venue": "McGraw-Hill",
+      "description": "Textbook treatment of the Banach–Steinhaus theorem via the Baire category theorem, the argument formalized here (Theorem 2.5)."
+    },
+    {
+      "title": "Mathlib4: Analysis.Normed.Operator.BanachSteinhaus",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Mathlib's packaged banach_steinhaus, deduced from the barrelled-space framework — deliberately NOT used here, where the classical Baire proof is reproduced instead."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Banach–Steinhaus theorem (1927) is the first of the three pillars of functional analysis built on Baire's category theorem, the others being the open mapping theorem and the closed graph theorem. Banach and Steinhaus phrased it as a 'condensation of singularities' principle: if a family of bounded operators fails to be uniformly bounded, the failure must be witnessed at a single point, a *point of resonance* where the operators blow up simultaneously. The standard application is the existence of a continuous periodic function whose Fourier series diverges at a point — the Dirichlet partial-sum operators are unbounded in operator norm, so resonance produces the bad function without an explicit construction. This entry formalizes the theorem by the textbook route (Rudin, Theorem 2.5): it builds directly on the gallery's own Baire category theorem rather than calling Mathlib's `banach_steinhaus`, which today is obtained through the more abstract barrelled-space / equicontinuity machinery.",
+    "problemStatement": "Let E be a Banach space (complete normed space over a nontrivially normed field 𝕜) and F a normed space. Given a family g : ι → E →L[𝕜] F of bounded linear operators that is *pointwise bounded* — for every x there is a finite C with ‖g i x‖ ≤ C for all i — prove the operator norms are *uniformly bounded*: there is a single C' with ‖g i‖ ≤ C' for all i. Equivalently (resonance form): if the operator norms are unbounded, there exists a point x at which sup_i ‖g i x‖ = ∞.",
+    "proofStrategy": "Form the closed sublevel sets e n = ⋂ i, {x | ‖g i x‖ ≤ n}; each is closed because x ↦ ‖g i x‖ is continuous (isClosed_le). Pointwise boundedness means every x lands in some e n, so ⋃ n e n = univ. Completeness makes E a Baire space, so the gallery category form baire_nonempty_interior yields an m with interior (e m) nonempty — a ball ball x ε on which every ‖g i ·‖ ≤ m. For y in the shell ε/‖c‖ ≤ ‖y‖ < ε, write g i y = g i (y+x) − g i x with both arguments in the ball, giving ‖g i y‖ ≤ 2m ≤ (2m/(ε/‖c‖))·‖y‖; opNorm_le_of_shell then bounds ‖g i‖ ≤ 2m/(ε/‖c‖), a constant independent of i. The equicontinuity form feeds this through le_opNorm; the resonance form is the contrapositive via push_neg.",
+    "keyInsights": [
+      "The mathematics is classical (Banach–Steinhaus, 1927); the contribution is formalizing it *self-contained from the gallery Baire theorem* rather than re-exporting Mathlib's banach_steinhaus. This keeps the dependency chain honest: only the operator-norm shell estimate and the Baire category form are used, exactly the ingredients of the textbook proof.",
+      "Continuity of x ↦ ‖g i x‖ is what makes each sublevel set closed, and closedness is what lets Baire act — the whole argument hinges on packaging the pointwise bound as a *countable closed cover* so that the category form applies.",
+      "Baire only gives a ball of *local* uniform boundedness around some unknown center x; the shell/translation trick (g i y = g i(y+x) − g i x) is the device that promotes this off-center local bound to a homogeneous operator-norm bound, absorbing the unknown center into a factor of 2.",
+      "The resonance restatement is the genuinely useful form in applications: rather than constructing a singular object directly, one shows the relevant operators are not uniformly bounded and lets exists_resonance_of_not_uniformly_bounded hand back a point where they condense — the mechanism behind divergent Fourier series.",
+      "This entry is distinct from Mathlib's current proof path: Mathlib routes banach_steinhaus through WithSeminorms.banach_steinhaus and the equicontinuous TFAE (barrelled spaces), so the direct Baire closed-set argument reproduced here is not what Mathlib runs internally."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: UBP from Baire",
+      "startLine": 3,
+      "endLine": 40,
+      "summary": "States the goal — derive Banach–Steinhaus from the gallery Baire category theorem rather than Mathlib's banach_steinhaus — and outlines the classical closed-set exhaustion argument, noting the distinction from Mathlib's barrelled-space derivation.",
+      "mathContext": "Pointwise bounded family of bounded operators on a Banach space ⇒ uniformly bounded operator norms."
+    },
+    {
+      "id": "uniform-boundedness",
+      "title": "The Uniform Boundedness Principle",
+      "startLine": 50,
+      "endLine": 97,
+      "summary": "uniform_boundedness: closed sublevel sets e n = ⋂ i {x | ‖g i x‖ ≤ n} (closed via isClosed_le) whose union is the whole space (pointwise boundedness); baire_nonempty_interior gives a ball of local uniform boundedness; the shell estimate opNorm_le_of_shell turns the off-center ball bound into ‖g i‖ ≤ 2m/(ε/‖c‖).",
+      "mathContext": "Baire ⇒ ball ball x ε with ∀ i, ‖g i ·‖ ≤ m on it; translation g i y = g i(y+x) − g i x ⇒ ‖g i y‖ ≤ 2m on the shell ⇒ ‖g i‖ ≤ 2m/(ε/‖c‖)."
+    },
+    {
+      "id": "consequences",
+      "title": "Equicontinuity and Resonance Forms",
+      "startLine": 99,
+      "endLine": 117,
+      "summary": "uniform_boundedness_with_const repackages the uniform bound as a single constant C' ≥ 0 with ‖g i x‖ ≤ C'·‖x‖ (via le_opNorm). exists_resonance_of_not_uniformly_bounded is the contrapositive resonance principle: non-uniformly-bounded norms force a single point x with sup_i ‖g i x‖ = ∞.",
+      "mathContext": "Equicontinuity form ‖g i x‖ ≤ C'‖x‖; resonance: ¬(uniform op-norm bound) ⇒ ∃ x, ¬∃ C, ∀ i, ‖g i x‖ ≤ C."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Banach–Steinhaus theorem (Uniform Boundedness Principle) is derived from the gallery Baire category theorem: a pointwise-bounded family of bounded linear operators from a Banach space into a normed space has uniformly bounded operator norms (uniform_boundedness), with an equicontinuity-form restatement ‖g i x‖ ≤ C'·‖x‖ (uniform_boundedness_with_const) and the contrapositive resonance principle that non-uniformly-bounded norms force a single point of simultaneous blow-up (exists_resonance_of_not_uniformly_bounded). 119 lines, 3 theorems, 0 axioms, 0 sorries.",
+    "implications": "The result completes the lead open question of the parent Baire entry. The proof is the classical Rudin-style closed-set exhaustion run on the gallery's own baire_nonempty_interior — deliberately self-contained from Mathlib's packaged banach_steinhaus, which today is obtained through the more abstract barrelled-space framework. The resonance form is the lever behind classical singularity-condensation arguments (e.g. divergent Fourier series), recorded as a follow-up open question, and the same Baire engine yields the open mapping and closed graph theorems, the natural next targets.",
+    "openQuestions": [
+      "Derive the open mapping and closed graph theorems from the same gallery Baire category theorem.",
+      "Use the resonance principle to formalize a continuous function with a Fourier series diverging at a point."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Resolves the **lead open question** of `baire-category-theorem-oq-01`: derive the **Uniform Boundedness Principle (Banach–Steinhaus)** directly from the gallery Baire category theorem, rather than invoking Mathlib's packaged `banach_steinhaus`.

The proof is the classical Rudin-style argument run on the gallery's own `BaireCategoryTheoremOQ01.baire_nonempty_interior`:
1. Closed sublevel sets `e n = ⋂ i, {x | ‖g i x‖ ≤ n}` (closed via continuity of the norm).
2. Pointwise boundedness ⇒ `⋃ n, e n = univ`.
3. Baire (category form) ⇒ a ball of *local* uniform boundedness.
4. Shell/translation estimate (`opNorm_le_of_shell`) ⇒ uniform operator-norm bound `‖g i‖ ≤ 2m/(ε/‖c‖)`.

This is **genuinely distinct from current Mathlib**, whose `banach_steinhaus` is deduced from the barrelled-space / equicontinuity (`WithSeminorms.banach_steinhaus`) framework — the direct closed-set Baire argument is not what Mathlib runs internally.

## Theorems (3, 0 def, 0 sorries, 0 axioms)
- `uniform_boundedness` — the Banach–Steinhaus theorem.
- `uniform_boundedness_with_const` — equicontinuity form: one constant `C' ≥ 0` with `‖g i x‖ ≤ C'·‖x‖`.
- `exists_resonance_of_not_uniformly_bounded` — contrapositive **resonance** principle: unbounded operator norms force a single point of simultaneous blow-up (the lever behind divergent-Fourier-series constructions).

## Verification
Kernel-verified with `lake env lean` (against `origin/main`'s parent file, byte-identical). All three theorems:
```
depends on axioms: [propext, Classical.choice, Quot.sound]
```
No `sorry`, no `native_decide`, no extra axioms.

## Files
- `proofs/Proofs/BaireCategoryTheoremOQ01OQ01.lean` (new, 119 lines)
- `src/data/proofs/baire-category-theorem-oq-01-oq-01/{meta,annotations}.json` (new)
- `proofs/Proofs.lean` — register the new import (and the parent, which was unregistered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)