### PR TITLE
research(urysohns-lemma-oq-01-oq-01-oq-01): Tietze extension as an explicit tsum of bounded continuous corrections

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3781,6 +3781,7 @@ import Proofs.UniformBellMultinomialOQ01
 import Proofs.UniformBellMultinomialOQ01OQ01
 import Proofs.UrysohnsLemmaOQ01
 import Proofs.UrysohnsLemmaOQ01OQ01
+import Proofs.UrysohnsLemmaOQ01OQ01OQ01
 import Proofs.UrysohnsLemmaOQ01OQ02
 import Proofs.VanAubelTheoremOQ01
 import Proofs.VandermondeInterpolationOQ01

--- a/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/UrysohnsLemmaOQ01OQ01OQ01.lean
@@ -1,0 +1,197 @@
+import Mathlib
+import Proofs.UrysohnsLemmaOQ01OQ01
+
+/-!
+# Tietze Extension as an Explicit Series of Bounded Continuous Corrections
+
+The parent entry (`urysohns-lemma-oq-01-oq-01`) isolates the *engine* of the classical
+Tietze proof — the one-step Urysohn approximation `urysohn_approx_step` and the
+quantitative iteration `urysohn_approx_iterate` — but it assembles the final extension by
+calling Mathlib's `TietzeExtension` machinery (`exists_restrict_eq`), which hides the
+limit behind a black box.
+
+This entry removes that black box.  We build the extension **by hand** as a genuinely
+convergent series
+
+    G  =  ∑' n, gₙ          in the Banach space  BoundedContinuousFunction X ℝ
+
+where each correction `gₙ` is the global bounded-continuous function produced by one
+application of Urysohn's lemma to the current residual, and `‖gₙ‖ ≤ (2/3)ⁿ · (M/3)`.
+
+The geometric majorant makes the series **absolutely convergent**, hence summable because
+`BoundedContinuousFunction X ℝ` is complete.  The partial sums approximate `f` on the
+closed set `s` with error `(2/3)ⁿ · M → 0`, so the sum restricts to `f`.  Summing the
+majorant, `‖G‖ ≤ ∑' n, (2/3)ⁿ · (M/3) = (M/3)·3 = M`, so the extension lands in the *same*
+sup-bound `[-M, M]` as the data — the explicit bounded Tietze extension.
+
+## Main results
+
+* `TietzeTsum.gbcf` — the `n`-th correction as a bounded continuous function on `X`.
+* `TietzeTsum.gbcf_norm_le` — the geometric sup-norm bound `‖gₙ‖ ≤ (2/3)ⁿ·(M/3)`.
+* `TietzeTsum.summable_gbcf` — absolute convergence of the correction series.
+* `tietze_extension_via_tsum` — the assembled theorem: there is a bounded continuous
+  `G = ∑' n, gₙ` with `G = f` on `s` and `|G| ≤ M` everywhere, built purely as the series.
+
+Everything is machine-checked with no `sorry`, and no part of Mathlib's `TietzeExtension`
+API is used.
+-/
+
+open Set Function Filter Topology
+
+namespace TietzeTsum
+
+variable {X : Type*} [TopologicalSpace X] [NormalSpace X] {s : Set X}
+  (hs : IsClosed s) (f : C(s, ℝ)) {M : ℝ} (hM : 0 ≤ M) (hf : ∀ x : s, |f x| ≤ M)
+
+/-- The residual `rₙ = f - (g₀ + … + g_{n-1})|_s` together with its geometric sup-bound
+`|rₙ| ≤ (2/3)ⁿ · M`.  The successor step applies the one-step Urysohn lemma
+`urysohn_approx_step` to the current residual and subtracts the resulting correction. -/
+noncomputable def Res : (n : ℕ) → {r : C(s, ℝ) // ∀ x : s, |r x| ≤ (2 / 3 : ℝ) ^ n * M}
+  | 0 => ⟨f, fun x => by simpa using hf x⟩
+  | n + 1 =>
+      let p := Res n
+      ⟨p.1 - restrictToClosed s
+          (urysohn_approx_step hs p.1 (mul_nonneg (by positivity) hM) p.2).choose,
+        fun x => by
+          have happ :=
+            (urysohn_approx_step hs p.1 (mul_nonneg (by positivity) hM) p.2).choose_spec.2 x
+          have hval :
+              (p.1 - restrictToClosed s
+                  (urysohn_approx_step hs p.1 (mul_nonneg (by positivity) hM) p.2).choose) x
+                = p.1 x - (urysohn_approx_step hs p.1 (mul_nonneg (by positivity) hM) p.2).choose
+                    (x : X) := by
+            simp [restrictToClosed]
+          rw [hval]
+          calc
+            |p.1 x - (urysohn_approx_step hs p.1 (mul_nonneg (by positivity) hM) p.2).choose (x : X)|
+                ≤ 2 / 3 * ((2 / 3 : ℝ) ^ n * M) := happ
+            _ = (2 / 3 : ℝ) ^ (n + 1) * M := by ring⟩
+
+/-- The `n`-th correction as a plain continuous function on `X`, obtained from Urysohn's lemma
+applied to the residual `Res n`. -/
+noncomputable def gcorr (n : ℕ) : C(X, ℝ) :=
+  (urysohn_approx_step hs (Res hs f hM hf n).1
+      (mul_nonneg (by positivity) hM) (Res hs f hM hf n).2).choose
+
+@[simp] lemma Res_zero : (Res hs f hM hf 0).1 = f := rfl
+
+/-- The defining recursion of the residual, in terms of the correction. -/
+lemma Res_succ_fst (n : ℕ) :
+    (Res hs f hM hf (n + 1)).1
+      = (Res hs f hM hf n).1 - restrictToClosed s (gcorr hs f hM hf n) := rfl
+
+/-- Each correction is globally bounded by `(2/3)ⁿ · (M/3)` — the engine of summability. -/
+lemma gcorr_bound (n : ℕ) (y : X) :
+    |gcorr hs f hM hf n y| ≤ (2 / 3 : ℝ) ^ n * (M / 3) := by
+  have h :=
+    (urysohn_approx_step hs (Res hs f hM hf n).1
+      (mul_nonneg (by positivity) hM) (Res hs f hM hf n).2).choose_spec.1 y
+  calc
+    |gcorr hs f hM hf n y| ≤ (2 / 3 : ℝ) ^ n * M / 3 := h
+    _ = (2 / 3 : ℝ) ^ n * (M / 3) := by ring
+
+/-- The `n`-th correction packaged as an element of the Banach space of bounded continuous
+functions. -/
+noncomputable def gbcf (n : ℕ) : BoundedContinuousFunction X ℝ :=
+  BoundedContinuousFunction.ofNormedAddCommGroup (gcorr hs f hM hf n)
+    (gcorr hs f hM hf n).continuous ((2 / 3 : ℝ) ^ n * (M / 3))
+    (fun y => by simpa [Real.norm_eq_abs] using gcorr_bound hs f hM hf n y)
+
+@[simp] lemma gbcf_apply (n : ℕ) (y : X) : gbcf hs f hM hf n y = gcorr hs f hM hf n y := rfl
+
+/-- Sup-norm bound on the `n`-th correction. -/
+lemma gbcf_norm_le (n : ℕ) : ‖gbcf hs f hM hf n‖ ≤ (2 / 3 : ℝ) ^ n * (M / 3) := by
+  refine (BoundedContinuousFunction.norm_le (mul_nonneg (by positivity) (by linarith))).2
+    (fun y => ?_)
+  simpa [Real.norm_eq_abs] using gcorr_bound hs f hM hf n y
+
+/-- The comparison geometric series `∑ (2/3)ⁿ·(M/3)` is summable. -/
+lemma summable_geo : Summable (fun n : ℕ => (2 / 3 : ℝ) ^ n * (M / 3)) :=
+  (summable_geometric_of_lt_one (by norm_num : (0:ℝ) ≤ 2 / 3)
+    (by norm_num : (2 / 3 : ℝ) < 1)).mul_right (M / 3)
+
+/-- **Absolute convergence of the correction series.** -/
+lemma summable_norm_gbcf : Summable (fun n => ‖gbcf hs f hM hf n‖) :=
+  Summable.of_nonneg_of_le (fun _ => norm_nonneg _) (gbcf_norm_le hs f hM hf)
+    (summable_geo (M := M))
+
+/-- The correction series is summable in the Banach space of bounded continuous functions. -/
+lemma summable_gbcf : Summable (gbcf hs f hM hf) :=
+  (summable_norm_gbcf hs f hM hf).of_norm
+
+end TietzeTsum
+
+open TietzeTsum in
+/-- **Tietze extension theorem, as an explicit series.**
+
+For a closed set `s` in a normal space `X` and a continuous `f : s → ℝ` with `|f| ≤ M`,
+the function `G = ∑' n, gₙ`, where each `gₙ` is the bounded-continuous Urysohn correction to
+the running residual, is a bounded continuous extension of `f` to all of `X` with the *same*
+sup-bound `|G| ≤ M`.  The construction is the genuine uniform limit of the partial sums and
+uses none of Mathlib's `TietzeExtension` machinery. -/
+theorem tietze_extension_via_tsum {X : Type*} [TopologicalSpace X] [NormalSpace X]
+    {s : Set X} (hs : IsClosed s) (f : C(s, ℝ)) {M : ℝ} (hM : 0 ≤ M)
+    (hf : ∀ x : s, |f x| ≤ M) :
+    ∃ G : BoundedContinuousFunction X ℝ,
+      (∀ x : s, G (x : X) = f x) ∧ G = ∑' n, gbcf hs f hM hf n ∧ (∀ y, |G y| ≤ M) := by
+  classical
+  set G : BoundedContinuousFunction X ℝ := ∑' n, gbcf hs f hM hf n with hG
+  have hsum : Summable (gbcf hs f hM hf) := summable_gbcf hs f hM hf
+  have hHasSum : HasSum (gbcf hs f hM hf) G := by rw [hG]; exact hsum.hasSum
+  -- The partial sums on `s` equal `f - rₙ`.
+  have psum : ∀ (x : s) (n : ℕ),
+      ∑ i ∈ Finset.range n, (gbcf hs f hM hf i) (x : X) = f x - (Res hs f hM hf n).1 x := by
+    intro x n
+    induction n with
+    | zero => simp
+    | succ n ih =>
+      rw [Finset.sum_range_succ, ih, Res_succ_fst]
+      simp only [ContinuousMap.sub_apply, restrictToClosed_apply, gbcf_apply]
+      ring
+  -- The residual tends to `0` pointwise on `s`.
+  have hpow : Tendsto (fun n => (2 / 3 : ℝ) ^ n * M) atTop (𝓝 0) := by
+    simpa using
+      (tendsto_pow_atTop_nhds_zero_of_lt_one (by norm_num : (0:ℝ) ≤ 2 / 3)
+        (by norm_num : (2 / 3 : ℝ) < 1)).mul_const M
+  have hres0 : ∀ x : s, Tendsto (fun n => (Res hs f hM hf n).1 x) atTop (𝓝 0) := by
+    intro x
+    refine squeeze_zero_norm (fun n => ?_) hpow
+    simpa [Real.norm_eq_abs] using (Res hs f hM hf n).2 x
+  refine ⟨G, fun x => ?_, hG, fun y => ?_⟩
+  · -- Evaluate the series at `x : s` and identify the limit with `f x`.
+    -- Evaluation at `(x : X)` is a continuous additive homomorphism.
+    let ev : BoundedContinuousFunction X ℝ →+ ℝ :=
+      { toFun := fun h => h (x : X), map_zero' := by simp, map_add' := by intro a b; simp }
+    have hev : Continuous ev := by
+      have hL : LipschitzWith 1 ev := by
+        rw [lipschitzWith_iff_dist_le_mul]
+        intro a b
+        simp only [ev, AddMonoidHom.coe_mk, ZeroHom.coe_mk, NNReal.coe_one, one_mul]
+        exact BoundedContinuousFunction.dist_coe_le_dist (x : X)
+      exact hL.continuous
+    have hx : HasSum (fun n => (gbcf hs f hM hf n) (x : X)) (G (x : X)) := by
+      have := hHasSum.map ev hev
+      simpa [ev, Function.comp] using this
+    have hpart : Tendsto
+        (fun n => ∑ i ∈ Finset.range n, (gbcf hs f hM hf i) (x : X)) atTop (𝓝 (G (x : X))) :=
+      hx.tendsto_sum_nat
+    have hpart' : Tendsto (fun n => f x - (Res hs f hM hf n).1 x) atTop (𝓝 (G (x : X))) := by
+      simpa only [psum x] using hpart
+    have hlim : Tendsto (fun n => f x - (Res hs f hM hf n).1 x) atTop (𝓝 (f x)) := by
+      simpa using Tendsto.const_sub (f x) (hres0 x)
+    exact tendsto_nhds_unique hpart' hlim
+  · -- Sup-norm bound: `‖G‖ ≤ ∑ (2/3)ⁿ (M/3) = M`.
+    have hnorm : ‖G‖ ≤ M := by
+      have h1 : ‖G‖ ≤ ∑' n, ‖gbcf hs f hM hf n‖ := by
+        rw [hG]; exact norm_tsum_le_tsum_norm (summable_norm_gbcf hs f hM hf)
+      have h2 : ∑' n, ‖gbcf hs f hM hf n‖ ≤ ∑' n, (2 / 3 : ℝ) ^ n * (M / 3) :=
+        Summable.tsum_le_tsum (gbcf_norm_le hs f hM hf) (summable_norm_gbcf hs f hM hf)
+          (summable_geo (M := M))
+      have h3 : ∑' n, (2 / 3 : ℝ) ^ n * (M / 3) = M := by
+        have hr : (1 - 2 / 3 : ℝ)⁻¹ = 3 := by norm_num
+        rw [tsum_mul_right, tsum_geometric_of_lt_one (by norm_num : (0:ℝ) ≤ 2 / 3)
+          (by norm_num : (2 / 3 : ℝ) < 1), hr]
+        ring
+      linarith [h1, h2, h3.ge, h3.le]
+    have := (BoundedContinuousFunction.norm_le hM).1 hnorm y
+    simpa [Real.norm_eq_abs] using this

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-residual-recursion",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 44,
+      "endLine": 81
+    },
+    "type": "definition",
+    "title": "The Residual Sequence and its Geometric Invariant",
+    "content": "`Res n` is the running residual rₙ = f − (g₀+…+g_{n-1})|_s of the Urysohn iteration, defined by structural recursion: Res 0 = f, and Res (n+1) = Res n − (Urysohn correction)|_s, where the correction is the choice term of the parent's `urysohn_approx_step` applied to Res n. The recursion is packaged in a subtype that carries the invariant |Res n| ≤ (2/3)ⁿ·M, proved at each step from the (2/3)-contraction clause of `urysohn_approx_step`. `gcorr n` extracts the n-th correction as an honest C(X, ℝ). `Res_zero` and `Res_succ_fst` record the two defining equations; crucially Res_succ_fst holds by `rfl`, which is what makes the later partial-sum telescoping a one-line induction.",
+    "mathContext": "$r_0=f,\\quad r_{n+1}=r_n-g_n|_s,\\quad |r_n(x)|\\le (2/3)^n M$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "structural recursion",
+      "residual / iteration",
+      "geometric contraction",
+      "subtype invariants"
+    ],
+    "prerequisites": [
+      "Urysohn's one-step approximation (parent entry)",
+      "continuous maps C(X, ℝ)",
+      "recursion carrying a proof invariant"
+    ]
+  },
+  {
+    "id": "ann-correction-bcf",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 107
+    },
+    "type": "definition",
+    "title": "Corrections as Bounded Continuous Functions",
+    "content": "`gcorr_bound` reads off the global bound |gcorr n y| ≤ (2/3)ⁿ·(M/3) directly from the |g| ≤ M/3 clause of the one-step Urysohn lemma. `gbcf n` then promotes the correction to a genuine element of the Banach space `BoundedContinuousFunction X ℝ` via `ofNormedAddCommGroup`, with `gbcf_apply` recording that it evaluates as gcorr n (a definitional `rfl`). `gbcf_norm_le` transfers the pointwise bound to the sup-norm ‖gbcf n‖ ≤ (2/3)ⁿ·(M/3) through `BoundedContinuousFunction.norm_le`. This sup-norm bound is the single quantity that drives both the summability of the series and the |G| ≤ M bound on the limit.",
+    "mathContext": "$\\|g_n\\|_\\infty\\le (2/3)^n (M/3),\\qquad g_n\\in (X\\to_b\\mathbb{R}).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "bounded continuous functions",
+      "sup-norm",
+      "ofNormedAddCommGroup"
+    ],
+    "prerequisites": [
+      "the bounded-continuous-function space and its norm",
+      "BoundedContinuousFunction.norm_le",
+      "absolute value vs. real norm"
+    ]
+  },
+  {
+    "id": "ann-summability",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 108,
+      "endLine": 121
+    },
+    "type": "insight",
+    "title": "Absolute Convergence in a Complete Space",
+    "content": "`summable_geo` is the convergent geometric majorant ∑ (2/3)ⁿ·(M/3). `summable_norm_gbcf` compares the correction norms against it (`Summable.of_nonneg_of_le`), and `summable_gbcf` concludes `Summable gbcf` by `Summable.of_norm` — absolute convergence implies convergence because `BoundedContinuousFunction X ℝ` is complete (ℝ is complete). This is the abstract fact that replaces Mathlib's TietzeExtension limit construction: where the parent entry delegated the assembly of the uniform limit to `exists_restrict_eq`, here the limit is produced purely from completeness and a geometric comparison.",
+    "mathContext": "$\\sum_n \\|g_n\\|<\\infty\\ \\Rightarrow\\ \\sum_n g_n\\ \\text{converges in the Banach space}.$",
+    "significance": "important",
+    "relatedConcepts": [
+      "absolute convergence",
+      "completeness",
+      "comparison test",
+      "geometric series"
+    ],
+    "prerequisites": [
+      "Summable.of_norm in a complete normed space",
+      "summability of the geometric series",
+      "comparison test for nonnegative series"
+    ]
+  },
+  {
+    "id": "ann-tietze-via-tsum",
+    "proofId": "urysohns-lemma-oq-01-oq-01-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 197
+    },
+    "type": "theorem",
+    "title": "The Tietze Extension as the Series Sum",
+    "content": "`tietze_extension_via_tsum` assembles the extension G = ∑' n, gbcf n. The partial-sum identity ∑_{i<n} gbcf i (↑x) = f x − Res n x on s is a one-line induction using the definitional recursion `Res_succ_fst`. Evaluation at ↑x is realized as a 1-Lipschitz additive homomorphism (`BoundedContinuousFunction.dist_coe_le_dist`), so `HasSum.map` carries `HasSum gbcf G` to `HasSum (gbcf · ↑x) (G ↑x)`; the partial sums therefore converge to G ↑x. They simultaneously equal f x − Res n x, which converges to f x because |Res n x| ≤ (2/3)ⁿ·M → 0 (`squeeze_zero_norm` against `tendsto_pow_atTop_nhds_zero_of_lt_one`). Uniqueness of limits gives G ↑x = f x. Finally `norm_tsum_le_tsum_norm` and `Summable.tsum_le_tsum` bound ‖G‖ ≤ ∑' (2/3)ⁿ·(M/3) = (1 − 2/3)⁻¹·(M/3) = M, and `BoundedContinuousFunction.norm_le` converts this to |G y| ≤ M everywhere — the sup-norm-preserving bounded Tietze extension, built with none of Mathlib's TietzeExtension machinery.",
+    "mathContext": "$G=\\sum_n g_n,\\quad G|_s=f,\\quad \\|G\\|_\\infty\\le M.$",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Tietze extension theorem",
+      "uniform limit / infinite series",
+      "HasSum and continuous homomorphisms",
+      "uniqueness of limits"
+    ],
+    "prerequisites": [
+      "HasSum.map through a continuous additive homomorphism",
+      "squeeze theorem and geometric decay",
+      "tsum monotonicity and the geometric sum value",
+      "the partial-sum telescoping identity"
+    ]
+  }
+]

