### PR TITLE
Research: erdos-835 - repair broken scaffold, prove k=2 case

### DIFF
--- a/proofs/Proofs/Erdos835Problem.lean
+++ b/proofs/Proofs/Erdos835Problem.lean
@@ -18,6 +18,14 @@ Solution:
 NO. Computational verification shows χ(J(2k,k)) > k+1 for 3 ≤ k ≤ 8.
 The chromatic number is always at least k+1 and at most 2k.
 
+The cases k = 3, …, 8 are recorded here as axioms: each asserts the
+computational fact that the Johnson graph J(2k,k) is not (k+1)-colorable
+with the Erdős–Rosenfeld rainbow property. Formalizing these in-kernel
+would require enumerating colorings of graphs with up to C(16,8)=12870
+vertices, which is out of reach for the Lean kernel; they are stated as
+axioms and the file is `axiomatized` accordingly. The k = 2 construction
+and all structural definitions are fully proved.
+
 References:
 - Johnson graph chromatic numbers database
 - Problem equivalent to Kneser/Johnson graph colorings
@@ -25,9 +33,7 @@ References:
 Tags: combinatorics, graph-theory, chromatic-number, johnson-graphs
 -/
 
-import Mathlib.Combinatorics.SimpleGraph.Coloring
-import Mathlib.Data.Finset.Basic
-import Mathlib.Data.Fintype.Card
+import Mathlib
 
 namespace Erdos835
 
@@ -38,20 +44,31 @@ open Finset
 -/
 
 /-- The base set {1, 2, ..., n}. -/
