### PR TITLE
Enrich Cayley's Image is a Regular Subgroup of Sₙ: add annotations

### DIFF
--- a/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cayleys-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,194 @@
+[
+  {
+    "id": "ann-cayreg-1",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "context",
+    "title": "Cayley's Theorem in its Regular Form",
+    "content": "**Module framing.** The parent built the finite Cayley homomorphism $\\mathrm{cayleyFinHom}\\,e : G \\to^* \\mathrm{Perm}(\\mathrm{Fin}\\,n)$ from a relabelling $e : G \\simeq \\mathrm{Fin}\\,n$ and proved it injective. This file studies its **image** $H = \\mathrm{range}(\\mathrm{cayleyFinHom}\\,e)$ and proves the three facts that characterise a *regular* permutation group:\n- **transitive** — some $\\sigma \\in H$ sends any $i$ to any $j$;\n- **free (semiregular)** — any $\\sigma \\in H$ fixing one point is the identity;\n- **sharply transitive** — combining these, a *unique* $\\sigma \\in H$ with $\\sigma i = j$.\n\nTogether with $|H| = n$, this identifies $H$ as the regular permutation group of degree $n$ — the concrete content of 'Cayley realises $G$ as a regular subgroup of $S_n$'.",
+    "mathContext": "A permutation group is **regular** iff it is transitive and free, equivalently sharply transitive: the action $H \\curvearrowright \\{1,\\dots,n\\}$ is a torsor, so $|H| = n$ and $H$ is isomorphic (as an $H$-set) to its own left-multiplication action. This is exactly the image of the left-regular representation.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Left-regular representation",
+      "Regular permutation group",
+      "Group action / torsor",
+      "Cayley's theorem"
+    ],
+    "prerequisites": [
+      "Cayley homomorphism cayleyFinHom (parent)",
+      "Equiv.Perm and subgroups"
+    ],
+    "tags": [
+      "module-header",
+      "regular-subgroup",
+      "framing"
+    ]
+  },
+  {
+    "id": "ann-cayreg-2",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 50,
+      "endLine": 63
+    },
+    "type": "definition",
+    "title": "The Regular Subgroup and its Action Formula",
+    "content": "**`regSubgroup e := (cayleyFinHom e).range`** is $H$, the image of the Cayley map as a `Subgroup (Equiv.Perm (Fin n))`.\n\nTwo helper facts:\n- **`mem_regSubgroup`**: $\\sigma \\in H \\iff \\exists g,\\ \\mathrm{cayleyFinHom}\\,e\\,g = \\sigma$ — membership is `MonoidHom.mem_range`.\n- **`cayleyFinHom_apply_relabel`**: at a *relabelled* point $e\\,x$, the Cayley permutation is just left multiplication, $e\\,x \\mapsto e(g\\cdot x)$. This is the bridge that lets group-theoretic facts about $g$ translate into facts about points of $\\mathrm{Fin}\\,n$.",
+    "mathContext": "Writing points as $e\\,x$ identifies $\\mathrm{Fin}\\,n$ with $G$, under which $\\mathrm{cayleyFinHom}\\,e\\,g$ becomes left translation $L_g : x \\mapsto g x$. The whole proof works by pulling each point back to $G$ via $e^{-1}$ and reasoning with the group law.",
+    "significance": "key",
+    "relatedConcepts": [
+      "MonoidHom.range",
+      "Left translation L_g",
+      "Relabelling e : G ≃ Fin n"
+    ],
+    "prerequisites": [
+      "MonoidHom.mem_range",
+      "Equiv.symm_apply_apply"
+    ],
+    "tags": [
+      "definition",
+      "regSubgroup",
+      "action-formula"
+    ]
+  },
+  {
+    "id": "ann-cayreg-3",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 65,
+      "endLine": 73
+    },
+    "type": "concept",
+    "title": "Transitivity: an Explicit Translation Witness",
+    "content": "**`regSubgroup_transitive`**: for any $i, j$, some $\\sigma \\in H$ has $\\sigma i = j$.\n\nThe witness is explicit: take $g = e^{-1}(j)\\cdot (e^{-1}(i))^{-1}$ so that $\\mathrm{cayleyFinHom}\\,e\\,g$ maps $i \\mapsto j$. The computation `inv_mul_cancel_right` followed by `apply_symm_apply` confirms it. Transitivity reflects that the left-translation action of a group on itself is transitive — you can always get from $i$ to $j$ by multiplying by the right group element.",
+    "mathContext": "In the group picture, sending $i = e\\,x$ to $j = e\\,y$ means finding $g$ with $g x = y$, namely $g = y x^{-1}$. Pulling back through $e$ gives the stated witness $e^{-1}(j)(e^{-1}(i))^{-1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Transitive action",
+      "Left translation",
+      "inv_mul_cancel_right"
+    ],
+    "prerequisites": [
+      "cayleyFinHom_apply",
+      "Group inverse laws"
+    ],
+    "tags": [
+      "transitivity",
+      "witness",
+      "free-action"
+    ]
+  },
+  {
+    "id": "ann-cayreg-4",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 75,
+      "endLine": 104
+    },
+    "type": "concept",
+    "title": "Freeness: Trivial Stabilisers ⇒ Determined by One Point",
+    "content": "**`regSubgroup_free`**: any $\\sigma \\in H$ fixing a single point is the identity. Pulling $\\sigma = \\mathrm{cayleyFinHom}\\,e\\,g$ back, the fixed-point equation $g\\cdot e^{-1}(i) = e^{-1}(i)$ cancels (right-multiply by the inverse) to $g = 1$, hence $\\sigma = 1$.\n\n**`regSubgroup_eq_of_apply_eq`** is the immediate corollary used everywhere below: two members of $H$ agreeing at one point are equal — apply freeness to $\\tau^{-1}\\sigma$, which fixes that point. This 'determined by one value' property is the rigidity behind sharp transitivity.",
+    "mathContext": "Freeness (semiregularity) says every point stabiliser $H_i$ is trivial. For a left-translation action this is just left-cancellation: $g x = x \\Rightarrow g = 1$. Trivial stabilisers make the orbit map $H \\to \\mathrm{orbit}$ injective, so $|H| = |\\mathrm{orbit}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Free action / semiregular",
+      "Trivial stabiliser",
+      "Left-cancellation",
+      "inv_mul_eq_one"
+    ],
+    "prerequisites": [
+      "cayleyFinHom injectivity",
+      "Subgroup mul_mem / inv_mem"
+    ],
+    "tags": [
+      "freeness",
+      "semiregular",
+      "stabiliser"
+    ]
+  },
+  {
+    "id": "ann-cayreg-5",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 106,
+      "endLine": 116
+    },
+    "type": "insight",
+    "title": "Sharp Transitivity: Existence ∧ Uniqueness",
+    "content": "**`regSubgroup_sharplyTransitive`**: for any $i, j$ there is a *unique* $\\sigma \\in H$ with $\\sigma i = j$.\n\nThe proof is the clean combination of the two pillars: `regSubgroup_transitive` supplies existence, `regSubgroup_eq_of_apply_eq` supplies uniqueness (any two such $\\sigma, \\tau$ agree at $i$, hence everywhere). Sharp (simple) transitivity is the *defining* property of a regular permutation group, and the `∃!` makes the action a torsor in the formal sense.",
+    "mathContext": "An action is **sharply transitive** iff for every ordered pair $(i, j)$ exactly one group element maps $i \\to j$. Equivalently the map $H \\to \\{1,\\dots,n\\}$, $\\sigma \\mapsto \\sigma i$, is a bijection for each fixed $i$ — the hallmark of a $G$-torsor.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Sharp / simple transitivity",
+      "Torsor",
+      "ExistsUnique"
+    ],
+    "prerequisites": [
+      "regSubgroup_transitive",
+      "regSubgroup_eq_of_apply_eq"
+    ],
+    "tags": [
+      "sharp-transitivity",
+      "uniqueness",
+      "torsor"
+    ]
+  },
+  {
+    "id": "ann-cayreg-6",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 118,
+      "endLine": 143
+    },
+    "type": "technique",
+    "title": "Order n and the Pretransitive Action Instance",
+    "content": "**`regSubgroup_card`**: $|H| = n$. Since $\\mathrm{cayleyFinHom}\\,e$ is injective, $H \\cong G$ (`cayleyFinRangeEquiv`), and $e : G \\simeq \\mathrm{Fin}\\,n$ gives $|G| = n$ — a chain of `Nat.card_congr` rewrites ending at `Fintype.card_fin`.\n\nThe action packaging makes the results usable by Mathlib's group-action API:\n- **`regSubgroup_isPretransitive`** — a `MulAction.IsPretransitive` *instance* from `regSubgroup_transitive`;\n- **`regSubgroup_smul_free`** — freeness restated for the subgroup's own $\\bullet$ action via `Subtype.ext`.",
+    "mathContext": "By the orbit–stabiliser theorem a transitive free action on $n$ points forces $|H| = n$; here it is obtained more directly from $H \\cong G \\cong \\mathrm{Fin}\\,n$. Exposing `IsPretransitive` lets downstream code invoke transitivity-driven lemmas automatically.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.card / Fintype.card",
+      "MulAction.IsPretransitive",
+      "Orbit–stabiliser",
+      "Subtype.ext"
+    ],
+    "prerequisites": [
+      "cayleyFinRangeEquiv (parent)",
+      "Nat.card_congr"
+    ],
+    "tags": [
+      "order",
+      "action-packaging",
+      "instance"
+    ]
+  },
+  {
+    "id": "ann-cayreg-7",
+    "proofId": "cayleys-theorem-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 145,
+      "endLine": 162
+    },
+    "type": "insight",
+    "title": "Conclusion: the Regular Subgroup of Degree n, with a Concrete Check",
+    "content": "**`cayley_regular_subgroup`** packages the headline: $|H| = n$ **and** the action is sharply transitive — exactly 'a regular permutation group of degree $n$'. It is the conjunction of `regSubgroup_card` and `regSubgroup_sharplyTransitive`.\n\nThe closing **`example`** is a concrete sanity check: the left-regular image of the cyclic group $\\mathbb{Z}/3$ (as `Multiplicative (ZMod 3)`) is a regular subgroup of $S_3$ of order $3$ — a verified instance of the abstract theorem.",
+    "mathContext": "A regular subgroup of $S_n$ of order $n$ is the image of *some* group of order $n$ under its left-regular representation; conversely every group of order $n$ arises this way. For $\\mathbb{Z}/3$ this is the cyclic subgroup $\\langle(1\\,2\\,3)\\rangle \\le S_3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Regular representation",
+      "Cyclic group Z/3 in S₃",
+      "Conjunction of results"
+    ],
+    "prerequisites": [
+      "regSubgroup_card",
+      "regSubgroup_sharplyTransitive"
+    ],
+    "tags": [
+      "conclusion",
+      "main-theorem",
+      "concrete-example"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `cayleys-theorem-oq-01-oq-01-oq-02` (*Cayley's Image is a Regular (Sharply Transitive) Subgroup of Sₙ*).

## What changed
Rich `meta.json` but **no `annotations.json`**. This PR adds inline annotations covering the full 163-line Lean file.

## Quality improvements
- **7 annotations** spanning every part of the proof:
  1. Module framing — Cayley's theorem in its regular form
  2. `regSubgroup` definition + the relabelling action formula `e x ↦ e (g·x)`
  3. Transitivity via an explicit translation witness
  4. Freeness / trivial stabilisers ⇒ determined by one point
  5. Sharp transitivity (existence ∧ uniqueness, torsor)
  6. Order n + `MulAction.IsPretransitive` instance packaging
  7. Conclusion `cayley_regular_subgroup` + the ZMod 3 concrete check
- Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, connecting to the left-regular representation, torsors, and orbit–stabiliser.
- All anchored to real Lean constructs; passes `pnpm annotations:build` with no errors for this slug.

## Integrity
No claims changed: `status: verified`, `badge: original`, `axiomCount: 0`, `sorries: 0` remain accurate against the Lean source.