### PR TITLE
research(algebraic-reals-meager-dense-gdelta-oq-01): algebraic reals as explicit Fσ, completing the Gδ/Fσ dichotomy

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -56,6 +56,8 @@ import Proofs.AlgebraicNumbersCountableOQ02OQ04
 import Proofs.AlgebraicNumbersCountableOQ04
 import Proofs.AlgebraicNumbersCountableOQ05
 import Proofs.AlgebraicRealsMeager
+import Proofs.AlgebraicRealsMeagerDenseGDelta
+import Proofs.AlgebraicRealsMeagerDenseGDeltaOQ01
 import Proofs.AlgebraicRealsMeagerOQ02
 import Proofs.AlgebraicRealsMeagerOQ03
 import Proofs.AlgebraicRealsNull

--- a/proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ01.lean
+++ b/proofs/Proofs/AlgebraicRealsMeagerDenseGDeltaOQ01.lean
@@ -1,0 +1,153 @@
+import Mathlib.Topology.GDelta.Basic
+import Mathlib.Topology.Baire.Lemmas
+import Mathlib.RingTheory.Algebraic.Basic
+import Mathlib.Data.Set.Lattice
+import Mathlib.Tactic
+import Proofs.AlgebraicRealsMeagerDenseGDelta
+
+/-!
+# The Algebraic Reals are an Explicit Fσ — completing the Gδ/Fσ dichotomy
+
+## Open Question (algebraic-reals-meager-dense-gdelta-oq-01)
+
+The parent entry `algebraic-reals-meager-dense-gdelta` exhibits the **transcendental** reals as
+a concrete dense `Gδ` and shows that the **algebraic** reals are *not* a `Gδ`. Its first open
+question asks to
+
+> "Dualize to the algebraic reals as an explicit Fσ (countable union of closed singletons) and
+>  record the full Gδ/Fσ classification of the dichotomy."
+
+Mathlib has the predicate `IsGδ` (a countable intersection of open sets) but **no** `Fσ`
+counterpart, so we first introduce one, dual in the exact sense of De Morgan:
+
+    IsFσ s  :↔  s is a countable union of closed sets
+            ↔  sᶜ is a Gδ          (`isFσ_iff_isGδ_compl`).
+
+With this in hand the dichotomy becomes a clean, complete classification of the two halves of
+the real line:
+
+| set                         | `Fσ` | `Gδ` | category   |
+|-----------------------------|------|------|------------|
+| algebraic reals             | ✓    | ✗    | meagre     |
+| transcendental reals        | ✗    | ✓    | comeagre   |
+
+The algebraic reals are the **explicit** countable union of closed singletons
+`⋃_{a algebraic} {a}` — each `{a}` closed because `ℝ` is `T1`, the index set countable
+(`AlgebraicNumbersCountable.algebraic_reals_countable`). Being meagre and dense they are not a
+`Gδ` (parent); dually, the transcendentals are a `Gδ` but, since their complement (the algebraic
+reals) is not a `Gδ`, they are *not* an `Fσ`. This is the mirror image of the parent and the
+classical companion to "`ℚ` is `Fσ` but not `Gδ`".
+
+## Main results
+
+* `IsFσ` : a set is `Fσ` if it is a countable union of closed sets (dual to `IsGδ`).
+* `isFσ_iff_isGδ_compl` : `s` is `Fσ` iff `sᶜ` is `Gδ` — the De Morgan duality.
+* `isFσ_of_countable` : in a `T1` space, every countable set is `Fσ` (dual to the parent's
+  `isGδ_compl_of_countable`).
+* `algebraicReals_eq_iUnion_singletons` : the algebraic reals *are* the union of their singletons.
+* `algebraicReals_isFσ` : **the headline** — the algebraic reals are an explicit `Fσ`.
+* `transcendentalReals_not_isFσ` : the transcendentals are *not* an `Fσ`.
+* `algebraic_gδ_fσ_dichotomy` : the packaged four-way classification of the dichotomy.
+-/
+
+open Set Topology
+
+namespace AlgebraicRealsMeagerDenseGDeltaOQ01
+
+/-! ### The `Fσ` predicate and its duality with `Gδ` -/
+
+/-- **A set is `Fσ` if it is a countable union of closed sets.**
+
+This is the exact dual of Mathlib's `IsGδ` (a countable intersection of open sets); the two are
+interchanged by complementation, recorded in `isFσ_iff_isGδ_compl`. -/
+def IsFσ {X : Type*} [TopologicalSpace X] (s : Set X) : Prop :=
+  ∃ T : Set (Set X), (∀ t ∈ T, IsClosed t) ∧ T.Countable ∧ s = ⋃₀ T
+
+/-- **`Fσ ⇒ Gδ` of the complement.** Complementing a countable union of closed sets gives a
+countable intersection of open sets (`Set.compl_sUnion`). -/
+theorem IsFσ.isGδ_compl {X : Type*} [TopologicalSpace X] {s : Set X} (hs : IsFσ s) :
+    IsGδ sᶜ := by
+  obtain ⟨T, hTc, hTcount, rfl⟩ := hs
+  refine ⟨compl '' T, ?_, hTcount.image _, ?_⟩
+  · rintro t ⟨u, hu, rfl⟩
+    exact isOpen_compl_iff.mpr (hTc u hu)
+  · rw [Set.compl_sUnion]
+
+/-- **`Gδ` of the complement ⇒ `Fσ`.** The reverse De Morgan passage: complementing a countable
+intersection of open sets gives a countable union of closed sets (`Set.compl_sInter`). -/
+theorem isFσ_of_isGδ_compl {X : Type*} [TopologicalSpace X] {s : Set X} (hs : IsGδ sᶜ) :
+    IsFσ s := by
+  obtain ⟨T, hTo, hTcount, hT⟩ := hs
+  refine ⟨compl '' T, ?_, hTcount.image _, ?_⟩
+  · rintro t ⟨u, hu, rfl⟩
+    exact (hTo u hu).isClosed_compl
+  · rw [← compl_compl s, hT, Set.compl_sInter]
+
+/-- **`Fσ`/`Gδ` duality.** `s` is `Fσ` exactly when `sᶜ` is `Gδ`. -/
+theorem isFσ_iff_isGδ_compl {X : Type*} [TopologicalSpace X] {s : Set X} :
+    IsFσ s ↔ IsGδ sᶜ :=
+  ⟨IsFσ.isGδ_compl, isFσ_of_isGδ_compl⟩
+
+/-- **In a `T1` space every countable set is `Fσ`** — explicitly, the union of its singletons.
+
+This is the dual of the parent's `isGδ_compl_of_countable`: there a countable set has `Gδ`
+*complement*; here the countable set is *itself* the countable union of the closed singletons
+`{a}` (closed because the space is `T1`). -/
+theorem isFσ_of_countable {X : Type*} [TopologicalSpace X] [T1Space X]
+    {s : Set X} (hs : s.Countable) : IsFσ s := by
+  refine ⟨(fun a => {a}) '' s, ?_, hs.image _, ?_⟩
+  · rintro t ⟨a, _, rfl⟩
+    exact isClosed_singleton
+  · rw [Set.sUnion_image, Set.biUnion_of_singleton]
+
+/-! ### The algebraic reals as a concrete `Fσ` -/
+
+/-- **The algebraic reals are the union of their singletons.** The explicit `Fσ` decomposition
+requested by the open question, displayed before packaging it into `IsFσ`. -/
+theorem algebraicReals_eq_iUnion_singletons :
+    {x : ℝ | IsAlgebraic ℚ x} = ⋃ a ∈ {x : ℝ | IsAlgebraic ℚ x}, {a} :=
+  (Set.biUnion_of_singleton _).symm
+
+/-- **The algebraic reals are an explicit `Fσ` in `ℝ`.**
+
+They are countable (`AlgebraicNumbersCountable.algebraic_reals_countable`), so by
+`isFσ_of_countable` they are the countable union of the closed singletons `{a}`, `a` algebraic —
+the dual structural statement to the parent's dense-`Gδ` transcendentals. -/
+theorem algebraicReals_isFσ : IsFσ {x : ℝ | IsAlgebraic ℚ x} :=
+  isFσ_of_countable AlgebraicNumbersCountable.algebraic_reals_countable
+
+/-- **The transcendental reals are *not* an `Fσ`.**
+
+If they were `Fσ`, their complement — the algebraic reals — would be a `Gδ`
+(`IsFσ.isGδ_compl`), contradicting the parent's `algebraicReals_not_isGδ`. So the transcendentals
+sit on the `Gδ`-only side of the dichotomy, exactly opposite the algebraic reals. -/
+theorem transcendentalReals_not_isFσ : ¬ IsFσ {x : ℝ | ¬ IsAlgebraic ℚ x} := by
+  intro h
+  apply AlgebraicRealsMeagerDenseGDelta.algebraicReals_not_isGδ
+  have hc : {x : ℝ | ¬ IsAlgebraic ℚ x}ᶜ = {x : ℝ | IsAlgebraic ℚ x} := by
+    ext x; simp only [mem_compl_iff, mem_setOf_eq, not_not]
+  rw [← hc]
+  exact h.isGδ_compl
+
+/-! ### The full Gδ/Fσ classification -/
+
+/-- **The complete dichotomy.** Packaging the four facts that classify each half of the line:
+
+* the **algebraic** reals are an `Fσ` but not a `Gδ`;
+* the **transcendental** reals are a `Gδ` but not an `Fσ`.
+
+The two sets are perfect complements in every sense — Baire category (meagre vs. comeagre,
+parent) and Borel complexity (`Fσ`-but-not-`Gδ` vs. `Gδ`-but-not-`Fσ`, here). -/
+theorem algebraic_gδ_fσ_dichotomy :
+    (IsFσ {x : ℝ | IsAlgebraic ℚ x} ∧ ¬ IsGδ {x : ℝ | IsAlgebraic ℚ x}) ∧
+      (IsGδ {x : ℝ | ¬ IsAlgebraic ℚ x} ∧ ¬ IsFσ {x : ℝ | ¬ IsAlgebraic ℚ x}) :=
+  ⟨⟨algebraicReals_isFσ, AlgebraicRealsMeagerDenseGDelta.algebraicReals_not_isGδ⟩,
+    ⟨AlgebraicRealsMeagerDenseGDelta.transcendentalReals_isGδ, transcendentalReals_not_isFσ⟩⟩
+
+end AlgebraicRealsMeagerDenseGDeltaOQ01
+
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ01.isFσ_iff_isGδ_compl
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ01.isFσ_of_countable
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ01.algebraicReals_isFσ
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ01.transcendentalReals_not_isFσ
+#print axioms AlgebraicRealsMeagerDenseGDeltaOQ01.algebraic_gδ_fσ_dichotomy

