### PR TITLE
Enrich Erdős #982 Thin-Vertex Reduction: add overview, conclusion, annotation depth

### DIFF
--- a/src/data/proofs/erdos-982-thin-vertex/annotations.json
+++ b/src/data/proofs/erdos-982-thin-vertex/annotations.json
@@ -6,7 +6,10 @@
     "type": "concept",
     "title": "Isolating the engine behind Erdős #982",
     "content": "Erdős Problem #982 asks whether every convex n-gon has a vertex with at least ⌊n/2⌋ distinct distances to the other vertices — OPEN, with the best known bound ≈ 0.361n (Nivasch–Pach–Pinchasi–Zerbib 2013) and ⌊n/2⌋ attained by the regular polygon. The parent entry (Erdos982Problem.lean) states the conjecture and axiomatizes the published bounds. This file proves, axiom-free, the purely combinatorial core common to all Moser-type arguments and shows precisely where the genuine geometric difficulty sits. Fixing a vertex p, the other vertices split into 'distance classes': sets of vertices equidistant from p, i.e. lying on one circle centred at p. Pigeonhole relates the number of distinct distances to the size of the largest class. The geometric — and open — part is only that some vertex has all classes small.",
-    "mathContext": "$f(n)\\ge\\lfloor n/2\\rfloor$ is conjectured; here we prove the reduction $(n-1)\\le(\\#\\text{distances})\\cdot(\\text{largest class})$ and its consequences."
+    "mathContext": "$f(n)\\ge\\lfloor n/2\\rfloor$ is conjectured; here we prove the reduction $(n-1)\\le(\\#\\text{distances})\\cdot(\\text{largest class})$ and its consequences.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős distinct distances", "convex polygons", "distance classes", "Nivasch–Pach–Pinchasi–Zerbib bound"],
+    "prerequisites": ["combinatorial geometry", "pigeonhole principle"]
   },
   {
     "id": "ann-erdos982thin-pigeonhole",
@@ -15,7 +18,10 @@
     "type": "key-step",
     "title": "The abstract fibre pigeonhole",
     "content": "card_le_image_mul is fully general: for any f : α → β with DecidableEq β and any finite s, if every value b in the image is attained by at most M elements of s, then s.card ≤ (s.image f).card · M. The proof rewrites s.card as the fibrewise sum ∑_{b ∈ s.image f} #{a ∈ s | f a = b} via Finset.card_eq_sum_card_fiberwise, bounds each summand by M with Finset.sum_le_sum, and collapses ∑ M = (#image)·M with Finset.sum_const. image_card_ge_div repackages this as s.card/M ≤ #image using Nat.div_le_of_le_mul. Nothing here is geometric — this is the entire combinatorial content.",
-    "mathContext": "$s = \\bigsqcup_{b} f^{-1}(b)$ over $\\#(\\mathrm{im}\\,f)$ classes each of size $\\le M$, so $|s|\\le \\#(\\mathrm{im}\\,f)\\cdot M$."
+    "mathContext": "$s = \\bigsqcup_{b} f^{-1}(b)$ over $\\#(\\mathrm{im}\\,f)$ classes each of size $\\le M$, so $|s|\\le \\#(\\mathrm{im}\\,f)\\cdot M$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "fibrewise cardinality", "Finset.image", "double counting"],
+    "prerequisites": ["Finset.card_eq_sum_card_fiberwise", "finite sums"]
   },
   {
     "id": "ann-erdos982thin-moser",
@@ -24,7 +30,10 @@
     "type": "technique",
     "title": "The Moser-type general bound",
     "content": "distinctDistances_ge_of_classes_le specialises the engine to f = dist p over S.erase p (the n−1 other vertices, card via Finset.card_erase_of_mem). If every circle centred at p carries ≤ M vertices, then p sees ≥ (n−1)/M distinct distances. M = 3 recovers Moser's 1952 bound f(n) ≥ ⌈n/3⌉; the entire family of published improvements (Erdős–Fishburn 1994, Dumitrescu 2006, NPPZ 2013) consists of better geometric bounds on M for a well-chosen vertex, not better combinatorics. The combinatorics is this one line.",
-    "mathContext": "All classes $\\le M \\Rightarrow \\#\\text{distances from }p \\ge \\dfrac{n-1}{M}$; Moser is $M=3$."
+    "mathContext": "All classes $\\le M \\Rightarrow \\#\\text{distances from }p \\ge \\dfrac{n-1}{M}$; Moser is $M=3$.",
+    "significance": "key",
+    "relatedConcepts": ["Moser's bound", "distinct distances from a vertex", "circles through equidistant points", "specialization of pigeonhole"],
+    "prerequisites": ["the abstract fibre pigeonhole", "Finset.card_erase_of_mem"]
   },
   {
     "id": "ann-erdos982thin-half",
@@ -33,7 +42,10 @@
     "type": "key-step",
     "title": "Thin vertex ⇒ ⌊n/2⌋, tight at the regular polygon",
     "content": "distinctDistances_ge_half is the headline. If every distance class of p has size ≤ 2 (no three equidistant neighbours), then card_le_image_mul gives (n−1) ≤ (#distances)·2, and omega closes ⌊n/2⌋ ≤ #distances. The improvement of the crude ⌈(n−1)/2⌉ to the exact ⌊n/2⌋ is the parity fact ⌈(n−1)/2⌉ = ⌊n/2⌋ (recorded separately as ceil_half_pred_eq_floor_half): for even n the diametric neighbour forms a class of size 1, so one class is short and the bound rounds up. conjecture_of_exists_thin_vertex then lifts a single thin vertex to maxDistinctDistances via Finset.le_sup: one thin vertex settles #982 for that polygon.",
-    "mathContext": "All classes $\\le 2 \\Rightarrow \\#\\text{distances}\\ge\\lceil (n-1)/2\\rceil=\\lfloor n/2\\rfloor$, exactly the regular-polygon value."
+    "mathContext": "All classes $\\le 2 \\Rightarrow \\#\\text{distances}\\ge\\lceil (n-1)/2\\rceil=\\lfloor n/2\\rfloor$, exactly the regular-polygon value.",
+    "significance": "key",
+    "relatedConcepts": ["thin vertex", "regular polygon tightness", "unique diameter", "Finset.le_sup"],
+    "prerequisites": ["the Moser-type bound", "omega arithmetic"]
   },
   {
     "id": "ann-erdos982thin-obstruction",
@@ -42,7 +54,10 @@
     "type": "concept",
     "title": "The obstruction: link to Erdős #97",
     "content": "exists_three_equidistant_of_few_distances is the contrapositive: if p sees fewer than ⌊n/2⌋ distinct distances then some circle centred at p passes through three other vertices (push_neg turns 'no class of size 3' into 'all classes ≤ 2', then the headline bound contradicts the hypothesis). This is the exact point where #982 stops being combinatorial. Erdős Problem #97 asked whether one can always find a vertex with no three equidistant neighbours — precisely a thin vertex — and that was DISPROVED. So a thin vertex is not guaranteed, the engine alone cannot close #982, and the gap to the conjecture is genuinely geometric. This file draws that line exactly.",
-    "mathContext": "$\\#\\text{distances from }p<\\lfloor n/2\\rfloor \\Rightarrow \\exists$ a circle at $p$ through $3$ vertices — the #97 configuration that cannot always be avoided."
+    "mathContext": "$\\#\\text{distances from }p<\\lfloor n/2\\rfloor \\Rightarrow \\exists$ a circle at $p$ through $3$ vertices — the #97 configuration that cannot always be avoided.",
+    "significance": "key",
+    "relatedConcepts": ["Erdős #97", "equidistant triples", "contrapositive", "geometric obstruction"],
+    "prerequisites": ["the thin-vertex bound", "push_neg / contraposition"]
   },
   {
     "id": "ann-erdos982thin-floor",
@@ -51,6 +66,9 @@
     "type": "key-step",
     "title": "Axiom-free base case and the unique-diameter arithmetic",
     "content": "maxDistinctDistances_pos proves that any set with ≥ 2 points has a vertex with ≥ 1 distinct distance: pick p, the erase is nonempty (Finset.card_erase_of_mem), so its image under dist p is nonempty (Finset.Nonempty.image), giving card ≥ 1, lifted by Finset.le_sup. triangle_case is the n = 3 instance ⌊3/2⌋ = 1 — the parent file left this as a sorry; here it is discharged without any axiom. ceil_half_pred_eq_floor_half records ⌈(n−1)/2⌉ = ⌊n/2⌋ (omega), the arithmetic reason the tight bound holds.",
-    "mathContext": "$|S|\\ge 2\\Rightarrow \\max\\text{distances}\\ge 1$ (the $n=3$ case), and $\\lceil(n-1)/2\\rceil=\\lfloor n/2\\rfloor$."
+    "mathContext": "$|S|\\ge 2\\Rightarrow \\max\\text{distances}\\ge 1$ (the $n=3$ case), and $\\lceil(n-1)/2\\rceil=\\lfloor n/2\\rfloor$.",
+    "significance": "supporting",
+    "relatedConcepts": ["base case", "Finset.Nonempty.image", "discharging a sorry axiom-free", "parity arithmetic"],
+    "prerequisites": ["Finset.le_sup", "omega"]
   }
 ]

