### PR TITLE
audit(amgm): record 4 clean AM-GM gallery entries [verified, kernel-checked]

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -144,6 +144,18 @@
       "lastAudited": "2026-05-03T20:24:34Z",
       "result": "clean"
     },
+    "amgm-inequality-oq-02-oq-03-oq-03-oq-01": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T02:18:44Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-02-oq-03-oq-03-oq-03": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T02:18:44Z",
+      "result": "clean"
+    },
     "amgm-inequality-oq-03": {
       "auditCount": 5,
       "issues": [],
@@ -172,6 +184,12 @@
       "auditCount": 2,
       "issues": [],
       "lastAudited": "2026-05-03T20:24:34Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-03-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T02:18:44Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02-oq-04": {
@@ -208,6 +226,12 @@
       "auditCount": 1,
       "issues": [],
       "lastAudited": "2026-05-08T01:32:00Z",
+      "result": "clean"
+    },
+    "amgm-inequality-oq-04-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-06-24T02:18:44Z",
       "result": "clean"
     },
     "amgm-inequality-oq-04-oq-05": {
@@ -17806,5 +17830,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-24T01:43:02Z"
+  "lastUpdated": "2026-06-24T02:18:44Z"
 }


### PR DESCRIPTION
## Gallery Integrity Audit — AM-GM batch

Audited 4 never-audited AM-GM entries. **All clean**, kernel-verified (`#print axioms` = standard triple only: `propext`, `Classical.choice`, `Quot.sound` — no `sorryAx`, no `Lean.ofReduceBool`). meta.json claims match Lean source in every case.

| Slug | Status/Badge | thm/ax/sorry | Verdict |
|------|-------------|--------------|---------|
| `amgm-inequality-oq-02-oq-03-oq-03-oq-01` | verified/mathlib | 3/0/0 | CLEAN |
| `amgm-inequality-oq-02-oq-03-oq-03-oq-03` | verified/mathlib | 3+1def/0/0 | CLEAN |
| `amgm-inequality-oq-03-oq-02-oq-01-oq-02` | verified/mathlib | 12/0/0 | CLEAN |
| `amgm-inequality-oq-04-oq-04` | verified/original | 4/0/0 | CLEAN |

### Notable verification

- **oq-02-oq-03-oq-03-oq-01** — critical risk **refuted**: imports `AmgmInequalityOQ02`, which carries `axiom maclaurin_step` and `axiom newton_log_concavity`. The theorems here route through the **proved** `maclaurin_sq_m1_ge_m2_general` (line 230 of the parent), not the axioms, so the `verified` claim doesn't leak parent assumptions. `mathlib` badge (Tier B) is honest — the analytic engine is Mathlib's `sq_sum_le_card_mul_sum_sq`, disclosed in `assumptions`.
- **oq-02-oq-03-oq-03-oq-03** — the only `sorry` match is in a docstring (`no \`sorry\``); actual sorry count is 0.
- **oq-03-oq-02-oq-01-oq-02** — `theoremCount: 12` = 4 private lemmas + 8 theorems; matches.
- **oq-04-oq-04** — AGM quadratic-convergence inequalities (nlinarith-style), `original` badge appropriate.

This PR only updates `audit-tracker.json` (4 new entries, `result: clean`).

---
Discovered during gallery integrity audit.