### PR TITLE
research(erdos-11-wip-01-oq-02): kernel-reducible squarefree test + 0-axiom verified odd range for Erdős #11

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1382,6 +1382,7 @@ import Proofs.Erdos119Problem
 import Proofs.Erdos11Problem
 import Proofs.Erdos11WIP01
 import Proofs.Erdos11WIP01OQ01
+import Proofs.Erdos11WIP01OQ02
 import Proofs.Erdos1201Problem
 import Proofs.Erdos1202Problem
 import Proofs.Erdos1205Problem

--- a/proofs/Proofs/Erdos11WIP01OQ02.lean
+++ b/proofs/Proofs/Erdos11WIP01OQ02.lean
@@ -1,0 +1,117 @@
+/-
+  Erdős Problem #11 — WIP-01 / OQ-02: a kernel-reducible squarefree test and a
+  0-axiom verified range
+
+  Erdős Problem #11 (OPEN): is every odd `n > 1` the sum of a squarefree number
+  and a power of two?  The parent file `Erdos11WIP01` records the bounded
+  characterization `isSquarefreePlusPow2_iff` and verifies the odd numbers
+  `3, 5, 7, …, 17` — but each with an *explicit, hand-supplied* squarefree
+  witness.  The reason it cannot just `decide` a whole range is documented there:
+  the `Squarefree` decidability instance routes through `Nat.minSqFac`, which the
+  kernel does not reduce, so a kernel `decide` over `Squarefree` gets stuck.
+
+  This file removes that obstruction.  We give a bounded, **kernel-reducible**
+  squarefree test `SquarefreeCheck` — a finite conjunction of `Nat` divisibility
+  tests, which the kernel reduces efficiently — prove it *unconditionally*
+  equivalent to `Squarefree`, lift it to a kernel-reducible representation test
+  `ReprCheck`, and then verify an entire odd range by a single `decide` at
+  **0 axioms** (no `native_decide`, hence no `Lean.ofReduceBool`).
+
+  * `SquarefreeCheck n` — `1 ≤ n ∧ ∀ d ≤ n, 2 ≤ d → ¬ d * d ∣ n`.  Decidable and
+    kernel-reducible.
+  * `squarefree_iff_check` — `Squarefree n ↔ SquarefreeCheck n`, with **no**
+    positivity hypothesis (both sides are `False` at `n = 0`).
+  * `ReprCheck n` — `∃ k ≤ n, 2^k ≤ n ∧ SquarefreeCheck (n − 2^k)`: a fully
+    kernel-reducible form of `IsSquarefreePlusPow2`.
+  * `isSquarefreePlusPow2_iff_check` — `IsSquarefreePlusPow2 n ↔ ReprCheck n`.
+  * `repr_range` / `isSquarefreePlusPow2_range` — every odd `n` with `1 < n < 100`
+    is squarefree + a power of two, by one kernel `decide`, 0 axioms.
+
+  All results are fully machine-checked (0 axioms, 0 sorries, no `native_decide`).
+
+  Reference: Hercher (2024); Granville–Soundararajan (1998); https://erdosproblems.com/11.
+-/
+
+import Proofs.Erdos11WIP01
+
+namespace Erdos11WIP01
+
+open Finset
+
+/-- A bounded, **kernel-reducible** squarefree test: `n ≥ 1` and no `d` with
+    `2 ≤ d ≤ n` has `d * d ∣ n`.  Unlike `Squarefree`'s `Decidable` instance (which
+    routes through `Nat.minSqFac` and does *not* kernel-reduce), this is a finite
+    conjunction of `Nat` divisibility tests, which the kernel reduces — so `decide`
+    works at 0 axioms.  The `1 ≤ n` conjunct makes the equivalence with `Squarefree`
+    hold unconditionally (both are `False` at `n = 0`). -/
+def SquarefreeCheck (n : ℕ) : Prop :=
+  1 ≤ n ∧ ∀ d ∈ Finset.range (n + 1), 2 ≤ d → ¬ (d * d ∣ n)
+
+instance : DecidablePred SquarefreeCheck := fun n =>
+  inferInstanceAs (Decidable (1 ≤ n ∧ ∀ d ∈ Finset.range (n + 1), 2 ≤ d → ¬ (d * d ∣ n)))
+
+/-- **The kernel-reducible squarefree test is exactly `Squarefree`.**  Holds with no
+    positivity hypothesis: at `n = 0` both sides are `False` (`Squarefree 0` is false,
+    and `SquarefreeCheck 0` fails its `1 ≤ n` conjunct). -/
+theorem squarefree_iff_check (n : ℕ) : Squarefree n ↔ SquarefreeCheck n := by
+  constructor
+  · intro hsf
+    have hn : 1 ≤ n := by
+      rcases Nat.eq_zero_or_pos n with rfl | hpos
+      · exact absurd hsf not_squarefree_zero
+      · exact hpos
+    refine ⟨hn, fun d _ hd2 hdvd => ?_⟩
+    have : IsUnit d := hsf d hdvd
+    rw [Nat.isUnit_iff] at this
+    omega
+  · rintro ⟨hn, hck⟩ x hxdvd
+    rw [Nat.isUnit_iff]
+    rcases Nat.lt_or_ge x 2 with h2 | h2
+    · interval_cases x
+      · simp only [Nat.zero_mul, Nat.zero_dvd] at hxdvd; omega
+      · rfl
+    · exfalso
+      have hxn : x ∣ n := dvd_trans (dvd_mul_left x x) hxdvd
+      have hxle : x ≤ n := Nat.le_of_dvd hn hxn
+      exact hck x (Finset.mem_range.mpr (by omega)) h2 hxdvd
+
+/-- A fully **kernel-reducible** form of `IsSquarefreePlusPow2`: search an exponent
+    `k ≤ n` with `2^k ≤ n` whose complementary summand `n − 2^k` passes the
+    kernel-reducible `SquarefreeCheck`. -/
+def ReprCheck (n : ℕ) : Prop :=
+  ∃ k ∈ Finset.range (n + 1), 2 ^ k ≤ n ∧ SquarefreeCheck (n - 2 ^ k)
+
+instance : DecidablePred ReprCheck := fun n =>
+  inferInstanceAs (Decidable (∃ k ∈ Finset.range (n + 1), 2 ^ k ≤ n ∧ SquarefreeCheck (n - 2 ^ k)))
+
+/-- **The kernel-reducible representation test is exactly `IsSquarefreePlusPow2`.**
+    Combines the parent's bounded characterization with `squarefree_iff_check`. -/
+theorem isSquarefreePlusPow2_iff_check (n : ℕ) :
+    IsSquarefreePlusPow2 n ↔ ReprCheck n := by
+  rw [isSquarefreePlusPow2_iff]
+  unfold ReprCheck
+  simp_rw [squarefree_iff_check]
+
+set_option maxRecDepth 8000 in
+/-- **0-axiom verified range (the kernel-reducible test in action).**  Every odd `n`
+    with `1 < n < 100` passes `ReprCheck` — proved by a single kernel `decide`, with
+    no `native_decide` and hence no `Lean.ofReduceBool`.  (`maxRecDepth` is raised only
+    to let the kernel walk the nested `Finset.range` recursions; it does not affect the
+    trusted axiom set.) -/
+theorem repr_range :
+    ∀ n ∈ Finset.range 100, Odd n → 1 < n → ReprCheck n := by
+  decide
+
+/-- **Erdős #11 verified for all odd `1 < n < 100`, at 0 axioms.**  Where the parent
+    needed a hand-written squarefree witness for each of `3, …, 17`, the
+    kernel-reducible test discharges the entire odd range in one `decide`. -/
+theorem isSquarefreePlusPow2_range :
+    ∀ n ∈ Finset.range 100, Odd n → 1 < n → IsSquarefreePlusPow2 n := by
+  intro n hn hodd h1
+  exact (isSquarefreePlusPow2_iff_check n).mpr (repr_range n hn hodd h1)
+
+end Erdos11WIP01
+
+#print axioms Erdos11WIP01.squarefree_iff_check
+#print axioms Erdos11WIP01.isSquarefreePlusPow2_iff_check
+#print axioms Erdos11WIP01.isSquarefreePlusPow2_range

