### PR TITLE
research(factor-remainder-theorem-oq-06): rational root theorem in concrete num/den form [verified, 0-sorry]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2701,6 +2701,7 @@ import Proofs.FactorRemainderTheoremOQ01OQ02
 import Proofs.FactorRemainderTheoremOQ02
 import Proofs.FactorRemainderTheoremOQ03
 import Proofs.FactorRemainderTheoremOQ05
+import Proofs.FactorRemainderTheoremOQ06
 import Proofs.FairGamesTheorem
 import Proofs.FairGamesTheoremOQ01
 import Proofs.FairGamesTheoremOQ02

--- a/proofs/Proofs/FactorRemainderTheoremOQ06.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ06.lean
@@ -1,0 +1,148 @@
+/-
+# Factor / Remainder Theorem, OQ-06: the rational root theorem in concrete `num/den` form
+
+The sibling entry `FactorRemainderTheoremOQ02.lean` states the rational root
+theorem for `p : ℤ[X]` using Mathlib's *abstract* fraction-ring numerator and
+denominator `IsFractionRing.num ℤ r` / `IsFractionRing.den ℤ r`. Those are only
+defined up to a unit, so the statements there divide by an object that a reader
+cannot directly compute.
+
+This file supplies the **textbook form**, stated in terms of the *canonical*
+reduced numerator and denominator `Rat.num` / `Rat.den` of a rational number:
+
+    aeval r p = 0  →  r.num ∣ p.coeff 0   ∧   (r.den : ℤ) ∣ p.leadingCoeff.
+
+This is the version actually used in computations ("a rational root `a/b` in
+lowest terms has `a ∣ a₀` and `b ∣ aₙ`"). The bridge from the abstract `num/den`
+to `Rat.num/Rat.den` is `Rat.associated_num_den` (Mathlib), which makes the two
+associated; divisibility then transfers across the association.
+
+## Main results
+
+- `num_dvd_constantCoeff`     : `aeval r p = 0 → r.num ∣ p.coeff 0`
+- `den_dvd_leadingCoeff`      : `aeval r p = 0 → (r.den : ℤ) ∣ p.leadingCoeff`
+- `monic_root_den_eq_one`     : a rational root of a monic `ℤ`-poly is an integer (`r.den = 1`)
+- `monic_root_num_dvd_const`  : an (integer) rational root of a monic poly divides the constant term
+- `no_rational_root_of_no_candidate` : the **rational root test** — if no `a/b` with
+  `a ∣ a₀`, `b ∣ aₙ` is a root, the polynomial has no rational root at all
+- `rational_root_candidates_finite` : the rational roots lie in an explicit finite
+  candidate set (numerator divides `a₀`, denominator divides `aₙ`)
+- `sq_ne_two` / `irrational-style` demonstration: `∀ r : ℚ, r ^ 2 ≠ 2`, proved from
+  the rational root theorem (the rational shadow of `√2 ∉ ℚ`)
+
+## Honest scope
+
+The underlying divisibility (`num_dvd_of_is_root`, `den_dvd_of_is_root`,
+`isInteger_of_is_root_of_monic`) and the `num/den` bridge (`Rat.associated_num_den`)
+are all Mathlib. The contribution here is the *concrete specialization* to
+`Rat.num/Rat.den` — the directly usable statement that neither Mathlib nor the
+sibling abstract entry records — together with the explicit root-test and finite
+candidate-set corollaries and a worked irrationality application. The proofs are
+short; this is a usability/synthesis entry, not a new theorem.
+
+## References
+
+- Mathlib `RingTheory.Polynomial.RationalRoot`, `RingTheory.Localization.Rat`
+- Sibling gallery entry factor-remainder-theorem-oq-02 (abstract `num/den` form)
+-/
+
+import Mathlib.RingTheory.Polynomial.RationalRoot
+import Mathlib.RingTheory.Localization.Rat
+import Mathlib.Tactic
+
+open Polynomial IsFractionRing
+
+namespace FactorRemainderTheoremOQ06
+
+variable {p : ℤ[X]} {r : ℚ}
+
+/-- **Rational root theorem, numerator part (concrete form).**
+If the rational number `r` (in lowest terms) is a root of `p ∈ ℤ[X]`, then its
+canonical numerator `r.num` divides the constant coefficient `p.coeff 0`. -/
+theorem num_dvd_constantCoeff (hr : aeval r p = 0) : r.num ∣ p.coeff 0 :=
+  ((Rat.isFractionRingNum r).symm.dvd).trans (num_dvd_of_is_root (A := ℤ) hr)
+
+/-- **Rational root theorem, denominator part (concrete form).**
+If the rational number `r` (in lowest terms) is a root of `p ∈ ℤ[X]`, then its
+canonical denominator `r.den` divides the leading coefficient `p.leadingCoeff`. -/
+theorem den_dvd_leadingCoeff (hr : aeval r p = 0) : (r.den : ℤ) ∣ p.leadingCoeff :=
+  (((Rat.associated_num_den r).2).symm.dvd).trans (den_dvd_of_is_root (A := ℤ) hr)
+
+/-- The pair (numerator divides `a₀`, denominator divides `aₙ`) packaged together —
+the data the rational root *test* enumerates over. -/
+theorem num_den_dvd (hr : aeval r p = 0) :
+    r.num ∣ p.coeff 0 ∧ (r.den : ℤ) ∣ p.leadingCoeff :=
+  ⟨num_dvd_constantCoeff hr, den_dvd_leadingCoeff hr⟩
+
+/-- **Integral root theorem (concrete form).**
+A rational root of a *monic* integer polynomial is an integer: its denominator is `1`. -/
+theorem monic_root_den_eq_one (hp : p.Monic) (hr : aeval r p = 0) : r.den = 1 := by
+  have hdvd : (r.den : ℤ) ∣ p.leadingCoeff := den_dvd_leadingCoeff hr
+  rw [hp.leadingCoeff] at hdvd
+  -- `r.den : ℤ` is a positive divisor of `1`, hence equals `1`.
+  have hpos : 0 < (r.den : ℤ) := by exact_mod_cast r.pos
+  have : (r.den : ℤ) = 1 := Int.eq_one_of_dvd_one hpos.le hdvd
+  exact_mod_cast this
+
+/-- For a monic integer polynomial, every rational root is an integer whose
+numerator divides the constant term — the classical "test integer divisors of `a₀`". -/
+theorem monic_root_num_dvd_const (hp : p.Monic) (hr : aeval r p = 0) :
+    r.den = 1 ∧ r.num ∣ p.coeff 0 :=
+  ⟨monic_root_den_eq_one hp hr, num_dvd_constantCoeff hr⟩
+
+/-- **The rational root test.** If *no* rational number whose numerator divides
+`p.coeff 0` and whose denominator divides `p.leadingCoeff` is a root, then `p`
+has no rational root whatsoever. (Contrapositive of `num_den_dvd`; the hypothesis
+is a finite check once `a₀, aₙ ≠ 0`.) -/
+theorem no_rational_root_of_no_candidate
+    (h : ∀ q : ℚ, q.num ∣ p.coeff 0 → (q.den : ℤ) ∣ p.leadingCoeff → aeval q p ≠ 0) :
+    ∀ q : ℚ, aeval q p ≠ 0 := by
+  intro q hq
+  exact h q (num_dvd_constantCoeff hq) (den_dvd_leadingCoeff hq) hq
+
+/-- The rational roots of `p` lie in the explicit set of fractions whose numerator
+divides `p.coeff 0` and whose denominator divides `p.leadingCoeff`. -/
+theorem rational_root_mem_candidates (hr : aeval r p = 0) :
+    r ∈ {q : ℚ | q.num ∣ p.coeff 0 ∧ (q.den : ℤ) ∣ p.leadingCoeff} :=
+  num_den_dvd hr
+
+/-! ### A worked irrationality application
+
+`X² − 2` is monic with constant term `−2`, so any rational root is an integer `n`
+with `n ∣ 2`; checking `n ∈ {±1, ±2}` rules them all out. This is the rational
+shadow of `√2 ∉ ℝ ∖ ℚ` (Mathlib's `irrational_sqrt_two`), here obtained purely
+inside `ℚ` from the rational root theorem. -/
+
+/-- `X² − 2 ∈ ℤ[X]` is monic. -/
+theorem monic_X_sq_sub_two : (X ^ 2 - C 2 : ℤ[X]).Monic :=
+  monic_X_pow_sub (n := 2) (lt_of_le_of_lt degree_C_le (by decide))
+
+/-- No integer squares to `2`. -/
+private theorem int_sq_ne_two (n : ℤ) : n ^ 2 ≠ 2 := by
+  intro hn
+  have hdvd : n ∣ 2 := ⟨n, by rw [← pow_two]; exact hn.symm⟩
+  have habs : |n| ≤ 2 := Int.le_of_dvd (by norm_num) ((abs_dvd n 2).mpr hdvd)
+  obtain ⟨hlo, hhi⟩ := abs_le.mp habs
+  interval_cases n <;> norm_num at hn
+
+/-- No rational number squares to `2`: the rational root theorem applied to
+`X² − 2`. The rational shadow of the irrationality of `√2`. -/
+theorem sq_ne_two (q : ℚ) : q ^ 2 ≠ 2 := by
+  intro hq
+  -- `q` is a root of `X² − 2`.
+  have hroot : aeval q (X ^ 2 - C 2 : ℤ[X]) = 0 := by
+    have he : aeval q (X ^ 2 - C 2 : ℤ[X]) = q ^ 2 - 2 := by
+      simp [map_sub, map_pow, aeval_X, map_ofNat]
+    rw [he, hq]; ring
+  -- Hence `q` is an integer (`q.den = 1`), so `q = q.num`.
+  have hden : q.den = 1 := monic_root_den_eq_one monic_X_sq_sub_two hroot
+  have hqint : q = (q.num : ℚ) := by
+    conv_lhs => rw [← Rat.num_div_den q, hden]
+    simp
+  -- The integer `q.num` would then square to `2`, impossible.
+  have hint : q.num ^ 2 = 2 := by
+    have : (q.num : ℚ) ^ 2 = 2 := by rw [← hqint]; exact hq
+    exact_mod_cast this
+  exact int_sq_ne_two q.num hint
+
+end FactorRemainderTheoremOQ06

--- a/src/data/proofs/factor-remainder-theorem-oq-06/meta.json
+++ b/src/data/proofs/factor-remainder-theorem-oq-06/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "factor-remainder-theorem-oq-06",
+  "title": "Factor/Remainder Theorem OQ-06: The Rational Root Theorem in Concrete num/den Form",
+  "slug": "factor-remainder-theorem-oq-06",
+  "description": "The textbook rational root theorem stated in the directly usable canonical reduced numerator/denominator (Rat.num / Rat.den): a rational root a/b of an integer polynomial has a ∣ a₀ and b ∣ aₙ. Specializes the sibling abstract-num/den form (OQ-02) and Mathlib's fraction-ring statement to the concrete reduced fraction, and applies it to the rational root test, the finite candidate set, and the irrationality of √2.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FactorRemainderTheoremOQ06.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "number-theory",
+      "rational-root-theorem",
+      "irrationality",
+      "factor-theorem"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "num_dvd_of_is_root",
+        "description": "Rational root theorem (abstract): the fraction-ring numerator num A r divides p.coeff 0",
+        "module": "Mathlib.RingTheory.Polynomial.RationalRoot"
+      },
+      {
+        "theorem": "den_dvd_of_is_root",
+        "description": "Rational root theorem (abstract): the fraction-ring denominator den A r divides p.leadingCoeff",
+        "module": "Mathlib.RingTheory.Polynomial.RationalRoot"
+      },
+      {
+        "theorem": "Rat.associated_num_den",
+        "description": "Bridge: IsFractionRing.num ℤ q is associated to q.num, and den ℤ q to q.den — the link from the abstract fraction-ring num/den to the canonical reduced Rat.num/Rat.den",
+        "module": "Mathlib.RingTheory.Localization.Rat"
+      },
+      {
+        "theorem": "monic_X_pow_sub",
+        "description": "X^n − p is monic when degree p < n — used to certify X² − 2 is monic",
+        "module": "Mathlib.Algebra.Polynomial.Monic"
+      },
+      {
+        "theorem": "Int.le_of_dvd",
+        "description": "A positive divisor bound, used to enumerate the integer candidates dividing 2",
+        "module": "Mathlib.Data.Int.GCD"
+      }
+    ],
+    "originalContributions": [
+      "Concrete statement of the rational root theorem using the canonical reduced fraction: num_dvd_constantCoeff (r.num ∣ p.coeff 0) and den_dvd_leadingCoeff ((r.den : ℤ) ∣ p.leadingCoeff). The sibling entry OQ-02 and Mathlib state these only with the abstract, unit-ambiguous IsFractionRing.num/den; this is the form a reader can actually compute with.",
+      "monic_root_den_eq_one: a rational root of a monic integer polynomial is an integer (r.den = 1), in concrete form — the integral root theorem specialized so the conclusion is directly r.den = 1.",
+      "no_rational_root_of_no_candidate: the rational root TEST — if no fraction whose numerator divides a₀ and whose denominator divides aₙ is a root, the polynomial has no rational root at all (a finite check once a₀, aₙ ≠ 0).",
+      "rational_root_mem_candidates: the rational roots lie in the explicit divisor-determined candidate set.",
+      "sq_ne_two: a worked application — no rational number squares to 2, obtained purely inside ℚ from the rational root theorem (the rational shadow of √2 ∉ ℚ)."
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 148,
+    "assumptions": "0 axioms, 0 sorries; only Lean/Mathlib foundational axioms (propext, Classical.choice, Quot.sound). HONEST SCOPE: the underlying divisibility (num_dvd_of_is_root, den_dvd_of_is_root) and the num/den-to-Rat.num/Rat.den bridge (Rat.associated_num_den) are all Mathlib. The contribution is the concrete specialization to Rat.num/Rat.den — the directly usable statement absent from both Mathlib and the abstract sibling entry OQ-02 — plus the root-test/candidate-set corollaries and the √2 application. The proofs are short; this is a usability/synthesis entry, not a new theorem.",
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The rational root theorem — that any rational root a/b (in lowest terms) of an integer polynomial aₙxⁿ + … + a₀ must have a ∣ a₀ and b ∣ aₙ — is the elementary engine behind countless irrationality proofs and the standard hand computation for finding rational roots. It is the integer-coefficient refinement of the factor theorem: clearing denominators turns a rational root into a divisibility constraint via coprimality of numerator and denominator. Mathlib proves it in considerable generality, for any root in the fraction field of a UFD, phrased through the fraction-ring numerator and denominator, which are only defined up to a unit. For ℤ ⊂ ℚ those abstract objects are *associated* to the familiar reduced numerator Rat.num and denominator Rat.den, but the statement a reader expects — divisibility of the literal reduced numerator and denominator — is not what the abstract theorem says verbatim.",
+    "problemStatement": "**Open Question**: State the rational root theorem in the concrete, directly usable form — for r : ℚ in lowest terms, r.num ∣ p.coeff 0 and (r.den : ℤ) ∣ p.leadingCoeff — and derive the rational root test and a worked irrationality consequence.\n\n**Answer**: Transfer Mathlib's abstract num/den divisibility across the association Rat.associated_num_den. This yields num_dvd_constantCoeff and den_dvd_leadingCoeff; specializing to monic p gives r.den = 1 (integral root theorem); and applying the result to X² − 2 shows ∀ r : ℚ, r² ≠ 2.",
+    "text": "The rational root theorem in canonical reduced-fraction form, with the rational root test, the explicit finite candidate set, and the irrationality of √2 as a worked consequence.",
+    "proofStrategy": "Four steps:\n1. **Concrete divisibility** (num_dvd_constantCoeff, den_dvd_leadingCoeff): combine Mathlib's abstract num_dvd_of_is_root / den_dvd_of_is_root with the association Rat.associated_num_den. Since Associated a b gives b ∣ a, divisibility of the abstract numerator transfers to the concrete Rat.num, and likewise for the denominator.\n2. **Integral root theorem** (monic_root_den_eq_one): for monic p the leading coefficient is 1, so the positive integer r.den divides 1, hence equals 1.\n3. **Root test** (no_rational_root_of_no_candidate, rational_root_mem_candidates): the contrapositive packaging — every rational root lies in the divisor-determined candidate set, so ruling out all candidates rules out every rational root.\n4. **Application** (sq_ne_two): X² − 2 is monic (monic_X_pow_sub), so a rational square root of 2 is an integer n with n² = 2; bounding |n| ≤ 2 via Int.le_of_dvd and checking the finitely many cases gives a contradiction.",
+    "keyInsights": [
+      "Mathlib's fraction-ring num/den are only defined up to a unit; over ℤ the units are ±1, so num ℤ r and Rat.num r are associated, and divisibility — being insensitive to unit factors — transfers cleanly across the association.",
+      "The concrete Rat.num/Rat.den form is the one used in practice: it states divisibility of the *literal* reduced numerator and denominator, not of a unit-ambiguous representative.",
+      "For a monic polynomial the denominator divides 1, collapsing the rational root theorem to 'rational roots are integers dividing the constant term' — the form used to test for integer roots.",
+      "The theorem bounds the rational roots inside an explicitly computable finite set (numerator divides a₀, denominator divides aₙ), turning root-finding/irrationality into a finite divisor check.",
+      "Irrationality of √2 falls out purely inside ℚ: no rational squares to 2, because the only integer candidates ±1, ±2 fail."
+    ],
+    "prerequisites": [
+      "Polynomials over ℤ and evaluation at a rational point (aeval)",
+      "The fraction field ℚ of ℤ and the canonical reduced numerator/denominator",
+      "Divisibility and associatedness in an integral domain"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: the abstract vs concrete forms of the rational root theorem and the num/den bridge",
+      "startLine": 1,
+      "endLine": 60,
+      "mathContext": "Mathlib states the rational root theorem with the unit-ambiguous IsFractionRing.num/den; this file restates it with the canonical Rat.num/Rat.den."
+    },
+    {
+      "id": "concrete-divisibility",
+      "title": "Part I: Concrete Divisibility (numerator and denominator)",
+      "summary": "num_dvd_constantCoeff (r.num ∣ p.coeff 0), den_dvd_leadingCoeff ((r.den : ℤ) ∣ p.leadingCoeff), and the packaged num_den_dvd",
+      "startLine": 61,
+      "endLine": 77,
+      "mathContext": "Transfers num_dvd_of_is_root / den_dvd_of_is_root across Rat.associated_num_den to the concrete reduced fraction."
+    },
+    {
+      "id": "integral-root",
+      "title": "Part II: The Integral Root Theorem",
+      "summary": "monic_root_den_eq_one (rational root of a monic ℤ-poly is an integer) and monic_root_num_dvd_const",
+      "startLine": 78,
+      "endLine": 95,
+      "mathContext": "For monic p, leadingCoeff = 1, so the positive divisor r.den equals 1; the integer root then divides the constant term."
+    },
+    {
+      "id": "root-test",
+      "title": "Part III: The Rational Root Test",
+      "summary": "no_rational_root_of_no_candidate (a finite candidate check certifies no rational roots) and rational_root_mem_candidates",
+      "startLine": 96,
+      "endLine": 110,
+      "mathContext": "Every rational root lies in the divisor-determined candidate set; ruling out the candidates rules out all rational roots."
+    },
+    {
+      "id": "application",
+      "title": "Part IV: A Worked Irrationality Application",
+      "summary": "monic_X_sq_sub_two and sq_ne_two: no rational number squares to 2, from the rational root theorem applied to X² − 2",
+      "startLine": 111,
+      "endLine": 148,
+      "mathContext": "X² − 2 is monic, so a rational root is an integer n with n² = 2; the candidates ±1, ±2 all fail."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry states the rational root theorem in its concrete, directly usable form — for a rational number r in lowest terms that is a root of an integer polynomial, the canonical reduced numerator r.num divides the constant coefficient and the denominator (r.den : ℤ) divides the leading coefficient — by transferring Mathlib's abstract fraction-ring statement across the association Rat.associated_num_den. It derives the integral root theorem (rational roots of monic ℤ-polynomials are integers), the rational root test with its explicit finite candidate set, and a worked irrationality application (∀ r : ℚ, r² ≠ 2). All results are verified with 0 sorries and 0 axioms beyond Lean's foundations.",
+    "implications": "The concrete num/den form is the one used in textbook root-finding and irrationality arguments; making it the literal statement (rather than a unit-ambiguous representative) closes the usability gap left by the abstract sibling entry OQ-02 and by Mathlib's general formulation.",
+    "openQuestions": [
+      "Generalize the √2 application to a clean criterion: for n : ℤ not a perfect k-th power, ∀ r : ℚ, rᵏ ≠ n.",
+      "Package the rational root test as a Decidable instance enumerating the finite candidate set when a₀, aₙ ≠ 0.",
+      "Relate the candidate-set bound to a height/Mahler-measure estimate on rational roots."
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "factor-remainder-theorem",
+      "relationship": "Parent theorem: the factor/remainder theorem (X − a) ∣ p ⟺ p(a) = 0"
+    },
+    {
+      "id": "factor-remainder-theorem-oq-02",
+      "relationship": "Sibling: states the rational root theorem in the abstract IsFractionRing.num/den form that this entry specializes to Rat.num/Rat.den"
+    },
+    {
+      "id": "factor-remainder-theorem-oq-05",
+      "relationship": "Sibling open question on the factor/remainder theorem (at-most-deg-roots bound)"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.RationalRoot",
+      "Mathlib.RingTheory.Localization.Rat",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Polynomial",
+      "IsFractionRing"
+    ],
+    "namespace": "FactorRemainderTheoremOQ06",
+    "lineCount": 148,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/FactorRemainderTheoremOQ06.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Serge Lang",
+      "title": "Algebra (rational root theorem, integral closure)",
+      "year": "2002",
+      "venue": "Springer GTM 211"
+    },
+    {
+      "authors": "Mathlib Community",
+      "title": "RingTheory.Polynomial.RationalRoot and RingTheory.Localization.Rat",
+      "year": "2025",
+      "venue": "Mathlib4"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "factor-remainder-theorem",
+      "relationship": "extends",
+      "description": "Refines the factor theorem to integer coefficients: a rational root forces divisibility of the constant and leading coefficients."
+    },
+    {
+      "targetId": "factor-remainder-theorem-oq-02",
+      "relationship": "specializes",
+      "description": "Restates the abstract num/den rational root theorem of OQ-02 in the concrete canonical Rat.num/Rat.den form."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

States the **rational root theorem in its concrete, directly usable form**, using the canonical reduced numerator/denominator of a rational number:

For `r : ℚ` in lowest terms with `aeval r p = 0` over `p : ℤ[X]`,

> `r.num ∣ p.coeff 0`   and   `(r.den : ℤ) ∣ p.leadingCoeff`.

The sibling gallery entry **OQ-02** and Mathlib's `RingTheory.Polynomial.RationalRoot` state this only with the *abstract*, unit-ambiguous `IsFractionRing.num`/`den` — objects a reader cannot compute with directly. This entry specializes to the literal `Rat.num`/`Rat.den` by transferring the divisibility across the association `Rat.associated_num_den` (Mathlib).

## Contents

- `num_dvd_constantCoeff` / `den_dvd_leadingCoeff` — the concrete divisibility statements.
- `monic_root_den_eq_one` — a rational root of a monic ℤ-polynomial is an integer (`r.den = 1`).
- `no_rational_root_of_no_candidate` / `rational_root_mem_candidates` — the **rational root test** and the explicit finite candidate set.
- `sq_ne_two` — `∀ r : ℚ, r² ≠ 2`, from the theorem applied to `X² − 2` (the rational shadow of `√2 ∉ ℚ`).

## Honest scope

The underlying divisibility (`num_dvd_of_is_root`, `den_dvd_of_is_root`) and the num/den bridge (`Rat.associated_num_den`) are all Mathlib. This is a **usability/synthesis entry** — the concrete `Rat.num`/`Rat.den` form absent from both Mathlib and the abstract sibling OQ-02, plus the root-test corollaries and a worked irrationality application. Proofs are short. Badge: **verified** (not `original`).

## Verification

- `lake env lean Proofs/FactorRemainderTheoremOQ06.lean` → exit 0 (kernel-verified against the pulled Mathlib cache, v4.26.0).
- `#print axioms` on the main results → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`; kernel `decide`/`interval_cases`).
- 148 lines, 10 theorems, 0 sorries, 0 `axiom` declarations.

Status: `verified`, badge `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)