### PR TITLE
research(fatou-lemma-oq-01-oq-02): escaping mass has no integrable majorant — why DCT cannot close Fatou's strict gap [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2960,6 +2960,7 @@ import Proofs.FairGamesTheoremOQ03
 import Proofs.FairGamesTheoremOQ03Aristotle
 import Proofs.FatouLemma
 import Proofs.FatouLemmaOQ01OQ01
+import Proofs.FatouLemmaOQ01OQ02
 import Proofs.FatouLemmaOQ01OQ02OQ01
 import Proofs.FermatDefectOne
 import Proofs.FermatDefectOneAristotle

--- a/proofs/Proofs/FatouLemmaOQ01OQ02.lean
+++ b/proofs/Proofs/FatouLemmaOQ01OQ02.lean
@@ -1,0 +1,161 @@
+import Mathlib
+import Proofs.FatouLemma
+
+/-
+# Fatou OQ-01-OQ-02: why dominated convergence cannot close Fatou's strict gap
+
+**Open Question (parent `FatouLemma`, openQuestions[1]).** The parent entry
+proves Fatou's lemma `∫⁻ liminfₙ fₙ ≤ liminfₙ ∫⁻ fₙ` and exhibits the
+escaping-mass sequence `escaping n = 𝟙_[n,n+1)` as a witness that the inequality
+is *strict*: `∫⁻ liminfₙ escaping n = 0 < 1 = liminfₙ ∫⁻ escaping n`. The open
+question asks to connect this to the Fatou ⇒ dominated-convergence route and to
+explain, **quantitatively**, why the dominated convergence theorem (DCT) does not
+rescue the escaping-mass gap.
+
+## The Fatou ⇒ DCT route
+
+The dominated convergence theorem is the partner of Fatou's lemma: it is exactly
+Fatou's inequality bracketed on both sides. Mathlib records this as
+`MeasureTheory.tendsto_lintegral_of_dominated_convergence`, whose proof *is* the
+two-sided Fatou sandwich — `lintegral_liminf_le` gives `∫⁻ F ≤ liminfₙ ∫⁻ fₙ`,
+the reverse Fatou `limsup_lintegral_le` gives `limsupₙ ∫⁻ fₙ ≤ ∫⁻ F`, and
+`tendsto_of_le_liminf_of_limsup_le` closes the squeeze. The decisive hypothesis
+of that theorem is the existence of an **integrable majorant** `g` with
+`fₙ ≤ g` and `∫⁻ g < ∞`: it is what powers the reverse Fatou step.
+
+## What is new here
+
+This file makes precise *why that hypothesis is unavoidable* on the
+escaping-mass example — formalizing the claim asserted only informally in the
+parent entry. We prove:
+
+* `escaping_no_integrable_majorant` — **every** `g` dominating all the bumps
+  (`escaping n ≤ g` for all `n`) has `∫⁻ g = ∞`. The pointwise supremum of the
+  bumps is the indicator of `[0, ∞)`, of infinite Lebesgue mass, so no integrable
+  majorant exists.
+* `escaping_not_dominated` — consequently the domination hypothesis of DCT can
+  **never** be met for this sequence.
+* `escaping_dct_failure` — the package: `escaping n → 0` pointwise, yet
+  `∫⁻ escaping n = 1 ↛ 0 = ∫⁻ 0`, and this does **not** contradict DCT precisely
+  because the sequence admits no integrable majorant. The escaping mass is the
+  sharp boundary case isolating the necessity of DCT's hypothesis.
+
+## Method
+
+If `escaping n ≤ g` for all `n` then for `x ≥ 0` the single bump
+`escaping ⌊x⌋₊` equals `1` at `x` (since `x ∈ [⌊x⌋₊, ⌊x⌋₊ + 1)`), giving
+`(Set.Ici 0).indicator 1 ≤ g`; integrating yields
+`∫⁻ g ≥ volume (Set.Ici 0) = ∞`.
+
+## References
+
+* Mathlib: `Mathlib/MeasureTheory/Integral/Lebesgue/DominatedConvergence.lean`
+  (`tendsto_lintegral_of_dominated_convergence`, `limsup_lintegral_le`).
+* Parent `Proofs/FatouLemma.lean` (`FatouLemma.escaping`).
+* Folland, *Real Analysis*, Thm 2.18 ff. (Fatou ⇒ DCT and the escaping-mass example).
+-/
+
+open MeasureTheory Filter Set Topology
+open scoped ENNReal Topology
+
+namespace FatouLemmaOQ01OQ02
+
+open FatouLemma
+
+/-! ## The escaping-mass sequence admits no integrable majorant -/
+
+/-- If `g` dominates every escaping bump, then `g` dominates the indicator of
+`[0, ∞)`. Indeed, for `x ≥ 0` the single bump `escaping ⌊x⌋₊` equals `1` at `x`
+(since `x ∈ [⌊x⌋₊, ⌊x⌋₊ + 1)`), and `escaping ⌊x⌋₊ ≤ g`; for `x < 0` the
+indicator is `0`. This is the pointwise supremum `⨆ₙ escaping n = 𝟙_[0,∞)` in the
+form needed below. -/
+theorem ici_indicator_le_of_dominates {g : ℝ → ℝ≥0∞} (hdom : ∀ n, escaping n ≤ g) :
+    (Set.Ici (0 : ℝ)).indicator 1 ≤ g := by
+  intro x
+  rcases le_or_gt 0 x with hx | hx
+  · -- `x ≥ 0`: the floor bump is `1` at `x`.
+    have hmem : x ∈ Set.Ico ((⌊x⌋₊ : ℝ)) ((⌊x⌋₊ : ℝ) + 1) :=
+      ⟨Nat.floor_le hx, Nat.lt_floor_add_one x⟩
+    have hbump : escaping ⌊x⌋₊ x = 1 := by
+      unfold escaping
+      rw [Set.indicator_of_mem hmem]
+      rfl
+    have hxi : x ∈ Set.Ici (0 : ℝ) := hx
+    rw [Set.indicator_of_mem hxi]
+    calc (1 : ℝ → ℝ≥0∞) x = escaping ⌊x⌋₊ x := hbump.symm
+      _ ≤ g x := hdom _ x
+  · -- `x < 0`: indicator is `0`.
+    have hxni : x ∉ Set.Ici (0 : ℝ) := by simp only [Set.mem_Ici, not_le]; linarith
+    rw [Set.indicator_of_notMem hxni]
+    exact zero_le _
+
+/-- **The escaping-mass sequence has no integrable majorant.** Every `g` with
+`escaping n ≤ g` for all `n` has infinite Lebesgue integral, because it dominates
+the indicator of `[0, ∞)`, whose integral is `volume (Set.Ici 0) = ∞`. This is
+the precise reason the dominated convergence theorem cannot apply to the
+escaping bumps. -/
+theorem escaping_no_integrable_majorant {g : ℝ → ℝ≥0∞} (hdom : ∀ n, escaping n ≤ g) :
+    ∫⁻ x, g x ∂(volume : Measure ℝ) = ∞ := by
+  have hle := ici_indicator_le_of_dominates hdom
+  have hmono : ∫⁻ x, (Set.Ici (0 : ℝ)).indicator (1 : ℝ → ℝ≥0∞) x ∂(volume : Measure ℝ)
+      ≤ ∫⁻ x, g x ∂(volume : Measure ℝ) := lintegral_mono hle
+  rw [lintegral_indicator_one measurableSet_Ici, Real.volume_Ici] at hmono
+  exact top_le_iff.mp hmono
+
+/-- **The domination hypothesis of DCT fails for escaping mass.** There is no
+function of finite integral dominating every bump, so the dominated convergence
+theorem simply does not apply to `escaping`. -/
+theorem escaping_not_dominated :
+    ¬ ∃ g : ℝ → ℝ≥0∞, (∫⁻ x, g x ∂(volume : Measure ℝ) ≠ ∞) ∧ (∀ n, escaping n ≤ g) := by
+  rintro ⟨g, hfin, hdom⟩
+  exact hfin (escaping_no_integrable_majorant hdom)
+
+/-! ## The escaping mass: pointwise limit `0`, integrals constant `1` -/
+
+/-- At every point `x`, the sequence `n ↦ escaping n x` converges to `0`: once
+`n ≥ ⌊x⌋₊ + 1` the bump has marched strictly to the right of `x`. (The parent's
+`escaping_liminf_zero` records only the `liminf`; here we expose the full limit,
+needed to phrase the DCT-failure package.) -/
+theorem escaping_tendsto_zero (x : ℝ) :
+    Tendsto (fun n => escaping n x) atTop (𝓝 0) := by
+  refine tendsto_const_nhds.congr' ?_
+  filter_upwards [eventually_ge_atTop (⌊x⌋₊ + 1)] with n hn
+  have hxn : x < (n : ℝ) := by
+    have h1 : x < (⌊x⌋₊ : ℝ) + 1 := Nat.lt_floor_add_one x
+    have h2 : ((⌊x⌋₊ + 1 : ℕ) : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+    push_cast at h2
+    linarith
+  have hnot : x ∉ Set.Ico (n : ℝ) (n + 1) := by
+    rw [Set.mem_Ico]; push_neg; intro h; linarith
+  show (0 : ℝ≥0∞) = escaping n x
+  unfold escaping
+  rw [Set.indicator_of_notMem hnot]
+
+/-- The escaping-mass integrals are constantly `1`, hence converge to `1` — not
+to `∫⁻ (pointwise limit) = ∫⁻ 0 = 0`. -/
+theorem escaping_lintegral_tendsto_one :
+    Tendsto (fun n => ∫⁻ x, escaping n x ∂(volume : Measure ℝ)) atTop (𝓝 1) := by
+  simp only [escaping_lintegral]
+  exact tendsto_const_nhds
+
+/-! ## The headline: a sharp instance where DCT's hypothesis is necessary -/
+
+/-- **Escaping mass is the sharp boundary case for DCT.** The bumps converge
+pointwise to `0`, yet their integrals converge to `1`, not to the integral
+`0` of the limit:
+```
+  escaping n x → 0   (∀ x),     ∫⁻ escaping n → 1 ≠ 0 = ∫⁻ 0.
+```
+This is **not** a contradiction with the dominated convergence theorem, because
+the escaping sequence has no integrable majorant (`escaping_not_dominated`) — DCT
+never applied. The failure of `∫⁻ escaping n → ∫⁻ (lim)` together with the
+failure of domination shows that DCT's integrable-majorant hypothesis cannot be
+dropped. -/
+theorem escaping_dct_failure :
+    (∀ x, Tendsto (fun n => escaping n x) atTop (𝓝 0)) ∧
+    (Tendsto (fun n => ∫⁻ x, escaping n x ∂(volume : Measure ℝ)) atTop (𝓝 1)) ∧
+    (∫⁻ _x, (0 : ℝ≥0∞) ∂(volume : Measure ℝ) = 0) ∧
+    ¬ ∃ g : ℝ → ℝ≥0∞, (∫⁻ x, g x ∂(volume : Measure ℝ) ≠ ∞) ∧ (∀ n, escaping n ≤ g) :=
+  ⟨escaping_tendsto_zero, escaping_lintegral_tendsto_one, lintegral_zero, escaping_not_dominated⟩
+
+end FatouLemmaOQ01OQ02

--- a/src/data/proofs/fatou-lemma-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "fatou-dct-route",
+    "proofId": "fatou-lemma-oq-01-oq-02",
+    "range": { "startLine": 8, "endLine": 24 },
+    "type": "concept",
+    "title": "Dominated Convergence Is Fatou Bracketed on Both Sides",
+    "content": "The dominated convergence theorem is the partner of Fatou's lemma: Fatou bounds ∫⁻ (lim) ≤ liminf ∫⁻, the reverse Fatou (limsup_lintegral_le) bounds limsup ∫⁻ ≤ ∫⁻ (lim), and the two together force ∫⁻ fₙ → ∫⁻ (lim). Mathlib's tendsto_lintegral_of_dominated_convergence is exactly this sandwich. The integrable-majorant hypothesis (∃ g, fₙ ≤ g, ∫⁻ g < ∞) is what powers the reverse-Fatou step — and is what fails on escaping mass.",
+    "mathContext": "$\\int^- F \\le \\liminf_n \\int^- f_n$ and $\\limsup_n \\int^- f_n \\le \\int^- F$ squeeze $\\int^- f_n \\to \\int^- F$.",
+    "significance": "key",
+    "relatedConcepts": ["dominated convergence theorem", "Fatou's lemma", "reverse Fatou", "integrable majorant"],
+    "prerequisites": ["measure theory", "lower Lebesgue integral", "liminf/limsup"]
+  },
+  {
+    "id": "no-integrable-majorant",
+    "proofId": "fatou-lemma-oq-01-oq-02",
+    "range": { "startLine": 62, "endLine": 105 },
+    "type": "technique",
+    "title": "No Integrable Majorant for the Escaping Bumps",
+    "content": "ici_indicator_le_of_dominates: if escaping n ≤ g for all n, then 𝟙_[0,∞) ≤ g, because for x ≥ 0 the single bump escaping ⌊x⌋₊ already equals 1 at x (x ∈ [⌊x⌋₊, ⌊x⌋₊+1) via Nat.floor_le and Nat.lt_floor_add_one). escaping_no_integrable_majorant then integrates: ∫⁻ g ≥ ∫⁻ 𝟙_[0,∞) = volume (Set.Ici 0) = ∞. The pointwise supremum of the bumps is the indicator of the whole half-line, of infinite mass — so no integrable majorant can exist.",
+    "mathContext": "$(\\forall n,\\ \\mathrm{escaping}\\,n \\le g) \\implies \\mathbf{1}_{[0,\\infty)} \\le g \\implies \\int^- g \\ge \\mathrm{vol}[0,\\infty) = \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["integrable majorant", "Real.volume_Ici", "lintegral_mono", "pointwise supremum"],
+    "prerequisites": ["lower Lebesgue integral", "indicator functions", "Nat.floor"]
+  },
+  {
+    "id": "limit-zero-integrals-one",
+    "proofId": "fatou-lemma-oq-01-oq-02",
+    "range": { "startLine": 117, "endLine": 140 },
+    "type": "technique",
+    "title": "Pointwise Limit 0, Integrals Constantly 1",
+    "content": "escaping_tendsto_zero: at each x the sequence n ↦ escaping n x converges to 0 — once n ≥ ⌊x⌋₊+1 the block [n,n+1) lies strictly to the right of x, so the bump is 0 there. escaping_lintegral_tendsto_one: the integrals are constantly 1 (parent's escaping_lintegral), hence converge to 1. The integrals therefore converge to 1, not to the integral 0 of the pointwise limit — the disagreement DCT would forbid under domination.",
+    "mathContext": "$\\mathrm{escaping}\\,n\\,x \\to 0\\ (\\forall x)$ while $\\int^- \\mathrm{escaping}\\,n \\to 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["pointwise convergence", "Tendsto.congr'", "constant sequence limit"],
+    "prerequisites": ["limits of sequences", "Nat.floor"]
+  },
+  {
+    "id": "dct-failure-package",
+    "proofId": "fatou-lemma-oq-01-oq-02",
+    "range": { "startLine": 142, "endLine": 160 },
+    "type": "concept",
+    "title": "The Sharp Boundary Case: DCT's Hypothesis Is Necessary",
+    "content": "escaping_dct_failure bundles four facts: escaping n x → 0 for every x; ∫⁻ escaping n → 1; ∫⁻ 0 = 0; and no integrable majorant exists. Read together they certify that DCT's integrable-majorant hypothesis cannot be dropped: here ∫⁻ fₙ → 1 ≠ 0 = ∫⁻ (lim), and the only reason this does not contradict DCT is that domination fails. This is the dual of the parent's strict-gap result — Fatou is strict, and DCT cannot rescue equality because its hypothesis is unmet.",
+    "mathContext": "$\\mathrm{escaping}\\,n \\to 0,\\ \\int^- \\mathrm{escaping}\\,n \\to 1 \\ne 0 = \\int^- 0,$ and no integrable majorant.",
+    "significance": "key",
+    "relatedConcepts": ["dominated convergence theorem", "necessity of hypotheses", "escaping mass", "counterexample"],
+    "prerequisites": ["dominated convergence theorem", "Lebesgue integral"]
+  }
+]

