### PR TITLE
Enrich Abel-Ruffini (2,2) survival coincidence: add index.ts + deepen annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 53 },
     "type": "concept",
     "title": "Two faces of the boundary: escape vs survival",
-    "content": "The parent file measured where the solvable range $\\{0,1,2,3,4\\}$ first **breaks** under the two type operations — additive escape at $5=2+3$, multiplicative escape at $6=2\\cdot 3$ (the value $5$ is prime, so unreachable as a product of factors $\\le 4$). This file measures the dual: where the range **holds**, i.e. which pairs of nontrivial solvable pieces still produce a solvable composite. The answer is symmetric where the escape was not: for both $\\oplus$ and $\\times$ the only surviving nontrivial pair is $(2,2)$, and since $2+2=4=2\\cdot 2$ both survivors land on the single degree $4$."
+    "content": "The parent file measured where the solvable range $\\{0,1,2,3,4\\}$ first **breaks** under the two type operations — additive escape at $5=2+3$, multiplicative escape at $6=2\\cdot 3$ (the value $5$ is prime, so unreachable as a product of factors $\\le 4$). This file measures the dual: where the range **holds**, i.e. which pairs of nontrivial solvable pieces still produce a solvable composite. The answer is symmetric where the escape was not: for both $\\oplus$ and $\\times$ the only surviving nontrivial pair is $(2,2)$, and since $2+2=4=2\\cdot 2$ both survivors land on the single degree $4$.",
+    "mathContext": "Escape (asymmetric): additive $5=2+3$ vs multiplicative $6=2\\cdot3$. Survival (symmetric): both operations preserve solvability of nontrivial pieces only at $(|\\alpha|,|\\beta|)=(2,2)$, where $2+2=4=2\\cdot2$.",
+    "significance": "key",
+    "relatedConcepts": ["preservation vs escape duality", "solvable range closure", "S₄ as largest solvable Sₙ"],
+    "prerequisites": ["solvable groups", "Abel–Ruffini threshold", "cardinality of finite types"]
   },
   {
     "id": "ann-nontrivial-range",
@@ -13,7 +17,11 @@
     "range": { "startLine": 54, "endLine": 67 },
     "type": "insight",
     "title": "A nontrivial solvable piece lives in {2,3,4}",
-    "content": "`card_nontrivial_solvable_mem` intersects the intrinsic threshold $\\mathrm{IsSolvable}(\\mathrm{Perm}\\,\\alpha)\\iff |\\alpha|\\le 4$ with the nontriviality hypothesis $|\\alpha|\\ge 2$. The degenerate $0$- and $1$-point pieces (where $\\mathrm{Perm}$ is trivial and the composite collapses to the other piece) are excluded, leaving exactly the solvable cardinalities that carry information: $2$, $3$, and $4$. These are the only inputs for which the preservation question is substantive."
+    "content": "`card_nontrivial_solvable_mem` intersects the intrinsic threshold $\\mathrm{IsSolvable}(\\mathrm{Perm}\\,\\alpha)\\iff |\\alpha|\\le 4$ with the nontriviality hypothesis $|\\alpha|\\ge 2$. The degenerate $0$- and $1$-point pieces (where $\\mathrm{Perm}$ is trivial and the composite collapses to the other piece) are excluded, leaving exactly the solvable cardinalities that carry information: $2$, $3$, and $4$. These are the only inputs for which the preservation question is substantive.",
+    "mathContext": "$|\\alpha|\\ge 2 \\wedge \\mathrm{IsSolvable}(\\mathrm{Perm}\\,\\alpha) \\iff |\\alpha|\\in\\{2,3,4\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["nontriviality hypothesis", "solvability threshold", "degenerate cases"],
+    "prerequisites": ["permutation group on a finite type", "solvability iff card ≤ 4"]
   },
   {
     "id": "ann-additive-survivor",
@@ -21,7 +29,11 @@
     "range": { "startLine": 68, "endLine": 84 },
     "type": "insight",
     "title": "The unique additive survivor is (2,2)",
-    "content": "`perm_sum_nontrivial_solvable_iff` rewrites the union threshold to the **linear** constraint $|\\alpha|+|\\beta|\\le 4$. With both summands at least $2$, the only solution is $|\\alpha|=|\\beta|=2$: any larger summand already gives $2+3=5$, the Abel–Ruffini degree. So $\\oplus$ preserves solvability of two nontrivial pieces in exactly one configuration, the $2+2=4$ disjoint union ($S_4$). The proof closes by `omega` once the threshold is unfolded."
+    "content": "`perm_sum_nontrivial_solvable_iff` rewrites the union threshold to the **linear** constraint $|\\alpha|+|\\beta|\\le 4$. With both summands at least $2$, the only solution is $|\\alpha|=|\\beta|=2$: any larger summand already gives $2+3=5$, the Abel–Ruffini degree. So $\\oplus$ preserves solvability of two nontrivial pieces in exactly one configuration, the $2+2=4$ disjoint union ($S_4$). The proof closes by `omega` once the threshold is unfolded.",
+    "mathContext": "$|\\alpha|,|\\beta|\\ge 2 \\wedge |\\alpha|+|\\beta|\\le 4 \\iff |\\alpha|=|\\beta|=2$; the composite is then $S_4$.",
+    "significance": "key",
+    "relatedConcepts": ["disjoint union cardinality", "linear constraint", "omega tactic"],
+    "prerequisites": ["Fintype.card_sum", "natural-number arithmetic"]
   },
   {
     "id": "ann-multiplicative-survivor",
@@ -29,15 +41,23 @@
     "range": { "startLine": 85, "endLine": 118 },
     "type": "technique",
     "title": "The unique multiplicative survivor, forced factor-by-factor",
-    "content": "`perm_prod_nontrivial_solvable_iff` faces the **nonlinear** cap $|\\alpha|\\cdot|\\beta|\\le 4$, which `omega` cannot read directly. The cap is forced one factor at a time: if either factor reached $3$ then `Nat.mul_le_mul` gives $3\\cdot 2 = 6 > 4$ (resp. $2\\cdot 3$), contradicting the bound, so each factor is $\\le 2$; combined with $\\ge 2$ both equal $2$. The survivor is again $(2,2)$ — the same pair as the additive case, even though the obstruction it dodges sits at $6$, not $5$."
+    "content": "`perm_prod_nontrivial_solvable_iff` faces the **nonlinear** cap $|\\alpha|\\cdot|\\beta|\\le 4$, which `omega` cannot read directly. The cap is forced one factor at a time: if either factor reached $3$ then `Nat.mul_le_mul` gives $3\\cdot 2 = 6 > 4$ (resp. $2\\cdot 3$), contradicting the bound, so each factor is $\\le 2$; combined with $\\ge 2$ both equal $2$. The survivor is again $(2,2)$ — the same pair as the additive case, even though the obstruction it dodges sits at $6$, not $5$.",
+    "mathContext": "$|\\alpha|,|\\beta|\\ge 2 \\wedge |\\alpha|\\cdot|\\beta|\\le 4 \\iff |\\alpha|=|\\beta|=2$; a factor $\\ge 3$ forces the product $\\ge 6$ via $\\mathrm{Nat.mul\\_le\\_mul}$.",
+    "significance": "key",
+    "relatedConcepts": ["Cartesian product cardinality", "nonlinear constraint", "Nat.mul_le_mul"],
+    "prerequisites": ["Fintype.card_prod", "monotonicity of multiplication"]
   },
   {
     "id": "ann-survival-coincides",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 119, "endLine": 156 },
