### PR TITLE
Enrich Wilson (n-2)! companion / ZMod-free primality test

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-05-oq-01-oq-01/annotations.json
@@ -1,0 +1,210 @@
+[
+  {
+    "id": "ann-wilson0501-overview",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 3,
+      "endLine": 59
+    },
+    "type": "context",
+    "title": "From the Wilson Trichotomy to a Primality Certificate and Kempner's Bound",
+    "content": "The docstring sets up the three threads this file weaves together. The parent entry classified the classical Wilson remainder (n-1)! mod n; here that classification is (1) sharpened — the composite divisibility n ∣ (n-1)! is shown to already hold at (n-2)! — and (2) repackaged as two decidable, ZMod-free primality tests and as the Kempner–Smarandache threshold S(n) < n. The n = 4 = 2² exception recurs in every result: it is the single composite modulus where the two factors of the minimal-factor split first fail to fit below n-2, so it must be carved out by hand (kernel `decide`, never `native_decide`, keeping the file axiom-free).",
+    "mathContext": "$(n-2)!\\bmod n = \\begin{cases}1 & n\\text{ prime}\\\\ 2 & n=4\\\\ 0 & n\\text{ composite},\\,n\\ne4\\end{cases}$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Wilson's theorem",
+      "Kempner–Smarandache function S(n)",
+      "primality test",
+      "factorial residues"
+    ],
+    "prerequisites": [
+      "Wilson's theorem (n-1)! ≡ -1 (mod n) for prime n",
+      "the parent trichotomy of (n-1)! mod n"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-engine",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 68,
+      "endLine": 81
+    },
+    "type": "technique",
+    "title": "The Divisibility Engine: Two Distinct Factors Multiply into m!",
+    "content": "mul_dvd_factorial is the reusable workhorse inherited from the parent: if 0 < a < b ≤ m then a·b ∣ m!. The proof is short and structural — write b! = b·(b-1)!, observe a ∣ (b-1)! because a ≤ b-1 (Nat.dvd_factorial), so a·b ∣ b!, and finally b! ∣ m! by factorial monotonicity since b ≤ m. The strict inequality a < b is what guarantees a and b are *distinct* contributors to the product m!, which is exactly what makes a·b (not just max(a,b)) divide m!.",
+    "mathContext": "$0 < a < b \\le m \\;\\Longrightarrow\\; a\\cdot b \\mid m! \\qquad(\\text{since } a\\mid(b-1)!,\\; a\\cdot b\\mid b\\cdot(b-1)!=b!\\mid m!)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.dvd_factorial",
+      "Nat.factorial_dvd_factorial",
+      "distinct factors",
+      "factorial monotonicity"
+    ],
+    "prerequisites": [
+      "b! = b·(b-1)! (Nat.factorial_succ)",
+      "divisibility transitivity"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-sharpening",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 83,
+      "endLine": 126
+    },
+    "type": "concept",
+    "title": "The Sharpening: n ∣ (n-2)! for Composite n ≠ 4",
+    "content": "The central new result. For composite n ≥ 2 with n ≠ 4, the modulus divides (n-2)! — one factorial step earlier than the parent's (n-1)!. Set p = minFac n and q = n/p. Two cases: if p < q, then q ≥ 3 forces 2q ≤ n hence q ≤ n-2, so the distinct factors p, q with p·q = n give n ∣ (n-2)! directly. If p = q, then n = p² with p ≥ 3 (the only square excluded is 4 = 2²), so 3p ≤ p² gives 2p ≤ n-2, and the distinct factors p, 2p yield 2n ∣ (n-2)!, hence n ∣ (n-2)!. The boundary n = 4 is exactly where 2 and 2·2 = 4 stop fitting below n-2.",
+    "mathContext": "$n = p\\cdot q,\\; p=\\operatorname{minFac}n:\\quad p<q\\Rightarrow q\\le n-2;\\quad p=q\\Rightarrow n=p^2,\\,p\\ge3,\\,2p\\le n-2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.minFac",
+      "minimal-factor split",
+      "mul_dvd_factorial",
+      "the n = 4 exception"
+    ],
+    "prerequisites": [
+      "least prime factor and prime/composite dichotomy",
+      "Nat.minFac_le_of_dvd, Nat.prime_def_minFac",
+      "the divisibility engine mul_dvd_factorial"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-pred-corollary",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 128,
+      "endLine": 134
+    },
+    "type": "insight",
+    "title": "The Parent's n ∣ (n-1)! as a Free Corollary",
+    "content": "Because (n-2)! ∣ (n-1)! (factorial monotonicity), the parent's composite divisibility n ∣ (n-1)! is now a one-line consequence of the sharper (n-2)! result. This makes explicit that the new theorem strictly dominates the old one: anything the parent proved on the composite side is recovered, and more. It is a clean illustration of how strengthening a lemma can absorb its predecessor.",
+    "mathContext": "$n \\mid (n-2)! \\;\\text{and}\\; (n-2)! \\mid (n-1)! \\;\\Longrightarrow\\; n \\mid (n-1)!$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "logical strengthening",
+      "Nat.factorial_dvd_factorial",
+      "divisibility transitivity"
+    ],
+    "prerequisites": [
+      "the sharper (n-2)! divisibility",
+      "(n-2)! ∣ (n-1)!"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-companion-residue",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 136,
+      "endLine": 164
+    },
+    "type": "concept",
+    "title": "The Prime Companion Residue (n-2)! ≡ 1 via Wilson",
+    "content": "For prime n, the cofactor below the Wilson factorial is exactly 1. The argument lives in ZMod n: Wilson's lemma gives (n-1)! = -1, and the cast (n-1 : ℕ) = -1 (since n = 0 in ZMod n). Splitting (n-1)! = (n-1)·(n-2)! and casting turns -1 = (-1)·(n-2)!, so by neg_inj the cofactor (n-2)! = 1 in ZMod n. The result is transported back to ℕ-remainder form through ZMod.natCast_eq_natCast_iff. Intuitively, (n-2)! = (n-1)!/(n-1) ≡ (-1)/(-1) ≡ 1.",
+    "mathContext": "$(n-1)! \\equiv -1,\\; n-1\\equiv -1 \\pmod n \\;\\Rightarrow\\; (n-2)! \\equiv \\frac{-1}{-1} \\equiv 1 \\pmod n$",
+    "significance": "key",
+    "relatedConcepts": [
+      "ZMod.wilsons_lemma",
+      "ZMod.natCast_eq_natCast_iff",
+      "neg_inj",
+      "cofactor"
+    ],
+    "prerequisites": [
+      "Wilson's lemma in ZMod form",
+      "the factorial split (n-1)! = (n-1)·(n-2)!",
+      "ℕ ↔ ZMod cast bridge"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-pred-prime",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 166,
+      "endLine": 177
+    },
+    "type": "technique",
+    "title": "Re-deriving the Classical Wilson Residue (n-1)! ≡ n-1",
+    "content": "The parent's prime branch — (n-1)! % n = n-1 for prime n — is recovered directly from ZMod.wilsons_lemma. Casting (n-1 : ℕ) to -1 in ZMod n, the lemma's (n-1)! = -1 becomes the congruence (n-1)! ≡ n-1 [MOD n], which Nat.mod_eq_of_lt converts to the remainder statement since n-1 < n. This is the residue n-1 ≡ -1 in its natural-number guise, kept alongside the companion residue so both Wilson factorials are documented in one place.",
+    "mathContext": "$(n-1)! \\equiv -1 \\equiv n-1 \\pmod n,\\quad n-1 < n \\;\\Rightarrow\\; (n-1)!\\bmod n = n-1$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "ZMod.wilsons_lemma",
+      "Nat.ModEq",
+      "Nat.mod_eq_of_lt"
+    ],
+    "prerequisites": [
+      "Wilson's lemma in ZMod form",
+      "congruence-to-remainder conversion"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-trichotomy",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 179,
+      "endLine": 197
+    },
+    "type": "concept",
+    "title": "The Companion Trichotomy of (n-2)! mod n",
+    "content": "factorial_sub_two_mod assembles the full classification by a case split on primality and then on n = 4. The prime case is the companion residue 1; the n = 4 case is the sporadic value 2, closed by ordinary kernel `decide` (so no Lean.ofReduceBool dependency); the remaining composite case is 0 via the sharper divisibility. The shape (1 / 2 / 0) mirrors the parent's trichotomy of (n-1)! (n-1 / 2 / 0) — the same sporadic 2 at n = 4, but a different prime value because the cofactor differs.",
+    "mathContext": "$(n-2)!\\bmod n = \\mathbf{1}[n\\text{ prime}] \\cdot 1 + \\mathbf{1}[n=4]\\cdot 2 + \\mathbf{1}[\\text{else}]\\cdot 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "trichotomy",
+      "kernel decide",
+      "Nat.dvd_iff_mod_eq_zero",
+      "case analysis"
+    ],
+    "prerequisites": [
+      "the prime companion residue and the composite divisibility",
+      "decidability of the n = 4 instance"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-primality-tests",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 199,
+      "endLine": 231
+    },
+    "type": "insight",
+    "title": "Two Decidable ZMod-Free Wilson Primality Tests",
+    "content": "These biconditionals answer the parent's first open question: turn the trichotomy into a primality certificate. n is prime ↔ (n-1)! % n = n-1, and equivalently ↔ (n-2)! % n = 1, both stated purely in natural-number remainder arithmetic (no ZMod in the statement). The forward direction is Wilson; the backward direction is precisely the trichotomy ruling out the two non-prime outcomes — for n = 4 the residue (2, resp. 2) is wrong, and for composite n ≠ 4 the residue is 0, neither of which equals the prime target value. Each test is a genuine decision procedure (slow, but decidable).",
+    "mathContext": "$n\\text{ prime} \\iff (n-1)!\\bmod n = n-1 \\iff (n-2)!\\bmod n = 1\\qquad(n\\ge2)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Wilson primality test",
+      "decidable biconditional",
+      "primality certificate",
+      "contrapositive via the trichotomy"
+    ],
+    "prerequisites": [
+      "the two prime residues and the composite divisibility",
+      "ruling out the n = 4 and composite cases"
+    ]
+  },
+  {
+    "id": "ann-wilson0501-kempner",
+    "proofId": "wilsons-theorem-oq-05-oq-01-oq-01",
+    "range": {
+      "startLine": 233,
+      "endLine": 259
+    },
+    "type": "insight",
+    "title": "The Kempner–Smarandache Threshold S(n) < n",
+    "content": "exists_lt_dvd_factorial_iff pins exactly when some factorial below n is already a multiple of n: (∃ m < n, n ∣ m!) ↔ (n composite ∧ n ≠ 4). Sufficiency uses the witness m = n-2 from the sharper divisibility. Necessity has two parts: a prime n divides m! only when n ≤ m (Nat.Prime.dvd_factorial), contradicting m < n; and for n = 4 no m < 4 works, checked by interval_cases + decide. In Kempner–Smarandache language, S(n) = min{m : n ∣ m!} drops below n precisely for composite n ≠ 4 — the same n = 4 exception that governs the Wilson residue, now seen as a statement about the location of the least factorial multiple.",
+    "mathContext": "$(\\exists m<n,\\; n\\mid m!) \\iff (\\neg\\,n\\text{ prime} \\wedge n\\ne4) \\iff S(n) < n$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Kempner–Smarandache function",
+      "Nat.Prime.dvd_factorial",
+      "interval_cases",
+      "least factorial multiple"
+    ],
+    "prerequisites": [
+      "the composite divisibility witness m = n-2",
+      "prime divides m! ⇔ n ≤ m",
+      "the n = 4 finite check"
+    ]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `wilsons-theorem-oq-05-oq-01-oq-01` (quality 43, 0 prior passes).

**Gap found:** rich meta.json but **no annotations.json** — the proof page had zero inline annotations.

**Added** `annotations.json` with 9 substantive annotations, each carrying `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:
- Overview tying together the three threads (sharpening, primality tests, Kempner bound) and the recurring n = 4 exception
- The `mul_dvd_factorial` divisibility engine (distinct factors → divide m!)
- The sharpening `n ∣ (n-2)!` for composite n ≠ 4 (minFac split, both case branches)
- The free `n ∣ (n-1)!` corollary documenting the strict strengthening
- The prime companion residue `(n-2)! ≡ 1` via `ZMod.wilsons_lemma`
- The re-derived classical residue `(n-1)! ≡ n-1`
- The companion trichotomy of `(n-2)! mod n` (1 / 2 / 0; n = 4 by kernel `decide`)
- The two decidable ZMod-free Wilson primality tests
- The Kempner–Smarandache threshold `S(n) < n ⇔ composite n ≠ 4`

**Verification:** JSON validated; `tsc -p tsconfig.json --noEmit` passes clean. No meta.json claims altered (status `verified`/badge `original`/0 axioms — consistent with the 0-sorry, 0-axiom Lean file; n = 4 closed by kernel `decide`, not `native_decide`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)