### PR TITLE
Enrich Dirichlet Approximation OQ-01-OQ-01: Optimality of the Hurwitz Constant √5

### DIFF
--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "dir-oq0101-ann-header",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "Hurwitz's theorem and the optimality half",
+    "content": "The docstring situates the result: Dirichlet (1842) gives infinitely many p/q with |α − p/q| < 1/q², and Hurwitz (1891) sharpens the constant to 1/√5, with √5 best possible. Mathlib has Dirichlet (constant 1), Legendre, and continued fractions, but neither the Hurwitz bound nor its sharpness. This file formalizes the optimality (sharpness) direction — for c > √5 the golden ratio is approximated within 1/(c·q²) by only finitely many fractions — leaving the existence half (the 1/√5 bound via three consecutive convergents) as future work.",
+    "mathContext": "Hurwitz: every irrational $\\alpha$ has infinitely many $p/q$ with $|\\alpha - p/q| < \\tfrac{1}{\\sqrt5\\,q^2}$, and $\\sqrt5$ is optimal; $\\varphi=\\tfrac{1+\\sqrt5}{2}$ is the extremal witness.",
+    "significance": "context",
+    "relatedConcepts": ["Diophantine approximation", "Hurwitz's theorem", "golden ratio", "badly approximable numbers"],
+    "prerequisites": ["Lean 4", "Mathlib", "elementary number theory"]
+  },
+  {
+    "id": "dir-oq0101-ann-finite-bounded-den",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-01",
+    "range": { "startLine": 59, "endLine": 93 },
+    "type": "technique",
+    "title": "Bounded-height finiteness (in-file infrastructure)",
+    "content": "finite_bounded_den re-derives, independently of the parent, the discreteness fact that converts a denominator bound into finiteness: the rationals in a bounded interval [a,b] with denominator ≤ N form a finite set. The map q ↦ (q.num, q.den) embeds them into the finite integer box [−M,M] × [1,N], where M bounds the numerators via |q.num| = |q|·q.den ≤ max|a||b|·N; injectivity comes from Rat.num_div_den (a rational is determined by its reduced numerator and denominator).",
+    "mathContext": "$\\{q\\in\\mathbb{Q} : a\\le q\\le b,\\ \\mathrm{den}(q)\\le N\\}$ is finite, embedded in $[-M,M]\\times[1,N]\\subset\\mathbb{Z}^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["finiteness", "bounded height", "injective embedding", "discreteness of ℚ"],
+    "prerequisites": ["Finset.Icc", "Set.Finite.of_finite_image", "rational num/den"]
+  },
+  {
+    "id": "dir-oq0101-ann-integer-norm",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-01",
+    "range": { "startLine": 114, "endLine": 137 },
+    "type": "insight",
+    "title": "The integer norm and its nonvanishing",
+    "content": "The arithmetic heart: with A = p − qφ and B = p − qψ, the symmetric-function identities φ+ψ=1 and φ·ψ=−1 (the coefficients of the minimal polynomial x²−x−1) make A·B collapse to the integer N = p² − pq − q². N is nonzero because φ (and ψ) are irrational — a vanishing factor would force φ = p/q ∈ ℚ. This is the only place irrationality is used: it upgrades the algebraic identity into the Diophantine lower bound that no analytic argument supplies.",
+    "mathContext": "$(p - q\\varphi)(p - q\\psi) = p^2 - pq - q^2 = N \\in \\mathbb{Z}$, and $N\\ne 0$ since $\\varphi,\\psi\\notin\\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic integer norm", "minimal polynomial", "irrationality", "conjugate"],
+    "prerequisites": ["golden ratio identities", "mul_eq_zero", "Rat.cast_def"]
+  },
+  {
+    "id": "dir-oq0101-ann-lower-bound",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-01",
+    "range": { "startLine": 138, "endLine": 161 },
+    "type": "insight",
+    "title": "Discreteness gives |A·B| ≥ 1; the conjugate gap is √5",
+    "content": "Setting a = |A|, b = |B|, the nonzero integer N has |N| ≥ 1 (Int.one_le_abs), so a·b = |A·B| = |N| ≥ 1. The conjugate gap φ − ψ = √5 yields B = A + q√5, hence by the triangle inequality b ≤ a + q√5. The golden ratio resists approximation precisely because the second factor is forced large (≈ q√5) whenever the first is small, while their product cannot dip below 1.",
+    "mathContext": "$1 \\le ab = |N|$ (discreteness of $\\mathbb{Z}$); $B = A + q\\sqrt5$ so $b \\le a + q\\sqrt5$ since $\\varphi-\\psi=\\sqrt5$.",
+    "significance": "key",
+    "relatedConcepts": ["discreteness of ℤ", "Int.one_le_abs", "triangle inequality", "spectral gap to conjugate"],
+    "prerequisites": ["absolute value of integers", "golden ratio conjugate identity"]
+  },
+  {
+    "id": "dir-oq0101-ann-denominator-bound",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-01",
+    "range": { "startLine": 162, "endLine": 220 },
+    "type": "technique",
+    "title": "Clearing denominators: (c² − c√5)·q² < 1 and finiteness",
+    "content": "From the hypothesis, a = q·|φ − r| < 1/(c·q). Combining 1 ≤ a² + a·q√5 with this and multiplying through by (c·q)² gives the uniform denominator bound (c² − c√5)·q² < 1. Because c > √5 makes the leading coefficient c² − c√5 = c(c−√5) > 0, the denominators q are bounded by an M depending only on c (at c = √5 the bound degenerates, matching Hurwitz's infinitely-many at the threshold). The value bound |φ − r| < 1 confines r to [φ−1, φ+1], and finite_bounded_den concludes finiteness.",
+    "mathContext": "$(c^2 - c\\sqrt5)\\,q^2 < 1$ with $c^2 - c\\sqrt5 > 0 \\iff c > \\sqrt5$; hence $q \\le M(c)$ and $r\\in[\\varphi-1,\\varphi+1]$.",
+    "significance": "key",
+    "relatedConcepts": ["denominator bound", "break-even constant", "nlinarith", "ordered-field estimates"],
+    "prerequisites": ["lt_div_iff₀", "nonlinear arithmetic", "the finiteness lemma"]
+  },
+  {
+    "id": "dir-oq0101-ann-corollaries",
+    "proofId": "dirichlet-approximation-theorem-oq-01-oq-01",
+    "range": { "startLine": 222, "endLine": 239 },
+    "type": "concept",
+    "title": "Corollaries: √5 is best possible",
+    "content": "not_infinite_approx_gt_sqrt5 restates finiteness as 'not infinite' for c > √5. hurwitz_constant_optimal is the headline sharpness statement: for any c > √5 it is false that every irrational has infinitely many approximations within 1/(c·q²) — the golden ratio (Real.goldenRatio_irrational) is the universal counterexample. This precisely complements Hurwitz's existence theorem: √5 cannot be improved.",
+    "mathContext": "$\\forall c > \\sqrt5,\\ \\neg\\,\\big(\\forall \\xi \\text{ irrational},\\ \\{r : |\\xi - r| < \\tfrac{1}{c\\,r.\\mathrm{den}^2}\\}\\text{ infinite}\\big)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["optimality", "counterexample", "Hurwitz constant", "Lagrange spectrum"],
+    "prerequisites": ["Set.Infinite", "irrationality of φ"]
+  }
+]

