### PR TITLE
Enrich Chebyshev–De Moivre for all integer indices n ∈ ℤ

### DIFF
--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "concept",
+    "title": "The open question: ℕ-indices to ℤ-indices",
+    "content": "The parent proved the algebraic De Moivre–Chebyshev identity `(C R n).eval(z + w) = zⁿ + wⁿ` on the unit-circle locus `z·w = 1`, but only for natural `n`. Mathlib indexes the Chebyshev polynomial of the third kind `C` over all of `ℤ` and proves the reflection symmetry `C R (-n) = C R n`, which strongly suggests the identity should close under negation. The header records the answer — YES, and the extension is *forced*: on `z·w = 1` we have `w = z⁻¹`, so the two-sided power map sends `-m` to `(zᵐ)⁻¹ = wᵐ`, and `C_{-n} = C_n` flips a negative index to a positive one. This is the discrete algebraic analogue of De Moivre's `(e^{iθ})ⁿ = e^{inθ}` holding for every `n ∈ ℤ`, not just `n ≥ 0`.",
+    "mathContext": "$(C_R\\,n)(z + z^{-1}) = z^n + (z^{-1})^n$ for every $n \\in \\mathbb{Z}$, on the locus $z\\cdot w = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev polynomials of the third kind", "De Moivre's theorem", "unit-circle locus", "reflection symmetry C_{-n}=C_n", "integer powers"],
+    "prerequisites": ["Chebyshev polynomials", "complex exponentials", "ℤ-indexed sequences"]
+  },
+  {
+    "id": "ann-imports",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 43, "endLine": 51 },
+    "type": "context",
+    "title": "Imports and opened namespaces",
+    "content": "Brings in Mathlib's Chebyshev polynomial library (`C` and the symmetry `C_neg`), the p-adic numbers `ℚ_[p]` for the specialization, `Mathlib.Tactic`, and the parent file `Proofs.DeMoivreOQ01OQ03` which supplies the natural-index engine `chebyshevC_eval_field` / `chebyshevC_eval_add`. Opening `DeMoivreChebyshevFiniteField` (the parent namespace) makes those parent lemmas available unqualified, so the integer extension is a thin layer over already-proved natural-index facts.",
+    "mathContext": "Parent engine: $(C_R\\,k)(z+w) = z^k + w^k$ for $k \\in \\mathbb{N}$, $z\\cdot w = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib.RingTheory.Polynomial.Chebyshev", "p-adic numbers", "namespace import", "dependency reuse"],
+    "prerequisites": ["Lean 4 imports", "namespaces"]
+  },
+  {
+    "id": "ann-field-int",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 60, "endLine": 83 },
+    "type": "insight",
+    "title": "The field identity for all n ∈ ℤ",
+    "content": "`chebyshevC_eval_field_int` is the headline result: in any field, for `z ≠ 0` and every integer `n`, `(C F n).eval(z + z⁻¹) = zⁿ + (z⁻¹)ⁿ` with `zⁿ` the ℤ-power (`zpow`). The proof is a clean two-case split on the sign of `n`. For `n ≥ 0`, `lift` turns `n` into a natural number and `zpow_natCast` collapses the ℤ-power to the ℕ-power, so the goal is *exactly* the parent's `chebyshevC_eval_field`. For `n < 0`, write `n = -m`; the symmetry `C_neg` rewrites `C(-m)` to `C(m)` reducing the left side to the parent's `zᵐ + (z⁻¹)ᵐ`, while `zpow_neg` folds the right side's negative powers back (`z^{-m} = (z⁻¹)ᵐ`, `(z⁻¹)^{-m} = zᵐ`), and a single `ring` matches the two. No custom induction is needed — the parent already did the order-2 recurrence over ℕ.",
+    "mathContext": "$n<0,\\ n=-m$: $C_{-m} = C_m$ gives $z^m + (z^{-1})^m$; $z^{-m} = (z^{-1})^m$, $(z^{-1})^{-m} = z^m$.",
+    "significance": "key",
+    "relatedConcepts": ["sign split", "Int.lift to ℕ", "zpow_natCast", "Polynomial.Chebyshev.C_neg", "zpow_neg"],
+    "prerequisites": ["ℤ-powers in a field", "field inverses", "case analysis on sign"]
+  },
+  {
+    "id": "ann-neg-fold",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 74, "endLine": 83 },
+    "type": "technique",
+    "title": "Folding negative powers back onto the unit circle",
+    "content": "The two helper equalities `h1 : z^(-m) = (z⁻¹)^m` and `h2 : (z⁻¹)^(-m) = z^m` are the algebraic content of \"the constraint z·w = 1 IS the symmetry.\" Each is pure `zpow` bookkeeping: `zpow_neg` turns a negative ℤ-power into the inverse of a positive one, `zpow_natCast` reconciles ℤ- and ℕ-powers, and `← inv_pow` / `inv_inv` move the inverse inside. Once both negative powers are rewritten as positive powers of the partner element, the negative-index goal becomes the positive-index parent identity up to commutativity, closed by `ring`. This is exactly why no new analytic input is needed: negation is absorbed by the unit-circle relation.",
+    "mathContext": "$z^{-m} = (z^m)^{-1} = (z^{-1})^m = w^m$, using $w = z^{-1}$ on $z\\cdot w = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["zpow_neg", "inv_pow", "inv_inv", "unit-circle relation", "exponent laws"],
+    "prerequisites": ["laws of exponents", "multiplicative inverses"]
+  },
+  {
+    "id": "ann-units-int",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 92, "endLine": 118 },
+    "type": "insight",
+    "title": "The units form: sharper than the field form",
+    "content": "`chebyshevC_eval_units_int` is the strongest statement: over an *arbitrary* commutative ring `R`, for a unit `z : Rˣ` and every integer `n`, `(C R n).eval(↑z + ↑z⁻¹) = ↑(zⁿ) + ↑(z⁻ⁿ)`, where `zⁿ : Rˣ` is the genuine ℤ-power in the unit group. It needs no division and no field — the field statement is just its image under `Units.val`. The proof mirrors the field case (same sign split, same `C_neg` flip) but transports each ℤ-power from the unit group to the ambient ring via `Units.val_pow_eq_pow_val`, and feeds the parent's general `chebyshevC_eval_add` the hypothesis `z.mul_inv : ↑z · ↑z⁻¹ = 1`. Working in `Rˣ` makes `z⁻¹` a literal group inverse, so the unit-circle constraint holds by definition rather than as an added hypothesis.",
+    "mathContext": "$z \\in R^\\times,\\ z^n \\in R^\\times$ the genuine $\\mathbb{Z}$-power; $\\uparrow(z^n) = (\\uparrow z)^n$ via `Units.val_pow_eq_pow_val`.",
+    "significance": "key",
+    "relatedConcepts": ["group of units Rˣ", "Units.val_pow_eq_pow_val", "division-free generality", "ℤ-power in a group", "Units.mul_inv"],
+    "prerequisites": ["units of a ring", "group ℤ-powers", "ring homomorphisms"]
+  },
+  {
+    "id": "ann-specializations",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 125, "endLine": 137 },
+    "type": "technique",
+    "title": "Finite-field and p-adic specializations",
+    "content": "`chebyshevC_eval_zmod_int` (over `ZMod p`) and `chebyshevC_eval_padic_int` (over `ℚ_[p]`) are one-line corollaries — literally `chebyshevC_eval_field_int z hz n` — since both `ZMod p` (for prime `p`) and `ℚ_[p]` are fields. This is the payoff of stating the headline result over an arbitrary field: the cryptographically relevant finite-field case and the number-theoretically relevant p-adic case come for free, now covering negative exponents (inverse exponentiation) uniformly.",
+    "mathContext": "$(C_{\\mathbb{F}_p}\\,n)(z+z^{-1}) = z^n + (z^{-1})^n$ and the same over $\\mathbb{Q}_p$, all $n\\in\\mathbb{Z}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ZMod p as a field", "p-adic numbers", "Chebyshev maps in cryptography", "free specialization"],
+    "prerequisites": ["finite fields", "p-adic numbers", "Fact (Nat.Prime p)"]
+  },
+  {
+    "id": "ann-checks",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 139, "endLine": 163 },
+    "type": "context",
+    "title": "Negative-index consistency checks",
+    "content": "Two worked `example`s confirm the unit-circle reduction at concrete negative indices. Over `ℝ` with `n = -1`: since `C(-1) = X`, evaluation at `z + z⁻¹` returns `z + z⁻¹`, matching `z⁻¹ + z`. Over `ZMod 7` with `n = -2`: `3⁻¹ = 5`, so `3 + 3⁻¹ = 1` and `C(-2)(1) = 1² - 2 = -1 = 6`, matching `3⁻² + (3⁻¹)⁻² = 5² + 3² = 4 + 2 = 6`. The file-local `private instance : Fact (Nat.Prime 7)` makes the field structure on `ZMod 7` a *closed* instance, keeping the `decide` proof of `3 ≠ 0` kernel-reducible (and hence axiom-free — no `native_decide`).",
+    "mathContext": "$\\mathbb{F}_7$, $n=-2$: $C_{-2}(1) = -1 = 6 = 3^{-2} + (3^{-1})^{-2}$.",
+    "significance": "context",
+    "relatedConcepts": ["worked examples", "kernel decide vs native_decide", "Fact instances", "concrete verification"],
+    "prerequisites": ["modular arithmetic", "Lean decide tactic"]
+  },
+  {
+    "id": "ann-verification",
+    "proofId": "de-moivre-oq-01-oq-03-oq-01",
+    "range": { "startLine": 165, "endLine": 175 },
+    "type": "context",
+    "title": "Verification and axiom status",
+    "content": "The closing `#check` block lists the four exported theorems. The entry is honestly badged `original` / `verified` with `axiomCount: 0`: 0 sorries, 0 `axiom` declarations, and no `native_decide` (the numeric checks use kernel `decide`, which depends on no extra axioms). All theorems depend only on the foundational `propext` / `Classical.choice` / `Quot.sound`. The single genuinely new mathematical ingredient beyond the parent is `Polynomial.Chebyshev.C_neg`; everything else is `zpow` bookkeeping.",
+    "mathContext": "Axioms: $\\{\\text{propext},\\ \\text{Classical.choice},\\ \\text{Quot.sound}\\}$ only; no $\\text{ofReduceBool}$.",
+    "significance": "context",
+    "relatedConcepts": ["axiom integrity", "#print axioms", "machine verification", "kernel decide"],
+    "prerequisites": ["Lean type theory", "trusted kernel"]
+  }
+]