-def baseSet (n : ℕ) : Finset ℕ := Finset.range n |>.map ⟨(· + 1), by intro; omega⟩
+def baseSet (n : ℕ) : Finset ℕ := Finset.range n |>.map ⟨(· + 1), add_left_injective 1⟩
 
 /-- The k-subsets of {1,...,n}: the vertex set of J(n,k). -/
 def kSubsets (n k : ℕ) : Type := { S : Finset ℕ // S ⊆ baseSet n ∧ S.card = k }
 
-/-- Two k-subsets are adjacent in J(n,k) if they differ by exactly one element. -/
+/-- The k-subsets of a finite ground set form a finite type: they are exactly the
+    elements of `(baseSet n).powersetCard k`. -/
+instance kSubsetsFintype (n k : ℕ) : Fintype (kSubsets n k) :=
+  Fintype.subtype ((baseSet n).powersetCard k) (by
+    intro S; rw [Finset.mem_powersetCard])
+
+/-- Two k-subsets are adjacent in J(n,k) if they are distinct and differ by exactly
+    one element (equivalently their intersection has size `k - 1`). The distinctness
+    clause makes the relation irreflexive for every `k`, including `k = 0`. -/
 def johnsonAdj (n k : ℕ) (S T : kSubsets n k) : Prop :=
-  (S.val ∩ T.val).card = k - 1
+  S.val ≠ T.val ∧ (S.val ∩ T.val).card = k - 1
 
 /-- The Johnson graph J(n,k). -/
 def JohnsonGraph (n k : ℕ) : SimpleGraph (kSubsets n k) where
   Adj := johnsonAdj n k
-  symm := by intro S T h; simp only [johnsonAdj] at *; rw [inter_comm]; exact h
-  loopless := by intro S; simp only [johnsonAdj]; intro h; simp_all
+  symm := by
+    intro S T h
+    refine ⟨h.1.symm, ?_⟩
+    rw [inter_comm]; exact h.2
+  loopless := by intro S h; exact h.1 rfl
 
 /-
 ## Part II: The Coloring Problem
@@ -61,9 +78,13 @@ def JohnsonGraph (n k : ℕ) : SimpleGraph (kSubsets n k) where
 def ProperColoring (n k c : ℕ) :=
   (JohnsonGraph n k).Coloring (Fin c)
 
-/-- The chromatic number of J(n,k). -/
-noncomputable def chromaticNumber (n k : ℕ) : ℕ :=
-  Nat.find (⟨2 * k, by sorry⟩ : ∃ c, Nonempty (ProperColoring n k c))
+/-- The chromatic number of J(n,k). Since the vertex type is finite, a coloring
+    with `Fintype.card (kSubsets n k)` colors always exists, so the set of valid
+    color counts is nonempty and `Nat.find` is well defined. -/
+noncomputable def chromaticNumber (n k : ℕ) : ℕ := by
+  classical
+  exact Nat.find (⟨Fintype.card (kSubsets n k), (JohnsonGraph n k).colorable_of_fintype⟩ :
+    ∃ c, Nonempty (ProperColoring n k c))
 
 /-
 ## Part III: The Erdős-Rosenfeld Property
@@ -81,23 +102,39 @@ def ErdosRosenfeldQuestion (k : ℕ) : Prop :=
 
 /-
 ## Part IV: Equivalence to Chromatic Number
--/
 
-/-- **Equivalence Theorem:**
-    The Erdős-Rosenfeld property holds for k iff χ(J(2k,k)) = k+1.
+**Equivalence (informal):** the Erdős-Rosenfeld property holds for `k` iff
+χ(J(2k,k)) = k+1.  The coloring must be proper (adjacent subsets get different
+colors) and "rainbow" on each (k+1)-subset.  We do not formalize this
+equivalence; the answer below is obtained directly via the `ErdosRosenfeldQuestion`
+predicate.
 
-    The coloring must be proper (adjacent subsets get different colors)
-    and "rainbow" on each (k+1)-subset. -/
-/-
 ## Part V: Known Results
 -/
 
 /-- **Base case k=2:**
-    χ(J(4,2)) = 3 = k+1. The Erdős-Rosenfeld property holds trivially. -/
+    χ(J(4,2)) = 3 = k+1.  The Erdős-Rosenfeld property holds: color the six
+    2-subsets of {1,2,3,4} by the three perfect matchings of K₄
+    ({1,2},{3,4} ↦ 0; {1,3},{2,4} ↦ 1; {1,4},{2,3} ↦ 2).  Each 3-subset
+    contains exactly one edge from each matching, hence sees all three colors. -/
 theorem k_equals_2 : ErdosRosenfeldQuestion 2 := by
-  use fun S => ⟨0, by omega⟩  -- Simplified; actual construction exists
-  intro A hA hCard c
-  sorry  -- The 6 edges of K₄ can be 3-colored properly
+  classical
+  refine ⟨fun S => if S.val = ({1,3}:Finset ℕ) ∨ S.val = ({2,4}:Finset ℕ) then 1
+                   else if S.val = ({1,4}:Finset ℕ) ∨ S.val = ({2,3}:Finset ℕ) then 2
+                   else 0, ?_⟩
+  intro A hA hcard c
+  have hbase : baseSet (2*2) = ({1,2,3,4} : Finset ℕ) := by decide
+  rw [hbase] at hA
+  have hmem : A ∈ (({1,2,3,4}:Finset ℕ).powersetCard 3) :=
+    Finset.mem_powersetCard.mpr ⟨hA, hcard⟩
+  fin_cases hmem <;> fin_cases c <;>
+    first
+      | exact ⟨⟨{1, 2}, by decide⟩, by decide, by decide⟩
+      | exact ⟨⟨{3, 4}, by decide⟩, by decide, by decide⟩
+      | exact ⟨⟨{1, 3}, by decide⟩, by decide, by decide⟩
+      | exact ⟨⟨{2, 4}, by decide⟩, by decide, by decide⟩
+      | exact ⟨⟨{1, 4}, by decide⟩, by decide, by decide⟩
+      | exact ⟨⟨{2, 3}, by decide⟩, by decide, by decide⟩
 
 /-- **Case k=3:** χ(J(6,3)) = 4 > 3+1. FAILS. -/
 axiom k_equals_3_fails : ¬ErdosRosenfeldQuestion 3
@@ -120,12 +157,10 @@ axiom k_equals_8_fails : ¬ErdosRosenfeldQuestion 8
 
 /-
 ## Part VI: Chromatic Number Bounds
--/
 
-/-- **Lower bound:** χ(J(2k,k)) ≥ k+1 for all k. -/
-/-- **Upper bound:** χ(J(2k,k)) ≤ 2k for all k. -/
-/-- **Computed values:** Known chromatic numbers of J(2k,k). -/
-/-
+Informally, χ(J(2k,k)) ≥ k+1 (lower bound), χ(J(2k,k)) ≤ 2k (upper bound), and the
+exact computed values for small `k` underlie the case axioms above.
+
 ## Part VII: The Answer
 -/
 

--- a/research/problems/erdos-835-incomplete-01/knowledge.md
+++ b/research/problems/erdos-835-incomplete-01/knowledge.md
@@ -20,3 +20,36 @@ erdos-11-wip-01 (PR #27788) this session.
 ### Next Steps
 - Erdős #835 main question is SOLVED (answer NO, 3≤k≤8); the scaffold's two sorries
   (chromatic-number def + k=2 construction) remain in `Erdos835Problem.lean`, not this file.
+
+## Session 2026-06-23 (researcher-3) — REVISIT: repaired sibling scaffold
+
+**Mode**: REVISIT (pool re-served completed slug). **Outcome**: progress —
+fixed the broken sibling file `Erdos835Problem.lean` (gallery slug `erdos-835`)
+and proved its k=2 case.
+
+### Finding
+`proofs/Proofs/Erdos835Problem.lean` was **registered in `Proofs.lean` but did
+not compile** — a build-integrity hole. Errors: baseSet embedding `by intro; omega`
+failed, `JohnsonGraph.loopless` unprovable for k=0 (johnsonAdj had no S≠T clause),
+`chromaticNumber`'s `Nat.find` lacked `DecidablePred`, three orphan `/--` doc
+comments (parse errors), and `interval_cases`/`fin_cases` unavailable under the
+narrow import set. Gallery meta (`erdos-835`) recorded 2 sorries.
+
+### What I Did
+- `import Mathlib` (was three narrow modules; tactics now resolve).
+- baseSet embedding → `add_left_injective 1`.
+- `johnsonAdj` now requires `S.val ≠ T.val` (irreflexive for all k) → loopless trivial.
+- Added `kSubsetsFintype` instance (via `Fintype.subtype` over `powersetCard`),
+  letting `chromaticNumber` use `colorable_of_fintype` as the `Nat.find` witness
+  (replaces the def-sorry); wrapped in `classical` for `DecidablePred`.
+- **Proved `k_equals_2`** (was a sorry with a mathematically-wrong constant-0
+  colouring): perfect-matching 3-colouring of K₄; enumerate the four 3-subsets via
+  `powersetCard` + `fin_cases`, discharge each colour by `decide`.
+- Kept the 6 computational axioms (k=3..8 — χ(J(2k,k))>k+1, out of kernel reach).
+- Updated `src/data/proofs/erdos-835/{meta.json,annotations.json}`: sorries 2→0,
+  lineCount 177→212, defs 10→11, realigned 21 annotations, fixed assumptions text.
+
+### Result
+`Erdos835Problem.lean` compiles clean (EXIT 0); `#print axioms k_equals_2` /
+`chromaticNumber` = standard triple only (kernel `decide`, no ofReduceBool/sorryAx).
+File status stays `axiomatized` (6 axioms) but now 0 sorries and actually builds.

--- a/src/data/proofs/erdos-835/annotations.json
+++ b/src/data/proofs/erdos-835/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "erdos-835",
     "range": {
       "startLine": 1,
-      "endLine": 26
+      "endLine": 34
     },
     "type": "concept",
     "title": "Problem Overview",
@@ -27,12 +27,12 @@
     "id": "ann-835-imports",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 28,
-      "endLine": 34
+      "startLine": 36,
+      "endLine": 36
     },
     "type": "concept",
     "title": "Imports and Setup",
-    "content": "Imports Mathlib's SimpleGraph.Coloring for proper graph colorings, Finset.Basic for finite set operations, and Fintype.Card for cardinality. Opens the Finset namespace for convenient access to set operations.",
+    "content": "Imports the full Mathlib library, providing SimpleGraph.Coloring for proper graph colorings, Finset/Fintype machinery for finite sets and cardinality, and the tactic suite (fin_cases, decide, interval_cases) used in the proofs. Opens the Finset namespace for convenient access to set operations.",
     "mathContext": "The formalization uses `SimpleGraph.Coloring` which provides $\\text{Coloring}(G, \\alpha) := \\{f : V \\to \\alpha \\mid \\forall u \\sim v,\\, f(u) \\neq f(v)\\}$ as a subtype of vertex-to-color functions.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -49,8 +49,8 @@
     "id": "ann-835-baseset",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 40,
-      "endLine": 41
+      "startLine": 46,
+      "endLine": 47
     },
     "type": "definition",
     "title": "Base Set {1,...,n}",
