### PR TITLE
Enrich Large Schröder numbers growth theory (schroder-numbers-oq-01)

### DIFF
--- a/src/data/proofs/schroder-numbers-oq-01/annotations.json
+++ b/src/data/proofs/schroder-numbers-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "schroder-numbers-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "The Missing Growth Theory of the Large Schröder Numbers",
+    "content": "The large Schröder numbers L(n) = 1, 2, 6, 22, 90, 394, … (OEIS A006318) count Schröder paths from (0,0) to (n,n) using steps (1,0), (0,1), (1,1) that never rise above the diagonal. Mathlib defines them by the convolution recurrence L(n+1) = L(n) + ∑_{i≤n} L(i)·L(n−i) and records base values, the recurrence, parity (even_largeSchroder), and the small/large bridge — but NO order information. This entry supplies the founding growth theory: positivity, the doubling step 2·L(n) ≤ L(n+1), strict monotonicity, and the exponential lower bound 2ⁿ ≤ L(n). The crux is that the lone i=0 term of the convolution already equals L(n).",
+    "mathContext": "$L(n+1) = L(n) + \\sum_{i\\le n} L(i)L(n-i)$; the $i=0$ term $L(0)L(n) = L(n)$ forces $L(n+1)\\ge 2L(n)$.",
+    "significance": "context",
+    "relatedConcepts": ["Schröder numbers", "convolution recurrence", "lattice paths", "growth bound"],
+    "prerequisites": ["recurrence relations", "enumerative combinatorics", "induction"]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "schroder-numbers-oq-01",
+    "range": { "startLine": 40, "endLine": 45 },
+    "type": "theorem",
+    "title": "largeSchroder_pos: Positivity by Induction",
+    "content": "largeSchroder_pos: 0 < L(n) for all n. Base L(0) = 1 > 0; the step rewrites L(n+1) by the recurrence as L(n) + (nonnegative convolution sum) and keeps positivity via lt_of_lt_of_le with Nat.le_add_right. Positivity is what later turns the doubling bound 2·L(n) ≤ L(n+1) into a STRICT inequality L(n) < L(n+1).",
+    "mathContext": "$L(0)=1>0$; $L(n+1) = L(n) + (\\ge 0) \\ge L(n) > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.largeSchroder_succ", "induction", "positivity"],
+    "prerequisites": ["induction", "recurrence relations"]
+  },
+  {
+    "id": "ann-doubling",
+    "proofId": "schroder-numbers-oq-01",
+    "range": { "startLine": 47, "endLine": 64 },
+    "type": "insight",
+    "title": "The Doubling Step: One Term Carries the Bound",
+    "content": "largeSchroder_le_sum extracts the lone i=0 summand L(0)·L(n−0) = L(n) from the convolution ∑_{i≤n} L(i)·L(n−i) via Finset.single_le_sum, giving L(n) ≤ ∑. Then two_mul_largeSchroder_le_succ rewrites the recurrence and 2·L(n) = L(n)+L(n), reducing by gcongr to exactly that bound: 2·L(n) ≤ L(n+1). The striking point is that NO finer analysis of the remaining convolution terms is needed — the single i=0 term already doubles the sequence each step. This doubling inequality is the engine behind every growth statement in the file.",
+    "mathContext": "$\\sum_{i\\le n} L(i)L(n-i) \\ge L(0)L(n) = L(n) \\Rightarrow L(n+1) = L(n) + \\sum \\ge 2L(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.single_le_sum", "gcongr", "doubling", "convolution"],
+    "prerequisites": ["finite sums", "lower-bounding by a single summand"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "schroder-numbers-oq-01",
+    "range": { "startLine": 66, "endLine": 75 },
+    "type": "theorem",
+    "title": "Strict Monotonicity",
+    "content": "largeSchroder_lt_succ derives L(n) < L(n+1) from the doubling bound 2·L(n) ≤ L(n+1) together with positivity L(n) > 0 (omega: 2L > L+0 when L > 0). strictMono_largeSchroder packages this into StrictMono L via strictMono_nat_of_lt_succ — a sequence increasing at every successor step is strictly monotone.",
+    "mathContext": "$2L(n) \\le L(n+1)$ and $L(n) > 0 \\Rightarrow L(n) < L(n+1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strictMono_nat_of_lt_succ", "omega", "strict monotonicity"],
+    "prerequisites": ["monotonicity", "order arithmetic"]
+  },
+  {
+    "id": "ann-growth",
+    "proofId": "schroder-numbers-oq-01",
+    "range": { "startLine": 77, "endLine": 100 },
+    "type": "theorem",
+    "title": "Exponential Lower Bound, Divergence, and Small-Schröder Positivity",
+    "content": "two_pow_le_largeSchroder: 2ⁿ ≤ L(n) by induction, 2^{n+1} = 2·2ⁿ ≤ 2·L(n) ≤ L(n+1) — the large Schröder numbers grow at least geometrically. largeSchroder_atTop concludes L(n) → ∞ from strict monotonicity (StrictMono.tendsto_atTop). smallSchroder_pos transfers positivity to the SMALL Schröder numbers for free: cases S(0)=S(1)=1, and for n+2 the Mathlib bridge 2·S(n+2) = L(n+1) > 0 forces S(n+2) > 0 by omega — no separate recurrence analysis needed.",
+    "mathContext": "$2^n \\le L(n)$; $L(n)\\to\\infty$; $2S(n+2) = L(n+1) > 0 \\Rightarrow S(n+2) > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["StrictMono.tendsto_atTop", "two_mul_smallSchroder_succ", "exponential growth", "induction"],
+    "prerequisites": ["induction", "filters / divergence"]
+  },
+  {
+    "id": "ann-concrete",
+    "proofId": "schroder-numbers-oq-01",
+    "range": { "startLine": 102, "endLine": 123 },
+    "type": "context",
+    "title": "Concrete Values L(3)=22, L(4)=90 (kernel decide, no native_decide)",
+    "content": "largeSchroder_three (=22) and largeSchroder_four (=90) are proved FROM the recurrence by expanding the Iic sum explicitly: rewrite Iic 2 = {0,1,2} (kernel decide on the finite-set equality only), split with Finset.sum_insert/sum_singleton, and norm_num on the base values. A final example checks the doubling bound at a concrete value, 2·L(3) = 44 ≤ 90 = L(4). Crucially these use kernel `decide` only on a finite-set equality, NOT native_decide — so the axiom profile stays clean (no Lean.ofReduceBool).",
+    "mathContext": "$L(3)=22,\\ L(4)=90$; $2\\cdot22 = 44 \\le 90$.",
+    "significance": "context",
+    "relatedConcepts": ["Finset.sum_insert", "decide vs native_decide", "axiom integrity", "A006318"],
+    "prerequisites": ["finite sums", "recurrence evaluation"]
+  }
+]

