### PR TITLE
research(ballot-problem-oq-02-oq-02-oq-05): first passage is a stopping time — ℱ_T-measurability of the hitting event [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -252,6 +252,7 @@ import Proofs.BallotProblemOQ01OQ04Core
 import Proofs.BallotProblemOQ01OQ04OQ01
 import Proofs.BallotProblemOQ02
 import Proofs.BallotProblemOQ02OQ02
+import Proofs.BallotProblemOQ02OQ02OQ05
 import Proofs.BallotProblemOQ02OQ05
 import Proofs.BallotProblemOQ03
 import Proofs.BallotProblemOQ03OQ01OQ01

--- a/proofs/Proofs/BallotProblemOQ02OQ02OQ05.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ02OQ05.lean
@@ -1,0 +1,204 @@
+/-
+# First Passage as a Stopping Time: Measurability of the Hitting Event (OQ-02-OQ-02-OQ-05)
+
+## Research Question
+
+The sibling `BallotProblemOQ02OQ02.lean` proves the pointwise characterization
+`{ω | firstPassageTime bm a ω ≤ T} = maxEvent bm a T` (under nonemptiness), where
+
+  `maxEvent bm a T = {ω | ∃ s ∈ [0,T], a ≤ W s ω}`
+
+is the event "the path reaches level `a` by time `T`". For `firstPassageTime` to be a
+genuine **stopping time** with respect to a filtration `ℱ` carrying the information of the
+process, the hitting event must be *observable by time `T`*: it must lie in `ℱ T`.
+
+This file proves exactly that.
+
+## What is new
+
+Mathlib's hitting-time API (`MeasureTheory.hittingBtwn`, `hittingBtwn_isStoppingTime`) is
+restricted to **discrete / well-founded** index types (`[WellFoundedLT ι]`): it does not apply
+to the continuous time line `ι = ℝ` of Brownian motion, where the Début theorem is needed.
+Nothing in Mathlib records the continuous-time fact that, for a process with continuous paths
+and time-slices adapted to a filtration, the first-passage event is `ℱ T`-measurable.
+
+The crux is a **continuity ⟹ countability** reduction. The defining event ranges over the
+*uncountable* index set `[0,T]`; we replace it by a countable rational grid:
+
+  `maxEvent bm a T = ⋂ₖ ⋃_{q ∈ ℚ ∩ [0,T]} {ω | a − 1/(k+1) < W q ω}`   (`maxEvent_eq_iInter_approxEvent`)
+
+Each set on the right is a preimage of an open ray under a single time-slice `W q`, hence
+`ℱ T`-measurable by adaptedness (`ℱ q ≤ ℱ T` for `q ≤ T`); a countable intersection of
+countable unions of such sets is `ℱ T`-measurable.
+
+## Method
+
+* `⊆` uses continuity of `t ↦ W t ω` and density of `ℚ ∩ [0,T]` in `[0,T]` (built here,
+  handling both endpoints via `exists_rat_btwn`): a witness `s₀` with `W s₀ ω ≥ a` is
+  approximated to within any tolerance `1/(k+1)` by a rational time `q`.
+* `⊇` uses sequential compactness of `[0,T]` (`IsCompact.tendsto_subseq`): rational witnesses
+  `q_k` with `W q_k ω > a − 1/(k+1)` accumulate at some `s* ∈ [0,T]`, and continuity forces
+  `W s* ω ≥ a` in the limit (`le_of_tendsto_of_tendsto'`).
+
+From the identity, `measurableSet_maxEvent` reads off `ℱ T`-measurability under adaptedness,
+and `firstPassage_measurableSet` transports it to the first-passage event `{ω | τ ≤ T}` via the
+sibling's characterization (under the standing nonemptiness hypothesis that makes `τ ≤ T`
+genuinely equivalent to hitting — recall `sInf ∅ = 0` makes the raw inequality degenerate).
+
+## References
+
+* Mathlib: `Mathlib/Probability/Process/HittingTime.lean` (discrete-time hitting times),
+  `Mathlib/Probability/Process/Filtration.lean`, `Mathlib/Topology/Sequences.lean`.
+* Sibling: `Proofs/BallotProblemOQ02OQ02.lean` (`fpt_le_set_eq_maxEvent`).
+* I. Karatzas, S. Shreve, *Brownian Motion and Stochastic Calculus*, §1.2 (first passage
+  times as stopping times for continuous adapted processes).
+-/
+import Mathlib
+import Proofs.BallotProblemOQ02OQ02
+
+namespace BallotProblemOQ02OQ02OQ05
+
+open Set MeasureTheory Filter Topology
+open BallotFPT
+
+variable {Ω : Type*} {m : MeasurableSpace Ω} {μ : Measure Ω} [IsProbabilityMeasure μ]
+
+/-! ## The countable rational approximation of the hitting event -/
+
+/-- The `k`-th rational approximation of the hitting event: there is a rational time
+`q ∈ [0,T]` at which the path exceeds `a − 1/(k+1)`. As `k → ∞` these shrink down to the
+exact hitting event. The union ranges over the countable set `ℚ`, so this set is built from
+countably many time-slices. -/
+def approxEvent (bm : BrownianMotion Ω μ) (a T : ℝ) (k : ℕ) : Set Ω :=
+  ⋃ (q : ℚ) (_ : (0 : ℝ) ≤ (q : ℝ) ∧ (q : ℝ) ≤ T), {ω | a - 1 / (k + 1) < bm.W (q : ℝ) ω}
+
+/-- **Density of the rational grid in `[0,T]`.** For `s₀ ∈ [0,T]` and any tolerance `ε > 0`,
+there is a rational `q ∈ [0,T]` with `|q − s₀| < ε`. Endpoints are handled by approximating
+from inside the interval. -/
+theorem exists_rat_near_in_Icc {T s₀ ε : ℝ} (hT : 0 ≤ T) (hs₀ : s₀ ∈ Icc 0 T) (hε : 0 < ε) :
+    ∃ q : ℚ, (0 : ℝ) ≤ (q : ℝ) ∧ (q : ℝ) ≤ T ∧ |(q : ℝ) - s₀| < ε := by
+  obtain ⟨hs0, hsT⟩ := hs₀
+  rcases eq_or_lt_of_le hT with hT0 | hTpos
+  · -- T = 0, so s₀ = 0; take q = 0
+    refine ⟨0, by norm_num, ?_, ?_⟩
+    · rw [← hT0]; norm_num
+    · have hs00 : s₀ = 0 := le_antisymm (by rw [← hT0] at hsT; exact hsT) hs0
+      rw [hs00]; simpa using hε
+  · -- T > 0: the open interval (max 0 (s₀-ε), min T (s₀+ε)) is nonempty; pick a rational in it
+    set L : ℝ := max 0 (s₀ - ε) with hL
+    set U : ℝ := min T (s₀ + ε) with hU
+    have hLU : L < U := by
+      rw [hL, hU, max_lt_iff, lt_min_iff, lt_min_iff]
+      refine ⟨⟨hTpos, by linarith⟩, ⟨by linarith, by linarith⟩⟩
+    obtain ⟨q, hqL, hqU⟩ := exists_rat_btwn hLU
+    have hq0 : (0 : ℝ) ≤ (q : ℝ) := le_of_lt (lt_of_le_of_lt (le_max_left _ _) hqL)
+    have hqT : (q : ℝ) ≤ T := le_of_lt (lt_of_lt_of_le hqU (min_le_left _ _))
+    refine ⟨q, hq0, hqT, ?_⟩
+    have h1 : s₀ - ε < (q : ℝ) := lt_of_le_of_lt (le_max_right _ _) hqL
+    have h2 : (q : ℝ) < s₀ + ε := lt_of_lt_of_le hqU (min_le_right _ _)
+    rw [abs_sub_lt_iff]
+    constructor <;> linarith
+
+/-- **The hitting event is the countable intersection of its rational approximations.** This is
+the analytic heart of the file: continuity of the paths lets the uncountable existential over
+`[0,T]` be tested on the countable rational grid. -/
+theorem maxEvent_eq_iInter_approxEvent (bm : BrownianMotion Ω μ) (a T : ℝ) (hT : 0 ≤ T) :
+    maxEvent bm a T = ⋂ k : ℕ, approxEvent bm a T k := by
+  ext ω
+  simp only [maxEvent, approxEvent, mem_setOf_eq, mem_iInter, mem_iUnion, exists_prop]
+  constructor
+  · -- forward: hit at s₀ ⟹ for each k a nearby rational exceeds a - 1/(k+1)
+    rintro ⟨s₀, hs₀_Icc, hs₀_ge⟩ k
+    have hcont : Continuous (fun t => bm.W t ω) := bm.path_continuous ω
+    have hk : (0 : ℝ) < 1 / (k + 1) := by positivity
+    -- by continuity, a δ-ball around s₀ keeps W within 1/(k+1) of W s₀ ω
+    have := Metric.continuous_iff.mp hcont s₀ (1 / (k + 1)) hk
+    obtain ⟨δ, hδ, hball⟩ := this
+    obtain ⟨q, hq0, hqT, hqδ⟩ := exists_rat_near_in_Icc hT hs₀_Icc hδ
+    refine ⟨q, ⟨hq0, hqT⟩, ?_⟩
+    have hdist : dist (bm.W (q : ℝ) ω) (bm.W s₀ ω) < 1 / (k + 1) := by
+      have : dist (q : ℝ) s₀ < δ := by rwa [Real.dist_eq]
+      exact hball _ this
+    rw [Real.dist_eq] at hdist
+    have : bm.W s₀ ω - bm.W (q : ℝ) ω < 1 / (k + 1) :=
+      lt_of_le_of_lt (le_abs_self _) (by rwa [abs_sub_comm] at hdist)
+    linarith
+  · -- backward: rational witnesses q_k accumulate at s*, continuity gives W s* ω ≥ a
+    intro h
+    choose q hq hWq using h
+    -- the real points x k = q k ∈ [0,T] (compact)
+    set x : ℕ → ℝ := fun k => (q k : ℝ) with hx
+    have hx_mem : ∀ k, x k ∈ Icc 0 T := fun k => ⟨(hq k).1, (hq k).2⟩
+    obtain ⟨s, hs_mem, φ, hφ_mono, hφ_tend⟩ :=
+      (isCompact_Icc (a := (0 : ℝ)) (b := T)).tendsto_subseq hx_mem
+    refine ⟨s, hs_mem, ?_⟩
+    have hcont : Continuous (fun t => bm.W t ω) := bm.path_continuous ω
+    -- W (x (φ j)) ω → W s ω
+    have hWtend : Tendsto (fun j => bm.W (x (φ j)) ω) atTop (𝓝 (bm.W s ω)) :=
+      ((hcont.tendsto s).comp hφ_tend)
+    -- a - 1/(φ j + 1) → a
+    have hφ_atTop : Tendsto φ atTop atTop := hφ_mono.tendsto_atTop
+    have hlow : Tendsto (fun j => a - 1 / ((φ j : ℝ) + 1)) atTop (𝓝 a) := by
+      have h0 : Tendsto (fun n : ℕ => 1 / ((n : ℝ) + 1)) atTop (𝓝 0) :=
+        tendsto_one_div_add_atTop_nhds_zero_nat
+      have := (h0.comp hφ_atTop)
+      simpa using (tendsto_const_nhds (x := a)).sub this
+    -- pointwise a - 1/(φ j + 1) ≤ W (x (φ j)) ω
+    have hle : ∀ j, a - 1 / ((φ j : ℝ) + 1) ≤ bm.W (x (φ j)) ω := by
+      intro j
+      have := hWq (φ j)
+      simp only [hx]
+      push_cast at this ⊢
+      linarith
+    exact le_of_tendsto_of_tendsto' hlow hWtend hle
+
+/-! ## Measurability of the hitting event under a filtration -/
+
+/-- **The first-passage event is observable by time `T`.** If each time-slice `W t` is
+adapted to a filtration `ℱ` (so `W t` is `ℱ t`-measurable), then the hitting event
+`{ω | ∃ s ∈ [0,T], a ≤ W s ω}` is `ℱ T`-measurable. This is the measurability content that
+makes the first passage time a stopping time in continuous time. -/
+theorem measurableSet_maxEvent (ℱ : Filtration ℝ m) (bm : BrownianMotion Ω μ)
+    (hadapt : ∀ t : ℝ, Measurable[ℱ t] (bm.W t)) (a T : ℝ) (hT : 0 ≤ T) :
+    MeasurableSet[ℱ T] (maxEvent bm a T) := by
+  rw [maxEvent_eq_iInter_approxEvent bm a T hT]
+  refine MeasurableSet.iInter (fun k => ?_)
+  unfold approxEvent
+  -- the union ranges over the countable set {q : ℚ | q ∈ [0,T]}
+  refine MeasurableSet.biUnion (Set.to_countable {q : ℚ | (0 : ℝ) ≤ (q : ℝ) ∧ (q : ℝ) ≤ T})
+    (fun q hq => ?_)
+  -- q ∈ [0,T]: W q is ℱ q-measurable, and ℱ q ≤ ℱ T, so the open-ray preimage is in ℱ T
+  have hWq : Measurable[ℱ T] (bm.W (q : ℝ)) :=
+    (hadapt (q : ℝ)).mono (ℱ.mono hq.2) le_rfl
+  have hset : {ω | a - 1 / (k + 1) < bm.W (q : ℝ) ω}
+      = bm.W (q : ℝ) ⁻¹' Ioi (a - 1 / (k + 1)) := by
+    ext ω; simp [mem_Ioi]
+  rw [hset]
+  exact hWq measurableSet_Ioi
+
+/-! ## First passage time is a stopping time -/
+
+/-- **First passage is a stopping time.** Under adaptedness of the paths and the standing
+nonemptiness hypothesis (every path actually reaches level `a`, so that `τ ≤ T` is genuinely the
+hitting event rather than the degenerate `sInf ∅ = 0` value), the first-passage event
+`{ω | firstPassageTime bm a ω ≤ T}` is `ℱ T`-measurable for every `T > 0`.
+
+Combined with `firstPassageTime ≥ 0`, this is the stopping-time property: the event "the
+process has hit level `a` by time `T`" is observable using only the information available at
+time `T`. -/
+theorem firstPassage_measurableSet (ℱ : Filtration ℝ m) (bm : BrownianMotion Ω μ)
+    (hadapt : ∀ t : ℝ, Measurable[ℱ t] (bm.W t)) (a T : ℝ) (hT : 0 < T)
+    (hne : ∀ ω, ({t : ℝ | 0 ≤ t ∧ bm.W t ω ≥ a}).Nonempty) :
+    MeasurableSet[ℱ T] {ω | firstPassageTime bm a ω ≤ T} := by
+  rw [fpt_le_set_eq_maxEvent bm a T hT hne]
+  exact measurableSet_maxEvent ℱ bm hadapt a T (le_of_lt hT)
+
+/-- The hitting event is monotone in the horizon `T`: more time can only help the path reach
+level `a`. (A sanity companion to the measurability result: the family `T ↦ maxEvent bm a T` is
+the increasing family of events whose `ℱ T`-measurability is the stopping-time property.) -/
+theorem maxEvent_mono (bm : BrownianMotion Ω μ) (a : ℝ) {T₁ T₂ : ℝ} (h : T₁ ≤ T₂) :
+    maxEvent bm a T₁ ⊆ maxEvent bm a T₂ := by
+  rintro ω ⟨s, ⟨hs0, hsT₁⟩, hsge⟩
+  exact ⟨s, ⟨hs0, le_trans hsT₁ h⟩, hsge⟩
+
+end BallotProblemOQ02OQ02OQ05

