### PR TITLE
research(lagrange-theorem-oq-01-oq-01-oq-02): register orphaned abelian-pq file in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3126,6 +3126,7 @@ import Proofs.LagrangeTheoremOQ01
 import Proofs.LagrangeTheoremOQ01OQ01
 import Proofs.LagrangeTheoremOQ01OQ01OQ01
 import Proofs.LagrangeTheoremOQ01OQ01OQ01ApproachB
+import Proofs.LagrangeTheoremOQ01OQ01OQ02
 import Proofs.LagrangeTheoremOQ01OQ02
 import Proofs.LagrangeTheoremOQ01OQ03
 import Proofs.LagrangeTheoremOQ02


### PR DESCRIPTION
## Summary

Registers the orphaned **abelian groups of order pq** entry
(`lagrange-theorem-oq-01-oq-01-oq-02`, status `verified`, 7 theorems, 0 sorries)
into the build graph. The complete Mathlib-only proof in
`LagrangeTheoremOQ01OQ01OQ02.lean` was never imported in `Proofs.lean`, so it was
never kernel-checked despite claiming `verified`.

## Math (unchanged)

Every abelian group of order `pq` (distinct primes) is cyclic and isomorphic to
`ℤ/pq`: `pq_abelian_isCyclic`, `pq_abelian_iso`, `pq_abelian_iso_zmod`, plus the
concrete instances of orders 6, 15, 35.

## Fix

- `proofs/Proofs.lean`: add `import Proofs.LagrangeTheoremOQ01OQ01OQ02`

## Verification

`lake env lean` (Lean v4.26.0): compiles clean, no errors, no sorries.
`#print axioms pq_abelian_isCyclic` → `[propext, Classical.choice, Quot.sound]`
only — confirming the axiom-free `verified` claim is honest. The file imports only
`Mathlib` and does **not** depend on the non-compiling `SylowTheoremOQ01` that
blocks the further non-abelian uniqueness extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
