### PR TITLE
Enrich Abel-Ruffini reflection/escape-cost asymmetry: add index.ts + deepen annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 64 },
     "type": "concept",
     "title": "Reflection and preservation are different directions",
-    "content": "The parent file paired the two type operations as 'products reflect, sums fail to preserve'. But **reflection** (solvability of the composite $\\Rightarrow$ solvability of a piece) and **preservation** (solvability of the pieces $\\Rightarrow$ solvability of the composite) are opposite implications. Compared honestly, both $\\oplus$ and $\\times$ reflect (each piece injects into the composite, so $|\\alpha| \\le |\\alpha|+|\\beta|$ and $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$) and neither preserves (solvable $2$- and $3$-point systems combine to unsolvable $5$- and $6$-point ones). The surviving distinction is purely arithmetic — the **cost of escaping** the solvable range $\\{0,1,2,3,4\\}$."
+    "content": "The parent file paired the two type operations as 'products reflect, sums fail to preserve'. But **reflection** (solvability of the composite $\\Rightarrow$ solvability of a piece) and **preservation** (solvability of the pieces $\\Rightarrow$ solvability of the composite) are opposite implications. Compared honestly, both $\\oplus$ and $\\times$ reflect (each piece injects into the composite, so $|\\alpha| \\le |\\alpha|+|\\beta|$ and $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$) and neither preserves (solvable $2$- and $3$-point systems combine to unsolvable $5$- and $6$-point ones). The surviving distinction is purely arithmetic — the **cost of escaping** the solvable range $\\{0,1,2,3,4\\}$.",
+    "mathContext": "Reflection: $\\mathrm{Solv}(\\mathrm{Perm}(\\alpha \\sqcup \\beta)) \\Rightarrow \\mathrm{Solv}(\\mathrm{Perm}\\,\\alpha)$. Preservation: $\\mathrm{Solv}(\\mathrm{Perm}\\,\\alpha) \\wedge \\mathrm{Solv}(\\mathrm{Perm}\\,\\beta) \\Rightarrow \\mathrm{Solv}(\\mathrm{Perm}(\\alpha \\sqcup \\beta))$ — converse implications, not a single asymmetry.",
+    "significance": "key",
+    "relatedConcepts": ["solvable group", "symmetric group", "reflection vs preservation", "monoidal structure on finite types"],
+    "prerequisites": ["solvable groups", "Abel–Ruffini theorem", "cardinality of finite types"]
   },
   {
     "id": "ann-sum-reflects",
@@ -13,7 +17,11 @@
     "range": { "startLine": 69, "endLine": 104 },
     "type": "insight",
     "title": "Sums reflect solvability too",
-    "content": "`perm_sum_reflects_solvable_left` rewrites the union threshold $|\\alpha|+|\\beta| \\le 4$ and the summand threshold $|\\alpha| \\le 4$; since $|\\alpha| \\le |\\alpha|+|\\beta|$ is linear, `omega` closes it. So solvability of $S_{\\alpha\\oplus\\beta}$ descends to $S_\\alpha$ exactly as it does for a Cartesian factor. `both_operations_reflect_solvability` packages the two halves, showing $\\oplus$ is **not** the non-reflecting operation the parent suggested — reflection is symmetric between the two constructions."
+    "content": "`perm_sum_reflects_solvable_left` rewrites the union threshold $|\\alpha|+|\\beta| \\le 4$ and the summand threshold $|\\alpha| \\le 4$; since $|\\alpha| \\le |\\alpha|+|\\beta|$ is linear, `omega` closes it. So solvability of $S_{\\alpha\\oplus\\beta}$ descends to $S_\\alpha$ exactly as it does for a Cartesian factor. `both_operations_reflect_solvability` packages the two halves, showing $\\oplus$ is **not** the non-reflecting operation the parent suggested — reflection is symmetric between the two constructions.",
+    "mathContext": "$|\\alpha| \\le |\\alpha|+|\\beta|$ and $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$ (for nonempty cofactor), so $|\\alpha\\oplus\\beta| \\le 4 \\Rightarrow |\\alpha| \\le 4$ and likewise for $\\times$; via $\\mathrm{Solv}(\\mathrm{Perm}\\,\\alpha) \\leftrightarrow |\\alpha| \\le 4$.",
+    "significance": "key",
+    "relatedConcepts": ["disjoint union", "Cartesian product", "monotonicity of cardinality", "permutation group embedding"],
+    "prerequisites": ["Fintype.card_sum", "Fintype.card_prod", "solvable group threshold"]
   },
   {
     "id": "ann-neither-preserves",
@@ -21,7 +29,11 @@
     "range": { "startLine": 106, "endLine": 135 },
     "type": "insight",
     "title": "Neither operation preserves solvability",
-    "content": "Reusing the parent's witness $S_{\\mathrm{Fin}\\,2}, S_{\\mathrm{Fin}\\,3}$ solvable, `neither_operation_preserves_solvability` shows their composite is unsolvable under **both** operations: $|\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3| = 5$ and $|\\mathrm{Fin}\\,2 \\times \\mathrm{Fin}\\,3| = 6$, both $\\ge 5$. Together with the reflection result this puts $\\oplus$ and $\\times$ on the same side of both implications."
+    "content": "Reusing the parent's witness $S_{\\mathrm{Fin}\\,2}, S_{\\mathrm{Fin}\\,3}$ solvable, `neither_operation_preserves_solvability` shows their composite is unsolvable under **both** operations: $|\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3| = 5$ and $|\\mathrm{Fin}\\,2 \\times \\mathrm{Fin}\\,3| = 6$, both $\\ge 5$. Together with the reflection result this puts $\\oplus$ and $\\times$ on the same side of both implications.",
+    "mathContext": "$\\mathrm{Solv}(\\mathrm{Perm}(\\mathrm{Fin}\\,2)) \\wedge \\mathrm{Solv}(\\mathrm{Perm}(\\mathrm{Fin}\\,3))$ yet $\\neg\\,\\mathrm{Solv}(\\mathrm{Perm}(\\mathrm{Fin}\\,5))$ and $\\neg\\,\\mathrm{Solv}(\\mathrm{Perm}(\\mathrm{Fin}\\,6))$, since $S_n$ is unsolvable for $n \\ge 5$.",
+    "significance": "key",
+    "relatedConcepts": ["counterexample", "S₅ unsolvable", "closure under operations", "Equiv.Perm.not_solvable"],
+    "prerequisites": ["S₅ non-solvability", "Fintype.card_fin", "counterexample construction"]
   },
   {
     "id": "ann-no-product-five",
@@ -29,7 +41,11 @@
     "range": { "startLine": 137, "endLine": 156 },
     "type": "technique",
     "title": "5 is multiplicatively unreachable: a primality argument",
-    "content": "`no_solvable_product_equals_five` is `interval_cases m <;> interval_cases n <;> omega` — a finite check over $m, n \\le 4$. The mathematical content is that $5$ is prime: $m\\cdot n = 5$ forces $\\{m,n\\} = \\{1,5\\}$, but $5 > 4$. `no_nontrivial_product_equals_five` makes the same point without an upper bound: if $m \\ge 3$ then $m\\cdot n \\ge 3\\cdot 2 = 6 > 5$ (`Nat.mul_le_mul`), and the remaining case $m = 2$ gives $2n = 5$, impossible by parity (`omega`)."
+    "content": "`no_solvable_product_equals_five` is `interval_cases m <;> interval_cases n <;> omega` — a finite check over $m, n \\le 4$. The mathematical content is that $5$ is prime: $m\\cdot n = 5$ forces $\\{m,n\\} = \\{1,5\\}$, but $5 > 4$. `no_nontrivial_product_equals_five` makes the same point without an upper bound: if $m \\ge 3$ then $m\\cdot n \\ge 3\\cdot 2 = 6 > 5$ (`Nat.mul_le_mul`), and the remaining case $m = 2$ gives $2n = 5$, impossible by parity (`omega`).",
+    "mathContext": "$5$ prime $\\Rightarrow$ $m\\cdot n = 5 \\Rightarrow \\min(m,n) = 1,\\ \\max(m,n) = 5 > 4$. Nontrivial form: $m,n \\ge 2 \\Rightarrow m\\cdot n \\ge 4$ and $m\\cdot n \\ne 5$ (parity/$\\ge 6$).",
+    "significance": "supporting",
+    "relatedConcepts": ["primality", "divisibility", "interval_cases", "Nat.mul_le_mul"],
+    "prerequisites": ["prime numbers", "natural-number arithmetic", "case analysis"]
   },
   {
     "id": "ann-escape-six",
@@ -37,7 +53,11 @@
     "range": { "startLine": 158, "endLine": 172 },
     "type": "insight",
     "title": "The minimal nontrivial multiplicative escape is 6",
-    "content": "`min_nontrivial_product_escape`: for factors $m, n \\ge 2$, any product that leaves $\\{\\le 4\\}$ is $\\ge 6$. Once $m\\cdot n \\neq 5$ is known, `omega` finishes — treating the product as an atom $t$ with $t > 4$ and $t \\neq 5$, hence $t \\ge 6$. The value $6 = 2\\cdot 3$ is attained, so $6$ is exactly the multiplicative analogue of the additive escape $5 = 2+3$."
+    "content": "`min_nontrivial_product_escape`: for factors $m, n \\ge 2$, any product that leaves $\\{\\le 4\\}$ is $\\ge 6$. Once $m\\cdot n \\neq 5$ is known, `omega` finishes — treating the product as an atom $t$ with $t > 4$ and $t \\neq 5$, hence $t \\ge 6$. The value $6 = 2\\cdot 3$ is attained, so $6$ is exactly the multiplicative analogue of the additive escape $5 = 2+3$.",
+    "mathContext": "$m,n \\ge 2 \\wedge m\\cdot n > 4 \\Rightarrow m\\cdot n \\ge 6$ (since $m\\cdot n \\ne 5$), and $2\\cdot 3 = 6$ is attained — versus the additive escape $2 + 3 = 5$.",
+    "significance": "key",
+    "relatedConcepts": ["minimal escape value", "closure of an interval", "additive vs multiplicative structure"],
+    "prerequisites": ["natural-number arithmetic", "omega tactic reasoning"]
   },
   {
     "id": "ann-escape-asymmetry",
@@ -45,6 +65,10 @@
     "range": { "startLine": 184, "endLine": 205 },
     "type": "insight",
     "title": "The boundary is crossed one step later under ×",
-    "content": "`escape_cost_asymmetry` collects three facts: $5 = 2+3$ is additively reachable from the solvable range and unsolvable; no product of two cardinalities $\\le 4$ equals $5$; and the first multiplicative escape $2\\cdot 3 = 6$ is unsolvable. `multiplicative_boundary_above_additive` records the resulting strict inequality $5 < 6$. So the degree $5$ — the Abel–Ruffini threshold — is additively reachable but multiplicatively skipped: $\\times$ crosses the boundary one step after $\\oplus$."
+    "content": "`escape_cost_asymmetry` collects three facts: $5 = 2+3$ is additively reachable from the solvable range and unsolvable; no product of two cardinalities $\\le 4$ equals $5$; and the first multiplicative escape $2\\cdot 3 = 6$ is unsolvable. `multiplicative_boundary_above_additive` records the resulting strict inequality $5 < 6$. So the degree $5$ — the Abel–Ruffini threshold — is additively reachable but multiplicatively skipped: $\\times$ crosses the boundary one step after $\\oplus$.",
+    "mathContext": "Additive boundary $= 2+3 = 5$; multiplicative boundary $= 2\\cdot 3 = 6$; $5 < 6$. The Abel–Ruffini degree $5$ is additively reachable yet multiplicatively unreachable from $\\{0,1,2,3,4\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Abel–Ruffini threshold", "additive vs multiplicative escape", "degree 5", "strict inequality"],
+    "prerequisites": ["Abel–Ruffini theorem", "solvability threshold n ≤ 4", "elementary arithmetic"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Proof,
+  annotations: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01` (Reflection Is Symmetric, the Escape Cost Is Not: Additive 5 vs Multiplicative 6).

## Changes
- **Created `index.ts`** — directory had only meta.json + annotations.json, so the page rendered 'proof not found' on the live site. Vite entry point now present.
- **Deepened all 6 annotations** — each previously had only `content`; added `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` covering reflection symmetry, the non-preservation counterexamples, the primality argument for 5, the minimal multiplicative escape 6, and the additive-5/multiplicative-6 asymmetry.

## Verification
- `pnpm build` passes; JSON validated.
- Annotation line ranges checked against the Lean file; `verified`/0-axiom/`mathlib` Tier-B status confirmed accurate (combinatorial packaging over Mathlib's S₅ non-solvability).