@@ -71,8 +71,8 @@
     "id": "ann-835-ksubsets",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 43,
-      "endLine": 44
+      "startLine": 49,
+      "endLine": 50
     },
     "type": "definition",
     "title": "k-Subsets Type",
@@ -95,12 +95,12 @@
     "id": "ann-835-johnson-adj",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 46,
-      "endLine": 48
+      "startLine": 58,
+      "endLine": 62
     },
     "type": "definition",
     "title": "Johnson Adjacency",
-    "content": "Two k-subsets S, T are adjacent in J(n,k) if their intersection has cardinality k-1, meaning they differ by exactly one element. Each vertex has degree k(n-k): there are k choices for the element to remove and n-k choices for the replacement.",
+    "content": "Two k-subsets S, T are adjacent in J(n,k) when they are distinct and their intersection has cardinality k-1, i.e. they differ by exactly one element. The explicit distinctness clause makes the relation irreflexive for every k (including k=0), so it yields a genuine SimpleGraph. Each vertex has degree k(n-k): k choices for the element to remove and n-k for the replacement.",
     "mathContext": "$S \\sim T$ in $J(n,k)$ iff $|S \\cap T| = k - 1$, equivalently $|S \\triangle T| = 2$. Each vertex has degree $k(n-k)$, so $J(2k,k)$ is $k^2$-regular.",
     "significance": "key",
     "relatedConcepts": [
@@ -119,8 +119,8 @@
     "id": "ann-835-johnson-graph",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 50,
-      "endLine": 54
+      "startLine": 64,
+      "endLine": 71
     },
     "type": "definition",
     "title": "Johnson Graph J(n,k)",
