### PR TITLE
Enrich The Equality Case of Lyapunov's Inequality (jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01)

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 43 },
+    "type": "context",
+    "title": "The Equality Case of Lyapunov's Inequality",
+    "content": "The parent JensenInequalityOQ01OQ01OQ01OQ01OQ01 proves Lyapunov's inequality: the weighted moment function A(t) = ∑ᵢ wᵢ·xᵢᵗ of a strictly positive family is log-convex, i.e. A(a·p+b·r) ≤ A(p)ᵃ·A(r)ᵇ for convex weights a, b > 0, a+b = 1. This file pins down the EQUALITY case: for distinct exponents p ≠ r, equality holds iff the data x is constant. Geometrically, the moment curve t ↦ log A(t) is STRICTLY convex off the degenerate locus where all xᵢ coincide (there A(t) = (∑wᵢ)·cᵗ is genuinely log-affine and every chord touches the curve). It imports two gallery entries: the parent (for the moment function and the inequality moment_interp_le) and the grandparent two-variable Young entry (for the AM–GM equality case).",
+    "mathContext": "$A(ap+br) = A(p)^a A(r)^b \\iff \\forall i\\,j,\\ x_i = x_j$ for $p\\ne r$, $a,b>0$, $a+b=1$.",
+    "significance": "context",
+    "relatedConcepts": ["Lyapunov inequality", "log-convexity", "equality case", "moment function", "strict convexity"],
+    "prerequisites": ["convexity", "power means", "AM–GM inequality"]
+  },
+  {
+    "id": "ann-abstract-core",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 53, "endLine": 80 },
+    "type": "insight",
+    "title": "normalized_amgm_sum_eq_one_iff: The Reusable Rigidity Core",
+    "content": "The abstract engine, isolated from all moment/rpow bookkeeping: for nonnegative probability vectors u, v (∑u = ∑v = 1) and convex weights a, b > 0, a+b = 1, the weighted geometric average ∑ᵢ uᵢᵃ·vᵢᵇ equals 1 IFF uᵢ = vᵢ for every i. The pointwise two-variable AM–GM uᵢᵃvᵢᵇ ≤ a·uᵢ + b·vᵢ (Real.geom_mean_le_arith_mean2_weighted) sums to ≤ 1 (the convex combination of two probability vectors is again a probability vector, hgsum). The crux: a sum of ≤'s is an equality iff it is termwise an equality (Finset.sum_eq_sum_iff_of_le), and each term is resolved by the grandparent's amgm_two_weighted_eq_iff. This lemma is a reusable template for the equality case of ANY inequality obtained by summing pointwise weighted AM–GM (discrete Hölder, Minkowski).",
+    "mathContext": "$\\sum_i u_i^a v_i^b = 1 \\iff \\forall i,\\ u_i = v_i$, given $\\sum u = \\sum v = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_eq_sum_iff_of_le", "amgm_two_weighted_eq_iff", "Real.geom_mean_le_arith_mean2_weighted", "probability vector"],
+    "prerequisites": ["AM–GM inequality", "finite sums", "convex combinations"]
+  },
+  {
+    "id": "ann-equality-forward",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 82, "endLine": 147 },
+    "type": "theorem",
+    "title": "moment_interp_eq_iff (Forward): Equality Forces Constant Data",
+    "content": "moment_interp_eq_iff is the main result: A(a·p+b·r) = A(p)ᵃ·A(r)ᵇ ↔ x constant, for p ≠ r. The forward direction normalises the two moment families to probability vectors Sᵢ = wᵢ·xᵢᵖ/A(p) and Tᵢ = wᵢ·xᵢʳ/A(r) (hSsum, hTsum sum to 1 by div_self). The pointwise interpolation identity (wxᵖ)ᵃ(wxʳ)ᵇ = w·x^{ap+br} (lemma term, via Real.mul_rpow and Real.rpow_add with a+b = 1) makes ∑ SᵢᵃTᵢᵇ = A(a·p+b·r)/(A(p)ᵃA(r)ᵇ), which equals 1 exactly under the hypothesised equality (hsum1). The core lemma then gives Sᵢ = Tᵢ for all i; unwinding (cancel wᵢ > 0 and the positive normalisers, mul_left_cancel₀) yields xᵢᵖ·A(r) = xᵢʳ·A(p), i.e. xᵢ^{p-r} = A(p)/A(r) is the SAME constant for every i. For p ≠ r the base injectivity Real.rpow_left_inj (with exponent p−r ≠ 0) forces xᵢ = xⱼ.",
+    "mathContext": "$S_i = T_i \\iff x_i^{p-r} = \\tfrac{A(p)}{A(r)}$ independent of $i$; injectivity of $t\\mapsto t^{p-r}$ ($p\\ne r$) gives $x_i = x_j$.",
+    "significance": "key",
+    "relatedConcepts": ["probability vector normalisation", "Real.rpow_left_inj", "interpolation identity", "mul_left_cancel₀"],
+    "prerequisites": ["real exponentiation", "moment function", "injectivity"]
+  },
+  {
+    "id": "ann-equality-backward",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 148, "endLine": 164 },
+    "type": "technique",
+    "title": "moment_interp_eq_iff (Backward): Constant Data Saturates",
+    "content": "The converse is a direct computation: if x is constant (xᵢ = x_{i0} for all i, using Nonempty ι to pick a witness i0), then A(t) = (∑ wᵢ)·x_{i0}ᵗ (hmoment, by factoring the constant power out of the sum). Both sides of the interpolation identity then collapse to (∑wᵢ)·x_{i0}^{ap+br} via the same Real.mul_rpow / Real.rpow_add / a+b = 1 manipulation as the forward term lemma. So on the degenerate (single-value) locus the moment function is exactly log-affine and Lyapunov's inequality is an equality.",
+    "mathContext": "$x$ constant $\\Rightarrow A(t) = (\\sum_i w_i)\\,c^t$; both sides $= (\\sum_i w_i)\\,c^{ap+br}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["log-affine", "Real.rpow_add", "degenerate locus", "Finset.sum_mul"],
+    "prerequisites": ["real exponentiation", "finite sums"]
+  },
+  {
+    "id": "ann-strict",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 165, "endLine": 176 },
+    "type": "technique",
+    "title": "moment_interp_lt_of_not_const: Strict Inequality off the Locus",
+    "content": "moment_interp_lt_of_not_const: when x is non-constant (∃ i j, xᵢ ≠ xⱼ), Lyapunov's inequality is STRICT, A(a·p+b·r) < A(p)ᵃ·A(r)ᵇ. The proof splits the parent's ≤ (moment_interp_le) into < or =; the equality branch is impossible because moment_interp_eq_iff would force x constant, contradicting hne (absurd). This is exactly the statement that t ↦ log A(t) is strictly convex away from the single-point locus.",
+    "mathContext": "$x$ non-constant $\\Rightarrow A(ap+br) < A(p)^a A(r)^b$ — strict log-convexity.",
+    "significance": "supporting",
+    "relatedConcepts": ["lt_of_le_of_ne", "strict convexity", "moment_interp_le"],
+    "prerequisites": ["Lyapunov inequality", "order trichotomy"]
+  },
+  {
+    "id": "ann-symmetric",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
+    "range": { "startLine": 178, "endLine": 211 },
+    "type": "theorem",
+    "title": "moment_lyapunov_eq_iff: The Symmetric Three-Exponent Equality",
+    "content": "moment_lyapunov_eq_iff: for p < q < r, the symmetric form A(q)^{r-p} = A(p)^{r-q}·A(r)^{q-p} holds iff x is constant. The exponents are chosen a = (r−q)/(r−p), b = (q−p)/(r−p) so that a, b > 0, a+b = 1 (hab) and a·p+b·r = q (hq_eq) — placing q as the convex interpolant of p and r. Then a(r−p) = r−q and b(r−p) = q−p (hexp1, hexp2) convert the two-exponent equality moment_interp_eq_iff at q into the symmetric three-exponent equality by raising both sides to the positive power r−p, with injectivity Real.rpow_left_inj (exponent r−p > 0) closing the loop. This is the standard symmetric statement of Lyapunov rigidity.",
+    "mathContext": "$a = \\tfrac{r-q}{r-p},\\ b = \\tfrac{q-p}{r-p}$, $ap+br = q$; $A(q)^{r-p} = A(p)^{r-q}A(r)^{q-p} \\iff x$ constant.",
+    "significance": "key",
+    "relatedConcepts": ["three-exponent form", "Real.rpow_left_inj", "convex interpolant", "log-convexity"],
+    "prerequisites": ["real exponentiation", "moment function", "injectivity"]
+  }
+]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const jensenInequalityOq01Oq01Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const jensenInequalityOq01Oq01Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const jensenInequalityOq01Oq01Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: jensenInequalityOq01Oq01Oq01Oq01Oq01Oq01Proof,
+  annotations: jensenInequalityOq01Oq01Oq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01`.

## What was missing
This entry had a rich, complete `meta.json` (with top-level `description`) but was **missing both `index.ts` and `annotations.json`**. Without `index.ts` the proof page renders 'proof not found' on the live site.

## Changes
- **Added `index.ts`** (Vite entry point) wiring meta + annotations + Lean source for `Proofs/JensenInequalityOQ01OQ01OQ01OQ01OQ01OQ01.lean`.
- **Added `annotations.json`** — 6 substantive annotations covering the whole file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - module header / equality case of Lyapunov's inequality
  - `normalized_amgm_sum_eq_one_iff` (the reusable rigidity core: summed AM–GM = equality iff termwise)
  - `moment_interp_eq_iff` forward (probability-vector normalisation → xᵢ^{p-r} constant → Real.rpow_left_inj)
  - `moment_interp_eq_iff` backward (constant data ⇒ log-affine moment, both sides collapse)
  - `moment_interp_lt_of_not_const` (strict log-convexity off the locus)
  - `moment_lyapunov_eq_iff` (symmetric three-exponent form via a=(r−q)/(r−p))

## Verification
- JSON validates; the `pnpm build` annotation validator reports no error for this entry. `tsc` cannot run in this fresh worktree (no `node_modules`), but `index.ts` follows the exact proven sibling pattern.
- Axiom integrity preserved: meta states 0 axioms / verified, consistent with the Lean file (depends only on propext/Classical.choice/Quot.sound, no native_decide).