### PR TITLE
research(pell-equation-oq-07-oq-01): Binet + companion-matrix closed forms [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3333,6 +3333,8 @@ import Proofs.PellEquationOQ05
 import Proofs.PellEquationOQ06
 import Proofs.PellEquationOQ06OQ01
 import Proofs.PellEquationOQ06OQ02
+import Proofs.PellEquationOQ07
+import Proofs.PellEquationOQ07OQ01
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ02

--- a/proofs/Proofs/PellEquationOQ07OQ01.lean
+++ b/proofs/Proofs/PellEquationOQ07OQ01.lean
@@ -1,0 +1,232 @@
+/-
+Pell's Equation OQ-07 → OQ-01: Binet and Companion-Matrix Closed Forms
+
+The parent entry (`pell-equation-oq-07`, `PellEquationOQ07.lean`, verified) extracts
+the *additive shadow* of the multiplicative structure of Pell solutions: each
+coordinate of the power sequence `aⁿ` of a generating quadratic integer
+`a = ⟨x₁, y₁⟩ ∈ ℤ√d` obeys the second-order recurrence
+
+    uₙ₊₂ = (2·x₁)·uₙ₊₁ − N(a)·uₙ                       (Cayley–Hamilton recurrence)
+
+— and for a Pell solution (`N(a) = 1`) this collapses to `uₙ₊₂ = 2x₁·uₙ₊₁ − uₙ`.
+That gives the *step rule* of the sequence. This entry supplies the two **closed
+forms** the recurrence is the shadow of:
+
+* a **Binet form** expressing each coordinate of `aⁿ` directly in terms of the
+  two conjugate roots `x₁ ± y₁√d` of the characteristic polynomial
+  `t² − (2x₁)·t + N(a)`, and
+* a **companion-matrix power** form `Mⁿ`, where `M` is the matrix of
+  multiplication-by-`a` on the basis `{1, √d}`, whose trace and determinant are
+  exactly the `(2x₁, N(a))` coefficients of that characteristic polynomial.
+
+## The mechanism: conjugation is the involution `star`
+
+`ℤ√d` carries the ring involution `star ⟨x, y⟩ = ⟨x, −y⟩` (Mathlib's `StarRing`
+instance), i.e. the Galois conjugation `x + y√d ↦ x − y√d`. Because `star` is a
+ring homomorphism on the commutative ring `ℤ√d`, it commutes with powers
+(`star_pow`). Reading the real and `√d` parts of `aⁿ ± (star a)ⁿ` isolates the two
+coordinates:
+
+    aⁿ + (star a)ⁿ = ⟨2·re(aⁿ), 0⟩,        aⁿ − (star a)ⁿ = ⟨0, 2·im(aⁿ)⟩.
+
+Mapping these into `ℝ` through the ring hom `Zsqrtd.lift √d : ℤ√d →+* ℝ`
+(`a ↦ a.re + a.im·√d`, defined for `d ≥ 0`) turns them into the classical Binet
+formulas, since `lift` sends `a` and `star a` to the conjugate reals
+`x₁ + y₁√d` and `x₁ − y₁√d`.
+
+## Main results
+
+* `pow_add_star_pow` / `pow_sub_star_pow` — the conjugate-symmetric decompositions
+  `aⁿ ± (star a)ⁿ` inside `ℤ√d` (coordinate isolation; no hypothesis on `d`).
+* `re_binet` — `re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ) / 2`  (`d ≥ 0`).
+* `im_binet` — `2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ`  (`d ≥ 0`).
+* `companion_pow` — `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]` for the
+  multiplication-by-`a` matrix `M = !![x₁, d·y₁; y₁, x₁]`.
+* `companion_trace` / `companion_det` — `tr M = 2x₁`, `det M = N(a)`: the
+  coefficients of the characteristic polynomial `t² − (2x₁)t + N(a)`, whose roots
+  are the conjugate units `x₁ ± y₁√d`.
+* `companion_det_pell` — `det M = 1` for a Pell generator (norm `1`).
+* Concrete `D = 2` checks against the chain `(3 + 2√2)ⁿ` (`1,3,17,99,…` /
+  `0,2,12,70,…`): `companion_pow_two`, numeric matrix and Binet examples.
+
+All proofs are `sorry`-free and axiom-free (no `native_decide`).
+
+References:
+- Parent entry: `pell-equation-oq-07` (the recurrence these are closed forms of).
+- Mathlib `Mathlib/NumberTheory/Zsqrtd/Basic.lean` (`Zsqrtd`, `star`, `norm`,
+  `lift`, `re_mul`, `im_mul`).
+- Companion matrix / Cayley–Hamilton: roots of `t² − (tr M)t + det M` are the
+  eigenvalues `x₁ ± y₁√d` of `M`.
+-/
+
+import Proofs.PellEquationOQ07
+
+namespace PellEquationOQ07OQ01
+
+open Zsqrtd
+
+variable {d : ℤ}
+
+/-
+## Conjugate-symmetric decomposition inside `ℤ√d`
+
+Conjugation `star : ℤ√d → ℤ√d`, `⟨x,y⟩ ↦ ⟨x,−y⟩`, is a ring involution, so it
+commutes with powers (`star_pow`). Adding/subtracting `aⁿ` and `(star a)ⁿ`
+isolates the two coordinates of the power sequence.
+-/
+
+/-- **Real-part isolation.** `aⁿ + (star a)ⁿ = ⟨2·re(aⁿ), 0⟩`: conjugation fixes the
+rational part and negates the `√d` part, so the sum is twice the real coordinate and
+purely rational. -/
+theorem pow_add_star_pow (a : ℤ√d) (n : ℕ) :
+    a ^ n + star a ^ n = ((2 * (a ^ n).re : ℤ) : ℤ√d) := by
+  have hstar : star (a ^ n) = star a ^ n := star_pow a n
+  refine Zsqrtd.ext ?_ ?_
+  · rw [re_add, ← hstar, re_star, re_intCast]; ring
+  · rw [im_add, ← hstar, im_star, im_intCast]; ring
+
+/-- **`√d`-part isolation.** `aⁿ − (star a)ⁿ = ⟨0, 2·im(aⁿ)⟩`: the difference cancels
+the rational part and doubles the `√d` coordinate. -/
+theorem pow_sub_star_pow (a : ℤ√d) (n : ℕ) :
+    a ^ n - star a ^ n = (⟨0, 2 * (a ^ n).im⟩ : ℤ√d) := by
+  have hstar : star (a ^ n) = star a ^ n := star_pow a n
+  refine Zsqrtd.ext ?_ ?_
+  · rw [re_sub, ← hstar, re_star]; ring
+  · rw [im_sub, ← hstar, im_star]; ring
+
+/-
+## The Binet closed forms over `ℝ`
+
+For `d ≥ 0` the assignment `a ↦ a.re + a.im·√d` is the ring homomorphism
+`Zsqrtd.lift ⟨√d, _⟩ : ℤ√d →+* ℝ`. It sends `a = ⟨x₁,y₁⟩` and `star a` to the
+conjugate reals `x₁ + y₁√d` and `x₁ − y₁√d`, the two roots of the characteristic
+polynomial. Applying it to the decompositions above gives Binet's formulas.
+-/
+
+/-- The real ring homomorphism `ℤ√d →+* ℝ`, `⟨x,y⟩ ↦ x + y·√d`, for `d ≥ 0`. -/
+private noncomputable def toReal (hd : 0 ≤ d) : ℤ√d →+* ℝ :=
+  Zsqrtd.lift ⟨Real.sqrt d, Real.mul_self_sqrt (by exact_mod_cast hd : (0 : ℝ) ≤ (d : ℝ))⟩
+
+private theorem toReal_apply (hd : 0 ≤ d) (a : ℤ√d) :
+    toReal hd a = (a.re : ℝ) + a.im * Real.sqrt d :=
+  Zsqrtd.lift_apply_apply _ a
+
+/-- **Binet's formula for the real coordinate.** For `d ≥ 0` and `a = ⟨x₁,y₁⟩`,
+`re(aⁿ) = ((x₁ + y₁√d)ⁿ + (x₁ − y₁√d)ⁿ) / 2` — the average of the `n`-th powers of
+the two conjugate roots of `t² − (2x₁)t + N(a)`. -/
+theorem re_binet (a : ℤ√d) (hd : 0 ≤ d) (n : ℕ) :
+    ((a ^ n).re : ℝ)
+      = (((a.re : ℝ) + a.im * Real.sqrt d) ^ n
+          + ((a.re : ℝ) - a.im * Real.sqrt d) ^ n) / 2 := by
+  have hsa : toReal hd (star a) = (a.re : ℝ) - a.im * Real.sqrt d := by
+    rw [toReal_apply, re_star, im_star]; push_cast; ring
+  have key : toReal hd (a ^ n) + toReal hd (star a ^ n)
+      = ((2 * (a ^ n).re : ℤ) : ℝ) := by
+    rw [← map_add, pow_add_star_pow a n, map_intCast]
+  rw [map_pow, map_pow, toReal_apply hd a, hsa] at key
+  push_cast at key
+  linarith [key]
+
+/-- **Binet's formula for the `√d` coordinate.** For `d ≥ 0` and `a = ⟨x₁,y₁⟩`,
+`2·im(aⁿ)·√d = (x₁ + y₁√d)ⁿ − (x₁ − y₁√d)ⁿ` — the difference of the `n`-th powers of
+the conjugate roots. (Stated multiplicatively so it also holds at `d = 0`.) -/
+theorem im_binet (a : ℤ√d) (hd : 0 ≤ d) (n : ℕ) :
+    ((a ^ n).im : ℝ) * (2 * Real.sqrt d)
+      = ((a.re : ℝ) + a.im * Real.sqrt d) ^ n
+          - ((a.re : ℝ) - a.im * Real.sqrt d) ^ n := by
+  have hsa : toReal hd (star a) = (a.re : ℝ) - a.im * Real.sqrt d := by
+    rw [toReal_apply, re_star, im_star]; push_cast; ring
+  have key : toReal hd (a ^ n) - toReal hd (star a ^ n)
+      = toReal hd (⟨0, 2 * (a ^ n).im⟩ : ℤ√d) := by
+    rw [← map_sub, pow_sub_star_pow a n]
+  rw [map_pow, map_pow, toReal_apply hd a, hsa, toReal_apply] at key
+  push_cast at key
+  linarith [key]
+
+/-
+## The companion-matrix closed form
+
+On the basis `{1, √d}`, multiplication by `a = ⟨x₁,y₁⟩` sends `1 ↦ ⟨x₁,y₁⟩` and
+`√d ↦ ⟨d·y₁, x₁⟩`, so its matrix is `M = !![x₁, d·y₁; y₁, x₁]`. Powers of `M`
+realise multiplication by `aⁿ`, hence carry the coordinates of `aⁿ`.
+-/
+
+/-- The multiplication-by-`a` matrix on the basis `{1, √d}`. -/
+def companion (a : ℤ√d) : Matrix (Fin 2) (Fin 2) ℤ :=
+  !![a.re, d * a.im; a.im, a.re]
+
+/-- **The companion-matrix power form.** `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]`:
+the powers of the multiplication matrix carry exactly the coordinates of the power
+sequence `aⁿ`. -/
+theorem companion_pow (a : ℤ√d) (n : ℕ) :
+    (companion a) ^ n
+      = !![(a ^ n).re, d * (a ^ n).im; (a ^ n).im, (a ^ n).re] := by
+  induction n with
+  | zero =>
+      simp only [pow_zero, pow_zero, re_one, im_one, mul_zero, Matrix.one_fin_two]
+  | succ k ih =>
+      have hre : (a ^ (k + 1)).re = (a ^ k).re * a.re + d * (a ^ k).im * a.im := by
+        rw [pow_succ, re_mul]
+      have him : (a ^ (k + 1)).im = (a ^ k).re * a.im + (a ^ k).im * a.re := by
+        rw [pow_succ, im_mul]
+      rw [pow_succ, ih, companion, hre, him]
+      ext i j
+      fin_cases i <;> fin_cases j <;>
+        simp [Matrix.mul_apply, Fin.sum_univ_two, Matrix.cons_val_zero,
+          Matrix.cons_val_one] <;> ring
+
+/-- **Trace of the companion matrix** equals `2·x₁`, the linear coefficient (with a
+sign) of the characteristic polynomial `t² − (2x₁)t + N(a)`. -/
+theorem companion_trace (a : ℤ√d) : (companion a).trace = 2 * a.re := by
+  rw [companion, Matrix.trace_fin_two_of]; ring
+
+/-- **Determinant of the companion matrix** equals the norm `N(a)`, the constant
+coefficient of the characteristic polynomial `t² − (2x₁)t + N(a)`. -/
+theorem companion_det (a : ℤ√d) : (companion a).det = a.norm := by
+  rw [companion, Matrix.det_fin_two_of, Zsqrtd.norm_def]
+
+/-- For a **Pell generator** (norm `1`) the companion matrix has determinant `1`, so
+its characteristic polynomial is `t² − (2x₁)t + 1`, with conjugate-unit roots
+`x₁ ± y₁√d`. -/
+theorem companion_det_pell (a : ℤ√d) (h : a.norm = 1) : (companion a).det = 1 := by
+  rw [companion_det, h]
+
+/-
+## Concrete `D = 2` checks
+
+The fundamental norm-`1` unit of `ℤ[√2]` is `3 + 2√2 = ⟨3,2⟩`. Its power sequence
+begins `1, 3, 17, 99, 577, …` (real part) and `0, 2, 12, 70, 408, …` (`√2` part).
+The companion matrix is `!![3, 4; 2, 3]`.
+-/
+
+/-- The `D = 2` companion matrix `M = !![3, 4; 2, 3]` and its power form. -/
+theorem companion_pow_two (n : ℕ) :
+    (!![3, 4; 2, 3] : Matrix (Fin 2) (Fin 2) ℤ) ^ n
+      = !![((⟨3, 2⟩ : ℤ√2) ^ n).re, 2 * ((⟨3, 2⟩ : ℤ√2) ^ n).im;
+            ((⟨3, 2⟩ : ℤ√2) ^ n).im, ((⟨3, 2⟩ : ℤ√2) ^ n).re] := by
+  have h := companion_pow (⟨3, 2⟩ : ℤ√2) n
+  rwa [companion, show ((⟨3, 2⟩ : ℤ√2)).re = 3 from rfl,
+    show ((⟨3, 2⟩ : ℤ√2)).im = 2 from rfl, show (2 : ℤ) * 2 = 4 from rfl] at h
+
+/-- The `n = 2` coordinates of `(3+2√2)ⁿ`: `(3+2√2)² = 17 + 12√2`. -/
+example : ((⟨3, 2⟩ : ℤ√2) ^ 2).re = 17 ∧ ((⟨3, 2⟩ : ℤ√2) ^ 2).im = 12 := by decide
+
+/-- `M² = !![17, 24; 12, 17]`, matching `(3+2√2)² = 17 + 12√2` via `companion_pow_two`. -/
+example : (!![3, 4; 2, 3] : Matrix (Fin 2) (Fin 2) ℤ) ^ 2 = !![17, 24; 12, 17] := by
+  rw [pow_two, Matrix.mul_fin_two]; norm_num
+
+/-- The determinant of the `D = 2` companion matrix is `1` (Pell norm). -/
+example : (companion (⟨3, 2⟩ : ℤ√2)).det = 1 :=
+  companion_det_pell _ PellEquationOQ07.norm_three_two
+
+#check @pow_add_star_pow
+#check @pow_sub_star_pow
+#check @re_binet
+#check @im_binet
+#check @companion_pow
+#check @companion_trace
+#check @companion_det
+#check @companion_det_pell
+#check @companion_pow_two
+
+end PellEquationOQ07OQ01

--- a/src/data/proofs/pell-equation-oq-07-oq-01/annotations.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01/annotations.json
@@ -1,0 +1,123 @@
+[
+  {
+    "id": "ann-pell-oq0701-docstring",
+    "proofId": "pell-equation-oq-07-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 60
+    },
+    "type": "context",
+    "title": "From the Recurrence to its Closed Forms",
+    "content": "The docstring answers the parent entry's first open question. The parent (pell-equation-oq-07) showed the coordinate sequences of aⁿ obey the recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ — the step rule. This entry supplies the two closed forms that rule is the shadow of: a Binet form in the conjugate roots x₁ ± y₁√d, and a companion-matrix power Mⁿ. The unifying mechanism is that Galois conjugation x + y√d ↦ x − y√d is exactly Mathlib's StarRing involution star on ℤ[√d], a ring homomorphism that commutes with powers (star_pow); reading the rational and √d parts of aⁿ ± (star a)ⁿ isolates the two coordinate sequences.",
+    "mathContext": "$(x_1 + y_1\\sqrt d)^n = x_n + y_n\\sqrt d$ and its conjugate $(x_1 - y_1\\sqrt d)^n = x_n - y_n\\sqrt d$ give $x_n,y_n$ as the average/difference of the conjugate units' powers.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Pell's equation",
+      "Binet formula",
+      "quadratic integers",
+      "Galois conjugation",
+      "companion matrix",
+      "linear recurrence"
+    ],
+    "prerequisites": [
+      "the ring ℤ[√d] (Zsqrtd)",
+      "the norm and conjugation on ℤ[√d]",
+      "linear recurrences and their characteristic polynomials"
+    ]
+  },
+  {
+    "id": "ann-pell-oq0701-conjugate-split",
+    "proofId": "pell-equation-oq-07-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 95
+    },
+    "type": "key-technique",
+    "title": "Conjugation = star Isolates the Coordinates",
+    "content": "pow_add_star_pow and pow_sub_star_pow are the algebraic heart of the Binet formula, proved with no analysis. Conjugation on ℤ[√d] is Mathlib's StarRing involution star ⟨x,y⟩ = ⟨x,−y⟩, which is a ring homomorphism and so commutes with powers: star (aⁿ) = (star a)ⁿ (star_pow). Since star fixes the rational part and negates the √d part, the sum aⁿ + (star a)ⁿ = ⟨2·re(aⁿ),0⟩ is purely rational and the difference aⁿ − (star a)ⁿ = ⟨0,2·im(aⁿ)⟩ is purely irrational. Each identity is closed by Zsqrtd.ext followed by reading re and im through re_star/im_star.",
+    "mathContext": "For $a = x + y\\sqrt d$ with conjugate $\\bar a = x - y\\sqrt d$: $a^n + \\bar a^n = 2\\,\\mathrm{re}(a^n)$ and $a^n - \\bar a^n = 2\\,\\mathrm{im}(a^n)\\sqrt d$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "StarRing involution",
+      "ring homomorphism",
+      "star_pow",
+      "Galois conjugation"
+    ],
+    "prerequisites": [
+      "the StarRing structure on ℤ[√d]",
+      "star commutes with powers"
+    ]
+  },
+  {
+    "id": "ann-pell-oq0701-binet",
+    "proofId": "pell-equation-oq-07-oq-01",
+    "range": {
+      "startLine": 106,
+      "endLine": 144
+    },
+    "type": "main-result",
+    "title": "Binet's Formula via the Real Evaluation Ring Hom",
+    "content": "re_binet and im_binet are the closed forms. The bridge from ℤ[√d] to ℝ is the ring homomorphism toReal = Zsqrtd.lift ⟨Real.sqrt d, _⟩ : ℤ[√d] →+* ℝ (defined for d ≥ 0, with √d·√d = d from Real.mul_self_sqrt), which sends a = ⟨x₁,y₁⟩ to x₁ + y₁√d and star a to x₁ − y₁√d — the two conjugate roots of the characteristic polynomial. Applying this ring hom to the integer decompositions of the previous step (using map_add/map_sub, map_pow, map_intCast) turns them directly into Binet's formulas: re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ)/2 and 2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ. No induction over n is required — the homomorphism carries all the structure. The im form is stated multiplicatively so it remains valid at d = 0.",
+    "mathContext": "$\\mathrm{re}(a^n) = \\tfrac12\\big((x_1+y_1\\sqrt d)^n + (x_1-y_1\\sqrt d)^n\\big)$, $\\;2\\,\\mathrm{im}(a^n)\\sqrt d = (x_1+y_1\\sqrt d)^n - (x_1-y_1\\sqrt d)^n$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "Binet formula",
+      "Zsqrtd.lift",
+      "ring homomorphism",
+      "Real.sqrt",
+      "conjugate roots"
+    ],
+    "prerequisites": [
+      "ring homomorphisms preserve sums, products, powers",
+      "Zsqrtd.lift evaluates √d at a chosen square root",
+      "Real.mul_self_sqrt"
+    ]
+  },
+  {
+    "id": "ann-pell-oq0701-companion",
+    "proofId": "pell-equation-oq-07-oq-01",
+    "range": {
+      "startLine": 154,
+      "endLine": 192
+    },
+    "type": "main-result",
+    "title": "The Companion-Matrix Power Form and the Eigenvalue Picture",
+    "content": "companion_pow gives the matrix closed form. The companion matrix M = !![x₁, d·y₁; y₁, x₁] is the matrix of multiplication-by-a on the basis {1, √d}, so Mⁿ realizes multiplication-by-aⁿ and its entries are exactly re(aⁿ) and im(aⁿ): Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]. The proof is a two-line induction using Matrix.mul_apply, Fin.sum_univ_two and Zsqrtd.re_mul/im_mul. companion_trace and companion_det compute tr M = 2x₁ and det M = N(a) — the coefficients of the characteristic polynomial t² − 2x₁·t + N(a), whose roots are the conjugate units x₁ ± y₁√d. For a Pell generator (N(a) = 1) companion_det_pell gives det M = 1, so the eigenvalues are conjugate units of the form x₁ ± y₁√d with product 1.",
+    "mathContext": "$M = \\begin{pmatrix} x_1 & d\\,y_1\\\\ y_1 & x_1\\end{pmatrix}$, $\\;M^n = \\begin{pmatrix} x_n & d\\,y_n\\\\ y_n & x_n\\end{pmatrix}$, $\\;\\operatorname{tr}M = 2x_1$, $\\;\\det M = N(a)$.",
+    "significance": "high",
+    "relatedConcepts": [
+      "companion matrix",
+      "characteristic polynomial",
+      "eigenvalues",
+      "matrix power",
+      "trace and determinant"
+    ],
+    "prerequisites": [
+      "2×2 matrix multiplication",
+      "trace and determinant of a 2×2 matrix",
+      "multiplication-by-a as a linear map on ℤ[√d]"
+    ]
+  },
+  {
+    "id": "ann-pell-oq0701-d-two",
+    "proofId": "pell-equation-oq-07-oq-01",
+    "range": {
+      "startLine": 194,
+      "endLine": 219
+    },
+    "type": "example",
+    "title": "The D = 2 Instance: !![3,4;2,3] and the Chain 1,3,17,99,577",
+    "content": "companion_pow_two specializes to the fundamental norm-1 unit 3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2], whose companion matrix is exactly the transfer matrix !![3,4;2,3] of the sibling entry pell-equation-oq-06-oq-03. Its n-th power carries the coordinates of (3+2√2)ⁿ: the real parts 1,3,17,99,577,… and √2 parts 0,2,12,70,408,…. The numeric checks confirm (3+2√2)² = 17 + 12√2 (by decide) and M² = !![17,24;12,17] (by Matrix.mul_fin_two + norm_num), and companion_det_pell gives det = 1.",
+    "mathContext": "$M = \\begin{pmatrix}3&4\\\\2&3\\end{pmatrix}$, $\\;M^2 = \\begin{pmatrix}17&24\\\\12&17\\end{pmatrix}$, $\\;(3+2\\sqrt2)^2 = 17 + 12\\sqrt2$, $\\;\\det M = 1$.",
+    "significance": "medium",
+    "relatedConcepts": [
+      "fundamental unit of ℤ[√2]",
+      "transfer matrix",
+      "Pell numbers"
+    ],
+    "prerequisites": [
+      "the unit 3 + 2√2 of ℤ[√2]",
+      "kernel decide for concrete ℤ[√d] arithmetic"
+    ]
+  }
+]

