### PR TITLE
research(de-moivre-oq-04-oq-01): primitive powers ωᵏ ⟺ gcd(k,n)=1 + φ(n) count [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -848,6 +848,7 @@ import Proofs.DeMoivreOQ03
 import Proofs.DeMoivreOQ03OQ01
 import Proofs.DeMoivreOQ03OQ01OQ01
 import Proofs.DeMoivreOQ04
+import Proofs.DeMoivreOQ04OQ01
 import Proofs.DeMoivreOQ05
 import Proofs.DeMoivreOQ05OQ01
 import Proofs.DeMoivreOQ05OQ01OQ01

--- a/proofs/Proofs/DeMoivreOQ04OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ04OQ01.lean
@@ -1,0 +1,122 @@
+import Mathlib
+import Proofs.DeMoivreOQ04
+
+/-
+# De Moivre OQ-04-OQ-01: Which powers ωᵏ are primitive, and the φ(n) count
+
+## Research Problem: de-moivre-oq-04-oq-01
+
+Parent `de-moivre-oq-04` isolated ω = cos(2π/n) + i·sin(2π/n) as a *primitive*
+n-th root of unity whose powers ω⁰, ω¹, …, ωⁿ⁻¹ enumerate **all** n-th roots of
+unity.  This file answers the parent's own follow-up:
+
+  *Which of the powers ωᵏ are themselves primitive n-th roots of unity, and how
+  many are there?*
+
+## Mathematical Content
+
+A power ζ = ωᵏ of a primitive n-th root ω is again primitive **iff** gcd(k, n) = 1.
+Indeed, the (multiplicative) order of ωᵏ is n / gcd(k, n), so ωᵏ has order n —
+i.e. is primitive — exactly when gcd(k, n) = 1.  Counting the exponents
+0 ≤ k < n with gcd(k, n) = 1 *is* the definition of Euler's totient, so there
+are precisely **φ(n)** primitive n-th roots of unity, and they are exactly the
+powers ωᵏ with k coprime to n.
+
+This recovers — concretely, in terms of the trigonometric generator
+ω = cos(2π/n) + i·sin(2π/n) — the classical fact that
+`(primitiveRoots n ℂ).card = φ(n)`.
+
+## Results
+- `omega_pow_isPrimitiveRoot_iff` — **headline**: ωᵏ is primitive ⟺ gcd(k,n)=1.
+- `primitiveRoots_eq_omega_image` — the primitive n-th roots are *exactly* the
+  ωᵏ with 0 ≤ k < n and gcd(k,n)=1.
+- `card_coprime_powers_eq_totient` — there are φ(n) such exponents k.
+- `card_primitiveRoots_via_omega` — hence `(primitiveRoots n ℂ).card = φ(n)`,
+  recovered through the explicit generator ω.
+
+## References
+- Mathlib: `IsPrimitiveRoot.pow_iff_coprime`, `IsPrimitiveRoot.eq_pow_of_pow_eq_one`,
+  `mem_primitiveRoots`, `Nat.totient_eq_card_coprime`.
+- Parent: `Proofs.DeMoivreOQ04` (`omega`, `omega_isPrimitiveRoot`, `omega_pow_injOn`).
+-/
+
+open Complex Real DeMoivreOQ04
+
+namespace DeMoivreOQ04OQ01
+
+/-! ## Part I: the primitivity criterion for a single power -/
+
+/-- **Headline.** The power ωᵏ is itself a primitive n-th root of unity **iff**
+    `k` is coprime to `n`.  Immediate from `pow_iff_coprime` applied to the
+    parent's primitive root ω. -/
+theorem omega_pow_isPrimitiveRoot_iff (n k : ℕ) (hn : 0 < n) :
+    IsPrimitiveRoot (omega n ^ k) n ↔ Nat.Coprime k n :=
+  (omega_isPrimitiveRoot n hn).pow_iff_coprime hn k
+
+/-- For example ω itself (k = 1) is primitive, since `gcd(1, n) = 1`. -/
+example (n : ℕ) (hn : 0 < n) : IsPrimitiveRoot (omega n ^ 1) n :=
+  (omega_pow_isPrimitiveRoot_iff n 1 hn).mpr (Nat.coprime_one_left n)
+
+/-! ## Part II: the primitive n-th roots are exactly the coprime powers of ω -/
+
+/-- **Structure theorem.** The set of primitive n-th roots of unity is *exactly*
+    the image of the coprime exponents `{k ∈ [0, n) : gcd(k, n) = 1}` under
+    `k ↦ ωᵏ`.
+
+    `⊇` is the headline criterion.  `⊆`: a primitive root ζ satisfies ζⁿ = 1, so
+    by `eq_pow_of_pow_eq_one` it equals ωⁱ for some `i < n`; primitivity of ωⁱ
+    then forces gcd(i, n) = 1. -/
+theorem primitiveRoots_eq_omega_image (n : ℕ) (hn : 0 < n) :
+    primitiveRoots n ℂ =
+      ((Finset.range n).filter (fun k => Nat.Coprime k n)).image (fun k => omega n ^ k) := by
+  haveI : NeZero n := ⟨hn.ne'⟩
+  ext ζ
+  simp only [mem_primitiveRoots hn, Finset.mem_image, Finset.mem_filter, Finset.mem_range]
+  constructor
+  · intro hζ
+    obtain ⟨i, hi, rfl⟩ := (omega_isPrimitiveRoot n hn).eq_pow_of_pow_eq_one hζ.pow_eq_one
+    exact ⟨i, ⟨hi, (omega_pow_isPrimitiveRoot_iff n i hn).mp hζ⟩, rfl⟩
+  · rintro ⟨i, ⟨_, hcop⟩, rfl⟩
+    exact (omega_pow_isPrimitiveRoot_iff n i hn).mpr hcop
+
+/-! ## Part III: the count is Euler's totient φ(n) -/
+
+/-- The number of exponents `0 ≤ k < n` with `gcd(k, n) = 1` is `φ(n)`.
+    This is `Nat.totient` up to the symmetry of coprimality. -/
+theorem card_coprime_powers_eq_totient (n : ℕ) :
+    ((Finset.range n).filter (fun k => Nat.Coprime k n)).card = Nat.totient n := by
+  rw [Nat.totient_eq_card_coprime]
+  congr 1
+  ext k
+  simp [Finset.mem_filter, Finset.mem_range, Nat.coprime_comm]
+
+/-- **Euler's totient count, recovered through ω.** There are exactly `φ(n)`
+    primitive n-th roots of unity.  We obtain the standard
+    `(primitiveRoots n ℂ).card = φ(n)` by counting the coprime powers of the
+    explicit generator ω = cos(2π/n) + i·sin(2π/n): the map `k ↦ ωᵏ` is injective
+    on `[0, n)` (parent `omega_pow_injOn`), so the image has the same cardinality
+    as the index set of coprime exponents. -/
+theorem card_primitiveRoots_via_omega (n : ℕ) (hn : 0 < n) :
+    (primitiveRoots n ℂ).card = Nat.totient n := by
+  rw [primitiveRoots_eq_omega_image n hn,
+    Finset.card_image_of_injOn
+      ((omega_pow_injOn n hn).mono (Finset.coe_subset.mpr (Finset.filter_subset _ _))),
+    card_coprime_powers_eq_totient n]
+
+/-! ## Part IV: Summary -/
+
+/-- **De Moivre OQ-04-OQ-01 Summary.** For n > 0, with ω = cos(2π/n) + i·sin(2π/n):
+    (1) ωᵏ is a primitive n-th root of unity ⟺ gcd(k, n) = 1;
+    (2) the primitive n-th roots of unity are exactly the powers ωᵏ with
+        0 ≤ k < n and gcd(k, n) = 1;
+    (3) there are exactly φ(n) of them. -/
+theorem demoivre_oq04_oq01_summary (n : ℕ) (hn : 0 < n) :
+    (∀ k, IsPrimitiveRoot (omega n ^ k) n ↔ Nat.Coprime k n) ∧
+    primitiveRoots n ℂ =
+      ((Finset.range n).filter (fun k => Nat.Coprime k n)).image (fun k => omega n ^ k) ∧
+    (primitiveRoots n ℂ).card = Nat.totient n :=
+  ⟨fun k => omega_pow_isPrimitiveRoot_iff n k hn,
+   primitiveRoots_eq_omega_image n hn,
+   card_primitiveRoots_via_omega n hn⟩
+
+end DeMoivreOQ04OQ01

--- a/src/data/proofs/de-moivre-oq-04-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-04-oq-01/meta.json
@@ -1,0 +1,192 @@
+{
+  "id": "de-moivre-oq-04-oq-01",
+  "title": "De Moivre OQ-04-OQ-01: Which Powers ωᵏ are Primitive, and the φ(n) Count",
+  "slug": "de-moivre-oq-04-oq-01",
+  "description": "Characterizes which powers of the generator ω = cos(2π/n) + i·sin(2π/n) are themselves primitive n-th roots of unity (ωᵏ is primitive ⟺ gcd(k,n) = 1), describes the primitive roots as exactly the coprime powers of ω, and recovers Euler's totient count (primitiveRoots n ℂ).card = φ(n) through the explicit generator.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ04OQ01.lean",
+    "tags": [
+      "complex-analysis",
+      "roots-of-unity",
+      "primitive-roots",
+      "euler-totient",
+      "de-moivre",
+      "number-theory",
+      "cyclotomy"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsPrimitiveRoot.pow_iff_coprime",
+        "description": "ζⁱ is a primitive n-th root of unity iff gcd(i,n) = 1, for ζ a primitive n-th root",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "IsPrimitiveRoot.eq_pow_of_pow_eq_one",
+        "description": "If ζ is a primitive n-th root and ξⁿ = 1, then ξ = ζⁱ for some i < n",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "mem_primitiveRoots",
+        "description": "Membership in primitiveRoots n R is equivalent to being a primitive n-th root of unity (for n > 0)",
+        "module": "Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots"
+      },
+      {
+        "theorem": "Nat.totient_eq_card_coprime",
+        "description": "φ(n) is the number of 0 ≤ a < n coprime to n",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.card_image_of_injOn",
+        "description": "An injective-on-domain image has the same cardinality as its index set",
+        "module": "Mathlib.Data.Finset.Image"
+      }
+    ],
+    "originalContributions": [
+      "Headline criterion omega_pow_isPrimitiveRoot_iff: the power ωᵏ of the trigonometric generator ω = cos(2π/n) + i·sin(2π/n) is itself a primitive n-th root of unity if and only if gcd(k,n) = 1",
+      "Structure theorem primitiveRoots_eq_omega_image: the set of primitive n-th roots of unity equals exactly the image of the coprime exponents {k ∈ [0,n) : gcd(k,n) = 1} under k ↦ ωᵏ",
+      "card_coprime_powers_eq_totient: the number of exponents 0 ≤ k < n with gcd(k,n) = 1 is φ(n), up to the symmetry of coprimality",
+      "card_primitiveRoots_via_omega: recovers Euler's totient count (primitiveRoots n ℂ).card = φ(n) concretely, by counting the coprime powers of the explicit generator ω and using injectivity of k ↦ ωᵏ on [0,n) (parent omega_pow_injOn)",
+      "Summary theorem bundling the criterion, the explicit description of the primitive-root set, and the φ(n) count"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 122,
+    "assumptions": "0 axioms, 0 sorries. The primitivity criterion is IsPrimitiveRoot.pow_iff_coprime applied to the parent's primitive root ω; the φ(n) count is obtained through the explicit trigonometric generator via injectivity of k ↦ ωᵏ on [0,n).",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Having identified ω = cos(2π/n) + i·sin(2π/n) as a generator of the n-th roots of unity (parent OQ-04), the natural next question — already raised by Gauss in the *Disquisitiones Arithmeticae* (1801) — is which of the powers ω⁰, ω¹, …, ωⁿ⁻¹ are themselves *generators*, i.e. primitive n-th roots. The answer, gcd(k,n) = 1, is the gateway to cyclotomy: the primitive n-th roots are exactly the roots of the cyclotomic polynomial Φₙ, whose degree φ(n) counts them. That there are φ(n) primitive n-th roots of unity — equivalently, that the multiplicative group μₙ has φ(n) generators — is one of the oldest appearances of Euler's totient outside elementary number theory.",
+    "problemStatement": "**Open Question (parent OQ-04, follow-up)**: Characterize which powers ωᵏ of the generator ω = cos(2π/n) + i·sin(2π/n) are themselves primitive n-th roots of unity, and recover Euler's totient count.\n\n**Answer**: ωᵏ is primitive **iff** gcd(k,n) = 1. The primitive n-th roots of unity are exactly the powers ωᵏ with 0 ≤ k < n and gcd(k,n) = 1, and there are precisely **φ(n)** of them, so (primitiveRoots n ℂ).card = φ(n).",
+    "text": "Characterizes which powers of ω = cos(2π/n) + i·sin(2π/n) are primitive (gcd(k,n) = 1) and recovers the count of φ(n) primitive n-th roots of unity through the explicit generator.",
+    "proofStrategy": "1. **Criterion**: Apply Mathlib's `IsPrimitiveRoot.pow_iff_coprime` to the parent's primitive root `omega_isPrimitiveRoot`, giving ωᵏ primitive ⟺ gcd(k,n) = 1 immediately.\n2. **Structure**: For the set equality primitiveRoots n ℂ = image of coprime exponents under k ↦ ωᵏ, the `⊇` direction is the criterion; for `⊆`, a primitive root ζ satisfies ζⁿ = 1, so `eq_pow_of_pow_eq_one` gives ζ = ωⁱ with i < n, and primitivity of ωⁱ forces gcd(i,n) = 1.\n3. **Count**: The number of coprime exponents in [0,n) is φ(n) by `Nat.totient_eq_card_coprime` (up to coprime symmetry). Since k ↦ ωᵏ is injective on [0,n) (parent `omega_pow_injOn`, restricted to the coprime subset), `Finset.card_image_of_injOn` transfers this to (primitiveRoots n ℂ).card = φ(n).",
+    "keyInsights": [
+      "The whole criterion is one Mathlib lemma — `pow_iff_coprime` — applied to the parent's generator: ωᵏ has order n/gcd(k,n), which equals n exactly when gcd(k,n) = 1",
+      "The **⊆ direction** of the structure theorem is where the parent's enumeration pays off: every primitive root is *some* power ωⁱ (because it is an n-th root of unity), and only then does the coprimality test apply",
+      "Counting **through the explicit generator** ω — rather than quoting Mathlib's abstract `card_primitiveRoots` — keeps the φ(n) count tied to the concrete trigonometric picture: φ(n) of the n equally-spaced vertices of the regular n-gon are primitive",
+      "Injectivity of k ↦ ωᵏ on [0,n) is exactly what makes the count of *exponents* equal the count of *roots*; without it the image could collapse",
+      "The φ(n) primitive n-th roots are precisely the roots of the cyclotomic polynomial Φₙ — this entry is the counting half of that identification"
+    ],
+    "prerequisites": [
+      "Roots of unity and the generator ω = cos(2π/n) + i·sin(2π/n) (parent OQ-04)",
+      "Primitive roots and the order of group elements",
+      "Euler's totient function φ(n) and coprimality"
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble and Problem Statement",
+      "summary": "Module docstring: characterize which powers ωᵏ are primitive (gcd(k,n) = 1) and recover the φ(n) count; lists results and Mathlib dependencies",
+      "startLine": 1,
+      "endLine": 46,
+      "mathContext": "**Goal**: ωᵏ is a primitive n-th root of unity ⟺ gcd(k,n) = 1, and there are φ(n) such powers."
+    },
+    {
+      "id": "criterion",
+      "title": "Part I: The Primitivity Criterion for a Single Power",
+      "summary": "omega_pow_isPrimitiveRoot_iff: ωᵏ is primitive ⟺ gcd(k,n) = 1, via IsPrimitiveRoot.pow_iff_coprime on the parent's ω; example: ω itself (k = 1) is primitive",
+      "startLine": 47,
+      "endLine": 59,
+      "mathContext": "$\\omega^k$ is primitive $\\iff \\gcd(k,n) = 1$, since $\\operatorname{ord}(\\omega^k) = n/\\gcd(k,n)$."
+    },
+    {
+      "id": "structure",
+      "title": "Part II: The Primitive Roots are Exactly the Coprime Powers of ω",
+      "summary": "primitiveRoots_eq_omega_image: primitiveRoots n ℂ = image of {k ∈ [0,n) : gcd(k,n) = 1} under k ↦ ωᵏ; ⊆ uses eq_pow_of_pow_eq_one, ⊇ is the criterion",
+      "startLine": 60,
+      "endLine": 81,
+      "mathContext": "$\\{\\zeta : \\zeta \\text{ primitive}\\} = \\{\\omega^k : 0 \\le k < n,\\ \\gcd(k,n) = 1\\}$."
+    },
+    {
+      "id": "totient-count",
+      "title": "Part III: The Count is Euler's Totient φ(n)",
+      "summary": "card_coprime_powers_eq_totient (#coprime exponents = φ(n)) and card_primitiveRoots_via_omega ((primitiveRoots n ℂ).card = φ(n)) via injectivity of k ↦ ωᵏ",
+      "startLine": 82,
+      "endLine": 105,
+      "mathContext": "$\\#\\{k \\in [0,n) : \\gcd(k,n)=1\\} = \\varphi(n)$, hence $\\#\\,(\\text{primitive }n\\text{-th roots}) = \\varphi(n)$."
+    },
+    {
+      "id": "summary",
+      "title": "Part IV: Summary Theorem",
+      "summary": "demoivre_oq04_oq01_summary bundles the criterion, the explicit description of the primitive-root set, and the φ(n) count",
+      "startLine": 106,
+      "endLine": 122,
+      "mathContext": "Three results in one: (1) ωᵏ primitive ⟺ gcd(k,n)=1, (2) the primitive roots are the coprime powers of ω, (3) there are φ(n) of them."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization characterizes the primitive n-th roots of unity among the powers of the trigonometric generator ω = cos(2π/n) + i·sin(2π/n): ωᵏ is primitive if and only if gcd(k,n) = 1. The primitive roots are exactly the coprime powers of ω, and counting them recovers Euler's totient: (primitiveRoots n ℂ).card = φ(n), obtained concretely through ω via injectivity of k ↦ ωᵏ on [0,n). Zero sorries, zero axioms beyond Lean's foundations.",
+    "implications": "Answers the parent OQ-04's first open question. The φ(n) count is the degree of the cyclotomic polynomial Φₙ, setting up the identification of the primitive n-th roots as the roots of Φₙ and the development of Φₙ as the minimal polynomial of ω over ℚ.",
+    "openQuestions": [
+      "Define the cyclotomic polynomial Φₙ as ∏(X − ωᵏ) over coprime k and prove deg Φₙ = φ(n)",
+      "Connect the regular n-gon vertices to Gauss's criterion for constructible polygons via the prime factorization of φ(n)"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-04",
+      "relationship": "Parent: ω generates the n-th roots of unity; this entry isolates the primitive ones"
+    },
+    {
+      "id": "euler-totient",
+      "relationship": "Recovers the φ(n) count of primitive n-th roots"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.DeMoivreOQ04"
+    ],
+    "opens": [
+      "Complex",
+      "Real",
+      "DeMoivreOQ04"
+    ],
+    "namespace": "DeMoivreOQ04OQ01",
+    "lineCount": 122,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ04OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Carl Friedrich Gauss",
+      "title": "Disquisitiones Arithmeticae (cyclotomy, primitive roots of unity)",
+      "year": "1801",
+      "venue": "Leipzig"
+    },
+    {
+      "authors": "Leonhard Euler",
+      "title": "Totient function and the count of generators of a cyclic group",
+      "year": "1763",
+      "venue": "Novi Commentarii"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-04",
+      "relationship": "extends",
+      "description": "Parent entry: ω = cos(2π/n) + i·sin(2π/n) generates all n-th roots of unity. This entry uses the parent's primitivity (omega_isPrimitiveRoot), injectivity (omega_pow_injOn), and enumeration to single out the primitive powers and count them."
+    },
+    {
+      "targetId": "euler-totient",
+      "relationship": "related",
+      "description": "The number of primitive n-th roots of unity is Euler's totient φ(n); this entry recovers that count concretely through the generator ω."
+    },
+    {
+      "targetId": "primitive-roots",
+      "relationship": "related",
+      "description": "The primitive n-th roots of unity are the generators of the cyclic group μₙ; ωᵏ generates μₙ exactly when gcd(k,n) = 1."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers parent **de-moivre-oq-04**'s first open question: *"Characterize which powers ωᵏ are themselves primitive (gcd(k,n)=1) and recover Euler's totient count."*

With ω = cos(2π/n) + i·sin(2π/n) the trigonometric generator of the n-th roots of unity (from the parent entry):

| Theorem | Statement |
|---------|-----------|
| `omega_pow_isPrimitiveRoot_iff` | ωᵏ is a primitive n-th root of unity **⟺ gcd(k,n) = 1** |
| `primitiveRoots_eq_omega_image` | the primitive n-th roots are **exactly** the powers ωᵏ with 0 ≤ k < n and gcd(k,n)=1 |
| `card_coprime_powers_eq_totient` | #{k ∈ [0,n) : gcd(k,n)=1} = φ(n) |
| `card_primitiveRoots_via_omega` | **(primitiveRoots n ℂ).card = φ(n)**, recovered through the explicit generator ω |
| `demoivre_oq04_oq01_summary` | bundles the three results |

## Math content

The primitivity criterion is `IsPrimitiveRoot.pow_iff_coprime` applied to the parent's `omega_isPrimitiveRoot`. The structure theorem's `⊆` direction uses `eq_pow_of_pow_eq_one` (every primitive root is *some* power ωⁱ since it is an n-th root of unity). The φ(n) count is obtained **concretely through ω**: injectivity of k ↦ ωᵏ on [0,n) (parent `omega_pow_injOn`) transfers the count of coprime exponents to the count of primitive roots — rather than quoting Mathlib's abstract `card_primitiveRoots`.

## Verification

- **5 theorems, 0 definitions, 0 sorries, 122 lines**
- **0 axioms** — `#print axioms demoivre_oq04_oq01_summary` → `[propext, Classical.choice, Quot.sound]` (standard triple only)
- Kernel-verified against Mathlib v4.26.0 (`lake env lean`, exit 0)
- Registered in `proofs/Proofs.lean`; gallery `meta.json` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)