### PR TITLE
Enrich Liouville measure–category duality (oq-05): add index.ts + annotations

### DIFF
--- a/src/data/proofs/liouville-theorem-oq-05/annotations.json
+++ b/src/data/proofs/liouville-theorem-oq-05/annotations.json
@@ -1,0 +1,103 @@
+[
+  {
+    "id": "ann-liouoq05-1",
+    "proofId": "liouville-theorem-oq-05",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "The Measure–Category Duality of Liouville Numbers",
+    "content": "**Module framing.** The parent Liouville family established that Liouville numbers are transcendental and *residual* (comeagre — topologically 'large'). This entry formalizes the measure-theoretic counterpoint that the gallery previously carried only as prose: **Borel's theorem** (1909) that the Liouville set has Lebesgue measure **zero**, and the resulting **measure–category duality**. The real line splits into two complementary pieces, each large in one sense and small in the other: the Liouville numbers are residual yet null; their complement is meagre yet of full measure. So 'topologically generic' and 'measure-typical' are genuinely different — the Liouville set is the textbook witness (cf. Erdős–Sierpiński duality).",
+    "mathContext": "$\\mathrm{vol}\\{x : \\mathrm{Liouville}\\,x\\} = 0$ yet the set is comeagre; the filters $\\mathrm{residual}\\,\\mathbb{R}$ and $\\mathrm{ae\\ volume}$ are disjoint.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Measure–category duality",
+      "Liouville numbers",
+      "Residual / comeagre sets",
+      "Erdős–Sierpiński duality"
+    ],
+    "prerequisites": [
+      "Lebesgue measure",
+      "Baire category / residual filter"
+    ],
+    "tags": ["module-header", "framing", "measure-category"]
+  },
+  {
+    "id": "ann-liouoq05-2",
+    "proofId": "liouville-theorem-oq-05",
+    "range": { "startLine": 51, "endLine": 62 },
+    "type": "concept",
+    "title": "Borel's Theorem: the Liouville Set is Null",
+    "content": "**`volume_liouville_eq_zero`** records Borel (1909): $\\mathrm{vol}\\{x : \\mathrm{Liouville}\\,x\\} = 0$, re-exporting Mathlib's `volume_setOf_liouville` — the measure-theoretic fact the gallery previously stated only as a comment. **`ae_not_liouville'`** is the equivalent 'almost every real is not Liouville' (`ae_not_liouville`): the non-Liouville reals are co-null. Despite Liouville numbers being uncountable and dense, in measure they are negligible — a striking contrast that sets up the duality.",
+    "mathContext": "$\\mathrm{vol}\\{x : \\mathrm{Liouville}\\,x\\} = 0$; equivalently $\\forall^{\\text{ae}} x,\\ \\neg\\,\\mathrm{Liouville}\\,x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Borel's measure-zero theorem",
+      "volume_setOf_liouville",
+      "Almost-everywhere / co-null"
+    ],
+    "prerequisites": [
+      "Lebesgue measure of a set",
+      "ae filter"
+    ],
+    "tags": ["borel", "measure-zero", "main-theorem"]
+  },
+  {
+    "id": "ann-liouoq05-3",
+    "proofId": "liouville-theorem-oq-05",
+    "range": { "startLine": 64, "endLine": 75 },
+    "type": "insight",
+    "title": "Residual yet Null: Genericity ≠ Typicality",
+    "content": "**`liouville_residual_and_null`** packages the central tension: the Liouville set is *simultaneously* residual (`eventually_residual_liouville`) and Lebesgue-null (`volume_setOf_liouville`). **`exists_residual_null`** abstracts this to the pure existence statement — there *is* a residual set of measure zero — proving that topological genericity does **not** imply measure-typicality. A comeagre set, 'large' to a topologist, can be invisible to a measure theorist.",
+    "mathContext": "$\\{x : \\mathrm{Liouville}\\,x\\} \\in \\mathrm{residual}\\,\\mathbb{R} \\ \\wedge\\ \\mathrm{vol}\\{\\cdots\\} = 0$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Comeagre / residual sets",
+      "eventually_residual_liouville",
+      "Genericity vs typicality"
+    ],
+    "prerequisites": [
+      "residual filter membership",
+      "Borel's theorem"
+    ],
+    "tags": ["residual-null", "genericity", "tension"]
+  },
+  {
+    "id": "ann-liouoq05-4",
+    "proofId": "liouville-theorem-oq-05",
+    "range": { "startLine": 77, "endLine": 89 },
+    "type": "concept",
+    "title": "The Dual: a Meagre Set of Full Measure",
+    "content": "**`exists_meagre_conull`** is the mirror image: there exists a meagre set whose complement is null (i.e. a meagre set of *full* measure). The witness is the complement of the Liouville set. The proof leans on the definitional unfolding `IsMeagre S ↔ Sᶜ ∈ residual ℝ`: with $S = \\{\\mathrm{Liouville}\\}^c$, `compl_compl` reduces 'IsMeagre $S$' to '$\\{\\mathrm{Liouville}\\} \\in \\mathrm{residual}$', and the full-measure claim to Borel's theorem. So measure-typicality dually fails to imply topological genericity — the non-Liouville reals are meagre yet almost-everywhere.",
+    "mathContext": "$\\exists S,\\ \\mathrm{IsMeagre}\\,S \\wedge \\mathrm{vol}\\,S^c = 0$, witnessed by $S = \\{x : \\mathrm{Liouville}\\,x\\}^c$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Meagre / first-category sets",
+      "IsMeagre ↔ complement residual",
+      "Full measure / co-null"
+    ],
+    "prerequisites": [
+      "Definition of IsMeagre",
+      "compl_compl"
+    ],
+    "tags": ["meagre-conull", "dual", "full-measure"]
+  },
+  {
+    "id": "ann-liouoq05-5",
+    "proofId": "liouville-theorem-oq-05",
+    "range": { "startLine": 91, "endLine": 99 },
+    "type": "insight",
+    "title": "The Duality as Filter Disjointness",
+    "content": "**`residual_ae_disjoint`** states the duality in its sharpest abstract form: the filters $\\mathrm{residual}\\,\\mathbb{R}$ (topological genericity) and $\\mathrm{ae\\ volume}$ (measure-typicality) are **disjoint** (`Real.disjoint_residual_ae`). No nonempty property can be both comeagre and almost-everywhere — the two notions of 'largeness' are not merely different but incompatible. The Liouville set witnesses the disjointness concretely: it lies in `residual ℝ` while its complement is co-null. This is the clean punchline the whole file builds toward.",
+    "mathContext": "$\\mathrm{Disjoint}\\,(\\mathrm{residual}\\,\\mathbb{R})\\,(\\mathrm{ae\\ volume})$ — comeagre and almost-everywhere cannot coincide on a nonempty property.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Filter disjointness",
+      "Real.disjoint_residual_ae",
+      "Measure–category duality"
+    ],
+    "prerequisites": [
+      "Filters and Disjoint",
+      "residual and ae filters"
+    ],
+    "tags": ["duality", "filter-disjointness", "punchline"]
+  }
+]

