### PR TITLE
research(infinitude-primes-4k3-oq-03-oq-01): infinitely many primes ≡ 1 (mod 3) via cyclotomic Φ₃

### DIFF
--- a/proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean
+++ b/proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean
@@ -1,0 +1,165 @@
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Data.Nat.Factorial.Basic
+import Mathlib.Data.ZMod.Basic
+import Mathlib.FieldTheory.Finite.Basic
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.Tactic
+
+/-!
+# Infinitely Many Primes ≡ 1 (mod 3) via the cyclotomic Φ₃ Euclid argument
+# (infinitude-primes-4k3-oq-03-oq-01)
+
+## The Open Question
+
+**OQ-03-OQ-01 from infinitude-primes-4k3**: The parent chain established infinitely many
+primes ≡ 3 (mod 4) (product argument) and ≡ 1 (mod 4) (Euler's criterion for −1). Can a
+*cyclotomic* Euclid-style argument prove infinitely many primes ≡ 1 (mod 3) using the third
+cyclotomic polynomial Φ₃(x) = x² + x + 1?
+
+## The Answer
+
+**Yes.** This is the smallest genuinely "cyclotomic" instance of the Euclid argument. The key
+fact about Φ₄(x) = x² + 1 used in the ≡ 1 (mod 4) case generalizes: a prime p dividing
+Φ₃(m) = m² + m + 1 forces the multiplicative order of m mod p to be exactly 3 (unless p = 3),
+and `orderOf m ∣ p − 1` then gives 3 ∣ p − 1, i.e. p ≡ 1 (mod 3).
+
+## The Proof Idea
+
+1. Given n, set m = 3 · (n+1)! and consider N = Φ₃(m) = m² + m + 1.
+2. N ≥ 2, so N has a prime factor p.
+3. **Coprimality**: p ∤ m, because p ∣ m would give p ∣ N − (m² + m) = 1.
+   In particular p ≠ 3 (since 3 ∣ m) and p > n (since every prime ≤ n+1 divides (n+1)! ∣ m).
+4. **Order argument**: m² + m + 1 ≡ 0 (mod p) ⟹ m³ ≡ 1 (mod p) (because
+   (m − 1)(m² + m + 1) = m³ − 1). So `orderOf m ∣ 3`, hence `orderOf m ∈ {1, 3}`.
+   - `orderOf m = 1` ⟹ m ≡ 1 ⟹ 3 ≡ 0 (mod p) ⟹ p = 3, contradiction.
+   - So `orderOf m = 3`, and `orderOf m ∣ p − 1` (Fermat) gives 3 ∣ p − 1, i.e. p ≡ 1 (mod 3).
+5. Hence for every n there is a prime p > n with p ≡ 1 (mod 3): infinitely many.
+
+## Comparison with the mod-4 siblings
+
+| | ≡ 3 (mod 4) | ≡ 1 (mod 4) | ≡ 1 (mod 3) (this file) |
+|-|-------------|-------------|--------------------------|
+| Polynomial | linear (4·k − 1) | Φ₄ = x² + 1 | Φ₃ = x² + x + 1 |
+| Key fact | product of ≡1 stays ≡1 | −1 is a QR ⟺ p ≡ 1 (mod 4) | ord₃(m) = 3 ⟹ 3 ∣ p − 1 |
+| Tool | parity of product | Euler's criterion | multiplicative order + Fermat |
+
+The cyclotomic order argument is the prototype for the general statement "infinitely many
+primes ≡ 1 (mod k) via Φ_k", specialized here to k = 3.
+
+## Summary: 5 theorems, 0 new axioms, 0 sorries
+-/
+
+namespace InfinitudePrimes4k3OQ03OQ01
+
+open Nat
+
+/-! ## Key Lemma: primes dividing m² + m + 1 (other than 3) are ≡ 1 (mod 3) -/
+
+/-- If a prime `p ≠ 3` divides `m² + m + 1 = Φ₃(m)`, then `p ≡ 1 (mod 3)`.
+
+    Working mod `p`, the divisibility gives `m² + m + 1 = 0`, hence `m³ = 1`
+    (since `(m − 1)(m² + m + 1) = m³ − 1`). Thus `orderOf m ∣ 3`, so the order is
+    `1` or `3`. Order `1` would force `m = 1` and then `3 = 0 (mod p)`, i.e. `p = 3`;
+    excluded. So the order is exactly `3`, and `orderOf m ∣ p − 1` (Fermat) yields
+    `3 ∣ p − 1`, i.e. `p ≡ 1 (mod 3)`. -/
+lemma prime_dvd_phi3_mod_three {p m : ℕ} (hp : Nat.Prime p) (hp3 : p ≠ 3)
+    (hdiv : p ∣ m ^ 2 + m + 1) : p % 3 = 1 := by
+  haveI : Fact (Nat.Prime p) := ⟨hp⟩
+  -- Reduce the divisibility to an equation in `ZMod p`.
+  have hz : ((m ^ 2 + m + 1 : ℕ) : ZMod p) = 0 := (ZMod.natCast_eq_zero_iff _ _).mpr hdiv
+  have h0 : (m : ZMod p) ^ 2 + (m : ZMod p) + 1 = 0 := by push_cast at hz; linear_combination hz
+  -- `m³ = 1` in `ZMod p`, because `(m − 1)(m² + m + 1) = m³ − 1`.
+  have hcube : (m : ZMod p) ^ 3 = 1 := by linear_combination ((m : ZMod p) - 1) * h0
+  -- `m ≠ 0` (else `0 = 1` in `ZMod p`).
+  have hm0 : (m : ZMod p) ≠ 0 := by
+    intro h; rw [h] at hcube; simp at hcube
+  -- The order of `m` divides 3, so it is 1 or 3.
+  have hord_dvd3 : orderOf (m : ZMod p) ∣ 3 := orderOf_dvd_of_pow_eq_one hcube
+  rcases (Nat.dvd_prime Nat.prime_three).mp hord_dvd3 with hord1 | hord3
+  · -- Order 1 ⟹ `m = 1` ⟹ `3 = 0 (mod p)` ⟹ `p = 3`: contradiction.
+    rw [orderOf_eq_one_iff] at hord1
+    rw [hord1] at h0
+    -- `h0 : 1² + 1 + 1 = 0`, so `(3 : ZMod p) = 0`, so `p ∣ 3`, so `p = 3`.
+    have h3 : ((3 : ℕ) : ZMod p) = 0 := by push_cast; linear_combination h0
+    have hp_dvd_3 : p ∣ 3 := (ZMod.natCast_eq_zero_iff 3 p).mp h3
+    exact absurd ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp hp_dvd_3) hp3
+  · -- Order 3, and `orderOf m ∣ p − 1` (Fermat) ⟹ `3 ∣ p − 1` ⟹ `p ≡ 1 (mod 3)`.
+    have hdvd : orderOf (m : ZMod p) ∣ p - 1 := ZMod.orderOf_dvd_card_sub_one hm0
+    rw [hord3] at hdvd
+    have hp2 : p ≥ 2 := hp.two_le
+    omega
+
+/-! ## The Main Theorem -/
+
+/-- **THE MAIN THEOREM: Infinitely many primes ≡ 1 (mod 3)**
+
+    Given any natural number `n`, there exists a prime `p > n` with `p ≡ 1 (mod 3)`.
+    The witness is a prime factor of `N = Φ₃(3·(n+1)!) = (3·(n+1)!)² + 3·(n+1)! + 1`. -/
+theorem infinitely_many_primes_1_mod_3 :
+    ∀ n : ℕ, ∃ p : ℕ, Nat.Prime p ∧ p > n ∧ p % 3 = 1 := by
+  intro n
+  set m := 3 * (n + 1).factorial with hm
+  have hfac : (n + 1).factorial ≥ 1 := Nat.factorial_pos _
+  have hm3 : m ≥ 3 := by rw [hm]; omega
+  -- `N = m² + m + 1 ≥ 2`, so it has a prime factor `p`.
+  have hN_ne1 : m ^ 2 + m + 1 ≠ 1 := by nlinarith [hm3]
+  obtain ⟨p, hp_prime, hp_div⟩ := Nat.exists_prime_and_dvd hN_ne1
+  -- `p ∤ m`: otherwise `p ∣ (m² + m + 1) − (m² + m) = 1`.
+  have hp_ndvd_m : ¬ p ∣ m := by
+    intro hpm
+    have h1 : p ∣ m ^ 2 + m := Nat.dvd_add (dvd_pow hpm two_ne_zero) hpm
+    have hsub : m ^ 2 + m + 1 - (m ^ 2 + m) = 1 := by omega
+    have : p ∣ 1 := by
+      have := Nat.dvd_sub hp_div h1
+      rwa [hsub] at this
+    exact hp_prime.not_dvd_one this
+  -- `p ≠ 3` since `3 ∣ m`.
+  have hp_ne3 : p ≠ 3 := by
+    intro h3
+    exact hp_ndvd_m (h3 ▸ (by rw [hm]; exact dvd_mul_right 3 _))
+  refine ⟨p, hp_prime, ?_, prime_dvd_phi3_mod_three hp_prime hp_ne3 hp_div⟩
+  -- `p > n`: every prime `≤ n+1` divides `(n+1)! ∣ m`, contradicting `p ∤ m`.
+  by_contra hle
+  push_neg at hle
+  apply hp_ndvd_m
+  rw [hm]
+  exact (Nat.dvd_factorial hp_prime.pos (by omega)).mul_left 3
+
+/-! ## Consequences -/
+
+/-- The set of primes `≡ 1 (mod 3)` is infinite. -/
+theorem primes_1_mod_3_infinite : Set.Infinite {p : ℕ | Nat.Prime p ∧ p % 3 = 1} := by
+  rw [Set.infinite_iff_exists_gt]
+  intro n
+  obtain ⟨p, hp_prime, hp_gt, hp_mod⟩ := infinitely_many_primes_1_mod_3 n
+  exact ⟨p, ⟨hp_prime, hp_mod⟩, hp_gt⟩
+
+/-- There is no largest prime `≡ 1 (mod 3)`. -/
+theorem no_largest_prime_1_mod_3 :
+    ¬∃ p : ℕ, Nat.Prime p ∧ p % 3 = 1 ∧ ∀ q : ℕ, Nat.Prime q → q % 3 = 1 → q ≤ p := by
+  intro ⟨p, _, _, hp_largest⟩
+  obtain ⟨q, hq_prime, hq_gt, hq_mod⟩ := infinitely_many_primes_1_mod_3 p
+  exact absurd (hp_largest q hq_prime hq_mod) (by omega)
+
+/-! ## Examples -/
+
+/-- 7 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 7 ∧ 7 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 13 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 13 ∧ 13 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 19 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 19 ∧ 19 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 31 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 31 ∧ 31 % 3 = 1 := ⟨by decide, rfl⟩
+
+/-- 37 is a prime ≡ 1 (mod 3). -/
+example : Nat.Prime 37 ∧ 37 % 3 = 1 := ⟨by decide, rfl⟩
+
+#check @infinitely_many_primes_1_mod_3
+#check @primes_1_mod_3_infinite
+#check @no_largest_prime_1_mod_3
+
+end InfinitudePrimes4k3OQ03OQ01

