### PR TITLE
research(bernoulli-inequality-oq-01-oq-02): second-order Bernoulli (1+a)ⁿ ≥ 1+na+C(n,2)a² + equality case [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -291,6 +291,7 @@ import Proofs.BaselProblemOQ14
 import Proofs.BellNumbersOQ01
 import Proofs.BernoulliInequalityOQ01
 import Proofs.BernoulliInequalityOQ01OQ01
+import Proofs.BernoulliInequalityOQ01OQ02
 import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04

--- a/proofs/Proofs/BernoulliInequalityOQ01OQ02.lean
+++ b/proofs/Proofs/BernoulliInequalityOQ01OQ02.lean
@@ -1,0 +1,170 @@
+import Mathlib
+import Proofs.BernoulliInequalityOQ01OQ01
+
+/-
+# Second-order Bernoulli and its equality characterization
+
+**Open question (bernoulli-inequality-oq-01-oq-02).** Characterize equality in
+Bernoulli's inequality `(1 + a)ⁿ ≥ 1 + n·a`.
+
+The *first-order* equality characterization is already settled by the parent and
+sibling entries: `BernoulliInequalityOQ01.one_add_mul_eq_pow_iff` gives it for
+`-1 < a`, and `BernoulliInequalityOQ01OQ01.one_add_mul_eq_pow_full_iff`
+sharpens it to Mathlib's full weak domain `-2 ≤ a`: equality `1 + n·a = (1+a)ⁿ`
+holds iff `a = 0 ∨ n ≤ 1`.  We record that result as a one-line corollary
+(`one_add_mul_eq_pow_iff_ge`) for the slug's literal `a ≥ -1` target.
+
+The new content of this entry is the **second-order** refinement.  For `a ≥ 0`,
+truncating the binomial expansion after the quadratic term gives the sharper
+lower bound
+
+  `(1 + a)ⁿ  ≥  1 + n·a + C(n,2)·a²`,   where `C(n,2) = n(n-1)/2`,
+
+and this inequality has its *own* sharp equality characterization, one step
+shifted from the first-order case:
+
+* `sq_bernoulli`        : `0 ≤ a → 1 + n·a + (n(n-1)/2)·a² ≤ (1+a)ⁿ`.
+* `sq_bernoulli_strict` : `0 < a → 3 ≤ n → 1 + n·a + (n(n-1)/2)·a² < (1+a)ⁿ`.
+* `sq_bernoulli_eq_iff` : for `0 ≤ a`, equality holds **iff** `a = 0 ∨ n ≤ 2`.
+
+The threshold moves from `n ≤ 1` (first order) to `n ≤ 2` (second order): the
+quadratic truncation is *exact* through `n = 2` — indeed `(1+a)² = 1 + 2a + a²`
+is the full expansion — and becomes strict precisely once the cubic term `a³`
+can appear, i.e. for `n ≥ 3` and `a > 0`.
+
+**Mechanism.** The inequality is a one-line induction: multiplying the inductive
+bound by `1 + a ≥ 0` and using `C(n,2) + n = C(n+1,2)` (Pascal) reproduces the
+next bound up to the discarded nonnegative tail `C(n,2)·a³ ≥ 0`.  Strictness for
+`n ≥ 3` comes from that tail being *strictly* positive once `n ≥ 3` and `a > 0`.
+
+**Relation to Mathlib.** Mathlib has the first-order weak form
+`one_add_mul_le_pow` (domain `-2 ≤ a`) and `rpow` Bernoulli forms, but no
+second-order integer-power Bernoulli with an equality characterization.  The
+restriction to `a ≥ 0` is sharp: for `-1 < a < 0` the quadratic truncation
+*overshoots* (e.g. `n = 3, a = -1/2`: the bound `1/4` exceeds `(1/2)³ = 1/8`),
+so the second-order inequality genuinely requires nonnegativity, unlike the
+first-order inequality which holds down to `a = -2`.
+-/
+
+namespace BernoulliInequalityOQ01OQ02
+
+variable {a : ℝ}
+
+/-- **Second-order Bernoulli inequality.** For `a ≥ 0` and every `n`, the binomial
+power dominates its quadratic Taylor truncation:
+`1 + n·a + (n(n-1)/2)·a² ≤ (1 + a)ⁿ`.
+
+This sharpens the first-order Bernoulli bound `1 + n·a ≤ (1+a)ⁿ` by the next
+binomial term `C(n,2)·a² = (n(n-1)/2)·a²`. -/
+theorem sq_bernoulli (ha : 0 ≤ a) (n : ℕ) :
+    1 + n * a + ((n : ℝ) * ((n : ℝ) - 1) / 2) * a ^ 2 ≤ (1 + a) ^ n := by
+  induction n with
+  | zero => simp
+  | succ m ih =>
+      have h1a : (0 : ℝ) ≤ 1 + a := by linarith
+      -- `m·(m-1) ≥ 0` for a natural `m` (so the discarded cubic tail is `≥ 0`).
+      have hm2 : 0 ≤ (m : ℝ) * ((m : ℝ) - 1) := by
+        rcases Nat.eq_zero_or_pos m with h | h
+        · subst h; simp
+        · have hm1 : (1 : ℝ) ≤ (m : ℝ) := by exact_mod_cast h
+          nlinarith
+      have ha3 : 0 ≤ a ^ 3 := by positivity
+      -- Multiply the inductive bound by the nonnegative factor `1 + a`.
+      have hstep := mul_le_mul_of_nonneg_right ih h1a
+      rw [pow_succ]
+      push_cast
+      nlinarith [hstep, mul_nonneg hm2 ha3]
+
+/-- **Strict second-order Bernoulli.** For `a > 0` and `n ≥ 3`, the quadratic
+truncation is a *strict* lower bound: `1 + n·a + (n(n-1)/2)·a² < (1 + a)ⁿ`.
+
+The discarded cubic tail `C(n,2)·a³` is strictly positive once `n ≥ 3`. -/
+theorem sq_bernoulli_strict (ha : 0 < a) :
+    ∀ {n : ℕ}, 3 ≤ n → 1 + n * a + ((n : ℝ) * ((n : ℝ) - 1) / 2) * a ^ 2 < (1 + a) ^ n := by
+  have ha' : 0 ≤ a := le_of_lt ha
+  have h1a : (0 : ℝ) < 1 + a := by linarith
+  intro n hn
+  induction n, hn using Nat.le_induction with
+  | base =>
+      have hexp : (1 + a) ^ 3 = 1 + 3 * a + 3 * a ^ 2 + a ^ 3 := by ring
+      have ha3 : (0 : ℝ) < a ^ 3 := by positivity
+      push_cast
+      nlinarith [hexp, ha3]
+  | succ m hm ih =>
+      have hm2 : 0 ≤ (m : ℝ) * ((m : ℝ) - 1) := by
+        have hm1 : (1 : ℝ) ≤ (m : ℝ) := by exact_mod_cast (by omega : 1 ≤ m)
+        nlinarith
+      have ha3 : 0 ≤ a ^ 3 := by positivity
+      have hstep := mul_lt_mul_of_pos_right ih h1a
+      rw [pow_succ]
+      push_cast
+      nlinarith [hstep, mul_nonneg hm2 ha3]
+
+/-- **Equality characterization for second-order Bernoulli.** For `a ≥ 0`,
+equality `1 + n·a + (n(n-1)/2)·a² = (1 + a)ⁿ` holds **iff** `a = 0 ∨ n ≤ 2`.
+
+The threshold `n ≤ 2` (versus `n ≤ 1` for the first-order inequality) reflects
+that the quadratic truncation is exact through degree two. -/
+theorem sq_bernoulli_eq_iff (ha : 0 ≤ a) {n : ℕ} :
+    1 + n * a + ((n : ℝ) * ((n : ℝ) - 1) / 2) * a ^ 2 = (1 + a) ^ n ↔ a = 0 ∨ n ≤ 2 := by
+  constructor
+  · intro heq
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨ha0, hn⟩ := hcon
+    have hpos : 0 < a := lt_of_le_of_ne ha (Ne.symm ha0)
+    have hlt := sq_bernoulli_strict hpos (by omega : 3 ≤ n)
+    linarith
+  · rintro (rfl | hn)
+    · simp
+    · interval_cases n <;> push_cast <;> ring
+
+/-- **Sharp strictness for second-order Bernoulli.** For `a ≥ 0`, the quadratic
+truncation is a strict lower bound exactly when `a ≠ 0` and `n ≥ 3`. -/
+theorem sq_bernoulli_strict_iff (ha : 0 ≤ a) {n : ℕ} :
+    1 + n * a + ((n : ℝ) * ((n : ℝ) - 1) / 2) * a ^ 2 < (1 + a) ^ n ↔ a ≠ 0 ∧ 3 ≤ n := by
+  constructor
+  · intro h
+    refine ⟨?_, ?_⟩
+    · rintro rfl; simp at h
+    · by_contra hn
+      push_neg at hn
+      interval_cases n <;> push_cast at h <;> nlinarith [h]
+  · rintro ⟨ha0, hn⟩
+    exact sq_bernoulli_strict (lt_of_le_of_ne ha (Ne.symm ha0)) hn
+
+/-- The second-order lower bound expressed with the binomial coefficient
+`C(n,2) = n.choose 2` it represents. -/
+theorem sq_bernoulli_choose (ha : 0 ≤ a) (n : ℕ) :
+    1 + n * a + (n.choose 2 : ℝ) * a ^ 2 ≤ (1 + a) ^ n := by
+  have hcast : (n.choose 2 : ℝ) = (n : ℝ) * ((n : ℝ) - 1) / 2 := by
+    rw [Nat.choose_two_right]
+    rcases Nat.eq_zero_or_pos n with h | h
+    · subst h; simp
+    · have : 1 ≤ n := h
+      push_cast [Nat.cast_sub this]
+      ring
+  rw [hcast]; exact sq_bernoulli ha n
+
+/-- **First-order equality characterization on `a ≥ -1`** (the slug's literal
+target), a one-line corollary of the sibling's full-domain version. -/
+theorem one_add_mul_eq_pow_iff_ge (ha : -1 ≤ a) {n : ℕ} :
+    1 + n * a = (1 + a) ^ n ↔ a = 0 ∨ n ≤ 1 :=
+  BernoulliInequalityOQ01OQ01.one_add_mul_eq_pow_full_iff (by linarith)
+
+/-- The exactness at `n = 2`: the quadratic truncation is the *full* expansion,
+so equality holds for every `a`. -/
+example : ∀ a : ℝ, 1 + 2 * a + ((2 : ℝ) * ((2 : ℝ) - 1) / 2) * a ^ 2 = (1 + a) ^ 2 := by
+  intro a; ring
+
+/-- Concrete strict instance: `a = 1, n = 4`. `1 + 4 + 6 = 11 < 16 = 2⁴`. -/
+example : (1 : ℝ) + 4 * 1 + ((4 : ℝ) * ((4 : ℝ) - 1) / 2) * 1 ^ 2 < (1 + 1) ^ 4 := by
+  norm_num
+
+/-- Sharpness of `a ≥ 0`: for `-1 < a < 0` the quadratic truncation *overshoots*.
+At `a = -1/2, n = 3` the bound `1/4` exceeds `(1/2)³ = 1/8`, so the second-order
+inequality genuinely fails outside `a ≥ 0`. -/
+example : ¬ (1 : ℝ) + 3 * (-1 / 2) + ((3 : ℝ) * ((3 : ℝ) - 1) / 2) * (-1 / 2) ^ 2
+    ≤ (1 + (-1 / 2)) ^ 3 := by norm_num
+
+end BernoulliInequalityOQ01OQ02

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "weak",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 59, "endLine": 76 },
+    "type": "insight",
+    "title": "Second-Order Bernoulli Inequality",
+    "content": "sq_bernoulli is the entry's core result: for a ≥ 0 and every n, (1+a)ⁿ ≥ 1 + n·a + (n(n−1)/2)·a², the binomial expansion truncated after the quadratic term. The proof is a one-line induction. The step multiplies the inductive bound by the nonnegative factor 1 + a (mul_le_mul_of_nonneg_right); the product is the next bound plus the discarded cubic tail (m(m−1)/2)·a³, which is ≥ 0 because m(m−1) ≥ 0 for a natural m and a³ ≥ 0. Pascal's identity C(m,2) + m = C(m+1,2) is exactly what makes the quadratic coefficients line up across the step, so nlinarith closes it from the single nonnegativity hint.",
+    "mathContext": "$(1+a)^n \\ge 1 + na + \\tfrac{n(n-1)}{2}a^2$ for $a \\ge 0$; step discards $\\tfrac{m(m-1)}{2}a^3 \\ge 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Bernoulli's inequality", "binomial expansion", "Pascal's identity", "induction"],
+    "prerequisites": ["induction", "ordered fields", "binomial coefficients"]
+  },
+  {
+    "id": "strict",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 101 },
+    "type": "insight",
+    "title": "Strict Second-Order Bernoulli",
+    "content": "sq_bernoulli_strict upgrades the bound to a strict inequality for a > 0 and n ≥ 3, by Nat.le_induction from n = 3. The base case is the identity (1+a)³ − (1 + 3a + 3a²) = a³ > 0: the entire gap at n = 3 is the cubic term. The step multiplies the strict hypothesis by 1 + a > 0 (mul_lt_mul_of_pos_right) and adds the nonnegative cubic tail. The result pinpoints n = 3 as the first index where the quadratic truncation strictly undershoots — for n ≤ 2 the truncation has no room to be strict.",
+    "mathContext": "$1 + na + \\tfrac{n(n-1)}{2}a^2 < (1+a)^n$ for $a > 0$, $n \\ge 3$; base gap is $a^3$.",
+    "significance": "key",
+    "relatedConcepts": ["strict inequality", "Nat.le_induction", "cubic remainder"],
+    "prerequisites": ["the weak second-order inequality", "strict monotonicity"]
+  },
+  {
+    "id": "eq-iff",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 103, "endLine": 120 },
+    "type": "concept",
+    "title": "Equality Characterization",
+    "content": "sq_bernoulli_eq_iff answers the open question's equality problem one order up: for a ≥ 0, equality 1 + n·a + (n(n−1)/2)·a² = (1+a)ⁿ holds iff a = 0 ∨ n ≤ 2. The forward direction is the contrapositive of sq_bernoulli_strict — if a ≠ 0 and n ≥ 3 the inequality is strict, so equality forces a = 0 or n ≤ 2. The backward direction collapses the quadratic and cubic terms at a = 0, and checks n = 0,1,2 by interval_cases and ring; at n = 2 the truncation IS the full expansion (1+a)² = 1 + 2a + a², so equality is automatic. The threshold n ≤ 2 sits exactly one step above the first-order n ≤ 1.",
+    "mathContext": "For $a \\ge 0$: equality iff $a = 0 \\vee n \\le 2$; exact at $n = 2$ since $(1+a)^2 = 1 + 2a + a^2$.",
+    "significance": "key",
+    "relatedConcepts": ["equality case", "iff characterization", "interval_cases", "contrapositive"],
+    "prerequisites": ["the strict second-order inequality"]
+  },
+  {
+    "id": "strict-iff",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 122, "endLine": 134 },
+    "type": "concept",
+    "title": "Strictness Characterization",
+    "content": "sq_bernoulli_strict_iff gives the sharp two-sided form: for a ≥ 0, strictness holds iff a ≠ 0 ∧ n ≥ 3. The backward direction is sq_bernoulli_strict; the forward direction supplies the failure witnesses — a = 0 collapses both sides to 1, and n ≤ 2 is dispatched by interval_cases together with nlinarith (the truncation is exact there). Combined with eq-iff this fully classifies the comparison: equality for a = 0 ∨ n ≤ 2, strict for a ≠ 0 ∧ n ≥ 3.",
+    "mathContext": "For $a \\ge 0$: $1 + na + \\tfrac{n(n-1)}{2}a^2 < (1+a)^n \\iff a \\ne 0 \\wedge n \\ge 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sharp characterization", "iff statements", "interval_cases"],
+    "prerequisites": ["the second-order inequalities"]
+  },
+  {
+    "id": "choose-and-first-order",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 136, "endLine": 153 },
+    "type": "concept",
+    "title": "Binomial-Coefficient Form and First-Order Corollary",
+    "content": "sq_bernoulli_choose restates the lower bound with the literal binomial coefficient, (1+a)ⁿ ≥ 1 + n·a + C(n,2)·a², bridging the explicit n(n−1)/2 coefficient to n.choose 2 via Nat.choose_two_right (with a careful Nat.cast_sub for the subtraction). one_add_mul_eq_pow_iff_ge records the slug's literal first-order target — equality 1 + n·a = (1+a)ⁿ iff a = 0 ∨ n ≤ 1 on a ≥ −1 — as a one-line corollary of the sibling's full-domain characterization (−2 ≤ a), making explicit that the first-order case is already settled and this entry supplies the next order.",
+    "mathContext": "$1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$; first-order equality iff $a = 0 \\vee n \\le 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["binomial coefficient", "Nat.choose_two_right", "corollary"],
+    "prerequisites": ["the second-order inequality", "the sibling's equality characterization"]
+  },
+  {
+    "id": "witnesses",
+    "proofId": "bernoulli-inequality-oq-01-oq-02",
+    "range": { "startLine": 155, "endLine": 169 },
+    "type": "example",
+    "title": "Exactness and Sharpness Witnesses",
+    "content": "Three witnesses anchor the classification. The n = 2 identity holds for every a — the quadratic truncation is the complete expansion (1+a)² = 1 + 2a + a². A concrete strict instance at a = 1, n = 4 gives 1 + 4 + 6 = 11 < 16 = 2⁴. The sharpness witness shows the hypothesis a ≥ 0 is necessary: at a = −1/2, n = 3 the truncation 1 − 3/2 + 3/8 = 1/4 EXCEEDS (1/2)³ = 1/8, so the second-order inequality fails on −1 < a < 0 — unlike the first-order inequality, which holds down to a = −2.",
+    "mathContext": "Exact at $n=2$; strict at $(1,4)$: $11<16$; fails at $(-1/2,3)$: $1/4 > 1/8$.",
+    "significance": "supporting",
+    "relatedConcepts": ["sharpness", "numeric witness", "domain restriction"],
+    "prerequisites": ["the second-order inequality and its equality case"]
+  }
+]

