### PR TITLE
Enrich converse multisection (geometric-series oq-09 chain): index.ts + annotations

### DIFF
--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-geomoq09chain-overview",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 71 },
+    "type": "concept",
+    "title": "The converse multisection and its minimal hypotheses",
+    "content": "The q-section (multisection) of a series ∑ f(m) splits it by residue class mod q into the q subseries n ↦ f(q·n+a). The parent proved the FORWARD direction — Summable f gives each residue subseries summable and the regrouping identity — over a complete Hausdorff uniform abelian group, where completeness makes each infinite subseries converge. This entry answers the parent's open question: the CONVERSE (residue summability ⟹ Summable f) is true and structurally cheaper, needing only a topological commutative monoid with continuous addition — no completeness, no group. The two directions are therefore asymmetric, and the equivalence holds exactly over a complete uniform abelian group.",
+    "mathContext": "Multisection: $\\sum_m f(m)=\\sum_{a<q}\\sum_n f(qn+a)$; converse asks $\\big(\\forall a,\\ \\text{Summable}(n\\mapsto f(qn+a))\\big)\\Rightarrow\\text{Summable}\\,f$.",
+    "significance": "context",
+    "relatedConcepts": ["multisection / q-section", "residue subseries", "summability", "completeness vs continuity", "Nat.divModEquiv"],
+    "prerequisites": ["infinite sums (HasSum / tsum)", "topological monoids and groups", "residue classes mod q"]
+  },
+  {
+    "id": "ann-geomoq09chain-inj",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 75, "endLine": 84 },
+    "type": "technique",
+    "title": "Injectivity of the residue map",
+    "content": "residue_injective shows n ↦ q·n + a is injective ℕ → ℕ for q ≠ 0 (Nat.add_right_cancel strips the +a, Nat.eq_of_mul_eq_mul_left strips the q·). This single fact is shared by both directions: the converse uses it inside the single-fiber embedding, and the forward direction feeds it to Summable.comp_injective. It is the reindexing backbone of the whole multisection.",
+    "mathContext": "$n\\mapsto qn+a$ injective for $q\\neq0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["injective reindexing", "Nat.eq_of_mul_eq_mul_left", "Nat.add_right_cancel"],
+    "prerequisites": ["cancellation in ℕ"]
+  },
+  {
+    "id": "ann-geomoq09chain-fiber",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 113 },
+    "type": "key-step",
+    "title": "The single-fiber embedding",
+    "content": "The technical heart of the completeness-free converse. fiber f q a embeds a residue subseries into ℕ × Fin q, supported on the single fiber {p.2 = a} and zero elsewhere. hasSum_fiber proves this embedding has the SAME HasSum as the subseries n ↦ f(q·n+a): the injection n ↦ (n,a) has that fiber as its range and the function vanishes off it, so Function.Injective.hasSum_iff transports the sum. Crucially this is a monoid-level lemma — no group or completeness — making the residue subseries' sum visible as a sum over the two-dimensional index ℕ × Fin q.",
+    "mathContext": "$\\mathrm{HasSum}\\,(\\text{fiber}\\,f\\,q\\,a)\\,S\\iff\\mathrm{HasSum}\\,(n\\mapsto f(qn+a))\\,S$, via the injection $n\\mapsto(n,a)$ with vanishing off its range.",
+    "significance": "key",
+    "relatedConcepts": ["Function.Injective.hasSum_iff", "single fiber of ℕ × Fin q", "support of a function", "two-dimensional reindexing"],
+    "prerequisites": ["HasSum reindexing along injections", "vanishing off the range condition"]
+  },
+  {
+    "id": "ann-geomoq09chain-converse",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 115, "endLine": 189 },
+    "type": "key-step",
+    "title": "The converse: a finite sum of HasSums, no completeness",
+    "content": "hasSum_of_residues is the main result: if each residue subseries has sum S a, then HasSum f (∑_{a<q} S a). Because q is FINITE, the q single-fiber embeddings assemble as a finite sum of HasSums (hasSum_sum — the only ContinuousAdd input). The pointwise fiberwise sum ∑_a fiber f q a p collapses (Finset.sum_eq_single) to the reindexed term f(q·p.1 + p.2), and (Nat.divModEquiv q).symm.hasSum_iff transports the two-dimensional HasSum back to f on ℕ. summable_of_residues is the Summable corollary; tsum_multisection_of_residues gives the value identity ∑_{a<q} ∑_n f(q·n+a) = ∑_m f(m) over a merely T2 monoid (T2 only supplies uniqueness of the sum). summable_of_even_odd / tsum_even_add_odd_of_residues are the q=2 specialisations.",
+    "mathContext": "Residue sums $S_a\\Rightarrow\\mathrm{HasSum}\\,f\\,\\big(\\sum_{a<q}S_a\\big)$ over any $\\mathrm{ContinuousAdd}$ monoid; value identity over $T_2$.",
+    "significance": "key",
+    "relatedConcepts": ["hasSum_sum (finite sum of HasSums)", "Finset.sum_eq_single", "Equiv.hasSum_iff", "Nat.divModEquiv", "T2 uniqueness of sums"],
+    "prerequisites": ["the single-fiber embedding", "finite sums of HasSums", "transport along ℕ ≃ ℕ × Fin q"]
+  },
+  {
+    "id": "ann-geomoq09chain-forward",
+    "proofId": "geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 191, "endLine": 236 },
+    "type": "insight",
+    "title": "The forward direction's asymmetry and the equivalence",
+    "content": "summable_residue is the forward inclusion — each residue subseries of a summable f is summable — via Summable.comp_injective along the injective residue map. Unlike the converse, this CONSUMES completeness: extracting an infinite subseries from a convergent series converges only by the Cauchy criterion, so the lemma lives in Mathlib's complete-uniform-group section. This is the genuine asymmetry: the converse reassembles f from FINITELY many given sums (needs nothing), the forward extracts an INFINITE subseries (needs completeness). summable_iff_residues packages both into the two-sided characterisation Summable f ↔ ∀ a, Summable (n ↦ f(q·n+a)) over a complete uniform abelian group, and a concrete check confirms ∑_n (1/2)^{2n} + ∑_n (1/2)^{2n+1} = ∑_m (1/2)^m.",
+    "mathContext": "Forward: $\\text{Summable}\\,f\\Rightarrow\\text{Summable}(n\\mapsto f(qn+a))$ needs completeness; equivalence over a complete uniform abelian group.",
+    "significance": "key",
+    "relatedConcepts": ["Summable.comp_injective", "Cauchy criterion", "complete uniform abelian group", "asymmetric hypotheses", "two-sided equivalence"],
+    "prerequisites": ["summability descends along injections (complete case)", "the converse direction", "uniform group structure"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ09OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOQ09OQ01OQ01OQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOQ09OQ01OQ01OQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const geometricSeriesOQ09OQ01OQ01OQ01OQ01Data: ProofData = {
+  proof: geometricSeriesOQ09OQ01OQ01OQ01OQ01Proof,
+  annotations: geometricSeriesOQ09OQ01OQ01OQ01OQ01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `geometric-series-oq-09-oq-01-oq-01-oq-01-oq-01` (the converse residue multisection: residue-subseries summability ⟺ summability, with asymmetric hypotheses).

The entry had a rich meta.json (overview, sections, conclusion, references, crossReferences) but was missing the two essentials:

- **`index.ts` (critical):** without it the proof page renders "proof not found" on the live site despite appearing in the gallery listing.
- **`annotations.json`:** no inline annotations existed. Added 5 (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`) covering the converse-multisection framing and minimal hypotheses, the injective residue map, the single-fiber embedding (`Function.Injective.hasSum_iff`), the completeness-free converse as a finite sum of HasSums (`hasSum_sum` + `Nat.divModEquiv`), and the forward direction's asymmetry (`Summable.comp_injective` consuming completeness) with the two-sided equivalence.

**Axiom integrity:** unchanged — status `verified`/badge `original`, 0 axioms, 0 sorries, no native_decide.

Build: `tsc -b` exit 0, `vite build` exit 0.