### PR TITLE
audit(angle-trisection-...-oq-05-oq-01-oq-01): Degree Factorisation kernel-verified clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17851,6 +17851,12 @@
       "lastAudited": "2026-06-24T03:29:50Z",
       "result": "clean",
       "issues": []
+    },
+    "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-24T03:40:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — CLEAN

**Proof**: `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-01-oq-01` — "The Degree Factorisation for Normal Extensions: [K : F] = |Aut_F(K)| · [K : F]_i"
**File**: `proofs/Proofs/NormalAutDegreeFormula.lean`

### Result: clean

Kernel-verified with Lean/Mathlib **v4.26.0**. `#print axioms` on all five substantive theorems (`finrank_eq_card_algEquiv_mul_finInsepDegree`, `card_algEquiv_dvd_finrank`, `finInsepDegree_eq_finrank_div_card`, `card_algEquiv_eq_finrank_iff_finInsepDegree_eq_one`, `card_algEquiv_eq_finrank_of_isSeparable`) reports only `[propext, Classical.choice, Quot.sound]`. No `sorryAx`, no `Lean.ofReduceBool`.

### Checks

| Claim | meta.json | Verified |
|-------|-----------|----------|
| status | `verified` | ✅ 0 sorries, 0 axioms (kernel-confirmed) |
| badge | `original` | ✅ defensible (see below) |
| sorries | 0 | ✅ |
| axiomCount | 0 | ✅ no axiom decls, no structure assumptions, no `native_decide` |
| theoremCount | 8 | ✅ |
| definitionCount | 0 | ✅ |
| lineCount | 147 | ✅ |
| True stubs | — | ✅ none |
| build graph | — | ✅ registered in `Proofs.lean` |

### Badge note
Unlike the sibling `…-oq-05-oq-01` (whose main results are literal one-line wrappers of `Normal.algHomEquivAut` → correctly `mathlib`), this entry's main result `finrank_eq_card_algEquiv_mul_finInsepDegree` is a genuine **synthesis** (the parent normal-automorphism equality fed into Mathlib's `finSepDegree_mul_finInsepDegree`), and its corollaries — divisibility, the inseparable-degree quotient, and the `iff` boundary proved via a real `Nat.eq_of_mul_eq_mul_left` cancellation — are non-trivial derivations not packaged in Mathlib. `original` is accurate; `originalContributions` transparently credit the Mathlib ingredients.

---
Discovered during gallery integrity audit. Tracker-only change.