### PR TITLE
Enrich Rank, Nullity, and Invertibility Are Similarity Invariants

### DIFF
--- a/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/meta.json
+++ b/src/data/proofs/matrix-similarity-invariants-oq-01-oq-01/meta.json
@@ -138,8 +138,9 @@
   ],
   "crossReferences": [
     {
-      "id": "matrix-similarity-invariants-oq-01",
-      "note": "Parent entry: determinant, trace, and characteristic polynomial as similarity invariants; defines the Similar relation reused here"
+      "targetId": "matrix-similarity-invariants-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry: determinant, trace, and characteristic polynomial as similarity invariants; defines the Similar relation reused here. This entry adds the structural invariants (rank, nullity, invertibility) on top of those scalar ones."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for `matrix-similarity-invariants-oq-01-oq-01` (quality 43, pass 0).

## Annotations (new)
The entry had **no `annotations.json`** — added 6 annotations covering every section, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`:
- Overview: structural vs scalar invariants
- The `Similar` relation and its groupoid (refl/symm) structure
- Invertibility invariance (cancelling units, no determinant needed)
- Rank invariance (conceptual, valid over any commutative ring)
- Nullity, rank–nullity, and the trivial-kernel ⇔ full-rank bridge
- The packaged `Similar.invariants` statement

## meta.json fix
- Fixed a **malformed `crossReferences` entry**: it used `{id, note}`, which match no field of the `CrossReference` type (`relationship` is required; the slug field is `targetId`/`proofId`), so the cross-link rendered empty. Converted to `{targetId, relationship, description}`.

## Integrity
No status/badge/axiom changes. Remains `status: verified`, `badge: mathlib` (Tier B), `axiomCount: 0`. Enrichment is additive plus one schema fix.

`pnpm build` passes.