@@ -143,8 +143,8 @@
     "id": "ann-835-coloring",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 60,
-      "endLine": 62
+      "startLine": 77,
+      "endLine": 79
     },
     "type": "definition",
     "title": "Proper Coloring",
@@ -167,8 +167,8 @@
     "id": "ann-835-chromatic",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 64,
-      "endLine": 66
+      "startLine": 81,
+      "endLine": 87
     },
     "type": "definition",
     "title": "Chromatic Number",
@@ -191,8 +191,8 @@
     "id": "ann-835-property",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 72,
-      "endLine": 76
+      "startLine": 93,
+      "endLine": 97
     },
     "type": "definition",
     "title": "Erdős-Rosenfeld Rainbow Property",
@@ -215,8 +215,8 @@
     "id": "ann-835-question",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 78,
-      "endLine": 80
+      "startLine": 99,
+      "endLine": 101
     },
     "type": "definition",
     "title": "The Erdős-Rosenfeld Question",
@@ -237,8 +237,8 @@
     "id": "ann-835-equiv",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 91,
-      "endLine": 93
+      "startLine": 103,
+      "endLine": 110
     },
     "type": "concept",
     "title": "Equivalence to Chromatic Number",
@@ -260,12 +260,12 @@
     "id": "ann-835-k2",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 99,
-      "endLine": 104
+      "startLine": 115,
+      "endLine": 137
     },
     "type": "concept",
     "title": "Base Case k = 2",
-    "content": "The base case k = 2 works: J(4,2) has 6 vertices (the 2-subsets of {1,2,3,4}) and is isomorphic to the octahedron graph (complement of 3K_2). Its chromatic number is 3 = k+1, and a proper 3-coloring satisfies the rainbow property. The constructive proof provides a witness coloring.",
+    "content": "The base case k = 2 is fully proved (no sorry). J(4,2) has 6 vertices (the 2-subsets of {1,2,3,4}). The witness colouring uses the three perfect matchings of K_4: {1,2},{3,4} -> 0; {1,3},{2,4} -> 1; {1,4},{2,3} -> 2. Every 3-subset A of {1,2,3,4} contains exactly one edge from each matching, so all three colours appear among its 2-subsets, establishing the Erdős-Rosenfeld rainbow property. The proof enumerates the four 3-subsets via powersetCard and discharges each colour by decide.",
     "mathContext": "$J(4,2) \\cong \\overline{3K_2}$ (octahedron), $\\chi(J(4,2)) = 3 = 2 + 1$. The 6 vertices are $\\{12, 13, 14, 23, 24, 34\\}$ and a valid coloring assigns complementary pairs the same color.",
     "significance": "key",
     "relatedConcepts": [
@@ -283,8 +283,8 @@
     "id": "ann-835-k3",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 106,
-      "endLine": 107
+      "startLine": 139,
+      "endLine": 140
     },
     "type": "concept",
     "title": "Case k = 3: Failure",
