### PR TITLE
Enrich Hall's theorem (necessity): add missing index.ts + annotations + crossRefs

### DIFF
--- a/src/data/proofs/halls-theorem-oq-01/annotations.json
+++ b/src/data/proofs/halls-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-hallsoq01-overview",
+    "proofId": "halls-theorem-oq-01",
+    "range": { "startLine": 1, "endLine": 47 },
+    "type": "concept",
+    "title": "Closing Hall's theorem to a biconditional",
+    "content": "Mathlib formalizes only the hard sufficiency direction of Hall's marriage theorem (Hall's condition ⟹ a saturating matching) via exists_isMatching_of_forall_ncard_le, plus its perfect-matching analogue. The elementary but indispensable converse — that any saturating matching forces Hall's condition — is absent, so Mathlib cannot state Hall's theorem as an honest 'if and only if'. This file supplies that necessity direction as a graph-agnostic lemma and assembles the textbook biconditionals together with a contrapositive deficiency certificate.",
+    "mathContext": "Hall's condition on $p_1$: $\\forall s\\subseteq p_1,\\ |s|\\le\\big|\\bigcup_{x\\in s}N(x)\\big|$, abbreviated $s.\\mathrm{ncard}\\le(\\bigcup_{x\\in s}G.\\mathrm{neighborSet}\\,x).\\mathrm{ncard}$.",
+    "significance": "context",
+    "relatedConcepts": ["Hall's marriage theorem", "bipartite matching", "systems of distinct representatives", "Mathlib gap", "biconditional"],
+    "prerequisites": ["simple graphs and subgraphs", "matchings", "set cardinality (ncard)"]
+  },
+  {
+    "id": "ann-hallsoq01-necessity",
+    "proofId": "halls-theorem-oq-01",
+    "range": { "startLine": 49, "endLine": 80 },
+    "type": "key-step",
+    "title": "Necessity via the matched-partner injection",
+    "content": "ncard_le_ncard_biUnion_neighborSet_of_isMatching is the whole content. From a matching M whose vertex set contains s, define φ sending each v ∈ M.verts to its unique M-neighbour (the IsMatching choice function). Three facts combine: (1) φ v is a G-neighbour of v since the matching is a subgraph (M.adj_sub), so φ maps s into ⋃ x ∈ s, G.neighborSet x; (2) φ is injective on s because two vertices M-adjacent to the same partner must coincide (hM.eq_of_adj_right); (3) an injection into a finite set does not increase ncard (Set.ncard_le_ncard_of_injOn), the neighbourhood being finite by local finiteness. Crucially this needs no bipartiteness — it is a fact about any matching in any locally finite graph.",
+    "mathContext": "$\\varphi:s\\hookrightarrow\\bigcup_{x\\in s}N(x)$ injective $\\Rightarrow s.\\mathrm{ncard}\\le(\\bigcup_{x\\in s}N(x)).\\mathrm{ncard}$.",
+    "significance": "key",
+    "relatedConcepts": ["matched-partner map", "injection on a set", "Set.ncard_le_ncard_of_injOn", "IsMatching.eq_of_adj_right", "local finiteness"],
+    "prerequisites": ["choice function from a matching", "Set.mem_biUnion", "ncard of finite sets"]
+  },
+  {
+    "id": "ann-hallsoq01-infinite",
+    "proofId": "halls-theorem-oq-01",
+    "range": { "startLine": 77, "endLine": 88 },
+    "type": "technique",
+    "title": "Infinite case and the perfect-matching global form",
+    "content": "The finite/infinite split (Set.finite_or_infinite) handles unboundedness cleanly: for infinite s, ncard's convention s.ncard = 0 makes the bound vacuously true, so no separate finiteness hypothesis on s is needed. ncard_le_of_isPerfectMatching then lifts necessity to the global form — a perfect matching saturates all of V (Subgraph.isSpanning_iff), so every set s, not just subsets of one part, satisfies Hall's bound.",
+    "mathContext": "For infinite $s$, $s.\\mathrm{ncard}=0\\le(\\cdots).\\mathrm{ncard}$; a perfect matching spans $V$, so the bound holds for all $s\\subseteq V$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ncard infinite convention", "perfect matching", "spanning subgraph", "Subgraph.isSpanning_iff"],
+    "prerequisites": ["Set.finite_or_infinite", "IsPerfectMatching", "subset_univ"]
+  },
+  {
+    "id": "ann-hallsoq01-biconditionals",
+    "proofId": "halls-theorem-oq-01",
+    "range": { "startLine": 90, "endLine": 114 },
+    "type": "key-step",
+    "title": "Assembling the marriage biconditionals",
+    "content": "hall_marriage pairs Mathlib's sufficiency (exists_isMatching_of_forall_ncard_le) with the new necessity lemma to give the full 'iff': for a locally finite bipartite graph with parts p₁, p₂, a matching saturating p₁ exists ⟺ Hall's condition holds on p₁. hall_perfect is the analogous global statement for perfect matchings. The forward directions are one-line citations of Mathlib; the reverse directions are the only genuinely new mathematics, supplied by the necessity lemmas.",
+    "mathContext": "$\\big(\\forall s\\subseteq p_1,\\ |s|\\le|N(s)|\\big)\\iff\\exists M,\\ p_1\\subseteq M.\\mathrm{verts}\\wedge M.\\mathrm{IsMatching}$.",
+    "significance": "key",
+    "relatedConcepts": ["if-and-only-if assembly", "exists_isMatching_of_forall_ncard_le", "IsBipartiteWith", "perfect matching biconditional"],
+    "prerequisites": ["the necessity lemma", "Mathlib's sufficiency direction", "bipartite graphs"]
+  },
+  {
+    "id": "ann-hallsoq01-deficiency",
+    "proofId": "halls-theorem-oq-01",
+    "range": { "startLine": 116, "endLine": 127 },
+    "type": "insight",
+    "title": "The deficiency obstruction certificate",
+    "content": "exists_violating_of_no_matching is the contrapositive of the marriage biconditional, obtained by by_contra/push_neg: if G admits no matching saturating p₁, then some s ⊆ p₁ has strictly fewer neighbours than vertices. This repackages 'no matching exists' into a concrete, checkable witness of failure — the practically useful obstruction form (a Hall-violating set is a deficiency certificate). It is the seed of the quantitative deficiency (Ore) version that bounds the maximum matching size by |p₁| − maxₛ(|s| − |N(s)|).",
+    "mathContext": "$\\neg\\exists$ saturating matching $\\Rightarrow\\exists s\\subseteq p_1,\\ |N(s)|<|s|$ — a concrete Hall-violating subset.",
+    "significance": "supporting",
+    "relatedConcepts": ["deficiency / Ore form", "contrapositive certificate", "by_contra / push_neg", "obstruction witness", "König's theorem"],
+    "prerequisites": ["the marriage biconditional", "contraposition", "negating a bounded quantifier"]
+  }
+]

