### PR TITLE
research(euler-totient-oq-10): Menon's identity ∑_{gcd(k,n)=1} gcd(k−1,n)=φ(n)·d(n)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2685,6 +2685,7 @@ import Proofs.EulerTotientOQ04OQ01
 import Proofs.EulerTotientOQ05
 import Proofs.EulerTotientOQ06
 import Proofs.EulerTotientOQ07
+import Proofs.EulerTotientOQ10
 import Proofs.EulerTotientOQ09
 import Proofs.EulerTotientOQ09OQ01
 import Proofs.FactorRemainderNullstellensatzOQ01

--- a/proofs/Proofs/EulerTotientOQ10.lean
+++ b/proofs/Proofs/EulerTotientOQ10.lean
@@ -1,0 +1,153 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.ZMod.Units
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.Coset.Card
+import Mathlib.Tactic
+
+/-
+# Menon's Identity (OQ-10)
+
+## Open Question
+
+Beyond the basic theory of the Euler totient `φ`, a classical identity over the
+units of `ℤ/nℤ` is **Menon's identity** (P. Kesava Menon, 1965):
+
+> For every `n ≥ 1`,
+>   `∑_{1 ≤ k ≤ n, gcd(k,n)=1} gcd(k − 1, n) = φ(n) · d(n)`,
+> where `d(n)` is the number of divisors of `n`.
+
+We give the slick **counting proof**, fully uniform in `n` (no factorisation, no
+multiplicativity bookkeeping).  Indexing the sum by the units `a ∈ (ℤ/nℤ)ˣ`, the
+summand is `gcd((a − 1).val, n)`.
+
+## Proof (counting over the divisor lattice)
+
+1. **Divisor expansion.**  For any `v` and `n ≠ 0`,
+     `gcd(v, n) = ∑_{d ∣ n, d ∣ v} φ(d)`,
+   because `∑_{e ∣ g} φ(e) = g` (Gauss, `Nat.sum_totient`) applied to
+   `g = gcd(v, n)`, whose divisors are exactly the common divisors of `v` and `n`.
+
+2. **Swap the order of summation.**
+     `LHS = ∑_{d ∣ n} φ(d) · #{a ∈ (ℤ/nℤ)ˣ : d ∣ (a − 1).val}`.
+
+3. **Count each fibre.**  The reduction `unitsMap : (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ` is a
+   *surjective* group homomorphism (`ZMod.unitsMap_surjective`), and
+     `d ∣ (a − 1).val ⟺ a ∈ ker(unitsMap)`.
+   For a surjective homomorphism of finite groups `|G| = |H| · |ker|`
+   (Lagrange + first isomorphism), so
+     `φ(d) · #{a : d ∣ (a − 1).val} = φ(d) · |ker| = φ(n)`.
+
+4. **Collapse.**  Every divisor `d ∣ n` contributes exactly `φ(n)`, hence
+     `LHS = ∑_{d ∣ n} φ(n) = φ(n) · d(n)`.
+
+This is genuinely new relative to Mathlib, which has the totient and the
+`unitsMap` reduction but **not** Menon's identity.
+
+## Summary Statistics
+
+- Sorries: 0
+- Axioms: `propext`, `Classical.choice`, `Quot.sound` (standard)
+-/
+
+open Finset
+
+namespace EulerTotientOQ10
+
+/-- **Divisor expansion of the gcd.**  For `n ≠ 0`,
+`gcd v n = ∑_{d ∣ n} (if d ∣ v then φ d else 0)`. -/
+theorem gcd_eq_sum_totient (v : ℕ) {n : ℕ} (hn : n ≠ 0) :
+    Nat.gcd v n = ∑ d ∈ n.divisors, (if d ∣ v then Nat.totient d else 0) := by
+  have hgne : Nat.gcd v n ≠ 0 := (Nat.gcd_pos_iff.mpr (Or.inr (Nat.pos_of_ne_zero hn))).ne'
+  have hgcd : (Nat.gcd v n).divisors = n.divisors.filter (· ∣ v) := by
+    ext d
+    simp only [Nat.mem_divisors, Finset.mem_filter, Nat.dvd_gcd_iff]
+    constructor
+    · rintro ⟨⟨hv, hnn⟩, -⟩
+      exact ⟨⟨hnn, hn⟩, hv⟩
+    · rintro ⟨⟨hnn, -⟩, hv⟩
+      exact ⟨⟨hv, hnn⟩, hgne⟩
+  calc Nat.gcd v n
+      = (Nat.gcd v n).divisors.sum Nat.totient := (Nat.sum_totient _).symm
+    _ = ∑ d ∈ n.divisors.filter (· ∣ v), Nat.totient d := by rw [hgcd]
+    _ = ∑ d ∈ n.divisors, (if d ∣ v then Nat.totient d else 0) := by
+          rw [Finset.sum_filter]
+
+/-- **The reduction-to-`1` criterion.**  A unit `a` of `ℤ/nℤ` reduces to `1` in
+`(ℤ/dℤ)ˣ` exactly when `d` divides the natural representative of `a − 1`. -/
+theorem dvd_val_sub_one_iff {n : ℕ} [NeZero n] {d : ℕ} (hd : d ∣ n)
+    (a : (ZMod n)ˣ) :
+    d ∣ ((a : ZMod n) - 1).val ↔ ZMod.unitsMap hd a = 1 := by
+  have cast_eq : ∀ i : ZMod n, ((i.val : ℕ) : ZMod d) = ZMod.castHom hd (ZMod d) i := by
+    intro i
+    rw [ZMod.natCast_val, ZMod.castHom_apply]
+  rw [← ZMod.natCast_eq_zero_iff, cast_eq, map_sub, map_one, sub_eq_zero,
+      Units.ext_iff, ZMod.unitsMap_val, Units.val_one, ZMod.castHom_apply]
+
+/-- **Fibre count.**  For `d ∣ n`, the number of units of `ℤ/nℤ` congruent to `1`
+modulo `d`, weighted by `φ(d)`, is exactly `φ(n)`. -/
+theorem totient_mul_fiber_card {n : ℕ} [NeZero n] {d : ℕ} (hd : d ∣ n)
+    [DecidablePred (fun a : (ZMod n)ˣ => d ∣ ((a : ZMod n) - 1).val)] :
+    (Finset.univ.filter
+      (fun a : (ZMod n)ˣ => d ∣ ((a : ZMod n) - 1).val)).card * Nat.totient d
+      = Nat.totient n := by
+  have hdne : d ≠ 0 := fun h => (NeZero.ne n) (Nat.eq_zero_of_zero_dvd (h ▸ hd))
+  have : NeZero d := ⟨hdne⟩
+  classical
+  -- The fibre is the kernel of the (surjective) reduction homomorphism.
+  have hfilter : (Finset.univ.filter
+      (fun a : (ZMod n)ˣ => d ∣ ((a : ZMod n) - 1).val))
+      = Finset.univ.filter (fun a : (ZMod n)ˣ => a ∈ (ZMod.unitsMap hd).ker) := by
+    ext a
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, MonoidHom.mem_ker,
+      dvd_val_sub_one_iff hd a]
+  rw [hfilter]
+  have hcard : (Finset.univ.filter (fun a : (ZMod n)ˣ => a ∈ (ZMod.unitsMap hd).ker)).card
+      = Nat.card (ZMod.unitsMap hd).ker := by
+    rw [Nat.card_eq_fintype_card]
+    exact (Fintype.card_subtype _).symm
+  rw [hcard]
+  -- |G| = |H| * |ker| for the surjective reduction map.
+  have hsurj := ZMod.unitsMap_surjective (m := n) hd
+  have key := Subgroup.card_eq_card_quotient_mul_card_subgroup (ZMod.unitsMap hd).ker
+  rw [Nat.card_congr
+    (QuotientGroup.quotientKerEquivOfSurjective (ZMod.unitsMap hd) hsurj).toEquiv] at key
+  have hn' : Nat.card (ZMod n)ˣ = Nat.totient n := by
+    rw [Nat.card_eq_fintype_card, ZMod.card_units_eq_totient]
+  have hd' : Nat.card (ZMod d)ˣ = Nat.totient d := by
+    rw [Nat.card_eq_fintype_card, ZMod.card_units_eq_totient]
+  rw [hn', hd'] at key
+  -- key : φ n = φ d * Nat.card ker ; goal : Nat.card ker * φ d = φ n
+  rw [key, mul_comm]
+
+/-- **Menon's identity.**  Summing `gcd(k − 1, n)` over the units `k` of `ℤ/nℤ`
+yields `φ(n) · d(n)`. -/
+theorem menon_identity (n : ℕ) [NeZero n] :
+    ∑ a : (ZMod n)ˣ, Nat.gcd (((a : ZMod n) - 1).val) n
+      = Nat.totient n * n.divisors.card := by
+  have hn : n ≠ 0 := NeZero.ne n
+  classical
+  calc ∑ a : (ZMod n)ˣ, Nat.gcd (((a : ZMod n) - 1).val) n
+      = ∑ a : (ZMod n)ˣ, ∑ d ∈ n.divisors,
+          (if d ∣ ((a : ZMod n) - 1).val then Nat.totient d else 0) := by
+        apply Finset.sum_congr rfl
+        intro a _
+        exact gcd_eq_sum_totient _ hn
+    _ = ∑ d ∈ n.divisors, ∑ a : (ZMod n)ˣ,
+          (if d ∣ ((a : ZMod n) - 1).val then Nat.totient d else 0) :=
+        Finset.sum_comm
+    _ = ∑ d ∈ n.divisors, Nat.totient n := by
+        apply Finset.sum_congr rfl
+        intro d hd
+        have hdn : d ∣ n := (Nat.mem_divisors.mp hd).1
+        rw [← Finset.sum_filter, Finset.sum_const, smul_eq_mul]
+        exact totient_mul_fiber_card hdn
+    _ = Nat.totient n * n.divisors.card := by
+        rw [Finset.sum_const, smul_eq_mul, mul_comm]
+
+/-! ### Worked example (small case) -/
+
+-- `n = 6`: units are `{1,5}`; `gcd(0,6)+gcd(4,6) = 6+2 = 8 = φ(6)·d(6) = 2·4`.
+example : ∑ a : (ZMod 6)ˣ, Nat.gcd (((a : ZMod 6) - 1).val) 6
+    = Nat.totient 6 * (Nat.divisors 6).card := menon_identity 6
+
+end EulerTotientOQ10

