### PR TITLE
research(borsuk-ulam-oq-02-oq-04): localization collapse of the equivariant index for non-free Z/p actions

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -421,6 +421,7 @@ import Proofs.BorsukUlamOQ02OQ01OQ04
 import Proofs.BorsukUlamOQ02OQ01OQ04OQ01
 import Proofs.BorsukUlamOQ02OQ02
 import Proofs.BorsukUlamOQ02OQ03
+import Proofs.BorsukUlamOQ02OQ04
 import Proofs.BorsukUlamOQ03
 import Proofs.BorsukUlamOQ03OQ01
 import Proofs.BorsukUlamOQ03OQ01OQ01

--- a/proofs/Proofs/BorsukUlamOQ02OQ04.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ04.lean
@@ -1,0 +1,263 @@
+/-
+Equivariant Index of Non-Free Z/p Actions: The Localization Collapse
+
+Open Question (borsuk-ulam-oq-02-oq-04):
+"For non-free Z/p actions: does the equivariant index still control vanishing,
+ or does control pass to the fixed-point set?"
+
+Answer: For NON-FREE Z/p actions (p prime) the Fadell-Husseini / Dold
+cohomological index DEGENERATES to the trivial value (the index ideal is 0,
+equivalently the numerical height is +infinity). It therefore no longer
+controls vanishing in any discriminating way: it returns the same value for
+EVERY space with a fixed point. The genuine obstruction collapses onto the
+fixed-point set, which is always nonempty for a non-free Z/p-action on a
+mod-p homology sphere (Smith theory). Vanishing is still forced, but trivially,
+by the fixed point: any Z/p-map of a fixed-point space into a fixed-point-free
+representation W sends the fixed point x0 into W^{Z/p} = {0}.
+
+Background:
+For a FREE Z/p-space the Fadell-Husseini index
+  iota(X) = sup { k : the k-th power of the Euler class survives in H^*_G(X) }
+is a finite number that grows with the topological complexity of X; it is the
+engine behind every Borsuk-Ulam bound (iota(S^n) = n for the antipodal action,
+iota(S^{2k-1}) = 2k-1 for the standard free rotation), and equivariant maps are
+monotone for it (X -> Y forces iota(X) <= iota(Y)). See OQ02OQ03 (Dold) and
+OQ02OQ01OQ04 (Fadell-Husseini) for the free theory.
+
+The Localization Theorem (Borel) explains the collapse: if X has a Z/p-fixed
+point x0, the inclusion {x0} -> X splits the structure map
+  H^*(BZ/p) -> H^*_{Z/p}(X)
+(restriction to x0 is a retraction), so this map is INJECTIVE. Hence no power
+of the Euler class is killed and iota(X) = +infinity. The index ideal
+Ind_{Z/p}(X) = ker(H^*(BG) -> H^*_G(X)) is therefore 0 -- it carries no
+obstruction.
+
+This file axiomatizes the index together with the localization property and
+derives the dichotomy. We model the index as a value in WithTop Nat, with
+the top element TOP standing for "+infinity = trivial index = no obstruction".
+
+Axiom count: 10 (4 carrier declarations + 1 sphere family + 1 test-map relation
++ 4 structural properties). Status: axiomatized.
+Theorem count: 11 consequences proved from the axioms.
+
+References:
+- Fadell & Husseini, "An ideal-valued cohomological index theory" (1988)
+- Dold, "Simple proofs of some Borsuk-Ulam results" (1983)
+- P.A. Smith, "Transformations of finite period" (1938) -- fixed-point theory
+- A. Borel, "Seminar on Transformation Groups" (1960) -- localization
+- Matousek, "Using the Borsuk-Ulam Theorem" (2003), Chapter 6
+-/
+
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Order.WithBot
+import Mathlib.Tactic
+
+set_option linter.unusedVariables false
+set_option linter.unusedTactic false
+
+namespace BorsukUlamOQ02OQ04
+
+-- ============================================================
+-- PART I: The Index Theory (Axiomatized Carriers)
+-- ============================================================
+
+/-- The carrier type of Z/p-spaces under consideration (mod-p homology spheres
+    with a continuous Z/p-action). Abstracted; we axiomatize the structure we
+    need rather than building equivariant cohomology. -/
+axiom Space : Type
+
+/-- The Fadell-Husseini / Dold cohomological index iota(X), valued in
+    `WithTop Nat`. A finite value `n` is the numerical height of the surviving
+    Euler-class powers; the top element `TOP` means "+infinity", i.e. the
+    index ideal is 0 and the index carries no obstruction. -/
+axiom idx : Space → WithTop ℕ
+
+/-- `GMap X Y` holds when a Z/p-equivariant continuous map `X -> Y` exists. -/
+axiom GMap : Space → Space → Prop
+
+/-- `HasFixedPoint X` holds when the Z/p-action on `X` has a fixed point,
+    i.e. `X^{Z/p}` is nonempty. For p prime this is exactly the failure of
+    freeness (every nonidentity element of Z/p generates the whole group, so a
+    point fixed by one nonidentity element is fixed by all of Z/p). -/
+axiom HasFixedPoint : Space → Prop
+
+/-- The standard FREE Z/p-sphere `freeSphere n` = `S^n` with a fixed-point-free
+    action (antipodal for p = 2; standard rotation for odd p). This is the unit
+    sphere `S(W)` of a fixed-point-free representation `W`. -/
+axiom freeSphere : ℕ → Space
+
+/-- `ZeroAvoidingMap X m` holds when there is a Z/p-map `X -> W \ {0}`, where `W`
+    is the fixed-point-free representation whose unit sphere is `freeSphere m`.
+    Its negation, `¬ ZeroAvoidingMap X m`, says every Z/p-map `X -> W` has a
+    zero -- i.e. vanishing is forced. -/
+axiom ZeroAvoidingMap : Space → ℕ → Prop
+
+-- ============================================================
+-- PART II: Axiomatized Properties
+-- ============================================================
+
+/-- Free-sphere index: `iota(freeSphere n) = n`. The free action gives a finite,
+    dimension-sensitive obstruction -- the content of Borsuk-Ulam / Yang. -/
+axiom idx_freeSphere (n : ℕ) : idx (freeSphere n) = (n : WithTop ℕ)
+
+/-- **Monotonicity (the engine of Borsuk-Ulam).** A Z/p-map `X -> Y` forces
+    `iota(X) <= iota(Y)`: equivariant maps can only increase the index. -/
+axiom idx_mono {X Y : Space} (h : GMap X Y) : idx X ≤ idx Y
+
+/-- **Localization collapse (Borel + Smith).** If `X` has a Z/p-fixed point then
+    the structure map `H^*(BG) -> H^*_G(X)` is split-injective, so no Euler-class
+    power dies and `iota(X) = +infinity = TOP`. This is the crux: a single fixed
+    point trivializes the index. -/
+axiom idx_localization {X : Space} (h : HasFixedPoint X) : idx X = ⊤
+
+/-- **Test-map scheme.** A zero-avoiding Z/p-map `X -> W \ {0}` is the same datum
+    as a Z/p-map into the unit sphere `freeSphere m = S(W)` (radial deformation
+    retraction). This is how the index controls vanishing. -/
+axiom zeroAvoiding_iff (X : Space) (m : ℕ) :
+    ZeroAvoidingMap X m ↔ GMap X (freeSphere m)
+
+-- ============================================================
+-- PART III: The Free Theory -- the index DOES control
+-- ============================================================
+
+/-- **Borsuk-Ulam bound (free case).** For `m < n` there is no Z/p-map
+    `freeSphere n -> freeSphere m`: the index obstruction `n > m` blocks it.
+    This is the classical antipodal Borsuk-Ulam (p = 2) and Yang's theorem
+    (odd p), recovered as the free, finite-index regime. -/
+theorem index_controls_free (n m : ℕ) (h : m < n) :
+    ¬ GMap (freeSphere n) (freeSphere m) := by
+  intro hmap
+  have hle : idx (freeSphere n) ≤ idx (freeSphere m) := idx_mono hmap
+  rw [idx_freeSphere, idx_freeSphere] at hle
+  have : n ≤ m := by exact_mod_cast hle
+  omega
+
+/-- The free index is a genuine (finite) obstruction: `iota(freeSphere n) ≠ TOP`. -/
+theorem free_index_finite (n : ℕ) : idx (freeSphere n) ≠ ⊤ := by
+  rw [idx_freeSphere]; simp
+
+/-- The free index DISCRIMINATES: distinct dimensions give distinct indices.
+    This is the discriminating power that the non-free case will lose. -/
+theorem index_discriminates_free (n m : ℕ) (h : n ≠ m) :
+    idx (freeSphere n) ≠ idx (freeSphere m) := by
+  rw [idx_freeSphere, idx_freeSphere]
+  exact fun hh => h (by exact_mod_cast hh)
+
+/-- Strict monotonicity of the free index in the dimension. -/
+theorem free_index_strict_mono (n m : ℕ) (h : n < m) :
+    idx (freeSphere n) < idx (freeSphere m) := by
+  rw [idx_freeSphere, idx_freeSphere]
+  exact_mod_cast h
+
+-- ============================================================
+-- PART IV: The Non-Free Collapse -- the index does NOT control
+-- ============================================================
+
+/-- **Index trivializes on fixed-point spaces.** Restatement of localization as
+    a named result: any non-free `X` (one with a Z/p-fixed point) has
+    `iota(X) = +infinity`. -/
+theorem index_trivial_of_fixedPoint {X : Space} (h : HasFixedPoint X) :
+    idx X = ⊤ := idx_localization h
+
+/-- **No discrimination.** Any two fixed-point spaces have the SAME index `TOP`.
+    The index has lost all power to distinguish non-free Z/p-spaces -- it is the
+    constant `+infinity` on this entire class. -/
+theorem index_no_discrimination {X Y : Space}
+    (hX : HasFixedPoint X) (hY : HasFixedPoint Y) : idx X = idx Y := by
+  rw [idx_localization hX, idx_localization hY]
+
+/-- **Fixed-point spaces admit no equivariant map to a free sphere.** If `X` has
+    a fixed point, the index `TOP` exceeds every finite `m`, so monotonicity
+    forbids a Z/p-map `X -> freeSphere m`. (A fixed point of `X` cannot map to
+    the free, fixed-point-free sphere.) -/
+theorem no_map_to_free_sphere_of_fixedPoint {X : Space}
+    (hfp : HasFixedPoint X) (m : ℕ) : ¬ GMap X (freeSphere m) := by
+  intro hmap
+  have hle : idx X ≤ idx (freeSphere m) := idx_mono hmap
+  rw [idx_localization hfp, idx_freeSphere] at hle
+  -- TOP ≤ ↑m  forces  ↑m = TOP, impossible; `simp` discharges via top_le_iff.
+  simp at hle
+
+/-- **Vanishing is forced for non-free actions.** If `X` has a Z/p-fixed point,
+    then for every fixed-point-free representation `W` (sphere `freeSphere m`)
+    NO zero-avoiding map exists: every Z/p-map `X -> W` has a zero. -/
+theorem vanishing_forced_of_fixedPoint {X : Space}
+    (hfp : HasFixedPoint X) (m : ℕ) : ¬ ZeroAvoidingMap X m := by
+  rw [zeroAvoiding_iff]
+  exact no_map_to_free_sphere_of_fixedPoint hfp m
+
+-- ============================================================
+-- PART V: The Dichotomy -- the answer to OQ-02-OQ-04
+-- ============================================================
+
+/-- **Main dichotomy.** For a non-free Z/p-space `X` (one with a fixed point):
+    the index degenerates to `TOP` (carrying no obstruction), yet vanishing is
+    still forced for every fixed-point-free target. The two facts together say
+    the *index* no longer controls vanishing -- control has passed to the
+    fixed-point set, whose nonemptiness alone forces the zero. -/
+theorem index_control_dichotomy {X : Space} (hfp : HasFixedPoint X) :
+    idx X = ⊤ ∧ ∀ m, ¬ ZeroAvoidingMap X m :=
+  ⟨idx_localization hfp, fun m => vanishing_forced_of_fixedPoint hfp m⟩
+
+/-- **Sharp contrast at fixed complexity.** Take any free sphere `freeSphere n`
+    and any non-free space `X`. Their indices are never equal: the free one is
+    finite (`n`), the non-free one is `TOP`. The index cleanly separates the two
+    regimes, but is informative only in the free one. -/
+theorem free_vs_nonfree_index {X : Space} (hfp : HasFixedPoint X) (n : ℕ) :
+    idx (freeSphere n) ≠ idx X := by
+  rw [idx_freeSphere, idx_localization hfp]
+  simp
+
+/-- **Control passes to the fixed-point set.** Equivalent packaging of the
+    answer: "does the index control vanishing?" For non-free `X` the index is
+    constant (`= idx Y` for every other non-free `Y`), so it cannot be what
+    distinguishes which maps vanish; nevertheless every map into a free target
+    vanishes. The discriminating data is `HasFixedPoint` itself. -/
+theorem control_passes_to_fixedPoints {X Y : Space}
+    (hX : HasFixedPoint X) (hY : HasFixedPoint Y) :
+    idx X = idx Y ∧ (∀ m, ¬ ZeroAvoidingMap X m) ∧ (∀ m, ¬ ZeroAvoidingMap Y m) :=
+  ⟨index_no_discrimination hX hY,
+   fun m => vanishing_forced_of_fixedPoint hX m,
+   fun m => vanishing_forced_of_fixedPoint hY m⟩
+
+-- ============================================================
+-- PART VI: Formalizability Assessment
+-- ============================================================
+
+/-
+## Answer to OQ-02-OQ-04
+
+**For non-free Z/p actions the equivariant index does NOT control vanishing.**
+It collapses (by localization) to the constant value +infinity on every
+fixed-point space, losing all discriminating power. Vanishing is still forced,
+but trivially: the genuine obstruction migrates to the fixed-point set
+`X^{Z/p}`, which is nonempty by Smith theory. In symbols, for `HasFixedPoint X`:
+
+  iota(X) = +infinity   (no index obstruction)
+  yet  every Z/p-map  X -> W \ {0}  fails to exist  (vanishing forced)
+
+because the fixed point `x0` satisfies `f(x0) in W^{Z/p} = {0}`.
+
+This is the exact opposite of the FREE regime (OQ02OQ03, OQ02OQ01OQ04), where
+iota is finite, dimension-sensitive, and is precisely the obstruction governing
+which equivariant maps exist.
+
+### Available in Mathlib (as of v4.x):
+1. Group actions, fixed-point sets (`MulAction`, `MulAction.fixedPoints`)
+2. `ZMod p`, primality (`Nat.Prime`)
+3. `WithTop`/`ENat` order theory (used here for the +infinity value)
+
+### Missing from Mathlib (to remove the axioms):
+1. Borel equivariant cohomology `H^*_G(-)` and the Euler class (~1300 lines)
+2. The localization theorem: a fixed point splits `H^*(BG) -> H^*_G(X)` (~250)
+3. Smith theory: a non-free Z/p-action on a mod-p homology sphere has nonempty
+   fixed-point set (~400 lines)
+4. The Fadell-Husseini index and its monotonicity (~300 lines)
+
+### Highest-value path:
+The single axiom doing the real work is `idx_localization` (the splitting). With
+a Borel-cohomology layer in place it is a 1-line consequence of the retraction
+`X -> {x0} -> X`. Everything else here is order arithmetic on `WithTop Nat`.
+-/
+
+end BorsukUlamOQ02OQ04

