### PR TITLE
Enrich Abel-Ruffini boundary under ⊕ and × (parent): add index.ts + deepen annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -5,7 +5,11 @@
     "range": { "startLine": 1, "endLine": 56 },
     "type": "concept",
     "title": "The threshold meets the algebra of finite types",
-    "content": "The ancestors reduced solvability of $S_\\alpha$ to a single arithmetic fact, $\\mathrm{IsSolvable}(S_\\alpha) \\iff |\\alpha| \\le 4$, and split $\\mathbb{N}$ into a solvable down-set $\\{\\le 4\\}$ and an unsolvable up-set $\\{\\ge 5\\}$. Here we ask how that threshold behaves under the two ways of building bigger finite types: disjoint union $\\alpha \\oplus \\beta$ (with $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$) and product $\\alpha \\times \\beta$ (with $|\\alpha\\times\\beta| = |\\alpha|\\cdot|\\beta|$). The threshold turns each into an arithmetic side-condition — and the two operations turn out to sit on **opposite sides** of the Abel–Ruffini boundary."
+    "content": "The ancestors reduced solvability of $S_\\alpha$ to a single arithmetic fact, $\\mathrm{IsSolvable}(S_\\alpha) \\iff |\\alpha| \\le 4$, and split $\\mathbb{N}$ into a solvable down-set $\\{\\le 4\\}$ and an unsolvable up-set $\\{\\ge 5\\}$. Here we ask how that threshold behaves under the two ways of building bigger finite types: disjoint union $\\alpha \\oplus \\beta$ (with $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$) and product $\\alpha \\times \\beta$ (with $|\\alpha\\times\\beta| = |\\alpha|\\cdot|\\beta|$). The threshold turns each into an arithmetic side-condition — and the two operations turn out to sit on **opposite sides** of the Abel–Ruffini boundary.",
+    "mathContext": "$\\mathrm{IsSolvable}(\\mathrm{Perm}\\,\\alpha) \\iff |\\alpha| \\le 4$; $|\\alpha\\oplus\\beta| = |\\alpha|+|\\beta|$, $|\\alpha\\times\\beta| = |\\alpha|\\cdot|\\beta|$.",
+    "significance": "key",
+    "relatedConcepts": ["solvability threshold", "monoidal structures on finite types", "down-set/up-set partition"],
+    "prerequisites": ["solvable groups", "Abel–Ruffini theorem", "cardinality of finite types"]
   },
   {
     "id": "ann-sum-threshold",
@@ -13,7 +17,11 @@
     "range": { "startLine": 64, "endLine": 70 },
     "type": "technique",
     "title": "Rewriting the threshold through a cardinality formula",
-    "content": "`perm_sum_solvable_iff` is one `rw`: apply the intrinsic threshold `perm_solvable_iff_card` to $S_{\\alpha\\oplus\\beta}$, then `Fintype.card_sum` evaluates $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$. The result\n$$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha| + |\\beta| \\le 4$$\nis the disjoint-union threshold as an **additive** condition. `perm_prod_solvable_iff` is the same proof with `Fintype.card_prod`, yielding the **multiplicative** condition $|\\alpha|\\cdot|\\beta| \\le 4$."
+    "content": "`perm_sum_solvable_iff` is one `rw`: apply the intrinsic threshold `perm_solvable_iff_card` to $S_{\\alpha\\oplus\\beta}$, then `Fintype.card_sum` evaluates $|\\alpha\\oplus\\beta| = |\\alpha| + |\\beta|$. The result\n$$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha| + |\\beta| \\le 4$$\nis the disjoint-union threshold as an **additive** condition. `perm_prod_solvable_iff` is the same proof with `Fintype.card_prod`, yielding the **multiplicative** condition $|\\alpha|\\cdot|\\beta| \\le 4$.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_{\\alpha\\oplus\\beta}) \\iff |\\alpha|+|\\beta| \\le 4$ and $\\mathrm{IsSolvable}(S_{\\alpha\\times\\beta}) \\iff |\\alpha|\\cdot|\\beta| \\le 4$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fintype.card_sum", "Fintype.card_prod", "rewriting tactic"],
+    "prerequisites": ["intrinsic solvability threshold", "cardinality formulas"]
   },
   {
     "id": "ann-products-reflect",
@@ -21,7 +29,11 @@
     "range": { "startLine": 96, "endLine": 108 },
     "type": "insight",
     "title": "Products reflect solvability downward",
-    "content": "A nonempty second factor only enlarges the carrier: $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$ whenever $|\\beta| \\ge 1$ (`Nat.le_mul_of_pos_right` with `Fintype.card_pos`). So if $|\\alpha|\\cdot|\\beta| \\le 4$ then already $|\\alpha| \\le 4$, and `perm_solvable_of_prod_solvable` concludes $\\mathrm{IsSolvable}(S_\\alpha)$. A Cartesian factor of a solvable permutation-product is **always** solvable — the product operation can never hide an unsolvable factor. The `omega` step is honest: with the product written as a single atom, $|\\alpha| \\le \\text{atom} \\le 4$ is linear."
+    "content": "A nonempty second factor only enlarges the carrier: $|\\alpha| \\le |\\alpha|\\cdot|\\beta|$ whenever $|\\beta| \\ge 1$ (`Nat.le_mul_of_pos_right` with `Fintype.card_pos`). So if $|\\alpha|\\cdot|\\beta| \\le 4$ then already $|\\alpha| \\le 4$, and `perm_solvable_of_prod_solvable` concludes $\\mathrm{IsSolvable}(S_\\alpha)$. A Cartesian factor of a solvable permutation-product is **always** solvable — the product operation can never hide an unsolvable factor. The `omega` step is honest: with the product written as a single atom, $|\\alpha| \\le \\text{atom} \\le 4$ is linear.",
+    "mathContext": "$|\\beta| \\ge 1 \\Rightarrow |\\alpha| \\le |\\alpha|\\cdot|\\beta|$, so $\\mathrm{IsSolvable}(S_{\\alpha\\times\\beta}) \\Rightarrow \\mathrm{IsSolvable}(S_\\alpha)$ — product reflects solvability.",
+    "significance": "key",
+    "relatedConcepts": ["reflection of solvability", "Nat.le_mul_of_pos_right", "subgroup closure"],
+    "prerequisites": ["monotonicity of multiplication", "Fintype.card_pos"]
   },
   {
     "id": "ann-sums-fail",
@@ -29,7 +41,11 @@
     "range": { "startLine": 149, "endLine": 162 },
     "type": "insight",
     "title": "Disjoint unions do NOT preserve solvability",
-    "content": "The exact opposite of products. `perm_sum_solvability_not_preserved` exhibits the minimal witness: $S_{\\mathrm{Fin}\\,2}$ and $S_{\\mathrm{Fin}\\,3}$ are both solvable ($2,3 \\le 4$), yet $S_{\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3}$ is **not** — the union has $2 + 3 = 5$ points, and $5 \\not\\le 4$. Two solvable systems join into an unsolvable one. This is the Abel–Ruffini obstruction in combinatorial dress: solvability of the pieces carries no information about solvability of their union."
+    "content": "The exact opposite of products. `perm_sum_solvability_not_preserved` exhibits the minimal witness: $S_{\\mathrm{Fin}\\,2}$ and $S_{\\mathrm{Fin}\\,3}$ are both solvable ($2,3 \\le 4$), yet $S_{\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3}$ is **not** — the union has $2 + 3 = 5$ points, and $5 \\not\\le 4$. Two solvable systems join into an unsolvable one. This is the Abel–Ruffini obstruction in combinatorial dress: solvability of the pieces carries no information about solvability of their union.",
+    "mathContext": "$\\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,2}) \\wedge \\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,3})$ but $\\neg\\,\\mathrm{IsSolvable}(S_{\\mathrm{Fin}\\,2 \\oplus \\mathrm{Fin}\\,3})$ since $2+3 = 5 > 4$.",
+    "significance": "key",
+    "relatedConcepts": ["non-preservation", "minimal counterexample", "S₅ unsolvable"],
+    "prerequisites": ["S₅ non-solvability", "Fintype.card_fin", "Fintype.card_sum"]
   },
   {
     "id": "ann-additive-escape",
@@ -37,6 +53,10 @@
     "range": { "startLine": 165, "endLine": 188 },
     "type": "concept",
     "title": "5 is the minimal additive escape — and the dichotomy",
-    "content": "The failure is sharp. Reading $\\{0,1,2,3,4\\}$ as the available cardinalities, `abel_ruffini_is_additive_escape` shows $5 = 2 + 3$ is a sum of two of them that leaves the set, that it is unsolvable, and that it is the **least** such escape. So the solvable cardinalities first break additive closure exactly at the Abel–Ruffini degree. `product_reflects_sum_does_not` then states the closure dichotomy as one theorem: solvability is reflected by $\\times$ but not preserved by $\\oplus$ — the two monoidal structures on finite types lie on opposite sides of the boundary $n = 5$."
+    "content": "The failure is sharp. Reading $\\{0,1,2,3,4\\}$ as the available cardinalities, `abel_ruffini_is_additive_escape` shows $5 = 2 + 3$ is a sum of two of them that leaves the set, that it is unsolvable, and that it is the **least** such escape. So the solvable cardinalities first break additive closure exactly at the Abel–Ruffini degree. `product_reflects_sum_does_not` then states the closure dichotomy as one theorem: solvability is reflected by $\\times$ but not preserved by $\\oplus$ — the two monoidal structures on finite types lie on opposite sides of the boundary $n = 5$.",
+    "mathContext": "$5 = 2+3$ is the least element of $\\{a+b : a,b \\le 4\\} \\setminus \\{\\le 4\\}$ and is unsolvable; closure dichotomy: $\\times$ reflects, $\\oplus$ does not preserve.",
+    "significance": "key",
+    "relatedConcepts": ["minimal additive escape", "closure dichotomy", "Abel–Ruffini degree 5"],
+    "prerequisites": ["additive closure of an interval", "solvability threshold"]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Proof,
+  annotations: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01` (The Abel–Ruffini Boundary Under ⊕ and ×: Products Reflect Solvability, Sums Do Not).

## Changes
- **Created `index.ts`** — directory had only meta.json + annotations.json, so the page rendered 'proof not found'. Vite entry point now present.
- **Deepened all 5 annotations** — each previously had only `content`; added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` covering the threshold-meets-algebra setup, the additive/multiplicative threshold rewrites, product reflection, sum non-preservation, and the minimal additive escape 5.

## Verification
- `pnpm build` passes; JSON validated.
- Line ranges checked against the Lean file; `verified`/0-axiom/`mathlib` Tier-B status confirmed.
- This is the parent of the two siblings enriched in #28748 (escape cost) and #28752 (survival coincidence).