### PR TITLE
research(chebyshev-sum-inequality-oq-01-oq-02-oq-01): strict reverse (antivarying) Chebyshev sum inequality [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3467,6 +3467,7 @@ import Proofs.RationalCanonicalFormExists
 import Proofs.RearrangementChebyshevEqOQ01
 import Proofs.RearrangementChebyshevEqOQ01OQ02
 import Proofs.RearrangementChebyshevStrictOQ01OQ02
+import Proofs.RearrangementChebyshevStrictOQ01OQ02OQ01
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge
 import Proofs.RepunitDivisibilityOQ01

--- a/proofs/Proofs/RearrangementChebyshevStrictOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/RearrangementChebyshevStrictOQ01OQ02OQ01.lean
@@ -1,0 +1,209 @@
+/-
+# Strict *reverse* Chebyshev sum inequality (the antivarying / mixed-monotone case)
+
+The parent file `RearrangementChebyshevStrictOQ01OQ02` proves the **strict** Chebyshev
+sum inequality for **monovarying** (e.g. both monotone) sequences:
+`(∑ f)(∑ g) < #s · ∑ f·g` unless one sequence is constant.
+
+This file answers the parent's open question by treating the **opposite** ordering
+regime — `f` and `g` **antivary** (the textbook case "`f` increasing, `g` decreasing").
+There the inequality reverses:
+
+    #s · ∑ f·g  ≤  (∑ f)(∑ g),
+
+with equality iff one sequence is constant; otherwise the inequality is **strict**:
+
+    #s · ∑ f·g  <  (∑ f)(∑ g)      i.e.   (∑ f)(∑ g) > #s · ∑ f·g.
+
+## Mechanism — the same order-free covariance identity
+
+Everything rides on the grandparent's `covariance_identity` (no order hypotheses):
+
+    ∑ᵢ∑ⱼ (fᵢ − fⱼ)(gᵢ − gⱼ) = 2·(#s·∑ fᵢgᵢ − (∑ fᵢ)(∑ gᵢ)).
+
+For **antivarying** `f, g` each summand `(fᵢ − fⱼ)(gᵢ − gⱼ)` is **non-positive**
+(`term_nonpos`), so the double sum is `≤ 0`, which is exactly the reverse bound. A single
+pair with both coordinates varying makes one summand strictly negative, forcing strictness.
+Note the equality *characterisation* — `∀ i j, fᵢ = fⱼ ∨ gᵢ = gⱼ` — is **identical** to the
+monovarying case, because a product of two reals is `0` regardless of the signs of the
+factors; only the *inequality direction* flips.
+
+## Main results
+
+* `term_nonpos` — each covariance summand is `≤ 0` when `f, g` antivary on `s`.
+* `chebyshev_sum_reverse` — the reverse bound `#s·∑ f·g ≤ (∑ f)(∑ g)` for `AntivaryOn f g s`.
+* `chebyshev_sum_reverse_eq_iff` — equality holds iff every pair `i, j ∈ s` satisfies
+  `f i = f j ∨ g i = g j` (same characterisation as the monovarying case).
+* `chebyshev_sum_reverse_eq_iff_const` — textbook form: for `f` monotone and `g` antitone on
+  a linearly ordered index with `s` nonempty, equality holds iff `f` or `g` is constant on `s`.
+* `chebyshev_sum_reverse_strict_of_pair` — the general antivariance form: one pair `a, b ∈ s`
+  with `f a ≠ f b` *and* `g a ≠ g b` already forces `(∑ f)(∑ g) > #s·∑ f·g`.
+* `chebyshev_sum_reverse_strict` — textbook strict form: `f` monotone, `g` antitone, `s`
+  nonempty, neither constant ⟹ `(∑ f)(∑ g) > #s·∑ f·g`.
+* `chebyshev_sum_reverse_strict_strictMonoAnti` — cleanest specialisation: `f` strictly
+  monotone, `g` strictly antitone, `1 < #s` ⟹ strict.
+
+Each strict result is `lt_of_le_of_ne` applied to the reverse `≤` and the negation of the
+equality characterisation; no new axioms are introduced.
+
+References:
+- Parent: `chebyshev-sum-inequality-oq-01-oq-02` (`RearrangementChebyshevStrictOQ01OQ02`,
+  the monovarying strict form).
+- Grandparent: `RearrangementChebyshevEqOQ01` (`covariance_identity`, equality machinery).
+- Mathlib `Mathlib/Order/Monotone/Monovary.lean` (`AntivaryOn`, `Monotone.antivary`).
+-/
+import Mathlib
+import Proofs.RearrangementChebyshevStrictOQ01OQ02
+
+open Finset
+
+namespace RearrangementChebyshevReverse
+
+open RearrangementChebyshevEq
+
+variable {ι : Type*} {s : Finset ι} {f g : ι → ℝ}
+
+/-- **Non-positivity of the covariance summand under antivariance.** If `f` and `g` antivary
+on `s`, then for `i, j ∈ s` the term `(f i − f j)(g i − g j) ≤ 0`: when `g` increases across a
+pair, `f` weakly decreases (and vice versa), so the two differences have opposite signs. This
+is the antivarying mirror of the grandparent's `term_nonneg`. -/
+theorem term_nonpos (hfg : AntivaryOn f g s) {i j : ι} (hi : i ∈ s) (hj : j ∈ s) :
+    (f i - f j) * (g i - g j) ≤ 0 := by
+  rcases lt_trichotomy (g i) (g j) with h | h | h
+  · -- `g i < g j` ⟹ `f j ≤ f i`: first factor `≥ 0`, second `< 0`.
+    have hf : f j ≤ f i := hfg hi hj h
+    nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ f i - f j) (by linarith : (0:ℝ) ≤ g j - g i)]
+  · have : g i - g j = 0 := by linarith
+    rw [this, mul_zero]
+  · -- `g j < g i` ⟹ `f i ≤ f j`: first factor `≤ 0`, second `> 0`.
+    have hf : f i ≤ f j := hfg hj hi h
+    nlinarith [mul_nonneg (by linarith : (0:ℝ) ≤ f j - f i) (by linarith : (0:ℝ) ≤ g i - g j)]
+
+/-- **Reverse Chebyshev sum inequality.** When `f` and `g` antivary on `s`,
+`#s · ∑ f·g ≤ (∑ f)(∑ g)` — the inequality of the monovarying case run backwards. One line
+from `covariance_identity`, whose double sum is now `≤ 0`. -/
+theorem chebyshev_sum_reverse (hfg : AntivaryOn f g s) :
+    (s.card : ℝ) * (∑ i ∈ s, f i * g i) ≤ (∑ i ∈ s, f i) * (∑ i ∈ s, g i) := by
+  have hsum : ∑ i ∈ s, ∑ j ∈ s, (f i - f j) * (g i - g j) ≤ 0 :=
+    Finset.sum_nonpos fun i hi => Finset.sum_nonpos fun j hj => term_nonpos hfg hi hj
+  rw [covariance_identity] at hsum
+  linarith
+
+/-- **Exact equality characterisation of the reverse inequality.** For `f, g` antivarying on
+`s`, equality `#s · ∑ f·g = (∑ f)(∑ g)` holds iff every pair `i, j ∈ s` has `f i = f j` or
+`g i = g j`. This is the *same* condition as in the monovarying case: a product vanishes
+exactly when a factor does, independent of sign. -/
+theorem chebyshev_sum_reverse_eq_iff (hfg : AntivaryOn f g s) :
+    (s.card : ℝ) * (∑ i ∈ s, f i * g i) = (∑ i ∈ s, f i) * (∑ i ∈ s, g i)
+      ↔ ∀ i ∈ s, ∀ j ∈ s, f i = f j ∨ g i = g j := by
+  have hid := covariance_identity (s := s) (f := f) (g := g)
+  rw [← sub_eq_zero]
+  constructor
+  · intro h
+    have hzero : ∑ i ∈ s, ∑ j ∈ s, (f i - f j) * (g i - g j) = 0 := by rw [hid]; linarith
+    intro i hi j hj
+    have h1 := (Finset.sum_eq_zero_iff_of_nonpos
+      (fun i hi => Finset.sum_nonpos fun j hj => term_nonpos hfg hi hj)).mp hzero i hi
+    have hterm : (f i - f j) * (g i - g j) = 0 :=
+      (Finset.sum_eq_zero_iff_of_nonpos fun j hj => term_nonpos hfg hi hj).mp h1 j hj
+    rcases mul_eq_zero.mp hterm with hf | hg
+    · exact Or.inl (sub_eq_zero.mp hf)
+    · exact Or.inr (sub_eq_zero.mp hg)
+  · intro h
+    have hzero : ∑ i ∈ s, ∑ j ∈ s, (f i - f j) * (g i - g j) = 0 := by
+      refine Finset.sum_eq_zero fun i hi => Finset.sum_eq_zero fun j hj => ?_
+      rcases h i hi j hj with hf | hg
+      · rw [hf]; ring
+      · rw [hg]; ring
+    rw [hzero] at hid
+    linarith
+
+/-- **Equality case for `f` monotone, `g` antitone (textbook form).** On a linearly ordered
+index with `s` nonempty, equality in the reverse inequality holds iff `f` is constant on `s`
+*or* `g` is constant on `s`. The extreme-pair argument: a monotone non-constant `f` already
+differs between `min' s` and `max' s`; an antitone non-constant `g` likewise. -/
+theorem chebyshev_sum_reverse_eq_iff_const [LinearOrder ι] (hf : Monotone f) (hg : Antitone g)
+    (hs : s.Nonempty) :
+    (s.card : ℝ) * (∑ i ∈ s, f i * g i) = (∑ i ∈ s, f i) * (∑ i ∈ s, g i)
+      ↔ (∀ i ∈ s, ∀ j ∈ s, f i = f j) ∨ (∀ i ∈ s, ∀ j ∈ s, g i = g j) := by
+  have hanti : AntivaryOn f g s := (hf.antivary hg).antivaryOn s
+  rw [chebyshev_sum_reverse_eq_iff hanti]
+  constructor
+  · intro h
+    by_contra hcon
+    push_neg at hcon
+    obtain ⟨⟨a, ha, b, hb, hfab⟩, ⟨c, hc, d, hd, hgcd⟩⟩ := hcon
+    set m := s.min' hs with hm_def
+    set M := s.max' hs with hM_def
+    have hm : m ∈ s := s.min'_mem hs
+    have hM : M ∈ s := s.max'_mem hs
+    -- `f` non-constant + monotone forces `f m ≠ f M`.
+    have hfmM : f m ≠ f M := fun he => hfab (by
+      have l1 : f m ≤ f a := hf (s.min'_le a ha)
+      have l2 : f a ≤ f M := hf (s.le_max' a ha)
+      have l3 : f m ≤ f b := hf (s.min'_le b hb)
+      have l4 : f b ≤ f M := hf (s.le_max' b hb)
+      linarith)
+    -- `g` non-constant + antitone forces `g m ≠ g M` (inequalities point the other way).
+    have hgmM : g m ≠ g M := fun he => hgcd (by
+      have l1 : g c ≤ g m := hg (s.min'_le c hc)
+      have l2 : g M ≤ g c := hg (s.le_max' c hc)
+      have l3 : g d ≤ g m := hg (s.min'_le d hd)
+      have l4 : g M ≤ g d := hg (s.le_max' d hd)
+      linarith)
+    rcases h m hm M hM with hfe | hge
+    · exact hfmM hfe
+    · exact hgmM hge
+  · rintro (hfc | hgc) i hi j hj
+    · exact Or.inl (hfc i hi j hj)
+    · exact Or.inr (hgc i hi j hj)
+
+/-- **Strict reverse Chebyshev inequality from a single doubly-varying pair.** If `f, g`
+antivary on `s` and one pair `a, b ∈ s` has `f a ≠ f b` *and* `g a ≠ g b`, then
+`(∑ f)(∑ g) > #s · ∑ f·g`. The pair alone breaks the equality characterisation. -/
+theorem chebyshev_sum_reverse_strict_of_pair (hfg : AntivaryOn f g s)
+    {a b : ι} (ha : a ∈ s) (hb : b ∈ s) (hfab : f a ≠ f b) (hgab : g a ≠ g b) :
+    (s.card : ℝ) * (∑ i ∈ s, f i * g i) < (∑ i ∈ s, f i) * (∑ i ∈ s, g i) := by
+  refine lt_of_le_of_ne (chebyshev_sum_reverse hfg) ?_
+  intro heq
+  have hpair := (chebyshev_sum_reverse_eq_iff hfg).mp heq a ha b hb
+  rcases hpair with hf | hg
+  · exact hfab hf
+  · exact hgab hg
+
+/-- **Strict reverse Chebyshev inequality for `f` monotone, `g` antitone (textbook form).** If
+`f` is monotone, `g` is antitone on a linearly ordered index, `s` is nonempty, and neither is
+constant on `s`, then `(∑ f)(∑ g) > #s · ∑ f·g` strictly. The single statement "the reverse
+Chebyshev inequality is strict unless one sequence is constant". -/
+theorem chebyshev_sum_reverse_strict [LinearOrder ι] (hf : Monotone f) (hg : Antitone g)
+    (hs : s.Nonempty)
+    (hf_nc : ∃ i ∈ s, ∃ j ∈ s, f i ≠ f j)
+    (hg_nc : ∃ i ∈ s, ∃ j ∈ s, g i ≠ g j) :
+    (s.card : ℝ) * (∑ i ∈ s, f i * g i) < (∑ i ∈ s, f i) * (∑ i ∈ s, g i) := by
+  refine lt_of_le_of_ne (chebyshev_sum_reverse ((hf.antivary hg).antivaryOn s)) ?_
+  intro heq
+  rcases (chebyshev_sum_reverse_eq_iff_const hf hg hs).mp heq with hfc | hgc
+  · obtain ⟨i, hi, j, hj, hij⟩ := hf_nc; exact hij (hfc i hi j hj)
+  · obtain ⟨i, hi, j, hj, hij⟩ := hg_nc; exact hij (hgc i hi j hj)
+
+/-- **Strict reverse Chebyshev inequality for strictly monotone `f`, strictly antitone `g`.**
+With at least two indices the inequality is always strict: strict monotonicity/antitonicity
+rule out constancy as soon as two distinct indices are present. -/
+theorem chebyshev_sum_reverse_strict_strictMonoAnti [LinearOrder ι] (hf : StrictMono f)
+    (hg : StrictAnti g) (hs : 1 < s.card) :
+    (s.card : ℝ) * (∑ i ∈ s, f i * g i) < (∑ i ∈ s, f i) * (∑ i ∈ s, g i) := by
+  obtain ⟨a, ha, b, hb, hab⟩ := Finset.one_lt_card.mp hs
+  have hfab : f a ≠ f b := fun h => hab (hf.injective h)
+  have hgab : g a ≠ g b := fun h => hab (hg.injective h)
+  exact chebyshev_sum_reverse_strict hf.monotone hg.antitone ⟨a, ha⟩
+    ⟨a, ha, b, hb, hfab⟩ ⟨a, ha, b, hb, hgab⟩
+
+#check @term_nonpos
+#check @chebyshev_sum_reverse
+#check @chebyshev_sum_reverse_eq_iff
+#check @chebyshev_sum_reverse_eq_iff_const
+#check @chebyshev_sum_reverse_strict_of_pair
+#check @chebyshev_sum_reverse_strict
+#check @chebyshev_sum_reverse_strict_strictMonoAnti
+
+end RearrangementChebyshevReverse

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "cheb-rev-ann-header",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 64 },
+    "type": "context",
+    "title": "The Reverse Regime: Same Identity, Opposite Sign",
+    "content": "The parent file proves the strict Chebyshev inequality for monovarying sequences. This file treats the opposite ordering regime — f and g antivary (f increasing, g decreasing) — where the inequality reverses to #s·∑ f·g ≤ (∑ f)(∑ g). The whole development reuses the grandparent's order-free covariance identity ∑ᵢ∑ⱼ (fᵢ−fⱼ)(gᵢ−gⱼ) = 2·(#s·∑ fᵢgᵢ − (∑ fᵢ)(∑ gᵢ)). Importing the parent strict file (Proofs.RearrangementChebyshevStrictOQ01OQ02) transitively brings the grandparent's covariance_identity, which `open RearrangementChebyshevEq` makes directly available.",
+    "mathContext": "Monovarying: $\\big(\\sum f\\big)\\big(\\sum g\\big) \\le \\#s\\sum f g$. Antivarying (this file): $\\#s\\sum f g \\le \\big(\\sum f\\big)\\big(\\sum g\\big)$.",
+    "significance": "context",
+    "relatedConcepts": ["Chebyshev's sum inequality", "AntivaryOn", "discrete covariance identity", "anticomonotone covariance"],
+    "prerequisites": ["finite sums over a Finset", "order-correlation predicates"]
+  },
+  {
+    "id": "cheb-rev-ann-bound",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 66, "endLine": 90 },
+    "type": "technique",
+    "title": "Sign Flip: Each Summand Is Non-Positive",
+    "content": "term_nonpos is the mirror of the grandparent's term_nonneg: under AntivaryOn f g s, when g increases across a pair f weakly decreases, so the two differences (f i − f j) and (g i − g j) have opposite signs and their product is ≤ 0. A trichotomy on g i vs g j feeds AntivaryOn to bound f the right way, and nlinarith closes each branch. chebyshev_sum_reverse then applies Finset.sum_nonpos to make the double sum ≤ 0, and rewriting with covariance_identity turns that into the reverse bound by a single linarith. This is exactly the monovarying proof with sum_nonneg replaced by sum_nonpos.",
+    "mathContext": "$(f_i - f_j)(g_i - g_j) \\le 0$ for antivarying $f,g$, hence $\\sum_i\\sum_j (f_i-f_j)(g_i-g_j) \\le 0$, i.e. $\\#s\\sum f g \\le \\big(\\sum f\\big)\\big(\\sum g\\big)$.",
+    "significance": "key",
+    "relatedConcepts": ["AntivaryOn", "covariance_identity", "Finset.sum_nonpos", "sign case split"],
+    "prerequisites": ["the order-free covariance identity", "trichotomy and nlinarith"]
+  },
+  {
+    "id": "cheb-rev-ann-equality",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 92, "endLine": 159 },
+    "type": "insight",
+    "title": "Identical Equality Condition, Antitone Extreme Pair",
+    "content": "chebyshev_sum_reverse_eq_iff shows equality holds iff ∀ i j ∈ s, f i = f j ∨ g i = g j — the SAME condition as the monovarying case, because a real product is zero exactly when a factor is, regardless of sign. The forward direction uses Finset.sum_eq_zero_iff_of_nonpos (the nonpos analogue of the grandparent's nonneg lemma) to pin each summand to 0, then mul_eq_zero. chebyshev_sum_reverse_eq_iff_const upgrades this to the textbook 'constant' form for f monotone, g antitone: the extreme-pair argument still produces f m ≠ f M at (min' s, max' s) for non-constant f, and for an antitone non-constant g the inequalities g M ≤ g c ≤ g m point the other way but still force g m ≠ g M.",
+    "mathContext": "Equality $\\iff f$ or $g$ constant on $s$; the rigidity lemma transfers from the monotone case because the $(\\min', \\max')$ argument is sign-agnostic.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_eq_zero_iff_of_nonpos", "mul_eq_zero", "extreme-pair argument", "Antitone", "rigidity"],
+    "prerequisites": ["the monovarying equality characterisation", "min'/max' of a nonempty Finset"]
+  },
+  {
+    "id": "cheb-rev-ann-strict",
+    "proofId": "chebyshev-sum-inequality-oq-01-oq-02-oq-01",
+    "range": { "startLine": 161, "endLine": 209 },
+    "type": "insight",
+    "title": "Three Strict Forms via lt_of_le_of_ne",
+    "content": "The strict statements mirror the parent exactly, each lt_of_le_of_ne of the reverse bound and the negated equality case. chebyshev_sum_reverse_strict_of_pair: one pair a, b ∈ s with f a ≠ f b AND g a ≠ g b forces (∑ f)(∑ g) > #s·∑ f·g under only AntivaryOn — strictness is local. chebyshev_sum_reverse_strict: the bridge (hf.antivary hg).antivaryOn s plus the negated constant-equality lemma gives the textbook 'f monotone, g antitone, neither constant ⇒ strict'. chebyshev_sum_reverse_strict_strictMonoAnti: Finset.one_lt_card extracts a ≠ b, and StrictMono.injective / StrictAnti.injective turn that into f a ≠ f b and g a ≠ g b automatically.",
+    "mathContext": "$f$ str. monotone, $g$ str. antitone, $1 < \\#s \\Rightarrow \\big(\\sum f\\big)\\big(\\sum g\\big) > \\#s\\sum f g$.",
+    "significance": "supporting",
+    "relatedConcepts": ["lt_of_le_of_ne", "Monotone.antivary", "StrictAnti.injective", "Finset.one_lt_card", "local-to-global strictness"],
+    "prerequisites": ["the reverse bound and its equality case", "the lt_of_le_of_ne pattern"]
+  }
+]

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/RearrangementChebyshevStrictOQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const chebyshevSumInequalityOQ01OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const chebyshevSumInequalityOQ01OQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const chebyshevSumInequalityOQ01OQ02OQ01Data: ProofData = {
+  proof: chebyshevSumInequalityOQ01OQ02OQ01Proof,
+  annotations: chebyshevSumInequalityOQ01OQ02OQ01Annotations,
+}

--- a/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-sum-inequality-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,166 @@
+{
+  "id": "chebyshev-sum-inequality-oq-01-oq-02-oq-01",
+  "title": "Strict Reverse Chebyshev Sum Inequality (Antivarying / Mixed-Monotone Case)",
+  "slug": "chebyshev-sum-inequality-oq-01-oq-02-oq-01",
+  "description": "The parent entry chebyshev-sum-inequality-oq-01-oq-02 packages the strict Chebyshev sum inequality for monovarying (e.g. both monotone) sequences. This entry answers the parent's own open question by treating the opposite ordering regime: when f and g antivary (the textbook 'f increasing, g decreasing' case) the inequality reverses to #s·∑ f·g ≤ (∑ f)(∑ g), strict unless one sequence is constant. Everything rides on the same order-free covariance identity from the grandparent: for antivarying f, g each summand (fᵢ−fⱼ)(gᵢ−gⱼ) is now non-positive, so the double sum is ≤ 0 — exactly the reversed bound — and a single doubly-varying pair makes one summand strictly negative. The equality characterisation ∀ i j, fᵢ=fⱼ ∨ gᵢ=gⱼ is identical to the monovarying case (a product vanishes regardless of factor signs); only the inequality direction flips. We give the same three layers as the parent plus the antitone equality-constant lemma.",
+  "meta": {
+    "author": "Classical (Chebyshev); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality",
+    "date": "1882",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "inequalities",
+      "order",
+      "chebyshev-sum-inequality",
+      "monotone",
+      "antitone",
+      "rearrangement",
+      "strict-inequality"
+    ],
+    "proofRepoPath": "Proofs/RearrangementChebyshevStrictOQ01OQ02OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 209,
+    "mathlibDependencies": [
+      {
+        "theorem": "Monotone.antivary",
+        "description": "A monotone f and an antitone g antivary — the bridge that feeds AntivaryOn into the reverse bound and the equality lemmas in the mixed-monotone textbook form",
+        "module": "Mathlib.Order.Monotone.Monovary"
+      },
+      {
+        "theorem": "Finset.sum_nonpos",
+        "description": "A finite sum of non-positive terms is non-positive — turns the per-term non-positivity (term_nonpos) into the ≤ 0 double sum that the covariance identity converts to the reverse bound",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_eq_zero_iff_of_nonpos",
+        "description": "A sum of non-positive terms vanishes iff every term vanishes — extracts the per-pair equality condition from the equality case in the antivarying regime",
+        "module": "Mathlib.Algebra.Order.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "lt_of_le_of_ne",
+        "description": "Upgrades the reverse ≤ bound to a strict < once equality is excluded by the negated equality characterisation",
+        "module": "Mathlib.Order.Basic"
+      },
+      {
+        "theorem": "StrictAnti.injective",
+        "description": "A strictly antitone g is injective — converts distinct indices a ≠ b into g a ≠ g b for the strictly-monotone/strictly-antitone specialisation",
+        "module": "Mathlib.Order.Monotone.Basic"
+      }
+    ],
+    "originalContributions": [
+      "term_nonpos: under AntivaryOn f g s each covariance summand (f i − f j)(g i − g j) ≤ 0, the antivarying mirror of the grandparent's term_nonneg",
+      "chebyshev_sum_reverse: the reverse Chebyshev bound #s·∑ f·g ≤ (∑ f)(∑ g) for antivarying f, g, one line from the order-free covariance identity whose double sum is now ≤ 0",
+      "chebyshev_sum_reverse_eq_iff: equality holds iff every pair i, j ∈ s has f i = f j ∨ g i = g j — the same characterisation as the monovarying case, since a product vanishes independent of factor signs",
+      "chebyshev_sum_reverse_eq_iff_const: the textbook form — for f monotone, g antitone on a linearly ordered index with s nonempty, equality holds iff f or g is constant on s, via the extreme-pair (min', max') argument adapted to an antitone g",
+      "chebyshev_sum_reverse_strict_of_pair: a single pair a, b ∈ s with f a ≠ f b and g a ≠ g b already forces (∑ f)(∑ g) > #s·∑ f·g under only AntivaryOn",
+      "chebyshev_sum_reverse_strict: the textbook strict form — f monotone, g antitone, s nonempty, neither constant ⇒ strict",
+      "chebyshev_sum_reverse_strict_strictMonoAnti: the clean specialisation — f strictly monotone, g strictly antitone, 1 < #s ⇒ strict, with injectivity supplying the varying pair"
+    ],
+    "dateAdded": "2026-06-23",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Chebyshev's sum inequality has two faces. For sequences sorted the same way (comonotone / monovarying) the mean of the products dominates the product of the means; for sequences sorted oppositely (one increasing, one decreasing — antivarying) the inequality reverses. The reverse form is the discrete shadow of the fact that two anticomonotone random variables have non-positive covariance, and it is the inequality that actually appears in rearrangement arguments where one factor is deliberately reversed. Mathlib records the non-strict reverse bound through the AntivaryOn predicate but, as in the monovarying case, says nothing about when it is tight. The parent entry settled the monovarying strict statement; this entry completes the symmetric picture for the antivarying regime, which is exactly the open question the parent posed.",
+    "problemStatement": "Let $f, g$ be real sequences on a finite nonempty index set $s$ with $f$ monotone and $g$ antitone (more generally, antivarying on $s$). Then the reverse Chebyshev bound holds:\n\n$$\\#s \\sum_{i\\in s} f_i g_i \\;\\le\\; \\Big(\\sum_{i\\in s} f_i\\Big)\\Big(\\sum_{i\\in s} g_i\\Big),$$\n\nwith equality iff $f$ or $g$ is constant on $s$. If neither is constant the inequality is strict, equivalently $\\big(\\sum f\\big)\\big(\\sum g\\big) > \\#s\\sum f g$. More generally a single pair $a, b \\in s$ with $f_a \\ne f_b$ and $g_a \\ne g_b$ already forces strictness.",
+    "proofStrategy": "The engine is the grandparent's order-free covariance identity ∑ᵢ∑ⱼ (fᵢ−fⱼ)(gᵢ−gⱼ) = 2·(#s·∑ fᵢgᵢ − (∑ fᵢ)(∑ gᵢ)).\n\n1. term_nonpos: for antivarying f, g a case split on the sign of g i − g j shows each summand (f i − f j)(g i − g j) ≤ 0 (the two differences have opposite signs).\n\n2. chebyshev_sum_reverse: Finset.sum_nonpos makes the double sum ≤ 0; the covariance identity then gives #s·∑ f·g ≤ (∑ f)(∑ g) by linarith.\n\n3. chebyshev_sum_reverse_eq_iff: equality forces the double sum to be 0; Finset.sum_eq_zero_iff_of_nonpos pins every summand to 0, and mul_eq_zero reads off f i = f j ∨ g i = g j. The converse is termwise.\n\n4. chebyshev_sum_reverse_eq_iff_const: the extreme-pair argument — a monotone non-constant f differs between min' s and max' s, and an antitone non-constant g likewise (the inequalities point the other way but the conclusion g m ≠ g M is the same).\n\n5. The strict statements are lt_of_le_of_ne of the reverse bound and the negated equality characterisation, with StrictAnti.injective supplying the varying pair in the strictly-monotone/strictly-antitone case.",
+    "keyInsights": [
+      "The covariance identity carries no order hypothesis, so it serves both regimes unchanged — only the sign of each summand flips (non-negative for monovarying, non-positive for antivarying), which is exactly why the inequality reverses.",
+      "The equality characterisation ∀ i j, f i = f j ∨ g i = g j is literally identical to the monovarying case, because a real product is zero precisely when a factor is zero, independent of the product's sign.",
+      "Strictness remains local: one index pair varying in both coordinates makes a single summand strictly negative and forces the global strict inequality.",
+      "An antitone g still produces an extreme varying pair at (min' s, max' s) once it is non-constant; the min'/max' argument is sign-agnostic, so the rigidity lemma transfers verbatim from the monotone case."
+    ],
+    "prerequisites": [
+      "Finite sums over a Finset and Finset.card",
+      "Monotone / Antitone / StrictMono / StrictAnti functions and the AntivaryOn order-correlation predicate",
+      "The discrete covariance identity and the equality machinery from the grandparent entry",
+      "The lt_of_le_of_ne pattern for upgrading ≤ to < by excluding equality"
+    ]
+  },
+  "conclusion": {
+    "summary": "We packaged the reverse (antivarying) form of Chebyshev's sum inequality and its strict statement: for f monotone and g antitone (more generally antivarying) on a finite set, #s·∑ f·g ≤ (∑ f)(∑ g), with equality iff one sequence is constant, otherwise strict. The whole development reuses the grandparent's order-free covariance identity with the sign of each summand flipped. All seven results are fully machine-checked and depend only on the foundational axioms (0 sorries, 0 axioms).",
+    "implications": "Together with the parent's monovarying strict form, this gives the complete strict-and-rigidity picture for both ordering regimes of Chebyshev's sum inequality: the same covariance identity yields the forward bound for comonotone sequences and the reverse bound for anticomonotone ones, each tight exactly when a sequence is constant.",
+    "openQuestions": [
+      "State the strict reverse inequality in the continuous (integral) form for a monotone and an antitone integrable function on an interval.",
+      "Derive the rearrangement inequality's extremal endpoints by combining the forward (sorted-same) and reverse (sorted-opposite) Chebyshev bounds."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 64,
+      "summary": "Imports (Mathlib and the parent strict file, which transitively brings the grandparent equality machinery), an expository docstring relating the reverse statement to the order-free covariance identity, and namespace setup opening RearrangementChebyshevEq."
+    },
+    {
+      "id": "reverse-bound",
+      "title": "Term Non-Positivity and the Reverse Bound",
+      "startLine": 66,
+      "endLine": 90,
+      "summary": "term_nonpos — each covariance summand (f i − f j)(g i − g j) ≤ 0 under AntivaryOn, by a sign case split; chebyshev_sum_reverse — Finset.sum_nonpos plus the covariance identity give #s·∑ f·g ≤ (∑ f)(∑ g)."
+    },
+    {
+      "id": "equality-case",
+      "title": "Equality Characterisation",
+      "startLine": 92,
+      "endLine": 159,
+      "summary": "chebyshev_sum_reverse_eq_iff — equality iff every pair varies in at most one coordinate, via Finset.sum_eq_zero_iff_of_nonpos; chebyshev_sum_reverse_eq_iff_const — the monotone/antitone textbook form through the extreme-pair (min', max') argument adapted to an antitone g."
+    },
+    {
+      "id": "strict-forms",
+      "title": "Strict Reverse Inequalities",
+      "startLine": 161,
+      "endLine": 209,
+      "summary": "chebyshev_sum_reverse_strict_of_pair (one doubly-varying pair forces strictness), chebyshev_sum_reverse_strict (monotone/antitone, neither constant), and chebyshev_sum_reverse_strict_strictMonoAnti (strictly monotone f, strictly antitone g, ≥ 2 indices), each lt_of_le_of_ne of the reverse bound and the negated equality case."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-sum-inequality-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "The monovarying strict form whose open question (the antivarying analogue) this entry answers, reusing its imports and the grandparent covariance identity"
+    },
+    {
+      "targetId": "chebyshev-sum-inequality",
+      "relationship": "extends",
+      "description": "Chebyshev's Sum Inequality"
+    }
+  ],
+  "references": [
+    {
+      "text": "Hardy, G. H., Littlewood, J. E., Pólya, G. (1952). Inequalities, 2nd ed., Cambridge University Press (Chebyshev's inequality, both ordering regimes, and equality cases).",
+      "url": "https://archive.org/details/Inequalities_201705"
+    },
+    {
+      "text": "Chebyshev's sum inequality.",
+      "url": "https://en.wikipedia.org/wiki/Chebyshev%27s_sum_inequality"
+    },
+    {
+      "text": "Mathlib4: Order.Monotone.Monovary (Monovary / Antivary) and Algebra.Order.Chebyshev.",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Order/Monotone/Monovary.html"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.RearrangementChebyshevStrictOQ01OQ02"
+    ],
+    "opens": [
+      "Finset",
+      "RearrangementChebyshevEq"
+    ],
+    "namespace": "RearrangementChebyshevReverse",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/RearrangementChebyshevStrictOQ01OQ02OQ01.lean",
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds **`chebyshev-sum-inequality-oq-01-oq-02-oq-01`** — the **strict reverse (antivarying)** Chebyshev sum inequality, answering the parent entry's own first open question (the `AntivaryOn` analogue of its monovarying strict result).

For `f` monotone and `g` antitone (more generally `AntivaryOn f g s`) the inequality **reverses**:

> `#s · ∑ f·g ≤ (∑ f)(∑ g)`,  strict unless one sequence is constant.

## Mechanism

The whole development reuses the grandparent's **order-free** `covariance_identity`. For antivarying `f, g` each summand `(fᵢ−fⱼ)(gᵢ−gⱼ)` is now **non-positive** (`term_nonpos`), so the double sum is `≤ 0` — exactly the reversed bound (`Finset.sum_nonpos`). The equality characterisation `∀ i j, fᵢ=fⱼ ∨ gᵢ=gⱼ` is **identical** to the monovarying case (a real product vanishes regardless of factor signs); only the inequality direction flips.

## Contents (7 theorems, 0 defs)

- `term_nonpos` — per-summand non-positivity under `AntivaryOn`
- `chebyshev_sum_reverse` — the reverse `≤` bound
- `chebyshev_sum_reverse_eq_iff` — exact equality characterisation
- `chebyshev_sum_reverse_eq_iff_const` — textbook form (f monotone, g antitone ⇒ equality iff one is constant), via the sign-agnostic extreme-pair (min'/max') argument
- `chebyshev_sum_reverse_strict_of_pair` — one doubly-varying pair forces strictness
- `chebyshev_sum_reverse_strict` — textbook strict form
- `chebyshev_sum_reverse_strict_strictMonoAnti` — strictly monotone f / strictly antitone g, ≥ 2 indices

## Verification

- **0 sorries, 0 axioms** — `#print axioms` shows only the standard triple (`propext`, `Classical.choice`, `Quot.sound`); no `native_decide`/`ofReduceBool`.
- Built with Lean **v4.26.0** / Mathlib. 209 lines.
- Gallery data (`meta.json`, `annotations.json`, `index.ts`) added; module registered in `proofs/Proofs.lean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
