### PR TITLE
research(euler-totient-oq-07-oq-04): finite-family totient coprimality criterion [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2719,6 +2719,7 @@ import Proofs.EulerTotientOQ04OQ01
 import Proofs.EulerTotientOQ05
 import Proofs.EulerTotientOQ06
 import Proofs.EulerTotientOQ07
+import Proofs.EulerTotientOQ07OQ04
 import Proofs.EulerTotientOQ10
 import Proofs.EulerTotientOQ09
 import Proofs.EulerTotientOQ09OQ01

--- a/proofs/Proofs/EulerTotientOQ07OQ04.lean
+++ b/proofs/Proofs/EulerTotientOQ07OQ04.lean
@@ -1,0 +1,135 @@
+import Mathlib.Data.Nat.Totient
+import Mathlib.Algebra.GCDMonoid.Finset
+import Mathlib.Tactic
+
+/-!
+# Setwise coprimality of a finite family of totients
+
+**Open Question (`euler-totient-oq-07-oq-04`)**: extend the *pairwise* coprimality
+criterion for Euler totients to an arbitrary finite family.
+
+The parent entry (`euler-totient-oq-07`) packages Mathlib's
+`Nat.totient_coprime_totient_iff`:
+
+  `gcd(φ m, φ n) = 1 ↔ (m = 1 ∨ m = 2) ∨ (n = 1 ∨ n = 2)`,
+
+together with the structural fact that for `m, n ≥ 3` the gcd is always even.
+The driving phenomenon is the **parity of the totient**: `φ(k)` is even for every
+`k > 2` (`Nat.totient_even`), and `φ(0) = 0` is even as well, so the *only* values
+of `k` with an **odd** totient are `k ∈ {1, 2}` (where `φ(k) = 1`).
+
+This file lifts the criterion from two arguments to a finite family
+`a : ι → ℕ` indexed by a `Finset s`.  The natural object is the setwise gcd
+`s.gcd (fun i ↦ φ (a i))`, i.e. the largest integer dividing *every* totient in
+the family.  The headline result is the clean biconditional
+
+  `s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2`.
+
+Read left to right: a finite family of totients is setwise coprime **iff at least
+one argument lands in `{1, 2}`** (contributing the unit `φ = 1`).  Equivalently,
+the moment *every* argument avoids `{1, 2}` the whole family shares the factor `2`.
+
+This is genuinely stronger than the pairwise statement — the pairwise case is the
+two-element specialization (`example` at the end) — and Mathlib has no
+finite-family form.
+
+## Contents
+
+* `two_dvd_totient_of_ne_one_two`   — `a ∉ {1,2} ⟹ 2 ∣ φ a` (the parity engine).
+* `two_dvd_gcd_totient_family`      — `(∀ i ∈ s, a i ∉ {1,2}) ⟹ 2 ∣ s.gcd (φ ∘ a)`.
+* `gcd_totient_family_eq_one_iff`   — the headline biconditional.
+* `gcd_totient_family_ne_one_of_forall` — its contrapositive, stated directly.
+
+Fully machine-checked: `0` sorries, `0` axioms (the `decide` calls reduce
+concrete small naturals in the kernel, not `native_decide`).
+-/
+
+namespace EulerTotientOQ07OQ04
+
+open Nat
+
+variable {ι : Type*}
+
+/-- **The parity engine.**  Every natural other than `1` and `2` has an *even*
+totient: `φ(0) = 0` is even, and `φ(k)` is even for all `k > 2`
+(`Nat.totient_even`).  Hence `2 ∣ φ(a)` whenever `a ∉ {1, 2}`. -/
+theorem two_dvd_totient_of_ne_one_two {a : ℕ} (h1 : a ≠ 1) (h2 : a ≠ 2) :
+    2 ∣ φ a := by
+  rcases Nat.eq_zero_or_pos a with h0 | hpos
+  · simp [h0]
+  · exact (totient_even (by omega)).two_dvd
+
+/-- **Shared factor of a totient family.**  If *every* argument avoids `{1, 2}`,
+then the totients all share the factor `2`, so `2` divides their setwise gcd.
+(For the empty family this is `2 ∣ 0`, which holds.) -/
+theorem two_dvd_gcd_totient_family (s : Finset ι) (a : ι → ℕ)
+    (h : ∀ i ∈ s, a i ≠ 1 ∧ a i ≠ 2) :
+    2 ∣ s.gcd (fun i ↦ φ (a i)) := by
+  apply Finset.dvd_gcd
+  intro i hi
+  obtain ⟨h1, h2⟩ := h i hi
+  exact two_dvd_totient_of_ne_one_two h1 h2
+
+/-- **Headline: setwise coprimality criterion for a finite family of totients.**
+The totients `{φ(a i) : i ∈ s}` are setwise coprime (their gcd is `1`) **iff at
+least one argument `a i` lies in `{1, 2}`**, where the totient equals the unit `1`.
+
+Equivalently: as soon as every argument avoids `{1, 2}`, the family shares the
+factor `2` (`two_dvd_gcd_totient_family`) and is never setwise coprime.  This is
+the finite-family generalization of the pairwise `Nat.totient_coprime_totient_iff`. -/
+theorem gcd_totient_family_eq_one_iff (s : Finset ι) (a : ι → ℕ) :
+    s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2 := by
+  constructor
+  · intro h
+    by_contra hcon
+    push_neg at hcon
+    have h2 : (2 : ℕ) ∣ s.gcd (fun i ↦ φ (a i)) :=
+      two_dvd_gcd_totient_family s a hcon
+    rw [h] at h2
+    exact absurd h2 (by decide)
+  · rintro ⟨i, hi, hai⟩
+    have hphi : φ (a i) = 1 := by rcases hai with h | h <;> simp [h]
+    have hdvd : s.gcd (fun j ↦ φ (a j)) ∣ φ (a i) := Finset.gcd_dvd hi
+    rw [hphi] at hdvd
+    exact Nat.dvd_one.mp hdvd
+
+/-- **Contrapositive form.**  If every argument of the family avoids `{1, 2}`, then
+the totients are *not* setwise coprime: their gcd is at least `2`. -/
+theorem gcd_totient_family_ne_one_of_forall (s : Finset ι) (a : ι → ℕ)
+    (h : ∀ i ∈ s, a i ≠ 1 ∧ a i ≠ 2) :
+    s.gcd (fun i ↦ φ (a i)) ≠ 1 := by
+  intro hcontra
+  obtain ⟨i, hi, hai⟩ := (gcd_totient_family_eq_one_iff s a).mp hcontra
+  obtain ⟨h1, h2⟩ := h i hi
+  rcases hai with h' | h' <;> [exact h1 h'; exact h2 h']
+
+/-! ### Recovering the pairwise parent and worked examples -/
+
+/-- The pairwise criterion `euler-totient-oq-07` is the two-element
+specialization: take the family `![m, n]` indexed by `Fin 2`. -/
+example (m n : ℕ) :
+    (Finset.univ : Finset (Fin 2)).gcd (fun i ↦ φ (![m, n] i)) = 1 ↔
+      (m = 1 ∨ m = 2) ∨ (n = 1 ∨ n = 2) := by
+  rw [gcd_totient_family_eq_one_iff]
+  constructor
+  · rintro ⟨i, -, hi⟩
+    fin_cases i <;> simp_all
+  · rintro (h | h)
+    · exact ⟨0, Finset.mem_univ _, by simpa using h⟩
+    · exact ⟨1, Finset.mem_univ _, by simpa using h⟩
+
+-- A three-element family hitting `{1,2}`: `φ 2 = 1` forces setwise coprimality,
+-- regardless of the other (large) arguments.
+example : (Finset.univ : Finset (Fin 3)).gcd (fun k ↦ φ (![100, 2, 999] k)) = 1 := by
+  rw [gcd_totient_family_eq_one_iff]
+  exact ⟨1, Finset.mem_univ _, Or.inr (by decide)⟩
+
+-- A family entirely outside `{1,2}` is never setwise coprime: `φ 3 = φ 4 = φ 9 = even`.
+example : (Finset.univ : Finset (Fin 3)).gcd (fun k ↦ φ (![3, 4, 9] k)) ≠ 1 := by
+  apply gcd_totient_family_ne_one_of_forall
+  decide
+
+-- The concrete shared factor of `2` for that family: `gcd(φ3, φ4, φ9) = gcd(2,2,6) = 2`.
+example : (Finset.univ : Finset (Fin 3)).gcd (fun k ↦ φ (![3, 4, 9] k)) = 2 := by decide
+
+end EulerTotientOQ07OQ04

--- a/src/data/proofs/euler-totient-oq-07-oq-04/annotations.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-two-dvd-totient-of-ne-one-two",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 51, "endLine": 63 },
+    "type": "theorem",
+    "title": "The Parity Engine: a ∉ {1,2} ⟹ 2 ∣ φ a",
+    "content": "Packages the totient's parity into a single divisibility usable element-by-element. The proof cases on `a`: if `a = 0` then `φ 0 = 0` is divisible by 2 (`simp`); otherwise `a` is positive and, being ≠ 1 and ≠ 2, satisfies `2 < a` (by `omega`), so `Nat.totient_even` makes `φ a` even and `Even.two_dvd` extracts the factor. The naturals with an odd totient are exactly {1, 2}.",
+    "mathContext": "$a\\notin\\{1,2\\} \\implies 2\\mid\\varphi(a)$, since $\\varphi(0)=0$ and $\\varphi(k)$ is even for $k>2$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient", "parity of totient", "divisibility", "Nat.totient_even"],
+    "prerequisites": ["Euler's totient function", "parity of φ", "divisibility by 2"]
+  },
+  {
+    "id": "ann-two-dvd-gcd-totient-family",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 65, "endLine": 71 },
+    "type": "theorem",
+    "title": "Shared Factor of a Totient Family: 2 ∣ s.gcd",
+    "content": "When every argument of the family avoids {1,2}, all the totients are even, so 2 divides each entry; `Finset.dvd_gcd` lifts this uniform per-element divisibility to a divisibility of the setwise gcd. Holds vacuously for the empty family (2 ∣ 0). This is the explicit common divisor of an entire family of totients — the structural fact that drives non-coprimality.",
+    "mathContext": "$(\\forall i\\in s,\\ a_i\\notin\\{1,2\\}) \\implies 2 \\mid \\gcd_{i\\in s}\\varphi(a_i)$, via $k\\mid f(i)\\ \\forall i \\implies k\\mid \\gcd_i f(i)$.",
+    "significance": "key",
+    "relatedConcepts": ["setwise gcd", "Finset.dvd_gcd", "common divisor", "parity of totient"],
+    "prerequisites": ["Finset.gcd", "divisibility", "parity of φ"]
+  },
+  {
+    "id": "ann-gcd-totient-family-eq-one-iff",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 80, "endLine": 96 },
+    "type": "theorem",
+    "title": "Headline: Setwise Coprimality ⟺ Some Argument in {1,2}",
+    "content": "The flagship biconditional generalizing the pairwise `Nat.totient_coprime_totient_iff` to an arbitrary finite family. Forward direction is the contrapositive: if no argument is in {1,2}, then `two_dvd_gcd_totient_family` gives 2 ∣ s.gcd, contradicting s.gcd = 1 (`2 ∣ 1` is false by `decide`). Reverse direction: an argument with φ(a i) = 1 makes the setwise gcd divide 1 via `Finset.gcd_dvd`, so it equals 1 by `Nat.dvd_one`. No induction on the family is needed — the two one-directional gcd facts suffice.",
+    "mathContext": "$\\gcd_{i\\in s}\\varphi(a_i) = 1 \\iff \\exists i\\in s,\\ a_i\\in\\{1,2\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["setwise gcd", "coprimality", "finite family", "Finset.gcd_dvd", "biconditional characterization"],
+    "prerequisites": ["Finset.gcd", "coprimality", "parity of φ", "dvd_one"]
+  },
+  {
+    "id": "ann-gcd-totient-family-ne-one-of-forall",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 98, "endLine": 104 },
+    "type": "theorem",
+    "title": "Contrapositive: Family Avoiding {1,2} Is Never Setwise Coprime",
+    "content": "States the practically useful direction directly: if every argument avoids {1,2} the totients are not setwise coprime. Proved by feeding a hypothetical gcd = 1 through the headline biconditional to extract an argument in {1,2}, contradicting the hypothesis. The clean 'no escape ⟹ shared factor' form callers reach for.",
+    "mathContext": "$(\\forall i\\in s,\\ a_i\\notin\\{1,2\\}) \\implies \\gcd_{i\\in s}\\varphi(a_i)\\neq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["setwise gcd", "coprimality", "contrapositive"],
+    "prerequisites": ["Finset.gcd", "coprimality"]
+  },
+  {
+    "id": "ann-pairwise-recovery",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 108, "endLine": 119 },
+    "type": "example",
+    "title": "Recovering the Pairwise Parent (Fin 2 Specialization)",
+    "content": "Shows the pairwise criterion of `euler-totient-oq-07` is exactly the two-element case: the setwise gcd over the family `![m, n]` indexed by `Fin 2` equals 1 iff (m ∈ {1,2}) ∨ (n ∈ {1,2}). Confirms the family theorem is a genuine generalization, not a parallel statement — `fin_cases` on the index recovers the two-argument disjunction.",
+    "mathContext": "$\\gcd(\\varphi(m),\\varphi(n)) = 1 \\iff (m\\in\\{1,2\\})\\lor(n\\in\\{1,2\\})$ as the Fin 2 instance.",
+    "significance": "supporting",
+    "relatedConcepts": ["specialization", "pairwise criterion", "Fin 2", "fin_cases"],
+    "prerequisites": ["Finset.univ over Fin n", "Matrix.cons notation"]
+  },
+  {
+    "id": "ann-worked-examples",
+    "proofId": "euler-totient-oq-07-oq-04",
+    "range": { "startLine": 121, "endLine": 133 },
+    "type": "example",
+    "title": "Worked Fin 3 Families",
+    "content": "Three concrete witnesses over Fin 3: the family ![100, 2, 999] is setwise coprime because a₁ = 2 gives φ = 1; the family ![3, 4, 9] is not setwise coprime (all arguments ≥ 3) via `gcd_totient_family_ne_one_of_forall`; and its setwise gcd is exactly gcd(φ3, φ4, φ9) = gcd(2, 2, 6) = 2 by kernel `decide`.",
+    "mathContext": "$\\gcd(\\varphi 100,\\varphi 2,\\varphi 999)=1$; $\\gcd(\\varphi 3,\\varphi 4,\\varphi 9)=\\gcd(2,2,6)=2\\neq 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["worked example", "kernel decide", "setwise gcd"],
+    "prerequisites": ["finite evaluation of φ", "Finset.gcd over Fin 3"]
+  }
+]