--- a/src/data/proofs/erdos-982-thin-vertex/meta.json
+++ b/src/data/proofs/erdos-982-thin-vertex/meta.json
@@ -122,6 +122,33 @@
       "significance": "The n = 3 base case of #982 (⌊3/2⌋ = 1), proved without any of the parent's axioms."
     }
   ],
+  "overview": {
+    "historicalContext": "Erdős Problem #982 asks whether every convex n-gon has some vertex from which at least ⌊n/2⌋ distinct distances to the other vertices are seen. The regular n-gon attains exactly ⌊n/2⌋ from every vertex, making ⌊n/2⌋ the conjectured extremal value. The lower-bound story begins with Moser (1952), whose pigeonhole argument gives ⌈n/3⌉ distinct distances at some vertex; successive geometric refinements by Erdős–Fishburn (1994), Dumitrescu (2006), and Nivasch–Pach–Pinchasi–Zerbib (2013, the current record ≈ 0.3614n) all improve the bound on how many vertices can lie on one circle, never the underlying combinatorics. The problem remains open. Its difficulty is tied to the disproved Erdős Problem #97: one cannot always find a vertex avoiding three equidistant neighbours, so the clean combinatorial route to ⌊n/2⌋ is provably blocked.",
+    "problemStatement": "For a convex polygon with vertex set S, |S| = n, let f(n) be the maximum over vertices p of the number of distinct distances dist(p, q), q ∈ S\\{p}. Erdős #982 conjectures f(n) ≥ ⌊n/2⌋. This file does not resolve the conjecture; it isolates the axiom-free combinatorial engine: $(n-1) \\le (\\#\\text{distinct distances from }p)\\cdot(\\text{largest distance class of }p)$, and derives the exact reduction of #982 to the geometric existence of a 'thin' vertex (one whose every distance class has size ≤ 2).",
+    "proofStrategy": "The whole file descends from one abstract inequality, card_le_image_mul: for f : α → β with decidable equality, if every fibre of f over a finite set s has ≤ M elements, then |s| ≤ |image f|·M (proved from Finset.card_eq_sum_card_fiberwise and Finset.sum_le_sum). Specialising f = dist p to the n−1 other vertices gives distinctDistances_ge_of_classes_le: all distance classes ≤ M ⇒ at least (n−1)/M distinct distances (M = 3 is Moser). Taking M = 2 and upgrading ⌈(n−1)/2⌉ to ⌊n/2⌋ by the unique-diameter parity fact (ceil_half_pred_eq_floor_half, omega) yields the headline distinctDistances_ge_half; lifting one thin vertex through Finset.le_sup gives conjecture_of_exists_thin_vertex. The contrapositive exists_three_equidistant_of_few_distances exposes the link to the disproved #97. Finally maxDistinctDistances_pos discharges the n = 3 base case axiom-free.",
+    "keyInsights": [
+      "All known vertex distinct-distance lower bounds for #982 — Moser's ⌈n/3⌉ and every published refinement — are the SAME one-line pigeonhole inequality (card_le_image_mul) specialised to f = dist p; the published progress is entirely in the geometric bound on the largest distance class, never in the combinatorics.",
+      "The conjectured bound ⌊n/2⌋ is exactly the M = 2 instance: 'no three vertices on a circle centred at p' forces ≥ ⌈(n−1)/2⌉ = ⌊n/2⌋ distances, and the regular polygon shows this is tight, so #982 reduces precisely to the existence of one thin vertex.",
+      "The parity gain from the crude ⌈(n−1)/2⌉ to the exact ⌊n/2⌋ is the unique-diameter phenomenon: a vertex's diametrically opposite neighbour forms a distance class of size 1, so one class is short and the bound rounds up — a genuinely geometric improvement encoded as a Nat arithmetic identity.",
+      "The obstruction is sharp and identifiable: fewer than ⌊n/2⌋ distances at p forces a circle through three vertices, which is exactly the configuration of Erdős #97 — and #97's disproof shows such configurations cannot always be avoided, so no purely combinatorial argument can close #982.",
+      "The file cleanly separates what is provable from what is open: every statement is axiom-free and convex-position-free, isolating the geometric content of #982 as the single open existence claim 'a thin vertex always exists', rather than entangling it with the published bounds (which the parent file axiomatizes)."
+    ],
+    "prerequisites": [
+      "The pigeonhole / fibrewise-counting principle for finite sets",
+      "Euclidean distance in the plane EuclideanSpace ℝ (Fin 2)",
+      "Floor division arithmetic on ℕ (⌊n/2⌋, ⌈(n−1)/2⌉)",
+      "Erdős distinct-distance problems and the status of #97 and #982"
+    ]
+  },
+  "conclusion": {
+    "summary": "This entry extracts, axiom-free, the combinatorial core shared by every Moser-type lower bound for Erdős #982. From the single fibre inequality (n−1) ≤ (#distinct distances from p)·(largest distance class of p) it derives: the Moser-type general bound (n−1)/M; the headline distinctDistances_ge_half (all classes ≤ 2 ⇒ p sees ≥ ⌊n/2⌋ distances, tight at the regular polygon); the packaged reduction conjecture_of_exists_thin_vertex (#982 follows from the existence of one thin vertex); the contrapositive linking few distances to a circle through three vertices (Erdős #97); and an axiom-free n = 3 base case. None of the parent file's four axioms are used.",
+    "implications": "The work pinpoints exactly where Erdős #982 stops being elementary: the combinatorics is a one-line pigeonhole, and the entire open difficulty is the geometric existence of a thin vertex. Because the relevant 'avoid three equidistant neighbours' configuration is the disproved Erdős #97, the reduction explains structurally why #982 has resisted purely combinatorial attacks and why all progress has come from refined geometric bounds on the largest distance class. It also provides a reusable, verified pigeonhole engine and discharges the parent's triangle base case without assumptions.",
+    "openQuestions": [
+      "Does every convex polygon have a thin vertex (all distance classes ≤ 2), or at least a vertex with largest class o(n)? This is the exact geometric gap to the full ⌊n/2⌋ conjecture.",
+      "Can the current record M-bound (Nivasch–Pach–Pinchasi–Zerbib, ≈ 0.3614n) be formalized over this engine by supplying the geometric bound on the largest distance class, thereby machine-checking the best known lower bound for #982?",
+      "Is there a quantitative trade-off — e.g. an averaging bound showing many vertices are simultaneously thin — that would beat the worst-case single-vertex pigeonhole?"
+    ]
+  },
   "sections": [
     {
       "id": "pigeonhole-engine",


### PR DESCRIPTION
Enrichment pass for `erdos-982-thin-vertex` (quality 43 → ~100, 0 prior passes).

This entry already had annotations.json but its meta.json had **no `overview` and no `conclusion` block**, and the annotations lacked `significance`/`relatedConcepts`.

## Changes
- **Added `overview`**: historicalContext (Moser 1952 → Erdős–Fishburn → Dumitrescu → NPPZ 2013, and the link to disproved #97), problemStatement, proofStrategy, **5 keyInsights**, and prerequisites.
- **Added `conclusion`**: summary, implications, and **3 openQuestions** (existence of a thin vertex; formalizing the NPPZ record over this engine; averaging trade-offs).
- **Enriched all 6 annotations** with `significance`, `relatedConcepts`, and `prerequisites` (previously absent).

## Accuracy / axiom integrity
Content written against the actual Lean source and the existing mainTheorems metadata. The file is axiom-free (0 axioms, 0 sorries, no native_decide) and the open status of #982 is preserved — the overview/conclusion are explicit that the geometric existence of a thin vertex is NOT proved. `status: verified` / `badge: original` left unchanged.

`pnpm build` passes; only the target entry's files are staged.