### PR TITLE
research(inclusion-exclusion-oq-04-oq-03): register orphaned Higher Bonferroni file + fix stale import

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3002,6 +3002,7 @@ import Proofs.HurwitzOnlyIf
 import Proofs.HurwitzTheorem
 import Proofs.HurwitzTheoremOQ04
 import Proofs.InclusionExclusion
+import Proofs.InclusionExclusionBonferroniGeneral
 import Proofs.InclusionExclusionGeneral
 import Proofs.InclusionExclusionOQ01
 import Proofs.InclusionExclusionOQ01OQ03

--- a/proofs/Proofs/InclusionExclusionBonferroniGeneral.lean
+++ b/proofs/Proofs/InclusionExclusionBonferroniGeneral.lean
@@ -1,7 +1,7 @@
 import Mathlib.Data.Finset.Powerset
 import Mathlib.Data.Fintype.Card
 import Mathlib.Data.Nat.Choose.Basic
-import Mathlib.Algebra.BigOperators.Ring
+import Mathlib.Algebra.BigOperators.Ring.Finset
 import Mathlib.Tactic
 
 /-

--- a/src/data/proofs/inclusion-exclusion-oq-04-oq-03/meta.json
+++ b/src/data/proofs/inclusion-exclusion-oq-04-oq-03/meta.json
@@ -100,7 +100,7 @@
       "Mathlib.Data.Finset.Powerset",
       "Mathlib.Data.Fintype.Card",
       "Mathlib.Data.Nat.Choose.Basic",
-      "Mathlib.Algebra.BigOperators.Ring",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
       "Mathlib.Tactic"
     ],
     "opens": [


### PR DESCRIPTION
## Summary

Salvages the **Higher Bonferroni Inequalities** gallery entry
(`inclusion-exclusion-oq-04-oq-03`, status `verified`/`original`). The 328-line
proof in `InclusionExclusionBonferroniGeneral.lean` was complete but **orphaned
from the build graph** — it was never imported in `Proofs.lean`, so it was never
kernel-checked despite the meta claiming `verified`. The file additionally carried
a **stale import** (`Mathlib.Algebra.BigOperators.Ring`, a module since split into
`Ring/Finset`, `Ring/List`, …) that would have failed to compile.

## What the proof contains (unchanged math)

Higher Bonferroni inequalities for an arbitrary finite set family `A : ι → Finset α`:
truncating the inclusion–exclusion sieve `bonf A m = Σ_{k=0}^m (-1)^k S_k` after an
even layer over-counts and after an odd layer under-counts the number of elements in
no set, with exactness at `m ≥ |ι|`. Proved via per-element reindexing + Pascal
telescoping of the partial alternating binomial sum.

## Fixes

- `proofs/Proofs.lean`: register `import Proofs.InclusionExclusionBonferroniGeneral`
- `InclusionExclusionBonferroniGeneral.lean`: `Mathlib.Algebra.BigOperators.Ring` → `.Ring.Finset`
- `meta.json`: update `leanFile.imports` to match

## Verification

`lake env lean` (Lean v4.26.0): compiles clean, no errors (only cosmetic
unused-section-variable linter warnings). `#print axioms` on `bonferroni_even`,
`bonferroni_odd`, `bonf_eq_noneCard_of_card_le` → `[propext, Classical.choice,
Quot.sound]` only (no `ofReduceBool`/`sorryAx`), confirming the axiom-free claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