--- a/research/problems/infinitude-primes-4k3-oq-03-oq-01/knowledge.md
+++ b/research/problems/infinitude-primes-4k3-oq-03-oq-01/knowledge.md
@@ -1,0 +1,42 @@
+# infinitude-primes-4k3-oq-03-oq-01
+
+**Problem**: Infinitely many primes ≡ 1 (mod 3) via the cyclotomic Φ₃ Euclid-style argument.
+
+**Status**: COMPLETED — verified, 0 axioms, 0 sorries.
+
+## Summary
+
+Proved `infinitely_many_primes_1_mod_3 : ∀ n, ∃ p, Nat.Prime p ∧ p > n ∧ p % 3 = 1`
+by the cyclotomic Euclid construction `N = Φ₃(3·(n+1)!) = (3·(n+1)!)² + 3·(n+1)! + 1`.
+File: `proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean` (165 lines, 4 theorems).
+
+## Session 2026-06-23 (Session 1) — FRESH
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Mirrored the architecture of the sibling `InfinitudePrimes4k1.lean` (≡ 1 mod 4 via Φ₄ = x²+1),
+  adapting it to Φ₃ = x²+x+1 with the multiplicative-order argument made explicit.
+- Key lemma `prime_dvd_phi3_mod_three`: prime p ≠ 3 dividing m²+m+1 ⟹ p ≡ 1 (mod 3).
+  Proof: cast to ℤ/p, `linear_combination ((m)-1)*h0` gives m³ = 1; `orderOf_dvd_of_pow_eq_one`
+  bounds order by 3; order 1 forces p = 3 (excluded); `ZMod.orderOf_dvd_card_sub_one` gives 3 ∣ p−1.
+- Main construction uses m = 3·(n+1)! so 3 ∣ m (forces coprime factor ≠ 3) and (n+1)! ∣ m (forces p > n).
+- Built on host (docker down): `LAKE_UNSAFE=1 lake build` with `ulimit -v`, 112 s, mathlib cached.
+- `#print axioms`: only propext, Classical.choice, Quot.sound → verified/0-axiom.
+
+### Key Findings
+- The factorization (x−1)(x²+x+1) = x³−1 is the entire "cyclotomic" content; in Lean it is a single
+  `linear_combination`. The order argument is identical to the Φ₄ case at d=4 vs d=3.
+- `ZMod.orderOf_dvd_card_sub_one {a ≠ 0} : orderOf a ∣ p − 1` is the clean Fermat-in-order-form lemma
+  (Mathlib.FieldTheory.Finite.Basic), avoiding manual `pow_card_sub_one_eq_one` + `orderOf_dvd_of_pow_eq_one`.
+- `ZMod.natCast_zmod_eq_zero_iff_dvd` is deprecated (since 2025-06-30) → use `ZMod.natCast_eq_zero_iff`.
+
+### Files Modified
+- proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean (new)
+- src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/{meta.json, annotations.json} (new)
+
+### Next Steps (follow-up open questions)
+- Generalize to a uniform Lean theorem: primes dividing Φ_d(k) with p ∤ d are ≡ 1 (mod d), subsuming
+  d = 3 (this file) and d = 4 (InfinitudePrimes4k1) under one cyclotomic argument.
+- Formalize the complementary ≡ 2 (mod 3) class via the elementary product argument.

