### PR TITLE
fix(audit): register orphaned CubeRoot3IrrationalOQ03 in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -815,6 +815,7 @@ import Proofs.CubeRoot3IrrationalOQ01
 import Proofs.CubeRoot3IrrationalOQ02
 import Proofs.CubeRoot3IrrationalOQ02OQ01
 import Proofs.CubeRoot3IrrationalOQ02OQ02
+import Proofs.CubeRoot3IrrationalOQ03
 import Proofs.CubeRoot3IrrationalOQ04
 import Proofs.CubeRoot3IrrationalOQ04A12
 import Proofs.CubeRoot3IrrationalOQ04Helpers


### PR DESCRIPTION
## Summary

The verified gallery entry **cube-root-3-irrational-oq-03** ("∛3 has degree 3 over ℚ": irreducibility of X³−3, minimal polynomial, [ℚ(∛3):ℚ]=3, and ℚ-linear independence of {1, ∛3, ∛9}) shipped with both its Lean file (`proofs/Proofs/CubeRoot3IrrationalOQ03.lean`) and gallery data (`src/data/proofs/cube-root-3-irrational-oq-03/`), but it was **never imported into `proofs/Proofs.lean`**.

Every sibling in the family is registered — OQ01, OQ02, OQ02OQ01, OQ02OQ02, OQ04, OQ04A12, … — **except OQ03**, which sits conspicuously absent between `OQ02OQ02` and `OQ04`. Because the file was outside the build graph, it was **never kernel-checked** by CI despite carrying `status: verified`.

## Verification

Kernel-verified clean against the build env (Lean v4.26.0):

- `lake env lean Proofs/CubeRoot3IrrationalOQ03.lean` → **exit 0** (0 sorries, 0 `axiom` declarations)
- `#print axioms` on all key theorems (`irreducible_X_cubed_sub_C_three`, `minpoly_cbrt3`, `finrank_adjoin_cbrt3`, `linearIndependent_cbrt3_powers`, `linindep_triple`) → `[propext, Classical.choice, Quot.sound]` only.

No `sorryAx`, no `Lean.ofReduceBool` — the entry's 0-axiom claim is honest. This PR makes that claim enforceable by adding the proof to the build graph.

## Change

One line: alphabetically-ordered `import Proofs.CubeRoot3IrrationalOQ03` between `OQ02OQ02` and `OQ04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)