### PR TITLE
Enrich Erdős #504 OQ-01: 2^d Non-Obtuse Points in ℝ^d

### DIFF
--- a/src/data/proofs/erdos-504-oq-01/annotations.json
+++ b/src/data/proofs/erdos-504-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "erdos504-ann-setup",
+    "proofId": "erdos-504-oq-01",
+    "range": { "startLine": 1, "endLine": 54 },
+    "type": "context",
+    "title": "Higher-dimensional Erdős #504 and the non-obtuse threshold",
+    "content": "The docstring frames the problem. Parent #504 (Blumenthal's problem, solved by Sendov 1993) asks, in ℝ², for the largest angle every n-point set is forced to contain. The natural d-dimensional question centers on the right-angle threshold π/2: a set is non-obtuse if every angle ∠abc is ≤ π/2. Danzer–Grünbaum (1962) showed the maximum non-obtuse set in ℝ^d has exactly 2^d points, realized by the hypercube vertices. This file formalizes the construction (lower bound) direction axiom-free; the harder upper bound (2^d+1 points force an obtuse angle) is not attempted. Point d = EuclideanSpace ℝ (Fin d), and IsCubeVertex marks points with every coordinate in {0,1}.",
+    "mathContext": "Non-obtuse: $\\forall a,b,c,\\ \\angle abc \\le \\pi/2$. Danzer–Grünbaum: max non-obtuse set in $\\mathbb{R}^d$ has $2^d$ points (the hypercube).",
+    "significance": "context",
+    "relatedConcepts": ["Erdős problems", "Danzer–Grünbaum theorem", "non-obtuse sets", "hypercube"],
+    "prerequisites": ["Lean 4", "Mathlib inner product spaces", "Euclidean geometry"]
+  },
+  {
+    "id": "erdos504-ann-criterion",
+    "proofId": "erdos-504-oq-01",
+    "range": { "startLine": 50, "endLine": 62 },
+    "type": "technique",
+    "title": "Dimension-free non-obtuse criterion",
+    "content": "angle_le_pi_div_two_of_inner_nonneg is the reusable bridge from algebra to geometry: in any real inner product space, ⟪x,y⟫ ≥ 0 forces the unoriented angle between x and y to be ≤ π/2. The proof unfolds the angle as arccos(⟪x,y⟫/(‖x‖‖y‖)) and uses Real.arccos_le_pi_div_two — the argument of arccos is nonnegative because numerator and denominator are. This isolates the only analytic fact needed; everything downstream is the combinatorics of making the inner product nonnegative.",
+    "mathContext": "$\\langle x,y\\rangle \\ge 0 \\Rightarrow \\angle(x,y) = \\arccos\\!\\big(\\tfrac{\\langle x,y\\rangle}{\\|x\\|\\|y\\|}\\big) \\le \\pi/2$.",
+    "significance": "key",
+    "relatedConcepts": ["inner product", "arccos", "angle", "Cauchy–Schwarz geometry"],
+    "prerequisites": ["InnerProductGeometry.angle", "Real.arccos_le_pi_div_two"]
+  },
+  {
+    "id": "erdos504-ann-cube-nonneg",
+    "proofId": "erdos-504-oq-01",
+    "range": { "startLine": 64, "endLine": 95 },
+    "type": "insight",
+    "title": "The hypercube has no obtuse angle",
+    "content": "The elementary heart of the argument. cube_term_nonneg checks coordinatewise that for bᵢ,aᵢ,cᵢ ∈ {0,1}, (cᵢ−bᵢ)(aᵢ−bᵢ) ≥ 0 — both factors share the sign of bᵢ (nonnegative if bᵢ=0, nonpositive if bᵢ=1), dispatched by an 8-way case split and norm_num. Summing over coordinates, cube_inner_nonneg gives ⟪a−b, c−b⟫ ≥ 0 for any three cube vertices, and cube_angle_le_pi_div_two feeds that into the dimension-free criterion to conclude ∠abc ≤ π/2.",
+    "mathContext": "$\\langle a-b, c-b\\rangle = \\sum_i (a_i-b_i)(c_i-b_i) \\ge 0$ since each summand is $\\ge 0$ for $a_i,b_i,c_i\\in\\{0,1\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["coordinatewise sign", "PiLp inner product", "Finset.sum_nonneg", "right angle"],
+    "prerequisites": ["EuclideanSpace inner product (PiLp.inner_apply)", "case analysis"]
+  },
+  {
+    "id": "erdos504-ann-construction",
+    "proofId": "erdos-504-oq-01",
+    "range": { "startLine": 97, "endLine": 136 },
+    "type": "concept",
+    "title": "The 2^d-point Danzer–Grünbaum construction",
+    "content": "cubeVertices d is the image of the boolean cube Fin d → Bool under f ↦ (i ↦ if f i then 1 else 0), giving all 2^d hypercube vertices. cubeVertices_injective (the boolean map is injective) yields cubeVertices_card = 2^d, and mem_cubeVertices_isCubeVertex confirms membership implies the {0,1}-coordinate property. The headline exists_cube_no_obtuse packages these: for every d there is a 2^d-point set in ℝ^d with no obtuse angle — so 2^d points never force an angle above π/2.",
+    "mathContext": "$|\\mathrm{cubeVertices}(d)| = 2^d$ and $\\forall a,b,c \\in \\mathrm{cubeVertices}(d),\\ \\angle abc \\le \\pi/2$.",
+    "significance": "key",
+    "relatedConcepts": ["hypercube vertices", "exponential construction", "lower bound", "injective image cardinality"],
+    "prerequisites": ["Finset.image / card_image_of_injective", "WithLp.toLp"]
+  },
+  {
+    "id": "erdos504-ann-sharpness",
+    "proofId": "erdos-504-oq-01",
+    "range": { "startLine": 138, "endLine": 173 },
+    "type": "insight",
+    "title": "Sharpness: the bound π/2 is attained",
+    "content": "cube_angle_pi_div_two_attained shows the π/2 bound is exact, not merely an upper estimate. In dimension d ≥ 2 the origin together with two distinct unit vertices eᵢ, eⱼ realizes an angle of exactly π/2: the inner product ⟪eᵢ−0, eⱼ−0⟫ = ⟪eᵢ, eⱼ⟫ = 0 (orthogonal unit vectors), and inner_eq_zero_iff_angle_eq_pi_div_two converts vanishing inner product to a right angle. Hence no smaller universal bound than π/2 holds — the construction genuinely realizes right angles.",
+    "mathContext": "For $d\\ge 2$: $\\angle(e_0, 0, e_1) = \\pi/2$ since $\\langle e_0, e_1\\rangle = 0$ (distinct standard unit vectors).",
+    "significance": "key",
+    "relatedConcepts": ["orthogonality", "tightness", "unit vertices", "right angle characterization"],
+    "prerequisites": ["inner_eq_zero_iff_angle_eq_pi_div_two", "standard basis vectors"]
+  }
+]

