### PR TITLE
Half-integer Gamma closed form Γ(n+1/2)=(2n)!√π/(4ⁿ n!) (gamma-reflection-formula-oq-01-oq-03)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2832,6 +2832,7 @@ import Proofs.GCDAlgorithmOQ01OQ03OQ01
 import Proofs.GCDAlgorithmOQ01OQ03OQ01OQ01
 import Proofs.GammaLogConvexityOQ01
 import Proofs.GammaReflectionFormulaOQ01
+import Proofs.GammaReflectionFormulaOQ01OQ03
 import Proofs.GaussLemmaPrimitiveOQ01
 import Proofs.GaussWilsonNonCyclic
 import Proofs.GaussWilsonNonCyclicOQ01

--- a/proofs/Proofs/GammaReflectionFormulaOQ01OQ03.lean
+++ b/proofs/Proofs/GammaReflectionFormulaOQ01OQ03.lean
@@ -1,0 +1,108 @@
+import Mathlib
+
+/-!
+# The half-integer Gamma values: `Γ(n + 1/2) = (2n)!·√π / (4ⁿ·n!)`
+
+The Gamma function takes a clean closed form at every half-integer.  Starting from
+the single transcendental value `Γ(1/2) = √π` and the functional equation
+`Γ(s + 1) = s·Γ(s)`, the value at `n + 1/2` is forced to be a **rational multiple of
+`√π`**:
+
+  `Γ(n + 1/2) = (2n)! / (4ⁿ · n!) · √π.`
+
+Equivalently the ratio `Γ(n + 1/2) / Γ(1/2)` is the rational number `(2n)!/(4ⁿ n!)`,
+which is also `(2n−1)!! / 2ⁿ` (the odd double factorial over a power of two).  So
+while `Γ(1/2) = √π` is irrational, *all* the arithmetic of the half-integer Gamma
+values is captured by elementary factorials.
+
+Mathlib provides the ingredients — `Real.Gamma_one_half_eq` (`Γ(1/2) = √π`),
+`Real.Gamma_add_one` (the functional equation), and the Legendre duplication formula
+`Real.Gamma_mul_Gamma_add_half` — but **not** this explicit half-integer closed form.
+This entry supplies it by induction on `n`: the base case is `Γ(1/2) = √π`, and the
+step multiplies by `n + 1/2` via the functional equation, the factor `(n + 1/2)`
+promoting `(2n)!/(4ⁿ n!)` to `(2n+2)!/(4ⁿ⁺¹ (n+1)!)` after one `ring` manipulation of
+the factorial recurrences.
+
+This refines `gamma-reflection-formula-oq-01` (OQ-03): the sibling `oq-01-oq-01`
+established `B(1/2,1/2) = π` (equivalently `Γ(1/2)² = π`); here we climb the whole
+half-integer ladder above `1/2`.
+-/
+
+namespace GammaReflectionFormulaOQ01OQ03
+
+open Real
+
+/-- **Closed form for the half-integer Gamma values.**
+`Γ(n + 1/2) = (2n)! / (4ⁿ · n!) · √π` for every natural number `n`.
+
+Proof by induction.  Base: `Γ(1/2) = √π` (`Real.Gamma_one_half_eq`) and the
+coefficient is `0!/(1·0!) = 1`.  Step: `Γ((n+1) + 1/2) = (n + 1/2)·Γ(n + 1/2)` by the
+functional equation `Real.Gamma_add_one`; substituting the inductive hypothesis and
+expanding the factorial recurrences `(2n+2)! = (2n+2)(2n+1)(2n)!`, `(n+1)! = (n+1)·n!`,
+`4ⁿ⁺¹ = 4·4ⁿ`, the identity closes by `field_simp`/`ring` — the factor `n + 1/2 =
+(2n+1)/2` is exactly what the recurrence needs. -/
+theorem gamma_nat_add_half (n : ℕ) :
+    Real.Gamma ((n : ℝ) + 1 / 2)
+      = ((2 * n).factorial : ℝ) / (4 ^ n * (n.factorial : ℝ)) * Real.sqrt π := by
+  induction n with
+  | zero => norm_num [Real.Gamma_one_half_eq]
+  | succ k ih =>
+    have hk : ((k : ℝ) + 1 / 2) ≠ 0 := by positivity
+    have hidx : ((k + 1 : ℕ) : ℝ) + 1 / 2 = ((k : ℝ) + 1 / 2) + 1 := by push_cast; ring
+    rw [hidx, Real.Gamma_add_one hk, ih]
+    -- factorial / power recurrences, cast to ℝ
+    have f1 : ((2 * (k + 1)).factorial : ℝ)
+        = (2 * (k : ℝ) + 2) * (2 * (k : ℝ) + 1) * ((2 * k).factorial : ℝ) := by
+      have he : 2 * (k + 1) = (2 * k + 1) + 1 := by ring
+      rw [he, Nat.factorial_succ, Nat.factorial_succ]; push_cast; ring
+    have f2 : (((k + 1).factorial : ℝ)) = ((k : ℝ) + 1) * (k.factorial : ℝ) := by
+      rw [Nat.factorial_succ]; push_cast; ring
+    have hpow : (4 : ℝ) ^ (k + 1) = 4 * 4 ^ k := by rw [pow_succ]; ring
+    have hkfac : (k.factorial : ℝ) ≠ 0 := by exact_mod_cast Nat.factorial_ne_zero k
+    have h4 : (4 : ℝ) ^ k ≠ 0 := by positivity
+    have hk1 : ((k : ℝ) + 1) ≠ 0 := by positivity
+    rw [f1, f2, hpow]
+    field_simp
+    ring
+
+/-- The half-integer Gamma value as a **rational multiple of `Γ(1/2)`**:
+`Γ(n + 1/2) = (2n)!/(4ⁿ n!) · Γ(1/2)`.  Makes explicit that the entire `n`-dependence
+is the rational coefficient `(2n)!/(4ⁿ n!)`; the only transcendental ingredient is the
+single value `Γ(1/2)`. -/
+theorem gamma_nat_add_half_eq_mul_gamma_half (n : ℕ) :
+    Real.Gamma ((n : ℝ) + 1 / 2)
+      = ((2 * n).factorial : ℝ) / (4 ^ n * (n.factorial : ℝ)) * Real.Gamma (1 / 2) := by
+  rw [Real.Gamma_one_half_eq]; exact gamma_nat_add_half n
+
+/-- **Positivity** of the half-integer Gamma values: `0 < Γ(n + 1/2)`.  Immediate from
+the closed form, since `(2n)!`, `4ⁿ`, `n!` and `√π` are all positive. -/
+theorem gamma_nat_add_half_pos (n : ℕ) : 0 < Real.Gamma ((n : ℝ) + 1 / 2) := by
+  rw [gamma_nat_add_half]
+  apply mul_pos
+  · apply div_pos
+    · exact_mod_cast Nat.factorial_pos (2 * n)
+    · exact mul_pos (by positivity) (by exact_mod_cast Nat.factorial_pos n)
+  · exact Real.sqrt_pos.mpr Real.pi_pos
+
+/-- Worked value `Γ(3/2) = √π / 2`, the `n = 1` instance.  Derived independently from
+the functional equation as a cross-check: `Γ(3/2) = Γ(1/2 + 1) = (1/2)·Γ(1/2)`. -/
+theorem gamma_three_half : Real.Gamma (3 / 2) = Real.sqrt π / 2 := by
+  rw [show (3 : ℝ) / 2 = 1 / 2 + 1 by norm_num, Real.Gamma_add_one (by norm_num),
+    Real.Gamma_one_half_eq]
+  ring
+
+/-- Worked value `Γ(5/2) = 3√π / 4`, the `n = 2` instance: `Γ(5/2) = (3/2)·Γ(3/2)`. -/
+theorem gamma_five_half : Real.Gamma (5 / 2) = 3 * Real.sqrt π / 4 := by
+  rw [show (5 : ℝ) / 2 = 3 / 2 + 1 by norm_num, Real.Gamma_add_one (by norm_num),
+    gamma_three_half]
+  ring
+
+/-- Consistency of the general formula with the worked value: instantiating
+`gamma_nat_add_half` at `n = 1` reproduces `Γ(3/2) = √π / 2`. -/
+theorem gamma_nat_add_half_one :
+    Real.Gamma (((1 : ℕ) : ℝ) + 1 / 2) = Real.sqrt π / 2 := by
+  rw [gamma_nat_add_half]
+  norm_num [Nat.factorial]
+  ring
+
+end GammaReflectionFormulaOQ01OQ03

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-gamma-refl-oq01-oq03-docstring",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 3,
+      "endLine": 29
+    },
+    "type": "context",
+    "title": "Half-Integer Gamma Values from One Transcendental Seed",
+    "content": "The docstring sets up the half-integer closed form Γ(n+1/2) = (2n)!/(4ⁿ·n!)·√π. The single transcendental ingredient is Γ(1/2)=√π (Mathlib's Real.Gamma_one_half_eq); the functional equation Γ(s+1)=s·Γ(s) (Real.Gamma_add_one) then forces every Γ(n+1/2) to be a rational multiple of √π, the coefficient (2n)!/(4ⁿ n!) — equivalently (2n−1)!!/2ⁿ. Mathlib has the base value, the functional equation, and even the Legendre duplication formula, but not this explicit half-integer closed form; this entry supplies it by induction.",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right)=\\dfrac{(2n)!}{4^n\\,n!}\\sqrt\\pi=\\dfrac{(2n-1)!!}{2^n}\\sqrt\\pi$"
+  },
+  {
+    "id": "ann-gamma-refl-oq01-oq03-closed-form",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 44,
+      "endLine": 70
+    },
+    "type": "key-step",
+    "title": "The Closed Form by Induction",
+    "content": "gamma_nat_add_half proves Γ(n+1/2) = (2n)!/(4ⁿ·n!)·√π for every n. Base case: Γ(1/2)=√π and the coefficient is 0!/(1·0!)=1. Inductive step: Γ((n+1)+1/2) = Γ((n+1/2)+1) = (n+1/2)·Γ(n+1/2) via Real.Gamma_add_one (with n+1/2 ≠ 0 by positivity); substitute the inductive hypothesis and rewrite the factorial/power recurrences (2n+2)! = (2n+2)(2n+1)(2n)!, (n+1)! = (n+1)·n!, 4ⁿ⁺¹ = 4·4ⁿ (cast to ℝ). The remaining real-arithmetic identity closes by field_simp/ring — the multiplier n+1/2 = (2n+1)/2 is exactly the factor the coefficient needs to advance.",
+    "mathContext": "$\\Gamma\\!\\left((n{+}1)+\\tfrac12\\right)=\\left(n+\\tfrac12\\right)\\Gamma\\!\\left(n+\\tfrac12\\right),\\quad \\tfrac{(2n+2)(2n+1)}{4(n+1)}=\\tfrac{2n+1}{2}=n+\\tfrac12$"
+  },
+  {
+    "id": "ann-gamma-refl-oq01-oq03-rational-multiple",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 72,
+      "endLine": 87
+    },
+    "type": "observation",
+    "title": "Rational Multiple of Γ(1/2), and Positivity",
+    "content": "gamma_nat_add_half_eq_mul_gamma_half rewrites the closed form as Γ(n+1/2) = (2n)!/(4ⁿ n!)·Γ(1/2), making explicit that the only transcendental ingredient is the single value Γ(1/2) and all n-dependence is the rational coefficient. gamma_nat_add_half_pos reads off 0 < Γ(n+1/2) for every n from the closed form, since (2n)!, 4ⁿ, n! and √π are all positive (mul_pos/div_pos with the factorial positivity lemmas).",
+    "mathContext": "$\\Gamma\\!\\left(n+\\tfrac12\\right)=\\dfrac{(2n)!}{4^n n!}\\,\\Gamma\\!\\left(\\tfrac12\\right)>0$"
+  },
+  {
+    "id": "ann-gamma-refl-oq01-oq03-worked-values",
+    "proofId": "gamma-reflection-formula-oq-01-oq-03",
+    "range": {
+      "startLine": 89,
+      "endLine": 107
+    },
+    "type": "observation",
+    "title": "Worked Values and Consistency Check",
+    "content": "gamma_three_half (Γ(3/2)=√π/2) and gamma_five_half (Γ(5/2)=3√π/4) are derived independently from the functional equation Γ(x+1)=x·Γ(x) and Γ(1/2)=√π, providing concrete checks at n=1,2. gamma_nat_add_half_one then instantiates the GENERAL closed form at n=1 and confirms it reproduces Γ(3/2)=√π/2 — closing the loop between the abstract formula and the hand-computed value.",
+    "mathContext": "$\\Gamma(3/2)=\\tfrac12\\sqrt\\pi,\\qquad \\Gamma(5/2)=\\tfrac34\\sqrt\\pi$"
+  }
+]