--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/annotations.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-armdg-oq01-isfsigma-def",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 57, "endLine": 66 },
+    "type": "definition",
+    "title": "The Fσ predicate, dual to Mathlib's IsGδ",
+    "content": "Mathlib carries IsGδ (a countable intersection of open sets) but — perhaps surprisingly — no Fσ counterpart. We supply one: IsFσ s holds when s is a countable union of closed sets, exactly mirroring the IsGδ definition with 'closed/union' in place of 'open/intersection'. Everything downstream is built on this single definition and its De Morgan duality with IsGδ.",
+    "mathContext": "$\\mathrm{IsF}_\\sigma(s) :\\Leftrightarrow \\exists\\, T \\subseteq \\mathcal{P}(X)\\ \\text{countable},\\ (\\forall t \\in T,\\ t\\ \\text{closed}) \\wedge s = \\bigcup_0 T$.",
+    "significance": "key",
+    "relatedConcepts": ["Fσ set", "Gδ set", "Borel hierarchy", "duality"],
+    "prerequisites": ["point-set topology", "open and closed sets"]
+  },
+  {
+    "id": "ann-armdg-oq01-duality",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 68, "endLine": 94 },
+    "type": "insight",
+    "title": "Fσ ⇔ Gδ-complement (De Morgan)",
+    "content": "The bridge that makes Fσ usable alongside Mathlib's IsGδ. Complementing a countable union of closed sets yields a countable intersection of their open complements: (⋃₀ T)ᶜ = ⋂₀ (compl '' T) by Set.compl_sUnion, and the image of a countable set stays countable. The reverse direction uses Set.compl_sInter symmetrically. Both packaged as isFσ_iff_isGδ_compl, so any Fσ statement can be discharged through Mathlib's existing Gδ API and vice versa.",
+    "mathContext": "$\\mathrm{IsF}_\\sigma(s) \\iff \\mathrm{IsG}_\\delta(s^c)$, via $(\\bigcup_0 T)^c = \\bigcap_0(\\,{\\cdot}^c\\,{}'' T)$.",
+    "significance": "key",
+    "relatedConcepts": ["De Morgan laws", "Fσ set", "Gδ set", "complementation"],
+    "prerequisites": ["point-set topology", "De Morgan laws for sets"]
+  },
+  {
+    "id": "ann-armdg-oq01-countable-fsigma",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 96, "endLine": 101 },
+    "type": "insight",
+    "title": "T1 ⟹ every countable set is an Fσ",
+    "content": "The structural dual of the parent's isGδ_compl_of_countable. A countable set s is the union of its own singletons (Set.biUnion_of_singleton), each closed because the space is T1, and the index family stays countable (image of a countable set). This is the explicit Fσ decomposition into closed singletons that the open question asks for — abstracted to its natural T1 generality.",
+    "mathContext": "$s = \\bigcup_{a \\in s} \\{a\\}$, a countable union of closed singletons $\\Rightarrow s$ is $F_\\sigma$ (in any $T_1$ space).",
+    "significance": "key",
+    "relatedConcepts": ["Fσ set", "T1 space", "closed singletons", "countable union"],
+    "prerequisites": ["separation axioms", "countability"]
+  },
+  {
+    "id": "ann-armdg-oq01-explicit-decomp",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 105, "endLine": 110 },
+    "type": "observation",
+    "title": "The algebraic reals as the union of their singletons",
+    "content": "Before packaging into IsFσ, the explicit decomposition is displayed: {x | IsAlgebraic ℚ x} = ⋃_{a algebraic} {a}. Trivial as a set identity (Set.biUnion_of_singleton), but it is precisely the concrete witness the open question requests — the algebraic reals written out as the countable union of closed singletons.",
+    "mathContext": "$\\{x \\in \\mathbb{R} : x\\ \\text{algebraic}/\\mathbb{Q}\\} = \\bigcup_{a\\ \\text{algebraic}} \\{a\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["algebraic numbers", "Fσ set", "singletons"],
+    "prerequisites": ["algebraic numbers"]
+  },
+  {
+    "id": "ann-armdg-oq01-algebraic-fsigma",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 112, "endLine": 117 },
+    "type": "insight",
+    "title": "Headline: the algebraic reals are an explicit Fσ",
+    "content": "The algebraic reals are countable (AlgebraicNumbersCountable.algebraic_reals_countable), so isFσ_of_countable exhibits them as the explicit Fσ ⋃_{a algebraic} {a}. This is the dual of the parent's headline (transcendentals = dense Gδ) and the answer to the first open question.",
+    "mathContext": "$\\{x : x\\ \\text{algebraic}\\}$ is $F_\\sigma$ — a countable union of closed singletons, since the algebraic reals are countable.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic numbers", "Fσ set", "countability"],
+    "prerequisites": ["algebraic numbers", "countability of algebraic reals"]
+  },
+  {
+    "id": "ann-armdg-oq01-transcendental-not-fsigma",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 119, "endLine": 130 },
+    "type": "insight",
+    "title": "The transcendentals are NOT an Fσ",
+    "content": "If the transcendental reals were an Fσ, then by the duality their complement — the algebraic reals — would be a Gδ, which the parent's algebraicReals_not_isGδ refutes. So the transcendentals sit on the Gδ-only side. This is the mirror image of the parent's not-Gδ result and the second half of the complete classification.",
+    "mathContext": "$\\{x : x\\ \\text{transcendental}\\}$ is not $F_\\sigma$, else $\\{x : x\\ \\text{algebraic}\\} = (\\cdot)^c$ would be $G_\\delta$.",
+    "significance": "key",
+    "relatedConcepts": ["transcendental numbers", "Fσ set", "Gδ set", "proof by contradiction"],
+    "prerequisites": ["Fσ/Gδ duality", "the algebraic reals are not Gδ"]
+  },
+  {
+    "id": "ann-armdg-oq01-dichotomy",
+    "proofId": "algebraic-reals-meager-dense-gdelta-oq-01",
+    "range": { "startLine": 132, "endLine": 153 },
+    "type": "insight",
+    "title": "The complete Gδ/Fσ classification",
+    "content": "algebraic_gδ_fσ_dichotomy packages the four facts: the algebraic reals are Fσ-but-not-Gδ, the transcendentals are Gδ-but-not-Fσ. Combined with the parent's Baire-category result (algebraic reals meagre, transcendentals comeagre), the algebraic/transcendental partition is now classified symmetrically on both axes — the exact analogue of ℚ versus the irrationals.",
+    "mathContext": "Algebraic reals: $F_\\sigma \\setminus G_\\delta$, meagre. Transcendentals: $G_\\delta \\setminus F_\\sigma$, comeagre.",
+    "significance": "key",
+    "relatedConcepts": ["Fσ set", "Gδ set", "Baire category", "algebraic vs transcendental", "rationals vs irrationals"],
+    "prerequisites": ["Fσ/Gδ duality", "Baire category"]
+  }
+]

