### PR TITLE
Enrich Chebyshev's Sum Inequality (monotone form): add annotations

### DIFF
--- a/src/data/proofs/chebyshev-sum-inequality-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01/annotations.json
@@ -1,0 +1,192 @@
+[
+  {
+    "id": "ann-chebmono-1",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 29
+    },
+    "type": "context",
+    "title": "Classical Monotone-Sequence Form vs Mathlib's Monovary API",
+    "content": "**Module framing.** Mathlib states Chebyshev's sum inequality through the *order-correlation* predicates `MonovaryOn` / `AntivaryOn` (`Mathlib/Algebra/Order/Chebyshev.lean`). These are the right level of generality but not the form usually quoted. The classical statement is about two sequences sorted **the same way**, $a_1 \\le \\dots \\le a_n$ and $b_1 \\le \\dots \\le b_n$:\n$$ \\Big(\\sum a_i\\Big)\\Big(\\sum b_i\\Big) \\le n\\sum a_i b_i, $$\nwith the inequality **reversing** for oppositely sorted sequences. This file packages exactly that, by feeding the `Monotone`/`Antitone` ⇒ `Monovary`/`Antivary` bridges into the Mathlib lemmas — plus a Cauchy–Schwarz square corollary and a mean-form restatement.",
+    "mathContext": "Two sequences **monovary** if they are ordered consistently: $(a_i - a_j)(b_i - b_j) \\ge 0$ for all $i, j$. Sorting both the same way is a sufficient (and the classical) instance. Mathlib's `Monotone.monovary` is the bridge from the sorted hypothesis to this correlation predicate.",
+    "significance": "context",
+    "relatedConcepts": [
+      "MonovaryOn / AntivaryOn",
+      "Rearrangement inequality",
+      "Order correlation",
+      "Chebyshev's sum inequality"
+    ],
+    "prerequisites": [
+      "Monotone / Antitone functions",
+      "Finset.sum"
+    ],
+    "tags": [
+      "module-header",
+      "monovary-bridge",
+      "framing"
+    ]
+  },
+  {
+    "id": "ann-chebmono-2",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 41,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "The Forward Inequality: Similarly Sorted Sequences",
+    "content": "**`chebyshev_monotone`**: for $f, g$ both monotone on $\\{0,\\dots,n-1\\}$, $\\big(\\sum f_i\\big)\\big(\\sum g_i\\big) \\le n\\sum f_i g_i$.\n\nThe proof is two lines: `(hf.monovary hg).monovaryOn _` turns the joint monotonicity into `MonovaryOn f g (range n)`, then `MonovaryOn.sum_mul_sum_le_card_mul_sum` is the Mathlib inequality and `simpa` discharges the `card (range n) = n` bookkeeping. All the analytic content lives in the Mathlib lemma; this file's job is to expose it in the textbook shape.",
+    "mathContext": "Equivalently $\\frac1n\\sum a_i b_i \\ge \\big(\\frac1n\\sum a_i\\big)\\big(\\frac1n\\sum b_i\\big)$: when large $a$'s pair with large $b$'s, the average of the products beats the product of the averages. It is the discrete sibling of $\\mathrm{Cov}(X, Y) \\ge 0$ for comonotone variables.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Monotone.monovary",
+      "sum_mul_sum_le_card_mul_sum",
+      "Covariance of comonotone variables"
+    ],
+    "prerequisites": [
+      "MonovaryOn",
+      "Finset.card_range"
+    ],
+    "tags": [
+      "main-result",
+      "forward-inequality",
+      "monotone"
+    ]
+  },
+  {
+    "id": "ann-chebmono-3",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 49,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "The Reverse Inequality: Oppositely Sorted Sequences",
+    "content": "**`chebyshev_antitone`**: for $f$ monotone and $g$ antitone, the inequality flips, $n\\sum f_i g_i \\le \\big(\\sum f_i\\big)\\big(\\sum g_i\\big)$.\n\nSymmetric to the forward case: `hf.antivary hg` gives `AntivaryOn f g (range n)`, and `AntivaryOn.card_mul_sum_le_sum_mul_sum` is the reversed Mathlib bound. Anti-sorting makes large $f$'s pair with small $g$'s, so the pointwise products are suppressed and the product of sums dominates.",
+    "mathContext": "If $f, g$ **antivary** then $(f_i - f_j)(g_i - g_j) \\le 0$: this is negative correlation, $\\mathrm{Cov}(X, Y) \\le 0$. The reversal is the exact statement that the rearrangement minimising $\\sum a_i b_{\\sigma(i)}$ is the oppositely sorted one.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Monotone.antivary",
+      "card_mul_sum_le_sum_mul_sum",
+      "Negative correlation"
+    ],
+    "prerequisites": [
+      "AntivaryOn",
+      "Antitone functions"
+    ],
+    "tags": [
+      "reverse-inequality",
+      "antitone",
+      "rearrangement"
+    ]
+  },
+  {
+    "id": "ann-chebmono-4",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 60
+    },
+    "type": "insight",
+    "title": "Cauchy–Schwarz Square Corollary: the Diagonal Case",
+    "content": "**`sq_sum_le`**: $\\big(\\sum f_i\\big)^2 \\le n\\sum f_i^2$ for *any* sequence $f$.\n\nThis is the self-monovarying special case $g = f$ of Chebyshev — and crucially it needs **no monotonicity hypothesis**, since every sequence monovaries with itself. It is delivered straight from Mathlib's `sq_sum_le_card_mul_sum_sq`. The bound is the discrete Cauchy–Schwarz (or power-mean) inequality: the square of the sum never exceeds $n$ times the sum of squares.",
+    "mathContext": "Equivalent to $\\operatorname{Var}(f) \\ge 0$: $\\frac1n\\sum f_i^2 - \\big(\\frac1n\\sum f_i\\big)^2 \\ge 0$. It is also Cauchy–Schwarz applied to $f$ and the constant sequence $1$: $\\langle f, \\mathbf 1\\rangle^2 \\le \\|f\\|^2\\,\\|\\mathbf 1\\|^2 = n\\sum f_i^2$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cauchy–Schwarz inequality",
+      "sq_sum_le_card_mul_sum_sq",
+      "Variance nonnegativity",
+      "Power mean inequality"
+    ],
+    "prerequisites": [
+      "Self-monovariance",
+      "Sum of squares"
+    ],
+    "tags": [
+      "cauchy-schwarz",
+      "corollary",
+      "diagonal-case"
+    ]
+  },
+  {
+    "id": "ann-chebmono-5",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 62,
+      "endLine": 72
+    },
+    "type": "technique",
+    "title": "Averaged Form: Mean of Products ≥ Product of Means",
+    "content": "**`chebyshev_mean`**: for similarly sorted $f, g$ and $n > 0$, $\\frac{\\sum f_i}{n}\\cdot\\frac{\\sum g_i}{n} \\le \\frac{\\sum f_i g_i}{n}$.\n\nThis divides the forward inequality through by $n^2$. The proof recasts the goal with `div_mul_div_comm` and `div_le_div_iff₀` (both denominators positive), reducing it to `chebyshev_monotone` plus an `nlinarith` cross-multiplication. This is the form in which Chebyshev's inequality is most directly compared with Jensen / AM-style mean inequalities.",
+    "mathContext": "In expectation language with the uniform measure: $\\mathbb{E}[fg] \\ge \\mathbb{E}[f]\\,\\mathbb{E}[g]$ when $f, g$ are comonotone — i.e. $\\mathrm{Cov}(f, g) \\ge 0$. The mean form makes the probabilistic reading transparent.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Arithmetic mean",
+      "div_le_div_iff₀",
+      "E[fg] ≥ E[f]E[g]"
+    ],
+    "prerequisites": [
+      "chebyshev_monotone",
+      "Ordered-field division lemmas"
+    ],
+    "tags": [
+      "mean-form",
+      "averaged",
+      "expectation"
+    ]
+  },
+  {
+    "id": "ann-chebmono-6",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 74,
+      "endLine": 90
+    },
+    "type": "technique",
+    "title": "General Form over an Arbitrary Finite Index Set",
+    "content": "**`chebyshev_monotoneOn` / `chebyshev_antitoneOn`**: the same forward and reverse inequalities for $f, g$ that are `MonotoneOn` / `AntitoneOn` a finite set $s \\subseteq \\iota$ in any `LinearOrder`, with $n$ replaced by $\\#s$.\n\nThese are one-liners — `(hf.monovaryOn hg).sum_mul_sum_le_card_mul_sum` and its antivary mirror — generalising beyond `range n` to an arbitrary indexing. They show the `range n` versions are merely the most familiar specialisation; the inequality only ever needed monotonicity *on the summation set*, not on all of $\\iota$.",
+    "mathContext": "`MonotoneOn f s` requires $f$ increasing only across $s$, the minimal hypothesis: the rearrangement/correlation structure is entirely a property of how $f, g$ co-order on the points actually summed.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "MonotoneOn / AntitoneOn",
+      "monovaryOn",
+      "Finset.card",
+      "Generalised index set"
+    ],
+    "prerequisites": [
+      "LinearOrder ι",
+      "MonovaryOn over a Finset"
+    ],
+    "tags": [
+      "general-form",
+      "monotoneOn",
+      "arbitrary-index"
+    ]
+  },
+  {
+    "id": "ann-chebmono-7",
+    "proofId": "chebyshev-sum-inequality-oq-01",
+    "range": {
+      "startLine": 92,
+      "endLine": 99
+    },
+    "type": "context",
+    "title": "Worked Instance: 9 ≤ 15",
+    "content": "**`example`**: the increasing sequence $0, 1, 2$ satisfies $(0+1+2)^2 \\le 3\\,(0^2+1^2+2^2)$, i.e. $9 \\le 15$, obtained directly from `sq_sum_le`. `Finset.sum_range_succ` unfolds the three-term sums and `simpa` finishes. A concrete sanity check that the abstract corollary specialises to a true numerical statement.",
+    "mathContext": "Here $\\big(\\sum f_i\\big)^2 = 9$ and $n\\sum f_i^2 = 3\\cdot 5 = 15$; the slack $15 - 9 = 6 = 2n\\operatorname{Var}$ measures the spread of $0,1,2$, vanishing only for constant sequences.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Finset.sum_range_succ",
+      "Numerical verification",
+      "sq_sum_le"
+    ],
+    "prerequisites": [
+      "sq_sum_le"
+    ],
+    "tags": [
+      "worked-example",
+      "sanity-check"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `chebyshev-sum-inequality-oq-01` (*Chebyshev's Sum Inequality in Classical Monotone-Sequence Form*).

## What changed
Rich `meta.json` but **no `annotations.json`**. This PR adds inline annotations covering the full 100-line Lean file.

## Quality improvements
- **7 annotations** spanning every part of the proof:
  1. Module framing — the classical monotone form vs Mathlib's Monovary/Antivary API
  2. `chebyshev_monotone` — the forward inequality for similarly sorted sequences
  3. `chebyshev_antitone` — the reverse inequality for oppositely sorted sequences
  4. `sq_sum_le` — the Cauchy–Schwarz square corollary (self-monovarying, no hypothesis)
  5. `chebyshev_mean` — the averaged form (mean of products ≥ product of means)
  6. `chebyshev_monotoneOn`/`chebyshev_antitoneOn` — general form over an arbitrary finite index set
  7. The worked 9 ≤ 15 instance
- Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`, connecting to rearrangement, covariance, and Cauchy–Schwarz.
- All anchored to real Lean constructs; passes `pnpm annotations:build` with no errors for this slug.

## Integrity
No claims changed: `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` remain accurate against the Lean source.