### PR TITLE
fix(audit): register orphaned AmgmInequalityOQ02OQ03OQ03OQ01 in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -82,6 +82,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ05
 import Proofs.AmgmInequalityOQ02OQ02
 import Proofs.AmgmInequalityOQ02OQ03
 import Proofs.AmgmInequalityOQ02OQ03OQ03
+import Proofs.AmgmInequalityOQ02OQ03OQ03OQ01
 import Proofs.AmgmInequalityOQ03
 import Proofs.AmgmInequalityOQ03OQ02OQ01
 import Proofs.AmgmInequalityOQ03OQ02OQ01OQ01

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17803,8 +17803,16 @@
       "lastAudited": "2026-06-24T01:43:02Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-03-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T01:55:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "Orphaned from build graph: file not imported in proofs/Proofs.lean despite status=verified; never kernel-checked in CI. Registered via this PR."
+      ]
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T01:43:02Z"
+  "lastUpdated": "2026-06-24T01:55:00Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — issue found & fixed

**Proof**: `amgm-inequality-oq-02-oq-03-oq-03-oq-01` — *Maclaurin's Step via Mathlib Symmetric Functions: Resolving the Newton-Identities Question*
**Severity**: build-graph integrity (status=`verified` but never kernel-checked in CI)

### Problem

The Lean file `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ01.lean` was **not imported** in `proofs/Proofs.lean`. With no import there is no `.olean` and the proof is never compiled by the deployer/CI build graph — so a `status: "verified"` entry was, in practice, never machine-checked. Same orphan pattern as #28588 and `gcd-oq-04-oq-01`.

### Verification before registering

I compiled the file directly (`lake env lean`, Mathlib v4.26.0) and confirmed the math is sound and the meta claims are accurate:

| Check | Result |
|-------|--------|
| compiles | ✓ clean, olean builds, no errors |
| sorries / axiom decls / True stubs | 0 / 0 / none (3 theorems, 130 lines — matches meta) |
| `#print axioms cauchy_schwarz_engine` | `[propext, Classical.choice, Quot.sound]` |
| `#print axioms newton_inequality_k1` | `[propext, Classical.choice, Quot.sound]` |
| `#print axioms maclaurin_step_one` | `[propext, Classical.choice, Quot.sound]` |

Crucially the three theorems do **not** depend on the parent `AmgmInequalityOQ02`'s `maclaurin_step` / `newton_log_concavity` axioms, nor on `sorryAx` / `Lean.ofReduceBool`. So the entry's headline claim — "0 axioms, de-axiomatizes the k=1 Maclaurin step" — is genuinely true, and the `verified` / `mathlib` (Tier B) framing is honest (the `assumptions` field already credits the parent's Cauchy–Schwarz packaging).

### Fix

- Add `import Proofs.AmgmInequalityOQ02OQ03OQ03OQ01` to `proofs/Proofs.lean` (alphabetical position, after `…OQ03OQ03`).
- Record the audit in `audit-tracker.json` (`issues-fixed`).

No change to the proof itself — it was already correct, just invisible to the build.

---
Discovered during gallery integrity audit.