### PR TITLE
fix(audit): register orphaned NormalAutDegreeFormula in Proofs.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3248,6 +3248,7 @@ import Proofs.NesbittInequalityOQ01
 import Proofs.NormEuclideanZsqrtdFamilyOQ03
 import Proofs.NormEuclideanZsqrtdFamilyOQ03OQ02
 import Proofs.NormEuclideanZsqrtdFamilyOQ03OQ02OQ01
+import Proofs.NormalAutDegreeFormula
 import Proofs.NormalAutFinSepDegreeEquality
 import Proofs.NewtonIndStep2
 import Proofs.NewtonInductiveStep


### PR DESCRIPTION
## Problem

`proofs/Proofs/NormalAutDegreeFormula.lean` (8 theorems on the degree formula for normal extensions, gallery status `verified`) exists on `main` but is **not imported** into `proofs/Proofs.lean`. Because nothing imports it, no `.olean` is produced and the kernel never checks it — a "verified" proof that has never actually been verified by CI.

Confirmed orphan:
```
$ git show origin/main:proofs/Proofs.lean | grep NormalAutDegreeFormula
(no output)
```

## Fix

Add the single missing import line, in alphabetical position alongside the sibling `NormalAutFinSepDegreeEquality`.

## Verification

Kernel-verified clean on Lean v4.26.0:
```
$ cd proofs && lake env lean Proofs/NormalAutDegreeFormula.lean
(EXIT 0 — no errors, no 'declaration uses sorry' warnings)
```
The only `sorry` token in the file is in a docstring ("No axioms, no \`sorry\`, no \`native_decide\`").

## Relationship to #28588

This is a minimal, conflict-free alternative to the auditor's PR #28588, which makes the same one-line registration but is stuck `CONFLICTING` and additionally rewrites ~hundreds of lines of `src/data/proofs/audit-tracker.json` as pure unicode re-encoding churn (`→` → `\\u2192`). This PR touches only the one line that matters. #28588 can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)