### PR TITLE
fix(audit): register orphaned CauchySchwarzIntegralOQ04 in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -572,6 +572,7 @@ import Proofs.CauchySchwarzIntegralOQ02OQ01
 import Proofs.CauchySchwarzIntegralOQ02OQ02
 import Proofs.CauchySchwarzIntegralOQ02OQ02OQ01
 import Proofs.CauchySchwarzIntegralOQ03
+import Proofs.CauchySchwarzIntegralOQ04
 import Proofs.CauchySchwarzOQ01
 import Proofs.CauchySchwarzOQ01OQ01
 import Proofs.CauchySchwarzOQ01OQ01OQ01


### PR DESCRIPTION
## Summary

The verified gallery entry **cauchy-schwarz-integral-oq-04** (the Cauchy–Schwarz core of the Heisenberg/Robertson uncertainty principle) shipped with both its Lean file (`proofs/Proofs/CauchySchwarzIntegralOQ04.lean`) and gallery data, but it was **never imported into `proofs/Proofs.lean`**. Outside the build graph, it was never kernel-checked despite carrying `status: verified`.

The file proves, over any `RCLike` inner product space:
- `abs_im_inner_le_norm_mul_norm`: `|Im⟪u,v⟫| ≤ ‖u‖·‖v‖`
- `im_inner_sq_le`: `(Im⟪u,v⟫)² ≤ ‖u‖²·‖v‖²`

— the analytic core that, with `u=(A−⟨A⟩)ψ`, `v=(B−⟨B⟩)ψ`, drives `Var(A)·Var(B) ≥ ¼|⟪ψ,[A,B]ψ⟫|²`.

## Verification

Kernel-verified clean (Lean v4.26.0):
- `lake env lean Proofs/CauchySchwarzIntegralOQ04.lean` → **exit 0** (2 theorems, 0 sorries, 0 `axiom` declarations; self-contained, imports only Mathlib)
- `#print axioms` on both theorems → `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`. The 0-axiom claim is honest.

## Change

One line: `import Proofs.CauchySchwarzIntegralOQ04` in alphabetical order after `OQ03`.

## Note: broader orphan class

A sweep of `Proofs.lean` vs tracked `Proofs/*.lean` on `origin/main` shows ~180 top-level Lean files that are not imported. Many are intentional (files with sorries: `*Incomplete01`, `*WIP01`, `*Aristotle` companions). A subset, like this one and `CubeRoot3IrrationalOQ03` (PR #28626), are genuinely-verified entries mistakenly left out of the build graph. This is worth a dedicated auditor/mechanic sweep — registering only the 0-sorry, kernel-clean ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)