### PR TITLE
research(fibonacci-identities-oq-03-oq-01): fib(4n+3) as a sum of two squares (iterated doubling)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2776,6 +2776,7 @@ import Proofs.FibonacciIdentitiesOQ01
 import Proofs.FibonacciIdentitiesOQ01OQ02
 import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ03
+import Proofs.FibonacciIdentitiesOQ03OQ01
 import Proofs.FibonacciIdentitiesOQ04
 import Proofs.FibonacciIdentitiesOQ04OQ01
 import Proofs.FiveColorTheorem

--- a/proofs/Proofs/FibonacciIdentitiesOQ03OQ01.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ03OQ01.lean
@@ -1,0 +1,81 @@
+import Mathlib
+
+/-
+# Fibonacci numbers at index `4n+3` as a sum of two squares (iterated doubling)
+
+The parent entry `FibonacciIdentitiesOQ03` records the two halves of the
+fast-doubling identities:
+
+* `Nat.fib_two_mul_add_one`  : `fib (2n+1) = fib (n+1)² + fib n²`   (odd → sum of two squares)
+* `Nat.fib_two_mul_add_two`  : `fib (2n+2) = fib (n+1)·(2·fib n + fib (n+1))` (even, product form)
+
+This entry **iterates the doubling once more**.  Writing `4n+3 = 2·(2n+1)+1`,
+the odd-doubling identity applied at index `2n+1` gives the *outer* layer
+
+  `fib (4n+3) = fib (2n+2)² + fib (2n+1)²`,
+
+an honest sum of two squares.  Substituting the *inner* layer — the two parent
+identities for `fib (2n+1)` and `fib (2n+2)` — re-expresses `fib (4n+3)` entirely
+in terms of the two consecutive base values `a = fib n`, `b = fib (n+1)`:
+
+  `fib (4n+3) = (b·(2a+b))² + (b²+a²)²`.
+
+This is a genuine sum-of-two-squares decomposition with *explicit* low-index
+terms, the content the open question asks for.  Everything is over `ℕ` with no
+truncated subtraction, so the existential "sum of two squares" reading holds
+without casting to `ℤ`.
+
+The proof is elementary: two applications of Mathlib's `fib_two_mul_add_one`
+(one to peel the outer layer, one for the inner odd term), one application of
+`fib_two_mul_add_two` for the inner even term, and `ring` to expand.
+-/
+
+namespace FibonacciIdentitiesOQ03OQ01
+
+/-- **Outer doubling layer.** Applying the odd fast-doubling identity at index
+`2n+1` expresses `fib (4n+3)` as the sum of the two squares `fib (2n+2)²` and
+`fib (2n+1)²`.  This is the `4n+3` companion of `Nat.fib_two_mul_add_one`. -/
+theorem fib_four_mul_add_three (n : ℕ) :
+    Nat.fib (4 * n + 3) = Nat.fib (2 * n + 2) ^ 2 + Nat.fib (2 * n + 1) ^ 2 := by
+  have h : Nat.fib (2 * (2 * n + 1) + 1)
+      = Nat.fib ((2 * n + 1) + 1) ^ 2 + Nat.fib (2 * n + 1) ^ 2 :=
+    Nat.fib_two_mul_add_one (2 * n + 1)
+  have hidx : 2 * (2 * n + 1) + 1 = 4 * n + 3 := by ring
+  have hidx2 : (2 * n + 1) + 1 = 2 * n + 2 := by ring
+  rw [hidx, hidx2] at h
+  exact h
+
+/-- **Iterated form.** Substituting the parent doubling identities for the inner
+`fib (2n+1)` and `fib (2n+2)` re-expresses `fib (4n+3)` as a sum of two squares
+in the two consecutive base values `fib n` and `fib (n+1)` alone:
+
+`fib (4n+3) = (fib (n+1)·(2·fib n + fib (n+1)))² + (fib (n+1)² + fib n²)²`. -/
+theorem fib_four_mul_add_three_iterated (n : ℕ) :
+    Nat.fib (4 * n + 3)
+      = (Nat.fib (n + 1) * (2 * Nat.fib n + Nat.fib (n + 1))) ^ 2
+        + (Nat.fib (n + 1) ^ 2 + Nat.fib n ^ 2) ^ 2 := by
+  rw [fib_four_mul_add_three, Nat.fib_two_mul_add_two, Nat.fib_two_mul_add_one]
+
+/-- **Existential reading.** Every Fibonacci number at index `4n+3` is a sum of
+two squares, exhibited with explicit low-index witnesses. -/
+theorem fib_four_mul_add_three_isSumSq (n : ℕ) :
+    ∃ a b : ℕ, Nat.fib (4 * n + 3) = a ^ 2 + b ^ 2 :=
+  ⟨Nat.fib (n + 1) * (2 * Nat.fib n + Nat.fib (n + 1)),
+   Nat.fib (n + 1) ^ 2 + Nat.fib n ^ 2,
+   fib_four_mul_add_three_iterated n⟩
+
+/-- **Integer form** of the iterated decomposition, making the two squares literal
+over `ℤ` (the `ℕ` statement already involves no subtraction, but the `ℤ` version
+is convenient for downstream algebra). -/
+theorem fib_four_mul_add_three_iterated_int (n : ℕ) :
+    (Nat.fib (4 * n + 3) : ℤ)
+      = ((Nat.fib (n + 1) : ℤ) * (2 * Nat.fib n + Nat.fib (n + 1))) ^ 2
+        + ((Nat.fib (n + 1) : ℤ) ^ 2 + (Nat.fib n : ℤ) ^ 2) ^ 2 := by
+  exact_mod_cast fib_four_mul_add_three_iterated n
+
+/-- Sanity checks against directly computed Fibonacci values. -/
+example : Nat.fib 3 = 2 := by decide          -- n = 0 : 4·0+3 = 3
+example : Nat.fib 7 = 13 := by decide          -- n = 1 : 4·1+3 = 7
+example : Nat.fib 11 = 89 := by decide         -- n = 2 : 4·2+3 = 11
+
+end FibonacciIdentitiesOQ03OQ01

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-01/annotations.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "ann-fiboq0301-1",
+    "proofId": "fibonacci-identities-oq-03-oq-01",
+    "range": { "startLine": 3, "endLine": 33 },
+    "type": "context",
+    "title": "Iterating the Doubling to Reach 4n+3",
+    "content": "**Module framing.** The parent entry records the odd fast-doubling identity $F_{2n+1} = F_{n+1}^2 + F_n^2$ (a sum of two squares) and the even one $F_{2n+2} = F_{n+1}(2F_n + F_{n+1})$ (product form). This entry **iterates the doubling**: writing $4n+3 = 2(2n+1)+1$, the odd-doubling identity applied at index $2n+1$ gives $F_{4n+3} = F_{2n+2}^2 + F_{2n+1}^2$, and substituting the parent identities for the inner terms yields a closed sum of two squares in the base values $F_n, F_{n+1}$. This answers the parent's first open question."
+  },
+  {
+    "id": "ann-fiboq0301-2",
+    "proofId": "fibonacci-identities-oq-03-oq-01",
+    "range": { "startLine": 38, "endLine": 46 },
+    "type": "key-step",
+    "title": "Outer Layer: F(4n+3) = F(2n+2)² + F(2n+1)²",
+    "content": "**The only doubling ingredient.** Applying `Nat.fib_two_mul_add_one` at index $2n+1$ turns $F_{2(2n+1)+1}$ into $F_{(2n+1)+1}^2 + F_{2n+1}^2$. The two index identities $2(2n+1)+1 = 4n+3$ and $(2n+1)+1 = 2n+2$ are pure arithmetic, discharged by `ring` and rewritten into the matched form. The even term $F_{2n+2}$ appears only as the base of an outer square, so no difference-of-squares step is needed and the result stays an honest sum of two squares — unlike the parent's even identity it never leaves $\\mathbb{N}$."
+  },
+  {
+    "id": "ann-fiboq0301-3",
+    "proofId": "fibonacci-identities-oq-03-oq-01",
+    "range": { "startLine": 53, "endLine": 57 },
+    "type": "key-step",
+    "title": "Inner Layer: Closed Form in F(n), F(n+1)",
+    "content": "**Substitute and you are done.** A single `rw` chain replaces $F_{2n+2}$ by `Nat.fib_two_mul_add_two` ($= F_{n+1}(2F_n+F_{n+1})$) and $F_{2n+1}$ by `Nat.fib_two_mul_add_one` ($= F_{n+1}^2+F_n^2$), giving $F_{4n+3} = (F_{n+1}(2F_n+F_{n+1}))^2 + (F_{n+1}^2+F_n^2)^2$. With $a = F_n$, $b = F_{n+1}$ this is $(b(2a+b))^2 + (b^2+a^2)^2$ — a fully explicit sum of two squares, not merely an existence claim."
+  },
+  {
+    "id": "ann-fiboq0301-4",
+    "proofId": "fibonacci-identities-oq-03-oq-01",
+    "range": { "startLine": 61, "endLine": 74 },
+    "type": "key-step",
+    "title": "Existential and Integer Forms",
+    "content": "**Packaging.** `fib_four_mul_add_three_isSumSq` gives $\\exists a\\,b,\\ F_{4n+3} = a^2 + b^2$ over $\\mathbb{N}$ with the explicit witnesses; `fib_four_mul_add_three_iterated_int` casts the decomposition to $\\mathbb{Z}$. The three `decide` checks that follow ($F_3=2$, $F_7=13$, $F_{11}=89$) confirm the $n=0,1,2$ instances by kernel reduction — `decide`, not `native_decide`, so no `Lean.ofReduceBool` and the entry stays 0-axiom."
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-01/index.ts
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FibonacciIdentitiesOQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fibonacciIdentitiesOQ03OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fibonacciIdentitiesOQ03OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const fibonacciIdentitiesOQ03OQ01Data: ProofData = {
+  proof: fibonacciIdentitiesOQ03OQ01Proof,
+  annotations: fibonacciIdentitiesOQ03OQ01Annotations,
+}

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-01/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-01/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "fibonacci-identities-oq-03-oq-01",
+  "title": "Fibonacci Numbers at Index 4n+3 as a Sum of Two Squares (Iterated Doubling)",
+  "slug": "fibonacci-identities-oq-03-oq-01",
+  "description": "The parent entry records the two halves of the fast-doubling identities: fib(2n+1) = fib(n+1)² + fib n² (odd → sum of two squares) and fib(2n+2) = fib(n+1)·(2·fib n + fib(n+1)) (even, product form). This entry iterates the doubling once more. Writing 4n+3 = 2·(2n+1)+1, the odd-doubling identity applied at index 2n+1 gives the outer layer fib(4n+3) = fib(2n+2)² + fib(2n+1)², an honest sum of two squares. Substituting the two parent identities for the inner fib(2n+1) and fib(2n+2) re-expresses fib(4n+3) entirely in terms of the two consecutive base values a = fib n, b = fib(n+1): fib(4n+3) = (b·(2a+b))² + (b²+a²)². This is a genuine sum-of-two-squares decomposition with explicit low-index terms, the content the open question asks for. Everything is over ℕ with no truncated subtraction, so the existential sum-of-two-squares reading holds without casting to ℤ. The proof is elementary: two applications of Mathlib's fib_two_mul_add_one (one to peel the outer layer, one for the inner odd term), one application of fib_two_mul_add_two for the inner even term, and ring to expand.",
+  "meta": {
+    "author": "Classical (fast-doubling Fibonacci identities); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Fibonacci_sequence#Identities",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "sum-of-squares",
+      "doubling-identity",
+      "integer-sequences",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ03OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_two_mul_add_one",
+        "description": "fib (2 * n + 1) = fib (n + 1) ^ 2 + fib n ^ 2 — the odd fast-doubling identity, applied at index 2n+1 to peel the outer layer fib(4n+3) = fib(2n+2)² + fib(2n+1)², and again at index n to expand the inner odd term",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_two_mul_add_two",
+        "description": "fib (2 * n + 2) = fib (n + 1) * (2 * fib n + fib (n + 1)) — the even fast-doubling identity in product form, substituted for the inner even term fib(2n+2)",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fib_four_mul_add_three: ∀ n : ℕ, fib (4n+3) = fib (2n+2) ^ 2 + fib (2n+1) ^ 2 — the outer doubling layer, the 4n+3 companion of Nat.fib_two_mul_add_one, expressing fib(4n+3) as a sum of two squares",
+      "fib_four_mul_add_three_iterated: ∀ n : ℕ, fib (4n+3) = (fib (n+1)·(2·fib n + fib (n+1))) ^ 2 + (fib (n+1) ^ 2 + fib n ^ 2) ^ 2 — the iterated form, re-expressing fib(4n+3) as a sum of two squares in the two consecutive base values fib n, fib(n+1) alone",
+      "fib_four_mul_add_three_isSumSq: ∀ n : ℕ, ∃ a b, fib (4n+3) = a ^ 2 + b ^ 2 — the existential sum-of-two-squares reading, with explicit low-index witnesses",
+      "fib_four_mul_add_three_iterated_int: the iterated decomposition over ℤ, making the two squares literal for downstream algebra"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 81,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext/Classical.choice/Quot.sound). The three numerical sanity checks use decide (kernel reduction, no native_decide / Lean.ofReduceBool).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The fast-doubling identities fib(2n) = fib(n)·(2·fib(n+1) − fib(n)), fib(2n+1) = fib(n+1)² + fib(n)², and fib(2n+2) = fib(n+1)·(2·fib(n) + fib(n+1)) compute one Fibonacci number at a doubled index from two Fibonacci squares, and underlie the O(log n) fast-doubling algorithm. The odd identity is a classical sum-of-two-squares statement. Applying it twice — once to reach index 4n+3, once to the inner odd term — yields a closed sum-of-two-squares form in the two base values fib(n), fib(n+1), the iterate-the-doubling phenomenon flagged as an open question by the parent entry.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-03 → oq-01)**: Combine the sum and difference identities to express fib(2n+1)·fib(2n+2) or fib(4n+3) as a sum of squares, iterating the doubling.\n\n**Result**: fib_four_mul_add_three (the outer layer fib(4n+3) = fib(2n+2)² + fib(2n+1)²), fib_four_mul_add_three_iterated (the closed form in fib n, fib(n+1)), the existential corollary fib_four_mul_add_three_isSumSq, and an ℤ version fib_four_mul_add_three_iterated_int.",
+    "text": "For every n, the Fibonacci number at index 4n+3 is a sum of two squares: directly fib(4n+3) = fib(2n+2)² + fib(2n+1)², and — substituting the parent doubling identities for the inner terms — fib(4n+3) = (fib(n+1)·(2·fib(n)+fib(n+1)))² + (fib(n+1)²+fib(n)²)², a sum of two squares with explicit low-index terms. The whole computation stays inside ℕ.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Outer layer.** Write 4n+3 = 2·(2n+1)+1 and apply Mathlib's Nat.fib_two_mul_add_one at index 2n+1. This gives fib(4n+3) = fib((2n+1)+1)² + fib(2n+1)² = fib(2n+2)² + fib(2n+1)². The two index rewrites 2·(2n+1)+1 = 4n+3 and (2n+1)+1 = 2n+2 are discharged by ring.\n2. **Inner layer.** Substitute the parent identities for the two inner terms: Nat.fib_two_mul_add_two gives fib(2n+2) = fib(n+1)·(2·fib(n)+fib(n+1)), and Nat.fib_two_mul_add_one (at index n) gives fib(2n+1) = fib(n+1)²+fib(n)². A single rw chain rewrites fib(4n+3) into the iterated form.\n3. **Existential / integer forms.** The existential reading instantiates a = fib(n+1)·(2·fib(n)+fib(n+1)), b = fib(n+1)²+fib(n)². The ℤ form follows by exact_mod_cast from the ℕ identity.\n4. Three decide checks (fib 3 = 2, fib 7 = 13, fib 11 = 89) confirm the n = 0, 1, 2 instances numerically."
+    ,
+    "keyInsights": [
+      "**Doubling twice stays a sum of two squares.** The odd fast-doubling identity is the only ingredient: applied at index 2n+1 it turns fib(4n+3) into fib(2n+2)² + fib(2n+1)², and the inner odd term fib(2n+1) is itself a sum of two squares. The even term fib(2n+2) enters only as the base of one of the two outer squares, so no difference-of-squares step is needed and the result stays a clean two-square sum.",
+      "**Closed form in two base values.** After substitution everything is a polynomial in a = fib(n) and b = fib(n+1): fib(4n+3) = (b(2a+b))² + (b²+a²)². The decomposition is fully explicit, not merely existential.",
+      "**No truncated subtraction.** Unlike the even difference-of-squares identity of the parent (which needs ℤ to be literal), the 4n+3 form is an honest sum, so it lives in ℕ and the existential ∃ a b, fib(4n+3) = a²+b² holds over ℕ directly.",
+      "**Answers the parent's open question.** The parent (fibonacci-identities-oq-03) explicitly asks to iterate the doubling to write fib(4n+3) as a sum of squares; this entry supplies exactly that, in named, iterated, existential, and integer forms."
+    ],
+    "prerequisites": [
+      "The fast-doubling Fibonacci identities Nat.fib_two_mul_add_one and Nat.fib_two_mul_add_two",
+      "The ring tactic for index normalization and polynomial expansion",
+      "exact_mod_cast for the ℕ→ℤ transfer"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Module docstring explaining the iterated-doubling strategy: 4n+3 = 2·(2n+1)+1 peels an outer odd-doubling layer, and substituting the parent identities for the inner terms gives a closed sum-of-two-squares form in fib n, fib(n+1).",
+      "mathContext": "$F_{4n+3} = F_{2n+2}^2 + F_{2n+1}^2 = (F_{n+1}(2F_n+F_{n+1}))^2 + (F_{n+1}^2+F_n^2)^2$."
+    },
+    {
+      "id": "outer",
+      "title": "Outer Doubling Layer",
+      "startLine": 35,
+      "endLine": 46,
+      "summary": "fib_four_mul_add_three: applying Nat.fib_two_mul_add_one at index 2n+1 (with ring index rewrites) gives fib(4n+3) = fib(2n+2)² + fib(2n+1)², the 4n+3 companion of the odd-doubling identity.",
+      "mathContext": "$F_{4n+3} = F_{2n+2}^2 + F_{2n+1}^2$."
+    },
+    {
+      "id": "iterated",
+      "title": "Iterated Closed Form",
+      "startLine": 48,
+      "endLine": 57,
+      "summary": "fib_four_mul_add_three_iterated: substituting Nat.fib_two_mul_add_two and Nat.fib_two_mul_add_one for the inner terms re-expresses fib(4n+3) as a sum of two squares in fib n and fib(n+1).",
+      "mathContext": "$F_{4n+3} = (F_{n+1}(2F_n+F_{n+1}))^2 + (F_{n+1}^2+F_n^2)^2$."
+    },
+    {
+      "id": "existential-int",
+      "title": "Existential and Integer Forms",
+      "startLine": 59,
+      "endLine": 79,
+      "summary": "fib_four_mul_add_three_isSumSq (every fib(4n+3) is a sum of two squares, explicit witnesses) and fib_four_mul_add_three_iterated_int (the same decomposition over ℤ), plus decide sanity checks for n = 0, 1, 2.",
+      "mathContext": "$\\exists a\\,b,\\ F_{4n+3} = a^2 + b^2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-03",
+      "relationship": "extends",
+      "description": "Directly answers the parent's first open question — iterating the doubling to express fib(4n+3) as a sum of squares — by reusing the parent's odd sum-of-squares and even product identities"
+    },
+    {
+      "targetId": "fibonacci-identities",
+      "relationship": "complements",
+      "description": "The base Fibonacci entry records the summation identities; this entry treats the per-term iterated doubled-index sum-of-two-squares identity"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) treatment of fib(4n+3) as a sum of two squares: the outer doubling layer fib(4n+3) = fib(2n+2)² + fib(2n+1)², the iterated closed form in the base values fib n and fib(n+1), the existential corollary, and an integer version.",
+    "implications": "Answers the parent entry's open question by showing that iterating the odd fast-doubling identity keeps a doubled-index Fibonacci number a sum of two squares, with a fully explicit decomposition in the two consecutive base values.",
+    "openQuestions": [
+      "Express the analogous fib(4n+1) = fib(2n+1)² + fib(2n)² in closed form in fib n, fib(n+1); the inner even term fib(2n) requires Mathlib's Nat.fib_two_mul, whose truncated subtraction must be handled over ℤ.",
+      "Iterate further to fib(8n+7) and identify the growth pattern of the explicit witness polynomials under repeated doubling."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "FibonacciIdentitiesOQ03OQ01",
+    "lineCount": 81,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/FibonacciIdentitiesOQ03OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Vorobiev, N. N.",
+      "title": "Fibonacci Numbers",
+      "year": "2002",
+      "venue": "Birkhäuser",
+      "note": "Fast-doubling identities and sum-of-squares readings"
+    },
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Doubled-index Fibonacci identities"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the first open question of **fibonacci-identities-oq-03**: *combine the sum/difference identities to express `fib(4n+3)` as a sum of squares, iterating the doubling.*

