### PR TITLE
research(sylow-theorem-oq-03-oq-02): counting forces normal Sylow q; Schur–Zassenhaus splits every order-pq group as Q⋊K

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3613,6 +3613,7 @@ import Proofs.SylowTheoremOQ01
 import Proofs.SylowTheoremOQ02
 import Proofs.SylowTheoremOQ02Orbit
 import Proofs.SylowTheoremOQ03
+import Proofs.SylowTheoremOQ03OQ02
 import Proofs.SylowTheoremSchurZassenhausOQ03
 import Proofs.SylowTheoremOQ03B
 import Proofs.SylowTheoremOQ04

--- a/proofs/Proofs/SylowTheoremOQ03OQ02.lean
+++ b/proofs/Proofs/SylowTheoremOQ03OQ02.lean
@@ -1,0 +1,211 @@
+import Mathlib.GroupTheory.Sylow
+import Mathlib.GroupTheory.SchurZassenhaus
+import Mathlib.GroupTheory.Complement
+import Mathlib.GroupTheory.SpecificGroups.Cyclic
+import Mathlib.Tactic
+
+/-
+# OQ-03-OQ-02: Counting forces a normal Sylow subgroup, and Schur–Zassenhaus splits it
+
+This entry (`sylow-theorem-oq-03-oq-02`) combines two ingredients the gallery
+already records separately:
+
+* the **Sylow counting bounds** `nₚ ≡ 1 [MOD p]` and `nₚ ∣ m` (third Sylow
+  theorem), and
+* the **Schur–Zassenhaus** complement theorem from the parent entry
+  `sylow-theorem-oq-03` (`Subgroup.exists_right_complement'_of_coprime`).
+
+## Mathematical content
+
+For distinct primes `p < q`, in *any* group `G` of order `pq` the counting
+congruences force the Sylow `q`-subgroup to be unique, hence normal: writing
+`n_q = card (Sylow q G)`, we have `n_q ∣ p` and `n_q ≡ 1 [MOD q]`, so
+`n_q ∈ {1, p}`; but `n_q = p` would give `q ∣ p - 1`, impossible since
+`0 < p - 1 < q`. Therefore `n_q = 1`.
+
+Because a Sylow subgroup is a Hall subgroup (`|Q|` is coprime to its index,
+`Sylow.card_coprime_index`), Schur–Zassenhaus applies to the now-normal `Q`
+with **no extra hypothesis**, producing a complement `K` of order `p`. Hence
+
+  **every group of order `pq` is an internal semidirect product `G = Q ⋊ K`,**
+  with `Q` cyclic of order `q` and `K` cyclic of order `p`.
+
+This is *unconditional* in `p ∣ q - 1`: it holds for the nonabelian groups
+(orders `6 = S₃`, `21`, …) just as for the cyclic ones, which is the new content
+relative to the sibling `sylow-theorem-oq-01` (that entry proves `G` is *cyclic*
+only when `p ∤ q - 1`, and leaves the nonabelian case as a stub). Here the
+*splitting* is always available; cyclicity is the special case where the
+complement also happens to be normal.
+
+The file is self-contained: it re-derives the `n_q = 1` counting from Mathlib
+(rather than importing the sibling structure), and invokes Schur–Zassenhaus
+directly.
+-/
+
+namespace SylowTheoremOQ03OQ02
+
+open scoped Classical
+open Subgroup
+
+variable {G : Type*} [Group G]
+
+/-! ## Section I: counting forces `n_q = 1` -/
+
+/-- In a group of order `p * q` (`p < q` primes), a Sylow `q`-subgroup has
+order exactly `q`: the `q`-part of `p * q` is `q¹`. -/
+theorem card_sylow_q {p q : ℕ} [Fact p.Prime] [Fact q.Prime] [Finite G]
+    (hpq : p < q) (hcard : Nat.card G = p * q) (Q : Sylow q G) :
+    Nat.card (Q : Subgroup G) = q := by
+  have hp : p.Prime := Fact.out
+  have hq : q.Prime := Fact.out
+  have hp0 : p ≠ 0 := hp.pos.ne'
+  have hq0 : q ≠ 0 := hq.pos.ne'
+  have hne : q ≠ p := (Nat.ne_of_lt hpq).symm
+  have hnotdvd : ¬ q ∣ p := by
+    intro hd
+    rcases (Nat.Prime.eq_one_or_self_of_dvd hp q hd) with h1 | hqp
+    · exact hq.one_lt.ne' h1
+    · exact hne hqp
+  have hfact : (Nat.card G).factorization q = 1 := by
+    rw [hcard, Nat.factorization_mul hp0 hq0, Finsupp.add_apply,
+      Nat.factorization_eq_zero_of_not_dvd hnotdvd, hq.factorization_self,
+      zero_add]
+  rw [Q.card_eq_multiplicity, hfact, pow_one]
+
+/-- The index of a Sylow `q`-subgroup in a group of order `p * q` is `p`. -/
+theorem index_sylow_q {p q : ℕ} [Fact p.Prime] [Fact q.Prime] [Finite G]
+    (hpq : p < q) (hcard : Nat.card G = p * q) (Q : Sylow q G) :
+    (Q : Subgroup G).index = p := by
+  have hq : q.Prime := Fact.out
+  have hmul := (Q : Subgroup G).card_mul_index
+  rw [card_sylow_q hpq hcard Q, hcard] at hmul
+  -- `q * index = p * q = q * p`
+  exact (Nat.eq_of_mul_eq_mul_left hq.pos (by rw [hmul]; ring)).symm
+
+/-- **Counting Sylow's theorem forces uniqueness.**
+For distinct primes `p < q`, any group of order `pq` has exactly one Sylow
+`q`-subgroup. -/
+theorem card_sylow_q_eq_one {p q : ℕ} [Fact p.Prime] [Fact q.Prime] [Finite G]
+    (hpq : p < q) (hcard : Nat.card G = p * q) :
+    Nat.card (Sylow q G) = 1 := by
+  have hp : p.Prime := Fact.out
+  have hq : q.Prime := Fact.out
+  obtain ⟨Q⟩ := (inferInstance : Nonempty (Sylow q G))
+  -- n_q divides the index p
+  have hdvd : Nat.card (Sylow q G) ∣ p := by
+    have := Q.card_dvd_index
+    rwa [index_sylow_q hpq hcard Q] at this
+  -- n_q ≡ 1 mod q
+  have hmod : Nat.card (Sylow q G) ≡ 1 [MOD q] := card_sylow_modEq_one q G
+  rcases (Nat.Prime.eq_one_or_self_of_dvd hp _ hdvd) with h1 | hp'
+  · exact h1
+  · -- n_q = p would give q ∣ p - 1, impossible
+    exfalso
+    rw [hp'] at hmod
+    have hp1 : 1 ≤ p := hp.one_lt.le
+    have hqdvd : q ∣ p - 1 := (Nat.modEq_iff_dvd' hp1).mp hmod.symm
+    have hpos : 0 < p - 1 := by have := hp.two_le; omega
+    have hle : q ≤ p - 1 := Nat.le_of_dvd hpos hqdvd
+    omega
+
+/-- The Sylow `q`-subgroup of a group of order `pq` (`p < q`) is normal. -/
+theorem sylow_q_normal {p q : ℕ} [Fact p.Prime] [Fact q.Prime] [Finite G]
+    (hpq : p < q) (hcard : Nat.card G = p * q) (Q : Sylow q G) :
+    (Q : Subgroup G).Normal := by
+  haveI : Subsingleton (Sylow q G) :=
+    (Nat.card_eq_one_iff_unique.mp (card_sylow_q_eq_one hpq hcard)).1
+  exact Q.normal_of_subsingleton
+
+/-! ## Section II: Schur–Zassenhaus splits the normal Sylow subgroup -/
+
+/-- **Main structural theorem.**
+For distinct primes `p < q`, every group of order `pq` is an internal
+semidirect product `G = Q ⋊ K`: there is a *normal* Sylow `q`-subgroup `Q`
+together with a complement `K` such that
+`Q ⊓ K = ⊥`, `Q ⊔ K = ⊤`, `|Q| = q`, and `|K| = p`.
+
+This is unconditional — it holds for the nonabelian groups of order `pq` as
+well as the cyclic ones. -/
+theorem exists_normal_sylow_complement {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    [Finite G] (hpq : p < q) (hcard : Nat.card G = p * q) :
+    ∃ (Q : Subgroup G) (K : Subgroup G), Q.Normal ∧ IsComplement' Q K ∧
+      Q ⊓ K = ⊥ ∧ Q ⊔ K = ⊤ ∧ Nat.card Q = q ∧ Nat.card K = p := by
+  obtain ⟨Q⟩ := (inferInstance : Nonempty (Sylow q G))
+  haveI hN : (Q : Subgroup G).Normal := sylow_q_normal hpq hcard Q
+  -- Hall property: |Q| coprime to its index ⇒ Schur–Zassenhaus applies
+  obtain ⟨K, hK⟩ := Subgroup.exists_right_complement'_of_coprime Q.card_coprime_index
+  have hQcard : Nat.card (Q : Subgroup G) = q := card_sylow_q hpq hcard Q
+  refine ⟨(Q : Subgroup G), K, hN, hK, hK.isCompl.inf_eq_bot, hK.isCompl.sup_eq_top,
+    hQcard, ?_⟩
+  -- |Q| * |K| = |G| = p * q, and |Q| = q ⇒ |K| = p
+  have hmul := hK.card_mul
+  rw [hQcard, hcard] at hmul
+  exact Nat.eq_of_mul_eq_mul_left (Fact.out : q.Prime).pos (by rw [hmul]; ring)
+
+/-- The factors of the semidirect decomposition are cyclic of prime order:
+`G = Z/q ⋊ Z/p`. -/
+theorem exists_cyclic_semidirect {p q : ℕ} [Fact p.Prime] [Fact q.Prime]
+    [Finite G] (hpq : p < q) (hcard : Nat.card G = p * q) :
+    ∃ (Q : Subgroup G) (K : Subgroup G), Q.Normal ∧ IsComplement' Q K ∧
+      Nat.card Q = q ∧ Nat.card K = p ∧ IsCyclic Q ∧ IsCyclic K := by
+  obtain ⟨Q, K, hN, hK, _, _, hQ, hKc⟩ := exists_normal_sylow_complement hpq hcard
+  exact ⟨Q, K, hN, hK, hQ, hKc, isCyclic_of_prime_card hQ, isCyclic_of_prime_card hKc⟩
+
+/-- A group of order `pq` (`p < q` primes) is never simple: the normal Sylow
+`q`-subgroup is a proper, nontrivial normal subgroup. -/
+theorem not_isSimpleGroup {p q : ℕ} [Fact p.Prime] [Fact q.Prime] [Finite G]
+    (hpq : p < q) (hcard : Nat.card G = p * q) : ¬ IsSimpleGroup G := by
+  intro hsimple
+  obtain ⟨Q⟩ := (inferInstance : Nonempty (Sylow q G))
+  haveI hN : (Q : Subgroup G).Normal := sylow_q_normal hpq hcard Q
+  have hp : p.Prime := Fact.out
+  have hq : q.Prime := Fact.out
+  have hQcard : Nat.card (Q : Subgroup G) = q := card_sylow_q hpq hcard Q
+  rcases hsimple.eq_bot_or_eq_top_of_normal (Q : Subgroup G) hN with hbot | htop
+  · -- |Q| = q > 1, so Q ≠ ⊥
+    rw [hbot] at hQcard
+    simp only [Subgroup.card_bot] at hQcard
+    exact hq.one_lt.ne hQcard
+  · -- |Q| = |G| = pq ≠ q since p > 1
+    rw [htop, Subgroup.card_top, hcard] at hQcard
+    have : p = 1 := by
+      have hqpos : 0 < q := hq.pos
+      nlinarith [hp.one_lt, hQcard]
+    exact hp.one_lt.ne' this
+
+/-! ## Section III: concrete small orders (including the nonabelian cases) -/
+
+/-- Every group of order `6` splits as `Z/3 ⋊ K` with `|K| = 2`. This holds for
+both `ℤ/6` and the nonabelian `S₃`. -/
+theorem order_six_splits [Finite G] (hcard : Nat.card G = 6) :
+    ∃ (Q : Subgroup G) (K : Subgroup G), Q.Normal ∧ IsComplement' Q K ∧
+      Nat.card Q = 3 ∧ Nat.card K = 2 := by
+  haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  obtain ⟨Q, K, hN, hK, _, _, hQ, hKc⟩ :=
+    exists_normal_sylow_complement (p := 2) (q := 3) (by norm_num) (by rw [hcard])
+  exact ⟨Q, K, hN, hK, hQ, hKc⟩
+
+/-- Every group of order `21` splits as `Z/7 ⋊ K` with `|K| = 3` (the
+nonabelian `Z/7 ⋊ Z/3` as well as `Z/21`). -/
+theorem order_twentyone_splits [Finite G] (hcard : Nat.card G = 21) :
+    ∃ (Q : Subgroup G) (K : Subgroup G), Q.Normal ∧ IsComplement' Q K ∧
+      Nat.card Q = 7 ∧ Nat.card K = 3 := by
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+  obtain ⟨Q, K, hN, hK, _, _, hQ, hKc⟩ :=
+    exists_normal_sylow_complement (p := 3) (q := 7) (by norm_num) (by rw [hcard])
+  exact ⟨Q, K, hN, hK, hQ, hKc⟩
+
+/-- Every group of order `15` is not simple (it has a normal Sylow
+`5`-subgroup), and in fact splits as `Z/5 ⋊ K`, `|K| = 3`. -/
+theorem order_fifteen_splits [Finite G] (hcard : Nat.card G = 15) :
+    ∃ (Q : Subgroup G) (K : Subgroup G), Q.Normal ∧ IsComplement' Q K ∧
+      Nat.card Q = 5 ∧ Nat.card K = 3 := by
+  haveI : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
+  haveI : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+  obtain ⟨Q, K, hN, hK, _, _, hQ, hKc⟩ :=
+    exists_normal_sylow_complement (p := 3) (q := 5) (by norm_num) (by rw [hcard])
+  exact ⟨Q, K, hN, hK, hQ, hKc⟩
+
+end SylowTheoremOQ03OQ02

--- a/src/data/proofs/sylow-theorem-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/sylow-theorem-oq-03-oq-02/annotations.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "ann-sylow-oq0302-header",
+    "line": 1,
+    "endLine": 50,
+    "type": "concept",
+    "title": "Counting + Schur–Zassenhaus: the Unconditional Splitting of Order-pq Groups",
+    "body": "This module combines two classical results. Sylow's third theorem constrains the number n_q of Sylow q-subgroups (n_q ≡ 1 mod q and n_q ∣ [G:Q]); at order pq with p < q this forces n_q = 1, so the Sylow q-subgroup is normal. The Schur–Zassenhaus theorem then provides a complement, because Sylow subgroups are automatically Hall subgroups (|Q| coprime to [G:Q]). The conclusion: every group of order pq is an internal semidirect product G = Q ⋊ K with Q cyclic of order q and K cyclic of order p — unconditionally in whether p divides q-1.",
+    "mathContext": "The splitting holds for the nonabelian groups (S₃ at order 6, ℤ/7 ⋊ ℤ/3 at order 21) as well as the cyclic ones. This is the new content relative to the sibling pq-classification entry, which proves cyclicity only when p ∤ q-1.",
+    "significance": "foundational",
+    "relatedConcepts": [
+      "sylow-theorems",
+      "schur-zassenhaus-theorem",
+      "semidirect-product",
+      "hall-subgroup",
+      "group-classification"
+    ],
+    "prerequisites": [
+      "Sylow's theorems",
+      "Schur–Zassenhaus existence",
+      "internal semidirect products"
+    ],
+    "content": "Forced normality is the bridge: counting decides that the larger prime's Sylow subgroup is normal, and the Hall property makes Schur–Zassenhaus split it for free.",
+    "proofId": "sylow-theorem-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 50 }
+  },
+  {
+    "id": "ann-sylow-oq0302-counting",
+    "line": 88,
+    "endLine": 110,
+    "type": "technique",
+    "title": "The Counting Heart: n_q ∣ p and n_q ≡ 1 mod q ⟹ n_q = 1",
+    "body": "card_sylow_q_eq_one is the crux. A Sylow q-subgroup has index p (Lagrange, since |Q| = q), so Sylow.card_dvd_index gives n_q ∣ p. As p is prime, n_q ∈ {1, p}. The value p is impossible: card_sylow_modEq_one gives n_q ≡ 1 mod q, so n_q = p would mean q ∣ p − 1; but 0 < p − 1 < q (because 2 ≤ p < q), and no positive number below q is divisible by q. Hence n_q = 1, and the unique Sylow q-subgroup is normal (Sylow.normal_of_subsingleton).",
+    "mathContext": "This rigidity is special to the larger prime q. The smaller prime's Sylow count satisfies n_p ∣ q and n_p ≡ 1 mod p, which permits n_p = q precisely when p ∣ q − 1 — exactly the case where the group can be nonabelian.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "sylow-third-theorem",
+      "lagrange-theorem",
+      "modular-arithmetic"
+    ],
+    "prerequisites": [
+      "Sylow III counting congruence",
+      "divisibility in ℕ"
+    ],
+    "content": "The whole classification turns on a one-line number-theoretic impossibility: q cannot divide p − 1 when p < q.",
+    "proofId": "sylow-theorem-oq-03-oq-02",
+    "range": { "startLine": 88, "endLine": 127 }
+  },
+  {
+    "id": "ann-sylow-oq0302-splitting",
+    "line": 129,
+    "endLine": 155,
+    "type": "concept",
+    "title": "Schur–Zassenhaus Applies for Free: G = Q ⋊ K",
+    "body": "exists_normal_sylow_complement assembles the main theorem. The Sylow q-subgroup Q is now normal (Section I), and Sylow.card_coprime_index says |Q| is coprime to its index — the Hall property — so the coprimality hypothesis of Schur–Zassenhaus is automatic. Subgroup.exists_right_complement'_of_coprime then yields a complement K, and the IsComplement' data gives Q ⊓ K = ⊥, Q ⊔ K = ⊤, |Q| = q, |K| = p. exists_cyclic_semidirect upgrades both factors to cyclic of prime order, so G ≅ ℤ/q ⋊ ℤ/p.",
+    "mathContext": "Cyclicity of G (the sibling entry's conclusion) is the special case where K too is normal — equivalent to p ∤ q − 1. The semidirect splitting needs no such hypothesis.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "schur-zassenhaus-theorem",
+      "complement-subgroup",
+      "hall-subgroup",
+      "cyclic-group"
+    ],
+    "prerequisites": [
+      "Schur–Zassenhaus existence",
+      "IsComplement' / internal semidirect product"
+    ],
+    "content": "Normality was the only missing ingredient; once counting supplies it, the Hall property closes the gap to a full semidirect decomposition.",
+    "proofId": "sylow-theorem-oq-03-oq-02",
+    "range": { "startLine": 128, "endLine": 177 }
+  },
+  {
+    "id": "ann-sylow-oq0302-concrete",
+    "line": 180,
+    "endLine": 211,
+    "type": "example",
+    "title": "Orders 6, 15, 21 — Nonabelian Groups Covered Uniformly",
+    "body": "order_six_splits, order_fifteen_splits, and order_twentyone_splits specialize the general theorem to |G| ∈ {6, 15, 21}. Each exhibits the normal Sylow subgroup and its complement: order 6 = ℤ/3 ⋊ K with |K| = 2 (covering both ℤ/6 and S₃), order 15 = ℤ/5 ⋊ K with |K| = 3 (only ℤ/15 exists here, since 3 ∤ 4), and order 21 = ℤ/7 ⋊ K with |K| = 3 (covering both ℤ/21 and the nonabelian ℤ/7 ⋊ ℤ/3, since 3 ∣ 6).",
+    "mathContext": "These instances show the splitting is genuinely uniform across abelian and nonabelian groups of the same order; the distinction (cyclic vs. nonabelian) lives entirely in the homomorphism ℤ/p → Aut(ℤ/q) defining the action.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric-group-S3",
+      "semidirect-product",
+      "group-of-order-pq"
+    ],
+    "prerequisites": [
+      "the general splitting theorem"
+    ],
+    "content": "S₃ and ℤ/6 are both ℤ/3 ⋊ (order 2); the formalization treats them with one lemma.",
+    "proofId": "sylow-theorem-oq-03-oq-02",
+    "range": { "startLine": 178, "endLine": 211 }
+  }
+]

