### PR TITLE
Enrich Rank, Nullity, and Invertibility Are Similarity Invariants

### DIFF
--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/meta.json
@@ -71,7 +71,8 @@
       "Rank invariance is conceptual, not computational: conjugation is multiplication by invertible matrices on both sides, and invertible multiplication preserves rank — no reference to det values or eigenvalues is needed, so it holds over any commutative ring",
       "Invertibility invariance needs no determinant at all: cancelling the surrounding units with Units.isUnit_mul_units suffices, with the determinant form obtained afterwards purely for convenience",
       "Once rank invariance and the rank–nullity identity are in hand, nullity invariance is a one-line arithmetic consequence (omega), illustrating how a single structural invariant propagates",
-      "nullity = 0 ⇔ rank = n packages 'injective ⇔ surjective ⇔ bijective' for finite-dimensional endomorphisms as an arithmetic fact about two natural numbers summing to n"
+      "nullity = 0 ⇔ rank = n packages 'injective ⇔ surjective ⇔ bijective' for finite-dimensional endomorphisms as an arithmetic fact about two natural numbers summing to n",
+      "The dimension count is where finiteness is doing the real work: the trivial-kernel ⇔ full-rank equivalence is exactly the failure of the infinite-dimensional case (the shift operator on K^∞ is injective but not surjective), so rank–nullity is not mere bookkeeping but the precise statement that endomorphisms of a finite-dimensional space cannot leak dimension"
     ],
     "prerequisites": [
       "Matrices over a commutative ring; the unit (invertible-matrix) group",


### PR DESCRIPTION
Enrichment pass for `matrix-similarity-invariants-oq-01-oq-01` (quality 43, pass 0).

## Changes
- **Added `annotations.json`** — the entry had none. 9 annotations with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`, covering the full Lean file: similarity relation, invertibility invariance (matrix + determinant forms), rank invariance over any commutative ring, nullity definition, matrix rank–nullity, nullity invariance, trivial-kernel ⇔ full-rank, and the packaged statement.
- **meta.json** — added a 5th `keyInsight` explaining why finiteness is essential (the shift-operator counterexample in infinite dimensions).

## Validation
Data pipeline (`annotations:build`, `research:build`, `research:enrich`) ran cleanly and validated both JSON files. (`tsc -b` skipped: `node_modules` not installed in this worktree — TS app compile, unrelated to data changes.)

## Axiom integrity
No change to status/badge/axiomCount. Entry remains `verified` / `mathlib` / 0 axioms.