### PR TITLE
research(abel-ruffini-galois-extensions-oq-11): Noether's problem for Sₙ — invariant ring is always a polynomial ring [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -18,6 +18,7 @@ import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep1
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4
 import Proofs.AbelRuffiniGaloisExtensionsOQ06GaloisDirectionStep4Aristotle
 import Proofs.AbelRuffiniGaloisExtensionsOQ07
+import Proofs.AbelRuffiniGaloisExtensionsOQ11
 import Proofs.AbelRuffiniOQ04
 import Proofs.AbelRuffiniOQ04OQ01
 import Proofs.AbelRuffiniOQ04OQ02

--- a/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ11.lean
+++ b/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ11.lean
@@ -1,0 +1,138 @@
+/-
+# Noether's rationality problem for the symmetric group `Sₙ` (openQuestion #11)
+
+This file formalizes the **universally positive core** of Noether's rationality
+problem (Emmy Noether 1918, *Gleichungen mit vorgeschriebener Gruppe*,
+Math. Ann. 78: 221–229) for the full symmetric group `G = Sₙ` acting on
+`K(x₁, …, xₙ)` by permuting the indeterminates.
+
+## Noether's problem
+
+For a finite group `G ≤ Sₙ` acting on the rational function field
+`K(x₁, …, xₙ)` by permuting the variables, Noether's problem asks whether the
+fixed field `K(x₁, …, xₙ)ᴳ` is *purely transcendental* over `K`, i.e. isomorphic
+to `K(y₁, …, yₙ)` for algebraically independent generators `yⱼ`.  A positive
+answer ("`G` is Noether-rational") upgrades the abstract inverse-Galois existence
+to an *explicit parametric* family of `G`-extensions of `K` (via Hilbert
+irreducibility).
+
+For arbitrary `G` the answer is **negative in general** — the first
+counterexample is Swan's `ℤ/47ℤ` (1969), and the precise obstruction is the
+Bogomolov multiplier `B₀(G)` (Saltman 1984, Bogomolov 1988).  But for the
+**full symmetric group `G = Sₙ`** the answer is positive for *every* `n`,
+independently of solvability: the invariant ring is the polynomial ring in the
+elementary symmetric polynomials `e₁, …, eₙ` (the fundamental theorem of
+symmetric functions), and its fraction field is `K(e₁, …, eₙ)`, purely
+transcendental of transcendence degree `n`.
+
+## The formalizable kernel
+
+The arithmetic heart is purely algebraic and holds over any commutative ring `R`:
+
+* `MvPolynomial.esymm_algebraicIndependent` — the `n` elementary symmetric
+  polynomials `e₁, …, eₙ` in the variables `σ` (with `n ≤ #σ`) are
+  **algebraically independent** over `R`.  Combined with the fundamental
+  theorem this is the transcendence-degree-`n` statement that makes the
+  `Sₙ`-fixed field purely transcendental.  (Mathlib has the fundamental theorem
+  `esymmAlgEquiv` but does *not* package algebraic independence of `esymm`.)
+
+* `MvPolynomial.noetherWitnessSn` / `Sn_invariantRing_polynomial` — re-exports
+  Mathlib's `esymmAlgEquiv` as the explicit **Noether-rationality witness for
+  `Sₙ`**: the ring of `Sₙ`-invariants `MvPolynomial σ R` is isomorphic, as an
+  `R`-algebra, to a polynomial ring in `n` generators.
+
+* `Sn_noetherRational_all_n` — the witness exists for **every** `n`.
+
+* `S5_not_solvable_but_noether_rational` — the **threshold contrast** with the
+  parent file (`Sₙ` solvable ↔ `n ≤ 4`): `S₅` is *not* solvable, yet its
+  invariant ring is still a polynomial ring.  Universal Noether-rationality of
+  `Sₙ` crosses the Abel–Ruffini solvability threshold untouched, isolating
+  *parametric construction* from *radical solvability*.
+
+All results are machine-checked with no `sorry` and no extra axioms.
+-/
+
+import Mathlib.RingTheory.MvPolynomial.Symmetric.FundamentalTheorem
+import Mathlib.RingTheory.AlgebraicIndependent.Defs
+import Mathlib.GroupTheory.Solvable
+
+open scoped BigOperators
+
+namespace MvPolynomial
+
+variable {σ : Type*} [Fintype σ] [DecidableEq σ] (R : Type*) [CommRing R] {n : ℕ}
+
+omit [DecidableEq σ] in
+/-- **Algebraic independence of the elementary symmetric polynomials.**
+
+If `n ≤ #σ`, then the `n` elementary symmetric polynomials `e₁, …, eₙ`
+(`fun i : Fin n ↦ esymm σ R (i + 1)`) are algebraically independent over `R`.
+
+This is the transcendence-degree-`n` core of Noether-rationality for `Sₙ`:
+together with the fundamental theorem of symmetric functions it shows that the
+ring of `Sₙ`-invariants is a *polynomial* ring in `n` algebraically independent
+generators, whence its fraction field is purely transcendental.
+
+The proof reduces algebraic independence to injectivity of
+`aeval (fun i ↦ esymm σ R (i + 1))`, which is exactly the injectivity of
+Mathlib's `esymmAlgHom` (the fundamental theorem provides it for `n ≤ #σ`). -/
+theorem esymm_algebraicIndependent (hn : n ≤ Fintype.card σ) :
+    AlgebraicIndependent R (fun i : Fin n => esymm σ R (i + 1)) := by
+  rw [algebraicIndependent_iff_injective_aeval]
+  intro p q h
+  apply esymmAlgHom_injective R hn
+  apply Subtype.ext
+  rw [esymmAlgHom_apply, esymmAlgHom_apply]
+  exact h
+
+/-- **Noether-rationality witness for `Sₙ` (algebra level).**
+
+When `#σ = n`, the ring of `Sₙ`-invariant polynomials `symmetricSubalgebra σ R`
+is isomorphic as an `R`-algebra to the polynomial ring `MvPolynomial (Fin n) R`,
+the isomorphism sending the `i`-th coordinate to the `(i+1)`-st elementary
+symmetric polynomial.  This is the constructive heart of Noether's positive
+answer for the full symmetric group; passing to fraction fields gives pure
+transcendence of the fixed field `K(x₁, …, xₙ)^{Sₙ} ≅ K(e₁, …, eₙ)`.
+
+This is a re-export of Mathlib's fundamental theorem of symmetric functions
+`esymmAlgEquiv`, named for its role in Noether's problem. -/
+noncomputable def noetherWitnessSn (hn : Fintype.card σ = n) :
+    MvPolynomial (Fin n) R ≃ₐ[R] symmetricSubalgebra σ R :=
+  esymmAlgEquiv σ R hn
+
+omit [DecidableEq σ] in
+/-- The ring of `Sₙ`-invariants is a polynomial ring in `n` generators
+(packaged as `Nonempty` of the algebra equivalence). -/
+theorem Sn_invariantRing_polynomial (hn : Fintype.card σ = n) :
+    Nonempty (MvPolynomial (Fin n) R ≃ₐ[R] symmetricSubalgebra σ R) :=
+  ⟨noetherWitnessSn R hn⟩
+
+/-- **Universal Noether-rationality of `Sₙ`.**
+
+For *every* `n`, the ring of `Sₙ`-invariants `symmetricSubalgebra (Fin n) R` is a
+polynomial ring in `n` generators — Noether's problem has a positive answer for
+the full symmetric group with no restriction on `n` (in particular, no
+solvability hypothesis). -/
+theorem Sn_noetherRational_all_n (n : ℕ) :
+    Nonempty (MvPolynomial (Fin n) R ≃ₐ[R] symmetricSubalgebra (Fin n) R) :=
+  ⟨esymmAlgEquiv (Fin n) R (Fintype.card_fin n)⟩
+
+/-- **Noether-rationality crosses the Abel–Ruffini solvability threshold.**
+
+The parent file proves `Sₙ` is solvable iff `n ≤ 4`.  Here we exhibit the sharp
+contrast at `n = 5`: the symmetric group `S₅` is **not** solvable
+(`Equiv.Perm.fin_5_not_solvable`, the group-theoretic heart of Abel–Ruffini),
+yet its invariant ring `symmetricSubalgebra (Fin 5) R` is **still** a polynomial
+ring in `5` generators (Noether-rational).
+
+Thus universal Noether-rationality of `Sₙ` is *independent* of solvability:
+the quintic has an explicit elementary-symmetric-function parametrization of its
+splitting data even though it has no radical recipe.  This separates *parametric
+construction* (always available for `Sₙ`) from *radical solvability* (only for
+`n ≤ 4`). -/
+theorem S5_not_solvable_but_noether_rational :
+    ¬ IsSolvable (Equiv.Perm (Fin 5)) ∧
+      Nonempty (MvPolynomial (Fin 5) R ≃ₐ[R] symmetricSubalgebra (Fin 5) R) :=
+  ⟨Equiv.Perm.fin_5_not_solvable, Sn_noetherRational_all_n R 5⟩
+
+end MvPolynomial

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-11/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-11/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "ann-abelruffini-oq11-docstring",
+    "proofId": "abel-ruffini-galois-extensions-oq-11",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "Noether's Problem and the Universally Positive Sₙ Core",
+    "content": "Noether (1918) asked whether the fixed field K(x₁,…,xₙ)^G of a finite group G ≤ Sₙ permuting variables is purely transcendental over K — a positive answer turning abstract inverse-Galois existence into an explicit parametric family of G-extensions of K. For arbitrary G the answer is negative in general (Swan's ℤ/47ℤ, 1969; the precise obstruction is Bogomolov's multiplier B₀(G)). But for the FULL symmetric group G = Sₙ it is positive for every n, independently of solvability: the fundamental theorem of symmetric functions makes the invariant ring the polynomial ring K[e₁,…,eₙ], whose fraction field K(e₁,…,eₙ) is purely transcendental of transcendence degree n. This file formalizes that core: algebraic independence of the eᵢ, the Noether-rationality witness, and the contrast with the parent's solvability threshold."
+  },
+  {
+    "id": "ann-abelruffini-oq11-algindep",
+    "proofId": "abel-ruffini-galois-extensions-oq-11",
+    "range": {
+      "startLine": 78,
+      "endLine": 96
+    },
+    "type": "key-insight",
+    "title": "Algebraic Independence of e₁,…,eₙ (the transcendence-degree-n core)",
+    "content": "esymm_algebraicIndependent: for n ≤ #σ the n elementary symmetric polynomials e₁,…,eₙ are algebraically independent over any commutative ring R. By algebraicIndependent_iff_injective_aeval this is exactly injectivity of aeval (fun i ↦ esymm σ R (i+1)); that map's values are the coordinates of Mathlib's esymmAlgHom (esymmAlgHom_apply: (esymmAlgHom σ R n p).val = aeval (fun i ↦ esymm σ R (i+1)) p), so injectivity follows from esymmAlgHom_injective composed with Subtype.ext. Mathlib supplies the fundamental theorem esymmAlgEquiv but NOT this algebraic-independence statement — it is the transcendence-degree-n fact that makes the Sₙ-fixed field purely transcendental rather than merely finitely generated."
+  },
+  {
+    "id": "ann-abelruffini-oq11-witness",
+    "proofId": "abel-ruffini-galois-extensions-oq-11",
+    "range": {
+      "startLine": 97,
+      "endLine": 124
+    },
+    "type": "key-insight",
+    "title": "The Noether-Rationality Witness for Sₙ (every n)",
+    "content": "noetherWitnessSn re-exports Mathlib's esymmAlgEquiv: when #σ = n the ring of Sₙ-invariant polynomials symmetricSubalgebra σ R is R-algebra isomorphic to the polynomial ring MvPolynomial (Fin n) R, the i-th coordinate mapping to the (i+1)-st elementary symmetric polynomial. Sn_invariantRing_polynomial packages this as Nonempty of the equivalence, and Sn_noetherRational_all_n asserts it for EVERY n with no solvability hypothesis — the constructive statement that the Sₙ-invariant ring is always an n-generator polynomial ring, the algebra-level heart of Noether-positivity for the full symmetric group."
+  },
+  {
+    "id": "ann-abelruffini-oq11-threshold",
+    "proofId": "abel-ruffini-galois-extensions-oq-11",
+    "range": {
+      "startLine": 125,
+      "endLine": 138
+    },
+    "type": "key-insight",
+    "title": "Noether-Rationality Crosses the Abel–Ruffini Threshold",
+    "content": "S5_not_solvable_but_noether_rational: S₅ is NOT solvable (Equiv.Perm.fin_5_not_solvable, the group-theoretic heart of Abel–Ruffini) yet its invariant ring is STILL a polynomial ring (Sn_noetherRational_all_n R 5). The parent file proves Sₙ solvable iff n ≤ 4; this conjunction shows universal Noether-rationality of Sₙ is independent of that threshold. The quintic has no radical recipe, but the splitting data of the generic degree-5 polynomial still admits an elementary-symmetric-function parametrization — separating parametric construction (universal for Sₙ) from radical solvability (only n ≤ 4)."
+  }
+]

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-11/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-11/meta.json
@@ -1,0 +1,163 @@
+{
+  "id": "abel-ruffini-galois-extensions-oq-11",
+  "slug": "abel-ruffini-galois-extensions-oq-11",
+  "title": "Noether's Problem for Sₙ: the Invariant Ring is Always a Polynomial Ring",
+  "leanFile": {
+    "imports": [
+      "Mathlib.RingTheory.MvPolynomial.Symmetric.FundamentalTheorem",
+      "Mathlib.RingTheory.AlgebraicIndependent.Defs",
+      "Mathlib.GroupTheory.Solvable"
+    ],
+    "opens": [
+      "scoped BigOperators"
+    ],
+    "namespace": "MvPolynomial",
+    "lineCount": 138,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "path": "Proofs/AbelRuffiniGaloisExtensionsOQ11.lean",
+    "sorries": 0
+  },
+  "description": "The universally positive core of Noether's rationality problem (Noether 1918) for the full symmetric group G = Sₙ acting on K(x₁,…,xₙ) by permuting variables. The new headline is `esymm_algebraicIndependent`: the n elementary symmetric polynomials e₁,…,eₙ (with n ≤ #σ) are algebraically independent over any commutative ring R — the transcendence-degree-n fact that, joined to Mathlib's fundamental theorem of symmetric functions (`esymmAlgEquiv`), makes the Sₙ-fixed field purely transcendental. Mathlib has the fundamental theorem but does not package algebraic independence of `esymm`. The file re-exports the fundamental theorem as the explicit Noether-rationality witness `noetherWitnessSn` (the Sₙ-invariant ring is an n-generator polynomial ring), proves it holds for every n (`Sn_noetherRational_all_n`), and exhibits the sharp threshold contrast with the parent file (`Sₙ` solvable ↔ n ≤ 4): `S5_not_solvable_but_noether_rational` shows S₅ is not solvable yet its invariant ring is still a polynomial ring. Universal Noether-rationality of Sₙ thus crosses the Abel–Ruffini solvability threshold untouched, separating parametric construction from radical solvability. Verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Noether%27s_problem",
+    "date": "2026-06-23",
+    "status": "verified",
+    "tags": [
+      "group-theory",
+      "galois-theory",
+      "invariant-theory",
+      "symmetric-polynomials",
+      "noether-problem",
+      "solvability",
+      "abel-ruffini",
+      "rationality",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensionsOQ11.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 138,
+    "dateAdded": "2026-06-23",
+    "theoremCount": 4,
+    "definitionCount": 1,
+    "originalContributions": [
+      "esymm_algebraicIndependent: the n elementary symmetric polynomials e₁,…,eₙ in the variables σ (with n ≤ #σ) are algebraically independent over any commutative ring R. Proved by reducing algebraic independence to injectivity of aeval (fun i ↦ esymm σ R (i+1)), which is exactly Mathlib's esymmAlgHom_injective. Mathlib supplies the fundamental theorem esymmAlgEquiv but does NOT package this algebraic-independence statement — it is the transcendence-degree-n core making the Sₙ-fixed field purely transcendental.",
+      "noetherWitnessSn: the explicit Noether-rationality witness for Sₙ at the algebra level — when #σ = n, the ring of Sₙ-invariant polynomials symmetricSubalgebra σ R is isomorphic as an R-algebra to the polynomial ring MvPolynomial (Fin n) R, sending the i-th coordinate to the (i+1)-st elementary symmetric polynomial (re-export of Mathlib's esymmAlgEquiv named for its Noether-problem role).",
+      "Sn_noetherRational_all_n: universal Noether-rationality of Sₙ — for EVERY n, the Sₙ-invariant ring symmetricSubalgebra (Fin n) R is an n-generator polynomial ring, with no solvability hypothesis on n.",
+      "S5_not_solvable_but_noether_rational: the threshold contrast — S₅ is not solvable (Equiv.Perm.fin_5_not_solvable, the group-theoretic heart of Abel–Ruffini) yet its invariant ring is still a polynomial ring (Noether-rational). Universal Noether-rationality of Sₙ is independent of solvability, separating parametric construction (always available for Sₙ) from radical solvability (only n ≤ 4)."
+    ],
+    "assumptions": "None beyond Lean/Mathlib's standard foundational axioms (propext, Classical.choice, Quot.sound). All four named results were confirmed via #print axioms to depend only on these — no sorryAx, no Lean.ofReduceBool. axiomCount = 0, status verified.",
+    "relatedProblems": [
+      {
+        "id": "abel-ruffini-galois-extensions",
+        "relationship": "Parent file. The parent classifies Sₙ solvability (Sₙ solvable iff n ≤ 4), the qualitative Abel–Ruffini threshold. This entry refines that to the constructive/parametric layer of Noether's problem: while radical solvability fails for n ≥ 5, the Sₙ-invariant ring is a polynomial ring for ALL n, so the splitting data of the generic degree-n polynomial always admits an elementary-symmetric-function parametrization — Noether-rationality crosses the solvability threshold untouched."
+      }
+    ]
+  },
+  "openQuestions": [
+    {
+      "id": "abel-ruffini-galois-extensions-oq-11-oq-01",
+      "question": "Lift the algebra-level witness noetherWitnessSn to the field level: formalize that the Sₙ-fixed field FractionRing(MvPolynomial σ K)^{Sₙ} is purely transcendental, i.e. K-isomorphic to a rational function field K(y₁,…,yₙ), by taking the fraction field of symmetricSubalgebra and identifying it with the fixed field of the induced permutation action.",
+      "significance": "high"
+    },
+    {
+      "id": "abel-ruffini-galois-extensions-oq-11-oq-02",
+      "question": "Formalize Mestre's theorem that ℚ(x₁,…,xₙ)^{Aₙ} is purely transcendental for all n, extending the Sₙ witness to the alternating subgroup via the discriminant square root δ = ∏_{i<j}(xᵢ-xⱼ).",
+      "significance": "high"
+    },
+    {
+      "id": "abel-ruffini-galois-extensions-oq-11-oq-03",
+      "question": "Formalize the first Noether-negative case: Swan's ℤ/47ℤ acting by cyclic permutation on ℚ(x₁,…,x₄₇), whose fixed field is not stably rational (non-trivial unramified Brauer group / Bogomolov multiplier B₀(G) ≠ 0).",
+      "significance": "medium"
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "extends",
+      "description": "The parent proves Sₙ solvable iff n ≤ 4 (qualitative Abel–Ruffini threshold). This entry adds the constructive Noether-rationality layer: the Sₙ-invariant ring is a polynomial ring for all n, and S₅ exemplifies the contrast — not solvable, yet Noether-rational."
+    }
+  ],
+  "references": [
+    {
+      "title": "Gleichungen mit vorgeschriebener Gruppe",
+      "author": "Emmy Noether",
+      "year": "1918",
+      "venue": "Mathematische Annalen 78: 221–229",
+      "description": "Origin of Noether's rationality problem: is the fixed field K(x₁,…,xₙ)^G purely transcendental? Positive answers give explicit parametric Galois realizations of G."
+    },
+    {
+      "title": "Mathlib4: RingTheory.MvPolynomial.Symmetric.FundamentalTheorem",
+      "author": "Mathlib Community",
+      "year": "2025",
+      "venue": "leanprover-community/mathlib4",
+      "description": "Source of MvPolynomial.esymmAlgEquiv (fundamental theorem of symmetric functions) and esymmAlgHom_injective, the bridges underpinning esymm_algebraicIndependent and noetherWitnessSn."
+    },
+    {
+      "title": "Invariant rational functions and a problem of Steenrod",
+      "author": "Richard G. Swan",
+      "year": "1969",
+      "venue": "Inventiones Mathematicae 7: 148–158",
+      "description": "First Noether-negative example: ℤ/47ℤ acting by cyclic permutation has non-purely-transcendental fixed field, obstruction in the unramified Brauer group."
+    },
+    {
+      "title": "The Brauer group of quotient spaces by linear group actions",
+      "author": "Fedor Bogomolov",
+      "year": "1988",
+      "venue": "Izvestiya 30: 455–485",
+      "description": "Modern obstruction theory for Noether's problem: the Bogomolov multiplier B₀(G), the unramified Brauer group, is the precise obstruction; B₀(G) ≠ 0 implies not stably rational."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Emmy Noether (1918) asked whether the fixed field K(x₁,…,xₙ)^G of a finite group G ≤ Sₙ permuting variables is purely transcendental over K — a positive answer upgrading abstract inverse-Galois existence to an explicit parametric family of G-extensions of K via Hilbert irreducibility. For arbitrary G the answer is negative in general (Swan's ℤ/47ℤ, 1969; the precise obstruction is Bogomolov's multiplier B₀(G)). But for the FULL symmetric group G = Sₙ the answer is positive for every n, independently of solvability: by the fundamental theorem of symmetric functions the invariant ring is the polynomial ring K[e₁,…,eₙ] in the elementary symmetric polynomials, whose fraction field K(e₁,…,eₙ) is purely transcendental of transcendence degree n. This is the constructive heart underneath van der Waerden's generic-Galois-group theorem and Cardano–Ferrari's low-degree formulas. Mathlib formalizes the fundamental theorem (esymmAlgEquiv) but records neither the algebraic independence of the eᵢ nor the Noether-problem reading; both are supplied here.",
+    "problemStatement": "Formalize the universally positive core of Noether's problem for Sₙ: prove the n elementary symmetric polynomials are algebraically independent (the transcendence-degree-n fact), package the fundamental theorem as the explicit Noether-rationality witness (Sₙ-invariant ring ≅ n-generator polynomial ring) for every n, and exhibit the threshold contrast with the parent's solvability classification — S₅ is not solvable yet Noether-rational."
+  },
+  "sections": [
+    {
+      "id": "docstring",
+      "title": "Module Docstring: Noether's Problem and the Sₙ Core",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "States Noether's rationality problem and its general negativity (Swan, Bogomolov multiplier), then the universally positive answer for the full symmetric group Sₙ: the invariant ring is the polynomial ring in e₁,…,eₙ, fraction field purely transcendental. Names the Mathlib sources (esymmAlgEquiv, esymmAlgHom_injective) and the new content (algebraic independence, the Noether witness, the solvability-threshold contrast).",
+      "mathContext": "$K(x_1,\\ldots,x_n)^{S_n} \\cong K(e_1,\\ldots,e_n)$ is purely transcendental for every $n$."
+    },
+    {
+      "id": "algebraic-independence",
+      "title": "Algebraic Independence of the Elementary Symmetric Polynomials",
+      "startLine": 78,
+      "endLine": 96,
+      "summary": "esymm_algebraicIndependent: for n ≤ #σ the n elementary symmetric polynomials e₁,…,eₙ are algebraically independent over R. Reduces (via algebraicIndependent_iff_injective_aeval) to injectivity of aeval (fun i ↦ esymm σ R (i+1)), discharged by Mathlib's esymmAlgHom_injective composed with Subtype.ext through esymmAlgHom_apply.",
+      "mathContext": "$\\mathrm{aeval}\\,(e_1,\\ldots,e_n)$ injective $\\iff$ $e_1,\\ldots,e_n$ algebraically independent."
+    },
+    {
+      "id": "noether-witness",
+      "title": "The Noether-Rationality Witness and Universal Positivity",
+      "startLine": 97,
+      "endLine": 124,
+      "summary": "noetherWitnessSn re-exports esymmAlgEquiv: when #σ = n the Sₙ-invariant ring symmetricSubalgebra σ R is R-algebra isomorphic to MvPolynomial (Fin n) R. Sn_invariantRing_polynomial and Sn_noetherRational_all_n package this as Nonempty of the equivalence and assert it for every n.",
+      "mathContext": "$\\mathrm{symmetricSubalgebra}\\,\\sigma\\,R \\cong_R \\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,n)\\,R$."
+    },
+    {
+      "id": "threshold-contrast",
+      "title": "Crossing the Abel–Ruffini Solvability Threshold",
+      "startLine": 125,
+      "endLine": 138,
+      "summary": "S5_not_solvable_but_noether_rational: S₅ is not solvable (Equiv.Perm.fin_5_not_solvable) yet its invariant ring is a polynomial ring (Sn_noetherRational_all_n R 5). Universal Noether-rationality of Sₙ is independent of solvability — parametric construction always available, radical solvability only for n ≤ 4.",
+      "mathContext": "$\\neg\\,\\mathrm{IsSolvable}(S_5)$ and yet $\\mathrm{MvPolynomial}\\,(\\mathrm{Fin}\\,5)\\,R \\cong_R \\mathrm{symmetricSubalgebra}\\,(\\mathrm{Fin}\\,5)\\,R$."
+    }
+  ],
+  "sorries": 0,
+  "conclusion": {
+    "summary": "The universally positive core of Noether's rationality problem for the full symmetric group Sₙ is formalized in four results. esymm_algebraicIndependent establishes that the n elementary symmetric polynomials are algebraically independent over any commutative ring (n ≤ #σ) — the transcendence-degree-n fact Mathlib does not package. noetherWitnessSn re-exports the fundamental theorem of symmetric functions as the explicit Noether-rationality witness (Sₙ-invariant ring ≅ n-generator polynomial ring), and Sn_noetherRational_all_n asserts it for every n. S5_not_solvable_but_noether_rational exhibits the sharp threshold contrast with the parent: S₅ is not solvable yet still Noether-rational. 138 lines, 4 theorems, 1 definition, 0 axioms, 0 sorries.",
+    "implications": "The fundamental theorem of symmetric functions is Mathlib's (used as the bridge), but the algebraic independence of the elementary symmetric polynomials, the Noether-rationality packaging, and the solvability-threshold contrast are new — hence the original badge. The entry isolates the constructive/parametric layer of the Abel–Ruffini classification: while no radical recipe exists for the quintic, the Sₙ-invariant ring is a polynomial ring for all n, so the splitting data of the generic degree-n polynomial always admits an elementary-symmetric-function parametrization. This separates parametric construction (universal for Sₙ) from radical solvability (only n ≤ 4), and sets up the field-level pure-transcendence statement and the Aₙ / Swan extensions as open questions.",
+    "openQuestions": [
+      "Lift noetherWitnessSn to the field level: the Sₙ-fixed field is purely transcendental, K-isomorphic to K(y₁,…,yₙ).",
+      "Formalize Mestre's positive answer for Aₙ via the discriminant square root.",
+      "Formalize Swan's Noether-negative ℤ/47ℤ (non-trivial Bogomolov multiplier)."
+    ]
+  }
+}


### PR DESCRIPTION
## Noether's rationality problem for the symmetric group Sₙ (openQuestion #11)

Formalizes the **universally positive core** of Noether's rationality problem (Emmy Noether 1918, *Gleichungen mit vorgeschriebener Gruppe*) for the full symmetric group `G = Sₙ` acting on `K(x₁,…,xₙ)` by permuting variables.

### Context
Noether's problem asks whether the fixed field `K(x₁,…,xₙ)^G` is purely transcendental — a positive answer turning abstract inverse-Galois existence into an **explicit parametric** family of `G`-extensions. For arbitrary `G` the answer is negative in general (Swan's `ℤ/47ℤ`, 1969; obstruction = Bogomolov multiplier `B₀(G)`). But for the **full symmetric group** it is positive for *every* `n`, independently of solvability: the fundamental theorem of symmetric functions makes the invariant ring the polynomial ring `K[e₁,…,eₙ]`, fraction field `K(e₁,…,eₙ)` purely transcendental of transcendence degree `n`.

