### PR TITLE
audit: record 3 amgm Newton–Girard entries clean (kernel-verified v4.26.0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17779,8 +17779,26 @@
       "lastAudited": "2026-06-24T00:23:38Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "result": "clean",
+      "lastAudited": "2026-06-24T01:10:00Z"
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "result": "clean",
+      "lastAudited": "2026-06-24T01:10:00Z"
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "result": "clean",
+      "lastAudited": "2026-06-24T01:10:00Z"
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-21T13:10:00Z"
+  "lastUpdated": "2026-06-24T01:10:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — 3 entries CLEAN

Re-audited the AM-GM OQ-02-OQ-01 Newton–Girard chain. All three files were **kernel-rebuilt on Mathlib v4.26.0** via `lake env lean` (exit 0, 0 errors), and `#print axioms` on every theorem shows only the standard foundational triple `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.

| Slug | Badge | Verdict |
|------|-------|---------|
| `amgm-inequality-oq-02-oq-01-oq-01` | `mathlib` | CLEAN — Full Newton–Girard recurrence; 3/4 thms are direct Mathlib restatements, honestly disclosed ("by invoking Mathlib's combinatorial development") |
| `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01` | `original` | CLEAN — Reverse Newton: `eₖ ∈ adjoin ℚ(power sums)` via strong induction; genuinely new content Mathlib lacks |
| `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01-oq-01-oq-01` | `original` | CLEAN — Power sums generate symmetric subalgebra; synthesis of Mathlib FTSP ∘ reverse Newton, Mathlib reliance fully disclosed |

All three: `status: verified`, `sorries: 0`, `axiomCount: 0`, narrative accurate per tier classification. Badges (`mathlib`/`original`) correctly match the actual provenance.

This PR only updates `audit-tracker.json` (audit bookkeeping).

---
Discovered during gallery integrity audit. Tracker records persisted via PR because concurrent `git reset --hard origin/main` on the shared checkout wipes in-place tracker edits.