### PR TITLE
Enrich crossing-zero power-mean equality case (amgm oq-03-oq-02-oq-01-oq-02): add index.ts + annotations

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-geommean-rpow-eq",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 86, "endLine": 94 },
+    "type": "technique",
+    "title": "The Structural Bridge: GM^r = ∏ (zᵢ^r)^wᵢ",
+    "content": "The algebraic identity that lets the equality case of weighted AM–GM be applied to the *powered* data. Raising the weighted geometric mean $\\mathrm{GM} = \\prod z_i^{w_i}$ to the power $r$ commutes with the product (since each factor is nonnegative): $(\\prod z_i^{w_i})^r = \\prod (z_i^{w_i})^r = \\prod (z_i^r)^{w_i}$, because both $(z_i^{w_i})^r$ and $(z_i^r)^{w_i}$ equal $z_i^{r w_i}$. The proof pushes the outer power inside via the helper `finset_prod_rpow` (an induction giving $(\\prod f_i)^r = \\prod f_i^r$) and reconciles the two iterated exponents with `Real.rpow_mul` and a `ring` step on $r\\cdot w_i = w_i\\cdot r$. This rewrites $\\mathrm{GM}^r$ into exactly the product form $\\prod(z_i^r)^{w_i}$ that the AM–GM equality lemma consumes.",
+    "mathContext": "$\\left(\\prod_i z_i^{w_i}\\right)^r = \\prod_i (z_i^r)^{w_i}$, both equal to $\\prod_i z_i^{r w_i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["real power function rpow", "weighted geometric mean", "products over finsets"],
+    "prerequisites": ["real exponentiation", "finite products", "induction on Finset"]
+  },
+  {
+    "id": "ann-core-equality",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 100, "endLine": 121 },
+    "type": "insight",
+    "title": "Core Equality: GM^r = ∑ wᵢ zᵢ^r ⟺ Data Constant",
+    "content": "The single engine of the whole entry. Apply the equality case of weighted AM–GM (`weighted_amgm_eq_iff`) to the substituted data $u_i = z_i^r$: its geometric side $\\prod (z_i^r)^{w_i}$ is $\\mathrm{GM}^r$ (by the bridge lemma), its arithmetic side is $\\sum w_i z_i^r$, and equality holds iff $z_j^r = z_k^r$ for all $j,k$. The crucial final move is `Real.rpow_left_inj`: on the positive reals with $r \\neq 0$, the map $x \\mapsto x^r$ is injective, so $z_j^r = z_k^r$ collapses to $z_j = z_k$. This is where the equality case of AM–GM is transported from the powered data back to the original data — and it works regardless of the sign of $r$.",
+    "mathContext": "$\\mathrm{GM}^r = \\sum_i w_i z_i^r \\iff \\forall j,k,\\; z_j^r = z_k^r \\iff \\forall j,k,\\; z_j = z_k$ (last step by injectivity of $x\\mapsto x^r$, $r\\neq 0$).",
+    "significance": "key",
+    "relatedConcepts": ["weighted AM-GM equality case", "injectivity", "Jensen's inequality"],
+    "prerequisites": ["weighted AM-GM inequality", "injective functions", "real exponentiation"]
+  },
+  {
+    "id": "ann-sign-independent",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 127, "endLine": 150 },
+    "type": "concept",
+    "title": "Sign-Independent Equality: M_r = GM ⟺ Constant for Every r ≠ 0",
+    "content": "The headline result. Although the *inequality* between $\\mathrm{GM}$ and $M_r$ reverses across zero ($\\mathrm{GM} \\le M_r$ for $r>0$, $M_r \\le \\mathrm{GM}$ for $r<0$), the *equality locus* is the same for both signs. The argument is purely algebraic: raising the power mean $M_r = (\\sum w_i z_i^r)^{1/r}$ to the $r$-th power recovers $\\sum w_i z_i^r$ exactly (since $\\tfrac1r\\cdot r = 1$ for any $r \\neq 0$ — no sign case-split). Then because $x \\mapsto x^r$ is injective on the positives, $M_r = \\mathrm{GM} \\iff M_r^r = \\mathrm{GM}^r \\iff \\sum w_i z_i^r = \\mathrm{GM}^r$, which the core lemma equates with constancy. The entire analytic content lives in the AM–GM equality case; the sign-independence is a free consequence of $r \\mapsto 1/r$ being a bijection away from 0.",
+    "mathContext": "$M_r = \\mathrm{GM} \\iff M_r^r = \\mathrm{GM}^r \\iff \\sum_i w_i z_i^r = \\mathrm{GM}^r \\iff \\forall j,k,\\; z_j = z_k.$",
+    "significance": "key",
+    "relatedConcepts": ["power mean", "geometric mean", "equality case", "bijection"],
+    "prerequisites": ["generalized (power) means", "real exponentiation", "injectivity"]
+  },
+  {
+    "id": "ann-crossing-eq",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 156, "endLine": 177 },
+    "type": "insight",
+    "title": "Crossing-Zero Equality by a Squeeze: M_r = M_t ⟺ Constant",
+    "content": "The sharp converse to crossing-zero monotonicity, for $r < 0 < t$. The forward direction is a squeeze: the parent inequalities give $M_r \\le \\mathrm{GM} \\le M_t$, and the hypothesis $M_r = M_t$ pins the entire chain together, forcing $M_r = \\mathrm{GM}$, which the sign-independent lemma converts to constancy. The reverse direction is immediate — if the data is constant then both $M_r$ and $M_t$ equal $\\mathrm{GM}$ by `power_mean_eq_geom_mean_iff` applied at each exponent. Note the geometric mean $M_0 = \\mathrm{GM}$ sits exactly at the crossover and acts as the pivot that the two endpoints are squeezed onto.",
+    "mathContext": "$M_r \\le \\mathrm{GM} \\le M_t$ and $M_r = M_t \\Rightarrow M_r = \\mathrm{GM} = M_t \\Rightarrow$ data constant.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "power mean monotonicity", "geometric mean"],
+    "prerequisites": ["power mean inequalities", "order (le_antisymm)"]
+  },
+  {
+    "id": "ann-strictness",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 179, "endLine": 219 },
+    "type": "technique",
+    "title": "Strictness for Non-Constant Data via lt_of_le_of_ne",
+    "content": "The three strict bounds — $M_r < \\mathrm{GM}$ ($r<0$), $\\mathrm{GM} < M_t$ ($t>0$), and $M_r < M_t$ ($r<0<t$) — all follow from a uniform recipe: take the non-strict bound already proved in the parent file and upgrade it with `lt_of_le_of_ne`. The remaining obligation is that the inequality is not an equality; assuming it were, the relevant equality characterization (`power_mean_eq_geom_mean_iff` or `power_mean_crossing_zero_eq_iff`) would force all data equal, contradicting the witness $z_j \\neq z_k$. This is the standard 'a non-strict bound with a ruled-out equality case is strict' pattern, and it is exactly where the equality theory pays off.",
+    "mathContext": "$a \\le b$ and $a \\neq b \\Rightarrow a < b$; here $a = b$ would imply constancy, contradicting $\\exists j,k,\\; z_j \\neq z_k$.",
+    "significance": "supporting",
+    "relatedConcepts": ["strict vs non-strict inequalities", "equality case", "proof by contradiction"],
+    "prerequisites": ["order relations", "the crossing-zero inequalities"]
+  },
+  {
+    "id": "ann-hm-gm-am",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01-oq-02",
+    "range": { "startLine": 225, "endLine": 241 },
+    "type": "context",
+    "title": "The Sharp Classical HM < GM < AM as a Specialization",
+    "content": "The famous chain harmonic ≤ geometric ≤ arithmetic mean, in its sharp form, is recovered with no extra work as the $r = -1$, $t = 1$ instance of the general theory. `hm_eq_gm_iff` is `power_mean_eq_geom_mean_iff` at $r=-1$; `hm_lt_gm_lt_am_of_ne` pairs the two strict crossing-zero bounds at $r=-1$ and $t=1$. That all three classical strict inequalities drop out of a single specialization illustrates the value of proving the result at the level of arbitrary power-mean exponents rather than for the three named means individually.",
+    "mathContext": "$M_{-1} = \\mathrm{HM},\\; M_0 = \\mathrm{GM},\\; M_1 = \\mathrm{AM}$; non-constant data $\\Rightarrow \\mathrm{HM} < \\mathrm{GM} < \\mathrm{AM}$.",
+    "significance": "context",
+    "relatedConcepts": ["harmonic mean", "arithmetic mean", "geometric mean", "AM-GM inequality"],
+    "prerequisites": ["classical means", "power mean specialization"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const amgmInequalityOq03Oq02Oq01Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const amgmInequalityOq03Oq02Oq01Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const amgmInequalityOq03Oq02Oq01Oq02Data: ProofData = {
+  proof: amgmInequalityOq03Oq02Oq01Oq02Proof,
+  annotations: amgmInequalityOq03Oq02Oq01Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `amgm-inequality-oq-03-oq-02-oq-01-oq-02` (Equality Case of the Crossing-Zero Power-Mean Chain).

## Changes
- **Created `index.ts`** — the directory had only `meta.json`, so the proof page rendered 'proof not found' on the live site. The Vite entry point is now present.
- **Created `annotations.json`** — 6 substantive annotations covering all five sections: the structural bridge GM^r = ∏(zᵢ^r)^wᵢ, the core AM–GM equality engine, the sign-independent M_r = GM ⟺ constant result, the crossing-zero squeeze, the lt_of_le_of_ne strictness pattern, and the sharp HM < GM < AM specialization. Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- `pnpm build` passes.
- Annotation line ranges checked against `AmgmInequalityOQ03OQ02OQ01OQ02.lean`.
- Axiom/status fields (`verified`, 0 axioms, badge `mathlib` Tier-B) confirmed accurate: the file's content is transport infrastructure around Mathlib's AM–GM equality case, correctly documented in `assumptions`.