### PR TITLE
Enrich Classification of primitive Pythagorean triples (pythagorean-triples-oq-06)

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-06/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-06/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "pythagorean-triples-oq-06",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "Euclid's Classification of Primitive Pythagorean Triples",
+    "content": "A Pythagorean triple solves x² + y² = z² in integers; it is PRIMITIVE when gcd(x,y) = 1. Euclid's classification (Elements, Book X) says every primitive triple is, up to swapping legs and signs, x = m²−n², y = 2mn, z = m²+n² for coprime integers m, n of OPPOSITE parity — and conversely every such (m,n) yields a primitive triple. Geometrically this is the genus-0 case of rational points on conics: dividing by z² turns x²+y²=z² into a rational point on the unit circle, and stereographic projection from (−1,0) parametrizes all such points by a single rational slope n/m — the source of the m, n. This file packages both directions on top of Mathlib's PythagoreanTriple.coprime_classification.",
+    "mathContext": "$x = m^2-n^2,\\ y = 2mn,\\ z = m^2+n^2$ for coprime $m,n$ of opposite parity.",
+    "significance": "context",
+    "relatedConcepts": ["Pythagorean triples", "Euclid parametrization", "stereographic projection", "rational points on conics"],
+    "prerequisites": ["number theory", "coprimality", "parity"]
+  },
+  {
+    "id": "ann-forward",
+    "proofId": "pythagorean-triples-oq-06",
+    "range": { "startLine": 29, "endLine": 40 },
+    "type": "theorem",
+    "title": "primitive_param: Every Primitive Triple is a Euclid Parametrization",
+    "content": "primitive_param (forward / exhaustiveness): every primitive Pythagorean triple with odd first leg x and positive hypotenuse z arises from coprime, opposite-parity integers m ≥ 0, n as (m²−n², 2mn, m²+n²). The proof is a direct application of Mathlib's coprime_classification' — the SHARPENED form that assumes x odd and z > 0, which fixes the leg order and signs (without those normalisations the classification only holds up to swapping legs and choosing signs). No primitive triple escapes the parametrization.",
+    "mathContext": "Primitive $(x,y,z)$, $x$ odd, $z>0$ $\\Rightarrow \\exists m,n$ coprime opposite-parity with the Euclid form.",
+    "significance": "key",
+    "relatedConcepts": ["PythagoreanTriple.coprime_classification'", "exhaustiveness", "normalization"],
+    "prerequisites": ["Pythagorean triples", "coprimality", "parity"]
+  },
+  {
+    "id": "ann-converse",
+    "proofId": "pythagorean-triples-oq-06",
+    "range": { "startLine": 42, "endLine": 53 },
+    "type": "theorem",
+    "title": "param_primitive: The Parametrization Yields a Primitive Triple",
+    "content": "param_primitive (converse / soundness): for any coprime integers m, n of opposite parity, the Euclid form (m²−n², 2mn, m²+n²) is a Pythagorean triple AND is primitive, gcd(m²−n², 2mn) = 1. It applies the .mpr direction of the biconditional coprime_classification with the explicit witness (m, n) and the trivial disjunction choices (Or.inl). The opposite-parity hypothesis is exactly what forces primitivity: if m, n shared parity, every term would be even and gcd ≥ 2.",
+    "mathContext": "Coprime opposite-parity $(m,n) \\Rightarrow (m^2-n^2, 2mn, m^2+n^2)$ is a primitive triple.",
+    "significance": "key",
+    "relatedConcepts": ["coprime_classification.mpr", "soundness", "opposite parity", "primitivity"],
+    "prerequisites": ["Pythagorean triples", "coprimality"]
+  },
+  {
+    "id": "ann-param-eq",
+    "proofId": "pythagorean-triples-oq-06",
+    "range": { "startLine": 55, "endLine": 59 },
+    "type": "technique",
+    "title": "param_eq: The Hypothesis-Free Euclid Identity",
+    "content": "param_eq: the parametrization always solves x²+y²=z², (m²−n²)² + (2mn)² = (m²+n²)², for ALL m, n with no coprimality or parity hypothesis — closed by a single ring. This isolates the purely algebraic content: coprimality and parity are needed only for primitivity and for the exhaustiveness of the parametrization, never for the equation itself.",
+    "mathContext": "$(m^2-n^2)^2 + (2mn)^2 = (m^2+n^2)^2$ — an identity in $\\mathbb{Z}[m,n]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ring", "polynomial identity", "algebraic identity"],
+    "prerequisites": ["polynomial arithmetic"]
+  },
+  {
+    "id": "ann-example",
+    "proofId": "pythagorean-triples-oq-06",
+    "range": { "startLine": 61, "endLine": 67 },
+    "type": "context",
+    "title": "triple_3_4_5: The Smallest Primitive Triple",
+    "content": "triple_3_4_5 recovers the smallest primitive Pythagorean triple (3,4,5) from the converse at m = 2, n = 1 (3 = 4−1, 4 = 2·2·1, 5 = 4+1). The side conditions — 2, 1 coprime and of opposite parity — are discharged by decide/norm_num. This is a concrete sanity check that the abstract classification is stated correctly, and (3,4,5) is the base case of the whole infinite family.",
+    "mathContext": "$m=2,\\,n=1$: $(2^2-1^2,\\ 2\\cdot2\\cdot1,\\ 2^2+1^2) = (3,4,5)$.",
+    "significance": "context",
+    "relatedConcepts": ["3-4-5 triple", "decide", "base case"],
+    "prerequisites": ["Pythagorean triples"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-06/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-06/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq06Data: ProofData = {
+  proof: pythagoreanTriplesOq06Proof,
+  annotations: pythagoreanTriplesOq06Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-06`.

## What was missing
Rich, complete `meta.json` (with top-level `description`) but **missing both `index.ts` and `annotations.json`** — so the proof page rendered 'proof not found' on the live site.

## Changes
- **Added `index.ts`** wiring meta + annotations + Lean source for `Proofs/PythagoreanTriplesOQ06.lean`.
- **Added `annotations.json`** — 5 substantive annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  - header / Euclid's classification as stereographic projection
  - `primitive_param` (forward / exhaustiveness via coprime_classification')
  - `param_primitive` (converse / soundness; opposite parity ⟺ primitivity)
  - `param_eq` (the hypothesis-free Euclid identity by ring)
  - `triple_3_4_5` (the smallest primitive triple, base case m=2,n=1)

## Verification
- JSON validates; `pnpm build` annotation validator reports no error for this entry. `tsc` cannot run in this fresh worktree (no `node_modules`); `index.ts` follows the proven sibling pattern.
- Axiom integrity preserved: meta states badge `mathlib` / 0 axioms, consistent with the Lean file (specializes Mathlib's coprime_classification, no axioms, no native_decide).