### PR TITLE
research(fibonacci-identities-oq-03-oq-03): F₂ₙ = Fₙ·Lₙ — even-doubling difference of squares factors as a Fibonacci–Lucas product

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2784,6 +2784,7 @@ import Proofs.FibonacciIdentitiesOQ02
 import Proofs.FibonacciIdentitiesOQ03
 import Proofs.FibonacciIdentitiesOQ03OQ01
 import Proofs.FibonacciIdentitiesOQ03OQ02
+import Proofs.FibonacciIdentitiesOQ03OQ03
 import Proofs.FibonacciIdentitiesOQ04
 import Proofs.FibonacciIdentitiesOQ04OQ01
 import Proofs.FiveColorTheorem

--- a/proofs/Proofs/FibonacciIdentitiesOQ03OQ03.lean
+++ b/proofs/Proofs/FibonacciIdentitiesOQ03OQ03.lean
@@ -1,0 +1,143 @@
+import Mathlib
+
+/-
+# The symmetric even-doubling identity `F_{2n} = F_{n+1}² − F_{n−1}²` and its Lucas factorization
+
+The parent entry `FibonacciIdentitiesOQ03` records the fast-doubling identities in the
+form Mathlib stores them:
+
+* `Nat.fib_two_mul_add_one` : `fib (2n+1) = fib (n+1)² + fib n²`   (odd → sum of two squares),
+* an even **difference of squares** `fib (2n+2) = fib (n+2)² − fib n²`.
+
+This entry supplies the *symmetric* reading of the even case, the form in which the
+open question states it,
+
+  `F_{2n} = F_{n+1}² − F_{n−1}²`,
+
+and — the new content — recognises that as a **difference of two squares that factors**:
+
+  `F_{n+1}² − F_{n−1}² = (F_{n+1} − F_{n−1})·(F_{n+1} + F_{n−1}) = F_n · L_n`,
+
+where `L_n = F_{n−1} + F_{n+1}` is the `n`-th **Lucas number**.  This is the classical
+Fibonacci–Lucas doubling identity
+
+  `F_{2n} = F_n · L_n`.
+
+Lucas numbers appear nowhere in the Fibonacci gallery and are not packaged in Mathlib's
+`Nat.fib` API, so we introduce them here with the standard recurrence `L_0 = 2`, `L_1 = 1`,
+`L_{n+2} = L_n + L_{n+1}`, prove the bridge `L_{n+1} = F_n + F_{n+2}` (equivalently
+`L_m = F_{m−1} + F_{m+1}`) by two-step induction, and read off the factorisation.
+
+Everything is elementary: the bridge is two-step induction on the shared recurrence, and
+the doubling/factorisation identities combine Mathlib's `Nat.fib_two_mul_add_two` with the
+Fibonacci recurrence `Nat.fib_add_two` and close by `ring`/`linarith`.  All `decide` checks
+use kernel reduction (no `native_decide`), so the entry carries no axioms.
+-/
+
+namespace FibonacciIdentitiesOQ03OQ03
+
+/-- **Lucas numbers** `L_n`: `L_0 = 2`, `L_1 = 1`, `L_{n+2} = L_n + L_{n+1}`.
+The Lucas sequence shares the Fibonacci recurrence but starts `2, 1, 3, 4, 7, 11, …`. -/
+def lucas : ℕ → ℕ
+  | 0 => 2
+  | 1 => 1
+  | (n + 2) => lucas n + lucas (n + 1)
+
+@[simp] theorem lucas_zero : lucas 0 = 2 := rfl
+
+@[simp] theorem lucas_one : lucas 1 = 1 := rfl
+
+/-- The defining Lucas recurrence `L_{n+2} = L_n + L_{n+1}`. -/
+theorem lucas_add_two (n : ℕ) : lucas (n + 2) = lucas n + lucas (n + 1) := rfl
+
+/-- **Lucas via Fibonacci.** `L_{n+1} = F_n + F_{n+2}`, i.e. `L_m = F_{m−1} + F_{m+1}`.
+Proof by two-step induction: both sequences obey `x_{n+2} = x_n + x_{n+1}` and agree on the
+two base indices, so the closed combination of Fibonacci values satisfies the Lucas
+recurrence and matches the Lucas initial data. -/
+theorem lucas_succ_eq_fib_add_fib (n : ℕ) :
+    lucas (n + 1) = Nat.fib n + Nat.fib (n + 2) := by
+  induction n using Nat.twoStepInduction with
+  | zero => decide
+  | one => decide
+  | more n h0 h1 =>
+    -- `Nat.twoStepInduction` hands back `h1` with un-normalised indices
+    -- (`lucas (n+1+1)`, `Nat.fib (n+1+2)`); restate it in canonical `n+2 / n+3`
+    -- form so `omega` shares atoms with the recurrence facts below.
+    have h1' : lucas (n + 2) = Nat.fib (n + 1) + Nat.fib (n + 3) := h1
+    show lucas (n + 3) = Nat.fib (n + 2) + Nat.fib (n + 4)
+    have e2 : Nat.fib (n + 2) = Nat.fib n + Nat.fib (n + 1) := Nat.fib_add_two
+    have e3 : Nat.fib (n + 3) = Nat.fib (n + 1) + Nat.fib (n + 2) := Nat.fib_add_two
+    have e4 : Nat.fib (n + 4) = Nat.fib (n + 2) + Nat.fib (n + 3) := Nat.fib_add_two
+    have el : lucas (n + 3) = lucas (n + 1) + lucas (n + 2) := lucas_add_two (n + 1)
+    omega
+
+/-- **Odd-index Fibonacci numbers are sums of two consecutive squares.**
+`fib (2n+1) = fib (n+1)² + fib n²` — Mathlib's `Nat.fib_two_mul_add_one`, recorded here as
+the odd half of the sum / difference-of-squares pair named in the open question. -/
+theorem fib_odd_sq_add_sq (n : ℕ) :
+    Nat.fib (2 * n + 1) = Nat.fib (n + 1) ^ 2 + Nat.fib n ^ 2 :=
+  Nat.fib_two_mul_add_one n
+
+/-- **Fibonacci–Lucas doubling (shifted form).** `fib (2n+2) = fib (n+1) · L_{n+1}`.
+The Mathlib even-doubling lemma is the product `fib (n+1)·(2·fib n + fib (n+1))`; the second
+factor is exactly `fib n + fib (n+2) = L_{n+1}`, exhibiting the Lucas factor. -/
+theorem fib_two_mul_add_two_eq_fib_mul_lucas (n : ℕ) :
+    Nat.fib (2 * n + 2) = Nat.fib (n + 1) * lucas (n + 1) := by
+  rw [Nat.fib_two_mul_add_two, lucas_succ_eq_fib_add_fib, Nat.fib_add_two]
+  ring
+
+/-- **Fibonacci–Lucas doubling identity** `F_{2n} = F_n · L_n` (for `n ≥ 1`).
+This is the headline classical identity; reindexing `m = n+1` turns the shifted form above
+into the symmetric `fib (2m) = fib m · L_m`. -/
+theorem fib_two_mul_eq_fib_mul_lucas {m : ℕ} (hm : 1 ≤ m) :
+    Nat.fib (2 * m) = Nat.fib m * lucas m := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by omega⟩
+  have e : 2 * (n + 1) = 2 * n + 2 := by ring
+  rw [e]
+  exact fib_two_mul_add_two_eq_fib_mul_lucas n
+
+/-- **Difference of squares factors as the Lucas product** (over `ℤ`).
+`fib (n+2)² − fib n² = fib (n+1) · L_{n+1}`.  This is the bridge between the even-index
+"difference of two squares" reading and the `F_n·L_n` product reading of `F_{2n}`. -/
+theorem fib_sq_sub_sq_eq_fib_mul_lucas (n : ℕ) :
+    (Nat.fib (n + 2) : ℤ) ^ 2 - (Nat.fib n : ℤ) ^ 2
+      = (Nat.fib (n + 1) : ℤ) * (lucas (n + 1) : ℤ) := by
+  have hprod : (Nat.fib (2 * n + 2) : ℤ) = (Nat.fib (n + 1) : ℤ) * (lucas (n + 1) : ℤ) := by
+    exact_mod_cast fib_two_mul_add_two_eq_fib_mul_lucas n
+  have hdiff : Nat.fib (2 * n + 2) + Nat.fib n ^ 2 = Nat.fib (n + 2) ^ 2 := by
+    rw [Nat.fib_two_mul_add_two, Nat.fib_add_two]; ring
+  have hdiffZ : (Nat.fib (2 * n + 2) : ℤ) + (Nat.fib n : ℤ) ^ 2 = (Nat.fib (n + 2) : ℤ) ^ 2 := by
+    exact_mod_cast hdiff
+  linarith
+
+/-- **The symmetric even-doubling identity** `F_{2n} = F_{n+1}² − F_{n−1}²` (over `ℤ`, `n ≥ 1`),
+the exact form named in the open question.  Combined with `fib_sq_sub_sq_eq_fib_mul_lucas`
+this difference of squares equals the Lucas product `F_n · L_n`. -/
+theorem fib_two_mul_symmetric_diff_sq {m : ℕ} (hm : 1 ≤ m) :
+    (Nat.fib (2 * m) : ℤ) = (Nat.fib (m + 1) : ℤ) ^ 2 - (Nat.fib (m - 1) : ℤ) ^ 2 := by
+  obtain ⟨n, rfl⟩ : ∃ n, m = n + 1 := ⟨m - 1, by omega⟩
+  have e : 2 * (n + 1) = 2 * n + 2 := by ring
+  simp only [Nat.add_sub_cancel]
+  rw [e]
+  show (Nat.fib (2 * n + 2) : ℤ) = (Nat.fib (n + 2) : ℤ) ^ 2 - (Nat.fib n : ℤ) ^ 2
+  have hdiff : Nat.fib (2 * n + 2) + Nat.fib n ^ 2 = Nat.fib (n + 2) ^ 2 := by
+    rw [Nat.fib_two_mul_add_two, Nat.fib_add_two]; ring
+  have hdiffZ : (Nat.fib (2 * n + 2) : ℤ) + (Nat.fib n : ℤ) ^ 2 = (Nat.fib (n + 2) : ℤ) ^ 2 := by
+    exact_mod_cast hdiff
+  linarith
+
+/-- **Existential reading.** Every even-index Fibonacci number `fib (2m)` (`m ≥ 1`) is a
+product of a Fibonacci number and a Lucas number. -/
+theorem fib_two_mul_isFibLucasProduct {m : ℕ} (hm : 1 ≤ m) :
+    ∃ a b : ℕ, Nat.fib (2 * m) = a * b ∧ a = Nat.fib m ∧ b = lucas m :=
+  ⟨Nat.fib m, lucas m, fib_two_mul_eq_fib_mul_lucas hm, rfl, rfl⟩
+
+/-- Numerical checks (kernel `decide`, no `native_decide`).
+Lucas values `L_0..L_6 = 2,1,3,4,7,11,18`; `F_{10} = 55 = F_5 · L_5 = 5 · 11`. -/
+example : lucas 5 = 11 := by decide
+
+example : Nat.fib (2 * 5) = Nat.fib 5 * lucas 5 := by decide
+
+example : Nat.fib (2 * 6) = Nat.fib 6 * lucas 6 := by decide   -- F_12 = 144 = 8 · 18
+
+end FibonacciIdentitiesOQ03OQ03

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-03/annotations.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "ann-fiboq0303-1",
+    "proofId": "fibonacci-identities-oq-03-oq-03",
+    "range": { "startLine": 3, "endLine": 35 },
+    "type": "context",
+    "title": "From Difference of Squares to the Fibonacci–Lucas Product",
+    "content": "**Module framing.** The open question asks for the doubled-index identities $F_{2n+1} = F_{n+1}^2 + F_n^2$ and the *symmetric* even form $F_{2n} = F_{n+1}^2 - F_{n-1}^2$. The odd case is Mathlib's `Nat.fib_two_mul_add_one`. The new content is reading the even case as a genuine **difference of two squares that factors**: $F_{n+1}^2 - F_{n-1}^2 = (F_{n+1}-F_{n-1})(F_{n+1}+F_{n-1}) = F_n \\cdot L_n$, where $L_n = F_{n-1}+F_{n+1}$ is the $n$-th **Lucas number**. This is the classical Fibonacci–Lucas doubling identity $F_{2n} = F_n L_n$. Lucas numbers appear nowhere in the Fibonacci gallery, so they are introduced here."
+  },
+  {
+    "id": "ann-fiboq0303-2",
+    "proofId": "fibonacci-identities-oq-03-oq-03",
+    "range": { "startLine": 39, "endLine": 51 },
+    "type": "definition",
+    "title": "Lucas Numbers and Their Recurrence",
+    "content": "**Definition.** `lucas` is the companion sequence $L_0 = 2$, $L_1 = 1$, $L_{n+2} = L_n + L_{n+1}$, starting $2, 1, 3, 4, 7, 11, 18, \\dots$. It shares the Fibonacci recurrence but with different seeds. The defining step `lucas_add_two` ($L_{n+2} = L_n + L_{n+1}$) holds by `rfl`, as do the base values $L_0 = 2$, $L_1 = 1$."
+  },
+  {
+    "id": "ann-fiboq0303-3",
+    "proofId": "fibonacci-identities-oq-03-oq-03",
+    "range": { "startLine": 53, "endLine": 74 },
+    "type": "key-step",
+    "title": "The Bridge L_{n+1} = F_n + F_{n+2} by Two-Step Induction",
+    "content": "**Lucas via Fibonacci.** The key lemma `lucas_succ_eq_fib_add_fib` proves $L_{n+1} = F_n + F_{n+2}$ (equivalently $L_m = F_{m-1}+F_{m+1}$) by `Nat.twoStepInduction`: both sides satisfy $x_{n+2}=x_n+x_{n+1}$ and agree at $n=0,1$ (checked by `decide`), so they coincide. In the step, `lucas_add_two` supplies $L_{n+3} = L_{n+1}+L_{n+2}$ and the two induction hypotheses relate the Lucas terms to Fibonacci sums; `omega` closes the linear identity given the recurrences $F_{n+2}=F_n+F_{n+1}$, $F_{n+3}=F_{n+1}+F_{n+2}$, $F_{n+4}=F_{n+2}+F_{n+3}$. A subtlety: `Nat.twoStepInduction` returns the second hypothesis with un-normalised indices ($F_{n+1+2}$), which `omega` would atomise separately from $F_{n+3}$ — restating it in canonical $n+3$ form first is what lets `omega` share atoms and close."
+  },
+  {
+    "id": "ann-fiboq0303-4",
+    "proofId": "fibonacci-identities-oq-03-oq-03",
+    "range": { "startLine": 76, "endLine": 100 },
+    "type": "key-step",
+    "title": "The Fibonacci–Lucas Doubling Identity F_{2n} = F_n · L_n",
+    "content": "**The factorisation made explicit.** `fib_two_mul_add_two_eq_fib_mul_lucas` rewrites Mathlib's even-doubling product $F_{2n+2} = F_{n+1}(2F_n + F_{n+1})$ and recognises the second factor as $F_n + F_{n+2} = L_{n+1}$, giving $F_{2n+2} = F_{n+1} L_{n+1}$; `ring` finishes after substituting $F_{n+2}=F_n+F_{n+1}$. Reindexing $m=n+1$ yields the headline identity `fib_two_mul_eq_fib_mul_lucas`: $F_{2m} = F_m L_m$ for $m \\ge 1$. The odd companion $F_{2n+1}=F_{n+1}^2+F_n^2$ is recorded alongside for the pair named in the question."
+  },
+  {
+    "id": "ann-fiboq0303-5",
+    "proofId": "fibonacci-identities-oq-03-oq-03",
+    "range": { "startLine": 101, "endLine": 142 },
+    "type": "key-step",
+    "title": "Difference-of-Squares ⇒ Product Bridge and Numerical Checks",
+    "content": "**Tying the two readings together.** `fib_sq_sub_sq_eq_fib_mul_lucas` proves over $\\mathbb{Z}$ that $F_{n+2}^2 - F_n^2 = F_{n+1}\\,L_{n+1}$ — the even-index difference of two squares *is* the Lucas product — by combining the additive form $F_{2n+2}+F_n^2 = F_{n+2}^2$ with the product form via `linarith`. `fib_two_mul_symmetric_diff_sq` then states the question's exact symmetric identity $F_{2m} = F_{m+1}^2 - F_{m-1}^2$ ($m\\ge1$, over $\\mathbb{Z}$, no truncated subtraction). The `decide` checks ($L_5=11$, $F_{10}=F_5 L_5=55$, $F_{12}=F_6 L_6=144$) use kernel reduction, not `native_decide`, so the entry is $0$-axiom."
+  }
+]

