### PR TITLE
research(cayleys-theorem-oq-01-oq-01-oq-01): sharper Cayley via coset action — G with index-k subgroup embeds in Sₖ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -652,6 +652,7 @@ import Proofs.CayleyHamiltonReductionOQ02OQ01Aristotle
 import Proofs.CayleyMengerHeronOQ05
 import Proofs.CayleysTheoremOQ01
 import Proofs.CayleysTheoremOQ01OQ01
+import Proofs.CayleysTheoremOQ01OQ01OQ01
 import Proofs.CayleysTheoremOQ01OQ01OQ02
 import Proofs.CayleysTheoremOQ01OQ01OQ02OQ01OQ02OQ01OQ01
 import Proofs.CayleysTheoremOQ01OQ01OQ02OQ02

--- a/proofs/Proofs/CayleysTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/CayleysTheoremOQ01OQ01OQ01.lean
@@ -1,0 +1,161 @@
+/-
+Proof: Sharper Cayley — a group with a subgroup of index k embeds in Sₖ
+Research: cayleys-theorem-oq-01-oq-01-oq-01
+
+Open question (from `cayleys-theorem-oq-01-oq-01`): "Sharpen n: a group of order
+n with a subgroup of index k embeds in S_k (the coset action), often far smaller
+than S_n; formalize the minimal-degree faithful permutation representation."
+
+Method: replace the *left-regular* representation `G →* Sym(G)` (degree n = |G|)
+by the *coset action* `G →* Sym(G ⧸ H)` (degree k = [G : H]).  The kernel of the
+coset action is the **normal core** `H.normalCore` (the largest normal subgroup
+of G contained in H), so the action is faithful exactly when H is *core-free*.
+In that case G embeds into `Sym(G ⧸ H)`, and transporting along a relabelling
+`G ⧸ H ≃ Fin k` lands G inside the standard symmetric group `Sₖ`.
+
+Since `k = [G : H] ≤ |G| = n` (with equality only for `H = ⊥`), this is the
+degree-`n!`-to-`k!` improvement over the parent's finite Cayley embedding; taking
+`H = ⊥` recovers the regular representation as the special case.
+-/
+
+import Mathlib.GroupTheory.GroupAction.Quotient
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Perm.Basic
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Logic.Equiv.Fin.Basic
+import Mathlib.Tactic
+
+/-
+# Sharper Cayley: the coset action `G →* Sym(G ⧸ H)`
+
+The parent entry embeds a finite group `G` of order `n` into `Sₙ` via the
+left-regular representation.  Here we sharpen the degree: for any subgroup
+`H ≤ G` of index `k`, the action of `G` on the set of left cosets `G ⧸ H` gives
+a homomorphism `cosetActionHom H : G →* Equiv.Perm (G ⧸ H)` into the symmetric
+group on `k` points.
+
+* Its kernel is `H.normalCore` (`cosetActionHom_ker`).
+* Hence it is injective iff `H` is core-free (`cosetActionHom_injective_iff`),
+  and then `G ↪ Sym(G ⧸ H)` (`exists_faithful_coset_rep`).
+* In every case `G ⧸ H.normalCore` embeds into `Sym(G ⧸ H)`
+  (`exists_quotient_faithful_rep`).
+* Transporting along `G ⧸ H ≃ Fin k` gives a representation into the concrete
+  `Sₖ = Equiv.Perm (Fin k)` (`exists_faithful_rep_on_fin`).
+* The degree drops from `n` to `k = [G : H] ≤ n` (`index_le_card`), i.e. from a
+  symmetric group of size `n!` to one of size `k!` (`card_perm_coset`).
+* Taking `H = ⊥` recovers the classical Cayley embedding (`bot_core_free`).
+-/
+
+namespace CayleyCoset
+
+open Equiv MulAction
+
+variable {G : Type*} [Group G] (H : Subgroup G)
+
+/-- Conjugation by a fixed bijection `e : α ≃ β`, packaged as a multiplicative
+isomorphism `Equiv.Perm α ≃* Equiv.Perm β` (relabelling of permutations). -/
+def permCongrMulEquiv {α β : Type*} (e : α ≃ β) : Equiv.Perm α ≃* Equiv.Perm β where
+  toEquiv := Equiv.permCongr e
+  map_mul' x y := by
+    ext b
+    simp [Equiv.permCongr_apply, Equiv.Perm.mul_apply]
+
+/-- The **coset action homomorphism**: `G` acts on the left cosets `G ⧸ H` by
+left multiplication, giving the permutation representation `G →* Sym(G ⧸ H)`. -/
+def cosetActionHom : G →* Equiv.Perm (G ⧸ H) := MulAction.toPermHom G (G ⧸ H)
+
+@[simp] theorem cosetActionHom_apply (g : G) (q : G ⧸ H) :
+    cosetActionHom H g q = g • q := rfl
+
+/-- The kernel of the coset action is the **normal core** of `H`: the largest
+normal subgroup of `G` contained in `H`. -/
+theorem cosetActionHom_ker : (cosetActionHom H).ker = H.normalCore :=
+  (Subgroup.normalCore_eq_ker H).symm
+
+/-- The coset action is faithful (injective) exactly when `H` is **core-free**
+(`H.normalCore = ⊥`). -/
+theorem cosetActionHom_injective_iff :
+    Function.Injective (cosetActionHom H) ↔ H.normalCore = ⊥ := by
+  rw [← MonoidHom.ker_eq_bot_iff, cosetActionHom_ker]
+
+/-- **Sharper Cayley (faithful form).** If `H` is core-free, then `G` embeds into
+the symmetric group on its `[G : H]` cosets `G ⧸ H`. -/
+theorem exists_faithful_coset_rep (hcore : H.normalCore = ⊥) :
+    ∃ f : G →* Equiv.Perm (G ⧸ H), Function.Injective f :=
+  ⟨cosetActionHom H, (cosetActionHom_injective_iff H).mpr hcore⟩
+
+/-- The coset action always realises the quotient `G ⧸ H.normalCore` as a
+subgroup of `Sym(G ⧸ H)`: the first isomorphism theorem identifies it with the
+image of the coset action, regardless of whether `H` is core-free. -/
+noncomputable def cosetQuotientEquivRange :
+    G ⧸ H.normalCore ≃* (cosetActionHom H).range :=
+  (QuotientGroup.quotientMulEquivOfEq (cosetActionHom_ker H).symm).trans
+    (QuotientGroup.quotientKerEquivRange (cosetActionHom H))
+
+/-- For an arbitrary subgroup `H`, the quotient `G ⧸ H.normalCore` embeds into
+`Sym(G ⧸ H)`. -/
+theorem exists_quotient_faithful_rep :
+    ∃ f : G ⧸ H.normalCore →* Equiv.Perm (G ⧸ H), Function.Injective f :=
+  ⟨(cosetActionHom H).range.subtype.comp (cosetQuotientEquivRange H).toMonoidHom,
+    (cosetActionHom H).range.subtype_injective.comp
+      (cosetQuotientEquivRange H).injective⟩
+
+/-- The coset action transported into the **concrete** symmetric group
+`Sₖ = Equiv.Perm (Fin k)` along a relabelling `e : G ⧸ H ≃ Fin k`. -/
+def cosetActionFinHom {k : ℕ} (e : G ⧸ H ≃ Fin k) : G →* Equiv.Perm (Fin k) :=
+  (permCongrMulEquiv e).toMonoidHom.comp (cosetActionHom H)
+
+theorem cosetActionFinHom_injective {k : ℕ} (e : G ⧸ H ≃ Fin k)
+    (hcore : H.normalCore = ⊥) : Function.Injective (cosetActionFinHom H e) := by
+  have h := (cosetActionHom_injective_iff H).mpr hcore
+  exact ((permCongrMulEquiv e).injective).comp h
+
+/-- **Sharper Cayley (concrete form).** A group with a core-free subgroup of
+index `k` embeds in the standard symmetric group `Sₖ = Equiv.Perm (Fin k)`. -/
+theorem exists_faithful_rep_on_fin [Fintype (G ⧸ H)] {k : ℕ}
+    (hk : Fintype.card (G ⧸ H) = k) (hcore : H.normalCore = ⊥) :
+    ∃ f : G →* Equiv.Perm (Fin k), Function.Injective f := by
+  subst hk
+  exact ⟨cosetActionFinHom H (Fintype.equivFin _),
+    cosetActionFinHom_injective H (Fintype.equivFin _) hcore⟩
+
+/-- The degree of the coset representation is `[G : H] = |G ⧸ H|`. -/
+theorem coset_degree_eq_index : H.index = Nat.card (G ⧸ H) :=
+  H.index_eq_card
+
+/-- The coset degree `k = [G : H]` never exceeds the order `n = |G|`: the
+coset action sits inside `Sₖ` with `Sₖ ≤ Sₙ`. -/
+theorem index_le_card [Finite G] : H.index ≤ Nat.card G :=
+  Nat.le_of_dvd Nat.card_pos H.index_dvd_card
+
+/-- Lagrange in degree form: `[G : H] = |G| / |H|`, so the coset degree is a
+proper divisor of `n` whenever `H` is nontrivial — the source of the
+`n! → k!` shrink in the size of the ambient symmetric group. -/
+theorem index_mul_card_eq : H.index * Nat.card H = Nat.card G :=
+  H.index_mul_card
+
+/-- The ambient symmetric group of the coset representation has order `k!`
+(versus `n!` for the regular representation). -/
+theorem card_perm_coset [Fintype (G ⧸ H)] [DecidableEq (G ⧸ H)] :
+    Fintype.card (Equiv.Perm (G ⧸ H)) = Nat.factorial (Fintype.card (G ⧸ H)) :=
+  Fintype.card_perm
+
+/-- The trivial subgroup is core-free, and its index is `|G|`; thus the parent's
+classical Cayley embedding `G ↪ Sₙ` is exactly the `H = ⊥` special case of the
+coset construction (`G ⧸ ⊥ ≃ G`). -/
+theorem bot_core_free : (⊥ : Subgroup G).normalCore = ⊥ :=
+  Subgroup.normalCore_eq_self ⊥
+
+example : (⊥ : Subgroup G).index = Nat.card G := Subgroup.index_bot
+
+/-- Worked instance: `S₃ = Equiv.Perm (Fin 3)` has a core-free subgroup of index
+`3` (any point-stabiliser), so it embeds back into `S₃` — degree `3`, far below
+the regular degree `|S₃| = 6` that Cayley's theorem would give.  We state the
+abstract guarantee the construction provides for any such subgroup. -/
+example (H : Subgroup (Equiv.Perm (Fin 3))) [Fintype (Equiv.Perm (Fin 3) ⧸ H)]
+    (hk : Fintype.card (Equiv.Perm (Fin 3) ⧸ H) = 3) (hcore : H.normalCore = ⊥) :
+    ∃ f : Equiv.Perm (Fin 3) →* Equiv.Perm (Fin 3), Function.Injective f :=
+  exists_faithful_rep_on_fin H hk hcore
+
+end CayleyCoset

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "cayley-oq010101-ann-header",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 56 },
+    "type": "concept",
+    "title": "Sharpening the degree: from Sₙ to Sₖ via the coset action",
+    "content": "The parent embeds a group of order $n$ into $S_n$ by the left-regular representation. Here the degree is sharpened to $k = [G:H]$ for a subgroup $H$: $G$ acts on the $k$ left cosets $G/H$, giving a homomorphism into $\\mathrm{Sym}(G/H)$. The crux is that the kernel of this action is the *normal core* $\\mathrm{core}_G(H)$ — the largest normal subgroup of $G$ inside $H$ — so the action is faithful exactly when $H$ is core-free. Then $G \\hookrightarrow S_k$ with $k \\le n$, often far smaller; taking $H = \\bot$ recovers the parent.",
+    "mathContext": "$G \\hookrightarrow S_k$, \\; $k = [G:H] \\le n = |G|$.",
+    "significance": "key",
+    "relatedConcepts": ["coset action", "normal core", "core-free subgroup", "minimal-degree permutation representation"],
+    "prerequisites": ["group actions", "cosets and index"]
+  },
+  {
+    "id": "cayley-oq010101-ann-permcongr",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 57, "endLine": 64 },
+    "type": "definition",
+    "title": "permCongrMulEquiv — relabelling permutations multiplicatively",
+    "content": "Bundles conjugation by a fixed bijection $e : \\alpha \\simeq \\beta$ as a `MulEquiv` $\\mathrm{Perm}\\,\\alpha \\simeq^* \\mathrm{Perm}\\,\\beta$ (underlying `Equiv.permCongr`), with `map_mul'` discharged by `ext`+`simp`. This is the device that turns the abstract symmetric group $\\mathrm{Sym}(G/H)$ into the concrete standard $S_k = \\mathrm{Perm}(\\mathrm{Fin}\\,k)$ once the $k$ cosets are numbered.",
+    "mathContext": "$\\sigma \\mapsto e\\,\\sigma\\,e^{-1}$ is an isomorphism $\\mathrm{Sym}(\\alpha) \\cong \\mathrm{Sym}(\\beta)$.",
+    "significance": "standard",
+    "relatedConcepts": ["conjugation", "MulEquiv", "permutation relabelling"],
+    "prerequisites": ["Equiv.permCongr", "multiplicative isomorphisms"]
+  },
+  {
+    "id": "cayley-oq010101-ann-coset-action-ker",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 82 },
+    "type": "key-step",
+    "title": "The coset action and its kernel = normal core",
+    "content": "`cosetActionHom H := MulAction.toPermHom G (G ⧸ H)` is the permutation representation of $G$ on its left cosets, with `cosetActionHom H g q = g • q`. The central fact `cosetActionHom_ker` states $\\ker = H.\\mathrm{normalCore}$ — an element acts trivially on *every* coset iff it lies in every conjugate of $H$, i.e. in the normal core. This restates Mathlib's `Subgroup.normalCore_eq_ker` in kernel-first form and is the mathematical heart of the whole entry. Combined with `MonoidHom.ker_eq_bot_iff`, `cosetActionHom_injective_iff` gives the clean criterion: the coset action is faithful $\\iff$ $H$ is core-free.",
+    "mathContext": "$\\ker(g \\mapsto (xH \\mapsto gxH)) = \\bigcap_{g} gHg^{-1} = \\mathrm{core}_G(H)$.",
+    "significance": "critical",
+    "relatedConcepts": ["normal core", "kernel of an action", "core-free subgroup", "faithful action"],
+    "prerequisites": ["MulAction.toPermHom", "Subgroup.normalCore"]
+  },
+  {
+    "id": "cayley-oq010101-ann-faithful-rep",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 84, "endLine": 103 },
+    "type": "key-step",
+    "title": "Faithful embedding, and the quotient embedding for arbitrary H",
+    "content": "When $H$ is core-free, `exists_faithful_coset_rep` produces $G \\hookrightarrow \\mathrm{Sym}(G/H)$. For an *arbitrary* $H$, the first isomorphism theorem (`QuotientGroup.quotientKerEquivRange`) together with the kernel computation gives `cosetQuotientEquivRange : G ⧸ H.normalCore ≃* range`, hence `exists_quotient_faithful_rep`: the quotient $G/\\mathrm{core}_G(H)$ always embeds into $\\mathrm{Sym}(G/H)$. So the normal core is the exact obstruction to faithfulness — nothing else can collapse.",
+    "mathContext": "$G/\\mathrm{core}_G(H) \\;\\cong\\; \\mathrm{im} \\;\\le\\; \\mathrm{Sym}(G/H)$.",
+    "significance": "key",
+    "relatedConcepts": ["first isomorphism theorem", "faithful representation", "quotient group"],
+    "prerequisites": ["QuotientGroup.quotientKerEquivRange", "MonoidHom.range"]
+  },
+  {
+    "id": "cayley-oq010101-ann-concrete-sk",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 105, "endLine": 122 },
+    "type": "key-step",
+    "title": "Landing in the concrete Sₖ = Perm(Fin k)",
+    "content": "Numbering the $k$ cosets by `e : G ⧸ H ≃ Fin k` and conjugating with `permCongrMulEquiv` gives `cosetActionFinHom : G →* Equiv.Perm (Fin k)`, injective when $H$ is core-free (`cosetActionFinHom_injective`). Instantiating at `Fintype.equivFin` yields `exists_faithful_rep_on_fin`: a core-free subgroup of index $k$ produces a genuine embedding $G \\hookrightarrow S_k$, with $k = $ `Fintype.card (G ⧸ H)` $= [G:H]$.",
+    "mathContext": "$G \\hookrightarrow S_k = \\mathrm{Perm}(\\mathrm{Fin}\\,k)$, \\; $k = [G:H]$.",
+    "significance": "key",
+    "relatedConcepts": ["standard symmetric group", "Fintype.equivFin", "permutation relabelling"],
+    "prerequisites": ["Fintype.equivFin", "permCongrMulEquiv"]
+  },
+  {
+    "id": "cayley-oq010101-ann-degree",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 161 },
+    "type": "concept",
+    "title": "Degree analysis and the H = ⊥ special case",
+    "content": "`coset_degree_eq_index` identifies the degree with $[G:H]$; `index_le_card` (from `index_dvd_card`) gives $k \\le n$; `index_mul_card_eq` is Lagrange $k\\,|H| = n$; and `card_perm_coset` gives $|\\mathrm{Sym}(G/H)| = k!$. So the ambient symmetric group shrinks from order $n!$ to $k!$. Finally `bot_core_free` shows $\\bot$ is core-free of index $n$, exhibiting the parent's regular representation $G \\hookrightarrow S_n$ as exactly the $H = \\bot$ instance — this entry strictly generalizes it. The worked $S_3$ example notes a point-stabiliser of index $3$ gives $S_3 \\hookrightarrow S_3$ (degree $3$), far below the regular degree $|S_3| = 6$.",
+    "mathContext": "$k = [G:H] \\le n$, \\; ambient group $k! \\le n!$; \\; $H=\\bot \\Rightarrow k = n$.",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange's theorem", "subgroup index", "factorial growth", "minimal degree"],
+    "prerequisites": ["Subgroup.index", "Fintype.card_perm"]
+  }
+]

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleysTheoremOQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleysTheoremOq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleysTheoremOq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleysTheoremOq01Oq01Oq01Data: ProofData = {
+  proof: cayleysTheoremOq01Oq01Oq01Proof,
+  annotations: cayleysTheoremOq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,206 @@
+{
+  "id": "cayleys-theorem-oq-01-oq-01-oq-01",
+  "title": "Sharper Cayley: a Group with a Subgroup of Index k Embeds in Sₖ",
+  "slug": "cayleys-theorem-oq-01-oq-01-oq-01",
+  "description": "Sharpens the degree of the finite Cayley embedding from n = |G| down to k = [G : H]. Where the parent (cayleys-theorem-oq-01-oq-01) embeds a finite group of order n into Sₙ via the left-regular representation, this entry uses the coset action: G acts on the set of left cosets G ⧸ H by left multiplication, giving a homomorphism cosetActionHom H := MulAction.toPermHom G (G ⧸ H) : G →* Equiv.Perm (G ⧸ H) into the symmetric group on the k = [G : H] cosets. The kernel of this action is exactly the normal core H.normalCore — the largest normal subgroup of G contained in H (cosetActionHom_ker, from Mathlib's Subgroup.normalCore_eq_ker) — so the action is faithful precisely when H is core-free (cosetActionHom_injective_iff: Injective ↔ H.normalCore = ⊥). When H is core-free, G embeds into Sym(G ⧸ H) (exists_faithful_coset_rep) and, transporting along a numbering G ⧸ H ≃ Fin k, into the concrete standard symmetric group Sₖ = Equiv.Perm (Fin k) (exists_faithful_rep_on_fin). For an arbitrary H the first isomorphism theorem realises the quotient G ⧸ H.normalCore as a subgroup of Sym(G ⧸ H) (cosetQuotientEquivRange, exists_quotient_faithful_rep). The degree drops from n to k = [G : H] ≤ |G| (index_le_card), i.e. the ambient symmetric group shrinks from order n! to k! (card_perm_coset). Taking H = ⊥ (core-free, of index n; bot_core_free) recovers the parent's regular-representation Cayley embedding as the special case, so this is a strict generalization that answers the parent's first listed open question.",
+  "meta": {
+    "author": "Classical (coset action / permutation representation); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Cayley%27s_theorem",
+    "date": "2026-06-23",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "cayley",
+      "coset-action",
+      "permutation-representation",
+      "normal-core",
+      "core-free",
+      "symmetric-group",
+      "subgroup-index",
+      "group-action",
+      "embedding",
+      "algebra",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/CayleysTheoremOQ01OQ01OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "MulAction.toPermHom",
+        "description": "G →* Equiv.Perm α for a group action — instantiated at the left coset action of G on G ⧸ H to give the coset permutation representation cosetActionHom",
+        "module": "Mathlib.Algebra.Group.Action.End"
+      },
+      {
+        "theorem": "Subgroup.normalCore_eq_ker",
+        "description": "H.normalCore = (MulAction.toPermHom G (G ⧸ H)).ker — the mathematical heart: identifies the kernel of the coset action with the normal core of H, giving the faithfulness criterion",
+        "module": "Mathlib.GroupTheory.GroupAction.Quotient"
+      },
+      {
+        "theorem": "MonoidHom.ker_eq_bot_iff",
+        "description": "f.ker = ⊥ ↔ Function.Injective f — converts the kernel computation into the 'faithful ⟺ core-free' equivalence",
+        "module": "Mathlib.Algebra.Group.Subgroup.Ker"
+      },
+      {
+        "theorem": "QuotientGroup.quotientKerEquivRange",
+        "description": "first isomorphism theorem G ⧸ ker f ≃* range f — used to realise G ⧸ H.normalCore as a subgroup of Sym(G ⧸ H) for arbitrary H",
+        "module": "Mathlib.GroupTheory.QuotientGroup.Basic"
+      },
+      {
+        "theorem": "Subgroup.index_eq_card",
+        "description": "H.index = Nat.card (G ⧸ H) — identifies the representation degree k with the subgroup index [G : H]",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Subgroup.index_dvd_card",
+        "description": "H.index ∣ Nat.card G — gives index_le_card, the degree comparison k = [G : H] ≤ n = |G| that makes the coset embedding sharper than the regular one",
+        "module": "Mathlib.GroupTheory.Index"
+      },
+      {
+        "theorem": "Fintype.card_perm",
+        "description": "Fintype.card (Equiv.Perm α) = (Fintype.card α)! — quantifies the ambient symmetric group as k! versus the regular representation's n!",
+        "module": "Mathlib.Data.Fintype.Perm"
+      },
+      {
+        "theorem": "Subgroup.normalCore_eq_self",
+        "description": "a normal subgroup equals its own normal core — gives bot_core_free ((⊥).normalCore = ⊥), recovering the parent's H = ⊥ regular representation as the special case",
+        "module": "Mathlib.Algebra.Group.Subgroup.Basic"
+      }
+    ],
+    "originalContributions": [
+      "cosetActionHom: the coset permutation representation G →* Equiv.Perm (G ⧸ H) packaged as MulAction.toPermHom G (G ⧸ H), with the apply lemma cosetActionHom_apply g q = g • q",
+      "cosetActionHom_ker: the kernel of the coset action is H.normalCore (restating Mathlib's normalCore_eq_ker in kernel-first form)",
+      "cosetActionHom_injective_iff: the coset action is faithful (injective) ⟺ H is core-free (H.normalCore = ⊥) — the precise faithfulness criterion absent as a packaged statement in Mathlib",
+      "exists_faithful_coset_rep: a core-free subgroup of index k yields an embedding G ↪ Sym(G ⧸ H)",
+      "cosetQuotientEquivRange / exists_quotient_faithful_rep: for arbitrary H, G ⧸ H.normalCore embeds in Sym(G ⧸ H) via the first isomorphism theorem",
+      "cosetActionFinHom / cosetActionFinHom_injective / exists_faithful_rep_on_fin: transport along G ⧸ H ≃ Fin k into the concrete standard symmetric group Sₖ = Equiv.Perm (Fin k), faithful when core-free",
+      "coset_degree_eq_index, index_le_card, index_mul_card_eq, card_perm_coset: the degree analysis — k = [G : H] ≤ n with ambient symmetric group of order k! ≤ n!, the quantitative 'far smaller than Sₙ' content",
+      "bot_core_free: ⊥ is core-free of index n, exhibiting the parent's regular-representation Cayley embedding as the H = ⊥ special case of this construction"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 161,
+    "assumptions": "None beyond Mathlib. Fully verified with 0 axioms and 0 sorries (#print axioms reports only the foundational propext / Classical.choice / Quot.sound; no sorryAx, no Lean.ofReduceBool, no decide/native_decide). Tier B: the mathematical core — that the kernel of the coset action is the normal core — is Mathlib's Subgroup.normalCore_eq_ker; this file assembles from it the faithfulness criterion, the index-k embedding into Sₖ, and the n! → k! degree comparison, hence badge 'mathlib'.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 12,
+    "definitionCount": 4
+  },
+  "overview": {
+    "historicalContext": "Cayley's theorem (1854) realises every group as a group of permutations; for a finite group of order n the classical embedding lands in Sₙ. But Sₙ is usually far larger than necessary. The coset action — G permuting the left cosets of a subgroup H — gives a permutation representation of degree only k = [G : H], and is the standard tool for the *minimal-degree faithful permutation representation* of a group. Its kernel is the normal core of H, so it is faithful exactly when H contains no nontrivial normal subgroup of G (H is 'core-free'). This is how one shows, for example, that a simple group with a subgroup of index k embeds in Sₖ (and in Aₖ), a workhorse of finite group theory and the classification of small simple groups.",
+    "problemStatement": "**Open Question (cayleys-theorem-oq-01-oq-01, first follow-up)**: Sharpen the degree n: a group of order n with a subgroup of index k embeds in Sₖ via the coset action, often far smaller than Sₙ; formalize the (minimal-degree) faithful permutation representation.\n\n**Result**: cosetActionHom H : G →* Equiv.Perm (G ⧸ H) with kernel H.normalCore (cosetActionHom_ker); faithfulness criterion cosetActionHom_injective_iff (Injective ↔ core-free); the embeddings exists_faithful_coset_rep and exists_faithful_rep_on_fin (into Sₖ = Equiv.Perm (Fin k)); the general quotient embedding exists_quotient_faithful_rep; and the degree comparison k = [G : H] ≤ n with ambient symmetric group k! ≤ n! (index_le_card, card_perm_coset).",
+    "text": "A subgroup H ≤ G of index k gives an action of G on the k left cosets G ⧸ H. The induced homomorphism G →* Sym(G ⧸ H) has kernel the normal core of H, so it is injective exactly when H is core-free; relabelling the k cosets by Fin k places the image in the standard symmetric group Sₖ. Since k = [G : H] ≤ |G| = n, with equality only for H = ⊥, this embeds G into a symmetric group of degree k — potentially far below the degree n given by the regular representation.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. The coset action. G acts on the left cosets G ⧸ H by g · (xH) = (gx)H. Mathlib packages this as the homomorphism cosetActionHom H := MulAction.toPermHom G (G ⧸ H) : G →* Equiv.Perm (G ⧸ H); on points cosetActionHom H g q = g • q.\n2. Kernel = normal core. The element g acts trivially on every coset iff g lies in every conjugate of H, i.e. in the normal core: cosetActionHom_ker restates Mathlib's Subgroup.normalCore_eq_ker as (cosetActionHom H).ker = H.normalCore.\n3. Faithfulness criterion. Combining with MonoidHom.ker_eq_bot_iff gives cosetActionHom_injective_iff: the coset action is injective ⟺ H.normalCore = ⊥ (H is core-free). When core-free, exists_faithful_coset_rep produces the embedding G ↪ Sym(G ⧸ H).\n4. Concrete Sₖ. A numbering e : G ⧸ H ≃ Fin k turns Sym(G ⧸ H) into the standard Sₖ = Equiv.Perm (Fin k) by conjugation (permCongrMulEquiv); cosetActionFinHom composes the coset action with it, and exists_faithful_rep_on_fin gives the embedding G ↪ Sₖ when core-free, with k = Fintype.card (G ⧸ H) = [G : H].\n5. The general (non-core-free) case. The first isomorphism theorem (QuotientGroup.quotientKerEquivRange) together with the kernel computation gives cosetQuotientEquivRange : G ⧸ H.normalCore ≃* range, hence exists_quotient_faithful_rep embedding G ⧸ H.normalCore in Sym(G ⧸ H).\n6. Degree analysis. coset_degree_eq_index identifies the degree with the index; index_le_card (from index_dvd_card) shows k ≤ n; index_mul_card_eq is the Lagrange relation k · |H| = n; and card_perm_coset gives |Sym(G ⧸ H)| = k!. Taking H = ⊥ (bot_core_free: (⊥).normalCore = ⊥, of index n) recovers the parent's regular-representation embedding into Sₙ.",
+    "keyInsights": [
+      "**The kernel of the coset action is the normal core.** This single fact (Mathlib's Subgroup.normalCore_eq_ker) drives everything: it makes 'faithful' synonymous with 'core-free', so the minimal faithful coset degree is governed by which subgroups contain no nontrivial normal subgroup.",
+      "**Degree k = [G : H], not n = |G|.** The regular representation is the case H = ⊥; any larger core-free H gives a strictly smaller degree, shrinking the ambient symmetric group from order n! to k!. This is the quantitative 'far smaller than Sₙ' the open question asks for.",
+      "**Faithful ⟺ core-free is sharp.** When H is not core-free the action still embeds the quotient G ⧸ H.normalCore (first isomorphism theorem); only the trivial-core obstruction can prevent G itself from embedding.",
+      "**This generalizes the parent, not just supplements it.** Setting H = ⊥ reproduces the left-regular Cayley embedding G ↪ Sₙ; the coset construction is the parent with the codomain index dialed from n down to any achievable k."
+    ],
+    "prerequisites": [
+      "Finite Cayley's theorem via the regular representation (parent entry cayleys-theorem-oq-01-oq-01)",
+      "The action of a group on the cosets of a subgroup, and the normal core of a subgroup (Subgroup.normalCore)",
+      "The first isomorphism theorem and the index/order (Lagrange) relations for subgroups"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Module docstring stating the sharper coset-action form (degree k = [G : H] in place of n = |G|), the normal-core / core-free strategy, imports for group actions on quotients, the first isomorphism theorem, Subgroup.index and Fintype.card_perm, and the namespace with subgroup variable H.",
+      "mathContext": "$G \\hookrightarrow S_k$, $k = [G : H]$, via the action on $G/H$."
+    },
+    {
+      "id": "coset-action",
+      "title": "The Coset Action and its Kernel",
+      "startLine": 57,
+      "endLine": 89,
+      "summary": "permCongrMulEquiv (conjugation Sym α ≃* Sym β), cosetActionHom H := MulAction.toPermHom G (G ⧸ H) with cosetActionHom_apply g q = g • q, the kernel computation cosetActionHom_ker (= H.normalCore), the faithfulness criterion cosetActionHom_injective_iff (Injective ↔ core-free), and exists_faithful_coset_rep.",
+      "mathContext": "$\\ker(\\text{coset action}) = \\mathrm{core}_G(H)$; faithful $\\iff$ core-free."
+    },
+    {
+      "id": "quotient-embedding",
+      "title": "The Quotient Embedding (Arbitrary H)",
+      "startLine": 90,
+      "endLine": 104,
+      "summary": "cosetQuotientEquivRange : G ⧸ H.normalCore ≃* (cosetActionHom H).range via QuotientGroup.quotientKerEquivRange and the kernel computation, and exists_quotient_faithful_rep embedding G ⧸ H.normalCore into Sym(G ⧸ H) for any H.",
+      "mathContext": "$G/\\mathrm{core}_G(H) \\hookrightarrow \\mathrm{Sym}(G/H)$."
+    },
+    {
+      "id": "concrete-sk",
+      "title": "Embedding into the Concrete Sₖ",
+      "startLine": 105,
+      "endLine": 122,
+      "summary": "cosetActionFinHom (transport along e : G ⧸ H ≃ Fin k), cosetActionFinHom_injective, and exists_faithful_rep_on_fin: a core-free subgroup of index k gives an embedding G ↪ Equiv.Perm (Fin k) = Sₖ with k = Fintype.card (G ⧸ H).",
+      "mathContext": "$G \\hookrightarrow S_k = \\mathrm{Perm}(\\mathrm{Fin}\\,k)$."
+    },
+    {
+      "id": "degree-analysis",
+      "title": "Degree Analysis and the H = ⊥ Special Case",
+      "startLine": 123,
+      "endLine": 161,
+      "summary": "coset_degree_eq_index (degree = [G : H]), index_le_card (k ≤ n), index_mul_card_eq (Lagrange k·|H| = n), card_perm_coset (|Sym(G ⧸ H)| = k!), bot_core_free recovering the parent's regular representation as H = ⊥, plus worked examples (index of ⊥; the S₃ point-stabiliser embedding S₃ ↪ S₃ of degree 3 < 6).",
+      "mathContext": "$k = [G:H] \\le n$, ambient group $k! \\le n!$; $H = \\bot$ gives degree $n$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "cayleys-theorem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: embeds a finite group of order n into Sₙ via the left-regular representation. This entry sharpens the degree to k = [G : H] via the coset action, recovering the parent as the H = ⊥ special case and answering its first open question."
+    },
+    {
+      "targetId": "cayleys-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the abstract Cayley theorem G ↪ Sym(G). The coset action replaces the regular self-action by the action on cosets of a subgroup."
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of the sharper, coset-action form of Cayley's theorem. The coset action cosetActionHom H : G →* Sym(G ⧸ H) has kernel H.normalCore (cosetActionHom_ker), so it is faithful iff H is core-free (cosetActionHom_injective_iff); when core-free, G embeds in Sₖ = Equiv.Perm (Fin k) with k = [G : H] (exists_faithful_rep_on_fin), and for arbitrary H the quotient G ⧸ H.normalCore embeds in Sym(G ⧸ H) (exists_quotient_faithful_rep). The degree k = [G : H] ≤ n (index_le_card) shrinks the ambient symmetric group from order n! to k! (card_perm_coset), and H = ⊥ recovers the parent's regular representation.",
+    "implications": "Provides the standard route to minimal-degree faithful permutation representations: faithfulness is governed entirely by the normal core, and the achievable degrees are the indices of core-free subgroups. This is the lever behind embeddings of simple groups into small Sₖ and the index-vs-order bounds used throughout finite group theory.",
+    "openQuestions": [
+      "Characterize the minimal faithful degree μ(G) = min over core-free H of [G : H] for specific families (e.g. cyclic, dihedral, simple groups) and prove the resulting embeddings into the minimal Sₖ.",
+      "Show that when [G : H] = k is the smallest prime dividing |G|, H is automatically normal (so the coset action realises G as a transitive subgroup of Sₖ with G/H cyclic) — the index-smallest-prime normality theorem as a corollary of the coset action."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.GroupTheory.GroupAction.Quotient",
+      "Mathlib.GroupTheory.QuotientGroup.Basic",
+      "Mathlib.GroupTheory.Index",
+      "Mathlib.GroupTheory.Perm.Basic",
+      "Mathlib.Data.Fintype.Perm",
+      "Mathlib.Logic.Equiv.Fin.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Equiv",
+      "MulAction"
+    ],
+    "namespace": "CayleyCoset",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 4,
+    "path": "Proofs/CayleysTheoremOQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Cayley, Arthur",
+      "title": "On the theory of groups, as depending on the symbolic equation θⁿ = 1",
+      "year": "1854",
+      "venue": "Philosophical Magazine, Series 4, 7(42)",
+      "note": "Original statement that every group can be represented as a group of permutations"
+    },
+    {
+      "authors": "Dummit, David S.; Foote, Richard M.",
+      "title": "Abstract Algebra",
+      "year": "2004",
+      "venue": "Wiley (3rd ed.)",
+      "note": "The coset action of a group on G/H, its kernel as the normal core, and faithfulness for core-free subgroups (minimal-degree permutation representations)"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `cayleys-theorem-oq-01-oq-01` (*Finite Cayley's Theorem*): sharpen the embedding degree from `n = |G|` to `k = [G : H]` using the **coset action** of `G` on the left cosets `G ⧸ H`.

Where the parent embeds a group of order `n` into `Sₙ` via the left-regular representation, this entry embeds `G` into `Sₖ` with `k = [G : H] ≤ n` — often dramatically smaller. The parent is recovered as the `H = ⊥` special case.

## Results (`proofs/Proofs/CayleysTheoremOQ01OQ01OQ01.lean`, namespace `CayleyCoset`)

- **`cosetActionHom H : G →* Equiv.Perm (G ⧸ H)`** — the coset permutation representation
- **`cosetActionHom_ker`** — kernel = `H.normalCore` (largest normal subgroup of `G` inside `H`), via Mathlib's `Subgroup.normalCore_eq_ker`
- **`cosetActionHom_injective_iff`** — the action is faithful ⟺ `H` is core-free (`H.normalCore = ⊥`)
- **`exists_faithful_coset_rep`** / **`exists_faithful_rep_on_fin`** — a core-free subgroup of index `k` gives `G ↪ Sₖ = Equiv.Perm (Fin k)`
- **`exists_quotient_faithful_rep`** — for arbitrary `H`, `G ⧸ H.normalCore ↪ Sym(G ⧸ H)` (first isomorphism theorem)
- **`index_le_card`**, **`index_mul_card_eq`**, **`card_perm_coset`** — degree analysis: `k = [G : H] ≤ n`, ambient symmetric group of order `k! ≤ n!`
- **`bot_core_free`** — `H = ⊥` is core-free of index `n`, exhibiting the parent's regular representation as the special case (strict generalization)

## Verification

- **12 theorems, 4 definitions, 161 lines**
- Kernel-verified on Lean/Mathlib **v4.26.0** (`lake env lean`, exit 0)
- `#print axioms` reports only `propext` / `Classical.choice` / `Quot.sound` — **0 axioms, 0 sorries**, no `sorryAx`, no `Lean.ofReduceBool`
- `status: verified`, `badge: mathlib` (the mathematical core — kernel = normal core — is Mathlib's `normalCore_eq_ker`; this file assembles the faithfulness criterion, the index-`k` embedding into `Sₖ`, and the `n! → k!` degree comparison)

## Gallery

Adds `src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-01/` (meta.json, annotations.json, index.ts) and registers the proof in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)