-    "type": "key-insight",
+    "type": "insight",
     "title": "Survival coincides though escape diverges",
-    "content": "`sum_prod_survival_coincide` chains the two equivalences: both reduce solvability of the nontrivial composite to the **same** condition $|\\alpha|=|\\beta|=2$, so $\\mathrm{IsSolvable}(\\mathrm{Perm}(\\alpha\\oplus\\beta))\\iff\\mathrm{IsSolvable}(\\mathrm{Perm}(\\alpha\\times\\beta))$ for nontrivial solvable pieces. This is the preservation-side counterpart to the parent's escape-cost **asymmetry**: the operations disagree on which degree they first break at ($5$ vs $6$) but agree exactly on which nontrivial pairs survive. `unique_survivor_characterization` packages either-composite-solvable $\\iff (2,2)$."
+    "content": "`sum_prod_survival_coincide` chains the two equivalences: both reduce solvability of the nontrivial composite to the **same** condition $|\\alpha|=|\\beta|=2$, so $\\mathrm{IsSolvable}(\\mathrm{Perm}(\\alpha\\oplus\\beta))\\iff\\mathrm{IsSolvable}(\\mathrm{Perm}(\\alpha\\times\\beta))$ for nontrivial solvable pieces. This is the preservation-side counterpart to the parent's escape-cost **asymmetry**: the operations disagree on which degree they first break at ($5$ vs $6$) but agree exactly on which nontrivial pairs survive. `unique_survivor_characterization` packages either-composite-solvable $\\iff (2,2)$.",
+    "mathContext": "$\\mathrm{IsSolvable}(\\mathrm{Perm}(\\alpha\\oplus\\beta)) \\iff \\mathrm{IsSolvable}(\\mathrm{Perm}(\\alpha\\times\\beta))$ for nontrivial solvable $\\alpha,\\beta$, both $\\iff |\\alpha|=|\\beta|=2$.",
+    "significance": "key",
+    "relatedConcepts": ["logical equivalence", "preservation symmetry", "escape asymmetry contrast"],
+    "prerequisites": ["the two threshold equivalences", "transitivity of iff"]
   },
   {
     "id": "ann-survivor-at-four",
@@ -45,14 +65,22 @@
     "range": { "startLine": 157, "endLine": 186 },
     "type": "insight",
     "title": "The survivor at degree 4 = S₄, one step below the threshold",
-    "content": "`survivor_at_four` exhibits the concrete survivor: both $\\mathrm{Perm}(\\mathrm{Fin}\\,2\\oplus\\mathrm{Fin}\\,2)$ and $\\mathrm{Perm}(\\mathrm{Fin}\\,2\\times\\mathrm{Fin}\\,2)$ are solvable, with $2+2=4=2\\cdot 2$. Both composites are $S_4$, the largest solvable symmetric group, realised simultaneously as a sum and as a product of two $2$-point systems. `survivor_degree_below_threshold` notes the survivor sits at $4$, and $4+1=5$ reaches the unsolvable $\\mathrm{Perm}(\\mathrm{Fin}\\,5)$ — the last solvable rung before Abel–Ruffini. The coincidence $2+2=2\\cdot 2$ is precisely why the additive and multiplicative survivors collapse to one degree."
+    "content": "`survivor_at_four` exhibits the concrete survivor: both $\\mathrm{Perm}(\\mathrm{Fin}\\,2\\oplus\\mathrm{Fin}\\,2)$ and $\\mathrm{Perm}(\\mathrm{Fin}\\,2\\times\\mathrm{Fin}\\,2)$ are solvable, with $2+2=4=2\\cdot 2$. Both composites are $S_4$, the largest solvable symmetric group, realised simultaneously as a sum and as a product of two $2$-point systems. `survivor_degree_below_threshold` notes the survivor sits at $4$, and $4+1=5$ reaches the unsolvable $\\mathrm{Perm}(\\mathrm{Fin}\\,5)$ — the last solvable rung before Abel–Ruffini. The coincidence $2+2=2\\cdot 2$ is precisely why the additive and multiplicative survivors collapse to one degree.",
+    "mathContext": "$2+2 = 4 = 2\\cdot2$, so $\\mathrm{Perm}(\\mathrm{Fin}\\,2\\oplus\\mathrm{Fin}\\,2) \\cong \\mathrm{Perm}(\\mathrm{Fin}\\,2\\times\\mathrm{Fin}\\,2) \\cong S_4$, solvable; $4$ is the top solvable degree ($5$ is unsolvable).",
+    "significance": "supporting",
+    "relatedConcepts": ["S₄", "largest solvable symmetric group", "fixed point 2+2=2·2"],
+    "prerequisites": ["concrete Fin witnesses", "Fintype.card_fin"]
   },
   {
     "id": "ann-escape-vs-survival",
     "proofId": "abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01",
     "range": { "startLine": 187, "endLine": 218 },
-    "type": "key-insight",
+    "type": "insight",
     "title": "Escape diverges, survival coincides — side by side",
-    "content": "`escape_diverges_survival_coincides` states both faces at once. **Escape (asymmetric):** there is a nontrivial additive escape at $5$ ($2+3$, both $\\le 4$) but no product of two factors $\\ge 2$ equals $5$, so the least nontrivial multiplicative escape is $6 > 5$. **Survival (symmetric):** for nontrivial solvable pieces the sum-composite is solvable iff the product-composite is, both exactly on $(2,2)$. Where the solvable range $\\{\\le 4\\}$ breaks depends on the operation; where it holds does not."
+    "content": "`escape_diverges_survival_coincides` states both faces at once. **Escape (asymmetric):** there is a nontrivial additive escape at $5$ ($2+3$, both $\\le 4$) but no product of two factors $\\ge 2$ equals $5$, so the least nontrivial multiplicative escape is $6 > 5$. **Survival (symmetric):** for nontrivial solvable pieces the sum-composite is solvable iff the product-composite is, both exactly on $(2,2)$. Where the solvable range $\\{\\le 4\\}$ breaks depends on the operation; where it holds does not.",
+    "mathContext": "Escape: additive $5$, multiplicative $\\ge 6$ (asymmetric). Survival: $\\mathrm{Solv}(\\mathrm{Perm}(\\alpha\\oplus\\beta)) \\iff \\mathrm{Solv}(\\mathrm{Perm}(\\alpha\\times\\beta))$ on nontrivial pieces, both $(2,2)$ (symmetric).",
+    "significance": "key",
+    "relatedConcepts": ["duality of breaking vs holding", "operation-dependence", "Abel–Ruffini boundary"],
+    "prerequisites": ["escape-cost asymmetry (parent)", "survival coincidence"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Proof,
+  annotations: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` (Escape Diverges, Survival Coincides: (2,2) Is the Unique Preservation Survivor).

## Changes
- **Created `index.ts`** — directory had only meta.json + annotations.json, so the page rendered 'proof not found'. Vite entry point now present.
- **Deepened all 7 annotations** — each previously had only `content`; added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` covering the escape/survival duality, the {2,3,4} nontrivial range, the unique additive and multiplicative survivors, the survival coincidence, and the S₄ realization.
- **Normalized** two annotations' non-standard `key-insight` type to `insight`.

## Verification
- `pnpm build` passes; JSON validated.
- Line ranges checked against the Lean file; `verified`/0-axiom/`mathlib` Tier-B status confirmed (combinatorial packaging over Mathlib's S₅ non-solvability).