### PR TITLE
research(frobenius-endomorphism-oq-01-oq-02): fixed field of Frobenius = prime subfield 𝔽ₚ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2811,6 +2811,7 @@ import Proofs.FriendshipTheoremOQ04
 import Proofs.FriendshipTheoremOQ04Amalgam
 import Proofs.FriendshipTheoremOQ04Universal
 import Proofs.FrobeniusEndomorphismOQ01
+import Proofs.FrobeniusEndomorphismOQ01OQ02
 import Proofs.FrobeniusEndomorphismOQ02
 import Proofs.FrobeniusNumber
 import Proofs.FrobeniusNumberOQ01

--- a/proofs/Proofs/FrobeniusEndomorphismOQ01OQ02.lean
+++ b/proofs/Proofs/FrobeniusEndomorphismOQ01OQ02.lean
@@ -1,0 +1,116 @@
+/-
+  The fixed field of the Frobenius endomorphism is the prime subfield.
+
+  Parent (`FrobeniusEndomorphismOQ01`) established that over a commutative ring
+  of prime characteristic `p` the Frobenius `x ↦ x ^ p` is a ring homomorphism,
+  and that over `ZMod p` it is the identity (Fermat's little theorem).
+
+  This file answers the open question: **which elements of a field `F` of
+  characteristic `p` are fixed by the Frobenius?**  The answer is the cleanest
+  possible: the fixed points are *exactly* the prime subfield `𝔽ₚ`.
+
+      frobenius F p x = x   ⟺   x ∈ (⊥ : Subfield F)   ⟺   ∃ a : ZMod p, ↑a = x.
+
+  Geometrically, `x ↦ x ^ p` fixes `x` iff `x` is a root of `Xᵖ - X`; this
+  polynomial has degree `p` and the `p` elements of the prime subfield `𝔽ₚ` are
+  `p` distinct roots (Fermat), so they exhaust the roots.  Mathlib packages this
+  as `Subfield.mem_bot_iff_pow_eq_self`; here we recast it in terms of the
+  Frobenius map itself, give the explicit `ZMod p` description of the fixed set,
+  record that the fixed field has exactly `p` elements, and connect to perfect
+  fields, where the Frobenius is bijective (an automorphism).
+
+  In particular, on a *finite* field `𝔽_{pⁿ}` the Frobenius is an automorphism
+  (perfect field) whose fixed field is the prime subfield `𝔽ₚ ⊊ 𝔽_{pⁿ}`
+  whenever `n > 1` — the Frobenius is the identity iff the field *is* its prime
+  subfield.
+
+  Fully verified: 0 sorries, 0 axioms, no `native_decide`.  This is a synthesis
+  of existing Mathlib results (`Subfield.mem_bot_iff_pow_eq_self`,
+  `fieldRange_castHom_eq_bot`, `Subfield.card_bot`, `bijective_frobenius`)
+  organised around the Frobenius fixed-field question.
+-/
+import Mathlib
+
+namespace FrobeniusEndomorphismOQ01OQ02
+
+open Polynomial
+
+variable {F : Type*} [Field F] (p : ℕ) [Fact p.Prime] [CharP F p]
+
+/-! ### The fixed field is the prime subfield `⊥ = 𝔽ₚ` -/
+
+/-- An element is fixed by the Frobenius iff it lies in the prime subfield
+`⊥`.  This is the central characterization: the *fixed field* of the Frobenius
+endomorphism of a field of characteristic `p` is the prime subfield. -/
+theorem frobenius_fixed_iff_mem_bot {x : F} :
+    frobenius F p x = x ↔ x ∈ (⊥ : Subfield F) := by
+  rw [frobenius_def, Subfield.mem_bot_iff_pow_eq_self]
+
+/-- The fixed point equation `xᵖ = x` (the defining equation of the fixed field)
+holds iff `x` is in the prime subfield. -/
+theorem pow_eq_self_iff_mem_bot {x : F} : x ^ p = x ↔ x ∈ (⊥ : Subfield F) :=
+  (Subfield.mem_bot_iff_pow_eq_self F p).symm
+
+/-- The fixed set of the Frobenius, as a `Set`, is exactly the prime subfield. -/
+theorem fixedSet_frobenius_eq_bot :
+    {x : F | frobenius F p x = x} = (⊥ : Subfield F) :=
+  Set.ext fun _ => frobenius_fixed_iff_mem_bot p
+
+/-! ### Explicit `ZMod p` description of the fixed field -/
+
+/-- The fixed points of the Frobenius are exactly the image of the canonical
+ring map `ZMod p → F`; i.e. they are the "integers mod `p`" sitting inside `F`.
+This makes the prime subfield `𝔽ₚ` explicit. -/
+theorem frobenius_fixed_iff_mem_primeField {x : F} :
+    frobenius F p x = x ↔ ∃ a : ZMod p, ZMod.castHom (dvd_refl p) F a = x := by
+  rw [frobenius_fixed_iff_mem_bot, ← ZMod.fieldRange_castHom_eq_bot p, RingHom.mem_fieldRange]
+
+/-- The canonical map `ZMod p → F` (the prime subfield `𝔽ₚ`) is fixed pointwise
+by the Frobenius: every element of `𝔽ₚ` satisfies `xᵖ = x` (Fermat). -/
+theorem frobenius_fixes_primeField (a : ZMod p) :
+    frobenius F p (ZMod.castHom (dvd_refl p) F a) = ZMod.castHom (dvd_refl p) F a :=
+  (frobenius_fixed_iff_mem_primeField p).2 ⟨a, rfl⟩
+
+/-! ### The fixed field has exactly `p` elements -/
+
+/-- The fixed field of the Frobenius has exactly `p` elements — it is `𝔽ₚ`. -/
+theorem card_fixedField_eq : Nat.card (⊥ : Subfield F) = p :=
+  Subfield.card_bot F p
+
+/-! ### Perfect fields: the Frobenius is an automorphism -/
+
+/-- On a **perfect** field of characteristic `p`, the Frobenius is bijective —
+an automorphism of `F`.  (Every finite field is perfect, so this applies to all
+finite fields.) -/
+theorem frobenius_bijective_of_perfectField [PerfectField F] :
+    Function.Bijective (frobenius F p) :=
+  bijective_frobenius F p
+
+/-- The Frobenius is injective on any field of characteristic `p` (a field is a
+domain, so `xᵖ = yᵖ → x = y`), and surjective exactly when the field is perfect.
+Here we record surjectivity on a perfect field. -/
+theorem frobenius_surjective_of_perfectField [PerfectField F] :
+    Function.Surjective (frobenius F p) :=
+  surjective_frobenius F p
+
+/-! ### Synthesis on a finite field `𝔽_{pⁿ}` -/
+
+variable (F) in
+/-- On a finite field, the Frobenius is simultaneously an automorphism (perfect
+field) and has fixed field equal to the prime subfield `𝔽ₚ`.  Thus the Frobenius
+is the identity iff the field coincides with its prime subfield (`n = 1`). -/
+theorem finiteField_frobenius_automorphism_with_primeField_fixed [Finite F] :
+    Function.Bijective (frobenius F p) ∧
+      ∀ x : F, frobenius F p x = x ↔ x ∈ (⊥ : Subfield F) :=
+  ⟨bijective_frobenius F p, fun _ => frobenius_fixed_iff_mem_bot p⟩
+
+/-! ### Concrete check -/
+
+private instance fact_five_prime : Fact (Nat.Prime 5) := ⟨by norm_num⟩
+
+/-- In `ZMod 5` (its own prime subfield) every element is fixed by the
+Frobenius `x ↦ x⁵`: the fixed field is all of `ZMod 5`. -/
+theorem frobenius_zmod_five_fixes_all : ∀ x : ZMod 5, frobenius (ZMod 5) 5 x = x := by
+  decide
+
+end FrobeniusEndomorphismOQ01OQ02

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-02-module-header",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02",
+    "type": "concept",
+    "range": {
+      "startLine": 1,
+      "endLine": 38
+    },
+    "title": "Module Header: The Fixed Field of the Frobenius",
+    "content": "The parent showed the Frobenius $x \\mapsto x^p$ is a ring homomorphism and is the identity on $\\mathbb{Z}/p$ (Fermat). This file answers: **which elements of a field $F$ of characteristic $p$ does the Frobenius fix?** The answer is the cleanest possible — the fixed points are *exactly* the prime subfield $\\mathbb{F}_p$:\n$$\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F) \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x.$$\nGeometrically $x$ is fixed iff it is a root of $X^p - X$; this degree-$p$ polynomial has the $p$ elements of $\\mathbb{F}_p$ (Fermat) as $p$ distinct roots, so they exhaust the roots. On a **perfect** field (every finite field) the Frobenius is bijective — an automorphism."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-02-fixed-field-bot",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02",
+    "type": "theorem",
+    "range": {
+      "startLine": 40,
+      "endLine": 57
+    },
+    "title": "The Fixed Field is the Prime Subfield ⊥",
+    "content": "`frobenius_fixed_iff_mem_bot`: $\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F)$ — the **central characterization**. The proof rewrites `frobenius_def` ($\\mathrm{frobenius}\\,F\\,p\\,x = x^p$, definitional) and applies Mathlib's `Subfield.mem_bot_iff_pow_eq_self`, whose content is that $X^p - X$ has degree $p$ and the $p$ Fermat-fixed elements of $\\mathbb{F}_p$ are all its roots.\n\n`pow_eq_self_iff_mem_bot`: the bare equation $x^p = x \\iff x \\in \\bot$. `fixedSet_frobenius_eq_bot`: the same fact as a `Set` equality $\\{x \\mid \\mathrm{frob}\\,x = x\\} = \\bot$, via `Set.ext`."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-02-primefield",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02",
+    "type": "theorem",
+    "range": {
+      "startLine": 59,
+      "endLine": 78
+    },
+    "title": "Explicit 𝔽ₚ Description and the Element Count",
+    "content": "`frobenius_fixed_iff_mem_primeField`: the fixed points are exactly the image of the canonical map $\\mathbb{Z}/p \\to F$, i.e. $\\mathrm{frob}\\,x = x \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x$. The proof bridges the $\\bot$ characterization through `ZMod.fieldRange_castHom_eq_bot` ($\\bot$ = range of $\\mathbb{Z}/p \\to F$) and `RingHom.mem_fieldRange` (membership = existential).\n\n`frobenius_fixes_primeField`: the easy inclusion — every $\\iota(a)$, $a : \\mathbb{Z}/p$, is fixed (Fermat inside $F$).\n\n`card_fixedField_eq`: $\\mathrm{Nat.card}\\,(\\bot) = p$ (`Subfield.card_bot`) — the fixed field has exactly $p$ elements, so the Frobenius is the identity on $\\mathbb{F}_{p^n}$ only when $n = 1$."
+  },
+  {
+    "id": "frobenius-endomorphism-oq-01-oq-02-perfect",
+    "proofId": "frobenius-endomorphism-oq-01-oq-02",
+    "type": "theorem",
+    "range": {
+      "startLine": 80,
+      "endLine": 116
+    },
+    "title": "Perfect Fields, Finite-Field Synthesis, and a Concrete Check",
+    "content": "`frobenius_bijective_of_perfectField` / `frobenius_surjective_of_perfectField`: on a **perfect** field the Frobenius is bijective (`bijective_frobenius`) — an automorphism. The instances `expChar_prime` ($\\mathbb{F}_p$-characteristic $\\Rightarrow$ ExpChar) and `PerfectField.toPerfectRing` make this apply to every finite field. Bijectivity *is* the definition of perfection.\n\n`finiteField_frobenius_automorphism_with_primeField_fixed`: the synthesis — on a finite field the Frobenius is simultaneously an automorphism and has fixed field $\\mathbb{F}_p$, the generator of $\\mathrm{Gal}(\\mathbb{F}_{p^n}/\\mathbb{F}_p)$.\n\n`frobenius_zmod_five_fixes_all`: a concrete `decide` check (kernel reduction, no `native_decide`) that $x \\mapsto x^5$ fixes every element of $\\mathbb{Z}/5 = \\mathbb{F}_5$, its own prime field."
+  }
+]