--- a/src/data/proofs/euler-totient-oq-10/annotations.json
+++ b/src/data/proofs/euler-totient-oq-10/annotations.json
@@ -1,0 +1,120 @@
+[
+  {
+    "id": "totient-oq10-ann-header",
+    "proofId": "euler-totient-oq-10",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "Menon's Identity and the Counting Proof",
+    "content": "Menon's identity (P. Kesava Menon, 1965) states that summing gcd(k − 1, n) over the residues k coprime to n equals φ(n)·d(n), where φ is Euler's totient and d(n) is the number of divisors. This file formalizes the counting proof, which is uniform in n and avoids any factorization or multiplicativity argument. The sum is indexed by the unit group (ℤ/nℤ)ˣ, so the summand is gcd((a − 1).val, n). Imports Mathlib's totient, ZMod units, and quotient-group / coset-cardinality infrastructure.",
+    "mathContext": "$\\sum_{a \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times} \\gcd((a-1).\\mathrm{val},\\, n) = \\varphi(n)\\, d(n).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Menon's identity",
+      "Euler's totient",
+      "number of divisors",
+      "unit group of ℤ/nℤ"
+    ],
+    "prerequisites": [
+      "totient function",
+      "gcd",
+      "reduced residue system"
+    ]
+  },
+  {
+    "id": "totient-oq10-ann-gcd-expansion",
+    "proofId": "euler-totient-oq-10",
+    "range": {
+      "startLine": 56,
+      "endLine": 73
+    },
+    "type": "lemma",
+    "title": "Divisor Expansion of the gcd",
+    "content": "gcd_eq_sum_totient proves gcd(v, n) = ∑_{d∣n} (if d∣v then φ(d) else 0) for n ≠ 0. The key step is the set identity (gcd v n).divisors = n.divisors.filter (· ∣ v): a number d divides gcd(v, n) exactly when it divides both v and n. Applying Gauss's identity Nat.sum_totient, which says ∑_{e∣g} φ(e) = g, to g = gcd(v, n) then rewrites the gcd as a divisor-filtered totient sum. This is the device that converts each summand of Menon's sum into a double sum amenable to exchange.",
+    "mathContext": "$\\gcd(v,n) = \\sum_{d \\mid \\gcd(v,n)} \\varphi(d) = \\sum_{\\substack{d \\mid n \\\\ d \\mid v}} \\varphi(d).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Gauss's totient identity",
+      "divisors of a gcd",
+      "divisor sums"
+    ],
+    "prerequisites": [
+      "totient function",
+      "divisors",
+      "gcd"
+    ]
+  },
+  {
+    "id": "totient-oq10-ann-criterion",
+    "proofId": "euler-totient-oq-10",
+    "range": {
+      "startLine": 75,
+      "endLine": 85
+    },
+    "type": "lemma",
+    "title": "The Reduction-to-1 Criterion",
+    "content": "dvd_val_sub_one_iff shows d ∣ (a − 1).val ⟺ unitsMap_{d∣n}(a) = 1 for a unit a of ℤ/nℤ. The proof routes the divisibility statement through ZMod.natCast_eq_zero_iff (so d ∣ m ⟺ (m : ZMod d) = 0) and the reduction ring homomorphism castHom : ZMod n →+* ZMod d (using map_sub / map_one), matching it against the value of unitsMap a. This criterion is what lets the counted residue set be replaced by the kernel of a group homomorphism.",
+    "mathContext": "$d \\mid (a-1).\\mathrm{val} \\iff \\mathrm{unitsMap}_{d \\mid n}(a) = 1 \\iff a \\in \\ker(\\mathrm{unitsMap}).$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "reduction homomorphism",
+      "kernel of a homomorphism",
+      "ZMod cast"
+    ],
+    "prerequisites": [
+      "units of ℤ/nℤ",
+      "ring homomorphisms",
+      "divisibility in ZMod"
+    ]
+  },
+  {
+    "id": "totient-oq10-ann-fibre-count",
+    "proofId": "euler-totient-oq-10",
+    "range": {
+      "startLine": 86,
+      "endLine": 120
+    },
+    "type": "theorem",
+    "title": "The Fibre Count via Lagrange",
+    "content": "totient_mul_fiber_card proves #{a ∈ (ℤ/nℤ)ˣ : d ∣ (a − 1).val}·φ(d) = φ(n) for d ∣ n. Using the reduction-to-1 criterion, the counted set equals the kernel of unitsMap. Because unitsMap is surjective (ZMod.unitsMap_surjective), Lagrange's theorem Subgroup.card_eq_card_quotient_mul_card_subgroup together with the first isomorphism theorem QuotientGroup.quotientKerEquivOfSurjective gives |(ℤ/nℤ)ˣ| = |(ℤ/dℤ)ˣ|·|ker|, i.e. φ(n) = φ(d)·|ker|. So every divisor d of n contributes the same value φ(n) to Menon's sum.",
+    "mathContext": "$\\#\\{a : d \\mid (a-1).\\mathrm{val}\\} \\cdot \\varphi(d) = |\\ker| \\cdot \\varphi(d) = \\varphi(n).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Lagrange's theorem",
+      "first isomorphism theorem",
+      "surjective homomorphism fibres",
+      "kernel cardinality"
+    ],
+    "prerequisites": [
+      "finite group cardinality",
+      "kernels and quotients",
+      "Euler's totient as |(ℤ/nℤ)ˣ|"
+    ]
+  },
+  {
+    "id": "totient-oq10-ann-menon",
+    "proofId": "euler-totient-oq-10",
+    "range": {
+      "startLine": 122,
+      "endLine": 153
+    },
+    "type": "theorem",
+    "title": "Menon's Identity",
+    "content": "menon_identity assembles the result: ∑_{a ∈ (ℤ/nℤ)ˣ} gcd((a − 1).val, n) = φ(n)·d(n). Each summand is expanded by gcd_eq_sum_totient, the order of summation is swapped by Finset.sum_comm, the inner sum is collapsed to (fibre).card • φ(d) and evaluated to φ(n) by totient_mul_fiber_card, and the resulting constant sum over the d(n) divisors gives φ(n)·d(n). A worked n = 6 example instantiates the theorem (units {1, 5}: gcd(0,6) + gcd(4,6) = 6 + 2 = 8 = φ(6)·d(6) = 2·4).",
+    "mathContext": "$\\sum_{a \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times} \\gcd((a-1).\\mathrm{val}, n) = \\sum_{d \\mid n} \\varphi(n) = \\varphi(n)\\, d(n).$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Menon's identity",
+      "swap of summation",
+      "divisor counting function",
+      "Euler's totient"
+    ],
+    "prerequisites": [
+      "double sums over Finsets",
+      "Gauss's totient identity",
+      "Lagrange's theorem"
+    ]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-10/index.ts
+++ b/src/data/proofs/euler-totient-oq-10/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/EulerTotientOQ10.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const eulerTotientOQ10Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const eulerTotientOQ10Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const eulerTotientOQ10Data: ProofData = {
+  proof: eulerTotientOQ10Proof,
+  annotations: eulerTotientOQ10Annotations,
+}