--- a/src/data/proofs/halls-theorem-oq-01/index.ts
+++ b/src/data/proofs/halls-theorem-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/HallsTheoremOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const hallsTheoremOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const hallsTheoremOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const hallsTheoremOQ01Data: ProofData = {
+  proof: hallsTheoremOQ01Proof,
+  annotations: hallsTheoremOQ01Annotations,
+}

--- a/src/data/proofs/halls-theorem-oq-01/meta.json
+++ b/src/data/proofs/halls-theorem-oq-01/meta.json
@@ -111,7 +111,23 @@
       "summary": "exists_violating_of_no_matching — the contrapositive certificate: no saturating matching ⟹ some subset violates Hall's condition."
     }
   ],
-  "crossReferences": [],
+  "crossReferences": [
+    {
+      "proofId": "halls-theorem-oq-01-oq-01",
+      "relationship": "Quantitative refinement",
+      "description": "The deficiency (Ore) form of Hall's theorem — the maximum matching size equals |p₁| minus the maximum Hall deficiency. Directly realises this entry's first open question, building on the deficiency certificate exists_violating_of_no_matching."
+    },
+    {
+      "proofId": "halls-theorem-oq-02",
+      "relationship": "Sibling specialisation",
+      "description": "Hall's theorem for balanced bipartite graphs, where the one-sided Hall condition already suffices for a perfect matching. Specialises the hall_perfect biconditional proved here to the |p₁| = |p₂| setting."
+    },
+    {
+      "proofId": "hall-marriage-theorem-oq-01",
+      "relationship": "Related application",
+      "description": "Systems of distinct representatives and concrete deficiency witnesses — the SDR corollary of the marriage biconditional, another consequence flagged in this entry's open questions."
+    }
+  ],
   "references": [
     {
       "text": "Hall, P. (1935). On Representatives of Subsets. Journal of the London Mathematical Society, 10(1), 26–30.",


### PR DESCRIPTION
Enrichment pass for `halls-theorem-oq-01` (Hall's marriage theorem, necessity direction / full biconditional).

The entry had a rich meta.json (overview, conclusion, sections, references) but was missing the essentials:

- **`index.ts` (critical):** without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing.
- **`annotations.json`:** no inline annotations existed. Added 5 (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the Mathlib-gap framing, the matched-partner injection that proves necessity, the infinite/perfect-matching global form, the assembled marriage biconditionals, and the deficiency obstruction certificate.
- **`crossReferences`:** was empty; linked the deficiency/Ore form (`halls-theorem-oq-01-oq-01`), the balanced-bipartite specialisation (`halls-theorem-oq-02`), and the SDR application (`hall-marriage-theorem-oq-01`).

**Axiom integrity:** unchanged — status `verified`/badge `original`, 0 axioms, 0 sorries, matching the Lean file (necessity is a graph-agnostic injection bound; biconditionals pair it with Mathlib's sufficiency).

Build: `tsc -b` exit 0, `vite build` exit 0.