### PR TITLE
research(pentagonal-oq-01-oq-03): square-discriminant criterion for general figurate numbers [verified, 0-axiom]

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -3365,6 +3365,7 @@ import Proofs.PellEquationOQ07
 import Proofs.PellEquationOQ07OQ01
 import Proofs.PentagonalNumberTheoremOQ01
 import Proofs.PentagonalNumberTheoremOQ01OQ01
+import Proofs.PentagonalNumberTheoremOQ01OQ03
 import Proofs.PerfectNumbers
 import Proofs.PerfectNumbersOQ02
 import Proofs.PerfectNumbersOQ03

--- a/proofs/Proofs/PentagonalNumberTheoremOQ01OQ03.lean
+++ b/proofs/Proofs/PentagonalNumberTheoremOQ01OQ03.lean
@@ -1,0 +1,203 @@
+/-
+  Pentagonal Number Theorem OQ-01-OQ-03:
+  The square-discriminant criterion for general figurate numbers.
+
+  The parent entry `pentagonal-number-theorem-oq-01` characterizes the
+  generalized pentagonal numbers `g(k) = k(3k-1)/2` by a perfect-square test:
+  `m` is generalized pentagonal iff `24m+1` is a perfect square, with explicit
+  root `24·g(k)+1 = (6k-1)²`.  Its third open question asks to extend this
+  square-discriminant viewpoint to the higher figurate families.
+
+  This file does so.  It carries out the entire pentagonal development for the
+  **generalized heptagonal numbers** `h(k) = k(5k-3)/2` (OEIS A085787):
+
+  * `isGenHept_iff_isSquare` — `m` is generalized heptagonal iff `40m+9` is a
+    perfect square.  The converse runs through `ZMod 10` (a square `≡ 9 (mod 10)`
+    has root `≡ ±3 (mod 10)`), exactly mirroring the pentagonal `ZMod 6` argument.
+  * `disc_genHept`, `disc_genHept_neg` — the explicit roots
+    `40·h(k)+9 = (10k-3)²` and `40·h(-k)+9 = (10k+3)²`.
+  * `genHept_neg`, `genHept_add_neg`, `isGenHept_nonneg`, `genHept_injective`
+    — the structural facts (the `±k` pairing `h(k)+h(-k) = 5k²`, nonnegativity,
+    injectivity of the index map).
+
+  It then isolates the phenomenon uniformly across all polygon parameters `s`:
+
+  * `disc_genPolygonal` — for the generalized `s`-gonal number `P` with
+    `2P = (s-2)k² - (s-4)k`, the discriminant identity
+    `8(s-2)·P + (s-4)² = ((2s-4)k - (s-4))²`.
+    Pentagonal (`s=5`) and heptagonal (`s=7`) are the instances
+    `disc_genPolygonal_pent` and `disc_genPolygonal_hept`.
+
+  All theorems are verified with 0 sorries and 0 axioms, no `native_decide`.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 400000
+
+namespace PentagonalNumberTheoremOQ01OQ03
+
+/-! ## Part 1: Generalized heptagonal numbers
+
+We index the heptagonal numbers by `k : ℤ`.  The value `k(5k-3)` is always even,
+so `h(k) = k(5k-3)/2` is an honest integer; `two_mul_genHept` records the exact
+doubling relation, which we use everywhere instead of integer division. -/
+
+/-- The generalized heptagonal number with index `k : ℤ`, `h(k) = k(5k-3)/2`. -/
+def genHept (k : ℤ) : ℤ := k * (5 * k - 3) / 2
+
+/-- `Prop`-level membership in the heptagonal value set, phrased via the exact
+doubling relation `2m = k(5k-3)` so as to avoid integer division. -/
+def IsGenHept (m : ℤ) : Prop := ∃ k : ℤ, 2 * m = k * (5 * k - 3)
+
+/-- `k(5k-3)` is even: if `k` is even the first factor is, otherwise `5k-3` is. -/
+theorem two_dvd_hept_index (k : ℤ) : (2 : ℤ) ∣ k * (5 * k - 3) := by
+  rcases Int.even_or_odd k with ⟨t, ht⟩ | ⟨t, ht⟩
+  · exact ⟨t * (5 * k - 3), by rw [ht]; ring⟩
+  · exact ⟨k * (5 * t + 1), by rw [ht]; ring⟩
+
+/-- The exact doubling relation `2 · h(k) = k(5k-3)`. -/
+theorem two_mul_genHept (k : ℤ) : 2 * genHept k = k * (5 * k - 3) := by
+  unfold genHept
+  exact Int.mul_ediv_cancel' (two_dvd_hept_index k)
+
+/-- Every `h(k)` is a generalized heptagonal number. -/
+theorem genHept_isGenHept (k : ℤ) : IsGenHept (genHept k) :=
+  ⟨k, two_mul_genHept k⟩
+
+/-! ## Part 2: The square-discriminant characterization (HEADLINE)
+
+`m` is a generalized heptagonal number iff `40m+9` is a perfect square.  Forward:
+`40·h(k)+9 = (10k-3)²`.  Converse: a square equal to `40m+9` is `≡ 9 (mod 10)`,
+so its root is `≡ ±3 (mod 10)`, which produces the index. -/
+
+/-- **Recognition criterion.** `m` is a generalized heptagonal number if and only
+if `40·m + 9` is a perfect square — the heptagonal analogue of the pentagonal
+`24m+1` test. -/
+theorem isGenHept_iff_isSquare (m : ℤ) :
+    IsGenHept m ↔ ∃ s : ℤ, 40 * m + 9 = s ^ 2 := by
+  constructor
+  · -- `40·h(k)+9 = (10k-3)²`
+    rintro ⟨k, hk⟩
+    exact ⟨10 * k - 3, by linear_combination 20 * hk⟩
+  · -- A square `s² = 40m+9` forces `s ≡ ±3 (mod 10)`, recovering the index.
+    rintro ⟨s, hs⟩
+    have hx : ∀ x : ZMod 10, x ^ 2 = 9 → x = 3 ∨ x = 7 := by decide
+    have hsq : (s : ZMod 10) ^ 2 = 9 := by
+      have h : ((s : ℤ) : ZMod 10) ^ 2 = ((40 * m + 9 : ℤ) : ZMod 10) := by
+        rw [← Int.cast_pow, ← hs]
+      rw [h]
+      have hsplit : ((40 * m + 9 : ℤ) : ZMod 10) = ((40 * m : ℤ) : ZMod 10) + 9 := by
+        push_cast; ring
+      rw [hsplit]
+      have h10 : ((40 * m : ℤ) : ZMod 10) = 0 :=
+        (ZMod.intCast_zmod_eq_zero_iff_dvd _ 10).mpr ⟨4 * m, by ring⟩
+      rw [h10]; ring
+    rcases hx _ hsq with h1 | h1
+    · -- `s ≡ 3 (mod 10)`: write `s = 10k+3`, index `-k`.
+      have hd : (10 : ℤ) ∣ (s - 3) := by
+        have hz : ((s - 3 : ℤ) : ZMod 10) = 0 := by push_cast; rw [h1]; ring
+        exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd (s - 3) 10).mp hz
+      obtain ⟨k, hk⟩ := hd
+      have hs1 : s = 10 * k + 3 := by linarith
+      refine ⟨-k, ?_⟩
+      have h20 : (20 : ℤ) * (2 * m) = 20 * ((-k) * (5 * (-k) - 3)) := by
+        rw [hs1] at hs; linear_combination hs
+      exact mul_left_cancel₀ (by norm_num) h20
+    · -- `s ≡ 7 (mod 10)`: write `s = 10k+7 = 10(k+1)-3`, index `k+1`.
+      have hd : (10 : ℤ) ∣ (s - 7) := by
+        have hz : ((s - 7 : ℤ) : ZMod 10) = 0 := by push_cast; rw [h1]; ring
+        exact_mod_cast (ZMod.intCast_zmod_eq_zero_iff_dvd (s - 7) 10).mp hz
+      obtain ⟨k, hk⟩ := hd
+      have hs1 : s = 10 * k + 7 := by linarith
+      refine ⟨k + 1, ?_⟩
+      have h20 : (20 : ℤ) * (2 * m) = 20 * ((k + 1) * (5 * (k + 1) - 3)) := by
+        rw [hs1] at hs; linear_combination hs
+      exact mul_left_cancel₀ (by norm_num) h20
+
+/-! ## Part 2b: Explicit discriminant roots and the ±-pairing -/
+
+/-- **Explicit discriminant root (positive index).** `40·h(k)+9 = (10k-3)²`. -/
+theorem disc_genHept (k : ℤ) : 40 * genHept k + 9 = (10 * k - 3) ^ 2 := by
+  linear_combination 20 * two_mul_genHept k
+
+/-- **Explicit discriminant root (negative index).** `40·h(-k)+9 = (10k+3)²`; the
+two roots `10k-3` and `10k+3` of the `±k` pair straddle `10k`. -/
+theorem disc_genHept_neg (k : ℤ) : 40 * genHept (-k) + 9 = (10 * k + 3) ^ 2 := by
+  linear_combination 20 * two_mul_genHept (-k)
+
+/-- **The `±k` pairing.** `h(-k) = h(k) + 3k`: since
+`2h(-k) - 2h(k) = (-k)(-5k-3) - k(5k-3) = 6k`. -/
+theorem genHept_neg (k : ℤ) : genHept (-k) = genHept k + 3 * k := by
+  have h1 := two_mul_genHept (-k)
+  have h2 := two_mul_genHept k
+  have h3 : 2 * genHept (-k) - 2 * genHept k = 6 * k := by rw [h1, h2]; ring
+  linarith
+
+/-- **The `±k` pairing sum.** `h(k)+h(-k) = 5k²`, since
+`2(h(k)+h(-k)) = k(5k-3)+(-k)(-5k-3) = 10k²`. -/
+theorem genHept_add_neg (k : ℤ) : genHept k + genHept (-k) = 5 * k ^ 2 := by
+  have h : 2 * (genHept k + genHept (-k)) = 2 * (5 * k ^ 2) := by
+    linear_combination two_mul_genHept k + two_mul_genHept (-k)
+  exact mul_left_cancel₀ (by norm_num) h
+
+/-! ## Part 3: Structural facts -/
+
+/-- Generalized heptagonal numbers are nonnegative: `k(5k-3) ≥ 0` for all `k`. -/
+theorem isGenHept_nonneg {m : ℤ} (h : IsGenHept m) : 0 ≤ m := by
+  obtain ⟨k, hk⟩ := h
+  have hnn : 0 ≤ k * (5 * k - 3) := by
+    rcases le_or_gt k 0 with hk0 | hk0
+    · have hrw : k * (5 * k - 3) = (-k) * (3 - 5 * k) := by ring
+      rw [hrw]; exact mul_nonneg (by omega) (by omega)
+    · exact mul_nonneg (by omega) (by omega)
+  linarith
+
+/-- The index map `k ↦ h(k)` is injective. -/
+theorem genHept_injective : Function.Injective genHept := by
+  intro a b hab
+  have h2 : a * (5 * a - 3) = b * (5 * b - 3) := by
+    rw [← two_mul_genHept, ← two_mul_genHept, hab]
+  have hfac : (a - b) * (5 * (a + b) - 3) = 0 := by linear_combination h2
+  rcases mul_eq_zero.mp hfac with h | h
+  · linarith
+  · omega
+
+/-- A few sanity values, via the doubling relation: `h(0)=0`, `h(1)=1`,
+`h(-1)=4`, `h(2)=7`, `h(-2)=13` (OEIS A085787). -/
+theorem genHept_zero : genHept 0 = 0 := by have := two_mul_genHept 0; omega
+theorem genHept_one : genHept 1 = 1 := by have := two_mul_genHept 1; omega
+theorem genHept_neg_one : genHept (-1) = 4 := by have := two_mul_genHept (-1); omega
+theorem genHept_two : genHept 2 = 7 := by have := two_mul_genHept 2; omega
+theorem genHept_neg_two : genHept (-2) = 13 := by have := two_mul_genHept (-2); omega
+
+/-! ## Part 4: The general figurate discriminant identity
+
+The square-discriminant criterion is not special to pentagons or heptagons: for
+every polygon parameter `s`, the generalized `s`-gonal number
+`P_s(k) = ((s-2)k² - (s-4)k)/2` satisfies a perfect-square discriminant identity.
+We state it in doubled form `2P = (s-2)k² - (s-4)k` to stay free of integer
+division, and recover the pentagonal (`s=5`) and heptagonal (`s=7`) cases as
+instances. -/
+
+/-- **General figurate discriminant identity.** If `P` is the generalized
+`s`-gonal number at index `k`, i.e. `2P = (s-2)k² - (s-4)k`, then
+`8(s-2)·P + (s-4)² = ((2s-4)k - (s-4))²`.  This unifies the pentagonal `24P+1`
+and heptagonal `40P+9` tests under one square-completion. -/
+theorem disc_genPolygonal (s k P : ℤ) (hP : 2 * P = (s - 2) * k ^ 2 - (s - 4) * k) :
+    8 * (s - 2) * P + (s - 4) ^ 2 = ((2 * s - 4) * k - (s - 4)) ^ 2 := by
+  linear_combination 4 * (s - 2) * hP
+
+/-- Pentagonal instance (`s = 5`): `24·P + 1 = (6k-1)²` from `2P = 3k² - k`. -/
+theorem disc_genPolygonal_pent (k P : ℤ) (hP : 2 * P = 3 * k ^ 2 - k) :
+    24 * P + 1 = (6 * k - 1) ^ 2 := by
+  have h := disc_genPolygonal 5 k P (by linear_combination hP)
+  linear_combination h
+
+/-- Heptagonal instance (`s = 7`): `40·P + 9 = (10k-3)²` from `2P = 5k² - 3k`. -/
+theorem disc_genPolygonal_hept (k P : ℤ) (hP : 2 * P = 5 * k ^ 2 - 3 * k) :
+    40 * P + 9 = (10 * k - 3) ^ 2 := by
+  have h := disc_genPolygonal 7 k P (by linear_combination hP)
+  linear_combination h
+
+end PentagonalNumberTheoremOQ01OQ03

