### PR TITLE
Enrich Rational Canonical Form: Minimal Polynomial Plus Invariant Factors

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "chm-oq0601-ann-header",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "The RCF readout and what is new relative to Mathlib",
+    "content": "The module docstring frames the rational canonical form (Frobenius normal form): every matrix over a field is similar to a block-diagonal sum of companion matrices $C(f_1)\\oplus\\cdots\\oplus C(f_k)$ whose blocks are the invariant factors $f_1\\mid f_2\\mid\\cdots\\mid f_k$. The classical readout recovers the two distinguished polynomials from these invariant factors: the characteristic polynomial is their product and the minimal polynomial is the largest. Mathlib v4.26.0 supplies the charpoly side (`charpoly_fromBlocks_zero₁₂`) but has no statement about the minimal polynomial of a block-diagonal matrix — that is the gap this file fills, for the two-factor case and for arbitrary nonderogatory blocks (so it applies verbatim to companion matrices).",
+    "mathContext": "$\\text{charpoly} = \\prod_i f_i$, $\\quad \\text{minpoly} = f_k$, for invariant factors $f_1\\mid\\cdots\\mid f_k$.",
+    "significance": "context",
+    "relatedConcepts": ["rational canonical form", "Frobenius normal form", "invariant factors", "companion matrix"],
+    "prerequisites": ["Lean 4", "Mathlib", "minimal and characteristic polynomials"]
+  },
+  {
+    "id": "chm-oq0601-ann-setup",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 56, "endLine": 62 },
+    "type": "definition",
+    "title": "Setup: a field and two block index types",
+    "content": "The development fixes a field `F` and two finite, decidable-equality index types `m` and `o` — the dimensions of the two diagonal blocks `A : Matrix m m F` and `D : Matrix o o F`. The block-diagonal sum then lives over the sum type `m ⊕ o`. Working with two separate index types (rather than a single `Fin n`) is exactly what lets the blocks have different sizes, mirroring companion blocks of different degrees.",
+    "mathContext": "$A \\oplus D = \\begin{pmatrix} A & 0 \\\\ 0 & D \\end{pmatrix}$ over $m \\oplus o$.",
+    "significance": "supporting",
+    "relatedConcepts": ["block matrices", "sum types", "matrix algebra over a field"],
+    "prerequisites": ["finite types", "matrices over a field"]
+  },
+  {
+    "id": "chm-oq0601-ann-algebramap",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 64, "endLine": 76 },
+    "type": "technique",
+    "title": "Scalar matrices split blockwise",
+    "content": "`algebraMap_fromBlocks` is the scalar-splitting helper: the scalar matrix $a\\cdot I$ over `m ⊕ o` is the block-diagonal sum of the scalar blocks $a\\cdot I_m$ and $a\\cdot I_o$. The proof rewrites each `algebraMap` as `a • 1` (`Algebra.algebraMap_eq_smul_one`), uses `fromBlocks_one` to see the identity as a block-diagonal sum, and pushes the scalar through with `fromBlocks_smul`. This is the base case that makes polynomial evaluation distribute over blocks.",
+    "mathContext": "$a\\cdot I_{m\\oplus o} = (a\\cdot I_m) \\oplus (a\\cdot I_o)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["scalar matrices", "algebra map", "block identity matrix"],
+    "prerequisites": ["algebra over a field", "smul on matrices"]
+  },
+  {
+    "id": "chm-oq0601-ann-aeval",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 78, "endLine": 90 },
+    "type": "technique",
+    "title": "Polynomial evaluation distributes over a block-diagonal matrix",
+    "content": "`aeval_fromBlocks` is the engine: for any polynomial $q$, $q(A\\oplus D) = q(A)\\oplus q(D)$. The proof is polynomial induction (`Polynomial.induction_on'`). The additive step distributes the block sum over addition (`fromBlocks_add`, with the off-diagonal zeros absorbed). The monomial step $a X^n$ combines three facts: powers of a block-diagonal matrix are blockwise (`fromBlocks_diagonal_pow`), the scalar splits (the previous helper), and block matrices multiply blockwise (`fromBlocks_multiply`). Conceptually this holds because $(A,D)\\mapsto A\\oplus D$ is an $F$-algebra homomorphism.",
+    "mathContext": "$q(A\\oplus D) = q(A)\\oplus q(D)$ for every $q\\in F[X]$, since $(A,D)\\mapsto A\\oplus D$ is an algebra homomorphism.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial induction", "algebra homomorphism", "aeval", "block matrix powers"],
+    "prerequisites": ["polynomial induction", "matrix powers of block matrices"]
+  },
+  {
+    "id": "chm-oq0601-ann-charpoly",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 91, "endLine": 98 },
+    "type": "concept",
+    "title": "Characteristic polynomial multiplies across blocks",
+    "content": "`charpoly_fromBlocks` records the charpoly half of the readout: $\\text{charpoly}(A\\oplus D) = \\text{charpoly}(A)\\cdot\\text{charpoly}(D)$. This is a direct restatement of Mathlib's `charpoly_fromBlocks_zero₁₂` (the characteristic polynomial of a block-triangular matrix is the product of its diagonal blocks' charpolys), instantiated at the block-diagonal case. It is the easy, pre-existing half — the new content is the minpoly counterpart that follows.",
+    "mathContext": "$\\det(XI - (A\\oplus D)) = \\det(XI - A)\\cdot\\det(XI - D)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["characteristic polynomial", "block-triangular determinant", "multiplicativity"],
+    "prerequisites": ["determinants of block matrices"]
+  },
+  {
+    "id": "chm-oq0601-ann-minpoly",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 100, "endLine": 135 },
+    "type": "insight",
+    "title": "Minimal polynomial of a block-diagonal sum (the new theorem)",
+    "content": "`minpoly_fromBlocks_of_dvd` is the central original result, missing from Mathlib: when the blocks' minimal polynomials form a divisibility chain $\\text{minpoly}\\,A \\mid \\text{minpoly}\\,D$, the minimal polynomial of $A\\oplus D$ is the larger one, $\\text{minpoly}\\,D$. The proof is a clean two-way divisibility. Forward: $\\text{minpoly}\\,D$ annihilates $A$ too (it is a multiple of $\\text{minpoly}\\,A$), so by `aeval_fromBlocks` it annihilates $A\\oplus D$, giving $\\text{minpoly}(A\\oplus D)\\mid\\text{minpoly}\\,D$ via `minpoly.dvd`. Reverse: extract the bottom-right block of $(\\text{minpoly}(A\\oplus D))(A\\oplus D)=0$ (`fromBlocks_apply₂₂`) to see $\\text{minpoly}(A\\oplus D)$ annihilates $D$, giving $\\text{minpoly}\\,D\\mid\\text{minpoly}(A\\oplus D)$. Two monic associates are equal (`eq_of_monic_of_associated`). In general the minpoly of a direct sum is the lcm; the chain hypothesis collapses the lcm to the larger element with no normalisation bookkeeping.",
+    "mathContext": "$\\text{minpoly}\\,A \\mid \\text{minpoly}\\,D \\;\\Longrightarrow\\; \\text{minpoly}(A\\oplus D) = \\text{minpoly}\\,D = \\operatorname{lcm}(\\text{minpoly}\\,A, \\text{minpoly}\\,D).$",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "least common multiple", "two-way divisibility", "monic associates", "block extraction"],
+    "prerequisites": ["minpoly.dvd", "monic polynomials and associates", "block matrix entry extraction"]
+  },
+  {
+    "id": "chm-oq0601-ann-readout",
+    "proofId": "cayley-hamilton-minpoly-oq-06-oq-01",
+    "range": { "startLine": 137, "endLine": 161 },
+    "type": "insight",
+    "title": "The RCF readout for two invariant factors",
+    "content": "`rcf_two_invariant_factors` packages the two halves into the textbook statement. For two nonderogatory blocks — $\\text{minpoly}\\,A = \\text{charpoly}\\,A = f_1$ and $\\text{minpoly}\\,D = \\text{charpoly}\\,D = f_2$ — with invariant factors forming a chain $f_1\\mid f_2$, the block-diagonal sum $A\\oplus D$ has charpoly $f_1\\cdot f_2$ (product of the invariant factors) and minpoly $f_2$ (the largest). The charpoly part is `charpoly_fromBlocks` rewritten with the hypotheses; the minpoly part feeds the chain into `minpoly_fromBlocks_of_dvd`. Because companion matrices satisfy exactly the nonderogatory hypothesis ($\\text{charpoly}(C f) = \\text{minpoly}(C f) = f$), this is precisely the readout for the canonical two-block RCF.",
+    "mathContext": "$f_1\\mid f_2 \\;\\Longrightarrow\\; \\text{charpoly}(A\\oplus D) = f_1 f_2 \\;\\wedge\\; \\text{minpoly}(A\\oplus D) = f_2.$",
+    "significance": "key",
+    "relatedConcepts": ["rational canonical form", "nonderogatory matrix", "invariant factors", "companion matrix"],
+    "prerequisites": ["companion matrix charpoly/minpoly identities", "the two block-diagonal readout lemmas"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/index.ts
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-06-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const cayleyHamiltonMinpolyOq06Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const cayleyHamiltonMinpolyOq06Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const cayleyHamiltonMinpolyOq06Oq01Data: ProofData = {
+  proof: cayleyHamiltonMinpolyOq06Oq01Proof,
+  annotations: cayleyHamiltonMinpolyOq06Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-06-oq-01` (quality 43, pass 0).

## Changes
- **Created missing `index.ts`** — the entry had only `meta.json`, so the proof page rendered "proof not found" on the live site. Added the Vite entry point importing the Lean source from `Proofs/CayleyHamiltonMinpolyOQ06OQ01.lean`.
- **Created `annotations.json`** — 7 substantive annotations, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering: the RCF readout framing and Mathlib gap, the two-block setup, the scalar-splitting helper `algebraMap_fromBlocks`, polynomial-evaluation distribution `aeval_fromBlocks`, charpoly multiplicativity, the new central theorem `minpoly_fromBlocks_of_dvd` (minpoly of a block-diagonal matrix, absent from Mathlib v4.26.0), and the headline readout `rcf_two_invariant_factors`.

## Verification
- `pnpm build` succeeds (✓ built).
- meta.json already `status: verified`, `badge: mathlib`, `axiomCount: 0`, 0 sorries; annotation content checked line-by-line against the Lean source.
