### PR TITLE
Enrich Gautschi Gamma log-convexity: add missing index.ts + annotations.json

### DIFF
--- a/src/data/proofs/gamma-log-convexity-oq-01/annotations.json
+++ b/src/data/proofs/gamma-log-convexity-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-gammalogconv-funceq",
+    "proofId": "gamma-log-convexity-oq-01",
+    "range": { "startLine": 29, "endLine": 32 },
+    "type": "definition",
+    "title": "Log form of the functional equation",
+    "content": "logGamma_add_one rewrites the recurrence Γ(x+1) = x·Γ(x) after taking logarithms: since x > 0 and Γ(x) > 0, log Γ(x+1) = log x + log Γ(x). This single linear increment is what later converts an abstract convexity bound into an explicit power of x. The proof is just Real.Gamma_add_one (to split Γ(x+1)) followed by Real.log_mul (to split the product), with positivity supplying the nonvanishing side conditions.",
+    "mathContext": "$\\log\\Gamma(x+1)-\\log\\Gamma(x)=\\log x$ for $x>0$ — the discrete derivative of $\\log\\Gamma$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma functional equation", "logarithm of a product", "Bohr–Mollerup theorem", "Real.Gamma_add_one"],
+    "prerequisites": ["the Gamma recurrence Γ(x+1)=x·Γ(x)", "log(ab)=log a+log b", "positivity of Γ on (0,∞)"]
+  },
+  {
+    "id": "ann-gammalogconv-core",
+    "proofId": "gamma-log-convexity-oq-01",
+    "range": { "startLine": 34, "endLine": 48 },
+    "type": "key-step",
+    "title": "The core two-point convexity estimate",
+    "content": "logGamma_le_lower is the engine. Applying convexOn_log_Gamma.2 — the two-point (Jensen) inequality for the convex function log∘Γ — at the convex combination x+s = (1−s)·x + s·(x+1) gives log Γ(x+s) ≤ (1−s)·log Γ(x) + s·log Γ(x+1). Substituting the functional-equation increment log Γ(x+1) = log x + log Γ(x) collapses the right-hand side to the clean form log Γ(x) + s·log x. The weights 1−s and s are nonnegative exactly because 0 ≤ s ≤ 1, which is the only constraint convexity needs.",
+    "mathContext": "$\\log\\Gamma(x+s)\\le(1-s)\\log\\Gamma(x)+s\\log\\Gamma(x+1)=\\log\\Gamma(x)+s\\log x$, with $x+s=(1-s)x+s(x+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["two-point convexity / Jensen inequality", "convexOn_log_Gamma", "convex combination", "logarithmic convexity"],
+    "prerequisites": ["convex functions on an interval", "the log functional equation lemma", "weight constraint 0≤s≤1"]
+  },
+  {
+    "id": "ann-gammalogconv-lower",
+    "proofId": "gamma-log-convexity-oq-01",
+    "range": { "startLine": 50, "endLine": 77 },
+    "type": "key-step",
+    "title": "Gautschi lower bound x^(1−s) ≤ Γ(x+1)/Γ(x+s)",
+    "content": "gautschi_lower exponentiates the core estimate. From log Γ(x+s) ≤ log Γ(x) + s·log x, monotonicity of exp (with Real.exp_log undoing the logs, since both sides are positive) yields Γ(x+s) ≤ Γ(x)·x^s. Then Γ(x+1) = x·Γ(x) and the power identity x^(1−s)·x^s = x let a short calc rearrange this into x^(1−s) ≤ Γ(x+1)/Γ(x+s). The division is handled by le_div_iff₀ using Γ(x+s) > 0.",
+    "mathContext": "$\\Gamma(x+s)\\le\\Gamma(x)\\,x^{s}\\Rightarrow x^{1-s}\\le\\dfrac{x\\,\\Gamma(x)}{\\Gamma(x+s)}=\\dfrac{\\Gamma(x+1)}{\\Gamma(x+s)}$.",
+    "significance": "key",
+    "relatedConcepts": ["Gautschi double inequality", "monotonicity of exp", "real powers (rpow)", "le_div_iff₀", "Gamma ratio bounds"],
+    "prerequisites": ["the core convexity estimate", "exp∘log = id on (0,∞)", "rpow arithmetic x^a·x^b=x^{a+b}"]
+  },
+  {
+    "id": "ann-gammalogconv-upper",
+    "proofId": "gamma-log-convexity-oq-01",
+    "range": { "startLine": 78, "endLine": 119 },
+    "type": "technique",
+    "title": "Gautschi upper bound via a forward decomposition",
+    "content": "gautschi_upper uses a different convex combination, x+1 = (1/(2−s))·(x+s) + ((1−s)/(2−s))·(x+2), placing x+1 between x+s and x+2. Convexity gives a bound with denominator (2−s); multiplying through by (2−s) (positive since s<1) and substituting log Γ(x+2) = log(x+1) + log Γ(x+1) clears it. An nlinarith rearrangement isolates log Γ(x+1) − log Γ(x+s) ≤ (1−s)·log(x+1), and exponentiating (via log_div and exp_log) gives Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s). Recasting the bound as one convex combination avoids the usual secant-slope monotonicity machinery and its division side conditions.",
+    "mathContext": "$x+1=\\tfrac{1}{2-s}(x+s)+\\tfrac{1-s}{2-s}(x+2)\\Rightarrow\\log\\Gamma(x+1)-\\log\\Gamma(x+s)\\le(1-s)\\log(x+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Gautschi double inequality", "secant-slope monotonicity", "field_simp denominator clearing", "nlinarith", "log of a quotient"],
+    "prerequisites": ["two-point convexity", "the log functional equation", "monotonicity of exp", "linear arithmetic over ℝ"]
+  },
+  {
+    "id": "ann-gammalogconv-bracket-midpoint",
+    "proofId": "gamma-log-convexity-oq-01",
+    "range": { "startLine": 121, "endLine": 148 },
+    "type": "insight",
+    "title": "Combined bracket and the multiplicative midpoint inequality",
+    "content": "gautschi_bracket simply pairs the two bounds into the two-sided statement x^(1−s) ≤ Γ(x+1)/Γ(x+s) ≤ (x+1)^(1−s). gamma_midpoint_sq_le specialises convexity to equal weights 1/2, 1/2 at points a, b: log Γ((a+b)/2) ≤ ½(log Γ(a) + log Γ(b)); using log_pow and log_mul, doubling, and exponentiating yields the multiplicative form Γ((a+b)/2)² ≤ Γ(a)·Γ(b). This is the cleanest direct witness that Γ itself (not just log Γ) is multiplicatively midpoint-convex.",
+    "mathContext": "$\\Gamma\\!\\left(\\tfrac{a+b}{2}\\right)^{2}\\le\\Gamma(a)\\,\\Gamma(b)$, the exponentiated midpoint convexity of $\\log\\Gamma$.",
+    "significance": "supporting",
+    "relatedConcepts": ["midpoint convexity", "AM–GM-type inequalities", "log_pow", "two-sided bracket", "multiplicative convexity"],
+    "prerequisites": ["the two Gautschi bounds", "midpoint (½,½) Jensen inequality", "exp∘log = id on (0,∞)"]
+  }
+]

--- a/src/data/proofs/gamma-log-convexity-oq-01/index.ts
+++ b/src/data/proofs/gamma-log-convexity-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GammaLogConvexityOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const gammaLogConvexityOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const gammaLogConvexityOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const gammaLogConvexityOQ01Data: ProofData = {
+  proof: gammaLogConvexityOQ01Proof,
+  annotations: gammaLogConvexityOQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `gamma-log-convexity-oq-01`.

The entry already had a rich meta.json (overview, conclusion, sections, references, keyInsights) but was missing two essentials:

- **`index.ts` (critical):** without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing.
- **`annotations.json`:** the entry had no inline annotations at all. Added 5 substantive annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the log functional-equation lemma, the core two-point convexity estimate, both Gautschi bounds (lower via x+s=(1−s)x+s(x+1), upper via the forward decomposition toward x+2), and the multiplicative midpoint inequality.

**Axiom integrity:** unchanged — status `verified`, 0 axioms, 0 sorries, no native_decide, matching the Lean file (derives everything from `Real.convexOn_log_Gamma` + the functional equation).

Build: `tsc -b` exit 0, `vite build` exit 0.