### PR TITLE
Enrich LTE p=2 integer v₂ form (oq-02): add index.ts + annotations

### DIFF
--- a/src/data/proofs/lifting-the-exponent-oq-02/annotations.json
+++ b/src/data/proofs/lifting-the-exponent-oq-02/annotations.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "ann-lteoq02-1",
+    "proofId": "lifting-the-exponent-oq-02",
+    "range": { "startLine": 5, "endLine": 42 },
+    "type": "context",
+    "title": "The p = 2 Lifting-the-Exponent Lemma, in Integer v₂ Form",
+    "content": "**Module framing.** The odd-prime LTE computes $v_p(x^n - y^n) = v_p(x-y) + v_p(n)$. The even prime $p=2$ is famously *different*: for **even** $n$ an extra $v_2(x+y)$ term appears and the count shifts by one, $v_2(x^n - y^n) + 1 = v_2(x+y) + v_2(x-y) + v_2(n)$. Mathlib proves the `emultiplicity` ($\\mathbb{N}_\\infty$-valued) version over ℤ (`Int.two_pow_sub_pow`) and a `padicValNat` version over ℕ, but **not** the `padicValInt` (finite integer $v_2$) form — the natural shape for the lemma's usual ℤ applications. This entry fills that gap by descending from the extended valuation to the finite integer form, manufacturing the finiteness facts en route.",
+    "mathContext": "$v_2(x^n - y^n) + 1 = v_2(x+y) + v_2(x-y) + v_2(n)$ for $2 \\mid x-y$, $2 \\nmid x$, $n$ even.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lifting the Exponent (LTE)",
+      "2-adic valuation",
+      "emultiplicity vs multiplicity vs padicVal",
+      "Even-prime anomaly"
+    ],
+    "prerequisites": [
+      "p-adic valuation",
+      "Int.two_pow_sub_pow"
+    ],
+    "tags": ["module-header", "framing", "lte", "p-equals-2"]
+  },
+  {
+    "id": "ann-lteoq02-2",
+    "proofId": "lifting-the-exponent-oq-02",
+    "range": { "startLine": 44, "endLine": 51 },
+    "type": "concept",
+    "title": "The ℕ∞-Valued Statement (re-export)",
+    "content": "**`two_lte_emultiplicity`** re-exports Mathlib's `Int.two_pow_sub_pow`: the LTE identity at the level of `emultiplicity` (valuation valued in $\\mathbb{N}_\\infty$, so $\\infty$ is allowed). This is the mathematical core supplied by Mathlib; everything below is the descent to finite, integer-valued forms. Working at `emultiplicity` first sidesteps having to prove anything is nonzero before stating the identity.",
+    "mathContext": "$\\mathrm{emult}_2(x^n - y^n) + 1 = \\mathrm{emult}_2(x+y) + \\mathrm{emult}_2(x-y) + \\mathrm{emult}_2(n)$ in $\\mathbb{N}_\\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "emultiplicity (ℕ∞-valued)",
+      "Int.two_pow_sub_pow"
+    ],
+    "prerequisites": [
+      "emultiplicity in a monoid"
+    ],
+    "tags": ["emultiplicity", "re-export", "mathlib"]
+  },
+  {
+    "id": "ann-lteoq02-3",
+    "proofId": "lifting-the-exponent-oq-02",
+    "range": { "startLine": 50, "endLine": 72 },
+    "type": "insight",
+    "title": "Extracting Nonvanishing from Finiteness",
+    "content": "**`two_pow_sub_pow_ne_zero`** proves $x^n - y^n \\ne 0$ rather than assuming it — the key enabling step for the finite forms. The argument is a clean contradiction: if $x^n - y^n = 0$, then `emultiplicity_zero` makes its valuation $\\infty$, so the LTE left side is $\\infty + 1 = \\infty$ (`top_add`); but the right side is finite, being a sum of finite multiplicities (`FiniteMultiplicity` for $x+y$, $x-y$, $n$, each from `Int.finiteMultiplicity_iff` with the nonzero hypotheses). Casting the finite right side to $\\mathbb{N}_\\infty$ via `Nat.cast_add` and using `ENat.coe_ne_top` derives $\\infty = (\\text{finite})$, a contradiction. This is how the extended valuation forces nonvanishing.",
+    "mathContext": "$x^n - y^n = 0 \\Rightarrow \\mathrm{emult} = \\infty$, but RHS finite $\\Rightarrow$ contradiction via $\\mathbb{N}_\\infty$ coercion.",
+    "significance": "key",
+    "relatedConcepts": [
+      "FiniteMultiplicity",
+      "Int.finiteMultiplicity_iff",
+      "ENat.coe_ne_top",
+      "emultiplicity_zero / top_add"
+    ],
+    "prerequisites": [
+      "emultiplicity of 0 is ⊤",
+      "Finiteness of 2-adic valuation"
+    ],
+    "tags": ["nonvanishing", "finiteness", "contradiction"]
+  },
+  {
+    "id": "ann-lteoq02-4",
+    "proofId": "lifting-the-exponent-oq-02",
+    "range": { "startLine": 70, "endLine": 96 },
+    "type": "concept",
+    "title": "The ℕ-Valued multiplicity Form",
+    "content": "**`two_lte_multiplicity`** descends the `emultiplicity` identity to the ℕ-valued `multiplicity`. With all four terms ($x^n-y^n$, $x+y$, $x-y$, $n$) proved to have `FiniteMultiplicity`, each `emultiplicity` rewrites to the cast of its finite `multiplicity` (`emultiplicity_eq_multiplicity`); the whole equation then lives in $\\mathbb{N}_\\infty$ as a cast of a ℕ equation, and `exact_mod_cast` strips the coercions. The nonvanishing of $x^n - y^n$ (previous lemma) is exactly what supplies its finiteness.",
+    "mathContext": "$\\mathrm{mult}_2(x^n-y^n) + 1 = \\mathrm{mult}_2(x+y) + \\mathrm{mult}_2(x-y) + \\mathrm{mult}_2(n)$ in ℕ.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "multiplicity (ℕ-valued)",
+      "FiniteMultiplicity.emultiplicity_eq_multiplicity",
+      "exact_mod_cast"
+    ],
+    "prerequisites": [
+      "two_pow_sub_pow_ne_zero",
+      "emultiplicity ↔ multiplicity for finite case"
+    ],
+    "tags": ["multiplicity", "descent", "casting"]
+  },
+  {
+    "id": "ann-lteoq02-5",
+    "proofId": "lifting-the-exponent-oq-02",
+    "range": { "startLine": 94, "endLine": 112 },
+    "type": "concept",
+    "title": "The Schoolbook padicValInt Form",
+    "content": "**`two_lte_padicValInt`** is the headline gap-filler: the familiar integer form $v_2(x^n - y^n) + 1 = v_2(x+y) + v_2(x-y) + v_2(n)$ with $v_2$ on ℤ as `padicValInt 2` and on ℕ as `padicValNat 2`. Each `padicValInt` rewrites to a `multiplicity` via `padicValInt.of_ne_one_ne_zero` (valid since the arguments are nonzero and $2 \\ne 1$), and the $n$-term bridges `multiplicity (2:ℤ) ↑n = padicValNat 2 n` through `padicValInt.of_nat`. The previous `multiplicity` form then closes it. This is the shape practitioners actually use.",
+    "mathContext": "$v_2(x^n-y^n) + 1 = v_2(x+y) + v_2(x-y) + v_2(n)$ via `padicValInt`/`padicValNat`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "padicValInt / padicValNat",
+      "padicValInt.of_ne_one_ne_zero",
+      "padicValInt.of_nat"
+    ],
+    "prerequisites": [
+      "two_lte_multiplicity",
+      "padicVal ↔ multiplicity bridge"
+    ],
+    "tags": ["padicval", "main-theorem", "schoolbook-form"]
+  },
+  {
+    "id": "ann-lteoq02-6",
+    "proofId": "lifting-the-exponent-oq-02",
+    "range": { "startLine": 114, "endLine": 128 },
+    "type": "concept",
+    "title": "Explicit Divisibility Consequence",
+    "content": "**`two_lte_pow_dvd`** turns the valuation identity into a concrete divisibility: $2^{\\,v_2(x+y)+v_2(x-y)+v_2(n)-1} \\mid x^n - y^n$. The exponent is exactly $v_2(x^n - y^n)$ (rearranging the schoolbook identity, with `omega` handling the $-1$), and `pow_multiplicity_dvd` gives that $p^{v_p(m)} \\mid m$. This is the practically useful corollary — a guaranteed power of $2$ dividing the difference, read straight off the seed valuations.",
+    "mathContext": "$2^{\\,v_2(x+y)+v_2(x-y)+v_2(n)-1} = 2^{\\,v_2(x^n-y^n)} \\mid x^n - y^n$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "pow_multiplicity_dvd",
+      "Divisibility certificate",
+      "omega"
+    ],
+    "prerequisites": [
+      "two_lte_padicValInt",
+      "p^{v_p(m)} ∣ m"
+    ],
+    "tags": ["divisibility", "corollary", "consequence"]
+  }
+]