--- a/src/data/proofs/sylow-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorem-oq-03-oq-02/meta.json
@@ -1,0 +1,213 @@
+{
+  "id": "sylow-theorem-oq-03-oq-02",
+  "title": "Counting Forces a Normal Sylow Subgroup: the Unconditional Splitting G = Q ⋊ K for Order pq",
+  "slug": "sylow-theorem-oq-03-oq-02",
+  "description": "Combines the Sylow counting bounds (n_q ≡ 1 mod q, n_q ∣ p) with the Schur–Zassenhaus complement theorem to show that for distinct primes p < q, EVERY group of order pq is an internal semidirect product G = Q ⋊ K — a normal Sylow q-subgroup Q (cyclic of order q) complemented by a subgroup K of order p (cyclic of order p). The counting congruences force the Sylow q-subgroup to be unique (n_q = 1); the Hall property of Sylow subgroups makes Schur–Zassenhaus apply with no extra hypothesis. Unlike the sibling pq-classification (which proves cyclicity only when p ∤ q-1), the splitting here is unconditional: it covers the nonabelian groups of order 6 and 21 as well as the cyclic ones.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Sylow_theorems",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SylowTheoremOQ03OQ02.lean",
+    "tags": [
+      "algebra",
+      "group-theory",
+      "sylow-theory",
+      "schur-zassenhaus",
+      "semidirect-product",
+      "group-classification",
+      "complements",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "card_sylow_modEq_one",
+        "description": "Sylow III: the number of Sylow p-subgroups is ≡ 1 mod p",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.card_dvd_index",
+        "description": "The number of Sylow p-subgroups divides the index of any one of them",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.card_eq_multiplicity",
+        "description": "A Sylow p-subgroup has order p^(multiplicity of p in |G|)",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.normal_of_subsingleton",
+        "description": "A unique Sylow subgroup is normal (in fact characteristic)",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Sylow.card_coprime_index",
+        "description": "Sylow subgroups are Hall subgroups: |P| is coprime to its index",
+        "module": "Mathlib.GroupTheory.Sylow"
+      },
+      {
+        "theorem": "Subgroup.exists_right_complement'_of_coprime",
+        "description": "Schur–Zassenhaus (existence): a normal subgroup of coprime order/index has a complement",
+        "module": "Mathlib.GroupTheory.SchurZassenhaus"
+      },
+      {
+        "theorem": "IsComplement'.isCompl / card_mul",
+        "description": "A complement pair is internally complementary (⊓ = ⊥, ⊔ = ⊤) and multiplies cardinalities",
+        "module": "Mathlib.GroupTheory.Complement"
+      },
+      {
+        "theorem": "isCyclic_of_prime_card",
+        "description": "A group of prime order is cyclic",
+        "module": "Mathlib.GroupTheory.SpecificGroups.Cyclic"
+      }
+    ],
+    "originalContributions": [
+      "card_sylow_q / index_sylow_q: in a group of order pq, a Sylow q-subgroup has order exactly q and index exactly p (the q-part of pq is q¹)",
+      "card_sylow_q_eq_one: the counting heart — n_q ∣ p and n_q ≡ 1 mod q force n_q = 1 (since n_q = p would give the impossible q ∣ p-1 with 0 < p-1 < q)",
+      "sylow_q_normal: the resulting unique Sylow q-subgroup is normal",
+      "exists_normal_sylow_complement: the main structural theorem — every group of order pq splits as G = Q ⋊ K with Q ⊓ K = ⊥, Q ⊔ K = ⊤, |Q| = q, |K| = p, obtained by feeding the forced normality into Schur–Zassenhaus via the automatic Hall coprimality",
+      "exists_cyclic_semidirect: the two factors are cyclic of prime order, so G = ℤ/q ⋊ ℤ/p",
+      "not_isSimpleGroup: a group of order pq is never simple (the normal Sylow q-subgroup is proper and nontrivial)",
+      "order_six_splits / order_twentyone_splits / order_fifteen_splits: concrete specializations covering the nonabelian cases (S₃ at order 6, ℤ/7 ⋊ ℤ/3 at order 21) as well as the cyclic ones"
+    ],
+    "axiomCount": 0,
+    "lineCount": 211,
+    "assumptions": "None. All 10 theorems are fully proved with 0 axioms and 0 sorries (no native_decide). #print axioms reports only [propext, Classical.choice, Quot.sound] for every result. The existence half of Schur–Zassenhaus and the Sylow counting theorems are invoked from Mathlib; the counting elimination forcing n_q = 1, the assembly of the splitting, and the concrete order specializations are proved here.",
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "prerequisites": [
+      "Sylow's theorems (especially the third: n_p ≡ 1 mod p and n_p ∣ [G:P])",
+      "Sylow subgroups as Hall subgroups (|P| coprime to its index)",
+      "Schur–Zassenhaus existence (coprime normal subgroup has a complement)",
+      "Subgroup complements / internal semidirect products (IsComplement')",
+      "Cardinality and factorization of natural numbers"
+    ],
+    "relatedProblems": [
+      {
+        "id": "sylow-theorem-oq-03",
+        "relationship": "Parent: Schur–Zassenhaus as an extension of Sylow theory. This entry realizes that entry's open question — 'combine the Sylow counting to force a Sylow subgroup normal, so Schur–Zassenhaus yields the full semidirect-product structure of every group of order n' — for the family n = pq."
+      },
+      {
+        "id": "sylow-theorem-oq-01",
+        "relationship": "Sibling: classification of groups of order pq. That entry proves G is cyclic when p ∤ q-1 and stubs the nonabelian case. This entry instead proves the unconditional semidirect SPLITTING (valid for the nonabelian groups too), of which cyclicity is the special case where the complement is also normal."
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Two classical pillars of finite group theory meet in the analysis of small-order groups. Sylow's third theorem (1872) constrains the number n_p of Sylow p-subgroups: n_p ≡ 1 (mod p) and n_p divides the index [G:P]. For a group of order pq with p < q prime, these constraints are rigid enough to force n_q = 1 — there is a unique, hence normal, Sylow q-subgroup. The Schur–Zassenhaus theorem (Schur 1904, Zassenhaus 1937) then takes over: a normal subgroup whose order is coprime to its index always has a complement, so the group is an internal semidirect product. Because every Sylow subgroup is automatically a Hall subgroup (|P| is coprime to [G:P]), the coprimality hypothesis of Schur–Zassenhaus is free, and the forced normality of the Sylow q-subgroup is the only ingredient needed. The conclusion — every group of order pq is ℤ/q ⋊ ℤ/p — is the prototype of the structure theory of small-order groups, and the dichotomy 'cyclic vs. nonabelian semidirect product' (governed by whether p ∣ q-1) is the first nontrivial example in any group-theory course.",
+    "problemStatement": "For distinct primes p < q, show that the Sylow counting congruences force the Sylow q-subgroup of any group of order pq to be normal, and combine this with Schur–Zassenhaus to conclude that every such group is an internal semidirect product G = Q ⋊ K with Q cyclic of order q and K cyclic of order p — unconditionally in whether p divides q-1. Specialize to the concrete orders 6, 15, and 21, including their nonabelian groups.",
+    "proofStrategy": "Counting first: a Sylow q-subgroup Q has order q (the q-part of pq is q¹, via Sylow.card_eq_multiplicity and factorization of pq) and hence index p (Lagrange). Sylow.card_dvd_index gives n_q ∣ p, and card_sylow_modEq_one gives n_q ≡ 1 mod q. Since p is prime, n_q ∈ {1, p}; the value p is excluded because it would give q ∣ p-1, impossible as 0 < p-1 < q. So n_q = 1, the Sylow q-subgroup is unique, and Sylow.normal_of_subsingleton makes it normal. Splitting second: a normal Sylow subgroup satisfies Schur–Zassenhaus for free because Sylow.card_coprime_index supplies the coprimality of |Q| with its index; Subgroup.exists_right_complement'_of_coprime then yields a complement K. The complement data (Q ⊓ K = ⊥, Q ⊔ K = ⊤, |K| = p) is read off from IsComplement', and isCyclic_of_prime_card makes both factors cyclic. Concrete orders 6, 15, 21 are instances of the general theorem with explicit primes.",
+    "keyInsights": [
+      "Sylow III is rigid at order pq: among the divisors {1, p} of the index that are ≡ 1 mod q, only 1 survives, because p ≡ 1 mod q would force q ≤ p-1, contradicting p < q. Hence the larger prime's Sylow subgroup is always normal.",
+      "Sylow subgroups are Hall subgroups, so the coprimality hypothesis of Schur–Zassenhaus is automatic. The only thing standing between 'normal Sylow subgroup' and 'the group splits' is normality — which the counting just supplied.",
+      "The resulting splitting G = Q ⋊ K is UNCONDITIONAL in p ∣ q-1: it holds for the nonabelian groups (S₃ of order 6, the order-21 group ℤ/7 ⋊ ℤ/3) exactly as for the cyclic ones. Cyclicity is the special case where the complement K is also normal (which needs p ∤ q-1); the semidirect structure needs nothing extra.",
+      "Both factors are cyclic of prime order, so the classification reads G ≅ ℤ/q ⋊ ℤ/p — the entire structure is determined by a single action ℤ/p → Aut(ℤ/q).",
+      "Everything is stated for an arbitrary finite group via Nat.card, so the results apply uniformly to every group of the given order without choosing a presentation."
+    ],
+    "prerequisites": [
+      "Sylow's theorems and the counting congruence n_p ≡ 1 mod p, n_p ∣ [G:P]",
+      "Sylow subgroups as Hall subgroups",
+      "Schur–Zassenhaus existence and internal semidirect products",
+      "Lagrange's theorem |H| · [G:H] = |G| and prime factorization of ℕ"
+    ]
+  },
+  "sections": [
+    {
+      "id": "counting",
+      "title": "Section I: Counting Forces n_q = 1 and Normality",
+      "startLine": 52,
+      "endLine": 127,
+      "summary": "card_sylow_q computes |Q| = q from the q-part of pq; index_sylow_q gives [G:Q] = p by Lagrange. card_sylow_q_eq_one is the counting heart: n_q ∣ p and n_q ≡ 1 mod q leave only n_q = 1 (n_q = p ruled out by q ∤ p-1). sylow_q_normal converts uniqueness into normality.",
+      "mathContext": "Sylow III is rigid enough at order pq to pin down n_q = 1, so the larger prime's Sylow subgroup is always normal."
+    },
+    {
+      "id": "splitting",
+      "title": "Section II: Schur–Zassenhaus Splits the Normal Sylow Subgroup",
+      "startLine": 128,
+      "endLine": 177,
+      "summary": "exists_normal_sylow_complement assembles the main theorem: feed the forced normality plus the automatic Hall coprimality (Sylow.card_coprime_index) into Schur–Zassenhaus to get a complement K, with the full splitting data Q ⊓ K = ⊥, Q ⊔ K = ⊤, |Q| = q, |K| = p. exists_cyclic_semidirect makes both factors cyclic of prime order; not_isSimpleGroup records that order-pq groups are never simple.",
+      "mathContext": "Every group of order pq is an internal semidirect product ℤ/q ⋊ ℤ/p; the only input beyond Mathlib's Schur–Zassenhaus is the forced normality from Section I."
+    },
+    {
+      "id": "concrete",
+      "title": "Section III: Concrete Orders 6, 15, 21 (Nonabelian Cases Included)",
+      "startLine": 178,
+      "endLine": 211,
+      "summary": "order_six_splits, order_fifteen_splits, order_twentyone_splits specialize the general theorem to |G| ∈ {6, 15, 21}, exhibiting the normal Sylow subgroup and its complement. These cover the nonabelian groups (S₃ at order 6, ℤ/7 ⋊ ℤ/3 at order 21) as well as the cyclic groups ℤ/6, ℤ/15, ℤ/21.",
+      "mathContext": "The splitting is uniform across abelian and nonabelian groups of the same order — the distinction lives entirely in the action defining the semidirect product."
+    }
+  ],
+  "conclusion": {
+    "summary": "A fully verified (0 sorries, 0 axioms, no native_decide) formalization in 211 lines with 10 theorems: the Sylow counting congruences force the Sylow q-subgroup of any group of order pq (p < q prime) to be normal, and Schur–Zassenhaus then exhibits every such group as an internal semidirect product G = Q ⋊ K with Q cyclic of order q and K cyclic of order p. #print axioms reports only [propext, Classical.choice, Quot.sound] for all results.",
+    "implications": "This realizes the parent Schur–Zassenhaus entry's open question for the family n = pq: counting forces a Sylow subgroup normal, and the Hall property makes Schur–Zassenhaus split it automatically. The contribution beyond the sibling pq-classification is that the SPLITTING is unconditional — it holds for the nonabelian groups of order 6 and 21, where the sibling's cyclicity result does not apply. The general theorem and its concrete instances are reusable building blocks for the structure theory of small-order groups, where a forced-normal Sylow subgroup repeatedly reduces a group to a semidirect product of smaller pieces.",
+    "openQuestions": [
+      "Extend the forced-normality + Schur–Zassenhaus pipeline to order p²q: count to force one Sylow subgroup normal, then split, classifying all groups of order p²q up to the action data.",
+      "Pin down the action: for order pq with p ∣ q-1, show the nonabelian group is unique up to isomorphism by classifying the nontrivial homomorphisms ℤ/p → Aut(ℤ/q) ≅ ℤ/(q-1) up to conjugacy."
+    ]
+  },
+  "status": "verified",
+  "badge": "original",
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.Sylow",
+      "Mathlib.GroupTheory.SchurZassenhaus",
+      "Mathlib.GroupTheory.Complement",
+      "Mathlib.GroupTheory.SpecificGroups.Cyclic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
+    "namespace": "SylowTheoremOQ03OQ02",
+    "lineCount": 211,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/SylowTheoremOQ03OQ02.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "sylow-theorem-oq-03",
+      "relationship": "extends",
+      "description": "Parent: Schur–Zassenhaus and the splitting of normal Sylow subgroups. This entry supplies the missing ingredient — the counting that forces a Sylow subgroup normal — so that the parent's splitting theorem applies to every group of order pq unconditionally."
+    },
+    {
+      "targetId": "sylow-theorem-oq-01",
+      "relationship": "related",
+      "description": "Sibling: classification of groups of order pq. That entry proves cyclicity when p ∤ q-1; this entry proves the unconditional semidirect-product splitting, covering the nonabelian groups it leaves as a stub."
+    },
+    {
+      "targetId": "sylow-theorem",
+      "relationship": "related",
+      "description": "Root Sylow entry. This entry uses the third Sylow theorem (counting congruence) as the engine that forces normality at order pq."
+    }
+  ],
+  "references": [
+    {
+      "key": "Sy1872",
+      "citation": "Sylow, L., Théorèmes sur les groupes de substitutions, Math. Ann. 5 (1872), 584–594.",
+      "type": "paper"
+    },
+    {
+      "key": "Za37",
+      "citation": "Zassenhaus, H., Lehrbuch der Gruppentheorie, Teubner (1937).",
+      "type": "book"
+    },
+    {
+      "key": "DF04",
+      "citation": "Dummit, D.S. and Foote, R.M., Abstract Algebra, 3rd ed., Wiley (2004), §4.5 (Sylow) and §5.5 (semidirect products).",
+      "type": "book"
+    },
+    {
+      "key": "Ro96",
+      "citation": "Robinson, D.J.S., A Course in the Theory of Groups, 2nd ed., Springer GTM 80 (1996), §9.1 (Schur–Zassenhaus).",
+      "type": "book"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

For distinct primes `p < q`, this entry **combines the Sylow counting bounds with Schur–Zassenhaus** to show that *every* group of order `pq` is an internal semidirect product `G = Q ⋊ K`:

- **Counting forces normality.** A Sylow `q`-subgroup has order `q` and index `p`, so `n_q ∣ p` and `n_q ≡ 1 (mod q)`; since `n_q = p` would give the impossible `q ∣ p−1` (as `0 < p−1 < q`), we get `n_q = 1` — the Sylow `q`-subgroup is **normal**.
- **Schur–Zassenhaus splits it for free.** Sylow subgroups are Hall subgroups (`Sylow.card_coprime_index`), so the coprimality hypothesis is automatic; `Subgroup.exists_right_complement'_of_coprime` yields a complement `K` of order `p`. The result: `Q ⊓ K = ⊥`, `Q ⊔ K = ⊤`, both factors cyclic of prime order, i.e. `G ≅ ℤ/q ⋊ ℤ/p`.

**New content vs. the sibling `sylow-theorem-oq-01`:** that entry proves `G` is *cyclic* only when `p ∤ q−1` and stubs the nonabelian case. Here the **splitting is unconditional** — it covers the nonabelian groups (`S₃` at order 6, `ℤ/7 ⋊ ℤ/3` at order 21) as well as the cyclic ones. This realizes the parent `sylow-theorem-oq-03` (Schur–Zassenhaus) entry's open question for the family `n = pq`.

## Verification

- **10 theorems, 0 definitions, 0 sorries, 0 axioms, 211 lines.**
- Kernel-verified with `lake env lean` (Mathlib v4.26.0).
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for every result — no `native_decide`, no `sorryAx`, no `Lean.ofReduceBool`. Status `verified`, badge `original`.

Includes concrete specializations `order_six_splits`, `order_fifteen_splits`, `order_twentyone_splits`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)