### PR TITLE
research(frobenius-endomorphism-oq-01-oq-03): Frobenius is a monomorphism on a domain and an automorphism on a finite field [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3092,6 +3092,7 @@ import Proofs.FriendshipTheoremOQ04Universal
 import Proofs.FrobeniusEndomorphismOQ01
 import Proofs.FrobeniusEndomorphismOQ01OQ01
 import Proofs.FrobeniusEndomorphismOQ01OQ02
+import Proofs.FrobeniusEndomorphismOQ01OQ03
 import Proofs.FrobeniusEndomorphismOQ02
 import Proofs.FrobeniusEndomorphismOQ02OQ01OQ01
 import Proofs.FrobeniusNumber

--- a/proofs/Proofs/FrobeniusEndomorphismOQ01OQ03.lean
+++ b/proofs/Proofs/FrobeniusEndomorphismOQ01OQ03.lean
@@ -1,0 +1,102 @@
+/-
+  Frobenius is a monomorphism on a domain and an automorphism on a finite field.
+
+  Building on `FrobeniusEndomorphismOQ01`, which packages the Frobenius
+  `x ↦ x ^ p` as a *ring homomorphism* in prime characteristic, this file
+  records the two structural facts that determine its image and kernel:
+
+    * **Injectivity over a domain.**  On any integral domain `R` of
+      characteristic `p` the Frobenius is injective, i.e. a *monomorphism*.
+      The reason is that an integral domain is reduced (no nonzero nilpotents),
+      and `x ^ p = y ^ p ⇒ (x - y) ^ p = 0 ⇒ x = y`.  Note injectivity can fail
+      badly without the reduced hypothesis: over `ZMod 4` (not a domain) we have
+      `0² = 2² = 0` even though the relevant power map collapses elements.
+
+    * **Bijectivity over a finite field.**  A finite field is a finite domain,
+      so the injective Frobenius is automatically *surjective* — an
+      *automorphism*.  This is the abstract source of the fact that every
+      element of a finite field of characteristic `p` is a `p`-th power, and it
+      packages the Frobenius as a genuine ring **equivalence** `K ≃+* K`.
+
+  Everything is Mathlib-backed (`frobenius_inj`, `Finite.injective_iff_bijective`,
+  `RingEquiv.ofBijective`) and fully verified: 0 sorries, 0 axioms, no
+  `native_decide`.
+-/
+import Mathlib
+
+namespace FrobeniusEndomorphismOQ01OQ03
+
+/-! ### Frobenius is a monomorphism on an integral domain -/
+
+section Domain
+
+variable (R : Type*) [CommRing R] [IsDomain R] (p : ℕ) [ExpChar R p]
+
+/-- **Frobenius is injective on an integral domain.**  In characteristic `p`,
+the map `x ↦ x ^ p` is a monomorphism: an integral domain is reduced, so the
+only `p`-th root of `0` is `0`, and `(x - y) ^ p = x ^ p - y ^ p`. -/
+theorem frobenius_injective : Function.Injective (frobenius R p) :=
+  frobenius_inj R p
+
+/-- The injectivity, spelled out as a cancellation rule on `p`-th powers:
+`x ^ p = y ^ p ↔ x = y` over an integral domain. -/
+theorem pow_p_left_inj {x y : R} : x ^ p = y ^ p ↔ x = y := by
+  constructor
+  · intro h
+    exact frobenius_injective R p (by simpa only [frobenius_def] using h)
+  · rintro rfl; rfl
+
+/-- The Frobenius has trivial kernel: `x ^ p = 0 ↔ x = 0`. -/
+theorem pow_p_eq_zero_iff {x : R} : x ^ p = 0 ↔ x = 0 := by
+  have h := pow_p_left_inj R p (x := x) (y := 0)
+  rwa [zero_pow (expChar_pos R p).ne'] at h
+
+end Domain
+
+/-! ### Frobenius is an automorphism on a finite field -/
+
+section FiniteField
+
+variable (K : Type*) [Field K] [Finite K] (p : ℕ) [ExpChar K p]
+
+/-- **Frobenius is bijective on a finite field.**  A finite field is a finite
+integral domain, so the injective Frobenius (a monomorphism) is automatically
+surjective — hence an automorphism. -/
+theorem frobenius_bijective : Function.Bijective (frobenius K p) :=
+  Finite.injective_iff_bijective.mp (frobenius_injective K p)
+
+/-- The Frobenius is surjective on a finite field: **every element is a `p`-th
+power**, `∀ y, ∃ x, x ^ p = y`. -/
+theorem exists_pow_p (y : K) : ∃ x : K, x ^ p = y := by
+  obtain ⟨x, hx⟩ := (frobenius_bijective K p).surjective y
+  exact ⟨x, by simpa only [frobenius_def] using hx⟩
+
+/-- The Frobenius packaged as a **ring automorphism** `K ≃+* K` of a finite
+field. -/
+noncomputable def frobeniusEquiv : K ≃+* K :=
+  RingEquiv.ofBijective (frobenius K p) (frobenius_bijective K p)
+
+@[simp]
+theorem frobeniusEquiv_apply (x : K) : frobeniusEquiv K p x = x ^ p := rfl
+
+/-- The automorphism agrees with the underlying ring hom. -/
+theorem coe_frobeniusEquiv : ⇑(frobeniusEquiv K p) = frobenius K p := rfl
+
+end FiniteField
+
+/-! ### Concrete checks -/
+
+instance : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+
+/-- On `ZMod 5` the Frobenius `x ↦ x⁵` is bijective (indeed the identity, by
+Fermat). -/
+theorem frobenius_bijective_zmod_five :
+    Function.Bijective (frobenius (ZMod 5) 5) :=
+  frobenius_bijective (ZMod 5) 5
+
+/-- Every element of `ZMod 7` is a `7`-th power (here trivially, `a = a⁷`). -/
+theorem exists_pow_seven_zmod_seven (y : ZMod 7) : ∃ x : ZMod 7, x ^ 7 = y :=
+  exists_pow_p (ZMod 7) 7 y
+
+end FrobeniusEndomorphismOQ01OQ03

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/annotations.json
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-module-header",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "title": "Module Header: Monomorphism and Automorphism",
+    "content": "Building on the parent Frobenius entry (the map $x \\mapsto x^p$ as a ring homomorphism), this file records the two structural facts that pin down the kernel and image of the Frobenius. On an **integral domain** it is injective — a *monomorphism* — because a domain is reduced and $x^p = y^p \\Rightarrow (x-y)^p = 0 \\Rightarrow x = y$. On a **finite field** the injective Frobenius is automatically surjective (a finite injective self-map is bijective), hence an *automorphism*: every element is a $p$-th power and the map packages as a ring equivalence $K \\simeq_{+*} K$. Fully verified: 0 sorries, 0 axioms, no `native_decide`."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-injective",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 31,
+      "endLine": 41
+    },
+    "title": "Frobenius is Injective on a Domain (Monomorphism)",
+    "content": "`frobenius_injective`: over an integral domain $R$ of characteristic $p$, the map $x \\mapsto x^p$ is injective. This is Mathlib's `frobenius_inj`, which asks only that $R$ be **reduced** (no nonzero nilpotents) — an integral domain qualifies. The mechanism: $x^p = y^p$ gives $(x-y)^p = x^p - y^p = 0$ (the freshman's dream), and in a reduced ring the only $p$-th root of $0$ is $0$, so $x = y$. The Frobenius is therefore a monomorphism."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-cancellation",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 43,
+      "endLine": 53
+    },
+    "title": "Cancellation and Trivial Kernel",
+    "content": "`pow_p_left_inj`: the injectivity as an explicit cancellation rule, $x^p = y^p \\iff x = y$ — the forward direction unfolds `frobenius_def` and applies `frobenius_injective`, the reverse is `rfl`.\n\n`pow_p_eq_zero_iff`: specializing $y = 0$ gives the trivial-kernel statement $x^p = 0 \\iff x = 0$, after rewriting $0^p = 0$ via `zero_pow (expChar_pos R p).ne'`. This 'no nonzero nilpotents' fact is the precise content that makes the Frobenius injective."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-bijective",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 58,
+      "endLine": 68
+    },
+    "title": "Frobenius is Bijective on a Finite Field (Automorphism)",
+    "content": "`frobenius_bijective`: over a finite field $K$ the Frobenius is bijective. A finite field is a finite integral domain, so the injective Frobenius (`frobenius_injective`) is automatically surjective by the pigeonhole principle `Finite.injective_iff_bijective`. Finiteness is exactly what upgrades the monomorphism to an *automorphism* — on an infinite domain (e.g. $\\mathbb{F}_p(t)$) the Frobenius is injective but not surjective."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-surjective",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 70,
+      "endLine": 74
+    },
+    "title": "Every Element is a p-th Power",
+    "content": "`exists_pow_p`: surjectivity restated — over a finite field, $\\forall y, \\exists x,\\ x^p = y$. The witness comes from `frobenius_bijective.surjective`, with `frobenius_def` unfolded. This is the defining property of a **perfect field**, proved here for the finite case as a corollary of finite injective $\\Rightarrow$ surjective."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-equiv",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "definition",
+    "range": {
+      "startLine": 76,
+      "endLine": 83
+    },
+    "title": "The Frobenius Ring Automorphism",
+    "content": "`frobeniusEquiv`: the Frobenius of a finite field packaged as a genuine ring **automorphism** $K \\simeq_{+*} K$, via `RingEquiv.ofBijective` applied to the bijective Frobenius. `frobeniusEquiv_apply` ($\\mathrm{frobeniusEquiv}\\,x = x^p$) and `coe_frobeniusEquiv` (the coercion equals the underlying ring hom) are both `rfl`. This is the generator of $\\mathrm{Gal}(K / \\mathbb{F}_p)$. It is `noncomputable` only because the inverse is extracted via choice — no extra axioms are introduced."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-03-concrete",
+    "proofId": "frobenius-endomorphism-oq-01-oq-03",
+    "type": "theorem",
+    "range": {
+      "startLine": 87,
+      "endLine": 100
+    },
+    "title": "Concrete Checks over ZMod 5 and ZMod 7",
+    "content": "With `Fact (Nat.Prime 5)` / `Fact (Nat.Prime 7)` supplied, $\\mathbb{Z}/5$ and $\\mathbb{Z}/7$ are finite fields and `ExpChar` resolves from `CharP` plus the prime fact. `frobenius_bijective_zmod_five`: $x \\mapsto x^5$ is bijective on $\\mathbb{Z}/5$ (here the identity, by Fermat). `exists_pow_seven_zmod_seven`: every element of $\\mathbb{Z}/7$ is a $7$-th power. Both are direct instantiations of the general finite-field theorems."
+  }
+]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-03/meta.json
@@ -1,0 +1,175 @@
+{
+  "id": "frobenius-endomorphism-oq-01-oq-03",
+  "title": "Frobenius is a Monomorphism on a Domain and an Automorphism on a Finite Field",
+  "slug": "frobenius-endomorphism-oq-01-oq-03",
+  "description": "Building on frobenius-endomorphism-oq-01 (the Frobenius x ↦ x^p as a ring homomorphism), this entry answers the parent's lead open question: the structural facts that fix the kernel and image of the Frobenius. On any integral domain of characteristic p it is INJECTIVE — a monomorphism — because a domain is reduced and x^p = y^p ⇒ (x−y)^p = 0 ⇒ x = y; equivalently x^p = 0 ⇔ x = 0 (trivial kernel) and x^p = y^p ⇔ x = y (cancellation). On a finite field, a finite domain, the injective Frobenius is automatically surjective (Finite.injective_iff_bijective), hence an AUTOMORPHISM: every element is a p-th power, and the map packages as a ring equivalence K ≃+* K (frobeniusEquiv). 9 theorems, 1 definition, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_endomorphism",
+    "date": "Ferdinand Georg Frobenius (late 19th century)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "ring-theory",
+      "field-theory",
+      "finite-fields",
+      "characteristic-p",
+      "frobenius",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). No native_decide, so no Lean.ofReduceBool is introduced. The automorphism frobeniusEquiv is noncomputable only because RingEquiv.ofBijective uses choice to extract the inverse — this introduces no extra axioms beyond the standard triple.",
+    "originalContributions": [
+      "Synthesis answering the parent OQ-01's lead open question ('Prove injectivity of the Frobenius on a domain — a monomorphism — and surjectivity on a finite field, hence an automorphism'). Each result is short, but the curated packaging of the monomorphism/automorphism dichotomy together with the explicit ring-equivalence is not a single Mathlib lemma.",
+      "frobenius_injective: the Frobenius is injective on any integral domain (a monomorphism), via Mathlib's frobenius_inj (a domain is reduced, so the only p-th root of 0 is 0)",
+      "pow_p_left_inj / pow_p_eq_zero_iff: the injectivity spelled out as cancellation x^p = y^p ⇔ x = y and trivial kernel x^p = 0 ⇔ x = 0 over a domain",
+      "frobenius_bijective: on a finite field the injective Frobenius is automatically surjective (Finite.injective_iff_bijective), hence an automorphism",
+      "exists_pow_p: surjectivity restated — over a finite field every element is a p-th power, ∀ y, ∃ x, x^p = y",
+      "frobeniusEquiv: the Frobenius packaged as a genuine ring automorphism K ≃+* K of a finite field (RingEquiv.ofBijective), with coe_frobeniusEquiv / frobeniusEquiv_apply identifying it with x ↦ x^p",
+      "frobenius_bijective_zmod_five / exists_pow_seven_zmod_seven: concrete instantiations over ZMod 5 and ZMod 7"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "frobenius_inj",
+        "description": "On a reduced commutative ring of characteristic p the Frobenius is injective. An integral domain is reduced, so frobenius_injective is this lemma. (Mathlib Algebra/CharP/Reduced.lean.)",
+        "module": "Mathlib.Algebra.CharP.Reduced"
+      },
+      {
+        "theorem": "Finite.injective_iff_bijective",
+        "description": "A self-map of a finite type is injective iff bijective. Turns the injective Frobenius on a finite field into a bijection, giving frobenius_bijective.",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "RingEquiv.ofBijective",
+        "description": "Packages a bijective ring hom as a ring equivalence; builds frobeniusEquiv : K ≃+* K from the bijective Frobenius.",
+        "module": "Mathlib.Algebra.Ring.Equiv"
+      },
+      {
+        "theorem": "expChar_pos",
+        "description": "The (exponential) characteristic is positive; used to discharge p ≠ 0 in zero_pow when extracting the trivial-kernel statement.",
+        "module": "Mathlib.Algebra.CharP.Defs"
+      }
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 102,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Frobenius endomorphism x ↦ x^p is the central operator of positive-characteristic algebra. Two of its structural properties separate the 'tame' from the 'wild': it is always injective on a domain (a monomorphism), but surjectivity is special — it holds for perfect fields, of which finite fields are the prototype. On a finite field the Frobenius is therefore an automorphism, and it generates the Galois group of the field over its prime subfield. This entry isolates exactly that monomorphism/automorphism dichotomy.",
+    "problemStatement": "**Open Question (OQ-01-OQ-03, follow-up to the Frobenius endomorphism entry)**: Prove that the Frobenius x ↦ x^p is injective on any integral domain (a monomorphism) and surjective on a finite field, hence an automorphism — and package the finite-field case as an explicit ring equivalence.\n\n**Formalized**: frobenius_injective, pow_p_left_inj, pow_p_eq_zero_iff (the domain monomorphism); frobenius_bijective, exists_pow_p, frobeniusEquiv (the finite-field automorphism); and concrete ZMod 5 / ZMod 7 instantiations.",
+    "text": "A 102-line formalization in two movements. (1) **Domain.** Over an integral domain R of characteristic p, frobenius_injective records that x ↦ x^p is injective — a monomorphism — because a domain is reduced (no nonzero nilpotents) and x^p = y^p forces (x−y)^p = 0 hence x = y. This is spelled out as the cancellation law pow_p_left_inj (x^p = y^p ⇔ x = y) and the trivial-kernel law pow_p_eq_zero_iff (x^p = 0 ⇔ x = 0). (2) **Finite field.** A finite field is a finite domain, so Finite.injective_iff_bijective upgrades injectivity to bijectivity (frobenius_bijective): the Frobenius is an automorphism. exists_pow_p restates surjectivity as 'every element is a p-th power', and frobeniusEquiv packages the map as a ring equivalence K ≃+* K. Concrete checks instantiate over ZMod 5 and ZMod 7. All theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**Monomorphism on a domain**: frobenius_injective = frobenius_inj R p (Mathlib), valid because IsDomain ⇒ IsReduced and (x−y)^p = x^p − y^p (the freshman's dream) means an equal pair of p-th powers has a nilpotent difference, which must vanish. pow_p_left_inj unfolds frobenius_def to turn injectivity into the cancellation iff; pow_p_eq_zero_iff specializes y = 0 and rewrites 0^p = 0 via zero_pow (expChar_pos R p).ne'.\n\n**Automorphism on a finite field**: frobenius_bijective = Finite.injective_iff_bijective.mp (frobenius_injective K p) — a finite field is a finite type and a domain, so injectivity is bijectivity. exists_pow_p extracts the surjective witness and unfolds frobenius_def. frobeniusEquiv = RingEquiv.ofBijective (frobenius K p) (frobenius_bijective K p), with frobeniusEquiv_apply and coe_frobeniusEquiv (both rfl) identifying it with x ↦ x^p.\n\n**Concrete**: ZMod 5 / ZMod 7 are fields once Fact (Nat.Prime ·) is supplied, and ExpChar resolves from CharP + the prime fact; the checks are direct instantiations of the general theorems.",
+    "keyInsights": [
+      "**Reduced, not just domain, is what injectivity needs**: Mathlib's frobenius_inj asks only for IsReduced (no nonzero nilpotents). A domain qualifies, but the real obstruction to injectivity is nilpotents: over ZMod 4 (not reduced) the 2-power map kills the nilpotent 2, so injectivity genuinely fails outside the reduced world.",
+      "**Finiteness is exactly what buys surjectivity**: injectivity is automatic on any domain, but an injective self-map need not be surjective on an infinite domain (e.g. Frobenius on the rational function field 𝔽_p(t) misses t). Finiteness collapses injective to bijective — this is why finite fields are perfect and the Frobenius is an automorphism there.",
+      "**Automorphism, not just bijection**: because the Frobenius is already a ring homomorphism, bijectivity promotes it to a ring automorphism K ≃+* K (frobeniusEquiv) — the generator of Gal(K / 𝔽_p).",
+      "**Every element is a p-th power**: exists_pow_p is the surjectivity face — the defining property of a perfect field, here proved for the finite case as a corollary of the pigeonhole (finite injective ⇒ surjective).",
+      "**0-axiom including the noncomputable equivalence**: frobeniusEquiv is noncomputable (its inverse comes from choice via RingEquiv.ofBijective) yet introduces no axioms beyond propext / Classical.choice / Quot.sound — and no native_decide anywhere."
+    ],
+    "prerequisites": [
+      "Integral domains and reduced rings (IsDomain, IsReduced); a domain has no nonzero nilpotents",
+      "The Frobenius ring homomorphism frobenius R p and its injectivity frobenius_inj on a reduced ring",
+      "Finite types and the pigeonhole principle Finite.injective_iff_bijective",
+      "Ring equivalences and RingEquiv.ofBijective",
+      "ZMod p as a finite field for prime p; CharP / ExpChar instances"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "frobenius-endomorphism-oq-01",
+      "relationship": "extends",
+      "description": "The parent packages the Frobenius x ↦ x^p as a ring homomorphism in prime characteristic and characterizes it as the identity on ZMod p and on finite fields. This entry answers its lead open question, supplying the two structural facts the parent left open: injectivity on a domain (monomorphism) and bijectivity on a finite field (automorphism)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FrobeniusEndomorphismOQ01OQ03",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/FrobeniusEndomorphismOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "frobenius_injective",
+      "type": "core",
+      "statement": "$R$ an integral domain of char $p$ $\\Rightarrow$ $x \\mapsto x^p$ is injective",
+      "significance": "The Frobenius is a monomorphism on any integral domain: a domain is reduced, so x^p = y^p forces (x−y)^p = 0 and hence x = y. Injectivity can fail without the reduced hypothesis (nilpotents).",
+      "description": "Frobenius is injective on an integral domain."
+    },
+    {
+      "name": "pow_p_left_inj",
+      "type": "supporting",
+      "statement": "$x^p = y^p \\iff x = y$ over an integral domain",
+      "significance": "The injectivity as an explicit cancellation rule on p-th powers.",
+      "description": "Cancellation of p-th powers over a domain."
+    },
+    {
+      "name": "pow_p_eq_zero_iff",
+      "type": "supporting",
+      "statement": "$x^p = 0 \\iff x = 0$ over an integral domain",
+      "significance": "The Frobenius has trivial kernel — the no-nonzero-nilpotents content, the heart of why it is injective.",
+      "description": "Trivial kernel of the Frobenius on a domain."
+    },
+    {
+      "name": "frobenius_bijective",
+      "type": "core",
+      "statement": "$K$ a finite field $\\Rightarrow$ $x \\mapsto x^p$ is bijective",
+      "significance": "A finite field is a finite domain, so the injective Frobenius is automatically surjective — an automorphism. Finiteness is exactly what upgrades the monomorphism to an isomorphism.",
+      "description": "Frobenius is bijective on a finite field."
+    },
+    {
+      "name": "exists_pow_p",
+      "type": "core",
+      "statement": "$K$ a finite field, $y \\in K$ $\\Rightarrow$ $\\exists x,\\ x^p = y$",
+      "significance": "Surjectivity restated: every element of a finite field is a p-th power — the defining property of a perfect field, here for the finite case.",
+      "description": "Every element of a finite field is a p-th power."
+    },
+    {
+      "name": "frobeniusEquiv",
+      "type": "core",
+      "statement": "$\\mathrm{frobeniusEquiv} : K \\simeq_{+*} K$, $x \\mapsto x^p$",
+      "significance": "The Frobenius of a finite field packaged as a genuine ring automorphism K ≃+* K — the generator of Gal(K / 𝔽_p).",
+      "description": "Frobenius as a ring automorphism of a finite field."
+    },
+    {
+      "name": "frobenius_bijective_zmod_five",
+      "type": "supporting",
+      "statement": "$x \\mapsto x^5$ is bijective on $\\mathbb{Z}/5$",
+      "significance": "Concrete instantiation of the finite-field automorphism for p = 5 (here the identity, by Fermat).",
+      "description": "Frobenius is bijective on ZMod 5."
+    }
+  ],
+  "references": [
+    {
+      "text": "Frobenius endomorphism — injective on a domain, an automorphism on a finite field (a perfect field).",
+      "url": "https://en.wikipedia.org/wiki/Frobenius_endomorphism"
+    },
+    {
+      "text": "Perfect field — a field of characteristic p on which the Frobenius is surjective; finite fields are perfect.",
+      "url": "https://en.wikipedia.org/wiki/Perfect_field"
+    },
+    {
+      "text": "Mathlib4: frobenius_inj (Algebra/CharP/Reduced.lean), Finite.injective_iff_bijective (Data/Fintype/Card.lean), RingEquiv.ofBijective (Algebra/Ring/Equiv.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Answers the lead open question of frobenius-endomorphism-oq-01: the Frobenius x ↦ x^p is injective on any integral domain (a monomorphism, via frobenius_inj and the reduced-ring argument), and on a finite field — a finite domain — the injective Frobenius is automatically surjective (Finite.injective_iff_bijective), hence an automorphism. The finite-field case is packaged as a ring equivalence frobeniusEquiv : K ≃+* K, with surjectivity restated as 'every element is a p-th power'. All 9 theorems and 1 definition verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "The monomorphism/automorphism dichotomy is the gateway to the Galois theory of finite fields: the Frobenius generates Gal(𝔽_{p^n} / 𝔽_p), surjectivity is the definition of a perfect field, and the failure of surjectivity on infinite domains (e.g. 𝔽_p(t)) is the source of inseparability. Injectivity on a domain underlies the well-definedness of the perfect closure and the Frobenius lift in arithmetic geometry.",
+    "openQuestions": [
+      "Exhibit frobeniusEquiv as a generator of the cyclic Galois group Gal(𝔽_{p^n} / 𝔽_p), with order exactly n",
+      "Characterize surjectivity of the Frobenius as the definition of a perfect field, and give an explicit non-perfect example (e.g. 𝔽_p(t)) where t has no p-th root"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **lead open question** of `frobenius-endomorphism-oq-01` ("Prove injectivity of the Frobenius on a domain — it is a monomorphism — and surjectivity on a finite field, hence an automorphism"). Isolates the two structural facts that pin down the kernel and image of the Frobenius `x ↦ x^p`.

### Monomorphism on an integral domain
- `frobenius_injective` — `x ↦ x^p` is injective on any integral domain (a domain is reduced, so `x^p = y^p ⇒ (x−y)^p = 0 ⇒ x = y`), via Mathlib's `frobenius_inj`.
- `pow_p_left_inj` — the cancellation law `x^p = y^p ↔ x = y`.
- `pow_p_eq_zero_iff` — the trivial-kernel law `x^p = 0 ↔ x = 0`.

### Automorphism on a finite field
- `frobenius_bijective` — a finite field is a finite domain, so the injective Frobenius is automatically surjective (`Finite.injective_iff_bijective`), hence an automorphism.
- `exists_pow_p` — surjectivity restated: every element of a finite field is a `p`-th power (the perfect-field property).
- `frobeniusEquiv : K ≃+* K` — the Frobenius packaged as an explicit ring automorphism (`RingEquiv.ofBijective`), the generator of `Gal(K / 𝔽_p)`.

### Concrete
- `frobenius_bijective_zmod_five`, `exists_pow_seven_zmod_seven` over `ZMod 5` / `ZMod 7`.

## Verification
- **9 theorems, 1 definition, 0 sorries, 0 axioms.**
- Kernel-verified with `lake env lean` (Mathlib v4.26.0); `#print axioms` shows only the standard triple `propext / Classical.choice / Quot.sound` — **no `native_decide`, no `Lean.ofReduceBool`**.
- `frobeniusEquiv` is `noncomputable` (its inverse comes from choice via `RingEquiv.ofBijective`) but introduces no axioms beyond the standard triple.
- Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)