### PR TITLE
Enrich The Equality Case of the Power Mean Inequality (jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01)

### DIFF
--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 49 },
+    "type": "context",
+    "title": "Sharpening Power-Mean Monotonicity into an Equality Criterion",
+    "content": "The parent (AmgmInequalityOQ03's power_mean_monotone_pos) shows the weighted power mean M_p = (∑ wᵢzᵢᵖ)^{1/p} is a non-decreasing function of p, but leaves open WHEN the inequality is strict. This file answers the classical sharpness question (Hardy–Littlewood–Pólya, Inequalities, 1934): for 0 < r < t, with strictly positive weights summing to 1 and strictly positive data, M_r = M_t ↔ all data zᵢ are equal — equivalently M_r < M_t unless the data is constant. The single engine is the equality case of strict Jensen (jensen_eq_iff, from JensenInequalityOQ01) applied to the strictly convex map x ↦ x^{t/r}.",
+    "mathContext": "$M_r = M_t \\iff \\forall j\\,k,\\ z_j = z_k$ for $0<r<t$; equivalently $M_r < M_t$ off the constant diagonal.",
+    "significance": "context",
+    "relatedConcepts": ["power mean inequality", "Jensen's inequality", "equality case", "strict convexity", "QM–AM inequality"],
+    "prerequisites": ["convexity", "power means", "weighted means"]
+  },
+  {
+    "id": "ann-wsum-pos",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "range": { "startLine": 57, "endLine": 71 },
+    "type": "technique",
+    "title": "wsum_pos: Strict Positivity of the Weighted Power-Sum",
+    "content": "wsum_pos: the weighted power-sum ∑ wᵢzᵢᵖ is strictly positive when the weights are nonnegative and sum to 1 and the data is strictly positive. Since the weights sum to 1 they cannot all be zero, so some w_{i₀} > 0 (by_contra + Finset.sum_eq_zero); that single strictly positive term mul_pos (w_{i₀}·z_{i₀}ᵖ > 0) is dominated by the whole nonnegative sum (Finset.single_le_sum). This guarantees the bases A = ∑wᵢzᵢʳ and B = ∑wᵢzᵢᵗ are positive, so the rpow exponent manipulations and injectivity lemmas downstream are valid.",
+    "mathContext": "$\\sum_i w_i z_i^p > 0$ when $w\\ge0$, $\\sum w = 1$, $z > 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.single_le_sum", "Real.rpow_pos_of_pos", "positivity"],
+    "prerequisites": ["finite sums", "real exponentiation"]
+  },
+  {
+    "id": "ann-jensen-engine",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "range": { "startLine": 73, "endLine": 107 },
+    "type": "insight",
+    "title": "The Engine: Strict Jensen for x ↦ x^{t/r} on the Powered Data",
+    "content": "The heart of power_mean_eq_iff_pos. The strictly convex map is x ↦ x^{t/r}, strictly convex on [0,∞) precisely because t/r > 1 (one_lt_div + strictConvexOn_rpow) — this is exactly why the equality criterion needs r < t STRICTLY. Feeding the powered data uᵢ = zᵢʳ into jensen_eq_iff yields (∑ wᵢuᵢ)^{t/r} = ∑ wᵢuᵢ^{t/r} ↔ every uᵢ equals the weighted mean. The right summand folds back via the exponent identity (zᵢʳ)^{t/r} = zᵢ^{r·(t/r)} = zᵢᵗ (Real.rpow_mul + hrt_eq: r·(t/r) = t), so ∑ wᵢ(zᵢʳ)^{t/r} = ∑ wᵢzᵢᵗ = B (hpow).",
+    "mathContext": "$x\\mapsto x^{t/r}$ strictly convex $\\iff t/r>1\\iff r<t$; $(z_i^r)^{t/r} = z_i^{r\\cdot(t/r)} = z_i^t$.",
+    "significance": "key",
+    "relatedConcepts": ["jensen_eq_iff", "strictConvexOn_rpow", "Real.rpow_mul", "strict convexity"],
+    "prerequisites": ["convex functions", "Jensen's inequality", "real exponentiation"]
+  },
+  {
+    "id": "ann-bridge-one",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "range": { "startLine": 108, "endLine": 126 },
+    "type": "technique",
+    "title": "Bridge 1: A^{t/r} = B ⟺ M_r = M_t",
+    "content": "The first translation (eqI) converts the Jensen left-hand equality (∑ wᵢzᵢʳ)^{t/r} = ∑ wᵢzᵢᵗ into the equality of means M_r = M_t. Unfolding weightedPowerMean = (∑wᵢzᵢᵖ)^{1/p}, both directions raise the means to the common power t: (1/r)·t = t/r and (1/t)·t = 1 (one_div_mul_cancel) via Real.rpow_mul, so M_rᵗ = A^{t/r} and M_tᵗ = B. The forward direction is a rewrite; the reverse uses injectivity of x ↦ xᵗ on the nonnegatives (Real.rpow_left_inj, t ≠ 0) to recover M_r = M_t from M_rᵗ = M_tᵗ.",
+    "mathContext": "$M_r^t = \\big(\\textstyle\\sum w_i z_i^r\\big)^{t/r} = A^{t/r}$, $M_t^t = B$; inject $x\\mapsto x^t$ ($t\\ne0$).",
+    "significance": "key",
+    "relatedConcepts": ["weightedPowerMean", "Real.rpow_left_inj", "Real.rpow_mul", "injectivity"],
+    "prerequisites": ["real exponentiation", "power means"]
+  },
+  {
+    "id": "ann-bridge-two",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "range": { "startLine": 127, "endLine": 140 },
+    "type": "technique",
+    "title": "Bridge 2: 'Each zⱼʳ Equals the Mean' ⟺ All Data Equal",
+    "content": "The second translation (eqII) converts the Jensen right-hand condition (∀ j, zⱼʳ = ∑ wᵢzᵢʳ) into 'all data equal'. Forward: if every zⱼʳ equals the same mean A, then zⱼʳ = zₖʳ, and injectivity of x ↦ xʳ on the nonnegatives (Real.rpow_left_inj, r ≠ 0) gives zⱼ = zₖ. Backward: if the data is constant then ∑ wᵢzᵢʳ = (∑wᵢ)·zⱼʳ = zⱼʳ (using ∑w = 1 and Finset.sum_mul). Chaining eqI, the Jensen equivalence hJ, and eqII yields the headline M_r = M_t ↔ all zᵢ equal.",
+    "mathContext": "$\\forall j,\\ z_j^r = \\textstyle\\sum w_i z_i^r \\iff \\forall j\\,k,\\ z_j = z_k$, via injectivity of $x\\mapsto x^r$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow_left_inj", "Finset.sum_mul", "injectivity", "constant data"],
+    "prerequisites": ["real exponentiation", "finite sums"]
+  },
+  {
+    "id": "ann-strict-and-corollaries",
+    "proofId": "jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01",
+    "range": { "startLine": 142, "endLine": 176 },
+    "type": "theorem",
+    "title": "Strict Inequality and the QM–AM Corollaries",
+    "content": "power_mean_lt_of_ne: for non-constant data, M_r < M_t strictly — combine the parent's non-strict power_mean_monotone_pos with power_mean_eq_iff_pos (lt_of_le_of_ne; equality would force constant data, contradicting hne). am_eq_qm_iff and am_lt_qm_of_ne are the r = 1, t = 2 specialisations: the arithmetic mean equals (resp. is strictly below) the quadratic mean iff the data is constant (resp. for non-constant data). The strict am_lt_qm_of_ne is the sharp classical QM–AM inequality — the algebraic statement that variance is strictly positive for any non-constant family.",
+    "mathContext": "$r=1,t=2$: $\\mathrm{AM} = \\mathrm{QM} \\iff$ data constant; $\\mathrm{AM} < \\mathrm{QM}$ for non-constant data (variance $>0$).",
+    "significance": "supporting",
+    "relatedConcepts": ["QM–AM inequality", "variance positivity", "lt_of_le_of_ne", "power_mean_monotone_pos"],
+    "prerequisites": ["power means", "quadratic mean", "order trichotomy"]
+  }
+]