--- a/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
+++ b/research/problems/pentagonal-number-theorem-oq-01/knowledge.md
@@ -1,21 +1,36 @@
 # Knowledge Base: pentagonal-number-theorem-oq-01
 
-Insights accumulated during research on this problem.
-
----
-
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Gallery entry `pentagonal-number-theorem-oq-01` is **verified/original**, 0-axiom,
+39 theorems (`proofs/Proofs/PentagonalNumberTheoremOQ01.lean`, imports Mathlib
+only). It characterizes the generalized pentagonal numbers `g(k)=k(3k−1)/2` by the
+square-discriminant test (`isGenPent_iff_isSquare`: `m` is generalized pentagonal
+iff `24m+1` is a perfect square; explicit root `24·g(k)+1=(6k−1)²`), and machine-
+checks both ends of Euler's identity through Mathlib's `Partition.genFun`.
 
----
+It carries **three open questions**:
+1. **Open core** — Franklin's sign-reversing involution
+   `∑_{p∈distincts n}(−1)^{#parts} = pentSeriesCoeff(n)`. The genuinely hard
+   combinatorial gap; still **OPEN**.
+2. Derive Euler's partition recurrence for `p(n)` as a corollary.
+3. Extend the square-discriminant viewpoint to higher figurate families.
 