--- a/src/data/proofs/euler-totient-oq-07-oq-04/meta.json
+++ b/src/data/proofs/euler-totient-oq-07-oq-04/meta.json
@@ -1,0 +1,152 @@
+{
+  "id": "euler-totient-oq-07-oq-04",
+  "title": "Setwise Coprimality of a Finite Family of Totients: $\\gcd_i \\varphi(a_i)=1$ Iff Some $a_i\\in\\{1,2\\}$",
+  "slug": "euler-totient-oq-07-oq-04",
+  "description": "Generalizes the pairwise coprimality criterion for Euler totients (parent `euler-totient-oq-07`) to an arbitrary finite family. For a family a : ι → ℕ indexed by a Finset s, the setwise gcd of the totients satisfies `s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2`: the family of totients is setwise coprime exactly when at least one argument lands in {1,2}, where φ = 1 is a unit. The engine is the parity of the totient — φ(0) = 0 and φ(k) is even for every k > 2 (`Nat.totient_even`), so {1,2} are the only naturals with an odd totient — combined with `Finset.dvd_gcd`/`Finset.gcd_dvd`: once every argument avoids {1,2} the whole family shares the factor 2. Mathlib has the pairwise `Nat.totient_coprime_totient_iff` but no finite-family form; this entry supplies it and directly answers a follow-up question posed in the parent's open-questions list. Fully machine-checked: 0 sorries, 0 axioms (the `decide` calls reduce concrete small naturals in the kernel, not `native_decide`).",
+  "meta": {
+    "author": "Euler (1763, totient function); finite-family coprimality criterion formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_totient_function",
+    "date": "1763",
+    "status": "verified",
+    "proofRepoPath": "Proofs/EulerTotientOQ07OQ04.lean",
+    "tags": [
+      "number-theory",
+      "euler-totient",
+      "coprimality",
+      "gcd",
+      "parity",
+      "finite-family",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 135,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The parity input is `Nat.totient_even` (φ(k) even for k > 2, via the order-2 unit −1 and Lagrange); the finite-family gcd reasoning uses `Finset.dvd_gcd` and `Finset.gcd_dvd`. The `decide` calls evaluate φ at concrete naturals (2, 3, 4, 9) and finite Fin 3 quantifications in the kernel (not `native_decide`), so the only axioms are the foundational `propext`, `Classical.choice`, `Quot.sound`.",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.totient_even",
+        "description": "`2 < n → Even n.totient`. The parity engine: every argument outside {1,2} (i.e. 0 or ≥ 3) has an even totient, so the family shares the factor 2.",
+        "module": "Mathlib.Data.Nat.Totient"
+      },
+      {
+        "theorem": "Finset.dvd_gcd",
+        "description": "`(∀ i ∈ s, k ∣ f i) → k ∣ s.gcd f`. Lifts the per-element divisibility 2 ∣ φ(a i) to 2 ∣ s.gcd (fun i ↦ φ (a i)).",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Finset.gcd_dvd",
+        "description": "`i ∈ s → s.gcd f ∣ f i`. Gives the converse direction: a single argument with φ = 1 forces the whole setwise gcd to divide 1, hence to equal 1.",
+        "module": "Mathlib.Algebra.GCDMonoid.Finset"
+      },
+      {
+        "theorem": "Nat.totient_coprime_totient_iff",
+        "description": "Pairwise criterion `(φ m).Coprime (φ n) ↔ (m ∈ {1,2}) ∨ (n ∈ {1,2})`. The two-argument special case this entry generalizes to families; recovered as the Fin 2 specialization.",
+        "module": "Mathlib.Data.Nat.Totient"
+      }
+    ],
+    "originalContributions": [
+      "`gcd_totient_family_eq_one_iff`: the finite-family criterion `s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2` — the headline generalization of the pairwise `Nat.totient_coprime_totient_iff`, which Mathlib does not state for families.",
+      "`two_dvd_totient_of_ne_one_two`: the clean parity statement `a ≠ 1 → a ≠ 2 → 2 ∣ φ a`, packaging φ(0) = 0 and `Nat.totient_even` into a single divisibility usable element-by-element.",
+      "`two_dvd_gcd_totient_family`: the shared-factor fact `(∀ i ∈ s, a i ∉ {1,2}) → 2 ∣ s.gcd (fun i ↦ φ (a i))` — the explicit common divisor of an entire totient family.",
+      "`gcd_totient_family_ne_one_of_forall`: the contrapositive stated directly — a family all of whose arguments avoid {1,2} is never setwise coprime."
+    ],
+    "prerequisites": [
+      "Euler's totient function φ(n) = |(ℤ/nℤ)ˣ|",
+      "Parity of φ: φ(n) even for n > 2 (the unit −1 of order 2 plus Lagrange), and φ(0) = 0",
+      "Setwise gcd over a Finset (Finset.gcd) and its universal/divisibility properties",
+      "Divisibility reasoning (dvd_gcd, gcd_dvd, dvd_one)"
+    ],
+    "dateAdded": "2026-06-23",
+    "relatedProblems": [
+      {
+        "id": "euler-totient-oq-07",
+        "relationship": "Parent: proves the pairwise criterion gcd(φ m, φ n) = 1 ↔ one of m, n ∈ {1,2} and the shared-factor bound 2 ≤ gcd for m, n ≥ 3. This entry lifts both to an arbitrary finite family and answers the parent's explicit open question on generalizing to families."
+      },
+      {
+        "id": "euler-totient-oq-06",
+        "relationship": "Sibling: establishes the parity classification φ(n) even ⟺ n ∉ {1,2}. This entry applies that exact dichotomy across a whole family: every argument outside {1,2} contributes an even totient, so the family shares the factor 2."
+      }
+    ]
+  },
+  "leanFile": {
+    "lineCount": 135,
+    "path": "Proofs/EulerTotientOQ07OQ04.lean",
+    "axiomCount": 0,
+    "sorries": 0,
+    "definitionCount": 0,
+    "theoremCount": 4
+  },
+  "sorries": 0,
+  "overview": {
+    "historicalContext": "Euler introduced the totient φ(n) — the order of the unit group (ℤ/nℤ)ˣ — in his 1763 generalization of Fermat's little theorem. A sharp parity constraint governs its values: for k > 2 the element −1 ∈ (ℤ/kℤ)ˣ has order 2, so Lagrange forces 2 ∣ φ(k); together with φ(0) = 0 this means {1,2} are the only naturals where φ is odd (and there φ = 1). The pairwise consequence — two totients are coprime iff some argument is 1 or 2 — is Mathlib's `Nat.totient_coprime_totient_iff`. The parent gallery entry recorded this and the explicit shared factor 2; its open-questions list then asks for the finite-family form. This entry supplies it: a family of totients is setwise coprime iff a single argument hits the odd-totient set {1,2}.",
+    "problemStatement": "**Open Question (euler-totient-oq-07-oq-04):** extend the pairwise coprimality criterion for Euler totients to a finite family. For a family a : ι → ℕ indexed by a Finset s, when is the setwise gcd of the totients {φ(a i)} equal to 1?",
+    "text": "s.gcd (fun i ↦ φ(a i)) = 1 iff at least one argument a i lies in {1,2} (where φ = 1). Equivalently, the moment every argument avoids {1,2} the whole family shares the factor 2 and the setwise gcd is at least 2.",
+    "proofStrategy": "The parity engine `two_dvd_totient_of_ne_one_two` splits on a i: if a i = 0 then φ(a i) = 0 is even; otherwise a i ≥ 3 (being ≠ 1, ≠ 2, > 0) and `Nat.totient_even` applies — so a i ∉ {1,2} ⟹ 2 ∣ φ(a i). The forward direction of the biconditional is the contrapositive: if no argument is in {1,2}, `Finset.dvd_gcd` lifts the uniform 2 ∣ φ(a i) to 2 ∣ s.gcd, contradicting gcd = 1. The reverse direction uses `Finset.gcd_dvd`: an argument with φ(a i) = 1 makes the setwise gcd divide 1, so it equals 1 by `Nat.dvd_one`. The pairwise parent is recovered as the Fin 2 specialization; worked examples evaluate the setwise gcd over Fin 3 families by kernel `decide`.",
+    "keyInsights": [
+      "**Setwise coprimality of a totient family is an all-or-nothing parity phenomenon.** A single unit value φ = 1 (from an argument in {1,2}) collapses the entire setwise gcd to 1; absent any such argument, every totient is even and 2 is a guaranteed common divisor.",
+      "**The {1,2} escape hatch is exactly the odd-totient set.** φ is odd only at 1 and 2; 0 and every k ≥ 3 give even totients. The criterion is therefore literally 'some argument has odd totient', uniform across families of any size.",
+      "**The generalization is genuinely stronger, not cosmetic.** The pairwise `Nat.totient_coprime_totient_iff` is the Fin 2 case; the family form covers arbitrary index sets (including the empty family, where the setwise gcd is 0 ≠ 1) and is what callers reasoning about products or simultaneous coprimality of many orders actually need.",
+      "**The proof is two one-directional Finset.gcd facts.** `Finset.dvd_gcd` (a common divisor of all entries divides the gcd) handles the no-escape direction; `Finset.gcd_dvd` (the gcd divides each entry) handles the escape direction — no induction on the family is required."
+    ],
+    "prerequisites": [
+      "Euler's totient φ and the unit group (ℤ/nℤ)ˣ",
+      "Parity of the totient (even for n > 2; φ(0) = 0) and divisibility by 2",
+      "Setwise gcd over a Finset and its divisibility characterization",
+      "Finite evaluation by kernel `decide`"
+    ]
+  },
+  "conclusion": {
+    "summary": "A finite family of Euler totients {φ(a i) : i ∈ s} is setwise coprime (s.gcd = 1) iff at least one argument a i lies in {1,2}; otherwise every totient is even and the setwise gcd is at least 2. 4 theorems, 135 lines, 0 sorries, 0 axioms. The criterion rests on the parity of φ (`Nat.totient_even`) and the two divisibility directions of `Finset.gcd`.",
+    "implications": "This is the form needed whenever many totients must be simultaneously coprime — e.g. CRT-style decompositions of unit groups or coprimality of several orders at once. The parity obstruction makes the answer immediate: simultaneous coprimality is possible only if all but at most the {1,2}-arguments are absent; any two arguments ≥ 3 already kill it via the shared factor 2.",
+    "openQuestions": [
+      "Pairwise vs setwise: characterize when the family {φ(a i)} is pairwise coprime (a strictly stronger condition than setwise gcd = 1), and relate it to the multiset of arguments avoiding {1,2}.",
+      "Quantify the setwise gcd's 2-adic valuation: for a family all of whose arguments are ≥ 3, is v₂(s.gcd) determined by the minimum of v₂(φ(a i)), and when does it exceed 1?"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header-overview",
+      "title": "Module Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring framing the goal — lift the pairwise totient-coprimality criterion to a finite family — with imports (`Mathlib.Data.Nat.Totient`, `Mathlib.Algebra.GCDMonoid.Finset`, `Mathlib.Tactic`), the contents list, the `EulerTotientOQ07OQ04` namespace, `open Nat` (so `φ` is `Nat.totient`), and the `{ι : Type*}` index variable."
+    },
+    {
+      "id": "parity-engine",
+      "title": "The Parity Engine and the Shared Family Factor",
+      "startLine": 55,
+      "endLine": 78,
+      "summary": "`two_dvd_totient_of_ne_one_two` (a ∉ {1,2} ⟹ 2 ∣ φ a, by casing a = 0 vs a ≥ 3 and `Nat.totient_even`) and `two_dvd_gcd_totient_family` (every argument outside {1,2} ⟹ 2 ∣ s.gcd of the totients, via `Finset.dvd_gcd`)."
+    },
+    {
+      "id": "headline-criterion",
+      "title": "The Finite-Family Coprimality Criterion",
+      "startLine": 79,
+      "endLine": 105,
+      "summary": "`gcd_totient_family_eq_one_iff` — the headline biconditional s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2 (forward: contrapositive via the shared factor 2; reverse: `Finset.gcd_dvd` plus `Nat.dvd_one`) — and `gcd_totient_family_ne_one_of_forall`, its contrapositive stated directly."
+    },
+    {
+      "id": "parent-recovery-examples",
+      "title": "Pairwise Recovery and Worked Examples",
+      "startLine": 106,
+      "endLine": 135,
+      "summary": "The Fin 2 specialization recovering the pairwise parent criterion, and worked Fin 3 families: one hitting {1,2} (φ 2 = 1 forces gcd = 1), one avoiding {1,2} (gcd ≠ 1), and the concrete value gcd(φ3, φ4, φ9) = gcd(2,2,6) = 2 by kernel `decide`."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "euler-totient-oq-07",
+      "relationship": "parent",
+      "description": "The parent proves the pairwise criterion gcd(φ m, φ n) = 1 ↔ one of m, n ∈ {1,2} and the shared-factor bound for m, n ≥ 3. This entry generalizes both to an arbitrary finite family — recovering the pairwise case as the Fin 2 specialization — and answers the parent's stated open question on families."
+    },
+    {
+      "targetId": "euler-totient-oq-06",
+      "relationship": "sibling",
+      "description": "oq-06 proves the parity classification φ(n) even ⟺ n ∉ {1,2}. This entry uses that dichotomy uniformly across a family: every argument outside {1,2} has an even totient, so the family shares the factor 2 and is never setwise coprime."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Generalizes the **pairwise** Euler-totient coprimality criterion (parent `euler-totient-oq-07`, Mathlib's `Nat.totient_coprime_totient_iff`) to an **arbitrary finite family** indexed by a `Finset`:

```
gcd_totient_family_eq_one_iff (s : Finset ι) (a : ι → ℕ) :
    s.gcd (fun i ↦ φ (a i)) = 1 ↔ ∃ i ∈ s, a i = 1 ∨ a i = 2
```

A finite family of totients is **setwise coprime iff at least one argument lands in {1,2}** (where φ = 1 is a unit). Equivalently, the moment every argument avoids {1,2} the whole family shares the factor 2.

This directly answers the open question posed in the parent entry's own `openQuestions` list ("Generalize to finite families"). Mathlib has no finite-family form.

## Why it's genuinely new (not a restatement)
- Mathlib provides only the **two-argument** `Nat.totient_coprime_totient_iff`; the family form is recovered here as the **Fin 2 specialization**.
- Proof needs **no induction** on the family — the two one-directional `Finset.gcd` facts (`Finset.dvd_gcd`, `Finset.gcd_dvd`) plus the parity engine `Nat.totient_even` suffice.

## Contents (4 theorems)
- `two_dvd_totient_of_ne_one_two` — `a ∉ {1,2} ⟹ 2 ∣ φ a` (parity engine; φ 0 = 0 and totient_even).
- `two_dvd_gcd_totient_family` — every argument outside {1,2} ⟹ `2 ∣ s.gcd`.
- `gcd_totient_family_eq_one_iff` — headline biconditional.
- `gcd_totient_family_ne_one_of_forall` — contrapositive stated directly.
- Worked examples: Fin 2 parent recovery; Fin 3 families (gcd = 1 escape, gcd ≠ 1, gcd = 2).

## Verification
- 135 lines, 0 sorries, **0 axioms**.
- `decide` calls are **kernel reductions** over small naturals / finite `Fin 3` quantifications — **not** `native_decide`.
- `#print axioms gcd_totient_family_eq_one_iff` ⇒ `[propext, Classical.choice, Quot.sound]` only.
- Built/type-checked on host via `lake env lean` (Docker daemon down this cycle); exit 0, no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)