### PR TITLE
research(gamma-reflection-formula-oq-01-oq-02): 1/Γ as entire function with zero set the non-positive integers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -17,6 +17,7 @@ import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4Aristotle
 import Proofs.AbelRuffiniGaloisExtensionsOQ07
 import Proofs.AbelRuffiniGaloisExtensionsOQ11
+import Proofs.AbelRuffiniObstructionOQ06
 import Proofs.AbelRuffiniOQ03
 import Proofs.AbelRuffiniOQ04
 import Proofs.AbelRuffiniOQ04OQ01
@@ -44,7 +45,6 @@ import Proofs.AbelRuffiniOQ07Order6
 import Proofs.AbelRuffiniOQ09
 import Proofs.AbelRuffiniOQ10
 import Proofs.AbelRuffiniOQ11
-import Proofs.AbelRuffiniObstructionOQ06
 import Proofs.AbundantDeficientDvdOQ04
 import Proofs.AbundantMultiplesOQ01
 import Proofs.AbundantNumberOQ01
@@ -1510,8 +1510,8 @@ import Proofs.Erdos1142Problem
 import Proofs.Erdos1143Problem
 import Proofs.Erdos1144Problem
 import Proofs.Erdos1145Problem
-import Proofs.Erdos1146Problem
 import Proofs.Erdos1146OQ04
+import Proofs.Erdos1146Problem
 import Proofs.Erdos1147Problem
 import Proofs.Erdos1148Problem
 import Proofs.Erdos1149Aristotle
@@ -3106,6 +3106,7 @@ import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
 import Proofs.GammaReflectionFormulaOQ01OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ01OQ01
+import Proofs.GammaReflectionFormulaOQ01OQ02
 import Proofs.GammaReflectionFormulaOQ01OQ03
 import Proofs.GammaReflectionFormulaOQ01OQ03OQ01
 import Proofs.GammaReflectionFormulaOQ01OQ03OQ01OQ01
@@ -3242,8 +3243,8 @@ import Proofs.HarmonicDivergenceOQ05
 import Proofs.HarmonicDivergenceOQ05OQ01
 import Proofs.HarmonicDivergenceOQ05OQ02
 import Proofs.HermiteFloorIdentity
-import Proofs.HermiteSawtoothIdentity
 import Proofs.HermiteLindemann