Writing `4n+3 = 2·(2n+1)+1`, the odd fast-doubling identity (`Nat.fib_two_mul_add_one`) applied at index `2n+1` peels an outer layer:

```
fib(4n+3) = fib(2n+2)² + fib(2n+1)²
```

Substituting the parent's two doubling identities for the inner terms gives a fully explicit sum of two squares in the consecutive base values `a = fib n`, `b = fib(n+1)`:

```
fib(4n+3) = (fib(n+1)·(2·fib n + fib(n+1)))² + (fib(n+1)² + fib n²)²
          = (b(2a+b))² + (b²+a²)²
```

Only the **odd** doubling identity is needed — the even term `fib(2n+2)` enters merely as the base of an outer square, so the result stays an honest sum and never leaves ℕ (no difference-of-squares / ℤ step), unlike the parent's even identity.

## Theorems (4, 0 sorries, 0 axioms)

- `fib_four_mul_add_three` — outer layer `fib(4n+3) = fib(2n+2)² + fib(2n+1)²`
- `fib_four_mul_add_three_iterated` — closed form in `fib n`, `fib(n+1)`
- `fib_four_mul_add_three_isSumSq` — existential `∃ a b, fib(4n+3) = a²+b²` (explicit witnesses)
- `fib_four_mul_add_three_iterated_int` — ℤ form

## Verification

- `lake env lean` type-checks clean (exit 0).
- `#print axioms` on the main theorems: `[propext, Classical.choice, Quot.sound]` only — 0 axioms, no `Lean.ofReduceBool` (numerical checks use `decide`, not `native_decide`).
- Registered in `proofs/Proofs.lean` (in build graph, not orphaned).
- `pnpm annotations:build` passes for this entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)