### PR TITLE
Enrich Carnot's Theorem — law-of-sines perimeter bridge

### DIFF
--- a/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "carnot-oq010302-ann-imports",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 3 },
+    "type": "context",
+    "title": "Imports: Mathlib and the two angle-level companions",
+    "content": "The file imports all of Mathlib — supplying the Euclidean-geometry layer (`Affine.Triangle`, the extended law of sines, the interior-angle sum, and the affine-independence/collinearity bridge) — together with the two companion entries that already settled the analytic content on the angle side: `CarnotTheoremOQ01OQ03` (the sharp bound `sin A + sin B + sin C ≤ 3√3/2`) and `CarnotTheoremOQ01OQ03OQ01` (its equality characterisation `A = B = C = π/3`). This entry adds only geometric plumbing; it imports the trigonometric facts rather than re-proving them.",
+    "mathContext": "Reused verbatim: $\\sin A + \\sin B + \\sin C \\le \\tfrac{3\\sqrt3}{2}$ and equality $\\iff A=B=C=\\tfrac{\\pi}{3}$.",
+    "significance": "context",
+    "relatedConcepts": ["law of sines", "circumradius", "affine independence", "modular proof reuse"],
+    "prerequisites": ["Lean 4", "Mathlib"]
+  },
+  {
+    "id": "carnot-oq010302-ann-overview",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 5, "endLine": 51 },
+    "type": "concept",
+    "title": "The law-of-sines bridge: from angles to metric geometry",
+    "content": "The module docstring frames the central move. The companions prove facts about *reals* $A,B,C$ summing to $\\pi$; the extended law of sines $a = 2R\\sin A$ is the hinge that turns any symmetric inequality in the angles into a metric statement about side lengths and the circumradius. Writing each side as $2R\\cdot\\sin(\\text{opposite angle})$ makes the perimeter equal to $2R(\\sin A + \\sin B + \\sin C)$, so the angle bound becomes $\\text{perimeter} \\le 3\\sqrt3\\,R$, attained iff the triangle is equilateral. This recovers the textbook theorem that the equilateral triangle has the greatest perimeter among all triangles inscribed in a fixed circle.",
+    "mathContext": "$\\text{perimeter}\\,t = 2R(\\sin A + \\sin B + \\sin C) \\le 2R\\cdot\\tfrac{3\\sqrt3}{2} = 3\\sqrt3\\,R$.",
+    "significance": "key",
+    "relatedConcepts": ["extended law of sines", "circumscribed circle", "perimeter maximisation", "extremal geometry"],
+    "prerequisites": ["Euclidean geometry", "trigonometry"]
+  },
+  {
+    "id": "carnot-oq010302-ann-variables",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 53, "endLine": 58 },
+    "type": "definition",
+    "title": "Ambient setting: a general real inner-product space",
+    "content": "The results are stated over an abstract real inner-product space `P` (a `NormedAddTorsor` over a vector space `V` with `InnerProductSpace ℝ V`), not over a fixed coordinate model. Because a triangle lives entirely within its 2-dimensional affine span, nothing is lost by ambient dimension, and the theorems specialise immediately to `EuclideanSpace ℝ (Fin 2)`, the Euclidean plane. The `open Real EuclideanGeometry` brings `∠` (the unoriented Euclidean angle) and `Real.sin` into scope.",
+    "mathContext": "$P$ a real inner-product torsor; the triangle's circumradius and angles are intrinsic to its affine span.",
+    "significance": "supporting",
+    "relatedConcepts": ["inner-product space", "affine torsor", "affine span", "intrinsic geometry"],
+    "prerequisites": ["normed torsors", "affine spaces"]
+  },
+  {
+    "id": "carnot-oq010302-ann-side-lemma",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 60, "endLine": 80 },
+    "type": "technique",
+    "title": "Each side as 2R·sin(opposite angle) — clearing the denominator",
+    "content": "`side_eq_two_mul_circumradius_mul_sin` is the reusable geometric core. Mathlib's extended law of sines gives $\\frac{\\text{dist}}{\\sin\\angle} = 2R$ as a *quotient*; to use it additively we must clear the denominator, which is only legal when $\\sin\\angle \\ne 0$. The triangle's affine independence (`t.independent`) is converted to non-collinearity of the three vertices via `affineIndependent_iff_not_collinear_of_ne`, and non-collinearity forces the interior angle strictly into $(0,\\pi)$ (`angle_pos_of_not_collinear`, `angle_lt_pi_of_not_collinear`), so `Real.sin_pos_of_pos_of_lt_pi` makes the sine positive, hence nonzero. Then `div_eq_iff` and `linear_combination` deliver the multiplicative form.",
+    "mathContext": "$\\dfrac{\\operatorname{dist}(p_{i_1},p_{i_3})}{\\sin\\angle_{i_2}} = 2R \\;\\Longrightarrow\\; \\operatorname{dist}(p_{i_1},p_{i_3}) = 2R\\sin\\angle_{i_2}$ (valid since $\\angle_{i_2}\\in(0,\\pi)$).",
+    "significance": "key",
+    "relatedConcepts": ["extended law of sines", "affine independence", "non-collinearity", "interior angle range"],
+    "prerequisites": ["law of sines", "affine independence ⇔ non-collinearity"]
+  },
+  {
+    "id": "carnot-oq010302-ann-angle-sum",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 82, "endLine": 91 },
+    "type": "technique",
+    "title": "Interior angles sum to π",
+    "content": "`angle_sum_eq_pi` is a convenience restatement of `EuclideanGeometry.angle_add_angle_add_angle_eq_pi` in the precise vertex ordering the side lemmas use: the angle at vertex 0 is `∠ p₁ p₀ p₂`, at vertex 1 is `∠ p₂ p₁ p₀`, at vertex 2 is `∠ p₀ p₂ p₁`. The lemma's required distinctness of two vertices is discharged from the triangle's injective `points` map (`t.independent.injective.ne (by decide)`). This supplies the `A + B + C = π` hypothesis that both companion angle-level results demand.",
+    "mathContext": "$\\angle_0 + \\angle_1 + \\angle_2 = \\pi$.",
+    "significance": "supporting",
+    "relatedConcepts": ["angle sum of a triangle", "Euclidean geometry", "vertex indexing"],
+    "prerequisites": ["Euclidean angle sum"]
+  },
+  {
+    "id": "carnot-oq010302-ann-perimeter-le",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 93, "endLine": 124 },
+    "type": "insight",
+    "title": "The geometric perimeter bound perimeter ≤ 3√3·R",
+    "content": "`perimeter_le` is the first headline theorem. Each of the three sides is rewritten via the side lemma to $2R\\sin(\\text{opposite angle})$ (`sA`, `sB`, `sC`), the angle sum feeds the companion bound `sin_sum_le` to get $\\sin A + \\sin B + \\sin C \\le \\tfrac{3\\sqrt3}{2}$, and `circumradius_nonneg` supplies $R \\ge 0$. Multiplying the bound by $R \\ge 0$ (`mul_le_mul_of_nonneg_left`) gives the slack inequality, and `nlinarith` closes the nonlinear arithmetic. Geometrically: no triangle inscribed in a circle of radius $R$ has perimeter exceeding $3\\sqrt3\\,R$.",
+    "mathContext": "$\\operatorname{dist}(p_0,p_1)+\\operatorname{dist}(p_1,p_2)+\\operatorname{dist}(p_2,p_0) \\le 3\\sqrt3\\cdot t.\\text{circumradius}$.",
+    "significance": "key",
+    "relatedConcepts": ["isoperimetric-type bound", "circumradius", "Jensen's inequality", "sine sum"],
+    "prerequisites": ["the companion sine bound", "monotonicity of multiplication"]
+  },
+  {
+    "id": "carnot-oq010302-ann-equality",
+    "proofId": "carnot-theorem-oq-01-oq-03-oq-02",
+    "range": { "startLine": 126, "endLine": 167 },
+    "type": "insight",
+    "title": "Equality iff equilateral — the sharp characterisation",
+    "content": "`perimeter_eq_iff_equilateral` upgrades the bound to an exact characterisation. The circumradius of a genuine triangle is strictly positive (`circumradius_pos`), so $2R \\ne 0$ and the factor cancels via `mul_right_inj'`: after rewriting the perimeter as $2R(\\sin A + \\sin B + \\sin C)$ and the right side as $2R\\cdot\\tfrac{3\\sqrt3}{2}$ (both by `ring`), the geometric equation is *equivalent* — not merely implied — to the angle-level sine equation. The companion uniqueness result `sin_sum_eq_iff_equilateral` then pins that to $A = B = C = \\pi/3$. Because the equivalence is lossless, the angle-level uniqueness lifts verbatim to the geometric statement.",
+    "mathContext": "$\\text{perimeter} = 3\\sqrt3\\,R \\iff \\angle_0=\\angle_1=\\angle_2=\\tfrac{\\pi}{3}$ (using $2R>0$ to cancel).",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "strict concavity", "uniqueness of maximiser", "equilateral triangle"],
+    "prerequisites": ["the companion equality characterisation", "positivity of the circumradius"]
+  }
+]

