### PR TITLE
fix(audit): register orphaned AmgmInequalityOQ02OQ03OQ03OQ03 in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -82,6 +82,7 @@ import Proofs.AmgmInequalityOQ02OQ01OQ05
 import Proofs.AmgmInequalityOQ02OQ02
 import Proofs.AmgmInequalityOQ02OQ03
 import Proofs.AmgmInequalityOQ02OQ03OQ03
+import Proofs.AmgmInequalityOQ02OQ03OQ03OQ03
 import Proofs.AmgmInequalityOQ03
 import Proofs.AmgmInequalityOQ03OQ02OQ01
 import Proofs.AmgmInequalityOQ03OQ02OQ01OQ01


### PR DESCRIPTION
## Fix

Register the orphaned, verified gallery entry `AmgmInequalityOQ02OQ03OQ03OQ03` into `proofs/Proofs.lean` so it is included in the build graph and actually kernel-checked.

## Evidence

**Before**: `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03OQ03.lean` exists and the gallery entry `amgm-inequality-oq-02-oq-03-oq-03-oq-03` is marked `status: verified` (badge `mathlib`, 0 sorries, 0 axioms), but there was **no** `import Proofs.AmgmInequalityOQ02OQ03OQ03OQ03` line in `proofs/Proofs.lean`. The proof was therefore orphaned from the build graph and never kernel-checked.

**After**: Added the missing import (alphabetically placed after `AmgmInequalityOQ02OQ03OQ03`). Kernel-verified clean with `lake env lean` (EXIT 0); the file imports only `Mathlib` and is self-contained.

This is the sibling orphan to `AmgmInequalityOQ02OQ03OQ03OQ01` (registered in #28592). One file per PR for conflict-free merging.

---
Automated fix by lean-mechanic agent.