### PR TITLE
audit(angle-trisection-...-oq-05): Automorphism Bound entry kernel-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17845,6 +17845,12 @@
       "lastAudited": "2026-06-24T03:21:59Z",
       "result": "clean",
       "issues": []
+    },
+    "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T03:29:50Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05` — "The Automorphism Bound: |Aut_F(K)| ≤ [K:F]_s"
**File**: `proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05.lean`

### Result: clean

Kernel-verified with Lean/Mathlib **v4.26.0**. `#print axioms` on all four substantive theorems —
`card_algEquiv_le_finSepDegree`, `card_algEquiv_le_finrank`,
`subsingleton_algEquiv_of_isPurelyInseparable`, `card_algEquiv_eq_one_of_isPurelyInseparable` —
reports only the foundational triple `[propext, Classical.choice, Quot.sound]`. No `sorryAx`, no `Lean.ofReduceBool`.

### Checks

| Claim | meta.json | Verified |
|-------|-----------|----------|
| status | `verified` | ✅ 0 sorries, 0 axioms (kernel-confirmed) |
| badge | `original` | ✅ honest — the `|Aut|≤[K:F]_s` lemma is not packaged by Mathlib v4.26; the `toEmb` injection is self-built infrastructure |
| sorries | 0 | ✅ (the lone `sorry` token is in the docstring prose) |
| axiomCount | 0 | ✅ no `axiom` decls, no structure-encoded assumptions, no `native_decide` |
| theoremCount | 6 | ✅ |
| definitionCount | 1 | ✅ `toEmb` |
| lineCount | 105 | ✅ |
| build graph | — | ✅ registered in `Proofs.lean` |

No delegation opacity: the description leads with "which Mathlib v4.26 does not package", and `mathlibDependencies` / `originalContributions` are properly scoped to what is independently proved.

---
Discovered during gallery integrity audit. Tracker-only change (records the clean result).