### PR TITLE
research(lagrange-theorem-oq-01-oq-01-oq-02): full cyclic case — every group of order pq with p∤q-1 is cyclic [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/LagrangeTheoremOQ01OQ01OQ02.lean
@@ -1,5 +1,5 @@
 /-
-  pq-Groups: Abelian isomorphism uniqueness
+  pq-Groups: Isomorphism uniqueness — abelian thread + full cyclic case
   (lagrange-theorem-oq-01-oq-01-oq-02)
 
   This answers the abelian portion of OQ-01-OQ-01-OQ-02 from Lagrange's Theorem OQ-01.
@@ -29,18 +29,25 @@
   so `isCyclic_of_orderOf_eq_card` makes `G` cyclic. Then
   `mulEquivOfCyclicCardEq` / `zmodCyclicMulEquiv` deliver the isomorphisms.
 
-  **Scope / what is deferred.** The *general* (not-necessarily-abelian)
-  uniqueness statements — "for `p ∤ (q-1)`, any two groups of order `pq` are
-  isomorphic" (cyclic case) and "any two non-cyclic groups of order `pq` are
-  isomorphic" (the `p ∣ (q-1)` non-abelian case) — depend on the parent's Sylow
-  classification `pq_unique_when_coprime` and on a full internal
-  semidirect-product recognition `ℤ/q ⋊ ℤ/p`, respectively. They are left as the
-  open directions (see this entry's open questions). NOTE: at the time of writing,
-  the parent dependency `Proofs.SylowTheoremOQ01` does not compile on Mathlib
-  v4.26.0 (renamed/removed lemmas such as `Nat.Prime.eq_of_dvd_of_prime`,
-  `orderOf_eq_one_iff_eq_one`), which is an independent repair task; the present
-  file deliberately avoids that dependency and imports only Mathlib so it is fully
-  machine-checked with `0` sorries and `0` axioms.
+  **The cyclic case (Part IV) is now resolved too**, self-containedly from Mathlib's
+  Sylow theory: when `¬ p ∣ (q-1)` and `¬ q ∣ (p-1)`, *every* group of order `pq`
+  (not merely the abelian ones) is cyclic. The Sylow counts `nₚ, n_q` are forced to
+  `1` (each divides the index of a Sylow subgroup and is `≡ 1` modulo its prime), so
+  both Sylow subgroups are normal; a finite group all of whose Sylow subgroups are
+  normal is nilpotent (`isNilpotent_of_finite_tfae`), and a finite nilpotent group of
+  squarefree order is cyclic (it is a Z-group — `IsZGroup.of_squarefree` — and a
+  nilpotent Z-group is cyclic). For `p < q` the side condition `¬ q ∣ (p-1)` is
+  automatic, recovering the classical criterion. Consequently any two groups of order
+  `pq` in this branch are isomorphic (`pq_cyclic_iso`), e.g. all groups of order `15`
+  or `35`.
+
+  **Scope / what is deferred.** Only the `p ∣ (q-1)` *non-abelian* uniqueness — "any
+  two non-cyclic groups of order `pq` are isomorphic" — remains open; it requires a
+  full internal semidirect-product recognition `ℤ/q ⋊ ℤ/p` (see this entry's open
+  questions). The parent dependency `Proofs.SylowTheoremOQ01` does not compile on
+  Mathlib v4.26.0 (renamed/removed lemmas), so this file deliberately avoids it and
+  imports only Mathlib, remaining fully machine-checked with `0` sorries and `0`
+  axioms (every theorem depends on exactly `[propext, Classical.choice, Quot.sound]`).
 
   **Key Mathlib tools**:
   - `exists_prime_orderOf_dvd_card` (Cauchy) and
@@ -48,13 +55,16 @@
   - `isCyclic_of_orderOf_eq_card` — a generator of full order makes `G` cyclic.
   - `mulEquivOfCyclicCardEq` — two cyclic groups of equal `Nat.card` are isomorphic.
   - `zmodCyclicMulEquiv` — a cyclic group `≅ Multiplicative (ZMod (Nat.card G))`.
+  - `card_sylow_modEq_one`, `Sylow.card_dvd_index` — Sylow's counting theorem (Part IV).
+  - `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae` — all-Sylow-normal ⟹
+    nilpotent; `IsZGroup.of_squarefree` and the nilpotent-Z-group `IsCyclic` instance.
 
   References:
   - Dummit, D. & Foote, R. (2004). Abstract Algebra, §4.5, Theorem 14.
   - Conrad, K. "Groups of order pq." Expository notes.
 
   Tags: group-theory, lagrange, pq-groups, classification, isomorphism, MulEquiv,
-        cyclic-groups, abelian-groups, ZMod, finite-groups
+        cyclic-groups, abelian-groups, Sylow, Z-group, nilpotent, ZMod, finite-groups
 -/
 
 import Mathlib
@@ -159,5 +169,150 @@ theorem order_15_abelian_pair
     Nonempty (G ≃* H) :=
   pq_abelian_iso (p := 3) (q := 5) (by norm_num) (by norm_num) (by norm_num)
     (by rw [hG]) (by rw [hH])
+
+/-!
+## Part IV: The cyclic case — *every* group of order `pq` is cyclic
+
+Part II showed the *abelian* groups of order `pq` form a single isomorphism class.
+Sylow theory now upgrades this to the full **cyclic branch** of the classification:
+when neither prime divides the other minus one (`¬ p ∣ (q-1)` and `¬ q ∣ (p-1)`),
+*both* Sylow subgroups are normal — with **no** commutativity hypothesis on `G`.
+A finite group all of whose Sylow subgroups are normal is nilpotent, and a finite
+nilpotent group of squarefree order is cyclic (it is a *Z-group* — every Sylow
+subgroup is cyclic — and a nilpotent Z-group is cyclic).
+
+For `p < q` the side condition `¬ q ∣ (p-1)` is automatic (`0 < p-1 < q`), so the
+single hypothesis `p ∤ (q-1)` already forces cyclicity, recovering the classical
+statement "`|G| = pq`, `p < q`, `p ∤ q-1 ⟹ G` cyclic" (e.g. every group of order
+`15` or `35` is cyclic, whereas order `6 = 2·3` escapes because `2 ∣ (3-1)`).
+
+**Key Mathlib tools**:
+- `card_sylow_modEq_one`, `Sylow.card_dvd_index` — Sylow's counting theorem forces
+  `nₚ = n_q = 1`.
+- `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae` — all Sylow normal ⟹ nilpotent.
+- `IsZGroup.of_squarefree` and the nilpotent-Z-group `IsCyclic` instance — finish.
+-/
+
+/-- For a group of order `pq` (`p ≠ q` primes) with `p ∤ (q-1)`, there is exactly one
+    Sylow `p`-subgroup. The count `nₚ` divides the index `q` of a Sylow `p`-subgroup and
+    satisfies `nₚ ≡ 1 (mod p)`; the alternative `nₚ = q` would give `q ≡ 1 (mod p)`,
+    i.e. `p ∣ (q-1)`, which is excluded. -/
+private theorem pq_card_sylow_one {G : Type*} [Group G] [Fintype G] {p q : ℕ}
+    [Fact p.Prime] (hq : Nat.Prime q) (hpq : p ≠ q)
+    (hcard : Fintype.card G = p * q) (hpd : ¬ p ∣ (q - 1)) :
+    Nat.card (Sylow p G) = 1 := by
+  have hp : Nat.Prime p := Fact.out
+  have hpnq : ¬ p ∣ q := (hp.coprime_iff_not_dvd).mp ((Nat.coprime_primes hp hq).mpr hpq)
+  -- a Sylow `p`-subgroup has order `p`, hence index `q`
+  have hcardP : Nat.card (default : Sylow p G) = p := by
+    rw [Sylow.card_eq_multiplicity, Nat.card_eq_fintype_card, hcard,
+        Nat.factorization_mul hp.pos.ne' hq.pos.ne', Finsupp.add_apply,
+        hp.factorization_self, Nat.factorization_eq_zero_of_not_dvd hpnq, add_zero, pow_one]
+  have hidx : (default : Sylow p G).index = q := by
+    have hmc := (default : Sylow p G).card_mul_index
+    rw [hcardP, Nat.card_eq_fintype_card, hcard] at hmc
+    exact Nat.eq_of_mul_eq_mul_left hp.pos hmc
+  have hdvd : Nat.card (Sylow p G) ∣ q := hidx ▸ (default : Sylow p G).card_dvd_index
+  have hmod : Nat.card (Sylow p G) ≡ 1 [MOD p] := card_sylow_modEq_one p G
+  rcases hq.eq_one_or_self_of_dvd _ hdvd with h1 | hqeq
+  · exact h1
+  · exact absurd ((Nat.modEq_iff_dvd' hq.one_lt.le).mp (hqeq ▸ hmod).symm) hpd
+
+/-- **Cyclic case (full).** For distinct primes `p ≠ q` with `¬ p ∣ (q-1)` and
+    `¬ q ∣ (p-1)`, *every* group of order `pq` is cyclic — not merely the abelian ones.
+    Both Sylow subgroups are forced normal (Sylow counting), making `G` nilpotent; being
+    a Z-group of squarefree order it is then cyclic. -/
+theorem pq_isCyclic {G : Type*} [Group G] [Fintype G] {p q : ℕ}
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p ≠ q)
+    (hpd : ¬ p ∣ (q - 1)) (hqd : ¬ q ∣ (p - 1))
+    (hcard : Fintype.card G = p * q) : IsCyclic G := by
+  haveI : Fact p.Prime := ⟨hp⟩
+  haveI : Fact q.Prime := ⟨hq⟩
+  -- squarefree order ⟹ Z-group (every Sylow subgroup is cyclic of prime order)
+  haveI : IsZGroup G := by
+    apply IsZGroup.of_squarefree
+    rw [Nat.card_eq_fintype_card, hcard]
+    exact (Nat.squarefree_mul ((Nat.coprime_primes hp hq).mpr hpq)).mpr
+      ⟨hp.prime.squarefree, hq.prime.squarefree⟩
+  -- every Sylow subgroup of `G` is normal
+  have hnorm : ∀ (r : ℕ) (_ : Fact r.Prime) (P : Sylow r G), (P : Subgroup G).Normal := by
+    intro r hr P
+    by_cases hrp : r = p
+    · subst hrp
+      haveI : Subsingleton (Sylow r G) :=
+        (Nat.card_eq_one_iff_unique.mp (pq_card_sylow_one hq hpq hcard hpd)).1
+      exact Sylow.normal_of_subsingleton P
+    · by_cases hrq : r = q
+      · subst hrq
+        haveI : Subsingleton (Sylow r G) :=
+          (Nat.card_eq_one_iff_unique.mp
+            (pq_card_sylow_one (p := r) (q := p) hp (Ne.symm hpq)
+              (by rw [hcard]; ring) hqd)).1
+        exact Sylow.normal_of_subsingleton P
+      · -- `r ∤ pq`: the Sylow `r`-subgroup is trivial, hence normal
+        have hrnp : ¬ r ∣ p * q := by
+          intro hdv
+          rcases (Nat.Prime.dvd_mul hr.out).mp hdv with h | h
+          · exact hrp ((Nat.prime_dvd_prime_iff_eq hr.out hp).mp h)
+          · exact hrq ((Nat.prime_dvd_prime_iff_eq hr.out hq).mp h)
+        have hPbot : (P : Subgroup G) = ⊥ := by
+          apply Subgroup.eq_bot_of_card_eq
+          rw [Sylow.card_eq_multiplicity, Nat.card_eq_fintype_card, hcard,
+              Nat.factorization_eq_zero_of_not_dvd hrnp, pow_zero]
+        rw [hPbot]; infer_instance
+  -- all Sylow subgroups normal ⟹ `G` nilpotent ⟹ (Z-group, squarefree) cyclic
+  haveI : Group.IsNilpotent G := (isNilpotent_of_finite_tfae (G := G)).out 3 0 |>.mp hnorm
+  infer_instance
+
+/-- **Cyclic-case uniqueness.** Under the same hypotheses, any two groups of order `pq`
+    are isomorphic to each other (each being cyclic of cardinality `pq`). -/
+theorem pq_cyclic_iso {G H : Type*} [Group G] [Group H] [Fintype G] [Fintype H] {p q : ℕ}
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hpq : p ≠ q)
+    (hpd : ¬ p ∣ (q - 1)) (hqd : ¬ q ∣ (p - 1))
+    (hG : Fintype.card G = p * q) (hH : Fintype.card H = p * q) :
+    Nonempty (G ≃* H) := by
+  haveI : IsCyclic G := pq_isCyclic hp hq hpq hpd hqd hG
+  haveI : IsCyclic H := pq_isCyclic hp hq hpq hpd hqd hH
+  refine ⟨mulEquivOfCyclicCardEq ?_⟩
+  rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, hG, hH]
+
+/-- **Classical cyclic criterion.** For primes `p < q` with `p ∤ (q-1)`, every group of
+    order `pq` is cyclic. The side condition `¬ q ∣ (p-1)` is automatic since
+    `0 < p-1 < q`. -/
+theorem pq_isCyclic_of_lt {G : Type*} [Group G] [Fintype G] {p q : ℕ}
+    (hp : Nat.Prime p) (hq : Nat.Prime q) (hlt : p < q)
+    (hpd : ¬ p ∣ (q - 1)) (hcard : Fintype.card G = p * q) : IsCyclic G := by
+  refine pq_isCyclic hp hq (Nat.ne_of_lt hlt) hpd ?_ hcard
+  intro hdvd
+  have hp2 := hp.two_le
+  have hle := Nat.le_of_dvd (by omega) hdvd
+  omega
+
+/-!
+## Part V: Concrete corollaries of the cyclic branch
+
+Orders `15 = 3·5` and `35 = 5·7` lie in the cyclic branch (`3 ∤ 4`, `5 ∤ 6`), so *every*
+group of those orders is cyclic — strengthening the abelian-only statements of Part III.
+-/
+
+/-- Every group of order `15` is cyclic (not just the abelian ones): `15 = 3·5`, `3 ∤ 4`. -/
+theorem order_15_cyclic {G : Type*} [Group G] [Fintype G] (hG : Fintype.card G = 15) :
+    IsCyclic G :=
+  pq_isCyclic_of_lt (p := 3) (q := 5) (by norm_num) (by norm_num) (by norm_num)
+    (by norm_num) (by rw [hG])
+
+/-- Every group of order `35` is cyclic: `35 = 5·7`, `5 ∤ 6`. -/
+theorem order_35_cyclic {G : Type*} [Group G] [Fintype G] (hG : Fintype.card G = 35) :
+    IsCyclic G :=
+  pq_isCyclic_of_lt (p := 5) (q := 7) (by norm_num) (by norm_num) (by norm_num)
+    (by norm_num) (by rw [hG])
+
+/-- Any two groups of order `15` are isomorphic to each other. -/
+theorem order_15_iso {G H : Type*} [Group G] [Group H] [Fintype G] [Fintype H]
+    (hG : Fintype.card G = 15) (hH : Fintype.card H = 15) : Nonempty (G ≃* H) := by
+  haveI : IsCyclic G := order_15_cyclic hG
+  haveI : IsCyclic H := order_15_cyclic hH
+  exact ⟨mulEquivOfCyclicCardEq
+    (by rw [Nat.card_eq_fintype_card, Nat.card_eq_fintype_card, hG, hH])⟩
 
 end LagrangeOQ01OQ01OQ02

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/annotations.json
@@ -4,14 +4,14 @@
     "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
     "range": { "startLine": 1, "endLine": 68 },
     "type": "concept",
-    "title": "From Counting to Isomorphisms (Abelian Thread)",
-    "content": "The parent classification answers the open question at the level of *how many* isomorphism classes of groups of order $pq$ exist (one when $p \\nmid (q-1)$, two when $p \\mid (q-1)$). This file upgrades the **abelian** case to genuine isomorphisms $G \\simeq^* H$ using Mathlib's `MulEquiv` machinery, self-containedly (imports only Mathlib). The general cyclic case and the non-abelian uniqueness are scoped out, as they depend on the parent Sylow classification.",
-    "mathContext": "For distinct primes $p < q$, a group of order $pq$ has a unique (hence normal) Sylow $q$-subgroup $Q \\cong \\mathbb{Z}/q$. When $p \\nmid (q-1)$ the group is cyclic; when $p \\mid (q-1)$ a non-abelian semidirect product $\\mathbb{Z}/q \\rtimes \\mathbb{Z}/p$ also exists. In the latter branch the abelian class is exactly the cyclic group $\\mathbb{Z}/pq$ resolved here."
+    "title": "From Counting to Isomorphisms (Abelian Thread + Full Cyclic Case)",
+    "content": "The parent classification answers the open question at the level of *how many* isomorphism classes of groups of order $pq$ exist (one when $p \\nmid (q-1)$, two when $p \\mid (q-1)$). This file upgrades that count to genuine isomorphisms $G \\simeq^* H$ using Mathlib's `MulEquiv` machinery, self-containedly (imports only Mathlib). Parts I–III resolve the **abelian** case for any $p \\neq q$; Parts IV–V resolve the **full cyclic branch** — when $p \\nmid (q-1)$ and $q \\nmid (p-1)$, *every* group of order $pq$ is cyclic (no commutativity assumed). Only the non-abelian $p \\mid (q-1)$ uniqueness is left open.",
+    "mathContext": "For distinct primes $p < q$, a group of order $pq$ has a unique (hence normal) Sylow $q$-subgroup $Q \\cong \\mathbb{Z}/q$. When $p \\nmid (q-1)$ the Sylow $p$-subgroup is also normal and the group is cyclic; when $p \\mid (q-1)$ a non-abelian semidirect product $\\mathbb{Z}/q \\rtimes \\mathbb{Z}/p$ also exists."
   },
   {
     "id": "ann-pq02-002-abelian-cyclic",
     "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 79, "endLine": 95 },
+    "range": { "startLine": 77, "endLine": 103 },
     "type": "key-insight",
     "title": "Abelian of Order pq ⟹ Cyclic (any p ≠ q)",
     "content": "`pq_abelian_isCyclic` proves every abelian group of order $pq$ is cyclic with NO divisibility hypothesis. Cauchy's theorem (`exists_prime_orderOf_dvd_card`) produces $a$ of order $p$ and $b$ of order $q$; because the group is abelian they commute, and as $p,q$ are coprime `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives $\\mathrm{ord}(ab) = pq = |G|$, so `isCyclic_of_orderOf_eq_card` makes $G$ cyclic. The Fintype.card hypothesis is bridged to Nat.card with `Nat.card_eq_fintype_card`.",
@@ -20,7 +20,7 @@
   {
     "id": "ann-pq02-003-abelian-iso",
     "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 104, "endLine": 113 },
+    "range": { "startLine": 105, "endLine": 124 },
     "type": "technique",
     "title": "Abelian-Case Uniqueness via mulEquivOfCyclicCardEq",
     "content": "`pq_abelian_iso` registers both $G$ and $H$ as cyclic instances (from `pq_abelian_isCyclic`) and produces $G \\simeq^* H$ from `mulEquivOfCyclicCardEq`, whose only obligation is the equality of cardinalities (bridged Fintype.card → Nat.card and rewritten by the order hypotheses).",
@@ -29,7 +29,7 @@
   {
     "id": "ann-pq02-004-zmod-model",
     "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 115, "endLine": 130 },
+    "range": { "startLine": 125, "endLine": 133 },
     "type": "technique",
     "title": "Canonical Representative ℤ/pq",
     "content": "`pq_abelian_iso_zmod` pins the canonical model: `zmodCyclicMulEquiv` yields $\\mathrm{Multiplicative}(\\mathbb{Z}/\\mathrm{Nat.card}\\,G) \\simeq^* G$, and the cardinality equality $\\mathrm{Nat.card}\\,G = pq$ is transported through the dependent type with the rewrite `hN ▸ (...).symm`, giving $G \\simeq^* \\mathrm{Multiplicative}(\\mathbb{Z}/pq)$.",
@@ -38,10 +38,28 @@
   {
     "id": "ann-pq02-005-corollaries",
     "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
-    "range": { "startLine": 131, "endLine": 163 },
+    "range": { "startLine": 134, "endLine": 173 },
     "type": "concept",
-    "title": "Concrete Corollaries",
+    "title": "Abelian Concrete Corollaries (orders 6, 15, 35)",
     "content": "`order_6_abelian_unique`, `order_15_abelian_unique`, `order_35_abelian_unique` give every abelian group of those orders as $\\mathbb{Z}/n$; `order_15_abelian_pair` states any two abelian groups of order 15 are isomorphic. `order_6` highlights that the abelian-case theorem pins the abelian class even though $6 = 2\\cdot 3$ falls in the non-cyclic branch ($2 \\mid 2$), where $S_3 \\cong D_3$ is the other class.",
     "mathContext": "Order 6 is the smallest order admitting a non-abelian group ($S_3$). The cyclic group $\\mathbb{Z}/6$ is the unique abelian group of that order."
+  },
+  {
+    "id": "ann-pq02-006-cyclic-case",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 174, "endLine": 291 },
+    "type": "key-insight",
+    "title": "The Cyclic Case: Every Group of Order pq Is Cyclic (no commutativity)",
+    "content": "`pq_isCyclic` proves that when $p \\nmid (q-1)$ and $q \\nmid (p-1)$, *every* group of order $pq$ is cyclic. The private lemma `pq_card_sylow_one` shows the number of Sylow $p$-subgroups is $1$: it divides the index $q$ of a Sylow $p$-subgroup (whose order is $p$ by `Sylow.card_eq_multiplicity`) via `Sylow.card_dvd_index`, and is $\\equiv 1 \\pmod p$ by `card_sylow_modEq_one`; the alternative $n_p = q$ would force $q \\equiv 1 \\pmod p$, i.e. $p \\mid (q-1)$, excluded. Applying it to both primes forces both Sylow subgroups to be unique, hence normal (`Sylow.normal_of_subsingleton`); off-primes have trivial Sylow subgroups ($\\bot$, normal). With every Sylow subgroup normal, `isNilpotent_of_finite_tfae` makes $G$ nilpotent, and since $pq$ is squarefree `IsZGroup.of_squarefree` makes $G$ a Z-group — a nilpotent Z-group is cyclic. `pq_cyclic_iso` then gives $G \\simeq^* H$, and `pq_isCyclic_of_lt` specializes to $p < q$ (discharging $q \\nmid (p-1)$ automatically).",
+    "mathContext": "This is the classical Hölder/Burnside criterion: a group of order $pq$ ($p < q$) is cyclic iff $p \\nmid (q-1)$. The proof here is the standard double-Sylow-normality argument, but routed through Mathlib's Z-group API ('all Sylow subgroups cyclic') so that 'nilpotent + squarefree order ⟹ cyclic' closes the goal without an explicit internal-direct-product construction."
+  },
+  {
+    "id": "ann-pq02-007-cyclic-corollaries",
+    "proofId": "lagrange-theorem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 292, "endLine": 318 },
+    "type": "concept",
+    "title": "Cyclic Concrete Corollaries (orders 15, 35)",
+    "content": "`order_15_cyclic` and `order_35_cyclic` state that EVERY group of order $15 = 3\\cdot 5$ ($3 \\nmid 4$) or $35 = 5\\cdot 7$ ($5 \\nmid 6$) is cyclic — strictly stronger than the abelian-only statements of Part III. `order_15_iso` concludes that any two groups of order 15 are isomorphic. Order $6 = 2\\cdot 3$ is excluded from the criterion precisely because $2 \\mid (3-1)$, matching the existence of the non-abelian $S_3$.",
+    "mathContext": "15 and 35 are the smallest non-prime, non-prime-power orders forcing cyclicity for purely arithmetic reasons (the smaller prime fails to divide the larger minus one), so up to isomorphism there is a unique group of each of those orders."
   }
 ]

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-01-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "lagrange-theorem-oq-01-oq-01-oq-02",
-  "title": "pq-Groups: Abelian Isomorphism Uniqueness (every abelian group of order pq is ℤ/pq)",
+  "title": "pq-Groups: Isomorphism Uniqueness — Abelian Thread + Full Cyclic Case (every group of order pq with p∤q-1 is ℤ/pq)",
   "slug": "lagrange-theorem-oq-01-oq-01-oq-02",
-  "description": "Upgrades the abelian portion of the parent pq-classification from a counting statement to genuine MulEquiv isomorphisms, using only Mathlib. For ANY distinct primes p ≠ q, every abelian group of order pq is cyclic (via Cauchy + the coprime-order product law), so any two abelian groups of order pq are isomorphic — each isomorphic to Multiplicative (ZMod pq). This identifies the abelian isomorphism class in BOTH branches of the classification (cyclic p ∤ q-1, and the non-cyclic p | q-1 branch where the other class is the non-abelian semidirect product). The general not-necessarily-abelian uniqueness is deferred (it depends on the parent Sylow classification, which currently does not compile on Mathlib v4.26.0).",
+  "description": "Upgrades the parent pq-classification from a counting statement to genuine MulEquiv isomorphisms, using only Mathlib. (1) ABELIAN thread: for ANY distinct primes p ≠ q, every abelian group of order pq is cyclic (Cauchy + the coprime-order product law), so any two are isomorphic — each ≅ Multiplicative (ZMod pq). (2) FULL CYCLIC case: when ¬ p∣(q-1) and ¬ q∣(p-1), EVERY group of order pq (not just the abelian ones) is cyclic — both Sylow subgroups are forced normal by Sylow counting, so G is nilpotent, and a nilpotent Z-group of squarefree order is cyclic. Consequently any two groups of order pq in this branch are isomorphic (e.g. all groups of order 15 or 35). Self-contained: imports only Mathlib, avoiding the parent's (non-compiling) Sylow file. Only the non-abelian p|(q-1) uniqueness remains open.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-06-23",
@@ -17,6 +17,9 @@
       "MulEquiv",
       "cyclic-groups",
       "abelian-groups",
+      "Sylow",
+      "Z-group",
+      "nilpotent",
       "ZMod",
       "finite-groups"
     ],
