### PR TITLE
Enrich Erdős #982 thin-vertex: add missing index.ts + crossReferences

### DIFF
--- a/src/data/proofs/erdos-982-thin-vertex/index.ts
+++ b/src/data/proofs/erdos-982-thin-vertex/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos982ThinVertex.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos982ThinVertexProof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos982ThinVertexAnnotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos982ThinVertexData: ProofData = {
+  proof: erdos982ThinVertexProof,
+  annotations: erdos982ThinVertexAnnotations,
+}

--- a/src/data/proofs/erdos-982-thin-vertex/meta.json
+++ b/src/data/proofs/erdos-982-thin-vertex/meta.json
@@ -182,5 +182,22 @@
       "summary": "ceil_half_pred_eq_floor_half: ⌈(n−1)/2⌉ = ⌊n/2⌋ for n ≥ 1 (Nat, via omega). Records the arithmetic reason the crude (n−1)/2 bound is improved to the tight ⌊n/2⌋ — the unique diameter contributes a class of size 1.",
       "mathContext": "From a regular even n-gon vertex the diametric neighbour is unique (class size 1) and the rest pair up (size 2), giving exactly 1 + (n−2)/2 = n/2 = ⌊n/2⌋ distinct distances."
     }
+  ],
+  "crossReferences": [
+    {
+      "proofId": "erdos-982",
+      "relationship": "Parent problem entry",
+      "description": "States the open Erdős #982 conjecture and axiomatizes the published bounds (moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false). This file proves the axiom-free combinatorial core those axioms sit on top of and discharges the parent's triangle_case."
+    },
+    {
+      "proofId": "erdos-97",
+      "relationship": "The obstruction, made precise",
+      "description": "Erdős #97 (equidistant vertices) — whether a vertex avoiding three equidistant neighbours always exists — was disproved. The contrapositive `exists_three_equidistant_of_few_distances` shows that disproof is exactly why a thin vertex is not guaranteed and #982 stays open."
+    },
+    {
+      "proofId": "erdos-divisibility-pigeonhole",
+      "relationship": "Shares the pigeonhole technique",
+      "description": "Another Erdős result whose engine is a fibrewise counting / pigeonhole argument, illustrating how the same `card_eq_sum_card_fiberwise`-style partition underlies distinct results across combinatorial number theory and discrete geometry."
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for `erdos-982-thin-vertex`.

Rebased onto current main after PR #28663 concurrently added overview/conclusion/annotation-field enrichment to this entry. To avoid clobbering that work, this PR is now scoped to the two pieces main still lacks:

- **`index.ts` (critical):** without it the proof page renders "proof not found" on the live site even though the entry appears in the gallery listing. Wires meta.json + annotations.json + the raw Lean source into the `ProofData` Vite glob.
- **`crossReferences`:** `erdos-982` (parent problem), `erdos-97` (the disproved obstruction explaining why a thin vertex is not guaranteed), `erdos-divisibility-pigeonhole` (shared fibrewise-counting / pigeonhole technique).

**Axiom integrity:** unchanged — status `verified`/badge `original`/axiomCount 0 matches the Lean file (no `axiom` decls, no assumption-carrying structures, no native_decide).

Build: `tsc -b` exit 0, `vite build` exit 0.