### PR TITLE
research(geometric-series-oq-01-oq-01-oq-01): discharge summable_partialSum sorry (Frobenius scaffold, 4→3)

### DIFF
--- a/proofs/Proofs/GeometricSeriesOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ01OQ01.lean
@@ -75,14 +75,6 @@ theorem tsum_eq_one_sub_mul_tsum_partialSum (b : ℕ → ℝ) {x : ℝ} (hx : |x
       = (1 - x) * ∑' n : ℕ, (∑ k ∈ Finset.range (n + 1), b k) * x ^ n := by
   sorry
 
-/-- **Growth bound ⇒ summability.** A Cesàro-convergent sequence of partial sums is bounded
-in average, so `Tₙ = O(n)`; together with `|x| < 1` this makes every series in the argument
-summable. (Packaged for the partial sums of `a`.) -/
-theorem summable_partialSum_mul_geometric (a : ℕ → ℝ) {L x : ℝ} (hx : |x| < 1)
-    (hL : Tendsto (fun N : ℕ => partialSum2 a N / ((N : ℝ) + 1)) atTop (𝓝 L)) :
-    Summable (fun n : ℕ => partialSum a n * x ^ n) := by
-  sorry
-
 /-- The same summability for the *second* partial sums `Tₙ`. Proved unconditionally from the
 Cesàro hypothesis: the means `τₙ = Tₙ/(n+1)` form a bounded sequence (they converge), so
 `Tₙ = (n+1)·τₙ = O(n)`, and `∑ n·|x|ⁿ` converges for `|x| < 1`. -/
@@ -120,6 +112,30 @@ theorem summable_partialSum2_mul_geometric (a : ℕ → ℝ) {L x : ℝ} (hx : |
         apply mul_le_mul_of_nonneg_right _ (by positivity)
         exact mul_le_mul_of_nonneg_left (hM n) hnn
     _ = (|U| + |V|) * (((n : ℝ) + 1) * |x| ^ n) := by ring
+
+/-- **Growth bound ⇒ summability.** A Cesàro-convergent sequence of partial sums is bounded
+in average, so `Tₙ = O(n)`; the first partial sums satisfy `Sₙ₊₁ = Tₙ₊₁ − Tₙ`, hence the
+weighted series `∑ Sₙ xⁿ` is the difference of two summable shifts of `∑ Tₙ xⁿ`. -/
+theorem summable_partialSum_mul_geometric (a : ℕ → ℝ) {L x : ℝ} (hx : |x| < 1)
+    (hL : Tendsto (fun N : ℕ => partialSum2 a N / ((N : ℝ) + 1)) atTop (𝓝 L)) :
+    Summable (fun n : ℕ => partialSum a n * x ^ n) := by
+  -- The second partial sums are summable against the geometric weight.
+  have hT : Summable (fun n : ℕ => partialSum2 a n * x ^ n) :=
+    summable_partialSum2_mul_geometric a hx hL
+  -- `Sₙ₊₁ = Tₙ₊₁ − Tₙ`, so `Sₙ₊₁ xⁿ⁺¹ = Tₙ₊₁ xⁿ⁺¹ − x·(Tₙ xⁿ)`.
+  have key : ∀ n : ℕ, partialSum a (n + 1) * x ^ (n + 1)
+      = partialSum2 a (n + 1) * x ^ (n + 1) - x * (partialSum2 a n * x ^ n) := by
+    intro n
+    have hrec : partialSum2 a (n + 1) = partialSum2 a n + partialSum a (n + 1) := by
+      simp [partialSum2, Finset.sum_range_succ]
+    rw [pow_succ, hrec]; ring
+  -- Both `Tₙ₊₁ xⁿ⁺¹` and `x·(Tₙ xⁿ)` are summable, hence so is the shifted `Sₙ₊₁ xⁿ⁺¹`.
+  have hTshift : Summable (fun n : ℕ => partialSum2 a (n + 1) * x ^ (n + 1)) :=
+    (summable_nat_add_iff 1).mpr hT
+  have hxT : Summable (fun n : ℕ => x * (partialSum2 a n * x ^ n)) := hT.mul_left x
+  have hSshift : Summable (fun n : ℕ => partialSum a (n + 1) * x ^ (n + 1)) :=
+    (hTshift.sub hxT).congr (fun n => (key n).symm)
+  exact (summable_nat_add_iff 1).mp hSshift
 
 /-- **Frobenius's theorem (general form).** If the Cesàro means `Tₙ/(n+1)` of the partial
 sums converge to `L`, then the Abel limit `lim_{x→1⁻} ∑ₙ aₙ xⁿ` equals `L`. -/


### PR DESCRIPTION
## Summary

Discharges one of the four sorries in the **Frobenius (Cesàro ⟹ Abel)** scaffold
for `geometric-series-oq-01-oq-01-oq-01` (scaffold from PR #28536, merged).

Proves `summable_partialSum_mul_geometric` — summability of the weighted first
partial sums `∑ Sₙ xⁿ` for `|x| < 1`.

## Approach

Rather than re-running the growth-bound argument, derive it from the **already-proven**
sibling `summable_partialSum2_mul_geometric` (summability of `∑ Tₙ xⁿ`, where
`Tₙ = ∑_{k≤n} Sₖ`) via the first-difference identity

    Sₙ₊₁ = Tₙ₊₁ − Tₙ   ⟹   Sₙ₊₁ xⁿ⁺¹ = Tₙ₊₁ xⁿ⁺¹ − x·(Tₙ xⁿ).

The right side is a difference of two summable series (a shift of `∑ Tₙ xⁿ` and
`x·∑ Tₙ xⁿ`), and `summable_nat_add_iff` transfers the resulting shifted summability
back to `∑ Sₙ xⁿ`. Also reorders the two summability lemmas so the `T`-lemma precedes
the `S`-lemma (fixes a forward reference).

## Verification

`lake env lean` (Lean v4.26.0): compiles with no errors. **3 sorries remain**
(Abel-summation telescoping identity, the main `ε`-argument `frobenius_cesaro_imp_abel`,
and the Grandi Cesàro-mean instance) — these are good Aristotle targets and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
