### PR TITLE
research(erdos-128-wip-01-oq-01-oq-01): clique-freeness pulls back along homomorphisms; every C₅-blow-up is K_r-free for all r ≥ 3 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1409,6 +1409,7 @@ import Proofs.Erdos126Problem
 import Proofs.Erdos127Problem
 import Proofs.Erdos128Problem
 import Proofs.Erdos128WIP01OQ01
+import Proofs.Erdos128WIP01OQ01OQ01
 import Proofs.Erdos129Problem
 import Proofs.Erdos12Problem
 import Proofs.Erdos12ProblemAPNPartI

--- a/proofs/Proofs/Erdos128WIP01OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos128WIP01OQ01OQ01.lean
@@ -1,0 +1,214 @@
+import Mathlib
+
+/-
+# Erdős #128 — clique-freeness pulls back along graph homomorphisms
+# (erdos-128-wip-01-oq-01-oq-01)
+
+## The Problem
+
+**Erdős Problem #128** ($250, OPEN). If every induced subgraph of an `n`-vertex
+graph `G` on `≥ ⌊n/2⌋` vertices has more than `n²/50` edges, must `G` contain a
+triangle? The constant `1/50` is conjectured optimal, witnessed by **blow-ups of
+`C₅`**, which are triangle-free with induced density `> 1/50` at every scale.
+
+The parent chain established that triangle-freeness is **hereditary** under induced
+subgraphs (`Erdos128WIP01.lean`) and, more sharply, that triangle-freeness pulls
+back along **arbitrary graph homomorphisms** (`triangleFree_of_hom` in
+`Erdos128WIP01OQ01.lean`), so blow-ups of `C₅` are triangle-free at every scale.
+
+This file lifts that homomorphism-pullback principle from triangles to **`K_r`-cliques
+of every order `r`**, and shows the triangle theory is the case `r = 3`.
+
+## Result
+
+Working in a self-contained re-declaration of the parent's `Graph` objects:
+
+1. `cliqueFree_of_hom` — **`K_r`-freeness pulls back along homomorphisms**, for every
+   `r`. If there is a graph homomorphism `f : G → H` and `H` has no `r`-clique, then
+   neither does `G`. (Irreflexivity of `H` makes the images of a `G`-clique distinct,
+   hence a genuine `H`-clique.) The parent `triangleFree_of_hom` is the case `r = 3`.
+
+2. `hasClique_mono` / `cliqueFree_mono` — clique-freeness is **monotone in the order**:
+   a smaller clique sits inside a larger one, so `K_m`-freeness forces `K_r`-freeness
+   for every `r ≥ m`. In particular triangle-free (`K_3`-free) ⟹ `K_r`-free for all
+   `r ≥ 3`.
+
+3. `hasTriangle_iff_hasClique_three` and `triangleFree_iff_cliqueFree_three` — the
+   **bridge** identifying the parent's `hasTriangle` / `triangleFree` with the `r = 3`
+   case of the clique predicates, recovering `triangleFree_of_hom` as a corollary.
+
+4. `blowup_cliqueFree` — every blow-up of a `K_r`-free graph is `K_r`-free.
+
+5. `C5_cliqueFree` — `C₅` has no `r`-clique for any `r ≥ 3`, and hence
+   `blowup_C5_cliqueFree` — **every blow-up of `C₅` is `K_r`-free for all `r ≥ 3`**, at
+   every size. This is the clique-order-uniform strengthening of the extremal
+   construction's triangle-freeness.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos128WIP01OQ01OQ01
+
+/-- A simple graph on `n` vertices. -/
+structure Graph (n : ℕ) where
+  adj : Fin n → Fin n → Prop
+  symm : ∀ u v, adj u v → adj v u
+  irrefl : ∀ v, ¬ adj v v
+
+/-- `G` contains a triangle: three distinct, mutually adjacent vertices. -/
+def Graph.hasTriangle {n : ℕ} (G : Graph n) : Prop :=
+  ∃ u v w : Fin n, u ≠ v ∧ v ≠ w ∧ u ≠ w ∧
+    G.adj u v ∧ G.adj v w ∧ G.adj u w
+
+/-- `G` is triangle-free. -/
+def Graph.triangleFree {n : ℕ} (G : Graph n) : Prop := ¬ G.hasTriangle
+
+/-- `G` contains an **`r`-clique**: an injective family of `r` vertices that are
+    pairwise adjacent. The injection records the `r` distinct vertices; pairwise
+    adjacency of distinct indices is the clique condition. -/
+def Graph.hasClique {n : ℕ} (G : Graph n) (r : ℕ) : Prop :=
+  ∃ s : Fin r → Fin n, Function.Injective s ∧ ∀ i j, i ≠ j → G.adj (s i) (s j)
+
+/-- `G` is **`K_r`-free**: it has no `r`-clique. -/
+def Graph.cliqueFree {n : ℕ} (G : Graph n) (r : ℕ) : Prop := ¬ G.hasClique r
+
+/-- A **graph homomorphism** `f : G → H`: it carries adjacent vertices to adjacent
+    vertices. (No injectivity or surjectivity is required.) -/
+def IsHom {n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k) : Prop :=
+  ∀ u v, G.adj u v → H.adj (f u) (f v)
+
+/-- **`K_r`-freeness pulls back along graph homomorphisms.** If there is a
+    homomorphism `f : G → H` and `H` is `K_r`-free, then so is `G`.
+
+    Given an `r`-clique `s` of `G`, the composite `f ∘ s` is an `r`-clique of `H`:
+    its entries are pairwise adjacent because `f` preserves edges, and they are
+    distinct because `H` is irreflexive — two equal images would be an `H`-loop. This
+    generalises `triangleFree_of_hom` (the case `r = 3`) from the parent file. -/
+theorem cliqueFree_of_hom {n k r : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k)
+    (hf : IsHom G H f) (hH : H.cliqueFree r) : G.cliqueFree r := by
+  rintro ⟨s, hinj, hadj⟩
+  apply hH
+  refine ⟨f ∘ s, ?_, ?_⟩
+  · intro a b hab
+    simp only [Function.comp_apply] at hab
+    by_contra hne
+    have hedge := hf (s a) (s b) (hadj a b hne)
+    rw [hab] at hedge
+    exact H.irrefl (f (s b)) hedge
+  · intro i j hij
+    simp only [Function.comp_apply]
+    exact hf (s i) (s j) (hadj i j hij)
+
+/-- **Clique-freeness is monotone in the order.** A `K_r`-clique restricts to a
+    `K_m`-clique whenever `m ≤ r` (take the first `m` of its `r` vertices), so the
+    existence of an `r`-clique entails an `m`-clique. -/
+theorem hasClique_mono {n : ℕ} (G : Graph n) {m r : ℕ} (hmr : m ≤ r)
+    (h : G.hasClique r) : G.hasClique m := by
+  obtain ⟨s, hinj, hadj⟩ := h
+  refine ⟨s ∘ Fin.castLE hmr, hinj.comp (Fin.castLE_injective hmr), ?_⟩
+  intro i j hij
+  simp only [Function.comp_apply]
+  exact hadj _ _ (fun heq => hij (Fin.castLE_injective hmr heq))
+
+/-- **`K_m`-freeness forces `K_r`-freeness for every `r ≥ m`.** Contrapositive of
+    `hasClique_mono`: if there were an `r`-clique it would contain an `m`-clique. -/
+theorem cliqueFree_mono {n : ℕ} (G : Graph n) {m r : ℕ} (hmr : m ≤ r)
+    (h : G.cliqueFree m) : G.cliqueFree r :=
+  fun hr => h (hasClique_mono G hmr hr)
+
+/-- An explicit triple `Fin 3 → Fin n` used to package a triangle as a `3`-clique. -/
+def triple {n : ℕ} (u v w : Fin n) : Fin 3 → Fin n :=
+  fun i => if i = 0 then u else if i = 1 then v else w
+
+/-- **A triangle is exactly a `3`-clique.** The two formulations of "three distinct
+    mutually adjacent vertices" agree. -/
+theorem hasTriangle_iff_hasClique_three {n : ℕ} (G : Graph n) :
+    G.hasTriangle ↔ G.hasClique 3 := by
+  constructor
+  · rintro ⟨u, v, w, huv, hvw, huw, auv, avw, auw⟩
+    refine ⟨triple u v w, ?_, ?_⟩
+    · intro i j h
+      fin_cases i <;> fin_cases j <;> simp_all [triple]
+    · have avu := G.symm _ _ auv
+      have awv := G.symm _ _ avw
+      have awu := G.symm _ _ auw
+      intro i j hij
+      fin_cases i <;> fin_cases j <;> simp_all [triple]
+  · rintro ⟨s, hinj, hadj⟩
+    exact ⟨s 0, s 1, s 2,
+      fun h => absurd (hinj h) (by decide),
+      fun h => absurd (hinj h) (by decide),
+      fun h => absurd (hinj h) (by decide),
+      hadj 0 1 (by decide), hadj 1 2 (by decide), hadj 0 2 (by decide)⟩
+
+/-- **Triangle-freeness is `K_3`-freeness.** -/
+theorem triangleFree_iff_cliqueFree_three {n : ℕ} (G : Graph n) :
+    G.triangleFree ↔ G.cliqueFree 3 :=
+  not_congr (hasTriangle_iff_hasClique_three G)
+
+/-- **Triangle-freeness pulls back along homomorphisms** — recovered as the `r = 3`
+    case of `cliqueFree_of_hom` via the bridge, reproducing the parent result. -/
+theorem triangleFree_of_hom {n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k)
+    (hf : IsHom G H f) (hH : H.triangleFree) : G.triangleFree :=
+  (triangleFree_iff_cliqueFree_three G).2
+    (cliqueFree_of_hom G H f hf ((triangleFree_iff_cliqueFree_three H).1 hH))
+
+/-- The **blow-up** of a base graph `H` along a class map `c : Fin n → Fin k`: two
+    vertices are adjacent exactly when their classes are adjacent in `H`. -/
+def blowup {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) : Graph n where
+  adj u v := H.adj (c u) (c v)
+  symm u v h := H.symm (c u) (c v) h
+  irrefl v h := H.irrefl (c v) h
+
+/-- The class map of a blow-up is a graph homomorphism `blowup H c → H`. -/
+theorem blowup_isHom {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) :
+    IsHom (blowup H c) H c := fun u v h => h
+
+/-- **Every blow-up of a `K_r`-free graph is `K_r`-free.** -/
+theorem blowup_cliqueFree {n k r : ℕ} (H : Graph k) (c : Fin n → Fin k)
+    (hH : H.cliqueFree r) : (blowup H c).cliqueFree r :=
+  cliqueFree_of_hom (blowup H c) H c (blowup_isHom H c) hH
+
+/-- The **5-cycle `C₅`** on `Fin 5`: `i ~ j` iff they are one step apart around the
+    cycle (modulo 5). -/
+def C5 : Graph 5 where
+  adj i j := i + 1 = j ∨ j + 1 = i
+  symm u v h := h.symm
+  irrefl := by decide
+
+/-- **`C₅` is triangle-free** (decision procedure over `Fin 5`, not `native_decide`). -/
+theorem C5_triangleFree : C5.triangleFree := by
+  unfold Graph.triangleFree Graph.hasTriangle C5
+  decide
+
+/-- **`C₅` is `K_r`-free for every `r ≥ 3`.** It is triangle-free, and clique-freeness
+    is monotone in the order. -/
+theorem C5_cliqueFree {r : ℕ} (hr : 3 ≤ r) : C5.cliqueFree r :=
+  cliqueFree_mono C5 hr ((triangleFree_iff_cliqueFree_three C5).1 C5_triangleFree)
+
+/-- **Every blow-up of `C₅` is `K_r`-free for all `r ≥ 3`**, at every size `n` and for
+    every class assignment `c : Fin n → Fin 5`. The conjectured-optimal extremal
+    construction for Erdős #128 contains no clique of any order `≥ 3` — a strengthening,
+    uniform in clique order, of its triangle-freeness. -/
+theorem blowup_C5_cliqueFree {n r : ℕ} (c : Fin n → Fin 5) (hr : 3 ≤ r) :
+    (blowup C5 c).cliqueFree r :=
+  blowup_cliqueFree C5 c (C5_cliqueFree hr)
+
+/-
+## Significance
+
+Erdős #128 asks whether density on every large induced subgraph forces a triangle; its
+conjecturally optimal constant `1/50` is witnessed by blow-ups of `C₅`. The parent chain
+showed triangle-freeness is hereditary and, sharper, homomorphism-monotone. This file
+lifts the homomorphism-pullback principle from triangles to cliques of **every order**:
+`cliqueFree_of_hom` shows `K_r`-freeness pulls back along any homomorphism, and
+`cliqueFree_mono` shows clique-freeness is monotone in `r`. Together with the bridge
+`triangleFree_iff_cliqueFree_three` (which recovers the parent's `triangleFree_of_hom`),
+they yield `blowup_C5_cliqueFree`: the extremal `C₅`-blow-ups contain no clique of any
+order `≥ 3`, at every scale. The remaining analytic content — that these blow-ups
+achieve induced density `> 1/50`, and that this constant is optimal — stays open.
+-/
+
+end Erdos128WIP01OQ01OQ01

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "erdos128-wip01oq01oq01-ann-header",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 48 },
+    "type": "context",
+    "title": "From triangles to cliques of every order",
+    "content": "Erdős Problem #128 ($250, open) asks whether a uniform edge-density condition on all large induced subgraphs forces a triangle; the conjectured-optimal constant 1/50 is witnessed by blow-ups of C₅. The parent entry proved triangle-freeness pulls back along arbitrary graph homomorphisms. This entry answers that parent's stated open question by lifting the pullback principle from triangles to K_r-cliques of every order r, adds clique-order monotonicity, and recovers the parent's triangle theorem as the case r = 3.",
+    "mathContext": "Conjectured optimal constant $1/50$; witnesses are blow-ups of $C_5$, shown here to be $K_r$-free for every $r \\ge 3$.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey–Turán theory", "clique-free graphs", "graph homomorphism", "C₅ blow-up"],
+    "prerequisites": ["graph theory", "extremal combinatorics"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01-ann-clique",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 75 },
+    "type": "definition",
+    "title": "r-clique and K_r-freeness",
+    "content": "An r-clique is recorded as an injective family s : Fin r → Fin n of vertices that are pairwise adjacent at distinct indices; the injection fixes the r distinct vertices and the adjacency condition makes them mutually joined. A graph is K_r-free when it has no r-clique. Encoding a clique as an injective Fin r → Fin n map is what makes the homomorphism-pullback argument a one-line composition with f.",
+    "mathContext": "$\\exists s : \\mathrm{Fin}\\,r \\to \\mathrm{Fin}\\,n,\\ \\mathrm{Injective}\\,s \\wedge \\forall i\\,j,\\ i \\ne j \\Rightarrow G.\\mathrm{adj}\\,(s\\,i)\\,(s\\,j)$.",
+    "significance": "standard",
+    "relatedConcepts": ["clique", "complete subgraph", "K_r"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01-ann-pullback",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 104 },
+    "type": "key-step",
+    "title": "K_r-freeness pulls back along homomorphisms",
+    "content": "If there is a homomorphism f : G → H and H is K_r-free, then so is G. Given an r-clique s of G, the composite f ∘ s is pairwise adjacent in H because f preserves edges, and it is injective because H is irreflexive: if f (s a) = f (s b) for a ≠ b then the G-edge s a ~ s b maps to an H-loop, which is impossible. So f ∘ s is an r-clique of H, contradicting K_r-freeness. The argument never used the number 3 — it works verbatim for every clique order, strictly generalizing the parent's triangleFree_of_hom.",
+    "mathContext": "$f : G \\to H$ a homomorphism, $H$ $K_r$-free $\\Rightarrow$ $G$ $K_r$-free; injectivity of $f \\circ s$ from irreflexivity of $H$.",
+    "significance": "key",
+    "relatedConcepts": ["graph homomorphism", "clique-free graphs", "monotone graph property"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01-ann-monotone",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01",
+    "range": { "startLine": 106, "endLine": 119 },
+    "type": "key-step",
+    "title": "Clique-freeness is monotone in the order",
+    "content": "A K_r-clique restricts to a K_m-clique whenever m ≤ r: compose the clique map with the order-embedding Fin.castLE, which is injective and preserves distinctness, so the first m vertices already form an m-clique (hasClique_mono). Contrapositively, K_m-freeness forces K_r-freeness for every r ≥ m (cliqueFree_mono). In particular a triangle-free graph (K_3-free) is K_r-free for all r ≥ 3 with no further combinatorics.",
+    "mathContext": "$m \\le r$: $G.\\mathrm{hasClique}\\,r \\Rightarrow G.\\mathrm{hasClique}\\,m$ via $s \\circ \\mathrm{Fin.castLE}$; hence $K_m$-free $\\Rightarrow K_r$-free.",
+    "significance": "key",
+    "relatedConcepts": ["clique number", "monotonicity", "Fin.castLE"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01-ann-bridge",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01",
+    "range": { "startLine": 121, "endLine": 156 },
+    "type": "key-step",
+    "title": "Triangles are exactly 3-cliques",
+    "content": "The parent's bespoke triangle predicate is identified with the r = 3 case of the clique predicate (hasTriangle_iff_hasClique_three). The forward direction reads three distinct mutually adjacent vertices off a 3-clique; the backward direction packages a triangle u,v,w as the injective triple Fin 3 → Fin n. Negating gives triangleFree_iff_cliqueFree_three, and the parent's triangleFree_of_hom drops out as a one-line corollary of cliqueFree_of_hom — so the general theorem subsumes the parent result rather than merely resembling it.",
+    "mathContext": "$G.\\mathrm{hasTriangle} \\leftrightarrow G.\\mathrm{hasClique}\\,3$, hence $G.\\mathrm{triangleFree} \\leftrightarrow G.\\mathrm{cliqueFree}\\,3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["triangle", "3-clique", "K_3"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01-ann-blowup-c5",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01",
+    "range": { "startLine": 158, "endLine": 197 },
+    "type": "key-step",
+    "title": "C₅-blow-ups are K_r-free for every r ≥ 3",
+    "content": "A blow-up's class map is a homomorphism, so blow-ups preserve K_r-freeness (blowup_cliqueFree). The concrete 5-cycle C₅ on Fin 5 is triangle-free by the ordinary kernel decision procedure (C5_triangleFree, not native_decide), hence K_r-free for every r ≥ 3 by clique-order monotonicity (C5_cliqueFree). Composing yields blowup_C5_cliqueFree: every blow-up of C₅, at every size n and class assignment c, contains no clique of any order ≥ 3 — a clique-order-uniform strengthening of the extremal construction's triangle-freeness, independent of the open edge-density estimate.",
+    "mathContext": "$C_5$ triangle-free (decide) $\\Rightarrow K_r$-free for $r \\ge 3$ $\\Rightarrow$ every $\\mathrm{blowup}\\,C_5\\,c$ is $K_r$-free for $r \\ge 3$.",
+    "significance": "key",
+    "relatedConcepts": ["C₅ blow-up", "extremal construction", "clique-free graphs"],
+    "prerequisites": ["graph theory", "decidable instances"]
+  }
+]

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos128WIP01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos128Wip01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos128Wip01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos128Wip01Oq01Oq01Data: ProofData = {
+  proof: erdos128Wip01Oq01Oq01Proof,
+  annotations: erdos128Wip01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01/meta.json
@@ -1,0 +1,129 @@
+{
+  "id": "erdos-128-wip-01-oq-01-oq-01",
+  "title": "Erdős #128: clique-freeness pulls back along graph homomorphisms (every C₅-blow-up is K_r-free for all r ≥ 3)",
+  "slug": "erdos-128-wip-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos128WIP01OQ01OQ01",
+    "lineCount": 214,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 8,
+    "path": "Proofs/Erdos128WIP01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Lifts the homomorphism-pullback principle of the parent entry erdos-128-wip-01-oq-01 from triangles to cliques of every order, directly answering that entry's stated open question. The parent proved triangle-freeness pulls back along arbitrary graph homomorphisms; this entry proves cliqueFree_of_hom: for every r, K_r-freeness pulls back along a homomorphism f : G -> H -- if H has no r-clique then neither does G, the r image vertices being forced distinct by H's irreflexivity. It adds hasClique_mono / cliqueFree_mono (clique-freeness is monotone in the order: a K_m-clique sits inside any K_r-clique with m <= r, so K_m-freeness forces K_r-freeness for all r >= m), and the bridge hasTriangle_iff_hasClique_three / triangleFree_iff_cliqueFree_three identifying the parent's triangle predicates with the r = 3 case, which recovers triangleFree_of_hom as a corollary. Blow-ups preserve K_r-freeness (blowup_cliqueFree), and C5 -- being triangle-free (C5_triangleFree, ordinary decision procedure, not native_decide) -- is K_r-free for every r >= 3 (C5_cliqueFree), so every blow-up of C5, at every size and class assignment, is K_r-free for all r >= 3 (blowup_C5_cliqueFree): a clique-order-uniform strengthening of the extremal construction's triangle-freeness. 11 theorems, 8 definitions + 1 structure, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos128WIP01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "extremal-graph-theory",
+      "triangle-free",
+      "clique-free",
+      "graph-homomorphism",
+      "ramsey-turan",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with `lake env lean Proofs/Erdos128WIP01OQ01OQ01.lean` (Lean v4.26.0, Mathlib pin): compiles with 0 errors. 0 sorries, 0 axiom declarations, no native_decide. #print axioms reports: cliqueFree_of_hom depends on no axioms at all; C5_cliqueFree, blowup_C5_cliqueFree, triangleFree_of_hom and hasTriangle_iff_hasClique_three depend only on the standard foundational axioms [propext, Classical.choice, Quot.sound] (the `decide` evaluation of C₅ over Fin 5 is the ordinary kernel decision procedure, NOT native_decide, so Lean.ofReduceBool is not used). Self-contained: the Graph objects are re-declared (the scaffold Erdos128Problem.lean does not build). Honest scope: the structural clique-pullback / clique-monotonicity facts and the K_r-freeness of the C₅-blow-up witnesses, NOT the open optimal-constant question (that these blow-ups achieve induced density > n²/50, and that 1/50 is optimal, remain open).",
+    "lineCount": 214,
+    "theoremCount": 11,
+    "definitionCount": 8,
+    "originalContributions": [
+      "cliqueFree_of_hom: K_r-freeness pulls back along graph homomorphisms, for every clique order r -- if f : G -> H is a homomorphism and H has no r-clique then neither does G; the r image vertices of a G-clique are forced distinct by H's irreflexivity (two equal images would be an H-loop). Strictly generalizes the parent's triangleFree_of_hom, which is the case r = 3.",
+      "hasClique_mono / cliqueFree_mono: clique-freeness is monotone in the order. A K_r-clique restricts to a K_m-clique for m <= r (compose the clique map with Fin.castLE), so K_m-freeness forces K_r-freeness for every r >= m. In particular triangle-free (K_3-free) implies K_r-free for all r >= 3.",
+      "hasTriangle_iff_hasClique_three / triangleFree_iff_cliqueFree_three: the bridge identifying the parent's hasTriangle / triangleFree with the r = 3 case of the clique predicates. The backward direction packages a triangle as an injective triple via an explicit map (triple); the forward direction reads three distinct mutually adjacent vertices off a 3-clique. This recovers triangleFree_of_hom as a corollary of cliqueFree_of_hom.",
+      "blowup_cliqueFree: every blow-up of a K_r-free graph is K_r-free, for every r (corollary of cliqueFree_of_hom applied to the class map).",
+      "C5_cliqueFree / blowup_C5_cliqueFree: C₅ has no clique of any order r >= 3 (it is triangle-free, and clique-freeness is monotone), hence every blow-up of C₅, at every size n and every class assignment c : Fin n -> Fin 5, is K_r-free for all r >= 3 -- the clique-order-uniform strengthening of the conjectured-optimal extremal construction's triangle-freeness."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #128 is a Ramsey–Turán-type question asking whether a uniform edge-density condition on all large induced subgraphs forces a triangle. The threshold constant 1/50 is conjectured optimal, witnessed by blow-ups of C₅ (and the Petersen graph), which are triangle-free yet have induced-subgraph density about 1/5 > 1/50. A long line of partial results (Erdős-Faudree-Rousseau-Schelp 1/16, Krivelevich, Razborov's flag-algebra 27/1024, Norin-Yepremyan) narrows the constant, but the exact 1/50 remains a $250 open problem. The parent chain isolated the structural reason the witnesses are triangle-free; this entry shows that reason is not special to triangles but holds for cliques of every order.",
+    "problemStatement": "Erdős #128: if every induced subgraph of an n-vertex graph G on >= floor(n/2) vertices has more than n²/50 edges, must G contain a triangle? This entry answers the parent entry's open question by generalizing the homomorphism-pullback principle from triangle-freeness to K_r-freeness for every clique order r, and shows the C₅-blow-up witnesses contain no clique of any order >= 3.",
+    "proofStrategy": "Re-declare the scaffold's Graph objects and define an r-clique as an injective family s : Fin r -> Fin n of pairwise-adjacent vertices. A homomorphism f preserves edges, so f ∘ s is again pairwise adjacent; its entries are distinct because H is irreflexive (equal images would be an H-loop), giving an H-clique of the same order -- hence K_r-freeness pulls back (cliqueFree_of_hom). Composing a clique map with Fin.castLE restricts a K_r-clique to a K_m-clique for m <= r, giving clique-order monotonicity (hasClique_mono / cliqueFree_mono). The triangle predicates are the r = 3 case (bridge via an explicit triple map), recovering triangleFree_of_hom. A blow-up's class map is a homomorphism, so blow-ups preserve K_r-freeness; C₅ is triangle-free by the finite decision procedure and therefore K_r-free for all r >= 3, and blowup_C5_cliqueFree is the composition.",
+    "keyInsights": [
+      "The homomorphism-pullback argument never used the number 3: the same irreflexivity-forces-distinctness step works for an injective family of any size, so K_r-freeness pulls back along homomorphisms for every clique order r.",
+      "Clique-freeness is monotone in the order — a smaller clique embeds in a larger one via Fin.castLE — so a single triangle-freeness fact propagates to K_r-freeness for all r >= 3 with no extra combinatorics.",
+      "Identifying the parent's bespoke triangle predicate with the r = 3 case of the clique predicate makes triangleFree_of_hom a one-line corollary, unifying the parent's result inside the general theorem.",
+      "Consequently the conjectured-optimal extremal witnesses (C₅-blow-ups) contain no clique of ANY order >= 3 at every scale — a structural fact uniform in clique order and independent of the open edge-density estimate."
+    ]
+  },
+  "sections": [
+    {
+      "id": "objects",
+      "title": "Graphs, cliques, and homomorphisms (re-declared)",
+      "summary": "Graph, hasTriangle, triangleFree, the r-clique predicates hasClique / cliqueFree, and the graph-homomorphism predicate IsHom.",
+      "startLine": 55,
+      "endLine": 80,
+      "mathContext": "Self-contained re-declaration; an r-clique is an injective family of r pairwise-adjacent vertices."
+    },
+    {
+      "id": "pullback",
+      "title": "Clique-freeness pulls back along homomorphisms",
+      "summary": "cliqueFree_of_hom: a homomorphism into a K_r-free graph forces K_r-freeness; the r image vertices are distinct by irreflexivity.",
+      "startLine": 89,
+      "endLine": 104,
+      "mathContext": "Generalizes the parent's triangleFree_of_hom (the case r = 3) to every clique order."
+    },
+    {
+      "id": "monotone",
+      "title": "Clique-freeness is monotone in the order",
+      "summary": "hasClique_mono / cliqueFree_mono: a K_r-clique restricts to a K_m-clique for m <= r, so K_m-freeness forces K_r-freeness for r >= m.",
+      "startLine": 107,
+      "endLine": 119,
+      "mathContext": "Restriction along Fin.castLE; in particular triangle-free implies K_r-free for all r >= 3."
+    },
+    {
+      "id": "bridge",
+      "title": "Triangles are 3-cliques (recovering the parent)",
+      "summary": "triple, hasTriangle_iff_hasClique_three, triangleFree_iff_cliqueFree_three, and triangleFree_of_hom recovered as the r = 3 corollary.",
+      "startLine": 121,
+      "endLine": 156,
+      "mathContext": "The parent's triangle predicate is exactly the r = 3 clique predicate, so triangleFree_of_hom follows from cliqueFree_of_hom."
+    },
+    {
+      "id": "blowup-c5",
+      "title": "Blow-ups and the C₅ witness, uniform in clique order",
+      "summary": "blowup, blowup_isHom, blowup_cliqueFree, C5, C5_triangleFree, C5_cliqueFree, blowup_C5_cliqueFree.",
+      "startLine": 158,
+      "endLine": 197,
+      "mathContext": "C₅ is triangle-free, hence K_r-free for every r >= 3, hence so is every blow-up of it at every scale."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #128 asks whether dense large induced subgraphs force a triangle, with conjectured-optimal constant 1/50 witnessed by C₅-blow-ups. The parent entry isolated the structural reason those witnesses are triangle-free (triangle-freeness pulls back along graph homomorphisms). This entry answers the parent's stated open question by lifting that principle to cliques of every order: cliqueFree_of_hom shows K_r-freeness pulls back along any homomorphism, cliqueFree_mono shows clique-freeness is monotone in r, and the bridge triangleFree_iff_cliqueFree_three recovers the parent's triangleFree_of_hom as the r = 3 case. Concretely, every blow-up of C₅ contains no clique of any order >= 3, at every size and class assignment (blowup_C5_cliqueFree). Self-contained over Mathlib, verified with the ordinary kernel decision procedure (no native_decide), 0 sorries, 0 axioms.",
+    "implications": "The extremal witness family is not merely triangle-free but K_r-free for every r >= 3, by a uniform pullback-plus-monotonicity argument independent of how its edges are counted. Any formal attack on the optimal constant 1/50 thus inherits a reusable foundation whose clique-freeness is established once and for all orders, and the clique-order generalization subsumes both the parent's homomorphism-pullback result and (via the bridge) its hereditary triangle-freeness.",
+    "openQuestions": [
+      "Formalize the edge-density estimate for C₅-blow-ups: that a balanced blow-up has induced-subgraph density > n²/50 on every floor(n/2)-subgraph, completing the lower-bound witness for the 1/50 constant.",
+      "Prove (or formalize a partial result toward) the main question: does density > n²/50 on every floor(n/2)-subgraph force a triangle?",
+      "Generalize beyond cliques to arbitrary forbidden subgraphs: an injective-homomorphism image of any fixed graph F pulls back along homomorphisms into irreflexive targets, of which clique-freeness is the F = K_r case."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-128-wip-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent entry proved triangle-freeness pulls back along arbitrary graph homomorphisms and listed as an open question the generalization to K_r-freeness. This entry proves exactly that (cliqueFree_of_hom), adds clique-order monotonicity, and recovers the parent's triangleFree_of_hom as the r = 3 case via an explicit triangle-as-3-clique bridge."
+    },
+    {
+      "targetId": "erdos-128-wip-01",
+      "relationship": "related",
+      "description": "The grandparent entry proved triangle-freeness is hereditary under induced subgraphs and the edge count is monotone; the clique-pullback theorem here subsumes that hereditary property at every clique order."
+    },
+    {
+      "targetId": "erdos-128",
+      "relationship": "related",
+      "description": "The base Erdős #128 scaffold, whose conjectured-optimal extremal witnesses are the C₅-blow-ups shown here to be K_r-free for every r >= 3."
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-128-wip-01.json
+++ b/src/data/research/problems/erdos-128-wip-01.json
@@ -11,7 +11,7 @@
     "whyMatters": []
   },
   "knowledge": {
-    "progressSummary": "Follow-up entry erdos-128-wip-01-oq-01: proved triangle-freeness pulls back along ARBITRARY graph homomorphisms (triangleFree_of_hom), generalizing the parent hereditary property; defined blow-up as adjacency-pullback along a class map (blowup, blowup_isHom, blowup_triangleFree); proved C5 triangle-free (decide) and hence every C5-blow-up triangle-free at every scale (blowup_C5_triangleFree) -- the triangle-freeness of the conjectured-optimal extremal construction, isolated from the open density estimate. 5 thm/5 def/1 struct, 0 sorries, 0 axioms (propext/Quot.sound only, no native_decide). Kernel-verified via lake env lean.",
+    "progressSummary": "Follow-up chain erdos-128-wip-01-oq-01-oq-01: lifted the parent's homomorphism-pullback of triangle-freeness to K_r-cliques of every order (cliqueFree_of_hom), added clique-order monotonicity (hasClique_mono/cliqueFree_mono), bridged triangles to 3-cliques to recover triangleFree_of_hom, and proved every C5-blow-up is K_r-free for all r>=3 (blowup_C5_cliqueFree) at every scale. 11 thm/8 def/1 struct, 0 sorries, 0 axioms (propext/Classical.choice/Quot.sound only, no native_decide). Kernel-verified via lake env lean.",
     "builtItems": [
       "hasTriangle_induce: induced triangle => ambient triangle",
       "triangleFree_induce: triangle-freeness hereditary",
@@ -19,7 +19,8 @@
       "triangleFree_of_no_edges: empty graph triangle-free",
       "triangleFree_of_hom: triangle-freeness pulls back along graph homomorphisms (Erdos128WIP01OQ01.lean)",
       "blowup + blowup_isHom + blowup_triangleFree: blow-up = pullback of adjacency along class map; class map is a homomorphism",
-      "C5_triangleFree + blowup_C5_triangleFree: C5 triangle-free (decide), hence every C5-blow-up triangle-free at every scale"
+      "C5_triangleFree + blowup_C5_triangleFree: C5 triangle-free (decide), hence every C5-blow-up triangle-free at every scale",
+      "cliqueFree_of_hom + hasClique_mono/cliqueFree_mono + triangleFree_iff_cliqueFree_three + blowup_C5_cliqueFree (Erdos128WIP01OQ01OQ01.lean): K_r-freeness pulls back along homomorphisms for every clique order, clique-freeness monotone in r, parent triangleFree_of_hom recovered as r=3, every C5-blow-up K_r-free for all r>=3"
     ],
     "insights": [
       "Induced adjacency entails ambient adjacency => substructures lift.",
@@ -27,14 +28,16 @@
       "Edge-count monotonicity underlies the density hypothesis denseSubgraphs.",
       "Triangle-freeness is homomorphism-monotone: a homomorphism into a triangle-free graph forces triangle-freeness; the three image vertices are distinct because the target is irreflexive.",
       "Induced subgraphs (identity map) and blow-ups (class map) are both graph homomorphisms, so one pullback theorem subsumes the parents hereditary property and the extremal-witness triangle-freeness.",
-      "The triangle-freeness of the C5-blow-up extremal construction is a purely structural fact, independent of the open edge-density estimate."
+      "The triangle-freeness of the C5-blow-up extremal construction is a purely structural fact, independent of the open edge-density estimate.",
+      "The homomorphism-pullback argument never used the number 3: the same irreflexivity-forces-distinctness step proves K_r-freeness pulls back for every clique order r, so the parent's triangle result is just the r=3 case.",
+      "Clique-freeness is monotone in the order (restrict via Fin.castLE), so one triangle-freeness fact propagates to K_r-freeness for all r>=3 with no extra combinatorics; the C5-blow-up extremal witnesses are thus clique-free of every order, not just triangle-free."
     ],
     "mathlibGaps": [
       "Scaffold Erdos128Problem.lean broken: missing DecidablePred instance for edgeCount filter (G.adj Prop not decidable) + trailing docstrings parse errors."
     ],
     "nextSteps": [
-      "Formalize the edge-density estimate for a balanced C5-blow-up: induced density > n^2/50 on every floor(n/2)-subgraph (the lower-bound witness).",
-      "Generalize triangleFree_of_hom to K_r-freeness pulls back along homomorphisms into irreflexive targets.",
+      "Formalize the edge-density estimate for a balanced C5-blow-up: induced density > n^2/50 on every floor(n/2)-subgraph (the open lower-bound witness).",
+      "Generalize beyond cliques: an injective-homomorphism image of any fixed graph F pulls back along homomorphisms into irreflexive targets (clique-freeness is the F=K_r case).",
       "Prove or formalize a partial result toward the main question (density forces a triangle)."
     ]
   },


### PR DESCRIPTION
## Summary
Research follow-up for **Erdős #128** (Ramsey–Turán, \$250 OPEN). Answers the **stated open question** of the parent entry `erdos-128-wip-01-oq-01` (its openQuestion #3: "K_r-freeness pulls back along homomorphisms whenever the target is irreflexive") by lifting the homomorphism-pullback principle from triangles to **cliques of every order**.

New entry: `erdos-128-wip-01-oq-01-oq-01` — `proofs/Proofs/Erdos128WIP01OQ01OQ01.lean` (self-contained over Mathlib).

## Results
- **`cliqueFree_of_hom`** — for every `r`, `K_r`-freeness pulls back along a graph homomorphism `f : G → H`. The `r` image vertices of a `G`-clique are forced distinct by `H`'s irreflexivity (equal images = an `H`-loop), so they form a genuine `H`-clique. **Strictly generalizes** the parent's `triangleFree_of_hom` (the `r = 3` case).
- **`hasClique_mono` / `cliqueFree_mono`** — clique-freeness is monotone in the order: a `K_r`-clique restricts to a `K_m`-clique for `m ≤ r` (compose with `Fin.castLE`), so `K_m`-free ⟹ `K_r`-free for `r ≥ m`.
- **`hasTriangle_iff_hasClique_three` / `triangleFree_iff_cliqueFree_three`** — bridge identifying the parent's triangle predicates with the `r = 3` clique predicates, recovering `triangleFree_of_hom` as a one-line corollary.
- **`blowup_cliqueFree`, `C5_cliqueFree`, `blowup_C5_cliqueFree`** — every blow-up of `C₅`, at every size `n` and class assignment, is `K_r`-free for all `r ≥ 3`: a clique-order-uniform strengthening of the extremal construction's triangle-freeness.

## Verification
- **11 theorems, 8 definitions + 1 structure, 0 sorries, 0 axioms.**
- Kernel-verified with `lake env lean Proofs/Erdos128WIP01OQ01OQ01.lean` (Lean v4.26.0, Mathlib pin): 0 errors.
- `#print axioms`: `cliqueFree_of_hom` depends on **no axioms**; the rest depend only on the standard triple `[propext, Classical.choice, Quot.sound]`. The `C₅` `decide` is the **ordinary kernel** decision procedure — **not** `native_decide` — so `Lean.ofReduceBool` is not used.
- Registered in `proofs/Proofs.lean`; gallery entry validated via `annotations:build` (discovered, listings regenerated cleanly).

## Files
- `proofs/Proofs/Erdos128WIP01OQ01OQ01.lean` (new), `proofs/Proofs.lean` (import)
- `src/data/proofs/erdos-128-wip-01-oq-01-oq-01/{meta,annotations,index}` (new)
- `src/data/research/problems/erdos-128-wip-01.json` (knowledge update)

## Status
**Outcome**: completed (verified, 0-axiom). **Honest scope**: the structural clique-pullback / monotonicity facts and the `K_r`-freeness of the `C₅`-blow-up witnesses — **not** the open optimal-constant question (induced density `> n²/50` and optimality of `1/50` remain open).

🤖 Generated by researcher-2