--- a/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/meta.json
+++ b/src/data/proofs/frobenius-endomorphism-oq-01-oq-02/meta.json
@@ -1,0 +1,187 @@
+{
+  "id": "frobenius-endomorphism-oq-01-oq-02",
+  "title": "The Fixed Field of the Frobenius is the Prime Subfield",
+  "slug": "frobenius-endomorphism-oq-01-oq-02",
+  "description": "In a field F of prime characteristic p, an element is fixed by the Frobenius x ↦ x^p exactly when it lies in the prime subfield 𝔽ₚ: frobenius F p x = x ↔ x ∈ (⊥ : Subfield F). Equivalently the fixed set equals the image of the canonical map ZMod p → F, and the fixed field has exactly p elements. Geometrically, x is fixed iff it is a root of X^p − X, and the p elements of 𝔽ₚ (Fermat) exhaust the roots. On a perfect field (every finite field), the Frobenius is bijective — an automorphism. Answers the parent's open question characterizing the fixed field and relating it to perfect fields. 10 theorems, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_endomorphism",
+    "date": "Ferdinand Georg Frobenius (late 19th century)",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "field-theory",
+      "finite-fields",
+      "characteristic-p",
+      "frobenius",
+      "perfect-fields",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/FrobeniusEndomorphismOQ01OQ02.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "None. All 10 theorems fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count). The concrete check in ZMod 5 uses decide, not native_decide, so no Lean.ofReduceBool is introduced.",
+    "originalContributions": [
+      "Packaging and recasting only — the central fact is Mathlib's Subfield.mem_bot_iff_pow_eq_self; there is no bridge lemma or mathematical content absent from Mathlib. The contribution is the curated Frobenius-fixed-field presentation, the explicit ZMod p description, and the synthesis with perfect-field bijectivity.",
+      "frobenius_fixed_iff_mem_bot: recasts mem_bot_iff_pow_eq_self in terms of the Frobenius map itself — the fixed field of x ↦ x^p is exactly the prime subfield ⊥ = 𝔽ₚ",
+      "fixedSet_frobenius_eq_bot: the fixed set {x | frobenius F p x = x} as a Set equals the prime subfield ⊥",
+      "frobenius_fixed_iff_mem_primeField: the explicit 𝔽ₚ form — fixed points are exactly the image of the canonical ZMod p → F (via ZMod.fieldRange_castHom_eq_bot and RingHom.mem_fieldRange)",
+      "frobenius_fixes_primeField: every element of the prime subfield 𝔽ₚ is a fixed point (Fermat, the easy inclusion)",
+      "card_fixedField_eq: the fixed field has exactly p elements (Subfield.card_bot)",
+      "frobenius_bijective_of_perfectField / frobenius_surjective_of_perfectField: on a perfect field the Frobenius is bijective (an automorphism), specializing to every finite field",
+      "finiteField_frobenius_automorphism_with_primeField_fixed: the synthesis on a finite field — Frobenius is simultaneously an automorphism and has fixed field 𝔽ₚ, so it is the identity iff the field is its own prime subfield",
+      "frobenius_zmod_five_fixes_all: concrete decide-check that every element of ZMod 5 (= 𝔽₅, its own prime field) is fixed by x ↦ x⁵"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Subfield.mem_bot_iff_pow_eq_self",
+        "description": "In a field of characteristic p, x ∈ (⊥ : Subfield F) ↔ x^p = x. The central characterization; frobenius_fixed_iff_mem_bot and pow_eq_self_iff_mem_bot are this lemma recast via the Frobenius map.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "ZMod.fieldRange_castHom_eq_bot",
+        "description": "The field range of the canonical ZMod p → F equals ⊥ (the prime subfield). Used to give frobenius_fixed_iff_mem_primeField its explicit 𝔽ₚ form.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "Subfield.card_bot",
+        "description": "Nat.card (⊥ : Subfield F) = p for a field of characteristic p. This is card_fixedField_eq.",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "bijective_frobenius",
+        "description": "On a perfect ring/field of characteristic p the Frobenius is bijective. Gives frobenius_bijective_of_perfectField (every finite field is a perfect field via the PerfectField → PerfectRing instance).",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "surjective_frobenius",
+        "description": "Surjectivity of the Frobenius on a perfect ring/field. Gives frobenius_surjective_of_perfectField.",
+        "module": "Mathlib.FieldTheory.Perfect"
+      },
+      {
+        "theorem": "RingHom.mem_fieldRange",
+        "description": "y ∈ f.fieldRange ↔ ∃ x, f x = y, turning membership in the prime subfield into the explicit existential over ZMod p.",
+        "module": "Mathlib.Algebra.Field.Subfield.Basic"
+      }
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 116,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Frobenius endomorphism x ↦ x^p is the central operator of characteristic-p algebra. Its fixed field — the set of x with x^p = x — is the prime subfield 𝔽ₚ, the smallest subfield, isomorphic to ℤ/pℤ. This single fact is the foundation of finite-field Galois theory: Gal(𝔽_{pⁿ}/𝔽ₚ) is generated by the Frobenius and its fixed field is precisely the base field 𝔽ₚ, while the fixed field of the q-power map x ↦ x^{pⁿ} is the intermediate field 𝔽_{pⁿ}. The bijectivity of the Frobenius is exactly the definition of a perfect field, the setting in which every algebraic extension is separable.",
+    "problemStatement": "**Open Question (OQ-02 of frobenius-endomorphism-oq-01)**: Characterize the fixed field of the Frobenius as the prime subfield 𝔽ₚ, and relate to perfect fields where the Frobenius is bijective.\n\n**Formalized**: frobenius_fixed_iff_mem_bot (fixed field = ⊥), fixedSet_frobenius_eq_bot (the fixed set as a Set), frobenius_fixed_iff_mem_primeField and frobenius_fixes_primeField (explicit ZMod p description), card_fixedField_eq (exactly p elements), frobenius_bijective_of_perfectField / frobenius_surjective_of_perfectField (perfect ⇒ automorphism), finiteField_frobenius_automorphism_with_primeField_fixed (synthesis on a finite field), and the ZMod 5 concrete check.",
+    "text": "A 116-line formalization answering the parent's lead open question. The heart is frobenius_fixed_iff_mem_bot: in a field F of characteristic p, frobenius F p x = x ↔ x ∈ (⊥ : Subfield F) — the fixed field of the Frobenius is the prime subfield. This is Mathlib's Subfield.mem_bot_iff_pow_eq_self recast through the Frobenius map (frobenius_def). Three views follow: the fixed set as a Set equals ⊥ (fixedSet_frobenius_eq_bot); the explicit 𝔽ₚ description as the image of ZMod p → F (frobenius_fixed_iff_mem_primeField), with the easy inclusion that 𝔽ₚ is fixed (frobenius_fixes_primeField); and the count Nat.card ⊥ = p (card_fixedField_eq). The perfect-field side records that on a perfect field — in particular every finite field — the Frobenius is bijective (frobenius_bijective_of_perfectField, frobenius_surjective_of_perfectField), and the finite-field synthesis bundles automorphism + fixed-field-𝔽ₚ together. A decide-check confirms every element of ZMod 5 is fixed. All 10 theorems compile with 0 sorries and 0 axioms; no native_decide.",
+    "proofStrategy": "**Fixed field = ⊥**: frobenius_fixed_iff_mem_bot rewrites frobenius_def (frobenius F p x = x^p, definitional) then applies Subfield.mem_bot_iff_pow_eq_self. The deep content of that Mathlib lemma is that X^p − X has degree p and the p elements of 𝔽ₚ (each fixed by Fermat) are p distinct roots, hence all roots; so x^p = x forces x ∈ 𝔽ₚ.\n\n**Explicit 𝔽ₚ**: frobenius_fixed_iff_mem_primeField rewrites the ⊥ characterization by ZMod.fieldRange_castHom_eq_bot (⊥ = range of ZMod p → F) and RingHom.mem_fieldRange (membership = existential). frobenius_fixes_primeField is the (⇐) direction applied to a : ZMod p.\n\n**Count**: card_fixedField_eq is Subfield.card_bot (the prime subfield has exactly p elements, since ZMod p ↪ F injectively).\n\n**Perfect fields**: with [Fact p.Prime] [CharP F p] the instance expChar_prime gives ExpChar F p, and PerfectField.toPerfectRing gives PerfectRing F p; bijective_frobenius / surjective_frobenius then apply. The finite-field synthesis combines bijective_frobenius (finite ⇒ perfect) with the fixed-field characterization.\n\n**Concrete**: frobenius_zmod_five_fixes_all is decide over ZMod 5 (kernel reduction, no native_decide).",
+    "keyInsights": [
+      "**The fixed field is the prime field**: x^p = x is the defining equation of 𝔽ₚ inside any characteristic-p field. The set of Frobenius-fixed points is not merely contained in 𝔽ₚ — it equals 𝔽ₚ, because X^p − X has at most p roots and 𝔽ₚ already supplies p distinct ones (Fermat).",
+      "**Two equalities, one fact**: 'the fixed field is ⊥' (intrinsic) and 'the fixed points are the image of ZMod p → F' (explicit) are the same statement, bridged by ZMod.fieldRange_castHom_eq_bot. The first is structural, the second computational.",
+      "**Counting pins it down**: the fixed field has exactly p elements (card_fixedField_eq). Combined with |𝔽_{pⁿ}| = pⁿ, the Frobenius is the identity on a finite field iff n = 1 — only the prime field is pointwise fixed.",
+      "**Bijectivity = perfection**: surjectivity of the Frobenius is, by definition, what it means for a field to be perfect. Finite fields are perfect (the injective Frobenius on a finite set is surjective), so there the Frobenius is an automorphism — the generator of the finite-field Galois group whose fixed field is the prime field.",
+      "**0-axiom including the numerics**: the ZMod 5 check uses decide (kernel reduction over the finite type), not native_decide, so the whole file rests only on propext / Classical.choice / Quot.sound."
+    ],
+    "prerequisites": [
+      "Prime / exponential characteristic and the Frobenius ring homomorphism (Mathlib CharP, ExpChar, frobenius)",
+      "The prime subfield ⊥ : Subfield F and the canonical embedding ZMod p ↪ F (ZMod.castHom)",
+      "The polynomial X^p − X, its degree, and Fermat's little theorem supplying its roots (behind Subfield.mem_bot_iff_pow_eq_self)",
+      "Perfect rings and fields: PerfectRing / PerfectField and bijectivity of the Frobenius",
+      "Decidability of universally-quantified statements over finite types (decide)"
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "frobenius-endomorphism-oq-01",
+      "relationship": "extends",
+      "description": "The parent packages the Frobenius as a ring homomorphism and shows it is the identity on ZMod p (Fermat) and on a finite field x^q = x. This entry answers the parent's lead open question: it characterizes the fixed field of the Frobenius as the prime subfield 𝔽ₚ and relates it to perfect fields where the Frobenius is bijective."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FrobeniusEndomorphismOQ01OQ02",
+    "lineCount": 116,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/FrobeniusEndomorphismOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "frobenius_fixed_iff_mem_bot",
+      "type": "core",
+      "statement": "$\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff x \\in (\\bot : \\mathrm{Subfield}\\,F)$",
+      "significance": "The central characterization: the fixed field of the Frobenius x ↦ x^p in a characteristic-p field is exactly the prime subfield 𝔽ₚ.",
+      "description": "Frobenius fixes x iff x lies in the prime subfield."
+    },
+    {
+      "name": "frobenius_fixed_iff_mem_primeField",
+      "type": "core",
+      "statement": "$\\mathrm{frobenius}\\,F\\,p\\,x = x \\iff \\exists a : \\mathbb{Z}/p,\\ \\iota(a) = x$",
+      "significance": "The explicit 𝔽ₚ form: the fixed points are precisely the image of the canonical map ZMod p → F, i.e. the 'integers mod p' inside F.",
+      "description": "Fixed points = image of the canonical ZMod p → F."
+    },
+    {
+      "name": "card_fixedField_eq",
+      "type": "core",
+      "statement": "$\\mathrm{Nat.card}\\,(\\bot : \\mathrm{Subfield}\\,F) = p$",
+      "significance": "The fixed field has exactly p elements — it is 𝔽ₚ. Combined with |𝔽_{pⁿ}| = pⁿ this shows the Frobenius is the identity only when the field is its own prime subfield.",
+      "description": "The prime subfield (fixed field) has exactly p elements."
+    },
+    {
+      "name": "frobenius_bijective_of_perfectField",
+      "type": "core",
+      "statement": "$F$ perfect $\\Rightarrow$ $\\mathrm{frobenius}\\,F\\,p$ bijective",
+      "significance": "On a perfect field (in particular every finite field) the Frobenius is bijective — a field automorphism. Bijectivity is the defining property of perfection.",
+      "description": "The Frobenius is an automorphism on a perfect field."
+    },
+    {
+      "name": "finiteField_frobenius_automorphism_with_primeField_fixed",
+      "type": "supporting",
+      "statement": "$F$ finite $\\Rightarrow$ $\\mathrm{frobenius}\\,F\\,p$ bijective $\\wedge\\ (\\forall x,\\ \\mathrm{frob}\\,x = x \\iff x \\in \\bot)$",
+      "significance": "The synthesis on a finite field: the Frobenius is simultaneously an automorphism and has fixed field 𝔽ₚ — the generator of Gal(𝔽_{pⁿ}/𝔽ₚ) fixing exactly the prime field.",
+      "description": "On a finite field: automorphism with fixed field 𝔽ₚ."
+    },
+    {
+      "name": "frobenius_fixes_primeField",
+      "type": "supporting",
+      "statement": "$\\mathrm{frobenius}\\,F\\,p\\,(\\iota\\,a) = \\iota\\,a$ for $a : \\mathbb{Z}/p$",
+      "significance": "The easy inclusion: every element of the prime subfield 𝔽ₚ is fixed by the Frobenius (Fermat's little theorem inside F).",
+      "description": "Every element of 𝔽ₚ is a Frobenius fixed point."
+    },
+    {
+      "name": "frobenius_zmod_five_fixes_all",
+      "type": "supporting",
+      "statement": "$\\forall x \\in \\mathbb{Z}/5,\\ \\mathrm{frobenius}\\,(\\mathbb{Z}/5)\\,5\\,x = x$",
+      "significance": "Concrete check that the fixed field of x ↦ x⁵ on ZMod 5 (= 𝔽₅, its own prime field) is all of ZMod 5, by decide over the finite type.",
+      "description": "Every element of ZMod 5 is fixed by x ↦ x⁵."
+    }
+  ],
+  "references": [
+    {
+      "text": "Frobenius endomorphism — the p-power map in characteristic p; its fixed field is the prime subfield and it generates the Galois group of finite fields.",
+      "url": "https://en.wikipedia.org/wiki/Frobenius_endomorphism"
+    },
+    {
+      "text": "Perfect field — a field on which the Frobenius is surjective (hence bijective); every finite field and every field of characteristic zero is perfect.",
+      "url": "https://en.wikipedia.org/wiki/Perfect_field"
+    },
+    {
+      "text": "Mathlib4: Subfield.mem_bot_iff_pow_eq_self, ZMod.fieldRange_castHom_eq_bot, Subfield.card_bot (FieldTheory/Finite/Basic.lean); bijective_frobenius, surjective_frobenius (FieldTheory/Perfect.lean).",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/"
+    }
+  ],
+  "conclusion": {
+    "summary": "Answers the parent's lead open question by characterizing the fixed field of the Frobenius x ↦ x^p in a field of characteristic p as the prime subfield 𝔽ₚ: frobenius_fixed_iff_mem_bot (= ⊥), with the explicit description as the image of ZMod p → F (frobenius_fixed_iff_mem_primeField) and the count Nat.card ⊥ = p (card_fixedField_eq). On a perfect field — every finite field — the Frobenius is bijective (frobenius_bijective_of_perfectField), and the finite-field synthesis bundles automorphism with fixed-field-𝔽ₚ. All 10 theorems verified with 0 sorries and 0 axioms, no native_decide.",
+    "implications": "The fixed field being the prime field is the cornerstone of finite-field Galois theory: the Frobenius generates Gal(𝔽_{pⁿ}/𝔽ₚ), whose fixed field is exactly 𝔽ₚ, and the intermediate fixed fields of its iterates are the subfields 𝔽_{pᵈ} for d ∣ n. Perfection (bijectivity of the Frobenius) is the dividing line that makes all algebraic extensions separable. These facts underlie the structure theory of finite and perfect fields and the Frobenius morphisms of arithmetic geometry in positive characteristic.",
+    "openQuestions": [
+      "Identify the fixed field of the n-fold iterate x ↦ x^{pⁿ} in 𝔽_{pᵐ} as the subfield 𝔽_{p^{gcd(n,m)}}, recovering the full subfield lattice",
+      "Exhibit an explicit imperfect field (e.g. 𝔽ₚ(t)) where the Frobenius fails to be surjective, sharpening the perfect-field dichotomy"
+    ]
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the lead **open question** of `frobenius-endomorphism-oq-01`: *characterize the fixed field of the Frobenius as the prime subfield 𝔽ₚ, and relate to perfect fields where the Frobenius is bijective.*

The central result is

```
frobenius_fixed_iff_mem_bot : frobenius F p x = x ↔ x ∈ (⊥ : Subfield F)
```

— in a field `F` of characteristic `p`, the **fixed field of the Frobenius** `x ↦ x^p` is exactly the **prime subfield** `𝔽ₚ`. Geometrically, `x` is fixed iff it is a root of `Xᵖ − X`; this degree-`p` polynomial already has the `p` Fermat-fixed elements of `𝔽ₚ` as distinct roots, so they exhaust the roots.

## What's proved (10 theorems, 0 sorries, 0 axioms)

- `frobenius_fixed_iff_mem_bot`, `pow_eq_self_iff_mem_bot`, `fixedSet_frobenius_eq_bot` — fixed field = `⊥` (as `↔` and as a `Set`)
- `frobenius_fixed_iff_mem_primeField` — explicit `ZMod p` description: fixed points = image of the canonical `ZMod p → F`
- `frobenius_fixes_primeField` — the easy inclusion: every element of `𝔽ₚ` is fixed (Fermat)
- `card_fixedField_eq` — the fixed field has exactly `p` elements
- `frobenius_bijective_of_perfectField` / `frobenius_surjective_of_perfectField` — on a perfect field (every finite field) the Frobenius is an automorphism
- `finiteField_frobenius_automorphism_with_primeField_fixed` — synthesis on a finite field
- `frobenius_zmod_five_fixes_all` — concrete `decide` check (no `native_decide`)

## Verification

`#print axioms` on every theorem returns only the standard triple `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. Kernel-verified via `lake env lean`.

## Honesty note

This is a **synthesis/packaging** entry (badge `mathlib`, like the parent): the deep content lives in Mathlib (`Subfield.mem_bot_iff_pow_eq_self`, `ZMod.fieldRange_castHom_eq_bot`, `Subfield.card_bot`, `bijective_frobenius`). The contribution is the curated Frobenius-fixed-field framing, the explicit `𝔽ₚ` description, and the perfect-field synthesis — not an independent proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)