@@ -24,92 +27,111 @@
     "sorries": 0,
     "dateAdded": "2026-06-23",
     "axiomCount": 0,
-    "lineCount": 163,
-    "theoremCount": 7,
+    "lineCount": 318,
+    "theoremCount": 14,
     "definitionCount": 0,
-    "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API (Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv`). No `axiom` declarations and no structure-encoded assumptions. Kernel-verified on Mathlib v4.26.0: every theorem depends on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (no `sorryAx`, no `Lean.ofReduceBool`).",
+    "assumptions": "None. Imports only Mathlib. Uses standard Mathlib group-theory API: Cauchy's theorem `exists_prime_orderOf_dvd_card`, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime`, `isCyclic_of_orderOf_eq_card`, `mulEquivOfCyclicCardEq`, `zmodCyclicMulEquiv` (abelian thread); and `card_sylow_modEq_one`, `Sylow.card_dvd_index`, `Sylow.normal_of_subsingleton`, `isNilpotent_of_finite_tfae`, `IsZGroup.of_squarefree` (cyclic case). No `axiom` declarations, no structure-encoded assumptions, no `native_decide`. Kernel-verified on Mathlib v4.26.0: all 14 theorems depend on exactly the standard `[propext, Classical.choice, Quot.sound]` triple (confirmed via `#print axioms`; no `sorryAx`, no `Lean.ofReduceBool`).",
     "originalContributions": [
       "pq_abelian_isCyclic: every finite ABELIAN group of order pq (any distinct primes p ≠ q) is cyclic — proved from Cauchy (elements of order p and q) plus the coprime-order product law orderOf(a·b) = pq = |G|. Holds with NO divisibility hypothesis, so it also applies inside the non-cyclic p | (q-1) branch.",
-      "pq_abelian_iso: consequently any two abelian groups of order pq are isomorphic (Nonempty (G ≃* H)) via mulEquivOfCyclicCardEq.",
-      "pq_abelian_iso_zmod: every abelian group of order pq is isomorphic to the canonical model Multiplicative (ZMod pq) via zmodCyclicMulEquiv.",
-      "Concrete corollaries order_6_abelian_unique, order_15_abelian_unique, order_35_abelian_unique (each abelian group of those orders ≅ ℤ/n), and order_15_abelian_pair (any two abelian groups of order 15 are isomorphic). order_6 illustrates that the abelian class is pinned even though 6 = 2·3 lies in the non-cyclic branch where S₃ is the other class.",
-      "Self-contained: imports only Mathlib, deliberately avoiding the parent Sylow classification dependency `Proofs.SylowTheoremOQ01` which does not compile on Mathlib v4.26.0."
+      "pq_abelian_iso / pq_abelian_iso_zmod: any two abelian groups of order pq are isomorphic, and each ≅ the canonical model Multiplicative (ZMod pq), via mulEquivOfCyclicCardEq and zmodCyclicMulEquiv.",
+      "pq_isCyclic (NEW, the full cyclic case): for distinct primes with ¬ p∣(q-1) and ¬ q∣(p-1), EVERY group of order pq is cyclic — no commutativity hypothesis. Proof: the Sylow counts nₚ, n_q each divide the index of a Sylow subgroup (= the other prime) and are ≡ 1 modulo their prime, so both are forced to 1 (the alternative would give p∣(q-1) or q∣(p-1)); hence both Sylow subgroups are normal, G is nilpotent (isNilpotent_of_finite_tfae), and a nilpotent Z-group of squarefree order is cyclic (IsZGroup.of_squarefree + the nilpotent-Z-group IsCyclic instance).",
+      "pq_isCyclic_of_lt: the classical criterion — for primes p < q with p∤(q-1), every group of order pq is cyclic (the side condition ¬ q∣(p-1) is discharged automatically since 0 < p-1 < q).",
+      "pq_cyclic_iso: consequently any two groups of order pq in the cyclic branch are isomorphic to each other.",
+      "Concrete corollaries: order_15_cyclic and order_35_cyclic (EVERY group of order 15 or 35 is cyclic, strengthening the abelian-only order_15/35_abelian_unique of Part III), and order_15_iso (any two groups of order 15 are isomorphic). Order 6 = 2·3 escapes the criterion (2 | (3-1)), matching the existence of the non-abelian S₃.",
+      "Self-contained: imports only Mathlib, deliberately avoiding the parent Sylow classification dependency `Proofs.SylowTheoremOQ01` which does not compile on Mathlib v4.26.0 — the cyclic case is rebuilt directly from Mathlib's Sylow/Z-group API."
     ]
   },
   "overview": {
-    "historicalContext": "The classification of groups of order pq (p < q distinct primes) is a classical application of Sylow theory due to Hölder/Burnside. The parent entry `lagrange-theorem-oq-01-oq-01` establishes the counting facts: the Sylow q-subgroup is always normal, and G is cyclic iff p ∤ (q-1); when p ∤ (q-1) there is a unique isomorphism class (ℤ/pq), and when p | (q-1) there are exactly two (ℤ/pq and a non-abelian semidirect product ℤ/q ⋊ ℤ/p). Sibling entry `lagrange-theorem-oq-01-oq-01-oq-01` supplies explicit non-cyclic witnesses (DihedralGroup q for p = 2, and the general semidirect product). The remaining gap, flagged in that sibling's open questions, is to turn the COUNTING statement into genuine ISOMORPHISMS using Mathlib's MulEquiv machinery. This file does that for the abelian thread, fully and self-containedly.",
-    "problemStatement": "Upgrade the pq-classification to isomorphism uniqueness via Mathlib's group-isomorphism machinery: 'any two groups of order pq are isomorphic to each other, for each of the two cases.' This file resolves the abelian thread: identify, up to MulEquiv, the abelian isomorphism class of order pq.",
-    "proofStrategy": "In a CommGroup of order pq, Cauchy's theorem (`exists_prime_orderOf_dvd_card`) yields a of order p and b of order q. Since the group is abelian a and b commute, and p, q being coprime, `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives orderOf(a·b) = p·q = |G|; `isCyclic_of_orderOf_eq_card` then makes G cyclic. Finally `mulEquivOfCyclicCardEq` (two cyclic groups of equal Nat.card are isomorphic) and `zmodCyclicMulEquiv` (a cyclic group ≅ Multiplicative (ZMod (Nat.card G))) deliver the isomorphism statements, bridging Fintype.card to Nat.card via `Nat.card_eq_fintype_card`.",
+    "historicalContext": "The classification of groups of order pq (p < q distinct primes) is a classical application of Sylow theory due to Hölder/Burnside. The parent entry `lagrange-theorem-oq-01-oq-01` establishes the counting facts: the Sylow q-subgroup is always normal, and G is cyclic iff p ∤ (q-1); when p ∤ (q-1) there is a unique isomorphism class (ℤ/pq), and when p | (q-1) there are exactly two (ℤ/pq and a non-abelian semidirect product ℤ/q ⋊ ℤ/p). Sibling entry `lagrange-theorem-oq-01-oq-01-oq-01` supplies explicit non-cyclic witnesses (DihedralGroup q for p = 2, and the general semidirect product). The remaining gap, flagged in that sibling's open questions, is to turn the COUNTING statement into genuine ISOMORPHISMS using Mathlib's MulEquiv machinery. This file does that for the abelian thread AND the full cyclic branch, self-containedly.",
+    "problemStatement": "Upgrade the pq-classification to isomorphism uniqueness via Mathlib's group-isomorphism machinery: 'any two groups of order pq are isomorphic to each other, for each of the two cases.' This file resolves (a) the abelian thread — identify, up to MulEquiv, the abelian isomorphism class of order pq — and (b) the full cyclic branch — when ¬ p∣(q-1), every group of order pq is cyclic, so any two are isomorphic.",
+    "proofStrategy": "ABELIAN (Parts I–III): in a CommGroup of order pq, Cauchy's theorem yields a of order p and b of order q; commutativity + coprimality give orderOf(a·b) = pq = |G| (Commute.orderOf_mul_eq_mul_orderOf_of_coprime), so isCyclic_of_orderOf_eq_card makes G cyclic; mulEquivOfCyclicCardEq and zmodCyclicMulEquiv deliver the isomorphisms (Fintype.card↔Nat.card via Nat.card_eq_fintype_card). CYCLIC (Parts IV–V): a private lemma pq_card_sylow_one shows the Sylow p-count is 1 — it divides the index q of a Sylow p-subgroup (whose order is p, computed via Sylow.card_eq_multiplicity) and is ≡ 1 (mod p) by card_sylow_modEq_one, while the alternative nₚ = q would give q ≡ 1 (mod p), i.e. p | (q-1), excluded. Applying it to both primes forces both Sylow subgroups to be unique hence normal (Sylow.normal_of_subsingleton). Off-primes have trivial Sylow subgroups (⊥, normal). So every Sylow subgroup is normal; isNilpotent_of_finite_tfae makes G nilpotent; IsZGroup.of_squarefree (pq squarefree) makes G a Z-group; and the nilpotent-Z-group IsCyclic instance finishes.",
     "keyInsights": [
-      "An abelian group of order pq is cyclic for EVERY pair of distinct primes, independent of whether p | (q-1). The squarefree order plus the coprime-order product law forces a generator a·b of order pq. This isolates the abelian isomorphism class on BOTH sides of the classification dichotomy.",
-      "Mathlib's `mulEquivOfCyclicCardEq` is exactly the tool that upgrades an `IsCyclic` fact to a genuine `MulEquiv` — the difference between 'one isomorphism class' and 'a concrete isomorphism'.",
-      "Fintype.card and Nat.card must be bridged (`Nat.card_eq_fintype_card`) because Cauchy/cardinality hypotheses use Fintype.card while the cyclic-iso API is phrased with Nat.card.",
-      "The coprime-order multiplication lemma lives in namespace Commute (used as dot notation `(Commute.all a b).orderOf_mul_eq_mul_orderOf_of_coprime`), not in the root namespace.",
-      "The general (non-abelian-allowed) cyclic case and the non-abelian uniqueness both require the parent Sylow classification; keeping this file Mathlib-only makes the abelian result robust and independently verifiable."
+      "An abelian group of order pq is cyclic for EVERY pair of distinct primes, independent of whether p | (q-1) — the squarefree order plus the coprime-order product law forces a generator a·b of order pq, isolating the abelian class on both sides of the dichotomy.",
+      "The cyclic case needs NO commutativity: Sylow's counting theorem alone forces both Sylow subgroups normal exactly when neither prime divides the other minus one. The two arithmetic facts nₚ | (index = other prime) and nₚ ≡ 1 (mod p) pin nₚ = 1.",
+      "Z-group theory is the clean finish: a finite group of squarefree order is automatically a Z-group (every Sylow subgroup has prime order, hence cyclic), and Mathlib packages 'nilpotent + Z-group ⟹ cyclic' as an instance — so once all Sylow subgroups are normal (⟹ nilpotent via isNilpotent_of_finite_tfae) the result is immediate.",
+      "The normality condition in isNilpotent_of_finite_tfae quantifies over ALL primes; off-primes (r ∤ pq) are handled by Sylow.card_eq_multiplicity giving a trivial Sylow subgroup (⊥), which is normal.",
+      "Mathlib's `mulEquivOfCyclicCardEq` upgrades an `IsCyclic` fact to a genuine `MulEquiv` — the difference between 'one isomorphism class' and a concrete isomorphism.",
+      "Keeping the file Mathlib-only (rather than depending on the parent `Proofs.SylowTheoremOQ01`, which does not compile on v4.26.0) makes both the abelian and cyclic results robust and independently kernel-verifiable."
     ],
     "prerequisites": [
       "Cauchy's theorem exists_prime_orderOf_dvd_card (Mathlib.GroupTheory.Perm.Cycle.Type)",
       "Commute.orderOf_mul_eq_mul_orderOf_of_coprime (Mathlib.GroupTheory.OrderOfElement)",
       "isCyclic_of_orderOf_eq_card, mulEquivOfCyclicCardEq, zmodCyclicMulEquiv (Mathlib.GroupTheory.SpecificGroups.Cyclic)",
+      "Sylow's counting theorem card_sylow_modEq_one, Sylow.card_dvd_index, Sylow.card_eq_multiplicity, Sylow.normal_of_subsingleton (Mathlib.GroupTheory.Sylow)",
+      "isNilpotent_of_finite_tfae (Mathlib.GroupTheory.Nilpotent); IsZGroup.of_squarefree and the nilpotent-Z-group IsCyclic instance (Mathlib.GroupTheory.SpecificGroups.ZGroup)",
       "Mathlib v4.26.0"
     ]
   },
   "sections": [
     {
       "id": "module-docstring",
-      "title": "Module Docstring: OQ Statement, Abelian Scope, Deferred Cases",
+      "title": "Module Docstring: OQ Statement, Abelian + Cyclic Scope, Deferred Non-Abelian Case",
       "startLine": 1,
       "endLine": 68,
-      "summary": "States OQ-01-OQ-01-OQ-02 (upgrade the counting classification to MulEquiv isomorphisms), the abelian thread delivered here, the proof of the key cyclicity step, and what is deferred (the general cyclic case and non-abelian uniqueness, which depend on the parent Sylow classification — currently not compiling on Mathlib v4.26.0). Lists the key Mathlib tools and cites Dummit–Foote §4.5 and Conrad's notes."
+      "summary": "States OQ-01-OQ-01-OQ-02 (upgrade the counting classification to MulEquiv isomorphisms), the abelian thread, the now-resolved full cyclic case (Sylow counting ⟹ both Sylow subgroups normal ⟹ nilpotent ⟹ Z-group cyclic), and what remains deferred (the non-abelian p|q-1 uniqueness, needing semidirect-product recognition). Lists the key Mathlib tools and cites Dummit–Foote §4.5 and Conrad's notes."
     },
     {
       "id": "abelian-cyclic",
       "title": "Part I — Abelian Groups of Order pq Are Cyclic",
       "startLine": 69,
-      "endLine": 95,
+      "endLine": 104,
       "summary": "pq_abelian_isCyclic: any abelian group of order pq is cyclic. Cauchy gives elements of orders p and q; the coprime-order product law makes their product a generator of order pq = |G|. No divisibility hypothesis, so this covers the abelian class in both branches."
     },
     {
       "id": "abelian-iso",
       "title": "Part II — Abelian Isomorphism Uniqueness",
-      "startLine": 96,
-      "endLine": 130,
+      "startLine": 105,
+      "endLine": 133,
       "summary": "pq_abelian_iso (any two abelian groups of order pq are isomorphic) and pq_abelian_iso_zmod (each ≅ Multiplicative (ZMod pq)), via mulEquivOfCyclicCardEq and zmodCyclicMulEquiv after Part I."
     },
     {
-      "id": "corollaries",
-      "title": "Part III — Concrete Corollaries (orders 6, 15, 35)",
-      "startLine": 131,
-      "endLine": 163,
+      "id": "abelian-corollaries",
+      "title": "Part III — Abelian Concrete Corollaries (orders 6, 15, 35)",
+      "startLine": 134,
+      "endLine": 173,
       "summary": "order_6_abelian_unique, order_15_abelian_unique, order_35_abelian_unique: every abelian group of those orders is ℤ/n. order_15_abelian_pair: any two abelian groups of order 15 are isomorphic. order_6 illustrates the abelian class being pinned even though 6 = 2·3 lies in the non-cyclic branch (2 | 2) where S₃ is the other class."
+    },
+    {
+      "id": "cyclic-case",
+      "title": "Part IV — The Cyclic Case: Every Group of Order pq Is Cyclic",
+      "startLine": 174,
+      "endLine": 291,
+      "summary": "pq_card_sylow_one (private): the Sylow p-count is 1 (it divides the index q and is ≡ 1 mod p; nₚ = q is excluded by p∤q-1). pq_isCyclic: for ¬p∣(q-1) and ¬q∣(p-1), every group of order pq is cyclic — both Sylow subgroups normal (Sylow.normal_of_subsingleton), off-primes trivial, so G nilpotent (isNilpotent_of_finite_tfae) and, being a squarefree-order Z-group (IsZGroup.of_squarefree), cyclic. pq_cyclic_iso: any two such groups are isomorphic. pq_isCyclic_of_lt: the classical p < q criterion with the q∤(p-1) side condition discharged automatically."
+    },
+    {
+      "id": "cyclic-corollaries",
+      "title": "Part V — Cyclic Concrete Corollaries (orders 15, 35)",
+      "startLine": 292,
+      "endLine": 318,
+      "summary": "order_15_cyclic and order_35_cyclic: EVERY group of order 15 or 35 is cyclic (15 = 3·5 with 3∤4, 35 = 5·7 with 5∤6), strengthening the abelian-only statements of Part III. order_15_iso: any two groups of order 15 are isomorphic."
     }
   ],
   "conclusion": {
-    "summary": "This file proves 7 theorems with 0 sorries and 0 axioms (kernel-verified: standard [propext, Classical.choice, Quot.sound] triple only). It identifies, up to MulEquiv, the abelian isomorphism class of order pq for every pair of distinct primes: every abelian group of order pq is cyclic, any two are isomorphic, and each is isomorphic to Multiplicative (ZMod pq).",
-    "implications": "Together with the parent (counting) and sibling oq-01-oq-01-oq-01 (explicit non-cyclic witnesses), the abelian side of the order-pq classification now has genuine isomorphisms, not just a class count. The outstanding pieces of full isomorphism uniqueness are the general cyclic case (for p ∤ q-1, any two groups of order pq are isomorphic) and the non-abelian case (any two non-cyclic groups of order pq are isomorphic) — both requiring the parent Sylow classification and, for the non-abelian case, an internal semidirect-product recognition ℤ/q ⋊ ℤ/p.",
+    "summary": "This file proves 14 theorems with 0 sorries and 0 axioms (kernel-verified: standard [propext, Classical.choice, Quot.sound] triple only, no native_decide). It resolves, up to MulEquiv, BOTH the abelian isomorphism class of order pq (every abelian group of order pq is cyclic ≅ ℤ/pq, for any distinct primes) and the full cyclic branch (when ¬p∣(q-1) and ¬q∣(p-1), every group of order pq is cyclic, so any two are isomorphic — e.g. all groups of order 15 and 35).",
+    "implications": "Together with the parent (counting) and sibling oq-01-oq-01-oq-01 (explicit non-cyclic witnesses), the cyclic side of the order-pq classification now has genuine isomorphisms, not just a class count — and crucially without assuming commutativity, rebuilt directly from Mathlib's Sylow/Z-group API rather than the parent's non-compiling Sylow file. The single outstanding piece of full isomorphism uniqueness is the non-abelian case (any two non-cyclic groups of order pq, with p | q-1, are isomorphic), which requires an internal semidirect-product recognition ℤ/q ⋊ ℤ/p.",
     "openQuestions": [
-      "General cyclic-case uniqueness: for distinct primes p < q with p ∤ (q-1), prove any two groups of order pq are isomorphic. This needs the parent's `pq_unique_when_coprime` (every order-pq group is cyclic when p ∤ q-1), which depends on `Proofs.SylowTheoremOQ01`; that file does not compile on Mathlib v4.26.0 and is an independent repair task.",
-      "Non-abelian uniqueness: prove any two non-cyclic groups of order pq (with p | q-1) are isomorphic, by recognizing each as the internal semidirect product ℤ/q ⋊ ℤ/p and showing all non-trivial actions ℤ/p → Aut(ℤ/q) yield isomorphic products.",
-      "REPAIR FLAG: the parent chain `Proofs.SylowTheoremOQ01` → `Proofs.LagrangeTheoremOQ01OQ01` uses Mathlib names absent in v4.26.0 (e.g. `Nat.Prime.eq_of_dvd_of_prime`, `orderOf_eq_one_iff_eq_one`); a Mechanic pass is needed before the cyclic-case upgrade can be built on top of it."
+      "Non-abelian uniqueness: prove any two non-cyclic groups of order pq (with p | q-1) are isomorphic, by recognizing each as the internal semidirect product ℤ/q ⋊ ℤ/p and showing all non-trivial actions ℤ/p → Aut(ℤ/q) yield isomorphic products. (The cyclic-case uniqueness, previously open here, is now resolved by pq_isCyclic / pq_cyclic_iso.)",
+      "Canonical model for the cyclic branch: package pq_isCyclic with zmodCyclicMulEquiv to state directly that every group of order pq (¬p∣q-1) is ≅ Multiplicative (ZMod pq), mirroring pq_abelian_iso_zmod but without the commutativity hypothesis.",
+      "REPAIR FLAG (lower priority now): the parent chain `Proofs.SylowTheoremOQ01` → `Proofs.LagrangeTheoremOQ01OQ01` uses Mathlib names absent in v4.26.0 (e.g. `Nat.Prime.eq_of_dvd_of_prime`, `orderOf_eq_one_iff_eq_one`); a Mechanic pass would let downstream entries reuse that infrastructure, though this file no longer depends on it."
     ]
   },
   "crossReferences": [
     {
       "targetId": "lagrange-theorem-oq-01-oq-01",
       "relationship": "extends",
-      "description": "Parent pq-classification (counting of isomorphism classes). This file upgrades the abelian class to a genuine MulEquiv, independently of the parent's (currently non-compiling) Sylow infrastructure."
+      "description": "Parent pq-classification (counting of isomorphism classes). This file upgrades both the abelian class and the full cyclic branch to genuine MulEquiv isomorphisms, independently of the parent's (currently non-compiling) Sylow infrastructure."
     },
     {
       "targetId": "lagrange-theorem-oq-01-oq-01-oq-01",
       "relationship": "related",
-      "description": "Sibling supplying explicit non-cyclic witnesses (DihedralGroup q and the general semidirect product). Its open-question list flags the isomorphism-uniqueness upgrade; this file delivers the abelian portion of it."
+      "description": "Sibling supplying explicit non-cyclic witnesses (DihedralGroup q and the general semidirect product). Its open-question list flags the isomorphism-uniqueness upgrade; this file delivers the abelian portion and the full cyclic branch, leaving only the non-abelian uniqueness."
     }
   ],
   "leanFile": {
     "namespace": "LagrangeOQ01OQ01OQ02",
-    "lineCount": 163,
+    "lineCount": 318,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 14,
     "definitionCount": 0,
     "path": "Proofs/LagrangeTheoremOQ01OQ01OQ02.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Extends the `lagrange-theorem-oq-01-oq-01-oq-02` entry (previously abelian-only) with the **full cyclic branch** of the order-`pq` classification: when `¬ p ∣ (q-1)` and `¬ q ∣ (p-1)`, **every** group of order `pq` is cyclic — *not just the abelian ones*. This resolves the cyclic-case isomorphism-uniqueness direction that the entry's docstring and open-questions previously deferred, and does so **self-containedly from Mathlib** (the parent `Proofs.SylowTheoremOQ01` does not compile on v4.26.0, so it is deliberately avoided).

## What's new (Part IV + V — 7 theorems, all 0-axiom)

| Theorem | Statement |
|---|---|
| `pq_card_sylow_one` (private) | The Sylow `p`-count is `1`: it divides the index `q` (`Sylow.card_dvd_index`, with the Sylow `p`-subgroup of order `p` via `Sylow.card_eq_multiplicity`) and is `≡ 1 (mod p)` (`card_sylow_modEq_one`); `n_p = q` would force `p ∣ (q-1)`. |
| `pq_isCyclic` | For distinct primes with `¬ p∣(q-1)`, `¬ q∣(p-1)`: every group of order `pq` is cyclic. Both Sylow subgroups forced normal, off-primes trivial ⟹ `G` nilpotent (`isNilpotent_of_finite_tfae`) ⟹ squarefree-order Z-group (`IsZGroup.of_squarefree`) ⟹ cyclic. |
| `pq_cyclic_iso` | Any two groups of order `pq` in this branch are isomorphic (`MulEquiv`). |
| `pq_isCyclic_of_lt` | Classical `p < q` criterion — the side condition `¬ q∣(p-1)` is discharged automatically (`0 < p-1 < q`). |
| `order_15_cyclic`, `order_35_cyclic`, `order_15_iso` | Every group of order `15` or `35` is cyclic — strengthening the Part III abelian-only corollaries. |

## Proof approach

The standard Hölder/Burnside double-Sylow-normality argument, but routed through Mathlib's **Z-group** API: a finite group of squarefree order is automatically a Z-group (all Sylow subgroups cyclic of prime order), and "nilpotent + Z-group ⟹ cyclic" is a Mathlib instance — so once Sylow counting forces both Sylow subgroups normal (hence `G` nilpotent), cyclicity follows without an explicit internal-direct-product construction.

## Verification

- Built/type-checked on **Mathlib v4.26.0** (`lake env lean`, Docker unavailable in this environment): **0 sorries, 0 axioms**.
- `#print axioms` confirms all six exposed theorems depend on exactly `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no `native_decide`/`Lean.ofReduceBool`.
- `meta.json` and `annotations.json` updated (14 theorems, 318 lines; new Part IV/V sections + annotations; status remains `verified`).

## Scope

Only the **non-abelian** `p ∣ (q-1)` uniqueness (recognizing each non-cyclic group of order `pq` as the internal semidirect product `ℤ/q ⋊ ℤ/p`) remains open; see the updated open-questions list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