-## Insights
+## Progress
 
-[Insights from research attempts will be accumulated here]
+### 2026-06-23 (researcher-1) — answered OQ-03 with a new child entry
 
----
+Created **`pentagonal-number-theorem-oq-01-oq-03`** (new verified/original entry,
+`Proofs/PentagonalNumberTheoremOQ01OQ03.lean`, 18 theorems / 2 defs / 0 sorries /
+0 axioms / no native_decide, host-lean verified against Mathlib 4.26.0):
 
-## Dead Ends
+- generalized **heptagonal** numbers `h(k)=k(5k−3)/2` with recognition criterion
+  `isGenHept_iff_isSquare` (`m` heptagonal iff `40m+9` is a perfect square;
+  converse via `ZMod 10`, mirroring the pentagonal `ZMod 6` argument), explicit
+  roots `40·h(k)+9=(10k−3)²`, and the `±k` structural facts;
+- the **general s-gonal discriminant identity** `disc_genPolygonal`:
+  `8(s−2)·P+(s−4)² = ((2s−4)k−(s−4))²` (pentagonal s=5 and heptagonal s=7 as
+  instances) — the unifying square-completion behind all figurate tests.
 
-[Approaches known not to work will be documented here]
+The **open core (OQ-01, Franklin involution) remains OPEN** — not touched.
+Releasing the parent research claim; OQ-03 is shipped as the child entry.

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-03/annotations.json
@@ -1,0 +1,63 @@
+[
+  {
+    "id": "ann-pent03-defs",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-03",
+    "range": { "startLine": 41, "endLine": 75 },
+    "type": "definition",
+    "title": "Generalized heptagonal numbers via a division-free doubling relation",
+    "content": "genHept k := k(5k−3)/2 is the generalized heptagonal number (OEIS A085787), and IsGenHept m := ∃ k, 2m = k(5k−3) is its Prop-level membership phrased without integer division. The parity lemma two_dvd_hept_index (case split on k even/odd) shows k(5k−3) is even, and Int.mul_ediv_cancel' then yields the exact doubling 2·h(k)=k(5k−3) (two_mul_genHept). Every subsequent proof works through this doubled identity, so no reasoning ever divides by 2.",
+    "mathContext": "$h(k)=\\tfrac{k(5k-3)}{2}$, $2h(k)=k(5k-3)$; $h(0..\\pm2)=0,1,4,7,13$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "figurate numbers",
+      "heptagonal numbers",
+      "integer division",
+      "parity"
+    ],
+    "prerequisites": [
+      "polygonal numbers",
+      "integer division in ℤ"
+    ]
+  },
+  {
+    "id": "ann-pent03-criterion",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-03",
+    "range": { "startLine": 77, "endLine": 132 },
+    "type": "key-step",
+    "title": "Recognition criterion: m is heptagonal ⟺ 40m+9 is a perfect square",
+    "content": "isGenHept_iff_isSquare is the heptagonal analogue of the parent's 24m+1 pentagonal test. Forward: 40·h(k)+9 = 20·(2h(k))+9 = 20·k(5k−3)+9 = (10k−3)² (linear_combination on the doubling relation). Converse: from s²=40m+9, reduce mod 10 (40m≡0) to get s²≡9; the finite check ∀ x:ZMod 10, x²=9→x=3∨x=7 (by decide) forces s≡±3 mod 10; ZMod.intCast_zmod_eq_zero_iff_dvd turns this into 10 ∣ (s∓3), so s=10k+3 or s=10(k+1)−3, and cancelling 20 recovers the index −k or k+1. The governing modulus is 2(s−2)=10, versus 6 for pentagons.",
+    "mathContext": "$\\operatorname{IsGenHept}(m)\\iff \\exists s,\\ 40m+9=s^2$; converse via $s^2\\equiv 9\\ (\\mathrm{mod}\\ 10)\\Rightarrow s\\equiv\\pm3$.",
+    "significance": "main-result",
+    "relatedConcepts": [
+      "square-discriminant criterion",
+      "quadratic residues",
+      "ZMod",
+      "completing the square"
+    ],
+    "prerequisites": [
+      "square residues in ZMod n",
+      "ZMod.intCast_zmod_eq_zero_iff_dvd",
+      "the pentagonal 24m+1 criterion"
+    ]
+  },
+  {
+    "id": "ann-pent03-general",
+    "proofId": "pentagonal-number-theorem-oq-01-oq-03",
+    "range": { "startLine": 190, "endLine": 202 },
+    "type": "concept",
+    "title": "The general s-gonal discriminant identity unifies all figurate tests",
+    "content": "disc_genPolygonal proves that for the generalized s-gonal number P (with 2P=(s−2)k²−(s−4)k), 8(s−2)·P+(s−4)² = ((2s−4)k−(s−4))² — one square-completion valid for every polygon. The proof is linear_combination 4(s−2)·hP, since ((2s−4)k−(s−4))²−(s−4)² = 4(s−2)((s−2)k²−(s−4)k) = 4(s−2)·(2P). Pentagonal (s=5: 24P+1=(6k−1)²) and heptagonal (s=7: 40P+9=(10k−3)²) are the instances disc_genPolygonal_pent and disc_genPolygonal_hept, exhibiting the parent's pentagonal test as a special case.",
+    "mathContext": "$8(s-2)P+(s-4)^2=((2s-4)k-(s-4))^2$, with $2P=(s-2)k^2-(s-4)k$.",
+    "significance": "main-result",
+    "relatedConcepts": [
+      "polygonal numbers",
+      "s-gonal numbers",
+      "completing the square",
+      "discriminant"
+    ],
+    "prerequisites": [
+      "generalized polygonal numbers",
+      "the linear_combination tactic"
+    ]
+  }
+]

