### PR TITLE
research(little-wedderburn-oq-02): classification of finite fields — existence + uniqueness of order q [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3193,6 +3193,7 @@ import Proofs.LiouvilleTheorem
 import Proofs.LiouvilleTheoremOQ04
 import Proofs.LiouvilleTheoremOQ05
 import Proofs.LittleWedderburnOQ01
+import Proofs.LittleWedderburnOQ02
 import Proofs.LittleWedderburnOQ01OQ01
 import Proofs.LovaszLocalLemma
 import Proofs.LovaszLocalLemmaOQ02

--- a/proofs/Proofs/LittleWedderburnOQ02.lean
+++ b/proofs/Proofs/LittleWedderburnOQ02.lean
@@ -1,0 +1,145 @@
+import Mathlib
+
+/-!
+# Classification of finite fields: existence and uniqueness of order `q`
+
+The parent proof (`LittleWedderburnOQ01`) records Wedderburn's little theorem —
+every finite division ring is a field — together with its arithmetic corollaries,
+in particular that the **order of a finite division ring is a prime power**
+`p ^ n`. The natural question one asks immediately afterwards is the **converse and
+classification**:
+
+> For which `q` does a finite field of order `q` exist, and how many are there?
+
+The answer is the classification of finite fields, originally due to Galois and
+Moore:
+
+* **Existence.** For every prime power `q = p ^ n` (`p` prime, `n ≥ 1`) there is a
+  field with exactly `q` elements — Mathlib's `GaloisField p n` is the canonical
+  model, with `Nat.card (GaloisField p n) = p ^ n`.
+* **Uniqueness.** Any two finite fields of the same cardinality are isomorphic as
+  rings (`FiniteField.ringEquivOfCardEq`). Together with existence this says the
+  finite fields of a given prime-power order form a single isomorphism class —
+  the field `GF(q)`.
+* **Sharpness.** A finite field's order is *necessarily* a prime power
+  (`FiniteField.isPrimePow_card`); equivalently a `Fintype` admits a field
+  structure iff its cardinality is a prime power.
+
+Mathlib supplies these ingredients individually (the canonical model `GaloisField`,
+its cardinality, the noncanonical isomorphism `ringEquivOfCardEq`, and the
+prime-power constraint), but it does **not** package them as the combined
+existence-and-uniqueness statement, nor does it record the **division-ring** form:
+combining Wedderburn with uniqueness shows that *any two finite division rings of
+the same order are isomorphic*, and that every finite division ring of order
+`p ^ n` is isomorphic to `GF(p ^ n)`. That bridge — the genuinely new derived
+content here — closes the loop opened by the parent: a finite division ring is not
+merely *a* field of prime-power order, it is *the* field `GF(q)`.
+
+Everything is fully machine-checked with no axioms or sorries.
+-/
+
+namespace LittleWedderburnOQ02
+
+/-! ## Existence: `GaloisField` realizes every prime-power order -/
+
+/-- **Existence (canonical model).** The Galois field `GF(p ^ n)` has exactly
+`p ^ n` elements. -/
+theorem card_galoisField (p n : ℕ) [Fact p.Prime] (hn : n ≠ 0) :
+    Nat.card (GaloisField p n) = p ^ n :=
+  GaloisField.card p n hn
+
+/-- **Existence (existential form).** For every prime `p` and exponent `n ≥ 1`
+there is a finite field with exactly `p ^ n` elements. -/
+theorem exists_field_of_primePow (p n : ℕ) (hp : p.Prime) (hn : n ≠ 0) :
+    ∃ (F : Type) (_ : Field F) (_ : Fintype F), Nat.card F = p ^ n := by
+  haveI := Fact.mk hp
+  haveI : Fintype (GaloisField p n) := Fintype.ofFinite _
+  exact ⟨GaloisField p n, inferInstance, inferInstance, GaloisField.card p n hn⟩
+
+/-! ## Uniqueness: equal order forces isomorphism -/
+
+/-- **Uniqueness.** Any two finite fields of the same cardinality are isomorphic
+as rings. -/
+theorem nonempty_ringEquiv_of_card_eq {K L : Type*} [Field K] [Field L]
+    [Fintype K] [Fintype L] (h : Fintype.card K = Fintype.card L) :
+    Nonempty (K ≃+* L) :=
+  ⟨FiniteField.ringEquivOfCardEq h⟩
+
+/-- **Uniqueness (`Nat.card` form).** The same statement phrased with `Nat.card`,
+for finite fields supplied only with a `Finite` instance. -/
+theorem nonempty_ringEquiv_of_natCard_eq {K L : Type*} [Field K] [Field L]
+    [Finite K] [Finite L] (h : Nat.card K = Nat.card L) :
+    Nonempty (K ≃+* L) := by
+  haveI := Fintype.ofFinite K
+  haveI := Fintype.ofFinite L
+  refine ⟨FiniteField.ringEquivOfCardEq ?_⟩
+  rwa [← Nat.card_eq_fintype_card, ← Nat.card_eq_fintype_card]
+
+/-! ## Existence + uniqueness combined: every field of order `p ^ n` is `GF(p ^ n)` -/
+
+/-- **Classification.** Every finite field of order `p ^ n` is isomorphic to the
+canonical model `GaloisField p n`. With `card_galoisField` this is the full
+existence-and-uniqueness statement: the finite fields of order `p ^ n` form a
+single isomorphism class, represented by `GF(p ^ n)`. -/
+theorem ringEquiv_galoisField_of_card {K : Type*} [Field K] [Fintype K]
+    (p n : ℕ) [Fact p.Prime] (h : Fintype.card K = p ^ n) :
+    Nonempty (K ≃+* GaloisField p n) := by
+  haveI : Fintype (GaloisField p n) := Fintype.ofFinite _
+  have hn : n ≠ 0 := by
+    rintro rfl
+    rw [pow_zero] at h
+    have := Fintype.one_lt_card (α := K)
+    omega
+  refine ⟨FiniteField.ringEquivOfCardEq ?_⟩
+  rw [h, ← Nat.card_eq_fintype_card]
+  exact (GaloisField.card p n hn).symm
+
+/-! ## Sharpness: only prime powers occur -/
+
+/-- **Necessity.** The order of a finite field is a prime power. -/
+theorem isPrimePow_card (K : Type*) [Field K] [Fintype K] :
+    IsPrimePow (Fintype.card K) :=
+  FiniteField.isPrimePow_card K
+
+/-- **Full characterization.** A finite type admits a field structure iff its
+cardinality is a prime power. -/
+theorem nonempty_field_iff (α : Type*) [Fintype α] :
+    Nonempty (Field α) ↔ IsPrimePow (Fintype.card α) :=
+  Fintype.nonempty_field_iff
+
+/-! ## Wedderburn bridge: from division rings to `GF(q)` -/
+
+/-- **Division-ring classification.** Every finite division ring of order `p ^ n`
+is isomorphic, as a ring, to `GF(p ^ n)`. Wedderburn's little theorem makes the
+division ring a field (the `littleWedderburn` instance), after which uniqueness
+identifies it with the canonical model. This is the division-ring strengthening of
+`ringEquiv_galoisField_of_card`, absent from Mathlib. -/
+theorem divisionRing_ringEquiv_galoisField (D : Type*) [DivisionRing D] [Fintype D]
+    (p n : ℕ) [Fact p.Prime] (h : Fintype.card D = p ^ n) :
+    Nonempty (D ≃+* GaloisField p n) :=
+  ringEquiv_galoisField_of_card (K := D) p n h
+
+/-- **No two distinct finite division rings of equal order.** Any two finite
+division rings with the same number of elements are isomorphic as rings: by
+Wedderburn each is a field, and finite fields are classified by their order. -/
+theorem divisionRing_nonempty_ringEquiv_of_card_eq (D E : Type*)
+    [DivisionRing D] [DivisionRing E] [Fintype D] [Fintype E]
+    (h : Fintype.card D = Fintype.card E) : Nonempty (D ≃+* E) :=
+  ⟨FiniteField.ringEquivOfCardEq h⟩
+
+/-! ## Worked instances -/
+
+/-- `GF(2 ^ 3) = GF(8)` has exactly `8` elements. -/
+theorem card_galoisField_eight : Nat.card (GaloisField 2 3) = 8 := by
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  have h := GaloisField.card 2 3 (by norm_num)
+  norm_num at h
+  exact h
+
+/-- For prime `p`, the prime field `ZMod p` is the order-`p` Galois field `GF(p)`:
+it is isomorphic to `GaloisField p 1`. -/
+theorem zmod_ringEquiv_galoisField (p : ℕ) [Fact p.Prime] :
+    Nonempty (ZMod p ≃+* GaloisField p 1) :=
+  ⟨(GaloisField.equivZmodP p).symm.toRingEquiv⟩
+
+end LittleWedderburnOQ02

--- a/src/data/proofs/little-wedderburn-oq-02/annotations.json
+++ b/src/data/proofs/little-wedderburn-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "existence-galoisfield",
+    "proofId": "little-wedderburn-oq-02",
+    "range": { "startLine": 43, "endLine": 57 },
+    "type": "concept",
+    "title": "Existence: GF(pⁿ) Realizes Every Prime-Power Order",
+    "content": "card_galoisField records that Mathlib's canonical Galois field GF(p^n) has exactly p^n elements (GaloisField.card, valid for n ≠ 0). GF(p^n) is built as the splitting field of X^(p^n) − X over the prime field 𝔽_p, whose p^n distinct roots ARE its elements. exists_field_of_primePow packages this existentially: for every prime p and exponent n ≥ 1 there is a finite field with exactly p^n elements. This is the existence half of the classification of finite fields.",
+    "mathContext": "$\\mathrm{GF}(p^n)$ is the splitting field of $X^{p^n} - X$ over $\\mathbb{F}_p$, with $|\\mathrm{GF}(p^n)| = p^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Galois field", "splitting field", "prime power", "Frobenius"],
+    "prerequisites": ["finite fields", "splitting fields"]
+  },
+  {
+    "id": "uniqueness-ringequiv",
+    "proofId": "little-wedderburn-oq-02",
+    "range": { "startLine": 59, "endLine": 76 },
+    "type": "concept",
+    "title": "Uniqueness: Equal Order Forces Isomorphism",
+    "content": "nonempty_ringEquiv_of_card_eq and nonempty_ringEquiv_of_natCard_eq wrap FiniteField.ringEquivOfCardEq as Nonempty (K ≃+* L): any two finite fields of the same cardinality are isomorphic as rings, in both Fintype.card and Nat.card forms. The underlying reason is that a field of order p^n is necessarily a splitting field of X^(p^n) − X over its prime subfield, and splitting fields of a fixed polynomial over a fixed base are unique up to isomorphism. The isomorphism is noncanonical (there is no preferred one), which is exactly why uniqueness is an isomorphism statement rather than an equality.",
+    "mathContext": "$|K| = |L| \\Rightarrow$ there is a ring isomorphism $K \\cong L$ for finite fields $K, L$.",
+    "significance": "key",
+    "relatedConcepts": ["uniqueness up to isomorphism", "splitting field uniqueness", "ring isomorphism"],
+    "prerequisites": ["finite fields", "field isomorphisms"]
+  },
+  {
+    "id": "classification-against-model",
+    "proofId": "little-wedderburn-oq-02",
+    "range": { "startLine": 78, "endLine": 95 },
+    "type": "insight",
+    "title": "The Classification: Every Field of Order pⁿ Is GF(pⁿ)",
+    "content": "ringEquiv_galoisField_of_card fuses existence and uniqueness against the canonical model: any finite field K of order p^n is ring-isomorphic to GaloisField p n. This is the packaged form of the classification — Mathlib supplies the model GF(p^n) and the noncanonical iso ringEquivOfCardEq separately, but not the statement that pins an arbitrary field of order p^n to the specific representative GF(p^n). A subtle point: the exponent n ≠ 0 is FORCED, not assumed — a field is nontrivial (0 ≠ 1) so its order is at least 2 (Fintype.one_lt_card), ruling out the would-be order p^0 = 1. The finite fields of order p^n therefore form a single isomorphism class with canonical representative GF(p^n).",
+    "mathContext": "$|K| = p^n \\Rightarrow K \\cong \\mathrm{GF}(p^n)$; $n \\ge 1$ is forced since a field has at least two elements.",
+    "significance": "key",
+    "relatedConcepts": ["classification of finite fields", "canonical model", "nontriviality", "isomorphism class"],
+    "prerequisites": ["finite fields", "cardinality of fields"]
+  },
+  {
+    "id": "sharpness-primepow",
+    "proofId": "little-wedderburn-oq-02",
+    "range": { "startLine": 97, "endLine": 108 },
+    "type": "insight",
+    "title": "Sharpness: Only Prime Powers Occur",
+    "content": "isPrimePow_card states the order of a finite field is a prime power (FiniteField.isPrimePow_card): a finite field is a finite-dimensional vector space over its prime subfield 𝔽_p, so its order is p^n. nonempty_field_iff sharpens this to a biconditional (Fintype.nonempty_field_iff): a finite type admits a field structure if and only if its cardinality is a prime power. Together with existence and uniqueness this completes the picture — the finite fields are exactly GF(p^n) for prime powers p^n, one per prime power and nothing else.",
+    "mathContext": "A finite field's order is a prime power; a $\\mathrm{Fintype}$ admits a field structure $\\iff$ its order is a prime power.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime power", "vector space dimension", "prime subfield", "characteristic"],
+    "prerequisites": ["finite fields", "vector spaces over finite fields"]
+  },
+  {
+    "id": "wedderburn-bridge",
+    "proofId": "little-wedderburn-oq-02",
+    "range": { "startLine": 110, "endLine": 128 },
+    "type": "insight",
+    "title": "Wedderburn Bridge: A Finite Division Ring of Order q Is GF(q)",
+    "content": "This is the genuinely new derived content and the payoff of the parent proof. divisionRing_ringEquiv_galoisField shows every finite division ring of order p^n is ring-isomorphic to GF(p^n); divisionRing_nonempty_ringEquiv_of_card_eq shows any two finite division rings of equal order are isomorphic as rings. The mechanism: littleWedderburn is an INSTANCE, so a [DivisionRing D] [Fintype D] automatically synthesizes Field D — every theorem proved above for finite fields then fires on division rings with no extra argument. The division-ring uniqueness is strictly stronger than the field version: a priori two division rings of equal order could be noncommutative, but Wedderburn rules that out before uniqueness even applies. A finite division ring is thus not merely some field of prime-power order — it is the unique field GF(q).",
+    "mathContext": "Finite division ring of order $p^n$ $\\cong \\mathrm{GF}(p^n)$; two finite division rings of equal order are isomorphic.",
+    "significance": "key",
+    "relatedConcepts": ["Wedderburn's little theorem", "division ring", "instance resolution", "noncommutativity ruled out"],
+    "prerequisites": ["Wedderburn's little theorem", "division rings", "finite fields"]
+  },
+  {
+    "id": "worked-instances",
+    "proofId": "little-wedderburn-oq-02",
+    "range": { "startLine": 130, "endLine": 143 },
+    "type": "concept",
+    "title": "Worked Instances: GF(8) and ℤ/pℤ = GF(p)",
+    "content": "card_galoisField_eight computes |GF(2^3)| = 8 — the field behind the AES S-box arithmetic. zmod_ringEquiv_galoisField identifies the prime field ZMod p with the order-p Galois field GF(p) = GaloisField p 1, using Mathlib's GaloisField.equivZmodP. The first is the smallest non-prime finite field (order 8 = 2^3, not prime), illustrating that finite fields exist at prime-power but not arbitrary orders; the second is the base case n = 1 of the classification.",
+    "mathContext": "$|\\mathrm{GF}(8)| = 8$ (smallest non-prime finite field); $\\mathbb{Z}/p\\mathbb{Z} \\cong \\mathrm{GF}(p)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["GF(8)", "AES", "prime field", "base case"],
+    "prerequisites": ["finite fields", "ZMod"]
+  }
+]