+import Proofs.HermiteSawtoothIdentity
 import Proofs.HeronsFormula
 import Proofs.HeronsFormulaOQ01
 import Proofs.HeronsFormulaOQ03

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ02.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ02.lean
@@ -1,0 +1,147 @@
+/-
+# Gamma Reflection OQ-01-OQ-02: `1/Γ` as an entire function with zero set the non-positive integers
+
+**Open Question (parent `GammaReflectionFormulaOQ01`).** The parent entry records Euler's
+reflection formula and the non-vanishing corollary `sin(π s) ≠ 0 ⟹ Γ s ≠ 0`. Reflection
+shows where `Γ` does *not* vanish; the dual object is the **reciprocal Gamma function**
+`1/Γ`, which is the canonical *entire* completion of `Γ`: where `Γ` has its simple poles
+(the non-positive integers), `1/Γ` has its zeros, and nowhere else.
+
+This file packages `1/Γ` as that entire function and pins down its zero set exactly.
+
+## What is new
+
+Mathlib already has the two ingredients as *separate* facts:
+
+* `Complex.differentiable_one_div_Gamma` — `s ↦ (Γ s)⁻¹` is differentiable on all of `ℂ`;
+* `Complex.Gamma_eq_zero_iff` — `Γ s = 0 ↔ s` is a non-positive integer.
+
+Neither Mathlib nor the parent entry combines them into the statement that `1/Γ` is an
+**entire function whose zero set is *exactly* the non-positive integers**, and Mathlib does
+not record the structural consequences derived here:
+
+* the zero set `{z | (Γ z)⁻¹ = 0}` equals `{0, -1, -2, …}` as a set (`zeroSet_invGamma`);
+* that zero set is **countable** (`countable_zeroSet`);
+* `1/Γ` is **not identically zero** (`invGamma_one : (Γ 1)⁻¹ = 1`), hence by the analytic
+  identity theorem **every zero is isolated** (`isolated_zeros`) — i.e. each pole of `Γ` is
+  a genuine, isolated point of the zero locus of `1/Γ`.
+
+## Method
+
+`(Γ z)⁻¹ = 0 ↔ Γ z = 0` (`inv_eq_zero`) reduces the zero-set question to Mathlib's
+`Gamma_eq_zero_iff`. Entirety is `differentiable_one_div_Gamma`, promoted to `AnalyticOnNhd`
+via `Differentiable.analyticAt` (holomorphic ⟹ analytic on `ℂ`). Isolation of zeros uses the
+principle of isolated zeros (`AnalyticAt.eventually_eq_zero_or_eventually_ne_zero`); the
+"identically zero near a point" branch is killed by the identity theorem
+(`eqOn_zero_of_preconnected_of_eventuallyEq_zero` on the preconnected set `univ`) together
+with `(Γ 1)⁻¹ = 1 ≠ 0`.
+
+## References
+
+* Mathlib: `Mathlib/Analysis/SpecialFunctions/Gamma/Beta.lean`,
+  `Mathlib/Analysis/Analytic/IsolatedZeros.lean`,
+  `Mathlib/Analysis/Analytic/Uniqueness.lean`.
+* Whittaker & Watson, *A Course of Modern Analysis*, §12.1 (the function `1/Γ`).
+-/
+import Mathlib
+
+namespace GammaReflectionFormulaOQ01OQ02
+
+open Complex
+open scoped Topology
+
+/-- The non-positive integers `{0, -1, -2, …}` as a subset of `ℂ`. -/
+def nonposInt : Set ℂ := {z : ℂ | ∃ n : ℕ, z = -n}
+
+/-! ## `1/Γ` is entire -/
+
+/-- **`1/Γ` is entire.** The reciprocal Gamma function `s ↦ (Γ s)⁻¹` is differentiable on all
+of `ℂ`, including the non-positive integers where `Γ` itself blows up. (Re-export of Mathlib's
+`differentiable_one_div_Gamma` under a stable name.) -/
+theorem differentiable_invGamma : Differentiable ℂ fun s : ℂ => (Gamma s)⁻¹ :=
+  Complex.differentiable_one_div_Gamma
+
+/-- `1/Γ` is analytic at every point of `ℂ` (holomorphic on `ℂ` ⟹ analytic). -/
+theorem analyticAt_invGamma (z : ℂ) : AnalyticAt ℂ (fun s : ℂ => (Gamma s)⁻¹) z :=
+  differentiable_invGamma.analyticAt z
+
+/-- `1/Γ` is analytic on all of `ℂ`: an entire function. -/
+theorem analyticOnNhd_invGamma :
+    AnalyticOnNhd ℂ (fun s : ℂ => (Gamma s)⁻¹) Set.univ :=
+  fun z _ => analyticAt_invGamma z
+
+/-! ## The zero set is exactly the non-positive integers -/
+
+/-- **Zero criterion:** `(Γ z)⁻¹ = 0` iff `z` is a non-positive integer. The reciprocal
+vanishes precisely at the poles of `Γ`. -/
+theorem invGamma_eq_zero_iff (z : ℂ) :
+    (Gamma z)⁻¹ = 0 ↔ ∃ n : ℕ, z = -n := by
+  rw [inv_eq_zero, Complex.Gamma_eq_zero_iff]
+
+/-- **Non-vanishing criterion:** `(Γ z)⁻¹ ≠ 0` iff `z` avoids every non-positive integer. -/
+theorem invGamma_ne_zero_iff (z : ℂ) :
+    (Gamma z)⁻¹ ≠ 0 ↔ ∀ n : ℕ, z ≠ -n := by
+  simp only [ne_eq, invGamma_eq_zero_iff, not_exists]
+
+/-- **The zero set of `1/Γ` is exactly `{0, -1, -2, …}`.** -/
+theorem zeroSet_invGamma :
+    {z : ℂ | (Gamma z)⁻¹ = 0} = nonposInt := by
+  ext z; exact invGamma_eq_zero_iff z
+
+/-- The non-positive integers are the range of `n ↦ -n`, hence a countable subset of `ℂ`. -/
+theorem nonposInt_eq_range : nonposInt = Set.range (fun n : ℕ => -(n : ℂ)) := by
+  ext z
+  simp only [nonposInt, Set.mem_setOf_eq, Set.mem_range, eq_comm]
+
+/-- **The zero set of `1/Γ` is countable.** -/
+theorem countable_zeroSet : {z : ℂ | (Gamma z)⁻¹ = 0}.Countable := by
+  rw [zeroSet_invGamma, nonposInt_eq_range]
+  exact Set.countable_range _
+
+/-! ## Concrete values and the recurrence -/
+
+/-- `1/Γ` is **not** identically zero: `(Γ 1)⁻¹ = 1`. -/
+theorem invGamma_one : (Gamma (1 : ℂ))⁻¹ = 1 := by
+  rw [Complex.Gamma_one, inv_one]
+
+/-- A sample zero: `(Γ 0)⁻¹ = 0` (the pole of `Γ` at the origin). -/
+theorem invGamma_zero : (Gamma (0 : ℂ))⁻¹ = 0 := by
+  rw [Complex.Gamma_zero, inv_zero]
+
+/-- A sample zero away from the origin: `(Γ (-3))⁻¹ = 0`. -/
+theorem invGamma_neg_three : (Gamma (-3 : ℂ))⁻¹ = 0 := by
+  rw [invGamma_eq_zero_iff]
+  exact ⟨3, by norm_num⟩
+
+/-- **The functional equation of `1/Γ`** (valid everywhere, including at `s = 0`):
+`(Γ s)⁻¹ = s · (Γ (s+1))⁻¹`. Reading off the factor `s` re-derives the zero at `s = 0`, and
+iterating produces the full ladder of zeros at `0, -1, -2, …`. -/
+theorem invGamma_recurrence (s : ℂ) :
+    (Gamma s)⁻¹ = s * (Gamma (s + 1))⁻¹ :=
+  Complex.one_div_Gamma_eq_self_mul_one_div_Gamma_add_one s
+
+/-! ## Every zero is isolated -/
+
+/-- **The zeros of `1/Γ` are isolated.** At any zero `z` of `1/Γ`, the function is nonzero
+throughout some punctured neighborhood of `z`. (So the poles of `Γ` are isolated points of the
+zero locus of `1/Γ`, none of them an accumulation point of zeros.)
+
+The proof applies the principle of isolated zeros to the entire function `1/Γ`; the alternative
+"`1/Γ ≡ 0` near `z`" is impossible because, by the identity theorem on the preconnected set `ℂ`,
+it would force `1/Γ ≡ 0` everywhere, contradicting `(Γ 1)⁻¹ = 1`. -/
+theorem isolated_zeros {z : ℂ} (_hz : (Gamma z)⁻¹ = 0) :
+    ∀ᶠ w in 𝓝[≠] z, (Gamma w)⁻¹ ≠ 0 := by
+  rcases (analyticAt_invGamma z).eventually_eq_zero_or_eventually_ne_zero with h | h
+  · -- `1/Γ` identically zero near `z` ⟹ identically zero on `ℂ` ⟹ contradicts `(Γ 1)⁻¹ = 1`
+    exfalso
+    have h' : (fun s : ℂ => (Gamma s)⁻¹) =ᶠ[𝓝 z] 0 := by
+      filter_upwards [h] with w hw using hw
+    have hEq : Set.EqOn (fun s : ℂ => (Gamma s)⁻¹) 0 Set.univ :=
+      AnalyticOnNhd.eqOn_zero_of_preconnected_of_eventuallyEq_zero
+        analyticOnNhd_invGamma isPreconnected_univ (Set.mem_univ z) h'
+    have : (Gamma (1 : ℂ))⁻¹ = 0 := hEq (Set.mem_univ 1)
+    rw [invGamma_one] at this
+    exact one_ne_zero this
+  · exact h
+
+end GammaReflectionFormulaOQ01OQ02

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-gamma-refl-oq0102-docstring",
+    "proofId": "gamma-reflection-formula-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 51 },
+    "type": "context",
+    "title": "1/Γ: the Entire Dual of the Gamma Function",
+    "content": "The docstring frames the reciprocal Gamma function 1/Γ as the canonical ENTIRE completion of the meromorphic Γ. Γ has simple poles at the non-positive integers 0, -1, -2, …; the reciprocal 1/Γ has no poles at all — where Γ blows up, 1/Γ simply vanishes — and its zero set is EXACTLY those non-positive integers. Mathlib already proves 1/Γ differentiable on all of ℂ (differentiable_one_div_Gamma) and characterizes the zeros of Γ (Gamma_eq_zero_iff) as separate facts, but does not assemble them into the entire-function-with-prescribed-zero-set picture, nor record that the zero set is countable and every zero isolated. This file supplies that packaging — the analytic dual of the parent's reflection-based non-vanishing.",
+    "mathContext": "Weierstrass: $1/\\Gamma(s) = s\\,e^{\\gamma s}\\prod_{n\\ge1}(1 + s/n)e^{-s/n}$, an entire function with zeros exactly at $\\{0,-1,-2,\\dots\\}$.",
+    "significance": "context",
+    "relatedConcepts": ["reciprocal Gamma function", "entire function", "Weierstrass product", "poles vs zeros", "meromorphic continuation"],
+    "prerequisites": ["the Gamma function and its poles", "entire / holomorphic functions", "complex analysis basics"]
+  },
+  {
+    "id": "ann-gamma-refl-oq0102-entire",
+    "proofId": "gamma-reflection-formula-oq-01-oq-02",
+    "range": { "startLine": 60, "endLine": 76 },
+    "type": "theorem",
+    "title": "1/Γ is Entire",
+    "content": "differentiable_invGamma re-exports Mathlib's differentiable_one_div_Gamma: s ↦ (Γ s)⁻¹ is differentiable on all of ℂ, INCLUDING the non-positive integers where Γ itself has no finite value. analyticAt_invGamma and analyticOnNhd_invGamma then promote this to analyticity at every point and on Set.univ, using Differentiable.analyticAt (a function holomorphic on ℂ is analytic everywhere — the Cauchy-integral fact). Together these say 1/Γ is a genuine entire function, the non-degeneracy backbone for the zero-set and isolation results below.",
+    "mathContext": "Holomorphic on $\\mathbb C \\Rightarrow$ analytic on $\\mathbb C$. The reciprocal removes the poles of $\\Gamma$ rather than inverting them.",
+    "significance": "fundamental",
+    "relatedConcepts": ["Complex.differentiable_one_div_Gamma", "Differentiable.analyticAt", "AnalyticOnNhd", "entire function"],
+    "prerequisites": ["holomorphic = analytic over ℂ", "Mathlib Gamma API"]
+  },
+  {
+    "id": "ann-gamma-refl-oq0102-zeroset",
+    "proofId": "gamma-reflection-formula-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 110 },
+    "type": "insight",
+    "title": "The Zero Set is Exactly {0, -1, -2, …}",
+    "content": "invGamma_eq_zero_iff is the heart of the entry: (Γ z)⁻¹ = 0 ↔ ∃ n : ℕ, z = -n. The proof is a two-step reduction — inv_eq_zero turns the reciprocal-vanishing into Γ z = 0, and Mathlib's Gamma_eq_zero_iff identifies that with z being a non-positive integer. This forward direction (a zero of 1/Γ can ONLY sit at a pole of Γ) is exactly the contrapositive of the parent's non-vanishing corollary, here phrased for the reciprocal. invGamma_ne_zero_iff is the dual. zeroSet_invGamma packages the literal set equality {z | (Γ z)⁻¹ = 0} = nonposInt, and nonposInt_eq_range / countable_zeroSet show that set is the range of n ↦ -n over ℕ, hence COUNTABLE.",
+    "mathContext": "$\\{z : (\\Gamma z)^{-1} = 0\\} = \\{0,-1,-2,\\dots\\}$, a countable subset of $\\mathbb C$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["Complex.Gamma_eq_zero_iff", "inv_eq_zero", "Set.countable_range", "zero set", "non-positive integers"],
+    "prerequisites": ["zeros of the Gamma function", "set-builder and range in Lean"]
+  },
+  {
+    "id": "ann-gamma-refl-oq0102-values",
+    "proofId": "gamma-reflection-formula-oq-01-oq-02",
+    "range": { "startLine": 112, "endLine": 132 },
+    "type": "theorem",
+    "title": "Concrete Values and the Functional Equation",
+    "content": "invGamma_one shows (Γ 1)⁻¹ = 1 — the crucial non-degeneracy fact that 1/Γ is NOT identically zero, without which the identity theorem could not exclude 1/Γ ≡ 0. invGamma_zero ((Γ 0)⁻¹ = 0) and invGamma_neg_three ((Γ -3)⁻¹ = 0) exhibit sample zeros. invGamma_recurrence re-exports the everywhere-valid functional equation (Γ s)⁻¹ = s·(Γ(s+1))⁻¹ (one_div_Gamma_eq_self_mul_one_div_Gamma_add_one): the explicit factor s seeds the zero at 0, and iterating it shifts the zero down the ladder 0, -1, -2, …, matching the zero set computed independently.",
+    "mathContext": "$(\\Gamma 1)^{-1} = 1$, $(\\Gamma 0)^{-1} = 0$; functional equation $(\\Gamma s)^{-1} = s\\,(\\Gamma(s+1))^{-1}$ valid at $s = 0$ too.",
+    "significance": "supporting",
+    "relatedConcepts": ["Complex.Gamma_one", "Complex.Gamma_zero", "one_div_Gamma_eq_self_mul_one_div_Gamma_add_one", "functional equation"],
+    "prerequisites": ["Gamma special values", "recurrence Γ(s+1) = s·Γ(s)"]
+  },
+  {
+    "id": "ann-gamma-refl-oq0102-isolated",
+    "proofId": "gamma-reflection-formula-oq-01-oq-02",
+    "range": { "startLine": 134, "endLine": 147 },
+    "type": "insight",
+    "title": "Every Zero is Isolated",
+    "content": "isolated_zeros is the analytic payoff: at any zero z of 1/Γ, the function is nonzero throughout a punctured neighborhood of z. The proof applies the principle of isolated zeros (AnalyticAt.eventually_eq_zero_or_eventually_ne_zero), which offers two alternatives — 1/Γ identically zero near z, or nonzero on a punctured neighborhood. The first is impossible: by the analytic identity theorem (eqOn_zero_of_preconnected_of_eventuallyEq_zero) on the preconnected set ℂ, local vanishing would force 1/Γ ≡ 0 everywhere, contradicting (Γ 1)⁻¹ = 1 ≠ 0. So only the second survives. Conceptually: the poles of Γ are isolated points of the zero locus of 1/Γ, none of them an accumulation point of zeros.",
+    "mathContext": "A nonzero entire function has isolated zeros. Here: $\\forall z_0$ with $(\\Gamma z_0)^{-1}=0$, $(\\Gamma w)^{-1} \\ne 0$ for $w$ in a punctured neighborhood of $z_0$.",
+    "significance": "fundamental",
+    "relatedConcepts": ["AnalyticAt.eventually_eq_zero_or_eventually_ne_zero", "identity theorem", "isPreconnected_univ", "isolated zeros"],
+    "prerequisites": ["principle of isolated zeros", "analytic continuation / identity theorem"]
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-02/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-02",
+  "slug": "gamma-reflection-formula-oq-01-oq-02",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Complex",
+      "Topology"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ02",
+    "lineCount": 147,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "title": "1/Γ as an Entire Function with Zero Set the Non-Positive Integers",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "complex-analysis",
+      "special-functions",
+      "gamma-function",
+      "entire-function",
+      "isolated-zeros",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 147,
+    "theoremCount": 13,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "differentiable_invGamma / analyticAt_invGamma / analyticOnNhd_invGamma: package the reciprocal Gamma function s ↦ (Γ s)⁻¹ as an ENTIRE function — differentiable on all of ℂ (Mathlib's differentiable_one_div_Gamma) and promoted to analytic at every point and on Set.univ via Differentiable.analyticAt.",
+      "invGamma_eq_zero_iff: (Γ z)⁻¹ = 0 ↔ ∃ n : ℕ, z = -n — the zero set of 1/Γ is exactly the non-positive integers (reduces to inv_eq_zero ∘ Complex.Gamma_eq_zero_iff).",
+      "invGamma_ne_zero_iff: dual non-vanishing criterion (Γ z)⁻¹ ≠ 0 ↔ ∀ n, z ≠ -n.",
+      "zeroSet_invGamma: the set equality {z | (Γ z)⁻¹ = 0} = {0, -1, -2, …} packaged as a Set ℂ.",
+      "countable_zeroSet: the zero set of 1/Γ is countable (it is the range of n ↦ -n over ℕ).",
+      "invGamma_one / invGamma_zero / invGamma_neg_three: concrete witnesses — (Γ 1)⁻¹ = 1 (so 1/Γ is NOT identically zero), (Γ 0)⁻¹ = 0, (Γ (-3))⁻¹ = 0.",
+      "invGamma_recurrence: the functional equation (Γ s)⁻¹ = s·(Γ (s+1))⁻¹ valid everywhere including s = 0 (Mathlib's one_div_Gamma_eq_self_mul_one_div_Gamma_add_one), re-exported as the mechanism generating the ladder of zeros.",
+      "isolated_zeros: every zero of 1/Γ is ISOLATED — at any zero z, 1/Γ is nonzero throughout a punctured neighborhood. Proved via the principle of isolated zeros, with the 'identically zero near z' branch ruled out by the analytic identity theorem on the preconnected set ℂ together with (Γ 1)⁻¹ = 1 ≠ 0."
+    ],
+    "prerequisites": [
+      "Complex Gamma function Complex.Gamma and its poles at the non-positive integers",
+      "Mathlib's Complex.differentiable_one_div_Gamma (1/Γ entire) and Complex.Gamma_eq_zero_iff",
+      "Holomorphic ⟹ analytic on ℂ (Differentiable.analyticAt)",
+      "Principle of isolated zeros and the analytic identity theorem (AnalyticAt.eventually_eq_zero_or_eventually_ne_zero, eqOn_zero_of_preconnected_of_eventuallyEq_zero)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Complex.differentiable_one_div_Gamma",
+        "description": "s ↦ (Γ s)⁻¹ is differentiable on all of ℂ, including the non-positive integers where Γ has poles — the entirety of 1/Γ.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.Gamma_eq_zero_iff",
+        "description": "Γ s = 0 ↔ ∃ m : ℕ, s = -m. Combined with inv_eq_zero this pins the zero set of 1/Γ to the non-positive integers.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Complex.one_div_Gamma_eq_self_mul_one_div_Gamma_add_one",
+        "description": "(Γ s)⁻¹ = s·(Γ (s+1))⁻¹, the everywhere-valid functional equation of 1/Γ re-exported as invGamma_recurrence.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Beta"
+      },
+      {
+        "theorem": "Differentiable.analyticAt",
+        "description": "A function differentiable on ℂ is analytic at every point — used to promote entirety of 1/Γ to AnalyticAt / AnalyticOnNhd.",
+        "module": "Mathlib.Analysis.Complex.CauchyIntegral"
+      },
+      {
+        "theorem": "AnalyticAt.eventually_eq_zero_or_eventually_ne_zero",
+        "description": "Principle of isolated zeros: an analytic function is either identically zero near a point or nonzero in a punctured neighborhood. Drives isolated_zeros.",
+        "module": "Mathlib.Analysis.Analytic.IsolatedZeros"
+      },
+      {
+        "theorem": "AnalyticOnNhd.eqOn_zero_of_preconnected_of_eventuallyEq_zero",
+        "description": "Analytic identity theorem: a function analytic on a preconnected set and vanishing near one point vanishes on the whole set — used (on Set.univ) to rule out 1/Γ being locally zero.",
+        "module": "Mathlib.Analysis.Analytic.Uniqueness"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-02-oq-01",
+      "question": "Strengthen isolated_zeros to an order statement: show 1/Γ has a SIMPLE zero (order exactly 1) at each non-positive integer -n, equivalently that Γ has a simple pole there with residue (-1)^n/n!, via analyticOrderAt of 1/Γ.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "extends",
+      "description": "The parent records Euler's reflection formula and the non-vanishing corollary 'sin(πs) ≠ 0 ⟹ Γ s ≠ 0', which shows where Γ does not vanish. This entry takes the dual analytic view: it packages the reciprocal 1/Γ as the canonical entire completion of Γ and pins its zero set to exactly the non-positive integers — the poles of Γ become the (isolated) zeros of 1/Γ."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Beta",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Complex.differentiable_one_div_Gamma, Complex.Gamma_eq_zero_iff, and the functional equation one_div_Gamma_eq_self_mul_one_div_Gamma_add_one."
+    },
+    {
+      "title": "A Course of Modern Analysis",
+      "author": "E. T. Whittaker and G. N. Watson",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "description": "§12.1 develops 1/Γ as an entire function (the Weierstrass product), with zeros exactly at the non-positive integers — the classical picture formalized here."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Euler's reflection formula shows the Gamma function never vanishes; its dual statement is that the reciprocal $1/\\Gamma$ is an *entire* function. This is the cleaner of the two analytic objects: $\\Gamma$ itself is meromorphic with simple poles at $0, -1, -2, \\dots$, but $1/\\Gamma$ has no poles at all — Weierstrass exhibited it directly as the entire product $1/\\Gamma(s) = s\\,e^{\\gamma s}\\prod_{n\\ge 1}(1 + s/n)e^{-s/n}$. Where $\\Gamma$ blows up, $1/\\Gamma$ simply vanishes, and the zero set of $1/\\Gamma$ is *exactly* the non-positive integers. Mathlib proves $1/\\Gamma$ differentiable on all of $\\mathbb C$ and characterizes the zeros of $\\Gamma$, but does not assemble these into the entire-function-with-prescribed-zero-set picture, nor record that the zero set is countable and that each zero is isolated. This entry supplies exactly that packaging, the analytic dual of the parent's reflection-based non-vanishing.",
+    "problemStatement": "Record the reciprocal Gamma function $s \\mapsto (\\Gamma s)^{-1}$ as an entire function on $\\mathbb C$ whose zero set is exactly the non-positive integers $\\{0, -1, -2, \\dots\\}$, and derive the structural consequences: the zero set is countable, $1/\\Gamma$ is not identically zero ($(\\Gamma 1)^{-1} = 1$), and consequently every zero is isolated.",
+    "proofStrategy": "Entirety is Mathlib's `differentiable_one_div_Gamma`, promoted to `AnalyticAt`/`AnalyticOnNhd` by `Differentiable.analyticAt` (a function holomorphic on $\\mathbb C$ is analytic everywhere). The zero set reduces by `inv_eq_zero` to $\\Gamma z = 0$, which Mathlib's `Gamma_eq_zero_iff` characterizes as $z$ a non-positive integer; this gives the iff, the set equality, and — writing the non-positive integers as the range of $n \\mapsto -n$ — countability via `Set.countable_range`. Isolation of zeros invokes the principle of isolated zeros (`AnalyticAt.eventually_eq_zero_or_eventually_ne_zero`); its 'identically zero near $z$' alternative is impossible because the analytic identity theorem (`eqOn_zero_of_preconnected_of_eventuallyEq_zero` on the preconnected set $\\mathbb C$) would then force $1/\\Gamma \\equiv 0$, contradicting $(\\Gamma 1)^{-1} = 1 \\ne 0$.",
+    "keyInsights": [
+      "The reciprocal $1/\\Gamma$ is the 'right' analytic object: it is entire (no poles), trading the poles of $\\Gamma$ for zeros. The single fact `differentiable_one_div_Gamma` already says $1/\\Gamma$ is holomorphic across the non-positive integers, where $\\Gamma$ itself is undefined as a finite value.",
+      "The zero set is pinned *exactly*: $(\\Gamma z)^{-1} = 0 \\iff z \\in \\{0,-1,-2,\\dots\\}$. The forward direction is the genuine content — a zero of $1/\\Gamma$ can only sit at a pole of $\\Gamma$ — and it is exactly the contrapositive of the parent's non-vanishing corollary, here phrased for the reciprocal.",
+      "Not-identically-zero is the crucial non-degeneracy hypothesis for everything analytic that follows: $(\\Gamma 1)^{-1} = 1$ is a one-line fact, but without it the identity theorem could not exclude $1/\\Gamma \\equiv 0$ and the zeros could in principle accumulate.",
+      "Isolation of zeros is the payoff: each pole of $\\Gamma$ is an isolated point of the zero locus of $1/\\Gamma$, none of them a limit of other zeros. This is the formal content behind 'the poles of $\\Gamma$ are isolated and simple', and it follows from entirety + non-degeneracy via the identity theorem.",
+      "The everywhere-valid functional equation $(\\Gamma s)^{-1} = s\\,(\\Gamma(s+1))^{-1}$ exhibits the zero-generating mechanism: the factor $s$ creates the zero at $0$, and iterating shifts it down the ladder $0, -1, -2, \\dots$, matching the zero set computed independently."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: 1/Γ, the Entire Dual of Γ",
+      "startLine": 1,
+      "endLine": 51,
+      "summary": "Frames 1/Γ as the canonical entire completion of the meromorphic Γ: where Γ has simple poles (the non-positive integers), 1/Γ has its zeros, and nowhere else. States what Mathlib already provides as separate facts (differentiable_one_div_Gamma, Gamma_eq_zero_iff) and the new packaging: entire function + exact zero set + countability + isolated zeros.",
+      "mathContext": "$1/\\Gamma(s) = s\\,e^{\\gamma s}\\prod_{n\\ge1}(1 + s/n)e^{-s/n}$ (Weierstrass), entire with zeros exactly at $\\{0,-1,-2,\\dots\\}$."
+    },
+    {
+      "id": "entire",
+      "title": "1/Γ is Entire",
+      "startLine": 60,
+      "endLine": 76,
+      "summary": "differentiable_invGamma re-exports that s ↦ (Γ s)⁻¹ is differentiable on all of ℂ; analyticAt_invGamma and analyticOnNhd_invGamma promote this to analyticity at every point and on Set.univ via Differentiable.analyticAt — i.e. 1/Γ is an entire function.",
+      "mathContext": "Holomorphic on $\\mathbb C$ $\\Rightarrow$ analytic on $\\mathbb C$. $1/\\Gamma$ has removable behavior across the poles of $\\Gamma$."
+    },
+    {
+      "id": "zero-set",
+      "title": "The Zero Set is Exactly the Non-Positive Integers",
+      "startLine": 78,
+      "endLine": 110,
+      "summary": "invGamma_eq_zero_iff: (Γ z)⁻¹ = 0 ↔ ∃ n, z = -n (via inv_eq_zero and Gamma_eq_zero_iff). invGamma_ne_zero_iff is the dual. zeroSet_invGamma packages the set equality {z | (Γ z)⁻¹ = 0} = nonposInt; nonposInt_eq_range and countable_zeroSet show that set is the range of n ↦ -n, hence countable.",
+      "mathContext": "$\\{z : (\\Gamma z)^{-1} = 0\\} = \\{0,-1,-2,\\dots\\}$, a countable set."
+    },
+    {
+      "id": "values-recurrence",
+      "title": "Concrete Values and the Functional Equation",
+      "startLine": 112,
+      "endLine": 132,
+      "summary": "invGamma_one ((Γ 1)⁻¹ = 1, so 1/Γ is not identically zero), invGamma_zero ((Γ 0)⁻¹ = 0) and invGamma_neg_three ((Γ -3)⁻¹ = 0) as sample zeros, and invGamma_recurrence ((Γ s)⁻¹ = s·(Γ(s+1))⁻¹) — the everywhere-valid functional equation whose factor s seeds the ladder of zeros.",
+      "mathContext": "$(\\Gamma 1)^{-1} = 1$, $(\\Gamma 0)^{-1} = 0$; $(\\Gamma s)^{-1} = s\\,(\\Gamma(s+1))^{-1}$."
+    },
+    {
+      "id": "isolated",
+      "title": "Every Zero is Isolated",
+      "startLine": 134,
+      "endLine": 147,
+      "summary": "isolated_zeros: at any zero z of 1/Γ, the function is nonzero throughout a punctured neighborhood. Proved by the principle of isolated zeros; the 'identically zero near z' alternative is excluded by the identity theorem on the preconnected ℂ together with (Γ 1)⁻¹ = 1 ≠ 0. So the poles of Γ are isolated points of the zero locus of 1/Γ.",
+      "mathContext": "A nonzero entire function has isolated zeros: $\\forall z_0$ with $f(z_0)=0$, $f \\ne 0$ on a punctured neighborhood of $z_0$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The reciprocal Gamma function s ↦ (Γ s)⁻¹ is packaged as an entire function on ℂ (differentiable_one_div_Gamma promoted via Differentiable.analyticAt) whose zero set is exactly the non-positive integers {0,-1,-2,…} (invGamma_eq_zero_iff / zeroSet_invGamma, from inv_eq_zero ∘ Gamma_eq_zero_iff). The zero set is countable (it is the range of n ↦ -n), 1/Γ is not identically zero ((Γ 1)⁻¹ = 1), and consequently every zero is isolated (isolated_zeros, via the principle of isolated zeros and the analytic identity theorem on ℂ). 147 lines, 13 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "This is the analytic dual of the parent's reflection-based non-vanishing: instead of recording where Γ does not vanish, it records 1/Γ as the entire function whose zeros are precisely the poles of Γ, and shows those zeros are isolated. The badge is 'original' because, although the two ingredients (entirety of 1/Γ, characterization of Γ's zeros) live in Mathlib, neither Mathlib nor the parent assembles the entire-function-with-prescribed-isolated-zero-set picture.",
+    "openQuestions": [
+      "Strengthen isolated_zeros to an order statement: 1/Γ has a simple zero (order exactly 1) at each -n, equivalently Γ has a simple pole there with residue (-1)^n/n!."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the parent `gamma-reflection-formula-oq-01`'s **openQuestions[1]**: package the reciprocal Gamma function `1/Γ` as the canonical **entire** completion of the meromorphic `Γ`, whose zero set is **exactly** the non-positive integers `{0, -1, -2, …}` — the analytic dual of the parent's reflection-based non-vanishing.

Mathlib supplies the two ingredients only as *separate* facts (`differentiable_one_div_Gamma`, `Gamma_eq_zero_iff`); neither Mathlib nor the parent assembles the entire-function-with-prescribed-isolated-zero-set picture.

## New content

- **`differentiable_invGamma` / `analyticAt_invGamma` / `analyticOnNhd_invGamma`** — `1/Γ` is entire (`differentiable_one_div_Gamma` promoted via `Differentiable.analyticAt`).
- **`invGamma_eq_zero_iff`** — `(Γ z)⁻¹ = 0 ↔ ∃ n : ℕ, z = -n` (the exact zero set; contrapositive of the parent's non-vanishing, phrased for the reciprocal). Plus dual `invGamma_ne_zero_iff`.
- **`zeroSet_invGamma` / `nonposInt_eq_range` / `countable_zeroSet`** — set equality `{z | (Γ z)⁻¹ = 0} = {0,-1,-2,…}` and its countability.
- **`invGamma_one`** (`(Γ 1)⁻¹ = 1`, so `1/Γ` is not identically zero), **`invGamma_zero`**, **`invGamma_neg_three`** (sample zeros), and **`invGamma_recurrence`** — the everywhere-valid functional equation `(Γ s)⁻¹ = s·(Γ(s+1))⁻¹`.
- **`isolated_zeros`** — every zero of `1/Γ` is isolated, via the principle of isolated zeros (`AnalyticAt.eventually_eq_zero_or_eventually_ne_zero`); the "identically zero near z" branch is excluded by the analytic identity theorem on the preconnected `ℂ` together with `(Γ 1)⁻¹ = 1 ≠ 0`.

## Verification

- 13 theorems, 1 definition, **0 axioms, 0 sorries**, 147 lines.
- `lake env lean` kernel-verifies clean (EXIT 0).
- `#print axioms` = standard triple only (`propext`, `Classical.choice`, `Quot.sound`) — no `sorryAx`, no `Lean.ofReduceBool`. Badge: `original`.
- Registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)