--- a/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-02/index.ts
+++ b/src/data/proofs/carnot-theorem-oq-01-oq-03-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CarnotTheoremOQ01OQ03OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const carnotTheoremOq01Oq03Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const carnotTheoremOq01Oq03Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const carnotTheoremOq01Oq03Oq02Data: ProofData = {
+  proof: carnotTheoremOq01Oq03Oq02Proof,
+  annotations: carnotTheoremOq01Oq03Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `carnot-theorem-oq-01-oq-03-oq-02` (quality 43, pass 0).

## Changes
- **Created missing `index.ts`** — the entry had only `meta.json`, so the proof page rendered "proof not found" on the live site despite appearing in the gallery listing. Added the Vite entry point importing the Lean source from `Proofs/CarnotTheoremOQ01OQ03OQ02.lean`.
- **Created `annotations.json`** — 7 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering: the imports/companion reuse, the law-of-sines bridge overview, the abstract inner-product-space setting, the side-length lemma (clearing the `sin ≠ 0` denominator via affine independence), the interior-angle sum, and both headline theorems `perimeter_le` and `perimeter_eq_iff_equilateral`.

## Verification
- `pnpm build` succeeds (✓ built).
- meta.json already verified `status: verified`, `badge: original`, `axiomCount: 0`, 0 sorries; annotation content checked against the Lean source line-by-line.