--- a/src/data/proofs/euler-totient-oq-10/meta.json
+++ b/src/data/proofs/euler-totient-oq-10/meta.json
@@ -1,0 +1,158 @@
+{
+  "id": "euler-totient-oq-10",
+  "title": "Menon's Identity: $\\sum_{\\gcd(k,n)=1}\\gcd(k-1,n)=\\varphi(n)\\,d(n)$",
+  "slug": "euler-totient-oq-10",
+  "description": "Formalizes Menon's identity (P. Kesava Menon, 1965), a classical arithmetic identity living over the unit group of ℤ/nℤ: summing gcd(k−1, n) over the residues k coprime to n yields φ(n)·d(n), where φ is Euler's totient and d(n) is the number of divisors of n. The proof is the slick counting argument, fully uniform in n with no factorization or multiplicativity bookkeeping. Indexing the sum by the units a ∈ (ℤ/nℤ)ˣ (so the summand is gcd((a−1).val, n)), three steps close it: (1) Divisor expansion — gcd(v, n) = ∑_{d∣n, d∣v} φ(d), obtained by applying Gauss's identity ∑_{e∣g} φ(e) = g to g = gcd(v,n), whose divisors are exactly the common divisors of v and n. (2) Swap of summation — Menon's sum becomes ∑_{d∣n} φ(d)·#{a ∈ (ℤ/nℤ)ˣ : d ∣ (a−1).val}. (3) Fibre count — the reduction homomorphism unitsMap : (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ is surjective (ZMod.unitsMap_surjective), and d ∣ (a−1).val ⟺ a ∈ ker(unitsMap); since for a surjective homomorphism of finite groups |G| = |H|·|ker| (Lagrange + first isomorphism theorem), each divisor d contributes φ(d)·|ker| = φ(n). Collapsing, ∑_{d∣n} φ(n) = φ(n)·d(n). This is genuinely new relative to Mathlib, which has Euler's totient and the unitsMap reduction but not Menon's identity. Fully machine-checked: 0 sorries, 0 axioms (only the foundational propext/Classical.choice/Quot.sound), no native_decide.",
+  "meta": {
+    "author": "P. Kesava Menon (1965); the counting proof formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Menon%27s_identity",
+    "date": "1965",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ10.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "menons-identity",
+      "arithmetic-functions",
+      "group-theory",
+      "units-of-zmod",
+      "gcd",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (no native_decide). The proof rests on Gauss's divisor-sum identity for the totient (`Nat.sum_totient`), the surjectivity of the unit-reduction homomorphism (`ZMod.unitsMap_surjective`), and Lagrange's theorem in the form `Subgroup.card_eq_card_quotient_mul_card_subgroup` combined with the first isomorphism theorem `QuotientGroup.quotientKerEquivOfSurjective`. The only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.sum_totient",
+        "description": "Gauss's identity `∑_{d ∣ n} φ(d) = n`. Applied to `g = gcd(v, n)` it yields the divisor expansion `gcd(v, n) = ∑_{d ∣ n, d ∣ v} φ(d)`, the first step of the counting proof.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "ZMod.unitsMap_surjective",
+        "description": "For `d ∣ n`, the reduction homomorphism `unitsMap : (ZMod n)ˣ →* (ZMod d)ˣ` is surjective. Surjectivity makes every fibre of the map equinumerous to the kernel, which is what turns the per-divisor count into the constant `φ(n)`.",
+        "module": "Mathlib.Data.ZMod.Units"
+      },
+      {
+        "theorem": "Subgroup.card_eq_card_quotient_mul_card_subgroup",
+        "description": "Lagrange's theorem `Nat.card G = Nat.card (G ⧸ H) · Nat.card H`. Applied to `H = ker(unitsMap)` together with the first isomorphism theorem gives `φ(n) = φ(d)·|ker|`, the fibre count.",
+        "module": "Mathlib.GroupTheory.Coset.Card"
+      },
+      {
+        "theorem": "QuotientGroup.quotientKerEquivOfSurjective",
+        "description": "First isomorphism theorem `G ⧸ ker φ ≃* H` for a surjective homomorphism `φ`. Identifies the quotient `(ZMod n)ˣ ⧸ ker(unitsMap)` with `(ZMod d)ˣ`, so its cardinality is `φ(d)`.",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "`(a : ZMod b) = 0 ↔ b ∣ a`. Bridges the divisibility condition `d ∣ (a−1).val` to the algebraic condition `unitsMap a = 1` that identifies the counted set with the kernel.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "originalContributions": [
+      "`menon_identity`: the headline theorem `∑_{a ∈ (ZMod n)ˣ} gcd((a − 1).val, n) = φ(n)·d(n)` for every n ≥ 1 — Menon's identity, which Mathlib does not contain.",
+      "`gcd_eq_sum_totient`: the divisor expansion `gcd(v, n) = ∑_{d ∣ n} (if d ∣ v then φ(d) else 0)`, derived by recognizing the divisors of `gcd(v, n)` as exactly the common divisors of `v` and `n` and applying Gauss's `Nat.sum_totient`.",
+      "`dvd_val_sub_one_iff`: the reduction-to-1 criterion `d ∣ (a − 1).val ⟺ unitsMap_{d∣n}(a) = 1`, which identifies the counted residue set with the kernel of the reduction homomorphism via the `castHom` ring map.",
+      "`totient_mul_fiber_card`: the fibre-count lemma `#{a ∈ (ZMod n)ˣ : d ∣ (a − 1).val}·φ(d) = φ(n)`, obtained by rewriting the counted set as the kernel of the surjective `unitsMap` and invoking Lagrange's theorem and the first isomorphism theorem."
+    ],
+    "prerequisites": [
+      "Euler's totient function φ(n) = |(ℤ/nℤ)ˣ| and the divisor-counting function d(n)",
+      "Gauss's identity ∑_{d∣n} φ(d) = n",
+      "The unit group (ℤ/nℤ)ˣ and the reduction homomorphism (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ for d ∣ n",
+      "Lagrange's theorem and the first isomorphism theorem for finite groups"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "euler-totient",
+        "relationship": "Ancestor: the gallery family on Euler's totient and his generalization of Fermat's little theorem. Menon's identity is a classical refinement summing a gcd over the unit group, with value φ(n)·d(n)."
+      },
+      {
+        "id": "euler-totient-oq-07",
+        "relationship": "Sibling: where oq-07 studies when two totient values are coprime, this entry establishes Menon's identity over the units of a single modulus."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 153,
+    "path": "Proofs/EulerTotientOQ10.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0,
+  "sections": [
+    {
+      "id": "overview",
+      "title": "Module Overview, Statement, and Imports",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Imports Mathlib's totient, ZMod units, and quotient-group infrastructure. States Menon's identity and lays out the three-step counting proof: divisor expansion of the gcd, a swap of summation, and a fibre count over the surjective reduction homomorphism."
+    },
+    {
+      "id": "gcd-expansion",
+      "title": "Divisor Expansion of the gcd",
+      "startLine": 56,
+      "endLine": 73,
+      "summary": "Proves gcd(v, n) = ∑_{d∣n} (if d∣v then φ(d) else 0). The divisors of gcd(v, n) are exactly the common divisors of v and n, so Gauss's identity ∑_{e∣g} φ(e) = g rewrites the gcd as a divisor-filtered totient sum."
+    },
+    {
+      "id": "fibre-count",
+      "title": "The Reduction-to-1 Criterion and the Fibre Count",
+      "startLine": 75,
+      "endLine": 120,
+      "summary": "Shows d ∣ (a − 1).val ⟺ unitsMap(a) = 1 (via the castHom ring map), identifying the counted residues with the kernel of the reduction homomorphism. Surjectivity of unitsMap plus Lagrange and the first isomorphism theorem give φ(d)·#{fibre} = φ(n)."
+    },
+    {
+      "id": "menon",
+      "title": "Menon's Identity and a Worked Example",
+      "startLine": 122,
+      "endLine": 153,
+      "summary": "Assembles the identity: expand each summand, swap the order of summation, apply the fibre count so each divisor contributes φ(n), and collapse the constant sum to φ(n)·d(n). A worked n = 6 example instantiates the theorem."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Menon's identity was published by the Indian mathematician P. Kesava Menon in 1965 (\"On the sum ∑(a−1, n) with (a, n) = 1\", Journal of the Indian Mathematical Society). It is a touchstone result in the theory of arithmetic functions over residue systems: it links the totient φ, the divisor-counting function d, and the structure of the unit group (ℤ/nℤ)ˣ in a single clean identity, and has since spawned a large literature of generalizations (to Dirichlet characters, to several variables, and to other number-theoretic gcd sums).",
+    "keyInsights": [
+      "Indexing Menon's sum by the units of ℤ/nℤ turns it into a sum of gcd((a−1).val, n) over a finite group, where the algebraic structure of the unit group can be brought to bear.",
+      "Gauss's identity ∑_{d∣m} φ(d) = m, applied to m = gcd(v, n), expands each gcd into a divisor sum and lets the two summations be exchanged.",
+      "The residues a with d ∣ (a − 1).val are precisely the kernel of the reduction homomorphism (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ; because that homomorphism is surjective, every fibre has the same size, so each divisor d contributes exactly φ(n) regardless of d.",
+      "No factorization or multiplicativity argument is needed: the counting proof is uniform in n and rests only on Gauss's identity and Lagrange's theorem."
+    ],
+    "prerequisites": [
+      "Euler's totient φ(n) = |(ℤ/nℤ)ˣ| and the number-of-divisors function d(n)",
+      "Gauss's divisor-sum identity ∑_{d∣n} φ(d) = n",
+      "The unit group (ℤ/nℤ)ˣ and the reduction map to (ℤ/dℤ)ˣ for d ∣ n",
+      "Lagrange's theorem and the first isomorphism theorem for finite groups"
+    ],
+    "problemStatement": "Prove Menon's identity: for every n ≥ 1, the sum of gcd(k − 1, n) over the residues k coprime to n equals φ(n)·d(n), where φ is Euler's totient and d(n) counts the divisors of n. Formally, ∑_{a ∈ (ℤ/nℤ)ˣ} gcd((a − 1).val, n) = φ(n)·d(n).",
+    "proofStrategy": "Work over the unit group (ℤ/nℤ)ˣ. First expand each gcd via Gauss's identity into ∑_{d∣n, d∣(a−1).val} φ(d). Swap the order of summation to collect, for each divisor d, the factor φ(d) times the number of units a with d ∣ (a − 1).val. Identify those units with the kernel of the surjective reduction homomorphism unitsMap : (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ; Lagrange's theorem and the first isomorphism theorem give φ(d)·|ker| = φ(n), so each divisor contributes φ(n). Summing over the d(n) divisors yields φ(n)·d(n).",
+    "text": "This entry formalizes Menon's identity by the counting proof. The Lean development is organized into four theorems: `gcd_eq_sum_totient` performs the divisor expansion of the gcd; `dvd_val_sub_one_iff` is the bridge identifying the divisibility condition with membership in the kernel of the reduction homomorphism; `totient_mul_fiber_card` is the group-theoretic fibre count delivering φ(n) per divisor; and `menon_identity` assembles these into the headline result. The argument avoids any appeal to multiplicativity of arithmetic functions, making it uniform in n, and is fully kernel-checked with no sorries and only the foundational axioms."
+  },
+  "conclusion": {
+    "implications": "Menon's identity is a clean closed form for a gcd sum over a reduced residue system, and the counting proof formalized here exposes exactly why the answer φ(n)·d(n) is independent of how n factors: each divisor of n contributes the constant φ(n) because the reduction map (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ is surjective with equinumerous fibres. The reusable pieces — the divisor expansion of the gcd and the surjective-fibre count over unitsMap — are the natural entry points for the many known generalizations of Menon's identity.",
+    "openQuestions": [
+      "Does the same fibre-counting template prove Menon's identity weighted by a Dirichlet character χ mod n, namely ∑_{gcd(k,n)=1} χ(k)·gcd(k−1, n) = φ(n)·d(n/cond χ) (the Sita Ramaiah / Nageswara Rao generalization)?",
+      "Can the two-variable form ∑_{gcd(k,n)=1} gcd(k − s, n) be evaluated by the same swap-and-count, and how does the answer depend on gcd(s, n)?"
+    ],
+    "summary": "A fully verified Lean 4 formalization of Menon's identity ∑_{gcd(k,n)=1} gcd(k − 1, n) = φ(n)·d(n) via the counting proof: divisor expansion of the gcd, a swap of summation, and a Lagrange-theorem fibre count over the surjective reduction homomorphism of unit groups. Mathlib does not contain Menon's identity. 4 theorems, 0 definitions, 0 sorries, 0 axioms beyond the foundational triple, no native_decide."
+  },
+  "crossReferences": [
+    {
+      "targetId": "euler-totient",
+      "relationship": "ancestor",
+      "description": "The gallery family on Euler's totient function. Menon's identity is a classical gcd sum over the unit group with value φ(n)·d(n), refining the basic theory of φ."
+    },
+    {
+      "targetId": "euler-totient-oq-07",
+      "relationship": "sibling",
+      "description": "oq-07 characterizes when two totient values φ(m), φ(n) are coprime; this entry establishes Menon's identity over the units of a single modulus n. Both sit under the euler-totient root."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Formalizes **Menon's identity** (P. Kesava Menon, 1965) — a classical arithmetic identity over the unit group of ℤ/nℤ that **Mathlib does not contain**:

> For every `n ≥ 1`,  `∑_{1 ≤ k ≤ n, gcd(k,n)=1} gcd(k − 1, n) = φ(n) · d(n)`,

where `φ` is Euler's totient and `d(n)` is the number of divisors of `n`. The sum is indexed by the units `a ∈ (ℤ/nℤ)ˣ`, so the summand is `gcd((a − 1).val, n)`.

## Proof (counting over the divisor lattice)

A single uniform argument, no factorization or multiplicativity bookkeeping:

1. **Divisor expansion** — `gcd(v, n) = ∑_{d∣n, d∣v} φ(d)`, from Gauss's `Nat.sum_totient` applied to `g = gcd(v, n)`, whose divisors are exactly the common divisors of `v` and `n`.
2. **Swap of summation** — `LHS = ∑_{d∣n} φ(d) · #{a ∈ (ℤ/nℤ)ˣ : d ∣ (a−1).val}`.
3. **Fibre count** — the reduction `unitsMap : (ℤ/nℤ)ˣ → (ℤ/dℤ)ˣ` is surjective (`ZMod.unitsMap_surjective`), and `d ∣ (a−1).val ⟺ a ∈ ker(unitsMap)`. For a surjective hom of finite groups `|G| = |H|·|ker|` (Lagrange + first isomorphism theorem), so each divisor contributes `φ(d)·|ker| = φ(n)`.
4. **Collapse** — `∑_{d∣n} φ(n) = φ(n)·d(n)`.

## Theorems

| Name | Statement |
|------|-----------|
| `gcd_eq_sum_totient` | `gcd(v,n) = ∑_{d∣n} (if d∣v then φ d else 0)` |
| `dvd_val_sub_one_iff` | `d ∣ (a−1).val ⟺ unitsMap a = 1` |
| `totient_mul_fiber_card` | `#{a : d ∣ (a−1).val} · φ(d) = φ(n)` |
| `menon_identity` | `∑_{a ∈ (ℤ/nℤ)ˣ} gcd((a−1).val, n) = φ(n)·d(n)` |

## Verification

- **4 theorems, 0 definitions, 0 sorries, 0 axioms** beyond the foundational `propext` / `Classical.choice` / `Quot.sound`; **no `native_decide`**.
- Kernel-verified with `lake env lean` (Mathlib 4.26.0); `#print axioms menon_identity` → `[propext, Classical.choice, Quot.sound]`.

## Slug note

The pool note for Menon's identity was attached to `euler-totient-oq-07`, but that slug was already shipped under a different interpretation (coprimality of two totients), and `oq-08` is contested by an in-flight PR (#27120). This lands as the next free sibling slug **`euler-totient-oq-10`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)