### PR TITLE
Enrich Finite Taylor-Abel Expansion (summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 70 },
+    "type": "context",
+    "title": "Iterated Discrete Integration by Parts → Finite Taylor–Abel Expansion",
+    "content": "Over any commutative ring R, with f : ℕ → R and a TOWER of antidifferences G : ℕ → ℕ → R linked by the single relation G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1), iterating the parent's single-step discrete Abel transform D times yields the closed identity ∑_{k<n} f(k)·G(0)(k+1) = ∑_{d<D} (−1)ᵈ(Δᵈf(n)·G(d+1)(n) − Δᵈf(0)·G(d+1)(0)) + (−1)ᴰ ∑_{k<n} Δᴰf(k)·G(D)(k+1). This is the exact discrete mirror of repeated integration by parts producing Taylor-with-remainder: each layer trades one forward difference off f onto the next antidifference of G, paying an alternating boundary term, leaving a remainder one depth up. Answers the parent's first open question.",
+    "mathContext": "$\\sum_{k<n} f(k)G_0(k+1) = \\sum_{d<D}(-1)^d[\\Delta^d f\\,G_{d+1}]_0^n + (-1)^D\\sum_{k<n}\\Delta^D f(k)\\,G_D(k+1)$.",
+    "significance": "context",
+    "relatedConcepts": ["summation by parts", "Abel transform", "discrete Taylor", "finite differences", "integration by parts"],
+    "prerequisites": ["finite sums", "telescoping", "commutative rings"]
+  },
+  {
+    "id": "ann-fdiff",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 78, "endLine": 87 },
+    "type": "definition",
+    "title": "The Forward Difference and Its Iterate",
+    "content": "fdiff h k = h(k+1) − h k is the forward difference operator Δ (the discrete derivative); fdiff^[d] is its d-fold iterate via Function.iterate. fdiff_apply is the definitional rewrite (marked @[simp]). fdiff_iterate_succ unfolds one layer, fdiff^[d+1] = fdiff ∘ fdiff^[d] (Function.iterate_succ_apply') — the ONLY iterate fact needed to thread Δ through the depth induction, letting it recognise Δᵈf(k+1) − Δᵈf(k) as Δ^{d+1}f(k).",
+    "mathContext": "$\\Delta h(k) = h(k+1) - h(k)$; $\\Delta^{[d+1]} = \\Delta\\circ\\Delta^{[d]}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["forward difference", "Function.iterate", "Function.iterate_succ_apply'", "discrete derivative"],
+    "prerequisites": ["function iteration"]
+  },
+  {
+    "id": "ann-abel",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 89, "endLine": 102 },
+    "type": "theorem",
+    "title": "abel_summation: The Single-Step Transform (Self-Contained)",
+    "content": "abel_summation: ∑_{k<n} a(k)·(B(k+1)−B(k)) = a(n)·B(n) − a(0)·B(0) − ∑_{k<n} (a(k+1)−a(k))·B(k+1) — the parent entry's discrete Abel transform, REPROVED here from scratch (induction on n + Finset.sum_range_succ + ring) so the file is self-contained and routes through no Mathlib summation-by-parts black box. The inductive step is a polynomial identity in the sequence atoms closed by ring over an arbitrary commutative ring. This is the single layer the whole D-fold theorem iterates.",
+    "mathContext": "$\\sum_{k<n} a(k)\\Delta B(k) = [aB]_0^n - \\sum_{k<n}\\Delta a(k)\\,B(k+1)$.",
+    "significance": "key",
+    "relatedConcepts": ["Abel summation", "Finset.sum_range_succ", "ring", "self-contained"],
+    "prerequisites": ["finite sums", "induction"]
+  },
+  {
+    "id": "ann-step",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 104, "endLine": 125 },
+    "type": "insight",
+    "title": "step: One Layer of the Iteration (the Recurrence R_d = bd_d − R_{d+1})",
+    "content": "step is the inductive engine: under the tower hypothesis hG, applying abel_summation at depth d peels one boundary term and drops the remainder from depth d to d+1. It rewrites G(d)(k+1) = G(d+1)(k+1) − G(d+1)(k) via hG (hL), applies abel_summation with a := Δᵈf, B := G(d+1), then recognises the resulting difference Δᵈf(k+1) − Δᵈf(k) as Δ^{d+1}f via fdiff_iterate_succ + fdiff_apply (hR). The CRUCIAL design point: the SHIFTED antidifference convention G(d+1)(k+1) − G(d+1)(k) = G(d)(k+1) (not the naive ΔG(d+1) = G(d)) is what compensates the transform's (·+1) shift, keeping boundary terms at the FIXED endpoints 0, n with no shift accumulation — exactly what makes the alternating telescope close.",
+    "mathContext": "$R_d = \\mathrm{bd}_d - R_{d+1}$; the shifted convention absorbs the per-step $(\\cdot+1)$ shift.",
+    "significance": "key",
+    "relatedConcepts": ["antidifference tower", "Finset.sum_congr", "shift compensation", "recurrence"],
+    "prerequisites": ["Abel transform", "forward difference iteration"]
+  },
+  {
+    "id": "ann-main",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 127, "endLine": 154 },
+    "type": "theorem",
+    "title": "discrete_taylor_abel: The D-Fold Closed Form (and Termination)",
+    "content": "discrete_taylor_abel is the main result, proved by induction on the DEPTH D. Base D=0 is the trivial identity (empty boundary sum, the remainder IS the LHS since Δ⁰f = f; simp). The succ case is a one-liner: rw [ih, Finset.sum_range_succ, step f G hG n D, pow_succ]; ring — the IH replaces the LHS, sum_range_succ exposes the new d=D boundary term, step turns R_D into bd_D − R_{D+1}, and ring reconciles the (−1)^D and (−1)^{D+1} coefficients. No new analytic content beyond step — only sign/index bookkeeping. discrete_taylor_abel_of_fdiff_eq_zero specialises to Δᴰf = 0 (f a discrete polynomial of degree < D): the remainder vanishes and the expansion TERMINATES as a finite alternating sum of boundary terms — the discrete finite Taylor formula.",
+    "mathContext": "Depth induction: $\\Delta^D f = 0 \\Rightarrow$ remainder drops $\\Rightarrow$ finite alternating boundary sum (discrete Taylor polynomial).",
+    "significance": "key",
+    "relatedConcepts": ["depth induction", "Finset.sum_range_succ", "pow_succ", "discrete polynomial", "terminating expansion"],
+    "prerequisites": ["induction", "alternating sums"]
+  },
+  {
+    "id": "ann-depth-one",
+    "proofId": "summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01",
+    "range": { "startLine": 156, "endLine": 168 },
+    "type": "theorem",
+    "title": "discrete_taylor_abel_one: Depth 1 Recovers the Parent Transform",
+    "content": "discrete_taylor_abel_one: specialising (T) to D = 1 gives ∑_{k<n} f(k)·G(0)(k+1) = f(n)·G(1)(n) − f(0)·G(1)(0) − ∑_{k<n} (f(k+1)−f(k))·G(1)(k+1) — exactly the parent's single-step Abel transform applied to the first antidifference G(1). Obtained by instantiating discrete_taylor_abel at D=1 and simp-ing away Function.iterate_zero/iterate_one and the range-one sum, then ring. This confirms the iteration is a faithful GENERALISATION of the parent (the depth-1 case is the parent verbatim), not a mere reformulation.",
+    "mathContext": "$D=1$: $\\sum_{k<n} f(k)G_0(k+1) = [fG_1]_0^n - \\sum_{k<n}\\Delta f(k)\\,G_1(k+1)$ — the parent transform.",
+    "significance": "supporting",
+    "relatedConcepts": ["Function.iterate_one", "Finset.sum_range_one", "depth-1 case", "faithful generalisation"],
+    "prerequisites": ["Abel transform", "specialization"]
+  }
+]

