### PR TITLE
Enrich Pythagorean parity dichotomy (oq-07): add index.ts + annotations

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-07/annotations.json
+++ b/src/data/proofs/pythagorean-triples-oq-07/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-sq-emod-four",
+    "proofId": "pythagorean-triples-oq-07",
+    "range": { "startLine": 35, "endLine": 39 },
+    "type": "technique",
+    "title": "An Odd Square is 1 mod 4",
+    "content": "The arithmetic seed of the entire dichotomy. Writing an odd integer as $a = 2k+1$, its square expands to $(2k+1)^2 = 4(k^2+k) + 1$, so the remainder on division by 4 is exactly 1. The proof destructures the oddness hypothesis `a % 2 = 1` into the witness `a = 2k+1` via `Int.odd_iff`, supplies the polynomial identity by `ring`, and lets `omega` read off the residue. Note this is stronger than 'odd squared is odd' (1 mod 2): the mod-4 refinement is what makes the parity obstruction below bite.",
+    "mathContext": "$a \\equiv 1 \\pmod 2 \\Rightarrow a^2 = (2k+1)^2 = 4(k^2+k)+1 \\equiv 1 \\pmod 4.$",
+    "significance": "key",
+    "relatedConcepts": ["quadratic residues", "modular arithmetic", "parity"],
+    "prerequisites": ["modular arithmetic", "integer division with remainder"]
+  },
+  {
+    "id": "ann-not-both-odd",
+    "proofId": "pythagorean-triples-oq-07",
+    "range": { "startLine": 46, "endLine": 54 },
+    "type": "insight",
+    "title": "Both Legs Odd is Impossible — for Every Triple",
+    "content": "The genuine content of the entry, and the one statement that needs no coprimality. If both legs were odd, each square is 1 mod 4 (by `sq_emod_four_of_odd`), so $x^2 + y^2 \\equiv 2 \\pmod 4$. But $x^2 + y^2 = z^2$ is a perfect square, and `Int.sq_ne_two_mod_four` says no square is 2 mod 4. The contradiction is handed to `omega`, which reasons about `% 4` over the opaque atoms $x{\\cdot}x$, $y{\\cdot}y$, $z{\\cdot}z$ once their residues and the Pythagorean equation are in context. Crucially this rules out two odd legs for ANY Pythagorean triple — primitivity is irrelevant here.",
+    "mathContext": "$x,y$ odd $\\Rightarrow x^2+y^2 \\equiv 1+1 = 2 \\pmod 4$, yet $z^2 \\not\\equiv 2 \\pmod 4$.",
+    "significance": "key",
+    "relatedConcepts": ["Pythagorean triples", "sum of two squares", "modular obstruction"],
+    "prerequisites": ["modular arithmetic", "Pythagorean triples"]
+  },
+  {
+    "id": "ann-not-both-even",
+    "proofId": "pythagorean-triples-oq-07",
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "context",
+    "title": "Both Legs Even is Impossible — Under Coprimality",
+    "content": "The complementary exclusion, and the only place primitivity enters. If $x$ and $y$ were both even, then $2 \\mid \\gcd(x,y) = 1$, which is absurd. Rather than invoke gcd divisibility directly, the proof leans on Mathlib's `even_odd_of_coprime`: a coprime triple already has one even and one odd leg, so assuming both even contradicts either branch, and `omega` discharges both via the residue mismatch.",
+    "mathContext": "$x,y$ even $\\Rightarrow 2 \\mid \\gcd(x,y)$; but $\\gcd(x,y)=1$, contradiction.",
+    "significance": "supporting",
+    "relatedConcepts": ["coprimality", "greatest common divisor", "primitive triples"],
+    "prerequisites": ["gcd and divisibility", "coprimality"]
+  },
+  {
+    "id": "ann-parity-dichotomy",
+    "proofId": "pythagorean-triples-oq-07",
+    "range": { "startLine": 71, "endLine": 75 },
+    "type": "concept",
+    "title": "The Parity Dichotomy (mod-2 form)",
+    "content": "The headline statement in its most computational form: in a primitive triple, either $x$ is even and $y$ odd, or vice versa. Here it is exactly Mathlib's `even_odd_of_coprime` applied to the coprimality hypothesis — the two exclusions above (both-odd, both-even) are the conceptual justification, while this line packages the positive disjunction directly. It serves as the bridge between the raw obstructions and the cleaner Even/Odd phrasing that follows.",
+    "mathContext": "$(x \\equiv 0 \\wedge y \\equiv 1) \\vee (x \\equiv 1 \\wedge y \\equiv 0) \\pmod 2.$",
+    "significance": "key",
+    "relatedConcepts": ["dichotomy", "parity", "primitive Pythagorean triples"],
+    "prerequisites": ["modular arithmetic", "logical disjunction"]
+  },
+  {
+    "id": "ann-exactly-one-even",
+    "proofId": "pythagorean-triples-oq-07",
+    "range": { "startLine": 77, "endLine": 90 },
+    "type": "definition",
+    "title": "Even/Odd Form and Opposite-Parity Equivalence",
+    "content": "Two readings of the same fact stated in Mathlib's structural `Even`/`Odd` predicates rather than raw residues. `exactly_one_even` translates each branch of the mod-2 disjunction through `Int.even_iff` / `Int.odd_iff` into $(\\text{Even } x \\wedge \\text{Odd } y) \\vee (\\text{Odd } x \\wedge \\text{Even } y)$. `even_iff_not_even` sharpens this to the biconditional $\\text{Even } x \\leftrightarrow \\neg\\,\\text{Even } y$ — the legs never share parity — closed by `simp` once the residues are substituted. The Even/Odd forms are the ones downstream lemmas usually want, since they compose with Mathlib's parity API.",
+    "mathContext": "$(\\text{Even }x \\wedge \\text{Odd }y) \\vee (\\text{Odd }x \\wedge \\text{Even }y)$, equivalently $\\text{Even }x \\leftrightarrow \\neg\\,\\text{Even }y.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Even and Odd predicates", "biconditional", "parity"],
+    "prerequisites": ["parity", "Lean Mathlib parity lemmas"]
+  },
+  {
+    "id": "ann-hypotenuse-odd",
+    "proofId": "pythagorean-triples-oq-07",
+    "range": { "startLine": 97, "endLine": 125 },
+    "type": "insight",
+    "title": "The Hypotenuse is Odd",
+    "content": "The corollary that completes the parity picture. With one even leg ($\\equiv 0 \\pmod 4$) and one odd leg ($\\equiv 1 \\pmod 4$), the equation $x^2 + y^2 = z^2$ forces $z^2 \\equiv 1 \\pmod 4$. An even $z = 2k$ would give $z^2 = 4k^2 \\equiv 0 \\pmod 4$, a contradiction, so $z$ is odd. The proof handles both branches of the dichotomy symmetrically: in each it computes the even leg's square as $\\equiv 0 \\pmod 4$ via the witness $x = k+k$ and the identity $(k+k)^2 = 4k^2$, pairs it with `sq_emod_four_of_odd` on the odd leg, and rules out an even hypotenuse by the same $4k^2$ device. This is the parity that the classical parametrisation $z = m^2 + n^2$ exhibits directly.",
+    "mathContext": "$z^2 = (\\text{even})^2 + (\\text{odd})^2 \\equiv 0 + 1 = 1 \\pmod 4 \\Rightarrow z \\text{ odd}.$",
+    "significance": "key",
+    "relatedConcepts": ["hypotenuse", "Pythagorean parametrisation", "modular arithmetic"],
+    "prerequisites": ["modular arithmetic", "parity", "Pythagorean triples"]
+  }
+]

