### PR TITLE
research(gram-linear-independence-iff-oq-01-oq-01): Hadamard's determinant inequality for Gram matrices [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2925,6 +2925,7 @@ import Proofs.GodelSecondIncompletenessOQ02Soundness
 import Proofs.GodelSecondIncompletenessOQ02Translate
 import Proofs.GoemansWilliamsonMaxCut
 import Proofs.GramLinearIndependenceOQ01
+import Proofs.GramLinearIndependenceOQ01OQ01
 import Proofs.GraphCore
 import Proofs.GreensTheorem
 import Proofs.GreensTheoremOQ01

--- a/proofs/Proofs/GramLinearIndependenceOQ01OQ01.lean
+++ b/proofs/Proofs/GramLinearIndependenceOQ01OQ01.lean
@@ -1,0 +1,236 @@
+import Mathlib
+
+/-!
+# Hadamard's determinant inequality for Gram matrices
+
+For a finite family of vectors `v : ι → E` in an inner product space `E` over `𝕜`
+(`ℝ` or `ℂ`) that fills the whole space (`finrank 𝕜 E = card ι`), the **Gramian**
+`det (gram 𝕜 v)` is bounded above by the product of the squared norms:
+
+* `hadamard_inequality` — **Hadamard's inequality**
+  `det (gram 𝕜 v) ≤ ∏ i, ‖v i‖²` (the determinant is a nonnegative real, compared in
+  `𝕜` via the `ComplexOrder`);
+* `re_gram_det_le_prod_norm_sq` — the same bound stated for the real part, avoiding any
+  order on `𝕜`.
+
+Geometrically the Gramian is the squared volume of the parallelepiped spanned by the
+`v i`, and Hadamard's inequality says this volume is largest, for fixed edge lengths,
+exactly when the edges are mutually orthogonal — the **equality case**:
+
+* `gram_det_of_orthogonal` — a pairwise orthogonal family attains equality
+  `det (gram 𝕜 v) = ∏ i, ⟪v i, v i⟫ = ∏ i, ‖v i‖²`;
+* `hadamard_eq_iff_orthogonal` — for a **linearly independent** family, equality holds
+  **iff** the vectors are pairwise orthogonal.
+
+The proof routes through Mathlib's Gram–Schmidt orthonormal basis
+`e := gramSchmidtOrthonormalBasis`. Writing `B` for the (upper-triangular) coordinate
+matrix `B i j = ⟪e i, v j⟫`, two facts drive everything:
+
+* `gram 𝕜 v = Bᴴ * B`  (completeness of the orthonormal basis), hence
+  `det (gram 𝕜 v) = ‖det B‖²`;
+* `det B = ∏ i, ⟪e i, v i⟫`  (Mathlib's `gramSchmidtOrthonormalBasis_det`: the matrix is
+  triangular), while Bessel's identity `‖v j‖² = ∑ i, ‖⟪e i, v j⟫‖²` forces each diagonal
+  factor `‖⟪e i, v i⟫‖² ≤ ‖v i‖²`, with equality only when the off-diagonal coordinates
+  vanish.
+
+Hadamard's inequality is absent from Mathlib (which has the Gram–Schmidt machinery but
+not this determinant bound). All results are machine-checked with no `sorry` and no extra
+axioms. This extends `gram-linear-independence-iff-oq-01`, which established positive
+(semi)definiteness and the Gramian linear-independence criterion.
+-/
+
+namespace GramLinearIndependenceOQ01OQ01
+
+open Matrix RCLike Finset Module InnerProductSpace
+open scoped ComplexOrder InnerProductSpace
+
+variable {𝕜 E ι : Type*} [RCLike 𝕜]
+variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+variable [Fintype ι] [LinearOrder ι] [LocallyFiniteOrderBot ι] [WellFoundedLT ι]
+variable [FiniteDimensional 𝕜 E]
+
+/-! ## The coordinate matrix `B i j = ⟪e i, v j⟫` -/
+
+/-- The coordinate matrix of `v` in the Gram–Schmidt orthonormal basis has entries
+`B i j = ⟪e i, v j⟫`. -/
+theorem coordMatrix_apply (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) (i j : ι) :
+    (gramSchmidtOrthonormalBasis h v).toBasis.toMatrix v i j = ⟪(gramSchmidtOrthonormalBasis h v) i, v j⟫_𝕜 := by
+  rw [Basis.toMatrix_apply, OrthonormalBasis.coe_toBasis_repr_apply,
+    OrthonormalBasis.repr_apply_apply]
+
+/-- **Key factorisation.** The Gram matrix is `Bᴴ * B`, where `B` is the coordinate
+matrix in the Gram–Schmidt orthonormal basis. This is just completeness of the basis:
+`⟪v i, v j⟫ = ∑ k, ⟪v i, e k⟫ * ⟪e k, v j⟫`. -/
+theorem gram_eq_conjTranspose_mul (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) :
+    Matrix.gram 𝕜 v = ((gramSchmidtOrthonormalBasis h v).toBasis.toMatrix v)ᴴ * (gramSchmidtOrthonormalBasis h v).toBasis.toMatrix v := by
+  ext i j
+  rw [Matrix.gram_apply, Matrix.mul_apply,
+    ← OrthonormalBasis.sum_inner_mul_inner (gramSchmidtOrthonormalBasis h v) (v i) (v j)]
+  refine Finset.sum_congr rfl fun k _ => ?_
+  rw [Matrix.conjTranspose_apply, coordMatrix_apply, coordMatrix_apply, star_def,
+    inner_conj_symm]
+
+/-! ## The determinant is `‖det B‖²` -/
+
+/-- The determinant of the coordinate matrix is the product of the diagonal inner
+products (the matrix is triangular). -/
+theorem coordMatrix_det (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) :
+    ((gramSchmidtOrthonormalBasis h v).toBasis.toMatrix v).det = ∏ i, ⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜 := by
+  rw [← Basis.det_apply, gramSchmidtOrthonormalBasis_det]
+
+/-- The Gramian equals the squared norm of the determinant of the coordinate matrix,
+which (the matrix being triangular) is `‖∏ i, ⟪e i, v i⟫‖²`. -/
+theorem gram_det_eq (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) :
+    (Matrix.gram 𝕜 v).det = ((‖∏ i, ⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 : ℝ) : 𝕜) := by
+  rw [gram_eq_conjTranspose_mul h v, Matrix.det_mul, Matrix.det_conjTranspose,
+    coordMatrix_det h v, star_def, RCLike.conj_mul]
+  push_cast
+  ring
+
+/-! ## Bessel's identity bounds each diagonal factor -/
+
+/-- Bessel: the squared diagonal coordinate is at most the squared norm,
+`‖⟪e i, v i⟫‖² ≤ ‖v i‖²`, since it is one term of the Parseval sum
+`‖v i‖² = ∑ k, ‖⟪e k, v i⟫‖²`. -/
+theorem abs_inner_sq_le_norm_sq (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) (i : ι) :
+    ‖⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 ≤ ‖v i‖ ^ 2 := by
+  rw [← OrthonormalBasis.sum_sq_norm_inner_right (gramSchmidtOrthonormalBasis h v) (v i)]
+  exact Finset.single_le_sum (f := fun k => ‖⟪(gramSchmidtOrthonormalBasis h v) k, v i⟫_𝕜‖ ^ 2)
+    (fun k _ => sq_nonneg _) (Finset.mem_univ i)
+
+/-! ## Hadamard's inequality -/
+
+/-- The real number underlying the Gramian, `‖det B‖² = ∏ i, ‖⟪e i, v i⟫‖²`, is bounded
+by the product of squared norms. This is the analytic heart of Hadamard's inequality. -/
+theorem norm_det_sq_le_prod_norm_sq (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) :
+    ‖∏ i, ⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 ≤ ∏ i, ‖v i‖ ^ 2 := by
+  rw [norm_prod, ← Finset.prod_pow]
+  exact Finset.prod_le_prod (fun i _ => sq_nonneg _)
+    (fun i _ => abs_inner_sq_le_norm_sq h v i)
+
+/-- **Hadamard's inequality.** The Gramian is at most the product of the squared norms.
+Both sides are nonnegative reals; the inequality is stated in `𝕜` via the `ComplexOrder`. -/
+theorem hadamard_inequality (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) :
+    (Matrix.gram 𝕜 v).det ≤ ((∏ i, ‖v i‖ ^ 2 : ℝ) : 𝕜) := by
+  rw [gram_det_eq h v, RCLike.ofReal_le_ofReal]
+  exact norm_det_sq_le_prod_norm_sq h v
+
+/-- **Hadamard's inequality**, real-part form (no order on `𝕜` required). -/
+theorem re_gram_det_le_prod_norm_sq (h : finrank 𝕜 E = Fintype.card ι) (v : ι → E) :
+    RCLike.re (Matrix.gram 𝕜 v).det ≤ ∏ i, ‖v i‖ ^ 2 := by
+  rw [gram_det_eq h v, RCLike.ofReal_re]
+  exact norm_det_sq_le_prod_norm_sq h v
+
+/-! ## Equality for orthogonal families -/
+
+omit [LocallyFiniteOrderBot ι] [WellFoundedLT ι] [FiniteDimensional 𝕜 E] in
+/-- A **pairwise orthogonal** family has a diagonal Gram matrix, so the Gramian is exactly
+the product of the diagonal entries `⟪v i, v i⟫`. (No dimension hypothesis is needed.) -/
+theorem gram_det_of_orthogonal {v : ι → E} (hv : Pairwise (⟪v ·, v ·⟫_𝕜 = 0)) :
+    (Matrix.gram 𝕜 v).det = ∏ i, ⟪v i, v i⟫_𝕜 := by
+  rw [show Matrix.gram 𝕜 v = Matrix.diagonal (fun i => ⟪v i, v i⟫_𝕜) from ?_,
+    Matrix.det_diagonal]
+  ext i j
+  rcases eq_or_ne i j with rfl | hij
+  · simp [Matrix.gram_apply]
+  · rw [Matrix.gram_apply, Matrix.diagonal_apply_ne _ hij, hv hij]
+
+omit [LocallyFiniteOrderBot ι] [WellFoundedLT ι] [FiniteDimensional 𝕜 E] in
+/-- Orthogonal version with squared norms: `det (gram 𝕜 v) = ∏ i, ‖v i‖²` in `𝕜`. -/
+theorem gram_det_of_orthogonal_norm {v : ι → E} (hv : Pairwise (⟪v ·, v ·⟫_𝕜 = 0)) :
+    (Matrix.gram 𝕜 v).det = ((∏ i, ‖v i‖ ^ 2 : ℝ) : 𝕜) := by
+  rw [gram_det_of_orthogonal hv]
+  push_cast
+  exact Finset.prod_congr rfl fun i _ => inner_self_eq_norm_sq_to_K (v i)
+
+/-! ## Equality iff orthogonal (linearly independent families) -/
+
+/-- For a linearly independent family of full size, each Gram–Schmidt diagonal inner
+product `⟪e i, v i⟫` is nonzero: their product is the determinant `e.det v`, a unit
+because `v` is a basis. -/
+theorem inner_diag_ne_zero (h : finrank 𝕜 E = Fintype.card ι) {v : ι → E}
+    (hv : LinearIndependent 𝕜 v) (i : ι) : ⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜 ≠ 0 := by
+  haveI : Nonempty ι := ⟨i⟩
+  have hspan : Submodule.span 𝕜 (Set.range v) = ⊤ := by
+    rw [← coe_basisOfLinearIndependentOfCardEqFinrank hv h.symm]
+    exact (basisOfLinearIndependentOfCardEqFinrank hv h.symm).span_eq
+  have hunit : IsUnit ((gramSchmidtOrthonormalBasis h v).toBasis.det v) :=
+    (Basis.is_basis_iff_det _).mp ⟨hv, hspan⟩
+  have hprod : ∏ k, ⟪(gramSchmidtOrthonormalBasis h v) k, v k⟫_𝕜 ≠ 0 := by
+    rw [← coordMatrix_det h v]
+    rw [Basis.det_apply] at hunit
+    exact hunit.ne_zero
+  exact fun hi => hprod (Finset.prod_eq_zero (Finset.mem_univ i) hi)
+
+/-- In the equality case, each diagonal factor is sharp: `‖⟪e i, v i⟫‖² = ‖v i‖²`.
+If some factor were strict, the product would be strictly smaller (all factors positive
+by `inner_diag_ne_zero`), contradicting equality. -/
+theorem diag_sq_eq_of_hadamard_eq (h : finrank 𝕜 E = Fintype.card ι) {v : ι → E}
+    (hv : LinearIndependent 𝕜 v)
+    (heq : ‖∏ i, ⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 = ∏ i, ‖v i‖ ^ 2) (i : ι) :
+    ‖⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 = ‖v i‖ ^ 2 := by
+  rw [norm_prod, ← Finset.prod_pow] at heq
+  by_contra hne
+  have hlt : ∏ k, ‖⟪(gramSchmidtOrthonormalBasis h v) k, v k⟫_𝕜‖ ^ 2 < ∏ k, ‖v k‖ ^ 2 :=
+    Finset.prod_lt_prod
+      (fun k _ => pow_pos (norm_pos_iff.mpr (inner_diag_ne_zero h hv k)) 2)
+      (fun k _ => abs_inner_sq_le_norm_sq h v k)
+      ⟨i, Finset.mem_univ i, lt_of_le_of_ne (abs_inner_sq_le_norm_sq h v i) hne⟩
+  exact absurd heq (ne_of_lt hlt)
+
+/-- Diagonal sharpness forces the off-diagonal coordinates to vanish:
+`⟪e k, v i⟫ = 0` for `k ≠ i`. (One term of Bessel's sum already accounts for the whole
+norm, so the rest must be zero.) -/
+theorem coord_off_diag_eq_zero (h : finrank 𝕜 E = Fintype.card ι) {v : ι → E}
+    (hsharp : ∀ i, ‖⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 = ‖v i‖ ^ 2) {k i : ι} (hki : k ≠ i) :
+    ⟪(gramSchmidtOrthonormalBasis h v) k, v i⟫_𝕜 = 0 := by
+  have hsum := OrthonormalBasis.sum_sq_norm_inner_right (gramSchmidtOrthonormalBasis h v) (v i)
+  rw [← Finset.sum_erase_add _ _ (Finset.mem_univ i), hsharp i] at hsum
+  have herase : ∑ x ∈ univ.erase i, ‖⟪(gramSchmidtOrthonormalBasis h v) x, v i⟫_𝕜‖ ^ 2 = 0 := by
+    linarith
+  have hz : ‖⟪(gramSchmidtOrthonormalBasis h v) k, v i⟫_𝕜‖ ^ 2 = 0 :=
+    (Finset.sum_eq_zero_iff_of_nonneg (fun j _ => sq_nonneg _)).mp herase k
+      (Finset.mem_erase.mpr ⟨hki, Finset.mem_univ k⟩)
+  exact norm_eq_zero.mp (pow_eq_zero_iff (by norm_num : (2 : ℕ) ≠ 0) |>.mp hz)
+
+/-- Diagonal sharpness implies pairwise orthogonality of `v`. -/
+theorem orthogonal_of_diag_sq_eq (h : finrank 𝕜 E = Fintype.card ι) {v : ι → E}
+    (hsharp : ∀ i, ‖⟪(gramSchmidtOrthonormalBasis h v) i, v i⟫_𝕜‖ ^ 2 = ‖v i‖ ^ 2) :
+    Pairwise (⟪v ·, v ·⟫_𝕜 = 0) := by
+  intro i j hij
+  rw [← OrthonormalBasis.sum_inner_mul_inner (gramSchmidtOrthonormalBasis h v) (v i) (v j)]
+  refine Finset.sum_eq_zero fun k _ => ?_
+  rcases eq_or_ne k i with rfl | hki
+  · -- k = i ≠ j, so the second factor ⟪e k, v j⟫ = 0
+    rw [coord_off_diag_eq_zero h hsharp hij, mul_zero]
+  · -- k ≠ i, so the first factor ⟪v i, e k⟫ = conj ⟪e k, v i⟫ = 0
+    rw [← inner_conj_symm, coord_off_diag_eq_zero h hsharp hki, map_zero, zero_mul]
+
+/-- **Hadamard equality case.** For a linearly independent family of full size, the
+Gramian equals the product of squared norms **iff** the vectors are pairwise orthogonal. -/
+theorem hadamard_eq_iff_orthogonal (h : finrank 𝕜 E = Fintype.card ι) {v : ι → E}
+    (hv : LinearIndependent 𝕜 v) :
+    (Matrix.gram 𝕜 v).det = ((∏ i, ‖v i‖ ^ 2 : ℝ) : 𝕜) ↔ Pairwise (⟪v ·, v ·⟫_𝕜 = 0) := by
+  constructor
+  · intro hd
+    rw [gram_det_eq h v, RCLike.ofReal_inj] at hd
+    exact orthogonal_of_diag_sq_eq h (diag_sq_eq_of_hadamard_eq h hv hd)
+  · exact gram_det_of_orthogonal_norm
+
+/-! ## Concrete corollaries on `EuclideanSpace` -/
+
+/-- **Hadamard's inequality on `EuclideanSpace`.** For any family of `n` vectors in
+`EuclideanSpace 𝕜 (Fin n)`, the Gramian is at most the product of the squared norms — the
+dimension hypothesis is automatic. -/
+theorem hadamard_inequality_euclidean {n : ℕ} (v : Fin n → EuclideanSpace 𝕜 (Fin n)) :
+    (Matrix.gram 𝕜 v).det ≤ ((∏ i, ‖v i‖ ^ 2 : ℝ) : 𝕜) :=
+  hadamard_inequality (by rw [finrank_euclideanSpace_fin, Fintype.card_fin]) v
+
+/-- **Hadamard equality case on `EuclideanSpace`.** A linearly independent family of `n`
+vectors in `EuclideanSpace 𝕜 (Fin n)` attains the Hadamard bound iff it is orthogonal. -/
+theorem hadamard_eq_iff_orthogonal_euclidean {n : ℕ} {v : Fin n → EuclideanSpace 𝕜 (Fin n)}
+    (hv : LinearIndependent 𝕜 v) :
+    (Matrix.gram 𝕜 v).det = ((∏ i, ‖v i‖ ^ 2 : ℝ) : 𝕜) ↔ Pairwise (⟪v ·, v ·⟫_𝕜 = 0) :=
+  hadamard_eq_iff_orthogonal (by rw [finrank_euclideanSpace_fin, Fintype.card_fin]) hv
+
+end GramLinearIndependenceOQ01OQ01

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "gram-eq-bhb",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01",
+    "range": { "startLine": 51, "endLine": 70 },
+    "type": "concept",
+    "title": "The Factorisation gram 𝕜 v = BᴴB",
+    "content": "Let e = gramSchmidtOrthonormalBasis 𝕜 v be Mathlib's Gram–Schmidt orthonormal basis and B the coordinate matrix B i j = ⟪e i, v j⟫ (coordMatrix_apply). The single identity that drives the whole proof is gram_eq_conjTranspose_mul: gram 𝕜 v = Bᴴ * B. It is pure completeness of the basis — expanding ⟪v i, v j⟫ = ∑ k, ⟪v i, e k⟫ * ⟪e k, v j⟫ (OrthonormalBasis.sum_inner_mul_inner) and recognising the right-hand side as the (i,j) entry of BᴴB, with the conjugate-transpose supplying ⟪v i, e k⟫ = conj ⟪e k, v i⟫.",
+    "mathContext": "$\\mathrm{Gram}(v) = B^{\\mathsf H} B$, $B_{ij} = \\langle e_i, v_j\\rangle$.",
+    "significance": "key",
+    "relatedConcepts": ["Gram matrix", "Gram–Schmidt orthonormal basis", "conjugate transpose", "Parseval completeness"],
+    "prerequisites": ["orthonormal bases", "matrix multiplication"]
+  },
+  {
+    "id": "det-norm-sq",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01",
+    "range": { "startLine": 72, "endLine": 87 },
+    "type": "technique",
+    "title": "The Gramian is ‖det B‖²",
+    "content": "From gram = BᴴB, multiplicativity gives det(gram) = det(Bᴴ)·det(B) = conj(det B)·det B = ‖det B‖² (Matrix.det_conjTranspose and RCLike.conj_mul). Because the coordinate matrix B is upper-triangular in the Gram–Schmidt basis, Mathlib's gramSchmidtOrthonormalBasis_det evaluates det B = ∏ i, ⟪e i, v i⟫. Hence gram_det_eq: det(gram 𝕜 v) = ‖∏ i, ⟪e i, v i⟫‖², a manifestly nonnegative real — the determinant has been reduced to a product of diagonal coordinates.",
+    "mathContext": "$\\det\\mathrm{Gram}(v) = \\lVert\\det B\\rVert^2 = \\bigl\\lVert\\prod_i \\langle e_i, v_i\\rangle\\bigr\\rVert^2$.",
+    "significance": "key",
+    "relatedConcepts": ["determinant multiplicativity", "triangular determinant", "RCLike conjugation"],
+    "prerequisites": ["determinants", "Gram–Schmidt triangularity"]
+  },
+  {
+    "id": "bessel-bound",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01",
+    "range": { "startLine": 89, "endLine": 121 },
+    "type": "insight",
+    "title": "Hadamard = Bessel, Diagonal by Diagonal",
+    "content": "Each diagonal factor is bounded by Bessel's inequality: ‖⟪e i, v i⟫‖² is just one term of the Parseval sum ‖v i‖² = ∑ k, ‖⟪e k, v i⟫‖² (OrthonormalBasis.sum_sq_norm_inner_right), so abs_inner_sq_le_norm_sq gives ‖⟪e i, v i⟫‖² ≤ ‖v i‖². Multiplying over i (all factors nonnegative) turns the equality det(gram) = ∏ ‖⟪e i, v i⟫‖² into Hadamard's inequality det(gram 𝕜 v) ≤ ∏ ‖v i‖² (hadamard_inequality, with re_gram_det_le_prod_norm_sq the order-free real-part form).",
+    "mathContext": "$\\lVert\\langle e_i, v_i\\rangle\\rVert^2 \\le \\lVert v_i\\rVert^2 \\Rightarrow \\det\\mathrm{Gram}(v) \\le \\prod_i \\lVert v_i\\rVert^2$.",
+    "significance": "key",
+    "relatedConcepts": ["Bessel's inequality", "Parseval identity", "product monotonicity", "Hadamard's inequality"],
+    "prerequisites": ["Bessel/Parseval", "ordered products"]
+  },
+  {
+    "id": "orthogonal-equality",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01",
+    "range": { "startLine": 123, "endLine": 143 },
+    "type": "concept",
+    "title": "Orthogonal Families Attain Equality",
+    "content": "The easy half of the equality characterisation needs no dimension hypothesis: if v is pairwise orthogonal then gram 𝕜 v is the diagonal matrix with entries ⟪v i, v i⟫, so det(gram 𝕜 v) = ∏ i, ⟪v i, v i⟫ = ∏ i, ‖v i‖² (gram_det_of_orthogonal, gram_det_of_orthogonal_norm). Geometrically: a rectangular box has volume equal to the product of its edge lengths.",
+    "mathContext": "$v$ orthogonal $\\Rightarrow \\mathrm{Gram}(v)$ diagonal $\\Rightarrow \\det = \\prod_i \\lVert v_i\\rVert^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["diagonal matrix", "orthogonal family", "determinant of diagonal"],
+    "prerequisites": ["diagonal matrices"]
+  },
+  {
+    "id": "equality-converse",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01",
+    "range": { "startLine": 145, "endLine": 218 },
+    "type": "insight",
+    "title": "Equality Forces Orthogonality: A Positivity Argument",
+    "content": "The hard direction is not a construction but a strictness argument. For a linearly independent full family, v is a basis, so det B = ∏ ⟪e i, v i⟫ is a unit and every diagonal factor is nonzero (inner_diag_ne_zero). Then strict product monotonicity (Finset.prod_lt_prod) converts product-equality into termwise sharpness ‖⟪e i, v i⟫‖² = ‖v i‖² (diag_sq_eq_of_hadamard_eq). Sharpness uses up the entire Parseval mass at index i, so the off-diagonal coordinates ⟪e k, v i⟫ (k ≠ i) must vanish (coord_off_diag_eq_zero); feeding this back through ⟪v i, v j⟫ = ∑ k, ⟪v i, e k⟫⟪e k, v j⟫ gives orthogonality (orthogonal_of_diag_sq_eq), assembled into hadamard_eq_iff_orthogonal.",
+    "mathContext": "independent $v$: $\\det\\mathrm{Gram}(v) = \\prod_i \\lVert v_i\\rVert^2 \\iff \\langle v_i, v_j\\rangle = 0\\ (i \\ne j)$.",
+    "significance": "key",
+    "relatedConcepts": ["strict product monotonicity", "basis determinant", "Bessel saturation", "orthogonality"],
+    "prerequisites": ["linear independence and bases", "ordered field inequalities"]
+  },
+  {
+    "id": "euclidean-corollaries",
+    "proofId": "gram-linear-independence-iff-oq-01-oq-01",
+    "range": { "startLine": 220, "endLine": 236 },
+    "type": "concept",
+    "title": "Concrete Forms on EuclideanSpace",
+    "content": "hadamard_inequality_euclidean and hadamard_eq_iff_orthogonal_euclidean specialise the abstract results to families of n vectors in EuclideanSpace 𝕜 (Fin n), where the dimension hypothesis finrank = n holds automatically (finrank_euclideanSpace_fin). These give directly applicable statements of Hadamard's bound and its orthogonality equality case for the standard coordinate model of n-dimensional inner product space.",
+    "mathContext": "$v : \\mathrm{Fin}\\,n \\to \\mathbb{E}^n$: $\\det\\mathrm{Gram}(v) \\le \\prod_i \\lVert v_i\\rVert^2$, equality $\\iff$ orthogonal.",
+    "significance": "supporting",
+    "relatedConcepts": ["EuclideanSpace", "finrank", "concrete instantiation"],
+    "prerequisites": ["finite-dimensional inner product spaces"]
+  }
+]

