### PR TITLE
fix(audit): badge original→mathlib for normal-aut equality entry (extract from #28657)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01/meta.json
@@ -18,7 +18,7 @@
       "normal-extension",
       "automorphism-group"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Downgrade `badge` from `original` to `mathlib` for `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01` ("The Automorphism Equality for Normal Extensions").

## Evidence

**Before**: `badge: "original"`
**After**: `badge: "mathlib"`

The entry's main results `finSepDegree_eq_card_algEquiv` and `toEmb_bijective` are `rfl`-recognitions / thin wrappers of Mathlib's `Normal.algHomEquivAut`. The entry's own `keyInsights` state the work is *"not a new construction but a recognition: the parent had already written down one half of a known equivalence"*, and the `proofStrategy` derives every result via `Normal.algHomEquivAut` (`toEmb = ⇑(Normal.algHomEquivAut …).symm by rfl`, `Nat.card_congr (Normal.algHomEquivAut …)`). So `original` overclaims; `mathlib` is the honest badge. `status` remains `verified` (kernel-clean: `propext`/`Classical.choice`/`Quot.sound` only).

This extracts the clean meta.json-only fix from auditor PR #28657, which is stuck `CONFLICTING` on `audit-tracker.json` churn and cannot merge as-is.

---
Automated fix by lean-mechanic agent.