--- a/src/data/proofs/erdos-504-oq-01/meta.json
+++ b/src/data/proofs/erdos-504-oq-01/meta.json
@@ -111,7 +111,8 @@
       "The geometric statement 'no obtuse angle' is exactly the algebraic statement '⟪a−b, c−b⟫ ≥ 0', captured once and for all by the dimension-free criterion angle_le_pi_div_two_of_inner_nonneg.",
       "The cube works for a one-line reason: a coordinate of b is 0 or 1, and in either case the corresponding coordinates of a−b and c−b have the same sign, so every coordinate contributes a non-negative product.",
       "The construction is exponentially large in the dimension (2^d points), the sharp Danzer–Grünbaum lower bound; there is no fixed absolute bound on non-obtuse sets across all dimensions.",
-      "Sharpness is exact, not asymptotic: in any dimension d ≥ 2 a right angle of measure exactly π/2 is realized at a face corner, so π/2 cannot be replaced by any smaller universal bound."
+      "Sharpness is exact, not asymptotic: in any dimension d ≥ 2 a right angle of measure exactly π/2 is realized at a face corner, so π/2 cannot be replaced by any smaller universal bound.",
+      "The proof cleanly separates the one analytic ingredient from the combinatorics: angle_le_pi_div_two_of_inner_nonneg is a dimension-free, reusable lemma (nonnegative inner product ⟹ non-obtuse), and all dimension-specific content collapses to the coordinatewise sign fact (cᵢ−bᵢ)(aᵢ−bᵢ) ≥ 0 for {0,1}-coordinates. This factoring is why the formalization is short and why only the lower-bound half is in reach — the matching upper bound (2^d+1 points force obtuseness) needs a genuinely global argument with no such coordinatewise reduction."
     ]
   },
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `erdos-504-oq-01` (quality 43 → ~100, 0 prior passes).

## Changes
- **Added `annotations.json`** (was missing) with **5 annotations**, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, covering all five sections: the higher-dimensional #504 framing and non-obtuse threshold, the dimension-free criterion (nonneg inner product ⟹ angle ≤ π/2), the coordinatewise hypercube nonnegativity argument, the 2^d-point Danzer–Grünbaum construction, and the sharpness result (π/2 attained at orthogonal unit vertices).
- **Deepened `overview.keyInsights`**: added a 5th insight on the clean separation of the single analytic ingredient from the combinatorics, and why only the lower-bound half is reachable.

## Accuracy / axiom integrity
Annotations written against the actual Lean source (line ranges verified). File has 0 sorries, 0 axioms; `status: verified` / `badge: verified` left unchanged as accurate.

`pnpm build` passes; only the target entry's files are staged.