--- a/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01/meta.json
+++ b/src/data/proofs/gram-linear-independence-iff-oq-01-oq-01/meta.json
@@ -1,0 +1,203 @@
+{
+  "id": "gram-linear-independence-iff-oq-01-oq-01",
+  "slug": "gram-linear-independence-iff-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Matrix",
+      "RCLike",
+      "Finset",
+      "Module",
+      "InnerProductSpace",
+      "ComplexOrder"
+    ],
+    "namespace": "GramLinearIndependenceOQ01OQ01",
+    "lineCount": 236,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "definitionCount": 0,
+    "path": "Proofs/GramLinearIndependenceOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "title": "Hadamard's Determinant Inequality for Gram Matrices, with the Orthogonality Equality Case",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GramLinearIndependenceOQ01OQ01.lean",
+    "tags": [
+      "linear-algebra",
+      "inner-product-space",
+      "gram-matrix",
+      "determinant",
+      "hadamard-inequality",
+      "gram-schmidt",
+      "orthogonality",
+      "research"
+    ],
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 236,
+    "theoremCount": 17,
+    "definitionCount": 0,
+    "badge": "original",
+    "originalContributions": [
+      "hadamard_inequality: Hadamard's determinant inequality det(gram 𝕜 v) ≤ ∏ i, ‖v i‖² for a full family of vectors (finrank 𝕜 E = card ι), stated in 𝕜 via the ComplexOrder — a determinant bound absent from Mathlib",
+      "re_gram_det_le_prod_norm_sq: the same bound on the real part RCLike.re (det gram) ≤ ∏ ‖v i‖², requiring no order on 𝕜",
+      "hadamard_eq_iff_orthogonal: the equality case — for a linearly independent family, det(gram 𝕜 v) = ∏ ‖v i‖² iff the vectors are pairwise orthogonal, exhibiting the Gramian as a squared volume that is maximal exactly for orthogonal edges",
+      "gram_eq_conjTranspose_mul: the key factorisation gram 𝕜 v = Bᴴ * B where B i j = ⟪e i, v j⟫ is the coordinate matrix in the Gram–Schmidt orthonormal basis, from completeness ⟪v i, v j⟫ = ∑ k, ⟪v i, e k⟫ * ⟪e k, v j⟫",
+      "gram_det_eq: the Gramian equals the squared norm of the determinant of the (triangular) coordinate matrix, det(gram 𝕜 v) = ‖∏ i, ⟪e i, v i⟫‖², combining det(BᴴB) = ‖det B‖² with Mathlib's gramSchmidtOrthonormalBasis_det",
+      "abs_inner_sq_le_norm_sq: Bessel's bound on each diagonal factor ‖⟪e i, v i⟫‖² ≤ ‖v i‖², one term of the Parseval sum ‖v i‖² = ∑ k, ‖⟪e k, v i⟫‖²",
+      "gram_det_of_orthogonal / gram_det_of_orthogonal_norm: a pairwise orthogonal family has a diagonal Gram matrix, so det(gram 𝕜 v) = ∏ i, ⟪v i, v i⟫ = ∏ i, ‖v i‖² (no dimension hypothesis needed)",
+      "inner_diag_ne_zero: for a linearly independent full family every Gram–Schmidt diagonal inner product ⟪e i, v i⟫ is nonzero, since their product is the determinant e.det v, a unit because v is a basis",
+      "coord_off_diag_eq_zero / orthogonal_of_diag_sq_eq: diagonal sharpness forces the off-diagonal coordinates ⟪e k, v i⟫ (k ≠ i) to vanish, hence pairwise orthogonality of v",
+      "hadamard_inequality_euclidean / hadamard_eq_iff_orthogonal_euclidean: concrete corollaries on EuclideanSpace 𝕜 (Fin n) where the dimension hypothesis is automatic"
+    ],
+    "prerequisites": [
+      "Gram matrix Matrix.gram 𝕜 v with entries ⟪v i, v j⟫ over an RCLike field 𝕜 (parent entry gram-linear-independence-iff-oq-01)",
+      "Mathlib's Gram–Schmidt orthonormal basis InnerProductSpace.gramSchmidtOrthonormalBasis and its triangularity gramSchmidtOrthonormalBasis_det",
+      "Completeness/Parseval for an orthonormal basis: OrthonormalBasis.sum_inner_mul_inner and OrthonormalBasis.sum_sq_norm_inner_right",
+      "Determinant algebra: Matrix.det_mul, Matrix.det_conjTranspose, Basis.det_apply; and RCLike.conj_mul (z * conj z = ‖z‖²)",
+      "Basis.is_basis_iff_det and basisOfLinearIndependentOfCardEqFinrank to identify a full independent family as a basis"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "InnerProductSpace.gramSchmidtOrthonormalBasis_det",
+        "description": "The determinant of a full family in its Gram–Schmidt orthonormal basis equals the product of the diagonal inner products ∏ i, ⟪e i, v i⟫ — the matrix of coordinates is upper-triangular.",
+        "module": "Mathlib.Analysis.InnerProductSpace.GramSchmidtOrtho"
+      },
+      {
+        "theorem": "OrthonormalBasis.sum_inner_mul_inner / sum_sq_norm_inner_right",
+        "description": "Completeness ∑ k, ⟪x, e k⟫ * ⟪e k, y⟫ = ⟪x, y⟫ (giving gram = BᴴB) and the Parseval identity ‖x‖² = ∑ k, ‖⟪e k, x⟫‖² (giving Bessel's diagonal bound).",
+        "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
+      },
+      {
+        "theorem": "Matrix.det_conjTranspose / Matrix.det_mul",
+        "description": "det(Mᴴ) = conj(det M) and multiplicativity of det, combining to det(BᴴB) = ‖det B‖² over an RCLike field.",
+        "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
+      },
+      {
+        "theorem": "Basis.is_basis_iff_det",
+        "description": "A family is a basis iff its determinant e.det v is a unit — used to show each Gram–Schmidt diagonal factor is nonzero for an independent full family.",
+        "module": "Mathlib.LinearAlgebra.Determinant"
+      },
+      {
+        "theorem": "Finset.prod_lt_prod",
+        "description": "Strict product monotonicity for positive factors: if all factors are positive, dominated termwise, and strictly dominated somewhere, the product is strictly smaller — the engine of the equality case.",
+        "module": "Mathlib.Algebra.Order.BigOperators.Ring.Finset"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Hadamard's inequality (Jacques Hadamard, 1893) bounds the absolute value of a determinant by the product of the Euclidean norms of its columns: |det A| ≤ ∏ ‖aⱼ‖. Squaring and reading the columns as a family of vectors in an inner product space turns this into a statement about the Gram determinant, det(gram v) ≤ ∏ ‖vⱼ‖², with equality exactly when the vectors are mutually orthogonal. Geometrically the Gramian is the squared volume of the parallelepiped spanned by the vectors, and Hadamard's inequality is the precise sense in which a box of fixed edge lengths has the largest volume when its edges are perpendicular. The result is foundational in numerical linear algebra (matrix conditioning), the geometry of numbers (Minkowski's lattice bounds), coding theory, and random-matrix theory. Mathlib formalizes the Gram–Schmidt machinery and the positive-definiteness criterion for Gram matrices but not this determinant bound; the parent entry supplied the Gramian linear-independence test, and this entry answers its first open question by establishing the quantitative Hadamard bound and its orthogonality equality case.",
+    "problemStatement": "For a finite family of vectors v : ι → E filling an inner product space E over an RCLike field 𝕜 (finrank 𝕜 E = card ι), prove Hadamard's inequality det(gram 𝕜 v) ≤ ∏ i, ‖v i‖² (the Gramian, a nonnegative real, is bounded by the product of squared norms), and characterise the equality case: for a linearly independent family equality holds iff the vectors are pairwise orthogonal. Provide concrete instances on EuclideanSpace 𝕜 (Fin n).",
+    "proofStrategy": "Route through Mathlib's Gram–Schmidt orthonormal basis e := gramSchmidtOrthonormalBasis. Let B be the coordinate matrix B i j = ⟪e i, v j⟫. Two facts drive the proof. (1) Completeness gives gram 𝕜 v = Bᴴ * B (gram_eq_conjTranspose_mul), hence det(gram 𝕜 v) = det(Bᴴ) · det(B) = ‖det B‖²; and the matrix B is upper-triangular, so det B = ∏ i, ⟪e i, v i⟫ (Mathlib's gramSchmidtOrthonormalBasis_det). Thus det(gram 𝕜 v) = ‖∏ i, ⟪e i, v i⟫‖² = ∏ i, ‖⟪e i, v i⟫‖² (gram_det_eq). (2) Bessel's identity ‖v i‖² = ∑ k, ‖⟪e k, v i⟫‖² bounds each diagonal factor by ‖⟪e i, v i⟫‖² ≤ ‖v i‖² (abs_inner_sq_le_norm_sq), and taking the product yields Hadamard (hadamard_inequality). For the equality case, when v is linearly independent it is a basis, so det B = ∏ ⟪e i, v i⟫ is a unit and every diagonal factor is nonzero (inner_diag_ne_zero); strict product monotonicity (Finset.prod_lt_prod) then forces each factor to be sharp ‖⟪e i, v i⟫‖² = ‖v i‖² (diag_sq_eq_of_hadamard_eq); sharpness drains the remaining Parseval mass, so the off-diagonal coordinates ⟪e k, v i⟫ vanish (coord_off_diag_eq_zero), and ⟪v i, v j⟫ = ∑ k, ⟪v i, e k⟫ ⟪e k, v j⟫ = 0 for i ≠ j (orthogonal_of_diag_sq_eq). The converse direction is direct: an orthogonal family has a diagonal Gram matrix (gram_det_of_orthogonal).",
+    "keyInsights": [
+      "Hadamard's bound is Bessel's inequality applied diagonal-by-diagonal then multiplied: the Gramian factors as ∏ i, ‖⟪e i, v i⟫‖² in the Gram–Schmidt basis, and each diagonal coordinate squared is at most the full squared norm because it is just one term of the Parseval sum ‖v i‖² = ∑ k, ‖⟪e k, v i⟫‖².",
+      "The whole proof is powered by a single matrix factorisation: gram 𝕜 v = Bᴴ B with B the coordinate matrix in the orthonormal basis. This turns the determinant into ‖det B‖² and lets Mathlib's triangularity of B (gramSchmidtOrthonormalBasis_det) finish the determinant computation with no extra work.",
+      "The equality case is a positivity argument, not a separate construction: independence makes every diagonal factor strictly positive (the product is a basis determinant, a unit), so Finset.prod_lt_prod converts product-equality into termwise-equality; the residual Parseval mass then forces the off-diagonal coordinates to zero, which is exactly orthogonality.",
+      "The orthogonal converse needs no dimension hypothesis at all — an orthogonal family already has a diagonal Gram matrix — so gram_det_of_orthogonal is the clean, fully general half of the iff; the dimension constraint only enters the hard direction through the Gram–Schmidt basis.",
+      "Working over an arbitrary RCLike field 𝕜 keeps the real and complex cases uniform: the Hermitian transpose supplies the conjugation in gram = BᴴB, and RCLike.conj_mul (z · conj z = ‖z‖²) turns the determinant of a Hermitian product into a manifestly nonnegative real."
+    ]
+  },
+  "sections": [
+    {
+      "id": "coordinate-matrix",
+      "title": "The Coordinate Matrix and the Factorisation gram = BᴴB",
+      "startLine": 51,
+      "endLine": 70,
+      "summary": "coordMatrix_apply identifies the coordinate matrix entries B i j = ⟪e i, v j⟫ in the Gram–Schmidt orthonormal basis. gram_eq_conjTranspose_mul proves the key factorisation gram 𝕜 v = Bᴴ * B from completeness of the basis: ⟪v i, v j⟫ = ∑ k, ⟪v i, e k⟫ * ⟪e k, v j⟫.",
+      "mathContext": "$\\mathrm{Gram}(v) = B^{\\mathsf H} B$, where $B_{ij} = \\langle e_i, v_j\\rangle$ in the Gram–Schmidt basis $e$."
+    },
+    {
+      "id": "determinant",
+      "title": "The Gramian as ‖det B‖²",
+      "startLine": 72,
+      "endLine": 87,
+      "summary": "coordMatrix_det records that the triangular coordinate matrix has determinant ∏ i, ⟪e i, v i⟫ (Mathlib's gramSchmidtOrthonormalBasis_det). gram_det_eq combines det(BᴴB) = conj(det B)·det B = ‖det B‖² with this to give det(gram 𝕜 v) = ‖∏ i, ⟪e i, v i⟫‖².",
+      "mathContext": "$\\det\\mathrm{Gram}(v) = \\lVert\\det B\\rVert^2 = \\bigl\\lVert\\textstyle\\prod_i \\langle e_i, v_i\\rangle\\bigr\\rVert^2$."
+    },
+    {
+      "id": "bessel-and-hadamard",
+      "title": "Bessel's Bound and Hadamard's Inequality",
+      "startLine": 89,
+      "endLine": 121,
+      "summary": "abs_inner_sq_le_norm_sq bounds each diagonal factor ‖⟪e i, v i⟫‖² ≤ ‖v i‖² (one term of the Parseval sum). norm_det_sq_le_prod_norm_sq multiplies these, and hadamard_inequality / re_gram_det_le_prod_norm_sq state Hadamard's bound det(gram 𝕜 v) ≤ ∏ ‖v i‖² in 𝕜 (ComplexOrder) and on the real part.",
+      "mathContext": "$\\lVert\\langle e_i, v_i\\rangle\\rVert^2 \\le \\lVert v_i\\rVert^2 \\Rightarrow \\det\\mathrm{Gram}(v) \\le \\prod_i \\lVert v_i\\rVert^2$."
+    },
+    {
+      "id": "orthogonal-case",
+      "title": "Equality for Orthogonal Families",
+      "startLine": 123,
+      "endLine": 143,
+      "summary": "gram_det_of_orthogonal and gram_det_of_orthogonal_norm show a pairwise orthogonal family has a diagonal Gram matrix, hence det(gram 𝕜 v) = ∏ i, ⟪v i, v i⟫ = ∏ i, ‖v i‖² — the easy half of the equality characterisation, needing no dimension hypothesis.",
+      "mathContext": "$v$ orthogonal $\\Rightarrow \\mathrm{Gram}(v)$ diagonal $\\Rightarrow \\det = \\prod_i \\lVert v_i\\rVert^2$."
+    },
+    {
+      "id": "equality-iff",
+      "title": "Equality iff Orthogonal (Independent Families)",
+      "startLine": 145,
+      "endLine": 218,
+      "summary": "inner_diag_ne_zero (independence ⇒ each diagonal factor nonzero, via the basis determinant being a unit), diag_sq_eq_of_hadamard_eq (equality ⇒ each factor sharp, by strict product monotonicity), coord_off_diag_eq_zero (sharpness ⇒ off-diagonal coordinates vanish), and orthogonal_of_diag_sq_eq assemble into hadamard_eq_iff_orthogonal.",
+      "mathContext": "$v$ independent: $\\det\\mathrm{Gram}(v) = \\prod_i \\lVert v_i\\rVert^2 \\iff \\langle v_i, v_j\\rangle = 0\\ (i \\ne j)$."
+    },
+    {
+      "id": "euclidean",
+      "title": "Concrete Corollaries on EuclideanSpace",
+      "startLine": 220,
+      "endLine": 236,
+      "summary": "hadamard_inequality_euclidean and hadamard_eq_iff_orthogonal_euclidean specialise to n vectors in EuclideanSpace 𝕜 (Fin n), where finrank = n is automatic, giving directly usable forms of the inequality and its equality case.",
+      "mathContext": "For $v : \\mathrm{Fin}\\,n \\to \\mathbb{E}^n$: $\\det\\mathrm{Gram}(v) \\le \\prod_i \\lVert v_i\\rVert^2$, equality $\\iff$ orthogonal."
+    }
+  ],
+  "openQuestions": [
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-01-oq-01",
+      "question": "Identify √(det gram 𝕜 v) with the k-dimensional volume of the parallelepiped spanned by v via the exterior power / Cauchy–Binet picture, turning Hadamard's inequality into the statement 'volume ≤ product of edge lengths'.",
+      "significance": "medium"
+    },
+    {
+      "id": "gram-linear-independence-iff-oq-01-oq-01-oq-02",
+      "question": "Derive the matrix form of Hadamard's inequality |det A| ≤ ∏ j, ‖col j A‖ for a square matrix A over 𝕜 as a corollary, by applying the Gram bound to the columns of A and using det(gram (cols A)) = |det A|².",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "gram-linear-independence-iff-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry established that the Gramian is nonnegative and characterises linear independence (det > 0 iff independent). This entry answers its first open question by quantifying the Gramian from above: Hadamard's inequality det(gram) ≤ ∏ ‖v i‖² with equality iff orthogonal."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "generalizes",
+      "description": "For two vectors the Gramian is ‖u‖²‖w‖² − |⟪u,w⟫|² and Hadamard reduces to |⟪u,w⟫|² ≤ ‖u‖²‖w‖² — the Cauchy–Schwarz inequality, with equality iff u, w are orthogonal (here, the dependent/aligned degenerate case is excluded by independence)."
+    }
+  ],
+  "references": [
+    {
+      "title": "Jacques Hadamard, Résolution d'une question relative aux déterminants",
+      "author": "J. Hadamard",
+      "year": "1893",
+      "venue": "Bulletin des Sciences Mathématiques",
+      "description": "Original statement of Hadamard's determinant inequality |det A| ≤ ∏ ‖column‖, the matrix form of the Gram determinant bound proved here."
+    },
+    {
+      "title": "Mathlib4: Analysis.InnerProductSpace.GramSchmidtOrtho",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of gramSchmidtOrthonormalBasis and gramSchmidtOrthonormalBasis_det, the triangular coordinate-matrix determinant that drives the proof."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "For a finite family v : ι → E filling an inner product space over an RCLike field 𝕜 (finrank 𝕜 E = card ι), the Gramian satisfies Hadamard's inequality det(gram 𝕜 v) ≤ ∏ i, ‖v i‖² (hadamard_inequality, and re_gram_det_le_prod_norm_sq on the real part). The proof factors the Gram matrix as gram 𝕜 v = Bᴴ B in the Gram–Schmidt orthonormal basis (gram_eq_conjTranspose_mul), so det(gram 𝕜 v) = ‖det B‖² = ‖∏ i, ⟪e i, v i⟫‖² (gram_det_eq, using Mathlib's gramSchmidtOrthonormalBasis_det), and Bessel's identity bounds each diagonal factor ‖⟪e i, v i⟫‖² ≤ ‖v i‖² (abs_inner_sq_le_norm_sq). The equality case is fully characterised: an orthogonal family has a diagonal Gram matrix giving equality (gram_det_of_orthogonal), and conversely a linearly independent family attaining equality must be orthogonal (hadamard_eq_iff_orthogonal), because independence makes the diagonal factors strictly positive, strict product monotonicity forces each to be sharp, and the residual Parseval mass pins the off-diagonal coordinates to zero. Concrete EuclideanSpace 𝕜 (Fin n) corollaries are provided. 236 lines, 17 theorems, 0 definitions, 0 axioms, 0 sorries.",
+    "implications": "This answers the parent entry's first open question and supplies to the gallery (and beyond Mathlib) the quantitative Hadamard bound on Gram determinants together with the sharp orthogonality equality case, realising the Gramian as a squared volume that is maximal for fixed edge lengths exactly when the edges are perpendicular. The factorisation gram = BᴴB and the Bessel diagonal bound are reusable for the volume/Cauchy–Binet refinements and the matrix form |det A| ≤ ∏ ‖col‖ recorded as open questions.",
+    "openQuestions": [
+      "Identify √(det gram) with the k-dimensional parallelepiped volume via exterior powers / Cauchy–Binet.",
+      "Derive the matrix Hadamard inequality |det A| ≤ ∏ ‖col j A‖ as a corollary on the columns of A."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Answers the **first open question** of `gram-linear-independence-iff-oq-01`: prove **Hadamard's inequality** `det(gram 𝕜 v) ≤ ∏ i, ‖v i‖²` with **equality iff the vectors are pairwise orthogonal**, exhibiting the Gramian as a squared volume. This determinant bound is **absent from Mathlib** (which has the Gram–Schmidt machinery and the positive-definiteness criterion, but not this inequality).

New file `proofs/Proofs/GramLinearIndependenceOQ01OQ01.lean` — **17 theorems, 0 definitions, 0 sorries, 0 axioms** (only `propext`/`Classical.choice`/`Quot.sound`).

## Mathematical content

For a finite family `v : ι → E` filling an inner product space over an `RCLike` field 𝕜 (`finrank 𝕜 E = card ι`):

- `hadamard_inequality` / `re_gram_det_le_prod_norm_sq` — Hadamard's bound (in 𝕜 via `ComplexOrder`, and on the real part).
- `hadamard_eq_iff_orthogonal` — for a **linearly independent** family, equality ⟺ pairwise orthogonality.
- `gram_det_of_orthogonal` — the orthogonal converse (diagonal Gram matrix; no dimension hypothesis).
- `hadamard_inequality_euclidean` / `hadamard_eq_iff_orthogonal_euclidean` — concrete `EuclideanSpace 𝕜 (Fin n)` corollaries.

## Proof route

Via Mathlib's Gram–Schmidt orthonormal basis `e`. With coordinate matrix `B i j = ⟪e i, v j⟫`:

1. Completeness ⟹ `gram 𝕜 v = Bᴴ B`, so `det(gram) = ‖det B‖²`.
2. `B` is triangular ⟹ `det B = ∏ i, ⟪e i, v i⟫` (`gramSchmidtOrthonormalBasis_det`), giving `det(gram) = ∏ i, ‖⟪e i, v i⟫‖²`.
3. Bessel: `‖⟪e i, v i⟫‖² ≤ ‖v i‖²` (one term of `‖v i‖² = ∑ k, ‖⟪e k, v i⟫‖²`); the product is Hadamard.
4. Equality case: independence makes each diagonal factor positive (basis determinant is a unit), so `Finset.prod_lt_prod` forces termwise sharpness; Bessel saturation then zeroes the off-diagonal coordinates ⟹ orthogonality.

## Verification

Type-checked against Mathlib (`lake env lean`); `#print axioms` on the headline theorems shows only `[propext, Classical.choice, Quot.sound]`. Registered in `Proofs.lean`; gallery `meta.json` + `annotations.json` added.