### PR TITLE
Enrich N-ball volume vanishes Vₙ→0 (area-of-circle oq-02-oq-02): add index.ts + annotations

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-volume-def",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 50, "endLine": 54 },
+    "type": "definition",
+    "title": "The Unit n-Ball Volume Vₙ",
+    "content": "`unitBallVolume n` is the closed-form volume of the unit ball in $\\mathbb{R}^n$, $V_n = \\pi^{n/2}/\\Gamma(n/2+1)$, working with $n$ as a natural number cast into the real exponent and Gamma argument. Keeping it as a standalone real-valued definition (rather than reaching for `EuclideanSpace.volume_ball` immediately) lets the limit argument be carried out by elementary real analysis; the bridge to the genuine Lebesgue measure is deferred to the final corollary. Non-negativity is immediate since $\\pi^{n/2} \\ge 0$ and $\\Gamma > 0$ on the positive reals.",
+    "mathContext": "$V_n = \\dfrac{\\pi^{n/2}}{\\Gamma\\!\\left(\\tfrac{n}{2}+1\\right)} \\ge 0.$",
+    "significance": "supporting",
+    "relatedConcepts": ["Gamma function", "n-ball volume", "EuclideanSpace.volume_ball"],
+    "prerequisites": ["Gamma function", "real exponentiation", "volume of balls"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 86, "endLine": 107 },
+    "type": "technique",
+    "title": "The Dimension Recurrence Vₙ = Vₙ₋₂·2π/n",
+    "content": "The engine that links consecutive even (and consecutive odd) dimensions. It is re-derived self-contained from the Gamma functional equation $\\Gamma(x+1) = x\\,\\Gamma(x)$: writing $\\Gamma(n/2+1) = (n/2)\\,\\Gamma(n/2)$ turns the ratio $V_n/V_{n-2}$ into $\\pi/(n/2) = 2\\pi/n$. The Lean proof closes deterministically with `div_eq_div_iff` and `ring` rather than a fragile `field_simp`. The factor $2\\pi/n$ drops below $1$ once $n > 2\\pi \\approx 6.28$, which is exactly why the volume peaks at $n = 5$ before decaying.",
+    "mathContext": "$\\dfrac{V_n}{V_{n-2}} = \\dfrac{2\\pi}{n}$, from $\\Gamma\\!\\left(\\tfrac{n}{2}+1\\right) = \\tfrac{n}{2}\\,\\Gamma\\!\\left(\\tfrac{n}{2}\\right).$",
+    "significance": "key",
+    "relatedConcepts": ["Gamma functional equation", "recurrence relation", "peak at n=5"],
+    "prerequisites": ["Gamma function recurrence Γ(x+1)=xΓ(x)", "algebraic manipulation"]
+  },
+  {
+    "id": "ann-even-closed-form",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 108, "endLine": 115 },
+    "type": "insight",
+    "title": "Exact Even Closed Form V₂ₘ = πᵐ/m!",
+    "content": "In even dimensions the half-integer Gamma collapses to a factorial: $\\Gamma(m+1) = m!$ (`Real.Gamma_nat_eq_factorial`), so $V_{2m} = \\pi^m/\\Gamma(m+1) = \\pi^m/m!$. This is the cleanest possible form — the limit question for the even subsequence becomes the textbook fact that an exponential is eventually beaten by a factorial, $x^m/m! \\to 0$. No estimates are needed; the closed form is exact.",
+    "mathContext": "$V_{2m} = \\dfrac{\\pi^m}{\\Gamma(m+1)} = \\dfrac{\\pi^m}{m!}.$",
+    "significance": "key",
+    "relatedConcepts": ["factorial", "Real.Gamma_nat_eq_factorial", "exponential vs factorial growth"],
+    "prerequisites": ["Γ(n+1) = n!", "factorial"]
+  },
+  {
+    "id": "ann-odd-bound",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 116, "endLine": 146 },
+    "type": "technique",
+    "title": "Uniform Odd Bound V₂ₘ₊₁ ≤ 2·πᵐ/m!",
+    "content": "Odd dimensions have no clean factorial form, so they are bounded instead of computed. Starting from $V_1 = 2$ and applying the recurrence, an induction on $m$ gives $V_{2m+1} \\le 2\\,\\pi^m/m!$. The inductive step needs the per-step inequality $2\\pi/(2m+3) \\le \\pi/(m+1)$ — i.e. $2(m+1) \\le 2m+3$ — discharged by `nlinarith`. The bound deliberately reuses the same $\\pi^m/m!$ shape as the even case, so a single factorial-dominance limit drives both subsequences.",
+    "mathContext": "$V_{2m+1} \\le 2\\,\\dfrac{\\pi^m}{m!}$, since each recurrence step scales by $\\dfrac{2\\pi}{2m+3} \\le \\dfrac{\\pi}{m+1}.$",
+    "significance": "key",
+    "relatedConcepts": ["induction", "uniform bound", "squeeze preparation"],
+    "prerequisites": ["mathematical induction", "the dimension recurrence", "nlinarith"]
+  },
+  {
+    "id": "ann-subsequence-limits",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 147, "endLine": 158 },
+    "type": "technique",
+    "title": "Both Subsequences Vanish",
+    "content": "`tendsto_even` is immediate: $V_{2m} = \\pi^m/m! \\to 0$ by Mathlib's `FloorSemiring.tendsto_pow_div_factorial_atTop`. `tendsto_odd` applies `squeeze_zero`: $0 \\le V_{2m+1} \\le 2\\,\\pi^m/m!$ and the upper bound tends to $0$ (the same Mathlib limit times the constant $2$), forcing the middle term to $0$. The factorial-beats-exponential lemma is thus the single analytic input for the whole theorem.",
+    "mathContext": "$V_{2m} \\to 0$ directly; $0 \\le V_{2m+1} \\le 2\\pi^m/m! \\to 0$ by squeeze.",
+    "significance": "supporting",
+    "relatedConcepts": ["squeeze theorem", "tendsto_pow_div_factorial_atTop", "subsequence convergence"],
+    "prerequisites": ["limits of sequences", "squeeze theorem"]
+  },
+  {
+    "id": "ann-main-limit",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 171, "endLine": 211 },
+    "type": "insight",
+    "title": "The Main Limit Vₙ → 0",
+    "content": "`unitBallVolume_tendsto_zero` combines the two subsequence limits into the full statement by an $\\varepsilon$–$N$ argument over the parity of $n$: given $\\varepsilon > 0$, pick thresholds from the even and odd limits, and for $n$ beyond their max the value is below $\\varepsilon$ whether $n$ is even or odd. Because the even and odd indices exhaust $\\mathbb{N}$, no dedicated even/odd interleaving combinator is required. The non-monotonic rise to the peak at $n=5$ is invisible here — only eventual factorial dominance matters.",
+    "mathContext": "$\\lim_{n\\to\\infty} V_n = 0$, via parity-split $\\varepsilon$–$N$.",
+    "significance": "key",
+    "relatedConcepts": ["epsilon-N limit", "parity decomposition", "concentration of measure"],
+    "prerequisites": ["definition of sequence limit", "subsequences covering ℕ"]
+  },
+  {
+    "id": "ann-measure-corollary",
+    "proofId": "area-of-circle-oq-02-oq-02",
+    "range": { "startLine": 212, "endLine": 229 },
+    "type": "context",
+    "title": "Lifting to the Genuine Lebesgue Measure",
+    "content": "The headline corollary bridges the elementary formula to real measure theory. `volume_unitBall_eq` identifies $\\mathrm{vol}(B^n(1)) = \\mathrm{ofReal}(V_n)$ for $n \\ge 1$ using `EuclideanSpace.volume_ball` and the identity $(\\sqrt\\pi)^n = \\pi^{n/2}$; then `volume_unitBall_toReal_tendsto_zero` transports the real limit through `ENNReal.toReal` to conclude the actual Lebesgue measure of the unit ball in $\\mathrm{EuclideanSpace}\\,\\mathbb{R}\\,(\\mathrm{Fin}\\,n)$ tends to $0$. This is the rigorous form of 'high-dimensional balls are negligible'.",
+    "mathContext": "$\\mathrm{vol}(B^n(1)) = \\mathrm{ofReal}(V_n) \\to 0$ in $\\mathbb{R}$ as $n \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lebesgue measure", "EuclideanSpace.volume_ball", "ENNReal.toReal"],
+    "prerequisites": ["measure theory", "Lebesgue measure of balls", "ENNReal coercions"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-02-oq-02/index.ts
+++ b/src/data/proofs/area-of-circle-oq-02-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ02OQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOq02Oq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOq02Oq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOq02Oq02Data: ProofData = {
+  proof: areaOfCircleOq02Oq02Proof,
+  annotations: areaOfCircleOq02Oq02Annotations,
+}


### PR DESCRIPTION
Enrichment pass for `area-of-circle-oq-02-oq-02` (N-Ball Volume Vanishes in High Dimensions: Vₙ → 0).

## Changes
- **Created `index.ts`** — directory had only meta.json, so the page rendered 'proof not found' on the live site. Vite entry point now present.
- **Created `annotations.json`** — 7 substantive annotations covering the unit-ball volume definition, the Gamma-derived dimension recurrence Vₙ = Vₙ₋₂·2π/n, the exact even closed form πᵐ/m!, the uniform odd bound 2·πᵐ/m!, the squeezed subsequence limits, the parity ε–N main limit, and the Lebesgue-measure corollary. Each has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

## Verification
- `pnpm build` passes; JSON validated.
- Annotation line ranges checked against `AreaOfCircleOQ02OQ02.lean` theorem positions.
- `verified`/0-axiom/badge `original` confirmed accurate against the Lean source.