### PR TITLE
research(dirichlet-approximation-oq-01-oq-01): optimality of the Hurwitz constant √5

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -894,6 +894,7 @@ import Proofs.DilworthTheoremOQ01
 import Proofs.DiniTheorem
 import Proofs.DirichletApproximation
 import Proofs.DirichletApproximationOQ01
+import Proofs.DirichletApproximationOQ01OQ01
 import Proofs.DirichletApproximationOQ02
 import Proofs.DirichletApproximationOQ03
 import Proofs.DirichletApproximationOQ04

--- a/proofs/Proofs/DirichletApproximationOQ01OQ01.lean
+++ b/proofs/Proofs/DirichletApproximationOQ01OQ01.lean
@@ -1,0 +1,239 @@
+/-
+# Dirichlet Approximation — OQ-01-OQ-01: Optimality of the Hurwitz Constant √5
+
+**Open Question (sharpening the approximation constant).** The parent entry
+`DirichletApproximationOQ01` upgrades Dirichlet's one-shot bound to the
+*infinitude* statement: every irrational `α` has infinitely many rationals
+`p/q` in lowest terms with `|α − p/q| < 1/q²`. Hurwitz's theorem sharpens the
+constant from `1` to `1/√5`:
+
+> every irrational `α` has infinitely many `p/q` with `|α − p/q| < 1/(√5·q²)`,
+> and the constant `√5` is **best possible** — it cannot be replaced by any
+> larger constant.
+
+This file formalizes the **optimality half** (the sharpness direction), which
+is the genuinely new content: it is *not* in Mathlib (Mathlib has Dirichlet's
+theorem with constant `1`, plus Legendre's theorem and continued fractions,
+but no Hurwitz bound and no optimality statement). The *existence* half of
+Hurwitz (the `1/√5` bound itself, via three consecutive continued-fraction
+convergents) is left as future work and is noted in the gallery entry.
+
+## The result
+
+For the golden ratio `φ = (1+√5)/2` and any constant `c > √5`, only **finitely
+many** rationals `p/q` satisfy `|φ − p/q| < 1/(c·q²)`. Consequently no
+Hurwitz-type theorem can hold with a constant exceeding `√5`: the golden ratio
+is the extremal irrational that pins the constant down.
+
+## Method (elementary, axiom-free)
+
+Write `A = p − qφ`, `B = p − qψ` where `ψ = (1−√5)/2` is the conjugate. Since
+`φ + ψ = 1` and `φ·ψ = −1` (both in Mathlib), the product
+`A·B = p² − pq − q² =: N` is an **integer**, and it is nonzero because `φ` is
+irrational (a zero factor would make `φ = p/q` rational). Hence `|A·B| ≥ 1`.
+Because `B = A + q√5`, the triangle inequality gives `|B| ≤ |A| + q√5`, so
+
+  `1 ≤ |A|·|B| ≤ |A|² + |A|·q√5`.
+
+Feeding in `|A| = q·|φ − p/q| < 1/(c·q)` and clearing denominators yields
+`(c² − c√5)·q² < 1`. As `c > √5` makes `c² − c√5 > 0`, the denominators `q`
+are bounded, so — together with the value bound `|φ − p/q| < 1` — the
+approximating fractions lie in a fixed bounded box of bounded height, a finite
+set.
+
+## References
+
+* A. Hurwitz, *Über die angenäherte Darstellung der Irrationalzahlen durch
+  rationale Brüche*, Math. Ann. 39 (1891).
+* G.H. Hardy & E.M. Wright, *An Introduction to the Theory of Numbers*, §11.8.
+* Mathlib: `Mathlib/NumberTheory/Real/GoldenRatio.lean`,
+  `Mathlib/NumberTheory/DiophantineApproximation/Basic.lean`.
+-/
+import Mathlib
+
+namespace DirichletApproximationOQ01OQ01
+
+open Set Real
+open scoped goldenRatio
+
+/-- **Bounded-height finiteness** (self-contained re-derivation of the
+infrastructure lemma from the parent entry). The rationals lying in a bounded
+real interval `[a, b]` whose denominator is at most `N` form a finite set: the
+map `q ↦ (q.num, q.den)` embeds them into the finite integer box
+`[-M, M] × [1, N]`, where `M` bounds the numerators via
+`|q.num| = |q|·q.den ≤ max |a| |b| · N`. -/
+theorem finite_bounded_den (a b : ℝ) (N : ℕ) :
+    {q : ℚ | a ≤ (q : ℝ) ∧ (q : ℝ) ≤ b ∧ q.den ≤ N}.Finite := by
+  obtain ⟨M, hM⟩ := exists_nat_ge (max |a| |b| * N)
+  apply Set.Finite.of_finite_image (f := fun q : ℚ => (q.num, q.den))
+  · apply Set.Finite.subset
+      ((Finset.Icc (-(M : ℤ)) (M : ℤ) ×ˢ Finset.Icc 1 N).finite_toSet)
+    rintro p ⟨q, ⟨ha, hb, hden⟩, rfl⟩
+    have hdpos : (0 : ℝ) < (q.den : ℝ) := by exact_mod_cast q.pos
+    have hnum : (q.num : ℝ) = (q : ℝ) * (q.den : ℝ) := by
+      rw [Rat.cast_def]; field_simp
+    have hqle : (q : ℝ) ≤ max |a| |b| :=
+      le_trans hb (le_trans (le_abs_self b) (le_max_right _ _))
+    have hqge : -max |a| |b| ≤ (q : ℝ) :=
+      le_trans (le_trans (neg_le_neg (le_max_left _ _)) (neg_abs_le a)) ha
+    have habsq : |(q : ℝ)| ≤ max |a| |b| := abs_le.mpr ⟨hqge, hqle⟩
+    have hdenR : (q.den : ℝ) ≤ (N : ℝ) := by exact_mod_cast hden
+    have habsnum : |(q.num : ℝ)| ≤ (M : ℝ) := by
+      rw [hnum, abs_mul, abs_of_pos hdpos]
+      calc |(q : ℝ)| * (q.den : ℝ)
+          ≤ max |a| |b| * (N : ℝ) := by gcongr
+        _ ≤ (M : ℝ) := hM
+    have hb1 : -(M : ℤ) ≤ q.num := by exact_mod_cast (abs_le.mp habsnum).1
+    have hb2 : q.num ≤ (M : ℤ) := by exact_mod_cast (abs_le.mp habsnum).2
+    simp only [Finset.coe_product, Finset.coe_Icc, Set.mem_prod, Set.mem_Icc]
+    exact ⟨⟨hb1, hb2⟩, q.pos, hden⟩
+  · intro x _ y _ hxy
+    simp only [Prod.mk.injEq] at hxy
+    rw [← Rat.num_div_den x, ← Rat.num_div_den y, hxy.1, hxy.2]
+
+set_option maxHeartbeats 1000000 in
+/-- **Optimality of the Hurwitz constant √5.** For any `c > √5`, only finitely
+many rationals approximate the golden ratio `φ` to within `1/(c·q²)`. -/
+theorem finite_approx_gt_sqrt5 {c : ℝ} (hc : Real.sqrt 5 < c) :
+    {r : ℚ | |Real.goldenRatio - (r : ℝ)| < 1 / (c * (r.den : ℝ) ^ 2)}.Finite := by
+  have hs_pos : (0 : ℝ) < Real.sqrt 5 := Real.sqrt_pos.mpr (by norm_num)
+  have hs_gt1 : (1 : ℝ) < Real.sqrt 5 := by
+    nlinarith [Real.sq_sqrt (show (0:ℝ) ≤ 5 by norm_num), Real.sqrt_nonneg 5]
+  have hc0 : (0 : ℝ) < c := lt_trans hs_pos hc
+  have hc1 : (1 : ℝ) < c := lt_trans hs_gt1 hc
+  have he : (0 : ℝ) < c ^ 2 - c * Real.sqrt 5 := by
+    nlinarith [mul_pos hc0 (sub_pos.mpr hc)]
+  obtain ⟨M, hM⟩ := exists_nat_ge (1 / (c ^ 2 - c * Real.sqrt 5))
+  apply Set.Finite.subset
+    (finite_bounded_den (Real.goldenRatio - 1) (Real.goldenRatio + 1) M)
+  intro r hr
+  simp only [Set.mem_setOf_eq] at hr ⊢
+  have hQpos : (0 : ℝ) < (r.den : ℝ) := by exact_mod_cast r.pos
+  have hQ1 : (1 : ℝ) ≤ (r.den : ℝ) := by exact_mod_cast r.pos
+  have hQne : (r.den : ℝ) ≠ 0 := hQpos.ne'
+  -- The integer norm  N = p² − pq − q²  factors as  (p − qφ)(p − qψ).
+  set N : ℤ := r.num ^ 2 - r.num * (r.den : ℤ) - (r.den : ℤ) ^ 2 with hNdef
+  have hid : ((r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio)
+      * ((r.num : ℝ) - (r.den : ℝ) * Real.goldenConj) = (N : ℝ) := by
+    have e1 : Real.goldenRatio + Real.goldenConj = 1 := Real.goldenRatio_add_goldenConj
+    have e2 : Real.goldenRatio * Real.goldenConj = -1 := Real.goldenRatio_mul_goldenConj
+    have expand : ((r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio)
+          * ((r.num : ℝ) - (r.den : ℝ) * Real.goldenConj)
+        = (r.num : ℝ) ^ 2
+            - (r.num : ℝ) * (r.den : ℝ) * (Real.goldenRatio + Real.goldenConj)
+            + (r.den : ℝ) ^ 2 * (Real.goldenRatio * Real.goldenConj) := by ring
+    rw [expand, e1, e2, hNdef]; push_cast; ring
+  -- N ≠ 0, otherwise φ (or ψ) would be rational.
+  have hNne : (N : ℝ) ≠ 0 := by
+    intro h0
+    have hzero : ((r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio)
+        * ((r.num : ℝ) - (r.den : ℝ) * Real.goldenConj) = 0 := by rw [hid, h0]
+    rcases mul_eq_zero.mp hzero with hA | hB
+    · refine Real.goldenRatio_irrational ⟨r, ?_⟩
+      have hnum : (r.num : ℝ) = (r.den : ℝ) * Real.goldenRatio := by linear_combination hA
+      rw [Rat.cast_def, div_eq_iff hQne, hnum]; ring
+    · refine Real.goldenConj_irrational ⟨r, ?_⟩
+      have hnum : (r.num : ℝ) = (r.den : ℝ) * Real.goldenConj := by linear_combination hB
+      rw [Rat.cast_def, div_eq_iff hQne, hnum]; ring
+  -- |A|, |B| and their basic estimates.
+  set a : ℝ := |(r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio| with ha_def
+  set b : ℝ := |(r.num : ℝ) - (r.den : ℝ) * Real.goldenConj| with hb_def
+  have ha0 : 0 ≤ a := abs_nonneg _
+  -- 1 ≤ a·b, since a·b = |N| ≥ 1.
+  have hab : 1 ≤ a * b := by
+    have hNne' : N ≠ 0 := fun h => hNne (by rw [h]; simp)
+    have hN1 : (1 : ℝ) ≤ |(N : ℝ)| := by
+      calc (1 : ℝ) ≤ ((|N| : ℤ) : ℝ) := by exact_mod_cast Int.one_le_abs hNne'
+        _ = |(N : ℝ)| := by rw [Int.cast_abs]
+    rw [ha_def, hb_def, ← abs_mul, hid]; exact hN1
+  -- b ≤ a + q√5, from  B = A + q√5  and the triangle inequality.
+  have hBeq : (r.num : ℝ) - (r.den : ℝ) * Real.goldenConj
+      = ((r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio) + (r.den : ℝ) * Real.sqrt 5 := by
+    linear_combination (r.den : ℝ) * Real.goldenRatio_sub_goldenConj
+  have hb_le : b ≤ a + (r.den : ℝ) * Real.sqrt 5 := by
+    have h3 : |(r.den : ℝ) * Real.sqrt 5| = (r.den : ℝ) * Real.sqrt 5 :=
+      abs_of_nonneg (by positivity)
+    rw [hb_def, hBeq, ha_def]
+    calc |((r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio) + (r.den : ℝ) * Real.sqrt 5|
+        ≤ |(r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio| + |(r.den : ℝ) * Real.sqrt 5| :=
+          abs_add_le _ _
+      _ = |(r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio| + (r.den : ℝ) * Real.sqrt 5 := by
+          rw [h3]
+  -- a < 1/(c·q).
+  have ha : a < 1 / (c * (r.den : ℝ)) := by
+    have haeq : a = (r.den : ℝ) * |Real.goldenRatio - (r : ℝ)| := by
+      rw [ha_def,
+        show (r.num : ℝ) - (r.den : ℝ) * Real.goldenRatio
+            = -((r.den : ℝ) * (Real.goldenRatio - (r : ℝ))) from by
+          rw [Rat.cast_def]; field_simp; ring,
+        abs_neg, abs_mul, abs_of_pos hQpos]
+    rw [haeq]
+    calc (r.den : ℝ) * |Real.goldenRatio - (r : ℝ)|
+        < (r.den : ℝ) * (1 / (c * (r.den : ℝ) ^ 2)) := by
+          exact mul_lt_mul_of_pos_left hr hQpos
+      _ = 1 / (c * (r.den : ℝ)) := by
+          rw [mul_one_div,
+            div_eq_div_iff (mul_pos hc0 (pow_pos hQpos 2)).ne' (mul_pos hc0 hQpos).ne']; ring
+  have hucq : a * (c * (r.den : ℝ)) < 1 :=
+    (lt_div_iff₀ (mul_pos hc0 hQpos)).mp ha
+  -- 1 ≤ a² + a·q√5.
+  have hstep : a * b ≤ a * (a + (r.den : ℝ) * Real.sqrt 5) :=
+    mul_le_mul_of_nonneg_left hb_le ha0
+  have hI : 1 ≤ a ^ 2 + a * (r.den : ℝ) * Real.sqrt 5 := by nlinarith [hab, hstep]
+  -- The crucial denominator bound: (c² − c√5)·q² < 1.
+  have hw0 : 0 ≤ a * (c * (r.den : ℝ)) := mul_nonneg ha0 (mul_nonneg hc0.le hQpos.le)
+  have hK : 0 < c * Real.sqrt 5 * (r.den : ℝ) ^ 2 :=
+    mul_pos (mul_pos hc0 hs_pos) (pow_pos hQpos 2)
+  -- Multiply  1 ≤ a² + a·q√5  by (c·q)²  to obtain  (c·q)² ≤ (a·c·q)² + (a·c·q)·K.
+  have E : (c * (r.den : ℝ)) ^ 2
+      ≤ (a * (c * (r.den : ℝ))) ^ 2
+        + (a * (c * (r.den : ℝ))) * (c * Real.sqrt 5 * (r.den : ℝ) ^ 2) := by
+    calc (c * (r.den : ℝ)) ^ 2
+        = (c * (r.den : ℝ)) ^ 2 * 1 := by ring
+      _ ≤ (c * (r.den : ℝ)) ^ 2 * (a ^ 2 + a * (r.den : ℝ) * Real.sqrt 5) :=
+          mul_le_mul_of_nonneg_left hI (sq_nonneg _)
+      _ = (a * (c * (r.den : ℝ))) ^ 2
+            + (a * (c * (r.den : ℝ))) * (c * Real.sqrt 5 * (r.den : ℝ) ^ 2) := by ring
+  have hw2 : (a * (c * (r.den : ℝ))) ^ 2 < 1 := by nlinarith [hw0, hucq]
+  have hw3 : (a * (c * (r.den : ℝ))) * (c * Real.sqrt 5 * (r.den : ℝ) ^ 2)
+      < c * Real.sqrt 5 * (r.den : ℝ) ^ 2 := by
+    have h := mul_lt_mul_of_pos_right hucq hK
+    rwa [one_mul] at h
+  have hbound : (c ^ 2 - c * Real.sqrt 5) * (r.den : ℝ) ^ 2 < 1 := by
+    nlinarith [E, hw2, hw3]
+  -- Hence q ≤ M, a bound depending only on c.
+  have hden_le : r.den ≤ M := by
+    have hq2 : (r.den : ℝ) ^ 2 < 1 / (c ^ 2 - c * Real.sqrt 5) := by
+      rw [lt_div_iff₀ he]; nlinarith [hbound]
+    have hqle : (r.den : ℝ) ≤ (r.den : ℝ) ^ 2 := by nlinarith [hQ1]
+    have hlt : (r.den : ℝ) < (M : ℝ) :=
+      lt_of_le_of_lt hqle (lt_of_lt_of_le hq2 hM)
+    have : r.den < M := by exact_mod_cast hlt
+    exact le_of_lt this
+  -- Value bound: |φ − r| < 1, so r lies in [φ−1, φ+1].
+  have hval : |Real.goldenRatio - (r : ℝ)| < 1 := by
+    have hb1 : 1 / (c * (r.den : ℝ) ^ 2) ≤ 1 := by
+      rw [div_le_one (by positivity)]
+      nlinarith [hc1, hQ1]
+    exact lt_of_lt_of_le hr hb1
+  rw [abs_lt] at hval
+  exact ⟨by linarith [hval.2], by linarith [hval.1], hden_le⟩
+
+/-- **The √5 set is not infinite.** Restating optimality: for `c > √5` there are
+*not* infinitely many `1/(c·q²)`-approximations to the golden ratio. -/
+theorem not_infinite_approx_gt_sqrt5 {c : ℝ} (hc : Real.sqrt 5 < c) :
+    ¬ {r : ℚ | |Real.goldenRatio - (r : ℝ)| < 1 / (c * (r.den : ℝ) ^ 2)}.Infinite :=
+  fun h => h (finite_approx_gt_sqrt5 hc)
+
+/-- **Optimality of the Hurwitz constant.** No Hurwitz-type theorem holds with a
+constant exceeding `√5`: for any `c > √5` it is false that *every* irrational
+has infinitely many approximations within `1/(c·q²)` — the golden ratio is a
+counterexample. This is the sharpness statement that complements Hurwitz's
+existence theorem. -/
+theorem hurwitz_constant_optimal {c : ℝ} (hc : Real.sqrt 5 < c) :
+    ¬ ∀ ξ : ℝ, Irrational ξ →
+        {r : ℚ | |ξ - (r : ℝ)| < 1 / (c * (r.den : ℝ) ^ 2)}.Infinite := by
+  intro H
+  exact not_infinite_approx_gt_sqrt5 hc (H Real.goldenRatio Real.goldenRatio_irrational)
+
+end DirichletApproximationOQ01OQ01

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,162 @@
+{
+  "id": "dirichlet-approximation-theorem-oq-01-oq-01",
+  "title": "Dirichlet Approximation OQ-01-OQ-01: Optimality of the Hurwitz Constant √5",
+  "slug": "dirichlet-approximation-theorem-oq-01-oq-01",
+  "description": "The sharpness half of Hurwitz's theorem, formalized over Mathlib's golden-ratio development. The parent entry upgrades Dirichlet's bound to infinitely many approximations |α − p/q| < 1/q²; Hurwitz sharpens the constant 1 to 1/√5 and asserts √5 is best possible. This entry proves the optimality (best-possible) direction: for the golden ratio φ = (1+√5)/2 and any constant c > √5, only finitely many rationals satisfy |φ − p/q| < 1/(c·q²) — hence no Hurwitz-type theorem can hold with a constant exceeding √5. The proof is elementary and axiom-free: writing A = p − qφ, B = p − qψ (ψ the conjugate), the product A·B = p² − pq − q² is a nonzero integer (nonzero because φ is irrational), so |A·B| ≥ 1; combining with B = A + q√5 and the triangle inequality yields (c² − c√5)·q² < 1, which bounds the denominators and confines the fractions to a finite box of bounded height (a self-contained re-derivation of the parent's finite_bounded_den lemma). Mathlib has Dirichlet's theorem (constant 1), Legendre's theorem, and continued fractions, but no Hurwitz bound and no optimality statement; the existence half of Hurwitz (the 1/√5 bound itself) is left as future work.",
+  "meta": {
+    "author": "Researcher agent (lean-genius), formalized in Lean 4 over Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Hurwitz%27s_theorem_(number_theory)",
+    "date": "1891",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DirichletApproximationOQ01OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-approximation",
+      "rational-approximation",
+      "irrational-numbers",
+      "golden-ratio",
+      "hurwitz-theorem",
+      "optimality"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.goldenRatio_add_goldenConj / Real.goldenRatio_mul_goldenConj / Real.goldenRatio_sub_goldenConj",
+        "description": "The defining symmetric functions of the golden ratio φ and its conjugate ψ: φ + ψ = 1, φ·ψ = −1, and φ − ψ = √5. These are exactly the coefficients of the minimal polynomial x² − x − 1, and they make the integer factorization (p − qφ)(p − qψ) = p² − pq − q² hold and give B = A + q√5.",
+        "module": "Mathlib.NumberTheory.Real.GoldenRatio"
+      },
+      {
+        "theorem": "Real.goldenRatio_irrational / Real.goldenConj_irrational",
+        "description": "φ and ψ are irrational. Used to show the integer norm N = p² − pq − q² is nonzero (a vanishing factor p − qφ would make φ = p/q rational), hence |N| ≥ 1.",
+        "module": "Mathlib.NumberTheory.Real.GoldenRatio"
+      },
+      {
+        "theorem": "Int.one_le_abs",
+        "description": "A nonzero integer has absolute value at least 1. Turns N ≠ 0 into the lower bound |A·B| = |N| ≥ 1 that drives the whole estimate.",
+        "module": "Mathlib.Algebra.Order.Ring.Int"
+      },
+      {
+        "theorem": "Set.Finite.of_finite_image / Finset.Icc / lt_div_iff₀",
+        "description": "Elementary finiteness and ordered-field machinery: a set with finite image under an injective map is finite (powers the in-file finite_bounded_den, embedding q ↦ (q.num, q.den) into the integer box [-M,M]×[1,N]); lt_div_iff₀ clears the denominator in the bound a < 1/(c·q).",
+        "module": "Mathlib.Data.Set.Finite.Basic / Mathlib.Algebra.Order.GroupWithZero.Unbundled.Basic"
+      },
+      {
+        "theorem": "Rat.cast_def / Rat.num_div_den / Rat.pos",
+        "description": "Rational-structure facts: (q : ℝ) = q.num/q.den, q determined by (num,den), and 0 < q.den. Convert between the rational error |φ − r| and the integer combination |p − qφ|, and provide the injectivity for finite_bounded_den.",
+        "module": "Mathlib.Data.Rat.Cast.Defs / Mathlib.Data.Rat.Defs"
+      }
+    ],
+    "originalContributions": [
+      "finite_approx_gt_sqrt5: the optimality (best-possible) half of Hurwitz's theorem — for every c > √5 the set {r : ℚ | |φ − r| < 1/(c·r.den²)} is finite. This is genuinely new content: Mathlib has Dirichlet's theorem with constant 1 and continued-fraction infrastructure but neither the Hurwitz bound nor its optimality. The proof is elementary and axiom-free.",
+      "The integer-norm factorization (p − qφ)(p − qψ) = p² − pq − q² = N over ℝ, with N ≠ 0 deduced from the irrationality of φ (a zero factor forces φ = p/q ∈ ℚ), giving the Diophantine lower bound |A·B| = |N| ≥ 1 — the arithmetic heart of why the golden ratio is badly approximable.",
+      "The clearing-of-denominators estimate: combining |A| = q·|φ − p/q| < 1/(c·q), the triangle bound |B| ≤ |A| + q√5, and 1 ≤ |A|·|B|, to derive the uniform denominator bound (c² − c√5)·q² < 1, valid because c > √5 makes c² − c√5 > 0.",
+      "not_infinite_approx_gt_sqrt5 and hurwitz_constant_optimal: the headline corollaries stating that for c > √5 there are not infinitely many approximations to φ, and consequently that no Hurwitz-type theorem holds with any constant exceeding √5 (the golden ratio is the extremal counterexample) — the precise sense in which √5 is optimal.",
+      "finite_bounded_den: a self-contained re-derivation (independent of the parent file) of the finiteness lemma for rationals of bounded height in a bounded real interval, used to turn the denominator bound plus the value bound |φ − r| < 1 into finiteness of the approximation set."
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "dirichlet-approximation-theorem-oq-01",
+        "relationship": "Parent entry: upgrades Dirichlet's one-shot bound to infinitely many approximations within 1/q². This OQ-01-OQ-01 answers its openQuestions[0] — 'is the √5 shown to be optimal via the golden ratio?' — by proving the sharpness direction of Hurwitz's theorem."
+      }
+    ],
+    "axiomCount": 0,
+    "lineCount": 239,
+    "assumptions": "0 axioms, 0 sorries. The only hypothesis is c > √5 (Real.sqrt 5 < c), which is exactly the threshold past which optimality kicks in. The result is proved in-file from elementary Mathlib facts about the golden ratio (the symmetric-function identities φ+ψ=1, φψ=−1, φ−ψ=√5 and the irrationality of φ, ψ) together with Int.one_le_abs and standard finiteness machinery. Badge is 'original' because the optimality theorem and all corollaries are new in-file results, not restatements of any Mathlib theorem (Mathlib contains neither Hurwitz's bound nor its sharpness).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Dirichlet's 1842 theorem gives, for every irrational α, infinitely many fractions p/q with |α − p/q| < 1/q². In 1891 Hurwitz sharpened the constant: infinitely many p/q satisfy |α − p/q| < 1/(√5·q²), and √5 is best possible — for any larger constant the statement fails, the golden ratio φ = (1+√5)/2 being the obstruction. Among all irrationals φ is the 'most badly approximable' (its continued fraction is [1;1,1,…]). The parent gallery entry formalizes the infinitude with constant 1 and asks, as its first open question, whether the constant can be sharpened to Hurwitz's √5 and whether √5 is shown optimal via the golden ratio. This entry settles the optimality direction.",
+    "problemStatement": "Let φ = (1+√5)/2 be the golden ratio and let c > √5. Then only finitely many rationals p/q satisfy\n\n$$\\left|\\varphi - \\frac{p}{q}\\right| < \\frac{1}{c\\,q^2}.$$\n\nConsequently the constant √5 in Hurwitz's theorem cannot be replaced by any larger constant: there is no c > √5 for which every irrational admits infinitely many approximations within 1/(c·q²).",
+    "text": "Mathlib provides Dirichlet's theorem (constant 1), Legendre's theorem, and continued fractions, but not Hurwitz's sharp bound and not its optimality. This entry proves the optimality (sharpness) half: the golden ratio is approximated within 1/(c·q²) by only finitely many fractions once c exceeds √5. The existence half of Hurwitz (the 1/√5 bound itself) is noted as future work.",
+    "proofStrategy": "Fix c > √5 and a rational r = p/q (q = r.den ≥ 1) with |φ − r| < 1/(c·q²). Let A = p − qφ and B = p − qψ where ψ = (1−√5)/2 is the conjugate. Using φ + ψ = 1 and φ·ψ = −1 (Mathlib), the product A·B equals the integer N = p² − pq − q². N is nonzero: a vanishing factor A = 0 or B = 0 would make φ or ψ equal to the rational p/q, contradicting their irrationality (Real.goldenRatio_irrational). Hence |A·B| = |N| ≥ 1 by Int.one_le_abs. Since φ − ψ = √5, we have B = A + q√5, so |B| ≤ |A| + q√5 by the triangle inequality, giving 1 ≤ |A|·|B| ≤ |A|² + |A|·q√5. Feeding in |A| = q·|φ − r| < 1/(c·q) and clearing denominators yields the uniform denominator bound (c² − c√5)·q² < 1. As c > √5 makes c² − c√5 = c(c − √5) > 0, the denominators are bounded by a constant M depending only on c; together with the value bound |φ − r| < 1 (so r ∈ [φ−1, φ+1]) the approximations lie in a finite box of bounded height, finite by the in-file finite_bounded_den. The corollaries not_infinite_approx_gt_sqrt5 and hurwitz_constant_optimal read off optimality.",
+    "keyInsights": [
+      "**The golden ratio's minimal polynomial does the arithmetic**: φ + ψ = 1 and φ·ψ = −1 are precisely the coefficients of x² − x − 1, and they make (p − qφ)(p − qψ) collapse to the integer p² − pq − q². The Diophantine rigidity of φ is encoded entirely in this integrality",
+      "**Irrationality ⟹ nonvanishing ⟹ |N| ≥ 1**: the single use of φ being irrational is to rule out N = 0; the discreteness of ℤ (Int.one_le_abs) then supplies the crucial lower bound |A·B| ≥ 1 that no purely analytic argument provides",
+      "**The conjugate gap is exactly √5**: B = A + q√5, so the second factor is forced to be large (≈ q√5) whenever the first is small. The product being ≥ 1 then squeezes |A| from below — the golden ratio resists approximation precisely because √5 = φ − ψ is the spectral gap to its conjugate",
+      "**√5 is the break-even constant**: the estimate produces (c² − c√5)·q² < 1, whose leading coefficient c² − c√5 is positive exactly when c > √5. At c = √5 the bound degenerates (consistent with Hurwitz's infinitely-many at the threshold); above it, denominators are bounded and only finitely many fractions survive",
+      "**Finitely many is sharpness**: bounding the denominators turns the approximation set into a bounded-height subset of a bounded interval, hence finite. The contrapositive — no c > √5 works for every irrational — is the optimality statement, with φ as the universal witness"
+    ],
+    "prerequisites": [
+      "Mathlib's golden-ratio development: the symmetric-function identities φ+ψ=1, φψ=−1, φ−ψ=√5, and the irrationality of φ and ψ",
+      "The integrality and discreteness of ℤ (a nonzero integer has |·| ≥ 1)",
+      "Elementary finiteness of bounded-height rationals in a bounded interval (re-derived in-file)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "overview-and-setup",
+      "title": "Module Overview and Setup",
+      "startLine": 1,
+      "endLine": 57,
+      "mathContext": "Goal: for c > √5, the set of rationals approximating φ within 1/(c·q²) is finite — the optimality half of Hurwitz's theorem.",
+      "summary": "Module docstring framing the open question (sharpness of the Hurwitz constant √5), the elementary axiom-free method via the integer norm (p − qφ)(p − qψ) = p² − pq − q², and the explicit note that Mathlib lacks both the Hurwitz bound and its optimality. Followed by import Mathlib, namespace DirichletApproximationOQ01OQ01, open Set Real, and open scoped goldenRatio."
+    },
+    {
+      "id": "finite-bounded-den",
+      "title": "Bounded-Height Finiteness (in-file infrastructure)",
+      "startLine": 59,
+      "endLine": 95,
+      "mathContext": "Rationals in a bounded interval [a,b] with denominator ≤ N form a finite set.",
+      "summary": "finite_bounded_den: a self-contained re-derivation (independent of the parent file) embedding q ↦ (q.num, q.den) into the finite integer box Finset.Icc(-M,M) ×ˢ Finset.Icc 1 N with M ≥ max|a||b|·N, and injectivity via Rat.num_div_den. This is the discreteness fact that converts the denominator bound into finiteness."
+    },
+    {
+      "id": "optimality-finiteness",
+      "title": "Optimality: Finitely Many Approximations Beyond √5",
+      "startLine": 97,
+      "endLine": 222,
+      "mathContext": "For c > √5, {r : ℚ | |φ − r| < 1/(c·r.den²)} is finite.",
+      "summary": "finite_approx_gt_sqrt5: the main theorem. Builds the integer norm N = p² − pq − q², proves the factorization (p − qφ)(p − qψ) = N via φ+ψ=1 and φψ=−1, shows N ≠ 0 from the irrationality of φ and ψ (a zero factor forces φ or ψ rational), and hence |A·B| = |N| ≥ 1. Using B = A + q√5 (from φ − ψ = √5) and the triangle inequality gives 1 ≤ |A|² + |A|·q√5; substituting |A| = q·|φ − r| < 1/(c·q) and clearing denominators yields (c² − c√5)·q² < 1. Since c² − c√5 > 0, the denominators are bounded by an M depending only on c; with |φ − r| < 1 confining r to [φ−1, φ+1], finite_bounded_den finishes."
+    },
+    {
+      "id": "optimality-corollaries",
+      "title": "Corollaries: √5 Is Best Possible",
+      "startLine": 224,
+      "endLine": 239,
+      "mathContext": "No Hurwitz-type theorem holds with a constant exceeding √5.",
+      "summary": "not_infinite_approx_gt_sqrt5: the approximation set for c > √5 is not infinite (a restatement of finiteness). hurwitz_constant_optimal: for any c > √5 it is false that every irrational has infinitely many approximations within 1/(c·q²) — the golden ratio is the counterexample (via Real.goldenRatio_irrational). This is the sharpness statement complementing Hurwitz's existence theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "The optimality (best-possible) half of Hurwitz's theorem is formalized: for the golden ratio φ and any c > √5, only finitely many rationals p/q satisfy |φ − p/q| < 1/(c·q²). The argument is elementary and axiom-free — the integer norm (p − qφ)(p − qψ) = p² − pq − q² is nonzero by irrationality of φ, so |·| ≥ 1, and the conjugate gap φ − ψ = √5 forces (c² − c√5)·q² < 1, bounding the denominators. The corollary hurwitz_constant_optimal states the conclusion in its sharpest form: no Hurwitz-type theorem can hold with a constant exceeding √5, the golden ratio being the universal obstruction. Zero sorries, zero axioms.",
+    "implications": "This pins down the constant in the central theorem of one-dimensional Diophantine approximation. Together with the parent's infinitude (constant 1) and the (future) existence half of Hurwitz (constant √5), it brackets the optimal approximation exponent and constant for irrationals exactly. The method — reduce approximability to the nonvanishing of an algebraic integer norm and exploit the conjugate gap — is the template for the Markov spectrum and for badly approximable numbers generally (numbers with bounded continued-fraction partial quotients).",
+    "openQuestions": [
+      "Can the existence half of Hurwitz be formalized — every irrational has infinitely many p/q with |α − p/q| < 1/(√5·q²) — via three consecutive continued-fraction convergents, completing the theorem?",
+      "Does the optimality argument generalize to the next Lagrange/Markov number (√8 for numbers not equivalent to the golden ratio), exhibiting the discrete spectrum of best constants?",
+      "Can 'badly approximable' be characterized in Lean as bounded partial quotients, with the golden ratio shown to be the extremal (worst-approximable) case?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "dirichlet-approximation-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: infinitely many approximations within 1/q² for irrational α. This entry answers its first open question by proving the optimality direction of the Hurwitz sharpening — √5 cannot be improved, with the golden ratio as witness."
+    },
+    {
+      "targetId": "dirichlet-approximation-theorem",
+      "relationship": "sharpens",
+      "description": "The grandparent one-shot Dirichlet bound. This entry sits at the sharp end of the same story: it identifies the exact constant √5 beyond which approximation of the golden ratio fails."
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/DirichletApproximationOQ01OQ01.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Real",
+      "goldenRatio"
+    ],
+    "namespace": "DirichletApproximationOQ01OQ01",
+    "lineCount": 239,
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the **optimality (sharpness) half of Hurwitz's theorem**, directly answering the parent entry's `openQuestions[0]`: *"is the √5 shown to be optimal via the golden ratio?"*

**Result.** For the golden ratio φ = (1+√5)/2 and any constant `c > √5`, only **finitely many** rationals `p/q` satisfy `|φ − p/q| < 1/(c·q²)`. Consequently no Hurwitz-type theorem can hold with a constant exceeding √5 — the golden ratio is the universal obstruction.

## Why this is new

Mathlib has Dirichlet's theorem (constant 1), Legendre's theorem, and continued fractions, but **neither the Hurwitz bound nor its optimality**. This is genuinely new, elementary, axiom-free content.

## Method (elementary)

Writing `A = p − qφ`, `B = p − qψ` (ψ the conjugate):
- `φ + ψ = 1`, `φ·ψ = −1` ⟹ `A·B = p² − pq − q² =: N ∈ ℤ`;
- `N ≠ 0` because φ is irrational (a zero factor forces φ = p/q ∈ ℚ), so `|A·B| = |N| ≥ 1`;
- `φ − ψ = √5` ⟹ `B = A + q√5`, so `|B| ≤ |A| + q√5`;
- combining `1 ≤ |A|·|B| ≤ |A|² + |A|·q√5` with `|A| = q·|φ − p/q| < 1/(c·q)` gives `(c² − c√5)·q² < 1`.

Since `c > √5` makes `c² − c√5 > 0`, denominators are bounded; with `|φ − r| < 1` confining `r` to `[φ−1, φ+1]`, the set is finite (in-file `finite_bounded_den`).

## Verification

- **4 theorems, 0 definitions, 0 axioms, 0 sorries, 239 lines**, Mathlib v4.26.0
- Kernel-verified: `#print axioms` of `finite_approx_gt_sqrt5` and `hurwitz_constant_optimal` = `[propext, Classical.choice, Quot.sound]` (standard triple — no `sorryAx`, no `Lean.ofReduceBool`)
- `status: verified`, `badge: original`

Theorems: `finite_approx_gt_sqrt5` (main), `not_infinite_approx_gt_sqrt5`, `hurwitz_constant_optimal`, `finite_bounded_den`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)