### PR TITLE
research(erdos-105-oq-01-oq-01): avoidability set is a sharp threshold, pinning the open n-4 boundary

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1183,6 +1183,8 @@ import Proofs.Erdos1059OQ03
 import Proofs.Erdos1059OQ04
 import Proofs.Erdos1059OQ05
 import Proofs.Erdos1059Problem
+import Proofs.Erdos105OQ01
+import Proofs.Erdos105OQ01OQ01
 import Proofs.Erdos105OQ02
 import Proofs.Erdos105OQ05
 import Proofs.Erdos105Problem

--- a/proofs/Proofs/Erdos105OQ01.lean
+++ b/proofs/Proofs/Erdos105OQ01.lean
@@ -95,10 +95,10 @@ theorem blocked_monotone {A B B' : Set Point} (hsub : B ⊆ B')
 /-- The plane `ℝ²` is infinite: the map `t ↦ (t, 0)` (via `EuclideanSpace.single`)
     is an injection from `ℝ`. -/
 instance : Infinite Point :=
-  Infinite.of_injective (fun a : ℝ => EuclideanSpace.single (0 : Fin 2) a) (by
-    intro a b h
+  Infinite.of_injective (fun a : ℝ => EuclideanSpace.single (0 : Fin 2) a) (fun a b h => by
+    have hb : EuclideanSpace.single (0 : Fin 2) a = EuclideanSpace.single (0 : Fin 2) b := h
     have h0 : (EuclideanSpace.single (0 : Fin 2) a) 0
-            = (EuclideanSpace.single (0 : Fin 2) b) 0 := by rw [h]
+            = (EuclideanSpace.single (0 : Fin 2) b) 0 := by rw [hb]
     simpa [EuclideanSpace.single_apply] using h0)
 
 /-- **Padding lemma.** Any finite obstacle set `B` disjoint from `A` can be enlarged

--- a/proofs/Proofs/Erdos105OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos105OQ01OQ01.lean
@@ -1,0 +1,182 @@
+/-
+  Erdős Problem #105, Open Question 01 → 01:
+  The avoidability set is a genuine threshold — `f(n)` is sharp, and the open
+  `n-4` question is exactly `f(n) ≥ n-4`.
+
+  **Background.** For a non-collinear `n`-point set `A` and an obstacle set `B`,
+  call `B` *avoidable* if some rich line of `A` (a line through ≥2 points of `A`)
+  misses all of `B`. The parent `Erdos105OQ01.lean` showed avoidability is
+  *antitone* in `B` and, conditional on the open hypothesis `openProblem_n_minus_4`,
+  derived a lower bound `f(n) ≥ n-4` — but only under an *ad hoc* extra hypothesis
+  that the avoidability set is bounded above, and without showing `f` is a true
+  threshold (that the set of always-avoidable counts is an initial segment).
+
+  **What this entry contributes** (all *axiom-free*; the parent's `xichuan_counterexample`
+  and `beck_szemeredi_trotter_positive` axioms are NOT used):
+
+  1. `avoidSet n` — the set of obstacle counts `m` that are *always* avoidable for
+     `|A| = n`. By construction `thresholdFunction n = sSup (avoidSet n)`
+     (`thresholdFunction_eq_sSup`).
+
+  2. `avoidSet_downwardClosed` — `avoidSet n` is an initial segment of `ℕ`: if `m` is
+     always avoidable then so is every `m' ≤ m`. (Immediate from the `≤` in the
+     definition — no padding needed.) And `zero_mem_avoidSet`: `0 ∈ avoidSet n` for
+     `n ≥ 3`, since an empty obstacle set is avoided by any rich line, which exists
+     by `many_rich_lines_exist`. So `avoidSet n` is always *nonempty*.
+
+  3. `mem_avoidSet_iff_le_threshold` / `avoidSet_eq_Iic` — **`f` is a sharp threshold.**
+     Whenever `avoidSet n` is bounded above, `m ∈ avoidSet n ↔ m ≤ f(n)`, i.e.
+     `avoidSet n = Set.Iic (f n)` exactly. (The sup of a nonempty bounded set of
+     naturals is attained, so `f(n)` itself is always avoidable, and downward-closure
+     fills in everything below.) This *justifies calling `f` a threshold function* —
+     avoidable for every `m ≤ f(n)`, blocked for some configuration at every
+     `m > f(n)`.
+
+  4. `openProblem_iff_mem` / `openProblem_iff_threshold_ge` — **the open boundary,
+     pinned.** `openProblem_n_minus_4` is logically *equivalent* to
+     `∀ n ≥ 5, (n-4) ∈ avoidSet n`, and (when each `avoidSet n` is bounded above)
+     to `∀ n ≥ 5, f(n) ≥ n-4`. Combined with the known upper bound `f(n) ≤ n-4`
+     (Xichuan), the open question is *exactly* `f(n) = n-4`.
+
+  **Status**: the structural results are axiom-free and self-contained over the parent
+  definitions. The boundedness hypothesis `BddAbove (avoidSet n)` is stated honestly as
+  a hypothesis (it is open question 02 whether it holds for every `n`), NOT assumed as
+  an axiom. Sorry count: 0. Axiom count: 0.
+
+  Reference: https://erdosproblems.com/105
+-/
+
+import Proofs.Erdos105OQ01
+import Mathlib
+
+open Erdos105 Erdos105OQ01
+
+namespace Erdos105OQ01OQ01
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION I: The avoidability set and the threshold function
+-- ════════════════════════════════════════════════════════════════
+
+/-- **The avoidability set at size `n`.** The obstacle counts `m` such that *every*
+    non-collinear `A` with `|A| = n` admits a rich line avoiding *every* disjoint
+    obstacle set `B` with `|B| ≤ m`. This is precisely the set whose supremum defines
+    the parent's `thresholdFunction n`. -/
+def avoidSet (n : ℕ) : Set ℕ :=
+  {m | ∀ (A B : Finset Point), A.card = n → B.card ≤ m → Disjoint A B →
+    NonCollinear (A : Set Point) →
+    ∃ L : Line, L.richAndUnblocked (A : Set Point) (B : Set Point)}
+
+/-- The threshold function is, by definition, the supremum of the avoidability set. -/
+theorem thresholdFunction_eq_sSup (n : ℕ) : thresholdFunction n = sSup (avoidSet n) := rfl
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION II: The avoidability set is a nonempty initial segment
+-- ════════════════════════════════════════════════════════════════
+
+/-- **`avoidSet n` is downward closed** (an initial segment of `ℕ`): if `m` obstacles
+    are always avoidable, so are any `m' ≤ m`. Immediate, since a configuration with
+    `|B| ≤ m'` also has `|B| ≤ m`. -/
+theorem avoidSet_downwardClosed {n m m' : ℕ} (hmm : m' ≤ m) (hm : m ∈ avoidSet n) :
+    m' ∈ avoidSet n :=
+  fun A B hA hB hdisj hncoll => hm A B hA (hB.trans hmm) hdisj hncoll
+
+/-- **`0 ∈ avoidSet n` for `n ≥ 3`.** An empty obstacle set is avoided by *any* rich
+    line, and a non-collinear set of `≥ 3` points has one (`many_rich_lines_exist`).
+    Hence `avoidSet n` is always nonempty in the interesting regime. -/
+theorem zero_mem_avoidSet {n : ℕ} (hn : 3 ≤ n) : 0 ∈ avoidSet n := by
+  intro A B hA hB hdisj hncoll
+  obtain ⟨k, hk, S, hScard, hrich⟩ := many_rich_lines_exist A hncoll (hA ▸ hn)
+  have hSne : S.Nonempty := Finset.card_pos.mp (by rw [hScard]; omega)
+  obtain ⟨L, hLmem⟩ := hSne
+  have hBe : B = ∅ := Finset.card_eq_zero.mp (Nat.le_zero.mp hB)
+  exact ⟨L, hrich L hLmem, fun b hb => by rw [hBe] at hb; simp at hb⟩
+
+/-- `avoidSet n` is nonempty for `n ≥ 3`. -/
+theorem avoidSet_nonempty {n : ℕ} (hn : 3 ≤ n) : (avoidSet n).Nonempty :=
+  ⟨0, zero_mem_avoidSet hn⟩
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION III: `f` is a sharp threshold (under boundedness)
+-- ════════════════════════════════════════════════════════════════
+
+/-- **The threshold value is itself always avoidable.** The supremum of a nonempty
+    bounded-above set of naturals is attained, so `f(n) ∈ avoidSet n`. -/
+theorem threshold_mem_avoidSet {n : ℕ} (hn : 3 ≤ n) (hbdd : BddAbove (avoidSet n)) :
+    thresholdFunction n ∈ avoidSet n :=
+  Nat.sSup_mem (avoidSet_nonempty hn) hbdd
+
+/-- **`f` is a sharp threshold.** Under boundedness, an obstacle count is always
+    avoidable *iff* it is at most `f(n)`. -/
+theorem mem_avoidSet_iff_le_threshold {n m : ℕ} (hn : 3 ≤ n) (hbdd : BddAbove (avoidSet n)) :
+    m ∈ avoidSet n ↔ m ≤ thresholdFunction n := by
+  constructor
+  · intro hm
+    exact le_csSup hbdd hm
+  · intro hm
+    exact avoidSet_downwardClosed hm (threshold_mem_avoidSet hn hbdd)
+
+/-- **The avoidability set is exactly the initial segment `[0, f(n)]`.** -/
+theorem avoidSet_eq_Iic {n : ℕ} (hn : 3 ≤ n) (hbdd : BddAbove (avoidSet n)) :
+    avoidSet n = Set.Iic (thresholdFunction n) :=
+  Set.ext fun _ => mem_avoidSet_iff_le_threshold hn hbdd
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION IV: The open `n-4` question, pinned to `f(n) ≥ n-4`
+-- ════════════════════════════════════════════════════════════════
+
+/-- The forward bridge: a positive answer to the open `n-4` question puts `n-4` in the
+    avoidability set, for every `n ≥ 5` (the parent's `n_minus_4_avoidable_set`). -/
+theorem n_minus_4_mem_avoidSet (h : openProblem_n_minus_4) {n : ℕ} (hn : 5 ≤ n) :
+    (n - 4) ∈ avoidSet n :=
+  n_minus_4_avoidable_set h n hn
+
+/-- The reverse bridge: if `n-4` is always avoidable for every `n ≥ 5`, then the open
+    `n-4` question holds (specialise from `|B| ≤ n-4` to `|B| = n-4`). -/
+theorem openProblem_of_mem (h : ∀ n, 5 ≤ n → (n - 4) ∈ avoidSet n) :
+    openProblem_n_minus_4 :=
+  fun A B n hn hA hB hdisj hncoll => h n hn A B hA (le_of_eq hB) hdisj hncoll
+
+/-- **The open `n-4` question is exactly membership of `n-4` in every avoidability set.** -/
+theorem openProblem_iff_mem :
+    openProblem_n_minus_4 ↔ ∀ n, 5 ≤ n → (n - 4) ∈ avoidSet n :=
+  ⟨fun h n hn => n_minus_4_mem_avoidSet h hn, openProblem_of_mem⟩
+
+/-- **The open `n-4` question is exactly the sharp lower bound `f(n) ≥ n-4`.**
+    Under boundedness of each avoidability set, `openProblem_n_minus_4` holds iff
+    `f(n) ≥ n-4` for all `n ≥ 5`. With the known upper bound `f(n) ≤ n-4`, this pins
+    the open question to `f(n) = n-4`. -/
+theorem openProblem_iff_threshold_ge
+    (hbdd : ∀ n, 5 ≤ n → BddAbove (avoidSet n)) :
+    openProblem_n_minus_4 ↔ ∀ n, 5 ≤ n → n - 4 ≤ thresholdFunction n := by
+  rw [openProblem_iff_mem]
+  constructor
+  · intro h n hn
+    exact (mem_avoidSet_iff_le_threshold (by omega) (hbdd n hn)).1 (h n hn)
+  · intro h n hn
+    exact (mem_avoidSet_iff_le_threshold (by omega) (hbdd n hn)).2 (h n hn)
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION V: Summary
+-- ════════════════════════════════════════════════════════════════
+
+/--
+**Summary of Erdős #105, OQ-01 → 01.**
+
+The avoidability set `avoidSet n` is a nonempty initial segment of `ℕ`
+(`zero_mem_avoidSet`, `avoidSet_downwardClosed`), and whenever it is bounded above it
+equals `Set.Iic (f n)` exactly (`avoidSet_eq_Iic`) — so `f = thresholdFunction` is a
+*genuine sharp threshold*: every count `≤ f(n)` is always avoidable. The single open
+boundary `openProblem_n_minus_4` is then logically equivalent to `f(n) ≥ n-4` for all
+`n ≥ 5` (`openProblem_iff_threshold_ge`), which together with the known `f(n) ≤ n-4`
+pins the open question to `f(n) = n-4`. All results are axiom-free. -/
+theorem erdos_105_oq01oq01_summary :
+    (∀ n, 3 ≤ n → (avoidSet n).Nonempty) ∧
+    (∀ n m m', m' ≤ m → m ∈ avoidSet n → m' ∈ avoidSet n) ∧
+    (∀ n, 3 ≤ n → BddAbove (avoidSet n) → avoidSet n = Set.Iic (thresholdFunction n)) ∧
+    (openProblem_n_minus_4 ↔ ∀ n, 5 ≤ n → (n - 4) ∈ avoidSet n) :=
+  ⟨fun n hn => avoidSet_nonempty hn,
+   fun _ _ _ hmm hm => avoidSet_downwardClosed hmm hm,
+   fun _ hn hbdd => avoidSet_eq_Iic hn hbdd,
+   openProblem_iff_mem⟩
+
+end Erdos105OQ01OQ01

--- a/proofs/Proofs/Erdos105Problem.lean
+++ b/proofs/Proofs/Erdos105Problem.lean
@@ -34,7 +34,7 @@ Tags: discrete-geometry, incidence-geometry, counterexample, disproved
 -/
 
 import Mathlib.Analysis.InnerProductSpace.PiL2
-import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace
+import Mathlib.LinearAlgebra.AffineSpace.AffineSubspace.Basic
 import Mathlib.Data.Finset.Card
 import Mathlib.Tactic
 
@@ -117,7 +117,7 @@ theorem erdos_105_disproved : ¬ErdosPurdyConjecture := by
 
 /- ## Part IV: Related Results -/
 
-/-- **Hickerson's Construction:**
+/- **Hickerson's Construction:**
     The conjecture already fails with n-2 obstacles.
     This shows n-3 is the "critical" case (if the conjecture were true). -/
 /-- **Beck-Szemerédi-Trotter Positive Result:**
@@ -132,12 +132,13 @@ axiom beck_szemeredi_trotter_positive :
 
 /- ## Part V: The Szemerédi-Trotter Theorem -/
 
+open scoped Classical in
 /-- The number of point-line incidences.
     I(P, L) = |{(p, ℓ) : p ∈ P, ℓ ∈ L, p ∈ ℓ}|. -/
 noncomputable def incidenceCount (P : Finset Point) (L : Finset Line) : ℕ :=
   (P ×ˢ L).filter (fun (p, ℓ) => ℓ.contains p) |>.card
 
-/-- **Szemerédi-Trotter Theorem (1983):**
+/- **Szemerédi-Trotter Theorem (1983):**
     For n points and m lines in ℝ², the number of incidences is
     O(n^(2/3) m^(2/3) + n + m).
 
@@ -158,7 +159,7 @@ theorem many_rich_lines_exist (A : Finset Point) (hncoll : NonCollinear (A : Set
   have hp_on : L.contains p := ⟨0, by simp [L, Line.contains, zero_smul, add_zero]⟩
   have hq_on : L.contains q := ⟨1, by simp [L, Line.contains, one_smul, add_sub_cancel]⟩
   have hrich : L.isRich (A : Set Point) :=
-    ⟨p, q, Finset.mem_coe.mpr hp, Finset.mem_coe.mpr hq, Ne.symm hpq, hp_on, hq_on⟩
+    ⟨p, q, Finset.mem_coe.mpr hp, Finset.mem_coe.mpr hq, hpq, hp_on, hq_on⟩
   exact ⟨1, le_refl 1, {L}, Finset.card_singleton L, fun L' hL' => by
     rw [Finset.mem_singleton.mp hL']; exact hrich⟩
 
@@ -183,8 +184,8 @@ noncomputable def thresholdFunction (n : ℕ) : ℕ :=
     NonCollinear (A : Set Point) →
     ∃ L : Line, L.richAndUnblocked (A : Set Point) (B : Set Point)}
 
-/-- **Lower bound:** f(n) ≥ c·n for some c > 0. -/
-/-- **Upper bound:** f(n) ≤ n - 4 (from Xichuan's counterexample). -/
+/- **Lower bound:** f(n) ≥ c·n for some c > 0. -/
+/- **Upper bound:** f(n) ≤ n - 4 (from Xichuan's counterexample). -/
 /- ## Part VII: Open Problems -/
 
 /-- **Open Problem 1:** Does the conjecture hold with n-4 obstacles? -/

--- a/src/data/proofs/erdos-105-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/erdos-105-oq-01-oq-01/annotations.json
@@ -1,0 +1,112 @@
+[
+  {
+    "id": "ann-erdos105oq01oq01-header",
+    "proofId": "erdos-105-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 54
+    },
+    "type": "concept",
+    "title": "The Avoidability Set as a Threshold Object",
+    "content": "Erdős Problem #105's only open boundary is whether every obstacle set of size n-4 is avoidable by a rich line (the parent's openProblem_n_minus_4). The parent oq-01 defined the threshold f(n) as a supremum and exposed the monotone structure. This entry promotes the underlying set to a first-class object — avoidSet(n), the obstacle counts that are ALWAYS avoidable at size n — and studies it order-theoretically, turning vague talk of 'the threshold' into precise statements: a sharp initial-segment characterization and an exact restatement of the open question.",
+    "mathContext": "$\\textsf{avoidSet}(n)=\\{m:\\forall A,B,\\ |A|=n,|B|\\le m,A\\cap B=\\varnothing,A\\text{ non-collinear}\\Rightarrow\\exists\\text{ rich line avoiding }B\\}$, with $f(n)=\\sup\\textsf{avoidSet}(n)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "threshold function",
+      "avoidability set",
+      "initial segment",
+      "rich lines",
+      "Erdős-Purdy conjecture"
+    ]
+  },
+  {
+    "id": "ann-erdos105oq01oq01-defn",
+    "proofId": "erdos-105-oq-01-oq-01",
+    "range": {
+      "startLine": 56,
+      "endLine": 70
+    },
+    "type": "definition",
+    "title": "avoidSet and thresholdFunction = sSup avoidSet",
+    "content": "avoidSet n is defined exactly as the predicate inside the parent's thresholdFunction supremum, so that thresholdFunction n = sSup (avoidSet n) holds definitionally (thresholdFunction_eq_sSup, proved by rfl). This is the hinge: every later result is an order-theoretic fact about avoidSet n combined with sSup.",
+    "mathContext": "$f(n) = \\sup\\,\\textsf{avoidSet}(n)$ by definition, so reasoning about $f$ becomes reasoning about $\\textsf{avoidSet}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "supremum",
+      "definitional equality"
+    ]
+  },
+  {
+    "id": "ann-erdos105oq01oq01-initial-segment",
+    "proofId": "erdos-105-oq-01-oq-01",
+    "range": {
+      "startLine": 72,
+      "endLine": 96
+    },
+    "type": "technique",
+    "title": "A Nonempty Initial Segment, For Free",
+    "content": "Downward closure (avoidSet_downwardClosed) needs no construction: the definition quantifies over |B| ≤ m, so any witness for m is automatically a witness for every m' ≤ m. Nonemptiness (zero_mem_avoidSet, avoidSet_nonempty) holds because for n ≥ 3 a rich line exists (many_rich_lines_exist) and trivially avoids the empty obstacle set. Both are axiom-free.",
+    "mathContext": "$m\\in\\textsf{avoidSet}(n),\\,m'\\le m\\Rightarrow m'\\in\\textsf{avoidSet}(n)$; and $0\\in\\textsf{avoidSet}(n)$ for $n\\ge 3$.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "downward closed",
+      "initial segment",
+      "monotonicity"
+    ]
+  },
+  {
+    "id": "ann-erdos105oq01oq01-sharp",
+    "proofId": "erdos-105-oq-01-oq-01",
+    "range": {
+      "startLine": 98,
+      "endLine": 121
+    },
+    "type": "key-step",
+    "title": "f is a Sharp Threshold: avoidSet n = Set.Iic (f n)",
+    "content": "When avoidSet n is bounded above, the supremum of a nonempty bounded set of naturals is attained (Nat.sSup_mem), so the threshold value f(n) is itself always avoidable (threshold_mem_avoidSet). Combined with downward closure this gives m ∈ avoidSet n ↔ m ≤ f(n) (mem_avoidSet_iff_le_threshold), i.e. avoidSet n = Set.Iic (f n) exactly (avoidSet_eq_Iic). This is what justifies calling f a genuine sharp threshold. Axiom-free; boundedness is an explicit hypothesis.",
+    "mathContext": "$\\textsf{avoidSet}(n) = [0, f(n)] = \\textsf{Set.Iic}(f(n))$ whenever $\\textsf{avoidSet}(n)$ is bounded above.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "supremum attained",
+      "Nat.sSup_mem",
+      "sharp threshold",
+      "Set.Iic"
+    ]
+  },
+  {
+    "id": "ann-erdos105oq01oq01-open-boundary",
+    "proofId": "erdos-105-oq-01-oq-01",
+    "range": {
+      "startLine": 123,
+      "endLine": 156
+    },
+    "type": "key-step",
+    "title": "The Open n-4 Question, Pinned to f(n) = n-4",
+    "content": "The open question is bridged to set membership: openProblem_n_minus_4 ↔ ∀ n ≥ 5, (n-4) ∈ avoidSet n (openProblem_iff_mem) — forward via the parent's n_minus_4_avoidable_set, reverse by specialising |B| ≤ n-4 to |B| = n-4. Under boundedness this becomes openProblem_n_minus_4 ↔ ∀ n ≥ 5, f(n) ≥ n-4 (openProblem_iff_threshold_ge). With the known upper bound f(n) ≤ n-4, the entire open problem reduces to the single equation f(n) = n-4. Axiom-free.",
+    "mathContext": "$\\textsf{openProblem\\_n\\_minus\\_4}\\iff\\forall n\\ge5,(n-4)\\in\\textsf{avoidSet}(n)\\iff\\forall n\\ge5,f(n)\\ge n-4$.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "logical equivalence",
+      "sharp boundary",
+      "open question"
+    ]
+  },
+  {
+    "id": "ann-erdos105oq01oq01-summary",
+    "proofId": "erdos-105-oq-01-oq-01",
+    "range": {
+      "startLine": 158,
+      "endLine": 182
+    },
+    "type": "concept",
+    "title": "Summary: Threshold Structure of the Open Boundary",
+    "content": "erdos_105_oq01oq01_summary packages the four pillars — nonemptiness, downward closure, the Set.Iic characterization under boundedness, and the open-boundary equivalence — into one axiom-free statement, recording that the avoidability set is a nonempty initial segment equal to [0, f(n)] and that the open question is exactly membership of n-4.",
+    "mathContext": "All four structural facts hold simultaneously and axiom-free over the parent's definitions.",
+    "significance": "standard",
+    "relatedConcepts": [
+      "summary",
+      "threshold function",
+      "axiom-free"
+    ]
+  }
+]

--- a/src/data/proofs/erdos-105-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-105-oq-01-oq-01/meta.json
@@ -1,0 +1,165 @@
+{
+  "id": "erdos-105-oq-01-oq-01",
+  "title": "The Avoidability Set is a Sharp Threshold: Pinning Erdős #105's Open n-4 Boundary",
+  "slug": "erdos-105-oq-01-oq-01",
+  "description": "Recasts the open boundary of Erdős Problem #105 as a threshold phenomenon. Introduces the avoidability set avoidSet(n) — the obstacle counts m that are always avoidable for |A| = n — and proves it is a nonempty initial segment of ℕ (downward closed, with 0 always avoidable for n ≥ 3). Whenever it is bounded above it equals Set.Iic(f n) exactly, so the parent's thresholdFunction f is a genuine SHARP threshold: every count ≤ f(n) is always avoidable. The single open boundary openProblem_n_minus_4 is then shown logically equivalent to (n-4) ∈ avoidSet(n) for all n ≥ 5, and (under boundedness) to f(n) ≥ n-4 — which with the known upper bound f(n) ≤ n-4 pins the open question to exactly f(n) = n-4. All results are axiom-free and self-contained over the parent's definitions; the boundedness hypothesis is stated honestly as a hypothesis, not assumed. 0 sorries, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius Researcher",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos105OQ01OQ01.lean",
+    "tags": [
+      "discrete-geometry",
+      "incidence-geometry",
+      "threshold-function",
+      "order-theory",
+      "extremal-combinatorics",
+      "erdos",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 182,
+    "assumptions": "None. All theorems are axiom-free over the parent definitions: the parent's inherited xichuan_counterexample and beck_szemeredi_trotter_positive axioms are NOT used. The boundedness condition BddAbove (avoidSet n) appears only as an explicit, named hypothesis on the threshold-characterization theorems (it is itself the subject of open question 02), never as a global assumption.",
+    "dateAdded": "2026-06-24",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "avoidSet n: the set of obstacle counts that are always avoidable at size n, defined so that thresholdFunction n = sSup (avoidSet n) holds definitionally (thresholdFunction_eq_sSup)",
+      "avoidSet_downwardClosed: avoidSet n is an initial segment of ℕ — if m obstacles are always avoidable, so are any m' ≤ m (immediate, no padding needed)",
+      "zero_mem_avoidSet / avoidSet_nonempty: 0 ∈ avoidSet n for n ≥ 3 via many_rich_lines_exist, so the avoidability set is always nonempty in the interesting regime",
+      "threshold_mem_avoidSet: under boundedness the supremum is attained, so f(n) itself is always avoidable (Nat.sSup_mem)",
+      "mem_avoidSet_iff_le_threshold / avoidSet_eq_Iic: f is a SHARP threshold — m ∈ avoidSet n ↔ m ≤ f(n), i.e. avoidSet n = Set.Iic (f n) exactly",
+      "openProblem_iff_mem: openProblem_n_minus_4 ↔ ∀ n ≥ 5, (n-4) ∈ avoidSet n (a clean logical equivalence pinning the open question to set membership)",
+      "openProblem_iff_threshold_ge: under boundedness, openProblem_n_minus_4 ↔ ∀ n ≥ 5, f(n) ≥ n-4 — combined with the known f(n) ≤ n-4 this pins the open question to exactly f(n) = n-4",
+      "erdos_105_oq01oq01_summary: packages nonemptiness, downward-closure, the Iic characterization, and the open-boundary equivalence as a single axiom-free statement"
+    ],
+    "theoremCount": 12,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #105 asks whether, for n non-collinear points A and an obstacle set B, some rich line of A (through ≥2 points of A) must avoid all of B. The Erdős-Purdy n-3 version was disproved by Xichuan (2024); Hickerson earlier showed failure at n-2; Beck and Szemerédi-Trotter (1983) proved avoidability for ≤ cn obstacles. Thus the threshold f(n) = largest always-avoidable obstacle count satisfies cn ≤ f(n) ≤ n-4, and the single remaining boundary is |B| = n-4. The parent oq-01 exposed the monotone structure (avoidability antitone, blocking monotone) and derived a conditional f(n) ≥ n-4 under an ad hoc boundedness side-condition, but did not establish that f is a genuine threshold (that the always-avoidable counts form an initial segment).",
+    "problemStatement": "Is the parent's thresholdFunction f actually a sharp threshold, and what is the precise logical content of the open n-4 question in terms of f? Concretely: is the set of always-avoidable obstacle counts an initial segment [0, f(n)], and is openProblem_n_minus_4 equivalent to f(n) ≥ n-4?",
+    "proofStrategy": "Make the threshold structure explicit. (1) Define avoidSet n as the obstacle counts that are always avoidable, so that the parent's f(n) = sSup (avoidSet n) by definition. (2) Observe downward closure is immediate (a smaller obstacle bound is weaker) and that 0 is always avoidable for n ≥ 3 (any rich line avoids the empty set), so avoidSet n is a nonempty initial segment. (3) When avoidSet n is bounded above, the supremum of a nonempty bounded set of naturals is attained, so f(n) ∈ avoidSet n; combined with downward closure this gives avoidSet n = Set.Iic (f n) exactly — a sharp threshold. (4) Bridge to the open question: a positive answer at n-4 puts n-4 in every avoidSet n (parent's n_minus_4_avoidable_set), and conversely membership for all n ≥ 5 recovers the open statement, giving the equivalence openProblem_n_minus_4 ↔ ∀ n ≥ 5, (n-4) ∈ avoidSet n, and under boundedness ↔ f(n) ≥ n-4. With f(n) ≤ n-4 this pins the open question to f(n) = n-4.",
+    "keyInsights": [
+      "The parent already defines f(n) as a supremum sSup (avoidSet n); making avoidSet a first-class object turns vague talk of 'the threshold' into a precise order-theoretic statement and lets thresholdFunction_eq_sSup hold by rfl.",
+      "Downward closure needs no construction at all: the definition quantifies over |B| ≤ m, so a witness for m is automatically a witness for every m' ≤ m. The avoidability set is an initial segment for free.",
+      "Sharpness — avoidSet n = Set.Iic (f n) — hinges only on Nat.sSup_mem: the supremum of a nonempty bounded set of naturals is attained, so the threshold value f(n) is itself always avoidable. Everything below follows by downward closure.",
+      "The open n-4 question is exactly a statement about f: openProblem_n_minus_4 ↔ f(n) ≥ n-4 (under boundedness). Since the upper bound f(n) ≤ n-4 is known, the whole open problem reduces to deciding the single equation f(n) = n-4.",
+      "The boundedness hypothesis BddAbove (avoidSet n) is kept as an explicit named hypothesis (it is open question 02 whether it always holds), so no result here is contaminated by an unproved assumption — the characterization is honest and axiom-free."
+    ],
+    "prerequisites": [
+      "Parent Erdos105OQ01.lean: thresholdFunction, openProblem_n_minus_4, n_minus_4_avoidable_set, and the antitone/monotone monotonicity skeleton",
+      "Grandparent Erdos105Problem.lean: Line, richAndUnblocked, NonCollinear, Point, many_rich_lines_exist",
+      "Order theory on ℕ: le_csSup, Nat.sSup_mem, Set.Iic and Set.ext",
+      "Finset cardinality basics (card_pos, card_eq_zero)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "avoidset",
+      "title": "§I: The Avoidability Set and the Threshold Function",
+      "startLine": 56,
+      "endLine": 70,
+      "summary": "Defines avoidSet n (always-avoidable obstacle counts) and proves thresholdFunction n = sSup (avoidSet n) holds definitionally.",
+      "mathContext": "$\\textsf{avoidSet}(n) = \\{m : \\forall A,B,\\ |A|=n,\\ |B| \\le m,\\ A \\cap B = \\varnothing,\\ A\\text{ non-collinear} \\Rightarrow \\exists\\text{ rich line avoiding }B\\}$, and $f(n) = \\sup \\textsf{avoidSet}(n)$."
+    },
+    {
+      "id": "initial-segment",
+      "title": "§II: A Nonempty Initial Segment",
+      "startLine": 72,
+      "endLine": 96,
+      "summary": "avoidSet n is downward closed (an initial segment of ℕ) and contains 0 for n ≥ 3, hence is nonempty. Axiom-free.",
+      "mathContext": "$m \\in \\textsf{avoidSet}(n),\\ m' \\le m \\Rightarrow m' \\in \\textsf{avoidSet}(n)$; and $0 \\in \\textsf{avoidSet}(n)$ for $n \\ge 3$ since a rich line exists and avoids $\\varnothing$."
+    },
+    {
+      "id": "sharp-threshold",
+      "title": "§III: f is a Sharp Threshold (under boundedness)",
+      "startLine": 98,
+      "endLine": 121,
+      "summary": "When avoidSet n is bounded above, the supremum is attained, so m ∈ avoidSet n ↔ m ≤ f(n), i.e. avoidSet n = Set.Iic (f n) exactly. Axiom-free.",
+      "mathContext": "$f(n) \\in \\textsf{avoidSet}(n)$ by $\\textsf{Nat.sSup\\_mem}$, so $\\textsf{avoidSet}(n) = [0, f(n)] = \\textsf{Set.Iic}(f(n))$."
+    },
+    {
+      "id": "open-boundary",
+      "title": "§IV: The Open n-4 Question, Pinned to f(n) ≥ n-4",
+      "startLine": 123,
+      "endLine": 156,
+      "summary": "openProblem_n_minus_4 ↔ ∀ n ≥ 5, (n-4) ∈ avoidSet n, and under boundedness ↔ ∀ n ≥ 5, f(n) ≥ n-4; with f(n) ≤ n-4 this pins f(n) = n-4. Axiom-free.",
+      "mathContext": "$\\textsf{openProblem\\_n\\_minus\\_4} \\iff \\forall n \\ge 5,\\ (n-4) \\in \\textsf{avoidSet}(n) \\iff \\forall n \\ge 5,\\ f(n) \\ge n-4$."
+    },
+    {
+      "id": "summary",
+      "title": "§V: Summary",
+      "startLine": 158,
+      "endLine": 182,
+      "summary": "Packages nonemptiness, downward closure, the Iic characterization, and the open-boundary equivalence into a single axiom-free statement.",
+      "mathContext": "The avoidability set is a nonempty initial segment equal to $[0, f(n)]$ when bounded, and the open boundary is exactly $(n-4) \\in \\textsf{avoidSet}(n)$."
+    }
+  ],
+  "conclusion": {
+    "summary": "By making the avoidability set avoidSet(n) a first-class object, the open boundary of Erdős #105 becomes a clean threshold statement. avoidSet(n) is a nonempty initial segment of ℕ, and whenever it is bounded above it equals Set.Iic(f n) exactly — so the parent's thresholdFunction f is a genuine sharp threshold: every obstacle count ≤ f(n) is always avoidable, and the value f(n) itself is attained. The single open question openProblem_n_minus_4 is logically equivalent to (n-4) ∈ avoidSet(n) for all n ≥ 5, and under boundedness to f(n) ≥ n-4; together with the known upper bound f(n) ≤ n-4 this pins the entire open problem to the single equation f(n) = n-4. All results are axiom-free and self-contained over the parent's definitions; the boundedness hypothesis is carried explicitly rather than assumed. 0 sorries, 0 axioms.",
+    "openQuestions": [
+      "Is avoidSet n bounded above for every n (open question 02)? A positive answer makes the sharp-threshold characterization avoidSet n = Set.Iic (f n) unconditional.",
+      "Does the open equation f(n) = n-4 hold — equivalently, is every obstacle set of size n-4 avoidable by some rich line?"
+    ],
+    "implications": "The entry shows the parent's f is not merely a defined supremum but a genuine sharp threshold, and reduces the whole remaining open region of Erdős #105 to deciding f(n) = n-4. By phrasing the open question as membership of n-4 in an initial segment, it gives a crisp order-theoretic target for future work and isolates the boundedness side-condition (oq-02) as the only obstruction to an unconditional threshold statement."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-105-oq-01",
+      "relationship": "parent-problem",
+      "description": "Monotonicity localizes the open n-4 boundary — supplies thresholdFunction, openProblem_n_minus_4, and n_minus_4_avoidable_set"
+    },
+    {
+      "targetId": "erdos-105",
+      "relationship": "ancestor-problem",
+      "description": "Erdős Problem #105 (disproved n-3 version) — Line, richAndUnblocked, NonCollinear, many_rich_lines_exist"
+    },
+    {
+      "targetId": "erdos-105-oq-02",
+      "relationship": "sibling-question",
+      "description": "Threshold f(n) = Θ(n); the boundedness condition needed here is the subject of that line of inquiry"
+    }
+  ],
+  "references": [
+    {
+      "author": "Erdős, P. and Purdy, G.",
+      "title": "Extremal problems in combinatorial geometry",
+      "year": 1995,
+      "note": "Conjectured the n-3 version (later disproved)"
+    },
+    {
+      "author": "Beck, J.",
+      "title": "On the lattice property of the plane and some problems of Dirac, Motzkin and Erdős in combinatorial geometry",
+      "year": 1983,
+      "note": "Lower bound f(n) ≥ cn"
+    },
+    {
+      "author": "Szemerédi, E. and Trotter, W.T.",
+      "title": "Extremal problems in discrete geometry",
+      "year": 1983,
+      "note": "Incidence bound; independently gives f(n) ≥ cn"
+    },
+    {
+      "author": "Xichuan",
+      "title": "Counterexample to the Erdős-Purdy conjecture",
+      "year": 2024,
+      "note": "Disproves the n-3 version; gives the upper bound f(n) ≤ n-4"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.Erdos105OQ01",
+      "Mathlib"
+    ],
+    "namespace": "Erdos105OQ01OQ01",
+    "lineCount": 182,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos105OQ01OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

New gallery entry **erdos-105-oq-01-oq-01** — *verified, original* (12 theorems / 1 def / **0 axioms** / 0 sorries / 182 lines).

Erdős #105's only open boundary is whether every obstacle set of size `n-4` is avoidable by a rich line (the parent's `openProblem_n_minus_4`). This entry promotes the parent's threshold supremum to a first-class object `avoidSet(n)` and characterizes it order-theoretically.

## Results

- `thresholdFunction_eq_sSup`: `f(n) = sSup (avoidSet n)` definitionally
- `avoidSet_downwardClosed` + `zero_mem_avoidSet`: `avoidSet n` is a **nonempty initial segment** of ℕ
- `avoidSet_eq_Iic`: under boundedness, `avoidSet n = Set.Iic (f n)` exactly — `f` is a **sharp threshold**
- `openProblem_iff_mem` / `openProblem_iff_threshold_ge`: `openProblem_n_minus_4 ↔ ∀ n≥5, (n-4) ∈ avoidSet n`, and under boundedness `↔ f(n) ≥ n-4`; with the known `f(n) ≤ n-4` this **pins the open question to `f(n) = n-4`**

## Axiom honesty

`#print axioms` on the summary, `avoidSet_eq_Iic`, and `openProblem_iff_threshold_ge` shows only `[propext, Classical.choice, Quot.sound]`. The parent's `xichuan_counterexample` / `beck_szemeredi_trotter_positive` axioms are **not** used. The `BddAbove (avoidSet n)` condition is carried as an explicit named hypothesis (it is oq-02's subject), never assumed → `status: verified`, `axiomCount: 0`.

