### PR TITLE
research(erdos-1023-oq-03): monotonicity F(n) ≤ F(m) of the union-free extremal function + register orphaned file

### DIFF
--- a/proofs/Proofs/Erdos1023ProblemOQ03.lean
+++ b/proofs/Proofs/Erdos1023ProblemOQ03.lean
@@ -189,8 +189,148 @@ theorem unionFreeMax_ge_two_pow_div (n : ℕ) :
         Nat.div_le_div_right (unionFreeMax_exponential_lower_bound n)
     _ = unionFreeMax n := Nat.mul_div_cancel_left _ (Nat.succ_pos n)
 
+/-!
+## Monotonicity of the extremal function
+
+A new structural property absent from the parent and the lower-bound section
+above: the extremal function `F(n) = unionFreeMax n` is **monotone**,
+`n ≤ m → F(n) ≤ F(m)`.
+
+The proof is by a *relabelling push-forward*. Any injection `e : Fin n ↪ Fin m`
+lifts to a map on set families, `pushFamily e`, that relabels every member set
+by `e`. This map
+
+  * preserves cardinality (`pushFamily_card`), because relabelling along an
+    embedding is injective; and
+  * preserves union-freeness (`pushFamily_unionFree`), because taking images
+    along an injection commutes with unions (`familyUnion_pushFamily`) and
+    keeps distinct sets distinct, so a spurious union among the relabelled sets
+    would pull back to a spurious union among the originals.
+
+Hence every achievable family size on `Fin n` is also achievable on `Fin m`,
+the set of achievable sizes only grows, and the supremum `unionFreeMax` is
+monotone (`unionFreeMax_mono`). Specialising to `m = n + 1` gives the successor
+form `F(n) ≤ F(n+1)` (`unionFreeMax_le_succ`).
+-/
+
+/-- The empty family is (vacuously) union-free; it witnesses `0 ∈` the set of
+achievable sizes, so that set is nonempty for every `n`. -/
+theorem isUnionFree_empty : isUnionFree (∅ : SetFamily n) :=
+  fun A hA => absurd hA (Finset.notMem_empty A)
+
+/-- Membership characterisation of `familyUnion`: a point lies in the union of a
+family iff it lies in some member. -/
+lemma mem_familyUnion {n : ℕ} {F : SetFamily n} {x : Fin n} :
+    x ∈ familyUnion F ↔ ∃ A ∈ F, x ∈ A := by
+  simp [familyUnion, Finset.mem_sup]
+
+/-- **Relabelling push-forward.** Transport a set family on `Fin n` to one on
+`Fin m` along an embedding `e : Fin n ↪ Fin m`, relabelling every member set by
+`e`. -/
+def pushFamily {n m : ℕ} (e : Fin n ↪ Fin m) (F : SetFamily n) : SetFamily m :=
+  F.map ⟨Finset.map e, Finset.map_injective e⟩
+
+/-- Membership in the push-forward: `B` is a relabelled member iff it is the
+image `A.map e` of some `A ∈ F`. -/
+@[simp] lemma mem_pushFamily {n m : ℕ} {e : Fin n ↪ Fin m} {F : SetFamily n}
+    {B : Finset (Fin m)} : B ∈ pushFamily e F ↔ ∃ A ∈ F, A.map e = B := by
+  simp [pushFamily, Finset.mem_map, Function.Embedding.coeFn_mk]
+
+/-- **Relabelling preserves family size.** Since `e` is injective, the induced
+relabelling of member sets is injective, so the push-forward has the same
+cardinality as the original family. -/
+@[simp] lemma pushFamily_card {n m : ℕ} (e : Fin n ↪ Fin m) (F : SetFamily n) :
+    (pushFamily e F).card = F.card := by
+  unfold pushFamily; exact Finset.card_map _
+
+/-- **Relabelling commutes with taking unions.** The union of a relabelled
+family is the relabelling of its union: `⋃ e[G] = e[⋃ G]`. This is the key
+compatibility making union-freeness stable under push-forward. -/
+lemma familyUnion_pushFamily {n m : ℕ} (e : Fin n ↪ Fin m) (G : SetFamily n) :
+    familyUnion (pushFamily e G) = (familyUnion G).map e := by
+  ext y
+  simp only [mem_familyUnion, mem_pushFamily, Finset.mem_map]
+  constructor
+  · rintro ⟨B, ⟨A, hA, rfl⟩, hyB⟩
+    rw [Finset.mem_map] at hyB
+    obtain ⟨a, ha, rfl⟩ := hyB
+    exact ⟨a, ⟨A, hA, ha⟩, rfl⟩
+  · rintro ⟨a, ⟨A, hA, ha⟩, rfl⟩
+    exact ⟨A.map e, ⟨A, hA, rfl⟩, Finset.mem_map.mpr ⟨a, ha, rfl⟩⟩
+
+/-- **Relabelling preserves union-freeness.** If `F` is union-free on `Fin n`
+and `e : Fin n ↪ Fin m` is an embedding, then the relabelled family
+`pushFamily e F` is union-free on `Fin m`. A spurious union `e[A₀] = ⋃ 𝒢` among
+the relabelled sets pulls back (the originals of `𝒢` form a subfamily `𝒢₀ ⊆ F`
+with `pushFamily e 𝒢₀ = 𝒢`) to a spurious union `A₀ = ⋃ 𝒢₀` in `F`, because
+relabelling is injective and commutes with unions. -/
+theorem pushFamily_unionFree {n m : ℕ} (e : Fin n ↪ Fin m) (F : SetFamily n)
+    (hF : isUnionFree F) : isUnionFree (pushFamily e F) := by
+  intro B hB hUnion
+  rw [mem_pushFamily] at hB
+  obtain ⟨A₀, hA₀, rfl⟩ := hB
+  obtain ⟨G, hGsub, hGcard, hBnotG, hGunion⟩ := hUnion
+  set G₀ : SetFamily n := F.filter (fun A => A.map e ∈ G) with hG₀def
+  have hGeq : G = pushFamily e G₀ := by
+    apply Finset.ext
+    intro C
+    rw [mem_pushFamily]
+    constructor
+    · intro hCG
+      have hCH : C ∈ pushFamily e F := Finset.mem_of_mem_erase (hGsub hCG)
+      rw [mem_pushFamily] at hCH
+      obtain ⟨A, hA, rfl⟩ := hCH
+      refine ⟨A, ?_, rfl⟩
+      rw [hG₀def, Finset.mem_filter]
+      exact ⟨hA, hCG⟩
+    · rintro ⟨A, hA, rfl⟩
+      rw [hG₀def, Finset.mem_filter] at hA
+      exact hA.2
+  refine hF A₀ hA₀ ⟨G₀, ?_, ?_, ?_, ?_⟩
+  · intro A hA
+    rw [hG₀def, Finset.mem_filter] at hA
+    rw [Finset.mem_erase]
+    refine ⟨?_, hA.1⟩
+    intro hAeq
+    apply hBnotG
+    rw [← hAeq]
+    exact hA.2
+  · have hcard : G₀.card = G.card := by rw [hGeq, pushFamily_card]
+    rw [hcard]; exact hGcard
+  · intro hA₀G₀
+    rw [hG₀def, Finset.mem_filter] at hA₀G₀
+    exact hBnotG hA₀G₀.2
+  · have h1 : familyUnion (pushFamily e G₀) = (familyUnion G₀).map e :=
+      familyUnion_pushFamily e G₀
+    rw [← hGeq, hGunion] at h1
+    exact (Finset.map_injective e h1).symm
+
+/-- **Monotonicity of the extremal function.** For `n ≤ m`, every union-free
+family on `Fin n` relabels to a union-free family of the same size on `Fin m`
+(via `Fin.castLEEmb`), so the set of achievable sizes can only grow and
+`F(n) ≤ F(m)`. -/
+theorem unionFreeMax_mono {n m : ℕ} (h : n ≤ m) :
+    unionFreeMax n ≤ unionFreeMax m := by
+  have hne : { k : ℕ | ∃ F : SetFamily n, isUnionFree F ∧ F.card = k }.Nonempty :=
+    ⟨0, ∅, isUnionFree_empty, Finset.card_empty⟩
+  apply csSup_le_csSup (unionFree_sizes_bddAbove m) hne
+  rintro k ⟨F, hF, rfl⟩
+  exact ⟨pushFamily (Fin.castLEEmb h) F, pushFamily_unionFree _ F hF,
+    pushFamily_card _ F⟩
+
+/-- `unionFreeMax` packaged as a `Monotone` function. -/
+theorem unionFreeMax_monotone : Monotone unionFreeMax :=
+  fun _ _ h => unionFreeMax_mono h
+
+/-- **Successor form of monotonicity:** `F(n) ≤ F(n+1)`. Adding one more ground
+element never decreases the maximum union-free family size. -/
+theorem unionFreeMax_le_succ (n : ℕ) : unionFreeMax n ≤ unionFreeMax (n + 1) :=
+  unionFreeMax_mono (Nat.le_succ n)
+
 #check @layer_antichain
 #check @unionFreeMax_ge_choose
 #check @unionFreeMax_exponential_lower_bound
