### PR TITLE
Enrich Generalized Ballot Numbers (Catalan triangle): add annotations

### DIFF
--- a/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/catalan-numbers-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-ballot-def",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 40, "endLine": 44 },
+    "type": "definition",
+    "title": "The Generalized Ballot Number B(p,q)",
+    "content": "`ballot p q = C(p+q, q) − C(p+q, p+1)`, the Catalan-triangle entry counting lattice paths to $(q,p)$ that stay weakly below the diagonal. The key design choice is indexing the subtrahend by $p+1$ rather than the reflected index $q-1$: this keeps every binomial index a genuine sum (never a truncated ℕ-subtraction), so the boundary values $B(p,0)=1$ and $B(p,q)=0$ for $q>p$ come out correctly with no side conditions on the indices.",
+    "mathContext": "$B(p,q) = \\binom{p+q}{q} - \\binom{p+q}{p+1}$, the count of monotone lattice paths to $(q,p)$ weakly below the diagonal (André's reflection principle).",
+    "significance": "key",
+    "relatedConcepts": ["Catalan triangle", "ballot numbers", "reflection principle", "lattice paths"],
+    "prerequisites": ["binomial coefficients", "ℕ truncated subtraction", "lattice-path counting"]
+  },
+  {
+    "id": "ann-ballot-key",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 63 },
+    "type": "theorem",
+    "title": "The Key Nonlinear Identity",
+    "content": "`ballot_key`: $(p+1)\\,C(p+q,p+1) = q\\,C(p+q,q)$ — the single engine that generates the entire two-parameter family. It is a one-line consequence of `Nat.choose_succ_right_eq` at $(p+q,p)$ (giving $C(p+q,p+1)\\cdot(p+1) = C(p+q,p)\\cdot(p+q-p)$), then rewriting $p+q-p = q$ and applying the symmetry $C(p+q,p) = C(p+q,q)$ (`Nat.choose_symm_add`), and reassociating. Every later result — closed form, genuineness, both boundary laws, the Catalan diagonal — falls out of this by elementary cancellation.",
+    "mathContext": "$(p+1)\\binom{p+q}{p+1} = q\\binom{p+q}{q}$, from $\\binom{n}{k+1}(k+1) = \\binom{n}{k}(n-k)$ at $(n,k)=(p+q,p)$.",
+    "significance": "key",
+    "relatedConcepts": ["binomial recurrence", "choose_succ_right_eq", "choose_symm_add"],
+    "prerequisites": ["binomial coefficient identities", "ℕ arithmetic"]
+  },
+  {
+    "id": "ann-genuine",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "technique",
+    "title": "Genuineness of the Subtraction (q ≤ p)",
+    "content": "`ballot_genuine`: for $q \\le p$, the right neighbour $C(p+q,p+1)$ never exceeds the diagonal coefficient $C(p+q,q)$, so the ℕ-subtraction in `ballot p q` is not truncated. The proof multiplies the key identity through: $(p+1)C(p+q,p+1) = q\\,C(p+q,q) \\le (p+1)C(p+q,q)$ because $q \\le p+1$, then cancels the positive factor $p+1$ (`Nat.le_of_mul_le_mul_left`). This is really one half of the binomial row's unimodality, read straight off `ballot_key`.",
+    "mathContext": "$q \\le p \\Rightarrow \\binom{p+q}{p+1} \\le \\binom{p+q}{q}$ (unimodality), so $B(p,q)$ is an exact subtraction.",
+    "significance": "supporting",
+    "relatedConcepts": ["unimodality of binomial coefficients", "ℕ-subtraction exactness", "cancellation"],
+    "prerequisites": ["the key identity", "monotonicity / cancellation in ℕ"]
+  },
+  {
+    "id": "ann-closed-form",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 78, "endLine": 105 },
+    "type": "insight",
+    "title": "The Division-Free Bertrand Ratio",
+    "content": "`ballot_closed_form`: $(p+1)\\,B(p,q) = (p+1-q)\\,C(p+q,q)$ for $q \\le p$ — the classical Bertrand ballot ratio $(p+1-q)/(p+1)$ stated over ℕ with no division. The proof partitions the diagonal coefficient $C(p+q,q) = B(p,q) + C(p+q,p+1)$ (genuine by `ballot_genuine`, closed by `omega`), multiplies by $p+1$, substitutes `ballot_key` to eliminate the neighbour $(p+1)C(p+q,p+1) = q\\,C(p+q,q)$, and closes with `Nat.sub_mul` + `omega`. No rational arithmetic, no real-valued probability.",
+    "mathContext": "$(p+1)\\,B(p,q) = (p+1-q)\\binom{p+q}{q}$ for $q\\le p$; the integer form of $B(p,q) = \\frac{p+1-q}{p+1}\\binom{p+q}{q}$.",
+    "significance": "key",
+    "relatedConcepts": ["Bertrand ballot theorem", "ballot ratio", "division-free identity"],
+    "prerequisites": ["the key identity", "genuineness", "Nat.sub_mul"]
+  },
+  {
+    "id": "ann-diagonal",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 107, "endLine": 124 },
+    "type": "insight",
+    "title": "The Catalan Diagonal B(n,n) = catalan n",
+    "content": "`ballot_diag`: the Catalan numbers are exactly the diagonal of the ballot triangle. At $p=q=n$ the Bertrand factor $p+1-q$ collapses to $1$, so the closed form reads $(n+1)\\,B(n,n) = C(2n,n)$; Mathlib's `succ_mul_catalan_eq_centralBinom` gives $(n+1)\\,\\mathrm{catalan}\\,n = C(2n,n)$ (with $\\mathrm{centralBinom}\\,n = C(2n,n)$ via `two_mul`); cancelling $n+1$ identifies the two. This recovers the parent entry's reflection form $\\mathrm{catalan}\\,n = C(2n,n) - C(2n,n+1)$ as the diagonal slice $B(n,n)$.",
+    "mathContext": "$B(n,n) = \\mathrm{catalan}\\,n$, since $(n+1)B(n,n) = \\binom{2n}{n} = (n+1)\\,\\mathrm{catalan}\\,n$.",
+    "significance": "key",
+    "relatedConcepts": ["Catalan numbers", "central binomial coefficient", "Dyck paths", "succ_mul_catalan_eq_centralBinom"],
+    "prerequisites": ["the closed form", "Catalan-central-binomial bridge"]
+  },
+  {
+    "id": "ann-boundary-zero",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 126, "endLine": 129 },
+    "type": "context",
+    "title": "Boundary Value B(p,0) = 1",
+    "content": "`ballot_zero`: $B(p,0) = C(p,0) - C(p,p+1) = 1 - 0 = 1$, the single all-down lattice path. The computation uses `Nat.choose_zero_right` ($C(p,0)=1$) and `Nat.choose_eq_zero_of_lt` ($C(p,p+1)=0$ since $p<p+1$). The $p+1$-indexing of the subtrahend is exactly what makes this boundary value fall out without a side condition.",
+    "mathContext": "$B(p,0) = \\binom{p}{0} - \\binom{p}{p+1} = 1 - 0 = 1$.",
+    "significance": "context",
+    "relatedConcepts": ["boundary values", "choose_eq_zero_of_lt"],
+    "prerequisites": ["binomial edge cases"]
+  },
+  {
+    "id": "ann-vanishing",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 131, "endLine": 144 },
+    "type": "technique",
+    "title": "Vanishing Above the Diagonal",
+    "content": "`ballot_eq_zero_of_lt`: $p < q \\Rightarrow B(p,q) = 0$ — the mirror image of genuineness. The same key identity now runs the other way: since $p+1 \\le q$, $(p+1)C(p+q,q) \\le q\\,C(p+q,q) = (p+1)C(p+q,p+1)$, so $C(p+q,q) \\le C(p+q,p+1)$ after cancelling $p+1$, and the truncated ℕ-subtraction collapses to $0$. Combinatorially, no path to $(q,p)$ with $q>p$ can stay weakly below the diagonal.",
+    "mathContext": "$p < q \\Rightarrow \\binom{p+q}{q} \\le \\binom{p+q}{p+1} \\Rightarrow B(p,q) = 0$ (truncated subtraction).",
+    "significance": "supporting",
+    "relatedConcepts": ["unimodality", "truncated subtraction", "boundary of the Catalan triangle"],
+    "prerequisites": ["the key identity", "cancellation in ℕ"]
+  },
+  {
+    "id": "ann-examples",
+    "proofId": "catalan-numbers-oq-01-oq-01-oq-02",
+    "range": { "startLine": 146, "endLine": 154 },
+    "type": "context",
+    "title": "Concrete Sanity Checks",
+    "content": "Three `decide` checks pin the definition to numbers: $B(3,3) = C(6,3)-C(6,4) = 20-15 = 5 = \\mathrm{catalan}\\,3$ (diagonal), $B(4,2) = 15-6 = 9$ (off-diagonal, and $(4{+}1)\\cdot 9 = 3\\cdot 15$ confirms the Bertrand ratio), and $B(2,5) = 0$ (above the diagonal). All use kernel `decide` on `Nat.choose` — not `native_decide` — so the entry stays genuinely axiom-free (no `Lean.ofReduceBool`).",
+    "mathContext": "$B(3,3)=5$, $B(4,2)=9$, $B(2,5)=0$.",
+    "significance": "context",
+    "relatedConcepts": ["decidable computation", "kernel decide vs native_decide"],
+    "prerequisites": ["Nat.choose evaluation"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `catalan-numbers-oq-01-oq-01-oq-02`.

**Gap found:** very rich `meta.json` (overview, 9 sections, references) but **no `annotations.json`**.

**Added:** `annotations.json` with 8 line-accurate annotations covering the whole file:
- The ballot-number definition $B(p,q)=\binom{p+q}{q}-\binom{p+q}{p+1}$ and the $p+1$-indexing rationale
- `ballot_key` $(p+1)\binom{p+q}{p+1}=q\binom{p+q}{q}$ — the single engine
- Genuineness ($q\le p$), the division-free Bertrand ratio closed form
- The Catalan diagonal $B(n,n)=\mathrm{catalan}\,n$
- Boundary $B(p,0)=1$ and vanishing $B(p,q)=0$ for $q>p$
- The kernel-`decide` sanity checks (axiom-free, no `native_decide`)

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`. All 8 pass the build's annotation-vs-Lean-construct validator.