### PR TITLE
research(pentagonal-number-theorem-oq-01-oq-01): ordered enumeration of the generalized pentagonal numbers (OEIS A001318) [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3345,6 +3345,7 @@ import Proofs.PellEquationOQ06OQ02
 import Proofs.PellEquationOQ07
 import Proofs.PellEquationOQ07OQ01
 import Proofs.PentagonalNumberTheoremOQ01
+import Proofs.PentagonalNumberTheoremOQ01OQ01
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ02
 import Proofs.PerfectNumbersOQ03

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean
@@ -1,0 +1,204 @@
+/-
+  # Pentagonal Number Theorem, OQ-01 → OQ-01:
+    The ordered enumeration of the generalized pentagonal numbers (OEIS A001318)
+
+  The parent entry `PentagonalNumberTheoremOQ01` builds the ℤ-indexed theory of the
+  generalized pentagonal numbers `g(k) = k(3k-1)/2` — the recognition criterion
+  (`m` is generalized pentagonal iff `24m+1` is a perfect square), injectivity of
+  the index map `k ↦ g(k)`, nonnegativity, and the concrete values
+  `g(0..±4) = 0,1,2,5,7,12,15,22,26`.  What it does **not** record is the *order*
+  structure: the index map `g : ℤ → ℤ` is injective but neither monotone nor
+  surjective onto an interval, and the generalized pentagonal numbers as a *set*
+  carry a canonical strictly-increasing enumeration
+
+      `0, 1, 2, 5, 7, 12, 15, 22, 26, 35, 40, …`   (OEIS A001318)
+
+  obtained by interleaving the two arms `g(k)` (k ≥ 1) and `g(-k)` (k ≥ 1) around
+  `g(0)=0`.  This file makes that enumeration precise.
+
+  ## What is proved (all 0-sorry, 0-axiom, building only on the parent + Mathlib)
+
+  * `genPent_succ_sub`            — the forward gap `g(k+1) - g(k) = 3k+1`;
+  * `genPent_lt_genPent_neg`      — `g(k) < g(-k)` for `k ≥ 1`  (the `±k` pair is ordered);
+  * `genPent_neg_lt_genPent_succ` — `g(-k) < g(k+1)` for `k ≥ 0`  (the interleaving step);
+  * `gpAt : ℕ → ℤ`               — the enumeration `0 ↦ g 0`, `2j-1 ↦ g j`, `2j ↦ g (-j)`;
+  * `gpAt_strictMono`            — **the enumeration is strictly increasing** (headline);
+  * `gpAt_injective`             — hence injective;
+  * `gpAt_isGenPent`             — every `gpAt n` is a generalized pentagonal number;
+  * `gpRank` / `gpAt_gpRank`     — the inverse rank `g(k) = gpAt (gpRank k)`;
+  * `isGenPent_iff_mem_range`    — **surjectivity**: `IsGenPent m ↔ ∃ n, gpAt n = m`;
+  * `range_gpAt`                 — `Set.range gpAt = {m | IsGenPent m}` (range = the set);
+  * `gpAt_enumerates`            — the capstone: `gpAt` is a strictly-increasing
+                                   bijection onto the generalized pentagonal numbers;
+  * `mem_range_gpAt_iff_isSquare`— ties the enumeration back to the parent's
+                                   square-discriminant criterion.
+
+  Together these say: the generalized pentagonal numbers are exactly the values of
+  the strictly-monotone sequence `gpAt`, so `gpAt n` is *the n-th smallest*
+  generalized pentagonal number — the order-theoretic content underlying A001318.
+-/
+
+import Mathlib
+import Proofs.PentagonalNumberTheoremOQ01
+
+set_option maxHeartbeats 400000
+
+namespace PentagonalNumberTheoremOQ01OQ01
+
+open PentagonalNumberTheoremOQ01
+
+/-! ## Part 1: The forward gap and the ordering of the `±k` pair
+
+The whole enumeration rests on three inequalities.  The forward gap
+`g(k+1) - g(k) = 3k+1` is an exact algebraic identity (from `2g(k)=k(3k-1)`); the
+parent's `genPent_neg : g(-k) = g(k)+k` then orders the `±k` pair and shows the
+arms interleave. -/
+
+/-- **Forward gap.** `g(k+1) - g(k) = 3k+1`, since `2(g(k+1)-g(k)) = (k+1)(3k+2) -
+k(3k-1) = 6k+2`. -/
+theorem genPent_succ_sub (k : ℤ) : genPent (k + 1) - genPent k = 3 * k + 1 := by
+  have key : 2 * (genPent (k + 1) - genPent k) = 2 * (3 * k + 1) := by
+    linear_combination two_mul_genPent (k + 1) - two_mul_genPent k
+  linarith
+
+/-- **The `±k` pair is ordered.** `g(k) < g(-k)` for `k ≥ 1`: by `genPent_neg`
+their difference is exactly `k ≥ 1`. -/
+theorem genPent_lt_genPent_neg {k : ℤ} (hk : 1 ≤ k) : genPent k < genPent (-k) := by
+  rw [genPent_neg]; linarith
+
+/-- **The arms interleave.** `g(-k) < g(k+1)` for `k ≥ 0`: from `genPent_neg`
+(`g(-k)=g(k)+k`) and the gap (`g(k+1)=g(k)+3k+1`), the difference is `2k+1 ≥ 1`. -/
+theorem genPent_neg_lt_genPent_succ {k : ℤ} (hk : 0 ≤ k) :
+    genPent (-k) < genPent (k + 1) := by
+  have hneg := genPent_neg k
+  have hgap := genPent_succ_sub k
+  linarith
+
+/-! ## Part 2: The enumeration `gpAt`
+
+`gpAt n` lists the generalized pentagonal numbers in increasing order: `gpAt 0 = g 0`,
+the odd positions `2j-1` carry the positive arm `g j`, and the even positions `2j`
+carry the negative arm `g(-j)`.  We package this with even/odd reduction lemmas so
+the index bookkeeping (ℕ ↔ ℤ casts, `n % 2`, `n / 2`) is discharged once. -/
+
+/-- The increasing enumeration of generalized pentagonal numbers.  Even index `2j`
+gives the negative arm `g(-j)`; odd index `2j+1` gives the positive arm `g(j+1)`. -/
+def gpAt (n : ℕ) : ℤ :=
+  if n % 2 = 0 then genPent (-(n / 2 : ℕ)) else genPent ((n + 1) / 2 : ℕ)
+
+/-- Reduction at even positions: `gpAt (2j) = g(-j)`. -/
+theorem gpAt_even (j : ℕ) : gpAt (2 * j) = genPent (-(j : ℤ)) := by
+  unfold gpAt
+  rw [if_pos (by omega), show (2 * j) / 2 = j from by omega]
+
+/-- Reduction at odd positions: `gpAt (2j+1) = g(j+1)`. -/
+theorem gpAt_odd (j : ℕ) : gpAt (2 * j + 1) = genPent ((j : ℤ) + 1) := by
+  unfold gpAt
+  rw [if_neg (by omega), show (2 * j + 1 + 1) / 2 = j + 1 from by omega]
+  norm_cast
+
+/-- **Headline: the enumeration is strictly increasing.** Consecutive values satisfy
+`gpAt n < gpAt (n+1)`: at an even step `2j → 2j+1` this is `g(-j) < g(j+1)`
+(interleaving), at an odd step `2j+1 → 2j+2` it is `g(j+1) < g(-(j+1))` (ordered
+pair). -/
+theorem gpAt_strictMono : StrictMono gpAt := by
+  apply strictMono_nat_of_lt_succ
+  intro n
+  rcases Nat.even_or_odd n with ⟨j, rfl⟩ | ⟨j, rfl⟩
+  · -- n = j + j (even)
+    rw [show j + j = 2 * j from (two_mul j).symm, gpAt_even, gpAt_odd]
+    exact genPent_neg_lt_genPent_succ (Nat.cast_nonneg j)
+  · -- n = 2j + 1 (odd)
+    rw [show 2 * j + 1 + 1 = 2 * (j + 1) from by ring, gpAt_odd, gpAt_even]
+    have h1 : (1 : ℤ) ≤ (j : ℤ) + 1 := by have := Nat.cast_nonneg (α := ℤ) j; linarith
+    have := genPent_lt_genPent_neg h1
+    push_cast
+    linarith
+
+/-- The enumeration is injective (strict monotonicity). -/
+theorem gpAt_injective : Function.Injective gpAt := gpAt_strictMono.injective
+
+/-- Every enumerated value is a generalized pentagonal number. -/
+theorem gpAt_isGenPent (n : ℕ) : IsGenPent (gpAt n) := by
+  unfold gpAt
+  split <;> exact genPent_isGenPent _
+
+/-! ## Part 3: The inverse rank and surjectivity
+
+`gpRank k` returns the position of `g(k)` in the enumeration, and `gpAt_gpRank`
+shows it is a genuine inverse on values.  Combined with the fact that every
+generalized pentagonal number is some `g(k)`, this gives surjectivity of `gpAt`
+onto `{m | IsGenPent m}`. -/
+
+/-- Every generalized pentagonal number is `g(k)` for an explicit index `k`. -/
+theorem isGenPent_exists_index {m : ℤ} (h : IsGenPent m) : ∃ k : ℤ, m = genPent k := by
+  obtain ⟨k, hk⟩ := h
+  refine ⟨k, ?_⟩
+  have h2 : 2 * m = 2 * genPent k := by rw [hk, two_mul_genPent k]
+  exact mul_left_cancel₀ (by norm_num) h2
+
+/-- The rank of `g(k)` in the enumeration: positive indices land on odd positions,
+nonpositive indices on even positions. -/
+def gpRank (k : ℤ) : ℕ := if 1 ≤ k then 2 * (k.toNat - 1) + 1 else 2 * (-k).toNat
+
+/-- **The rank inverts the enumeration on values:** `gpAt (gpRank k) = g(k)`. -/
+theorem gpAt_gpRank (k : ℤ) : gpAt (gpRank k) = genPent k := by
+  unfold gpRank
+  by_cases hk : 1 ≤ k
+  · rw [if_pos hk, gpAt_odd]
+    congr 1
+    have h0 : 0 ≤ k := by linarith
+    have ht : (k.toNat : ℤ) = k := Int.toNat_of_nonneg h0
+    have ht1 : 1 ≤ k.toNat := by omega
+    rw [Nat.cast_sub ht1, ht]
+    push_cast
+    ring
+  · rw [if_neg hk, gpAt_even]
+    congr 1
+    have h0 : 0 ≤ -k := by omega
+    have ht : ((-k).toNat : ℤ) = -k := Int.toNat_of_nonneg h0
+    rw [ht]
+    ring
+
+/-- **Surjectivity onto the generalized pentagonal numbers.** Every generalized
+pentagonal number appears in the enumeration. -/
+theorem exists_gpAt_eq {m : ℤ} (h : IsGenPent m) : ∃ n : ℕ, gpAt n = m := by
+  obtain ⟨k, rfl⟩ := isGenPent_exists_index h
+  exact ⟨gpRank k, gpAt_gpRank k⟩
+
+/-- **Characterization of the range.** `m` is a generalized pentagonal number iff it
+occurs in the enumeration `gpAt`. -/
+theorem isGenPent_iff_mem_range (m : ℤ) : IsGenPent m ↔ ∃ n : ℕ, gpAt n = m :=
+  ⟨exists_gpAt_eq, by rintro ⟨n, rfl⟩; exact gpAt_isGenPent n⟩
+
+/-- **The range of the enumeration is exactly the set of generalized pentagonal
+numbers.** -/
+theorem range_gpAt : Set.range gpAt = {m : ℤ | IsGenPent m} := by
+  ext m
+  simp only [Set.mem_range, Set.mem_setOf_eq]
+  exact (isGenPent_iff_mem_range m).symm
+
+/-! ## Part 4: Capstone and the bridge to the square-discriminant criterion -/
+
+/-- **Capstone.** The generalized pentagonal numbers are precisely the values of the
+strictly-increasing sequence `gpAt`; equivalently, `gpAt n` is the `n`-th smallest
+generalized pentagonal number.  This is the order-theoretic content underlying
+OEIS A001318. -/
+theorem gpAt_enumerates :
+    StrictMono gpAt ∧ Set.range gpAt = {m : ℤ | IsGenPent m} :=
+  ⟨gpAt_strictMono, range_gpAt⟩
+
+/-- **Enumeration meets the recognition criterion.** Composing surjectivity with the
+parent's square-discriminant criterion, a number occurs in the enumeration iff
+`24m+1` is a perfect square. -/
+theorem mem_range_gpAt_iff_isSquare (m : ℤ) :
+    (∃ n : ℕ, gpAt n = m) ↔ ∃ s : ℤ, 24 * m + 1 = s ^ 2 := by
+  rw [← isGenPent_iff_mem_range, isGenPent_iff_isSquare]
+
+/-- Sanity check against OEIS A001318: the first seven terms are `0,1,2,5,7,12,15`. -/
+theorem gpAt_values :
+    gpAt 0 = 0 ∧ gpAt 1 = 1 ∧ gpAt 2 = 2 ∧ gpAt 3 = 5 ∧
+      gpAt 4 = 7 ∧ gpAt 5 = 12 ∧ gpAt 6 = 15 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_⟩ <;> decide
+
+end PentagonalNumberTheoremOQ01OQ01

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "pent-oq0101-header",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "concept",
+    "title": "The open question: from an injective index map to an ordered enumeration",
+    "content": "The parent entry built the ℤ-indexed index theory of the generalized pentagonal numbers g(k)=k(3k-1)/2 — the recognition criterion, injectivity of k ↦ g(k), nonnegativity, concrete values. What it does NOT record is the ORDER: the index map g : ℤ → ℤ is injective but neither monotone nor surjective onto an interval, so g(n) is not the n-th pentagonal number. The pentagonal numbers as a SET carry a canonical strictly-increasing enumeration 0,1,2,5,7,12,15,22,26,… (OEIS A001318) obtained by interleaving the two arms g(k) (k ≥ 1) and g(-k) (k ≥ 1) around g(0)=0. This file constructs that enumeration gpAt and proves it is a strictly-increasing bijection onto the pentagonal set — so gpAt n really is the n-th smallest generalized pentagonal number.",
+    "mathContext": "$g:\\mathbb{Z}\\to\\mathbb{Z}$ injective but not monotone; the set $\\{g(k)\\}$ enumerated in order is OEIS A001318.",
+    "significance": "key",
+    "relatedConcepts": ["generalized pentagonal numbers", "OEIS A001318", "strictly monotone enumeration", "order isomorphism", "interleaving of arms"],
+    "prerequisites": ["the parent index theory", "strict monotonicity on ℕ"]
+  },
+  {
+    "id": "pent-oq0101-imports",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 41, "endLine": 48 },
+    "type": "context",
+    "title": "Imports and the parent namespace",
+    "content": "Brings in Mathlib and the parent file Proofs.PentagonalNumberTheoremOQ01, then opens the parent namespace PentagonalNumberTheoremOQ01 so its lemmas — genPent, IsGenPent, two_mul_genPent, genPent_neg, genPent_isGenPent, isGenPent_iff_isSquare — are available unqualified. The entire enumeration is a thin order-theoretic layer over the parent's already-proved algebraic facts; no new number theory is introduced.",
+    "mathContext": "Parent engine: $2\\,g(k) = k(3k-1)$ (two_mul_genPent) and $g(-k) = g(k)+k$ (genPent_neg).",
+    "significance": "context",
+    "relatedConcepts": ["namespace import", "dependency reuse", "Mathlib"],
+    "prerequisites": ["Lean 4 imports", "namespaces"]
+  },
+  {
+    "id": "pent-oq0101-gap-ordering",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 50, "endLine": 75 },
+    "type": "insight",
+    "title": "Three inequalities: the forward gap and the ±k pair",
+    "content": "The whole enumeration rests on three integer inequalities. genPent_succ_sub gives the exact forward gap g(k+1)-g(k)=3k+1 as a single linear_combination of the parent's two_mul_genPent at k and k+1. The parent's pairing genPent_neg (g(-k)=g(k)+k) then yields genPent_lt_genPent_neg: g(k) < g(-k) for k ≥ 1 (their difference is exactly k, so the ±k pair is ordered with the negative arm above the positive). Combining the pairing with the gap gives genPent_neg_lt_genPent_succ: g(-k) < g(k+1) for k ≥ 0 (difference 2k+1 ≥ 1, so the arms interleave). These two inequalities are precisely the consecutive-step facts the monotonicity proof consumes.",
+    "mathContext": "$g(-k)-g(k)=k$ (ordered pair); $g(k+1)-g(-k)=(3k+1)-k=2k+1$ (interleaving step).",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination", "forward difference", "±k pairing genPent_neg", "interleaving"],
+    "prerequisites": ["integer inequalities", "the doubling relation 2g(k)=k(3k-1)"]
+  },
+  {
+    "id": "pent-oq0101-gpat-strictmono",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 77, "endLine": 124 },
+    "type": "insight",
+    "title": "The enumeration gpAt and the headline strict monotonicity",
+    "content": "gpAt encodes the interleaving by the parity of the index: even position 2j carries the negative arm g(-j), odd position 2j+1 carries the positive arm g(j+1) (so gpAt 0 = g(0)). The reduction lemmas gpAt_even and gpAt_odd discharge the ℕ↔ℤ cast and n%2/n/2 bookkeeping once. The headline gpAt_strictMono uses strictMono_nat_of_lt_succ to reduce monotonicity to gpAt n < gpAt (n+1), then Nat.even_or_odd splits: the even step 2j → 2j+1 is the interleaving inequality g(-j) < g(j+1), the odd step 2j+1 → 2j+2 is the ordered-pair inequality g(j+1) < g(-(j+1)). Strict monotonicity immediately gives gpAt_injective via StrictMono.injective, and gpAt_isGenPent confirms every enumerated value is a generalized pentagonal number.",
+    "mathContext": "even $2j\\mapsto g(-j)$, odd $2j+1\\mapsto g(j+1)$; consecutive steps dispatch to the two Part-1 inequalities.",
+    "significance": "key",
+    "relatedConcepts": ["strictMono_nat_of_lt_succ", "Nat.even_or_odd", "StrictMono.injective", "parity encoding"],
+    "prerequisites": ["strict monotonicity of ℕ-sequences", "even/odd case analysis"]
+  },
+  {
+    "id": "pent-oq0101-rank-surjectivity",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 126, "endLine": 180 },
+    "type": "technique",
+    "title": "The inverse rank gpRank and surjectivity",
+    "content": "isGenPent_exists_index extracts from the parent's doubling relation that every generalized pentagonal number is g(k) for an explicit index k (cancelling the factor 2 via mul_left_cancel₀). gpRank then names the position of g(k) — positive indices land on odd positions 2(k-1)+1, nonpositive indices on even positions 2(-k) — and gpAt_gpRank proves gpAt (gpRank k) = g(k), so the rank genuinely inverts the enumeration on values (the Int.toNat_of_nonneg bookkeeping reconciles the ℕ-valued rank with the ℤ-index). Composing the two gives exists_gpAt_eq (surjectivity) and hence range_gpAt: Set.range gpAt = {m | IsGenPent m} — the enumeration hits exactly the parent's recognized set.",
+    "mathContext": "$\\mathrm{gpRank}(k) = 2(k-1)+1$ for $k\\ge 1$, $2(-k)$ for $k\\le 0$; $\\mathrm{gpAt}(\\mathrm{gpRank}\\,k)=g(k)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Int.toNat_of_nonneg", "mul_left_cancel₀", "left inverse on values", "surjectivity"],
+    "prerequisites": ["ℤ↔ℕ casts", "the parent's membership predicate IsGenPent"]
+  },
+  {
+    "id": "pent-oq0101-capstone",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 181, "endLine": 198 },
+    "type": "insight",
+    "title": "Capstone: a strictly-increasing bijection, bridged to 24m+1=□",
+    "content": "gpAt_enumerates bundles StrictMono gpAt with Set.range gpAt = {m | IsGenPent m}: the generalized pentagonal numbers are precisely the values of a strictly-increasing sequence, so gpAt is an order isomorphism onto them and gpAt n is the n-th smallest. mem_range_gpAt_iff_isSquare then composes surjectivity with the parent's recognition criterion isGenPent_iff_isSquare, giving the directly-usable statement that a number occurs in the enumeration iff 24m+1 is a perfect square — uniting the order viewpoint of this entry with the square-discriminant viewpoint of the parent.",
+    "mathContext": "$\\mathrm{StrictMono}\\,\\mathrm{gpAt}\\ \\wedge\\ \\mathrm{range}\\,\\mathrm{gpAt}=\\{m\\mid \\mathrm{IsGenPent}\\,m\\}$; occurrence $\\iff 24m+1=s^2$.",
+    "significance": "key",
+    "relatedConcepts": ["order isomorphism", "bijection", "square-discriminant criterion", "n-th smallest"],
+    "prerequisites": ["range of a function", "the parent's isGenPent_iff_isSquare"]
+  },
+  {
+    "id": "pent-oq0101-values",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-01",
+    "range": { "startLine": 199, "endLine": 204 },
+    "type": "context",
+    "title": "OEIS A001318 sanity check and axiom status",
+    "content": "gpAt_values checks the first seven terms gpAt 0..6 = 0,1,2,5,7,12,15 against OEIS A001318 by kernel decide (not native_decide, so no Lean.ofReduceBool). The entry is honestly badged original / verified with axiomCount 0: 0 sorries, 0 axiom declarations, no structure-encoded hypotheses, and the headline theorems gpAt_strictMono, gpAt_enumerates, range_gpAt, mem_range_gpAt_iff_isSquare each #print axioms to only [propext, Classical.choice, Quot.sound]. The file compiles cleanly against Mathlib 4.26.0.",
+    "mathContext": "Axioms: $\\{\\text{propext},\\ \\text{Classical.choice},\\ \\text{Quot.sound}\\}$ only; kernel decide, no ofReduceBool.",
+    "significance": "context",
+    "relatedConcepts": ["OEIS A001318", "kernel decide vs native_decide", "axiom integrity", "#print axioms"],
+    "prerequisites": ["Lean decide tactic", "trusted kernel"]
+  }
+]

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PentagonalNumberTheoremOQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pentagonalNumberTheoremOQ01OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pentagonalNumberTheoremOQ01OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pentagonalNumberTheoremOQ01OQ01Data: ProofData = {
+  proof: pentagonalNumberTheoremOQ01OQ01Proof,
+  annotations: pentagonalNumberTheoremOQ01OQ01Annotations,
+}

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-01/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "pentagonal-number-theorem-oq-01-oq-01",
+  "title": "Pentagonal Number Theorem: The Ordered Enumeration of the Generalized Pentagonal Numbers (OEIS A001318)",
+  "slug": "pentagonal-number-theorem-oq-01-oq-01",
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.PentagonalNumberTheoremOQ01"
+    ],
+    "opens": [
+      "PentagonalNumberTheoremOQ01"
+    ],
+    "namespace": "PentagonalNumberTheoremOQ01OQ01",
+    "lineCount": 204,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 2,
+    "path": "Proofs/PentagonalNumberTheoremOQ01OQ01.lean",
+    "sorries": 0
+  },
+  "description": "Supplies the order-theoretic content missing from the parent's index theory: the parent's index map g(k)=k(3k-1)/2 is injective but neither monotone nor surjective onto an interval, so the generalized pentagonal numbers as a SET carry a canonical strictly-increasing enumeration 0,1,2,5,7,12,15,22,26,… (OEIS A001318) obtained by interleaving the two arms g(k) and g(-k) around g(0)=0. This entry constructs that enumeration gpAt : ℕ → ℤ, proves it is strictly monotone (hence injective), that its range is exactly {m | IsGenPent m}, and packages the capstone gpAt_enumerates: gpAt is a strictly-increasing bijection onto the generalized pentagonal numbers — so gpAt n is THE n-th smallest generalized pentagonal number. The enumeration is then tied back to the parent's square-discriminant criterion (24m+1=□). All 0-sorry, 0-axiom, building only on the parent entry and Mathlib.",
+  "meta": {
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "partitions",
+      "pentagonal-numbers",
+      "integer-arithmetic",
+      "order-theory",
+      "enumeration",
+      "research"
+    ],
+    "mathlib_version": "4.26.0",
+    "proofRepoPath": "Proofs/PentagonalNumberTheoremOQ01OQ01.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "strictMono_nat_of_lt_succ",
+        "description": "(∀ n, f n < f (n+1)) → StrictMono f — reduces the headline monotonicity of gpAt to the two consecutive-step inequalities (even step = interleaving, odd step = ordered ±k pair)",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "StrictMono.injective",
+        "description": "a strictly monotone function on a linear order is injective — gives gpAt_injective for free from gpAt_strictMono",
+        "module": "Mathlib.Order.Monotone.Basic"
+      },
+      {
+        "theorem": "Nat.even_or_odd",
+        "description": "every natural number is even or odd — the case split n = 2j / n = 2j+1 driving the consecutive-step proof of strict monotonicity",
+        "module": "Mathlib.Algebra.Parity"
+      },
+      {
+        "theorem": "Int.toNat_of_nonneg",
+        "description": "0 ≤ a → (a.toNat : ℤ) = a — converts the ℤ-index k back through the ℕ-valued rank gpRank when proving gpAt (gpRank k) = g(k)",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "mul_left_cancel₀",
+        "description": "a ≠ 0 → a*b = a*c → b = c — recovers the explicit index k from a generalized pentagonal value via 2m = 2·g(k), reused from the parent's doubling relation",
+        "module": "Mathlib.Algebra.GroupWithZero.Basic"
+      }
+    ],
+    "originalContributions": [
+      "gpAt (def) and gpAt_strictMono: the canonical strictly-increasing enumeration of the generalized pentagonal numbers, with even index 2j carrying the negative arm g(-j) and odd index 2j+1 carrying the positive arm g(j+1). Strict monotonicity is the headline — gpAt n is the n-th smallest generalized pentagonal number, the order structure underlying OEIS A001318 that the parent's injective-but-non-monotone index map g does not record.",
+      "genPent_succ_sub: the exact forward gap g(k+1)-g(k)=3k+1, a one-line linear_combination of the parent's doubling relation two_mul_genPent at k and k+1 — the algebraic engine of the ordering.",
+      "genPent_lt_genPent_neg and genPent_neg_lt_genPent_succ: the two inequalities that order the ±k pair (g(k) < g(-k) for k ≥ 1, difference exactly k) and interleave the arms (g(-k) < g(k+1) for k ≥ 0, difference 2k+1), both read off from the parent's genPent_neg pairing g(-k)=g(k)+k together with the forward gap.",
+      "gpRank (def) and gpAt_gpRank: an explicit inverse rank g(k) ↦ position, sending positive indices to odd positions and nonpositive indices to even positions, with gpAt (gpRank k) = g(k) proving it genuinely inverts the enumeration on values.",
+      "range_gpAt / isGenPent_iff_mem_range: surjectivity — the range of gpAt is exactly the set {m | IsGenPent m} of generalized pentagonal numbers; combined with strict monotonicity this is the bijection.",
+      "gpAt_enumerates: the capstone packaging StrictMono gpAt ∧ Set.range gpAt = {m | IsGenPent m} — the generalized pentagonal numbers are precisely the values of a strictly-increasing sequence, i.e. gpAt is an order isomorphism onto them.",
+      "mem_range_gpAt_iff_isSquare: ties the enumeration back to the parent's recognition criterion — a number occurs in gpAt iff 24m+1 is a perfect square — and gpAt_values machine-checks the first seven terms 0,1,2,5,7,12,15 against OEIS A001318."
+    ],
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "lineCount": 204,
+    "assumptions": "None counted: 0 axiom declarations, 0 sorries, no structure-encoded hypotheses. The headline results gpAt_strictMono, gpAt_enumerates, range_gpAt and mem_range_gpAt_iff_isSquare each #print axioms to only [propext, Classical.choice, Quot.sound] — the standard foundational axioms, none counted under the project's axiom policy. gpAt_values is discharged by decide (kernel Decidable evaluation, no native_decide / Lean.ofReduceBool). Machine-verified: the file compiles cleanly against Mathlib 4.26.0 (Built Proofs.PentagonalNumberTheoremOQ01OQ01, 7744 jobs, exit 0).",
+    "theoremCount": 16,
+    "definitionCount": 2
+  },
+  "overview": {
+    "historicalContext": "The generalized pentagonal numbers g(k)=k(3k-1)/2 for k ∈ ℤ are the exponents in Euler's pentagonal number theorem ∏(1-xⁿ)=∑(-1)ᵏx^{g(k)}. As a sequence ordered by size they are OEIS A001318: 0,1,2,5,7,12,15,22,26,35,40,…. The parent entry PentagonalNumberTheoremOQ01 builds the number-theoretic index theory — the recognition criterion, injectivity of k ↦ g(k), nonnegativity, concrete values — but the index map g : ℤ → ℤ, while injective, is neither monotone nor surjective onto an interval. The order in which A001318 lists the pentagonal numbers comes from interleaving the two arms g(k) (k ≥ 1, the positive arm) and g(-k) (k ≥ 1, the negative arm) around g(0)=0. This entry makes that interleaving precise and proves it is the unique increasing enumeration of the set.",
+    "problemStatement": "Construct the canonical strictly-increasing enumeration of the generalized pentagonal numbers and prove it is a bijection onto them. Concretely, build gpAt : ℕ → ℤ with gpAt 0 = g(0), odd positions carrying the positive arm and even positions the negative arm, and establish\n\n$$ \\mathrm{StrictMono}\\,\\mathrm{gpAt} \\quad\\text{and}\\quad \\mathrm{range}\\,\\mathrm{gpAt} = \\{\\, m \\mid m \\text{ is generalized pentagonal} \\,\\}, $$\n\nso that gpAt n is the n-th smallest generalized pentagonal number.",
+    "text": "An order-theoretic refinement of the parent's index theory: the strictly-increasing enumeration of the generalized pentagonal numbers, proved to be a bijection onto the set the parent recognizes via the square-discriminant test.",
+    "proofStrategy": "1. **Three inequalities (Part 1)**: the forward gap g(k+1)-g(k)=3k+1 is an exact identity (linear_combination of the parent's two_mul_genPent); the parent's genPent_neg (g(-k)=g(k)+k) then gives g(k) < g(-k) for k ≥ 1 (the ±k pair is ordered) and, with the gap, g(-k) < g(k+1) for k ≥ 0 (the arms interleave).\n\n2. **Enumeration and monotonicity (Part 2)**: define gpAt by the parity of n (even 2j ↦ g(-j), odd 2j+1 ↦ g(j+1)) with even/odd reduction lemmas discharging the ℕ↔ℤ cast bookkeeping once. strictMono_nat_of_lt_succ reduces monotonicity to consecutive steps, and the even/odd split feeds in exactly the two Part-1 inequalities.\n\n3. **Inverse rank and surjectivity (Part 3)**: gpRank k returns the position of g(k); gpAt_gpRank proves it inverts the enumeration on values. Since every generalized pentagonal number is some g(k) (from the parent's doubling relation), gpAt is surjective onto {m | IsGenPent m}, giving range_gpAt.\n\n4. **Capstone and bridge (Part 4)**: gpAt_enumerates bundles strict monotonicity with the range characterization; mem_range_gpAt_iff_isSquare composes surjectivity with the parent's recognition criterion, and gpAt_values checks the first seven A001318 terms by decide.",
+    "keyInsights": [
+      "The whole enumeration rests on three integer inequalities, each a one- or two-line consequence of the parent's doubling relation and ±k pairing: the forward gap 3k+1, the ordered pair (difference k), and the interleaving step (difference 2k+1).",
+      "Encoding the enumeration by the parity of the index — even 2j ↦ g(-j), odd 2j+1 ↦ g(j+1) — turns strict monotonicity into a single consecutive-step check that the even and odd cases dispatch to the two pairing inequalities.",
+      "Strict monotonicity does double duty: it is the headline order statement AND it delivers injectivity for free (StrictMono.injective), so the bijection onto the pentagonal set needs only surjectivity proved separately.",
+      "Surjectivity reduces to the parent's structural fact that every generalized pentagonal number is g(k) for an explicit index k; the rank gpRank then names the position, so the abstract range equals the parent's recognized set.",
+      "The order structure is genuinely new information: the parent's index map g is injective but not monotone, so 'the n-th pentagonal number' is not g(n) — it is gpAt n, the interleaving of the two arms."
+    ],
+    "prerequisites": [
+      "The parent entry's generalized-pentagonal index theory (genPent, IsGenPent, two_mul_genPent, genPent_neg, isGenPent_iff_isSquare)",
+      "Strict monotonicity of sequences on ℕ and order isomorphisms",
+      "Elementary integer arithmetic and parity reasoning"
+    ]
+  },
+  "sections": [
+    {
+      "id": "ordering",
+      "title": "Part 1 — The Forward Gap and the Ordering of the ±k Pair",
+      "startLine": 50,
+      "endLine": 75,
+      "summary": "genPent_succ_sub (the exact forward gap g(k+1)-g(k)=3k+1), genPent_lt_genPent_neg (g(k) < g(-k) for k ≥ 1, the ±k pair is ordered), and genPent_neg_lt_genPent_succ (g(-k) < g(k+1) for k ≥ 0, the arms interleave).",
+      "mathContext": "The gap is a linear_combination of the parent's two_mul_genPent at k and k+1. The pairing genPent_neg (g(-k)=g(k)+k) then makes g(-k)-g(k)=k ≥ 1 and, with the gap, g(k+1)-g(-k)=2k+1 ≥ 1 — the two inequalities that order and interleave the arms."
+    },
+    {
+      "id": "enumeration",
+      "title": "Part 2 — The Enumeration gpAt and Strict Monotonicity (Headline)",
+      "startLine": 77,
+      "endLine": 124,
+      "summary": "gpAt (even index 2j ↦ g(-j), odd index 2j+1 ↦ g(j+1)) with reduction lemmas gpAt_even / gpAt_odd, the headline gpAt_strictMono, gpAt_injective (from StrictMono.injective), and gpAt_isGenPent (every enumerated value is generalized pentagonal).",
+      "mathContext": "strictMono_nat_of_lt_succ reduces monotonicity to gpAt n < gpAt (n+1); the parity split sends the even step 2j → 2j+1 to the interleaving inequality g(-j) < g(j+1) and the odd step 2j+1 → 2j+2 to the ordered-pair inequality g(j+1) < g(-(j+1))."
+    },
+    {
+      "id": "surjectivity",
+      "title": "Part 3 — The Inverse Rank and Surjectivity",
+      "startLine": 126,
+      "endLine": 180,
+      "summary": "isGenPent_exists_index (every generalized pentagonal number is g(k) for an explicit k), gpRank (the position of g(k)), gpAt_gpRank (the rank inverts the enumeration on values), exists_gpAt_eq, isGenPent_iff_mem_range, and range_gpAt: Set.range gpAt = {m | IsGenPent m}.",
+      "mathContext": "gpRank sends positive indices to odd positions 2(k-1)+1 and nonpositive indices to even positions 2(-k); gpAt_gpRank checks gpAt (gpRank k) = g(k) by the parity definition. Composed with isGenPent_exists_index this gives surjectivity onto the parent's recognized set."
+    },
+    {
+      "id": "capstone",
+      "title": "Part 4 — Capstone and the Bridge to the Square-Discriminant Criterion",
+      "startLine": 181,
+      "endLine": 204,
+      "summary": "gpAt_enumerates (StrictMono gpAt ∧ Set.range gpAt = {m | IsGenPent m} — gpAt is a strictly-increasing bijection onto the generalized pentagonal numbers), mem_range_gpAt_iff_isSquare (a number occurs in gpAt iff 24m+1 is a perfect square), and gpAt_values (first seven terms 0,1,2,5,7,12,15 by decide).",
+      "mathContext": "The capstone bundles the order statement with the range characterization, so gpAt n is the n-th smallest generalized pentagonal number. The bridge composes surjectivity with the parent's isGenPent_iff_isSquare to recover the recognition criterion on the enumeration, and the value check pins the sequence to OEIS A001318."
+    }
+  ],
+  "openQuestions": [
+    "Strengthen gpAt_enumerates to an explicit OrderIso ℕ ≃o {m : ℤ // IsGenPent m}, packaging strict monotonicity and the range bijection as a single order isomorphism onto the subtype of generalized pentagonal numbers.",
+    "Give a closed form for gpRank ∘ (g restricted to one arm) and an inverse-rank formula expressing gpAt n directly via ⌈n/2⌉, exhibiting the n-th pentagonal number without the parity case split.",
+    "Use the enumeration to index Euler's partition recurrence p(n) = ∑(-1)^{k-1}(p(n-g_k)+p(n-g_{-k})) by rank, summing over the initial segment of gpAt below n rather than over the index interval [-n,n]."
+  ],
+  "conclusion": {
+    "summary": "This entry adds the order-theoretic layer to the parent's index theory: it constructs gpAt, the canonical strictly-increasing enumeration of the generalized pentagonal numbers obtained by interleaving the arms g(k) and g(-k) around g(0)=0, and proves it is a bijection onto the set {m | IsGenPent m} that the parent recognizes via 24m+1=□. The headline gpAt_strictMono together with range_gpAt gives the capstone gpAt_enumerates — gpAt n is the n-th smallest generalized pentagonal number — all machine-verified with 0 axioms and 0 sorries.",
+    "implications": "The parent's index map g is injective but not monotone, so 'the n-th generalized pentagonal number' is not g(n); this entry supplies the correct object gpAt n and proves it lists exactly OEIS A001318 in order. The whole construction rests on three short integer inequalities derived from the parent's doubling relation and ±k pairing, illustrating how an order structure can be bootstrapped from purely algebraic identities. The bijection range_gpAt is the form a formalization of Euler's partition recurrence wants when summing the pentagonal shifts by rank rather than by index.",
+    "openQuestions": [
+      "Promote the bijection to an explicit OrderIso ℕ ≃o {m // IsGenPent m}.",
+      "Derive a parity-free closed form for gpAt n (and its inverse gpRank) via ⌈n/2⌉.",
+      "Re-index Euler's partition recurrence by rank using the initial segment of gpAt below n."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "pentagonal-number-theorem-oq-01",
+      "relationship": "extends",
+      "description": "The parent entry: the division-free index theory of the generalized pentagonal numbers g(k)=k(3k-1)/2 — the recognition criterion 24m+1=□, injectivity of the index map, nonnegativity, the ±k pairing g(-k)=g(k)+k, and the concrete A001318 values. This entry consumes that pairing and the doubling relation to build the strictly-increasing enumeration the parent's injective-but-non-monotone index map does not provide, and ties the enumeration back to the parent's square-discriminant criterion."
+    },
+    {
+      "proofId": "partition-theorem",
+      "relationship": "related",
+      "description": "Euler's theorem that partitions into odd parts equinumerate partitions into distinct parts. The pentagonal exponents enumerated here in increasing order are exactly the supports of Euler's lacunary series ∏(1-xⁿ)=∑(-1)ᵏx^{g(k)} that governs the distinct-parts generating function."
+    },
+    {
+      "proofId": "triangular-reciprocals",
+      "relationship": "related",
+      "description": "The triangular numbers T(n)=n(n+1)/2 are the figurate neighbours of the pentagonal numbers g(k)=k(3k-1)/2; both are quadratic-in-index half-integers carrying a canonical increasing enumeration, and both admit a perfect-square recognition test (8m+1=□ for triangulars, 24m+1=□ for pentagonals)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Extends the gallery entry **pentagonal-number-theorem-oq-01** with the order-theoretic content its index theory omits. The parent's index map `g(k)=k(3k-1)/2` is injective but **neither monotone nor surjective onto an interval**, so `g(n)` is *not* the n-th pentagonal number. The generalized pentagonal numbers as a *set* carry a canonical strictly-increasing enumeration

> `0, 1, 2, 5, 7, 12, 15, 22, 26, 35, 40, …`  (OEIS A001318)

obtained by interleaving the two arms `g(k)` (k ≥ 1) and `g(-k)` (k ≥ 1) around `g(0)=0`. This entry constructs that enumeration and proves it is a strictly-increasing bijection onto the pentagonal set — so `gpAt n` really *is* the n-th smallest generalized pentagonal number.

## What is proved

- `genPent_succ_sub` — exact forward gap `g(k+1)-g(k)=3k+1` (a `linear_combination` of the parent's doubling relation)
- `genPent_lt_genPent_neg` / `genPent_neg_lt_genPent_succ` — the ±k pair is ordered and the arms interleave
- **`gpAt_strictMono`** (headline) — the enumeration `gpAt : ℕ → ℤ` is strictly increasing
- `gpRank` / `gpAt_gpRank` — explicit inverse rank, `gpAt (gpRank k) = g(k)`
- `range_gpAt` — surjectivity: `Set.range gpAt = {m | IsGenPent m}`
- **`gpAt_enumerates`** (capstone) — `gpAt` is a strictly-increasing bijection onto the generalized pentagonal numbers
- `mem_range_gpAt_iff_isSquare` — bridge to the parent's square-discriminant criterion `24m+1=□`
- `gpAt_values` — first seven terms match OEIS A001318 (kernel `decide`)

## Verification

- **16 theorems, 2 defs, 204 lines, 0 sorries, 0 axioms**
- Headline theorems `#print axioms` to only `[propext, Classical.choice, Quot.sound]` (no `native_decide` / `Lean.ofReduceBool`)
- Builds clean against Mathlib 4.26.0: `Built Proofs.PentagonalNumberTheoremOQ01OQ01`, 7744 jobs, exit 0
- Gallery data (meta.json, annotations.json, index.ts) added; annotation ranges validated against source

Status: `verified` / badge `original`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)