### PR TITLE
research(little-wedderburn-oq-01-oq-01): uniqueness/classification of finite fields by cardinality [verified]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3190,6 +3190,7 @@ import Proofs.LiouvilleTheorem
 import Proofs.LiouvilleTheoremOQ04
 import Proofs.LiouvilleTheoremOQ05
 import Proofs.LittleWedderburnOQ01
+import Proofs.LittleWedderburnOQ01OQ01
 import Proofs.LovaszLocalLemma
 import Proofs.LovaszLocalLemmaOQ02
 import Proofs.LovaszLocalLemmaOQ02Aristotle

--- a/proofs/Proofs/LittleWedderburnOQ01OQ01.lean
+++ b/proofs/Proofs/LittleWedderburnOQ01OQ01.lean
@@ -1,0 +1,110 @@
+import Mathlib
+
+/-!
+# Uniqueness of finite fields: the classification by cardinality
+
+The parent entry (`LittleWedderburnOQ01`) records the *arithmetic shadow* of
+Wedderburn's little theorem: the order of a finite division ring is a prime power
+`p ^ n`. The natural companion to that existence-of-shape statement is a
+**uniqueness** statement: for each prime power `q` there is, up to isomorphism,
+**exactly one** finite field of order `q`.
+
+Mathlib supplies one half of this — `FiniteField.ringEquivOfCardEq`, which builds a
+(noncanonical) ring isomorphism between any two finite fields of equal cardinality,
+routed through the Galois field `GaloisField p n`. What is not recorded is the clean
+*classification* packaging usually quoted alongside the prime-power corollary:
+
+* the full **iff** `Nonempty (K ≃+* K') ↔ card K = card K'` (the reverse direction —
+  isomorphic fields have equal order — is the easy bijection direction and is *not*
+  in Mathlib as a named lemma);
+* its contrapositive: finite fields of *different* orders are never isomorphic;
+* the **canonical representative**: every finite field of order `p ^ n` is isomorphic
+  to `GaloisField p n`, so the Galois field is *the* field of that order;
+* the **existence-and-uniqueness** statement combined, and the concrete corollaries
+  that a field of prime order `p` is isomorphic to `ZMod p`, while `ZMod 2` and
+  `ZMod 3` are not isomorphic.
+
+The heavy lifting (the existence of the isomorphism for equal cardinality) is
+Mathlib's `ringEquivOfCardEq`; the new content here is the classification *iff* and
+its consequences, which turn that one-directional construction into the standard
+"exactly one finite field of each prime-power order" statement. Everything is fully
+machine-checked with no axioms or sorries.
+-/
+
+namespace LittleWedderburnOQ01OQ01
+
+/-! ## The classification theorem -/
+
+/-- **Classification of finite fields by order.** Two finite fields are
+ring-isomorphic **iff** they have the same number of elements.
+
+The forward direction is the elementary observation that a ring isomorphism is in
+particular a bijection of the underlying types; the reverse direction is the
+substantive uniqueness theorem (Mathlib's `FiniteField.ringEquivOfCardEq`, built by
+realizing both fields as splitting fields of `X ^ q - X`). -/
+theorem ringEquiv_iff_card_eq (K K' : Type*) [Field K] [Fintype K] [Field K'] [Fintype K'] :
+    Nonempty (K ≃+* K') ↔ Fintype.card K = Fintype.card K' := by
+  constructor
+  · rintro ⟨e⟩
+    exact Fintype.card_congr e.toEquiv
+  · intro h
+    exact ⟨FiniteField.ringEquivOfCardEq h⟩
+
+/-- **Finite fields of different orders are never isomorphic.** The contrapositive of
+the classification: cardinality is a complete isomorphism invariant for finite
+fields. -/
+theorem not_nonempty_ringEquiv_of_card_ne (K K' : Type*) [Field K] [Fintype K]
+    [Field K'] [Fintype K'] (h : Fintype.card K ≠ Fintype.card K') :
+    ¬ Nonempty (K ≃+* K') := by
+  rw [ringEquiv_iff_card_eq]
+  exact h
+
+/-! ## Existence: every prime power is realized -/
+
+/-- **Existence.** For a prime `p` and exponent `n ≠ 0`, the Galois field
+`GaloisField p n` is a finite field of order exactly `p ^ n`. (A re-export of
+`GaloisField.card`, recorded here as the existence half of the classification.) -/
+theorem galoisField_card (p n : ℕ) [Fact p.Prime] (hn : n ≠ 0) :
+    Nat.card (GaloisField p n) = p ^ n :=
+  GaloisField.card p n hn
+
+/-- **Canonical representative (uniqueness).** Any finite field `K` of order `p ^ n`
+is ring-isomorphic to `GaloisField p n`: among all finite fields, the Galois field is
+*the* representative of its order up to isomorphism. -/
+theorem nonempty_ringEquiv_galoisField (K : Type*) [Field K] [Fintype K] (p n : ℕ)
+    [Fact p.Prime] (hn : n ≠ 0) (h : Fintype.card K = p ^ n) :
+    Nonempty (K ≃+* GaloisField p n) := by
+  haveI : Fintype (GaloisField p n) := Fintype.ofFinite _
+  refine ⟨FiniteField.ringEquivOfCardEq ?_⟩
+  rw [h, ← Nat.card_eq_fintype_card, GaloisField.card p n hn]
+
+/-- **Existence and uniqueness combined.** For every prime power `q = p ^ n`
+(`p` prime, `n ≠ 0`) there is a finite field of order `q` — namely `GaloisField p n` —
+and every finite field of order `q` is isomorphic to it. This is the precise sense in
+which there is, up to isomorphism, exactly one field of each prime-power order. -/
+theorem exists_unique_field_of_primePow (p n : ℕ) [Fact p.Prime] (hn : n ≠ 0) :
+    Nat.card (GaloisField p n) = p ^ n ∧
+      ∀ (K : Type) [Field K] [Fintype K], Fintype.card K = p ^ n →
+        Nonempty (K ≃+* GaloisField p n) := by
+  refine ⟨GaloisField.card p n hn, ?_⟩
+  intro K _ _ h
+  exact nonempty_ringEquiv_galoisField K p n hn h
+
+/-! ## Concrete corollaries -/
+
+/-- A finite field of *prime* order `p` is ring-isomorphic to `ZMod p`. (The `n = 1`
+case of the canonical-representative theorem, against the standard model `ZMod p`.) -/
+theorem nonempty_ringEquiv_zmod (K : Type*) [Field K] [Fintype K] (p : ℕ) [Fact p.Prime]
+    (h : Fintype.card K = p) : Nonempty (K ≃+* ZMod p) := by
+  refine ⟨FiniteField.ringEquivOfCardEq ?_⟩
+  rw [h, ZMod.card]
+
+/-- The prime fields `ZMod 2` and `ZMod 3` are **not** isomorphic: they have
+different orders, so the classification rules out any ring isomorphism. -/
+theorem zmod_two_not_ringEquiv_zmod_three : ¬ Nonempty (ZMod 2 ≃+* ZMod 3) := by
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  haveI : Fact (Nat.Prime 3) := ⟨by norm_num⟩
+  rw [ringEquiv_iff_card_eq, ZMod.card, ZMod.card]
+  decide
+
+end LittleWedderburnOQ01OQ01

--- a/src/data/proofs/little-wedderburn-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/little-wedderburn-oq-01-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "classification-iff",
+    "proofId": "little-wedderburn-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 64 },
+    "type": "concept",
+    "title": "Classification of Finite Fields by Order",
+    "content": "ringEquiv_iff_card_eq is the headline: two finite fields are ring-isomorphic IFF they have the same number of elements. The forward direction is elementary — a ring isomorphism is in particular a type equivalence (e.toEquiv), so Fintype.card_congr forces equal cardinality. The reverse direction is the deep half, Mathlib's FiniteField.ringEquivOfCardEq, which builds the isomorphism by realizing both fields as splitting fields of X^q − X over their common prime subfield and invoking splitting-field uniqueness. The value of the iff is in pairing the trivial converse with the deep direction to state the standard classification.",
+    "mathContext": "$K \\cong K' \\iff |K| = |K'|$. Cardinality is a complete isomorphism invariant for finite fields — a phenomenon special to the finite case.",
+    "significance": "key",
+    "relatedConcepts": ["finite field", "ring isomorphism", "splitting field", "cardinality invariant"],
+    "prerequisites": ["finite fields", "ring isomorphisms"]
+  },
+  {
+    "id": "contrapositive",
+    "proofId": "little-wedderburn-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 72 },
+    "type": "insight",
+    "title": "Different Orders Are Never Isomorphic",
+    "content": "not_nonempty_ringEquiv_of_card_ne is the contrapositive of the classification iff: if two finite fields have different cardinalities there is no ring isomorphism between them. This is what makes cardinality a COMPLETE invariant — it both unites fields of equal order (via the iff's reverse direction) and separates fields of different order. The proof is a one-line rewrite by the iff followed by the cardinality hypothesis.",
+    "mathContext": "$|K| \\neq |K'| \\Rightarrow K \\not\\cong K'$: the order of a finite field determines its isomorphism type completely.",
+    "significance": "supporting",
+    "relatedConcepts": ["isomorphism invariant", "finite field", "contrapositive"],
+    "prerequisites": ["finite fields"]
+  },
+  {
+    "id": "canonical-representative",
+    "proofId": "little-wedderburn-oq-01-oq-01",
+    "range": { "startLine": 74, "endLine": 100 },
+    "type": "concept",
+    "title": "Existence and the Canonical Representative",
+    "content": "galoisField_card records existence: GaloisField p n has exactly p^n elements (Mathlib's GaloisField.card, stated for Nat.card). nonempty_ringEquiv_galoisField is the canonical-representative form of uniqueness — every finite field of order p^n is isomorphic to the single fixed model GaloisField p n, upgrading 'pairwise isomorphic' to 'all isomorphic to one object'. The Fintype/Nat.card bridge uses Nat.card_eq_fintype_card. exists_unique_field_of_primePow bundles the two into one statement: for each prime power there is a field of that order and every such field is isomorphic to the Galois field — 'exactly one finite field of each prime-power order'.",
+    "mathContext": "$|\\mathrm{GF}(p^n)| = p^n$, and every field of order $p^n$ is $\\cong \\mathrm{GF}(p^n)$: existence (Galois field realizes each prime power) plus uniqueness (a canonical representative).",
+    "significance": "key",
+    "relatedConcepts": ["Galois field", "canonical representative", "existence and uniqueness", "prime power"],
+    "prerequisites": ["finite fields", "Galois fields"]
+  },
+  {
+    "id": "concrete-corollaries",
+    "proofId": "little-wedderburn-oq-01-oq-01",
+    "range": { "startLine": 102, "endLine": 110 },
+    "type": "context",
+    "title": "Concrete Corollaries: Prime Fields",
+    "content": "nonempty_ringEquiv_zmod is the n = 1 specialization: a finite field of prime order p is ring-isomorphic to ZMod p, the standard model of the prime field 𝔽_p (proved via ringEquivOfCardEq with ZMod.card). zmod_two_not_ringEquiv_zmod_three reads a concrete non-isomorphism straight off the classification iff: ZMod 2 and ZMod 3 are not isomorphic because 2 ≠ 3, settled by decide after rewriting both cardinalities. These ground the abstract classification in the most familiar finite fields.",
+    "mathContext": "$|K| = p \\Rightarrow K \\cong \\mathbb{Z}/p\\mathbb{Z}$; and $\\mathbb{Z}/2\\mathbb{Z} \\not\\cong \\mathbb{Z}/3\\mathbb{Z}$ since $2 \\neq 3$.",
+    "significance": "context",
+    "relatedConcepts": ["ZMod p", "prime field", "𝔽_p", "non-isomorphism"],
+    "prerequisites": ["modular arithmetic", "finite fields"]
+  }
+]

--- a/src/data/proofs/little-wedderburn-oq-01-oq-01/meta.json
+++ b/src/data/proofs/little-wedderburn-oq-01-oq-01/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "little-wedderburn-oq-01-oq-01",
+  "slug": "little-wedderburn-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "LittleWedderburnOQ01OQ01",
+    "lineCount": 110,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "path": "Proofs/LittleWedderburnOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Uniqueness of Finite Fields: Classification by Cardinality",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LittleWedderburnOQ01OQ01.lean",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "finite-field",
+      "galois-field",
+      "classification",
+      "ring-isomorphism",
+      "wedderburn",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 110,
+    "theoremCount": 7,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "ringEquiv_iff_card_eq: the full classification iff — two finite fields are ring-isomorphic IFF they have the same cardinality. Mathlib records only the reverse direction (ringEquivOfCardEq, building the isomorphism from equal cardinality); the forward direction (isomorphic ⟹ equal order, via the underlying bijection) is supplied here and combined into the standard classification statement",
+      "not_nonempty_ringEquiv_of_card_ne: the contrapositive — finite fields of different orders are never isomorphic, so cardinality is a complete isomorphism invariant",
+      "nonempty_ringEquiv_galoisField: the canonical-representative form of uniqueness — every finite field of order p^n is ring-isomorphic to GaloisField p n, so the Galois field is THE field of that order up to isomorphism",
+      "exists_unique_field_of_primePow: existence and uniqueness combined into one statement — for each prime power q = p^n there is a finite field of order q and every such field is isomorphic to GaloisField p n (the precise 'exactly one finite field of each prime-power order')",
+      "nonempty_ringEquiv_zmod: the n = 1 specialization — a finite field of prime order p is ring-isomorphic to ZMod p",
+      "zmod_two_not_ringEquiv_zmod_three: a concrete non-isomorphism (ZMod 2 ≇ ZMod 3) read off the classification iff, demonstrating cardinality as the invariant"
+    ],
+    "prerequisites": [
+      "Mathlib's FiniteField.ringEquivOfCardEq: any two finite fields of equal cardinality are (noncanonically) ring-isomorphic, built by realizing both as splitting fields of X^q - X over their common prime subfield",
+      "GaloisField.card: the Galois field GaloisField p n has exactly p^n elements (n ≠ 0)",
+      "Fintype.card_congr: equipotent types have equal Fintype cardinality (forward direction of the iff)",
+      "ZMod.card: |ZMod n| = n for n ≠ 0"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "FiniteField.ringEquivOfCardEq",
+        "description": "Uniqueness of finite fields: any two finite fields of the same cardinality are ring-isomorphic. The substantive engine behind the reverse direction of the classification iff.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "GaloisField.card",
+        "description": "Nat.card (GaloisField p n) = p ^ n for a prime p and n ≠ 0; the existence half of the classification.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "description": "An equivalence of types induces equality of Fintype cardinalities; gives the forward direction (isomorphic ⟹ equal order).",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "ZMod.card",
+        "description": "The cardinality of ZMod n is n (for n ≠ 0); used for the prime-field specialization and the concrete non-isomorphism.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classification of finite fields is one of the oldest structure theorems in algebra, due to E. H. Moore (1893), who proved that a finite field — which he called a 'Galois field' after Évariste Galois's posthumously published work on imaginary roots of congruences — is determined up to isomorphism by its number of elements, and that this number is always a prime power. Together with Wedderburn's little theorem (1905), which removes the commutativity hypothesis by showing every finite division ring is already a field, this yields the complete picture: for every prime power q = p^n there is exactly one field of order q up to isomorphism (denoted GF(q) or 𝔽_q), and there are no finite fields of any other order. The modern construction realizes 𝔽_q as the splitting field of X^q − X over the prime field 𝔽_p, whose q roots are exactly the elements of the field; uniqueness follows because any field of order q is such a splitting field, and splitting fields are unique up to isomorphism. This entry is the uniqueness companion to the parent's prime-power-order corollary of Wedderburn.",
+    "problemStatement": "Establish that for each prime power q there is, up to isomorphism, exactly one finite field of order q. Concretely: prove the classification iff that two finite fields are ring-isomorphic precisely when they have the same number of elements; deduce that fields of different orders are never isomorphic; exhibit GaloisField p n as the canonical representative of order p^n (every finite field of that order is isomorphic to it); and specialize to the prime-order case (a field of order p is isomorphic to ZMod p) with a concrete non-isomorphism ZMod 2 ≇ ZMod 3.",
+    "proofStrategy": "The substantive direction rests on Mathlib's FiniteField.ringEquivOfCardEq, which constructs a ring isomorphism between any two finite fields of equal cardinality by realizing each as a splitting field of X^q − X over its prime subfield and invoking uniqueness of splitting fields. ringEquiv_iff_card_eq packages this with its easy converse: a ring isomorphism is in particular a type equivalence, so Fintype.card_congr gives equal cardinality. The contrapositive not_nonempty_ringEquiv_of_card_ne is then immediate. For the canonical representative, GaloisField.card supplies Nat.card (GaloisField p n) = p^n; bridging to Fintype.card via Nat.card_eq_fintype_card and feeding ringEquivOfCardEq yields nonempty_ringEquiv_galoisField, and exists_unique_field_of_primePow bundles existence and uniqueness. The concrete corollaries instantiate the iff on ZMod p (using ZMod.card) — isomorphism to a prime field, and the non-isomorphism ZMod 2 ≇ ZMod 3 settled by 2 ≠ 3.",
+    "keyInsights": [
+      "Cardinality is a complete isomorphism invariant for finite fields: |K| = |K'| is not merely necessary but sufficient for K ≅ K'. This is the content of the classification iff, and it is special to finite fields — for infinite fields equal cardinality is far from sufficient (ℝ and ℂ are equinumerous but not isomorphic).",
+      "The reverse direction (equal order ⟹ isomorphic) is the deep half and is Mathlib's ringEquivOfCardEq, built from splitting-field uniqueness of X^q − X. The forward direction (isomorphic ⟹ equal order) is trivial — a bijection — so the value of the iff is in pairing them into the standard classification statement.",
+      "GaloisField p n serves as a canonical representative: rather than only knowing that two equinumerous fields are isomorphic to each other, every field of order p^n is isomorphic to the single fixed model GaloisField p n. This upgrades 'pairwise isomorphic' to 'all isomorphic to one object'.",
+      "Existence and uniqueness are logically independent inputs: existence is GaloisField.card (the Galois field realizes every prime power), uniqueness is ringEquivOfCardEq. Combined they give 'exactly one field of each prime-power order', the statement Moore's theorem is usually quoted as.",
+      "The 'mathlib' badge is honest: the hard theorem (uniqueness via splitting fields) lives in Mathlib's ringEquivOfCardEq; the new content here is the classification iff, its contrapositive, the canonical-representative packaging, and the concrete specializations that Mathlib does not record as named statements."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Classification by Cardinality",
+      "startLine": 3,
+      "endLine": 47,
+      "summary": "Frames the entry as the uniqueness companion to the parent's prime-power-order corollary: for each prime power q there is, up to isomorphism, exactly one finite field of order q. Notes that Mathlib supplies only one direction (ringEquivOfCardEq) and that the new content is the classification iff, its contrapositive, the canonical representative, and the concrete corollaries.",
+      "mathContext": "For each prime power $q$ there is, up to isomorphism, exactly one finite field of order $q$."
+    },
+    {
+      "id": "classification",
+      "title": "The Classification Theorem",
+      "startLine": 49,
+      "endLine": 72,
+      "summary": "ringEquiv_iff_card_eq: two finite fields are ring-isomorphic iff they have equal cardinality — forward via Fintype.card_congr on the underlying equivalence, reverse via Mathlib's FiniteField.ringEquivOfCardEq. not_nonempty_ringEquiv_of_card_ne: the contrapositive, that fields of different orders are never isomorphic.",
+      "mathContext": "$K \\cong K' \\iff |K| = |K'|$; cardinality is a complete isomorphism invariant."
+    },
+    {
+      "id": "existence",
+      "title": "Existence and the Canonical Representative",
+      "startLine": 74,
+      "endLine": 100,
+      "summary": "galoisField_card: GaloisField p n has order p^n (existence). nonempty_ringEquiv_galoisField: every finite field of order p^n is isomorphic to GaloisField p n (uniqueness via a fixed representative). exists_unique_field_of_primePow: existence and uniqueness combined — exactly one finite field of each prime-power order.",
+      "mathContext": "$|\\mathrm{GF}(p^n)| = p^n$, and every field of order $p^n$ is $\\cong \\mathrm{GF}(p^n)$."
+    },
+    {
+      "id": "corollaries",
+      "title": "Concrete Corollaries",
+      "startLine": 102,
+      "endLine": 110,
+      "summary": "nonempty_ringEquiv_zmod: a finite field of prime order p is isomorphic to ZMod p (the n = 1 case). zmod_two_not_ringEquiv_zmod_three: ZMod 2 and ZMod 3 are not isomorphic, read directly off the classification iff since 2 ≠ 3.",
+      "mathContext": "$|K| = p \\Rightarrow K \\cong \\mathbb{Z}/p\\mathbb{Z}$; $\\mathbb{Z}/2\\mathbb{Z} \\not\\cong \\mathbb{Z}/3\\mathbb{Z}$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "little-wedderburn-oq-01-oq-01-oq-01",
+      "question": "Strengthen the noncanonical uniqueness to a Galois-theoretic statement: the automorphism group Aut(GaloisField p n) is cyclic of order n, generated by the Frobenius x ↦ x^p, so the finitely many isomorphisms between two fields of order p^n form a torsor under this cyclic group.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "little-wedderburn-oq-01",
+      "relationship": "extends",
+      "description": "The parent proves the existence-of-shape half — the order of a finite division ring (hence finite field) is a prime power p^n. This entry is the uniqueness companion: for each prime power there is exactly one field of that order up to isomorphism."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: FieldTheory.Finite.GaloisField",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of FiniteField.ringEquivOfCardEq (uniqueness of finite fields) and GaloisField.card."
+    },
+    {
+      "title": "A doubly-infinite system of simple groups",
+      "author": "Eliakim Hastings Moore",
+      "year": "1893",
+      "venue": "Bulletin of the New York Mathematical Society 3: 73–78",
+      "description": "Introduces 'Galois fields' and proves that a finite field is determined up to isomorphism by its (prime-power) order."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The classification of finite fields by cardinality is formalized as the iff that two finite fields are ring-isomorphic exactly when they have the same number of elements (ringEquiv_iff_card_eq), with its contrapositive that fields of different orders never coincide. The Galois field GaloisField p n is exhibited as the canonical representative of order p^n — every finite field of that order is isomorphic to it — and existence and uniqueness are bundled into 'exactly one finite field of each prime-power order'. Concretely, a field of prime order p is isomorphic to ZMod p, while ZMod 2 and ZMod 3 are not isomorphic. 110 lines, 7 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The deep direction (equal order ⟹ isomorphic) rests on Mathlib's FiniteField.ringEquivOfCardEq via splitting-field uniqueness (hence the mathlib badge); the new content is the classification iff, its contrapositive, the canonical-representative packaging over GaloisField, and the concrete specializations to prime fields. Together with the parent's prime-power-order corollary of Wedderburn, this completes the existence-and-uniqueness statement for finite fields: exactly one field of each prime-power order, none of any other order.",
+    "openQuestions": [
+      "Upgrade noncanonical uniqueness to the Galois description: Aut(GF(p^n)) is cyclic of order n, generated by Frobenius."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Ships the **uniqueness/classification** companion to `little-wedderburn-oq-01` (which records the prime-power-order *shape* of a finite division ring). For each prime power `q` there is, up to isomorphism, **exactly one** finite field of order `q`.

Mathlib provides only the one-directional engine `FiniteField.ringEquivOfCardEq` (equal cardinality ⟹ isomorphic). This entry packages it into the standard classification statement and its consequences.

## Theorems (7, all 0-axiom)

- `ringEquiv_iff_card_eq` — two finite fields are ring-isomorphic **iff** they have equal order. The forward direction (isomorphic ⟹ equal order, via the underlying bijection) is the new content; the reverse is Mathlib's `ringEquivOfCardEq`.
- `not_nonempty_ringEquiv_of_card_ne` — contrapositive: cardinality is a complete isomorphism invariant.
- `galoisField_card` — existence: `GaloisField p n` has order `p^n`.
- `nonempty_ringEquiv_galoisField` — canonical representative: every order-`p^n` field is isomorphic to `GaloisField p n`.
- `exists_unique_field_of_primePow` — existence + uniqueness combined.
- `nonempty_ringEquiv_zmod` — prime-order field ≅ `ZMod p`.
- `zmod_two_not_ringEquiv_zmod_three` — concrete non-isomorphism read off the classification.

## Verification

- **Kernel-verified clean** via `lake env lean Proofs/LittleWedderburnOQ01OQ01.lean` (EXIT 0).
- `#print axioms` on the main results: standard triple `[propext, Classical.choice, Quot.sound]` only — **no `Lean.ofReduceBool`**, no `sorryAx`. The `decide` for `2 ≠ 3` is kernel `decide`, not `native_decide`.
- 7 theorems, 0 defs, 0 axioms, 0 sorries, 110 lines.
- `badge: mathlib` (the substantive uniqueness engine is Mathlib's; the classification packaging and corollaries are the local contribution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)