### PR TITLE
research(cauchy-schwarz-lp-duality): kernel-verify 3 ingredient lemmas, fix real bug, register orphaned file

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -546,6 +546,7 @@ import Proofs.CauchyInterlacingKeystone
 import Proofs.CauchyInterlacingOQ01OQ01
 import Proofs.CauchySchwarz
 import Proofs.CauchySchwarzIntegral
+import Proofs.CauchySchwarzIntegralLpDualitySynthesis
 import Proofs.CauchySchwarzIntegralOQ01
 import Proofs.CauchySchwarzIntegralOQ01OQ01
 import Proofs.CauchySchwarzIntegralOQ01OQ01OQ01

--- a/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
+++ b/proofs/Proofs/CauchySchwarzIntegralLpDualitySynthesis.lean
@@ -67,21 +67,26 @@ dependency chain (the σ-finite Riesz theorem and `extByZeroCLM`); see the accou
 
 ## Status
 
-WORK IN PROGRESS. Three ingredient lemmas are now source-complete and self-contained:
-the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support of an Lᵖ
-function), `sigmaFinite_restrict_iUnion` (step 2: countable-union σ-finiteness, a
-genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`), and
-`eLpNorm_rpow_restrict_union` (step 3: `q`-power Lᵠ-seminorm additivity over a
+WORK IN PROGRESS. Three ingredient lemmas are now **kernel-verified** and
+self-contained: the bridge lemma `memLp_exists_sigmaFinite_support` (σ-finite support
+of an Lᵖ function), `sigmaFinite_restrict_iUnion` (step 2: countable-union
+σ-finiteness, a genuine Mathlib gap, proved here from `Measure.sigmaFinite_of_countable`),
+and `eLpNorm_rpow_restrict_union` (step 3: `q`-power Lᵠ-seminorm additivity over a
 disjoint union, the analytic identity driving the maximality gluing, also absent from
 Mathlib for a general finite exponent). The headline reduction
 `riesz_lp_surjective_general` still carries a single `sorry` for the remaining
 maximality *plumbing* (step 1's `extByZeroCLM` pullback and step 3's sequence/gluing
 bookkeeping) — it does **not** yet eliminate the axiom.
 
-NOT BUILD-VERIFIED: the local Docker build wrapper has been hanging and Aristotle is
-unavailable, so `sigmaFinite_restrict_iUnion` is source-complete but its proof has not
-been kernel-checked locally; the deployer build-gate is the verifier. Do not present
-this file as verified until the `sorry` is discharged and the file builds.
+BUILD STATUS (2026-06-23, researcher-1): the three ingredient lemmas above are now
+kernel-checked via host `lake env lean` against Mathlib v4.26.0 (Docker remained
+down; the host single-file path works). This fixed a real defect that the prior
+"source-complete" sessions had never compiled: the complement branch of
+`sigmaFinite_restrict_iUnion` left the goal `μ ((⋃ n, S n)ᶜ ∩ ⋃ n, S n) < ⊤` unsolved
+under a bare `simp`; it is discharged by `Set.compl_inter_self` (the set is `sᶜ ∩ s = ∅`).
+The file now compiles with exactly one expected `sorry` warning (the headline
+maximality). The axiom is **not** yet eliminated — do not present the headline as
+verified until the `sorry` is discharged.
 
 ## References
 
@@ -153,7 +158,7 @@ theorem sigmaFinite_restrict_iUnion {S : ℕ → Set α}
         ← Measure.restrict_apply' (hSm p.1)]
       exact measure_spanningSets_lt_top _ _
     · show (μ.restrict (⋃ n, S n)) ((⋃ n, S n)ᶜ) < ∞
-      rw [Measure.restrict_apply' hTm]
+      rw [Measure.restrict_apply' hTm, Set.compl_inter_self]
       simp
   · rw [Set.sUnion_union, Set.sUnion_range, Set.sUnion_singleton]
     refine Set.eq_univ_of_forall fun x => ?_

--- a/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
+++ b/research/problems/cauchy-schwarz-integral-lp-duality-synthesis/knowledge.md
@@ -369,3 +369,38 @@ Full scaffold (with the maximality `sorry` and the reduction blueprint docstring
    (`eLpNorm_rpow_restrict_union`) available — what remains there is the `eLpNorm = 0 ⇒
    ae-zero` step (`eLpNorm_eq_zero_iff`) + uniqueness bookkeeping.
 5. Assemble `riesz_lp_surjective_general`, build green, swap parent axiom, flip meta.
+
+### 2026-06-23 (Session 8, researcher-1) — PROGRESS (verifier UNBLOCKED; 3 ingredient lemmas now kernel-verified; real bug fixed)
+
+**Mode:** REVISIT. **Outcome:** real verified progress (first kernel check in 8 sessions).
+
+**Headline:** the 7-session "verifier blackout" was a false constraint. Docker is still
+down (`docker info` timeout), but the **host single-file path works**:
+`cd proofs && lake env lean <file>` resolves against the prebuilt Mathlib v4.26.0 oleans
+at `.lake/packages/mathlib/.lake/build/lib/lean/` (7382 oleans present — note the
+`lib/lean/` segment, not `lib/`). A trivial `import Mathlib` file compiled EXIT 0.
+
+**What I verified / fixed in `CauchySchwarzIntegralLpDualitySynthesis.lean`:**
+- Compiling the file (orphaned from `Proofs.lean`, so CI had **never** built it) exposed a
+  **real defect** that every prior "source-complete" session missed: the complement branch
+  of `sigmaFinite_restrict_iUnion` left `μ ((⋃ n, S n)ᶜ ∩ ⋃ n, S n) < ⊤` unsolved under a
+  bare `simp`. Fixed with `Set.compl_inter_self` (`sᶜ ∩ s = ∅`) before `simp`.
+- After the fix the file compiles with **exactly one** expected `sorry` warning (the
+  headline maximality). `#print axioms` on all three ingredient lemmas
+  (`memLp_exists_sigmaFinite_support`, `sigmaFinite_restrict_iUnion`,
+  `eLpNorm_rpow_restrict_union`) → `[propext, Classical.choice, Quot.sound]` only. No
+  `sorryAx`, no `ofReduceBool`. Genuinely verified, axiom-free Mathlib-gap lemmas.
+- **Registered the file in `proofs/Proofs.lean`** (inserted in LC_ALL=C order after
+  `CauchySchwarzIntegral`) so CI now compiles it — durable verification + regression guard.
+  Root cause it was missed for 7 sessions: orphaned from the build graph, never compiled.
+
+**Axiom NOT eliminated.** The headline `riesz_lp_surjective_general` still carries the
+documented maximality `sorry` (step 1 `extByZeroCLM` pullback + step 3 sequence/gluing).
+The parent `axiom riesz_lp_surjective` is untouched; `axiomCount` unchanged. This session
+hardened the *ingredients* of the reduction into kernel-checked form, it did not close the
+reduction.
+
+**Next session:** verifier IS available via host `lake env lean` — discharge the headline
+maximality. Prereq: re-expose `extByZeroCLM` (currently `private` in `…Incomplete01.lean`)
+and build the σ-finite chain (`…OQ01OQ01.lean`) to confirm `riesz_lp_surjective_sigma_finite`
+truly compiles, then wire steps 1–3 (ingredients now all verified).


### PR DESCRIPTION
## Summary

The Lᵖ-duality synthesis scaffold (`CauchySchwarzIntegralLpDualitySynthesis.lean`) was **orphaned from `Proofs.lean`**, so CI had never compiled it — and 7 prior "source-complete" sessions never kernel-checked it (they only tried Docker + Aristotle, both down). The host single-file path `lake env lean` works against the prebuilt Mathlib v4.26.0 oleans, so this session finally compiled it.

## What this PR does

1. **Fixes a real defect.** Compiling exposed an unsolved goal in `sigmaFinite_restrict_iUnion`: the complement branch left `μ ((⋃ n, S n)ᶜ ∩ ⋃ n, S n) < ⊤` under a bare `simp`. Fixed with `Set.compl_inter_self` (`sᶜ ∩ s = ∅`).
2. **Kernel-verifies 3 Mathlib-gap ingredient lemmas.** After the fix the file compiles with exactly one expected `sorry` (the headline maximality). `#print axioms` on all three —
   - `memLp_exists_sigmaFinite_support` (σ-finite support of an Lᵖ function),
   - `sigmaFinite_restrict_iUnion` (countable-union σ-finiteness of a restriction),
   - `eLpNorm_rpow_restrict_union` (`q`-power Lᵠ-seminorm additivity over a disjoint union)
   — shows the **standard triple only** `[propext, Classical.choice, Quot.sound]` (no `sorryAx`, no `ofReduceBool`).
3. **Registers the file in `proofs/Proofs.lean`** (LC_ALL=C order, after `CauchySchwarzIntegral`) so CI now compiles it — durable verification + regression guard. Root cause it was missed: orphaned from the build graph.

## What this PR does NOT do

The parent `axiom riesz_lp_surjective` is **unchanged**; `axiomCount` is untouched. The headline reduction `riesz_lp_surjective_general` still carries the documented maximality `sorry` (step 1 `extByZeroCLM` pullback + step 3 sequence/gluing). This PR hardens the reduction's *ingredients* into verified form; it does not yet eliminate the axiom.

## Verification

`lake env lean` (host, Mathlib v4.26.0) — compiles with one expected `sorry` warning; all three ingredient lemmas pass `#print axioms` with the standard triple only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)