### PR TITLE
audit: AM-GM Newton + angle-trisection batch (5 kernel-verified; 2 theoremCount fixes)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/meta.json
@@ -53,7 +53,7 @@
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       }
     ],
-    "theoremCount": 12,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "overview": {
@@ -228,7 +228,7 @@
     "namespace": "PowerMeanCrossZeroEq",
     "lineCount": 243,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 8,
     "definitionCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean"

--- a/src/data/proofs/angle-trisection-oq-01-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01-oq-04/meta.json
@@ -57,7 +57,7 @@
     "lineCount": 172,
     "assumptions": "None — fully verified from Mathlib with 0 axioms (only propext / Classical.choice / Quot.sound) and 0 sorries. Crucially, no native_decide is used: small totients are computed with kernel `decide` and the general facts via structural totient lemmas, so this entry does NOT depend on Lean.ofReduceBool (unlike the parent). The full Gauss–Wantzel equivalence (constructible ⇔ n = 2^a·distinct Fermat primes) as a single biconditional, and the parent's 3 geometric axioms, remain out of scope.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 24,
+    "theoremCount": 22,
     "definitionCount": 1
   },
   "overview": {
@@ -148,7 +148,7 @@
     "namespace": "AngleTrisectionGaussWantzel",
     "lineCount": 172,
     "axiomCount": 0,
-    "theoremCount": 24,
+    "theoremCount": 22,
     "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ01OQ04.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit — AM-GM Newton & Angle-Trisection batch (5 entries)

Audited 5 never-audited `verified` gallery entries. Every theorem was kernel-rebuilt with `lake env lean` on Lean **v4.26.0** (EXIT 0) and checked with `#print axioms`: all depend only on `[propext, Classical.choice, Quot.sound]` — **no `sorryAx`, no `Lean.ofReduceBool`**.

### CLEAN — claims accurate
| slug | finding |
|------|---------|
| `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01-oq-01` | General Newton–Girard recurrence; badge `mathlib` correct (headline delegates to `psum_eq_mul_esymm_sub_sum`, contributions scoped to the antidiagonal reindexing). *Already recorded by a concurrent auditor.* |
| `amgm-inequality-oq-02-oq-03-oq-03-oq-01` | Maclaurin k=1 step. Imports a parent carrying `maclaurin_step` / `newton_log_concavity` **axioms** — verified via `#print axioms` that the de-axiomatized `maclaurin_step_one` does **not** leak them. De-axiomatization claim is genuine; badge `mathlib` correct (Tier B, Cauchy–Schwarz engine from Mathlib). |
| `amgm-inequality-oq-02-oq-03-oq-03-oq-03` | Power-mean `Mp ≤ Mq`. Honestly corrects the open question's stated direction and discloses the positive-exponent restriction (matching Mathlib's own TODO). |

### ISSUES-FIXED — minor metadata overstatement (substance verified; status/badge unchanged)
| slug | fix |
|------|-----|
| `amgm-inequality-oq-03-oq-02-oq-01-oq-02` | `theoremCount` 12 → **8** (actual named theorems). Math kernel-verified, badge `mathlib` honest. |
| `angle-trisection-oq-01-oq-04` | `theoremCount` 24 → **22**. Confirmed the "no `native_decide` / does NOT depend on `Lean.ofReduceBool`" claim is **honest** — only kernel `decide` is used. |

No status, badge, sorry, or axiom-count claims required correction. Tracker updated for the 4 newly-audited slugs.

---
Discovered during autonomous gallery integrity audit.