--- a/src/data/proofs/lifting-the-exponent-oq-02/index.ts
+++ b/src/data/proofs/lifting-the-exponent-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LiftingTheExponentOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const liftingTheExponentOQ02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const liftingTheExponentOQ02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const liftingTheExponentOQ02Data: ProofData = {
+  proof: liftingTheExponentOQ02Proof,
+  annotations: liftingTheExponentOQ02Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `lifting-the-exponent-oq-02`

This entry shipped with only `meta.json` — it was **missing `index.ts`** (Vite's `import.meta.glob` could not discover it, so the page rendered "proof not found" on the live site) and had **no `annotations.json`**.

### Changes
- **Added `index.ts`** (standard gallery template) pointing at `Proofs/LiftingTheExponentOQ02.lean`.
- **Added `annotations.json`** with **6 substantive annotations** covering every section:
  1. The p=2 LTE framing (even-prime anomaly; the `padicValInt` gap in Mathlib)
  2. The ℕ∞-valued `emultiplicity` re-export
  3. Extracting `xⁿ−yⁿ ≠ 0` from finiteness (the enabling contradiction)
  4. The ℕ-valued `multiplicity` descent
  5. The schoolbook `padicValInt` form (the gap-filler)
  6. The explicit divisibility consequence
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

### Verification
- `tsc -b` (full project typecheck) passes (exit 0), including the new `index.ts`.
- Axiom integrity preserved: `status: verified`, `badge: mathlib`, `axiomCount: 0` — consistent with the meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)