### PR TITLE
Enrich Abel-Ruffini ⊕⊊× containment by AM-GM: add index.ts + deepen annotations

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/annotations.json
@@ -8,7 +8,19 @@
     },
     "type": "concept",
     "title": "What survives when nontriviality is dropped",
-    "content": "The parent file proved a **coincidence**: for pieces of size $\\ge 2$, $\\mathrm{Perm}(\\alpha\\oplus\\beta)$ is solvable iff $\\mathrm{Perm}(\\alpha\\times\\beta)$ is, the unique survivor being $(2,2)$. Remove the hypothesis $\\mathrm{card}\\,\\alpha,\\mathrm{card}\\,\\beta\\ge 2$ and the equivalence degrades into a **strict containment**: every solvable disjoint union is a solvable product, but not conversely. The survivor sets are nested, $\\{a+b\\le 4\\}\\subsetneq\\{ab\\le 4\\}$, and the difference is carried entirely by the degenerate cardinalities $0$ and $1$."
+    "content": "The parent file proved a **coincidence**: for pieces of size $\\ge 2$, $\\mathrm{Perm}(\\alpha\\oplus\\beta)$ is solvable iff $\\mathrm{Perm}(\\alpha\\times\\beta)$ is, the unique survivor being $(2,2)$. Remove the hypothesis $\\mathrm{card}\\,\\alpha,\\mathrm{card}\\,\\beta\\ge 2$ and the equivalence degrades into a **strict containment**: every solvable disjoint union is a solvable product, but not conversely. The survivor sets are nested, $\\{a+b\\le 4\\}\\subsetneq\\{ab\\le 4\\}$, and the difference is carried entirely by the degenerate cardinalities $0$ and $1$.",
+    "mathContext": "$\\{a+b\\le 4\\}\\subsetneq\\{ab\\le 4\\}$; the gap lies in the degenerate cardinalities $0,1$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "strict containment",
+      "preservation coincidence",
+      "degenerate cardinalities"
+    ],
+    "prerequisites": [
+      "solvable groups",
+      "Abel–Ruffini threshold",
+      "cardinality of finite types"
+    ]
   },
   {
     "id": "ann-amgm",
@@ -17,9 +29,20 @@
       "startLine": 61,
       "endLine": 90
     },
-    "type": "key-step",
+    "type": "technique",
     "title": "AM–GM is the mechanism",
-    "content": "Everything rests on one elementary inequality of naturals: $4ab\\le(a+b)^2$, because $(a+b)^2-4ab=(a-b)^2\\ge 0$. It is the arithmetic mean–geometric mean inequality, and it makes the **sum** the harder quantity to bound: $a+b\\le 4$ forces $ab\\le\\tfrac{(a+b)^2}{4}\\le 4$, but $ab\\le 4$ says nothing about $a+b$. The Lean proof discharges $4ab\\le(a+b)^2$ over $\\mathbb{Z}$ via `zify` then `nlinarith [sq_nonneg ((a:\\mathbb{Z})-b)]`, then bounds $(a+b)^2\\le 16$ to land the cap-$4$ specialization."
+    "content": "Everything rests on one elementary inequality of naturals: $4ab\\le(a+b)^2$, because $(a+b)^2-4ab=(a-b)^2\\ge 0$. It is the arithmetic mean–geometric mean inequality, and it makes the **sum** the harder quantity to bound: $a+b\\le 4$ forces $ab\\le\\tfrac{(a+b)^2}{4}\\le 4$, but $ab\\le 4$ says nothing about $a+b$. The Lean proof discharges $4ab\\le(a+b)^2$ over $\\mathbb{Z}$ via `zify` then `nlinarith [sq_nonneg ((a:\\mathbb{Z})-b)]`, then bounds $(a+b)^2\\le 16$ to land the cap-$4$ specialization.",
+    "mathContext": "$(a-b)^2\\ge 0 \\Rightarrow 4ab\\le(a+b)^2$, so $a+b\\le 4 \\Rightarrow ab\\le 4$, but not conversely.",
+    "significance": "key",
+    "relatedConcepts": [
+      "AM–GM inequality",
+      "sq_nonneg",
+      "nlinarith"
+    ],
+    "prerequisites": [
+      "arithmetic mean–geometric mean inequality",
+      "natural-number arithmetic"
+    ]
   },
   {
     "id": "ann-containment",
@@ -28,9 +51,20 @@
       "startLine": 91,
       "endLine": 110
     },
-    "type": "key-step",
+    "type": "technique",
     "title": "The product is the more permissive operation",
