### PR TITLE
research(tietze-extension-theorem-oq-01-oq-01): converse of Tietze — the Tietze property implies normality [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3761,6 +3761,7 @@ import Proofs.ThreeSquaresWitnessObstruction
 import Proofs.ThreeSubgroupsLemmaOQ01
 import Proofs.ThueMorse
 import Proofs.TietzeExtensionTheoremOQ01
+import Proofs.TietzeExtensionTheoremOQ01OQ01
 import Proofs.TractatusOntology
 import Proofs.TractatusOntologyEquiv
 import Proofs.TractatusOntologyHorn

--- a/proofs/Proofs/TietzeExtensionTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/TietzeExtensionTheoremOQ01OQ01.lean
@@ -1,0 +1,158 @@
+/-
+# The Converse of the Tietze Extension Theorem
+
+The classical Tietze extension theorem states that in a *normal* topological space,
+every continuous real-valued function defined on a closed subset extends to a
+continuous function on the whole space.  The parent entry
+(`TietzeExtensionTheoremOQ01`) develops this forward direction and derives Urysohn's
+lemma from it.
+
+This file proves the **converse**: a space in which every continuous real function on a
+closed set extends to the whole space is automatically *normal*.  Together with the
+forward direction this gives the equivalence
+
+  `normal  ⟺  Tietze extension property`,
+
+closing one of the standard characterisations of normality (alongside Urysohn's lemma).
+
+## The construction
+
+Given two disjoint closed sets `A` and `B`, their union `s = A ∪ B` is closed.  Inside
+`s` each of `A` and `B` is **clopen** (relatively open and closed), because they are
+disjoint closed sets whose union is all of `s`.  Hence the two-valued function
+
+  `f : s → ℝ`,   `f = 0` on `A`,   `f = 1` on `B`
+
+is continuous on `s` (it is locally constant on a clopen partition).  The Tietze
+property extends `f` to a continuous `F : X → ℝ`.  The preimages
+`F ⁻¹' (Iio ½)` and `F ⁻¹' (Ioi ½)` are then disjoint open neighbourhoods of `A`
+and `B`, witnessing normality.
+
+Notably the argument uses **no separation hypothesis** on `X` whatsoever: the Tietze
+extension property alone forces normality (in Mathlib's `NormalSpace`, which does not
+bundle `T1`).  The classical statement "a `T1` space with the Tietze property is
+normal" then follows immediately, and is recorded as a corollary.
+
+All results are fully machine-checked with no `sorry` and no extra axioms.
+-/
+import Mathlib
+
+namespace TietzeExtensionTheoremOQ01OQ01
+
+open Set Topology
+
+variable {X : Type*} [TopologicalSpace X]
+
+/-- The **Tietze extension property** of a topological space `X`: every continuous
+real-valued function on a closed subset `s ⊆ X` extends to a continuous function on all
+of `X`.  This is exactly the conclusion of Mathlib's `ContinuousMap.exists_restrict_eq`
+for `NormalSpace`s; here we take it as a hypothesis in order to prove its converse. -/
+def HasTietzeExtensionProperty (X : Type*) [TopologicalSpace X] : Prop :=
+  ∀ {s : Set X}, IsClosed s → ∀ f : C(s, ℝ), ∃ g : C(X, ℝ), g.restrict s = f
+
+/-- Every normal space has the Tietze extension property: this is the *forward*
+direction of the Tietze theorem, recorded here so the converse below completes a genuine
+equivalence. -/
+theorem hasTietzeExtensionProperty_of_normalSpace [NormalSpace X] :
+    HasTietzeExtensionProperty X :=
+  fun hs f => f.exists_restrict_eq hs
+
+/-- **Key geometric fact.** If `A` and `B` are disjoint closed sets with union `s`, then,
+viewed inside the subspace `s`, the part lying over `B` is clopen.  (By symmetry the same
+holds for `A`.) -/
+theorem isClopen_subtype_of_disjoint_closed {A B : Set X} (hA : IsClosed A) (hB : IsClosed B)
+    (hAB : Disjoint A B) :
+    IsClopen {x : (A ∪ B : Set X) | (x : X) ∈ B} := by
+  constructor
+  · -- closed: preimage of the closed set `B` under the (continuous) inclusion
+    exact hB.preimage continuous_subtype_val
+  · -- open: its complement in `s` is the closed part over `A`
+    have hcompl : {x : (A ∪ B : Set X) | (x : X) ∈ B}ᶜ = {x : (A ∪ B : Set X) | (x : X) ∈ A} := by
+      ext x
+      have hx : (x : X) ∈ A ∪ B := x.2
+      simp only [mem_compl_iff, mem_setOf_eq]
+      constructor
+      · intro hxB
+        rcases hx with hxA | hxB'
+        · exact hxA
+        · exact absurd hxB' hxB
+      · intro hxA hxB
+        exact (hAB.le_bot ⟨hxA, hxB⟩).elim
+    rw [← isClosed_compl_iff, hcompl]
+    exact hA.preimage continuous_subtype_val
+
+/-- **Converse of the Tietze extension theorem.**  A topological space in which every
+continuous real function on a closed set extends to the whole space is *normal*.
+
+No separation axiom on `X` is required. -/
+theorem normalSpace_of_hasTietzeExtensionProperty
+    (h : HasTietzeExtensionProperty X) : NormalSpace X := by
+  classical
+  refine ⟨fun A B hA hB hAB => ?_⟩
+  -- Work on the closed union `s = A ∪ B`.
+  set s : Set X := A ∪ B with hs_def
+  have hs : IsClosed s := hA.union hB
+  -- The part of `s` lying over `B` is clopen, so the `{0,1}`-valued indicator is continuous.
+  set Bsub : Set s := {x : s | (x : X) ∈ B} with hBsub_def
+  have hBclopen : IsClopen Bsub := isClopen_subtype_of_disjoint_closed hA hB hAB
+  have hfront : frontier {x : s | x ∈ Bsub} = (∅ : Set s) := by
+    simpa [Bsub, setOf_mem_eq] using hBclopen.frontier_eq
+  -- `f = 1` on `B`, `f = 0` on `A`, continuous on `s`.
+  have hcont : Continuous fun x : s => if x ∈ Bsub then (1 : ℝ) else 0 := by
+    refine Continuous.if (fun a ha => ?_) continuous_const continuous_const
+    rw [hfront] at ha
+    exact absurd ha (Set.notMem_empty a)
+  let f : C(s, ℝ) := ⟨fun x => if x ∈ Bsub then (1 : ℝ) else 0, hcont⟩
+  -- Extend `f` to all of `X` via the Tietze property.
+  obtain ⟨F, hF⟩ := h hs f
+  -- Pointwise description of the extension on `s`.
+  have hval : ∀ x : s, F x = if x ∈ Bsub then (1 : ℝ) else 0 := by
+    intro x
+    have := ContinuousMap.congr_fun hF x
+    simpa [f] using this
+  -- `F = 0` on `A`.
+  have hFA : ∀ a ∈ A, F a = 0 := by
+    intro a ha
+    have hmem : a ∈ s := Or.inl ha
+    have hnotB : (⟨a, hmem⟩ : s) ∉ Bsub := by
+      simp only [hBsub_def, mem_setOf_eq]
+      exact fun hbB => (hAB.le_bot ⟨ha, hbB⟩).elim
+    have := hval ⟨a, hmem⟩
+    simpa [hnotB] using this
+  -- `F = 1` on `B`.
+  have hFB : ∀ b ∈ B, F b = 1 := by
+    intro b hb
+    have hmem : b ∈ s := Or.inr hb
+    have hinB : (⟨b, hmem⟩ : s) ∈ Bsub := by
+      simp only [hBsub_def, mem_setOf_eq]; exact hb
+    have := hval ⟨b, hmem⟩
+    simpa [hinB] using this
+  -- Separate `A` and `B` by the open level sets of `F`.
+  refine ⟨F ⁻¹' Iio (1 / 2), F ⁻¹' Ioi (1 / 2),
+    isOpen_Iio.preimage F.continuous, isOpen_Ioi.preimage F.continuous, ?_, ?_, ?_⟩
+  · intro a ha
+    simp only [mem_preimage, mem_Iio, hFA a ha]; norm_num
+  · intro b hb
+    simp only [mem_preimage, mem_Ioi, hFB b hb]; norm_num
+  · rw [Set.disjoint_left]
+    intro x hx hx'
+    simp only [mem_preimage, mem_Iio] at hx
+    simp only [mem_preimage, mem_Ioi] at hx'
+    linarith
+
+/-- **Classical statement.**  A `T1` space with the Tietze extension property is normal
+(hence a `T4` space).  The `T1` hypothesis is not actually used by the proof — normality
+follows from the extension property alone — but is included to match the usual
+"normal ⟺ Tietze" phrasing where normality is taken to include `T1`. -/
+theorem t1Space_normalSpace_of_hasTietzeExtensionProperty [T1Space X]
+    (h : HasTietzeExtensionProperty X) : NormalSpace X :=
+  normalSpace_of_hasTietzeExtensionProperty h
+
+/-- **The equivalence.**  For any topological space, normality is *equivalent* to the
+Tietze extension property. -/
+theorem normalSpace_iff_hasTietzeExtensionProperty :
+    NormalSpace X ↔ HasTietzeExtensionProperty X :=
+  ⟨fun _ => hasTietzeExtensionProperty_of_normalSpace,
+   normalSpace_of_hasTietzeExtensionProperty⟩
+
+end TietzeExtensionTheoremOQ01OQ01

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,100 @@
+[
+  {
+    "id": "ann-tietze-property",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 58
+    },
+    "type": "definition",
+    "title": "The Tietze Extension Property",
+    "content": "`HasTietzeExtensionProperty X` abstracts the conclusion of the Tietze extension theorem into a hypothesis on the space: for every closed s ⊆ X and every f ∈ C(s, ℝ) there is g ∈ C(X, ℝ) with g.restrict s = f. The forward direction `hasTietzeExtensionProperty_of_normalSpace` shows every NormalSpace has this property — it is exactly Mathlib's `ContinuousMap.exists_restrict_eq` repackaged. Stating it this way lets the converse below be assembled into a genuine equivalence rather than a one-sided restatement.",
+    "mathContext": "$\\mathrm{TietzeProp}(X):\\ \\forall s\\ \\text{closed},\\ \\forall f\\in C(s,\\mathbb{R}),\\ \\exists g\\in C(X,\\mathbb{R}),\\ g|_s=f$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Tietze extension theorem",
+      "normal space",
+      "continuous extension",
+      "ContinuousMap.restrict"
+    ],
+    "prerequisites": [
+      "normal spaces",
+      "bundled continuous maps C(s, ℝ)",
+      "function restriction"
+    ]
+  },
+  {
+    "id": "ann-clopen-lemma",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 60,
+      "endLine": 82
+    },
+    "type": "theorem",
+    "title": "The Clopen Boundary Lemma",
+    "content": "`isClopen_subtype_of_disjoint_closed` is the geometric heart of the argument. For disjoint closed A, B, look at the subspace s = A ∪ B. The part of s lying over B is closed, being the preimage of the closed set B under the continuous inclusion s ↪ X. It is also open: its complement in s is the part lying over A, because every point of s belongs to A or B (it is their union) and not to both (they are disjoint); that complement is again the preimage of a closed set, so it is closed, making the original set open. Hence it is clopen.",
+    "mathContext": "Inside $s=A\\cup B$, the set $\\{x:x\\in B\\}$ is clopen — closed as the preimage of $B$, open since its complement is $\\{x:x\\in A\\}$ (using $A\\cap B=\\varnothing$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "clopen set",
+      "subspace topology",
+      "preimage of closed set",
+      "disjoint closed sets"
+    ],
+    "prerequisites": [
+      "IsClosed.preimage",
+      "isClosed_compl_iff",
+      "subtype topology"
+    ]
+  },
+  {
+    "id": "ann-converse-main",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 84,
+      "endLine": 141
+    },
+    "type": "theorem",
+    "title": "The Converse: Tietze Property Implies Normality",
+    "content": "`normalSpace_of_hasTietzeExtensionProperty` is the new content. Since the part of s = A ∪ B over B is clopen, it has empty frontier, so the two-valued function x ↦ (if x ∈ B then 1 else 0) is continuous on s by `Continuous.if` (the frontier hypothesis is vacuous) — this is the {0,1} boundary function f, equal to 0 on A and 1 on B. The Tietze property extends f to F ∈ C(X, ℝ); unwinding F.restrict s = f at points of A and B gives F = 0 on A and F = 1 on B. Finally F⁻¹(Iio ½) and F⁻¹(Ioi ½) are open (preimages of open rays under the continuous F), contain A and B respectively, and are disjoint because ½ separates the two rays — exactly the disjoint open neighbourhoods required by NormalSpace. No separation axiom on X is used anywhere.",
+    "mathContext": "Extend the $\\{0,1\\}$ boundary function on $A\\cup B$ to $F:X\\to\\mathbb{R}$; then $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$ and $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens, so $X$ is normal.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "Tietze extension converse",
+      "normal space",
+      "SeparatedNhds",
+      "level sets of continuous functions",
+      "Continuous.if"
+    ],
+    "prerequisites": [
+      "clopen boundary lemma",
+      "Continuous.if and empty frontier",
+      "isOpen_Iio / isOpen_Ioi",
+      "NormalSpace constructor"
+    ]
+  },
+  {
+    "id": "ann-corollaries",
+    "proofId": "tietze-extension-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 143,
+      "endLine": 156
+    },
+    "type": "theorem",
+    "title": "The T1 Statement and the Full Equivalence",
+    "content": "`t1Space_normalSpace_of_hasTietzeExtensionProperty` restates the result under the classical T1 hypothesis used in textbook phrasings of 'normal ⟺ Tietze'; the hypothesis is not used by the proof, so the entry is explicit that the bare extension property already forces normality. `normalSpace_iff_hasTietzeExtensionProperty` then pairs the converse with the forward direction into a true biconditional: a space is normal if and only if it has the Tietze extension property. This is the arrow absent from Mathlib, completing the loop 'normal ⟺ Tietze ⟺ Urysohn' opened by the parent entry.",
+    "mathContext": "$\\mathrm{T1}+\\mathrm{TietzeProp}\\Rightarrow\\mathrm{Normal}$; and $\\mathrm{Normal}\\iff\\mathrm{TietzeProp}$.",
+    "significance": "important",
+    "relatedConcepts": [
+      "T1 space",
+      "normal space characterization",
+      "biconditional equivalence",
+      "Urysohn's lemma"
+    ],
+    "prerequisites": [
+      "the converse theorem",
+      "forward Tietze direction",
+      "T1Space"
+    ]
+  }
+]

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/TietzeExtensionTheoremOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const tietzeExtensionTheoremOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const tietzeExtensionTheoremOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const tietzeExtensionTheoremOQ01OQ01Data: ProofData = {
+  proof: tietzeExtensionTheoremOQ01OQ01Proof,
+  annotations: tietzeExtensionTheoremOQ01OQ01Annotations,
+}