--- a/research/problems/borsuk-ulam-oq-02-oq-04/knowledge.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-04/knowledge.md
@@ -1,0 +1,50 @@
+# borsuk-ulam-oq-02-oq-04 — Knowledge
+
+**Status: RESOLVED & FORMALIZED (axiomatized), researcher-3, 2026-06-23.**
+
+## Question
+For non-free `Z/p` actions (p prime): does the equivariant (Fadell-Husseini /
+Dold) cohomological index still control vanishing, or does control pass to the
+fixed-point set?
+
+## Answer
+**No — the index does NOT control vanishing for non-free actions.** It collapses
+to the trivial value `+∞` on every fixed-point space and loses all discriminating
+power; control passes to the (nonempty) fixed-point set `X^{Z/p}`.
+
+## Mathematical core
+- **Localization (Borel, 1960):** a `Z/p`-fixed point `x0 ∈ X` splits the
+  structure map `H*(BG) → H*_G(X)` (restriction to `x0` is a retraction), so the
+  map is injective, no Euler-class power dies, and the numerical index
+  `ι(X) = +∞`. Equivalently the Fadell-Husseini index ideal `Ind_G(X) = 0`.
+- **Smith theory (1938):** for `Z/p` prime on a mod-`p` homology sphere, the
+  action is free **iff** `X^{Z/p} = ∅`; non-free ⇒ nonempty fixed set. (Each
+  nonidentity element of `Z/p` generates the whole group, so a point fixed by one
+  is fixed by all.)
+- **Why vanishing is still forced — but trivially:** for a fixed-point-free
+  representation `W`, `W^{Z/p} = {0}`. A fixed point `x0` must map to a fixed
+  point, so `f(x0) ∈ W^{Z/p} = {0}`, i.e. `f(x0) = 0`. The zero comes from the
+  fixed point, not from global topology / the index.
+
+## Formalization
+`proofs/Proofs/BorsukUlamOQ02OQ04.lean` (registered `Proofs.lean`).
+- Model: `idx : Space → WithTop ℕ`, `⊤ = +∞ = no obstruction`.
+- 10 axioms (6 carriers + 4 properties), 11 theorems, 0 sorries, status
+  **axiomatized** (badge `axiom`).
+- Load-bearing axiom: `idx_localization` (the splitting). The rest is order
+  arithmetic on `WithTop ℕ` (`WithTop.top_le_iff`, `WithTop.coe_ne_top`).
+- Key theorems: `index_controls_free` (free BU bound), `index_no_discrimination`
+  (index constant on non-free spaces), `no_map_to_free_sphere_of_fixedPoint`,
+  `vanishing_forced_of_fixedPoint`, `index_control_dichotomy`,
+  `control_passes_to_fixedPoints`.
+
+## De-axiomatization path
+Needs a Borel equivariant cohomology layer in Mathlib (~2250 lines: H*_G, Euler
+class, localization, Smith theory, FH index). With it, `idx_localization` is a
+1-line consequence of the retraction `X → {x0} → X`.
+
+## Extensions (not done)
+- Relative/quantitative index over the fixed-point stratum for *partially* free
+  actions (free away from a lower-dimensional fixed set).
+- `(Z/p)^k` elementary abelian: the FH index is ideal-valued, not numerical —
+  does the collapse persist?