--- a/src/data/proofs/fatou-lemma-oq-01-oq-02/meta.json
+++ b/src/data/proofs/fatou-lemma-oq-01-oq-02/meta.json
@@ -1,0 +1,167 @@
+{
+  "id": "fatou-lemma-oq-01-oq-02",
+  "slug": "fatou-lemma-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.FatouLemma"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Filter",
+      "Set",
+      "Topology"
+    ],
+    "namespace": "FatouLemmaOQ01OQ02",
+    "lineCount": 161,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/FatouLemmaOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "Why Dominated Convergence Cannot Close Fatou's Strict Gap",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FatouLemmaOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "measure-theory",
+      "integration",
+      "convergence",
+      "real-analysis",
+      "fatou",
+      "dominated-convergence",
+      "lebesgue-integral",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 161,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "badge": "synthesis",
+    "originalContributions": [
+      "escaping_no_integrable_majorant: the headline — the escaping-mass sequence escaping n = 𝟙_[n,n+1) admits NO integrable majorant. Every g : ℝ → ℝ≥0∞ with escaping n ≤ g for all n has ∫⁻ g = ∞. This formalizes the claim the parent entry asserted only informally, and is the precise quantitative reason the dominated convergence theorem cannot be applied to the escaping bumps. Mathlib records DCT and its integrable-majorant hypothesis but no witness that the hypothesis is genuinely necessary.",
+      "ici_indicator_le_of_dominates: the supporting mechanism — any g dominating all bumps dominates the indicator of [0,∞). For x ≥ 0 the single bump escaping ⌊x⌋₊ already equals 1 at x (as x ∈ [⌊x⌋₊, ⌊x⌋₊+1)), so 𝟙_[0,∞) ≤ g pointwise; this is the pointwise supremum ⨆ₙ escaping n = 𝟙_[0,∞) in usable form. Integrating against volume (Set.Ici 0) = ∞ forces ∫⁻ g = ∞.",
+      "escaping_not_dominated: the domination hypothesis of DCT can never be met for escaping mass — there is no g of finite integral dominating every bump. The clean negative statement that pins the failure on the hypothesis.",
+      "escaping_tendsto_zero: at every point x the bumps converge to 0 (once n ≥ ⌊x⌋₊+1 the interval [n,n+1) lies strictly right of x). The parent recorded only the liminf; the full pointwise limit is exposed here to phrase the DCT-failure package.",
+      "escaping_dct_failure: the package isolating the sharp boundary case — escaping n x → 0 for every x, yet ∫⁻ escaping n → 1 ≠ 0 = ∫⁻ 0, and this is consistent with DCT precisely because no integrable majorant exists. The simultaneous failure of integral-convergence and of domination demonstrates that DCT's integrable-majorant hypothesis cannot be dropped."
+    ],
+    "prerequisites": [
+      "FatouLemma.escaping: the parent's marching-indicator sequence escaping n = 𝟙_[n,n+1) on ℝ (reused, not redefined).",
+      "FatouLemma.escaping_lintegral: each bump carries unit mass ∫⁻ escaping n = 1.",
+      "MeasureTheory.lintegral_indicator_one: ∫⁻ of the indicator of a measurable set equals the measure of the set.",
+      "Real.volume_Ici: the Lebesgue measure of [a, ∞) is ∞.",
+      "Nat.floor_le / Nat.lt_floor_add_one: ⌊x⌋₊ ≤ x < ⌊x⌋₊ + 1 for x ≥ 0, locating the unique bump covering x.",
+      "MeasureTheory.lintegral_mono: monotonicity of the lower Lebesgue integral, turning 𝟙_[0,∞) ≤ g into ∫⁻ 𝟙_[0,∞) ≤ ∫⁻ g."
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "MeasureTheory.tendsto_lintegral_of_dominated_convergence",
+        "description": "Lebesgue's dominated convergence theorem at the ℝ≥0∞ level, whose Mathlib proof IS the two-sided Fatou sandwich (lintegral_liminf_le and limsup_lintegral_le bracketing the limit). Cited as the Fatou ⇒ DCT route; this entry shows its integrable-majorant hypothesis genuinely fails on escaping mass.",
+        "module": "Mathlib.MeasureTheory.Integral.Lebesgue.DominatedConvergence"
+      },
+      {
+        "theorem": "MeasureTheory.lintegral_indicator_one",
+        "description": "∫⁻ a, s.indicator 1 a ∂μ = μ s for measurable s. Used both to evaluate the bump integral (via the parent) and to read ∫⁻ 𝟙_[0,∞) = volume (Set.Ici 0).",
+        "module": "Mathlib.MeasureTheory.Integral.Lebesgue.Basic"
+      },
+      {
+        "theorem": "Real.volume_Ici",
+        "description": "volume (Set.Ici a) = ∞: the half-line has infinite Lebesgue measure. This is what forces ∫⁻ g = ∞ for any majorant g of the escaping bumps.",
+        "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.lintegral_mono",
+        "description": "Monotonicity of the lower Lebesgue integral. Lifts the pointwise bound 𝟙_[0,∞) ≤ g to the integral bound ∞ = ∫⁻ 𝟙_[0,∞) ≤ ∫⁻ g.",
+        "module": "Mathlib.MeasureTheory.Integral.Lebesgue.Basic"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Fatou's lemma, the monotone convergence theorem, and the dominated convergence theorem (DCT) form the three convergence pillars of Lebesgue integration, and they are logically linked: MCT ⇒ Fatou ⇒ DCT. The Fatou ⇒ DCT step is classical — apply Fatou to the nonnegative sequences g + fₙ and g − fₙ built from an integrable majorant g — and it is exactly why DCT carries the integrable-majorant hypothesis. The escaping unit bumps 𝟙_[n,n+1) marching to +∞ are the textbook example (Folland Thm 2.18 ff.) showing Fatou's inequality is strict; the parent entry formalized that strict gap. What the parent left informal is the dual statement on the DCT side: that the very same sequence has no integrable majorant, so DCT never applies — which is why its integrals (all equal to 1) need not converge to the integral (0) of the pointwise limit. This entry formalizes that obstruction.",
+    "problemStatement": "Make explicit why the dominated convergence theorem does not close the strict gap Fatou's lemma exhibits on the escaping-mass sequence escaping n = 𝟙_[n,n+1). Concretely: prove that no function g of finite Lebesgue integral dominates every bump (escaping n ≤ g for all n forces ∫⁻ g = ∞), so DCT's integrable-majorant hypothesis is unsatisfiable here; and package this with the pointwise limit escaping n x → 0 and the constant integrals ∫⁻ escaping n = 1 to display the boundary case where DCT's hypothesis is necessary.",
+    "proofStrategy": "The Fatou ⇒ DCT route is delegated to Mathlib's tendsto_lintegral_of_dominated_convergence, whose proof is the two-sided Fatou sandwich (Fatou for the liminf, reverse Fatou for the limsup), powered by the integrable majorant. The new content is the obstruction. ici_indicator_le_of_dominates: if escaping n ≤ g for all n, then for x ≥ 0 the single bump escaping ⌊x⌋₊ equals 1 at x (because x ∈ [⌊x⌋₊, ⌊x⌋₊+1) via Nat.floor_le and Nat.lt_floor_add_one), so the indicator of [0,∞) is pointwise ≤ g. escaping_no_integrable_majorant: integrating, ∫⁻ g ≥ ∫⁻ 𝟙_[0,∞) = volume (Set.Ici 0) = ∞ (Real.volume_Ici, lintegral_mono, top_le_iff). escaping_not_dominated negates the existence of a finite-integral majorant. escaping_tendsto_zero gives the full pointwise limit (each point is eventually left behind), and escaping_dct_failure assembles limit 0, integrals → 1, ∫⁻ 0 = 0, and no-majorant into one statement.",
+    "keyInsights": [
+      "DCT is Fatou bracketed on both sides, and the bracket is held shut by the integrable majorant: Fatou bounds ∫⁻(lim) ≤ liminf ∫⁻, the reverse Fatou bounds limsup ∫⁻ ≤ ∫⁻(lim), and the majorant is exactly what licenses the reverse inequality. Remove the majorant and the upper bracket — hence the conclusion — can fail.",
+      "The escaping bumps make 'no integrable majorant' precise: the pointwise supremum ⨆ₙ 𝟙_[n,n+1) is 𝟙_[0,∞), which already has infinite mass, so any g above all bumps is non-integrable. The obstruction is not subtle smallness but the full half-line of escaping mass.",
+      "This is the sharp partner of the parent's strict-gap result. The parent showed Fatou's inequality is strict (0 < 1) on escaping mass; this entry shows the failure to recover equality is not a defect of DCT but a failure of its hypothesis — the two together pin down exactly why Fatou is an inequality and what it costs to upgrade it.",
+      "The package escaping_dct_failure is a clean necessity proof: it exhibits a sequence converging pointwise whose integrals do not converge to the integral of the limit, alongside the demonstration that DCT's hypothesis is unmet — a textbook 'the hypothesis cannot be dropped' certificate, formalized.",
+      "Reusing the parent's escaping and escaping_lintegral keeps the entry focused: the only new analytic input is locating, for each x ≥ 0, the one bump that covers it, which is pure floor arithmetic."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Fatou ⇒ DCT and the Escaping-Mass Obstruction",
+      "startLine": 4,
+      "endLine": 58,
+      "summary": "Recalls the Fatou ⇒ DCT route (Mathlib's tendsto_lintegral_of_dominated_convergence is the two-sided Fatou sandwich, held shut by an integrable majorant) and states the new content: the escaping-mass sequence has no integrable majorant, so DCT cannot apply, which is why its integrals (constantly 1) do not converge to the integral 0 of the pointwise limit.",
+      "mathContext": "DCT $=$ Fatou bracketed on both sides; the integrable majorant powers the reverse Fatou step."
+    },
+    {
+      "id": "no-majorant",
+      "title": "No Integrable Majorant",
+      "startLine": 60,
+      "endLine": 115,
+      "summary": "ici_indicator_le_of_dominates: a majorant of all bumps dominates 𝟙_[0,∞), since for x ≥ 0 the bump escaping ⌊x⌋₊ equals 1 at x. escaping_no_integrable_majorant: integrating gives ∫⁻ g ≥ volume (Set.Ici 0) = ∞. escaping_not_dominated: hence no finite-integral majorant exists.",
+      "mathContext": "$\\forall n,\\ \\mathrm{escaping}\\,n \\le g \\implies \\mathbf{1}_{[0,\\infty)} \\le g \\implies \\int^- g = \\infty$."
+    },
+    {
+      "id": "limit-and-integrals",
+      "title": "Pointwise Limit 0, Integrals Constant 1",
+      "startLine": 117,
+      "endLine": 140,
+      "summary": "escaping_tendsto_zero: at each x the bumps converge to 0 (once n ≥ ⌊x⌋₊+1 the interval is strictly right of x). escaping_lintegral_tendsto_one: the integrals are constantly 1, so they converge to 1, not to ∫⁻ of the limit.",
+      "mathContext": "$\\mathrm{escaping}\\,n\\,x \\to 0$ for every $x$, while $\\int^- \\mathrm{escaping}\\,n \\to 1$."
+    },
+    {
+      "id": "dct-failure",
+      "title": "The Headline: DCT's Hypothesis Is Necessary",
+      "startLine": 142,
+      "endLine": 160,
+      "summary": "escaping_dct_failure bundles the four facts — pointwise limit 0, integrals → 1, ∫⁻ 0 = 0, and no integrable majorant — into the certificate that DCT's integrable-majorant hypothesis cannot be dropped: the conclusion ∫⁻ fₙ → ∫⁻ (lim) fails here exactly because the hypothesis is unmet.",
+      "mathContext": "$\\mathrm{escaping}\\,n \\to 0$, $\\int^- \\mathrm{escaping}\\,n \\to 1 \\ne 0 = \\int^- 0$, no integrable majorant."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "fatou-lemma-oq-01-oq-02-oq-01",
+      "question": "Formalize the elementary real-valued Fatou ⇒ DCT derivation directly via the g + fₙ and g − fₙ trick (rather than invoking Mathlib's packaged dominated convergence theorem): prove that for real integrable fₙ with |fₙ| ≤ g (g integrable) and fₙ → F a.e., ∫ fₙ → ∫ F, by applying lintegral Fatou to the two nonnegative sequences and converting through ENNReal.ofReal.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fatou-lemma-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry proves Fatou's lemma and shows its inequality is strict on the escaping-mass sequence, asserting informally that the sequence has no integrable majorant. This entry formalizes that assertion (escaping_no_integrable_majorant) and uses it to explain, on the DCT side, why the strict gap cannot be closed — the dominated convergence theorem never applies to escaping mass."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: MeasureTheory.Integral.Lebesgue.DominatedConvergence",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of tendsto_lintegral_of_dominated_convergence and limsup_lintegral_le — the dominated convergence theorem realized as the two-sided Fatou sandwich."
+    },
+    {
+      "title": "Real Analysis: Modern Techniques and Their Applications",
+      "author": "Folland",
+      "year": "1999",
+      "venue": "Wiley",
+      "description": "Standard reference for the Fatou ⇒ DCT route (apply Fatou to g ± fₙ), the integrable-majorant hypothesis, and the escaping-mass example (Thm 2.18 ff.)."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The dominated convergence theorem is Fatou's lemma bracketed on both sides, with the integrable-majorant hypothesis powering the reverse-Fatou (limsup) bound; Mathlib's tendsto_lintegral_of_dominated_convergence packages exactly this sandwich. This entry formalizes why that hypothesis is unavoidable on the escaping-mass sequence escaping n = 𝟙_[n,n+1): every majorant g of all the bumps dominates the indicator of [0,∞), so ∫⁻ g = ∞ (escaping_no_integrable_majorant) and no finite-integral majorant exists (escaping_not_dominated). Packaged with the pointwise limit escaping n x → 0 and the constant integrals ∫⁻ escaping n = 1, escaping_dct_failure exhibits the sharp boundary case: integrals converge to 1, not to the integral 0 of the limit, consistently with DCT only because its hypothesis is unmet. 161 lines, 6 theorems, 0 axioms, 0 sorries.",
+    "implications": "Together with the parent's strict-gap result, this completes the two-sided picture of the escaping-mass example: Fatou's inequality is strict (parent) and the dominated convergence theorem cannot rescue equality because its integrable-majorant hypothesis genuinely fails (this entry). It is a formalized certificate that DCT's hypothesis cannot be dropped, and motivates the open question of reproducing the elementary real-valued g ± fₙ derivation in full.",
+    "openQuestions": [
+      "Formalize the elementary real-valued g ± fₙ Fatou ⇒ DCT derivation directly, rather than invoking Mathlib's packaged dominated convergence theorem."
+    ]
+  }
+}