--- a/src/data/proofs/little-wedderburn-oq-02/meta.json
+++ b/src/data/proofs/little-wedderburn-oq-02/meta.json
@@ -1,0 +1,191 @@
+{
+  "id": "little-wedderburn-oq-02",
+  "slug": "little-wedderburn-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "LittleWedderburnOQ02",
+    "lineCount": 145,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "path": "Proofs/LittleWedderburnOQ02.lean",
+    "sorries": 0
+  },
+  "title": "Classification of Finite Fields: Existence and Uniqueness of Order q",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LittleWedderburnOQ02.lean",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "finite-field",
+      "galois-field",
+      "wedderburn",
+      "classification",
+      "prime-power",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 145,
+    "theoremCount": 11,
+    "definitionCount": 0,
+    "badge": "mathlib",
+    "originalContributions": [
+      "ringEquiv_galoisField_of_card: every finite field of order p^n is ring-isomorphic to the canonical model GaloisField p n — the combined existence-and-uniqueness statement (Mathlib has the canonical model and the noncanonical iso ringEquivOfCardEq separately, but not the packaged classification against GF(p^n))",
+      "divisionRing_ringEquiv_galoisField: every finite DIVISION RING of order p^n is ring-isomorphic to GF(p^n) — the division-ring strengthening that fuses Wedderburn's little theorem (littleWedderburn) with finite-field uniqueness; absent from Mathlib",
+      "divisionRing_nonempty_ringEquiv_of_card_eq: any two finite division rings of equal cardinality are isomorphic as rings — Wedderburn makes each a field, then uniqueness identifies them; the division-ring form of finite-field uniqueness",
+      "exists_field_of_primePow: the existential form of existence — for every prime p and exponent n ≥ 1 there is a finite field with exactly p^n elements, witnessed by GaloisField p n",
+      "card_galoisField: the canonical witness GF(p^n) has exactly p^n elements (GaloisField.card)",
+      "nonempty_ringEquiv_of_card_eq / nonempty_ringEquiv_of_natCard_eq: uniqueness phrased as Nonempty (K ≃+* L) for finite fields of equal order, in both Fintype.card and Nat.card forms",
+      "isPrimePow_card / nonempty_field_iff: sharpness — a finite field's order is a prime power, and a Fintype admits a field structure iff its cardinality is a prime power",
+      "card_galoisField_eight / zmod_ringEquiv_galoisField: worked instances — GF(2^3) has 8 elements, and the prime field ZMod p is the order-p Galois field GF(p) = GaloisField p 1"
+    ],
+    "prerequisites": [
+      "Mathlib's GaloisField p n: the canonical Galois field as a splitting field of X^(p^n) - X over ZMod p, with GaloisField.card giving |GF(p^n)| = p^n",
+      "FiniteField.ringEquivOfCardEq: any two finite fields of equal cardinality are (noncanonically) ring-isomorphic",
+      "littleWedderburn: every finite division ring is a field (the parent theorem's engine)",
+      "FiniteField.isPrimePow_card / Fintype.nonempty_field_iff: a finite field's order is a prime power, and conversely every prime power is realized"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "GaloisField.card",
+        "description": "The Galois field GF(p^n) has exactly p^n elements (Nat.card (GaloisField p n) = p^n for n ≠ 0); the existence half of the classification.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "FiniteField.ringEquivOfCardEq",
+        "description": "Any two finite fields of the same cardinality are isomorphic as rings; the uniqueness half of the classification.",
+        "module": "Mathlib.FieldTheory.Finite.GaloisField"
+      },
+      {
+        "theorem": "littleWedderburn",
+        "description": "The instance turning any finite division ring into a field; the bridge that lets the field classification apply to division rings.",
+        "module": "Mathlib.RingTheory.LittleWedderburn"
+      },
+      {
+        "theorem": "FiniteField.isPrimePow_card / Fintype.nonempty_field_iff",
+        "description": "A finite field's order is a prime power, and a Fintype admits a field structure iff its cardinality is a prime power; the sharpness of the classification.",
+        "module": "Mathlib.FieldTheory.Finite.Basic / Mathlib.FieldTheory.Cardinality"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The classification of finite fields — for each prime power q there is, up to isomorphism, exactly one field of order q, written GF(q) or 𝔽_q — is one of the foundational results of 19th-century algebra. Évariste Galois introduced 'Galois imaginaries' (finite fields of prime-power order) in 1830; E. H. Moore proved in 1893 that every finite field is one of Galois's, giving the modern existence-and-uniqueness theorem. Existence is constructive: GF(p^n) is the splitting field of X^(p^n) − X over the prime field 𝔽_p, and its p^n roots are exactly its elements. Uniqueness follows because any field of order p^n is such a splitting field, and splitting fields of a fixed polynomial over a fixed base are unique up to isomorphism. The result sits directly atop Wedderburn's little theorem (the parent proof): Wedderburn shows a finite division ring is automatically a field of prime-power order, and the classification then pins that field down to GF(q) exactly — so a finite division ring is not merely some field of prime-power order, it is THE field GF(q). Finite fields underpin coding theory, cryptography (AES operates in GF(2^8)), combinatorial designs, and the theory of algebraic curves over finite fields.",
+    "problemStatement": "Establish the classification of finite fields as the existence-and-uniqueness companion to the prime-power-order corollary of Wedderburn (the parent proof's open question little-wedderburn-oq-01-oq-02): for every prime power q = p^n there exists a field of order q (the canonical Galois field GF(p^n)), any two finite fields of order q are isomorphic, only prime powers occur as finite-field orders, and — fusing this with Wedderburn — every finite division ring of order p^n is isomorphic to GF(p^n), with any two finite division rings of equal order isomorphic.",
+    "proofStrategy": "Existence is Mathlib's GaloisField p n together with GaloisField.card (|GF(p^n)| = p^n for n ≠ 0); exists_field_of_primePow packages it existentially. Uniqueness is FiniteField.ringEquivOfCardEq, wrapped as Nonempty (K ≃+* L) in both Fintype.card and Nat.card forms. ringEquiv_galoisField_of_card combines the two: a field of order p^n matches GF(p^n) in cardinality (n ≠ 0 forced because a field is nontrivial, so its order exceeds 1), hence is isomorphic to it. Sharpness uses FiniteField.isPrimePow_card and Fintype.nonempty_field_iff. The division-ring bridge is the genuinely new step: with the littleWedderburn instance in scope, [DivisionRing D] [Fintype D] already synthesizes Field D, so ringEquiv_galoisField_of_card and ringEquivOfCardEq apply verbatim to division rings — yielding divisionRing_ringEquiv_galoisField and divisionRing_nonempty_ringEquiv_of_card_eq. Worked instances compute |GF(8)| = 8 and identify ZMod p with GaloisField p 1 via GaloisField.equivZmodP.",
+    "keyInsights": [
+      "Existence and uniqueness are two different uses of one object: the splitting field of X^(p^n) − X. Existence builds it (GaloisField); uniqueness observes that any field of that order IS that splitting field, so all such fields coincide up to isomorphism.",
+      "n ≠ 0 is forced, not assumed: a field is nontrivial, so its order is at least 2; a putative field of order p^0 = 1 cannot exist. This is why the classification ranges over exponents n ≥ 1.",
+      "The division-ring bridge is where the parent pays off. Because littleWedderburn is an instance, every theorem proved for finite fields fires automatically on finite division rings — so 'a finite division ring of order q is GF(q)' needs no new argument beyond invoking the field result on D.",
+      "Two finite division rings of the same order are isomorphic: a strictly stronger statement than the field version, since a priori the division rings could be noncommutative — Wedderburn rules that out before uniqueness even applies.",
+      "The 'mathlib' badge is honest: the deep machinery (the GaloisField construction, splitting-field uniqueness, and Wedderburn itself) lives in Mathlib; the original content is the packaging of existence and uniqueness into the classification statement and its lift to division rings, which Mathlib does not record."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Classifying Finite Fields",
+      "startLine": 3,
+      "endLine": 39,
+      "summary": "Frames the classification of finite fields as the existence-and-uniqueness converse to the parent's prime-power-order corollary. Names the Mathlib ingredients (GaloisField as canonical model, GaloisField.card, ringEquivOfCardEq, isPrimePow_card) and identifies the new derived content: the packaged classification against GF(p^n) and the division-ring bridge fusing Wedderburn with uniqueness.",
+      "mathContext": "For each prime power q there is, up to isomorphism, exactly one field of order q — and every finite division ring of order q is that field GF(q)."
+    },
+    {
+      "id": "existence",
+      "title": "Existence: GaloisField Realizes Every Prime-Power Order",
+      "startLine": 43,
+      "endLine": 57,
+      "summary": "card_galoisField records |GF(p^n)| = p^n (GaloisField.card). exists_field_of_primePow gives the existential form: for every prime p and n ≥ 1 there is a finite field with exactly p^n elements, witnessed by GaloisField p n.",
+      "mathContext": "$|\\mathrm{GF}(p^n)| = p^n$; for every prime power there exists a finite field of that order."
+    },
+    {
+      "id": "uniqueness",
+      "title": "Uniqueness: Equal Order Forces Isomorphism",
+      "startLine": 59,
+      "endLine": 76,
+      "summary": "nonempty_ringEquiv_of_card_eq and nonempty_ringEquiv_of_natCard_eq wrap FiniteField.ringEquivOfCardEq: any two finite fields of equal cardinality are isomorphic as rings, in both Fintype.card and Nat.card forms.",
+      "mathContext": "$|K| = |L| \\Rightarrow K \\cong L$ for finite fields."
+    },
+    {
+      "id": "classification",
+      "title": "Existence + Uniqueness: Every Field of Order pⁿ Is GF(pⁿ)",
+      "startLine": 78,
+      "endLine": 95,
+      "summary": "ringEquiv_galoisField_of_card combines existence and uniqueness: any finite field of order p^n is isomorphic to the canonical model GaloisField p n. The exponent n ≠ 0 is forced from Fintype.one_lt_card (a field is nontrivial).",
+      "mathContext": "$|K| = p^n \\Rightarrow K \\cong \\mathrm{GF}(p^n)$: the finite fields of order $p^n$ form one isomorphism class."
+    },
+    {
+      "id": "sharpness",
+      "title": "Sharpness: Only Prime Powers Occur",
+      "startLine": 97,
+      "endLine": 108,
+      "summary": "isPrimePow_card: the order of a finite field is a prime power (FiniteField.isPrimePow_card). nonempty_field_iff: a Fintype admits a field structure iff its cardinality is a prime power (Fintype.nonempty_field_iff).",
+      "mathContext": "A finite field's order is a prime power; conversely every prime power is realized and no other order is."
+    },
+    {
+      "id": "wedderburn-bridge",
+      "title": "Wedderburn Bridge: From Division Rings to GF(q)",
+      "startLine": 110,
+      "endLine": 128,
+      "summary": "divisionRing_ringEquiv_galoisField: every finite division ring of order p^n is ring-isomorphic to GF(p^n) — littleWedderburn upgrades D to a field, then the classification applies. divisionRing_nonempty_ringEquiv_of_card_eq: any two finite division rings of equal order are isomorphic as rings.",
+      "mathContext": "A finite division ring of order $p^n$ is $\\mathrm{GF}(p^n)$; two finite division rings of equal order are isomorphic."
+    },
+    {
+      "id": "instances",
+      "title": "Worked Instances: GF(8) and ℤ/pℤ = GF(p)",
+      "startLine": 130,
+      "endLine": 143,
+      "summary": "card_galoisField_eight: GF(2^3) has exactly 8 elements. zmod_ringEquiv_galoisField: the prime field ZMod p is the order-p Galois field GF(p) = GaloisField p 1, via GaloisField.equivZmodP.",
+      "mathContext": "$|\\mathrm{GF}(8)| = 8$; $\\mathbb{Z}/p\\mathbb{Z} \\cong \\mathrm{GF}(p)$."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "little-wedderburn-oq-02-oq-01",
+      "question": "Formalize the subfield lattice of GF(p^n): GF(p^m) embeds in GF(p^n) iff m ∣ n, giving the divisor lattice of subfields and the Frobenius-Galois correspondence for the cyclic extension GF(p^n)/GF(p).",
+      "significance": "medium"
+    },
+    {
+      "id": "little-wedderburn-oq-02-oq-02",
+      "question": "Count the monic irreducible polynomials of degree n over GF(p) via Möbius inversion of p^n = Σ_{d ∣ n} d·(number of monic irreducibles of degree d), exhibiting the necklace/Gauss formula as a consequence of the classification.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "little-wedderburn-oq-01",
+      "relationship": "parent",
+      "description": "The parent proof establishes Wedderburn's little theorem and the corollary that a finite division ring has prime-power order; this entry supplies the existence-and-uniqueness classification that pins that order down to the unique field GF(q), answering the parent's open question little-wedderburn-oq-01-oq-02."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: FieldTheory.Finite.GaloisField",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of the GaloisField construction, GaloisField.card, and FiniteField.ringEquivOfCardEq."
+    },
+    {
+      "title": "A doubly-infinite system of simple groups",
+      "author": "E. H. Moore",
+      "year": "1893",
+      "venue": "Bulletin of the New York Mathematical Society / Mathematical Papers Chicago Congress",
+      "description": "Proves that every finite field is a Galois field, establishing the uniqueness half of the classification."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The classification of finite fields is established as the existence-and-uniqueness companion to Wedderburn's prime-power-order corollary. For every prime power q = p^n the canonical Galois field GF(p^n) has exactly q elements (existence); any two finite fields of equal order are isomorphic as rings (uniqueness); every finite field of order p^n is isomorphic to GF(p^n); and a finite field's order is necessarily a prime power (sharpness). Fusing this with the parent's Wedderburn theorem, every finite division ring of order p^n is isomorphic to GF(p^n), and any two finite division rings of equal order are isomorphic. Worked instances compute |GF(8)| = 8 and identify ZMod p with GF(p). 145 lines, 11 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The deep machinery — the GaloisField splitting-field construction, splitting-field uniqueness, and Wedderburn's little theorem — lives in Mathlib (hence the mathlib badge); the original content is the assembly of existence and uniqueness into the classification statement against the canonical model GF(p^n), and its lift to division rings, neither of which Mathlib records. This closes the loop opened by the parent: a finite division ring is not merely a field of prime-power order, it is the unique field GF(q).",
+    "openQuestions": [
+      "Formalize the subfield lattice GF(p^m) ⊆ GF(p^n) ⟺ m ∣ n and the Frobenius-Galois correspondence.",
+      "Count monic irreducibles of degree n over GF(p) by Möbius inversion of the classification."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent proof's open question **little-wedderburn-oq-01-oq-02**: the **classification of finite fields**. For every prime power $q = p^n$ there is a field of order $q$, unique up to isomorphism — and, fusing this with Wedderburn's little theorem, every finite *division ring* of order $q$ is the field $\mathrm{GF}(q)$.

New gallery entry `little-wedderburn-oq-02` (`Proofs/LittleWedderburnOQ02.lean`), child of `little-wedderburn-oq-01`.

## Results (11 theorems, 0 defs, 0 axioms, 0 sorries)

- **Existence** — `card_galoisField`, `exists_field_of_primePow`: `GaloisField p n` realizes every prime-power order, $|\mathrm{GF}(p^n)| = p^n$ (`GaloisField.card`).
- **Uniqueness** — `nonempty_ringEquiv_of_card_eq`, `nonempty_ringEquiv_of_natCard_eq`: any two finite fields of equal order are ring-isomorphic (`FiniteField.ringEquivOfCardEq`).
- **Classification** — `ringEquiv_galoisField_of_card`: every finite field of order $p^n$ is isomorphic to the canonical model $\mathrm{GF}(p^n)$; $n \neq 0$ is *forced* from `Fintype.one_lt_card` (a field is nontrivial).
- **Sharpness** — `isPrimePow_card`, `nonempty_field_iff`: a finite field's order is a prime power, and a `Fintype` admits a field structure iff its order is a prime power.
- **Wedderburn bridge (new derived content)** — `divisionRing_ringEquiv_galoisField`, `divisionRing_nonempty_ringEquiv_of_card_eq`: every finite division ring of order $p^n$ is isomorphic to $\mathrm{GF}(p^n)$, and any two finite division rings of equal order are isomorphic. The `littleWedderburn` instance upgrades `D` to a field, after which the field classification fires automatically.
- **Worked instances** — `card_galoisField_eight` ($|\mathrm{GF}(8)| = 8$), `zmod_ringEquiv_galoisField` ($\mathbb{Z}/p\mathbb{Z} \cong \mathrm{GF}(p) = \mathrm{GaloisField}\ p\ 1$).

## Originality / badge

Mathlib supplies the canonical model (`GaloisField`), splitting-field uniqueness (`ringEquivOfCardEq`), and Wedderburn (`littleWedderburn`) *separately*. The original content is the assembly into the existence-and-uniqueness classification against `GF(p^n)` and its lift to division rings — neither recorded in Mathlib. Badge: **mathlib** (the deep engine is Mathlib's).

## Verification

- Kernel-verified with `lake env lean Proofs/LittleWedderburnOQ02.lean` (EXIT 0).
- `#print axioms` on the key theorems = standard triple `[propext, Classical.choice, Quot.sound]` only — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`. Genuinely 0-axiom.
- `pnpm annotations:build` produces no warnings for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)