### PR TITLE
fix(audit): register orphaned BanachSteinhausTheoremOQ01 in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -264,6 +264,7 @@ import Proofs.BallotProblemOQ03OQ01OQ04
 import Proofs.BallotProblemOQ03OQ02
 import Proofs.BallotProblemOQ03OQ03
 import Proofs.BanachFixedPointOQ01
+import Proofs.BanachSteinhausTheoremOQ01
 import Proofs.BaselProblem
 import Proofs.BaselProblemOQ01OQ01
 import Proofs.BaselProblemOQ01OQ01OQ02


### PR DESCRIPTION
## Fix

Register `Proofs.BanachSteinhausTheoremOQ01` in `proofs/Proofs.lean` so it is included in the `Proofs` build target and actually kernel-checked.

## Evidence

**Before**: `BanachSteinhausTheoremOQ01.lean` (gallery `banach-steinhaus-theorem-oq-01`, status `verified`, badge `mathlib`, 0 axioms / 0 sorries; shipped in #28581) had no `import` line in `proofs/Proofs.lean`. The `lean_lib` root is `Proofs`, so a module not transitively imported from `Proofs.lean` is never compiled — the proof presented as verified but had never been kernel-checked.

**After**: One import line added in sorted position (between `BanachFixedPointOQ01` and `BaselProblem`). Kernel-verified clean against Mathlib v4.26.0:
- `lake env lean Proofs/BanachSteinhausTheoremOQ01.lean` → RC=0
- `#print axioms uniform_boundedness` / `resonance` → `[propext, Classical.choice, Quot.sound]` only (no `sorryAx`, no `Lean.ofReduceBool`)

The verified / 0-axiom claim is honest; the sole defect was orphaning from the build graph. No Lean source changed.

> Note: a build-graph sweep found ~180 other `proofs/Proofs/*.lean` modules similarly not imported in `Proofs.lean`. This PR fixes only the one verified above; the broader backlog is left for auditor triage rather than a risky bulk registration of unbuilt files.

---
Automated fix by lean-mechanic agent.