### PR TITLE
research(erdos-128-wip-01-oq-01-oq-01-oq-01): forbidden-subgraph freeness pulls back along homomorphisms

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1417,6 +1417,7 @@ import Proofs.Erdos127Problem
 import Proofs.Erdos128Problem
 import Proofs.Erdos128WIP01OQ01
 import Proofs.Erdos128WIP01OQ01OQ01
+import Proofs.Erdos128WIP01OQ01OQ01OQ01
 import Proofs.Erdos129Problem
 import Proofs.Erdos12Problem
 import Proofs.Erdos12ProblemAPNPartI

--- a/proofs/Proofs/Erdos128WIP01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos128WIP01OQ01OQ01OQ01.lean
@@ -1,0 +1,219 @@
+import Mathlib
+
+/-
+# Erdős #128 — forbidden-subgraph freeness pulls back along homomorphisms
+# (erdos-128-wip-01-oq-01-oq-01-oq-01)
+
+## The Problem
+
+**Erdős Problem #128** ($250, OPEN). If every induced subgraph of an `n`-vertex
+graph `G` on `≥ ⌊n/2⌋` vertices has more than `n²/50` edges, must `G` contain a
+triangle? The constant `1/50` is conjectured optimal, witnessed by **blow-ups of
+`C₅`**, which are triangle-free with induced density `> 1/50` at every scale.
+
+The parent chain showed triangle-freeness is hereditary (`Erdos128WIP01.lean`),
+then that it pulls back along **graph homomorphisms** (`triangleFree_of_hom`,
+`Erdos128WIP01OQ01.lean`), and then lifted that pullback from triangles to
+**`K_r`-cliques of every order** (`cliqueFree_of_hom`, `Erdos128WIP01OQ01OQ01.lean`).
+That last entry's stated open question asks to generalise once more — beyond
+cliques to **arbitrary forbidden subgraphs `F`**, "of which clique-freeness is the
+`F = K_r` case." This file answers it.
+
+## Result
+
+The right notion is a **homomorphic copy** of `F`: a graph homomorphism
+`φ : F → G` (no injectivity required). Working self-contained over Mathlib:
+
+1. `homFree_of_hom` — **`F`-homomorphic-copy-freeness pulls back along homomorphisms**,
+   for *every* fixed graph `F`. If there is a homomorphism `f : G → H` and `H` has no
+   homomorphic copy of `F`, then neither does `G`. The proof is *pure composition*:
+   `f ∘ φ` is a homomorphic copy of `F` in `H`. No irreflexivity is needed here — the
+   irreflexivity that the clique argument used reappears only in the bridge below.
+
+2. `hasHomCopy_mono` — **homomorphic-copy containment is monotone along homomorphisms**:
+   a homomorphism `F' → F` turns a homomorphic copy of `F` into one of `F'`. This
+   generalises the clique-order monotonicity `hasClique_mono` (which is the inclusion
+   `K_m → K_r`).
+
+3. `hasHomCopy_completeGraph_iff` / `cliqueFree_iff_homFree_completeGraph` — **the bridge**.
+   Over an irreflexive target, a homomorphic copy of the complete graph `K_r` is exactly
+   an `r`-clique (the homomorphism is forced injective by irreflexivity). Hence
+   `K_r`-freeness *is* `K_r`-homomorphic-copy-freeness, and `cliqueFree_of_hom` is recovered
+   as the `F = K_r` corollary of `homFree_of_hom`.
+
+4. `blowup_homFree` — every blow-up of an `F`-free graph is `F`-free, for every `F`.
+
+5. `C5_homFree` / `blowup_C5_homFree` — `C₅` has no homomorphic copy of `K_r` for any
+   `r ≥ 3`, hence neither does any blow-up of `C₅`, at every size. Via the bridge this
+   recovers `blowup_C5_cliqueFree`: the extremal construction is `K_r`-free for all `r ≥ 3`.
+
+## Summary: 0 sorries, 0 axioms, no `native_decide`. Self-contained over Mathlib.
+-/
+
+set_option linter.unusedVariables false
+
+namespace Erdos128WIP01OQ01OQ01OQ01
+
+/-- A simple graph on `n` vertices. -/
+structure Graph (n : ℕ) where
+  adj : Fin n → Fin n → Prop
+  symm : ∀ u v, adj u v → adj v u
+  irrefl : ∀ v, ¬ adj v v
+
+/-- A **graph homomorphism** `f : G → H`: it carries adjacent vertices to adjacent
+    vertices. (No injectivity or surjectivity is required.) -/
+def IsHom {n k : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k) : Prop :=
+  ∀ u v, G.adj u v → H.adj (f u) (f v)
+
+/-! ### Homomorphic copies of a fixed graph `F` -/
+
+/-- `G` **contains a homomorphic copy of `F`**: there is a graph homomorphism
+    `φ : F → G`. Unlike a clique this asks for no injectivity — `F`'s edges must be
+    realised by edges of `G`, nothing more. -/
+def hasHomCopy {m n : ℕ} (F : Graph m) (G : Graph n) : Prop :=
+  ∃ φ : Fin m → Fin n, IsHom F G φ
+
+/-- `G` is **`F`-free**: it has no homomorphic copy of `F`. -/
+def homFree {m n : ℕ} (F : Graph m) (G : Graph n) : Prop := ¬ hasHomCopy F G
+
+/-- **`F`-freeness pulls back along graph homomorphisms**, for every fixed `F`.
+    If there is a homomorphism `f : G → H` and `H` is `F`-free, then so is `G`.
+
+    The argument is *pure composition*: a homomorphic copy `φ : F → G` composed with
+    `f` is a homomorphic copy `f ∘ φ : F → H`. No irreflexivity is required — this is
+    the general structural reason behind `cliqueFree_of_hom`, with the clique case's
+    appeal to irreflexivity isolated entirely in the bridge below. -/
+theorem homFree_of_hom {m n k : ℕ} (F : Graph m) (G : Graph n) (H : Graph k)
+    (f : Fin n → Fin k) (hf : IsHom G H f) (hH : homFree F H) : homFree F G := by
+  rintro ⟨φ, hφ⟩
+  exact hH ⟨f ∘ φ, fun a b hab => hf _ _ (hφ a b hab)⟩
+
+/-- **Homomorphic-copy containment is monotone along homomorphisms.** A homomorphism
+    `g : F' → F` turns a homomorphic copy of `F` into one of `F'` (precompose). This
+    generalises clique-order monotonicity: the inclusion `K_m → K_r` for `m ≤ r`. -/
+theorem hasHomCopy_mono {m' m n : ℕ} (F' : Graph m') (F : Graph m) (G : Graph n)
+    (g : Fin m' → Fin m) (hg : IsHom F' F g) (h : hasHomCopy F G) : hasHomCopy F' G := by
+  obtain ⟨φ, hφ⟩ := h
+  exact ⟨φ ∘ g, fun a b hab => hφ (g a) (g b) (hg a b hab)⟩
+
+/-! ### Cliques as the `F = K_r` case -/
+
+/-- `G` contains an **`r`-clique**: an injective family of `r` pairwise-adjacent vertices. -/
+def Graph.hasClique {n : ℕ} (G : Graph n) (r : ℕ) : Prop :=
+  ∃ s : Fin r → Fin n, Function.Injective s ∧ ∀ i j, i ≠ j → G.adj (s i) (s j)
+
+/-- `G` is **`K_r`-free**: it has no `r`-clique. -/
+def Graph.cliqueFree {n : ℕ} (G : Graph n) (r : ℕ) : Prop := ¬ G.hasClique r
+
+/-- The **complete graph `K_r`** on `Fin r`: distinct vertices are adjacent. -/
+def completeGraph (r : ℕ) : Graph r where
+  adj i j := i ≠ j
+  symm u v h := Ne.symm h
+  irrefl v h := h rfl
+
+/-- The inclusion `Fin.castLE` is a homomorphism `K_m → K_r` for `m ≤ r`. -/
+theorem completeGraph_castLE_isHom {m r : ℕ} (hmr : m ≤ r) :
+    IsHom (completeGraph m) (completeGraph r) (Fin.castLE hmr) :=
+  fun a b hab heq => hab (Fin.castLE_injective hmr heq)
+
+/-- **A homomorphic copy of `K_r` is exactly an `r`-clique** (the target is irreflexive,
+    so a homomorphism out of the complete graph is forced injective: distinct vertices
+    are adjacent in `K_r`, hence have adjacent — therefore distinct — images). This is
+    the precise sense in which clique-freeness is the `F = K_r` instance of `homFree`. -/
+theorem hasHomCopy_completeGraph_iff {n : ℕ} (G : Graph n) (r : ℕ) :
+    hasHomCopy (completeGraph r) G ↔ G.hasClique r := by
+  constructor
+  · rintro ⟨φ, hφ⟩
+    refine ⟨φ, ?_, fun i j hij => hφ i j hij⟩
+    intro a b hab
+    by_contra hne
+    exact G.irrefl (φ b) (hab ▸ hφ a b hne)
+  · rintro ⟨s, hinj, hadj⟩
+    exact ⟨s, fun a b hab => hadj a b hab⟩
+
+/-- **`K_r`-freeness is `K_r`-homomorphic-copy-freeness.** -/
+theorem cliqueFree_iff_homFree_completeGraph {n : ℕ} (G : Graph n) (r : ℕ) :
+    G.cliqueFree r ↔ homFree (completeGraph r) G :=
+  not_congr (hasHomCopy_completeGraph_iff G r).symm
+
+/-- **`K_r`-freeness pulls back along homomorphisms** — recovered as the `F = K_r`
+    corollary of `homFree_of_hom` through the bridge, reproducing the parent's
+    `cliqueFree_of_hom`. -/
+theorem cliqueFree_of_hom {n k r : ℕ} (G : Graph n) (H : Graph k) (f : Fin n → Fin k)
+    (hf : IsHom G H f) (hH : H.cliqueFree r) : G.cliqueFree r :=
+  (cliqueFree_iff_homFree_completeGraph G r).2
+    (homFree_of_hom (completeGraph r) G H f hf
+      ((cliqueFree_iff_homFree_completeGraph H r).1 hH))
+
+/-! ### Blow-ups and the `C₅` witness -/
+
+/-- The **blow-up** of `H` along a class map `c : Fin n → Fin k`: two vertices are
+    adjacent exactly when their classes are adjacent in `H`. -/
+def blowup {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) : Graph n where
+  adj u v := H.adj (c u) (c v)
+  symm u v h := H.symm (c u) (c v) h
+  irrefl v h := H.irrefl (c v) h
+
+/-- The class map of a blow-up is a homomorphism `blowup H c → H`. -/
+theorem blowup_isHom {n k : ℕ} (H : Graph k) (c : Fin n → Fin k) :
+    IsHom (blowup H c) H c := fun u v h => h
+
+/-- **Every blow-up of an `F`-free graph is `F`-free**, for every fixed `F` — the
+    forbidden-subgraph generalisation of `blowup_cliqueFree`. -/
+theorem blowup_homFree {m n k : ℕ} (F : Graph m) (H : Graph k) (c : Fin n → Fin k)
+    (hH : homFree F H) : homFree F (blowup H c) :=
+  homFree_of_hom F (blowup H c) H c (blowup_isHom H c) hH
+
+/-- The **5-cycle `C₅`** on `Fin 5`: `i ~ j` iff one step apart around the cycle. -/
+def C5 : Graph 5 where
+  adj i j := i + 1 = j ∨ j + 1 = i
+  symm u v h := h.symm
+  irrefl := by decide
+
+set_option maxRecDepth 4000 in
+/-- **`C₅` has no homomorphic copy of `K₃`** (ordinary decision procedure over the
+    finite function space, *not* `native_decide`). -/
+theorem C5_homFree_three : homFree (completeGraph 3) C5 := by
+  unfold homFree hasHomCopy IsHom completeGraph C5
+  decide
+
+/-- **`C₅` has no homomorphic copy of `K_r` for any `r ≥ 3`.** By monotonicity: a copy
+    of `K_r` would, via the inclusion `K₃ → K_r`, give a copy of `K₃`. -/
+theorem C5_homFree {r : ℕ} (hr : 3 ≤ r) : homFree (completeGraph r) C5 :=
+  fun h => C5_homFree_three
+    (hasHomCopy_mono (completeGraph 3) (completeGraph r) C5 _
+      (completeGraph_castLE_isHom hr) h)
+
+/-- **Every blow-up of `C₅` is `K_r`-homomorphic-copy-free for all `r ≥ 3`**, at every
+    size `n` and for every class assignment `c : Fin n → Fin 5`. -/
+theorem blowup_C5_homFree {n r : ℕ} (c : Fin n → Fin 5) (hr : 3 ≤ r) :
+    homFree (completeGraph r) (blowup C5 c) :=
+  blowup_homFree (completeGraph r) C5 c (C5_homFree hr)
+
+/-- **`C₅` is `K_r`-free for every `r ≥ 3`** — the parent's `C5_cliqueFree`, recovered
+    from the forbidden-subgraph framework via the bridge. -/
+theorem C5_cliqueFree {r : ℕ} (hr : 3 ≤ r) : C5.cliqueFree r :=
+  (cliqueFree_iff_homFree_completeGraph C5 r).2 (C5_homFree hr)
+
+/-- **Every blow-up of `C₅` is `K_r`-free for all `r ≥ 3`** — the parent's
+    `blowup_C5_cliqueFree`, recovered as an instance of the general `blowup_homFree`. -/
+theorem blowup_C5_cliqueFree {n r : ℕ} (c : Fin n → Fin 5) (hr : 3 ≤ r) :
+    (blowup C5 c).cliqueFree r :=
+  (cliqueFree_iff_homFree_completeGraph (blowup C5 c) r).2 (blowup_C5_homFree c hr)
+
+/-
+## Significance
+
+The parent chain narrowed the structural reason the `C₅`-blow-up witnesses for Erdős #128
+are triangle-free: triangle-freeness pulls back along homomorphisms, and (one level down)
+so does `K_r`-freeness for every clique order. This file isolates the *general* mechanism:
+freeness of a homomorphic copy of **any** fixed graph `F` pulls back along homomorphisms,
+by nothing more than composing `f ∘ φ`. The clique results are then the `F = K_r` instance —
+`hasHomCopy_completeGraph_iff` shows a homomorphic copy of the complete graph is exactly a
+clique once the target is irreflexive, recovering `cliqueFree_of_hom`, `C5_cliqueFree`, and
+`blowup_C5_cliqueFree` as corollaries. Clique-order monotonicity becomes monotonicity along
+homomorphisms `F' → F`. The analytic content of Erdős #128 — that the `C₅`-blow-ups achieve
+induced density `> 1/50`, and that `1/50` is optimal — remains open.
+-/
+
+end Erdos128WIP01OQ01OQ01OQ01

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "erdos128-wip01oq01oq01oq01-ann-header",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 3, "endLine": 53 },
+    "type": "context",
+    "title": "From cliques to arbitrary forbidden subgraphs",
+    "content": "Erdős Problem #128 ($250, open) asks whether a uniform edge-density condition on all large induced subgraphs forces a triangle; the conjectured-optimal constant 1/50 is witnessed by blow-ups of C₅. The parent chain lifted the homomorphism-pullback principle from triangles to K_r-cliques of every order. This entry answers that parent's stated open question by generalizing once more — beyond cliques to arbitrary forbidden subgraphs F — and shows clique-freeness is exactly the F = K_r case.",
+    "mathContext": "A homomorphic copy of $F$ in $G$ is a graph homomorphism $\\varphi : F \\to G$, with no injectivity required.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey–Turán theory", "forbidden subgraph", "graph homomorphism", "C₅ blow-up"],
+    "prerequisites": ["graph theory", "extremal combinatorics"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01-ann-homcopy",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 77 },
+    "type": "definition",
+    "title": "Homomorphic copy of a fixed graph F",
+    "content": "G contains a homomorphic copy of F when there is a graph homomorphism φ : F → G — a map carrying each edge of F to an edge of G. Unlike a clique or an induced copy, this asks for no injectivity: F's edges must be realized, nothing more. F-freeness (homFree) is the absence of any such copy. This is the notion under which the pullback below is purely formal.",
+    "mathContext": "$\\mathrm{hasHomCopy}\\,F\\,G := \\exists\\,\\varphi : \\mathrm{Fin}\\,m \\to \\mathrm{Fin}\\,n,\\ \\mathrm{IsHom}\\,F\\,G\\,\\varphi$.",
+    "significance": "key",
+    "relatedConcepts": ["graph homomorphism", "subgraph containment", "homomorphism density"],
+    "prerequisites": ["graph theory"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01-ann-pullback",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 92 },
+    "type": "theorem",
+    "title": "homFree_of_hom — pullback by pure composition",
+    "content": "For every fixed graph F: if there is a homomorphism f : G → H and H has no homomorphic copy of F, then neither does G. The proof composes — a copy φ : F → G followed by f is a copy f ∘ φ : F → H. No irreflexivity is used here; this is the general structural reason behind the parent's cliqueFree_of_hom, with the clique case's appeal to irreflexivity moved entirely into the bridge.",
+    "mathContext": "If $f : G \\to H$ is a homomorphism and $H$ is $F$-free, then $G$ is $F$-free, because $f \\circ \\varphi$ is a homomorphic copy of $F$ in $H$.",
+    "significance": "key",
+    "relatedConcepts": ["homomorphism composition", "monotone graph parameters", "pullback"],
+    "prerequisites": ["graph homomorphism"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01-ann-mono",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 97 },
+    "type": "theorem",
+    "title": "hasHomCopy_mono — monotone along homomorphisms",
+    "content": "A homomorphism g : F' → F turns a homomorphic copy of F into one of F' by precomposition. This generalizes clique-order monotonicity (hasClique_mono): the inclusion K_m → K_r for m ≤ r is a homomorphism, so a copy of K_r restricts to a copy of K_m.",
+    "mathContext": "$\\mathrm{IsHom}\\,F'\\,F\\,g$ and a copy $\\varphi$ of $F$ give the copy $\\varphi \\circ g$ of $F'$.",
+    "significance": "important",
+    "relatedConcepts": ["graph minor order", "homomorphism order", "monotonicity"],
+    "prerequisites": ["graph homomorphism"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01-ann-bridge",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 117, "endLine": 146 },
+    "type": "theorem",
+    "title": "The complete-graph bridge — clique-freeness is the F = K_r case",
+    "content": "Over an irreflexive target a homomorphic copy of the complete graph K_r is exactly an r-clique: distinct vertices of K_r are adjacent, so their images are adjacent and — by irreflexivity — distinct, forcing the homomorphism to be injective. Hence K_r-freeness is K_r-homomorphic-copy-freeness (cliqueFree_iff_homFree_completeGraph), and the parent's cliqueFree_of_hom is recovered as the F = K_r corollary of homFree_of_hom. This is where, and only where, irreflexivity enters.",
+    "mathContext": "$\\mathrm{hasHomCopy}\\,(K_r)\\,G \\iff G.\\mathrm{hasClique}\\,r$ for irreflexive $G$.",
+    "significance": "key",
+    "relatedConcepts": ["complete graph", "clique", "irreflexive graph", "injective homomorphism"],
+    "prerequisites": ["graph homomorphism", "clique"]
+  },
+  {
+    "id": "erdos128-wip01oq01oq01oq01-ann-c5",
+    "proofId": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 148, "endLine": 202 },
+    "type": "theorem",
+    "title": "C₅-blow-ups are K_r-free for all r ≥ 3",
+    "content": "The class map of a blow-up is a homomorphism, so blow-ups preserve F-freeness for every F (blowup_homFree). C₅ has no homomorphic copy of K_3 by the ordinary finite decision procedure (decide, with maxRecDepth raised — not native_decide), and by monotonicity none of K_r for r ≥ 3, so every blow-up of C₅ at every size and class assignment is free of K_r-copies. Via the bridge this recovers the parent's blowup_C5_cliqueFree: the conjectured-optimal extremal construction is K_r-free for all r ≥ 3, now as an instance of the forbidden-subgraph framework.",
+    "mathContext": "$\\mathrm{blowup}\\,C_5\\,c$ has no homomorphic copy of $K_r$, hence no $r$-clique, for every $r \\ge 3$.",
+    "significance": "key",
+    "relatedConcepts": ["blow-up", "C₅", "extremal construction", "decision procedure"],
+    "prerequisites": ["graph blow-up", "finite decidability"]
+  }
+]

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos128WIP01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos128Wip01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos128Wip01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos128Wip01Oq01Oq01Oq01Data: ProofData = {
+  proof: erdos128Wip01Oq01Oq01Oq01Proof,
+  annotations: erdos128Wip01Oq01Oq01Oq01Annotations,
+}

--- a/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-128-wip-01-oq-01-oq-01-oq-01/meta.json
@@ -1,0 +1,123 @@
+{
+  "id": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+  "title": "Erdős #128: forbidden-subgraph freeness pulls back along homomorphisms (clique-freeness is the F = K_r case)",
+  "slug": "erdos-128-wip-01-oq-01-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "Erdos128WIP01OQ01OQ01OQ01",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 8,
+    "path": "Proofs/Erdos128WIP01OQ01OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Answers the parent entry erdos-128-wip-01-oq-01-oq-01's stated open question by generalizing clique-freeness pullback from cliques to arbitrary forbidden subgraphs. The parent proved K_r-freeness pulls back along graph homomorphisms; this entry isolates the general mechanism. A homomorphic copy of a fixed graph F in G is a graph homomorphism phi : F -> G (no injectivity required). homFree_of_hom shows F-homomorphic-copy-freeness pulls back along any homomorphism f : G -> H, for every F, by pure composition (f . phi is a copy of F in H) -- crucially requiring no irreflexivity. hasHomCopy_mono shows homomorphic-copy containment is monotone along homomorphisms F' -> F, generalizing clique-order monotonicity (the inclusion K_m -> K_r). The bridge hasHomCopy_completeGraph_iff proves that over an irreflexive target a homomorphic copy of the complete graph K_r is exactly an r-clique (the homomorphism is forced injective by irreflexivity), so K_r-freeness IS K_r-homomorphic-copy-freeness (cliqueFree_iff_homFree_completeGraph) and the parent's cliqueFree_of_hom is recovered as the F = K_r corollary. blowup_homFree generalizes blow-up preservation to every F, and C5_homFree / blowup_C5_homFree / blowup_C5_cliqueFree recover the extremal witnesses' K_r-freeness for all r >= 3 from the general framework, via an ordinary decision procedure (not native_decide). 13 theorems, 8 definitions + 1 structure, 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "date": "formalized 2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos128WIP01OQ01OQ01OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "graph-theory",
+      "extremal-graph-theory",
+      "triangle-free",
+      "clique-free",
+      "forbidden-subgraph",
+      "graph-homomorphism",
+      "ramsey-turan",
+      "erdos-problems"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "Machine-checked with `lake env lean Proofs/Erdos128WIP01OQ01OQ01OQ01.lean` (Lean v4.26.0, Mathlib pin): compiles with 0 errors. 0 sorries, 0 axiom declarations, no native_decide. #print axioms reports: homFree_of_hom, hasHomCopy_mono, cliqueFree_of_hom, and hasHomCopy_completeGraph_iff depend on NO axioms at all; C5_homFree_three, C5_homFree, blowup_C5_homFree, and blowup_C5_cliqueFree depend only on the standard foundational axioms [propext, Classical.choice, Quot.sound] (the `decide` evaluation of C₅ over Fin 5 / the function space Fin 3 -> Fin 5 is the ordinary kernel decision procedure, NOT native_decide, so Lean.ofReduceBool is not used; maxRecDepth is raised for the C5_homFree_three decision only). Self-contained: the Graph objects are re-declared. Honest scope: the structural forbidden-subgraph-pullback / monotonicity facts, the complete-graph bridge, and the K_r-freeness of the C₅-blow-up witnesses, NOT the open optimal-constant question (that these blow-ups achieve induced density > n²/50, and that 1/50 is optimal, remain open).",
+    "lineCount": 219,
+    "theoremCount": 13,
+    "definitionCount": 8,
+    "originalContributions": [
+      "homFree_of_hom: forbidden-subgraph freeness pulls back along graph homomorphisms, for EVERY fixed graph F. A homomorphic copy of F is a graph homomorphism phi : F -> G (no injectivity required); if f : G -> H is a homomorphism and H has no homomorphic copy of F then neither does G, because f . phi is a homomorphic copy of F in H. The proof is pure composition and needs no irreflexivity -- this is the general structural reason behind the parent's cliqueFree_of_hom, with the clique case's appeal to irreflexivity isolated entirely in the bridge.",
+      "hasHomCopy_mono: homomorphic-copy containment is monotone along homomorphisms. A homomorphism g : F' -> F turns a homomorphic copy of F into one of F' by precomposition. This generalizes clique-order monotonicity (hasClique_mono), which is the special case of the inclusion homomorphism K_m -> K_r for m <= r.",
+      "hasHomCopy_completeGraph_iff / cliqueFree_iff_homFree_completeGraph: the bridge identifying the F = K_r case with cliques. Over an irreflexive target a homomorphic copy of the complete graph K_r is exactly an r-clique -- a homomorphism out of K_r is forced injective because distinct K_r vertices are adjacent, so their images are adjacent and (by irreflexivity) distinct. Hence K_r-freeness IS K_r-homomorphic-copy-freeness, and this is the precise sense in which clique-freeness is the F = K_r instance.",
+      "cliqueFree_of_hom: the parent's clique-freeness pullback, recovered as the F = K_r corollary of homFree_of_hom through the bridge -- one application of the general theorem.",
+      "blowup_homFree: every blow-up of an F-free graph is F-free, for every fixed F (the forbidden-subgraph generalization of blowup_cliqueFree), since the class map of a blow-up is a homomorphism.",
+      "C5_homFree / blowup_C5_homFree / blowup_C5_cliqueFree: C₅ has no homomorphic copy of K_r for any r >= 3 (it has none of K_3 by the ordinary decision procedure, and copy-containment is monotone), hence neither does any blow-up of C₅ at any size or class assignment; via the bridge this recovers the parent's blowup_C5_cliqueFree, exhibiting the conjectured-optimal extremal construction as K_r-free for all r >= 3 -- now as an instance of the uniform forbidden-subgraph framework."
+    ]
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #128 is a Ramsey–Turán-type question asking whether a uniform edge-density condition on all large induced subgraphs forces a triangle. The threshold constant 1/50 is conjectured optimal, witnessed by blow-ups of C₅ (and the Petersen graph), which are triangle-free yet have induced-subgraph density about 1/5 > 1/50. A long line of partial results (Erdős–Faudree–Rousseau–Schelp 1/16, Krivelevich, Razborov's flag-algebra 27/1024, Norin–Yepremyan) narrows the constant, but the exact 1/50 remains a $250 open problem. The parent chain isolated the structural reason the witnesses avoid cliques: triangle-freeness, then K_r-freeness, pulls back along graph homomorphisms. This entry shows that pullback principle is not special to cliques at all -- it holds for every forbidden subgraph, with the clique case recovered through a complete-graph bridge.",
+    "problemStatement": "Erdős #128: if every induced subgraph of an n-vertex graph G on >= floor(n/2) vertices has more than n²/50 edges, must G contain a triangle? This entry answers the parent entry's open question by generalizing the homomorphism-pullback principle from cliques to arbitrary forbidden subgraphs F -- freeness of a homomorphic copy of any fixed F pulls back along homomorphisms -- and identifies clique-freeness as the F = K_r instance, recovering the parent's clique results and the C₅-blow-up witnesses' K_r-freeness for every r >= 3.",
+    "proofStrategy": "Re-declare the scaffold's Graph objects and define a homomorphic copy of F in G as a graph homomorphism phi : F -> G (a map preserving edges, with no injectivity demanded). The pullback theorem homFree_of_hom is then pure composition: given f : G -> H and a copy phi : F -> G, the composite f . phi : F -> H preserves edges, so a copy of F in G yields one in H -- F-freeness pulls back, with no irreflexivity needed. Monotonicity hasHomCopy_mono precomposes a copy of F with a homomorphism F' -> F. For the clique bridge, define the complete graph K_r (distinct vertices adjacent); a homomorphism out of K_r into an irreflexive G sends distinct (hence adjacent) vertices to adjacent, therefore distinct, images, so it is injective -- i.e. exactly an r-clique (hasHomCopy_completeGraph_iff). This makes cliqueFree_of_hom a one-line corollary. A blow-up's class map is a homomorphism, so blow-ups preserve F-freeness; C₅ has no homomorphic copy of K_3 by the finite decision procedure (maxRecDepth raised), and by monotonicity none of K_r for r >= 3, so blowup_C5_cliqueFree follows via the bridge.",
+    "keyInsights": [
+      "The pullback argument never used cliques: a homomorphic copy is just an edge-preserving map, and composing it with a homomorphism gives a copy in the target -- so freeness of a homomorphic copy of ANY fixed graph F pulls back, by composition alone, with no appeal to irreflexivity.",
+      "Irreflexivity is exactly what the complete-graph bridge needs and the general pullback does not: over an irreflexive target a homomorphism out of K_r is automatically injective, so a homomorphic copy of K_r is precisely an r-clique. This localizes the parent's irreflexivity step to a single equivalence.",
+      "Clique-order monotonicity is a special case of monotonicity along homomorphisms: the inclusion K_m -> K_r is a homomorphism, and precomposing a copy with it restricts a K_r-copy to a K_m-copy.",
+      "Consequently the parent's whole clique theory -- cliqueFree_of_hom, the C₅-blow-up witnesses' K_r-freeness for all r >= 3 -- drops out of one general forbidden-subgraph theorem plus the complete-graph bridge, and the framework now applies to any fixed forbidden subgraph, not only complete ones."
+    ]
+  },
+  "sections": [
+    {
+      "id": "objects",
+      "title": "Graphs, homomorphisms, and homomorphic copies (re-declared)",
+      "summary": "Graph, the homomorphism predicate IsHom, and the homomorphic-copy notions hasHomCopy / homFree of a fixed graph F.",
+      "startLine": 56,
+      "endLine": 77,
+      "mathContext": "Self-contained re-declaration; a homomorphic copy of F in G is a graph homomorphism F -> G, with no injectivity required."
+    },
+    {
+      "id": "pullback",
+      "title": "Forbidden-subgraph freeness pulls back along homomorphisms",
+      "summary": "homFree_of_hom: a homomorphism into an F-free graph forces F-freeness, by composing f . phi; hasHomCopy_mono: monotonicity along homomorphisms F' -> F.",
+      "startLine": 82,
+      "endLine": 97,
+      "mathContext": "The general mechanism behind the parent's cliqueFree_of_hom -- pure composition, no irreflexivity."
+    },
+    {
+      "id": "cliques",
+      "title": "Cliques as the F = K_r case",
+      "summary": "The complete graph K_r and the bridge hasHomCopy_completeGraph_iff (a homomorphic copy of K_r over an irreflexive target is exactly an r-clique), giving cliqueFree_iff_homFree_completeGraph and recovering cliqueFree_of_hom.",
+      "startLine": 99,
+      "endLine": 146,
+      "mathContext": "Irreflexivity forces a homomorphism out of K_r to be injective, identifying homomorphic copies of K_r with r-cliques."
+    },
+    {
+      "id": "blowups",
+      "title": "Blow-ups and the C₅ witness",
+      "summary": "blowup_homFree (every blow-up of an F-free graph is F-free) and the C₅ application: C5_homFree, blowup_C5_homFree, and the recovered C5_cliqueFree / blowup_C5_cliqueFree for all r >= 3.",
+      "startLine": 148,
+      "endLine": 202,
+      "mathContext": "The class map of a blow-up is a homomorphism; C₅ has no homomorphic copy of K_r for r >= 3 by the finite decision procedure plus monotonicity."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős #128 asks whether dense large induced subgraphs force a triangle, with conjectured-optimal constant 1/50 witnessed by C₅-blow-ups. The parent chain showed triangle-freeness, then K_r-freeness, pulls back along graph homomorphisms. This entry answers the parent's open question by isolating the general mechanism: homFree_of_hom shows freeness of a homomorphic copy of ANY fixed graph F pulls back along homomorphisms, by pure composition with no irreflexivity; hasHomCopy_mono makes it monotone along homomorphisms F' -> F; and the bridge hasHomCopy_completeGraph_iff identifies homomorphic copies of K_r over irreflexive targets with r-cliques, recovering cliqueFree_of_hom and the C₅-blow-up witnesses' K_r-freeness for all r >= 3 as the F = K_r instance. Self-contained over Mathlib, verified with the ordinary kernel decision procedure (no native_decide), 0 sorries, 0 axioms.",
+    "implications": "The clique-pullback theory of the parent is a single corollary of a forbidden-subgraph principle that applies to every fixed F, with the only use of irreflexivity confined to the complete-graph bridge. Any formal attack on the optimal constant 1/50 thus inherits a reusable, F-uniform foundation: the extremal C₅-blow-ups are free of homomorphic copies of every complete graph K_r (r >= 3), and the same pullback would establish freeness of any other fixed forbidden subgraph whenever the base graph is.",
+    "openQuestions": [
+      "Formalize the edge-density estimate for C₅-blow-ups: that a balanced blow-up has induced-subgraph density > n²/50 on every floor(n/2)-subgraph, completing the lower-bound witness for the 1/50 constant.",
+      "Prove (or formalize a partial result toward) the main question: does density > n²/50 on every floor(n/2)-subgraph force a triangle?",
+      "Strengthen the forbidden-subgraph notion from homomorphic copies to induced or injective (subgraph) copies, and characterize for which F injective-copy-freeness also pulls back along homomorphisms (it does not in general -- non-adjacent vertices of F may collapse under the homomorphism -- so the complete graphs are exactly the F for which homomorphic and injective copies coincide over irreflexive targets)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-128-wip-01-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "The parent entry lifted homomorphism-pullback from triangles to K_r-cliques (cliqueFree_of_hom) and listed as an open question the generalization beyond cliques to arbitrary forbidden subgraphs. This entry proves exactly that (homFree_of_hom), generalizes clique-order monotonicity to monotonicity along homomorphisms, and recovers cliqueFree_of_hom as the F = K_r case via the complete-graph bridge."
+    },
+    {
+      "targetId": "erdos-128-wip-01-oq-01",
+      "relationship": "related",
+      "description": "The grandparent entry proved triangle-freeness pulls back along graph homomorphisms (triangleFree_of_hom); that is the F = K_3 instance of the forbidden-subgraph pullback established here."
+    },
+    {
+      "targetId": "erdos-128",
+      "relationship": "related",
+      "description": "The base Erdős #128 scaffold, whose conjectured-optimal extremal witnesses are the C₅-blow-ups shown here to be free of homomorphic copies of K_r -- hence K_r-free -- for every r >= 3."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Answers the open question of parent entry **erdos-128-wip-01-oq-01-oq-01** (which lifted homomorphism-pullback from triangles to `K_r`-cliques): generalizes clique-freeness pullback from cliques to **arbitrary forbidden subgraphs** `F`, "of which clique-freeness is the `F = K_r` case."

A **homomorphic copy** of a fixed graph `F` in `G` is a graph homomorphism `φ : F → G` (no injectivity required).

- **`homFree_of_hom`** — `F`-homomorphic-copy-freeness pulls back along *any* homomorphism `f : G → H`, for *every* `F`, by **pure composition** (`f ∘ φ` is a copy of `F` in `H`). Crucially needs **no irreflexivity** — this is the general mechanism behind the parent's `cliqueFree_of_hom`.
- **`hasHomCopy_mono`** — copy-containment is monotone along homomorphisms `F' → F` (precompose), generalizing clique-order monotonicity (the inclusion `K_m → K_r`).
- **`hasHomCopy_completeGraph_iff` / `cliqueFree_iff_homFree_completeGraph`** — the bridge: over an irreflexive target a homomorphic copy of `K_r` is **exactly an `r`-clique** (the homomorphism is forced injective by irreflexivity). So `K_r`-freeness *is* the `F = K_r` instance, and `cliqueFree_of_hom` is recovered as a one-line corollary. Irreflexivity enters here and only here.
- **`blowup_homFree`** — every blow-up of an `F`-free graph is `F`-free, for every `F`.
- **`C5_homFree` / `blowup_C5_homFree` / `blowup_C5_cliqueFree`** — `C₅` has no homomorphic copy of `K_r` for any `r ≥ 3` (none of `K_3` by the ordinary `decide`, then monotonicity), recovering the conjectured-optimal extremal witnesses' `K_r`-freeness for all `r ≥ 3` from the framework.

## Verification

`verified` / `original` — 13 theorems, 8 defs + 1 structure, **0 sorries, 0 axioms**, 219 lines. Self-contained over Mathlib, registered in `Proofs.lean`.

`#print axioms`: `homFree_of_hom`, `hasHomCopy_mono`, `cliqueFree_of_hom`, `hasHomCopy_completeGraph_iff` depend on **no axioms at all**; the `C₅`/blow-up theorems use only `[propext, Classical.choice, Quot.sound]` — **no `Lean.ofReduceBool`** (ordinary `decide`, not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)