### PR TITLE
research(basel-problem-oq-15): ζ(8) = π⁸/9450 and the π-free ratio ζ(8)/ζ(2)⁴ = 24/175 [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -292,6 +292,7 @@ import Proofs.BaselProblemOQ11
 import Proofs.BaselProblemOQ12
 import Proofs.BaselProblemOQ13
 import Proofs.BaselProblemOQ14
+import Proofs.BaselProblemOQ15
 import Proofs.BellNumbersOQ01
 import Proofs.BernoulliInequalityOQ01
 import Proofs.BernoulliInequalityOQ01OQ01

--- a/proofs/Proofs/BaselProblemOQ15.lean
+++ b/proofs/Proofs/BaselProblemOQ15.lean
@@ -1,0 +1,90 @@
+/-
+# Basel Problem OQ-15: the value ζ(8) = π⁸/9450 and the ζ(8)/ζ(2)⁴ ratio
+
+## Open Question
+Formalize `∑' n, 1 / n⁸ = π⁸ / 9450`, the next even-argument value after
+`ζ(2) = π²/6`, `ζ(4) = π⁴/90`, and `ζ(6) = π⁶/945`, by instantiating Mathlib's
+even-zeta formula `hasSum_zeta_nat` / `riemannZeta_two_mul_nat` at `k = 4`, plus the
+dimensionless (π-free) Euler ratio `ζ(8) / ζ(2)⁴ = 24/175`.
+
+## Approach
+Mathlib proves the general even-zeta formula
+`hasSum_zeta_nat : HasSum (fun n => 1/n^(2k)) ((-1)^(k+1)·2^(2k-1)·π^(2k)·B_{2k}/(2k)!)`.
+Mathlib packages `bernoulli'_two`, `bernoulli'_four`, `bernoulli'_six` but not
+`bernoulli'_eight`, so we first compute `bernoulli 8 = -1/30` from the defining
+recurrence (`bernoulli'_def`), using that the odd-index `bernoulli' 3, 5, 7` vanish.
+Substituting `k = 4` then gives `2⁷·π⁸·(-1/30)/8! = π⁸/9450` (since `128/(30·40320) = 1/9450`).
+
+The companion `riemannZeta_two_mul_nat` gives the value of the analytically-continued
+`riemannZeta 8`. Finally, dividing `ζ(8) = π⁸/9450` by `ζ(2)⁴ = π⁸/1296` cancels π,
+leaving the rational `1296/9450 = 24/175`, the degree-8 analogue of the parent chain's
+`ζ(4)/ζ(2)² = 2/5` and `ζ(6)/ζ(2)³ = 8/35`.
+
+Sorry-free and axiom-free.
+-/
+import Mathlib
+
+namespace BaselProblemOQ15
+
+open Real BigOperators
+
+/-- **The eighth Bernoulli number `B₈ = -1/30`.** Mathlib packages `bernoulli'_two`,
+`bernoulli'_four`, and `bernoulli'_six` but not `bernoulli'_eight`; we compute it from
+the defining recurrence `bernoulli'_def`, using that the odd-index `bernoulli' 3, 5, 7`
+vanish. -/
+theorem bernoulli_eight : (bernoulli 8 : ℚ) = -1 / 30 := by
+  have h3 : bernoulli' 3 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  have h5 : bernoulli' 5 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  have h7 : bernoulli' 7 = 0 := bernoulli'_eq_zero_of_odd (by decide) (by norm_num)
+  -- Mathlib packages `bernoulli'_two` and `bernoulli'_four` but not `bernoulli'_six`;
+  -- compute `B'₆ = 1/42` from the recurrence (this is the only Bernoulli value missing).
+  have h6 : bernoulli' 6 = 1 / 42 := by
+    rw [bernoulli'_def]
+    norm_num [Finset.sum_range_succ, Finset.sum_range_zero, h5,
+      show Nat.choose 6 1 = 6 from rfl, show Nat.choose 6 2 = 15 from rfl,
+      show Nat.choose 6 3 = 20 from rfl, show Nat.choose 6 4 = 15 from rfl,
+      show Nat.choose 6 5 = 6 from rfl]
+  rw [bernoulli_eq_bernoulli'_of_ne_one (by decide : (8 : ℕ) ≠ 1), bernoulli'_def]
+  norm_num [Finset.sum_range_succ, Finset.sum_range_zero, h3, h5, h6, h7,
+    show Nat.choose 8 1 = 8 from rfl, show Nat.choose 8 2 = 28 from rfl,
+    show Nat.choose 8 3 = 56 from rfl, show Nat.choose 8 4 = 70 from rfl,
+    show Nat.choose 8 5 = 56 from rfl, show Nat.choose 8 6 = 28 from rfl,
+    show Nat.choose 8 7 = 8 from rfl]
+
+/-- The summable family `n ↦ 1/n⁸` has sum `π⁸/9450`, the `k = 4` instance of Mathlib's
+even-zeta formula `hasSum_zeta_nat`. -/
+theorem hasSum_one_div_nat_pow_eight :
+    HasSum (fun n : ℕ => (1 : ℝ) / (n : ℝ) ^ 8) (π ^ 8 / 9450) := by
+  convert hasSum_zeta_nat (by norm_num : (4 : ℕ) ≠ 0) using 1
+  rw [show (2 * 4 : ℕ) = 8 from rfl, bernoulli_eight]
+  norm_num [Nat.factorial]
+  ring
+
+/-- **ζ(8) = π⁸/9450.** The infinite sum `∑' n, 1/n⁸` over the naturals equals `π⁸/9450`. -/
+theorem tsum_one_div_nat_pow_eight :
+    ∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8 = π ^ 8 / 9450 :=
+  hasSum_one_div_nat_pow_eight.tsum_eq
+
+/-- The Riemann zeta function at `8` equals `π⁸/9450`, via Mathlib's
+`riemannZeta_two_mul_nat` at `k = 4`. -/
+theorem riemannZeta_eight_eq : riemannZeta 8 = (π : ℂ) ^ 8 / 9450 := by
+  have h := riemannZeta_two_mul_nat (by norm_num : (4 : ℕ) ≠ 0)
+  rw [show (2 * 4 : ℕ) = 8 from rfl, bernoulli_eight,
+    show (2 : ℂ) * ((4 : ℕ) : ℂ) = 8 by norm_num] at h
+  rw [h]
+  push_cast [Nat.factorial]
+  ring
+
+/-- **Euler's ratio `ζ(8) / ζ(2)⁴ = 24/175`.** Dividing the even-zeta values
+`ζ(8) = π⁸/9450` and `ζ(2) = π²/6` makes π cancel (`ζ(2)⁴ = π⁸/1296`), leaving the
+rational `1296/9450 = 24/175`. This continues the chain `ζ(4)/ζ(2)² = 2/5`,
+`ζ(6)/ζ(2)³ = 8/35`. -/
+theorem tsum_eight_div_tsum_two_fourth :
+    (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 8) / (∑' n : ℕ, (1 : ℝ) / (n : ℝ) ^ 2) ^ 4 = 24 / 175 := by
+  rw [tsum_one_div_nat_pow_eight, hasSum_zeta_two.tsum_eq]
+  have hπ : (π : ℝ) ≠ 0 := Real.pi_ne_zero
+  have h8 : (π : ℝ) ^ 8 ≠ 0 := pow_ne_zero _ hπ
+  field_simp
+  ring
+
+end BaselProblemOQ15

--- a/src/data/proofs/basel-problem-oq-15/annotations.json
+++ b/src/data/proofs/basel-problem-oq-15/annotations.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": "baseloq15-header",
+    "proofId": "basel-problem-oq-15",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "concept",
+    "title": "Module Header and Problem Setup",
+    "content": "The open question, posed by the parent $\\zeta(6)$ entry, asks for $\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$, the degree-8 even-zeta value, plus the ratio chain $\\zeta(2k)/\\pi^{2k}$. Euler's 1740 formula $\\zeta(2k) = (-1)^{k+1} B_{2k}(2\\pi)^{2k}/(2(2k)!)$ gives this at $k=4$ using $B_8 = -1/30$. Mathlib formalizes the underlying Hurwitz-zeta computation as `hasSum_zeta_nat`, but stops its packaged Bernoulli evaluations at $B_4$ — so the entry must first compute $B_6$ and then $B_8$."
+  },
+  {
+    "id": "baseloq15-bernoulli-eight",
+    "proofId": "basel-problem-oq-15",
+    "range": {
+      "startLine": 35,
+      "endLine": 54
+    },
+    "type": "theorem",
+    "title": "The Eighth Bernoulli Number B₈ = −1/30",
+    "content": "`bernoulli_eight` proves $B_8 = -1/30$. Mathlib packages `bernoulli'_two` $(=1/6)$ and `bernoulli'_four` $(=-1/30)$ but neither `bernoulli'_six` nor `bernoulli'_eight`, so we expand the defining recurrence $B_n = 1 - \\sum_{k<n}\\binom{n}{k}B_k/(n+1-k)$ over the range $k = 0,\\dots,7$. The odd terms $B_3 = B_5 = B_7 = 0$ come from `bernoulli'_eq_zero_of_odd`; the one value past Mathlib's packaging, $B_6 = 1/42$, is computed in-line from the range-6 recurrence; and the explicit binomials $\\binom{8}{1},\\dots,\\binom{8}{7} = 8,28,56,70,56,28,8$ are supplied to `norm_num`. Reaching $B_8$ thus unrolls the recurrence twice — the computational step the gallery adds over a pure Mathlib lookup."
+  },
+  {
+    "id": "baseloq15-zeta-eight",
+    "proofId": "basel-problem-oq-15",
+    "range": {
+      "startLine": 56,
+      "endLine": 80
+    },
+    "type": "theorem",
+    "title": "The Value ζ(8) = π⁸/9450",
+    "content": "`tsum_one_div_nat_pow_eight` is the headline result $\\sum' n,\\ 1/n^8 = \\pi^8/9450$. It comes from `hasSum_one_div_nat_pow_eight`, the $k=4$ instance of `hasSum_zeta_nat`: substituting $B_8 = -1/30$ and $8! = 40320$ into $(-1)^5\\cdot 2^7\\cdot\\pi^8\\cdot B_8/8!$ gives $128\\cdot(1/30)/40320 = 1/9450$. `riemannZeta_eight_eq` records the same value for the analytically continued zeta, $\\zeta(8) = \\pi^8/9450$ over $\\mathbb{C}$, via `riemannZeta_two_mul_nat`."
+  },
+  {
+    "id": "baseloq15-ratio",
+    "proofId": "basel-problem-oq-15",
+    "range": {
+      "startLine": 82,
+      "endLine": 90
+    },
+    "type": "theorem",
+    "title": "Euler's π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
+    "content": "`tsum_eight_div_tsum_two_fourth` divides the even-zeta values: $\\zeta(8)/\\zeta(2)^4 = (\\pi^8/9450)/(\\pi^2/6)^4 = (\\pi^8/9450)/(\\pi^8/1296) = 1296/9450 = 24/175$. The $\\pi$ cancels entirely, leaving a rational determined only by the Bernoulli numbers $B_2 = 1/6$ and $B_8 = -1/30$. This continues the chain $\\zeta(4)/\\zeta(2)^2 = 2/5$ and $\\zeta(6)/\\zeta(2)^3 = 8/35$, the degree-8 link of the requested ratio chain."
+  }
+]

--- a/src/data/proofs/basel-problem-oq-15/meta.json
+++ b/src/data/proofs/basel-problem-oq-15/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "basel-problem-oq-15",
+  "title": "ζ(8) = π⁸/9450: the Degree-8 Basel Value and the π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
+  "slug": "basel-problem-oq-15",
+  "description": "The value ζ(8) = ∑' n, 1/n⁸ = π⁸/9450, the next even-argument zeta value after ζ(2) = π²/6, ζ(4) = π⁴/90, and ζ(6) = π⁶/945, obtained by instantiating Mathlib's even-argument zeta formula at k = 4. Because Mathlib packages no bernoulli'_six or bernoulli'_eight, the eighth Bernoulli number B₈ = −1/30 is computed from the defining recurrence (in turn computing B₆ = 1/42). Includes the riemannZeta 8 value and Euler's dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175.",
+  "meta": {
+    "author": "Euler (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
+    "date": "1740",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "analysis",
+      "basel-problem",
+      "riemann-zeta",
+      "bernoulli-numbers",
+      "euler",
+      "extension",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BaselProblemOQ15.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "hasSum_zeta_nat",
+        "description": "HasSum (fun n => 1/n^(2k)) ((-1)^(k+1)·2^(2k-1)·π^(2k)·B_{2k}/(2k)!) — the general even-argument zeta formula",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      },
+      {
+        "theorem": "riemannZeta_two_mul_nat",
+        "description": "riemannZeta (2k) = (-1)^(k+1)·2^(2k-1)·π^(2k)·B_{2k}/(2k)! — the same formula for the analytically continued zeta",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "bernoulli'_eq_zero_of_odd",
+        "description": "Odd Bernoulli numbers greater than 1 vanish — used to compute B₈ via the recurrence",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "bernoulli'_def",
+        "description": "The defining recurrence B'_n = 1 − ∑_{k<n} C(n,k)·B'_k/(n+1−k) — expanded to compute B₆ and B₈",
+        "module": "Mathlib.NumberTheory.Bernoulli"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "HasSum (fun n => 1/n²) (π²/6) — the classical Basel value, used in the ratio",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      }
+    ],
+    "originalContributions": [
+      "bernoulli_eight: the eighth Bernoulli number B₈ = −1/30, computed from the bernoulli'_def recurrence; this requires first computing B₆ = 1/42 (Mathlib packages only bernoulli'_two and bernoulli'_four)",
+      "hasSum_one_div_nat_pow_eight: HasSum (fun n => 1/n⁸) (π⁸/9450), the k = 4 instance of the even-zeta formula",
+      "tsum_one_div_nat_pow_eight: the headline tsum value ∑' n, 1/n⁸ = π⁸/9450",
+      "riemannZeta_eight_eq: the riemannZeta 8 = π⁸/9450 value over ℂ via riemannZeta_two_mul_nat",
+      "tsum_eight_div_tsum_two_fourth: Euler's dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175, π cancelling between the even-zeta values"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 90,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. #print axioms reports only [propext, Classical.choice, Quot.sound] — no native_decide, no sorryAx.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 5,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Euler solved the Basel problem ζ(2) = ∑ 1/n² = π²/6 in 1735 and by 1740 had the full even family ζ(2k) = (−1)^{k+1} B_{2k} (2π)^{2k} / (2(2k)!), where B_{2k} are the Bernoulli numbers. At k = 4 this gives ζ(8) = π⁸/9450, with B₈ = −1/30. Each even-zeta value is a rational multiple of a power of π and hence transcendental; the odd values ζ(2k+1) remain far less understood (ζ(3) was proved irrational by Apéry in 1978, but ζ(5), ζ(7), … are still open). The dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175 is the π-free shadow of the formula at degree 8, depending only on the Bernoulli numbers B₂ = 1/6 and B₈ = −1/30.",
+    "problemStatement": "**Open Question (basel-problem-oq-15)**: Formalize ∑' n, 1/n⁸ = π⁸/9450 — the degree-8 even-zeta value requested by the parent ζ(6) entry ('Formalize ζ(8) = π⁸/9450 by computing B₈ = −1/30 from the recurrence') — by instantiating Mathlib's even-argument zeta formula at k = 4, together with the ratio chain ζ(2k)/π^{2k}.\n\n**Result**: tsum_one_div_nat_pow_eight proves ∑' n, 1/n⁸ = π⁸/9450. The companion riemannZeta_eight_eq gives riemannZeta 8 = π⁸/9450, and tsum_eight_div_tsum_two_fourth derives Euler's dimensionless ratio ζ(8)/ζ(2)⁴ = 24/175.",
+    "text": "The value ζ(8) = ∑' n, 1/n⁸ = π⁸/9450, the degree-8 analogue of the Basel problem, with the riemannZeta 8 value and the π-free Euler ratio ζ(8)/ζ(2)⁴ = 24/175.",
+    "proofStrategy": "**Proof Strategy: compute B₈, then specialise the even-zeta formula.**\n\n1. Mathlib packages `bernoulli'_two` (= 1/6) and `bernoulli'_four` (= −1/30) but neither `bernoulli'_six` nor `bernoulli'_eight`. We compute `bernoulli 8 = −1/30` from the defining recurrence `bernoulli'_def`, expanding the range-8 sum: the odd indices `bernoulli' 3, 5, 7` vanish (`bernoulli'_eq_zero_of_odd`), `bernoulli' 0,1,2,4` are reduced by `norm_num`, and the one remaining value `bernoulli' 6 = 1/42` is itself computed in-line from the range-6 recurrence. The explicit binomials C(8,k) are supplied to `norm_num`.\n2. `hasSum_zeta_nat` at k = 4 gives `HasSum (fun n => 1/n⁸) ((−1)⁵·2⁷·π⁸·B₈/8!)`. Substituting B₈ = −1/30 and 8! = 40320 reduces 128·(1/30)/40320 = 128/1209600 = 1/9450, so the sum is π⁸/9450; `.tsum_eq` gives the tsum value.\n3. `riemannZeta_two_mul_nat` at k = 4 gives the same value for the analytically-continued zeta at 8.\n4. For the ratio, rewrite ∑ 1/n⁸ = π⁸/9450 and ∑ 1/n² = π²/6; the fourth-power denominator is π⁸/1296, and (π⁸/9450)/(π⁸/1296) = 1296/9450 = 24/175 after `field_simp` (π ≠ 0) and `ring`.",
+    "keyInsights": [
+      "**Even zeta values are rational multiples of powers of π.** ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!); at k = 4, B₈ = −1/30 yields ζ(8) = π⁸/9450.",
+      "**The missing Bernoulli numbers are the real work.** Mathlib stops its packaged Bernoulli evaluations at B₄; reaching B₈ = −1/30 forces the recurrence to be unrolled twice (B₆ = 1/42 as an intermediate), the one step the gallery adds over a pure Mathlib lookup.",
+      "**The ratio ζ(8)/ζ(2)⁴ is π-free.** Dividing the even-zeta values cancels π entirely, leaving the rational 24/175 — a structural fact about the Bernoulli numbers, not about π. It continues the chain ζ(4)/ζ(2)² = 2/5, ζ(6)/ζ(2)³ = 8/35."
+    ],
+    "prerequisites": [
+      "Infinite sums / tsum and HasSum in Mathlib",
+      "The Riemann zeta function and its even-argument values",
+      "Bernoulli numbers and their defining recurrence",
+      "The classical Basel value ζ(2) = π²/6"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Module docstring stating the open question and approach, Mathlib import, BaselProblemOQ15 namespace, and Real/BigOperators opens.",
+      "mathContext": "The degree-8 Basel value ζ(8) = ∑_{n≥1} 1/n⁸ = π⁸/9450, the k=4 case of Euler's even-zeta formula."
+    },
+    {
+      "id": "bernoulli-eight",
+      "title": "The Eighth Bernoulli Number B₈ = −1/30",
+      "startLine": 35,
+      "endLine": 54,
+      "summary": "bernoulli_eight computes B₈ = −1/30 from the defining recurrence bernoulli'_def, using bernoulli'_eq_zero_of_odd for B₃ = B₅ = B₇ = 0, an in-line computation of B₆ = 1/42, and the explicit binomial coefficients C(8,k).",
+      "mathContext": "$B_8 = -1/30$, computed from $B_n = 1 - \\sum_{k<n}\\binom{n}{k}B_k/(n+1-k)$; reaching it requires the intermediate $B_6 = 1/42$, since Mathlib packages only $B_2, B_4$."
+    },
+    {
+      "id": "zeta-eight",
+      "title": "The Value ζ(8) = π⁸/9450",
+      "startLine": 56,
+      "endLine": 80,
+      "summary": "hasSum_one_div_nat_pow_eight (HasSum form), tsum_one_div_nat_pow_eight (the headline tsum value ∑' n, 1/n⁸ = π⁸/9450), and riemannZeta_eight_eq (the riemannZeta 8 value over ℂ).",
+      "mathContext": "$\\sum_{n=1}^\\infty 1/n^8 = \\pi^8/9450$ and $\\zeta(8) = \\pi^8/9450$, from Mathlib's `hasSum_zeta_nat` and `riemannZeta_two_mul_nat` at k = 4."
+    },
+    {
+      "id": "ratio",
+      "title": "Euler's π-free Ratio ζ(8)/ζ(2)⁴ = 24/175",
+      "startLine": 82,
+      "endLine": 90,
+      "summary": "tsum_eight_div_tsum_two_fourth divides ζ(8) by ζ(2)⁴, cancelling π to leave the rational 24/175.",
+      "mathContext": "$\\zeta(8)/\\zeta(2)^4 = (\\pi^8/9450)/(\\pi^2/6)^4 = (\\pi^8/9450)/(\\pi^8/1296) = 1296/9450 = 24/175$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "basel-problem-oq-08-oq-02",
+      "relationship": "extends",
+      "description": "The parent entry proves ζ(6) = π⁶/945 and lists 'Formalize ζ(8) = π⁸/9450 by computing B₈ = −1/30 from the recurrence' as an open question; this entry answers it"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "The Basel problem proves ζ(2) = π²/6; this entry is the degree-8 analogue ζ(8) = π⁸/9450, and the ratio theorem combines both even-zeta values"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) formalization of ζ(8) = ∑' n, 1/n⁸ = π⁸/9450, the degree-8 Basel value, together with the eighth Bernoulli number B₈ = −1/30, the riemannZeta 8 value, and Euler's π-free ratio ζ(8)/ζ(2)⁴ = 24/175. Directly answers the open question posed by the parent ζ(6) entry.",
+    "implications": "Establishes the next even-zeta value in the gallery after ζ(2), ζ(4), and ζ(6). Computing B₈ from the recurrence (via the intermediate B₆) shows how to push two steps past Mathlib's packaged Bernoulli evaluations, the template for ζ(10), ζ(12), …. The π-free ratio ζ(8)/ζ(2)⁴ = 24/175 isolates the Bernoulli-number content of the even-zeta formula, independent of the transcendence of π.",
+    "openQuestions": [
+      "Formalize the general even-zeta formula ζ(2k) = (−1)^{k+1} B_{2k}(2π)^{2k}/(2(2k)!) as a single Lean statement, removing the need to compute each B_{2k} separately.",
+      "Formalize ζ(10) = π¹⁰/93555 by computing B₁₀ = 5/66 from the recurrence."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "BigOperators"
+    ],
+    "namespace": "BaselProblemOQ15",
+    "lineCount": 90,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ15.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Euler, Leonhard",
+      "title": "De summis serierum reciprocarum",
+      "year": "1740",
+      "venue": "Commentarii academiae scientiarum Petropolitanae 7, pp. 123–134",
+      "note": "Derives the even-zeta values ζ(2k) as rational multiples of π^{2k}, including ζ(8) = π⁸/9450"
+    },
+    {
+      "authors": "Apéry, Roger",
+      "title": "Irrationalité de ζ(2) et ζ(3)",
+      "year": "1979",
+      "venue": "Astérisque 61, pp. 11–13",
+      "note": "Highlights the contrast: odd zeta values are arithmetically hard, while even ones (like ζ(8)) are explicit rational multiples of powers of π"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes **ζ(8) = ∑' n, 1/n⁸ = π⁸/9450**, the degree-8 even-argument zeta value — the next member of the Basel family after ζ(2)=π²/6, ζ(4)=π⁴/90, ζ(6)=π⁶/945. This directly answers the parent ζ(6) entry's *own* listed open question: *"Formalize ζ(8) = π⁸/9450 by computing B₈ = −1/30 from the recurrence."*

**Problem**: `basel-problem-oq-15` (pool: tier B, tractability 6).

## Results (`BaselProblemOQ15`, 5 theorems, 0 defs)

| Theorem | Statement |
|---|---|
| `bernoulli_eight` | B₈ = −1/30, from the `bernoulli'_def` recurrence |
| `hasSum_one_div_nat_pow_eight` | `HasSum (fun n => 1/n⁸) (π⁸/9450)` |
| `tsum_one_div_nat_pow_eight` | ∑' n, 1/n⁸ = π⁸/9450 |
| `riemannZeta_eight_eq` | riemannZeta 8 = π⁸/9450 over ℂ |
| `tsum_eight_div_tsum_two_fourth` | ζ(8)/ζ(2)⁴ = 24/175 (π-free) |

## Substance

Mathlib provides the general even-zeta formula `hasSum_zeta_nat`/`riemannZeta_two_mul_nat` but packages explicit Bernoulli values only up to B₄. The real work is **B₈ = −1/30**: reaching it unrolls the defining recurrence twice (the intermediate B₆ = 1/42 is computed in-line, since Mathlib has no `bernoulli'_six`/`bernoulli'_eight`). Substituting k=4: 2⁷·(−1/30)/8! = 128/1209600 = 1/9450. The π-free ratio ζ(8)/ζ(2)⁴ = 1296/9450 = 24/175 continues the chain ζ(4)/ζ(2)²=2/5, ζ(6)/ζ(2)³=8/35.

## Verification

- Type-checked on host against Mathlib **v4.26.0** oleans (Docker was down): **0 sorries, 0 errors**.
- `#print axioms` on all four headline theorems: only `[propext, Classical.choice, Quot.sound]` — **no `native_decide`, no `sorryAx`**. Genuinely 0-axiom.
- `pnpm annotations:validate`: entry passes (annotation line-ranges resolve to Lean constructs).

## Files
- `proofs/Proofs/BaselProblemOQ15.lean` (new, 90 L)
- `proofs/Proofs.lean` (registered module)
- `src/data/proofs/basel-problem-oq-15/{meta,annotations}.json` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)