--- a/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "imports",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 6 },
+    "type": "concept",
+    "title": "Imports: Order Theory over a Finite Field",
+    "content": "Unlike the mod-4 sibling, which imported NumberTheory.SumTwoSquares for Euler's criterion, this file imports FieldTheory.Finite.Basic and GroupTheory.OrderOfElement. The whole proof runs on multiplicative order in ℤ/p: ZMod.orderOf_dvd_card_sub_one (Fermat's little theorem in order form) and orderOf_dvd_of_pow_eq_one. ZMod.natCast_eq_zero_iff bridges divisibility in ℕ and equations in ℤ/p, and Nat.dvd_factorial / Nat.exists_prime_and_dvd power the Euclid construction.",
+    "mathContext": "The argument needs $\\mathbb{Z}/p$ to be a field (so $\\mathbb{F}_p^\\times$ has order $p-1$) and Lagrange's theorem $\\mathrm{ord}(a) \\mid |\\mathbb{F}_p^\\times| = p-1$. These live in `Mathlib.FieldTheory.Finite.Basic` and `Mathlib.GroupTheory.OrderOfElement`.",
+    "significance": "supporting",
+    "relatedConcepts": ["multiplicative order", "Fermat's little theorem", "finite fields", "ZMod p"],
+    "prerequisites": ["ZMod p as a field", "orderOf in a finite group", "Lagrange's theorem"]
+  },
+  {
+    "id": "oq-answer",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 8, "endLine": 50 },
+    "type": "concept",
+    "title": "Answering OQ-03-OQ-01: The Cyclotomic Φ₃ Argument",
+    "content": "The parent entry infinitude-primes-4k3-oq-03 explicitly proposed (in its openQuestions) the construction N = Φ₃(3·k!) = (3·k!)² + 3·k! + 1 for proving infinitely many primes ≡ 1 (mod 3). This file realizes that proposal. Φ₃(x) = x² + x + 1 is the third cyclotomic polynomial; the smallest genuinely cyclotomic case of the Euclid-style infinitude argument (Φ₂ and the linear cases are degenerate; Φ₄ = x²+1 is the mod-4 sibling).",
+    "mathContext": "The general fact: for the $d$-th cyclotomic polynomial $\\Phi_d$, any prime $p \\nmid d$ dividing $\\Phi_d(k)$ satisfies $p \\equiv 1 \\pmod d$. Here $d = 3$, $\\Phi_3(x) = x^2 + x + 1$, and the excluded prime is $p = 3 = d$.",
+    "significance": "key",
+    "relatedConcepts": ["cyclotomic polynomial", "Euclid's proof", "Dirichlet's theorem", "arithmetic progressions"],
+    "prerequisites": ["cyclotomic polynomials", "Euclid's infinitude of primes"]
+  },
+  {
+    "id": "key-lemma-cube",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 65, "endLine": 73 },
+    "type": "proof-technique",
+    "title": "From Divisibility to m³ = 1 via linear_combination",
+    "content": "The divisibility p ∣ m² + m + 1 is cast into ℤ/p as h0 : (m)² + m + 1 = 0. The cubing step m³ = 1 is then a one-line linear_combination over the factorization (m − 1)(m² + m + 1) = m³ − 1: `linear_combination ((m : ZMod p) - 1) * h0`. This is the cyclotomic heart of the argument — Φ₃(m) = 0 is exactly what makes m a primitive cube root of unity (or 1).",
+    "mathContext": "$(m-1)(m^2+m+1) = m^3 - 1$, so $m^2+m+1 = 0 \\Rightarrow m^3 - 1 = (m-1)\\cdot 0 = 0 \\Rightarrow m^3 = 1$ in $\\mathbb{Z}/p$.",
+    "significance": "key",
+    "relatedConcepts": ["roots of unity", "linear_combination tactic", "polynomial factorization", "Φ₃"],
+    "prerequisites": ["commutative ring identities", "linear_combination tactic"]
+  },
+  {
+    "id": "key-lemma-order",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 79, "endLine": 90 },
+    "type": "proof-technique",
+    "title": "Order Exactly 3 ⟹ 3 ∣ p − 1",
+    "content": "From m³ = 1, orderOf_dvd_of_pow_eq_one gives orderOf m ∣ 3, so the order is 1 or 3 (Nat.dvd_prime Nat.prime_three). Order 1 means m = 1, making m² + m + 1 = 3 = 0 in ℤ/p, i.e. p ∣ 3, i.e. p = 3 — excluded by hypothesis. Hence the order is exactly 3, and ZMod.orderOf_dvd_card_sub_one (Fermat) gives 3 ∣ p − 1. With p ≥ 2, omega concludes p % 3 = 1.",
+    "mathContext": "$\\mathrm{ord}(m) \\mid 3 \\Rightarrow \\mathrm{ord}(m) \\in \\{1,3\\}$. $\\mathrm{ord}(m)=1 \\Rightarrow m=1 \\Rightarrow 3 \\equiv 0 \\Rightarrow p=3$ (excluded). So $\\mathrm{ord}(m)=3 \\mid p-1$, i.e. $p \\equiv 1 \\pmod 3$.",
+    "significance": "key",
+    "relatedConcepts": ["multiplicative order", "Lagrange's theorem", "Fermat's little theorem", "primitive roots"],
+    "prerequisites": ["orderOf and pow_eq_one", "order divides group order"]
+  },
+  {
+    "id": "construction-coprimality",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 119 },
+    "type": "proof-technique",
+    "title": "Coprimality: Any Prime Factor of N is Coprime to m",
+    "content": "With m = 3·(n+1)! and N = m² + m + 1, a prime factor p of N cannot divide m: p ∣ m would give p ∣ m² + m, hence p ∣ N − (m² + m) = 1, impossible. This single coprimality fact does triple duty: it forces p ≠ 3 (because 3 ∣ m), it forces p > n (because every prime ≤ n+1 divides (n+1)! ∣ m, via Nat.dvd_factorial), and it is the precondition the key lemma needs.",
+    "mathContext": "$p \\mid m \\Rightarrow p \\mid m(m+1) = m^2 + m \\Rightarrow p \\mid (m^2+m+1) - (m^2+m) = 1$, contradicting $p$ prime. So $\\gcd(p, m) = 1$; since $3 \\mid m$ and $(n+1)! \\mid m$, this yields $p \\neq 3$ and $p > n$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclid's coprimality trick", "Nat.dvd_factorial", "factorial divisibility"],
+    "prerequisites": ["divisibility arithmetic", "factorial prime divisibility"]
+  },
+  {
+    "id": "set-infinite",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 130, "endLine": 142 },
+    "type": "concept",
+    "title": "Packaging: Set.Infinite and No Largest Prime",
+    "content": "The ∀ n, ∃ p > n form is repackaged two ways. primes_1_mod_3_infinite uses Set.infinite_iff_exists_gt to state that {p prime | p ≡ 1 (mod 3)} is Set.Infinite. no_largest_prime_1_mod_3 states the dual: no prime in the class dominates all others, proved by beating any candidate maximum with the larger prime the main theorem supplies.",
+    "mathContext": "$\\{p \\mid \\mathrm{Prime}\\,p \\wedge p \\bmod 3 = 1\\}$ is infinite $\\iff$ for every $n$ there is a larger member $\\iff$ no member is maximal.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.Infinite", "Set.infinite_iff_exists_gt", "unboundedness"],
+    "prerequisites": ["Set.Infinite in Mathlib"]
+  },
+  {
+    "id": "examples",
+    "proofId": "infinitude-primes-4k3-oq-03-oq-01",
+    "range": { "startLine": 144, "endLine": 163 },
+    "type": "concept",
+    "title": "The Family Begins: 7, 13, 19, 31, 37",
+    "content": "Concrete members of the infinite family, each ≡ 1 (mod 3) and verified by decide. Note 7 = Φ₃(2), 13 = Φ₃(3): the cyclotomic values themselves produce such primes. The primes ≡ 2 (mod 3) (5, 11, 17, 23, …) form the complementary class, which would be handled by an elementary product argument rather than the cyclotomic one.",
+    "mathContext": "$7,13,19,31,37 \\equiv 1 \\pmod 3$. Indeed $\\Phi_3(2) = 7$ and $\\Phi_3(3) = 13$ are themselves primes $\\equiv 1 \\pmod 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide tactic", "cyclotomic values", "residue classes mod 3"],
+    "prerequisites": ["decidability of Nat.Prime for small numbers"]
+  }
+]

