### PR TITLE
audit: register 3 orphaned AM-GM proofs in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -82,9 +82,12 @@ import Proofs.AmgmInequalityOQ02OQ01OQ05
 import Proofs.AmgmInequalityOQ02OQ02
 import Proofs.AmgmInequalityOQ02OQ03
 import Proofs.AmgmInequalityOQ02OQ03OQ03
+import Proofs.AmgmInequalityOQ02OQ03OQ03OQ01
+import Proofs.AmgmInequalityOQ02OQ03OQ03OQ03
 import Proofs.AmgmInequalityOQ03
 import Proofs.AmgmInequalityOQ03OQ02OQ01
 import Proofs.AmgmInequalityOQ03OQ02OQ01OQ01
+import Proofs.AmgmInequalityOQ03OQ02OQ01OQ02
 import Proofs.AmgmInequalityOQ03OQ02OQ04
 import Proofs.AmgmInequalityOQ03OQ03
 import Proofs.AmgmInequalityOQ03OQ04


### PR DESCRIPTION
## Gallery Integrity: Build-Graph Orphans

Three AM-GM gallery entries claim `status: verified` but were **never imported in `proofs/Proofs.lean`**. With no import there is no `.olean` in the canonical build, so CI never kernel-checks them — the public "verified" badge was not backed by a build-graph guarantee.

This PR adds the three missing `import` lines (alphabetically placed). No source changes.

## Kernel verification (before registering)

Each file was compiled fresh via `lake env lean` and audited with `#print axioms`. All theorems depend only on the **standard triple** `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, and **not** on the parent `AmgmInequalityOQ02`'s `maclaurin_step` / `newton_log_concavity` axioms:

| File | Badge | Theorems | Axioms |
|------|-------|----------|--------|
| `AmgmInequalityOQ02OQ03OQ03OQ01` | mathlib | 3 | standard triple ✓ |
| `AmgmInequalityOQ02OQ03OQ03OQ03` | mathlib | 3 | standard triple ✓ |
| `AmgmInequalityOQ03OQ02OQ01OQ02` | mathlib | 8 | standard triple ✓ |

The gallery claims are mathematically accurate; the only defect was the missing build-graph registration. No meta.json changes needed.

## Note: broader orphan pattern

A full sweep (`comm` of `proofs/Proofs/*.lean` basenames vs `import Proofs.*`) found **190** unregistered `.lean` files. Many are legitimately excluded (`*Incomplete*`, `*WIP*`, `Scratch*`, `*Aristotle` companions, axiomatized scaffolds), but others claim `verified`. A systematic pass to register verified-but-orphaned entries is worth a follow-up (mechanic).

---
Discovered during gallery integrity audit.