### PR TITLE
research(erdos-1023-oq-03): register orphaned 0-axiom lower-bound file in build graph

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1103,6 +1103,7 @@ import Proofs.Erdos1023OQ01
 import Proofs.Erdos1023OQ01OQ01
 import Proofs.Erdos1023OQ01Problem
 import Proofs.Erdos1023Problem
+import Proofs.Erdos1023ProblemOQ03
 import Proofs.Erdos1024Problem
 import Proofs.Erdos1025OQ04
 import Proofs.Erdos1025Problem


### PR DESCRIPTION
## Summary

`Erdos1023ProblemOQ03.lean` is shipped in the gallery as **erdos-1023-oq-03** (`verified`, 0 axioms, 11 theorems / 7 definitions / 0 sorries — explicit exponential lower bound `2ⁿ ≤ (n+1)·F(n)` for union-free families). But it was **never imported in `Proofs.lean`**, so it sat outside the build graph and was never CI-checked. This PR adds the single import line so the verified claim is actually enforced.

## Verification

Docker was unavailable, so kernel-checked directly via `lake env lean` against the v4.26.0 Mathlib pin:
- File compiles with **0 errors**.
- `#print axioms` on `unionFreeMax_exponential_lower_bound`, `unionFreeMax_ge_choose`, `layer_antichain`, `unionFreeMax_ge_two_pow_div` reports only `[propext, Classical.choice, Quot.sound]` — **no axioms, no native_decide**. Confirms the gallery's 0-axiom claim.

## Note on namespace collision

A separate file `Erdos1023OQ03.lean` (different math — k-union-free families — and **no gallery entry**) reuses the same `namespace Erdos1023OQ03` and re-declares the same infrastructure (`SetFamily`, `isUnionFree`, `layer`, …). Registering both would cause a declaration clash, so only the canonical gallery file (`Erdos1023ProblemOQ03.lean`) is registered here. The other orphan is left untouched (out of scope; it has no gallery entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)