--- a/src/data/proofs/schroder-numbers-oq-01/index.ts
+++ b/src/data/proofs/schroder-numbers-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SchroderNumbersOQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const schroderNumbersOq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const schroderNumbersOq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const schroderNumbersOq01Data: ProofData = {
+  proof: schroderNumbersOq01Proof,
+  annotations: schroderNumbersOq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `schroder-numbers-oq-01`.

## What was missing
Rich, complete `meta.json` (with top-level `description`) but **missing both `index.ts` and `annotations.json`** — so the proof page rendered 'proof not found' on the live site.

## Changes
- **Added `index.ts`** wiring meta + annotations + Lean source for `Proofs/SchroderNumbersOQ01.lean`.
- **Added `annotations.json`** — 6 substantive annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  - header / the missing growth theory
  - `largeSchroder_pos` (positivity by induction)
  - the doubling step (one convolution term carries the bound)
  - strict monotonicity
  - the 2ⁿ lower bound, divergence, and small-Schröder positivity
  - concrete values L(3)=22, L(4)=90 (kernel decide, not native_decide)

## Verification
- JSON validates; `pnpm build` annotation validator reports no error for this entry. `tsc` cannot run in this fresh worktree (no `node_modules`); `index.ts` follows the proven sibling pattern.
- Axiom integrity preserved: meta states badge `verified` / 0 axioms, consistent with the Lean file (kernel decide only on a finite-set equality, no native_decide → no Lean.ofReduceBool).