--- a/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/tietze-extension-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,180 @@
+{
+  "id": "tietze-extension-theorem-oq-01-oq-01",
+  "slug": "tietze-extension-theorem-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Topology"
+    ],
+    "namespace": "TietzeExtensionTheoremOQ01OQ01",
+    "lineCount": 158,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/TietzeExtensionTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "The Converse of the Tietze Extension Theorem: the Tietze Property Implies Normality",
+  "description": "The parent entry derives Urysohn's lemma from the Tietze extension theorem in a normal space; this entry proves the reverse implication, closing the equivalence 'normal ⟺ Tietze extension property'. The Tietze extension property of a space X is taken as a hypothesis: every continuous real function on a closed subset extends continuously to all of X. The main theorem normalSpace_of_hasTietzeExtensionProperty shows that any space with this property is normal — and, sharper than the classical statement, no separation axiom on X is needed. Given disjoint closed sets A and B, their union s = A ∪ B is closed and, inside the subspace s, the part lying over B is clopen (closed as a preimage of B; open because its complement in s is the closed part over A, using disjointness). Hence the {0,1}-valued function that is 0 on A and 1 on B is continuous on s (it is locally constant on a clopen partition, here proved directly via Continuous.if with empty frontier). The Tietze property extends it to a continuous F : X → ℝ, and the disjoint open level sets F⁻¹(Iio ½) and F⁻¹(Ioi ½) separate A from B, witnessing normality. The classical 'a T1 space with the Tietze property is normal' is recorded as a corollary, and the full equivalence normalSpace_iff_hasTietzeExtensionProperty packages both directions.",
+  "overview": {
+    "historicalContext": "Heinrich Tietze (1915) proved that a continuous real-valued function on a closed subset of a metric space extends continuously to the whole space; Pavel Urysohn (1925) generalized this to arbitrary normal spaces. The Tietze extension theorem, Urysohn's lemma, and normality are the three classically equivalent expressions of the separation of disjoint closed sets by continuous functions. The forward implications — normal ⟹ Urysohn ⟹ Tietze — are the textbook development and are formalized in Mathlib (Mathlib.Topology.TietzeExtension) and in this entry's parent. The reverse direction, that the Tietze extension property characterizes normality, is the missing arrow that completes the equivalence; it is short but is not recorded in Mathlib. This entry supplies it with an explicit clopen boundary-function construction, mirroring the parent's derivation of Urysohn from Tietze but running the logic in the opposite direction: there the extension theorem is used to build a separator, here the ability to extend an arbitrary boundary function is shown to force the separation property itself.",
+    "problemStatement": "Take as hypothesis that a topological space X has the Tietze extension property: for every closed set s ⊆ X, every f ∈ C(s, ℝ) admits g ∈ C(X, ℝ) with g.restrict s = f. Prove that X is then a normal space (Mathlib's NormalSpace: disjoint closed sets admit disjoint open neighbourhoods). Deduce the classical statement that a T1 space with the Tietze property is normal, and assemble the full equivalence normal ⟺ Tietze property.",
+    "proofStrategy": "Let A, B be disjoint closed sets and set s = A ∪ B, which is closed. The key geometric lemma isClopen_subtype_of_disjoint_closed shows that, inside the subspace s, the set Bsub = {x ∈ s | x ∈ B} is clopen: it is closed as the preimage of the closed set B under the continuous inclusion, and open because its complement in s equals {x ∈ s | x ∈ A} (every point of s lies in A or B, and not both since A, B are disjoint), again a preimage of a closed set. A clopen set has empty frontier, so the two-valued function x ↦ (if x ∈ Bsub then 1 else 0) is continuous on s by Continuous.if (the frontier hypothesis is vacuous), giving f ∈ C(s, ℝ) equal to 1 on B and 0 on A. The Tietze property yields F ∈ C(X, ℝ) with F.restrict s = f; unwinding this restriction equality gives F = 0 on A and F = 1 on B. Finally F⁻¹(Iio ½) and F⁻¹(Ioi ½) are open (preimages of open sets under continuous F), contain A and B respectively (0 < ½ and 1 > ½), and are disjoint (½ separates the two rays), exhibiting SeparatedNhds A B and hence NormalSpace X. The T1 corollary discards the unused separation hypothesis, and the equivalence pairs this converse with the forward direction hasTietzeExtensionProperty_of_normalSpace (Mathlib's ContinuousMap.exists_restrict_eq).",
+    "keyInsights": [
+      "The converse needs no separation axiom. The classical phrasing assumes a T1 space, but the proof never uses T1: the bare Tietze extension property forces Mathlib's NormalSpace (which is not bundled with T1) on its own. The T1 version is a strict corollary, and stating it separately keeps the logical content honest.",
+      "Normality is recovered from a single extension. Where the textbook builds the Tietze extension out of repeated Urysohn separations, here one application of the extension property to one explicit boundary function produces the separating neighbourhoods directly — the equivalence with normality is concrete, not folklore.",
+      "The whole construction is encoded in one clopen set, exactly as in the parent's forward direction. On the closed union A ∪ B the part over B is simultaneously closed (preimage of B) and open (its complement is the preimage of A, by disjointness). Clopen-ness gives an empty frontier, which is precisely the side condition that makes the {0,1} indicator continuous via Continuous.if, with no ε–δ argument.",
+      "Half is the only threshold that matters. Once a continuous F equals 0 on A and 1 on B, any value strictly between separates them; ½ is chosen so that F⁻¹(Iio ½) and F⁻¹(Ioi ½) are automatically disjoint open sets, turning the analytic extension back into a topological separation.",
+      "Pairing the converse with Mathlib's forward direction yields a genuine iff. hasTietzeExtensionProperty_of_normalSpace is ContinuousMap.exists_restrict_eq repackaged as the defined property, so normalSpace_iff_hasTietzeExtensionProperty is a true equivalence rather than a one-sided restatement — the arrow this entry adds is the one absent from the library."
+    ]
+  },
+  "sections": [
+    {
+      "id": "tietze-property",
+      "title": "The Tietze Extension Property and the Forward Direction",
+      "startLine": 46,
+      "endLine": 58,
+      "summary": "HasTietzeExtensionProperty X packages the conclusion of the Tietze theorem as a property: every continuous real function on a closed set extends to all of X. hasTietzeExtensionProperty_of_normalSpace records the forward direction — every NormalSpace has this property — as a thin wrapper around Mathlib's ContinuousMap.exists_restrict_eq, so the converse below completes a genuine equivalence.",
+      "mathContext": "$\\mathrm{TietzeProp}(X):\\ \\forall\\,s\\ \\text{closed},\\ \\forall f\\in C(s,\\mathbb{R}),\\ \\exists g\\in C(X,\\mathbb{R}),\\ g|_s=f$; and $\\mathrm{Normal}\\Rightarrow\\mathrm{TietzeProp}$."
+    },
+    {
+      "id": "clopen-lemma",
+      "title": "The Clopen Boundary Lemma",
+      "startLine": 60,
+      "endLine": 82,
+      "summary": "isClopen_subtype_of_disjoint_closed: for disjoint closed A, B, the part of the subspace s = A ∪ B lying over B is clopen. Closed as the preimage of B under the continuous inclusion; open because its complement in s is exactly the part over A (each point of s is in A or B and not both), again a preimage of a closed set. This is the geometric engine of the whole argument.",
+      "mathContext": "Inside $s=A\\cup B$, the set $\\{x : x\\in B\\}$ is clopen: closed (preimage of $B$) and open (complement is $\\{x:x\\in A\\}$, by $A\\cap B=\\varnothing$)."
+    },
+    {
+      "id": "converse",
+      "title": "The Converse: Tietze Property Implies Normal",
+      "startLine": 84,
+      "endLine": 141,
+      "summary": "normalSpace_of_hasTietzeExtensionProperty: the main result. The clopen set has empty frontier, so x ↦ (if x ∈ B then 1 else 0) is continuous on s by Continuous.if; the Tietze property extends it to F : X → ℝ with F = 0 on A, F = 1 on B; then F⁻¹(Iio ½) and F⁻¹(Ioi ½) are disjoint open neighbourhoods of A and B. No separation axiom on X is used.",
+      "mathContext": "Disjoint closed $A,B$: extend the $\\{0,1\\}$ boundary function on $A\\cup B$ to $F:X\\to\\mathbb{R}$; then $F^{-1}(-\\infty,\\tfrac12)\\supseteq A$ and $F^{-1}(\\tfrac12,\\infty)\\supseteq B$ are disjoint opens."
+    },
+    {
+      "id": "corollaries",
+      "title": "The T1 Statement and the Equivalence",
+      "startLine": 143,
+      "endLine": 156,
+      "summary": "t1Space_normalSpace_of_hasTietzeExtensionProperty restates the result under the classical T1 hypothesis (which is not actually used). normalSpace_iff_hasTietzeExtensionProperty pairs the converse with the forward direction into the full equivalence normal ⟺ Tietze extension property.",
+      "mathContext": "$\\mathrm{T1}+\\mathrm{TietzeProp}\\Rightarrow\\mathrm{Normal}$; and $\\mathrm{Normal}\\iff\\mathrm{TietzeProp}$."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/TietzeExtensionTheoremOQ01OQ01.lean",
+    "tags": [
+      "topology",
+      "separation-axioms",
+      "normal-space",
+      "tietze-extension",
+      "clopen-set",
+      "continuous-function",
+      "extension-theorem",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 158,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "HasTietzeExtensionProperty: a reusable predicate capturing the conclusion of the Tietze extension theorem as a hypothesis on a space — every continuous real function on a closed set extends to the whole space",
+      "isClopen_subtype_of_disjoint_closed: the geometric lemma that for disjoint closed A, B the part of the subspace A ∪ B lying over B is clopen (closed as a preimage of B; open because its complement is the preimage of A, by disjointness)",
+      "normalSpace_of_hasTietzeExtensionProperty: NEW CONTENT — the converse of the Tietze extension theorem. A space with the Tietze extension property is normal, with the separating open sets produced as the strict sub-/super-level sets of an extended {0,1} boundary function. Sharper than the classical statement: no separation axiom on X is required, and the proof is not present in Mathlib",
+      "t1Space_normalSpace_of_hasTietzeExtensionProperty: the classical phrasing 'a T1 space with the Tietze extension property is normal', obtained as a corollary (the T1 hypothesis is not used internally)",
+      "normalSpace_iff_hasTietzeExtensionProperty: the full equivalence normal ⟺ Tietze extension property, pairing the new converse with the forward direction (Mathlib's ContinuousMap.exists_restrict_eq), completing the loop 'normal ⟺ Tietze ⟺ Urysohn' begun in the parent entry"
+    ],
+    "prerequisites": [
+      "Normal topological spaces (Mathlib's NormalSpace) and SeparatedNhds",
+      "The bundled continuous-map type C(s, ℝ) and ContinuousMap.restrict / restrict equality",
+      "Mathlib's Tietze theorem ContinuousMap.exists_restrict_eq (used only for the forward direction)",
+      "Subspace topology and clopen sets: IsClosed.preimage, isClosed_compl_iff, IsClopen, IsClopen.frontier_eq",
+      "Continuity of two-valued functions across an empty frontier: Continuous.if",
+      "Open level sets of continuous functions: isOpen_Iio, isOpen_Ioi, IsOpen.preimage"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "ContinuousMap.exists_restrict_eq",
+        "description": "Mathlib's Tietze extension theorem for NormalSpaces; used here only to prove the forward direction hasTietzeExtensionProperty_of_normalSpace, making the final equivalence genuine.",
+        "module": "Mathlib.Topology.TietzeExtension"
+      },
+      {
+        "theorem": "Continuous.if",
+        "description": "A function 'if p then f else g' is continuous when f, g are continuous and they agree on the frontier of {p}; with a clopen predicate the frontier is empty, so the {0,1} boundary function on A ∪ B is continuous.",
+        "module": "Mathlib.Topology.Piecewise"
+      },
+      {
+        "theorem": "IsClopen.frontier_eq",
+        "description": "A clopen set has empty frontier — the side condition that discharges the frontier hypothesis of Continuous.if for the boundary function.",
+        "module": "Mathlib.Topology.Separation.Basic"
+      },
+      {
+        "theorem": "IsClosed.preimage / isClosed_compl_iff",
+        "description": "Used to show that the part over B is clopen in the subspace A ∪ B (closed as a preimage of B; open because its complement is the preimage of A).",
+        "module": "Mathlib.Topology.Basic"
+      },
+      {
+        "theorem": "NormalSpace / SeparatedNhds",
+        "description": "Target structure: NormalSpace is built by exhibiting, for disjoint closed sets, the disjoint open neighbourhoods F⁻¹(Iio ½) and F⁻¹(Ioi ½).",
+        "module": "Mathlib.Topology.Separation.Regular"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "tietze-extension-theorem-oq-01-oq-01-oq-01",
+      "question": "Strengthen the converse to the bounded Tietze property: show that a space in which every continuous function into a closed interval [a,b] on a closed set extends into [a,b] is normal, matching the range-controlled forward direction and Urysohn separation into [0,1].",
+      "significance": "medium"
+    },
+    {
+      "id": "tietze-extension-theorem-oq-01-oq-01-oq-02",
+      "question": "Establish the parallel converse for Urysohn's lemma directly: a space in which every pair of disjoint closed sets is separated by a continuous [0,1]-valued function is normal, and identify it with the Tietze converse via the parent's urysohn_of_tietze, giving a fully formalized three-way equivalence normal ⟺ Urysohn ⟺ Tietze.",
+      "significance": "high"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "tietze-extension-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. It derives Urysohn's lemma from the Tietze extension theorem in a normal space (the forward direction) and records as an open question the converse characterization proved here; this entry supplies that converse, reusing the same clopen boundary-function idea in reverse to show the Tietze extension property forces normality."
+    },
+    {
+      "targetId": "urysohns-lemma-oq-01",
+      "relationship": "related",
+      "description": "Companion separation theorem. Together with the parent's Urysohn-from-Tietze derivation, the converse here completes the functional characterization of normality: normal spaces are exactly those with the Tietze extension property (equivalently, those satisfying Urysohn separation)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Topology.TietzeExtension",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of ContinuousMap.exists_restrict_eq, used for the forward direction of the equivalence. The converse implication proved in this entry is not present in Mathlib."
+    },
+    {
+      "title": "James Munkres, Topology",
+      "author": "J. R. Munkres",
+      "year": "2000",
+      "venue": "Prentice Hall, 2nd ed.",
+      "description": "Standard reference for the Tietze extension theorem, Urysohn's lemma, and their equivalence with normality (§35), including the characterization of normal spaces by the extension property."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "This entry proves the converse of the Tietze extension theorem: a space with the Tietze extension property — every continuous real function on a closed set extends to the whole space — is normal. For disjoint closed A, B the union A ∪ B is closed, and inside it the part over B is clopen (closed as a preimage of B, open because its complement is the preimage of A by disjointness), so the {0,1} boundary function 0 on A, 1 on B is continuous; the Tietze property extends it to F : X → ℝ, and the disjoint open level sets F⁻¹(Iio ½), F⁻¹(Ioi ½) separate A and B. The proof uses no separation axiom, so the classical 'T1 + Tietze property ⟹ normal' is a corollary, and pairing the converse with Mathlib's forward direction yields the equivalence normal ⟺ Tietze extension property. 158 lines, 5 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "Completes the equivalence 'normal ⟺ Tietze ⟺ Urysohn' begun in the parent entry, which derived Urysohn's lemma from Tietze. The reverse arrow added here — the Tietze property forces normality — is not in Mathlib; it is obtained by the same clopen boundary-function construction run in the opposite direction. The sharpened form (no T1 needed) isolates exactly how much separation the extension property already encodes, and the defined predicate HasTietzeExtensionProperty makes the characterization reusable.",
+    "openQuestions": [
+      "Prove the bounded (interval-valued) form of the converse, matching range-controlled Tietze extension.",
+      "Establish the Urysohn-separation converse directly and identify it with the Tietze converse for a fully formalized three-way equivalence normal ⟺ Urysohn ⟺ Tietze."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves the **converse of the Tietze extension theorem**, completing the equivalence `normal ⟺ Tietze extension property`. The parent entry (`tietze-extension-theorem-oq-01`) derives Urysohn's lemma *from* Tietze in a normal space and records this converse as its open question OQ[1]; this entry supplies it.

**Main result** `normalSpace_of_hasTietzeExtensionProperty`: a space in which every continuous real function on a closed set extends continuously to the whole space is **normal** — sharper than the classical statement, since **no separation axiom on `X` is required** (Mathlib's `NormalSpace` is not bundled with `T1`).

## Proof

Given disjoint closed `A`, `B`, the union `s = A ∪ B` is closed. Inside the subspace `s` the part lying over `B` is **clopen**: closed as the preimage of `B`, open because its complement in `s` is the preimage of `A` (using disjointness). A clopen set has empty frontier, so the `{0,1}`-valued function `0`-on-`A`/`1`-on-`B` is continuous on `s` via `Continuous.if`. The Tietze property extends it to `F : X → ℝ`, and the disjoint open level sets `F⁻¹(Iio ½)`, `F⁻¹(Ioi ½)` separate `A` and `B`, witnessing normality.

The same clopen boundary-function idea as the parent's `urysohn_of_tietze`, run in reverse.

## Contents
- `HasTietzeExtensionProperty` — the extension property as a reusable predicate
- `hasTietzeExtensionProperty_of_normalSpace` — forward direction (Mathlib `ContinuousMap.exists_restrict_eq`)
- `isClopen_subtype_of_disjoint_closed` — the clopen boundary lemma
- `normalSpace_of_hasTietzeExtensionProperty` — **the converse (new content; not in Mathlib)**
- `t1Space_normalSpace_of_hasTietzeExtensionProperty` — classical `T1` phrasing (corollary)
- `normalSpace_iff_hasTietzeExtensionProperty` — the full equivalence

## Verification
- **5 theorems, 1 definition, 0 axioms, 0 sorries, 158 lines**
- Kernel-verified with `lake env lean` on Lean v4.26.0
- `#print axioms` = `{propext, Classical.choice, Quot.sound}` — standard triple, **no `sorryAx`, no `Lean.ofReduceBool`**
- Status `verified`, badge `original`
- Gallery annotations validate clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)