### PR TITLE
audit: amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01 CLEAN (General Newton–Girard recurrence)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17797,8 +17797,14 @@
       "issues": [],
       "result": "clean",
       "lastAudited": "2026-06-24T01:10:00Z"
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T01:43:02Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T01:10:00Z"
+  "lastUpdated": "2026-06-24T01:43:02Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01` — *General Newton–Girard Recurrence for Arbitrary k*
**Result**: CLEAN, no issues. Records audit in `audit-tracker.json`.

### Verification

| Check | Result |
|-------|--------|
| sorries | 0 (grep + kernel) |
| axiom declarations | 0 |
| True stubs | none |
| `#print axioms` | `[propext, Classical.choice, Quot.sound]` for both `psum_recurrence` and `mul_esymm_recurrence` — no `sorryAx`, no `Lean.ofReduceBool` |
| theoremCount / lineCount | 2 / 152 — match source |
| mainTheorems statements | match source verbatim |
| native_decide | none (the `decide` calls are kernel-level Finset facts on small literals) |

### Tier classification

**Tier B (mathlib badge)** — correctly applied. The headline identity delegates to Mathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum`, which is **explicitly credited** in the overview's first paragraph and in `assumptions`. The genuine new content is the reindexing of Mathlib's filtered antidiagonal `{a ∈ antidiagonal k | 0 < a.1 < k}` to the closed-form interval sum over `Ico 1 k`. No delegation opacity, no overclaiming.

The subsumption claim ("k=4 and k=5 recovered verbatim") is accurate: the example RHS expressions match the parent's `psum_four_eq` / `psum_five_eq` statements exactly.

Kernel-verified at Mathlib v4.26.0 via `lake env lean`.

---
Discovered during gallery integrity audit.