### PR TITLE
research(gamma-reflection-formula-oq-01-oq-03): half-integer closed form Γ(n+1/2)=(2n)!√π/(4ⁿ n!)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2851,6 +2851,7 @@ import Proofs.GCDAlgorithmOQ01OQ03OQ01OQ01
 import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
 import Proofs.GammaReflectionFormulaOQ01OQ01
+import Proofs.GammaReflectionFormulaOQ01OQ03
 import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ03.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ03.lean
@@ -1,0 +1,125 @@
+/-
+# Gamma Reflection OQ-01-OQ-03: The half-integer closed form `Γ(n+1/2) = (2n)!√π / (4ⁿ n!)`
+
+**Open Question (parent `GammaReflectionFormulaOQ01`).** The parent entry establishes
+Euler's reflection formula and the special value `Γ(1/2) = √π`. The sibling
+`GammaReflectionFormulaOQ01OQ01` evaluated the symmetric Beta value `B(1/2,1/2) = π`.
+This file pushes the half-integer thread one structural step further and produces the
+**explicit closed form of `Γ` at every half-integer**:
+
+> `Γ(n + 1/2) = (2n)! · √π / (4ⁿ · n!)`   for all `n : ℕ`.
+
+## What is new
+
+Mathlib has the two ingredients in isolation — the special value
+`Real.Gamma_one_half_eq : Γ(1/2) = √π` and the functional equation
+`Real.Gamma_add_one : Γ(s+1) = s·Γ(s)` — but it does **not** record the resulting
+half-integer closed form, nor its packaging through the central binomial coefficient.
+Both are derived here by a single induction. The closed form turns every value
+`Γ(3/2), Γ(5/2), …` into an elementary expression in factorials and `√π`; the two
+spot-check corollaries `Γ(3/2) = √π/2` and `Γ(5/2) = 3√π/4` fall straight out.
+
+## Method
+
+Induction on `n`. The base case `Γ(1/2) = √π` is `Real.Gamma_one_half_eq`. For the step,
+write `Γ((n+1)+1/2) = Γ((n+1/2)+1) = (n+1/2)·Γ(n+1/2)` via `Real.Gamma_add_one`, insert
+the inductive hypothesis, and clear denominators: the half-integer recursion factor
+`n+1/2` is exactly `(2n+2)(2n+1) / (4(n+1))`, which is the ratio of consecutive closed
+forms. `field_simp; ring` discharges the resulting factorial identity.
+
+## References
+
+* Mathlib: `Mathlib/Analysis/SpecialFunctions/Gamma/Basic.lean`,
+  `Mathlib/Analysis/SpecialFunctions/Gaussian/GaussianIntegral.lean`.
+* Whittaker & Watson, *A Course of Modern Analysis*, §12.14 (the duplication formula
+  and half-integer values of `Γ`).
+-/
+import Mathlib
+
+namespace GammaReflectionFormulaOQ01OQ03
+
+open scoped Real
+
+/-! ## The half-integer closed form -/
+
+/-- **Closed form of `Γ` at half-integers.**
+`Γ(n + 1/2) = (2n)! · √π / (4ⁿ · n!)` for every `n : ℕ`. Proved by induction from
+`Γ(1/2) = √π` (`Real.Gamma_one_half_eq`) and the functional equation
+`Γ(s+1) = s·Γ(s)` (`Real.Gamma_add_one`). -/
+theorem gamma_nat_add_half (n : ℕ) :
+    Real.Gamma (n + 1 / 2) =
+      ((2 * n).factorial : ℝ) * Real.sqrt π / (4 ^ n * (n.factorial : ℝ)) := by
+  induction n with
+  | zero =>
+    simp only [Nat.cast_zero, zero_add, Nat.mul_zero, Nat.factorial_zero, Nat.cast_one,
+      pow_zero, one_mul, mul_one, div_one]
+    exact Real.Gamma_one_half_eq
+  | succ k ih =>
+    -- Nonvanishing of the inductive denominators.
+    have hk : ((k.factorial : ℝ)) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero k)
+    have h4 : (4 : ℝ) ^ k ≠ 0 := by positivity
+    have hk1 : ((k : ℝ) + 1) ≠ 0 := by positivity
+    have hs : ((k : ℝ) + 1 / 2) ≠ 0 := by positivity
+    -- Factorial recursions, transported to `ℝ`.
+    have hnat : (2 * (k + 1)).factorial = (2 * k + 2) * (2 * k + 1) * (2 * k).factorial := by
+      have h1 : 2 * (k + 1) = (2 * k + 1) + 1 := by ring
+      rw [h1, Nat.factorial_succ, Nat.factorial_succ]; ring
+    have e2 : ((2 * (k + 1)).factorial : ℝ)
+        = (2 * (k : ℝ) + 2) * (2 * (k : ℝ) + 1) * ((2 * k).factorial : ℝ) := by
+      rw [hnat]; push_cast; ring
+    have efk : (((k + 1).factorial) : ℝ) = ((k : ℝ) + 1) * (k.factorial : ℝ) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    -- Step `Γ((k+1)+1/2) = (k+1/2)·Γ(k+1/2)`, then substitute the closed form.
+    have harg : ((k + 1 : ℕ) : ℝ) + 1 / 2 = ((k : ℝ) + 1 / 2) + 1 := by push_cast; ring
+    rw [harg, Real.Gamma_add_one hs, ih, e2, efk, pow_succ]
+    field_simp
+    try ring
+
+/-! ## Consequences -/
+
+/-- **Ratio to `Γ(1/2)`.** Dividing by `√π = Γ(1/2)` exhibits the half-integer Gamma
+quotient as a pure rational number, `Γ(n+1/2)/√π = (2n)!/(4ⁿ n!)`. -/
+theorem gamma_nat_add_half_div_sqrt_pi (n : ℕ) :
+    Real.Gamma (n + 1 / 2) / Real.sqrt π =
+      ((2 * n).factorial : ℝ) / (4 ^ n * (n.factorial : ℝ)) := by
+  rw [gamma_nat_add_half]
+  have hπ : Real.sqrt π ≠ 0 := by positivity
+  field_simp
+  try ring
+
+/-- **Central-binomial packaging.** Since `(2n)! = C(2n,n)·(n!)²`, the closed form reads
+`Γ(n+1/2) = C(2n,n) · n! · √π / 4ⁿ`, tying the half-integer Gamma values to the central
+binomial coefficients. -/
+theorem gamma_nat_add_half_centralBinom (n : ℕ) :
+    Real.Gamma (n + 1 / 2) =
+      ((2 * n).choose n : ℝ) * (n.factorial : ℝ) * Real.sqrt π / 4 ^ n := by
+  rw [gamma_nat_add_half]
+  have hk : ((n.factorial : ℝ)) ≠ 0 := Nat.cast_ne_zero.mpr (Nat.factorial_ne_zero n)
+  have h4 : (4 : ℝ) ^ n ≠ 0 := by positivity
+  -- `C(2n,n)·n!·n! = (2n)!` from `Nat.choose_mul_factorial_mul_factorial`.
+  have hchoose : ((2 * n).choose n) * n.factorial * n.factorial = (2 * n).factorial := by
+    have h := Nat.choose_mul_factorial_mul_factorial (Nat.le_mul_of_pos_left n (by norm_num) :
+      n ≤ 2 * n)
+    rwa [show 2 * n - n = n by omega] at h
+  have hcast : ((2 * n).factorial : ℝ)
+      = ((2 * n).choose n : ℝ) * (n.factorial : ℝ) * (n.factorial : ℝ) := by
+    rw [← hchoose]; push_cast; ring
+  rw [hcast]
+  field_simp
+  try ring
+
+/-! ## Spot checks at small half-integers -/
+
+/-- `Γ(3/2) = √π / 2` (the case `n = 1`). -/
+theorem gamma_three_half : Real.Gamma (3 / 2) = Real.sqrt π / 2 := by
+  rw [show (3 / 2 : ℝ) = 1 / 2 + 1 by norm_num, Real.Gamma_add_one (by norm_num),
+    Real.Gamma_one_half_eq]
+  ring
+
+/-- `Γ(5/2) = 3√π / 4` (the case `n = 2`). -/
+theorem gamma_five_half : Real.Gamma (5 / 2) = 3 * Real.sqrt π / 4 := by
+  rw [show (5 / 2 : ℝ) = 3 / 2 + 1 by norm_num, Real.Gamma_add_one (by norm_num),
+    gamma_three_half]
+  ring
+
+end GammaReflectionFormulaOQ01OQ03

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-03",
+  "slug": "gamma-reflection-formula-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "scoped Real"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ03",
+    "lineCount": 125,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Integer Closed Form Γ(n+1/2) = (2n)!√π / (4ⁿ n!)",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ03.lean",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "factorial",
+      "central-binomial",
+      "reflection-formula",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 125,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "gamma_nat_add_half: the explicit half-integer closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) for all n : ℕ, proved by a single induction from Γ(1/2) = √π (Real.Gamma_one_half_eq) and the functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one). Mathlib has both ingredients separately but does not record the closed form.",
+      "gamma_nat_add_half_div_sqrt_pi: the ratio to Γ(1/2), Γ(n+1/2)/√π = (2n)!/(4ⁿ n!), exhibiting the half-integer Gamma quotient as a pure rational number.",
+      "gamma_nat_add_half_centralBinom: the central-binomial packaging Γ(n+1/2) = C(2n,n)·n!·√π/4ⁿ, obtained from (2n)! = C(2n,n)·(n!)² (Nat.choose_mul_factorial_mul_factorial), tying half-integer Gamma values to the central binomial coefficients.",
+      "gamma_three_half: the spot-check value Γ(3/2) = √π/2 (the case n = 1).",
+      "gamma_five_half: the spot-check value Γ(5/2) = 3√π/4 (the case n = 2)."
+    ],
+    "prerequisites": [
+      "Euler Gamma function Real.Gamma and the value Γ(1/2) = √π (Real.Gamma_one_half_eq)",
+      "The functional equation Γ(s+1) = s·Γ(s) (Real.Gamma_add_one) for s ≠ 0",
+      "Factorial recursion Nat.factorial_succ and the central binomial identity Nat.choose_mul_factorial_mul_factorial",
+      "Basic real-field manipulation (field_simp / ring) to clear factorial denominators"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "Γ(1/2) = √π over ℝ — the base case of the induction.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gaussian.GaussianIntegral"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Γ(s+1) = s·Γ(s) for s ≠ 0 — the functional equation driving the inductive step Γ((n+1)+1/2) = (n+1/2)·Γ(n+1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n! — used to expand (2n+2)! and (n+1)! when matching consecutive closed forms.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "choose n k · k! · (n-k)! = n!; at (2n, n) it gives (2n)! = C(2n,n)·(n!)², the central-binomial packaging of the closed form.",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+      "question": "Express the same half-integer values through the double factorial, Γ(n+1/2) = (2n-1)!!·√π/2ⁿ, and prove the equivalence (2n)!/(4ⁿ n!) = (2n-1)!!/2ⁿ with the odd double factorial.",
+      "significance": "low"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "The sibling evaluates the symmetric Beta value B(1/2,1/2) = π from Γ(1/2)² = π; this entry pushes the same half-integer thread to the full closed form of Γ at every half-integer."
+    },
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "extends",
+      "description": "The parent establishes Euler's reflection formula and Γ(1/2) = √π; this entry iterates the functional equation Γ(s+1) = s·Γ(s) from that base value to the half-integer closed form."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_add_one (the functional equation) and the Gamma-function development."
+    },
+    {
+      "title": "A Course of Modern Analysis",
+      "author": "E. T. Whittaker and G. N. Watson",
+      "year": "1927",
+      "venue": "Cambridge University Press",
+      "description": "Classical reference for half-integer values of the Gamma function and the duplication formula (§12.14)."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The values of Euler's Gamma function at half-integers are among the oldest computed special values: from Γ(1/2) = √π (equivalently the Gaussian integral) the functional equation Γ(s+1) = s·Γ(s) generates Γ(3/2) = √π/2, Γ(5/2) = 3√π/4, and in general Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!). This closed form is the half-integer analogue of Γ(n+1) = n! and underlies the volume of the n-ball, the moments of the Gaussian, and the normalisation of the Beta and Student distributions. The numerator/denominator combination (2n)!/(4ⁿ n!) is exactly C(2n,n)·n!/4ⁿ, so the half-integer Gamma values are central binomial coefficients in disguise. Mathlib formalises Γ(1/2) = √π and the functional equation but does not record the closed form; it is supplied here.",
+    "problemStatement": "Prove the closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) for every natural number n, and package it through the ratio to Γ(1/2) and through the central binomial coefficient, recovering the concrete values Γ(3/2) = √π/2 and Γ(5/2) = 3√π/4.",
+    "proofStrategy": "Induct on n. The base case Γ(1/2) = √π is Real.Gamma_one_half_eq. For the step, rewrite Γ((n+1)+1/2) as Γ((n+1/2)+1) = (n+1/2)·Γ(n+1/2) using Real.Gamma_add_one (with n+1/2 ≠ 0 by positivity), substitute the inductive hypothesis, and observe that the half-integer recursion factor n+1/2 equals (2n+2)(2n+1)/(4(n+1)) — the ratio of consecutive closed forms. Transporting the factorial recursions (2n+2)! = (2n+2)(2n+1)(2n)! and (n+1)! = (n+1)·n! to ℝ and clearing denominators with field_simp closes the step. The ratio and central-binomial corollaries follow by dividing by √π and substituting (2n)! = C(2n,n)·(n!)²; the small values are independent two-line derivations from the functional equation.",
+    "keyInsights": [
+      "The half-integer closed form is the exact analogue of Γ(n+1) = n!: a single induction off Γ(1/2) = √π using only the functional equation Γ(s+1) = s·Γ(s) produces all values Γ(n+1/2) at once.",
+      "The inductive step works because the half-integer recursion factor n+1/2 is precisely (2n+2)(2n+1)/(4(n+1)), the ratio of the (n+1)-th and n-th closed forms — so the proof reduces to an elementary factorial identity dischargeable by field_simp.",
+      "The combination (2n)!/(4ⁿ n!) is the central binomial coefficient up to a factorial: (2n)! = C(2n,n)·(n!)² gives Γ(n+1/2) = C(2n,n)·n!·√π/4ⁿ, linking the Gamma half-integer values to the central binomial coefficients.",
+      "Dividing by √π = Γ(1/2) shows Γ(n+1/2)/Γ(1/2) = (2n)!/(4ⁿ n!) is a rational number, the clean half-integer analogue of Γ(n+1)/Γ(1) = n!.",
+      "The badge is original: Mathlib has Γ(1/2) = √π and the functional equation as separate facts but does not record the resulting half-integer closed form or its central-binomial packaging."
+    ]
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: The Half-Integer Closed Form",
+      "startLine": 1,
+      "endLine": 49,
+      "summary": "States the open question — extend the half-integer thread to the explicit closed form Γ(n+1/2) = (2n)!√π/(4ⁿ n!) — names the two Mathlib ingredients (Real.Gamma_one_half_eq, Real.Gamma_add_one) that exist only in isolation, and outlines the single-induction method.",
+      "mathContext": "$\\Gamma(n+\\tfrac12) = \\dfrac{(2n)!\\,\\sqrt{\\pi}}{4^{n}\\,n!}$."
+    },
+    {
+      "id": "closed-form",
+      "title": "The Half-Integer Closed Form",
+      "startLine": 51,
+      "endLine": 86,
+      "summary": "gamma_nat_add_half proves the closed form by induction: base case Γ(1/2) = √π; step Γ((k+1)+1/2) = (k+1/2)·Γ(k+1/2) via Real.Gamma_add_one, then the factorial recursions are transported to ℝ and field_simp closes the consecutive-ratio identity.",
+      "mathContext": "$\\Gamma((k{+}1)+\\tfrac12) = (k+\\tfrac12)\\,\\Gamma(k+\\tfrac12)$, with $k+\\tfrac12 = \\dfrac{(2k+2)(2k+1)}{4(k+1)}$."
+    },
+    {
+      "id": "consequences",
+      "title": "Ratio and Central-Binomial Packaging",
+      "startLine": 88,
+      "endLine": 118,
+      "summary": "gamma_nat_add_half_div_sqrt_pi divides by √π to give the rational quotient (2n)!/(4ⁿ n!). gamma_nat_add_half_centralBinom uses (2n)! = C(2n,n)·(n!)² to rewrite the closed form as C(2n,n)·n!·√π/4ⁿ.",
+      "mathContext": "$\\dfrac{\\Gamma(n+\\tfrac12)}{\\sqrt{\\pi}} = \\dfrac{(2n)!}{4^{n} n!} = \\dbinom{2n}{n}\\dfrac{n!}{4^{n}}$."
+    },
+    {
+      "id": "spot-checks",
+      "title": "Spot Checks at Small Half-Integers",
+      "startLine": 120,
+      "endLine": 125,
+      "summary": "gamma_three_half and gamma_five_half evaluate Γ(3/2) = √π/2 and Γ(5/2) = 3√π/4 directly from the functional equation, matching the closed form at n = 1 and n = 2.",
+      "mathContext": "$\\Gamma(3/2) = \\sqrt{\\pi}/2$, $\\Gamma(5/2) = 3\\sqrt{\\pi}/4$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The half-integer closed form Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!) is proved for all n by a single induction off Γ(1/2) = √π using only the functional equation Γ(s+1) = s·Γ(s); the half-integer recursion factor n+1/2 = (2n+2)(2n+1)/(4(n+1)) makes the step an elementary factorial identity. The closed form is repackaged as the rational ratio Γ(n+1/2)/√π = (2n)!/(4ⁿ n!) and through the central binomial coefficient C(2n,n), and verified at Γ(3/2) = √π/2 and Γ(5/2) = 3√π/4. 125 lines, 5 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "Mathlib supplies Γ(1/2) = √π and the functional equation but not the half-integer closed form or its central-binomial form — hence the original badge. The result is the half-integer analogue of Γ(n+1) = n! and the standard ingredient for n-ball volumes, Gaussian moments, and Beta/Student normalisations.",
+    "openQuestions": [
+      "Express the same values through the odd double factorial, Γ(n+1/2) = (2n-1)!!·√π/2ⁿ, and prove (2n)!/(4ⁿ n!) = (2n-1)!!/2ⁿ."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Proves the explicit **closed form of the Gamma function at every half-integer**:

> Γ(n + 1/2) = (2n)! · √π / (4ⁿ · n!)   for all `n : ℕ`.

Mathlib has the two ingredients in isolation — `Real.Gamma_one_half_eq` (Γ(1/2)=√π) and `Real.Gamma_add_one` (Γ(s+1)=s·Γ(s)) — but does **not** record the resulting closed form. A single induction supplies it.

## Theorems (`GammaReflectionFormulaOQ01OQ03`)

- `gamma_nat_add_half`: Γ(n+1/2) = (2n)!·√π/(4ⁿ·n!)
- `gamma_nat_add_half_div_sqrt_pi`: the rational ratio Γ(n+1/2)/√π = (2n)!/(4ⁿ n!)
- `gamma_nat_add_half_centralBinom`: Γ(n+1/2) = C(2n,n)·n!·√π/4ⁿ (from (2n)!=C(2n,n)·(n!)²)
- `gamma_three_half`, `gamma_five_half`: Γ(3/2)=√π/2, Γ(5/2)=3√π/4

## Method

Induction on `n`. Base: Γ(1/2)=√π. Step: Γ((n+1)+1/2) = (n+1/2)·Γ(n+1/2) via the functional equation; the recursion factor `n+1/2` equals `(2n+2)(2n+1)/(4(n+1))`, exactly the ratio of consecutive closed forms, so `field_simp` discharges the factorial identity.

## Verification

- **verified / original**, 5 theorems, 0 definitions, **0 axioms, 0 sorries**.
- `#print axioms` reports only `propext, Classical.choice, Quot.sound` (no `sorryAx`, no `Lean.ofReduceBool`).
- Compiled against Mathlib via `lake env lean`.

Extends the half-integer thread from the sibling `gamma-reflection-formula-oq-01-oq-01` (B(1/2,1/2)=π).

🤖 Generated with [Claude Code](https://claude.com/claude-code)