--- a/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/index.ts
+++ b/src/data/proofs/jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PowerMeanEqualityOQ.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const jensenInequalityOq01Oq01Oq01Oq04Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const jensenInequalityOq01Oq01Oq01Oq04Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const jensenInequalityOq01Oq01Oq01Oq04Oq01Data: ProofData = {
+  proof: jensenInequalityOq01Oq01Oq01Oq04Oq01Proof,
+  annotations: jensenInequalityOq01Oq01Oq01Oq04Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `jensen-inequality-oq-01-oq-01-oq-01-oq-04-oq-01`.

## What was missing
This entry had a rich, complete `meta.json` (with top-level `description`) but was **missing both `index.ts` and `annotations.json`**. Without `index.ts` the proof page renders 'proof not found' on the live site.

## Changes
- **Added `index.ts`** (Vite entry point) wiring meta + annotations + Lean source for `Proofs/PowerMeanEqualityOQ.lean`.
- **Added `annotations.json`** — 6 substantive annotations covering the whole file, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`:
  - module header / sharpening monotonicity into an equality criterion
  - `wsum_pos` (strict positivity of the weighted power-sum)
  - the strict-Jensen engine for x ↦ x^{t/r} on powered data (strict convexity ⟺ r < t)
  - bridge 1: A^{t/r} = B ⟺ M_r = M_t (injectivity of x↦xᵗ)
  - bridge 2: each zⱼʳ = mean ⟺ all data equal (injectivity of x↦xʳ)
  - strict inequality + QM–AM corollaries (variance positivity)

## Verification
- JSON validates; the `pnpm build` annotation validator reports no error for this entry (an initial line-range mismatch on `wsum_pos` was corrected). `tsc` cannot run in this fresh worktree (no `node_modules`), but `index.ts` follows the exact proven sibling pattern.
- Axiom integrity preserved: meta states 0 axioms / verified, consistent with the Lean file (no axioms, no native_decide).