--- a/research/problems/borsuk-ulam-oq-02-oq-04/problem.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-04/problem.md
@@ -1,0 +1,72 @@
+# Problem: Non-free Z/p actions — does the equivariant index still control vanishing?
+
+## Statement
+
+### Plain Language
+For a non-free action of Z/p (p prime), does the equivariant cohomological
+(Fadell-Husseini / Dold) index still control vanishing — i.e. still determine
+which equivariant maps `X → W \ {0}` exist — or does control pass to the
+fixed-point set `X^{Z/p}`?
+
+### Formal Statement
+Let `p` be prime and let `X` be a mod-`p` homology sphere with a continuous
+`Z/p`-action. Write `ι(X)` for the Fadell-Husseini cohomological index (the
+numerical height of the surviving Euler-class powers in `H*_{Z/p}(X)`). Decide
+the behaviour of `ι` and of the vanishing problem when the action is **not free**
+(equivalently, when `X^{Z/p} ≠ ∅`, by Smith theory for `Z/p`).
+
+$$
+X^{\mathbb{Z}/p} \neq \varnothing \;\Longrightarrow\; \iota(X) = +\infty,
+\qquad\text{yet every } \mathbb{Z}/p\text{-map } X \to W\setminus\{0\} \text{ fails to exist.}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 4
+tags:
+  - topology
+  - algebraic-topology
+  - borsuk-ulam
+  - equivariant
+  - cohomology
+  - group-actions
+  - localization
+  - smith-theory
+  - fadell-husseini
+  - seeker-selected
+```
+
+**Significance**: 6/10
+**Tractability**: 4/10
+
+## Why This Matters
+
+1. **Sharp regime boundary** — pins down exactly why combinatorial applications
+   of Borsuk-Ulam (Kneser, Schrijver, Necklace Splitting) require *free* actions:
+   freeness is what keeps the index finite and discriminating.
+2. **Localization made concrete** — turns the Borel localization theorem into a
+   crisp, machine-checkable statement about index degeneration.
+
+## Resolution (this entry)
+
+**Answer: NO.** For non-free `Z/p` actions the equivariant index does *not*
+control vanishing. By the localization theorem a single fixed point splits the
+structure map `H*(BG) → H*_G(X)`, so the index collapses to the constant value
+`+∞` on every fixed-point space and loses all discriminating power. Vanishing is
+still forced, but trivially, by the nonempty fixed-point set: the fixed point
+`x0` maps into `W^{Z/p} = {0}`. Control passes to `X^{Z/p}`.
+
+Formalized (axiomatized) in `proofs/Proofs/BorsukUlamOQ02OQ04.lean`:
+10 axioms, 11 theorems, 0 sorries.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| borsuk-ulam-oq-02-oq-03 (Dold index) | Free-theory counterpart: finite, dimension-sensitive index |
+| borsuk-ulam-oq-02-oq-01-oq-04 (Fadell-Husseini) | Ideal-valued index whose height degenerates here |
+| borsuk-ulam-oq-02 | Parent: equivariant Borsuk-Ulam for other group actions |
+| borsuk-ulam | Grandparent: classical free Z/2 case |

--- a/research/problems/borsuk-ulam-oq-02-oq-04/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-04/state.md
@@ -1,0 +1,32 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-06-23
+**Iteration**: 1
+
+## Current Focus
+
+Resolved and formalized (axiomatized). No open follow-up in this entry.
+
+## Active Approach
+
+Axiomatized index theory in `WithTop ℕ` (TOP = +∞ = trivial index), with the
+Borel localization collapse as the single load-bearing axiom; the dichotomy
+derived as 11 theorems.
+
+## Blockers
+
+None. Full de-axiomatization needs a Borel equivariant cohomology layer in
+Mathlib (~2250 lines; see Part VI of the Lean file).
+
+## Next Action
+
+None — deliverable shipped. Possible extension: relative index over the
+fixed-point stratum for partially free actions, or (Z/p)^k via the ideal-valued
+Fadell-Husseini index.
+
+## Attempt Counts
+
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-index-axiom",
+    "proofId": "borsuk-ulam-oq-02-oq-04",
+    "range": { "startLine": 70, "endLine": 73 },
+    "type": "definition",
+    "title": "The Equivariant Index, valued in WithTop ℕ",
+    "content": "The index `idx X : WithTop ℕ` models the Fadell-Husseini / Dold cohomological index iota(X): the numerical height, i.e. the largest k for which the k-th power of the Euler class survives in Borel equivariant cohomology H*_G(X). The key modelling choice is the value `⊤` (TOP): it stands for +infinity, equivalently the Fadell-Husseini index ideal Ind_G(X) = ker(H*(BG) → H*_G(X)) being 0 — no power of the Euler class is killed, so the index carries NO obstruction. A finite value n is the dimension-sensitive obstruction of the free regime.",
+    "mathContext": "$\\iota(X) = \\sup\\{k : w^k \\neq 0 \\text{ in } H^*_G(X)\\} \\in \\mathbb{N} \\cup \\{+\\infty\\}$, with $+\\infty \\leftrightarrow \\mathrm{Ind}_G(X) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Fadell-Husseini index", "Borel equivariant cohomology", "Euler class", "index ideal"],
+    "prerequisites": ["algebraic topology", "equivariant cohomology", "order theory (WithTop)"]
+  },
+  {
+    "id": "ann-localization-axiom",
+    "proofId": "borsuk-ulam-oq-02-oq-04",
+    "range": { "startLine": 107, "endLine": 111 },
+    "type": "insight",
+    "title": "Localization Collapse: a fixed point trivializes the index",
+    "content": "This is the single load-bearing axiom. If X has a Z/p-fixed point x0, the inclusion {x0} → X is split by restriction (the constant map X → {x0} is a Z/p-retraction onto the fixed point), so the structure map H*(BG) → H*_G(X) is split-injective. Hence no power of the Euler class dies and iota(X) = +infinity = ⊤. Mathematically this is the Borel localization theorem: equivariant cohomology, after inverting the Euler class, is supported on the fixed-point set. Once a fixed point exists, the index can no longer 'see' the rest of the space.",
+    "mathContext": "$H^*(BG) \\to H^*_G(X)$ split-injective $\\Rightarrow$ $\\iota(X) = +\\infty$. (Borel, Seminar on Transformation Groups, 1960.)",
+    "significance": "key",
+    "relatedConcepts": ["localization theorem", "fixed-point set", "split injection", "Euler class"],
+    "prerequisites": ["equivariant cohomology", "transformation groups", "Smith theory"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "borsuk-ulam-oq-02-oq-04",
+    "range": { "startLine": 103, "endLine": 105 },
+    "type": "concept",
+    "title": "Monotonicity: the engine of Borsuk-Ulam",
+    "content": "An equivariant map X → Y forces iota(X) ≤ iota(Y). This single inequality is what turns the index into an obstruction: to rule out a map S^n → S^m one shows iota(S^n) = n > m = iota(S^m). The non-free collapse weaponizes the SAME inequality in reverse — since iota(X) = ⊤ for a fixed-point space, and ⊤ ≤ m is impossible for finite m, no equivariant map X → freeSphere m can exist.",
+    "mathContext": "Equivariant $f : X \\to Y \\Rightarrow \\iota(X) \\le \\iota(Y)$; functoriality of the index ideal under $f^*$.",
+    "significance": "supporting",
+    "relatedConcepts": ["equivariant maps", "monotone invariant", "obstruction theory"],
+    "prerequisites": ["equivariant cohomology"]
+  },
+  {
+    "id": "ann-free-regime",
+    "proofId": "borsuk-ulam-oq-02-oq-04",
+    "range": { "startLine": 127, "endLine": 134 },
+    "type": "insight",
+    "title": "Free regime: the index DOES control",
+    "content": "For free spheres the index is finite (iota(freeSphere n) = n) and dimension-sensitive: index_controls_free recovers the classical Borsuk-Ulam / Yang obstruction (no equivariant map S^n → S^m for m < n), and index_discriminates_free shows the index separates distinct dimensions. This is exactly the regime of the sibling formalizations OQ02OQ03 (Dold) and OQ02OQ01OQ04 (Fadell-Husseini): freeness keeps the index finite and informative.",
+    "mathContext": "Free action $\\Rightarrow \\iota(S^n) = n$ finite, strictly increasing in $n$; the Borsuk-Ulam/Yang obstruction.",
+    "significance": "key",
+    "relatedConcepts": ["Borsuk-Ulam theorem", "Yang's theorem", "free action", "dimension obstruction"],
+    "prerequisites": ["Borsuk-Ulam theorem", "free group actions"]
+  },
+  {
+    "id": "ann-vanishing-forced",
+    "proofId": "borsuk-ulam-oq-02-oq-04",
+    "range": { "startLine": 173, "endLine": 196 },
+    "type": "insight",
+    "title": "Non-free regime: vanishing forced, but trivially",
+    "content": "no_map_to_free_sphere_of_fixedPoint and vanishing_forced_of_fixedPoint show that, despite the index being the uninformative ⊤, every equivariant map of a fixed-point space into a fixed-point-free representation W still has a zero. The reason is NOT the index: it is the fixed point itself. The fixed point x0 must map to a Z/p-fixed point of W, but W^{Z/p} = {0}, so f(x0) = 0 directly. The global topology that the index used to detect is entirely bypassed — control has migrated to the fixed-point set.",
+    "mathContext": "$x_0 \\in X^{\\mathbb{Z}/p} \\Rightarrow f(x_0) \\in W^{\\mathbb{Z}/p} = \\{0\\}$; the zero is at the fixed point.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point set", "test-map scheme", "representation sphere", "vanishing"],
+    "prerequisites": ["group representations", "fixed-point theory"]
+  },
+  {
+    "id": "ann-dichotomy",
+    "proofId": "borsuk-ulam-oq-02-oq-04",
+    "range": { "startLine": 199, "endLine": 224 },
+    "type": "insight",
+    "title": "The Dichotomy: the answer to OQ-02-OQ-04",
+    "content": "index_control_dichotomy and control_passes_to_fixedPoints package the resolution. For a non-free X: iota(X) = ⊤ (no index obstruction) AND every map into a free target vanishes (vanishing forced) AND iota is constant across all non-free spaces (index_no_discrimination). The conjunction is the precise meaning of 'the index does not control vanishing for non-free actions': it returns the same value for every fixed-point space, so it cannot be what distinguishes which maps vanish. The discriminating invariant is HasFixedPoint — i.e. the fixed-point set — itself.",
+    "mathContext": "$\\mathrm{HasFixedPoint}(X) \\Rightarrow \\iota(X) = \\top \\wedge \\forall m,\\ \\neg\\,\\mathrm{ZeroAvoiding}(X,m)$; control via $X^{\\mathbb{Z}/p}$.",
+    "significance": "key",
+    "relatedConcepts": ["dichotomy", "fixed-point set", "Smith theory", "equivariant obstruction"],
+    "prerequisites": ["equivariant cohomology", "Smith theory", "Borsuk-Ulam theorem"]
+  }
+]

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-04/meta.json
@@ -1,0 +1,159 @@
+{
+  "id": "borsuk-ulam-oq-02-oq-04",
+  "title": "Non-Free Z/p Index: The Localization Collapse",
+  "slug": "borsuk-ulam-oq-02-oq-04",
+  "description": "Axiomatized resolution of the open question whether the equivariant (Fadell-Husseini / Dold) cohomological index still controls vanishing for NON-FREE Z/p actions. Answer: it does not. By the Borel localization theorem a single fixed point splits the structure map H*(BG) -> H*_G(X), so the index collapses to the trivial value +infinity on every fixed-point space, losing all discriminating power. Vanishing is still forced, but trivially, by the nonempty fixed-point set (Smith theory). From 10 axioms we derive 11 theorems separating the free (finite, dimension-sensitive) regime from the non-free (constant +infinity) collapse.",
+  "meta": {
+    "author": "Lean Genius (after Fadell-Husseini 1988, Dold 1983, Smith 1938, Borel 1960)",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/BorsukUlamOQ02OQ04.lean",
+    "tags": [
+      "topology",
+      "algebraic-topology",
+      "borsuk-ulam",
+      "equivariant",
+      "cohomology",
+      "group-actions",
+      "localization",
+      "smith-theory",
+      "fadell-husseini",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 10,
+    "lineCount": 264,
+    "assumptions": "Carriers: Space (Z/p-spaces), idx (Fadell-Husseini index in WithTop Nat), GMap (existence of equivariant map), HasFixedPoint (fixed-point set nonempty), freeSphere (free Z/p-spheres), ZeroAvoidingMap (test-map relation). Properties: idx_freeSphere (free index = n), idx_mono (equivariant maps increase index), idx_localization (a fixed point trivializes the index: idx = TOP), zeroAvoiding_iff (test-map scheme: zero-avoiding map <-> map to free sphere).",
+    "originalContributions": [
+      "Resolves OQ-02-OQ-04: for non-free Z/p actions the equivariant index does NOT control vanishing; it collapses to +infinity and control passes to the fixed-point set",
+      "Models the Fadell-Husseini / Dold index in WithTop Nat with TOP = '+infinity = index ideal 0 = no obstruction', cleanly capturing the localization degeneration",
+      "Proved index_controls_free: the finite free index recovers the classical Borsuk-Ulam / Yang obstruction",
+      "Proved idx_localization-driven collapse: index_trivial_of_fixedPoint, index_no_discrimination (the index is constant on all fixed-point spaces)",
+      "Proved no_map_to_free_sphere_of_fixedPoint and vanishing_forced_of_fixedPoint: vanishing is forced for non-free actions despite the trivial index",
+      "Proved index_control_dichotomy and control_passes_to_fixedPoints: the packaged answer separating the free and non-free regimes",
+      "Formalizability assessment isolating idx_localization (the splitting H*(BG) -> H*_G(X)) as the single axiom doing the real work"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "WithTop.top_le_iff",
+        "description": "In WithTop, TOP <= a iff a = TOP; drives the non-free collapse proofs",
+        "module": "Mathlib.Order.WithBot"
+      },
+      {
+        "theorem": "WithTop.coe_ne_top",
+        "description": "A finite coerced value is never TOP; separates the free and non-free regimes",
+        "module": "Mathlib.Order.WithBot"
+      }
+    ],
+    "theoremCount": 11,
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "Borsuk-Ulam (1933) is governed, in its modern cohomological form, by the equivariant index of a FREE group action: Dold (1983) and Fadell-Husseini (1988) attach to each free Z/p-space a numerical / ideal-valued index whose monotonicity under equivariant maps is the engine of every Borsuk-Ulam bound. But almost all naturally occurring actions are NOT free. The behaviour of the index under fixed points is governed by two classical pillars of transformation-group theory: P.A. Smith's fixed-point theory (1938), which shows a Z/p-action on a mod-p homology sphere is either free or has a nonempty fixed-point set, and Borel's localization theorem (1960), which shows equivariant cohomology is controlled, after inverting the Euler class, by the fixed-point set. Together they predict that the index must degenerate once a fixed point appears -- the question OQ-02-OQ-04 makes precise.",
+    "problemStatement": "For a non-free $\\mathbb{Z}/p$-action ($p$ prime), does the equivariant cohomological index $\\iota(X)$ still control vanishing -- i.e. still determine which equivariant maps $X \\to W \\setminus \\{0\\}$ exist -- or does control pass to the fixed-point set $X^{\\mathbb{Z}/p}$? Make the dichotomy precise and prove it.",
+    "proofStrategy": "Model $\\iota$ as a value in $\\mathrm{WithTop}\\,\\mathbb{N}$, with $\\top$ standing for $+\\infty$ (index ideal $0$, no obstruction). Axiomatize the free-sphere value $\\iota(S^n)=n$, monotonicity under equivariant maps, the localization collapse $\\mathrm{HasFixedPoint}(X)\\Rightarrow \\iota(X)=\\top$, and the test-map equivalence between zero-avoiding maps and maps to free spheres. From these, derive (free regime) the Borsuk-Ulam bound and dimension-discrimination, and (non-free regime) that $\\iota$ is constant $\\top$, admits no map to any free sphere, and forces vanishing trivially -- the discriminating data being $\\mathrm{HasFixedPoint}$ itself.",
+    "keyInsights": [
+      "A single Z/p-fixed point splits the structure map H*(BG) -> H*_G(X) (restriction to the fixed point is a retraction), so the map is injective and NO Euler-class power dies: the index is +infinity",
+      "The free index is finite and dimension-sensitive (it discriminates S^n from S^m); the non-free index is the constant +infinity (it discriminates nothing) -- this is the precise sense in which control is lost",
+      "Vanishing is still forced for non-free actions, but for a trivial reason: the fixed point x0 maps into the fixed subspace W^{Z/p} = {0} of any fixed-point-free representation, so f(x0) = 0 directly -- no global topology is used",
+      "Control passes to the fixed-point set X^{Z/p}, which is nonempty exactly when the action is non-free (Smith theory for Z/p on mod-p homology spheres)",
+      "The order structure of WithTop Nat captures the collapse exactly: TOP <= n is impossible for finite n, which is why a fixed-point space admits no equivariant map to a free sphere"
+    ]
+  },
+  "sections": [
+    {
+      "id": "carriers",
+      "title": "The Index Theory (Carriers)",
+      "startLine": 56,
+      "endLine": 100,
+      "summary": "Axiomatizes the carrier type of Z/p-spaces, the index idx valued in WithTop Nat, the equivariant-map relation GMap, the fixed-point predicate HasFixedPoint, the free spheres, and the zero-avoiding test-map relation.",
+      "mathContext": "The index iota(X) is the Fadell-Husseini numerical height: the largest k for which the k-th Euler-class power survives in H*_G(X). TOP encodes +infinity, i.e. the index ideal is 0 and carries no obstruction."
+    },
+    {
+      "id": "properties",
+      "title": "Axiomatized Properties",
+      "startLine": 102,
+      "endLine": 132,
+      "summary": "Four properties: free-sphere value (iota = n), monotonicity under equivariant maps, the localization collapse (a fixed point forces iota = TOP), and the test-map equivalence.",
+      "mathContext": "idx_localization is the crux -- the Borel localization / splitting that trivializes the index. The other three are the standard free-theory axioms shared with the Dold and Fadell-Husseini formalizations."
+    },
+    {
+      "id": "free-regime",
+      "title": "The Free Theory: the index DOES control",
+      "startLine": 134,
+      "endLine": 170,
+      "summary": "From a finite index, derives the Borsuk-Ulam bound (no map freeSphere n -> freeSphere m for m < n), finiteness of the obstruction, dimension-discrimination, and strict monotonicity.",
+      "mathContext": "This is the regime of OQ02OQ03 (Dold) and OQ02OQ01OQ04 (Fadell-Husseini): the index is a finite, dimension-sensitive obstruction governing equivariant maps between free spheres."
+    },
+    {
+      "id": "nonfree-collapse",
+      "title": "The Non-Free Collapse: the index does NOT control",
+      "startLine": 172,
+      "endLine": 214,
+      "summary": "From the localization axiom, derives that the index is TOP on every fixed-point space, is constant there (no discrimination), forbids equivariant maps to free spheres, and forces vanishing.",
+      "mathContext": "The localization collapse: idx = +infinity exceeds every finite index, so monotonicity forbids a map to a free sphere, and via the test-map scheme every map into a fixed-point-free representation has a zero."
+    },
+    {
+      "id": "dichotomy",
+      "title": "The Dichotomy (answer to OQ-02-OQ-04)",
+      "startLine": 216,
+      "endLine": 244,
+      "summary": "Packages the answer: for non-free X the index degenerates to TOP yet vanishing is forced; the index never matches a free index; control passes to the fixed-point set.",
+      "mathContext": "The free and non-free regimes are cleanly separated by the index, but the index is informative only in the free one. For non-free actions the discriminating invariant is HasFixedPoint, not iota."
+    },
+    {
+      "id": "formalizability",
+      "title": "Formalizability Assessment",
+      "startLine": 246,
+      "endLine": 263,
+      "summary": "Gap analysis: ~2250 lines of Borel equivariant cohomology, localization, Smith theory, and the Fadell-Husseini index needed to remove the axioms. The single load-bearing axiom is idx_localization (the splitting).",
+      "mathContext": "With a Borel-cohomology layer, idx_localization is a 1-line consequence of the retraction X -> {x0} -> X. Everything else here is order arithmetic on WithTop Nat."
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization resolves the open question OQ-02-OQ-04 in the negative: for non-free Z/p actions the equivariant cohomological index does NOT control vanishing. From 10 axioms (modelling the index in WithTop Nat with TOP = +infinity, plus monotonicity, the localization collapse, and the test-map scheme) we derive 11 machine-verified theorems. The free regime recovers the classical finite, dimension-sensitive Borsuk-Ulam obstruction; the non-free regime collapses to the constant +infinity, forbids equivariant maps to free spheres, and forces vanishing trivially via the fixed point -- so the genuine control passes to the (nonempty) fixed-point set.",
+    "implications": "The dichotomy explains why combinatorial applications of Borsuk-Ulam (Kneser, Schrijver, Necklace Splitting) insist on FREE actions: freeness is exactly what keeps the index finite and discriminating. For non-free configuration spaces one must instead analyze the fixed-point stratum directly, as in equivariant obstruction theory. The formalization isolates the localization splitting H*(BG) -> H*_G(X) as the single highest-value Mathlib target: with it, the collapse is a one-line corollary.",
+    "openQuestions": [
+      "Can the Borel localization theorem (a fixed point splits H*(BG) -> H*_G(X)) be formalized in Mathlib on top of an equivariant-cohomology layer, turning idx_localization into a proved lemma?",
+      "For PARTIALLY free actions (free away from a lower-dimensional fixed stratum), can a relative index valued in the cohomology of the fixed-point set restore quantitative control of vanishing?",
+      "Does the analogous collapse hold for non-free actions of elementary abelian p-groups (Z/p)^k, where the Fadell-Husseini index is ideal-valued rather than numerical?"
+    ]
+  },
+  "openQuestions": [],
+  "crossReferences": [
+    {
+      "targetId": "borsuk-ulam-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Direct sibling and free-theory counterpart: OQ02OQ03 formalizes the Dold index for FREE G-spaces (finite, dimension-sensitive); this file shows what happens to that index when freeness fails."
+    },
+    {
+      "targetId": "borsuk-ulam-oq-02-oq-01-oq-04",
+      "relationship": "extends",
+      "description": "The Fadell-Husseini ideal-valued index whose numerical height this file uses; here the height degenerates to +infinity precisely when the FH index ideal collapses to 0 under a fixed point."
+    },
+    {
+      "targetId": "borsuk-ulam-oq-02",
+      "relationship": "extends",
+      "description": "Parent OQ on equivariant Borsuk-Ulam for other group actions; this file answers the non-free branch of that program for Z/p."
+    },
+    {
+      "targetId": "borsuk-ulam",
+      "relationship": "related",
+      "description": "Grandparent: the classical Z/2 antipodal Borsuk-Ulam, the prototypical FREE-action case where the index is finite and fully controls vanishing."
+    },
+    {
+      "targetId": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "Conceptual dual: where Borsuk-Ulam exploits free actions and the index, fixed-point phenomena (Brouwer, Smith) govern the non-free regime onto which control here collapses."
+    }
+  ],
+  "leanFile": {
+    "axiomCount": 10,
+    "lineCount": 264,
+    "path": "Proofs/BorsukUlamOQ02OQ04.lean",
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 11
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Open Question

**OQ-02-OQ-04:** For non-free `Z/p` actions (p prime), does the equivariant (Fadell-Husseini / Dold) cohomological index still control vanishing, or does control pass to the fixed-point set?

## Answer

**No — the index does NOT control vanishing for non-free actions.** By the Borel localization theorem, a single `Z/p`-fixed point `x0` splits the structure map `H*(BG) → H*_G(X)` (restriction to `x0` is a retraction), so the map is injective, no Euler-class power dies, and the numerical index `ι(X) = +∞` (index ideal `= 0`). The index becomes **constant on every fixed-point space**, losing all discriminating power. Vanishing is still forced, but trivially: the obstruction migrates to the fixed-point set `X^{Z/p}`, which is nonempty for a non-free `Z/p`-action on a mod-p homology sphere (Smith theory). A fixed point `x0` of a `Z/p`-map into a fixed-point-free representation `W` must land in `W^{Z/p} = {0}`, so `f(x0) = 0`.

This is the exact opposite of the **free** regime (cf. OQ02OQ03 Dold, OQ02OQ01OQ04 Fadell-Husseini), where `ι` is finite, dimension-sensitive, and is precisely the obstruction governing which equivariant maps exist.

## Formalization

`proofs/Proofs/BorsukUlamOQ02OQ04.lean` (registered in `Proofs.lean`):
- Index modeled in `WithTop ℕ` with `⊤ = +∞ = no obstruction`.
- **10 axioms** (6 carriers + 4 properties), **11 theorems**, **0 sorries**.
- Load-bearing axiom: `idx_localization` (the splitting). Everything else is order arithmetic on `WithTop ℕ` (`WithTop.top_le_iff`, `WithTop.coe_ne_top`).
- Key theorems: `index_controls_free` (finite free regime recovers classical Borsuk-Ulam / Yang), `index_no_discrimination`, `no_map_to_free_sphere_of_fixedPoint`, `vanishing_forced_of_fixedPoint`, `index_control_dichotomy`, `control_passes_to_fixedPoints`.

## Status

**`axiomatized`** (badge `axiom`). De-axiomatization requires a Borel equivariant cohomology layer in Mathlib (~2250 lines: `H*_G`, Euler class, localization, Smith theory, FH index) — assessed in Part VI of the Lean file. With it, `idx_localization` is a 1-line consequence of the retraction `X → {x0} → X`.

## Verification

Builds clean: `✔ [3058/3058] Built Proofs.BorsukUlamOQ02OQ04 (21s)`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)