+#check @unionFreeMax_mono
+#check @pushFamily_unionFree
 
 end Erdos1023OQ03

--- a/src/data/proofs/erdos-1023-oq-03/meta.json
+++ b/src/data/proofs/erdos-1023-oq-03/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-1023-oq-03",
-  "title": "Erdős #1023: an axiom-free exponential lower bound F(n) ≥ 2ⁿ/(n+1) for union-free families from single-layer constructions",
+  "title": "Erdős #1023: an axiom-free exponential lower bound F(n) ≥ 2ⁿ/(n+1) and monotonicity F(n) ≤ F(m) for union-free families from single-layer constructions",
   "slug": "erdos-1023-oq-03",
   "leanFile": {
     "imports": [
@@ -10,14 +10,14 @@
       "Finset"
     ],
     "namespace": "Erdos1023OQ03",
-    "lineCount": 196,
+    "lineCount": 336,
     "axiomCount": 0,
-    "theoremCount": 11,
-    "definitionCount": 7,
+    "theoremCount": 20,
+    "definitionCount": 8,
     "path": "Proofs/Erdos1023ProblemOQ03.lean",
     "sorries": 0
   },
-  "description": "Isolates the fully self-contained, axiom-free part of Erdős Problem #1023 (union-free families: F(n) = max size of a family of subsets of {1,…,n} with no member the union of two or more others). The parent file proves F(n) = C(n, ⌊n/2⌋) but routes the matching UPPER bound through Problem 447 as an external input (5 axioms). This entry develops only the LOWER-bound construction, which needs no axioms. Three points: (1) the middle layer is not special — EVERY layer (all k-element subsets, any fixed k) is an antichain, hence union-free, so F(n) ≥ C(n, k) for every k (unionFreeMax_ge_choose), strictly generalising the parent's middle-layer bound; (2) summing the binomial row 2ⁿ = Σ C(n,k) and bounding each term by the central one gives 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋) (two_pow_le_succ_mul_central); (3) combining them yields the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), i.e. F(n) ≥ 2ⁿ/(n+1), proved purely from the single middle-layer construction and independent of the harder upper bound. This already certifies F(n) grows exponentially — the crude pigeonhole 2ⁿ/(n+1) differs from the true ~√(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1). Self-contained: the small lower-bound infrastructure (set families, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared from the parent so nothing depends on the axiom-carrying asymptotic section. 11 theorems, 7 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "description": "Isolates the fully self-contained, axiom-free part of Erdős Problem #1023 (union-free families: F(n) = max size of a family of subsets of {1,…,n} with no member the union of two or more others). The parent file proves F(n) = C(n, ⌊n/2⌋) but routes the matching UPPER bound through Problem 447 as an external input (5 axioms). This entry develops only the LOWER-bound construction, which needs no axioms. Three points: (1) the middle layer is not special — EVERY layer (all k-element subsets, any fixed k) is an antichain, hence union-free, so F(n) ≥ C(n, k) for every k (unionFreeMax_ge_choose), strictly generalising the parent's middle-layer bound; (2) summing the binomial row 2ⁿ = Σ C(n,k) and bounding each term by the central one gives 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋) (two_pow_le_succ_mul_central); (3) combining them yields the explicit, axiom-free exponential lower bound 2ⁿ ≤ (n+1)·F(n), i.e. F(n) ≥ 2ⁿ/(n+1), proved purely from the single middle-layer construction and independent of the harder upper bound. This already certifies F(n) grows exponentially — the crude pigeonhole 2ⁿ/(n+1) differs from the true ~√(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1). A fourth, structural point is added: (4) the extremal function is MONOTONE, F(n) ≤ F(m) for n ≤ m (unionFreeMax_mono), with successor form F(n) ≤ F(n+1) (unionFreeMax_le_succ). The proof is a relabelling push-forward — any injection Fin n ↪ Fin m lifts to a map pushFamily on set families that relabels every member set, preserving cardinality (pushFamily_card) and union-freeness (pushFamily_unionFree, via familyUnion_pushFamily: taking images along an injection commutes with unions), so every achievable family size on Fin n is achievable on Fin m and the supremum can only grow. Self-contained: the small lower-bound infrastructure (set families, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared from the parent so nothing depends on the axiom-carrying asymptotic section. 20 theorems, 8 definitions, 0 sorries, 0 axioms, no native_decide.",
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "date": "formalized 2026",
@@ -36,17 +36,21 @@
     "sorries": 0,
     "dateAdded": "2026-06-22",
     "axiomCount": 0,
