### PR TITLE
Enrich Fibonacci strong divisibility (oq-02): add index.ts + annotations

### DIFF
--- a/src/data/proofs/fibonacci-identities-oq-02/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-02/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-fiboq02-1",
+    "proofId": "fibonacci-identities-oq-02",
+    "range": { "startLine": 3, "endLine": 34 },
+    "type": "context",
+    "title": "Fibonacci as a Strong Divisibility Sequence",
+    "content": "**Module framing.** A sequence $a_n$ is a *strong divisibility sequence* when $\\gcd(a_m, a_n) = a_{\\gcd(m,n)}$ — the value-gcd is pinned to a single term whose index is the index-gcd. The Fibonacci numbers satisfy this (Lucas, 1870s), and Mathlib records it as `Nat.fib_gcd` together with the one-directional corollary `Nat.fib_dvd : m ∣ n → fib m ∣ fib n`. This entry repackages the law as the family headline and extracts two facts Mathlib does **not** state: coprimality transfer, and the *full* biconditional $F_m \\mid F_n \\iff m \\mid n$ for $m \\ge 3$ (the forward direction is the new content). The $3 \\le m$ hypothesis is sharp because $F_1 = F_2 = 1$ are the only repeated values.",
+    "mathContext": "$F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$, with $F_0=0,\\ F_1=F_2=1,\\ F_{n+2}=F_{n+1}+F_n$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Strong divisibility sequence",
+      "Lucas sequences",
+      "Fibonacci divisibility",
+      "Elliptic divisibility sequences"
+    ],
+    "prerequisites": [
+      "gcd and divisibility on ℕ",
+      "The Fibonacci recurrence and base values"
+    ],
+    "tags": ["module-header", "framing", "strong-divisibility"]
+  },
+  {
+    "id": "ann-fiboq02-2",
+    "proofId": "fibonacci-identities-oq-02",
+    "range": { "startLine": 38, "endLine": 47 },
+    "type": "concept",
+    "title": "The Strong Divisibility Law and its Easy Corollary",
+    "content": "**`fib_gcd`** restates Mathlib's `Nat.fib_gcd`: $F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$. This is strictly stronger than the divisibility corollary — it determines the *exact* gcd of two Fibonacci numbers, not merely a one-way implication. **`fib_dvd_of_dvd`** is the easy direction $m \\mid n \\Rightarrow F_m \\mid F_n$ (Mathlib's `Nat.fib_dvd`), which is itself a consequence: if $m \\mid n$ then $\\gcd(m,n) = m$, so $\\gcd(F_m, F_n) = F_m$, i.e. $F_m \\mid F_n$.",
+    "mathContext": "$F_{\\gcd(m,n)} = \\gcd(F_m, F_n)$; and $m \\mid n \\Rightarrow \\gcd(m,n)=m \\Rightarrow F_m \\mid F_n$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.fib_gcd",
+      "Nat.fib_dvd",
+      "gcd as a meet"
+    ],
+    "prerequisites": [
+      "Mathlib's Fibonacci API",
+      "gcd_eq_left for divisibility"
+    ],
+    "tags": ["strong-divisibility", "headline", "corollary"]
+  },
+  {
+    "id": "ann-fiboq02-3",
+    "proofId": "fibonacci-identities-oq-02",
+    "range": { "startLine": 49, "endLine": 54 },
+    "type": "technique",
+    "title": "Coprimality Transfer",
+    "content": "**`fib_coprime_of_coprime`**: coprime indices give coprime Fibonacci values, $\\gcd(m,n)=1 \\Rightarrow \\gcd(F_m,F_n)=1$. The proof is a three-step rewrite: unfold `Nat.Coprime` to a gcd equality, rewrite $\\gcd(F_m,F_n)$ *backwards* through `Nat.fib_gcd` to $F_{\\gcd(m,n)}$, substitute the hypothesis $\\gcd(m,n)=1$, and finish with $F_1 = 1$ (`Nat.fib_one`). It is a clean illustration that strong-divisibility instantly yields the coprimality statement Mathlib lacks.",
+    "mathContext": "$\\gcd(m,n)=1 \\Rightarrow \\gcd(F_m,F_n) = F_{\\gcd(m,n)} = F_1 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.Coprime",
+      "Coprimality transfer",
+      "Nat.fib_one"
+    ],
+    "prerequisites": [
+      "Definition of Nat.Coprime (gcd = 1)",
+      "Rewriting with fib_gcd"
+    ],
+    "tags": ["coprime", "transfer", "rewrite"]
+  },
+  {
+    "id": "ann-fiboq02-4",
+    "proofId": "fibonacci-identities-oq-02",
+    "range": { "startLine": 56, "endLine": 94 },
+    "type": "insight",
+    "title": "The Full Characterization: Monotonicity Upgrades the gcd Equality",
+    "content": "**`fib_dvd_iff`** ($3 \\le m$): $F_m \\mid F_n \\iff m \\mid n$ — the genuinely new content, since Mathlib carries only the reverse. The forward proof is the model argument for strong divisibility sequences:\n1. **Reduce** $F_m \\mid F_n$ to $\\gcd(F_m,F_n) = F_m$ (`Nat.gcd_eq_left`), which `Nat.fib_gcd` turns into $F_{\\gcd(m,n)} = F_m$.\n2. **Bound** $\\gcd(m,n) \\le m$ (it divides $m$).\n3. **Exclude degeneracy**: $F_m \\ge F_3 = 2$ by monotonicity, so $\\gcd(m,n) \\in \\{0,1\\}$ is impossible (both force $F_{\\gcd} \\le 1$) — established by `interval_cases` + `decide`; hence $\\gcd(m,n) \\ge 2$.\n4. **Apply strict monotonicity** on $\\mathrm{Ici}\\,2$ (`Nat.fib_lt_fib`): $\\gcd(m,n) < m$ would give $F_{\\gcd} < F_m$, contradicting equality, so $\\gcd(m,n) = m$, i.e. $m \\mid n$.\nThe reverse is `Nat.fib_dvd`. This is exactly where injectivity-on-$\\mathrm{Ici}\\,2$ converts a *value* equality into an *index* equality.",
+    "mathContext": "For $m \\ge 3$: $F_m \\mid F_n \\Rightarrow F_{\\gcd(m,n)} = F_m,\\ \\gcd \\le m,\\ \\gcd \\ge 2 \\xRightarrow{\\text{strict mono}} \\gcd(m,n) = m$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Strict monotonicity of fib on Ici 2",
+      "Nat.fib_lt_fib",
+      "gcd_eq_left_iff_dvd",
+      "interval_cases"
+    ],
+    "prerequisites": [
+      "Nat.fib_mono and Nat.fib_lt_fib",
+      "gcd divides each argument"
+    ],
+    "tags": ["main-theorem", "monotonicity", "characterization", "beyond-mathlib"]
+  },
+  {
+    "id": "ann-fiboq02-5",
+    "proofId": "fibonacci-identities-oq-02",
+    "range": { "startLine": 96, "endLine": 109 },
+    "type": "context",
+    "title": "Worked Examples and the Sharp Boundary",
+    "content": "Three concrete instances ground the theory: the strong-divisibility law at $(12,8)$ ($F_{\\gcd(12,8)} = F_4 = 3$), the numeric check $\\gcd(F_{12},F_8) = \\gcd(144,21) = 3$ by `decide` (kernel evaluation — note this uses `decide`, not `native_decide`, so no `Lean.ofReduceBool` axiom enters), and the characterization specialised to $m=3$: $F_3 = 2 \\mid F_n \\iff 3 \\mid n$, the familiar 'every third Fibonacci number is even'. The latter also illustrates the sharp boundary: at $m=2$, $F_2 = 1$ divides *every* $F_n$ while $2 \\mid n$ fails for odd $n$, so the biconditional genuinely requires $m \\ge 3$.",
+    "mathContext": "$F_{\\gcd(12,8)} = F_4 = 3 = \\gcd(144,21)$; $\\ F_3 = 2 \\mid F_n \\iff 3 \\mid n$; sharpness fails at $m=2$ since $F_2 = 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "decide vs native_decide (axiom hygiene)",
+      "Every third Fibonacci is even",
+      "Sharpness of hypotheses"
+    ],
+    "prerequisites": [
+      "Kernel evaluation via decide",
+      "The characterization fib_dvd_iff"
+    ],
+    "tags": ["examples", "sharpness", "axiom-hygiene"]
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-02/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ02Data: ProofData = {
+  proof: fibonacciIdentitiesOQ02Proof,
+  annotations: fibonacciIdentitiesOQ02Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `fibonacci-identities-oq-02`

This entry shipped with only `meta.json` — it was **missing `index.ts`** (Vite's `import.meta.glob` could not discover it, so the page rendered "proof not found" on the live site) and had **no `annotations.json`**.

### Changes
- **Added `index.ts`** (standard gallery template) pointing at `Proofs/FibonacciIdentitiesOQ02.lean`.
- **Added `annotations.json`** with **5 substantive annotations** covering every section:
  1. Strong-divisibility framing (Lucas sequences, the sharp `3 ≤ m` boundary)
  2. The law `fib_gcd` + the easy corollary `fib_dvd_of_dvd`
  3. Coprimality transfer (`fib_coprime_of_coprime`)
  4. The full characterization `fib_dvd_iff` — how strict monotonicity on `Ici 2` upgrades a value equality to an index equality (the content beyond Mathlib's one-directional `Nat.fib_dvd`)
  5. Worked examples, sharpness at `m = 2`, and the `decide`-not-`native_decide` axiom hygiene note
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

### Verification
- `tsc -b` (full project typecheck) passes (exit 0), including the new `index.ts`.
- Axiom integrity preserved: `status: verified`, `badge: mathlib`, `axiomCount: 0`; example uses `decide` (kernel), not `native_decide`, so no `Lean.ofReduceBool` — consistent with the meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)