### PR TITLE
research(lagrange-theorem-oq-01-oq-01-oq-02): abelian isomorphism uniqueness for groups of order pq

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
@@ -1,0 +1,163 @@
+/-
+  pq-Groups: Abelian isomorphism uniqueness
+  (lagrange-theorem-oq-01-oq-01-oq-02)
+
+  This answers the abelian portion of OQ-01-OQ-01-OQ-02 from Lagrange's Theorem OQ-01.
+
+  **Open Question (OQ-01-OQ-01-OQ-02)**: The parent classification
+  (entry `lagrange-theorem-oq-01-oq-01`) shows that for distinct primes `p < q`
+  the *number* of isomorphism classes of groups of order `pq` is one when
+  `p ∤ (q-1)` (only `ℤ/pq`) and two when `p ∣ (q-1)` (the cyclic group and a
+  non-abelian semidirect product). The OQ asks to upgrade this *counting*
+  statement to genuine *isomorphism uniqueness* using Mathlib's group-isomorphism
+  machinery (`MulEquiv`): "any two groups of order `pq` are isomorphic to each
+  other, for each of the two cases."
+
+  This file resolves the **abelian** thread completely and self-containedly
+  (depending only on Mathlib): *every* abelian group of order `pq` is cyclic, and
+  hence any two abelian groups of order `pq` are isomorphic — each isomorphic to
+  `Multiplicative (ZMod (pq))`. Crucially this needs **no** divisibility
+  hypothesis, so it pins down the abelian isomorphism class in *both* branches of
+  the classification (in the `p ∣ (q-1)` branch the two classes are exactly
+  "abelian = cyclic `ℤ/pq`" and "non-abelian = `ℤ/q ⋊ ℤ/p`"; this file fully
+  resolves the first).
+
+  **Proof of the key step** (`pq_abelian_isCyclic`): Cauchy's theorem
+  (`exists_prime_orderOf_dvd_card`) supplies `a` of order `p` and `b` of order `q`.
+  Since the group is abelian, `a` and `b` commute, and as `p, q` are coprime
+  `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives `orderOf (a*b) = pq = |G|`,
+  so `isCyclic_of_orderOf_eq_card` makes `G` cyclic. Then
+  `mulEquivOfCyclicCardEq` / `zmodCyclicMulEquiv` deliver the isomorphisms.
+
+  **Scope / what is deferred.** The *general* (not-necessarily-abelian)
+  uniqueness statements — "for `p ∤ (q-1)`, any two groups of order `pq` are
+  isomorphic" (cyclic case) and "any two non-cyclic groups of order `pq` are
+  isomorphic" (the `p ∣ (q-1)` non-abelian case) — depend on the parent's Sylow
+  classification `pq_unique_when_coprime` and on a full internal
+  semidirect-product recognition `ℤ/q ⋊ ℤ/p`, respectively. They are left as the
+  open directions (see this entry's open questions). NOTE: at the time of writing,
+  the parent dependency `Proofs.SylowTheoremOQ01` does not compile on Mathlib
+  v4.26.0 (renamed/removed lemmas such as `Nat.Prime.eq_of_dvd_of_prime`,
+  `orderOf_eq_one_iff_eq_one`), which is an independent repair task; the present
+  file deliberately avoids that dependency and imports only Mathlib so it is fully
+  machine-checked with `0` sorries and `0` axioms.
+
+  **Key Mathlib tools**:
+  - `exists_prime_orderOf_dvd_card` (Cauchy) and
+    `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` — produce an element of order `pq`.
+  - `isCyclic_of_orderOf_eq_card` — a generator of full order makes `G` cyclic.
+  - `mulEquivOfCyclicCardEq` — two cyclic groups of equal `Nat.card` are isomorphic.
+  - `zmodCyclicMulEquiv` — a cyclic group `≅ Multiplicative (ZMod (Nat.card G))`.
+
+  References:
+  - Dummit, D. & Foote, R. (2004). Abstract Algebra, §4.5, Theorem 14.
+  - Conrad, K. "Groups of order pq." Expository notes.
+
+  Tags: group-theory, lagrange, pq-groups, classification, isomorphism, MulEquiv,
+        cyclic-groups, abelian-groups, ZMod, finite-groups
+-/
+
+import Mathlib
+
+open Subgroup Fintype
+
+namespace LagrangeOQ01OQ01OQ02
+
+/-!
+## Part I: Abelian groups of order `pq` are cyclic
+
+A finite abelian group whose order is a product of two distinct primes is cyclic.
+Cauchy's theorem gives an element `a` of order `p` and an element `b` of order
+`q`; the group being abelian they commute, and as `p, q` are coprime the product
+`a * b` has order `pq = |G|`, so `G` is cyclic.  No divisibility hypothesis on
+`p, q` is needed, so this also identifies the abelian class inside the non-cyclic
+`p ∣ (q-1)` branch of the classification.
+-/
+
+/-- **Abelian groups of order `pq` are cyclic.** For distinct primes `p ≠ q`,
+    every abelian group of order `pq` is cyclic (squarefree order). -/
+theorem pq_abelian_isCyclic {G : Type*} [CommGroup G] [Fintype G]
+    {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p ≠ q)
+    (hcard : Fintype.card G = p * q) : IsCyclic G := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  obtain ⟨a, ha⟩ : ∃ a : G, orderOf a = p :=
+    exists_prime_orderOf_dvd_card p (by rw [hcard]; exact Dvd.intro q rfl)
+  obtain ⟨b, hb⟩ : ∃ b : G, orderOf b = q :=
+    exists_prime_orderOf_dvd_card q (by rw [hcard]; exact Dvd.intro_left p rfl)
+  have hco : (orderOf a).Coprime (orderOf b) := by
+    rw [ha, hb]; exact (Nat.coprime_primes hp hq).2 hpq
+  have hmul : orderOf (a * b) = p * q := by
+    rw [(Commute.all a b).orderOf_mul_eq_mul_orderOf_of_coprime hco, ha, hb]
+  exact isCyclic_of_orderOf_eq_card (a * b) (by rw [hmul, Nat.card_eq_fintype_card, hcard])
+
+/-!
+## Part II: Abelian isomorphism uniqueness
+
+Two cyclic groups of the same cardinality are isomorphic (`mulEquivOfCyclicCardEq`),
+and a cyclic group is isomorphic to `Multiplicative (ZMod (Nat.card G))`
+(`zmodCyclicMulEquiv`).  Combined with Part I, this gives the abelian uniqueness.
+-/
+
+/-- **Abelian-case uniqueness.** For distinct primes `p ≠ q`, any two abelian
+    groups of order `pq` are isomorphic. -/
+theorem pq_abelian_iso {G H : Type*} [CommGroup G] [CommGroup H] [Fintype G] [Fintype H]
+    {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p ≠ q)
+    (hG : Fintype.card G = p * q) (hH : Fintype.card H = p * q) :
+    Nonempty (G ≃* H) := by
+  haveI : IsCyclic G := pq_abelian_isCyclic hp hq hpq hG
+  haveI : IsCyclic H := pq_abelian_isCyclic hp hq hpq hH
+  refine ⟨mulEquivOfCyclicCardEq ?_⟩
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, hG, hH]
+
+/-- **Abelian-case canonical form.** For distinct primes `p ≠ q`, every abelian
+    group of order `pq` is isomorphic to `Multiplicative (ZMod (pq))`. -/
+theorem pq_abelian_iso_zmod {G : Type*} [CommGroup G] [Fintype G]
+    {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p ≠ q)
+    (hcard : Fintype.card G = p * q) :
+    Nonempty (G ≃* Multiplicative (ZMod (p * q))) := by
+  haveI hc : IsCyclic G := pq_abelian_isCyclic hp hq hpq hcard
+  have hN : Nat.card G = p * q := by rw [Nat.card_eq_fintype_card, hcard]
+  exact ⟨hN ▸ (zmodCyclicMulEquiv hc).symm⟩
+
+/-!
+## Part III: Concrete corollaries
+
+For each squarefree order `pq` the abelian isomorphism class is now a direct
+instance of the theorems above.  Order `15 = 3·5` and `35 = 5·7` lie in the
+cyclic branch, while order `6 = 2·3` lies in the non-cyclic branch (`2 ∣ 2`) where
+`S₃` is the other class — yet in every case the *abelian* group of that order is
+uniquely `ℤ/pq`.
+-/
+
+/-- Every abelian group of order `6` is isomorphic to `ℤ/6` (the non-abelian class
+    of that order being `S₃`). -/
+theorem order_6_abelian_unique
+    {G : Type*} [CommGroup G] [Fintype G] (hG : Fintype.card G = 6) :
+    Nonempty (G ≃* Multiplicative (ZMod 6)) :=
+  pq_abelian_iso_zmod (p := 2) (q := 3) (by norm_num) (by norm_num) (by norm_num)
+    (by rw [hG])
+
+/-- Every abelian group of order `15` is isomorphic to `ℤ/15`. -/
+theorem order_15_abelian_unique
+    {G : Type*} [CommGroup G] [Fintype G] (hG : Fintype.card G = 15) :
+    Nonempty (G ≃* Multiplicative (ZMod 15)) :=
+  pq_abelian_iso_zmod (p := 3) (q := 5) (by norm_num) (by norm_num) (by norm_num)
+    (by rw [hG])
+
+/-- Every abelian group of order `35` is isomorphic to `ℤ/35`. -/
+theorem order_35_abelian_unique
+    {G : Type*} [CommGroup G] [Fintype G] (hG : Fintype.card G = 35) :
+    Nonempty (G ≃* Multiplicative (ZMod 35)) :=
+  pq_abelian_iso_zmod (p := 5) (q := 7) (by norm_num) (by norm_num) (by norm_num)
+    (by rw [hG])
+
+/-- Any two abelian groups of order `15` are isomorphic to each other. -/
+theorem order_15_abelian_pair
+    {G H : Type*} [CommGroup G] [CommGroup H] [Fintype G] [Fintype H]
+    (hG : Fintype.card G = 15) (hH : Fintype.card H = 15) :
+    Nonempty (G ≃* H) :=
+  pq_abelian_iso (p := 3) (q := 5) (by norm_num) (by norm_num) (by norm_num)
+    (by rw [hG]) (by rw [hH])
+
+end LagrangeOQ01OQ01OQ02

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/knowledge.md
@@ -1,0 +1,65 @@
+# lagrange-theorem-oq-01-oq-01-oq-02 — Isomorphism uniqueness for groups of order pq
+
+**Problem**: Upgrade the parent pq-classification (counting of isomorphism classes)
+to genuine `MulEquiv` isomorphisms: "any two groups of order pq are isomorphic to
+each other, for each of the two cases" (cyclic case `p ∤ q-1`; non-cyclic case
+`p | q-1`).
+
+## Summary of progress
+
+- **Abelian case: SOLVED & verified.** Every abelian group of order `pq` (any
+  distinct primes `p ≠ q`) is cyclic, hence any two are isomorphic, each ≅
+  `Multiplicative (ZMod pq)`. Shipped in `Proofs/LagrangeTheoremOQ01OQ01OQ02.lean`
+  (7 theorems, 0 sorries, 0 axioms, Mathlib-only, kernel-verified standard triple).
+- **General cyclic case & non-abelian case: BLOCKED** on the parent Sylow
+  classification.
+
+## Session 2026-06-23 (Session 1) — Abelian uniqueness, FRESH
+
+**Mode**: FRESH · **Outcome**: progress (verified partial)
+
+### What I Did
+- Claimed the problem (after bernoulli/cayley were taken by sibling agents).
+- Planned the full upgrade: cyclic case via parent `pq_unique_when_coprime` +
+  `mulEquivOfCyclicCardEq`; abelian case via Cauchy + coprime-order product law.
+- Wrote and **kernel-verified all proof logic** against real Mathlib (clean
+  `lake env lean`, EXIT 0).
+- **Discovered a blocker**: the parent dependency chain
+  `Proofs.SylowTheoremOQ01` → `Proofs.LagrangeTheoremOQ01OQ01` does **not compile**
+  on Mathlib v4.26.0 — 14 deterministic errors including unknown constant
+  `Nat.Prime.eq_of_dvd_of_prime` and unknown identifier `orderOf_eq_one_iff_eq_one`
+  (both confirmed absent from the v4.26.0 Mathlib source). This is real API drift,
+  not the transient olean-cache corruption that also plagued the session.
+- **Pivoted** to a self-contained, Mathlib-only file delivering the abelian thread,
+  which needs none of the parent infrastructure.
+
+### Key Findings
+- `pq_abelian_isCyclic`: an abelian group of order `pq` is cyclic for EVERY pair of
+  distinct primes — squarefree order + the coprime-order product law
+  `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` force a generator `a·b` of order
+  `pq`. No divisibility hypothesis, so the abelian class is pinned in BOTH branches.
+- Mathlib's `mulEquivOfCyclicCardEq` (two cyclic groups of equal `Nat.card` are
+  isomorphic) is exactly the count→isomorphism upgrade tool; `zmodCyclicMulEquiv`
+  gives the canonical `Multiplicative (ZMod n)` model.
+- Bridge `Fintype.card` ↔ `Nat.card` via `Nat.card_eq_fintype_card`.
+- `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` is in namespace `Commute` (dot
+  notation `(Commute.all a b)....`), not the root namespace — first guess
+  `orderOf_mul_eq_mul_orderOf_of_coprime` failed with unknown identifier.
+
+### Files Modified / Added
+- `proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean` (NEW, 163 lines, 7 thms)
+- `src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/{meta.json,annotations.json}` (NEW)
+- `src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json` (knowledge update)
+
+### Next Steps
+1. **Mechanic repair** of `Proofs/SylowTheoremOQ01.lean` (and dependent
+   `LagrangeTheoremOQ01OQ01.lean`) for Mathlib v4.26.0 — the parent entry is marked
+   `verified` but is stale. Until then `pq_unique_when_coprime` cannot be imported.
+2. After repair: add the general cyclic case `pq_cyclic_case_iso` (for `p ∤ q-1`,
+   any two order-pq groups isomorphic) and `pq_iso_zmod_of_coprime`. The proof logic
+   was already drafted and verified against an axiom-stub of `pq_unique_when_coprime`.
+3. Non-abelian uniqueness: recognize any non-cyclic order-pq group as the internal
+   semidirect product `ℤ/q ⋊ ℤ/p`; reuse the sibling `oq-01-oq-01-oq-01`
+   ApproachB `actionHom` infrastructure; show all nontrivial actions give isomorphic
+   products. Mathlib has `SemidirectProduct.mulEquivSubgroup` for the internal
+   recognition but lacks a normal-complement → semidirect lemma packaged for this.

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/problem.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/problem.md
@@ -1,0 +1,35 @@
+# Problem: Prove the full isomorphism uniqueness: any two groups of order pq are isomorp...
+
+## Statement
+
+### Plain Language
+Formal mathematical investigation: Prove the full isomorphism uniqueness: any two groups of order pq are isomorp....
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 6
+tags:
+  - seeker-selected
+  - extension
+```
+
+**Significance**: 6/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - Important mathematical result
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/state.md
+++ b/research/problems/lagrange-theorem-oq-01-oq-01-oq-02/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: ACT
+**Since**: 2026-06-23T18:53:14-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id": "ann-pq02-001-header",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 68 },
+    "type": "concept",
+    "title": "From Counting to Isomorphisms (Abelian Thread)",
+    "content": "The parent classification answers the open question at the level of *how many* isomorphism classes of groups of order $pq$ exist (one when $p \\nmid (q-1)$, two when $p \\mid (q-1)$). This file upgrades the **abelian** case to genuine isomorphisms $G \\simeq^* H$ using Mathlib's `MulEquiv` machinery, self-containedly (imports only Mathlib). The general cyclic case and the non-abelian uniqueness are scoped out, as they depend on the parent Sylow classification.",
+    "mathContext": "For distinct primes $p < q$, a group of order $pq$ has a unique (hence normal) Sylow $q$-subgroup $Q \\cong \\mathbb{Z}/q$. When $p \\nmid (q-1)$ the group is cyclic; when $p \\mid (q-1)$ a non-abelian semidirect product $\\mathbb{Z}/q \\rtimes \\mathbb{Z}/p$ also exists. In the latter branch the abelian class is exactly the cyclic group $\\mathbb{Z}/pq$ resolved here."
+  },
+  {
+    "id": "ann-pq02-002-abelian-cyclic",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 79, "endLine": 95 },
+    "type": "key-insight",
+    "title": "Abelian of Order pq ⟹ Cyclic (any p ≠ q)",
+    "content": "`pq_abelian_isCyclic` proves every abelian group of order $pq$ is cyclic with NO divisibility hypothesis. Cauchy's theorem (`exists_prime_orderOf_dvd_card`) produces $a$ of order $p$ and $b$ of order $q$; because the group is abelian they commute, and as $p,q$ are coprime `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives $\\mathrm{ord}(ab) = pq = |G|$, so `isCyclic_of_orderOf_eq_card` makes $G$ cyclic. The Fintype.card hypothesis is bridged to Nat.card with `Nat.card_eq_fintype_card`.",
+    "mathContext": "A finite abelian group is cyclic iff each of its Sylow subgroups is cyclic (true here, since each has prime order) and their orders are pairwise coprime. For squarefree order $pq$ this is automatic, independent of the action structure that distinguishes the non-abelian case."
+  },
+  {
+    "id": "ann-pq02-003-abelian-iso",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 104, "endLine": 113 },
+    "type": "technique",
+    "title": "Abelian-Case Uniqueness via mulEquivOfCyclicCardEq",
+    "content": "`pq_abelian_iso` registers both $G$ and $H$ as cyclic instances (from `pq_abelian_isCyclic`) and produces $G \\simeq^* H$ from `mulEquivOfCyclicCardEq`, whose only obligation is the equality of cardinalities (bridged Fintype.card → Nat.card and rewritten by the order hypotheses).",
+    "mathContext": "`mulEquivOfCyclicCardEq` packages the classical fact that a finite cyclic group is determined up to isomorphism by its order: both groups embed into $\\mathrm{Multiplicative}(\\mathbb{Z}/n)$ via a chosen generator."
+  },
+  {
+    "id": "ann-pq02-004-zmod-model",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 115, "endLine": 130 },
+    "type": "technique",
+    "title": "Canonical Representative ℤ/pq",
+    "content": "`pq_abelian_iso_zmod` pins the canonical model: `zmodCyclicMulEquiv` yields $\\mathrm{Multiplicative}(\\mathbb{Z}/\\mathrm{Nat.card}\\,G) \\simeq^* G$, and the cardinality equality $\\mathrm{Nat.card}\\,G = pq$ is transported through the dependent type with the rewrite `hN ▸ (...).symm`, giving $G \\simeq^* \\mathrm{Multiplicative}(\\mathbb{Z}/pq)$.",
+    "mathContext": "Working with `Multiplicative (ZMod n)` keeps the additive cyclic group $\\mathbb{Z}/n$ but views it multiplicatively, matching the `Group`/`MulEquiv` setting."
+  },
+  {
+    "id": "ann-pq02-005-corollaries",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 131, "endLine": 163 },
+    "type": "concept",
+    "title": "Concrete Corollaries",
+    "content": "`order_6_abelian_unique`, `order_15_abelian_unique`, `order_35_abelian_unique` give every abelian group of those orders as $\\mathbb{Z}/n$; `order_15_abelian_pair` states any two abelian groups of order 15 are isomorphic. `order_6` highlights that the abelian-case theorem pins the abelian class even though $6 = 2\\cdot 3$ falls in the non-cyclic branch ($2 \\mid 2$), where $S_3 \\cong D_3$ is the other class.",
+    "mathContext": "Order 6 is the smallest order admitting a non-abelian group ($S_3$). The cyclic group $\\mathbb{Z}/6$ is the unique abelian group of that order."
+  }
+]

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "lagrange-theorem-oq-01-oq-01-oq-02",
+  "title": "pq-Groups: Abelian Isomorphism Uniqueness (every abelian group of order pq is ℤ/pq)",
+  "slug": "lagrange-theorem-oq-01-oq-01-oq-02",
+  "description": "Upgrades the abelian portion of the parent pq-classification from a counting statement to genuine MulEquiv isomorphisms, using only Mathlib. For ANY distinct primes p ≠ q, every abelian group of order pq is cyclic (via Cauchy + the coprime-order product law), so any two abelian groups of order pq are isomorphic — each isomorphic to Multiplicative (ZMod pq). This identifies the abelian isomorphism class in BOTH branches of the classification (cyclic p ∤ q-1, and the non-cyclic p | q-1 branch where the other class is the non-abelian semidirect product). The general not-necessarily-abelian uniqueness is deferred (it depends on the parent Sylow classification, which currently does not compile on Mathlib v4.26.0).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
+    "tags": [
+      "group-theory",
+      "lagrange",
+      "pq-groups",
+      "classification",
+      "isomorphism",
+      "MulEquiv",
+      "cyclic-groups",
+      "abelian-groups",
+      "ZMod",
+      "finite-groups"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 163,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API (Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv`). No `axiom` declarations and no structure-encoded assumptions. Kernel-verified on Mathlib v4.26.0: every theorem depends on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (no `sorryAx`, no `Lean.ofReduceBool`).",
+    "originalContributions": [
+      "pq_abelian_isCyclic: every finite ABELIAN group of order pq (any distinct primes p ≠ q) is cyclic — proved from Cauchy (elements of order p and q) plus the coprime-order product law orderOf(a·b) = pq = |G|. Holds with NO divisibility hypothesis, so it also applies inside the non-cyclic p | (q-1) branch.",
+      "pq_abelian_iso: consequently any two abelian groups of order pq are isomorphic (Nonempty (G ≃* H)) via mulEquivOfCyclicCardEq.",
+      "pq_abelian_iso_zmod: every abelian group of order pq is isomorphic to the canonical model Multiplicative (ZMod pq) via zmodCyclicMulEquiv.",
+      "Concrete corollaries order_6_abelian_unique, order_15_abelian_unique, order_35_abelian_unique (each abelian group of those orders ≅ ℤ/n), and order_15_abelian_pair (any two abelian groups of order 15 are isomorphic). order_6 illustrates that the abelian class is pinned even though 6 = 2·3 lies in the non-cyclic branch where S₃ is the other class.",
+      "Self-contained: imports only Mathlib, deliberately avoiding the parent Sylow classification dependency `Proofs.SylowTheoremOQ01` which does not compile on Mathlib v4.26.0."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classification of groups of order pq (p < q distinct primes) is a classical application of Sylow theory due to Hölder/Burnside. The parent entry `lagrange-theorem-oq-01-oq-01` establishes the counting facts: the Sylow q-subgroup is always normal, and G is cyclic iff p ∤ (q-1); when p ∤ (q-1) there is a unique isomorphism class (ℤ/pq), and when p | (q-1) there are exactly two (ℤ/pq and a non-abelian semidirect product ℤ/q ⋊ ℤ/p). Sibling entry `lagrange-theorem-oq-01-oq-01-oq-01` supplies explicit non-cyclic witnesses (DihedralGroup q for p = 2, and the general semidirect product). The remaining gap, flagged in that sibling's open questions, is to turn the COUNTING statement into genuine ISOMORPHISMS using Mathlib's MulEquiv machinery. This file does that for the abelian thread, fully and self-containedly.",
+    "problemStatement": "Upgrade the pq-classification to isomorphism uniqueness via Mathlib's group-isomorphism machinery: 'any two groups of order pq are isomorphic to each other, for each of the two cases.' This file resolves the abelian thread: identify, up to MulEquiv, the abelian isomorphism class of order pq.",
+    "proofStrategy": "In a CommGroup of order pq, Cauchy's theorem (`exists_prime_orderOf_dvd_card`) yields a of order p and b of order q. Since the group is abelian a and b commute, and p, q being coprime, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives orderOf(a·b) = p·q = |G|; `isCyclic_of_orderOf_eq_card` then makes G cyclic. Finally `mulEquivOfCyclicCardEq` (two cyclic groups of equal Nat.card are isomorphic) and `zmodCyclicMulEquiv` (a cyclic group ≅ Multiplicative (ZMod (Nat.card G))) deliver the isomorphism statements, bridging Fintype.card to Nat.card via `Nat.card_eq_fintype_card`.",
+    "keyInsights": [
+      "An abelian group of order pq is cyclic for EVERY pair of distinct primes, independent of whether p | (q-1). The squarefree order plus the coprime-order product law forces a generator a·b of order pq. This isolates the abelian isomorphism class on BOTH sides of the classification dichotomy.",
+      "Mathlib's `mulEquivOfCyclicCardEq` is exactly the tool that upgrades an `IsCyclic` fact to a genuine `MulEquiv` — the difference between 'one isomorphism class' and 'a concrete isomorphism'.",
+      "Fintype.card and Nat.card must be bridged (`Nat.card_eq_fintype_card`) because Cauchy/cardinality hypotheses use Fintype.card while the cyclic-iso API is phrased with Nat.card.",
+      "The coprime-order multiplication lemma lives in namespace Commute (used as dot notation `(Commute.all a b).orderOf_mul_eq_mul_orderOf_of_coprime`), not in the root namespace.",
+      "The general (non-abelian-allowed) cyclic case and the non-abelian uniqueness both require the parent Sylow classification; keeping this file Mathlib-only makes the abelian result robust and independently verifiable."
+    ],
+    "prerequisites": [
+      "Cauchy's theorem exists_prime_orderOf_dvd_card (Mathlib.GroupTheory.Perm.Cycle.Type)",
+      "Commute.orderOf_mul_eq_mul_orderOf_of_coprime (Mathlib.GroupTheory.OrderOfElement)",
+      "isCyclic_of_orderOf_eq_card, mulEquivOfCyclicCardEq, zmodCyclicMulEquiv (Mathlib.GroupTheory.SpecificGroups.Cyclic)",
+      "Mathlib v4.26.0"
+    ]
+  },
+  "sections": [
+    {
+      "id": "module-docstring",
+      "title": "Module Docstring: OQ Statement, Abelian Scope, Deferred Cases",
+      "startLine": 1,
+      "endLine": 68,
+      "summary": "States OQ-01-OQ-01-OQ-02 (upgrade the counting classification to MulEquiv isomorphisms), the abelian thread delivered here, the proof of the key cyclicity step, and what is deferred (the general cyclic case and non-abelian uniqueness, which depend on the parent Sylow classification — currently not compiling on Mathlib v4.26.0). Lists the key Mathlib tools and cites Dummit–Foote §4.5 and Conrad's notes."
+    },
+    {
+      "id": "abelian-cyclic",
+      "title": "Part I — Abelian Groups of Order pq Are Cyclic",
+      "startLine": 69,
+      "endLine": 95,
+      "summary": "pq_abelian_isCyclic: any abelian group of order pq is cyclic. Cauchy gives elements of orders p and q; the coprime-order product law makes their product a generator of order pq = |G|. No divisibility hypothesis, so this covers the abelian class in both branches."
+    },
+    {
+      "id": "abelian-iso",
+      "title": "Part II — Abelian Isomorphism Uniqueness",
+      "startLine": 96,
+      "endLine": 130,
+      "summary": "pq_abelian_iso (any two abelian groups of order pq are isomorphic) and pq_abelian_iso_zmod (each ≅ Multiplicative (ZMod pq)), via mulEquivOfCyclicCardEq and zmodCyclicMulEquiv after Part I."
+    },
+    {
+      "id": "corollaries",
+      "title": "Part III — Concrete Corollaries (orders 6, 15, 35)",
+      "startLine": 131,
+      "endLine": 163,
+      "summary": "order_6_abelian_unique, order_15_abelian_unique, order_35_abelian_unique: every abelian group of those orders is ℤ/n. order_15_abelian_pair: any two abelian groups of order 15 are isomorphic. order_6 illustrates the abelian class being pinned even though 6 = 2·3 lies in the non-cyclic branch (2 | 2) where S₃ is the other class."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file proves 7 theorems with 0 sorries and 0 axioms (kernel-verified: standard [propext, Classical.choice, Quot.sound] triple only). It identifies, up to MulEquiv, the abelian isomorphism class of order pq for every pair of distinct primes: every abelian group of order pq is cyclic, any two are isomorphic, and each is isomorphic to Multiplicative (ZMod pq).",
+    "implications": "Together with the parent (counting) and sibling oq-01-oq-01-oq-01 (explicit non-cyclic witnesses), the abelian side of the order-pq classification now has genuine isomorphisms, not just a class count. The outstanding pieces of full isomorphism uniqueness are the general cyclic case (for p ∤ q-1, any two groups of order pq are isomorphic) and the non-abelian case (any two non-cyclic groups of order pq are isomorphic) — both requiring the parent Sylow classification and, for the non-abelian case, an internal semidirect-product recognition ℤ/q ⋊ ℤ/p.",
+    "openQuestions": [
+      "General cyclic-case uniqueness: for distinct primes p < q with p ∤ (q-1), prove any two groups of order pq are isomorphic. This needs the parent's `pq_unique_when_coprime` (every order-pq group is cyclic when p ∤ q-1), which depends on `Proofs.SylowTheoremOQ01`; that file does not compile on Mathlib v4.26.0 and is an independent repair task.",
+      "Non-abelian uniqueness: prove any two non-cyclic groups of order pq (with p | q-1) are isomorphic, by recognizing each as the internal semidirect product ℤ/q ⋊ ℤ/p and showing all non-trivial actions ℤ/p → Aut(ℤ/q) yield isomorphic products.",
+      "REPAIR FLAG: the parent chain `Proofs.SylowTheoremOQ01` → `Proofs.LagrangeTheoremOQ01OQ01` uses Mathlib names absent in v4.26.0 (e.g. `Nat.Prime.eq_of_dvd_of_prime`, `orderOf_eq_one_iff_eq_one`); a Mechanic pass is needed before the cyclic-case upgrade can be built on top of it."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "lagrange-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent pq-classification (counting of isomorphism classes). This file upgrades the abelian class to a genuine MulEquiv, independently of the parent's (currently non-compiling) Sylow infrastructure."
+    },
+    {
+      "targetId": "lagrange-theorem-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling supplying explicit non-cyclic witnesses (DihedralGroup q and the general semidirect product). Its open-question list flags the isomorphism-uniqueness upgrade; this file delivers the abelian portion of it."
+    }
+  ],
+  "leanFile": {
+    "namespace": "LagrangeOQ01OQ01OQ02",
+    "lineCount": 163,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib"
+    ]
+  },
+  "sorries": 0
+}

--- a/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/lagrange-theorem-oq-01-oq-01-oq-02.json
@@ -1,0 +1,347 @@
+{
+  "slug": "lagrange-theorem-oq-01-oq-01-oq-02",
+  "title": "Prove the full isomorphism uniqueness: any two groups of order pq are isomorp...",
+  "phase": "ACT",
+  "status": "in-progress",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal mathematical investigation: Prove the full isomorphism uniqueness: any two groups of order pq are isomorp....",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-06-23T23:16:23.903Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS (verified, self-contained): abelian-case isomorphism uniqueness fully formalized — every abelian group of order pq is cyclic ≅ ℤ/pq (7 thms, 0 sorries, 0 axioms, Mathlib-only). General cyclic + non-abelian uniqueness BLOCKED on parent SylowTheoremOQ01 which fails to compile on v4.26.0.",
+    "builtItems": [
+      "pq_abelian_isCyclic (LagrangeTheoremOQ01OQ01OQ02.lean): any CommGroup of order pq is cyclic (no divisibility hyp) via Cauchy exists_prime_orderOf_dvd_card + Commute.orderOf_mul_eq_mul_orderOf_of_coprime + isCyclic_of_orderOf_eq_card",
+      "pq_abelian_iso, pq_abelian_iso_zmod: any two abelian order-pq groups isomorphic, each ≅ Multiplicative (ZMod pq), via mulEquivOfCyclicCardEq + zmodCyclicMulEquiv",
+      "Concrete: order_6/15/35_abelian_unique (≅ ℤ/n), order_15_abelian_pair. Kernel-verified standard triple, 0 axioms"
+    ],
+    "insights": [
+      "Mathlib mulEquivOfCyclicCardEq (Cyclic.lean:787) upgrades IsCyclic-level classification to genuine MulEquiv from equal Nat.card — short but is the count→isomorphism step",
+      "Abelian of squarefree order pq is cyclic for EVERY pair of distinct primes, independent of p|(q-1); isolates the abelian iso class on both sides of the dichotomy",
+      "Fintype.card (parent) must be bridged to Nat.card (cyclic-iso API) via Nat.card_eq_fintype_card",
+      "Commute.orderOf_mul_eq_mul_orderOf_of_coprime is in namespace Commute (dot notation), not _root_",
+      "BLOCKER: parent chain Proofs.SylowTheoremOQ01 → LagrangeTheoremOQ01OQ01 does NOT compile on Mathlib v4.26.0 — uses removed/renamed names Nat.Prime.eq_of_dvd_of_prime and orderOf_eq_one_iff_eq_one (confirmed absent from Mathlib source; 14 deterministic errors). The parent entry is marked verified but is stale → Mechanic repair needed. This file therefore imports ONLY Mathlib and delivers the abelian case independently."
+    ],
+    "mathlibGaps": [
+      "No Mathlib lemma recognizing an internal semidirect product from a normal subgroup + complement (needed for nonabelian uniqueness)",
+      "Parent SylowTheoremOQ01.lean stale on v4.26.0 (renamed lemmas) — must be repaired before the general cyclic-case (p∤q-1 ⟹ cyclic) and non-abelian uniqueness can build on pq_unique_when_coprime"
+    ],
+    "nextSteps": [
+      "Non-abelian uniqueness: recognize any non-cyclic order-pq group as internal semidirect product ZMod q ⋊ ZMod p, and show all nontrivial actions ZMod p → Aut(ZMod q) give isomorphic products — the harder open direction",
+      "Consider whether Mathlib SemidirectProduct + the sibling oq-01-oq-01-oq-01 ApproachB actionHom infrastructure can be reused to build the nonabelian iso"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "extension"
+  ],
+  "relatedProofs": [
+    "lagrange-theorem",
+    "lagrange-theorem-oq-01",
+    "lagrange-theorem-oq-01-oq-01",
+    "lagrange-theorem-oq-01-oq-01-oq-01",
+    "lagrange-theorem-oq-01-oq-02",
+    "lagrange-theorem-oq-01-oq-03",
+    "lagrange-theorem-oq-02",
+    "lagrange-theorem-oq-02-oq-01",
+    "lagrange-theorem-oq-02-oq-01-oq-01",
+    "lagrange-theorem-oq-02-oq-01-oq-02",
+    "lagrange-theorem-oq-02-oq-02",
+    "lagrange-theorem-oq-02-oq-02-oq-01",
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-01",
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01",
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-01-oq-01-oq-01",
+    "lagrange-theorem-oq-02-oq-02-oq-01-oq-02",
+    "lagrange-theorem-oq-03",
+    "lagrange-theorem-oq-05",
+    "lagrange-theorem-oq-06",
+    "lagrange-theorem-oq-07",
+    "lagrange-theorem-oq-07-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-23T23:16:23.903Z",
+  "lastUpdate": "2026-06-23",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/LagrangeTheorem.lean",
+      "filename": "LagrangeTheorem.lean",
+      "lineCount": 223,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheorem.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01.lean",
+      "filename": "LagrangeTheoremOQ01.lean",
+      "lineCount": 142,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01OQ01.lean",
+      "filename": "LagrangeTheoremOQ01OQ01.lean",
+      "lineCount": 170,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01OQ01OQ01.lean",
+      "filename": "LagrangeTheoremOQ01OQ01OQ01.lean",
+      "lineCount": 141,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01OQ01OQ01ApproachB.lean",
+      "filename": "LagrangeTheoremOQ01OQ01OQ01ApproachB.lean",
+      "lineCount": 441,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ01ApproachB.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
+      "filename": "LagrangeTheoremOQ01OQ01OQ02.lean",
+      "lineCount": 168,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01OQ02.lean",
+      "filename": "LagrangeTheoremOQ01OQ02.lean",
+      "lineCount": 122,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ01OQ03.lean",
+      "filename": "LagrangeTheoremOQ01OQ03.lean",
+      "lineCount": 212,
+      "theoremCount": 13,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02.lean",
+      "filename": "LagrangeTheoremOQ02.lean",
+      "lineCount": 208,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ01.lean",
+      "lineCount": 231,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ01OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ01OQ01.lean",
+      "lineCount": 138,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ01OQ02.lean",
+      "filename": "LagrangeTheoremOQ02OQ01OQ02.lean",
+      "lineCount": 77,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ02.lean",
+      "filename": "LagrangeTheoremOQ02OQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ02OQ01.lean",
+      "lineCount": 196,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ02OQ01OQ01.lean",
+      "lineCount": 110,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean",
+      "lineCount": 104,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean",
+      "lineCount": 125,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean",
+      "filename": "LagrangeTheoremOQ02OQ02OQ01OQ02.lean",
+      "lineCount": 121,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ03.lean",
+      "filename": "LagrangeTheoremOQ03.lean",
+      "lineCount": 374,
+      "theoremCount": 27,
+      "axiomCount": 2,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ05.lean",
+      "filename": "LagrangeTheoremOQ05.lean",
+      "lineCount": 114,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ05.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ06.lean",
+      "filename": "LagrangeTheoremOQ06.lean",
+      "lineCount": 114,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ06.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ07.lean",
+      "filename": "LagrangeTheoremOQ07.lean",
+      "lineCount": 129,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ07.lean"
+    },
+    {
+      "path": "Proofs/LagrangeTheoremOQ07OQ02.lean",
+      "filename": "LagrangeTheoremOQ07OQ02.lean",
+      "lineCount": 159,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ07OQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Resolves the **abelian thread** of OQ-01-OQ-01-OQ-02 (Lagrange's Theorem chain): upgrade the parent pq-group *classification* (a count of isomorphism classes) to genuine `MulEquiv` isomorphisms via Mathlib's group-isomorphism machinery.

**Self-contained (imports only Mathlib), fully verified: 7 theorems, 0 sorries, 0 axioms.** Kernel-checked on Mathlib v4.26.0 — every theorem depends on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (no `sorryAx`, no `Lean.ofReduceBool`).

### Results
- `pq_abelian_isCyclic` — every abelian group of order `pq` (any distinct primes `p ≠ q`) is **cyclic**. Cauchy's theorem gives `a` of order `p` and `b` of order `q`; abelian ⇒ they commute, `p,q` coprime ⇒ `orderOf (a*b) = pq = |G|`, so `G` is cyclic. **No divisibility hypothesis** — this pins the abelian class in *both* branches of the classification.
- `pq_abelian_iso` / `pq_abelian_iso_zmod` — any two abelian groups of order `pq` are isomorphic, each `≅ Multiplicative (ZMod pq)`.
- Concrete corollaries: `order_6_abelian_unique`, `order_15_abelian_unique`, `order_35_abelian_unique`, `order_15_abelian_pair`. (Order 6 illustrates the abelian class being unique even though `6 = 2·3` lies in the non-cyclic branch where `S₃` is the other class.)

### Scope / deferred
The **general cyclic case** (`p ∤ q-1` ⇒ any two order-`pq` groups isomorphic) and the **non-abelian uniqueness** depend on the parent Sylow classification `pq_unique_when_coprime`.

⚠️ **Repair flag**: the parent chain `Proofs.SylowTheoremOQ01` → `Proofs.LagrangeTheoremOQ01OQ01` does **not compile on Mathlib v4.26.0** — it uses removed/renamed names (`Nat.Prime.eq_of_dvd_of_prime`, `orderOf_eq_one_iff_eq_one`, confirmed absent from the v4.26.0 source; 14 deterministic errors). The parent entry `lagrange-theorem-oq-01-oq-01` is marked `verified` but is stale and needs a **Mechanic** pass. This PR deliberately avoids that dependency.

### Files
- `proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean` (new, 163 lines)
- `src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/{meta.json,annotations.json}` (new)
- research knowledge updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)