-    "content": "Feeding AM–GM into the parent chain's thresholds $\\mathrm{Perm}(\\alpha\\oplus\\beta)\\text{ solvable}\\iff\\mathrm{card}\\,\\alpha+\\mathrm{card}\\,\\beta\\le 4$ and $\\mathrm{Perm}(\\alpha\\times\\beta)\\text{ solvable}\\iff\\mathrm{card}\\,\\alpha\\cdot\\mathrm{card}\\,\\beta\\le 4$ gives, with **no** hypothesis on the pieces, $\\mathrm{Perm}(\\alpha\\oplus\\beta)\\text{ solvable}\\Rightarrow\\mathrm{Perm}(\\alpha\\times\\beta)\\text{ solvable}$. The $\\oplus$-survivor set is a subset of the $\\times$-survivor set."
+    "content": "Feeding AM–GM into the parent chain's thresholds $\\mathrm{Perm}(\\alpha\\oplus\\beta)\\text{ solvable}\\iff\\mathrm{card}\\,\\alpha+\\mathrm{card}\\,\\beta\\le 4$ and $\\mathrm{Perm}(\\alpha\\times\\beta)\\text{ solvable}\\iff\\mathrm{card}\\,\\alpha\\cdot\\mathrm{card}\\,\\beta\\le 4$ gives, with **no** hypothesis on the pieces, $\\mathrm{Perm}(\\alpha\\oplus\\beta)\\text{ solvable}\\Rightarrow\\mathrm{Perm}(\\alpha\\times\\beta)\\text{ solvable}$. The $\\oplus$-survivor set is a subset of the $\\times$-survivor set.",
+    "mathContext": "$\\mathrm{Perm}(\\alpha\\oplus\\beta)\\text{ solvable} \\Rightarrow \\mathrm{Perm}(\\alpha\\times\\beta)\\text{ solvable}$ unconditionally, via $a+b\\le4\\Rightarrow ab\\le4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "one-directional implication",
+      "survivor-set inclusion",
+      "product permissiveness"
+    ],
+    "prerequisites": [
+      "sum/product thresholds",
+      "AM–GM cap"
+    ]
   },
   {
     "id": "ann-strictness",
@@ -39,9 +73,20 @@
       "startLine": 111,
       "endLine": 137
     },
-    "type": "key-step",
+    "type": "technique",
     "title": "The witness (Fin 1, Fin 4)",
-    "content": "The inclusion is proper. Take $\\alpha=\\mathrm{Fin}\\,1$, $\\beta=\\mathrm{Fin}\\,4$. The product $\\mathrm{Fin}\\,1\\times\\mathrm{Fin}\\,4$ has $1\\cdot 4=4$ points, so $\\mathrm{Perm}$ on it is solvable ($S_4$); the union $\\mathrm{Fin}\\,1\\oplus\\mathrm{Fin}\\,4$ has $1+4=5$ points, so $\\mathrm{Perm}$ on it is not. A single trivial factor — $\\mathrm{card}\\,1$, the multiplicative neutral — separates the two operations, and it does so exactly at the Abel–Ruffini threshold $5$."
+    "content": "The inclusion is proper. Take $\\alpha=\\mathrm{Fin}\\,1$, $\\beta=\\mathrm{Fin}\\,4$. The product $\\mathrm{Fin}\\,1\\times\\mathrm{Fin}\\,4$ has $1\\cdot 4=4$ points, so $\\mathrm{Perm}$ on it is solvable ($S_4$); the union $\\mathrm{Fin}\\,1\\oplus\\mathrm{Fin}\\,4$ has $1+4=5$ points, so $\\mathrm{Perm}$ on it is not. A single trivial factor — $\\mathrm{card}\\,1$, the multiplicative neutral — separates the two operations, and it does so exactly at the Abel–Ruffini threshold $5$.",
+    "mathContext": "$(\\mathrm{Fin}\\,1,\\mathrm{Fin}\\,4)$: $1\\cdot4=4$ solvable but $1+4=5$ unsolvable — the inclusion is proper.",
+    "significance": "key",
+    "relatedConcepts": [
+      "proper inclusion witness",
+      "multiplicative identity",
+      "degree-5 threshold"
+    ],
+    "prerequisites": [
+      "concrete Fin witnesses",
+      "Fintype.card_fin"
+    ]
   },
   {
     "id": "ann-gap",
@@ -50,9 +95,20 @@
       "startLine": 138,
       "endLine": 170
     },
-    "type": "key-step",
+    "type": "technique",
     "title": "The gap is exactly the trivial pieces",
