### PR TITLE
Enrich arcosh logarithmic form and addition law

### DIFF
--- a/src/data/proofs/arsinh-log-formula-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/arsinh-log-formula-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "arcosh-oq0102-ann-eqlog",
+    "proofId": "arsinh-log-formula-oq-01-oq-02",
+    "range": { "startLine": 43, "endLine": 48 },
+    "type": "definition",
+    "title": "Logarithmic form of arcosh (the open question)",
+    "content": "States the closed form arcosh x = log(x + √(x²−1)). Mathlib defines Real.arcosh by exactly this expression, so the identity holds by rfl; it is recorded as a named lemma mirroring the parent's arsinh_eq_log. This is the literal answer to the parent's second open question, and the 'mathlib' badge content — the genuinely new material is the algebraic addition laws built on top of it.",
+    "mathContext": "$\\operatorname{arcosh} x = \\log\\!\\big(x + \\sqrt{x^2 - 1}\\big)$, the inverse of $\\cosh$ restricted to $[1,\\infty)$.",
+    "significance": "key",
+    "relatedConcepts": ["inverse hyperbolic cosine", "logarithmic form", "Real.arcosh", "definitional equality"],
+    "prerequisites": ["hyperbolic functions", "natural logarithm"]
+  },
+  {
+    "id": "arcosh-oq0102-ann-helper",
+    "proofId": "arsinh-log-formula-oq-01-oq-02",
+    "range": { "startLine": 50, "endLine": 54 },
+    "type": "technique",
+    "title": "Radicand-nonnegativity helper",
+    "content": "For x ≥ 1 the radicand x²−1 is nonnegative, so √(x²−1)·√(x²−1) = x²−1 (Real.mul_self_sqrt, discharged by nlinarith). This little lemma is what lets the square roots cancel cleanly in the doubling law and is implicitly the reason sinh(arcosh x) = √(x²−1) is well-defined on the domain.",
+    "mathContext": "$x \\ge 1 \\Rightarrow x^2 - 1 \\ge 0$, so $\\sqrt{x^2-1}\\cdot\\sqrt{x^2-1} = x^2 - 1$.",
+    "significance": "technical",
+    "relatedConcepts": ["square root of nonnegative reals", "Real.mul_self_sqrt", "nlinarith"],
+    "prerequisites": ["properties of √ on [0,∞)"]
+  },
+  {
+    "id": "arcosh-oq0102-ann-add",
+    "proofId": "arsinh-log-formula-oq-01-oq-02",
+    "range": { "startLine": 56, "endLine": 71 },
+    "type": "insight",
+    "title": "Addition law for arcosh",
+    "content": "The headline new result: for x, y ≥ 1, arcosh x + arcosh y = arcosh(xy + √(x²−1)√(y²−1)). The proof is a clean 'apply cosh, then invert' argument: cosh(arcosh x + arcosh y) is expanded by cosh_add and the inverse facts cosh(arcosh x)=x, sinh(arcosh x)=√(x²−1), giving the bracketed expression; since both arcosh values are ≥ 0 their sum lies in [0,∞) where arcosh inverts cosh (arcosh_cosh), closing the goal. This is the cosh-angle-addition counterpart of the parent's arsinh addition law, and is absent from Mathlib.",
+    "mathContext": "$\\operatorname{arcosh} x + \\operatorname{arcosh} y = \\operatorname{arcosh}\\!\\big(xy + \\sqrt{x^2-1}\\,\\sqrt{y^2-1}\\big)$, from $\\cosh(a+b)=\\cosh a\\cosh b+\\sinh a\\sinh b$.",
+    "significance": "key",
+    "relatedConcepts": ["hyperbolic angle addition", "cosh_add", "cosh_arcosh / sinh_arcosh", "inverting on the principal domain"],
+    "prerequisites": ["cosh addition formula", "arcosh inverse facts", "arcosh_nonneg"]
+  },
+  {
+    "id": "arcosh-oq0102-ann-sub",
+    "proofId": "arsinh-log-formula-oq-01-oq-02",
+    "range": { "startLine": 73, "endLine": 89 },
+    "type": "concept",
+    "title": "Subtraction law for arcosh",
+    "content": "The dual of the addition law: for 1 ≤ y ≤ x, arcosh x − arcosh y = arcosh(xy − √(x²−1)√(y²−1)), from cosh(a−b)=cosh a cosh b − sinh a sinh b. The domain bookkeeping is the subtle part: the hypothesis y ≤ x makes arcosh y ≤ arcosh x (arcosh_le_arcosh, monotonicity), so the difference is ≥ 0 and lands in [0,∞) where arcosh inverts cosh — exactly the condition needed to apply arcosh_cosh.",
+    "mathContext": "$\\operatorname{arcosh} x - \\operatorname{arcosh} y = \\operatorname{arcosh}\\!\\big(xy - \\sqrt{x^2-1}\\,\\sqrt{y^2-1}\\big)$ for $1 \\le y \\le x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cosh subtraction formula", "monotonicity of arcosh", "arcosh_le_arcosh", "domain conditions"],
+    "prerequisites": ["cosh subtraction formula", "arcosh monotonicity"]
+  },
+  {
+    "id": "arcosh-oq0102-ann-double",
+    "proofId": "arsinh-log-formula-oq-01-oq-02",
+    "range": { "startLine": 91, "endLine": 98 },
+    "type": "concept",
+    "title": "Doubling law for arcosh",
+    "content": "The x = y specialisation of the addition law: for x ≥ 1, 2·arcosh x = arcosh(2x²−1). After rewriting 2·arcosh x as arcosh x + arcosh x and applying arcosh_add, the radicand-helper √(x²−1)·√(x²−1)=x²−1 collapses the inner expression x·x + (x²−1) to 2x²−1 by ring. The cosh-side analogue of the double-angle formula.",
+    "mathContext": "$2\\operatorname{arcosh} x = \\operatorname{arcosh}(2x^2 - 1)$, since $x\\cdot x + \\sqrt{x^2-1}^{\\,2} = x^2 + (x^2-1) = 2x^2-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["hyperbolic double-angle", "specialisation of addition law", "ring normalisation"],
+    "prerequisites": ["arcosh_add", "the radicand helper"]
+  },
+  {
+    "id": "arcosh-oq0102-ann-values",
+    "proofId": "arsinh-log-formula-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 114 },
+    "type": "technique",
+    "title": "Concrete evaluations arcosh(5/4)=log 2, arcosh(5/3)=log 3",
+    "content": "Two explicit values mirroring the parent's arsinh(3/4)=log 2 and arsinh(4/3)=log 3. Each is computed directly from the logarithmic form: the radical √((5/4)²−1) simplifies to the rational 3/4 (and √((5/3)²−1) to 4/3) because the radicand is a perfect rational square, so arcosh(5/4)=log(5/4+3/4)=log 2 by norm_num. These exhibit the 3-4-5 Pythagorean structure behind cosh(log 2)=5/4.",
+    "mathContext": "$\\operatorname{arcosh}\\tfrac54 = \\log\\!\\big(\\tfrac54+\\tfrac34\\big) = \\log 2$; $\\;\\operatorname{arcosh}\\tfrac53 = \\log\\!\\big(\\tfrac53+\\tfrac43\\big) = \\log 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["closed-form evaluation", "perfect-square radicands", "Pythagorean triples", "Real.sqrt_sq"],
+    "prerequisites": ["arcosh_eq_log", "norm_num"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `arsinh-log-formula-oq-01-oq-02`.

The entry shipped with rich meta.json but **no annotations.json** — zero inline annotation coverage. This pass fills it.

## Changes
- **annotations.json** (newly created): 6 line-ranged annotations spanning the whole file:
  - the logarithmic form `arcosh x = log(x + √(x²−1))` (definitional in Mathlib)
  - the radicand-nonnegativity helper
  - the addition law (apply-cosh-then-invert argument)
  - the subtraction law (with its monotonicity-based domain bookkeeping)
  - the doubling law (specialisation of addition)
  - the concrete evaluations `arcosh(5/4)=log 2`, `arcosh(5/3)=log 3`
  - each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`

Verified with `pnpm build` (exit 0). No mathematical claims changed; status/badge/axiomCount untouched.