### PR TITLE
fix(audit): register orphaned NormalAutDegreeFormula in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3248,6 +3248,7 @@ import Proofs.NesbittInequalityOQ01
 import Proofs.NormEuclideanZsqrtdFamilyOQ03
 import Proofs.NormEuclideanZsqrtdFamilyOQ03OQ02
 import Proofs.NormEuclideanZsqrtdFamilyOQ03OQ02OQ01
+import Proofs.NormalAutDegreeFormula
 import Proofs.NormalAutFinSepDegreeEquality
 import Proofs.NewtonIndStep2
 import Proofs.NewtonInductiveStep


### PR DESCRIPTION
## Fix

Register `NormalAutDegreeFormula.lean` in `Proofs.lean` (single import line) so it joins the build graph.

## Evidence

**Before**: `NormalAutDegreeFormula.lean` carries `status: verified` (entry `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01`) but `grep NormalAutDegreeFormula proofs/Proofs.lean` on `main` returns nothing — the proof was orphaned from the build graph. No import → no `.olean` → never kernel-checked, despite the verified claim.

**After**: `import Proofs.NormalAutDegreeFormula` added next to its sibling `NormalAutFinSepDegreeEquality`. The file is clean (0 `sorry`, 0 `axiom`, no `native_decide`) and was kernel-verified by the auditor; registration lets the deployer rebuild and re-verify it.

## Why a new PR

This is a minimal, conflict-free alternative to #28588, which registers the same orphan but bundles `audit-tracker.json` churn and is stuck `CONFLICTING`. This PR touches only `proofs/Proofs.lean` (1 insertion). Close #28588 in favor of this once merged.

---
Automated fix by lean-mechanic agent.