--- a/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dirichlet-approximation-theorem-oq-01-oq-01/meta.json
@@ -104,12 +104,20 @@
       "summary": "finite_bounded_den: a self-contained re-derivation (independent of the parent file) embedding q ↦ (q.num, q.den) into the finite integer box Finset.Icc(-M,M) ×ˢ Finset.Icc 1 N with M ≥ max|a||b|·N, and injectivity via Rat.num_div_den. This is the discreteness fact that converts the denominator bound into finiteness."
     },
     {
-      "id": "optimality-finiteness",
-      "title": "Optimality: Finitely Many Approximations Beyond √5",
+      "id": "optimality-integer-norm",
+      "title": "Main Theorem, Part 1: The Integer Norm and |A·B| ≥ 1",
       "startLine": 97,
+      "endLine": 161,
+      "mathContext": "(p − qφ)(p − qψ) = p² − pq − q² = N ∈ ℤ, N ≠ 0 by irrationality, so |A·B| = |N| ≥ 1; and B = A + q√5.",
+      "summary": "The arithmetic core of finite_approx_gt_sqrt5. Sets up c > √5 (so c² − c√5 > 0), builds the integer norm N = p² − pq − q², and proves the factorization (p − qφ)(p − qψ) = N via the golden-ratio identities φ+ψ=1, φψ=−1. Shows N ≠ 0 from the irrationality of φ and ψ (a zero factor would force one of them rational), giving the Diophantine lower bound |A·B| = |N| ≥ 1 (Int.one_le_abs). Records the conjugate-gap relation B = A + q√5 (from φ − ψ = √5) and the triangle bound b ≤ a + q√5."
+    },
+    {
+      "id": "optimality-denominator-bound",
+      "title": "Main Theorem, Part 2: Denominator Bound and Finiteness",
+      "startLine": 162,
       "endLine": 222,
-      "mathContext": "For c > √5, {r : ℚ | |φ − r| < 1/(c·r.den²)} is finite.",
-      "summary": "finite_approx_gt_sqrt5: the main theorem. Builds the integer norm N = p² − pq − q², proves the factorization (p − qφ)(p − qψ) = N via φ+ψ=1 and φψ=−1, shows N ≠ 0 from the irrationality of φ and ψ (a zero factor forces φ or ψ rational), and hence |A·B| = |N| ≥ 1. Using B = A + q√5 (from φ − ψ = √5) and the triangle inequality gives 1 ≤ |A|² + |A|·q√5; substituting |A| = q·|φ − r| < 1/(c·q) and clearing denominators yields (c² − c√5)·q² < 1. Since c² − c√5 > 0, the denominators are bounded by an M depending only on c; with |φ − r| < 1 confining r to [φ−1, φ+1], finite_bounded_den finishes."
+      "mathContext": "(c² − c√5)·q² < 1 with c² − c√5 > 0 ⇒ q ≤ M(c); |φ − r| < 1 ⇒ r ∈ [φ−1, φ+1]; finite by finite_bounded_den.",
+      "summary": "Turns the lower bound into finiteness. Substitutes |A| = q·|φ − r| < 1/(c·q) into 1 ≤ |A|² + |A|·q√5 and clears denominators to derive the uniform bound (c² − c√5)·q² < 1. Since c² − c√5 = c(c − √5) > 0, the denominators are bounded by an M depending only on c; combined with the value bound |φ − r| < 1 (confining r to [φ−1, φ+1]), finite_bounded_den concludes that the approximation set is finite."
     },
     {
       "id": "optimality-corollaries",


### PR DESCRIPTION
Enrichment pass for `dirichlet-approximation-theorem-oq-01-oq-01` (quality 43 → ~100, 0 prior passes).

## Changes
- **Added `annotations.json`** (was missing) with **6 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`: the Hurwitz/optimality framing, the bounded-height finiteness lemma, the integer-norm factorization and its nonvanishing (irrationality ⇒ |N| ≥ 1), the conjugate-gap relation B = A + q√5, the denominator bound (c²−c√5)·q² < 1 and finiteness, and the optimality corollaries.
- **Split the main-theorem section** into two (integer norm / denominator bound) so the `sections` track the proof phases at finer grain.

## Accuracy / axiom integrity
Annotations written against the actual Lean source (line ranges verified). File has 0 sorries, 0 axioms; the sole hypothesis is c > √5. `status: verified` / `badge: original` left unchanged as accurate.

`pnpm build` passes; only the target entry's files are staged.