--- a/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/meta.json
@@ -1,0 +1,230 @@
+{
+  "id": "infinitude-primes-4k3-oq-03-oq-01",
+  "title": "Infinitely Many Primes ≡ 1 (mod 3) via the Cyclotomic Φ₃ Euclid Argument",
+  "slug": "infinitude-primes-4k3-oq-03-oq-01",
+  "description": "Answers OQ-03-OQ-01 from infinitude-primes-4k3: proves infinitely many primes ≡ 1 (mod 3) by the cyclotomic Euclid argument. For N = Φ₃(3·(n+1)!) = (3·(n+1)!)² + 3·(n+1)! + 1, any prime factor p has multiplicative order exactly 3 mod p (unless p = 3), so orderOf m ∣ p−1 forces 3 ∣ p−1, i.e. p ≡ 1 (mod 3). This is the smallest genuinely cyclotomic instance of the Euclid-style infinitude argument — the prototype for 'primes ≡ 1 (mod k) via Φ_k'. 4 theorems, 0 axioms, 0 sorries.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions",
+    "date": "formalized 2026",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "elementary",
+      "primes",
+      "cyclotomic",
+      "modular-arithmetic",
+      "multiplicative-order"
+    ],
+    "proofRepoPath": "Proofs/InfinitudePrimes4k3OQ03OQ01.lean",
+    "parentProofId": "infinitude-primes-4k3-oq-03",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "newAxiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.orderOf_dvd_card_sub_one",
+        "description": "For a ≠ 0 in ZMod p (p prime), orderOf a ∣ p − 1 (Fermat's little theorem in order form)",
+        "module": "Mathlib.FieldTheory.Finite.Basic"
+      },
+      {
+        "theorem": "orderOf_dvd_of_pow_eq_one",
+        "description": "If a^n = 1 then orderOf a ∣ n",
+        "module": "Mathlib.GroupTheory.OrderOfElement"
+      },
+      {
+        "theorem": "ZMod.natCast_eq_zero_iff",
+        "description": "(a : ZMod b) = 0 ↔ b ∣ a — bridges divisibility and the residue ring",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Nat.dvd_factorial",
+        "description": "Prime p ≤ n+1 divides (n+1)! — yields the new prime exceeding n",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.exists_prime_and_dvd",
+        "description": "Every n ≠ 1 has a prime divisor",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ],
+    "originalContributions": [
+      "prime_dvd_phi3_mod_three: any prime p ≠ 3 dividing m² + m + 1 satisfies p ≡ 1 (mod 3), via the order-3 argument (m³ = 1 in ZMod p, orderOf m = 3, orderOf m ∣ p − 1)",
+      "infinitely_many_primes_1_mod_3: ∀ n, ∃ prime p > n with p ≡ 1 (mod 3) — the cyclotomic Euclid construction N = Φ₃(3·(n+1)!)",
+      "primes_1_mod_3_infinite: the set {p prime | p ≡ 1 (mod 3)} is Set.Infinite",
+      "no_largest_prime_1_mod_3: there is no maximal prime ≡ 1 (mod 3)"
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 165,
+    "assumptions": "0 axioms — #print axioms reports only propext, Classical.choice, Quot.sound (the standard foundational axioms, which do not count as assumptions). No native_decide, no sorry.",
+    "definitionCount": 0
+  },
+  "overview": {
+    "historicalContext": "The infinitude of primes in an arithmetic progression $\\{a + kd : \\gcd(a,d)=1\\}$ is **Dirichlet's theorem** (1837), whose general proof requires Dirichlet $L$-functions and their non-vanishing at $s = 1$. For special residue classes, however, **elementary Euclid-style proofs** exist. The classes $a \\equiv 1 \\pmod d$ are the universal elementary case: they are handled by the **cyclotomic polynomial** $\\Phi_d(x)$, whose defining property is that any prime $p \\nmid d$ dividing $\\Phi_d(k)$ (for some integer $k$) satisfies $p \\equiv 1 \\pmod d$.\n\nThis file formalizes the smallest genuinely cyclotomic instance: $d = 3$, $\\Phi_3(x) = x^2 + x + 1$. It is the natural next step after the sibling mod-4 entries: `infinitude-primes-4k3` ($p \\equiv 3 \\pmod 4$, product argument), `infinitude-primes-4k1` ($p \\equiv 1 \\pmod 4$, Euler's criterion / $\\Phi_4(x) = x^2 + 1$). The parent entry `infinitude-primes-4k3-oq-03` explicitly posed this construction as an open question; this file answers it.\n\nThe mechanism is the **multiplicative order**. If a prime $p$ divides $\\Phi_3(m) = m^2 + m + 1$, then since $(m-1)\\,\\Phi_3(m) = m^3 - 1$, we get $m^3 \\equiv 1 \\pmod p$. The order of $m$ in $\\mathbb{F}_p^\\times$ divides $3$, and (excluding $p = 3$) cannot be $1$, so it is exactly $3$. Lagrange's theorem / Fermat's little theorem then forces $3 \\mid p - 1$. This is the same engine that, for general $d$, shows $\\Phi_d$ detects primes $\\equiv 1 \\pmod d$.",
+    "problemStatement": "**Open Question (infinitude-primes-4k3-OQ-03-OQ-01)**: The mod-4 siblings prove infinitely many primes $\\equiv 3 \\pmod 4$ (elementary product argument) and $\\equiv 1 \\pmod 4$ (Euler's criterion, $\\Phi_4 = x^2 + 1$). Can a genuinely *cyclotomic* Euclid-style argument, using $\\Phi_3(x) = x^2 + x + 1$, prove infinitely many primes $\\equiv 1 \\pmod 3$?\n\n**Answer**: Yes. With $N = \\Phi_3(3\\cdot(n+1)!) = (3\\cdot(n+1)!)^2 + 3\\cdot(n+1)! + 1$, every prime factor $p$ is coprime to $m = 3\\cdot(n+1)!$ (else $p \\mid 1$), hence $p \\neq 3$ and $p > n$; the order argument gives $p \\equiv 1 \\pmod 3$. As $n$ varies this produces arbitrarily large such primes.",
+    "proofStrategy": "**Key lemma `prime_dvd_phi3_mod_three`**: For a prime $p \\neq 3$ with $p \\mid m^2 + m + 1$, work in $\\mathbb{Z}/p$. The cast gives $m^2 + m + 1 = 0$; `linear_combination (m-1)·(that equation)` proves $m^3 = 1$. Then `orderOf_dvd_of_pow_eq_one` gives $\\mathrm{ord}(m) \\mid 3$, so $\\mathrm{ord}(m) \\in \\{1, 3\\}$ (`Nat.dvd_prime Nat.prime_three`). Order $1$ means $m = 1$, whence $1 + 1 + 1 = 3 = 0$ in $\\mathbb{Z}/p$, i.e. $p \\mid 3$, i.e. $p = 3$ — contradiction. So $\\mathrm{ord}(m) = 3$, and `ZMod.orderOf_dvd_card_sub_one` gives $3 \\mid p - 1$; `omega` concludes $p \\bmod 3 = 1$.\n\n**Main theorem `infinitely_many_primes_1_mod_3`**: Set $m = 3\\cdot(n+1)!$, so $m \\geq 3$ and $N = m^2 + m + 1 \\geq 2$ has a prime factor $p$ (`Nat.exists_prime_and_dvd`). Coprimality $p \\nmid m$ follows because $p \\mid m \\Rightarrow p \\mid m^2 + m \\Rightarrow p \\mid N - (m^2+m) = 1$. Then $p \\neq 3$ (since $3 \\mid m$) and $p > n$ (else $p \\mid (n+1)! \\mid m$, via `Nat.dvd_factorial`). The key lemma gives $p \\equiv 1 \\pmod 3$.",
+    "keyInsights": [
+      "**The cyclotomic order mechanism**: A prime $p$ dividing $\\Phi_3(m) = m^2+m+1$ forces $m^3 \\equiv 1 \\pmod p$ but $m \\not\\equiv 1$ (for $p \\neq 3$), so $m$ has multiplicative order exactly $3$. Lagrange then gives $3 \\mid |\\mathbb{F}_p^\\times| = p-1$. This single idea generalizes to every $\\Phi_d$: it is the reason $\\equiv 1 \\pmod d$ is the universally-elementary residue class.",
+      "**The algebraic identity is the whole proof**: $(m-1)(m^2+m+1) = m^3 - 1$ is what converts the divisibility hypothesis into $m^3 = 1$. In Lean this is a one-liner — `linear_combination ((m:ZMod p) - 1) * h0` — exposing that the 'cyclotomic' content is exactly this factorization of $x^3 - 1$.",
+      "**Why $m = 3\\cdot(n+1)!$ (not just $(n+1)!$)**: The factor of $3$ guarantees $3 \\mid m$, which simultaneously (a) makes the coprime prime factor automatically $\\neq 3$, so the order argument applies, and (b) is harmless to the $p > n$ argument since every prime $\\le n+1$ already divides $(n+1)!$. A single construction thus handles both the 'exclude $p=3$' and 'find a large prime' requirements.",
+      "**Coprimality replaces primality-of-N**: Unlike the classic Euclid proof, $N = m^2+m+1$ need not be coprime to all small primes by inspection. Instead, any prime factor $p$ of $N$ is *forced* coprime to $m$ because $p \\mid m$ would give $p \\mid N - m(m+1) = 1$. This is the cyclotomic analogue of '$N$ leaves remainder 1'.",
+      "**Contrast with the mod-4 siblings**: $\\equiv 3 \\pmod 4$ uses a parity/product argument (no field theory); $\\equiv 1 \\pmod 4$ uses Euler's criterion for $-1$ being a QR (i.e. $\\Phi_4 = x^2+1$ and order $4$); $\\equiv 1 \\pmod 3$ uses $\\Phi_3 = x^2+x+1$ and order $3$. The mod-4 and mod-3 '≡1' cases are the *same* order argument at $\\Phi_4$ and $\\Phi_3$; this file makes the order mechanism fully explicit rather than routing through the sum-of-two-squares API.",
+      "**The complementary class $\\equiv 2 \\pmod 3$ is easier, not harder**: $\\equiv 2 \\pmod 3$ admits an elementary product argument (parallel to $\\equiv 3 \\pmod 4$): a product of numbers $\\equiv 1 \\pmod 3$ stays $\\equiv 1$, so a number $\\equiv 2 \\pmod 3$ has a prime factor $\\equiv 2 \\pmod 3$. Together $\\{1,2\\} \\pmod 3$ exhaust the primes $> 3$, giving a complete elementary mod-3 classification analogous to the mod-4 one."
+    ],
+    "prerequisites": [
+      "Euclid's infinitude of primes (build N with a prime factor outside any finite set)",
+      "Modular arithmetic in ZMod p and the field structure of ℤ/p for p prime",
+      "Multiplicative order in a finite group and Lagrange's theorem (orderOf a ∣ |G|)",
+      "Fermat's little theorem in the form orderOf a ∣ p − 1 (ZMod.orderOf_dvd_card_sub_one)",
+      "The factorization x³ − 1 = (x − 1)(x² + x + 1), i.e. the cyclotomic polynomial Φ₃",
+      "The factorial's prime-divisibility property (Nat.dvd_factorial)"
+    ]
+  },
+  "mainTheorems": [
+    {
+      "name": "infinitely_many_primes_1_mod_3",
+      "type": "core",
+      "statement": "$\\forall n \\in \\mathbb{N}, \\; \\exists p$ prime, $p > n$ and $p \\equiv 1 \\pmod 3$",
+      "significance": "Direct answer to OQ-03-OQ-01 from `infinitude-primes-4k3`. The witness is a prime factor of $N = \\Phi_3(3\\cdot(n+1)!) = (3\\cdot(n+1)!)^2 + 3\\cdot(n+1)! + 1$. Coprimality of any prime factor with $m = 3\\cdot(n+1)!$ delivers both $p \\neq 3$ and $p > n$; the order-3 key lemma delivers $p \\equiv 1 \\pmod 3$. This is the smallest genuinely cyclotomic case of the Euclid-style argument.",
+      "description": "Main theorem: infinitely many primes ≡ 1 (mod 3) via the Φ₃ construction."
+    },
+    {
+      "name": "prime_dvd_phi3_mod_three",
+      "type": "core",
+      "statement": "$p$ prime, $p \\neq 3$, $p \\mid m^2 + m + 1 \\;\\Rightarrow\\; p \\equiv 1 \\pmod 3$",
+      "significance": "The mathematical heart of the proof and the cyclotomic detector lemma. In $\\mathbb{Z}/p$: $m^2+m+1 = 0 \\Rightarrow m^3 = 1$ (via $(m-1)\\Phi_3(m) = m^3-1$), so $\\mathrm{ord}(m) \\mid 3$. Order $1$ forces $p = 3$ (excluded); order $3$ with $\\mathrm{ord}(m) \\mid p-1$ gives $3 \\mid p-1$. This is the $d = 3$ specialization of the general fact that primes dividing $\\Phi_d(k)$ are $\\equiv 1 \\pmod d$.",
+      "description": "Key lemma: primes ≠ 3 dividing Φ₃(m) are ≡ 1 (mod 3), by the multiplicative-order argument."
+    },
+    {
+      "name": "primes_1_mod_3_infinite",
+      "type": "core",
+      "statement": "$\\{p \\text{ prime} \\mid p \\equiv 1 \\pmod 3\\}$ is $\\mathrm{Set.Infinite}$",
+      "significance": "Packages the main theorem as a Set.Infinite statement via `Set.infinite_iff_exists_gt`: for every bound $n$ there is a larger element of the set. The set-level form is the cleanest interface for downstream use and matches the sibling `primes_1_mod_4_infinite`.",
+      "description": "Set-level form: the residue class 1 (mod 3) contains infinitely many primes."
+    },
+    {
+      "name": "no_largest_prime_1_mod_3",
+      "type": "supporting",
+      "statement": "$\\neg\\,\\exists p$ prime with $p \\equiv 1 \\pmod 3$ that is $\\geq$ every prime $\\equiv 1 \\pmod 3$",
+      "significance": "The 'no maximal element' reformulation, dual to infinitude. Proof: any claimed maximum $p$ is beaten by the prime $> p$ produced by the main theorem; `omega` closes the contradiction. Makes the infinitude concrete in the order-theoretic sense.",
+      "description": "There is no largest prime ≡ 1 (mod 3)."
+    }
+  ],
+  "references": [
+    {
+      "type": "research-paper",
+      "citation": "Dirichlet, P.G.L. (1837). \"Beweis des Satzes, dass jede unbegrenzte arithmetische Progression, deren erstes Glied und Differenz ganze Zahlen ohne gemeinschaftlichen Factor sind, unendlich viele Primzahlen enthält.\" Abhandlungen der Königlich Preussischen Akademie der Wissenschaften, 45-81.",
+      "relevance": "Dirichlet's theorem on primes in arithmetic progressions. The class $\\equiv 1 \\pmod 3$ formalized here is the elementary special case; Dirichlet's general proof needs $L$-functions, which the cyclotomic Euclid argument avoids entirely for residue $1$."
+    },
+    {
+      "type": "textbook",
+      "citation": "Hardy, G.H., and Wright, E.M. (2008). \"An Introduction to the Theory of Numbers,\" 6th ed. Oxford University Press. §2.2 (Euclid's proof and variants), §6 (Fermat's and Euler's theorems, order mod p).",
+      "relevance": "Standard reference for the Euclid-style infinitude proofs in specific residue classes and for the multiplicative-order machinery (Fermat's little theorem, order dividing p−1) that powers the key lemma here."
+    },
+    {
+      "type": "textbook",
+      "citation": "Ireland, K., and Rosen, M. (1990). \"A Classical Introduction to Modern Number Theory,\" 2nd ed. Springer GTM 84. Ch. 3-4 (congruences, structure of $(\\mathbb{Z}/n)^\\times$), Ch. 13 (cyclotomic fields).",
+      "relevance": "Develops the cyclotomic polynomials $\\Phi_d$ and the theorem that primes dividing $\\Phi_d(k)$ are either $\\equiv 1 \\pmod d$ or divide $d$ — exactly the statement specialized to $d=3$ in `prime_dvd_phi3_mod_three`."
+    },
+    {
+      "type": "research-paper",
+      "citation": "Murty, M. Ram (1988). \"Primes in certain arithmetic progressions.\" Functiones et Approximatio Commentarii Mathematici, 35, 249-259.",
+      "relevance": "Characterizes the arithmetic progressions $\\{a + kd\\}$ admitting Euclid-style elementary infinitude proofs as those with $a^2 \\equiv 1 \\pmod d$. For $d = 3$ these are $a = 1$ (cyclotomic, this file) and $a = 2$ (product argument), exhausting the primes $> 3$."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Mathlib.FieldTheory.Finite.Basic\" — `ZMod.orderOf_dvd_card_sub_one`, `ZMod.pow_card_sub_one_eq_one`. (accessed 2026)",
+      "relevance": "Supplies Fermat's little theorem in multiplicative-order form: for $a \\neq 0$ in $\\mathbb{Z}/p$, $\\mathrm{orderOf}\\,a \\mid p - 1$. This is the step that converts $\\mathrm{ord}(m) = 3$ into $3 \\mid p - 1$."
+    },
+    {
+      "type": "library",
+      "citation": "The Mathlib Community. \"Proofs.InfinitudePrimes4k1\" and \"Proofs.InfinitudePrimes4k3\" — sibling mod-4 infinitude proofs. (this repository, accessed 2026)",
+      "relevance": "The mod-4 siblings: $\\equiv 1 \\pmod 4$ ($\\Phi_4 = x^2+1$, Euler's criterion) and $\\equiv 3 \\pmod 4$ (product argument). This file is the mod-3 analogue of the $\\equiv 1$ case, making the underlying order argument explicit rather than routing through the sum-of-two-squares API."
+    }
+  ],
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports and Module Overview",
+      "startLine": 1,
+      "endLine": 50,
+      "summary": "Imports Nat primes/factorial, ZMod basics, FieldTheory.Finite.Basic (Fermat in order form), and GroupTheory.OrderOfElement. The module docstring states OQ-03-OQ-01, answers it affirmatively, and gives a comparison table positioning this cyclotomic Φ₃ proof against the mod-4 siblings.",
+      "mathContext": "Dependency essentials: $\\Phi_3(x) = x^2+x+1$, the identity $(x-1)\\Phi_3(x) = x^3-1$, and the field structure of $\\mathbb{Z}/p$ giving $\\mathrm{ord}(a) \\mid p-1$."
+    },
+    {
+      "id": "key-lemma",
+      "title": "prime_dvd_phi3_mod_three: The Cyclotomic Detector",
+      "startLine": 56,
+      "endLine": 90,
+      "summary": "The core lemma: a prime p ≠ 3 dividing m² + m + 1 satisfies p ≡ 1 (mod 3). Casts the divisibility into ZMod p, derives m³ = 1 by linear_combination over the factorization (m−1)(m²+m+1)=m³−1, bounds the order by 3, rules out order 1 (which forces p = 3), and applies Fermat's little theorem in order form to get 3 ∣ p−1.",
+      "mathContext": "In $\\mathbb{F}_p$: $m^2+m+1=0 \\Rightarrow m^3=1 \\Rightarrow \\mathrm{ord}(m)\\mid 3$. $\\mathrm{ord}(m)=1 \\Rightarrow m=1 \\Rightarrow 3=0 \\Rightarrow p=3$ (excluded). So $\\mathrm{ord}(m)=3$ and $3\\mid p-1$."
+    },
+    {
+      "id": "main-theorem",
+      "title": "infinitely_many_primes_1_mod_3: The Euclid Construction",
+      "startLine": 92,
+      "endLine": 126,
+      "summary": "Sets m = 3·(n+1)! and N = m²+m+1 ≥ 2. Extracts a prime factor p, proves p ∤ m (else p ∣ N − (m²+m) = 1), deduces p ≠ 3 (since 3 ∣ m) and p > n (else p ∣ (n+1)! ∣ m), and applies the key lemma.",
+      "mathContext": "$N = \\Phi_3(3(n+1)!)$. Any prime $p \\mid N$ is coprime to $m=3(n+1)!$, hence $p\\neq 3$, $p>n$, and $p\\equiv 1\\pmod 3$ by the key lemma."
+    },
+    {
+      "id": "consequences",
+      "title": "primes_1_mod_3_infinite and no_largest_prime_1_mod_3",
+      "startLine": 128,
+      "endLine": 142,
+      "summary": "Two standard reformulations: the residue class is Set.Infinite (via Set.infinite_iff_exists_gt) and admits no maximal prime.",
+      "mathContext": "$\\{p \\text{ prime} \\mid p\\equiv 1\\pmod 3\\}$ is infinite; equivalently no prime in the class dominates all others."
+    },
+    {
+      "id": "examples",
+      "title": "Worked Examples",
+      "startLine": 144,
+      "endLine": 163,
+      "summary": "Concrete primes ≡ 1 (mod 3): 7, 13, 19, 31, 37, each verified by decide. #check lines confirm the three top-level theorem signatures.",
+      "mathContext": "$7,13,19,31,37 \\equiv 1 \\pmod 3$ — the start of the infinite family."
+    }
+  ],
+  "conclusion": {
+    "summary": "OQ-03-OQ-01 is answered: infinitely many primes ≡ 1 (mod 3), by the cyclotomic Euclid argument with N = Φ₃(3·(n+1)!). The key lemma makes the multiplicative-order mechanism explicit — any prime ≠ 3 dividing m²+m+1 has order 3 mod p, forcing 3 ∣ p−1. 4 theorems, 0 axioms, 0 sorries.",
+    "implications": "This is the smallest genuinely cyclotomic instance of the Euclid-style infinitude argument, and the prototype for the general statement 'infinitely many primes ≡ 1 (mod k) via Φ_k'. Where the sibling `infinitude-primes-4k1` routed the ≡ 1 (mod 4) case through Mathlib's sum-of-two-squares API, this file exposes the underlying order argument directly: $m^3 = 1$, $\\mathrm{ord}(m) = 3$, $3 \\mid p - 1$. The same three lines, with $\\Phi_d$ in place of $\\Phi_3$, prove infinitude for every class $\\equiv 1 \\pmod d$.",
+    "openQuestions": [
+      "Generalize to a single Lean theorem: for any $d$, primes dividing $\\Phi_d(k)$ with $p \\nmid d$ are $\\equiv 1 \\pmod d$, yielding infinitely many primes ≡ 1 (mod d) uniformly. This would subsume `infinitude-primes-4k1` ($d=4$) and this file ($d=3$) under one cyclotomic argument.",
+      "Formalize the complementary elementary case ≡ 2 (mod 3) via the product argument (a product of numbers ≡ 1 mod 3 stays ≡ 1), completing the elementary mod-3 classification of primes parallel to the mod-4 one.",
+      "Quantify: combine with a Mertens/Chebyshev-style lower bound to show the count of primes ≡ 1 (mod 3) up to x grows, moving from 'infinitely many' toward the correct density 1/2 among primes > 3 (the analytic content of Dirichlet's theorem)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "infinitude-primes-4k3-oq-03",
+      "relationship": "parent",
+      "description": "The mod-4 OQ-03 entry whose openQuestions explicitly proposed the Φ₃ construction N = (3·k!)² + 3·k! + 1; this file answers it."
+    },
+    {
+      "proofId": "infinitude-primes-4k1",
+      "relationship": "sibling",
+      "description": "The ≡ 1 (mod 4) proof via Φ₄ = x² + 1 and Euler's criterion. This file is the mod-3 analogue, making the multiplicative-order argument explicit instead of routing through sum-of-two-squares."
+    },
+    {
+      "proofId": "infinitude-primes-4k3",
+      "relationship": "ancestor",
+      "description": "The ≡ 3 (mod 4) elementary proof and the root of this OQ chain; introduces the Euclid-style construction adapted here to the cyclotomic setting."
+    },
+    {
+      "proofId": "infinitude-primes",
+      "relationship": "ancestor",
+      "description": "Euclid's base infinitude of primes; all residue-class variants, including this cyclotomic one, adapt its 'new prime factor outside a finite set' structure."
+    }
+  ],
+  "leanFile": {
+    "namespace": "InfinitudePrimes4k3OQ03OQ01",
+    "lineCount": 165,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "path": "Proofs/InfinitudePrimes4k3OQ03OQ01.lean",
+    "sorries": 0
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers **OQ-03-OQ-01** from `infinitude-primes-4k3` — a construction the parent gallery entry (`infinitude-primes-4k3-oq-03`) proposed verbatim in its `openQuestions`. Proves there are **infinitely many primes ≡ 1 (mod 3)** by the cyclotomic Euclid-style argument with

$$N = \Phi_3(3\cdot(n+1)!) = (3\cdot(n+1)!)^2 + 3\cdot(n+1)! + 1.$$

This is the smallest genuinely *cyclotomic* instance of the Euclid infinitude argument, and the prototype for "primes ≡ 1 (mod k) via Φ_k".

## The mathematics

**Key lemma** `prime_dvd_phi3_mod_three`: any prime `p ≠ 3` dividing `m² + m + 1` satisfies `p ≡ 1 (mod 3)`.
- In `ℤ/p`, the divisibility gives `m² + m + 1 = 0`, hence `m³ = 1` via the factorization `(m−1)(m²+m+1) = m³−1` (one `linear_combination`).
- `orderOf m ∣ 3`, so the order is 1 or 3. Order 1 ⟹ `m = 1` ⟹ `3 = 0` in `ℤ/p` ⟹ `p = 3` (excluded).
- So the order is exactly 3, and `ZMod.orderOf_dvd_card_sub_one` (Fermat) gives `3 ∣ p − 1`.

**Construction**: `m = 3·(n+1)!` makes every prime factor of `N` coprime to `m` (else `p ∣ N − (m²+m) = 1`), which simultaneously forces `p ≠ 3` (since `3 ∣ m`) and `p > n` (since `(n+1)! ∣ m`).

Contrast with the mod-4 sibling `InfinitudePrimes4k1` (Φ₄ = x²+1), which routes through Mathlib's sum-of-two-squares API; this file exposes the underlying multiplicative-order argument directly.

## Theorems
- `infinitely_many_primes_1_mod_3 : ∀ n, ∃ p, Nat.Prime p ∧ p > n ∧ p % 3 = 1`
- `prime_dvd_phi3_mod_three` (key lemma)
- `primes_1_mod_3_infinite : {p | Nat.Prime p ∧ p % 3 = 1}.Infinite`
- `no_largest_prime_1_mod_3`

## Verification
- **verified · 4 theorems · 0 axioms · 0 sorries**
- Host-built against Mathlib (Lean v4.26.0); `#print axioms` reports only `propext`, `Classical.choice`, `Quot.sound` (the standard foundational axioms — no extra assumptions, no `native_decide`).

## Files
- `proofs/Proofs/InfinitudePrimes4k3OQ03OQ01.lean` (new, 165 lines)
- `src/data/proofs/infinitude-primes-4k3-oq-03-oq-01/{meta.json, annotations.json}` (new)
- `research/problems/infinitude-primes-4k3-oq-03-oq-01/knowledge.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)