--- a/src/data/proofs/pythagorean-triples-oq-07/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-07/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ07.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pythagoreanTriplesOq07Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pythagoreanTriplesOq07Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pythagoreanTriplesOq07Data: ProofData = {
+  proof: pythagoreanTriplesOq07Proof,
+  annotations: pythagoreanTriplesOq07Annotations,
+}

--- a/src/data/proofs/pythagorean-triples-oq-07/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-07/meta.json
@@ -65,7 +65,8 @@
       "The 'both odd is impossible' obstruction holds for EVERY Pythagorean triple, not just primitive ones — coprimality is only needed to exclude the both-even case",
       "The whole dichotomy rests on a single residue fact: an odd square is 1 mod 4, so two odd squares sum to 2 mod 4, which Int.sq_ne_two_mod_four rules out as a square",
       "omega closes the modular contradictions once the squares are rewritten in the form 4·(…)+r: it reasons about % with a literal modulus over the atoms x·x, y·y, z·z",
-      "The hypotenuse is forced odd: with one even leg (≡0 mod 4) and one odd leg (≡1 mod 4), z² ≡ 1 mod 4, and an even z would give z² ≡ 0 mod 4"
+      "The hypotenuse is forced odd: with one even leg (≡0 mod 4) and one odd leg (≡1 mod 4), z² ≡ 1 mod 4, and an even z would give z² ≡ 0 mod 4",
+      "The two exclusions are asymmetric in strength: both-odd is a universal arithmetic obstruction (mod 4), while both-even is a structural consequence of primitivity (gcd) — only the latter uses the coprimality hypothesis"
     ],
     "prerequisites": [
       "Modular arithmetic (residues mod 4)",


### PR DESCRIPTION
Enrichment pass for `pythagorean-triples-oq-07` (Parity Dichotomy: exactly one leg of a primitive Pythagorean triple is even).

## Changes
- **Created `index.ts`** — the directory had only `meta.json`, so the proof page rendered 'proof not found' on the live site. The Vite entry point is now present and the page loads.
- **Created `annotations.json`** — 6 substantive annotations covering all five proof parts (mod-4 obstruction, both-odd impossible, both-even impossible, the dichotomy + Even/Odd forms, hypotenuse odd), each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.
- **meta.json** — added a 5th `keyInsight` on the asymmetric strength of the two exclusions (universal mod-4 obstruction vs. structural coprimality argument).

## Verification
- `pnpm build` passes (data enrichment + tsc + vite).
- JSON validated for both files.
- Annotation line ranges checked against `PythagoreanTriplesOQ07.lean`; axiom/status fields (`verified`, 0 axioms, badge `mathlib`) confirmed accurate against the Lean source.