--- a/src/data/proofs/ballot-problem-oq-02-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02-oq-05/annotations.json
@@ -1,0 +1,97 @@
+[
+  {
+    "id": "ann-ballot-oq020205-docstring",
+    "proofId": "ballot-problem-oq-02-oq-02-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 56
+    },
+    "type": "context",
+    "title": "First Passage as a Stopping Time",
+    "content": "The docstring frames the research question: for the first passage time τ_a = inf{t ≥ 0 : W_t ≥ a} to be a stopping time, the hitting event {ω | ∃ s ∈ [0,T], a ≤ W s ω} must be observable by time T, i.e. lie in ℱ T. Mathlib formalises hitting times only for well-founded (discrete) index types, so the continuous time line ℝ — where the analytic continuity argument is required — is not covered. The new content is the continuity ⟹ countability reduction and the ℱ T-measurability of the hitting event it yields.",
+    "mathContext": "$\\{\\omega : \\exists s\\in[0,T],\\ a\\le W_s(\\omega)\\}\\in\\mathcal F_T$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "stopping time",
+      "filtration",
+      "first passage time",
+      "hitting time",
+      "Brownian motion"
+    ],
+    "prerequisites": [
+      "filtrations and adapted processes",
+      "measurable sets and σ-algebras",
+      "continuity of sample paths"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq020205-density",
+    "proofId": "ballot-problem-oq-02-oq-02-oq-05",
+    "range": {
+      "startLine": 58,
+      "endLine": 117
+    },
+    "type": "key-step",
+    "title": "The Rational Grid and Its Density in [0,T]",
+    "content": "approxEvent defines the k-th rational approximation of the hitting event: there is a rational time q ∈ [0,T] at which the path exceeds the slackened level a − 1/(k+1). The union ranges over the countable set ℚ, so the approximation is built from countably many time-slices. exists_rat_near_in_Icc proves the supporting density fact — every s₀ ∈ [0,T] is within any ε of a rational q ∈ [0,T] — handling interior and endpoints uniformly by applying exists_rat_btwn to the nonempty open interval (max 0 (s₀−ε), min T (s₀+ε)).",
+    "mathContext": "$\\mathrm{approx}_k=\\bigcup_{q\\in\\mathbb Q\\cap[0,T]}\\{\\omega: a-\\tfrac1{k+1}<W_q(\\omega)\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "density of the rationals",
+      "countable cover",
+      "exists_rat_btwn"
+    ],
+    "prerequisites": [
+      "density of ℚ in ℝ",
+      "order arithmetic on intervals"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq020205-identity",
+    "proofId": "ballot-problem-oq-02-oq-02-oq-05",
+    "range": {
+      "startLine": 118,
+      "endLine": 152
+    },
+    "type": "key-step",
+    "title": "Continuity Collapses the Uncountable Hitting Event",
+    "content": "maxEvent_eq_iInter_approxEvent is the analytic heart: the hitting event equals ⋂ₖ approxEvent. The ⊆ direction takes a real hitting time s₀ with W s₀ ω ≥ a, uses continuity to find a δ-ball keeping W within 1/(k+1), and picks a rational q ∈ [0,T] inside it. The ⊇ direction takes rational witnesses q_k with W q_k ω > a − 1/(k+1); they lie in the compact set [0,T], so a subsequence converges to some s* ∈ [0,T] (IsCompact.tendsto_subseq), and continuity sends the values to W s* ω while the shrinking bounds tend to a, forcing a ≤ W s* ω via le_of_tendsto_of_tendsto'. The strict slack 1/(k+1) is essential — with the closed condition on rationals alone the ⊇ direction fails.",
+    "mathContext": "$\\mathrm{maxEvent}\\ bm\\ a\\ T=\\bigcap_{k}\\bigcup_{q\\in\\mathbb Q\\cap[0,T]}\\{\\omega:a-\\tfrac1{k+1}<W_q(\\omega)\\}$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "sequential compactness",
+      "limit of inequalities",
+      "uniform continuity on compacts",
+      "Début theorem (continuous-time analogue)"
+    ],
+    "prerequisites": [
+      "IsCompact.tendsto_subseq",
+      "limits of monotone tolerances",
+      "continuity of paths"
+    ]
+  },
+  {
+    "id": "ann-ballot-oq020205-measurability",
+    "proofId": "ballot-problem-oq-02-oq-02-oq-05",
+    "range": {
+      "startLine": 153,
+      "endLine": 204
+    },
+    "type": "key-step",
+    "title": "ℱ T-Measurability and the Stopping-Time Property",
+    "content": "measurableSet_maxEvent reads measurability off the countable identity: each set {ω | a − 1/(k+1) < W q ω} is the preimage of an open ray under the single time-slice W q, which is ℱ q-measurable by adaptedness and hence ℱ T-measurable since ℱ q ≤ ℱ T for q ≤ T (Filtration.mono); a countable union (over ℚ ∩ [0,T], via MeasurableSet.biUnion) of countable intersections is ℱ T-measurable. firstPassage_measurableSet transports this to the first-passage event {ω | firstPassageTime bm a ω ≤ T} through the sibling's fpt_le_set_eq_maxEvent, under the nonemptiness hypothesis that makes τ ≤ T equivalent to hitting (sInf ∅ = 0 otherwise makes the inequality degenerate). maxEvent_mono records that the events increase in the horizon T — the monotone family whose ℱ T-measurability is the stopping-time property.",
+    "mathContext": "$\\{\\omega:\\mathrm{firstPassageTime}\\ bm\\ a\\ \\omega\\le T\\}\\in\\mathcal F_T$ for $T>0$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "measurability of preimages",
+      "filtration monotonicity",
+      "countable unions",
+      "stopping time"
+    ],
+    "prerequisites": [
+      "MeasurableSet.biUnion",
+      "Filtration.mono",
+      "measurability of open-ray preimages"
+    ]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-02-oq-02-oq-05/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02-oq-02-oq-05/meta.json
@@ -1,0 +1,172 @@
+{
+  "id": "ballot-problem-oq-02-oq-02-oq-05",
+  "slug": "ballot-problem-oq-02-oq-02-oq-05",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BallotProblemOQ02OQ02"
+    ],
+    "opens": [
+      "Set",
+      "MeasureTheory",
+      "Filter",
+      "Topology",
+      "BallotFPT"
+    ],
+    "namespace": "BallotProblemOQ02OQ02OQ05",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/BallotProblemOQ02OQ02OQ05.lean",
+    "sorries": 0
+  },
+  "title": "First Passage as a Stopping Time: Measurability of the Hitting Event",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BallotProblemOQ02OQ02OQ05.lean",
+    "tags": [
+      "probability",
+      "measure-theory",
+      "stopping-time",
+      "filtration",
+      "first-passage-time",
+      "brownian-motion",
+      "hitting-time",
+      "continuity",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 204,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "badge": "original",
+    "originalContributions": [
+      "maxEvent_eq_iInter_approxEvent: the analytic core — for a process with continuous paths, the hitting event {ω | ∃ s ∈ [0,T], a ≤ W s ω} equals the countable expression ⋂ₖ ⋃_{q ∈ ℚ∩[0,T]} {ω | a − 1/(k+1) < W q ω}. Continuity collapses the uncountable existential over [0,T] onto a countable rational grid. The ⊆ direction uses continuity + density of the rational grid; the ⊇ direction uses sequential compactness of [0,T] and a limit inequality.",
+      "measurableSet_maxEvent: under adaptedness of the time-slices to a filtration ℱ (each W t is ℱ t-measurable), the hitting event is ℱ T-measurable. This is the measurability content that makes the continuous-time first passage time a stopping time — a fact Mathlib's hitting-time API does not provide for ℝ-indexed processes.",
+      "firstPassage_measurableSet: the first-passage event {ω | firstPassageTime bm a ω ≤ T} is ℱ T-measurable for every T > 0, under adaptedness and the standing nonemptiness hypothesis that makes τ ≤ T genuinely equivalent to hitting (recall sInf ∅ = 0 makes the raw inequality degenerate). This is the stopping-time property of the first passage time.",
+      "exists_rat_near_in_Icc: density of the rational grid ℚ ∩ [0,T] in [0,T], proved uniformly in both interior and endpoint cases via exists_rat_btwn applied to the open interval (max 0 (s₀−ε), min T (s₀+ε)).",
+      "maxEvent_mono: the hitting events form an increasing family in the horizon T, the monotone family of events whose ℱ T-measurability is exactly the stopping-time property."
+    ],
+    "prerequisites": [
+      "MeasureTheory.Filtration and adaptedness (each time-slice W t measurable with respect to ℱ t)",
+      "Sequential compactness of closed intervals: IsCompact.tendsto_subseq for [0,T]",
+      "Density of the rationals in ℝ: exists_rat_btwn",
+      "Limit inequalities for sequences: le_of_tendsto_of_tendsto'",
+      "The sibling characterization fpt_le_set_eq_maxEvent (Proofs/BallotProblemOQ02OQ02.lean)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "IsCompact.tendsto_subseq",
+        "description": "A sequence valued in a compact set has a convergent subsequence; applied to the rational hitting witnesses in [0,T] to extract an accumulation time s* ∈ [0,T].",
+        "module": "Mathlib.Topology.Sequences"
+      },
+      {
+        "theorem": "exists_rat_btwn",
+        "description": "Between any two reals there is a rational; used to produce a rational time in [0,T] arbitrarily close to a real hitting time, handling endpoints uniformly.",
+        "module": "Mathlib.Algebra.Order.Archimedean.Basic"
+      },
+      {
+        "theorem": "MeasureTheory.Filtration.mono",
+        "description": "ℱ q ≤ ℱ T for q ≤ T; promotes ℱ q-measurability of the time-slice W q to ℱ T-measurability for q ∈ [0,T].",
+        "module": "Mathlib.Probability.Process.Filtration"
+      },
+      {
+        "theorem": "MeasurableSet.biUnion",
+        "description": "A countable union of measurable sets is measurable; applied to the countable rational grid {q : ℚ | q ∈ [0,T]}.",
+        "module": "Mathlib.MeasureTheory.MeasurableSpace.Basic"
+      },
+      {
+        "theorem": "tendsto_one_div_add_atTop_nhds_zero_nat",
+        "description": "1/(n+1) → 0; provides the shrinking tolerance a − 1/(φ j + 1) → a in the limit-inequality step of the ⊇ direction.",
+        "module": "Mathlib.Order.Filter.Archimedean"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "ballot-problem-oq-02-oq-02-oq-05-oq-01",
+      "question": "Upgrade the filtration to be right-continuous and prove the strict first-passage event {ω | firstPassageTime bm a ω < T} is also ℱ T-measurable, removing the standing nonemptiness hypothesis by treating the degenerate sInf ∅ = 0 branch explicitly.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "The sibling proves the pointwise characterization {ω | firstPassageTime ≤ T} = maxEvent under nonemptiness; this entry equips that hitting event with a filtration and proves it is ℱ T-measurable, i.e., that the first passage time is a stopping time."
+    }
+  ],
+  "references": [
+    {
+      "title": "Brownian Motion and Stochastic Calculus",
+      "author": "Ioannis Karatzas and Steven E. Shreve",
+      "year": "1991",
+      "venue": "Springer GTM 113",
+      "description": "Standard reference (§1.2) for first passage / hitting times of continuous adapted processes as stopping times, via the right-continuous filtration and the Début theorem."
+    },
+    {
+      "title": "Mathlib4: Probability.Process.HittingTime",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Mathlib's discrete-/well-founded-time hitting-time API (hittingBtwn, hittingBtwn_isStoppingTime), which does not cover the continuous time line ℝ addressed here."
+    }
+  ],
+  "overview": {
+    "historicalContext": "A stopping time is a random time τ such that the event {τ ≤ T} is decidable from the information available by time T — formally, {τ ≤ T} ∈ ℱ T for a filtration ℱ. The first passage time of a level a, τ_a = inf{t ≥ 0 : W_t ≥ a}, is the prototypical example and underlies the optional stopping theorem, the reflection principle, and the arcsine and ballot laws. For a continuous adapted process the result is classical (Karatzas–Shreve §1.2) but its proof is genuinely analytic: the defining infimum ranges over an uncountable set of times, so measurability is not automatic. The standard device is to test the hitting condition on a countable dense grid of rational times, which is valid precisely because the paths are continuous. Mathlib formalises hitting times only for well-founded (discrete) index types, where this analytic step is unnecessary; the continuous-time statement is supplied here.",
+    "problemStatement": "Equip the continuous-path process of the sibling entry with a filtration ℱ to which its time-slices are adapted, and prove that the first-passage / hitting event is ℱ T-measurable — establishing that the first passage time is a stopping time in continuous time.",
+    "proofStrategy": "Reduce the uncountable hitting event maxEvent bm a T = {ω | ∃ s ∈ [0,T], a ≤ W s ω} to the countable expression ⋂ₖ ⋃_{q ∈ ℚ∩[0,T]} {ω | a − 1/(k+1) < W q ω}. The ⊆ inclusion: a real hitting time s₀ is approximated within 1/(k+1) by a rational time q ∈ [0,T] using path continuity and density of the rational grid (exists_rat_near_in_Icc). The ⊇ inclusion: rational witnesses q_k with W q_k ω > a − 1/(k+1) lie in the compact set [0,T], so a subsequence converges to some s* ∈ [0,T] (IsCompact.tendsto_subseq); continuity sends the values to W s* ω and the shrinking lower bounds to a, forcing a ≤ W s* ω (le_of_tendsto_of_tendsto'). Each set in the countable expression is the preimage of an open ray under a single time-slice W q, hence ℱ T-measurable by adaptedness and ℱ q ≤ ℱ T (Filtration.mono); a countable intersection of countable unions of such sets is ℱ T-measurable. Transporting through the sibling's fpt_le_set_eq_maxEvent gives the stopping-time property of the first passage time.",
+    "keyInsights": [
+      "Continuity is exactly what makes the hitting event measurable: it lets an existential over the uncountable index [0,T] be tested on a countable rational grid, the only reason a projection-type set turns out to be measurable at all.",
+      "The strict-inequality slack a − 1/(k+1) is essential. With the non-strict condition a ≤ W q ω on rationals one loses the ⊇ direction (a continuous path can touch level a only at irrational times); the ⋂ₖ over shrinking tolerances recovers the closed event via a limit.",
+      "Sequential compactness of [0,T] does the work of the Début theorem here: rational near-hitting times accumulate at a genuine hitting time, which is where the measurable countable description meets the topological hitting event.",
+      "The sInf ∅ = 0 convention from the sibling entry makes the raw inequality τ ≤ T degenerate for paths that never reach a, so the clean stopping-time statement for the first passage time is stated under the nonemptiness hypothesis; the measurability of the hitting event itself (measurableSet_maxEvent) is unconditional.",
+      "Mathlib's hitting-time machinery is discrete-time only ([WellFoundedLT ι]); the continuous-time index ℝ requires this separate continuity-to-countability argument, which is the original content of the entry."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: First Passage as a Stopping Time",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "States the research question — for the first passage time to be a stopping time, the hitting event must be ℱ T-measurable — and explains the continuity ⟹ countability reduction and why Mathlib's discrete hitting-time API does not apply to continuous time.",
+      "mathContext": "$\\{\\omega : \\exists s\\in[0,T],\\ a\\le W_s(\\omega)\\}\\in\\mathcal F_T$."
+    },
+    {
+      "id": "approx",
+      "title": "The Countable Rational Approximation",
+      "startLine": 58,
+      "endLine": 117,
+      "summary": "Defines approxEvent, the k-th rational approximation of the hitting event. exists_rat_near_in_Icc establishes density of ℚ ∩ [0,T] in [0,T] (interior and endpoints handled uniformly via exists_rat_btwn).",
+      "mathContext": "$\\mathrm{approx}_k=\\bigcup_{q\\in\\mathbb Q\\cap[0,T]}\\{\\omega: a-\\tfrac1{k+1}<W_q(\\omega)\\}$."
+    },
+    {
+      "id": "identity",
+      "title": "The Countable Identity (Analytic Heart)",
+      "startLine": 118,
+      "endLine": 152,
+      "summary": "maxEvent_eq_iInter_approxEvent proves the hitting event equals the countable intersection of its rational approximations. Forward via continuity + rational density; backward via IsCompact.tendsto_subseq and a limit inequality.",
+      "mathContext": "$\\mathrm{maxEvent}=\\bigcap_k\\mathrm{approx}_k$."
+    },
+    {
+      "id": "measurability",
+      "title": "Measurability under a Filtration",
+      "startLine": 153,
+      "endLine": 204,
+      "summary": "measurableSet_maxEvent reads ℱ T-measurability of the hitting event off the countable identity using adaptedness and Filtration.mono. firstPassage_measurableSet transports it to the first-passage event via the sibling's characterization; maxEvent_mono records the increasing family.",
+      "mathContext": "$\\{\\omega:\\tau\\le T\\}\\in\\mathcal F_T$ for $T>0$ under nonemptiness."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The hitting event {ω | ∃ s ∈ [0,T], a ≤ W s ω} of a continuous-path process is rewritten as the countable expression ⋂ₖ ⋃_{q ∈ ℚ∩[0,T]} {ω | a − 1/(k+1) < W q ω} (maxEvent_eq_iInter_approxEvent), using path continuity and density of the rational grid (forward) and sequential compactness of [0,T] with a limit inequality (backward). Under adaptedness of the time-slices to a filtration ℱ, each set in this expression is ℱ T-measurable, so the hitting event is ℱ T-measurable (measurableSet_maxEvent); transporting through the sibling's characterization gives the stopping-time property of the first passage time (firstPassage_measurableSet). 204 lines, 5 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "This is the continuous-time measurability content that Mathlib's discrete hitting-time API omits: it certifies that the first passage time of a continuous adapted process is a stopping time, the hypothesis underlying optional stopping and the reflection principle for the ballot/arcsine line of entries. The badge is original — the continuity-to-countability reduction and its filtration-measurability consequence are not in Mathlib.",
+    "openQuestions": [
+      "Upgrade to a right-continuous filtration and handle the degenerate sInf ∅ = 0 branch to obtain the stopping-time property without the nonemptiness hypothesis."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the open question **ballot-problem-oq-02-oq-02-oq-05**: prove that the first passage time of a continuous adapted process is a **stopping time** — i.e. the hitting event is `ℱ T`-measurable.

The sibling `BallotProblemOQ02OQ02` established the pointwise characterization `{ω | firstPassageTime bm a ω ≤ T} = maxEvent bm a T`. This entry equips that hitting event with a filtration and proves it is observable by time `T`.

## Why this is new

Mathlib's hitting-time API (`hittingBtwn`, `hittingBtwn_isStoppingTime`) is restricted to **well-founded / discrete** index types (`[WellFoundedLT ι]`); it does not cover the continuous time line `ι = ℝ`, where the Début theorem / an analytic continuity argument is required. Nothing in Mathlib records the continuous-time measurability of the first-passage event.

## The argument

The crux is a **continuity ⟹ countability** reduction:

```
maxEvent bm a T  =  ⋂ₖ ⋃_{q ∈ ℚ∩[0,T]} {ω | a − 1/(k+1) < W q ω}
```

- `⊆` : continuity + density of the rational grid in `[0,T]` (`exists_rat_near_in_Icc`, endpoints handled uniformly via `exists_rat_btwn`).
- `⊇` : sequential compactness of `[0,T]` (`IsCompact.tendsto_subseq`) + a limit inequality (`le_of_tendsto_of_tendsto'`). The strict slack `1/(k+1)` is essential — the closed condition on rationals alone loses this direction.

Each set on the right is the preimage of an open ray under a single time-slice `W q`, hence `ℱ T`-measurable by adaptedness and `ℱ q ≤ ℱ T` (`Filtration.mono`); a countable union of countable intersections is `ℱ T`-measurable (`measurableSet_maxEvent`). `firstPassage_measurableSet` transports this to the first-passage event via the sibling characterization (under the standing nonemptiness hypothesis, since `sInf ∅ = 0` otherwise makes `τ ≤ T` degenerate).

## Verification

- **204 lines, 5 theorems, 1 definition, 0 axioms, 0 sorries.**
- Kernel-checked with `lake env lean`; `#print axioms` shows only `propext / Classical.choice / Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Badge: **verified / original**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
