### PR TITLE
research(gamma-reflection-formula-oq-01-oq-01): B(1/2,1/2)=π and the arcsine total mass [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2846,6 +2846,7 @@ import Proofs.GCDAlgorithmOQ01OQ03OQ01
 import Proofs.GCDAlgorithmOQ01OQ03OQ01OQ01
 import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
+import Proofs.GammaReflectionFormulaOQ01OQ01
 import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ01.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ01.lean
@@ -1,0 +1,119 @@
+/-
+# Gamma Reflection OQ-01-OQ-01: The Beta value `B(1/2, 1/2) = π`
+
+**Open Question (parent `GammaReflectionFormulaOQ01`, openQuestions[0]).** The parent
+entry establishes Euler's reflection formula and the special value `Γ(1/2)² = π`. This
+file feeds that value through the **Beta–Gamma relation**
+`B(x, y) = Γ(x)·Γ(y) / Γ(x + y)` to evaluate
+
+> `B(1/2, 1/2) = Γ(1/2)² / Γ(1) = π`,
+
+and identifies this `π` with the **total mass of the (unnormalized) arcsine density**
+`1/√(t(1−t))` on `[0, 1]`:
+
+> `∫₀¹ dt / √(t(1−t)) = π`.
+
+## What is new
+
+Mathlib has the Beta integral `Complex.betaIntegral` and the Beta–Gamma identity
+`Complex.Gamma_mul_Gamma_eq_betaIntegral`, but it does **not** evaluate `B(1/2, 1/2)`,
+nor does it record the closed form `∫₀¹ dt/√(t(1−t)) = π`. Both are derived here. The
+arcsine-density reading turns the reflection-formula constant `π` into a concrete
+probability normalization (the arcsine law on `[0,1]` has density `1/(π√(t(1−t)))`).
+
+## Method
+
+`Complex.Gamma_mul_Gamma_eq_betaIntegral` gives `Γ(1/2)·Γ(1/2) = Γ(1)·B(1/2,1/2)`.
+With `Γ(1) = 1` (`Complex.Gamma_one`) and `Γ(1/2) = π^(1/2)`
+(`Complex.Gamma_one_half_eq`), the left side is `π^(1/2)·π^(1/2) = π^(1/2+1/2) = π`,
+so `B(1/2,1/2) = π`. Unfolding `betaIntegral` and casting the complex integrand
+`x^(-1/2)·(1−x)^(-1/2)` to the real `1/√(x(1−x))` throughout `[0,1]` (via
+`Complex.ofReal_cpow`) turns this into the real arcsine integral, then
+`intervalIntegral.integral_ofReal` transports the value `π` back to `ℝ`.
+
+## References
+
+* Mathlib: `Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean`,
+  `Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean`.
+* Whittaker & Watson, *A Course of Modern Analysis*, §12.4 (the Beta function).
+-/
+import Mathlib
+
+namespace GammaReflectionFormulaOQ01OQ01
+
+open scoped Real
+
+/-! ## The Beta value at the symmetric point -/
+
+/-- **The Beta value `B(1/2,1/2) = π`** (Mathlib's complex Beta integral).
+From the Beta–Gamma relation `Γ(1/2)·Γ(1/2) = Γ(1)·B(1/2,1/2)`, with `Γ(1) = 1` and
+`Γ(1/2) = π^(1/2)`, the product is `π^(1/2)·π^(1/2) = π^(1/2+1/2) = π`. -/
+theorem betaIntegral_half_half :
+    Complex.betaIntegral (1 / 2) (1 / 2) = (π : ℂ) := by
+  have h := Complex.Gamma_mul_Gamma_eq_betaIntegral
+    (s := (1 / 2 : ℂ)) (t := (1 / 2 : ℂ)) (by norm_num) (by norm_num)
+  rw [show (1 / 2 : ℂ) + 1 / 2 = 1 by norm_num, Complex.Gamma_one, one_mul] at h
+  rw [Complex.Gamma_one_half_eq] at h
+  have h0 : (π : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero
+  rw [← h, ← Complex.cpow_add _ _ h0, show (1 / 2 : ℂ) + 1 / 2 = 1 by norm_num,
+    Complex.cpow_one]
+
+/-- **The Beta value as a ratio of Gamma values**, over the real Gamma function:
+`B(1/2,1/2) = Γ(1/2)·Γ(1/2) / Γ(1) = π`. This is the textbook form of the Beta–Gamma
+relation specialized at `(1/2, 1/2)`, recovering the parent's `Γ(1/2)² = π`. -/
+theorem beta_half_half_gamma_ratio :
+    Real.Gamma (1 / 2) * Real.Gamma (1 / 2) / Real.Gamma 1 = π := by
+  rw [Real.Gamma_one, div_one, ← pow_two, Real.Gamma_one_half_eq,
+    Real.sq_sqrt Real.pi_pos.le]
+
+/-! ## The arcsine total mass
+
+We now read `B(1/2,1/2) = π` as a statement about a real integral. The complex Beta
+integrand at `(1/2,1/2)` is `x^(1/2-1)·(1-x)^(1/2-1)`; on `[0,1]` this is the cast of
+the real arcsine kernel `1/√(x(1-x))` (both sides vanish at the endpoints, where the
+`x^(-1/2)` / `(1-x)^(-1/2)` powers are read as `0`). -/
+
+/-- Pointwise identification of the complex Beta integrand at `(1/2, 1/2)` with the
+real arcsine kernel, valid throughout `[0,1]`. -/
+theorem beta_integrand_eq {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    (x : ℂ) ^ ((1 / 2 : ℂ) - 1) * (1 - (x : ℂ)) ^ ((1 / 2 : ℂ) - 1)
+      = ((1 / Real.sqrt (x * (1 - x)) : ℝ) : ℂ) := by
+  have h1x : 0 ≤ 1 - x := by linarith
+  rw [show (1 / 2 : ℂ) - 1 = ((-(1 / 2) : ℝ) : ℂ) by push_cast; ring,
+    show (1 : ℂ) - (x : ℂ) = ((1 - x : ℝ) : ℂ) by push_cast; ring,
+    ← Complex.ofReal_cpow hx0, ← Complex.ofReal_cpow h1x, ← Complex.ofReal_mul]
+  norm_cast
+  -- reals: `x^(-(1/2)) * (1-x)^(-(1/2)) = 1 / √(x(1-x))`
+  rw [Real.sqrt_mul hx0, Real.sqrt_eq_rpow, Real.sqrt_eq_rpow,
+    Real.rpow_neg hx0, Real.rpow_neg h1x]
+  ring
+
+/-- **Total mass of the arcsine kernel:** `∫₀¹ dx / √(x(1-x)) = π`.
+
+Transport of `betaIntegral_half_half` along `intervalIntegral.integral_ofReal`: the
+complex Beta integral `B(1/2,1/2)` is literally the interval integral of the real
+arcsine kernel cast to `ℂ`, so its value `π` is real and equals `∫₀¹ 1/√(x(1-x))`. -/
+theorem arcsine_total_mass :
+    ∫ x in (0 : ℝ)..1, 1 / Real.sqrt (x * (1 - x)) = π := by
+  have key : Complex.betaIntegral (1 / 2) (1 / 2)
+      = ∫ x in (0 : ℝ)..1, ((1 / Real.sqrt (x * (1 - x)) : ℝ) : ℂ) := by
+    rw [Complex.betaIntegral]
+    refine intervalIntegral.integral_congr (fun x hx => ?_)
+    rw [Set.uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1)] at hx
+    exact beta_integrand_eq hx.1 hx.2
+  rw [intervalIntegral.integral_ofReal, betaIntegral_half_half] at key
+  exact_mod_cast key.symm
+
+/-- **The arcsine law is a probability distribution:** its density `1/(π√(x(1-x)))`
+has total mass `1` over `[0,1]`. Immediate from `arcsine_total_mass` by factoring out
+the normalising `1/π`. -/
+theorem arcsine_density_total_mass :
+    ∫ x in (0 : ℝ)..1, 1 / (π * Real.sqrt (x * (1 - x))) = 1 := by
+  have h : ∀ x : ℝ, 1 / (π * Real.sqrt (x * (1 - x)))
+      = π⁻¹ * (1 / Real.sqrt (x * (1 - x))) := by
+    intro x; rw [mul_comm π, ← div_div]; ring
+  simp_rw [h]
+  rw [intervalIntegral.integral_const_mul, arcsine_total_mass,
+    inv_mul_cancel₀ Real.pi_ne_zero]
+
+end GammaReflectionFormulaOQ01OQ01

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/annotations.json
@@ -1,0 +1,95 @@
+[
+  {
+    "id": "ann-gamma-refl-oq0101-docstring",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 39
+    },
+    "type": "context",
+    "title": "From Γ(1/2)² = π to the Arcsine Mass",
+    "content": "The docstring answers the parent's first open question: derive the Beta value B(1/2,1/2) = π from Γ(1/2)² = π through Euler's Beta–Gamma integral relation B(x,y) = Γ(x)Γ(y)/Γ(x+y). Mathlib has the Beta integral (Complex.betaIntegral) and the relation (Complex.Gamma_mul_Gamma_eq_betaIntegral) but evaluates neither B(1/2,1/2) nor the resulting real integral. The new content: B(1/2,1/2) = π, the closed form ∫₀¹ dt/√(t(1-t)) = π for the total mass of the arcsine kernel, and the fact that the normalised arcsine density 1/(π√(t(1-t))) integrates to 1 — so the reflection-formula constant π is the normaliser of the arcsine distribution.",
+    "mathContext": "$B(1/2,1/2) = \\Gamma(1/2)^2/\\Gamma(1) = \\pi$ and $\\int_0^1 dt/\\sqrt{t(1-t)} = \\pi$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Beta function",
+      "Gamma function",
+      "arcsine distribution",
+      "Euler integral",
+      "special functions"
+    ],
+    "prerequisites": [
+      "the Gamma and Beta functions",
+      "Euler's Beta–Gamma relation",
+      "interval integrals"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq0101-beta-value",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 67
+    },
+    "type": "key-step",
+    "title": "B(1/2,1/2) = π via the Beta–Gamma Relation",
+    "content": "betaIntegral_half_half instantiates Γ(s)·Γ(t) = Γ(s+t)·B(s,t) at s = t = 1/2. The right-hand Gamma factor is Γ(1/2+1/2) = Γ(1) = 1, leaving B(1/2,1/2) = Γ(1/2)². Substituting Γ(1/2) = π^(1/2) (Complex.Gamma_one_half_eq) and applying the cpow addition law π^(1/2)·π^(1/2) = π^(1/2+1/2) = π^1 = π gives the value. beta_half_half_gamma_ratio records the same fact in textbook ratio form over the real Gamma function, B(1/2,1/2) = Γ(1/2)²/Γ(1) = π, directly recovering the parent's Γ(1/2)² = π via Real.sq_sqrt.",
+    "mathContext": "$\\Gamma(1/2)\\Gamma(1/2) = \\Gamma(1)B(1/2,1/2)$ with $\\Gamma(1)=1$ and $\\Gamma(1/2)=\\pi^{1/2}$, so $B(1/2,1/2)=\\pi$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Beta–Gamma relation",
+      "complex power cpow",
+      "Gamma(1/2) = √π"
+    ],
+    "prerequisites": [
+      "Complex.Gamma_mul_Gamma_eq_betaIntegral",
+      "Complex.Gamma_one_half_eq",
+      "cpow addition law"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq0101-integrand",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 76,
+      "endLine": 89
+    },
+    "type": "key-step",
+    "title": "Complex Beta Integrand = Real Arcsine Kernel",
+    "content": "beta_integrand_eq identifies the complex Beta integrand at (1/2,1/2), namely x^(1/2-1)·(1-x)^(1/2-1), with the cast of the real arcsine kernel 1/√(x(1-x)), valid for every x ∈ [0,1]. The exponent 1/2-1 = -1/2, and for 0 ≤ x both x^(-1/2) and (1-x)^(-1/2) are casts of their real counterparts (Complex.ofReal_cpow). Over ℝ the product x^(-1/2)·(1-x)^(-1/2) collapses to 1/√(x(1-x)) using Real.sqrt_mul and rpow/sqrt conversions. This pointwise identity is what lets the complex Beta integral be read as a real integral.",
+    "mathContext": "$x^{-1/2}(1-x)^{-1/2} = \\dfrac{1}{\\sqrt{x(1-x)}}$ for $x \\in [0,1]$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "real/complex cpow cast",
+      "rpow and sqrt",
+      "arcsine kernel"
+    ],
+    "prerequisites": [
+      "Complex.ofReal_cpow",
+      "Real.sqrt_mul",
+      "Real.rpow_neg"
+    ]
+  },
+  {
+    "id": "ann-gamma-refl-oq0101-arcsine-mass",
+    "proofId": "gamma-reflection-formula-oq-01-oq-01",
+    "range": {
+      "startLine": 91,
+      "endLine": 118
+    },
+    "type": "key-step",
+    "title": "Arcsine Total Mass and Probability Normalisation",
+    "content": "arcsine_total_mass transports the complex value to the real closed form ∫₀¹ dx/√(x(1-x)) = π: by the pointwise identity, Complex.betaIntegral (1/2) (1/2) equals the interval integral of the cast real kernel, so intervalIntegral.integral_ofReal turns it into the cast of the real arcsine integral, whose value must therefore be π. arcsine_density_total_mass then factors out the constant 1/π (intervalIntegral.integral_const_mul) to conclude ∫₀¹ dx/(π√(x(1-x))) = 1 — the arcsine law is a genuine probability distribution, normalised exactly by the reflection-formula constant π.",
+    "mathContext": "$\\int_0^1 \\frac{dx}{\\sqrt{x(1-x)}} = \\pi \\;\\Rightarrow\\; \\int_0^1 \\frac{dx}{\\pi\\sqrt{x(1-x)}} = 1$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "arcsine distribution",
+      "probability normalisation",
+      "interval integral transport"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_ofReal",
+      "intervalIntegral.integral_const_mul"
+    ]
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-01/meta.json
@@ -1,0 +1,169 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-01",
+  "slug": "gamma-reflection-formula-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped Real"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ01",
+    "lineCount": 119,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "B(1/2,1/2) = π and the Total Mass of the Arcsine Density",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ01.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "beta-function",
+      "arcsine-distribution",
+      "reflection-formula",
+      "probability",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 119,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "betaIntegral_half_half: the special Beta value B(1/2,1/2) = π, obtained by feeding s = t = 1/2 into Mathlib's Beta–Gamma relation Γ(s)·Γ(t) = Γ(s+t)·B(s,t) (where Γ(1) = 1) and collapsing Γ(1/2)² = π^(1/2)·π^(1/2) = π. Mathlib defines the Beta integral but does not evaluate it at (1/2,1/2).",
+      "beta_half_half_gamma_ratio: the textbook ratio form B(1/2,1/2) = Γ(1/2)·Γ(1/2)/Γ(1) = π over the real Gamma function, recovering the parent's Γ(1/2)² = π.",
+      "beta_integrand_eq: pointwise identification on [0,1] of the complex Beta integrand x^(1/2-1)·(1-x)^(1/2-1) with the cast of the real arcsine kernel 1/√(x(1-x)), via Complex.ofReal_cpow.",
+      "arcsine_total_mass: the closed form ∫₀¹ dx/√(x(1-x)) = π for the total mass of the (unnormalised) arcsine kernel, transported from the complex Beta value through intervalIntegral.integral_ofReal. Not in Mathlib.",
+      "arcsine_density_total_mass: the arcsine law on [0,1] is a probability distribution — its density 1/(π√(x(1-x))) integrates to 1 — exhibiting the reflection-formula constant π as the normalisation of the arcsine distribution."
+    ],
+    "prerequisites": [
+      "Euler Gamma function Real.Gamma / Complex.Gamma and the value Γ(1/2) = √π (Complex.Gamma_one_half_eq)",
+      "Mathlib's Beta integral Complex.betaIntegral and the Beta–Gamma relation Complex.Gamma_mul_Gamma_eq_betaIntegral",
+      "Real/complex cpow and the cast Complex.ofReal_cpow for non-negative bases",
+      "intervalIntegral.integral_ofReal to transport a real-valued complex integral back to ℝ"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.Gamma_mul_Gamma_eq_betaIntegral",
+        "description": "Γ(s)·Γ(t) = Γ(s+t)·B(s,t) for s,t of positive real part — Euler's Beta–Gamma integral relation, the bridge from Γ(1/2)² to B(1/2,1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.Gamma_one_half_eq",
+        "description": "Γ(1/2) = π^(1/2) over ℂ, used (with the cpow addition law) to evaluate Γ(1/2)·Γ(1/2) = π.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "Γ(1/2) = √π over ℝ, used for the real ratio form B(1/2,1/2) = Γ(1/2)²/Γ(1).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Complex.ofReal_cpow",
+        "description": "(↑x)^(↑r) = ↑(x^r) for 0 ≤ x, used to identify the complex Beta integrand with the cast real arcsine kernel pointwise on [0,1].",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Complex"
+      },
+      {
+        "theorem": "intervalIntegral.integral_ofReal",
+        "description": "∫ (↑(f x) : ℂ) = ↑(∫ f x); transports the real-valued complex Beta integral back to the real arcsine integral.",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-01-oq-01",
+      "question": "Compute the general symmetric Beta value B(s,1-s) = π/sin(πs) by combining the Beta–Gamma relation with Euler's reflection formula, recovering B(1/2,1/2) = π as the case s = 1/2.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "extends",
+      "description": "The parent establishes Γ(1/2)² = π from Euler's reflection formula; this entry feeds that value through the Beta–Gamma relation to evaluate B(1/2,1/2) = π and reads it as the total mass of the arcsine density."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-03",
+      "relationship": "related",
+      "description": "That entry proves Γ(1/2) = √π via the Gaussian integral, the value squared here to give B(1/2,1/2) = Γ(1/2)²/Γ(1) = π."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.betaIntegral and the Beta–Gamma relation Complex.Gamma_mul_Gamma_eq_betaIntegral."
+    },
+    {
+      "title": "A Course of Modern Analysis",
+      "author": "E. T. Whittaker and G. N. Watson",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "description": "Classical reference for the Beta function and the identity B(x,y) = Γ(x)Γ(y)/Γ(x+y) (§12.4)."
+    },
+    {
+      "title": "The Arcsine Law",
+      "author": "Paul Lévy",
+      "year": "1939",
+      "venue": "historical",
+      "description": "The arcsine distribution on [0,1] with density 1/(π√(x(1-x))), whose normalisation constant π is the Beta value computed here."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Beta function B(x,y) = ∫₀¹ tˣ⁻¹(1-t)ʸ⁻¹ dt was studied by Euler alongside the Gamma function, and the two are joined by the celebrated Euler integral identity B(x,y) = Γ(x)Γ(y)/Γ(x+y). The symmetric value B(1/2,1/2) is the simplest non-trivial special value: it equals Γ(1/2)²/Γ(1) = π, the same π that Euler's reflection formula produces at s = 1/2. The integrand at (1/2,1/2) is 1/√(t(1-t)), whose antiderivative is the arcsine — so the value π is literally ∫₀¹ dt/√(t(1-t)), the total mass of the (unnormalised) arcsine kernel. Dividing by π gives the density 1/(π√(t(1-t))) of the arcsine distribution, which appears in Lévy's arcsine laws for Brownian motion and in the spectral theory of random matrices. Mathlib formalises the Beta integral and the Beta–Gamma relation but does not record this special value or the arcsine closed form; both are supplied here.",
+    "problemStatement": "Derive the Beta value B(1/2,1/2) = π from Γ(1/2)² = π via Mathlib's Beta–Gamma relation, and exhibit the same π as the total mass ∫₀¹ dt/√(t(1-t)) of the arcsine density on [0,1], so that the normalised arcsine density 1/(π√(t(1-t))) integrates to 1.",
+    "proofStrategy": "Instantiate the Beta–Gamma relation Γ(s)·Γ(t) = Γ(s+t)·B(s,t) at s = t = 1/2: the right factor Γ(1) = 1, so B(1/2,1/2) = Γ(1/2)². Evaluating Γ(1/2) = π^(1/2) (Complex.Gamma_one_half_eq) and using the cpow law π^(1/2)·π^(1/2) = π^(1/2+1/2) = π gives B(1/2,1/2) = π. For the arcsine reading, unfold Complex.betaIntegral and identify the complex integrand x^(1/2-1)·(1-x)^(1/2-1) with the cast of the real kernel 1/√(x(1-x)) pointwise on [0,1] (Complex.ofReal_cpow), so the complex Beta integral is the cast of a real integral; intervalIntegral.integral_ofReal then transports the value π back to ℝ, yielding ∫₀¹ dx/√(x(1-x)) = π. Factoring out 1/π gives the probability normalisation.",
+    "keyInsights": [
+      "The Beta–Gamma relation turns the parent's transcendental special value Γ(1/2)² = π into a value of a concrete real integral: B(1/2,1/2) is not just an abstract product of Gamma values but the area ∫₀¹ dt/√(t(1-t)).",
+      "The same constant π appears in three guises — the reflection-formula special value Γ(1/2)², the Beta integral B(1/2,1/2), and the total mass of the arcsine kernel — and the proof makes the chain of equalities fully explicit.",
+      "Identifying the complex Beta integrand with the real arcsine kernel needs care only at the cast: for 0 ≤ x the powers x^(-1/2) and (1-x)^(-1/2) are the casts of their real counterparts (Complex.ofReal_cpow), after which the value is real and transports back by integral_ofReal.",
+      "The arcsine distribution's normalisation constant is exactly this Beta value: 1/(π√(x(1-x))) integrates to 1 precisely because ∫₀¹ dx/√(x(1-x)) = π. The reflection-formula π is the probability normaliser of the arcsine law.",
+      "The badge is original: Mathlib supplies the Beta integral and the Beta–Gamma relation, but neither the special value B(1/2,1/2) = π nor the real closed form ∫₀¹ dx/√(x(1-x)) = π is in the library."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: From Γ(1/2)² to the Arcsine Mass",
+      "startLine": 1,
+      "endLine": 39,
+      "summary": "States the open question — derive B(1/2,1/2) = π from Γ(1/2)² = π via the Beta–Gamma relation — and the arcsine reading ∫₀¹ dt/√(t(1-t)) = π. Names the Mathlib sources (Complex.betaIntegral, Complex.Gamma_mul_Gamma_eq_betaIntegral) and the new content: the special value, the real closed form, and the probability normalisation of the arcsine law.",
+      "mathContext": "$B(1/2,1/2) = \\Gamma(1/2)^2/\\Gamma(1) = \\pi$ and $\\int_0^1 dt/\\sqrt{t(1-t)} = \\pi$."
+    },
+    {
+      "id": "beta-value",
+      "title": "The Beta Value at the Symmetric Point",
+      "startLine": 46,
+      "endLine": 67,
+      "summary": "betaIntegral_half_half computes B(1/2,1/2) = π from the Beta–Gamma relation at s = t = 1/2 (Γ(1) = 1, Γ(1/2) = π^(1/2), cpow addition). beta_half_half_gamma_ratio records the real ratio form B(1/2,1/2) = Γ(1/2)²/Γ(1) = π recovering the parent's Γ(1/2)² = π.",
+      "mathContext": "$\\Gamma(1/2)\\Gamma(1/2) = \\Gamma(1)\\,B(1/2,1/2)$, $\\Gamma(1)=1$, $\\Gamma(1/2)=\\pi^{1/2}$."
+    },
+    {
+      "id": "arcsine-mass",
+      "title": "The Arcsine Total Mass",
+      "startLine": 69,
+      "endLine": 118,
+      "summary": "beta_integrand_eq identifies the complex Beta integrand x^(1/2-1)(1-x)^(1/2-1) with the cast of 1/√(x(1-x)) on [0,1]. arcsine_total_mass transports B(1/2,1/2) = π to the real closed form ∫₀¹ dx/√(x(1-x)) = π via integral_ofReal. arcsine_density_total_mass factors out 1/π to show the arcsine density integrates to 1.",
+      "mathContext": "$\\int_0^1 \\frac{dx}{\\sqrt{x(1-x)}} = \\pi$, hence $\\int_0^1 \\frac{dx}{\\pi\\sqrt{x(1-x)}} = 1$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The Beta value B(1/2,1/2) = π is derived from Γ(1/2)² = π via Mathlib's Beta–Gamma relation Γ(s)Γ(t) = Γ(s+t)B(s,t) at s = t = 1/2 (with Γ(1) = 1 and Γ(1/2) = π^(1/2)). Unfolding the Beta integral and identifying its integrand with the real arcsine kernel 1/√(x(1-x)) on [0,1] transports the value to the real closed form ∫₀¹ dx/√(x(1-x)) = π, and factoring out 1/π shows the arcsine density 1/(π√(x(1-x))) integrates to 1. 119 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "The Beta integral and the Beta–Gamma relation are Mathlib's (used as bridges), but the special value B(1/2,1/2) = π, the real closed form ∫₀¹ dx/√(x(1-x)) = π, and the arcsine probability normalisation are new — hence the original badge. The entry exhibits the reflection-formula constant π simultaneously as a Gamma special value, a Beta integral, and the normalising constant of the arcsine distribution.",
+    "openQuestions": [
+      "Compute the general symmetric Beta value B(s,1-s) = π/sin(πs) by combining the Beta–Gamma relation with Euler's reflection formula."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **gamma-reflection-formula-oq-01**: derive the Beta special value **B(1/2, 1/2) = π** from `Γ(1/2)² = π` via Mathlib's Beta–Gamma integral relation, and exhibit the same `π` as the **total mass of the arcsine density** on `[0,1]`.

## Results (`proofs/Proofs/GammaReflectionFormulaOQ01OQ01.lean`)

| Theorem | Statement |
|---|---|
| `betaIntegral_half_half` | `B(1/2,1/2) = π`, from `Γ(s)Γ(t) = Γ(s+t)B(s,t)` at `s=t=1/2` (`Γ(1)=1`, `Γ(1/2)=π^(1/2)`, cpow addition) |
| `beta_half_half_gamma_ratio` | textbook ratio form `Γ(1/2)²/Γ(1) = π` over `ℝ` |
| `beta_integrand_eq` | complex Beta integrand `x^(1/2-1)(1-x)^(1/2-1)` = cast of the real arcsine kernel `1/√(x(1-x))` on `[0,1]` |
| `arcsine_total_mass` | `∫₀¹ dx/√(x(1-x)) = π` (transported via `intervalIntegral.integral_ofReal`) |
| `arcsine_density_total_mass` | the arcsine density `1/(π√(x(1-x)))` integrates to `1` |

## Verification

- **119 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.**
- `#print axioms` on all five theorems lists only `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Genuinely 0-axiom (`status: verified`, badge `original`).
- Mathlib supplies the Beta integral and the Beta–Gamma relation (used as bridges); the special value `B(1/2,1/2)=π`, the real closed form `∫₀¹ dx/√(x(1-x))=π`, and the arcsine probability normalisation are new.

Registered in `proofs/Proofs.lean`; gallery entry under `src/data/proofs/gamma-reflection-formula-oq-01-oq-01/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)