### PR TITLE
research(antitone-integral-sum-comparison-oq-01-oq-02): convergence of the harmonic defect to the Euler–Mascheroni constant γ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -148,6 +148,7 @@ import Proofs.AngleTrisectionOQ05OQ03
 import Proofs.AngleTrisectionOQ05OQ04
 import Proofs.AntitoneIntegralSumComparisonOQ01OQ01
 import Proofs.AntitoneIntegralSumComparisonOQ01OQ01OQ02
+import Proofs.AntitoneIntegralSumComparisonOQ01OQ02
 import Proofs.ArchimedesMethodOfExhaustion
 import Proofs.AreaFromCircumferenceIntegral
 import Proofs.AreaOfCircle

--- a/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02.lean
+++ b/proofs/Proofs/AntitoneIntegralSumComparisonOQ01OQ02.lean
@@ -1,0 +1,124 @@
+import Mathlib
+
+/-
+# Antitone Integral Test OQ-01 → OQ-02: convergence to the Euler–Mascheroni constant
+
+The parent file (`AntitoneIntegralSumComparison`, "The Integral Test") ran the antitone
+integral comparison on `f x = 1/x` and pinned the **harmonic defect**
+
+  `aₙ := Hₙ − log(n+1)`,   `Hₙ = harmonic n = ∑_{k=1}^{n} 1/k`
+
+between two integrals, proving `0 ≤ aₙ` (`harmonic_sub_log_nonneg`) and
+`aₙ ≤ 1` (`harmonic_succ_sub_log_le_one`).  That established **boundedness** of the defect
+sequence, but stopped short of the headline consequence.
+
+The defect is also monotone increasing, so a bounded-monotone argument forces it to
+**converge**.  Its limit is the **Euler–Mascheroni constant** `γ ≈ 0.5772…`.  This file
+answers the parent's open question — *does the defect converge, and to what?* — by bridging
+the parent's setup to Mathlib's `Real.eulerMascheroniConstant`.
+
+## Main results
+
+* `tendsto_harmonic_sub_log_add_one` : the parent's exact sequence `Hₙ − log(n+1) → γ`.
+* `tendsto_harmonic_sub_log` : the textbook form `Hₙ − log n → γ` — i.e. `Hₙ ∼ log n + γ`.
+* `harmonic_sub_log_add_one_lt_gamma` / `gamma_lt_harmonic_sub_log` : the two parent-style
+  sequences **bracket** `γ` from below and above for every `n ≥ 1`.
+* `gamma_mem_Ioo` : the resulting nested enclosure `γ ∈ (Hₙ − log(n+1), Hₙ − log n)`.
+* `tendsto_bracket_width` : the bracket width `log(n+1) − log n → 0`, so the enclosure pins
+  `γ` to arbitrary precision.
+* `gamma_pos`, `gamma_lt_one`, `gamma_mem_Ioo_half_twoThirds` : `0 < γ < 1`, sharpened to
+  `1/2 < γ < 2/3`.
+* `harmonic_six`, `gamma_enclosure_six` : a concrete rational bracket
+  `49/20 − log 7 < γ < 49/20 − log 6`.
+
+All statements reduce to Mathlib's Euler–Mascheroni development; the file is `sorry`-free
+and `axiom`-free (standard foundations only).
+-/
+
+namespace AntitoneIntegralSumComparisonOQ01OQ02
+
+open Filter Topology Real
+
+/-- **Convergence of the parent's defect sequence.**  The harmonic defect
+`Hₙ − log(n+1)` — the very sequence the parent file bounded in `[0,1]` — converges to the
+Euler–Mascheroni constant `γ`.  This is the answer to the parent's open question. -/
+theorem tendsto_harmonic_sub_log_add_one :
+    Tendsto (fun n : ℕ ↦ (harmonic n : ℝ) - Real.log (n + 1)) atTop
+      (𝓝 Real.eulerMascheroniConstant) :=
+  Real.tendsto_harmonic_sub_log_add_one
+
+/-- **Textbook form: `Hₙ − log n → γ`,** equivalently `Hₙ ∼ log n + γ`.  Shifting the
+logarithm's argument from `n+1` to `n` does not change the limit, since
+`log(n+1) − log n → 0`. -/
+theorem tendsto_harmonic_sub_log :
+    Tendsto (fun n : ℕ ↦ (harmonic n : ℝ) - Real.log n) atTop
+      (𝓝 Real.eulerMascheroniConstant) :=
+  Real.tendsto_harmonic_sub_log
+
+/-- **Lower bracket.**  Every term of the parent's increasing sequence lies strictly below
+`γ`: `Hₙ − log(n+1) < γ`. -/
+theorem harmonic_sub_log_add_one_lt_gamma (n : ℕ) :
+    (harmonic n : ℝ) - Real.log (n + 1) < Real.eulerMascheroniConstant := by
+  have := Real.eulerMascheroniSeq_lt_eulerMascheroniConstant n
+  simpa [Real.eulerMascheroniSeq] using this
+
+/-- **Upper bracket.**  The companion decreasing sequence lies strictly above `γ`:
+`γ < Hₙ − log n` for `n ≥ 1`. -/
+theorem gamma_lt_harmonic_sub_log (n : ℕ) (hn : 1 ≤ n) :
+    Real.eulerMascheroniConstant < (harmonic n : ℝ) - Real.log n := by
+  have h := Real.eulerMascheroniConstant_lt_eulerMascheroniSeq' n
+  have hn0 : n ≠ 0 := by omega
+  simpa [Real.eulerMascheroniSeq', hn0] using h
+
+/-- **Nested enclosure.**  For every `n ≥ 1`,
+`γ ∈ (Hₙ − log(n+1), Hₙ − log n)`. -/
+theorem gamma_mem_Ioo (n : ℕ) (hn : 1 ≤ n) :
+    Real.eulerMascheroniConstant ∈
+      Set.Ioo ((harmonic n : ℝ) - Real.log (n + 1)) ((harmonic n : ℝ) - Real.log n) :=
+  ⟨harmonic_sub_log_add_one_lt_gamma n, gamma_lt_harmonic_sub_log n hn⟩
+
+/-- **Bracket width.**  The gap between the upper and lower brackets at index `n` is
+`log(n+1) − log n`. -/
+theorem bracket_width (n : ℕ) :
+    ((harmonic n : ℝ) - Real.log n) - ((harmonic n : ℝ) - Real.log (n + 1))
+      = Real.log (n + 1) - Real.log n := by
+  ring
+
+/-- **The enclosure pins down `γ`.**  The bracket width `log(n+1) − log n` tends to `0`, so
+the nested intervals from `gamma_mem_Ioo` shrink to the single point `γ`. -/
+theorem tendsto_bracket_width :
+    Tendsto (fun n : ℕ ↦ Real.log (n + 1) - Real.log n) atTop (𝓝 0) := by
+  have h := tendsto_harmonic_sub_log.sub tendsto_harmonic_sub_log_add_one
+  have hzero : Real.eulerMascheroniConstant - Real.eulerMascheroniConstant = 0 := sub_self _
+  rw [hzero] at h
+  refine h.congr (fun n ↦ ?_)
+  ring
+
+/-- `γ` is positive. -/
+theorem gamma_pos : 0 < Real.eulerMascheroniConstant :=
+  lt_trans (by norm_num) Real.one_half_lt_eulerMascheroniConstant
+
+/-- `γ < 1`. -/
+theorem gamma_lt_one : Real.eulerMascheroniConstant < 1 :=
+  lt_trans Real.eulerMascheroniConstant_lt_two_thirds (by norm_num)
+
+/-- **Sharp numeric bounds:** `1/2 < γ < 2/3`. -/
+theorem gamma_mem_Ioo_half_twoThirds :
+    Real.eulerMascheroniConstant ∈ Set.Ioo (1 / 2 : ℝ) (2 / 3) :=
+  ⟨Real.one_half_lt_eulerMascheroniConstant, Real.eulerMascheroniConstant_lt_two_thirds⟩
+
+/-- The sixth harmonic number `H₆ = 1 + 1/2 + ⋯ + 1/6 = 49/20`. -/
+theorem harmonic_six : (harmonic 6 : ℝ) = 49 / 20 := by
+  norm_num [harmonic, Finset.sum_range_succ]
+
+/-- **Concrete rational enclosure at `n = 6`:** `49/20 − log 7 < γ < 49/20 − log 6`. -/
+theorem gamma_enclosure_six :
+    (49 / 20 : ℝ) - Real.log 7 < Real.eulerMascheroniConstant ∧
+      Real.eulerMascheroniConstant < (49 / 20 : ℝ) - Real.log 6 := by
+  have hlo := harmonic_sub_log_add_one_lt_gamma 6
+  have hhi := gamma_lt_harmonic_sub_log 6 (by norm_num)
+  rw [harmonic_six] at hlo hhi
+  norm_num at hlo hhi
+  exact ⟨by linarith [hlo], by linarith [hhi]⟩
+
+end AntitoneIntegralSumComparisonOQ01OQ02

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-isc-oq0102-tendsto-add-one",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02",
+    "range": { "startLine": 45, "endLine": 48 },
+    "type": "theorem",
+    "title": "The Defect Converges to γ",
+    "content": "tendsto_harmonic_sub_log_add_one states that the parent's exact defect sequence Hₙ − log(n+1) converges to the Euler–Mascheroni constant γ. The parent file only proved this sequence is bounded in [0,1]; combined with its monotonicity it must converge, and γ is the limit. This is the direct answer to the parent's open question, obtained by bridging to Mathlib's Real.tendsto_harmonic_sub_log_add_one.",
+    "mathContext": "\\lim_{n\\to\\infty}\\Big(H_n - \\log(n+1)\\Big) = \\gamma",
+    "significance": "key",
+    "relatedConcepts": [
+      "Euler–Mascheroni constant",
+      "harmonic numbers",
+      "monotone convergence",
+      "integral test"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0102-tendsto-log",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02",
+    "range": { "startLine": 53, "endLine": 56 },
+    "type": "theorem",
+    "title": "Textbook Form: Hₙ ∼ log n + γ",
+    "content": "tendsto_harmonic_sub_log gives the standard statement Hₙ − log n → γ, equivalently the asymptotic Hₙ = log n + γ + o(1). It differs from the parent's form only in using log n instead of log(n+1); the limit is unchanged because the gap log(n+1) − log n = log(1 + 1/n) tends to 0. Bridges Real.tendsto_harmonic_sub_log.",
+    "mathContext": "H_n = \\log n + \\gamma + o(1)",
+    "significance": "key",
+    "relatedConcepts": [
+      "asymptotic expansion",
+      "harmonic numbers",
+      "logarithmic growth"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0102-brackets",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 71 },
+    "type": "theorem",
+    "title": "Two-Sided Bracketing of γ",
+    "content": "harmonic_sub_log_add_one_lt_gamma and gamma_lt_harmonic_sub_log show the two parent-style sequences trap γ: Hₙ − log(n+1) < γ < Hₙ − log n for every n ≥ 1. The lower sequence increases to γ, the upper decreases to γ. The proofs unfold Mathlib's eulerMascheroniSeq and eulerMascheroniSeq' (the latter on its n ≠ 0 branch) inside the strict bound lemmas eulerMascheroniSeq_lt_eulerMascheroniConstant and eulerMascheroniConstant_lt_eulerMascheroniSeq'.",
+    "mathContext": "H_n - \\log(n+1) < \\gamma < H_n - \\log n \\qquad (n \\ge 1)",
+    "significance": "important",
+    "relatedConcepts": [
+      "nested intervals",
+      "monotone sequences",
+      "squeeze"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0102-width",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02",
+    "range": { "startLine": 82, "endLine": 95 },
+    "type": "theorem",
+    "title": "Bracket Width → 0 Pins Down γ",
+    "content": "bracket_width identifies the gap between the upper and lower brackets as exactly log(n+1) − log n, and tendsto_bracket_width shows it tends to 0. The latter is proved by subtracting the two convergent bracket sequences (both → γ), so their difference tends to γ − γ = 0, then matching the resulting function pointwise. Consequently the nested intervals (Hₙ − log(n+1), Hₙ − log n) shrink to the single point γ — a constructive enclosure to arbitrary precision.",
+    "mathContext": "\\big(H_n-\\log n\\big)-\\big(H_n-\\log(n+1)\\big) = \\log(n+1)-\\log n \\to 0",
+    "significance": "important",
+    "relatedConcepts": [
+      "nested interval theorem",
+      "rate of convergence",
+      "limit arithmetic"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0102-bounds",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02",
+    "range": { "startLine": 98, "endLine": 108 },
+    "type": "theorem",
+    "title": "Numeric Bounds 1/2 < γ < 2/3",
+    "content": "gamma_pos and gamma_lt_one record 0 < γ < 1, sharpened by gamma_mem_Ioo_half_twoThirds to the Mathlib estimate 1/2 < γ < 2/3 (the true value is γ ≈ 0.5772). These chain Mathlib's one_half_lt_eulerMascheroniConstant and eulerMascheroniConstant_lt_two_thirds through norm_num.",
+    "mathContext": "\\tfrac12 < \\gamma < \\tfrac23",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "explicit constants",
+      "rational bounds"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "ann-isc-oq0102-enclosure-six",
+    "proofId": "antitone-integral-sum-comparison-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 121 },
+    "type": "theorem",
+    "title": "Concrete Rational Enclosure at n = 6",
+    "content": "harmonic_six computes the sixth harmonic number H₆ = 1 + 1/2 + ⋯ + 1/6 = 49/20 by norm_num, and gamma_enclosure_six substitutes it into the n = 6 brackets to give the explicit enclosure 49/20 − log 7 < γ < 49/20 − log 6 — a fully verified two-sided estimate of γ in closed form.",
+    "mathContext": "\\tfrac{49}{20} - \\log 7 < \\gamma < \\tfrac{49}{20} - \\log 6",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "harmonic numbers",
+      "explicit enclosure",
+      "worked example"
+    ],
+    "prerequisites": []
+  }
+]

--- a/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/meta.json
+++ b/src/data/proofs/antitone-integral-sum-comparison-oq-01-oq-02/meta.json
@@ -1,0 +1,80 @@
+{
+  "id": "antitone-integral-sum-comparison-oq-01-oq-02",
+  "slug": "antitone-integral-sum-comparison-oq-01-oq-02",
+  "title": "From the Integral Test to the Euler–Mascheroni Constant: Convergence of the Harmonic Defect",
+  "status": "verified",
+  "badge": "mathlib",
+  "leanFile": {
+    "namespace": "AntitoneIntegralSumComparisonOQ01OQ02",
+    "lineCount": 124,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_constant",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AntitoneIntegralSumComparisonOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "integral-test",
+      "harmonic-numbers",
+      "euler-mascheroni",
+      "convergence",
+      "asymptotics",
+      "monotone-convergence"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (only the foundational propext / Classical.choice / Quot.sound). The substantive results are Mathlib's Euler–Mascheroni development; this entry bridges the parent's defect sequence to them.",
+    "lineCount": 124,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "originalContributions": [
+      "tendsto_harmonic_sub_log_add_one: the parent's exact defect sequence Hₙ − log(n+1) — which the parent file only bounded in [0,1] — converges to the Euler–Mascheroni constant γ (bridges Real.tendsto_harmonic_sub_log_add_one)",
+      "tendsto_harmonic_sub_log: the textbook companion form Hₙ − log n → γ, i.e. the asymptotic Hₙ ∼ log n + γ (bridges Real.tendsto_harmonic_sub_log)",
+      "harmonic_sub_log_add_one_lt_gamma / gamma_lt_harmonic_sub_log: the two parent-style sequences bracket γ — Hₙ − log(n+1) < γ < Hₙ − log n for n ≥ 1 — packaged from Mathlib's eulerMascheroniSeq / eulerMascheroniSeq' bounds",
+      "gamma_mem_Ioo: the nested enclosure γ ∈ (Hₙ − log(n+1), Hₙ − log n)",
+      "bracket_width / tendsto_bracket_width: the enclosure width is exactly log(n+1) − log n and tends to 0, so the nested intervals pin γ to arbitrary precision (derived by squeezing the two convergent bracket sequences)",
+      "gamma_pos / gamma_lt_one / gamma_mem_Ioo_half_twoThirds: 0 < γ < 1, sharpened to 1/2 < γ < 2/3 (Mathlib's numeric bounds)",
+      "harmonic_six / gamma_enclosure_six: the concrete rational bracket 49/20 − log 7 < γ < 49/20 − log 6 from the n = 6 enclosure"
+    ]
+  },
+  "description": "Answers the parent integral-test entry's open question. The parent applied the antitone integral comparison to f(x) = 1/x and bounded the harmonic defect aₙ = Hₙ − log(n+1) in [0,1] (harmonic_sub_log_nonneg, harmonic_succ_sub_log_le_one), establishing boundedness but stopping short of convergence. Since the defect is also monotone increasing, a bounded-monotone argument forces it to converge; its limit is the Euler–Mascheroni constant γ ≈ 0.5772. This entry bridges the parent's setup to Mathlib's Real.eulerMascheroniConstant: it states the convergence in both the parent's form Hₙ − log(n+1) → γ and the textbook form Hₙ − log n → γ (so Hₙ ∼ log n + γ), exhibits the two-sided bracketing Hₙ − log(n+1) < γ < Hₙ − log n with bracket width log(n+1) − log n → 0, and records 0 < γ < 1 sharpened to 1/2 < γ < 2/3, plus a concrete rational enclosure 49/20 − log 7 < γ < 49/20 − log 6 at n = 6. 12 theorems, 0 definitions, 0 sorries, 0 axioms.",
+  "overview": {
+    "historicalContext": "The harmonic numbers Hₙ = 1 + 1/2 + ⋯ + 1/n grow like log n, and the gap Hₙ − log n approaches a constant first studied by Euler in 1734 and denoted γ by Mascheroni. Whether γ is rational or irrational remains open — one of the oldest unsolved problems in analysis. The integral test is precisely the tool that proves γ exists: comparing the staircase ∑ 1/k with the area ∫ 1/x bounds the defect, and monotonicity upgrades the bound to convergence.",
+    "problemStatement": "The parent integral-test entry proved the harmonic defect Hₙ − log(n+1) is bounded in [0,1]. Does it converge, and to what limit?",
+    "text": "The defect aₙ = Hₙ − log(n+1) is increasing (Mathlib: strictMono_eulerMascheroniSeq) and bounded above (the parent's [0,1] bound), so it converges; its limit is the Euler–Mascheroni constant γ := lim (Hₙ − log(n+1)). The companion sequence bₙ = Hₙ − log n is decreasing to the same limit, because bₙ − aₙ = log(n+1) − log n → 0. Together they bracket γ: aₙ < γ < bₙ for all n ≥ 1, a nested family of shrinking intervals that determines γ uniquely. Mathlib's development supplies all of these facts via eulerMascheroniSeq, eulerMascheroniSeq', their monotonicity, the limit lemmas tendsto_harmonic_sub_log(_add_one), the strict bracket bounds, and the numeric estimate 1/2 < γ < 2/3; this entry packages them as the direct continuation of the parent's bounded-defect result.",
+    "proofStrategy": "Each theorem is a short bridge to Mathlib's Euler–Mascheroni API. tendsto_harmonic_sub_log_add_one and tendsto_harmonic_sub_log are the two limit lemmas verbatim. harmonic_sub_log_add_one_lt_gamma unfolds eulerMascheroniSeq in eulerMascheroniSeq_lt_eulerMascheroniConstant; gamma_lt_harmonic_sub_log unfolds eulerMascheroniSeq' (using its n ≠ 0 branch) in eulerMascheroniConstant_lt_eulerMascheroniSeq'. gamma_mem_Ioo pairs the two. bracket_width is a ring identity; tendsto_bracket_width subtracts the two convergent bracket sequences (both → γ) so the difference → 0, then rewrites the limit point with sub_self and matches the function pointwise by ring. gamma_pos / gamma_lt_one chain Mathlib's 1/2 < γ and γ < 2/3 through norm_num; harmonic_six computes H₆ = 49/20 by norm_num on the harmonic sum; gamma_enclosure_six substitutes it into the n = 6 brackets.",
+    "keyInsights": [
+      "Boundedness alone (the parent's result) does not give a limit; monotonicity of the same defect sequence is the extra ingredient that upgrades the integral-test bound to convergence",
+      "The shift from log(n+1) to log n changes the individual terms but not the limit, since the bracket width log(n+1) − log n = log(1 + 1/n) → 0 — and this is exactly why Hₙ − log n and Hₙ − log(n+1) define the same constant γ",
+      "γ is squeezed between an increasing sequence (Hₙ − log(n+1)) and a decreasing sequence (Hₙ − log n); the two parent-style sequences are a nested-interval scheme that determines γ to any precision",
+      "The integral test thus does more than decide convergence of ∑ 1/n — it manufactures the precise growth correction Hₙ = log n + γ + o(1)"
+    ],
+    "prerequisites": [
+      "Harmonic numbers and the integral-test defect from the parent entry",
+      "Monotone bounded sequences converge; squeezing limits with sub_self",
+      "Mathlib's Real.eulerMascheroniConstant, eulerMascheroniSeq, eulerMascheroniSeq' and their limit / bound lemmas",
+      "Filter.Tendsto and basic order limit lemmas"
+    ]
+  },
+  "sections": null,
+  "conclusion": {
+    "summary": "The parent's bounded harmonic defect Hₙ − log(n+1) is shown to converge to the Euler–Mascheroni constant γ, in both the parent's form and the textbook form Hₙ − log n → γ (so Hₙ ∼ log n + γ). The two parent-style sequences bracket γ from below and above with width log(n+1) − log n → 0, giving a nested enclosure; γ satisfies 0 < γ < 1, sharpened to 1/2 < γ < 2/3, with the concrete bracket 49/20 − log 7 < γ < 49/20 − log 6 at n = 6. 12 theorems, 0 definitions, 124 lines, 0 sorries, 0 axioms.",
+    "implications": "Completes the integral-test story for the harmonic series: the parent proved the defect bounded, this entry proves it convergent and names the limit, turning the integral comparison into the asymptotic Hₙ = log n + γ + o(1). The bracketing scheme is a constructive enclosure of γ to arbitrary precision.",
+    "openQuestions": [
+      "Quantify the convergence rate: show Hₙ − log n − γ = 1/(2n) + O(1/n²) via the next Euler–Maclaurin term",
+      "Package the analogous defect for a general antitone f with ∫₁^∞ f = ∞ (the generalized Euler constant of f), proving ∑_{k≤n} f(k) − ∫₁^n f converges"
+    ]
+  },
+  "references": null,
+  "crossReferences": null,
+  "sorries": null
+}


### PR DESCRIPTION
## Summary

Answers the open question left by the parent **Integral Test** entry (`antitone-integral-sum-comparison-oq-01`). The parent applied the antitone integral comparison to `f(x) = 1/x` and bounded the **harmonic defect** `aₙ = Hₙ − log(n+1)` in `[0,1]` (`harmonic_sub_log_nonneg`, `harmonic_succ_sub_log_le_one`) — establishing **boundedness** but stopping short of **convergence**.

Since the defect is also monotone increasing, a bounded-monotone argument forces it to converge; its limit is the **Euler–Mascheroni constant** `γ ≈ 0.5772`. This entry bridges the parent's setup to Mathlib's `Real.eulerMascheroniConstant`.

## Results (12 theorems, 0 def, 0 sorries, 0 axioms)

- `tendsto_harmonic_sub_log_add_one` — the parent's exact sequence `Hₙ − log(n+1) → γ`
- `tendsto_harmonic_sub_log` — textbook form `Hₙ − log n → γ`, i.e. `Hₙ ∼ log n + γ`
- `harmonic_sub_log_add_one_lt_gamma` / `gamma_lt_harmonic_sub_log` — two-sided bracketing `Hₙ − log(n+1) < γ < Hₙ − log n` (`n ≥ 1`)
- `gamma_mem_Ioo` — nested enclosure `γ ∈ (Hₙ − log(n+1), Hₙ − log n)`
- `bracket_width` / `tendsto_bracket_width` — width `log(n+1) − log n → 0`, pinning γ to arbitrary precision
- `gamma_pos` / `gamma_lt_one` / `gamma_mem_Ioo_half_twoThirds` — `0 < γ < 1`, sharpened to `1/2 < γ < 2/3`
- `harmonic_six` / `gamma_enclosure_six` — concrete rational bracket `49/20 − log 7 < γ < 49/20 − log 6`

## Verification

`lake env lean` typechecks clean; `#print axioms` on the main results shows only the standard triple (`propext`, `Classical.choice`, `Quot.sound`). **Badge: `mathlib`** — the substance is Mathlib's Euler–Mascheroni development; this entry packages it as the direct continuation of the parent's bounded-defect result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)