@@ -306,8 +306,8 @@
     "id": "ann-835-k4-k5",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 109,
-      "endLine": 113
+      "startLine": 142,
+      "endLine": 146
     },
     "type": "concept",
     "title": "Cases k = 4, 5: Clear Failure",
@@ -328,8 +328,8 @@
     "id": "ann-835-k6",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 115,
-      "endLine": 117
+      "startLine": 148,
+      "endLine": 150
     },
     "type": "concept",
     "title": "Case k = 6: Erdős-Rosenfeld 'Not Sure'",
@@ -350,8 +350,8 @@
     "id": "ann-835-k7-k8",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 119,
-      "endLine": 123
+      "startLine": 152,
+      "endLine": 156
     },
     "type": "concept",
     "title": "Cases k = 7, 8: Largest Verified",
@@ -372,8 +372,8 @@
     "id": "ann-835-lower-bound",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 129,
-      "endLine": 131
+      "startLine": 158,
+      "endLine": 162
     },
     "type": "concept",
     "title": "Lower Bound χ >= k+1",
@@ -395,8 +395,8 @@
     "id": "ann-835-upper-bound",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 133,
-      "endLine": 135
+      "startLine": 158,
+      "endLine": 162
     },
     "type": "concept",
     "title": "Upper Bound χ <= 2k",
@@ -417,8 +417,8 @@
     "id": "ann-835-values",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 137,
-      "endLine": 145
+      "startLine": 158,
+      "endLine": 162
     },
     "type": "concept",
     "title": "Known Chromatic Number Table",
@@ -439,8 +439,8 @@
     "id": "ann-835-main",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 160,
-      "endLine": 169
+      "startLine": 167,
+      "endLine": 185
     },
     "type": "concept",
     "title": "Main Theorem: erdos_835",
@@ -462,8 +462,8 @@
     "id": "ann-835-unique",
     "proofId": "erdos-835",
     "range": {
-      "startLine": 171,
-      "endLine": 177
+      "startLine": 187,
+      "endLine": 198
     },
     "type": "concept",
     "title": "Uniqueness of k = 2",

--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 835,
     "erdosUrl": "https://erdosproblems.com/835",
     "erdosProblemStatus": "solved",
@@ -41,13 +41,14 @@
       "kSubsets: k-subsets type",
       "ErdosRosenfeldQuestion: formal statement",
       "chromaticNumber: chromatic number definition",
-      "Known results for k=3 through k=8"
+      "Known results for k=3 through k=8",
+      "k_equals_2: explicit perfect-matching 3-colouring of J(4,2) (proved, 0 sorries)"
     ],
     "axiomCount": 6,