--- a/src/data/proofs/de-moivre-oq-01-oq-03-oq-01/index.ts
+++ b/src/data/proofs/de-moivre-oq-01-oq-03-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DeMoivreOQ01OQ03OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const deMoivreOq01Oq03Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const deMoivreOq01Oq03Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const deMoivreOq01Oq03Oq01Data: ProofData = {
+  proof: deMoivreOq01Oq03Oq01Proof,
+  annotations: deMoivreOq01Oq03Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `de-moivre-oq-01-oq-03-oq-01` (quality 43, pass 0).

## What changed
- **Created missing `index.ts`** — the entry had only `meta.json`, so the proof page rendered "proof not found" on the live site despite appearing in the gallery listing. The page is now reachable.
- **Added `annotations.json`** — 8 annotations spanning the full 175-line Lean file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
  - the open question (ℕ-indices ⟶ ℤ-indices) and the dependency imports
  - `chebyshevC_eval_field_int`: the field identity for all `n ∈ ℤ` via a sign split, with the negative-power fold (`zpow_neg`, `C_neg`) isolated as its own annotation
  - `chebyshevC_eval_units_int`: the division-free units form over an arbitrary commutative ring (sharper than the field form)
  - the finite-field / p-adic free specializations
  - the negative-index consistency checks (`n=-1` over ℝ, `n=-2` over `ZMod 7`), noting kernel `decide` vs `native_decide`
  - the axiom-status annotation confirming `original`/`verified`, `axiomCount: 0`

## Verification
- `pnpm build` passes (JSON validated, site builds clean).
- Axiom/status fields in `meta.json` checked against the Lean source — accurate (only propext/Classical.choice/Quot.sound; the numeric checks use kernel `decide`, not `native_decide`).

No changes to mathematical claims; existing `meta.json` content preserved.