### PR TITLE
Enrich Erdős #11 kernel-reducible squarefree test: add index.ts + annotations

### DIFF
--- a/src/data/proofs/erdos-11-wip-01-oq-02/annotations.json
+++ b/src/data/proofs/erdos-11-wip-01-oq-02/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-erdos11wipoq02-context",
+    "proofId": "erdos-11-wip-01-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "Removing the kernel-decide obstruction for squarefreeness",
+    "content": "Erdős Problem #11 (OPEN) asks whether every odd n > 1 is the sum of a squarefree number and a power of two. The parent erdos-11-wip-01 verified small odd cases but had to supply an explicit squarefree witness for each, because a kernel `decide` over Mathlib's Squarefree gets stuck: its Decidable instance routes through Nat.minSqFac, which the kernel does not reduce. This file removes that obstruction by replacing Squarefree's instance with a bounded, kernel-reducible test, proving it equivalent to Squarefree, and using it to verify a whole odd range by a single 0-axiom `decide` (no native_decide, hence no Lean.ofReduceBool).",
+    "mathContext": "Erdős #11: $\\forall$ odd $n>1$, $\\exists$ squarefree $m$ and $k$ with $n=m+2^k$ — OPEN; here verified for all odd $1<n<100$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős Problem #11", "squarefree numbers", "powers of two", "kernel reduction vs native_decide", "Nat.minSqFac"],
+    "prerequisites": ["squarefree integers", "decidability and kernel reduction", "the parent IsSquarefreePlusPow2 characterization"]
+  },
+  {
+    "id": "ann-erdos11wipoq02-check",
+    "proofId": "erdos-11-wip-01-oq-02",
+    "range": { "startLine": 41, "endLine": 76 },
+    "type": "key-step",
+    "title": "A kernel-reducible squarefree test, unconditionally equivalent to Squarefree",
+    "content": "SquarefreeCheck n := 1 ≤ n ∧ ∀ d ∈ range(n+1), 2 ≤ d → ¬ d*d ∣ n is a finite conjunction of Nat divisibility tests — which the kernel DOES reduce (Nat arithmetic is special-cased) — made decidable by Finset.decidableBAll + Nat.decidable_dvd. squarefree_iff_check proves Squarefree n ↔ SquarefreeCheck n with NO positivity hypothesis: at n = 0 both sides are False (Squarefree 0 is false via not_squarefree_zero; the 1 ≤ n conjunct fails). Forward: any d ≥ 2 with d*d ∣ n would be a unit (Nat.isUnit_iff ⟹ d = 1), contradiction. Backward: any x with x*x ∣ n is forced to 1 — x = 0 contradicts 1 ≤ n (0 ∣ n), and x ≥ 2 gives x ∣ n (dvd_mul_left + dvd_trans) hence x ≤ n (Nat.le_of_dvd), contradicting the check.",
+    "mathContext": "$\\text{Squarefree}\\,n\\iff\\big(1\\le n\\wedge\\forall d\\le n,\\ 2\\le d\\Rightarrow d^2\\nmid n\\big)$, unconditionally.",
+    "significance": "key",
+    "relatedConcepts": ["bounded decidable test", "Nat.isUnit_iff", "not_squarefree_zero", "Nat.le_of_dvd", "Finset.decidableBAll", "kernel-reducible divisibility"],
+    "prerequisites": ["the d²∣n squarefree characterization", "units in ℕ are exactly 1", "decidable bounded quantifiers"]
+  },
+  {
+    "id": "ann-erdos11wipoq02-repr",
+    "proofId": "erdos-11-wip-01-oq-02",
+    "range": { "startLine": 78, "endLine": 93 },
+    "type": "technique",
+    "title": "Lifting the test to the representation predicate",
+    "content": "ReprCheck n := ∃ k ∈ range(n+1), 2^k ≤ n ∧ SquarefreeCheck (n − 2^k) is a fully kernel-reducible form of IsSquarefreePlusPow2: search an exponent k whose complementary summand n − 2^k passes the kernel-reducible squarefree test. isSquarefreePlusPow2_iff_check obtains IsSquarefreePlusPow2 n ↔ ReprCheck n cheaply, by rewriting the parent's bounded characterization isSquarefreePlusPow2_iff and then simp_rw with squarefree_iff_check. Folding positivity into SquarefreeCheck keeps ReprCheck honest — it cannot accept a pure power of two via a spurious squarefree-0 summand.",
+    "mathContext": "$\\text{IsSquarefreePlusPow2}\\,n\\iff\\exists k\\le n,\\ 2^k\\le n\\wedge\\text{SquarefreeCheck}(n-2^k)$.",
+    "significance": "key",
+    "relatedConcepts": ["IsSquarefreePlusPow2", "bounded existential search", "simp_rw rewriting", "decidable existential over a Finset", "parent characterization reuse"],
+    "prerequisites": ["the squarefree test equivalence", "the parent isSquarefreePlusPow2_iff", "decidable ∃ over Finset.range"]
+  },
+  {
+    "id": "ann-erdos11wipoq02-range",
+    "proofId": "erdos-11-wip-01-oq-02",
+    "range": { "startLine": 95, "endLine": 117 },
+    "type": "insight",
+    "title": "The 0-axiom verified range by a single kernel decide",
+    "content": "repr_range proves ∀ n ∈ range 100, Odd n → 1 < n → ReprCheck n by one kernel `decide`; maxRecDepth is raised to 8000 only so the kernel can walk the nested Finset.range recursions — this does NOT enlarge the trusted axiom set. isSquarefreePlusPow2_range transports it through the iff to conclude every odd 1 < n < 100 is squarefree + a power of two. Critically this uses kernel `decide`, not `native_decide`, so #print axioms (run at the end of the file) shows only the standard propext / Classical.choice / Quot.sound triple — no Lean.ofReduceBool — keeping the verified range genuinely 0-axiom, replacing the parent's per-number hand-written witnesses.",
+    "mathContext": "$\\forall$ odd $n,\\ 1<n<100:\\ \\text{IsSquarefreePlusPow2}\\,n$, by one kernel decide; axioms = $\\{$propext, Classical.choice, Quot.sound$\\}$ only.",
+    "significance": "key",
+    "relatedConcepts": ["kernel decide vs native_decide", "Lean.ofReduceBool", "maxRecDepth", "#print axioms", "0-axiom verified range"],
+    "prerequisites": ["the kernel-reducible ReprCheck", "decide on bounded ranges", "the foundational axiom triple"]
+  }
+]

--- a/src/data/proofs/erdos-11-wip-01-oq-02/index.ts
+++ b/src/data/proofs/erdos-11-wip-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos11WIP01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos11Wip01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos11Wip01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos11Wip01Oq02Data: ProofData = {
+  proof: erdos11Wip01Oq02Proof,
+  annotations: erdos11Wip01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `erdos-11-wip-01-oq-02` (a kernel-reducible squarefree test and a 0-axiom verified range for Erdős #11).

The entry had a rich meta.json (overview, conclusion, sections, references, crossReferences) but was missing the two essentials:

- **`index.ts` (critical):** without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing.
- **`annotations.json`:** no inline annotations existed. Added 4 (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the kernel-`decide` obstruction (Squarefree routes through Nat.minSqFac), `SquarefreeCheck` + its unconditional equivalence to `Squarefree`, the lift to `ReprCheck`, and the 0-axiom verified odd range via a single kernel `decide`.

**Axiom integrity:** verified — status `verified`/badge `original`, 0 axioms, 0 sorries, **kernel `decide` only (no native_decide)**, so #print axioms shows just propext/Classical.choice/Quot.sound with no Lean.ofReduceBool. The annotations make this distinction explicit.

Build: `tsc -b` exit 0, `vite build` exit 0.