--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/meta.json
@@ -1,0 +1,214 @@
+{
+  "id": "algebraic-reals-meager-dense-gdelta-oq-01",
+  "title": "The Algebraic Reals are an Explicit Fσ — Completing the Gδ/Fσ Dichotomy",
+  "slug": "algebraic-reals-meager-dense-gdelta-oq-01",
+  "description": "Dualizes the parent's dense-Gδ transcendentals to the algebraic side: the algebraic reals {x : ℝ | IsAlgebraic ℚ x} are exhibited as an explicit Fσ — the countable union ⋃_{a algebraic} {a} of closed singletons. Since Mathlib has the predicate IsGδ but no Fσ counterpart, this entry introduces IsFσ (a countable union of closed sets) and proves the De Morgan duality isFσ_iff_isGδ_compl: s is Fσ iff sᶜ is Gδ. It then derives the abstract lemma that every countable set in a T1 space is Fσ (dual to the parent's isGδ_compl_of_countable), applies it to the algebraic reals, and shows the transcendentals are NOT an Fσ (their Fσ-ness would make the algebraic reals Gδ, contradicting the parent). The headline is the packaged four-way classification: algebraic reals are Fσ-but-not-Gδ (and meagre), transcendentals are Gδ-but-not-Fσ (and comeagre) — the exact algebraic/transcendental analogue of ℚ/irrationals.",
+  "meta": {
+    "author": "lean-genius researcher",
+    "sourceUrl": "https://en.wikipedia.org/wiki/F%CF%83_set",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AlgebraicRealsMeagerDenseGDeltaOQ01.lean",
+    "tags": [
+      "topology",
+      "baire-category",
+      "real-analysis",
+      "f-sigma-set",
+      "g-delta-set",
+      "descriptive-set-theory",
+      "algebraic-numbers",
+      "transcendental-numbers",
+      "borel-hierarchy"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "IsGδ",
+        "description": "Mathlib's predicate for a countable intersection of open sets; dualized here to IsFσ",
+        "module": "Mathlib.Topology.GDelta.Basic"
+      },
+      {
+        "theorem": "Set.compl_sUnion",
+        "description": "(⋃₀ S)ᶜ = ⋂₀ (compl '' S) — De Morgan, turning a countable union of closed sets into a countable intersection of open sets",
+        "module": "Mathlib.Data.Set.Lattice"
+      },
+      {
+        "theorem": "Set.compl_sInter",
+        "description": "(⋂₀ S)ᶜ = ⋃₀ (compl '' S) — the reverse De Morgan passage for the duality",
+        "module": "Mathlib.Data.Set.Lattice"
+      },
+      {
+        "theorem": "Set.biUnion_of_singleton",
+        "description": "⋃ x ∈ s, {x} = s — every set is the union of its singletons, the explicit Fσ decomposition for a countable set",
+        "module": "Mathlib.Data.Set.Lattice"
+      },
+      {
+        "theorem": "isClosed_singleton",
+        "description": "In a T1 space every singleton is closed — each piece of the Fσ decomposition",
+        "module": "Mathlib.Topology.Separation.Basic"
+      },
+      {
+        "theorem": "Set.Countable.image",
+        "description": "The image of a countable set is countable — the index family of the Fσ decomposition stays countable",
+        "module": "Mathlib.Data.Set.Countable"
+      }
+    ],
+    "originalContributions": [
+      "IsFσ: introduced the Fσ predicate (a countable union of closed sets) dual to Mathlib's IsGδ, which has no Fσ counterpart",
+      "isFσ_iff_isGδ_compl: PROVED the De Morgan duality — s is Fσ iff sᶜ is Gδ — via Set.compl_sUnion / Set.compl_sInter (both directions IsFσ.isGδ_compl and isFσ_of_isGδ_compl)",
+      "isFσ_of_countable: PROVED in any T1 space every countable set is an Fσ, exhibited explicitly as the union of its closed singletons (dual to the parent's isGδ_compl_of_countable)",
+      "algebraicReals_eq_iUnion_singletons: PROVED the explicit decomposition {x | IsAlgebraic ℚ x} = ⋃_{a algebraic} {a}, displaying the Fσ structure before packaging",
+      "algebraicReals_isFσ (HEADLINE): PROVED the algebraic reals are an explicit Fσ in ℝ — the countable union of closed singletons requested by the parent's open question",
+      "transcendentalReals_not_isFσ: PROVED the transcendental reals are NOT an Fσ — were they Fσ, their complement (the algebraic reals) would be a Gδ, contradicting the parent's algebraicReals_not_isGδ",
+      "algebraic_gδ_fσ_dichotomy: PROVED the packaged four-way classification — algebraic reals Fσ-but-not-Gδ, transcendentals Gδ-but-not-Fσ — completing the Gδ/Fσ side of the dichotomy alongside the parent's meagre/comeagre Baire-category side"
+    ],
+    "axiomCount": 0,
+    "prerequisites": [
+      "Gδ sets (Mathlib's IsGδ) and the dual Fσ notion",
+      "De Morgan duality for arbitrary unions/intersections of sets",
+      "Baire category: the algebraic reals are dense and meagre, the transcendentals comeagre (parent)",
+      "Countability of the algebraic reals (Algebraic.countable)"
+    ],
+    "lineCount": 153,
+    "relatedProblems": [
+      {
+        "id": "algebraic-reals-meager-dense-gdelta",
+        "relationship": "Parent: exhibits the transcendentals as a dense Gδ and the algebraic reals as not-Gδ; its first open question asks for the dual Fσ presentation of the algebraic reals and the full Gδ/Fσ classification, which this entry supplies"
+      },
+      {
+        "id": "algebraic-reals-meager",
+        "relationship": "Grandparent: the algebraic reals are meagre and dense, the Baire-category half of the dichotomy this entry completes on the Borel-complexity side"
+      },
+      {
+        "id": "algebraic-numbers-countable",
+        "relationship": "The algebraic reals are countable — the countability input that drives the Fσ decomposition into singletons"
+      }
+    ],
+    "assumptions": "0 axioms (only propext, Classical.choice, Quot.sound — the standard Mathlib triple; no sorryAx, no native_decide). The Fσ predicate is introduced locally because Mathlib provides IsGδ but no Fσ counterpart; all results are proved from Mathlib's set-theoretic De Morgan lemmas, T1 separation, and countability, reusing the parent's algebraicReals_not_isGδ and transcendentalReals_isGδ.",
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "leanFile": {
+    "lineCount": 153,
+    "namespace": "AlgebraicRealsMeagerDenseGDeltaOQ01",
+    "opens": [
+      "Set",
+      "Topology"
+    ],
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "substantiveTheoremCount": 7,
+    "computationalVerifications": 0,
+    "lemmaCount": 0,
+    "imports": [
+      "Mathlib.Topology.GDelta.Basic",
+      "Mathlib.Topology.Baire.Lemmas",
+      "Mathlib.RingTheory.Algebraic.Basic",
+      "Mathlib.Data.Set.Lattice",
+      "Mathlib.Tactic",
+      "Proofs.AlgebraicRealsMeagerDenseGDelta"
+    ],
+    "path": "Proofs/AlgebraicRealsMeagerDenseGDeltaOQ01.lean",
+    "sorries": 0,
+    "definitionCount": 1,
+    "additionalFiles": []
+  },
+  "sorries": 0,
+  "mainTheorems": [
+    {
+      "name": "IsFσ",
+      "type": "definition",
+      "description": "A set is Fσ if it is a countable union of closed sets — the predicate dual to Mathlib's IsGδ",
+      "leanType": "∀ {X : Type*} [TopologicalSpace X], Set X → Prop"
+    },
+    {
+      "name": "isFσ_iff_isGδ_compl",
+      "type": "core",
+      "description": "The De Morgan duality: s is Fσ exactly when its complement is Gδ",
+      "leanType": "∀ {X : Type*} [TopologicalSpace X] {s : Set X}, IsFσ s ↔ IsGδ sᶜ"
+    },
+    {
+      "name": "isFσ_of_countable",
+      "type": "core",
+      "description": "In any T1 space every countable set is an Fσ, exhibited as the union of its closed singletons (dual to the parent's isGδ_compl_of_countable)",
+      "leanType": "∀ {X : Type*} [TopologicalSpace X] [T1Space X] {s : Set X}, s.Countable → IsFσ s"
+    },
+    {
+      "name": "algebraicReals_isFσ",
+      "type": "headline",
+      "description": "The algebraic reals are an explicit Fσ in ℝ — the countable union of closed singletons requested by the parent's open question",
+      "leanType": "IsFσ {x : ℝ | IsAlgebraic ℚ x}"
+    },
+    {
+      "name": "transcendentalReals_not_isFσ",
+      "type": "core",
+      "description": "The transcendental reals are NOT an Fσ — their Fσ-ness would force the algebraic reals to be a Gδ, contradicting the parent",
+      "leanType": "¬ IsFσ {x : ℝ | ¬ IsAlgebraic ℚ x}"
+    },
+    {
+      "name": "algebraic_gδ_fσ_dichotomy",
+      "type": "headline",
+      "description": "The complete classification: algebraic reals are Fσ-but-not-Gδ, transcendentals are Gδ-but-not-Fσ",
+      "leanType": "(IsFσ {x : ℝ | IsAlgebraic ℚ x} ∧ ¬ IsGδ {x : ℝ | IsAlgebraic ℚ x}) ∧ (IsGδ {x : ℝ | ¬ IsAlgebraic ℚ x} ∧ ¬ IsFσ {x : ℝ | ¬ IsAlgebraic ℚ x})"
+    }
+  ],
+  "overview": "The parent entry exhibits the transcendental reals as an explicit dense Gδ and shows the algebraic reals are not a Gδ — the Baire-category and one half of the Borel-complexity story. Its first open question asks for the dual: present the algebraic reals as an explicit Fσ (a countable union of closed singletons) and record the full Gδ/Fσ classification. Mathlib carries the predicate IsGδ but, surprisingly, no Fσ counterpart, so this entry first introduces IsFσ (a countable union of closed sets) and proves it is dual to IsGδ under complementation — isFσ_iff_isGδ_compl, both directions through the set-theoretic De Morgan laws Set.compl_sUnion and Set.compl_sInter. With the predicate in hand, every countable set in a T1 space is an Fσ (the union of its closed singletons), so the countable algebraic reals are the explicit Fσ ⋃_{a algebraic} {a}. Dually, the transcendentals cannot be an Fσ: that would make their complement — the algebraic reals — a Gδ, which the parent refuted. The result is the complete four-way classification: the algebraic reals are Fσ-but-not-Gδ (and meagre), the transcendentals are Gδ-but-not-Fσ (and comeagre), the exact algebraic/transcendental analogue of ℚ versus the irrationals.",
+  "conclusion": {
+    "summary": "A 154-line, 0-sorry, 0-axiom formalization that completes the Gδ/Fσ classification of the algebraic/transcendental dichotomy. It introduces the Fσ predicate missing from Mathlib, proves its De Morgan duality with IsGδ, and uses it to exhibit the algebraic reals as an explicit Fσ (the countable union of closed singletons) while showing the transcendentals are not an Fσ.",
+    "implications": "The pairing is now symmetric on both axes: in Baire category the algebraic reals are meagre and the transcendentals comeagre (parent); in Borel complexity the algebraic reals are Fσ-but-not-Gδ and the transcendentals are Gδ-but-not-Fσ (here). This is precisely the structure of ℚ versus the irrationals, transported to the algebraic/transcendental partition. The locally-defined IsFσ predicate and the duality isFσ_iff_isGδ_compl are reusable for any descriptive-complexity argument over Mathlib, which currently lacks an Fσ notion.",
+    "openQuestions": [
+      "Lift the Fσ/Gδ classification into Mathlib's Borel hierarchy: show the algebraic reals lie in Σ⁰₂ \\ Π⁰₂ and the transcendentals in Π⁰₂ \\ Σ⁰₂, connecting IsFσ/IsGδ to MeasurableSpace.GenerateMeasurable levels.",
+      "Make the Fσ presentation fully constructive by exhibiting an explicit enumeration a : ℕ → ℝ of the algebraic reals and the resulting increasing sequence of finite closed sets ⋃_{k ≤ n} {a k}."
+    ]
+  },
+  "references": [
+    {
+      "title": "Fσ set — Wikipedia",
+      "url": "https://en.wikipedia.org/wiki/F%CF%83_set"
+    },
+    {
+      "title": "Oxtoby, Measure and Category (Springer GTM 2)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4684-9339-9"
+    },
+    {
+      "title": "Kechris, Classical Descriptive Set Theory (Springer GTM 156)",
+      "url": "https://link.springer.com/book/10.1007/978-1-4612-4190-4"
+    }
+  ],
+  "crossReferences": [],
+  "sections": [
+    {
+      "id": "fsigma-predicate-duality",
+      "title": "The Fσ predicate and its duality with Gδ",
+      "startLine": 57,
+      "endLine": 94,
+      "summary": "Introduces IsFσ (a countable union of closed sets), dual to Mathlib's IsGδ, then proves the De Morgan duality isFσ_iff_isGδ_compl (s is Fσ iff sᶜ is Gδ) from Set.compl_sUnion and Set.compl_sInter — both directions IsFσ.isGδ_compl and isFσ_of_isGδ_compl."
+    },
+    {
+      "id": "countable-is-fsigma",
+      "title": "Countable sets are Fσ in T1 spaces",
+      "startLine": 96,
+      "endLine": 101,
+      "summary": "isFσ_of_countable: in any T1 space a countable set is an Fσ, exhibited explicitly as the union of its closed singletons — the structural dual of the parent's isGδ_compl_of_countable."
+    },
+    {
+      "id": "algebraic-reals-fsigma",
+      "title": "The algebraic reals as a concrete Fσ",
+      "startLine": 103,
+      "endLine": 130,
+      "summary": "algebraicReals_eq_iUnion_singletons displays the explicit decomposition; algebraicReals_isFσ packages it via isFσ_of_countable on the countable algebraic reals; transcendentalReals_not_isFσ shows the transcendentals are not Fσ (else their algebraic complement would be Gδ, contradicting the parent)."
+    },
+    {
+      "id": "full-dichotomy",
+      "title": "The full Gδ/Fσ classification",
+      "startLine": 132,
+      "endLine": 153,
+      "summary": "algebraic_gδ_fσ_dichotomy packages the four facts — algebraic reals Fσ-but-not-Gδ, transcendentals Gδ-but-not-Fσ — completing the Borel-complexity half of the dichotomy that pairs with the parent's Baire-category half. Closing #print axioms confirm 0 axioms."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the first open question of `algebraic-reals-meager-dense-gdelta`: **dualize** the parent's dense-Gδ transcendentals to present the **algebraic reals as an explicit Fσ** (a countable union of closed singletons), and record the **full Gδ/Fσ classification** of the dichotomy.

Mathlib carries the predicate `IsGδ` (countable intersection of opens) but — surprisingly — **no Fσ counterpart**. This entry supplies one and uses it to complete the Borel-complexity half of the algebraic/transcendental dichotomy, pairing with the parent's Baire-category half.

## Results (1 def + 7 theorems, all verified)

| name | statement |
|------|-----------|
| `IsFσ` | a set is Fσ iff it is a countable union of closed sets (dual to `IsGδ`) |
| `isFσ_iff_isGδ_compl` | **duality**: `IsFσ s ↔ IsGδ sᶜ` (via `Set.compl_sUnion`/`compl_sInter`) |
| `isFσ_of_countable` | in a T1 space every countable set is Fσ — the union of its closed singletons (dual to the parent's `isGδ_compl_of_countable`) |
| `algebraicReals_eq_iUnion_singletons` | the explicit decomposition `{x | IsAlgebraic ℚ x} = ⋃_{a alg} {a}` |
| `algebraicReals_isFσ` *(headline)* | the algebraic reals are an explicit Fσ |
| `transcendentalReals_not_isFσ` | the transcendentals are **not** Fσ (else their algebraic complement would be Gδ, contradicting the parent) |
| `algebraic_gδ_fσ_dichotomy` *(headline)* | the packaged four-way classification |

**The complete classification:**

| set | Fσ | Gδ | Baire category |
|-----|----|----|----------------|
| algebraic reals | ✓ | ✗ | meagre |
| transcendental reals | ✗ | ✓ | comeagre |

— the exact algebraic/transcendental analogue of ℚ versus the irrationals.

## Verification

- `verified`, badge `original`, **0 axioms** (standard triple `propext`/`Classical.choice`/`Quot.sound` only — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`), **0 sorries**, 153 lines.
- Kernel-verified on Mathlib 4.26.0 (`#print axioms` on all five headline results).

## Build-graph fix

The parent `AlgebraicRealsMeagerDenseGDelta` was **orphaned** from `proofs/Proofs.lean` (status `verified` but never imported → never kernel-checked in the build graph). This PR registers both the parent and the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)