-    "assumptions": "Machine-checked against the Mathlib pin (Lean v4.26.0). 0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound] for every theorem (verified on unionFreeMax_exponential_lower_bound, unionFreeMax_ge_choose, layer_antichain, unionFreeMax_ge_two_pow_div). Self-contained: the lower-bound infrastructure (SetFamily, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared here verbatim from the parent Erdos1023Problem.lean, whose asymptotic section carries the 5 axioms routing the matching upper bound through Problem 447 — those are neither imported nor used here. Honest scope: this is the unconditional LOWER bound F(n) ≥ 2ⁿ/(n+1) (the exponential growth certificate), not the sharp value F(n) = C(n, ⌊n/2⌋), whose upper half remains the parent's axiomatised external input.",
-    "lineCount": 196,
-    "theoremCount": 11,
-    "definitionCount": 7,
+    "assumptions": "Machine-checked against the Mathlib pin (Lean v4.26.0). 0 sorries, 0 axiom declarations, no native_decide; #print axioms reports only the standard foundational axioms [propext, Classical.choice, Quot.sound] for every theorem (verified on unionFreeMax_exponential_lower_bound, unionFreeMax_ge_choose, layer_antichain, unionFreeMax_ge_two_pow_div, unionFreeMax_mono, pushFamily_unionFree, unionFreeMax_le_succ). Self-contained: the lower-bound infrastructure (SetFamily, isUnionFree, isAntichain, antichain_unionFree, unionFreeMax, layer) is re-declared here verbatim from the parent Erdos1023Problem.lean, whose asymptotic section carries the 5 axioms routing the matching upper bound through Problem 447 — those are neither imported nor used here. Honest scope: this is the unconditional LOWER bound F(n) ≥ 2ⁿ/(n+1) (the exponential growth certificate) plus the structural monotonicity F(n) ≤ F(m), not the sharp value F(n) = C(n, ⌊n/2⌋), whose upper half remains the parent's axiomatised external input.",
+    "lineCount": 336,
+    "theoremCount": 20,
+    "definitionCount": 8,
     "originalContributions": [
       "layer_antichain: every layer (the family of all k-element subsets of Fin n) is an antichain, for every k — generalising the parent's middleLayer_antichain (the k = n/2 case)",
       "layer_unionFree: every layer is union-free, immediate from layer_antichain and antichain_unionFree",
       "unionFreeMax_ge_choose: the lower bound F(n) ≥ C(n, k) holds at EVERY layer k, strictly generalising the parent's single middle-layer bound F(n) ≥ C(n, ⌊n/2⌋)",
       "two_pow_le_succ_mul_central: the row-sum bound 2ⁿ ≤ (n+1)·C(n, ⌊n/2⌋), from Σ_{k} C(n,k) = 2ⁿ with each term ≤ the central coefficient (Nat.choose_le_middle)",
       "unionFreeMax_exponential_lower_bound: the explicit axiom-free bound 2ⁿ ≤ (n+1)·F(n), certifying exponential growth of F(n) without the harder upper bound",
-      "unionFreeMax_ge_two_pow_div: the division form 2ⁿ/(n+1) ≤ F(n)"
+      "unionFreeMax_ge_two_pow_div: the division form 2ⁿ/(n+1) ≤ F(n)",
+      "pushFamily / familyUnion_pushFamily / pushFamily_card: a relabelling push-forward of set families along an embedding Fin n ↪ Fin m that preserves cardinality and commutes with familyUnion (taking images along an injection distributes over unions)",
+      "pushFamily_unionFree: union-freeness is preserved under the relabelling push-forward — a spurious union among relabelled sets pulls back to one among the originals",
+      "unionFreeMax_mono / unionFreeMax_monotone: monotonicity of the extremal function, F(n) ≤ F(m) for n ≤ m — a structural property of F absent from the parent, obtained by pushing an extremal family forward along Fin.castLEEmb so the set of achievable sizes can only grow",
+      "unionFreeMax_le_succ: the successor form F(n) ≤ F(n+1)"
     ]
   },
   "overview": {
@@ -57,7 +61,8 @@
       "The lower bound F(n) ≥ C(n, ⌊n/2⌋) is not special to the middle level: EVERY binomial coefficient C(n,k) is realised by a union-free family, because every layer is an antichain and antichains are union-free.",
       "The central binomial coefficient already controls the whole row: 2ⁿ = Σ_k C(n,k) ≤ (n+1)·C(n, ⌊n/2⌋), so a single layer captures at least a 1/(n+1) fraction of all 2ⁿ subsets.",
       "Combining the two gives an unconditional exponential lower bound 2ⁿ/(n+1) ≤ F(n) that needs none of the axiomatised upper-bound machinery — the crude pigeonhole differs from the sharp √(2/π)·2ⁿ/√n only by the polynomial factor √n/(n+1).",
-      "Separating the axiom-free lower-bound half from the axiom-carrying upper-bound half makes the unconditional content of the formalization explicit and machine-verifiable as 0-axiom."
+      "Separating the axiom-free lower-bound half from the axiom-carrying upper-bound half makes the unconditional content of the formalization explicit and machine-verifiable as 0-axiom.",
+      "Monotonicity is structural, not numeric: relabelling a union-free family along an injection Fin n ↪ Fin m preserves both its size and its union-freeness (image along an injection commutes with unions), so F(n) ≤ F(m) follows by transporting extremal families forward — independent of the exact value of F."
     ]
   },
   "sections": [
@@ -82,8 +87,16 @@
       "title": "Single-layer constructions and the exponential lower bound",
       "summary": "layer_antichain, layer_unionFree, unionFreeMax_ge_choose (F(n) ≥ C(n,k) for every k), two_pow_le_succ_mul_central (2ⁿ ≤ (n+1)·C(n,⌊n/2⌋)), unionFreeMax_exponential_lower_bound (2ⁿ ≤ (n+1)·F(n)), unionFreeMax_ge_two_pow_div (2ⁿ/(n+1) ≤ F(n)).",
       "startLine": 128,
-      "endLine": 196,
+      "endLine": 191,
       "mathContext": "Finset.eq_of_subset_of_card_le for the antichain property, le_csSup for the per-layer lower bound, Nat.sum_range_choose + Nat.choose_le_middle for the row bound, gcongr and Nat.div lemmas to assemble the exponential bound."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity of the extremal function via relabelling push-forward",
+      "summary": "isUnionFree_empty (nonemptiness witness) and mem_familyUnion; pushFamily (relabel a family along Fin n ↪ Fin m), pushFamily_card (injective relabelling preserves size), familyUnion_pushFamily (images along an injection commute with unions), pushFamily_unionFree (union-freeness is preserved by pushing forward), and the payoff unionFreeMax_mono / unionFreeMax_monotone (F(n) ≤ F(m) for n ≤ m, via Fin.castLEEmb) with the successor form unionFreeMax_le_succ (F(n) ≤ F(n+1)).",
+      "startLine": 192,
+      "endLine": 336,
+      "mathContext": "A new structural property of the extremal function, absent from the parent: F is monotone. Pushing an extremal union-free family forward along the standard embedding Fin n ↪ Fin m relabels its members injectively while preserving union-freeness, so every achievable family size on n ground elements is achievable on m ≥ n, and the supremum unionFreeMax can only increase."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Adds a new **structural** result to the axiom-free Erdős #1023 OQ-03 gallery entry (union-free families): the extremal function `F(n) = unionFreeMax n` is **monotone**,

> `n ≤ m → F(n) ≤ F(m)`  (`unionFreeMax_mono`, `unionFreeMax_monotone`)

with the successor form `F(n) ≤ F(n+1)` (`unionFreeMax_le_succ`). This is a property of `F` absent from both the parent (`Erdos1023Problem.lean`) and the existing lower-bound section.

## Mathematical content

The proof is a **relabelling push-forward**. Any embedding `e : Fin n ↪ Fin m` lifts to a map `pushFamily e` on set families that relabels every member set by `e`. It:

- preserves cardinality — `pushFamily_card` (relabelling along an injection is injective);
- commutes with unions — `familyUnion_pushFamily` (`⋃ e[G] = e[⋃ G]`, the image of an injection distributes over unions);
- preserves union-freeness — `pushFamily_unionFree`: a spurious union `e[A₀] = ⋃ 𝒢` among the relabelled sets pulls back (the originals of `𝒢` form `𝒢₀ ⊆ F` with `pushFamily e 𝒢₀ = 𝒢`) to a spurious union `A₀ = ⋃ 𝒢₀` in `F`.

Pushing an extremal family forward along `Fin.castLEEmb` therefore shows every achievable family size on `Fin n` is achievable on `Fin m`, so the supremum `unionFreeMax` can only grow.

## Build-graph registration

The canonical OQ-03 file's registration in `Proofs.lean` already landed via #28726 (merged); after rebasing onto `main`, this PR's diff is just the new monotonicity content + `meta.json`. No namespace clash: the unregistered twin `Erdos1023OQ03.lean` (different math — k-union-free families — but same `namespace Erdos1023OQ03`) stays out of the build graph, and the parent uses `namespace Erdos1023`.

## Verification

Docker was down, so verified via the host Lean kernel (`LAKE_UNSAFE=1 lake env lean`):

- 0 errors, 0 `sorry`.
- `#print axioms` reports only `[propext, Classical.choice, Quot.sound]` for `unionFreeMax_mono`, `pushFamily_unionFree`, and `unionFreeMax_le_succ` — **axiom-free** (no `sorryAx`, no `Lean.ofReduceBool`).

`meta.json` updated: 11→20 theorems, 7→8 definitions, 196→336 lines; status stays `verified`/`badge: verified`, `axiomCount: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