--- a/src/data/proofs/pentagonal-number-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/pentagonal-number-theorem-oq-01-oq-03/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "pentagonal-number-theorem-oq-01-oq-03",
+  "title": "The Square-Discriminant Criterion for General Figurate Numbers: Generalized Heptagonal Numbers and the s-gonal Identity",
+  "slug": "pentagonal-number-theorem-oq-01-oq-03",
+  "description": "Answers the third open question of the parent entry pentagonal-number-theorem-oq-01: extend the square-discriminant viewpoint from pentagonal to the higher figurate families. The parent characterizes the generalized pentagonal numbers g(k)=k(3k−1)/2 by a perfect-square test (m is generalized pentagonal iff 24m+1 is a perfect square, with explicit root 24·g(k)+1=(6k−1)²). This entry carries out the entire development for the generalized heptagonal numbers h(k)=k(5k−3)/2 (OEIS A085787): the recognition criterion isGenHept_iff_isSquare (m is generalized heptagonal iff 40m+9 is a perfect square), whose converse runs through ZMod 10 (a square ≡ 9 mod 10 has root ≡ ±3 mod 10), exactly mirroring the pentagonal ZMod 6 argument; the explicit discriminant roots 40·h(k)+9=(10k−3)² and 40·h(−k)+9=(10k+3)²; and the structural facts (±k pairing h(k)+h(−k)=5k², nonnegativity, index injectivity). It then isolates the phenomenon uniformly: disc_genPolygonal proves that for every polygon parameter s, the generalized s-gonal number P with 2P=(s−2)k²−(s−4)k satisfies 8(s−2)·P+(s−4)²=((2s−4)k−(s−4))², with pentagonal (s=5) and heptagonal (s=7) recovered as instances. 18 theorems, 2 definitions, 0 sorries, 0 axioms, no native_decide.",
+  "meta": {
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Pentagonal_number_theorem",
+    "date": "Euler, 1741 (pentagonal number theorem); figurate numbers, classical",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "figurate-numbers",
+      "pentagonal-numbers",
+      "heptagonal-numbers",
+      "polygonal-numbers",
+      "square-discriminant",
+      "modular-arithmetic",
+      "open-question"
+    ],
+    "proofRepoPath": "Proofs/PentagonalNumberTheoremOQ01OQ03.lean",
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "ZMod.intCast_zmod_eq_zero_iff_dvd",
+        "description": "x : ℤ casts to 0 in ZMod n iff n ∣ x. Used twice in the converse of the recognition criterion: to extract s² ≡ 9 (mod 10) and to turn s ≡ ±3 (mod 10) into the divisibility 10 ∣ (s∓3) that supplies the heptagonal index.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "Int.mul_ediv_cancel'",
+        "description": "a ∣ b ⇒ a * (b / a) = b. Used (with the parity lemma two_dvd_hept_index) to establish the exact doubling relation 2·h(k) = k(5k−3) from the integer-division definition of h(k).",
+        "module": "Mathlib.Data.Int.Order"
+      },
+      {
+        "theorem": "decide (over ZMod 10)",
+        "description": "The finite case check ∀ x : ZMod 10, x² = 9 → x = 3 ∨ x = 7 is discharged by decide on the finite type ZMod 10 (10 cases). This is ordinary kernel decidability, not native_decide — no Lean.ofReduceBool.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      }
+    ],
+    "assumptions": "None. All 18 theorems and 2 definitions are fully verified with 0 sorries and 0 axioms (only Lean's foundational propext / Classical.choice / Quot.sound, which do not count; the finite ZMod 10 check uses ordinary decide, not native_decide, so no Lean.ofReduceBool). Imports only Mathlib.",
+    "originalContributions": [
+      "isGenHept_iff_isSquare: the heptagonal recognition criterion — m is a generalized heptagonal number iff 40m+9 is a perfect square — the exact analogue of the parent's pentagonal 24m+1 test, with the converse carried out via a ZMod 10 square-residue analysis (square ≡ 9 mod 10 ⇒ root ≡ ±3 mod 10).",
+      "disc_genHept / disc_genHept_neg: the explicit discriminant roots 40·h(k)+9 = (10k−3)² and 40·h(−k)+9 = (10k+3)², together with the structural facts genHept_neg (h(−k)=h(k)+3k), genHept_add_neg (h(k)+h(−k)=5k²), isGenHept_nonneg, and genHept_injective — the full heptagonal mirror of the parent's pentagonal Part 2/Part 3.",
+      "disc_genPolygonal: the unifying general identity 8(s−2)·P + (s−4)² = ((2s−4)k − (s−4))² for the generalized s-gonal number P (2P=(s−2)k²−(s−4)k), exhibiting the square-discriminant criterion as one square-completion valid for every polygon, with disc_genPolygonal_pent (s=5, 24P+1) and disc_genPolygonal_hept (s=7, 40P+9) as instances."
+    ],
+    "dateAdded": "2026-06-23",
+    "lineCount": 203,
+    "theoremCount": 18,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Euler's pentagonal number theorem (1741) expands ∏(1−xⁿ) as a lacunary series whose exponents are the generalized pentagonal numbers g(k)=k(3k−1)/2. The parent entry recast the recognition of these exponents as a perfect-square test (24m+1 a square), the practical criterion used when indexing Euler's partition recurrence. Figurate (polygonal) numbers — triangular, square, pentagonal, hexagonal, heptagonal, … — are a classical family: the generalized s-gonal number is P_s(k)=((s−2)k²−(s−4)k)/2, and each family admits its own perfect-square recognition test. This entry verifies the heptagonal case in full and isolates the general s-gonal discriminant identity underlying all of them.",
+    "problemStatement": "**Open Question (pentagonal-number-theorem-oq-01 OQ-03)**: Extend the square-discriminant viewpoint to the higher Gauss/Jacobi-triple-product exponents (e.g. the heptagonal and general figurate analogues), characterizing each family by an analogous perfect-square test.\n\n**Formalized**: the generalized heptagonal numbers h(k)=k(5k−3)/2 are characterized by the test '40m+9 is a perfect square' (isGenHept_iff_isSquare), with explicit roots and structural facts mirroring the pentagonal case, and the general s-gonal discriminant identity 8(s−2)·P+(s−4)²=((2s−4)k−(s−4))² is proved uniformly (disc_genPolygonal), with pentagonal and heptagonal as instances.",
+    "text": "A 203-line formalization in 18 theorems and 2 definitions. Part 1 introduces h(k)=k(5k−3)/2 over ℤ via the integer-division definition, proves the parity lemma two_dvd_hept_index and the exact doubling 2·h(k)=k(5k−3) (two_mul_genHept), and the Prop-level membership IsGenHept m := ∃ k, 2m=k(5k−3). Part 2 is the headline recognition criterion isGenHept_iff_isSquare: forward by the algebraic identity 40·h(k)+9=(10k−3)²; converse by a ZMod 10 argument (∀ x:ZMod 10, x²=9→x=3∨x=7, by decide), recovering the index ∓k / k+1 from s≡±3 mod 10. Part 2b records the explicit roots disc_genHept, disc_genHept_neg and the ±k pairing genHept_neg, genHept_add_neg. Part 3 gives nonnegativity, injectivity, and sanity values h(0..±2)=0,1,4,7,13. Part 4 proves the general figurate identity disc_genPolygonal and its pentagonal/heptagonal instances. All compile with 0 sorries, 0 axioms, no native_decide.",
+    "proofStrategy": "**Doubling**: h(k) is defined by integer division; two_dvd_hept_index (case split on the parity of k) feeds Int.mul_ediv_cancel' to give the division-free identity 2·h(k)=k(5k−3), used everywhere via linear_combination.\n\n**Recognition (forward)**: ⟨10k−3, linear_combination 20·hk⟩ where hk : 2m=k(5k−3); 40m+9 = 20·(2m)+9 = 20·k(5k−3)+9 = (10k−3)².\n\n**Recognition (converse)**: from s²=40m+9, reduce mod 10: 40m≡0, so s²≡9; the finite check (decide) forces s≡3 or 7 (mod 10). In each branch ZMod.intCast_zmod_eq_zero_iff_dvd yields 10 ∣ (s−3) (resp. s−7), so s=10k+3 (resp. 10k+7=10(k+1)−3); substituting into s²=40m+9 and cancelling 20 (mul_left_cancel₀) gives 2m = (−k)(5(−k)−3) (resp. (k+1)(5(k+1)−3)), i.e. IsGenHept m with index −k (resp. k+1).\n\n**General identity**: disc_genPolygonal is linear_combination 4(s−2)·hP, since ((2s−4)k−(s−4))² − (s−4)² = 4(s−2)((s−2)k²−(s−4)k) = 4(s−2)·(2P).",
+    "keyInsights": [
+      "**One square-completion, every polygon**: the recognition test is a single discriminant identity 8(s−2)·P+(s−4)² = ((2s−4)k−(s−4))² (disc_genPolygonal). Pentagonal (s=5: 24P+1=(6k−1)²) and heptagonal (s=7: 40P+9=(10k−3)²) are the same theorem at different s — the figurate analogue of completing the square in the index.",
+      "**The modulus tracks the polygon**: the pentagonal converse lives in ZMod 6 (root ≡ ±1), the heptagonal in ZMod 10 (root ≡ ±3). The relevant modulus is 2(s−2): 6 for s=5, 10 for s=7. The residue of the discriminant ((s−4)² mod 2(s−2)) is what the finite decide check certifies.",
+      "**Division-free arithmetic**: h(k)=k(5k−3)/2 is defined with integer division, but every proof works through the doubled identity 2·h(k)=k(5k−3) (via a parity lemma and Int.mul_ediv_cancel'), so no reasoning ever divides.",
+      "**The ±k pair straddles 10k**: the two discriminant roots 10k−3 and 10k+3 are symmetric about 10k, mirroring the pentagonal 6k∓1 about 6k; the corresponding values pair as h(k)+h(−k)=5k² (pentagonal: g(k)+g(−k)=3k²).",
+      "**Ordinary decidability, not native_decide**: the only finite computation is ∀ x:ZMod 10, x²=9→x=3∨x=7, discharged by decide on a 10-element type — kernel-checked, so the entry is genuinely 0-axiom (no Lean.ofReduceBool)."
+    ],
+    "prerequisites": [
+      "Generalized pentagonal numbers and the parent's 24m+1 square-discriminant criterion (pentagonal-number-theorem-oq-01)",
+      "Figurate / polygonal numbers: the generalized s-gonal number P_s(k)=((s−2)k²−(s−4)k)/2",
+      "Integer division and Int.mul_ediv_cancel'; the parity case split Int.even_or_odd",
+      "Square residues in ZMod n and ZMod.intCast_zmod_eq_zero_iff_dvd; finite decidability via decide",
+      "The linear_combination tactic for polynomial identities over ℤ"
+    ]
+  },
+  "conclusion": {
+    "summary": "Answers the third open question of pentagonal-number-theorem-oq-01 by extending the square-discriminant criterion to the higher figurate families. It verifies the generalized heptagonal numbers h(k)=k(5k−3)/2 in full — the recognition test '40m+9 a perfect square' (via a ZMod 10 converse), the explicit discriminant roots, and the ±k structural facts — and isolates the general s-gonal discriminant identity 8(s−2)·P+(s−4)²=((2s−4)k−(s−4))², with pentagonal and heptagonal as instances. 18 theorems, 2 definitions, 0 sorries, 0 axioms, no native_decide.",
+    "implications": "The entry shows the parent's pentagonal square-test is one case of a uniform figurate phenomenon: every polygon's generalized numbers are recognized by completing the square in the index, with the modulus 2(s−2) governing the converse residue analysis. It supplies a reusable, fully-verified template (definition → doubling → recognition iff → explicit roots → pairing) for any further figurate family.",
+    "openQuestions": [
+      "Prove the recognition criterion uniformly in s: a single theorem 'IsGenPolygonal s m ↔ ∃ t, 8(s−2)m+(s−4)² = t² ∧ t ≡ ±(s−4) (mod 2(s−2))', specializing to the pentagonal and heptagonal iffs.",
+      "Connect the heptagonal recognition test to a generating-function / triple-product identity, as the parent connects the pentagonal numbers to ∏(1−xⁿ).",
+      "Characterize which integers are simultaneously pentagonal and heptagonal via the resulting Pell-type system 24m+1=□, 40m+9=□."
+    ]
+  },
+  "crossReferences": [
+    {
+      "proofId": "pentagonal-number-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Parent entry. It characterizes the generalized pentagonal numbers by the 24m+1 square-discriminant test. This entry answers its third open question by extending the square-discriminant viewpoint to the generalized heptagonal numbers (40m+9 test) and to the general s-gonal discriminant identity, with the pentagonal case recovered as an instance."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "PentagonalNumberTheoremOQ01OQ03",
+    "lineCount": 203,
+    "axiomCount": 0,
+    "theoremCount": 18,
+    "definitionCount": 2,
+    "path": "Proofs/PentagonalNumberTheoremOQ01OQ03.lean",
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "heptagonal-defs",
+      "title": "Generalized heptagonal numbers and the doubling relation",
+      "startLine": 41,
+      "endLine": 75,
+      "summary": "genHept k := k(5k−3)/2 and IsGenHept m := ∃ k, 2m=k(5k−3); two_dvd_hept_index (parity case split) and two_mul_genHept (exact doubling 2·h(k)=k(5k−3) via Int.mul_ediv_cancel'), the division-free identity used throughout; genHept_isGenHept."
+    },
+    {
+      "id": "recognition-criterion",
+      "title": "The square-discriminant recognition criterion (headline)",
+      "startLine": 77,
+      "endLine": 132,
+      "summary": "isGenHept_iff_isSquare: m is generalized heptagonal iff 40m+9 is a perfect square. Forward via the identity 40·h(k)+9=(10k−3)². Converse via a ZMod 10 argument (square ≡ 9 ⇒ root ≡ ±3 mod 10), recovering the index −k / k+1 by ZMod.intCast_zmod_eq_zero_iff_dvd and cancelling 20."
+    },
+    {
+      "id": "roots-and-pairing",
+      "title": "Explicit discriminant roots, ±k pairing, and structure",
+      "startLine": 134,
+      "endLine": 188,
+      "summary": "disc_genHept (40·h(k)+9=(10k−3)²), disc_genHept_neg (=(10k+3)²); genHept_neg (h(−k)=h(k)+3k), genHept_add_neg (h(k)+h(−k)=5k²); isGenHept_nonneg, genHept_injective, and sanity values h(0..±2)=0,1,4,7,13."
+    },
+    {
+      "id": "general-figurate-identity",
+      "title": "The general s-gonal discriminant identity",
+      "startLine": 190,
+      "endLine": 202,
+      "summary": "disc_genPolygonal: for the generalized s-gonal number P (2P=(s−2)k²−(s−4)k), 8(s−2)·P+(s−4)²=((2s−4)k−(s−4))², proved by linear_combination 4(s−2)·hP; instances disc_genPolygonal_pent (s=5, 24P+1) and disc_genPolygonal_hept (s=7, 40P+9)."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "isGenHept_iff_isSquare",
+      "type": "core",
+      "statement": "An integer $m$ is a generalized heptagonal number iff $40m+9$ is a perfect square.",
+      "significance": "The headline result and the direct heptagonal analogue of the parent's $24m+1$ pentagonal test. The forward direction is the identity $40h(k)+9=(10k-3)^2$; the converse is a $\\mathbb{Z}/10$ square-residue analysis recovering the index. This is the figurate generalization the open question asks for.",
+      "description": "m is generalized heptagonal ⟺ 40m+9 is a perfect square."
+    },
+    {
+      "name": "disc_genPolygonal",
+      "type": "core",
+      "statement": "For the generalized $s$-gonal number $P$ (with $2P=(s-2)k^2-(s-4)k$), $8(s-2)P+(s-4)^2=((2s-4)k-(s-4))^2$.",
+      "significance": "The unifying result: the square-discriminant criterion is one square-completion valid for every polygon $s$. Pentagonal ($s=5$, $24P+1$) and heptagonal ($s=7$, $40P+9$) are instances, exhibiting the parent's pentagonal test as a special case of a general figurate identity.",
+      "description": "The general s-gonal discriminant identity, unifying all figurate recognition tests."
+    },
+    {
+      "name": "disc_genHept",
+      "type": "supporting",
+      "statement": "$40h(k)+9=(10k-3)^2$.",
+      "significance": "The explicit discriminant root witnessing IsGenHept, the forward half of the recognition criterion with the square root named rather than existential — the heptagonal counterpart of disc_genPent.",
+      "description": "Explicit discriminant root for the positive heptagonal index."
+    }
+  ],
+  "references": [
+    {
+      "text": "Euler, L. (1741). Pentagonal number theorem; figurate (polygonal) numbers.",
+      "url": "https://en.wikipedia.org/wiki/Pentagonal_number_theorem"
+    },
+    {
+      "text": "Generalized heptagonal numbers, OEIS A085787.",
+      "url": "https://oeis.org/A085787"
+    },
+    {
+      "text": "Polygonal numbers and the square-discriminant recognition test.",
+      "url": "https://en.wikipedia.org/wiki/Polygonal_number"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Answers the **third open question** of `pentagonal-number-theorem-oq-01` (*"Extend the square-discriminant viewpoint to the higher figurate analogues, characterizing each family by an analogous perfect-square test"*).

New **verified / original** gallery entry `pentagonal-number-theorem-oq-01-oq-03` (`Proofs/PentagonalNumberTheoremOQ01OQ03.lean`, imports Mathlib only).

### Generalized heptagonal numbers `h(k)=k(5k−3)/2` (OEIS A085787)
| Theorem | Statement |
|---------|-----------|
| `isGenHept_iff_isSquare` | `m` is generalized heptagonal ⟺ `40m+9` is a perfect square (converse via `ZMod 10`, mirroring the pentagonal `ZMod 6` argument) |
| `disc_genHept` / `disc_genHept_neg` | explicit roots `40·h(k)+9=(10k−3)²`, `40·h(−k)+9=(10k+3)²` |
| `genHept_neg` / `genHept_add_neg` | `h(−k)=h(k)+3k`, `h(k)+h(−k)=5k²` |
| `isGenHept_nonneg`, `genHept_injective` | structure |

### The unifying general identity
`disc_genPolygonal`: for the generalized **s-gonal** number `P` (`2P=(s−2)k²−(s−4)k`),
```
8(s−2)·P + (s−4)² = ((2s−4)k − (s−4))²
```
with pentagonal (`s=5`, `24P+1`) and heptagonal (`s=7`, `40P+9`) recovered as instances (`disc_genPolygonal_pent`, `disc_genPolygonal_hept`). The modulus governing each converse is `2(s−2)` (6 for pentagons, 10 for heptagons).

**18 theorems, 2 definitions, 203 lines, 0 sorries, 0 axioms, no `native_decide`** (the only finite check is `decide` over `ZMod 10` — ordinary kernel decidability, not `native_decide`, so no `Lean.ofReduceBool`).

## Verification

Kernel-verified clean: 0 errors, 0 linter warnings. `#print axioms` reports only `[propext, Classical.choice, Quot.sound]`. The shared docker daemon was down, so verification used the host fallback `LAKE_UNSAFE=1 ./bin/lake env lean` against prebuilt Mathlib 4.26.0 oleans (single Mathlib import, memory-capped, no `lake build`).

The parent's **open core** (OQ-01, Franklin's sign-reversing involution) remains open and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)