-    "lineCount": 177,
-    "assumptions": "6 axioms: k_equals_3_fails, k_equals_4_fails, k_equals_5_fails, k_equals_6_fails, k_equals_7_fails, k_equals_8_fails. 2 sorries.",
+    "lineCount": 212,
+    "assumptions": "6 axioms encoding the computational solution (χ(J(2k,k)) > k+1): k_equals_3_fails, k_equals_4_fails, k_equals_5_fails, k_equals_6_fails, k_equals_7_fails, k_equals_8_fails. 0 sorries: the k=2 construction and all structural definitions are fully proved (kernel-checked, standard axioms only).",
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős and Moshe Rosenfeld. It connects to the broader theory of Johnson graphs $J(n,k)$, named after Selmer M. Johnson who studied them in the context of error-correcting codes in the 1960s. Johnson graphs are a fundamental family in algebraic graph theory — they are distance-transitive and their eigenvalues are given by Eberlein polynomials (dual Hahn polynomials). The chromatic number question for Johnson graphs relates to the Kneser graph framework: the Kneser graph $K(n,k)$ has the same vertex set but connects disjoint (rather than nearly-equal) subsets. Lovász's celebrated 1978 proof that $\\chi(K(n,k)) = n - 2k + 2$ using algebraic topology was a landmark of topological combinatorics, but the Johnson graph chromatic problem is structurally different and resists similar techniques. Erdős and Rosenfeld specifically asked whether the $k$-subsets of $\\{1,\\ldots,2k\\}$ can be $(k+1)$-colored so that every $(k+1)$-subset sees all colors — a 'rainbow' condition equivalent to $\\chi(J(2k,k)) = k + 1$. Computational verification (for $3 \\leq k \\leq 8$) shows the answer is NO: the chromatic number always exceeds $k+1$ except for the trivial case $k = 2$.",
@@ -145,20 +146,18 @@
   },
   "leanFile": {
     "imports": [
-      "Mathlib.Combinatorics.SimpleGraph.Coloring",
-      "Mathlib.Data.Finset.Basic",
-      "Mathlib.Data.Fintype.Card"
+      "Mathlib"
     ],
     "opens": [
       "Finset"
     ],
     "namespace": "Erdos835",
-    "lineCount": 177,
+    "lineCount": 212,
     "axiomCount": 6,
     "theoremCount": 3,
-    "definitionCount": 10,
+    "definitionCount": 11,
     "path": "Proofs/Erdos835Problem.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "references": [
     {
@@ -184,5 +183,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos835Problem.lean` (gallery slug `erdos-835`) was **registered in `Proofs.lean` but did not compile** — a build-integrity hole. This PR makes it compile cleanly and replaces the placeholder k=2 sorry with a real proof.

## The breakage
The committed file had: a `baseSet` embedding proof (`by intro; omega`) that fails, `JohnsonGraph.loopless` that is unprovable for k=0 (the adjacency had no `S ≠ T` clause), `chromaticNumber`'s `Nat.find` with no `DecidablePred` instance, three orphan `/-- … -/` doc comments causing parse errors, and `interval_cases`/`fin_cases` unavailable under the narrow import set. The gallery `meta.json` also recorded 2 sorries.

## Fixes
- `import Mathlib` (was three narrow modules) so the tactic suite resolves.
- `baseSet` embedding → `add_left_injective 1`.
- `johnsonAdj` now requires `S.val ≠ T.val` (irreflexive for **all** k, incl. k=0) → `loopless` is trivial; this is the mathematically correct Johnson adjacency.
- Added `kSubsetsFintype` instance (`Fintype.subtype` over `(baseSet n).powersetCard k`); `chromaticNumber` now uses `(JohnsonGraph n k).colorable_of_fintype` as the `Nat.find` witness (removes the def-sorry), wrapped in `classical`.
- **Proved `k_equals_2`** — previously a `sorry` sitting on a *mathematically wrong* constant-0 colouring. New witness: the three perfect matchings of K₄ ({1,2},{3,4}↦0; {1,3},{2,4}↦1; {1,4},{2,3}↦2). Each 3-subset contains one edge per matching, so all three colours appear. Proof enumerates the four 3-subsets via `powersetCard` + `fin_cases` and discharges each colour by kernel `decide`.
- Kept the 6 computational axioms (k=3..8: χ(J(2k,k)) > k+1) — out of kernel reach.

## Verification
- `lake env lean Proofs/Erdos835Problem.lean` → EXIT 0 (clean).
- `#print axioms k_equals_2` and `#print axioms chromaticNumber` = `[propext, Classical.choice, Quot.sound]` only (kernel `decide`, **no** `Lean.ofReduceBool`/`sorryAx`).

## Status
**Outcome**: progress (integrity repair + k=2 proof). File stays `axiomatized` (6 axioms) — honest — but now **0 sorries** and **actually builds**. Updated `meta.json`/`annotations.json` (sorries 2→0, lineCount 177→212, defs 10→11, 21 annotations realigned).

**Next Steps**: the 6 case axioms remain (genuine computational facts; formalizing in-kernel needs enumerating colourings of graphs up to C(16,8)=12870 vertices).

🤖 Generated by researcher-3