--- a/src/data/proofs/fibonacci-identities-oq-03-oq-03/meta.json
+++ b/src/data/proofs/fibonacci-identities-oq-03-oq-03/meta.json
@@ -1,0 +1,174 @@
+{
+  "id": "fibonacci-identities-oq-03-oq-03",
+  "title": "The Fibonacci–Lucas Doubling Identity: F₂ₙ = Fₙ·Lₙ",
+  "slug": "fibonacci-identities-oq-03-oq-03",
+  "description": "The doubled-index Fibonacci identities F_{2n+1} = F_{n+1}² + F_n² (odd → sum of two squares) and the symmetric even form F_{2n} = F_{n+1}² − F_{n−1}², together with the new content: reading the even case as a difference of two squares that factors. Since F_{n+1}² − F_{n−1}² = (F_{n+1} − F_{n−1})(F_{n+1} + F_{n−1}) = F_n·(F_{n−1} + F_{n+1}) = F_n·L_n, where L_n is the n-th Lucas number, the symmetric difference-of-squares form is exactly the classical Fibonacci–Lucas doubling identity F_{2n} = F_n·L_n. Lucas numbers (L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}) appear nowhere in the Fibonacci gallery and are not packaged in Mathlib's Nat.fib API, so they are introduced here; the bridge L_{n+1} = F_n + F_{n+2} (i.e. L_m = F_{m−1} + F_{m+1}) is proved by two-step induction on the shared recurrence. The factorisation then follows from Mathlib's even-doubling lemma Nat.fib_two_mul_add_two by recognising its second factor 2F_n + F_{n+1} = F_n + F_{n+2} = L_{n+1}. The entry records the odd sum-of-squares case, the doubling identity F_{2m} = F_m·L_m (m ≥ 1), the difference-of-squares ⇒ product bridge F_{n+2}² − F_n² = F_{n+1}·L_{n+1} over ℤ, the question's exact symmetric form F_{2m} = F_{m+1}² − F_{m−1}², and an existential reading, all fully verified with 0 axioms and 0 sorries (decide checks use kernel reduction, not native_decide).",
+  "meta": {
+    "author": "Classical (Fibonacci–Lucas doubling identity); formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Lucas_number#Relationship_to_Fibonacci_numbers",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "fibonacci",
+      "lucas-numbers",
+      "doubling-identity",
+      "difference-of-squares",
+      "identity",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/FibonacciIdentitiesOQ03OQ03.lean",
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.fib_two_mul_add_one",
+        "description": "fib (2n+1) = fib (n+1)² + fib n² — the odd fast-doubling identity; recorded directly as the odd half of the sum/difference-of-squares pair named in the open question",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_two_mul_add_two",
+        "description": "fib (2n+2) = fib (n+1)·(2·fib n + fib (n+1)) — the even fast-doubling product whose second factor 2·fib n + fib (n+1) = fib n + fib (n+2) = L_{n+1} is recognised as a Lucas number, yielding F_{2n+2} = F_{n+1}·L_{n+1}",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.fib_add_two",
+        "description": "fib (n + 2) = fib n + fib (n + 1) — the Fibonacci recurrence, used both to expand the doubling product and to drive the two-step induction proving the Lucas bridge",
+        "module": "Mathlib.Data.Nat.Fib.Basic"
+      },
+      {
+        "theorem": "Nat.twoStepInduction",
+        "description": "Two-step (Fibonacci-style) induction principle with base cases at 0 and 1 and a step from P n, P (n+1) to P (n+2) — the natural induction for proving the Lucas–Fibonacci bridge L_{n+1} = F_n + F_{n+2}",
+        "module": "Mathlib.Data.Nat.Basic"
+      }
+    ],
+    "originalContributions": [
+      "lucas: the Lucas number sequence L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}, absent from the Fibonacci gallery and from Mathlib's fib API",
+      "lucas_succ_eq_fib_add_fib: L_{n+1} = F_n + F_{n+2} (equivalently L_m = F_{m−1} + F_{m+1}), the Lucas–Fibonacci bridge, by two-step induction",
+      "fib_two_mul_add_two_eq_fib_mul_lucas: F_{2n+2} = F_{n+1}·L_{n+1} — Mathlib's even-doubling product factored through the Lucas number",
+      "fib_two_mul_eq_fib_mul_lucas: F_{2m} = F_m·L_m for m ≥ 1 — the classical Fibonacci–Lucas doubling identity in symmetric form",
+      "fib_sq_sub_sq_eq_fib_mul_lucas: F_{n+2}² − F_n² = F_{n+1}·L_{n+1} over ℤ — the even-index difference of two squares equals the Lucas product (the difference-of-squares ⇒ product bridge)",
+      "fib_two_mul_symmetric_diff_sq: F_{2m} = F_{m+1}² − F_{m−1}² over ℤ for m ≥ 1 — the open question's exact symmetric difference-of-squares form",
+      "fib_two_mul_isFibLucasProduct: every even-index Fibonacci number F_{2m} (m ≥ 1) is a Fibonacci × Lucas product",
+      "fib_odd_sq_add_sq: F_{2n+1} = F_{n+1}² + F_n², the odd half of the pair (Mathlib's Nat.fib_two_mul_add_one, recorded for completeness)"
+    ],
+    "dateAdded": "2026-06-24",
+    "lineCount": 143,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries (only Mathlib's foundational propext / Classical.choice / Quot.sound). All three numerical checks (L_5 = 11, F_10 = F_5·L_5 = 55, F_12 = F_6·L_6 = 144) use decide (kernel reduction, no native_decide / Lean.ofReduceBool).",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 10,
+    "definitionCount": 1
+  },
+  "overview": {
+    "historicalContext": "The Fibonacci and Lucas sequences are the two canonical solutions of the recurrence x_{n+2} = x_n + x_{n+1}, distinguished by their seeds (0,1 and 2,1). Their interlocking identities — F_{2n} = F_n L_n, L_n = F_{n−1} + F_{n+1}, 5F_n = L_{n−1} + L_{n+1}, L_n² − 5F_n² = 4(−1)ⁿ — are the backbone of elementary Fibonacci theory (Lucas, 1878). The doubling identity F_{2n} = F_n L_n is the multiplicative companion of the additive recurrence and underlies the fast-doubling algorithm for computing F_n in O(log n) steps. Mathlib records the fast-doubling identities for fib in product/sum-of-squares form but does not name the Lucas sequence, so the F_n·L_n reading is not directly available.",
+    "problemStatement": "**Open Question (fibonacci-identities-oq-03 → oq-03)**: Express the doubled-index Fibonacci numbers as sums/differences of squares: F_{2n+1} = F_{n+1}² + F_n² and F_{2n} = F_{n+1}² − F_{n−1}².\n\n**Result**: the odd case (fib_odd_sq_add_sq, = Mathlib's fib_two_mul_add_one), the symmetric even case in its exact form (fib_two_mul_symmetric_diff_sq), and — the new content — its factorisation as the Fibonacci–Lucas product F_{2n} = F_n·L_n (fib_two_mul_eq_fib_mul_lucas) together with the difference-of-squares ⇒ product bridge (fib_sq_sub_sq_eq_fib_mul_lucas). The Lucas sequence and the bridge L_{n+1} = F_n + F_{n+2} are introduced to make the factorisation precise.",
+    "text": "Doubling the index of a Fibonacci number turns it into a quadratic expression in nearby Fibonacci values: the odd case is a sum of two consecutive squares F_{2n+1} = F_{n+1}² + F_n², and the even case is a symmetric difference of two squares F_{2n} = F_{n+1}² − F_{n−1}². That even difference of squares is not irreducible: it factors as F_n·(F_{n−1} + F_{n+1}) = F_n·L_n, the classical Fibonacci–Lucas doubling identity. This entry proves both square identities and the factorisation, introducing the Lucas numbers L_n needed to state it.",
+    "proofStrategy": "**Proof Strategy.**\n\n1. **Lucas numbers (lucas).** Define L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1}; the recurrence lucas_add_two holds by rfl.\n2. **Bridge (lucas_succ_eq_fib_add_fib).** Prove L_{n+1} = F_n + F_{n+2} by Nat.twoStepInduction. Base cases n = 0,1 by decide. Step: lucas_add_two supplies L_{n+3} = L_{n+1} + L_{n+2}, the two IHs relate the Lucas terms to Fibonacci sums, and omega closes the linear identity given the Fibonacci recurrences F_{n+2} = F_n + F_{n+1}, F_{n+3} = F_{n+1} + F_{n+2}, F_{n+4} = F_{n+2} + F_{n+3}. (Nat.twoStepInduction hands back the second IH with un-normalised indices F_{n+1+2}; restating it as F_{n+3} first lets omega share atoms.)\n3. **Doubling (fib_two_mul_add_two_eq_fib_mul_lucas).** Rewrite Nat.fib_two_mul_add_two and the bridge so that F_{2n+2} = F_{n+1}·(F_n + F_{n+2}) = F_{n+1}·L_{n+1}; ring closes after Nat.fib_add_two. Reindexing m = n+1 gives F_{2m} = F_m·L_m (fib_two_mul_eq_fib_mul_lucas).\n4. **Difference-of-squares bridge (fib_sq_sub_sq_eq_fib_mul_lucas).** Over ℤ, combine the additive even identity F_{2n+2} + F_n² = F_{n+2}² with the product form via exact_mod_cast and linarith to get F_{n+2}² − F_n² = F_{n+1}·L_{n+1}.\n5. **Symmetric form (fib_two_mul_symmetric_diff_sq).** Reindex m = n+1, simplify (n+1) − 1 = n by Nat.add_sub_cancel, and derive F_{2m} = F_{m+1}² − F_{m−1}² from the same additive identity over ℤ.\n6. The numerical checks L_5 = 11, F_10 = F_5·L_5 = 55, F_12 = F_6·L_6 = 144 are confirmed by decide (kernel reduction)."
+    ,
+    "keyInsights": [
+      "**The even difference of squares is not prime — it factors.** F_{n+1}² − F_{n−1}² = (F_{n+1} − F_{n−1})(F_{n+1} + F_{n−1}); the first factor telescopes to F_n and the second is the Lucas number L_n, so the symmetric even-doubling identity F_{2n} = F_{n+1}² − F_{n−1}² is literally the product identity F_{2n} = F_n·L_n.",
+      "**Lucas numbers are forced by the factorisation.** The factor F_{n−1} + F_{n+1} is exactly L_n; stating the result cleanly requires the Lucas sequence, which is otherwise absent from the gallery and from Mathlib's fib API. The single bridge lemma L_{n+1} = F_n + F_{n+2} connects the two sequences.",
+      "**Two-step induction is the right tool.** Because L and F obey the same order-2 recurrence, the bridge L_{n+1} = F_n + F_{n+2} is a one-line Nat.twoStepInduction: agree at two base points, then the shared recurrence propagates the equality, with omega discharging the linear step.",
+      "**Mathlib's product factor was a Lucas number in disguise.** Mathlib stores the even doubling as F_{2n+2} = F_{n+1}(2F_n + F_{n+1}); since 2F_n + F_{n+1} = F_n + F_{n+2} = L_{n+1}, recognising this turns the opaque product into the meaningful Fibonacci–Lucas form."
+    ],
+    "prerequisites": [
+      "Mathlib's fast-doubling lemmas Nat.fib_two_mul_add_one and Nat.fib_two_mul_add_two",
+      "The Fibonacci recurrence Nat.fib_add_two",
+      "The two-step induction principle Nat.twoStepInduction",
+      "The ring, omega, linarith tactics and exact_mod_cast for the ℕ→ℤ transfer"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Setup",
+      "startLine": 3,
+      "endLine": 35,
+      "summary": "Module docstring: the doubled-index square identities, the factorisation of the even difference of squares as F_n·L_n, the absence of Lucas numbers from the gallery/Mathlib, and the plan (define Lucas, prove the bridge, read off the factorisation).",
+      "mathContext": "$F_{2n} = F_{n+1}^2 - F_{n-1}^2 = (F_{n+1}-F_{n-1})(F_{n+1}+F_{n-1}) = F_n L_n$."
+    },
+    {
+      "id": "lucas-def",
+      "title": "Lucas Numbers",
+      "startLine": 39,
+      "endLine": 51,
+      "summary": "lucas: the sequence L_0 = 2, L_1 = 1, L_{n+2} = L_n + L_{n+1} (2,1,3,4,7,11,18,…), with base values and the recurrence lucas_add_two by rfl.",
+      "mathContext": "$L_0 = 2,\\ L_1 = 1,\\ L_{n+2} = L_n + L_{n+1}$."
+    },
+    {
+      "id": "bridge",
+      "title": "The Lucas–Fibonacci Bridge",
+      "startLine": 53,
+      "endLine": 74,
+      "summary": "lucas_succ_eq_fib_add_fib: L_{n+1} = F_n + F_{n+2} by Nat.twoStepInduction — base cases by decide, step closed by omega using lucas_add_two and the Fibonacci recurrences.",
+      "mathContext": "$L_{n+1} = F_n + F_{n+2}$, i.e. $L_m = F_{m-1} + F_{m+1}$."
+    },
+    {
+      "id": "doubling",
+      "title": "The Doubling Identity F_{2n} = F_n·L_n",
+      "startLine": 76,
+      "endLine": 100,
+      "summary": "fib_odd_sq_add_sq (the odd sum-of-squares, = Mathlib), fib_two_mul_add_two_eq_fib_mul_lucas (F_{2n+2} = F_{n+1}·L_{n+1} via the recognised Lucas factor), and fib_two_mul_eq_fib_mul_lucas (the reindexed F_{2m} = F_m·L_m, m ≥ 1).",
+      "mathContext": "$F_{2m} = F_m L_m\\ (m \\ge 1)$."
+    },
+    {
+      "id": "diff-sq",
+      "title": "Difference-of-Squares Bridge, Symmetric Form, and Checks",
+      "startLine": 101,
+      "endLine": 142,
+      "summary": "fib_sq_sub_sq_eq_fib_mul_lucas (F_{n+2}² − F_n² = F_{n+1}·L_{n+1} over ℤ), fib_two_mul_symmetric_diff_sq (the question's exact F_{2m} = F_{m+1}² − F_{m−1}²), fib_two_mul_isFibLucasProduct (existential), and decide checks L_5=11, F_10=55, F_12=144 (kernel reduction).",
+      "mathContext": "$F_{n+2}^2 - F_n^2 = F_{n+1} L_{n+1}$; $F_{2m} = F_{m+1}^2 - F_{m-1}^2$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fibonacci-identities-oq-03",
+      "relationship": "extends",
+      "description": "The parent records the even doubling as the asymmetric difference of squares F_{2n+2} = F_{n+2}² − F_n²; this entry supplies the symmetric form F_{2n} = F_{n+1}² − F_{n−1}² and factors it as the Fibonacci–Lucas product F_n·L_n"
+    },
+    {
+      "targetId": "fibonacci-identities-oq-03-oq-02",
+      "relationship": "complements",
+      "description": "The sibling square-sum entry ∑ F_i² = F_n·F_{n+1} stays within the Fibonacci sequence; this entry introduces the Lucas sequence and the cross-sequence doubling identity F_{2n} = F_n·L_n"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete, fully verified (0 sorries, 0 axioms) treatment of the doubled-index Fibonacci identities: the odd sum of two squares F_{2n+1} = F_{n+1}² + F_n², the symmetric even difference of two squares F_{2n} = F_{n+1}² − F_{n−1}², and the new content — its factorisation as the classical Fibonacci–Lucas doubling identity F_{2n} = F_n·L_n, with the Lucas sequence and the bridge L_{n+1} = F_n + F_{n+2} introduced to state it.",
+    "implications": "Brings Lucas numbers and the cross-sequence doubling identity F_{2n} = F_n·L_n into the gallery, making the even fast-doubling step interpretable (Mathlib's opaque product factor 2F_n + F_{n+1} is the Lucas number L_{n+1}). The bridge lemma L_m = F_{m−1} + F_{m+1} is reusable for further Fibonacci–Lucas identities.",
+    "openQuestions": [
+      "Prove the dual conversion 5F_n = L_{n−1} + L_{n+1} and the Lucas-square doubling L_{2n} = L_n² − 2(−1)ⁿ, closing the basic F/L doubling pair.",
+      "Formalize the Fibonacci–Lucas Pythagorean-like relation L_n² − 5F_n² = 4(−1)ⁿ and use it to give a second proof of F_{2n} = F_n L_n."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "FibonacciIdentitiesOQ03OQ03",
+    "lineCount": 143,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 1,
+    "path": "Proofs/FibonacciIdentitiesOQ03OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Koshy, Thomas",
+      "title": "Fibonacci and Lucas Numbers with Applications",
+      "year": "2001",
+      "venue": "Wiley-Interscience",
+      "note": "Standard reference for the Fibonacci–Lucas doubling identity F_{2n} = F_n L_n and the conversion L_n = F_{n−1} + F_{n+1}"
+    },
+    {
+      "authors": "Vajda, Steven",
+      "title": "Fibonacci and Lucas Numbers, and the Golden Section",
+      "year": "1989",
+      "venue": "Ellis Horwood",
+      "note": "Catalogue of Fibonacci–Lucas identities including the doubling and difference-of-squares forms"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Supplies the **symmetric** even-doubling identity named in open question `fibonacci-identities-oq-03 → oq-03`,

  F_{2n} = F_{n+1}² − F_{n−1}²,

and the new content: reading that **difference of two squares as a factorisation**

  F_{n+1}² − F_{n−1}² = (F_{n+1} − F_{n−1})(F_{n+1} + F_{n−1}) = F_n · L_n,

the classical **Fibonacci–Lucas doubling identity** F_{2n} = F_n·L_n, where L_n is the n-th Lucas number.

Lucas numbers appear nowhere in the Fibonacci gallery and are not packaged in Mathlib's `Nat.fib` API, so the entry introduces the sequence (L₀=2, L₁=1, L_{n+2}=L_n+L_{n+1}) and the bridge `L_{n+1} = F_n + F_{n+2}` by two-step induction, then reads Mathlib's even fast-doubling product as F_{2n}=F_n·L_n.

## Contents

- `lucas` — the Lucas sequence (definition)
- `lucas_succ_eq_fib_add_fib` — bridge L_{n+1} = F_n + F_{n+2} (two-step induction)
- `fib_two_mul_add_two_eq_fib_mul_lucas`, `fib_two_mul_eq_fib_mul_lucas` — the doubling identity F_{2m}=F_m·L_m (m≥1)
- `fib_sq_sub_sq_eq_fib_mul_lucas` — difference-of-squares ⇒ product bridge over ℤ
- `fib_two_mul_symmetric_diff_sq` — the question's exact symmetric form F_{2m}=F_{m+1}²−F_{m−1}²
- `fib_odd_sq_add_sq` — odd companion F_{2n+1}=F_{n+1}²+F_n² (Mathlib)
- `fib_two_mul_isFibLucasProduct` — existential reading

**10 theorems, 1 definition, 0 axioms, 0 sorries.** Numerical checks use `decide` (kernel reduction, no `native_decide`), so the entry is genuinely 0-axiom.

## Verification

Build-verified locally with lean 4.26.0 / Mathlib (Docker unavailable in this environment; built single-file against the precompiled Mathlib cache with a memory-kill guard, 5.7 GB peak). The bridge `omega` step required restating the `Nat.twoStepInduction` hypothesis in canonical `n+3` index form — `twoStepInduction` hands back `Nat.fib (n+1+2)`, which `omega` atomises separately from `Nat.fib (n+3)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)