### PR TITLE
research(de-moivre-oq-01-oq-03-oq-01): integer-index Chebyshev–De Moivre identity over all n ∈ ℤ

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -839,6 +839,7 @@ import Proofs.DeGuaTheorem
 import Proofs.DeMoivre
 import Proofs.DeMoivreOQ01
 import Proofs.DeMoivreOQ01OQ03
+import Proofs.DeMoivreOQ01OQ03OQ01
 import Proofs.DeMoivreOQ02
 import Proofs.DeMoivreOQ02OQ02
 import Proofs.DeMoivreOQ02OQ02OQ01

--- a/proofs/Proofs/DeMoivreOQ01OQ03OQ01.lean
+++ b/proofs/Proofs/DeMoivreOQ01OQ03OQ01.lean
@@ -1,0 +1,175 @@
+/-
+# Chebyshev–De Moivre for all integer indices `n ∈ ℤ`
+  (de-moivre-oq-01-oq-03-oq-01)
+
+## Open Question (OQ-01 of de-moivre-oq-01-oq-03)
+The parent established the algebraic De Moivre–Chebyshev identity
+  `(C R n).eval (z + w) = zⁿ + wⁿ`     whenever `z · w = 1`,
+but only for **natural** indices `n : ℕ`.  The Chebyshev polynomial of the third
+kind `C` is, however, indexed by all of `ℤ` in Mathlib, and the symmetry
+`C R (-n) = C R n` (`Polynomial.Chebyshev.C_neg`) strongly suggests the identity
+should close up under negation.  Does it?
+
+## Answer: YES — and the extension is *forced* by the `z·w = 1` constraint.
+
+On the "unit circle" `z · w = 1` we have `w = z⁻¹` and `z = w⁻¹`, so the two-sided
+power map `m ↦ zᵐ` (now with `m : ℤ`) sends `-m` to `(zᵐ)⁻¹ = wᵐ`.  Combined with
+`C R (-n) = C R n`, the negative-index identity reduces to the positive one with the
+roles of `z` and `w` swapped:
+
+      `(C R (-m)).eval (z + w) = (C R m).eval (z + w) = zᵐ + wᵐ = w⁻ᵐ + z⁻ᵐ`.
+
+We package this two ways:
+
+* **Units form** over an arbitrary `CommRing R`: for `z : Rˣ` and `n : ℤ`,
+      `(C R n).eval (z + z⁻¹) = ↑(zⁿ) + ↑(z⁻ⁿ)`,
+  where `zⁿ : Rˣ` is the genuine ℤ-power in the unit group.  This is the sharpest
+  statement: it needs no division and no field structure.
+* **Field form**: for any field `F`, `z ≠ 0`, and `n : ℤ`,
+      `(C F n).eval (z + z⁻¹) = zⁿ + (z⁻¹)ⁿ`     (`zⁿ` = `zpow`).
+  Specializes for free to finite fields `ZMod p`, the p-adics `ℚ_[p]`, ℝ and ℂ.
+
+This is the integer-index closure of the parent's de Moivre identity: the power map
+`z ↦ zⁿ` is conjugate to evaluation of a fixed integer-indexed polynomial for *every*
+`n ∈ ℤ`, positive, zero, or negative.
+
+## Status
+- All theorems proved (0 sorries, 0 axioms, no `native_decide`).
+- Reuses the parent's natural-index engine `chebyshevC_eval_field`; the only new
+  ingredient is `Chebyshev.C_neg` plus `zpow` bookkeeping.
+- Builds on `Mathlib.RingTheory.Polynomial.Chebyshev` and the parent file.
+-/
+
+import Mathlib.RingTheory.Polynomial.Chebyshev
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Tactic
+import Proofs.DeMoivreOQ01OQ03
+
+namespace DeMoivreChebyshevIntegerIndex
+
+open Polynomial.Chebyshev
+open DeMoivreChebyshevFiniteField
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART I: THE FIELD IDENTITY FOR ALL `n ∈ ℤ`
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+variable {F : Type*} [Field F]
+
+/-- **Integer-index De Moivre–Chebyshev identity (field form).**
+    In any field `F`, for `z ≠ 0` and *every* integer `n : ℤ`,
+      `(C F n).eval (z + z⁻¹) = zⁿ + (z⁻¹)ⁿ`,
+    where `zⁿ` denotes the `ℤ`-power (`zpow`).  This extends the parent's
+    natural-index identity `chebyshevC_eval_field` to all of `ℤ`, using the
+    Chebyshev symmetry `C F (-n) = C F n`. -/
+theorem chebyshevC_eval_field_int (z : F) (hz : z ≠ 0) (n : ℤ) :
+    (C F n).eval (z + z⁻¹) = z ^ n + (z⁻¹) ^ n := by
+  -- Split into `n ≥ 0` and `n < 0`.
+  rcases le_or_gt 0 n with hn | hn
+  · -- Nonnegative: lift `n` to a natural number and invoke the parent identity.
+    lift n to ℕ using hn with k
+    rw [zpow_natCast, zpow_natCast]
+    exact_mod_cast chebyshevC_eval_field z hz k
+  · -- Negative: write `n = -m` with `m = -n > 0`, use `C_neg` to flip the index.
+    obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = -(m : ℤ) :=
+      ⟨(-n).toNat, by rw [Int.toNat_of_nonneg (by omega)]; ring⟩
+    -- On the unit circle the negative powers fold back: `z^(-m) = (z⁻¹)^m`, etc.
+    have h1 : z ^ (-(m : ℤ)) = (z⁻¹) ^ m := by
+      rw [zpow_neg, zpow_natCast, ← inv_pow]
+    have h2 : (z⁻¹) ^ (-(m : ℤ)) = z ^ m := by
+      rw [zpow_neg, zpow_natCast, ← inv_pow, inv_inv]
+    rw [C_neg, chebyshevC_eval_field z hz m, h1, h2]
+    ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART II: THE UNITS IDENTITY OVER AN ARBITRARY COMMUTATIVE RING
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+variable {R : Type*} [CommRing R]
+
+/-- **Integer-index De Moivre–Chebyshev identity (units form).**
+    For any commutative ring `R`, any unit `z : Rˣ`, and *every* integer `n : ℤ`,
+      `(C R n).eval (↑z + ↑z⁻¹) = ↑(zⁿ) + ↑(z⁻ⁿ)`,
+    where `zⁿ : Rˣ` is the genuine `ℤ`-power in the unit group.  This is the
+    division-free sharpening of the field form: it holds over *any* `CommRing`. -/
+theorem chebyshevC_eval_units_int (z : Rˣ) (n : ℤ) :
+    (C R n).eval ((z : R) + (↑z⁻¹ : R)) = (↑(z ^ n) : R) + (↑(z ^ (-n)) : R) := by
+  -- Coercion of the genuine ℤ-power in `Rˣ` to `R`, matched against the parent's
+  -- ℕ-indexed identity in both sign branches.
+  rcases le_or_gt 0 n with hn | hn
+  · -- Nonnegative index.
+    lift n to ℕ using hn with k
+    have h1 : (↑(z ^ (k : ℤ)) : R) = (z : R) ^ k := by
+      rw [zpow_natCast, Units.val_pow_eq_pow_val]
+    have h2 : (↑(z ^ (-(k : ℤ))) : R) = (↑z⁻¹ : R) ^ k := by
+      rw [zpow_neg, zpow_natCast, ← inv_pow, Units.val_pow_eq_pow_val]
+    rw [h1, h2]
+    exact chebyshevC_eval_add (z : R) (↑z⁻¹ : R) z.mul_inv k
+  · -- Negative index: `n = -m`, flip the polynomial index via `C_neg`.
+    obtain ⟨m, rfl⟩ : ∃ m : ℕ, n = -(m : ℤ) :=
+      ⟨(-n).toNat, by rw [Int.toNat_of_nonneg (by omega)]; ring⟩
+    have h1 : (↑(z ^ (-(m : ℤ))) : R) = (↑z⁻¹ : R) ^ m := by
+      rw [zpow_neg, zpow_natCast, ← inv_pow, Units.val_pow_eq_pow_val]
+    have h2 : (↑(z ^ (-(-(m : ℤ)))) : R) = (z : R) ^ m := by
+      rw [neg_neg, zpow_natCast, Units.val_pow_eq_pow_val]
+    rw [C_neg, h1, h2, chebyshevC_eval_add (z : R) (↑z⁻¹ : R) z.mul_inv m]
+    ring
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART III: SPECIALIZATIONS — finite fields and p-adics, now over ℤ
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Finite-field form (all `n ∈ ℤ`).** For a prime `p`, nonzero `z : ZMod p`,
+    and any integer `n`, `(C (ZMod p) n).eval (z + z⁻¹) = zⁿ + (z⁻¹)ⁿ`. -/
+theorem chebyshevC_eval_zmod_int (p : ℕ) [Fact p.Prime] (z : ZMod p) (hz : z ≠ 0)
+    (n : ℤ) :
+    (C (ZMod p) n).eval (z + z⁻¹) = z ^ n + (z⁻¹) ^ n :=
+  chebyshevC_eval_field_int z hz n
+
+/-- **p-adic form (all `n ∈ ℤ`).** Over `ℚ_[p]`, for `z ≠ 0` and any integer `n`,
+    `(C ℚ_[p] n).eval (z + z⁻¹) = zⁿ + (z⁻¹)ⁿ`. -/
+theorem chebyshevC_eval_padic_int (p : ℕ) [Fact p.Prime] (z : ℚ_[p]) (hz : z ≠ 0)
+    (n : ℤ) :
+    (C ℚ_[p] n).eval (z + z⁻¹) = z ^ n + (z⁻¹) ^ n :=
+  chebyshevC_eval_field_int z hz n
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IV: CONSISTENCY CHECKS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Negative index over `ℝ`: `C (-1) = X`, so evaluating at `z + z⁻¹` returns
+    `z + z⁻¹`, matching `z⁻¹ + z` (the `n = -1` instance). -/
+example (z : ℝ) (hz : z ≠ 0) :
+    (C ℝ (-1)).eval (z + z⁻¹) = z ^ (-1 : ℤ) + (z⁻¹) ^ (-1 : ℤ) :=
+  chebyshevC_eval_field_int z hz (-1)
+
+/-- In `ZMod 7`: `3⁻¹ = 5`, `3 + 3⁻¹ = 1`, and the `n = -2` instance reads
+    `C (-2) (1) = 1² − 2 = −1 = 6`, matching `3⁻² + (3⁻¹)⁻² = 5² + 3² = 4 + 2 = 6`.
+    (The `[Fact (Nat.Prime 7)]` binder supplies the field structure on `ZMod 7`
+    needed to interpret the `ℤ`-power `z ^ (-2 : ℤ)`.) -/
+-- A concrete (file-local) primality witness, so the field structure on `ZMod 7`
+-- used to interpret the `ℤ`-power `z ^ (-2 : ℤ)` is a closed instance (not a free
+-- variable), keeping the `decide` of `3 ≠ 0` kernel-reducible.
+private instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+
+example :
+    (C (ZMod 7) (-2)).eval ((3 : ZMod 7) + (3 : ZMod 7)⁻¹)
+      = (3 : ZMod 7) ^ (-2 : ℤ) + ((3 : ZMod 7)⁻¹) ^ (-2 : ℤ) := by
+  have h3 : (3 : ZMod 7) ≠ 0 := by decide
+  exact chebyshevC_eval_zmod_int 7 3 h3 (-2)
+
+/-
+═══════════════════════════════════════════════════════════════════════════════
+VERIFICATION
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+#check @chebyshevC_eval_field_int
+#check @chebyshevC_eval_units_int
+#check @chebyshevC_eval_zmod_int
+#check @chebyshevC_eval_padic_int
+
+end DeMoivreChebyshevIntegerIndex

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01/meta.json
@@ -1,0 +1,184 @@
+{
+  "id": "de-moivre-oq-01-oq-03-oq-01",
+  "title": "Chebyshev–De Moivre for all integer indices n ∈ ℤ",
+  "slug": "de-moivre-oq-01-oq-03-oq-01",
+  "description": "Closes the parent's first open question: the algebraic De Moivre–Chebyshev identity (C R n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ, proved by the parent only for natural n, extends to ALL integers n ∈ ℤ. The extension is forced by the constraint z·w = 1: on the unit circle w = z⁻¹, so the two-sided power map sends −m to (zᵐ)⁻¹ = wᵐ; combined with the Chebyshev symmetry C R (−n) = C R n (Polynomial.Chebyshev.C_neg) the negative-index case reduces to the positive one with z and w swapped. Packaged two ways: a division-free units form over an arbitrary commutative ring (zⁿ : Rˣ the genuine ℤ-power) and a field form (zⁿ = zpow) specializing for free to ZMod p, ℚ_p, ℝ and ℂ. 0 axioms, 0 sorries, no native_decide.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_polynomials",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DeMoivreOQ01OQ03OQ01.lean",
+    "tags": [
+      "chebyshev-polynomials",
+      "de-moivre",
+      "integer-indices",
+      "finite-fields",
+      "p-adic",
+      "polynomials",
+      "ring-theory",
+      "units",
+      "extension",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.Chebyshev.C_neg",
+        "description": "C R (−n) = C R n: the negation symmetry of the Chebyshev polynomial of the third kind, the single new ingredient that flips a negative index to a positive one",
+        "module": "Mathlib.RingTheory.Polynomial.Chebyshev"
+      },
+      {
+        "theorem": "zpow_neg",
+        "description": "z^(−n) = (z^n)⁻¹: the ℤ-power negation law, used to match z^(−m) with w^m on the unit circle",
+        "module": "Mathlib.Algebra.GroupWithZero.Units.Lemmas"
+      },
+      {
+        "theorem": "Units.val_pow_eq_pow_val",
+        "description": "↑(zⁿ) = (↑z)ⁿ for z : Rˣ: bridges the genuine ℤ-power in the unit group to the ambient ring element in the units form",
+        "module": "Mathlib.Algebra.Group.Units"
+      },
+      {
+        "theorem": "zpow_natCast",
+        "description": "z^(↑k) = z^k: identifies the ℤ-power at a nonnegative index with the ordinary ℕ-power, reducing the n ≥ 0 case to the parent identity",
+        "module": "Mathlib.Algebra.GroupPower.Basic"
+      }
+    ],
+    "originalContributions": [
+      "chebyshevC_eval_field_int: the integer-index De Moivre–Chebyshev identity (C F n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ for EVERY n ∈ ℤ over any field, z ≠ 0 — closing the parent's first open question (parent proved only n ∈ ℕ)",
+      "chebyshevC_eval_units_int: the sharpest, division-free form over an ARBITRARY commutative ring — (C R n).eval(↑z + ↑z⁻¹) = ↑(zⁿ) + ↑(z⁻ⁿ) with zⁿ : Rˣ the genuine ℤ-power in the unit group, needing no field structure",
+      "chebyshevC_eval_zmod_int and chebyshevC_eval_padic_int: the integer-index finite-field and p-adic specializations, free corollaries of the field form",
+      "Negative-index worked checks over ℝ (n = −1) and ZMod 7 (n = −2), confirming the unit-circle reduction z^(−m) = w^m"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "lineCount": 175,
+    "assumptions": "0 axioms, 0 sorries, no native_decide. All theorems depend only on the standard foundational axioms propext / Classical.choice / Quot.sound (verified via #print axioms). The negative-index examples use kernel `decide` for the nonzero hypotheses (axiom-free), not `native_decide`.",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "**From ℕ to ℤ: closing the orbit**\n\nThe parent established the algebraic heart of De Moivre's theorem: on the locus $z\\cdot w = 1$, the power map $z \\mapsto z^n$ is conjugate to evaluation of one fixed polynomial, the Chebyshev polynomial of the third kind $C_n$, giving $(C_R\\,n)(z+w) = z^n + w^n$. But that identity was proved only for natural exponents $n$.\n\nMathlib indexes the Chebyshev polynomials over all of $\\mathbb{Z}$, and they satisfy the reflection symmetry $C_{-n} = C_n$. The power map $z \\mapsto z^n$ is likewise defined for every $n \\in \\mathbb{Z}$ once $z$ is a unit. It is natural — and, as it turns out, forced — that the De Moivre identity should close up under negation, so that the single statement $(C_R\\,n)(z + z^{-1}) = z^n + (z^{-1})^n$ holds for every integer $n$, positive, zero or negative.",
+    "problemStatement": "**Open question (OQ-01 of de-moivre-oq-01-oq-03):** Does the algebraic De Moivre–Chebyshev identity extend cleanly to negative / integer indices $n \\in \\mathbb{Z}$, using the symmetry $C_{-n} = C_n$ together with $w = z^{-1}$, giving $(C_R\\,n)(z + z^{-1}) = z^n + (z^{-1})^n$ for all $n \\in \\mathbb{Z}$?\n\n**Answer: YES**, and the extension is forced by the unit-circle constraint $z\\cdot w = 1$. On that locus $w = z^{-1}$ and $z = w^{-1}$, so the two-sided power map sends $-m$ to $(z^m)^{-1} = w^m$. Combined with $C_{-n} = C_n$, the negative-index identity is exactly the positive-index one with the roles of $z$ and $w$ exchanged.",
+    "text": "The parent's algebraic De Moivre–Chebyshev identity (C R n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ, proved only for natural n, extends to every integer n ∈ ℤ. The negative-index case reduces to the positive one via C R (−n) = C R n and the unit-circle relation z^(−m) = (z⁻¹)^m. Packaged as a division-free units form over any commutative ring and a field form covering ZMod p, ℚ_p, ℝ, ℂ.",
+    "proofStrategy": "**Strategy**\n\n1. **Split on the sign of the index.** For $n \\geq 0$, lift $n$ to a natural number; the genuine $\\mathbb{Z}$-power collapses to the $\\mathbb{N}$-power (`zpow_natCast`) and the goal is exactly the parent's natural-index identity `chebyshevC_eval_field` / `chebyshevC_eval_add`.\n\n2. **Negative index via reflection.** For $n < 0$, write $n = -m$ with $m \\in \\mathbb{N}$. The Chebyshev symmetry `C_neg` rewrites $C(-m)$ as $C(m)$, reducing the left side to the parent identity $z^m + (z^{-1})^m$. On the right, `zpow_neg` turns $z^{-m}$ into $(z^m)^{-1} = (z^{-1})^m$ and $(z^{-1})^{-m}$ into $z^m$, so both sides agree after a single `ring` (field form) or commutativity (units form).\n\n3. **Units form first, field form as the clean headline.** The units version is stated over an arbitrary commutative ring with $z : R^\\times$ and the genuine $\\mathbb{Z}$-power in the unit group, so it needs no division; `Units.val_pow_eq_pow_val` transports it to ambient ring elements. The field version is the same argument with $w = z^{-1}$ and `mul_inv_cancel₀`.\n\n4. **Specializations.** `chebyshevC_eval_zmod_int` and `chebyshevC_eval_padic_int` are one-line instantiations at $\\mathbb{F}_p$ and $\\mathbb{Q}_p$. Negative-index numeric checks over $\\mathbb{R}$ and $\\mathbb{F}_7$ confirm the reduction.",
+    "keyInsights": [
+      "**Negation closes for free.** No new analytic input is needed: the symmetry C_{-n} = C_n plus the unit-circle relation z⁻¹ = w turns every negative-index instance into a positive-index one with z and w swapped.",
+      "**The constraint z·w = 1 IS the symmetry.** It is exactly the unit-circle hypothesis that makes z^(−m) = wᵐ, so the same hypothesis that powered the parent's cross-term collapse also powers the negation closure.",
+      "**Units form is sharper than the field form.** Over an arbitrary commutative ring, the genuine ℤ-power lives in the unit group Rˣ, so the integer-index identity needs no division and no field — the field statement is just its image under Units.val.",
+      "**Sign split, not custom induction.** Because the parent already did the order-2 induction over ℕ, extending to ℤ is a clean two-case split (n ≥ 0 and n < 0); the negative case is pure rewriting (C_neg, zpow_neg, inv_inv).",
+      "**Mathlib's ℤ-indexing pays off.** Chebyshev C is indexed by ℤ in Mathlib with C_neg already proved, so the polynomial side of the integer extension is a single rewrite rather than a redefinition."
+    ],
+    "prerequisites": [
+      "The parent's natural-index identity (C R n).eval(z + w) = zⁿ + wⁿ for z·w = 1",
+      "Chebyshev polynomials of the third kind over ℤ and the symmetry C_{-n} = C_n",
+      "ℤ-powers (zpow) in a group / field and the laws zpow_neg, zpow_natCast",
+      "Units Rˣ of a commutative ring and the genuine ℤ-power in the unit group"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "summary": "Imports Mathlib's Chebyshev polynomial library, the p-adic numbers, and the parent file providing the natural-index engine.",
+      "startLine": 49,
+      "endLine": 53,
+      "mathContext": "Brings in `Polynomial.Chebyshev.C` with its symmetry `C_neg`, `ℚ_[p]`, and the parent's `chebyshevC_eval_add` / `chebyshevC_eval_field`."
+    },
+    {
+      "id": "field-int",
+      "title": "The Field Identity for all n ∈ ℤ",
+      "summary": "Proves `chebyshevC_eval_field_int`: in any field, for z ≠ 0 and every integer n, (C F n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ, by splitting on the sign of n and using C_neg / zpow_neg for the negative case.",
+      "startLine": 63,
+      "endLine": 90,
+      "mathContext": "The integer-index identity $(C_F\\,n)(z + z^{-1}) = z^n + (z^{-1})^n$. The $n < 0$ case reduces to the parent via $C_{-m} = C_m$ and $z^{-m} = (z^{-1})^m$."
+    },
+    {
+      "id": "units-int",
+      "title": "The Units Identity over a Commutative Ring",
+      "summary": "Proves `chebyshevC_eval_units_int`: over an arbitrary commutative ring, for z : Rˣ and every integer n, (C R n).eval(↑z + ↑z⁻¹) = ↑(zⁿ) + ↑(z⁻ⁿ), the division-free sharpening.",
+      "startLine": 96,
+      "endLine": 124,
+      "mathContext": "The sharpest form, over any `CommRing`: the genuine $\\mathbb{Z}$-power $z^n : R^\\times$ in the unit group, transported to $R$ by `Units.val_pow_eq_pow_val`."
+    },
+    {
+      "id": "specializations",
+      "title": "Finite Fields and p-adics over ℤ",
+      "summary": "One-line specializations `chebyshevC_eval_zmod_int` (finite fields) and `chebyshevC_eval_padic_int` (p-adics), plus negative-index numeric checks over ℝ and ZMod 7.",
+      "startLine": 130,
+      "endLine": 170,
+      "mathContext": "The integer-index field identity at $\\mathbb{F}_p$ and $\\mathbb{Q}_p$; e.g. in $\\mathbb{F}_7$ the $n = -2$ instance reads $C_{-2}(1) = -1 = 6 = 3^{-2} + (3^{-1})^{-2}$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The parent's first open question is answered affirmatively: the algebraic De Moivre–Chebyshev identity extends from natural exponents to ALL integers n ∈ ℤ. The negative-index case is forced by the unit-circle constraint and the Chebyshev symmetry C_{-n} = C_n, reducing to the positive case with z and w swapped. Stated in a division-free units form over any commutative ring and a field form covering ZMod p, ℚ_p, ℝ and ℂ. 4 theorems, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "**Significance**\n\n1. **The orbit is complete.** The power map z ↦ zⁿ is conjugate to evaluation of the fixed integer-indexed polynomial C for every n ∈ ℤ — the two-sided closure of the parent's one-sided result.\n\n2. **Division-free generality.** The units form holds over any commutative ring with the ℤ-power taken in the unit group, so the integer extension needs neither a field nor division; the field statement is its Units.val image.\n\n3. **Cryptographic two-sidedness.** In the finite-field Lucas/Chebyshev setting, negative exponents correspond to inverse 'exponentiation', and the identity now covers them uniformly — relevant to decryption / inversion in Chebyshev-map schemes.",
+    "openQuestions": [
+      "Does the integer-index identity assemble into the full semigroup/group law C_{mn} = C_m ∘ C_n over ℤ, exhibiting n ↦ C_n as a monoid homomorphism (ℤ, ·) → (End, ∘) restricted to the unit-circle locus?"
+    ]
+  },
+  "relatedProblems": [
+    {
+      "id": "de-moivre-oq-01-oq-03",
+      "relationship": "Parent. This closes its first open question by extending the natural-index identity (C R n).eval(z+w) = zⁿ + wⁿ to all integer indices n ∈ ℤ."
+    },
+    {
+      "id": "de-moivre-oq-01",
+      "relationship": "Grandparent. The Chebyshev–De Moivre connection whose finite-field/p-adic form the parent established."
+    },
+    {
+      "id": "de-moivre",
+      "relationship": "Root De Moivre formalization; the integer-index closure mirrors (e^{iθ})ⁿ = e^{inθ} holding for all n ∈ ℤ."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.Polynomial.Chebyshev",
+      "Mathlib.NumberTheory.Padics.PadicNumbers",
+      "Mathlib.Tactic",
+      "Proofs.DeMoivreOQ01OQ03"
+    ],
+    "opens": [
+      "Polynomial.Chebyshev",
+      "DeMoivreChebyshevFiniteField"
+    ],
+    "namespace": "DeMoivreChebyshevIntegerIndex",
+    "lineCount": 175,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ01OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "A. de Moivre",
+      "title": "Miscellanea Analytica de Seriebus et Quadraturis",
+      "year": "1730",
+      "venue": "London",
+      "note": "(cos θ + i sin θ)^n = cos(nθ) + i sin(nθ), valid for all integer n"
+    },
+    {
+      "authors": "P. L. Chebyshev",
+      "title": "Théorie des mécanismes connus sous le nom de parallélogrammes",
+      "year": "1853",
+      "venue": "Mémoires des Savants étrangers présentés à l'Académie de Saint-Pétersbourg",
+      "note": "Introduced the polynomials T_n, U_n; the third-kind C_n satisfies C_{-n} = C_n"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "de-moivre-oq-01-oq-03",
+      "relationship": "extends",
+      "description": "Closes the parent's first open question by extending (C R n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ from natural n to all integer n ∈ ℤ"
+    },
+    {
+      "targetId": "de-moivre",
+      "relationship": "foundational",
+      "description": "De Moivre's theorem (e^{iθ})ⁿ = e^{inθ} holds for all n ∈ ℤ; this is the algebraic integer-index analogue on the unit-circle locus z·w = 1"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Closes the **first open question** of the verified parent `de-moivre-oq-01-oq-03`: extend the algebraic De Moivre–Chebyshev identity from natural exponents to **all integers** `n ∈ ℤ`.

The parent proved, over any commutative ring with `z·w = 1`,
`(C R n).eval(z + w) = zⁿ + wⁿ` — but only for `n : ℕ`. Here it closes up under negation:

- **`chebyshevC_eval_field_int`** — for any field `F`, `z ≠ 0`, and every `n : ℤ`: `(C F n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ` (`zⁿ` = `zpow`).
- **`chebyshevC_eval_units_int`** — the division-free sharpening over an **arbitrary commutative ring**, with `zⁿ : Rˣ` the genuine ℤ-power in the unit group (no field, no division).
- **`chebyshevC_eval_zmod_int`**, **`chebyshevC_eval_padic_int`** — one-line specializations to finite fields and the p-adics.

## Why it works

The unit-circle constraint `z·w = 1` *is* the symmetry: it makes `z^(−m) = (z⁻¹)^m`. Combined with the Chebyshev reflection `C R (−n) = C R n` (`Polynomial.Chebyshev.C_neg`), the negative-index case is exactly the positive case with `z` and `w` exchanged. The proof is a clean sign split on `n`, reusing the parent's ℕ-engine `chebyshevC_eval_add` — no new induction.

## Verification

- 4 theorems, 0 sorries, **0 axioms**, no `native_decide`.
- `#print axioms` on all four: `[propext, Classical.choice, Quot.sound]` only.
- Builds against `Mathlib 4.26.0` and the parent file `Proofs.DeMoivreOQ01OQ03`; registered in `Proofs.lean`.
- Negative-index worked checks over ℝ (`n = −1`) and `ZMod 7` (`n = −2`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)