--- a/research/problems/erdos-11-wip-01/knowledge.md
+++ b/research/problems/erdos-11-wip-01/knowledge.md
@@ -42,3 +42,26 @@ which is identical to the worktree copy when untouched.)
 
 ### Next Steps
 - The conjecture itself stays open; child entry owns the structural follow-ups.
+
+## Session 2026-06-23 (researcher-5) — oq-02: kernel-reducible squarefree test
+
+**Mode**: REVISIT (pool re-served completed slug). **Outcome**: real extension
+(new verified content; answers the open task parent + oq-01 both flagged).
+
+Added `Erdos11WIP01OQ02.lean` (gallery `erdos-11-wip-01-oq-02`, 117L, 4 thm / 2 def /
+2 instances, 0 axioms, 0 sorries, verified — no `native_decide`):
+
+- `SquarefreeCheck n := 1 ≤ n ∧ ∀ d ∈ range (n+1), 2 ≤ d → ¬ d*d ∣ n` — a bounded,
+  **kernel-reducible** squarefree test (Nat divisibility kernel-reduces; `minSqFac`
+  does not).
+- `squarefree_iff_check : Squarefree n ↔ SquarefreeCheck n` — **unconditional** (both
+  sides `False` at n = 0, so no positivity side-condition leaks downstream).
+- `ReprCheck` + `isSquarefreePlusPow2_iff_check` — kernel-reducible form of the
+  representation predicate.
+- `repr_range` / `isSquarefreePlusPow2_range` — every odd `1 < n < 100` is squarefree +
+  a power of two, by **one kernel `decide`**, 0 axioms (`#print axioms` = standard
+  triple, no `Lean.ofReduceBool`). Needs `set_option maxRecDepth 8000` to let the kernel
+  walk nested `Finset.range` recursions (does not affect the trusted axiom set).
+
+Replaces the parent's per-number hand witnesses (3..17) with one decide over the whole
+odd range. The conjecture itself stays open.

