### PR TITLE
fix(audit): correct theoremCount 7→8 for algebraic-reals Fσ entry

### DIFF
--- a/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/meta.json
+++ b/src/data/proofs/algebraic-reals-meager-dense-gdelta-oq-01/meta.json
@@ -88,7 +88,7 @@
       }
     ],
     "assumptions": "0 axioms (only propext, Classical.choice, Quot.sound — the standard Mathlib triple; no sorryAx, no native_decide). The Fσ predicate is introduced locally because Mathlib provides IsGδ but no Fσ counterpart; all results are proved from Mathlib's set-theoretic De Morgan lemmas, T1 separation, and countability, reusing the parent's algebraicReals_not_isGδ and transcendentalReals_isGδ.",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 1,
     "additionalFiles": []
   },
@@ -101,7 +101,7 @@
     ],
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "substantiveTheoremCount": 7,
     "computationalVerifications": 0,
     "lemmaCount": 0,


### PR DESCRIPTION
## Integrity Fix

**Proof**: `algebraic-reals-meager-dense-gdelta-oq-01` — *The Algebraic Reals are an Explicit Fσ*

**Problem**: `theoremCount` undercounted (7 → actual 8).

## Evidence

The Lean file `Proofs/AlgebraicRealsMeagerDenseGDeltaOQ01.lean` declares **8** theorems:

1. `IsFσ.isGδ_compl` ← the dotted-name theorem missed by the count
2. `isFσ_of_isGδ_compl`
3. `isFσ_iff_isGδ_compl`
4. `isFσ_of_countable`
5. `algebraicReals_eq_iUnion_singletons`
6. `algebraicReals_isFσ`
7. `transcendentalReals_not_isFσ`
8. `algebraic_gδ_fσ_dichotomy`

`meta.json` recorded `theoremCount: 7` in both `meta` and `leanFile`.

## Audit Verdict: CLEAN (apart from this miscount)

Kernel-verified via `#print axioms` (v4.26.0): all five headline theorems depend **only** on the standard triple `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. 

- `status: verified` ✓ (0 sorries, 0 axioms, no structure-encoded assumptions)
- `badge: original` ✓ — genuinely original (introduces `IsFσ`, which Mathlib lacks, plus the De Morgan duality and full Gδ/Fσ dichotomy; not a Mathlib wrapper)
- `definitionCount: 1`, `lineCount: 153` ✓
- Registered in `Proofs.lean` build graph (line 60) — not orphaned ✓

## Fix

`theoremCount: 7 → 8` in both locations. Undercount only (no overclaim), so credibility was not at risk — corrected for accuracy.

---
Discovered during gallery integrity audit.