### PR TITLE
audit: 3 entries kernel-verified clean (Fσ algebraic reals, 2 angle-trisection)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17827,6 +17827,24 @@
       "lastAudited": "2026-06-24T01:43:02Z",
       "result": "clean",
       "issues": []
+    },
+    "algebraic-reals-meager-dense-gdelta-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T03:21:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T03:21:59Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T03:21:59Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — Clean Batch

Three gallery entries audited and kernel-verified against Mathlib v4.26.0. All depend only on the standard triple (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `Lean.ofReduceBool`. 0 sorries, 0 True stubs.

| Entry | Badge | Result |
|-------|-------|--------|
| `algebraic-reals-meager-dense-gdelta-oq-01` | verified/original | ✅ clean |
| `angle-trisection-cos-20-gal-oq-02` | verified/original | ✅ clean |
| `angle-trisection-oq-01-oq-04` | verified/mathlib | ✅ clean |

### Findings

- **algebraic-reals-meager-dense-gdelta-oq-01** — 8 theorems + 1 def. Introduces the `IsFσ` predicate (Mathlib has `IsGδ` but no Fσ counterpart) and proves the De Morgan duality `isFσ_iff_isGδ_compl`. Badge `original` is honest — genuine infrastructure, not a Mathlib wrapper. `theoremCount` was already corrected to 8 by a concurrent enrichment.
- **angle-trisection-cos-20-gal-oq-02** — 10 theorems. Totients computed with kernel `decide` (no `native_decide`). Exemplary honest SCOPE disclaimer: supplies the algebraic ingredients of [ℚ(cos 2π/n):ℚ] = φ(n)/2, not the field-degree equality (blocked on Kronecker–Weber in Mathlib). No axiom masking.
- **angle-trisection-oq-01-oq-04** — 22 theorems + 1 def (Gauss–Wantzel structural tools). The "no `native_decide`" claim verified HONEST (axiom check shows no `Lean.ofReduceBool`). Badge `mathlib` correct. `theoremCount` overstatement (24→22) already fixed by #28605.

No integrity issues requiring correction. This PR records the clean audit results in the tracker.

---
Discovered during autonomous gallery integrity audit.