### PR TITLE
research(amgm-oq-03-02-04-02): HM ≤ GM ≤ AM as power means M₋₁ ≤ M₀ ≤ M₁ [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -92,6 +92,7 @@ import Proofs.AmgmInequalityOQ03OQ02OQ01
 import Proofs.AmgmInequalityOQ03OQ02OQ01OQ01
 import Proofs.AmgmInequalityOQ03OQ02OQ01OQ02
 import Proofs.AmgmInequalityOQ03OQ02OQ04
+import Proofs.AmgmInequalityOQ03OQ02OQ04OQ02
 import Proofs.AmgmInequalityOQ03OQ03
 import Proofs.AmgmInequalityOQ03OQ04
 import Proofs.AmgmInequalityOQ04

--- a/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04OQ02.lean
@@ -1,0 +1,146 @@
+/-
+  AM-GM OQ-03-OQ-02-OQ-04-OQ-02: The HM ≤ GM ≤ AM chain as power means
+
+  The power mean of a positive family x : ι → ℝ at exponent r is
+    M_r(x) = (Σ xᵢ^r / n)^{1/r}    (r ≠ 0),     M_0(x) = (Π xᵢ)^{1/n}.
+  Three classical means are the values at r = -1, 0, 1:
+    M_{-1}(x) = n / (Σ xᵢ⁻¹)   = harmonic mean   (HM)
+    M_0(x)    = (Π xᵢ)^{1/n}   = geometric mean  (GM)
+    M_1(x)    = (Σ xᵢ) / n     = arithmetic mean (AM)
+
+  We prove the two adjacent links of the power-mean monotonicity chain at these
+  exponents, i.e. the full HM ≤ GM ≤ AM inequality:
+    M_{-1}(x) ≤ M_0(x) ≤ M_1(x).
+
+  The two inequalities are obtained from Mathlib's weighted mean inequalities
+  (`Real.harm_mean_le_geom_mean_weighted`, `Real.geom_mean_le_arith_mean_weighted`)
+  specialised to the uniform weights wᵢ = 1/n; the new content here is the
+  identification of HM/GM/AM with the unified power-mean object M_r at the three
+  exponents, packaging the classical chain inside the power-mean framework that
+  the parent (amgm-inequality-oq-03-oq-02-oq-04) uses to study the r → ±∞ limits.
+
+  Parent: amgm-inequality-oq-03-oq-02-oq-04 (extreme power-mean limits)
+-/
+import Mathlib
+
+namespace AmgmOQ03OQ02OQ04OQ02
+
+open Real Finset
+
+variable {ι : Type*} [Fintype ι] [Nonempty ι]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART I: DEFINITIONS
+-- ═══════════════════════════════════════════════════════════════
+
+/-- Unweighted power mean at exponent `r` (matches the parent's definition). -/
+noncomputable def powerMean (x : ι → ℝ) (r : ℝ) : ℝ :=
+  if r = 0 then (∏ i : ι, x i) ^ ((Fintype.card ι : ℝ)⁻¹)
+  else ((∑ i : ι, (x i) ^ r) / Fintype.card ι) ^ (1 / r)
+
+/-- Arithmetic mean `(Σ xᵢ)/n`. -/
+noncomputable def arithMean (x : ι → ℝ) : ℝ := (∑ i : ι, x i) / Fintype.card ι
+
+/-- Geometric mean `(Π xᵢ)^{1/n}`. -/
+noncomputable def geomMean (x : ι → ℝ) : ℝ := (∏ i : ι, x i) ^ ((Fintype.card ι : ℝ)⁻¹)
+
+/-- Harmonic mean `n / (Σ xᵢ⁻¹)`. -/
+noncomputable def harmMean (x : ι → ℝ) : ℝ := (Fintype.card ι : ℝ) / (∑ i : ι, (x i)⁻¹)
+
+private lemma card_ne_zero : (Fintype.card ι : ℝ) ≠ 0 :=
+  Nat.cast_ne_zero.mpr Fintype.card_pos.ne'
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART II: THE THREE CLASSICAL MEANS AS POWER MEANS
+-- ═══════════════════════════════════════════════════════════════
+
+omit [Nonempty ι] in
+/-- The power mean at exponent `1` is the arithmetic mean. -/
+lemma powerMean_one (x : ι → ℝ) : powerMean x 1 = arithMean x := by
+  rw [powerMean, if_neg one_ne_zero, arithMean]
+  simp only [Real.rpow_one, div_one]
+
+omit [Nonempty ι] in
+/-- The power mean at exponent `0` is the geometric mean (by definition). -/
+lemma powerMean_zero (x : ι → ℝ) : powerMean x 0 = geomMean x := by
+  rw [powerMean, if_pos rfl]; rfl
+
+omit [Nonempty ι] in
+/-- The power mean at exponent `-1` is the harmonic mean. -/
+lemma powerMean_neg_one (x : ι → ℝ) (hx : ∀ i, 0 < x i) :
+    powerMean x (-1) = harmMean x := by
+  have hne : (-1 : ℝ) ≠ 0 := by norm_num
+  have hsum : ∑ i : ι, (x i) ^ (-1 : ℝ) = ∑ i : ι, (x i)⁻¹ := by
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [Real.rpow_neg_one]
+  have hbase : 0 ≤ (∑ i : ι, (x i)⁻¹) / (Fintype.card ι : ℝ) :=
+    div_nonneg (Finset.sum_nonneg fun i _ => (inv_pos.2 (hx i)).le) (Nat.cast_nonneg _)
+  rw [powerMean, if_neg hne, harmMean, hsum,
+      show (1 : ℝ) / (-1) = -(1 : ℝ) by norm_num,
+      Real.rpow_neg hbase, Real.rpow_one, inv_div]
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART III: THE TWO LINKS OF THE CHAIN
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **GM ≤ AM** (the link `M₀ ≤ M₁`): the geometric mean is at most the
+    arithmetic mean. Specialises Mathlib's weighted AM-GM to uniform weights. -/
+theorem geomMean_le_arithMean (x : ι → ℝ) (hx : ∀ i, 0 ≤ x i) :
+    geomMean x ≤ arithMean x := by
+  have hn' : (Fintype.card ι : ℝ) ≠ 0 := card_ne_zero
+  have hw : ∀ i ∈ (univ : Finset ι), (0 : ℝ) ≤ (Fintype.card ι : ℝ)⁻¹ :=
+    fun _ _ => by positivity
+  have hw' : ∑ _i ∈ (univ : Finset ι), (Fintype.card ι : ℝ)⁻¹ = 1 := by
+    rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+    exact mul_inv_cancel₀ hn'
+  have key := Real.geom_mean_le_arith_mean_weighted (univ : Finset ι)
+    (fun _ => (Fintype.card ι : ℝ)⁻¹) x hw hw' (fun i _ => hx i)
+  rw [geomMean, arithMean]
+  calc (∏ i : ι, x i) ^ ((Fintype.card ι : ℝ)⁻¹)
+      = ∏ i : ι, (x i) ^ ((Fintype.card ι : ℝ)⁻¹) :=
+        (Real.finset_prod_rpow univ x (fun i _ => hx i) _).symm
+    _ ≤ ∑ i : ι, (Fintype.card ι : ℝ)⁻¹ * x i := key
+    _ = (∑ i : ι, x i) / Fintype.card ι := by
+        rw [← Finset.mul_sum, div_eq_mul_inv, mul_comm]
+
+/-- **HM ≤ GM** (the link `M₋₁ ≤ M₀`): the harmonic mean is at most the
+    geometric mean. Specialises Mathlib's weighted HM-GM to uniform weights. -/
+theorem harmMean_le_geomMean (x : ι → ℝ) (hx : ∀ i, 0 < x i) :
+    harmMean x ≤ geomMean x := by
+  have hn' : (Fintype.card ι : ℝ) ≠ 0 := card_ne_zero
+  have hw : ∀ i ∈ (univ : Finset ι), (0 : ℝ) < (Fintype.card ι : ℝ)⁻¹ :=
+    fun _ _ => by positivity
+  have hw' : ∑ _i ∈ (univ : Finset ι), (Fintype.card ι : ℝ)⁻¹ = 1 := by
+    rw [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+    exact mul_inv_cancel₀ hn'
+  have key := Real.harm_mean_le_geom_mean_weighted (univ : Finset ι)
+    (fun _ => (Fintype.card ι : ℝ)⁻¹) x univ_nonempty hw hw' (fun i _ => hx i)
+  rw [harmMean, geomMean]
+  calc (Fintype.card ι : ℝ) / (∑ i : ι, (x i)⁻¹)
+      = (∑ i : ι, (Fintype.card ι : ℝ)⁻¹ / x i)⁻¹ := by
+        have hsum : ∑ i : ι, (Fintype.card ι : ℝ)⁻¹ / x i
+            = (Fintype.card ι : ℝ)⁻¹ * ∑ i : ι, (x i)⁻¹ := by
+          rw [Finset.mul_sum]
+          exact Finset.sum_congr rfl (fun i _ => div_eq_mul_inv _ _)
+        rw [hsum, mul_inv, inv_inv, div_eq_mul_inv]
+    _ ≤ ∏ i : ι, (x i) ^ ((Fintype.card ι : ℝ)⁻¹) := key
+    _ = (∏ i : ι, x i) ^ ((Fintype.card ι : ℝ)⁻¹) :=
+        Real.finset_prod_rpow univ x (fun i _ => (hx i).le) _
+
+-- ═══════════════════════════════════════════════════════════════
+-- PART IV: THE FULL CHAIN
+-- ═══════════════════════════════════════════════════════════════
+
+/-- **HM ≤ GM ≤ AM** stated for the classical means. -/
+theorem harm_le_geom_le_arith (x : ι → ℝ) (hx : ∀ i, 0 < x i) :
+    harmMean x ≤ geomMean x ∧ geomMean x ≤ arithMean x :=
+  ⟨harmMean_le_geomMean x hx, geomMean_le_arithMean x (fun i => (hx i).le)⟩
+
+/-- **The power-mean chain `M₋₁ ≤ M₀ ≤ M₁`** stated for `powerMean`. -/
+theorem powerMean_chain (x : ι → ℝ) (hx : ∀ i, 0 < x i) :
+    powerMean x (-1) ≤ powerMean x 0 ∧ powerMean x 0 ≤ powerMean x 1 := by
+  rw [powerMean_neg_one x hx, powerMean_zero, powerMean_one]
+  exact harm_le_geom_le_arith x hx
+
+end AmgmOQ03OQ02OQ04OQ02

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04-oq-02/meta.json
@@ -1,0 +1,241 @@
+{
+  "id": "amgm-inequality-oq-03-oq-02-oq-04-oq-02",
+  "title": "The Pythagorean Means as Power Means: HM ≤ GM ≤ AM",
+  "slug": "amgm-inequality-oq-03-oq-02-oq-04-oq-02",
+  "description": "Identifies the three classical (Pythagorean) means as power means at the exponents r = -1, 0, 1 — HM = M₋₁, GM = M₀, AM = M₁ — and proves the two adjacent links of the power-mean monotonicity chain at these points, i.e. the full HM ≤ GM ≤ AM inequality M₋₁ ≤ M₀ ≤ M₁. Each link specialises Mathlib's weighted mean inequalities to uniform weights wᵢ = 1/n. 8 theorems/lemmas, 4 definitions, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-23",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ02OQ04OQ02.lean",
+    "tags": [
+      "analysis",
+      "inequalities",
+      "power-means",
+      "pythagorean-means",
+      "amgm"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-23",
+    "axiomCount": 0,
+    "assumptions": "None. Fully machine-verified (depends only on propext, Classical.choice, Quot.sound).",
+    "lineCount": 146,
+    "theoremCount": 8,
+    "definitionCount": 4,
+    "originalContributions": [
+      "powerMean_one / powerMean_zero / powerMean_neg_one: closed-form identification of the arithmetic, geometric and harmonic means as the power mean M_r at r = 1, 0, -1 — the bridge that places the three classical means inside the single power-mean object used by the parent entry",
+      "harm_le_geom_le_arith and powerMean_chain: the full HM ≤ GM ≤ AM inequality, stated both for the named means and as the power-mean monotonicity chain M₋₁ ≤ M₀ ≤ M₁, answering the open question posed in the parent (amgm-inequality-oq-03-oq-02-oq-04)"
+    ],
+    "prerequisites": [
+      "Unweighted power mean M_r(x) = (Σ xᵢ^r / n)^{1/r} on a finite, nonempty index type ι (matching the parent's definition)",
+      "Real power function rpow and its identities (Real.rpow_one, Real.rpow_neg_one, Real.rpow_neg, Real.finset_prod_rpow)",
+      "Mathlib's weighted mean inequalities (Real.geom_mean_le_arith_mean_weighted, Real.harm_mean_le_geom_mean_weighted)",
+      "Specialisation to uniform weights wᵢ = 1/n with Σ wᵢ = 1"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.geom_mean_le_arith_mean_weighted",
+        "description": "Weighted AM-GM: ∏ zᵢ^{wᵢ} ≤ ∑ wᵢ zᵢ for nonnegative weights summing to 1. Specialised to wᵢ = 1/n it gives GM ≤ AM (geomMean_le_arithMean).",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "Real.harm_mean_le_geom_mean_weighted",
+        "description": "Weighted HM-GM: (∑ wᵢ/zᵢ)⁻¹ ≤ ∏ zᵢ^{wᵢ} for positive weights summing to 1. Specialised to wᵢ = 1/n it gives HM ≤ GM (harmMean_le_geomMean).",
+        "module": "Mathlib.Analysis.MeanInequalities"
+      },
+      {
+        "theorem": "Real.finset_prod_rpow",
+        "description": "∏ᵢ fᵢ^r = (∏ᵢ fᵢ)^r for nonnegative fᵢ. Converts the product-of-powers form returned by the weighted lemmas into the closed-form geometric mean (∏ xᵢ)^{1/n}.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_neg_one",
+        "description": "x^{-1} = x⁻¹ (rpow). Used inside the sum to rewrite Σ xᵢ^{-1} = Σ xᵢ⁻¹ when identifying M₋₁ with the harmonic mean.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_neg",
+        "description": "x^{-y} = (x^y)⁻¹ for 0 ≤ x. Applied to the outer exponent 1/(-1) = -1 to turn ((Σ xᵢ⁻¹)/n)^{-1} into the harmonic-mean closed form n/(Σ xᵢ⁻¹).",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The arithmetic, geometric and harmonic means are the three classical 'Pythagorean means' studied by the Pythagorean school and codified by Archytas and Nicomachus; the chain HM ≤ GM ≤ AM (with equality iff all entries coincide) is one of the oldest inequalities in mathematics. The unifying observation that all three are values of a single one-parameter family of power means M_r(x) = (Σ xᵢ^r / n)^{1/r} — with HM = M₋₁, GM = M₀ (the limit value), AM = M₁ — is due to the systematic theory of means developed by Schur, Hardy, Littlewood and Pólya (Inequalities, 1934, §2.9) and the quasi-arithmetic-mean characterisation of Kolmogorov and Nagumo (1930). The monotonicity M_r ≤ M_s for r ≤ s places the full interpolation min = M₋∞ ≤ HM ≤ GM ≤ AM ≤ M₊∞ = max in a single picture; this entry formalises the three central, finitely-spaced links HM ≤ GM ≤ AM.",
+    "problemStatement": "For x : ι → ℝ on a finite nonempty index type with all xᵢ > 0, prove (1) HM = M₋₁, GM = M₀, AM = M₁ as closed forms of the power mean, and (2) the chain HM ≤ GM ≤ AM, equivalently M₋₁ ≤ M₀ ≤ M₁.",
+    "text": "The power mean M_r is the same piecewise object used by the parent entry. We first compute its values at r = 1, 0, -1: M₁ reduces to (Σ xᵢ)/n via rpow_one, M₀ is the geometric mean by definition, and M₋₁ reduces to n/(Σ xᵢ⁻¹) via rpow_neg_one (inside the sum) and rpow_neg (on the outer exponent 1/(-1) = -1). The two inequalities then come from Mathlib's weighted mean inequalities at uniform weights wᵢ = 1/n: GM ≤ AM is Real.geom_mean_le_arith_mean_weighted after converting ∏ xᵢ^{1/n} = (∏ xᵢ)^{1/n} with Real.finset_prod_rpow, and HM ≤ GM is Real.harm_mean_le_geom_mean_weighted after rewriting Σ (1/n)/xᵢ = (1/n) Σ xᵢ⁻¹.",
+    "proofStrategy": "Closed-form identities (powerMean_one, powerMean_zero, powerMean_neg_one) bridge the named means and the power-mean object; the two inequality theorems specialise the corresponding weighted Mathlib lemmas to uniform weights; powerMean_chain rewrites the chain through those identities so it reads as M₋₁ ≤ M₀ ≤ M₁.",
+    "keyInsights": [
+      "All three Pythagorean means are values of one power-mean object: HM = M₋₁, GM = M₀, AM = M₁",
+      "Uniform weights wᵢ = 1/n turn the general weighted AM-GM and HM-GM lemmas into the unweighted classical chain",
+      "M₋₁ = n/(Σ xᵢ⁻¹): the outer exponent 1/(-1) = -1 plus rpow_neg gives the harmonic-mean closed form",
+      "∏ xᵢ^{1/n} = (∏ xᵢ)^{1/n} (Real.finset_prod_rpow) is the only nontrivial rewrite needed to match the geometric-mean form"
+    ],
+    "prerequisites": [
+      "powerMean definition M_r(x) = (Σ xᵢ^r / n)^{1/r} (r ≠ 0), M₀ = (∏ xᵢ)^{1/n}",
+      "Real.geom_mean_le_arith_mean_weighted and Real.harm_mean_le_geom_mean_weighted",
+      "rpow identities: Real.rpow_one, Real.rpow_neg_one, Real.rpow_neg, Real.finset_prod_rpow"
+    ]
+  },
+  "conclusion": {
+    "summary": "The classical HM ≤ GM ≤ AM chain is proved as the power-mean monotonicity links M₋₁ ≤ M₀ ≤ M₁, with the three means identified in closed form. 8 theorems/lemmas, 4 definitions, 0 sorries, 0 axioms, 146 lines.",
+    "implications": "Closes the open question posed by the parent entry (amgm-inequality-oq-03-oq-02-oq-04): the parent established the extreme limits M_r → max/min and asked for the finite Pythagorean interpolation, which this entry supplies. Together they give the endpoints (max, min) and the central rungs (HM, GM, AM) of the full power-mean ladder.",
+    "openQuestions": [
+      "Prove the full monotonicity M_r(x) ≤ M_s(x) for all r ≤ s (not just the three exponents -1, 0, 1), via convexity of t ↦ t^{s/r} and Jensen's inequality",
+      "Establish the equality case: HM = GM = AM (equivalently M_r constant in r) holds iff all xᵢ are equal"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "powerMean_one",
+      "type": "supporting",
+      "description": "The power mean at exponent 1 equals the arithmetic mean (Σ xᵢ)/n.",
+      "leanType": "(x : ι → ℝ) → powerMean x 1 = arithMean x"
+    },
+    {
+      "name": "powerMean_zero",
+      "type": "supporting",
+      "description": "The power mean at exponent 0 equals the geometric mean (∏ xᵢ)^{1/n} (by definition).",
+      "leanType": "(x : ι → ℝ) → powerMean x 0 = geomMean x"
+    },
+    {
+      "name": "powerMean_neg_one",
+      "type": "supporting",
+      "description": "The power mean at exponent -1 equals the harmonic mean n/(Σ xᵢ⁻¹), for positive xᵢ.",
+      "leanType": "(x : ι → ℝ) (hx : ∀ i, 0 < x i) → powerMean x (-1) = harmMean x"
+    },
+    {
+      "name": "geomMean_le_arithMean",
+      "type": "core",
+      "description": "GM ≤ AM (the link M₀ ≤ M₁): the geometric mean is at most the arithmetic mean. Specialises Real.geom_mean_le_arith_mean_weighted to uniform weights.",
+      "leanType": "(x : ι → ℝ) (hx : ∀ i, 0 ≤ x i) → geomMean x ≤ arithMean x"
+    },
+    {
+      "name": "harmMean_le_geomMean",
+      "type": "core",
+      "description": "HM ≤ GM (the link M₋₁ ≤ M₀): the harmonic mean is at most the geometric mean. Specialises Real.harm_mean_le_geom_mean_weighted to uniform weights.",
+      "leanType": "(x : ι → ℝ) (hx : ∀ i, 0 < x i) → harmMean x ≤ geomMean x"
+    },
+    {
+      "name": "harm_le_geom_le_arith",
+      "type": "core",
+      "description": "The full HM ≤ GM ≤ AM chain, stated for the named Pythagorean means.",
+      "leanType": "(x : ι → ℝ) (hx : ∀ i, 0 < x i) → harmMean x ≤ geomMean x ∧ geomMean x ≤ arithMean x"
+    },
+    {
+      "name": "powerMean_chain",
+      "type": "core",
+      "description": "The power-mean monotonicity chain M₋₁ ≤ M₀ ≤ M₁ at the three classical exponents, obtained from the chain via the closed-form identities.",
+      "leanType": "(x : ι → ℝ) (hx : ∀ i, 0 < x i) → powerMean x (-1) ≤ powerMean x 0 ∧ powerMean x 0 ≤ powerMean x 1"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Hardy, G. H.; Littlewood, J. E.; Pólya, G.",
+      "title": "Inequalities",
+      "year": "1934",
+      "venue": "Cambridge University Press",
+      "note": "§2.9–2.10: the power means M_r interpolate the classical means, with HM = M₋₁, GM = M₀, AM = M₁, and the monotonicity M_r ≤ M_s for r ≤ s yields HM ≤ GM ≤ AM."
+    },
+    {
+      "authors": "Kolmogorov, Andrey N.",
+      "title": "Sur la notion de la moyenne",
+      "year": "1930",
+      "venue": "Atti della Reale Accademia Nazionale dei Lincei. Rendiconti, 12, 388–391",
+      "note": "Axiomatic characterisation of the quasi-arithmetic means; the power means are the canonical one-parameter family containing HM, GM and AM."
+    },
+    {
+      "authors": "Bullen, P. S.",
+      "title": "Handbook of Means and Their Inequalities",
+      "year": "2003",
+      "venue": "Mathematics and Its Applications, Vol. 560, Springer (Kluwer)",
+      "doi": "10.1007/978-94-017-0399-4",
+      "note": "Chapter II surveys the Pythagorean means and the power-mean inequality; the chain HM ≤ GM ≤ AM is Theorem 1 of §II.2."
+    },
+    {
+      "authors": "Mathlib contributors",
+      "title": "Mathlib.Analysis.MeanInequalities",
+      "year": "2024",
+      "venue": "Mathlib4",
+      "url": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/MeanInequalities.html",
+      "note": "Provides Real.geom_mean_le_arith_mean_weighted and Real.harm_mean_le_geom_mean_weighted, the weighted mean inequalities specialised here to uniform weights."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Finset"
+    ],
+    "namespace": "AmgmOQ03OQ02OQ04OQ02",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "sorries": 0,
+    "path": "Proofs/AmgmInequalityOQ03OQ02OQ04OQ02.lean",
+    "theoremCount": 8,
+    "definitionCount": 4
+  },
+  "crossReferences": [
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02-oq-04",
+      "relationship": "parent",
+      "description": "Extreme Power Mean Limits: M_r → max and min (poses the HM ≤ GM ≤ AM interpolation as an open question)"
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-02",
+      "relationship": "foundational",
+      "description": "Power Mean Limit: lim_{r→0} M_r = GM (identifies M₀ with the geometric mean)"
+    },
+    {
+      "targetId": "amgm-inequality-oq-03",
+      "relationship": "foundational",
+      "description": "Power Mean Interpolation: Weighted Power Means"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "foundational",
+      "description": "Arithmetic Mean - Geometric Mean Inequality"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring documenting the Pythagorean means as power means and the HM ≤ GM ≤ AM chain, Mathlib import, namespace/open declarations, and the finite nonempty index type ι."
+    },
+    {
+      "id": "sec-definitions",
+      "title": "Definitions",
+      "startLine": 37,
+      "endLine": 51,
+      "summary": "The power mean M_r (matching the parent), plus the arithmetic, geometric and harmonic means in closed form, and a private nonzero-cardinality lemma."
+    },
+    {
+      "id": "sec-identities",
+      "title": "The Three Classical Means as Power Means",
+      "startLine": 53,
+      "endLine": 87,
+      "summary": "powerMean_one (M₁ = AM), powerMean_zero (M₀ = GM, by definition) and powerMean_neg_one (M₋₁ = HM, via rpow_neg_one inside the sum and rpow_neg on the outer exponent)."
+    },
+    {
+      "id": "sec-links",
+      "title": "The Two Links of the Chain",
+      "startLine": 88,
+      "endLine": 133,
+      "summary": "geomMean_le_arithMean (GM ≤ AM) and harmMean_le_geomMean (HM ≤ GM), each specialising the corresponding weighted Mathlib mean inequality to uniform weights wᵢ = 1/n."
+    },
+    {
+      "id": "sec-chain",
+      "title": "The Full Chain",
+      "startLine": 134,
+      "endLine": 146,
+      "summary": "harm_le_geom_le_arith (HM ≤ GM ≤ AM for the named means) and powerMean_chain (the same as M₋₁ ≤ M₀ ≤ M₁ via the closed-form identities)."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Formalizes the classical **HM ≤ GM ≤ AM** chain inside the power-mean framework, answering the open question explicitly posed by the parent entry `amgm-inequality-oq-03-oq-02-oq-04` ("Formalize the full Pythagorean means interpolation: HM ≤ GM ≤ AM as special cases of the power mean monotonicity chain").

The three Pythagorean means are identified as values of the single power-mean object `M_r(x) = (Σ xᵢ^r / n)^{1/r}` (the parent's definition):

- `powerMean_one`: **AM** = M₁ = (Σ xᵢ)/n
- `powerMean_zero`: **GM** = M₀ = (∏ xᵢ)^{1/n}
- `powerMean_neg_one`: **HM** = M₋₁ = n/(Σ xᵢ⁻¹)

and the two adjacent links of the monotonicity chain are proved:

- `geomMean_le_arithMean`: **GM ≤ AM** (M₀ ≤ M₁)
- `harmMean_le_geomMean`: **HM ≤ GM** (M₋₁ ≤ M₀)
- `harm_le_geom_le_arith` / `powerMean_chain`: the full **HM ≤ GM ≤ AM**, i.e. M₋₁ ≤ M₀ ≤ M₁

Each inequality specialises a Mathlib weighted mean inequality (`Real.geom_mean_le_arith_mean_weighted`, `Real.harm_mean_le_geom_mean_weighted`) to the uniform weights wᵢ = 1/n. The new content is the closed-form identification linking the named means to the power-mean object, packaging the classical chain in the same framework the parent uses for the r → ±∞ limits.

## Verification

- **Status**: verified, **0 axioms** (depends only on `propext`, `Classical.choice`, `Quot.sound`)
- 0 sorries, 0 `native_decide`
- 8 theorems/lemmas, 4 definitions, 146 lines
- `lake env lean Proofs/AmgmInequalityOQ03OQ02OQ04OQ02.lean` → exit 0, 0 errors (docker host build; docker daemon down)

## Files
- `proofs/Proofs/AmgmInequalityOQ03OQ02OQ04OQ02.lean` (new)
- `proofs/Proofs.lean` (import added)
- `src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04-oq-02/meta.json` (new gallery entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)