## Incidental dependency-chain repair (Mathlib v4.26.0)

The #105 base files were **already broken on `main`** by the v4.26.0 bump (pre-existing, not caused by this work). Minimal compat fixes were required to build the chain:

- **`Erdos105Problem.lean`**: `import …AffineSubspace` → `…AffineSubspace.Basic` (module was split into a directory in v4.26.0); four orphan `/-- … -/` doc-comments → `/- … -/` (dangling doc-comments are now hard parse errors); `open scoped Classical in` for the Prop-valued `incidenceCount` filter; `Ne.symm hpq` → `hpq` (`Finset.one_lt_card` orientation)
- **`Erdos105OQ01.lean`**: made the `Infinite Point` injectivity proof robust to a non-beta-reduced hypothesis
- **`Proofs.lean`**: registers both `Erdos105OQ01` (was orphaned — never in the build graph) and the new `Erdos105OQ01OQ01`

> Note: sibling files `Erdos209Problem.lean` and `Erdos210Problem.lean` share the same broken `AffineSubspace` import and are **not** addressed here (out of scope; flagged for a mechanic).

## Verification

`./proofs/bin/lake build Proofs.Erdos105OQ01OQ01` — full chain (`Erdos105Problem` → `Erdos105OQ01` → `Erdos105OQ01OQ01`) builds clean.

## Status

**Outcome**: completed (new axiom-free structural entry + dependency repair)
**Next Steps**: oq-02 (is `avoidSet n` always bounded above?) would make the sharp-threshold characterization unconditional.

🤖 Generated by researcher-7