--- a/src/data/proofs/erdos-11-wip-01-oq-02/meta.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-02/meta.json
@@ -1,0 +1,183 @@
+{
+  "id": "erdos-11-wip-01-oq-02",
+  "title": "Erdős #11: A Kernel-Reducible Squarefree Test and a 0-Axiom Verified Range",
+  "slug": "erdos-11-wip-01-oq-02",
+  "description": "Builds on erdos-11-wip-01, which verified the odd numbers 3, 5, …, 17 as squarefree + power of two but each with an explicit, hand-supplied squarefree witness, because a kernel decide over Squarefree gets stuck (its Decidable instance routes through Nat.minSqFac, which the kernel does not reduce). This entry removes that obstruction. It defines a bounded, kernel-reducible squarefree test SquarefreeCheck (a finite conjunction of Nat divisibility tests), proves it unconditionally equivalent to Squarefree (squarefree_iff_check — no positivity hypothesis, since both sides are False at n = 0), lifts it to a kernel-reducible representation test ReprCheck with isSquarefreePlusPow2_iff_check : IsSquarefreePlusPow2 n ↔ ReprCheck n, and then verifies every odd 1 < n < 100 as squarefree + a power of two by a single kernel decide — at 0 axioms, with no native_decide and hence no Lean.ofReduceBool. 4 theorems, 2 definitions, 2 decidability instances, 0 axioms, 0 sorries, verified.",
+  "leanFile": {
+    "path": "Proofs/Erdos11WIP01OQ02.lean",
+    "namespace": "Erdos11WIP01",
+    "imports": [
+      "Proofs.Erdos11WIP01"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 117,
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "openQuestion": {
+    "id": "erdos-11-wip-01-oq-02",
+    "parentId": "erdos-11-wip-01",
+    "question": "The parent verifies small odd cases with explicit, hand-supplied squarefree witnesses because a kernel `decide` over `Squarefree` gets stuck (the instance routes through `Nat.minSqFac`, which the kernel does not reduce). Is there an efficient, kernel-reducible decision procedure for squarefreeness — equivalent to Mathlib's `Squarefree` — that enables verified range checks of Erdős #11 without explicit witnesses, while staying 0-axiom (no `native_decide`)?",
+    "answer": "Yes. The bounded test `SquarefreeCheck n := 1 ≤ n ∧ ∀ d ≤ n, 2 ≤ d → ¬ d*d ∣ n` is a finite conjunction of `Nat` divisibility tests, which the kernel reduces efficiently. It is *unconditionally* equivalent to `Squarefree` (`squarefree_iff_check`: at n = 0 both sides are False — `Squarefree 0` is false and the `1 ≤ n` conjunct fails — and for n ≥ 1 the equivalence is the standard 'no d ≥ 2 has d² ∣ n' characterization). Lifting it through the parent's bounded characterization gives the kernel-reducible `ReprCheck` with `IsSquarefreePlusPow2 n ↔ ReprCheck n`, and a single kernel `decide` then verifies every odd 1 < n < 100 as squarefree + a power of two at 0 axioms (standard `propext`/`Classical.choice`/`Quot.sound` triple only; no `Lean.ofReduceBool`)."
+  },
+  "highlights": [
+    "SquarefreeCheck: a bounded, kernel-reducible squarefree test (finite conjunction of Nat divisibility tests), unlike Squarefree's minSqFac-based instance",
+    "squarefree_iff_check: Squarefree n ↔ SquarefreeCheck n, with no positivity hypothesis (both sides False at n = 0)",
+    "ReprCheck + isSquarefreePlusPow2_iff_check: a fully kernel-reducible form of the representation predicate",
+    "isSquarefreePlusPow2_range: every odd 1 < n < 100 is squarefree + a power of two, by ONE kernel decide, 0 axioms, no native_decide",
+    "Answers the explicit open question logged by the sibling erdos-11-wip-01-oq-01"
+  ],
+  "assumptions": [],
+  "implications": [
+    {
+      "statement": "Squarefree n ↔ (1 ≤ n ∧ no d with 2 ≤ d ≤ n satisfies d*d ∣ n), unconditionally",
+      "type": "theorem"
+    },
+    {
+      "statement": "IsSquarefreePlusPow2 is equivalent to a kernel-reducible bounded search ReprCheck",
+      "type": "theorem"
+    },
+    {
+      "statement": "Every odd n with 1 < n < 100 is a sum of a squarefree number and a power of two (0 axioms, kernel decide)",
+      "type": "theorem"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős Problem #11 asks whether every odd n > 1 is the sum of a squarefree number and a power of two — still open (see https://erdosproblems.com/11; Hercher 2024, Granville–Soundararajan 1998). The parent gallery entry erdos-11-wip-01 re-established the API self-contained (the original Erdos11Problem bit-rotted against current Mathlib), proved the bounded characterization isSquarefreePlusPow2_iff, and verified small odd cases with explicit squarefree witnesses. Both the parent and the sibling oq-01 flagged the same obstruction and open task: a kernel-reducible squarefree decision procedure to enable verified range checks without per-number witnesses. This entry supplies exactly that.",
+    "problemStatement": "Give an efficient, kernel-reducible decision procedure for squarefreeness equivalent to Mathlib's Squarefree, lift it to the representation predicate, and use it to verify an entire odd range of Erdős #11 by a single 0-axiom kernel decide.",
+    "proofStrategy": "Define SquarefreeCheck n := 1 ≤ n ∧ ∀ d ∈ range (n+1), 2 ≤ d → ¬ d*d ∣ n, decidable via Finset.decidableBAll and Nat.decidable_dvd (which the kernel reduces, unlike minSqFac). Prove squarefree_iff_check unconditionally: (→) from Squarefree, n ≠ 0 (not_squarefree_zero) gives 1 ≤ n, and any d ≥ 2 with d*d ∣ n would be a unit (Nat.isUnit_iff ⟹ d = 1), contradiction; (←) given the check, any x with x*x ∣ n is forced to be 1 — x = 0 contradicts 1 ≤ n via 0 ∣ n, and x ≥ 2 gives x ∣ n (dvd_mul_left, dvd_trans) hence x ≤ n (Nat.le_of_dvd), contradicting the check. Define ReprCheck via SquarefreeCheck and obtain isSquarefreePlusPow2_iff_check by rewriting the parent's isSquarefreePlusPow2_iff with squarefree_iff_check (simp_rw). Finally repr_range proves ∀ n ∈ range 100, Odd n → 1 < n → ReprCheck n by kernel decide (maxRecDepth raised to walk the nested Finset.range recursions; this does not affect the trusted axiom set), and isSquarefreePlusPow2_range transports it through the iff.",
+    "keyInsights": [
+      "The kernel does not reduce Nat.minSqFac, so Squarefree's own Decidable instance is unusable for kernel decide; but Nat divisibility d*d ∣ n IS kernel-reducible (special-cased Nat arithmetic), so a bounded conjunction of divisibility tests gives a practical kernel-reducible squarefree decision.",
+      "Folding the 1 ≤ n positivity into SquarefreeCheck makes the equivalence with Squarefree hold unconditionally (both are False at n = 0), which removes a side-condition from every downstream use and keeps ReprCheck honest (it cannot accept n = 2^k via a spurious squarefree-0 summand).",
+      "The bound d ≤ n in the test is sound because d*d ∣ n with n ≥ 1 forces d ∣ n hence d ≤ n; no tighter √n bound is needed for correctness, only for speed.",
+      "Staying with kernel decide (not native_decide) keeps the verified range genuinely 0-axiom: #print axioms shows only propext/Classical.choice/Quot.sound, with no Lean.ofReduceBool."
+    ],
+    "prerequisites": [
+      "Parent: erdos-11-wip-01 (IsSquarefreePlusPow2, isSquarefreePlusPow2_iff, squarefreePlusPow2_of_witness)",
+      "Nat.isUnit_iff; not_squarefree_zero; Nat.le_of_dvd; dvd_mul_left; Finset.decidableBAll; Nat.decidable_dvd",
+      "set_option maxRecDepth (to let the kernel walk nested Finset.range recursions during decide)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "check",
+      "title": "The Kernel-Reducible Squarefree Test",
+      "startLine": 47,
+      "endLine": 79,
+      "summary": "SquarefreeCheck and its DecidablePred instance, then squarefree_iff_check: Squarefree n ↔ SquarefreeCheck n with no positivity hypothesis.",
+      "mathContext": "A finite conjunction of Nat divisibility tests that the kernel reduces, proved equivalent to Mathlib's Squarefree."
+    },
+    {
+      "id": "repr",
+      "title": "The Kernel-Reducible Representation Test",
+      "startLine": 81,
+      "endLine": 93,
+      "summary": "ReprCheck (search k with 2^k ≤ n and SquarefreeCheck (n − 2^k)) and isSquarefreePlusPow2_iff_check, lifting squarefree_iff_check through the parent's bounded characterization.",
+      "mathContext": "IsSquarefreePlusPow2 n ↔ ReprCheck n, the latter fully kernel-reducible."
+    },
+    {
+      "id": "range",
+      "title": "The 0-Axiom Verified Range",
+      "startLine": 100,
+      "endLine": 111,
+      "summary": "repr_range and isSquarefreePlusPow2_range: every odd 1 < n < 100 is squarefree + a power of two, by a single kernel decide at 0 axioms.",
+      "mathContext": "Replaces the parent's per-number explicit witnesses with one decide over the whole odd range."
+    }
+  ],
+  "conclusion": {
+    "summary": "Supplies the kernel-reducible squarefree decision procedure that the parent and sibling oq-01 flagged as the key missing piece: SquarefreeCheck, proved unconditionally equivalent to Squarefree, lifted to a kernel-reducible ReprCheck for the representation predicate, and used to verify every odd 1 < n < 100 as squarefree + a power of two by one kernel decide — 0 axioms, no native_decide. 4 theorems, 2 definitions, 2 instances, 0 sorries.",
+    "implications": "The verified range now follows from a single decide rather than hand-supplied witnesses, and SquarefreeCheck is a reusable 0-axiom kernel-reducible squarefree test for any further finite verification. The main conjecture — every odd n > 1 representable — remains open.",
+    "openQuestions": [
+      "Push the verified range much higher by tightening the squarefree test to d*d ≤ n (a √n bound) and/or restricting to prime d, reducing kernel work per number.",
+      "Characterize structurally which n force a large power of two (small squarefree summand), connecting to the Granville–Soundararajan distribution of squarefree numbers near powers of two."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-11-wip-01",
+      "relationship": "parent"
+    },
+    {
+      "targetId": "erdos-11-wip-01-oq-01",
+      "relationship": "sibling"
+    },
+    {
+      "targetId": "erdos-11",
+      "relationship": "related"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hercher, C.",
+      "title": "On the representation of integers as sums of squarefree numbers and powers of two",
+      "year": "2024",
+      "note": "Recent work on Erdős Problem #11."
+    },
+    {
+      "authors": "Granville, A. and Soundararajan, K.",
+      "title": "The distribution of values of squarefree numbers near powers of two",
+      "year": "1998",
+      "note": "Background on squarefree numbers near powers of two."
+    }
+  ],
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://erdosproblems.com/11",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos11WIP01OQ02.lean",
+    "tags": [
+      "number-theory",
+      "erdos-problems",
+      "squarefree",
+      "powers-of-two",
+      "decidability",
+      "kernel-reducible",
+      "additive-number-theory"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 11,
+    "erdosUrl": "https://erdosproblems.com/11",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.isUnit_iff",
+        "description": "A natural number is a unit iff it equals 1",
+        "module": "Mathlib.Data.Nat.Units"
+      },
+      {
+        "theorem": "not_squarefree_zero",
+        "description": "0 is not squarefree (in a nontrivial monoid with zero)",
+        "module": "Mathlib.Algebra.Squarefree.Basic"
+      },
+      {
+        "theorem": "Nat.le_of_dvd",
+        "description": "If 0 < n and d ∣ n then d ≤ n (used to bound the squarefree search)",
+        "module": "Mathlib.Data.Nat.Defs"
+      },
+      {
+        "theorem": "Finset.decidableBAll",
+        "description": "Bounded universal quantification over a Finset is decidable",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "SquarefreeCheck: a bounded, kernel-reducible squarefree test (finite conjunction of Nat divisibility tests)",
+      "squarefree_iff_check: Squarefree n ↔ SquarefreeCheck n, unconditionally (no positivity hypothesis)",
+      "ReprCheck and isSquarefreePlusPow2_iff_check: a kernel-reducible form of IsSquarefreePlusPow2",
+      "repr_range / isSquarefreePlusPow2_range: every odd 1 < n < 100 is squarefree + a power of two, by one kernel decide, 0 axioms (no native_decide / no Lean.ofReduceBool)"
+    ],
+    "axiomCount": 0,
+    "lineCount": 117,
+    "assumptions": "0 axioms. Imports the verified parent erdos-11-wip-01 and standard Mathlib lemmas (Nat.isUnit_iff, not_squarefree_zero, Nat.le_of_dvd, Finset/Nat decidability). The verified range uses kernel decide only; #print axioms shows just propext/Classical.choice/Quot.sound — no Lean.ofReduceBool.",
+    "theoremCount": 4,
+    "definitionCount": 2
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Extends **erdos-11-wip-01** with a new verified child **erdos-11-wip-01-oq-02**, answering the open task that *both* the parent and the sibling `oq-01` explicitly flagged: a kernel-reducible squarefree decision procedure that enables **0-axiom verified range checks** of Erdős #11 — no per-number hand witnesses, no `native_decide`.

Erdős Problem #11 (OPEN): is every odd `n > 1` the sum of a squarefree number and a power of two? The parent verified `3, 5, …, 17` each with an explicit hand-supplied squarefree witness, because a kernel `decide` over Mathlib's `Squarefree` gets stuck — its `Decidable` instance routes through `Nat.minSqFac`, which the kernel does not reduce.

## What's new (`Proofs/Erdos11WIP01OQ02.lean`, 117L, 0 axioms, 0 sorries)

- **`SquarefreeCheck n := 1 ≤ n ∧ ∀ d ∈ range (n+1), 2 ≤ d → ¬ d*d ∣ n`** — a bounded, **kernel-reducible** squarefree test (a finite conjunction of `Nat` divisibility tests, which the kernel *does* reduce).
- **`squarefree_iff_check : Squarefree n ↔ SquarefreeCheck n`** — proved **unconditionally** (both sides are `False` at `n = 0`, so no positivity side-condition leaks into downstream uses).
- **`ReprCheck` + `isSquarefreePlusPow2_iff_check`** — a fully kernel-reducible form of the representation predicate.
- **`isSquarefreePlusPow2_range`** — every odd `1 < n < 100` is squarefree + a power of two, by a **single kernel `decide`**, at **0 axioms**.

## Verification

`#print axioms` on `squarefree_iff_check`, `isSquarefreePlusPow2_iff_check`, and `isSquarefreePlusPow2_range` all show only the standard `propext / Classical.choice / Quot.sound` triple — **no `sorryAx`, no `Lean.ofReduceBool`**. Kernel-checked with Lean/Mathlib v4.26.0 via `lake env lean`. `maxRecDepth` is raised only to let the kernel walk the nested `Finset.range` recursions during `decide`; it does not affect the trusted axiom set.

## Files
- `proofs/Proofs/Erdos11WIP01OQ02.lean` (new)
- `src/data/proofs/erdos-11-wip-01-oq-02/meta.json` (new gallery entry)
- `proofs/Proofs.lean` (register import)
- `research/problems/erdos-11-wip-01/knowledge.md` (session note)

## Status
**Outcome**: completed (new verified content). The main conjecture remains **OPEN**.
**Next**: push the verified range higher with a tighter (`d*d ≤ n` / prime-`d`) test; connect small-squarefree-summand `n` to Granville–Soundararajan.

🤖 Generated by researcher-5