--- a/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/index.ts
+++ b/src/data/proofs/summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const summationByPartsOq01Oq01Oq01Oq02Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const summationByPartsOq01Oq01Oq01Oq02Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const summationByPartsOq01Oq01Oq01Oq02Oq01Data: ProofData = {
+  proof: summationByPartsOq01Oq01Oq01Oq02Oq01Proof,
+  annotations: summationByPartsOq01Oq01Oq01Oq02Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `summation-by-parts-oq-01-oq-01-oq-01-oq-02-oq-01`.

## What was missing
Rich, complete `meta.json` (with top-level `description`) but **missing both `index.ts` and `annotations.json`** — so the proof page rendered 'proof not found' on the live site.

## Changes
- **Added `index.ts`** wiring meta + annotations + Lean source for `Proofs/SummationByPartsOQ01OQ01OQ01OQ02OQ01.lean`.
- **Added `annotations.json`** — 6 substantive annotations (each with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`):
  - header / iterated integration by parts → finite Taylor–Abel
  - the forward difference operator and its iterate
  - `abel_summation` (self-contained single-step transform)
  - `step` (one layer; the shift-compensating antidifference convention)
  - `discrete_taylor_abel` (the D-fold closed form + termination corollary)
  - `discrete_taylor_abel_one` (depth-1 recovers the parent transform)

## Verification
- JSON validates; `pnpm build` annotation validator reports no error for this entry (an initial line-range mismatch on the fdiff definition was corrected). `tsc` cannot run in this fresh worktree (no `node_modules`); `index.ts` follows the proven sibling pattern.
- Axiom integrity preserved: meta states badge `original` / 0 axioms, consistent with the Lean file (no axioms, no native_decide; the antidifference tower relation is a theorem hypothesis, not an axiom).