--- a/src/data/research/problems/fatou-lemma-oq-01-oq-02.json
+++ b/src/data/research/problems/fatou-lemma-oq-01-oq-02.json
@@ -1,0 +1,91 @@
+{
+  "slug": "fatou-lemma-oq-01-oq-02",
+  "title": "Why dominated convergence cannot close Fatou's strict gap (no integrable majorant for escaping mass)",
+  "status": "active",
+  "phase": "ACT",
+  "tier": "C",
+  "tags": [
+    "analysis",
+    "measure-theory",
+    "dominated-convergence",
+    "fatou"
+  ],
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{The escaping-mass sequence } \\mathrm{escaping}\\,n = \\mathbf{1}_{[n,n+1)} \\text{ has no integrable majorant: } (\\forall n,\\ \\mathrm{escaping}\\,n \\le g) \\implies \\int^- g = \\infty, \\text{ so DCT's domination hypothesis fails.}",
+    "plain": "The parent entry `fatou-lemma-oq-01` (verified) proves Fatou's lemma and shows its inequality is strict on the escaping-mass sequence escaping n = 𝟙_[n,n+1), asserting INFORMALLY that the sequence has no integrable majorant. This problem formalizes that assertion and uses it to explain, on the dominated-convergence side, why the strict gap cannot be closed. The Fatou ⇒ DCT route is Mathlib's tendsto_lintegral_of_dominated_convergence (the two-sided Fatou sandwich, powered by an integrable majorant); we prove that every g dominating all the bumps has ∫⁻ g = ∞ (because ⨆ₙ escaping n = 𝟙_[0,∞), of infinite mass), so DCT never applies — which is exactly why ∫⁻ escaping n = 1 ↛ 0 = ∫⁻ (pointwise limit).",
+    "whyMatters": []
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-23T20:30:00-07:00",
+    "iteration": 1,
+    "focus": "Formalize the no-integrable-majorant obstruction and package the DCT-failure certificate.",
+    "blockers": [],
+    "nextAction": "Open follow-up OQ: the elementary real-valued g ± fₙ Fatou ⇒ DCT derivation.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "started": "2026-06-23T20:30:00-07:00",
+  "lastUpdate": "2026-06-23T20:30:00-07:00",
+  "knowledge": {
+    "progressSummary": "COMPLETE: shipped verified/synthesis escaping-mass DCT obstruction — escaping_no_integrable_majorant + escaping_dct_failure, 6 thm/0 ax/0 sorries/161L.",
+    "builtItems": [
+      "FatouLemmaOQ01OQ02.lean: escaping_no_integrable_majorant (∀ majorant g, ∫⁻ g = ∞), ici_indicator_le_of_dominates (𝟙_[0,∞) ≤ g), escaping_not_dominated, escaping_tendsto_zero, escaping_lintegral_tendsto_one, escaping_dct_failure (DCT-necessity package). 6 thm/0 ax/0 s/161L."
+    ],
+    "insights": [
+      "The pointwise supremum ⨆ₙ 𝟙_[n,n+1) is 𝟙_[0,∞), of infinite Lebesgue mass, so any majorant of all escaping bumps is non-integrable — formalized via the single floor bump escaping ⌊x⌋₊ covering each x ≥ 0 (Nat.floor_le, Nat.lt_floor_add_one).",
+      "DCT is Fatou bracketed on both sides; Mathlib's tendsto_lintegral_of_dominated_convergence IS that sandwich. The integrable-majorant hypothesis powers the reverse-Fatou (limsup) bound, and the escaping-mass example shows it is genuinely necessary: integrals → 1 ≠ 0 = ∫⁻(lim) precisely because no integrable majorant exists.",
+      "Reusing the parent's escaping and escaping_lintegral keeps the only new analytic input to pure floor arithmetic (locating the one bump covering each point)."
+    ],
+    "mathlibGaps": [
+      "Mathlib records DCT and its integrable-majorant hypothesis but no witness that the hypothesis is necessary; the escaping-mass no-majorant obstruction is not in Mathlib.",
+      "Mathlib proves DCT via the L¹/Bochner machinery and via the lintegral Fatou sandwich, but does not record the elementary real-valued g ± fₙ derivation explicitly."
+    ],
+    "nextSteps": [
+      "Follow-up OQ fatou-lemma-oq-01-oq-02-oq-01: formalize the real-valued g ± fₙ Fatou ⇒ DCT derivation directly (apply lintegral Fatou to g + fₙ and g − fₙ, convert through ENNReal.ofReal), rather than invoking Mathlib's packaged DCT."
+    ],
+    "markdown": "# Knowledge Base: fatou-lemma-oq-01-oq-02\n\n## Problem Understanding\n\nFormalize why dominated convergence cannot close the strict Fatou gap on the escaping-mass sequence: the sequence has no integrable majorant, so DCT's hypothesis is unsatisfiable.\n\n## Insights\n\n- ⨆ₙ 𝟙_[n,n+1) = 𝟙_[0,∞) has infinite mass ⇒ no integrable majorant.\n- DCT = two-sided Fatou sandwich; integrable majorant powers the reverse-Fatou step.\n\n## Result\n\nShipped verified/synthesis: escaping_no_integrable_majorant, escaping_dct_failure (6 thm, 0 ax, 0 sorries, 161 lines).\n"
+  },
+  "knownResults": {
+    "proven": [
+      "escaping_no_integrable_majorant: every g with escaping n ≤ g for all n has ∫⁻ g = ∞.",
+      "escaping_dct_failure: escaping n → 0 pointwise, ∫⁻ escaping n → 1 ≠ 0 = ∫⁻ 0, and no integrable majorant — DCT's hypothesis is necessary."
+    ],
+    "open": [
+      "Elementary real-valued g ± fₙ Fatou ⇒ DCT derivation (follow-up OQ)."
+    ],
+    "goal": "Explain quantitatively why DCT does not rescue Fatou's strict gap on escaping mass."
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/FatouLemma.lean",
+      "filename": "FatouLemma.lean",
+      "lineCount": 142,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FatouLemma.lean"
+    },
+    {
+      "path": "Proofs/FatouLemmaOQ01OQ02.lean",
+      "filename": "FatouLemmaOQ01OQ02.lean",
+      "lineCount": 161,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FatouLemmaOQ01OQ02.lean"
+    }
+  ],
+  "relatedProofs": [
+    "fatou-lemma-oq-01"
+  ],
+  "references": []
+}


