### PR TITLE
research(basel-problem-oq-08-oq-02-oq-01): ζ(8) = π⁸/9450 and π-free ratio ζ(8)/ζ(2)⁴ = 24/175

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -285,6 +285,7 @@ import Proofs.BaselProblemOQ04OQ03
 import Proofs.BaselProblemOQ05
 import Proofs.BaselProblemOQ08
 import Proofs.BaselProblemOQ08OQ02
+import Proofs.BaselProblemOQ08OQ02OQ01
 import Proofs.BaselProblemOQ09
 import Proofs.BaselProblemOQ10
 import Proofs.BaselProblemOQ11

--- a/proofs/Proofs/BaselProblemOQ08OQ02OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ08OQ02OQ01.lean
@@ -1,0 +1,98 @@
+/-
+# Basel Problem OQ-08-OQ-02-OQ-01: the value ζ(8) = π⁸/9450 and the π-free ratio ζ(8)/ζ(2)⁴
+
+## Open Question
+Formalize `∑' n, 1 / n⁸ = π⁸ / 9450`, the next even-argument value after the parent
+`ζ(6) = π⁶/945` (itself following `ζ(2) = π²/6` and `ζ(4) = π⁴/90`), by instantiating
+Mathlib's even-zeta formula `hasSum_zeta_nat` / `riemannZeta_two_mul_nat` at `k = 4`,
+plus the dimensionless (π-free) Euler ratio `ζ(8) / ζ(2)⁴ = 24/175`.
+
+## Approach
+Mathlib proves the general even-zeta formula
+`hasSum_zeta_nat : HasSum (fun n => 1/n^(2k)) ((-1)^(k+1)·2^(2k-1)·π^(2k)·B_{2k}/(2k)!)`.
+As with `ζ(6)`, Mathlib packages `bernoulli'_two`, `bernoulli'_four` (both `@[simp]`)
+but provides no `bernoulli'_six` or `bernoulli'_eight`. We first compute
+`bernoulli 6 = 1/42` and then `bernoulli 8 = -1/30` from the defining recurrence
+`bernoulli'_def`, supplying the non-`simp` summands `bernoulli' 5 = bernoulli' 7 = 0`
+(odd indices `> 1`) and the freshly-computed `bernoulli' 6 = 1/42`.
+Substituting `k = 4` then gives `2⁷·π⁸·(−1/30)/40320 = π⁸/9450`.
+
+The companion `riemannZeta_two_mul_nat` gives the value of the analytically-continued
+`riemannZeta 8`. Finally, dividing `ζ(8) = π⁸/9450` by `ζ(2)⁴ = π⁸/1296` cancels π,
+leaving the rational `1296/9450 = 24/175`, the degree-8 analogue of the parent's
+`ζ(6)/ζ(2)³ = 8/35` and `ζ(4)/ζ(2)² = 2/5`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace BaselProblemOQ08OQ02OQ01
+
+open Real BigOperators
+
+/-- **The sixth Bernoulli number `B₆ = 1/42`.** Mathlib packages `bernoulli'_two` and
+`bernoulli'_four` but not `bernoulli'_six`; we compute it from the defining recurrence
+`bernoulli'_def`, using that the odd-index `bernoulli' 5` vanishes. (Identical to the
+parent ζ(6) entry's lemma; reproduced here because `B₆` is a summand of the `B₈`
+recurrence.) -/
+theorem bernoulli_six : (bernoulli 6 : ℚ) = 1 / 42 := by
+  have h5 : bernoulli' 5 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide : (6 : ℕ) ≠ 1), bernoulli'_def]
+  norm_num [Finset.sum_range_succ, Finset.sum_range_zero, h5,
+    show Nat.choose 6 1 = 6 from rfl, show Nat.choose 6 2 = 15 from rfl,
+    show Nat.choose 6 3 = 20 from rfl, show Nat.choose 6 4 = 15 from rfl,
+    show Nat.choose 6 5 = 6 from rfl]
+
+/-- **The eighth Bernoulli number `B₈ = −1/30`.** Computed from `bernoulli'_def`, using
+that the odd-index `bernoulli' 5` and `bernoulli' 7` vanish and that `bernoulli' 6 = 1/42`
+(from `bernoulli_six`); the lower summands `bernoulli' 0..4` are resolved by their
+`@[simp]` lemmas. Remarkably `B₈ = B₄ = −1/30`. -/
+theorem bernoulli_eight : (bernoulli 8 : ℚ) = -1 / 30 := by
+  have h5 : bernoulli' 5 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  have h7 : bernoulli' 7 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  have h6 : bernoulli' 6 = 1 / 42 := by
+    rw [← bernoulli_eq_bernoulli'_of_ne_one (by decide : (6 : ℕ) ≠ 1)]; exact bernoulli_six
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide : (8 : ℕ) ≠ 1), bernoulli'_def]
+  norm_num [Finset.sum_range_succ, Finset.sum_range_zero, h5, h6, h7,
+    show Nat.choose 8 1 = 8 from rfl, show Nat.choose 8 2 = 28 from rfl,
+    show Nat.choose 8 3 = 56 from rfl, show Nat.choose 8 4 = 70 from rfl,
+    show Nat.choose 8 5 = 56 from rfl, show Nat.choose 8 6 = 28 from rfl,
+    show Nat.choose 8 7 = 8 from rfl]
+
+/-- The summable family `n ↦ 1/n⁸` has sum `π⁸/9450`, the `k = 4` instance of Mathlib's
+even-zeta formula `hasSum_zeta_nat`. -/
+theorem hasSum_one_div_nat_pow_eight :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8) (π ^ 8 / 9450) := by
+  convert hasSum_zeta_nat (by norm_num : (4 : ℕ) ≠ 0) using 1
+  rw [show (2 * 4 : ℕ) = 8 from rfl, bernoulli_eight]
+  norm_num [Nat.factorial]
+  ring
+
+/-- **ζ(8) = π⁸/9450.** The infinite sum `∑' n, 1/n⁸` over the naturals equals `π⁸/9450`. -/
+theorem tsum_one_div_nat_pow_eight :
+    ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8 = π ^ 8 / 9450 :=
+  hasSum_one_div_nat_pow_eight.tsum_eq
+
+/-- The Riemann zeta function at `8` equals `π⁸/9450`, via Mathlib's
+`riemannZeta_two_mul_nat` at `k = 4`. -/
+theorem riemannZeta_eight_eq : riemannZeta 8 = (π : ℂ) ^ 8 / 9450 := by
+  have h := riemannZeta_two_mul_nat (by norm_num : (4 : ℕ) ≠ 0)
+  rw [show (2 * 4 : ℕ) = 8 from rfl, bernoulli_eight,
+    show (2 : ℂ) * ((4 : ℕ) : ℂ) = 8 by norm_num] at h
+  rw [h]
+  push_cast [Nat.factorial]
+  ring
+
+/-- **Euler's ratio `ζ(8) / ζ(2)⁴ = 24/175`.** Dividing the even-zeta values
+`ζ(8) = π⁸/9450` and `ζ(2) = π²/6` makes π cancel (`ζ(2)⁴ = π⁸/1296`), leaving the
+rational `1296/9450 = 24/175`. This is the degree-8 analogue of `ζ(6)/ζ(2)³ = 8/35`
+and `ζ(4)/ζ(2)² = 2/5`. -/
+theorem tsum_eight_div_tsum_two_pow_four :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8) / (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 4 = 24 / 175 := by
+  rw [tsum_one_div_nat_pow_eight, hasSum_zeta_two.tsum_eq]
+  have hπ : (π : ℝ) ≠ 0 := Real.pi_ne_zero
+  have h8 : (π : ℝ) ^ 8 ≠ 0 := pow_ne_zero _ hπ
+  field_simp
+  ring
+
+end BaselProblemOQ08OQ02OQ01

--- a/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "baseloq08oq02oq01-header",
+    "proofId": "basel-problem-oq-08-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question, posed by the parent $\\zeta(6)$ entry, asks for $\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$, the degree-8 even-zeta value, plus the π-free ratio $\\zeta(8)/\\zeta(2)^4$. Euler's 1740 formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=4$ using $B_8 = -1/30$. Mathlib formalizes the underlying Hurwitz-zeta computation as `hasSum_zeta_nat`, but stops its packaged Bernoulli evaluations at $B_4$ — so the entry must first compute $B_6$ and then $B_8$, the recurrence for $B_8$ consuming $B_6$ as a summand."
+  },
+  {
+    "id": "baseloq08oq02oq01-bernoulli-numbers",
+    "proofId": "basel-problem-oq-08-oq-02-oq-01",
+    "range": {
+      "startLine": 32,
+      "endLine": 62
+    },
+    "type": "theorem",
+    "title": "The Bernoulli Numbers B₆ = 1/42 and B₈ = −1/30",
+    "content": "`bernoulli_six` recomputes $B_6 = 1/42$ (reused here because it is a summand of the $B_8$ recurrence). `bernoulli_eight` then proves $B_8 = -1/30$ by expanding the defining recurrence $B_n = 1 - \\sum_{k<n}\\binom{n}{k}B_k/(n+1-k)$ over $k = 0,\\dots,7$: the odd terms $B_5 = B_7 = 0$ come from `bernoulli'_eq_zero_of_odd`, $B_6 = 1/42$ is bridged in via `bernoulli_eq_bernoulli'_of_ne_one`, the lower $B_0,\\dots,B_4$ are resolved by their `@[simp]` lemmas, and the binomials $\\binom{8}{1},\\dots,\\binom{8}{7} = 8,28,56,70,56,28,8$ are supplied to `norm_num`. Remarkably $B_8 = B_4 = -1/30$."
+  },
+  {
+    "id": "baseloq08oq02oq01-zeta-eight",
+    "proofId": "basel-problem-oq-08-oq-02-oq-01",
+    "range": {
+      "startLine": 63,
+      "endLine": 88
+    },
+    "type": "theorem",
+    "title": "The Value ζ(8) = π⁸/9450",
+    "content": "`tsum_one_div_nat_pow_eight` is the headline result $\\sum' n,\\ 1/n^8 = \\pi^8/9450$. It comes from `hasSum_one_div_nat_pow_eight`, the $k=4$ instance of `hasSum_zeta_nat`: substituting $B_8 = -1/30$ and $8! = 40320$ into $(-1)^5\\cdot 2^7\\cdot\\pi^8\\cdot B_8/8!$ gives $(-1)\\cdot 128\\cdot(-1/30)/40320 = 1/9450$. `riemannZeta_eight_eq` records the same value for the analytically continued zeta, $\\zeta(8) = \\pi^8/9450$ over $\\mathbb{C}$, via `riemannZeta_two_mul_nat`."
+  },
+  {
+    "id": "baseloq08oq02oq01-ratio",
+    "proofId": "basel-problem-oq-08-oq-02-oq-01",
+    "range": {
+      "startLine": 89,
+      "endLine": 98
+    },
+    "type": "theorem",
+    "title": "Euler's π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
+    "content": "`tsum_eight_div_tsum_two_pow_four` divides the even-zeta values: $\\zeta(8)/\\zeta(2)^4 = (\\pi^8/9450)/(\\pi^2/6)^4 = (\\pi^8/9450)/(\\pi^8/1296) = 1296/9450 = 24/175$. The $\\pi$ cancels entirely, leaving a rational determined only by the Bernoulli numbers $B_2 = 1/6$ and $B_8 = -1/30$. This continues the ratio chain $\\zeta(4)/\\zeta(2)^2 = 2/5$, $\\zeta(6)/\\zeta(2)^3 = 8/35$, $\\zeta(8)/\\zeta(2)^4 = 24/175$."
+  }
+]