--- a/src/data/proofs/pell-equation-oq-07-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-07-oq-01/meta.json
@@ -1,0 +1,81 @@
+{
+  "id": "pell-equation-oq-07-oq-01",
+  "title": "Binet and Companion-Matrix Closed Forms for Pell Coordinate Sequences",
+  "slug": "pell-equation-oq-07-oq-01",
+  "description": "The parent entry (pell-equation-oq-07) extracts the second-order linear recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ that the coordinate sequences of the power sequence aⁿ of a generator a = ⟨x₁,y₁⟩ ∈ ℤ[√d] satisfy — the recurrence is the additive shadow of the multiplicative power structure. This entry answers the parent's own first open question by supplying the two closed forms the recurrence is the shadow of: a Binet form expressing each coordinate of aⁿ in terms of the conjugate roots x₁ ± y₁√d of the characteristic polynomial t² − 2x₁·t + N(a), and a companion-matrix power form Mⁿ. The mechanism is that Galois conjugation x + y√d ↦ x − y√d is exactly Mathlib's ring involution star on ℤ[√d], which commutes with powers (star_pow); reading the real and √d parts of aⁿ ± (star a)ⁿ isolates the two coordinate sequences as aⁿ + (star a)ⁿ = ⟨2·re(aⁿ),0⟩ and aⁿ − (star a)ⁿ = ⟨0,2·im(aⁿ)⟩. Mapping these into ℝ through the ring hom Zsqrtd.lift √d (defined for d ≥ 0), which sends a and star a to the conjugate reals x₁ ± y₁√d, yields Binet's formulas re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ)/2 and 2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ. The companion matrix M = ⟨⟨x₁, d·y₁⟩, ⟨y₁, x₁⟩⟩ of multiplication-by-a on the basis {1,√d} has Mⁿ = ⟨⟨re(aⁿ), d·im(aⁿ)⟩, ⟨im(aⁿ), re(aⁿ)⟩⟩, with trace 2x₁ and determinant N(a) — the coefficients of the characteristic polynomial whose roots are the conjugate units, made explicit (eigenvalue picture).",
+  "leanFile": "Proofs/PellEquationOQ07OQ01.lean",
+  "sorries": 0,
+  "meta": {
+    "author": "Lean Genius (Binet/companion-matrix closed forms via conjugation = star in ℤ[√d]); Binet / Lagrange (classical closed-form Pell theory)",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/PellEquationOQ07OQ01.lean",
+    "tags": [
+      "number-theory",
+      "diophantine-equations",
+      "pell-equation",
+      "quadratic-integers",
+      "zsqrtd",
+      "binet-formula",
+      "closed-form",
+      "companion-matrix",
+      "characteristic-polynomial",
+      "conjugation",
+      "research"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-06-23",
+    "lineCount": 232,
+    "originalContributions": [
+      "pow_add_star_pow / pow_sub_star_pow: the conjugate-symmetric decompositions aⁿ + (star a)ⁿ = ⟨2·re(aⁿ),0⟩ and aⁿ − (star a)ⁿ = ⟨0,2·im(aⁿ)⟩ inside ℤ[√d] for every a and any d, isolating each coordinate of the power sequence — proved by Zsqrtd.ext + star_pow (conjugation is Mathlib's StarRing involution, a ring hom that commutes with powers)",
+      "re_binet: Binet's formula for the real coordinate, re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ)/2 for d ≥ 0, obtained by pushing the integer decomposition through the ring hom Zsqrtd.lift ⟨√d, _⟩ : ℤ[√d] →+* ℝ that sends a and star a to the conjugate roots x₁ ± y₁√d",
+      "im_binet: Binet's formula for the √d coordinate, 2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ (stated multiplicatively so it holds at d = 0 too), the difference of the conjugate roots' n-th powers",
+      "companion (def) + companion_pow: the multiplication-by-a matrix M = !![x₁, d·y₁; y₁, x₁] on the basis {1,√d} satisfies Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)], proved by induction using Matrix.mul_apply, Fin.sum_univ_two and Zsqrtd.re_mul/im_mul — powers of the matrix carry exactly the coordinates of aⁿ",
+      "companion_trace / companion_det / companion_det_pell: tr M = 2x₁ and det M = N(a) are the coefficients of the characteristic polynomial t² − 2x₁·t + N(a), whose roots are the conjugate units x₁ ± y₁√d (the eigenvalue picture); for a Pell generator (N(a) = 1) the determinant is 1, giving t² − 2x₁·t + 1",
+      "companion_pow_two: the D = 2 instance — the companion matrix !![3,4;2,3] of the fundamental unit 3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2] has Mⁿ carrying the coordinates of (3+2√2)ⁿ; numeric checks M² = !![17,24;12,17] and (3+2√2)² = 17 + 12√2 against the chain 1,3,17,99,577 / 0,2,12,70,408"
+    ],
+    "assumptions": "None. Fully machine-checked: 0 axioms, 0 sorries, no native_decide (the two `decide` uses are kernel `decide`, not `native_decide`, so no Lean.ofReduceBool). #print axioms reports only the standard triple [propext, Classical.choice, Quot.sound]; Classical.choice enters solely through Real.sqrt. Uses Mathlib's Zsqrtd API (star/star_pow, re_mul, im_mul, norm_def, lift), the Real.sqrt API (mul_self_sqrt), the 2×2 Matrix API (mul_apply, det_fin_two_of, trace_fin_two_of, one_fin_two), and standard tactics (induction, simp, ring, linarith, push_cast, decide).",
+    "theoremCount": 10,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "pell-equation-oq-07",
+      "relationship": "extends",
+      "description": "The parent derives the recurrence uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ for the coordinate sequences of aⁿ via Cayley–Hamilton in ℤ[√d], and lists the Binet and companion-matrix closed forms as its first open question. This entry proves exactly those: the Binet form via conjugation = star and Zsqrtd.lift, and the companion-matrix power form Mⁿ with trace 2x₁, determinant N(a)."
+    },
+    {
+      "targetId": "pell-equation-oq-06-oq-03",
+      "relationship": "related",
+      "description": "The sibling proves the D = 2 chain obeys uₙ₊₂ = 6uₙ₊₁ − uₙ and attributes the 6 to a transfer matrix [[3,4],[2,3]]. This entry proves that exact matrix !![3,4;2,3] is the companion matrix of 3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2] and that its n-th power carries the coordinates of (3+2√2)ⁿ, with the conjugate-unit eigenvalues 3 ± 2√2 made explicit."
+    },
+    {
+      "targetId": "pell-equation",
+      "relationship": "related",
+      "description": "The root entry classifies Pell solutions multiplicatively as powers of a fundamental unit. This entry gives the explicit closed forms of the coordinates of those powers — the Binet average/difference of the conjugate units and the companion-matrix power — turning the abstract power classification into computable formulas."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Binet's formula — expressing the n-th term of a Lucas-type sequence as a combination of the n-th powers of the two roots of its characteristic polynomial — is the classical closed form for Pell coordinate sequences: writing (x₁ + y₁√D)ⁿ = xₙ + yₙ√D and its conjugate (x₁ − y₁√D)ⁿ = xₙ − yₙ√D, addition and subtraction give xₙ = ((x₁+y₁√D)ⁿ + (x₁−y₁√D)ⁿ)/2 and yₙ√D = ((x₁+y₁√D)ⁿ − (x₁−y₁√D)ⁿ)/2. Equivalently the column (xₙ, yₙ) is the n-th power of the companion matrix [[x₁, D·y₁],[y₁, x₁]] applied to (1,0); the matrix is the transfer matrix of the linear recurrence and its eigenvalues are the conjugate units x₁ ± y₁√D, roots of t² − 2x₁t + N. This entry formalizes both closed forms inside Mathlib's quadratic-integer ring ℤ[√d] for arbitrary d, identifying Galois conjugation with the StarRing involution and the conjugate roots with the image of a, star a under the real evaluation Zsqrtd.lift √d.",
+    "problemStatement": "The parent entry derived the recurrence the Pell coordinate sequences satisfy but left their closed forms as an open question: can one express re(aⁿ) and im(aⁿ) directly in terms of the conjugate roots x₁ ± y₁√d of the characteristic polynomial (Binet form), and realize the coordinate vector as a power of the companion matrix, making the eigenvalue picture explicit?",
+    "proofStrategy": "Work in Mathlib's ℤ√d = Zsqrtd d. (1) Identify Galois conjugation with the StarRing involution star ⟨x,y⟩ = ⟨x,−y⟩, which commutes with powers (star_pow). Prove pow_add_star_pow and pow_sub_star_pow by Zsqrtd.ext, reading re/im of aⁿ ± (star a)ⁿ. (2) For d ≥ 0 build the ring hom toReal = Zsqrtd.lift ⟨Real.sqrt d, Real.mul_self_sqrt _⟩ : ℤ[√d] →+* ℝ, sending a ↦ a.re + a.im·√d; it sends a and star a to x₁ ± y₁√d. Push the two integer decompositions through toReal (map_add/map_sub, map_pow, map_intCast) and finish with push_cast + linarith to get re_binet and im_binet. (3) Define the companion matrix and prove companion_pow by induction with Matrix.mul_apply, Fin.sum_univ_two and Zsqrtd.re_mul/im_mul; compute trace (trace_fin_two_of) and determinant (det_fin_two_of + norm_def). (4) Instantiate at a = ⟨3,2⟩ ∈ ℤ[√2] for the D = 2 matrix !![3,4;2,3] and numeric checks by decide / norm_num.",
+    "keyInsights": [
+      "Galois conjugation x + y√d ↦ x − y√d is exactly Mathlib's StarRing involution star on ℤ[√d]. Because star is a ring homomorphism on the commutative ring ℤ[√d], star (aⁿ) = (star a)ⁿ (star_pow): conjugation commutes with taking powers, which is the entire content needed to split the power sequence into its two coordinates.",
+      "Adding and subtracting aⁿ and (star a)ⁿ isolates the coordinates: aⁿ + (star a)ⁿ = ⟨2·re(aⁿ),0⟩ is purely rational and aⁿ − (star a)ⁿ = ⟨0,2·im(aⁿ)⟩ is purely irrational, because conjugation fixes the rational part and negates the √d part. This is the algebraic heart of Binet's formula, proved with no analysis at all.",
+      "The bridge to the real closed form is the ring hom Zsqrtd.lift ⟨√d,_⟩ : ℤ[√d] →+* ℝ, which evaluates a = ⟨x₁,y₁⟩ at √d to x₁ + y₁√d and star a to x₁ − y₁√d. Applying a ring hom to the integer decompositions turns them into Binet's averages/differences of the conjugate roots — the homomorphism does all the work, no induction over n is needed for the closed form.",
+      "The companion matrix M = [[x₁, d·y₁],[y₁, x₁]] is the matrix of multiplication-by-a in the basis {1,√d}, so Mⁿ is multiplication-by-aⁿ and its entries are exactly re(aⁿ), im(aⁿ). Its trace 2x₁ and determinant N(a) are the coefficients of the characteristic polynomial t² − 2x₁t + N(a), whose roots are the conjugate units — the eigenvalue picture behind Binet made fully explicit.",
+      "Everything specializes cleanly to D = 2: the fundamental unit 3 + 2√2 = ⟨3,2⟩ has companion matrix !![3,4;2,3] (determinant 1, trace 6), and its powers reproduce the chain 1,3,17,99,577 (real part) and 0,2,12,70,408 (√2 part) — connecting to the sibling pell-equation-oq-06-oq-03's transfer matrix and the parent's coefficient 6."
+    ]
+  },
+  "conclusion": {
+    "summary": "This fully verified 232-line file (0 sorries, 0 axioms, no native_decide) answers the parent entry's first open question by proving the two closed forms of the Pell coordinate sequences. The algebraic engine is that Galois conjugation is Mathlib's StarRing involution star, which commutes with powers; adding/subtracting aⁿ and (star a)ⁿ isolates re(aⁿ) and im(aⁿ), and pushing these through the real evaluation ring hom Zsqrtd.lift √d yields Binet's formulas re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ)/2 and 2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ. The companion matrix M = [[x₁,d·y₁],[y₁,x₁]] satisfies Mⁿ = [[re(aⁿ),d·im(aⁿ)],[im(aⁿ),re(aⁿ)]] with trace 2x₁ and determinant N(a), exhibiting the conjugate units as the eigenvalues.",
+    "implications": "The closed forms complete the picture begun by the parent: the recurrence, the Binet formula, and the matrix power are three faces of the same conjugate-unit structure. The technique — identify conjugation with star, split a power sequence by star-symmetry, then evaluate through Zsqrtd.lift — is reusable for any quadratic-integer sequence (Lucas/Fibonacci-type sequences, continued-fraction convergents, units of real quadratic fields) and complements Mathlib's Pell.Solution₁ API, which records the multiplicative structure but neither the Binet form nor the companion-matrix power.",
+    "openQuestions": [
+      "Prove the Cassini/Catalan-type identity xₙ₋₁xₙ₊₁ − xₙ² = (constant)·(N(a))ⁿ from det(Mⁿ) = (det M)ⁿ = N(a)ⁿ, deriving the determinant identity directly from the companion-matrix closed form.",
+      "Connect companion_pow and re_binet to Mathlib's Pell.Solution₁: show the coordinate maps n ↦ re(aⁿ), n ↦ im(aⁿ) of a fundamental Solution₁ generator are the Binet sequences, giving a closed-form reformulation of the power classification.",
+      "Derive the asymptotics xₙ/yₙ → √D and the exponential growth rate xₙ ~ (x₁+y₁√D)ⁿ/2 from re_binet, since the subdominant conjugate root x₁ − y₁√D has absolute value < 1 for a Pell unit."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of the parent entry `pell-equation-oq-07`: the **closed forms** behind the Pell coordinate recurrence `uₙ₊₂ = 2x₁·uₙ₊₁ − N(a)·uₙ`. Working in Mathlib's `ℤ[√d] = Zsqrtd d`.

## What's new (`PellEquationOQ07OQ01.lean`, verified, 0 sorries / 0 axioms)

- **`pow_add_star_pow` / `pow_sub_star_pow`** — Galois conjugation `x+y√d ↦ x−y√d` is Mathlib's `StarRing` involution `star`, a ring hom that commutes with powers (`star_pow`). Hence `aⁿ + (star a)ⁿ = ⟨2·re(aⁿ),0⟩` and `aⁿ − (star a)ⁿ = ⟨0,2·im(aⁿ)⟩` isolate the two coordinate sequences — purely algebraic, no analysis.
- **`re_binet` / `im_binet`** — pushing those decompositions through the ring hom `Zsqrtd.lift √d : ℤ[√d] →+* ℝ` (which sends `a`, `star a` to the conjugate roots `x₁ ± y₁√d`) yields Binet's formulas
  `re(aⁿ) = ((x₁+y₁√d)ⁿ + (x₁−y₁√d)ⁿ)/2` and `2·im(aⁿ)·√d = (x₁+y₁√d)ⁿ − (x₁−y₁√d)ⁿ` (`d ≥ 0`). No induction over `n` — the homomorphism carries the structure.
- **`companion` + `companion_pow`** — the multiplication-by-`a` matrix `M = !![x₁, d·y₁; y₁, x₁]` satisfies `Mⁿ = !![re(aⁿ), d·im(aⁿ); im(aⁿ), re(aⁿ)]`. `companion_trace`/`companion_det` give `tr M = 2x₁`, `det M = N(a)` — the coefficients of the characteristic polynomial `t² − 2x₁·t + N(a)`, whose roots are the conjugate units (the eigenvalue picture). `companion_det_pell`: `det = 1` for a Pell generator.
- **D = 2 instance** — the companion matrix `!![3,4;2,3]` of `3 + 2√2 = ⟨3,2⟩ ∈ ℤ[√2]`; numeric checks `M² = !![17,24;12,17]` and `(3+2√2)² = 17 + 12√2` against the chain `1,3,17,99,577` / `0,2,12,70,408`.

## Verification

- Kernel-verified with `lake env lean` (v4.26.0), 0 sorries.
- `#print axioms` → `[propext, Classical.choice, Quot.sound]` (standard triple only; `Classical.choice` enters only via `Real.sqrt`). No `native_decide` / `Lean.ofReduceBool`.
- Also registers the previously **orphaned** parent `Proofs.PellEquationOQ07` into the build graph (the new file imports it; added both import lines to `Proofs.lean`).

Includes gallery `meta.json` + `annotations.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)