### PR DESCRIPTION
## Summary

Answers the parent entry's open question `fatou-lemma-oq-01` OQ[1] on the **dominated-convergence side**: it formalizes *why* DCT cannot close the strict Fatou gap on the escaping-mass sequence `escaping n = 𝟙_[n,n+1)`.

The parent (`fatou-lemma-oq-01`, verified) proves Fatou's lemma and shows its inequality is strict on escaping mass, **asserting only informally** that the sequence has no integrable majorant. This entry proves that assertion and packages the consequence.

## Results (`Proofs/FatouLemmaOQ01OQ02.lean`)

- **`escaping_no_integrable_majorant`** — every `g` with `escaping n ≤ g` for all `n` has `∫⁻ g = ∞`. (Pointwise `⨆ₙ escaping n = 𝟙_[0,∞)`, of infinite Lebesgue mass.)
- `ici_indicator_le_of_dominates` — the mechanism: for `x ≥ 0` the single bump `escaping ⌊x⌋₊` equals `1` at `x`, so `𝟙_[0,∞) ≤ g`.
- `escaping_not_dominated` — no finite-integral majorant exists ⇒ DCT's hypothesis is unsatisfiable here.
- `escaping_tendsto_zero` / `escaping_lintegral_tendsto_one` — pointwise limit `0`, integrals constantly `1`.
- **`escaping_dct_failure`** — the certificate: `escaping n → 0` pointwise, `∫⁻ escaping n → 1 ≠ 0 = ∫⁻ 0`, and no integrable majorant — consistent with DCT only because domination fails, so DCT's integrable-majorant hypothesis cannot be dropped.

The Fatou ⇒ DCT route itself is Mathlib's `tendsto_lintegral_of_dominated_convergence` (the two-sided Fatou sandwich); this entry supplies the obstruction Mathlib lacks. Reuses `FatouLemma.escaping`.

## Verification

- **6 theorems, 0 definitions, 0 axioms, 0 sorries, 161 lines.** Status `verified`, badge `synthesis`.
- Kernel-verified via `lake env lean` (v4.26.0): `#print axioms` on every result lists only the standard triple `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`, no `native_decide`.
- Registered in `proofs/Proofs.lean`.

## Follow-up open question

`fatou-lemma-oq-01-oq-02-oq-01`: formalize the elementary real-valued `g ± fₙ` Fatou ⇒ DCT derivation directly (apply lintegral Fatou to `g + fₙ` and `g − fₙ`, convert via `ENNReal.ofReal`), rather than invoking Mathlib's packaged DCT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)