--- a/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bernoulli-inequality-oq-01-oq-02/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "bernoulli-inequality-oq-01-oq-02",
+  "title": "Second-Order Bernoulli (1+a)ⁿ ≥ 1 + na + C(n,2)a² and Its Equality Case",
+  "slug": "bernoulli-inequality-oq-01-oq-02",
+  "description": "The first-order equality case of Bernoulli's inequality is already settled by the parent (a > −1) and sibling (−2 ≤ a) entries: 1 + n·a = (1+a)ⁿ iff a = 0 ∨ n ≤ 1. This entry proves the next, second-order, refinement: for a ≥ 0, truncating the binomial expansion after the quadratic term gives (1+a)ⁿ ≥ 1 + n·a + (n(n−1)/2)·a², and this sharper inequality has its own equality characterization, one step shifted — equality iff a = 0 ∨ n ≤ 2. Strictness holds exactly when a ≠ 0 and n ≥ 3, the regime in which the discarded cubic tail (n(n−1)/2)·a³ is positive. The restriction a ≥ 0 is sharp: for −1 < a < 0 the quadratic truncation overshoots.",
+  "meta": {
+    "author": "Jacob Bernoulli (1689); second-order refinement and equality classification",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Bernoulli%27s_inequality",
+    "date": "1689",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BernoulliInequalityOQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequality",
+      "bernoulli-inequality",
+      "binomial-theorem",
+      "equality-case",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "mul_le_mul_of_nonneg_right",
+        "description": "Monotonicity of multiplication by a nonnegative constant; the inductive step multiplies the second-order bound by the factor 1 + a ≥ 0.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "mul_lt_mul_of_pos_right",
+        "description": "Strict monotonicity of multiplication by a positive constant; drives the strict second-order induction for a > 0, n ≥ 3.",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      },
+      {
+        "theorem": "Nat.le_induction",
+        "description": "Induction from a base value (here n = 3), used for the strict second-order inequality.",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "Nat.choose_two_right",
+        "description": "n.choose 2 = n·(n−1)/2; bridges the explicit coefficient used in the induction to the binomial-coefficient form C(n,2).",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "one_add_mul_le_pow",
+        "description": "First-order weak Bernoulli inequality on −2 ≤ a; the result this entry refines by the next binomial term.",
+        "module": "Mathlib.Algebra.Order.Ring.Pow"
+      }
+    ],
+    "originalContributions": [
+      "sq_bernoulli: the second-order Bernoulli inequality (1+a)ⁿ ≥ 1 + n·a + (n(n−1)/2)·a² for all a ≥ 0 and n, sharpening the first-order bound by the next binomial term C(n,2)·a² — a second-order integer-power Bernoulli absent from Mathlib",
+      "sq_bernoulli_strict: the strict form 1 + n·a + (n(n−1)/2)·a² < (1+a)ⁿ for a > 0 and n ≥ 3, isolating the regime where the discarded cubic tail (n(n−1)/2)·a³ is strictly positive",
+      "sq_bernoulli_eq_iff: the equality characterization for the second-order bound on a ≥ 0 — equality iff a = 0 ∨ n ≤ 2, the threshold shifted one step up from the first-order case (n ≤ 1) because the quadratic truncation is exact through degree two",
+      "sq_bernoulli_strict_iff: the sharp two-sided strictness characterization on a ≥ 0 — strictness holds iff a ≠ 0 ∧ n ≥ 3",
+      "Sharpness of the hypothesis a ≥ 0: a numeric witness (a = −1/2, n = 3) showing the quadratic truncation overshoots on −1 < a < 0, so unlike the first-order inequality the second-order one genuinely requires nonnegativity",
+      "one_add_mul_eq_pow_iff_ge: the slug's literal first-order target (equality iff a = 0 ∨ n ≤ 1 on a ≥ −1) recorded as a one-line corollary of the sibling's full-domain characterization"
+    ],
+    "dateAdded": "2026-06-23",
+    "axioms": 0,
+    "axiomCount": 0,
+    "lineCount": 170,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (depends only on propext, Classical.choice, Quot.sound).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Bernoulli's inequality $1 + na \\le (1+a)^n$ (Jacob Bernoulli, 1689) is the degree-one truncation of the binomial expansion $(1+a)^n = \\sum_{k} \\binom{n}{k} a^k$. For $a \\ge 0$ every binomial term is nonnegative, so each successive truncation is again a lower bound. Mathlib provides the first-order form `one_add_mul_le_pow` (on $-2 \\le a$) and `rpow` Bernoulli inequalities, but not the second-order truncation $1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$ nor its equality case.",
+    "problemStatement": "**Open Question (OQ-01-OQ-02):** Characterize equality in Bernoulli's inequality. The first-order equality case is already known — $1 + na = (1+a)^n$ iff $a = 0 \\vee n \\le 1$ (parent on $a > -1$, sibling on $-2 \\le a$). What is the next refinement? For $a \\ge 0$, does the quadratic truncation $1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$ hold, and when is it an equality?\n\n**Answer:** Yes for all $a \\ge 0$. Equality holds iff $a = 0 \\vee n \\le 2$, and the inequality is strict iff $a \\ne 0 \\wedge n \\ge 3$. The equality threshold moves from $n \\le 1$ (first order) to $n \\le 2$ (second order), since the quadratic truncation is the *exact* expansion through degree two. The hypothesis $a \\ge 0$ is necessary: for $-1 < a < 0$ the truncation overshoots.",
+    "text": "Bernoulli's inequality keeps only the constant and linear terms of the binomial expansion. For a ≥ 0 the quadratic term C(n,2)a² is also nonnegative, so adding it back yields a sharper lower bound (1+a)ⁿ ≥ 1 + na + C(n,2)a². The proof is a one-line induction: multiply the bound by 1 + a ≥ 0 and use Pascal's identity C(n,2) + n = C(n+1,2), discarding the nonnegative cubic tail C(n,2)a³. Equality survives exactly as long as that tail is zero — i.e. a = 0 or n ≤ 2 — and the inequality becomes strict precisely when n ≥ 3 and a > 0.",
+    "proofStrategy": "1. **Second-order inequality** (`sq_bernoulli`): induction on $n$. Base $n = 0$ is trivial. Step: multiply the inductive bound by $1 + a \\ge 0$ (`mul_le_mul_of_nonneg_right`); the product equals the next bound plus the nonnegative cubic tail $\\frac{m(m-1)}{2}a^3$ (using $m(m-1) \\ge 0$ for a natural $m$), so `nlinarith` closes it. Pascal's identity $\\binom{m}{2} + m = \\binom{m+1}{2}$ is what makes the quadratic coefficient line up.\n2. **Strict inequality** (`sq_bernoulli_strict`): `Nat.le_induction` from $n = 3$. Base: $(1+a)^3 - (1 + 3a + 3a^2) = a^3 > 0$. Step: the strict hypothesis times $1 + a > 0$, plus the nonnegative cubic tail.\n3. **Equality iff** (`sq_bernoulli_eq_iff`): the forward direction is the contrapositive — if $a \\ne 0$ and $n \\ge 3$ then `sq_bernoulli_strict` forbids equality; conversely $a = 0$ collapses the quadratic and cubic terms, and $n \\le 2$ is checked by `interval_cases` + `ring` (at $n = 2$ the truncation is the full expansion $(1+a)^2 = 1 + 2a + a^2$).\n4. **Strict iff** (`sq_bernoulli_strict_iff`) and the binomial-coefficient restatement (`sq_bernoulli_choose`, via `Nat.choose_two_right`) round out the classification.",
+    "keyInsights": [
+      "**Each binomial truncation is a Bernoulli inequality, and its equality threshold rises by one.** First order is exact through $n \\le 1$; second order through $n \\le 2$. The pattern continues: the degree-$k$ truncation is exact iff $n \\le k$ or $a = 0$.",
+      "**Nonnegativity is now essential.** The first-order Bernoulli inequality holds down to $a = -2$, but the second-order one needs $a \\ge 0$: for $-1 < a < 0$ the quadratic term overcorrects and the truncation overshoots (at $a = -1/2, n = 3$ the bound $1/4$ exceeds $(1/2)^3 = 1/8$). The extra term is a genuine constraint, not free slack.",
+      "**The cubic tail is the entire story of strictness.** The induction discards exactly $\\binom{m}{2}a^3$ at each step; equality is preserved while that term vanishes (small $n$ or $a = 0$) and broken the instant it is positive ($n \\ge 3$, $a > 0$).",
+      "**Pascal's identity carries the induction.** The quadratic coefficients match across the step precisely because $\\binom{m}{2} + \\binom{m}{1} = \\binom{m+1}{2}$ — the same recurrence that builds the binomial coefficients builds the inequality."
+    ],
+    "prerequisites": [
+      "Bernoulli's first-order inequality and the binomial expansion",
+      "Induction, including induction from a base case (Nat.le_induction)",
+      "Pascal's identity for binomial coefficients",
+      "Monotonicity of multiplication by a nonnegative/positive constant"
+    ]
+  },
+  "sections": [
+    {
+      "id": "weak",
+      "title": "Second-Order Bernoulli Inequality",
+      "startLine": 59,
+      "endLine": 76,
+      "summary": "sq_bernoulli: for a ≥ 0 and every n, (1+a)ⁿ ≥ 1 + n·a + (n(n−1)/2)·a². One-line induction multiplying by 1 + a ≥ 0 and discarding the nonnegative cubic tail (m(m−1)/2)·a³.",
+      "mathContext": "$(1+a)^n \\ge 1 + na + \\frac{n(n-1)}{2}a^2$ for $a \\ge 0$."
+    },
+    {
+      "id": "strict",
+      "title": "Strict Second-Order Bernoulli",
+      "startLine": 78,
+      "endLine": 101,
+      "summary": "sq_bernoulli_strict: for a > 0 and n ≥ 3 the truncation is a strict lower bound. Nat.le_induction from n = 3, where (1+a)³ − (1 + 3a + 3a²) = a³ > 0.",
+      "mathContext": "$1 + na + \\frac{n(n-1)}{2}a^2 < (1+a)^n$ for $a > 0$, $n \\ge 3$."
+    },
+    {
+      "id": "eq-iff",
+      "title": "Equality Characterization",
+      "startLine": 103,
+      "endLine": 120,
+      "summary": "sq_bernoulli_eq_iff: for a ≥ 0, equality holds iff a = 0 ∨ n ≤ 2 — the threshold shifted one step up from the first-order n ≤ 1.",
+      "mathContext": "For $a \\ge 0$: equality iff $a = 0 \\vee n \\le 2$."
+    },
+    {
+      "id": "strict-iff",
+      "title": "Strictness Characterization",
+      "startLine": 122,
+      "endLine": 134,
+      "summary": "sq_bernoulli_strict_iff: for a ≥ 0, strictness holds iff a ≠ 0 ∧ n ≥ 3.",
+      "mathContext": "For $a \\ge 0$: strict iff $a \\ne 0 \\wedge n \\ge 3$."
+    },
+    {
+      "id": "choose-and-first-order",
+      "title": "Binomial-Coefficient Form and First-Order Corollary",
+      "startLine": 136,
+      "endLine": 153,
+      "summary": "sq_bernoulli_choose restates the bound with the literal C(n,2) = n.choose 2 via Nat.choose_two_right; one_add_mul_eq_pow_iff_ge records the slug's first-order equality case (a = 0 ∨ n ≤ 1 on a ≥ −1) as a corollary of the sibling.",
+      "mathContext": "$1 + na + \\binom{n}{2}a^2 \\le (1+a)^n$; first-order equality iff $a = 0 \\vee n \\le 1$."
+    },
+    {
+      "id": "witnesses",
+      "title": "Exactness and Sharpness Witnesses",
+      "startLine": 155,
+      "endLine": 169,
+      "summary": "The n = 2 identity (truncation = full expansion), a concrete strict instance (a = 1, n = 4: 11 < 16), and the sharpness witness showing the bound fails for −1 < a < 0 (a = −1/2, n = 3).",
+      "mathContext": "Exact at $n=2$; strict at $(a,n)=(1,4)$; fails at $(a,n)=(-1/2,3)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "For a ≥ 0 the quadratic truncation of the binomial expansion is a valid Bernoulli-type lower bound, (1+a)ⁿ ≥ 1 + n·a + (n(n−1)/2)·a², with equality iff a = 0 ∨ n ≤ 2 and strictness iff a ≠ 0 ∧ n ≥ 3. This refines the first-order equality case (a = 0 ∨ n ≤ 1) by one step, the increment reflecting that the quadratic truncation is exact through degree two. The hypothesis a ≥ 0 is sharp. Verified: 0 sorries, 0 axioms.",
+    "implications": "Mathlib carries only the first-order integer-power Bernoulli inequality (on −2 ≤ a) and rpow forms; the second-order truncation and its equality case were absent. This entry supplies them and exposes the general pattern: the degree-k binomial truncation is a lower bound for a ≥ 0 whose equality threshold is n ≤ k, generalizing the classical n ≤ 1 case.",
+    "openQuestions": [
+      "Does the degree-k binomial truncation 1 + Σ_{j≤k} C(n,j)a^j ≤ (1+a)ⁿ hold for all a ≥ 0 with equality iff a = 0 ∨ n ≤ k, by the same Pascal induction?",
+      "On −1 < a < 0 the even and odd truncations bracket (1+a)ⁿ from opposite sides; can the second-order truncation be replaced by a sharp two-sided enclosure there?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "bernoulli-inequality-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The sibling settles the first-order equality case on the full weak domain −2 ≤ a; this entry moves up one order, to the quadratic truncation and its equality case on a ≥ 0"
+    },
+    {
+      "targetId": "bernoulli-inequality-oq-01",
+      "relationship": "extends",
+      "description": "The parent characterizes first-order strictness and equality for a > −1; this entry adds the next binomial term and its own equality characterization"
+    },
+    {
+      "targetId": "binomial-theorem-oq-05",
+      "relationship": "related",
+      "description": "binomial-theorem-oq-05 proves the first-order strict Bernoulli inequality for a > 0; the second-order truncation here is the next term of the same expansion"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BernoulliInequalityOQ01OQ01"
+    ],
+    "opens": [],
+    "namespace": "BernoulliInequalityOQ01OQ02",
+    "lineCount": 170,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BernoulliInequalityOQ01OQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Jacob Bernoulli",
+      "title": "Positiones Arithmeticae de Seriebus Infinitis",
+      "year": "1689",
+      "venue": "Basel",
+      "note": "Origin of the inequality 1 + nx ≤ (1+x)ⁿ; the present entry adds the next binomial term"
+    },
+    {
+      "authors": "D. S. Mitrinović",
+      "title": "Analytic Inequalities",
+      "year": "1970",
+      "venue": "Springer-Verlag",
+      "note": "Standard reference on Bernoulli's inequality and its higher-order refinements"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Second-Order Bernoulli and Its Equality Case

**Problem (`bernoulli-inequality-oq-01-oq-02`):** characterize equality in Bernoulli's inequality.

The *first-order* equality case is already settled in the gallery — the parent (`bernoulli-inequality-oq-01`, for `a > −1`) and sibling (`bernoulli-inequality-oq-01-oq-01`, for the full weak domain `−2 ≤ a`) both prove `1 + n·a = (1+a)ⁿ ⟺ a = 0 ∨ n ≤ 1`. So the literal first-order target is **already redundant**. This entry delivers the genuinely new content: the **second-order** refinement and its own equality characterization.

### Result

For `a ≥ 0`, truncating the binomial expansion after the quadratic term is again a lower bound:
```
(1 + a)ⁿ  ≥  1 + n·a + (n(n−1)/2)·a²    (= 1 + n·a + C(n,2)·a²)
```
- **Equality** iff `a = 0 ∨ n ≤ 2`
- **Strict** iff `a ≠ 0 ∧ n ≥ 3`

The equality threshold moves up exactly one step from the first-order `n ≤ 1`, because the quadratic truncation is the *exact* expansion through degree two (`(1+a)² = 1 + 2a + a²`).

The hypothesis `a ≥ 0` is **sharp** (unlike first-order Bernoulli, which holds down to `a = −2`): at `a = −1/2, n = 3` the bound `1/4` overshoots `(1/2)³ = 1/8`. A numeric witness for this is included.

### Mechanism
One-line induction: multiply the bound by `1 + a ≥ 0` and use Pascal's identity `C(n,2) + n = C(n+1,2)`, discarding the nonnegative cubic tail `C(n,2)·a³`. Strictness for `n ≥ 3` is precisely that tail being positive.

### Theorems (6 theorems, 0 axioms, 0 sorries, 170 lines)
| Theorem | Statement |
|---|---|
| `sq_bernoulli` | `a ≥ 0 → 1 + n·a + (n(n−1)/2)·a² ≤ (1+a)ⁿ` |
| `sq_bernoulli_strict` | `a > 0 → n ≥ 3 → … < (1+a)ⁿ` |
| `sq_bernoulli_eq_iff` | `a ≥ 0 → (equality ↔ a = 0 ∨ n ≤ 2)` |
| `sq_bernoulli_strict_iff` | `a ≥ 0 → (strict ↔ a ≠ 0 ∧ n ≥ 3)` |
| `sq_bernoulli_choose` | binomial-coefficient restatement via `Nat.choose_two_right` |
| `one_add_mul_eq_pow_iff_ge` | slug's first-order target, as a corollary of the sibling |

### Verification
- Builds clean in docker: `./proofs/scripts/docker-build.sh Proofs.BernoulliInequalityOQ01OQ02` → exit 0
- No `sorry`, no `axiom`, no `native_decide`/`decide` → standard triple (`propext`, `Classical.choice`, `Quot.sound`), **0 axioms**
- `status: verified`, `badge: original`

Mathlib has the first-order integer-power Bernoulli (`one_add_mul_le_pow`) and `rpow` forms, but no second-order integer-power Bernoulli with an equality case — that is this entry's contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)