--- a/src/data/proofs/liouville-theorem-oq-05/index.ts
+++ b/src/data/proofs/liouville-theorem-oq-05/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/LiouvilleTheoremOQ05.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const liouvilleTheoremOQ05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const liouvilleTheoremOQ05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const liouvilleTheoremOQ05Data: ProofData = {
+  proof: liouvilleTheoremOQ05Proof,
+  annotations: liouvilleTheoremOQ05Annotations,
+}


### PR DESCRIPTION
## Enrichment pass for `liouville-theorem-oq-05`

This entry shipped with only `meta.json` — it was **missing `index.ts`** (Vite's `import.meta.glob` could not discover it, so the page rendered "proof not found" on the live site) and had **no `annotations.json`**.

### Changes
- **Added `index.ts`** (standard gallery template) pointing at `Proofs/LiouvilleTheoremOQ05.lean`.
- **Added `annotations.json`** with **5 substantive annotations** covering every section:
  1. The measure–category duality framing (Erdős–Sierpiński context)
  2. Borel's measure-zero theorem (`volume_liouville_eq_zero`, `ae_not_liouville'`)
  3. Residual yet null — genericity ≠ typicality (`exists_residual_null`)
  4. The dual meagre-conull set (`exists_meagre_conull`)
  5. The duality as filter disjointness of `residual ℝ` and `ae volume`
- Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

### Verification
- `tsc -b` (full project typecheck) passes (exit 0), including the new `index.ts`.
- Axiom integrity preserved: `status: verified`, `badge: mathlib`, `axiomCount: 0` — consistent with the meta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)