### PR TITLE
Enrich Norm-Euclidean ℤ[√d] uniform family (d ∈ {−1,−2}): add annotations

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-rounding-bound",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 56, "endLine": 81 },
+    "type": "technique",
+    "title": "The Rational Rounding Bound",
+    "content": "`sq_two_mul_sub_round_le`: the only analytic ingredient of the whole development. Rounding $m/k$ to the nearest integer $q$ keeps the scaled error within $\\pm k/2$, i.e. $(2(m-qk))^2 \\le k^2$. The proof works over ℚ: Mathlib's `abs_sub_round` gives $|m/k - q| \\le 1/2$, scaling by $k$ yields $|m - qk| \\le k/2$, squaring gives the bound, and `exact_mod_cast` transports the rational inequality back to ℤ. Everything geometric downstream reduces to this one covering-radius fact about a single coordinate.",
+    "mathContext": "$\\left(2\\big(m - \\mathrm{round}(m/k)\\cdot k\\big)\\right)^2 \\le k^2$, from $|m/k - \\mathrm{round}(m/k)| \\le \\tfrac12$.",
+    "significance": "key",
+    "relatedConcepts": ["nearest-integer rounding", "abs_sub_round", "covering radius"],
+    "prerequisites": ["rounding on ℚ", "casting ℤ ↔ ℚ", "absolute value inequalities"]
+  },
+  {
+    "id": "ann-quo-rem",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 86, "endLine": 108 },
+    "type": "definition",
+    "title": "Nearest-Lattice-Point Quotient and Remainder",
+    "content": "`quo` rounds each rational coordinate of $x\\cdot\\overline{y}/N(y)$ to the nearest integer, giving the lattice point closest to the true quotient; `rem` is $r = x - y\\cdot q$. Crucially this is done purely algebraically over ℚ — no embedding into ℂ — which is what makes the argument uniform in $d$ (the irrational $\\sqrt{-d}$ never appears, only the integer $d$). `quo_zero` records the $y=0$ convention $q=0$ that `EuclideanDomain.quotient_zero` requires, and `quotient_mul_add_remainder` confirms $y\\cdot q + r = x$.",
+    "mathContext": "$q = \\big\\langle \\mathrm{round}\\tfrac{(x\\bar y)_{\\mathrm{re}}}{N(y)},\\ \\mathrm{round}\\tfrac{(x\\bar y)_{\\mathrm{im}}}{N(y)} \\big\\rangle,\\quad r = x - yq.$",
+    "significance": "key",
+    "relatedConcepts": ["nearest-lattice-point division", "Zsqrtd coordinates", "rational rounding"],
+    "prerequisites": ["Zsqrtd (norm, star/conjugate)", "Euclidean division setup"]
+  },
+  {
+    "id": "ann-rem-star-coords",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 110, "endLine": 134 },
+    "type": "technique",
+    "title": "Conjugate Trick: Coordinates of r·ȳ Are the Rounding Errors",
+    "content": "The key algebraic step. Multiplying the remainder $r$ by the conjugate $\\overline{y}$ turns each coordinate of $r\\overline{y}$ into exactly the scaled rounding error of the corresponding coordinate. `rem_mul_star_re`/`rem_mul_star_im` prove $(r\\overline{y})_{\\mathrm{re}} = (x\\overline{y})_{\\mathrm{re}} - q_{\\mathrm{re}}\\cdot N(y)$ (and likewise for im), using $y\\cdot\\overline{y} = N(y)$ (`norm_eq_mul_conj`). This is what lets the single-coordinate rounding bound be applied to the algebraic remainder.",
+    "mathContext": "$(r\\bar y)_{\\mathrm{re}} = (x\\bar y)_{\\mathrm{re}} - q_{\\mathrm{re}}\\,N(y)$, the scaled rounding error, since $y\\bar y = N(y)$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugate / star", "norm_eq_mul_conj", "rounding error"],
+    "prerequisites": ["Zsqrtd conjugation", "real/imag parts of products"]
+  },
+  {
+    "id": "ann-uniform-bound",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 138, "endLine": 158 },
+    "type": "theorem",
+    "title": "The Uniform Norm Bound (all negative d)",
+    "content": "`four_mul_norm_rem_le`: the single inequality $4\\,N(r)\\,N(y) \\le (1-d)\\,N(y)^2$, valid for EVERY negative $d$. Norm multiplicativity ($N(r\\overline{y}) = N(r)N(y)$ via `norm_mul`, `norm_conj`) plus the norm formula $N(R) = R_{\\mathrm{re}}^2 - d\\,R_{\\mathrm{im}}^2$ rewrites $4N(r)N(y)$ as $(2R_{\\mathrm{re}})^2 - d(2R_{\\mathrm{im}})^2$; the two coordinate bounds then give $\\le (1-d)N(y)^2$ by `nlinarith`. All the $d$-dependence has collapsed into the constant $(1-d)/4$, the squared covering radius of the rectangular lattice. The degenerate $N(y)=0$ case (only $y=0$) makes both sides vanish.",
+    "mathContext": "$4\\,N(r)\\,N(y) = (2R_{\\mathrm{re}})^2 - d(2R_{\\mathrm{im}})^2 \\le (1-d)\\,N(y)^2,\\quad R = r\\bar y.$",
+    "significance": "key",
+    "relatedConcepts": ["norm multiplicativity", "covering radius", "uniform bound"],
+    "prerequisites": ["Zsqrtd norm formula", "norm_mul / norm_conj", "nlinarith"]
+  },
+  {
+    "id": "ann-norm-rem-lt",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 160, "endLine": 180 },
+    "type": "insight",
+    "title": "Strict Decrease for d ∈ {−1,−2}",
+    "content": "`norm_rem_lt` specialises the uniform bound to $-2 \\le d < 0$: there the factor $(1-d)/4 \\le 3/4 < 1$, so $N(r) < N(y)$ — the defining property of a norm-Euclidean domain. `exists_quotient_remainder` repackages this as the existence of $q,r$ with $x = yq+r$ and $|N(r)| < |N(y)|$ (the `.natAbs` form `EuclideanDomain` wants). The threshold is sharp: $(1-d)/4 < 1 \\iff |d| < 3$, forcing exactly $d \\in \\{-1,-2\\}$.",
+    "mathContext": "$-2 \\le d < 0 \\Rightarrow \\tfrac{1-d}{4} \\le \\tfrac34 < 1 \\Rightarrow N(r) < N(y).$",
+    "significance": "key",
+    "relatedConcepts": ["norm-Euclidean domain", "Euclidean division", "arithmetic threshold"],
+    "prerequisites": ["the uniform norm bound", "natAbs of integers"]
+  },
+  {
+    "id": "ann-euclidean-domain",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 185, "endLine": 217 },
+    "type": "theorem",
+    "title": "One Euclidean Domain for the Whole Family",
+    "content": "`euclideanDomain` assembles a single `EuclideanDomain (ℤ√d)` value from the data above, parameterized only by $-2 \\le d < 0$: the quotient/remainder, the well-founded size $|N(\\cdot)|$ (`r_wellFounded` via `measure`), the `remainder_lt` from `norm_rem_lt`, and `mul_left_not_lt` from norm multiplicativity. `euclideanDomainNegOne` and `euclideanDomainNegTwo` then recover the Gaussian integers $\\mathbb{Z}[i]$ and $\\mathbb{Z}[\\sqrt{-2}]$ as the two members $d=-1,-2$ of the same proof — the unification the open question asked for.",
+    "mathContext": "$\\mathbb{Z}[\\sqrt d]$ is a Euclidean domain for every $-2 \\le d < 0$; $d=-1 \\Rightarrow \\mathbb{Z}[i]$, $d=-2 \\Rightarrow \\mathbb{Z}[\\sqrt{-2}]$.",
+    "significance": "key",
+    "relatedConcepts": ["EuclideanDomain structure", "Gaussian integers", "well-founded recursion"],
+    "prerequisites": ["EuclideanDomain typeclass", "well-founded relations"]
+  },
+  {
+    "id": "ann-obstruction",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03",
+    "range": { "startLine": 219, "endLine": 227 },
+    "type": "insight",
+    "title": "The Honest Obstruction at d ≤ −3",
+    "content": "`nearest_point_factor_ge_one_of_le_neg_three`: for $d \\le -3$ the uniform factor satisfies $1-d \\ge 4$, i.e. $(1-d)/4 \\ge 1$, so the covering-radius bound no longer forces strict decrease (a one-line `omega`). This is not a defect of the proof but a genuine arithmetic obstruction: for squarefree $d \\le -3$ the ring of integers of $\\mathbb{Q}(\\sqrt d)$ is the larger $\\mathbb{Z}[(1+\\sqrt d)/2]$, and $\\mathbb{Z}[\\sqrt{-3}]$ is not even integrally closed (hence not a PID). The boundary $|d|=3$ is exactly where $\\mathbb{Z}[\\sqrt d]$ stops being the maximal order — so the $\\mathbb{Z}[\\sqrt d]$ family provably ends at $d=-2$.",
+    "mathContext": "$d \\le -3 \\Rightarrow 1-d \\ge 4 \\Rightarrow \\tfrac{1-d}{4} \\ge 1$; the correct rings for $d=-3,-7,-11$ are $\\mathbb{Z}[(1+\\sqrt d)/2]$.",
+    "significance": "key",
+    "relatedConcepts": ["ring of integers", "integral closure", "imaginary quadratic fields", "maximal order"],
+    "prerequisites": ["rings of integers of quadratic fields", "norm-Euclidean discriminants"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03-oq-03`.

**Gap found:** rich `meta.json` (overview, 5 sections, original contributions) but **no `annotations.json`**.

**Added:** `annotations.json` with 7 line-accurate annotations covering the full proof:
- The rational rounding bound `sq_two_mul_sub_round_le` (the sole analytic input)
- Nearest-lattice-point `quo`/`rem`, defined over ℚ-coordinates (no ℂ embedding — the source of uniformity in $d$)
- The conjugate trick: $(r\bar y)$ coordinates are exactly the scaled rounding errors
- The uniform bound $4N(r)N(y)\le(1-d)N(y)^2$ valid for **every** negative $d$
- Strict decrease $N(r)<N(y)$ for $-2\le d<0$, i.e. $d\in\{-1,-2\}$
- The single `EuclideanDomain` packaging $\mathbb{Z}[i]$ and $\mathbb{Z}[\sqrt{-2}]$ from one proof
- The honest obstruction at $d\le-3$ (factor $\ge 1$; the maximal order is $\mathbb{Z}[(1+\sqrt d)/2]$)

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All 7 pass the build's annotation-vs-Lean-construct validator.