--- a/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-08-oq-02-oq-01/meta.json
@@ -1,0 +1,171 @@
+{
+  "id": "basel-problem-oq-08-oq-02-oq-01",
+  "title": "ζ(8) = π⁸/9450: the Degree-8 Basel Value and the π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
+  "slug": "basel-problem-oq-08-oq-02-oq-01",
+  "description": "The value ζ(8) = ∑' n, 1/n⁸ = π⁸/9450, the next even-argument zeta value after ζ(6) = π⁶/945, obtained by instantiating Mathlib's even-argument zeta formula at k = 4. Because Mathlib provides no bernoulli'_six or bernoulli'_eight, the eighth Bernoulli number B₈ = −1/30 is computed from the defining recurrence (which itself needs B₆ = 1/42). Includes the riemannZeta 8 value and Euler's dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175.",
+  "meta": {
+    "author": "Euler (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
+    "date": "1740",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "basel-problem",
+      "riemann-zeta",
+      "bernoulli-numbers",
+      "euler",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BaselProblemOQ08OQ02OQ01.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "HasSum (fun n => 1/n^(2k)) ((-1)^(k+1)·2^(2k-1)·π^(2k)·B_{2k}/(2k)!) — the general even-argument zeta formula",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_two_mul_nat",
+        "description": "riemannZeta (2k) = (-1)^(k+1)·2^(2k-1)·π^(2k)·B_{2k}/(2k)! — the same formula for the analytically continued zeta",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "Odd Bernoulli numbers greater than 1 vanish — used to clear B₅ and B₇ in the B₆ and B₈ recurrences",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli_eq_bernoulli'_of_ne_one",
+        "description": "bernoulli n = bernoulli' n for n ≠ 1 — bridges the freshly-computed B₆ into the B₈ recurrence summand",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "HasSum (fun n => 1/n²) (π²/6) — the classical Basel value, used in the ratio",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      }
+    ],
+    "originalContributions": [
+      "bernoulli_six: the sixth Bernoulli number B₆ = 1/42, computed from the bernoulli'_def recurrence (needed as a summand of the B₈ recurrence)",
+      "bernoulli_eight: the eighth Bernoulli number B₈ = −1/30, computed from the bernoulli'_def recurrence using B₅ = B₇ = 0 and B₆ = 1/42 (Mathlib packages only bernoulli'_two and bernoulli'_four)",
+      "hasSum_one_div_nat_pow_eight: HasSum (fun n => 1/n⁸) (π⁸/9450), the k = 4 instance of the even-zeta formula",
+      "tsum_one_div_nat_pow_eight: the headline tsum value ∑' n, 1/n⁸ = π⁸/9450",
+      "riemannZeta_eight_eq: the riemannZeta 8 = π⁸/9450 value over ℂ via riemannZeta_two_mul_nat",
+      "tsum_eight_div_tsum_two_pow_four: Euler's dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175, π cancelling between the even-zeta values"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 98,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 6,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler solved the Basel problem ζ(2) = ∑ 1/n² = π²/6 in 1735 and by 1740 had the full even family ζ(2k) = (−1)^{k+1} B_{2k} (2π)^{2k} / (2(2k)!), where B_{2k} are the Bernoulli numbers. At k = 4 this gives ζ(8) = π⁸/9450, with B₈ = −1/30 — coincidentally equal to B₄. Each even-zeta value is a rational multiple of a power of π and hence transcendental; the odd values ζ(2k+1) remain far less understood (ζ(3) was proved irrational by Apéry in 1978, but ζ(5), ζ(7), … are still open). The dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175 is the π-free shadow of the formula at degree 8, depending only on the Bernoulli numbers B₂ = 1/6 and B₈ = −1/30.",
+    "problemStatement": "**Open Question (basel-problem-oq-08-oq-02-oq-01)**: Formalize ∑' n, 1/n⁸ = π⁸/9450 — the degree-8 even-zeta value requested by the parent ζ(6) entry — by instantiating Mathlib's even-argument zeta formula at k = 4, together with the π-free ratio ζ(8)/ζ(2)⁴.\n\n**Result**: tsum_one_div_nat_pow_eight proves ∑' n, 1/n⁸ = π⁸/9450. The companion riemannZeta_eight_eq gives riemannZeta 8 = π⁸/9450, and tsum_eight_div_tsum_two_pow_four derives Euler's dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175.",
+    "text": "The value ζ(8) = ∑' n, 1/n⁸ = π⁸/9450, the degree-8 analogue of the Basel problem, with the riemannZeta 8 value and the π-free Euler ratio ζ(8)/ζ(2)⁴ = 24/175.",
+    "proofStrategy": "**Proof Strategy: compute B₈ (which needs B₆), then specialise the even-zeta formula.**\n\n1. Mathlib packages `bernoulli'_two` (= 1/6) and `bernoulli'_four` (= −1/30) but no `bernoulli'_six` or `bernoulli'_eight`. We first recompute `bernoulli 6 = 1/42` (as in the parent entry) because it is a summand of the B₈ recurrence, then compute `bernoulli 8 = −1/30` from the defining recurrence `bernoulli'_def`, expanding the range-8 sum and using that `bernoulli' 5 = bernoulli' 7 = 0` (odd indices > 1, via `bernoulli'_eq_zero_of_odd`), `bernoulli' 6 = 1/42`, and the lower `bernoulli' 0..4` from their `@[simp]` lemmas, with the explicit binomial coefficients C(8,k).\n2. `hasSum_zeta_nat` at k = 4 gives `HasSum (fun n => 1/n⁸) ((−1)⁵·2⁷·π⁸·B₈/8!)`. Substituting B₈ = −1/30 and 8! = 40320 reduces (−1)·128·(−1/30)/40320 = 128/1209600 = 1/9450, so the sum is π⁸/9450; `.tsum_eq` gives the tsum value.\n3. `riemannZeta_two_mul_nat` at k = 4 gives the same value for the analytically-continued zeta at 8.\n4. For the ratio, rewrite ∑ 1/n⁸ = π⁸/9450 and ∑ 1/n² = π²/6; the fourth power of the denominator is π⁸/1296, and (π⁸/9450)/(π⁸/1296) = 1296/9450 = 24/175 after `field_simp` (π ≠ 0) and `ring`.",
+    "keyInsights": [
+      "**Even zeta values are rational multiples of powers of π.** ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!); at k = 4, B₈ = −1/30 yields ζ(8) = π⁸/9450.",
+      "**The Bernoulli recurrence chains.** Mathlib stops its packaged Bernoulli evaluations at B₄, and computing B₈ from the recurrence requires B₆ as a summand — so the degree-8 value genuinely builds on the degree-6 work rather than restarting from Mathlib. Curiously B₈ = B₄ = −1/30 even though the recurrences differ.",
+      "**The ratio ζ(8)/ζ(2)⁴ is π-free.** Dividing the even-zeta values cancels π entirely, leaving the rational 24/175 — a structural fact about the Bernoulli numbers, not about π. It continues the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35, ζ(8)/ζ(2)⁴ = 24/175."
+    ],
+    "prerequisites": [
+      "Infinite sums / tsum and HasSum in Mathlib",
+      "The Riemann zeta function and its even-argument values",
+      "Bernoulli numbers and their defining recurrence",
+      "The classical Basel value ζ(2) = π²/6 and its degree-6 analogue ζ(6) = π⁶/945"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Module docstring stating the open question and approach, Mathlib import, BaselProblemOQ08OQ02OQ01 namespace, and Real/BigOperators opens.",
+      "mathContext": "The degree-8 Basel value ζ(8) = ∑_{n≥1} 1/n⁸ = π⁸/9450, the k=4 case of Euler's even-zeta formula."
+    },
+    {
+      "id": "bernoulli-numbers",
+      "title": "The Bernoulli Numbers B₆ = 1/42 and B₈ = −1/30",
+      "startLine": 32,
+      "endLine": 62,
+      "summary": "bernoulli_six recomputes B₆ = 1/42 (a summand of the B₈ recurrence); bernoulli_eight computes B₈ = −1/30 from bernoulli'_def, using B₅ = B₇ = 0, B₆ = 1/42, and the binomials C(8,k).",
+      "mathContext": "$B_6 = 1/42$ and $B_8 = -1/30$, computed from $B_n = 1 - \\sum_{k<n}\\binom{n}{k}B_k/(n+1-k)$; Mathlib packages only $B_2, B_4$."
+    },
+    {
+      "id": "zeta-eight",
+      "title": "The Value ζ(8) = π⁸/9450",
+      "startLine": 63,
+      "endLine": 88,
+      "summary": "hasSum_one_div_nat_pow_eight (HasSum form), tsum_one_div_nat_pow_eight (the headline tsum value ∑' n, 1/n⁸ = π⁸/9450), and riemannZeta_eight_eq (the riemannZeta 8 value over ℂ).",
+      "mathContext": "$\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$ and $\\zeta(8) = \\pi^8/9450$, from Mathlib's `hasSum_zeta_nat` and `riemannZeta_two_mul_nat` at k = 4."
+    },
+    {
+      "id": "ratio",
+      "title": "Euler's π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
+      "startLine": 89,
+      "endLine": 98,
+      "summary": "tsum_eight_div_tsum_two_pow_four divides ζ(8) by ζ(2)⁴, cancelling π to leave the rational 24/175.",
+      "mathContext": "$\\zeta(8)/\\zeta(2)^4 = (\\pi^8/9450)/(\\pi^2/6)^4 = (\\pi^8/9450)/(\\pi^8/1296) = 1296/9450 = 24/175$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-08-oq-02",
+      "relationship": "extends",
+      "description": "The parent entry proves ζ(6) = π⁶/945 and lists 'Formalize ζ(8) = π⁸/9450 by computing B₈ = −1/30 from the recurrence' as an open question; this entry answers it, reusing the B₆ computation as a summand"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "The Basel problem proves ζ(2) = π²/6; this entry is the degree-8 analogue ζ(8) = π⁸/9450, and the ratio theorem combines both even-zeta values"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of ζ(8) = ∑' n, 1/n⁸ = π⁸/9450, the degree-8 Basel value, together with the Bernoulli numbers B₆ = 1/42 and B₈ = −1/30, the riemannZeta 8 value, and Euler's π-free ratio ζ(8)/ζ(2)⁴ = 24/175. Directly answers the open question posed by the parent ζ(6) entry.",
+    "implications": "Establishes the next even-zeta value in the gallery after ζ(2), ζ(4), and ζ(6). Computing B₈ from the recurrence — chaining through B₆ — demonstrates how the Bernoulli computation accumulates rather than resetting at each degree, the template for ζ(10), ζ(12), …. The π-free ratio ζ(8)/ζ(2)⁴ = 24/175 extends the ratio chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35.",
+    "openQuestions": [
+      "Formalize ζ(10) = π¹⁰/93555 by computing B₁₀ = 5/66 from the recurrence, continuing the chain.",
+      "State the general even-zeta formula ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!) as a single reusable Lean lemma, with B_{2k} supplied by a verified recurrence, removing the per-degree Bernoulli computation."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "BigOperators"
+    ],
+    "namespace": "BaselProblemOQ08OQ02OQ01",
+    "lineCount": 98,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ08OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "De summis serierum reciprocarum",
+      "year": "1740",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 7, pp. 123–134",
+      "note": "Derives the even-zeta values ζ(2k) as rational multiples of π^{2k}, including ζ(8) = π⁸/9450"
+    },
+    {
+      "authors": "Apéry, Roger",
+      "title": "Irrationalité de ζ(2) et ζ(3)",
+      "year": "1979",
+      "venue": "Astérisque 61, pp. 11–13",
+      "note": "Highlights the contrast: odd zeta values are arithmetically hard, while even ones (like ζ(8)) are explicit rational multiples of powers of π"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the parent **ζ(6)** entry's open question: *"Formalize ζ(8) = π⁸/9450 by computing B₈ = −1/30 from the recurrence."*

The degree-8 even-zeta value, the next after ζ(2), ζ(4), ζ(6) in the gallery. **Verified, 0 sorries, 0 axioms** (axiom profile: `propext, Classical.choice, Quot.sound` only).

## Results (6 theorems, 98 lines)

| Theorem | Statement |
|---|---|
| `bernoulli_six` | B₆ = 1/42 (reused as a summand of the B₈ recurrence) |
| `bernoulli_eight` | B₈ = −1/30, from `bernoulli'_def` using B₅ = B₇ = 0, B₆ = 1/42 |
| `hasSum_one_div_nat_pow_eight` | `HasSum (fun n => 1/n⁸) (π⁸/9450)`, k=4 of `hasSum_zeta_nat` |
| `tsum_one_div_nat_pow_eight` | **∑' n, 1/n⁸ = π⁸/9450** (headline) |
| `riemannZeta_eight_eq` | `riemannZeta 8 = π⁸/9450` over ℂ |
| `tsum_eight_div_tsum_two_pow_four` | **ζ(8)/ζ(2)⁴ = 24/175** (π-free ratio) |

## Approach

Mathlib's `hasSum_zeta_nat` / `riemannZeta_two_mul_nat` give the general even-zeta formula but stop packaged Bernoulli values at B₄. Computing B₈ from the defining recurrence requires B₆ as a summand, so the degree-8 value genuinely chains through the degree-6 work. Substituting B₈ = −1/30 and 8! = 40320 into `(−1)⁵·2⁷·π⁸·B₈/8!` reduces to π⁸/9450. The ratio cancels π entirely, continuing the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35, ζ(8)/ζ(2)⁴ = 24/175.

## Verification

Type-checked on host (`lake env lean`, Lean v4.26.0 + Mathlib 4.26.0), exit 0. `#print axioms` on all headline theorems shows only the standard foundational triple — no `sorryAx`, no `ofReduceBool`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)