--- a/src/data/proofs/gamma-reflection-formula-oq-01-oq-03/meta.json
+++ b/src/data/proofs/gamma-reflection-formula-oq-01-oq-03/meta.json
@@ -1,0 +1,139 @@
+{
+  "id": "gamma-reflection-formula-oq-01-oq-03",
+  "slug": "gamma-reflection-formula-oq-01-oq-03",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
+    "namespace": "GammaReflectionFormulaOQ01OQ03",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/GammaReflectionFormulaOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "title": "The Half-Integer Gamma Values: Γ(n+1/2) = (2n)!·√π / (4ⁿ·n!)",
+  "description": "Addresses OQ-03 from gamma-reflection-formula-oq-01: extend the single transcendental value Γ(1/2)=√π to the full closed form of the Gamma function at every half-integer. Starting from Γ(1/2)=√π and the functional equation Γ(s+1)=s·Γ(s), induction forces Γ(n+1/2) = (2n)!/(4ⁿ·n!)·√π — so while Γ(1/2)=√π is irrational, the entire n-dependence is the rational coefficient (2n)!/(4ⁿ n!). The entry proves the closed form, the rational-multiple-of-Γ(1/2) reformulation, positivity of all half-integer values, and two worked values Γ(3/2)=√π/2 and Γ(5/2)=3√π/4 derived independently as cross-checks, plus a consistency check that the general formula reproduces Γ(3/2). Mathlib has Γ(1/2)=√π, the functional equation, and the Legendre duplication formula but not this explicit half-integer closed form. 6 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_gamma_function#Half-integer_arguments",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GammaReflectionFormulaOQ01OQ03.lean",
+    "parentProofId": "gamma-reflection-formula-oq-01",
+    "tags": [
+      "analysis",
+      "special-functions",
+      "gamma-function",
+      "half-integer",
+      "factorial",
+      "induction",
+      "research"
+    ],
+    "badge": "original",
+    "axiomCount": 0,
+    "newAxiomCount": 0,
+    "sorries": 0,
+    "lineCount": 107,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "originalContributions": [
+      "gamma_nat_add_half: the half-integer closed form Γ(n+1/2) = (2n)!/(4ⁿ·n!)·√π for every n, proved by induction — base case Γ(1/2)=√π, inductive step multiplies by (n+1/2) via the functional equation and promotes the factorial coefficient through the recurrences (2n+2)!=(2n+2)(2n+1)(2n)!, (n+1)!=(n+1)·n!, 4ⁿ⁺¹=4·4ⁿ (closes by field_simp/ring). Absent from Mathlib.",
+      "gamma_nat_add_half_eq_mul_gamma_half: the rational-multiple form Γ(n+1/2) = (2n)!/(4ⁿ n!)·Γ(1/2), making explicit that the only transcendental ingredient is the single value Γ(1/2) and all n-dependence is the rational coefficient",
+      "gamma_nat_add_half_pos: positivity 0 < Γ(n+1/2) for every n, immediate from the closed form since (2n)!, 4ⁿ, n!, √π are all positive",
+      "gamma_three_half: Γ(3/2) = √π/2, the n=1 value, derived independently from Γ(1/2+1)=(1/2)·Γ(1/2) as a cross-check of the general formula",
+      "gamma_five_half: Γ(5/2) = 3√π/4, the n=2 value, derived from Γ(3/2+1)=(3/2)·Γ(3/2)",
+      "gamma_nat_add_half_one: consistency check that instantiating the general closed form at n=1 reproduces Γ(3/2)=√π/2, matching the independently derived gamma_three_half"
+    ],
+    "prerequisites": [
+      "Euler Gamma function Real.Gamma",
+      "Mathlib's Real.Gamma_one_half_eq (Γ(1/2)=√π)",
+      "The functional equation Real.Gamma_add_one (Γ(s+1)=s·Γ(s))",
+      "Factorial recurrence Nat.factorial_succ and positivity Nat.factorial_pos"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.Gamma_one_half_eq",
+        "description": "Γ(1/2) = √π — the single transcendental base value the whole half-integer ladder is built on.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Real.Gamma_add_one",
+        "description": "Γ(s+1) = s·Γ(s) for s ≠ 0 — the functional equation driving the induction step (multiplying by n+1/2).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_succ",
+        "description": "(n+1)! = (n+1)·n! — expanded twice to turn (2n+2)! into (2n+2)(2n+1)(2n)! in the inductive step.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.factorial_pos / Nat.factorial_ne_zero",
+        "description": "n! > 0 and n! ≠ 0, cast to ℝ for the field_simp denominators and the positivity corollary.",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      }
+    ],
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The closed form is proved by ordinary induction on n; the inductive step is a real-arithmetic identity discharged by field_simp/ring after rewriting the factorial and power recurrences, and the worked values use only the functional equation and Γ(1/2)=√π. No native_decide, no axiomatized hypotheses. The deep ingredient Γ(1/2)=√π is delegated to Mathlib; the half-integer closed form, its rational-multiple reformulation, the positivity corollary, and the worked-value cross-checks are the original content, none of which is in Mathlib (which records only Γ(1/2)=√π, the functional equation, and the Legendre duplication formula)."
+  },
+  "openQuestions": [
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-03-oq-01",
+      "question": "Rewrite the coefficient (2n)!/(4ⁿ n!) as the odd double factorial over a power of two, (2n−1)!!/2ⁿ, and formalize the double-factorial identity Γ(n+1/2) = (2n−1)!!·√π/2ⁿ.",
+      "significance": "low"
+    },
+    {
+      "id": "gamma-reflection-formula-oq-01-oq-03-oq-02",
+      "question": "Combine the half-integer closed form with reflection to recover the negative half-integer values Γ(−n+1/2) = (−4)ⁿ n!·√π/(2n)!.",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gamma-reflection-formula-oq-01",
+      "relationship": "extends",
+      "description": "The parent re-exports Euler reflection and derives Γ(1/2)²=π and the special-value products; this entry instead climbs the half-integer ladder above 1/2, expressing every Γ(n+1/2) as a rational multiple of √π via the functional equation."
+    },
+    {
+      "targetId": "area-of-circle-oq-07-oq-03",
+      "relationship": "related",
+      "description": "That entry establishes Γ(1/2)=√π via the Gaussian integral — the single base value this entry propagates up the half-integer ladder."
+    }
+  ],
+  "references": [
+    {
+      "title": "Mathlib4: Analysis.SpecialFunctions.Gamma.Basic",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of Real.Gamma_one_half_eq, Real.Gamma_add_one, and Real.Gamma_nat_eq_factorial."
+    },
+    {
+      "title": "Particular values of the gamma function",
+      "author": "Wikipedia",
+      "year": "2024",
+      "venue": "encyclopedia",
+      "description": "Half-integer arguments Γ(n+1/2) = (2n)!√π/(4ⁿ n!) and the equivalent double-factorial form."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Euler's Gamma function interpolates the factorial, $\\Gamma(n+1)=n!$, and its values at the half-integers form the next most classical family after the integers. The single value $\\Gamma(1/2)=\\sqrt\\pi$ — equivalently the Gaussian integral $\\int_{-\\infty}^{\\infty}e^{-x^2}\\,dx=\\sqrt\\pi$ — is transcendental, yet every other half-integer value is a *rational* multiple of it. Iterating the functional equation $\\Gamma(s+1)=s\\,\\Gamma(s)$ upward from $1/2$ gives $\\Gamma(3/2)=\\tfrac12\\sqrt\\pi$, $\\Gamma(5/2)=\\tfrac34\\sqrt\\pi$, and in general the closed form $\\Gamma(n+\\tfrac12)=\\dfrac{(2n)!}{4^n\\,n!}\\sqrt\\pi$, equivalently $\\dfrac{(2n-1)!!}{2^n}\\sqrt\\pi$. This formula is ubiquitous: it gives the volume of the $n$-ball, the normalization of the Gaussian and chi/chi-squared distributions, and the moments $\\int x^{2n}e^{-x^2}dx$. Mathlib records the base value $\\Gamma(1/2)=\\sqrt\\pi$, the functional equation, and even the Legendre duplication formula $\\Gamma(s)\\Gamma(s+\\tfrac12)=2^{1-2s}\\sqrt\\pi\\,\\Gamma(2s)$, but it does not record the explicit half-integer closed form — this entry supplies it.",
+    "problemStatement": "**Open Question (gamma-reflection-formula-OQ-01-OQ-03)**: Establish the closed form of the Gamma function at the half-integers, $\\Gamma(n+\\tfrac12)=\\dfrac{(2n)!}{4^n\\,n!}\\sqrt\\pi$, extending the sibling result $B(1/2,1/2)=\\pi$ (equivalently $\\Gamma(1/2)^2=\\pi$) from the single value $1/2$ to the whole ladder $n+\\tfrac12$.\n\n**What this entry establishes**: the closed form $\\Gamma(n+\\tfrac12)=(2n)!/(4^n n!)\\cdot\\sqrt\\pi$ for every $n$, its reformulation as the rational multiple $(2n)!/(4^n n!)$ of $\\Gamma(1/2)$, the positivity $0<\\Gamma(n+\\tfrac12)$, and the worked values $\\Gamma(3/2)=\\sqrt\\pi/2$, $\\Gamma(5/2)=3\\sqrt\\pi/4$ as independent cross-checks.",
+    "proofStrategy": "**gamma_nat_add_half** (the closed form): induction on $n$. The base case $\\Gamma(1/2)=\\sqrt\\pi$ is Mathlib's `Real.Gamma_one_half_eq`, and the coefficient $0!/(4^0\\,0!)=1$. For the step, $\\Gamma((n+1)+\\tfrac12)=\\Gamma((n+\\tfrac12)+1)=(n+\\tfrac12)\\,\\Gamma(n+\\tfrac12)$ by the functional equation `Real.Gamma_add_one` (with $n+\\tfrac12\\ne0$). Substituting the inductive hypothesis leaves a pure real-arithmetic identity: rewriting the factorial recurrences $(2n+2)!=(2n+2)(2n+1)(2n)!$ and $(n+1)!=(n+1)\\,n!$ (two applications of `Nat.factorial_succ`, cast to $\\mathbb R$) and $4^{n+1}=4\\cdot4^n$, the goal closes by `field_simp`/`ring` — the multiplier $n+\\tfrac12=(2n+1)/2$ is exactly the factor the factorial coefficient needs to advance.\n\n**gamma_nat_add_half_eq_mul_gamma_half** rewrites $\\sqrt\\pi$ back to $\\Gamma(1/2)$. **gamma_nat_add_half_pos** applies `mul_pos`/`div_pos` to the closed form using positivity of factorials and $\\sqrt\\pi$. The worked values $\\Gamma(3/2),\\Gamma(5/2)$ are derived directly from `Real.Gamma_add_one` and `Real.Gamma_one_half_eq`, giving an independent check that the general formula's $n=1,2$ instances are correct.",
+    "keyInsights": [
+      "**One transcendental, infinitely many rationals**: $\\Gamma(1/2)=\\sqrt\\pi$ is the only irrational ingredient; every $\\Gamma(n+\\tfrac12)$ is the rational number $(2n)!/(4^n n!)$ times that single value. The functional equation propagates one hard value into a whole arithmetic family.",
+      "**The factorial coefficient advances by exactly $n+\\tfrac12$**: $(2n+2)!/(4^{n+1}(n+1)!) = \\tfrac{(2n+2)(2n+1)}{4(n+1)}\\cdot(2n)!/(4^n n!) = \\tfrac{2n+1}{2}\\cdot(2n)!/(4^n n!) = (n+\\tfrac12)\\cdot(2n)!/(4^n n!)$ — the multiplier the functional equation supplies is precisely the coefficient's growth factor, which is why the induction closes by `ring`.",
+      "**This is the Gaussian-integral / $n$-ball constant**: $(2n)!/(4^n n!)\\sqrt\\pi$ is the value behind $\\int x^{2n}e^{-x^2}dx$ and the volume of the unit $n$-ball; the elementary closed form makes those normalizations machine-checkable.",
+      "**Mathlib has the neighbours but not this**: $\\Gamma(1/2)=\\sqrt\\pi$, $\\Gamma(s+1)=s\\Gamma(s)$, $\\Gamma(n+1)=n!$, and even Legendre duplication are all in Mathlib; the explicit half-integer closed form sits one short induction away and is what this entry contributes.",
+      "**The badge is `original`**: the deep input $\\Gamma(1/2)=\\sqrt\\pi$ is Mathlib's, but the closed form, its rational-multiple reading, the positivity corollary, and the worked-value cross-checks are derived here and are absent from Mathlib."
+    ]
+  },
+  "conclusion": {
+    "summary": "A complete, fully verified (0 sorries, 0 axioms) derivation of the half-integer Gamma closed form Γ(n+1/2) = (2n)!/(4ⁿ n!)·√π by induction from Γ(1/2)=√π and the functional equation, with the rational-multiple reformulation, the positivity corollary, and the worked values Γ(3/2)=√π/2 and Γ(5/2)=3√π/4 as independent cross-checks.",
+    "implications": "Provides the explicit half-integer Gamma values absent from Mathlib — the constant behind Gaussian moments, the chi/chi-squared normalizations, and the volume of the n-ball — in a reusable, machine-checked form, and exhibits the structural fact that all half-integer Gamma values are rational multiples of the single transcendental value √π."
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Addresses **OQ-03** of `gamma-reflection-formula-oq-01`. Extends the single transcendental value Γ(1/2)=√π to the full half-integer ladder of the Gamma function, via the functional equation Γ(s+1)=s·Γ(s):

$$\Gamma\!\left(n+\tfrac12\right) = \frac{(2n)!}{4^n\,n!}\sqrt\pi \quad\text{for every } n.$$

So while Γ(1/2)=√π is irrational, the entire n-dependence is the **rational** coefficient (2n)!/(4ⁿ n!) — equivalently (2n−1)!!/2ⁿ. This is the constant behind Gaussian moments, the chi/chi-squared normalizations, and the volume of the n-ball.

## Results (`Proofs/GammaReflectionFormulaOQ01OQ03.lean`, 6 theorems, 0 axioms, 0 sorries)

- **`gamma_nat_add_half`** — the closed form, by induction on n. Base: Γ(1/2)=√π. Step: Γ((n+1)+1/2) = (n+1/2)·Γ(n+1/2) via `Real.Gamma_add_one`, then the factorial/power recurrences ((2n+2)! = (2n+2)(2n+1)(2n)!, etc.) close the real-arithmetic identity by `field_simp`/`ring` — the multiplier n+1/2 = (2n+1)/2 is exactly the coefficient's growth factor.
- **`gamma_nat_add_half_eq_mul_gamma_half`** — rational-multiple-of-Γ(1/2) reformulation.
- **`gamma_nat_add_half_pos`** — positivity 0 < Γ(n+1/2).
- **`gamma_three_half`**, **`gamma_five_half`** — Γ(3/2)=√π/2, Γ(5/2)=3√π/4, derived independently from the functional equation as cross-checks.
- **`gamma_nat_add_half_one`** — consistency: the general formula at n=1 reproduces Γ(3/2).

## Relationship to Mathlib

Mathlib provides Γ(1/2)=√π (`Real.Gamma_one_half_eq`), the functional equation (`Real.Gamma_add_one`), Γ(n+1)=n! (`Real.Gamma_nat_eq_factorial`), and even the Legendre duplication formula — but **not** this explicit half-integer closed form. Badge: `original`.

## Verification

Typechecked against **Mathlib v4.26.0** (`lake env lean`): exit 0, no errors, no sorries. (Docker build host was wedged this session; verified via the host toolchain against the prebuilt Mathlib oleans.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)