### New results
| Theorem | Statement |
|---|---|
| `esymm_algebraicIndependent` | the `n` elementary symmetric polynomials `e₁,…,eₙ` (`n ≤ #σ`) are **algebraically independent** over any commutative ring `R` — the transcendence-degree-`n` core. Mathlib has `esymmAlgEquiv` but **not** this packaging. |
| `noetherWitnessSn` | re-exports `esymmAlgEquiv` as the explicit Noether-rationality witness: `Sₙ`-invariant ring `≅` `n`-generator polynomial ring (`#σ = n`). |
| `Sn_noetherRational_all_n` | the witness exists for **every** `n`, no solvability hypothesis. |
| `S5_not_solvable_but_noether_rational` | **threshold contrast** with the parent (`Sₙ` solvable ↔ `n ≤ 4`): `S₅` is *not* solvable (`Equiv.Perm.fin_5_not_solvable`) yet its invariant ring is *still* a polynomial ring. |

The last result isolates the constructive layer of Abel–Ruffini: the quintic has no radical recipe, yet the splitting data of the generic degree-`n` polynomial always admits an elementary-symmetric-function parametrization. Universal Noether-rationality of `Sₙ` crosses the solvability threshold untouched — separating **parametric construction** (universal for `Sₙ`) from **radical solvability** (only `n ≤ 4`).

### Verification
- **138 lines, 4 theorems, 1 definition, 0 sorries.**
- Compiles cleanly (host `lake env lean`, exit 0, no warnings).
- `#print axioms` on all four results: depends only on `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `Lean.ofReduceBool`. **axiomCount = 0, status verified.**
- Docker daemon was down this cycle; verified via the documented host fallback `LAKE_UNSAFE=1 ./bin/lake env lean`.

### Files
- `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ11.lean` (new)
- `proofs/Proofs.lean` (import)
- `src/data/proofs/abel-ruffini-galois-extensions-oq-11/{meta,annotations}.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)