### PR TITLE
fix(audit): register orphaned AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02 in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -123,6 +123,7 @@ import Proofs.AngleTrisectionOQ02OQ01OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01
 import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05
+import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02
 import Proofs.AngleTrisectionOQ02OQ01OQ02
 import Proofs.AngleTrisectionOQ02OQ01OQ02Aristotle
 import Proofs.AngleTrisectionOQ02OQ01OQ02Incomplete01


### PR DESCRIPTION
## Integrity Issue: orphaned verified entry

**Proof**: `angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01-oq-05-oq-02`
**Title**: Sharpness of the Automorphism Bound: |Aut_F(K)| = [K : F]_s ⟺ K/F Normal
**Problem**: The entry is marked `status: "verified"` / `badge: "original"`, but its Lean file `Proofs/AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02.lean` was **not imported in `proofs/Proofs.lean`**. An unimported file is excluded from the build graph, so it was never compiled or kernel-checked in CI — the "verified" claim had no backing.

## Verification

Kernel-verified locally with `lake env lean` against Mathlib v4.26.0:

- Compiles clean, **0 errors**
- 0 `sorry`, 0 `axiom` declarations, 0 `native_decide` (the `sorry`/`native_decide` strings appear only in the docstring)
- 6 theorems, 1 definition, 147 lines — matches meta.json exactly
- `#print axioms` on all three main results reports only the foundational triple:
  - `normal_iff_card_aut_eq_card_algHom` → `[propext, Classical.choice, Quot.sound]`
  - `normal_iff_card_aut_eq_finSepDegree` → `[propext, Classical.choice, Quot.sound]`
  - `card_aut_lt_finSepDegree_of_not_normal` → `[propext, Classical.choice, Quot.sound]`

This matches the `assumptions` field's claim. All meta.json metadata is accurate; the only defect was the missing build-graph registration.

## Fix

Add `import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01OQ05OQ02` to `proofs/Proofs.lean` (alphabetically after the parent `...OQ05`), so the verified entry is permanently covered by the build.

---
Discovered during gallery integrity audit.