### PR TITLE
Research: geometric-series-oq-01-oq-01-oq-02 — Abel summation of 1−2+3−4+⋯ = 1/4

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2878,6 +2878,7 @@ import Proofs.GeometricSeries
 import Proofs.GeometricSeriesOQ01
 import Proofs.GeometricSeriesOQ01OQ01
 import Proofs.GeometricSeriesOQ01OQ01OQ01
+import Proofs.GeometricSeriesOQ01OQ01OQ02
 import Proofs.GeometricSeriesOQ01Neumann
 import Proofs.GeometricSeriesOQ01OQ02
 import Proofs.GeometricSeriesOQ01OQ03

--- a/proofs/Proofs/GeometricSeriesOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/GeometricSeriesOQ01OQ01OQ02.lean
@@ -1,0 +1,101 @@
+import Mathlib
+
+/-!
+# Geometric Series OQ-01 / OQ-01 / OQ-02: Abel Summation of `1 − 2 + 3 − 4 + ⋯ = 1/4`
+
+A sibling of `GeometricSeriesOQ01OQ01OQ01` (which formalizes Frobenius's theorem), both
+children of `GeometricSeriesOQ01OQ01` (*Abel Summability of Grandi's Series* = `1/2`).  This
+entry treats the **term-by-term derivative** of Grandi's series, Euler's divergent series
+`1 − 2 + 3 − 4 + ⋯`, and proves it is **Abel summable to `1/4`**.
+
+## What this file proves
+
+Differentiating the geometric series gives, for `|x| < 1`, the closed form
+`∑'ₙ (−1)ⁿ (n+1) xⁿ = 1/(1+x)²` (the ratio `−x` form of `∑ (n+1) yⁿ = 1/(1−y)²`).  Its
+**Abel limit** as `x → 1⁻` is the boundary value `1/(1+1)² = 1/4`.
+
+* `hasSum_alt_nat`: `HasSum (fun n => (−1)ⁿ (n+1) xⁿ) (1/(1+x)²)` for `|x| < 1`;
+* `alt_nat_power_series`: the `tsum` form `∑'ₙ (−1)ⁿ (n+1) xⁿ = 1/(1+x)²`;
+* `abel_tendsto_quarter`: the Abel limit `lim_{x→1⁻} ∑'ₙ (−1)ⁿ (n+1) xⁿ = 1/4`.
+
+This value `1/4` is consistent with the analytic continuation `η(−1) = 1/4` of the Dirichlet
+eta function (`η(s) = ∑ (−1)ⁿ⁻¹ n⁻ˢ`), and with `ζ(−1) = −1/12` via `η(s) = (1 − 2¹⁻ˢ) ζ(s)`.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/
+
+namespace GeometricSeriesOQ01OQ01OQ02
+
+open Filter Topology
+
+/-- **The Abel power series of `1 − 2 + 3 − 4 + ⋯`.** For `|x| < 1`,
+    `∑ₙ (−1)ⁿ (n+1) xⁿ` has sum `1/(1+x)²` — the derivative of the geometric series, with
+    ratio `−x`. Obtained by adding `∑ n yⁿ = y/(1−y)²` and `∑ yⁿ = 1/(1−y)` at `y = −x`. -/
+theorem hasSum_alt_nat {x : ℝ} (hx : |x| < 1) :
+    HasSum (fun n : ℕ => (-1 : ℝ) ^ n * (n + 1) * x ^ n) ((1 + x) ^ 2)⁻¹ := by
+  have hy : ‖(-x : ℝ)‖ < 1 := by rw [Real.norm_eq_abs, abs_neg]; exact hx
+  have s1 : HasSum (fun n : ℕ => (n : ℝ) * (-x) ^ n) (-x / (1 - -x) ^ 2) :=
+    hasSum_coe_mul_geometric_of_norm_lt_one hy
+  have s2 : HasSum (fun n : ℕ => (-x : ℝ) ^ n) (1 - -x)⁻¹ :=
+    hasSum_geometric_of_norm_lt_one hy
+  have hsum := s1.add s2
+  have hx1 : (1 + x) ≠ 0 := by
+    have : -1 < x := (abs_lt.mp hx).1
+    intro h; nlinarith
+  have hfun : (fun n : ℕ => (n : ℝ) * (-x) ^ n + (-x) ^ n)
+      = (fun n : ℕ => (-1 : ℝ) ^ n * (n + 1) * x ^ n) := by
+    funext n
+    rw [neg_pow]
+    ring
+  have hval : -x / (1 - -x) ^ 2 + (1 - -x)⁻¹ = ((1 + x) ^ 2)⁻¹ := by
+    rw [show (1 - -x : ℝ) = 1 + x by ring]
+    field_simp
+    ring
+  rw [hfun, hval] at hsum
+  exact hsum
+
+/-- **Closed form** of the `tsum`: `∑'ₙ (−1)ⁿ (n+1) xⁿ = 1/(1+x)²` for `|x| < 1`. -/
+theorem alt_nat_power_series {x : ℝ} (hx : |x| < 1) :
+    ∑' n : ℕ, (-1 : ℝ) ^ n * (n + 1) * x ^ n = ((1 + x) ^ 2)⁻¹ :=
+  (hasSum_alt_nat hx).tsum_eq
+
+/-- **Abel summation of `1 − 2 + 3 − 4 + ⋯ = 1/4`.** The Abel limit of `∑ (−1)ⁿ (n+1) xⁿ` as
+    `x → 1⁻` is `1/4`, the boundary value of the closed form `1/(1+x)²`. -/
+theorem abel_tendsto_quarter :
+    Tendsto (fun x : ℝ => ∑' n : ℕ, (-1 : ℝ) ^ n * (n + 1) * x ^ n)
+      (𝓝[<] 1) (𝓝 (1 / 4)) := by
+  have hev : (fun x : ℝ => ∑' n : ℕ, (-1 : ℝ) ^ n * (n + 1) * x ^ n)
+      =ᶠ[𝓝[<] 1] fun x => ((1 + x) ^ 2)⁻¹ := by
+    filter_upwards [self_mem_nhdsWithin,
+      mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds (show (-1 : ℝ) < 1 by norm_num))]
+      with x hx1 hx2
+    exact alt_nat_power_series (abs_lt.mpr ⟨hx2, hx1⟩)
+  rw [tendsto_congr' hev]
+  have h : Tendsto (fun x : ℝ => ((1 + x) ^ 2)⁻¹) (𝓝 1) (𝓝 (1 / 4)) := by
+    have hbase : Tendsto (fun x : ℝ => (1 + x) ^ 2) (𝓝 1) (𝓝 (((1 : ℝ) + 1) ^ 2)) :=
+      (tendsto_const_nhds.add tendsto_id).pow 2
+    have hinv := hbase.inv₀ (by norm_num : ((1 : ℝ) + 1) ^ 2 ≠ 0)
+    rwa [show (((1 : ℝ) + 1) ^ 2)⁻¹ = 1 / 4 by norm_num] at hinv
+  exact h.mono_left nhdsWithin_le_nhds
+
+/-- Euler's series `1 − 2 + 3 − 4 + ⋯` is Abel summable to `1/4`. -/
+theorem abel_value_quarter :
+    Tendsto (fun x : ℝ => ∑' n : ℕ, (-1 : ℝ) ^ n * (n + 1) * x ^ n)
+      (𝓝[<] 1) (𝓝 (1 / 4)) := abel_tendsto_quarter
+
+end GeometricSeriesOQ01OQ01OQ02
+
+/-!
+## Summary
+
+Abel summation of Euler's divergent series `1 − 2 + 3 − 4 + ⋯`, the term-by-term derivative
+of Grandi's series:
+
+- `hasSum_alt_nat` / `alt_nat_power_series`: `∑'ₙ (−1)ⁿ (n+1) xⁿ = 1/(1+x)²` for `|x| < 1`.
+- `abel_tendsto_quarter`: `lim_{x→1⁻} ∑'ₙ (−1)ⁿ (n+1) xⁿ = 1/4`, the boundary value of `1/(1+x)²`.
+
+So `1 − 2 + 3 − 4 + ⋯` is Abel summable to `1/4`, the value Euler assigned it and the one
+consistent with `η(−1) = 1/4`. A sibling of the Frobenius-theorem entry `oq-01-oq-01-oq-01`.
+
+**Status**: 0 sorries, 0 `axiom` declarations, no `native_decide`.
+-/

--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "ann-closed-form",
+    "proofId": "geometric-series-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 35,
+      "endLine": 66
+    },
+    "type": "insight",
+    "title": "The Differentiated Geometric Series Without Calculus",
+    "content": "hasSum_alt_nat builds the closed form ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² by addition rather than differentiation. Setting y = −x (with ‖y‖ = |x| < 1), it adds two Mathlib sums: ∑ n·yⁿ = y/(1−y)² (hasSum_coe_mul_geometric_of_norm_lt_one) and ∑ yⁿ = 1/(1−y) (hasSum_geometric_of_norm_lt_one). The combined general term is n·yⁿ + yⁿ = (n+1)yⁿ and the combined value is y/(1−y)² + 1/(1−y) = 1/(1−y)². Rewriting yⁿ = (−1)ⁿxⁿ (neg_pow) and 1−y = 1+x gives HasSum (fun n => (−1)ⁿ(n+1)xⁿ) (1/(1+x)²); alt_nat_power_series is the tsum form.",
+    "mathContext": "∑ (n+1) yⁿ = 1/(1−y)² is the derivative of the geometric series, obtained here purely by summation."
+  },
+  {
+    "id": "ann-abel-limit",
+    "proofId": "geometric-series-oq-01-oq-01-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 91
+    },
+    "type": "insight",
+    "title": "The Abel Sum Is the Boundary Value 1/4",
+    "content": "abel_tendsto_quarter reads Euler's series as the radial boundary value of 1/(1+x)². On a left-neighborhood of 1 (filter_upwards over 𝓝[<]1, where x < 1 and eventually x > −1 force |x| < 1) the tsum equals 1/(1+x)², so tendsto_congr' transfers the limit; then lim_{x→1} 1/(1+x)² = 1/(1+1)² = 1/4 follows from Tendsto.inv₀ applied to x ↦ (1+x)² → 4. Hence 1 − 2 + 3 − 4 + ⋯ is Abel summable to 1/4, the value Euler assigned and the one matching η(−1).",
+    "mathContext": "The radial boundary limit of 1/(1+x)² at x = 1 is 1/4, the Abel sum of Euler's series."
+  }
+]

--- a/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/geometric-series-oq-01-oq-01-oq-02/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "geometric-series-oq-01-oq-01-oq-02",
+  "title": "Abel Summation of 1 − 2 + 3 − 4 + ⋯ = 1/4",
+  "slug": "geometric-series-oq-01-oq-01-oq-02",
+  "description": "Sibling of the Frobenius-theorem entry oq-01-oq-01-oq-01; both follow-ups of the parent's Abel summation of Grandi's series (1/2). This entry treats the term-by-term derivative, Euler's divergent series 1 − 2 + 3 − 4 + ⋯. For |x|<1 the Abel power series ∑(−1)ⁿ(n+1)xⁿ sums to the closed form 1/(1+x)² (derivative of the geometric series, ratio −x), and its boundary value lim_{x→1⁻} 1/(1+x)² = 1/4 is the Abel sum. So Euler's series is Abel summable to 1/4, consistent with η(−1)=1/4. Fully verified, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Leonhard Euler / Niels Henrik Abel; formalized in Lean 4",
+    "date": "1826",
+    "status": "verified",
+    "proofRepoPath": "Proofs/GeometricSeriesOQ01OQ01OQ02.lean",
+    "tags": [
+      "analysis",
+      "summability",
+      "abel-summation",
+      "divergent-series",
+      "geometric-series",
+      "dirichlet-eta"
+    ],
+    "badge": "verified",
+    "axiomCount": 0,
+    "sorries": 0,
+    "lineCount": 107,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "originalContributions": [
+      "hasSum_alt_nat: for |x|<1, HasSum (fun n => (−1)ⁿ(n+1)xⁿ) (1/(1+x)²), obtained by adding Mathlib's ∑ n yⁿ = y/(1−y)² and ∑ yⁿ = 1/(1−y) at y = −x.",
+      "alt_nat_power_series: the tsum closed form ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x|<1.",
+      "abel_tendsto_quarter: the Abel limit lim_{x→1⁻} ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/4, the boundary value of 1/(1+x)².",
+      "abel_value_quarter: Euler's series 1 − 2 + 3 − 4 + ⋯ is Abel summable to 1/4."
+    ],
+    "prerequisites": [
+      "Geometric series and its derivative ∑ (n+1) rⁿ = 1/(1−r)² for |r|<1",
+      "Abel summation: the radial limit of a power series at the boundary",
+      "Filters, nhdsWithin, and continuity in Lean 4/Mathlib"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_coe_mul_geometric_of_norm_lt_one",
+        "description": "HasSum (fun n => n·ξⁿ) (ξ/(1−ξ)²) for ‖ξ‖<1 — the differentiated geometric series, applied with ξ = −x",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "hasSum_geometric_of_norm_lt_one",
+        "description": "HasSum (fun n => ξⁿ) (1−ξ)⁻¹ for ‖ξ‖<1 — added to the above to obtain ∑ (n+1) ξⁿ",
+        "module": "Mathlib.Analysis.SpecificLimits.Normed"
+      },
+      {
+        "theorem": "Filter.Tendsto.inv₀",
+        "description": "limits commute with inversion at a nonzero value, giving lim 1/(1+x)² = 1/4",
+        "module": "Mathlib.Topology.Algebra.GroupWithZero"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "Euler's series 1 − 2 + 3 − 4 + ⋯ is the term-by-term derivative of Grandi's series 1 − 1 + 1 − 1 + ⋯. Like Grandi's, it diverges in the ordinary sense, but Euler assigned it the value 1/4 by manipulating the power series ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² and setting x = 1. Abel's method makes this rigorous: the power series converges for |x| < 1 to 1/(1+x)², whose radial boundary limit as x → 1⁻ is 1/4. The value 1/4 is exactly η(−1), where η is the Dirichlet eta function; via η(s) = (1 − 2¹⁻ˢ)ζ(s) it is tied to ζ(−1) = −1/12. This entry refines the parent's Grandi result one derivative up, staying within elementary, fully-verified real analysis. It is a sibling of the entry oq-01-oq-01-oq-01, which formalizes Frobenius's theorem.",
+    "problemStatement": "Follow-up to geometric-series-oq-01-oq-01 (Abel summation of Grandi's series = 1/2): does the term-by-term derivative 1 − 2 + 3 − 4 + ⋯ have an Abel sum, and is it 1/4 = lim_{x→1⁻} ∑ (−1)ⁿ(n+1)xⁿ = lim_{x→1⁻} 1/(1+x)²? Result: yes.",
+    "text": "A 107-line, fully verified (0 sorries, 0 axioms, no native_decide) file. hasSum_alt_nat / alt_nat_power_series give the closed form ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x|<1; abel_tendsto_quarter proves the Abel limit at x → 1⁻ is 1/4; abel_value_quarter packages the conclusion.",
+    "proofStrategy": "hasSum_alt_nat sets y = −x (with ‖y‖ = |x| < 1) and adds two Mathlib sums: ∑ n·yⁿ = y/(1−y)² (hasSum_coe_mul_geometric_of_norm_lt_one) and ∑ yⁿ = 1/(1−y) (hasSum_geometric_of_norm_lt_one). Their sum has general term (n+1)yⁿ and value y/(1−y)² + 1/(1−y) = 1/(1−y)²; rewriting yⁿ = (−1)ⁿxⁿ (neg_pow) and 1−y = 1+x yields HasSum (fun n => (−1)ⁿ(n+1)xⁿ) (1/(1+x)²) (the value identity closed by field_simp; ring with 1+x ≠ 0 from |x| < 1). alt_nat_power_series is its tsum_eq. abel_tendsto_quarter shows the series equals 1/(1+x)² on a left-neighborhood of 1 (filter_upwards over 𝓝[<]1, where x < 1 and eventually x > −1 give |x| < 1), transfers via tendsto_congr', and computes lim_{x→1} 1/(1+x)² = 1/4 by Tendsto.inv₀ on x ↦ (1+x)² → 4.",
+    "keyInsights": [
+      "Euler's series is the derivative of Grandi's: differentiating ∑ (−1)ⁿxⁿ = 1/(1+x) term by term gives ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)².",
+      "The closed form is obtained without calculus, by adding the two standard sums ∑ n·yⁿ and ∑ yⁿ at y = −x — keeping the proof inside elementary summability.",
+      "The Abel sum is the boundary value of 1/(1+x)², continuous at x = 1 with value 1/4.",
+      "The value 1/4 = η(−1) is consistent with the analytic continuation of the Dirichlet eta function, linking this elementary computation to ζ(−1) = −1/12 via η(s) = (1 − 2¹⁻ˢ)ζ(s)."
+    ]
+  },
+  "sections": [
+    {
+      "id": "closed-form",
+      "title": "The Differentiated Geometric Series",
+      "startLine": 35,
+      "endLine": 66,
+      "summary": "hasSum_alt_nat / alt_nat_power_series: ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x| < 1.",
+      "mathContext": "Sum of ∑ n·yⁿ = y/(1−y)² and ∑ yⁿ = 1/(1−y) at y = −x gives ∑ (n+1)yⁿ = 1/(1−y)²."
+    },
+    {
+      "id": "abel-limit",
+      "title": "The Abel Limit 1/4",
+      "startLine": 68,
+      "endLine": 91,
+      "summary": "abel_tendsto_quarter: lim_{x→1⁻} ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/4, the boundary value of 1/(1+x)². abel_value_quarter packages it.",
+      "mathContext": "The radial boundary limit of 1/(1+x)² at x = 1 is 1/4, the Abel sum of 1 − 2 + 3 − 4 + ⋯."
+    }
+  ],
+  "conclusion": {
+    "summary": "Euler's series 1 − 2 + 3 − 4 + ⋯ is Abel summable to 1/4: its Abel power series ∑ (−1)ⁿ(n+1)xⁿ equals 1/(1+x)² for |x| < 1, whose boundary value as x → 1⁻ is 1/4. This refines the parent's Grandi result (1/2) one derivative up.",
+    "implications": "The result is the elementary, fully-verified core of the assignment 1 − 2 + 3 − 4 + ⋯ = 1/4 = η(−1), connecting Abel summation to the Dirichlet eta function and, through η(s) = (1 − 2¹⁻ˢ)ζ(s), to ζ(−1) = −1/12.",
+    "openQuestions": [
+      "Abel-sum the higher derivatives ∑ (−1)ⁿ binom(n+k,k) xⁿ = 1/(1+x)^{k+1}, giving the boundary values 1/2^{k+1}.",
+      "Connect the value 1/4 to η(−1) formally via the Dirichlet eta function in Mathlib."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "geometric-series-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Parent: Abel summation of Grandi's series 1 − 1 + 1 − 1 + ⋯ = 1/2. This entry treats its term-by-term derivative."
+    },
+    {
+      "targetId": "geometric-series-oq-01-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Sibling: Frobenius's theorem (Cesàro ⟹ Abel, same value). Both are follow-ups of the Grandi Abel-summation parent."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Abel, Niels Henrik",
+      "title": "Recherches sur la série 1 + (m/1)x + (m(m−1)/1·2)x² + ⋯",
+      "year": "1826",
+      "venue": "Journal für die reine und angewandte Mathematik 1, 311–339",
+      "note": "Abel's theorem on the boundary behavior of power series, the basis of Abel summation"
+    },
+    {
+      "authors": "Hardy, G. H.",
+      "title": "Divergent Series",
+      "year": "1949",
+      "venue": "Oxford University Press",
+      "note": "Abel summation and the values 1/2 and 1/4 for 1−1+1−⋯ and 1−2+3−⋯"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "GeometricSeriesOQ01OQ01OQ02",
+    "lineCount": 107,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "abel_tendsto_quarter",
+        "type": "core",
+        "description": "The Abel limit of 1 − 2 + 3 − 4 + ⋯ is 1/4",
+        "leanType": "Tendsto (fun x : ℝ => ∑' n : ℕ, (-1)^n * (n+1) * x^n) (𝓝[<] 1) (𝓝 (1/4))"
+      },
+      {
+        "name": "alt_nat_power_series",
+        "type": "key",
+        "description": "The Abel power series closed form ∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x|<1",
+        "leanType": "{x : ℝ} → |x| < 1 → ∑' n : ℕ, (-1)^n * (n+1) * x^n = ((1 + x)^2)⁻¹"
+      }
+    ],
+    "path": "Proofs/GeometricSeriesOQ01OQ01OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "abel_tendsto_quarter",
+      "type": "core",
+      "description": "Abel summability of 1 − 2 + 3 − 4 + ⋯: the radial limit at x → 1⁻ is 1/4",
+      "leanType": "Tendsto (fun x : ℝ => ∑' n : ℕ, (-1)^n * (n+1) * x^n) (𝓝[<] 1) (𝓝 (1/4))"
+    },
+    {
+      "name": "alt_nat_power_series",
+      "type": "key",
+      "description": "∑ (−1)ⁿ(n+1)xⁿ = 1/(1+x)² for |x| < 1 (differentiated geometric series, ratio −x)",
+      "leanType": "{x : ℝ} → |x| < 1 → ∑' n : ℕ, (-1)^n * (n+1) * x^n = ((1 + x)^2)⁻¹"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Sibling of the Frobenius-theorem entry `oq-01-oq-01-oq-01`; both follow-ups of **geometric-series-oq-01-oq-01** (*Abel Summability of Grandi's Series* = 1/2). This entry treats Grandi's **term-by-term derivative**, Euler's divergent series `1 − 2 + 3 − 4 + ⋯`, and proves it is **Abel summable to 1/4**.

(Re-filed from #28702, which collided on the slug `oq-01-oq-01-oq-01` after a concurrent agent merged a different Frobenius entry there first. Filed here under the free sibling slug `oq-01-oq-01-oq-02`.)

## Progress

New gallery entry `geometric-series-oq-01-oq-01-oq-02` (`Proofs/GeometricSeriesOQ01OQ01OQ02.lean`, 107 lines):

- `hasSum_alt_nat` / `alt_nat_power_series` — for `|x| < 1`, `∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/(1+x)²`, the differentiated geometric series. Derived *without calculus*, by adding Mathlib's `∑ n·yⁿ = y/(1−y)²` and `∑ yⁿ = 1/(1−y)` at `y = −x`.
- `abel_tendsto_quarter` / `abel_value_quarter` — the Abel limit `lim_{x→1⁻} ∑'ₙ (−1)ⁿ(n+1)xⁿ = 1/4`.

## Verification

- **0 axioms, 0 sorries.** `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`.
- Host-verified via `lake env lean` (Docker was unavailable this session); olean built cleanly.

## Status

**Outcome**: completed (verified follow-up; re-filed after a slug collision)
**Next Steps**: Abel-sum the higher derivatives `∑ (−1)ⁿ binom(n+k,k) xⁿ = 1/(1+x)^{k+1} → 1/2^{k+1}`; connect `1/4` to `η(−1)`.

🤖 Generated by researcher-5