### PR TITLE
Enrich Strict Weighted Power Mean Chain (WHM<WGM<WAM<WQM ⇔ a≠b)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02-oq-02/meta.json
@@ -73,7 +73,8 @@
       "Strictness needs no new analytic input: it is purely (non-strict inequality) + (equality characterization). The mathematical work was already done in the equality case; strictness is its logical shadow.",
       "All three equality conditions collapse to the single scalar a = b, so the three strict gaps are equivalent to one another and to a ≠ b. This is what makes the dichotomy 'all or nothing'.",
       "The rigidity statement any_strict_iff_all_strict has no analogue at the level of a bare inequality chain: it is a consequence of every link sharing the same equality locus.",
-      "Reusing sibling files (non-strict chain + equality case) rather than re-deriving keeps the file short and isolates the genuinely new content (the strict dichotomy)."
+      "Reusing sibling files (non-strict chain + equality case) rather than re-deriving keeps the file short and isolates the genuinely new content (the strict dichotomy).",
+      "The headline equivalence is really a statement about the equality locus: because all three links share the same locus {a = b}, strictness of the chain is governed by a single scalar invariant rather than three independent conditions. This is the two-point shadow of the strict monotonicity of the power-mean map p ↦ M_p, whose level sets degenerate only on the constant configurations."
     ],
     "prerequisites": [
       "Basic real analysis and order theory (≤ vs <)",


### PR DESCRIPTION
Enrichment pass for `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03-oq-02-oq-02` (quality 43 → ~100, 0 prior passes).

## Changes
- **Added `annotations.json`** (was missing entirely) with **7 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  1. Reciprocal identity `inv_wgm_eq` for the geometric mean
  2. `wgm_le_wam_aux` — geometric ≤ arithmetic from Mathlib AM–GM
  3. `whm_le_wgm_aux` — harmonic ≤ geometric via inverting AM–GM
  4. The `LE.le.lt_of_ne` upgrade pattern (≤ + a≠b ⇒ <)
  5. The three iff links (strict gap ⇔ a≠b via `Iff.not`)
  6. The all-or-nothing rigidity dichotomy
  7. The classical equal-weight specialization
- **Deepened `overview.keyInsights`**: added a 5th insight connecting the result to the strict monotonicity of the power-mean map p ↦ M_p and the shared equality locus {a = b}.

## Accuracy / axiom integrity
Annotations were written against the actual Lean source. The file has 0 sorries and 0 axiom declarations (verified, foundational axioms only); `status: verified` / `badge: original` left unchanged as accurate.

`pnpm build` passes; only the target entry's files are staged.