--- a/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/urysohns-lemma-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "urysohns-lemma-oq-01-oq-01-oq-01",
+  "slug": "urysohns-lemma-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.UrysohnsLemmaOQ01OQ01"
+    ],
+    "opens": [
+      "Set",
+      "Function",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "TietzeTsum",
+    "lineCount": 197,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "path": "Proofs/UrysohnsLemmaOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Tietze Extension as an Explicit Series of Bounded Continuous Corrections",
+  "description": "A fully self-contained construction of the Tietze extension as a genuinely convergent series in the Banach space of bounded continuous functions BoundedContinuousFunction X ℝ, using none of Mathlib's TietzeExtension machinery. The parent entry urysohns-lemma-oq-01-oq-01 exposes the engine of the classical proof — the one-step Urysohn approximation urysohn_approx_step and the geometric iterate urysohn_approx_iterate — but assembles the final extension by invoking Mathlib's exists_restrict_eq, hiding the limit behind a black box. This entry removes the black box. The residual sequence Res n carries the running error rₙ = f − (g₀+…+g_{n-1})|_s with its sup-bound |rₙ| ≤ (2/3)ⁿ·M; the correction gcorr n is the global continuous function returned by one Urysohn step applied to rₙ, with |gcorr n| ≤ (2/3)ⁿ·(M/3); gbcf n packages it as an element of the Banach space. The geometric majorant gives absolute convergence (summable_norm_gbcf), hence summability (summable_gbcf) because the bounded-continuous-function space over ℝ is complete. The headline tietze_extension_via_tsum builds G = ∑' n, gbcf n directly: evaluation at a point is a continuous additive homomorphism, so the series evaluates pointwise to the limit of the partial sums f x − rₙ x → f x on s, giving G = f on s; summing the majorant, ‖G‖ ≤ ∑' (2/3)ⁿ·(M/3) = M, so the extension lands in the same sup-bound [−M, M] as the data. This answers the first recorded open question of urysohns-lemma-oq-01-oq-01 verbatim.",
+  "overview": {
+    "historicalContext": "The classical textbook derivation of the Tietze extension theorem from Urysohn's lemma is a uniformly convergent series: each term is supplied by Urysohn's lemma applied to the two extreme sublevel/superlevel sets of the current residual, and the factor 2/3 forces geometric convergence. The standard analysis course (e.g. Munkres) states the limit is uniform because the partial sums are dominated by a convergent geometric series and the ambient sup-norm space is complete. Mathlib's Mathlib.Topology.TietzeExtension formalizes this argument, but its public theorems (ContinuousMap.exists_restrict_eq and friends) deliver only the final extension; the convergent series itself is internal. The parent gallery entry urysohns-lemma-oq-01-oq-01 isolated the per-step engine and its quantitative geometric rate as standalone lemmas, but still delegated the assembly of the limit to Mathlib's machinery. This entry completes the program: it constructs the series by hand in BoundedContinuousFunction X ℝ — the genuine Banach space whose completeness powers the convergence — and proves the resulting sum is a sup-norm-preserving Tietze extension, citing only the abstract completeness/summability API and never the TietzeExtension theorems.",
+    "problemStatement": "Build the uniform limit of the Urysohn iteration explicitly. For a closed set s in a normal space X and a continuous f : C(s, ℝ) with |f| ≤ M, construct a sequence of bounded continuous corrections gₙ : BoundedContinuousFunction X ℝ with ‖gₙ‖ ≤ (2/3)ⁿ·(M/3), prove the correction series ∑ gₙ is absolutely convergent (hence summable by completeness), and show its sum G satisfies G = f on s and |G| ≤ M everywhere — all without routing the convergence through Mathlib's TietzeExtension machinery.",
+    "proofStrategy": "Res defines the residual sequence by structural recursion: Res 0 = f, and Res (n+1) = Res n − (Urysohn correction)|_s, where the correction is the choice term of the parent's urysohn_approx_step applied to Res n; the subtype carries the invariant |Res n| ≤ (2/3)ⁿ·M, proved from the step's (2/3)-contraction. gcorr n extracts the n-th correction as a C(X, ℝ); gcorr_bound reads off |gcorr n| ≤ (2/3)ⁿ·(M/3) from the step's |g| ≤ M/3 clause. gbcf n promotes gcorr n to BoundedContinuousFunction X ℝ via ofNormedAddCommGroup, and gbcf_norm_le transfers the pointwise bound to the sup-norm with BoundedContinuousFunction.norm_le. Comparison with the geometric series ∑ (2/3)ⁿ·(M/3) (summable_geo) gives Summable (‖gbcf ·‖) (summable_norm_gbcf), hence Summable gbcf (summable_gbcf) since the space is complete (Summable.of_norm). For the main theorem, G := ∑' n, gbcf n. The partial-sum identity psum — ∑_{i<n} gbcf i (↑x) = f x − Res n x on s — is a one-line induction using the defining recursion Res_succ_fst. Evaluation at ↑x is a 1-Lipschitz additive homomorphism (BoundedContinuousFunction.dist_coe_le_dist), so HasSum.map carries HasSum gbcf G to HasSum (gbcf · ↑x) (G ↑x); its partial sums therefore converge to G ↑x. They also equal f x − Res n x, which converges to f x because |Res n x| ≤ (2/3)ⁿ·M → 0 (squeeze_zero_norm against tendsto_pow_atTop_nhds_zero_of_lt_one). Uniqueness of limits gives G ↑x = f x. Finally norm_tsum_le_tsum_norm and Summable.tsum_le_tsum bound ‖G‖ ≤ ∑' (2/3)ⁿ·(M/3) = (1 − 2/3)⁻¹·(M/3) = M, and BoundedContinuousFunction.norm_le converts this to |G y| ≤ M everywhere.",
+    "keyInsights": [
+      "The construction lives in the right Banach space. The corrections are packaged as elements of BoundedContinuousFunction X ℝ, whose completeness (over the complete field ℝ) is exactly what turns the absolutely convergent majorant ∑ (2/3)ⁿ·(M/3) into an actual sum. Summable.of_norm — absolute convergence implies convergence in a complete space — is the single abstract fact that replaces Mathlib's TietzeExtension limit construction.",
+      "Evaluation is a continuous linear functional, so the series commutes with it. The map G ↦ G(↑x) is 1-Lipschitz (BoundedContinuousFunction.dist_coe_le_dist), hence a continuous additive homomorphism; HasSum.map then pushes the vector-valued HasSum gbcf G to the scalar HasSum (gbcf · ↑x) (G ↑x). This is what lets a statement about the abstract sum G be checked pointwise against the explicit partial sums.",
+      "The residual recursion IS the partial-sum telescoping. Because Res is defined by Res (n+1) = Res n − (correction)|_s, the identity ∑_{i<n} gbcf i (↑x) = f x − Res n x falls out of a trivial induction (Res_succ_fst is definitional, rfl). The whole convergence-to-f argument reduces to Res n → 0, which is immediate from the geometric invariant.",
+      "Sup-norm preservation comes for free from summing the majorant. The same geometric bound that proves summability also bounds the sum: ‖G‖ ≤ ∑' (2/3)ⁿ·(M/3) = (1/3·M)·(1−2/3)⁻¹ = M. So the explicit extension automatically respects the data's bound [−M, M] — the bounded Tietze extension — without any separate clamping or truncation step.",
+      "This closes the gap the parent left open. urysohns-lemma-oq-01-oq-01 named the engine but delegated the limit to Mathlib; here the limit is assembled from elementary completeness/summability, so the entire chain from Urysohn's lemma to the Tietze extension is now in-file and independent of Mathlib.Topology.TietzeExtension."
+    ]
+  },
+  "sections": [
+    {
+      "id": "residual-recursion",
+      "title": "The Residual Sequence and its Geometric Invariant",
+      "startLine": 44,
+      "endLine": 81,
+      "summary": "Res n is the running residual rₙ = f − (g₀+…+g_{n-1})|_s, defined by structural recursion (Res 0 = f, Res (n+1) = Res n − correction|_s), packaged in a subtype carrying the invariant |Res n| ≤ (2/3)ⁿ·M (proved from the parent's (2/3)-contraction). gcorr n extracts the n-th Urysohn correction as a C(X, ℝ). Res_zero and Res_succ_fst record the defining equations (both rfl).",
+      "mathContext": "$r_0=f,\\ r_{n+1}=r_n-g_n|_s,\\ |r_n|\\le (2/3)^n M$ on $s$."
+    },
+    {
+      "id": "correction-bcf",
+      "title": "Corrections as Bounded Continuous Functions",
+      "startLine": 83,
+      "endLine": 107,
+      "summary": "gcorr_bound reads off the global bound |gcorr n| ≤ (2/3)ⁿ·(M/3) from the one-step Urysohn lemma. gbcf n promotes the correction to an element of BoundedContinuousFunction X ℝ via ofNormedAddCommGroup, with gbcf_apply identifying its values, and gbcf_norm_le transfers the pointwise bound to the sup-norm ‖gbcf n‖ ≤ (2/3)ⁿ·(M/3) using BoundedContinuousFunction.norm_le.",
+      "mathContext": "$\\|g_n\\|_\\infty\\le (2/3)^n\\,(M/3)$, with $g_n\\in (X\\to_b\\mathbb{R})$."
+    },
+    {
+      "id": "summability",
+      "title": "Absolute Convergence in a Complete Space",
+      "startLine": 108,
+      "endLine": 121,
+      "summary": "summable_geo is the convergent geometric majorant ∑ (2/3)ⁿ·(M/3). summable_norm_gbcf compares against it (Summable.of_nonneg_of_le) to get summability of the norms, and summable_gbcf concludes Summable gbcf by Summable.of_norm — absolute convergence implies convergence because BoundedContinuousFunction X ℝ is complete. This is the abstract fact that replaces Mathlib's TietzeExtension limit.",
+      "mathContext": "$\\sum_n \\|g_n\\|<\\infty\\ \\Rightarrow\\ \\sum_n g_n\\ \\text{converges in the Banach space}$."
+    },
+    {
+      "id": "tietze-via-tsum",
+      "title": "The Tietze Extension as the Series Sum",
+      "startLine": 123,
+      "endLine": 197,
+      "summary": "tietze_extension_via_tsum builds G = ∑' n, gbcf n. The partial-sum identity ∑_{i<n} gbcf i (↑x) = f x − Res n x on s is a one-line induction on Res_succ_fst. Evaluation at ↑x is a 1-Lipschitz additive homomorphism, so HasSum.map gives HasSum (gbcf · ↑x) (G ↑x); the partial sums converge both to G ↑x and (since Res n → 0) to f x, so G = f on s by uniqueness of limits. norm_tsum_le_tsum_norm and Summable.tsum_le_tsum bound ‖G‖ ≤ ∑' (2/3)ⁿ·(M/3) = M, giving |G| ≤ M everywhere.",
+      "mathContext": "$G=\\sum_n g_n,\\ G|_s=f,\\ \\|G\\|_\\infty\\le M$, none of Mathlib's TietzeExtension used."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry constructs the Tietze extension explicitly as a convergent series G = ∑' n, gₙ in the Banach space BoundedContinuousFunction X ℝ, with each gₙ a single Urysohn correction to the running residual bounded by ‖gₙ‖ ≤ (2/3)ⁿ·(M/3). Absolute convergence of the geometric majorant gives summability in the complete space (Summable.of_norm); the partial sums telescope to f x − rₙ x on s and converge to f x because the residual decays like (2/3)ⁿ·M; and summing the majorant gives ‖G‖ ≤ M, so the extension preserves the data's sup-bound. The whole construction avoids Mathlib's TietzeExtension machinery entirely. 197 lines, 9 theorems/lemmas, 3 definitions, 0 axioms, 0 sorries; the main theorem depends only on propext / Classical.choice / Quot.sound.",
+    "implications": "This answers the first recorded open question of urysohns-lemma-oq-01-oq-01 verbatim: the limit is now assembled from elementary completeness and summability rather than delegated to Mathlib. Together with the parent (which isolated the engine and its rate) and the companion tietze-extension-theorem-oq-01 (Urysohn from Tietze), the chain from Urysohn's lemma to a sup-norm-preserving Tietze extension is fully in-file and independent of Mathlib.Topology.TietzeExtension. The construction is the natural setting for the remaining open question — tracking the partial-sum norms to recover the exact norm-preserving form — since ‖G‖ ≤ M already falls out of the majorant.",
+    "openQuestions": [
+      "Strengthen the sup-norm bound to the sharp norm-preserving equality ‖G‖ = ‖f‖ (not merely ‖G‖ ≤ M) by tracking the partial-sum norms in the series, recovering the standard norm-preserving Tietze form directly from the explicit construction.",
+      "Generalize the explicit-series construction from ℝ-valued to Banach-space-valued (or interval-constrained) data, where the same geometric majorant and completeness argument should apply with a vector-valued Urysohn step."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "urysohns-lemma-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. It isolated the one-step Urysohn approximation engine and the geometric iterate but assembled the final extension via Mathlib's TietzeExtension machinery. This entry answers its first recorded open question by building the uniform limit explicitly as a tsum of bounded continuous corrections, with no TietzeExtension machinery."
+    },
+    {
+      "targetId": "urysohns-lemma-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent entry deriving the Tietze extension theorem from Urysohn's lemma."
+    },
+    {
+      "targetId": "tietze-extension-theorem-oq-01",
+      "relationship": "related",
+      "description": "Companion entry running the equivalence the other way (Urysohn's lemma from the assembled Tietze theorem). Together with this entry's explicit forward construction, the two exhibit Urysohn's lemma and the Tietze extension theorem as equivalent functional expressions of normality."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/UrysohnsLemmaOQ01OQ01OQ01.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "urysohns-lemma",
+      "tietze-extension",
+      "bounded-continuous-function",
+      "banach-space",
+      "infinite-series",
+      "tsum",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 197,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "badge": "original",
+    "assumptions": "0 axioms, 0 sorries. The main theorem tietze_extension_via_tsum depends only on Mathlib's standard foundational axioms propext / Classical.choice / Quot.sound (no sorryAx, no Lean.ofReduceBool). Classical.choice enters through the per-step correction, which is the choice term of the parent's urysohn_approx_step existence statement. The construction uses only abstract completeness/summability API (Summable.of_norm, HasSum.map, norm_tsum_le_tsum_norm, Summable.tsum_le_tsum) and the parent's urysohn_approx_step; it does NOT use any theorem from Mathlib.Topology.TietzeExtension.",
+    "originalContributions": [
+      "tietze_extension_via_tsum: the Tietze extension built by hand as a convergent series G = ∑' n, gₙ in BoundedContinuousFunction X ℝ, proved to satisfy G = f on the closed set and |G| ≤ M everywhere, using none of Mathlib's TietzeExtension machinery — the explicit uniform limit that the parent entry delegated to Mathlib",
+      "Res: the residual sequence rₙ = f − (g₀+…+g_{n-1})|_s defined by structural recursion, carrying the geometric invariant |rₙ| ≤ (2/3)ⁿ·M in its subtype, with the defining recursion Res_succ_fst holding definitionally",
+      "gbcf and gbcf_norm_le: the n-th Urysohn correction packaged as a bounded continuous function with the sharp geometric sup-norm bound ‖gₙ‖ ≤ (2/3)ⁿ·(M/3), the term that makes the correction series absolutely convergent",
+      "summable_norm_gbcf / summable_gbcf: absolute convergence of the correction series via comparison with the geometric majorant, and summability in the complete space BoundedContinuousFunction X ℝ via Summable.of_norm — the abstract completeness fact that powers the construction",
+      "The pointwise-evaluation argument: evaluation at a point is realized as a 1-Lipschitz additive homomorphism, letting HasSum.map transfer the vector-valued HasSum to a scalar one so the abstract sum can be checked against the explicit telescoping partial sums f x − rₙ x → f x"
+    ],
+    "prerequisites": [
+      "The Banach space of bounded continuous functions BoundedContinuousFunction X ℝ and its completeness",
+      "Absolute convergence implies convergence in a complete space (Summable.of_norm) and norm/tsum monotonicity (norm_tsum_le_tsum_norm, Summable.tsum_le_tsum)",
+      "The parent's one-step Urysohn approximation lemma urysohn_approx_step (Proofs.UrysohnsLemmaOQ01OQ01)",
+      "Geometric series summability and value (summable_geometric_of_lt_one, tsum_geometric_of_lt_one)",
+      "HasSum.map for pushing a HasSum through a continuous additive homomorphism, and squeeze/Lipschitz reasoning for the limit"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "BoundedContinuousFunction.ofNormedAddCommGroup",
+        "description": "Packages a continuous function bounded in norm as an element of the bounded-continuous-function space; used to promote each Urysohn correction gcorr n to gbcf n.",
+        "module": "Mathlib.Topology.ContinuousMap.Bounded.Normed"
+      },
+      {
+        "theorem": "Summable.of_norm",
+        "description": "Absolute convergence implies convergence in a complete normed space; turns the geometric majorant bound into Summable gbcf. The abstract fact that replaces Mathlib's TietzeExtension limit construction.",
+        "module": "Mathlib.Analysis.Normed.Group.InfiniteSum"
+      },
+      {
+        "theorem": "HasSum.map",
+        "description": "Pushes a HasSum through a continuous additive homomorphism; applied to pointwise evaluation (a 1-Lipschitz hom) to evaluate the vector-valued series at a point.",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "BoundedContinuousFunction.dist_coe_le_dist",
+        "description": "Pointwise distance is bounded by sup-distance; gives the 1-Lipschitz continuity of evaluation used to build the evaluation homomorphism.",
+        "module": "Mathlib.Topology.ContinuousMap.Compact"
+      },
+      {
+        "theorem": "tsum_geometric_of_lt_one",
+        "description": "Closed form of the geometric series ∑' n, rⁿ = (1 − r)⁻¹; combined with tsum_mul_right gives ∑' (2/3)ⁿ·(M/3) = M for the sup-norm bound ‖G‖ ≤ M.",
+        "module": "Mathlib.Analysis.SpecificLimits.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "urysohns-lemma-oq-01-oq-01-oq-01-oq-01",
+      "question": "Strengthen the sup-norm bound to the sharp norm-preserving equality ‖G‖ = ‖f‖ by tracking the partial-sum norms in the explicit series, recovering the standard norm-preserving Tietze form directly from the construction.",
+      "significance": "medium"
+    },
+    {
+      "id": "urysohns-lemma-oq-01-oq-01-oq-01-oq-02",
+      "question": "Generalize the explicit-series construction from ℝ-valued data to Banach-space-valued or interval-constrained data, where the same geometric majorant and completeness argument should carry through with a vector-valued Urysohn step.",
+      "significance": "medium"
+    }
+  ],
+  "references": [
+    {
+      "title": "Tietze extension theorem",
+      "url": "https://en.wikipedia.org/wiki/Tietze_extension_theorem"
+    },
+    {
+      "title": "Urysohn's lemma",
+      "url": "https://en.wikipedia.org/wiki/Urysohn%27s_lemma"
+    },
+    {
+      "title": "Mathlib: BoundedContinuousFunction (completeness, ofNormedAddCommGroup)",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Topology/ContinuousMap/Bounded/Basic.html"
+    }
+  ],
+  "status": "verified",
+  "badge": "original",
+  "axiomCount": 0,
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first recorded open question** of `urysohns-lemma-oq-01-oq-01` verbatim: build the uniform limit of the Urysohn iteration **explicitly** in the Banach space `BoundedContinuousFunction X ℝ`, as a genuinely convergent series, using **none** of Mathlib's `TietzeExtension` machinery. The parent entry isolated the per-step engine but delegated the assembly of the limit to `exists_restrict_eq`; this entry removes that black box.

## What's proved

For a closed `s` in a normal space `X` and `f : C(s, ℝ)` with `|f| ≤ M`:

- **`Res n`** — the residual `rₙ = f − (g₀+…+g_{n-1})|_s` by structural recursion, carrying the invariant `|rₙ| ≤ (2/3)ⁿ·M`; the defining recursion `Res_succ_fst` holds by `rfl`.
- **`gbcf n` / `gbcf_norm_le`** — each Urysohn correction packaged as a bounded continuous function, with the geometric sup-norm bound `‖gₙ‖ ≤ (2/3)ⁿ·(M/3)`.
- **`summable_norm_gbcf` / `summable_gbcf`** — absolute convergence via the geometric majorant, hence summability by completeness (`Summable.of_norm`). This is the abstract fact that replaces Mathlib's `TietzeExtension` limit.
- **`tietze_extension_via_tsum`** — `G = ∑' n, gₙ` with `G = f` on `s` and `|G| ≤ M` everywhere. Evaluation at a point is a 1-Lipschitz additive homomorphism, so `HasSum.map` evaluates the series pointwise; the partial sums telescope to `f x − rₙ x → f x`, and summing the majorant gives `‖G‖ ≤ ∑' (2/3)ⁿ·(M/3) = M`.

## Verification

- **197 lines, 9 theorems/lemmas, 3 definitions, 0 axioms, 0 sorries.**
- Kernel-verified (`lake env lean`): `tietze_extension_via_tsum` depends only on `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`.
- Uses **no** theorem from `Mathlib.Topology.TietzeExtension`.
- Badge: `original`, status `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)