-    "content": "Any pair in the gap — a product-survivor $ab\\le 4$ that is not a sum-survivor $a+b>4$ — must have a trivial piece, $a\\le 1$ or $b\\le 1$. If both were $\\ge 2$, then $a+b\\ge 5$ forces one factor $\\ge 3$ and so $ab\\ge 3\\cdot 2=6>4$, a contradiction. Hence among pieces of size $\\ge 2$ the two caps coincide: $ab\\le 4\\iff a+b\\le 4$. This is precisely the arithmetic reason the parent's preservation coincidence required nontriviality."
+    "content": "Any pair in the gap — a product-survivor $ab\\le 4$ that is not a sum-survivor $a+b>4$ — must have a trivial piece, $a\\le 1$ or $b\\le 1$. If both were $\\ge 2$, then $a+b\\ge 5$ forces one factor $\\ge 3$ and so $ab\\ge 3\\cdot 2=6>4$, a contradiction. Hence among pieces of size $\\ge 2$ the two caps coincide: $ab\\le 4\\iff a+b\\le 4$. This is precisely the arithmetic reason the parent's preservation coincidence required nontriviality.",
+    "mathContext": "$ab\\le4 \\wedge a+b>4 \\Rightarrow \\min(a,b)\\le1$; if $a,b\\ge2$ then $a+b\\ge5$ forces $ab\\ge6$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "gap characterization",
+      "trivial pieces",
+      "nontriviality hypothesis"
+    ],
+    "prerequisites": [
+      "case analysis",
+      "Nat.mul_le_mul"
+    ]
   },
   {
     "id": "ann-restore",
@@ -63,7 +119,18 @@
     },
     "type": "concept",
     "title": "Nontriviality restores the symmetry",
-    "content": "`nontriviality_restores_symmetry` is the pure-arithmetic statement $a,b\\ge 2\\Rightarrow(ab\\le 4\\iff a+b\\le 4)$ — both sides true exactly at $a=b=2$. It is the engine behind the parent's $\\mathrm{sum\\_prod\\_survival\\_coincide}$: deleting the degenerate sizes deletes the entire gap between the two survivor sets, collapsing the containment back to an equivalence."
+    "content": "`nontriviality_restores_symmetry` is the pure-arithmetic statement $a,b\\ge 2\\Rightarrow(ab\\le 4\\iff a+b\\le 4)$ — both sides true exactly at $a=b=2$. It is the engine behind the parent's $\\mathrm{sum\\_prod\\_survival\\_coincide}$: deleting the degenerate sizes deletes the entire gap between the two survivor sets, collapsing the containment back to an equivalence.",
+    "mathContext": "$a,b\\ge2 \\Rightarrow (ab\\le4 \\iff a+b\\le4)$, both true exactly at $a=b=2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "recovered symmetry",
+      "parent coincidence",
+      "collapse to equivalence"
+    ],
+    "prerequisites": [
+      "the gap characterization",
+      "natural-number arithmetic"
+    ]
   },
   {
     "id": "ann-fullpicture",
@@ -74,6 +141,17 @@
     },
     "type": "concept",
     "title": "Containment, strictness, and the recovered coincidence",
-    "content": "`without_nontriviality_only_containment` assembles the three facts into one statement: (1) the unconditional containment $\\oplus\\Rightarrow\\times$; (2) the strict-inclusion witness $(\\mathrm{Fin}\\,1,\\mathrm{Fin}\\,4)$; (3) the parent's coincidence, imported as the $\\mathrm{card}\\ge 2$ restriction. The parent's symmetric picture is the shadow this containment casts once the trivial cardinalities are removed."
+    "content": "`without_nontriviality_only_containment` assembles the three facts into one statement: (1) the unconditional containment $\\oplus\\Rightarrow\\times$; (2) the strict-inclusion witness $(\\mathrm{Fin}\\,1,\\mathrm{Fin}\\,4)$; (3) the parent's coincidence, imported as the $\\mathrm{card}\\ge 2$ restriction. The parent's symmetric picture is the shadow this containment casts once the trivial cardinalities are removed.",
+    "mathContext": "Containment $\\oplus\\Rightarrow\\times$; strict witness $(\\mathrm{Fin}\\,1,\\mathrm{Fin}\\,4)$; coincidence under $\\mathrm{card}\\ge2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "assembled statement",
+      "containment vs coincidence",
+      "shadow of symmetry"
+    ],
+    "prerequisites": [
+      "the three component facts",
+      "logical packaging"
+    ]
   }
 ]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ08OQ01OQ01OQ01OQ01OQ01OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Oq01Data: ProofData = {
+  proof: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Oq01Proof,
+  annotations: abelRuffiniOq04Oq02Oq02Oq08Oq01Oq01Oq01Oq01Oq01Oq01Oq01Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-oq-04-oq-02-oq-02-oq-08-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01-oq-01` (Drop Nontriviality and Survival Becomes One-Directional: ⊕-Survival ⊊ ×-Survival by AM–GM).

## Changes
- **Created `index.ts`** — directory had only meta.json + annotations.json, so the page rendered 'proof not found'. Vite entry point now present.
- **Deepened all 7 annotations** — each previously had only `content`; added `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites` covering the containment overview, the AM–GM mechanism (4ab ≤ (a+b)²), the one-directional implication, the (Fin 1, Fin 4) strict witness, the trivial-piece gap, and the recovered symmetry.
- **Normalized** the non-standard `key-step` annotation type to `technique`.

## Verification
- `pnpm build` passes; JSON validated.
- Line ranges checked against the Lean file; `verified`/0-axiom/`mathlib` Tier-B status confirmed.
- Completes the Abel–Ruffini ⊕/× family alongside #28753 (parent boundary), #28748 (escape cost), #28752 (survival coincidence).