### PR TITLE
audit(angle-trisection-oq-02-oq-02-oq-02): fix theoremCount 17→16

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 246,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "assumptions": "None. 0 axioms, 0 sorries, no native_decide (only kernel `decide` for the finite-product instances 15 = 3·5 and 240 = 2^4·3·5, which depends only on the standard foundational axioms). The geometric step of Gauss–Wantzel (constructibility ⇔ φ(n) a power of two) is NOT used here; this entry isolates the purely number-theoretic characterization.",
     "mathlibDependencies": [
       {
@@ -65,7 +65,7 @@
     "namespace": "AngleTrisectionOQ02OQ02OQ02",
     "lineCount": 246,
     "axiomCount": 0,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ02OQ02OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `angle-trisection-oq-02-oq-02-oq-02` (Gauss–Wantzel: the Number-Theoretic Core for General n)

**Issue (LOW severity)**: `theoremCount` overstated by 1.

## Evidence

`proofs/Proofs/AngleTrisectionOQ02OQ02OQ02.lean` contains exactly **16** `theorem`/`lemma` declarations (line-anchored grep). The only apparent 17th match is on line 218, where the word `theorem.` appears inside a `/- -/` comment, not as a declaration.

meta.json claimed `theoremCount: 17` in **both** `meta.theoremCount` and `leanFile.theoremCount`.

## Fix

Corrected both occurrences 17 → 16.

## Other claims — verified clean

- **0 sorries** (the one `sorry` token is in a docstring)
- **0 axioms**, no structure-encoded assumptions
- **Registered** in `proofs/Proofs.lean` build graph
- **No `native_decide`**; kernel `decide` used only for finite-product facts `15 = 3·5` and `240 = 2^4·3·5` (standard foundational axioms) — disclosed in `assumptions`
- `definitionCount: 1`, `lineCount: 246` accurate
- Badge `original` defensible: general number-theoretic characterization, not a Mathlib wrapper

---
Discovered during gallery integrity audit.