### PR TITLE
Enrich Similar Matrices Share a Minimal Polynomial: add annotations

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06/annotations.json
@@ -1,0 +1,167 @@
+[
+  {
+    "id": "ann-chmoq06-1",
+    "proofId": "cayley-hamilton-minpoly-oq-06",
+    "range": {
+      "startLine": 25,
+      "endLine": 30
+    },
+    "type": "context",
+    "title": "Universe-Polymorphic K-Algebra Setting",
+    "content": "**Setup**: `{K : Type*} [Field K]` and `{A : Type*} [Ring A] [Algebra K A]`.\n\nThe entire development is stated for an arbitrary $K$-algebra $A$, not just matrices. This is deliberate: the inner-conjugation argument never touches matrix entries, only the ring multiplication and the unit $u$. The matrix theorem is recovered for free at the end by instantiating $A = \\mathrm{Matrix}\\ n\\ n\\ K$.\n\nNote that $A$ is only required to be a (possibly noncommutative) ring — conjugation is interesting precisely when $A$ is noncommutative, since in a commutative ring $u x u^{-1} = x$ trivially.",
+    "mathContext": "A $K$-algebra is a ring $A$ together with a ring homomorphism $K \\to A$ landing in the center of $A$. Working at this generality means the result simultaneously covers matrix algebras, group algebras $K[G]$, division algebras, and endomorphism rings.",
+    "significance": "context",
+    "relatedConcepts": [
+      "K-algebra",
+      "Noncommutative ring",
+      "Central subfield"
+    ],
+    "prerequisites": [
+      "Algebra over a field",
+      "Units of a ring"
+    ],
+    "tags": [
+      "setup",
+      "generality",
+      "k-algebra"
+    ]
+  },
+  {
+    "id": "ann-chmoq06-2",
+    "proofId": "cayley-hamilton-minpoly-oq-06",
+    "range": {
+      "startLine": 32,
+      "endLine": 41
+    },
+    "type": "definition",
+    "title": "Inner Conjugation as an Algebra Equivalence",
+    "content": "**`innerAlgEquiv u : A ≃ₐ[K] A`** sends $x \\mapsto u \\cdot x \\cdot u^{-1}$ with inverse $x \\mapsto u^{-1} \\cdot x \\cdot u$.\n\nThe bundled `AlgEquiv` requires discharging several structure fields, each a one-liner here:\n- **`left_inv` / `right_inv`**: $u^{-1}(u x u^{-1})u = x$ and its mirror, by `simp [mul_assoc]` cancelling $u^{-1} u = u u^{-1} = 1$.\n- **`map_mul'`**: $u(xy)u^{-1} = (u x u^{-1})(u y u^{-1})$ because the inner $u^{-1} u$ collapses — again `simp [mul_assoc]`.\n- **`map_add'`**: $u(x+y)u^{-1} = uxu^{-1} + uyu^{-1}$ by distributivity (`mul_add`, `add_mul`).\n\nThe heavy lifting is purely associativity plus the unit-cancellation lemmas; no integrality or finiteness is invoked.",
+    "mathContext": "An **inner automorphism** of $A$ is conjugation by a unit, $\\iota_u(x) = u x u^{-1}$. The map $u \\mapsto \\iota_u$ is a group homomorphism $A^\\times \\to \\mathrm{Aut}_K(A)$ whose image is the normal subgroup of inner automorphisms; its kernel is the units commuting with all of $A$ (the central units).",
+    "significance": "key",
+    "relatedConcepts": [
+      "Inner automorphism",
+      "Algebra automorphism",
+      "Skolem–Noether theorem"
+    ],
+    "prerequisites": [
+      "AlgEquiv structure",
+      "Units.mul_inv",
+      "mul_assoc"
+    ],
+    "tags": [
+      "inner-automorphism",
+      "definition",
+      "algebra-equivalence"
+    ]
+  },
+  {
+    "id": "ann-chmoq06-3",
+    "proofId": "cayley-hamilton-minpoly-oq-06",
+    "range": {
+      "startLine": 42,
+      "endLine": 43
+    },
+    "type": "technique",
+    "title": "The commutes' Field: Centrality of the Scalars",
+    "content": "**`commutes' r`**: an `AlgEquiv` must fix the image of the structure map, i.e. $\\iota_u(\\mathrm{algebraMap}_K\\,r) = \\mathrm{algebraMap}_K\\,r$.\n\nThe proof is `rw [← Algebra.commutes r (u : A), mul_assoc, Units.mul_inv, mul_one]`:\n$$ u \\cdot (\\kappa\\,r) \\cdot u^{-1} = (\\kappa\\,r) \\cdot u \\cdot u^{-1} = (\\kappa\\,r) \\cdot 1 = \\kappa\\,r, $$\nwhere $\\kappa = \\mathrm{algebraMap}_K$. The first step uses `Algebra.commutes`: scalars are *central*, so they slide past $u$. This is exactly the property that makes inner conjugation a $K$-algebra map (over $K$) and not merely a ring map.",
+    "mathContext": "Centrality $\\kappa(r)\\,a = a\\,\\kappa(r)$ for all $a$ is part of the definition of a $K$-algebra. It is what guarantees inner automorphisms are $K$-linear: they fix $K$ pointwise even while permuting the rest of $A$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Center of an algebra",
+      "Algebra.commutes",
+      "K-linearity of inner automorphisms"
+    ],
+    "prerequisites": [
+      "Algebra.commutes",
+      "Units.mul_inv"
+    ],
+    "tags": [
+      "centrality",
+      "commutes",
+      "k-linear"
+    ]
+  },
+  {
+    "id": "ann-chmoq06-4",
+    "proofId": "cayley-hamilton-minpoly-oq-06",
+    "range": {
+      "startLine": 49,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Inner Conjugation Preserves the Minimal Polynomial",
+    "content": "**`minpoly_units_conj`**: $\\mu_K(u x u^{-1}) = \\mu_K(x)$ for any unit $u$ and any $x$.\n\nThe proof is two lines: feed `innerAlgEquiv u` into Mathlib's `minpoly.algEquiv_eq`, which states $\\mu_A(f\\,x) = \\mu_A(x)$ for any algebra equivalence $f$, then `simpa` rewrites $f\\,x$ to $u x u^{-1}$ using `innerAlgEquiv_apply`.\n\nCrucially **no integrality hypothesis** is required: `minpoly.algEquiv_eq` is unconditional. If $x$ is not integral over $K$, both minimal polynomials are $0$ by convention, and equality still holds.",
+    "mathContext": "The minimal polynomial $\\mu_K(x)$ is the monic generator of $\\ker(\\mathrm{ev}_x : K[X] \\to A)$. An algebra equivalence $f$ intertwines evaluation, $f(\\mathrm{ev}_x\\,p) = \\mathrm{ev}_{f(x)}\\,p$, so it carries the annihilator of $x$ isomorphically onto that of $f(x)$ — hence identical minimal polynomials.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Minimal polynomial",
+      "minpoly.algEquiv_eq",
+      "Annihilator ideal"
+    ],
+    "prerequisites": [
+      "minpoly.algEquiv_eq",
+      "Evaluation homomorphism aeval"
+    ],
+    "tags": [
+      "minimal-polynomial",
+      "invariance",
+      "main-result"
+    ]
+  },
+  {
+    "id": "ann-chmoq06-5",
+    "proofId": "cayley-hamilton-minpoly-oq-06",
+    "range": {
+      "startLine": 56,
+      "endLine": 61
+    },
+    "type": "technique",
+    "title": "The u⁻¹ x u Presentation by Symmetry",
+    "content": "**`minpoly_units_conj'`**: $\\mu_K(u^{-1} x u) = \\mu_K(x)$.\n\nRather than re-prove anything, this applies `minpoly_units_conj` with the unit $u^{-1}$ in place of $u$: conjugation by $u^{-1}$ is $x \\mapsto u^{-1} x (u^{-1})^{-1} = u^{-1} x u$ after `simpa` simplifies $(u^{-1})^{-1} = u$ via `inv_inv`.\n\nProviding both presentations matters because the standard textbook form of matrix similarity is $N = U^{-1} M U$, while the cleanest abstract statement is $u x u^{-1}$. Exposing both spares downstream users a manual `inv_inv` rewrite.",
+    "mathContext": "Inner automorphisms form a group: $\\iota_u \\circ \\iota_v = \\iota_{uv}$ and $\\iota_u^{-1} = \\iota_{u^{-1}}$. So conjugating by $u^{-1}$ is the inverse automorphism, and since automorphisms preserve $\\mu_K$, both directions give the same invariance.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Group of inner automorphisms",
+      "inv_inv",
+      "Matrix similarity normal form"
+    ],
+    "prerequisites": [
+      "Units.inv_inv",
+      "minpoly_units_conj"
+    ],
+    "tags": [
+      "symmetry",
+      "presentation",
+      "convenience-lemma"
+    ]
+  },
+  {
+    "id": "ann-chmoq06-6",
+    "proofId": "cayley-hamilton-minpoly-oq-06",
+    "range": {
+      "startLine": 63,
+      "endLine": 77
+    },
+    "type": "insight",
+    "title": "Matrix Specialisation: Similar Matrices Share a Minimal Polynomial",
+    "content": "**`minpoly_matrix_units_conj`**: for a unit matrix $U$ and any $M$, $\\mu_K(U^{-1} M U) = \\mu_K(M)$ — and the $U M U^{-1}$ form via `minpoly_matrix_units_conj'`.\n\nBoth are **one-line corollaries**: instantiate the abstract lemmas at $A = \\mathrm{Matrix}\\ n\\ n\\ K$. The only new typeclass data is `[Fintype n] [DecidableEq n]`, needed to make $\\mathrm{Matrix}\\ n\\ n\\ K$ a ring.\n\nThis is the **minimal-polynomial companion** of Mathlib's `Matrix.charpoly_units_conj`. Together they establish that both the characteristic and the minimal polynomial are similarity invariants — the starting point for canonical-form theory.",
+    "mathContext": "Two matrices are **similar**, $M \\sim N$, when $N = U^{-1} M U$ for invertible $U$; this is the same linear map written in two bases. Similarity invariants (trace, determinant, $\\chi$, $\\mu$, rank, eigenvalues with multiplicity) are exactly the basis-independent data of an endomorphism.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Matrix similarity",
+      "Matrix.charpoly_units_conj",
+      "Rational canonical form",
+      "Similarity invariants"
+    ],
+    "prerequisites": [
+      "Matrix ring structure",
+      "Units of a matrix ring",
+      "minpoly_units_conj"
+    ],
+    "tags": [
+      "matrix-similarity",
+      "specialisation",
+      "canonical-form"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-06` (*Similar Matrices Share a Minimal Polynomial*).

## What changed
The entry had a rich `meta.json` but **no `annotations.json`**. This PR adds inline annotations covering the full 79-line Lean file.

## Quality improvements
- **6 annotations** spanning every part of the proof:
  1. Universe-polymorphic K-algebra setup
  2. `innerAlgEquiv` — inner conjugation as a K-algebra equivalence
  3. The `commutes'` field — centrality of the scalars (why it is K-linear)
  4. `minpoly_units_conj` — inner conjugation preserves the minimal polynomial
  5. The `u⁻¹ x u` presentation by symmetry
  6. Matrix specialisation — similar matrices share a minimal polynomial
- Every annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, connecting the result to inner automorphisms, the Skolem–Noether theorem, and similarity-invariant / canonical-form theory.
- All annotations anchored to real Lean constructs; entry passes `pnpm annotations:build` with **no errors** for this slug.

## Integrity
No claims changed: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` all remain accurate against the Lean source (built on Mathlib's unconditional `minpoly.algEquiv_eq`).